### PR TITLE
chore: add OSS security automation and community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,116 @@
+name: Bug report
+description: Report something that is not working in mlxcel
+title: "fix: <short description>"
+labels: ["type:bug", "status:ready"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. The information below helps us reproduce the issue and ship a fix faster.
+
+        **Security issues**: Do **not** file security vulnerabilities here. See [SECURITY.md](https://github.com/lablup/mlxcel/blob/main/SECURITY.md) for the private reporting channel.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A short, factual description of the bug.
+      placeholder: e.g. "mlxcel-server crashes on /v1/chat/completions when the prompt contains a 4-byte UTF-8 character"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: |
+        Minimal commands or HTTP requests that reproduce the issue. Include the prompt and seed if relevant.
+      placeholder: |
+        1. `mlxcel download mlx-community/Qwen3.5-0.8B-OptiQ-4bit`
+        2. `mlxcel generate -m models/Qwen3.5-0.8B-OptiQ-4bit -p "..." -n 100 --seed 42`
+        3. Observed: ...
+        4. Expected: ...
+      render: bash
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include error messages, panic backtraces, or unexpected output verbatim.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: mlxcel version
+      description: Output of `mlxcel --version` or the commit SHA you built from.
+      placeholder: e.g. "v0.0.27" or "main @ abc1234"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: Install method
+      options:
+        - Homebrew (lablup/tap)
+        - Pre-built release binary (GitHub Releases)
+        - Built from source
+        - Other (please describe in Additional context)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS (Apple Silicon)
+        - Linux + CUDA (gb10)
+        - Linux + CUDA (gh200)
+        - Linux + CUDA (other — please specify in Additional context)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model checkpoint
+      description: The Hugging Face repo ID or local path of the model you were running, if relevant.
+      placeholder: e.g. "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Server / CLI output, ideally with `RUST_LOG=mlxcel=debug` set for stack traces.
+      render: text
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that might help — workarounds you tried, related issues, screenshots, etc.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and did not find a duplicate
+          required: true
+        - label: This is not a security vulnerability (those go to SECURITY.md instead)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/lablup/mlxcel/security/advisories/new
+    about: Report a security issue privately. Do not file these as public issues. See SECURITY.md for the full policy.
+  - name: Question or discussion
+    url: https://github.com/lablup/mlxcel/discussions
+    about: General questions, design discussion, or "is this supported?" go here instead of issues.
+  - name: Upstream MLX issues
+    url: https://github.com/ml-explore/mlx/issues
+    about: Bugs that reproduce against upstream MLX C++ libraries (not mlxcel-specific) should be reported upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,74 @@
+name: Feature request
+description: Propose a new capability, model family, or behavior change for mlxcel
+title: "feat: <short description>"
+labels: ["type:enhancement", "status:ready"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a feature. mlxcel tracks model coverage with [mlx-lm](https://github.com/ml-explore/mlx-lm) and [mlx-vlm](https://github.com/Blaizzy/mlx-vlm) where practical; the more upstream context you can provide, the easier it is to scope.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this feature solve? Who is the user, and what are they trying to do today?
+      placeholder: |
+        e.g. "I want to serve LFM2-VL via mlxcel-server, but the architecture is not in the detection table."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: |
+        Describe what should be built. For new model families, include the upstream reference (mlx-lm / mlx-vlm path or HF architecture).
+        For new server features, sketch the CLI flag or API surface.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered, and why they were not chosen.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - New model family
+        - Server / API surface (mlxcel-server)
+        - CLI behavior (mlxcel)
+        - Inference performance
+        - Surgery operation
+        - Tooling / documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this is done? List the conditions in checkbox form.
+      placeholder: |
+        - [ ] Model loads from `mlx-community/...` without conversion
+        - [ ] `mlxcel list` includes the new architecture
+        - [ ] End-to-end inference matches Python reference within RMS < 5e-3
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Upstream PRs, papers, benchmark numbers, etc.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and discussions and did not find a duplicate
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+<!--
+Thanks for opening a pull request! Please fill out the sections below.
+For the full contributor contract see AGENTS.md and CONTRIBUTING.md.
+-->
+
+## Summary
+
+<!-- One or two sentences: what does this PR do, and why? -->
+
+## Related issues
+
+<!-- Use closing keywords ("Closes #123", "Fixes #456") so the issue auto-closes on merge.
+     For tracking-only references use "Refs #..." or "Part of #..." instead. -->
+
+Closes #
+
+## Type of change
+
+<!-- Tick all that apply. -->
+
+- [ ] `feat` — new user-visible feature
+- [ ] `fix` — bug fix
+- [ ] `perf` — performance improvement (include before/after numbers in the PR body)
+- [ ] `refactor` — internal restructuring without behavior change
+- [ ] `chore` — build, CI, dependencies, release infrastructure
+- [ ] `docs` — documentation only
+- [ ] `test` — tests only
+
+## Test plan
+
+<!--
+What did you run to convince yourself this works? Be specific.
+For inference changes, real-checkpoint validation is required — synthetic-only is not enough.
+-->
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo test --release`
+- [ ] `cargo deny check`
+- [ ] Validated with a real checkpoint (specify which, e.g. `mlx-community/Qwen3.5-0.8B-OptiQ-4bit`): ...
+
+## Notes for reviewers
+
+<!-- Anything reviewers should know: assumed invariants, follow-up work, risks, alternatives considered. -->
+
+## Checklist
+
+- [ ] PR title uses a Conventional Commits prefix (`feat:`, `fix:`, etc.)
+- [ ] One logical change per PR (split unrelated changes)
+- [ ] Updated `docs/` if user-facing behavior or supported models changed
+- [ ] Updated `// Used by: ...` comments on any shared function I modified (see `docs/code-guidelines.md`)
+- [ ] No secrets, credentials, or `.env` files committed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,97 @@
+# Dependabot configuration for automated dependency updates.
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+updates:
+  # Cargo (Rust) dependencies — root `mlxcel` binary crate.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels:
+      - "type:dependency"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # Cargo (Rust) dependencies — `mlxcel-core` library crate (separate Cargo.lock).
+  - package-ecosystem: "cargo"
+    directory: "/src/lib/mlxcel-core"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels:
+      - "type:dependency"
+      - "area:core"
+    commit-message:
+      prefix: "deps(core)"
+      include: "scope"
+
+  # Cargo (Rust) dependencies — `mlxcel-surgery` library crate.
+  - package-ecosystem: "cargo"
+    directory: "/src/lib/mlxcel-surgery"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels:
+      - "type:dependency"
+      - "area:surgery"
+    commit-message:
+      prefix: "deps(surgery)"
+      include: "scope"
+
+  # GitHub Actions dependencies.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    labels:
+      - "type:dependency"
+      - "type:chore"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+# PR / push CI for security audit. Builds and tests are covered by
+# release.yml (signed artifacts) and pipeline-parallel-ci.yml (distributed
+# runs); this workflow runs the lightweight cargo-deny gate on every
+# touched-Rust change so license drift and new advisories are caught at
+# PR time.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - 'deny.toml'
+              - '.github/workflows/ci.yml'
+
+  deny:
+    name: cargo-deny
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+          log-level: warn

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+# Citation File Format (CFF) v1.2.0
+# Docs: https://citation-file-format.github.io/
+cff-version: 1.2.0
+title: "mlxcel: High-performance LLM/VLM/VLA inference on Apple Silicon and CUDA GPUs"
+message: "If you use this software, please cite it as below."
+type: software
+authors:
+  - name: "Lablup Inc."
+    website: "https://lablup.com"
+repository-code: "https://github.com/lablup/mlxcel"
+url: "https://github.com/lablup/mlxcel"
+abstract: >-
+  mlxcel is a Rust inference runtime and OpenAI-compatible model server for
+  MLX-format checkpoints. It targets Apple Silicon (primary) and Linux/CUDA
+  (secondary), provides continuous batching, prompt-prefix caching, speculative
+  decoding, KV-cache compression, and tensor/pipeline parallelism for
+  selected model families. Model coverage tracks the mlx-lm and mlx-vlm
+  projects where practical.
+keywords:
+  - mlx
+  - llm
+  - vlm
+  - vla
+  - inference
+  - apple-silicon
+  - cuda
+  - rust
+license: Apache-2.0
+version: "0.0.27"
+date-released: "2026-05-18"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to mlxcel
+
+Thank you for your interest in contributing to mlxcel! This document covers the basics for getting started. For the deeper working contract — invariants for the request path, MLX upstream pin synchronization, model-porting checklist — read [`AGENTS.md`](AGENTS.md) after this.
+
+## Quick links
+
+| You want to... | Read |
+|----------------|------|
+| Report a security vulnerability | [`SECURITY.md`](SECURITY.md) — **do not** open a public issue |
+| File a bug or feature request | [GitHub Issues](https://github.com/lablup/mlxcel/issues) (use the templates) |
+| Build and test locally | [`docs/installation.md`](docs/installation.md) |
+| Understand the architecture | [`docs/architecture.md`](docs/architecture.md) |
+| Add a new model family | [`docs/adding-models.md`](docs/adding-models.md) |
+| Understand the project conventions | [`AGENTS.md`](AGENTS.md) |
+
+## How to contribute
+
+### Reporting issues
+
+- Search existing issues first.
+- Use the bug-report or feature-request template — they prompt for the information we need to act on the issue.
+- Include the mlxcel version (`mlxcel --version`), platform (macOS Apple Silicon / Linux CUDA + GPU model), and the checkpoint you were running.
+- For inference correctness or performance reports, also include the prompt and seed so the run is reproducible.
+
+### Submitting pull requests
+
+1. Fork the repository and create a feature branch off `main`:
+   ```bash
+   git checkout -b feat/short-description
+   ```
+2. Make your changes. Keep one PR scoped to **one logical change** — a model port, an MLX bump, and a CLI rename are three PRs.
+3. Build and test for your target:
+   ```bash
+   # macOS (Apple Silicon)
+   cargo build --release --features metal,accelerate
+   cargo test --release
+
+   # Linux / CUDA
+   cargo build --release --features cuda
+   cargo test --release
+   ```
+4. Run the local quality gates:
+   ```bash
+   cargo fmt --check
+   cargo clippy --all-targets -- -D warnings
+   cargo deny check        # advisories + licenses + sources
+   ```
+5. For inference changes, validate against a real checkpoint — synthetic or build-only validation is not enough (see [`AGENTS.md`](AGENTS.md) for why).
+6. Commit with a conventional prefix (see below) and a clear message.
+7. Push to your fork and open a Pull Request. The PR template will prompt for a summary, test plan, and linked issues.
+
+### Commit and PR conventions
+
+Write commits, PR titles, and issue comments in **English**. Use Conventional Commits prefixes:
+
+| Prefix | When |
+|--------|------|
+| `feat:` | New user-visible feature |
+| `fix:` | Bug fix |
+| `perf:` | Performance improvement with measurable evidence |
+| `refactor:` | Internal restructuring without behavior change |
+| `chore:` | Build, CI, dependencies, release infrastructure |
+| `docs:` | Documentation |
+| `test:` | Tests only |
+
+### Code standards
+
+- Follow standard Rust conventions: `rustfmt`, `clippy -D warnings`, idiomatic ownership and error handling.
+- Tests live next to the code (`_tests.rs` files) for unit tests, and under `tests/` for end-to-end integration.
+- When modifying a function shared by multiple models, update the `// Used by: Model1, Model2, …` comment above it. See [`docs/code-guidelines.md`](docs/code-guidelines.md).
+- Do not introduce Python on the inference request path. Python is acceptable only for benchmarks and out-of-band tooling.
+
+### Adding a new model family
+
+See [`docs/adding-models.md`](docs/adding-models.md) for the full checklist. The short version: land one working checkpoint plus tests before broadening, mirror the `mlx-lm` / `mlx-vlm` directory shape where it helps, and update [`docs/supported-models.md`](docs/supported-models.md) plus the detection table in `src/models/detection.rs`.
+
+### Bumping the MLX upstream pin
+
+The pinned MLX C++ commit lives in three files that must stay in sync — see the "MLX upstream commit upgrade" section of [`AGENTS.md`](AGENTS.md) for the list and the mandatory post-bump validation.
+
+## Development environment
+
+Detailed setup instructions are in [`docs/installation.md`](docs/installation.md).
+
+Minimum:
+
+- Rust **1.93+** (project uses edition 2024)
+- macOS: Apple Silicon Mac on macOS Sonoma+; Xcode Command Line Tools
+- Linux: CUDA 13+ toolchain, OpenBLAS, LAPACK (see [`docs/installation.md`](docs/installation.md) for the package list)
+
+Recommended local tooling:
+
+```bash
+cargo install cargo-deny --locked
+cargo install cargo-audit --locked
+```
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to abide by its terms.
+
+## Questions
+
+- General questions, design discussion: open a [GitHub Discussion](https://github.com/lablup/mlxcel/discussions) (when enabled) or a `question` issue.
+- Security: see [`SECURITY.md`](SECURITY.md).
+
+## License
+
+By contributing to mlxcel, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,9 +2336,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -2595,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # mlxcel
 
+[![License: Apache 2.0](https://img.shields.io/github/license/lablup/mlxcel)](LICENSE)
+[![Latest Release](https://img.shields.io/github/v/release/lablup/mlxcel)](https://github.com/lablup/mlxcel/releases/latest)
+[![CI](https://github.com/lablup/mlxcel/actions/workflows/ci.yml/badge.svg)](https://github.com/lablup/mlxcel/actions/workflows/ci.yml)
+
 High-performance LLM/VLM inference runtime and server for Apple Silicon. The CLI and server are implemented in Rust and execute models through native MLX C++ bindings. Linux/CUDA builds are supported as a secondary target.
 
 ## Overview
@@ -142,7 +146,9 @@ for the CLI summary, and see [Supported models](docs/supported-models.md) for th
 
 ## Contributing
 
-Issues and pull requests are welcome. New model architectures, performance work, bug fixes, and documentation improvements are all useful. For larger changes, please open an issue first so the scope and validation plan can be discussed.
+Issues and pull requests are welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contributor workflow, local quality gates (`cargo fmt`, `clippy`, `cargo test`, `cargo deny check`), and commit conventions. New model architectures, performance work, bug fixes, and documentation improvements are all useful. For larger changes, please open an issue first so the scope and validation plan can be discussed.
+
+For security vulnerabilities, see [`SECURITY.md`](SECURITY.md) — do **not** file these as public issues.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,280 @@
+# Security Policy
+
+## Overview
+
+The mlxcel team takes security seriously. We appreciate the security research community's efforts in helping us keep mlxcel and its users safe. This document outlines how we accept vulnerability reports, what to expect from our response process, and what is in and out of scope.
+
+## Supported Versions
+
+We provide security updates for the following versions:
+
+| Version              | Supported          | End of Support              |
+| -------------------- | ------------------ | --------------------------- |
+| 0.0.x (>=0.0.27)     | :white_check_mark: | Current pre-1.0 line        |
+| < 0.0.27             | :x:                | Pre-public release; unsupported |
+
+> **Note**: mlxcel is currently in the pre-1.0 (`0.0.x`) line. Until the project cuts its first minor release, the latest published `0.0.x` stable is the only supported version and security fixes ship as a new patch release. End-of-support dates will be defined when the project reaches `0.1.0`.
+
+We strongly recommend always running the latest stable release to ensure you have the most recent security fixes.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+If you discover a security vulnerability in mlxcel, please report it through one of the following channels:
+
+### Preferred: GitHub Security Advisories
+
+1. Navigate to the [Security Advisories](https://github.com/lablup/mlxcel/security/advisories) page
+2. Click **Report a vulnerability**
+3. Fill out the form with as much detail as possible
+
+This channel keeps the report private until a fix is ready and lets us collaborate with you on the patch.
+
+### Alternative: Email
+
+Send an email to **security@lablup.com** with the following information:
+
+- Subject line: `[SECURITY] mlxcel - <brief description>`
+- Detailed description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Potential impact and attack scenarios
+- Proof of concept (if available)
+- Your contact information for follow-up
+
+For sensitive disclosures, you may request our PGP key by emailing security@lablup.com with subject `[PGP KEY REQUEST]`.
+
+### What to Include
+
+A good vulnerability report should include:
+
+1. **Type of vulnerability** (e.g., authentication bypass, deserialization, command injection)
+2. **Affected component** (e.g., `mlxcel-server` HTTP endpoint, weight loader, downloader)
+3. **Affected versions**
+4. **Detailed description** of the vulnerability and its potential impact
+5. **Step-by-step reproduction** with example requests, commands, or input files
+6. **Proof of concept** (code, scripts, or demonstration)
+7. **Suggested mitigation** (optional but appreciated)
+8. **CVE identifier** (if already assigned)
+
+### What to Expect
+
+- **Initial acknowledgment**: within **48-72 hours** for all severity levels
+- **Status updates**: at least weekly during investigation and remediation
+- **Validation**: our team will validate the report and determine severity
+- **Fix timeline**: see the severity table below
+- **Disclosure**: coordinated with you per the policy below
+- **Credit**: with your permission, we will publicly credit you in the security advisory and release notes
+
+## Disclosure Policy
+
+We follow a **90-day coordinated disclosure policy**:
+
+1. **Day 0**: vulnerability reported
+2. **Day 0-7**: triage, validation, severity assessment
+3. **Day 7-60**: develop, test, and review the fix
+4. **Day 60-75**: prepare the security advisory and coordinate with the reporter
+5. **Day 75-90**: release patched versions and publish the advisory
+6. **Day 90**: public disclosure (may be extended by mutual agreement)
+
+### Severity-Based Timelines
+
+| Severity | Target Fix Timeline | Target Disclosure |
+| -------- | ------------------- | ----------------- |
+| Critical | 24-48 hours         | 7-14 days         |
+| High     | 1 week              | 30 days           |
+| Medium   | 2-4 weeks           | 60 days           |
+| Low      | Next patch release  | 90 days           |
+
+We may request an extension if the fix requires significant architectural changes, coordination with upstream MLX libraries, or additional testing across model architectures.
+
+## Security Update Process
+
+When we ship a security fix we will:
+
+1. Publish a **GitHub Security Advisory** with CVE (if applicable), description, affected/fixed versions, mitigation guidance, and reporter credit
+2. Release a patched version following semantic versioning
+3. Update `CHANGELOG.md` with the security fix
+4. Announce through GitHub Releases
+
+Users can stay informed by:
+
+- Watching the repository with **Security alerts** enabled
+- Following the [Security Advisories](https://github.com/lablup/mlxcel/security/advisories) page
+- Monitoring the [Releases](https://github.com/lablup/mlxcel/releases) page
+
+## Scope
+
+### In Scope
+
+We are interested in reports about the following classes of vulnerability in mlxcel itself (the `mlxcel` CLI, `mlxcel-server` HTTP server, `mlxcel-core` runtime, and `mlxcel-surgery` operations):
+
+#### Authentication & Authorization
+- Authentication bypass on `mlxcel-server` HTTP endpoints
+- API-key handling weaknesses (leakage, weak comparison, missing validation)
+- Authorization bypass between sessions or tenants on a shared server
+
+#### Code Execution & Deserialization
+- Crafted model checkpoints (safetensors, GGUF, weight shards) that trigger memory-corruption, OOB reads/writes, integer overflows, or arbitrary code execution during weight loading
+- Crafted YAML inputs (e.g., `--surgery <config.yaml>`) that lead to unsafe deserialization or path traversal
+- Crafted prompts or HTTP payloads that lead to native crashes, panics with secret exposure, or memory corruption in the FFI boundary
+
+#### Data Exposure
+- Cross-request leakage of KV-cache contents on shared `mlxcel-server` instances
+- Sensitive data in logs, error messages, or traces (API keys, prompt contents from other sessions, file paths beyond the server's intended scope)
+- Path-traversal in `mlxcel download` or weight loaders
+
+#### Denial of Service
+- Resource exhaustion via crafted prompts, weight shapes, or HTTP request patterns that disproportionately consume CPU, GPU, memory, or disk
+- Algorithmic-complexity attacks in the sampler, tokenizer, scheduler, or speculative-decoding paths
+- Crashes that take down `mlxcel-server` reliably from a single request
+- Rate-limit bypass (if rate limiting is configured)
+
+#### Cryptographic Issues
+- Missing or weak TLS verification when fetching models via `mlxcel download`
+- Insecure handling of checksums or signatures on downloaded artifacts
+- Use of weak random sources where cryptographic randomness is required
+
+#### Distributed Mode (Pipeline / Tensor Parallel)
+- Unauthenticated peer discovery (mDNS) accepting hostile peers
+- Tampering with inter-node tensor traffic
+- Replay or injection attacks against the pipeline-parallel control plane
+
+#### Release & Supply Chain
+- Tampering with published GitHub release assets, the Homebrew formula, or workflow definitions that would let an attacker substitute the binary
+- Workflows that would allow a forked PR or arbitrary contributor to obtain release-signing secrets or self-hosted runner access
+
+### Out of Scope
+
+The following are **not** treated as security vulnerabilities by this policy:
+
+#### Model Behavior
+- Model output quality, factual errors, hallucinations, or jailbreaks
+- Prompt-injection effects on model output (this is a model-behavior concern, not a runtime vulnerability)
+- Bias, fairness, or content-moderation issues
+
+#### Upstream MLX
+- Vulnerabilities in the underlying MLX C++ libraries (please report to [ml-explore/mlx](https://github.com/ml-explore/mlx))
+- Issues that only reproduce against unmaintained or upstream-deprecated model architectures
+
+#### Dependency Vulnerabilities Without mlxcel Impact
+- Known advisories on third-party crates that do not affect any code path mlxcel actually exercises (please open a regular issue or PR with the relevant `[advisories.ignore]` justification for `deny.toml`)
+
+#### Non-Security Bugs
+- General bugs without security implications (please file a regular issue)
+- Performance regressions without DoS implications
+- Feature requests
+
+#### Social Engineering / Physical
+- Phishing or social engineering against maintainers or users
+- Physical access to user hardware
+
+## Safe Harbor
+
+Lablup Inc. supports the security research community and will not pursue legal action against researchers who:
+
+1. **Act in good faith** to report vulnerabilities responsibly
+2. **Avoid privacy violations** by not accessing, modifying, or deleting data beyond what is needed to demonstrate the issue
+3. **Avoid service disruption** by not degrading availability for others
+4. **Do not publicly disclose** the vulnerability before we have had a reasonable time to respond
+5. **Follow this security policy** and coordinate disclosure timelines
+
+We will work with you to understand and validate your report. We will not file legal claims or contact law enforcement about your research if you comply with this policy.
+
+Safe harbor applies to research conducted on:
+
+- Local development environments
+- Test environments you have explicit permission to test
+- Publicly-accessible instances of `mlxcel-server` that you operate
+
+Do **not** test against production systems you do not own, access other users' data, or conduct testing that could harm availability for others.
+
+## Security Best Practices for Operators
+
+While we work to make mlxcel secure by default, operators running `mlxcel-server` in production should:
+
+### Server Configuration
+- **Bind to a trusted interface** — `mlxcel-server` does not assume the network it is exposed on is trusted; put it behind a TLS-terminating reverse proxy for any non-loopback exposure
+- **Enable authentication** if you expose the server to multiple clients; do not assume API keys are optional
+- **Restrict network access** with firewalls or network policies; assume any unauthenticated path is reachable from the open internet if it is bound to `0.0.0.0`
+- **Keep model files under controlled paths** — the server's file-system access is your responsibility
+
+### Model Sourcing
+- **Verify checksums** of downloaded model checkpoints (`.sha256` files are published alongside release assets and Hugging Face provides hashes for model files)
+- **Treat checkpoints as code** — a malicious safetensors file can attempt to exploit loader bugs; only load models from sources you trust
+
+### Distributed Mode
+- **Do not enable mDNS-based discovery on untrusted networks** — use explicit static peer lists in any environment where the local network is not fully under your control
+
+### Updates
+- **Subscribe to security advisories** and apply patches promptly
+- **Test updates** in staging before production
+
+## Security Features
+
+mlxcel currently ships the following security-relevant practices and features:
+
+- **Hardened release pipeline**: top-level default-deny GitHub Actions permissions, per-job grants, `github.repository` guards against fork `workflow_dispatch`, and `persist-credentials: false` on every checkout to prevent token leakage into `.git/config` on self-hosted runners
+- **Repository ruleset on `main`**: blocks force-push and branch deletion (Ruleset `main protection`, no bypass actors)
+- **`cargo-deny` audit**: vulnerability, license, and source-provenance checks gate every PR
+- **Automated dependency updates**: Dependabot runs weekly across all Cargo crates and GitHub Actions
+- **Verified secret-scanning baseline**: `.gitleaksignore` documents known false positives, and GitHub native Secret Scanning is enabled on this public repository
+- **Reproducible release artifacts**: every release asset is published with a `.sha256` companion file
+
+## Dependency Security Auditing
+
+mlxcel uses automated tools to catch vulnerable dependencies before they reach a release.
+
+### Automated CI/CD Checks
+- **cargo-deny**: runs on every PR and push to `main` (advisories, licenses, bans, sources)
+- **Dependabot**: weekly scans across `cargo` (root, `mlxcel-core`, `mlxcel-surgery`) and `github-actions` ecosystems
+- **GitHub Security Alerts**: real-time vulnerability notifications via Dependabot
+
+### Local Security Audits
+
+Before submitting a PR, run security checks locally:
+
+```bash
+# Install (one-time)
+cargo install cargo-deny --locked
+
+# Comprehensive check (advisories + licenses + bans + sources)
+cargo deny check
+
+# Or, for vulnerability-only check
+cargo install cargo-audit --locked
+cargo audit
+```
+
+### Configuration Files
+
+- **`deny.toml`**: `cargo-deny` configuration (advisories, license allow-list, sources)
+- **`.github/dependabot.yml`**: Dependabot schedule, grouping, and ecosystems
+- **`.gitleaksignore`**: justifications for verified-false-positive secret scanner findings
+
+### Accepting an Unfixable Advisory
+
+If an advisory exists for a dependency mlxcel cannot upgrade out of (e.g., transitive, no patched version published, not exploitable in our context), document the exception in `deny.toml`:
+
+```toml
+[advisories]
+ignore = [
+    { id = "RUSTSEC-XXXX-XXXX", reason = "Not exploitable in our usage: <specific reason>" },
+]
+```
+
+## Security Contacts
+
+- **Security advisories**: [Report a vulnerability](https://github.com/lablup/mlxcel/security/advisories/new)
+- **Email**: security@lablup.com
+- **Organization**: Lablup Inc.
+
+## Acknowledgments
+
+We will thank security researchers here as we receive and address reports.
+
+---
+
+**Last Updated**: 2026-05-18
+**Version**: 1.0

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,84 @@
+# cargo-deny configuration.
+# Docs: https://embarkstudios.github.io/cargo-deny/checks/index.html
+
+[graph]
+# Target platforms that mlxcel actually ships binaries for.
+# macOS Apple Silicon (Metal) + Linux aarch64 CUDA (gb10, gh200) are the
+# release targets per `.github/workflows/release.yml`.
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+]
+all-features = false
+no-default-features = false
+
+# ============================================================================
+# Advisories — RustSec vulnerability checking
+# ============================================================================
+[advisories]
+db-path = "~/.cargo/advisory-db"
+ignore = [
+    # `bincode 1.3.3` — used by mlxcel-core. The bincode 1.x team has permanently
+    # ceased development (RUSTSEC-2025-0141). No safe upgrade exists; bincode 2.x
+    # is a different crate with a breaking API. Migration to an alternative
+    # (postcard / bitcode / rkyv) is tracked separately and is not a runtime
+    # security issue — the advisory is "unmaintained", not a vulnerability.
+    { id = "RUSTSEC-2025-0141", reason = "bincode 1.x permanently unmaintained; migration tracked in a follow-up issue; no runtime vulnerability" },
+
+    # `paste 1.0.15` — transitive via the `tokenizers` crate (HF). The author
+    # archived the project (RUSTSEC-2024-0436). `pastey` is a drop-in fork but
+    # adoption depends on upstream `tokenizers` switching. No runtime vulnerability
+    # — pure macro-expansion crate used at build time.
+    { id = "RUSTSEC-2024-0436", reason = "Transitive via tokenizers; archived but no runtime impact; awaiting upstream switch to pastey" },
+]
+
+# ============================================================================
+# Licenses — License compliance for OSS release
+# ============================================================================
+[licenses]
+confidence-threshold = 0.8
+# OSI-approved permissive licenses compatible with Apache-2.0 distribution.
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "MIT-0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "BSL-1.0",
+    "Unlicense",
+    "OpenSSL",
+]
+
+# Private/internal crates (mlxcel, mlxcel-core, mlxcel-surgery) without
+# external registry presence — they're Apache-2.0 per their own Cargo.toml.
+[licenses.private]
+ignore = false
+registries = []
+
+# ============================================================================
+# Bans — Crate banning and duplicate checking
+# ============================================================================
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+highlight = "all"
+workspace-default-features = "allow"
+deny = []
+skip = []
+skip-tree = []
+
+# ============================================================================
+# Sources — Registry and source provenance
+# ============================================================================
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = []
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Implements remaining OSS release follow-up work for #1: D-section security automation, B-section community health files, E-section README polish, plus a bonus discovery (the missing general PR-time audit gate).

**Hold the merge** — per #1, stack additional follow-ups on this branch or on `main` and merge them together when the OSS release follow-up is ready to ship.

## Section D — Security automation

- `.github/dependabot.yml` — cargo (root, `mlxcel-core`, `mlxcel-surgery`) + github-actions, weekly Monday 09:00 KST, minor/patch grouping, per-area labels (`area:core`, `area:surgery`).
- `deny.toml` — `cargo-deny` config restricted to shipping platforms (`aarch64-apple-darwin`, `aarch64-unknown-linux-gnu`), permissive license allow-list, crates.io as only registry.
- **`.github/workflows/ci.yml`** *(bonus, not in original #1)* — PR-time `cargo deny check` gate via `EmbarkStudios/cargo-deny-action@v2` on `ubuntu-latest`, path-filtered to Rust changes, top-level read-only permissions and `persist-credentials: false`. Closes the "external PR can land without security audit" gap discovered while writing this PR.

**Advisory fixes applied to `Cargo.lock`:**
- `rustls-webpki` `0.103.10 → 0.103.13` — RUSTSEC-2026-0098 / 0099 / 0104 (name-constraint wildcard bug, CRL parsing panic)
- `rand` `0.9.2 → 0.9.4` — RUSTSEC-2026-0097 (`ThreadRng` unsoundness under custom logger + reseed)

**Documented exceptions in `deny.toml`** for unmaintained crates with no safe upgrade:
- `bincode` 1.3.3 — RUSTSEC-2025-0141 (project permanently shut down; migration to postcard/bitcode/rkyv tracked separately)
- `paste` 1.0.15 — RUSTSEC-2024-0436 (archived; transitive via `tokenizers`; pure macro crate with no runtime impact)

**Deviation from #1 D-section**: GitHub-native CodeQL is **not** included because Rust support is in beta tier and produces low-signal results for cargo crates. The functionally equivalent coverage comes from `cargo deny check` (RustSec advisories + license + source provenance), which is now also wired into the PR gate via `ci.yml`.

## Section B — Community health files

- `SECURITY.md` — 90-day coordinated disclosure, severity-based fix timelines, in-scope sections specific to mlxcel (weight-loader deserialization, KV-cache cross-request leakage, distributed-mode peer discovery, release-pipeline tampering), explicitly out-of-scope items (model output quality, upstream MLX bugs, prompt injection).
- `CONTRIBUTING.md` — entry-level contributor guide pointing to `AGENTS.md` for the deep working contract.
- `CITATION.cff` — Citation File Format v1.2.0 metadata, Apache-2.0, v0.0.27.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured form with version / install method / platform / model / logs.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — structured form with problem / proposal / scope / acceptance.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; routes security reports to `SECURITY.md`, questions to Discussions, upstream MLX bugs to `ml-explore/mlx`.
- `.github/PULL_REQUEST_TEMPLATE.md` — summary + test plan + conventional-commit checklist + shared-function comment-update reminder.

After this merges, the community profile health should rise from **50% → 100%**.

## Section E — README polish

- Status badges added directly under the H1: license (Apache-2.0), latest release, CI status (links to the new `ci.yml`). Homebrew badge intentionally omitted because `lablup/tap` is a third-party tap and shields.io's `homebrew/v` only resolves against homebrew-core.
- Contributing section now links to `CONTRIBUTING.md` (workflow + quality gates) and `SECURITY.md` (vulnerability reports) with a "do not file as public issues" note.
- `docs/` link integrity check passed: no `docs_internal/` references remain anywhere in the public-facing tree.

## Test plan

- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok` after the advisory fixes and ignore-with-justification entries
- [x] `docs_internal` grep across `docs/`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `AGENTS.md` returns 0 matches
- [ ] `ci.yml` runs successfully on this PR after push (verifies the workflow is well-formed and the cargo-deny gate passes against the lock file in this branch)
- [ ] Visual inspection of issue / PR templates at `https://github.com/lablup/mlxcel/issues/new/choose` after merge
- [ ] README badges render correctly on the public main page after merge
- [ ] First Dependabot run after merge (next Monday 09:00 KST) produces expected per-area-labeled PRs

## Explicitly out of scope (follow-up PRs)

- **`cargo fmt` drift cleanup**: 214 fmt violations are accumulated in the tree. A separate fmt-only PR will reformat the tree and add `cargo fmt --check` to the CI gate. Skipping it here keeps this PR reviewable and lets the fmt diff land as a clearly-labeled noisy commit.
- **`cargo clippy` and `cargo test` as PR-level gates**: these need a self-hosted macOS Apple Silicon runner because of the MLX C++ FFI build. Future `ci.yml` extension.
- **`packaging` env required-reviewer hardening** to a real 4-eyes principle: currently registered with `prevent_self_review: false` while release tooling is being automated. Revisit later (tracked in #1 A-section follow-up note).

## Refs

- Part of #1