### PR TITLE
ci: add clippy and cargo test gates via self-hosted macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
 # PR / push CI for lightweight quality gates. Builds and tests are covered by
 # release.yml (signed artifacts) and pipeline-parallel-ci.yml (distributed
-# runs); this workflow runs cargo-deny (license / advisory) and cargo-fmt
-# checks on every touched-Rust change so formatting drift and license issues
-# are caught at PR time.
+# runs); this workflow runs cargo-deny (license / advisory), cargo-fmt, and
+# cargo-clippy + cargo-test checks on every touched-Rust change so formatting
+# drift, license issues, and lint/test regressions are caught at PR time.
+#
+# Note on CUDA gating: CUDA verification stays exclusive to release.yml because
+# it requires a Linux self-hosted runner (currently only the GB10 node used for
+# release builds). Adding a PR-level CUDA gate would double runner cost for
+# limited additional safety on PRs that don't touch CUDA-specific code paths.
 
 name: CI
 
@@ -70,3 +75,30 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
+
+  clippy-and-test:
+    name: clippy + test (macOS ARM64)
+    needs: changes
+    # Only run when Rust files changed; block fork-PR access to the self-hosted
+    # runner pool (mirrors the guard in release.yml and pipeline-parallel-ci.yml).
+    if: >-
+      needs.changes.outputs.rust == 'true' &&
+      github.repository == 'lablup/mlxcel' &&
+      (github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: self-hosted-macos-26-arm64
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Build (verify MLX FFI compiles)
+        run: cargo build --release --features metal,accelerate
+      - name: Clippy
+        run: cargo clippy --all-targets --features metal,accelerate -- -D warnings
+      - name: Test
+        run: cargo test --release --features metal,accelerate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,11 @@ Thank you for your interest in contributing to mlxcel! This document covers the 
 4. Run the local quality gates:
    ```bash
    cargo fmt --all -- --check   # enforced by CI; fmt violations block merge
-   cargo clippy --all-targets -- -D warnings
+   cargo clippy --all-targets --features metal,accelerate -- -D warnings   # enforced by CI on self-hosted macOS runner
+   cargo test --release --features metal,accelerate                         # enforced by CI on self-hosted macOS runner
    cargo deny check             # advisories + licenses + sources
    ```
+   CI enforces `clippy` (with `-D warnings`) and `cargo test` on the `self-hosted-macos-26-arm64` runner on every PR that touches Rust files. CUDA verification is not gated at PR time — that stays exclusive to `release.yml`.
 5. For inference changes, validate against a real checkpoint — synthetic or build-only validation is not enough (see [`AGENTS.md`](AGENTS.md) for why).
 6. Commit with a conventional prefix (see below) and a clear message.
 7. Push to your fork and open a Pull Request. The PR template will prompt for a summary, test plan, and linked issues.


### PR DESCRIPTION
## Summary

- Add `clippy-and-test` job to `.github/workflows/ci.yml` running on `self-hosted-macos-26-arm64`
- Gate with same path-filter (`needs.changes.outputs.rust == 'true'`) as `deny` and `fmt` jobs
- Apply fork-PR security guard from `release.yml` / `pipeline-parallel-ci.yml` to prevent fork-authored code from reaching the canonical self-hosted runner pool
- Update `CONTRIBUTING.md` local quality-gate list to match CI enforcement

## What changed

- `.github/workflows/ci.yml`: added `clippy-and-test` job with three steps: `cargo build --release`, `cargo clippy --all-targets -- -D warnings`, `cargo test --release` (all with `--features metal,accelerate`); updated file header comment to document the CUDA decision
- `CONTRIBUTING.md`: expanded the local quality-gate list to include `--features metal,accelerate` on clippy and test commands, with a note that these are now enforced by CI on the macOS self-hosted runner

## CUDA decision

CUDA verification stays exclusive to `release.yml` and is not gated at PR time for two reasons:

1. It requires a Linux self-hosted runner — currently only the `GB10` node used for release builds is available with a working CUDA toolchain.
2. PR-level CUDA gating would double runner cost for limited additional safety on PRs that do not touch CUDA-specific code paths.

## Test plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — passes)
- [x] Job `if:` condition mirrors `release.yml` fork-PR guard exactly
- [x] `persist-credentials: false` on checkout, `permissions: contents: read` at job level
- [x] First run of the new job will fire on the self-hosted runner after this PR is opened (build time 15-30+ min for cold MLX C++ compile; orchestrator is aware and will wait)

Closes #5
