### PR TITLE
chore(make): add CI-faithful verify targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,55 @@ ci: fmt-check check clippy test ## CI workflow: format check, check, lint, test
 .PHONY: pre-commit
 pre-commit: fmt clippy test ## Pre-commit checks
 
+# ----------------------------------------------------------------------------
+# CI-faithful local gate (matches .github/workflows/ci.yml exactly)
+#
+# The `verify*` targets reproduce the GitHub Actions `clippy + test (macOS
+# ARM64)` job step-for-step. They differ from the looser `clippy` / `test`
+# targets above in three ways that have repeatedly bitten us:
+#
+#   1. `--features metal,accelerate` — the CI feature set. Without it, large
+#      gated regions of mlxcel-core (parts of cache/turbo/quant, the
+#      attention-dispatch helpers, etc.) are never type-checked locally, so
+#      lint or build errors land first on CI.
+#   2. `-D warnings` — promotes every clippy warning to an error, matching
+#      `-- -D warnings` in CI. The default `clippy` target uses `-W warnings`
+#      and silently hides regressions.
+#   3. `cargo test --release` — CI runs tests in release mode for realistic
+#      MLX/Metal codegen. Debug-mode tests can pass while release-mode tests
+#      hit different optimisation paths.
+#
+# Run `make verify` before opening or updating a PR. Run `make verify-clean`
+# (which prepends `cargo clean`) when you suspect clippy's per-crate result
+# cache is masking a regression — most often after editing shared code in
+# mlxcel-core that other crates inherit lints from.
+# ----------------------------------------------------------------------------
+
+.PHONY: verify-fmt
+verify-fmt: ## CI-faithful: cargo fmt --all -- --check
+	@echo "$(CYAN)[verify] fmt check...$(RESET)"
+	$(CARGO) fmt --all -- --check
+
+.PHONY: verify-clippy
+verify-clippy: ## CI-faithful: clippy --all-targets --features metal,accelerate -- -D warnings
+	@echo "$(CYAN)[verify] clippy (features=metal,accelerate, -D warnings)...$(RESET)"
+	$(CARGO) clippy --all-targets --features metal,accelerate -- -D warnings
+
+.PHONY: verify-test
+verify-test: ## CI-faithful: cargo test --release --features metal,accelerate
+	@echo "$(CYAN)[verify] test (release, features=metal,accelerate)...$(RESET)"
+	$(CARGO) test --release --features metal,accelerate
+
+.PHONY: verify
+verify: verify-fmt verify-clippy verify-test ## Run the full CI-faithful gate locally (recommended before push)
+	@echo "$(GREEN)[verify] OK — matches GitHub Actions clippy+test job$(RESET)"
+
+.PHONY: verify-clean
+verify-clean: ## Run `verify` after a `cargo clean` (use when clippy's cache may be hiding a regression)
+	@echo "$(YELLOW)[verify-clean] dropping target/ to force a fresh clippy/test pass...$(RESET)"
+	$(CARGO) clean
+	@$(MAKE) --no-print-directory verify
+
 # ============================================================================
 # Quick Examples
 # ============================================================================


### PR DESCRIPTION
## Summary

Adds a `verify*` family of Makefile targets that reproduce the GitHub Actions `clippy + test (macOS ARM64)` job exactly. The existing `clippy` / `test` / `ci` / `pre-commit` targets are weaker than CI in three ways that have repeatedly bitten us:

1. **Default features** — without `--features metal,accelerate`, large gated regions of `mlxcel-core` (parts of `cache/turbo/quant`, the attention-dispatch helpers, the metal/accelerate-only branches in `generate.rs`) aren't even type-checked locally.
2. **`-W warnings` instead of `-D warnings`** — local clippy silently passes on regressions that CI will reject.
3. **Debug-mode tests** — CI runs `cargo test --release`, which exercises different optimisation paths.

This gap cost us three CI rounds (~45 min wasted on the self-hosted runner) while shipping the gpt-oss bf16 fix (#17) and the clippy 1.95 sweep (#18). The new targets close it.

## New targets

| Target | Command |
|---|---|
| `verify-fmt` | `cargo fmt --all -- --check` |
| `verify-clippy` | `cargo clippy --all-targets --features metal,accelerate -- -D warnings` |
| `verify-test` | `cargo test --release --features metal,accelerate` |
| `verify` | runs the three above (recommended before push) |
| `verify-clean` | `cargo clean` + `verify` (use when clippy's per-crate cache may be hiding a regression after editing shared mlxcel-core code) |

## Not changed

The existing looser targets (`fmt-check`, `clippy`, `test`, `ci`, `pre-commit`) are preserved — they remain useful for fast inner-loop iteration where strict CI parity isn't needed. The header comment block above the `verify*` block explains the distinction so the two sets don't accidentally get collapsed later.

## Test plan

- [x] `make verify-fmt` succeeds on a clean tree
- [x] Manual review of each command vs `.github/workflows/ci.yml` lines 77, 102, 104
- [ ] Will exercise `make verify` end-to-end in the next "before push" cycle