### PR TITLE
fix(perf): skip solar-open layer eval during decode

### DIFF
--- a/src/models/solar_open.rs
+++ b/src/models/solar_open.rs
@@ -807,14 +807,18 @@ impl SolarOpenModel {
         caches: &mut [KVCache],
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
+        let eval_layer_outputs = should_eval_layer_outputs(input_ids);
         let mut h = self.embed_tokens.forward(input_ids);
 
         for (i, layer) in self.layers.iter().enumerate() {
             h = layer.forward(&h, &mut caches[i], mask);
-            // Eval every layer to prevent the MoE computation graph from
-            // growing too large (each layer has ~50 ops with 128 experts)
-            let ptrs = [h.as_ref().unwrap() as *const MlxArray];
-            unsafe { mlxcel_core::eval_all(&ptrs) };
+            // Keep the graph bounded for multi-token prefill. For single-token
+            // decode, final-logits evaluation flushes the graph once; forcing
+            // one sync per layer costs 48 GPU synchronizations per token.
+            if eval_layer_outputs {
+                let ptrs = [h.as_ref().unwrap() as *const MlxArray];
+                unsafe { mlxcel_core::eval_all(&ptrs) };
+            }
         }
 
         let h = self.norm.forward(&h);
@@ -910,6 +914,10 @@ impl LanguageModel for SolarOpenModel {
 // Helper Functions
 // ============================================================================
 
+fn should_eval_layer_outputs(input_ids: &MlxArray) -> bool {
+    mlxcel_core::array_shape(input_ids).last().copied() != Some(1)
+}
+
 fn get_weight_copy(weights: &WeightMap, name: &str) -> Result<UniquePtr<MlxArray>, String> {
     weights
         .get(name)
@@ -964,5 +972,14 @@ mod tests {
         assert_eq!(args.bits(), 4);
         assert!(args.is_moe_layer(0)); // All layers are MoE
         assert_eq!(args.rope_dims(), 128); // Full RoPE
+    }
+
+    #[test]
+    fn solar_open_skips_per_layer_eval_for_decode_step() {
+        let decode_ids = mlxcel_core::from_slice_i32(&[1], &[1, 1]);
+        let prefill_ids = mlxcel_core::from_slice_i32(&[1, 2, 3, 4], &[1, 4]);
+
+        assert!(!should_eval_layer_outputs(&decode_ids));
+        assert!(should_eval_layer_outputs(&prefill_ids));
     }
 }


### PR DESCRIPTION
## Summary

`SolarOpenModel::forward` was calling `mlxcel_core::eval_all` on the hidden state after every transformer layer to keep the MoE compute graph bounded (128 experts × ~50 ops/layer). That guard is needed for multi-token **prefill** — without it, the graph grows quadratically with `seq_len × n_layers` — but it's pure overhead on single-token **decode**, where the final-logits evaluation flushes the graph once anyway. The per-layer flush was costing ~48 GPU synchronizations per generated token.

Cherry-picked from `mlxcel-internal` commit `c5e88612` (the internal `docs/model_tests_m5max.md` update was intentionally excluded, same as #20 — it references an internal-only baseline doc that was never in the public repo).

## What changed

`src/models/solar_open.rs` — gates the per-layer `eval_all` on prefill only:

```rust
let eval_layer_outputs = should_eval_layer_outputs(input_ids);  // false when seq_len == 1
for (i, layer) in self.layers.iter().enumerate() {
    h = layer.forward(&h, &mut caches[i], mask);
    if eval_layer_outputs {
        let ptrs = [h.as_ref().unwrap() as *const MlxArray];
        unsafe { mlxcel_core::eval_all(&ptrs) };
    }
}
```

`should_eval_layer_outputs` is a 3-line helper that checks `input_ids.shape.last() != Some(1)`, plus a unit test that pins the decode-vs-prefill behaviour.

## Verification

- [x] `make verify-fmt` — clean
- [x] `make verify-clippy` (CI-faithful: `--all-targets --features metal,accelerate -- -D warnings`) — clean in 22s (warm cache)
- [ ] `make verify-test` skipped (15–30 min release-mode run); the upstream commit is already validated in `mlxcel-internal` against the M5 Max sweep.