### PR TITLE
chore(ci): drop clippy+test from release pipeline; keep gate local-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,16 @@
 # advisory) and cargo-fmt on every touched-Rust change so formatting drift and
 # license issues are caught at PR time.
 #
-# Clippy and cargo-test used to run here as `clippy + test (macOS ARM64)` on
-# the self-hosted Apple Silicon runner, but each run consumed ~15 minutes of
-# that single shared runner per PR push. Those gates were moved to the release
-# workflow (`release.yml::build-macos`), which now runs fmt/clippy/test before
-# producing signed artifacts. Local developers should run `make verify` (or
-# `make verify-clean` for a cache-clear pass) before pushing to catch
-# regressions that release-time CI will otherwise surface.
+# Clippy and cargo-test do NOT run in any workflow. They used to run on the
+# self-hosted Apple Silicon runner — first here at PR time, then briefly in
+# release.yml — and in both cases consumed ~30 min per run, blocking either
+# PRs or releases on a shared resource for failures that `make verify`
+# reliably catches on the developer's machine in a fraction of the time.
+#
+# Quality gate lives locally. Pre-push checklist:
+#   make verify         # fmt + clippy(metal,accelerate, -D warnings) + test(release)
+#   make verify-clean   # same, after `cargo clean` — use when clippy's
+#                       # per-crate cache may be hiding a regression
 #
 # Note on CUDA gating: CUDA verification stays exclusive to release.yml because
 # it requires a Linux self-hosted runner (currently only the GB10 node used for

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,21 +96,24 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin
-          components: clippy, rustfmt
 
-      # Quality gate — fmt / clippy / test. Used to live in ci.yml's
-      # `clippy + test (macOS ARM64)` job, but consumed ~15 min of the shared
-      # self-hosted runner on every PR push for limited PR-time signal. Moved
-      # here so the cost is paid once per release. Local devs should run
-      # `make verify` before pushing to catch regressions earlier.
-      - name: Format check
-        run: cargo fmt --all -- --check
-
-      - name: Clippy
-        run: cargo clippy --all-targets --features metal,accelerate -- -D warnings
-
-      - name: Test
-        run: cargo test --release --features metal,accelerate
+      # Lint and test deliberately do not run in this workflow.
+      #
+      # `clippy + test` against the macOS Apple Silicon target takes ~30+ min
+      # on the shared self-hosted runner. We tried gating it at PR time
+      # (ci.yml::clippy-and-test) and at release time (this job, see #21),
+      # and in both cases the cost outweighed the signal — PRs and releases
+      # were both being blocked on a slow shared resource for failures that
+      # `make verify` / `make verify-clean` reliably catch on the developer's
+      # machine in a fraction of the time.
+      #
+      # Quality gate lives locally now. Pre-push checklist:
+      #   make verify         # fmt + clippy(metal,accelerate, -D warnings) + test(release)
+      #   make verify-clean   # same, after `cargo clean` — use when clippy's
+      #                       # per-crate cache may be hiding a regression
+      #
+      # PR-time CI (ci.yml) still runs cargo-deny and cargo-fmt on ubuntu
+      # for cheap license/format drift detection.
 
       - name: Build release binaries
         run: cargo build --release --target aarch64-apple-darwin --locked


### PR DESCRIPTION
## Summary

PR #21 moved `clippy + test` from PR-time `ci.yml` into `release.yml::build-macos` on the assumption that paying ~15 min once per release was cheaper than paying it on every PR push. The first real run came in at **~30+ min** on the shared self-hosted Apple Silicon runner, which inverts the trade-off — release builds now block on a slow lint/test pass that `make verify` would have caught locally in seconds.

This PR drops clippy+test from the release pipeline entirely. The quality gate is now **local-only**, via the `verify*` targets introduced in #19.

## What changed

**`release.yml`** — removed from `build-macos`:
- `Format check` step
- `Clippy` step
- `Test` step
- `components: clippy, rustfmt` from the toolchain install

The `build-macos` job is back to its pre-#21 shape: build → sign → package → upload. A long comment block in its place documents *why* lint/test aren't here and points at `make verify` / `make verify-clean`.

**`ci.yml`** — header comment updated:
- Removed the "moved to release.yml" claim that's now wrong.
- Added the same pre-push checklist (`make verify`, `make verify-clean`).

## What didn't change

PR-time CI still runs `cargo-deny` + `cargo-fmt` on ubuntu (both are cheap, neither touches the self-hosted runner). `pipeline-parallel-ci.yml` is untouched.

## Trade-off

- **Cost saved**: release builds no longer wait 30+ min on lint/test.
- **Cost added**: developers must run `make verify` before pushing — otherwise lint/test regressions land on `main` until somebody runs it locally.
- **Net**: aligns with the actual workflow (`make verify` exists, takes ~2 min on a warm cache, and we already use it before every push in practice).