### PR TITLE
fix(perf): use MLX fast RMSNorm in GatedDeltaNet decode path

### DIFF
--- a/src/models/gated_delta.rs
+++ b/src/models/gated_delta.rs
@@ -400,6 +400,18 @@ pub fn gated_delta_update(
     gated_delta_ops(q, k, v, &g, &beta, state, mask)
 }
 
+/// Fast RMS normalization without a learned scale, followed by scalar scaling.
+///
+/// Mirrors mlx-lm's `mx.fast.rms_norm(x, None, eps) * scale` path for linear
+/// attention q/k normalization, avoiding the expanded square/mean/sqrt/divide
+/// graph on every decode step.
+///
+/// Used by: Qwen3Next, Qwen3.5, KimiLinear
+pub fn scaled_fast_rms_norm_no_weight(x: &MlxArray, scale: f32, eps: f32) -> UniquePtr<MlxArray> {
+    let normed = mlxcel_core::fast_rms_norm_no_weight(x, eps);
+    mlxcel_core::multiply_scalar(&normed, scale)
+}
+
 // RMSNorm with optional gating.
 /// RMSNorm with optional SwiGLU gating (for GatedDeltaNet output).
 /// Gating: silu(gate) * rms_norm(x)
@@ -418,13 +430,10 @@ impl RMSNormGated {
     pub fn forward(&self, x: &MlxArray, gate: Option<&MlxArray>) -> UniquePtr<MlxArray> {
         let target_dtype = mlxcel_core::array_dtype(x);
 
-        // RMS normalization
-        let x_sq = mlxcel_core::square(x);
-        let mean_sq = mlxcel_core::mean_axis(&x_sq, -1, true);
-        let eps_arr = mlxcel_core::full_f32(&[1], self.eps, mlxcel_core::array_dtype(&mean_sq));
-        let rms = mlxcel_core::sqrt(&mlxcel_core::add(&mean_sq, &eps_arr));
-        let normed = mlxcel_core::divide(x, &rms);
-        let scaled = mlxcel_core::multiply(&normed, &self.weight);
+        // Reference mlx-lm uses mx.fast.rms_norm here. Keeping this as the
+        // fast kernel avoids expanding the gated delta decode graph with
+        // square/mean/sqrt/divide/multiply per linear-attention layer.
+        let scaled = mlxcel_core::fast_rms_norm(x, &self.weight, self.eps);
 
         // Apply SwiGLU gating: silu(gate) * x
         // Python mlx-lm promotes the gated path to float32 before restoring the

--- a/src/models/kimi_linear.rs
+++ b/src/models/kimi_linear.rs
@@ -22,7 +22,7 @@
 //!
 //! Reference: mlx-lm/mlx_lm/models/kimi_linear.py
 
-use crate::models::gated_delta::gated_delta_update;
+use crate::models::gated_delta::{gated_delta_update, scaled_fast_rms_norm_no_weight};
 use crate::models::switch_layers::SwitchGLU;
 use mlxcel_core::dtype;
 use mlxcel_core::generate::LanguageModel;
@@ -590,22 +590,11 @@ impl KimiDeltaAttention {
         let k = mlxcel_core::reshape(&k_conv, &[b, t, self.num_heads, self.head_dim]);
         let v = mlxcel_core::reshape(&v_conv, &[b, t, self.num_heads, self.head_dim]);
 
-        // RMS normalize Q and K (without learned weight)
-        let q_dtype = mlxcel_core::array_dtype(&q);
-        let eps_arr = mlxcel_core::full_f32(&[1], 1e-6, q_dtype);
+        // RMS normalize Q and K (without learned weight). Reference mlx-lm
+        // uses mx.fast.rms_norm here; keep it fused instead of expanding it.
         let inv_scale = self.scale;
-
-        let q_sq = mlxcel_core::square(&q);
-        let q_sq_mean = mlxcel_core::mean_axis(&q_sq, -1, true);
-        let q_rms = mlxcel_core::sqrt(&mlxcel_core::add(&q_sq_mean, &eps_arr));
-        let scale_q = mlxcel_core::full_f32(&[1], inv_scale * inv_scale, q_dtype);
-        let q = mlxcel_core::multiply(&mlxcel_core::divide(&q, &q_rms), &scale_q);
-
-        let k_sq = mlxcel_core::square(&k);
-        let k_sq_mean = mlxcel_core::mean_axis(&k_sq, -1, true);
-        let k_rms = mlxcel_core::sqrt(&mlxcel_core::add(&k_sq_mean, &eps_arr));
-        let scale_k = mlxcel_core::full_f32(&[1], inv_scale, q_dtype);
-        let k = mlxcel_core::multiply(&mlxcel_core::divide(&k, &k_rms), &scale_k);
+        let q = scaled_fast_rms_norm_no_weight(&q, inv_scale * inv_scale, 1e-6);
+        let k = scaled_fast_rms_norm_no_weight(&k, inv_scale, 1e-6);
 
         // Compute gating logits
         let a_logits = self.f_b_proj.forward(&self.f_a_proj.forward(x));

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -28,7 +28,9 @@
 use crate::distributed::pipeline::LayerFilter;
 use crate::distributed::pipeline::StageExecutionOutput;
 use crate::distributed::pipeline::partial_loading::filter_weight_map;
-use crate::models::gated_delta::{GatedDeltaCache, RMSNormGated, gated_delta_update};
+use crate::models::gated_delta::{
+    GatedDeltaCache, RMSNormGated, gated_delta_update, scaled_fast_rms_norm_no_weight,
+};
 use crate::models::model_owned::ModelOwnedSequenceState;
 use crate::models::qwen_mrope_state::MRopeState;
 use crate::models::qwen3_next::{
@@ -424,22 +426,12 @@ impl Qwen35GatedDeltaNet {
             })
         });
 
-        // Apply RMS norm with scaling (same as Qwen3Next)
+        // Apply RMS norm with scaling (same as Qwen3Next). Reference mlx-lm
+        // keeps this on mx.fast.rms_norm rather than expanding it into
+        // primitive ops.
         let inv_scale = (self.head_k_dim as f32).powf(-0.5);
-        let q_dtype = mlxcel_core::array_dtype(&q);
-        let eps_arr = mlxcel_core::full_f32(&[1], 1e-6, q_dtype);
-
-        let q_sq = mlxcel_core::square(&q);
-        let q_sq_mean = mlxcel_core::mean_axis(&q_sq, -1, true);
-        let q_rms = mlxcel_core::sqrt(&mlxcel_core::add(&q_sq_mean, &eps_arr));
-        let scale_q = mlxcel_core::full_f32(&[1], inv_scale * inv_scale, q_dtype);
-        let q = mlxcel_core::multiply(&mlxcel_core::divide(&q, &q_rms), &scale_q);
-
-        let k_sq = mlxcel_core::square(&k);
-        let k_sq_mean = mlxcel_core::mean_axis(&k_sq, -1, true);
-        let k_rms = mlxcel_core::sqrt(&mlxcel_core::add(&k_sq_mean, &eps_arr));
-        let scale_k = mlxcel_core::full_f32(&[1], inv_scale, q_dtype);
-        let k = mlxcel_core::multiply(&mlxcel_core::divide(&k, &k_rms), &scale_k);
+        let q = scaled_fast_rms_norm_no_weight(&q, inv_scale * inv_scale, 1e-6);
+        let k = scaled_fast_rms_norm_no_weight(&k, inv_scale, 1e-6);
 
         // Run gated delta update (use guarded_mask which is None if batch dims mismatch)
         let (out, new_state) = gated_delta_update(
@@ -616,20 +608,8 @@ impl Qwen35GatedDeltaNet {
 
         // RMSNorm scaling for q and k (preserves the verify-pass dtype).
         let inv_scale = (self.head_k_dim as f32).powf(-0.5);
-        let q_dtype = mlxcel_core::array_dtype(&q);
-        let eps_arr = mlxcel_core::full_f32(&[1], 1e-6, q_dtype);
-
-        let q_sq = mlxcel_core::square(&q);
-        let q_sq_mean = mlxcel_core::mean_axis(&q_sq, -1, true);
-        let q_rms = mlxcel_core::sqrt(&mlxcel_core::add(&q_sq_mean, &eps_arr));
-        let scale_q = mlxcel_core::full_f32(&[1], inv_scale * inv_scale, q_dtype);
-        let q = mlxcel_core::multiply(&mlxcel_core::divide(&q, &q_rms), &scale_q);
-
-        let k_sq = mlxcel_core::square(&k);
-        let k_sq_mean = mlxcel_core::mean_axis(&k_sq, -1, true);
-        let k_rms = mlxcel_core::sqrt(&mlxcel_core::add(&k_sq_mean, &eps_arr));
-        let scale_k = mlxcel_core::full_f32(&[1], inv_scale, q_dtype);
-        let k = mlxcel_core::multiply(&mlxcel_core::divide(&k, &k_rms), &scale_k);
+        let q = scaled_fast_rms_norm_no_weight(&q, inv_scale * inv_scale, 1e-6);
+        let k = scaled_fast_rms_norm_no_weight(&k, inv_scale, 1e-6);
 
         // Capture the snapshot BEFORE the gated_delta_update consumes/mutates
         // the recurrent state. The drafter uses these to replay over the
@@ -737,20 +717,8 @@ impl Qwen35GatedDeltaNet {
         );
 
         let inv_scale = (self.head_k_dim as f32).powf(-0.5);
-        let q_dtype = mlxcel_core::array_dtype(&q);
-        let eps_arr = mlxcel_core::full_f32(&[1], 1e-6, q_dtype);
-
-        let q_sq = mlxcel_core::square(&q);
-        let q_sq_mean = mlxcel_core::mean_axis(&q_sq, -1, true);
-        let q_rms = mlxcel_core::sqrt(&mlxcel_core::add(&q_sq_mean, &eps_arr));
-        let scale_q = mlxcel_core::full_f32(&[1], inv_scale * inv_scale, q_dtype);
-        let q = mlxcel_core::multiply(&mlxcel_core::divide(&q, &q_rms), &scale_q);
-
-        let k_sq = mlxcel_core::square(&k);
-        let k_sq_mean = mlxcel_core::mean_axis(&k_sq, -1, true);
-        let k_rms = mlxcel_core::sqrt(&mlxcel_core::add(&k_sq_mean, &eps_arr));
-        let scale_k = mlxcel_core::full_f32(&[1], inv_scale, q_dtype);
-        let k = mlxcel_core::multiply(&mlxcel_core::divide(&k, &k_rms), &scale_k);
+        let q = scaled_fast_rms_norm_no_weight(&q, inv_scale * inv_scale, 1e-6);
+        let k = scaled_fast_rms_norm_no_weight(&k, inv_scale, 1e-6);
 
         let beta = mlxcel_core::sigmoid(&b_proj);
         let g = crate::models::gated_delta::compute_g(&self.a_log, &a, &self.dt_bias);

--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -32,7 +32,9 @@ mod helpers;
 #[path = "qwen3_next_helpers_tests.rs"]
 mod helper_tests;
 
-use crate::models::gated_delta::{GatedDeltaCache, RMSNormGated, gated_delta_update};
+use crate::models::gated_delta::{
+    GatedDeltaCache, RMSNormGated, gated_delta_update, scaled_fast_rms_norm_no_weight,
+};
 use mlxcel_core::dtype;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
@@ -368,23 +370,11 @@ impl GatedDeltaNet {
                 .map(|s| mlxcel_core::copy(s.as_ref().unwrap()))
         });
 
-        // Apply RMS norm with scaling
+        // Apply RMS norm with scaling. Reference mlx-lm keeps this on
+        // mx.fast.rms_norm rather than expanding it into primitive ops.
         let inv_scale = (self.head_k_dim as f32).powf(-0.5);
-        let q_dtype = mlxcel_core::array_dtype(&q);
-        let eps_arr = mlxcel_core::full_f32(&[1], 1e-6, q_dtype);
-
-        // Manual RMS norm: x / sqrt(mean(x^2) + eps)
-        let q_sq = mlxcel_core::square(&q);
-        let q_sq_mean = mlxcel_core::mean_axis(&q_sq, -1, true);
-        let q_rms = mlxcel_core::sqrt(&mlxcel_core::add(&q_sq_mean, &eps_arr));
-        let scale_q = mlxcel_core::full_f32(&[1], inv_scale * inv_scale, q_dtype);
-        let q = mlxcel_core::multiply(&mlxcel_core::divide(&q, &q_rms), &scale_q);
-
-        let k_sq = mlxcel_core::square(&k);
-        let k_sq_mean = mlxcel_core::mean_axis(&k_sq, -1, true);
-        let k_rms = mlxcel_core::sqrt(&mlxcel_core::add(&k_sq_mean, &eps_arr));
-        let scale_k = mlxcel_core::full_f32(&[1], inv_scale, q_dtype);
-        let k = mlxcel_core::multiply(&mlxcel_core::divide(&k, &k_rms), &scale_k);
+        let q = scaled_fast_rms_norm_no_weight(&q, inv_scale * inv_scale, 1e-6);
+        let k = scaled_fast_rms_norm_no_weight(&k, inv_scale, 1e-6);
 
         // Run gated delta update
         let (out, new_state) = gated_delta_update(


### PR DESCRIPTION
## Summary
GatedDeltaNet linear-attention layers (Qwen3.5, Qwen3-Next, KimiLinear) were computing Q/K and gated-output RMSNorm by expanding the formula into primitive MLX ops on every decode step (`square` → `mean_axis` → `add(eps)` → `sqrt` → `divide` → `multiply(scale)`). Six graph nodes per call; per-step overhead dominates on Apple Silicon. Reference mlx-lm uses `mx.fast.rms_norm` for these paths.

This PR replaces those expanded graphs with the fast kernel.

## Changes
- `src/models/gated_delta.rs`
  - Add `scaled_fast_rms_norm_no_weight(x, scale, eps)` — wraps `mlxcel_core::fast_rms_norm_no_weight` and post-multiplies by a scalar (mirrors `mx.fast.rms_norm(x, None, eps) * scale`).
  - Collapse `RMSNormGated::forward` to a single `fast_rms_norm` call before the SwiGLU gate.
- `src/models/qwen3_5.rs`, `src/models/qwen3_next.rs`, `src/models/kimi_linear.rs`
  - Replace the manual Q/K RMSNorm-and-scale blocks at every call site (prefill, decode, and for Qwen3.5 the speculative-decoding verify pass) with `scaled_fast_rms_norm_no_weight`.
  - Q uses `inv_scale^2`, K uses `inv_scale`, where `inv_scale = head_k_dim^-0.5` — same numerics as before, one MLX primitive instead of six.

## Performance (M5 Max, 4-bit, decode tok/s)
| Model | Before | After | Speedup | mlx-lm parity |
| --- | ---: | ---: | ---: | ---: |
| qwen3.5-0.8b-4bit | 425.16 | **535.43** | +25.9% | 68% → **96%** |

Measured 5-run mean on `def fibonacci(n):\n    ` (100 tokens, `--profile --no-chat-template`). Before runs: 427.17, 428.86, 423.32, 423.65, 422.78. After runs: 535.44, 535.26, 535.06, 536.12, 535.25.

Other GatedDeltaNet families (Qwen3-Next, KimiLinear) share the helper and benefit from the same kernel switch; their absolute numbers are tracked separately.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --features metal,accelerate`
- [ ] Manual (M5 Max): `qwen3.5-0.8b-4bit` 100-tok decode reproduces ~535 tok/s on `def fibonacci(n):\n    `.
- [ ] Manual: Qwen3.5 speculative-decoding draft/verify path still produces identical tokens to greedy decode (verify-pass RMSNorm dtype agreement preserved).
- [ ] Manual: smoke-run Qwen3-Next and KimiLinear families — outputs unchanged, decode tok/s steady or up.