### PR TITLE
docs: refresh README performance snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,50 +73,27 @@ Linux/CUDA builds use the `cuda` feature and require the CUDA toolkit plus the s
 
 ## Performance
 
-Benchmark results depend on model family, quantization, prompt length, decode
-length, batch shape, and hardware. See [Benchmarks](docs/benchmarks.md) for
-methodology notes and caveats.
+mlxcel targets near-`mlx-lm` / `mlx-vlm` decode throughput for MLX-format
+checkpoints while keeping a native Rust runtime. In the mlxcel 0.0.28 M5 Max
+128GB benchmark set, text decode averaged **95%** of `mlx-lm` across 67
+comparable pairs (median 97%); **50 / 67** text rows reached at least 90%
+parity, and **16 / 67** matched or exceeded `mlx-lm`. Comparable VLM decode
+averaged **94%** of `mlx-vlm` across 17 pairs (median 95%), with **12 / 17**
+rows at or above 90% parity.
 
-The current M5 Max reference snapshot is from the 2026-05-18 full sweep, with
-Qwen3-VL and several targeted rows refreshed on 2026-05-19. It used mlxcel
-0.0.28, MLX 0.31.2, mlx-lm 0.31.3 (`ed1fca4`), and mlx-vlm 0.4.4 on a 128GB
-MacBook Pro M5 Max. Against `mlx-lm`, 67 text pairs were comparable: average
-mlxcel/mlx-lm decode throughput was **95%** (median 97%, range 71%-129%),
-**50 / 67** rows reached at least 90% parity, and **16 / 67** were at or above
-`mlx-lm`. The comparable VLM set averaged **94%** of `mlx-vlm` (median 95%,
-range 76%-107%), with **12 / 17** rows at or above 90% parity.
+Representative decode throughput is shown below in tokens per second. M5 Max
+reference columns are same-host `mlx-lm` or `mlx-vlm` runs; M1 Ultra values are
+included as mlxcel-only capacity references. Absolute results depend on model
+family, quantization, prompt shape, decode length, and hardware. See
+[Benchmarks](docs/benchmarks.md) for methodology and caveats.
 
-Recent hot-path work targeted rows that had fallen well behind the Python
-references. These M5 Max spot checks show the post-fix decode rates for the
-affected families. Values are decode tok/s; the ratio is `mlxcel / reference`.
-
-| Refreshed row | mlxcel | mlx-lm | Ratio |
-|---------------|-------:|-------:|------:|
-| GPT-OSS 120B 4bit | 113 tok/s | 110 tok/s | 102% |
-| GLM-4 Flash 4bit | 111 tok/s | 108 tok/s | 103% |
-| Solar Open 100B 4bit | 66 tok/s | 66 tok/s | 99% |
-| Gemma 2B 4bit | 214 tok/s | 223 tok/s | 96% |
-| Falcon Mamba 7B 4bit | 94 tok/s | 94 tok/s | 100% |
-| StarCoder2 3B 4bit | 215 tok/s | 214 tok/s | 100% |
-| Qwen3.5 0.8B 4bit | 535 tok/s | 555 tok/s | 96% |
-| Qwen3-VL 30B-A3B 4bit, text path | 146 tok/s | 148 tok/s | 99% |
-| Qwen3-VL 32B 4bit, text path | 27 tok/s | 29 tok/s | 94% |
-
-Current Apple Silicon capacity snapshots are selected rows from full-suite
-`mlxcel generate --profile` runs, with the 2026-05-19 targeted refreshes used
-where applicable. The M1 Ultra column is mlxcel-only; M5 Max columns include
-the same-host Python reference when available. `FAIL` in a reference column
-means the reference runtime failed to load or run that checkpoint under the
-recorded configuration.
-
-| Text model | M1 Ultra mlxcel<br>2026-05-08 | M5 Max mlxcel<br>2026-05-18/19 | M5 Max mlx-lm | mlxcel / mlx-lm |
-|------------|------------------------------:|-------------------------------:|--------------:|----------------:|
+| Text model | M1 Ultra mlxcel | M5 Max mlxcel | M5 Max mlx-lm | mlxcel / mlx-lm |
+|------------|----------------:|--------------:|--------------:|----------------:|
 | SmolLM-135M 4bit | 365 tok/s | 919 tok/s | 712 tok/s | 129% |
 | Llama 3.1 8B 4bit | 109 tok/s | 113 tok/s | 117 tok/s | 96% |
 | Qwen2.5 7B 4bit | 113 tok/s | 126 tok/s | 124 tok/s | 102% |
 | Gemma 2B 4bit | 82 tok/s | 214 tok/s | 223 tok/s | 96% |
 | Gemma 3 4B 4bit | 104 tok/s | 145 tok/s | 182 tok/s | 80% |
-| Gemma 4 E2B 4bit | 124 tok/s | 222 tok/s | FAIL | - |
 | Gemma 4 26B-A4B 4bit | 72 tok/s | 136 tok/s | 141 tok/s | 97% |
 | Qwen3 MoE 30B 4bit | 72 tok/s | 153 tok/s | 147 tok/s | 104% |
 | GLM-4 Flash 4bit | 36 tok/s | 111 tok/s | 108 tok/s | 103% |
@@ -124,23 +101,22 @@ recorded configuration.
 | Mixtral 8x7B 4bit | 54 tok/s | 63 tok/s | 66 tok/s | 96% |
 | StarCoder2 3B 4bit | 105 tok/s | 215 tok/s | 214 tok/s | 100% |
 | Qwen3.5 0.8B 4bit | 183 tok/s | 535 tok/s | 555 tok/s | 96% |
-| Llama 4 Scout 17B 4bit | 37 tok/s | 48 tok/s | FAIL | - |
+| Qwen3-VL 30B-A3B 4bit, text path | 22 tok/s | 146 tok/s | 148 tok/s | 99% |
+| Qwen3-VL 32B 4bit, text path | 18 tok/s | 27 tok/s | 29 tok/s | 94% |
 | GPT-OSS 120B 4bit | 20 tok/s | 113 tok/s | 110 tok/s | 102% |
 | Solar Open 100B 4bit | 14 tok/s | 66 tok/s | 66 tok/s | 99% |
 
-| VLM model | M1 Ultra mlxcel<br>2026-05-08 | M5 Max mlxcel<br>2026-05-18 | M5 Max mlx-vlm | mlxcel / mlx-vlm |
-|-----------|------------------------------:|----------------------------:|---------------:|-----------------:|
+| VLM model | M1 Ultra mlxcel | M5 Max mlxcel | M5 Max mlx-vlm | mlxcel / mlx-vlm |
+|-----------|----------------:|--------------:|---------------:|-----------------:|
 | LLaVA Interleave Qwen 0.5B bf16 | 262 tok/s | 342 tok/s | 345 tok/s | 99% |
-| Qwen3-VL 2B 4bit | 158 tok/s | 276 tok/s | FAIL | - |
-| Qwen3-VL 30B-A3B 4bit | 22 tok/s | 35 tok/s | FAIL | - |
-| Qwen3-VL 32B 4bit | 18 tok/s | 20 tok/s | FAIL | - |
 | Gemma 4 E2B 4bit | 106 tok/s | 216 tok/s | 202 tok/s | 107% |
 | Gemma 4 26B-A4B 4bit | 66 tok/s | 129 tok/s | 137 tok/s | 94% |
 | Phi 3.5 Vision 4bit | 88 tok/s | 121 tok/s | 160 tok/s | 76% |
-| Llama 4 Scout 17B 4bit | 35 tok/s | 48 tok/s | FAIL | - |
 
-The 2026-05-18 M5 Max sweep tested 98 text model directories with 89 pass, 4
-partial, and 5 fail results, plus a separate 98-entry VLM prompt pass. VLM runs
+The M5 Max sweep covers 98 text model directories plus a separate 98-entry VLM
+prompt pass. Ratio summaries include only rows where both mlxcel and the Python
+reference produced comparable decode measurements; unsupported checkpoints and
+benchmark-configuration failures are tracked in the benchmark notes. VLM runs
 used a 224x224 benchmark fixture image and should be read separately because
 vision preprocessing, image size, and prompt construction differ by family.
 Re-run the benchmark suite on your target hardware before using these numbers

--- a/README.md
+++ b/README.md
@@ -77,46 +77,74 @@ Benchmark results depend on model family, quantization, prompt length, decode
 length, batch shape, and hardware. See [Benchmarks](docs/benchmarks.md) for
 methodology notes and caveats.
 
-As a reference-runtime comparison, a 2026-05-08 run on Mac Studio M1 Ultra
-compared 37 4-bit text checkpoints against `mlx-lm` using mlxcel 0.0.25, MLX
-0.31.2, and mlx-lm 0.31.3. Decode throughput averaged about **1.19x** of the
-mlx-lm baseline; **35 / 37** text models were faster than `mlx-lm`, and all 37
-stayed within 90% of parity. In the same M1 Ultra benchmark set, 5 / 6
-comparable VLMs were at or above `mlx-vlm` decode parity.
+The current M5 Max reference snapshot is from the 2026-05-18 full sweep, with
+Qwen3-VL and several targeted rows refreshed on 2026-05-19. It used mlxcel
+0.0.28, MLX 0.31.2, mlx-lm 0.31.3 (`ed1fca4`), and mlx-vlm 0.4.4 on a 128GB
+MacBook Pro M5 Max. Against `mlx-lm`, 67 text pairs were comparable: average
+mlxcel/mlx-lm decode throughput was **95%** (median 97%, range 71%-129%),
+**50 / 67** rows reached at least 90% parity, and **16 / 67** were at or above
+`mlx-lm`. The comparable VLM set averaged **94%** of `mlx-vlm` (median 95%,
+range 76%-107%), with **12 / 17** rows at or above 90% parity.
 
-Current Apple Silicon capacity snapshots are shown below as absolute decode
-throughput, not as cross-runtime comparisons. Numbers are selected rows from
-full-suite `mlxcel generate --profile` runs.
+Recent hot-path work targeted rows that had fallen well behind the Python
+references. These M5 Max spot checks show the post-fix decode rates for the
+affected families. Values are decode tok/s; the ratio is `mlxcel / reference`.
 
-| Text model | M1 Ultra 128GB<br>2026-05-08 | M5 Max 128GB<br>2026-05-18 |
-|------------|-----------------------------:|---------------------------:|
-| SmolLM-135M 4bit | 365 tok/s | 919 tok/s |
-| Llama 3.1 8B 4bit | 109 tok/s | 113 tok/s |
-| Qwen2.5 7B 4bit | 113 tok/s | 126 tok/s |
-| Gemma 3 4B 4bit | 104 tok/s | 145 tok/s |
-| Gemma 4 E2B 4bit | 124 tok/s | 222 tok/s |
-| Gemma 4 26B-A4B 4bit | 72 tok/s | 136 tok/s |
-| Qwen3 MoE 30B 4bit | 72 tok/s | 152 tok/s |
-| Nemotron-H 30B 4bit | 90 tok/s | 156 tok/s |
-| Mixtral 8x7B 4bit | 54 tok/s | 63 tok/s |
-| Llama 4 Scout 17B 4bit | 37 tok/s | 48 tok/s |
-| Solar Open 100B 4bit | 14 tok/s | 16 tok/s |
+| Refreshed row | mlxcel | mlx-lm | Ratio |
+|---------------|-------:|-------:|------:|
+| GPT-OSS 120B 4bit | 113 tok/s | 110 tok/s | 102% |
+| GLM-4 Flash 4bit | 111 tok/s | 108 tok/s | 103% |
+| Solar Open 100B 4bit | 66 tok/s | 66 tok/s | 99% |
+| Gemma 2B 4bit | 214 tok/s | 223 tok/s | 96% |
+| Falcon Mamba 7B 4bit | 94 tok/s | 94 tok/s | 100% |
+| StarCoder2 3B 4bit | 215 tok/s | 214 tok/s | 100% |
+| Qwen3.5 0.8B 4bit | 535 tok/s | 555 tok/s | 96% |
+| Qwen3-VL 30B-A3B 4bit, text path | 146 tok/s | 148 tok/s | 99% |
+| Qwen3-VL 32B 4bit, text path | 27 tok/s | 29 tok/s | 94% |
 
-| VLM model | M1 Ultra 128GB<br>2026-05-08 | M5 Max 128GB<br>2026-05-18 |
-|-----------|-----------------------------:|---------------------------:|
-| LLaVA Interleave Qwen 0.5B bf16 | 262 tok/s | 342 tok/s |
-| Qwen3-VL 2B 4bit | 158 tok/s | 276 tok/s |
-| Gemma 4 E2B 4bit | 106 tok/s | 216 tok/s |
-| Gemma 4 26B-A4B 4bit | 66 tok/s | 129 tok/s |
-| Phi 3.5 Vision 4bit | 88 tok/s | 121 tok/s |
-| Llama 4 Scout 17B 4bit | 35 tok/s | 48 tok/s |
+Current Apple Silicon capacity snapshots are selected rows from full-suite
+`mlxcel generate --profile` runs, with the 2026-05-19 targeted refreshes used
+where applicable. The M1 Ultra column is mlxcel-only; M5 Max columns include
+the same-host Python reference when available. `FAIL` in a reference column
+means the reference runtime failed to load or run that checkpoint under the
+recorded configuration.
+
+| Text model | M1 Ultra mlxcel<br>2026-05-08 | M5 Max mlxcel<br>2026-05-18/19 | M5 Max mlx-lm | mlxcel / mlx-lm |
+|------------|------------------------------:|-------------------------------:|--------------:|----------------:|
+| SmolLM-135M 4bit | 365 tok/s | 919 tok/s | 712 tok/s | 129% |
+| Llama 3.1 8B 4bit | 109 tok/s | 113 tok/s | 117 tok/s | 96% |
+| Qwen2.5 7B 4bit | 113 tok/s | 126 tok/s | 124 tok/s | 102% |
+| Gemma 2B 4bit | 82 tok/s | 214 tok/s | 223 tok/s | 96% |
+| Gemma 3 4B 4bit | 104 tok/s | 145 tok/s | 182 tok/s | 80% |
+| Gemma 4 E2B 4bit | 124 tok/s | 222 tok/s | FAIL | - |
+| Gemma 4 26B-A4B 4bit | 72 tok/s | 136 tok/s | 141 tok/s | 97% |
+| Qwen3 MoE 30B 4bit | 72 tok/s | 153 tok/s | 147 tok/s | 104% |
+| GLM-4 Flash 4bit | 36 tok/s | 111 tok/s | 108 tok/s | 103% |
+| Nemotron-H 30B 4bit | 90 tok/s | 156 tok/s | 179 tok/s | 87% |
+| Mixtral 8x7B 4bit | 54 tok/s | 63 tok/s | 66 tok/s | 96% |
+| StarCoder2 3B 4bit | 105 tok/s | 215 tok/s | 214 tok/s | 100% |
+| Qwen3.5 0.8B 4bit | 183 tok/s | 535 tok/s | 555 tok/s | 96% |
+| Llama 4 Scout 17B 4bit | 37 tok/s | 48 tok/s | FAIL | - |
+| GPT-OSS 120B 4bit | 20 tok/s | 113 tok/s | 110 tok/s | 102% |
+| Solar Open 100B 4bit | 14 tok/s | 66 tok/s | 66 tok/s | 99% |
+
+| VLM model | M1 Ultra mlxcel<br>2026-05-08 | M5 Max mlxcel<br>2026-05-18 | M5 Max mlx-vlm | mlxcel / mlx-vlm |
+|-----------|------------------------------:|----------------------------:|---------------:|-----------------:|
+| LLaVA Interleave Qwen 0.5B bf16 | 262 tok/s | 342 tok/s | 345 tok/s | 99% |
+| Qwen3-VL 2B 4bit | 158 tok/s | 276 tok/s | FAIL | - |
+| Qwen3-VL 30B-A3B 4bit | 22 tok/s | 35 tok/s | FAIL | - |
+| Qwen3-VL 32B 4bit | 18 tok/s | 20 tok/s | FAIL | - |
+| Gemma 4 E2B 4bit | 106 tok/s | 216 tok/s | 202 tok/s | 107% |
+| Gemma 4 26B-A4B 4bit | 66 tok/s | 129 tok/s | 137 tok/s | 94% |
+| Phi 3.5 Vision 4bit | 88 tok/s | 121 tok/s | 160 tok/s | 76% |
+| Llama 4 Scout 17B 4bit | 35 tok/s | 48 tok/s | FAIL | - |
 
 The 2026-05-18 M5 Max sweep tested 98 text model directories with 89 pass, 4
-partial, and 5 fail results; 62 of 93 numeric text runs reached at least 100
-decode tok/s. VLM runs used a 224x224 benchmark fixture image and should be
-read separately because vision preprocessing, image size, and prompt
-construction differ by family. Re-run the benchmark suite on your target
-hardware before using these numbers for capacity planning.
+partial, and 5 fail results, plus a separate 98-entry VLM prompt pass. VLM runs
+used a 224x224 benchmark fixture image and should be read separately because
+vision preprocessing, image size, and prompt construction differ by family.
+Re-run the benchmark suite on your target hardware before using these numbers
+for capacity planning.
 
 ## Supported models
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -21,21 +21,25 @@ For every benchmark run, include:
 Averages are useful only after the raw rows are available. Avoid statements such
 as "faster than X" unless the comparable model set and exclusions are explicit.
 
-## Historical reference from README
+## README reference snapshot
 
-The root README mentions one historical run:
+The root README currently summarizes the latest Apple Silicon reference
+snapshot:
 
-- Date: 2026-05-08
-- Hardware: Mac Studio M1 Ultra
-- Runtime: mlxcel 0.0.25
+- Date: 2026-05-18 full sweep, with selected targeted rows refreshed on 2026-05-19
+- Hardware: MacBook Pro M5 Max, 128GB
+- Runtime: mlxcel 0.0.28
 - MLX: 0.31.2
-- Baseline: mlx-lm 0.31.3
-- Scope: 37 comparable 4-bit text checkpoints
-- Reported decode-throughput average: about 119% of the mlx-lm baseline
+- Baselines: mlx-lm 0.31.3 (`ed1fca4`) and mlx-vlm 0.4.4
+- Scope: 98 text model directories plus a separate 98-entry VLM prompt pass
+- Comparable text pairs: 67; average mlxcel/mlx-lm decode throughput 95%, median 97%, with 50 / 67 rows at or above 90% parity
+- Comparable VLM pairs: 17; average mlxcel/mlx-vlm decode throughput 94%, median 95%, with 12 / 17 rows at or above 90% parity
 
-That number is kept as a historical reference, not as a current release claim.
-Before using it in release notes or capacity planning, add the raw table and
-rerun the suite on the target hardware.
+An earlier 2026-05-08 M1 Ultra snapshot reported about 119% of the mlx-lm
+baseline across 37 comparable 4-bit text checkpoints. That number is kept only
+as historical context; use the current raw rows and rerun the suite on the
+target hardware before relying on README numbers for release notes or capacity
+planning.
 
 ## Suggested benchmark commands
 


### PR DESCRIPTION
## Summary

- Refresh the README Performance section for the mlxcel 0.0.28 release snapshot.
- Replace the old M1 Ultra aggregate claim with the latest M5 Max text/VLM parity summary.
- Add same-host mlx-lm / mlx-vlm reference throughput columns to the representative tables.
- Update benchmark notes so the linked methodology page matches the README snapshot.

## Validation

- `git diff --check`
