### PR TITLE
docs: use plain Qwen3.5-0.8B-4bit in README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ brew install mlxcel
 
 ```bash
 # Download an MLX-format checkpoint from Hugging Face.
-mlxcel download mlx-community/Qwen3.5-0.8B-OptiQ-4bit
+mlxcel download mlx-community/Qwen3.5-0.8B-4bit
 
 # One-off generation.
 mlxcel generate \
-    -m models/Qwen3.5-0.8B-OptiQ-4bit \
+    -m models/Qwen3.5-0.8B-4bit \
     -p "Hello, world!" -n 100
 
 # OpenAI-compatible server.
 mlxcel-server \
-    -m models/Qwen3.5-0.8B-OptiQ-4bit \
+    -m models/Qwen3.5-0.8B-4bit \
     --port 8080
 ```
 


### PR DESCRIPTION
## Summary

The README quickstart referenced `mlx-community/Qwen3.5-0.8B-OptiQ-4bit`, an OptiQ-quantized variant that is not the default checkpoint a first-time user reaches for. Switch the `download`, `generate`, and `mlxcel-server` examples to `mlx-community/Qwen3.5-0.8B-4bit` so the quickstart uses the same plain 4-bit checkpoint that already appears in the performance table, and so newcomers do not need to know what OptiQ is before they can run the first example.

## Changes

- `README.md` lines 40, 44, 49 — three occurrences of `Qwen3.5-0.8B-OptiQ-4bit` replaced with `Qwen3.5-0.8B-4bit`.

## Verification

- `mlx-community/Qwen3.5-0.8B-4bit` exists on Hugging Face (HTTP 200, `base_model: Qwen/Qwen3.5-0.8B-Base`).
- `grep -n OptiQ README.md` returns no matches after the change.