### PR TITLE
docs: organize benchmark result reports

### DIFF
--- a/docs/benchmark_results/benchmark-report.md
+++ b/docs/benchmark_results/benchmark-report.md
@@ -1,0 +1,159 @@
+# Benchmark Report - 2026-05-19
+
+This report summarizes mlxcel performance on Apple Silicon using the
+2026-05-19 benchmark campaign. It covers two 128 GB Apple Silicon systems:
+
+- Mac Studio M1 Ultra
+- MacBook Pro M5 Max
+
+The same report also compares mlxcel against the Python reference stacks:
+`mlx-lm` for text models and `mlx-vlm` for vision-language models.
+
+The short version: mlxcel is already at practical decode parity with the
+Python MLX stacks on most comparable models, and it completes many models that
+the Python baseline did not complete in this sweep. The strongest public story
+is same-host decode throughput and model coverage. Short-prompt prefill is
+reported separately because it is more prompt-shape-sensitive and, for VLMs,
+includes image encoder and projector work.
+
+## Headline Results
+
+| Host | Mode | Baseline | Comparable pairs | Prefill median vs baseline | Decode median vs baseline | Decode result |
+|------|------|----------|-----------------:|---------------------------:|--------------------------:|---------------|
+| M5 Max | Text | mlx-lm | 67 | 0.66x | **98%** | 59/67 at >=90% parity |
+| M1 Ultra | Text | mlx-lm | 74 | 0.58x | **96%** | 56/74 at >=90% parity |
+| M5 Max | VLM | mlx-vlm | 17 | 0.63x | **99%** | 14/17 at >=90% parity |
+| M1 Ultra | VLM | mlx-vlm | 17 | 0.93x | **98%** | 11/17 at >=90% parity |
+
+Ratios above use successful runs only. Baseline rows use exact CSV model
+identifiers and compare mlxcel and the Python stack on the same host. Decode
+parity is the primary comparison point because it measures steady-state
+generation after the KV cache is built.
+
+## Why This Matters
+
+mlxcel is not only running close to the Python reference implementations on
+the common path; it is also running models that the Python baseline did not
+complete in this sweep. With a generated-token threshold of 5 tokens:
+
+| Host | Mode | mlxcel successful, Python baseline unavailable or failed | Comparable successful pairs |
+|------|------|---------------------------------------------------------:|----------------------------:|
+| M5 Max | Text | 25 | 66 |
+| M1 Ultra | Text | 22 | 73 |
+| M5 Max | VLM | 12 | 17 |
+| M1 Ultra | VLM | 20 | 17 |
+
+This is the useful public framing: mlxcel is a Rust inference engine with
+direct MLX bindings that is already near Python decode performance for many
+models, while providing broad model coverage across text, MoE, hybrid SSM,
+and VLM families.
+
+## Representative Text Models
+
+All values are tokens per second. Prefill and decode are shown separately.
+The final column compares mlxcel decode throughput against mlx-lm on the same
+host.
+
+| Host | Model | Class | mlxcel prefill | mlxcel decode | mlx-lm decode | vs mlx-lm |
+|------|-------|-------|---------------:|--------------:|--------------:|----------:|
+| M5 Max | smollm-135m-4bit | Small dense | 900.78 | 883.99 | 711.54 | **124%** |
+| M5 Max | qwen2.5-7b-4bit | Dense 7B | 299.05 | 126.63 | 123.59 | **102%** |
+| M5 Max | gpt-oss-120b-4bit | Large MoE | 23.71 | 113.34 | 110.35 | **103%** |
+| M5 Max | solar-open-100b-4bit | Large MoE | 200.85 | 65.59 | 66.30 | 99% |
+| M5 Max | qwen3.5-35b-a3b-4bit | Hybrid MoE | 36.32 | 145.49 | 152.96 | 95% |
+| M5 Max | nemotron-h-30b-4bit | Hybrid SSM/MoE | 31.22 | 171.76 | 178.80 | 96% |
+| M1 Ultra | phi-3.5-moe-4bit | MoE | 9.16 | 76.13 | 69.28 | **110%** |
+| M1 Ultra | minicpm3-4b-4bit | MLA | 87.60 | 79.08 | 73.26 | **108%** |
+| M1 Ultra | qwen2.5-0.5b-4bit | Small dense | 452.68 | 329.45 | 315.48 | **104%** |
+| M1 Ultra | gpt-oss-120b-4bit | Large MoE | 3.79 | 59.62 | 57.58 | **104%** |
+| M1 Ultra | command-r7b-4bit | Dense 7B | 29.10 | 111.42 | 107.75 | **103%** |
+| M1 Ultra | solar-open-100b-4bit | Large MoE | 11.19 | 36.20 | 35.69 | **101%** |
+
+The table shows the central performance claim without cross-hardware ranking:
+mlxcel is already close to mlx-lm on the same machine for dense 7B models,
+newer hybrid MoE families, and very large MoE models such as GPT-OSS 120B.
+
+## Representative VLM Models
+
+All values are tokens per second. VLM prefill includes vision-side work when
+the run uses image input, so decode is the cleaner apples-to-apples baseline
+comparison.
+
+| Host | Model | Class | mlxcel prefill | mlxcel decode | mlx-vlm decode | vs mlx-vlm |
+|------|-------|-------|---------------:|--------------:|---------------:|-----------:|
+| M5 Max | qwen3.5-0.8b-4bit | Hybrid GatedDeltaNet VLM | 463.75 | 477.51 | 410.96 | **116%** |
+| M5 Max | qwen3.5-35b-a3b-4bit | Hybrid MoE VLM | 38.18 | 149.57 | 128.80 | **116%** |
+| M5 Max | gemma-4-e2b-it-4bit | Gemma 4 VLM | 2534.10 | 215.86 | 201.70 | **107%** |
+| M5 Max | molmo2-4b | Molmo2 vision encoder | 1605.72 | 64.35 | 66.80 | 96% |
+| M1 Ultra | llava-interleave-qwen-0.5b-bf16 | SigLIP + Qwen2 | 3334.88 | 263.41 | 225.15 | **117%** |
+| M1 Ultra | aya-vision-8b | SigLIP + Cohere2 | 349.35 | 111.11 | 103.74 | **107%** |
+| M1 Ultra | molmo2-4b | Molmo2 vision encoder | 576.46 | 59.54 | 60.87 | 98% |
+| M1 Ultra | phi-3.5-vision-4bit | CLIP + HD tiling | 793.61 | 92.64 | 92.53 | **100%** |
+| M1 Ultra | pixtral-12b-4bit | Pixtral ViT + Mistral | 442.19 | 60.29 | - | - |
+
+The VLM data is most compelling as a coverage and decode-throughput story:
+mlxcel runs many VLM paths in the same benchmark matrix, and its comparable
+decode results sit near mlx-vlm median parity on both Apple Silicon hosts.
+
+## Where mlxcel Looks Strongest
+
+- **Steady-state decode:** M5 Max text decode is within 2% of mlx-lm median
+  parity and VLM decode is within 1% of mlx-vlm median parity. M1 Ultra shows
+  the same pattern, with 96% text median parity and 98% VLM median parity.
+- **Large MoE practicality:** GPT-OSS 120B reaches 113.34 tok/s on M5 Max and
+  is slightly faster than mlx-lm on the same host in this sweep. Solar-Open
+  100B reaches 65.59 tok/s and is effectively at mlx-lm parity.
+- **Model coverage:** mlxcel completes many runs where the Python baseline
+  fails or is unavailable in the same benchmark matrix. This is especially
+  visible for VLM wrappers, Gemma 4 variants, ERNIE, Hunyuan, ExaOne4, and
+  several newer hybrid/MoE families.
+
+## Reading the Numbers Correctly
+
+- **Decode tok/s** is the headline metric. It measures autoregressive token
+  generation after prefill and is the fairest cross-runtime comparison.
+- **Prefill tok/s** is shown because it affects time-to-first-token, but this
+  campaign uses short prompts. Long-context prefill should be benchmarked
+  separately before making public claims about long-prompt throughput.
+- **VLM prefill** may include image preprocessing, vision encoder, and
+  projector overhead. Compare VLM prefill numbers only when the image path and
+  processor setup are the same.
+- **Baseline failures are sweep-specific.** A `FAIL` in this report means the
+  referenced checkout and local model directory did not complete this run. It
+  should not be read as a permanent limitation of mlx-lm or mlx-vlm.
+
+## Benchmark Method
+
+| Item | M1 Ultra | M5 Max |
+|------|----------|--------|
+| Hardware | Mac Studio M1 Ultra, 128 GB RAM | MacBook Pro M5 Max, 128 GB RAM |
+| OS | macOS 26.4 | macOS 26.4 |
+| mlxcel | 0.0.28 | 0.0.28 |
+| MLX pin | `84961223` via mlxcel-core | `84961223` via mlxcel-core |
+| Text prompt | `Hello, how are you today?` | `Hello, how are you today?` |
+| VLM prompt | `What is in this image?` | `What is in this image?` |
+| Max generated tokens | 100 | 100 |
+| Oversize policy | >65 GB skipped for Python baseline | same benchmark campaign policy |
+
+The M5 Max benchmark campaign ran as one continuous campaign across calendar
+midnight. For public reporting it is grouped under 2026-05-19. CSV filenames
+still reflect the date of each sub-sweep.
+
+## Source Data
+
+Source-of-truth CSVs:
+
+- `benchmarks/metal_m1ultra_2026-05-19.csv`
+- `benchmarks/metal_m1ultra_vlm_2026-05-19.csv`
+- `benchmarks/pylm_m1ultra_2026-05-19.csv`
+- `benchmarks/pylm_m1ultra_vlm_2026-05-19.csv`
+- `benchmarks/metal_m5max_2026-05-19.csv`
+- `benchmarks/metal_m5max_vlm_2026-05-19.csv`
+- `benchmarks/pylm_m5max_2026-05-18.csv`
+- `benchmarks/pylm_m5max_vlm_2026-05-18.csv`
+
+Full per-hardware details:
+
+- [M1 Ultra detailed results](model_tests_m1ultra.md)
+- [M5 Max detailed results](model_tests_m5max.md)
+- [Rolling benchmark index](model_tests.md)

--- a/docs/benchmark_results/model_tests.md
+++ b/docs/benchmark_results/model_tests.md
@@ -1,0 +1,296 @@
+# Model Compatibility & Performance Tests
+
+Per-hardware benchmark results and cross-hardware comparison for mlxcel.
+
+For a public, data-driven Apple Silicon summary that combines M1 Ultra,
+M5 Max, and mlx-lm / mlx-vlm baselines, see
+[Benchmark Report - 2026-05-19](benchmark-report.md).
+
+## Per-Hardware Results
+
+| Hardware | File | Status | Last Updated |
+|----------|------|--------|-------------|
+| Mac Studio M1 Ultra 128GB | [model_tests_m1ultra.md](model_tests_m1ultra.md) | Active | 2026-05-19 |
+| MacBook Pro M5 Max 128GB | [model_tests_m5max.md](model_tests_m5max.md) | Active | 2026-05-19 |
+| NVIDIA GB10 (DIGITS) | [model_tests_gb10.md](model_tests_gb10.md) | Active | 2026-05-19 |
+
+## Benchmark CSVs
+
+Current source-of-truth data lives in `benchmarks/`:
+
+| CSV | Hardware | Date | Type |
+|-----|----------|------|------|
+| `metal_m5max_2026-05-19.csv` | M5 Max | 2026-05-19 (mlxcel 0.0.28, MLX 0.31.2) | Text |
+| `metal_m5max_vlm_2026-05-19.csv` | M5 Max | 2026-05-19 (mlxcel 0.0.28, MLX 0.31.2) | VLM |
+| `pylm_m5max_2026-05-18.csv` | M5 Max | 2026-05-19 benchmark campaign (mlx-lm 0.31.3 baseline; CSV date crossed midnight) | Text |
+| `pylm_m5max_vlm_2026-05-18.csv` | M5 Max | 2026-05-19 benchmark campaign (mlx-vlm 0.4.4 baseline; CSV date crossed midnight) | VLM |
+| `metal_m1ultra_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlxcel 0.0.28, MLX commit 84961223; >65GB skipped) | Text |
+| `metal_m1ultra_vlm_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlxcel 0.0.28, MLX commit 84961223; >65GB skipped) | VLM |
+| `pylm_m1ultra_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlx-lm 0.31.3 baseline, `references/mlx-lm` @ `df1d3f3`; >65GB skipped) | Text |
+| `pylm_m1ultra_vlm_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlx-vlm baseline, `references/mlx-vlm` @ `d85ca4d`; >65GB skipped) | VLM |
+| `cuda_gb10_2026-05-19.csv` | GB10 | 2026-05-19 (mlxcel 0.0.27, MLX 0.31.2) | Text |
+| `cuda_gb10_vlm_2026-05-19.csv` | GB10 | 2026-05-19 (mlxcel 0.0.27, MLX 0.31.2) | VLM |
+
+## Cross-Hardware Comparison
+
+The table below summarizes the current cross-hardware decode readings for selected models.
+
+### Decode Speed Summary (tok/s, selected models)
+
+| Model | Params | M1 Ultra | M5 Max | GB10 |
+|-------|--------|----------|--------|------|
+| SmolLM-135M | 135M | 352.11 | 883.99 | 567.57 |
+| ERNIE-4.5-0.3B | 300M | 413.23 | 1035.74 | 600.45 |
+| Qwen2.5-0.5B (4bit) | 500M | 329.45 | 678.07 | 463.31 |
+| Llama-3.2-1B | 1B | 332.54 | 539.67 | 226.87 |
+| Qwen3-0.6B | 600M | 198.08 | 510.83 | 203.04* |
+| StableLM-1.6B | 1.6B | 270.47 | 424.32 | 186.64 |
+| Gemma-3-1B | 1B | 196.54 | 381.28 | 182.97 |
+| EXAONE-3.5-2.4B | 2.4B | 190.43 | 287.68 | 104.06 |
+| SmolLM3-3B | 3B | 136.43 | 232.92 | 101.88 |
+| Nemotron-H-30B | 30B | 89.96 | 171.76 | 25.75 |
+| Qwen3-MoE-30B | 30B | 70.56 | 151.40 | 56.65 |
+| Llama-3.1-8B | 8B | 108.45 | 116.85 | 49.46 |
+| Qwen2.5-7B | 7B | 111.29 | 126.63 | 54.18 |
+| Mixtral-8x7B | 47B | 53.49 | 65.07 | 28.05 |
+| GPT-OSS-120B | 120B (MoE) | 59.62 | 113.34 | 48.70 |
+| Solar-Open-100B | 100B (MoE) | 36.20 | 65.59 | 18.88 |
+
+*Qwen3-0.6B on GB10 produced only 9 tokens before EOS at 2026-05-19; the decode rate is from that short window and should be compared cautiously with full-token runs.
+
+M1 Ultra column is from 2026-05-19 with mlxcel 0.0.28 / MLX pin commit `84961223` (post-0.32.0) / no cooldown.
+M5 Max column is from 2026-05-19 with mlxcel 0.0.28 / MLX 0.31.2 / `--cooldown 15 --big-cooldown 15`.
+GB10 column is from 2026-05-19 with mlxcel 0.0.27 / MLX 0.31.2 / `bench_decode.sh` default cooldowns.
+M1 Ultra and M5 Max use mlxcel 0.0.28 with the same MLX pin, so their gap is primarily a hardware delta. M5 Max is roughly 1.7x faster than M1 Ultra on the selected rows (avg ~1.76x, median ~1.86x), while the largest MoE models have a narrower gap: gpt-oss-120b runs at 113.34 vs 59.62 tok/s (1.90x) and solar-open-100b runs at 65.59 vs 36.20 tok/s (1.81x).
+For Qwen2.5-0.5B, the 4-bit variant is the comparable row across both Apple Silicon hosts. The bf16 variant is available on M5 Max at 402.30 tok/s but fails warmup on M1 Ultra in this campaign.
+
+## Overall Status (mlxcel 0.0.28 on both M5 Max and M1 Ultra; MLX upstream `84961223`)
+
+| Metric | Count |
+|--------|-------|
+| Supported model architectures | 89+ ModelType variants |
+| Text models tested (M1 Ultra, 2026-05-19) | 82 pass, 2 partial, 6 fail, 13 pending, 3 skip (>65GB) |
+| Text models tested (M5 Max, 2026-05-19) | 89 pass, 4 partial, 5 fail (98 total) |
+| Text models tested (GB10, 2026-05-19) | 41 pass, 56 partial, 14 fail (111 total) |
+| VLM models tested (GB10, 2026-05-19) | 13 pass, 19 partial, 3 fail (image path) |
+| VLM models tested (M5 Max, 2026-05-19) | 24 working, 3 fail (from VLM sweep) |
+| VLM models tested (M1 Ultra, 2026-05-19) | 33 pass, 4 partial, 2 fail |
+| Beating mlx-lm on M1 Ultra (text, >100%) | 36/40 (90%, 5-19 baseline) |
+| At 90%+ parity on M1 Ultra (text) | 40/40 (100%, 5-19 baseline) |
+| Beating mlx-lm on M5 Max (text, >=100%) | 23/67 (34%, 5-19 mlxcel vs 5-18 mlx-lm) |
+| At 90%+ parity on M5 Max (text) | 59/67 (88%, 5-19 mlxcel vs 5-18 mlx-lm) |
+| Average vs mlx-lm on M5 Max (text) | 96% decode speed (median 98%, 5-19 mlxcel vs 5-18 mlx-lm) |
+| Average vs mlx-vlm on M5 Max (VLM) | 95% decode speed (median 99%, 5-19 mlxcel vs 5-18 mlx-vlm; 19 pairs) |
+
+## Generating Benchmarks
+
+```bash
+# Full text benchmark (auto-names CSV by hardware+date)
+./scripts/bench_decode.sh all
+
+# Full VLM benchmark
+./scripts/bench_decode.sh all --vlm
+
+# Single model
+./scripts/bench_decode.sh models/<model-name>
+```
+
+After benchmarking, update the corresponding `model_tests_<hardware>.md` file from the CSV.
+
+## Prompt cache benchmarks
+
+Feature: cross-request prompt-prefix KV cache. Bench driver:
+[`tests/prompt_cache_prefill_bench.rs`](../../tests/prompt_cache_prefill_bench.rs) (run with
+`cargo test --test prompt_cache_prefill_bench --release -- --ignored --nocapture`).
+
+### What the bench measures
+
+For each conversation depth in `{1, 2, 4, 8, 16}` the bench issues a warmup
+turn against the `/v1/chat/completions` streaming endpoint, then a
+measurement turn with an identical prefix. It records:
+
+| Column | Definition |
+| --- | --- |
+| `cache` | `on` = server started with `--prompt-cache-enabled=true`; `off` = disabled. |
+| `prompt_tokens` | `usage.prompt_tokens` from the final streaming chunk. |
+| `cached_tokens` | `usage.prompt_tokens_details.cached_tokens` when present; otherwise `-`. |
+| `ttft_ms` | Time to first content delta (proxy for prefill latency on a non-speculative decoder). |
+| `prefill_ms` | Same quantity as `ttft_ms`; kept as a separate column for compatibility with existing CSV readers. |
+| `decode_tps` | `completion_tokens / (total - ttft)`. |
+| `total_ms` | End-to-end wall-clock time for the measurement turn. |
+
+### Expected qualitative behavior
+
+On a functioning cache at depths >= 2 the measurement turn reports
+`cached_tokens > 0` and `ttft_ms` sits below the matching `cache=off` row
+for the same depth. The exact per-depth ratio depends on model and host;
+target order-of-magnitude (single-digit billion parameter model, dense
+backend) is:
+
+* Depth 1: ratio ≈ 1.0 (no preceding conversation to reuse).
+* Depth 2–4: ratio 0.3 – 0.8 (partial prefix reuse).
+* Depth 8–16: ratio 0.1 – 0.4 (near-constant cache adopt, linear cold
+  prefill on the off row).
+
+Record measured numbers for a specific host under a new sub-heading
+(e.g. `### M5 Max, qwen3-0.6b-4bit`) when updating this file.
+
+### Validation scope
+
+The harness itself is end-to-end exercised via the integration test
+`tests/prompt_cache_e2e.rs`, which asserts the wire contract
+(`cached_tokens == 0` on turn 1, `> 0` and monotonic on turns 2..5) and
+the prefill-latency ratio bound (≤ 1.3× turn 1) whenever the server is
+able to serve the model. Host-specific prompt-cache throughput numbers
+should be appended here after running on M1 Ultra, M5 Max, GB10, or Hopper.
+
+## TurboQuant KV cache benchmarks
+
+Feature: TurboQuant KV cache compression (turbo3 / turbo4 modes). Bench
+driver: `tests/turbo_kv_e2e.rs` (run with
+`cargo test --test turbo_kv_e2e --release -- --ignored --nocapture`).
+
+For the full config guide, tuning knobs, and architectural description see
+[`docs/turbo-kv-cache.md`](../turbo-kv-cache.md).
+
+### Source CSV
+
+`benchmarks/turbo_kv/2026-04-26_Mac.localdomain.csv`
+
+### Measured PPL evaluation throughput — 2026-04-26, Mac.localdomain
+
+The quality gate runs wikitext-2 PPL evaluation and records eval throughput
+(tok/s) and wall-clock time over a 4K-token evaluation window. Numbers below
+are from the first validated run.
+
+| Model | KV mode | PPL eval tok/s | Wall clock ms | Gate result |
+|---|---|---|---|---|
+| Meta-Llama-3.1-8B-Instruct-4bit | fp16 | 733.76 | 111,617 | baseline |
+| Meta-Llama-3.1-8B-Instruct-4bit | turbo4asym | 490.32 | 167,034 | **pass** |
+
+Notes:
+- Llama-3.1-8B-Instruct-4bit passes the turbo4asym PPL gate cleanly.
+- The active Qwen2.5 quality-gate fixture is `Qwen2.5-1.5B-4bit` (base variant). Numbers for that row are pending a fresh gate run.
+- Gemma-3-4b-it-4bit is ready for a quality-gate run but is not represented in this table yet.
+- Decode/prefill tok/s measurements (as distinct from PPL eval throughput) are a follow-up item.
+
+## Speculative drafters
+
+This section records the current parity and perf envelope for the speculative
+drafter pairings in the local benchmark setup (Gemma 4 MTP, Qwen 3.5 DFlash).
+
+### Methodology
+
+Driven by `src/bin/speculative_bench.rs` and `tests/speculative_parity.rs`:
+
+- Prompt: 17-token-ish instruction (see `DEFAULT_PROMPT` in the bench source).
+- Max new tokens: 96 (matches the upstream `mlx-vlm` README perf-table conditions).
+- Sampling: greedy (`temperature = 0.0`).
+- Decode-only timing (excludes prefill). Numbers come from `GenerationStats::decode_tok_per_sec`, which divides the generated token count by the decode wall-clock — matches the upstream `_dflash_rounds` / `_mtp_rounds` reporting convention.
+- Warm-up: one 4-token generation before the timed run so MLX's lazy Metal kernel compilation doesn't inflate the first measurement.
+
+Invocations:
+
+```bash
+# Single pairing:
+./target/release/speculative_bench \
+    --target models/qwen3.5-4b-4bit \
+    --kind none \
+    --batch 1 \
+    --max-tokens 96 \
+    2>&1 | tee /tmp/bench-qwen35-baseline.log
+
+# Full sweep across reachable pairings:
+./target/release/speculative_bench --sweep --batch 1 --max-tokens 96 \
+    2>&1 | tee /tmp/bench-sweep.log
+```
+
+### Hardware + MLX pin
+
+- **Hardware**: Apple M1 Ultra, 128 GB unified memory.
+- **MLX upstream commit pin**: `84961223c02925bef6bef95d3a0a046779bde935`
+  (`src/lib/mlxcel-core/build.rs::MLX_EXPECTED_COMMIT` at the time of measurement).
+- Re-measure after each MLX pin bump so the perf table reflects the active runtime.
+
+### Reachable pairings
+
+These are the pairings whose target + drafter checkpoints are present on
+the M1 Ultra reference host. The no-drafter baseline rows are real numbers
+captured on the host; the speculative numerator (tok/s) rows remain a
+perf-bench follow-up, but **correctness parity is verified** end-to-end
+by the `#[ignore]`-gated tests in `tests/speculative_parity.rs`.
+
+| Pairing                       | Kind   | B | block_size | tok/s | speedup vs no-drafter | status                                                                |
+|-------------------------------|--------|---|------------|-------|------------------------|-----------------------------------------------------------------------|
+| Qwen 3.5 4B (no drafter)      | none   | 1 | —          | 95.4  | 1.00×                  | ok                                                                    |
+| Qwen 3.5 4B + DFlash          | dflash | 1 | 16         | —     | —                      | parity verified; tok/s row is a perf-bench follow-up                  |
+| Gemma 4 31B (no drafter)      | none   | 1 | —          | 20.4  | 1.00×                  | ok                                                                    |
+| Gemma 4 31B + MTP assistant   | mtp    | 1 | 4          | —     | —                      | parity verified; tok/s row is a perf-bench follow-up                  |
+
+### Deferred pairings
+
+These pairings cannot be measured today because the drafter checkpoint is
+not on the reference host AND/OR an upstream dependency is unresolved.
+
+| Pairing                          | Drafter checkpoint                              | Status / blocker                                                                  |
+|----------------------------------|-------------------------------------------------|-----------------------------------------------------------------------------------|
+| Gemma 4 E2B + MTP assistant      | `mlx-community/gemma-4-E2B-it-assistant-bf16`   | drafter checkpoint not on disk; centroid LM head support required                 |
+| Gemma 4 E4B + MTP assistant      | `mlx-community/gemma-4-E4B-it-assistant-bf16`   | drafter checkpoint not on disk; centroid LM head support required                 |
+| Gemma 4 26B-A4B + MTP assistant  | `mlx-community/gemma-4-26B-A4B-it-assistant-bf16` | drafter checkpoint not on disk                                                  |
+
+### Real-model byte-equality parity test
+
+`tests/speculative_parity.rs` carries two `#[ignore]`-gated real-model
+tests — `greedy_parity_dflash_qwen35_4b` and `greedy_parity_mtp_gemma4_31b`
+— that verify speculative-decoding **correctness** end-to-end.
+Each test runs two phases:
+
+1. **Structural phase** (in-process): load the target, assert the model
+   variant, resolve the drafter kind, load the drafter, and — for DFlash —
+   `bind()` the drafter to the target.
+2. **Byte-equality phase** (subprocess): spawn `mlxcel-server` twice
+   against the same target — once with `--model-draft --draft-kind
+   {dflash,mtp} --draft-block-size {16,4}` and once without any
+   `--draft-*` flag — submit the same fixed prompt to
+   `/v1/chat/completions` at `temperature = 0`, and assert the two
+   responses are byte-identical (same `message.content` *and* same
+   `usage.completion_tokens`). The two servers run sequentially so a
+   32–48 GB host only holds one target's weights at a time.
+
+#### CI hardware lane / fixed cadence
+
+These tests are `#[ignore]`-gated so `cargo test` on a dev machine (or a
+CI host without the model checkpoints) skips them. They are run on the
+**hardware lane** — an Apple Silicon runner with the model checkpoints
+mounted under `models/` — on a fixed cadence:
+
+```bash
+# Run both speculative real-model parity tests serially (required:
+# they share GPU memory and each spawns mlxcel-server subprocesses).
+cargo test --test speculative_parity --release -- --ignored --test-threads=1 --nocapture
+```
+
+A test whose checkpoints are absent self-skips with a log line, so the
+invocation is safe to wire into any Apple Silicon CI lane regardless of
+which checkpoints that lane has provisioned.
+
+Once the perf-bench numerators are captured, the speculative tok/s rows in
+the table above flip on, and the table grows additional rows for the
+`(block_size ∈ {2, 3, 4, 5, 6, 8}, B ∈ {1, 4, 8})` MTP sweep and
+`(block_size ∈ {4, 8, 16, 24, 32}, B ∈ {1, 4, 8})` DFlash sweep.
+
+### Expected speedup envelope (per upstream `mlx-vlm` README)
+
+For comparison with the eventual measured numbers — these are the
+upstream M3 Max / 96 GB results, NOT mlxcel measurements:
+
+| Pairing               | B | block_size | upstream speedup                                                          |
+|-----------------------|---|------------|---------------------------------------------------------------------------|
+| Gemma 4 26B-A4B + MTP | 4 | 3          | 3.94×                                                                     |
+| Gemma 4 31B + MTP     | 4 | 3          | 2.29×                                                                     |
+| Gemma 4 E4B + MTP     | 4 | 4          | 1.56×                                                                     |
+| Gemma 4 E4B + MTP     | 16| any        | slower than baseline (overhead > speedup at high B on small target)       |
+
+DFlash speedup envelope is not documented as concretely upstream. mlxcel's
+measured numbers will become the reference table once the speculative
+perf-bench numerators are captured on the hardware lane.

--- a/docs/benchmark_results/model_tests_gb10.md
+++ b/docs/benchmark_results/model_tests_gb10.md
@@ -1,0 +1,290 @@
+# Model Compatibility & Performance Tests (NVIDIA GB10)
+
+Compatibility and performance testing for mlxcel models on **NVIDIA GB10 (DIGITS)**, running the CUDA backend.
+
+## Test Environment
+
+| Item | Value |
+|------|-------|
+| **Hardware** | NVIDIA GB10 (DIGITS), 122 GB Unified Memory |
+| **OS** | Linux (aarch64), kernel 6.17 |
+| **Backend** | CUDA 13.0 |
+| **mlxcel version** | 0.0.27 |
+| **MLX version** | 0.31.2 (via mlxcel-core) |
+| **Test Prompt** | "Hello, how are you today?" (text) / "What is in this image?" (VLM) |
+| **Max Tokens** | 100 |
+| **Test Date** | 2026-05-19 |
+| **CSV** | `benchmarks/cuda_gb10_2026-05-19.csv`, `benchmarks/cuda_gb10_vlm_2026-05-19.csv` |
+
+## Legend
+
+- ✅ Pass: Model generates 100 tokens cleanly
+- ⚠️ Partial: Loads but generates fewer tokens than `max_tokens`, or output quality is suspect
+- ❌ Fail: Does not work (warmup failure, OOM skip, or 0 tokens generated)
+
+## Basic Transformers
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| llama-3.2-1b-4bit | Llama-3.2-1B-4bit | ⚠️ | 250.04 | 226.87 | 31 tokens |
+| llama-3.1-8b-4bit | Llama-3.1-8B-Instruct-4bit | ✅ | 99.90 | 49.46 | 100 tokens |
+| llama-3.1-8b-bf16 | Llama-3.1-8B-Instruct (bf16) | ⚠️ | 17.99 | 15.02 | 87 tokens |
+| phi-2-4bit | phi-2-hf-4bit | ⚠️ | 8.50 | 3.64 | 1 token (likely EOS) |
+| phi-3-mini-4bit | Phi-3-mini-4k-instruct-4bit | ⚠️ | 14.55 | 87.70 | 25 tokens |
+| phi-3.5-mini-4bit | Phi-3.5-mini-instruct-4bit | ⚠️ | 13.01 | 55.82 | 40 tokens |
+| phi-4-4bit | Phi-4-4bit | ✅ | 5.26 | 27.61 | 100 tokens |
+| qwen2-0.5b | Qwen2.5-0.5B (bf16) | ✅ | 104.61 | 459.78 | |
+| qwen2.5-0.5b-4bit | Qwen2.5-0.5B-Instruct-4bit | ✅ | 111.01 | 463.31 | |
+| qwen2.5-0.5b-bf16 | Qwen2.5-0.5B (bf16) | ✅ | 59.93 | 200.52 | |
+| qwen2.5-7b | Qwen2.5-7B (bf16) | ✅ | 18.12 | 53.93 | |
+| qwen2.5-7b-4bit | Qwen2.5-7B-Instruct-4bit | ✅ | 17.39 | 54.18 | |
+| qwen2.5-7b-8bit | Qwen2.5-7B-8bit | ✅ | 13.72 | 30.71 | |
+| qwen3-0.6b | Qwen3-0.6B (bf16) | ⚠️ | 56.07 | 203.04 | 9 tokens (EOS) |
+| qwen3-0.6b-4bit | Qwen3-0.6B-4bit | ⚠️ | 59.52 | 206.59 | 9 tokens |
+| qwen3-1.7b-4bit | Qwen3-1.7B-4bit | ⚠️ | 37.54 | 139.13 | 14 tokens |
+| qwen3-4b-4bit | Qwen3-4B-4bit | ⚠️ | 26.75 | 78.79 | 36 tokens |
+| qwen3-8b-4bit | Qwen3-8B-4bit | ⚠️ | 18.17 | 48.01 | 33 tokens |
+| smollm-135m-4bit | SmolLM-135M-Instruct-4bit | ✅ | 53.53 | 567.57 | |
+| smollm3-3b-4bit | SmolLM3-3B-4bit | ⚠️ | 124.78 | 101.88 | 46 tokens |
+| stablelm-1.6b-4bit | stablelm-2-1_6b-chat-4bit | ⚠️ | 42.33 | 186.64 | 71 tokens |
+| starcoder2-3b-4bit | starcoder2-3b-4bit | ✅ | 7.55 | 102.47 | |
+| olmo-1b-4bit | OLMo-1B-hf-4bit | ✅ | 12.40 | 97.95 | |
+| olmo2-7b-4bit | OLMo2-7B-4bit | ⚠️ | 19.67 | 51.63 | 27 tokens |
+| olmo3-32b-4bit | OLMo3-32B-4bit | ✅ | 10.15 | 11.63 | |
+| minicpm-2b-4bit | MiniCPM-2B-sft-bf16-4bit | ✅ | 18.06 | 120.84 | |
+| mimo-7b-4bit | MiMo-7B-RL-4bit | ✅ | 24.58 | 53.19 | |
+
+## Gemma Family
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| gemma-2b-4bit | gemma-2b-it-4bit | ⚠️ | 16.02 | 99.45 | 49 tokens |
+| gemma2-2b-4bit | gemma-2-2b-it-4bit | ⚠️ | 16.99 | 73.14 | 18 tokens |
+| gemma3-1b-4bit | gemma-3-1b-it-4bit | ⚠️ | 25.58 | 182.97 | 34 tokens |
+| gemma3-4b-4bit | gemma-3-4b-it-4bit | ⚠️ | 17.11 | 80.03 | 72 tokens |
+| gemma3n-e2b-4bit | gemma-3n-E2B-it-4bit | ⚠️ | 13.05 | 75.41 | 68 tokens |
+| gemma3n-e4b-4bit | gemma-3n-E4B-it-4bit | ⚠️ | 10.91 | 52.59 | 74 tokens |
+| gemma3n-e4b-bf16 | gemma-3n-E4B-it (bf16) | ⚠️ | 3.28 | 21.64 | 69 tokens |
+
+### Gemma 4
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| gemma-4-e2b-it-4bit | Gemma-4-E2B-it-4bit | ✅ | 48.36 | 99.24 | 100 tokens |
+| gemma-4-e2b-it-8bit | Gemma-4-E2B-it-8bit | ✅ | 44.90 | 57.10 | |
+| gemma-4-e4b-it-4bit | Gemma-4-E4B-it-4bit | ⚠️ | 46.35 | 46.37 | 36 tokens |
+| gemma-4-e4b-it-8bit | Gemma-4-E4B-it-8bit | ⚠️ | 43.04 | 26.79 | 39 tokens |
+| gemma-4-26b-a4b-it-4bit | Gemma-4-26B-A4B-it-4bit | ❌ | - | FAIL | warmup failure |
+| gemma-4-31b-4bit | Gemma-4-31B-4bit | ✅ | 14.23 | 8.92 | |
+| gemma-4-31b-it-4bit | Gemma-4-31B-it-4bit | ⚠️ | 34.84 | 8.47 | 26 tokens |
+| gemma-4-31B-it-assistant-bf16 | Gemma-4-31B-it-assistant (bf16) | ❌ | - | FAIL | warmup failure |
+| Gemma-4-31b-it-nvfp4 | Gemma-4-31B-it (NVFP4) | ⚠️ | 9.53 | 0.93 | 26 tokens; unusably slow |
+
+## EXAONE
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| exaone-3.5-2.4b-4bit | EXAONE-3.5-2.4B-Instruct-4bit | ✅ | 73.09 | 104.06 | |
+| exaone4-1.2b-4bit | exaone-4.0-1.2b-4bit | ⚠️ | 38.87 | 176.69 | 18 tokens |
+
+## Cohere / Command R
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| command-r7b-4bit | c4ai-command-r7b-4bit | ✅ | 7.39 | 52.38 | |
+| aya-expanse-8b-4bit | aya-expanse-8b-4bit | ✅ | 7.54 | 52.84 | |
+
+## MoE (Mixture of Experts)
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| mixtral-8x7b-4bit | Mixtral-8x7B-Instruct-v0.1-4bit | ⚠️ | 2.31 | 28.05 | 73 tokens |
+| qwen1.5-moe-a2.7b-4bit | Qwen1.5-MoE-A2.7B-Chat-4bit | ✅ | 7.36 | 106.99 | |
+| qwen3-moe-4bit | Qwen3-30B-A3B-4bit | ⚠️ | 4.11 | 56.65 | 34 tokens |
+| qwen3-30b-a3b-4bit | Qwen3-30B-A3B-4bit | ⚠️ | 3.92 | 56.81 | 34 tokens |
+| phi-3.5-moe-4bit | Phi-3.5-MoE-instruct-4bit | ✅ | 1.25 | 50.71 | |
+| minimax-m2-3bit | MiniMax-M2-3bit | ✅ | 0.28 | 22.14 | |
+| gpt-oss-20b-mxfp4 | gpt-oss-20b-MXFP4 | ⚠️ | 25.77 | 76.30 | 58 tokens |
+| gpt-oss-120b-4bit | gpt-oss-120b-4bit | ⚠️ | 1.10 | 48.70 | 65 tokens |
+| deepseek-v2-lite-4bit | DeepSeek-V2-Lite-Chat-4bit | ✅ | 4.73 | 95.27 | |
+| deepseek-v3-4bit | DeepSeek-V3-0324-4bit | ❌ | - | FAIL | missing weight file |
+| llama-4-scout-17b-4bit | Llama-4-Scout-17B-16E-4bit | ✅ | 1.17 | 20.93 | 100 tokens |
+
+## MLA (Multi-head Latent Attention)
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| minicpm3-4b-4bit | MiniCPM3-4B-4bit | ✅ | 19.06 | 50.09 | |
+
+## DeepSeek Family
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| deepseek-coder-1.3b-4bit | deepseek-coder-1.3b-4bit | ✅ | 72.25 | 92.93 | |
+| deepseek-r1-distill-7b-4bit | DeepSeek-R1-Distill-Qwen-7B-4bit | ✅ | 5.83 | 58.60 | |
+
+## Nemotron Family
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| nemotron-h-30b-4bit | Nemotron-H-30B-4bit | ⚠️ | 4.34 | 25.75 | 46 tokens |
+| nemotron-nas-30b-4bit | Nemotron-NAS-30B-A3B-4bit | ⚠️ | 3.96 | 28.35 | 46 tokens |
+
+## SSM / Mamba / Hybrid Models
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| falcon-mamba-7b-4bit | Falcon-Mamba-7B-4bit | ⚠️ | 8.12 | 21.45 | 2 tokens (EOS) |
+| mamba2-1.3b-4bit | mamba2-1.3b-4bit | ✅ | 7.45 | 81.02 | |
+| jamba-v0.1-4bit | Jamba-v0.1-4bit | ✅ | 46.49 | 80.91 | 100 tokens |
+
+## Chinese / Asian Language Models
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| baichuan-m1-14b-4bit | Baichuan-M1-14B-Instruct-4bit | ⚠️ | 2.51 | 26.74 | 39 tokens |
+| glm4-flash-4bit | GLM-4-Flash-4bit | ✅ | 2.13 | 51.52 | 100 tokens |
+| GLM-5.1-4bit | GLM-5.1-4bit | ❌ | - | FAIL | warmup failure |
+| internlm2-7b-4bit | InternLM2-7B-4bit | ✅ | 18.72 | 50.65 | |
+| internlm3-8b-4bit | internlm3-8b-instruct-4bit | ✅ | 24.59 | 44.14 | |
+| ernie-4.5-0.3b-4bit | ERNIE-4.5-0.3B-Instruct-4bit | ✅ | 119.90 | 600.45 | |
+| hunyuan-13b | Hunyuan-Large (bf16, 13B) | ✅ | 0.55 | 14.78 | |
+| hunyuan-4bit | Hunyuan-Large-Instruct-4bit | ✅ | 0.92 | 14.70 | |
+| hunyuan-dense-4bit | Hunyuan-1.8B-Instruct-4bit | ⚠️ | 28.81 | 150.94 | 41 tokens |
+| hunyuan-1.8b-4bit | Hunyuan-1.8B-Instruct-4bit | ⚠️ | 27.03 | 149.45 | 41 tokens |
+| hunyuan-large-4bit | Hunyuan-Large-Instruct-4bit | ✅ | 0.92 | 14.35 | |
+| hunyuan-moe-a13b-bf16 | Hunyuan-MoE-A13B (bf16) | ✅ | 0.49 | 14.84 | |
+
+## Mistral Family
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| ministral-3b-4bit | Ministral-3B-Instruct-4bit | ⚠️ | 922.10 | 91.05 | 34 tokens |
+| mistral-small-3.1-24b-4bit | mistral-small-3.1-24b-4bit | ✅ | 1.95 | 16.28 | 100 tokens |
+| pixtral-12b | pixtral-12b (bf16) | ✅ | 2.51 | 33.26 | |
+| pixtral-12b-4bit | pixtral-12b-4bit | ✅ | 2.48 | 33.45 | 100 tokens |
+
+## VLM-capable Models (text-only pass)
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| aya-vision-8b | aya-vision-8b | ⚠️ | 7.63 | 51.44 | 87 tokens |
+| bunny-llama3-8b-4bit | Bunny-Llama-3-8B-V-4bit | ⚠️ | 18.12 | 52.40 | 40 tokens |
+| llava-1.5-7b-4bit | llava-1.5-7b-4bit | ✅ | 9.12 | 55.83 | |
+| llava-next-mistral-7b-4bit | llava-v1.6-mistral-7b-4bit | ✅ | 16.17 | 52.48 | |
+| llava-interleave-qwen-0.5b-bf16 | llava-interleave-qwen-0.5b-bf16 | ⚠️ | 41.50 | 203.89 | 49 tokens |
+| molmo2-4b | molmo2-4b | ⚠️ | 7.16 | 26.63 | 33 tokens |
+| molmo-7b | Molmo-7B | ❌ | - | FAIL | warmup |
+| paligemma2-3b-6bit | paligemma2-3b | ❌ | 6.98 | 0.00 | 0 tokens generated |
+| phi-3.5-vision-4bit | Phi-3.5-vision-instruct-4bit | ⚠️ | 20.97 | 56.30 | 43 tokens |
+| internvl3-1b | InternVL3-1B | ❌ | - | FAIL | warmup |
+| qwen2-vl-2b | Qwen2-VL-2B (bf16) | ⚠️ | 44.43 | 97.37 | 35 tokens |
+| qwen2-vl-2b-4bit | Qwen2-VL-2B-Instruct-4bit | ⚠️ | 46.07 | 96.64 | 35 tokens |
+| qwen2.5-vl-3b | Qwen2.5-VL-3B (bf16) | ❌ | - | FAIL | warmup |
+| qwen2.5-vl-3b-4bit | Qwen2.5-VL-3B-Instruct-4bit | ❌ | - | FAIL | warmup |
+| qwen3-vl-2b | Qwen3-VL-2B (bf16) | ⚠️ | 29.83 | 161.91 | 59 tokens |
+| qwen3-vl-2b-4bit | Qwen3-VL-2B-Instruct-4bit | ⚠️ | 30.45 | 162.74 | 59 tokens |
+| qwen3-vl-30b-a3b-4bit | Qwen3-VL-30B-A3B-4bit | ⚠️ | 2.97 | 55.81 | 34 tokens |
+| qwen3-vl-32b-4bit | Qwen3-VL-32B-4bit | ⚠️ | 2.70 | 11.00 | 37 tokens |
+
+## Qwen3.5 / Qwen3-next (new architectures)
+
+| Model | Test Model | Status | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|-----------------|----------------|-------|
+| qwen3.5-0.8b-4bit | Qwen3.5-0.8B-4bit | ⚠️ | 28.15 | 147.92 | 18 tokens |
+| qwen3.5-2b-4bit | Qwen3.5-2B-4bit | ⚠️ | 24.00 | 111.43 | 31 tokens |
+| qwen3.5-4b-4bit | Qwen3.5-4B-4bit | ⚠️ | 18.97 | 59.28 | 31 tokens |
+| qwen3.5-9b-4bit | Qwen3.5-9B-4bit | ⚠️ | 12.64 | 37.93 | 31 tokens |
+| qwen3.5-9b-bf16 | Qwen3.5-9B (bf16) | ⚠️ | 3.21 | 13.02 | 31 tokens |
+| qwen3.5-27b-4bit | Qwen3.5-27B-4bit | ⚠️ | 3.42 | 12.17 | 30 tokens |
+| qwen3.5-35b-a3b-4bit | Qwen3.5-35B-A3B-4bit | ⚠️ | 3.57 | 47.35 | 31 tokens |
+| Qwen3.5-4B-DFlash | Qwen3.5-4B-DFlash | ❌ | - | FAIL | warmup failure |
+| Qwen3.5-397B-A17B-4bit | Qwen3.5-397B-A17B-4bit | ❌ | - | SKIP | skipped (OOM estimate) |
+| qwen3-next-480b-4bit | Qwen3-next-480B-4bit | ❌ | - | SKIP | skipped (OOM estimate) |
+| solar-open-100b-4bit | Solar-Open-100B-4bit | ⚠️ | 57.78 | 18.88 | 100 tokens |
+
+## VLM Benchmark (image input)
+
+| Model | Test Model | Status | Generated Tokens | Prefill (tok/s) | Decode (tok/s) | Notes |
+|-------|------------|--------|------------------|-----------------|----------------|-------|
+| aya-vision-8b | aya-vision-8b | ✅ | 100 | 101.13 | 39.64 | |
+| bunny-llama3-8b-4bit | Bunny-Llama-3-8B-V-4bit | ⚠️ | 37 | 453.73 | 36.15 | |
+| gemma3-4b-4bit | gemma-3-4b-it-4bit | ⚠️ | 16 | 201.51 | 64.42 | |
+| gemma3n-e2b-4bit | gemma-3n-E2B-it-4bit | ⚠️ | 29 | 144.98 | 67.64 | |
+| gemma3n-e4b-4bit | gemma-3n-E4B-it-4bit | ⚠️ | 33 | 132.96 | 45.18 | |
+| gemma3n-e4b-bf16 | gemma-3n-E4B-it (bf16) | ⚠️ | 24 | 52.54 | 20.38 | |
+| gemma-4-31b-4bit | Gemma-4-31B-4bit | ⚠️ | 8 | 214.15 | 7.58 | VLM-mode result |
+| gemma-4-31b-it-4bit | Gemma-4-31B-it-4bit | ⚠️ | 27 | 225.56 | 8.36 | VLM-mode result |
+| gemma-4-e2b-it-4bit | Gemma-4-E2B-it-4bit | ⚠️ | 20 | 486.92 | 82.05 | 20 tokens |
+| gemma-4-e2b-it-8bit | Gemma-4-E2B-it-8bit | ⚠️ | 11 | 466.89 | 44.77 | 11 tokens |
+| gemma-4-e4b-it-4bit | Gemma-4-E4B-it-4bit | ⚠️ | 47 | 443.17 | 46.52 | |
+| gemma-4-e4b-it-8bit | Gemma-4-E4B-it-8bit | ⚠️ | 11 | 414.08 | 23.92 | |
+| llama-4-scout-17b-4bit | Llama-4-Scout-17B-16E-4bit | ⚠️ | 60 | 3.59 | 19.66 | |
+| llava-1.5-7b-4bit | llava-1.5-7b-4bit | ✅ | 100 | 410.70 | 52.33 | |
+| llava-interleave-qwen-0.5b-bf16 | llava-interleave-qwen-0.5b-bf16 | ⚠️ | 32 | 843.42 | 147.49 | |
+| llava-next-mistral-7b-4bit | llava-v1.6-mistral-7b-4bit | ✅ | 100 | 388.13 | 51.66 | |
+| ministral-3b-4bit | Ministral-3B-Instruct-4bit | ✅ | 100 | 1668.44 | 86.69 | |
+| mistral-small-3.1-24b-4bit | mistral-small-3.1-24b-4bit | ✅ | 100 | 317.94 | 15.52 | |
+| molmo2-4b | molmo2-4b | ⚠️ | 46 | 169.20 | 26.54 | |
+| paligemma2-3b-6bit | paligemma2-3b | ⚠️ | 2 | 545.97 | 21.69 | |
+| phi-3.5-vision-4bit | Phi-3.5-vision-instruct-4bit | ⚠️ | 19 | 426.23 | 45.33 | |
+| pixtral-12b | pixtral-12b (bf16) | ✅ | 100 | 527.64 | 30.29 | |
+| pixtral-12b-4bit | pixtral-12b-4bit | ✅ | 100 | 545.24 | 30.38 | VLM-mode result |
+| qwen2-vl-2b | Qwen2-VL-2B (bf16) | ❌ | 0 | 26.01 | 0.00 | 0 tokens generated |
+| qwen2-vl-2b-4bit | Qwen2-VL-2B-Instruct-4bit | ❌ | 0 | 25.42 | 0.00 | 0 tokens generated |
+| qwen3-vl-2b | Qwen3-VL-2B (bf16) | ✅ | 100 | 34.43 | 131.32 | VLM-mode result |
+| qwen3-vl-2b-4bit | Qwen3-VL-2B-Instruct-4bit | ✅ | 100 | 30.85 | 126.26 | VLM-mode result |
+| qwen3-vl-30b-a3b-4bit | Qwen3-VL-30B-A3B-4bit | ❌ | 0 | 2.95 | 0.00 | 0 tokens generated (decode timing out) |
+| qwen3-vl-32b-4bit | Qwen3-VL-32B-4bit | ⚠️ | 100 | 2.97 | 10.76 | VLM-mode result |
+| qwen3.5-27b-4bit | Qwen3.5-27B-4bit | ✅ | 100 | 3.58 | 12.72 | |
+| qwen3.5-35b-a3b-4bit | Qwen3.5-35B-A3B-4bit | ✅ | 100 | 3.63 | 48.15 | |
+| qwen3.5-9b-bf16 | Qwen3.5-9B (bf16) | ⚠️ | 77 | 2.83 | 13.28 | |
+| qwen3.5-2b-4bit | Qwen3.5-2B-4bit | ✅ | 100 | 17.43 | 125.51 | VLM-mode result |
+| qwen3.5-4b-4bit | Qwen3.5-4B-4bit | ✅ | 100 | 15.42 | 63.07 | VLM-mode result |
+| qwen3.5-9b-4bit | Qwen3.5-9B-4bit | ⚠️ | 50 | 11.22 | 38.30 | VLM-mode result |
+| qwen3.5-0.8b-4bit | Qwen3.5-0.8B-4bit | ⚠️ | 70 | 23.21 | 182.11 | VLM-mode result |
+
+> The VLM sweep treats every model directory as a candidate, so non-VLM models that load the image preprocessor without error appear here. Pure text models that warmup-fail in VLM mode (most of the suite) are recorded as `FAIL:warmup` in the CSV and omitted from this table.
+
+---
+
+## Summary
+
+**Test date**: 2026-05-19 | **Hardware**: NVIDIA GB10 (DIGITS) | **mlxcel**: 0.0.27 | **MLX**: 0.31.2
+
+| Metric | Count |
+|--------|-------|
+| **Total text models attempted** | 111 |
+| **Pass (✅)** | 41 |
+| **Partial (⚠️)** | 56 |
+| **Fail (❌)** | 14 |
+| **VLM models attempted (image)** | 111 (full sweep) |
+| **VLM Pass (✅)** | 13 |
+| **VLM Partial (⚠️)** | 19 |
+| **VLM Fail (❌, image path)** | 3 (qwen2-vl 2B fp16/4bit, qwen3-vl-30b-a3b) |
+
+The remaining ~76 rows in the VLM CSV are text-only models that fail warmup in VLM mode. Their text-suite results are above in the per-family tables.
+
+### Current-state observations
+
+- GB10 text coverage is broad but many rows are partial because the model exits before the requested 100 tokens.
+- Small dense models and several VLM-capable text paths produce the highest decode rates, with `ernie-4.5-0.3b-4bit`, `smollm-135m-4bit`, and Qwen2.5 0.5B variants leading the table.
+- Large MoE and hybrid models run, but decode throughput is much lower than on Apple Silicon for this campaign.
+- The VLM image sweep has 13 clean passes, 19 partial rows, and 3 image-path failures; text-only warmup failures from the full VLM candidate sweep are omitted from the table.
+
+### Failing models (14 total)
+
+Real CUDA-specific or model-specific failures:
+
+- `deepseek-v3-4bit`: missing weight file
+- `gemma-4-26b-a4b-it-4bit`: warmup failure
+- `gemma-4-31B-it-assistant-bf16`: warmup failure
+- `GLM-5.1-4bit`: warmup failure
+- `Qwen3.5-4B-DFlash`: warmup failure
+- `internvl3-1b`, `molmo-7b`: warmup, model-specific issues
+- `paligemma2-3b-6bit`: loads but 0 tokens generated
+
+Skipped (OOM estimate, not real failure):
+
+- `Qwen3.5-397B-A17B-4bit`
+- `qwen3-next-480b-4bit`

--- a/docs/benchmark_results/model_tests_m1ultra.md
+++ b/docs/benchmark_results/model_tests_m1ultra.md
@@ -1,0 +1,637 @@
+# Model Compatibility & Performance Tests (M1 Ultra)
+
+Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra 128GB**, with comparison against Python mlx-lm / mlx-vlm.
+
+## Test Environment
+
+| Item | Value |
+|------|-------|
+| **Hardware** | Mac Studio M1 Ultra, 128GB RAM |
+| **OS** | macOS 26.4 (Tahoe) |
+| **mlxcel version** | 0.0.28 |
+| **MLX version** | post-0.32.0 pin (commit 84961223, via mlxcel-core) |
+| **mlx-lm baseline** | 0.31.3 (dev checkout `references/mlx-lm` @ `df1d3f3`) |
+| **mlx-vlm baseline** | dev checkout `references/mlx-vlm` @ `d85ca4d` |
+| **Test Prompt** | "Hello, how are you today?" (text) / "What is in this image?" (VLM) |
+| **Max Tokens** | 100 |
+| **Test Date** | 2026-05-19 full sweep (mlxcel + mlx-lm + mlx-vlm baselines all from this date) |
+| **Baseline CSVs** | `benchmarks/pylm_m1ultra_2026-05-19.csv` (mlx-lm, 75 ran / 33 FAIL / 3 oversize-skip / 1 exit-fail) + `benchmarks/pylm_m1ultra_vlm_2026-05-19.csv` (mlx-vlm, 20 working VLM models) |
+
+## Legend
+
+- ✅ Pass: Model works correctly
+- ⚠️ Partial: Loads but output quality problems
+- ❌ Fail: Does not work
+- 📦 Model Issue: Model file incomplete or wrong format
+- ⏳ Pending: Not yet tested
+
+## Basic Transformers
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
+|-------|------------|--------|---------|--------|-----------|-------|
+| llama3 | Llama-3.2-1B-Instruct-4bit | ✅ | 868.15 | 332.54 | **123%** | mlx-lm: 269.91; only 48 tokens |
+| llama3 (8B bf16) | Llama-3.1-8B-Instruct (bf16) | ✅ | 134.07 | 35.43 | **118%** | mlx-lm: 29.94; non-quantized |
+| llama3.1 | Llama-3.1-8B-Instruct-4bit | ✅ | 333.55 | 108.45 | **122%** | mlx-lm: 89.06; only 54 tokens |
+| llama4 | Llama-4-Scout-17B-16E-Instruct-4bit | ⚠️ | 3.89 | 36.36 | **108%** | mlx-lm: 33.68; long outputs repetitive |
+| qwen2 | Qwen2.5-0.5B-Instruct-4bit | ✅ | 452.68 | 329.45 | **146%** | mlx-lm: 225.37 |
+| qwen2 (7B 4bit) | Qwen2.5-7B-Instruct-4bit | ✅ | 163.03 | 111.29 | **125%** | mlx-lm: 89.23 |
+| qwen2 (7B 8bit) | Qwen2.5-7B-Instruct-8bit | ✅ | 85.63 | 69.61 | - | 8-bit quantized |
+| qwen3 | Qwen3-0.6B-4bit | ✅ | 224.19 | 198.08 | 91% | mlx-lm: 217.22 |
+| qwen3 (1.7B) | Qwen3-1.7B-4bit | ✅ | 161.66 | 193.24 | - |  |
+| qwen3 (4B) | Qwen3-4B-4bit | ✅ | 124.36 | 118.85 | - |  |
+| qwen3 (8B) | Qwen3-8B-4bit | ✅ | 77.00 | 80.64 | - |  |
+| qwen3_5 (0.8B) | Qwen3.5-0.8B-4bit | ✅ | 173.90 | 205.52 | - | Hybrid GatedDeltaNet |
+| qwen3_5 (2B) | Qwen3.5-2B-4bit | ✅ | 168.61 | 175.73 | - | Hybrid GatedDeltaNet; only 36 tokens |
+| qwen3_5 (4B) | Qwen3.5-4B-4bit | ✅ | 107.33 | 101.21 | - | Hybrid GatedDeltaNet; only 36 tokens |
+| qwen3_5 (9B 4bit) | qwen3.5-9B-4bit | ✅ | 67.38 | 72.02 | - | Hybrid GatedDeltaNet; only 29 tokens |
+| qwen3_5 (9B bf16) | qwen3.5-9B (bf16) | ✅ | 126.90 | 31.11 | - | bf16, not quantized; Hybrid GatedDeltaNet (compiled fused kernel) |
+| qwen3_5 (27B) | qwen3.5-27B-4bit | ✅ | 28.07 | 24.11 | **111%** | mlx-lm: 21.76; Hybrid Transformer+GatedDeltaNet; VLM wrapper format |
+| qwen3_6 | qwen3.6-35B-A3B-4bit | ✅ | 21.51 | 67.07 | - | MoE architecture; 100 tokens |
+| qwen3_next | qwen3-next-480B-4bit | ⏳ | - | SKIP | - | Qwen3Next 480B architecture; >65GB skipped on 128GB host |
+| qwen2 (1.5B) | Qwen2.5-1.5B-Instruct-4bit | ✅ | 299.16 | 238.66 | - | 100 tokens |
+| qwen2 (1.5B base) | Qwen2.5-1.5B-4bit | ✅ | 231.58 | 236.02 | - | base variant; 100 tokens |
+| phi | phi-2-hf-4bit-mlx | ✅ | 46.33 | 52.59 | - | mlx-lm fails to load; only 1 token (likely EOS) |
+| phi3 | Phi-3-mini-4k-instruct-4bit | ✅ | 64.97 | 143.69 | 100% | mlx-lm: 144.17; only 25 tokens |
+| phi3small | Phi-3.5-mini-instruct-4bit | ✅ | 58.62 | 116.86 | 82% | mlx-lm: 141.80; only 40 tokens |
+| phi4 | Phi-4-4bit | ✅ | 34.61 | 58.03 | **116%** | mlx-lm: 49.92 |
+| smollm3 | SmolLM-135M-Instruct-4bit | ✅ | 244.49 | 352.11 | **118%** | mlx-lm: 297.15 |
+| smollm3 (3B) | SmolLM3-3B-4bit | ✅ | 327.29 | 136.43 | **129%** | mlx-lm: 105.56 |
+| stablelm | stablelm-2-1_6b-chat-4bit | ✅ | 244.27 | 270.47 | **131%** | mlx-lm: 206.29; only 59 tokens |
+| starcoder2 | starcoder2-3b-4bit | ✅ | 55.90 | 167.20 | **119%** | mlx-lm: 140.89 |
+| olmo | OLMo-1B-hf-4bit | ✅ | 49.05 | 209.70 | - | mlx-lm: requires ai2-olmo |
+| olmo2 | OLMo2-7B-4bit | ✅ | 88.94 | 103.37 | **113%** | mlx-lm: 91.21; only 27 tokens |
+| olmo3 | OLMo3.1-32B-4bit | ✅ | 68.86 | 21.95 | **116%** | mlx-lm: 18.92 |
+| minicpm | MiniCPM-2B-sft-bf16-4bit | ✅ | 94.14 | 162.79 | **130%** | mlx-lm: 124.90 |
+| mimo | MiMo-7B-RL-4bit | ✅ | 110.54 | 85.14 | **121%** | mlx-lm: 70.49 |
+
+## Gemma Family
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
+|-------|------------|--------|---------|--------|-----------|-------|
+| gemma | gemma-2b-it-4bit | ✅ | 84.91 | 192.52 | - | mlx-lm: 69.49; only 49 tokens |
+| gemma2 | gemma-2-2b-it-4bit | ✅ | 98.07 | 135.27 | 86% | mlx-lm: 157.00; only 18 tokens |
+| gemma3 | gemma-3-1b-it-4bit | ✅ | 129.49 | 196.54 | **175%** | mlx-lm: 112.37; only 34 tokens |
+| gemma3 (4B) | gemma-3-4b-it-4bit | ✅ | 74.48 | 103.61 | - | only 86 tokens |
+| gemma4 (31B) | gemma-4-31b-4bit | ✅ | 12.70 | 20.31 | - |  |
+| gemma4 (31B-it) | gemma-4-31b-it-4bit | ✅ | 27.73 | 19.39 | - | instruction-tuned variant |
+| gemma4 (26B A4B) | gemma-4-26b-a4b-it-4bit | ✅ | 137.85 | 70.27 | - | only 26 tokens |
+| gemma4 (E2B 4bit) | gemma-4-e2b-it-4bit | ✅ | 170.04 | 118.94 | - | only 34 tokens |
+| gemma4 (E2B 8bit) | gemma-4-e2b-it-8bit | ✅ | 91.80 | 87.56 | - | only 38 tokens |
+| gemma4 (E4B 4bit) | gemma-4-e4b-it-4bit | ✅ | 129.20 | 82.77 | - | only 25 tokens |
+| gemma4 (E4B 8bit) | gemma-4-e4b-it-8bit | ✅ | 72.12 | 59.06 | - | only 39 tokens |
+| gemma3n | gemma-3n-E2B-it-4bit | ✅ | 69.38 | 76.18 | - | only 69 tokens |
+| gemma3n (E4B) | gemma-3n-E4B-it-4bit | ✅ | 52.01 | 58.96 | - | only 74 tokens |
+| gemma3n (E4B bf16) | gemma-3n-E4B-it (bf16) | ✅ | 92.67 | 34.36 | - | bf16; only 72 tokens |
+| recurrent_gemma | - | ⏳ | - | - | - | Griffin SSM+attention hybrid |
+
+## EXAONE
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
+|-------|------------|--------|---------|--------|-----------|-------|
+| exaone | EXAONE-3.5-2.4B-Instruct-4bit | ✅ | 259.44 | 190.43 | **126%** | mlx-lm: 150.80 |
+| exaone4 | exaone-4.0-1.2b-4bit | ✅ | 153.22 | 213.60 | - | mlx-lm: fails to load; only 18 tokens |
+| exaone_moe | - | ⏳ | - | - | - | |
+
+## Cohere Command R
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
+|-------|------------|--------|---------|--------|-----------|-------|
+| cohere | c4ai-command-r7b-12-2024-4bit | ✅ | 29.10 | 111.42 | **142%** | mlx-lm: 78.67 |
+| cohere2 | aya-expanse-8b-4bit | ✅ | 29.80 | 107.92 | **130%** | mlx-lm: 83.08 |
+
+## MoE (Mixture of Experts)
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
+|-------|------------|--------|---------|--------|-----------|-------|
+| minimax | MiniMax-M2-3bit | ⏳ | - | SKIP | - | mlx-lm: 18.2; >65GB skipped on 128GB host (93GB) |
+| mixtral | Mixtral-8x7B-Instruct-v0.1-4bit | ✅ | 11.57 | 53.49 | **114%** | mlx-lm: 47.12; only 73 tokens |
+| qwen2_moe | Qwen1.5-MoE-A2.7B-Chat-4bit | ✅ | 34.93 | 142.23 | **127%** | mlx-lm: 111.82; only 43 tokens |
+| qwen3_moe | Qwen3-30B-A3B-4bit | ✅ | 24.08 | 70.56 | **124%** | mlx-lm: 56.91 |
+| qwen3_5_moe | qwen3.5-35B-A3B-4bit | ✅ | 20.92 | 70.21 | **176%** | mlx-lm: 39.95; Hybrid GatedDeltaNet + MoE (256 experts); only 34 tokens |
+| phimoe | Phi-3.5-MoE-instruct-4bit | ✅ | 9.16 | 76.13 | **124%** | mlx-lm: 61.16 |
+| solar_open | Solar-Open-100B-4bit | ✅ | 11.19 | 36.20 | **120%** | mlx-lm: 30.26; 128 experts, top-8; 54GB |
+| solar_open (int4) | Solar-Open-100B-int4 | ✅ | - | 11.55 | - | mlx-lm: fails to load; 128 experts, top-8; int4 quantization; 54GB |
+| olmoe | - | ⏳ | - | - | - | |
+| gpt_oss (20B) | gpt-oss-20b-MXFP4-Q4 | ✅ | 133.13 | 92.08 | **130%** | mlx-lm: 71.06; MXFP4 quantization; 32 experts |
+| gpt_oss (120B) | gpt-oss-120b-4bit | ✅ | 3.79 | 59.62 | **127%** | mlx-lm: 47.12; 128 experts, top-4; 61GB model |
+
+## DeepSeek Family
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
+|-------|------------|--------|---------|--------|-----------|-------|
+| deepseek | deepseek-coder-1.3b-instruct-4bit | ✅ | 445.51 | 162.80 | - | mlx-lm: fails to load |
+| deepseek_v2 | DeepSeek-V2-Lite-Chat-4bit | ✅ | 31.17 | 94.74 | **402%** | mlx-lm: 23.55; only 18 tokens |
+| deepseek_r1 | DeepSeek-R1-Distill-Qwen-7B-4bit | ✅ | 51.47 | 110.52 | **126%** | mlx-lm: 87.53 |
+| deepseek_v3 | deepseek-v3-4bit | ⏳ | - | SKIP | - | MoE + MLA; >65GB skipped on 128GB host (99GB) |
+| deepseek_v32 | - | ⏳ | - | - | - | |
+
+## MLA (Multi-head Latent Attention)
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
+|-------|------------|--------|---------|--------|-----------|-------|
+| minicpm3 | MiniCPM3-4B-4bit | ✅ | 87.60 | 79.08 | **125%** | mlx-lm: 63.04 |
+
+## Nemotron Family
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
+|-------|------------|--------|---------|--------|-----------|-------|
+| nemotron_h | Nemotron-H-30B-4bit | ✅ | 17.03 | 89.96 | **119%** | mlx-lm: 75.78; Hybrid Mamba2+Transformer+MoE; SSM Metal kernel |
+| nemotron_nas | Nemotron-NAS-30B-A3B-4bit | ✅ | 17.85 | 89.10 | **117%** | mlx-lm: 76.81; Hybrid Mamba2+Transformer+MoE |
+| nemotron_h_nano_omni | Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | ✅ | 16.22 | 80.67 | - | Mamba2+Transformer+MoE+Parakeet audio; 100 tokens |
+
+## SSM / Mamba Models
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
+|-------|------------|--------|---------|--------|-----------|-------|
+| mamba | Falcon-Mamba-7B-4bit | ⚠️ | 31.10 | 30.78 | - | mlx-lm: fails to load; only 2 tokens due to chat template EOS |
+| mamba2 | mamba2-1.3b-4bit | ✅ | 83.50 | 107.35 | - | mlx-lm: fails (ModelArgs error) |
+| jamba | Jamba-v0.1-4bit | ✅ | 193.67 | 92.02 | 92% | mlx-lm: 100.13; only 76 tokens |
+| rwkv7 | - | ⏳ | - | - | - | RWKV v7 linear attention |
+
+## Chinese / Asian Language Models
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
+|-------|------------|--------|---------|--------|-----------|-------|
+| baichuan | Baichuan-M1-14B-Instruct-4bit | ✅ | 21.74 | 46.86 | **114%** | mlx-lm: 40.95; only 39 tokens |
+| glm4 | GLM-4-Flash-4bit | ✅ | 13.81 | 45.37 | - | Only 18 tokens |
+| glm4_moe | - | ⏳ | - | - | - | |
+| glm4_moe_lite | GLM-4.7-Flash-4bit | ✅ | - | 31.54 | 76% | mlx-lm: 41.55; only 18 tokens |
+| glm5 | GLM-5-4bit | ❌ | - | FAIL | - | warmup failure (persistent) |
+| internlm2 | InternLM2-7B-4bit | ✅ | 81.86 | 109.04 | **120%** | mlx-lm: 90.69 |
+| internlm3 | internlm3-8b-instruct-4bit | ✅ | 109.49 | 86.13 | - | mlx-lm: fails to load |
+| ernie4_5 | ERNIE-4.5-0.3B-Instruct-4bit | ✅ | 474.07 | 413.23 | - | mlx-lm: fails to load |
+| ernie4_5_moe | - | ⏳ | - | - | - | |
+| hunyuan_moe | Hunyuan-Large-Instruct-4bit | ✅ | 5.72 | 44.51 | - | mlx-lm: fails to load |
+| hunyuan_moe_13b | HunYuan-MoE-A13B-Instruct (bf16) | ❌ | - | FAIL | - | mlx-lm: fails to load; Tiktoken tokenizer; bf16; warmup failure |
+| hunyuan_v1_dense | Hunyuan-1.8B-Instruct-4bit | ✅ | 114.33 | 176.58 | **1214%** | mlx-lm: 14.54; only 41 tokens |
+| kimi_linear | - | ⏳ | - | - | - | Kimi linear attention (Moonshot) |
+| step3p5 | - | ⏳ | - | - | - | Step 3.5 (StepFun) |
+
+## Other Models
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
+|-------|------------|--------|---------|--------|-----------|-------|
+| ministral3 | Ministral-3B-Instruct-4bit | ✅ | 803.53 | 140.72 | 91% | mlx-lm: 154.36; VLM wrapper; text-only mode; only 34 tokens |
+| mistral4 | - | ⏳ | - | - | - | MLA + MoE; implemented but no MLX model available |
+| moondream3 | moondream3-preview-4bit | ⚠️ | - | 8.45 | - | mlx-lm: fails to load; text-only test; SigLIP + MLP; image output garbled; only 14 tokens |
+| longcat_flash | - | ⏳ | - | - | - | |
+| longcat_flash_ngram | - | ⏳ | - | - | - | |
+| mistral_small | mistral-small-3.1-24b-4bit | ✅ | 12.88 | 31.82 | - | text-only mode |
+
+## Vision-Language Models (VLM)
+
+| Model | Test Model | Status | Prefill | Decode | vs mlx-vlm | Notes |
+|-------|------------|--------|---------|--------|------------|-------|
+| gemma3 | gemma-3-4b-it-4bit | ✅ | 249.32 | 80.13 | - | SigLIP + AvgPool; 275 prompt, 16 gen |
+| gemma3n (E2B) | gemma-3n-E2B-it-4bit | ✅ | 509.31 | 71.05 | - | MobileNetV5 + MSFA; 273 prompt, 49 gen |
+| gemma3n (E4B bf16) | gemma-3n-E4B-it (bf16) | ✅ | 582.41 | 31.57 | - | MobileNetV5 + MSFA; bf16; 273 prompt, 24 gen |
+| gemma3n (E4B 4bit) | gemma-3n-E4B-it-4bit | ✅ | 367.98 | 55.82 | - | 273 prompt, 33 gen |
+| gemma4 (E2B 4bit) | gemma-4-e2b-it-4bit | ✅ | 579.44 | 104.47 | - | 274 prompt, 100 gen |
+| gemma4 (E2B 8bit) | gemma-4-e2b-it-8bit | ✅ | 480.19 | 80.92 | - | 274 prompt, 100 gen |
+| gemma4 (E4B 4bit) | gemma-4-e4b-it-4bit | ✅ | 393.36 | 74.13 | - | 274 prompt, 54 gen |
+| gemma4 (E4B 8bit) | gemma-4-e4b-it-8bit | ✅ | 343.13 | 54.78 | - | 274 prompt, 35 gen |
+| gemma4 (31B 4bit) | gemma-4-31b-4bit | ✅ | 75.67 | 15.54 | - | 274 prompt, 100 gen |
+| gemma4 (31B-it 4bit) | gemma-4-31b-it-4bit | ✅ | 78.04 | 18.57 | - | 274 prompt, 100 gen |
+| gemma4 (26B A4B) | gemma-4-26b-a4b-it-4bit | ✅ | 262.22 | 65.65 | - | 277 prompt, 28 gen |
+| llava 1.5 | llava-1.5-7b-4bit | ✅ | 675.20 | 103.82 | - | CLIP + MLP; Vicuna-7b; 583 prompt, 100 gen; mlx-vlm requires PyTorch |
+| llava-interleave | llava-interleave-qwen-0.5b-bf16 | ✅ | 3334.88 | 263.41 | **122%** | mlx-vlm: 215.71; SigLIP + MLP; Qwen2-0.5b; 754 prompt, 36 gen |
+| llava-next | llava-v1.6-mistral-7b-4bit | ✅ | 642.25 | 106.65 | - | CLIP + MLP; Mistral; 590 prompt, 100 gen; mlx-vlm template error |
+| llava-bunny | Bunny-Llama-3-8B-V-4bit | ✅ | 619.07 | 95.70 | **150%** | mlx-vlm: 63.66; SigLIP + MLP; Llama3; 746 prompt, 37 gen |
+| llama4 | Llama-4-Scout-17B-16E-Instruct-4bit | ✅ | 13.86 | 35.66 | - | 162 prompt, 100 gen |
+| aya-vision | aya-vision-8b | ✅ | 349.35 | 111.11 | **126%** | mlx-vlm: 87.87; SigLIP + SwiGLU; Cohere2; 176 prompt, 100 gen |
+| paligemma | paligemma2-3b (6-bit) | ⚠️ | 1195.96 | 38.37 | - | SigLIP + Linear; Gemma2; 1032 prompt, only 2 gen tokens |
+| pixtral | pixtral-12b-4bit | ✅ | 442.19 | 60.29 | **106%** | mlx-vlm: 57.15; Pixtral ViT; Mistral; 4102 prompt, 100 gen |
+| mistral3 | mistral-small-3.1-24b-4bit | ✅ | 127.52 | 29.78 | - | Pixtral ViT + PatchMerger; Mistral; 3032 prompt, 100 gen; mlx-vlm error |
+| ministral3 | Ministral-3B-Instruct-4bit | ✅ | 524.83 | 124.42 | - | Pixtral ViT; 3566 prompt, 100 gen |
+| phi3.5-vision | Phi-3.5-vision-instruct-4bit | ✅ | 793.61 | 92.64 | 89% | mlx-vlm: 103.52; CLIP + HD tiling; Phi3; 773 prompt, 19 gen |
+| phi4mm | phi-4-multimodal-instruct (bf16) | ✅ | 571.90 | 25.42 | - | SigLIP + HD transform + AvgPool2d; Phi3; SuScaledRoPE + runtime LoRA; 2635 tokens; 12GB bf16 |
+| moondream3 | moondream3-preview-4bit | ⚠️ | 1.36 | 10.05 | - | SigLIP + MLP; image output garbled; only 63 tokens |
+| minicpm-o | MiniCPM-o-2_6-4bit | ✅ | 33.67 | 70.80 | - | SigLIP + Resampler; Qwen3; 80 tokens |
+| molmo | Molmo-7B | ❌ | - | FAIL | - | warmup failure; unsupported architecture (only molmo2 supported) |
+| molmo2 | molmo2-4b | ✅ | 576.46 | 59.54 | **102%** | mlx-vlm: 58.65; fast SDPA vision encoder; 430 prompt, 100 gen |
+| internvl3 | InternVL3-1B | ❌ | - | FAIL | - | warmup failure; unsupported architecture |
+| nemotron-omni | Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | ✅ | 134.62 | 68.89 | - | Mamba2+Transformer+MoE+Parakeet audio; 100 gen |
+| youtu-vl | youtu-vl-4b-instruct | ⚠️ | 343.06 | 20.70 | - | only 1 gen token |
+| qwen2-vl | Qwen2-VL-2B-Instruct-4bit | ⚠️ | 122.33 | 0.00 | - | Custom ViT + MRoPE; text-only pass; VLM warmup failure |
+| qwen2.5-vl | Qwen2.5-VL-3B-Instruct-4bit | ✅ | 306.99 | 97.66 | - | Windowed ViT + MRoPE; 91 prompt, 46 gen; mlx-vlm requires PyTorch |
+| qwen3-vl | Qwen3-VL-2B-Instruct-4bit | ✅ | 128.47 | 167.93 | - | DeepStack + vectorized MRoPE; 100 gen |
+| qwen3-vl (4B) | Qwen3-VL-4B-Instruct-4bit | ✅ | 92.27 | 94.79 | - | DeepStack + vectorized MRoPE; 100 gen |
+| qwen3-vl (8B) | Qwen3-VL-8B-Instruct-4bit | ✅ | 60.24 | 66.35 | - | DeepStack + vectorized MRoPE; 100 gen |
+| qwen3-vl (32B) | Qwen3-VL-32B-Instruct-4bit | ✅ | 20.99 | 18.47 | - | DeepStack + vectorized MRoPE; 100 gen |
+| qwen3-vl-moe | Qwen3-VL-30B-A3B-Instruct-4bit | ✅ | 20.40 | 22.41 | - | MoE (128 experts) + DeepStack; 100 gen |
+| qwen3.5-vl (0.8B) | qwen3.5-0.8B-4bit | ✅ | 145.40 | 212.96 | - | Hybrid GatedDeltaNet VLM; 57 prompt, 53 gen |
+| qwen3.5-vl (2B) | qwen3.5-2B-4bit | ✅ | 118.75 | 178.66 | - | Hybrid GatedDeltaNet VLM; 57 prompt, 58 gen |
+| qwen3.5-vl (4B) | qwen3.5-4B-4bit | ✅ | 80.81 | 101.63 | - | Hybrid GatedDeltaNet VLM; 57 prompt, 30 gen |
+| qwen3.5-vl (9B 4bit) | qwen3.5-9B-4bit | ✅ | 31.13 | 73.21 | - | Hybrid GatedDeltaNet VLM; 57 prompt, 62 gen |
+| qwen3.5-vl (9B bf16) | qwen3.5-9B (bf16) | ✅ | 105.93 | 31.76 | - | Hybrid GatedDeltaNet VLM; 57 prompt, 78 gen; bf16 |
+| qwen3.5-vl (27B) | qwen3.5-27B-4bit | ✅ | 26.50 | 24.96 | - | Hybrid GatedDeltaNet VLM; 57 prompt, 42 gen |
+| qwen3.5-vl-moe | qwen3.5-35B-A3B-4bit | ✅ | 20.21 | 68.55 | - | Hybrid GatedDeltaNet + MoE VLM; 57 prompt, 47 gen |
+| qwen3.6-vl-moe | qwen3.6-35B-A3B-4bit | ✅ | 20.94 | 68.62 | - | Hybrid GatedDeltaNet + MoE VLM; 100 gen |
+| molmo-point | - | ⏳ | - | - | - | Molmo-Point (point detection); implemented but no MLX model available |
+
+**VLM test conditions**: Image: 224x224 PNG (test_image.png) unless noted. Prompt: "What is in this image?" Max tokens: 100. Prefill includes vision encoder + projector overhead. mlx-vlm v0.4.1. Decode speed measured separately from prefill using `--profile` mode. Many models require PyTorch for mlx-vlm's HuggingFace processor: marked with "-" in vs mlx-vlm column. Three text-only models (`deepseek-v3-4bit` 99GB, `minimax-m2-3bit` 93GB, `qwen3-next-480b-4bit` 251GB) skipped on this 128GB host per >65GB threshold.
+
+## Summary Statistics
+
+| Status | Count |
+|--------|-------|
+| ✅ Pass | 115 (82 text + 33 VLM) |
+| ⚠️ Partial | 6 (2 text + 4 VLM) |
+| ❌ Fail | 8 (6 text + 2 VLM) |
+| ⏳ Pending / Skipped (>65GB) | 16 (13 text pending + 3 oversize skip) |
+
+## Performance Comparison
+
+### Outperforming mlx-lm (>100%)
+
+| Model | mlxcel | mlx-lm | vs mlx-lm |
+|-------|--------|--------|-----------|
+| hunyuan_v1_dense | 176.58 | 14.54 | **1214%** |
+| deepseek_v2 | 94.74 | 23.55 | **402%** |
+| qwen3_5_moe | 70.21 | 39.95 | **176%** |
+| gemma3 (1B) | 196.54 | 112.37 | **175%** |
+| qwen2 | 329.45 | 225.37 | **146%** |
+| cohere | 111.42 | 78.67 | **142%** |
+| stablelm | 270.47 | 206.29 | **131%** |
+| cohere2 | 107.92 | 83.08 | **130%** |
+| minicpm | 162.79 | 124.90 | **130%** |
+| gpt_oss (20B) | 92.08 | 71.06 | **130%** |
+| smollm3 (3B) | 136.43 | 105.56 | **129%** |
+| qwen2_moe | 142.23 | 111.82 | **127%** |
+| gpt_oss (120B) | 59.62 | 47.12 | **127%** |
+| exaone | 190.43 | 150.80 | **126%** |
+| deepseek_r1 | 110.52 | 87.53 | **126%** |
+| qwen2 (7B 4bit) | 111.29 | 89.23 | **125%** |
+| minicpm3 | 79.08 | 63.04 | **125%** |
+| qwen3_moe | 70.56 | 56.91 | **124%** |
+| phimoe | 76.13 | 61.16 | **124%** |
+| llama3 (1B) | 332.54 | 269.91 | **123%** |
+| llama3.1 | 108.45 | 89.06 | **122%** |
+| mimo | 85.14 | 70.49 | **121%** |
+| internlm2 | 109.04 | 90.69 | **120%** |
+| solar_open | 36.20 | 30.26 | **120%** |
+| nemotron_h | 89.96 | 75.78 | **119%** |
+| starcoder2 | 167.20 | 140.89 | **119%** |
+| smollm3 | 352.11 | 297.15 | **118%** |
+| llama3 (8B bf16) | 35.43 | 29.94 | **118%** |
+| nemotron_nas | 89.10 | 76.81 | **117%** |
+| phi4 | 58.03 | 49.92 | **116%** |
+| olmo3 | 21.95 | 18.92 | **116%** |
+| baichuan | 46.86 | 40.95 | **114%** |
+| mixtral | 53.49 | 47.12 | **114%** |
+| olmo2 | 103.37 | 91.21 | **113%** |
+| qwen3_5 (27B) | 24.11 | 21.76 | **111%** |
+| llama4 | 36.36 | 33.68 | **108%** |
+
+### Near parity (90-100%)
+
+| Model | mlxcel | mlx-lm | vs mlx-lm |
+|-------|--------|--------|-----------|
+| phi3 | 143.69 | 144.17 | 100% |
+| jamba | 92.02 | 100.13 | 92% |
+| qwen3 (0.6B) | 198.08 | 217.22 | 91% |
+| ministral3 | 140.72 | 154.36 | 91% |
+
+### Needs optimization (<90%)
+
+| Model | mlxcel | mlx-lm | vs mlx-lm | Notes |
+|-------|--------|--------|-----------|-------|
+| phi3.5-vision (VLM) | 92.64 | 103.52 | 89% | Only 19 gen tokens |
+| gemma2 | 135.27 | 157.00 | 86% | Only 18 tokens |
+| phi3small | 116.86 | 141.80 | 82% | Only 40 tokens |
+| glm4_moe_lite | 31.54 | 41.55 | 76% | Only 18 tokens |
+
+### No mlx-lm comparison available
+
+| Model | mlxcel | Reason |
+|-------|--------|--------|
+| ernie4_5 | 413.23 | mlx-lm: fails to load |
+| qwen3_5 (0.8B) | 205.52 | Not benchmarked in mlx-lm |
+| exaone4 | 213.60 | mlx-lm: fails to load; only 18 tokens |
+| olmo | 209.70 | mlx-lm: requires ai2-olmo |
+| qwen3 (1.7B) | 193.24 | Not benchmarked in mlx-lm |
+| gemma (2B) | 192.52 | only 49 tokens |
+| deepseek | 162.80 | mlx-lm: fails to load |
+| qwen3_5 (2B) | 175.73 | Not benchmarked in mlx-lm |
+| qwen3 (4B) | 118.85 | Not benchmarked in mlx-lm |
+| mamba2 | 107.35 | mlx-lm: ModelArgs error |
+| gemma3 (4B) | 103.61 | Not benchmarked in mlx-lm |
+| qwen3_5 (4B) | 101.21 | Not benchmarked in mlx-lm |
+| internlm3 | 86.13 | mlx-lm: fails to load |
+| qwen3 (8B) | 80.64 | Not benchmarked in mlx-lm |
+| qwen2 (7B 8bit) | 69.61 | 8-bit quantized; no mlx-lm comparison |
+| gemma3n (E2B) | 76.18 | only 69 tokens |
+| qwen3_5 (9B 4bit) | 72.02 | Not benchmarked in mlx-lm |
+| gemma4 (E2B 4bit) | 118.94 | only 34 tokens |
+| gemma4 (E2B 8bit) | 87.56 | only 38 tokens |
+| gemma4 (E4B 4bit) | 82.77 | only 25 tokens |
+| gemma3n (E4B) | 58.96 | only 74 tokens |
+| gemma4 (E4B 8bit) | 59.06 | only 39 tokens |
+| phi | 52.59 | mlx-lm: fails to load; only 1 token (EOS) |
+| gemma4 (26B A4B) | 70.27 | only 26 tokens |
+| hunyuan_moe | 44.51 | mlx-lm: fails to load |
+| glm4 | 45.37 | Only 18 tokens |
+| mamba | 30.78 | mlx-lm: fails to load; only 2 tokens (chat template EOS) |
+| qwen3_5 (9B bf16) | 31.11 | bf16, not quantized |
+| gemma4 (31B) | 20.31 | no mlx-lm comparison |
+| gemma4 (31B-it) | 19.39 | no mlx-lm comparison |
+| gemma3n (E4B bf16) | 34.36 | bf16; only 72 tokens |
+| nemotron_h_nano_omni | 80.67 | Mamba2+Transformer+MoE+Parakeet audio |
+| solar_open (int4) | 11.55 | mlx-lm: fails to load; int4 quantization; 54GB |
+| moondream3 | 8.45 | mlx-lm: fails to load; text-only test; only 14 tokens |
+| mistral4 | - | No MLX model available; implemented |
+| molmo-point | - | No MLX model available; implemented |
+
+### VLM Performance Comparison (vs mlx-vlm, decode-only)
+
+| Model | mlxcel | mlx-vlm | vs mlx-vlm | Notes |
+|-------|--------|---------|------------|-------|
+| llava-bunny | 95.70 | 63.66 | **150%** | |
+| aya-vision | 111.11 | 87.87 | **126%** | |
+| llava-interleave | 263.41 | 215.71 | **122%** | |
+| pixtral | 60.29 | 57.15 | **106%** | |
+| molmo2 | 59.54 | 58.65 | **102%** | fast SDPA vision encoder |
+| phi3.5-vision | 92.64 | 103.52 | 89% | Only 19 gen tokens |
+
+### Overall
+
+- **Text models with comparison (40):** all of `Outperforming mlx-lm`, `Near parity`, and `Needs optimization` tables combined
+- **Beating mlx-lm (>100%):** 36/40 (90%)
+- **At 90%+ parity:** 40/40 (100%) of the comparable set
+- **VLM models with comparison (6):** 5/6 at or above parity (83%)
+- **No comparison available:** 40+ (mlx-lm / mlx-vlm fails to load or no benchmark)
+
+## Performance vs mlx-lm / mlx-vlm baseline (2026-05-19, same-day sweep)
+
+Source CSVs (same M1 Ultra host, mlxcel 0.0.28 with `--cooldown 0`; mlx-lm/mlx-vlm baselines from same 2026-05-19 sweep with `PYLM_BENCH_MAX_GB=65`):
+
+- mlxcel: `benchmarks/metal_m1ultra_2026-05-19.csv`
+- mlx-lm: `benchmarks/pylm_m1ultra_2026-05-19.csv` (mlx-lm 0.31.3 dev checkout in `references/mlx-lm` @ `df1d3f3`)
+- mlxcel VLM: `benchmarks/metal_m1ultra_vlm_2026-05-19.csv`
+- mlx-vlm: `benchmarks/pylm_m1ultra_vlm_2026-05-19.csv` (mlx-vlm dev checkout in `references/mlx-vlm` @ `d85ca4d`)
+
+Both sides were re-run on 2026-05-19 (unlike the M5 Max page, which reused 5-18 baselines). All 4 sweeps use the same `--max-tokens 100`, same `Hello, how are you today?` / `What is in this image?` prompts, and the same >65GB skip threshold (deepseek-v3-4bit, minimax-m2-3bit, qwen3-next-480b-4bit excluded from both sides).
+
+Numbers are decode tok/s. `mlxcel vs mlx-lm` is `mlxcel / mlx-lm` as a percentage; **bold** = mlxcel >= mlx-lm. `FAIL` cells are real load/runtime errors on that backend with this configuration. The mlx-lm checkout used here (`df1d3f3`) differs from the M5 Max page's `ed1fca4`, so some FAIL categories differ.
+
+### Aggregate (text)
+
+- **Comparable text pairs**: 74
+- **mlxcel >= mlx-lm**: 14 / 74 (19%)
+- **mlxcel >= 90% parity**: 56 / 74 (76%)
+- **Average mlxcel/mlx-lm**: 93% (median 96%, range 34%-110%)
+
+### Aggregate (VLM, models with >=5 generated tokens both sides)
+
+- **Comparable VLM pairs**: 17
+- **mlxcel >= mlx-vlm**: 8 / 17 (47%)
+- **mlxcel >= 90% parity**: 11 / 17 (65%)
+- **Average mlxcel/mlx-vlm**: 98% (median 98%, range 77%-119%)
+
+### Text decode (tok/s)
+
+| Model | mlxcel | mlx-lm | mlxcel vs mlx-lm |
+|-------|--------|--------|------------------|
+| GLM-5-4bit | FAIL | FAIL | - |
+| Meta-Llama-3.1-8B-Instruct-4bit | 107.55 | 109.84 | 98% |
+| Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | 80.67 | FAIL | - |
+| Qwen2.5-1.5B-4bit | 236.02 | 241.41 | 98% |
+| Qwen2.5-1.5B-Instruct-4bit | 238.66 | 239.20 | 100% |
+| Qwen2.5-7B-Instruct-4bit | 111.29 | 110.90 | **100%** |
+| Qwen3.5-0.8B-OptiQ-4bit | FAIL | 265.86 | - |
+| Qwen3.5-27B-DFlash | FAIL | FAIL | - |
+| Qwen3.5-4B-DFlash | FAIL | FAIL | - |
+| aya-expanse-8b-4bit | 107.92 | 112.74 | 96% |
+| aya-vision-8b | 110.88 | FAIL | - |
+| baichuan-m1-14b-4bit | 46.86 | 49.11 | 95% |
+| bunny-llama3-8b-4bit | 101.44 | FAIL | - |
+| command-r7b-4bit | 111.42 | 107.75 | **103%** |
+| deepseek-coder-1.3b-4bit | 162.80 | FAIL | - |
+| deepseek-r1-distill-7b-4bit | 110.52 | 111.34 | 99% |
+| deepseek-v2-lite-4bit | 94.74 | 117.06 | 81% |
+| deepseek-v3-4bit | FAIL | FAIL | - |
+| ernie-4.5-0.3b-4bit | 413.23 | FAIL | - |
+| exaone-3.5-2.4b-4bit | 190.43 | 194.65 | 98% |
+| exaone4-1.2b-4bit | 213.60 | FAIL | - |
+| falcon-mamba-7b-4bit | 30.78 | 91.04 | 34% |
+| gemma-2b-4bit | 192.52 | 207.78 | 93% |
+| gemma-3-4b-it-4bit | 103.12 | 109.72 | 94% |
+| gemma-4-26b-a4b-it-4bit | 70.27 | 72.52 | 97% |
+| gemma-4-31B-it-assistant-bf16 | FAIL | FAIL | - |
+| gemma-4-31b-4bit | 20.31 | 20.36 | 100% |
+| gemma-4-31b-it-4bit | 19.39 | 20.23 | 96% |
+| gemma-4-e2b-it-4bit | 118.94 | FAIL | - |
+| gemma-4-e2b-it-8bit | 87.56 | FAIL | - |
+| gemma-4-e4b-it-4bit | 82.77 | FAIL | - |
+| gemma-4-e4b-it-8bit | 59.06 | FAIL | - |
+| gemma2-2b-4bit | 135.27 | 153.50 | 88% |
+| gemma3-1b-4bit | 196.54 | 211.50 | 93% |
+| gemma3-4b-4bit | 103.61 | 109.48 | 95% |
+| gemma3n-e2b-4bit | 76.18 | FAIL | - |
+| gemma3n-e4b-4bit | 58.96 | FAIL | - |
+| gemma3n-e4b-bf16 | 34.36 | 39.02 | 88% |
+| glm4-flash-4bit | 45.37 | 49.47 | 92% |
+| gpt-oss-120b-4bit | 59.62 | 57.58 | **104%** |
+| gpt-oss-20b-mxfp4 | 92.08 | 89.51 | **103%** |
+| hunyuan-1.8b-4bit | 176.58 | 200.59 | 88% |
+| hunyuan-large-4bit | 44.51 | FAIL | - |
+| hunyuan-moe-a13b-bf16 | FAIL | FAIL | - |
+| internlm2-7b-4bit | 109.04 | 111.92 | 97% |
+| internlm3-8b-4bit | 86.13 | FAIL | - |
+| internvl3-1b | FAIL | FAIL | - |
+| jamba-v0.1-4bit | 92.02 | 131.04 | 70% |
+| llama-3.1-8b-4bit | 108.45 | 110.66 | 98% |
+| llama-3.1-8b-bf16 | 35.43 | 35.32 | **100%** |
+| llama-3.2-1b-4bit | 332.54 | 418.25 | 80% |
+| llama-4-scout-17b-4bit | 36.36 | FAIL | - |
+| llava-1.5-7b-4bit | 115.81 | FAIL | - |
+| llava-interleave-qwen-0.5b-bf16 | 304.49 | FAIL | - |
+| llava-next-mistral-7b-4bit | 112.56 | FAIL | - |
+| mamba2-1.3b-4bit | 107.35 | FAIL | - |
+| mimo-7b-4bit | 85.14 | 86.17 | 99% |
+| minicpm-2b-4bit | 162.79 | 156.47 | **104%** |
+| minicpm3-4b-4bit | 79.08 | 73.26 | **108%** |
+| minimax-m2-3bit | FAIL | FAIL | - |
+| ministral-3b-4bit | 140.72 | 159.34 | 88% |
+| mistral-small-3.1-24b-4bit | 31.82 | 31.97 | 100% |
+| mixtral-8x7b-4bit | 53.49 | 54.91 | 97% |
+| molmo-7b | FAIL | FAIL | - |
+| molmo2-4b | 59.66 | FAIL | - |
+| nemotron-h-30b-4bit | 89.96 | 93.34 | 96% |
+| nemotron-nas-30b-4bit | 89.10 | 92.93 | 96% |
+| olmo-1b-4bit | 209.70 | FAIL | - |
+| olmo2-7b-4bit | 103.37 | 110.88 | 93% |
+| olmo3-32b-4bit | 21.95 | 21.57 | **102%** |
+| paligemma2-3b-6bit | 0.00 | FAIL | - |
+| phi-2-4bit | 52.59 | FAIL | - |
+| phi-3-mini-4bit | 143.69 | 171.36 | 84% |
+| phi-3.5-mini-4bit | 116.86 | 166.30 | 70% |
+| phi-3.5-moe-4bit | 76.13 | 69.28 | **110%** |
+| phi-3.5-vision-4bit | 117.59 | FAIL | - |
+| phi-4-4bit | 58.03 | 58.68 | 99% |
+| pixtral-12b-4bit | 69.10 | 69.49 | 99% |
+| qwen1.5-moe-a2.7b-4bit | 142.23 | 144.98 | 98% |
+| qwen2-vl-2b-4bit | 143.25 | 236.86 | 60% |
+| qwen2.5-0.5b-4bit | 329.45 | 315.48 | **104%** |
+| qwen2.5-0.5b-bf16 | FAIL | FAIL | - |
+| qwen2.5-7b-4bit | 111.18 | 111.38 | 100% |
+| qwen2.5-7b-8bit | 69.61 | 70.46 | 99% |
+| qwen2.5-vl-3b-4bit | 98.81 | 160.42 | 62% |
+| qwen3-0.6b-4bit | 198.08 | 299.61 | 66% |
+| qwen3-1.7b-4bit | 193.24 | 221.37 | 87% |
+| qwen3-30b-a3b-4bit | 70.56 | 70.18 | **101%** |
+| qwen3-4b-4bit | 118.85 | 123.92 | 96% |
+| qwen3-8b-4bit | 80.64 | 84.54 | 95% |
+| qwen3-moe-4bit | 70.34 | 69.67 | **101%** |
+| qwen3-next-480b-4bit | FAIL | FAIL | - |
+| qwen3-vl-2b-4bit | 211.50 | 222.67 | 95% |
+| qwen3-vl-30b-a3b-4bit | 67.65 | 70.04 | 97% |
+| qwen3-vl-32b-4bit | 21.07 | 21.99 | 96% |
+| qwen3-vl-4b-4bit | 117.49 | 124.02 | 95% |
+| qwen3-vl-8b-4bit | 81.16 | 84.46 | 96% |
+| qwen3.5-0.8b-4bit | 205.52 | 269.52 | 76% |
+| qwen3.5-27b-4bit | 24.11 | 25.93 | 93% |
+| qwen3.5-2b-4bit | 175.73 | 211.68 | 83% |
+| qwen3.5-35b-a3b-4bit | 70.21 | 76.44 | 92% |
+| qwen3.5-4b-4bit | 101.21 | 115.60 | 88% |
+| qwen3.5-9b-4bit | 72.02 | 81.27 | 89% |
+| qwen3.5-9b-bf16 | 31.11 | 34.22 | 91% |
+| qwen3.6-35b-a3b-4bit | 67.07 | 73.18 | 92% |
+| smollm-135m-4bit | 352.11 | 375.91 | 94% |
+| smollm3-3b-4bit | 136.43 | 141.66 | 96% |
+| solar-open-100b-4bit | 36.20 | 35.69 | **101%** |
+| stablelm-1.6b-4bit | 270.47 | 280.65 | 96% |
+| starcoder2-3b-4bit | 167.20 | 166.17 | **101%** |
+| youtu-vl-4b-instruct | 0.00 | FAIL | - |
+
+### VLM decode (tok/s)
+
+| Model | mlxcel | mlx-vlm | mlxcel vs mlx-vlm |
+|-------|--------|--------|------------------|
+| Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | 68.89 | FAIL | - |
+| aya-vision-8b | 111.11 | 103.74 | **107%** |
+| bunny-llama3-8b-4bit | 95.70 | FAIL | - |
+| gemma-3-4b-it-4bit | 77.84 | 97.36 | 80% |
+| gemma-4-26b-a4b-it-4bit | 65.65 | 61.07 | **107%** |
+| gemma-4-31b-4bit | 15.54 | 20.30 | 77% |
+| gemma-4-31b-it-4bit | 18.57 | 19.78 | 94% |
+| gemma-4-e2b-it-4bit | 104.47 | 97.19 | **107%** |
+| gemma-4-e2b-it-8bit | 80.92 | 91.06 | 89% |
+| gemma-4-e4b-it-4bit | 74.13 | 70.34 | **105%** |
+| gemma-4-e4b-it-8bit | 54.78 | 63.25 | 87% |
+| gemma3-4b-4bit | 80.13 | 93.79 | 85% |
+| gemma3n-e2b-4bit | 71.05 | 59.57 | **119%** |
+| gemma3n-e4b-4bit | 55.82 | 50.00 | **112%** |
+| gemma3n-e4b-bf16 | 31.57 | 36.18 | 87% |
+| internvl3-1b | FAIL | 264.40 | - |
+| llama-4-scout-17b-4bit | 35.66 | FAIL | - |
+| llava-1.5-7b-4bit | 103.82 | FAIL | - |
+| llava-interleave-qwen-0.5b-bf16 | 263.41 | 225.15 | **117%** |
+| llava-next-mistral-7b-4bit | 106.65 | 109.51 | 97% |
+| ministral-3b-4bit | 124.42 | FAIL | - |
+| mistral-small-3.1-24b-4bit | 29.78 | FAIL | - |
+| molmo-7b | FAIL | 38399.52 (anomalous) | - |
+| molmo2-4b | 59.54 | 60.87 | 98% |
+| paligemma2-3b-6bit | 38.37 | 70.45 | 54% |
+| phi-3.5-vision-4bit | 92.64 | 92.53 | **100%** |
+| pixtral-12b-4bit | 60.29 | FAIL | - |
+| qwen2-vl-2b-4bit | 0.00 | FAIL | - |
+| qwen2.5-vl-3b-4bit | 97.66 | FAIL | - |
+| qwen3-vl-2b-4bit | 167.93 | FAIL | - |
+| qwen3-vl-30b-a3b-4bit | 22.41 | FAIL | - |
+| qwen3-vl-32b-4bit | 18.47 | FAIL | - |
+| qwen3-vl-4b-4bit | 94.79 | FAIL | - |
+| qwen3-vl-8b-4bit | 66.35 | FAIL | - |
+| qwen3.5-0.8b-4bit | 212.96 | FAIL | - |
+| qwen3.5-27b-4bit | 24.96 | FAIL | - |
+| qwen3.5-2b-4bit | 178.66 | FAIL | - |
+| qwen3.5-35b-a3b-4bit | 68.55 | FAIL | - |
+| qwen3.5-4b-4bit | 101.63 | FAIL | - |
+| qwen3.5-9b-4bit | 73.21 | FAIL | - |
+| qwen3.5-9b-bf16 | 31.76 | FAIL | - |
+| qwen3.6-35b-a3b-4bit | 68.62 | FAIL | - |
+| youtu-vl-4b-instruct | 20.70 | FAIL | - |
+
+### mlx-lm / mlx-vlm fail categories (text + VLM)
+
+mlx-lm side text FAILs are mostly the same architecture support gaps as on M5 Max: VLM-only loaders routed through the text path (`aya-vision-8b`, `bunny-llama3-8b-4bit`, `llava-*`, `paligemma2-3b-6bit`, `phi-3.5-vision-4bit`, `gemma-4-e{2,4}b-it-{4,8}bit`, `gemma3n-e{2,4}b-4bit`), `transformers` config schema drift (`exaone4-1.2b-4bit`), custom remote code refused (`hunyuan-*`, `deepseek-coder-1.3b-4bit`, `ernie-4.5-0.3b-4bit`), unsupported architectures (`internvl3-1b`, `molmo-7b`, `internlm3-8b-4bit`, `nemotron-*`-omni and 4 drafter checkpoints), `ModelArgs` mismatch (`mamba2-1.3b-4bit`, `phi-2-4bit`, `gemma-4-31B-it-assistant-bf16`), and 4 oversize SKIPs (deepseek-v3-4bit, minimax-m2-3bit, qwen3-next-480b-4bit applied symmetrically). These are backend-specific compatibility outcomes for the `df1d3f3` checkout and should not be counted as silent mlxcel performance wins.
+
+mlx-vlm side VLM FAILs: most text models trivially fail when routed through `mlx-vlm` (no image processor for text-only checkpoints), so the VLM table effectively compares only the ~20 actual VLM models. Two genuine VLM cells where mlx-vlm works but mlxcel does not (`internvl3-1b`, `molmo-7b`) are architectures mlxcel does not yet implement — the molmo-7b 38k tok/s reading is a metric artifact (1 generated token) and should not be read as real throughput.
+
+The four mlxcel rows where the gap is widest on text — `falcon-mamba-7b-4bit` (34%), `qwen2-vl-2b-4bit` (60%), `qwen2.5-vl-3b-4bit` (62%), `qwen3-0.6b-4bit` (66%) — are the same model classes flagged on M5 Max as having the most headroom: mamba SSM kernel, MRoPE VLM text-only fast path, and the small-Qwen3 decode hot path.
+
+## Known Issues
+
+| Model | Issue | Priority |
+|-------|-------|----------|
+| hunyuan-moe-a13b-bf16 | Warmup failure; Tiktoken tokenizer; bf16 | High |
+| qwen2.5-0.5b-bf16 | Warmup failure; bf16 non-quantized | Medium |
+| Qwen3.5-4B-DFlash / Qwen3.5-27B-DFlash | Drafter checkpoint — not a standalone inference model | Low |
+| Qwen3.5-0.8B-OptiQ-4bit | Warmup failure on new OptiQ quant variant | Medium |
+| gemma-4-31B-it-assistant-bf16 | Drafter checkpoint — not a standalone inference model | Low |
+| falcon-mamba | Chat template causes early EOS (only 2 tokens); decode now 30.78 tok/s | Medium |
+| paligemma | Only 2 VLM gen tokens | High |
+| youtu-vl-4b-instruct | VLM produces only 1 token; text-only produces 0 tokens | Medium |
+| llama4 | Repetitive output on long generations | Low |
+| moondream3 | Image output garbled; text-only works; needs reconstruct_from_crops | Medium |
+| internvl3 | Warmup failure; unsupported architecture | Medium |
+| molmo-7b | Warmup failure; unsupported architecture (only molmo2 supported) | Low |
+| qwen-vl family | Broadcast shape errors on M5 Max with 224x224 images | Medium |
+| GLM-5-4bit | Persistent warmup failure | Medium |
+
+## Notes
+
+- All tests use 4-bit quantized models unless noted (Nemotron uses 8-bit)
+- Performance measured with `--profile` flag (separate prefill/decode timing)
+- vs mlx-lm percentage is based on **decode speed only**
+- Prefill tok/s and decode tok/s are reported separately; units omitted from table headers for brevity
+- Prefill shown as "-" for models not measured in this run
+
+## Tokenizer Support
+
+| Format | File | Models | Crate |
+|--------|------|--------|-------|
+| HuggingFace | `tokenizer.json` | Most models | `tokenizers` |
+| SentencePiece | `tokenizer.model` | Gemma, Llama 1/2, older models | `sentencepiece` |
+| Tiktoken | `*.tiktoken` | HunYuan MoE (13B) | Custom BPE (fancy-regex) |
+
+## TurboQuant KV cache — M1 Ultra latest readings
+
+Latest available TurboQuant readings for the M1 Ultra benchmark page. These measurements are separate from the standard model sweep above because they exercise KV-cache storage modes rather than model architecture coverage.
+
+| Item | Value |
+|------|-------|
+| Hardware | Apple M1 Ultra, 128 GB unified memory |
+| Model | `Meta-Llama-3.1-8B-Instruct-4bit` |
+| CSV | `benchmarks/turbo_kv/2026-04-29_Apple_M1_Ultra_Meta-Llama-3.1-8B-Instruct-4bit.csv` |
+
+CSV rows where `stage=prefill` include a single-token follow-up only to populate the KV cache. Use `prefill_tok_s` for those rows and ignore their sub-millisecond `decode_tok_s` values.
+
+### Decode @ 4K context
+
+| Mode | Decode tok/s | x FP16 | Gate context |
+|------|-------------:|-------:|--------------|
+| `fp16` | 90.36 | 1.000x | baseline |
+| `int8` | 61.24 | 0.678x | tracking only |
+| `turbo4-asym` | 3.92 | 0.043x | below M5 Max gate |
+| `turbo4` | 16.34 | 0.181x | below M5 Max gate |
+| `turbo4-delegated` | 18.22 | 0.202x | below M5 Max gate |
+
+`turbo4-asym` produced 51 tokens before early EOS; the other Turbo modes ran the full 80-token decode budget.
+
+### Prefill @ 8K context
+
+| Mode | Prefill tok/s | x FP16 | Gate context |
+|------|--------------:|-------:|--------------|
+| `fp16` | 678.28 | 1.000x | baseline |
+| `int8` | 676.82 | 0.998x | tracking only |
+| `turbo4-asym` | 471.12 | 0.694x | below M5 Max gate |
+| `turbo4` | 365.07 | 0.538x | below M5 Max gate |
+| `turbo4-delegated` | 678.96 | 1.001x | meets best-effort target |
+
+### M1 Ultra reading
+
+- `turbo4-delegated` is the practical Turbo mode on this M1 Ultra reading when prefill latency matters.
+- Turbo decode modes are far below FP16 decode throughput on this hardware generation.
+- `int8` has near-FP16 prefill and lower decode throughput, with a half-sized KV cache.
+- Use compressed Turbo modes on M1 Ultra only when the memory savings outweigh the decode cost for the workload.

--- a/docs/benchmark_results/model_tests_m5max.md
+++ b/docs/benchmark_results/model_tests_m5max.md
@@ -1,0 +1,519 @@
+# Model Compatibility & Performance Tests (M5 Max)
+
+Compatibility and performance testing for mlxcel models on **MacBook Pro M5 Max 128GB**, with same-host mlx-lm / mlx-vlm reference measurements and current cross-hardware ratios where available.
+
+## Test Environment
+
+| Item | Value |
+|------|-------|
+| **Hardware** | MacBook Pro M5 Max, 128GB RAM |
+| **OS** | macOS 26.4 (Tahoe) |
+| **mlxcel version** | 0.0.28 |
+| **MLX version** | 0.31.2 (via mlxcel-core; pinned commit `84961223`) |
+| **mlx-lm baseline** | 0.31.3 (dev checkout `references/mlx-lm`, commit `ed1fca4`) |
+| **mlx-vlm baseline** | 0.4.4 |
+| **Test Prompt** | "Hello, how are you today?" (text) / "What is in this image?" (VLM) |
+| **Max Tokens** | 100 |
+| **Test Date** | 2026-05-19 full sweep |
+| **Benchmark Status** | Full text + VLM sweep on mlxcel (98 text + VLM passes) with `--cooldown 15 --big-cooldown 15`; mlx-lm / mlx-vlm baseline sub-sweeps collected in the same 2026-05-19 benchmark campaign, with CSV date fields crossing midnight |
+
+## Legend
+
+- ✅ Pass: Model works correctly
+- ⚠️ Partial: Loads but output quality problems or low token count
+- ❌ Fail: Does not work
+
+## Basic Transformers
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| llama3 | Llama-3.2-1B-Instruct-4bit | ✅ | 2537.22 | 539.67 | **1.49x** | 31 tokens |
+| llama3.1 | Llama-3.1-8B-Instruct-4bit | ✅ | 791.11 | 116.85 | 1.07x | 100 tokens |
+| llama3 (8B bf16) | Llama-3.1-8B-Instruct (bf16) | ⚠️ | 216.42 | 33.14 | 0.93x | 87 tokens; bf16; slow decode |
+| llama4 | Llama-4-Scout-17B-16E-4bit | ✅ | 33.22 | 49.08 | **1.34x** | 100 tokens |
+| command-r7b | c4ai-command-r7b-4bit | ✅ | 54.23 | 114.02 | 1.03x | 100 tokens |
+| aya-expanse-8b | aya-expanse-8b-4bit | ✅ | 61.67 | 113.47 | 1.05x | 100 tokens |
+| aya-vision-8b | aya-vision-8b (text-only) | ✅ | 62.64 | 112.55 | 1.05x | 87 tokens; text-only |
+| deepseek-r1 | DeepSeek-R1-Distill-Qwen-7B-4bit | ✅ | 97.01 | 126.33 | **1.13x** | 100 tokens |
+| internlm2 | InternLM2-7B-4bit | ✅ | 132.26 | 116.61 | 1.05x | 100 tokens |
+| internlm3 | internlm3-8b-instruct-4bit | ✅ | 193.15 | 101.67 | **1.18x** | 100 tokens |
+| mimo | MiMo-7B-RL-4bit | ✅ | 212.00 | 120.09 | **1.40x** | 100 tokens |
+| minicpm | MiniCPM-2B-sft-bf16-4bit | ✅ | 186.60 | 233.32 | **1.44x** | 100 tokens |
+| bunny-llama3-8b | Bunny-Llama-3-8B-V-4bit (text) | ✅ | 142.00 | 114.79 | **1.13x** | 40 tokens; text-only |
+| llava-1.5-7b | llava-1.5-7b-4bit (text) | ✅ | 72.62 | 124.69 | 1.06x | 100 tokens; text-only |
+| llava-next | llava-v1.6-mistral-7b-4bit (text) | ✅ | 132.77 | 123.31 | 1.08x | 100 tokens; text-only |
+| llava-interleave | llava-interleave-qwen-0.5b-bf16 (text) | ✅ | 1382.24 | 398.56 | **1.26x** | 49 tokens |
+
+## Gemma Family
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| gemma | gemma-2b-it-4bit | ✅ | 185.18 | 215.48 | **2.64x** | 49 tokens |
+| gemma2 | gemma-2-2b-it-4bit | ✅ | 259.94 | 194.65 | **1.45x** | 18 tokens |
+| gemma3 | gemma-3-1b-it-4bit | ✅ | 393.21 | 381.28 | **1.94x** | 30 tokens |
+| gemma3 (4B) | gemma-3-4b-it-4bit | ✅ | 172.83 | 150.64 | **1.45x** | 79 tokens |
+| gemma3n (E2B) | gemma-3n-E2B-it-4bit | ✅ | 145.84 | 157.76 | **2.32x** | 71 tokens |
+| gemma3n (E4B) | gemma-3n-E4B-it-4bit | ✅ | 113.08 | 109.61 | **2.05x** | 71 tokens |
+| gemma3n (E4B bf16) | gemma-3n-E4B-it (bf16) | ✅ | 244.12 | 38.23 | **2.98x** | 72 tokens; Gemma3n language MLP bf16 preserved, other bf16 materialized as f16; 78% of mlx-lm decode |
+| gemma4 (26B MoE) | gemma-4-26b-a4b-it-4bit | ✅ | 363.66 | 138.24 | **1.92x** | 26 tokens |
+| gemma4 (31B) | gemma-4-31b-4bit | ✅ | 32.42 | 28.85 | **1.46x** | 100 tokens |
+| gemma4 (31B IT) | gemma-4-31b-it-4bit | ✅ | 123.44 | 27.63 | **1.43x** | 26 tokens |
+| gemma4 (31B nvfp4) | Gemma-4-31b-it-nvfp4 | ⚠️ | 82.98 | 7.18 | - | 26 tokens; nvfp4 has no fast Metal kernel |
+| gemma4 (E2B 4bit) | gemma-4-e2b-it-4bit | ✅ | 469.95 | 223.42 | **1.81x** | 28 tokens |
+| gemma4 (E2B 8bit) | gemma-4-e2b-it-8bit | ✅ | 466.79 | 136.83 | **1.57x** | 33 tokens |
+| gemma4 (E4B 4bit) | gemma-4-e4b-it-4bit | ✅ | 355.58 | 137.25 | **1.62x** | 33 tokens |
+| gemma4 (E4B 8bit) | gemma-4-e4b-it-8bit | ✅ | 346.58 | 80.59 | **1.33x** | 33 tokens |
+
+## EXAONE
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| exaone | EXAONE-3.5-2.4B-Instruct-4bit | ✅ | 640.53 | 287.68 | **1.49x** | 100 tokens |
+| exaone4 | exaone-4.0-1.2b-4bit | ✅ | 397.30 | 416.96 | **2.10x** | 10 tokens |
+
+## Qwen Family
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| qwen2.5 (0.5B) | Qwen2.5-0.5B-Instruct-4bit | ✅ | 1553.86 | 678.07 | **2.03x** | 100 tokens |
+| qwen2.5 (0.5B bf16) | Qwen2.5-0.5B-Instruct (bf16) | ✅ | 1852.06 | 402.30 | - | 100 tokens |
+| qwen2.5 (7B) | Qwen2.5-7B-Instruct-4bit | ✅ | 299.05 | 126.63 | **1.12x** | 100 tokens |
+| qwen2.5 (7B 8bit) | Qwen2.5-7B-Instruct-8bit | ✅ | 165.65 | 69.09 | 0.98x | 100 tokens |
+| qwen2.5-vl (3B) | Qwen2.5-VL-3B-Instruct-4bit | ❌ | - | FAIL | - | FAIL:warmup |
+| qwen2-vl (2B) | Qwen2-VL-2B-Instruct-4bit | ✅ | 558.13 | 271.60 | **1.89x** | 35 tokens |
+| qwen1.5-moe | Qwen1.5-MoE-A2.7B-Chat-4bit | ✅ | 74.50 | 239.93 | **1.77x** | 100 tokens |
+| qwen3 (0.6B) | Qwen3-0.6B-4bit | ✅ | 754.40 | 510.83 | **2.35x** | 9 tokens |
+| qwen3 (1.7B) | Qwen3-1.7B-4bit | ✅ | 509.32 | 362.95 | **1.84x** | 14 tokens |
+| qwen3 (4B) | Qwen3-4B-4bit | ✅ | 269.77 | 190.99 | **1.59x** | 41 tokens |
+| qwen3 (8B) | Qwen3-8B-4bit | ✅ | 146.10 | 111.86 | **1.38x** | 33 tokens |
+| qwen3-30b-a3b | Qwen3-30B-A3B-4bit | ✅ | 41.82 | 151.57 | **2.09x** | 34 tokens |
+| qwen3-moe | Qwen3-MoE-30B-4bit | ✅ | 42.77 | 151.40 | **2.11x** | 34 tokens |
+| qwen3-vl (2B) | Qwen3-VL-2B-Instruct-4bit | ✅ | 370.07 | 368.28 | **2.35x** | 58 tokens; text-only |
+| qwen3-vl (30B MoE) | Qwen3-VL-30B-A3B-Instruct-4bit | ✅ | 34.29 | 144.25 | **3.48x** | 35 tokens; text-only |
+| qwen3-vl (32B) | Qwen3-VL-32B-Instruct-4bit | ✅ | 35.45 | 27.49 | **1.59x** | 30 tokens; text-only |
+| qwen3-next (480B) | Qwen3-Next-480B-4bit | ❌ | - | FAIL | - | SKIP:oom_estimate |
+| qwen3.5 (0.8B) | Qwen3.5-0.8B-4bit | ✅ | 534.84 | 504.32 | **2.75x** | 29 tokens |
+| qwen3.5 (2B) | Qwen3.5-2B-4bit | ✅ | 385.95 | 325.94 | **2.09x** | 28 tokens |
+| qwen3.5 (4B) | Qwen3.5-4B-4bit | ✅ | 235.87 | 167.43 | **1.87x** | 31 tokens |
+| qwen3.5 (9B) | Qwen3.5-9B-4bit | ✅ | 127.47 | 101.89 | **1.56x** | 31 tokens |
+| qwen3.5 (9B bf16) | Qwen3.5-9B (bf16) | ✅ | 244.35 | 30.48 | 1.02x | 31 tokens |
+| qwen3.5 (27B) | Qwen3.5-27B-4bit | ✅ | 47.00 | 32.67 | **1.46x** | 32 tokens |
+| qwen3.5-35b-a3b | Qwen3.5-35B-A3B-4bit | ✅ | 36.32 | 145.49 | **2.33x** | 31 tokens |
+| qwen3.6-35b-a3b | Qwen3.6-35B-A3B-4bit | ✅ | 35.39 | 140.99 | **2.37x** | 27 tokens |
+
+## Phi Family
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| phi-2 | phi-2-hf-4bit-mlx | ⚠️ | 101.35 | 71.95 | **1.29x** | 1 tokens (likely EOS) |
+| phi-3-mini | Phi-3-mini-4k-instruct-4bit | ✅ | 153.75 | 205.16 | **1.42x** | 25 tokens |
+| phi-3.5-mini | Phi-3.5-mini-instruct-4bit | ✅ | 136.54 | 163.64 | **1.36x** | 40 tokens |
+| phi-3.5-moe | Phi-3.5-MoE-instruct-4bit | ✅ | 16.69 | 114.78 | **1.46x** | 100 tokens |
+| phi-3.5-vision | Phi-3.5-vision-instruct-4bit | ✅ | 196.46 | 163.69 | **1.37x** | 43 tokens; text-only |
+| phi-4 | Phi-4-4bit | ✅ | 69.26 | 63.66 | 1.07x | 100 tokens |
+
+## OLMo Family
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| olmo-1b | OLMo-1B-hf-4bit | ✅ | 135.52 | 245.18 | **1.16x** | 100 tokens |
+| olmo2-7b | OLMo2-7B-4bit | ✅ | 181.48 | 117.64 | **1.13x** | 27 tokens |
+| olmo3-32b | OLMo3.1-32B-4bit | ✅ | 138.49 | 29.02 | **1.32x** | 100 tokens |
+
+## MoE (Mixture of Experts)
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| minimax | MiniMax-M2-3bit | ✅ | 3.96 | 72.71 | **2.20x** | 100 tokens |
+| mixtral | Mixtral-8x7B-Instruct-v0.1-4bit | ✅ | 21.35 | 65.07 | **1.19x** | 73 tokens |
+| gpt_oss (20B) | gpt-oss-20b-MXFP4-Q4 | ✅ | 245.45 | 171.75 | **2.11x** | 100 tokens |
+| gpt_oss (120B) | gpt-oss-120b-4bit | ✅ | 23.71 | 113.34 | **5.75x** | 74 tokens |
+| solar-open-100b | Solar-Open-100B-4bit | ✅ | 200.85 | 65.59 | **4.74x** | 100 tokens |
+
+## DeepSeek Family
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| deepseek | deepseek-coder-1.3b-instruct-4bit | ✅ | 895.50 | 182.64 | **1.11x** | 100 tokens |
+| deepseek_v2 | DeepSeek-V2-Lite-Chat-4bit | ✅ | 61.91 | 205.65 | **2.06x** | 44 tokens |
+| deepseek_v3 | - | ❌ | - | FAIL | - | FAIL:warmup |
+
+## MLA (Multi-head Latent Attention)
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| minicpm3 | MiniCPM3-4B-4bit | ✅ | 189.71 | 133.89 | **1.68x** | 100 tokens |
+
+## Nemotron Family
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| nemotron_h | Nemotron-H-30B-4bit | ✅ | 31.22 | 171.76 | **1.91x** | 46 tokens |
+| nemotron_nas | Nemotron-NAS-30B-A3B-4bit | ✅ | 30.91 | 170.87 | **1.91x** | 46 tokens |
+
+## SSM / Mamba Models
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| mamba | Falcon-Mamba-7B-4bit | ⚠️ | 65.75 | 61.01 | **2.06x** | 2 tokens; chat template EOS |
+| mamba2 | mamba2-1.3b-4bit | ✅ | 193.29 | 181.66 | **1.74x** | 100 tokens |
+| jamba | Jamba-v0.1-4bit | ✅ | 400.29 | 182.82 | **1.91x** | 100 tokens |
+
+## Chinese / Asian Language Models
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| baichuan | Baichuan-M1-14B-Instruct-4bit | ✅ | 42.90 | 63.12 | **1.33x** | 41 tokens |
+| glm4_moe_lite | GLM-4.7-Flash-4bit | ✅ | 27.47 | 97.85 | **2.75x** | 18 tokens |
+| ernie4_5 | ERNIE-4.5-0.3B-Instruct-4bit | ✅ | 1041.17 | 1035.74 | **2.43x** | 100 tokens |
+| hunyuan_moe | Hunyuan-Large-Instruct-4bit | ✅ | 21.19 | 63.77 | **1.43x** | 36 tokens |
+| hunyuan_moe_13b | HunYuan-MoE-A13B-Instruct (bf16) | ✅ | 12.36 | 64.08 | - | 36 tokens |
+| hunyuan_v1_dense | Hunyuan-1.8B-Instruct-4bit | ✅ | 288.72 | 326.83 | **1.93x** | 42 tokens |
+
+## Other Models
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| ministral3 | Ministral-3B-Instruct-4bit | ✅ | 4535.65 | 223.09 | **1.58x** | 34 tokens; VLM wrapper |
+| mistral-small | mistral-small-3.1-24b-4bit | ✅ | 25.68 | 41.64 | **1.30x** | 100 tokens |
+| molmo2 | molmo2-4b | ✅ | 78.79 | 63.86 | 1.06x | 33 tokens |
+| molmo-7b | molmo-7b | ❌ | - | FAIL | - | FAIL:warmup |
+| internvl3 | internvl3-1b | ❌ | - | FAIL | - | FAIL:warmup |
+| smollm-135m | SmolLM-135M-Instruct-4bit | ✅ | 900.78 | 883.99 | **2.42x** | 100 tokens |
+| smollm3-3b | SmolLM3-3B-4bit | ✅ | 939.19 | 232.92 | **1.74x** | 44 tokens |
+| stablelm-1.6b | stablelm-2-1_6b-chat-4bit | ✅ | 462.00 | 424.32 | **1.64x** | 59 tokens |
+| starcoder2-3b | starcoder2-3b-4bit | ✅ | 108.25 | 216.96 | **2.06x** | 100 tokens |
+| pixtral-12b | pixtral-12b-4bit | ✅ | 38.11 | 76.56 | 1.08x | 100 tokens; text-only |
+| paligemma2-3b | paligemma2-3b (6-bit) | ✅ | 90.23 | 150.39 | - | 100 tokens; text-only |
+
+## VLM (image input) — full sweep
+
+Below table reports the per-VLM-prompt run from `bench_decode.sh all --vlm`.
+All entries use the VLM prompt 'What is in this image?' (no image attached;
+result reflects text-only response throughput on the VLM code path).
+
+| Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
+|-------|------------|--------|---------|--------|-------------|-------|
+| aya-vision-8b | aya-vision-8b | ✅ | 957.33 | 111.35 | 1.00x | 84 tokens |
+| bunny-llama3-8b | bunny-llama3-8b-4bit | ✅ | 2511.48 | 112.15 | **1.18x** | 37 tokens |
+| gemma3 (4B) | gemma3-4b-4bit | ✅ | 534.35 | 127.87 | **1.65x** | 16 tokens |
+| gemma4 (26B MoE) | gemma-4-26b-a4b-it-4bit | ✅ | 833.33 | 134.17 | **2.02x** | 30 tokens |
+| gemma4 (31B) | gemma-4-31b-4bit | ✅ | 427.10 | 23.28 | **1.55x** | 5 tokens |
+| gemma4 (31B IT) | gemma-4-31b-it-4bit | ✅ | 443.69 | 27.23 | **1.46x** | 28 tokens |
+| gemma4 (E2B 4bit) | gemma-4-e2b-it-4bit | ✅ | 2534.10 | 215.86 | **2.04x** | 46 tokens |
+| gemma4 (E2B 8bit) | gemma-4-e2b-it-8bit | ✅ | 2437.00 | 133.67 | **1.60x** | 43 tokens |
+| gemma4 (E4B 4bit) | gemma-4-e4b-it-4bit | ✅ | 1918.33 | 134.24 | **1.78x** | 29 tokens |
+| gemma4 (E4B 8bit) | gemma-4-e4b-it-8bit | ✅ | 1553.54 | 76.17 | **1.36x** | 12 tokens |
+| internvl3 (1B) | internvl3-1b | ❌ | - | FAIL | - | FAIL:warmup |
+| llama4 (Scout) | llama-4-scout-17b-4bit | ✅ | 99.00 | 48.18 | **1.37x** | 100 tokens |
+| llava-1.5-7b | llava-1.5-7b-4bit | ✅ | 2641.79 | 118.30 | **1.15x** | 100 tokens |
+| llava-interleave | llava-interleave-qwen-0.5b-bf16 | ✅ | 11604.57 | 335.07 | **1.28x** | 36 tokens |
+| llava-next | llava-next-mistral-7b-4bit | ✅ | 2544.77 | 121.81 | **1.14x** | 100 tokens |
+| ministral3 | ministral-3b-4bit | ✅ | 2759.83 | 195.92 | **1.57x** | 100 tokens |
+| mistral-small (3.1 24B) | mistral-small-3.1-24b-4bit | ✅ | 707.88 | 39.56 | **1.33x** | 100 tokens |
+| molmo-7b | molmo-7b | ❌ | - | FAIL | - | FAIL:warmup |
+| molmo2 (4B) | molmo2-4b | ✅ | 1605.72 | 64.35 | 1.08x | 46 tokens |
+| paligemma2 (3B 6-bit) | paligemma2-3b-6bit | ✅ | 3842.86 | 73.82 | **1.90x** | 2 tokens |
+| phi-3.5-vision | phi-3.5-vision-4bit | ✅ | 2610.88 | 123.34 | **1.39x** | 19 tokens |
+| pixtral (12B) | pixtral-12b-4bit | ✅ | 1984.38 | 69.66 | **1.16x** | 100 tokens |
+| qwen2-vl (2B) | qwen2-vl-2b-4bit | ⚠️ | 420.59 | 0 | - | loaded; 0 generated tokens |
+| qwen2.5-vl (3B) | qwen2.5-vl-3b-4bit | ❌ | - | FAIL | - | FAIL:warmup |
+| qwen3-vl (2B) | qwen3-vl-2b-4bit | ✅ | 347.36 | 280.57 | **1.77x** | 100 tokens |
+| qwen3-vl (30B MoE) | qwen3-vl-30b-a3b-4bit | ✅ | 37.76 | 34.85 | **1.56x** | 2 tokens |
+| qwen3-vl (32B) | qwen3-vl-32b-4bit | ✅ | 37.19 | 19.68 | 1.07x | 100 tokens |
+
+## Summary Statistics
+
+| Status | Count |
+|--------|-------|
+| ✅ Pass | 89 |
+| ⚠️ Partial | 4 (llama-3.1-8b-bf16, Gemma-4-31b-it-nvfp4, phi-2-4bit, falcon-mamba-7b-4bit) |
+| ❌ Fail | 5 (qwen2.5-vl-3b-4bit, qwen3-next-480b-4bit, deepseek-v3-4bit, molmo-7b, internvl3-1b) |
+
+98 models tested in total.
+
+## Performance vs mlx-lm / mlx-vlm baseline (2026-05-19 benchmark campaign)
+
+Source CSVs (same M5 Max host, mlxcel 0.0.28 with `--cooldown 15 --big-cooldown 15`):
+
+- mlxcel: `benchmarks/metal_m5max_2026-05-19.csv`
+- mlx-lm: `benchmarks/pylm_m5max_2026-05-18.csv` (mlx-lm 0.31.3 dev checkout in `references/mlx-lm`)
+- mlxcel VLM: `benchmarks/metal_m5max_vlm_2026-05-19.csv`
+- mlx-vlm: `benchmarks/pylm_m5max_vlm_2026-05-18.csv` (mlx-vlm 0.4.4)
+
+The M5 Max baseline sub-sweeps ran as part of the same continuous benchmark
+campaign and crossed calendar midnight. For public reporting, this campaign is
+grouped under 2026-05-19 even though the Python baseline CSV filenames carry
+2026-05-18 dates. Numbers are decode tok/s.
+`mlxcel vs mlx-lm` is `mlxcel / mlx-lm` as a percentage; **bold** =
+mlxcel >= mlx-lm. `FAIL` cells are real load/runtime errors on that
+backend with this configuration. The mlx-lm checkout pulled in for this
+run is `ed1fca4` ("Thread local generation stream"); some text models
+that work on other mlx-lm releases fail on this snapshot.
+
+### Aggregate (text)
+
+- **Comparable text pairs**: 67
+- **mlxcel >= mlx-lm**: 23 / 67 (34%)
+- **mlxcel >= 90% parity**: 59 / 67 (88%)
+- **Average mlxcel/mlx-lm**: 96% (median 98%, range 44%-124%)
+
+### Aggregate (VLM, models with >=5 generated tokens both sides)
+
+- **Comparable VLM pairs**: 19
+- **mlxcel >= mlx-vlm**: 7 / 19 (36%)
+- **mlxcel >= 90% parity**: 14 / 19 (73%)
+- **Average mlxcel/mlx-vlm**: 95% (median 99%, range 58%-117%)
+
+### Text decode (tok/s)
+
+| Model | mlxcel | mlx-lm | mlxcel vs mlx-lm |
+|-------|--------|--------|------------------|
+| Gemma-4-31b-it-nvfp4 | 7.18 | FAIL | - |
+| aya-expanse-8b-4bit | 113.47 | 113.87 | 100% |
+| aya-vision-8b | 112.55 | FAIL | - |
+| baichuan-m1-14b-4bit | 63.12 | 64.86 | 97% |
+| bunny-llama3-8b-4bit | 114.79 | FAIL | - |
+| command-r7b-4bit | 114.02 | 110.67 | **103%** |
+| deepseek-coder-1.3b-4bit | 182.64 | FAIL | - |
+| deepseek-r1-distill-7b-4bit | 126.33 | 125.63 | **101%** |
+| deepseek-v2-lite-4bit | 205.65 | 215.00 | 96% |
+| ernie-4.5-0.3b-4bit | 1035.74 | FAIL | - |
+| exaone-3.5-2.4b-4bit | 287.68 | 289.01 | 100% |
+| exaone4-1.2b-4bit | 416.96 | FAIL | - |
+| falcon-mamba-7b-4bit | 61.01 | 140.10 | 44% |
+| gemma-2b-4bit | 215.48 | 223.27 | 97% |
+| gemma-4-26b-a4b-it-4bit | 138.24 | 141.08 | 98% |
+| gemma-4-31b-4bit | 28.85 | 28.79 | **100%** |
+| gemma-4-31b-it-4bit | 27.63 | 28.74 | 96% |
+| gemma-4-e2b-it-4bit | 223.42 | FAIL | - |
+| gemma-4-e2b-it-8bit | 136.83 | FAIL | - |
+| gemma-4-e4b-it-4bit | 137.25 | FAIL | - |
+| gemma-4-e4b-it-8bit | 80.59 | FAIL | - |
+| gemma2-2b-4bit | 194.65 | 241.76 | 81% |
+| gemma3-1b-4bit | 381.28 | 388.52 | 98% |
+| gemma3-4b-4bit | 150.64 | 181.66 | 83% |
+| gemma3n-e2b-4bit | 157.76 | FAIL | - |
+| gemma3n-e4b-4bit | 109.61 | FAIL | - |
+| gemma3n-e4b-bf16 | 38.23 | 48.72 | 78% |
+| glm4-flash-4bit | 97.85 | 104.03 | 94% |
+| gpt-oss-120b-4bit | 113.34 | 110.35 | **103%** |
+| gpt-oss-20b-mxfp4 | 171.75 | 168.33 | **102%** |
+| hunyuan-1.8b-4bit | 326.83 | 349.93 | 93% |
+| hunyuan-large-4bit | 63.77 | FAIL | - |
+| hunyuan-moe-a13b-bf16 | 64.08 | FAIL | - |
+| internlm2-7b-4bit | 116.61 | 117.98 | 99% |
+| internlm3-8b-4bit | 101.67 | FAIL | - |
+| jamba-v0.1-4bit | 182.82 | 219.38 | 83% |
+| llama-3.1-8b-4bit | 116.85 | 117.43 | 100% |
+| llama-3.1-8b-bf16 | 33.14 | 34.29 | 97% |
+| llama-3.2-1b-4bit | 539.67 | 578.64 | 93% |
+| llama-4-scout-17b-4bit | 49.08 | FAIL | - |
+| llava-1.5-7b-4bit | 124.69 | FAIL | - |
+| llava-interleave-qwen-0.5b-bf16 | 398.56 | FAIL | - |
+| llava-next-mistral-7b-4bit | 123.31 | FAIL | - |
+| mamba2-1.3b-4bit | 181.66 | FAIL | - |
+| mimo-7b-4bit | 120.09 | 118.85 | **101%** |
+| minicpm-2b-4bit | 233.32 | 228.46 | **102%** |
+| minicpm3-4b-4bit | 133.89 | FAIL | - |
+| minimax-m2-3bit | 72.71 | 68.94 | **105%** |
+| ministral-3b-4bit | 223.09 | 231.92 | 96% |
+| mistral-small-3.1-24b-4bit | 41.64 | 41.49 | **100%** |
+| mixtral-8x7b-4bit | 65.07 | 66.08 | 98% |
+| molmo2-4b | 63.86 | FAIL | - |
+| nemotron-h-30b-4bit | 171.76 | 178.80 | 96% |
+| nemotron-nas-30b-4bit | 170.87 | 178.39 | 96% |
+| olmo-1b-4bit | 245.18 | FAIL | - |
+| olmo2-7b-4bit | 117.64 | 120.79 | 97% |
+| olmo3-32b-4bit | 29.02 | 28.99 | **100%** |
+| paligemma2-3b-6bit | 150.39 | FAIL | - |
+| phi-2-4bit | 71.95 | FAIL | - |
+| phi-3-mini-4bit | 205.16 | 212.74 | 96% |
+| phi-3.5-mini-4bit | 163.64 | 207.79 | 79% |
+| phi-3.5-moe-4bit | 114.78 | 107.56 | **107%** |
+| phi-3.5-vision-4bit | 163.69 | FAIL | - |
+| phi-4-4bit | 63.66 | 62.28 | **102%** |
+| pixtral-12b-4bit | 76.56 | 74.95 | **102%** |
+| qwen1.5-moe-a2.7b-4bit | 239.93 | 237.50 | **101%** |
+| qwen2-vl-2b-4bit | 271.60 | 381.98 | 71% |
+| qwen2.5-0.5b-4bit | 678.07 | 637.17 | **106%** |
+| qwen2.5-0.5b-bf16 | 402.30 | 402.73 | 100% |
+| qwen2.5-7b-4bit | 126.63 | 123.59 | **102%** |
+| qwen2.5-7b-8bit | 69.09 | 67.44 | **102%** |
+| qwen3-0.6b-4bit | 510.83 | 651.14 | 78% |
+| qwen3-1.7b-4bit | 362.95 | 384.84 | 94% |
+| qwen3-30b-a3b-4bit | 151.57 | 147.22 | **103%** |
+| qwen3-4b-4bit | 190.99 | 190.94 | **100%** |
+| qwen3-8b-4bit | 111.86 | 113.40 | 99% |
+| qwen3-moe-4bit | 151.40 | 146.51 | **103%** |
+| qwen3-vl-2b-4bit | 368.28 | 382.50 | 96% |
+| qwen3-vl-30b-a3b-4bit | 144.25 | 146.87 | 98% |
+| qwen3-vl-32b-4bit | 27.49 | 28.51 | 96% |
+| qwen3.5-0.8b-4bit | 504.32 | 545.45 | 92% |
+| qwen3.5-27b-4bit | 32.67 | 34.05 | 96% |
+| qwen3.5-2b-4bit | 325.94 | 345.59 | 94% |
+| qwen3.5-35b-a3b-4bit | 145.49 | 152.96 | 95% |
+| qwen3.5-4b-4bit | 167.43 | 174.45 | 96% |
+| qwen3.5-9b-4bit | 101.89 | 108.27 | 94% |
+| qwen3.5-9b-bf16 | 30.48 | 32.09 | 95% |
+| qwen3.6-35b-a3b-4bit | 140.99 | 146.93 | 96% |
+| smollm-135m-4bit | 883.99 | 711.54 | **124%** |
+| smollm3-3b-4bit | 232.92 | 239.14 | 97% |
+| solar-open-100b-4bit | 65.59 | 66.30 | 99% |
+| stablelm-1.6b-4bit | 424.32 | 423.68 | **100%** |
+| starcoder2-3b-4bit | 216.96 | 214.76 | **101%** |
+
+### VLM decode (tok/s)
+
+| Model | mlxcel | mlx-vlm | mlxcel vs mlx-vlm |
+|-------|--------|---------|-------------------|
+| aya-vision-8b | 111.35 | FAIL | - |
+| bunny-llama3-8b-4bit | 112.15 | FAIL | - |
+| gemma-4-26b-a4b-it-4bit | 134.17 | 136.57 | 98% |
+| gemma-4-31b-4bit | 23.28 | 39.85 | 58% |
+| gemma-4-31b-it-4bit | 27.23 | 30.20 | 90% |
+| gemma-4-e2b-it-4bit | 215.86 | 201.70 | **107%** |
+| gemma-4-e2b-it-8bit | 133.67 | 150.51 | 89% |
+| gemma-4-e4b-it-4bit | 134.24 | 131.24 | **102%** |
+| gemma-4-e4b-it-8bit | 76.17 | 90.00 | 85% |
+| gemma3-4b-4bit | 127.87 | FAIL | - |
+| gemma3n-e2b-4bit | FAIL | 124.63 | - |
+| gemma3n-e4b-4bit | FAIL | 93.55 | - |
+| gemma3n-e4b-bf16 | FAIL | 49.88 | - |
+| internvl3-1b | FAIL | 529.33 | - |
+| llama-4-scout-17b-4bit | 48.31 | FAIL | - |
+| llava-1.5-7b-4bit | 118.30 | FAIL | - |
+| llava-interleave-qwen-0.5b-bf16 | 335.07 | 345.08 | 97% |
+| llava-next-mistral-7b-4bit | 121.81 | FAIL | - |
+| ministral-3b-4bit | 195.92 | FAIL | - |
+| mistral-small-3.1-24b-4bit | 39.56 | FAIL | - |
+| molmo-7b | FAIL | 56471.65 (anomalous) | - |
+| molmo2-4b | 64.35 | 66.80 | 96% |
+| paligemma2-3b-6bit | 73.82 | 124.55 | 59% |
+| phi-3.5-vision-4bit | 123.34 | 159.63 | 77% |
+| pixtral-12b-4bit | 69.66 | FAIL | - |
+| qwen2-vl-2b-4bit | 0.00 | 279.55 | - |
+| qwen3-vl-2b-4bit | 280.57 | FAIL | - |
+| qwen3-vl-30b-a3b-4bit | 34.85 | FAIL | - |
+| qwen3-vl-32b-4bit | 19.68 | FAIL | - |
+| qwen3.5-0.8b-4bit | 477.51 | 410.96 | **116%** |
+| qwen3.5-27b-4bit | 33.01 | 33.44 | 99% |
+| qwen3.5-2b-4bit | 321.54 | 318.14 | **101%** |
+| qwen3.5-35b-a3b-4bit | 149.57 | 128.80 | **116%** |
+| qwen3.5-4b-4bit | 169.57 | 166.46 | **102%** |
+| qwen3.5-9b-4bit | 102.39 | 102.48 | 100% |
+| qwen3.5-9b-bf16 | 31.00 | 31.45 | 99% |
+| qwen3.6-35b-a3b-4bit | 144.82 | 123.70 | **117%** |
+
+### mlx-lm fail categories (text)
+
+The mlx-lm-side FAILs in this campaign are:
+unsupported architectures (`deepseek-v3-4bit`, `internvl3-1b`,
+`molmo-7b`, `qwen2.5-vl-3b-4bit`), `transformers` config schema drift
+(`exaone4-1.2b-4bit`, the `gemma-4-e{2,4}b-it-{4,8}bit` and
+`gemma3n-e{2,4}b-4bit` family), tokenizer wrapper bugs
+(`internlm3-8b-4bit`), `ModelArgs` mismatch (`mamba2-1.3b-4bit`,
+`phi-2-4bit`, `minicpm3-4b-4bit`, `Gemma-4-31b-it-nvfp4`), VLM-only
+loaders routed through the text path (`aya-vision-8b`,
+`bunny-llama3-8b-4bit`, `llava-*`, `paligemma2-3b-6bit`,
+`phi-3.5-vision-4bit`), custom remote code refused (`hunyuan-*`,
+`deepseek-coder-1.3b-4bit`, `ernie-4.5-0.3b-4bit`), and one runtime
+crash (`olmo-1b-4bit`). These are backend-specific compatibility outcomes for
+the referenced mlx-lm/mlx-vlm checkouts; they should not be counted as silent
+mlxcel performance wins.
+
+## Known Issues
+
+| Model | Issue | Priority |
+|-------|-------|----------|
+| deepseek-v3-4bit | MoE + MLA; still fails warmup | Medium |
+| qwen3-next-480b-4bit | OOM-skip on 128 GB; weights exceed 85% memory budget | Medium |
+| qwen2.5-vl-3b-4bit | FAIL:warmup | Medium |
+| Gemma-4-31b-it-nvfp4 | nvfp4 quantization runs at 7.18 tok/s; no fast Metal kernel for nvfp4 | Medium |
+| falcon-mamba-7b-4bit | Generic chat prompt exits after `<|im_end|>`; use a non-chat code prompt for perf checks | Low |
+| phi-2-4bit | Generates only 1 token — likely EOS handling | Low |
+| llama-3.1-8b-bf16 | bf16 → f16 conversion path is functional but slow | Low |
+| internvl3-1b | unsupported architecture | Low |
+| molmo-7b | unsupported architecture | Low |
+
+## Notes
+
+- All tests use 4-bit quantized models unless noted.
+- Performance measured with `--profile` flag (separate prefill/decode timing).
+- `vs M1 Ultra` ratios are retained as cross-hardware context and should be
+  refreshed together with the M1 Ultra table when public cross-hardware claims
+  depend on them.
+- Prefill and decode tok/s reported separately.
+- Full text + VLM sweep on 2026-05-19: 98 text models (`bench_decode.sh all`) and a matching `bench_decode.sh all --vlm` pass, both at `--cooldown 15 --big-cooldown 15`.
+- Cooldown discipline on M5 Max: 15s general / 15s big-model cooldowns were sufficient for this back-to-back run on a freshly-built binary; longer cooldowns (`--cooldown 30 --big-cooldown 30`) remain the safer default for marathon sessions or when thermal headroom is uncertain.
+- Measurement noise on very fast small models remains high (qwen3.5-0.8b-4bit and
+  similar can span ±15% across back-to-back runs because 100 tokens generate in
+  under 300 ms).
+
+## TurboQuant KV cache — M5 Max latest readings
+
+Latest available TurboQuant readings for the M5 Max benchmark page. These measurements are separate from the standard model sweep above because they exercise KV-cache storage modes rather than model architecture coverage.
+
+| Item | Value |
+|------|-------|
+| Hardware | Apple M5 Max, 128 GB unified memory |
+| Model | `models/llama-3.1-8b-4bit` |
+| Decode CSV | `benchmarks/turbo_kv/2026-05-03_Apple_M5_Max_llama-3.1-8b-4bit.csv` |
+| FP16 fast-path CSVs | 2026-05-07 M5 Max lazy-sidecar rows under `benchmarks/turbo_kv/` |
+
+CSV rows where `stage=prefill` include a single-token follow-up only to populate the KV cache. Use `prefill_tok_s` for those rows and ignore their sub-millisecond `decode_tok_s` values.
+
+### PPL evaluation throughput
+
+The quality gate measures wikitext-2 PPL evaluation throughput over a 4K-token window. It is distinct from decode tok/s.
+
+| Model | KV mode | PPL eval tok/s | Wall clock ms | Gate |
+|---|---|---:|---:|---|
+| Meta-Llama-3.1-8B-Instruct-4bit | fp16 | 733.76 | 111,617 | baseline |
+| Meta-Llama-3.1-8B-Instruct-4bit | turbo4asym | 490.32 | 167,034 | pass |
+
+For the full config guide, tuning knobs, and architectural description, see [`docs/turbo-kv-cache.md`](../turbo-kv-cache.md).
+
+### Decode @ 4K context
+
+| Mode | Decode tok/s | x FP16 | Generated | Gate | Verdict |
+|------|-------------:|-------:|----------:|------|---------|
+| `fp16` | 101.29 | 1.000x | 80 | baseline | baseline |
+| `int8` | 72.79 | 0.719x | 80 | tracking | tracking |
+| `turbo4-asym` | 9.15 | 0.090x | 80 | >=0.97x | fail |
+| `turbo4` | 20.76 | 0.205x | 80 | >=0.93x | fail |
+| `turbo4-delegated` | 27.28 | 0.269x | 80 | >=0.97x | fail |
+| `turbo3-asym` | 6.36 | 0.063x | 80 | tracking | tracking |
+| `turbo4-delegated` FP16 fast path + lazy sidecars | 102.15 | 0.977x | 100 | >=0.97x | pass |
+
+### Decode @ 16K context
+
+| Mode | Decode tok/s | x FP16 | Generated | Gate | Verdict |
+|------|-------------:|-------:|----------:|------|---------|
+| `fp16` | 63.58 | 1.000x | 19 | baseline | baseline |
+| `int8` | 36.35 | 0.572x | 80 | tracking | tracking |
+| `turbo4-asym` | 3.87 | 0.061x | 26 | >=0.95x | fail |
+| `turbo4` | 6.76 | 0.106x | 80 | >=0.90x | fail |
+| `turbo4-delegated` | 3.41 | 0.054x | 21 | >=0.95x | fail |
+| `turbo3-asym` | 1.85 | 0.029x | 54 | tracking | tracking |
+| `turbo4-delegated` FP16 fast path + lazy sidecars | 66.63 | 1.039x | 19 | >=0.95x | pass |
+
+The repeated-paragraph 16K prompt exits early on several modes; per-token rates use the actually generated token count.
+
+### Prefill @ 8K context
+
+| Mode | Prefill tok/s | x FP16 | Gate | Verdict |
+|------|--------------:|-------:|------|---------|
+| `fp16` | 2444.34 | 1.000x | baseline | baseline |
+| `int8` | 2664.41 | 1.090x | tracking | tracking |
+| `turbo4-asym` | 1680.45 | 0.687x | >=1.00x | fail |
+| `turbo4` | 1157.40 | 0.474x | >=1.00x | fail |
+| `turbo4-delegated` | 2942.94 | 1.204x | best-effort | pass |
+| `turbo3-asym` | 1579.36 | 0.646x | tracking | tracking |
+
+### M5 Max reading
+
+- `int8` is the practical drop-in KV mode for memory-constrained long-context workloads on M5 Max: decode is slower than fp16, but prefill is faster and the KV cache is half-sized.
+- `turbo4-delegated` is the only compressed Turbo mode with a passing prefill reading in this matrix.
+- Compressed-only Turbo decode modes remain far below FP16 decode throughput on these readings.
+- The optional `turbo4-delegated` FP16 fast path reaches FP16-class decode at 4K and 16K, but it keeps a full FP16 V working set while enabled, so it is a speed path rather than a compressed-memory result.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -21,25 +21,16 @@ For every benchmark run, include:
 Averages are useful only after the raw rows are available. Avoid statements such
 as "faster than X" unless the comparable model set and exclusions are explicit.
 
-## README reference snapshot
+## Current result snapshot
 
-The root README currently summarizes the latest Apple Silicon reference
-snapshot:
+Keep public result summaries in a single place so aggregate numbers do not drift
+between documents. The current Apple Silicon benchmark report is:
 
-- Date: 2026-05-18 full sweep, with selected targeted rows refreshed on 2026-05-19
-- Hardware: MacBook Pro M5 Max, 128GB
-- Runtime: mlxcel 0.0.28
-- MLX: 0.31.2
-- Baselines: mlx-lm 0.31.3 (`ed1fca4`) and mlx-vlm 0.4.4
-- Scope: 98 text model directories plus a separate 98-entry VLM prompt pass
-- Comparable text pairs: 67; average mlxcel/mlx-lm decode throughput 95%, median 97%, with 50 / 67 rows at or above 90% parity
-- Comparable VLM pairs: 17; average mlxcel/mlx-vlm decode throughput 94%, median 95%, with 12 / 17 rows at or above 90% parity
+- [Benchmark Report - 2026-05-19](benchmark_results/benchmark-report.md)
 
-An earlier 2026-05-08 M1 Ultra snapshot reported about 119% of the mlx-lm
-baseline across 37 comparable 4-bit text checkpoints. That number is kept only
-as historical context; use the current raw rows and rerun the suite on the
-target hardware before relying on README numbers for release notes or capacity
-planning.
+Use that report and its linked raw per-hardware tables for release notes,
+README updates, or capacity planning. This page should stay focused on
+methodology, required metadata, and caveats.
 
 ## Suggested benchmark commands
 


### PR DESCRIPTION
## Summary

Organizes the per-platform benchmark result reports under a dedicated `docs/benchmark_results/` directory and refreshes the top-level `docs/benchmarks.md` to point at them.

- Adds platform-specific reports: `model_tests_m5max.md`, `model_tests_m1ultra.md`, `model_tests_gb10.md`
- Adds aggregated `benchmark-report.md` and `model_tests.md`
- Updates `docs/benchmarks.md` to link to the new layout

## Test plan

- [x] Markdown links resolve from `docs/benchmarks.md` to the new files
- [x] No code paths touched — docs-only change