### PR TITLE
fix: reset model-owned VLM fallback state

### DIFF
--- a/src/lib/mlxcel-core/src/generate.rs
+++ b/src/lib/mlxcel-core/src/generate.rs
@@ -237,6 +237,20 @@ pub trait LanguageModel {
     /// so that padding positions do not corrupt subsequent decode steps.
     fn trim_internal_caches(&self, _excess: i32) {}
 
+    /// Reset model-owned fallback runtime state before a fresh single-row
+    /// generation starts.
+    ///
+    /// Most models store all request-local state in the `KVCache` slice owned
+    /// by [`CxxGenerator`], so the default is a no-op. Models that keep a
+    /// fallback cache slot on `&self` (for legacy CLI / benchmark paths that
+    /// do not carry a `SequenceId`) override this to clear that slot without
+    /// touching scheduler-owned per-sequence maps.
+    ///
+    /// Used by: `CxxGenerator::{reset_with_model, generate_streaming,
+    /// generate_with_stats, generate_streaming_with_embeddings,
+    /// generate_with_stats_and_embeddings, evaluate_loglikelihoods}`.
+    fn reset_runtime_state(&self) {}
+
     /// Release any model-owned sequence state associated with the provided
     /// external cache slice before the scheduler drops that cache set.
     ///
@@ -782,8 +796,9 @@ impl CxxGenerator {
     /// Reset generator state including model-internal caches.
     ///
     /// Models with internal RefCell caches (sliding window, SSM, hybrid) reset
-    /// their own state inside `make_caches()`. This method ensures both the
-    /// generator's cache vector and the model's internal caches are cleared.
+    /// their own fallback state inside `reset_runtime_state()`. This method
+    /// ensures both the generator's cache vector and the model's internal
+    /// single-row caches are cleared.
     /// The kv_cache_mode is applied to the freshly created caches.
     ///
     /// Honors the Boundary-V policy (issue #478): when `self.kv_cache_mode`
@@ -792,6 +807,7 @@ impl CxxGenerator {
     /// The boundary count is read from `MLXCEL_KV_BOUNDARY_V_LAYERS` so a
     /// runtime-tuned count is honored on every reset.
     pub fn reset_with_model<M: LanguageModel + ?Sized>(&mut self, model: &M) {
+        model.reset_runtime_state();
         self.caches = model.make_caches();
         // Apply the configured KV cache mode (with Boundary-V upgrade) to
         // all freshly created caches.
@@ -854,8 +870,11 @@ impl CxxGenerator {
         sampling: &SamplingConfig,
         mut on_token: F,
     ) -> Vec<i32> {
-        // Reset state
-        self.reset();
+        // Reset generator-owned caches and model-owned fallback caches. The
+        // latter matters for model-owned cache families (Gemma 3/4, Llama 4,
+        // Qwen 3.5 Next) whose legacy single-row path does not carry a
+        // `SequenceId`.
+        self.reset_with_model(model);
 
         // Axis B: merge any generator-cached language-bias map into the
         // sampling config before seeding/penalty evaluation. Empty cached
@@ -1122,8 +1141,9 @@ impl CxxGenerator {
         sampling: &SamplingConfig,
         mut on_token: F,
     ) -> Vec<i32> {
-        // Reset state
-        self.reset();
+        // Reset generator-owned caches and model-owned fallback caches. See
+        // `generate_streaming` for the model-owned cache rationale.
+        self.reset_with_model(model);
 
         // Axis B: inject generator-cached language-bias into the sampling config.
         let sampling_cow = self.compose_sampling(sampling);
@@ -1269,7 +1289,7 @@ impl CxxGenerator {
     ) -> (Vec<i32>, GenerationStats) {
         use std::time::Instant;
 
-        self.reset();
+        self.reset_with_model(model);
 
         // Axis B: inject generator-cached language-bias into the sampling config.
         let sampling_cow = self.compose_sampling(sampling);
@@ -1417,8 +1437,9 @@ impl CxxGenerator {
     ) -> (Vec<i32>, GenerationStats) {
         use std::time::Instant;
 
-        // Reset state
-        self.reset();
+        // Reset generator-owned caches and model-owned fallback caches. See
+        // `generate_streaming` for the model-owned cache rationale.
+        self.reset_with_model(model);
 
         // Axis B: inject generator-cached language-bias into the sampling config.
         let sampling_cow = self.compose_sampling(sampling);
@@ -2140,6 +2161,61 @@ mod tests {
         model.trim_internal_caches(8);
         model.trim_internal_caches(0);
         model.trim_internal_caches(-1);
+    }
+
+    struct TrackingResetModel {
+        reset_call_count: std::cell::Cell<usize>,
+    }
+
+    impl TrackingResetModel {
+        fn new() -> Self {
+            Self {
+                reset_call_count: std::cell::Cell::new(0),
+            }
+        }
+    }
+
+    impl LanguageModel for TrackingResetModel {
+        fn forward(
+            &self,
+            input_ids: &MlxArray,
+            _caches: &mut [KVCache],
+            _mask: Option<&MlxArray>,
+        ) -> UniquePtr<MlxArray> {
+            ffi::eval(input_ids);
+            ffi::zeros(&[1, 1, 4], crate::dtype::FLOAT32)
+        }
+
+        fn make_caches(&self) -> Vec<KVCache> {
+            vec![KVCache::new()]
+        }
+
+        fn num_layers(&self) -> usize {
+            1
+        }
+
+        fn eos_token_ids(&self) -> Vec<i32> {
+            vec![99]
+        }
+
+        fn reset_runtime_state(&self) {
+            self.reset_call_count.set(self.reset_call_count.get() + 1);
+        }
+    }
+
+    #[test]
+    fn reset_with_model_invokes_runtime_state_hook() {
+        let model = TrackingResetModel::new();
+        let mut generator = CxxGenerator::new(model.num_layers());
+
+        assert_eq!(model.reset_call_count.get(), 0);
+        generator.reset_with_model(&model);
+
+        assert_eq!(
+            model.reset_call_count.get(),
+            1,
+            "reset_with_model must reset model-owned fallback state"
+        );
     }
 
     /// A model that overrides trim_internal_caches records each call so we can

--- a/src/loaded_model.rs
+++ b/src/loaded_model.rs
@@ -300,6 +300,10 @@ impl LanguageModel for LoadedModel {
         delegate_language_model!(self, after_prefill())
     }
 
+    fn reset_runtime_state(&self) {
+        delegate_language_model!(self, reset_runtime_state())
+    }
+
     fn release_sequence_state(&self, caches: &mut [mlxcel_core::layers::KVCache]) {
         delegate_language_model!(self, release_sequence_state(caches))
     }

--- a/src/models/gemma3.rs
+++ b/src/models/gemma3.rs
@@ -1204,6 +1204,17 @@ impl mlxcel_core::generate::LanguageModel for Gemma3Wrapper {
             .prepare_sequence_state(seq_id, self.model.make_caches());
     }
 
+    fn reset_runtime_state(&self) {
+        // Used by: CxxGenerator single-row generation paths. Gemma 3 owns
+        // its fallback sliding/global KV cache state inside
+        // `ModelOwnedSequenceState`; the caller-provided `KVCache` slice is
+        // intentionally empty/ignored. Reset the fallback slot before each
+        // fresh CLI / benchmark generation so a second VLM prefill does not
+        // reuse offsets from a previous run with a stale 4D attention mask
+        // (issue #731).
+        self.reset_caches();
+    }
+
     fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
         self.sequence_state.release_sequence_state(seq_id)
     }

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -3346,6 +3346,14 @@ impl LanguageModel for Gemma4Wrapper {
             .prepare_sequence_state(seq_id, self.model.make_caches());
     }
 
+    fn reset_runtime_state(&self) {
+        // Used by: CxxGenerator single-row generation paths. Gemma 4 owns
+        // its fallback cache slot inside `ModelOwnedSequenceState`; reset it
+        // for fresh CLI / benchmark runs without touching scheduler-owned
+        // per-sequence entries.
+        self.reset_caches();
+    }
+
     fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
         self.sequence_state.release_sequence_state(seq_id);
     }

--- a/src/models/llama4.rs
+++ b/src/models/llama4.rs
@@ -1728,6 +1728,14 @@ impl LanguageModel for Llama4Wrapper {
             .prepare_sequence_state(seq_id, self.model.make_llama4_caches());
     }
 
+    fn reset_runtime_state(&self) {
+        // Used by: CxxGenerator single-row generation paths. Llama 4 owns
+        // iGQA cache state inside `ModelOwnedSequenceState`; reset only the
+        // legacy fallback slot, leaving scheduler-owned per-sequence entries
+        // untouched.
+        self.reset_caches();
+    }
+
     fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
         self.sequence_state.release_sequence_state(seq_id)
     }

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -2575,6 +2575,17 @@ impl LanguageModel for Qwen35Model {
             .prepare_sequence_state(seq_id, self.make_internal_caches());
     }
 
+    fn reset_runtime_state(&self) {
+        // Used by: CxxGenerator single-row generation paths. Qwen 3.5 Next
+        // owns mixed attention / GatedDelta cache state in
+        // `ModelOwnedSequenceState`; reset the fallback cache slot for fresh
+        // CLI / benchmark runs without touching scheduler-owned sequence
+        // entries. Do not clear the MRoPE fallback here: VLM callers populate
+        // it during embedding preparation immediately before generation.
+        self.sequence_state
+            .replace_internal(self.make_internal_caches());
+    }
+
     fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
         self.sequence_state.release_sequence_state(seq_id);
         // Issue #540: drop the per-sequence MRoPE entry alongside the

--- a/src/vision/gemma4_vl.rs
+++ b/src/vision/gemma4_vl.rs
@@ -551,6 +551,14 @@ impl LanguageModel for Gemma4VLModel {
         self.text_model.prepare_sequence_state(seq_id);
     }
 
+    fn reset_runtime_state(&self) {
+        // Used by: CxxGenerator single-row generation paths. Reset only the
+        // text backbone's fallback cache slot; the VLM per-layer-inputs
+        // fallback is populated by `get_input_embeddings*` immediately before
+        // `forward_with_embeddings*` consumes it.
+        self.text_model.reset_runtime_state();
+    }
+
     fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
         // Issue #543: drop the per-sequence `per_layer_inputs`
         // alongside the text model's per-sequence cache release so

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -262,6 +262,10 @@ impl LanguageModel for VisionLanguageModel {
         self.text_model.after_prefill()
     }
 
+    fn reset_runtime_state(&self) {
+        self.text_model.reset_runtime_state()
+    }
+
     fn trim_internal_caches(&self, excess: i32) {
         self.text_model.trim_internal_caches(excess)
     }

--- a/src/vision/qwen3_5_vl.rs
+++ b/src/vision/qwen3_5_vl.rs
@@ -377,6 +377,14 @@ impl LanguageModel for Qwen35VLModel {
         );
     }
 
+    fn reset_runtime_state(&self) {
+        // Used by: CxxGenerator single-row generation paths. Reset the
+        // hybrid text backbone's fallback mixed-cache slot while preserving
+        // the MRoPE fallback written by VLM embedding preparation just before
+        // generation starts.
+        mlxcel_core::generate::LanguageModel::reset_runtime_state(&self.text_model);
+    }
+
     /// Issue #540: forward `seq_ids` to the underlying Qwen3.5 model so
     /// each row's MRoPE state resolves correctly in mixed VL+text
     /// batches. `Qwen35Model::forward_batched_with_context_and_ids`

--- a/tests/vlm_concurrency.rs
+++ b/tests/vlm_concurrency.rs
@@ -1,0 +1,191 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Ignored real-model VLM server concurrency smoke tests.
+//!
+//! Issue #731 fixed a Gemma 3n VLM race where the MobileNet/MSFA
+//! `per_layer_inputs` tensor was parked in one model-wide fallback slot. A
+//! burst of two server requests could have one row consume the other's tensor
+//! or panic after the slot was drained. The test below runs the real HTTP
+//! stack with two concurrent image requests so the scheduler exercises the
+//! sequence-aware binding path.
+//!
+//! To run the gated test:
+//! ```text
+//! cargo test --release --test vlm_concurrency -- --ignored
+//! ```
+
+mod common;
+
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use common::{repo_binary_path, repo_model_dir};
+
+const GEMMA3N_E2B_MODEL: &str = "gemma3n-e2b-4bit";
+
+fn reserve_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+fn fixture_image_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/test_image.png")
+}
+
+fn fixture_image_data_uri() -> String {
+    let bytes = std::fs::read(fixture_image_path()).expect("read VLM fixture image");
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    format!("data:image/png;base64,{encoded}")
+}
+
+fn spawn_server(args: &[&str]) -> Child {
+    Command::new(repo_binary_path("mlxcel-server"))
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mlxcel-server")
+}
+
+fn stop_server(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+async fn wait_for_health(client: &reqwest::Client, base_url: &str) {
+    let deadline = Instant::now() + Duration::from_secs(90);
+    while Instant::now() < deadline {
+        if let Ok(response) = client.get(format!("{base_url}/health")).send().await
+            && response.status().is_success()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    panic!("mlxcel-server did not become healthy at {base_url}");
+}
+
+async fn post_vlm_chat(
+    client: reqwest::Client,
+    base_url: String,
+    image_data_uri: String,
+    text: &'static str,
+) -> serde_json::Value {
+    let response = client
+        .post(format!("{base_url}/v1/chat/completions"))
+        .json(&serde_json::json!({
+            "model": "gemma3n-vl-test",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": image_data_uri}},
+                    {"type": "text", "text": text}
+                ]
+            }],
+            "max_tokens": 24,
+            "temperature": 0.0
+        }))
+        .send()
+        .await
+        .expect("send VLM chat request");
+    let status = response.status();
+    let body = response
+        .json::<serde_json::Value>()
+        .await
+        .expect("parse VLM chat response");
+    assert!(
+        status.is_success(),
+        "VLM chat request returned non-success status {status}: {body}"
+    );
+    body
+}
+
+fn has_chat_choice(response: &serde_json::Value) -> bool {
+    response["choices"][0]["message"]["content"].is_string()
+}
+
+#[tokio::test]
+#[ignore = "requires local Gemma 3n VLM weights and the mlxcel-server binary"]
+async fn gemma3n_vlm_two_concurrent_image_requests_do_not_cross_contaminate_state() {
+    let model_dir = repo_model_dir(GEMMA3N_E2B_MODEL);
+    if !model_dir.exists() {
+        eprintln!(
+            "Skipping test: model directory not found at {}",
+            model_dir.display()
+        );
+        return;
+    }
+
+    let port = reserve_port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let model_arg = model_dir.to_string_lossy().to_string();
+    let port_arg = port.to_string();
+    let mut child = spawn_server(&[
+        "--model",
+        &model_arg,
+        "--alias",
+        "gemma3n-vl-test",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &port_arg,
+        "--parallel",
+        "2",
+        "--max-batch-size",
+        "2",
+        "--max-queue-depth",
+        "8",
+        "--no-warmup",
+    ]);
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(180))
+        .build()
+        .expect("build reqwest client");
+    wait_for_health(&client, &base_url).await;
+
+    let image_a = fixture_image_data_uri();
+    let image_b = fixture_image_data_uri();
+    let handle_a = tokio::spawn(post_vlm_chat(
+        client.clone(),
+        base_url.clone(),
+        image_a,
+        "What is in this image? Answer in one short sentence.",
+    ));
+    let handle_b = tokio::spawn(post_vlm_chat(
+        client.clone(),
+        base_url.clone(),
+        image_b,
+        "Describe the main object in this image in one short sentence.",
+    ));
+
+    let response_a = handle_a.await.expect("join VLM request A");
+    let response_b = handle_b.await.expect("join VLM request B");
+    stop_server(&mut child);
+
+    assert!(
+        has_chat_choice(&response_a),
+        "missing chat choice: {response_a}"
+    );
+    assert!(
+        has_chat_choice(&response_b),
+        "missing chat choice: {response_b}"
+    );
+}


### PR DESCRIPTION
## Summary

VLM single-row generation paths (CLI and `bench` invocations that do not carry a `SequenceId`) were leaking fallback cache state between runs. `CxxGenerator::generate_streaming{,_with_embeddings}` and `generate_with_stats{,_and_embeddings}` only called `self.reset()`, which clears the generator-owned `KVCache` vector but never touches the model-owned fallback slot inside `ModelOwnedSequenceState`. A second VLM prefill then reused offsets from the previous run against a freshly built 4D attention mask, producing wrong outputs or panicking when the cached position fell outside the new mask.

## Fix

Introduce a new `LanguageModel::reset_runtime_state()` trait hook with a default no-op body (correct for models whose entire state lives in the caller's `KVCache` slice) and call it from `CxxGenerator::reset_with_model`. Switch every single-row generation path off the bare `reset()` and onto `reset_with_model(model)` so the generator-owned caches and the model-owned fallback caches are cleared in lockstep. Per-sequence scheduler entries are intentionally untouched — only the legacy fallback slot used by `SequenceId`-less paths is reset.

## Per-Model Implementations

- **Gemma 3, Gemma 4, Llama 4** — forward the hook to their existing `reset_caches()` routines.
- **Qwen 3.5 Next** — calls `sequence_state.replace_internal(make_internal_caches())` directly so the VLM-populated MRoPE fallback slot is preserved; VLM callers write that slot during embedding preparation immediately before generation begins.
- **Gemma4VLModel / Qwen35VLModel** — delegate to the text backbone's hook.
- **VisionLanguageModel / LoadedModel** — propagate the new hook through their existing `delegate_language_model!` machinery so every wrapper layer participates.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --tests --features metal,accelerate`
- [x] `cargo clippy --features metal,accelerate --all-targets -- -D warnings`
- [x] `reset_with_model_invokes_runtime_state_hook` unit test (uses a tracking model to guarantee `reset_with_model` actually invokes the new hook, so future single-row paths cannot silently regress past it)
- [ ] `tests/vlm_concurrency.rs` — ignored, weight-gated smoke test driving two concurrent image chat requests against a real `mlxcel-server` Gemma 3n VLM instance; run locally with `cargo test --release --test vlm_concurrency -- --ignored` when Gemma 3n VLM weights are available