### PR TITLE
fix(vision): align Gemma 3n VLM per-layer-inputs to padded prefill

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,15 @@ path = "src/bin/mlx_server.rs"
 name = "speculative_bench"
 path = "src/bin/speculative_bench.rs"
 
+# Same-process decode benchmark harness used by `scripts/bench_decode.sh`.
+# It loads a model once, runs the warmup generation, resets model/cache state,
+# then runs the measured pass in the same process. This mirrors the Python
+# `stream_generate` timing more closely than two separate `mlxcel generate`
+# invocations, especially for prefill.
+[[bin]]
+name = "mlxcel-bench-decode"
+path = "src/bin/bench_decode.rs"
+
 [features]
 default = ["surgery"]
 metal = ["mlxcel-core/metal"]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ in the prefill path.
 | Mode | Baseline | M5 Max pairs | M5 Max median vs baseline | M1 Ultra pairs | M1 Ultra median vs baseline |
 |------|----------|-------------:|--------------------------:|---------------:|----------------------------:|
 | Text | `mlx-lm` | 66 | **2.70x** | 73 | **1.76x** |
-| VLM | `mlx-vlm` | 17 | 0.68x | 17 | **1.33x** |
+| VLM | `mlx-vlm` | 20 | 0.94x | 17 | **1.33x** |
 
 ### Decode: steady-state token generation
 
@@ -101,7 +101,7 @@ averaged **100%** of `mlx-vlm` with a **100%** median.
 | Mode | Baseline | Comparable pairs | Average vs baseline | Median vs baseline | >=90% parity | >= baseline | Range |
 |------|----------|-----------------:|--------------------:|-------------------:|-------------:|------------:|------:|
 | Text | `mlx-lm` | 66 | 97% | **99%** | 58 / 66 (88%) | 24 / 66 (36%) | 72%-127% |
-| VLM | `mlx-vlm` | 17 | 100% | **100%** | 14 / 17 (82%) | 7 / 17 (41%) | 77%-123% |
+| VLM | `mlx-vlm` | 20 | 100% | **100%** | 16 / 20 (80%) | 9 / 20 (45%) | 74%-123% |
 
 Representative decode throughput is shown below in tokens per second. M5 Max
 reference columns are same-host `mlx-lm` or `mlx-vlm` runs; M1 Ultra values are
@@ -135,6 +135,7 @@ family, quantization, prompt shape, decode length, and hardware. See
 | Qwen3.5 0.8B 4bit | 202 tok/s | 506 tok/s | 411 tok/s | 123% |
 | Qwen3.5 35B-A3B 4bit | 71 tok/s | 151 tok/s | 129 tok/s | 117% |
 | Gemma 4 E2B 4bit | 107 tok/s | 217 tok/s | 202 tok/s | 108% |
+| Gemma 3n E2B 4bit | 72 tok/s | 151 tok/s | 125 tok/s | 121% |
 | Gemma 4 26B-A4B 4bit | 63 tok/s | 134 tok/s | 137 tok/s | 98% |
 | Molmo2 4B | 59 tok/s | 64 tok/s | 67 tok/s | 96% |
 | Phi 3.5 Vision 4bit | 94 tok/s | 123 tok/s | 160 tok/s | 77% |

--- a/docs/benchmark_results/benchmark-report.md
+++ b/docs/benchmark_results/benchmark-report.md
@@ -22,7 +22,7 @@ includes image encoder and projector work.
 |------|------|----------|-----------------:|---------------------------:|--------------------------:|---------------|
 | M5 Max | Text | mlx-lm | 66 | **2.70x** | **99%** | 58/66 at >=90% parity |
 | M1 Ultra | Text | mlx-lm | 73 | **1.76x** | **97%** | 62/73 at >=90% parity |
-| M5 Max | VLM | mlx-vlm | 17 | 0.68x | **100%** | 14/17 at >=90% parity |
+| M5 Max | VLM | mlx-vlm | 20 | 0.94x | **100%** | 16/20 at >=90% parity |
 | M1 Ultra | VLM | mlx-vlm | 17 | **1.33x** | **98%** | 11/17 at >=90% parity |
 
 Ratios above use successful runs only. Baseline rows use exact CSV model
@@ -36,11 +36,9 @@ the same process. This is the benchmark method used for the current Apple
 Silicon results. VLM prefill remains more prompt-shape- and processor-sensitive
 than text prefill, so decode remains the primary VLM comparison.
 
-Gemma 3 and Gemma 3n VLM rows use the default warmup=20 path where the
-run succeeds. On M5 Max, the Gemma 3 VLM row (gemma3-4b-4bit) succeeds,
-while the three Gemma 3n VLM rows fail on the M5 Max VLM path with a
-broadcast mismatch and are excluded from comparable ratio summaries; the same
-checkpoints pass the M5 Max text-only path.
+Gemma 3 and Gemma 3n VLM rows are included in the M5 Max VLM table.
+The Gemma3n E2B and E4B 4-bit checkpoints run above mlx-vlm decode parity
+in this sweep, while the E4B bf16 checkpoint is successful but below parity.
 
 ## Why This Matters
 
@@ -52,7 +50,7 @@ complete in this sweep. With a generated-token threshold of 5 tokens:
 |------|------|---------------------------------------------------------:|----------------------------:|
 | M5 Max | Text | 25 | 66 |
 | M1 Ultra | Text | 22 | 73 |
-| M5 Max | VLM | 12 | 17 |
+| M5 Max | VLM | 12 | 20 |
 | M1 Ultra | VLM | 20 | 17 |
 
 This is the useful public framing: mlxcel is a Rust inference engine with
@@ -96,6 +94,7 @@ comparison.
 | M5 Max | qwen3.5-0.8b-4bit | Hybrid GatedDeltaNet VLM | 1294.94 | 505.94 | 410.96 | **123%** |
 | M5 Max | qwen3.5-35b-a3b-4bit | Hybrid MoE VLM | 355.32 | 151.34 | 128.80 | **117%** |
 | M5 Max | gemma-4-e2b-it-4bit | Gemma 4 VLM | 2787.47 | 217.32 | 201.70 | **108%** |
+| M5 Max | gemma3n-e2b-4bit | Gemma 3n VLM | 2893.48 | 151.36 | 124.63 | **121%** |
 | M5 Max | molmo2-4b | Molmo2 vision encoder | 2512.31 | 64.01 | 66.80 | 96% |
 | M1 Ultra | llava-interleave-qwen-0.5b-bf16 | SigLIP + Qwen2 | 8589.48 | 269.86 | 225.15 | **120%** |
 | M1 Ultra | aya-vision-8b | SigLIP + Cohere2 | 591.80 | 109.36 | 103.74 | **105%** |
@@ -167,6 +166,7 @@ Source-of-truth CSVs:
 - `benchmarks/pylm_m1ultra_vlm_2026-05-19.csv`
 - `benchmarks/metal_m5max_2026-05-19.csv`
 - `benchmarks/metal_m5max_vlm_2026-05-19.csv`
+- `benchmarks/metal_m5max_vlm_2026-05-20.csv`
 - `benchmarks/pylm_m5max_2026-05-18.csv`
 - `benchmarks/pylm_m5max_vlm_2026-05-18.csv`
 

--- a/docs/benchmark_results/model_tests.md
+++ b/docs/benchmark_results/model_tests.md
@@ -11,7 +11,7 @@ M5 Max, and mlx-lm / mlx-vlm baselines, see
 | Hardware | File | Status | Last Updated |
 |----------|------|--------|-------------|
 | Mac Studio M1 Ultra 128GB | [model_tests_m1ultra.md](model_tests_m1ultra.md) | Active | 2026-05-19 |
-| MacBook Pro M5 Max 128GB | [model_tests_m5max.md](model_tests_m5max.md) | Active | 2026-05-19 |
+| MacBook Pro M5 Max 128GB | [model_tests_m5max.md](model_tests_m5max.md) | Active | 2026-05-20 |
 | NVIDIA GB10 (DIGITS) | [model_tests_gb10.md](model_tests_gb10.md) | Active | 2026-05-19 |
 
 ## Benchmark CSVs
@@ -22,6 +22,7 @@ Current source-of-truth data lives in `benchmarks/`:
 |-----|----------|------|------|
 | `metal_m5max_2026-05-19.csv` | M5 Max | 2026-05-19 (mlxcel 0.0.28, MLX 0.31.2) | Text |
 | `metal_m5max_vlm_2026-05-19.csv` | M5 Max | 2026-05-19 (mlxcel 0.0.28, MLX 0.31.2) | VLM |
+| `metal_m5max_vlm_2026-05-20.csv` | M5 Max | 2026-05-20 (mlxcel 0.0.28, MLX 0.31.2; Gemma3n VLM entries) | VLM |
 | `pylm_m5max_2026-05-18.csv` | M5 Max | 2026-05-19 benchmark campaign (mlx-lm 0.31.3 baseline; CSV date crossed midnight) | Text |
 | `pylm_m5max_vlm_2026-05-18.csv` | M5 Max | 2026-05-19 benchmark campaign (mlx-vlm 0.4.4 baseline; CSV date crossed midnight) | VLM |
 | `metal_m1ultra_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlxcel 0.0.28, MLX commit 84961223; >65GB skipped) | Text |
@@ -73,14 +74,14 @@ For Qwen2.5-0.5B, the 4-bit variant is the comparable row across both Apple Sili
 | Text models tested (M5 Max, 2026-05-19) | 89 pass, 4 partial, 5 fail (98 total) |
 | Text models tested (GB10, 2026-05-19) | 41 pass, 56 partial, 14 fail (111 total) |
 | VLM models tested (GB10, 2026-05-19) | 13 pass, 19 partial, 3 fail (image path) |
-| VLM models tested (M5 Max, 2026-05-19) | 24 working, 3 fail (from VLM sweep) |
+| VLM models tested (M5 Max, 2026-05-19 campaign) | 27 working, 3 fail (from VLM sweep) |
 | VLM models tested (M1 Ultra, 2026-05-19) | 33 pass, 4 partial, 2 fail |
 | Beating mlx-lm on M1 Ultra (text, >100%) | 36/40 (90%, 5-19 baseline) |
 | At 90%+ parity on M1 Ultra (text) | 40/40 (100%, 5-19 baseline) |
-| Beating mlx-lm on M5 Max (text, >=100%) | 23/67 (34%, 5-19 mlxcel vs 5-18 mlx-lm) |
-| At 90%+ parity on M5 Max (text) | 59/67 (88%, 5-19 mlxcel vs 5-18 mlx-lm) |
-| Average vs mlx-lm on M5 Max (text) | 96% decode speed (median 98%, 5-19 mlxcel vs 5-18 mlx-lm) |
-| Average vs mlx-vlm on M5 Max (VLM) | 95% decode speed (median 99%, 5-19 mlxcel vs 5-18 mlx-vlm; 19 pairs) |
+| Beating mlx-lm on M5 Max (text, >=100%) | 24/66 (36%, 5-19 mlxcel vs 5-18 mlx-lm) |
+| At 90%+ parity on M5 Max (text) | 58/66 (88%, 5-19 mlxcel vs 5-18 mlx-lm) |
+| Average vs mlx-lm on M5 Max (text) | 97% decode speed (median 99%, 5-19 mlxcel vs 5-18 mlx-lm) |
+| Average vs mlx-vlm on M5 Max (VLM) | 100% decode speed (median 100%, 20 comparable pairs) |
 
 ## Generating Benchmarks
 

--- a/docs/benchmark_results/model_tests_m5max.md
+++ b/docs/benchmark_results/model_tests_m5max.md
@@ -189,17 +189,17 @@ Compatibility and performance testing for mlxcel models on **MacBook Pro M5 Max 
 ## VLM (image input) — full sweep
 
 Below table reports the per-VLM-prompt run from `bench_decode.sh all --vlm`.
-All entries use the VLM prompt 'What is in this image?' (no image attached;
-result reflects text-only response throughput on the VLM code path).
+All entries use the VLM prompt 'What is in this image?' with
+`tests/fixtures/test_image.png`.
 
 | Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
 |-------|------------|--------|---------|--------|-------------|-------|
 | aya-vision-8b | aya-vision-8b | ✅ | 1616.46 | 112.09 | 1.02x | 84 tokens |
 | bunny-llama3-8b | bunny-llama3-8b-4bit | ✅ | 2851.65 | 112.24 | **1.17x** | 37 tokens |
 | gemma3 (4B) | gemma3-4b-4bit | ✅ | 567.95 | 127.61 | **1.69x** | 16 tokens |
-| gemma3n (E2B 4bit) | gemma3n-e2b-4bit | ❌ | - | FAIL | - | FAIL:bench; broadcast `(1,288,256) vs (1,273,256)` |
-| gemma3n (E4B 4bit) | gemma3n-e4b-4bit | ❌ | - | FAIL | - | FAIL:bench; broadcast `(1,288,256) vs (1,273,256)` |
-| gemma3n (E4B bf16) | gemma3n-e4b-bf16 | ❌ | - | FAIL | - | FAIL:bench; broadcast `(1,288,256) vs (1,273,256)`; bf16→f16 conversion path |
+| gemma3n (E2B 4bit) | gemma3n-e2b-4bit | ✅ | 2893.48 | 151.36 | **2.08x** | 29 tokens |
+| gemma3n (E4B 4bit) | gemma3n-e4b-4bit | ✅ | 2186.03 | 106.01 | **1.87x** | 33 tokens |
+| gemma3n (E4B bf16) | gemma3n-e4b-bf16 | ✅ | 2025.46 | 36.95 | **1.16x** | 24 tokens; bf16→f16 conversion path |
 | gemma4 (26B MoE) | gemma-4-26b-a4b-it-4bit | ✅ | 864.73 | 134.38 | **2.13x** | 30 tokens |
 | gemma4 (31B) | gemma-4-31b-4bit | ✅ | 430.80 | 23.41 | **1.51x** | 5 tokens |
 | gemma4 (31B IT) | gemma-4-31b-it-4bit | ✅ | 445.15 | 27.21 | **1.49x** | 28 tokens |
@@ -241,7 +241,7 @@ Source CSVs (same M5 Max host, mlxcel 0.0.28 with `--cooldown 15 --big-cooldown 
 
 - mlxcel: `benchmarks/metal_m5max_2026-05-19.csv`
 - mlx-lm: `benchmarks/pylm_m5max_2026-05-18.csv` (mlx-lm 0.31.3 dev checkout in `references/mlx-lm`)
-- mlxcel VLM: `benchmarks/metal_m5max_vlm_2026-05-19.csv`
+- mlxcel VLM: `benchmarks/metal_m5max_vlm_2026-05-19.csv`, `benchmarks/metal_m5max_vlm_2026-05-20.csv` (Gemma3n VLM entries)
 - mlx-vlm: `benchmarks/pylm_m5max_vlm_2026-05-18.csv` (mlx-vlm 0.4.4)
 
 The M5 Max baseline sub-sweeps ran as part of the same continuous benchmark
@@ -263,10 +263,10 @@ snapshot.
 
 ### Aggregate (VLM, models with >=5 generated tokens both sides)
 
-- **Comparable VLM pairs**: 17
-- **mlxcel >= mlx-vlm**: 7 / 17 (41%)
-- **mlxcel >= 90% parity**: 14 / 17 (82%)
-- **Average mlxcel/mlx-vlm**: 100% (median 100%, range 77%-123%)
+- **Comparable VLM pairs**: 20
+- **mlxcel >= mlx-vlm**: 9 / 20 (45%)
+- **mlxcel >= 90% parity**: 16 / 20 (80%)
+- **Average mlxcel/mlx-vlm**: 100% (median 100%, range 74%-123%)
 
 ### Text decode (tok/s)
 
@@ -385,9 +385,9 @@ snapshot.
 | gemma-4-e4b-it-4bit | 134.10 | 131.24 | **102%** |
 | gemma-4-e4b-it-8bit | 76.28 | 90.00 | 85% |
 | gemma3-4b-4bit | 127.61 | FAIL | - |
-| gemma3n-e2b-4bit | FAIL | 124.63 | - |
-| gemma3n-e4b-4bit | FAIL | 93.55 | - |
-| gemma3n-e4b-bf16 | FAIL | 49.88 | - |
+| gemma3n-e2b-4bit | 151.36 | 124.63 | **121%** |
+| gemma3n-e4b-4bit | 106.01 | 93.55 | **113%** |
+| gemma3n-e4b-bf16 | 36.95 | 49.88 | 74% |
 | internvl3-1b | FAIL | 529.33 | - |
 | llama-4-scout-17b-4bit | 48.33 | FAIL | - |
 | llava-1.5-7b-4bit | 117.70 | FAIL | - |

--- a/scripts/bench_decode.sh
+++ b/scripts/bench_decode.sh
@@ -11,9 +11,11 @@
 #   e.g. benchmarks/metal_m1ultra_2026-03-31.csv
 #   VLM: benchmarks/metal_m1ultra_vlm_2026-03-31.csv
 #
-# The script runs each model twice: a warmup pass (discarded) to preheat Metal
-# shader compilation and memory-mapping, followed by the measured pass.
-# Both passes use --profile for structured timing output.
+# The script uses `mlxcel-bench-decode` so each model is loaded once and the
+# warmup pass (discarded) and measured pass run in the same process. This keeps
+# Metal/MLX warm state alive for the measured prefill, matching the Python
+# `bench_mlxlm.py` harness and avoiding cold-prefill skew from two separate
+# `mlxcel generate` invocations.
 #
 # CSV columns (14):
 #   model, model_path, prompt_tokens, generated_tokens,
@@ -37,6 +39,7 @@ set -euo pipefail
 trap 'echo "Interrupted (signal received)" >&2; exit 130' INT TERM
 
 MLXCEL="./target/release/mlxcel"
+MLXCEL_BENCH="./target/release/mlxcel-bench-decode"
 MODELS_DIR="./models"
 BENCHMARKS_DIR="./benchmarks"
 TEXT_PROMPT="Hello, how are you today?"
@@ -47,6 +50,7 @@ TIMEOUT=300
 JIT_PREHEAT_TIMEOUT=600
 VLM_IMAGE="tests/fixtures/test_image.png"
 VLM_MODE=0
+NO_CHAT_TEMPLATE=0
 OUTPUT=""
 SUFFIX=""
 DATE=$(date '+%Y-%m-%d')
@@ -181,6 +185,9 @@ Options:
   --vlm               VLM mode (use image prompt)
   --image PATH        Image for VLM benchmark (default: tests/fixtures/test_image.png)
   --prompt TEXT        Override text prompt
+  --no-chat-template   Disable automatic chat template application in the
+                       mlxcel benchmark runner. Use this when comparing
+                       against raw-prompt mlx-lm stream_generate baselines.
   --max-tokens N      Max tokens to generate (default: 100)
   --warmup-tokens N   Tokens for warmup pass (default: 20)
   --timeout N         Timeout per run in seconds (default: 300)
@@ -290,29 +297,25 @@ bench_one() {
     extra_args+=(--image "$VLM_IMAGE")
   fi
 
-  # --- Warmup pass (preheat Metal shaders / CUDA JIT kernels & memory maps) ---
+  # --- Same-process warmup + measured pass ---
   # On CUDA, the first run of a model triggers JIT kernel compilation which can
-  # take several minutes. Use JIT_PREHEAT_TIMEOUT (default 600s) for the warmup
-  # pass so these models are not incorrectly marked as FAIL:warmup.
-  local warmup_timeout="$TIMEOUT"
+  # take several minutes. The bench runner performs warmup and measurement in a
+  # single process, so allow the CUDA run to consume both the JIT preheat budget
+  # and the normal measured-run budget.
+  local run_timeout="$TIMEOUT"
   if [[ "$BACKEND" == "cuda" ]]; then
-    warmup_timeout="$JIT_PREHEAT_TIMEOUT"
+    run_timeout=$((JIT_PREHEAT_TIMEOUT + TIMEOUT))
   fi
-  >&2 printf '>>> [warmup] %s ...\n' "$model_name"
-  if ! timeout "$warmup_timeout" "$MLXCEL" generate \
-      -m "$model_path" -p "$prompt" -n "$WARMUP_TOKENS" \
-      ${extra_args[@]+"${extra_args[@]}"} --profile >/dev/null 2>&1; then
-    >&2 echo "    warmup failed"
-    echo "${model_name},${model_path},,,,,,,$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\",FAIL:warmup"
-    return
+  if [[ "$NO_CHAT_TEMPLATE" -eq 1 ]]; then
+    extra_args+=(--no-chat-template)
   fi
 
-  # --- Measured pass ---
-  >&2 printf '>>> [bench]  %s ...\n' "$model_name"
+  >&2 printf '>>> [bench]  %s (same-process warmup=%s) ...\n' "$model_name" "$WARMUP_TOKENS"
   local raw
-  if ! raw=$(timeout "$TIMEOUT" "$MLXCEL" generate \
+  if ! raw=$(timeout "$run_timeout" "$MLXCEL_BENCH" \
       -m "$model_path" -p "$prompt" -n "$MAX_TOKENS" \
-      ${extra_args[@]+"${extra_args[@]}"} --profile 2>&1); then
+      --warmup-tokens "$WARMUP_TOKENS" \
+      ${extra_args[@]+"${extra_args[@]}"} 2>&1); then
     >&2 echo "    benchmark failed"
     echo "${model_name},${model_path},,,,,,,$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\",FAIL:bench"
     return
@@ -365,6 +368,7 @@ while [[ $# -gt 0 ]]; do
     --vlm)            VLM_MODE=1; shift ;;
     --image)          VLM_IMAGE="$2"; VLM_MODE=1; shift 2 ;;
     --prompt)         TEXT_PROMPT="$2"; shift 2 ;;
+    --no-chat-template) NO_CHAT_TEMPLATE=1; shift ;;
     --max-tokens)     MAX_TOKENS="$2"; shift 2 ;;
     --warmup-tokens)  WARMUP_TOKENS="$2"; shift 2 ;;
     --timeout)        TIMEOUT="$2"; shift 2 ;;
@@ -391,6 +395,10 @@ fi
 
 if [[ ! -x "$MLXCEL" ]]; then
   echo "Error: $MLXCEL not found. Run 'cargo build --release' first." >&2
+  exit 1
+fi
+if [[ ! -x "$MLXCEL_BENCH" ]]; then
+  echo "Error: $MLXCEL_BENCH not found. Run 'cargo build --release --bin mlxcel-bench-decode' first." >&2
   exit 1
 fi
 

--- a/scripts/bench_mlxlm.py
+++ b/scripts/bench_mlxlm.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""mlx-lm / mlx-vlm baseline sweep matching mlxcel's bench_decode.sh schema.
+
+Run modes:
+  ./scripts/bench_mlxlm.py all               # text sweep, all models
+  ./scripts/bench_mlxlm.py all --vlm         # VLM sweep, all models
+  ./scripts/bench_mlxlm.py models/<dir>      # single model
+
+Output CSV: benchmarks/pylm_<hw>_YYYY-MM-DD[ _vlm].csv
+
+Each model runs in a fresh Python subprocess for memory isolation and
+to survive crashes. Numbers come from mlx-lm / mlx-vlm's own
+`prompt_tps` / `generation_tps` fields on the final stream_generate
+response after a warmup pass.
+"""
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import date
+from pathlib import Path
+
+TEXT_PROMPT = "Hello, how are you today?"
+VLM_PROMPT = "What is in this image?"
+VLM_IMAGE = "tests/fixtures/test_image.png"
+MAX_TOKENS = 100
+WARMUP_TOKENS = 4
+MODELS_DIR = Path("./models")
+BENCHMARKS_DIR = Path("./benchmarks")
+# Memory budget: 85% of 128 GB. Override with PYLM_BENCH_MAX_GB env var to
+# enforce a tighter cap (e.g. PYLM_BENCH_MAX_GB=65 to skip very large MoE
+# models on a 128 GB host where 85% × 128 GB ≈ 108 GB still admits them).
+_env_max_gb = os.environ.get("PYLM_BENCH_MAX_GB")
+if _env_max_gb:
+    MEMORY_LIMIT_BYTES = int(float(_env_max_gb) * 1024 * 1024 * 1024)
+else:
+    MEMORY_LIMIT_BYTES = int(128 * 1024 * 1024 * 1024 * 0.85)
+# Thermal cooldown thresholds
+BIG_MODEL_GB = 20
+
+CSV_HEADER = (
+    "model,model_path,prompt_tokens,generated_tokens,"
+    "prefill_ms,prefill_tok_s,decode_ms,decode_tok_s,"
+    "date,hardware,mlx_version,build_type,max_tokens,prompt"
+)
+
+
+def detect_hardware():
+    try:
+        chip = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except Exception:
+        chip = "unknown"
+    mapping = {
+        "M1 Ultra": ("m1ultra", "Apple_M1_Ultra_128GB"),
+        "M1 Max": ("m1max", "Apple_M1_Max"),
+        "M2 Ultra": ("m2ultra", "Apple_M2_Ultra"),
+        "M3 Ultra": ("m3ultra", "Apple_M3_Ultra"),
+        "M3 Max": ("m3max", "Apple_M3_Max"),
+        "M4 Max": ("m4max", "Apple_M4_Max"),
+        "M5 Ultra": ("m5ultra", "Apple_M5_Ultra"),
+        "M5 Max": ("m5max", "Apple_M5_Max_128GB"),
+    }
+    for key, val in mapping.items():
+        if key in chip:
+            return val
+    return ("unknown", chip.replace(" ", "_"))
+
+
+def estimate_model_size(model_path: Path) -> int:
+    """Sum of safetensors file sizes (bytes). Tolerates broken symlinks."""
+    total = 0
+    for f in model_path.glob("*.safetensors"):
+        try:
+            total += f.stat().st_size
+        except (FileNotFoundError, OSError):
+            continue
+    return total
+
+
+def is_vlm(model_path: Path) -> bool:
+    """Detect VLM by config.json contents or preprocessor presence."""
+    cfg = model_path / "config.json"
+    if not cfg.exists():
+        return False
+    try:
+        with open(cfg) as f:
+            data = json.load(f)
+    except Exception:
+        return False
+    if "vision_config" in data or "image_processor_type" in data:
+        return True
+    archs = data.get("architectures", []) or []
+    VLM_ARCH_SUBSTR = (
+        "Llava", "PaliGemma", "Qwen2VL", "Qwen2_5_VL", "Qwen3VL",
+        "Idefics", "Pixtral", "Bunny", "Phi3V", "Phi35V", "AyaVision",
+        "Gemma3ForConditional", "Gemma4ForConditional", "Mllama",
+        "Mistral3", "Llama4", "MolmoForCausalLM", "Molmo", "InternVL",
+        "GotOcr", "Smolvlm", "Florence", "Kimi",
+    )
+    for a in archs:
+        if any(sub in a for sub in VLM_ARCH_SUBSTR):
+            return True
+    # Has image preprocessor → likely VLM
+    if (model_path / "preprocessor_config.json").exists():
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Single-model benchmark subprocess code
+# ---------------------------------------------------------------------------
+
+SUBPROCESS_TEXT_CODE = """
+import json, sys, time
+from mlx_lm import load, stream_generate
+
+model_path = sys.argv[1]
+prompt = sys.argv[2]
+warmup_tokens = int(sys.argv[3])
+max_tokens = int(sys.argv[4])
+
+try:
+    model, tokenizer = load(model_path, tokenizer_config={'trust_remote_code': True})
+except Exception as e:
+    print('ERROR load:', repr(e), file=sys.stderr)
+    sys.exit(2)
+
+# Warmup
+try:
+    for _ in stream_generate(model, tokenizer, prompt=prompt, max_tokens=warmup_tokens):
+        pass
+except Exception as e:
+    print('ERROR warmup:', repr(e), file=sys.stderr)
+    sys.exit(3)
+
+# Measured pass
+last = None
+try:
+    for r in stream_generate(model, tokenizer, prompt=prompt, max_tokens=max_tokens):
+        last = r
+except Exception as e:
+    print('ERROR bench:', repr(e), file=sys.stderr)
+    sys.exit(4)
+
+if last is None:
+    print('ERROR no_output', file=sys.stderr)
+    sys.exit(5)
+
+result = {
+    'prompt_tokens': getattr(last, 'prompt_tokens', None),
+    'prefill_tps': getattr(last, 'prompt_tps', None),
+    'gen_tokens': getattr(last, 'generation_tokens', None),
+    'decode_tps': getattr(last, 'generation_tps', None),
+    'finish_reason': getattr(last, 'finish_reason', None),
+}
+print('RESULT', json.dumps(result))
+"""
+
+SUBPROCESS_VLM_CODE = """
+import json, sys, time
+from mlx_vlm import load, stream_generate
+from mlx_vlm.prompt_utils import apply_chat_template
+from mlx_vlm.utils import load_config
+
+model_path = sys.argv[1]
+prompt_text = sys.argv[2]
+warmup_tokens = int(sys.argv[3])
+max_tokens = int(sys.argv[4])
+image_path = sys.argv[5]
+
+try:
+    model, processor = load(model_path)
+except Exception as e:
+    print('ERROR load:', repr(e), file=sys.stderr)
+    sys.exit(2)
+
+try:
+    config = load_config(model_path)
+    formatted_prompt = apply_chat_template(processor, config, prompt_text, num_images=1)
+except Exception as e:
+    # Fallback: use raw prompt
+    formatted_prompt = prompt_text
+
+# Warmup
+try:
+    for _ in stream_generate(model, processor, prompt=formatted_prompt, image=image_path, max_tokens=warmup_tokens):
+        pass
+except Exception as e:
+    print('ERROR warmup:', repr(e), file=sys.stderr)
+    sys.exit(3)
+
+last = None
+try:
+    for r in stream_generate(model, processor, prompt=formatted_prompt, image=image_path, max_tokens=max_tokens):
+        last = r
+except Exception as e:
+    print('ERROR bench:', repr(e), file=sys.stderr)
+    sys.exit(4)
+
+if last is None:
+    print('ERROR no_output', file=sys.stderr)
+    sys.exit(5)
+
+# mlx-vlm GenerationResult vs mlx-lm GenerationResponse — slightly different fields
+result = {
+    'prompt_tokens': getattr(last, 'prompt_tokens', None),
+    'prefill_tps': getattr(last, 'prompt_tps', None),
+    'gen_tokens': getattr(last, 'generation_tokens', None),
+    'decode_tps': getattr(last, 'generation_tps', None),
+}
+print('RESULT', json.dumps(result))
+"""
+
+
+def bench_one(model_path: Path, vlm: bool, vlm_image: str, max_tokens: int,
+              warmup_tokens: int, timeout: int):
+    """Returns (status, fields_dict_or_None)."""
+    if vlm:
+        prompt = VLM_PROMPT
+        code = SUBPROCESS_VLM_CODE
+        args = [
+            "python3", "-c", code,
+            str(model_path), prompt, str(warmup_tokens), str(max_tokens), vlm_image,
+        ]
+    else:
+        prompt = TEXT_PROMPT
+        code = SUBPROCESS_TEXT_CODE
+        args = [
+            "python3", "-c", code,
+            str(model_path), prompt, str(warmup_tokens), str(max_tokens),
+        ]
+
+    try:
+        proc = subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return ("FAIL:timeout", None)
+
+    if proc.returncode == 0:
+        for line in proc.stdout.splitlines():
+            if line.startswith("RESULT "):
+                try:
+                    data = json.loads(line[len("RESULT "):])
+                    return ("OK", data)
+                except json.JSONDecodeError:
+                    pass
+        return ("FAIL:no_result", None)
+
+    # Map exit codes to FAIL types matching bench_decode.sh
+    code_to_status = {2: "FAIL:warmup", 3: "FAIL:warmup", 4: "FAIL:bench", 5: "FAIL:no_output"}
+    return (code_to_status.get(proc.returncode, "FAIL:exit"), None)
+
+
+# ---------------------------------------------------------------------------
+# Sweep driver
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("model", help='"all" for sweep, or models/<dir> for single')
+    ap.add_argument("--vlm", action="store_true", help="VLM mode (use image prompt)")
+    ap.add_argument("--image", default=VLM_IMAGE, help=f"VLM image (default: {VLM_IMAGE})")
+    ap.add_argument("--cooldown", type=int, default=30, help="Seconds between models (default: 30)")
+    ap.add_argument("--big-cooldown", type=int, default=30, help="Seconds after big model (default: 30)")
+    ap.add_argument("--big-threshold-gb", type=float, default=BIG_MODEL_GB)
+    ap.add_argument("--max-tokens", type=int, default=MAX_TOKENS)
+    ap.add_argument("--warmup-tokens", type=int, default=WARMUP_TOKENS)
+    ap.add_argument("--timeout", type=int, default=600, help="Per-model seconds (default: 600)")
+    ap.add_argument("--suffix", default="", help="Optional CSV filename suffix")
+    args = ap.parse_args()
+
+    hw_short, hw_full = detect_hardware()
+    today = date.today().isoformat()
+    # Get versions
+    try:
+        import mlx_lm, mlx_vlm
+        if args.vlm:
+            mlx_version = f"mlx-vlm-{mlx_vlm.__version__}"
+        else:
+            mlx_version = f"mlx-lm-{mlx_lm.__version__}"
+    except Exception:
+        mlx_version = "unknown"
+
+    # Filename: pylm_<hw>_<date>[_vlm][_<suffix>].csv
+    parts = ["pylm", hw_short, today]
+    if args.vlm:
+        parts.insert(2, "vlm")
+    name = "_".join(parts)
+    if args.suffix:
+        name = f"{name}_{args.suffix}"
+    if args.model != "all":
+        single = Path(args.model).name
+        name = f"{name}_single_{single}"
+    csv_path = BENCHMARKS_DIR / f"{name}.csv"
+    BENCHMARKS_DIR.mkdir(exist_ok=True)
+
+    # Discover models
+    if args.model == "all":
+        model_dirs = sorted(p for p in MODELS_DIR.iterdir() if p.is_dir())
+    else:
+        p = Path(args.model)
+        if not p.is_dir():
+            sys.exit(f"Error: {p} is not a directory")
+        model_dirs = [p]
+
+    # VLM image check
+    if args.vlm and not Path(args.image).exists():
+        sys.exit(f"Error: VLM image not found at {args.image}")
+
+    big_threshold_bytes = int(args.big_threshold_gb * 1024**3)
+
+    # Resume: skip models already in the CSV
+    already_done = set()
+    if csv_path.exists():
+        with open(csv_path) as f:
+            reader = csv.reader(f)
+            header = next(reader, None)
+            for row in reader:
+                if row and row[0]:
+                    already_done.add(row[0])
+        print(f">>> Resume: {len(already_done)} models already in {csv_path}", file=sys.stderr)
+    else:
+        with open(csv_path, "w") as f:
+            f.write(CSV_HEADER + "\n")
+
+    def append_row(line: str):
+        with open(csv_path, "a") as f:
+            f.write(line + "\n")
+
+    for i, mdir in enumerate(model_dirs, 1):
+        if mdir.name in already_done:
+            print(f">>> [{i}/{len(model_dirs)}] [skip-done] {mdir.name}", file=sys.stderr)
+            continue
+        name = mdir.name
+        size = estimate_model_size(mdir)
+        size_gb = size / 1024**3
+
+        # OOM guard (same as bench_decode.sh)
+        if size > MEMORY_LIMIT_BYTES:
+            print(f">>> [skip]   {name} ({size_gb:.1f} GB > {MEMORY_LIMIT_BYTES/1024**3:.1f} GB limit)", file=sys.stderr)
+            prompt = VLM_PROMPT if args.vlm else TEXT_PROMPT
+            append_row(f'{name},./{mdir}/,,,,,,,{today},{hw_full},{mlx_version},python,{args.max_tokens},"{prompt}",SKIP:oom_estimate')
+            continue
+
+        print(f">>> [{i}/{len(model_dirs)}] [warmup+bench] {name} ({size_gb:.1f} GB) ...", file=sys.stderr)
+        t0 = time.perf_counter()
+        status, fields = bench_one(
+            mdir, vlm=args.vlm, vlm_image=args.image,
+            max_tokens=args.max_tokens, warmup_tokens=args.warmup_tokens,
+            timeout=args.timeout,
+        )
+        elapsed = time.perf_counter() - t0
+        prompt = VLM_PROMPT if args.vlm else TEXT_PROMPT
+
+        if status != "OK":
+            print(f"    {status} ({elapsed:.1f}s)", file=sys.stderr)
+            append_row(f'{name},./{mdir}/,,,,,,,{today},{hw_full},{mlx_version},python,{args.max_tokens},"{prompt}",{status}')
+        else:
+            f = fields
+            pt = f.get("prompt_tokens") or ""
+            gt = f.get("gen_tokens") or ""
+            pre_tps = f.get("prefill_tps")
+            dec_tps = f.get("decode_tps")
+            pre_ms = ""
+            dec_ms = ""
+            if pre_tps and pt:
+                try:
+                    pre_ms = f"{(int(pt) / float(pre_tps)) * 1000:.2f}"
+                except Exception:
+                    pass
+            if dec_tps and gt:
+                try:
+                    dec_ms = f"{(int(gt) / float(dec_tps)) * 1000:.2f}"
+                except Exception:
+                    pass
+            pre_tps_s = f"{pre_tps:.2f}" if pre_tps else ""
+            dec_tps_s = f"{dec_tps:.2f}" if dec_tps else ""
+            print(f"    decode: {dec_tps_s} tok/s ({elapsed:.1f}s)", file=sys.stderr)
+            append_row(
+                f'{name},./{mdir}/,{pt},{gt},{pre_ms},{pre_tps_s},{dec_ms},{dec_tps_s},'
+                f'{today},{hw_full},{mlx_version},python,{args.max_tokens},"{prompt}"'
+            )
+
+        # Cooldown
+        if i < len(model_dirs):
+            cd = args.big_cooldown if size > big_threshold_bytes else args.cooldown
+            if cd > 0:
+                print(f"    cooldown: {cd}s", file=sys.stderr)
+                time.sleep(cd)
+
+    print(f"\nResults saved to: {csv_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bin/bench_decode.rs
+++ b/src/bin/bench_decode.rs
@@ -1,0 +1,335 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Same-process decode benchmark harness.
+//!
+//! `scripts/bench_decode.sh` compares mlxcel against Python `mlx-lm` /
+//! `mlx-vlm` baselines collected by `scripts/bench_mlxlm.py`.  The Python
+//! harness loads the model once, performs warmup, and then measures
+//! `stream_generate()` in the same process.  Shelling out to
+//! `mlxcel generate` twice makes the measured prefill path cold again, which
+//! disproportionately penalizes one-shot prefill timings while leaving the
+//! multi-token decode loop mostly amortized.
+//!
+//! This binary keeps the CLI-facing prompt/VLM preparation semantics but runs
+//! warmup and measured generation against one loaded model in one process.
+
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use mlxcel::cli::turbo_args::{TurboKvCacheArgs, resolve_kv_cache_mode};
+use mlxcel::sampling::{ResolvedSamplingParams, build_sampling_config};
+use mlxcel::server::chat_template::{ChatMessage, ChatTemplateProcessor};
+use mlxcel::tokenizer::{MlxcelTokenizer, load_tokenizer};
+use mlxcel::vision::merge::InputEmbeddings;
+use mlxcel::{CxxGenerator, LanguageModel, LoadedModel, SamplingConfig};
+use mlxcel_core::cache::KVCacheMode;
+
+/// Same-process benchmark for `scripts/bench_decode.sh`.
+#[derive(Parser, Debug)]
+#[command(name = "mlxcel-bench-decode")]
+struct Args {
+    /// Path to the model directory.
+    #[arg(short = 'm', long)]
+    model: PathBuf,
+
+    /// Prompt text.
+    #[arg(short = 'p', long)]
+    prompt: String,
+
+    /// Maximum generated tokens in the measured pass.
+    #[arg(short = 'n', long, default_value_t = 100)]
+    max_tokens: usize,
+
+    /// Generated tokens in the warmup pass.
+    #[arg(long, default_value_t = 20)]
+    warmup_tokens: usize,
+
+    /// Image path(s) for VLM benchmark mode.
+    #[arg(long, value_name = "PATH", num_args = 1..)]
+    image: Vec<PathBuf>,
+
+    /// Disable automatic chat-template application.
+    #[arg(long, default_value_t = false)]
+    no_chat_template: bool,
+
+    /// Shared KV-cache mode flags, matching `mlxcel generate`.
+    #[command(flatten)]
+    turbo: TurboKvCacheArgs,
+}
+
+struct PreparedPrompt {
+    tokens: Vec<i32>,
+    embeddings: Option<InputEmbeddings>,
+}
+
+fn apply_user_chat_template(processor: &ChatTemplateProcessor, user_prompt: &str) -> String {
+    let messages = [ChatMessage {
+        role: "user".to_string(),
+        content: user_prompt.to_string(),
+    }];
+    processor
+        .apply(&messages, None)
+        .unwrap_or_else(|_| user_prompt.to_string())
+}
+
+fn apply_vlm_chat_template(
+    processor: &ChatTemplateProcessor,
+    user_prompt: &str,
+    num_images: usize,
+) -> String {
+    if !processor.supports_image_content() {
+        return apply_user_chat_template(processor, user_prompt);
+    }
+
+    let mut content_parts: Vec<serde_json::Value> = Vec::new();
+    for _ in 0..num_images {
+        content_parts.push(serde_json::json!({"type": "image"}));
+    }
+    content_parts.push(serde_json::json!({"type": "text", "text": user_prompt}));
+
+    let messages = serde_json::json!([{
+        "role": "user",
+        "content": content_parts,
+    }]);
+
+    processor
+        .apply_raw(&messages, None)
+        .unwrap_or_else(|_| apply_user_chat_template(processor, user_prompt))
+}
+
+fn load_cli_prompt(
+    model_path: &Path,
+    user_prompt: &str,
+    no_chat_template: bool,
+    num_images: usize,
+) -> String {
+    if no_chat_template {
+        return user_prompt.to_string();
+    }
+
+    let processor = ChatTemplateProcessor::from_model_path(model_path)
+        .ok()
+        .flatten();
+    processor.map_or_else(
+        || user_prompt.to_string(),
+        |processor| {
+            if num_images > 0 {
+                apply_vlm_chat_template(&processor, user_prompt, num_images)
+            } else {
+                apply_user_chat_template(&processor, user_prompt)
+            }
+        },
+    )
+}
+
+fn tokenize_prompt(tokenizer: &MlxcelTokenizer, prompt: &str) -> Result<Vec<i32>> {
+    // Matches the CLI generate path: chat templates that render a BOS token
+    // should not receive a duplicate special token from the tokenizer.
+    let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
+    let ids = tokenizer
+        .encode(prompt, add_special)
+        .map_err(|err| anyhow::anyhow!("tokenization failed: {err}"))?;
+    Ok(ids.into_iter().map(|id| id as i32).collect())
+}
+
+fn prepare_prompt(
+    model: &LoadedModel,
+    model_path: &Path,
+    tokenizer: &MlxcelTokenizer,
+    user_prompt: &str,
+    no_chat_template: bool,
+    image_paths: &[PathBuf],
+) -> Result<PreparedPrompt> {
+    let prompt = load_cli_prompt(model_path, user_prompt, no_chat_template, image_paths.len());
+    let mut tokens = tokenize_prompt(tokenizer, &prompt)?;
+
+    if image_paths.is_empty() {
+        return Ok(PreparedPrompt {
+            tokens,
+            embeddings: None,
+        });
+    }
+
+    let images = image_paths
+        .iter()
+        .map(|path| {
+            image::open(path).with_context(|| format!("failed to load image {}", path.display()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let prepared = mlxcel::vlm_runtime::prepare_and_compute_vlm_embeddings(
+        model,
+        &mut tokens,
+        &prompt,
+        &images,
+        |text, add_special| {
+            tokenizer
+                .encode(text, add_special)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|id| id as i32)
+                .collect()
+        },
+    )?;
+
+    Ok(PreparedPrompt {
+        tokens,
+        embeddings: prepared.map(|prepared| prepared.embeddings),
+    })
+}
+
+fn sampling_config(model_path: &Path) -> SamplingConfig {
+    build_sampling_config(ResolvedSamplingParams {
+        temperature: 0.0,
+        top_k: 0,
+        top_p: 1.0,
+        min_p: 0.0,
+        seed: None,
+        repetition_penalty: 1.0,
+        dry_multiplier: 0.0,
+        dry_base: 1.75,
+        dry_allowed_length: 2,
+        dry_penalty_last_n: 0,
+        dry_sequence_breakers: Vec::new(),
+        frequency_penalty: 0.0,
+        presence_penalty: 0.0,
+        stop_token_ids: mlxcel::read_eos_token_ids(model_path),
+    })
+}
+
+fn warmup(
+    model: &LoadedModel,
+    prepared: &PreparedPrompt,
+    max_tokens: usize,
+    sampling: &SamplingConfig,
+    kv_cache_mode: KVCacheMode,
+) -> Result<()> {
+    if max_tokens == 0 {
+        return Ok(());
+    }
+
+    let mut generator = CxxGenerator::new_with_kv_mode(model.num_layers(), kv_cache_mode);
+    if let Some(embeddings) = prepared.embeddings.as_ref() {
+        let (input_embeds, mask) = mlxcel::vlm_runtime::prepared_embedding_refs(embeddings)?;
+        let _ = generator.generate_streaming_with_embeddings(
+            model,
+            &prepared.tokens,
+            Some(input_embeds),
+            mask,
+            max_tokens,
+            sampling,
+            |_| true,
+        );
+    } else {
+        let _ = generator.generate(model, &prepared.tokens, max_tokens, sampling);
+    }
+
+    // Reset any model-owned cache state (hybrid/recurrent models) before the
+    // measured pass.  Keeping the process alive preserves MLX/Metal warm state
+    // while avoiding semantic leakage from the warmup generation.
+    generator.reset_with_model(model);
+    mlxcel_core::synchronize_default();
+    Ok(())
+}
+
+fn measured(
+    model: &LoadedModel,
+    prepared: &PreparedPrompt,
+    max_tokens: usize,
+    sampling: &SamplingConfig,
+    kv_cache_mode: KVCacheMode,
+) -> Result<mlxcel::GenerationStats> {
+    let mut generator = CxxGenerator::new_with_kv_mode(model.num_layers(), kv_cache_mode);
+    let (_tokens, stats) = if let Some(embeddings) = prepared.embeddings.as_ref() {
+        let (input_embeds, mask) = mlxcel::vlm_runtime::prepared_embedding_refs(embeddings)?;
+        generator.generate_with_stats_and_embeddings(
+            model,
+            &prepared.tokens,
+            Some(input_embeds),
+            mask,
+            max_tokens,
+            sampling,
+        )
+    } else {
+        generator.generate_with_stats(model, &prepared.tokens, max_tokens, sampling)
+    };
+    mlxcel_core::synchronize_default();
+    Ok(stats)
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let kv_cache_mode = resolve_kv_cache_mode(
+        args.turbo.cache_type_k.as_deref(),
+        args.turbo.cache_type_v.as_deref(),
+        args.turbo.kv_cache_mode.as_deref(),
+    )
+    .map_err(|err| anyhow::anyhow!("{err}"))?;
+
+    // Keep `--turbo-boundary-v` semantics identical to `mlxcel generate`.
+    // This must happen before any generator/cache construction.
+    args.turbo.apply_to_environment();
+
+    let _runtime = mlxcel::initialize_runtime();
+    mlxcel_core::synchronize_default();
+    mlxcel_core::clear_memory_cache();
+
+    let (model, loaded_tokenizer) =
+        mlxcel::load_model(&args.model).context("failed to load model")?;
+    let tokenizer = load_tokenizer(&args.model).unwrap_or(loaded_tokenizer);
+    let sampling = sampling_config(&args.model);
+
+    let prepared = prepare_prompt(
+        &model,
+        &args.model,
+        &tokenizer,
+        &args.prompt,
+        args.no_chat_template,
+        &args.image,
+    )?;
+    warmup(
+        &model,
+        &prepared,
+        args.warmup_tokens,
+        &sampling,
+        kv_cache_mode,
+    )?;
+    drop(prepared);
+
+    // Some VLM models store single-use state on the model during prepare_prompt
+    // (e.g., Gemma 3n caches per_layer_inputs that the first prefill takes()
+    // and Gemma 3 carries an attention-mask shape that only matches the first
+    // call). The warmup pass consumes that state, so regenerate the prepared
+    // prompt before the measured pass. For text-only models this is cheap; for
+    // VLM it re-runs the vision encoder against now-warm MLX/Metal state.
+    let prepared = prepare_prompt(
+        &model,
+        &args.model,
+        &tokenizer,
+        &args.prompt,
+        args.no_chat_template,
+        &args.image,
+    )?;
+    let stats = measured(&model, &prepared, args.max_tokens, &sampling, kv_cache_mode)?;
+
+    println!("[Profile Results]");
+    stats.print();
+    io::stdout().flush()?;
+
+    mlxcel_core::clear_memory_cache();
+    Ok(())
+}

--- a/src/vision/gemma3n_vl.rs
+++ b/src/vision/gemma3n_vl.rs
@@ -121,6 +121,34 @@ impl Gemma3nVLModel {
 
         merged
     }
+
+    fn align_per_layer_inputs_to_embeddings(
+        per_layer_inputs: &MlxArray,
+        input_embeddings: &MlxArray,
+    ) -> Option<UniquePtr<MlxArray>> {
+        let pli_shape = mlxcel_core::array_shape(per_layer_inputs);
+        let embed_shape = mlxcel_core::array_shape(input_embeddings);
+        let current_seq = pli_shape[1];
+        let target_seq = embed_shape[1];
+
+        if current_seq == target_seq {
+            return None;
+        }
+
+        if current_seq > target_seq {
+            return Some(mlxcel_core::slice(
+                per_layer_inputs,
+                &[0, 0, 0, 0],
+                &[pli_shape[0], target_seq, pli_shape[2], pli_shape[3]],
+            ));
+        }
+
+        let pad_rows = target_seq - current_seq;
+        let dtype = mlxcel_core::array_dtype(per_layer_inputs);
+        let padding =
+            mlxcel_core::zeros(&[pli_shape[0], pad_rows, pli_shape[2], pli_shape[3]], dtype);
+        Some(mlxcel_core::concatenate(per_layer_inputs, &padding, 1))
+    }
 }
 
 impl LanguageModel for Gemma3nVLModel {
@@ -143,9 +171,17 @@ impl LanguageModel for Gemma3nVLModel {
         if let Some(embeds) = input_embeddings {
             // VLM prefill: use cached per_layer_inputs
             let pli = self.cached_per_layer_inputs.borrow_mut().take().unwrap();
+            // Issue #736: M5 tile-aligned prefill pads the token stream and
+            // merged embeddings to an NA tile length. The projected
+            // per-layer tensor is produced before that generic padding step,
+            // so align it here before Gemma3n's per-layer blend.
+            let aligned_pli = Self::align_per_layer_inputs_to_embeddings(&pli, embeds);
+            let pli_ref = aligned_pli
+                .as_ref()
+                .map_or_else(|| pli.as_ref().unwrap(), |array| array.as_ref().unwrap());
             self.text_model
                 .language_model
-                .forward_with_inputs(embeds, &pli, caches)
+                .forward_with_inputs(embeds, pli_ref, caches)
         } else {
             self.text_model.language_model.forward(input_ids, caches)
         }
@@ -165,5 +201,45 @@ impl LanguageModel for Gemma3nVLModel {
 
     fn eos_token_ids(&self) -> Vec<i32> {
         mlxcel_core::generate::LanguageModel::eos_token_ids(&self.text_model)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Gemma3nVLModel;
+
+    #[test]
+    fn align_per_layer_inputs_pads_to_embedding_sequence_length() {
+        let per_layer_inputs = mlxcel_core::zeros(&[1, 273, 2, 256], mlxcel_core::dtype::FLOAT32);
+        let embeddings = mlxcel_core::zeros(&[1, 288, 128], mlxcel_core::dtype::FLOAT32);
+
+        let aligned =
+            Gemma3nVLModel::align_per_layer_inputs_to_embeddings(&per_layer_inputs, &embeddings)
+                .expect("expected padding for shorter per_layer_inputs");
+
+        assert_eq!(mlxcel_core::array_shape(&aligned), vec![1, 288, 2, 256]);
+    }
+
+    #[test]
+    fn align_per_layer_inputs_slices_to_embedding_sequence_length() {
+        let per_layer_inputs = mlxcel_core::zeros(&[1, 288, 2, 256], mlxcel_core::dtype::FLOAT32);
+        let embeddings = mlxcel_core::zeros(&[1, 273, 128], mlxcel_core::dtype::FLOAT32);
+
+        let aligned =
+            Gemma3nVLModel::align_per_layer_inputs_to_embeddings(&per_layer_inputs, &embeddings)
+                .expect("expected slicing for longer per_layer_inputs");
+
+        assert_eq!(mlxcel_core::array_shape(&aligned), vec![1, 273, 2, 256]);
+    }
+
+    #[test]
+    fn align_per_layer_inputs_leaves_matching_sequence_length_untouched() {
+        let per_layer_inputs = mlxcel_core::zeros(&[1, 273, 2, 256], mlxcel_core::dtype::FLOAT32);
+        let embeddings = mlxcel_core::zeros(&[1, 273, 128], mlxcel_core::dtype::FLOAT32);
+
+        let aligned =
+            Gemma3nVLModel::align_per_layer_inputs_to_embeddings(&per_layer_inputs, &embeddings);
+
+        assert!(aligned.is_none());
     }
 }

--- a/tests/vlm_concurrency.rs
+++ b/tests/vlm_concurrency.rs
@@ -37,6 +37,7 @@ use base64::Engine as _;
 use common::{repo_binary_path, repo_model_dir};
 
 const GEMMA3N_E2B_MODEL: &str = "gemma3n-e2b-4bit";
+const GEMMA3N_E4B_MODEL: &str = "gemma3n-e4b-4bit";
 
 fn reserve_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
@@ -119,6 +120,44 @@ async fn post_vlm_chat(
 
 fn has_chat_choice(response: &serde_json::Value) -> bool {
     response["choices"][0]["message"]["content"].is_string()
+}
+
+#[test]
+#[ignore = "requires local Gemma 3n VLM weights and the mlxcel-bench-decode binary"]
+fn gemma3n_vlm_single_row_bench_prefill_accepts_m5_tile_padding() {
+    let model_dir = repo_model_dir(GEMMA3N_E4B_MODEL);
+    if !model_dir.exists() {
+        eprintln!(
+            "Skipping test: model directory not found at {}",
+            model_dir.display()
+        );
+        return;
+    }
+
+    let model_arg = model_dir.to_string_lossy().to_string();
+    let image_arg = fixture_image_path().to_string_lossy().to_string();
+    let output = Command::new(repo_binary_path("mlxcel-bench-decode"))
+        .args([
+            "-m",
+            &model_arg,
+            "-p",
+            "What is in this image?",
+            "--image",
+            &image_arg,
+            "-n",
+            "4",
+            "--warmup-tokens",
+            "20",
+        ])
+        .output()
+        .expect("run mlxcel-bench-decode");
+
+    assert!(
+        output.status.success(),
+        "single-row Gemma 3n VLM prefill failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #35 — Gemma 3n VLM single-row prefill aborted with a `[broadcast_shapes]` mismatch (e.g. `(1,288,256)` vs `(1,273,256)`) whenever the prefill path padded the token stream and merged embeddings up to a tile-aligned length. The projected per-layer-inputs tensor is captured in `get_input_embeddings` before that generic padding step, so the per-layer blend in `forward_with_embeddings` tried to broadcast the unpadded per-layer tensor against the padded embeddings and threw.

## Fix

- Add `Gemma3nVLModel::align_per_layer_inputs_to_embeddings`: pads the per-layer tensor with zeros when shorter than the embeddings sequence, slices when longer, and returns `None` (no clone) when they already match.
- The VLM prefill path runs the cached per-layer tensor through this helper before `forward_with_inputs`, so a tile-padded embedding stream no longer mismatches the per-layer blend.

## Tooling (`mlxcel-bench-decode`)

- Port the `mlxcel-bench-decode` same-process benchmark harness: load the model once, run warmup, reset model/cache state, then run the measured pass in the same process — mirroring Python `stream_generate` timing far better than two cold `mlxcel generate` invocations.
- Rewrite `scripts/bench_decode.sh` to drive this binary (single load, `--no-chat-template` passthrough, combined warmup+measured timeout).
- Add `scripts/bench_mlxlm.py` as the matching `mlx-lm` / `mlx-vlm` baseline sweep.

## Docs

- Refresh the README parity tables and M5 Max benchmark docs: the three Gemma 3n VLM rows move from FAIL (broadcast abort) to passing decode throughput, and a Gemma 3n E2B row joins the representative decode table.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --features metal,accelerate --all-targets -- -D warnings`
- [x] `cargo build --release --features metal,accelerate --bin mlxcel-bench-decode` (binary links)
- [x] `align_per_layer_inputs_*` unit tests (pad / slice / no-op) — 3 passed
- [ ] `gemma3n_vlm_single_row_bench_prefill_accepts_m5_tile_padding` — ignored, weight-gated; run locally with `cargo test --release --test vlm_concurrency -- --ignored` against a Gemma 3n VLM checkpoint