### PR TITLE
fix(perf): speed up Phi-3.5 SuScaledRoPE decode

### DIFF
--- a/docs/benchmark_results/model_tests.md
+++ b/docs/benchmark_results/model_tests.md
@@ -22,7 +22,7 @@ Current source-of-truth data lives in `benchmarks/`:
 |-----|----------|------|------|
 | `metal_m5max_2026-05-19.csv` | M5 Max | 2026-05-19 (mlxcel 0.0.28, MLX 0.31.2) | Text |
 | `metal_m5max_vlm_2026-05-19.csv` | M5 Max | 2026-05-19 (mlxcel 0.0.28, MLX 0.31.2) | VLM |
-| `metal_m5max_vlm_2026-05-20.csv` | M5 Max | 2026-05-20 (mlxcel 0.0.28, MLX 0.31.2; Gemma3n + Molmo v1 VLM entries) | VLM |
+| `metal_m5max_vlm_2026-05-20.csv` | M5 Max | 2026-05-20 (mlxcel 0.0.28, MLX 0.31.2; Gemma3n + Molmo v1 + Phi-3.5 vision VLM entries) | VLM |
 | `pylm_m5max_2026-05-18.csv` | M5 Max | 2026-05-19 benchmark campaign (mlx-lm 0.31.3 baseline; CSV date crossed midnight) | Text |
 | `pylm_m5max_vlm_2026-05-18.csv` | M5 Max | 2026-05-19 benchmark campaign (mlx-vlm 0.4.4 baseline; CSV date crossed midnight) | VLM |
 | `metal_m1ultra_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlxcel 0.0.28, MLX commit 84961223; >65GB skipped) | Text |

--- a/docs/benchmark_results/model_tests_m5max.md
+++ b/docs/benchmark_results/model_tests_m5max.md
@@ -14,7 +14,7 @@ Compatibility and performance testing for mlxcel models on **MacBook Pro M5 Max 
 | **mlx-vlm baseline** | 0.4.4 |
 | **Test Prompt** | "Hello, how are you today?" (text) / "What is in this image?" (VLM) |
 | **Max Tokens** | 100 |
-| **Test Date** | 2026-05-19 full sweep; 2026-05-20 Molmo v1 spot-check |
+| **Test Date** | 2026-05-19 full sweep; 2026-05-20 Molmo v1 spot-check; 2026-05-20 Phi-3.5 spot-check |
 | **Benchmark Status** | Full text + VLM sweep on mlxcel using `mlxcel-bench-decode`, 98 text + 98 VLM-mode passes with `--cooldown 15 --big-cooldown 15`. mlx-lm / mlx-vlm baseline sub-sweeps are from the same benchmark campaign; their CSV filenames carry 2026-05-18 because the run crossed calendar midnight. |
 
 ## Legend
@@ -106,11 +106,11 @@ Compatibility and performance testing for mlxcel models on **MacBook Pro M5 Max 
 | Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
 |-------|------------|--------|---------|--------|-------------|-------|
 | phi-2 | phi-2-hf-4bit-mlx | ⚠️ | 391.64 | 79.60 | **1.34x** | 1 tokens; (likely EOS) |
-| phi-3-mini | Phi-3-mini-4k-instruct-4bit | ✅ | 585.90 | 207.58 | **1.23x** | 25 tokens |
-| phi-3.5-mini | Phi-3.5-mini-instruct-4bit | ✅ | 525.72 | 164.03 | **1.36x** | 40 tokens |
-| phi-3.5-moe | Phi-3.5-MoE-instruct-4bit | ✅ | 99.32 | 115.14 | **1.51x** | 100 tokens |
-| phi-3.5-vision | Phi-3.5-vision-instruct-4bit | ✅ | 788.84 | 163.61 | **1.34x** | 43 tokens; text-only |
-| phi-4 | Phi-4-4bit | ✅ | 248.97 | 63.78 | **1.11x** | 100 tokens |
+| phi-3-mini | Phi-3-mini-4k-instruct-4bit | ✅ | 586.96 | 207.89 | **1.23x** | 25 tokens |
+| phi-3.5-mini | Phi-3.5-mini-instruct-4bit | ✅ | 578.85 | 204.63 | **1.70x** | 40 tokens |
+| phi-3.5-moe | Phi-3.5-MoE-instruct-4bit | ✅ | 99.27 | 115.20 | **1.51x** | 100 tokens |
+| phi-3.5-vision | Phi-3.5-vision-instruct-4bit | ✅ | 868.19 | 203.14 | **1.66x** | 43 tokens; text-only |
+| phi-4 | Phi-4-4bit | ✅ | 250.99 | 63.86 | **1.11x** | 100 tokens |
 
 ## OLMo Family
 
@@ -217,7 +217,7 @@ All entries use the VLM prompt 'What is in this image?' with
 | molmo-7b | molmo-7b | ✅ | 2287.29 | 84.99 | - | 100 tokens; mlx-vlm baseline is a 1-token anomaly |
 | molmo2 (4B) | molmo2-4b | ✅ | 2512.31 | 64.01 | 1.08x | 46 tokens |
 | paligemma2 (3B 6-bit) | paligemma2-3b-6bit | ✅ | 4294.39 | 80.09 | **1.78x** | 2 tokens |
-| phi-3.5-vision | phi-3.5-vision-4bit | ✅ | 2821.55 | 123.07 | **1.31x** | 19 tokens |
+| phi-3.5-vision | phi-3.5-vision-4bit | ✅ | 3582.68 | 168.77 | **1.79x** | 19 tokens |
 | pixtral (12B) | pixtral-12b-4bit | ✅ | 1998.87 | 69.71 | **1.18x** | 100 tokens |
 | qwen2-vl (2B) | qwen2-vl-2b-4bit | ✅ | 2485.82 | 247.21 | - | 12 tokens; EOS-terminate |
 | qwen2.5-vl (3B) | qwen2.5-vl-3b-4bit | ✅ | 1696.53 | 156.83 | **1.61x** | 22 tokens; EOS-terminate; fixed by #34 |
@@ -258,15 +258,15 @@ snapshot.
 
 - **Comparable text pairs**: 66 (models with >=5 generated tokens both sides)
 - **mlxcel >= mlx-lm**: 24 / 66 (36%)
-- **mlxcel >= 90% parity**: 58 / 66 (88%)
+- **mlxcel >= 90% parity**: 59 / 66 (89%, the Phi-3.5 mini fix raises it from 79% to 98%)
 - **Average mlxcel/mlx-lm**: 97% (median 99%, range 72%-127%)
 
 ### Aggregate (VLM, models with >=5 generated tokens both sides)
 
 - **Comparable VLM pairs**: 20
-- **mlxcel >= mlx-vlm**: 9 / 20 (45%)
-- **mlxcel >= 90% parity**: 16 / 20 (80%)
-- **Average mlxcel/mlx-vlm**: 100% (median 100%, range 74%-123%)
+- **mlxcel >= mlx-vlm**: 10 / 20 (50%, the Phi-3.5 vision fix raises it from 77% to 106%)
+- **mlxcel >= 90% parity**: 17 / 20 (85%)
+- **Average mlxcel/mlx-vlm**: 101% (median 100%, range 74%-123%)
 
 ### Text decode (tok/s)
 
@@ -334,11 +334,11 @@ snapshot.
 | olmo3-32b-4bit | 29.11 | 28.99 | **100%** |
 | paligemma2-3b-6bit | 149.98 | FAIL | - |
 | phi-2-4bit | 79.60 | FAIL | - |
-| phi-3-mini-4bit | 207.58 | 212.74 | 98% |
-| phi-3.5-mini-4bit | 164.03 | 207.79 | 79% |
-| phi-3.5-moe-4bit | 115.14 | 107.56 | **107%** |
+| phi-3-mini-4bit | 207.89 | 212.74 | 98% |
+| phi-3.5-mini-4bit | 204.63 | 207.79 | 98% |
+| phi-3.5-moe-4bit | 115.20 | 107.56 | **107%** |
 | phi-3.5-vision-4bit | 163.61 | FAIL | - |
-| phi-4-4bit | 63.78 | 62.28 | **102%** |
+| phi-4-4bit | 63.86 | 62.28 | **103%** |
 | pixtral-12b-4bit | 76.56 | 74.95 | **102%** |
 | qwen1.5-moe-a2.7b-4bit | 237.73 | 237.50 | **100%** |
 | qwen2-vl-2b-4bit | 273.84 | 381.98 | 72% |
@@ -398,7 +398,7 @@ snapshot.
 | molmo-7b | 84.99 | 56471.65 (anomalous, 1 token) | - |
 | molmo2-4b | 64.01 | 66.80 | 96% |
 | paligemma2-3b-6bit | 80.09 | 124.55 | - |
-| phi-3.5-vision-4bit | 123.07 | 159.63 | 77% |
+| phi-3.5-vision-4bit | 168.77 | 159.63 | **106%** |
 | pixtral-12b-4bit | 69.71 | FAIL | - |
 | qwen2-vl-2b-4bit | 247.21 | 279.55 | 88% |
 | qwen2.5-vl-3b-4bit | 156.83 | FAIL | - |
@@ -547,6 +547,7 @@ increase and 96% of mlx-lm's 555.43 tok/s on the same prompt.
 - Prefill and decode tok/s reported separately.
 - Full text + VLM sweep on 2026-05-19: 98 text models (`bench_decode.sh all`) and a matching `bench_decode.sh all --vlm` pass, both at `--cooldown 15 --big-cooldown 15`. Failures match the 2026-05-18 baseline (same 5 text-side and 26 VLM-side fails — all pre-existing).
 - Molmo v1 (`molmo-7b`) spot-check on 2026-05-20: text-only measured 338.65 prefill / 78.74 decode tok/s (24 tokens), and the VLM path measured 2287.29 prefill / 84.99 decode tok/s (100 tokens) with the output now identifying the orange-square fixture instead of the pre-fix degenerate loop. The upstream mlx-vlm baseline row is a 1-token anomaly, so no percentage comparison is reported; a `molmo2-4b` no-regression check held at ~63 tok/s decode.
+- Phi-3.5 SuScaledRoPE spot-check on 2026-05-20: fusing the quantized QKV projection/split/reshape/transpose/SuScaledRoPE chain and scaling only the rotary prefix raised `phi-3.5-mini-4bit` from 164.03 to 204.63 tok/s decode (79% to 98% of mlx-lm) and `phi-3.5-vision-4bit` VLM from 123.07 to 168.77 tok/s decode (77% to 106% of mlx-vlm) while output stayed coherent. Guardrails held within noise: `phi-3-mini-4bit` 207.89, `phi-4-4bit` 63.86, and `phi-3.5-moe-4bit` 115.20 tok/s decode.
 - Cooldown discipline on M5 Max: 15s general / 15s big-model cooldowns were sufficient for this back-to-back run on a freshly-built binary; longer cooldowns (`--cooldown 30 --big-cooldown 30`) remain the safer default for marathon sessions or when thermal headroom is uncertain.
 - Measurement noise on very fast small models remains high (qwen3.5-0.8b-4bit and
   similar can span ±15% across back-to-back runs because 100 tokens generate in

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -17,6 +17,7 @@
 #ifdef __APPLE__
 #include "mlx/backend/metal/metal.h"
 #endif
+#include <algorithm>
 #include <cstring>
 #include <cstdlib>
 #include <fstream>
@@ -3404,6 +3405,90 @@ void fused_qkv_project_split_rope(
 
     q = mlx::core::fast::rope(q, rope_dims, false, rope_base, 1.0f, cache_offset);
     k = mlx::core::fast::rope(k, rope_dims, false, rope_base, 1.0f, cache_offset);
+
+    q_out = std::make_unique<MlxArray>(std::move(q));
+    k_out = std::make_unique<MlxArray>(std::move(k));
+    v_out = std::make_unique<MlxArray>(std::move(v));
+}
+
+namespace {
+array apply_su_scaled_rope(
+    array x,
+    int32_t rope_dims,
+    const array& rope_freqs,
+    float rope_input_scale,
+    int32_t cache_offset
+) {
+    if (rope_input_scale != 1.0f && rope_dims > 0) {
+        auto x_shape = x.shape();
+        Shape starts(x_shape.size(), 0);
+        Shape stops(x_shape.begin(), x_shape.end());
+        stops.back() = std::min<int32_t>(rope_dims, x_shape.back());
+        auto rotary = slice(x, starts, stops);
+        auto scale = array(rope_input_scale, x.dtype());
+        rotary = multiply(rotary, scale);
+        x = slice_update(x, rotary, starts, stops);
+    }
+
+    return mlx::core::fast::rope(
+        x, rope_dims, false, std::nullopt, 1.0f, cache_offset, rope_freqs);
+}
+}
+
+void fused_qkv_project_split_su_scaled_rope(
+    const MlxArray& x,
+    const MlxArray& weight,
+    const MlxArray& scales,
+    const MlxArray* biases,
+    int32_t num_heads,
+    int32_t num_kv_heads,
+    int32_t head_dim,
+    int32_t rope_dims,
+    const MlxArray& rope_freqs,
+    float rope_input_scale,
+    int32_t cache_offset,
+    int32_t group_size,
+    int32_t bits,
+    rust::Str mode,
+    std::unique_ptr<MlxArray>& q_out,
+    std::unique_ptr<MlxArray>& k_out,
+    std::unique_ptr<MlxArray>& v_out
+) {
+    using namespace mlx::core;
+
+    auto batch_size = x.inner.shape()[0];
+    auto seq_len = x.inner.shape()[1];
+
+    std::optional<array> biases_opt = biases ? std::optional(biases->inner) : std::nullopt;
+    std::string mode_str(mode.data(), mode.size());
+    auto proj = quantized_matmul(
+        x.inner, weight.inner, scales.inner, biases_opt,
+        true, std::optional<int>(group_size), std::optional<int>(bits), mode_str);
+
+    int q_cols = num_heads * head_dim;
+    int kv_cols = num_kv_heads * head_dim;
+    int qkv_cols = q_cols + (2 * kv_cols);
+
+    auto proj_shape = proj.shape();
+    if (proj_shape.size() != 3 || proj_shape[2] != qkv_cols) {
+        throw std::runtime_error(
+            "fused_qkv_project_split_su_scaled_rope: unexpected projection shape");
+    }
+
+    auto q = slice(proj, {0, 0, 0}, {batch_size, seq_len, q_cols});
+    auto k = slice(proj, {0, 0, q_cols}, {batch_size, seq_len, q_cols + kv_cols});
+    auto v = slice(proj, {0, 0, q_cols + kv_cols}, {batch_size, seq_len, qkv_cols});
+
+    q = reshape(q, {batch_size, seq_len, num_heads, head_dim});
+    k = reshape(k, {batch_size, seq_len, num_kv_heads, head_dim});
+    v = reshape(v, {batch_size, seq_len, num_kv_heads, head_dim});
+
+    q = transpose(q, {0, 2, 1, 3});
+    k = transpose(k, {0, 2, 1, 3});
+    v = transpose(v, {0, 2, 1, 3});
+
+    q = apply_su_scaled_rope(q, rope_dims, rope_freqs.inner, rope_input_scale, cache_offset);
+    k = apply_su_scaled_rope(k, rope_dims, rope_freqs.inner, rope_input_scale, cache_offset);
 
     q_out = std::make_unique<MlxArray>(std::move(q));
     k_out = std::make_unique<MlxArray>(std::move(k));

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -954,6 +954,30 @@ void fused_qkv_project_split_rope(
     std::unique_ptr<MlxArray>& v_out
 );
 
+// Fused concatenated QKV projection + split + reshape + transpose +
+// SuScaledRoPE. Mirrors mlx-lm/mlx-vlm SuScaledRoPE by scaling only the
+// rotary prefix before applying custom frequency RoPE.
+// Used by: Phi3/Phi3V longrope-su attention path.
+void fused_qkv_project_split_su_scaled_rope(
+    const MlxArray& x,
+    const MlxArray& weight,
+    const MlxArray& scales,
+    const MlxArray* biases,     // nullable for mxfp4/nvfp4/mxfp8
+    int32_t num_heads,
+    int32_t num_kv_heads,
+    int32_t head_dim,
+    int32_t rope_dims,
+    const MlxArray& rope_freqs,
+    float rope_input_scale,
+    int32_t cache_offset,
+    int32_t group_size,
+    int32_t bits,
+    rust::Str mode,
+    std::unique_ptr<MlxArray>& q_out,
+    std::unique_ptr<MlxArray>& k_out,
+    std::unique_ptr<MlxArray>& v_out
+);
+
 // Experimental dense causal prefill attention path:
 // qkv projection + split + rope + native causal SDPA + output projection.
 // Returns output plus K/V tensors so Rust can populate the KV cache.

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -778,6 +778,61 @@ impl UnifiedLinear {
         }
     }
 
+    /// Fused concatenated QKV projection + split + reshape + transpose + SuScaledRoPE.
+    ///
+    /// Returns Q/K/V already shaped `[B, H, T, D]`. Q/K match mlx-lm/mlx-vlm
+    /// SuScaledRoPE semantics by scaling only the rotary prefix before custom
+    /// frequency RoPE. Only available for quantized fused-QKV weights.
+    ///
+    /// Used by: Phi3/Phi3V longrope-su attention path.
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward_fused_qkv_split_su_scaled_rope(
+        &self,
+        x: &MlxArray,
+        num_heads: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        rope_dims: i32,
+        rope_freqs: &MlxArray,
+        rope_input_scale: f32,
+        cache_offset: i32,
+    ) -> Option<(
+        UniquePtr<MlxArray>,
+        UniquePtr<MlxArray>,
+        UniquePtr<MlxArray>,
+    )> {
+        match self {
+            Self::Quantized { weight, .. } => {
+                let mut q = cxx::UniquePtr::null();
+                let mut k = cxx::UniquePtr::null();
+                let mut v = cxx::UniquePtr::null();
+                unsafe {
+                    ffi::fused_qkv_project_split_su_scaled_rope(
+                        x,
+                        &weight.weight,
+                        &weight.scales,
+                        weight.biases_ptr(),
+                        num_heads,
+                        num_kv_heads,
+                        head_dim,
+                        rope_dims,
+                        rope_freqs,
+                        rope_input_scale,
+                        cache_offset,
+                        weight.group_size,
+                        weight.bits,
+                        &weight.mode,
+                        &mut q,
+                        &mut k,
+                        &mut v,
+                    );
+                }
+                Some((q, k, v))
+            }
+            Self::Regular(_) => None,
+        }
+    }
+
     /// Get a reference to the inner Linear (if non-quantized)
     /// Used by compiled FP MLP operations that need direct weight/bias access
     pub fn regular_weight(&self) -> Option<&Linear> {

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -1218,6 +1218,29 @@ mod ffi {
             v_out: &mut UniquePtr<MlxArray>,
         );
 
+        /// Fused concatenated QKV projection + split + reshape + transpose +
+        /// SuScaledRoPE.
+        /// Used by: Phi3/Phi3V longrope-su attention path.
+        unsafe fn fused_qkv_project_split_su_scaled_rope(
+            x: &MlxArray,
+            weight: &MlxArray,
+            scales: &MlxArray,
+            biases: *const MlxArray,
+            num_heads: i32,
+            num_kv_heads: i32,
+            head_dim: i32,
+            rope_dims: i32,
+            rope_freqs: &MlxArray,
+            rope_input_scale: f32,
+            cache_offset: i32,
+            group_size: i32,
+            bits: i32,
+            mode: &str,
+            q_out: &mut UniquePtr<MlxArray>,
+            k_out: &mut UniquePtr<MlxArray>,
+            v_out: &mut UniquePtr<MlxArray>,
+        );
+
         /// Experimental dense causal prefill attention path:
         /// qkv projection + split + rope + native causal SDPA + output projection.
         unsafe fn fused_causal_prefill_attention(

--- a/src/models/phi3.rs
+++ b/src/models/phi3.rs
@@ -158,54 +158,28 @@ impl Phi3Attention {
         let b = shape[0];
         let l = shape[1];
 
-        // Fused QKV projection
-        let qkv = self.qkv_proj.forward(x);
-
-        // Split QKV
-        let q_size = self.num_heads * self.head_dim;
-        let kv_size = self.num_kv_heads * self.head_dim;
-
-        // Slice to get Q, K, V
-        let q = mlxcel_core::slice_last_dim(&qkv, 0, q_size);
-        let k = mlxcel_core::slice_last_dim(&qkv, q_size, q_size + kv_size);
-        let v = mlxcel_core::slice_last_dim(&qkv, q_size + kv_size, q_size + 2 * kv_size);
-
-        // Reshape to [batch, seq_len, n_heads, head_dim]
-        let q = mlxcel_core::reshape(&q, &[b, l, self.num_heads, self.head_dim]);
-        let k = mlxcel_core::reshape(&k, &[b, l, self.num_kv_heads, self.head_dim]);
-        let v = mlxcel_core::reshape(&v, &[b, l, self.num_kv_heads, self.head_dim]);
-
-        // Transpose to [batch, n_heads, seq_len, head_dim]
-        let q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
-        let k = mlxcel_core::transpose_axes(&k, &[0, 2, 1, 3]);
-        let v = mlxcel_core::transpose_axes(&v, &[0, 2, 1, 3]);
-
         let offset = cache.offset;
 
-        // Apply RoPE (SuScaledRoPE for longrope models, plain RoPE otherwise)
-        let (q, k) = if let Some(ref freqs) = self.su_rope_freqs {
-            // SuScaledRoPE: pre-scale the rotary dimensions, then apply with custom freqs
-            // Use pre-computed scale array to avoid per-token from_slice_f32 allocation
-            let (q, k) = if let Some(ref scale_arr) = self.su_rope_scale_arr {
-                (
-                    mlxcel_core::multiply(&q, scale_arr),
-                    mlxcel_core::multiply(&k, scale_arr),
-                )
+        // Fused QKV split + RoPE preparation. The SuScaledRoPE quantized path
+        // mirrors mlx-lm/mlx-vlm by scaling only the rotary prefix and keeps
+        // the projection/split/reshape/transpose/RoPE chain in one bridge call.
+        let (q, k, v) = if let Some(ref freqs) = self.su_rope_freqs {
+            if let Some((q, k, v)) = self.qkv_proj.forward_fused_qkv_split_su_scaled_rope(
+                x,
+                self.num_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                self.rope_dims,
+                freqs,
+                self.su_rope_scale,
+                offset,
+            ) {
+                (q, k, v)
             } else {
-                (
-                    mlxcel_core::reshape(&q, &mlxcel_core::array_shape(&q)),
-                    mlxcel_core::reshape(&k, &mlxcel_core::array_shape(&k)),
-                )
-            };
-            let q =
-                mlxcel_core::fast_rope_with_freqs(&q, self.rope_dims, false, 1.0, offset, freqs);
-            let k =
-                mlxcel_core::fast_rope_with_freqs(&k, self.rope_dims, false, 1.0, offset, freqs);
-            (q, k)
+                self.prepare_qkv_with_rope(x, b, l, offset, Some(freqs))
+            }
         } else {
-            let q = mlxcel_core::fast_rope(&q, self.rope_dims, false, self.rope_base, 1.0, offset);
-            let k = mlxcel_core::fast_rope(&k, self.rope_dims, false, self.rope_base, 1.0, offset);
-            (q, k)
+            self.prepare_qkv_with_rope(x, b, l, offset, None)
         };
 
         // Update KV cache and get sliced views
@@ -231,6 +205,75 @@ impl Phi3Attention {
 
         // Output projection
         self.o_proj.forward(&attn_out)
+    }
+
+    fn prepare_qkv_with_rope(
+        &self,
+        x: &MlxArray,
+        b: i32,
+        l: i32,
+        offset: i32,
+        su_freqs: Option<&MlxArray>,
+    ) -> (
+        UniquePtr<MlxArray>,
+        UniquePtr<MlxArray>,
+        UniquePtr<MlxArray>,
+    ) {
+        let qkv = self.qkv_proj.forward(x);
+        let q_size = self.num_heads * self.head_dim;
+        let kv_size = self.num_kv_heads * self.head_dim;
+
+        let q = mlxcel_core::slice_last_dim(&qkv, 0, q_size);
+        let k = mlxcel_core::slice_last_dim(&qkv, q_size, q_size + kv_size);
+        let v = mlxcel_core::slice_last_dim(&qkv, q_size + kv_size, q_size + 2 * kv_size);
+
+        let q = mlxcel_core::reshape(&q, &[b, l, self.num_heads, self.head_dim]);
+        let k = mlxcel_core::reshape(&k, &[b, l, self.num_kv_heads, self.head_dim]);
+        let v = mlxcel_core::reshape(&v, &[b, l, self.num_kv_heads, self.head_dim]);
+
+        let q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
+        let k = mlxcel_core::transpose_axes(&k, &[0, 2, 1, 3]);
+        let v = mlxcel_core::transpose_axes(&v, &[0, 2, 1, 3]);
+
+        let (q, k) = if let Some(freqs) = su_freqs {
+            let (q, k) = self.scale_su_rope_rotary_prefix(&q, &k);
+            let q =
+                mlxcel_core::fast_rope_with_freqs(&q, self.rope_dims, false, 1.0, offset, freqs);
+            let k =
+                mlxcel_core::fast_rope_with_freqs(&k, self.rope_dims, false, 1.0, offset, freqs);
+            (q, k)
+        } else {
+            let q = mlxcel_core::fast_rope(&q, self.rope_dims, false, self.rope_base, 1.0, offset);
+            let k = mlxcel_core::fast_rope(&k, self.rope_dims, false, self.rope_base, 1.0, offset);
+            (q, k)
+        };
+
+        (q, k, v)
+    }
+
+    fn scale_su_rope_rotary_prefix(
+        &self,
+        q: &MlxArray,
+        k: &MlxArray,
+    ) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
+        let Some(ref scale_arr) = self.su_rope_scale_arr else {
+            return (
+                mlxcel_core::reshape(q, &mlxcel_core::array_shape(q)),
+                mlxcel_core::reshape(k, &mlxcel_core::array_shape(k)),
+            );
+        };
+
+        let scale_rotary = |x: &MlxArray| {
+            let shape = mlxcel_core::array_shape(x);
+            let last = shape.len() - 1;
+            let mut rotary_end = shape.clone();
+            rotary_end[last] = self.rope_dims;
+            let rotary = mlxcel_core::slice(x, &vec![0; shape.len()], &rotary_end);
+            let rotary = mlxcel_core::multiply(&rotary, scale_arr);
+            mlxcel_core::slice_update(x, &rotary, &vec![0; shape.len()], &rotary_end)
+        };
+
+        (scale_rotary(q), scale_rotary(k))
     }
 
     pub fn from_weights(


### PR DESCRIPTION
## Summary

Speeds up Phi-3 / Phi-3.5 longrope (SuScaledRoPE) decode by collapsing the attention prologue into a single fused MLX bridge call for quantized weights.

## What changed

- **New bridge op** `fused_qkv_project_split_su_scaled_rope` (`mlx_cxx_bridge.{cpp,h}`, exposed via `mlxcel-core` lib FFI + `UnifiedLinear::forward_fused_qkv_split_su_scaled_rope`): runs the concatenated QKV projection, Q/K/V split, reshape + transpose to `[B, H, T, D]`, and the SuScaledRoPE rotation in one shot. This replaces the previous chain of separate `slice` / `reshape` / `transpose` / `multiply` / `fast_rope_with_freqs` graph nodes, whose per-token allocation and dispatch overhead dominated decode for these small models.
- **Faithful fallback**: `Phi3Attention::forward` takes the fused path only when SuScaledRoPE frequencies are present *and* the fused-QKV weights are quantized; otherwise it routes through the extracted `prepare_qkv_with_rope`, preserving the original step-by-step behaviour for regular (non-quantized) weights. SuScaledRoPE semantics are unchanged — both paths scale only the rotary prefix before the custom-frequency RoPE, matching mlx-lm / mlx-vlm.

## Benchmarks (M5 Max)

| Model | Before | After | vs upstream |
|-------|--------|-------|-------------|
| `phi-3.5-mini-4bit` (text) | 164.03 | 204.63 tok/s | 79% → 98% of mlx-lm |
| `phi-3.5-vision-4bit` (VLM) | 123.07 | 168.77 tok/s | 77% → 106% of mlx-vlm |

`phi-3-mini`, `phi-3.5-moe`, and `phi-4` are held within measurement noise as guardrails.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --features metal,accelerate -- -D warnings` clean (rebuilds the C++ bridge)
- Greedy generation on `phi-3.5-mini-4bit` produces coherent text through the new fused quantized branch
