### PR TITLE
fix(perf): align Gemma dense GeGLU with mlx-lm

### DIFF
--- a/docs/benchmark_results/model_tests.md
+++ b/docs/benchmark_results/model_tests.md
@@ -22,7 +22,7 @@ Current source-of-truth data lives in `benchmarks/`:
 |-----|----------|------|------|
 | `metal_m5max_2026-05-19.csv` | M5 Max | 2026-05-19 (mlxcel 0.0.28, MLX 0.31.2) | Text |
 | `metal_m5max_vlm_2026-05-19.csv` | M5 Max | 2026-05-19 (mlxcel 0.0.28, MLX 0.31.2) | VLM |
-| `metal_m5max_vlm_2026-05-20.csv` | M5 Max | 2026-05-20 (mlxcel 0.0.28, MLX 0.31.2; Gemma3n + Molmo v1 + Phi-3.5 vision VLM entries) | VLM |
+| `metal_m5max_vlm_2026-05-20.csv` | M5 Max | 2026-05-20 (mlxcel 0.0.28, MLX 0.31.2; Gemma3n + Molmo v1 + Phi-3.5 vision + Gemma3 4B VLM entries) | VLM |
 | `pylm_m5max_2026-05-18.csv` | M5 Max | 2026-05-19 benchmark campaign (mlx-lm 0.31.3 baseline; CSV date crossed midnight) | Text |
 | `pylm_m5max_vlm_2026-05-18.csv` | M5 Max | 2026-05-19 benchmark campaign (mlx-vlm 0.4.4 baseline; CSV date crossed midnight) | VLM |
 | `metal_m1ultra_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlxcel 0.0.28, MLX commit 84961223; >65GB skipped) | Text |
@@ -46,7 +46,7 @@ The table below summarizes the current cross-hardware decode readings for select
 | Llama-3.2-1B | 1B | 332.54 | 539.67 | 226.87 |
 | Qwen3-0.6B | 600M | 198.08 | 510.83 | 203.04* |
 | StableLM-1.6B | 1.6B | 270.47 | 424.32 | 186.64 |
-| Gemma-3-1B | 1B | 196.54 | 381.28 | 182.97 |
+| Gemma-3-1B | 1B | 196.54 | 399.65 | 182.97 |
 | EXAONE-3.5-2.4B | 2.4B | 190.43 | 287.68 | 104.06 |
 | SmolLM3-3B | 3B | 136.43 | 232.92 | 101.88 |
 | Nemotron-H-30B | 30B | 89.96 | 171.76 | 25.75 |
@@ -78,9 +78,9 @@ For Qwen2.5-0.5B, the 4-bit variant is the comparable row across both Apple Sili
 | VLM models tested (M1 Ultra, 2026-05-19) | 33 pass, 4 partial, 2 fail |
 | Beating mlx-lm on M1 Ultra (text, >100%) | 36/40 (90%, 5-19 baseline) |
 | At 90%+ parity on M1 Ultra (text) | 40/40 (100%, 5-19 baseline) |
-| Beating mlx-lm on M5 Max (text, >=100%) | 24/66 (36%, 5-19 mlxcel vs 5-18 mlx-lm) |
-| At 90%+ parity on M5 Max (text) | 58/66 (88%, 5-19 mlxcel vs 5-18 mlx-lm) |
-| Average vs mlx-lm on M5 Max (text) | 97% decode speed (median 99%, 5-19 mlxcel vs 5-18 mlx-lm) |
+| Beating mlx-lm on M5 Max (text, >=100%) | 27/66 (41%, 5-19 mlxcel vs 5-18 mlx-lm) |
+| At 90%+ parity on M5 Max (text) | 61/66 (92%, 5-19 mlxcel vs 5-18 mlx-lm) |
+| Average vs mlx-lm on M5 Max (text) | 98% decode speed (median 99%, 5-19 mlxcel vs 5-18 mlx-lm) |
 | Average vs mlx-vlm on M5 Max (VLM) | 100% decode speed (median 100%, 20 comparable pairs) |
 
 ## Generating Benchmarks

--- a/docs/benchmark_results/model_tests_m5max.md
+++ b/docs/benchmark_results/model_tests_m5max.md
@@ -14,7 +14,7 @@ Compatibility and performance testing for mlxcel models on **MacBook Pro M5 Max 
 | **mlx-vlm baseline** | 0.4.4 |
 | **Test Prompt** | "Hello, how are you today?" (text) / "What is in this image?" (VLM) |
 | **Max Tokens** | 100 |
-| **Test Date** | 2026-05-19 full sweep; 2026-05-20 Molmo v1 spot-check; 2026-05-20 Phi-3.5 spot-check |
+| **Test Date** | 2026-05-19 full sweep; 2026-05-20 Molmo v1 spot-check; 2026-05-20 Phi-3.5 spot-check; 2026-05-20 Gemma2/Gemma3 dense spot-check |
 | **Benchmark Status** | Full text + VLM sweep on mlxcel using `mlxcel-bench-decode`, 98 text + 98 VLM-mode passes with `--cooldown 15 --big-cooldown 15`. mlx-lm / mlx-vlm baseline sub-sweeps are from the same benchmark campaign; their CSV filenames carry 2026-05-18 because the run crossed calendar midnight. |
 
 ## Legend
@@ -48,10 +48,10 @@ Compatibility and performance testing for mlxcel models on **MacBook Pro M5 Max 
 
 | Model | Test Model | Status | Prefill | Decode | vs M1 Ultra | Notes |
 |-------|------------|--------|---------|--------|-------------|-------|
-| gemma | gemma-2b-it-4bit | ✅ | 1346.43 | 210.51 | 1.08x | 49 tokens; issue #718 |
-| gemma2 | gemma-2-2b-it-4bit | ✅ | 1130.43 | 196.72 | **1.52x** | 18 tokens |
-| gemma3 | gemma-3-1b-it-4bit | ✅ | 2117.64 | 382.07 | **1.95x** | 20 tokens |
-| gemma3 (4B) | gemma-3-4b-it-4bit | ✅ | 794.31 | 146.43 | **1.47x** | 91 tokens |
+| gemma | gemma-2b-it-4bit | ✅ | 1288.22 | 217.38 | 1.12x | 49 tokens |
+| gemma2 | gemma-2-2b-it-4bit | ✅ | 1266.11 | 241.96 | **1.87x** | 18 tokens; full-budget raw prompt 245.83 tok/s |
+| gemma3 | gemma-3-1b-it-4bit | ✅ | 2072.39 | 399.65 | **2.04x** | 30 tokens |
+| gemma3 (4B) | gemma-3-4b-it-4bit | ✅ | 819.97 | 182.16 | **1.83x** | 81 tokens; full-budget raw prompt 183.77 tok/s |
 | gemma3n (E2B) | gemma-3n-E2B-it-4bit | ✅ | 812.25 | 158.71 | **2.06x** | 71 tokens |
 | gemma3n (E4B) | gemma-3n-E4B-it-4bit | ✅ | 601.09 | 110.24 | **1.83x** | 71 tokens |
 | gemma3n (E4B bf16) | gemma-3n-E4B-it (bf16) | ✅ | 348.30 | 39.19 | **1.14x** | 72 tokens; issue #716; Gemma3n language MLP bf16 preserved, other bf16 materialized as f16; 78% of mlx-lm decode |
@@ -196,7 +196,7 @@ All entries use the VLM prompt 'What is in this image?' with
 |-------|------------|--------|---------|--------|-------------|-------|
 | aya-vision-8b | aya-vision-8b | ✅ | 1616.46 | 112.09 | 1.02x | 84 tokens |
 | bunny-llama3-8b | bunny-llama3-8b-4bit | ✅ | 2851.65 | 112.24 | **1.17x** | 37 tokens |
-| gemma3 (4B) | gemma3-4b-4bit | ✅ | 567.95 | 127.61 | **1.69x** | 16 tokens |
+| gemma3 (4B) | gemma3-4b-4bit | ✅ | 593.32 | 159.58 | **2.11x** | 16 tokens |
 | gemma3n (E2B 4bit) | gemma3n-e2b-4bit | ✅ | 2893.48 | 151.36 | **2.08x** | 29 tokens |
 | gemma3n (E4B 4bit) | gemma3n-e4b-4bit | ✅ | 2186.03 | 106.01 | **1.87x** | 33 tokens |
 | gemma3n (E4B bf16) | gemma3n-e4b-bf16 | ✅ | 2025.46 | 36.95 | **1.16x** | 24 tokens; bf16→f16 conversion path |
@@ -257,9 +257,9 @@ snapshot.
 ### Aggregate (text)
 
 - **Comparable text pairs**: 66 (models with >=5 generated tokens both sides)
-- **mlxcel >= mlx-lm**: 24 / 66 (36%)
-- **mlxcel >= 90% parity**: 59 / 66 (89%, the Phi-3.5 mini fix raises it from 79% to 98%)
-- **Average mlxcel/mlx-lm**: 97% (median 99%, range 72%-127%)
+- **mlxcel >= mlx-lm**: 27 / 66 (41%)
+- **mlxcel >= 90% parity**: 61 / 66 (92%, the Phi-3.5 and Gemma dense fixes add Phi-3.5 mini, Gemma2-2b, and Gemma3-4b)
+- **Average mlxcel/mlx-lm**: 98% (median 99%, range 72%-127%)
 
 ### Aggregate (VLM, models with >=5 generated tokens both sides)
 
@@ -286,7 +286,7 @@ snapshot.
 | exaone-3.5-2.4b-4bit | 282.35 | 289.01 | 98% |
 | exaone4-1.2b-4bit | 424.44 | FAIL | - |
 | falcon-mamba-7b-4bit | 63.19 | 140.10 | 45% |
-| gemma-2b-4bit | 210.51 | 223.27 | 94% |
+| gemma-2b-4bit | 217.38 | 223.27 | 97% |
 | gemma-4-26b-a4b-it-4bit | 137.12 | 141.08 | 97% |
 | gemma-4-31b-4bit | 28.59 | 28.79 | 99% |
 | gemma-4-31b-it-4bit | 27.34 | 28.74 | 95% |
@@ -294,9 +294,9 @@ snapshot.
 | gemma-4-e2b-it-8bit | 136.69 | FAIL | - |
 | gemma-4-e4b-it-4bit | 136.68 | FAIL | - |
 | gemma-4-e4b-it-8bit | 80.88 | FAIL | - |
-| gemma2-2b-4bit | 196.72 | 241.76 | 81% |
-| gemma3-1b-4bit | 382.07 | 388.52 | 98% |
-| gemma3-4b-4bit | 146.43 | 181.66 | 81% |
+| gemma2-2b-4bit | 241.96 | 241.76 | **100%** |
+| gemma3-1b-4bit | 399.65 | 388.52 | **103%** |
+| gemma3-4b-4bit | 182.16 | 181.66 | **100%** |
 | gemma3n-e2b-4bit | 158.71 | FAIL | - |
 | gemma3n-e4b-4bit | 110.24 | FAIL | - |
 | gemma3n-e4b-bf16 | 39.19 | 48.72 | 80% |
@@ -384,7 +384,7 @@ snapshot.
 | gemma-4-e2b-it-8bit | 133.74 | 150.51 | 89% |
 | gemma-4-e4b-it-4bit | 134.10 | 131.24 | **102%** |
 | gemma-4-e4b-it-8bit | 76.28 | 90.00 | 85% |
-| gemma3-4b-4bit | 127.61 | FAIL | - |
+| gemma3-4b-4bit | 159.58 | FAIL | - |
 | gemma3n-e2b-4bit | 151.36 | 124.63 | **121%** |
 | gemma3n-e4b-4bit | 106.01 | 93.55 | **113%** |
 | gemma3n-e4b-bf16 | 36.95 | 49.88 | 74% |
@@ -548,6 +548,7 @@ increase and 96% of mlx-lm's 555.43 tok/s on the same prompt.
 - Full text + VLM sweep on 2026-05-19: 98 text models (`bench_decode.sh all`) and a matching `bench_decode.sh all --vlm` pass, both at `--cooldown 15 --big-cooldown 15`. Failures match the 2026-05-18 baseline (same 5 text-side and 26 VLM-side fails — all pre-existing).
 - Molmo v1 (`molmo-7b`) spot-check on 2026-05-20: text-only measured 338.65 prefill / 78.74 decode tok/s (24 tokens), and the VLM path measured 2287.29 prefill / 84.99 decode tok/s (100 tokens) with the output now identifying the orange-square fixture instead of the pre-fix degenerate loop. The upstream mlx-vlm baseline row is a 1-token anomaly, so no percentage comparison is reported; a `molmo2-4b` no-regression check held at ~63 tok/s decode.
 - Phi-3.5 SuScaledRoPE spot-check on 2026-05-20: fusing the quantized QKV projection/split/reshape/transpose/SuScaledRoPE chain and scaling only the rotary prefix raised `phi-3.5-mini-4bit` from 164.03 to 204.63 tok/s decode (79% to 98% of mlx-lm) and `phi-3.5-vision-4bit` VLM from 123.07 to 168.77 tok/s decode (77% to 106% of mlx-vlm) while output stayed coherent. Guardrails held within noise: `phi-3-mini-4bit` 207.89, `phi-4-4bit` 63.86, and `phi-3.5-moe-4bit` 115.20 tok/s decode.
+- Gemma2/Gemma3 dense spot-check on 2026-05-20: aligning the Gemma2/Gemma3 dense MLP with mlx-lm's tanh-approx GeGLU (`nn.gelu_approx`) and fusing the quantized QKV preparation raised `gemma2-2b-4bit` from 196.72 to 241.96 tok/s decode (81% to 100% of mlx-lm) and `gemma3-4b-4bit` from 146.43 to 182.16 tok/s decode (81% to 100%), with the `gemma3-4b-4bit` VLM row rising from 127.61 to 159.58 tok/s. Guardrails held: `gemma-2b-4bit` 217.38 and `gemma3-1b-4bit` 399.65 tok/s decode.
 - Cooldown discipline on M5 Max: 15s general / 15s big-model cooldowns were sufficient for this back-to-back run on a freshly-built binary; longer cooldowns (`--cooldown 30 --big-cooldown 30`) remain the safer default for marathon sessions or when thermal headroom is uncertain.
 - Measurement noise on very fast small models remains high (qwen3.5-0.8b-4bit and
   similar can span ±15% across back-to-back runs because 100 tokens generate in

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -1198,7 +1198,7 @@ std::unique_ptr<MlxArray> compiled_gpt_oss_swiglu_activation(
 }
 
 // Compiled GELU: x * 0.5 * (1 + erf(x / sqrt(2)))
-// Used by: Gemma2, Gemma3, StarCoder2
+// Used by: StarCoder2
 namespace {
     static std::function<std::vector<array>(const std::vector<array>&)> get_compiled_gelu() {
         auto fn = [](const std::vector<array>& inputs) -> std::vector<array> {
@@ -1223,7 +1223,7 @@ std::unique_ptr<MlxArray> compiled_gelu(const MlxArray& x) {
 
 // Compiled GELU approx: erf-based GELU (x * 0.5 * (1 + erf(x / sqrt(2))))
 // Uses erf instead of tanh for numerical stability with bf16 inputs.
-// Used by: Gemma2, Gemma3 (Python uses gelu_approx)
+// Used by: legacy/tests
 namespace {
     static std::function<std::vector<array>(const std::vector<array>&)> get_compiled_gelu_approx() {
         auto fn = [](const std::vector<array>& inputs) -> std::vector<array> {
@@ -1249,7 +1249,7 @@ std::unique_ptr<MlxArray> compiled_gelu_approx(const MlxArray& x) {
 }
 
 // Compiled GeGLU: gelu(gate) * x
-// Used by: Gemma2, Gemma3 MLP layers
+// Used by: legacy/tests for precise GeGLU
 namespace {
     static std::function<std::vector<array>(const std::vector<array>&)> get_compiled_geglu() {
         auto fn = [](const std::vector<array>& inputs) -> std::vector<array> {
@@ -1585,7 +1585,7 @@ std::unique_ptr<MlxArray> compiled_softcap_sdpa_gqa(
 
 // Compiled GELU MLP forward: down_proj(gelu(gate_proj(x)) * up_proj(x))
 // Compiles entire MLP into a single cached graph
-// Used by: Gemma2, Gemma3 and other GELU-gated models
+// Used by: legacy/tests for precise GELU-gated models
 namespace {
     static std::function<std::vector<array>(const std::vector<array>&)>
     get_compiled_qgelu_mlp() {
@@ -1692,7 +1692,7 @@ std::unique_ptr<MlxArray> compiled_gelu_mlp_forward(
 }
 
 // Compiled quantized GeGLU MLP using Python MLX's tanh-approx GELU.
-// Used by: Gemma4
+// Used by: Gemma2, Gemma3, Gemma4
 namespace {
     static std::function<std::vector<array>(const std::vector<array>&)>
     get_compiled_qgelu_approx_mlp() {
@@ -1959,7 +1959,7 @@ std::unique_ptr<MlxArray> compiled_swiglu_mlp_forward_fp16(
 // The GeGLU activation (gelu(gate) * up) uses the compiled geglu kernel
 // which correctly fuses element-wise ops only.
 //
-// Used by: Gemma2, Gemma3, StarCoder2 and other GELU-gated FP models
+// Used by: Gemma, Gemma4 and other GELU-gated FP models
 std::unique_ptr<MlxArray> compiled_gelu_mlp_forward_fp16(
     const MlxArray& x,
     const MlxArray& gate_weight,
@@ -3402,6 +3402,70 @@ void fused_qkv_project_split_rope(
     q = transpose(q, {0, 2, 1, 3});
     k = transpose(k, {0, 2, 1, 3});
     v = transpose(v, {0, 2, 1, 3});
+
+    q = mlx::core::fast::rope(q, rope_dims, false, rope_base, 1.0f, cache_offset);
+    k = mlx::core::fast::rope(k, rope_dims, false, rope_base, 1.0f, cache_offset);
+
+    q_out = std::make_unique<MlxArray>(std::move(q));
+    k_out = std::make_unique<MlxArray>(std::move(k));
+    v_out = std::make_unique<MlxArray>(std::move(v));
+}
+
+void fused_qkv_project_split_norm_rope(
+    const MlxArray& x,
+    const MlxArray& weight,
+    const MlxArray& scales,
+    const MlxArray* biases,
+    const MlxArray& q_norm_weight,
+    const MlxArray& k_norm_weight,
+    int32_t num_heads,
+    int32_t num_kv_heads,
+    int32_t head_dim,
+    int32_t rope_dims,
+    float rope_base,
+    float rms_eps,
+    int32_t cache_offset,
+    int32_t group_size,
+    int32_t bits,
+    rust::Str mode,
+    std::unique_ptr<MlxArray>& q_out,
+    std::unique_ptr<MlxArray>& k_out,
+    std::unique_ptr<MlxArray>& v_out
+) {
+    using namespace mlx::core;
+
+    auto batch_size = x.inner.shape()[0];
+    auto seq_len = x.inner.shape()[1];
+
+    std::optional<array> biases_opt = biases ? std::optional(biases->inner) : std::nullopt;
+    std::string mode_str(mode.data(), mode.size());
+    auto proj = quantized_matmul(
+        x.inner, weight.inner, scales.inner, biases_opt,
+        true, std::optional<int>(group_size), std::optional<int>(bits), mode_str);
+
+    int q_cols = num_heads * head_dim;
+    int kv_cols = num_kv_heads * head_dim;
+    int qkv_cols = q_cols + (2 * kv_cols);
+
+    auto proj_shape = proj.shape();
+    if (proj_shape.size() != 3 || proj_shape[2] != qkv_cols) {
+        throw std::runtime_error("fused_qkv_project_split_norm_rope: unexpected projection shape");
+    }
+
+    auto q = slice(proj, {0, 0, 0}, {batch_size, seq_len, q_cols});
+    auto k = slice(proj, {0, 0, q_cols}, {batch_size, seq_len, q_cols + kv_cols});
+    auto v = slice(proj, {0, 0, q_cols + kv_cols}, {batch_size, seq_len, qkv_cols});
+
+    q = reshape(q, {batch_size, seq_len, num_heads, head_dim});
+    k = reshape(k, {batch_size, seq_len, num_kv_heads, head_dim});
+    v = reshape(v, {batch_size, seq_len, num_kv_heads, head_dim});
+
+    q = transpose(q, {0, 2, 1, 3});
+    k = transpose(k, {0, 2, 1, 3});
+    v = transpose(v, {0, 2, 1, 3});
+
+    q = mlx::core::fast::rms_norm(q, q_norm_weight.inner, rms_eps);
+    k = mlx::core::fast::rms_norm(k, k_norm_weight.inner, rms_eps);
 
     q = mlx::core::fast::rope(q, rope_dims, false, rope_base, 1.0f, cache_offset);
     k = mlx::core::fast::rope(k, rope_dims, false, rope_base, 1.0f, cache_offset);

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -374,12 +374,12 @@ std::unique_ptr<MlxArray> compiled_relu_squared(const MlxArray& x);
 std::unique_ptr<MlxArray> compiled_silu(const MlxArray& x);
 
 // Compiled gelu: x * 0.5 * (1 + erf(x / sqrt(2))) — single fused kernel
-// Used by: Gemma2, Gemma3, StarCoder2, and other GELU-based models
+// Used by: StarCoder2 and other precise GELU-based models
 std::unique_ptr<MlxArray> compiled_gelu(const MlxArray& x);
 
 // Compiled gelu_approx: erf-based GELU (x * 0.5 * (1 + erf(x / sqrt(2)))) — fused kernel
 // Uses erf instead of tanh for numerical stability with bf16 inputs.
-// Used by: Gemma2, Gemma3 (matches Python nn.gelu_approx)
+// Used by: legacy/tests
 std::unique_ptr<MlxArray> compiled_gelu_approx(const MlxArray& x);
 
 // Compiled gelu_topk: sparse GELU with dynamic threshold — single fused kernel
@@ -408,7 +408,7 @@ std::unique_ptr<MlxArray> compiled_gpt_oss_swiglu_activation(
 
 // GeGLU activation - compiled with kernel fusion (shapeless=true)
 // output = gelu(gate) * x
-// Used by: Gemma, Gemma2, Gemma3 MLP layers
+// Used by: legacy/tests for precise GeGLU
 std::unique_ptr<MlxArray> compiled_geglu_activation(
     const MlxArray& gate,
     const MlxArray& x
@@ -466,7 +466,7 @@ std::unique_ptr<MlxArray> compiled_softcap_sdpa_gqa(
 
 // Compiled GELU MLP forward: down_proj(gelu(gate_proj(x)) * up_proj(x))
 // Fuses gate_proj + gelu + up_proj + multiply + down_proj into compiled graph
-// Used by: Gemma2, Gemma3 and other GELU-gated MLP models
+// Used by: legacy/tests for precise GELU-gated MLP models
 std::unique_ptr<MlxArray> compiled_gelu_mlp_forward(
     const MlxArray& x,
     const MlxArray& gate_proj,
@@ -485,7 +485,7 @@ std::unique_ptr<MlxArray> compiled_gelu_mlp_forward(
 
 // Compiled GELU-approx MLP forward: down_proj(gelu_approx(gate_proj(x)) * up_proj(x))
 // Fuses the quantized projections and Python MLX tanh-approx GeGLU.
-// Used by: Gemma4 dense MLP
+// Used by: Gemma2, Gemma3, Gemma4 dense MLP
 std::unique_ptr<MlxArray> compiled_gelu_approx_mlp_forward(
     const MlxArray& x,
     const MlxArray& gate_proj,
@@ -543,7 +543,7 @@ std::unique_ptr<MlxArray> compiled_swiglu_mlp_forward_fp16(
 // Compiled GELU MLP forward for non-quantized (FP16/BF16) weights:
 //   down_proj(gelu(gate_proj(x)) * up_proj(x))
 // Fuses gate_proj + gelu + up_proj + multiply + down_proj into compiled graph.
-// Used by: Gemma2, Gemma3, StarCoder2 and other GELU-gated FP models
+// Used by: Gemma, Gemma4 and other GELU-gated FP models
 std::unique_ptr<MlxArray> compiled_gelu_mlp_forward_fp16(
     const MlxArray& x,
     const MlxArray& gate_weight,
@@ -934,7 +934,7 @@ std::unique_ptr<MlxArray> fused_qkv_project_and_rope(
 );
 
 // Fused concatenated QKV projection + split + reshape + transpose + RoPE.
-// Used by: Llama3-family fused attention preparation path.
+// Used by: Llama3-family and Gemma2 fused attention preparation paths.
 void fused_qkv_project_split_rope(
     const MlxArray& x,
     const MlxArray& weight,
@@ -945,6 +945,31 @@ void fused_qkv_project_split_rope(
     int32_t head_dim,
     int32_t rope_dims,
     float rope_base,
+    int32_t cache_offset,
+    int32_t group_size,
+    int32_t bits,
+    rust::Str mode,
+    std::unique_ptr<MlxArray>& q_out,
+    std::unique_ptr<MlxArray>& k_out,
+    std::unique_ptr<MlxArray>& v_out
+);
+
+// Fused concatenated QKV projection + split + reshape + transpose +
+// GemmaRMSNorm(Q/K) + RoPE.
+// Used by: Gemma3 dense attention preparation path.
+void fused_qkv_project_split_norm_rope(
+    const MlxArray& x,
+    const MlxArray& weight,
+    const MlxArray& scales,
+    const MlxArray* biases,     // nullable for mxfp4/nvfp4/mxfp8
+    const MlxArray& q_norm_weight,
+    const MlxArray& k_norm_weight,
+    int32_t num_heads,
+    int32_t num_kv_heads,
+    int32_t head_dim,
+    int32_t rope_dims,
+    float rope_base,
+    float rms_eps,
     int32_t cache_offset,
     int32_t group_size,
     int32_t bits,

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -415,6 +415,11 @@ impl GemmaRMSNorm {
     pub fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
         ffi::fast_rms_norm(x, &self.adjusted_weight, self.eps)
     }
+
+    /// Pre-adjusted `(1 + weight)` tensor used by fused Gemma attention paths.
+    pub fn adjusted_weight(&self) -> &MlxArray {
+        &self.adjusted_weight
+    }
 }
 
 /// Layer Normalization layer (standard LayerNorm with weight and optional bias)
@@ -1158,6 +1163,108 @@ impl FusedQKVLinear {
                         self.head_dim,
                         rope_dims,
                         rope_base,
+                        cache_offset,
+                        weight.group_size,
+                        weight.bits,
+                        &weight.mode,
+                        &mut q,
+                        &mut k,
+                        &mut v,
+                    );
+                }
+                Some((q, k, v))
+            }
+            UnifiedLinear::Regular(_) => None,
+        }
+    }
+
+    /// Fused concatenated QKV projection + split + reshape + transpose + RoPE.
+    ///
+    /// Returns Q/K/V already shaped `[B, H, T, D]`. Q/K have RoPE applied.
+    /// Only available for quantized fused-QKV weights.
+    ///
+    /// Used by: Gemma2 dense attention path.
+    pub fn forward_split_rope_quantized(
+        &self,
+        x: &MlxArray,
+        rope_dims: i32,
+        rope_base: f32,
+        cache_offset: i32,
+    ) -> Option<(
+        UniquePtr<MlxArray>,
+        UniquePtr<MlxArray>,
+        UniquePtr<MlxArray>,
+    )> {
+        match &self.qkv_proj {
+            UnifiedLinear::Quantized { weight, .. } => {
+                let mut q = cxx::UniquePtr::null();
+                let mut k = cxx::UniquePtr::null();
+                let mut v = cxx::UniquePtr::null();
+                unsafe {
+                    ffi::fused_qkv_project_split_rope(
+                        x,
+                        &weight.weight,
+                        &weight.scales,
+                        weight.biases_ptr(),
+                        self.n_heads,
+                        self.n_kv_heads,
+                        self.head_dim,
+                        rope_dims,
+                        rope_base,
+                        cache_offset,
+                        weight.group_size,
+                        weight.bits,
+                        &weight.mode,
+                        &mut q,
+                        &mut k,
+                        &mut v,
+                    );
+                }
+                Some((q, k, v))
+            }
+            UnifiedLinear::Regular(_) => None,
+        }
+    }
+
+    /// Fused concatenated QKV projection + split + reshape + transpose +
+    /// GemmaRMSNorm(Q/K) + RoPE.
+    ///
+    /// Returns Q/K/V already shaped `[B, H, T, D]`. Q/K are normalized and
+    /// have RoPE applied. Only available for quantized fused-QKV weights.
+    ///
+    /// Used by: Gemma3 dense attention path.
+    pub fn forward_split_norm_rope_quantized(
+        &self,
+        x: &MlxArray,
+        q_norm: &GemmaRMSNorm,
+        k_norm: &GemmaRMSNorm,
+        rope_dims: i32,
+        rope_base: f32,
+        cache_offset: i32,
+    ) -> Option<(
+        UniquePtr<MlxArray>,
+        UniquePtr<MlxArray>,
+        UniquePtr<MlxArray>,
+    )> {
+        match &self.qkv_proj {
+            UnifiedLinear::Quantized { weight, .. } => {
+                let mut q = cxx::UniquePtr::null();
+                let mut k = cxx::UniquePtr::null();
+                let mut v = cxx::UniquePtr::null();
+                unsafe {
+                    ffi::fused_qkv_project_split_norm_rope(
+                        x,
+                        &weight.weight,
+                        &weight.scales,
+                        weight.biases_ptr(),
+                        q_norm.adjusted_weight(),
+                        k_norm.adjusted_weight(),
+                        self.n_heads,
+                        self.n_kv_heads,
+                        self.head_dim,
+                        rope_dims,
+                        rope_base,
+                        q_norm.eps,
                         cache_offset,
                         weight.group_size,
                         weight.bits,
@@ -2549,7 +2656,7 @@ pub fn metal4_attention(
 ///
 /// Returns `None` if any projection is quantized (caller should use the quantized path).
 ///
-/// Used by: Gemma2, Gemma3, StarCoder2 and other GELU-gated FP models
+/// Used by: Gemma, Gemma4 and other GELU-gated FP models
 pub fn compiled_gelu_mlp_fp16(
     x: &MlxArray,
     gate_proj: &UnifiedLinear,

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -540,20 +540,20 @@ mod ffi {
         fn compiled_silu(x: &MlxArray) -> UniquePtr<MlxArray>;
 
         /// Compiled gelu: x * 0.5 * (1 + erf(x / sqrt(2))) — single fused kernel
-        /// Used by: Gemma2, Gemma3, StarCoder2, and other GELU-based models
+        /// Used by: StarCoder2 and other precise GELU-based models
         fn compiled_gelu(x: &MlxArray) -> UniquePtr<MlxArray>;
 
         /// Compiled gelu_approx: erf-based GELU (x * 0.5 * (1 + erf(x / sqrt(2))))
         /// Uses erf instead of tanh for numerical stability with bf16 inputs.
-        /// Used by: Gemma2, Gemma3 (Python uses gelu_approx)
+        /// Used by: legacy/tests
         fn compiled_gelu_approx(x: &MlxArray) -> UniquePtr<MlxArray>;
 
         /// Compiled GeGLU activation: gelu(gate) * x — single fused kernel
-        /// Used by: Gemma2, Gemma3 MLP layers
+        /// Used by: legacy/tests for precise GeGLU
         fn compiled_geglu_activation(gate: &MlxArray, x: &MlxArray) -> UniquePtr<MlxArray>;
 
         /// Compiled GeGLU activation using Python MLX tanh-approx GELU.
-        /// Used by: Gemma4 MLP and SwitchGeGLU layers
+        /// Used by: Gemma2, Gemma3, Gemma4 MLP and SwitchGeGLU layers
         fn compiled_geglu_approx_activation(gate: &MlxArray, x: &MlxArray) -> UniquePtr<MlxArray>;
 
         /// Compiled gelu_topk: sparse GELU with dynamic threshold — single fused kernel
@@ -596,7 +596,7 @@ mod ffi {
 
         /// Compiled GELU MLP forward: down_proj(gelu(gate_proj(x)) * up_proj(x))
         /// Fuses entire MLP into a single compiled graph
-        /// Used by: Gemma2, Gemma3 and other GELU-gated MLP models
+        /// Used by: legacy/tests for precise GELU-gated MLP models
         unsafe fn compiled_gelu_mlp_forward(
             x: &MlxArray,
             gate_proj: &MlxArray,
@@ -615,7 +615,7 @@ mod ffi {
 
         /// Compiled GELU-approx MLP forward:
         /// down_proj(gelu_approx(gate_proj(x)) * up_proj(x)).
-        /// Used by: Gemma4 dense MLP
+        /// Used by: Gemma2, Gemma3, Gemma4 dense MLP
         unsafe fn compiled_gelu_approx_mlp_forward(
             x: &MlxArray,
             gate_proj: &MlxArray,
@@ -672,7 +672,7 @@ mod ffi {
 
         /// Compiled GELU MLP forward for non-quantized (FP16/BF16) weights
         /// Fuses gate_proj + gelu + up_proj + multiply + down_proj into compiled graph
-        /// Used by: Gemma2, Gemma3, StarCoder2 and other GELU-gated FP models
+        /// Used by: Gemma, Gemma4 and other GELU-gated FP models
         unsafe fn compiled_gelu_mlp_forward_fp16(
             x: &MlxArray,
             gate_weight: &MlxArray,
@@ -1198,7 +1198,7 @@ mod ffi {
         ) -> UniquePtr<MlxArray>;
 
         /// Fused concatenated QKV projection + split + reshape + transpose + RoPE.
-        /// Used by: Llama3-family fused attention preparation path.
+        /// Used by: Llama3-family and Gemma2 fused attention preparation paths.
         unsafe fn fused_qkv_project_split_rope(
             x: &MlxArray,
             weight: &MlxArray,
@@ -1209,6 +1209,31 @@ mod ffi {
             head_dim: i32,
             rope_dims: i32,
             rope_base: f32,
+            cache_offset: i32,
+            group_size: i32,
+            bits: i32,
+            mode: &str,
+            q_out: &mut UniquePtr<MlxArray>,
+            k_out: &mut UniquePtr<MlxArray>,
+            v_out: &mut UniquePtr<MlxArray>,
+        );
+
+        /// Fused concatenated QKV projection + split + reshape + transpose +
+        /// GemmaRMSNorm(Q/K) + RoPE.
+        /// Used by: Gemma3 dense attention preparation path.
+        unsafe fn fused_qkv_project_split_norm_rope(
+            x: &MlxArray,
+            weight: &MlxArray,
+            scales: &MlxArray,
+            biases: *const MlxArray,
+            q_norm_weight: &MlxArray,
+            k_norm_weight: &MlxArray,
+            num_heads: i32,
+            num_kv_heads: i32,
+            head_dim: i32,
+            rope_dims: i32,
+            rope_base: f32,
+            rms_eps: f32,
             cache_offset: i32,
             group_size: i32,
             bits: i32,

--- a/src/models/gemma2.rs
+++ b/src/models/gemma2.rs
@@ -138,25 +138,32 @@ impl Attention {
         let shape = mlxcel_core::array_shape(x);
         let b = shape[0];
         let l = shape[1];
-
-        // Fused QKV projection: single matmul → split into Q, K, V
-        let (q, k, v) = self.qkv_proj.forward(x);
-
-        // Reshape to [batch, seq_len, n_heads, head_dim]
-        let q = mlxcel_core::reshape(&q, &[b, l, self.num_heads, self.head_dim]);
-        let k = mlxcel_core::reshape(&k, &[b, l, self.num_kv_heads, self.head_dim]);
-        let v = mlxcel_core::reshape(&v, &[b, l, self.num_kv_heads, self.head_dim]);
-
-        // Transpose to [batch, n_heads, seq_len, head_dim]
-        let q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
-        let k = mlxcel_core::transpose_axes(&k, &[0, 2, 1, 3]);
-        let v = mlxcel_core::transpose_axes(&v, &[0, 2, 1, 3]);
-
         let offset = cache.offset;
 
-        // Apply RoPE
-        let q = mlxcel_core::fast_rope(&q, self.rope_dims, false, self.rope_base, 1.0, offset);
-        let k = mlxcel_core::fast_rope(&k, self.rope_dims, false, self.rope_base, 1.0, offset);
+        let (q, k, v) = if let Some((q, k, v)) =
+            self.qkv_proj
+                .forward_split_rope_quantized(x, self.rope_dims, self.rope_base, offset)
+        {
+            (q, k, v)
+        } else {
+            // Fused QKV projection: single matmul → split into Q, K, V
+            let (q, k, v) = self.qkv_proj.forward(x);
+
+            // Reshape to [batch, seq_len, n_heads, head_dim]
+            let q = mlxcel_core::reshape(&q, &[b, l, self.num_heads, self.head_dim]);
+            let k = mlxcel_core::reshape(&k, &[b, l, self.num_kv_heads, self.head_dim]);
+            let v = mlxcel_core::reshape(&v, &[b, l, self.num_kv_heads, self.head_dim]);
+
+            // Transpose to [batch, n_heads, seq_len, head_dim]
+            let q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
+            let k = mlxcel_core::transpose_axes(&k, &[0, 2, 1, 3]);
+            let v = mlxcel_core::transpose_axes(&v, &[0, 2, 1, 3]);
+
+            // Apply RoPE
+            let q = mlxcel_core::fast_rope(&q, self.rope_dims, false, self.rope_base, 1.0, offset);
+            let k = mlxcel_core::fast_rope(&k, self.rope_dims, false, self.rope_base, 1.0, offset);
+            (q, k, v)
+        };
 
         // Update KV cache and get sliced views
         let (cache_k, cache_v) = cache.update_and_fetch(k, v);
@@ -241,7 +248,7 @@ impl MLP {
             self.down_proj.quantized_weight(),
         ) {
             return unsafe {
-                mlxcel_core::compiled_gelu_mlp_forward(
+                mlxcel_core::compiled_gelu_approx_mlp_forward(
                     x,
                     &gate_qw.weight,
                     &gate_qw.scales,
@@ -259,20 +266,10 @@ impl MLP {
             };
         }
 
-        // Non-quantized path: fused compiled FP MLP
-        if let Some(result) = mlxcel_core::layers::compiled_gelu_mlp_fp16(
-            x,
-            &self.gate_proj,
-            &self.up_proj,
-            &self.down_proj,
-        ) {
-            return result;
-        }
-
         // Fallback: separate operations with compiled activation
         let gate = self.gate_proj.forward(x);
         let up = self.up_proj.forward(x);
-        let activated = mlxcel_core::compiled_geglu_activation(&gate, &up);
+        let activated = mlxcel_core::compiled_geglu_approx_activation(&gate, &up);
         self.down_proj.forward(&activated)
     }
 

--- a/src/models/gemma3.rs
+++ b/src/models/gemma3.rs
@@ -138,28 +138,39 @@ impl Attention {
         let shape = mlxcel_core::array_shape(x);
         let b = shape[0];
         let l = shape[1];
-
-        // Fused QKV projection: single matmul → split into Q, K, V
-        let (q, k, v) = self.qkv_proj.forward(x);
-
-        // Reshape and transpose to [batch, n_heads, seq_len, head_dim]
-        let q = mlxcel_core::reshape(&q, &[b, l, self.num_heads, self.head_dim]);
-        let k = mlxcel_core::reshape(&k, &[b, l, self.num_kv_heads, self.head_dim]);
-        let v = mlxcel_core::reshape(&v, &[b, l, self.num_kv_heads, self.head_dim]);
-
-        let q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
-        let k = mlxcel_core::transpose_axes(&k, &[0, 2, 1, 3]);
-        let v = mlxcel_core::transpose_axes(&v, &[0, 2, 1, 3]);
-
-        // Apply Q/K normalization AFTER transpose (matches Python mlx-lm)
-        let q = self.q_norm.forward(&q);
-        let k = self.k_norm.forward(&k);
-
         let offset = cache.offset();
 
-        // Apply RoPE
-        let q = mlxcel_core::fast_rope(&q, self.head_dim, false, self.rope_base, 1.0, offset);
-        let k = mlxcel_core::fast_rope(&k, self.head_dim, false, self.rope_base, 1.0, offset);
+        let (q, k, v) = if let Some((q, k, v)) = self.qkv_proj.forward_split_norm_rope_quantized(
+            x,
+            &self.q_norm,
+            &self.k_norm,
+            self.head_dim,
+            self.rope_base,
+            offset,
+        ) {
+            (q, k, v)
+        } else {
+            // Fused QKV projection: single matmul → split into Q, K, V
+            let (q, k, v) = self.qkv_proj.forward(x);
+
+            // Reshape and transpose to [batch, n_heads, seq_len, head_dim]
+            let q = mlxcel_core::reshape(&q, &[b, l, self.num_heads, self.head_dim]);
+            let k = mlxcel_core::reshape(&k, &[b, l, self.num_kv_heads, self.head_dim]);
+            let v = mlxcel_core::reshape(&v, &[b, l, self.num_kv_heads, self.head_dim]);
+
+            let q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
+            let k = mlxcel_core::transpose_axes(&k, &[0, 2, 1, 3]);
+            let v = mlxcel_core::transpose_axes(&v, &[0, 2, 1, 3]);
+
+            // Apply Q/K normalization AFTER transpose (matches Python mlx-lm)
+            let q = self.q_norm.forward(&q);
+            let k = self.k_norm.forward(&k);
+
+            // Apply RoPE
+            let q = mlxcel_core::fast_rope(&q, self.head_dim, false, self.rope_base, 1.0, offset);
+            let k = mlxcel_core::fast_rope(&k, self.head_dim, false, self.rope_base, 1.0, offset);
+            (q, k, v)
+        };
 
         // Update KV cache and get sliced views
         let (cache_k, cache_v) = cache.update_and_fetch(k, v);
@@ -428,7 +439,7 @@ impl MLP {
             self.down_proj.quantized_weight(),
         ) {
             return unsafe {
-                mlxcel_core::compiled_gelu_mlp_forward(
+                mlxcel_core::compiled_gelu_approx_mlp_forward(
                     x,
                     &gate_qw.weight,
                     &gate_qw.scales,
@@ -446,20 +457,10 @@ impl MLP {
             };
         }
 
-        // Non-quantized path: fused compiled FP MLP
-        if let Some(result) = mlxcel_core::layers::compiled_gelu_mlp_fp16(
-            x,
-            &self.gate_proj,
-            &self.up_proj,
-            &self.down_proj,
-        ) {
-            return result;
-        }
-
         // Fallback: separate operations with compiled activation
         let gate = self.gate_proj.forward(x);
         let up = self.up_proj.forward(x);
-        let activated = mlxcel_core::compiled_geglu_activation(&gate, &up);
+        let activated = mlxcel_core::compiled_geglu_approx_activation(&gate, &up);
         self.down_proj.forward(&activated)
     }
 


### PR DESCRIPTION
## Summary

Aligns the Gemma2 / Gemma3 dense MLP with Python mlx-lm's tanh-approximation GeGLU and fuses the quantized attention prologue for both models. This is both a parity correction and a decode speedup.

## What changed

- **GeGLU parity**: the Gemma2/Gemma3 dense MLP now uses `nn.gelu_approx` (tanh-approx GeGLU), matching mlx-lm, instead of the erf-based precise GELU. The dense path reuses Gemma4's already-compiled `compiled_gelu_approx_mlp_forward` / `compiled_geglu_approx_activation` kernels. `mlxcel-core` kernel doc comments are updated to reflect which models drive each variant.
- **Fused quantized QKV**:
  - Gemma2 → `UnifiedLinear::forward_split_rope_quantized` (QKV projection + split + reshape + transpose + RoPE).
  - Gemma3 → `forward_split_norm_rope_quantized`, which additionally applies GemmaRMSNorm on Q/K before RoPE via the new `fused_qkv_project_split_norm_rope` bridge.
- **Faithful fallback**: both attention call sites fall back to the original step-by-step Rust path for non-quantized weights, so behaviour there is unchanged.

## Benchmarks (M5 Max)

| Model | Before | After | vs mlx-lm |
|-------|--------|-------|-----------|
| `gemma2-2b-4bit` (text) | 196.72 | 241.96 tok/s | 81% → 100% |
| `gemma3-4b-4bit` (text) | 146.43 | 182.16 tok/s | 81% → 100% |
| `gemma3-4b-4bit` (VLM) | 127.61 | 159.58 tok/s | — |

`gemma-2b` and `gemma3-1b` stay healthy as guardrails.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --features metal,accelerate -- -D warnings` clean (rebuilds the C++ bridge)
- Greedy generation on `gemma-3-4b-it-4bit` produces coherent text through the fused Gemma3 norm-rope path + gelu_approx MLP
