### PR TITLE
fix(cuda): append 90a arch suffix for Hopper auto-detect/fallback builds

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -76,17 +76,22 @@ CUDA_HOME=/opt/cuda cargo build --release --features cuda
 
 `src/lib/mlxcel-core/build.rs` reads `MLX_CUDA_ARCHITECTURES`. If it is unset,
 the build script tries to detect the compute capability with `nvidia-smi` and
-falls back to `90` when detection fails.
+falls back to `90a` when detection fails. For SM 90 and above it appends CUDA's
+architecture-specific `a` suffix (so `90` becomes `90a`), because the dedicated
+Hopper quantized kernel (`qmm_sm90`) is only compiled when `90a` is in the arch
+list. An explicitly set `MLX_CUDA_ARCHITECTURES` is used verbatim, so include the
+suffix yourself for Hopper (`90a`).
 
 ```bash
-# Hopper / GH200-style target.
-MLX_CUDA_ARCHITECTURES=90 cargo build --release --features cuda
+# Hopper / GH200-style target. The `a` suffix is required for the Hopper
+# quantized kernel; plain `90` builds without it.
+MLX_CUDA_ARCHITECTURES=90a cargo build --release --features cuda
 
 # GB10 / DGX Spark-style target used by the release workflow.
 MLX_CUDA_ARCHITECTURES=121 cargo build --release --features cuda
 
 # Multiple targets, if your MLX/CUDA toolchain supports them.
-MLX_CUDA_ARCHITECTURES="90;121" cargo build --release --features cuda
+MLX_CUDA_ARCHITECTURES="90a;121" cargo build --release --features cuda
 ```
 
 The repository release workflow currently builds Linux ARM64 CUDA artifacts for
@@ -98,7 +103,7 @@ combinations as source builds that need local validation.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `CUDA_HOME` | CUDA toolkit root used by the build script | `/usr/local/cuda` when present |
-| `MLX_CUDA_ARCHITECTURES` | CUDA SM target list, build-time | auto-detect via `nvidia-smi`, then `90` fallback |
+| `MLX_CUDA_ARCHITECTURES` | CUDA SM target list, build-time | auto-detect via `nvidia-smi`, then `90a` fallback |
 | `MLXCEL_DEVICE` | Runtime device hint (`gpu` or `cpu`) | auto |
 | `MLXCEL_WIRED_LIMIT` | Apple Silicon wired-memory ceiling, e.g. `64GB`; `0`/`none` disables it | `max` |
 | `LLAMA_ARG_*` | Environment-backed server options accepted by clap | unset |

--- a/src/lib/mlxcel-core/build.rs
+++ b/src/lib/mlxcel-core/build.rs
@@ -217,9 +217,19 @@ fn build_mlx() -> PathBuf {
             config.define("CMAKE_CUDA_COMPILER", "/usr/local/cuda/bin/nvcc");
         }
 
-        // Set CUDA architecture - use env var or auto-detect via nvidia-smi
+        // CUDA architecture selection. An explicitly set MLX_CUDA_ARCHITECTURES is
+        // honored verbatim (escape hatch); otherwise we auto-detect via nvidia-smi
+        // and fall back to Hopper's sm_90a.
+        //
+        // The `a` suffix is load-bearing: MLX only defines MLX_CUDA_SM90A_ENABLED
+        // (which compiles the dedicated Hopper `qmm_sm90` quantized kernel) when
+        // "90a" is in the arch list. MLX's own CMake appends that suffix for
+        // cc >= 90, but only inside its `if(NOT DEFINED MLX_CUDA_ARCHITECTURES)`
+        // branch. Because we always pass MLX_CUDA_ARCHITECTURES explicitly, that
+        // branch never runs, so we apply the same rule ourselves here and in
+        // detect_cuda_arch. See docs/installation.md (CUDA architecture selection).
         let cuda_arch = env::var("MLX_CUDA_ARCHITECTURES")
-            .unwrap_or_else(|_| detect_cuda_arch().unwrap_or_else(|| "90".to_string()));
+            .unwrap_or_else(|_| detect_cuda_arch().unwrap_or_else(|| "90a".to_string()));
         config.define("MLX_CUDA_ARCHITECTURES", &cuda_arch);
     }
 
@@ -248,14 +258,15 @@ fn detect_cuda_arch() -> Option<String> {
         .output()
         .ok()?;
     let caps = String::from_utf8_lossy(&output.stdout);
-    // Parse "X.Y" compute capabilities, convert to SM number (e.g. "9.0" -> "90")
+    // Parse "X.Y" compute capabilities, convert to SM number (e.g. "9.0" -> "90"),
+    // and append the architecture-specific "a" suffix for cc >= 90 (e.g. "90a").
     let archs: Vec<String> = caps
         .lines()
         .filter_map(|line| {
             let line = line.trim();
             let parts: Vec<&str> = line.split('.').collect();
             if parts.len() == 2 {
-                Some(format!("{}{}", parts[0], parts[1]))
+                Some(sm_arch_with_suffix(&format!("{}{}", parts[0], parts[1])))
             } else {
                 None
             }
@@ -269,6 +280,21 @@ fn detect_cuda_arch() -> Option<String> {
         unique.sort();
         unique.dedup();
         Some(unique.join(";"))
+    }
+}
+
+/// Append CUDA's architecture-specific `a` suffix for SM >= 90, mirroring MLX's
+/// own CMake logic (`MLX_CUDA_ARCHITECTURES GREATER_EQUAL 90` -> append `a`).
+///
+/// The `a` suffix enables architecture-specific features (e.g. Hopper wgmma/TMA)
+/// the dedicated quantized kernels rely on, and it gates MLX_CUDA_SM90A_ENABLED on
+/// "90a" (not "90"). SM < 90 (e.g. Ampere sm_80/sm_86) has no `a` variant and is
+/// returned unchanged.
+#[cfg(feature = "cuda")]
+fn sm_arch_with_suffix(sm: &str) -> String {
+    match sm.parse::<u32>() {
+        Ok(n) if n >= 90 => format!("{sm}a"),
+        _ => sm.to_string(),
     }
 }
 


### PR DESCRIPTION
## Summary

CUDA quantized inference on Hopper uses the dedicated `qmm_sm90` WGMMA kernel, which MLX compiles only when `MLX_CUDA_SM90A_ENABLED` is defined. MLX gates that define on `90a` (not plain `90`) being in the arch list.

`build.rs` always passes `MLX_CUDA_ARCHITECTURES` explicitly, so the MLX CMake `90 -> 90a` auto-suffix (gated on `if(NOT DEFINED MLX_CUDA_ARCHITECTURES)`) never runs. Auto-detect (`nvidia-smi` reports `9.0`, parsed to `90`) and the unset fallback (`90`) both produced builds without the Hopper kernel. On Hopper this silently drops the dedicated path, and configs that select `qmm_sm90` can hit a runtime `"Hopper-only kernel is not available"`.

## Changes

- `detect_cuda_arch` appends the architecture-specific `a` suffix for cc >= 90 (mirroring the MLX CMake rule): `90` becomes `90a`, `121` becomes `121a`.
- The unset fallback now defaults to `90a`.
- An explicitly set `MLX_CUDA_ARCHITECTURES` is still honored verbatim (escape hatch).
- `docs/installation.md`: document the `a`-suffix behavior and the verbatim escape hatch, and update the examples and env-var table.

## Notes

- The release workflow already builds the GH200 artifact with `90a`, so released binaries are unaffected. This fixes source and auto-detect builds.
- Suffix logic verified in isolation (`90` to `90a`, `121` to `121a`; `89/86/80/75` unchanged). The CUDA path is `#[cfg(feature = "cuda")]`-gated, so the metal/accelerate CI build does not exercise it.
