### PR TITLE
fix: tighten memory estimator preflight coverage

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -208,11 +208,7 @@ fn log_estimate_vs_actual_delta(est: &MemoryEstimate, snap: &mlxcel_core::memory
 
     let est_bytes = est.total_bytes;
     let actual = snap.active_bytes;
-    let (delta_label, delta_bytes) = if actual >= est_bytes {
-        ("over-estimated by", actual.saturating_sub(est_bytes))
-    } else {
-        ("under-estimated by", est_bytes.saturating_sub(actual))
-    };
+    let (delta_label, delta_bytes) = estimate_delta_label_and_bytes(est_bytes, actual);
     let ratio = if est_bytes > 0 {
         actual as f64 / est_bytes as f64
     } else {
@@ -239,6 +235,19 @@ fn log_estimate_vs_actual_delta(est: &MemoryEstimate, snap: &mlxcel_core::memory
     );
 }
 
+fn estimate_delta_label_and_bytes(estimate: u64, actual: u64) -> (&'static str, u64) {
+    if actual >= estimate {
+        ("under-estimated by", actual.saturating_sub(estimate))
+    } else {
+        ("over-estimated by", estimate.saturating_sub(actual))
+    }
+}
+
+fn memory_preflight_ctx_len(prompt_tokens: usize, max_tokens: usize) -> u64 {
+    let total = prompt_tokens.saturating_add(max_tokens).max(1);
+    u64::try_from(total).unwrap_or(u64::MAX)
+}
+
 /// Run the `--estimate-memory` preflight for `mlxcel generate`.
 ///
 /// Returns `Some(estimate)` when the user passed `--estimate-memory`
@@ -251,28 +260,27 @@ fn log_estimate_vs_actual_delta(est: &MemoryEstimate, snap: &mlxcel_core::memory
 /// figure and the override flags. Always prints the formatted
 /// breakdown before aborting so operators can see the same byte
 /// table `mlxcel inspect` would have shown.
-fn run_memory_preflight(args: &GenerateArgs) -> Result<Option<MemoryEstimate>> {
+fn run_memory_preflight(
+    args: &GenerateArgs,
+    prompt_token_count: usize,
+) -> Result<Option<MemoryEstimate>> {
     if !args.generation.estimate_memory {
         return Ok(None);
     }
 
-    // Derive int8 KV from the existing --cache-type-k / --cache-type-v
-    // pair so the preflight reflects what the loaded cache will
-    // actually allocate. Mixed-precision configurations fall back to
-    // FP16 sizing because the size formula does not model them
-    // directly — surfaced in the printed breakdown.
-    let kv_int8 = matches!(
-        (
-            args.generation.turbo.cache_type_k.as_deref(),
-            args.generation.turbo.cache_type_v.as_deref(),
-        ),
-        (Some("int8"), Some("int8")) | (Some("i8"), Some("i8"))
-    );
+    let kv_cache_mode = resolve_kv_cache_mode(
+        args.generation.turbo.cache_type_k.as_deref(),
+        args.generation.turbo.cache_type_v.as_deref(),
+        args.generation.turbo.kv_cache_mode.as_deref(),
+    )
+    .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let kv_int8 = matches!(kv_cache_mode, KVCacheMode::Int8);
 
-    // Use the user's `--max-tokens` as the KV ctx_len input. This
-    // matches the way `mlxcel inspect --max-tokens N` sizes the KV
-    // estimate, so the preflight and the inspect view never disagree.
-    let ctx_len = args.generation.max_tokens.max(1) as u64;
+    // Size the KV cache for the tokens that can actually enter the cache:
+    // rendered prompt tokens plus the requested decode budget. This still runs
+    // before model load, but after tokenizer/template processing has made the
+    // prompt length knowable.
+    let ctx_len = memory_preflight_ctx_len(prompt_token_count, args.generation.max_tokens);
 
     let estimate =
         estimate_total_memory(&args.model.model, ctx_len, 1, QuantHint::Default, kv_int8);
@@ -1052,15 +1060,6 @@ pub(crate) fn run_generate(args: GenerateArgs) -> Result<()> {
         }
     }
 
-    // Memory preflight (issue #56). Runs the unified estimator and
-    // aborts when total > available. Skipped when --estimate-memory
-    // was not passed. --force / --no-memory-check downgrades the
-    // abort to a warning. Sub-issue C's `MLXCEL_MEMORY_LIMIT` env hook
-    // is honoured transparently by the estimator's
-    // `resolve_available_memory` step (MLX allocator soft cap wins
-    // over OS RAM when nonzero).
-    let preflight_estimate = run_memory_preflight(&args)?;
-
     let pipeline_requested = cli_pipeline_requested(&args);
     let tokenizer = load_tokenizer(&args.model.model)?;
     let prompt = load_cli_prompt(
@@ -1070,6 +1069,11 @@ pub(crate) fn run_generate(args: GenerateArgs) -> Result<()> {
         args.generation.image.len(),
     );
     let mut prompt_tokens = tokenize_prompt(&tokenizer, &prompt)?;
+
+    // Memory preflight (issue #56). Runs after prompt rendering/tokenization so
+    // long prompts are included in the KV-cache budget, but still before the
+    // model weights are loaded.
+    let preflight_estimate = run_memory_preflight(&args, prompt_tokens.len())?;
 
     let sampling_config =
         build_cli_sampling_config(&args, mlxcel::read_eos_token_ids(&args.model.model));

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 use super::{
-    apply_user_chat_template, cli_pipeline_requested, generated_suffix,
-    generation_stats_from_duration, resolve_cli_pipeline_assignments, resolve_cli_prompt,
-    validate_pipeline_parallel_args, validate_tensor_parallel_args,
+    apply_user_chat_template, cli_pipeline_requested, estimate_delta_label_and_bytes,
+    generated_suffix, generation_stats_from_duration, memory_preflight_ctx_len,
+    resolve_cli_pipeline_assignments, resolve_cli_prompt, validate_pipeline_parallel_args,
+    validate_tensor_parallel_args,
 };
 use mlxcel::server::chat_template::ChatTemplateProcessor;
 use std::fs;
@@ -38,6 +39,24 @@ fn generation_stats_from_duration_handles_zero_elapsed_time() {
 
     assert_eq!(stats.decode_time_ms, 0.0);
     assert_eq!(stats.decode_tok_per_sec, 0.0);
+}
+
+#[test]
+fn estimate_delta_labels_match_actual_direction() {
+    assert_eq!(
+        estimate_delta_label_and_bytes(100, 125),
+        ("under-estimated by", 25)
+    );
+    assert_eq!(
+        estimate_delta_label_and_bytes(125, 100),
+        ("over-estimated by", 25)
+    );
+}
+
+#[test]
+fn memory_preflight_ctx_len_includes_prompt_and_generation_budget() {
+    assert_eq!(memory_preflight_ctx_len(4096, 128), 4224);
+    assert_eq!(memory_preflight_ctx_len(0, 0), 1);
 }
 
 #[test]

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -24,7 +24,9 @@
 
 use anyhow::{Result, anyhow};
 
+use mlxcel::cli::turbo_args::resolve_kv_cache_mode;
 use mlxcel::memory_estimate::{QuantHint, estimate_total_memory, format_estimate};
+use mlxcel_core::cache::KVCacheMode;
 
 use crate::InspectArgs;
 
@@ -40,18 +42,13 @@ pub(crate) fn run_inspect(args: InspectArgs) -> Result<()> {
     // Translate the user-facing `--quant` label into the typed hint.
     let quant = parse_quant_hint(&args.quant)?;
 
-    // Translate the K/V cache flag pair into the int8/fp16 decision the
-    // estimator understands. Both flags must point at int8 for KV
-    // bytes to halve; any other combination is treated as fp16 (the
-    // default) since mixed-precision KV is not directly modelled in
-    // the size formula. Surface the consequence in the printed output.
-    let kv_int8 = matches!(
-        (
-            args.turbo.cache_type_k.as_deref(),
-            args.turbo.cache_type_v.as_deref(),
-        ),
-        (Some("int8"), Some("int8")) | (Some("i8"), Some("i8"))
-    );
+    let kv_cache_mode = resolve_kv_cache_mode(
+        args.turbo.cache_type_k.as_deref(),
+        args.turbo.cache_type_v.as_deref(),
+        args.turbo.kv_cache_mode.as_deref(),
+    )
+    .map_err(|e| anyhow!("{}", e))?;
+    let kv_int8 = matches!(kv_cache_mode, KVCacheMode::Int8);
 
     let estimate = estimate_total_memory(&args.model, args.max_tokens, args.batch, quant, kv_int8);
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -20,6 +20,7 @@
 //! on schema and routing.
 
 use mlxcel::cli::speculative_args::{env_fallback_draft_block_size, env_fallback_draft_kind};
+use mlxcel::cli::turbo_args::resolve_kv_cache_mode;
 use mlxcel::memory_estimate::{QuantHint, estimate_total_memory, format_bytes, format_estimate};
 use mlxcel::server::{
     ServerStartupInput, env_fallback_apc_block_size, env_fallback_apc_enabled,
@@ -31,6 +32,7 @@ use mlxcel::server::{
     env_fallback_prompt_cache_max_entries, env_fallback_prompt_cache_min_prefix,
     env_fallback_prompt_cache_ttl, env_fallback_reasoning_budget, start_server,
 };
+use mlxcel_core::cache::KVCacheMode;
 
 /// Run the `mlxcel serve` subcommand.
 #[tokio::main]
@@ -57,24 +59,18 @@ fn run_serve_memory_preflight(args: &crate::ServeArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let kv_int8 = matches!(
-        (
-            args.turbo.cache_type_k.as_deref(),
-            args.turbo.cache_type_v.as_deref(),
-        ),
-        (Some("int8"), Some("int8")) | (Some("i8"), Some("i8"))
-    );
+    let kv_cache_mode = resolve_kv_cache_mode(
+        args.turbo.cache_type_k.as_deref(),
+        args.turbo.cache_type_v.as_deref(),
+        args.turbo.kv_cache_mode.as_deref(),
+    )
+    .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let kv_int8 = matches!(kv_cache_mode, KVCacheMode::Int8);
 
-    // `--ctx-size 0` is the "use model default" sentinel; in that
-    // case we fall back to 8192 to match the historical sizing used
-    // by `--recommend-quant`.
-    let ctx_len = if args.ctx_size > 0 {
-        args.ctx_size as u64
-    } else {
-        mlxcel::memory_estimate::DEFAULT_CTX_LEN
-    };
+    let ctx_len = serve_preflight_ctx_len(args);
+    let batch = serve_preflight_batch(args);
 
-    let estimate = estimate_total_memory(&args.model, ctx_len, 1, QuantHint::Default, kv_int8);
+    let estimate = estimate_total_memory(&args.model, ctx_len, batch, QuantHint::Default, kv_int8);
 
     let banner = format_estimate(&args.model, &estimate);
     println!("{banner}");
@@ -99,6 +95,29 @@ fn run_serve_memory_preflight(args: &crate::ServeArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn serve_preflight_ctx_len(args: &crate::ServeArgs) -> u64 {
+    // `--ctx-size 0` is the "use model default" sentinel; in that case we
+    // fall back to 8192 to match the historical sizing used by
+    // `--recommend-quant`. `--max-kv-size` caps the plain KV cache length.
+    let mut ctx_len = if args.ctx_size > 0 {
+        args.ctx_size as u64
+    } else {
+        mlxcel::memory_estimate::DEFAULT_CTX_LEN
+    };
+    if args.max_kv_size > 0 {
+        ctx_len = ctx_len.min(args.max_kv_size as u64);
+    }
+    ctx_len.max(1)
+}
+
+fn serve_preflight_batch(args: &crate::ServeArgs) -> u64 {
+    if args.no_batch {
+        return 1;
+    }
+    let active_sequences = args.max_batch_size.unwrap_or(args.n_parallel).max(1);
+    u64::try_from(active_sequences).unwrap_or(u64::MAX)
 }
 
 fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStartupInput> {

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -14,7 +14,7 @@
 
 use std::path::PathBuf;
 
-use super::build_startup_input;
+use super::{build_startup_input, serve_preflight_batch, serve_preflight_ctx_len};
 
 fn sample_args() -> crate::ServeArgs {
     crate::ServeArgs {
@@ -150,6 +150,36 @@ fn build_startup_input_preserves_edge_flags_for_normalization() {
         vec!["\n".to_string(), "\t".to_string()]
     );
     assert_eq!(input.decode_storage_backend, None);
+}
+
+#[test]
+fn serve_preflight_batch_uses_max_batch_size_when_batching_enabled() {
+    let args = sample_args();
+    assert_eq!(serve_preflight_batch(&args), 4);
+}
+
+#[test]
+fn serve_preflight_batch_falls_back_to_parallelism_and_honors_no_batch() {
+    let mut args = sample_args();
+    args.max_batch_size = None;
+    assert_eq!(serve_preflight_batch(&args), 3);
+
+    args.no_batch = true;
+    assert_eq!(serve_preflight_batch(&args), 1);
+}
+
+#[test]
+fn serve_preflight_ctx_len_uses_default_and_max_kv_cap() {
+    let mut args = sample_args();
+    args.ctx_size = 0;
+    assert_eq!(
+        serve_preflight_ctx_len(&args),
+        mlxcel::memory_estimate::DEFAULT_CTX_LEN
+    );
+
+    args.ctx_size = 8192;
+    args.max_kv_size = 2048;
+    assert_eq!(serve_preflight_ctx_len(&args), 2048);
 }
 
 #[test]

--- a/src/execution/memory_estimate.rs
+++ b/src/execution/memory_estimate.rs
@@ -52,7 +52,7 @@ use mlxcel_core::hardware::{
 };
 use mlxcel_core::weights::weight_footprint_bytes;
 
-use super::quant_advisor::{estimate_kv_cache_bytes_from_path, estimate_model_params_billions};
+use super::quant_advisor::estimate_model_params_billions;
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -99,6 +99,13 @@ pub const DEFAULT_HEADROOM_FACTOR: f64 = 1.20;
 /// log a warning. Used during calibration on Apple Silicon (see the
 /// recipe on [`DEFAULT_HEADROOM_FACTOR`]).
 pub const HEADROOM_FACTOR_ENV: &str = "MLXCEL_HEADROOM_FACTOR";
+
+/// Env var applied by `execution::runtime` as an MLX allocator soft cap.
+///
+/// `mlxcel inspect` and the `serve --estimate-memory` preflight run before
+/// that runtime initializer, so the estimator must read this env var directly
+/// as well as checking `mlxcel_core::memory::memory_limit()`.
+const MEMORY_LIMIT_ENV: &str = "MLXCEL_MEMORY_LIMIT";
 
 /// Default context length when the caller does not pass one (e.g. the
 /// quant advisor's legacy 8K sizing). Matches the previous
@@ -200,9 +207,9 @@ pub struct MemoryEstimate {
     /// this is `HardwareCapabilities::unified_memory_gb << 30`. On
     /// Linux/CUDA it falls back to `/proc/meminfo::MemAvailable` (or
     /// `MemTotal` when the former is missing). On any platform a
-    /// nonzero MLX allocator soft limit (`memory_limit()`) caps this
-    /// figure — the preflight is meaningful even with no OS query
-    /// because operators can pin a budget via `MLXCEL_MEMORY_LIMIT`.
+    /// nonzero `MLXCEL_MEMORY_LIMIT` / MLX allocator soft limit caps
+    /// this figure — the preflight is meaningful even with no OS
+    /// query because operators can pin a budget explicitly.
     pub available_bytes: u64,
     /// `total_bytes <= available_bytes`. The preflight uses this
     /// directly.
@@ -276,8 +283,8 @@ pub fn estimate_total_memory(
 
     // ── KV cache ─────────────────────────────────────────────────────────────
     let (kv_cache_bytes, kv_source) =
-        match estimate_kv_cache_bytes_from_path(model_dir, ctx_len, kv_dtype_int8) {
-            Some(b) => (b, KvSource::Config),
+        match kv_cache_params_from_path(model_dir, ctx_len, kv_dtype_int8, batch) {
+            Some(params) => (kv_cache_bytes_from_params(&params), KvSource::Config),
             None => (0, KvSource::Unavailable),
         };
 
@@ -386,18 +393,29 @@ fn resolve_weight_bytes(model_dir: &Path) -> (u64, WeightsSource) {
 /// Resolve the best-known "available unified memory" figure in bytes.
 ///
 /// Resolution order:
-/// 1. `mlxcel_core::memory::memory_limit()` when nonzero — the MLX
-///    allocator soft cap (set by `MLXCEL_MEMORY_LIMIT`) is the most
-///    authoritative "what will MLX actually let me allocate" signal.
-/// 2. `HardwareCapabilities::unified_memory_gb << 30` when nonzero —
+/// 1. `MLXCEL_MEMORY_LIMIT` when set to a nonzero value — this catches
+///    estimate-only commands that run before the MLX runtime initializer
+///    applies the allocator soft cap.
+/// 2. `mlxcel_core::memory::memory_limit()` when nonzero — the already-applied
+///    MLX allocator soft cap is the next most authoritative "what will MLX
+///    actually let me allocate" signal.
+/// 3. `HardwareCapabilities::unified_memory_gb << 30` when nonzero —
 ///    populated by `sysctl(hw.memsize)` on macOS.
-/// 3. `/proc/meminfo::MemAvailable` (then `MemTotal`) on Linux —
+/// 4. `/proc/meminfo::MemAvailable` (then `MemTotal`) on Linux —
 ///    fallback when running on dev hardware without Apple Silicon
 ///    detection. Mirrors what `free -b` shows.
-/// 4. `0` when nothing is detectable. The preflight then reports
+/// 5. `0` when nothing is detectable. The preflight then reports
 ///    `fits = false` for any nonzero `total_bytes`, which is the safe
 ///    direction.
 fn resolve_available_memory(hw: &HardwareCapabilities) -> u64 {
+    // Honour the env var before runtime initialization. `generate` applies the
+    // cap via `initialize_runtime()` before calling the estimator, but `inspect`
+    // and `serve --estimate-memory` intentionally estimate before runtime
+    // bring-up.
+    if let Some(env_limit) = resolve_env_memory_limit_bytes() {
+        return env_limit;
+    }
+
     // Honour an explicit MLX allocator cap first — that's what
     // generation will actually be limited by once it runs.
     let mlx_limit = mlxcel_core::memory::memory_limit();
@@ -414,6 +432,40 @@ fn resolve_available_memory(hw: &HardwareCapabilities) -> u64 {
         }
     }
     0
+}
+
+fn resolve_env_memory_limit_bytes() -> Option<u64> {
+    let raw = std::env::var(MEMORY_LIMIT_ENV).ok()?;
+    parse_optional_memory_size_bytes(&raw)
+}
+
+fn parse_optional_memory_size_bytes(raw: &str) -> Option<u64> {
+    let s = raw.trim();
+    if s.is_empty() || s == "0" || s.eq_ignore_ascii_case("none") {
+        return None;
+    }
+
+    let upper = s.to_ascii_uppercase();
+    if let Some(n) = upper.strip_suffix("GB") {
+        return parse_scaled_memory_size(n, 1024.0 * 1024.0 * 1024.0);
+    }
+    if let Some(n) = upper.strip_suffix("MB") {
+        return parse_scaled_memory_size(n, 1024.0 * 1024.0);
+    }
+
+    s.parse::<u64>().ok().filter(|v| *v > 0)
+}
+
+fn parse_scaled_memory_size(raw: &str, scale: f64) -> Option<u64> {
+    let value = raw.trim().parse::<f64>().ok()?;
+    if !value.is_finite() || value <= 0.0 {
+        return None;
+    }
+    let bytes = value * scale;
+    if !bytes.is_finite() || bytes <= 0.0 {
+        return None;
+    }
+    Some(bytes.min(u64::MAX as f64) as u64)
 }
 
 /// Parse `/proc/meminfo` for `MemAvailable` (preferred) or `MemTotal`.
@@ -477,21 +529,36 @@ pub fn kv_cache_params_from_path(
     let hidden_size = text_cfg
         .get("hidden_size")
         .or_else(|| text_cfg.get("d_model"))
-        .and_then(|v| v.as_u64())?;
+        .or_else(|| text_cfg.get("dim"))
+        .or_else(|| text_cfg.get("model_dim"))
+        .and_then(|v| v.as_u64());
     let num_heads = text_cfg
         .get("num_attention_heads")
         .or_else(|| text_cfg.get("num_heads"))
+        .or_else(|| text_cfg.get("n_heads"))
+        .or_else(|| text_cfg.get("n_head"))
         .and_then(|v| v.as_u64())
         .unwrap_or(1);
     let num_kv_heads = text_cfg
         .get("num_key_value_heads")
+        .or_else(|| text_cfg.get("num_kv_heads"))
+        .or_else(|| text_cfg.get("n_kv_heads"))
+        .or_else(|| text_cfg.get("n_head_kv"))
+        .or_else(|| text_cfg.get("multi_query_group_num"))
         .and_then(|v| v.as_u64())
         .unwrap_or(num_heads);
-    // Use `checked_div` to satisfy clippy::manual_checked_ops (Rust
-    // 1.95+). 64 is the historical fallback used in
-    // `quant_advisor::estimate_kv_cache_bytes_from_config` for the
-    // same `num_heads == 0` edge case.
-    let head_dim = hidden_size.checked_div(num_heads).unwrap_or(64);
+    let explicit_head_dim = text_cfg
+        .get("head_dim")
+        .or_else(|| text_cfg.get("head_size"))
+        .and_then(|v| v.as_u64());
+    let head_dim = if let Some(head_dim) = explicit_head_dim {
+        head_dim
+    } else if let Some(hidden_size) = hidden_size {
+        // 64 is the historical fallback for malformed configs with zero heads.
+        hidden_size.checked_div(num_heads).unwrap_or(64)
+    } else {
+        return None;
+    };
 
     Some(KvCacheParams {
         num_layers,
@@ -640,6 +707,34 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    struct EnvRestore {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvRestore {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            // SAFETY: callers hold crate::test_support::env_lock() while this
+            // guard is alive, serializing process-global environment mutation.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            // SAFETY: the creating test holds crate::test_support::env_lock()
+            // until after this guard is dropped.
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
     fn write_minimal_config(dir: &Path) {
         let cfg = serde_json::json!({
             "hidden_size": 4096,
@@ -662,6 +757,7 @@ mod tests {
         );
         let mut f = std::fs::File::create(dir.join("model.safetensors.index.json")).unwrap();
         f.write_all(s.as_bytes()).unwrap();
+        std::fs::File::create(dir.join("x.safetensors")).unwrap();
     }
 
     #[test]
@@ -743,6 +839,65 @@ mod tests {
         let int8 = estimate_total_memory(tmp.path(), 8192, 1, QuantHint::Default, true);
         assert!(int8.kv_dtype_int8);
         assert_eq!(int8.kv_cache_bytes * 2, fp16.kv_cache_bytes);
+    }
+
+    #[test]
+    fn estimate_scales_kv_cache_by_batch() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_minimal_config(tmp.path());
+
+        let batch1 = estimate_total_memory(tmp.path(), 8192, 1, QuantHint::Default, false);
+        let batch4 = estimate_total_memory(tmp.path(), 8192, 4, QuantHint::Default, false);
+
+        assert_eq!(batch4.batch, 4);
+        assert_eq!(batch4.kv_cache_bytes, batch1.kv_cache_bytes * 4);
+    }
+
+    #[test]
+    fn kv_params_prefer_explicit_head_dim_when_hidden_division_differs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = serde_json::json!({
+            "text_config": {
+                "hidden_size": 1536,
+                "num_hidden_layers": 35,
+                "num_attention_heads": 8,
+                "num_key_value_heads": 1,
+                "head_dim": 256
+            }
+        });
+        std::fs::write(
+            tmp.path().join("config.json"),
+            serde_json::to_string(&cfg).unwrap(),
+        )
+        .unwrap();
+
+        let params = kv_cache_params_from_path(tmp.path(), 256, false, 1).unwrap();
+        assert_eq!(params.head_dim, 256);
+        assert_eq!(kv_cache_bytes_from_params(&params), 35 * 2 * 256 * 2 * 256);
+    }
+
+    #[test]
+    fn available_memory_honors_env_limit_before_runtime_init() {
+        let _env = crate::test_support::env_lock::env_lock();
+        let _restore = EnvRestore::set(MEMORY_LIMIT_ENV, "512MB");
+
+        let tmp = tempfile::tempdir().unwrap();
+        write_minimal_config(tmp.path());
+
+        let est = estimate_total_memory(tmp.path(), 1024, 1, QuantHint::Default, false);
+        assert_eq!(est.available_bytes, 512 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_optional_memory_size_rejects_non_positive_and_non_finite() {
+        assert_eq!(parse_optional_memory_size_bytes("0"), None);
+        assert_eq!(parse_optional_memory_size_bytes("none"), None);
+        assert_eq!(parse_optional_memory_size_bytes("-1GB"), None);
+        assert_eq!(parse_optional_memory_size_bytes("NaNGB"), None);
+        assert_eq!(
+            parse_optional_memory_size_bytes("1.5GB"),
+            Some((1.5 * 1024.0 * 1024.0 * 1024.0) as u64),
+        );
     }
 
     #[test]

--- a/src/execution/quant_advisor.rs
+++ b/src/execution/quant_advisor.rs
@@ -60,6 +60,8 @@ fn estimate_params_from_config(config: &serde_json::Value) -> Option<f64> {
     let hidden_size = text_cfg
         .get("hidden_size")
         .or_else(|| text_cfg.get("d_model"))
+        .or_else(|| text_cfg.get("dim"))
+        .or_else(|| text_cfg.get("model_dim"))
         .and_then(|v| v.as_f64())?;
 
     let num_layers = text_cfg
@@ -94,16 +96,31 @@ fn estimate_params_from_config(config: &serde_json::Value) -> Option<f64> {
     let num_heads = text_cfg
         .get("num_attention_heads")
         .or_else(|| text_cfg.get("num_heads"))
+        .or_else(|| text_cfg.get("n_heads"))
+        .or_else(|| text_cfg.get("n_head"))
         .and_then(|v| v.as_f64())
         .unwrap_or(hidden_size / 64.0);
 
     let kv_heads = text_cfg
         .get("num_key_value_heads")
+        .or_else(|| text_cfg.get("num_kv_heads"))
+        .or_else(|| text_cfg.get("n_kv_heads"))
+        .or_else(|| text_cfg.get("n_head_kv"))
+        .or_else(|| text_cfg.get("multi_query_group_num"))
         .and_then(|v| v.as_f64())
         .unwrap_or(num_heads);
 
-    // head_dim inferred from hidden_size / num_heads.
-    let head_dim = (hidden_size / num_heads).round();
+    let head_dim = text_cfg
+        .get("head_dim")
+        .or_else(|| text_cfg.get("head_size"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or_else(|| {
+            if num_heads > 0.0 && num_heads.is_finite() {
+                (hidden_size / num_heads).round()
+            } else {
+                64.0
+            }
+        });
 
     // Parameter count estimate:
     //   embedding:  vocab_size × hidden_size (input + output embedding shared)
@@ -323,22 +340,38 @@ fn estimate_kv_cache_bytes_from_config(
     let hidden_size = text_cfg
         .get("hidden_size")
         .or_else(|| text_cfg.get("d_model"))
-        .and_then(|v| v.as_u64())?;
+        .or_else(|| text_cfg.get("dim"))
+        .or_else(|| text_cfg.get("model_dim"))
+        .and_then(|v| v.as_u64());
 
     let num_heads = text_cfg
         .get("num_attention_heads")
         .or_else(|| text_cfg.get("num_heads"))
+        .or_else(|| text_cfg.get("n_heads"))
+        .or_else(|| text_cfg.get("n_head"))
         .and_then(|v| v.as_u64())
         .unwrap_or(1);
 
     let num_kv_heads = text_cfg
         .get("num_key_value_heads")
+        .or_else(|| text_cfg.get("num_kv_heads"))
+        .or_else(|| text_cfg.get("n_kv_heads"))
+        .or_else(|| text_cfg.get("n_head_kv"))
+        .or_else(|| text_cfg.get("multi_query_group_num"))
         .and_then(|v| v.as_u64())
         .unwrap_or(num_heads);
 
-    // head_dim is usually hidden_size / num_heads; fall back to 64 if num_heads is 0.
-    // Uses `checked_div` to satisfy clippy::manual_checked_ops (Rust 1.95+).
-    let head_dim = hidden_size.checked_div(num_heads).unwrap_or(64);
+    let explicit_head_dim = text_cfg
+        .get("head_dim")
+        .or_else(|| text_cfg.get("head_size"))
+        .and_then(|v| v.as_u64());
+    let head_dim = if let Some(head_dim) = explicit_head_dim {
+        head_dim
+    } else if let Some(hidden_size) = hidden_size {
+        hidden_size.checked_div(num_heads).unwrap_or(64)
+    } else {
+        return None;
+    };
 
     let params = KvCacheParams {
         num_layers,
@@ -464,6 +497,22 @@ mod tests {
     }
 
     #[test]
+    fn kv_cache_estimate_prefers_explicit_head_dim() {
+        let config = serde_json::json!({
+            "text_config": {
+                "hidden_size": 1536,
+                "num_hidden_layers": 35,
+                "num_attention_heads": 8,
+                "num_key_value_heads": 1,
+                "head_dim": 256
+            }
+        });
+
+        let bytes = estimate_kv_cache_bytes_from_config(&config, 256, false).unwrap();
+        assert_eq!(bytes, 35 * 2 * 256 * 2 * 256);
+    }
+
+    #[test]
     fn returns_none_for_empty_config() {
         let config = serde_json::json!({});
         let result = estimate_params_from_config(&config);
@@ -551,6 +600,7 @@ mod tests {
             r#"{"metadata": {"total_size": 14000000000}, "weight_map": {"w": "x.safetensors"}}"#;
         let mut f = std::fs::File::create(tmp.path().join("model.safetensors.index.json")).unwrap();
         f.write_all(index_json.as_bytes()).unwrap();
+        std::fs::File::create(tmp.path().join("x.safetensors")).unwrap();
 
         let advice = advise_quantization(tmp.path(), &hw, None);
         assert_eq!(advice.exact_weight_bytes, Some(14_000_000_000));

--- a/src/lib/mlxcel-core/src/weights.rs
+++ b/src/lib/mlxcel-core/src/weights.rs
@@ -212,10 +212,10 @@ fn read_safetensors_header_bytes(path: &Path) -> Option<u64> {
         let dtype = meta.get("dtype").and_then(|v| v.as_str())?;
         let shape = meta.get("shape").and_then(|v| v.as_array())?;
         let itemsize = safetensors_dtype_itemsize(dtype)?;
-        let numel: u64 = shape
-            .iter()
-            .filter_map(|d| d.as_u64())
-            .fold(1u64, |acc, d| acc.saturating_mul(d));
+        let mut numel: u64 = 1;
+        for dim in shape {
+            numel = numel.saturating_mul(dim.as_u64()?);
+        }
         total = total.saturating_add(numel.saturating_mul(itemsize));
     }
     Some(total)
@@ -227,10 +227,15 @@ fn read_safetensors_header_bytes(path: &Path) -> Option<u64> {
 /// loading any tensors into memory.
 ///
 /// Resolution order:
-/// 1. `metadata.total_size` from `model.safetensors.index.json` (sharded models).
-/// 2. Safetensors binary header of a single `model.safetensors` file (sum of
+/// 1. `metadata.total_size` from a valid `model.safetensors.index.json`
+///    whose referenced shards exist (sharded models).
+/// 2. Sum of safetensors binary headers for valid index shards when the index
+///    lacks `metadata.total_size`.
+/// 3. Safetensors binary header of a single `model.safetensors` file (sum of
 ///    dtype × shape-product for every tensor entry — no tensor data is read).
-/// 3. Returns `None` when neither source is available; callers should fall back
+/// 4. Sum of all local `*.safetensors` headers when the index is stale but the
+///    directory contains loadable safetensors files.
+/// 5. Returns `None` when no source is available; callers should fall back
 ///    to an analytical estimate (e.g. `ModelProfile::total_param_bytes`).
 ///
 /// The returned value is the exact number of weight-parameter bytes on disk.
@@ -238,9 +243,18 @@ fn read_safetensors_header_bytes(path: &Path) -> Option<u64> {
 pub fn weight_footprint_bytes<P: AsRef<Path>>(model_dir: P) -> Option<u64> {
     let dir = model_dir.as_ref();
 
-    // 1. Try sharded index first.
-    if let Ok(Some((_shards, Some(total_size)))) = parse_shard_index_with_total_size(dir) {
-        return Some(total_size);
+    // 1. Try sharded index first, but only trust it if the loader would use the
+    // same shard list. Repackaged mlx-community quants can ship stale upstream
+    // indexes; using their metadata.total_size would over-reject preflight.
+    if let Ok(Some((shards, total_size))) = parse_shard_index_with_total_size(dir) {
+        if let Ok(paths) = validate_index_shards(dir, &shards) {
+            if let Some(total_size) = total_size {
+                return Some(total_size);
+            }
+            if let Some(total) = sum_safetensors_header_bytes(&paths) {
+                return Some(total);
+            }
+        }
     }
 
     // 2. Try single-file safetensors header.
@@ -249,7 +263,21 @@ pub fn weight_footprint_bytes<P: AsRef<Path>>(model_dir: P) -> Option<u64> {
         return read_safetensors_header_bytes(&single_file);
     }
 
-    None
+    // 3. Mirror the loader's stale-index fallback: all local *.safetensors
+    // files in deterministic order.
+    let paths = glob_safetensors(dir).ok()?;
+    sum_safetensors_header_bytes(&paths)
+}
+
+fn sum_safetensors_header_bytes(paths: &[std::path::PathBuf]) -> Option<u64> {
+    if paths.is_empty() {
+        return None;
+    }
+    let mut total: u64 = 0;
+    for path in paths {
+        total = total.saturating_add(read_safetensors_header_bytes(path)?);
+    }
+    Some(total)
 }
 
 /// Check if a path is a broken symlink (exists as a symlink but target is missing).
@@ -825,6 +853,15 @@ mod tests {
         // No data region written — the header reader only needs the JSON.
     }
 
+    fn write_safetensors_raw_header(path: &std::path::PathBuf, header_json: &str) {
+        use std::io::Write;
+        let header_bytes = header_json.as_bytes();
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(&(header_bytes.len() as u64).to_le_bytes())
+            .unwrap();
+        f.write_all(header_bytes).unwrap();
+    }
+
     #[test]
     fn test_parse_shard_index_with_total_size_present() {
         let dir = tempfile::tempdir().unwrap();
@@ -859,6 +896,7 @@ mod tests {
         // Sharded model with index.json providing total_size.
         let dir = tempfile::tempdir().unwrap();
         write_index_with_total_size(dir.path(), 999_000);
+        touch_safetensors(dir.path(), "model-00001-of-00001.safetensors");
 
         let footprint = weight_footprint_bytes(dir.path());
         assert_eq!(footprint, Some(999_000));
@@ -895,6 +933,41 @@ mod tests {
 
         let footprint = weight_footprint_bytes(dir.path());
         assert_eq!(footprint, Some(512 * 128 * 2));
+    }
+
+    #[test]
+    fn test_weight_footprint_bytes_index_without_total_size_sums_valid_shards() {
+        let dir = tempfile::tempdir().unwrap();
+        write_index_without_total_size(dir.path());
+        let shard = dir.path().join("model-00001-of-00001.safetensors");
+        write_safetensors_stub(&shard, "F16", &[2, 8]);
+
+        let footprint = weight_footprint_bytes(dir.path());
+        assert_eq!(footprint, Some(2 * 8 * 2));
+    }
+
+    #[test]
+    fn test_weight_footprint_bytes_ignores_stale_index_total_size() {
+        let dir = tempfile::tempdir().unwrap();
+        write_index_with_total_size(dir.path(), 999_000);
+        let file = dir.path().join("model.safetensors");
+        write_safetensors_stub(&file, "F32", &[4, 4]);
+
+        let footprint = weight_footprint_bytes(dir.path());
+        assert_eq!(footprint, Some(4 * 4 * 4));
+    }
+
+    #[test]
+    fn test_weight_footprint_bytes_rejects_non_numeric_shape_dim() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("model.safetensors");
+        write_safetensors_raw_header(
+            &file,
+            r#"{"bad_tensor": {"dtype": "F32", "shape": [2, "bad"], "data_offsets": [0, 0]}}"#,
+        );
+
+        let footprint = weight_footprint_bytes(dir.path());
+        assert_eq!(footprint, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up audit for epic #52 after reviewing the merged sub-issue work (#53, #54, #55, #56 and PRs #64-#67). The original architecture was in place, but several CLI/runtime paths could still report a memory estimate that did not match the load that would actually happen.

This PR tightens those gaps so the estimator remains conservative and consistent across `inspect`, `generate --estimate-memory`, `serve --estimate-memory`, and `--recommend-quant`.

Refs #52.

## Review Findings Fixed

- `estimate_total_memory(..., batch, ...)` accepted a batch argument but still used a KV-cache helper hardcoded to batch 1.
- `generate --estimate-memory` estimated KV cache from `--max-tokens` only, so long prompts were not counted before model load.
- `serve --estimate-memory` ignored serving concurrency/batching knobs and sized KV as batch 1.
- `inspect` / `serve --estimate-memory` run before runtime initialization, so `MLXCEL_MEMORY_LIMIT` was not reflected in available-memory calculation.
- `inspect`, `generate`, and `serve` manually inferred int8 KV only from split K/V flags, missing the legacy `--kv-cache-mode int8` path and shared validation behavior.
- Runtime estimate-vs-actual logging labeled under/over-estimation backwards.
- KV-cache config parsing ignored explicit `head_dim` and common field aliases, underestimating models whose head dimension differs from `hidden_size / num_attention_heads`.
- Safetensors header parsing silently skipped non-numeric shape dimensions.
- Weight footprint estimation trusted stale `model.safetensors.index.json::metadata.total_size` even when the referenced shards were not the files the loader would use.

## Changes

- Route unified memory estimation through `kv_cache_params_from_path(..., batch)` so batch scales KV bytes.
- Parse `MLXCEL_MEMORY_LIMIT` directly in the estimator before checking the already-applied MLX allocator cap.
- Expand KV config parsing for `dim`, `model_dim`, `n_heads`, `n_head`, `num_kv_heads`, `n_kv_heads`, `n_head_kv`, `multi_query_group_num`, `head_dim`, and `head_size`.
- Move `generate --estimate-memory` preflight after prompt rendering/tokenization but before model load, using `prompt_tokens + max_tokens` for KV context length.
- Make `inspect`, `generate`, and `serve` use the shared `resolve_kv_cache_mode` helper.
- Make `serve --estimate-memory` use `ctx_size`, `max_kv_size`, `max_batch_size`, `n_parallel`, and `no_batch` to derive the preflight shape.
- Make `weight_footprint_bytes` trust index metadata only after validating shard filenames and existence, sum valid shard headers when total size is missing, and fall back to local safetensors headers for stale indexes.
- Reject malformed safetensors headers with non-numeric shape dimensions instead of undercounting them.
- Add regression tests for batch scaling, explicit head_dim, env memory caps, prompt+generation sizing, serve preflight shape, stale indexes, and malformed headers.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `cargo clippy -p mlxcel --lib --bin mlxcel --tests -- -D warnings`
- `cargo clippy -p mlxcel-core --lib --tests -- -D warnings`
- `cargo test -p mlxcel memory_estimate --lib`
- `cargo test -p mlxcel quant_advisor --lib`
- `cargo test -p mlxcel --bin mlxcel`
- `cargo test -p mlxcel-core weights::tests`

Additional broader checks:

- `cargo test -p mlxcel --lib` ran 2,893 tests and failed only `models::sanitize_tests::load_and_sanitize_weights_dequantizes_nvfp4_gemma4_checkpoint`. I verified the same test fails on `origin/main` with the same assertion, so it is not introduced by this PR.
- `cargo test -p mlxcel-core --lib` ran 774 tests and failed two existing environment-sensitive FFI tests: `ffi_tests::test_from_bytes_fp16_native_dtype` and `ffi_tests::test_memory_functions`. The focused `weights::tests` suite covering this PR passed.

## Security / Performance Notes

- The estimator no longer accepts malformed safetensors shapes by silently dropping invalid dimensions.
- Stale or invalid index metadata cannot force the preflight to use an unrelated `total_size`; it must match validated local shards or fall back to actual local safetensors headers.
- No tensor payloads are read for estimation; only safetensors headers and config JSON are inspected, preserving pre-load behavior.
- Batch/concurrency sizing is now conservative for server preflight, reducing the chance of admitting a model that later OOMs under configured serving load.
