### PR TITLE
docs: document MLXCEL_CAPTURE_DECODE and clarify headroom wording

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -32,7 +32,7 @@ and cached on first use. Set them before starting `mlxcel` or `mlxcel-server`.
 | `MLXCEL_DEVICE` | `gpu`, `metal`, `cpu` | `gpu` hint | `cpu` requests CPU execution. Invalid values are ignored with a warning and treated as `gpu`; if no GPU backend is available, runtime falls back to CPU. |
 | `MLXCEL_WIRED_LIMIT` | `max`, `0`, `none`, bytes, `NGB`, `NMB` | `max` | Apple Silicon GPU wired-memory limit. Unset/empty/`max` sets MLX's reported GPU max memory size; `0`/`none` disables the limit; numeric values set an explicit limit. |
 | `MLXCEL_MEMORY_LIMIT` | `0`, `none`, bytes, `NGB`, `NMB` | unset | Soft MLX allocator memory cap. Unset/`0`/`none` lets MLX use its backend default; numeric values cap the allocator and make MLX raise an exception once allocations would push the working set past this value. Also feeds the `mlxcel inspect` / `--estimate-memory` preflight as the authoritative "available unified memory" figure when nonzero. |
-| `MLXCEL_HEADROOM_FACTOR` | positive `f64` | `1.20` | Runtime/activation headroom multiplier used by the unified memory estimator (`mlxcel inspect`, `--estimate-memory`, `--recommend-quant`). Values `<= 1.0` disable the headroom term; invalid values warn and fall back to the default. Override only for calibration runs — see the in-code recipe in `src/execution/memory_estimate.rs`. |
+| `MLXCEL_HEADROOM_FACTOR` | positive `f64` | `1.20` | Runtime/activation headroom multiplier used by the unified memory estimator (`mlxcel inspect`, `--estimate-memory`, `--recommend-quant`). Positive values `<= 1.0` disable the headroom term; invalid or non-positive values warn and fall back to the default. Override only for calibration runs — see the in-code recipe in `src/execution/memory_estimate.rs`. |
 | `MLXCEL_CACHE_DIR` | directory path | `$HOME/.cache/mlxcel` | Root for the tokenizer language-analysis disk cache used by language-bias features. Files live under `tokenizer-scripts/`. |
 | `MLXCEL_SERVER_DECODE_STORAGE` | `auto`, `dense`, `paged` | `auto` | Server continuous-batching decode storage. `--decode-storage-backend` takes precedence. Invalid values warn and fall back to `auto`. |
 | `MLXCEL_SURGERY` | YAML file path | unset | Feature-gated weight-load surgery configuration. `--surgery` takes precedence when the `surgery` feature is built. |
@@ -169,6 +169,7 @@ throughput measurements. Use them for diagnosis, not capacity planning.
 | `MLXCEL_PROFILE_LAYER_BUILD` | presence enables | off | Adds Gemma 4 layer-build timing. |
 | `MLXCEL_PROFILE_LAYER_SUBOPS` | presence enables | off | Adds Gemma 4 per-suboperation timing. |
 | `MLXCEL_EXPORT_DECODE_DOT` | file path | unset | Exports the first decode graph pair to DOT. |
+| `MLXCEL_CAPTURE_DECODE` | path | unset | Captures one warmed decode token to a Metal GPU trace and exits; requires `MTL_CAPTURE_ENABLED=1`. |
 | `MLXCEL_METAL_CAPTURE_PATH` | file path | unset | Starts a Metal capture around steady-state generation; requires `MTL_CAPTURE_ENABLED=1`. |
 | `MLXCEL_DEBUG_GEMMA4_LOAD` | presence enables | off | Emits Gemma 4 safetensors loading diagnostics. |
 | `MLXCEL_NO_PRECISION_WARNING` | presence suppresses | warning on | Suppresses the bf16-on-Apple-Silicon precision/performance note. |


### PR DESCRIPTION
Closes #71

The environment variables reference (`docs/environment-variables.md`) was missing the `MLXCEL_CAPTURE_DECODE` diagnostic and described `MLXCEL_HEADROOM_FACTOR` imprecisely. Both are documentation-only fixes; no code changes.

## Changes

- Add an `MLXCEL_CAPTURE_DECODE` row to the profiling/diagnostics table. It captures one warmed decode token to a Metal GPU trace and then exits, and requires `MTL_CAPTURE_ENABLED=1` like the adjacent `MLXCEL_METAL_CAPTURE_PATH` capture.
- Reword `MLXCEL_HEADROOM_FACTOR` so the description matches runtime behavior: positive values at or below 1.0 disable the headroom term, while invalid or non-positive values warn and fall back to the default 1.20.

## Verification

Documentation only. `git diff` confirms the two table edits and no other changes.