### PR TITLE
feat(server): add Anthropic-style /v1/messages API endpoint

### DIFF
--- a/src/server/anthropic_translator.rs
+++ b/src/server/anthropic_translator.rs
@@ -1,0 +1,804 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Translator between the Anthropic Messages API and the internal
+//! chat-completions request/response pipeline.
+//!
+//! Ported from upstream mlx-vlm `server/anthropic.py` (PR #1196, commit
+//! `313ad22`) and the tool-call image-handling fix (PR #1200, commit
+//! `f2e19de`).
+//!
+//! ## Inbound
+//!
+//! [`anthropic_request_to_chat`] flattens an [`AnthropicRequest`] into the
+//! [`ChatCompletionRequest`] shape consumed by
+//! [`crate::server::chat_request::prepare_chat_request_with_cache`]:
+//!
+//! 1. Render `system` (string or text-block array) as a leading system turn.
+//! 2. Walk each message's content blocks:
+//!    - `text` → message text
+//!    - `image` (user role) → an `image_url` content part (media plumbing)
+//!    - `tool_use` (assistant role) → `tool_calls` on the assistant turn
+//!    - `tool_result` (user role) → a `role: tool` message; **image blocks
+//!      inside the tool result become `image_url` parts** (the #1200 fix)
+//!    - `thinking` / unknown → dropped
+//! 3. Convert `tools` / `tool_choice` into the chat-request fields. Server
+//!    tools (no `input_schema`) are dropped because the local server cannot
+//!    execute them.
+//!
+//! ## Outbound
+//!
+//! [`build_content_blocks`] turns the generation result (visible text,
+//! optional reasoning, parsed tool calls) into the ordered Anthropic
+//! response `content[]`. [`anthropic_stop_reason`] and
+//! [`apply_stop_sequences`] mirror the upstream stop-reason mapping.
+
+use crate::server::tool_calls::types::ParsedToolCall;
+use crate::server::types::anthropic_request::{
+    AnthropicContentBlock, AnthropicMessage, AnthropicMessageContent, AnthropicRequest,
+    AnthropicRole, AnthropicToolChoice, AnthropicToolResultBlock, AnthropicToolResultContent,
+};
+use crate::server::types::anthropic_response::AnthropicResponseBlock;
+use crate::server::types::request::{
+    ChatCompletionRequest, ContentPart, FunctionDefinition, ImageUrl, Message, MessageContent,
+    Role, SamplingParams, Tool, ToolCallFunction, ToolCallInMessage, ToolChoice,
+    ToolChoiceFunction, ToolChoiceFunctionName,
+};
+
+/// Generate a short hex id (16 chars) for synthetic tool-call ids.
+pub fn short_uuid() -> String {
+    let full = uuid::Uuid::new_v4().simple().to_string();
+    full[..16].to_string()
+}
+
+/// Result of flattening an Anthropic request into the internal chat shape.
+#[derive(Debug)]
+pub struct AnthropicTranslated {
+    /// Synthetic chat request driving the generation pipeline.
+    pub chat_request: ChatCompletionRequest,
+}
+
+/// Flatten an [`AnthropicRequest`] into a [`ChatCompletionRequest`].
+///
+/// The route layer applies `state.config.default_max_tokens` when the request
+/// omits `max_tokens`; this function performs only the structural translation.
+pub fn anthropic_request_to_chat(request: &AnthropicRequest) -> AnthropicTranslated {
+    let mut messages: Vec<Message> = Vec::new();
+
+    // 1. System prompt (string or text-block array) → leading system turn.
+    if let Some(system) = request.system.as_ref()
+        && let Some(text) = system.to_text()
+    {
+        messages.push(Message {
+            role: Role::System,
+            content: MessageContent::Text(text),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        });
+    }
+
+    // 2. Walk conversation turns.
+    for message in &request.messages {
+        append_message(&mut messages, message);
+    }
+
+    // 3. Tools / tool_choice.
+    let tools = convert_tools(request);
+    let tool_choice = convert_tool_choice(request.tool_choice.as_ref());
+
+    // 4. Sampling params.
+    //
+    // Anthropic's extended-thinking `budget_tokens` maps onto the internal
+    // `thinking_budget_tokens` alias so the shared budget resolution
+    // (`thinking_budget::pick_budget_alias` / `resolve_request_budget`) used
+    // by the chat and responses routes applies uniformly.
+    let thinking_budget_tokens = request
+        .thinking
+        .as_ref()
+        .and_then(|t| t.budget_tokens)
+        .and_then(|b| i32::try_from(b).ok());
+    let params = SamplingParams {
+        max_tokens: request.max_tokens,
+        temperature: request.temperature,
+        top_p: request.top_p,
+        top_k: request.top_k,
+        // Anthropic `stop_sequences` are applied as native stop sequences so
+        // the scheduler halts generation early; the outbound assembly also
+        // truncates defensively via `apply_stop_sequences`.
+        stop: request.stop_sequences.clone(),
+        thinking_budget_tokens,
+        ..Default::default()
+    };
+
+    let chat_request = ChatCompletionRequest {
+        model: request.model.clone(),
+        messages,
+        stream: request.stream,
+        stream_options: None,
+        logprobs: None,
+        top_logprobs: None,
+        tools,
+        tool_choice,
+        parallel_tool_calls: None,
+        chat_template_kwargs: None,
+        extra_body: None,
+        prompt_cache_key: None,
+        user: None,
+        extra_body_fields: serde_json::Map::new(),
+        response_format: None,
+        params,
+    };
+
+    AnthropicTranslated { chat_request }
+}
+
+/// Append a single Anthropic message (and any tool-result turns it implies)
+/// to the running internal message list.
+fn append_message(out: &mut Vec<Message>, message: &AnthropicMessage) {
+    let role = match message.role {
+        AnthropicRole::User => Role::User,
+        AnthropicRole::Assistant => Role::Assistant,
+    };
+
+    match &message.content {
+        AnthropicMessageContent::Text(text) => {
+            out.push(Message {
+                role,
+                content: MessageContent::Text(text.clone()),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            });
+        }
+        AnthropicMessageContent::Blocks(blocks) => {
+            let mut text_parts: Vec<String> = Vec::new();
+            let mut image_parts: Vec<ContentPart> = Vec::new();
+            let mut tool_calls: Vec<ToolCallInMessage> = Vec::new();
+            let mut tool_results: Vec<Message> = Vec::new();
+
+            for block in blocks {
+                match block {
+                    AnthropicContentBlock::Text { text } => {
+                        if !text.is_empty() {
+                            text_parts.push(text.clone());
+                        }
+                    }
+                    AnthropicContentBlock::Document { source } => {
+                        if let Some(text) = document_text(source.as_ref()) {
+                            text_parts.push(text);
+                        }
+                    }
+                    AnthropicContentBlock::Image { source } => {
+                        // Images only carry meaning on user turns.
+                        if message.role == AnthropicRole::User
+                            && let Some(url) = source.to_image_ref()
+                        {
+                            image_parts.push(ContentPart::ImageUrl {
+                                image_url: ImageUrl { url },
+                            });
+                        }
+                    }
+                    AnthropicContentBlock::ToolUse { id, name, input } => {
+                        if message.role == AnthropicRole::Assistant {
+                            tool_calls.push(tool_use_to_call(
+                                id.as_deref(),
+                                name.as_deref(),
+                                input.as_ref(),
+                            ));
+                        }
+                    }
+                    AnthropicContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        ..
+                    } => {
+                        if message.role == AnthropicRole::User {
+                            tool_results.push(tool_result_message(
+                                tool_use_id.as_deref(),
+                                content.as_ref(),
+                            ));
+                        }
+                    }
+                    AnthropicContentBlock::Thinking { .. } | AnthropicContentBlock::Unknown => {
+                        // Dropped: thinking traces and unknown blocks do not
+                        // feed back into the next prompt.
+                    }
+                }
+            }
+
+            let joined_text = text_parts.join("\n");
+            let has_text = !joined_text.trim().is_empty();
+
+            // Emit the primary turn when it carries text, tool calls, or
+            // images, OR when there are no tool results (mirror upstream:
+            // a message that is *only* tool_results does not emit an empty
+            // assistant/user turn). This keeps an empty user turn from being
+            // injected ahead of the tool result messages.
+            let has_images = !image_parts.is_empty();
+            if has_text || !tool_calls.is_empty() || has_images || tool_results.is_empty() {
+                let content = if has_images {
+                    // Multimodal: text first (if any), then image parts.
+                    let mut parts: Vec<ContentPart> = Vec::new();
+                    if has_text {
+                        parts.push(ContentPart::Text { text: joined_text });
+                    }
+                    parts.extend(image_parts);
+                    MessageContent::Parts(parts)
+                } else {
+                    MessageContent::Text(joined_text)
+                };
+                out.push(Message {
+                    role,
+                    content,
+                    name: None,
+                    tool_call_id: None,
+                    tool_calls: if tool_calls.is_empty() {
+                        None
+                    } else {
+                        Some(tool_calls)
+                    },
+                });
+            }
+
+            out.extend(tool_results);
+        }
+    }
+}
+
+/// Convert an Anthropic `tool_use` block into an internal assistant
+/// `tool_calls` entry.
+fn tool_use_to_call(
+    id: Option<&str>,
+    name: Option<&str>,
+    input: Option<&serde_json::Value>,
+) -> ToolCallInMessage {
+    let arguments = match input {
+        Some(v) => serde_json::to_string(v).unwrap_or_else(|_| "{}".to_string()),
+        None => "{}".to_string(),
+    };
+    ToolCallInMessage {
+        id: id
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("toolu_{}", short_uuid())),
+        call_type: "function".to_string(),
+        function: ToolCallFunction {
+            name: name.unwrap_or("").to_string(),
+            arguments,
+        },
+    }
+}
+
+/// Convert an Anthropic `tool_result` block into a `role: tool` message.
+///
+/// Per PR #1200, image blocks inside the tool result are surfaced as
+/// `image_url` content parts so they flow through the media plumbing; text
+/// blocks are concatenated. When no images are present, the content is a
+/// plain string (the common case).
+fn tool_result_message(
+    tool_use_id: Option<&str>,
+    content: Option<&AnthropicToolResultContent>,
+) -> Message {
+    let (text, images) = tool_result_to_text_and_images(content);
+
+    let message_content = if images.is_empty() {
+        MessageContent::Text(text)
+    } else {
+        let mut parts: Vec<ContentPart> = Vec::new();
+        if !text.is_empty() {
+            parts.push(ContentPart::Text { text });
+        }
+        for url in images {
+            parts.push(ContentPart::ImageUrl {
+                image_url: ImageUrl { url },
+            });
+        }
+        MessageContent::Parts(parts)
+    };
+
+    Message {
+        role: Role::Tool,
+        content: message_content,
+        name: None,
+        tool_call_id: tool_use_id.map(|s| s.to_string()),
+        tool_calls: None,
+    }
+}
+
+/// Flatten `tool_result.content` into `(joined_text, image_refs)`.
+fn tool_result_to_text_and_images(
+    content: Option<&AnthropicToolResultContent>,
+) -> (String, Vec<String>) {
+    match content {
+        None => (String::new(), Vec::new()),
+        Some(AnthropicToolResultContent::Text(s)) => (s.clone(), Vec::new()),
+        Some(AnthropicToolResultContent::Blocks(blocks)) => {
+            let mut text_parts: Vec<String> = Vec::new();
+            let mut images: Vec<String> = Vec::new();
+            for block in blocks {
+                match block {
+                    AnthropicToolResultBlock::Text { text } => {
+                        if !text.is_empty() {
+                            text_parts.push(text.clone());
+                        }
+                    }
+                    AnthropicToolResultBlock::Image { source } => {
+                        if let Some(url) = source.to_image_ref() {
+                            images.push(url);
+                        }
+                    }
+                    AnthropicToolResultBlock::Unknown => {}
+                }
+            }
+            (text_parts.join("\n"), images)
+        }
+    }
+}
+
+/// Extract text from a `document` block's `source` when it is a text source.
+fn document_text(source: Option<&serde_json::Value>) -> Option<String> {
+    let source = source?;
+    let obj = source.as_object()?;
+    if obj.get("type").and_then(|t| t.as_str()) == Some("text") {
+        obj.get("data")
+            .and_then(|d| d.as_str())
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
+    } else {
+        None
+    }
+}
+
+/// Convert Anthropic tools into internal `function` tools, dropping server
+/// tools (those without an `input_schema`).
+fn convert_tools(request: &AnthropicRequest) -> Option<Vec<Tool>> {
+    let tools = request.tools.as_ref()?;
+    let out: Vec<Tool> = tools
+        .iter()
+        .filter_map(|t| {
+            let name = t.name.as_ref()?;
+            let input_schema = t.input_schema.as_ref()?;
+            if name.is_empty() {
+                return None;
+            }
+            Some(Tool {
+                tool_type: "function".to_string(),
+                function: FunctionDefinition {
+                    name: name.clone(),
+                    description: t.description.clone(),
+                    parameters: Some(input_schema.clone()),
+                },
+            })
+        })
+        .collect();
+    if out.is_empty() { None } else { Some(out) }
+}
+
+/// Map Anthropic `tool_choice` onto the internal [`ToolChoice`].
+fn convert_tool_choice(choice: Option<&AnthropicToolChoice>) -> Option<ToolChoice> {
+    let choice = choice?;
+    match choice {
+        AnthropicToolChoice::Mode(s) => Some(ToolChoice::Mode(s.clone())),
+        AnthropicToolChoice::Spec(spec) => match spec.choice_type.as_str() {
+            "auto" => Some(ToolChoice::Mode("auto".to_string())),
+            "none" => Some(ToolChoice::Mode("none".to_string())),
+            "any" => Some(ToolChoice::Mode("required".to_string())),
+            "tool" => spec.name.as_ref().map(|name| {
+                ToolChoice::Specific(ToolChoiceFunction {
+                    choice_type: "function".to_string(),
+                    function: ToolChoiceFunctionName { name: name.clone() },
+                })
+            }),
+            _ => None,
+        },
+    }
+}
+
+/// Map an internal finish reason / tool-call presence / stop-sequence match
+/// onto an Anthropic `stop_reason`.
+pub fn anthropic_stop_reason(
+    finish_reason: &str,
+    tool_calls: bool,
+    stop_sequence: Option<&str>,
+) -> String {
+    if tool_calls {
+        return "tool_use".to_string();
+    }
+    if stop_sequence.is_some() {
+        return "stop_sequence".to_string();
+    }
+    match finish_reason {
+        "length" => "max_tokens".to_string(),
+        "tool_calls" => "tool_use".to_string(),
+        _ => "end_turn".to_string(),
+    }
+}
+
+/// Truncate `text` at the first matching stop sequence. Returns the
+/// truncated text and the matched sequence (if any), mirroring upstream
+/// `_apply_stop_sequences`.
+pub fn apply_stop_sequences(
+    text: &str,
+    stop_sequences: Option<&[String]>,
+) -> (String, Option<String>) {
+    let Some(seqs) = stop_sequences else {
+        return (text.to_string(), None);
+    };
+    if text.is_empty() || seqs.is_empty() {
+        return (text.to_string(), None);
+    }
+    let mut best_index: Option<usize> = None;
+    let mut best_sequence: Option<&str> = None;
+    for seq in seqs {
+        if seq.is_empty() {
+            continue;
+        }
+        if let Some(idx) = text.find(seq.as_str())
+            && best_index.map(|b| idx < b).unwrap_or(true)
+        {
+            best_index = Some(idx);
+            best_sequence = Some(seq.as_str());
+        }
+    }
+    match best_index {
+        Some(idx) => (
+            text[..idx].to_string(),
+            best_sequence.map(|s| s.to_string()),
+        ),
+        None => (text.to_string(), None),
+    }
+}
+
+/// Assemble the ordered Anthropic response `content[]` from a generation
+/// result: optional thinking block, visible text block, then tool_use
+/// blocks. Always returns at least one block (an empty text block when the
+/// model produced nothing) to satisfy the Anthropic schema.
+pub fn build_content_blocks(
+    visible_text: &str,
+    reasoning_text: Option<&str>,
+    parsed_tool_calls: Option<&[ParsedToolCall]>,
+    include_thinking: bool,
+) -> Vec<AnthropicResponseBlock> {
+    let mut blocks: Vec<AnthropicResponseBlock> = Vec::new();
+
+    if include_thinking
+        && let Some(reasoning) = reasoning_text
+        && !reasoning.is_empty()
+    {
+        blocks.push(AnthropicResponseBlock::Thinking {
+            thinking: reasoning.to_string(),
+            signature: String::new(),
+        });
+    }
+
+    if !visible_text.is_empty() {
+        blocks.push(AnthropicResponseBlock::Text {
+            text: visible_text.to_string(),
+        });
+    }
+
+    if let Some(calls) = parsed_tool_calls {
+        for call in calls {
+            blocks.push(parsed_call_to_tool_use(call));
+        }
+    }
+
+    if blocks.is_empty() {
+        blocks.push(AnthropicResponseBlock::Text {
+            text: String::new(),
+        });
+    }
+
+    blocks
+}
+
+/// Convert an internal [`ParsedToolCall`] into an Anthropic `tool_use`
+/// response block. The stringified arguments are parsed back into a JSON
+/// object; a parse failure yields an empty object (never a crash).
+pub fn parsed_call_to_tool_use(call: &ParsedToolCall) -> AnthropicResponseBlock {
+    let input = if call.arguments.is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::from_str::<serde_json::Value>(&call.arguments)
+            .ok()
+            .filter(|v| v.is_object())
+            .unwrap_or_else(|| serde_json::json!({}))
+    };
+    AnthropicResponseBlock::ToolUse {
+        id: format!("toolu_{}", short_uuid()),
+        name: call.name.clone(),
+        input,
+    }
+}
+
+/// Whether the request's `thinking` config enables extended thinking output.
+pub fn thinking_enabled(request: &AnthropicRequest) -> bool {
+    request
+        .thinking
+        .as_ref()
+        .and_then(|t| t.thinking_type.as_deref())
+        .map(|t| matches!(t, "enabled" | "adaptive"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::types::anthropic_request::AnthropicRequest;
+
+    fn parse_req(body: &str) -> AnthropicRequest {
+        serde_json::from_str(body).unwrap()
+    }
+
+    #[test]
+    fn system_string_becomes_leading_system_message() {
+        let req = parse_req(
+            r#"{"model":"m","max_tokens":8,"system":"be terse","messages":[{"role":"user","content":"hi"}]}"#,
+        );
+        let t = anthropic_request_to_chat(&req);
+        assert_eq!(t.chat_request.messages.len(), 2);
+        assert!(matches!(t.chat_request.messages[0].role, Role::System));
+        assert_eq!(t.chat_request.messages[0].content.text(), "be terse");
+        assert!(matches!(t.chat_request.messages[1].role, Role::User));
+        assert_eq!(t.chat_request.messages[1].content.text(), "hi");
+        assert_eq!(t.chat_request.params.max_tokens, Some(8));
+    }
+
+    #[test]
+    fn user_image_block_becomes_image_url_part() {
+        let req = parse_req(
+            r#"{"model":"m","messages":[{"role":"user","content":[
+                {"type":"text","text":"look"},
+                {"type":"image","source":{"type":"base64","media_type":"image/png","data":"QUJD"}}
+            ]}]}"#,
+        );
+        let t = anthropic_request_to_chat(&req);
+        let urls = t.chat_request.image_urls();
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0], "data:image/png;base64,QUJD");
+        // Text preserved alongside image.
+        assert_eq!(t.chat_request.messages[0].content.text(), "look");
+    }
+
+    #[test]
+    fn assistant_tool_use_becomes_tool_calls() {
+        let req = parse_req(
+            r#"{"model":"m","messages":[{"role":"assistant","content":[
+                {"type":"tool_use","id":"toolu_1","name":"get_weather","input":{"city":"SF"}}
+            ]}]}"#,
+        );
+        let t = anthropic_request_to_chat(&req);
+        let msg = &t.chat_request.messages[0];
+        assert!(matches!(msg.role, Role::Assistant));
+        let calls = msg.tool_calls.as_ref().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "toolu_1");
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[0].function.arguments, r#"{"city":"SF"}"#);
+    }
+
+    #[test]
+    fn tool_result_text_becomes_tool_message() {
+        let req = parse_req(
+            r#"{"model":"m","messages":[{"role":"user","content":[
+                {"type":"tool_result","tool_use_id":"toolu_1","content":"sunny"}
+            ]}]}"#,
+        );
+        let t = anthropic_request_to_chat(&req);
+        // Only the tool message — no empty user turn ahead of it.
+        assert_eq!(t.chat_request.messages.len(), 1);
+        let msg = &t.chat_request.messages[0];
+        assert!(matches!(msg.role, Role::Tool));
+        assert_eq!(msg.tool_call_id.as_deref(), Some("toolu_1"));
+        assert_eq!(msg.content.text(), "sunny");
+    }
+
+    #[test]
+    fn tool_result_with_image_surfaces_image_url_part() {
+        // PR #1200: image content inside a tool result must flow through.
+        let req = parse_req(
+            r#"{"model":"m","messages":[{"role":"user","content":[
+                {"type":"tool_result","tool_use_id":"toolu_1","content":[
+                    {"type":"text","text":"chart"},
+                    {"type":"image","source":{"type":"base64","media_type":"image/jpeg","data":"WFla"}}
+                ]}
+            ]}]}"#,
+        );
+        let t = anthropic_request_to_chat(&req);
+        assert_eq!(t.chat_request.messages.len(), 1);
+        let msg = &t.chat_request.messages[0];
+        assert!(matches!(msg.role, Role::Tool));
+        assert_eq!(msg.tool_call_id.as_deref(), Some("toolu_1"));
+        assert_eq!(msg.content.text(), "chart");
+        let urls = msg.content.image_urls();
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0], "data:image/jpeg;base64,WFla");
+        // And the whole-request image extractor sees it too.
+        assert_eq!(t.chat_request.image_urls().len(), 1);
+    }
+
+    #[test]
+    fn tools_convert_and_drop_server_tools() {
+        let req = parse_req(
+            r#"{"model":"m","messages":[],"tools":[
+                {"name":"f","description":"d","input_schema":{"type":"object"}},
+                {"name":"web_search"},
+                {"type":"web_search_20250305","name":"web_search","max_uses":3}
+            ]}"#,
+        );
+        let t = anthropic_request_to_chat(&req);
+        let tools = t.chat_request.tools.as_ref().unwrap();
+        // Only the function tool with input_schema survives.
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "f");
+        assert!(tools[0].function.parameters.is_some());
+    }
+
+    #[test]
+    fn all_valid_function_tools_preserved_for_max_tools_guard() {
+        // The route-layer MAX_TOOLS guard inspects the converted tool count,
+        // so the translator must preserve every valid function tool.
+        let tools: Vec<String> = (0..200)
+            .map(|i| {
+                format!(r#"{{"name":"f{i}","description":"d","input_schema":{{"type":"object"}}}}"#)
+            })
+            .collect();
+        let body = format!(
+            r#"{{"model":"m","messages":[],"tools":[{}]}}"#,
+            tools.join(",")
+        );
+        let req = parse_req(&body);
+        let t = anthropic_request_to_chat(&req);
+        assert_eq!(t.chat_request.tools.as_ref().unwrap().len(), 200);
+    }
+
+    #[test]
+    fn tool_choice_any_maps_to_required() {
+        let req = parse_req(r#"{"model":"m","messages":[],"tool_choice":{"type":"any"}}"#);
+        let t = anthropic_request_to_chat(&req);
+        assert_eq!(
+            t.chat_request.tool_choice.as_ref().unwrap().mode(),
+            "required"
+        );
+    }
+
+    #[test]
+    fn tool_choice_named_tool_maps_to_specific() {
+        let req =
+            parse_req(r#"{"model":"m","messages":[],"tool_choice":{"type":"tool","name":"f"}}"#);
+        let t = anthropic_request_to_chat(&req);
+        let tc = t.chat_request.tool_choice.as_ref().unwrap();
+        assert_eq!(tc.specific_function(), Some("f"));
+    }
+
+    #[test]
+    fn stop_sequences_propagate_to_sampling_params() {
+        let req = parse_req(
+            r#"{"model":"m","max_tokens":8,"stop_sequences":["END","STOP"],"messages":[{"role":"user","content":"x"}]}"#,
+        );
+        let t = anthropic_request_to_chat(&req);
+        assert_eq!(
+            t.chat_request.params.stop.as_deref(),
+            Some(&["END".to_string(), "STOP".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn stop_reason_mapping() {
+        assert_eq!(anthropic_stop_reason("stop", false, None), "end_turn");
+        assert_eq!(anthropic_stop_reason("length", false, None), "max_tokens");
+        assert_eq!(anthropic_stop_reason("tool_calls", false, None), "tool_use");
+        assert_eq!(anthropic_stop_reason("stop", true, None), "tool_use");
+        assert_eq!(
+            anthropic_stop_reason("stop", false, Some("END")),
+            "stop_sequence"
+        );
+        // tool_use wins over stop_sequence.
+        assert_eq!(anthropic_stop_reason("stop", true, Some("END")), "tool_use");
+    }
+
+    #[test]
+    fn apply_stop_sequences_truncates_at_first_match() {
+        let (text, seq) = apply_stop_sequences(
+            "hello END world STOP",
+            Some(&["STOP".to_string(), "END".to_string()]),
+        );
+        assert_eq!(text, "hello ");
+        assert_eq!(seq.as_deref(), Some("END"));
+    }
+
+    #[test]
+    fn apply_stop_sequences_no_match_returns_input() {
+        let (text, seq) = apply_stop_sequences("hello", Some(&["X".to_string()]));
+        assert_eq!(text, "hello");
+        assert_eq!(seq, None);
+    }
+
+    #[test]
+    fn content_blocks_text_only() {
+        let blocks = build_content_blocks("hi", None, None, false);
+        assert_eq!(blocks.len(), 1);
+        assert!(matches!(&blocks[0], AnthropicResponseBlock::Text { text } if text == "hi"));
+    }
+
+    #[test]
+    fn content_blocks_empty_yields_empty_text() {
+        let blocks = build_content_blocks("", None, None, false);
+        assert_eq!(blocks.len(), 1);
+        assert!(matches!(&blocks[0], AnthropicResponseBlock::Text { text } if text.is_empty()));
+    }
+
+    #[test]
+    fn content_blocks_thinking_then_text() {
+        let blocks = build_content_blocks("answer", Some("reasoning"), None, true);
+        assert_eq!(blocks.len(), 2);
+        assert!(
+            matches!(&blocks[0], AnthropicResponseBlock::Thinking { thinking, .. } if thinking == "reasoning")
+        );
+        assert!(matches!(&blocks[1], AnthropicResponseBlock::Text { text } if text == "answer"));
+    }
+
+    #[test]
+    fn content_blocks_thinking_suppressed_when_disabled() {
+        let blocks = build_content_blocks("answer", Some("reasoning"), None, false);
+        assert_eq!(blocks.len(), 1);
+        assert!(matches!(&blocks[0], AnthropicResponseBlock::Text { .. }));
+    }
+
+    #[test]
+    fn content_blocks_with_tool_calls() {
+        let calls = vec![ParsedToolCall {
+            name: "f".to_string(),
+            arguments: r#"{"a":1}"#.to_string(),
+        }];
+        let blocks = build_content_blocks("", None, Some(&calls), false);
+        assert_eq!(blocks.len(), 1);
+        match &blocks[0] {
+            AnthropicResponseBlock::ToolUse { name, input, id } => {
+                assert_eq!(name, "f");
+                assert_eq!(input["a"], 1);
+                assert!(id.starts_with("toolu_"));
+            }
+            _ => panic!("expected tool_use"),
+        }
+    }
+
+    #[test]
+    fn parsed_call_invalid_args_become_empty_object() {
+        let call = ParsedToolCall {
+            name: "f".to_string(),
+            arguments: "not json".to_string(),
+        };
+        let block = parsed_call_to_tool_use(&call);
+        match block {
+            AnthropicResponseBlock::ToolUse { input, .. } => {
+                assert!(input.is_object());
+                assert_eq!(input.as_object().unwrap().len(), 0);
+            }
+            _ => panic!("expected tool_use"),
+        }
+    }
+
+    #[test]
+    fn thinking_enabled_detection() {
+        let req = parse_req(
+            r#"{"model":"m","messages":[],"thinking":{"type":"enabled","budget_tokens":1024}}"#,
+        );
+        assert!(thinking_enabled(&req));
+        let req2 = parse_req(r#"{"model":"m","messages":[],"thinking":{"type":"disabled"}}"#);
+        assert!(!thinking_enabled(&req2));
+        let req3 = parse_req(r#"{"model":"m","messages":[]}"#);
+        assert!(!thinking_enabled(&req3));
+    }
+}

--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -103,6 +103,12 @@ pub fn create_app(state: AppState) -> Router {
             get(routes::retrieve_response).delete(routes::delete_response),
         )
         .route("/v1/responses/:id/cancel", post(routes::cancel_response))
+        // Anthropic Messages API (/v1/messages surface).
+        .route("/v1/messages", post(routes::anthropic_messages))
+        .route(
+            "/v1/messages/count_tokens",
+            post(routes::anthropic_count_tokens),
+        )
         // Issue #552: prompt-cache observability endpoints (always mounted —
         // the handlers return a stable "disabled" payload when the cache is
         // off so monitoring clients can poll without conditional logic).
@@ -118,6 +124,11 @@ pub fn create_app(state: AppState) -> Router {
             get(routes::retrieve_response).delete(routes::delete_response),
         )
         .route("/responses/:id/cancel", post(routes::cancel_response))
+        .route("/messages", post(routes::anthropic_messages))
+        .route(
+            "/messages/count_tokens",
+            post(routes::anthropic_count_tokens),
+        )
         // llama-server compatible endpoints
         .route("/completion", post(routes::native_completion))
         .route("/tokenize", post(routes::tokenize))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,6 +14,7 @@
 
 //! OpenAI/llama-server compatible HTTP server for mlxcel
 
+pub mod anthropic_translator;
 pub mod app;
 pub mod batch;
 mod chat_request;
@@ -33,6 +34,7 @@ pub mod speculative_dispatch;
 mod startup;
 mod state;
 mod streaming;
+pub mod streaming_anthropic;
 pub mod streaming_responses;
 pub mod structured;
 pub mod thinking_budget;

--- a/src/server/routes/anthropic.rs
+++ b/src/server/routes/anthropic.rs
@@ -1,0 +1,602 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! HTTP handlers for the Anthropic Messages API.
+//!
+//! Ported from upstream mlx-vlm `server/anthropic.py` (PR #1196, commit
+//! `313ad22`) plus the tool-call image-handling fix (PR #1200, commit
+//! `f2e19de`).
+//!
+//! Endpoints:
+//!
+//! - `POST /v1/messages`               — create a message (sync or streaming)
+//! - `POST /v1/messages/count_tokens`  — count prompt tokens for a request
+//!
+//! The handlers are intentionally thin: the inbound/outbound translation
+//! lives in [`crate::server::anthropic_translator`], the SSE encoding in
+//! [`crate::server::streaming_anthropic`], and the actual generation reuses
+//! the existing chat building blocks (`prepare_chat_request_with_cache`,
+//! `build_generate_options`, `tool_calls::*`). Only the Anthropic envelope
+//! sequencing is new here.
+
+use axum::{
+    Json,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response, sse::Sse},
+};
+
+use crate::server::AppState;
+use crate::server::anthropic_translator::{
+    AnthropicTranslated, anthropic_request_to_chat, anthropic_stop_reason, apply_stop_sequences,
+    build_content_blocks, parsed_call_to_tool_use, short_uuid, thinking_enabled,
+};
+use crate::server::chat_request::prepare_chat_request_with_cache;
+use crate::server::config::ReasoningBudgetOverride;
+use crate::server::streaming_anthropic::{AnthropicBlockEmitter, anthropic_sse_channel};
+use crate::server::thinking_budget::{pick_budget_alias, resolve_request_budget};
+use crate::server::tool_calls;
+use crate::server::tool_calls::stream_filter::StreamFilter;
+use crate::server::types::anthropic_request::AnthropicRequest;
+use crate::server::types::anthropic_response::{
+    AnthropicErrorResponse, AnthropicMessageResponse, AnthropicResponseBlock, AnthropicUsage,
+};
+use crate::server::types::anthropic_stream::{
+    AnthropicMessageDeltaBody, AnthropicMessageDeltaUsage, AnthropicStreamError,
+    AnthropicStreamEvent,
+};
+
+use super::chat::{MAX_TOOLS, build_generate_options, parse_priority_header};
+
+/// POST /v1/messages
+pub async fn anthropic_messages(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<AnthropicRequest>,
+) -> Response {
+    let translated = anthropic_request_to_chat(&request);
+
+    // Enforce the tools array size limit to prevent DoS via template
+    // rendering, matching the chat-completions route. The check runs on the
+    // *converted* function tools (server tools without `input_schema` are
+    // already dropped) since that is what reaches the chat template.
+    if let Some(ref tools) = translated.chat_request.tools
+        && tools.len() > MAX_TOOLS
+    {
+        return AnthropicErrorResponse::bad_request(format!(
+            "Too many tools: {}. Maximum allowed is {MAX_TOOLS}.",
+            tools.len()
+        ))
+        .into_response();
+    }
+
+    // Resolve the thinking budget exactly as the chat / responses routes do.
+    let effective_max_tokens = translated
+        .chat_request
+        .params
+        .max_tokens
+        .unwrap_or(state.config.default_max_tokens);
+    let raw_budget = pick_budget_alias(
+        translated.chat_request.params.thinking_budget_tokens,
+        translated.chat_request.params.thinking_token_budget,
+        translated.chat_request.params.thinking_budget,
+    );
+    let budget_override = match resolve_request_budget(
+        raw_budget,
+        state.config.reasoning_budget,
+        effective_max_tokens,
+    ) {
+        Ok(eff) => {
+            if raw_budget.is_some() {
+                ReasoningBudgetOverride::Explicit(eff)
+            } else {
+                ReasoningBudgetOverride::InheritServerDefault
+            }
+        }
+        Err(err) => return AnthropicErrorResponse::bad_request(err.to_string()).into_response(),
+    };
+
+    let include_thinking = thinking_enabled(&request);
+    let priority = parse_priority_header(&headers);
+
+    if request.stream {
+        stream_messages(
+            state,
+            request,
+            translated,
+            priority,
+            budget_override,
+            include_thinking,
+        )
+        .await
+    } else {
+        non_stream_messages(
+            state,
+            request,
+            translated,
+            priority,
+            budget_override,
+            include_thinking,
+        )
+        .await
+    }
+}
+
+async fn non_stream_messages(
+    state: AppState,
+    request: AnthropicRequest,
+    translated: AnthropicTranslated,
+    priority: crate::server::batch::RequestPriority,
+    budget_override: ReasoningBudgetOverride,
+    include_thinking: bool,
+) -> Response {
+    if !state.can_accept_request() {
+        return AnthropicErrorResponse::overloaded("All slots are busy. Please try again later.")
+            .into_response();
+    }
+
+    let model_id = state.display_model_id().to_string();
+    let prompt_cache_enabled = state.prompt_cache.is_some();
+    let prepared = match prepare_chat_request_with_cache(
+        &state.chat_template,
+        &translated.chat_request,
+        state.config.chat_template_kwargs.as_ref(),
+        prompt_cache_enabled,
+    )
+    .await
+    {
+        Ok(prepared) => prepared,
+        Err(err) => return AnthropicErrorResponse::bad_request(err.to_string()).into_response(),
+    };
+
+    let mut options = build_generate_options(&translated.chat_request.params, &state.config);
+    options.priority = priority;
+    options.reasoning_budget = budget_override;
+
+    let result = match state.model_provider.generate_with_media_and_videos(
+        prepared.prompt,
+        options,
+        prepared.image_data,
+        prepared.audio_data,
+        prepared.videos,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            return AnthropicErrorResponse::api_error(format!("Generation failed: {e}"))
+                .into_response();
+        }
+    };
+
+    state.metrics.record_request(
+        result.prompt_tokens,
+        result.completion_tokens,
+        result.generation_time_ms,
+    );
+
+    // Parse tool calls and recover the visible/reasoning split using the
+    // shared chat helpers.
+    let parsed_tools = if tool_calls::should_parse_tool_calls(&translated.chat_request) {
+        Some(tool_calls::parse_tool_calls(
+            &result.text,
+            translated.chat_request.tools.as_deref(),
+        ))
+    } else {
+        None
+    };
+    let parsed_tool_calls = parsed_tools
+        .as_ref()
+        .filter(|p| p.has_tool_calls())
+        .map(|p| p.tool_calls.clone());
+
+    let (visible_text, reasoning_text) =
+        split_visible_reasoning(&result.text, parsed_tools.as_ref());
+
+    // Anthropic stop sequences: truncate visible text defensively (the
+    // scheduler already halts on native stop sequences, but a match may
+    // land inside a buffered chunk). Skip when tool calls were produced.
+    let (final_text, stop_sequence) = if parsed_tool_calls.is_some() {
+        (visible_text, None)
+    } else {
+        apply_stop_sequences(&visible_text, request.stop_sequences.as_deref())
+    };
+
+    let content_blocks = build_content_blocks(
+        &final_text,
+        reasoning_text.as_deref(),
+        parsed_tool_calls.as_deref(),
+        include_thinking,
+    );
+    let stop_reason = anthropic_stop_reason(
+        &result.finish_reason,
+        parsed_tool_calls.is_some(),
+        stop_sequence.as_deref(),
+    );
+
+    let response = AnthropicMessageResponse::new(
+        format!("msg_{}", short_uuid()),
+        content_blocks,
+        model_id,
+        Some(stop_reason),
+        stop_sequence,
+        AnthropicUsage {
+            input_tokens: result.prompt_tokens,
+            output_tokens: result.completion_tokens,
+        },
+    );
+
+    Json(response).into_response()
+}
+
+async fn stream_messages(
+    state: AppState,
+    request: AnthropicRequest,
+    translated: AnthropicTranslated,
+    priority: crate::server::batch::RequestPriority,
+    budget_override: ReasoningBudgetOverride,
+    include_thinking: bool,
+) -> Response {
+    if !state.can_accept_request() {
+        return AnthropicErrorResponse::overloaded("All slots are busy. Please try again later.")
+            .into_response();
+    }
+
+    let model_id = state.display_model_id().to_string();
+    let prompt_cache_enabled = state.prompt_cache.is_some();
+    let prepared = match prepare_chat_request_with_cache(
+        &state.chat_template,
+        &translated.chat_request,
+        state.config.chat_template_kwargs.as_ref(),
+        prompt_cache_enabled,
+    )
+    .await
+    {
+        Ok(prepared) => prepared,
+        Err(err) => return AnthropicErrorResponse::bad_request(err.to_string()).into_response(),
+    };
+
+    let mut options = build_generate_options(&translated.chat_request.params, &state.config);
+    options.priority = priority;
+    options.reasoning_budget = budget_override;
+
+    let (sender, stream, cancelled, keepalive) = anthropic_sse_channel(128);
+
+    let model_id_for_task = model_id.clone();
+    let stop_sequences = request.stop_sequences.clone();
+    let parse_tools = tool_calls::should_parse_tool_calls(&translated.chat_request);
+    let tools_for_parser = if parse_tools {
+        translated.chat_request.tools.clone()
+    } else {
+        None
+    };
+
+    // Encode the rendered prompt once so the streaming `message_start` can
+    // report the real prompt `input_tokens` up front (matches upstream; the
+    // prior hardcoded 0 left strict Anthropic SDK clients without prompt
+    // usage). Falls back to 0 if tokenization fails.
+    let prompt_tokens = state
+        .tokenizer
+        .encode(&prepared.prompt, true)
+        .map(|ids| ids.len())
+        .unwrap_or(0);
+
+    tokio::task::spawn_blocking(move || {
+        let message_id = format!("msg_{}", short_uuid());
+
+        // message_start carries the real prompt token count up front (matches
+        // upstream); output_tokens accrues over the stream and is finalized in
+        // the closing message_delta.
+        let start_message = AnthropicMessageResponse::new(
+            message_id.clone(),
+            vec![],
+            model_id_for_task.clone(),
+            None,
+            None,
+            AnthropicUsage {
+                input_tokens: prompt_tokens,
+                output_tokens: 0,
+            },
+        );
+        let _ = sender.send_event(&AnthropicStreamEvent::MessageStart {
+            message: start_message,
+        });
+
+        // Shared streaming state.
+        let accumulated_raw = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let acc_clone = accumulated_raw.clone();
+        let stream_filter = std::sync::Arc::new(std::sync::Mutex::new(StreamFilter::new()));
+        let filter_for_callback = stream_filter.clone();
+        let emitter = std::sync::Arc::new(std::sync::Mutex::new(AnthropicBlockEmitter::new()));
+        let emitter_for_callback = emitter.clone();
+        let sender_clone = sender.clone();
+        // Accumulated visible text (post-filter) for the stop-sequence scan.
+        let visible_acc = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let visible_for_callback = visible_acc.clone();
+
+        let result = state
+            .model_provider
+            .generate_streaming_with_logprobs_cancellable_videos(
+                prepared.prompt,
+                options,
+                prepared.image_data,
+                prepared.audio_data,
+                prepared.videos,
+                cancelled,
+                |token, _lp| {
+                    if let Ok(mut acc) = acc_clone.lock() {
+                        acc.push_str(&token);
+                    }
+                    let emit = filter_for_callback
+                        .lock()
+                        .ok()
+                        .map(|mut f| f.feed(&token))
+                        .unwrap_or_default();
+
+                    if let Ok(mut em) = emitter_for_callback.lock() {
+                        // Reasoning chunk → thinking block (only when extended
+                        // thinking was requested; otherwise the reasoning is
+                        // dropped from the visible stream, matching upstream).
+                        if include_thinking
+                            && let Some(reasoning) = emit.reasoning.filter(|s| !s.is_empty())
+                        {
+                            em.open_thinking(&sender_clone);
+                            em.emit_thinking_delta(&sender_clone, reasoning);
+                        }
+
+                        if let Some(text) = emit.content.filter(|s| !s.is_empty()) {
+                            if let Ok(mut v) = visible_for_callback.lock() {
+                                v.push_str(&text);
+                            }
+                            em.open_text(&sender_clone);
+                            em.emit_text_delta(&sender_clone, text);
+                        }
+                    }
+                },
+            );
+
+        // Flush any buffered content out of the stream filter.
+        let trailing = stream_filter
+            .lock()
+            .ok()
+            .map(|mut f| f.flush())
+            .unwrap_or_default();
+        if let Some(text) = trailing.content.filter(|s| !s.is_empty())
+            && let Ok(mut em) = emitter.lock()
+        {
+            if let Ok(mut v) = visible_acc.lock() {
+                v.push_str(&text);
+            }
+            em.open_text(&sender);
+            em.emit_text_delta(&sender, text);
+        }
+
+        let result = match result {
+            Ok(r) => r,
+            Err(err) => {
+                if let Ok(mut em) = emitter.lock() {
+                    em.close_open_block(&sender);
+                }
+                let _ = sender.send_event(&AnthropicStreamEvent::Error {
+                    error: AnthropicStreamError {
+                        error_type: "api_error".to_string(),
+                        message: err.to_string(),
+                    },
+                });
+                return;
+            }
+        };
+
+        state.metrics.record_request(
+            result.prompt_tokens,
+            result.completion_tokens,
+            result.generation_time_ms,
+        );
+
+        // Close any still-open text/thinking block before tool_use blocks.
+        if let Ok(mut em) = emitter.lock() {
+            em.close_open_block(&sender);
+        }
+
+        // Parse tool calls from the full raw output.
+        let full_raw = accumulated_raw
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default();
+        let parsed_tools = if parse_tools {
+            Some(tool_calls::parse_tool_calls(
+                &full_raw,
+                tools_for_parser.as_deref(),
+            ))
+        } else {
+            None
+        };
+        let parsed_calls = parsed_tools
+            .as_ref()
+            .filter(|p| p.has_tool_calls())
+            .map(|p| p.tool_calls.clone());
+
+        if let Some(calls) = parsed_calls.as_ref()
+            && let Ok(mut em) = emitter.lock()
+        {
+            for call in calls {
+                let block = parsed_call_to_tool_use(call);
+                if let AnthropicResponseBlock::ToolUse { id, name, input } = block {
+                    let input_json = serde_json::to_string(&input).unwrap_or_default();
+                    em.emit_tool_use(&sender, id, name, &input_json);
+                }
+            }
+        }
+
+        // Stop-sequence detection on the visible text (skip when tool calls
+        // were produced, mirroring upstream).
+        let stop_sequence = if parsed_calls.is_some() {
+            None
+        } else {
+            let visible = visible_acc.lock().map(|g| g.clone()).unwrap_or_default();
+            apply_stop_sequences(&visible, stop_sequences.as_deref()).1
+        };
+
+        let stop_reason = anthropic_stop_reason(
+            &result.finish_reason,
+            parsed_calls.is_some(),
+            stop_sequence.as_deref(),
+        );
+
+        let _ = sender.send_event(&AnthropicStreamEvent::MessageDelta {
+            delta: AnthropicMessageDeltaBody {
+                stop_reason: Some(stop_reason),
+                stop_sequence,
+            },
+            usage: AnthropicMessageDeltaUsage {
+                output_tokens: result.completion_tokens,
+            },
+        });
+        let _ = sender.send_event(&AnthropicStreamEvent::MessageStop);
+    });
+
+    Sse::new(stream)
+        .keep_alive(keepalive.into_inner())
+        .into_response()
+}
+
+/// POST /v1/messages/count_tokens
+///
+/// Renders the prompt through the chat template and returns the prompt token
+/// count. Mirrors the upstream `anthropic_count_tokens_endpoint`.
+pub async fn anthropic_count_tokens(
+    State(state): State<AppState>,
+    Json(request): Json<AnthropicRequest>,
+) -> Response {
+    let translated = anthropic_request_to_chat(&request);
+
+    // Enforce the tools array size limit before rendering the chat template.
+    // count_tokens expands `tools` into the template just like the main
+    // endpoint, so it needs the same MAX_TOOLS guard to avoid a
+    // template-rendering DoS (the main `anthropic_messages` handler applies
+    // the identical check).
+    if let Some(ref tools) = translated.chat_request.tools
+        && tools.len() > MAX_TOOLS
+    {
+        return AnthropicErrorResponse::bad_request(format!(
+            "Too many tools: {}. Maximum allowed is {MAX_TOOLS}.",
+            tools.len()
+        ))
+        .into_response();
+    }
+
+    let prompt_cache_enabled = state.prompt_cache.is_some();
+    let prepared = match prepare_chat_request_with_cache(
+        &state.chat_template,
+        &translated.chat_request,
+        state.config.chat_template_kwargs.as_ref(),
+        prompt_cache_enabled,
+    )
+    .await
+    {
+        Ok(prepared) => prepared,
+        Err(err) => return AnthropicErrorResponse::bad_request(err.to_string()).into_response(),
+    };
+
+    let token_count = match state.tokenizer.encode(&prepared.prompt, true) {
+        Ok(ids) => ids.len(),
+        Err(e) => {
+            return AnthropicErrorResponse::bad_request(format!("Tokenization error: {e}"))
+                .into_response();
+        }
+    };
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "input_tokens": token_count })),
+    )
+        .into_response()
+}
+
+/// Split the raw generation output into `(visible_text, reasoning?)`.
+///
+/// Mirrors the chat/responses split: when tool parsing ran, the parser's
+/// `content` is the visible text; otherwise structural tokens are stripped.
+/// Reasoning is recovered from a `<think>...</think>` block (inline or
+/// open-primed close-only) so it can populate a dedicated `thinking` block.
+fn split_visible_reasoning(
+    raw: &str,
+    parsed: Option<&tool_calls::ToolCallParseResult>,
+) -> (String, Option<String>) {
+    let reasoning = extract_reasoning_from_raw(raw);
+    let visible_source = match parsed {
+        Some(p) => p.content.clone(),
+        None => tool_calls::clean_structural_tokens(raw),
+    };
+    let visible = if let Some((_, after_close)) = visible_source.split_once("</think>") {
+        after_close.trim_start().to_string()
+    } else {
+        visible_source.trim_start().to_string()
+    };
+    (visible, reasoning)
+}
+
+/// Recover the reasoning chunk from raw output (inline `<think>...</think>`
+/// or open-primed close-only `...</think>`). Returns `None` when empty.
+fn extract_reasoning_from_raw(raw: &str) -> Option<String> {
+    if let Some(rest) = raw.strip_prefix("<think>")
+        && let Some(end) = rest.find("</think>")
+    {
+        let reason = rest[..end].trim();
+        return if reason.is_empty() {
+            None
+        } else {
+            Some(reason.to_string())
+        };
+    }
+    if let Some(end) = raw.find("</think>") {
+        let reason = raw[..end].trim();
+        return if reason.is_empty() {
+            None
+        } else {
+            Some(reason.to_string())
+        };
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_no_think_returns_cleaned() {
+        let (visible, reasoning) = split_visible_reasoning("hello world", None);
+        assert_eq!(visible, "hello world");
+        assert_eq!(reasoning, None);
+    }
+
+    #[test]
+    fn split_inline_think_block() {
+        let (visible, reasoning) = split_visible_reasoning("<think>reasoning</think>answer", None);
+        assert_eq!(visible, "answer");
+        assert_eq!(reasoning.as_deref(), Some("reasoning"));
+    }
+
+    #[test]
+    fn split_open_primed_close_only() {
+        let (visible, reasoning) = split_visible_reasoning("trace text</think>final", None);
+        assert_eq!(visible, "final");
+        assert_eq!(reasoning.as_deref(), Some("trace text"));
+    }
+
+    #[test]
+    fn extract_reasoning_empty_yields_none() {
+        assert_eq!(extract_reasoning_from_raw("</think>x"), None);
+        assert_eq!(extract_reasoning_from_raw("<think></think>x"), None);
+    }
+}

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -18,6 +18,7 @@
 //! policy belongs in `server/request_options.rs`, `server/chat_request.rs`,
 //! `server/media.rs`, `server/streaming.rs`, and `server/model_worker.rs`.
 
+pub mod anthropic;
 pub mod cache;
 pub mod chat;
 pub mod completions;
@@ -31,6 +32,7 @@ pub mod responses;
 pub mod slots;
 pub mod tokenize;
 
+pub use anthropic::{anthropic_count_tokens, anthropic_messages};
 pub use cache::{cache_reset, cache_stats};
 pub use chat::chat_completions;
 pub use completions::completions;

--- a/src/server/streaming_anthropic.rs
+++ b/src/server/streaming_anthropic.rs
@@ -1,0 +1,331 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SSE encoder for the Anthropic Messages API (`POST /v1/messages`).
+//!
+//! Mirrors [`crate::server::streaming_responses`]: each on-wire frame carries
+//! an `event:` header (the event name) plus a typed `data:` payload. The
+//! channel pattern matches [`crate::server::streaming::sse_channel`] —
+//! generation runs on a blocking task that calls
+//! [`AnthropicStreamSender::send_event`]; the receiver maps each frame into
+//! an [`axum::response::sse::Event`].
+//!
+//! [`AnthropicBlockEmitter`] owns the Anthropic content-block index state
+//! machine ported from the upstream `open_block` / `close_open_block`
+//! closures in `server/anthropic.py`: there is at most one open block at a
+//! time, and `index` increments each time a block closes.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use axum::response::sse::{Event, KeepAlive};
+use futures::Stream;
+use futures::StreamExt;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::server::types::anthropic_response::AnthropicResponseBlock;
+use crate::server::types::anthropic_stream::{AnthropicBlockDelta, AnthropicStreamEvent};
+
+const KEEPALIVE_INTERVAL_SECS: u64 = 15;
+
+/// Cancellation token shared with the scheduler for client-disconnect detection.
+pub(crate) type CancellationToken = Arc<AtomicBool>;
+
+/// One frame on the wire: the SSE `event:` header value plus the
+/// JSON-serialised payload.
+struct AnthropicFrame {
+    name: &'static str,
+    data: String,
+}
+
+/// Blocking sender used by the generation task.
+#[derive(Clone)]
+pub struct AnthropicStreamSender {
+    tx: mpsc::Sender<Result<AnthropicFrame, Infallible>>,
+    cancelled: CancellationToken,
+}
+
+impl AnthropicStreamSender {
+    /// Send a typed Anthropic SSE event. Silently drops the event when the
+    /// receiver has been dropped (client disconnected); the cancellation
+    /// token is flipped so the scheduler can abort the underlying sequence.
+    pub fn send_event(&self, event: &AnthropicStreamEvent) -> Result<(), serde_json::Error> {
+        let payload = serde_json::to_string(event)?;
+        let frame = AnthropicFrame {
+            name: event.event_name(),
+            data: payload,
+        };
+        if self.tx.blocking_send(Ok(frame)).is_err() {
+            self.cancelled.store(true, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+}
+
+/// Newtype wrapping the keepalive configuration.
+pub struct AnthropicSseKeepAlive(KeepAlive);
+
+impl AnthropicSseKeepAlive {
+    fn default_for_long_prefill() -> Self {
+        // Anthropic clients accept `ping` events; the axum keepalive comment
+        // frame is also tolerated. We use the standard keepalive comment to
+        // match the Responses-API encoder.
+        Self(KeepAlive::new().interval(Duration::from_secs(KEEPALIVE_INTERVAL_SECS)))
+    }
+
+    pub fn into_inner(self) -> KeepAlive {
+        self.0
+    }
+}
+
+/// Construct an Anthropic-API SSE channel.
+///
+/// Returns `(sender, stream, cancelled, keepalive)`. The stream is fed into
+/// `Sse::new(stream).keep_alive(keepalive.into_inner())`. The cancellation
+/// token flips when the receiver is dropped so the scheduler can abort
+/// orphaned sequences.
+pub fn anthropic_sse_channel(
+    buffer: usize,
+) -> (
+    AnthropicStreamSender,
+    impl Stream<Item = Result<Event, Infallible>>,
+    CancellationToken,
+    AnthropicSseKeepAlive,
+) {
+    let cancelled: CancellationToken = Arc::new(AtomicBool::new(false));
+    let (tx, rx) = mpsc::channel::<Result<AnthropicFrame, Infallible>>(buffer);
+    let stream = ReceiverStream::new(rx)
+        .map(|frame| frame.map(|f| Event::default().event(f.name).data(f.data)));
+    let sender = AnthropicStreamSender {
+        tx,
+        cancelled: cancelled.clone(),
+    };
+    (
+        sender,
+        stream,
+        cancelled,
+        AnthropicSseKeepAlive::default_for_long_prefill(),
+    )
+}
+
+/// The kind of content block currently open in the stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpenBlock {
+    Text,
+    Thinking,
+}
+
+/// Stateful emitter that drives the Anthropic content-block index machine.
+///
+/// At most one block is open at a time. `block_index` is the index assigned
+/// to the *next* block to open and is bumped on each close. Tool-use blocks
+/// are emitted directly via [`AnthropicBlockEmitter::emit_tool_use`] (they
+/// open and close in one shot) after any text/thinking block has closed.
+pub struct AnthropicBlockEmitter {
+    block_index: usize,
+    open: Option<OpenBlock>,
+}
+
+impl Default for AnthropicBlockEmitter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AnthropicBlockEmitter {
+    pub fn new() -> Self {
+        Self {
+            block_index: 0,
+            open: None,
+        }
+    }
+
+    /// The index of the currently open (or next) block.
+    pub fn current_index(&self) -> usize {
+        self.block_index
+    }
+
+    /// Close the open block (if any), emitting `content_block_stop` and
+    /// advancing the index. No-op when no block is open.
+    pub fn close_open_block(&mut self, sender: &AnthropicStreamSender) {
+        if self.open.is_none() {
+            return;
+        }
+        let _ = sender.send_event(&AnthropicStreamEvent::ContentBlockStop {
+            index: self.block_index,
+        });
+        self.open = None;
+        self.block_index += 1;
+    }
+
+    /// Ensure a text block is open, closing any differently-typed block
+    /// first. Emits `content_block_start` for a freshly opened block.
+    pub fn open_text(&mut self, sender: &AnthropicStreamSender) {
+        self.open_kind(sender, OpenBlock::Text);
+    }
+
+    /// Ensure a thinking block is open, closing any differently-typed block
+    /// first. Emits `content_block_start` for a freshly opened block.
+    pub fn open_thinking(&mut self, sender: &AnthropicStreamSender) {
+        self.open_kind(sender, OpenBlock::Thinking);
+    }
+
+    fn open_kind(&mut self, sender: &AnthropicStreamSender, kind: OpenBlock) {
+        if self.open == Some(kind) {
+            return;
+        }
+        self.close_open_block(sender);
+        let content_block = match kind {
+            OpenBlock::Text => AnthropicResponseBlock::Text {
+                text: String::new(),
+            },
+            OpenBlock::Thinking => AnthropicResponseBlock::Thinking {
+                thinking: String::new(),
+                signature: String::new(),
+            },
+        };
+        let _ = sender.send_event(&AnthropicStreamEvent::ContentBlockStart {
+            index: self.block_index,
+            content_block,
+        });
+        self.open = Some(kind);
+    }
+
+    /// Emit a text delta on the currently open text block.
+    pub fn emit_text_delta(&self, sender: &AnthropicStreamSender, text: String) {
+        let _ = sender.send_event(&AnthropicStreamEvent::ContentBlockDelta {
+            index: self.block_index,
+            delta: AnthropicBlockDelta::TextDelta { text },
+        });
+    }
+
+    /// Emit a thinking delta on the currently open thinking block.
+    pub fn emit_thinking_delta(&self, sender: &AnthropicStreamSender, thinking: String) {
+        let _ = sender.send_event(&AnthropicStreamEvent::ContentBlockDelta {
+            index: self.block_index,
+            delta: AnthropicBlockDelta::ThinkingDelta { thinking },
+        });
+    }
+
+    /// Emit a complete `tool_use` block: `content_block_start`, a single
+    /// `input_json_delta` (when the JSON is non-empty), then
+    /// `content_block_stop`. Advances the index. Any open text/thinking
+    /// block must be closed first by the caller.
+    pub fn emit_tool_use(
+        &mut self,
+        sender: &AnthropicStreamSender,
+        id: String,
+        name: String,
+        input_json: &str,
+    ) {
+        let _ = sender.send_event(&AnthropicStreamEvent::ContentBlockStart {
+            index: self.block_index,
+            content_block: AnthropicResponseBlock::ToolUse {
+                id,
+                name,
+                // The block starts with an empty input; the partial JSON is
+                // streamed via input_json_delta to match the Anthropic
+                // protocol.
+                input: serde_json::json!({}),
+            },
+        });
+        if !input_json.is_empty() {
+            let _ = sender.send_event(&AnthropicStreamEvent::ContentBlockDelta {
+                index: self.block_index,
+                delta: AnthropicBlockDelta::InputJsonDelta {
+                    partial_json: input_json.to_string(),
+                },
+            });
+        }
+        let _ = sender.send_event(&AnthropicStreamEvent::ContentBlockStop {
+            index: self.block_index,
+        });
+        self.block_index += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn channel_round_trips_event_with_header() {
+        let (sender, stream, _cancelled, _keepalive) = anthropic_sse_channel(8);
+        let send_task = tokio::task::spawn_blocking(move || {
+            sender
+                .send_event(&AnthropicStreamEvent::MessageStop)
+                .expect("send");
+            drop(sender);
+        });
+        send_task.await.expect("blocking task");
+        let collected: Vec<_> = stream.collect().await;
+        assert_eq!(collected.len(), 1);
+        let _ = collected.into_iter().next().unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn emitter_block_index_machine() {
+        // Drive the emitter and collect the produced frames to confirm the
+        // open/close/advance index machine matches the Anthropic protocol.
+        let (sender, stream, _cancelled, _keepalive) = anthropic_sse_channel(64);
+        let task = tokio::task::spawn_blocking(move || {
+            let mut em = AnthropicBlockEmitter::new();
+            // Open text, emit a delta.
+            em.open_text(&sender);
+            em.emit_text_delta(&sender, "hi".to_string());
+            assert_eq!(em.current_index(), 0);
+            // Switch to thinking (closes text → index 1).
+            em.open_thinking(&sender);
+            assert_eq!(em.current_index(), 1);
+            em.emit_thinking_delta(&sender, "r".to_string());
+            // Close the thinking block (→ index 2).
+            em.close_open_block(&sender);
+            assert_eq!(em.current_index(), 2);
+            // Tool use opens+closes in one shot (→ index 3).
+            em.emit_tool_use(&sender, "toolu_1".to_string(), "f".to_string(), "{\"a\":1}");
+            assert_eq!(em.current_index(), 3);
+            drop(sender);
+        });
+        task.await.expect("task");
+        let frames: Vec<_> = stream.collect().await;
+        // Expected on-wire frames:
+        //  start(0,text), delta(0), stop(0),
+        //  start(1,thinking), delta(1), stop(1),
+        //  start(2,tool_use), delta(2,input_json), stop(2)
+        assert_eq!(frames.len(), 9);
+        for f in frames {
+            let _ = f.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn emitter_idempotent_open_same_kind() {
+        let (sender, stream, _cancelled, _keepalive) = anthropic_sse_channel(16);
+        let task = tokio::task::spawn_blocking(move || {
+            let mut em = AnthropicBlockEmitter::new();
+            em.open_text(&sender);
+            em.open_text(&sender); // no-op, same kind
+            em.emit_text_delta(&sender, "x".to_string());
+            assert_eq!(em.current_index(), 0);
+            drop(sender);
+        });
+        task.await.expect("task");
+        let frames: Vec<_> = stream.collect().await;
+        // Only one start + one delta — the second open_text is a no-op.
+        assert_eq!(frames.len(), 2);
+    }
+}

--- a/src/server/types/anthropic_request.rs
+++ b/src/server/types/anthropic_request.rs
@@ -1,0 +1,443 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Anthropic Messages API request types (`POST /v1/messages`).
+//!
+//! Ported from upstream mlx-vlm `server/anthropic.py` (PR #1196, commit
+//! `313ad22`) plus the tool-call image-handling fix (PR #1200, commit
+//! `f2e19de`). These types model the inbound Anthropic
+//! [Messages](https://docs.anthropic.com/en/api/messages) schema; the
+//! translation into the internal chat-completions shape lives in
+//! [`crate::server::anthropic_translator`].
+
+use serde::Deserialize;
+
+/// Top-level `POST /v1/messages` request body.
+///
+/// Mirrors the Anthropic Messages request. Fields the local server cannot
+/// honour (e.g. `metadata`, server-side tools) are accepted and ignored so
+/// SDK clients keep working.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AnthropicRequest {
+    /// Model identifier (must match the loaded model alias or path).
+    pub model: String,
+    /// Conversation turns.
+    pub messages: Vec<AnthropicMessage>,
+    /// Optional system prompt: a bare string or an array of text blocks.
+    #[serde(default)]
+    pub system: Option<AnthropicSystem>,
+    /// Maximum number of tokens to generate. Required by the Anthropic API;
+    /// optional here so callers that omit it fall back to the server default.
+    #[serde(default)]
+    pub max_tokens: Option<usize>,
+    /// Up to N custom stop sequences. Generation text is truncated at the
+    /// first matching sequence and `stop_reason` becomes `stop_sequence`.
+    #[serde(default)]
+    pub stop_sequences: Option<Vec<String>>,
+    /// Whether to stream the response as SSE events.
+    #[serde(default)]
+    pub stream: bool,
+    /// Sampling temperature (0.0 = greedy).
+    #[serde(default)]
+    pub temperature: Option<f32>,
+    /// Nucleus sampling threshold.
+    #[serde(default)]
+    pub top_p: Option<f32>,
+    /// Top-k sampling.
+    #[serde(default)]
+    pub top_k: Option<usize>,
+    /// Tool definitions available for the model.
+    #[serde(default)]
+    pub tools: Option<Vec<AnthropicTool>>,
+    /// Controls how the model selects tools.
+    #[serde(default)]
+    pub tool_choice: Option<AnthropicToolChoice>,
+    /// Anthropic extended-thinking configuration. Read for `enable_thinking`
+    /// and `budget_tokens` derivation.
+    #[serde(default)]
+    pub thinking: Option<AnthropicThinking>,
+    /// Extra fields are tolerated (metadata, container, etc.) so SDK callers
+    /// that send richer payloads do not get 400s.
+    #[serde(default, flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// `system` may be a plain string or an array of typed content blocks.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum AnthropicSystem {
+    /// Bare string system prompt.
+    Text(String),
+    /// Array of blocks (only `text` blocks contribute text).
+    Blocks(Vec<AnthropicSystemBlock>),
+}
+
+impl AnthropicSystem {
+    /// Flatten the system prompt into a single string. Returns `None` when
+    /// the prompt is empty after trimming.
+    pub fn to_text(&self) -> Option<String> {
+        match self {
+            AnthropicSystem::Text(s) => {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(s.clone())
+                }
+            }
+            AnthropicSystem::Blocks(blocks) => {
+                let joined = blocks
+                    .iter()
+                    .filter_map(|b| b.text.as_deref())
+                    .filter(|t| !t.is_empty())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let trimmed = joined.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            }
+        }
+    }
+}
+
+/// A single block within an array-form `system` prompt.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AnthropicSystemBlock {
+    /// Block type (only `text` is interpreted).
+    #[serde(rename = "type", default)]
+    pub block_type: Option<String>,
+    /// Text payload for `text` blocks.
+    #[serde(default)]
+    pub text: Option<String>,
+}
+
+/// A single conversation turn.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AnthropicMessage {
+    /// `user` or `assistant`.
+    pub role: AnthropicRole,
+    /// Content: a bare string or an array of typed content blocks.
+    pub content: AnthropicMessageContent,
+}
+
+/// Message role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AnthropicRole {
+    User,
+    Assistant,
+}
+
+impl AnthropicRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AnthropicRole::User => "user",
+            AnthropicRole::Assistant => "assistant",
+        }
+    }
+}
+
+/// Message content: a bare string or an array of typed content blocks.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum AnthropicMessageContent {
+    /// Plain text content.
+    Text(String),
+    /// Array of content blocks.
+    Blocks(Vec<AnthropicContentBlock>),
+}
+
+/// A typed content block inside a message.
+///
+/// `Unknown` is the catch-all for block types the server does not model
+/// (e.g. `redacted_thinking`); they are tolerated and dropped during
+/// translation.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum AnthropicContentBlock {
+    /// Plain text block.
+    #[serde(rename = "text")]
+    Text { text: String },
+    /// Image block with a `source` (base64 or url).
+    #[serde(rename = "image")]
+    Image { source: AnthropicImageSource },
+    /// Document block; only the `text`-typed source contributes text.
+    #[serde(rename = "document")]
+    Document {
+        #[serde(default)]
+        source: Option<serde_json::Value>,
+    },
+    /// Assistant tool-call request.
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        #[serde(default)]
+        id: Option<String>,
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(default)]
+        input: Option<serde_json::Value>,
+    },
+    /// User-supplied tool result. `content` may itself contain image blocks
+    /// (the PR #1200 fix).
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        #[serde(default)]
+        tool_use_id: Option<String>,
+        #[serde(default)]
+        content: Option<AnthropicToolResultContent>,
+        #[serde(default)]
+        name: Option<String>,
+    },
+    /// Extended-thinking block (dropped during inbound translation).
+    #[serde(rename = "thinking")]
+    Thinking {
+        #[serde(default)]
+        thinking: Option<String>,
+    },
+    /// Any other block type — tolerated and ignored.
+    #[serde(other)]
+    Unknown,
+}
+
+/// `tool_result.content` may be a bare string or an array of blocks
+/// (text and/or image).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum AnthropicToolResultContent {
+    /// Bare string content.
+    Text(String),
+    /// Array of nested blocks (text and image supported).
+    Blocks(Vec<AnthropicToolResultBlock>),
+}
+
+/// A nested block inside `tool_result.content`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum AnthropicToolResultBlock {
+    /// Text block.
+    #[serde(rename = "text")]
+    Text { text: String },
+    /// Image block (PR #1200: images inside tool results).
+    #[serde(rename = "image")]
+    Image { source: AnthropicImageSource },
+    /// Tolerated unknown block.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Image source: a base64 payload or a URL.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum AnthropicImageSource {
+    /// Base64-encoded image data with a media type.
+    #[serde(rename = "base64")]
+    Base64 {
+        #[serde(default)]
+        media_type: Option<String>,
+        data: String,
+    },
+    /// Remote image URL.
+    #[serde(rename = "url")]
+    Url { url: String },
+    /// Tolerated unknown source type.
+    #[serde(other)]
+    Unknown,
+}
+
+impl AnthropicImageSource {
+    /// Convert the source into an `image_url`-style reference understood by
+    /// the internal media plumbing: a `data:<media_type>;base64,<data>` URI
+    /// for base64 sources, or the bare URL for url sources. Returns `None`
+    /// for unknown/empty sources.
+    pub fn to_image_ref(&self) -> Option<String> {
+        match self {
+            AnthropicImageSource::Base64 { media_type, data } => {
+                if data.is_empty() {
+                    return None;
+                }
+                let media = media_type.as_deref().unwrap_or("image/png");
+                Some(format!("data:{media};base64,{data}"))
+            }
+            AnthropicImageSource::Url { url } => {
+                if url.is_empty() {
+                    None
+                } else {
+                    Some(url.clone())
+                }
+            }
+            AnthropicImageSource::Unknown => None,
+        }
+    }
+}
+
+/// Tool definition (Anthropic shape).
+#[derive(Debug, Clone, Deserialize)]
+pub struct AnthropicTool {
+    /// Tool name. Server tools (no `input_schema`) are dropped.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// JSON Schema for the tool's input.
+    #[serde(default)]
+    pub input_schema: Option<serde_json::Value>,
+}
+
+/// Tool-choice spec (Anthropic shape).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum AnthropicToolChoice {
+    /// Bare string form (rare; tolerated).
+    Mode(String),
+    /// Object form: `{ "type": "auto" | "any" | "none" | "tool", ... }`.
+    Spec(AnthropicToolChoiceSpec),
+}
+
+/// Object-form tool choice.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AnthropicToolChoiceSpec {
+    #[serde(rename = "type")]
+    pub choice_type: String,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// Extended-thinking configuration block.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AnthropicThinking {
+    /// `enabled`, `adaptive`, or `disabled`.
+    #[serde(rename = "type", default)]
+    pub thinking_type: Option<String>,
+    /// Token budget for thinking.
+    #[serde(default)]
+    pub budget_tokens: Option<usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_string_round_trips() {
+        let sys: AnthropicSystem = serde_json::from_str("\"be terse\"").unwrap();
+        assert_eq!(sys.to_text().as_deref(), Some("be terse"));
+    }
+
+    #[test]
+    fn system_blocks_join_text() {
+        let sys: AnthropicSystem =
+            serde_json::from_str(r#"[{"type":"text","text":"a"},{"type":"text","text":"b"}]"#)
+                .unwrap();
+        assert_eq!(sys.to_text().as_deref(), Some("a\nb"));
+    }
+
+    #[test]
+    fn system_empty_is_none() {
+        let sys: AnthropicSystem = serde_json::from_str("\"   \"").unwrap();
+        assert_eq!(sys.to_text(), None);
+    }
+
+    #[test]
+    fn base64_image_source_builds_data_uri() {
+        let src = AnthropicImageSource::Base64 {
+            media_type: Some("image/jpeg".to_string()),
+            data: "QUJD".to_string(),
+        };
+        assert_eq!(
+            src.to_image_ref().as_deref(),
+            Some("data:image/jpeg;base64,QUJD")
+        );
+    }
+
+    #[test]
+    fn base64_image_default_media_type() {
+        let src = AnthropicImageSource::Base64 {
+            media_type: None,
+            data: "QUJD".to_string(),
+        };
+        assert_eq!(
+            src.to_image_ref().as_deref(),
+            Some("data:image/png;base64,QUJD")
+        );
+    }
+
+    #[test]
+    fn url_image_source_passes_through() {
+        let src = AnthropicImageSource::Url {
+            url: "https://example.com/x.png".to_string(),
+        };
+        assert_eq!(
+            src.to_image_ref().as_deref(),
+            Some("https://example.com/x.png")
+        );
+    }
+
+    #[test]
+    fn parse_full_request_with_tool_result_image() {
+        let body = r#"{
+            "model": "m",
+            "max_tokens": 64,
+            "system": "sys",
+            "stop_sequences": ["STOP"],
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "toolu_1", "name": "get_image", "input": {}}
+                ]},
+                {"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "toolu_1", "content": [
+                        {"type": "text", "text": "here"},
+                        {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "QUJD"}}
+                    ]}
+                ]}
+            ],
+            "tools": [
+                {"name": "get_image", "description": "d", "input_schema": {"type": "object"}}
+            ]
+        }"#;
+        let req: AnthropicRequest = serde_json::from_str(body).unwrap();
+        assert_eq!(req.model, "m");
+        assert_eq!(req.max_tokens, Some(64));
+        assert_eq!(
+            req.stop_sequences.as_deref(),
+            Some(&["STOP".to_string()][..])
+        );
+        assert_eq!(req.messages.len(), 3);
+        assert!(req.tools.is_some());
+    }
+
+    #[test]
+    fn unknown_content_block_is_tolerated() {
+        let body = r#"{"role":"user","content":[{"type":"redacted_thinking","data":"x"}]}"#;
+        let msg: AnthropicMessage = serde_json::from_str(body).unwrap();
+        match msg.content {
+            AnthropicMessageContent::Blocks(b) => {
+                assert!(matches!(b[0], AnthropicContentBlock::Unknown));
+            }
+            _ => panic!("expected blocks"),
+        }
+    }
+
+    #[test]
+    fn extra_top_level_fields_tolerated() {
+        let body = r#"{"model":"m","messages":[],"metadata":{"user_id":"u"},"container":"c"}"#;
+        let req: AnthropicRequest = serde_json::from_str(body).unwrap();
+        assert!(req.extra.contains_key("metadata"));
+        assert!(req.extra.contains_key("container"));
+    }
+}

--- a/src/server/types/anthropic_response.rs
+++ b/src/server/types/anthropic_response.rs
@@ -1,0 +1,224 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Anthropic Messages API response types (`POST /v1/messages`).
+//!
+//! Ported from upstream mlx-vlm `server/anthropic.py` (PR #1196). These
+//! types model the outbound Anthropic
+//! [Messages](https://docs.anthropic.com/en/api/messages) response and the
+//! error envelope. Outbound assembly lives in
+//! [`crate::server::anthropic_translator`].
+
+use serde::Serialize;
+
+/// Top-level non-streaming `POST /v1/messages` response.
+#[derive(Debug, Clone, Serialize)]
+pub struct AnthropicMessageResponse {
+    /// `msg_<uuid>`.
+    pub id: String,
+    /// Always `"message"`.
+    #[serde(rename = "type")]
+    pub message_type: String,
+    /// Always `"assistant"`.
+    pub role: String,
+    /// Ordered output content blocks.
+    pub content: Vec<AnthropicResponseBlock>,
+    /// Echoed model identifier.
+    pub model: String,
+    /// Why generation stopped: `end_turn`, `max_tokens`, `stop_sequence`,
+    /// `tool_use`, or `null` (streaming `message_start`).
+    pub stop_reason: Option<String>,
+    /// The matched stop sequence (when `stop_reason == "stop_sequence"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_sequence: Option<String>,
+    /// Token usage.
+    pub usage: AnthropicUsage,
+}
+
+impl AnthropicMessageResponse {
+    /// Construct a response with the standard `type`/`role` constants.
+    pub fn new(
+        id: String,
+        content: Vec<AnthropicResponseBlock>,
+        model: String,
+        stop_reason: Option<String>,
+        stop_sequence: Option<String>,
+        usage: AnthropicUsage,
+    ) -> Self {
+        Self {
+            id,
+            message_type: "message".to_string(),
+            role: "assistant".to_string(),
+            content,
+            model,
+            stop_reason,
+            stop_sequence,
+            usage,
+        }
+    }
+}
+
+/// An output content block in a response.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum AnthropicResponseBlock {
+    /// Visible text.
+    #[serde(rename = "text")]
+    Text { text: String },
+    /// Extended-thinking trace.
+    #[serde(rename = "thinking")]
+    Thinking { thinking: String, signature: String },
+    /// Tool-call request emitted by the model.
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+}
+
+/// Token usage counters.
+#[derive(Debug, Clone, Serialize)]
+pub struct AnthropicUsage {
+    /// Prompt tokens.
+    pub input_tokens: usize,
+    /// Generated tokens.
+    pub output_tokens: usize,
+}
+
+/// Anthropic error envelope: `{ "type": "error", "error": {...} }`.
+#[derive(Debug, Clone, Serialize)]
+pub struct AnthropicErrorResponse {
+    #[serde(rename = "type")]
+    pub envelope_type: String,
+    pub error: AnthropicErrorBody,
+    /// HTTP status code (not serialised — used by IntoResponse).
+    #[serde(skip)]
+    pub status: axum::http::StatusCode,
+}
+
+/// Inner error object.
+#[derive(Debug, Clone, Serialize)]
+pub struct AnthropicErrorBody {
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub message: String,
+}
+
+impl AnthropicErrorResponse {
+    /// Build an error with an explicit HTTP status and Anthropic error type.
+    pub fn new(
+        status: axum::http::StatusCode,
+        message: impl Into<String>,
+        error_type: impl Into<String>,
+    ) -> Self {
+        Self {
+            envelope_type: "error".to_string(),
+            error: AnthropicErrorBody {
+                error_type: error_type.into(),
+                message: message.into(),
+            },
+            status,
+        }
+    }
+
+    /// 400 `invalid_request_error`.
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self::new(
+            axum::http::StatusCode::BAD_REQUEST,
+            message,
+            "invalid_request_error",
+        )
+    }
+
+    /// 503 `overloaded_error` — all generation slots busy.
+    pub fn overloaded(message: impl Into<String>) -> Self {
+        Self::new(
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            message,
+            "overloaded_error",
+        )
+    }
+
+    /// 500 `api_error` — generation failure.
+    pub fn api_error(message: impl Into<String>) -> Self {
+        Self::new(
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            message,
+            "api_error",
+        )
+    }
+}
+
+impl axum::response::IntoResponse for AnthropicErrorResponse {
+    fn into_response(self) -> axum::response::Response {
+        (self.status, axum::Json(self)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_response_serializes_with_constants() {
+        let resp = AnthropicMessageResponse::new(
+            "msg_1".to_string(),
+            vec![AnthropicResponseBlock::Text {
+                text: "hi".to_string(),
+            }],
+            "m".to_string(),
+            Some("end_turn".to_string()),
+            None,
+            AnthropicUsage {
+                input_tokens: 5,
+                output_tokens: 3,
+            },
+        );
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["type"], "message");
+        assert_eq!(v["role"], "assistant");
+        assert_eq!(v["content"][0]["type"], "text");
+        assert_eq!(v["content"][0]["text"], "hi");
+        assert_eq!(v["stop_reason"], "end_turn");
+        assert_eq!(v["usage"]["input_tokens"], 5);
+        assert_eq!(v["usage"]["output_tokens"], 3);
+        // stop_sequence omitted when None
+        assert!(v.get("stop_sequence").is_none());
+    }
+
+    #[test]
+    fn tool_use_block_serializes() {
+        let block = AnthropicResponseBlock::ToolUse {
+            id: "toolu_1".to_string(),
+            name: "get_weather".to_string(),
+            input: serde_json::json!({"location": "SF"}),
+        };
+        let v = serde_json::to_value(&block).unwrap();
+        assert_eq!(v["type"], "tool_use");
+        assert_eq!(v["id"], "toolu_1");
+        assert_eq!(v["name"], "get_weather");
+        assert_eq!(v["input"]["location"], "SF");
+    }
+
+    #[test]
+    fn error_envelope_shape() {
+        let err = AnthropicErrorResponse::bad_request("nope");
+        let v = serde_json::to_value(&err).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["error"]["type"], "invalid_request_error");
+        assert_eq!(v["error"]["message"], "nope");
+        assert_eq!(err.status, axum::http::StatusCode::BAD_REQUEST);
+    }
+}

--- a/src/server/types/anthropic_stream.rs
+++ b/src/server/types/anthropic_stream.rs
@@ -1,0 +1,225 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Anthropic Messages API streaming SSE event types.
+//!
+//! Ported from upstream mlx-vlm `server/anthropic.py` (PR #1196). The
+//! Anthropic streaming protocol uses named SSE events, each carrying a typed
+//! `data:` payload whose `type` field matches the `event:` name. This module
+//! owns the typed event enum; the SSE encoder lives in
+//! [`crate::server::streaming_anthropic`].
+//!
+//! ## Envelope ordering
+//!
+//! For a typical text-only generation, the encoder emits:
+//!
+//! 1. `message_start` (empty `content`, `usage.input_tokens` populated)
+//! 2. `content_block_start` (index 0, empty `text` block)
+//! 3. N × `content_block_delta` (`text_delta`)
+//! 4. `content_block_stop` (index 0)
+//! 5. `message_delta` (`stop_reason`, `usage.output_tokens`)
+//! 6. `message_stop`
+//!
+//! Thinking blocks open a `thinking` content block (with `thinking_delta` /
+//! `signature_delta`); tool calls open `tool_use` blocks with
+//! `input_json_delta`.
+
+use serde::Serialize;
+
+use super::anthropic_response::{AnthropicMessageResponse, AnthropicResponseBlock};
+
+/// A typed streaming event. The `event:` SSE header name is returned by
+/// [`AnthropicStreamEvent::event_name`]; the variant serialises to the
+/// `data:` payload.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum AnthropicStreamEvent {
+    /// `message_start`: opening envelope with the partial message object.
+    #[serde(rename = "message_start")]
+    MessageStart { message: AnthropicMessageResponse },
+    /// `content_block_start`: a new content block opened at `index`.
+    #[serde(rename = "content_block_start")]
+    ContentBlockStart {
+        index: usize,
+        content_block: AnthropicResponseBlock,
+    },
+    /// `content_block_delta`: an incremental update to the block at `index`.
+    #[serde(rename = "content_block_delta")]
+    ContentBlockDelta {
+        index: usize,
+        delta: AnthropicBlockDelta,
+    },
+    /// `content_block_stop`: the block at `index` is complete.
+    #[serde(rename = "content_block_stop")]
+    ContentBlockStop { index: usize },
+    /// `message_delta`: top-level updates (stop reason, cumulative usage).
+    #[serde(rename = "message_delta")]
+    MessageDelta {
+        delta: AnthropicMessageDeltaBody,
+        usage: AnthropicMessageDeltaUsage,
+    },
+    /// `message_stop`: terminal event.
+    #[serde(rename = "message_stop")]
+    MessageStop,
+    /// `error`: mid-stream failure envelope.
+    #[serde(rename = "error")]
+    Error { error: AnthropicStreamError },
+    /// `ping`: keep-alive (Anthropic sends these; we map keepalive to it).
+    #[serde(rename = "ping")]
+    Ping,
+}
+
+impl AnthropicStreamEvent {
+    /// The SSE `event:` header value.
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            AnthropicStreamEvent::MessageStart { .. } => "message_start",
+            AnthropicStreamEvent::ContentBlockStart { .. } => "content_block_start",
+            AnthropicStreamEvent::ContentBlockDelta { .. } => "content_block_delta",
+            AnthropicStreamEvent::ContentBlockStop { .. } => "content_block_stop",
+            AnthropicStreamEvent::MessageDelta { .. } => "message_delta",
+            AnthropicStreamEvent::MessageStop => "message_stop",
+            AnthropicStreamEvent::Error { .. } => "error",
+            AnthropicStreamEvent::Ping => "ping",
+        }
+    }
+}
+
+/// Incremental delta payload for a content block.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum AnthropicBlockDelta {
+    /// Append text to a `text` block.
+    #[serde(rename = "text_delta")]
+    TextDelta { text: String },
+    /// Append reasoning to a `thinking` block.
+    #[serde(rename = "thinking_delta")]
+    ThinkingDelta { thinking: String },
+    /// Finalise a `thinking` block's cryptographic signature.
+    #[serde(rename = "signature_delta")]
+    SignatureDelta { signature: String },
+    /// Append partial JSON to a `tool_use` block's input.
+    #[serde(rename = "input_json_delta")]
+    InputJsonDelta { partial_json: String },
+}
+
+/// `message_delta.delta` body.
+#[derive(Debug, Clone, Serialize)]
+pub struct AnthropicMessageDeltaBody {
+    pub stop_reason: Option<String>,
+    pub stop_sequence: Option<String>,
+}
+
+/// `message_delta.usage` body (cumulative output tokens).
+#[derive(Debug, Clone, Serialize)]
+pub struct AnthropicMessageDeltaUsage {
+    pub output_tokens: usize,
+}
+
+/// Mid-stream error body.
+#[derive(Debug, Clone, Serialize)]
+pub struct AnthropicStreamError {
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::types::anthropic_response::AnthropicUsage;
+
+    #[test]
+    fn event_names_match_type_tags() {
+        let cases: Vec<(AnthropicStreamEvent, &str)> = vec![
+            (
+                AnthropicStreamEvent::ContentBlockStop { index: 0 },
+                "content_block_stop",
+            ),
+            (AnthropicStreamEvent::MessageStop, "message_stop"),
+            (AnthropicStreamEvent::Ping, "ping"),
+        ];
+        for (ev, name) in cases {
+            assert_eq!(ev.event_name(), name);
+            let v = serde_json::to_value(&ev).unwrap();
+            assert_eq!(v["type"], name);
+        }
+    }
+
+    #[test]
+    fn message_start_serializes_message() {
+        let ev = AnthropicStreamEvent::MessageStart {
+            message: AnthropicMessageResponse::new(
+                "msg_1".to_string(),
+                vec![],
+                "m".to_string(),
+                None,
+                None,
+                AnthropicUsage {
+                    input_tokens: 7,
+                    output_tokens: 0,
+                },
+            ),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(v["type"], "message_start");
+        assert_eq!(v["message"]["type"], "message");
+        assert_eq!(v["message"]["usage"]["input_tokens"], 7);
+        assert!(v["message"]["stop_reason"].is_null());
+    }
+
+    #[test]
+    fn text_delta_shape() {
+        let ev = AnthropicStreamEvent::ContentBlockDelta {
+            index: 0,
+            delta: AnthropicBlockDelta::TextDelta {
+                text: "hi".to_string(),
+            },
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(v["type"], "content_block_delta");
+        assert_eq!(v["index"], 0);
+        assert_eq!(v["delta"]["type"], "text_delta");
+        assert_eq!(v["delta"]["text"], "hi");
+    }
+
+    #[test]
+    fn input_json_delta_shape() {
+        let ev = AnthropicStreamEvent::ContentBlockDelta {
+            index: 2,
+            delta: AnthropicBlockDelta::InputJsonDelta {
+                partial_json: "{\"a\":1}".to_string(),
+            },
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(v["delta"]["type"], "input_json_delta");
+        assert_eq!(v["delta"]["partial_json"], "{\"a\":1}");
+    }
+
+    #[test]
+    fn message_delta_shape() {
+        let ev = AnthropicStreamEvent::MessageDelta {
+            delta: AnthropicMessageDeltaBody {
+                stop_reason: Some("end_turn".to_string()),
+                stop_sequence: None,
+            },
+            usage: AnthropicMessageDeltaUsage { output_tokens: 12 },
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(v["type"], "message_delta");
+        assert_eq!(v["delta"]["stop_reason"], "end_turn");
+        assert!(v["delta"]["stop_sequence"].is_null());
+        assert_eq!(v["usage"]["output_tokens"], 12);
+    }
+}

--- a/src/server/types/mod.rs
+++ b/src/server/types/mod.rs
@@ -14,6 +14,9 @@
 
 //! OpenAI-compatible API types
 
+pub mod anthropic_request;
+pub mod anthropic_response;
+pub mod anthropic_stream;
 pub mod request;
 pub mod response;
 pub mod responses_request;
@@ -21,6 +24,9 @@ pub mod responses_response;
 pub mod responses_stream;
 pub mod stream;
 
+// Anthropic types are accessed through their module paths (e.g.
+// `types::anthropic_request::AnthropicRequest`) to avoid colliding with the
+// OpenAI type glob below (both define `Tool`, `Role`, `MessageContent`, etc.).
 pub use request::*;
 pub use response::*;
 pub use responses_request::*;


### PR DESCRIPTION
Closes #73

Adds an Anthropic Messages-compatible API surface to mlxcel-server so clients written against the Anthropic schema can use the server without a translation shim. Ported from upstream mlx-vlm `server/anthropic.py` (PR #1196) plus the tool-result image-handling fix (PR #1200).

## New endpoints

- `POST /v1/messages` (and `/messages` alias): create a message, synchronous or SSE streaming.
- `POST /v1/messages/count_tokens` (and `/messages/count_tokens` alias): prompt token count.

## What it covers

- Request schema: top-level `system` (string or text-block array), `messages`, `max_tokens`, `stop_sequences`, `temperature`/`top_p`/`top_k`, function `tools` + `tool_choice`, and `thinking`.
- Content blocks: `text`, `image` (base64 and url), `tool_use`, and `tool_result`, including image content nested inside `tool_result` blocks so vision models consume tool-produced images.
- Streaming: the Anthropic SSE event sequence (`message_start`, `content_block_start`/`delta`/`stop`, `message_delta`, `message_stop`, `error`) with `usage` populated on both the non-streaming response and the streaming `message_delta`.
- Reuses the existing generation, chat-template, media, tool-call, and thinking-budget plumbing rather than duplicating the generation loop, structured like the existing Responses API endpoint.
- Both the message and `count_tokens` routes reject oversized tool arrays via the shared `MAX_TOOLS` bound to prevent template-rendering DoS.

## Files

- `types/anthropic_request.rs`, `anthropic_response.rs`, `anthropic_stream.rs`: inbound/outbound types + typed SSE event enum.
- `anthropic_translator.rs`: request translation, outbound content-block assembly, stop-reason mapping, stop-sequence truncation.
- `streaming_anthropic.rs`: SSE channel + content-block index state machine.
- `routes/anthropic.rs`: thin handlers; route registration in `app.rs`; module wiring in `types/mod.rs`, `mod.rs`, `routes/mod.rs`.

## Notes

User-facing API documentation is deferred to a follow-up; this PR is the functional endpoint plus tests.

## Verification

- `cargo fmt --check` clean.
- `cargo clippy --features metal,accelerate --all-targets -- -D warnings` clean.
- 44 new unit tests pass, covering request translation, content-block assembly, stop-reason mapping, the tools DoS guard, and the streaming state machine.