### PR TITLE
fix(cache): correct mask offset for batched quantized KV caches

### DIFF
--- a/src/lib/mlxcel-core/src/cache/batch_quant.rs
+++ b/src/lib/mlxcel-core/src/cache/batch_quant.rs
@@ -102,6 +102,9 @@
 //! [`super::turbo::sparse_v`] remain unchanged.
 
 use super::{KVCache, KVCacheMode};
+use crate::ffi::MlxArray;
+use crate::utils;
+use cxx::UniquePtr;
 
 /// Quantization scheme exposed via the `--kv-quant-scheme` CLI flag.
 ///
@@ -420,6 +423,26 @@ pub struct BatchQuantizedKVCache {
     /// [`extend`](Self::extend) / [`filter`](Self::filter) port across
     /// directly.
     pub offset: Vec<i32>,
+    /// Actual number of tokens stored in the KV buffer (shared across the
+    /// batch since all sequences are padded to the same length).
+    ///
+    /// This is the Rust analogue of Python `BatchKVCache._idx` /
+    /// `BatchQuantizedKVCache._idx`. It starts at 0 and advances by
+    /// `num_steps` on every [`update_after_decode`](Self::update_after_decode)
+    /// call.  Callers must invoke `update_after_decode` after the initial
+    /// prefill to bring `idx` in sync with the actual buffer occupancy.
+    /// **This field must be used — not `offset` — when computing the mask
+    /// offset for [`Self::make_mask`].**
+    ///
+    /// `filter` adjusts `idx` when it trims leading padding (mirrors
+    /// Python `self._idx -= min_lp`).  `extend` takes the max of both
+    /// caches' `idx` values (mirrors Python `self._idx = max(…)`).
+    ///
+    /// See upstream mlx-vlm PR #1208 (commit 2a55b80) for the original
+    /// Python bug-fix: using the logical `offset` (which starts negative
+    /// for padded sequences) instead of the actual buffer index caused
+    /// incorrect causal mask shapes. Rust mirrors the fix here.
+    pub idx: i32,
 }
 
 impl BatchQuantizedKVCache {
@@ -444,11 +467,18 @@ impl BatchQuantizedKVCache {
             .map(KVCache::new_with_mode)
             .collect();
         let offset = left_padding.iter().map(|&lp| -lp).collect();
+        // `idx` starts at 0 (empty buffer); it will grow as tokens are
+        // added via `update_after_decode`. The initial prefill populates
+        // `max(left_padding)` slots of padding + the actual prompt tokens,
+        // so callers must call `update_after_decode` after prefill to keep
+        // `idx` in sync. See [`Self::update_after_decode`] and
+        // [`Self::make_mask`].
         Ok(Self {
             caches,
             config,
             left_padding,
             offset,
+            idx: 0,
         })
     }
 
@@ -494,12 +524,17 @@ impl BatchQuantizedKVCache {
         Ok(())
     }
 
-    /// Advance the per-sequence offsets by `num_steps`.
+    /// Advance the per-sequence offsets and the shared buffer index by
+    /// `num_steps`.
     ///
     /// Called by the scheduler after a successful `update_and_fetch` on
     /// the underlying per-layer caches. The tensor-side cache update is
     /// performed directly on `self.caches[layer_idx]` — this method only
     /// keeps the bookkeeping fields in sync.
+    ///
+    /// `idx` (actual number of stored tokens) is advanced
+    /// alongside `offset` so that [`Self::make_mask`] can use the correct
+    /// buffer length rather than the potentially-negative logical offset.
     pub fn update_after_decode(&mut self, num_steps: i32) -> Result<(), String> {
         if num_steps < 0 {
             return Err(format!(
@@ -510,7 +545,40 @@ impl BatchQuantizedKVCache {
         for off in &mut self.offset {
             *off += num_steps;
         }
+        self.idx += num_steps;
         Ok(())
+    }
+
+    /// Build the causal attention mask for the next `n` query tokens.
+    ///
+    /// Mirrors the upstream `BatchKVCache.make_mask` / `BatchQuantizedKVCache.make_mask`
+    /// fix from mlx-vlm PR #1208 (commit `2a55b80`).
+    ///
+    /// **Bug in the original Python (pre-fix):** `create_attention_mask` was
+    /// called with `offset=self.offset`, where `self.offset` is an array that
+    /// starts at `[-left_padding[i] for i in range(B)]` — negative for padded
+    /// sequences.  This produced a mask with an incorrect shape (or a crash).
+    ///
+    /// **The fix:** use `self._idx` (actual number of tokens in the buffer) as
+    /// the `offset` parameter to `create_causal_mask`, and apply the
+    /// `left_padding` filter on top to exclude leading padding positions.
+    ///
+    /// In Rust, `self.idx` is the analogue of Python `self._idx`.
+    ///
+    /// Returns `None` when `n == 1` and there is no left-padding (the common
+    /// single-token decode case where no mask is needed).
+    pub fn make_mask(&self, n: i32) -> Option<UniquePtr<MlxArray>> {
+        // Single-token decode with no left-padding: masking is unnecessary
+        // because there is only one query token and it always attends to the
+        // entire (already-correct) KV context.
+        if n == 1 && self.left_padding.iter().all(|&p| p == 0) {
+            return None;
+        }
+        Some(utils::create_causal_mask_with_left_padding(
+            n,
+            self.idx,
+            &self.left_padding,
+        ))
     }
 
     /// Drop sequences not in `batch_indices`, preserving per-row vector
@@ -554,11 +622,24 @@ impl BatchQuantizedKVCache {
         self.offset = new_offset;
         // Trim leading padding once it becomes uniform across the
         // surviving batch — mirrors the upstream "min_lp > 0" branch.
+        //
+        // Review fix: upstream Python also does `self._idx -= min_lp`
+        // here (see `BatchQuantizedKVCache.filter`, commit 2a55b80). We must
+        // mirror that so `make_mask` continues to compute the correct
+        // `total_len = n + idx` after a trim.
         if let Some(&min_lp) = self.left_padding.iter().min() {
             if min_lp > 0 {
                 for lp in &mut self.left_padding {
                     *lp -= min_lp;
                 }
+                // Precondition: callers invoke `update_after_decode` (which
+                // advances `idx`) before `filter` whenever `left_padding` is
+                // nonzero, so `idx >= min_lp` holds here and `idx` stays
+                // non-negative. Mirrors upstream `self._idx -= min_lp`; a
+                // negative `idx` would make `make_mask` build a degenerate
+                // `total_len = n + idx`. The scheduler upholds this once these
+                // caches move onto the live decode path.
+                self.idx -= min_lp;
                 // The actual K/V tensor trim (slicing leading
                 // `min_lp` tokens out of each layer cache) is the
                 // scheduler's responsibility because it requires
@@ -598,6 +679,10 @@ impl BatchQuantizedKVCache {
         }
         self.left_padding.extend_from_slice(&other.left_padding);
         self.offset.extend_from_slice(&other.offset);
+        // Mirrors upstream Python `BatchQuantizedKVCache.extend`:
+        // `self._idx = max(self._idx, other._idx)` so that `make_mask`
+        // uses the longer of the two buffer lengths after the merge.
+        self.idx = self.idx.max(other.idx);
         Ok(())
     }
 }
@@ -658,6 +743,10 @@ pub struct BatchTurboQuantKVCache {
     /// Logical sequence offsets. Same semantics as on
     /// [`BatchQuantizedKVCache`].
     pub offset: Vec<i32>,
+    /// Actual number of tokens stored in the KV buffer. Analogue of
+    /// `BatchTurboQuantKVCache._idx` in upstream Python.
+    /// See [`BatchQuantizedKVCache::idx`] for the full rationale.
+    pub idx: i32,
 }
 
 impl BatchTurboQuantKVCache {
@@ -695,6 +784,7 @@ impl BatchTurboQuantKVCache {
             config,
             left_padding,
             offset,
+            idx: 0,
         })
     }
 
@@ -727,6 +817,9 @@ impl BatchTurboQuantKVCache {
     }
 
     /// See [`BatchQuantizedKVCache::update_after_decode`].
+    ///
+    /// advances `idx` alongside `offset` so that
+    /// [`Self::make_mask`] uses the correct buffer length.
     pub fn update_after_decode(&mut self, num_steps: i32) -> Result<(), String> {
         if num_steps < 0 {
             return Err(format!(
@@ -737,7 +830,24 @@ impl BatchTurboQuantKVCache {
         for off in &mut self.offset {
             *off += num_steps;
         }
+        self.idx += num_steps;
         Ok(())
+    }
+
+    /// Build the causal attention mask for the next `n` query tokens.
+    ///
+    /// Mirrors the upstream `BatchTurboQuantKVCache.make_mask` fix from
+    /// mlx-vlm PR #1208 (commit `2a55b80`). See
+    /// [`BatchQuantizedKVCache::make_mask`] for the full rationale.
+    pub fn make_mask(&self, n: i32) -> Option<UniquePtr<MlxArray>> {
+        if n == 1 && self.left_padding.iter().all(|&p| p == 0) {
+            return None;
+        }
+        Some(utils::create_causal_mask_with_left_padding(
+            n,
+            self.idx,
+            &self.left_padding,
+        ))
     }
 
     /// See [`BatchQuantizedKVCache::filter`].
@@ -765,11 +875,22 @@ impl BatchTurboQuantKVCache {
         let new_offset: Vec<i32> = batch_indices.iter().map(|&i| self.offset[i]).collect();
         self.left_padding = new_left_padding;
         self.offset = new_offset;
+        // Mirrors upstream Python `BatchQuantizedKVCache.filter`: also
+        // decrement `_idx` by `min_lp` when padding is trimmed, so that
+        // `make_mask` keeps computing the correct `total_len = n + idx`.
         if let Some(&min_lp) = self.left_padding.iter().min() {
             if min_lp > 0 {
                 for lp in &mut self.left_padding {
                     *lp -= min_lp;
                 }
+                // Precondition: callers invoke `update_after_decode` (which
+                // advances `idx`) before `filter` whenever `left_padding` is
+                // nonzero, so `idx >= min_lp` holds here and `idx` stays
+                // non-negative. Mirrors upstream `self._idx -= min_lp`; a
+                // negative `idx` would make `make_mask` build a degenerate
+                // `total_len = n + idx`. The scheduler upholds this once these
+                // caches move onto the live decode path.
+                self.idx -= min_lp;
             }
         }
         Ok(())
@@ -793,6 +914,8 @@ impl BatchTurboQuantKVCache {
         }
         self.left_padding.extend_from_slice(&other.left_padding);
         self.offset.extend_from_slice(&other.offset);
+        // Mirrors upstream `BatchQuantizedKVCache.extend`: take max _idx.
+        self.idx = self.idx.max(other.idx);
         Ok(())
     }
 }
@@ -1007,6 +1130,51 @@ mod tests {
         assert_eq!(cache.offset, vec![5, 3]);
     }
 
+    /// `update_after_decode` must advance `idx` alongside `offset`.
+    /// This confirms that the fix applied `idx += num_steps` so that
+    /// `make_mask` sees the correct buffer length.
+    #[test]
+    fn batch_quantized_update_after_decode_advances_idx() {
+        let cfg = BatchKvQuantConfig::new(KvQuantScheme::Uniform, 8, 64, false).unwrap();
+        // left_padding=[2,0]: idx starts at 0, offset starts at [-2, 0]
+        let mut cache = BatchQuantizedKVCache::new(cfg, 2, vec![2, 0]).unwrap();
+        assert_eq!(cache.idx, 0, "idx starts at 0");
+        // Simulate prefill: 5 tokens deposited (2 padding + 3 real)
+        cache.update_after_decode(5).unwrap();
+        assert_eq!(cache.idx, 5, "idx must advance by num_steps");
+        // offset is per-sequence, idx is shared
+        assert_eq!(cache.offset, vec![3, 5], "offset advances independently");
+    }
+
+    /// `make_mask` must return None for the single-token decode
+    /// case when there is no left-padding (no MLX ops needed).
+    #[test]
+    fn batch_quantized_make_mask_none_when_no_padding_single_token() {
+        let cfg = BatchKvQuantConfig::new(KvQuantScheme::Uniform, 8, 64, false).unwrap();
+        let mut cache = BatchQuantizedKVCache::new(cfg, 2, vec![0, 0]).unwrap();
+        cache.update_after_decode(5).unwrap();
+        // Single token, no padding → no mask needed (fast path)
+        assert!(cache.make_mask(1).is_none());
+    }
+
+    /// `make_mask` must return Some when left_padding is non-zero
+    /// — tests that verify the actual mask values are in `ffi_tests.rs` because
+    /// those call `create_causal_mask_with_left_padding` which requires the
+    /// MLX C++ runtime.
+    #[test]
+    fn batch_quantized_make_mask_returns_some_when_padding_present_metadata_check() {
+        // This test only checks the return variant (Some vs None),
+        // not the actual mask values.  See ffi_tests for value tests.
+        let cfg = BatchKvQuantConfig::new(KvQuantScheme::Uniform, 8, 64, false).unwrap();
+        let cache0 = BatchQuantizedKVCache::new(cfg, 2, vec![0, 0]).unwrap();
+        // Zero idx → mask for n=1, no padding → None
+        assert!(cache0.make_mask(1).is_none());
+        // Fake: manually set idx without calling MLX (pure metadata test)
+        // We cannot easily call make_mask(1) with padding in a no-MLX test
+        // because the make_mask impl calls create_causal_mask_with_left_padding.
+        // The MLX tests in ffi_tests.rs cover the non-None path.
+    }
+
     #[test]
     fn batch_quantized_update_rejects_negative_steps() {
         let cfg = BatchKvQuantConfig::new(KvQuantScheme::Uniform, 8, 64, false).unwrap();
@@ -1147,5 +1315,108 @@ mod tests {
         let mut cache = BatchTurboQuantKVCache::new(cfg, 4, vec![3, 0]).unwrap();
         cache.update_after_decode(7).unwrap();
         assert_eq!(cache.offset, vec![4, 7]);
+    }
+
+    /// `BatchTurboQuantKVCache::update_after_decode` must advance
+    /// `idx` alongside `offset`.
+    #[test]
+    fn batch_turboquant_update_after_decode_advances_idx() {
+        let cfg = BatchKvQuantConfig::new(KvQuantScheme::TurboQuant, 4, 64, true).unwrap();
+        let mut cache = BatchTurboQuantKVCache::new(cfg, 4, vec![3, 0]).unwrap();
+        assert_eq!(cache.idx, 0, "idx starts at 0");
+        cache.update_after_decode(7).unwrap();
+        assert_eq!(cache.idx, 7, "idx must advance by num_steps");
+    }
+
+    /// `BatchTurboQuantKVCache::make_mask` must return None for
+    /// n=1 with no left-padding.
+    #[test]
+    fn batch_turboquant_make_mask_none_when_no_padding_single_token() {
+        let cfg = BatchKvQuantConfig::new(KvQuantScheme::TurboQuant, 4, 64, true).unwrap();
+        let mut cache = BatchTurboQuantKVCache::new(cfg, 4, vec![0, 0]).unwrap();
+        cache.update_after_decode(5).unwrap();
+        assert!(cache.make_mask(1).is_none());
+    }
+
+    /// metadata test — no MLX ops, just verifies None path.
+    #[test]
+    fn batch_turboquant_make_mask_none_for_no_padding_single_token_metadata() {
+        let cfg = BatchKvQuantConfig::new(KvQuantScheme::TurboQuant, 4, 64, true).unwrap();
+        let cache = BatchTurboQuantKVCache::new(cfg, 4, vec![0, 0]).unwrap();
+        assert!(cache.make_mask(1).is_none());
+    }
+
+    // ── filter/extend idx invariants ────────
+
+    /// `filter` with `min_lp > 0` must decrement `idx` by `min_lp`,
+    /// mirroring upstream Python `BatchQuantizedKVCache.filter` which does
+    /// `self._idx -= min_lp`.
+    #[test]
+    fn batch_quantized_filter_trims_idx_with_min_padding() {
+        let cfg = BatchKvQuantConfig::new(KvQuantScheme::Uniform, 8, 64, false).unwrap();
+        // B=3: padding=[2, 3, 5].  After update_after_decode(7): idx=7.
+        let mut cache = BatchQuantizedKVCache::new(cfg, 2, vec![2, 3, 5]).unwrap();
+        cache.update_after_decode(7).unwrap();
+        assert_eq!(cache.idx, 7);
+        // Keep seqs 0 and 2 (left_padding=[2, 5]).  min_lp=2 → trim 2 from idx.
+        cache.filter(&[0, 2]).unwrap();
+        assert_eq!(cache.left_padding, vec![0, 3], "min_lp=2 trimmed from each");
+        assert_eq!(cache.idx, 5, "idx must be decremented by min_lp=2");
+    }
+
+    /// `filter` with `min_lp == 0` must NOT change `idx`.
+    #[test]
+    fn batch_quantized_filter_no_trim_preserves_idx() {
+        let cfg = BatchKvQuantConfig::new(KvQuantScheme::Uniform, 8, 64, false).unwrap();
+        let mut cache = BatchQuantizedKVCache::new(cfg, 2, vec![0, 3]).unwrap();
+        cache.update_after_decode(5).unwrap();
+        assert_eq!(cache.idx, 5);
+        cache.filter(&[0, 1]).unwrap();
+        // min_lp=0 → no trim → idx unchanged
+        assert_eq!(cache.idx, 5, "idx must remain 5 when min_lp=0");
+    }
+
+    /// `extend` must take `max(self.idx, other.idx)`, mirroring upstream Python.
+    #[test]
+    fn batch_quantized_extend_takes_max_idx() {
+        let cfg = BatchKvQuantConfig::new(KvQuantScheme::Uniform, 8, 64, true).unwrap();
+        let mut left = BatchQuantizedKVCache::new(cfg, 4, vec![0, 1]).unwrap();
+        left.update_after_decode(7).unwrap();
+        assert_eq!(left.idx, 7);
+
+        let mut right = BatchQuantizedKVCache::new(cfg, 4, vec![2, 3, 4]).unwrap();
+        right.update_after_decode(10).unwrap();
+        assert_eq!(right.idx, 10);
+
+        left.extend(&right).unwrap();
+        assert_eq!(left.idx, 10, "extend must take max(7, 10) = 10");
+        assert_eq!(left.batch_size(), 5);
+    }
+
+    /// `BatchTurboQuantKVCache::filter` must also decrement `idx` by `min_lp`.
+    #[test]
+    fn batch_turboquant_filter_trims_idx_with_min_padding() {
+        let cfg = BatchKvQuantConfig::new(KvQuantScheme::TurboQuant, 4, 64, false).unwrap();
+        let mut cache = BatchTurboQuantKVCache::new(cfg, 4, vec![3, 5]).unwrap();
+        cache.update_after_decode(8).unwrap();
+        assert_eq!(cache.idx, 8);
+        // Keep both; min_lp=3 → trim 3 from idx.
+        cache.filter(&[0, 1]).unwrap();
+        assert_eq!(cache.left_padding, vec![0, 2], "min_lp=3 trimmed");
+        assert_eq!(cache.idx, 5, "idx decremented by min_lp=3");
+    }
+
+    /// `BatchTurboQuantKVCache::extend` must take max idx.
+    #[test]
+    fn batch_turboquant_extend_takes_max_idx() {
+        let cfg = BatchKvQuantConfig::new(KvQuantScheme::TurboQuant, 4, 64, false).unwrap();
+        let mut left = BatchTurboQuantKVCache::new(cfg, 4, vec![0]).unwrap();
+        left.update_after_decode(5).unwrap();
+
+        let mut right = BatchTurboQuantKVCache::new(cfg, 4, vec![0]).unwrap();
+        right.update_after_decode(9).unwrap();
+
+        left.extend(&right).unwrap();
+        assert_eq!(left.idx, 9, "extend must take max(5, 9) = 9");
     }
 }

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -1410,3 +1410,231 @@ fn test_wht_fp16_preserves_dtype() {
         "wht(wht(x)) must round-trip in fp16 to within 5e-3",
     );
 }
+
+// ── batched quantized KV cache mask offset regression ────────────
+
+/// `create_causal_mask_with_left_padding` (no padding) must produce the same
+/// result as `create_causal_mask` (the non-batched version).
+///
+/// This guards the fast-path branch in the function.
+#[test]
+fn test_create_causal_mask_with_left_padding_no_padding_matches_causal_mask() {
+    let n = 3_i32;
+    let offset = 5_i32; // 5 tokens already cached
+
+    let reference = crate::utils::create_causal_mask(n, offset);
+    let tested = crate::utils::create_causal_mask_with_left_padding(n, offset, &[]);
+
+    eval(&reference);
+    eval(&tested);
+
+    // Shapes must match
+    let ref_shape = array_shape(&reference);
+    let test_shape = array_shape(&tested);
+    assert_eq!(
+        ref_shape, test_shape,
+        "shape mismatch: {ref_shape:?} vs {test_shape:?}"
+    );
+
+    // Values must match via allclose
+    let close = allclose(&reference, &tested, 1e-5, 1e-5);
+    eval(&close);
+    assert!(
+        item_bool(&close),
+        "create_causal_mask_with_left_padding(no padding) must equal create_causal_mask"
+    );
+}
+
+/// `create_causal_mask_with_left_padding` with left-padding must produce a
+/// `[B, 1, n, n+offset]` shaped mask where the padded key positions for each
+/// sequence are set to −∞.
+///
+/// Mirrors upstream `TestMakeMask::test_make_mask_matches_batch_kv_cache_with_left_padding`
+/// from mlx-vlm PR #1208 (`test_batch_quantized_cache.py`).
+#[test]
+fn test_create_causal_mask_with_left_padding_masks_padding_positions() {
+    // B=2: seq 0 has 2 padding tokens, seq 1 has none.
+    // After 5 tokens cached (offset=5, including padding), n=2 new query tokens.
+    let left_padding = [2_i32, 0];
+    let offset = 5_i32; // actual tokens in buffer (_idx)
+    let n = 2_i32; // query tokens this step
+
+    let mask = crate::utils::create_causal_mask_with_left_padding(n, offset, &left_padding);
+    eval(&mask);
+
+    // Shape: [B=2, 1, n=2, total_len=7]
+    let total_len = n + offset;
+    let b = left_padding.len() as i32;
+    let shape = array_shape(&mask);
+    assert_eq!(
+        shape,
+        vec![b, 1, n, total_len],
+        "expected shape [{b}, 1, {n}, {total_len}], got {shape:?}"
+    );
+
+    // For sequence 0 (left_padding=2): key positions 0 and 1 must be -inf.
+    // For sequence 1 (left_padding=0): all key positions within causal reach
+    // must be 0 (attended).
+    //
+    // Check: the minimum value of the mask is -inf (there is at least one
+    // masked slot: the first 2 key positions of sequence 0).
+    let min_val = min_all(&mask);
+    eval(&min_val);
+    let min_f = item_f32(&min_val);
+    assert!(
+        min_f.is_infinite() && min_f < 0.0,
+        "mask must contain at least one -inf (padded slot for seq 0), got min={min_f}"
+    );
+
+    // Check: the maximum value is 0.0 (attended positions).
+    let max_val = max_all(&mask);
+    eval(&max_val);
+    let max_f = item_f32(&max_val);
+    assert_eq!(
+        max_f, 0.0,
+        "attended positions must be 0.0, got max={max_f}"
+    );
+}
+
+/// `BatchQuantizedKVCache::make_mask` must return `None` for the single-token
+/// decode case when there is no left-padding (the common fast path).
+#[test]
+fn test_batch_quantized_kv_cache_make_mask_none_for_single_token_no_padding() {
+    use crate::cache::batch_quant::{BatchKvQuantConfig, BatchQuantizedKVCache, KvQuantScheme};
+
+    let cfg = BatchKvQuantConfig::new(KvQuantScheme::Uniform, 8, 64, false).unwrap();
+    let mut cache = BatchQuantizedKVCache::new(cfg, 2, vec![0, 0]).unwrap();
+    cache.update_after_decode(5).unwrap();
+
+    // Single query token, no left padding → None (no mask needed)
+    let mask = cache.make_mask(1);
+    assert!(
+        mask.is_none(),
+        "make_mask(1) with no left_padding should return None"
+    );
+}
+
+/// `BatchQuantizedKVCache::make_mask` must use `idx` (actual buffer tokens),
+/// not `offset` (which starts negative for padded sequences).
+///
+/// After `update_after_decode(5)` on a cache with `left_padding=[2,0]`:
+/// - `offset = [-2+5, 0+5] = [3, 5]`  ← wrong value for mask offset
+/// - `idx = 5`  ← correct: 5 tokens actually in the buffer
+///
+/// The mask must have shape `[B=2, 1, n, n + idx=5]`, not `[B=2, 1, n, n+3]`
+/// or some other shape derived from `offset`.
+///
+/// Mirrors upstream `test_make_mask_matches_batch_kv_cache_with_left_padding`
+/// (mlx-vlm PR #1208).
+#[test]
+fn test_batch_quantized_kv_cache_make_mask_uses_idx_not_offset() {
+    use crate::cache::batch_quant::{BatchKvQuantConfig, BatchQuantizedKVCache, KvQuantScheme};
+
+    // B=2: seq 0 has 2 padding tokens, seq 1 has none.
+    let left_padding = vec![2_i32, 0];
+    let cfg = BatchKvQuantConfig::new(KvQuantScheme::Uniform, 8, 64, false).unwrap();
+    let mut cache = BatchQuantizedKVCache::new(cfg, 2, left_padding).unwrap();
+
+    // Simulate: prefill deposited `max(left_padding)=2` padding tokens +
+    // 3 real tokens = 5 total. Then 0 decode steps.
+    // We model this by setting idx manually via update_after_decode(5)
+    // (as if the prefill advanced the counter).
+    cache.update_after_decode(5).unwrap();
+
+    // At this point:
+    //   cache.offset = [-2+5, 0+5] = [3, 5]  ← logical positions
+    //   cache.idx    = 5                       ← actual tokens stored
+    assert_eq!(cache.idx, 5, "idx must be 5 after update_after_decode(5)");
+
+    // Request mask for n=2 new query tokens.
+    let n = 2_i32;
+    let mask_opt = cache.make_mask(n);
+    assert!(
+        mask_opt.is_some(),
+        "make_mask(2) with left_padding=[2,0] must return Some (not None)"
+    );
+    let mask = mask_opt.unwrap();
+    eval(&mask);
+
+    // Expected shape: [B=2, 1, n=2, n + idx = 2+5 = 7]
+    let expected_shape = vec![2_i32, 1, n, n + 5];
+    let actual_shape = array_shape(&mask);
+    assert_eq!(
+        actual_shape, expected_shape,
+        "make_mask shape must be {expected_shape:?} (using idx=5, not offset), got {actual_shape:?}"
+    );
+
+    // Verify that the mask contains -inf values (at the padded positions of seq 0).
+    let min_val = min_all(&mask);
+    eval(&min_val);
+    assert!(
+        item_f32(&min_val).is_infinite(),
+        "mask must contain -inf for padded positions in seq 0"
+    );
+}
+
+/// `BatchTurboQuantKVCache::make_mask` mirrors the same fix as
+/// `BatchQuantizedKVCache::make_mask`.
+///
+/// Mirrors upstream `test_batch_turboquant_make_mask_matches_batch_kv_cache_with_left_padding`
+/// (`test_turboquant.py`, mlx-vlm PR #1208).
+#[test]
+fn test_batch_turboquant_kv_cache_make_mask_uses_idx_not_offset() {
+    use crate::cache::batch_quant::{BatchKvQuantConfig, BatchTurboQuantKVCache, KvQuantScheme};
+
+    let left_padding = vec![2_i32, 0];
+    let cfg = BatchKvQuantConfig::new(KvQuantScheme::TurboQuant, 4, 64, false).unwrap();
+    let mut cache = BatchTurboQuantKVCache::new(cfg, 4, left_padding).unwrap();
+    cache.update_after_decode(5).unwrap();
+
+    assert_eq!(cache.idx, 5, "idx must be 5 after update_after_decode(5)");
+
+    let n = 2_i32;
+    let mask_opt = cache.make_mask(n);
+    assert!(mask_opt.is_some(), "make_mask(2) must return Some");
+    let mask = mask_opt.unwrap();
+    eval(&mask);
+
+    let expected_shape = vec![2_i32, 1, n, n + 5];
+    let actual_shape = array_shape(&mask);
+    assert_eq!(
+        actual_shape, expected_shape,
+        "TurboQuant make_mask shape must be {expected_shape:?}, got {actual_shape:?}"
+    );
+
+    let min_val = min_all(&mask);
+    eval(&min_val);
+    assert!(
+        item_f32(&min_val).is_infinite(),
+        "mask must contain -inf for padded positions"
+    );
+}
+
+/// `BatchQuantizedKVCache::make_mask` with no left-padding and n>1 must return
+/// a standard causal mask (not None), matching `BatchKVCache.make_mask` shape.
+#[test]
+fn test_batch_quantized_kv_cache_make_mask_no_padding_multi_token() {
+    use crate::cache::batch_quant::{BatchKvQuantConfig, BatchQuantizedKVCache, KvQuantScheme};
+
+    let cfg = BatchKvQuantConfig::new(KvQuantScheme::Uniform, 8, 64, false).unwrap();
+    let mut cache = BatchQuantizedKVCache::new(cfg, 2, vec![0, 0]).unwrap();
+    cache.update_after_decode(5).unwrap();
+
+    // n>1 with no left-padding: must return Some (prefill-like scenario).
+    let n = 3_i32;
+    let mask_opt = cache.make_mask(n);
+    assert!(
+        mask_opt.is_some(),
+        "make_mask(3) must return Some even with no left_padding"
+    );
+    let mask = mask_opt.unwrap();
+    eval(&mask);
+
+    // Without left_padding → shape is [n, n+idx] (2D causal mask)
+    let expected_shape = vec![n, n + 5];
+    let actual_shape = array_shape(&mask);
+    assert_eq!(
+        actual_shape, expected_shape,
+        "no-padding multi-token mask shape must be {expected_shape:?}, got {actual_shape:?}"
+    );
+}

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -109,6 +109,100 @@ pub fn create_causal_mask(size: i32, offset: i32) -> UniquePtr<MlxArray> {
     ffi::where_cond(&bool_mask, &zeros, &neg_inf)
 }
 
+/// Create a causal attention mask with per-sequence left-padding support.
+///
+/// Mirrors the Python `mlx_lm.models.base.create_causal_mask` with the
+/// `left_padding` argument.  Used by [`crate::cache::batch_quant::BatchQuantizedKVCache::make_mask`]
+/// and [`crate::cache::batch_quant::BatchTurboQuantKVCache::make_mask`].
+///
+/// # Arguments
+/// * `n` — Number of query tokens in the current step (usually 1 for decode).
+/// * `offset` — Actual number of tokens already in the KV buffer (`_idx` in Python
+///   terminology, **not** the logical `offset` that starts negative for padded
+///   sequences).  The total key length returned is `n + offset`.
+/// * `left_padding` — Per-sequence number of leading padding tokens.  The mask
+///   zeroes out (sets to −∞) key positions that are padding for each sequence.
+///   When empty or all-zero the result is identical to [`create_causal_mask`].
+///
+/// # Returns
+/// Additive mask with 0 for attended positions and −∞ for masked positions.
+///
+/// # Shape note
+/// * **No padding** (`left_padding` empty or all-zero): `[n, n+offset]`, same
+///   as [`create_causal_mask`].
+/// * **With padding** (`left_padding` has at least one non-zero element):
+///   `[B, 1, n, n+offset]` where `B = left_padding.len()`.  The `[B, 1]`
+///   leading dims allow broadcasting against a `[B, H, n, n+offset]` score
+///   tensor in batched SDPA.
+///
+/// Used by: BatchQuantizedKVCache, BatchTurboQuantKVCache
+pub fn create_causal_mask_with_left_padding(
+    n: i32,
+    offset: i32,
+    left_padding: &[i32],
+) -> UniquePtr<MlxArray> {
+    let total_len = n + offset;
+
+    // ── Base causal (lower-triangular) mask ─────────────────────────────────
+    // Shape: [n, total_len]  (0 = attend, -inf = mask after conversion)
+    let ones = ffi::ones(&[n, total_len], dtype::FLOAT32);
+    // `tril(ones, offset)` keeps the lower triangle starting `offset` columns
+    // to the right of the main diagonal — i.e. the first `offset + q` entries
+    // of query row `q`.  That matches the causal condition
+    // `q_pos (= q + offset) >= k_pos`.
+    let causal_tril = ffi::tril(&ones, offset);
+
+    if left_padding.is_empty() || left_padding.iter().all(|&p| p == 0) {
+        // Fast path: no per-sequence padding — identical to create_causal_mask.
+        let zeros = ffi::zeros(&[n, total_len], dtype::FLOAT32);
+        let neg_inf = ffi::full_f32(&[n, total_len], f32::NEG_INFINITY, dtype::FLOAT32);
+        let bool_mask = ffi::greater(&causal_tril, &zeros);
+        return ffi::where_cond(&bool_mask, &zeros, &neg_inf);
+    }
+
+    // ── Left-padding filter ─────────────────────────────────────────────────
+    // For each sequence `b`, key positions `k < left_padding[b]` are padding
+    // and must be masked.  We build:
+    //
+    //   lp_tensor : [B, 1, 1, 1]  — per-sequence padding count
+    //   rinds     : [1, 1, 1, total_len]  — key position indices
+    //   lp_mask   : [B, 1, 1, total_len]  — True where key pos >= lp[b]
+    //
+    // Then broadcast-multiply with the causal mask.
+
+    let b = left_padding.len() as i32;
+
+    // Key position indices: 0, 1, …, total_len-1  (shape [1, 1, 1, total_len])
+    let rinds_1d = ffi::arange_i32(0, total_len, 1);
+    let rinds = ffi::reshape(&rinds_1d, &[1, 1, 1, total_len]);
+
+    // Per-sequence left-padding: shape [B, 1, 1, 1]
+    let lp_tensor = ffi::from_slice_i32(left_padding, &[b, 1, 1, 1]);
+
+    // lp_mask[b,0,0,k] = (k >= left_padding[b])  — True = attend, False = mask
+    // Using `greater_equal(rinds, lp_tensor)` broadcasts [B,1,1,total_len].
+    let lp_mask = ffi::greater_equal(&rinds, &lp_tensor);
+
+    // Causal mask broadcast: [1, 1, n, total_len]
+    let causal_4d = ffi::reshape(&causal_tril, &[1, 1, n, total_len]);
+
+    // Cast lp_mask to float for multiply (it is currently bool/int8 from the
+    // greater_equal; we need float 0/1 to combine with the causal float mask).
+    // Trick: use where_cond with ones/zeros to convert.
+    let ones_lp = ffi::ones(&[b, 1, 1, total_len], dtype::FLOAT32);
+    let zeros_lp = ffi::zeros(&[b, 1, 1, total_len], dtype::FLOAT32);
+    let lp_mask_f32 = ffi::where_cond(&lp_mask, &ones_lp, &zeros_lp);
+
+    // Combined: shape [B, 1, n, total_len]  (causal broadcasts over B)
+    let combined = ffi::multiply(&causal_4d, &lp_mask_f32);
+
+    // Convert 0/1 float mask to additive 0 / -inf mask.
+    let zeros_out = ffi::zeros(&[b, 1, n, total_len], dtype::FLOAT32);
+    let neg_inf_out = ffi::full_f32(&[b, 1, n, total_len], f32::NEG_INFINITY, dtype::FLOAT32);
+    let bool_out = ffi::greater(&combined, &zeros_out);
+    ffi::where_cond(&bool_out, &zeros_out, &neg_inf_out)
+}
+
 /// Create a boolean causal attention mask.
 /// Used by: same as `create_causal_mask` (experimental path)
 ///


### PR DESCRIPTION
Closes #75

Batched quantized KV caches built an incorrect causal mask for left-padded sequences and lacked a dedicated mask-construction method. Mirrors the upstream mlx-vlm fix in PR #1208 (commit 2a55b80).

## Root cause

The mask offset must come from the number of tokens actually stored in the buffer. The cache `offset` field starts at `-left_padding[i]` and is negative for padded sequences, so using it as the mask offset produced incorrect causal mask shapes and wrong attention masking during batched quantized decode.

## Fix

- Track the buffered-token count (`idx`) separately from `offset` in both `BatchQuantizedKVCache` and `BatchTurboQuantKVCache`, advancing it in `update_after_decode` alongside `offset`. The `filter` and `extend` paths trim and combine `idx` consistently with per-sequence left padding.
- Add `make_mask(n)` to both caches using `idx` (not `offset`) as the mask offset and `left_padding` to exclude per-sequence padding positions. The single-token, no-padding case returns no mask.
- Add `create_causal_mask_with_left_padding` to `utils.rs`, a causal-mask builder that accepts a `left_padding` argument.

## Verification

- `cargo fmt --check` clean.
- `cargo clippy --features metal,accelerate --all-targets -- -D warnings` clean.
- 33 unit tests pass, covering the buffered-token advance, the idx-vs-offset mask offset, left-padding exclusion, and the single-token no-mask path.