### PR TITLE
fix(speculative): per-position verify attention for Qwen3.5 MTP parity

### DIFF
--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -932,12 +932,23 @@ impl Qwen35DecoderLayer {
                 None,
                 snapshot_sink,
             ),
+            // MTP target-verify pass: full-attention layers
+            // compute per-query-position causal attention so the verify
+            // logits stay bit-aligned with single-token decode. Mirrors
+            // upstream `Qwen3_5DecoderLayer.__call__`'s `target_verify=True`
+            // propagation into `Qwen3_5Attention`.
             (Qwen35AttentionVariant::FullAttention(attn), Qwen3NextCache::Attention(c)) => {
-                attn.forward_with_position_ids(&normed, c, mask, position_ids)
+                attn.forward_with_position_ids_verify(&normed, c, mask, position_ids, true)
             }
             (Qwen35AttentionVariant::FullAttention(attn), _) => {
                 let mut temp_cache = KVCache::new();
-                attn.forward_with_position_ids(&normed, &mut temp_cache, mask, position_ids)
+                attn.forward_with_position_ids_verify(
+                    &normed,
+                    &mut temp_cache,
+                    mask,
+                    position_ids,
+                    true,
+                )
             }
         };
 
@@ -1159,6 +1170,20 @@ impl Qwen35Model {
     /// for both `Qwen35Model` and `Qwen35VLModel` text-only DFlash bursts
     /// (issues #670 and #691).
     pub(crate) fn make_speculative_caches(&self) -> Vec<Qwen3NextCache> {
+        self.make_internal_caches()
+    }
+
+    /// Public test seam: construct the heterogeneous attention +
+    /// linear-attention cache vector the verify pass expects.
+    ///
+    /// Functionally identical to [`Self::make_speculative_caches`], exposed
+    /// so out-of-crate integration tests (notably the
+    /// verify-vs-decode logit-parity test in `tests/`) can drive
+    /// [`Self::forward_speculative`] directly without going through the
+    /// server burst dispatch. Not intended for production callers — the
+    /// server path uses `make_speculative_caches` internally.
+    #[doc(hidden)]
+    pub fn make_speculative_caches_for_test(&self) -> Vec<Qwen3NextCache> {
         self.make_internal_caches()
     }
 

--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -525,7 +525,39 @@ impl Qwen3NextAttention {
         mask: Option<&MlxArray>,
         position_ids: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
-        let output = self.forward_hidden_with_position_ids(x, cache, mask, position_ids);
+        self.forward_with_position_ids_verify(x, cache, mask, position_ids, false)
+    }
+
+    /// Variant of [`Self::forward_with_position_ids`] that opts into the
+    /// MTP target-verify attention path when `target_verify` is set.
+    ///
+    /// `target_verify == false` is byte-identical to
+    /// [`Self::forward_with_position_ids`] (the standard decode / prefill
+    /// path). `target_verify == true` with a multi-token verify block routes
+    /// scaled-dot-product attention through the per-query-position causal
+    /// loop in [`Self::forward_hidden_with_position_ids_verify`], mirroring
+    /// upstream `Qwen3_5Attention.__call__`'s `target_verify and L > 1`
+    /// branch (`mlx-vlm/mlx_vlm/models/qwen3_5/language.py`). This eliminates
+    /// the batched-SDPA-vs-decode logit drift that flips speculative
+    /// accept/reject decisions away from the drafter-less greedy pass.
+    ///
+    /// Used by: `Qwen35DecoderLayer::forward_with_capture` (the Qwen 3.5 MTP
+    /// verify pass).
+    pub(crate) fn forward_with_position_ids_verify(
+        &self,
+        x: &MlxArray,
+        cache: &mut KVCache,
+        mask: Option<&MlxArray>,
+        position_ids: Option<&MlxArray>,
+        target_verify: bool,
+    ) -> UniquePtr<MlxArray> {
+        let output = self.forward_hidden_with_position_ids_verify(
+            x,
+            cache,
+            mask,
+            position_ids,
+            target_verify,
+        );
         self.o_proj.forward(&output)
     }
 
@@ -535,6 +567,31 @@ impl Qwen3NextAttention {
         cache: &mut KVCache,
         mask: Option<&MlxArray>,
         position_ids: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        self.forward_hidden_with_position_ids_verify(x, cache, mask, position_ids, false)
+    }
+
+    /// Hidden-state attention forward with an opt-in MTP target-verify path.
+    ///
+    /// When `target_verify` is `true` and the query block spans more than one
+    /// position (`l > 1`), scaled-dot-product attention is computed **per
+    /// query position**: query `i` attends only to keys/values
+    /// `[.. prefix_len + i + 1]`, exactly as it would during single-token
+    /// decode. This is a faithful port of upstream's
+    /// `target_verify and L > 1` attention branch and guarantees the verify
+    /// logits match the per-token decode logits bit-for-bit modulo the
+    /// kernel's own reduction order, so the speculative walk's greedy argmax
+    /// agrees with the drafter-less greedy decode.
+    ///
+    /// When `target_verify` is `false`, the body is byte-identical to the
+    /// historical [`Self::forward_hidden_with_position_ids`] decode path.
+    pub(crate) fn forward_hidden_with_position_ids_verify(
+        &self,
+        x: &MlxArray,
+        cache: &mut KVCache,
+        mask: Option<&MlxArray>,
+        position_ids: Option<&MlxArray>,
+        target_verify: bool,
     ) -> UniquePtr<MlxArray> {
         let shape = mlxcel_core::array_shape(x);
         let b = shape[0];
@@ -621,8 +678,17 @@ impl Qwen3NextAttention {
         // Update KV cache
         let (cache_k, cache_v) = cache.update_and_fetch(keys, values);
 
-        // Scaled dot-product attention
-        let attn_out = if l > 1 && mask.is_none() {
+        // Scaled dot-product attention.
+        //
+        // MTP target-verify path: when verifying a multi-token
+        // draft block, attention is computed per query position so each
+        // position sees exactly the prefix it would see during single-token
+        // decode. This mirrors upstream `Qwen3_5Attention.__call__`'s
+        // `target_verify and L > 1` branch and keeps the verify logits from
+        // drifting away from the drafter-less greedy decode.
+        let attn_out = if target_verify && l > 1 {
+            self.attend_per_position(&queries, &cache_k, &cache_v)
+        } else if l > 1 && mask.is_none() {
             mlxcel_core::causal_attention(&queries, &cache_k, &cache_v, self.scale, 0.0, 0)
         } else {
             let mask_ptr = mask.map(|m| m as *const _).unwrap_or(std::ptr::null());
@@ -640,6 +706,58 @@ impl Qwen3NextAttention {
         // Apply sigmoid gating to output
         let gate_sigmoid = mlxcel_core::sigmoid(&gate);
         mlxcel_core::multiply(&output, &gate_sigmoid)
+    }
+
+    /// Per-query-position causal attention for the MTP target-verify pass.
+    ///
+    /// `queries`/`keys`/`values` are `[B, H, L_q, D]` / `[B, H_kv, L_kv, D]`
+    /// after the KV cache update, so `L_kv = prefix_len + L_q`. For each
+    /// query position `i` we attend `queries[:, :, i:i+1, :]` to the
+    /// causal prefix `keys[:, :, .. prefix_len + i + 1, :]` (and the matching
+    /// `values` slice) with no mask — the slice itself enforces causality, so
+    /// each position computes exactly the attention it would compute during
+    /// single-token decode. Results are concatenated back along the query
+    /// axis into `[B, H, L_q, D]`.
+    ///
+    /// Faithful port of upstream
+    /// `mlx-vlm/mlx_vlm/models/qwen3_5/language.py::Qwen3_5Attention.__call__`
+    /// (`target_verify and L > 1` branch). This is the load-bearing fix for
+    /// Qwen 3.5 MTP verification drift / sampling parity.
+    fn attend_per_position(
+        &self,
+        queries: &MlxArray,
+        keys: &MlxArray,
+        values: &MlxArray,
+    ) -> UniquePtr<MlxArray> {
+        let q_shape = mlxcel_core::array_shape(queries);
+        let k_shape = mlxcel_core::array_shape(keys);
+        let v_shape = mlxcel_core::array_shape(values);
+        let b = q_shape[0];
+        let n_q_heads = q_shape[1];
+        let l_q = q_shape[2];
+        let head_dim = q_shape[3];
+        let n_kv_heads = k_shape[1];
+        let l_kv = k_shape[2];
+        let prefix_len = l_kv - l_q;
+
+        let mut out: Option<UniquePtr<MlxArray>> = None;
+        for i in 0..l_q {
+            // queries[:, :, i:i+1, :]
+            let q_i = mlxcel_core::slice(queries, &[0, 0, i, 0], &[b, n_q_heads, i + 1, head_dim]);
+            // keys/values[:, :, : prefix_len + i + 1, :]
+            let kv_len = prefix_len + i + 1;
+            let k_i = mlxcel_core::slice(keys, &[0, 0, 0, 0], &[b, n_kv_heads, kv_len, head_dim]);
+            let v_i =
+                mlxcel_core::slice(values, &[0, 0, 0, 0], &[b, n_kv_heads, kv_len, v_shape[3]]);
+            // Single-query attention, no mask: the K/V slice is already the
+            // exact causal prefix, matching the single-token decode call.
+            let attn_i = mlxcel_core::layers::attention(&q_i, &k_i, &v_i, self.scale, None, 0.0, 0);
+            out = Some(match out {
+                None => attn_i,
+                Some(prev) => mlxcel_core::concatenate(&prev, &attn_i, 2),
+            });
+        }
+        out.expect("attend_per_position requires l_q >= 1")
     }
 
     pub(crate) fn from_weights(

--- a/tests/qwen35_mtp_verify_parity.rs
+++ b/tests/qwen35_mtp_verify_parity.rs
@@ -1,0 +1,219 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Qwen 3.5 MTP target-verify logit / sampling parity.
+//!
+//! ## What this pins
+//!
+//! The MTP / DFlash round loop verifies a multi-token draft block in a
+//! single `Qwen35Model::forward_speculative` pass and takes the target's
+//! per-position argmax to decide which proposals to accept. For the
+//! speculative output to be byte-identical to the drafter-less greedy
+//! decode at `temperature = 0`, every verify position's logits must agree
+//! with what single-token decode would have produced at the same absolute
+//! position. Upstream mlx-vlm PR #1188 fixed a drift here for Qwen 3.5 by
+//! computing verify-mode attention per query position; this test is the
+//! direct regression gate for that fix.
+//!
+//! ## Method (no drafter needed)
+//!
+//! Pick a fixed prefix sequence. Then:
+//!
+//! 1. **Verify forward** — run the whole `[1, L]` sequence through
+//!    `forward_speculative` (the multi-token verify path, which routes
+//!    full-attention layers through the per-query-position causal
+//!    attention) and read the per-position argmax `verify_argmax[i]`.
+//! 2. **Decode reference** — for each position `i`, run a *fresh* prefill
+//!    of the prefix `tokens[..=i]` through `forward_speculative` with a
+//!    single-token tail so the final position takes the standard
+//!    single-query decode SDPA branch, and read its last-position argmax
+//!    `decode_argmax[i]`.
+//! 3. Assert `verify_argmax[i] == decode_argmax[i]` for every position.
+//!
+//! Both paths share the same projections, RoPE, gated-delta recurrence and
+//! LM head; the only difference is the attention shape over the block. So
+//! any mismatch is exactly the verification-drift bug this issue targets.
+//! Using `forward_speculative` for both the block forward and the
+//! per-position reference keeps the comparison apples-to-apples (same
+//! capture path, same caches) while still exercising the two distinct
+//! attention branches.
+//!
+//! ## Invocation
+//!
+//! ```bash
+//! cargo test --test qwen35_mtp_verify_parity --release -- --ignored --nocapture
+//! ```
+//!
+//! `#[ignore]`-gated as real-model heavy: it loads a Qwen 3.5 4-bit
+//! checkpoint. The CI hardware lane runs it on a fixed cadence; dev runs
+//! skip it by default.
+
+mod common;
+
+use common::repo_model_dir;
+
+use mlxcel::models::Qwen35Model;
+use mlxcel::models::qwen3_next::Qwen3NextCache;
+use mlxcel::{LoadedModel, initialize_runtime, load_model};
+
+/// Candidate Qwen 3.5 text checkpoints, smallest first. The test uses the
+/// first one present on disk so it runs on hosts that only fetched one
+/// size.
+const CANDIDATE_TARGETS: &[&str] = &["qwen3.5-0.8b-4bit", "qwen3.5-2b-4bit", "qwen3.5-4b-4bit"];
+
+/// Fixed prefix token ids fed through both paths. Arbitrary in-vocab ids;
+/// the exact tokens do not matter — only that the verify and decode paths
+/// agree on the argmax at every position. Length is the verify-block span.
+const PREFIX_TOKENS: &[i32] = &[785, 3974, 13876, 8533, 4290, 374, 264, 1273, 315];
+
+/// Read the per-position argmax token ids out of a `[1, L, vocab]` logits
+/// tensor.
+fn per_position_argmax(logits: &mlxcel_core::MlxArray) -> Vec<i32> {
+    let shape = mlxcel_core::array_shape(logits);
+    assert_eq!(shape.len(), 3, "expected [1, L, vocab] logits");
+    let l = shape[1];
+    let argmax = mlxcel_core::argmax_last_axis(logits); // [1, L]
+    mlxcel_core::eval(&argmax);
+    let mut out = Vec::with_capacity(l as usize);
+    for i in 0..l {
+        // argmax is [1, L]; slice cell (0, i).
+        let cell = mlxcel_core::slice(&argmax, &[0, i], &[1, i + 1]);
+        out.push(mlxcel_core::item_i32(&cell));
+    }
+    out
+}
+
+/// Resolve the inner text `Qwen35Model` from a loaded checkpoint, or `None`
+/// for non-Qwen-3.5 variants.
+///
+/// `mlx-community` publishes most Qwen 3.5 checkpoints — including the
+/// text-only sizes — as `Qwen3_5ForConditionalGeneration`, so they load as
+/// the VLM-wrapped variant. The wrapper's `text_model` is the `Qwen35Model`
+/// the verify pass runs on, so we reach into it for the VLM variants too
+/// (mirrors `tests/speculative_parity.rs`).
+fn as_qwen35(loaded: &LoadedModel) -> Option<&Qwen35Model> {
+    match loaded {
+        LoadedModel::Qwen35(m) | LoadedModel::Qwen35Moe(m) => Some(m),
+        LoadedModel::Qwen35VLM(vlm) | LoadedModel::Qwen35MoeVLM(vlm) => Some(&vlm.text_model),
+        _ => None,
+    }
+}
+
+/// Greedy argmax at the final position of `prefix`, computed via a fresh
+/// single-token-tail decode so the last position takes the standard
+/// single-query decode attention branch (`l == 1`).
+fn decode_argmax_at_last(model: &Qwen35Model, prefix: &[i32]) -> i32 {
+    assert!(!prefix.is_empty());
+    let mut caches: Vec<Qwen3NextCache> = model.make_speculative_caches_for_test();
+
+    // Prefill everything except the last token (if any), then forward the
+    // last token alone so its forward uses the single-query decode SDPA.
+    let split = prefix.len() - 1;
+    if split > 0 {
+        let head = &prefix[..split];
+        let head_arr = mlxcel_core::from_slice_i32(head, &[1, head.len() as i32]);
+        let out = model.forward_speculative(&head_arr, &mut caches, &[]);
+        mlxcel_core::eval(&out.logits);
+    }
+    let tail = &prefix[split..]; // exactly one token
+    let tail_arr = mlxcel_core::from_slice_i32(tail, &[1, tail.len() as i32]);
+    let out = model.forward_speculative(&tail_arr, &mut caches, &[]);
+    let argmax = per_position_argmax(&out.logits);
+    *argmax
+        .last()
+        .expect("decode produced at least one logit row")
+}
+
+/// The Qwen 3.5 MTP verify pass must produce per-position
+/// argmax tokens identical to single-token decode at the same positions.
+///
+/// This is the load-bearing correctness gate for the verification-drift /
+/// sampling-parity fix ported from upstream mlx-vlm PR #1188.
+#[test]
+#[ignore = "real-model heavy (loads a Qwen 3.5 4-bit checkpoint); runs in CI hardware lane only"]
+fn qwen35_verify_block_argmax_matches_single_token_decode() {
+    let _runtime = initialize_runtime();
+    mlxcel_core::synchronize_default();
+    mlxcel_core::clear_memory_cache();
+
+    // Resolve the first available target checkpoint.
+    let target = CANDIDATE_TARGETS
+        .iter()
+        .map(|name| (name, repo_model_dir(name)))
+        .find(|(_, path)| path.exists());
+    let (name, target_path) = match target {
+        Some((name, path)) => (name, path),
+        None => {
+            eprintln!(
+                "Skipping qwen35_verify_block_argmax_matches_single_token_decode: \
+                 no Qwen 3.5 checkpoint on disk (looked for {CANDIDATE_TARGETS:?}). \
+                 Run `mlxcel download mlx-community/Qwen3.5-0.8B-4bit` to populate.",
+            );
+            return;
+        }
+    };
+    eprintln!("[mtp-parity] using target {name} at {target_path:?}");
+
+    let (loaded, _tokenizer) = load_model(&target_path).expect("Qwen 3.5 target must load");
+    let model = as_qwen35(&loaded).unwrap_or_else(|| {
+        panic!(
+            "checkpoint {name} did not load as a Qwen 3.5 text variant \
+             (Qwen35 / Qwen35Moe); got a different LoadedModel variant"
+        )
+    });
+
+    // ---- Verify forward: the whole prefix in one multi-token pass. ----
+    let prefix_arr = mlxcel_core::from_slice_i32(PREFIX_TOKENS, &[1, PREFIX_TOKENS.len() as i32]);
+    let mut verify_caches: Vec<Qwen3NextCache> = model.make_speculative_caches_for_test();
+    let verify_out = model.forward_speculative(&prefix_arr, &mut verify_caches, &[]);
+    let verify_argmax = per_position_argmax(&verify_out.logits);
+    assert_eq!(
+        verify_argmax.len(),
+        PREFIX_TOKENS.len(),
+        "verify forward must emit one logit row per input position"
+    );
+
+    // ---- Decode reference: per-position single-token decode. ----
+    //
+    // Compare every position from index 1 onward (position 0 has no prefix
+    // to drift, so it is trivially equal; positions >= 1 are where the
+    // batched-vs-per-position attention difference can surface).
+    let mut mismatches: Vec<(usize, i32, i32)> = Vec::new();
+    for i in 1..PREFIX_TOKENS.len() {
+        let decode_tok = decode_argmax_at_last(model, &PREFIX_TOKENS[..=i]);
+        if verify_argmax[i] != decode_tok {
+            mismatches.push((i, verify_argmax[i], decode_tok));
+        }
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "[mtp-parity] Qwen 3.5 verify-pass argmax diverged from single-token decode at {} of {} \
+         positions (verify != decode): {:?}. This is the verification-drift / sampling-parity \
+         bug upstream mlx-vlm PR #1188 fixed — the multi-token verify forward must compute \
+         attention per query position so its logits match single-token decode.",
+        mismatches.len(),
+        PREFIX_TOKENS.len() - 1,
+        mismatches,
+    );
+
+    eprintln!(
+        "[mtp-parity] PASS: all {} verify positions match single-token decode argmax",
+        PREFIX_TOKENS.len() - 1,
+    );
+
+    drop(loaded);
+    mlxcel_core::synchronize_default();
+    mlxcel_core::clear_memory_cache();
+}


### PR DESCRIPTION
Closes #77

The Qwen 3.5 MTP target-verify pass could produce per-position logits that disagree with single-token decode, flipping the speculative accept/reject decision and breaking the temperature-0 byte-equality invariant (greedy speculative output must equal drafter-less greedy decode). Mirrors the upstream mlx-vlm fix in PR #1188 (commit 45e6ece).

## Root cause

`Qwen35Model::forward_speculative` verifies the whole draft block in one forward. Its full-attention layers ran the batched fused causal attention over the multi-token block, whose reduction order differs from single-query decode attention. The resulting per-position logit drift can flip the target's argmax at a verify position, diverging the accept/reject decision from the drafter-less greedy pass. Qwen 3.5 is especially sensitive because its gated attention and quantized projections amplify the drift through the gate.

## Fix

Thread a `target_verify` flag through the Qwen 3.5 verify pass. When verifying a multi-token block, compute attention per query position: query `i` attends only to keys and values up to `prefix_len + i + 1` with no mask, exactly as during single-token decode. The decode and prefill paths are untouched (`target_verify` defaults to false; all existing call sites pass false), so non-speculative inference is byte-identical and pays zero overhead.

## Files

- `src/models/qwen3_next.rs`: target-verify-aware attention wrappers + `attend_per_position`; existing wrappers delegate with `target_verify = false`.
- `src/models/qwen3_5.rs`: `forward_with_capture` routes full-attention layers through verify-aware attention with `target_verify = true`.
- `tests/qwen35_mtp_verify_parity.rs`: ignore-gated real-model regression test.

## Verification

- `cargo fmt --check` clean.
- `cargo clippy --features metal,accelerate --all-targets -- -D warnings` clean.
- Parity test run against `qwen3.5-0.8b-4bit`: all 8 verify positions match single-token decode argmax.