### PR TITLE
feat(models): add RT-DETRv2 object detection model

### DIFF
--- a/src/commands/detect.rs
+++ b/src/commands/detect.rs
@@ -1,0 +1,132 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! CLI handler for `mlxcel detect`.
+//!
+//! Runs object detection on an image with an RT-DETRv2 checkpoint and prints
+//! bounding boxes (`l, t, r, b, label, confidence` in original-image pixels).
+//! This is the output surface for detection models, kept separate from the
+//! text/VLM `generate` loop because detection emits boxes rather than tokens.
+
+use anyhow::{Result, anyhow};
+
+use mlxcel::initialize_runtime;
+use mlxcel::vision::detection::RtDetrV2Predictor;
+
+use crate::DetectArgs;
+
+/// Run the `mlxcel detect` subcommand.
+pub(crate) fn run_detect(args: DetectArgs) -> Result<()> {
+    if !args.model.exists() {
+        return Err(anyhow!(
+            "Model directory does not exist: {}",
+            args.model.display()
+        ));
+    }
+    if !args.image.exists() {
+        return Err(anyhow!(
+            "Image file does not exist: {}",
+            args.image.display()
+        ));
+    }
+    if !(0.0..=1.0).contains(&args.threshold) {
+        return Err(anyhow!(
+            "--threshold must be in [0, 1], got {}",
+            args.threshold
+        ));
+    }
+
+    // Initialize the MLX runtime (selects GPU/CPU) before any forward pass.
+    let _runtime = initialize_runtime();
+
+    let predictor = RtDetrV2Predictor::from_pretrained(&args.model, args.threshold)
+        .map_err(|e| anyhow!("failed to load RT-DETRv2 model: {e}"))?;
+
+    let result = predictor
+        .predict_path(&args.image)
+        .map_err(|e| anyhow!("detection failed: {e}"))?;
+
+    // Sort detections by descending confidence for stable, readable output.
+    let mut detections = result.detections;
+    detections.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    match args.format {
+        OutputFormat::Text => {
+            if detections.is_empty() {
+                println!(
+                    "No detections above threshold {:.2} in {}",
+                    args.threshold,
+                    args.image.display()
+                );
+                return Ok(());
+            }
+            println!(
+                "{} detection(s) in {} (threshold {:.2}):",
+                detections.len(),
+                args.image.display(),
+                args.threshold
+            );
+            println!(
+                "{:<22} {:>7}  {:>8} {:>8} {:>8} {:>8}",
+                "label", "conf", "l", "t", "r", "b"
+            );
+            for d in &detections {
+                println!(
+                    "{:<22} {:>7.3}  {:>8.2} {:>8.2} {:>8.2} {:>8.2}",
+                    d.class_name, d.score, d.bbox[0], d.bbox[1], d.bbox[2], d.bbox[3]
+                );
+            }
+        }
+        OutputFormat::Json => {
+            let arr: Vec<serde_json::Value> = detections
+                .iter()
+                .map(|d| {
+                    serde_json::json!({
+                        "label": d.class_name,
+                        "label_id": d.label,
+                        "confidence": d.score,
+                        "box": {
+                            "l": d.bbox[0],
+                            "t": d.bbox[1],
+                            "r": d.bbox[2],
+                            "b": d.bbox[3],
+                        }
+                    })
+                })
+                .collect();
+            let out = serde_json::json!({
+                "image": args.image.display().to_string(),
+                "threshold": args.threshold,
+                "detections": arr,
+            });
+            println!("{}", serde_json::to_string_pretty(&out)?);
+        }
+    }
+
+    Ok(())
+}
+
+/// Output format for the `detect` subcommand.
+#[derive(Clone, Copy, Debug, Default, clap::ValueEnum)]
+pub(crate) enum OutputFormat {
+    /// Human-readable aligned table.
+    #[default]
+    Text,
+    /// Machine-readable JSON.
+    Json,
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,12 +18,14 @@
 //! argument/schema wiring while command-specific execution logic evolves in
 //! isolated modules.
 
+pub(crate) mod detect;
 pub(crate) mod download;
 pub(crate) mod generate;
 mod generate_vlm;
 pub(crate) mod inspect;
 mod serve;
 
+pub(crate) use detect::run_detect;
 pub(crate) use download::run_download;
 pub(crate) use generate::run_generate;
 pub(crate) use inspect::run_inspect;

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,19 @@ enum Commands {
 
     /// Download a HuggingFace model repository snapshot
     Download(DownloadArgs),
+
+    /// Detect objects in an image with an RT-DETRv2 model.
+    ///
+    /// Loads an RT-DETRv2 object-detection checkpoint and prints bounding
+    /// boxes (`l, t, r, b`), class labels, and confidences in original-image
+    /// pixel coordinates. Detection models output boxes rather than a token
+    /// stream, so this is a separate surface from `generate`.
+    ///
+    /// Examples:
+    ///
+    ///     mlxcel detect -m models/docling-layout-heron-mlx-bf16 -i page.png
+    ///     mlxcel detect -m models/rt-detr-v2 -i img.jpg --threshold 0.5 --format json
+    Detect(DetectArgs),
 }
 
 #[derive(Args, Debug)]
@@ -285,6 +298,26 @@ pub(crate) struct InspectArgs {
     // estimate matches what the loaded model would actually allocate.
     #[command(flatten)]
     pub(crate) turbo: TurboKvCacheArgs,
+}
+
+/// Arguments for the `mlxcel detect` subcommand.
+#[derive(Args, Debug)]
+pub(crate) struct DetectArgs {
+    /// Path to the RT-DETRv2 model directory (config.json + safetensors).
+    #[arg(short, long, value_name = "PATH")]
+    pub(crate) model: std::path::PathBuf,
+
+    /// Path to the input image file (PNG, JPEG, etc.).
+    #[arg(short, long, value_name = "PATH")]
+    pub(crate) image: std::path::PathBuf,
+
+    /// Confidence threshold in [0, 1]; detections below it are dropped.
+    #[arg(short, long, default_value_t = 0.3, value_name = "FLOAT")]
+    pub(crate) threshold: f32,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = commands::detect::OutputFormat::Text)]
+    pub(crate) format: commands::detect::OutputFormat,
 }
 
 /// Sampling strategy options
@@ -1186,6 +1219,7 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::Inspect(args) => commands::run_inspect(args),
         Commands::Download(args) => commands::run_download(args),
+        Commands::Detect(args) => commands::run_detect(args),
     }
 }
 

--- a/src/vision/detection/mod.rs
+++ b/src/vision/detection/mod.rs
@@ -1,0 +1,32 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Object-detection vision models.
+//!
+//! Detection models output bounding boxes (`l, t, r, b, label, confidence`)
+//! rather than a token stream, so they sit outside the text/VLM generation flow
+//! (`LanguageModel`, the generate loop) and are exposed through the `detect`
+//! CLI subcommand instead.
+//!
+//! Note: this module is for object *detection* and is distinct from
+//! `crate::models::detection`, which performs config-driven model-*type*
+//! classification. The naming overlap is unfortunate; the model-type module is
+//! the older one and renaming it is deferred to a follow-up so concurrent work
+//! on that file is not disrupted.
+
+pub mod rt_detr_v2;
+
+pub use rt_detr_v2::{
+    Detection, DetectionResult, RtDetrV2Config, RtDetrV2Model, RtDetrV2Predictor,
+};

--- a/src/vision/detection/rt_detr_v2/backbone.rs
+++ b/src/vision/detection/rt_detr_v2/backbone.rs
@@ -1,0 +1,305 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ResNet-50-vd / ResNet-101-vd backbone for RT-DETRv2.
+//!
+//! Port of the backbone half of
+//! `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/vision.py`. Returns features at
+//! the strides selected by `out_features` (default stages 2/3/4 -> strides
+//! 8/16/32). The `vd` variant uses a 3-conv stem + 3x3 stride-2 maxpool and
+//! AvgPool-based downsampling shortcuts.
+
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+use super::config::BackboneConfig;
+use super::layers::{Activation, ConvBn, ConvNorm, avg_pool_2x2, max_pool_3x3_s2_p1};
+
+const BOTTLENECK_EXPANSION: usize = 4;
+
+/// One of the three shortcut variants in a bottleneck block.
+enum ShortCut {
+    /// Identity skip (stride 1, channels unchanged) — no parameters.
+    Identity,
+    /// Plain 1x1 conv + BN (stride-1 channel change).
+    Conv(ConvBn),
+    /// vd downsampling: AvgPool 2x2 stride 2, then 1x1 conv + BN (the conv is
+    /// stored under `.proj`).
+    AvgPool(ConvBn),
+}
+
+impl ShortCut {
+    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        match self {
+            ShortCut::Identity => mlxcel_core::copy(x),
+            ShortCut::Conv(c) => c.forward(x),
+            ShortCut::AvgPool(c) => {
+                let pooled = avg_pool_2x2(x);
+                c.forward(&pooled)
+            }
+        }
+    }
+}
+
+/// ResNet bottleneck: 1x1 -> 3x3 -> 1x1 (last has no activation) + shortcut +
+/// post-add activation.
+struct BottleNeck {
+    shortcut: ShortCut,
+    conv0: ConvNorm,
+    conv1: ConvNorm,
+    conv2: ConvNorm,
+    act: Activation,
+}
+
+impl BottleNeck {
+    fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        in_c: usize,
+        out_c: usize,
+        stride: i32,
+        downsample_in_bottleneck: bool,
+        act: Activation,
+        eps: f32,
+    ) -> Result<Self, String> {
+        let should_apply_shortcut = (in_c != out_c) || (stride != 1);
+        // Conv channel dims (out_c / expansion for the reduce convs) are read
+        // from the checkpoint weights by key, so we don't size them here; the
+        // expansion constant is documented on `BOTTLENECK_EXPANSION`.
+        debug_assert_eq!(out_c % BOTTLENECK_EXPANSION, 0);
+
+        let shortcut = if !should_apply_shortcut {
+            ShortCut::Identity
+        } else if stride == 2 {
+            // AvgPoolShortCut: inner 1x1 conv+BN lives under `.shortcut.proj`.
+            ShortCut::AvgPool(ConvBn::from_weights(
+                weights,
+                &format!("{prefix}.shortcut.proj"),
+                1,
+                eps,
+            )?)
+        } else {
+            ShortCut::Conv(ConvBn::from_weights(
+                weights,
+                &format!("{prefix}.shortcut"),
+                stride,
+                eps,
+            )?)
+        };
+
+        // stride-2 sits on the first 1x1 if downsample_in_bottleneck, else on
+        // the middle 3x3.
+        let first_stride = if downsample_in_bottleneck { stride } else { 1 };
+        let middle_stride = if downsample_in_bottleneck { 1 } else { stride };
+
+        // layer.0: 1x1 (pad 0), layer.1: 3x3 (pad 1), layer.2: 1x1 (pad 0, no act).
+        let conv0 = ConvNorm::from_weights(
+            weights,
+            &format!("{prefix}.layer.0"),
+            first_stride,
+            0,
+            act,
+            eps,
+        )?;
+        let conv1 = ConvNorm::from_weights(
+            weights,
+            &format!("{prefix}.layer.1"),
+            middle_stride,
+            1,
+            act,
+            eps,
+        )?;
+        let conv2 = ConvNorm::from_weights(
+            weights,
+            &format!("{prefix}.layer.2"),
+            1,
+            0,
+            Activation::None,
+            eps,
+        )?;
+
+        Ok(Self {
+            shortcut,
+            conv0,
+            conv1,
+            conv2,
+            act,
+        })
+    }
+
+    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        let residual = self.shortcut.forward(x);
+        let y = self.conv0.forward(x);
+        let y = self.conv1.forward(&y);
+        let y = self.conv2.forward(&y);
+        let y = mlxcel_core::add(&y, &residual);
+        self.act.apply(&y)
+    }
+}
+
+/// A ResNet stage: `depth` bottleneck blocks. The first block downsamples /
+/// projects; the rest are stride-1 identity-or-projection blocks.
+struct Stage {
+    blocks: Vec<BottleNeck>,
+}
+
+impl Stage {
+    fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        cfg: &BackboneConfig,
+        in_c: usize,
+        out_c: usize,
+        stride: i32,
+        depth: usize,
+        act: Activation,
+        eps: f32,
+    ) -> Result<Self, String> {
+        let mut blocks = Vec::with_capacity(depth);
+        // First block: in_c -> out_c at `stride`.
+        blocks.push(BottleNeck::from_weights(
+            weights,
+            &format!("{prefix}.layers.0"),
+            in_c,
+            out_c,
+            stride,
+            cfg.downsample_in_bottleneck,
+            act,
+            eps,
+        )?);
+        // Remaining blocks: out_c -> out_c, stride 1.
+        for i in 1..depth {
+            blocks.push(BottleNeck::from_weights(
+                weights,
+                &format!("{prefix}.layers.{i}"),
+                out_c,
+                out_c,
+                1,
+                cfg.downsample_in_bottleneck,
+                act,
+                eps,
+            )?);
+        }
+        Ok(Self { blocks })
+    }
+
+    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        let mut y = mlxcel_core::copy(x);
+        for block in &self.blocks {
+            y = block.forward(&y);
+        }
+        y
+    }
+}
+
+/// Stem: three 3x3 ConvNorm layers (stride 2/1/1) then a 3x3 stride-2 maxpool.
+struct Embeddings {
+    conv0: ConvNorm,
+    conv1: ConvNorm,
+    conv2: ConvNorm,
+}
+
+impl Embeddings {
+    fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        cfg: &BackboneConfig,
+        act: Activation,
+        eps: f32,
+    ) -> Result<Self, String> {
+        // embedder.0 stride 2, embedder.1/2 stride 1, all 3x3 pad 1.
+        let conv0 =
+            ConvNorm::from_weights(weights, &format!("{prefix}.embedder.0"), 2, 1, act, eps)?;
+        let conv1 =
+            ConvNorm::from_weights(weights, &format!("{prefix}.embedder.1"), 1, 1, act, eps)?;
+        let conv2 =
+            ConvNorm::from_weights(weights, &format!("{prefix}.embedder.2"), 1, 1, act, eps)?;
+        let _ = cfg;
+        Ok(Self {
+            conv0,
+            conv1,
+            conv2,
+        })
+    }
+
+    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        let y = self.conv0.forward(x);
+        let y = self.conv1.forward(&y);
+        let y = self.conv2.forward(&y);
+        max_pool_3x3_s2_p1(&y)
+    }
+}
+
+/// ResNet-vd backbone.
+pub struct Backbone {
+    embedder: Embeddings,
+    stages: Vec<Stage>,
+    out_stage_indices: Vec<usize>,
+}
+
+impl Backbone {
+    pub fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        cfg: &BackboneConfig,
+        eps: f32,
+    ) -> Result<Self, String> {
+        let act = Activation::parse(&cfg.hidden_act)?;
+
+        let embedder =
+            Embeddings::from_weights(weights, &format!("{prefix}.embedder"), cfg, act, eps)?;
+
+        let mut stages = Vec::with_capacity(cfg.depths.len());
+        let mut prev_c = cfg.embedding_size;
+        for (i, (&out_c, &depth)) in cfg.hidden_sizes.iter().zip(cfg.depths.iter()).enumerate() {
+            let stride = if i == 0 {
+                if cfg.downsample_in_first_stage { 2 } else { 1 }
+            } else {
+                2
+            };
+            stages.push(Stage::from_weights(
+                weights,
+                &format!("{prefix}.encoder.stages.{i}"),
+                cfg,
+                prev_c,
+                out_c,
+                stride,
+                depth,
+                act,
+                eps,
+            )?);
+            prev_c = out_c;
+        }
+
+        Ok(Self {
+            embedder,
+            stages,
+            out_stage_indices: cfg.out_stage_indices(),
+        })
+    }
+
+    /// Returns the selected feature maps (NHWC), one per `out_features` entry.
+    pub fn forward(&self, pixel_values: &MlxArray) -> Vec<UniquePtr<MlxArray>> {
+        let mut x = self.embedder.forward(pixel_values);
+        let mut all_stages: Vec<UniquePtr<MlxArray>> = Vec::with_capacity(self.stages.len());
+        for stage in &self.stages {
+            x = stage.forward(&x);
+            all_stages.push(mlxcel_core::copy(&x));
+        }
+        self.out_stage_indices
+            .iter()
+            .map(|&i| mlxcel_core::copy(&all_stages[i]))
+            .collect()
+    }
+}

--- a/src/vision/detection/rt_detr_v2/common.rs
+++ b/src/vision/detection/rt_detr_v2/common.rs
@@ -1,0 +1,43 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Small shared helpers for the RT-DETRv2 modules.
+
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+/// Copy a weight by exact key, erroring with the missing key name.
+///
+/// RT-DETRv2 weights are dense bf16 (no quantization), so a plain `copy` of the
+/// MLX-managed lazy array is the right load primitive — there is no
+/// quantized-vs-regular branch to detect.
+pub fn copy_weight(weights: &WeightMap, key: &str) -> Result<UniquePtr<MlxArray>, String> {
+    weights
+        .get(key)
+        .map(|w| mlxcel_core::copy(w))
+        .ok_or_else(|| format!("RT-DETRv2 weight not found: {key}"))
+}
+
+/// Like [`copy_weight`] but optional; returns `None` if the key is absent.
+pub fn copy_weight_opt(weights: &WeightMap, key: &str) -> Option<UniquePtr<MlxArray>> {
+    weights.get(key).map(|w| mlxcel_core::copy(w))
+}
+
+/// Cast an array to float32 for numerically-sensitive sub-graphs (softmax,
+/// attention, anchor logits). The detection head's box coordinates are
+/// precision-sensitive, so the whole forward runs in f32 regardless of the
+/// checkpoint's stored dtype.
+pub fn to_f32(x: &MlxArray) -> UniquePtr<MlxArray> {
+    mlxcel_core::astype(x, mlxcel_core::dtype::FLOAT32)
+}

--- a/src/vision/detection/rt_detr_v2/config.rs
+++ b/src/vision/detection/rt_detr_v2/config.rs
@@ -1,0 +1,436 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! RT-DETRv2 configuration.
+//!
+//! Mirrors the HuggingFace `RTDetrV2Config` schema
+//! (`transformers.models.rt_detr_v2.configuration_rt_detr_v2`) and the
+//! upstream mlx-vlm port in
+//! `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/config.py`. The HF
+//! `config.json` stores backbone / hybrid-encoder / decoder fields flat at
+//! the top level; this module parses them into one [`RtDetrV2Config`] and
+//! exposes typed sub-views (`backbone()`, `encoder()`, `transformer()`).
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+/// Default for [`RtDetrV2Config::image_size`] when neither `image_size` nor a
+/// `size.{height,width}` block is present.
+const DEFAULT_IMAGE_SIZE: usize = 640;
+
+fn default_image_size() -> usize {
+    DEFAULT_IMAGE_SIZE
+}
+fn default_num_labels() -> usize {
+    17
+}
+fn default_d_model() -> usize {
+    256
+}
+fn default_encoder_hidden_dim() -> usize {
+    256
+}
+fn default_encoder_in_channels() -> Vec<usize> {
+    vec![512, 1024, 2048]
+}
+fn default_feat_strides() -> Vec<usize> {
+    vec![8, 16, 32]
+}
+fn default_encoder_layers() -> usize {
+    1
+}
+fn default_encoder_ffn_dim() -> usize {
+    1024
+}
+fn default_encoder_attention_heads() -> usize {
+    8
+}
+fn default_encoder_activation() -> String {
+    "gelu".to_string()
+}
+fn default_encode_proj_layers() -> Vec<usize> {
+    vec![2]
+}
+fn default_positional_encoding_temperature() -> f32 {
+    10000.0
+}
+fn default_activation() -> String {
+    "silu".to_string()
+}
+fn default_layer_norm_eps() -> f32 {
+    1e-5
+}
+fn default_hidden_expansion() -> f32 {
+    1.0
+}
+fn default_batch_norm_eps() -> f32 {
+    1e-5
+}
+fn default_decoder_layers() -> usize {
+    6
+}
+fn default_decoder_attention_heads() -> usize {
+    8
+}
+fn default_decoder_ffn_dim() -> usize {
+    1024
+}
+fn default_decoder_in_channels() -> Vec<usize> {
+    vec![256, 256, 256]
+}
+fn default_decoder_activation() -> String {
+    "relu".to_string()
+}
+fn default_decoder_method() -> String {
+    "default".to_string()
+}
+fn default_decoder_n_levels() -> usize {
+    3
+}
+fn default_decoder_n_points() -> usize {
+    4
+}
+fn default_decoder_offset_scale() -> f32 {
+    0.5
+}
+fn default_num_feature_levels() -> usize {
+    3
+}
+fn default_num_queries() -> usize {
+    300
+}
+
+/// ResNet-vd backbone configuration.
+///
+/// The `vd` variant has a 3-stage stem (3x3 -> 3x3 -> 3x3, stride 2/1/1)
+/// followed by a 3x3 stride-2 max-pool, and uses `AvgPool2x2 stride 2 + 1x1
+/// conv` for downsampling shortcuts. Depths default to ResNet-50
+/// (`[3, 4, 6, 3]`); ResNet-101 is `[3, 4, 23, 3]`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BackboneConfig {
+    #[serde(default = "BackboneConfig::default_depths")]
+    pub depths: Vec<usize>,
+    #[serde(default)]
+    pub downsample_in_bottleneck: bool,
+    #[serde(default)]
+    pub downsample_in_first_stage: bool,
+    #[serde(default = "BackboneConfig::default_embedding_size")]
+    pub embedding_size: usize,
+    #[serde(default = "BackboneConfig::default_hidden_act")]
+    pub hidden_act: String,
+    #[serde(default = "BackboneConfig::default_hidden_sizes")]
+    pub hidden_sizes: Vec<usize>,
+    #[serde(default = "BackboneConfig::default_num_channels")]
+    pub num_channels: usize,
+    #[serde(default = "BackboneConfig::default_out_features")]
+    pub out_features: Vec<String>,
+}
+
+impl BackboneConfig {
+    fn default_depths() -> Vec<usize> {
+        vec![3, 4, 6, 3]
+    }
+    fn default_embedding_size() -> usize {
+        64
+    }
+    fn default_hidden_act() -> String {
+        "relu".to_string()
+    }
+    fn default_hidden_sizes() -> Vec<usize> {
+        vec![256, 512, 1024, 2048]
+    }
+    fn default_num_channels() -> usize {
+        3
+    }
+    fn default_out_features() -> Vec<String> {
+        vec![
+            "stage2".to_string(),
+            "stage3".to_string(),
+            "stage4".to_string(),
+        ]
+    }
+
+    /// Zero-based stage indices selected by `out_features` (e.g. `stage2` ->
+    /// index 1). Stage 0 (stride 4) is computed but typically dropped.
+    pub fn out_stage_indices(&self) -> Vec<usize> {
+        self.out_features
+            .iter()
+            .filter_map(|name| name.strip_prefix("stage"))
+            .filter_map(|n| n.parse::<usize>().ok())
+            .map(|n| n - 1)
+            .collect()
+    }
+}
+
+impl Default for BackboneConfig {
+    fn default() -> Self {
+        Self {
+            depths: Self::default_depths(),
+            downsample_in_bottleneck: false,
+            downsample_in_first_stage: false,
+            embedding_size: Self::default_embedding_size(),
+            hidden_act: Self::default_hidden_act(),
+            hidden_sizes: Self::default_hidden_sizes(),
+            num_channels: Self::default_num_channels(),
+            out_features: Self::default_out_features(),
+        }
+    }
+}
+
+/// `size: {"height": H, "width": W}` block from `preprocessor_config.json` or
+/// `config.json`. We require square inputs, so only the height is used.
+#[derive(Debug, Clone, Deserialize)]
+struct SizeBlock {
+    #[serde(default)]
+    height: Option<usize>,
+    #[serde(default)]
+    width: Option<usize>,
+    #[serde(default)]
+    shortest_edge: Option<usize>,
+}
+
+/// Top-level RT-DETRv2 configuration parsed from `config.json`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RtDetrV2Config {
+    #[serde(default = "default_image_size")]
+    pub image_size: usize,
+    /// HF stores the resize target under `size: {height, width}` in some
+    /// checkpoints; captured here so [`Self::resolve`] can fold it into
+    /// `image_size`.
+    #[serde(default)]
+    size: Option<SizeBlock>,
+
+    #[serde(default = "default_num_labels")]
+    pub num_labels: usize,
+    #[serde(default)]
+    pub id2label: Option<BTreeMap<String, String>>,
+
+    #[serde(default)]
+    pub backbone_config: BackboneConfig,
+
+    #[serde(default = "default_d_model")]
+    pub d_model: usize,
+    #[serde(default = "default_encoder_hidden_dim")]
+    pub encoder_hidden_dim: usize,
+    #[serde(default = "default_encoder_in_channels")]
+    pub encoder_in_channels: Vec<usize>,
+    #[serde(default = "default_feat_strides")]
+    pub feat_strides: Vec<usize>,
+    #[serde(default = "default_encoder_layers")]
+    pub encoder_layers: usize,
+    #[serde(default = "default_encoder_ffn_dim")]
+    pub encoder_ffn_dim: usize,
+    #[serde(default = "default_encoder_attention_heads")]
+    pub encoder_attention_heads: usize,
+    #[serde(default = "default_encoder_activation")]
+    pub encoder_activation_function: String,
+    #[serde(default = "default_encode_proj_layers")]
+    pub encode_proj_layers: Vec<usize>,
+    #[serde(default = "default_positional_encoding_temperature")]
+    pub positional_encoding_temperature: f32,
+    #[serde(default = "default_activation")]
+    pub activation_function: String,
+    #[serde(default)]
+    pub normalize_before: bool,
+    #[serde(default = "default_layer_norm_eps")]
+    pub layer_norm_eps: f32,
+    #[serde(default = "default_hidden_expansion")]
+    pub hidden_expansion: f32,
+    #[serde(default = "default_batch_norm_eps")]
+    pub batch_norm_eps: f32,
+
+    #[serde(default = "default_decoder_layers")]
+    pub decoder_layers: usize,
+    #[serde(default = "default_decoder_attention_heads")]
+    pub decoder_attention_heads: usize,
+    #[serde(default = "default_decoder_ffn_dim")]
+    pub decoder_ffn_dim: usize,
+    #[serde(default = "default_decoder_in_channels")]
+    pub decoder_in_channels: Vec<usize>,
+    #[serde(default = "default_decoder_activation")]
+    pub decoder_activation_function: String,
+    #[serde(default = "default_decoder_method")]
+    pub decoder_method: String,
+    #[serde(default = "default_decoder_n_levels")]
+    pub decoder_n_levels: usize,
+    #[serde(default = "default_decoder_n_points")]
+    pub decoder_n_points: usize,
+    #[serde(default = "default_decoder_offset_scale")]
+    pub decoder_offset_scale: f32,
+    #[serde(default = "default_num_feature_levels")]
+    pub num_feature_levels: usize,
+    #[serde(default = "default_num_queries")]
+    pub num_queries: usize,
+}
+
+impl RtDetrV2Config {
+    /// Parse a `config.json` string into a resolved config.
+    pub fn from_json_str(s: &str) -> Result<Self, String> {
+        let mut cfg: RtDetrV2Config =
+            serde_json::from_str(s).map_err(|e| format!("RT-DETRv2 config parse error: {e}"))?;
+        cfg.resolve();
+        Ok(cfg)
+    }
+
+    /// Fold the optional `size` block into `image_size`. Called once after
+    /// deserialization.
+    fn resolve(&mut self) {
+        if let Some(size) = &self.size
+            && let Some(h) = size.height.or(size.shortest_edge).or(size.width)
+        {
+            self.image_size = h;
+        }
+    }
+
+    /// Validate cross-field invariants the forward path relies on. Mirrors the
+    /// `raise` checks scattered through the Python modules so a malformed
+    /// checkpoint fails at load time with a clear message rather than mid-graph.
+    pub fn validate(&self) -> Result<(), String> {
+        if !self.d_model.is_multiple_of(self.decoder_attention_heads) {
+            return Err(format!(
+                "d_model ({}) must be divisible by decoder_attention_heads ({})",
+                self.d_model, self.decoder_attention_heads
+            ));
+        }
+        if !self
+            .encoder_hidden_dim
+            .is_multiple_of(self.encoder_attention_heads)
+        {
+            return Err(format!(
+                "encoder_hidden_dim ({}) must be divisible by encoder_attention_heads ({})",
+                self.encoder_hidden_dim, self.encoder_attention_heads
+            ));
+        }
+        if !self.encoder_hidden_dim.is_multiple_of(4) {
+            return Err(format!(
+                "encoder_hidden_dim ({}) must be divisible by 4 for the sine \
+                 position embedding",
+                self.encoder_hidden_dim
+            ));
+        }
+        if self.decoder_method != "default" && self.decoder_method != "discrete" {
+            return Err(format!(
+                "Unsupported decoder_method {:?}; expected 'default' or 'discrete'",
+                self.decoder_method
+            ));
+        }
+        if self.encoder_in_channels.len() != self.backbone_config.out_features.len() {
+            return Err(format!(
+                "encoder_in_channels ({}) must match backbone out_features ({})",
+                self.encoder_in_channels.len(),
+                self.backbone_config.out_features.len()
+            ));
+        }
+        Ok(())
+    }
+
+    /// Backbone sub-config.
+    pub fn backbone(&self) -> &BackboneConfig {
+        &self.backbone_config
+    }
+
+    /// Number of feature-pyramid levels (one per backbone output feature).
+    pub fn num_levels(&self) -> usize {
+        self.encoder_in_channels.len()
+    }
+
+    /// Ordered class-name list resolved from `id2label`, sorted by integer id.
+    /// `None` when the checkpoint provides no label map (numeric fallback at
+    /// decode time).
+    pub fn class_names(&self) -> Option<Vec<String>> {
+        let map = self.id2label.as_ref()?;
+        if map.is_empty() {
+            return None;
+        }
+        let mut entries: Vec<(i64, String)> = map
+            .iter()
+            .filter_map(|(k, v)| k.parse::<i64>().ok().map(|id| (id, v.clone())))
+            .collect();
+        entries.sort_by_key(|(id, _)| *id);
+        Some(entries.into_iter().map(|(_, v)| v).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DOCLING_CONFIG: &str = r#"{
+        "model_type": "rt_detr_v2",
+        "architectures": ["RTDetrV2ForObjectDetection"],
+        "backbone_config": {
+            "depths": [3, 4, 6, 3],
+            "embedding_size": 64,
+            "hidden_sizes": [256, 512, 1024, 2048],
+            "out_features": ["stage2", "stage3", "stage4"]
+        },
+        "d_model": 256,
+        "encoder_hidden_dim": 256,
+        "encoder_in_channels": [512, 1024, 2048],
+        "num_labels": 17,
+        "num_queries": 300,
+        "decoder_layers": 6,
+        "id2label": {"0": "caption", "1": "footnote", "10": "title", "2": "formula"}
+    }"#;
+
+    #[test]
+    fn parses_docling_config() {
+        let cfg = RtDetrV2Config::from_json_str(DOCLING_CONFIG).unwrap();
+        assert_eq!(cfg.d_model, 256);
+        assert_eq!(cfg.num_queries, 300);
+        assert_eq!(cfg.num_labels, 17);
+        assert_eq!(cfg.backbone_config.depths, vec![3, 4, 6, 3]);
+        assert_eq!(cfg.num_levels(), 3);
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn class_names_sorted_by_int_id() {
+        let cfg = RtDetrV2Config::from_json_str(DOCLING_CONFIG).unwrap();
+        let names = cfg.class_names().unwrap();
+        // Keys 0,1,2,10 -> sorted numerically, not lexically.
+        assert_eq!(names, vec!["caption", "footnote", "formula", "title"]);
+    }
+
+    #[test]
+    fn out_stage_indices_are_zero_based() {
+        let cfg = RtDetrV2Config::from_json_str(DOCLING_CONFIG).unwrap();
+        assert_eq!(cfg.backbone_config.out_stage_indices(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn resnet101_depths_via_default_when_absent() {
+        let json = r#"{"backbone_config": {"depths": [3, 4, 23, 3]}}"#;
+        let cfg = RtDetrV2Config::from_json_str(json).unwrap();
+        assert_eq!(cfg.backbone_config.depths, vec![3, 4, 23, 3]);
+        // Top-level fields fall back to defaults.
+        assert_eq!(cfg.d_model, 256);
+        assert_eq!(cfg.image_size, 640);
+    }
+
+    #[test]
+    fn size_block_folds_into_image_size() {
+        let json = r#"{"size": {"height": 800, "width": 800}}"#;
+        let cfg = RtDetrV2Config::from_json_str(json).unwrap();
+        assert_eq!(cfg.image_size, 800);
+    }
+
+    #[test]
+    fn validate_rejects_indivisible_d_model() {
+        let json = r#"{"d_model": 250, "decoder_attention_heads": 8}"#;
+        let cfg = RtDetrV2Config::from_json_str(json).unwrap();
+        assert!(cfg.validate().is_err());
+    }
+}

--- a/src/vision/detection/rt_detr_v2/hybrid_encoder.rs
+++ b/src/vision/detection/rt_detr_v2/hybrid_encoder.rs
@@ -1,0 +1,489 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! RT-DETRv2 hybrid encoder: AIFI transformer on the deepest level, top-down
+//! FPN, bottom-up PAN.
+//!
+//! Port of the hybrid-encoder half of
+//! `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/vision.py`. All feature maps
+//! are NHWC. Output is `num_levels` feature maps at the original strides, all
+//! with `encoder_hidden_dim` channels.
+
+use mlxcel_core::layers::{LayerNorm, Linear};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+use super::common::{copy_weight, copy_weight_opt};
+use super::config::RtDetrV2Config;
+use super::layers::{Activation, ConvNorm, upsample_nearest_2x};
+
+/// Multi-head self-attention with position embeddings added to q,k (not v).
+/// Shared by AIFI here and by the decoder's `SelfAttention` (same field names
+/// `q_proj`/`k_proj`/`v_proj`/`out_proj`).
+pub struct SelfAttention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    out_proj: Linear,
+    n_heads: i32,
+    head_dim: i32,
+    scale: f32,
+}
+
+impl SelfAttention {
+    pub fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        d_model: usize,
+        n_heads: usize,
+    ) -> Result<Self, String> {
+        let head_dim = d_model / n_heads;
+        Ok(Self {
+            q_proj: Linear::from_weights(weights, &format!("{prefix}.q_proj"))?,
+            k_proj: Linear::from_weights(weights, &format!("{prefix}.k_proj"))?,
+            v_proj: Linear::from_weights(weights, &format!("{prefix}.v_proj"))?,
+            out_proj: Linear::from_weights(weights, &format!("{prefix}.out_proj"))?,
+            n_heads: n_heads as i32,
+            head_dim: head_dim as i32,
+            scale: (head_dim as f32).powf(-0.5),
+        })
+    }
+
+    /// `x`: (B, N, D). `pos`: optional (·, N, D) added to q,k.
+    pub fn forward(&self, x: &MlxArray, pos: Option<&MlxArray>) -> UniquePtr<MlxArray> {
+        let shape = mlxcel_core::array_shape(x);
+        let (b, n, d) = (shape[0], shape[1], shape[2]);
+        let qk = match pos {
+            Some(p) => mlxcel_core::add(x, p),
+            None => mlxcel_core::copy(x),
+        };
+        let split = |proj: &Linear, src: &MlxArray| {
+            let t = proj.forward(src);
+            let t = mlxcel_core::reshape(&t, &[b, n, self.n_heads, self.head_dim]);
+            mlxcel_core::transpose_axes(&t, &[0, 2, 1, 3])
+        };
+        let q = split(&self.q_proj, &qk);
+        let k = split(&self.k_proj, &qk);
+        let v = split(&self.v_proj, x);
+        let out = unsafe {
+            mlxcel_core::scaled_dot_product_attention(&q, &k, &v, self.scale, std::ptr::null())
+        };
+        let out = mlxcel_core::transpose_axes(&out, &[0, 2, 1, 3]);
+        let out = mlxcel_core::reshape(&out, &[b, n, d]);
+        self.out_proj.forward(&out)
+    }
+}
+
+/// One AIFI encoder layer: pre/post-norm MHSA + FFN.
+struct EncoderLayer {
+    self_attn: SelfAttention,
+    self_attn_ln: LayerNorm,
+    fc1: Linear,
+    fc2: Linear,
+    final_ln: LayerNorm,
+    act: Activation,
+    normalize_before: bool,
+}
+
+impl EncoderLayer {
+    fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        cfg: &RtDetrV2Config,
+    ) -> Result<Self, String> {
+        let d = cfg.encoder_hidden_dim;
+        Ok(Self {
+            self_attn: SelfAttention::from_weights(
+                weights,
+                &format!("{prefix}.self_attn"),
+                d,
+                cfg.encoder_attention_heads,
+            )?,
+            self_attn_ln: load_layer_norm(
+                weights,
+                &format!("{prefix}.self_attn_layer_norm"),
+                cfg.layer_norm_eps,
+            )?,
+            fc1: Linear::from_weights(weights, &format!("{prefix}.fc1"))?,
+            fc2: Linear::from_weights(weights, &format!("{prefix}.fc2"))?,
+            final_ln: load_layer_norm(
+                weights,
+                &format!("{prefix}.final_layer_norm"),
+                cfg.layer_norm_eps,
+            )?,
+            act: Activation::parse(&cfg.encoder_activation_function)?,
+            normalize_before: cfg.normalize_before,
+        })
+    }
+
+    fn forward(&self, x: &MlxArray, pos: &MlxArray) -> UniquePtr<MlxArray> {
+        // Self-attention sub-block.
+        let residual = mlxcel_core::copy(x);
+        let h = if self.normalize_before {
+            self.self_attn_ln.forward(x)
+        } else {
+            mlxcel_core::copy(x)
+        };
+        let h = self.self_attn.forward(&h, Some(pos));
+        let h = mlxcel_core::add(&residual, &h);
+        let h = if self.normalize_before {
+            h
+        } else {
+            self.self_attn_ln.forward(&h)
+        };
+
+        // FFN sub-block.
+        let residual = mlxcel_core::copy(&h);
+        let f = if self.normalize_before {
+            self.final_ln.forward(&h)
+        } else {
+            mlxcel_core::copy(&h)
+        };
+        let f = self.fc2.forward(&self.act.apply(&self.fc1.forward(&f)));
+        let f = mlxcel_core::add(&residual, &f);
+        if self.normalize_before {
+            f
+        } else {
+            self.final_ln.forward(&f)
+        }
+    }
+}
+
+/// Attention-based Intra-scale Feature Interaction: a stack of `EncoderLayer`s
+/// over a single flattened feature map, plus a 2D sine position embedding.
+struct Aifi {
+    layers: Vec<EncoderLayer>,
+    embed_dim: usize,
+    temperature: f32,
+}
+
+impl Aifi {
+    fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        cfg: &RtDetrV2Config,
+    ) -> Result<Self, String> {
+        let mut layers = Vec::with_capacity(cfg.encoder_layers);
+        for i in 0..cfg.encoder_layers {
+            layers.push(EncoderLayer::from_weights(
+                weights,
+                &format!("{prefix}.layers.{i}"),
+                cfg,
+            )?);
+        }
+        Ok(Self {
+            layers,
+            embed_dim: cfg.encoder_hidden_dim,
+            temperature: cfg.positional_encoding_temperature,
+        })
+    }
+
+    /// `x`: (B, H, W, C). Returns the same shape.
+    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        let shape = mlxcel_core::array_shape(x);
+        let (b, h, w, c) = (shape[0], shape[1], shape[2], shape[3]);
+        let mut flat = mlxcel_core::reshape(x, &[b, h * w, c]);
+        let pos = sine_position_embedding(h, w, self.embed_dim, self.temperature);
+        for layer in &self.layers {
+            flat = layer.forward(&flat, &pos);
+        }
+        mlxcel_core::reshape(&flat, &[b, h, w, c])
+    }
+}
+
+/// 2D sinusoidal position embedding, `(1, H*W, embed_dim)`.
+///
+/// `embed_dim` is split into `[sin(h), cos(h), sin(w), cos(w)]` quarters. Built
+/// in f32 from `arange` + broadcast to mirror
+/// `SinePositionEmbedding` in the reference (`meshgrid` with default "xy"
+/// indexing, then `out_w/out_h = grid.flatten()[:, None] * omega[None, :]`).
+fn sine_position_embedding(
+    height: i32,
+    width: i32,
+    embed_dim: usize,
+    temperature: f32,
+) -> UniquePtr<MlxArray> {
+    let pos_dim = (embed_dim / 4) as i32;
+    let dt = mlxcel_core::dtype::FLOAT32;
+
+    // omega[j] = 1 / temperature^(j / pos_dim), shape (pos_dim,).
+    let omega: Vec<f32> = (0..pos_dim)
+        .map(|j| 1.0 / temperature.powf(j as f32 / pos_dim as f32))
+        .collect();
+    let omega = mlxcel_core::from_slice_f32(&omega, &[pos_dim]);
+
+    // meshgrid(grid_w, grid_h) with "xy" indexing produces gw, gh each of shape
+    // (height, width); flatten row-major. Build the flattened coordinate
+    // vectors directly: for index k = r*width + col (r in [0,height),
+    // col in [0,width)) gw=col, gh=r.
+    let n = (height * width) as usize;
+    let mut gw_flat = vec![0f32; n];
+    let mut gh_flat = vec![0f32; n];
+    for r in 0..height {
+        for col in 0..width {
+            let k = (r * width + col) as usize;
+            gw_flat[k] = col as f32;
+            gh_flat[k] = r as f32;
+        }
+    }
+    let gw = mlxcel_core::from_slice_f32(&gw_flat, &[height * width, 1]);
+    let gh = mlxcel_core::from_slice_f32(&gh_flat, &[height * width, 1]);
+    let omega_row = mlxcel_core::reshape(&omega, &[1, pos_dim]);
+
+    // out_* = grid[:, None] * omega[None, :] -> (H*W, pos_dim).
+    let out_w = mlxcel_core::multiply(&gw, &omega_row);
+    let out_h = mlxcel_core::multiply(&gh, &omega_row);
+
+    let parts = [
+        mlxcel_core::sin(&out_h),
+        mlxcel_core::cos(&out_h),
+        mlxcel_core::sin(&out_w),
+        mlxcel_core::cos(&out_w),
+    ];
+    // Concatenate along the feature axis -> (H*W, embed_dim).
+    let mut pe = mlxcel_core::concatenate(&parts[0], &parts[1], 1);
+    pe = mlxcel_core::concatenate(&pe, &parts[2], 1);
+    pe = mlxcel_core::concatenate(&pe, &parts[3], 1);
+    let pe = mlxcel_core::astype(&pe, dt);
+    // (1, H*W, embed_dim).
+    mlxcel_core::expand_dims(&pe, 0)
+}
+
+/// RepVGG block: 3x3 conv + 1x1 conv branches summed and activated.
+struct RepVggBlock {
+    conv1: ConvNorm, // 3x3, pad 1
+    conv2: ConvNorm, // 1x1, pad 0
+    act: Activation,
+}
+
+impl RepVggBlock {
+    fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        act: Activation,
+        eps: f32,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            conv1: ConvNorm::from_weights(
+                weights,
+                &format!("{prefix}.conv1"),
+                1,
+                1,
+                Activation::None,
+                eps,
+            )?,
+            conv2: ConvNorm::from_weights(
+                weights,
+                &format!("{prefix}.conv2"),
+                1,
+                0,
+                Activation::None,
+                eps,
+            )?,
+            act,
+        })
+    }
+
+    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        let y = mlxcel_core::add(&self.conv1.forward(x), &self.conv2.forward(x));
+        self.act.apply(&y)
+    }
+}
+
+/// CSPNet block built from RepVGG blocks. `conv3` collapses to identity when
+/// `hidden_channels == out_channels` (no `conv3.*` keys present).
+struct CspRepLayer {
+    conv1: ConvNorm,
+    conv2: ConvNorm,
+    bottlenecks: Vec<RepVggBlock>,
+    conv3: Option<ConvNorm>,
+}
+
+impl CspRepLayer {
+    fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        num_blocks: usize,
+        act: Activation,
+        eps: f32,
+    ) -> Result<Self, String> {
+        let conv1 = ConvNorm::from_weights(weights, &format!("{prefix}.conv1"), 1, 0, act, eps)?;
+        let conv2 = ConvNorm::from_weights(weights, &format!("{prefix}.conv2"), 1, 0, act, eps)?;
+        let mut bottlenecks = Vec::with_capacity(num_blocks);
+        for i in 0..num_blocks {
+            bottlenecks.push(RepVggBlock::from_weights(
+                weights,
+                &format!("{prefix}.bottlenecks.{i}"),
+                act,
+                eps,
+            )?);
+        }
+        // conv3 only exists when hidden_channels != out_channels; detect by key.
+        let conv3 = if copy_weight_opt(weights, &format!("{prefix}.conv3.conv.weight")).is_some() {
+            Some(ConvNorm::from_weights(
+                weights,
+                &format!("{prefix}.conv3"),
+                1,
+                0,
+                act,
+                eps,
+            )?)
+        } else {
+            None
+        };
+        Ok(Self {
+            conv1,
+            conv2,
+            bottlenecks,
+            conv3,
+        })
+    }
+
+    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        let mut a = self.conv1.forward(x);
+        for b in &self.bottlenecks {
+            a = b.forward(&a);
+        }
+        let b = self.conv2.forward(x);
+        let sum = mlxcel_core::add(&a, &b);
+        match &self.conv3 {
+            Some(c) => c.forward(&sum),
+            None => sum,
+        }
+    }
+}
+
+/// The hybrid encoder.
+pub struct HybridEncoder {
+    aifi: Vec<Aifi>,
+    encode_proj_layers: Vec<usize>,
+    lateral_convs: Vec<ConvNorm>,
+    fpn_blocks: Vec<CspRepLayer>,
+    downsample_convs: Vec<ConvNorm>,
+    pan_blocks: Vec<CspRepLayer>,
+}
+
+impl HybridEncoder {
+    pub fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        cfg: &RtDetrV2Config,
+    ) -> Result<Self, String> {
+        let act = Activation::parse(&cfg.activation_function)?;
+        let eps = cfg.batch_norm_eps;
+        let num_levels = cfg.num_levels();
+        let num_fpn = num_levels - 1;
+
+        let mut aifi = Vec::with_capacity(cfg.encode_proj_layers.len());
+        for i in 0..cfg.encode_proj_layers.len() {
+            aifi.push(Aifi::from_weights(
+                weights,
+                &format!("{prefix}.aifi.{i}"),
+                cfg,
+            )?);
+        }
+
+        let mut lateral_convs = Vec::with_capacity(num_fpn);
+        let mut fpn_blocks = Vec::with_capacity(num_fpn);
+        for i in 0..num_fpn {
+            lateral_convs.push(ConvNorm::from_weights(
+                weights,
+                &format!("{prefix}.lateral_convs.{i}"),
+                1,
+                0,
+                act,
+                eps,
+            )?);
+            fpn_blocks.push(CspRepLayer::from_weights(
+                weights,
+                &format!("{prefix}.fpn_blocks.{i}"),
+                3,
+                act,
+                eps,
+            )?);
+        }
+
+        let mut downsample_convs = Vec::with_capacity(num_fpn);
+        let mut pan_blocks = Vec::with_capacity(num_fpn);
+        for i in 0..num_fpn {
+            downsample_convs.push(ConvNorm::from_weights(
+                weights,
+                &format!("{prefix}.downsample_convs.{i}"),
+                2,
+                1,
+                act,
+                eps,
+            )?);
+            pan_blocks.push(CspRepLayer::from_weights(
+                weights,
+                &format!("{prefix}.pan_blocks.{i}"),
+                3,
+                act,
+                eps,
+            )?);
+        }
+
+        Ok(Self {
+            aifi,
+            encode_proj_layers: cfg.encode_proj_layers.clone(),
+            lateral_convs,
+            fpn_blocks,
+            downsample_convs,
+            pan_blocks,
+        })
+    }
+
+    /// `features`: one NHWC map per level. Returns `num_levels` fused maps.
+    pub fn forward(&self, features: Vec<UniquePtr<MlxArray>>) -> Vec<UniquePtr<MlxArray>> {
+        let mut feats = features;
+
+        // AIFI on each level in encode_proj_layers.
+        for (i, &lvl) in self.encode_proj_layers.iter().enumerate() {
+            feats[lvl] = self.aifi[i].forward(&feats[lvl]);
+        }
+
+        // Top-down FPN.
+        let num_fpn = self.lateral_convs.len();
+        let mut fpn: Vec<UniquePtr<MlxArray>> = vec![mlxcel_core::copy(&feats[feats.len() - 1])];
+        for idx in 0..num_fpn {
+            let backbone_feat = &feats[num_fpn - idx - 1];
+            let top_feat = self.lateral_convs[idx].forward(&fpn[fpn.len() - 1]);
+            // Overwrite the last FPN entry with the lateral-projected feature.
+            let last = fpn.len() - 1;
+            fpn[last] = mlxcel_core::copy(&top_feat);
+            let up = upsample_nearest_2x(&top_feat);
+            let fused = mlxcel_core::concatenate(&up, backbone_feat, 3);
+            fpn.push(self.fpn_blocks[idx].forward(&fused));
+        }
+        fpn.reverse();
+
+        // Bottom-up PAN.
+        let num_pan = self.downsample_convs.len();
+        let mut pan: Vec<UniquePtr<MlxArray>> = vec![mlxcel_core::copy(&fpn[0])];
+        for idx in 0..num_pan {
+            let down = self.downsample_convs[idx].forward(&pan[pan.len() - 1]);
+            let up = &fpn[idx + 1];
+            let fused = mlxcel_core::concatenate(&down, up, 3);
+            pan.push(self.pan_blocks[idx].forward(&fused));
+        }
+        pan
+    }
+}
+
+/// Load a `LayerNorm` (weight + bias) from `{prefix}.weight` / `{prefix}.bias`.
+pub fn load_layer_norm(weights: &WeightMap, prefix: &str, eps: f32) -> Result<LayerNorm, String> {
+    let weight = copy_weight(weights, &format!("{prefix}.weight"))?;
+    let bias = copy_weight_opt(weights, &format!("{prefix}.bias"));
+    Ok(LayerNorm::new(weight, bias, eps))
+}

--- a/src/vision/detection/rt_detr_v2/layers.rs
+++ b/src/vision/detection/rt_detr_v2/layers.rs
@@ -1,0 +1,402 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared low-level building blocks for the RT-DETRv2 vision tower.
+//!
+//! These primitives (Conv2d, inference BatchNorm, max/avg pool, nearest
+//! upsample, `grid_sample`) are not all exposed by `mlxcel-core`, so they are
+//! composed here from the available array ops. All tensors are NHWC.
+//!
+//! `grid_sample` follows PyTorch `mode="bilinear", padding_mode="zeros",
+//! align_corners=False`, the exact semantics the upstream Metal kernel and its
+//! pure-MLX fallback implement (see
+//! `references/mlx-vlm/mlx_vlm/models/kernels.py::grid_sample`).
+
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+use super::common::copy_weight;
+
+/// Resolve an activation name to a closure. `None` -> identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Activation {
+    Relu,
+    Silu,
+    Gelu,
+    None,
+}
+
+impl Activation {
+    pub fn parse(name: &str) -> Result<Self, String> {
+        match name {
+            "relu" => Ok(Activation::Relu),
+            "silu" => Ok(Activation::Silu),
+            "gelu" => Ok(Activation::Gelu),
+            other => Err(format!("Unsupported activation: {other}")),
+        }
+    }
+
+    pub fn apply(self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        match self {
+            Activation::Relu => mlxcel_core::relu(x),
+            Activation::Silu => mlxcel_core::silu(x),
+            // RT-DETRv2 uses exact (erf) GELU, matching nn.GELU() default.
+            Activation::Gelu => mlxcel_core::gelu(x),
+            Activation::None => mlxcel_core::copy(x),
+        }
+    }
+}
+
+/// 2D convolution (no bias) loaded from a single `*.weight` key. The weight is
+/// stored in MLX NHWC layout `(out, kH, kW, in)`.
+pub struct Conv2d {
+    weight: UniquePtr<MlxArray>,
+    stride: i32,
+    padding: i32,
+}
+
+impl Conv2d {
+    pub fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        stride: i32,
+        padding: i32,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            weight: copy_weight(weights, &format!("{prefix}.weight"))?,
+            stride,
+            padding,
+        })
+    }
+
+    pub fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        mlxcel_core::conv2d(
+            x,
+            &self.weight,
+            self.stride,
+            self.stride,
+            self.padding,
+            self.padding,
+            1,
+            1,
+            1,
+        )
+    }
+}
+
+/// Inference-time BatchNorm over the channel (last) axis of an NHWC tensor:
+/// `y = (x - running_mean) / sqrt(running_var + eps) * weight + bias`.
+///
+/// Used by every conv block in the ResNet backbone and the hybrid encoder.
+pub struct BatchNorm {
+    weight: UniquePtr<MlxArray>,
+    bias: UniquePtr<MlxArray>,
+    running_mean: UniquePtr<MlxArray>,
+    running_var: UniquePtr<MlxArray>,
+    eps: f32,
+}
+
+impl BatchNorm {
+    pub fn from_weights(weights: &WeightMap, prefix: &str, eps: f32) -> Result<Self, String> {
+        Ok(Self {
+            weight: copy_weight(weights, &format!("{prefix}.weight"))?,
+            bias: copy_weight(weights, &format!("{prefix}.bias"))?,
+            running_mean: copy_weight(weights, &format!("{prefix}.running_mean"))?,
+            running_var: copy_weight(weights, &format!("{prefix}.running_var"))?,
+            eps,
+        })
+    }
+
+    pub fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        let centered = mlxcel_core::subtract(x, &self.running_mean);
+        let eps_arr = mlxcel_core::full_f32(&[1], self.eps, mlxcel_core::array_dtype(x));
+        let var_eps = mlxcel_core::add(&self.running_var, &eps_arr);
+        let inv_std = mlxcel_core::rsqrt(&var_eps);
+        let scaled = mlxcel_core::multiply(&centered, &inv_std);
+        let with_weight = mlxcel_core::multiply(&scaled, &self.weight);
+        mlxcel_core::add(&with_weight, &self.bias)
+    }
+}
+
+/// Conv2d (no bias) + BatchNorm + optional activation. The most common block in
+/// the model; the backbone `RTDetrResNetConvLayer` and the hybrid-encoder
+/// `RTDetrV2ConvNormLayer` both reduce to this once weights are renamed (both
+/// surface `.conv.` / `.bn.` sub-keys).
+pub struct ConvNorm {
+    conv: Conv2d,
+    bn: BatchNorm,
+    act: Activation,
+}
+
+impl ConvNorm {
+    pub fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        stride: i32,
+        padding: i32,
+        act: Activation,
+        eps: f32,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            conv: Conv2d::from_weights(weights, &format!("{prefix}.conv"), stride, padding)?,
+            bn: BatchNorm::from_weights(weights, &format!("{prefix}.bn"), eps)?,
+            act,
+        })
+    }
+
+    pub fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        let y = self.conv.forward(x);
+        let y = self.bn.forward(&y);
+        self.act.apply(&y)
+    }
+}
+
+/// 1x1 Conv (no bias) + BatchNorm, no activation. Used by `ShortCut`,
+/// `EncoderInputProj`, and `DecoderInputProj`.
+pub struct ConvBn {
+    conv: Conv2d,
+    bn: BatchNorm,
+}
+
+impl ConvBn {
+    pub fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        stride: i32,
+        eps: f32,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            // kernel 1x1 -> padding 0.
+            conv: Conv2d::from_weights(weights, &format!("{prefix}.conv"), stride, 0)?,
+            bn: BatchNorm::from_weights(weights, &format!("{prefix}.bn"), eps)?,
+        })
+    }
+
+    pub fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        self.bn.forward(&self.conv.forward(x))
+    }
+}
+
+/// Average pool 2x2 stride 2 (vd downsampling shortcut), via the `mlxcel-core`
+/// depthwise-conv-backed `avg_pool2d`.
+pub fn avg_pool_2x2(x: &MlxArray) -> UniquePtr<MlxArray> {
+    mlxcel_core::avg_pool2d(x, 2, 2, 2, 2, 0, 0)
+}
+
+/// Max pool 3x3 stride 2 padding 1 over an NHWC tensor (ResNet-vd stem
+/// `pooler`).
+///
+/// `mlxcel-core` exposes `avg_pool2d` but not `max_pool2d`, so this composes
+/// the op from `pad` + gather + element-wise `maximum`. The padded border is
+/// filled with a large negative sentinel so it never wins the max (PyTorch
+/// MaxPool2d uses `-inf` padding). Output positions are
+/// `out = floor((H + 2*pad - kernel) / stride) + 1`, matching PyTorch.
+pub fn max_pool_3x3_s2_p1(x: &MlxArray) -> UniquePtr<MlxArray> {
+    max_pool2d(x, 3, 2, 1)
+}
+
+/// General square max pool over NHWC. `kernel`/`stride`/`pad` are scalar
+/// (square). See [`max_pool_3x3_s2_p1`] for the algorithm note.
+pub fn max_pool2d(x: &MlxArray, kernel: i32, stride: i32, pad: i32) -> UniquePtr<MlxArray> {
+    let shape = mlxcel_core::array_shape(x);
+    debug_assert_eq!(shape.len(), 4, "max_pool2d expects NHWC");
+    let (h, w) = (shape[1], shape[2]);
+
+    // Pad H and W with a large-negative sentinel; channels/batch untouched.
+    // NEG sentinel: avoid true -inf to keep arithmetic well-defined under f16.
+    const NEG: f32 = -1.0e30;
+    let padded = mlxcel_core::pad(x, &[0, 0, pad, pad, pad, pad, 0, 0], NEG);
+
+    let out_h = (h + 2 * pad - kernel) / stride + 1;
+    let out_w = (w + 2 * pad - kernel) / stride + 1;
+
+    // For each kernel offset (ky, kx), gather the strided window slice
+    // [B, out_h, out_w, C] and fold it into the running max.
+    let mut acc: Option<UniquePtr<MlxArray>> = None;
+    for ky in 0..kernel {
+        // Row indices into the padded tensor: ky + stride * [0..out_h).
+        let h_idx: Vec<i32> = (0..out_h).map(|o| ky + stride * o).collect();
+        let h_idx_arr = mlxcel_core::from_slice_i32(&h_idx, &[out_h]);
+        // Gather along H (axis 1).
+        let rows = mlxcel_core::take(&padded, &h_idx_arr, 1);
+        for kx in 0..kernel {
+            let w_idx: Vec<i32> = (0..out_w).map(|o| kx + stride * o).collect();
+            let w_idx_arr = mlxcel_core::from_slice_i32(&w_idx, &[out_w]);
+            // Gather along W (axis 2) of the row-gathered tensor.
+            let cell = mlxcel_core::take(&rows, &w_idx_arr, 2);
+            acc = Some(match acc {
+                None => cell,
+                Some(prev) => mlxcel_core::maximum(&prev, &cell),
+            });
+        }
+    }
+    acc.expect("max_pool2d kernel must be >= 1")
+}
+
+/// Nearest-neighbour 2x upsample of an NHWC tensor along H and W.
+///
+/// Matches `references/.../vision.py::_upsample_nearest_2x`:
+/// `broadcast x[:, :, None, :, None, :] -> (B, H, 2, W, 2, C)` then reshape.
+pub fn upsample_nearest_2x(x: &MlxArray) -> UniquePtr<MlxArray> {
+    let shape = mlxcel_core::array_shape(x);
+    let (b, h, w, c) = (shape[0], shape[1], shape[2], shape[3]);
+    // Insert singleton axes at positions 2 and 4 -> (B, H, 1, W, 1, C).
+    let expanded = mlxcel_core::expand_dims_multi(x, &[2, 4]);
+    let broadcast = mlxcel_core::broadcast_to(&expanded, &[b, h, 2, w, 2, c]);
+    mlxcel_core::reshape(&broadcast, &[b, h * 2, w * 2, c])
+}
+
+/// Bilinear `grid_sample` over an NHWC tensor with `padding_mode="zeros"` and
+/// `align_corners=False`.
+///
+/// Args:
+/// - `x`: `(B, H, W, C)`.
+/// - `grid`: `(B, gN, gM, 2)`, normalized to `[-1, 1]` (last dim is `(gx, gy)`).
+///
+/// Returns `(B, gN, gM, C)`. This is a faithful Rust port of the pure-MLX
+/// fallback `_grid_sample_mlx` in
+/// `references/mlx-vlm/mlx_vlm/models/kernels.py`, which is numerically
+/// identical to the upstream Metal kernel.
+pub fn grid_sample(x: &MlxArray, grid: &MlxArray) -> UniquePtr<MlxArray> {
+    let xs = mlxcel_core::array_shape(x);
+    let gs = mlxcel_core::array_shape(grid);
+    let (b, h, w, c) = (xs[0], xs[1], xs[2], xs[3]);
+    let (g_n, g_m) = (gs[1], gs[2]);
+
+    let dtype = mlxcel_core::array_dtype(x);
+    let f = |v: f32| mlxcel_core::full_f32(&[1], v, dtype);
+
+    // Split grid into x / y components, each (B, gN, gM). Slice the last axis
+    // then drop the size-1 trailing dim via reshape (not `squeeze`, which would
+    // collapse *all* unit dims).
+    let grid_x = slice_last(grid, 0, 1, &gs);
+    let grid_y = slice_last(grid, 1, 2, &gs);
+    let grid_x = mlxcel_core::reshape(&grid_x, &[b, g_n, g_m]);
+    let grid_y = mlxcel_core::reshape(&grid_y, &[b, g_n, g_m]);
+
+    // Unnormalize to pixel coords: ix = ((gx + 1) * W - 1) / 2.
+    let ix = {
+        let t = mlxcel_core::add(&grid_x, &f(1.0));
+        let t = mlxcel_core::multiply_scalar(&t, w as f32);
+        let t = mlxcel_core::subtract(&t, &f(1.0));
+        mlxcel_core::divide_scalar(&t, 2.0)
+    };
+    let iy = {
+        let t = mlxcel_core::add(&grid_y, &f(1.0));
+        let t = mlxcel_core::multiply_scalar(&t, h as f32);
+        let t = mlxcel_core::subtract(&t, &f(1.0));
+        mlxcel_core::divide_scalar(&t, 2.0)
+    };
+
+    let ix0 = mlxcel_core::floor(&ix);
+    let iy0 = mlxcel_core::floor(&iy);
+    let one = f(1.0);
+    let ix1 = mlxcel_core::add(&ix0, &one);
+    let iy1 = mlxcel_core::add(&iy0, &one);
+
+    // Bilinear weights (each (B, gN, gM)).
+    let wa = mlxcel_core::multiply(
+        &mlxcel_core::subtract(&ix1, &ix),
+        &mlxcel_core::subtract(&iy1, &iy),
+    );
+    let wb = mlxcel_core::multiply(
+        &mlxcel_core::subtract(&ix, &ix0),
+        &mlxcel_core::subtract(&iy1, &iy),
+    );
+    let wc = mlxcel_core::multiply(
+        &mlxcel_core::subtract(&ix1, &ix),
+        &mlxcel_core::subtract(&iy, &iy0),
+    );
+    let wd = mlxcel_core::multiply(
+        &mlxcel_core::subtract(&ix, &ix0),
+        &mlxcel_core::subtract(&iy, &iy0),
+    );
+
+    let x_flat = mlxcel_core::reshape(x, &[b, h * w, c]);
+
+    // Gather one bilinear corner: zero out-of-bounds, clip indices, gather.
+    let gather = |yy: &MlxArray, xx: &MlxArray| -> UniquePtr<MlxArray> {
+        let h_arr = f(h as f32);
+        let w_arr = f(w as f32);
+        let zero = mlxcel_core::full_f32(&[1], 0.0, dtype);
+        let hm1 = f((h - 1) as f32);
+        let wm1 = f((w - 1) as f32);
+
+        // valid = (yy>=0)&(yy<H)&(xx>=0)&(xx<W) as 0/1 float mask.
+        let vy_lo = ge(yy, &zero, dtype);
+        let vy_hi = lt(yy, &h_arr, dtype);
+        let vx_lo = ge(xx, &zero, dtype);
+        let vx_hi = lt(xx, &w_arr, dtype);
+        let valid = mlxcel_core::multiply(
+            &mlxcel_core::multiply(&vy_lo, &vy_hi),
+            &mlxcel_core::multiply(&vx_lo, &vx_hi),
+        ); // (B, gN, gM)
+
+        let yy_c = mlxcel_core::clip(yy, &zero, &hm1);
+        let xx_c = mlxcel_core::clip(xx, &zero, &wm1);
+        // flat index = yy_c * W + xx_c, as int32, shape (B, gN*gM).
+        let idx = mlxcel_core::add(&mlxcel_core::multiply(&yy_c, &w_arr), &xx_c);
+        let idx = mlxcel_core::astype(&idx, mlxcel_core::dtype::INT32);
+        let idx = mlxcel_core::reshape(&idx, &[b, g_n * g_m]);
+        // Expand index to (B, gN*gM, C) and gather along axis 1.
+        let idx = mlxcel_core::expand_dims(&idx, 2);
+        let idx = mlxcel_core::broadcast_to(&idx, &[b, g_n * g_m, c]);
+        let vals = mlxcel_core::take_along_axis(&x_flat, &idx, 1); // (B, gN*gM, C)
+        let vals = mlxcel_core::reshape(&vals, &[b, g_n, g_m, c]);
+        // Multiply by validity mask (broadcast over channel).
+        let valid = mlxcel_core::expand_dims(&valid, 3); // (B, gN, gM, 1)
+        mlxcel_core::multiply(&vals, &valid)
+    };
+
+    // Weighted sum of the four corners; weights need a trailing channel axis.
+    let wch = |wt: &MlxArray| mlxcel_core::expand_dims(wt, 3);
+    let term_a = mlxcel_core::multiply(&wch(&wa), &gather(&iy0, &ix0));
+    let term_b = mlxcel_core::multiply(&wch(&wb), &gather(&iy0, &ix1));
+    let term_c = mlxcel_core::multiply(&wch(&wc), &gather(&iy1, &ix0));
+    let term_d = mlxcel_core::multiply(&wch(&wd), &gather(&iy1, &ix1));
+
+    let s1 = mlxcel_core::add(&term_a, &term_b);
+    let s2 = mlxcel_core::add(&term_c, &term_d);
+    mlxcel_core::add(&s1, &s2)
+}
+
+/// Slice `[start, stop)` along the last axis, preserving rank.
+fn slice_last(a: &MlxArray, start: i32, stop: i32, shape: &[i32]) -> UniquePtr<MlxArray> {
+    let last = shape.len() - 1;
+    let mut starts: Vec<i32> = vec![0; shape.len()];
+    let mut stops: Vec<i32> = shape.to_vec();
+    starts[last] = start;
+    stops[last] = stop;
+    mlxcel_core::slice(a, &starts, &stops)
+}
+
+/// Element-wise `a >= b` as a 0/1 float mask in `dtype`.
+fn ge(a: &MlxArray, b: &MlxArray, dtype: i32) -> UniquePtr<MlxArray> {
+    // a >= b  <=>  NOT (a < b). Use maximum trick: (a >= b) = (maximum(a,b)==a).
+    // Simpler: compute via where_cond on a boolean from subtraction sign.
+    // diff = a - b; mask = diff >= 0. We synthesize the comparison with
+    // clip-free arithmetic: sign-based using `maximum`.
+    let one = mlxcel_core::full_f32(&[1], 1.0, dtype);
+    let zero = mlxcel_core::full_f32(&[1], 0.0, dtype);
+    let cond = mlxcel_core::greater_equal(a, b);
+    mlxcel_core::where_cond(&cond, &one, &zero)
+}
+
+/// Element-wise `a < b` as a 0/1 float mask in `dtype`.
+fn lt(a: &MlxArray, b: &MlxArray, dtype: i32) -> UniquePtr<MlxArray> {
+    let one = mlxcel_core::full_f32(&[1], 1.0, dtype);
+    let zero = mlxcel_core::full_f32(&[1], 0.0, dtype);
+    let cond = mlxcel_core::less(a, b);
+    mlxcel_core::where_cond(&cond, &one, &zero)
+}

--- a/src/vision/detection/rt_detr_v2/mod.rs
+++ b/src/vision/detection/rt_detr_v2/mod.rs
@@ -1,0 +1,55 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! RT-DETRv2 real-time object-detection model.
+//!
+//! A full Rust port of the upstream mlx-vlm RT-DETRv2 model (PR #1195,
+//! `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/`). Architecture:
+//!
+//! ```text
+//! Image (NHWC) -> ResNet-50/101-vd backbone (strides 8/16/32)
+//!              -> per-level 1x1 conv+BN encoder input projection
+//!              -> HybridEncoder: AIFI (deepest level) + FPN + PAN
+//!              -> encoder query selection (top-K over flat positions x labels)
+//!              -> deformable-attention decoder (iterative bbox refinement)
+//!              -> {pred_logits (B, Q, num_labels), pred_boxes (B, Q, 4)}
+//! ```
+//!
+//! Unlike text/VLM models, RT-DETRv2 produces bounding boxes rather than a
+//! token stream, so it lives outside the `LanguageModel`/generate flow. It is
+//! driven through [`RtDetrV2Predictor`] (see the `detect` CLI subcommand).
+//!
+//! The whole forward path runs in float32 for box-coordinate precision,
+//! regardless of the stored checkpoint dtype (the shipped checkpoints are
+//! bf16). This matches the reference, whose dtype-sensitive ops (softmax, SDPA,
+//! anchor logits) are computed in f32 and whose predictor reads f32 anyway.
+
+pub mod backbone;
+pub mod common;
+pub mod config;
+pub mod hybrid_encoder;
+pub mod layers;
+pub mod model;
+pub mod predictor;
+pub mod processor;
+pub mod sanitize;
+pub mod transformer;
+
+#[cfg(test)]
+mod tests;
+
+pub use config::{BackboneConfig, RtDetrV2Config};
+pub use model::{DetectionOutput, RtDetrV2Model};
+pub use predictor::{DEFAULT_THRESHOLD, Detection, DetectionResult, RtDetrV2Predictor};
+pub use processor::{ProcessorConfig, RtDetrV2Processor};

--- a/src/vision/detection/rt_detr_v2/model.rs
+++ b/src/vision/detection/rt_detr_v2/model.rs
@@ -1,0 +1,247 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Top-level RT-DETRv2 model: vision tower (backbone + hybrid encoder) ->
+//! per-level decoder input projection -> encoder query selection -> deformable
+//! decoder.
+//!
+//! Port of `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/rt_detr_v2.py`.
+
+use std::path::Path;
+
+use mlxcel_core::layers::{LayerNorm, Linear};
+use mlxcel_core::weights::{WeightMap, load_weights_from_dir};
+use mlxcel_core::{MlxArray, UniquePtr};
+
+use super::backbone::Backbone;
+use super::common::to_f32;
+use super::config::RtDetrV2Config;
+use super::hybrid_encoder::{HybridEncoder, load_layer_norm};
+use super::layers::ConvBn;
+use super::sanitize;
+use super::transformer::{Decoder, Mlp, SpatialShape, generate_anchors};
+
+/// The vision tower: backbone -> per-level 1x1 conv+BN input projection ->
+/// hybrid encoder.
+struct VisionTower {
+    backbone: Backbone,
+    encoder_input_proj: Vec<ConvBn>,
+    hybrid_encoder: HybridEncoder,
+}
+
+impl VisionTower {
+    fn from_weights(weights: &WeightMap, cfg: &RtDetrV2Config) -> Result<Self, String> {
+        let eps = cfg.batch_norm_eps;
+        let backbone = Backbone::from_weights(weights, "vision.backbone", cfg.backbone(), eps)?;
+        let mut encoder_input_proj = Vec::with_capacity(cfg.num_levels());
+        for i in 0..cfg.num_levels() {
+            encoder_input_proj.push(ConvBn::from_weights(
+                weights,
+                &format!("vision.encoder_input_proj.{i}"),
+                1,
+                eps,
+            )?);
+        }
+        let hybrid_encoder = HybridEncoder::from_weights(weights, "vision.hybrid_encoder", cfg)?;
+        Ok(Self {
+            backbone,
+            encoder_input_proj,
+            hybrid_encoder,
+        })
+    }
+
+    fn forward(&self, pixel_values: &MlxArray) -> Vec<UniquePtr<MlxArray>> {
+        let c_features = self.backbone.forward(pixel_values);
+        let proj: Vec<UniquePtr<MlxArray>> = self
+            .encoder_input_proj
+            .iter()
+            .zip(c_features.iter())
+            .map(|(p, c)| p.forward(c))
+            .collect();
+        self.hybrid_encoder.forward(proj)
+    }
+}
+
+/// Detection forward output: pre-decode logits and normalized boxes.
+pub struct DetectionOutput {
+    /// (B, num_queries, num_labels).
+    pub pred_logits: UniquePtr<MlxArray>,
+    /// (B, num_queries, 4) normalized (cx, cy, w, h) in [0, 1].
+    pub pred_boxes: UniquePtr<MlxArray>,
+}
+
+/// The full RT-DETRv2 detection model.
+pub struct RtDetrV2Model {
+    config: RtDetrV2Config,
+    vision: VisionTower,
+    decoder_input_proj: Vec<ConvBn>,
+    enc_output_fc: Linear,
+    enc_output_ln: LayerNorm,
+    enc_score_head: Linear,
+    enc_bbox_head: Mlp,
+    decoder: Decoder,
+}
+
+impl RtDetrV2Model {
+    /// Load a model from a directory containing `config.json` and one or more
+    /// `*.safetensors`. Accepts both pre-converted MLX checkpoints and raw HF
+    /// `RTDetrV2ForObjectDetection` checkpoints (the rename pipeline runs only
+    /// when [`sanitize::needs_sanitize`] detects HF layout).
+    pub fn load<P: AsRef<Path>>(dir: P) -> Result<Self, String> {
+        let dir = dir.as_ref();
+        let config_path = dir.join("config.json");
+        let config_str = std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("failed to read {}: {e}", config_path.display()))?;
+        let config = RtDetrV2Config::from_json_str(&config_str)?;
+        config.validate()?;
+
+        let raw = load_weights_from_dir(dir)?;
+        let weights = if sanitize::needs_sanitize(&raw) {
+            sanitize::sanitize(raw)
+        } else {
+            raw
+        };
+
+        Self::from_weights(weights, config)
+    }
+
+    /// Build the model from an already-sanitized (MLX-layout) weight map.
+    pub fn from_weights(weights: WeightMap, config: RtDetrV2Config) -> Result<Self, String> {
+        let eps = config.batch_norm_eps;
+        let ln_eps = config.layer_norm_eps;
+        let d = config.d_model;
+
+        let vision = VisionTower::from_weights(&weights, &config)?;
+
+        let mut decoder_input_proj = Vec::with_capacity(config.decoder_in_channels.len());
+        for i in 0..config.decoder_in_channels.len() {
+            decoder_input_proj.push(ConvBn::from_weights(
+                &weights,
+                &format!("decoder_input_proj.{i}"),
+                1,
+                eps,
+            )?);
+        }
+
+        let enc_output_fc = Linear::from_weights(&weights, "enc_output.fc")?;
+        let enc_output_ln = load_layer_norm(&weights, "enc_output.ln", ln_eps)?;
+        let enc_score_head = Linear::from_weights(&weights, "enc_score_head")?;
+        let enc_bbox_head = Mlp::from_weights(&weights, "enc_bbox_head", 3)?;
+        let decoder = Decoder::from_weights(&weights, "decoder", &config)?;
+
+        // `denoising_class_embed` is training-only; intentionally not loaded.
+        let _ = d;
+
+        Ok(Self {
+            config,
+            vision,
+            decoder_input_proj,
+            enc_output_fc,
+            enc_output_ln,
+            enc_score_head,
+            enc_bbox_head,
+            decoder,
+        })
+    }
+
+    pub fn config(&self) -> &RtDetrV2Config {
+        &self.config
+    }
+
+    /// Forward pass.
+    ///
+    /// `pixel_values`: (B, image_size, image_size, 3) NHWC in [0, 1]. The whole
+    /// graph runs in f32 for box-coordinate precision regardless of the stored
+    /// checkpoint dtype.
+    pub fn forward(&self, pixel_values: &MlxArray) -> DetectionOutput {
+        let pixel_values = to_f32(pixel_values);
+        let enc_features = self.vision.forward(&pixel_values);
+
+        // Per-level decoder input projection (1x1 conv + BN).
+        let proj: Vec<UniquePtr<MlxArray>> = self
+            .decoder_input_proj
+            .iter()
+            .zip(enc_features.iter())
+            .map(|(p, f)| p.forward(f))
+            .collect();
+
+        let spatial_shapes: Vec<SpatialShape> = proj
+            .iter()
+            .map(|f| {
+                let s = mlxcel_core::array_shape(f);
+                (s[1], s[2])
+            })
+            .collect();
+
+        // Flatten each level (B, H*W, C) and concatenate along the token axis.
+        let mut flat = {
+            let s = mlxcel_core::array_shape(&proj[0]);
+            mlxcel_core::reshape(&proj[0], &[s[0], s[1] * s[2], s[3]])
+        };
+        for f in proj.iter().skip(1) {
+            let s = mlxcel_core::array_shape(f);
+            let r = mlxcel_core::reshape(f, &[s[0], s[1] * s[2], s[3]]);
+            flat = mlxcel_core::concatenate(&flat, &r, 1);
+        }
+
+        // Encoder query selection: score every position, take top-K.
+        let (anchors, valid_mask) = generate_anchors(&spatial_shapes);
+        // memory = flat * valid_mask (broadcast over channels).
+        let memory = mlxcel_core::multiply(&flat, &valid_mask);
+        let output_memory = self
+            .enc_output_ln
+            .forward(&self.enc_output_fc.forward(&memory));
+        let enc_scores = self.enc_score_head.forward(&output_memory); // (B, S, num_labels)
+        let enc_coord_logits =
+            mlxcel_core::add(&self.enc_bbox_head.forward(&output_memory), &anchors); // (B, S, 4)
+
+        let k = self.config.num_queries as i32;
+        // scores_max over labels (axis -1) -> (B, S).
+        let scores_max = mlxcel_core::max_axis(&enc_scores, -1, false);
+        // top-K indices: argpartition on -scores then take first K, then sort.
+        let neg_scores = mlxcel_core::multiply_scalar(&scores_max, -1.0);
+        let part = mlxcel_core::argpartition(&neg_scores, k - 1, 1); // (B, S)
+        let topk_idx = slice_first_k(&part, k); // (B, K)
+        let topk_scores = mlxcel_core::take_along_axis(&scores_max, &topk_idx, 1); // (B, K)
+        let order = mlxcel_core::argsort(&mlxcel_core::multiply_scalar(&topk_scores, -1.0), 1);
+        let topk_idx = mlxcel_core::take_along_axis(&topk_idx, &order, 1); // (B, K) sorted
+
+        let s0 = mlxcel_core::array_shape(&topk_idx)[0];
+        // Gather reference points: idx broadcast to (B, K, 4).
+        let gather_idx_b =
+            mlxcel_core::broadcast_to(&mlxcel_core::expand_dims(&topk_idx, 2), &[s0, k, 4]);
+        let ref_points_unact = mlxcel_core::take_along_axis(&enc_coord_logits, &gather_idx_b, 1); // (B, K, 4)
+
+        // Gather target content: idx broadcast to (B, K, D).
+        let d_model = mlxcel_core::array_shape(&output_memory)[2];
+        let gather_idx_d =
+            mlxcel_core::broadcast_to(&mlxcel_core::expand_dims(&topk_idx, 2), &[s0, k, d_model]);
+        let target = mlxcel_core::take_along_axis(&output_memory, &gather_idx_d, 1); // (B, K, D)
+
+        let dec = self
+            .decoder
+            .forward(&target, &ref_points_unact, &flat, &spatial_shapes);
+
+        DetectionOutput {
+            pred_logits: dec.pred_logits,
+            pred_boxes: dec.pred_boxes,
+        }
+    }
+}
+
+/// Slice the first `k` entries along axis 1 of a 2D index array `(B, S)`.
+fn slice_first_k(idx: &MlxArray, k: i32) -> UniquePtr<MlxArray> {
+    let shape = mlxcel_core::array_shape(idx);
+    mlxcel_core::slice(idx, &[0, 0], &[shape[0], k])
+}

--- a/src/vision/detection/rt_detr_v2/predictor.rs
+++ b/src/vision/detection/rt_detr_v2/predictor.rs
@@ -1,0 +1,175 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! RT-DETRv2 postprocessing and predictor.
+//!
+//! Port of `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/generate.py`. The
+//! predictor runs the model on one image and decodes detections: it does a flat
+//! top-K over the `(queries x labels)` score space (so one query can yield
+//! multiple detections — matching `RTDetrImageProcessor.post_process_object_
+//! detection` for `use_focal_loss=True` models), thresholds, and converts the
+//! normalized `(cx, cy, w, h)` boxes to `(l, t, r, b)` pixel coordinates in the
+//! original image.
+
+use std::path::Path;
+
+use mlxcel_core::MlxArray;
+
+use super::model::RtDetrV2Model;
+use super::processor::RtDetrV2Processor;
+
+/// Default confidence threshold (matches the upstream predictor).
+pub const DEFAULT_THRESHOLD: f32 = 0.3;
+
+/// One detected box.
+#[derive(Debug, Clone)]
+pub struct Detection {
+    /// `(left, top, right, bottom)` in original-image pixel coordinates.
+    pub bbox: [f32; 4],
+    /// Confidence in `[0, 1]`.
+    pub score: f32,
+    /// Integer class id.
+    pub label: usize,
+    /// Human-readable class name (resolved via `config.id2label`, else the
+    /// stringified id).
+    pub class_name: String,
+}
+
+/// All detections for one image.
+#[derive(Debug, Clone, Default)]
+pub struct DetectionResult {
+    pub detections: Vec<Detection>,
+}
+
+/// Inference wrapper over [`RtDetrV2Model`] + [`RtDetrV2Processor`].
+pub struct RtDetrV2Predictor {
+    model: RtDetrV2Model,
+    processor: RtDetrV2Processor,
+    threshold: f32,
+    labels: Option<Vec<String>>,
+}
+
+impl RtDetrV2Predictor {
+    /// Build a predictor from a model directory.
+    pub fn from_pretrained<P: AsRef<Path>>(dir: P, threshold: f32) -> Result<Self, String> {
+        let dir = dir.as_ref();
+        let model = RtDetrV2Model::load(dir)?;
+        let processor = RtDetrV2Processor::from_pretrained(dir)?;
+        let labels = model.config().class_names();
+        Ok(Self {
+            model,
+            processor,
+            threshold,
+            labels,
+        })
+    }
+
+    pub fn model(&self) -> &RtDetrV2Model {
+        &self.model
+    }
+
+    /// Detect objects in one image file.
+    pub fn predict_path<P: AsRef<Path>>(&self, path: P) -> Result<DetectionResult, String> {
+        let processed = self.processor.process_path(path)?;
+        let out = self.model.forward(&processed.pixel_values);
+        let (img_w, img_h) = processed.original_size;
+
+        let logits_shape = mlxcel_core::array_shape(&out.pred_logits);
+        // (B, Q, num_labels) — batch is 1.
+        let q = logits_shape[1] as usize;
+        let num_labels = logits_shape[2] as usize;
+
+        let logits = to_f32_vec(&out.pred_logits); // length B*Q*num_labels
+        let boxes = to_f32_vec(&out.pred_boxes); // length B*Q*4
+
+        let detections =
+            self.decode_one(&logits, &boxes, q, num_labels, img_w as f32, img_h as f32);
+        Ok(DetectionResult { detections })
+    }
+
+    /// Top-K extraction across the flat `(queries x labels)` score space.
+    fn decode_one(
+        &self,
+        logits: &[f32],
+        boxes: &[f32],
+        q: usize,
+        num_labels: usize,
+        img_w: f32,
+        img_h: f32,
+    ) -> Vec<Detection> {
+        // scores = sigmoid(logits), flattened to q*num_labels.
+        let flat_len = q * num_labels;
+        let mut scored: Vec<(usize, f32)> = Vec::with_capacity(flat_len);
+        for (i, &l) in logits.iter().take(flat_len).enumerate() {
+            scored.push((i, sigmoid(l)));
+        }
+        // Top-K = top-`q` by score (upstream takes k = min(Q, flat.size) = Q).
+        let k = q.min(flat_len);
+        // Partial sort: select the k highest scores, then sort descending.
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(k);
+
+        let mut detections = Vec::new();
+        for (flat_idx, score) in scored {
+            if score < self.threshold {
+                continue;
+            }
+            let query = flat_idx / num_labels;
+            let label = flat_idx % num_labels;
+
+            // box = boxes[query] = (cx, cy, w, h) normalized.
+            let bx = query * 4;
+            let cx = boxes[bx] * img_w;
+            let cy = boxes[bx + 1] * img_h;
+            let bw = boxes[bx + 2] * img_w;
+            let bh = boxes[bx + 3] * img_h;
+            let x1 = (cx - bw / 2.0).clamp(0.0, img_w);
+            let y1 = (cy - bh / 2.0).clamp(0.0, img_h);
+            let x2 = (cx + bw / 2.0).clamp(0.0, img_w);
+            let y2 = (cy + bh / 2.0).clamp(0.0, img_h);
+
+            let class_name = match &self.labels {
+                Some(names) if label < names.len() => names[label].clone(),
+                _ => label.to_string(),
+            };
+
+            detections.push(Detection {
+                bbox: [x1, y1, x2, y2],
+                score,
+                label,
+                class_name,
+            });
+        }
+        detections
+    }
+}
+
+fn sigmoid(x: f32) -> f32 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+/// Materialize an MLX array and read it back as a row-major `Vec<f32>`.
+///
+/// The forward path produces f32 outputs, so a direct 4-byte LE parse is
+/// correct. `contiguous` guarantees row-major before extraction.
+fn to_f32_vec(arr: &MlxArray) -> Vec<f32> {
+    let contiguous = mlxcel_core::contiguous(arr, false);
+    let c = contiguous.as_ref().expect("contiguous returned null");
+    mlxcel_core::eval(c);
+    let bytes = mlxcel_core::array_to_raw_bytes(c);
+    bytes
+        .chunks_exact(4)
+        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .collect()
+}

--- a/src/vision/detection/rt_detr_v2/processor.rs
+++ b/src/vision/detection/rt_detr_v2/processor.rs
@@ -1,0 +1,194 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! RT-DETRv2 image preprocessing.
+//!
+//! Port of `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/processing_rt_detr_v2.py`:
+//! resize to `image_size` (bilinear), rescale by `rescale_factor` (1/255), and
+//! optionally normalize with `image_mean` / `image_std`. The default
+//! RT-DETRv2 preprocessor does NOT normalize (`do_normalize: false`); silently
+//! adding mean/std subtraction is the classic way to get subtly-wrong outputs,
+//! so the flag is read from `preprocessor_config.json` and defaulted to false.
+
+use std::path::Path;
+
+use mlxcel_core::{MlxArray, UniquePtr};
+use serde::Deserialize;
+
+const DEFAULT_IMAGE_SIZE: usize = 640;
+const DEFAULT_RESCALE: f32 = 1.0 / 255.0;
+
+/// Preprocessing configuration parsed from `preprocessor_config.json`.
+#[derive(Debug, Clone)]
+pub struct ProcessorConfig {
+    pub image_size: usize,
+    pub rescale_factor: f32,
+    pub do_normalize: bool,
+    pub image_mean: [f32; 3],
+    pub image_std: [f32; 3],
+}
+
+impl Default for ProcessorConfig {
+    fn default() -> Self {
+        Self {
+            image_size: DEFAULT_IMAGE_SIZE,
+            rescale_factor: DEFAULT_RESCALE,
+            do_normalize: false,
+            image_mean: [0.485, 0.456, 0.406],
+            image_std: [0.229, 0.224, 0.225],
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSize {
+    #[serde(default)]
+    height: Option<usize>,
+    #[serde(default)]
+    width: Option<usize>,
+    #[serde(default)]
+    shortest_edge: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPreprocessor {
+    #[serde(default)]
+    size: Option<RawSize>,
+    #[serde(default)]
+    rescale_factor: Option<f32>,
+    #[serde(default)]
+    do_normalize: Option<bool>,
+    #[serde(default)]
+    image_mean: Option<Vec<f32>>,
+    #[serde(default)]
+    image_std: Option<Vec<f32>>,
+}
+
+impl ProcessorConfig {
+    /// Build a processor config from a model directory. Reads
+    /// `preprocessor_config.json` when present; otherwise falls back to
+    /// `config.json`'s `image_size` for the resize target.
+    pub fn from_pretrained<P: AsRef<Path>>(dir: P) -> Result<Self, String> {
+        let dir = dir.as_ref();
+        let mut cfg = ProcessorConfig::default();
+
+        let preproc_path = dir.join("preprocessor_config.json");
+        if preproc_path.is_file() {
+            let raw_str = std::fs::read_to_string(&preproc_path)
+                .map_err(|e| format!("failed to read {}: {e}", preproc_path.display()))?;
+            let pp: RawPreprocessor = serde_json::from_str(&raw_str)
+                .map_err(|e| format!("preprocessor_config parse error: {e}"))?;
+            if let Some(size) = pp.size
+                && let Some(h) = size.height.or(size.shortest_edge).or(size.width)
+            {
+                cfg.image_size = h;
+            }
+            if let Some(r) = pp.rescale_factor {
+                cfg.rescale_factor = r;
+            }
+            if let Some(n) = pp.do_normalize {
+                cfg.do_normalize = n;
+            }
+            if let Some(m) = pp.image_mean
+                && m.len() == 3
+            {
+                cfg.image_mean = [m[0], m[1], m[2]];
+            }
+            if let Some(s) = pp.image_std
+                && s.len() == 3
+            {
+                cfg.image_std = [s[0], s[1], s[2]];
+            }
+        } else {
+            let config_path = dir.join("config.json");
+            if config_path.is_file()
+                && let Ok(s) = std::fs::read_to_string(&config_path)
+                && let Ok(v) = serde_json::from_str::<serde_json::Value>(&s)
+                && let Some(sz) = v.get("image_size").and_then(|x| x.as_u64())
+            {
+                cfg.image_size = sz as usize;
+            }
+        }
+        Ok(cfg)
+    }
+}
+
+/// Output of preprocessing one image.
+pub struct ProcessedImage {
+    /// (1, image_size, image_size, 3) NHWC in [0, 1] (or normalized).
+    pub pixel_values: UniquePtr<MlxArray>,
+    /// Original `(width, height)` for rescaling boxes back to pixel coords.
+    pub original_size: (u32, u32),
+}
+
+/// RT-DETRv2 image preprocessor.
+pub struct RtDetrV2Processor {
+    config: ProcessorConfig,
+}
+
+impl RtDetrV2Processor {
+    pub fn new(config: ProcessorConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn from_pretrained<P: AsRef<Path>>(dir: P) -> Result<Self, String> {
+        Ok(Self::new(ProcessorConfig::from_pretrained(dir)?))
+    }
+
+    pub fn config(&self) -> &ProcessorConfig {
+        &self.config
+    }
+
+    /// Load and preprocess an image file.
+    pub fn process_path<P: AsRef<Path>>(&self, path: P) -> Result<ProcessedImage, String> {
+        let img = image::open(path.as_ref())
+            .map_err(|e| format!("failed to open image {}: {e}", path.as_ref().display()))?;
+        Ok(self.process_image(&img))
+    }
+
+    /// Preprocess a decoded image.
+    pub fn process_image(&self, image: &image::DynamicImage) -> ProcessedImage {
+        let rgb = image.to_rgb8();
+        let original_size = (rgb.width(), rgb.height());
+
+        let size = self.config.image_size as u32;
+        // PIL `Image.Resampling.BILINEAR` == triangle (linear) kernel.
+        let resized =
+            image::imageops::resize(&rgb, size, size, image::imageops::FilterType::Triangle);
+
+        let n = (size * size) as usize;
+        let mut data = vec![0f32; n * 3];
+        let rescale = self.config.rescale_factor;
+        let do_norm = self.config.do_normalize;
+        let mean = self.config.image_mean;
+        let std = self.config.image_std;
+
+        for (i, px) in resized.pixels().enumerate() {
+            let base = i * 3;
+            for c in 0..3 {
+                let mut v = px[c] as f32 * rescale;
+                if do_norm {
+                    v = (v - mean[c]) / std[c];
+                }
+                data[base + c] = v;
+            }
+        }
+
+        let pixel_values = mlxcel_core::from_slice_f32(&data, &[1, size as i32, size as i32, 3]);
+        ProcessedImage {
+            pixel_values,
+            original_size,
+        }
+    }
+}

--- a/src/vision/detection/rt_detr_v2/sanitize.rs
+++ b/src/vision/detection/rt_detr_v2/sanitize.rs
@@ -1,0 +1,316 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! HuggingFace -> MLX weight-key translation for RT-DETRv2.
+//!
+//! Mirrors the rename pipeline in
+//! `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/convert.py` (the single
+//! source of truth upstream). Two transformations are applied per key:
+//!
+//!   1. Name rewrite: strip the `model.` prefix, then apply submodule-specific
+//!      substring/prefix rules in order.
+//!   2. Conv2d weight layout transpose: PyTorch `(out, in, kH, kW)` ->
+//!      MLX NHWC `(out, kH, kW, in)` for any `*.conv.weight` 4D tensor.
+//!
+//! Keys matching `DROP_PATTERNS` (`*.num_batches_tracked`) are dropped — MLX
+//! BatchNorm has no slot for that counter.
+//!
+//! Pre-converted mlx-community checkpoints already carry MLX-layout keys (and
+//! NHWC conv weights), so [`needs_sanitize`] returns `false` for them and the
+//! pipeline is skipped — re-running it would double-transpose conv weights.
+
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+const HF_PREFIX: &str = "model.";
+
+/// Decide whether a freshly-loaded weight map is in raw HuggingFace layout and
+/// therefore needs the rename + transpose pipeline.
+///
+/// MLX-layout checkpoints (produced by `convert.py` or shipped as
+/// `mlx-community/*-mlx-*`) surface keys under `vision.backbone.` /
+/// `decoder.layers.`; raw HF checkpoints surface `model.backbone.` /
+/// `backbone.model.` / `model.decoder.` and the `*.convolution.` /
+/// `*.normalization.` field names. We sniff a few unambiguous markers.
+pub fn needs_sanitize(weights: &WeightMap) -> bool {
+    let mut has_mlx_marker = false;
+    let mut has_hf_marker = false;
+    for key in weights.keys() {
+        if key.starts_with("vision.backbone.") || key.starts_with("vision.hybrid_encoder.") {
+            has_mlx_marker = true;
+        }
+        if key.starts_with("model.backbone.")
+            || key.starts_with("backbone.model.")
+            || key.contains(".convolution.")
+            || key.contains(".normalization.")
+            || key.starts_with("model.decoder.")
+            || key.starts_with("model.encoder.")
+        {
+            has_hf_marker = true;
+        }
+        // Early out once both decisions are unambiguous.
+        if has_mlx_marker {
+            return false;
+        }
+        if has_hf_marker {
+            return true;
+        }
+    }
+    // No markers at all: treat as already-MLX (no-op) to avoid corrupting an
+    // unexpected layout.
+    has_hf_marker
+}
+
+/// True when `key` (already stripped of the `model.` prefix) should be dropped.
+fn should_drop(stripped: &str) -> bool {
+    stripped.ends_with(".num_batches_tracked")
+}
+
+/// Strip the leading `model.` prefix HF uses on the whole module tree.
+fn strip_prefix(key: &str) -> &str {
+    key.strip_prefix(HF_PREFIX).unwrap_or(key)
+}
+
+/// Apply the ordered rename rules to a prefix-stripped key.
+///
+/// Order matters: later rules can rely on earlier ones having fired (e.g. the
+/// generic `encoder.` -> `vision.hybrid_encoder.` rule runs *after* the more
+/// specific `encoder.encoder.` -> AIFI rule and the `encoder_input_proj`
+/// rules). This is a 1:1 port of `convert.RENAMES`.
+fn rename_stripped(key: &str) -> String {
+    let mut out = key.to_string();
+
+    // Backbone: HF wraps the ResNet body in `backbone.model.X`.
+    out = replace_prefix(&out, "backbone.model.", "vision.backbone.");
+
+    // vd downsampling shortcut: Sequential[AvgPool, ShortCut] indexes the
+    // inner ShortCut at `.1.` (AvgPool at `.0.` has no params).
+    out = out.replace(".shortcut.1.", ".shortcut.proj.");
+
+    // RTDetrResNetConvLayer field names.
+    out = out.replace(".convolution.", ".conv.");
+    out = out.replace(".normalization.", ".bn.");
+
+    // AIFI keys on disk are prefixed `encoder.encoder.` (older HF naming).
+    out = replace_prefix(&out, "encoder.encoder.", "vision.hybrid_encoder.aifi.");
+
+    // encoder_input_proj is Sequential[Conv, BN]: `.{N}.0.X` / `.{N}.1.X`.
+    out = rename_indexed_seq(&out, "encoder_input_proj.", "vision.encoder_input_proj.");
+
+    // Hybrid encoder body (FPN/PAN/laterals/downsamples): all under `encoder.*`.
+    out = replace_prefix(&out, "encoder.", "vision.hybrid_encoder.");
+
+    // RTDetrV2ConvNormLayer field rename (`.norm.` -> `.bn.`).
+    out = out.replace(".norm.", ".bn.");
+
+    // decoder_input_proj is also Sequential[Conv, BN].
+    out = rename_indexed_seq(&out, "decoder_input_proj.", "decoder_input_proj.");
+
+    // enc_output is Sequential[Linear, LayerNorm].
+    out = replace_prefix(&out, "enc_output.0.", "enc_output.fc.");
+    out = replace_prefix(&out, "enc_output.1.", "enc_output.ln.");
+
+    out
+}
+
+/// `replace_prefix(s, from, to)` rewrites `s` only if it starts with `from`.
+fn replace_prefix(s: &str, from: &str, to: &str) -> String {
+    match s.strip_prefix(from) {
+        Some(rest) => format!("{to}{rest}"),
+        None => s.to_string(),
+    }
+}
+
+/// Rewrite a `Sequential[Conv, BN]` block stored as `{base}{N}.0.X` /
+/// `{base}{N}.1.X` into `{dest}{N}.conv.X` / `{dest}{N}.bn.X`.
+///
+/// Mirrors the two `^{base}(\d+)\.0\.` / `\.1\.` regex rules in `convert.py`,
+/// but without a regex engine: it only fires when the key starts with `base`
+/// followed by an integer index and then `.0.` or `.1.`.
+fn rename_indexed_seq(key: &str, base: &str, dest: &str) -> String {
+    let Some(rest) = key.strip_prefix(base) else {
+        return key.to_string();
+    };
+    // rest = "{N}.0.X" or "{N}.1.X" (or something else, left untouched).
+    let Some(dot) = rest.find('.') else {
+        return key.to_string();
+    };
+    let (idx, tail) = rest.split_at(dot);
+    if idx.is_empty() || !idx.bytes().all(|b| b.is_ascii_digit()) {
+        return key.to_string();
+    }
+    if let Some(after) = tail.strip_prefix(".0.") {
+        format!("{dest}{idx}.conv.{after}")
+    } else if let Some(after) = tail.strip_prefix(".1.") {
+        format!("{dest}{idx}.bn.{after}")
+    } else {
+        key.to_string()
+    }
+}
+
+/// Translate one HF key to its MLX form (prefix-strip + rename rules).
+pub fn rename_key(key: &str) -> String {
+    rename_stripped(strip_prefix(key))
+}
+
+/// Run the full sanitize pipeline over `weights`, returning a new map with
+/// MLX-layout keys, conv weights transposed to NHWC, and `num_batches_tracked`
+/// counters dropped. Consumes the input map.
+pub fn sanitize(weights: WeightMap) -> WeightMap {
+    let mut out: WeightMap = WeightMap::with_capacity(weights.len());
+    for (k, v) in weights {
+        let stripped = strip_prefix(&k);
+        if should_drop(stripped) {
+            continue;
+        }
+        let new_key = rename_stripped(stripped);
+        let value = maybe_transpose_conv(&new_key, v);
+        out.insert(new_key, value);
+    }
+    out
+}
+
+/// PyTorch conv weights are `(out, in, kH, kW)`; MLX wants NHWC
+/// `(out, kH, kW, in)`. Transpose any 4D `*.conv.weight`.
+fn maybe_transpose_conv(key: &str, value: UniquePtr<MlxArray>) -> UniquePtr<MlxArray> {
+    if key.ends_with(".conv.weight") {
+        let shape = mlxcel_core::array_shape(&value);
+        if shape.len() == 4 {
+            return mlxcel_core::transpose_axes(&value, &[0, 2, 3, 1]);
+        }
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_model_prefix() {
+        assert_eq!(strip_prefix("model.foo.bar"), "foo.bar");
+        assert_eq!(strip_prefix("foo.bar"), "foo.bar");
+    }
+
+    #[test]
+    fn backbone_rename() {
+        assert_eq!(
+            rename_key("model.backbone.model.embedder.embedder.0.convolution.weight"),
+            "vision.backbone.embedder.embedder.0.conv.weight"
+        );
+        assert_eq!(
+            rename_key("model.backbone.model.embedder.embedder.0.normalization.running_mean"),
+            "vision.backbone.embedder.embedder.0.bn.running_mean"
+        );
+    }
+
+    #[test]
+    fn vd_shortcut_rename() {
+        assert_eq!(
+            rename_key(
+                "model.backbone.model.encoder.stages.1.layers.0.shortcut.1.convolution.weight"
+            ),
+            "vision.backbone.encoder.stages.1.layers.0.shortcut.proj.conv.weight"
+        );
+    }
+
+    #[test]
+    fn aifi_rename() {
+        assert_eq!(
+            rename_key("model.encoder.encoder.0.layers.0.self_attn.q_proj.weight"),
+            "vision.hybrid_encoder.aifi.0.layers.0.self_attn.q_proj.weight"
+        );
+    }
+
+    #[test]
+    fn encoder_input_proj_seq_rename() {
+        assert_eq!(
+            rename_key("model.encoder_input_proj.0.0.weight"),
+            "vision.encoder_input_proj.0.conv.weight"
+        );
+        assert_eq!(
+            rename_key("model.encoder_input_proj.2.1.running_var"),
+            "vision.encoder_input_proj.2.bn.running_var"
+        );
+    }
+
+    #[test]
+    fn hybrid_encoder_body_and_norm_rename() {
+        assert_eq!(
+            rename_key("model.encoder.lateral_convs.0.norm.weight"),
+            "vision.hybrid_encoder.lateral_convs.0.bn.weight"
+        );
+    }
+
+    #[test]
+    fn decoder_input_proj_and_enc_output_rename() {
+        assert_eq!(
+            rename_key("model.decoder_input_proj.1.0.weight"),
+            "decoder_input_proj.1.conv.weight"
+        );
+        assert_eq!(
+            rename_key("model.decoder_input_proj.1.1.bias"),
+            "decoder_input_proj.1.bn.bias"
+        );
+        assert_eq!(
+            rename_key("model.enc_output.0.weight"),
+            "enc_output.fc.weight"
+        );
+        assert_eq!(rename_key("model.enc_output.1.bias"), "enc_output.ln.bias");
+    }
+
+    #[test]
+    fn decoder_layers_passthrough() {
+        // Decoder layer keys have no `model.` content rules beyond prefix strip.
+        assert_eq!(
+            rename_key("model.decoder.layers.0.self_attn.q_proj.weight"),
+            "decoder.layers.0.self_attn.q_proj.weight"
+        );
+        assert_eq!(
+            rename_key("model.decoder.bbox_embed.0.layers.2.weight"),
+            "decoder.bbox_embed.0.layers.2.weight"
+        );
+    }
+
+    #[test]
+    fn drop_num_batches_tracked() {
+        assert!(should_drop(
+            "vision.backbone.embedder.embedder.0.bn.num_batches_tracked"
+        ));
+        assert!(!should_drop(
+            "vision.backbone.embedder.embedder.0.bn.running_mean"
+        ));
+    }
+
+    #[test]
+    fn needs_sanitize_detects_layout() {
+        // We can't construct MlxArrays cheaply here; test the key-marker logic
+        // through a small synthetic map keyed by name only is enough because
+        // needs_sanitize never dereferences the values.
+        // (Values are required by the type, so build trivial scalars.)
+        let mut mlx_map: WeightMap = WeightMap::new();
+        mlx_map.insert(
+            "vision.backbone.embedder.embedder.0.conv.weight".to_string(),
+            mlxcel_core::zeros(&[1], mlxcel_core::dtype::FLOAT32),
+        );
+        assert!(!needs_sanitize(&mlx_map));
+
+        let mut hf_map: WeightMap = WeightMap::new();
+        hf_map.insert(
+            "model.backbone.model.embedder.embedder.0.convolution.weight".to_string(),
+            mlxcel_core::zeros(&[1], mlxcel_core::dtype::FLOAT32),
+        );
+        assert!(needs_sanitize(&hf_map));
+    }
+}

--- a/src/vision/detection/rt_detr_v2/tests.rs
+++ b/src/vision/detection/rt_detr_v2/tests.rs
@@ -1,0 +1,140 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for RT-DETRv2 primitives that don't require a checkpoint.
+//!
+//! These exercise the host-side helpers (anchor generation, the composed
+//! pooling / upsample / grid_sample ops) against hand-computed references so a
+//! regression in the math surfaces without a multi-hundred-MB model download.
+
+use mlxcel_core::MlxArray;
+
+use super::layers::{grid_sample, max_pool_3x3_s2_p1, upsample_nearest_2x};
+use super::transformer::{generate_anchors, inverse_sigmoid};
+
+/// Read a small MLX array to a row-major `Vec<f32>`.
+fn read_f32(arr: &MlxArray) -> Vec<f32> {
+    let c = mlxcel_core::contiguous(arr, false);
+    let c = c.as_ref().unwrap();
+    mlxcel_core::eval(c);
+    mlxcel_core::array_to_raw_bytes(c)
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+#[test]
+fn upsample_nearest_2x_doubles_hw() {
+    // (1, 2, 2, 1) with values [[1,2],[3,4]] -> (1, 4, 4, 1) nearest.
+    let data = [1.0f32, 2.0, 3.0, 4.0];
+    let x = mlxcel_core::from_slice_f32(&data, &[1, 2, 2, 1]);
+    let up = upsample_nearest_2x(&x);
+    let shape = mlxcel_core::array_shape(&up);
+    assert_eq!(shape, vec![1, 4, 4, 1]);
+    let v = read_f32(&up);
+    // Row 0: 1 1 2 2 ; Row 1: 1 1 2 2 ; Row 2: 3 3 4 4 ; Row 3: 3 3 4 4.
+    let expected = [
+        1.0, 1.0, 2.0, 2.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 3.0, 3.0, 4.0, 4.0,
+    ];
+    for (a, b) in v.iter().zip(expected.iter()) {
+        assert!((a - b).abs() < 1e-6, "got {a}, want {b}");
+    }
+}
+
+#[test]
+fn max_pool_3x3_s2_p1_on_4x4() {
+    // 4x4 ramp 0..16, single channel. With kernel 3, stride 2, pad 1 ->
+    // out = floor((4 + 2 - 3) / 2) + 1 = 2x2.
+    let data: Vec<f32> = (0..16).map(|i| i as f32).collect();
+    let x = mlxcel_core::from_slice_f32(&data, &[1, 4, 4, 1]);
+    let pooled = max_pool_3x3_s2_p1(&x);
+    let shape = mlxcel_core::array_shape(&pooled);
+    assert_eq!(shape, vec![1, 2, 2, 1]);
+    // Padded grid (pad=1) has the 4x4 ramp centered; window centers at output
+    // (0,0) cover rows -1..1, cols -1..1 -> max of {0,1,4,5} = 5.
+    // (0,1) cover cols 1..3 -> max of {1,2,3,5,6,7} = 7.
+    // (1,0) -> max of {4,5,8,9,12,13} = 13.
+    // (1,1) -> max of {5,6,7,9,10,11,13,14,15} = 15.
+    let v = read_f32(&pooled);
+    assert_eq!(v, vec![5.0, 7.0, 13.0, 15.0]);
+}
+
+#[test]
+fn grid_sample_center_is_bilinear_mean() {
+    // 2x2 single-channel image [[0,1],[2,3]]. Sample at normalized (0,0) which
+    // (align_corners=False) maps to pixel (0.5, 0.5) -> bilinear average of all
+    // four corners = (0+1+2+3)/4 = 1.5.
+    let img = [0.0f32, 1.0, 2.0, 3.0];
+    let x = mlxcel_core::from_slice_f32(&img, &[1, 2, 2, 1]);
+    // grid (1, 1, 1, 2) = (gx=0, gy=0).
+    let grid = mlxcel_core::from_slice_f32(&[0.0, 0.0], &[1, 1, 1, 2]);
+    let out = grid_sample(&x, &grid);
+    let shape = mlxcel_core::array_shape(&out);
+    assert_eq!(shape, vec![1, 1, 1, 1]);
+    let v = read_f32(&out);
+    assert!((v[0] - 1.5).abs() < 1e-5, "got {}", v[0]);
+}
+
+#[test]
+fn grid_sample_out_of_bounds_is_zero_padded() {
+    let img = [5.0f32, 6.0, 7.0, 8.0];
+    let x = mlxcel_core::from_slice_f32(&img, &[1, 2, 2, 1]);
+    // Far outside [-1,1] -> all four corners out of bounds -> zero.
+    let grid = mlxcel_core::from_slice_f32(&[5.0, 5.0], &[1, 1, 1, 2]);
+    let out = grid_sample(&x, &grid);
+    let v = read_f32(&out);
+    assert!(v[0].abs() < 1e-6, "got {}", v[0]);
+}
+
+#[test]
+fn generate_anchors_shapes_and_logit_consistency() {
+    // Two tiny levels: 2x2 and 1x1.
+    let shapes = [(2, 2), (1, 1)];
+    let (anchors, mask) = generate_anchors(&shapes);
+    let a_shape = mlxcel_core::array_shape(&anchors);
+    let m_shape = mlxcel_core::array_shape(&mask);
+    // total = 4 + 1 = 5 positions.
+    assert_eq!(a_shape, vec![1, 5, 4]);
+    assert_eq!(m_shape, vec![1, 5, 1]);
+
+    let a = read_f32(&anchors);
+    let m = read_f32(&mask);
+    // For each valid position, sigmoid(logit) should reconstruct the anchor
+    // center within [eps, 1-eps]; for masked positions the logit is f32::MAX.
+    for (i, &valid) in m.iter().enumerate() {
+        if valid > 0.5 {
+            // first component (cx) sigmoid in (0,1).
+            let s = 1.0 / (1.0 + (-a[i * 4]).exp());
+            assert!(s > 0.0 && s < 1.0);
+        } else {
+            assert_eq!(a[i * 4], f32::MAX);
+        }
+    }
+}
+
+#[test]
+fn inverse_sigmoid_is_logit() {
+    // inverse_sigmoid(0.5) == log(0.5/0.5) == 0.
+    let x = mlxcel_core::from_slice_f32(&[0.5], &[1]);
+    let out = inverse_sigmoid(&x, 1e-5);
+    let v = read_f32(&out);
+    assert!(v[0].abs() < 1e-4, "got {}", v[0]);
+
+    // inverse_sigmoid then sigmoid round-trips a mid-range value.
+    let x = mlxcel_core::from_slice_f32(&[0.73], &[1]);
+    let inv = inverse_sigmoid(&x, 1e-5);
+    let back = mlxcel_core::sigmoid(&inv);
+    let v = read_f32(&back);
+    assert!((v[0] - 0.73).abs() < 1e-4, "got {}", v[0]);
+}

--- a/src/vision/detection/rt_detr_v2/transformer.rs
+++ b/src/vision/detection/rt_detr_v2/transformer.rs
@@ -1,0 +1,498 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! RT-DETRv2 transformer: deformable-attention decoder, MLP heads, and the
+//! anchor priors used by encoder query selection.
+//!
+//! Port of `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/transformer.py`.
+//! Multi-scale deformable attention samples each feature level via the shared
+//! bilinear `grid_sample` (see [`super::layers::grid_sample`]) and weighted-sums
+//! across levels with the softmaxed attention weights.
+
+use mlxcel_core::layers::{LayerNorm, Linear};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+use super::config::RtDetrV2Config;
+use super::hybrid_encoder::{SelfAttention, load_layer_norm};
+use super::layers::{Activation, grid_sample};
+
+/// Per-level spatial shape `(H, W)`.
+pub type SpatialShape = (i32, i32);
+
+/// Numerically-stable inverse sigmoid: `log(clip(x) / (1 - clip(x)))`.
+pub fn inverse_sigmoid(x: &MlxArray, eps: f32) -> UniquePtr<MlxArray> {
+    let dt = mlxcel_core::array_dtype(x);
+    let zero = mlxcel_core::full_f32(&[1], 0.0, dt);
+    let one = mlxcel_core::full_f32(&[1], 1.0, dt);
+    let eps_a = mlxcel_core::full_f32(&[1], eps, dt);
+    let x = mlxcel_core::clip(x, &zero, &one);
+    let x1 = mlxcel_core::clip(&x, &eps_a, &one);
+    let one_minus = mlxcel_core::subtract(&one, &x);
+    let x2 = mlxcel_core::clip(&one_minus, &eps_a, &one);
+    mlxcel_core::log(&mlxcel_core::divide(&x1, &x2))
+}
+
+/// Multi-layer perceptron with ReLU between layers. Field `layers` is a list of
+/// `nn.Linear` matching `RTDetrV2MLPPredictionHead` saved keys
+/// `.layers.{i}.{weight,bias}`.
+pub struct Mlp {
+    layers: Vec<Linear>,
+}
+
+impl Mlp {
+    pub fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        num_layers: usize,
+    ) -> Result<Self, String> {
+        let mut layers = Vec::with_capacity(num_layers);
+        for i in 0..num_layers {
+            layers.push(Linear::from_weights(
+                weights,
+                &format!("{prefix}.layers.{i}"),
+            )?);
+        }
+        Ok(Self { layers })
+    }
+
+    pub fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        let n = self.layers.len();
+        let mut h = mlxcel_core::copy(x);
+        for (i, layer) in self.layers.iter().enumerate() {
+            h = layer.forward(&h);
+            if i < n - 1 {
+                h = mlxcel_core::relu(&h);
+            }
+        }
+        h
+    }
+}
+
+/// Multi-scale deformable attention.
+///
+/// Reference points are 4D `(cx, cy, w, h)` normalized to `[0, 1]`. Sampling
+/// offsets are predicted per `(n_heads, n_levels, n_points)` and scaled by
+/// `1/n_points * ref_wh * offset_scale` before being added to the reference
+/// center. Sampling itself is bilinear `grid_sample` per level; outputs are
+/// concatenated and weighted-summed by the softmaxed attention weights.
+struct MsDeformableAttention {
+    sampling_offsets: Linear,
+    attention_weights: Linear,
+    value_proj: Linear,
+    output_proj: Linear,
+    n_heads: i32,
+    head_dim: i32,
+    n_levels: i32,
+    n_points: i32,
+    offset_scale: f32,
+    /// `decoder_method == "default"` maps sampling locations from `[0,1]` to
+    /// `[-1,1]` for grid_sample; `"discrete"` uses them as-is.
+    method_default: bool,
+}
+
+impl MsDeformableAttention {
+    fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        cfg: &RtDetrV2Config,
+    ) -> Result<Self, String> {
+        let d = cfg.d_model;
+        let n_heads = cfg.decoder_attention_heads;
+        Ok(Self {
+            sampling_offsets: Linear::from_weights(weights, &format!("{prefix}.sampling_offsets"))?,
+            attention_weights: Linear::from_weights(
+                weights,
+                &format!("{prefix}.attention_weights"),
+            )?,
+            value_proj: Linear::from_weights(weights, &format!("{prefix}.value_proj"))?,
+            output_proj: Linear::from_weights(weights, &format!("{prefix}.output_proj"))?,
+            n_heads: n_heads as i32,
+            head_dim: (d / n_heads) as i32,
+            n_levels: cfg.decoder_n_levels as i32,
+            n_points: cfg.decoder_n_points as i32,
+            offset_scale: cfg.decoder_offset_scale,
+            method_default: cfg.decoder_method == "default",
+        })
+    }
+
+    /// Args:
+    /// - `query`: (B, Q, D).
+    /// - `reference_points`: (B, Q, 1, 4) center+wh, broadcast across levels.
+    /// - `value`: (B, sum_HW, D) flattened multi-scale encoder features.
+    /// - `spatial_shapes`: per-level (H, W).
+    /// - `pos`: optional (B, Q, D) added to query.
+    fn forward(
+        &self,
+        query: &MlxArray,
+        reference_points: &MlxArray,
+        value: &MlxArray,
+        spatial_shapes: &[SpatialShape],
+        pos: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        let query = match pos {
+            Some(p) => mlxcel_core::add(query, p),
+            None => mlxcel_core::copy(query),
+        };
+        let qshape = mlxcel_core::array_shape(&query);
+        let (b, q, d) = (qshape[0], qshape[1], qshape[2]);
+        let n_heads = self.n_heads;
+        let head_dim = self.head_dim;
+        let total_points = self.n_levels * self.n_points;
+
+        let v_len = mlxcel_core::array_shape(value)[1];
+        let v = self.value_proj.forward(value);
+        let v = mlxcel_core::reshape(&v, &[b, v_len, n_heads, head_dim]);
+
+        let offsets = self.sampling_offsets.forward(&query);
+        let offsets = mlxcel_core::reshape(&offsets, &[b, q, n_heads, total_points, 2]);
+
+        let attn = self.attention_weights.forward(&query);
+        let attn = mlxcel_core::reshape(&attn, &[b, q, n_heads, total_points]);
+        let attn = mlxcel_core::softmax(&attn, -1);
+
+        // n_points_scale = 1/n_points broadcast to (1,1,1,total_points,1).
+        let n_pts_scale = 1.0f32 / self.n_points as f32;
+
+        // ref_xy: (B, Q, 1, 1, 2), ref_wh: (B, Q, 1, 1, 2) by slicing the 4D
+        // reference and inserting the head axis. reference_points is
+        // (B, Q, 1, 4): [:, :, None(level)->kept-as-1, :2] / [..., 2:].
+        let ref_xy = slice_last2(reference_points, 0, 2); // (B,Q,1,2)
+        let ref_wh = slice_last2(reference_points, 2, 4); // (B,Q,1,2)
+        // Insert the head axis at position 2 -> (B,Q,1,1,2).
+        let ref_xy = mlxcel_core::expand_dims(&ref_xy, 2);
+        let ref_wh = mlxcel_core::expand_dims(&ref_wh, 2);
+
+        // loc = ref_xy + offsets * n_pts_scale * ref_wh * offset_scale.
+        let scaled = mlxcel_core::multiply_scalar(&offsets, n_pts_scale * self.offset_scale);
+        let scaled = mlxcel_core::multiply(&scaled, &ref_wh);
+        let loc = mlxcel_core::add(&ref_xy, &scaled); // (B,Q,n_heads,total_points,2)
+
+        // Split loc per level along the points axis (axis 3).
+        // Each level slice: (B,Q,n_heads,n_points,2).
+        let mut sampled_per_level: Vec<UniquePtr<MlxArray>> =
+            Vec::with_capacity(spatial_shapes.len());
+
+        // Build the per-level value chunks (split along axis 1).
+        let mut v_offset = 0i32;
+        for (lvl, &(h, w)) in spatial_shapes.iter().enumerate() {
+            let level_size = h * w;
+            // value chunk: (B, level_size, n_heads, head_dim).
+            let v_chunk = mlxcel_core::slice(
+                &v,
+                &[0, v_offset, 0, 0],
+                &[b, v_offset + level_size, n_heads, head_dim],
+            );
+            v_offset += level_size;
+            // reshape to (B, H, W, n_heads, head_dim), then
+            // transpose(0,3,1,2,4) -> (B,n_heads,H,W,head_dim), then
+            // reshape to (B*n_heads, H, W, head_dim).
+            let v_l = mlxcel_core::reshape(&v_chunk, &[b, h, w, n_heads, head_dim]);
+            let v_l = mlxcel_core::transpose_axes(&v_l, &[0, 3, 1, 2, 4]);
+            let v_l = mlxcel_core::reshape(&v_l, &[b * n_heads, h, w, head_dim]);
+
+            // sampling locations for this level: slice loc points
+            // [lvl*n_points, (lvl+1)*n_points) along axis 3.
+            let p0 = (lvl as i32) * self.n_points;
+            let p1 = p0 + self.n_points;
+            let samp = mlxcel_core::slice(&loc, &[0, 0, 0, p0, 0], &[b, q, n_heads, p1, 2]); // (B,Q,n_heads,n_points,2)
+            // transpose(0,2,1,3,4) -> (B,n_heads,Q,n_points,2), reshape to
+            // (B*n_heads, Q, n_points, 2).
+            let samp = mlxcel_core::transpose_axes(&samp, &[0, 2, 1, 3, 4]);
+            let samp = mlxcel_core::reshape(&samp, &[b * n_heads, q, self.n_points, 2]);
+            let samp = if self.method_default {
+                // 2*samp - 1.
+                let t = mlxcel_core::multiply_scalar(&samp, 2.0);
+                let one = mlxcel_core::full_f32(&[1], 1.0, mlxcel_core::array_dtype(&t));
+                mlxcel_core::subtract(&t, &one)
+            } else {
+                samp
+            };
+            // grid_sample -> (B*n_heads, Q, n_points, head_dim).
+            sampled_per_level.push(grid_sample(&v_l, &samp));
+        }
+
+        // Concatenate along the points axis -> (B*n_heads, Q, total_points, head_dim).
+        let mut sampled = mlxcel_core::copy(&sampled_per_level[0]);
+        for s in sampled_per_level.iter().skip(1) {
+            sampled = mlxcel_core::concatenate(&sampled, s, 2);
+        }
+
+        // attn weights: (B,Q,n_heads,total_points) -> transpose(0,2,1,3) ->
+        // (B,n_heads,Q,total_points) -> reshape (B*n_heads, Q, total_points).
+        let w = mlxcel_core::transpose_axes(&attn, &[0, 2, 1, 3]);
+        let w = mlxcel_core::reshape(&w, &[b * n_heads, q, total_points]);
+        let w = mlxcel_core::expand_dims(&w, 3); // (B*n_heads, Q, total_points, 1)
+
+        // out = (sampled * w).sum(axis=2) -> (B*n_heads, Q, head_dim).
+        let weighted = mlxcel_core::multiply(&sampled, &w);
+        let out = mlxcel_core::sum_axis(&weighted, 2, false);
+        // reshape (B,n_heads,Q,head_dim) -> transpose(0,2,1,3) -> (B,Q,n_heads,head_dim)
+        // -> reshape (B,Q,D).
+        let out = mlxcel_core::reshape(&out, &[b, n_heads, q, head_dim]);
+        let out = mlxcel_core::transpose_axes(&out, &[0, 2, 1, 3]);
+        let out = mlxcel_core::reshape(&out, &[b, q, d]);
+        self.output_proj.forward(&out)
+    }
+}
+
+/// One decoder block: self-attn -> norm -> deformable cross-attn -> norm ->
+/// FFN -> norm.
+struct DecoderLayer {
+    self_attn: SelfAttention,
+    self_attn_ln: LayerNorm,
+    encoder_attn: MsDeformableAttention,
+    encoder_attn_ln: LayerNorm,
+    fc1: Linear,
+    fc2: Linear,
+    final_ln: LayerNorm,
+    act: Activation,
+}
+
+impl DecoderLayer {
+    fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        cfg: &RtDetrV2Config,
+    ) -> Result<Self, String> {
+        let d = cfg.d_model;
+        Ok(Self {
+            self_attn: SelfAttention::from_weights(
+                weights,
+                &format!("{prefix}.self_attn"),
+                d,
+                cfg.decoder_attention_heads,
+            )?,
+            self_attn_ln: load_layer_norm(
+                weights,
+                &format!("{prefix}.self_attn_layer_norm"),
+                cfg.layer_norm_eps,
+            )?,
+            encoder_attn: MsDeformableAttention::from_weights(
+                weights,
+                &format!("{prefix}.encoder_attn"),
+                cfg,
+            )?,
+            encoder_attn_ln: load_layer_norm(
+                weights,
+                &format!("{prefix}.encoder_attn_layer_norm"),
+                cfg.layer_norm_eps,
+            )?,
+            fc1: Linear::from_weights(weights, &format!("{prefix}.fc1"))?,
+            fc2: Linear::from_weights(weights, &format!("{prefix}.fc2"))?,
+            final_ln: load_layer_norm(
+                weights,
+                &format!("{prefix}.final_layer_norm"),
+                cfg.layer_norm_eps,
+            )?,
+            act: Activation::parse(&cfg.decoder_activation_function)?,
+        })
+    }
+
+    fn forward(
+        &self,
+        x: &MlxArray,
+        pos: &MlxArray,
+        encoder_hidden_states: &MlxArray,
+        reference_points: &MlxArray,
+        spatial_shapes: &[SpatialShape],
+    ) -> UniquePtr<MlxArray> {
+        // Self-attention.
+        let residual = mlxcel_core::copy(x);
+        let h = self.self_attn.forward(x, Some(pos));
+        let h = mlxcel_core::add(&residual, &h);
+        let h = self.self_attn_ln.forward(&h);
+
+        // Deformable cross-attention.
+        let residual = mlxcel_core::copy(&h);
+        let c = self.encoder_attn.forward(
+            &h,
+            reference_points,
+            encoder_hidden_states,
+            spatial_shapes,
+            Some(pos),
+        );
+        let h = mlxcel_core::add(&residual, &c);
+        let h = self.encoder_attn_ln.forward(&h);
+
+        // FFN.
+        let residual = mlxcel_core::copy(&h);
+        let f = self.fc2.forward(&self.act.apply(&self.fc1.forward(&h)));
+        let h = mlxcel_core::add(&residual, &f);
+        self.final_ln.forward(&h)
+    }
+}
+
+/// Output of the decoder forward (only the inference-relevant trajectories).
+pub struct DecoderOutput {
+    /// (B, num_queries, num_labels) — last layer logits.
+    pub pred_logits: UniquePtr<MlxArray>,
+    /// (B, num_queries, 4) — last layer reference points (cx,cy,w,h) in [0,1].
+    pub pred_boxes: UniquePtr<MlxArray>,
+}
+
+/// Decoder stack with iterative bbox refinement. Per-layer `bbox_embed`
+/// (3-layer MLP) and `class_embed` (Linear) heads are attached here.
+pub struct Decoder {
+    layers: Vec<DecoderLayer>,
+    query_pos_head: Mlp,
+    bbox_embed: Vec<Mlp>,
+    class_embed: Vec<Linear>,
+    layer_norm_eps: f32,
+}
+
+impl Decoder {
+    pub fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        cfg: &RtDetrV2Config,
+    ) -> Result<Self, String> {
+        let mut layers = Vec::with_capacity(cfg.decoder_layers);
+        for i in 0..cfg.decoder_layers {
+            layers.push(DecoderLayer::from_weights(
+                weights,
+                &format!("{prefix}.layers.{i}"),
+                cfg,
+            )?);
+        }
+        // query_pos_head is a 2-layer MLP (4 -> 2d -> d).
+        let query_pos_head = Mlp::from_weights(weights, &format!("{prefix}.query_pos_head"), 2)?;
+
+        let mut bbox_embed = Vec::with_capacity(cfg.decoder_layers);
+        let mut class_embed = Vec::with_capacity(cfg.decoder_layers);
+        for i in 0..cfg.decoder_layers {
+            bbox_embed.push(Mlp::from_weights(
+                weights,
+                &format!("{prefix}.bbox_embed.{i}"),
+                3,
+            )?);
+            class_embed.push(Linear::from_weights(
+                weights,
+                &format!("{prefix}.class_embed.{i}"),
+            )?);
+        }
+
+        Ok(Self {
+            layers,
+            query_pos_head,
+            bbox_embed,
+            class_embed,
+            layer_norm_eps: cfg.layer_norm_eps,
+        })
+    }
+
+    /// Args:
+    /// - `target`: (B, Q, D) initial query content.
+    /// - `reference_points_unact`: (B, Q, 4) in logit space (pre-sigmoid).
+    /// - `encoder_hidden_states`: (B, sum_HW, D).
+    /// - `spatial_shapes`: per-level (H, W).
+    pub fn forward(
+        &self,
+        target: &MlxArray,
+        reference_points_unact: &MlxArray,
+        encoder_hidden_states: &MlxArray,
+        spatial_shapes: &[SpatialShape],
+    ) -> DecoderOutput {
+        let mut hidden = mlxcel_core::copy(target);
+        let mut ref_points = mlxcel_core::sigmoid(reference_points_unact); // (B,Q,4)
+
+        let mut last_logits: Option<UniquePtr<MlxArray>> = None;
+        let mut last_refs: Option<UniquePtr<MlxArray>> = None;
+
+        for idx in 0..self.layers.len() {
+            // (B, Q, 1, 4) broadcasts across feature levels in cross-attn.
+            let ref_input = mlxcel_core::expand_dims(&ref_points, 2);
+            let pos_embed = self.query_pos_head.forward(&ref_points);
+            hidden = self.layers[idx].forward(
+                &hidden,
+                &pos_embed,
+                encoder_hidden_states,
+                &ref_input,
+                spatial_shapes,
+            );
+
+            let predicted_corners = self.bbox_embed[idx].forward(&hidden);
+            let inv = inverse_sigmoid(&ref_points, 1e-5);
+            let new_refs = mlxcel_core::sigmoid(&mlxcel_core::add(&predicted_corners, &inv));
+            ref_points = mlxcel_core::copy(&new_refs);
+
+            last_refs = Some(new_refs);
+            last_logits = Some(self.class_embed[idx].forward(&hidden));
+        }
+
+        DecoderOutput {
+            pred_logits: last_logits.expect("decoder must have >= 1 layer"),
+            pred_boxes: last_refs.expect("decoder must have >= 1 layer"),
+        }
+    }
+
+    pub fn layer_norm_eps(&self) -> f32 {
+        self.layer_norm_eps
+    }
+}
+
+/// Multi-scale anchor priors for encoder query selection.
+///
+/// Returns `(anchors_logit, valid_mask)` where anchors are `(1, sum_HW, 4)` in
+/// logit space and the mask (`(1, sum_HW, 1)`, 0/1 float) marks positions whose
+/// sigmoid falls in `[eps, 1-eps]`. Built in f32 on the host to mirror
+/// `generate_anchors` exactly (`grid_size=0.05`, `eps=1e-2`).
+pub fn generate_anchors(
+    spatial_shapes: &[SpatialShape],
+) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
+    const GRID_SIZE: f32 = 0.05;
+    const EPS: f32 = 1e-2;
+    let big = f32::MAX;
+
+    let total: usize = spatial_shapes.iter().map(|&(h, w)| (h * w) as usize).sum();
+    let mut anchors_logit = vec![0f32; total * 4];
+    let mut valid_mask = vec![0f32; total];
+
+    let mut pos = 0usize;
+    for (level, &(h, w)) in spatial_shapes.iter().enumerate() {
+        let wh = GRID_SIZE * 2f32.powi(level as i32);
+        for r in 0..h {
+            for col in 0..w {
+                // grid_xy = (col+0.5)/w, (r+0.5)/h ; anchors = [gx, gy, wh, wh].
+                let gx = (col as f32 + 0.5) / w as f32;
+                let gy = (r as f32 + 0.5) / h as f32;
+                let anchor = [gx, gy, wh, wh];
+                // valid if all components in (eps, 1-eps).
+                let valid = anchor.iter().all(|&v| v > EPS && v < 1.0 - EPS);
+                valid_mask[pos] = if valid { 1.0 } else { 0.0 };
+                let base = pos * 4;
+                for (j, &a) in anchor.iter().enumerate() {
+                    // logit = log(a / (1-a)); masked-out positions -> +big.
+                    anchors_logit[base + j] = if valid { (a / (1.0 - a)).ln() } else { big };
+                }
+                pos += 1;
+            }
+        }
+    }
+
+    let anchors = mlxcel_core::from_slice_f32(&anchors_logit, &[1, total as i32, 4]);
+    let mask = mlxcel_core::from_slice_f32(&valid_mask, &[1, total as i32, 1]);
+    (anchors, mask)
+}
+
+/// Slice `[start, stop)` along the last axis of a rank-N array, preserving rank.
+fn slice_last2(a: &MlxArray, start: i32, stop: i32) -> UniquePtr<MlxArray> {
+    let shape = mlxcel_core::array_shape(a);
+    let last = shape.len() - 1;
+    let mut starts: Vec<i32> = vec![0; shape.len()];
+    let mut stops: Vec<i32> = shape.clone();
+    starts[last] = start;
+    stops[last] = stop;
+    mlxcel_core::slice(a, &starts, &stops)
+}

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -29,6 +29,7 @@ use anyhow::Result;
 
 pub mod config;
 pub mod connectors;
+pub mod detection;
 pub mod encoders;
 pub mod feature_cache;
 pub mod merge;


### PR DESCRIPTION
Closes #79

Adds RT-DETRv2, a real-time detection transformer. This is a new task type: the model emits bounding boxes `(left, top, right, bottom, label, confidence)` rather than a token stream, so it lives outside the LanguageModel/generate flow and is exposed through a new top-level `mlxcel detect` subcommand. Ported from the upstream mlx-vlm RT-DETRv2 model (PR #1195).

## Architecture

- ResNet-50-vd / ResNet-101-vd backbone (3-conv stem, stride-2 maxpool, AvgPool-based vd downsampling shortcuts), depth read from the backbone config so both variants share one module.
- Hybrid encoder: AIFI transformer on the deepest level (2D sine position embedding), top-down FPN, bottom-up PAN with RepVGG/CSPRep blocks.
- Encoder query selection (top-K over the flattened position-by-label score space) feeding a six-layer deformable-attention decoder with iterative bbox refinement.
- Multi-scale deformable attention via a pure-MLX bilinear grid_sample (padding zeros, align_corners false).

## Notes

- The forward path runs in float32 for box-coordinate precision; weights stay in their stored dtype (bf16) so float32-input by bf16-weight promotion matches the reference. The HF-to-MLX rename pipeline runs only on raw HF layout, so pre-converted checkpoints load as-is.
- `mlxcel detect` (`--model`, `--image`, `--threshold`, `--format text|json`) is a separate subcommand rather than an overload of `generate`/`serve`, because the output is boxes, not tokens.
- The existing model-type classification module is left untouched; this model registers no new generate-flow model type.

## Files

New `src/vision/detection/rt_detr_v2/` (config, sanitize, layers, backbone, hybrid_encoder, transformer, model, processor, predictor) plus `src/commands/detect.rs` and the `detect` wiring in `src/main.rs`.

## Verification

- `cargo fmt --check` clean.
- `cargo clippy --features metal,accelerate --all-targets -- -D warnings` clean.
- 22 unit tests pass, covering grid_sample, max/avg pool, nearest upsample, anchor generation, the inverse-sigmoid round-trip, the rename pipeline, and config parsing. (No detection checkpoint on this host for an end-to-end run; the numerical kernels are unit-tested.)