### PR TITLE
fix: harden MiniCPM-V 4.6 image grid handling

### DIFF
--- a/src/loading/vlm_special.rs
+++ b/src/loading/vlm_special.rs
@@ -589,7 +589,34 @@ pub(crate) fn load_minicpmv4_6_vlm(model_path: &Path) -> Result<LoadedModel> {
         .and_then(|v| v.as_u64())
         .unwrap_or(448) as usize;
 
-    let processor = MiniCPMOProcessor::new(patch_size, scale_resolution, image_feature_size);
+    let resize_multiple_for_axis = |axis: usize| -> Result<usize> {
+        let vit_factor = vision_config.window_kernel_size[axis].max(1);
+        let merge_factor = model_cfg.merge_kernel_size[axis].max(1);
+        let mut downsample = vit_factor;
+        for _ in 0..model_cfg.merger_times {
+            downsample = downsample.checked_mul(merge_factor).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "MiniCPM-V 4.6 image downsample factor overflowed while building processor"
+                )
+            })?;
+        }
+        patch_size.checked_mul(downsample).ok_or_else(|| {
+            anyhow::anyhow!("MiniCPM-V 4.6 resize alignment overflowed while building processor")
+        })
+    };
+
+    // Upstream MiniCPM-V 4.6 `_find_best_resize` aligns dimensions to
+    // `patch_size * 4` for the default 2x2 VitMerger followed by a 2x2
+    // Merger.  Compute that alignment from config instead of hardcoding 4 so
+    // rectangular images still reserve the same number of text placeholders as
+    // vision tokens emitted by the dynamic grid.
+    let processor = MiniCPMOProcessor::new_with_resize_multiples(
+        patch_size,
+        scale_resolution,
+        image_feature_size,
+        resize_multiple_for_axis(0)?,
+        resize_multiple_for_axis(1)?,
+    );
 
     let eos_token_ids = match full_config.get("eos_token_id") {
         Some(Value::Array(values)) => values

--- a/src/multimodal/minicpmo_prompt.rs
+++ b/src/multimodal/minicpmo_prompt.rs
@@ -41,6 +41,13 @@ pub fn minicpmo_image_placeholder(image_feature_size: usize) -> String {
     )
 }
 
+fn minicpmo_image_placeholders(image_feature_sizes: &[usize]) -> Vec<String> {
+    image_feature_sizes
+        .iter()
+        .map(|&size| minicpmo_image_placeholder(size))
+        .collect()
+}
+
 pub fn count_minicpmo_image_markers(prompt: &str) -> usize {
     prompt.matches(MINICPMO_IMAGE_INLINE_MARKER).count()
         + prompt.matches(MINICPMO_IMAGE_START_TOKEN).count()
@@ -52,7 +59,15 @@ pub fn ensure_minicpmo_image_placeholders(
     num_images: usize,
     image_feature_size: usize,
 ) -> Result<String, String> {
-    let placeholder = minicpmo_image_placeholder(image_feature_size);
+    ensure_minicpmo_image_placeholders_with_sizes(prompt, &vec![image_feature_size; num_images])
+}
+
+pub fn ensure_minicpmo_image_placeholders_with_sizes(
+    prompt: &str,
+    image_feature_sizes: &[usize],
+) -> Result<String, String> {
+    let num_images = image_feature_sizes.len();
+    let placeholders = minicpmo_image_placeholders(image_feature_sizes);
 
     let normalized = prompt.replace(MINICPMO_IMAGE_INLINE_MARKER, MINICPMO_IMAGE_MARKER_SENTINEL);
     let marker_count = normalized.matches(MINICPMO_IMAGE_START_TOKEN).count();
@@ -69,7 +84,17 @@ pub fn ensure_minicpmo_image_placeholders(
                 total_markers, num_images
             ));
         }
-        let expanded = normalized.replace(MINICPMO_IMAGE_MARKER_SENTINEL, &placeholder);
+        let mut expanded = String::with_capacity(
+            normalized.len() + placeholders.iter().map(String::len).sum::<usize>(),
+        );
+        let mut parts = normalized.split(MINICPMO_IMAGE_MARKER_SENTINEL);
+        if let Some(first) = parts.next() {
+            expanded.push_str(first);
+        }
+        for (placeholder, part) in placeholders.iter().zip(parts) {
+            expanded.push_str(placeholder);
+            expanded.push_str(part);
+        }
         // If prompt already has chat formatting, return as-is
         if expanded.contains("<|im_start|>") {
             return Ok(expanded);
@@ -85,7 +110,7 @@ pub fn ensure_minicpmo_image_placeholders(
         return Ok(prompt.to_string());
     }
 
-    let image_prefix = placeholder.repeat(num_images);
+    let image_prefix = placeholders.concat();
     if let Some(pos) = prompt.rfind("<|im_start|>user\n") {
         let insert_pos = pos + "<|im_start|>user\n".len();
         Ok(format!(
@@ -162,7 +187,23 @@ pub fn prepare_minicpmo_prompt_tokens<E>(
 where
     E: FnMut(&str, bool) -> Vec<i32>,
 {
-    let text = ensure_minicpmo_image_placeholders(prompt, num_images, image_feature_size)?;
+    prepare_minicpmo_prompt_tokens_with_image_feature_sizes(
+        prompt,
+        &vec![image_feature_size; num_images],
+        &mut encode,
+    )
+}
+
+pub fn prepare_minicpmo_prompt_tokens_with_image_feature_sizes<E>(
+    prompt: &str,
+    image_feature_sizes: &[usize],
+    mut encode: E,
+) -> Result<MiniCPMOPromptTokens, String>
+where
+    E: FnMut(&str, bool) -> Vec<i32>,
+{
+    let num_images = image_feature_sizes.len();
+    let text = ensure_minicpmo_image_placeholders_with_sizes(prompt, image_feature_sizes)?;
     let tokens = encode(&text, true);
 
     if num_images == 0 {

--- a/src/multimodal/minicpmo_prompt_tests.rs
+++ b/src/multimodal/minicpmo_prompt_tests.rs
@@ -14,8 +14,9 @@
 
 use super::{
     MINICPMO_IMAGE_END_TOKEN, MINICPMO_IMAGE_START_TOKEN, MINICPMO_UNK_TOKEN,
-    compute_minicpmo_image_bounds, ensure_minicpmo_image_placeholders, minicpmo_image_placeholder,
-    prepare_minicpmo_prompt_tokens,
+    compute_minicpmo_image_bounds, ensure_minicpmo_image_placeholders,
+    ensure_minicpmo_image_placeholders_with_sizes, minicpmo_image_placeholder,
+    prepare_minicpmo_prompt_tokens, prepare_minicpmo_prompt_tokens_with_image_feature_sizes,
 };
 
 fn fake_encode(text: &str, add_special: bool) -> Vec<i32> {
@@ -62,6 +63,16 @@ fn ensure_minicpmo_placeholders_replaces_existing_markers() {
 }
 
 #[test]
+fn ensure_minicpmo_placeholders_replaces_markers_with_per_image_sizes() {
+    let prompt = "<|im_start|>user\n<image>first <image>second<|im_end|>";
+    let text = ensure_minicpmo_image_placeholders_with_sizes(prompt, &[2, 4]).unwrap();
+
+    assert!(
+        text.contains("<image><unk><unk></image>first <image><unk><unk><unk><unk></image>second")
+    );
+}
+
+#[test]
 fn ensure_minicpmo_placeholders_inserts_after_user_tag_when_missing() {
     let prompt = "<|im_start|>user\nDescribe this.<|im_end|>";
     let text = ensure_minicpmo_image_placeholders(prompt, 1, 2).unwrap();
@@ -95,4 +106,24 @@ fn prepare_minicpmo_prompt_tokens_encodes_prompt_and_bounds() {
         &prepared.tokens[image_start_pos..=image_end_pos],
         &[10, 12, 12, 12, 11]
     );
+}
+
+#[test]
+fn prepare_minicpmo_prompt_tokens_uses_per_image_feature_sizes() {
+    let prepared = prepare_minicpmo_prompt_tokens_with_image_feature_sizes(
+        "<|im_start|>user\n<image> A <image> B<|im_end|>",
+        &[2, 4],
+        fake_encode,
+    )
+    .unwrap();
+
+    assert_eq!(prepared.image_slots, 2);
+    assert_eq!(prepared.image_bounds.len(), 2);
+
+    let spans: Vec<usize> = prepared
+        .image_bounds
+        .iter()
+        .map(|&(start, end)| end - start)
+        .collect();
+    assert_eq!(spans, vec![2, 4]);
 }

--- a/src/multimodal/vlm_runtime.rs
+++ b/src/multimodal/vlm_runtime.rs
@@ -26,7 +26,9 @@ use image::DynamicImage;
 use mlxcel_core::MlxArray;
 
 use crate::internvl_prompt::insert_internvl_image_tokens;
-use crate::minicpmo_prompt::prepare_minicpmo_prompt_tokens;
+use crate::minicpmo_prompt::{
+    prepare_minicpmo_prompt_tokens, prepare_minicpmo_prompt_tokens_with_image_feature_sizes,
+};
 use crate::moondream3_prompt::{Moondream3PromptMode, prepare_moondream3_prompt_tokens};
 use crate::phi3v_prompt::prepare_phi3v_prompt_tokens;
 use crate::phi4_siglip_prompt::prepare_phi4_siglip_prompt_tokens;
@@ -314,16 +316,24 @@ where
         // (`<image><unk>...<unk></image>`) but uses Qwen3.5 text backbone +
         // the VitMerger+Merger vision pipeline instead of the resampler.
         VlmRuntimeRef::MiniCPMV46(minicpmv46) => {
-            let prepared = prepare_minicpmo_prompt_tokens(
+            let processed_images = minicpmv46.processor.preprocess(images);
+            let image_feature_sizes: Vec<usize> = processed_images
+                .iter()
+                .map(|processed| {
+                    minicpmv46
+                        .image_feature_size_for_processed(processed)
+                        .map_err(|err| anyhow::anyhow!("{}", err))
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let prepared = prepare_minicpmo_prompt_tokens_with_image_feature_sizes(
                 prompt,
-                images.len(),
-                minicpmv46.processor.image_feature_size,
+                &image_feature_sizes,
                 &mut encode,
             )
             .map_err(|err| anyhow::anyhow!("{}", err))?;
             *prompt_tokens = prepared.tokens;
 
-            let processed_images = minicpmv46.processor.preprocess(images);
             let input_ids_arr = prompt_ids_array(prompt_tokens);
             let embeddings = minicpmv46.get_input_embeddings(
                 &input_ids_arr,

--- a/src/vision/encoders/minicpmv4_6.rs
+++ b/src/vision/encoders/minicpmv4_6.rs
@@ -251,6 +251,11 @@ impl VitMerger {
     ) -> Result<Self, String> {
         let group_h = merge_group_size[0];
         let group_w = merge_group_size[1];
+        if group_h == 0 || group_w == 0 {
+            return Err(
+                "MiniCPM-V 4.6 VitMerger window_kernel_size entries must be positive".to_string(),
+            );
+        }
         let group_tokens = (group_h * group_w) as i32;
         let group_hidden_size = (vision_hidden_size * group_h * group_w) as i32;
 
@@ -406,6 +411,12 @@ impl MiniCPMV46Merger {
         group_size: i32,
         bits: i32,
     ) -> Result<Self, String> {
+        if merge_kernel_size[0] == 0 || merge_kernel_size[1] == 0 {
+            return Err(
+                "MiniCPM-V 4.6 merger merge_kernel_size entries must be positive".to_string(),
+            );
+        }
+
         let mut blocks = Vec::with_capacity(merger_times);
         for i in 0..merger_times {
             blocks.push(MergerBlock::from_weights(
@@ -423,6 +434,27 @@ impl MiniCPMV46Merger {
             merge_h: merge_kernel_size[0],
             merge_w: merge_kernel_size[1],
         })
+    }
+
+    /// Validate and compute the output spatial grid for the configured
+    /// post-ViT Merger blocks without running any MLX kernels.
+    pub fn output_grid_size(
+        &self,
+        mut grid_h: usize,
+        mut grid_w: usize,
+    ) -> Result<(usize, usize), String> {
+        for _ in &self.blocks {
+            if !grid_h.is_multiple_of(self.merge_h) || !grid_w.is_multiple_of(self.merge_w) {
+                return Err(format!(
+                    "MiniCPM-V 4.6 patch grid {}x{} is not divisible by merger kernel {}x{}",
+                    grid_h, grid_w, self.merge_h, self.merge_w
+                ));
+            }
+            grid_h /= self.merge_h;
+            grid_w /= self.merge_w;
+        }
+
+        Ok((grid_h, grid_w))
     }
 
     /// `x` shape: `[seq_len, hidden_size]`  (no batch dim).
@@ -528,6 +560,41 @@ impl MiniCPMV46VisionModel {
             insert_layer_id: model_cfg.insert_layer_id,
             num_layers: vision_cfg.num_hidden_layers,
         })
+    }
+
+    /// Compute how many vision tokens the full MiniCPM-V 4.6 vision pipeline
+    /// emits for a preprocessed patch grid.
+    ///
+    /// Used by request-time prompt preparation to reserve exactly one
+    /// `<unk>` placeholder per emitted vision token before text tokenization.
+    pub fn output_token_count_for_spatial_shape(
+        &self,
+        spatial_shape: (i32, i32),
+    ) -> Result<usize, String> {
+        if spatial_shape.0 <= 0 || spatial_shape.1 <= 0 {
+            return Err(format!(
+                "MiniCPM-V 4.6 spatial shape must be positive, got {:?}",
+                spatial_shape
+            ));
+        }
+
+        let grid_h = spatial_shape.0 as usize;
+        let grid_w = spatial_shape.1 as usize;
+        if !grid_h.is_multiple_of(self.vit_merger.group_h)
+            || !grid_w.is_multiple_of(self.vit_merger.group_w)
+        {
+            return Err(format!(
+                "MiniCPM-V 4.6 patch grid {}x{} is not divisible by VitMerger group {}x{}",
+                grid_h, grid_w, self.vit_merger.group_h, self.vit_merger.group_w
+            ));
+        }
+
+        let grid_h = grid_h / self.vit_merger.group_h;
+        let grid_w = grid_w / self.vit_merger.group_w;
+        let (grid_h, grid_w) = self.merger.output_grid_size(grid_h, grid_w)?;
+        grid_h
+            .checked_mul(grid_w)
+            .ok_or_else(|| "MiniCPM-V 4.6 output token count overflowed usize".to_string())
     }
 
     /// Run the full vision forward pass on a single image.

--- a/src/vision/encoders/minicpmv4_6_tests.rs
+++ b/src/vision/encoders/minicpmv4_6_tests.rs
@@ -155,3 +155,31 @@ fn merger_single_round_honors_4x4_merge_kernel_size() {
     assert_eq!(mlxcel_core::array_shape(&tokens), vec![64, out_dim]);
     assert_eq!((h, w), (8, 8));
 }
+
+#[test]
+fn merger_output_grid_size_rejects_non_divisible_spatial_grid() {
+    let inner_dim = 2i32;
+    let merge_tokens = 4i32;
+    let in_dim = inner_dim * merge_tokens;
+    let mid_dim = 2i32;
+    let out_dim = 2i32;
+
+    let mut weights = WeightMap::new();
+    insert_merger_block_weights(&mut weights, "merger", 0, in_dim, mid_dim, out_dim);
+
+    let merger = MiniCPMV46Merger::from_weights(&weights, "merger", 1, [2, 2], 1e-6, 0, 0).unwrap();
+
+    assert_eq!(merger.output_grid_size(16, 12).unwrap(), (8, 6));
+    assert!(merger.output_grid_size(15, 12).is_err());
+}
+
+#[test]
+fn merger_rejects_zero_merge_kernel_size() {
+    let weights = WeightMap::new();
+    let err = match MiniCPMV46Merger::from_weights(&weights, "merger", 0, [0, 2], 1e-6, 0, 0) {
+        Ok(_) => panic!("expected zero merge_kernel_size to be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(err.contains("merge_kernel_size"));
+}

--- a/src/vision/minicpmv4_6_vl.rs
+++ b/src/vision/minicpmv4_6_vl.rs
@@ -39,6 +39,14 @@ pub struct MiniCPMV46VLModel {
 }
 
 impl MiniCPMV46VLModel {
+    pub fn image_feature_size_for_processed(
+        &self,
+        processed: &processors::minicpmo::MiniCPMOImageInput,
+    ) -> Result<usize, String> {
+        self.vision_model
+            .output_token_count_for_spatial_shape(processed.spatial_shape)
+    }
+
     pub fn get_input_embeddings(
         &self,
         input_ids: &MlxArray,

--- a/src/vision/processors/minicpmo.rs
+++ b/src/vision/processors/minicpmo.rs
@@ -29,23 +29,48 @@ pub struct MiniCPMOProcessor {
     pub patch_size: usize,
     pub scale_resolution: usize,
     pub image_feature_size: usize,
+    resize_multiple_h: usize,
+    resize_multiple_w: usize,
     mean: [f32; 3],
     std: [f32; 3],
 }
 
 impl MiniCPMOProcessor {
     pub fn new(patch_size: usize, scale_resolution: usize, image_feature_size: usize) -> Self {
+        Self::new_with_resize_multiples(
+            patch_size,
+            scale_resolution,
+            image_feature_size,
+            patch_size,
+            patch_size,
+        )
+    }
+
+    /// Create a processor whose resized dimensions are rounded to caller
+    /// supplied multiples.
+    ///
+    /// Used by: MiniCPM-O (`patch_size`) and MiniCPM-V 4.6
+    /// (`patch_size * VitMerger * Merger`) preprocessing paths.
+    pub fn new_with_resize_multiples(
+        patch_size: usize,
+        scale_resolution: usize,
+        image_feature_size: usize,
+        resize_multiple_h: usize,
+        resize_multiple_w: usize,
+    ) -> Self {
         Self {
             patch_size,
             scale_resolution,
             image_feature_size,
+            resize_multiple_h: resize_multiple_h.max(1),
+            resize_multiple_w: resize_multiple_w.max(1),
             mean: [0.5, 0.5, 0.5],
             std: [0.5, 0.5, 0.5],
         }
     }
 
-    fn ensure_divide(&self, length: usize) -> usize {
-        ((length.max(self.patch_size) + self.patch_size / 2) / self.patch_size) * self.patch_size
+    fn ensure_divide(&self, length: usize, divisor: usize) -> usize {
+        ((length.max(divisor) + divisor / 2) / divisor) * divisor
     }
 
     pub(crate) fn find_best_resize(&self, width: usize, height: usize) -> (usize, usize) {
@@ -63,8 +88,8 @@ impl MiniCPMOProcessor {
         }
 
         (
-            self.ensure_divide(resized_w.max(self.patch_size)),
-            self.ensure_divide(resized_h.max(self.patch_size)),
+            self.ensure_divide(resized_w.max(self.patch_size), self.resize_multiple_w),
+            self.ensure_divide(resized_h.max(self.patch_size), self.resize_multiple_h),
         )
     }
 

--- a/src/vision/processors/minicpmo_tests.rs
+++ b/src/vision/processors/minicpmo_tests.rs
@@ -26,6 +26,22 @@ fn find_best_resize_respects_patch_alignment() {
 }
 
 #[test]
+fn find_best_resize_can_align_to_minicpmv46_downsample_factor() {
+    // MiniCPM-V 4.6 runs a 2x2 VitMerger and a 2x2 Merger after patching, so
+    // both image dimensions must be divisible by patch_size * 4.  The base
+    // MiniCPM-O processor only aligns to patch_size; this constructor is the
+    // upstream MiniCPM-V `_find_best_resize(... merge_factor=patch_size*4)`
+    // equivalent.
+    let processor = MiniCPMOProcessor::new_with_resize_multiples(14, 448, 64, 56, 56);
+    let (width, height) = processor.find_best_resize(1000, 400);
+
+    assert_eq!(width % 56, 0);
+    assert_eq!(height % 56, 0);
+    assert!(width >= 56);
+    assert!(height >= 56);
+}
+
+#[test]
 fn preprocess_outputs_hwc_tensor_and_spatial_shape() {
     let processor = MiniCPMOProcessor::new(14, 448, 64);
     let image = DynamicImage::ImageRgb8(RgbImage::from_pixel(63, 31, image::Rgb([255, 0, 0])));


### PR DESCRIPTION
Hardens MiniCPM-V 4.6 dynamic image grid preprocessing and prompt placeholder spans so multi-image and non-square inputs produce correct per-image visual-token counts.

## Problem

The MiniCPM-V 4.6 path assumed a single fixed `image_feature_size` for every image when building prompt placeholders, and the encoder did not validate that the spatial grid was divisible by the merge and window group sizes. With dynamic-resolution inputs (multiple images, or aspect ratios that resize to different grids) this produced placeholder spans that did not match the number of visual tokens each image actually yields, and could feed a non-divisible grid into the VitMerger and Merger.

## Changes

- Build prompt placeholders from a per-image feature size derived from each preprocessed image. `prepare_minicpmo_prompt_tokens_with_image_feature_sizes` takes a slice of per-image feature sizes instead of one shared size times the image count; the MiniCPM-V 4.6 runtime arm preprocesses images first, derives each image's feature size via `image_feature_size_for_processed`, and threads the slice through.
- Add a divisibility guard in the encoder: the Merger and VitMerger reject a spatial grid that is not a multiple of their merge and window group sizes, instead of silently producing a misshapen tensor.
- Align the image processor's best-resize search to the MiniCPM-V 4.6 downsample factor so the chosen grid is always compatible with the two-stage visual compression.

## Verification

- `cargo fmt --check` clean.
- `cargo clippy --features metal,accelerate --all-targets -- -D warnings` clean.
- 22 unit tests pass, covering per-image feature sizes, placeholder span computation, the grid divisibility guards, and patch/downsample-aligned resizing.