### PR TITLE
fix(vision): make Gemma 3n VLM per_layer_inputs sequence-aware

### DIFF
--- a/src/loaded_model_capabilities.rs
+++ b/src/loaded_model_capabilities.rs
@@ -276,6 +276,62 @@ impl LoadedModel {
         }
     }
 
+    /// Drain the freshly written Gemma 3n VLM `per_layer_inputs` fallback
+    /// slot into the per-`SequenceId` map under `seq_id` (issue #85).
+    ///
+    /// This is a no-op for non-Gemma-3n models. The caller passes the id
+    /// the scheduler already allocated for the request; the VLM runtime
+    /// transfers the fallback slot's tensor into its per-`SequenceId`
+    /// map. When the fallback is empty (text-only request after a
+    /// Gemma 3n VLM model load), the binding leaves the map without an
+    /// entry — the prefill consumer then surfaces `None` for
+    /// `per_layer_inputs`, matching the no-VLM-prefill semantics.
+    pub fn bind_gemma3n_per_layer_inputs_to_sequence(
+        &self,
+        seq_id: mlxcel_core::cache::SequenceId,
+    ) {
+        if let Some(VlmRuntimeRef::Gemma3n(gemma3n)) = self.vlm_runtime() {
+            gemma3n.bind_per_layer_inputs_to_sequence(seq_id);
+        }
+    }
+
+    /// Take the per-sequence Gemma 3n `per_layer_inputs` tensor out of
+    /// the underlying VL model. Used by the scheduler's preemption path
+    /// so the tensor survives the eviction (which releases the old
+    /// sequence id) and can be reinstalled under the freshly allocated
+    /// id — `prepare_request_vlm_embeddings` does not run again on
+    /// re-prefill, so without the take/install round trip the re-prefill
+    /// would observe `per_layer_inputs == None` and panic in
+    /// `Gemma3nVLModel::forward_with_embeddings_and_sequence_id`.
+    ///
+    /// Returns `None` for non-Gemma-3n models or when no entry exists
+    /// for `seq_id`.
+    pub fn take_gemma3n_per_layer_inputs_entry(
+        &self,
+        seq_id: mlxcel_core::cache::SequenceId,
+    ) -> Option<mlxcel_core::UniquePtr<mlxcel_core::MlxArray>> {
+        if let Some(VlmRuntimeRef::Gemma3n(gemma3n)) = self.vlm_runtime() {
+            return gemma3n.take_per_layer_inputs_for_sequence(seq_id);
+        }
+        None
+    }
+
+    /// Re-install a previously taken Gemma 3n `per_layer_inputs` tensor
+    /// under `seq_id`. No-op for non-Gemma-3n models or when the
+    /// snapshot is `None`.
+    pub fn install_gemma3n_per_layer_inputs_entry(
+        &self,
+        seq_id: mlxcel_core::cache::SequenceId,
+        snapshot: Option<mlxcel_core::UniquePtr<mlxcel_core::MlxArray>>,
+    ) {
+        if snapshot.is_none() {
+            return;
+        }
+        if let Some(VlmRuntimeRef::Gemma3n(gemma3n)) = self.vlm_runtime() {
+            gemma3n.install_per_layer_inputs_for_sequence(seq_id, snapshot);
+        }
+    }
+
     pub fn image_token_block_info(&self) -> Option<vlm_prompt::ImageTokenBlockInfo> {
         image_token_block_info_from_runtime(self.vlm_runtime()?)
     }

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1511,6 +1511,16 @@ impl BatchScheduler {
         // everything that is not a Gemma 4 VLM.
         self.model.bind_gemma4_per_layer_inputs_to_sequence(seq_id);
 
+        // Issue #85: same lifecycle invariant for Gemma 3n VLM. The
+        // legacy `Gemma3nVLModel.cached_per_layer_inputs` cell was a
+        // single fallback slot with no per-sequence binding; under a
+        // burst of Gemma 3n VLM requests the next prepare would
+        // overwrite the slot before the first prefill consumed it (or
+        // panic on `Option::unwrap` when the timing flipped). The
+        // call below is a no-op for everything that is not a
+        // Gemma 3n VLM.
+        self.model.bind_gemma3n_per_layer_inputs_to_sequence(seq_id);
+
         let decode_state = StreamingDecodeState::new(&self.tokenizer, &prompt_tokens);
 
         // Issue #409: resolve the effective thinking-token budget for this
@@ -2924,6 +2934,14 @@ impl BatchScheduler {
             // it out before `release_sequence_caches` drains the map.
             let pli_snapshot = self.model.take_gemma4_per_layer_inputs_entry(victim.seq_id);
 
+            // Issue #85: same for Gemma 3n VLM `per_layer_inputs`.
+            // Without this round trip the re-prefill would panic in
+            // `Gemma3nVLModel::forward_with_embeddings_and_sequence_id`
+            // (per_layer_inputs missing for this sequence).
+            let pli3n_snapshot = self
+                .model
+                .take_gemma3n_per_layer_inputs_entry(victim.seq_id);
+
             // Release its KV cache
             self.release_sequence_caches(victim.seq_id);
 
@@ -2958,6 +2976,9 @@ impl BatchScheduler {
                     // input_ids (no decode-time updates).
                     self.model
                         .install_gemma4_per_layer_inputs_entry(new_id, pli_snapshot);
+                    // Issue #85: same for Gemma 3n `per_layer_inputs`.
+                    self.model
+                        .install_gemma3n_per_layer_inputs_entry(new_id, pli3n_snapshot);
                     if let Err(err) = victim.state.transition_to(SequenceState::Queued) {
                         tracing::error!("Eviction state transition error: {err}");
                         self.release_sequence_caches(new_id);

--- a/src/vision/gemma3n_per_layer_inputs_state.rs
+++ b/src/vision/gemma3n_per_layer_inputs_state.rs
@@ -1,0 +1,141 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Per-sequence `per_layer_inputs` state for Gemma 3n VLM (issue #85).
+//!
+//! `Gemma3nVLModel::get_input_embeddings` projects the Gemma 3n
+//! `per_layer_inputs` tensor (shape `[1, T, L, h]`) while preparing a
+//! request's VLM embeddings. That tensor is consumed later, at prefill
+//! time, by `Gemma3nVLModel::forward_with_embeddings_and_sequence_id`
+//! when it calls
+//! `text_model.language_model.forward_with_inputs(embeds, &pli, caches)`.
+//!
+//! Before this module landed, the projected tensor lived on a single
+//! `RefCell<Option<UniquePtr<MlxArray>>>` field (`cached_per_layer_inputs`)
+//! on `Gemma3nVLModel`. The scheduler's `drain_incoming_requests` runs
+//! the embedding-prep step once per request at enqueue time and the
+//! prefill step asynchronously at scheduling time. When 2+ Gemma 3n VLM
+//! requests are enqueued before the first one prefills (a typical burst
+//! on an idle server), each `prepare_request_vlm_embeddings` overwrites
+//! the same cell. The first prefill then `take()`s **the latest writer's**
+//! `per_layer_inputs` instead of its own, or — if the prepares interleave
+//! with the prefills such that the slot is already drained — panics on
+//! `Option::unwrap()` at `gemma3n_vl.rs:145`.
+//!
+//! The container below mirrors
+//! [`crate::vision::gemma4_per_layer_inputs_state::Gemma4PerLayerInputsState`]
+//! so the scheduler wires both per-sequence states identically. The same
+//! comment about lifecycle ownership applies:
+//!
+//! - **Per-`SequenceId` map** is the primary slot;
+//!   `bind_fallback_to_sequence` transfers a freshly written fallback
+//!   into this map under the scheduler-allocated id, draining the
+//!   fallback in the same step so the next request cannot inherit the
+//!   previous row's tensor.
+//! - **Fallback slot** preserves legacy single-instance callers (CLI
+//!   `mlxcel generate`, `mlxcel-bench-decode`, single-row tests). It also
+//!   acts as a last-resort when `take_for_sequence(id)` finds no entry
+//!   under `id` (e.g., a request that started before per-sequence wiring
+//!   landed).
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use mlxcel_core::cache::SequenceId;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+/// Per-sequence container for Gemma 3n VLM `per_layer_inputs` tensors.
+///
+/// Used by: [`crate::vision::Gemma3nVLModel`]. The value stored is the
+/// projected `per_layer_inputs` tensor that
+/// `Gemma3nLanguageModel::project_per_layer_inputs` produces; the prefill
+/// path then passes it into `forward_with_inputs` so the language model
+/// can blend the per-layer projection into its layer stack.
+#[derive(Default)]
+pub(crate) struct Gemma3nPerLayerInputsState {
+    sequences: RefCell<HashMap<SequenceId, UniquePtr<MlxArray>>>,
+    fallback: RefCell<Option<UniquePtr<MlxArray>>>,
+}
+
+impl Gemma3nPerLayerInputsState {
+    /// Construct an empty state container.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Store `per_layer_inputs` in the fallback slot. Used by the legacy
+    /// single-instance call path (`mlxcel-bench-decode`, CLI
+    /// `mlxcel generate`, single-row tests) before any sequence id has
+    /// been allocated.
+    ///
+    /// `per_layer_inputs == None` clears the fallback.
+    pub(crate) fn set_fallback(&self, per_layer_inputs: Option<UniquePtr<MlxArray>>) {
+        *self.fallback.borrow_mut() = per_layer_inputs;
+    }
+
+    /// Move the fallback slot's contents into the per-sequence map under
+    /// `seq_id`. Drains the fallback so the next request cannot inherit
+    /// the previous row's tensor — this is the burst-enqueue race fix
+    /// from issue #85.
+    ///
+    /// If the fallback slot is empty (text-only request after a Gemma 3n
+    /// VLM model load — `prepare_request_vlm_embeddings` returns `None`
+    /// in that case and never writes the slot), `seq_id` is left absent
+    /// from the map. A subsequent `take_for_sequence(seq_id)` returns
+    /// `None`, and the prefill consumer can decide whether to fall back
+    /// to the slot or treat that as a hard error.
+    pub(crate) fn bind_fallback_to_sequence(&self, seq_id: SequenceId) {
+        let mut fallback = self.fallback.borrow_mut();
+        if let Some(value) = fallback.take() {
+            self.sequences.borrow_mut().insert(seq_id, value);
+        }
+    }
+
+    /// Take a row's per-layer-inputs out of the map for prefill
+    /// consumption. Returns `None` when no entry exists — the prefill
+    /// path then falls back to the legacy single-row slot via
+    /// [`Self::take_fallback`].
+    pub(crate) fn take_for_sequence(&self, seq_id: SequenceId) -> Option<UniquePtr<MlxArray>> {
+        self.sequences.borrow_mut().remove(&seq_id)
+    }
+
+    /// Drain the fallback slot. Used by the legacy CLI / bench prefill
+    /// path (`Gemma3nVLModel::forward_with_embeddings_and_sequence_id`
+    /// with `seq_id == None`) to consume the tensor exactly once,
+    /// mirroring the original `RefCell::take()` semantics.
+    pub(crate) fn take_fallback(&self) -> Option<UniquePtr<MlxArray>> {
+        self.fallback.borrow_mut().take()
+    }
+
+    /// Drop a single sequence's stored tensor. Called from
+    /// `Gemma3nVLModel::release_sequence_state_by_id` so the map drains
+    /// in step with the scheduler's per-sequence cache release. No-op
+    /// when the map has no entry for the id (text-only request, request
+    /// that finished before the binding step ran).
+    pub(crate) fn release_sequence(&self, seq_id: SequenceId) {
+        self.sequences.borrow_mut().remove(&seq_id);
+    }
+
+    /// Re-install a previously taken tensor under `seq_id`. Used by the
+    /// preemption path so a VL row that was evicted before completing
+    /// prefill can resume under its freshly allocated id without
+    /// rerunning the vision encoder.
+    pub(crate) fn bind_for_sequence(&self, seq_id: SequenceId, value: UniquePtr<MlxArray>) {
+        self.sequences.borrow_mut().insert(seq_id, value);
+    }
+}
+
+#[cfg(test)]
+#[path = "gemma3n_per_layer_inputs_state_tests.rs"]
+mod tests;

--- a/src/vision/gemma3n_per_layer_inputs_state_tests.rs
+++ b/src/vision/gemma3n_per_layer_inputs_state_tests.rs
@@ -1,0 +1,220 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the Gemma 3n per-layer-inputs per-sequence state container
+//! (issue #85).
+//!
+//! These cover the burst-enqueue race the container is designed to close:
+//! when 2+ Gemma 3n VLM requests are enqueued within one
+//! `drain_incoming_requests` tick, each `prepare_request_vlm_embeddings`
+//! writes the fallback slot and the scheduler's
+//! `bind_fallback_to_sequence(seq_id)` must isolate the freshly written
+//! tensor under that sequence id before the next request overwrites the
+//! fallback. The "preemption round trip" test covers the take/install
+//! round trip mirroring [`super::Gemma3nPerLayerInputsState::bind_for_sequence`].
+
+use super::Gemma3nPerLayerInputsState;
+use mlxcel_core::cache::SequenceId;
+
+/// Build a tiny `[1, 1, 1, 1]` per-layer-inputs tensor whose single value
+/// identifies the producer. The real shape is `[1, T, L, h_per_layer]`
+/// but the state container is shape-agnostic — the tests only need to
+/// verify which writer's tensor surfaces at each lookup.
+fn make_pli(value: f32) -> mlxcel_core::UniquePtr<mlxcel_core::MlxArray> {
+    mlxcel_core::from_slice_f32(&[value], &[1, 1, 1, 1])
+}
+
+fn read_pli_scalar(arr: &mlxcel_core::MlxArray) -> f32 {
+    mlxcel_core::eval(arr);
+    let bytes = mlxcel_core::array_to_raw_bytes(arr);
+    f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+}
+
+#[test]
+#[ignore = "requires serial MLX execution"]
+fn fallback_round_trip_take_returns_value() {
+    // Legacy CLI / bench path: `set_fallback` then `take_fallback`
+    // returns the tensor and leaves the fallback empty for the next
+    // caller.
+    let state = Gemma3nPerLayerInputsState::new();
+    state.set_fallback(Some(make_pli(7.0)));
+    let taken = state.take_fallback().expect("fallback held a value");
+    assert!((read_pli_scalar(taken.as_ref().unwrap()) - 7.0).abs() < 1e-5);
+    assert!(
+        state.take_fallback().is_none(),
+        "second take must observe an empty fallback"
+    );
+}
+
+#[test]
+#[ignore = "requires serial MLX execution"]
+fn set_fallback_with_none_clears_slot() {
+    // Defensive: passing `None` must wipe a stale value left by an
+    // earlier turn so the next prefill does not inherit it.
+    let state = Gemma3nPerLayerInputsState::new();
+    state.set_fallback(Some(make_pli(3.0)));
+    state.set_fallback(None);
+    assert!(
+        state.take_fallback().is_none(),
+        "set_fallback(None) must clear the slot"
+    );
+}
+
+#[test]
+#[ignore = "requires serial MLX execution"]
+fn bind_fallback_drains_into_per_sequence_slot() {
+    // Server flow: vision wrapper writes the freshly projected tensor
+    // to the fallback before the scheduler knows the request's id; the
+    // scheduler then binds it to the allocated id. After bind the
+    // fallback must be empty so a subsequent request cannot inherit it.
+    let state = Gemma3nPerLayerInputsState::new();
+    let seq = SequenceId::from_raw(11);
+    state.set_fallback(Some(make_pli(42.0)));
+    state.bind_fallback_to_sequence(seq);
+
+    let consumed = state
+        .take_for_sequence(seq)
+        .expect("seq must hold the bound tensor");
+    assert!((read_pli_scalar(consumed.as_ref().unwrap()) - 42.0).abs() < 1e-5);
+    assert!(
+        state.take_fallback().is_none(),
+        "bind_fallback_to_sequence must drain the fallback"
+    );
+}
+
+#[test]
+#[ignore = "requires serial MLX execution"]
+fn bind_fallback_with_empty_slot_leaves_seq_absent() {
+    // Text-only request after a Gemma 3n VLM model load: the wrapper
+    // sets the fallback to `None` and the scheduler still calls
+    // `bind_fallback_to_sequence`. The map must be left without an
+    // entry so a `take_for_sequence` returns `None` and the prefill
+    // path falls through to the (still empty) fallback slot — which
+    // matches the no-per-layer-inputs semantics.
+    let state = Gemma3nPerLayerInputsState::new();
+    let seq = SequenceId::from_raw(12);
+    state.bind_fallback_to_sequence(seq);
+    assert!(
+        state.take_for_sequence(seq).is_none(),
+        "binding an empty fallback must leave seq absent so the prefill consumer surfaces None"
+    );
+}
+
+/// Issue #85 root-cause regression: simulate the burst-enqueue race.
+///
+/// `prepare_request_vlm_embeddings` writes the fallback slot once per
+/// request; the scheduler's bind step claims it before the next
+/// request runs. Without the bind step, the second
+/// `prepare_request_vlm_embeddings` would overwrite the cell and the
+/// first prefill would consume the wrong tensor — or, when the timing
+/// flips, the second prefill would observe `None` and the legacy
+/// `take().unwrap()` would panic.
+#[test]
+#[ignore = "requires serial MLX execution"]
+fn burst_enqueue_race_each_seq_consumes_its_own_tensor() {
+    let state = Gemma3nPerLayerInputsState::new();
+    let row_a = SequenceId::from_raw(101);
+    let row_b = SequenceId::from_raw(102);
+
+    // Enqueue tick: two Gemma 3n VLM requests arrive back-to-back.
+
+    // Request A: vision wrapper writes its tensor to the fallback.
+    state.set_fallback(Some(make_pli(1.0)));
+    // Scheduler binds it under row A's seq id immediately after.
+    state.bind_fallback_to_sequence(row_a);
+
+    // Request B: same producer/consumer pair, different value.
+    state.set_fallback(Some(make_pli(2.0)));
+    state.bind_fallback_to_sequence(row_b);
+
+    // Prefill tick: each row consumes its own tensor.
+    let pli_a = state.take_for_sequence(row_a).expect("row_a tensor");
+    let pli_b = state.take_for_sequence(row_b).expect("row_b tensor");
+
+    assert!(
+        (read_pli_scalar(pli_a.as_ref().unwrap()) - 1.0).abs() < 1e-5,
+        "row_a must consume its own tensor (1.0), not row_b's (2.0)"
+    );
+    assert!(
+        (read_pli_scalar(pli_b.as_ref().unwrap()) - 2.0).abs() < 1e-5,
+        "row_b must consume its own tensor (2.0)"
+    );
+}
+
+#[test]
+#[ignore = "requires serial MLX execution"]
+fn release_drops_only_target_sequence() {
+    let state = Gemma3nPerLayerInputsState::new();
+    let a = SequenceId::from_raw(201);
+    let b = SequenceId::from_raw(202);
+    state.set_fallback(Some(make_pli(10.0)));
+    state.bind_fallback_to_sequence(a);
+    state.set_fallback(Some(make_pli(20.0)));
+    state.bind_fallback_to_sequence(b);
+
+    state.release_sequence(a);
+
+    assert!(
+        state.take_for_sequence(a).is_none(),
+        "released seq must no longer resolve"
+    );
+    assert!(
+        state.take_for_sequence(b).is_some(),
+        "untouched seq must still resolve"
+    );
+}
+
+/// Preemption round trip — mirrors the Gemma 4 / Qwen MRoPE preemption
+/// flows.
+///
+/// Eviction releases the old id; the saved tensor must survive the
+/// release and reinstall under the freshly allocated id so the
+/// re-prefill sees the same projection (`prepare_request_vlm_embeddings`
+/// does not re-run on re-prefill).
+#[test]
+#[ignore = "requires serial MLX execution"]
+fn preemption_round_trip_carries_tensor_to_new_id() {
+    let state = Gemma3nPerLayerInputsState::new();
+    let id_a = SequenceId::from_raw(301);
+    let id_b = SequenceId::from_raw(302);
+
+    // Original prefill: tensor stored under id_a.
+    state.set_fallback(Some(make_pli(99.0)));
+    state.bind_fallback_to_sequence(id_a);
+
+    // Eviction simulation: take out the entry, release the id.
+    let saved = state.take_for_sequence(id_a).expect("entry must exist");
+    state.release_sequence(id_a);
+
+    assert!(
+        state.take_for_sequence(id_a).is_none(),
+        "release must drain id_a"
+    );
+
+    // Re-queue under a fresh id; install the saved entry.
+    state.bind_for_sequence(id_b, saved);
+
+    let consumed = state
+        .take_for_sequence(id_b)
+        .expect("id_b must hold tensor");
+    assert!((read_pli_scalar(consumed.as_ref().unwrap()) - 99.0).abs() < 1e-5);
+}
+
+#[test]
+#[ignore = "requires serial MLX execution"]
+fn take_for_sequence_returns_none_for_unknown_id() {
+    let state = Gemma3nPerLayerInputsState::new();
+    let unknown = SequenceId::from_raw(401);
+    assert!(state.take_for_sequence(unknown).is_none());
+}

--- a/src/vision/gemma3n_vl.rs
+++ b/src/vision/gemma3n_vl.rs
@@ -16,17 +16,32 @@
 //!
 //! MobileNetV5 vision encoder + Gemma3n language model
 
-use super::{encoders, merge, processors};
+use super::{
+    encoders, gemma3n_per_layer_inputs_state::Gemma3nPerLayerInputsState, merge, processors,
+};
 use crate::LanguageModel;
+use mlxcel_core::cache::SequenceId;
 use mlxcel_core::layers::KVCache;
 use mlxcel_core::{MlxArray, UniquePtr};
 
 /// Gemma 3n VLM: MobileNetV5 vision encoder + Gemma3n language model
 ///
 /// Unlike ViT-based VLMs, Gemma 3n uses a convolutional MobileNetV5 encoder
-/// with Multi-Scale Fusion Adapter. The language model has a unique per_layer_inputs
-/// mechanism that requires special handling (cached between get_input_embeddings
-/// and forward_with_embeddings).
+/// with Multi-Scale Fusion Adapter. The language model has a unique
+/// `per_layer_inputs` mechanism that requires special handling: the
+/// projected tensor is produced during `get_input_embeddings` and consumed
+/// later by the prefill `forward_with_embeddings_and_sequence_id` call.
+///
+/// Issue #85: the `per_layer_inputs` tensor used to live in a single
+/// `RefCell<Option<UniquePtr<MlxArray>>>` field on this struct. Under
+/// concurrent VLM requests on `mlxcel-server`, two prepares could overwrite
+/// the slot before either prefill consumed it, leaking one row's tensor
+/// into another row's prefill (or panicking on `Option::unwrap()` when the
+/// slot was already drained). The state is now held in
+/// [`Gemma3nPerLayerInputsState`], a per-`SequenceId` map with a fallback
+/// slot for legacy single-instance callers, mirroring the Gemma 4
+/// [`Gemma4PerLayerInputsState`](crate::vision::gemma4_per_layer_inputs_state::Gemma4PerLayerInputsState)
+/// container.
 pub struct Gemma3nVLModel {
     pub text_model: crate::models::Gemma3nModel,
     pub vision_tower: encoders::gemma3n::Gemma3nVisionModel,
@@ -36,8 +51,11 @@ pub struct Gemma3nVLModel {
     pub boi_token_id: i32,                              // 255_999 (<start_of_image>)
     pub eoi_token_id: i32,                              // 262_144 (<end_of_image>)
     pub vision_hidden_size: usize,                      // 2048
-    /// Store per_layer_inputs between get_input_embeddings and forward_with_embeddings
-    cached_per_layer_inputs: std::cell::RefCell<Option<UniquePtr<MlxArray>>>,
+    /// Per-sequence storage for the projected `per_layer_inputs` tensor
+    /// that is produced during embedding prep and consumed during the
+    /// prefill `forward_with_embeddings_and_sequence_id` call. See module
+    /// [`crate::vision::gemma3n_per_layer_inputs_state`] for the lifecycle.
+    per_layer_inputs_state: Gemma3nPerLayerInputsState,
 }
 
 impl Gemma3nVLModel {
@@ -60,11 +78,19 @@ impl Gemma3nVLModel {
             boi_token_id,
             eoi_token_id,
             vision_hidden_size,
-            cached_per_layer_inputs: std::cell::RefCell::new(None),
+            per_layer_inputs_state: Gemma3nPerLayerInputsState::new(),
         }
     }
 
-    /// Get input embeddings with vision features merged in
+    /// Get input embeddings with vision features merged in.
+    ///
+    /// Side effect: writes the freshly projected `per_layer_inputs` tensor
+    /// into the per-layer-inputs state container's fallback slot. The
+    /// scheduler binds it to a `SequenceId` right after
+    /// `prepare_request_vlm_embeddings` returns (see issue #85). Legacy
+    /// single-row callers (CLI `mlxcel generate`, `mlxcel-bench-decode`,
+    /// single-row tests) consume it via `take_fallback` on the next
+    /// prefill.
     pub fn get_input_embeddings(
         &self,
         input_ids: &MlxArray,
@@ -116,10 +142,76 @@ impl Gemma3nVLModel {
             input_ids,
         );
 
-        // 6. Cache per_layer_inputs for use in forward_with_embeddings
-        *self.cached_per_layer_inputs.borrow_mut() = Some(per_layer_inputs);
+        // 6. Park the projected per_layer_inputs in the state container's
+        //    fallback slot. The scheduler's
+        //    `bind_gemma3n_per_layer_inputs_to_sequence` immediately
+        //    transfers it into the per-sequence map under the request's
+        //    `SequenceId`. Single-row callers (bench / CLI) consume it
+        //    via `take_fallback` on the next prefill.
+        self.per_layer_inputs_state
+            .set_fallback(Some(per_layer_inputs));
 
         merged
+    }
+
+    // -- Per-sequence per_layer_inputs (issue #85) --------------------
+    //
+    // Thin wrappers around `Gemma3nPerLayerInputsState`. The scheduler
+    // calls them via `LoadedModel::*` capability helpers (see
+    // `loaded_model_capabilities.rs`) right after
+    // `prepare_request_vlm_embeddings`, mirroring the Gemma 4 binding
+    // flow in `gemma4_per_layer_inputs_state`.
+
+    /// Drain the container's fallback slot into the per-`SequenceId` map
+    /// under `seq_id`. No-op when the slot is empty (text-only request
+    /// after a Gemma 3n VLM model load).
+    pub fn bind_per_layer_inputs_to_sequence(&self, seq_id: SequenceId) {
+        self.per_layer_inputs_state
+            .bind_fallback_to_sequence(seq_id);
+    }
+
+    /// Drop a sequence's stored `per_layer_inputs`. Called from
+    /// [`Self::release_sequence_state_by_id`] so the map drains in step
+    /// with the scheduler's per-sequence cache cleanup.
+    pub fn release_per_layer_inputs(&self, seq_id: SequenceId) {
+        self.per_layer_inputs_state.release_sequence(seq_id);
+    }
+
+    /// Take a sequence's tensor out of the map without dropping the
+    /// `UniquePtr`. Used by the scheduler's preemption path so the
+    /// tensor can be carried across the eviction (which releases the old
+    /// sequence id) and reinstalled under the freshly allocated id with
+    /// [`Self::install_per_layer_inputs_for_sequence`].
+    pub fn take_per_layer_inputs_for_sequence(
+        &self,
+        seq_id: SequenceId,
+    ) -> Option<UniquePtr<MlxArray>> {
+        self.per_layer_inputs_state.take_for_sequence(seq_id)
+    }
+
+    /// Re-install a previously taken tensor under `seq_id`. No-op when
+    /// the snapshot is `None`.
+    pub fn install_per_layer_inputs_for_sequence(
+        &self,
+        seq_id: SequenceId,
+        snapshot: Option<UniquePtr<MlxArray>>,
+    ) {
+        if let Some(value) = snapshot {
+            self.per_layer_inputs_state.bind_for_sequence(seq_id, value);
+        }
+    }
+
+    /// Internal helper: resolve the active per_layer_inputs tensor for a
+    /// VLM prefill. Prefers the per-`SequenceId` slot (server flow) and
+    /// falls back to the fallback slot (CLI / bench / single-row).
+    fn take_per_layer_inputs(&self, seq_id: Option<SequenceId>) -> Option<UniquePtr<MlxArray>> {
+        match seq_id {
+            Some(id) => self
+                .per_layer_inputs_state
+                .take_for_sequence(id)
+                .or_else(|| self.per_layer_inputs_state.take_fallback()),
+            None => self.per_layer_inputs_state.take_fallback(),
+        }
     }
 
     fn align_per_layer_inputs_to_embeddings(
@@ -166,11 +258,37 @@ impl LanguageModel for Gemma3nVLModel {
         input_ids: &MlxArray,
         input_embeddings: Option<&MlxArray>,
         caches: &mut [KVCache],
+        mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        // No `seq_id` plumbed through (legacy CLI / bench / direct call).
+        // Route to the per-sequence dispatch with `seq_id == None`, which
+        // resolves the per_layer_inputs from the fallback slot.
+        self.forward_with_embeddings_and_sequence_id(
+            input_ids,
+            input_embeddings,
+            None,
+            caches,
+            mask,
+        )
+    }
+
+    fn forward_with_embeddings_and_sequence_id(
+        &self,
+        input_ids: &MlxArray,
+        input_embeddings: Option<&MlxArray>,
+        seq_id: Option<SequenceId>,
+        caches: &mut [KVCache],
         _mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
         if let Some(embeds) = input_embeddings {
-            // VLM prefill: use cached per_layer_inputs
-            let pli = self.cached_per_layer_inputs.borrow_mut().take().unwrap();
+            // VLM prefill: resolve the request's projected per_layer_inputs
+            // from the per-`SequenceId` map (server flow) or the fallback
+            // slot (CLI / bench). An absent tensor at this point is an
+            // internal invariant violation: `get_input_embeddings` must
+            // have populated the fallback slot before this consumer ran.
+            let pli = self
+                .take_per_layer_inputs(seq_id)
+                .expect("gemma3n VLM prefill: per_layer_inputs missing for this sequence");
             // Issue #736: M5 tile-aligned prefill pads the token stream and
             // merged embeddings to an NA tile length. The projected
             // per-layer tensor is produced before that generic padding step,
@@ -201,6 +319,20 @@ impl LanguageModel for Gemma3nVLModel {
 
     fn eos_token_ids(&self) -> Vec<i32> {
         mlxcel_core::generate::LanguageModel::eos_token_ids(&self.text_model)
+    }
+
+    fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
+        // Issue #85: drop the per-sequence `per_layer_inputs` alongside
+        // the text model's per-sequence cache release so the map cannot
+        // grow without bound across long-running server sessions.
+        self.per_layer_inputs_state.release_sequence(seq_id);
+        // The text model (Gemma3nModel) uses the trait's default no-op
+        // for release_sequence_state_by_id today; the call below is kept
+        // for forward-compat when the text backbone gains per-seq state.
+        mlxcel_core::generate::LanguageModel::release_sequence_state_by_id(
+            &self.text_model,
+            seq_id,
+        );
     }
 }
 

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -36,6 +36,7 @@ pub mod merge;
 pub mod processors;
 
 // VLM model implementations
+pub mod gemma3n_per_layer_inputs_state;
 pub mod gemma3n_vl;
 pub mod gemma4_multimodal_embedder;
 pub mod gemma4_per_layer_inputs_state;


### PR DESCRIPTION
## Summary

Gemma 3n VLM stashed its projected `per_layer_inputs` tensor in a single `RefCell<Option<…>>` cell that `get_input_embeddings` wrote and `forward_with_embeddings` drained via `take().unwrap()`. The batch scheduler runs embedding-prep at enqueue time but prefill asynchronously, so a burst of concurrent Gemma 3n VLM requests could overwrite the cell before the first prefill consumed it — the first prefill then saw the wrong row's tensor, or panicked on `None` when the timing flipped. This affects only the batched `mlxcel-server` path; single-row CLI / bench paths are unaffected.

## Fix

Replace the cell with `Gemma3nPerLayerInputsState` (a per-`SequenceId` map plus a fallback slot), mirroring the existing `Gemma4PerLayerInputsState`:

- Override `forward_with_embeddings_and_sequence_id` on `Gemma3nVLModel` so prefill resolves from the seq-keyed map first and falls back to the legacy slot for CLI / bench / single-row callers; the legacy `forward_with_embeddings` routes through it with `seq_id = None`.
- Wire `release_sequence_state_by_id` to drain the map alongside the scheduler's per-sequence cache cleanup.
- Add the `LoadedModel` capability methods (`bind` / `take` / `install_gemma3n_per_layer_inputs_*`) and hook them into `drain_incoming_requests` and the preemption round trip, next to the Gemma 4 calls.

## Testing

- `make verify-clippy` (`--all-targets --features metal,accelerate -- -D warnings`) — clean
- `make verify-fmt` — clean
- New `Gemma3nPerLayerInputsState` unit tests (burst-enqueue race, fallback round trip, release semantics, preemption round trip) — 8/8 pass (`--ignored`, serial MLX)

Closes #85
