### PR TITLE
chore: pin Rust toolchain to 1.95.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,11 @@
+# Pinned so rustfmt/clippy are reproducible and do not drift between
+# checkouts, CI, and the internal development repo. The drift this prevents:
+# with an unpinned `stable`, two checkouts formatted at different times pick
+# up different rustfmt/clippy releases and diverge purely by timing.
+#
+# Bump this deliberately (and re-run `cargo fmt` across the tree) rather than
+# letting `stable` float. Keep this version identical in mlxcel and the
+# internal development repo.
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Neither repo pinned a Rust toolchain — CI used `dtolnay/rust-toolchain@stable` and local builds used each developer's default `stable`. Because the public and internal repos were last formatted/linted under different stable releases (clippy `1.93` vs `1.95`), their trees diverged across many files **purely by formatting/lint timing**, not by any functional change. (That timing drift is what produced the spurious cross-repo `src` divergence.)

## Change

- Add `rust-toolchain.toml` pinning **1.95.0** with the `rustfmt` and `clippy` components, so formatting and lints are reproducible across checkouts, CI, and the internal development repo.
- Point the fmt gate (`ci.yml`) at `@1.95.0` to match. Other cargo invocations — the `pipeline-parallel-ci.yml` clippy gate and `release.yml` builds — pick up the pin through `rust-toolchain.toml` at cargo-invocation time, so their workflows are left unchanged.

Bump the version deliberately (and re-run `cargo fmt`) rather than letting `stable` float.

## Testing

- `cargo fmt --all -- --check` passes under the pinned 1.95.0 toolchain (rustup auto-installed `1.95.0-aarch64-apple-darwin` from the pin).
