### PR TITLE
chore: ignore root models symlink in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ Cargo.lock
 # Local documentation and plans
 DISCUSSION.md
 plan/
-/models/
+/models
 AGENTS.md
 CLAUDE.md
 /references/


### PR DESCRIPTION
## Summary

The repo-local `models -> ../mlxcel-internal/models` developer symlink kept showing as an untracked entry in `git status`, even though `.gitignore` already had a `/models/` rule. The trailing slash restricts that pattern to **directories**, and a symlink is not a directory for gitignore matching purposes, so the symlink was never actually ignored.

## Change

Drop the trailing slash on line 20: `/models/` → `/models`. A root-anchored pattern without a trailing slash matches a file, directory, or symlink named `models`, so the local convenience symlink is now ignored. This symlink points into the private internal repo and must never be committed to the public mirror.

No real `models/` directory regresses: `/models` still ignores a directory and everything under it, so this is strictly more general than the previous rule.

## Verification

- `git check-ignore -v models` → `.gitignore:20:/models	models` (now matched)
- `git status` no longer lists `models` as untracked
