### PR TITLE
chore: pin Rust toolchain to 1.93.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@1.93.1
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,5 +7,5 @@
 # letting `stable` float. Keep this version identical in mlxcel and the
 # internal development repo.
 [toolchain]
-channel = "1.95.0"
+channel = "1.93.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- Downgrade pinned Rust toolchain from 1.95.0 (set in #87) to 1.93.1 in both `rust-toolchain.toml` and the CI `cargo fmt` job
- Aligns with the internal development repo's pinned version per the comment in `rust-toolchain.toml`
- `cargo fmt --all` produces no diff under 1.93.1, so no source formatting changes are needed

## Test plan
- [x] `cargo fmt --all` is clean under 1.93.1 locally
- [ ] CI `cargo fmt --check` passes with the new pin