### PR TITLE
fix(server): tolerate missing/null content in chat messages

### DIFF
--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -363,6 +363,60 @@ fn build_raw_json_messages_includes_tool_fields() {
     assert_eq!(arr[1]["role"].as_str().unwrap(), "tool");
 }
 
+#[test]
+fn deserialize_tool_call_request_without_assistant_content() {
+    // Issue #89: OpenAI-compatible clients omit `content` on the assistant
+    // `tool_calls` message of a multi-turn tool loop. The follow-up request
+    // must deserialize instead of being rejected with HTTP 422.
+    let json = r#"{
+        "model": "test",
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "get_system_info", "arguments": "{}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "mem: 12GB free"}
+        ]
+    }"#;
+    let req: ChatCompletionRequest =
+        serde_json::from_str(json).expect("missing assistant content must deserialize");
+    assert_eq!(req.messages.len(), 3);
+    assert_eq!(req.messages[1].content.text(), "");
+    assert!(req.messages[1].tool_calls.is_some());
+}
+
+#[test]
+fn build_raw_json_messages_emits_empty_content_for_missing_field() {
+    // Issue #89 follow-up: a `tool_calls` message that omitted `content` must
+    // still render a `"content"` key (empty string) so Jinja chat templates
+    // that reference `message.content` keep rendering.
+    let json = r#"{
+        "model": "test",
+        "messages": [
+            {"role": "user", "content": "Call weather"},
+            {"role": "assistant", "tool_calls": [{
+                "id": "call_abc",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": "{}"}
+            }]}
+        ]
+    }"#;
+    let request: ChatCompletionRequest = serde_json::from_str(json).unwrap();
+    let raw = build_raw_json_messages(&request);
+    let arr = raw.as_array().unwrap();
+    assert_eq!(arr.len(), 2);
+
+    let assistant = &arr[1];
+    assert!(assistant.get("tool_calls").is_some());
+    assert_eq!(
+        assistant.get("content").and_then(|c| c.as_str()),
+        Some(""),
+        "content key must be present and empty for Jinja templates"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Issue #410 — preserve_thinking plumbing through prepare_chat_request
 // ---------------------------------------------------------------------------

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -269,10 +269,44 @@ impl MessageContent {
     }
 }
 
+impl Default for MessageContent {
+    /// Empty text — the canonical "no content" value.
+    ///
+    /// Assistant messages whose payload is a `tool_calls` array legitimately
+    /// omit `content` or send `null` (issue #89); both map to this.
+    fn default() -> Self {
+        MessageContent::Text(String::new())
+    }
+}
+
+/// Deserialize [`MessageContent`], tolerating an explicit JSON `null`.
+///
+/// Paired with `#[serde(default)]` on the field, this lets `content` accept
+/// the three shapes OpenAI-compatible clients emit on assistant messages that
+/// carry `tool_calls` (issue #89): the key is absent (handled by `default`),
+/// the value is `null` (mapped to empty content here), or the value is a
+/// normal string / multimodal array. Without it, axum's `Json` extractor
+/// rejects the follow-up request of a tool-calling loop with HTTP 422
+/// (`missing field 'content'`).
+fn deserialize_message_content<'de, D>(deserializer: D) -> Result<MessageContent, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<MessageContent>::deserialize(deserializer)?.unwrap_or_default())
+}
+
 /// Chat message
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub role: Role,
+    /// Message content.
+    ///
+    /// Optional and nullable per the OpenAI Chat Completions spec: assistant
+    /// messages that carry `tool_calls` may omit `content` or send `null`. A
+    /// missing or `null` value deserializes to empty text (issue #89), keeping
+    /// the `content` field present for Jinja chat templates that read
+    /// `message.content`.
+    #[serde(default, deserialize_with = "deserialize_message_content")]
     pub content: MessageContent,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -703,4 +737,64 @@ pub struct TokenizeRequest {
 pub struct DetokenizeRequest {
     /// Token IDs to decode
     pub tokens: Vec<i32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_content_default_is_empty_text() {
+        let c = MessageContent::default();
+        assert_eq!(c.text(), "");
+        assert!(matches!(c, MessageContent::Text(_)));
+    }
+
+    #[test]
+    fn message_without_content_field_deserializes_to_empty() {
+        // OpenAI-compatible clients omit `content` on assistant messages whose
+        // payload is a `tool_calls` array (issue #89).
+        let json = r#"{
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "call_1", "type": "function",
+                 "function": {"name": "get_system_info", "arguments": "{}"}}
+            ]
+        }"#;
+        let msg: Message = serde_json::from_str(json).expect("missing content must deserialize");
+        assert_eq!(msg.content.text(), "");
+        assert!(msg.tool_calls.is_some());
+    }
+
+    #[test]
+    fn message_with_null_content_deserializes_to_empty() {
+        // Some clients send `"content": null` rather than omitting the key.
+        let json = r#"{"role": "assistant", "content": null}"#;
+        let msg: Message = serde_json::from_str(json).expect("null content must deserialize");
+        assert_eq!(msg.content.text(), "");
+        assert!(matches!(msg.content, MessageContent::Text(_)));
+    }
+
+    #[test]
+    fn message_with_string_content_deserializes() {
+        let json = r#"{"role": "user", "content": "hello"}"#;
+        let msg: Message = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.content.text(), "hello");
+        assert!(matches!(msg.content, MessageContent::Text(_)));
+    }
+
+    #[test]
+    fn message_with_multimodal_content_deserializes() {
+        let json = r#"{"role": "user", "content": [
+            {"type": "text", "text": "describe"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+        ]}"#;
+        let msg: Message = serde_json::from_str(json).unwrap();
+        assert!(matches!(msg.content, MessageContent::Parts(_)));
+        assert_eq!(msg.content.text(), "describe");
+        assert_eq!(
+            msg.content.image_urls(),
+            vec!["data:image/png;base64,AAAA".to_string()]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Multi-turn tool-calling against mlxcel's `/v1/chat/completions` failed at the second round: OpenAI-compatible clients omit `content` (or send `content: null`) on assistant messages that carry `tool_calls`, but `Message.content` was a required, non-nullable field, so axum's `Json` extractor rejected the follow-up request with **HTTP 422** (`missing field 'content'`) before the handler ran. `llama-server` tolerates this, so the incompatibility was mlxcel-specific and broke agentic tool loops at the first tool round.

## Fix

- `MessageContent` now implements `Default` → empty text.
- `Message.content` uses `#[serde(default, deserialize_with = "deserialize_message_content")]`: a **missing** key falls back to the default; an explicit **`null`** is mapped to empty content by the custom deserializer; normal **string** / **multimodal** content is unaffected.
- The field stays typed as `MessageContent` (not `Option<…>`), so every existing consumer (`content.text()`) and constructor is untouched.
- `build_raw_json_messages` keeps emitting a `"content"` key — empty string when absent — so Jinja chat templates that reference `message.content` keep rendering (issue follow-up #1).

## Tests

- `request.rs`: type-level unit tests — `Default` is empty text, deserialize with missing field, explicit `null`, plain string, and multimodal array.
- `chat_request_tests.rs`: the issue's exact 3-message reproduction deserializes, and `build_raw_json_messages` emits `"content": ""` for a `tool_calls` message that omitted content.

Verified with `cargo fmt --check`, `cargo clippy --all-targets --features metal,accelerate -- -D warnings`, and the targeted test run (9/9 pass).

Fixes #89
