### PR TITLE
feat(download): global model store + default migration + HF-cache read reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,6 +1892,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "dirs",
  "fancy-regex 0.17.0",
  "futures",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,14 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 base64 = "0.22"
 
 # Utils
+# `dirs` resolves the platform home directory for the downloader's HF-cache
+# read-reuse default (`~/.cache/huggingface/hub`) when neither `HF_HUB_CACHE`
+# nor `HF_HOME` is set (issue #93). Already present transitively via
+# mlxcel-core; promoted to a direct dependency so `src/downloader/store.rs`
+# can call `dirs::home_dir()` without leaning on a transitive re-export. The
+# mlxcel store root itself comes from `mlxcel_core::cache_root()`, which uses
+# the same crate.
+dirs = "6"
 glob = "0.3.2"
 path-clean = "1.0.1"
 minijinja = { version = "2.20", features = ["loop_controls"] }

--- a/README.md
+++ b/README.md
@@ -37,27 +37,39 @@ brew install mlxcel
 ### Run a model
 
 ```bash
-# Download an MLX-format checkpoint from Hugging Face.
+# Download an MLX-format checkpoint from Hugging Face. By default it lands in
+# the location-independent global store at
+# ${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>, so a model
+# downloaded once is runnable from any directory. If the repo is already in
+# your HuggingFace cache (HF_HUB_CACHE / HF_HOME), the existing snapshot is
+# reused instead of re-downloading.
 mlxcel download mlx-community/Qwen3.5-0.8B-4bit
+# -> ~/.cache/mlxcel/models/mlx-community/Qwen3.5-0.8B-4bit
 
 # Check the memory budget before loading anything.
-mlxcel inspect -m models/Qwen3.5-0.8B-4bit --max-tokens 32768
+mlxcel inspect \
+    -m ~/.cache/mlxcel/models/mlx-community/Qwen3.5-0.8B-4bit \
+    --max-tokens 32768
 
 # One-off generation.
 mlxcel generate \
-    -m models/Qwen3.5-0.8B-4bit \
+    -m ~/.cache/mlxcel/models/mlx-community/Qwen3.5-0.8B-4bit \
     -p "Hello, world!" -n 100
 
 # Same generation, but refuse to start if the model + 32K KV cache will not fit.
 mlxcel generate \
-    -m models/Qwen3.5-0.8B-4bit \
+    -m ~/.cache/mlxcel/models/mlx-community/Qwen3.5-0.8B-4bit \
     -p "Hello, world!" -n 32768 \
     --estimate-memory
 
 # OpenAI-compatible server.
 mlxcel-server \
-    -m models/Qwen3.5-0.8B-4bit \
+    -m ~/.cache/mlxcel/models/mlx-community/Qwen3.5-0.8B-4bit \
     --port 8080
+
+# Prefer a project-local checkout? Opt out of the global store with --local-dir;
+# the snapshot lands exactly where you point it.
+mlxcel download mlx-community/Qwen3.5-0.8B-4bit --local-dir ./models/Qwen3.5-0.8B-4bit
 ```
 
 `mlxcel inspect` is read-only and prints a byte-level breakdown of weights /

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -33,7 +33,7 @@ and cached on first use. Set them before starting `mlxcel` or `mlxcel-server`.
 | `MLXCEL_WIRED_LIMIT` | `max`, `0`, `none`, bytes, `NGB`, `NMB` | `max` | Apple Silicon GPU wired-memory limit. Unset/empty/`max` sets MLX's reported GPU max memory size; `0`/`none` disables the limit; numeric values set an explicit limit. |
 | `MLXCEL_MEMORY_LIMIT` | `0`, `none`, bytes, `NGB`, `NMB` | unset | Soft MLX allocator memory cap. Unset/`0`/`none` lets MLX use its backend default; numeric values cap the allocator and make MLX raise an exception once allocations would push the working set past this value. Also feeds the `mlxcel inspect` / `--estimate-memory` preflight as the authoritative "available unified memory" figure when nonzero. |
 | `MLXCEL_HEADROOM_FACTOR` | positive `f64` | `1.20` | Runtime/activation headroom multiplier used by the unified memory estimator (`mlxcel inspect`, `--estimate-memory`, `--recommend-quant`). Positive values `<= 1.0` disable the headroom term; invalid or non-positive values warn and fall back to the default. Override only for calibration runs — see the in-code recipe in `src/execution/memory_estimate.rs`. |
-| `MLXCEL_CACHE_DIR` | directory path | `$HOME/.cache/mlxcel` | Root for the tokenizer language-analysis disk cache used by language-bias features. Files live under `tokenizer-scripts/`. |
+| `MLXCEL_CACHE_DIR` | directory path | `$HOME/.cache/mlxcel` | Root for mlxcel's on-disk caches. The tokenizer language-analysis disk cache (language-bias features) lives under `tokenizer-scripts/`, and `mlxcel download`'s location-independent global model store lives under `models/<owner>/<name>`. |
 | `MLXCEL_SERVER_DECODE_STORAGE` | `auto`, `dense`, `paged` | `auto` | Server continuous-batching decode storage. `--decode-storage-backend` takes precedence. Invalid values warn and fall back to `auto`. |
 | `MLXCEL_SURGERY` | YAML file path | unset | Feature-gated weight-load surgery configuration. `--surgery` takes precedence when the `surgery` feature is built. |
 
@@ -71,6 +71,8 @@ CUDA builds also use non-`MLXCEL_*` variables such as `CUDA_HOME` and
 |----------|--------|---------|-------|
 | `MLXCEL_NO_PROGRESS` | any non-empty value | unset | Suppresses interactive download progress bars. `NO_COLOR` and `CI=true` also suppress bars. |
 | `MLXCEL_ALLOW_INSECURE_ENDPOINT` | any non-empty value | unset | Allows sending a Hugging Face token to a non-HTTPS `HF_ENDPOINT`. Leave unset outside audited internal mirrors. |
+| `HF_HUB_CACHE` | directory path | unset | Probed read-only for an already-downloaded snapshot before `mlxcel download` fetches anything (the existing copy is reused, never re-fetched). Used verbatim as the HuggingFace Hub cache directory. mlxcel never writes into the HF content-addressed layout. |
+| `HF_HOME` | directory path | `$HOME/.cache/huggingface` | Fallback HuggingFace cache root when `HF_HUB_CACHE` is unset; the hub lives under `HF_HOME/hub`. Same read-only reuse semantics as `HF_HUB_CACHE`. |
 
 ## Server prompt-cache variables
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -117,9 +117,11 @@ For the complete `MLXCEL_*` reference, see
 ./target/release/mlxcel --version
 ./target/release/mlxcel-server --version
 
+# `download` defaults to the global store at
+# ${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>.
 ./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit
 ./target/release/mlxcel generate \
-    -m models/Qwen3-0.6B-4bit \
+    -m ~/.cache/mlxcel/models/mlx-community/Qwen3-0.6B-4bit \
     -p "Hello" -n 1
 ```
 

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -100,7 +100,9 @@ Thunderbolt mode:
   path uses the shared TCP transport core over the Bridge network.
 
 Subcommands:
-  download <REPO_ID>    Fetch a HuggingFace model snapshot into models/<basename>
+  download <REPO_ID>    Fetch a HuggingFace model snapshot into the global store
+                        (${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>);
+                        reuses an existing HuggingFace cache copy. --local-dir opts out.
 
 See also: docs/distributed.md"
 )]

--- a/src/downloader/cli.rs
+++ b/src/downloader/cli.rs
@@ -31,11 +31,15 @@ use std::path::PathBuf;
 #[derive(Args, Debug, Clone)]
 #[command(after_help = "\
 Examples:
-  # Default destination is `models/<repo_basename>`:
+  # Default destination is the global store at
+  # ${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>:
   mlxcel download mlx-community/Qwen3-4B-4bit
-  # → models/Qwen3-4B-4bit/
+  # -> ~/.cache/mlxcel/models/mlx-community/Qwen3-4B-4bit/
 
-  # Explicit local directory:
+  # If the repo is already in your HuggingFace cache (HF_HUB_CACHE / HF_HOME),
+  # the download is skipped and the existing snapshot is reused.
+
+  # Explicit local directory (opt-out of the global store):
   mlxcel download mlx-community/Qwen3-4B-4bit --local-dir /tmp/qwen
 
   # Specific revision (branch, tag, or commit hash):
@@ -51,11 +55,14 @@ pub struct DownloadArgs {
     #[arg(value_name = "REPO_ID")]
     pub repo_id: String,
 
-    /// Local destination directory.
+    /// Local destination directory (opt-out of the global store).
     ///
-    /// Defaults to `models/<repo_basename>` under the current working
-    /// directory (e.g. `mlx-community/Qwen3-4B-4bit` →
-    /// `models/Qwen3-4B-4bit`).
+    /// When omitted, the snapshot lands in the location-independent global
+    /// store at `${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>`
+    /// (e.g. `mlx-community/Qwen3-4B-4bit` ->
+    /// `~/.cache/mlxcel/models/mlx-community/Qwen3-4B-4bit`). An existing
+    /// HuggingFace cache copy is reused instead of re-downloading. Pass this
+    /// flag to write the snapshot to an explicit path instead.
     #[arg(long, value_name = "PATH")]
     pub local_dir: Option<PathBuf>,
 

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -29,8 +29,12 @@
 //!   `HUGGING_FACE_HUB_TOKEN` env > anonymous. Tokens are validated to be
 //!   pure printable-ASCII (no control chars) before they are used in an
 //!   `Authorization` header (issue #650, L3).
-//! - **Default destination** — `models/<repo_basename>` under the current
-//!   working directory, mirroring the `CLAUDE.md` "Testing Models" convention.
+//! - **Default destination** — the location-independent global store at
+//!   `${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>` (issue
+//!   #93), so a model downloaded once runs from any directory. `--local-dir`
+//!   is the explicit opt-out. Before downloading, an existing HuggingFace Hub
+//!   cache snapshot of the same repo is reused read-only (no re-fetch). See
+//!   [`store`] for the path resolution and HF-cache probing.
 //! - **Caching** — without `--force`, an existing snapshot with all expected
 //!   files at the right size is treated as a no-op. With `--force`, every file
 //!   is re-fetched and overwritten.
@@ -76,11 +80,13 @@ mod cli;
 mod errors;
 mod filters;
 mod progress;
+mod store;
 
 pub use cli::DownloadArgs;
 pub use errors::map_hf_error;
 pub use filters::{is_wanted_file, repo_basename};
 pub use progress::should_show_progress;
+pub use store::{hf_cache_snapshot, model_dir, store_root};
 
 use anyhow::{Context, Result, anyhow};
 use futures::StreamExt;
@@ -151,8 +157,10 @@ const PARTIAL_TEMPFILE_STALE_AGE: Duration = Duration::from_secs(60 * 60);
 pub struct DownloadOptions {
     /// HuggingFace repository identifier, e.g. `mlx-community/Qwen3-4B-4bit`.
     pub repo_id: String,
-    /// Local destination directory. When `None`, defaults to
-    /// `models/<repo_basename>` under the current working directory.
+    /// Local destination directory. When `None`, defaults to the global store
+    /// at `${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>`
+    /// (issue #93). `Some(path)` is the explicit opt-out and writes the
+    /// snapshot at `path` verbatim.
     pub local_dir: Option<PathBuf>,
     /// Repository revision (branch, tag, or commit). Defaults to `main` when
     /// `None`.
@@ -177,13 +185,27 @@ impl DownloadOptions {
         }
     }
 
-    /// Resolve the destination directory, applying the
-    /// `models/<repo_basename>` default when no explicit `--local-dir` was
-    /// given.
+    /// Resolve the destination directory for a fresh download.
+    ///
+    /// - An explicit `--local-dir PATH` is honored verbatim (the opt-out).
+    /// - Otherwise the default is the location-independent global store at
+    ///   `${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>`
+    ///   (issue #93), so a model downloaded once is runnable from any
+    ///   directory.
+    /// - As a last-resort fallback (no home directory *and* `MLXCEL_CACHE_DIR`
+    ///   unset — practically never on a supported platform), we degrade to the
+    ///   legacy per-CWD `models/<repo_basename>` so the downloader still
+    ///   produces a usable path instead of panicking.
+    ///
+    /// Note: this returns the *write* destination only. HuggingFace-cache
+    /// read-reuse (skipping the download entirely when a snapshot already
+    /// exists under `$HF_HUB_CACHE` / `$HF_HOME`) is handled separately in
+    /// [`download_repo`] so that `--local-dir` continues to mean "write here".
     pub fn resolve_local_dir(&self) -> PathBuf {
         match &self.local_dir {
             Some(path) => path.clone(),
-            None => PathBuf::from("models").join(repo_basename(&self.repo_id)),
+            None => store::model_dir(&self.repo_id)
+                .unwrap_or_else(|| PathBuf::from("models").join(repo_basename(&self.repo_id))),
         }
     }
 }
@@ -550,6 +572,28 @@ async fn stream_to_tempfile(
 /// invalid repo id, missing authentication on a gated repo, missing revision,
 /// network failure, and on-disk I/O errors.
 pub fn download_repo(opts: DownloadOptions) -> Result<()> {
+    // HF-cache read-reuse (issue #93): when the caller did not pin an explicit
+    // `--local-dir` and is not forcing a refresh, reuse a complete snapshot
+    // already present in the HuggingFace Hub cache (`$HF_HUB_CACHE` /
+    // `$HF_HOME` / `~/.cache/huggingface/hub`). This lets users who already
+    // pulled a model with mlx-lm / transformers skip re-fetching gigabytes.
+    // The reuse is strictly read-only — we never write into the HF
+    // content-addressed layout. An explicit `--local-dir` keeps "write here"
+    // semantics and bypasses this short-circuit entirely.
+    if opts.local_dir.is_none()
+        && !opts.force
+        && let Some(hf_snapshot) = store::hf_cache_snapshot(&opts.repo_id, opts.revision.as_deref())
+    {
+        println!(
+            "[mlxcel download] repo={} revision={} already present in HuggingFace cache; \
+             reusing without re-download: {}",
+            opts.repo_id,
+            opts.revision.as_deref().unwrap_or("main"),
+            hf_snapshot.display(),
+        );
+        return Ok(());
+    }
+
     let local_dir = opts.resolve_local_dir();
     let token = resolve_token(opts.token.as_deref());
     let endpoint = hf_endpoint();

--- a/src/downloader/store.rs
+++ b/src/downloader/store.rs
@@ -1,0 +1,477 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Location-independent global model store (epic #92, issue #93).
+//!
+//! Today's per-CWD `models/<basename>` default ties a downloaded snapshot to
+//! the directory it was fetched from. This module introduces a single shared
+//! store so a model downloaded once can be run from anywhere, mirroring the
+//! mlx-lm / ollama / LM Studio convenience UX.
+//!
+//! # Layout
+//!
+//! - **Store root** — [`store_root`] = `${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}`.
+//!   This reuses the exact same root and env-var semantics as the tokenizer
+//!   language-analysis disk cache via [`mlxcel_core::cache_root`]; the model
+//!   store lives in a sibling `models/` subtree next to `tokenizer-scripts/`.
+//! - **Per-model directory** — [`model_dir`] = `store_root()/models/<owner>/<name>`.
+//!   The `<owner>/<name>` namespacing matches HuggingFace / LM Studio and
+//!   prevents same-name collisions across owners (e.g.
+//!   `mlx-community/Qwen3-4B-4bit` vs `Qwen/Qwen3-4B-4bit`).
+//!
+//! # HuggingFace cache read-reuse
+//!
+//! [`hf_cache_snapshot`] probes an existing HuggingFace Hub cache
+//! (`HF_HUB_CACHE`, then `HF_HOME/hub`, then `~/.cache/huggingface/hub`) for a
+//! complete snapshot of the requested repo + revision. When found, the caller
+//! reuses it directly so users who already pulled a model with mlx-lm /
+//! transformers do not re-fetch gigabytes. This is **read-only**: mlxcel never
+//! writes into the HF content-addressed layout.
+
+use std::path::{Path, PathBuf};
+
+/// Sub-directory under the mlxcel cache root that holds downloaded model
+/// snapshots, e.g. `${MLXCEL_CACHE_DIR}/models/<owner>/<name>`.
+pub const MODELS_SUBDIR: &str = "models";
+
+/// HuggingFace Hub cache sub-directory (under `HF_HOME`) and the trailing
+/// segment of the default `~/.cache/huggingface/hub` path.
+const HF_HUB_SUBDIR: &str = "hub";
+
+/// Resolve the mlxcel store root directory
+/// (`${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}`).
+///
+/// Delegates to [`mlxcel_core::cache_root`] so the model store and the
+/// tokenizer language-analysis disk cache always agree on the root and on the
+/// `MLXCEL_CACHE_DIR` override. Returns `None` only when neither
+/// `MLXCEL_CACHE_DIR` nor a home directory can be determined.
+pub fn store_root() -> Option<PathBuf> {
+    mlxcel_core::cache_root()
+}
+
+/// Resolve the global store directory for a given HuggingFace `repo_id`.
+///
+/// Returns `store_root()/models/<owner>/<name>`. When `repo_id` has no `/`
+/// separator (e.g. a bare `gpt2`), the whole id is used as the final path
+/// component so the layout stays well-formed.
+///
+/// Returns `None` when [`store_root`] cannot be resolved (no
+/// `MLXCEL_CACHE_DIR` and no home directory).
+pub fn model_dir(repo_id: &str) -> Option<PathBuf> {
+    let root = store_root()?;
+    Some(model_dir_in(&root, repo_id))
+}
+
+/// Pure helper: compose `<root>/models/<owner>/<name>` from an explicit store
+/// root. Split out so unit tests can assert the layout without depending on
+/// process-wide env state.
+///
+/// `repo_id` segments are sanitized to stay inside the per-model directory:
+/// only the `<owner>` and `<name>` components are honored, and any path
+/// traversal (`.`, `..`, empty segments) or absolute/backslash shapes collapse
+/// to a single safe `<name>` component. This mirrors the downloader's
+/// `is_safe_relative_path` posture so an adversarial repo id cannot escape the
+/// store root.
+fn model_dir_in(root: &Path, repo_id: &str) -> PathBuf {
+    let mut dir = root.join(MODELS_SUBDIR);
+    for segment in sanitize_repo_id_segments(repo_id) {
+        dir.push(segment);
+    }
+    dir
+}
+
+/// Split a HuggingFace `repo_id` into the path segments used under
+/// `models/`, rejecting any unsafe component.
+///
+/// HuggingFace repo ids are `<owner>/<name>` (exactly one slash) or a bare
+/// `<name>`. We keep `Normal` components only; if sanitization leaves nothing
+/// usable (e.g. `repo_id` was `..` or `/`), we fall back to a single
+/// `"_unknown_"` segment so the path is still well-formed and contained.
+fn sanitize_repo_id_segments(repo_id: &str) -> Vec<String> {
+    use std::path::Component;
+    let trimmed = repo_id.trim().replace('\\', "/");
+    let mut out: Vec<String> = Vec::new();
+    for raw in trimmed.split('/') {
+        if raw.is_empty() || raw == "." || raw == ".." {
+            continue;
+        }
+        // Defensive: collapse any residual path semantics in a single segment.
+        let seg = Path::new(raw);
+        let mut ok = true;
+        for c in seg.components() {
+            match c {
+                Component::Normal(s) if !s.is_empty() => {}
+                _ => {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if ok {
+            out.push(raw.to_string());
+        }
+    }
+    if out.is_empty() {
+        out.push("_unknown_".to_string());
+    }
+    out
+}
+
+/// Resolve the HuggingFace Hub cache directory, honoring the standard env vars.
+///
+/// Precedence (matches `huggingface_hub`):
+/// 1. `HF_HUB_CACHE` — used verbatim as the hub directory.
+/// 2. `HF_HOME/hub` — when `HF_HOME` is set.
+/// 3. `$HOME/.cache/huggingface/hub` — the default.
+///
+/// Empty / whitespace-only env values are ignored so an exported-but-empty
+/// `HF_HOME=""` does not short-circuit the fallback chain.
+fn hf_hub_cache_dir() -> Option<PathBuf> {
+    if let Some(dir) = non_empty_env("HF_HUB_CACHE") {
+        return Some(PathBuf::from(dir));
+    }
+    if let Some(home) = non_empty_env("HF_HOME") {
+        return Some(PathBuf::from(home).join(HF_HUB_SUBDIR));
+    }
+    dirs::home_dir().map(|h| h.join(".cache").join("huggingface").join(HF_HUB_SUBDIR))
+}
+
+/// Read an env var, returning `Some(trimmed-as-owned)` only for a non-empty,
+/// non-whitespace value.
+fn non_empty_env(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// HuggingFace's on-disk repo-folder name for a model: `models--<owner>--<name>`,
+/// with every `/` in the repo id replaced by `--`.
+fn hf_repo_folder(repo_id: &str) -> String {
+    format!("models--{}", repo_id.replace('/', "--"))
+}
+
+/// Probe an existing HuggingFace Hub cache for a complete snapshot of
+/// `repo_id` at `revision` (defaulting to `main`).
+///
+/// Returns the snapshot directory (`.../models--<owner>--<name>/snapshots/<sha>`)
+/// only when it exists and looks complete (contains a `config.json`). The
+/// lookup is **read-only** — nothing is written into the HF cache.
+///
+/// # Revision resolution
+/// HuggingFace names snapshot directories by commit SHA, not by branch/tag.
+/// We therefore try, in order:
+/// 1. A snapshot directory literally named `revision` (works when the caller
+///    passes a commit hash).
+/// 2. The SHA recorded in `refs/<revision>` (works for branch/tag names like
+///    `main`), then the snapshot directory named by that SHA.
+pub fn hf_cache_snapshot(repo_id: &str, revision: Option<&str>) -> Option<PathBuf> {
+    let hub = hf_hub_cache_dir()?;
+    let repo_dir = hub.join(hf_repo_folder(repo_id));
+    if !repo_dir.is_dir() {
+        return None;
+    }
+    let revision = revision.unwrap_or("main");
+    let snapshots = repo_dir.join("snapshots");
+
+    // 1. Direct: revision is already a snapshot dir name (commit hash).
+    let direct = snapshots.join(revision);
+    if snapshot_is_complete(&direct) {
+        return Some(direct);
+    }
+
+    // 2. Indirect: resolve refs/<revision> -> commit SHA, then snapshots/<sha>.
+    let ref_path = repo_dir.join("refs").join(revision);
+    if let Ok(sha) = std::fs::read_to_string(&ref_path) {
+        let sha = sha.trim();
+        if !sha.is_empty() {
+            let by_sha = snapshots.join(sha);
+            if snapshot_is_complete(&by_sha) {
+                return Some(by_sha);
+            }
+        }
+    }
+
+    None
+}
+
+/// True when `dir` is an existing directory that contains a `config.json`.
+///
+/// Mirrors the downloader's own completeness gate (`snapshot_complete`), which
+/// also keys on `config.json` presence. Snapshot entries in the HF cache are
+/// symlinks into the content-addressed `blobs/` store; `Path::exists` follows
+/// symlinks, so a present-and-non-dangling `config.json` is a good signal that
+/// the snapshot was fully materialized.
+fn snapshot_is_complete(dir: &Path) -> bool {
+    dir.is_dir() && dir.join("config.json").exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Env-var-sensitive tests must serialize through the crate-wide `ENV_LOCK`
+    // (issue #573): Rust 2024's `set_var`/`remove_var` are `unsafe` because
+    // libc's env block has no internal lock and concurrent mutation is UB.
+    use crate::test_support::env_lock::env_lock;
+
+    /// Restore an env var to a prior captured state.
+    fn restore_env(key: &str, prev: Option<String>) {
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
+    // ── store_root / model_dir ───────────────────────────────────────────────
+
+    #[test]
+    fn store_root_honors_mlxcel_cache_dir_override() {
+        let _guard = env_lock();
+        let prev = std::env::var("MLXCEL_CACHE_DIR").ok();
+        unsafe {
+            std::env::set_var("MLXCEL_CACHE_DIR", "/tmp/mlxcel-store-test");
+        }
+        let root = store_root();
+        restore_env("MLXCEL_CACHE_DIR", prev);
+
+        assert_eq!(root, Some(PathBuf::from("/tmp/mlxcel-store-test")));
+    }
+
+    #[test]
+    fn model_dir_uses_owner_name_layout_under_override() {
+        let _guard = env_lock();
+        let prev = std::env::var("MLXCEL_CACHE_DIR").ok();
+        unsafe {
+            std::env::set_var("MLXCEL_CACHE_DIR", "/tmp/mlxcel-store-test");
+        }
+        let dir = model_dir("mlx-community/Qwen3-4B-4bit");
+        restore_env("MLXCEL_CACHE_DIR", prev);
+
+        assert_eq!(
+            dir,
+            Some(
+                PathBuf::from("/tmp/mlxcel-store-test")
+                    .join("models")
+                    .join("mlx-community")
+                    .join("Qwen3-4B-4bit")
+            )
+        );
+    }
+
+    #[test]
+    fn model_dir_in_separates_owners_with_same_name() {
+        let root = PathBuf::from("/store");
+        let a = model_dir_in(&root, "mlx-community/Qwen3-4B-4bit");
+        let b = model_dir_in(&root, "Qwen/Qwen3-4B-4bit");
+        assert_ne!(a, b);
+        assert_eq!(
+            a,
+            PathBuf::from("/store/models/mlx-community/Qwen3-4B-4bit")
+        );
+        assert_eq!(b, PathBuf::from("/store/models/Qwen/Qwen3-4B-4bit"));
+    }
+
+    #[test]
+    fn model_dir_in_handles_bare_repo_id() {
+        let root = PathBuf::from("/store");
+        assert_eq!(
+            model_dir_in(&root, "gpt2"),
+            PathBuf::from("/store/models/gpt2")
+        );
+    }
+
+    #[test]
+    fn model_dir_in_rejects_path_traversal() {
+        let root = PathBuf::from("/store");
+        // A malicious repo id must never escape the models/ subtree.
+        let escaped = model_dir_in(&root, "../../etc/passwd");
+        assert!(
+            escaped.starts_with(PathBuf::from("/store").join("models")),
+            "sanitized path {escaped:?} escaped the models/ subtree"
+        );
+        assert_eq!(
+            escaped,
+            PathBuf::from("/store/models/etc/passwd"),
+            "only Normal components should survive sanitization"
+        );
+
+        // A repo id that sanitizes to nothing collapses to a contained marker.
+        let only_dots = model_dir_in(&root, "..");
+        assert_eq!(only_dots, PathBuf::from("/store/models/_unknown_"));
+    }
+
+    #[test]
+    fn hf_repo_folder_matches_hf_layout() {
+        assert_eq!(
+            hf_repo_folder("mlx-community/Qwen3-4B-4bit"),
+            "models--mlx-community--Qwen3-4B-4bit"
+        );
+        assert_eq!(hf_repo_folder("gpt2"), "models--gpt2");
+    }
+
+    // ── hf_cache_snapshot ────────────────────────────────────────────────────
+
+    /// Build a fake HF hub cache for `repo_id` with a single snapshot named by
+    /// `sha`, a `refs/<branch>` pointer, and a `config.json` inside the
+    /// snapshot. Returns the hub root.
+    fn make_hf_cache(
+        hub: &Path,
+        repo_id: &str,
+        sha: &str,
+        branch: &str,
+        complete: bool,
+    ) -> PathBuf {
+        let repo_dir = hub.join(hf_repo_folder(repo_id));
+        let snap = repo_dir.join("snapshots").join(sha);
+        std::fs::create_dir_all(&snap).unwrap();
+        if complete {
+            std::fs::write(snap.join("config.json"), b"{}").unwrap();
+        }
+        let refs = repo_dir.join("refs");
+        std::fs::create_dir_all(&refs).unwrap();
+        std::fs::write(refs.join(branch), sha).unwrap();
+        repo_dir
+    }
+
+    #[test]
+    fn hf_cache_snapshot_resolves_branch_via_refs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hub = tmp.path().join("hub");
+        let sha = "0123456789abcdef0123456789abcdef01234567";
+        make_hf_cache(&hub, "mlx-community/Qwen3-4B-4bit", sha, "main", true);
+
+        let _guard = env_lock();
+        let prev_cache = std::env::var("HF_HUB_CACHE").ok();
+        let prev_home = std::env::var("HF_HOME").ok();
+        unsafe {
+            std::env::set_var("HF_HUB_CACHE", &hub);
+            std::env::remove_var("HF_HOME");
+        }
+        let found = hf_cache_snapshot("mlx-community/Qwen3-4B-4bit", None);
+        restore_env("HF_HUB_CACHE", prev_cache);
+        restore_env("HF_HOME", prev_home);
+
+        assert_eq!(
+            found,
+            Some(
+                hub.join(hf_repo_folder("mlx-community/Qwen3-4B-4bit"))
+                    .join("snapshots")
+                    .join(sha)
+            )
+        );
+    }
+
+    #[test]
+    fn hf_cache_snapshot_resolves_direct_commit_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hub = tmp.path().join("hub");
+        let sha = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+        make_hf_cache(&hub, "owner/model", sha, "main", true);
+
+        let _guard = env_lock();
+        let prev_cache = std::env::var("HF_HUB_CACHE").ok();
+        let prev_home = std::env::var("HF_HOME").ok();
+        unsafe {
+            std::env::set_var("HF_HUB_CACHE", &hub);
+            std::env::remove_var("HF_HOME");
+        }
+        // Pass the SHA directly as the revision.
+        let found = hf_cache_snapshot("owner/model", Some(sha));
+        restore_env("HF_HUB_CACHE", prev_cache);
+        restore_env("HF_HOME", prev_home);
+
+        assert_eq!(
+            found,
+            Some(
+                hub.join(hf_repo_folder("owner/model"))
+                    .join("snapshots")
+                    .join(sha)
+            )
+        );
+    }
+
+    #[test]
+    fn hf_cache_snapshot_uses_hf_home_hub_subdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Here we set HF_HOME (not HF_HUB_CACHE); the hub lives under HF_HOME/hub.
+        let hf_home = tmp.path();
+        let hub = hf_home.join("hub");
+        let sha = "1111111111111111111111111111111111111111";
+        make_hf_cache(&hub, "owner/model", sha, "main", true);
+
+        let _guard = env_lock();
+        let prev_cache = std::env::var("HF_HUB_CACHE").ok();
+        let prev_home = std::env::var("HF_HOME").ok();
+        unsafe {
+            std::env::remove_var("HF_HUB_CACHE");
+            std::env::set_var("HF_HOME", hf_home);
+        }
+        let found = hf_cache_snapshot("owner/model", None);
+        restore_env("HF_HUB_CACHE", prev_cache);
+        restore_env("HF_HOME", prev_home);
+
+        assert_eq!(
+            found,
+            Some(
+                hub.join(hf_repo_folder("owner/model"))
+                    .join("snapshots")
+                    .join(sha)
+            )
+        );
+    }
+
+    #[test]
+    fn hf_cache_snapshot_none_when_incomplete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hub = tmp.path().join("hub");
+        let sha = "2222222222222222222222222222222222222222";
+        // complete=false → no config.json inside the snapshot.
+        make_hf_cache(&hub, "owner/model", sha, "main", false);
+
+        let _guard = env_lock();
+        let prev_cache = std::env::var("HF_HUB_CACHE").ok();
+        let prev_home = std::env::var("HF_HOME").ok();
+        unsafe {
+            std::env::set_var("HF_HUB_CACHE", &hub);
+            std::env::remove_var("HF_HOME");
+        }
+        let found = hf_cache_snapshot("owner/model", None);
+        restore_env("HF_HUB_CACHE", prev_cache);
+        restore_env("HF_HOME", prev_home);
+
+        assert_eq!(found, None);
+    }
+
+    #[test]
+    fn hf_cache_snapshot_none_when_repo_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hub = tmp.path().join("hub");
+        std::fs::create_dir_all(&hub).unwrap();
+
+        let _guard = env_lock();
+        let prev_cache = std::env::var("HF_HUB_CACHE").ok();
+        let prev_home = std::env::var("HF_HOME").ok();
+        unsafe {
+            std::env::set_var("HF_HUB_CACHE", &hub);
+            std::env::remove_var("HF_HOME");
+        }
+        let found = hf_cache_snapshot("owner/never-downloaded", None);
+        restore_env("HF_HUB_CACHE", prev_cache);
+        restore_env("HF_HOME", prev_home);
+
+        assert_eq!(found, None);
+    }
+}

--- a/src/downloader/tests.rs
+++ b/src/downloader/tests.rs
@@ -46,20 +46,44 @@ fn repo_basename_strips_owner() {
 }
 
 #[test]
-fn default_local_dir_is_models_basename() {
+fn default_local_dir_is_global_store() {
+    // Issue #93: with no --local-dir, the default is the location-independent
+    // global store at `${MLXCEL_CACHE_DIR}/models/<owner>/<name>` (not the
+    // legacy per-CWD `models/<basename>`).
+    let _guard = env_lock();
+    let prev = std::env::var("MLXCEL_CACHE_DIR").ok();
+    unsafe {
+        std::env::set_var("MLXCEL_CACHE_DIR", "/tmp/mlxcel-resolve-test");
+    }
     let opts = DownloadOptions::from_args(&args("mlx-community/Qwen3-4B-4bit"));
+    let resolved = opts.resolve_local_dir();
+    restore_env("MLXCEL_CACHE_DIR", prev);
+
     assert_eq!(
-        opts.resolve_local_dir(),
-        PathBuf::from("models").join("Qwen3-4B-4bit")
+        resolved,
+        PathBuf::from("/tmp/mlxcel-resolve-test")
+            .join("models")
+            .join("mlx-community")
+            .join("Qwen3-4B-4bit")
     );
 }
 
 #[test]
 fn explicit_local_dir_is_respected() {
+    // An explicit --local-dir is the opt-out: it is honored verbatim and does
+    // not consult MLXCEL_CACHE_DIR / the global store.
+    let _guard = env_lock();
+    let prev = std::env::var("MLXCEL_CACHE_DIR").ok();
+    unsafe {
+        std::env::set_var("MLXCEL_CACHE_DIR", "/tmp/should-be-ignored");
+    }
     let mut a = args("mlx-community/Qwen3-4B-4bit");
     a.local_dir = Some(PathBuf::from("/tmp/custom-dir"));
     let opts = DownloadOptions::from_args(&a);
-    assert_eq!(opts.resolve_local_dir(), PathBuf::from("/tmp/custom-dir"));
+    let resolved = opts.resolve_local_dir();
+    restore_env("MLXCEL_CACHE_DIR", prev);
+
+    assert_eq!(resolved, PathBuf::from("/tmp/custom-dir"));
 }
 
 #[test]

--- a/src/lib/mlxcel-core/src/lang_analyzer/cache.rs
+++ b/src/lib/mlxcel-core/src/lang_analyzer/cache.rs
@@ -36,6 +36,28 @@ use super::{LangAnalyzerError, TokenLanguageIndex, CURRENT_VERSION};
 pub const CACHE_SUBDIR: &str = "tokenizer-scripts";
 
 // ============================================================================
+// Cache root resolution
+// ============================================================================
+
+/// Resolve the mlxcel cache root directory.
+///
+/// Reads `MLXCEL_CACHE_DIR` from the environment; falls back to
+/// `$HOME/.cache/mlxcel` via [`dirs::home_dir`]. Returns `None` only when
+/// neither `MLXCEL_CACHE_DIR` nor a home directory can be determined.
+///
+/// This is the single source of truth for the cache root across the codebase.
+/// The tokenizer language-analysis disk cache stores its files under
+/// `cache_root()/tokenizer-scripts/`, and the downloader's global model store
+/// (issue #93) stores model snapshots under `cache_root()/models/`. Sharing
+/// one resolver keeps the `MLXCEL_CACHE_DIR` override semantics identical for
+/// every consumer.
+pub fn cache_root() -> Option<PathBuf> {
+    std::env::var_os("MLXCEL_CACHE_DIR")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".cache/mlxcel")))
+}
+
+// ============================================================================
 // Cache path resolution
 // ============================================================================
 
@@ -48,10 +70,7 @@ pub const CACHE_SUBDIR: &str = "tokenizer-scripts";
 /// Panics only if neither `MLXCEL_CACHE_DIR` nor a home directory can be
 /// determined. In practice this should not happen on any supported platform.
 pub fn cache_path(vocab_hash: &str) -> PathBuf {
-    let base = std::env::var_os("MLXCEL_CACHE_DIR")
-        .map(PathBuf::from)
-        .or_else(|| dirs::home_dir().map(|h| h.join(".cache/mlxcel")))
-        .expect("no home directory and MLXCEL_CACHE_DIR not set");
+    let base = cache_root().expect("no home directory and MLXCEL_CACHE_DIR not set");
     base.join(CACHE_SUBDIR).join(format!("{vocab_hash}.bin"))
 }
 

--- a/src/lib/mlxcel-core/src/lang_analyzer/mod.rs
+++ b/src/lib/mlxcel-core/src/lang_analyzer/mod.rs
@@ -25,7 +25,7 @@
 //! - **B4** (`cache` submodule): disk cache for `TokenLanguageIndex` (vocab-hash keyed, postcard 1.x).
 
 pub mod cache;
-pub use cache::{cache_path, load_or_build, save, try_load};
+pub use cache::{cache_path, cache_root, load_or_build, save, try_load};
 
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -2291,6 +2291,12 @@ pub use lang_analyzer::{
     ExceptionConfig, InclusionPolicy, LangAnalyzerError, LangBiasConfig, LangBiasSet, LanguageCode,
 };
 
+// Re-export the shared mlxcel cache-root resolver (`${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}`)
+// so downstream crates (e.g. the `mlxcel` CLI downloader's global model store, issue #93)
+// derive their on-disk locations from the exact same root and env-var semantics the
+// tokenizer language-analysis disk cache already uses.
+pub use lang_analyzer::cache_root;
+
 fn use_single_query_maskless_path() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| {


### PR DESCRIPTION
## Summary

Foundation of epic #92. Introduces a single location-independent model store, makes it the default for all downloads, and reuses an existing HuggingFace cache on read — so a model fetched once is runnable from any directory (mlx-lm / ollama / LM Studio-style UX).

Previously `mlxcel download <repo-id>` wrote to a per-CWD `models/<basename>`, tying the snapshot to the directory it was fetched from. This PR moves the default to the global store while keeping `--local-dir` as the explicit opt-out.

## What changed

- **New `src/downloader/store.rs`**:
  - `store_root()` = `${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}`, derived from the shared `mlxcel_core::cache_root()` helper so the model store and the tokenizer language-analysis disk cache agree on the root and the `MLXCEL_CACHE_DIR` override.
  - `model_dir(repo_id)` = `store_root()/models/<owner>/<name>` — `<owner>/<name>` namespacing prevents same-name collisions across owners (e.g. `mlx-community/Qwen3-4B-4bit` vs `Qwen/Qwen3-4B-4bit`). Repo-id segments are sanitized so an adversarial id cannot escape the store root.
  - `hf_cache_snapshot(repo_id, revision)` probes `HF_HUB_CACHE`, then `HF_HOME/hub`, then `~/.cache/huggingface/hub` for a complete `models--<owner>--<name>/snapshots/<sha>` and returns it when present. Branch/tag revisions resolve via the `refs/<rev>` pointer; raw commit hashes resolve directly.
- **`DownloadOptions::resolve_local_dir()`** now defaults to `model_dir(repo_id)`. `--local-dir` is honored verbatim. A last-resort degrade to the legacy per-CWD `models/<basename>` only triggers when neither `MLXCEL_CACHE_DIR` nor a home directory is resolvable (practically never on a supported platform) so the downloader never panics.
- **`download_repo()`** gains a read-only HF-cache reuse short-circuit: when no `--local-dir` is pinned and `--force` is not set, an already-present snapshot in the HF cache is reused without re-downloading. mlxcel never writes into the HF content-addressed layout. An explicit `--local-dir` bypasses the short-circuit entirely ("write here").
- **`mlxcel_core::cache_root()`** (new, re-exported from the crate root): factors the `MLXCEL_CACHE_DIR`/home-dir resolution out of `cache_path()` into one source of truth. `cache_path()` now calls it, preserving byte-identical behavior (all 8 existing cache tests still pass).
- **`dirs`** promoted to a direct dependency of the `mlxcel` crate for the HF-cache default home-dir lookup. Already present transitively via mlxcel-core; no lockfile version change.
- **Docs / help**: `download --help` examples, the `mlxcel-server` command summary, and the README / installation / environment-variables docs updated to the new default path and HF-cache reuse semantics. No tracker URLs in help text.

The shared `DownloadArgs` means the `mlxcel-server download` path mirrors this behavior identically.

## Acceptance criteria

- [x] `mlxcel download mlx-community/Qwen3-4B-4bit` lands in `~/.cache/mlxcel/models/mlx-community/Qwen3-4B-4bit` (or under `$MLXCEL_CACHE_DIR`) — verified via resolved `dest=` line.
- [x] `--local-dir PATH` still places the snapshot at PATH — verified (bypasses store + HF reuse).
- [x] If the repo already exists under `$HF_HOME` / `$HF_HUB_CACHE`, the download is skipped and the HF path is used/reported — verified end-to-end against a fake cache (no network, no store dir created).
- [x] Existing per-CWD `./models/<basename>` snapshots remain loadable — unaffected; model loading takes arbitrary local paths, and only the *write* default changed.
- [x] `--help` / README / CLI-help consistency test updated; no tracker URLs in help text — `tests/cli_help_consistency.rs` passes (its golden blocks cover the TurboQuant / speculative flag groups, not the download path; the download help was updated and manually verified).
- [x] Unit tests for `store_root` / `model_dir` / `hf_cache_snapshot` including `MLXCEL_CACHE_DIR` and `HF_HOME` / `HF_HUB_CACHE` overrides.

## Testing

- `cargo test --lib downloader::store` — 11 passed
- `cargo test --lib downloader::tests::` — 43 passed, 1 ignored (live network)
- `cargo test -p mlxcel-core --lib lang_analyzer::cache` — 8 passed (cache_root refactor is behavior-preserving)
- `cargo test --test cli_help_consistency` — 8 passed
- `cargo clippy --lib --tests --features metal,accelerate -- -D warnings` (both crates) — clean
- `cargo fmt --check` — clean
- Manual end-to-end: HF-cache reuse short-circuit fires without network; `--local-dir` writes verbatim; default resolves to the global store path.

Broad `cargo test --lib` / release-build verification was deferred to central CI per the watchdog guard.

Closes #93.