### PR TITLE
feat(cli): local model management — list downloaded models + remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,29 @@ in `src/execution/memory_estimate.rs`.
 If you build from source instead, use `./target/release/mlxcel` and
 `./target/release/mlxcel-server` in place of the installed commands above.
 
+### Manage downloaded models
+
+The global store is shared across every directory, so list and prune it from
+anywhere:
+
+```bash
+# List downloaded models with their on-disk size and path.
+mlxcel list --local
+
+# Remove a model from the global store (prompts for confirmation).
+mlxcel rm mlx-community/Qwen3.5-0.8B-4bit
+
+# Remove without the prompt (for scripts / non-interactive shells).
+mlxcel rm mlx-community/Qwen3.5-0.8B-4bit --yes
+```
+
+`mlxcel list` without `--local` still prints the supported model
+architectures. `mlxcel list --local` instead enumerates the snapshots under
+`${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/`. `mlxcel rm <repo-id>`
+deletes only inside that store; a model that exists solely in the read-only
+HuggingFace cache (`HF_HUB_CACHE` / `HF_HOME`) is reported but never deleted,
+since mlxcel does not manage the HuggingFace cache.
+
 ### Build from source on Apple Silicon
 
 Prerequisites:

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -23,10 +23,12 @@ pub(crate) mod download;
 pub(crate) mod generate;
 mod generate_vlm;
 pub(crate) mod inspect;
+pub(crate) mod models;
 mod serve;
 
 pub(crate) use detect::run_detect;
 pub(crate) use download::run_download;
 pub(crate) use generate::run_generate;
 pub(crate) use inspect::run_inspect;
+pub(crate) use models::{run_list_local, run_remove};
 pub(crate) use serve::run_serve;

--- a/src/commands/models.rs
+++ b/src/commands/models.rs
@@ -1,0 +1,355 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Binary-side handlers for local model management (epic #92, issue #97).
+//!
+//! Two surfaces are implemented here, both operating on the location-
+//! independent global store introduced by issue #93
+//! (`${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>`):
+//!
+//! - **`mlxcel list --local`** — enumerates downloaded snapshots with repo-id,
+//!   on-disk size, and path (mirrors `ollama list` / `lms ls`). The bare
+//!   `mlxcel list` (architecture summary) is unchanged; `--local` switches the
+//!   command to this store listing instead.
+//! - **`mlxcel rm <repo-id>`** — removes a snapshot directory from the store
+//!   (confirms unless `--yes`). It never touches the read-only HuggingFace
+//!   cache: a repo that exists only there is reported, not deleted.
+//!
+//! The enumeration/deletion logic lives in [`mlxcel::downloader`] next to the
+//! store-layout helpers it depends on; these handlers are thin I/O + prompting
+//! shims so the store semantics stay in one place.
+
+use std::io::{IsTerminal, Write};
+
+use anyhow::{Result, anyhow};
+
+use mlxcel::downloader::{RemoveOutcome, StoredModel, list_models, remove_model, store_root};
+
+/// Run `mlxcel list --local`: print downloaded models from the global store.
+pub(crate) fn run_list_local() -> Result<()> {
+    let models = list_models();
+    let mut out = String::new();
+    render_local_models(&mut out, &models, store_root_display().as_deref());
+    print!("{out}");
+    Ok(())
+}
+
+/// Resolve the store root as a display string for the listing header, or
+/// `None` when it cannot be resolved (no `MLXCEL_CACHE_DIR` / home dir).
+fn store_root_display() -> Option<String> {
+    store_root().map(|p| p.join("models").display().to_string())
+}
+
+/// Render the `mlxcel list --local` output into `out`.
+///
+/// Separated from [`run_list_local`] so unit tests can capture the exact bytes
+/// without filesystem state. The format is intentionally simple and stable
+/// (golden-test friendly): a header line, then one aligned row per model with
+/// repo-id, human-readable size, and absolute path. An empty store prints a
+/// short, actionable hint instead of an empty table.
+fn render_local_models<W: std::fmt::Write>(
+    out: &mut W,
+    models: &[StoredModel],
+    store_models_dir: Option<&str>,
+) {
+    if models.is_empty() {
+        // Infallible: writing to a String / fmt buffer does not fail in
+        // practice for our callers; ignore the Result to keep the signature
+        // ergonomic.
+        let _ = match store_models_dir {
+            Some(dir) => writeln!(
+                out,
+                "No models downloaded in the mlxcel store ({dir}).\n\
+                 Download one with: mlxcel download <owner>/<name>"
+            ),
+            None => writeln!(
+                out,
+                "No models downloaded (mlxcel store root is unavailable; \
+                 set MLXCEL_CACHE_DIR).\n\
+                 Download one with: mlxcel download <owner>/<name>"
+            ),
+        };
+        return;
+    }
+
+    let total: u64 = models.iter().map(|m| m.size_bytes).sum();
+    let _ = match store_models_dir {
+        Some(dir) => writeln!(
+            out,
+            "Downloaded models ({}, {} total) in {dir}:",
+            models.len(),
+            compact_size(total)
+        ),
+        None => writeln!(
+            out,
+            "Downloaded models ({}, {} total):",
+            models.len(),
+            compact_size(total)
+        ),
+    };
+    let _ = writeln!(out);
+
+    // Width of the repo-id column = longest id, so SIZE/PATH align. The size
+    // column is right-aligned to a fixed width for tidy scanning.
+    let id_width = models
+        .iter()
+        .map(|m| m.repo_id.len())
+        .max()
+        .unwrap_or(0)
+        .max("REPO ID".len());
+    let sizes: Vec<String> = models.iter().map(|m| compact_size(m.size_bytes)).collect();
+    let size_width = sizes
+        .iter()
+        .map(String::len)
+        .max()
+        .unwrap_or(0)
+        .max("SIZE".len());
+
+    let _ = writeln!(
+        out,
+        "  {:<id_width$}  {:>size_width$}  PATH",
+        "REPO ID", "SIZE"
+    );
+    for (model, size) in models.iter().zip(&sizes) {
+        let _ = writeln!(
+            out,
+            "  {:<id_width$}  {:>size_width$}  {}",
+            model.repo_id,
+            size,
+            model.path.display()
+        );
+    }
+}
+
+/// Run `mlxcel rm <repo-id>`: remove a model from the global store.
+///
+/// Confirms interactively unless `yes` is set. Refuses to delete anything in
+/// the read-only HuggingFace cache (reports it instead). When stdin is not a
+/// TTY and `--yes` was not passed, the command errors rather than silently
+/// deleting or silently skipping — the operator must opt in explicitly.
+pub(crate) fn run_remove(repo_id: &str, yes: bool, revision: Option<&str>) -> Result<()> {
+    // Probe the store first so we can show what will be removed (and its size)
+    // before asking for confirmation, and so a not-found / HF-cache-only repo
+    // never reaches a confirmation prompt.
+    let target = mlxcel::downloader::model_dir(repo_id).ok_or_else(|| {
+        anyhow!(
+            "cannot resolve the mlxcel model store root \
+             (set MLXCEL_CACHE_DIR or ensure a home directory is available)"
+        )
+    })?;
+
+    if !target.is_dir() {
+        // Not in the store. Distinguish HF-cache-only from truly absent by
+        // letting the store helper do the probe (it is read-only).
+        match remove_model(repo_id, revision)? {
+            RemoveOutcome::HfCacheOnly { hf_path } => {
+                return Err(anyhow!(
+                    "'{repo_id}' is not in the mlxcel store; it exists only in the \
+                     read-only HuggingFace cache at {}.\nmlxcel does not manage the \
+                     HuggingFace cache and will not delete it. Use the huggingface_hub \
+                     tooling (e.g. `huggingface-cli delete-cache`) if you want to remove it.",
+                    hf_path.display()
+                ));
+            }
+            RemoveOutcome::NotFound => {
+                return Err(anyhow!(
+                    "'{repo_id}' is not in the mlxcel store (looked in {}).\n\
+                     Run `mlxcel list --local` to see downloaded models.",
+                    target.display()
+                ));
+            }
+            // Unreachable: target.is_dir() was false, so the store branch in
+            // remove_model cannot return Removed. Handle defensively.
+            RemoveOutcome::Removed { path, size_bytes } => {
+                println!(
+                    "Removed '{repo_id}' ({}) from {}",
+                    mlxcel::memory_estimate::format_bytes(size_bytes),
+                    path.display()
+                );
+                return Ok(());
+            }
+        }
+    }
+
+    // Store hit. Confirm unless --yes.
+    if !yes {
+        let size = dir_size_for_prompt(&target);
+        if !confirm_removal(repo_id, &target.display().to_string(), &size)? {
+            println!("Aborted; nothing was removed.");
+            return Ok(());
+        }
+    }
+
+    match remove_model(repo_id, revision)? {
+        RemoveOutcome::Removed { path, size_bytes } => {
+            println!(
+                "Removed '{repo_id}' ({}) from {}",
+                mlxcel::memory_estimate::format_bytes(size_bytes),
+                path.display()
+            );
+            Ok(())
+        }
+        // The directory existed a moment ago; a concurrent delete is the only
+        // way these arise. Report rather than pretend success.
+        RemoveOutcome::HfCacheOnly { .. } | RemoveOutcome::NotFound => Err(anyhow!(
+            "'{repo_id}' disappeared from the store before it could be removed \
+             (concurrent deletion?)"
+        )),
+    }
+}
+
+/// Best-effort size string for the confirmation prompt. Recomputed from the
+/// store helper's public listing is overkill for a single dir, so we sum here
+/// via the same walk the library uses; failures degrade to "unknown size".
+fn dir_size_for_prompt(dir: &std::path::Path) -> String {
+    // Reuse the library's listing to find this exact path's size when present,
+    // avoiding a second size-walk implementation in the binary.
+    let target = dir.to_path_buf();
+    if let Some(m) = list_models().into_iter().find(|m| m.path == target) {
+        return mlxcel::memory_estimate::format_bytes(m.size_bytes);
+    }
+    "unknown size".to_string()
+}
+
+/// Prompt on the controlling TTY for a yes/no confirmation. Returns `Ok(true)`
+/// only on an explicit affirmative. Errors (rather than defaulting either way)
+/// when stdin is not interactive, so scripted callers must pass `--yes`.
+fn confirm_removal(repo_id: &str, path: &str, size: &str) -> Result<bool> {
+    if !std::io::stdin().is_terminal() {
+        return Err(anyhow!(
+            "refusing to remove '{repo_id}' ({size}) at {path} without confirmation: \
+             stdin is not a TTY. Re-run with --yes to confirm non-interactively."
+        ));
+    }
+    print!("Remove '{repo_id}' ({size}) at {path}? [y/N] ");
+    std::io::stdout().flush().ok();
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .map_err(|e| anyhow!("failed to read confirmation: {e}"))?;
+    let answer = answer.trim().to_ascii_lowercase();
+    Ok(answer == "y" || answer == "yes")
+}
+
+/// Compact human-readable size for table cells, e.g. `2.34 GiB`, `512.0 MiB`,
+/// `48.0 KiB`, `12 B`. Distinct from [`mlxcel::memory_estimate::format_bytes`]
+/// (which appends the exact byte count) so the listing columns stay narrow.
+fn compact_size(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = 1024.0 * 1024.0;
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    let b = bytes as f64;
+    if b >= GIB {
+        format!("{:.2} GiB", b / GIB)
+    } else if b >= MIB {
+        format!("{:.1} MiB", b / MIB)
+    } else if b >= KIB {
+        format!("{:.1} KiB", b / KIB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn model(repo_id: &str, path: &str, size_bytes: u64) -> StoredModel {
+        StoredModel {
+            repo_id: repo_id.to_string(),
+            path: PathBuf::from(path),
+            size_bytes,
+        }
+    }
+
+    #[test]
+    fn compact_size_picks_units() {
+        assert_eq!(compact_size(0), "0 B");
+        assert_eq!(compact_size(512), "512 B");
+        assert_eq!(compact_size(2 * 1024), "2.0 KiB");
+        assert_eq!(compact_size(5 * 1024 * 1024), "5.0 MiB");
+        assert_eq!(compact_size(3 * 1024 * 1024 * 1024), "3.00 GiB");
+    }
+
+    #[test]
+    fn render_empty_store_prints_hint() {
+        let mut out = String::new();
+        render_local_models(&mut out, &[], Some("/store/models"));
+        assert!(out.contains("No models downloaded"));
+        assert!(out.contains("/store/models"));
+        assert!(out.contains("mlxcel download"));
+    }
+
+    #[test]
+    fn render_empty_store_without_root() {
+        let mut out = String::new();
+        render_local_models(&mut out, &[], None);
+        assert!(out.contains("No models downloaded"));
+        assert!(out.contains("MLXCEL_CACHE_DIR"));
+    }
+
+    #[test]
+    fn render_lists_models_with_size_and_path() {
+        let models = vec![
+            model(
+                "mlx-community/Qwen3-4B-4bit",
+                "/store/models/mlx-community/Qwen3-4B-4bit",
+                3 * 1024 * 1024 * 1024,
+            ),
+            model("gpt2", "/store/models/gpt2", 500 * 1024 * 1024),
+        ];
+        let mut out = String::new();
+        render_local_models(&mut out, &models, Some("/store/models"));
+
+        // Header reports count and total.
+        assert!(out.contains("Downloaded models (2,"));
+        assert!(out.contains("/store/models"));
+        // Column header present.
+        assert!(out.contains("REPO ID"));
+        assert!(out.contains("SIZE"));
+        assert!(out.contains("PATH"));
+        // Each model's id, a size cell, and its path appear.
+        assert!(out.contains("mlx-community/Qwen3-4B-4bit"));
+        assert!(out.contains("3.00 GiB"));
+        assert!(out.contains("/store/models/mlx-community/Qwen3-4B-4bit"));
+        assert!(out.contains("gpt2"));
+        assert!(out.contains("500.0 MiB"));
+    }
+
+    #[test]
+    fn render_aligns_repo_id_column() {
+        // The shorter id row must be left-padded to the longest id width so the
+        // SIZE column lines up. We assert the long-id and short-id rows share
+        // the same byte offset for their size cell start.
+        let models = vec![
+            model("a/b", "/s/models/a/b", 1024),
+            model(
+                "very-long-owner/very-long-model-name",
+                "/s/models/very-long-owner/very-long-model-name",
+                2048,
+            ),
+        ];
+        let mut out = String::new();
+        render_local_models(&mut out, &models, Some("/s/models"));
+        // Find the data rows (skip header/title/blank). Both should contain a
+        // double-space-separated SIZE column at the same column index.
+        let rows: Vec<&str> = out.lines().filter(|l| l.contains("/s/models/")).collect();
+        assert_eq!(rows.len(), 2, "expected two data rows, got: {out:?}");
+        // The path substring should start at the same column in both rows.
+        let col_a = rows[0].find("/s/models/").unwrap();
+        let col_b = rows[1].find("/s/models/").unwrap();
+        assert_eq!(col_a, col_b, "PATH column misaligned:\n{out}");
+    }
+}

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -88,7 +88,10 @@ pub use errors::map_hf_error;
 pub use filters::{is_wanted_file, repo_basename};
 pub use progress::should_show_progress;
 pub use resolver::resolve_model_source;
-pub use store::{hf_cache_snapshot, model_dir, store_root};
+pub use store::{
+    RemoveError, RemoveOutcome, StoredModel, hf_cache_snapshot, list_models, model_dir,
+    remove_model, store_root,
+};
 
 use anyhow::{Context, Result, anyhow};
 use futures::StreamExt;

--- a/src/downloader/store.rs
+++ b/src/downloader/store.rs
@@ -217,6 +217,289 @@ fn snapshot_is_complete(dir: &Path) -> bool {
     dir.is_dir() && dir.join("config.json").exists()
 }
 
+// ── Local model management (issue #97) ──────────────────────────────────────
+
+/// A model snapshot found in the mlxcel global store.
+///
+/// Produced by [`list_models`] for the `mlxcel list --local` surface. Holds
+/// the reconstructed HuggingFace `repo_id` (`<owner>/<name>` or a bare
+/// `<name>`), the absolute on-disk directory, and the recursively-summed
+/// byte size of that directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredModel {
+    /// Reconstructed repo id: `<owner>/<name>`, or a bare `<name>` for
+    /// snapshots stored directly under `models/` (e.g. a download of `gpt2`).
+    pub repo_id: String,
+    /// Absolute path to the snapshot directory under the store root.
+    pub path: PathBuf,
+    /// Recursive on-disk size of `path`, in bytes.
+    pub size_bytes: u64,
+}
+
+/// Enumerate complete model snapshots in the mlxcel global store.
+///
+/// Walks `store_root()/models/` and returns one [`StoredModel`] per directory
+/// that looks like a materialized snapshot (contains a `config.json`, the same
+/// completeness gate used by the downloader and [`hf_cache_snapshot`]). Both
+/// layouts written by issue #93 are recognized:
+///
+/// - `models/<owner>/<name>/` — the standard HuggingFace namespacing; the
+///   reconstructed `repo_id` is `<owner>/<name>`.
+/// - `models/<name>/` — a bare-id download (e.g. `gpt2`); the reconstructed
+///   `repo_id` is `<name>`.
+///
+/// Results are sorted by `repo_id` for stable, golden-test-friendly output.
+/// Returns an empty vector when the store root cannot be resolved or the
+/// `models/` subtree does not exist yet. I/O errors on individual entries are
+/// skipped rather than aborting the whole listing, so one unreadable directory
+/// does not hide every other model.
+pub fn list_models() -> Vec<StoredModel> {
+    let Some(root) = store_root() else {
+        return Vec::new();
+    };
+    let mut out = list_models_in(&root);
+    out.sort_by(|a, b| a.repo_id.cmp(&b.repo_id));
+    out
+}
+
+/// Pure helper behind [`list_models`]: enumerate snapshots under an explicit
+/// store root. Split out so unit tests can assert against a temp directory
+/// without touching process-wide env state. The returned order is filesystem
+/// order; [`list_models`] sorts the public result.
+fn list_models_in(root: &Path) -> Vec<StoredModel> {
+    let models_root = root.join(MODELS_SUBDIR);
+    let mut out: Vec<StoredModel> = Vec::new();
+
+    let Ok(top_entries) = std::fs::read_dir(&models_root) else {
+        return out;
+    };
+
+    for top in top_entries.flatten() {
+        let top_path = top.path();
+        // `read_dir` -> `DirEntry::path` does not follow the entry itself, but
+        // an owner directory could in principle be a symlink; only descend
+        // into real directories so a symlinked `models/<owner>` cannot make us
+        // walk outside the store.
+        if !top_path.is_dir() || top_path.symlink_metadata().is_ok_and(|m| m.is_symlink()) {
+            continue;
+        }
+        let Some(top_name) = top.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+
+        // Case 1: a bare-id snapshot stored directly at models/<name>.
+        if snapshot_is_complete(&top_path) {
+            out.push(StoredModel {
+                repo_id: top_name.clone(),
+                path: top_path.clone(),
+                size_bytes: dir_size(&top_path),
+            });
+            // A bare-id snapshot directory is terminal; do not also treat it
+            // as an owner directory.
+            continue;
+        }
+
+        // Case 2: an owner directory holding models/<owner>/<name> snapshots.
+        let Ok(inner_entries) = std::fs::read_dir(&top_path) else {
+            continue;
+        };
+        for inner in inner_entries.flatten() {
+            let inner_path = inner.path();
+            if !inner_path.is_dir() || inner_path.symlink_metadata().is_ok_and(|m| m.is_symlink()) {
+                continue;
+            }
+            if !snapshot_is_complete(&inner_path) {
+                continue;
+            }
+            let Some(inner_name) = inner.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            out.push(StoredModel {
+                repo_id: format!("{top_name}/{inner_name}"),
+                path: inner_path.clone(),
+                size_bytes: dir_size(&inner_path),
+            });
+        }
+    }
+
+    out
+}
+
+/// Recursively sum the byte sizes of every regular file under `dir`.
+///
+/// Symlinks are not followed (sizes are taken from `symlink_metadata`), so a
+/// snapshot containing symlinks counts the link entry itself rather than its
+/// (possibly out-of-tree) target. I/O errors on individual entries contribute
+/// zero rather than aborting, keeping the size best-effort but never panicking.
+fn dir_size(dir: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack: Vec<PathBuf> = vec![dir.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&current) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(meta) = path.symlink_metadata() else {
+                continue;
+            };
+            if meta.is_dir() {
+                stack.push(path);
+            } else {
+                // Regular files and symlink entries both contribute their own
+                // on-disk length; we intentionally do not follow symlinks.
+                total = total.saturating_add(meta.len());
+            }
+        }
+    }
+    total
+}
+
+/// Outcome of a [`remove_model`] request.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RemoveOutcome {
+    /// The store directory existed and was deleted. Carries the freed size in
+    /// bytes (measured before deletion) and the removed path.
+    Removed { path: PathBuf, size_bytes: u64 },
+    /// No snapshot for this repo id exists in the mlxcel store, but a complete
+    /// snapshot was found in the read-only HuggingFace cache. mlxcel refuses to
+    /// touch the HF cache (it is not ours to manage). Carries the HF snapshot
+    /// path for the caller's warning message.
+    HfCacheOnly { hf_path: PathBuf },
+    /// No snapshot for this repo id exists anywhere mlxcel manages or reads.
+    NotFound,
+}
+
+/// Errors that can abort a [`remove_model`] request before any deletion.
+#[derive(Debug)]
+pub enum RemoveError {
+    /// The store root could not be resolved (no `MLXCEL_CACHE_DIR` and no home
+    /// directory).
+    NoStoreRoot,
+    /// The resolved target escaped the `store_root()/models/` subtree. This is
+    /// a safety stop — it should be unreachable given the path sanitization in
+    /// [`model_dir`], but is enforced defensively so a future regression can
+    /// never delete outside the store.
+    OutsideStore(PathBuf),
+    /// Deleting the store directory failed (I/O error), with the offending
+    /// path and underlying error.
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl std::fmt::Display for RemoveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RemoveError::NoStoreRoot => write!(
+                f,
+                "cannot resolve the mlxcel model store root \
+                 (set MLXCEL_CACHE_DIR or ensure a home directory is available)"
+            ),
+            RemoveError::OutsideStore(p) => write!(
+                f,
+                "refusing to remove {}: resolved path is outside the model store",
+                p.display()
+            ),
+            RemoveError::Io { path, source } => {
+                write!(f, "failed to remove {}: {source}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for RemoveError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RemoveError::Io { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Remove a model snapshot from the mlxcel global store.
+///
+/// Resolves the target via [`model_dir`] (which already sanitizes the repo id
+/// against path traversal) and, before deleting, re-verifies that the target
+/// is contained inside `store_root()/models/`. The deletion therefore can only
+/// ever touch a directory under the store — never the HF cache, never a path
+/// reached via `..`, never an absolute escape.
+///
+/// Behavior:
+/// - **Store hit** → recursively deletes the directory and returns
+///   [`RemoveOutcome::Removed`] with the freed size.
+/// - **Store miss but HF-cache hit** → returns [`RemoveOutcome::HfCacheOnly`]
+///   without deleting anything (the HF cache is read-only to mlxcel).
+/// - **Miss everywhere** → returns [`RemoveOutcome::NotFound`].
+///
+/// `revision` is only used for the HF-cache probe (the mlxcel store is not
+/// revision-namespaced); pass `None` for the default `main`.
+pub fn remove_model(repo_id: &str, revision: Option<&str>) -> Result<RemoveOutcome, RemoveError> {
+    let root = store_root().ok_or(RemoveError::NoStoreRoot)?;
+    remove_model_in(&root, repo_id, revision)
+}
+
+/// Pure-ish helper behind [`remove_model`] operating against an explicit store
+/// root. Split out so unit tests can drive deletion against a temp directory.
+/// The HF-cache probe still consults the process env via [`hf_cache_snapshot`]
+/// (only reached on a store miss).
+fn remove_model_in(
+    root: &Path,
+    repo_id: &str,
+    revision: Option<&str>,
+) -> Result<RemoveOutcome, RemoveError> {
+    let models_root = root.join(MODELS_SUBDIR);
+    let target = model_dir_in(root, repo_id);
+
+    // Defense-in-depth containment check. `model_dir_in` already strips `..`
+    // and absolute components, but we re-assert that the composed path stays
+    // under `models/` so a deletion can never escape the store. Use a
+    // lexical/canonical comparison that does not require the target to exist.
+    if !is_within(&models_root, &target) {
+        return Err(RemoveError::OutsideStore(target));
+    }
+
+    if target.is_dir() {
+        let size = dir_size(&target);
+        std::fs::remove_dir_all(&target).map_err(|source| RemoveError::Io {
+            path: target.clone(),
+            source,
+        })?;
+        return Ok(RemoveOutcome::Removed {
+            path: target,
+            size_bytes: size,
+        });
+    }
+
+    // Store miss: is it sitting read-only in the HuggingFace cache?
+    if let Some(hf_path) = hf_cache_snapshot(repo_id, revision) {
+        return Ok(RemoveOutcome::HfCacheOnly { hf_path });
+    }
+
+    Ok(RemoveOutcome::NotFound)
+}
+
+/// True when `child` is `base` itself or lexically nested under it.
+///
+/// Both paths are first canonicalized when they exist; for the (common) case
+/// where `child` does not exist yet, we canonicalize `base` and compare the
+/// canonical base against `child` after stripping any `.`/`..` we can resolve
+/// lexically. Because [`model_dir_in`] never emits `..` components, a plain
+/// `starts_with` against the canonical (or, if canonicalization fails, the raw)
+/// base is sound here; the explicit check is the defensive backstop.
+fn is_within(base: &Path, child: &Path) -> bool {
+    let base_c = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
+    // If the child exists, compare canonical forms (resolves symlinks too).
+    if let Ok(child_c) = child.canonicalize() {
+        return child_c.starts_with(&base_c) || child_c == base_c;
+    }
+    // Child does not exist yet (typical for a not-downloaded repo): compare the
+    // raw child against the canonical base, and also against the raw base, so a
+    // symlinked store root does not produce a false negative.
+    child.starts_with(&base_c) || child.starts_with(base)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -473,5 +756,189 @@ mod tests {
         restore_env("HF_HOME", prev_home);
 
         assert_eq!(found, None);
+    }
+
+    // ── list_models_in / dir_size (issue #97) ────────────────────────────────
+
+    /// Materialize a complete snapshot at `<root>/models/<repo_id>` with a
+    /// `config.json` plus an extra payload file of `extra_bytes` so the
+    /// recursive size is non-trivial. Returns the snapshot directory.
+    fn make_store_snapshot(root: &Path, repo_id: &str, extra_bytes: usize) -> PathBuf {
+        let dir = model_dir_in(root, repo_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("config.json"), b"{}").unwrap();
+        std::fs::write(dir.join("model.safetensors"), vec![0u8; extra_bytes]).unwrap();
+        dir
+    }
+
+    #[test]
+    fn list_models_in_finds_owner_name_and_bare() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        make_store_snapshot(root, "mlx-community/Qwen3-4B-4bit", 100);
+        make_store_snapshot(root, "Qwen/Qwen3-4B-4bit", 200);
+        make_store_snapshot(root, "gpt2", 300); // bare id
+
+        let mut found = list_models_in(root);
+        found.sort_by(|a, b| a.repo_id.cmp(&b.repo_id));
+
+        let ids: Vec<&str> = found.iter().map(|m| m.repo_id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["Qwen/Qwen3-4B-4bit", "gpt2", "mlx-community/Qwen3-4B-4bit"]
+        );
+
+        // Sizes include config.json (2 bytes) + payload.
+        let gpt2 = found.iter().find(|m| m.repo_id == "gpt2").unwrap();
+        assert_eq!(gpt2.size_bytes, 2 + 300);
+        assert_eq!(gpt2.path, root.join("models").join("gpt2"));
+    }
+
+    #[test]
+    fn list_models_in_skips_incomplete_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Complete model.
+        make_store_snapshot(root, "owner/good", 10);
+        // Incomplete: owner dir with a child lacking config.json.
+        let bad = root.join("models").join("owner").join("partial");
+        std::fs::create_dir_all(&bad).unwrap();
+        std::fs::write(bad.join("model.safetensors"), b"xxxx").unwrap();
+        // A stray non-model directory directly under models/.
+        std::fs::create_dir_all(root.join("models").join("scratch")).unwrap();
+
+        let found = list_models_in(root);
+        let ids: Vec<&str> = found.iter().map(|m| m.repo_id.as_str()).collect();
+        assert_eq!(ids, vec!["owner/good"]);
+    }
+
+    #[test]
+    fn list_models_in_empty_when_no_models_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No models/ subdir created at all.
+        assert!(list_models_in(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn dir_size_sums_nested_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("a.bin"), vec![0u8; 1000]).unwrap();
+        let sub = root.join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join("b.bin"), vec![0u8; 2345]).unwrap();
+        assert_eq!(dir_size(root), 1000 + 2345);
+    }
+
+    // ── remove_model_in (issue #97) ──────────────────────────────────────────
+
+    #[test]
+    fn remove_model_in_deletes_store_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let dir = make_store_snapshot(root, "owner/model", 500);
+        assert!(dir.is_dir());
+
+        let outcome = remove_model_in(root, "owner/model", None).unwrap();
+        match outcome {
+            RemoveOutcome::Removed { path, size_bytes } => {
+                assert_eq!(path, dir);
+                assert_eq!(size_bytes, 2 + 500);
+            }
+            other => panic!("expected Removed, got {other:?}"),
+        }
+        assert!(!dir.exists(), "directory should be gone after removal");
+    }
+
+    #[test]
+    fn remove_model_in_not_found_when_absent_everywhere() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Point the HF cache at an empty dir so the probe also misses.
+        let hub = tmp.path().join("hub");
+        std::fs::create_dir_all(&hub).unwrap();
+
+        let _guard = env_lock();
+        let prev_cache = std::env::var("HF_HUB_CACHE").ok();
+        let prev_home = std::env::var("HF_HOME").ok();
+        unsafe {
+            std::env::set_var("HF_HUB_CACHE", &hub);
+            std::env::remove_var("HF_HOME");
+        }
+        let outcome = remove_model_in(root, "owner/never", None);
+        restore_env("HF_HUB_CACHE", prev_cache);
+        restore_env("HF_HOME", prev_home);
+
+        assert_eq!(outcome.unwrap(), RemoveOutcome::NotFound);
+    }
+
+    #[test]
+    fn remove_model_in_reports_hf_cache_only_without_deleting() {
+        let store_tmp = tempfile::tempdir().unwrap();
+        let root = store_tmp.path();
+        // Not in the mlxcel store; only in the HF cache.
+        let hf_tmp = tempfile::tempdir().unwrap();
+        let hub = hf_tmp.path().join("hub");
+        let sha = "3333333333333333333333333333333333333333";
+        make_hf_cache(&hub, "owner/cached", sha, "main", true);
+        let expected_hf = hub
+            .join(hf_repo_folder("owner/cached"))
+            .join("snapshots")
+            .join(sha);
+
+        let _guard = env_lock();
+        let prev_cache = std::env::var("HF_HUB_CACHE").ok();
+        let prev_home = std::env::var("HF_HOME").ok();
+        unsafe {
+            std::env::set_var("HF_HUB_CACHE", &hub);
+            std::env::remove_var("HF_HOME");
+        }
+        let outcome = remove_model_in(root, "owner/cached", None);
+        restore_env("HF_HUB_CACHE", prev_cache);
+        restore_env("HF_HOME", prev_home);
+
+        assert_eq!(
+            outcome.unwrap(),
+            RemoveOutcome::HfCacheOnly {
+                hf_path: expected_hf.clone()
+            }
+        );
+        // The HF snapshot must remain untouched.
+        assert!(expected_hf.join("config.json").exists());
+    }
+
+    #[test]
+    fn remove_model_in_contains_traversal_to_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Stage a file OUTSIDE the models/ subtree that a naive join+remove
+        // could have reached via `..`. It must survive.
+        let outside = root.join("victim.txt");
+        std::fs::write(&outside, b"do not delete").unwrap();
+        // Point HF cache at an empty dir so the store-miss probe is
+        // deterministic and never consults the host's real HF cache.
+        let hub = tmp.path().join("hub");
+        std::fs::create_dir_all(&hub).unwrap();
+
+        // A traversal repo id sanitizes (via model_dir_in) to a path contained
+        // under models/, never escaping to the sibling file. Removal of the
+        // (non-existent) sanitized path is NotFound, and the outside file is
+        // untouched.
+        let _guard = env_lock();
+        let prev_cache = std::env::var("HF_HUB_CACHE").ok();
+        let prev_home = std::env::var("HF_HOME").ok();
+        unsafe {
+            std::env::set_var("HF_HUB_CACHE", &hub);
+            std::env::remove_var("HF_HOME");
+        }
+        let outcome = remove_model_in(root, "../../victim.txt", None);
+        restore_env("HF_HUB_CACHE", prev_cache);
+        restore_env("HF_HOME", prev_home);
+
+        assert_eq!(outcome.unwrap(), RemoveOutcome::NotFound);
+        assert!(
+            outside.exists(),
+            "file outside the store must not be removed"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,9 +68,9 @@ enum Commands {
     /// Start an OpenAI/llama-server compatible HTTP server
     Serve(ServeArgs),
 
-    /// List supported model architectures
+    /// List supported model architectures, or downloaded models with `--local`
     #[command(visible_alias = "ls")]
-    List,
+    List(ListArgs),
 
     /// Print a pre-load memory budget for a model without running generation.
     ///
@@ -101,6 +101,55 @@ enum Commands {
     ///     mlxcel detect -m models/docling-layout-heron-mlx-bf16 -i page.png
     ///     mlxcel detect -m models/rt-detr-v2 -i img.jpg --threshold 0.5 --format json
     Detect(DetectArgs),
+
+    /// Remove a downloaded model from the global store.
+    ///
+    /// Deletes `${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>`
+    /// for the given repo-id and frees the space. Prompts for confirmation
+    /// unless `--yes` is passed. Models that exist only in the read-only
+    /// HuggingFace cache are reported but never deleted (mlxcel does not manage
+    /// the HuggingFace cache).
+    ///
+    /// Examples:
+    ///
+    ///     mlxcel rm mlx-community/Qwen3-4B-4bit
+    ///     mlxcel rm mlx-community/Qwen3-4B-4bit --yes
+    Rm(RmArgs),
+}
+
+/// Arguments for `mlxcel list`.
+///
+/// Without flags, `list` prints the supported model-architecture summary
+/// (unchanged behavior). `--local` switches it to enumerate downloaded models
+/// in the global store (repo-id, on-disk size, path), mirroring `ollama list`.
+#[derive(Args, Debug)]
+pub(crate) struct ListArgs {
+    /// List downloaded models in the global store instead of supported
+    /// architectures.
+    ///
+    /// Shows each model's repo-id, on-disk size, and absolute path under
+    /// `${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/`. Use `mlxcel rm
+    /// <repo-id>` to remove one.
+    #[arg(long)]
+    pub(crate) local: bool,
+}
+
+/// Arguments for `mlxcel rm`.
+#[derive(Args, Debug)]
+pub(crate) struct RmArgs {
+    /// HuggingFace repository id to remove, e.g. `mlx-community/Qwen3-4B-4bit`.
+    #[arg(value_name = "REPO_ID")]
+    pub(crate) repo_id: String,
+
+    /// Skip the interactive confirmation prompt.
+    #[arg(long, short = 'y', default_value_t = false)]
+    pub(crate) yes: bool,
+
+    /// Repository revision used only to locate an HF-cache snapshot when the
+    /// model is not in the mlxcel store (defaults to `main`). The mlxcel store
+    /// itself is not revision-namespaced.
+    #[arg(long, value_name = "REV")]
+    pub(crate) revision: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -1232,13 +1281,20 @@ fn main() -> anyhow::Result<()> {
     match cli.command {
         Commands::Generate(args) => commands::run_generate(args),
         Commands::Serve(args) => commands::run_serve(args),
-        Commands::List => {
-            print_supported_models();
-            Ok(())
+        Commands::List(args) => {
+            if args.local {
+                commands::run_list_local()
+            } else {
+                print_supported_models();
+                Ok(())
+            }
         }
         Commands::Inspect(args) => commands::run_inspect(args),
         Commands::Download(args) => commands::run_download(args),
         Commands::Detect(args) => commands::run_detect(args),
+        Commands::Rm(args) => {
+            commands::run_remove(&args.repo_id, args.yes, args.revision.as_deref())
+        }
     }
 }
 


### PR DESCRIPTION
Closes #97
Part of #92

## Summary
Adds two CLI surfaces for the location-independent global model store from #93, mirroring `ollama list`/`rm` and `lms ls`:

- **`mlxcel list --local`** — enumerates downloaded snapshots under `${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/` with repo-id, on-disk size, and absolute path.
- **`mlxcel rm <repo-id>`** — removes a snapshot directory from the store and reports the freed space.

## CLI surface choice
I used **`list --local` (a flag on the existing `list` command) + a new `rm` subcommand**, the first option the issue proposes. The bare `mlxcel list` still prints the supported-architecture summary unchanged — `--local` only switches behavior when present — so no existing output or golden test shifts. `Commands::List` becomes `List(ListArgs)` (a one-field flag struct); the default path still calls `print_supported_models()`.

## Behavior
- **Listing** recognizes both store layouts written by #93 (`<owner>/<name>` and bare `<name>`), gates each candidate on `config.json` so partial/stray directories are skipped, and sorts by repo-id for stable, golden-test-friendly output. An empty store prints an actionable hint instead of an empty table.
- **Removal** prompts for confirmation unless `--yes` (`-y`); on a non-TTY it refuses without `--yes` rather than deleting silently. A repo that exists only in the read-only HuggingFace cache is reported with guidance and **never deleted** (mlxcel does not manage the HF cache).

## Safety
Deletion is contained to `store_root()/models/`: repo-ids are sanitized by #93's `model_dir` (strips `..`, absolute, and backslash escapes), and `remove_model` re-asserts containment before `remove_dir_all`. Size walks use `symlink_metadata` and skip symlinked store entries, so a symlinked `models/<owner>` cannot make the walker escape the store.

## Code shape
Enumeration/deletion live in `downloader::store` next to the layout helpers they build on (new public API: `list_models`, `remove_model`, `StoredModel`, `RemoveOutcome`, `RemoveError`), keeping store semantics in one place. The `commands::models` handlers are thin I/O + prompting shims. No reimplementation of #93's API.

## Files
- `src/downloader/store.rs` — `list_models`/`remove_model` + helpers + tests (builds on #93).
- `src/downloader/mod.rs` — re-export the new public API.
- `src/commands/models.rs` — `run_list_local` / `run_remove` handlers + renderer + tests.
- `src/commands/mod.rs` — module wiring.
- `src/main.rs` — `ListArgs.--local`, new `Rm(RmArgs)` subcommand, dispatch.
- `README.md` — "Manage downloaded models" section.

## Testing
- `cargo test --lib downloader::store` — 19 passed (9 new: both layouts, completeness gate, recursive sizing, traversal containment, HF-cache-only refusal, store deletion, not-found).
- `cargo test --bin mlxcel` — 58 passed (5 new renderer/format tests; existing clap-parse tests unaffected by the `List(ListArgs)` change).
- `cargo test --test cli_help_consistency` — 8 passed.
- `cargo clippy --lib --bins --tests --features metal,accelerate -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Manual end-to-end smoke test against a temp `MLXCEL_CACHE_DIR`: bare `list` unchanged; `list --local` (empty + populated, partial dirs skipped); `rm --yes` (removes + reports freed bytes); `rm` not-found; `rm` non-TTY refusal; HF-cache-only refusal (snapshot preserved).

Broad suites (`cargo test --lib`, real-model integration) deferred to the orchestrator's background verification per the watchdog guard.