### PR TITLE
feat(cli): repo-id-aware -m resolver with auto-download (generate/serve/inspect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ mlxcel-server \
 mlxcel download mlx-community/Qwen3.5-0.8B-4bit --local-dir ./models/Qwen3.5-0.8B-4bit
 ```
 
+`-m/--model` on `mlxcel generate`, `mlxcel serve`, and `mlxcel inspect` accepts a HuggingFace `owner/name` repo-id directly, so the explicit `download` step is optional — pass the repo-id and mlxcel reuses a local `./models/<name>` directory, the HuggingFace cache, or the mlxcel store, and downloads into the mlxcel store on a miss:
+
+```bash
+# Auto-download on first use, reuse from the store afterwards — runs from any directory.
+mlxcel generate -m mlx-community/Qwen3.5-0.8B-4bit -p "Hello, world!" -n 100
+mlxcel inspect -m mlx-community/Qwen3.5-0.8B-4bit --max-tokens 32768
+mlxcel serve -m mlx-community/Qwen3.5-0.8B-4bit --port 8080
+```
+
+An existing local path is still used as-is, so `-m ./models/...` and `-m ~/.cache/mlxcel/...` behave exactly as before.
+
 `mlxcel inspect` is read-only and prints a byte-level breakdown of weights /
 KV cache / runtime headroom against available unified memory without loading
 any tensors. `--estimate-memory` on `mlxcel generate` and `mlxcel serve`

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1020,24 +1020,28 @@ pub(crate) fn run_generate(mut args: GenerateArgs) -> Result<()> {
     let runtime = initialize_runtime();
     print_runtime_setup(&runtime);
 
-    // Resolve `-m` into a concrete model directory (epic #92, issue #94)
-    // before any consumer reads it. An existing path is used verbatim
-    // (byte-identical to the pre-#94 local-path behavior); an `owner/name`
-    // HuggingFace repo-id is reused from the legacy CWD / HF cache / mlxcel
-    // store, or auto-downloaded into the mlxcel store on a miss. Done up front
-    // so quantization advice, tokenizer load, memory preflight, and model load
-    // all see the resolved path with no further changes.
-    args.model.model = resolve_model_source(&args.model.model)?;
-
     // Axis A weight-load surgery (Epic #363, issue #371). Parse the
     // YAML and install the pipeline *before* any heavier validation
     // so a malformed / missing surgery config fails fast with a clear
     // error rather than being masked by an unrelated tensor-parallel
     // or pipeline-parallel diagnostic. When `--surgery` is absent this
     // is a no-op and the load path remains bit-exact identical to the
-    // pre-#371 baseline.
+    // pre-#371 baseline. This reads only the `--surgery` YAML path, never
+    // the model directory, so it must stay ahead of the `-m` resolver below
+    // — a malformed surgery config never triggers an auto-download.
     #[cfg(feature = "surgery")]
     install_surgery_pipeline_from_cli(&args)?;
+
+    // Resolve `-m` into a concrete model directory (epic #92, issue #94)
+    // before any consumer reads it. An existing path is used verbatim
+    // (byte-identical to the pre-#94 local-path behavior); an `owner/name`
+    // HuggingFace repo-id is reused from the legacy CWD / HF cache / mlxcel
+    // store, or auto-downloaded into the mlxcel store on a miss. Placed after
+    // the (model-independent) surgery YAML validation but before the
+    // tensor/pipeline-parallel validators and the quantization-advice,
+    // tokenizer, memory-preflight, and model-load steps — all of which read
+    // the model directory and therefore need the resolved path.
+    args.model.model = resolve_model_source(&args.model.model)?;
 
     validate_tensor_parallel_args(&args)?;
     validate_pipeline_parallel_args(&args)?;

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -32,6 +32,7 @@ use mlxcel::{
         },
         resolve_model_shard_plan, shard_config_from_cli, validate_supported_runtime,
     },
+    downloader::resolve_model_source,
     initialize_runtime, load_model, load_model_with_adapter, load_model_with_tensor_parallel,
     memory_estimate::{
         MemoryEstimate, QuantHint, estimate_total_memory, format_bytes, format_estimate,
@@ -1015,9 +1016,18 @@ fn install_surgery_pipeline_from_cli(args: &GenerateArgs) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn run_generate(args: GenerateArgs) -> Result<()> {
+pub(crate) fn run_generate(mut args: GenerateArgs) -> Result<()> {
     let runtime = initialize_runtime();
     print_runtime_setup(&runtime);
+
+    // Resolve `-m` into a concrete model directory (epic #92, issue #94)
+    // before any consumer reads it. An existing path is used verbatim
+    // (byte-identical to the pre-#94 local-path behavior); an `owner/name`
+    // HuggingFace repo-id is reused from the legacy CWD / HF cache / mlxcel
+    // store, or auto-downloaded into the mlxcel store on a miss. Done up front
+    // so quantization advice, tokenizer load, memory preflight, and model load
+    // all see the resolved path with no further changes.
+    args.model.model = resolve_model_source(&args.model.model)?;
 
     // Axis A weight-load surgery (Epic #363, issue #371). Parse the
     // YAML and install the pipeline *before* any heavier validation

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -25,19 +25,22 @@
 use anyhow::{Result, anyhow};
 
 use mlxcel::cli::turbo_args::resolve_kv_cache_mode;
+use mlxcel::downloader::resolve_model_source;
 use mlxcel::memory_estimate::{QuantHint, estimate_total_memory, format_estimate};
 use mlxcel_core::cache::KVCacheMode;
 
 use crate::InspectArgs;
 
 /// Run the `mlxcel inspect` subcommand.
-pub(crate) fn run_inspect(args: InspectArgs) -> Result<()> {
-    if !args.model.exists() {
-        return Err(anyhow!(
-            "Model directory does not exist: {}",
-            args.model.display()
-        ));
-    }
+pub(crate) fn run_inspect(mut args: InspectArgs) -> Result<()> {
+    // Resolve `-m` into a concrete model directory (epic #92, issue #94): an
+    // existing path is used as-is (byte-identical to the pre-#94 behavior),
+    // while an `owner/name` HuggingFace repo-id is reused from the legacy CWD /
+    // HF cache / mlxcel store or auto-downloaded into the mlxcel store. On a
+    // miss-and-error this returns a clear message; on success `args.model` is
+    // guaranteed to name an existing snapshot, so the downstream estimator
+    // path is unchanged.
+    args.model = resolve_model_source(&args.model)?;
 
     // Translate the user-facing `--quant` label into the typed hint.
     let quant = parse_quant_hint(&args.quant)?;

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -21,6 +21,7 @@
 
 use mlxcel::cli::speculative_args::{env_fallback_draft_block_size, env_fallback_draft_kind};
 use mlxcel::cli::turbo_args::resolve_kv_cache_mode;
+use mlxcel::downloader::resolve_model_source;
 use mlxcel::memory_estimate::{QuantHint, estimate_total_memory, format_bytes, format_estimate};
 use mlxcel::server::{
     ServerStartupInput, env_fallback_apc_block_size, env_fallback_apc_enabled,
@@ -37,7 +38,16 @@ use mlxcel_core::cache::KVCacheMode;
 
 /// Run the `mlxcel serve` subcommand.
 #[tokio::main]
-pub(crate) async fn run_serve(args: crate::ServeArgs) -> anyhow::Result<()> {
+pub(crate) async fn run_serve(mut args: crate::ServeArgs) -> anyhow::Result<()> {
+    // Resolve `-m` into a concrete model directory (epic #92, issue #94)
+    // before the memory preflight or the server reads it. An existing path is
+    // used verbatim (byte-identical to the pre-#94 local-path behavior); an
+    // `owner/name` HuggingFace repo-id is reused from the legacy CWD / HF cache
+    // / mlxcel store, or auto-downloaded into the mlxcel store on a miss. Done
+    // here (not in `build_startup_input`) so the preflight estimate also sees
+    // the resolved path.
+    args.model = resolve_model_source(&args.model)?;
+
     // Issue #56: preflight memory check before the server begins
     // accepting connections. Refuses to start when total > available
     // unless --force was passed. Skipped when --estimate-memory is

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -80,12 +80,14 @@ mod cli;
 mod errors;
 mod filters;
 mod progress;
+mod resolver;
 mod store;
 
 pub use cli::DownloadArgs;
 pub use errors::map_hf_error;
 pub use filters::{is_wanted_file, repo_basename};
 pub use progress::should_show_progress;
+pub use resolver::resolve_model_source;
 pub use store::{hf_cache_snapshot, model_dir, store_root};
 
 use anyhow::{Context, Result, anyhow};

--- a/src/downloader/resolver.rs
+++ b/src/downloader/resolver.rs
@@ -1,0 +1,228 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Repo-id-aware `-m/--model` resolver (epic #92, issue #94).
+//!
+//! Lets every subcommand that takes `-m/--model` (`generate`, `serve`,
+//! `inspect`) accept either a local path *or* a HuggingFace repo-id, auto-
+//! downloading the snapshot on a cache miss. The model is then runnable from
+//! any directory — the mlx-lm / ollama / LM Studio convenience UX.
+//!
+//! # Resolution order (locked design, epic #92)
+//!
+//! [`resolve_model_source`] applies exactly this precedence:
+//!
+//! 1. **Existing on-disk path** — if the `-m` value already names an existing
+//!    path (file or directory), it is used verbatim. This is byte-identical to
+//!    the pre-#94 behavior, so every existing `-m models/foo` / `-m
+//!    /abs/path` invocation keeps working with no observable difference, even
+//!    when the path happens to look like an `owner/name` repo-id.
+//! 2. **`owner/name` repo-id shape** — when the value is *not* an existing path
+//!    but matches `^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$` (exactly one slash), it is
+//!    treated as a HuggingFace repo-id and resolved in this sub-order: (a)
+//!    legacy per-CWD `./models/<basename>` snapshot if complete (bridges the
+//!    pre-#93 default download location); (b) an existing HuggingFace Hub cache
+//!    snapshot ([`store::hf_cache_snapshot`], read-only reuse); (c) the mlxcel
+//!    global store ([`store::model_dir`]) if complete; (d) on a miss, download
+//!    the snapshot into the mlxcel global store via the shared hardened
+//!    downloader ([`download_repo`]) and use it.
+//! 3. **Neither** — a clear, actionable error (not an existing path and not a
+//!    valid `owner/name` repo-id).
+//!
+//! The "completeness" gate for the legacy and store directories keys on a
+//! present `config.json`, mirroring the downloader's own `snapshot_complete`
+//! check and [`store::hf_cache_snapshot`]'s gate. A directory that exists but
+//! lacks `config.json` (e.g. a half-written or unrelated `models/` folder) is
+//! treated as a miss so the resolver never hands a model loader a path that
+//! will fail to load.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+
+use super::filters::repo_basename;
+use super::store;
+use super::{DownloadOptions, download_repo};
+
+/// Legacy per-CWD download root used by mlxcel before the global store
+/// (epic #92, issue #93). A repo-id whose basename already lives under
+/// `./models/<basename>` is reused from there for back-compat.
+const LEGACY_MODELS_DIR: &str = "models";
+
+/// File whose presence marks a model snapshot directory as complete enough to
+/// load. Mirrors the downloader's `snapshot_complete` gate and
+/// [`store::hf_cache_snapshot`], both of which key on `config.json`.
+const SNAPSHOT_MARKER: &str = "config.json";
+
+/// Resolve a `-m/--model` value into a concrete on-disk model directory,
+/// auto-downloading a HuggingFace repo-id on a cache miss.
+///
+/// See the [module docs](self) for the full precedence. On success the
+/// returned [`PathBuf`] is guaranteed to name an existing path; for the
+/// repo-id branch it is the reused or freshly-downloaded snapshot directory.
+///
+/// # Errors
+///
+/// Returns an actionable [`anyhow::Error`] when the value is neither an
+/// existing path nor a valid `owner/name` repo-id, or when an auto-download was
+/// required but failed (network / auth / disk — the underlying
+/// [`download_repo`] error is propagated with context).
+pub fn resolve_model_source(value: &Path) -> Result<PathBuf> {
+    // 1. Existing on-disk path wins unconditionally — byte-identical to the
+    //    pre-#94 local-path behavior. Checked before any repo-id shape test so
+    //    a local directory literally named `owner/name` is still used as-is.
+    if value.exists() {
+        return Ok(value.to_path_buf());
+    }
+
+    // The repo-id branch requires a UTF-8 string. A non-UTF-8 `-m` value can
+    // only be a (non-existent) local path, so fall through to the error arm.
+    let Some(value_str) = value.to_str() else {
+        return Err(not_a_model_error(value));
+    };
+
+    // 2. `owner/name` repo-id shape → reuse-or-download.
+    if is_repo_id_shape(value_str) {
+        return resolve_repo_id(value_str, None);
+    }
+
+    // 3. Neither an existing path nor a valid repo-id.
+    Err(not_a_model_error(value))
+}
+
+/// Resolve a value already known to have `owner/name` repo-id shape: reuse an
+/// existing snapshot (legacy CWD → HF cache → mlxcel store) or download into
+/// the mlxcel global store on a miss.
+///
+/// `revision` selects the HF-cache snapshot revision (branch / tag / commit);
+/// `None` means `main`. The CLI subcommands do not currently expose a
+/// `--revision` flag, so they pass `None`, matching `mlxcel download`'s default.
+fn resolve_repo_id(repo_id: &str, revision: Option<&str>) -> Result<PathBuf> {
+    let cwd_models = PathBuf::from(LEGACY_MODELS_DIR);
+
+    // 2a–2c: reuse an existing snapshot without re-downloading.
+    if let Some(hit) = locate_cached_snapshot(repo_id, revision, &cwd_models) {
+        return Ok(hit);
+    }
+
+    // 2d: cache miss → download into the mlxcel global store (local_dir: None),
+    //     then re-locate where it landed. We reuse the shared hardened
+    //     downloader rather than forking it, so allow-list filtering, token
+    //     handling, progress UX, and HF-cache reuse all stay in lock-step with
+    //     `mlxcel download`.
+    println!("[mlxcel] model '{repo_id}' not found locally; downloading into the mlxcel store...");
+    download_repo(DownloadOptions {
+        repo_id: repo_id.to_string(),
+        local_dir: None,
+        revision: revision.map(str::to_string),
+        token: None,
+        force: false,
+    })
+    .map_err(|err| anyhow!("failed to download model '{repo_id}': {err}"))?;
+
+    // After a successful download the snapshot is reachable via either the HF
+    // cache (download_repo reuses an existing HF snapshot read-only) or the
+    // mlxcel store. Re-run the same lookup to return the real landing path.
+    locate_cached_snapshot(repo_id, revision, &cwd_models).ok_or_else(|| {
+        anyhow!(
+            "downloaded model '{repo_id}' but could not locate its snapshot \
+             afterwards (expected under the mlxcel store or HuggingFace cache)"
+        )
+    })
+}
+
+/// Probe every reuse location for a complete snapshot of `repo_id`, in the
+/// locked precedence order: legacy per-CWD `./models/<basename>`, then the
+/// HuggingFace Hub cache, then the mlxcel global store.
+///
+/// `cwd_models` is the legacy models root (normally `./models`); it is a
+/// parameter so unit tests can point it at a temp dir. Returns the first
+/// complete snapshot found, or `None` when every location misses.
+fn locate_cached_snapshot(
+    repo_id: &str,
+    revision: Option<&str>,
+    cwd_models: &Path,
+) -> Option<PathBuf> {
+    // 2a. Legacy per-CWD `./models/<basename>` (pre-#93 default location).
+    let legacy = cwd_models.join(repo_basename(repo_id));
+    if snapshot_is_complete(&legacy) {
+        return Some(legacy);
+    }
+
+    // 2b. Existing HuggingFace Hub cache snapshot (read-only reuse). Its own
+    //     completeness gate already requires a `config.json`.
+    if let Some(hf) = store::hf_cache_snapshot(repo_id, revision) {
+        return Some(hf);
+    }
+
+    // 2c. mlxcel global store (`${MLXCEL_CACHE_DIR}/models/<owner>/<name>`).
+    if let Some(store_dir) = store::model_dir(repo_id)
+        && snapshot_is_complete(&store_dir)
+    {
+        return Some(store_dir);
+    }
+
+    None
+}
+
+/// True when `dir` is an existing directory containing a [`SNAPSHOT_MARKER`]
+/// (`config.json`).
+///
+/// Used as the completeness gate for the legacy CWD and mlxcel-store
+/// directories so a half-written or unrelated `models/` folder is treated as a
+/// miss instead of being handed to a model loader that would then fail.
+fn snapshot_is_complete(dir: &Path) -> bool {
+    dir.is_dir() && dir.join(SNAPSHOT_MARKER).exists()
+}
+
+/// True when `value` has HuggingFace `owner/name` repo-id shape:
+/// `^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$` — exactly one `/`, with both the owner
+/// and name segments non-empty and composed only of ASCII alphanumerics, `.`,
+/// `_`, or `-`.
+///
+/// Implemented with direct char checks (no regex dependency). The single-slash
+/// constraint is what distinguishes a repo-id from a multi-segment relative
+/// path like `models/foo/bar`, which — if it does not exist on disk — is a
+/// user error rather than a repo-id.
+fn is_repo_id_shape(value: &str) -> bool {
+    let mut parts = value.split('/');
+    let (Some(owner), Some(name), None) = (parts.next(), parts.next(), parts.next()) else {
+        return false;
+    };
+    is_repo_segment(owner) && is_repo_segment(name)
+}
+
+/// True when `segment` is non-empty and every byte is an ASCII alphanumeric or
+/// one of `.`, `_`, `-`.
+fn is_repo_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+}
+
+/// Build the "neither a path nor a repo-id" error for an unresolvable `-m`
+/// value.
+fn not_a_model_error(value: &Path) -> anyhow::Error {
+    anyhow!(
+        "model '{}' is neither an existing path nor a valid HuggingFace \
+         repo-id (expected `owner/name`, e.g. `mlx-community/Qwen3-4B-4bit`). \
+         Pass a local model directory or a repo-id to auto-download.",
+        value.display()
+    )
+}
+
+#[cfg(test)]
+#[path = "resolver_tests.rs"]
+mod tests;

--- a/src/downloader/resolver_tests.rs
+++ b/src/downloader/resolver_tests.rs
@@ -1,0 +1,421 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the repo-id-aware `-m/--model` resolver (issue #94).
+//!
+//! Network-free by construction: every test exercises a reuse branch (existing
+//! path, repo-id shape, legacy CWD, HF-cache, mlxcel store) or a parse/error
+//! branch. The download branch (2d) is the only path that touches the network
+//! and is covered end-to-end by the acceptance criteria, not by a unit test.
+
+use super::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+// Env-var-sensitive tests must serialize through the crate-wide `ENV_LOCK`
+// (issue #573): Rust 2024's `set_var`/`remove_var` are `unsafe` because
+// libc's env block has no internal lock and concurrent mutation is UB.
+use crate::test_support::env_lock::env_lock;
+
+/// Restore an env var to a prior captured state.
+fn restore_env(key: &str, prev: Option<String>) {
+    unsafe {
+        match prev {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+}
+
+/// Create a complete (loadable) snapshot directory: `dir` plus a `config.json`.
+fn make_complete_snapshot(dir: &Path) {
+    fs::create_dir_all(dir).unwrap();
+    fs::write(dir.join("config.json"), b"{}").unwrap();
+}
+
+// ── is_repo_id_shape ────────────────────────────────────────────────────────
+
+#[test]
+fn repo_id_shape_accepts_owner_name() {
+    assert!(is_repo_id_shape("mlx-community/Qwen3-4B-4bit"));
+    assert!(is_repo_id_shape("Qwen/Qwen3-4B-4bit"));
+    assert!(is_repo_id_shape("owner/model"));
+    // `.`, `_`, `-` are all valid HF id characters.
+    assert!(is_repo_id_shape("some.owner_1/my-model.v2"));
+}
+
+#[test]
+fn repo_id_shape_rejects_non_owner_name() {
+    // No slash → bare name (not the `owner/name` shape this resolver gates on).
+    assert!(!is_repo_id_shape("gpt2"));
+    // More than one slash → relative path, not a repo-id.
+    assert!(!is_repo_id_shape("models/foo/bar"));
+    assert!(!is_repo_id_shape("a/b/c"));
+    // Empty segments.
+    assert!(!is_repo_id_shape("/model"));
+    assert!(!is_repo_id_shape("owner/"));
+    assert!(!is_repo_id_shape("/"));
+    assert!(!is_repo_id_shape(""));
+    // Illegal characters per the locked `[A-Za-z0-9._-]` segment set: space,
+    // `~`, `:`. (`~` is not in the allowed set, so `~/model` is rejected.)
+    assert!(!is_repo_id_shape("owner name/model"));
+    assert!(!is_repo_id_shape("~/model"));
+    assert!(!is_repo_id_shape("owner/mo:del"));
+}
+
+#[test]
+fn repo_id_shape_matches_locked_dot_owner_spec() {
+    // The locked regex `^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$` includes `.`, so a
+    // value like `./models` *does* match the shape. Back-compat is preserved
+    // regardless: `resolve_model_source` checks `value.exists()` (branch 1)
+    // before the repo-id branch, so an existing `./models` directory is used
+    // as a path. Only a non-existent `./models` would fall through to the
+    // repo-id branch (and then fail at the HF API as a malformed owner) — an
+    // acceptable user error, not a back-compat regression.
+    assert!(is_repo_id_shape("./models"));
+}
+
+// ── snapshot_is_complete ────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_is_complete_requires_config_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("snap");
+    // Missing entirely.
+    assert!(!snapshot_is_complete(&dir));
+    // Exists but no config.json → still incomplete (would fail to load).
+    fs::create_dir_all(&dir).unwrap();
+    assert!(!snapshot_is_complete(&dir));
+    // With config.json → complete.
+    fs::write(dir.join("config.json"), b"{}").unwrap();
+    assert!(snapshot_is_complete(&dir));
+}
+
+#[test]
+fn snapshot_is_complete_false_for_file_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = tmp.path().join("not-a-dir");
+    fs::write(&file, b"x").unwrap();
+    assert!(!snapshot_is_complete(&file));
+}
+
+// ── resolve_model_source: branch 1 (existing path, byte-identical) ───────────
+
+#[test]
+fn existing_directory_path_is_used_verbatim() {
+    let tmp = tempfile::tempdir().unwrap();
+    let model = tmp.path().join("local-model");
+    fs::create_dir_all(&model).unwrap();
+
+    let resolved = resolve_model_source(&model).unwrap();
+    assert_eq!(resolved, model);
+}
+
+#[test]
+fn existing_file_path_is_used_verbatim() {
+    // The on-disk check uses `Path::exists`, which is true for files too. A
+    // model loader will reject a file, but the resolver must not second-guess
+    // an explicit existing path — that is the byte-identical back-compat rule.
+    let tmp = tempfile::tempdir().unwrap();
+    let file = tmp.path().join("weights.safetensors");
+    fs::write(&file, b"x").unwrap();
+
+    let resolved = resolve_model_source(&file).unwrap();
+    assert_eq!(resolved, file);
+}
+
+#[test]
+fn existing_path_shaped_like_repo_id_is_still_used_verbatim() {
+    // A local directory literally named `owner/name` that exists on disk must
+    // be used as-is (branch 1 wins over the repo-id branch). We create the
+    // directory under a temp root and resolve via its full path.
+    let tmp = tempfile::tempdir().unwrap();
+    let model = tmp.path().join("owner").join("name");
+    fs::create_dir_all(&model).unwrap();
+
+    let resolved = resolve_model_source(&model).unwrap();
+    assert_eq!(resolved, model);
+}
+
+// ── resolve_model_source: branch 3 (error) ──────────────────────────────────
+
+#[test]
+fn nonexistent_non_repo_id_value_errors_clearly() {
+    // A value that is neither an existing path nor `owner/name` shape.
+    let err = resolve_model_source(Path::new("definitely-not-here")).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("neither an existing path"), "got: {msg}");
+    assert!(msg.contains("owner/name"), "got: {msg}");
+}
+
+#[test]
+fn nonexistent_multi_segment_path_errors_clearly() {
+    // `a/b/c` has too many slashes to be a repo-id and does not exist.
+    let err = resolve_model_source(Path::new("no/such/nested/path")).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("neither an existing path"), "got: {msg}");
+}
+
+// ── locate_cached_snapshot: branch 2a (legacy ./models/<basename>) ───────────
+
+#[test]
+fn locate_prefers_legacy_cwd_models_when_complete() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cwd_models = tmp.path().join("models");
+    let legacy = cwd_models.join("Qwen3-4B-4bit");
+    make_complete_snapshot(&legacy);
+
+    // Point the mlxcel store and HF cache at empty temp dirs so only the
+    // legacy location can hit.
+    let _guard = env_lock();
+    let prev_cache_dir = std::env::var("MLXCEL_CACHE_DIR").ok();
+    let prev_hf_cache = std::env::var("HF_HUB_CACHE").ok();
+    let prev_hf_home = std::env::var("HF_HOME").ok();
+    let empty_store = tmp.path().join("store");
+    let empty_hf = tmp.path().join("hf");
+    fs::create_dir_all(&empty_hf).unwrap();
+    unsafe {
+        std::env::set_var("MLXCEL_CACHE_DIR", &empty_store);
+        std::env::set_var("HF_HUB_CACHE", &empty_hf);
+        std::env::remove_var("HF_HOME");
+    }
+
+    let hit = locate_cached_snapshot("mlx-community/Qwen3-4B-4bit", None, &cwd_models);
+
+    restore_env("MLXCEL_CACHE_DIR", prev_cache_dir);
+    restore_env("HF_HUB_CACHE", prev_hf_cache);
+    restore_env("HF_HOME", prev_hf_home);
+
+    assert_eq!(hit, Some(legacy));
+}
+
+#[test]
+fn locate_ignores_incomplete_legacy_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cwd_models = tmp.path().join("models");
+    // Legacy dir exists but has no config.json → must be skipped.
+    fs::create_dir_all(cwd_models.join("Qwen3-4B-4bit")).unwrap();
+
+    let _guard = env_lock();
+    let prev_cache_dir = std::env::var("MLXCEL_CACHE_DIR").ok();
+    let prev_hf_cache = std::env::var("HF_HUB_CACHE").ok();
+    let prev_hf_home = std::env::var("HF_HOME").ok();
+    let empty_store = tmp.path().join("store");
+    let empty_hf = tmp.path().join("hf");
+    fs::create_dir_all(&empty_hf).unwrap();
+    unsafe {
+        std::env::set_var("MLXCEL_CACHE_DIR", &empty_store);
+        std::env::set_var("HF_HUB_CACHE", &empty_hf);
+        std::env::remove_var("HF_HOME");
+    }
+
+    let hit = locate_cached_snapshot("mlx-community/Qwen3-4B-4bit", None, &cwd_models);
+
+    restore_env("MLXCEL_CACHE_DIR", prev_cache_dir);
+    restore_env("HF_HUB_CACHE", prev_hf_cache);
+    restore_env("HF_HOME", prev_hf_home);
+
+    assert_eq!(hit, None);
+}
+
+// ── locate_cached_snapshot: branch 2b (HuggingFace cache reuse) ──────────────
+
+#[test]
+fn locate_reuses_hf_cache_snapshot() {
+    let tmp = tempfile::tempdir().unwrap();
+    let hub = tmp.path().join("hf");
+    // Build a fake HF hub snapshot: models--owner--model/snapshots/<sha>/config.json
+    let sha = "0123456789abcdef0123456789abcdef01234567";
+    let repo_dir = hub.join("models--owner--model");
+    let snap = repo_dir.join("snapshots").join(sha);
+    make_complete_snapshot(&snap);
+    let refs = repo_dir.join("refs");
+    fs::create_dir_all(&refs).unwrap();
+    fs::write(refs.join("main"), sha).unwrap();
+
+    // Empty legacy + empty mlxcel store so only the HF cache can hit.
+    let cwd_models = tmp.path().join("no-models");
+
+    let _guard = env_lock();
+    let prev_cache_dir = std::env::var("MLXCEL_CACHE_DIR").ok();
+    let prev_hf_cache = std::env::var("HF_HUB_CACHE").ok();
+    let prev_hf_home = std::env::var("HF_HOME").ok();
+    let empty_store = tmp.path().join("store");
+    unsafe {
+        std::env::set_var("MLXCEL_CACHE_DIR", &empty_store);
+        std::env::set_var("HF_HUB_CACHE", &hub);
+        std::env::remove_var("HF_HOME");
+    }
+
+    let hit = locate_cached_snapshot("owner/model", None, &cwd_models);
+
+    restore_env("MLXCEL_CACHE_DIR", prev_cache_dir);
+    restore_env("HF_HUB_CACHE", prev_hf_cache);
+    restore_env("HF_HOME", prev_hf_home);
+
+    assert_eq!(hit, Some(snap));
+}
+
+// ── locate_cached_snapshot: branch 2c (mlxcel global store) ──────────────────
+
+#[test]
+fn locate_uses_mlxcel_store_when_complete() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store_root = tmp.path().join("store");
+    // mlxcel store layout: <root>/models/<owner>/<name>/config.json
+    let store_dir = store_root.join("models").join("owner").join("model");
+    make_complete_snapshot(&store_dir);
+
+    // Empty legacy + empty HF cache so only the mlxcel store can hit.
+    let cwd_models = tmp.path().join("no-models");
+    let empty_hf = tmp.path().join("hf");
+    fs::create_dir_all(&empty_hf).unwrap();
+
+    let _guard = env_lock();
+    let prev_cache_dir = std::env::var("MLXCEL_CACHE_DIR").ok();
+    let prev_hf_cache = std::env::var("HF_HUB_CACHE").ok();
+    let prev_hf_home = std::env::var("HF_HOME").ok();
+    unsafe {
+        std::env::set_var("MLXCEL_CACHE_DIR", &store_root);
+        std::env::set_var("HF_HUB_CACHE", &empty_hf);
+        std::env::remove_var("HF_HOME");
+    }
+
+    let hit = locate_cached_snapshot("owner/model", None, &cwd_models);
+
+    restore_env("MLXCEL_CACHE_DIR", prev_cache_dir);
+    restore_env("HF_HUB_CACHE", prev_hf_cache);
+    restore_env("HF_HOME", prev_hf_home);
+
+    assert_eq!(hit, Some(store_dir));
+}
+
+#[test]
+fn locate_returns_none_on_total_miss() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cwd_models = tmp.path().join("no-models");
+    let empty_hf = tmp.path().join("hf");
+    fs::create_dir_all(&empty_hf).unwrap();
+    let empty_store = tmp.path().join("store");
+
+    let _guard = env_lock();
+    let prev_cache_dir = std::env::var("MLXCEL_CACHE_DIR").ok();
+    let prev_hf_cache = std::env::var("HF_HUB_CACHE").ok();
+    let prev_hf_home = std::env::var("HF_HOME").ok();
+    unsafe {
+        std::env::set_var("MLXCEL_CACHE_DIR", &empty_store);
+        std::env::set_var("HF_HUB_CACHE", &empty_hf);
+        std::env::remove_var("HF_HOME");
+    }
+
+    let hit = locate_cached_snapshot("owner/never-downloaded", None, &cwd_models);
+
+    restore_env("MLXCEL_CACHE_DIR", prev_cache_dir);
+    restore_env("HF_HUB_CACHE", prev_hf_cache);
+    restore_env("HF_HOME", prev_hf_home);
+
+    assert_eq!(hit, None);
+}
+
+// ── precedence: legacy CWD beats both HF cache and mlxcel store ──────────────
+
+#[test]
+fn legacy_cwd_wins_over_hf_and_store() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Populate all three locations for the same repo-id.
+    let cwd_models = tmp.path().join("models");
+    let legacy = cwd_models.join("model");
+    make_complete_snapshot(&legacy);
+
+    let hub = tmp.path().join("hf");
+    let sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let repo_dir = hub.join("models--owner--model");
+    make_complete_snapshot(&repo_dir.join("snapshots").join(sha));
+    let refs = repo_dir.join("refs");
+    fs::create_dir_all(&refs).unwrap();
+    fs::write(refs.join("main"), sha).unwrap();
+
+    let store_root = tmp.path().join("store");
+    make_complete_snapshot(&store_root.join("models").join("owner").join("model"));
+
+    let _guard = env_lock();
+    let prev_cache_dir = std::env::var("MLXCEL_CACHE_DIR").ok();
+    let prev_hf_cache = std::env::var("HF_HUB_CACHE").ok();
+    let prev_hf_home = std::env::var("HF_HOME").ok();
+    unsafe {
+        std::env::set_var("MLXCEL_CACHE_DIR", &store_root);
+        std::env::set_var("HF_HUB_CACHE", &hub);
+        std::env::remove_var("HF_HOME");
+    }
+
+    let hit = locate_cached_snapshot("owner/model", None, &cwd_models);
+
+    restore_env("MLXCEL_CACHE_DIR", prev_cache_dir);
+    restore_env("HF_HUB_CACHE", prev_hf_cache);
+    restore_env("HF_HOME", prev_hf_home);
+
+    // Legacy CWD must win the precedence race.
+    assert_eq!(hit, Some(legacy));
+}
+
+// ── end-to-end reuse via resolve_model_source (store hit, no download) ───────
+
+#[test]
+fn resolve_model_source_reuses_store_without_download() {
+    // A repo-id that does not exist as a path but is already in the mlxcel
+    // store must resolve to the store dir with no network access.
+    let tmp = tempfile::tempdir().unwrap();
+    let store_root = tmp.path().join("store");
+    let store_dir = store_root.join("models").join("owner").join("model");
+    make_complete_snapshot(&store_dir);
+    let empty_hf = tmp.path().join("hf");
+    fs::create_dir_all(&empty_hf).unwrap();
+
+    // Run from a CWD with no `./models` so branch 2a misses. The resolver uses
+    // a relative `./models`, so we chdir into an empty temp dir for this test.
+    let run_dir = tmp.path().join("run");
+    fs::create_dir_all(&run_dir).unwrap();
+
+    let _guard = env_lock();
+    let prev_cache_dir = std::env::var("MLXCEL_CACHE_DIR").ok();
+    let prev_hf_cache = std::env::var("HF_HUB_CACHE").ok();
+    let prev_hf_home = std::env::var("HF_HOME").ok();
+    let prev_cwd = std::env::current_dir().ok();
+    unsafe {
+        std::env::set_var("MLXCEL_CACHE_DIR", &store_root);
+        std::env::set_var("HF_HUB_CACHE", &empty_hf);
+        std::env::remove_var("HF_HOME");
+    }
+    std::env::set_current_dir(&run_dir).unwrap();
+
+    let resolved = resolve_model_source(Path::new("owner/model"));
+
+    if let Some(cwd) = prev_cwd {
+        let _ = std::env::set_current_dir(cwd);
+    }
+    restore_env("MLXCEL_CACHE_DIR", prev_cache_dir);
+    restore_env("HF_HUB_CACHE", prev_hf_cache);
+    restore_env("HF_HOME", prev_hf_home);
+
+    assert_eq!(resolved.unwrap(), store_dir);
+}
+
+/// Smoke check that the legacy models constant did not drift from the
+/// downloader's own basename helper expectations.
+#[test]
+fn legacy_models_dir_basename_roundtrip() {
+    assert_eq!(LEGACY_MODELS_DIR, "models");
+    let legacy = PathBuf::from(LEGACY_MODELS_DIR).join(repo_basename("owner/model"));
+    assert_eq!(legacy, PathBuf::from("models/model"));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,8 +157,15 @@ pub(crate) struct GenerateArgs {
 #[derive(Args, Debug)]
 #[command(next_help_heading = "Model Options")]
 pub(crate) struct ModelOptions {
-    /// Path to the model directory
-    #[arg(short, long, value_name = "PATH")]
+    /// Path to a local model directory, or a HuggingFace `owner/name`
+    /// repo-id to auto-download.
+    ///
+    /// An existing local path is used as-is. Otherwise an `owner/name`
+    /// repo-id (e.g. `mlx-community/Qwen3-4B-4bit`) is resolved from a
+    /// legacy `./models/<name>` directory, the HuggingFace cache, or the
+    /// mlxcel store, and downloaded into the mlxcel store on a miss so it
+    /// runs from any directory.
+    #[arg(short, long, value_name = "PATH_OR_REPO_ID")]
     pub(crate) model: PathBuf,
 
     /// Path to LoRA adapter directory (optional)
@@ -270,8 +277,14 @@ pub(crate) struct GenerationOptions {
 #[derive(Args, Debug)]
 #[command(next_help_heading = "Inspect Options")]
 pub(crate) struct InspectArgs {
-    /// Path to the model directory.
-    #[arg(short, long, value_name = "PATH")]
+    /// Path to a local model directory, or a HuggingFace `owner/name`
+    /// repo-id to auto-download.
+    ///
+    /// An existing local path is used as-is; an `owner/name` repo-id
+    /// (e.g. `mlx-community/Qwen3-4B-4bit`) is resolved from a legacy
+    /// `./models/<name>` directory, the HuggingFace cache, or the mlxcel
+    /// store, and downloaded into the mlxcel store on a miss.
+    #[arg(short, long, value_name = "PATH_OR_REPO_ID")]
     pub(crate) model: std::path::PathBuf,
 
     /// Maximum number of tokens to estimate KV cache for.
@@ -459,8 +472,14 @@ Thunderbolt mode:
 
 See also: docs/distributed.md")]
 pub(crate) struct ServeArgs {
-    /// Path to the model directory
-    #[arg(short, long, env = "LLAMA_ARG_MODEL", value_name = "PATH")]
+    /// Path to a local model directory, or a HuggingFace `owner/name`
+    /// repo-id to auto-download.
+    ///
+    /// An existing local path is used as-is; an `owner/name` repo-id
+    /// (e.g. `mlx-community/Qwen3-4B-4bit`) is resolved from a legacy
+    /// `./models/<name>` directory, the HuggingFace cache, or the mlxcel
+    /// store, and downloaded into the mlxcel store on a miss.
+    #[arg(short, long, env = "LLAMA_ARG_MODEL", value_name = "PATH_OR_REPO_ID")]
     model: PathBuf,
 
     /// Path to LoRA adapter directory


### PR DESCRIPTION
Closes #94
Part of #92

## Summary
Makes `-m/--model` accept either a local path or a HuggingFace `owner/name` repo-id across `generate`, `serve`, and `inspect`, auto-downloading on a cache miss so a model fetched once runs from any directory — the mlx-lm / ollama / LM Studio convenience UX. Built on the #93 global model store and HuggingFace-cache read-reuse helpers (`store::model_dir`, `store::hf_cache_snapshot`), reusing the existing hardened downloader rather than forking it.

## Resolver precedence (locked design)
New `downloader::resolve_model_source(&Path) -> Result<PathBuf>` applies exactly this order:

1. **Existing on-disk path** → used verbatim. Byte-identical to the pre-#94 local-path behavior, even when the path happens to look like `owner/name`. Checked first so no existing invocation changes.
2. **`owner/name` repo-id shape** (matches `^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`) → resolved as: (a) legacy per-CWD `./models/<basename>` if complete; (b) existing HuggingFace Hub cache snapshot (read-only reuse); (c) mlxcel global store if complete; (d) on a miss, auto-download into the mlxcel store via `download_repo`/`DownloadOptions`, then re-locate the snapshot to return its real landing path.
3. **Neither** → a clear, actionable error.

The legacy and store reuse branches gate on a present `config.json` (mirroring the downloader's own `snapshot_complete` and `store::hf_cache_snapshot` gates), so a half-written or unrelated directory is treated as a miss instead of being handed to a model loader that would then fail.

## Integration
Each subcommand resolves its `-m` value once at the top of its handler, leaving every downstream `.model` consumer untouched:

- `run_generate` — resolves `args.model.model` before quantization advice, tokenizer load, memory preflight, and model load.
- `run_serve` — resolves `args.model` before the memory preflight (so the estimate sees the resolved path) and before the server starts.
- `run_inspect` — resolves `args.model`, replacing the old bespoke existence check (the resolver guarantees existence or errors).

Auto-download prints the same progress UX as `mlxcel download` because it routes through the identical `download_repo` entry point (allow-list filtering, token handling, HF-cache reuse, progress bars).

## Tests
- 18 new unit tests in `src/downloader/resolver_tests.rs` cover every branch: existing path (directory, file, and a repo-id-shaped directory), the `owner/name` shape parser (including the locked `.`-owner edge case), the `config.json` completeness gate, legacy CWD reuse, HF-cache reuse, mlxcel-store reuse, total miss, full precedence ordering, and both error arms. Network-free by construction; the download branch is left to the acceptance criteria.
- Existing downloader + store + serve/generate/inspect command unit tests pass unchanged.

## Manual verification
- `mlxcel inspect -m models/olmo-1b-4bit` → unchanged output (`Model: models/olmo-1b-4bit`), byte-identical back-compat.
- `mlxcel inspect -m fakeowner/olmo-1b-4bit` (with empty `MLXCEL_CACHE_DIR`/`HF_HUB_CACHE`) → reuses legacy `./models/olmo-1b-4bit` with no download.
- `mlxcel inspect -m this-is-not-a-model` / `mlxcel serve -m not-a-real-model` → clear error, exit code 1, no port bind.

## Local checks (orchestrator should run broad verification)
- `cargo check --lib --tests --features metal,accelerate` ✓
- `cargo check --bins --features metal,accelerate` ✓
- `cargo clippy --lib --tests --features metal,accelerate -- -D warnings` ✓ and `--bins` ✓
- `cargo test --lib downloader:: --features metal,accelerate` ✓ (83 passed)
- `cargo test --bin mlxcel commands::{generate,serve,inspect} --features metal,accelerate` ✓
- `cargo fmt --check` ✓
- Deferred to orchestrator: full `cargo test` / `cargo test --release` real-model suites (watchdog guard).