### PR TITLE
feat(cli): interactive chat REPL (multi-turn, streaming, slash commands, multiline)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -448,6 +454,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,7 +488,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -505,7 +520,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -919,6 +934,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +954,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "esaxx-rs"
@@ -970,6 +997,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "fdeflate"
@@ -1307,6 +1345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,7 +1672,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
@@ -1911,6 +1958,7 @@ dependencies = [
  "path-clean",
  "percent-encoding",
  "reqwest",
+ "rustyline",
  "safetensors",
  "sentencepiece",
  "serde",
@@ -2016,6 +2064,27 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
 ]
 
 [[package]]
@@ -2356,7 +2425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -2396,7 +2465,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -2424,6 +2493,16 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -2698,6 +2777,28 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "ryu"
@@ -3607,6 +3708,12 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,13 @@ blake3 = "1.8"
 # CLI
 clap = { version = "4.6.1", features = ["derive", "env"] }
 
+# Interactive chat REPL line editing (epic #92, issue #96). `rustyline`
+# provides the readline-style line editor (history, cursor movement,
+# Ctrl-C / Ctrl-D handling) for `mlxcel`'s interactive chat loop. Only the
+# offline CLI REPL uses it; the server is unaffected. Default features pull
+# in the terminal backend so arrow-key history works out of the box.
+rustyline = "14"
+
 # Image processing (for VLM)
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
 

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -1,0 +1,481 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Interactive multi-turn chat REPL (epic #92, issue #96).
+//!
+//! A line-edited, streaming chat loop in the spirit of `mlx_lm.chat` /
+//! `ollama run`. It is deliberately a thin orchestration layer over the
+//! **existing** generation machinery — it forks none of it:
+//!
+//! * model resolution → [`mlxcel::downloader::resolve_model_source`] (the same
+//!   `-m`-accepts-a-repo-id resolver `generate` / `serve` / `inspect` use,
+//!   issue #94),
+//! * tokenization → [`mlxcel::tokenizer::MlxcelTokenizer`] via
+//!   [`mlxcel::tokenizer::load_tokenizer`],
+//! * prompt rendering → [`ChatTemplateProcessor`] (the exact chat-template path
+//!   `generate` applies),
+//! * sampling → [`build_sampling_config`] over [`ResolvedSamplingParams`] (the
+//!   same `SamplingConfig` assembly `generate` uses),
+//! * token generation → [`CxxGenerator::generate_streaming`] (the same
+//!   streaming decode loop the offline `generate` path drives),
+//! * incremental detokenization → [`StreamingDecodeState`] (the server's own
+//!   byte-fallback-safe streaming detokenizer, now shared).
+//!
+//! ## Multi-turn context
+//!
+//! The full conversation ([`ChatMessage`] history) is re-rendered through the
+//! chat template every turn and the resulting prompt is fed to
+//! `generate_streaming`. This is the correctness-first reuse path: the
+//! generator re-prefills the accumulated context on each turn (it owns and
+//! resets its KV cache per call), so context is preserved without
+//! reimplementing a bespoke cross-turn KV-append loop that would diverge from
+//! the canonical generation code. `/clear` simply empties the history.
+//!
+//! ## Reusable entry point
+//!
+//! [`run_chat`] is a free function taking a self-contained [`ChatOptions`] so
+//! the forthcoming `mlxcel run` verb (issue #95) can dispatch straight into the
+//! REPL without going through `GenerateArgs`. The `generate` subcommand calls
+//! [`run_chat`] when invoked with no `-p/--prompt`.
+
+use std::io::{self, IsTerminal, Write as IoWrite};
+use std::path::PathBuf;
+use std::time::Instant;
+
+use anyhow::{Result, anyhow};
+use rustyline::DefaultEditor;
+use rustyline::error::ReadlineError;
+
+use mlxcel::sampling::{ResolvedSamplingParams, build_sampling_config};
+use mlxcel::server::chat_template::{ChatMessage, ChatTemplateProcessor};
+use mlxcel::server::model_provider::model_worker::StreamingDecodeState;
+use mlxcel::tokenizer::{MlxcelTokenizer, load_tokenizer};
+use mlxcel::{CxxGenerator, LanguageModel, SamplingConfig, initialize_runtime, load_model};
+use mlxcel_core::cache::KVCacheMode;
+
+/// Triple-quote fence that opens / closes an ollama-style multiline input
+/// block.
+const MULTILINE_FENCE: &str = "\"\"\"";
+
+/// Self-contained configuration for the interactive chat REPL.
+///
+/// Constructed by the `generate` subcommand (no-prompt path) and by the
+/// future `mlxcel run` verb (issue #95). Keeping this a plain options struct —
+/// rather than borrowing `GenerateArgs` — is what lets #95 reuse [`run_chat`]
+/// without dragging in the offline generate flag surface.
+#[derive(Debug, Clone)]
+pub struct ChatOptions {
+    /// Local model directory **or** a HuggingFace `owner/name` repo-id. Passed
+    /// verbatim to [`mlxcel::downloader::resolve_model_source`], so a repo-id
+    /// auto-downloads exactly like `generate -m <repo-id>`.
+    pub model: PathBuf,
+    /// Maximum number of tokens to generate per assistant turn.
+    pub max_tokens: usize,
+    /// Resolved sampling knobs (temperature / top-k / top-p / min-p /
+    /// penalties). The same struct `generate` builds its `SamplingConfig` from.
+    pub sampling: ResolvedSamplingParams,
+    /// KV-cache quantization mode for the generator.
+    pub kv_cache_mode: KVCacheMode,
+    /// When `true`, skip chat-template application and feed raw user text to
+    /// the model (mirrors `generate --no-chat-template`). Multi-turn context is
+    /// then concatenated as plain text.
+    pub no_chat_template: bool,
+}
+
+impl ChatOptions {
+    /// Construct chat options with the conventional REPL defaults
+    /// (greedy-friendly sampling left to the caller; everything else inert).
+    ///
+    /// Callers typically build [`ResolvedSamplingParams`] from their own CLI
+    /// flags; this helper only fixes the non-sampling knobs so `mlxcel run`
+    /// (issue #95) and the `generate` no-prompt path share one default surface.
+    pub fn new(model: PathBuf, max_tokens: usize, sampling: ResolvedSamplingParams) -> Self {
+        Self {
+            model,
+            max_tokens,
+            sampling,
+            kv_cache_mode: KVCacheMode::Fp16,
+            no_chat_template: false,
+        }
+    }
+}
+
+/// Outcome of interpreting a single submitted line / block.
+enum Action {
+    /// A complete user message ready to send to the model.
+    Send(String),
+    /// `/bye` (or EOF) — leave the REPL.
+    Exit,
+    /// Empty input — reprompt without sending.
+    Empty,
+}
+
+/// Result of dispatching a slash command.
+enum SlashOutcome {
+    /// Input was not a slash command — treat it as a user message.
+    NotACommand,
+    /// A command was handled; continue the loop (no conversation reset).
+    Handled,
+    /// `/clear` — conversation was reset; the caller should also reset
+    /// generator state before the next turn.
+    Cleared,
+    /// `/bye` — leave the REPL cleanly.
+    Exit,
+}
+
+/// Run the interactive multi-turn chat REPL until the user exits.
+///
+/// Reusable entry point for both the `generate` no-prompt path and the
+/// `mlxcel run` verb (issue #95). Loads the model once, then loops: read a
+/// line (or a `"""` multiline block), interpret slash commands, render the
+/// accumulated conversation through the chat template, and stream the
+/// assistant reply token-by-token via the shared [`CxxGenerator`].
+///
+/// # Errors
+///
+/// Returns an error if the model cannot be resolved / loaded, the tokenizer
+/// cannot be read, or the terminal line editor cannot be initialized. Per-turn
+/// generation never aborts the loop; a `/clear` or a fresh turn always recovers.
+pub fn run_chat(opts: ChatOptions) -> Result<()> {
+    let runtime = initialize_runtime();
+    println!("Runtime device: {}", runtime.device);
+
+    // Reuse the exact `-m` resolver `generate` / `serve` / `inspect` use, so a
+    // repo-id auto-downloads into the global store (epic #92, issues #93/#94).
+    let model_path = mlxcel::downloader::resolve_model_source(&opts.model)?;
+
+    println!("Loading model from {model_path:?}...");
+    let load_start = Instant::now();
+    let (model, _tok_from_load) = load_model(&model_path)?;
+    let tokenizer = load_tokenizer(&model_path)?;
+    println!(
+        "Model loaded in {:.2}s.",
+        load_start.elapsed().as_secs_f64()
+    );
+
+    // Same chat-template discovery as `generate`'s `load_cli_prompt`. `None`
+    // (no template, or `--no-chat-template`) falls back to raw-text turns.
+    let processor = if opts.no_chat_template {
+        None
+    } else {
+        ChatTemplateProcessor::from_model_path(&model_path)
+            .ok()
+            .flatten()
+    };
+    if processor.is_none() && !opts.no_chat_template {
+        eprintln!("Note: no chat template found for this model; sending raw text per turn.");
+    }
+
+    // Build the SamplingConfig once via the shared assembly used by `generate`.
+    // Stop tokens come from the model's config, exactly like the offline path.
+    let mut sampling = opts.sampling.clone();
+    if sampling.stop_token_ids.is_empty() {
+        sampling.stop_token_ids = mlxcel::read_eos_token_ids(&model_path);
+    }
+    let sampling_config = build_sampling_config(sampling);
+
+    // One generator for the whole session. `generate_streaming` resets its KV
+    // cache per call, so re-rendering the full transcript each turn preserves
+    // context without forking the generation loop.
+    let mut generator = CxxGenerator::new_with_kv_mode(model.num_layers(), opts.kv_cache_mode);
+
+    let mut editor = DefaultEditor::new()
+        .map_err(|e| anyhow!("failed to initialize the interactive line editor: {e}"))?;
+    let interactive = io::stdin().is_terminal();
+
+    print_banner(interactive);
+
+    let mut conversation: Vec<ChatMessage> = Vec::new();
+
+    loop {
+        let action = read_input(&mut editor, interactive);
+        match action {
+            Action::Exit => {
+                println!("Bye!");
+                break;
+            }
+            Action::Empty => continue,
+            Action::Send(user_text) => {
+                match handle_slash_command(&user_text, &mut conversation) {
+                    SlashOutcome::Exit => {
+                        println!("Bye!");
+                        break;
+                    }
+                    SlashOutcome::Cleared => {
+                        // `/clear` already reset the transcript; also drop any
+                        // generator-side state for a clean next prefill.
+                        generator.reset_with_model(&model);
+                        continue;
+                    }
+                    SlashOutcome::Handled => continue,
+                    SlashOutcome::NotACommand => {}
+                }
+
+                conversation.push(ChatMessage {
+                    role: "user".to_string(),
+                    content: user_text,
+                });
+
+                let prompt =
+                    render_prompt(processor.as_ref(), &conversation, opts.no_chat_template);
+                let reply = stream_turn(
+                    &mut generator,
+                    &model,
+                    &tokenizer,
+                    &prompt,
+                    opts.max_tokens,
+                    &sampling_config,
+                )?;
+
+                conversation.push(ChatMessage {
+                    role: "assistant".to_string(),
+                    content: reply,
+                });
+            }
+        }
+    }
+
+    mlxcel_core::clear_memory_cache();
+    Ok(())
+}
+
+/// Print the one-time greeting / help hint.
+fn print_banner(interactive: bool) {
+    println!();
+    println!("mlxcel interactive chat. Type a message and press Enter.");
+    println!("Commands: /bye (exit), /clear (reset conversation), /? or /help (this list).");
+    println!("Multiline: open and close a block with {MULTILINE_FENCE} on their own lines.");
+    if !interactive {
+        // Piped / redirected stdin: rustyline still reads lines, but there is
+        // no TTY to edit on. Make the degraded mode explicit instead of looking
+        // hung.
+        eprintln!("(non-interactive stdin detected: reading messages until EOF)");
+    }
+    println!();
+}
+
+/// Read one logical user submission: a single line, or a `"""`-fenced
+/// multiline block. Returns an [`Action`] describing what to do next.
+fn read_input(editor: &mut DefaultEditor, interactive: bool) -> Action {
+    let prompt = if interactive { ">>> " } else { "" };
+    let line = match editor.readline(prompt) {
+        Ok(line) => line,
+        // Ctrl-D / EOF (also fired at end of a piped stdin) exits cleanly so a
+        // non-interactive invocation never hangs.
+        Err(ReadlineError::Eof) => return Action::Exit,
+        // Ctrl-C cancels the current line without exiting the REPL.
+        Err(ReadlineError::Interrupted) => {
+            println!("(^C — type /bye to exit)");
+            return Action::Empty;
+        }
+        Err(_) => return Action::Exit,
+    };
+
+    // Record the raw line in history (best-effort; history is non-essential).
+    let _ = editor.add_history_entry(line.as_str());
+
+    let trimmed = line.trim();
+
+    // Triple-quote opens a multiline block: keep reading until the closing
+    // fence (ollama-style). The opening fence may carry inline text after it.
+    if let Some(rest) = trimmed.strip_prefix(MULTILINE_FENCE) {
+        return read_multiline_block(editor, rest);
+    }
+
+    if trimmed.is_empty() {
+        return Action::Empty;
+    }
+
+    Action::Send(trimmed.to_string())
+}
+
+/// Continue reading lines after an opening `"""` until the closing `"""`.
+///
+/// `first_rest` is whatever followed the opening fence on the same line. The
+/// closing fence may appear alone or with trailing text before it; everything
+/// up to (but not including) the fence is part of the message.
+fn read_multiline_block(editor: &mut DefaultEditor, first_rest: &str) -> Action {
+    let mut buf = String::new();
+
+    // Inline text after the opening fence, e.g. `"""hello` starts the body.
+    let first = first_rest.trim_start();
+    if let Some(before) = first.strip_suffix(MULTILINE_FENCE) {
+        // Single-line `"""body"""` form.
+        return finalize_multiline(before);
+    }
+    if !first.is_empty() {
+        buf.push_str(first);
+        buf.push('\n');
+    }
+
+    loop {
+        match editor.readline("... ") {
+            Ok(line) => {
+                let _ = editor.add_history_entry(line.as_str());
+                if let Some(before) = line.strip_suffix(MULTILINE_FENCE) {
+                    buf.push_str(before);
+                    return finalize_multiline(&buf);
+                }
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+            // EOF mid-block: send whatever was accumulated so we never hang.
+            Err(ReadlineError::Eof) => return finalize_multiline(&buf),
+            Err(ReadlineError::Interrupted) => {
+                println!("(^C — multiline input discarded)");
+                return Action::Empty;
+            }
+            Err(_) => return Action::Exit,
+        }
+    }
+}
+
+/// Trim a finished multiline body and turn it into a [`Action::Send`], or
+/// [`Action::Empty`] when nothing meaningful was entered.
+fn finalize_multiline(body: &str) -> Action {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        Action::Empty
+    } else {
+        Action::Send(trimmed.to_string())
+    }
+}
+
+/// Handle a slash command, returning a [`SlashOutcome`] that tells the loop
+/// whether to send the input as a message, continue, reset, or exit.
+fn handle_slash_command(input: &str, conversation: &mut Vec<ChatMessage>) -> SlashOutcome {
+    if !input.starts_with('/') {
+        return SlashOutcome::NotACommand;
+    }
+    // First whitespace-delimited token is the command.
+    let command = input.split_whitespace().next().unwrap_or(input);
+    match command {
+        "/bye" => SlashOutcome::Exit,
+        "/clear" => {
+            conversation.clear();
+            println!("Conversation cleared.");
+            SlashOutcome::Cleared
+        }
+        "/?" | "/help" => {
+            print_help();
+            SlashOutcome::Handled
+        }
+        other => {
+            println!("Unknown command: {other}. Type /? for the list of commands.");
+            SlashOutcome::Handled
+        }
+    }
+}
+
+/// Print the slash-command help block (`/?`).
+fn print_help() {
+    println!("Available commands:");
+    println!("  /bye           Exit the chat.");
+    println!("  /clear         Reset the conversation (clears all prior turns).");
+    println!("  /?, /help      Show this help.");
+    println!("  {MULTILINE_FENCE} ... {MULTILINE_FENCE}   Wrap multiline input as one message.");
+}
+
+/// Render the accumulated conversation into a model prompt.
+///
+/// Uses the chat template when available (the exact path `generate` uses for a
+/// single user turn, generalized to the full transcript). Without a template
+/// (or with `--no-chat-template`) it concatenates the turns as plain text.
+fn render_prompt(
+    processor: Option<&ChatTemplateProcessor>,
+    conversation: &[ChatMessage],
+    no_chat_template: bool,
+) -> String {
+    if no_chat_template {
+        return concat_plaintext(conversation);
+    }
+    match processor {
+        Some(p) => p
+            .apply(conversation, None)
+            .unwrap_or_else(|_| concat_plaintext(conversation)),
+        None => concat_plaintext(conversation),
+    }
+}
+
+/// Plain-text transcript fallback when no chat template is in play.
+fn concat_plaintext(conversation: &[ChatMessage]) -> String {
+    let mut out = String::new();
+    for msg in conversation {
+        out.push_str(&msg.content);
+        out.push('\n');
+    }
+    out
+}
+
+/// Tokenize, stream-generate, and print one assistant turn; return the decoded
+/// reply text (to append to the transcript).
+///
+/// Tokenization matches `generate::tokenize_prompt` (skip the extra BOS when
+/// the rendered prompt already embeds one). Generation goes through
+/// [`CxxGenerator::generate_streaming`] — the same loop the offline path uses —
+/// with a per-token callback that streams text via [`StreamingDecodeState`].
+fn stream_turn<M: LanguageModel>(
+    generator: &mut CxxGenerator,
+    model: &M,
+    tokenizer: &MlxcelTokenizer,
+    prompt: &str,
+    max_tokens: usize,
+    sampling_config: &SamplingConfig,
+) -> Result<String> {
+    let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
+    let prompt_tokens: Vec<i32> = tokenizer
+        .encode(prompt, add_special)
+        .map_err(|e| anyhow!("Tokenization failed: {e}"))?
+        .iter()
+        .map(|&x| x as i32)
+        .collect();
+
+    // Stream display through the shared incremental detokenizer (byte-fallback
+    // safe), while separately collecting the raw generated ids so the
+    // transcript reply is decoded byte-exactly at the end — independent of any
+    // tail bytes the streaming view held back.
+    let mut decode_state = StreamingDecodeState::new(tokenizer, &prompt_tokens);
+    let mut generated_ids: Vec<u32> = Vec::with_capacity(max_tokens);
+    let mut stdout = io::stdout();
+
+    generator.generate_streaming(
+        model,
+        &prompt_tokens,
+        max_tokens,
+        sampling_config,
+        |token_id| {
+            generated_ids.push(token_id as u32);
+            if let Some(text) = decode_state.on_token(token_id, tokenizer) {
+                print!("{text}");
+                let _ = stdout.flush();
+            }
+            true
+        },
+    );
+
+    // Resolve any byte-fallback / split-UTF-8 remainder held back mid-stream so
+    // the displayed line is complete, then close out the assistant block.
+    decode_state.flush(tokenizer);
+    println!();
+    println!();
+
+    // Decode the full assistant turn for the transcript (skip special tokens so
+    // template markers do not leak into the next turn's rendered history).
+    let reply = tokenizer.decode(&generated_ids, true).unwrap_or_default();
+    Ok(reply)
+}
+
+#[cfg(test)]
+#[path = "chat_tests.rs"]
+mod tests;

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -442,11 +442,12 @@ fn stream_turn<M: LanguageModel>(
         .collect();
 
     // Stream display through the shared incremental detokenizer (byte-fallback
-    // safe), while separately collecting the raw generated ids so the
-    // transcript reply is decoded byte-exactly at the end — independent of any
-    // tail bytes the streaming view held back.
+    // safe), accumulating exactly what was printed. The raw generated ids are
+    // collected in parallel so the final turn text is decoded byte-exactly,
+    // independent of any tail bytes the streaming view held back mid-stream.
     let mut decode_state = StreamingDecodeState::new(tokenizer, &prompt_tokens);
     let mut generated_ids: Vec<u32> = Vec::with_capacity(max_tokens);
+    let mut streamed = String::new();
     let mut stdout = io::stdout();
 
     generator.generate_streaming(
@@ -459,20 +460,26 @@ fn stream_turn<M: LanguageModel>(
             if let Some(text) = decode_state.on_token(token_id, tokenizer) {
                 print!("{text}");
                 let _ = stdout.flush();
+                streamed.push_str(&text);
             }
             true
         },
     );
 
-    // Resolve any byte-fallback / split-UTF-8 remainder held back mid-stream so
-    // the displayed line is complete, then close out the assistant block.
-    decode_state.flush(tokenizer);
+    // Decode the full assistant turn (skip special tokens so template markers do
+    // not leak into the next turn's rendered history). This is the byte-exact
+    // turn text used both for the transcript and to flush any tail the streaming
+    // view held back (e.g. a multi-byte char split across the final tokens).
+    let reply = tokenizer.decode(&generated_ids, true).unwrap_or_default();
+    if let Some(tail) = reply.strip_prefix(&streamed)
+        && !tail.is_empty()
+    {
+        print!("{tail}");
+        let _ = stdout.flush();
+    }
     println!();
     println!();
 
-    // Decode the full assistant turn for the transcript (skip special tokens so
-    // template markers do not leak into the next turn's rendered history).
-    let reply = tokenizer.decode(&generated_ids, true).unwrap_or_default();
     Ok(reply)
 }
 

--- a/src/commands/chat_tests.rs
+++ b/src/commands/chat_tests.rs
@@ -1,0 +1,172 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the interactive chat REPL's pure helpers (issue #96).
+//!
+//! These cover slash-command dispatch, multiline-block finalization, and
+//! prompt rendering — the logic that does not require a loaded model. The
+//! end-to-end streaming loop is exercised by the orchestrator's broader,
+//! real-model integration runs.
+
+use super::*;
+
+fn user(content: &str) -> ChatMessage {
+    ChatMessage {
+        role: "user".to_string(),
+        content: content.to_string(),
+    }
+}
+
+fn assistant(content: &str) -> ChatMessage {
+    ChatMessage {
+        role: "assistant".to_string(),
+        content: content.to_string(),
+    }
+}
+
+#[test]
+fn slash_bye_signals_exit() {
+    let mut convo = vec![user("hi")];
+    assert!(matches!(
+        handle_slash_command("/bye", &mut convo),
+        SlashOutcome::Exit
+    ));
+    // Exit must not mutate the transcript.
+    assert_eq!(convo.len(), 1);
+}
+
+#[test]
+fn slash_clear_resets_conversation() {
+    let mut convo = vec![user("hi"), assistant("hello")];
+    assert!(matches!(
+        handle_slash_command("/clear", &mut convo),
+        SlashOutcome::Cleared
+    ));
+    assert!(convo.is_empty());
+}
+
+#[test]
+fn slash_help_aliases_are_handled_without_reset() {
+    let mut convo = vec![user("hi")];
+    assert!(matches!(
+        handle_slash_command("/?", &mut convo),
+        SlashOutcome::Handled
+    ));
+    assert!(matches!(
+        handle_slash_command("/help", &mut convo),
+        SlashOutcome::Handled
+    ));
+    assert_eq!(convo.len(), 1, "help must not mutate the transcript");
+}
+
+#[test]
+fn unknown_slash_command_is_handled_not_sent() {
+    let mut convo = Vec::new();
+    assert!(matches!(
+        handle_slash_command("/nope", &mut convo),
+        SlashOutcome::Handled
+    ));
+}
+
+#[test]
+fn non_slash_input_is_not_a_command() {
+    let mut convo = Vec::new();
+    assert!(matches!(
+        handle_slash_command("hello there", &mut convo),
+        SlashOutcome::NotACommand
+    ));
+    // A message that merely contains a slash mid-string is still a message.
+    assert!(matches!(
+        handle_slash_command("what is 1/2", &mut convo),
+        SlashOutcome::NotACommand
+    ));
+}
+
+#[test]
+fn slash_command_ignores_trailing_args() {
+    let mut convo = vec![user("hi")];
+    // `/clear` with trailing tokens still dispatches on the first token.
+    assert!(matches!(
+        handle_slash_command("/clear everything", &mut convo),
+        SlashOutcome::Cleared
+    ));
+    assert!(convo.is_empty());
+}
+
+#[test]
+fn finalize_multiline_trims_and_detects_empty() {
+    assert!(matches!(finalize_multiline("   \n  "), Action::Empty));
+    match finalize_multiline("  line one\nline two  ") {
+        Action::Send(text) => assert_eq!(text, "line one\nline two"),
+        _ => panic!("expected Send"),
+    }
+}
+
+#[test]
+fn concat_plaintext_joins_turns_with_newlines() {
+    let convo = vec![user("first"), assistant("second"), user("third")];
+    assert_eq!(concat_plaintext(&convo), "first\nsecond\nthird\n");
+}
+
+#[test]
+fn render_prompt_without_template_falls_back_to_plaintext() {
+    let convo = vec![user("hello")];
+    // No processor and not forced: plain-text fallback.
+    assert_eq!(render_prompt(None, &convo, false), "hello\n");
+    // `no_chat_template` forces plain-text even if a processor were present.
+    assert_eq!(render_prompt(None, &convo, true), "hello\n");
+}
+
+#[test]
+fn render_prompt_with_template_renders_all_turns() {
+    // A minimal Jinja chat template that simply marks each role+content.
+    let template = "{% for m in messages %}<{{ m.role }}>{{ m.content }}</{{ m.role }}>\
+        {% endfor %}{% if add_generation_prompt %}<gen>{% endif %}"
+        .to_string();
+    let processor = ChatTemplateProcessor::with_template(template);
+    let convo = vec![user("hi"), assistant("hello"), user("again")];
+
+    let rendered = render_prompt(Some(&processor), &convo, false);
+    assert_eq!(
+        rendered,
+        "<user>hi</user><assistant>hello</assistant><user>again</user><gen>"
+    );
+    // Multi-turn context is preserved: the prior assistant turn is present.
+    assert!(rendered.contains("<assistant>hello</assistant>"));
+}
+
+#[test]
+fn chat_options_new_sets_conventional_defaults() {
+    let sampling = ResolvedSamplingParams {
+        temperature: 0.0,
+        top_k: 0,
+        top_p: 1.0,
+        min_p: 0.0,
+        seed: None,
+        repetition_penalty: 1.0,
+        dry_multiplier: 0.0,
+        dry_base: 1.75,
+        dry_allowed_length: 2,
+        dry_penalty_last_n: 0,
+        dry_sequence_breakers: Vec::new(),
+        frequency_penalty: 0.0,
+        presence_penalty: 0.0,
+        stop_token_ids: Vec::new(),
+    };
+    let opts = ChatOptions::new(PathBuf::from("models/foo"), 128, sampling);
+    assert_eq!(opts.max_tokens, 128);
+    assert!(!opts.no_chat_template);
+    assert!(matches!(opts.kv_cache_mode, KVCacheMode::Fp16));
+    assert!(opts.sampling.stop_token_ids.is_empty());
+}

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1016,7 +1016,74 @@ fn install_surgery_pipeline_from_cli(args: &GenerateArgs) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn run_generate(mut args: GenerateArgs) -> Result<()> {
+/// Build [`ChatOptions`] for the interactive REPL from the parsed generate
+/// args. Reuses the same sampling-knob mapping `build_cli_sampling_config`
+/// uses (so the REPL and one-shot `generate` sample identically) and resolves
+/// the KV-cache mode through the shared `resolve_kv_cache_mode` helper.
+///
+/// `stop_token_ids` is left empty here and filled in by `run_chat` from the
+/// model's config once the model directory is resolved, mirroring the one-shot
+/// path's `read_eos_token_ids(&args.model.model)`.
+fn chat_options_from_args(args: &GenerateArgs) -> Result<crate::commands::ChatOptions> {
+    let kv_cache_mode = resolve_kv_cache_mode(
+        args.generation.turbo.cache_type_k.as_deref(),
+        args.generation.turbo.cache_type_v.as_deref(),
+        args.generation.turbo.kv_cache_mode.as_deref(),
+    )
+    .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let sampling = ResolvedSamplingParams {
+        temperature: args.sampling.temp,
+        top_k: args.sampling.top_k,
+        top_p: args.sampling.top_p,
+        min_p: args.sampling.min_p,
+        seed: None,
+        repetition_penalty: args.sampling.repetition_penalty,
+        dry_multiplier: args.sampling.dry_multiplier,
+        dry_base: args.sampling.dry_base,
+        dry_allowed_length: args.sampling.dry_allowed_length,
+        dry_penalty_last_n: args.sampling.dry_penalty_last_n,
+        dry_sequence_breakers: Vec::new(),
+        frequency_penalty: 0.0,
+        presence_penalty: 0.0,
+        stop_token_ids: Vec::new(),
+    };
+
+    let mut opts = crate::commands::ChatOptions::new(
+        args.model.model.clone(),
+        args.generation.max_tokens,
+        sampling,
+    );
+    opts.kv_cache_mode = kv_cache_mode;
+    opts.no_chat_template = args.generation.no_chat_template;
+    Ok(opts)
+}
+
+pub(crate) fn run_generate(args: GenerateArgs) -> Result<()> {
+    // Epic #92 / issue #96: no `-p/--prompt` means "interactive chat". Route to
+    // the reusable REPL entry point before any one-shot-only setup. The REPL
+    // initializes its own runtime, resolves `-m` (repo-id auto-download), loads
+    // the model + tokenizer, and reuses the same chat-template / SamplingConfig
+    // / streaming-generation path as the one-shot flow below. Advanced
+    // parallelism / speculative / surgery flags are not applied in the
+    // interactive scope (per #96: "scoped to the CLI run/generate path only").
+    if args.generation.prompt.is_none() {
+        let opts = chat_options_from_args(&args)?;
+        return crate::commands::run_chat(opts);
+    }
+
+    run_generate_once(args)
+}
+
+/// One-shot (`-p`-supplied) text generation — the historical `generate` flow.
+fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
+    // Safe: the only caller (`run_generate`) guarantees `prompt` is `Some`.
+    let user_prompt = args
+        .generation
+        .prompt
+        .clone()
+        .expect("run_generate_once requires a prompt");
+
     let runtime = initialize_runtime();
     print_runtime_setup(&runtime);
 
@@ -1078,7 +1145,7 @@ pub(crate) fn run_generate(mut args: GenerateArgs) -> Result<()> {
     let tokenizer = load_tokenizer(&args.model.model)?;
     let prompt = load_cli_prompt(
         &args.model.model,
-        &args.generation.prompt,
+        &user_prompt,
         args.generation.no_chat_template,
         args.generation.image.len(),
     );
@@ -1210,7 +1277,7 @@ pub(crate) fn run_generate(mut args: GenerateArgs) -> Result<()> {
             pipeline_sampling.token_bias = token_bias.clone();
         }
         let num_layers = resolve_cli_pipeline_num_layers(&args.model.model)?;
-        print_generation_preamble(&args.generation.prompt)?;
+        print_generation_preamble(&user_prompt)?;
         generate_pipeline_text(
             &args.model.model,
             num_layers,
@@ -1231,7 +1298,7 @@ pub(crate) fn run_generate(mut args: GenerateArgs) -> Result<()> {
             args.generation.fps,
             &tokenizer,
         )?;
-        print_generation_preamble(&args.generation.prompt)?;
+        print_generation_preamble(&user_prompt)?;
         run_generation_mode(
             &model,
             &args,

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -116,7 +116,7 @@ fn sample_generate_args(model_path: PathBuf) -> crate::GenerateArgs {
             num_draft_tokens: 3,
         },
         generation: crate::GenerationOptions {
-            prompt: "Hello".to_string(),
+            prompt: Some("Hello".to_string()),
             image: Vec::new(),
             audio: None,
             video: Vec::new(),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,6 +18,7 @@
 //! argument/schema wiring while command-specific execution logic evolves in
 //! isolated modules.
 
+pub(crate) mod chat;
 pub(crate) mod detect;
 pub(crate) mod download;
 pub(crate) mod generate;
@@ -26,6 +27,7 @@ pub(crate) mod inspect;
 pub(crate) mod models;
 mod serve;
 
+pub(crate) use chat::{ChatOptions, run_chat};
 pub(crate) use detect::run_detect;
 pub(crate) use download::run_download;
 pub(crate) use generate::run_generate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,9 +234,14 @@ pub(crate) struct ModelOptions {
 #[derive(Args, Debug)]
 #[command(next_help_heading = "Generation Options")]
 pub(crate) struct GenerationOptions {
-    /// The prompt to generate text from
+    /// The prompt to generate text from.
+    ///
+    /// When omitted, `mlxcel generate` drops into an interactive multi-turn
+    /// chat REPL (streaming output, `/bye` / `/clear` / `/?` slash commands,
+    /// and `"""` multiline blocks) instead of running a single completion —
+    /// mirroring `mlx_lm.chat` / `ollama run`.
     #[arg(short, long, value_name = "TEXT")]
-    pub(crate) prompt: String,
+    pub(crate) prompt: Option<String>,
 
     /// Image file paths for vision-language models (VLM)
     #[arg(long, value_name = "PATH", num_args = 1..)]

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -88,8 +88,14 @@ pub struct GenerationResult {
     pub cached_tokens: usize,
 }
 
+// `pub` (not `pub(crate)`) so the offline interactive chat REPL
+// (`mlxcel::commands::chat`, epic #92 / issue #96) can reuse
+// [`model_worker::StreamingDecodeState`] for incremental, byte-fallback-safe
+// detokenization instead of forking a second detokenizer. The server's
+// streaming path is the canonical owner of this logic; the REPL is a second
+// consumer of the exact same code.
 #[path = "model_worker.rs"]
-pub(crate) mod model_worker;
+pub mod model_worker;
 
 /// Thread-safe model provider using channels
 pub struct ModelProvider {

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -1024,7 +1024,15 @@ pub(crate) fn build_generation_result_with_cache(
 /// indefinitely on pathological model outputs.
 const BYTE_FALLBACK_BUFFER_MAX: usize = 4;
 
-pub(crate) struct StreamingDecodeState {
+/// Incremental, byte-fallback-safe detokenizer for streaming generation.
+///
+/// Owns the running token-id buffer and emits only the newly-resolved UTF-8
+/// suffix as each token arrives, holding back incomplete multi-byte sequences
+/// (byte-fallback `<0xXX>` tokens and split byte-level BPE pieces) until they
+/// form valid UTF-8. This is the canonical detokenizer for the server's
+/// streaming responses and is also reused by the offline interactive chat
+/// REPL (epic #92 / issue #96) so the two surfaces never diverge.
+pub struct StreamingDecodeState {
     all_ids: Vec<u32>,
     prev_decoded_len: usize,
     generated_text: String,
@@ -1038,7 +1046,7 @@ pub(crate) struct StreamingDecodeState {
 }
 
 impl StreamingDecodeState {
-    pub(crate) fn new(tokenizer: &MlxcelTokenizer, prompt_tokens: &[i32]) -> Self {
+    pub fn new(tokenizer: &MlxcelTokenizer, prompt_tokens: &[i32]) -> Self {
         let all_ids: Vec<u32> = prompt_tokens.iter().map(|&x| x as u32).collect();
         let prev_decoded_len = tokenizer.decode(&all_ids, false).unwrap_or_default().len();
 
@@ -1052,11 +1060,7 @@ impl StreamingDecodeState {
         }
     }
 
-    pub(crate) fn on_token(
-        &mut self,
-        token_id: i32,
-        tokenizer: &MlxcelTokenizer,
-    ) -> Option<String> {
+    pub fn on_token(&mut self, token_id: i32, tokenizer: &MlxcelTokenizer) -> Option<String> {
         if self.first_token_time.is_none() {
             self.first_token_time = Some(Instant::now());
         }
@@ -1193,7 +1197,7 @@ impl StreamingDecodeState {
     /// Also drains the byte-fallback buffer: any accumulated bytes that did not
     /// form a complete UTF-8 sequence are emitted as U+FFFD replacement
     /// characters so that the streamed output matches the non-streaming result.
-    pub(crate) fn flush(&mut self, tokenizer: &MlxcelTokenizer) {
+    pub fn flush(&mut self, tokenizer: &MlxcelTokenizer) {
         // Drain the byte-fallback buffer first. Any incomplete byte sequences
         // are flushed as replacement characters here; we then skip past the
         // corresponding replacement chars in the full-decode result below so


### PR DESCRIPTION
Closes #96
Part of #92 (unified download + run).

## Summary
Adds an interactive multi-turn chat REPL entered from `mlxcel generate` when no `-p/--prompt` is supplied, in the spirit of `mlx_lm.chat` / `ollama run`. The assistant reply streams token-by-token, conversation context is preserved across turns, and the loop supports slash commands and `"""` multiline input.

## Acceptance criteria (issue #96)
- [x] `<repo-id>` with no prompt opens a working REPL; assistant output streams token-by-token. (`mlxcel generate -m <repo-id>` with no `-p`; `mlxcel run` is issue #95 and dispatches into this same entry point.)
- [x] Conversation context persists across turns; `/clear` resets it.
- [x] `"""` multiline input is accepted as a single message.
- [x] `/bye` exits cleanly; `/?` (and `/help`) lists commands.
- [x] Piped / non-interactive stdin works and degrades gracefully (reads until EOF, exits cleanly — verified, no hang).

## Reuse, not fork (required by #96)
The REPL is a thin orchestration layer over the existing generation path and forks none of it:
- **Model resolution** → `downloader::resolve_model_source` (issue #94) so `-m` accepts a repo-id and auto-downloads, exactly like `generate` / `serve` / `inspect`.
- **Tokenization** → `MlxcelTokenizer` via `tokenizer::load_tokenizer`.
- **Prompt rendering** → `server::chat_template::ChatTemplateProcessor` (the exact chat-template path `generate` uses, generalized from one user turn to the full transcript).
- **Sampling** → `sampling::build_sampling_config` over `ResolvedSamplingParams` (the same `SamplingConfig` assembly `generate` uses; stop tokens from `read_eos_token_ids`).
- **Token generation** → `CxxGenerator::generate_streaming` (the same streaming decode loop the offline `generate` path drives).
- **Incremental detokenization** → the server's `StreamingDecodeState` (byte-fallback / split-UTF-8 safe), now shared rather than duplicated.

Multi-turn context is preserved by re-rendering the full `ChatMessage` transcript through the chat template each turn and letting the generator re-prefill (it owns and resets its KV cache per `generate_streaming` call). This is the correctness-first reuse path; it avoids a bespoke cross-turn KV-append loop that would diverge from the canonical generation code. `/clear` empties the transcript and resets generator state.

## Reusable entry point (for #95)
The interactive loop is a free function, not buried in a command handler, so the forthcoming `mlxcel run` verb (#95) can dispatch straight into it:

```rust
// src/commands/chat.rs
pub fn run_chat(opts: ChatOptions) -> anyhow::Result<()>;

pub struct ChatOptions {
    pub model: std::path::PathBuf,          // local dir or owner/name repo-id
    pub max_tokens: usize,
    pub sampling: mlxcel::sampling::ResolvedSamplingParams,
    pub kv_cache_mode: mlxcel_core::cache::KVCacheMode,
    pub no_chat_template: bool,
}
impl ChatOptions {
    pub fn new(model: PathBuf, max_tokens: usize, sampling: ResolvedSamplingParams) -> Self;
}
```

`#95` will build a `ChatOptions` (from a repo-id + its own flags) and call `run_chat` for the no-prompt path.

## Notable changes
- `generate`'s `--prompt` is now `Option<String>`; supplying it preserves the historical one-shot flow (`run_generate_once`) byte-for-byte. Omitting it routes to `run_chat`.
- `StreamingDecodeState` and the `server::model_provider::model_worker` module are promoted to `pub` so the offline REPL reuses the exact server detokenizer.
- New dependency: `rustyline` (line editor / history / Ctrl-C / Ctrl-D) for the REPL only; the server is unaffected.

## Tests
- New `src/commands/chat_tests.rs`: slash-command dispatch (`/bye` `/clear` `/?` `/help`, unknown, non-command, trailing-args), multiline finalization, prompt rendering with and without a chat template (verifies all turns are rendered → multi-turn context), plaintext fallback, and `ChatOptions` defaults. 11 tests, all passing.
- Existing `commands::generate::tests` (26) and `server::model_provider::model_worker` (15) pass unchanged.
- `tests/cli_help_consistency.rs` (8) passes (no forbidden `issue #`/`epic #` substrings in `--help`).
- Manual end-to-end smoke tests against `qwen3-0.6b-4bit` and `smollm-135m-4bit`: streaming multi-turn, `/?`, `/clear`, `/bye`, `"""` multiline, and piped-stdin EOF — all exit 0, no hang.

`cargo check`/`cargo clippy --lib --bins --tests --features metal,accelerate -- -D warnings` clean; `cargo fmt --check` clean.

Broad workspace test suites were not run locally (watchdog scope); left to central verification.