### PR TITLE
feat(cli): add `mlxcel run` verb (one-shot + REPL dispatch + default-model fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ mlxcel serve -m mlx-community/Qwen3.5-0.8B-4bit --port 8080
 
 An existing local path is still used as-is, so `-m ./models/...` and `-m ~/.cache/mlxcel/...` behave exactly as before.
 
+For an `ollama run`-style one-liner, use `mlxcel run`. It takes the model as a positional argument (repo-id or local path, resolved and auto-downloaded exactly like `-m` above) and chooses interactive chat or one-shot generation based on whether you pass `-p`:
+
+```bash
+# Interactive multi-turn chat REPL (no -p).
+mlxcel run mlx-community/Qwen3.5-0.8B-4bit
+
+# One-shot generation, then exit (-p). Identical output to the equivalent `generate`.
+mlxcel run mlx-community/Qwen3.5-0.8B-4bit -p "Hello, world!" -n 100
+
+# No model argument → falls back to the default model
+# `mlx-community/Llama-3.2-3B-Instruct-4bit` (mlx-lm parity), auto-downloaded on first use.
+mlxcel run
+```
+
+`mlxcel run` shares `mlxcel generate`'s sampling and generation flags (`-n`, `--temp`, `--top-p`, `--no-chat-template`, the TurboQuant KV-cache flags, …), so it is a thin convenience wrapper over the same code path — not a separate engine.
+
 `mlxcel inspect` is read-only and prints a byte-level breakdown of weights /
 KV cache / runtime headroom against available unified memory without loading
 any tensors. `--estimate-memory` on `mlxcel generate` and `mlxcel serve`

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod generate;
 mod generate_vlm;
 pub(crate) mod inspect;
 pub(crate) mod models;
+pub(crate) mod run;
 mod serve;
 
 pub(crate) use chat::{ChatOptions, run_chat};
@@ -33,4 +34,5 @@ pub(crate) use download::run_download;
 pub(crate) use generate::run_generate;
 pub(crate) use inspect::run_inspect;
 pub(crate) use models::{run_list_local, run_remove};
+pub(crate) use run::{RunArgs, run_run};
 pub(crate) use serve::run_serve;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,0 +1,141 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `mlxcel run` verb (epic #92, issue #95) — the ollama-/mlx-lm-style entry
+//! point.
+//!
+//! `run` is the capstone of the unified download + run epic. It is a thin
+//! dispatcher that forks **no** model-loading or generation code — it builds a
+//! [`GenerateArgs`] from its own (deliberately small) flag surface and hands it
+//! straight to [`crate::commands::run_generate`], which already routes:
+//!
+//! * **no `-p/--prompt`** → the interactive multi-turn chat REPL
+//!   ([`crate::commands::run_chat`], issue #96), and
+//! * **with `-p`** → the historical one-shot `generate` flow
+//!   (`run_generate_once`), including the repo-id-aware `-m` resolver
+//!   ([`mlxcel::downloader::resolve_model_source`], issue #94).
+//!
+//! Routing through `run_generate` (rather than re-implementing the
+//! prompt/no-prompt branch) is what guarantees `mlxcel run <repo-id> -p "..."`
+//! produces byte-identical output to the equivalent `mlxcel generate -m
+//! <repo-id> -p "..."` invocation — they execute the same code.
+//!
+//! ## Default-model fallback
+//!
+//! When no model argument is supplied, `run` falls back to [`DEFAULT_MODEL`],
+//! mirroring `mlx_lm.generate` / `mlx_lm.chat` (both default to the same
+//! repo-id). The repo-id is auto-downloaded into the mlxcel global store on
+//! first use by the shared resolver, so `mlxcel run` with no arguments works
+//! from any directory.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Args;
+
+use crate::{GenerateArgs, GenerationOptions, ModelOptions, SamplingOptions};
+
+/// Default model used when `mlxcel run` is invoked without a model argument.
+///
+/// Matches the `DEFAULT_MODEL` constant `mlx_lm.generate` and `mlx_lm.chat`
+/// fall back to, so a user moving from mlx-lm gets the same out-of-the-box
+/// model. Documented in the `run` `--help` text and the project README.
+pub(crate) const DEFAULT_MODEL: &str = "mlx-community/Llama-3.2-3B-Instruct-4bit";
+
+/// Arguments for `mlxcel run`.
+///
+/// `run` mirrors `ollama run`: pass a model (repo-id or local path) and either
+/// stream an interactive chat (no `-p`) or print a one-shot completion (`-p
+/// "..."`). The model argument is **optional** — omitting it loads
+/// [`DEFAULT_MODEL`]. Sampling and generation flags are the *same* clap groups
+/// [`GenerateArgs`] flattens ([`GenerationOptions`] / [`SamplingOptions`]), so
+/// `--help` and behavior stay in lock-step with `mlxcel generate` and no flag
+/// is duplicated.
+#[derive(Args, Debug)]
+#[command(next_help_heading = "Run Options")]
+pub(crate) struct RunArgs {
+    /// Model to run: a local directory **or** a HuggingFace `owner/name`
+    /// repo-id to auto-download (resolved exactly like `mlxcel generate -m`).
+    ///
+    /// Optional — when omitted, `mlxcel run` falls back to the default model
+    /// `mlx-community/Llama-3.2-3B-Instruct-4bit` (mlx-lm parity) and
+    /// auto-downloads it into the mlxcel store on first use. Given as a
+    /// positional argument so `mlxcel run <repo-id>` reads like `ollama run`.
+    #[arg(value_name = "MODEL_OR_REPO_ID")]
+    pub(crate) model: Option<PathBuf>,
+
+    /// Path to LoRA adapter directory (optional). Mirrors `mlxcel generate
+    /// --adapter`.
+    #[arg(long, value_name = "PATH")]
+    pub(crate) adapter: Option<PathBuf>,
+
+    /// Generation options shared verbatim with `mlxcel generate` (`-p/--prompt`,
+    /// `-n/--max-tokens`, image/audio/video inputs, `--no-chat-template`, the
+    /// TurboQuant KV-cache flags, …). Omitting `-p/--prompt` drops into the
+    /// interactive chat REPL.
+    #[command(flatten)]
+    pub(crate) generation: GenerationOptions,
+
+    /// Sampling options shared verbatim with `mlxcel generate` (temperature,
+    /// top-k/p, min-p, repetition + DRY penalties).
+    #[command(flatten)]
+    pub(crate) sampling: SamplingOptions,
+}
+
+impl RunArgs {
+    /// Lower the `run` flag surface onto a full [`GenerateArgs`], filling the
+    /// model (default-model fallback) and leaving every advanced flag group
+    /// (`tensor_parallel` / `pipeline_parallel` / `speculative` / `lang_bias`
+    /// / `surgery`) at its clap default — `run` intentionally does not expose
+    /// them, matching the minimal `ollama run` surface. The resulting
+    /// `GenerateArgs` is then driven by the unchanged `run_generate` dispatch.
+    fn into_generate_args(self) -> GenerateArgs {
+        let model = self.model.unwrap_or_else(|| PathBuf::from(DEFAULT_MODEL));
+
+        GenerateArgs {
+            model: ModelOptions {
+                model,
+                adapter: self.adapter,
+                // `run` does not surface offline speculative decoding; keep the
+                // same defaults `mlxcel generate` uses when the flags are absent.
+                draft_model: None,
+                num_draft_tokens: 3,
+            },
+            generation: self.generation,
+            sampling: self.sampling,
+            pipeline_parallel: crate::PipelineParallelOptions::default(),
+            tensor_parallel: crate::TensorParallelOptions::default(),
+            lang_bias: mlxcel::lang_bias::LangBiasCliArgs::default(),
+            speculative: mlxcel::cli::speculative_args::SpeculativeArgs::default(),
+            #[cfg(feature = "surgery")]
+            surgery: None,
+        }
+    }
+}
+
+/// Handle `mlxcel run`.
+///
+/// Resolves the default model when none is given, then dispatches through the
+/// shared [`crate::commands::run_generate`] path: no prompt → interactive chat
+/// REPL (issue #96); `-p` → one-shot generation (the historical `generate`
+/// flow). Model resolution / auto-download is performed by the same
+/// [`mlxcel::downloader::resolve_model_source`] resolver (issue #94) those paths
+/// already use.
+pub(crate) fn run_run(args: RunArgs) -> Result<()> {
+    crate::commands::run_generate(args.into_generate_args())
+}
+
+#[cfg(test)]
+#[path = "run_tests.rs"]
+mod tests;

--- a/src/commands/run_tests.rs
+++ b/src/commands/run_tests.rs
@@ -1,0 +1,177 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Argument-parsing and lowering tests for the `mlxcel run` verb (issue #95).
+//!
+//! These cover the clap surface and the `RunArgs -> GenerateArgs` lowering
+//! only; they never load a model or run generation (the dispatch into
+//! `run_generate` is exercised end-to-end by the real-model integration
+//! suites). The point is to lock the three documented `run` behaviors —
+//! one-shot (`-p`), no-prompt REPL, and default-model fallback — at the
+//! arg-construction boundary.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use super::{DEFAULT_MODEL, RunArgs};
+use crate::{Cli, Commands};
+
+/// Parse a `mlxcel run ...` command line into [`RunArgs`], panicking with the
+/// clap error if it does not parse.
+fn parse_run(argv: &[&str]) -> RunArgs {
+    let cli = Cli::try_parse_from(argv).expect("run command line should parse");
+    match cli.command {
+        Commands::Run(args) => args,
+        other => panic!("expected a Run command, got {other:?}"),
+    }
+}
+
+#[test]
+fn run_with_repo_id_and_prompt_is_one_shot() {
+    // `mlxcel run <repo-id> -p "..."` → model + prompt populated, so the
+    // shared `run_generate` dispatch takes the one-shot branch.
+    let args = parse_run(&[
+        "mlxcel",
+        "run",
+        "mlx-community/Qwen3-4B-4bit",
+        "-p",
+        "Hello, world!",
+    ]);
+    assert_eq!(
+        args.model.as_deref(),
+        Some(std::path::Path::new("mlx-community/Qwen3-4B-4bit"))
+    );
+    assert_eq!(args.generation.prompt.as_deref(), Some("Hello, world!"));
+
+    // The lowered GenerateArgs must carry the same model + prompt verbatim.
+    let gen_args = args.into_generate_args();
+    assert_eq!(
+        gen_args.model.model,
+        PathBuf::from("mlx-community/Qwen3-4B-4bit")
+    );
+    assert_eq!(gen_args.generation.prompt.as_deref(), Some("Hello, world!"));
+}
+
+#[test]
+fn run_with_repo_id_no_prompt_enters_repl() {
+    // `mlxcel run <repo-id>` (no -p) → prompt is None, which `run_generate`
+    // routes into the interactive chat REPL (issue #96).
+    let args = parse_run(&["mlxcel", "run", "mlx-community/Qwen3-4B-4bit"]);
+    assert!(
+        args.generation.prompt.is_none(),
+        "no -p must leave prompt None so dispatch enters the REPL"
+    );
+
+    let gen_args = args.into_generate_args();
+    assert_eq!(
+        gen_args.model.model,
+        PathBuf::from("mlx-community/Qwen3-4B-4bit")
+    );
+    assert!(gen_args.generation.prompt.is_none());
+}
+
+#[test]
+fn run_with_no_model_falls_back_to_default_model() {
+    // `mlxcel run` (no model arg) → default-model fallback (mlx-lm style).
+    let args = parse_run(&["mlxcel", "run"]);
+    assert!(
+        args.model.is_none(),
+        "model is optional; omitting it must parse to None"
+    );
+
+    let gen_args = args.into_generate_args();
+    assert_eq!(
+        gen_args.model.model,
+        PathBuf::from(DEFAULT_MODEL),
+        "absent model must lower to the documented default repo-id"
+    );
+    // No prompt either → the default model is run interactively.
+    assert!(gen_args.generation.prompt.is_none());
+}
+
+#[test]
+fn run_no_model_with_prompt_uses_default_model_one_shot() {
+    // `mlxcel run -p "..."` → default model, one-shot.
+    let args = parse_run(&["mlxcel", "run", "-p", "Hi"]);
+    assert!(args.model.is_none());
+    assert_eq!(args.generation.prompt.as_deref(), Some("Hi"));
+
+    let gen_args = args.into_generate_args();
+    assert_eq!(gen_args.model.model, PathBuf::from(DEFAULT_MODEL));
+    assert_eq!(gen_args.generation.prompt.as_deref(), Some("Hi"));
+}
+
+#[test]
+fn default_model_matches_mlx_lm() {
+    // Locks the documented default to the mlx-lm `DEFAULT_MODEL` value. If a
+    // future change picks a different default, this test forces the README /
+    // help text to be updated deliberately.
+    assert_eq!(DEFAULT_MODEL, "mlx-community/Llama-3.2-3B-Instruct-4bit");
+}
+
+#[test]
+fn run_shares_generate_sampling_and_generation_flags() {
+    // The sampling/generation flags must be the *same* clap groups `generate`
+    // uses, so a value provided to `run` round-trips into the lowered
+    // GenerateArgs unchanged.
+    let args = parse_run(&[
+        "mlxcel",
+        "run",
+        "mlx-community/Qwen3-4B-4bit",
+        "-p",
+        "x",
+        "-n",
+        "42",
+        "--temp",
+        "0.7",
+        "--top-p",
+        "0.95",
+        "--no-chat-template",
+    ]);
+    let gen_args = args.into_generate_args();
+    assert_eq!(gen_args.generation.max_tokens, 42);
+    assert!(gen_args.generation.no_chat_template);
+    assert_eq!(gen_args.sampling.temp, 0.7);
+    assert_eq!(gen_args.sampling.top_p, 0.95);
+}
+
+#[test]
+fn run_accepts_adapter_flag() {
+    let args = parse_run(&[
+        "mlxcel",
+        "run",
+        "mlx-community/Qwen3-4B-4bit",
+        "--adapter",
+        "adapters/lora",
+    ]);
+    let gen_args = args.into_generate_args();
+    assert_eq!(gen_args.model.adapter, Some(PathBuf::from("adapters/lora")));
+}
+
+#[test]
+fn run_lowers_advanced_groups_to_inert_defaults() {
+    // `run` does not expose tensor/pipeline parallelism or speculative
+    // decoding; the lowered GenerateArgs must leave them at the same inert
+    // single-device defaults `generate` uses when those flags are absent, so
+    // the dispatched one-shot path behaves identically to a plain `generate`.
+    let gen_args = parse_run(&["mlxcel", "run", "mlx-community/Qwen3-4B-4bit", "-p", "x"])
+        .into_generate_args();
+    assert_eq!(gen_args.tensor_parallel.tp_size, 1);
+    assert_eq!(gen_args.pipeline_parallel.pp_size, 1);
+    assert_eq!(gen_args.pipeline_parallel.pp_micro_batch_size, 1);
+    assert!(gen_args.model.draft_model.is_none());
+    assert_eq!(gen_args.model.num_draft_tokens, 3);
+    assert!(gen_args.speculative.draft_kind.is_none());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,23 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
+    /// Run a model: interactive chat, or one-shot generation with `-p`.
+    ///
+    /// Mirrors `ollama run` / mlx-lm ergonomics. Pass a HuggingFace
+    /// `owner/name` repo-id or a local model directory (auto-downloaded and
+    /// resolved exactly like `mlxcel generate -m`):
+    ///
+    ///     mlxcel run mlx-community/Qwen3-4B-4bit            # interactive chat
+    ///     mlxcel run mlx-community/Qwen3-4B-4bit -p "Hi"    # one-shot, then exit
+    ///     mlxcel run                                        # default model, interactive
+    ///
+    /// With no `-p/--prompt`, `run` drops into the interactive multi-turn chat
+    /// REPL. With `-p`, it produces a single completion and exits — identical
+    /// to the equivalent `mlxcel generate` invocation. With no model argument,
+    /// it falls back to the default model
+    /// `mlx-community/Llama-3.2-3B-Instruct-4bit` (mlx-lm parity).
+    Run(commands::RunArgs),
+
     /// Generate text from a prompt
     #[command(visible_alias = "gen")]
     Generate(GenerateArgs),
@@ -487,6 +504,35 @@ pub(crate) struct PipelineParallelOptions {
     /// Micro-batch size for pipeline parallelism.
     #[arg(long = "pp-micro-batch-size", default_value_t = 1, value_name = "N")]
     pub(crate) pp_micro_batch_size: usize,
+}
+
+// `Default` impls for the parallelism option groups so the `mlxcel run`
+// dispatcher (`commands::run`) can build a `GenerateArgs` while leaving these
+// advanced groups at their inert single-device defaults — `run` deliberately
+// does not expose tensor/pipeline parallelism. These MUST stay in lock-step
+// with the `#[arg(default_value*)]` attributes above; the
+// `run_defaults_match_clap_defaults` test in `main_tests.rs` fails the build if
+// they ever drift.
+
+impl Default for TensorParallelOptions {
+    fn default() -> Self {
+        Self {
+            tp_size: 1,
+            tp_moe_mode: "expert_parallel".to_string(),
+            tp_embedding_mode: "replicated".to_string(),
+            tp_lm_head_mode: "replicated".to_string(),
+        }
+    }
+}
+
+impl Default for PipelineParallelOptions {
+    fn default() -> Self {
+        Self {
+            pp_size: 1,
+            pp_layers: None,
+            pp_micro_batch_size: 1,
+        }
+    }
 }
 
 /// Server options
@@ -1284,6 +1330,7 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
+        Commands::Run(args) => commands::run_run(args),
         Commands::Generate(args) => commands::run_generate(args),
         Commands::Serve(args) => commands::run_serve(args),
         Commands::List(args) => {

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -14,7 +14,45 @@
 
 use clap::Parser;
 
-use super::{Cli, Commands, FAMILY_ORDER, write_supported_models};
+use super::{
+    Cli, Commands, FAMILY_ORDER, PipelineParallelOptions, TensorParallelOptions,
+    write_supported_models,
+};
+
+/// The `Default` impls for the parallelism option groups (used by the `mlxcel
+/// run` lowering in `commands::run`) MUST match the values clap fills when the
+/// corresponding flags are absent on `mlxcel generate`. If a `#[arg(default_*)]`
+/// attribute ever changes without updating the matching `Default` impl, the
+/// `run`-dispatched one-shot path would silently diverge from a plain
+/// `generate`. This test pins the two together.
+#[test]
+fn run_defaults_match_clap_defaults() {
+    let cli = Cli::try_parse_from(["mlxcel", "generate", "-m", "models/foo", "-p", "hi"])
+        .expect("minimal generate must parse");
+    let Commands::Generate(args) = cli.command else {
+        panic!("expected generate command");
+    };
+
+    let tp_default = TensorParallelOptions::default();
+    assert_eq!(args.tensor_parallel.tp_size, tp_default.tp_size);
+    assert_eq!(args.tensor_parallel.tp_moe_mode, tp_default.tp_moe_mode);
+    assert_eq!(
+        args.tensor_parallel.tp_embedding_mode,
+        tp_default.tp_embedding_mode
+    );
+    assert_eq!(
+        args.tensor_parallel.tp_lm_head_mode,
+        tp_default.tp_lm_head_mode
+    );
+
+    let pp_default = PipelineParallelOptions::default();
+    assert_eq!(args.pipeline_parallel.pp_size, pp_default.pp_size);
+    assert_eq!(args.pipeline_parallel.pp_layers, pp_default.pp_layers);
+    assert_eq!(
+        args.pipeline_parallel.pp_micro_batch_size,
+        pp_default.pp_micro_batch_size
+    );
+}
 
 /// Issue #26: the rendered `mlxcel list` output must mention every model
 /// that is registered in `ALL_MODEL_TYPES`. This is the safety net that

--- a/tests/cli_help_consistency.rs
+++ b/tests/cli_help_consistency.rs
@@ -214,6 +214,49 @@ fn mlxcel_server_help_lists_all_turbo_flags_and_modes() {
     assert_invariants("mlxcel-server", &help);
 }
 
+/// Issue #95: `mlxcel run` flattens the same `GenerationOptions` group as
+/// `mlxcel generate` (which carries the shared `TurboKvCacheArgs`), so its
+/// `--help` MUST expose the identical TurboQuant KV-cache flag block. This
+/// locks the new `run` verb into the same cross-binary invariant the other
+/// surfaces already satisfy.
+#[test]
+fn mlxcel_run_help_lists_all_turbo_flags_and_modes() {
+    let help = help_output("mlxcel", &["run", "--help"]);
+    assert_invariants("mlxcel run", &help);
+}
+
+/// Issue #95: `mlxcel run` shares `generate`'s sampling/generation flag groups
+/// and documents the mlx-lm-style default-model fallback. Assert the shared
+/// flags and the documented default repo-id are present so the `run` surface
+/// cannot silently drop them or change the default without updating this test.
+#[test]
+fn mlxcel_run_help_lists_shared_flags_and_default_model() {
+    let help = help_output("mlxcel", &["run", "--help"]);
+
+    // Shared generation/sampling flags (the same clap groups `generate` uses).
+    for sig in [
+        "--prompt <TEXT>",
+        "--max-tokens <N>",
+        "--temp <FLOAT>",
+        "--top-p <FLOAT>",
+        "--top-k <K>",
+        "--no-chat-template",
+        "--adapter <PATH>",
+    ] {
+        assert!(
+            help.contains(sig),
+            "mlxcel run help is missing shared flag {sig:?}.\nHelp was:\n{help}"
+        );
+    }
+
+    // The documented default model (mlx-lm parity). If the default repo-id
+    // changes, this test forces the help text + README to be updated too.
+    assert!(
+        help.contains("mlx-community/Llama-3.2-3B-Instruct-4bit"),
+        "mlxcel run help must document the default model repo-id.\nHelp was:\n{help}"
+    );
+}
+
 /// Cross-binary equivalence: the four shared flags should appear with the
 /// same names and same value-name in every binary's help block. We do NOT
 /// require byte-identical blocks because clap interleaves binary-specific
@@ -225,6 +268,9 @@ fn turbo_flag_signatures_match_across_binaries() {
     let generate_help = help_output("mlxcel", &["generate", "--help"]);
     let serve_help = help_output("mlxcel", &["serve", "--help"]);
     let server_help = help_output("mlxcel-server", &["--help"]);
+    // Issue #95: `run` flattens the same `GenerationOptions` (TurboKvCacheArgs)
+    // group, so it must carry the identical flag signatures.
+    let run_help = help_output("mlxcel", &["run", "--help"]);
 
     let signatures = [
         "--cache-type-k <TYPE>",
@@ -244,6 +290,10 @@ fn turbo_flag_signatures_match_across_binaries() {
         assert!(
             server_help.contains(sig),
             "mlxcel-server is missing flag signature {sig:?}"
+        );
+        assert!(
+            run_help.contains(sig),
+            "mlxcel run is missing flag signature {sig:?}"
         );
     }
 }


### PR DESCRIPTION
Closes #95

Part of epic #92 (unified download + run). This is the capstone verb — `mlxcel run` — that brings `ollama run` / mlx-lm ergonomics to the CLI by reusing the building blocks shipped by the other sub-issues (no forking).

## What it does

- `mlxcel run <repo-id-or-path>` (no `-p`) → interactive multi-turn chat REPL.
- `mlxcel run <repo-id-or-path> -p "..."` → one-shot generation, then exit (output identical to the equivalent `mlxcel generate`).
- `mlxcel run` (no model) → default-model fallback to `mlx-community/Llama-3.2-3B-Instruct-4bit` (the same `DEFAULT_MODEL` `mlx_lm.generate` / `mlx_lm.chat` use), auto-downloaded on first use.
- Model is a positional argument (`mlxcel run <repo-id>`) for `ollama run` parity; repo-ids auto-download via the shared resolver.

## Reuse, not duplication

`run` is a thin dispatcher. It lowers `RunArgs` onto a full `GenerateArgs` and calls the unchanged `commands::run_generate`, which already branches:

- no `-p` → `run_chat` (the interactive REPL entry point from #96),
- `-p` → `run_generate_once` (the historical one-shot generate flow),
- both through `downloader::resolve_model_source` (the repo-id-aware `-m` resolver from #94).

Routing through `run_generate` is what guarantees `mlxcel run <repo-id> -p "..."` executes the same code as `mlxcel generate -m <repo-id> -p "..."`. `run` flattens the same `GenerationOptions` / `SamplingOptions` clap groups as `generate`, so sampling/generation flags (including the shared TurboQuant KV-cache group) stay in lock-step and nothing is duplicated.

The advanced flag groups `run` intentionally does not expose (tensor/pipeline parallel, speculative, lang-bias, surgery) are lowered to their inert clap defaults. New `Default` impls for the two parallelism option structs are pinned to clap's own defaults by a drift-guard unit test (`run_defaults_match_clap_defaults`), so the dispatched one-shot path cannot silently diverge from a plain `generate`.

## Acceptance criteria (#95)

- [x] `mlxcel run <repo-id> -p "..."` produces output identical to the equivalent `generate` invocation (same code path).
- [x] `mlxcel run <repo-id>` with no prompt enters the REPL (#96).
- [x] `mlxcel run` with no args loads the documented default model.
- [x] `--help` documents the verb; CLI-help consistency test updated.

## Tests

- `src/commands/run_tests.rs`: parsing + lowering for one-shot, no-prompt REPL, default-model fallback, shared-flag round-trip, adapter, and inert advanced-group defaults.
- `src/main_tests.rs`: `run_defaults_match_clap_defaults` drift guard.
- `tests/cli_help_consistency.rs`: `mlxcel run --help` carries the shared Turbo flag block and shared sampling/generation flags, and documents the default repo-id; `run` added to the cross-binary Turbo signature check.

## Verification

- `cargo check --lib --bins --tests --features metal,accelerate` — clean.
- `cargo clippy --bin mlxcel --tests --features metal,accelerate -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo test --bin mlxcel` (run + main_tests modules) — 78 passed.
- `cargo test --test cli_help_consistency` — 10 passed.
- Manual: `mlxcel --help` lists `run`; `mlxcel run` (no args) resolves the default model and triggers auto-download via the shared resolver; two positional args correctly error.