### PR TITLE
fix(multimodal): inject video resource caps instead of reading env in the decode path

### DIFF
--- a/src/multimodal/video.rs
+++ b/src/multimodal/video.rs
@@ -123,6 +123,76 @@ const DEFAULT_MAX_DURATION_SEC: f64 = 600.0;
 /// Default = 256 MiB.
 const DEFAULT_MAX_PNG_FRAME_BYTES: usize = 256 * 1024 * 1024;
 
+/// Resource caps for video decoding (resolution, duration, per-PNG-frame size).
+///
+/// Resolved once from the environment at the public entry point via
+/// [`VideoLimits::from_env`] and threaded through the probe/extract path, so the
+/// decode hot path never reads process-global `std::env`. This lets tests inject
+/// explicit caps instead of calling `std::env::set_var`, which mutates the
+/// process-global environment and races across the threaded test runner (and is
+/// `unsafe` for exactly that reason) — see issue #103.
+#[derive(Debug, Clone, Copy)]
+pub struct VideoLimits {
+    /// Max source pixel count (width × height).
+    pub max_pixels: u64,
+    /// Max source duration in seconds.
+    pub max_duration_sec: f64,
+    /// Max bytes accumulated for a single PNG frame before the stream is
+    /// rejected as malformed.
+    pub max_png_frame_bytes: usize,
+}
+
+impl Default for VideoLimits {
+    /// The compile-time defaults (`DEFAULT_MAX_*`), used when the corresponding
+    /// env var is unset or unparseable.
+    fn default() -> Self {
+        Self {
+            max_pixels: DEFAULT_MAX_PIXELS,
+            max_duration_sec: DEFAULT_MAX_DURATION_SEC,
+            max_png_frame_bytes: DEFAULT_MAX_PNG_FRAME_BYTES,
+        }
+    }
+}
+
+impl VideoLimits {
+    /// Resolve caps from `MLXCEL_VIDEO_MAX_{PIXELS,DURATION_SEC,PNG_FRAME_BYTES}`,
+    /// each falling back to its compile-time default on a missing or unparseable
+    /// value. This is the single place these env vars are read.
+    pub fn from_env() -> Self {
+        Self::from_raw(
+            std::env::var("MLXCEL_VIDEO_MAX_PIXELS").ok().as_deref(),
+            std::env::var("MLXCEL_VIDEO_MAX_DURATION_SEC")
+                .ok()
+                .as_deref(),
+            std::env::var("MLXCEL_VIDEO_MAX_PNG_FRAME_BYTES")
+                .ok()
+                .as_deref(),
+        )
+    }
+
+    /// Pure parser shared by [`from_env`](Self::from_env): maps already-fetched
+    /// env strings to caps, falling back to the defaults. Kept env-free so it is
+    /// unit-testable without mutating the process environment.
+    fn from_raw(
+        pixels: Option<&str>,
+        duration_sec: Option<&str>,
+        png_frame_bytes: Option<&str>,
+    ) -> Self {
+        let defaults = Self::default();
+        Self {
+            max_pixels: pixels
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(defaults.max_pixels),
+            max_duration_sec: duration_sec
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(defaults.max_duration_sec),
+            max_png_frame_bytes: png_frame_bytes
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(defaults.max_png_frame_bytes),
+        }
+    }
+}
+
 /// PNG file format constants used by the single-pass stream splitter.
 const PNG_SIGNATURE: &[u8; 8] = b"\x89PNG\r\n\x1a\n";
 const PNG_IEND_CHUNK_LEN: usize = 12; // 4-byte length + 4-byte "IEND" + 4-byte CRC
@@ -623,7 +693,7 @@ struct VideoMeta {
 /// pass an opened fd (issue #601) instead of the canonical path. The fd
 /// path closes the TOCTOU window between the resolver's `canonicalize`
 /// and ffmpeg's `open`.
-fn probe_video(source: &VideoSource) -> Result<VideoMeta, VideoError> {
+fn probe_video(source: &VideoSource, limits: &VideoLimits) -> Result<VideoMeta, VideoError> {
     let canonical_path = source.canonical_path();
     // For path-variant sources we still verify the path exists; for fd-variant
     // sources the fd was opened by the resolver and the file is guaranteed
@@ -719,7 +789,15 @@ fn probe_video(source: &VideoSource) -> Result<VideoMeta, VideoError> {
         .filter(|f| f.is_finite() && *f > 0.0)
         .unwrap_or(1.0);
 
-    apply_probe_caps(canonical_path, nb_frames, fps, width, height, duration)
+    apply_probe_caps(
+        canonical_path,
+        nb_frames,
+        fps,
+        width,
+        height,
+        duration,
+        limits,
+    )
 }
 
 /// Enforce resolution and duration caps on raw ffprobe field values, returning
@@ -743,6 +821,7 @@ fn apply_probe_caps(
     width: Option<u32>,
     height: Option<u32>,
     duration: Option<f64>,
+    limits: &VideoLimits,
 ) -> Result<VideoMeta, VideoError> {
     // If ffprobe did not report duration, default to +∞ so the duration cap
     // trips immediately rather than silently bypassing the check.
@@ -771,7 +850,7 @@ fn apply_probe_caps(
     let h = height.unwrap_or(u32::MAX);
 
     // ── Resolution cap check ─────────────────────────────────────────────
-    let max_pixels = read_env_u64("MLXCEL_VIDEO_MAX_PIXELS", DEFAULT_MAX_PIXELS);
+    let max_pixels = limits.max_pixels;
     // Use saturating_mul so that u32::MAX * u32::MAX saturates to u64::MAX
     // instead of overflowing back to 0 and silently bypassing the cap.
     let pixels = (w as u64).saturating_mul(h as u64);
@@ -785,7 +864,7 @@ fn apply_probe_caps(
     }
 
     // ── Duration cap check ───────────────────────────────────────────────
-    let max_duration = read_env_f64("MLXCEL_VIDEO_MAX_DURATION_SEC", DEFAULT_MAX_DURATION_SEC);
+    let max_duration = limits.max_duration_sec;
     if duration_sec > max_duration {
         return Err(VideoError::DurationTooLong {
             seconds: duration_sec,
@@ -800,24 +879,6 @@ fn apply_probe_caps(
         height: h,
         duration_sec,
     })
-}
-
-/// Read an environment variable as a `u64`, returning `default` on missing
-/// or parse failure.
-fn read_env_u64(name: &str, default: u64) -> u64 {
-    std::env::var(name)
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(default)
-}
-
-/// Read an environment variable as an `f64`, returning `default` on missing
-/// or parse failure.
-fn read_env_f64(name: &str, default: f64) -> f64 {
-    std::env::var(name)
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(default)
 }
 
 /// Parse `"30000/1001"` style rationals returned by ffprobe.
@@ -893,6 +954,18 @@ pub fn load_video(
     load_video_source(&source, target_fps, target_nframes)
 }
 
+/// Like [`load_video`] but with explicit resource [`VideoLimits`] instead of
+/// resolving them from the environment.
+pub fn load_video_with_limits(
+    path: &Path,
+    target_fps: Option<f64>,
+    target_nframes: Option<usize>,
+    limits: &VideoLimits,
+) -> Result<Vec<DynamicImage>, VideoError> {
+    let source = VideoSource::from_path(path.to_path_buf());
+    load_video_source_with_limits(&source, target_fps, target_nframes, limits)
+}
+
 /// Decode a [`VideoSource`] into uniformly-sampled frames.
 ///
 /// Equivalent to [`load_video`] but accepts a [`VideoSource`] so the
@@ -904,11 +977,24 @@ pub fn load_video_source(
     target_fps: Option<f64>,
     target_nframes: Option<usize>,
 ) -> Result<Vec<DynamicImage>, VideoError> {
+    load_video_source_with_limits(source, target_fps, target_nframes, &VideoLimits::from_env())
+}
+
+/// Like [`load_video_source`] but with explicit resource [`VideoLimits`]
+/// instead of resolving them from the environment. Lets callers (and tests)
+/// pin the caps deterministically; [`load_video_source`] is the env-resolving
+/// convenience wrapper over this.
+pub fn load_video_source_with_limits(
+    source: &VideoSource,
+    target_fps: Option<f64>,
+    target_nframes: Option<usize>,
+    limits: &VideoLimits,
+) -> Result<Vec<DynamicImage>, VideoError> {
     if !ffmpeg_available() {
         return Err(VideoError::FfmpegMissing);
     }
     let canonical = source.canonical_path().to_path_buf();
-    let meta = probe_video(source)?;
+    let meta = probe_video(source, limits)?;
     let nframes =
         smart_nframes(meta.total_frames, meta.fps, target_fps, target_nframes).map_err(|err| {
             match err {
@@ -921,7 +1007,7 @@ pub fn load_video_source(
         })?;
 
     let indices = uniform_indices(meta.total_frames, nframes);
-    let frames = extract_frames_single_pass(source, &indices, meta.fps)?;
+    let frames = extract_frames_single_pass(source, &indices, meta.fps, limits)?;
 
     if frames.is_empty() {
         return Err(VideoError::EmptyVideo(canonical));
@@ -996,6 +1082,7 @@ fn extract_frames_single_pass(
     source: &VideoSource,
     indices: &[usize],
     _video_fps: f64,
+    limits: &VideoLimits,
 ) -> Result<Vec<DynamicImage>, VideoError> {
     if indices.is_empty() {
         return Ok(Vec::new());
@@ -1064,7 +1151,12 @@ fn extract_frames_single_pass(
         .take()
         .expect("stdout was piped but is None — this is a bug");
 
-    let frames = split_png_stream(stdout, source.canonical_path(), indices.len())?;
+    let frames = split_png_stream(
+        stdout,
+        source.canonical_path(),
+        indices.len(),
+        limits.max_png_frame_bytes,
+    )?;
 
     // Collect stderr and wait for the process exit status.
     let output = child.wait_with_output().map_err(|err| VideoError::Io {
@@ -1106,6 +1198,7 @@ fn split_png_stream<R: Read>(
     mut reader: R,
     path: &Path,
     expected_frames: usize,
+    max_png_frame_bytes: usize,
 ) -> Result<Vec<DynamicImage>, VideoError> {
     // IEND chunk bytes: length (4 bytes = 0) + type "IEND" (4) + CRC (4).
     // The CRC of IEND with no data is always 0xAE426082.
@@ -1113,12 +1206,9 @@ fn split_png_stream<R: Read>(
         0x00, 0x00, 0x00, 0x00, b'I', b'E', b'N', b'D', 0xAE, 0x42, 0x60, 0x82,
     ];
 
-    // Per-frame accumulation cap. A stream that never emits IEND would grow
-    // buf without bound; reject it once the cap is exceeded.
-    let max_png_frame_bytes = read_env_u64(
-        "MLXCEL_VIDEO_MAX_PNG_FRAME_BYTES",
-        DEFAULT_MAX_PNG_FRAME_BYTES as u64,
-    ) as usize;
+    // Per-frame accumulation cap (resolved by the caller from `VideoLimits`).
+    // A stream that never emits IEND would grow buf without bound; reject it
+    // once the cap is exceeded.
 
     let mut frames = Vec::with_capacity(expected_frames);
     let mut buf: Vec<u8> = Vec::new();

--- a/src/multimodal/video_tests.rs
+++ b/src/multimodal/video_tests.rs
@@ -266,22 +266,13 @@ fn load_video_rejects_oversized_resolution() {
         }
     };
 
-    // Temporarily set a very small pixel cap (e.g. 50x50 = 2500 pixels).
-    // We can't set env vars in a truly isolated way in unit tests without
-    // side effects, so we use a helper that reads the env var at call time.
-    // Run the actual check: create a wrapper that overrides the environment.
-    let result = {
-        // SAFETY: standard test, no multi-threading inside this block that
-        // reads MLXCEL_VIDEO_MAX_PIXELS.
-        unsafe {
-            std::env::set_var("MLXCEL_VIDEO_MAX_PIXELS", "2500");
-        }
-        let r = load_video(&video_path, Some(2.0), None);
-        unsafe {
-            std::env::remove_var("MLXCEL_VIDEO_MAX_PIXELS");
-        }
-        r
+    // Inject a tiny pixel cap (50×50 = 2500) via VideoLimits so the test never
+    // touches the process-global environment (issue #103).
+    let limits = VideoLimits {
+        max_pixels: 2500,
+        ..VideoLimits::default()
     };
+    let result = load_video_with_limits(&video_path, Some(2.0), None, &limits);
 
     // Clean up the temp video.
     let _ = std::fs::remove_file(&video_path);
@@ -296,7 +287,7 @@ fn load_video_rejects_oversized_resolution() {
             assert_eq!(width, 100, "width should match");
             assert_eq!(height, 100, "height should match");
             assert_eq!(pixels, 10_000, "pixels should be width*height");
-            assert_eq!(max_pixels, 2500, "max_pixels should match the env var");
+            assert_eq!(max_pixels, 2500, "max_pixels should match the injected cap");
         }
         Err(other) => panic!("expected ResolutionTooLarge, got: {other:?}"),
         Ok(_) => panic!("expected ResolutionTooLarge error, but load_video succeeded"),
@@ -319,16 +310,13 @@ fn load_video_rejects_overlong_duration() {
         }
     };
 
-    let result = {
-        unsafe {
-            std::env::set_var("MLXCEL_VIDEO_MAX_DURATION_SEC", "2");
-        }
-        let r = load_video(&video_path, Some(2.0), None);
-        unsafe {
-            std::env::remove_var("MLXCEL_VIDEO_MAX_DURATION_SEC");
-        }
-        r
+    // Inject a 2-second cap via VideoLimits so the test never touches the
+    // process-global environment (issue #103).
+    let limits = VideoLimits {
+        max_duration_sec: 2.0,
+        ..VideoLimits::default()
     };
+    let result = load_video_with_limits(&video_path, Some(2.0), None, &limits);
 
     let _ = std::fs::remove_file(&video_path);
 
@@ -341,7 +329,10 @@ fn load_video_rejects_overlong_duration() {
                 seconds > 2.0,
                 "reported duration {seconds:.2}s should exceed the cap"
             );
-            assert_eq!(max_seconds, 2.0, "max_seconds should match the env var");
+            assert_eq!(
+                max_seconds, 2.0,
+                "max_seconds should match the injected cap"
+            );
         }
         Err(other) => panic!("expected DurationTooLong, got: {other:?}"),
         Ok(_) => panic!("expected DurationTooLong error, but load_video succeeded"),
@@ -405,6 +396,7 @@ fn probe_video_missing_width_trips_resolution_cap() {
         None, // width missing
         Some(100),
         Some(10.0),
+        &VideoLimits::default(),
     );
     match result {
         Err(VideoError::ResolutionTooLarge {
@@ -437,6 +429,7 @@ fn probe_video_missing_height_trips_resolution_cap() {
         Some(100),
         None, // height missing
         Some(10.0),
+        &VideoLimits::default(),
     );
     match result {
         Err(VideoError::ResolutionTooLarge { width, height, .. }) => {
@@ -464,6 +457,7 @@ fn probe_video_missing_duration_trips_duration_cap() {
         Some(100),
         Some(100),
         None, // duration missing
+        &VideoLimits::default(),
     );
     match result {
         Err(VideoError::DurationTooLong {
@@ -494,6 +488,7 @@ fn probe_video_both_dimensions_missing_saturates_not_overflows() {
         None, // width missing
         None, // height missing
         Some(10.0),
+        &VideoLimits::default(),
     );
     match result {
         Err(VideoError::ResolutionTooLarge {
@@ -532,21 +527,12 @@ fn probe_video_both_dimensions_missing_saturates_not_overflows() {
 fn split_png_stream_rejects_oversized_frame() {
     use std::path::Path;
 
-    // Set a tiny cap so we don't need to allocate 256 MiB in the test.
-    // SAFETY: no other threads read MLXCEL_VIDEO_MAX_PNG_FRAME_BYTES here.
-    unsafe {
-        std::env::set_var("MLXCEL_VIDEO_MAX_PNG_FRAME_BYTES", "1024");
-    }
-
-    // Feed 2 KiB of random-ish bytes with no IEND marker.
-    // The cap is 1 KiB, so the function must reject before reading all 2 KiB.
+    // Feed 2 KiB of random-ish bytes with no IEND marker, with a tiny 1 KiB cap
+    // passed directly (no env mutation, issue #103) so the function must reject
+    // before reading all 2 KiB rather than allocating 256 MiB.
     let bogus: Vec<u8> = (0u8..=255).cycle().take(2048).collect();
     let path = Path::new("/synthetic/no-iend.png");
-    let result = split_png_stream(bogus.as_slice(), path, 1);
-
-    unsafe {
-        std::env::remove_var("MLXCEL_VIDEO_MAX_PNG_FRAME_BYTES");
-    }
+    let result = split_png_stream(bogus.as_slice(), path, 1, 1024);
 
     match result {
         Err(VideoError::Extract { message, .. }) => {
@@ -558,6 +544,24 @@ fn split_png_stream_rejects_oversized_frame() {
         Err(other) => panic!("expected Extract error for oversized frame, got: {other:?}"),
         Ok(_) => panic!("expected rejection of stream without IEND, but got frames"),
     }
+}
+
+/// `VideoLimits::from_raw` parses overrides and falls back to the compile-time
+/// defaults — exercised purely (no process env touched, issue #103).
+#[test]
+fn video_limits_from_raw_parses_overrides_and_falls_back() {
+    let defaults = VideoLimits::default();
+
+    let parsed = VideoLimits::from_raw(Some("2500"), Some("2"), Some("1024"));
+    assert_eq!(parsed.max_pixels, 2500);
+    assert_eq!(parsed.max_duration_sec, 2.0);
+    assert_eq!(parsed.max_png_frame_bytes, 1024);
+
+    // Missing or unparseable values fall back to the defaults.
+    let fallback = VideoLimits::from_raw(None, Some("not-a-number"), None);
+    assert_eq!(fallback.max_pixels, defaults.max_pixels);
+    assert_eq!(fallback.max_duration_sec, defaults.max_duration_sec);
+    assert_eq!(fallback.max_png_frame_bytes, defaults.max_png_frame_bytes);
 }
 
 // ─── Issue #601: VideoSource fd path through ffmpeg ──────────────────────────
@@ -640,10 +644,14 @@ fn load_video_source_fd_variant_matches_path_variant_frame_count() {
         }
     };
 
-    // Path-based decode (baseline). Use a cap above the synthetic clip's
-    // 4-second duration so this parity test exercises fd-vs-path decoding
-    // rather than the unrelated max-duration guard.
-    let path_frames = load_video(&video_path, Some(5.0), None)
+    // Decode with explicit default limits so this parity test is independent of
+    // the ambient environment (issue #103). `Some(5.0)` is the target FPS, not a
+    // duration cap; the shared default limits keep fd and path on equal footing
+    // for the frame-count comparison.
+    let limits = VideoLimits::default();
+
+    // Path-based decode (baseline).
+    let path_frames = load_video_with_limits(&video_path, Some(5.0), None, &limits)
         .expect("path-based load_video must succeed for synthetic video");
 
     // Fd-based decode (the issue #601 path).
@@ -651,7 +659,7 @@ fn load_video_source_fd_variant_matches_path_variant_frame_count() {
     let owned_fd = std::os::fd::OwnedFd::from(std_file);
     let canonical = std::fs::canonicalize(&video_path).expect("canonicalise");
     let source = VideoSource::from_fd(owned_fd, canonical);
-    let fd_frames = load_video_source(&source, Some(5.0), None)
+    let fd_frames = load_video_source_with_limits(&source, Some(5.0), None, &limits)
         .expect("fd-based load_video_source must succeed for the same synthetic video");
 
     let _ = std::fs::remove_file(&video_path);


### PR DESCRIPTION
## Problem
`apply_probe_caps` and `split_png_stream` read the video resource caps (`MLXCEL_VIDEO_MAX_PIXELS`, `MLXCEL_VIDEO_MAX_DURATION_SEC`, `MLXCEL_VIDEO_MAX_PNG_FRAME_BYTES`) directly from `std::env` deep in the decode path. Three unit tests exercised those caps by mutating the process environment with `std::env::set_var`.

Because the environment is process-global and Rust runs unit tests as concurrent threads in one process, a `set_var` in one test leaked into others for its set→remove window. `load_video_source_fd_variant_matches_path_variant_frame_count` (decodes a 4 s clip, expects success) intermittently read a leaked `MLXCEL_VIDEO_MAX_DURATION_SEC=2` and failed with `DurationTooLong { seconds: 4.0, max_seconds: 2.0 }`; it passed in isolation. This is also unsound — concurrent `setenv`/`getenv` is a libc data race, which is why `std::env::set_var` is `unsafe`.

## Fix
Resolve the environment once at the boundary and thread the caps through the decode path:
- `pub struct VideoLimits { max_pixels, max_duration_sec, max_png_frame_bytes }` with `from_env()` (the single env-read site) and a pure private `from_raw` parser; `Default` returns the compile-time defaults.
- `apply_probe_caps`, `probe_video`, `extract_frames_single_pass` take `&VideoLimits`; `split_png_stream` takes the byte cap as a parameter.
- New `load_video_source_with_limits` / `load_video_with_limits`. The existing `load_video` / `load_video_source` / `load_videos` keep their signatures and call `VideoLimits::from_env()`, so production callers (`server/model_worker.rs`, `commands/generate_vlm.rs`) are unchanged.
- Cap tests inject `VideoLimits` (no `set_var`); the fd-vs-path parity test uses explicit default limits; added a pure `from_raw` parse/fallback test; removed the now-unused `read_env_u64` / `read_env_f64`.

## Validation
- No `std::env::set_var` / `remove_var` remains in `video_tests.rs`; the cap env vars are read in exactly one place (`VideoLimits::from_env`).
- `cargo fmt --all --check` clean; `cargo clippy --release --all-targets -- -D warnings` clean.
- `cargo test --release -p mlxcel --lib` run **twice**: **2943 passed, 0 failed, 87 ignored** each time, including `load_video_source_fd_variant_matches_path_variant_frame_count` (the ffmpeg-backed cap/fd tests decode real synthetic videos).

Closes #103