### PR TITLE
fix(distributed): bind ephemeral ports directly in pipeline runtime tests

### DIFF
--- a/src/distributed/pipeline/runtime.rs
+++ b/src/distributed/pipeline/runtime.rs
@@ -460,7 +460,6 @@ impl PipelineModelRuntime for RemotePipelineRuntime {
 
 #[cfg(test)]
 mod tests {
-    use std::net::TcpListener;
     use std::sync::{Arc, Mutex};
     use std::thread;
 
@@ -497,7 +496,7 @@ mod tests {
                 runtime.block_on(async move {
                     let transport = Arc::new(
                         TcpTransport::bind(TcpTransportConfig {
-                            bind_address: reserve_bind_address(),
+                            bind_address: "127.0.0.1:0".to_string(),
                             ..Default::default()
                         })
                         .await?,
@@ -653,13 +652,6 @@ mod tests {
         }
     }
 
-    fn reserve_bind_address() -> String {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
-        let addr = listener.local_addr().expect("local addr");
-        drop(listener);
-        addr.to_string()
-    }
-
     async fn send_stub_response(
         transport: &Arc<TcpTransport>,
         peer: &str,
@@ -715,7 +707,7 @@ mod tests {
         let runtime = RemotePipelineRuntime::new(RemotePipelineRuntimeConfig {
             stage_peers: vec![stage.addr().to_string()],
             transport_backend: TransportBackend::Tcp,
-            bind_address: reserve_bind_address(),
+            bind_address: "127.0.0.1:0".to_string(),
             stage_timeout: Duration::from_secs(1),
         })
         .expect("create runtime");
@@ -742,7 +734,7 @@ mod tests {
         let runtime = RemotePipelineRuntime::new(RemotePipelineRuntimeConfig {
             stage_peers: vec![stage.addr().to_string()],
             transport_backend: TransportBackend::Tcp,
-            bind_address: reserve_bind_address(),
+            bind_address: "127.0.0.1:0".to_string(),
             stage_timeout: Duration::from_millis(100),
         })
         .expect("create runtime");


### PR DESCRIPTION
## Problem
The `distributed::pipeline::runtime` tests (e.g. `remote_runtime_timeout_cleans_up_sequence_state`) failed intermittently — **~2/8 runs** of that module — with `stub stage startup channel dropped`.

Root cause is an ephemeral-port TOCTOU in `reserve_bind_address()`: it binds `127.0.0.1:0`, reads the port, then **drops the listener** and returns the address; the stub stage / runtime **re-bind** that address after spinning up a Tokio runtime. In the release→re-bind gap a concurrent test grabs the same port, so `TcpTransport::bind` fails with `AddrInUse`. In the stub stage that error returns before `startup_tx.send(...)`, dropping the sender, so `StubStageHandle::spawn` surfaces the misleading "startup channel dropped" (hiding the real `AddrInUse`).

## Fix
Bind `127.0.0.1:0` directly through `TcpTransport`, which holds the listener (no gap) and resolves the real port via `local_addr()` — already published by the stub via `startup_tx` and used by the runtime as `reply_addr`. This matches the existing `remote_runtime_rejects_*` tests that already use `bind_address: "127.0.0.1:0"`.

- Replace the three `bind_address: reserve_bind_address()` sites (stub transport + the two `RemotePipelineRuntimeConfig`s) with `"127.0.0.1:0".to_string()`.
- Remove the now-unused `reserve_bind_address` helper and its `use std::net::TcpListener;` import.

Net: +3 / −11 lines.

## Validation
- `cargo test -p mlxcel --lib distributed::pipeline::runtime` run **16×**: **0 failures** (baseline was ~2/8).
- Full lib suite green over repeated runs (2943 passed, 0 failed).
- `cargo fmt --all --check` clean; `cargo clippy --release --all-targets -- -D warnings` clean (no unused-import / dead-code).

Closes #105