### PR TITLE
fix(downloader): serialize the secure-endpoint refusal test through ENV_LOCK

### DIFF
--- a/src/downloader/tests.rs
+++ b/src/downloader/tests.rs
@@ -617,6 +617,11 @@ fn validate_token_rejects_control_chars() {
 /// operator explicitly opts out.
 #[test]
 fn require_secure_endpoint_refuses_plaintext_with_token() {
+    // For the http+token case, `require_secure_endpoint_for_token` reads
+    // MLXCEL_ALLOW_INSECURE_ENDPOINT (via `is_insecure_endpoint_opt_out`).
+    // Serialize through the crate-wide ENV_LOCK so this read cannot observe the
+    // value mid-window from the opt-out tests, which set that var under the lock.
+    let _env_guard = env_lock();
     let err = require_secure_endpoint_for_token("http://mirror.internal/", Some("hf_xxx"))
         .expect_err("plaintext endpoint with token must error");
     let msg = err.to_string();


### PR DESCRIPTION
## Problem
`downloader::tests::require_secure_endpoint_refuses_plaintext_with_token` fails intermittently under the full multi-threaded `cargo test --lib` (~2/6 runs). It asserts `require_secure_endpoint_for_token("http://…", Some(token))` returns `Err`, but occasionally gets `Ok`.

For the `http://` + token case, that function reads `MLXCEL_ALLOW_INSECURE_ENDPOINT` (via `is_insecure_endpoint_opt_out`). The test does **not** acquire the crate-wide `ENV_LOCK`, while the sibling `require_secure_endpoint_honors_opt_out` / `_treats_empty_opt_out_as_unset` tests set that var under `env_lock()`. Without the lock the refusal test can observe `MLXCEL_ALLOW_INSECURE_ENDPOINT="1"` mid-window → opt-out path → `Ok` → `expect_err` panics. (Concurrent `setenv`/`getenv` is also a libc data race — the reason `std::env::set_var` is `unsafe`.)

## Fix
Acquire `env_lock()` at the start of `require_secure_endpoint_refuses_plaintext_with_token`, matching the contract already followed by the opt-out tests and the progress-bar tests. The sibling `allows_https_with_token` / `allows_plaintext_anonymous` tests short-circuit before any env read (https scheme / no token), so they don't touch the environment and need no guard. (+5 lines.)

## Validation
- All five `require_secure_endpoint_*` tests pass; `cargo fmt --all --check` clean; `cargo clippy --release --all-targets -- -D warnings` clean.
- Full `cargo test --lib` green over 6 consecutive runs (2955 passed, 0 failed).

> This is a timing-dependent race: it surfaced ~2/6 on a higher-concurrency tree (the internal development repo) and is hard to reproduce in a few runs here, but the root cause is structural (an env read outside `ENV_LOCK`) and the fix conforms the test to the repo's documented env-serialization contract.

Closes #110