### PR TITLE
docs: recompute M5 Max decode aggregates and feature optimized models

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ in the prefill path.
 ### Decode: steady-state token generation
 
 Decode stays close to the Python MLX references on the same host. For M5 Max,
-text decode averaged **98%** of `mlx-lm` with a **99%** median, while VLM decode
-averaged **101%** of `mlx-vlm` with a **100%** median.
+text decode averaged **99%** of `mlx-lm` with a **99%** median, while VLM decode
+averaged **102%** of `mlx-vlm` with a **101%** median.
 
 | Mode | Baseline | Comparable pairs | Average vs baseline | Median vs baseline | >=90% parity | >= baseline | Range |
 |------|----------|-----------------:|--------------------:|-------------------:|-------------:|------------:|------:|
-| Text | `mlx-lm` | 66 | 98% | **99%** | 62 / 66 (94%) | 27 / 66 (41%) | 72%-127% |
-| VLM | `mlx-vlm` | 20 | 101% | **100%** | 17 / 20 (85%) | 10 / 20 (50%) | 74%-123% |
+| Text | `mlx-lm` | 66 | 99% | **99%** | 62 / 66 (94%) | 27 / 66 (41%) | 72%-127% |
+| VLM | `mlx-vlm` | 22 | 102% | **101%** | 18 / 22 (82%) | 11 / 22 (50%) | 74%-123% |
 
 Representative decode throughput is shown below in tokens per second. M5 Max
 reference columns are same-host `mlx-lm` or `mlx-vlm` runs; M1 Ultra values are
@@ -159,6 +159,9 @@ family, quantization, prompt shape, decode length, and hardware. See
 | Qwen2.5 7B 4bit | 110 tok/s | 126 tok/s | 124 tok/s | 102% |
 | Gemma 2B 4bit | 190 tok/s | 217 tok/s | 223 tok/s | 97% |
 | Gemma 3 4B 4bit | 114 tok/s | 182 tok/s | 182 tok/s | 100% |
+| Gemma 2 2B 4bit | 129 tok/s | 242 tok/s | 242 tok/s | 100% |
+| Phi-3.5-mini 4bit | 121 tok/s | 205 tok/s | 208 tok/s | 98% |
+| Jamba v0.1 4bit (hybrid SSM) | 112 tok/s | 216 tok/s | 219 tok/s | 98% |
 | Gemma 4 26B-A4B 4bit | 73 tok/s | 137 tok/s | 141 tok/s | 97% |
 | Qwen3 MoE 30B 4bit | 71 tok/s | 156 tok/s | 147 tok/s | 106% |
 | GLM-4 Flash 4bit | 47 tok/s | 104 tok/s | 104 tok/s | 100% |
@@ -178,6 +181,7 @@ family, quantization, prompt shape, decode length, and hardware. See
 | Qwen3.5 35B-A3B 4bit | 71 tok/s | 151 tok/s | 129 tok/s | 117% |
 | Gemma 4 E2B 4bit | 107 tok/s | 217 tok/s | 202 tok/s | 108% |
 | Gemma 3n E2B 4bit | 72 tok/s | 151 tok/s | 125 tok/s | 121% |
+| InternVL3 1B | - | 601 tok/s | 529 tok/s | 114% |
 | Gemma 4 26B-A4B 4bit | 63 tok/s | 134 tok/s | 137 tok/s | 98% |
 | Molmo2 4B | 59 tok/s | 64 tok/s | 67 tok/s | 96% |
 | Phi 3.5 Vision 4bit | 94 tok/s | 123 tok/s | 160 tok/s | 77% |

--- a/docs/benchmark_results/benchmark-report.md
+++ b/docs/benchmark_results/benchmark-report.md
@@ -20,9 +20,9 @@ includes image encoder and projector work.
 
 | Host | Mode | Baseline | Comparable pairs | Prefill median vs baseline | Decode median vs baseline | Decode result |
 |------|------|----------|-----------------:|---------------------------:|--------------------------:|---------------|
-| M5 Max | Text | mlx-lm | 66 | **2.70x** | **99%** | 58/66 at >=90% parity |
+| M5 Max | Text | mlx-lm | 66 | **2.70x** | **99%** | 62/66 at >=90% parity |
 | M1 Ultra | Text | mlx-lm | 73 | **1.76x** | **97%** | 62/73 at >=90% parity |
-| M5 Max | VLM | mlx-vlm | 20 | 0.94x | **100%** | 16/20 at >=90% parity |
+| M5 Max | VLM | mlx-vlm | 22 | 0.94x | **101%** | 18/22 at >=90% parity |
 | M1 Ultra | VLM | mlx-vlm | 17 | **1.33x** | **98%** | 11/17 at >=90% parity |
 
 Ratios above use successful runs only. Baseline rows use exact CSV model
@@ -48,9 +48,9 @@ complete in this sweep. With a generated-token threshold of 5 tokens:
 
 | Host | Mode | mlxcel successful, Python baseline unavailable or failed | Comparable successful pairs |
 |------|------|---------------------------------------------------------:|----------------------------:|
-| M5 Max | Text | 25 | 66 |
+| M5 Max | Text | 26 | 66 |
 | M1 Ultra | Text | 22 | 73 |
-| M5 Max | VLM | 12 | 20 |
+| M5 Max | VLM | 12 | 22 |
 | M1 Ultra | VLM | 20 | 17 |
 
 This is the useful public framing: mlxcel is a Rust inference engine with

--- a/docs/benchmark_results/model_tests_m5max.md
+++ b/docs/benchmark_results/model_tests_m5max.md
@@ -259,14 +259,14 @@ snapshot.
 - **Comparable text pairs**: 66 (models with >=5 generated tokens both sides)
 - **mlxcel >= mlx-lm**: 27 / 66 (41%)
 - **mlxcel >= 90% parity**: 62 / 66 (94%, the Phi-3.5, Gemma dense, and Jamba fixes raise four models past 90%)
-- **Average mlxcel/mlx-lm**: 98% (median 99%, range 72%-127%)
+- **Average mlxcel/mlx-lm**: 99% (median 99%, range 72%-127%)
 
 ### Aggregate (VLM, models with >=5 generated tokens both sides)
 
-- **Comparable VLM pairs**: 20
-- **mlxcel >= mlx-vlm**: 10 / 20 (50%, the Phi-3.5 vision fix raises it from 77% to 106%)
-- **mlxcel >= 90% parity**: 17 / 20 (85%)
-- **Average mlxcel/mlx-vlm**: 101% (median 100%, range 74%-123%)
+- **Comparable VLM pairs**: 22
+- **mlxcel >= mlx-vlm**: 11 / 22 (50%)
+- **mlxcel >= 90% parity**: 18 / 22 (82%)
+- **Average mlxcel/mlx-vlm**: 102% (median 101%, range 74%-123%)
 
 ### Text decode (tok/s)
 


### PR DESCRIPTION
docs: recompute M5 Max decode aggregates and feature optimized models

Recompute the M5 Max decode-parity aggregates from current mlxcel values against the fixed mlx-lm / mlx-vlm baselines (baselines unchanged; only mlxcel-derived ratios recomputed), and feature the recently optimized models in the README decode tables.

- Text decode: average 98% -> 99% (median 99%), 62/66 at >=90% parity; the benchmark report headline is corrected from the stale 58/66.
- VLM decode: average 101% -> 102%, median 100% -> 101%, 22 comparable pairs (was 20), 18/22 at >=90% parity; coverage counts reflect internvl3.
- README decode tables add Gemma 2 2B (100%), Phi-3.5-mini (98%), Jamba (98%), and InternVL3 1B (114% vs mlx-vlm).
