### PR TITLE
docs: reflect the 2026-05-28 M1 Ultra re-benchmark in public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,37 +154,37 @@ family, quantization, prompt shape, decode length, and hardware. See
 
 | Text model | M1 Ultra mlxcel | M5 Max mlxcel | M5 Max mlx-lm | mlxcel / mlx-lm |
 |------------|----------------:|--------------:|--------------:|----------------:|
-| SmolLM-135M 4bit | 407 tok/s | 905 tok/s | 712 tok/s | 127% |
-| Llama 3.1 8B 4bit | 107 tok/s | 117 tok/s | 117 tok/s | 99% |
-| Qwen2.5 7B 4bit | 110 tok/s | 126 tok/s | 124 tok/s | 102% |
-| Gemma 2B 4bit | 190 tok/s | 217 tok/s | 223 tok/s | 97% |
-| Gemma 3 4B 4bit | 114 tok/s | 182 tok/s | 182 tok/s | 100% |
-| Gemma 2 2B 4bit | 129 tok/s | 242 tok/s | 242 tok/s | 100% |
-| Phi-3.5-mini 4bit | 121 tok/s | 205 tok/s | 208 tok/s | 98% |
-| Jamba v0.1 4bit (hybrid SSM) | 112 tok/s | 216 tok/s | 219 tok/s | 98% |
-| Gemma 4 26B-A4B 4bit | 73 tok/s | 137 tok/s | 141 tok/s | 97% |
+| SmolLM-135M 4bit | 384 tok/s | 905 tok/s | 712 tok/s | 127% |
+| Llama 3.1 8B 4bit | 109 tok/s | 117 tok/s | 117 tok/s | 99% |
+| Qwen2.5 7B 4bit | 113 tok/s | 126 tok/s | 124 tok/s | 102% |
+| Gemma 2B 4bit | 195 tok/s | 217 tok/s | 223 tok/s | 97% |
+| Gemma 3 4B 4bit | 118 tok/s | 182 tok/s | 182 tok/s | 100% |
+| Gemma 2 2B 4bit | 170 tok/s | 242 tok/s | 242 tok/s | 100% |
+| Phi-3.5-mini 4bit | 167 tok/s | 205 tok/s | 208 tok/s | 98% |
+| Jamba v0.1 4bit (hybrid SSM) | 124 tok/s | 216 tok/s | 219 tok/s | 98% |
+| Gemma 4 26B-A4B 4bit | 72 tok/s | 137 tok/s | 141 tok/s | 97% |
 | Qwen3 MoE 30B 4bit | 71 tok/s | 156 tok/s | 147 tok/s | 106% |
-| GLM-4 Flash 4bit | 47 tok/s | 104 tok/s | 104 tok/s | 100% |
-| Nemotron-H 30B 4bit | 90 tok/s | 177 tok/s | 179 tok/s | 99% |
-| Mixtral 8x7B 4bit | 54 tok/s | 65 tok/s | 66 tok/s | 99% |
-| StarCoder2 3B 4bit | 171 tok/s | 216 tok/s | 215 tok/s | 101% |
-| Qwen3.5 0.8B 4bit | 243 tok/s | 517 tok/s | 545 tok/s | 95% |
-| Qwen3-VL 30B-A3B 4bit, text path | 70 tok/s | 151 tok/s | 147 tok/s | 103% |
+| GLM-4 Flash 4bit | 48 tok/s | 104 tok/s | 104 tok/s | 100% |
+| Nemotron-H 30B 4bit | 92 tok/s | 177 tok/s | 179 tok/s | 99% |
+| Mixtral 8x7B 4bit | 55 tok/s | 65 tok/s | 66 tok/s | 99% |
+| StarCoder2 3B 4bit | 173 tok/s | 216 tok/s | 215 tok/s | 101% |
+| Qwen3.5 0.8B 4bit | 244 tok/s | 517 tok/s | 545 tok/s | 95% |
+| Qwen3-VL 30B-A3B 4bit, text path | 71 tok/s | 151 tok/s | 147 tok/s | 103% |
 | Qwen3-VL 32B 4bit, text path | 21 tok/s | 28 tok/s | 29 tok/s | 96% |
-| GPT-OSS 120B 4bit | 59 tok/s | 114 tok/s | 110 tok/s | 103% |
+| GPT-OSS 120B 4bit | 61 tok/s | 114 tok/s | 110 tok/s | 103% |
 | Solar Open 100B 4bit | 36 tok/s | 65 tok/s | 66 tok/s | 99% |
 
 | VLM model | M1 Ultra mlxcel | M5 Max mlxcel | M5 Max mlx-vlm | mlxcel / mlx-vlm |
 |-----------|----------------:|--------------:|---------------:|-----------------:|
-| LLaVA Interleave Qwen 0.5B bf16 | 270 tok/s | 344 tok/s | 345 tok/s | 100% |
-| Qwen3.5 0.8B 4bit | 202 tok/s | 506 tok/s | 411 tok/s | 123% |
-| Qwen3.5 35B-A3B 4bit | 71 tok/s | 151 tok/s | 129 tok/s | 117% |
+| LLaVA Interleave Qwen 0.5B bf16 | 266 tok/s | 344 tok/s | 345 tok/s | 100% |
+| Qwen3.5 0.8B 4bit | 234 tok/s | 506 tok/s | 411 tok/s | 123% |
+| Qwen3.5 35B-A3B 4bit | 70 tok/s | 151 tok/s | 129 tok/s | 117% |
 | Gemma 4 E2B 4bit | 107 tok/s | 217 tok/s | 202 tok/s | 108% |
-| Gemma 3n E2B 4bit | 72 tok/s | 151 tok/s | 125 tok/s | 121% |
-| InternVL3 1B | - | 601 tok/s | 529 tok/s | 114% |
-| Gemma 4 26B-A4B 4bit | 63 tok/s | 134 tok/s | 137 tok/s | 98% |
-| Molmo2 4B | 59 tok/s | 64 tok/s | 67 tok/s | 96% |
-| Phi 3.5 Vision 4bit | 94 tok/s | 123 tok/s | 160 tok/s | 77% |
+| Gemma 3n E2B 4bit | 73 tok/s | 151 tok/s | 125 tok/s | 121% |
+| InternVL3 1B | 229 tok/s | 601 tok/s | 529 tok/s | 114% |
+| Gemma 4 26B-A4B 4bit | 66 tok/s | 134 tok/s | 137 tok/s | 98% |
+| Molmo2 4B | 60 tok/s | 64 tok/s | 67 tok/s | 96% |
+| Phi 3.5 Vision 4bit | 123 tok/s | 169 tok/s | 160 tok/s | 106% |
 
 The M5 Max sweep covers 98 text model directories and a matching 98-entry VLM
 mode pass. Ratio summaries include only rows where both mlxcel and the Python

--- a/docs/benchmark_results/benchmark-report.md
+++ b/docs/benchmark_results/benchmark-report.md
@@ -21,9 +21,9 @@ includes image encoder and projector work.
 | Host | Mode | Baseline | Comparable pairs | Prefill median vs baseline | Decode median vs baseline | Decode result |
 |------|------|----------|-----------------:|---------------------------:|--------------------------:|---------------|
 | M5 Max | Text | mlx-lm | 66 | **2.70x** | **99%** | 62/66 at >=90% parity |
-| M1 Ultra | Text | mlx-lm | 73 | **1.76x** | **97%** | 62/73 at >=90% parity |
+| M1 Ultra | Text | mlx-lm | 74 | **1.76x** | **99%** | 64/74 at >=90% parity |
 | M5 Max | VLM | mlx-vlm | 22 | 0.94x | **101%** | 18/22 at >=90% parity |
-| M1 Ultra | VLM | mlx-vlm | 17 | **1.33x** | **98%** | 11/17 at >=90% parity |
+| M1 Ultra | VLM | mlx-vlm | 18 | **1.33x** | **98%** | 12/18 at >=90% parity |
 
 Ratios above use successful runs only. Baseline rows use exact CSV model
 identifiers and compare mlxcel and the Python stack on the same host. Decode
@@ -49,9 +49,9 @@ complete in this sweep. With a generated-token threshold of 5 tokens:
 | Host | Mode | mlxcel successful, Python baseline unavailable or failed | Comparable successful pairs |
 |------|------|---------------------------------------------------------:|----------------------------:|
 | M5 Max | Text | 26 | 66 |
-| M1 Ultra | Text | 22 | 73 |
+| M1 Ultra | Text | 23 | 74 |
 | M5 Max | VLM | 12 | 22 |
-| M1 Ultra | VLM | 20 | 17 |
+| M1 Ultra | VLM | 20 | 18 |
 
 This is the useful public framing: mlxcel is a Rust inference engine with
 direct MLX bindings that is already near Python decode performance for many
@@ -72,12 +72,12 @@ host.
 | M5 Max | solar-open-100b-4bit | Large MoE | 210.91 | 65.36 | 66.30 | 99% |
 | M5 Max | qwen3.5-35b-a3b-4bit | Hybrid MoE | 480.89 | 151.63 | 152.96 | 99% |
 | M5 Max | nemotron-h-30b-4bit | Hybrid SSM/MoE | 414.31 | 177.18 | 178.80 | 99% |
-| M1 Ultra | phi-3.5-moe-4bit | MoE | 107.87 | 76.24 | 69.28 | **110%** |
-| M1 Ultra | minicpm3-4b-4bit | MLA | 230.24 | 80.24 | 73.26 | **110%** |
-| M1 Ultra | qwen2.5-0.5b-4bit | Small dense | 1094.10 | 355.29 | 315.48 | **113%** |
-| M1 Ultra | gpt-oss-120b-4bit | Large MoE | 161.69 | 58.89 | 57.58 | **102%** |
-| M1 Ultra | command-r7b-4bit | Dense 7B | 92.20 | 110.22 | 107.75 | **102%** |
-| M1 Ultra | solar-open-100b-4bit | Large MoE | 73.74 | 35.88 | 35.69 | **100%** |
+| M1 Ultra | phi-3.5-moe-4bit | MoE | 112.10 | 77.71 | 69.28 | **112%** |
+| M1 Ultra | minicpm3-4b-4bit | MLA | 241.44 | 80.78 | 73.26 | **110%** |
+| M1 Ultra | qwen2.5-0.5b-4bit | Small dense | 1243.98 | 349.52 | 315.48 | **111%** |
+| M1 Ultra | gpt-oss-120b-4bit | Large MoE | 114.12 | 61.19 | 57.58 | **106%** |
+| M1 Ultra | command-r7b-4bit | Dense 7B | 81.17 | 114.34 | 107.75 | **106%** |
+| M1 Ultra | solar-open-100b-4bit | Large MoE | 75.37 | 36.26 | 35.69 | **102%** |
 
 The table shows the central performance claim without cross-hardware ranking:
 mlxcel is already close to mlx-lm on the same machine for dense 7B models,
@@ -96,11 +96,11 @@ comparison.
 | M5 Max | gemma-4-e2b-it-4bit | Gemma 4 VLM | 2787.47 | 217.32 | 201.70 | **108%** |
 | M5 Max | gemma3n-e2b-4bit | Gemma 3n VLM | 2893.48 | 151.36 | 124.63 | **121%** |
 | M5 Max | molmo2-4b | Molmo2 vision encoder | 2512.31 | 64.01 | 66.80 | 96% |
-| M1 Ultra | llava-interleave-qwen-0.5b-bf16 | SigLIP + Qwen2 | 8589.48 | 269.86 | 225.15 | **120%** |
-| M1 Ultra | aya-vision-8b | SigLIP + Cohere2 | 591.80 | 109.36 | 103.74 | **105%** |
-| M1 Ultra | molmo2-4b | Molmo2 vision encoder | 1011.99 | 59.36 | 60.87 | 98% |
-| M1 Ultra | phi-3.5-vision-4bit | CLIP + HD tiling | 1164.87 | 94.10 | 92.53 | **102%** |
-| M1 Ultra | pixtral-12b-4bit | Pixtral ViT + Mistral | 473.22 | 59.17 | - | - |
+| M1 Ultra | llava-interleave-qwen-0.5b-bf16 | SigLIP + Qwen2 | 3961.62 | 265.57 | 225.15 | **118%** |
+| M1 Ultra | aya-vision-8b | SigLIP + Cohere2 | 444.01 | 113.59 | 103.74 | **110%** |
+| M1 Ultra | molmo2-4b | Molmo2 vision encoder | 727.26 | 60.31 | 60.87 | 99% |
+| M1 Ultra | phi-3.5-vision-4bit | CLIP + HD tiling | 991.67 | 122.63 | 92.53 | **133%** |
+| M1 Ultra | pixtral-12b-4bit | Pixtral ViT + Mistral | 447.97 | 60.25 | - | - |
 
 The VLM data is most compelling as a coverage and decode-throughput story:
 mlxcel runs many VLM paths in the same benchmark matrix, and its comparable
@@ -110,14 +110,14 @@ decode results sit near mlx-vlm median parity on both Apple Silicon hosts.
 
 - **Steady-state decode:** M5 Max text decode is within 1% of mlx-lm median
   parity and VLM decode reaches mlx-vlm median parity. M1 Ultra shows
-  the same pattern, with 97% text median parity and 98% VLM median parity.
+  the same pattern, with 99% text median parity and 98% VLM median parity.
 - **Short-prompt text prefill:** mlxcel prefill is 2.70x mlx-lm median on M5
   Max text and 1.76x mlx-lm median on M1 Ultra text. Representative M5 Max
   values include gpt-oss-120b at 334.68 tok/s and nemotron-h-30b at
   414.31 tok/s.
 - **Large MoE practicality:** GPT-OSS 120B reaches 114.03 tok/s on M5 Max and
-  58.89 tok/s on M1 Ultra, both at or slightly above mlx-lm parity on the same
-  host. Solar-Open 100B reaches 65.36 tok/s (M5 Max) / 35.88 tok/s (M1 Ultra),
+  61.19 tok/s on M1 Ultra, both at or slightly above mlx-lm parity on the same
+  host. Solar-Open 100B reaches 65.36 tok/s (M5 Max) / 36.26 tok/s (M1 Ultra),
   also at mlx-lm parity.
 - **Model coverage:** mlxcel completes many runs where the Python baseline
   fails or is unavailable in the same benchmark matrix. This is especially

--- a/docs/benchmark_results/model_tests.md
+++ b/docs/benchmark_results/model_tests.md
@@ -10,7 +10,7 @@ M5 Max, and mlx-lm / mlx-vlm baselines, see
 
 | Hardware | File | Status | Last Updated |
 |----------|------|--------|-------------|
-| Mac Studio M1 Ultra 128GB | [model_tests_m1ultra.md](model_tests_m1ultra.md) | Active | 2026-05-19 |
+| Mac Studio M1 Ultra 128GB | [model_tests_m1ultra.md](model_tests_m1ultra.md) | Active | 2026-05-28 |
 | MacBook Pro M5 Max 128GB | [model_tests_m5max.md](model_tests_m5max.md) | Active | 2026-05-27 |
 | NVIDIA GB10 (DIGITS) | [model_tests_gb10.md](model_tests_gb10.md) | Active | 2026-05-19 |
 

--- a/docs/benchmark_results/model_tests_m1ultra.md
+++ b/docs/benchmark_results/model_tests_m1ultra.md
@@ -8,14 +8,14 @@ Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra
 |------|-------|
 | **Hardware** | Mac Studio M1 Ultra, 128GB RAM |
 | **OS** | macOS 26.4 (Tahoe) |
-| **mlxcel version** | 0.0.28 |
+| **mlxcel version** | 0.1.0 |
 | **MLX version** | post-0.32.0 pin (commit 84961223, via mlxcel-core) |
 | **Bench harness** | `mlxcel-bench-decode` (model load, warmup, and measured pass in one process) |
 | **mlx-lm baseline** | 0.31.3 (dev checkout `references/mlx-lm` @ `df1d3f3` — "Fix Gemma 4 sanitize() not stripping KV projections for shared layers" #1240) |
 | **mlx-vlm baseline** | dev checkout `references/mlx-vlm` @ `d85ca4d` — "Compatibility bridge for non-VL models" #1181 |
 | **Test Prompt** | "Hello, how are you today?" (text) / "What is in this image?" (VLM) |
 | **Max Tokens** | 100 (measured pass); 20 (warmup pass, same process) |
-| **Test Date** | 2026-05-19 full sweep (mlxcel + mlx-lm + mlx-vlm baselines); 2026-05-21 mlxcel refresh of Molmo / Phi-3.5 / Gemma dense / Jamba / InternVL on current main |
+| **Test Date** | 2026-05-19 full sweep (baseline); 2026-05-28 full text + VLM re-benchmark on mlxcel 0.1.0 (`--cooldown 0`) |
 | **Baseline CSVs** | `benchmarks/pylm_m1ultra_2026-05-19.csv` (mlx-lm, 75 ran / 33 FAIL / 3 oversize-skip / 1 exit-fail) + `benchmarks/pylm_m1ultra_vlm_2026-05-19.csv` (mlx-vlm, 20 working VLM models) |
 
 ## Legend
@@ -30,99 +30,99 @@ Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
 |-------|------------|--------|---------|--------|-----------|-------|
-| llama3 | Llama-3.2-1B-Instruct-4bit | ✅ | 1988.07 | 377.90 | 90% | mlx-lm: 418.25; only 48 tokens |
-| llama3 (8B bf16) | Llama-3.1-8B-Instruct (bf16) | ✅ | 419.02 | 35.15 | 100% | mlx-lm: 35.32; non-quantized |
-| llama3.1 | Llama-3.1-8B-Instruct-4bit | ✅ | 471.57 | 107.23 | 97% | mlx-lm: 110.66; only 54 tokens |
-| llama4 | Llama-4-Scout-17B-16E-Instruct-4bit | ⚠️ | 125.84 | 35.21 | - | mlx-lm: FAIL; long outputs repetitive |
-| qwen2 | Qwen2.5-0.5B-Instruct-4bit | ✅ | 1094.10 | 355.29 | **113%** | mlx-lm: 315.48 |
-| qwen2 (7B 4bit) | Qwen2.5-7B-Instruct-4bit | ✅ | 310.40 | 110.67 | 100% | mlx-lm: 110.90 |
-| qwen2 (7B 8bit) | Qwen2.5-7B-Instruct-8bit | ✅ | 315.31 | 69.08 | 98% | mlx-lm: 70.46; 8-bit quantized |
-| qwen3 | Qwen3-0.6B-4bit | ✅ | 559.24 | 295.09 | 98% | mlx-lm: 299.61 |
-| qwen3 (1.7B) | Qwen3-1.7B-4bit | ✅ | 390.56 | 195.30 | 88% | mlx-lm: 221.37 |
-| qwen3 (4B) | Qwen3-4B-4bit | ✅ | 240.16 | 120.70 | 97% | mlx-lm: 123.92 |
-| qwen3 (8B) | Qwen3-8B-4bit | ✅ | 165.63 | 79.85 | 94% | mlx-lm: 84.54 |
-| qwen3_5 (0.8B) | Qwen3.5-0.8B-4bit | ✅ | 478.37 | 243.32 | 90% | mlx-lm: 269.52; Hybrid GatedDeltaNet |
-| qwen3_5 (2B) | Qwen3.5-2B-4bit | ✅ | 387.77 | 172.05 | 81% | mlx-lm: 211.68; Hybrid GatedDeltaNet; only 36 tokens |
-| qwen3_5 (4B) | Qwen3.5-4B-4bit | ✅ | 242.19 | 95.76 | 83% | mlx-lm: 115.60; Hybrid GatedDeltaNet; only 36 tokens |
-| qwen3_5 (9B 4bit) | qwen3.5-9B-4bit | ✅ | 151.81 | 72.36 | 89% | mlx-lm: 81.27; Hybrid GatedDeltaNet; only 29 tokens |
-| qwen3_5 (9B bf16) | qwen3.5-9B (bf16) | ✅ | 150.65 | 31.28 | 91% | mlx-lm: 34.22; bf16, not quantized; Hybrid GatedDeltaNet (compiled fused kernel) |
-| qwen3_5 (27B) | qwen3.5-27B-4bit | ✅ | 50.99 | 24.25 | 94% | mlx-lm: 25.93; Hybrid Transformer+GatedDeltaNet; VLM wrapper format |
-| qwen3_6 | qwen3.6-35B-A3B-4bit | ✅ | 223.86 | 68.77 | 94% | mlx-lm: 73.18; MoE architecture; 100 tokens |
+| llama3 | Llama-3.2-1B-Instruct-4bit | ✅ | 1951.01 | 373.43 | 89% | mlx-lm: 418.25; only 48 tokens |
+| llama3 (8B bf16) | Llama-3.1-8B-Instruct (bf16) | ✅ | 427.93 | 35.77 | **101%** | mlx-lm: 35.32; non-quantized |
+| llama3.1 | Llama-3.1-8B-Instruct-4bit | ✅ | 486.38 | 109.49 | 99% | mlx-lm: 110.66; only 54 tokens |
+| llama4 | Llama-4-Scout-17B-16E-Instruct-4bit | ⚠️ | 120.77 | 36.66 | - | mlx-lm: FAIL; long outputs repetitive |
+| qwen2 | Qwen2.5-0.5B-Instruct-4bit | ✅ | 1243.98 | 349.52 | **111%** | mlx-lm: 315.48 |
+| qwen2 (7B 4bit) | Qwen2.5-7B-Instruct-4bit | ✅ | 318.26 | 112.68 | **102%** | mlx-lm: 110.90 |
+| qwen2 (7B 8bit) | Qwen2.5-7B-Instruct-8bit | ✅ | 314.56 | 71.15 | **101%** | mlx-lm: 70.46; 8-bit quantized |
+| qwen3 | Qwen3-0.6B-4bit | ✅ | 572.83 | 284.03 | 95% | mlx-lm: 299.61 |
+| qwen3 (1.7B) | Qwen3-1.7B-4bit | ✅ | 416.92 | 197.55 | 89% | mlx-lm: 221.37 |
+| qwen3 (4B) | Qwen3-4B-4bit | ✅ | 250.77 | 121.42 | 98% | mlx-lm: 123.92 |
+| qwen3 (8B) | Qwen3-8B-4bit | ✅ | 166.07 | 81.38 | 96% | mlx-lm: 84.54 |
+| qwen3_5 (0.8B) | Qwen3.5-0.8B-4bit | ✅ | 541.70 | 244.18 | 91% | mlx-lm: 269.52; Hybrid GatedDeltaNet |
+| qwen3_5 (2B) | Qwen3.5-2B-4bit | ✅ | 423.60 | 179.54 | 85% | mlx-lm: 211.68; Hybrid GatedDeltaNet; only 36 tokens |
+| qwen3_5 (4B) | Qwen3.5-4B-4bit | ✅ | 252.63 | 102.31 | 89% | mlx-lm: 115.60; Hybrid GatedDeltaNet; only 36 tokens |
+| qwen3_5 (9B 4bit) | qwen3.5-9B-4bit | ✅ | 158.73 | 72.75 | 90% | mlx-lm: 81.27; Hybrid GatedDeltaNet; only 29 tokens |
+| qwen3_5 (9B bf16) | qwen3.5-9B (bf16) | ✅ | 152.39 | 31.85 | 93% | mlx-lm: 34.22; bf16, not quantized; Hybrid GatedDeltaNet (compiled fused kernel) |
+| qwen3_5 (27B) | qwen3.5-27B-4bit | ✅ | 53.45 | 24.52 | 95% | mlx-lm: 25.93; Hybrid Transformer+GatedDeltaNet; VLM wrapper format |
+| qwen3_6 | qwen3.6-35B-A3B-4bit | ✅ | 244.19 | 70.36 | 96% | mlx-lm: 73.18; MoE architecture; 100 tokens |
 | qwen3_next | qwen3-next-480B-4bit | ⏳ | - | SKIP | - | Qwen3Next 480B architecture; >65GB skipped on 128GB host |
-| qwen2 (1.5B) | Qwen2.5-1.5B-Instruct-4bit | ✅ | 808.08 | 240.24 | **100%** | mlx-lm: 239.20; 100 tokens |
-| qwen2 (1.5B base) | Qwen2.5-1.5B-4bit | ✅ | 701.57 | 241.44 | **100%** | mlx-lm: 241.41; base variant; 100 tokens |
-| phi | phi-2-hf-4bit-mlx | ✅ | 134.96 | 59.62 | - | mlx-lm fails to load; only 1 token (likely EOS) |
-| phi3 | Phi-3-mini-4k-instruct-4bit | ✅ | 173.84 | 167.27 | 98% | mlx-lm: 171.36; only 25 tokens |
-| phi3small | Phi-3.5-mini-instruct-4bit | ✅ | 218.87 | 160.90 | 97% | mlx-lm: 166.30; only 40 tokens |
-| phi4 | Phi-4-4bit | ✅ | 111.29 | 57.02 | 97% | mlx-lm: 58.68 |
-| smollm3 | SmolLM-135M-Instruct-4bit | ✅ | 486.25 | 407.36 | **108%** | mlx-lm: 375.91 |
-| smollm3 (3B) | SmolLM3-3B-4bit | ✅ | 568.57 | 136.34 | 96% | mlx-lm: 141.66 |
-| stablelm | stablelm-2-1_6b-chat-4bit | ✅ | 656.55 | 280.32 | 100% | mlx-lm: 280.65; only 59 tokens |
-| starcoder2 | starcoder2-3b-4bit | ✅ | 177.66 | 171.30 | **103%** | mlx-lm: 166.17 |
-| olmo | OLMo-1B-hf-4bit | ✅ | 179.80 | 219.54 | - | mlx-lm: FAIL |
-| olmo2 | OLMo2-7B-4bit | ✅ | 281.23 | 103.66 | 93% | mlx-lm: 110.88; only 27 tokens |
-| olmo3 | OLMo3.1-32B-4bit | ✅ | 81.40 | 21.79 | **101%** | mlx-lm: 21.57 |
-| minicpm | MiniCPM-2B-sft-bf16-4bit | ✅ | 298.42 | 163.05 | **104%** | mlx-lm: 156.47 |
-| mimo | MiMo-7B-RL-4bit | ✅ | 240.27 | 85.28 | 99% | mlx-lm: 86.17 |
+| qwen2 (1.5B) | Qwen2.5-1.5B-Instruct-4bit | ✅ | 874.09 | 243.11 | **102%** | mlx-lm: 239.20; 100 tokens |
+| qwen2 (1.5B base) | Qwen2.5-1.5B-4bit | ✅ | 756.00 | 244.93 | **101%** | mlx-lm: 241.41; base variant; 100 tokens |
+| phi | phi-2-hf-4bit-mlx | ✅ | 146.30 | 62.61 | - | mlx-lm fails to load; only 1 token (likely EOS) |
+| phi3 | Phi-3-mini-4k-instruct-4bit | ✅ | 198.89 | 172.17 | **100%** | mlx-lm: 171.36; only 25 tokens |
+| phi3small | Phi-3.5-mini-instruct-4bit | ✅ | 231.09 | 167.07 | **100%** | mlx-lm: 166.30; only 40 tokens |
+| phi4 | Phi-4-4bit | ✅ | 112.86 | 58.83 | **100%** | mlx-lm: 58.68 |
+| smollm3 | SmolLM-135M-Instruct-4bit | ✅ | 607.34 | 383.55 | **102%** | mlx-lm: 375.91 |
+| smollm3 (3B) | SmolLM3-3B-4bit | ✅ | 582.75 | 137.92 | 97% | mlx-lm: 141.66 |
+| stablelm | stablelm-2-1_6b-chat-4bit | ✅ | 667.72 | 285.79 | **102%** | mlx-lm: 280.65; only 59 tokens |
+| starcoder2 | starcoder2-3b-4bit | ✅ | 177.03 | 172.82 | **104%** | mlx-lm: 166.17 |
+| olmo | OLMo-1B-hf-4bit | ✅ | 188.64 | 212.53 | - | mlx-lm: FAIL |
+| olmo2 | OLMo2-7B-4bit | ✅ | 278.00 | 104.17 | 94% | mlx-lm: 110.88; only 27 tokens |
+| olmo3 | OLMo3.1-32B-4bit | ✅ | 81.70 | 22.14 | **103%** | mlx-lm: 21.57 |
+| minicpm | MiniCPM-2B-sft-bf16-4bit | ✅ | 298.90 | 165.32 | **106%** | mlx-lm: 156.47 |
+| mimo | MiMo-7B-RL-4bit | ✅ | 232.90 | 86.26 | **100%** | mlx-lm: 86.17 |
 
 ## Gemma Family
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
 |-------|------------|--------|---------|--------|-----------|-------|
-| gemma | gemma-2b-it-4bit | ✅ | 378.01 | 189.91 | 91% | mlx-lm: 207.78; only 49 tokens |
-| gemma2 | gemma-2-2b-it-4bit | ✅ | 334.20 | 163.85 | **107%** | mlx-lm: 153.50; only 18 tokens |
-| gemma3 | gemma-3-1b-it-4bit | ✅ | 431.88 | 225.75 | **107%** | mlx-lm: 211.50; only 34 tokens |
-| gemma3 (4B) | gemma-3-4b-it-4bit | ✅ | 203.23 | 113.61 | **104%** | mlx-lm: 109.48; only 86 tokens |
-| gemma4 (31B) | gemma-4-31b-4bit | ✅ | 24.54 | 20.15 | 99% | mlx-lm: 20.36 |
-| gemma4 (31B-it) | gemma-4-31b-it-4bit | ✅ | 52.04 | 19.06 | 94% | mlx-lm: 20.23; instruction-tuned variant |
-| gemma4 (26B A4B) | gemma-4-26b-a4b-it-4bit | ✅ | 168.66 | 73.18 | **101%** | mlx-lm: 72.52; only 26 tokens |
-| gemma4 (E2B 4bit) | gemma-4-e2b-it-4bit | ✅ | 257.28 | 116.08 | - | mlx-lm: FAIL; only 34 tokens |
-| gemma4 (E2B 8bit) | gemma-4-e2b-it-8bit | ✅ | 212.56 | 87.42 | - | mlx-lm: FAIL; only 38 tokens |
-| gemma4 (E4B 4bit) | gemma-4-e4b-it-4bit | ✅ | 175.01 | 81.88 | - | mlx-lm: FAIL; only 25 tokens |
-| gemma4 (E4B 8bit) | gemma-4-e4b-it-8bit | ✅ | 165.49 | 59.35 | - | mlx-lm: FAIL; only 39 tokens |
-| gemma3n | gemma-3n-E2B-it-4bit | ✅ | 238.51 | 76.86 | - | mlx-lm: FAIL; only 69 tokens |
-| gemma3n (E4B) | gemma-3n-E4B-it-4bit | ✅ | 169.94 | 60.18 | - | mlx-lm: FAIL; only 74 tokens |
-| gemma3n (E4B bf16) | gemma-3n-E4B-it (bf16) | ✅ | 169.01 | 35.65 | 91% | mlx-lm: 39.02; bf16; AltUp/MLP decode graph scheduling |
+| gemma | gemma-2b-it-4bit | ✅ | 332.44 | 194.67 | 94% | mlx-lm: 207.78; only 49 tokens |
+| gemma2 | gemma-2-2b-it-4bit | ✅ | 340.38 | 169.77 | **111%** | mlx-lm: 153.50; only 18 tokens |
+| gemma3 | gemma-3-1b-it-4bit | ✅ | 412.77 | 232.91 | **110%** | mlx-lm: 211.50; only 34 tokens |
+| gemma3 (4B) | gemma-3-4b-it-4bit | ✅ | 204.48 | 117.12 | **107%** | mlx-lm: 109.48; only 86 tokens |
+| gemma4 (31B) | gemma-4-31b-4bit | ✅ | 16.81 | 20.48 | **101%** | mlx-lm: 20.36 |
+| gemma4 (31B-it) | gemma-4-31b-it-4bit | ✅ | 47.28 | 19.61 | 97% | mlx-lm: 20.23; instruction-tuned variant |
+| gemma4 (26B A4B) | gemma-4-26b-a4b-it-4bit | ✅ | 166.86 | 71.76 | 99% | mlx-lm: 72.52; only 26 tokens |
+| gemma4 (E2B 4bit) | gemma-4-e2b-it-4bit | ✅ | 254.45 | 119.67 | - | mlx-lm: FAIL; only 34 tokens |
+| gemma4 (E2B 8bit) | gemma-4-e2b-it-8bit | ✅ | 230.17 | 89.23 | - | mlx-lm: FAIL; only 38 tokens |
+| gemma4 (E4B 4bit) | gemma-4-e4b-it-4bit | ✅ | 182.08 | 84.43 | - | mlx-lm: FAIL; only 25 tokens |
+| gemma4 (E4B 8bit) | gemma-4-e4b-it-8bit | ✅ | 163.78 | 60.61 | - | mlx-lm: FAIL; only 39 tokens |
+| gemma3n | gemma-3n-E2B-it-4bit | ✅ | 227.00 | 78.75 | - | mlx-lm: FAIL; only 69 tokens |
+| gemma3n (E4B) | gemma-3n-E4B-it-4bit | ✅ | 171.02 | 61.51 | - | mlx-lm: FAIL; only 74 tokens |
+| gemma3n (E4B bf16) | gemma-3n-E4B-it (bf16) | ✅ | 174.94 | 34.96 | 90% | mlx-lm: 39.02; bf16; AltUp/MLP decode graph scheduling |
 | recurrent_gemma | - | ⏳ | - | - | - | Griffin SSM+attention hybrid |
 
 ## EXAONE
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
 |-------|------------|--------|---------|--------|-----------|-------|
-| exaone | EXAONE-3.5-2.4B-Instruct-4bit | ✅ | 672.62 | 199.04 | **102%** | mlx-lm: 194.65 |
-| exaone4 | exaone-4.0-1.2b-4bit | ✅ | 464.33 | 252.36 | - | mlx-lm: FAIL; only 18 tokens |
+| exaone | EXAONE-3.5-2.4B-Instruct-4bit | ✅ | 687.90 | 200.53 | **103%** | mlx-lm: 194.65 |
+| exaone4 | exaone-4.0-1.2b-4bit | ✅ | 409.39 | 247.55 | - | mlx-lm: FAIL; only 18 tokens |
 | exaone_moe | - | ⏳ | - | - | - | |
 
 ## Cohere Command R
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
 |-------|------------|--------|---------|--------|-----------|-------|
-| cohere | c4ai-command-r7b-12-2024-4bit | ✅ | 92.20 | 110.22 | **102%** | mlx-lm: 107.75 |
-| cohere2 | aya-expanse-8b-4bit | ✅ | 98.87 | 107.30 | 95% | mlx-lm: 112.74 |
+| cohere | c4ai-command-r7b-12-2024-4bit | ✅ | 81.17 | 114.34 | **106%** | mlx-lm: 107.75 |
+| cohere2 | aya-expanse-8b-4bit | ✅ | 97.98 | 110.58 | 98% | mlx-lm: 112.74 |
 
 ## MoE (Mixture of Experts)
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
 |-------|------------|--------|---------|--------|-----------|-------|
 | minimax | MiniMax-M2-3bit | ⏳ | - | SKIP | - | mlx-lm: 18.2; >65GB skipped on 128GB host (93GB) |
-| mixtral | Mixtral-8x7B-Instruct-v0.1-4bit | ✅ | 78.43 | 53.62 | 98% | mlx-lm: 54.91; only 73 tokens |
-| qwen2_moe | Qwen1.5-MoE-A2.7B-Chat-4bit | ✅ | 378.81 | 144.37 | 100% | mlx-lm: 144.98; only 43 tokens |
-| qwen3_moe | Qwen3-30B-A3B-4bit | ✅ | 183.00 | 71.07 | **101%** | mlx-lm: 70.18 |
-| qwen3_5_moe | qwen3.5-35B-A3B-4bit | ✅ | 216.08 | 72.05 | 94% | mlx-lm: 76.44; Hybrid GatedDeltaNet + MoE (256 experts); only 34 tokens |
-| phimoe | Phi-3.5-MoE-instruct-4bit | ✅ | 105.77 | 74.41 | **107%** | mlx-lm: 69.28 |
-| solar_open | Solar-Open-100B-4bit | ✅ | 73.74 | 35.88 | **101%** | mlx-lm: 35.69; 128 experts, top-8; layer-eval skip (PR #724); 54GB |
+| mixtral | Mixtral-8x7B-Instruct-v0.1-4bit | ✅ | 81.80 | 54.66 | 100% | mlx-lm: 54.91; only 73 tokens |
+| qwen2_moe | Qwen1.5-MoE-A2.7B-Chat-4bit | ✅ | 390.03 | 147.24 | **102%** | mlx-lm: 144.98; only 43 tokens |
+| qwen3_moe | Qwen3-30B-A3B-4bit | ✅ | 191.96 | 72.17 | **103%** | mlx-lm: 70.18 |
+| qwen3_5_moe | qwen3.5-35B-A3B-4bit | ✅ | 239.05 | 71.38 | 93% | mlx-lm: 76.44; Hybrid GatedDeltaNet + MoE (256 experts); only 34 tokens |
+| phimoe | Phi-3.5-MoE-instruct-4bit | ✅ | 112.10 | 77.71 | **112%** | mlx-lm: 69.28 |
+| solar_open | Solar-Open-100B-4bit | ✅ | 75.37 | 36.26 | **102%** | mlx-lm: 35.69; 128 experts, top-8; layer-eval skip (PR #724); 54GB |
 | solar_open (int4) | Solar-Open-100B-int4 | ✅ | - | 11.55 | - | mlx-lm: fails to load; 128 experts, top-8; int4 quantization; 54GB |
 | olmoe | - | ⏳ | - | - | - | |
-| gpt_oss (20B) | gpt-oss-20b-MXFP4-Q4 | ✅ | 284.10 | 88.89 | 99% | mlx-lm: 89.51; MXFP4 quantization; 32 experts; bf16 decode fix (PR #721) |
-| gpt_oss (120B) | gpt-oss-120b-4bit | ✅ | 161.69 | 58.89 | **102%** | mlx-lm: 57.58; 128 experts, top-4; 61GB model; bf16 decode fix (PR #721) |
+| gpt_oss (20B) | gpt-oss-20b-MXFP4-Q4 | ✅ | 286.09 | 93.46 | **104%** | mlx-lm: 89.51; MXFP4 quantization; 32 experts; bf16 decode fix (PR #721) |
+| gpt_oss (120B) | gpt-oss-120b-4bit | ✅ | 114.12 | 61.19 | **106%** | mlx-lm: 57.58; 128 experts, top-4; 61GB model; bf16 decode fix (PR #721) |
 
 ## DeepSeek Family
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
 |-------|------------|--------|---------|--------|-----------|-------|
-| deepseek | deepseek-coder-1.3b-instruct-4bit | ✅ | 1354.70 | 164.77 | - | mlx-lm: FAIL |
-| deepseek_v2 | DeepSeek-V2-Lite-Chat-4bit | ✅ | 217.30 | 111.86 | 96% | mlx-lm: 117.06; only 18 tokens |
-| deepseek_r1 | DeepSeek-R1-Distill-Qwen-7B-4bit | ✅ | 158.52 | 110.82 | 100% | mlx-lm: 111.34 |
+| deepseek | deepseek-coder-1.3b-instruct-4bit | ✅ | 1306.40 | 165.72 | - | mlx-lm: FAIL |
+| deepseek_v2 | DeepSeek-V2-Lite-Chat-4bit | ✅ | 207.71 | 112.45 | 96% | mlx-lm: 117.06; only 18 tokens |
+| deepseek_r1 | DeepSeek-R1-Distill-Qwen-7B-4bit | ✅ | 156.36 | 113.52 | **102%** | mlx-lm: 111.34 |
 | deepseek_v3 | deepseek-v3-4bit | ⏳ | - | SKIP | - | MoE + MLA; >65GB skipped on 128GB host (99GB) |
 | deepseek_v32 | - | ⏳ | - | - | - | |
 
@@ -130,41 +130,41 @@ Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
 |-------|------------|--------|---------|--------|-----------|-------|
-| minicpm3 | MiniCPM3-4B-4bit | ✅ | 230.24 | 80.24 | **110%** | mlx-lm: 73.26 |
+| minicpm3 | MiniCPM3-4B-4bit | ✅ | 241.44 | 80.78 | **110%** | mlx-lm: 73.26 |
 
 ## Nemotron Family
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
 |-------|------------|--------|---------|--------|-----------|-------|
-| nemotron_h | Nemotron-H-30B-4bit | ✅ | 173.69 | 90.25 | 97% | mlx-lm: 93.34; Hybrid Mamba2+Transformer+MoE; SSM Metal kernel |
-| nemotron_nas | Nemotron-NAS-30B-A3B-4bit | ✅ | 165.59 | 90.67 | 98% | mlx-lm: 92.93; Hybrid Mamba2+Transformer+MoE |
-| nemotron_h_nano_omni | Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | ✅ | 165.84 | 83.29 | - | mlx-lm: FAIL; NEW (5-19); Mamba2+Transformer+MoE+Parakeet audio; 100 tokens |
+| nemotron_h | Nemotron-H-30B-4bit | ✅ | 168.46 | 91.68 | 98% | mlx-lm: 93.34; Hybrid Mamba2+Transformer+MoE; SSM Metal kernel |
+| nemotron_nas | Nemotron-NAS-30B-A3B-4bit | ✅ | 169.94 | 92.26 | 99% | mlx-lm: 92.93; Hybrid Mamba2+Transformer+MoE |
+| nemotron_h_nano_omni | Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | ✅ | 171.39 | 87.56 | - | mlx-lm: FAIL; NEW (5-19); Mamba2+Transformer+MoE+Parakeet audio; 100 tokens |
 
 ## SSM / Mamba Models
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
 |-------|------------|--------|---------|--------|-----------|-------|
-| mamba | Falcon-Mamba-7B-4bit | ⚠️ | 92.67 | 42.91 | 47% | mlx-lm: 91.04; only 2 tokens due to chat template EOS |
-| mamba2 | mamba2-1.3b-4bit | ✅ | 162.53 | 102.63 | - | mlx-lm: FAIL |
-| jamba | Jamba-v0.1-4bit | ✅ | 325.65 | 119.33 | 91% | mlx-lm: 131.04; only 76 tokens |
+| mamba | Falcon-Mamba-7B-4bit | ⚠️ | 91.13 | 42.83 | 47% | mlx-lm: 91.04; only 2 tokens due to chat template EOS |
+| mamba2 | mamba2-1.3b-4bit | ✅ | 172.43 | 101.13 | - | mlx-lm: FAIL |
+| jamba | Jamba-v0.1-4bit | ✅ | 336.05 | 123.65 | 94% | mlx-lm: 131.04; only 76 tokens |
 | rwkv7 | - | ⏳ | - | - | - | RWKV v7 linear attention |
 
 ## Chinese / Asian Language Models
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
 |-------|------------|--------|---------|--------|-----------|-------|
-| baichuan | Baichuan-M1-14B-Instruct-4bit | ✅ | 57.64 | 40.32 | 82% | mlx-lm: 49.11; only 39 tokens |
-| glm4 | GLM-4-Flash-4bit | ✅ | 130.01 | 47.32 | 96% | mlx-lm: 49.47; Only 18 tokens |
+| baichuan | Baichuan-M1-14B-Instruct-4bit | ✅ | 53.98 | 40.13 | 82% | mlx-lm: 49.11; only 39 tokens |
+| glm4 | GLM-4-Flash-4bit | ✅ | 132.26 | 47.92 | 97% | mlx-lm: 49.47; Only 18 tokens |
 | glm4_moe | - | ⏳ | - | - | - | |
 | glm4_moe_lite | GLM-4.7-Flash-4bit | ✅ | - | 31.54 | 76% | mlx-lm: 41.55; only 18 tokens |
 | glm5 | GLM-5-4bit | ❌ | - | FAIL | - | warmup failure (persistent) |
-| internlm2 | InternLM2-7B-4bit | ✅ | 211.75 | 107.52 | 96% | mlx-lm: 111.92 |
-| internlm3 | internlm3-8b-instruct-4bit | ✅ | 313.73 | 86.88 | - | mlx-lm: FAIL |
-| ernie4_5 | ERNIE-4.5-0.3B-Instruct-4bit | ✅ | 996.41 | 526.70 | - | mlx-lm: FAIL |
+| internlm2 | InternLM2-7B-4bit | ✅ | 215.62 | 110.98 | 99% | mlx-lm: 111.92 |
+| internlm3 | internlm3-8b-instruct-4bit | ✅ | 310.99 | 87.98 | - | mlx-lm: FAIL |
+| ernie4_5 | ERNIE-4.5-0.3B-Instruct-4bit | ✅ | 1009.89 | 510.17 | - | mlx-lm: FAIL |
 | ernie4_5_moe | - | ⏳ | - | - | - | |
-| hunyuan_moe | Hunyuan-Large-Instruct-4bit | ✅ | 64.69 | 44.22 | - | mlx-lm: FAIL |
+| hunyuan_moe | Hunyuan-Large-Instruct-4bit | ✅ | 65.24 | 45.22 | - | mlx-lm: FAIL |
 | hunyuan_moe_13b | HunYuan-MoE-A13B-Instruct (bf16) | ❌ | - | FAIL | - | mlx-lm: fails to load; Tiktoken tokenizer; bf16; warmup failure |
-| hunyuan_v1_dense | Hunyuan-1.8B-Instruct-4bit | ✅ | 280.48 | 182.98 | 91% | mlx-lm: 200.59; only 41 tokens |
+| hunyuan_v1_dense | Hunyuan-1.8B-Instruct-4bit | ✅ | 277.87 | 188.41 | 94% | mlx-lm: 200.59; only 41 tokens |
 | kimi_linear | - | ⏳ | - | - | - | Kimi linear attention (Moonshot) |
 | step3p5 | - | ⏳ | - | - | - | Step 3.5 (StepFun) |
 
@@ -172,62 +172,62 @@ Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-lm | Notes |
 |-------|------------|--------|---------|--------|-----------|-------|
-| ministral3 | Ministral-3B-Instruct-4bit | ✅ | 888.69 | 145.06 | 91% | mlx-lm: 159.34; VLM wrapper; text-only mode; only 34 tokens |
+| ministral3 | Ministral-3B-Instruct-4bit | ✅ | 904.59 | 144.52 | 91% | mlx-lm: 159.34; VLM wrapper; text-only mode; only 34 tokens |
 | mistral4 | - | ⏳ | - | - | - | MLA + MoE; implemented but no MLX model available |
 | moondream3 | moondream3-preview-4bit | ⚠️ | - | 8.45 | - | mlx-lm: fails to load; text-only test; SigLIP + MLP; image output garbled; only 14 tokens |
 | longcat_flash | - | ⏳ | - | - | - | |
 | longcat_flash_ngram | - | ⏳ | - | - | - | |
-| mistral_small | mistral-small-3.1-24b-4bit | ✅ | 34.88 | 31.70 | 99% | mlx-lm: 31.97; text-only mode |
+| mistral_small | mistral-small-3.1-24b-4bit | ✅ | 33.87 | 32.07 | **100%** | mlx-lm: 31.97; text-only mode |
 
 ## Vision-Language Models (VLM)
 
 | Model | Test Model | Status | Prefill | Decode | vs mlx-vlm | Notes |
 |-------|------------|--------|---------|--------|------------|-------|
-| gemma3 | gemma-3-4b-it-4bit | ✅ | 218.56 | 85.61 | 91% | mlx-vlm: 93.79; SigLIP + AvgPool; 275 prompt, 16 gen |
-| gemma3n (E2B) | gemma-3n-E2B-it-4bit | ✅ | 771.46 | 72.38 | **122%** | mlx-vlm: 59.57; MobileNetV5 + MSFA; 273 prompt, 29 gen |
-| gemma3n (E4B bf16) | gemma-3n-E4B-it (bf16) | ✅ | 644.18 | 32.12 | 89% | mlx-vlm: 36.18; MobileNetV5 + MSFA; bf16 prefill path retune (PR #727); bf16; 273 prompt, 24 gen |
-| gemma3n (E4B 4bit) | gemma-3n-E4B-it-4bit | ✅ | 490.04 | 56.69 | **113%** | mlx-vlm: 50.00; 273 prompt, 33 gen |
-| gemma4 (E2B 4bit) | gemma-4-e2b-it-4bit | ✅ | 989.24 | 107.06 | **110%** | mlx-vlm: 97.19; 274 prompt, 100 gen |
-| gemma4 (E2B 8bit) | gemma-4-e2b-it-8bit | ✅ | 969.00 | 80.48 | 88% | mlx-vlm: 91.06; 274 prompt, 100 gen |
-| gemma4 (E4B 4bit) | gemma-4-e4b-it-4bit | ✅ | 561.68 | 72.91 | **104%** | mlx-vlm: 70.34; 274 prompt, 54 gen |
-| gemma4 (E4B 8bit) | gemma-4-e4b-it-8bit | ✅ | 534.96 | 54.83 | 87% | mlx-vlm: 63.25; 274 prompt, 35 gen |
-| gemma4 (31B 4bit) | gemma-4-31b-4bit | ✅ | 95.02 | 15.46 | 76% | mlx-vlm: 20.30; 274 prompt, 100 gen |
-| gemma4 (31B-it 4bit) | gemma-4-31b-it-4bit | ✅ | 99.07 | 18.32 | 93% | mlx-vlm: 19.78; 274 prompt, 100 gen |
-| gemma4 (26B A4B) | gemma-4-26b-a4b-it-4bit | ✅ | 476.14 | 63.18 | **103%** | mlx-vlm: 61.07; 277 prompt, 28 gen |
-| llava 1.5 | llava-1.5-7b-4bit | ✅ | 804.92 | 101.61 | - | CLIP + MLP; Vicuna-7b; 583 prompt, 100 gen; mlx-vlm requires PyTorch |
-| llava-interleave | llava-interleave-qwen-0.5b-bf16 | ✅ | 8589.48 | 269.86 | **120%** | mlx-vlm: 225.15; SigLIP + MLP; Qwen2-0.5b; 754 prompt, 36 gen |
-| llava-next | llava-v1.6-mistral-7b-4bit | ✅ | 748.12 | 105.41 | 96% | mlx-vlm: 109.51; CLIP + MLP; Mistral; 590 prompt, 100 gen; mlx-vlm template error |
-| llava-bunny | Bunny-Llama-3-8B-V-4bit | ✅ | 724.90 | 96.07 | - | mlx-vlm: FAIL; SigLIP + MLP; Llama3; 746 prompt, 37 gen |
-| llama4 | Llama-4-Scout-17B-16E-Instruct-4bit | ✅ | 194.61 | 31.73 | - | mlx-vlm: FAIL; 162 prompt, 100 gen |
-| aya-vision | aya-vision-8b | ✅ | 591.80 | 109.36 | **105%** | mlx-vlm: 103.74; SigLIP + SwiGLU; Cohere2; 176 prompt, 100 gen |
-| paligemma | paligemma2-3b (6-bit) | ⚠️ | 1571.48 | 45.09 | 64% | mlx-vlm: 70.45; SigLIP + Linear; Gemma2; 1032 prompt, only 2 gen tokens |
-| pixtral | pixtral-12b-4bit | ✅ | 473.22 | 59.17 | - | mlx-vlm: FAIL; Pixtral ViT; Mistral; 4102 prompt, 100 gen |
-| mistral3 | mistral-small-3.1-24b-4bit | ✅ | 144.54 | 29.69 | - | mlx-vlm: FAIL; Pixtral ViT + PatchMerger; Mistral; 3032 prompt, 100 gen; mlx-vlm error |
-| ministral3 | Ministral-3B-Instruct-4bit | ✅ | 891.57 | 123.91 | - | mlx-vlm: FAIL; Pixtral ViT; 3566 prompt, 100 gen |
-| phi3.5-vision | Phi-3.5-vision-instruct-4bit | ✅ | 960.85 | 117.63 | **127%** | mlx-vlm: 92.53; CLIP + HD tiling; Phi3; 773 prompt, 19 gen |
+| gemma3 | gemma-3-4b-it-4bit | ✅ | 241.77 | 87.01 | 93% | mlx-vlm: 93.79; SigLIP + AvgPool; 275 prompt, 16 gen |
+| gemma3n (E2B) | gemma-3n-E2B-it-4bit | ✅ | 771.21 | 72.83 | **122%** | mlx-vlm: 59.57; MobileNetV5 + MSFA; 273 prompt, 29 gen |
+| gemma3n (E4B bf16) | gemma-3n-E4B-it (bf16) | ✅ | 659.78 | 32.46 | 90% | mlx-vlm: 36.18; MobileNetV5 + MSFA; bf16 prefill path retune (PR #727); bf16; 273 prompt, 24 gen |
+| gemma3n (E4B 4bit) | gemma-3n-E4B-it-4bit | ✅ | 492.52 | 57.50 | **115%** | mlx-vlm: 50.00; 273 prompt, 33 gen |
+| gemma4 (E2B 4bit) | gemma-4-e2b-it-4bit | ✅ | 732.53 | 106.92 | **110%** | mlx-vlm: 97.19; 274 prompt, 100 gen |
+| gemma4 (E2B 8bit) | gemma-4-e2b-it-8bit | ✅ | 724.08 | 81.98 | 90% | mlx-vlm: 91.06; 274 prompt, 100 gen |
+| gemma4 (E4B 4bit) | gemma-4-e4b-it-4bit | ✅ | 460.74 | 75.15 | **107%** | mlx-vlm: 70.34; 274 prompt, 54 gen |
+| gemma4 (E4B 8bit) | gemma-4-e4b-it-8bit | ✅ | 455.71 | 56.16 | 89% | mlx-vlm: 63.25; 274 prompt, 35 gen |
+| gemma4 (31B 4bit) | gemma-4-31b-4bit | ✅ | 84.50 | 15.82 | 78% | mlx-vlm: 20.30; 274 prompt, 100 gen |
+| gemma4 (31B-it 4bit) | gemma-4-31b-it-4bit | ✅ | 88.04 | 18.86 | 95% | mlx-vlm: 19.78; 274 prompt, 100 gen |
+| gemma4 (26B A4B) | gemma-4-26b-a4b-it-4bit | ✅ | 288.28 | 66.40 | **109%** | mlx-vlm: 61.07; 277 prompt, 28 gen |
+| llava 1.5 | llava-1.5-7b-4bit | ✅ | 754.41 | 104.03 | - | CLIP + MLP; Vicuna-7b; 583 prompt, 100 gen; mlx-vlm requires PyTorch |
+| llava-interleave | llava-interleave-qwen-0.5b-bf16 | ✅ | 3961.62 | 265.57 | **118%** | mlx-vlm: 225.15; SigLIP + MLP; Qwen2-0.5b; 754 prompt, 36 gen |
+| llava-next | llava-v1.6-mistral-7b-4bit | ✅ | 715.00 | 107.17 | 98% | mlx-vlm: 109.51; CLIP + MLP; Mistral; 590 prompt, 100 gen; mlx-vlm template error |
+| llava-bunny | Bunny-Llama-3-8B-V-4bit | ✅ | 673.16 | 95.36 | - | mlx-vlm: FAIL; SigLIP + MLP; Llama3; 746 prompt, 37 gen |
+| llama4 | Llama-4-Scout-17B-16E-Instruct-4bit | ✅ | 180.73 | 35.88 | - | mlx-vlm: FAIL; 162 prompt, 100 gen |
+| aya-vision | aya-vision-8b | ✅ | 444.01 | 113.59 | **109%** | mlx-vlm: 103.74; SigLIP + SwiGLU; Cohere2; 176 prompt, 100 gen |
+| paligemma | paligemma2-3b (6-bit) | ⚠️ | 1477.45 | 50.25 | 71% | mlx-vlm: 70.45; SigLIP + Linear; Gemma2; 1032 prompt, only 2 gen tokens |
+| pixtral | pixtral-12b-4bit | ✅ | 447.97 | 60.25 | - | mlx-vlm: FAIL; Pixtral ViT; Mistral; 4102 prompt, 100 gen |
+| mistral3 | mistral-small-3.1-24b-4bit | ✅ | 128.84 | 29.72 | - | mlx-vlm: FAIL; Pixtral ViT + PatchMerger; Mistral; 3032 prompt, 100 gen; mlx-vlm error |
+| ministral3 | Ministral-3B-Instruct-4bit | ✅ | 526.95 | 125.75 | - | mlx-vlm: FAIL; Pixtral ViT; 3566 prompt, 100 gen |
+| phi3.5-vision | Phi-3.5-vision-instruct-4bit | ✅ | 991.67 | 122.63 | **133%** | mlx-vlm: 92.53; CLIP + HD tiling; Phi3; 773 prompt, 19 gen |
 | phi4mm | phi-4-multimodal-instruct (bf16) | ✅ | 571.90 | 25.42 | - | SigLIP + HD transform + AvgPool2d; Phi3; SuScaledRoPE + runtime LoRA; 2635 tokens; 12GB bf16 |
 | moondream3 | moondream3-preview-4bit | ⚠️ | 1.36 | 10.05 | - | SigLIP + MLP; image output garbled; only 63 tokens |
 | minicpm-o | MiniCPM-o-2_6-4bit | ✅ | 33.67 | 70.80 | - | SigLIP + Resampler; Qwen3; 80 tokens |
-| molmo | Molmo-7B | ✅ | 555.19 | 77.98 | - | CLIP ViT + attention pooling + OLMo text; mlx-vlm baseline is a 1-token anomaly; 327 prompt, 100 gen |
-| molmo2 | molmo2-4b | ✅ | 1011.99 | 59.36 | 98% | mlx-vlm: 60.87; fast SDPA vision encoder; 430 prompt, 100 gen |
-| internvl3 | InternVL3-1B | ✅ | 1760.25 | 225.51 | 85% | mlx-vlm: 264.40; InternViT + pixel-shuffle + Qwen2; 293 prompt, 8 gen |
-| nemotron-omni | Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | ✅ | 312.49 | 67.97 | - | mlx-vlm: FAIL; NEW (5-19); Mamba2+Transformer+MoE+Parakeet audio; 100 gen |
-| youtu-vl | youtu-vl-4b-instruct | ⚠️ | 569.47 | 24.19 | - | mlx-vlm: FAIL; NEW (5-19); only 1 gen token |
-| qwen2-vl | Qwen2-VL-2B-Instruct-4bit | ⚠️ | 527.90 | 0.00 | - | Custom ViT + MRoPE; text-only pass; VLM warmup failure |
-| qwen2.5-vl | Qwen2.5-VL-3B-Instruct-4bit | ✅ | 855.62 | 97.51 | - | Windowed ViT + MRoPE; 91 prompt, 46 gen; mlx-vlm requires PyTorch |
-| qwen3-vl | Qwen3-VL-2B-Instruct-4bit | ✅ | 353.61 | 170.02 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
-| qwen3-vl (4B) | Qwen3-VL-4B-Instruct-4bit | ✅ | 235.74 | 94.30 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
-| qwen3-vl (8B) | Qwen3-VL-8B-Instruct-4bit | ✅ | 174.56 | 66.15 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
-| qwen3-vl (32B) | Qwen3-VL-32B-Instruct-4bit | ✅ | 52.91 | 18.69 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
-| qwen3-vl-moe | Qwen3-VL-30B-A3B-Instruct-4bit | ✅ | 166.66 | 26.39 | - | mlx-vlm: FAIL; MoE (128 experts) + DeepStack (PR #729); 100 gen |
-| qwen3.5-vl (0.8B) | qwen3.5-0.8B-4bit | ✅ | 348.40 | 202.24 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 53 gen |
-| qwen3.5-vl (2B) | qwen3.5-2B-4bit | ✅ | 440.76 | 178.21 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 58 gen |
-| qwen3.5-vl (4B) | qwen3.5-4B-4bit | ✅ | 259.33 | 93.67 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 30 gen |
-| qwen3.5-vl (9B 4bit) | qwen3.5-9B-4bit | ✅ | 172.50 | 71.85 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 62 gen |
-| qwen3.5-vl (9B bf16) | qwen3.5-9B (bf16) | ✅ | 160.80 | 30.74 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 78 gen; bf16 |
-| qwen3.5-vl (27B) | qwen3.5-27B-4bit | ✅ | 57.73 | 24.35 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 42 gen |
-| qwen3.5-vl-moe | qwen3.5-35B-A3B-4bit | ✅ | 233.93 | 71.20 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet + MoE VLM; 57 prompt, 47 gen; gated delta decode RMSNorm fix (PR #730) |
-| qwen3.6-vl-moe | qwen3.6-35B-A3B-4bit | ✅ | 227.36 | 68.03 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet + MoE VLM; 100 gen |
+| molmo | Molmo-7B | ✅ | 579.49 | 81.61 | - | CLIP ViT + attention pooling + OLMo text; mlx-vlm baseline is a 1-token anomaly; 327 prompt, 100 gen |
+| molmo2 | molmo2-4b | ✅ | 727.26 | 60.31 | 99% | mlx-vlm: 60.87; fast SDPA vision encoder; 430 prompt, 100 gen |
+| internvl3 | InternVL3-1B | ✅ | 1902.58 | 228.83 | 87% | mlx-vlm: 264.40; InternViT + pixel-shuffle + Qwen2; 293 prompt, 8 gen |
+| nemotron-omni | Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | ✅ | 263.15 | 69.37 | - | mlx-vlm: FAIL; NEW (5-19); Mamba2+Transformer+MoE+Parakeet audio; 100 gen |
+| youtu-vl | youtu-vl-4b-instruct | ⚠️ | 408.21 | 24.47 | - | mlx-vlm: FAIL; NEW (5-19); only 1 gen token |
+| qwen2-vl | Qwen2-VL-2B-Instruct-4bit | ✅ | 788.00 | 124.99 | - | Custom ViT + MRoPE; VLM image mode fixed (#749); 100 gen |
+| qwen2.5-vl | Qwen2.5-VL-3B-Instruct-4bit | ✅ | 599.48 | 97.81 | - | Windowed ViT + MRoPE; 91 prompt, 46 gen; mlx-vlm requires PyTorch |
+| qwen3-vl | Qwen3-VL-2B-Instruct-4bit | ✅ | 766.49 | 162.21 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
+| qwen3-vl (4B) | Qwen3-VL-4B-Instruct-4bit | ✅ | 490.85 | 90.14 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
+| qwen3-vl (8B) | Qwen3-VL-8B-Instruct-4bit | ✅ | 313.03 | 62.62 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
+| qwen3-vl (32B) | Qwen3-VL-32B-Instruct-4bit | ✅ | 92.07 | 17.92 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
+| qwen3-vl-moe | Qwen3-VL-30B-A3B-Instruct-4bit | ✅ | 296.81 | 40.88 | - | mlx-vlm: FAIL; MoE (128 experts) + DeepStack (PR #729); 100 gen |
+| qwen3.5-vl (0.8B) | qwen3.5-0.8B-4bit | ✅ | 946.46 | 233.81 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 53 gen |
+| qwen3.5-vl (2B) | qwen3.5-2B-4bit | ✅ | 546.64 | 172.92 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 58 gen |
+| qwen3.5-vl (4B) | qwen3.5-4B-4bit | ✅ | 332.57 | 100.46 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 30 gen |
+| qwen3.5-vl (9B 4bit) | qwen3.5-9B-4bit | ✅ | 196.03 | 74.05 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 62 gen |
+| qwen3.5-vl (9B bf16) | qwen3.5-9B (bf16) | ✅ | 279.39 | 32.74 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 78 gen; bf16 |
+| qwen3.5-vl (27B) | qwen3.5-27B-4bit | ✅ | 74.86 | 25.24 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 42 gen |
+| qwen3.5-vl-moe | qwen3.5-35B-A3B-4bit | ✅ | 274.14 | 70.22 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet + MoE VLM; 57 prompt, 47 gen; gated delta decode RMSNorm fix (PR #730) |
+| qwen3.6-vl-moe | qwen3.6-35B-A3B-4bit | ✅ | 274.13 | 66.80 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet + MoE VLM; 100 gen |
 | molmo-point | - | ⏳ | - | - | - | Molmo-Point (point detection); implemented but no MLX model available |
 
 **VLM test conditions**: Image: 224x224 PNG (test_image.png) unless noted. Prompt: "What is in this image?" Max tokens: 100. Prefill includes vision encoder + projector overhead. mlx-vlm baseline uses the `d85ca4d` dev checkout. mlxcel decode speed was measured with `mlxcel-bench-decode` (model load, warmup, and measured pass in one process). Models with unavailable or failed mlx-vlm runs are marked with "-" in the vs mlx-vlm column. Three text-only models (`deepseek-v3-4bit` 99GB, `minimax-m2-3bit` 93GB, `qwen3-next-480b-4bit` 251GB) skipped on this 128GB host per >65GB threshold. Two Gemma 3 VLM rows (gemma-3-4b-it-4bit, gemma3-4b-4bit) were measured with `--warmup-tokens 0` because the prepared 4D attention mask shape is single-use against the first prefill's KV cache offset. The three Gemma 3n VLM rows use the default warmup=20 path.
@@ -236,10 +236,10 @@ Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra
 
 | Status | Count |
 |--------|-------|
-| ✅ Pass | 117 (82 text + 35 VLM) |
-| ⚠️ Partial | 6 (2 text + 4 VLM) |
-| ❌ Fail | 6 (6 text + 0 VLM) |
-| ⏳ Pending / Skipped (>65GB) | 16 (13 text pending + 3 oversize skip) |
+| ✅ Pass | 120 (78 text + 42 VLM) |
+| ⚠️ Partial | 6 (3 text + 3 VLM) |
+| ❌ Fail | 2 (2 text + 0 VLM) |
+| ⏳ Pending / Skipped (>65GB) | 16 (12 text pending + 1 VLM pending + 3 oversize skip) |
 
 ## Performance Comparison
 
@@ -251,217 +251,217 @@ runtime comparison.
 
 | Mode | Comparable pairs | Median mlxcel/baseline | >=90% parity | >= baseline | Range |
 |------|-----------------:|-----------------------:|-------------:|------------:|------:|
-| Text vs mlx-lm | 73 | 97% | 65/73 (89%) | 20/73 (27%) | 47%-113% |
-| VLM vs mlx-vlm | 18 | 98% | 12/18 (67%) | 8/18 (44%) | 76%-127% |
+| Text vs mlx-lm | 74 | 99% | 64/74 (86%) | 35/74 (47%) | 47%-112% |
+| VLM vs mlx-vlm | 18 | 98% | 12/18 (67%) | 8/18 (44%) | 78%-133% |
 
 ### Representative decode wins
 
 | Model | mlxcel | Baseline | vs baseline |
 |-------|-------:|---------:|------------:|
-| qwen2.5-0.5b-4bit | 355.29 | 315.48 | **113%** |
-| phi-3.5-moe-4bit | 74.41 | 69.28 | **107%** |
-| minicpm3-4b-4bit | 80.24 | 73.26 | **110%** |
-| smollm-135m-4bit | 407.36 | 375.91 | **108%** |
-| llava-interleave-qwen-0.5b-bf16 (VLM) | 269.86 | 225.15 | **120%** |
-| gemma3n-e2b-4bit (VLM) | 72.38 | 59.57 | **122%** |
-| gemma-4-e2b-it-4bit (VLM) | 107.06 | 97.19 | **110%** |
-| phi-3.5-vision-4bit (VLM) | 117.63 | 92.53 | **127%** |
+| qwen2.5-0.5b-4bit | 349.52 | 315.48 | **111%** |
+| phi-3.5-moe-4bit | 77.71 | 69.28 | **112%** |
+| minicpm3-4b-4bit | 80.78 | 73.26 | **110%** |
+| smollm-135m-4bit | 383.55 | 375.91 | **102%** |
+| llava-interleave-qwen-0.5b-bf16 (VLM) | 265.57 | 225.15 | **118%** |
+| gemma3n-e2b-4bit (VLM) | 72.83 | 59.57 | **122%** |
+| gemma-4-e2b-it-4bit (VLM) | 106.92 | 97.19 | **110%** |
+| phi-3.5-vision-4bit (VLM) | 122.63 | 92.53 | **133%** |
 
 ### Main optimization gaps
 
 | Model | mlxcel | Baseline | vs baseline | Notes |
 |-------|-------:|---------:|------------:|-------|
-| falcon-mamba-7b-4bit | 42.91 | 91.04 | 47% | Chat template causes early EOS; only 2 generated tokens |
-| qwen2.5-vl-3b-4bit (text path) | 98.53 | 160.42 | 61% | VLM wrapper text-only comparison |
-| qwen2-vl-2b-4bit (text path) | 150.02 | 236.86 | 63% | VLM wrapper text-only comparison |
-| gemma-4-31b-4bit (VLM) | 15.46 | 20.30 | 76% | large VLM path |
-| gemma-3-4b-it-4bit (VLM) | 85.61 | 97.36 | 88% | measured with warmup=0; see VLM test conditions |
+| falcon-mamba-7b-4bit | 42.83 | 91.04 | 47% | Chat template causes early EOS; only 2 generated tokens |
+| qwen2.5-vl-3b-4bit (text path) | 100.54 | 160.42 | 63% | VLM wrapper text-only comparison |
+| qwen2-vl-2b-4bit (text path) | 152.33 | 236.86 | 64% | VLM wrapper text-only comparison |
+| gemma-4-31b-4bit (VLM) | 15.82 | 20.30 | 78% | large VLM path |
+| gemma-3-4b-it-4bit (VLM) | 87.01 | 97.36 | 89% | measured with warmup=0; see VLM test conditions |
 
-## Performance vs mlx-lm / mlx-vlm baseline (2026-05-19, same-day sweep)
+## Performance vs mlx-lm / mlx-vlm baseline (mlxcel 2026-05-28 vs pinned 2026-05-19 reference)
 
-Source CSVs (same M1 Ultra host, mlxcel 0.0.28 with `--cooldown 0`; mlx-lm/mlx-vlm baselines from same 2026-05-19 sweep with `PYLM_BENCH_MAX_GB=65`):
+Source CSVs (same M1 Ultra host; mlxcel 0.1.0 measured 2026-05-28 with `--cooldown 0`; mlx-lm / mlx-vlm baselines from the pinned 2026-05-19 reference checkout with `PYLM_BENCH_MAX_GB=65`):
 
-- mlxcel: `benchmarks/metal_m1ultra_2026-05-19.csv`
+- mlxcel: `benchmarks/metal_m1ultra_2026-05-28.csv`
+- mlxcel VLM: `benchmarks/metal_m1ultra_vlm_2026-05-28.csv`
 - mlx-lm: `benchmarks/pylm_m1ultra_2026-05-19.csv` (mlx-lm 0.31.3 dev checkout in `references/mlx-lm` @ `df1d3f3`)
-- mlxcel VLM: `benchmarks/metal_m1ultra_vlm_2026-05-19.csv`
 - mlx-vlm: `benchmarks/pylm_m1ultra_vlm_2026-05-19.csv` (mlx-vlm dev checkout in `references/mlx-vlm` @ `d85ca4d`)
 
-All 4 sweeps use the same `--max-tokens 100`, same `Hello, how are you today?` / `What is in this image?` prompts, and the same >65GB skip threshold (deepseek-v3-4bit, minimax-m2-3bit, qwen3-next-480b-4bit excluded from both sides).
+The mlx-lm / mlx-vlm baselines are the pinned 2026-05-19 reference checkout (the reference is fixed, so its decode on this host is stable); the mlxcel side is the 2026-05-28 full sweep. All sweeps use `--max-tokens 100` and the same `Hello, how are you today?` / `What is in this image?` prompts. `deepseek-v3-4bit` and `qwen3-next-480b-4bit` exceed the 128GB host on both sides; `minimax-m2-3bit` now fits and runs on the mlxcel side (32.62 tok/s) but mlx-lm still fails it, so it stays outside the comparable set.
 
 Numbers are decode tok/s. `mlxcel vs mlx-lm` is `mlxcel / mlx-lm` as a percentage; **bold** = mlxcel >= mlx-lm. `FAIL` cells are real load/runtime errors on that backend with this configuration. The mlx-lm checkout used here (`df1d3f3` — "Fix Gemma 4 sanitize() not stripping KV projections for shared layers" #1240) is newer than the M5 Max page's `ed1fca4`, so some FAIL categories differ.
 
 ### Aggregate (text)
 
-- **Comparable text pairs**: 73
-- **mlxcel >= mlx-lm**: 20 / 73 (27%)
-- **mlxcel >= 90% parity**: 66 / 73 (90%)
-- **Average mlxcel/mlx-lm**: 96% (median 97%, range 47%-113%)
+- **Comparable text pairs**: 74
+- **mlxcel >= mlx-lm**: 35 / 74 (47%)
+- **mlxcel >= 90% parity**: 64 / 74 (86%)
+- **Average mlxcel/mlx-lm**: 97% (median 99%, range 47%-112%)
 
 ### Aggregate (VLM, models with >=5 generated tokens both sides)
 
 - **Comparable VLM pairs**: 18
 - **mlxcel >= mlx-vlm**: 8 / 18 (44%)
 - **mlxcel >= 90% parity**: 12 / 18 (67%)
-- **Average mlxcel/mlx-vlm**: 99% (median 98%, range 76%-127%)
+- **Average mlxcel/mlx-vlm**: 101% (median 98%, range 78%-133%)
 
 ### Text decode (tok/s)
 
 | Model | mlxcel | mlx-lm | mlxcel vs mlx-lm |
 |-------|--------|--------|------------------|
-| Meta-Llama-3.1-8B-Instruct-4bit | 106.61 | 109.84 | 97% |
-| Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | 83.29 | FAIL | - |
-| Qwen2.5-1.5B-4bit | 241.44 | 241.41 | **100%** |
-| Qwen2.5-1.5B-Instruct-4bit | 240.24 | 239.20 | **100%** |
-| Qwen2.5-7B-Instruct-4bit | 110.67 | 110.90 | 100% |
+| Meta-Llama-3.1-8B-Instruct-4bit | 109.58 | 109.84 | 100% |
+| Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | 87.56 | FAIL | - |
+| Qwen2.5-1.5B-4bit | 244.93 | 241.41 | **101%** |
+| Qwen2.5-1.5B-Instruct-4bit | 243.11 | 239.20 | **102%** |
+| Qwen2.5-7B-Instruct-4bit | 112.68 | 110.90 | **102%** |
 | Qwen3.5-0.8B-OptiQ-4bit | FAIL | 265.86 | - |
-| aya-expanse-8b-4bit | 107.30 | 112.74 | 95% |
-| aya-vision-8b | 109.57 | FAIL | - |
-| baichuan-m1-14b-4bit | 40.32 | 49.11 | 82% |
-| bunny-llama3-8b-4bit | 102.29 | FAIL | - |
-| command-r7b-4bit | 110.22 | 107.75 | **102%** |
-| deepseek-coder-1.3b-4bit | 164.77 | FAIL | - |
-| deepseek-r1-distill-7b-4bit | 110.82 | 111.34 | 100% |
-| deepseek-v2-lite-4bit | 111.86 | 117.06 | 96% |
+| aya-expanse-8b-4bit | 110.58 | 112.74 | 98% |
+| aya-vision-8b | 112.84 | FAIL | - |
+| baichuan-m1-14b-4bit | 40.13 | 49.11 | 82% |
+| bunny-llama3-8b-4bit | 105.55 | FAIL | - |
+| command-r7b-4bit | 114.34 | 107.75 | **106%** |
+| deepseek-coder-1.3b-4bit | 165.72 | FAIL | - |
+| deepseek-r1-distill-7b-4bit | 113.52 | 111.34 | **102%** |
+| deepseek-v2-lite-4bit | 112.45 | 117.06 | 96% |
 | deepseek-v3-4bit | - | FAIL | - |
-| ernie-4.5-0.3b-4bit | 526.70 | FAIL | - |
-| exaone-3.5-2.4b-4bit | 199.04 | 194.65 | **102%** |
-| exaone4-1.2b-4bit | 252.36 | FAIL | - |
-| falcon-mamba-7b-4bit | 42.91 | 91.04 | 47% |
-| gemma-2b-4bit | 189.91 | 207.78 | 91% |
-| gemma-3-4b-it-4bit | 113.61 | 109.72 | **104%** |
-| gemma-4-26b-a4b-it-4bit | 73.18 | 72.52 | **101%** |
-| gemma-4-31b-4bit | 20.15 | 20.36 | 99% |
-| gemma-4-31b-it-4bit | 19.06 | 20.23 | 94% |
-| gemma-4-e2b-it-4bit | 116.08 | FAIL | - |
-| gemma-4-e2b-it-8bit | 87.42 | FAIL | - |
-| gemma-4-e4b-it-4bit | 81.88 | FAIL | - |
-| gemma-4-e4b-it-8bit | 59.35 | FAIL | - |
-| gemma2-2b-4bit | 163.85 | 153.50 | **107%** |
-| gemma3-1b-4bit | 225.75 | 211.50 | **107%** |
-| gemma3-4b-4bit | 112.95 | 109.48 | **103%** |
-| gemma3n-e2b-4bit | 76.86 | FAIL | - |
-| gemma3n-e4b-4bit | 60.18 | FAIL | - |
-| gemma3n-e4b-bf16 | 35.65 | 39.02 | 91% |
-| glm4-flash-4bit | 47.32 | 49.47 | 96% |
-| gpt-oss-120b-4bit | 58.89 | 57.58 | **102%** |
-| gpt-oss-20b-mxfp4 | 88.89 | 89.51 | 99% |
-| hunyuan-1.8b-4bit | 182.98 | 200.59 | 91% |
-| hunyuan-large-4bit | 44.22 | FAIL | - |
-| internlm2-7b-4bit | 107.52 | 111.92 | 96% |
-| internlm3-8b-4bit | 86.88 | FAIL | - |
-| jamba-v0.1-4bit | 119.33 | 131.04 | 91% |
-| llama-3.1-8b-4bit | 107.23 | 110.66 | 97% |
-| llama-3.1-8b-bf16 | 35.15 | 35.32 | 100% |
-| llama-3.2-1b-4bit | 377.90 | 418.25 | 90% |
-| llama-4-scout-17b-4bit | 35.21 | FAIL | - |
-| llava-1.5-7b-4bit | 115.94 | FAIL | - |
-| llava-interleave-qwen-0.5b-bf16 | 314.17 | FAIL | - |
-| llava-next-mistral-7b-4bit | 113.47 | FAIL | - |
-| mamba2-1.3b-4bit | 102.63 | FAIL | - |
-| mimo-7b-4bit | 85.28 | 86.17 | 99% |
-| minicpm-2b-4bit | 163.05 | 156.47 | **104%** |
-| minicpm3-4b-4bit | 80.24 | 73.26 | **110%** |
-| minimax-m2-3bit | - | FAIL | - |
-| ministral-3b-4bit | 145.06 | 159.34 | 91% |
-| mistral-small-3.1-24b-4bit | 31.70 | 31.97 | 99% |
-| mixtral-8x7b-4bit | 53.62 | 54.91 | 98% |
-| molmo2-4b | 59.67 | FAIL | - |
-| nemotron-h-30b-4bit | 90.25 | 93.34 | 97% |
-| nemotron-nas-30b-4bit | 90.67 | 92.93 | 98% |
-| olmo-1b-4bit | 219.54 | FAIL | - |
-| olmo2-7b-4bit | 103.66 | 110.88 | 93% |
-| olmo3-32b-4bit | 21.79 | 21.57 | **101%** |
+| ernie-4.5-0.3b-4bit | 510.17 | FAIL | - |
+| exaone-3.5-2.4b-4bit | 200.53 | 194.65 | **103%** |
+| exaone4-1.2b-4bit | 247.55 | FAIL | - |
+| falcon-mamba-7b-4bit | 42.83 | 91.04 | 47% |
+| gemma-2b-4bit | 194.67 | 207.78 | 94% |
+| gemma-3-4b-it-4bit | 117.12 | 109.72 | **107%** |
+| gemma-4-26b-a4b-it-4bit | 71.76 | 72.52 | 99% |
+| gemma-4-31b-4bit | 20.48 | 20.36 | **101%** |
+| gemma-4-31b-it-4bit | 19.61 | 20.23 | 97% |
+| gemma-4-e2b-it-4bit | 119.67 | FAIL | - |
+| gemma-4-e2b-it-8bit | 89.23 | FAIL | - |
+| gemma-4-e4b-it-4bit | 84.43 | FAIL | - |
+| gemma-4-e4b-it-8bit | 60.61 | FAIL | - |
+| gemma2-2b-4bit | 169.77 | 153.50 | **111%** |
+| gemma3-1b-4bit | 232.91 | 211.50 | **110%** |
+| gemma3-4b-4bit | 117.66 | 109.48 | **107%** |
+| gemma3n-e2b-4bit | 78.75 | FAIL | - |
+| gemma3n-e4b-4bit | 61.51 | FAIL | - |
+| gemma3n-e4b-bf16 | 34.96 | 39.02 | 90% |
+| glm4-flash-4bit | 47.92 | 49.47 | 97% |
+| gpt-oss-120b-4bit | 61.19 | 57.58 | **106%** |
+| gpt-oss-20b-mxfp4 | 93.46 | 89.51 | **104%** |
+| hunyuan-1.8b-4bit | 188.41 | 200.59 | 94% |
+| hunyuan-large-4bit | 45.22 | FAIL | - |
+| internlm2-7b-4bit | 110.98 | 111.92 | 99% |
+| internlm3-8b-4bit | 87.98 | FAIL | - |
+| jamba-v0.1-4bit | 123.65 | 131.04 | 94% |
+| llama-3.1-8b-4bit | 109.49 | 110.66 | 99% |
+| llama-3.1-8b-bf16 | 35.77 | 35.32 | **101%** |
+| llama-3.2-1b-4bit | 373.43 | 418.25 | 89% |
+| llama-4-scout-17b-4bit | 36.66 | FAIL | - |
+| llava-1.5-7b-4bit | 117.93 | FAIL | - |
+| llava-interleave-qwen-0.5b-bf16 | 320.61 | FAIL | - |
+| llava-next-mistral-7b-4bit | 116.03 | FAIL | - |
+| mamba2-1.3b-4bit | 101.13 | FAIL | - |
+| mimo-7b-4bit | 86.26 | 86.17 | **100%** |
+| minicpm-2b-4bit | 165.32 | 156.47 | **106%** |
+| minicpm3-4b-4bit | 80.78 | 73.26 | **110%** |
+| minimax-m2-3bit | 32.62 | FAIL | - |
+| ministral-3b-4bit | 144.52 | 159.34 | 91% |
+| mistral-small-3.1-24b-4bit | 32.07 | 31.97 | **100%** |
+| mixtral-8x7b-4bit | 54.66 | 54.91 | 100% |
+| molmo2-4b | 60.26 | FAIL | - |
+| nemotron-h-30b-4bit | 91.68 | 93.34 | 98% |
+| nemotron-nas-30b-4bit | 92.26 | 92.93 | 99% |
+| olmo-1b-4bit | 212.53 | FAIL | - |
+| olmo2-7b-4bit | 104.17 | 110.88 | 94% |
+| olmo3-32b-4bit | 22.14 | 21.57 | **103%** |
 | paligemma2-3b-6bit | 0.00 | FAIL | - |
-| phi-2-4bit | 59.62 | FAIL | - |
-| phi-3-mini-4bit | 167.27 | 171.36 | 98% |
-| phi-3.5-mini-4bit | 160.90 | 166.30 | 97% |
-| phi-3.5-moe-4bit | 74.41 | 69.28 | **107%** |
-| phi-3.5-vision-4bit | 160.16 | FAIL | - |
-| phi-4-4bit | 57.02 | 58.68 | 97% |
-| pixtral-12b-4bit | 68.90 | 69.49 | 99% |
-| qwen1.5-moe-a2.7b-4bit | 144.37 | 144.98 | 100% |
-| qwen2-vl-2b-4bit | 150.02 | 236.86 | 63% |
-| qwen2.5-0.5b-4bit | 355.29 | 315.48 | **113%** |
-| qwen2.5-7b-4bit | 109.77 | 111.38 | 99% |
-| qwen2.5-7b-8bit | 69.08 | 70.46 | 98% |
-| qwen2.5-vl-3b-4bit | 98.53 | 160.42 | 61% |
-| qwen3-0.6b-4bit | 295.09 | 299.61 | 98% |
-| qwen3-1.7b-4bit | 195.30 | 221.37 | 88% |
-| qwen3-30b-a3b-4bit | 71.07 | 70.18 | **101%** |
-| qwen3-4b-4bit | 120.70 | 123.92 | 97% |
-| qwen3-8b-4bit | 79.85 | 84.54 | 94% |
-| qwen3-moe-4bit | 71.47 | 69.67 | **103%** |
+| phi-2-4bit | 62.61 | FAIL | - |
+| phi-3-mini-4bit | 172.17 | 171.36 | **100%** |
+| phi-3.5-mini-4bit | 167.07 | 166.30 | **100%** |
+| phi-3.5-moe-4bit | 77.71 | 69.28 | **112%** |
+| phi-3.5-vision-4bit | 166.72 | FAIL | - |
+| phi-4-4bit | 58.83 | 58.68 | **100%** |
+| pixtral-12b-4bit | 70.97 | 69.49 | **102%** |
+| qwen1.5-moe-a2.7b-4bit | 147.24 | 144.98 | **102%** |
+| qwen2-vl-2b-4bit | 152.33 | 236.86 | 64% |
+| qwen2.5-0.5b-4bit | 349.52 | 315.48 | **111%** |
+| qwen2.5-7b-4bit | 113.30 | 111.38 | **102%** |
+| qwen2.5-7b-8bit | 71.15 | 70.46 | **101%** |
+| qwen2.5-vl-3b-4bit | 100.54 | 160.42 | 63% |
+| qwen3-0.6b-4bit | 284.03 | 299.61 | 95% |
+| qwen3-1.7b-4bit | 197.55 | 221.37 | 89% |
+| qwen3-30b-a3b-4bit | 70.60 | 70.18 | **101%** |
+| qwen3-4b-4bit | 121.42 | 123.92 | 98% |
+| qwen3-8b-4bit | 81.38 | 84.54 | 96% |
+| qwen3-moe-4bit | 72.17 | 69.67 | **104%** |
 | qwen3-next-480b-4bit | - | FAIL | - |
-| qwen3-vl-2b-4bit | 215.98 | 222.67 | 97% |
-| qwen3-vl-30b-a3b-4bit | 69.78 | 70.04 | 100% |
-| qwen3-vl-32b-4bit | 20.68 | 21.99 | 94% |
-| qwen3-vl-4b-4bit | 113.84 | 124.02 | 92% |
-| qwen3-vl-8b-4bit | 79.36 | 84.46 | 94% |
-| qwen3.5-0.8b-4bit | 243.32 | 269.52 | 90% |
-| qwen3.5-27b-4bit | 24.25 | 25.93 | 94% |
-| qwen3.5-2b-4bit | 172.05 | 211.68 | 81% |
-| qwen3.5-35b-a3b-4bit | 72.05 | 76.44 | 94% |
-| qwen3.5-4b-4bit | 95.76 | 115.60 | 83% |
-| qwen3.5-9b-4bit | 72.36 | 81.27 | 89% |
-| qwen3.5-9b-bf16 | 31.28 | 34.22 | 91% |
-| qwen3.6-35b-a3b-4bit | 68.77 | 73.18 | 94% |
-| smollm-135m-4bit | 407.36 | 375.91 | **108%** |
-| smollm3-3b-4bit | 136.34 | 141.66 | 96% |
-| solar-open-100b-4bit | 35.88 | 35.69 | **101%** |
-| stablelm-1.6b-4bit | 280.32 | 280.65 | 100% |
-| starcoder2-3b-4bit | 171.30 | 166.17 | **103%** |
+| qwen3-vl-2b-4bit | 214.75 | 222.67 | 96% |
+| qwen3-vl-30b-a3b-4bit | 70.74 | 70.04 | **101%** |
+| qwen3-vl-32b-4bit | 21.25 | 21.99 | 97% |
+| qwen3-vl-4b-4bit | 119.23 | 124.02 | 96% |
+| qwen3-vl-8b-4bit | 81.34 | 84.46 | 96% |
+| qwen3.5-0.8b-4bit | 244.18 | 269.52 | 91% |
+| qwen3.5-27b-4bit | 24.52 | 25.93 | 95% |
+| qwen3.5-2b-4bit | 179.54 | 211.68 | 85% |
+| qwen3.5-35b-a3b-4bit | 71.38 | 76.44 | 93% |
+| qwen3.5-4b-4bit | 102.31 | 115.60 | 89% |
+| qwen3.5-9b-4bit | 72.75 | 81.27 | 90% |
+| qwen3.5-9b-bf16 | 31.85 | 34.22 | 93% |
+| qwen3.6-35b-a3b-4bit | 70.36 | 73.18 | 96% |
+| smollm-135m-4bit | 383.55 | 375.91 | **102%** |
+| smollm3-3b-4bit | 137.92 | 141.66 | 97% |
+| solar-open-100b-4bit | 36.26 | 35.69 | **102%** |
+| stablelm-1.6b-4bit | 285.79 | 280.65 | **102%** |
+| starcoder2-3b-4bit | 172.82 | 166.17 | **104%** |
 | youtu-vl-4b-instruct | 0.00 | FAIL | - |
 
 ### VLM decode (tok/s)
 
 | Model | mlxcel | mlx-vlm | mlxcel vs mlx-vlm |
 |-------|--------|--------|------------------|
-| Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | 67.97 | FAIL | - |
-| aya-vision-8b | 109.36 | 103.74 | **105%** |
-| bunny-llama3-8b-4bit | 96.07 | FAIL | - |
+| Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | 69.37 | FAIL | - |
+| aya-vision-8b | 113.59 | 103.74 | **109%** |
+| bunny-llama3-8b-4bit | 95.36 | FAIL | - |
 | deepseek-v3-4bit | - | FAIL | - |
-| gemma-3-4b-it-4bit | 85.61 | 97.36 | 88% |
-| gemma-4-26b-a4b-it-4bit | 63.18 | 61.07 | **103%** |
-| gemma-4-31b-4bit | 15.46 | 20.30 | 76% |
-| gemma-4-31b-it-4bit | 18.32 | 19.78 | 93% |
-| gemma-4-e2b-it-4bit | 107.06 | 97.19 | **110%** |
-| gemma-4-e2b-it-8bit | 80.48 | 91.06 | 88% |
-| gemma-4-e4b-it-4bit | 72.91 | 70.34 | **104%** |
-| gemma-4-e4b-it-8bit | 54.83 | 63.25 | 87% |
-| gemma3-4b-4bit | 86.97 | 93.79 | 93% |
-| gemma3n-e2b-4bit | 72.38 | 59.57 | **122%** |
-| gemma3n-e4b-4bit | 56.69 | 50.00 | **113%** |
-| gemma3n-e4b-bf16 | 32.12 | 36.18 | 89% |
-| internvl3-1b | 225.51 | 264.40 | 85% |
-| llama-4-scout-17b-4bit | 31.73 | FAIL | - |
-| llava-1.5-7b-4bit | 101.61 | FAIL | - |
-| llava-interleave-qwen-0.5b-bf16 | 269.86 | 225.15 | **120%** |
-| llava-next-mistral-7b-4bit | 105.41 | 109.51 | 96% |
+| gemma-3-4b-it-4bit | 87.01 | 97.36 | 89% |
+| gemma-4-26b-a4b-it-4bit | 66.40 | 61.07 | **109%** |
+| gemma-4-31b-4bit | 15.82 | 20.30 | 78% |
+| gemma-4-31b-it-4bit | 18.86 | 19.78 | 95% |
+| gemma-4-e2b-it-4bit | 106.92 | 97.19 | **110%** |
+| gemma-4-e2b-it-8bit | 81.98 | 91.06 | 90% |
+| gemma-4-e4b-it-4bit | 75.15 | 70.34 | **107%** |
+| gemma-4-e4b-it-8bit | 56.16 | 63.25 | 89% |
+| gemma3-4b-4bit | 83.74 | 93.79 | 89% |
+| gemma3n-e2b-4bit | 72.83 | 59.57 | **122%** |
+| gemma3n-e4b-4bit | 57.50 | 50.00 | **115%** |
+| gemma3n-e4b-bf16 | 32.46 | 36.18 | 90% |
+| internvl3-1b | 228.83 | 264.40 | 87% |
+| llama-4-scout-17b-4bit | 35.88 | FAIL | - |
+| llava-1.5-7b-4bit | 104.03 | FAIL | - |
+| llava-interleave-qwen-0.5b-bf16 | 265.57 | 225.15 | **118%** |
+| llava-next-mistral-7b-4bit | 107.17 | 109.51 | 98% |
 | minimax-m2-3bit | - | FAIL | - |
-| ministral-3b-4bit | 123.91 | FAIL | - |
-| mistral-small-3.1-24b-4bit | 29.69 | FAIL | - |
-| molmo-7b | 77.98 | 38399.52 (anomalous) | - |
-| molmo2-4b | 59.36 | 60.87 | 98% |
-| paligemma2-3b-6bit | 45.09 | 70.45 | 64% |
-| phi-3.5-vision-4bit | 117.63 | 92.53 | **127%** |
-| pixtral-12b-4bit | 59.17 | FAIL | - |
-| qwen2-vl-2b-4bit | 0.00 | FAIL | - |
-| qwen2.5-vl-3b-4bit | 97.51 | FAIL | - |
+| ministral-3b-4bit | 125.75 | FAIL | - |
+| mistral-small-3.1-24b-4bit | 29.72 | FAIL | - |
+| molmo-7b | 81.61 | 38399.52 (anomalous) | - |
+| molmo2-4b | 60.31 | 60.87 | 99% |
+| paligemma2-3b-6bit | 50.25 | 70.45 | 71% |
+| phi-3.5-vision-4bit | 122.63 | 92.53 | **133%** |
+| pixtral-12b-4bit | 60.25 | FAIL | - |
+| qwen2-vl-2b-4bit | 124.99 | FAIL | - |
+| qwen2.5-vl-3b-4bit | 97.81 | FAIL | - |
 | qwen3-next-480b-4bit | - | FAIL | - |
-| qwen3-vl-2b-4bit | 170.02 | FAIL | - |
-| qwen3-vl-30b-a3b-4bit | 26.39 | FAIL | - |
-| qwen3-vl-32b-4bit | 18.69 | FAIL | - |
-| qwen3-vl-4b-4bit | 94.30 | FAIL | - |
-| qwen3-vl-8b-4bit | 66.15 | FAIL | - |
-| qwen3.5-0.8b-4bit | 202.24 | FAIL | - |
-| qwen3.5-27b-4bit | 24.35 | FAIL | - |
-| qwen3.5-2b-4bit | 178.21 | FAIL | - |
-| qwen3.5-35b-a3b-4bit | 71.20 | FAIL | - |
-| qwen3.5-4b-4bit | 93.67 | FAIL | - |
-| qwen3.5-9b-4bit | 71.85 | FAIL | - |
-| qwen3.5-9b-bf16 | 30.74 | FAIL | - |
-| qwen3.6-35b-a3b-4bit | 68.03 | FAIL | - |
-| youtu-vl-4b-instruct | 24.19 | FAIL | - |
+| qwen3-vl-2b-4bit | 162.21 | FAIL | - |
+| qwen3-vl-30b-a3b-4bit | 40.88 | FAIL | - |
+| qwen3-vl-32b-4bit | 17.92 | FAIL | - |
+| qwen3-vl-4b-4bit | 90.14 | FAIL | - |
+| qwen3-vl-8b-4bit | 62.62 | FAIL | - |
+| qwen3.5-0.8b-4bit | 233.81 | FAIL | - |
+| qwen3.5-27b-4bit | 25.24 | FAIL | - |
+| qwen3.5-2b-4bit | 172.92 | FAIL | - |
+| qwen3.5-35b-a3b-4bit | 70.22 | FAIL | - |
+| qwen3.5-4b-4bit | 100.46 | FAIL | - |
+| qwen3.5-9b-4bit | 74.05 | FAIL | - |
+| qwen3.5-9b-bf16 | 32.74 | FAIL | - |
+| qwen3.6-35b-a3b-4bit | 66.80 | FAIL | - |
+| youtu-vl-4b-instruct | 24.47 | FAIL | - |
 
 ## Comprehensive Validation (2026-03-10)
 
@@ -491,8 +491,8 @@ Ran all 80 local models (45GB threshold) to verify text/image generation.
 | Qwen3.5-4B-DFlash / Qwen3.5-27B-DFlash | Drafter checkpoint — not a standalone inference model | Low |
 | Qwen3.5-0.8B-OptiQ-4bit | Warmup failure on new OptiQ quant variant | Medium |
 | gemma-4-31B-it-assistant-bf16 | Drafter checkpoint — not a standalone inference model | Low |
-| falcon-mamba | Chat template causes early EOS (only 2 tokens); decode now 42.91 tok/s | Medium |
-| paligemma | Only 2 VLM gen tokens; decode is not comparable despite 45.09 tok/s measured | High |
+| falcon-mamba | Chat template causes early EOS (only 2 tokens); decode now 42.83 tok/s | Medium |
+| paligemma | Only 2 VLM gen tokens; decode is not comparable despite 50.25 tok/s measured | High |
 | youtu-vl-4b-instruct | NEW (5-19); VLM produces only 1 token; text-only produces 0 tokens | Medium |
 | llama4 | Repetitive output on long generations | Low |
 | moondream3 | Image output garbled; text-only works; needs reconstruct_from_crops | Medium |


### PR DESCRIPTION
docs: reflect the 2026-05-28 M1 Ultra re-benchmark in public docs

Mirror the internal 2026-05-28 M1 Ultra full sweep (mlxcel 0.1.0) into the public benchmark docs. mlx-lm / mlx-vlm baselines are unchanged; only mlxcel M1 Ultra figures and their ratios are refreshed.

- README: M1 Ultra column refreshed across both representative decode tables; the Phi-3.5-vision M5 VLM row corrected to its post-#743 value (169 tok/s, 106%).
- benchmark-report.md: M1 Ultra headline (text 74 pairs, 99% median, 64/74 at >=90%; VLM 18 pairs, 98% median, 12/18 at >=90%), M1 representative text + VLM rows, and the M1 prose figures.
- model_tests_m1ultra.md: full per-model M1 refresh with recomputed ratios, aggregate blocks (text avg 97% / median 99%; VLM avg 101% / median 98%), internvl3 now passing on M1, and summary statistics.
- index: M1 Ultra last-updated date set to 2026-05-28.

The cross-hardware quick table stays a labeled 2026-05-19 same-version snapshot, new internal/experimental models from the sweep are kept out of the public set, and the M1 prefill aggregate is unchanged (the sweep targeted decode).
