### PR TITLE
fix: chat_template.jinja downloader allow-list and base-model UX warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **`chat_template.jinja` is now downloaded** alongside the rest of the model snapshot. The downloader allow-list in `src/downloader/filters.rs::is_wanted_file` only accepted exact-name `chat_template` (no extension) plus the broader `*.json` / `*.safetensors` / `*.tiktoken` / `*.model` / constrained `*.txt` allowances, but the actual HuggingFace convention is `chat_template.jinja`. The file was being filtered out at download time, leaving `ChatTemplateProcessor::from_model_path`'s `chat_template.jinja` fallback dead and forcing the REPL into the raw-text path for any model that ships its template as a separate Jinja file (e.g. `mlx-community/gemma-4-e4b-it-4bit`). `is_wanted_file` now also accepts `*.jinja` files; the `is_safe_relative_path` and `is_explicitly_denied` guards still run before the allow-list so no new attack surface is opened (#132, PR #134).
+- **`mlxcel run` warning for models without a chat template is now actionable**: it states that the model is likely a base / non-instruction-tuned model, that chat replies will be incoherent or repetitive, suggests trying an `-it` (instruction-tuned) variant on the Hub (e.g. for `gemma-4-e4b-4bit`, try `gemma-4-e4b-it-4bit`), and explains how to proceed silently (`--no-chat-template`) or with one-shot completion (`mlxcel generate -p <prompt>`). The explicit `--no-chat-template` path remains completely silent (no regression) (#132, PR #134).
+
 ## [v0.1.0] - 2026-05-28
 
 ### Added

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -186,7 +186,15 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
             .flatten()
     };
     if processor.is_none() && !opts.no_chat_template {
-        eprintln!("Note: no chat template found for this model; sending raw text per turn.");
+        eprintln!("Note: this model ships no chat template and is likely a base (non-instruction-tuned) model.");
+        eprintln!("      Chat responses will likely be incoherent or repetitive — base models are not designed");
+        eprintln!("      for interactive conversation.");
+        eprintln!();
+        eprintln!("      Try an instruction-tuned variant instead. On the HuggingFace Hub these are typically");
+        eprintln!("      named with an \"-it\" suffix (e.g. for gemma-4-e4b-4bit, try gemma-4-e4b-it-4bit).");
+        eprintln!();
+        eprintln!("      To proceed without this warning: pass --no-chat-template (raw text mode, silent),");
+        eprintln!("      or use `mlxcel generate -p <prompt>` for one-shot text completion.");
     }
 
     // Build the SamplingConfig once via the shared assembly used by `generate`.

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -186,14 +186,24 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
             .flatten()
     };
     if processor.is_none() && !opts.no_chat_template {
-        eprintln!("Note: this model ships no chat template and is likely a base (non-instruction-tuned) model.");
-        eprintln!("      Chat responses will likely be incoherent or repetitive — base models are not designed");
+        eprintln!(
+            "Note: this model ships no chat template and is likely a base (non-instruction-tuned) model."
+        );
+        eprintln!(
+            "      Chat responses will likely be incoherent or repetitive — base models are not designed"
+        );
         eprintln!("      for interactive conversation.");
         eprintln!();
-        eprintln!("      Try an instruction-tuned variant instead. On the HuggingFace Hub these are typically");
-        eprintln!("      named with an \"-it\" suffix (e.g. for gemma-4-e4b-4bit, try gemma-4-e4b-it-4bit).");
+        eprintln!(
+            "      Try an instruction-tuned variant instead. On the HuggingFace Hub these are typically"
+        );
+        eprintln!(
+            "      named with an \"-it\" suffix (e.g. for gemma-4-e4b-4bit, try gemma-4-e4b-it-4bit)."
+        );
         eprintln!();
-        eprintln!("      To proceed without this warning: pass --no-chat-template (raw text mode, silent),");
+        eprintln!(
+            "      To proceed without this warning: pass --no-chat-template (raw text mode, silent),"
+        );
         eprintln!("      or use `mlxcel generate -p <prompt>` for one-shot text completion.");
     }
 

--- a/src/downloader/filters.rs
+++ b/src/downloader/filters.rs
@@ -69,6 +69,10 @@ pub fn is_wanted_file(path: &str) -> bool {
     if has_extension(base, "tiktoken") {
         return true;
     }
+    // HuggingFace ships chat templates as chat_template.jinja, not inlined JSON.
+    if has_extension(base, "jinja") {
+        return true;
+    }
     if has_extension(base, "model") {
         // sentencepiece tokenizer.model and friends.
         return true;

--- a/src/downloader/tests.rs
+++ b/src/downloader/tests.rs
@@ -170,6 +170,7 @@ fn allow_list_includes_configs_and_tokenizer_files() {
     assert!(is_wanted_file("preprocessor_config.json"));
     assert!(is_wanted_file("processor_config.json"));
     assert!(is_wanted_file("chat_template.json"));
+    assert!(is_wanted_file("chat_template.jinja"));
     assert!(is_wanted_file("merges.txt"));
     assert!(is_wanted_file("vocab.json"));
     assert!(is_wanted_file("vocab.txt"));


### PR DESCRIPTION
## Summary

Two stacked root causes that together produced garbage output when running `mlxcel run gemma-4-e4b-4bit`: the downloader silently dropped `chat_template.jinja` (so instruction-tuned models had no working template), and the UX warning for base models gave no actionable guidance.

## What changed

- `src/downloader/filters.rs` — Added `has_extension(base, "jinja")` to the extension allow-list, immediately after the `tiktoken` clause. HuggingFace ships chat templates as `chat_template.jinja`; the previous allow-list covered every other relevant extension but missed this one, so the file was silently filtered out during snapshot download. The `is_safe_relative_path` guard that runs first is unchanged; no new attack surface is opened.
- `src/downloader/tests.rs` — Added `assert!(is_wanted_file("chat_template.jinja"))` immediately after the existing `chat_template.json` assertion in `allow_list_includes_configs_and_tokenizer_files`.
- `src/commands/chat.rs` — Replaced the single-line `Note:` eprintln with an 8-line block that explains the base-model cause, warns that responses will be incoherent, names the `-it` suffix convention for instruction-tuned Hub variants, and tells the user to pass `--no-chat-template` for silent raw-text mode or `mlxcel generate -p` for one-shot completion. The `--no-chat-template` path remains completely silent.

## Side-effect: `src/server/chat_template.rs` fallback now fires

The loader at `src/server/chat_template.rs:80-89` already had a fallback that reads `chat_template.jinja` from the model directory. That fallback was dead code because the file was never downloaded. Once Sub-task A lands, the fallback starts working automatically for any model that ships its template this way — no changes to that file were needed or made.

## Verification

```
cargo check --lib --tests
# → Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 44s (0 errors)

cargo test --lib downloader::tests
# → running 46 tests
# → test result: ok. 45 passed; 0 failed; 1 ignored (live_download_smoke_test, expected)

cargo clippy --lib --tests -- -D warnings
# → Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 29s (0 warnings)
```

End-to-end download verification (Sub-task A.3 — actually re-downloading `mlx-community/gemma-4-e4b-it-4bit`, confirming `chat_template.jinja` lands in the model store, and confirming `mlxcel run` produces coherent multi-turn chat) is deferred to the reviewer / orchestrator. It requires network access and a full model download and is out of scope for this automated implementation step. Please run this verification before merging.

Closes #132
