### PR TITLE
fix: structured User/Assistant fallback when no chat template exists

### DIFF
--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -202,9 +202,10 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
         );
         eprintln!();
         eprintln!(
-            "      To proceed without this warning: pass --no-chat-template (raw text mode, silent),"
+            "      Falling back to a generic User/Assistant prompt format to mitigate echo loops."
         );
-        eprintln!("      or use `mlxcel generate -p <prompt>` for one-shot text completion.");
+        eprintln!("      For raw text mode without role markers, pass --no-chat-template;");
+        eprintln!("      for one-shot completion, use `mlxcel generate -p <prompt>`.");
     }
 
     // Build the SamplingConfig once via the shared assembly used by `generate`.
@@ -419,9 +420,21 @@ fn print_help() {
 
 /// Render the accumulated conversation into a model prompt.
 ///
-/// Uses the chat template when available (the exact path `generate` uses for a
-/// single user turn, generalized to the full transcript). Without a template
-/// (or with `--no-chat-template`) it concatenates the turns as plain text.
+/// Three paths, in priority order:
+///
+/// 1. `--no-chat-template` (explicit user opt-in) → [`concat_plaintext`]: raw
+///    content-only concatenation, no role markers. Mirrors the offline
+///    `generate --no-chat-template` mode for completion-style usage.
+/// 2. A chat template is present → [`ChatTemplateProcessor::apply`]: the exact
+///    path `generate` uses for a single turn, generalized to the full
+///    transcript. Template render failure falls back to (3).
+/// 3. No template found and the user did not opt out →
+///    [`concat_userassistant_fallback`]: a minimal `User:` / `Assistant:`
+///    pseudo-template (issue #133). A bare concatenation here leaves base
+///    models without any structural cue and they collapse into raw-text echo
+///    loops; labeling turns and cueing the next assistant turn substantially
+///    reduces that pathology without claiming to give base models
+///    chat-grade behavior.
 fn render_prompt(
     processor: Option<&ChatTemplateProcessor>,
     conversation: &[ChatMessage],
@@ -433,18 +446,58 @@ fn render_prompt(
     match processor {
         Some(p) => p
             .apply(conversation, None)
-            .unwrap_or_else(|_| concat_plaintext(conversation)),
-        None => concat_plaintext(conversation),
+            .unwrap_or_else(|_| concat_userassistant_fallback(conversation)),
+        None => concat_userassistant_fallback(conversation),
     }
 }
 
-/// Plain-text transcript fallback when no chat template is in play.
+/// Raw, role-less concatenation for the explicit `--no-chat-template` path
+/// (and template render-failure fallback when the user has opted into raw
+/// mode). One newline between turns, nothing else — mirrors offline
+/// `generate --no-chat-template` so completion-style usage is unaffected by
+/// the structured fallback added in issue #133.
 fn concat_plaintext(conversation: &[ChatMessage]) -> String {
     let mut out = String::new();
     for msg in conversation {
         out.push_str(&msg.content);
         out.push('\n');
     }
+    out
+}
+
+/// Generic `User:` / `Assistant:` pseudo-template fallback for models that
+/// ship no chat template (issue #133).
+///
+/// This is *not* a true chat template — no BOS/EOS markers, no model-specific
+/// special tokens — and the upstream `processor.is_none()` warning still
+/// fires telling the user the model is likely a base / non-instruction-tuned
+/// variant. The point is narrower: a bare content-only concatenation leaves
+/// the model without any structural cue and base models tend to collapse
+/// into echo loops where they parrot the user's last line indefinitely. A
+/// minimal role-labeled format with a trailing `Assistant:` cue (no newline)
+/// nudges the model to produce an assistant turn next instead of continuing
+/// to complete its own prompt.
+fn concat_userassistant_fallback(conversation: &[ChatMessage]) -> String {
+    let mut out = String::new();
+    for msg in conversation {
+        match msg.role.as_str() {
+            "user" => out.push_str("User: "),
+            "assistant" => out.push_str("Assistant: "),
+            "system" => out.push_str("System: "),
+            other => {
+                // Unknown role (e.g. "tool"): still mark it so the model has
+                // something to anchor on rather than silently merging it into
+                // the prior turn.
+                out.push_str(other);
+                out.push_str(": ");
+            }
+        }
+        out.push_str(&msg.content);
+        out.push_str("\n\n");
+    }
+    // No trailing newline: the bare `Assistant:` token is the cue that asks
+    // the model for an assistant turn next.
+    out.push_str("Assistant:");
     out
 }
 

--- a/src/commands/chat_tests.rs
+++ b/src/commands/chat_tests.rs
@@ -116,15 +116,56 @@ fn finalize_multiline_trims_and_detects_empty() {
 #[test]
 fn concat_plaintext_joins_turns_with_newlines() {
     let convo = vec![user("first"), assistant("second"), user("third")];
+    // `concat_plaintext` is the raw `--no-chat-template` path: content only,
+    // no role markers, one newline between turns.
     assert_eq!(concat_plaintext(&convo), "first\nsecond\nthird\n");
 }
 
 #[test]
-fn render_prompt_without_template_falls_back_to_plaintext() {
+fn user_assistant_fallback_labels_all_turns_and_cues_assistant() {
+    let convo = vec![user("hi"), assistant("hello"), user("again")];
+    let rendered = concat_userassistant_fallback(&convo);
+    assert_eq!(
+        rendered,
+        "User: hi\n\nAssistant: hello\n\nUser: again\n\nAssistant:"
+    );
+    // Trailing `Assistant:` without a newline is the cue that nudges the
+    // model to produce an assistant turn next instead of continuing the
+    // transcript with another `User:` line.
+    assert!(rendered.ends_with("Assistant:"));
+    assert!(!rendered.ends_with('\n'));
+}
+
+#[test]
+fn user_assistant_fallback_marks_unknown_roles_instead_of_dropping_them() {
+    let convo = vec![ChatMessage {
+        role: "tool".to_string(),
+        content: "result".to_string(),
+    }];
+    let rendered = concat_userassistant_fallback(&convo);
+    // Unknown role is preserved verbatim with the same `Role: ` pattern so
+    // the model can still anchor on a turn boundary.
+    assert!(rendered.starts_with("tool: result"));
+    assert!(rendered.ends_with("Assistant:"));
+}
+
+#[test]
+fn render_prompt_without_template_uses_user_assistant_fallback() {
     let convo = vec![user("hello")];
-    // No processor and not forced: plain-text fallback.
-    assert_eq!(render_prompt(None, &convo, false), "hello\n");
-    // `no_chat_template` forces plain-text even if a processor were present.
+    // No processor, not forced raw: structured User/Assistant fallback so
+    // base models do not collapse into echo loops (issue #133).
+    assert_eq!(
+        render_prompt(None, &convo, false),
+        "User: hello\n\nAssistant:"
+    );
+}
+
+#[test]
+fn render_prompt_no_chat_template_flag_uses_raw_concatenation() {
+    let convo = vec![user("hello")];
+    // Explicit `--no-chat-template` is the completion-style opt-in: raw
+    // concat, no role markers. The new structured fallback must not leak
+    // into this path.
     assert_eq!(render_prompt(None, &convo, true), "hello\n");
 }
 


### PR DESCRIPTION
## Summary

Complements PR #134 (issue #132) by improving the *fallback path* for models that ship no chat template, not just the warning text in front of it. Models without a `chat_template` field in `tokenizer_config.json` and no `chat_template.jinja` (typically base / non-instruction-tuned models) previously fell back to bare content-only concatenation in `concat_plaintext`, which left the model with no structural cue and let it collapse into echo loops — base models are completion models, and the most natural continuation of an unstructured prompt is to parrot the user's last line indefinitely (the exact symptom reported in #133).

#132 chose to address this from the avoidance side: warn the user that the model is likely a base variant and point at the `-it` counterpart. That stance is unchanged — the warning still fires, the suggested `-it` variant is still surfaced — but the fallback path that runs when a user proceeds anyway (or uses a model that simply has no `-it` variant) is now substantially less hostile.

Reporter's experiment in #133 already validated the direction: a manual `User:` / `Assistant:` fallback measurably reduced the echo behavior even on a base model.

## What changed

- `src/commands/chat.rs::render_prompt` — three paths, dispatched in priority order:
    - `--no-chat-template` (explicit user opt-in): unchanged. Raw `concat_plaintext`, no role markers — the offline `generate --no-chat-template` parallel for completion-style usage must not change.
    - Chat template present: unchanged. Template render failure now falls back to the structured form rather than raw concat, since by then we already know the user is in chat mode.
    - No template + not opted out: new `concat_userassistant_fallback`. Generic `User:` / `Assistant:` pseudo-template with a trailing `Assistant:` cue (no newline) that nudges the model to produce an assistant turn next instead of continuing its own prompt with another `User:` line.
- `concat_userassistant_fallback` labels `user` / `assistant` / `system` explicitly; unknown roles (e.g. `tool`) are preserved verbatim with the same `Role: ` pattern instead of silently merging into the prior turn.
- The upstream `processor.is_none()` warning still fires and still names base-model behavior as the underlying cause. Only the closing two lines change to describe what the fallback actually does now: `--no-chat-template` is now the documented escape hatch for raw concat, not just a way to silence the warning.

This is *not* a true chat template — no BOS/EOS markers, no model-specific special tokens — and the PR makes no claim that base models will suddenly do chat well. The point is narrower: removing the immediate echo-loop pathology so that proceeding past the warning is not actively user-hostile.

## What this does NOT change

- The 132/#134 warning still fires with the same base-model framing — users are not misled into thinking chat now works on base models.
- `--no-chat-template` semantics: raw concatenation, no role markers, no trailing cue. This stays the offline `generate --no-chat-template` parallel.
- The chat template path (`processor.is_some()`): identical render through `ChatTemplateProcessor::apply`.
- Multi-turn context handling: the full transcript is still re-rendered every turn; #133's reporter side note about "weak context retention" was the base model mimicking instruction-tuned refusal patterns, not a missing-history bug. The whole conversation has always been in the prompt.

## Tests

`src/commands/chat_tests.rs`:

- `concat_plaintext_joins_turns_with_newlines` — clarified as the `--no-chat-template` path.
- `user_assistant_fallback_labels_all_turns_and_cues_assistant` (new) — multi-turn render, pins the trailing `Assistant:` cue without a newline.
- `user_assistant_fallback_marks_unknown_roles_instead_of_dropping_them` (new) — `tool`-style fallback.
- `render_prompt_without_template_uses_user_assistant_fallback` (new) — implicit-fallback dispatch.
- `render_prompt_no_chat_template_flag_uses_raw_concatenation` (new) — pins that the explicit opt-in still gets raw concat.

## Verification

```
cargo fmt --check
cargo check --lib --tests --features metal,accelerate
cargo test --bin mlxcel --features metal,accelerate commands::chat
# → 14 passed; 0 failed
cargo clippy --bin mlxcel --features metal,accelerate --tests -- -D warnings
# → no warnings
```

End-to-end verification with `mlxcel run mlx-community/Qwen3.5-0.8B-4bit` (the exact model in #133) to confirm the echo pathology is gone is deferred to the reviewer. The expectation, matching the reporter's local experiment, is that responses to follow-up questions like `explain about the tc39 of ecma` no longer collapse into raw-text repetition; quality will still be limited by the model itself being a base model.

Closes #133