### PR TITLE
fix: make base-model warning's instruct advice family-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- **Base-model warning no longer presents `-it` as a universal instruction-tuned naming convention.** The warning `mlxcel run` / `mlxcel generate` prints when a model ships no chat template (added in PR #134) recommended trying a variant "named with an `-it` suffix" — but `-it` is the Gemma convention. For other families the advice was wrong: Llama and Qwen2.5 instruction-tuned checkpoints use `-Instruct`, and Qwen3 / Qwen3.5 use the plain repo name (with `-Base` marking the non-instruct variant), so a user running `Qwen3.5-0.8B-Base` was pointed at a non-existent `-it` repo instead of being told to drop `-Base`. The advice now names the per-family conventions (Gemma `-it`; Llama / Qwen2.5 `-Instruct`; Qwen3 / Qwen3.5 plain name vs. `-Base`). Base-model detection is unchanged — it keys on chat-template absence, never on the model name.
+
 ## [v0.1.2] - 2026-05-29
 
 ### Fixed

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -195,11 +195,15 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
         eprintln!("      for interactive conversation.");
         eprintln!();
         eprintln!(
-            "      Try an instruction-tuned variant instead. On the HuggingFace Hub these are typically"
+            "      Try an instruction-tuned variant instead. Naming conventions vary by family:"
         );
         eprintln!(
-            "      named with an \"-it\" suffix (e.g. for gemma-4-e4b-4bit, try gemma-4-e4b-it-4bit)."
+            "      Gemma uses an \"-it\" suffix (e.g. gemma-4-e4b-it-4bit); Llama and Qwen2.5 use"
         );
+        eprintln!(
+            "      \"-Instruct\"; Qwen3/Qwen3.5 use the plain name, with \"-Base\" marking the"
+        );
+        eprintln!("      non-instruct variant.");
         eprintln!();
         eprintln!(
             "      Falling back to a generic User/Assistant prompt format to mitigate echo loops."


### PR DESCRIPTION
## Summary

The no-chat-template warning that `mlxcel run` / the chat REPL prints when a model ships no chat template advised users to "try a variant named with an `-it` suffix". That is the **Gemma** naming convention only. For other families the advice was actively misleading: Llama and Qwen2.5 instruction-tuned checkpoints use `-Instruct`, and Qwen3 / Qwen3.5 use the plain repo name with `-Base` marking the *non*-instruct variant. So a user running `Qwen3.5-0.8B-Base` (the base sibling of this repo's own README test model `Qwen3.5-0.8B`) was pointed at a non-existent `-it` repo instead of simply being told to drop `-Base`.

The advice now states the per-family conventions:

- Gemma → `-it` suffix (e.g. `gemma-4-e4b-it-4bit`)
- Llama / Qwen2.5 → `-Instruct`
- Qwen3 / Qwen3.5 → plain name, with `-Base` marking the non-instruct variant

Base-model **detection** is unchanged — it keys on chat-template absence (`processor.is_none()`), never on the model name. Only the human-facing advice text changed.

## Changes

- `src/commands/chat.rs` — replace the `-it`-only advice block in the base-model warning with family-aware guidance.
- `CHANGELOG.md` — `[Unreleased] → Fixed` entry.

## Tests

- `cargo fmt --check` — clean.
- `cargo check --features metal,accelerate --bin mlxcel` — compiles. No test asserts the warning wording, so no test change is required.

## Related

Follow-up to the base-model warning introduced in #134 and the structured `User`/`Assistant` fallback in #136.
