### PR TITLE
chore: purge leaked mlxcel-internal issue/PR numbers from public source and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,5 +101,9 @@ jobs:
       # caught in review. Does not fail the build (a genuine lablup/mlxcel #N is
       # fine); run locally with STRICT=1 to gate. See CONTRIBUTING.md.
       - name: Flag unqualified cross-repository references
-        run: python3 scripts/ci/check_cross_repo_refs.py "origin/${{ github.base_ref }}"
+        # Pass the base ref via env (not interpolated into the shell) so a branch
+        # name can never reach shell parsing; the script reads BASE_REF as input.
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: python3 scripts/ci/check_cross_repo_refs.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,21 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  cross-repo-refs:
+    name: cross-repo refs
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      # Advisory: lists bare 3+-digit '#NNN' added on this PR so unqualified
+      # upstream refs (-> org/repo#NNN) and any leaked private-repo numbers are
+      # caught in review. Does not fail the build (a genuine lablup/mlxcel #N is
+      # fine); run locally with STRICT=1 to gate. See CONTRIBUTING.md.
+      - name: Flag unqualified cross-repository references
+        run: python3 scripts/ci/check_cross_repo_refs.py "origin/${{ github.base_ref }}"
+

--- a/.github/workflows/pipeline-parallel-ci.yml
+++ b/.github/workflows/pipeline-parallel-ci.yml
@@ -18,7 +18,7 @@ name: Pipeline Parallel CI
 #     runner lab are expected to be available on hosts tagged with
 #     `pp-three-host`.
 #
-# Out of scope (see issue #344):
+# Out of scope:
 #   - running the 3-host job on every PR
 #   - cross-OS matrices on the self-hosted path
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - README "Run a model" section now leads with the `mlxcel run` one-liner instead of the verbose explicit-download flow, and collapses the core verbs (`generate`, `serve`, `inspect`, `--estimate-memory`) into a single one-line-comment block. Store-root precedence, `-m` resolution rules, `--local-dir` / `--models-dir`, `MLXCEL_DEFAULT_ORG`, and the memory preflight env vars now live behind a single link to `docs/environment-variables.md` (which already documents them) and a compressed model-management paragraph. Net: README drops about 58 lines with no loss of documented behavior (#114).
 - M5 Max detailed table, README headline version, and the benchmark report method table refreshed to the 2026-05-27 full-sweep state on mlxcel 0.1.0. `internvl3-1b` now passes in both text (661 tok/s) and VLM (601 tok/s, ahead of mlx-vlm's 529 tok/s), raising the M5 Max pass count to 94. `paligemma2-3b-6bit` text decode is 168.83 tok/s and `qwen3-vl-30b-a3b-4bit` VLM is 56.38 tok/s over a 45-token sample. Aggregate parity statistics and the M1 Ultra / GB10 columns remain on the 2026-05-19 baseline campaign that was not re-run (#115).
 - M5 Max decode aggregates recomputed against the unchanged `mlx-lm` / `mlx-vlm` baselines (baselines unchanged, only mlxcel-derived ratios recomputed). Text decode average 98% to 99% (median 99%), 62 of 66 at >=90% parity; the benchmark report headline is corrected from the stale 58 of 66. VLM decode average 101% to 102%, median 100% to 101%, 22 comparable pairs (was 20), 18 of 22 at >=90% parity (coverage counts reflect internvl3). README decode tables add Gemma 2 2B (100%), Phi-3.5-mini (98%), Jamba (98%), and InternVL3 1B (114% vs mlx-vlm) (#127).
-- 2026-05-28 M1 Ultra full sweep mirrored into the public benchmark docs (mlxcel 0.1.0; `mlx-lm` / `mlx-vlm` baselines unchanged). README M1 Ultra column refreshed across both representative decode tables (Phi-3.5-vision M5 VLM row corrected to its post-#743 value, 169 tok/s, 106%); benchmark report headline updated to text 74 pairs / 99% median / 64 of 74 at >=90%, VLM 18 pairs / 98% median / 12 of 18 at >=90%; `model_tests_m1ultra.md` per-model refresh with aggregate blocks (text avg 97% / median 99%; VLM avg 101% / median 98%) and `internvl3` now passing on M1. The cross-hardware quick table stays a labeled 2026-05-19 same-version snapshot (#130).
+- 2026-05-28 M1 Ultra full sweep mirrored into the public benchmark docs (mlxcel 0.1.0; `mlx-lm` / `mlx-vlm` baselines unchanged). README M1 Ultra column refreshed across both representative decode tables (Phi-3.5-vision M5 VLM row corrected to its post- value, 169 tok/s, 106%); benchmark report headline updated to text 74 pairs / 99% median / 64 of 74 at >=90%, VLM 18 pairs / 98% median / 12 of 18 at >=90%; `model_tests_m1ultra.md` per-model refresh with aggregate blocks (text avg 97% / median 99%; VLM avg 101% / median 98%) and `internvl3` now passing on M1. The cross-hardware quick table stays a labeled 2026-05-19 same-version snapshot (#130).
 - Reword the v0.0.31 #86 entry in CHANGELOG.md and `debian/changelog` to match the GitHub release note. The fix landed at the batch scheduler level: a burst of concurrent VLM requests overwrote a single shared `per_layer_inputs` cell before prefill consumed it, reading the wrong sequence's tensor. The earlier wording described the symptom as a per-layer input shape issue, which understated the concurrency cause.
 
 ## [v0.0.31] - 2026-05-27
@@ -140,113 +140,113 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [v0.0.27] - 2026-05-16
 
 ### Added
-- **End-to-end speculative decoding for Gemma 4 MTP and Qwen 3.5 DFlash drafter families** (epic #633, #632). New `Drafter` trait + `DrafterKind` enum + `model_type` auto-detection (#624). Ported drafter components: `MaskedEmbedder` for Gemma 4 E2B / E4B (#627), drafter masks (bidirectional full + sliding-window) and `normalize_batched_shared_kv_states` helper (#628), `Gemma4AssistantDraftModel` (4-layer drafter + pre/post projections) (#626), and `DFlashDraftModel` (5-layer drafter + `DFlashAttention` + `DFlashKVCache`) (#635). Target-side hooks: Gemma 4 `return_hidden` / `return_shared_kv` / `rollback_speculative_cache` for MTP (#625); Qwen 3.5 `return_hidden` + `capture_layer_ids` + GDN-aware `rollback_speculative_cache` for DFlash (#634). Round loops: DFlash single-batch (#636), `MtpGenerator` single-batch (#629), batched DFlash with continuous batching + GDN-aware rollback (#637), and batched MTP with continuous batching + left-padding normalization (#631). Greedy-parity + perf benchmark scaffolding under `src/bin/speculative_bench.rs` (#632) and real-model byte-equality end-to-end tests (#685).
-- **Server speculative dispatch.** Speculative dispatch resolution and `MtpTarget` adapters wired into the inference server (#666); the assistant model paths now plug into the real `MaskedEmbedder` and `make_drafter_masks`; speculative dispatch is wired into the scheduler via per-request B=1 bursts (#670) and a B>1 batched path via `MtpBatchedGenerator` / `DFlashBatchedGenerator` (#684). Per-request properties propagated through the speculative-burst path: cancellation propagation through `MtpGenerator` / `DFlashGenerator` (#681), `token_history` threading through the speculative-burst first sample (#682), logprobs support (#686), thinking-budget enforcement (#687), and prompt-cache donate symmetric with the classic path (#680) and into the B>1 batched arm (#689).
-- **CLI:** `--draft-kind {dflash,mtp}` and `--draft-block-size` flags on both `mlxcel` and `mlxcel-server` (#630).
-- **OpenAI Responses API (Phase 1)** at `/v1/responses` for both binaries (#622, #623). New modules `responses_store`, `responses_translator`, `conversation_store`, `streaming_responses`, `routes/responses`, and request/response/stream type modules under `types/responses_*`. Implements conversation store with shared-LRU semantics, `response.created` / `response.in_progress` / `response.completed` SSE event stream, reasoning-trace forwarding, response cancellation, and four new CLI flags. User guide at `docs/responses-api.md`.
-- **APC block-level partial cache adoption in the scheduler** (issue #580). When Automatic Prefix Caching is enabled, a request whose prompt shares the first N blocks with a cached entry but diverges at block N+1 now reuses blocks 0..N and re-prefills only from the divergence boundary — rather than cold-prefilling the entire prompt. Three components: `DetachedKVCache::trim_to` and `DetachedCacheSet::truncate_to` in `mlxcel-core` perform per-layer KV tensor slicing on the detached handle (mirroring `KVCache::trim` semantics, covering FP16/INT8/Turbo4/Turbo4Delegated sidecars); the `PromptCacheStore` lookup relaxes the legacy "stored prefix must be fully contained in request" gate when APC is on, routing the actual common-prefix depth through the existing `apc_consistent_prefix_len` block-hash discriminator; and `Scheduler::try_adopt_cached_prefix` calls `truncate_to(matched_len)` before adoption when the lookup returns a sub-entry-length match. APC-off retains the pre-#580 behaviour bit-exactly. Wall-clock bench procedure on Apple Silicon documented in `docs/apc-partial-adoption-bench.md` (#580, #607).
-- **Nemotron H Nano Omni audio modality** (issue #582). Ports the Parakeet/Conformer sound encoder (`NemotronOmniSoundEncoder`), mel-spectrogram feature extractor (`NemotronOmniFeatureExtractor`), and audio projector (`NemotronOmniSoundProjection`) from the upstream `mlx-vlm` Python reference. The encoder implements depthwise/pointwise Conv2D subsampling, Transformer-XL relative positional encoding, multi-head self-attention with per-head u/v bias terms, a GLU+BatchNorm convolution module, and half-weight feed-forward blocks. Audio weights are loaded conditionally when `sound_config` is present in `config.json`; the loader applies the upstream `sanitize_audio_weights` transpose pass before population. The VLM runtime path (`generate_vlm`) accepts `--audio <wav>`, runs the feature extractor and encoder, merges the resulting token embeddings at `sound_context_token_id` slots, and interleaves them with vision tokens when both modalities are present. Bring-up procedure for Apple Silicon engineers documented in `docs/nemotron-h-nano-omni-audio-bringup.md` (#582, #609).
-- **`mlxcel download` / `mlxcel-server download` progress bars** (#648, #649). New `src/downloader/progress.rs` module provides terminal-aware suppression (`should_show_progress`), a `MultiProgress` factory, and 6 suppression unit tests. The downloader streams files via `reqwest` to a `NamedTempFile` and atomically renames into place; outer `stream_file` and inner `stream_to_tempfile` are split so the progress bar covers the network read and the rename is observable.
-- **Server `--max-kv-size` flag** matching llama-server, plus a tightened chat-completion response envelope (#618).
-- **Tokenizer support for multi-token think and tool-call sequences** so chat templates that emit `<think>` / `<tool_call>` across multiple BPE tokens stream and parse correctly (#590, #613).
+- **End-to-end speculative decoding for Gemma 4 MTP and Qwen 3.5 DFlash drafter families**. New `Drafter` trait + `DrafterKind` enum + `model_type` auto-detection. Ported drafter components: `MaskedEmbedder` for Gemma 4 E2B / E4B, drafter masks (bidirectional full + sliding-window) and `normalize_batched_shared_kv_states` helper, `Gemma4AssistantDraftModel` (4-layer drafter + pre/post projections), and `DFlashDraftModel` (5-layer drafter + `DFlashAttention` + `DFlashKVCache`). Target-side hooks: Gemma 4 `return_hidden` / `return_shared_kv` / `rollback_speculative_cache` for MTP; Qwen 3.5 `return_hidden` + `capture_layer_ids` + GDN-aware `rollback_speculative_cache` for DFlash. Round loops: DFlash single-batch, `MtpGenerator` single-batch, batched DFlash with continuous batching + GDN-aware rollback, and batched MTP with continuous batching + left-padding normalization. Greedy-parity + perf benchmark scaffolding under `src/bin/speculative_bench.rs` and real-model byte-equality end-to-end tests.
+- **Server speculative dispatch.** Speculative dispatch resolution and `MtpTarget` adapters wired into the inference server; the assistant model paths now plug into the real `MaskedEmbedder` and `make_drafter_masks`; speculative dispatch is wired into the scheduler via per-request B=1 bursts and a B>1 batched path via `MtpBatchedGenerator` / `DFlashBatchedGenerator`. Per-request properties propagated through the speculative-burst path: cancellation propagation through `MtpGenerator` / `DFlashGenerator`, `token_history` threading through the speculative-burst first sample, logprobs support, thinking-budget enforcement, and prompt-cache donate symmetric with the classic path and into the B>1 batched arm.
+- **CLI:** `--draft-kind {dflash,mtp}` and `--draft-block-size` flags on both `mlxcel` and `mlxcel-server`.
+- **OpenAI Responses API (Phase 1)** at `/v1/responses` for both binaries. New modules `responses_store`, `responses_translator`, `conversation_store`, `streaming_responses`, `routes/responses`, and request/response/stream type modules under `types/responses_*`. Implements conversation store with shared-LRU semantics, `response.created` / `response.in_progress` / `response.completed` SSE event stream, reasoning-trace forwarding, response cancellation, and four new CLI flags. User guide at `docs/responses-api.md`.
+- **APC block-level partial cache adoption in the scheduler**. When Automatic Prefix Caching is enabled, a request whose prompt shares the first N blocks with a cached entry but diverges at block N+1 now reuses blocks 0..N and re-prefills only from the divergence boundary — rather than cold-prefilling the entire prompt. Three components: `DetachedKVCache::trim_to` and `DetachedCacheSet::truncate_to` in `mlxcel-core` perform per-layer KV tensor slicing on the detached handle (mirroring `KVCache::trim` semantics, covering FP16/INT8/Turbo4/Turbo4Delegated sidecars); the `PromptCacheStore` lookup relaxes the legacy "stored prefix must be fully contained in request" gate when APC is on, routing the actual common-prefix depth through the existing `apc_consistent_prefix_len` block-hash discriminator; and `Scheduler::try_adopt_cached_prefix` calls `truncate_to(matched_len)` before adoption when the lookup returns a sub-entry-length match. APC-off retains the earlier behaviour bit-exactly. Wall-clock bench procedure on Apple Silicon documented in `docs/apc-partial-adoption-bench.md`.
+- **Nemotron H Nano Omni audio modality**. Ports the Parakeet/Conformer sound encoder (`NemotronOmniSoundEncoder`), mel-spectrogram feature extractor (`NemotronOmniFeatureExtractor`), and audio projector (`NemotronOmniSoundProjection`) from the upstream `mlx-vlm` Python reference. The encoder implements depthwise/pointwise Conv2D subsampling, Transformer-XL relative positional encoding, multi-head self-attention with per-head u/v bias terms, a GLU+BatchNorm convolution module, and half-weight feed-forward blocks. Audio weights are loaded conditionally when `sound_config` is present in `config.json`; the loader applies the upstream `sanitize_audio_weights` transpose pass before population. The VLM runtime path (`generate_vlm`) accepts `--audio <wav>`, runs the feature extractor and encoder, merges the resulting token embeddings at `sound_context_token_id` slots, and interleaves them with vision tokens when both modalities are present. Bring-up procedure for Apple Silicon engineers documented in `docs/nemotron-h-nano-omni-audio-bringup.md`.
+- **`mlxcel download` / `mlxcel-server download` progress bars**. New `src/downloader/progress.rs` module provides terminal-aware suppression (`should_show_progress`), a `MultiProgress` factory, and 6 suppression unit tests. The downloader streams files via `reqwest` to a `NamedTempFile` and atomically renames into place; outer `stream_file` and inner `stream_to_tempfile` are split so the progress bar covers the network read and the rename is observable.
+- **Server `--max-kv-size` flag** matching llama-server, plus a tightened chat-completion response envelope.
+- **Tokenizer support for multi-token think and tool-call sequences** so chat templates that emit `<think>` / `<tool_call>` across multiple BPE tokens stream and parse correctly.
 
 ### Changed
-- **`StreamFilter` extended** to handle multi-token markers and reset state when a partial marker is broken by a non-marker token (#613).
+- **`StreamFilter` extended** to handle multi-token markers and reset state when a partial marker is broken by a non-marker token.
 - **Speculative drafter epic follow-ups hardened** post-merge — covers misc invariants surfaced by integration testing against the real `z-lab/Qwen3.5-4B-DFlash` checkpoint and the `mlx-community/gemma-4-*` drafter variants.
-- **README and speculative decoding guidance refreshed** to match the current code paths and the latest M1 Ultra / M5 Max benchmarks (#700).
+- **README and speculative decoding guidance refreshed** to match the current code paths and the latest M1 Ultra / M5 Max benchmarks.
 
 ### Performance
 - **Qwen 3.5 DFlash greedy-argmax decode-path optimization** that drops the per-decode-step copy and an unnecessary argmax temporary, restoring decode tok/s on Qwen 3.5 32B / 9B DFlash configurations.
-- **Avoid slow Gemma 4 MTP singleton bursts** — the speculative-burst path now correctly short-circuits to the classic path when the batch size collapses to 1 with no draft tokens accepted, eliminating a per-step over-evaluation regression introduced by the initial dispatch wiring (#698).
+- **Avoid slow Gemma 4 MTP singleton bursts** — the speculative-burst path now correctly short-circuits to the classic path when the batch size collapses to 1 with no draft tokens accepted, eliminating a per-step over-evaluation regression introduced by the initial dispatch wiring.
 
 ### Fixed
-- **DFlash drafter lazy-bind** for the upstream `z-lab/Qwen3.5-4B-DFlash` checkpoint — `Drafter::bind` was previously not called on the DFlash family, causing an internal cache mis-binding on the first speculative burst. The drafter now performs lazy-bind on first use, matching the MTP path (#683).
-- **Enable DFlash for Qwen 3.5 VLM text requests** — pure-text generations against a Qwen 3.5 VLM checkpoint can now resolve a DFlash drafter when one is available, instead of silently falling back to the classic path (#694).
-- **Speculative-rollback safety:** validate trimmable cache and reserve the last token in prefill so a rolled-back speculative burst always lands on a valid sampling boundary (#612).
-- **Prompt cache RadixTrie:** `pop_prefixes` now uses correct immediate-prefix semantics (#617).
-- **MiniMax M2 parallel tool calling parser** correctly emits one `ChatToolCall` per parallel call instead of merging them into a single call (#616).
-- **Server tool-call buffering:** preserve token positions when buffering parallel tool calls (#615); skip the tool→normal transition when `tool_call_end` is empty so streaming continues correctly for templates without an explicit close marker (#614).
-- **`video_url` allowlist TOCTOU race** closed by passing the resolved `OwnedFd` to ffmpeg via `/dev/fd/N` instead of re-opening the path inside the subprocess. Symlink swaps between `metadata` and the subsequent open now cannot mis-route the subprocess. Audit hardening from #601 (#611).
-- **Gemma 4:** skip `k_proj` / `v_proj` / `k_norm` weight load for KV-shared layers — the previous load step would error out on real Gemma 4 E2B / E4B checkpoints that omit these tensors per KV-shared design (#608).
-- **Nemotron-H:** default `time_step_limit` to `(0.0, +inf)` regardless of `time_step_min` / `time_step_max` to match the upstream mlx-lm `time_step_limit` behaviour even when only one of the bounds is supplied (#619).
-- **`gated_delta` masked Metal kernel variants:** zero-init `y[dv_idx]` when the mask is false (#610).
-- Tests: add `max_kv_size` field to the `ServeArgs` test fixture (#620).
+- **DFlash drafter lazy-bind** for the upstream `z-lab/Qwen3.5-4B-DFlash` checkpoint — `Drafter::bind` was previously not called on the DFlash family, causing an internal cache mis-binding on the first speculative burst. The drafter now performs lazy-bind on first use, matching the MTP path.
+- **Enable DFlash for Qwen 3.5 VLM text requests** — pure-text generations against a Qwen 3.5 VLM checkpoint can now resolve a DFlash drafter when one is available, instead of silently falling back to the classic path.
+- **Speculative-rollback safety:** validate trimmable cache and reserve the last token in prefill so a rolled-back speculative burst always lands on a valid sampling boundary.
+- **Prompt cache RadixTrie:** `pop_prefixes` now uses correct immediate-prefix semantics.
+- **MiniMax M2 parallel tool calling parser** correctly emits one `ChatToolCall` per parallel call instead of merging them into a single call.
+- **Server tool-call buffering:** preserve token positions when buffering parallel tool calls; skip the tool→normal transition when `tool_call_end` is empty so streaming continues correctly for templates without an explicit close marker.
+- **`video_url` allowlist TOCTOU race** closed by passing the resolved `OwnedFd` to ffmpeg via `/dev/fd/N` instead of re-opening the path inside the subprocess. Symlink swaps between `metadata` and the subsequent open now cannot mis-route the subprocess. Audit hardening.
+- **Gemma 4:** skip `k_proj` / `v_proj` / `k_norm` weight load for KV-shared layers — the previous load step would error out on real Gemma 4 E2B / E4B checkpoints that omit these tensors per KV-shared design.
+- **Nemotron-H:** default `time_step_limit` to `(0.0, +inf)` regardless of `time_step_min` / `time_step_max` to match the upstream mlx-lm `time_step_limit` behaviour even when only one of the bounds is supplied.
+- **`gated_delta` masked Metal kernel variants:** zero-init `y[dv_idx]` when the mask is false.
+- Tests: add `max_kv_size` field to the `ServeArgs` test fixture.
 - Address upstream-sync review follow-ups carried over from the v0.0.26 sync cycle.
 
 ### Security
-- **Downloader security hardening** post-#649 (#650, #652): plaintext `HF_ENDPOINT` + token warning (M1), client connect / read timeouts (M2), URL path percent-encoding for `?` / `#` / `%` in filenames (L1), `O_NOFOLLOW` tempfile creation (L2), `Result`-based token-ASCII handling instead of `expect("token must be ASCII")` (L3), stale `.mlxcel-partial.*` cleanup at download start (L5), and parallel HEAD requests bounded by `buffer_unordered(8)` (L6).
-- **Closed the residual TOCTOU window in the `video_url` allowlist resolver** (issue #601, PR #611). The dominant canonicalise → ffmpeg-open race was already closed by passing an `OwnedFd` to ffmpeg via `/dev/fd/N`. This change hardens the narrowed metadata→open gap by opening every allowlisted video file with `O_NOFOLLOW`: a symlink swap that occurs between the `metadata` call and the `open` syscall now returns `ELOOP` instead of silently following the swapped-in link. Subprocesses continue to receive `/dev/fd/N` (never the path), so they cannot be misdirected post-open regardless. A startup warning is now also emitted on non-Unix targets when `MLXCEL_VIDEO_DIR_ALLOWLIST` is set, because `O_NOFOLLOW` and fd-passing are unavailable on those platforms.
+- **Downloader security hardening** post-plaintext `HF_ENDPOINT` + token warning (M1), client connect / read timeouts (M2), URL path percent-encoding for `?` / `#` / `%` in filenames (L1), `O_NOFOLLOW` tempfile creation (L2), `Result`-based token-ASCII handling instead of `expect("token must be ASCII")` (L3), stale `.mlxcel-partial.*` cleanup at download start (L5), and parallel HEAD requests bounded by `buffer_unordered(8)` (L6).
+- **Closed the residual TOCTOU window in the `video_url` allowlist resolver**. The dominant canonicalise → ffmpeg-open race was already closed by passing an `OwnedFd` to ffmpeg via `/dev/fd/N`. This change hardens the narrowed metadata→open gap by opening every allowlisted video file with `O_NOFOLLOW`: a symlink swap that occurs between the `metadata` call and the `open` syscall now returns `ELOOP` instead of silently following the swapped-in link. Subprocesses continue to receive `/dev/fd/N` (never the path), so they cannot be misdirected post-open regardless. A startup warning is now also emitted on non-Unix targets when `MLXCEL_VIDEO_DIR_ALLOWLIST` is set, because `O_NOFOLLOW` and fd-passing are unavailable on those platforms.
 
 ### CI
 - Bump GitHub Actions to Node 24 runtime to clear the Node 20 deprecation warning surfaced on the macOS runners.
 
 ### Chore
-- Replace `.map_or(false, ...)` with `.is_some_and(...)` in tokenizer call sites (clippy 1.93 lint clean-up) (#651).
+- Replace `.map_or(false, ...)` with `.is_some_and(...)` in tokenizer call sites (clippy 1.93 lint clean-up).
 
 ## [v0.0.26] - 2026-05-10
 
 ### Added
-- **TurboQuant KV cache.** New 3–4 bit KV cache compression family built on a Walsh–Hadamard transform op (#470) and a Lloyd-Max PolarQuant codebook generator ported to Rust (#472). Four KV cache modes wired through `KVCacheMode`: `Turbo4` symmetric with per-model allowlist (#476), `Turbo4Asym` Fp16-K + Turbo4-V (#474), `Turbo3Asym` 3-bit Fp16-K + Turbo3-V (#477), and `Turbo4Delegated` with a FP16 hot tail + packed turbo cold body (#479). TurboQuant + `RotatingKVCache` integration covers sliding-window attention (B9). Sparse-V dequant scaffolding (#480), Boundary-V layer protection that keeps the first/last layer at FP16 (#478), and a packed-aware `PagedKvLayout` (#482) round out the runtime. Quality gates: wikitext-2 PPL + NIAH harness (#475), full 283K-token test split fixture (#492), per-model PPL/NIAH results committed (#493), and VLM B3 quality gates with image-token kurtosis (#510). Speed gate matrix runner with M1 Ultra (#509) and M5 Max readings. User guide and validated config matrix published (#485).
-- **Server flag parity for KV quantization.** `--cache-type-k` and `--cache-type-v` flags accept `f16`, `q8_0`, `q4_0`, etc. matching llama-server semantics, with TurboQuant modes exposed as `mlxcel_turbo*` variants (#484). KV cache quantization extended to continuous batching (#545) and a unified `--kv-cache-mode` flag layout shared across `mlxcel`, `mlxcel-server`, and `mlxcel download` (#567).
-- **Automatic Prefix Caching (APC) with hash blocks** (#552). Hash-keyed block-table prefix reuse on top of v0.0.25's cross-sequence prompt-prefix KV cache, enabling shared physical blocks across requests with the same hashed prefix without per-request token-prefix matching cost.
-- **OpenAI-compatible `response_format: {"type": "json_schema", ...}`** structured-output support for `/v1/chat/completions` and `/v1/completions` (#550). Constrained decoding via `llguidance` (the same backend used by upstream mlx-vlm PR #1047) ensures every emitted token keeps the partial output conforming to the supplied schema. Per-request schema validation enforces a 64 KiB size cap, a 32-level nesting depth limit, and a 64-entry `$ref` count limit so an adversarial schema cannot exhaust CPU or memory during grammar compilation. The tokenizer environment is cached by SHA-256 fingerprint so consecutive requests to the same model share the build cost (~1–2 s for a 150k-vocab tokenizer). Reusable per-sequence `mask_buf` and `bias_buf` allocations eliminate per-token `Vec` allocation on the hot decode path. The legacy `json_object` mode is rejected with a clean 400 in this MVP; `json_schema` with a well-formed schema is the supported path. Supported on HuggingFace BPE tokenizers; SentencePiece and Tiktoken backends return a clean `UnsupportedTokenizer` error. Verbose llguidance internals are never surfaced in public error messages — they are routed to server-side tracing only.
-- **`mlxcel download` / `mlxcel-server download` subcommand** to fetch HuggingFace model repository snapshots without Python tooling (#457, #486). Uses `hf-hub` with an allow-list file filter (SafeTensors, tokenizer, and config files only), cache-hit detection, and formatted per-file progress output. Supports `--local-dir`, `--revision`, `--token`, and `--force`. Default destination mirrors the `models/<repo-basename>` convention from AGENTS.md.
-- **`/health` endpoint** now includes `context_size` (the configured `--ctx-size` value; `0` means model default) and `tool_call_parser` (`"mlxcel"` when the chat template exposes the `tools` variable, `null` otherwise) (#549, #572). Both fields are present once a model is loaded; `context_size` is absent while loading, `tool_call_parser` serializes as `null` during startup so monitoring clients can distinguish "template has no tool support" from "model not yet loaded". The tool-support heuristic is extracted into a shared `template_mentions_tools()` helper used by both the health route and the existing `compute_supports_tools` fallback path.
-- **Paged scheduler dispatch on `PagedKvLayout::cache_mode`** so the scheduler routes batches into the matching paged decode kernel for each KV cache mode (#508).
-- **Video input infrastructure for VLMs.** Gemma 4 video support with the new VLM video input pipeline (#553); ffmpeg-backed frame extraction with single-pass extraction and a `Drop` guard for cleanup of temporary frame files (#597); `video_url` content blocks wired through `/v1/chat/completions` (#596); content-preservation tests covering the frame extraction path (#598).
-- **New models.** Youtu-VL vision-language model (#555); Nemotron H Nano Omni vision (#554) plus follow-up correctness/validation hardening (#595).
-- Multi-task M1 Ultra benchmark refresh to 2026-05-08 (#577) and full M1 Ultra column resync in `benchmarks-by-hardware.md` (#578).
+- **TurboQuant KV cache.** New 3–4 bit KV cache compression family built on a Walsh–Hadamard transform op and a Lloyd-Max PolarQuant codebook generator ported to Rust. Four KV cache modes wired through `KVCacheMode`: `Turbo4` symmetric with per-model allowlist, `Turbo4Asym` Fp16-K + Turbo4-V, `Turbo3Asym` 3-bit Fp16-K + Turbo3-V, and `Turbo4Delegated` with a FP16 hot tail + packed turbo cold body. TurboQuant + `RotatingKVCache` integration covers sliding-window attention (B9). Sparse-V dequant scaffolding, Boundary-V layer protection that keeps the first/last layer at FP16, and a packed-aware `PagedKvLayout` round out the runtime. Quality gates: wikitext-2 PPL + NIAH harness, full 283K-token test split fixture, per-model PPL/NIAH results committed, and VLM B3 quality gates with image-token kurtosis. Speed gate matrix runner with M1 Ultra and M5 Max readings. User guide and validated config matrix published.
+- **Server flag parity for KV quantization.** `--cache-type-k` and `--cache-type-v` flags accept `f16`, `q8_0`, `q4_0`, etc. matching llama-server semantics, with TurboQuant modes exposed as `mlxcel_turbo*` variants. KV cache quantization extended to continuous batching and a unified `--kv-cache-mode` flag layout shared across `mlxcel`, `mlxcel-server`, and `mlxcel download`.
+- **Automatic Prefix Caching (APC) with hash blocks**. Hash-keyed block-table prefix reuse on top of v0.0.25's cross-sequence prompt-prefix KV cache, enabling shared physical blocks across requests with the same hashed prefix without per-request token-prefix matching cost.
+- **OpenAI-compatible `response_format: {"type": "json_schema", ...}`** structured-output support for `/v1/chat/completions` and `/v1/completions`. Constrained decoding via `llguidance` (the same backend used by upstream mlx-vlm PR #1047) ensures every emitted token keeps the partial output conforming to the supplied schema. Per-request schema validation enforces a 64 KiB size cap, a 32-level nesting depth limit, and a 64-entry `$ref` count limit so an adversarial schema cannot exhaust CPU or memory during grammar compilation. The tokenizer environment is cached by SHA-256 fingerprint so consecutive requests to the same model share the build cost (~1–2 s for a 150k-vocab tokenizer). Reusable per-sequence `mask_buf` and `bias_buf` allocations eliminate per-token `Vec` allocation on the hot decode path. The legacy `json_object` mode is rejected with a clean 400 in this MVP; `json_schema` with a well-formed schema is the supported path. Supported on HuggingFace BPE tokenizers; SentencePiece and Tiktoken backends return a clean `UnsupportedTokenizer` error. Verbose llguidance internals are never surfaced in public error messages — they are routed to server-side tracing only.
+- **`mlxcel download` / `mlxcel-server download` subcommand** to fetch HuggingFace model repository snapshots without Python tooling. Uses `hf-hub` with an allow-list file filter (SafeTensors, tokenizer, and config files only), cache-hit detection, and formatted per-file progress output. Supports `--local-dir`, `--revision`, `--token`, and `--force`. Default destination mirrors the `models/<repo-basename>` convention from AGENTS.md.
+- **`/health` endpoint** now includes `context_size` (the configured `--ctx-size` value; `0` means model default) and `tool_call_parser` (`"mlxcel"` when the chat template exposes the `tools` variable, `null` otherwise). Both fields are present once a model is loaded; `context_size` is absent while loading, `tool_call_parser` serializes as `null` during startup so monitoring clients can distinguish "template has no tool support" from "model not yet loaded". The tool-support heuristic is extracted into a shared `template_mentions_tools()` helper used by both the health route and the existing `compute_supports_tools` fallback path.
+- **Paged scheduler dispatch on `PagedKvLayout::cache_mode`** so the scheduler routes batches into the matching paged decode kernel for each KV cache mode.
+- **Video input infrastructure for VLMs.** Gemma 4 video support with the new VLM video input pipeline; ffmpeg-backed frame extraction with single-pass extraction and a `Drop` guard for cleanup of temporary frame files; `video_url` content blocks wired through `/v1/chat/completions`; content-preservation tests covering the frame extraction path.
+- **New models.** Youtu-VL vision-language model; Nemotron H Nano Omni vision plus follow-up correctness/validation hardening.
+- Multi-task M1 Ultra benchmark refresh to 2026-05-08 and full M1 Ultra column resync in `benchmarks-by-hardware.md`.
 
 ### Changed
-- **MLX upstream pin bumped twice.** First from the v0.0.25 baseline (`5d7e96cd`) to v0.32.0 / `c9aa5605` (#565), then forward to `84961223` covering 3 PRs: #3443 splits the CUDA `qmm_naive` / `qmm_sm80` kernel bodies into new `qmm_naive.cuh` / `qmm_sm80.cuh` headers without changing the public ABI consumed by mlxcel's `patches/mlx/backend/cuda/quantized/qmm/qmm.h`; #3463 routes the CPU JIT preamble through `JitCompiler::get_preamble()` and renames the prebuilt symbol from `get_kernel_preamble` to `get_prebuilt_preamble` (mlxcel does not call either directly); #3475 fixes contiguity-flag accuracy in `AsStrided` by computing `data_size` from the actually-occupied stride range. Three-location pin update applied to `src/lib/mlx-cpp/CMakeLists.txt`, `src/lib/mlxcel-core/build.rs`, and `.github/workflows/release.yml` per `CLAUDE.md`. Fused Metal kernel launchers in `src/lib/mlx-cpp/turbo/` re-validated against both bumps: `mlx::core::fast::metal_kernel`, `mlx::core::full`, `mlx::core::Shape`, `mlx::core::float32`, `mlx::core::int32`, and `metal::fast::exp` symbols unchanged.
-- **Refactor:** unified TurboQuant KV-cache CLI flags across `mlxcel`, `mlxcel-server`, and `mlxcel download` so all binaries accept the same `--kv-cache-mode` / `--cache-type-{k,v}` syntax (#567).
-- mlx-lm version reference in docs bumped from 0.31.2 to 0.31.3 (#606). The `bridge-overhead-microbench` reference at v0.31.2 is preserved because it pins the MLX C++ runtime, not the mlx-lm Python package.
+- **MLX upstream pin bumped twice.** First from the v0.0.25 baseline (`5d7e96cd`) to v0.32.0 / `c9aa5605`, then forward to `84961223` covering 3 PRs: #3443 splits the CUDA `qmm_naive` / `qmm_sm80` kernel bodies into new `qmm_naive.cuh` / `qmm_sm80.cuh` headers without changing the public ABI consumed by mlxcel's `patches/mlx/backend/cuda/quantized/qmm/qmm.h`; #3463 routes the CPU JIT preamble through `JitCompiler::get_preamble()` and renames the prebuilt symbol from `get_kernel_preamble` to `get_prebuilt_preamble` (mlxcel does not call either directly); #3475 fixes contiguity-flag accuracy in `AsStrided` by computing `data_size` from the actually-occupied stride range. Three-location pin update applied to `src/lib/mlx-cpp/CMakeLists.txt`, `src/lib/mlxcel-core/build.rs`, and `.github/workflows/release.yml` per `CLAUDE.md`. Fused Metal kernel launchers in `src/lib/mlx-cpp/turbo/` re-validated against both bumps: `mlx::core::fast::metal_kernel`, `mlx::core::full`, `mlx::core::Shape`, `mlx::core::float32`, `mlx::core::int32`, and `metal::fast::exp` symbols unchanged.
+- **Refactor:** unified TurboQuant KV-cache CLI flags across `mlxcel`, `mlxcel-server`, and `mlxcel download` so all binaries accept the same `--kv-cache-mode` / `--cache-type-{k,v}` syntax.
+- mlx-lm version reference in docs bumped from 0.31.2 to 0.31.3. The `bridge-overhead-microbench` reference at v0.31.2 is preserved because it pins the MLX C++ runtime, not the mlx-lm Python package.
 
 ### Performance
-- **Sparse-V kernel:** fused per-thread Metal kernel that skips the full SDPA pass when sparse-V dequant predicts zero contribution (#505); precomputed kernel rescale to drop per-token threadgroup barriers (#520).
-- **Turbo4Delegated decode hot path:** unified K storage to drop the per-step K concat (#527); cold-V dequant cache across decode steps (#525) followed by a cold-V dequant Metal kernel that retires the FP16 memo (#530); steel-attention-envelope fused SDPA kernel (#531) with parallelized Pass 1 softmax (#534); delegated FP16 predecode compaction (#536) and lazy delegated FP16 sidecars (#537); compressed fold moved before decode.
-- **Compressed dequant-SDPA paths** for TurboQuant decode (#562).
-- **Server hot-path:** thread-local generation stream and uniform-batch RoPE collapse to remove per-request allocation in the steady-state batching loop (#556).
+- **Sparse-V kernel:** fused per-thread Metal kernel that skips the full SDPA pass when sparse-V dequant predicts zero contribution; precomputed kernel rescale to drop per-token threadgroup barriers.
+- **Turbo4Delegated decode hot path:** unified K storage to drop the per-step K concat; cold-V dequant cache across decode steps followed by a cold-V dequant Metal kernel that retires the FP16 memo; steel-attention-envelope fused SDPA kernel with parallelized Pass 1 softmax; delegated FP16 predecode compaction and lazy delegated FP16 sidecars; compressed fold moved before decode.
+- **Compressed dequant-SDPA paths** for TurboQuant decode.
+- **Server hot-path:** thread-local generation stream and uniform-batch RoPE collapse to remove per-request allocation in the steady-state batching loop.
 
 ### Fixed
-- **TurboQuant continuous batching:** correct batch cache offset merging when batches with different cache offsets are joined or split (#564); Turbo3 split-flag, documentation alignment, and an `ENV_LOCK` race in concurrent process startup (#573).
-- **Vision / VLM mixed batching:** per-sequence MRoPE alignment for mixed VL+text batches (#558); per-sequence `per_layer_inputs` for Gemma 4 E2B/E4B VLM (#561); mixed-length batching support for Gemma 4 (#560); relaxed cached-position shape check in Qwen VL chunked prefill (#557); Qwen3.5-MoE batch-size validation on cached `position_ids` reuse (#559).
-- **Streaming and sampling:** correct streamed detokenization for byte-fallback tokens that previously leaked raw byte fragments to the client (#570); top-p filter correctness for batched logits (#569); token queue timeout handling during long prefills so clients no longer see spurious 408s on slow first-token paths (#571); `StreamFilter` extended to cover Hermes-style `<tool_call>` / `</tool_call>` and Mistral Nemo `[TOOL_CALLS]` markers, which previously leaked raw markup into `delta.content` during streaming (#551, #576). Partial-marker buffering at token boundaries correctly holds back prefixes (e.g. `<tool_`) until the full tag can be confirmed, then releases them to `delta.content` if they turn out not to be a boundary. Gemma 4 `<|tool_call>` suppression is unaffected; the delimiter table ordering ensures the Gemma 4 pipe-delimited form wins the tiebreak over the Hermes plain form.
-- **Models:** Gemma3-4B attention SIGABRT from a sliding-window mask `T_k` mismatch on long-context prompts (#507); preserve Qwen2 fused QKV bias when it is present in the checkpoint (#517); test fixture swap to Qwen2.5-1.5B base variant for the B3 quality gate (#506); harden post-merge review findings on the Nemotron-H Nano Omni vision PR.
+- **TurboQuant continuous batching:** correct batch cache offset merging when batches with different cache offsets are joined or split; Turbo3 split-flag, documentation alignment, and an `ENV_LOCK` race in concurrent process startup.
+- **Vision / VLM mixed batching:** per-sequence MRoPE alignment for mixed VL+text batches; per-sequence `per_layer_inputs` for Gemma 4 E2B/E4B VLM; mixed-length batching support for Gemma 4; relaxed cached-position shape check in Qwen VL chunked prefill; Qwen3.5-MoE batch-size validation on cached `position_ids` reuse.
+- **Streaming and sampling:** correct streamed detokenization for byte-fallback tokens that previously leaked raw byte fragments to the client; top-p filter correctness for batched logits; token queue timeout handling during long prefills so clients no longer see spurious 408s on slow first-token paths; `StreamFilter` extended to cover Hermes-style `<tool_call>` / `</tool_call>` and Mistral Nemo `[TOOL_CALLS]` markers, which previously leaked raw markup into `delta.content` during streaming. Partial-marker buffering at token boundaries correctly holds back prefixes (e.g. `<tool_`) until the full tag can be confirmed, then releases them to `delta.content` if they turn out not to be a boundary. Gemma 4 `<|tool_call>` suppression is unaffected; the delimiter table ordering ensures the Gemma 4 pipe-delimited form wins the tiebreak over the Hermes plain form.
+- **Models:** Gemma3-4B attention SIGABRT from a sliding-window mask `T_k` mismatch on long-context prompts; preserve Qwen2 fused QKV bias when it is present in the checkpoint; test fixture swap to Qwen2.5-1.5B base variant for the B3 quality gate; harden post-merge review findings on the Nemotron-H Nano Omni vision PR.
 
 ### Security
-- Path-traversal defense in the downloader: `is_safe_relative_path` pre-filters each sibling filename returned by the HuggingFace API (rejects absolute paths, `..` components, backslash separators, and empty components). A secondary canonicalized `starts_with` guard on the resolved destination path is applied before writing each file. Download target files are written to a temporary path and atomically renamed into place, preventing partial writes from leaving corrupt files in the output directory (fixes C1 and H1 from security review of #457).
-- Structured-output schema limits (64 KiB serialized size, 32 nesting depth, 64 `$ref` count) and tightened `llguidance` parser caps (`max_grammar_size: 100 000`, `max_lexer_states: 50 000`) applied before grammar compilation so an adversarial client cannot use the schema endpoint as a CPU/memory exhaustion vector. Schema content is never echoed in public error messages (#550).
+- Path-traversal defense in the downloader: `is_safe_relative_path` pre-filters each sibling filename returned by the HuggingFace API (rejects absolute paths, `..` components, backslash separators, and empty components). A secondary canonicalized `starts_with` guard on the resolved destination path is applied before writing each file. Download target files are written to a temporary path and atomically renamed into place, preventing partial writes from leaving corrupt files in the output directory (fixes C1 and H1 from security review).
+- Structured-output schema limits (64 KiB serialized size, 32 nesting depth, 64 `$ref` count) and tightened `llguidance` parser caps (`max_grammar_size: 100 000`, `max_lexer_states: 50 000`) applied before grammar compilation so an adversarial client cannot use the schema endpoint as a CPU/memory exhaustion vector. Schema content is never echoed in public error messages.
 
 ## [v0.0.25] - 2026-04-24
 
 ### Added
-- Cross-sequence prompt-prefix KV cache. New `KVCache::trim/detach/adopt` API enables adopting a previously-cached prefix on the next request. Backed by `PromptCacheStore`, an in-process LRU keyed by tokenized prompt prefix, plus a longest common token-prefix matcher (`PrefixMatcher`) for fast lookup. Paged KV cache gains block-table prefix reuse so adopted prefixes share physical blocks. Scheduler integration prefills only the unmatched suffix on cache hits. Wired into the server via `--prompt-cache-size`, `--prompt-cache-min-tokens`, and matching `LLAMA_ARG_*` env vars; multimodal/vision-aware cache key (`MultimodalDigest`) prevents cross-modality collisions. OpenAI-compatible `cached_tokens` is reported in `/v1/chat/completions` responses, mirrored to Prometheus counters, and verified by a multi-turn E2E test plus a prefill-latency benchmark. Design rationale and operator guide added to docs (#418, #419, #420, #421, #422, #423, #424, #425, #426, #427, #428, #429, #430, #431, #432, #433, #434, #435, #436, #437, #438).
-- Language-bias steering (Axis B, Phase 1). New `lang_analyzer` module with a Unicode script classifier (B2, #391) and `TokenLanguageIndex` builder that scans the tokenizer vocabulary, partitions tokens by script, and persists the result to disk for fast warm starts (B3 #392, B4 #394). Sampling primitive `TokenBiasMap` + `apply_token_bias` (#390) is wired through `LangBiasSet` with `Conservative` / `Strict` policies (B5 #393), exposed via CLI flags and a YAML config (B6 #395), `LLAMA_ARG_LANG_BIAS` env var in `mlxcel-server` (B7 #397), `LangBiasConfig` injection into the generator pipelines (B8 #398), tracing fields and Prometheus counters (B9 #400), byte-fragment CJK classification via UTF-8 start-byte analysis so byte-level BPE tokenizers correctly attribute fragments (#408, closes #405), byte-level reverse map for token decoding (#402, fixes #401), and integration tests for the steering matrix (B10 #399, #407). User guide and Quickstart published (B11 #396, #404).
-- `thinking_token_budget` sampling parameter for the Qwen3 family — caps tokens emitted between `<think>` / `</think>` markers without disabling streaming (#411).
-- `preserve_thinking` chat-template hook for Qwen 3.6 so multi-turn conversations retain prior `<think>` blocks instead of stripping them on subsequent turns (#412).
-- `StreamFilter` extended to recognize Qwen-style `<think>` / `</think>` token boundaries during streaming and route the segment into `reasoning_content` (#445).
-- `thinking_budget_tokens` extended to Gemma 4 (#442).
-- `feat(benchmarks)`: bridge-overhead microbench tool measuring per-op cost of the Rust cxx bridge against Python nanobind across MLX primitives, with a published baseline and reproduction steps (#450).
-- `feat(ci)`: multi-stage pipeline-parallel smoke job activated using a Qwen3-0.6B fixture so PR runs catch PP regressions (#415).
+- Cross-sequence prompt-prefix KV cache. New `KVCache::trim/detach/adopt` API enables adopting a previously-cached prefix on the next request. Backed by `PromptCacheStore`, an in-process LRU keyed by tokenized prompt prefix, plus a longest common token-prefix matcher (`PrefixMatcher`) for fast lookup. Paged KV cache gains block-table prefix reuse so adopted prefixes share physical blocks. Scheduler integration prefills only the unmatched suffix on cache hits. Wired into the server via `--prompt-cache-size`, `--prompt-cache-min-tokens`, and matching `LLAMA_ARG_*` env vars; multimodal/vision-aware cache key (`MultimodalDigest`) prevents cross-modality collisions. OpenAI-compatible `cached_tokens` is reported in `/v1/chat/completions` responses, mirrored to Prometheus counters, and verified by a multi-turn E2E test plus a prefill-latency benchmark. Design rationale and operator guide added to docs.
+- Language-bias steering (Axis B, Phase 1). New `lang_analyzer` module with a Unicode script classifier (B2) and `TokenLanguageIndex` builder that scans the tokenizer vocabulary, partitions tokens by script, and persists the result to disk for fast warm starts (B3, B4). Sampling primitive `TokenBiasMap` + `apply_token_bias` is wired through `LangBiasSet` with `Conservative` / `Strict` policies (B5), exposed via CLI flags and a YAML config (B6), `LLAMA_ARG_LANG_BIAS` env var in `mlxcel-server` (B7), `LangBiasConfig` injection into the generator pipelines (B8), tracing fields and Prometheus counters (B9), byte-fragment CJK classification via UTF-8 start-byte analysis so byte-level BPE tokenizers correctly attribute fragments, byte-level reverse map for token decoding, and integration tests for the steering matrix (B10). User guide and Quickstart published (B11).
+- `thinking_token_budget` sampling parameter for the Qwen3 family — caps tokens emitted between `<think>` / `</think>` markers without disabling streaming.
+- `preserve_thinking` chat-template hook for Qwen 3.6 so multi-turn conversations retain prior `<think>` blocks instead of stripping them on subsequent turns.
+- `StreamFilter` extended to recognize Qwen-style `<think>` / `</think>` token boundaries during streaming and route the segment into `reasoning_content`.
+- `thinking_budget_tokens` extended to Gemma 4.
+- `feat(benchmarks)`: bridge-overhead microbench tool measuring per-op cost of the Rust cxx bridge against Python nanobind across MLX primitives, with a published baseline and reproduction steps.
+- `feat(ci)`: multi-stage pipeline-parallel smoke job activated using a Qwen3-0.6B fixture so PR runs catch PP regressions.
 - Per-layer + per-sub-op decode profiling for Gemma 4, plus a Gemma 4 perf harness with the 2026-04-22 baseline used to drive the parity work below.
 
 ### Fixed
-- Prompt cache prefix isolation — sequences whose prompts share a non-trivial prefix no longer leak adopted KV state across each other after detach/adopt (#448).
-- `MultimodalDigest` propagated to all `PromptCacheKey` callers after the issue #421 + #425 merge so vision-aware cache lookups stay collision-free.
-- Gemma 4 `enable_thinking=false` no longer triggers degenerate output, and `reasoning_content` now streams correctly when `enable_thinking=true` (#440).
-- Tool-only assistant turns now emit `content: null` instead of `""` to match the OpenAI Chat Completions schema (#441).
-- `chat-template`: support flattened `extra_body` and pseudo-user tool responses so OpenAI-style tool flows render correctly under HF-style templates (#413).
-- `lang-analyzer`: decode tokens using the byte-level reverse map (#401) instead of the textual tokenizer view, so byte-level BPE (Qwen, Llama) tokens are classified by their actual code-point payload (#402).
-- `ci`: unblock Pipeline Parallel CI on Ubuntu by installing LAPACK and treating clippy `-D warnings` consistently (#414).
+- Prompt cache prefix isolation — sequences whose prompts share a non-trivial prefix no longer leak adopted KV state across each other after detach/adopt.
+- `MultimodalDigest` propagated to all `PromptCacheKey` callers after the + merge so vision-aware cache lookups stay collision-free.
+- Gemma 4 `enable_thinking=false` no longer triggers degenerate output, and `reasoning_content` now streams correctly when `enable_thinking=true`.
+- Tool-only assistant turns now emit `content: null` instead of `""` to match the OpenAI Chat Completions schema.
+- `chat-template`: support flattened `extra_body` and pseudo-user tool responses so OpenAI-style tool flows render correctly under HF-style templates.
+- `lang-analyzer`: decode tokens using the byte-level reverse map instead of the textual tokenizer view, so byte-level BPE (Qwen, Llama) tokens are classified by their actual code-point payload.
+- `ci`: unblock Pipeline Parallel CI on Ubuntu by installing LAPACK and treating clippy `-D warnings` consistently.
 - `vision`: read Gemma 4 encoder `hidden_size` from after `input_proj` so the multimodal projector wires the correct dimension on encoders that include a learned input projection.
-- Bumped `cc` to 1.2.60 to silence the BSD `ar` probe warning surfaced by recent `cc-rs` releases (#439).
+- Bumped `cc` to 1.2.60 to silence the BSD `ar` probe warning surfaced by recent `cc-rs` releases.
 
 ### Changed
-- Gemma 4 mlx-lm decode parity pass (closes the remaining gap on 26B / 31B / e2b, #454):
-  - Router RMS norm fused with top-k-then-softmax to remove a separate normalization pass (#451).
-  - SwitchGeGLU gate / up / geglu / down fused into a single `mlx::core::compile` window (#452).
-  - Metal-trace-driven attention / RoPE / per-layer chain fusion (#453).
+- Gemma 4 mlx-lm decode parity pass (closes the remaining gap on 26B / 31B / e2b):
+  - Router RMS norm fused with top-k-then-softmax to remove a separate normalization pass.
+  - SwitchGeGLU gate / up / geglu / down fused into a single `mlx::core::compile` window.
+  - Metal-trace-driven attention / RoPE / per-layer chain fusion.
   - Compiled Gemma 4 SwitchGeGLU decode path enabled.
   - Single-query causal masks skipped in decode.
   - BF16 decode graph aligned with mlx-lm.
@@ -256,95 +256,95 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Router top-k aligned with mlx-lm.
   - Load and MoE decode paths tuned.
   - Redundant residual copies in the decoder layer dropped.
-  - SwitchGeGLU `expand_dims` collapsed and a MoE inner profiler added (#447).
-- `Qwen 3.5`: SSM decode masks aligned with mlx-lm; benchmark artifacts cleanup (#455).
-- `MLX`: upstream pin upgraded to **v0.31.2**; in-tree SDPA and steel-attention overlays dropped now that upstream covers them. Three-location update (`src/lib/mlx-cpp/CMakeLists.txt`, `src/lib/mlxcel-core/build.rs`, `.github/workflows/release.yml`) per CLAUDE.md (#449).
-- `CUDA`: QMM patches updated for the new upstream `lhs/rhs_indices` signatures (#456).
-- `deploy`: SIGTERM the running `mlxcel-server` after binary copy so the respawned supervisor picks up the new binary (#443).
+  - SwitchGeGLU `expand_dims` collapsed and a MoE inner profiler added.
+- `Qwen 3.5`: SSM decode masks aligned with mlx-lm; benchmark artifacts cleanup.
+- `MLX`: upstream pin upgraded to **v0.31.2**; in-tree SDPA and steel-attention overlays dropped now that upstream covers them. Three-location update (`src/lib/mlx-cpp/CMakeLists.txt`, `src/lib/mlxcel-core/build.rs`, `.github/workflows/release.yml`) per CLAUDE.md.
+- `CUDA`: QMM patches updated for the new upstream `lhs/rhs_indices` signatures.
+- `deploy`: SIGTERM the running `mlxcel-server` after binary copy so the respawned supervisor picks up the new binary.
 - `style`: `cargo fmt` swept across server modules to land previously-unformatted blocks.
 
 ## [v0.0.24] - 2026-04-18
 
 ### Added
-- Zero-config multi-machine pipeline-parallel bring-up: `mlxcel-server --pp-auto N` declares pipeline depth; peers register via `--cluster-peers` seeds or opt-in mDNS discovery (`--cluster-discovery=mdns`). New `src/distributed/cluster_init.rs` owns deterministic stage assignment, port allocation, and byte-identical TOML emission consumed by the existing manual-TOML runtime path (#342, #352).
-- RDMA-aware transport backend with transparent TCP fallback. Negotiates `io_uring` registered buffers on Linux and `kqueue` batched send on macOS, emits exactly one structured log line on fallback, and preserves the `Arc<dyn Transport>` abstraction used by `activation_transfer.rs`. New `rdma_capabilities.rs`, `rdma_transport.rs`, and `bench_activation.rs` harness (#351, closes #343).
-- 2D `(pp_stage, tp_rank)` mesh composing PP with TP for Llama-70B-class topologies. Adds `NodeRole::PipelineTensorParallel`, validation for exact `pp_size × tp_size` coverage with unique coordinates, registry helpers, `TrafficClass` routing (`TpCollective` / `PpActivation`), and grid-coherent KV admission (`coordinated_2d_admission`) (#354, addresses #346).
-- Byte-accurate pipeline auto-partition with adjacency constraints. `ModelProfile` gains per-layer byte weights plus layer-adjacency constraints so the balancer refuses to cut MoE expert layers or Gemma 4 KV-shared source/consumer pairs. Drops the hand-specified `--pp-layers` requirement for MoE and gemma-4-e2b-it-4bit. Extracted into `partition_balance`, `partition_profile`, and `partition_quality` modules (#357, resolves #348).
-- Elastic pipeline-parallel repartitioning behind `--enable-elastic-pp`. `RepartitionCoordinator` drives `Idle → Draining → Rebalancing → Resuming → Idle` and emits `RepartitionEvent` to a transport-agnostic sink without a full cluster restart. CLI flags: `--elastic-pp-drain-timeout`, `--elastic-pp-pressure-fraction`, `--elastic-pp-cool-down` (#349, #358).
-- Per-stage LoRA adapter composition across pipeline ranks via the existing `--adapter` flag. Each stage loads only the adapter tensors inside its layer range through a new filtered safetensors loader (`load_safetensors_filtered`), fuses them in place with the same `fuse_lora_weights_into` primitive that backs the non-PP path, and unchanged-family guards (`ensure_no_adapter`) prevent silent drops. Llama family implements composition; parity integration test asserts bit-equality with the single-process adapter run (#347, #355).
-- Stage-executor coverage for five new families: Mistral dense, Mixtral 8x7B MoE, DeepSeek V3 (MLA + routed MoE with MTP-trailer strip), Llama 4 Scout text-only tower, and Mamba-family hybrids Jamba and Nemotron-H. `StageFamily` enum plus `supported_families()` surfaces per-family capability on the server startup log (#345, #356).
-- Pipeline-parallel observability: `/metrics` endpoint renders per-stage utilization, rolling bubble ratio, activation-transfer latency histograms (p50/p95/p99 per stage pair), and KV admission rejection counters labeled by stage and reason. `--metrics-port`, `--debug-pp-trace <PATH>` (chrome-tracing JSON), and `AdmissionDiagnostic` replace opaque 500s on rejection. Grafana dashboard JSON at `docs_internal/performance/pipeline-dashboard.json` (#350, #359).
-- Multi-host pipeline-parallel regression CI harness at `.github/workflows/pipeline-parallel-ci.yml`: `two-host-logical` on GitHub runners (path-filtered, intended as required status) plus `three-host-real-model` gated by the `ci:pp-three-host` PR label or manual dispatch. Shares shell entry points with local reproduction (#353, refs #344).
-- `VisionFeatureCache` LRU for multi-turn VLM image feature reuse, wired through Gemma 4 VLM, Qwen2.5-VL, and Qwen3-VL via `_with_cache` variants. Cache keys are filesystem paths or SHA-256 digests of inline payloads. New `--vision-cache-size N` CLI flag (default 20, 0 disables) (#334, matches #325).
-- Null/empty-cache safety guards in the batch scheduler. Pure-text requests with zero tokenized prompt tokens are rejected before admission (VLM image/audio injection paths unaffected); `execute_decode_step` and `execute_batched_decode` no-op on empty `seq_ids`. Mirrors the upstream mlx-lm BatchKVCache extend/filter/merge null guards (#333, closes #324).
+- Zero-config multi-machine pipeline-parallel bring-up: `mlxcel-server --pp-auto N` declares pipeline depth; peers register via `--cluster-peers` seeds or opt-in mDNS discovery (`--cluster-discovery=mdns`). New `src/distributed/cluster_init.rs` owns deterministic stage assignment, port allocation, and byte-identical TOML emission consumed by the existing manual-TOML runtime path.
+- RDMA-aware transport backend with transparent TCP fallback. Negotiates `io_uring` registered buffers on Linux and `kqueue` batched send on macOS, emits exactly one structured log line on fallback, and preserves the `Arc<dyn Transport>` abstraction used by `activation_transfer.rs`. New `rdma_capabilities.rs`, `rdma_transport.rs`, and `bench_activation.rs` harness.
+- 2D `(pp_stage, tp_rank)` mesh composing PP with TP for Llama-70B-class topologies. Adds `NodeRole::PipelineTensorParallel`, validation for exact `pp_size × tp_size` coverage with unique coordinates, registry helpers, `TrafficClass` routing (`TpCollective` / `PpActivation`), and grid-coherent KV admission (`coordinated_2d_admission`) (addresses).
+- Byte-accurate pipeline auto-partition with adjacency constraints. `ModelProfile` gains per-layer byte weights plus layer-adjacency constraints so the balancer refuses to cut MoE expert layers or Gemma 4 KV-shared source/consumer pairs. Drops the hand-specified `--pp-layers` requirement for MoE and gemma-4-e2b-it-4bit. Extracted into `partition_balance`, `partition_profile`, and `partition_quality` modules.
+- Elastic pipeline-parallel repartitioning behind `--enable-elastic-pp`. `RepartitionCoordinator` drives `Idle → Draining → Rebalancing → Resuming → Idle` and emits `RepartitionEvent` to a transport-agnostic sink without a full cluster restart. CLI flags: `--elastic-pp-drain-timeout`, `--elastic-pp-pressure-fraction`, `--elastic-pp-cool-down`.
+- Per-stage LoRA adapter composition across pipeline ranks via the existing `--adapter` flag. Each stage loads only the adapter tensors inside its layer range through a new filtered safetensors loader (`load_safetensors_filtered`), fuses them in place with the same `fuse_lora_weights_into` primitive that backs the non-PP path, and unchanged-family guards (`ensure_no_adapter`) prevent silent drops. Llama family implements composition; parity integration test asserts bit-equality with the single-process adapter run.
+- Stage-executor coverage for five new families: Mistral dense, Mixtral 8x7B MoE, DeepSeek V3 (MLA + routed MoE with MTP-trailer strip), Llama 4 Scout text-only tower, and Mamba-family hybrids Jamba and Nemotron-H. `StageFamily` enum plus `supported_families()` surfaces per-family capability on the server startup log.
+- Pipeline-parallel observability: `/metrics` endpoint renders per-stage utilization, rolling bubble ratio, activation-transfer latency histograms (p50/p95/p99 per stage pair), and KV admission rejection counters labeled by stage and reason. `--metrics-port`, `--debug-pp-trace <PATH>` (chrome-tracing JSON), and `AdmissionDiagnostic` replace opaque 500s on rejection. Grafana dashboard JSON at `docs_internal/performance/pipeline-dashboard.json`.
+- Multi-host pipeline-parallel regression CI harness at `.github/workflows/pipeline-parallel-ci.yml`: `two-host-logical` on GitHub runners (path-filtered, intended as required status) plus `three-host-real-model` gated by the `ci:pp-three-host` PR label or manual dispatch. Shares shell entry points with local reproduction (refs).
+- `VisionFeatureCache` LRU for multi-turn VLM image feature reuse, wired through Gemma 4 VLM, Qwen2.5-VL, and Qwen3-VL via `_with_cache` variants. Cache keys are filesystem paths or SHA-256 digests of inline payloads. New `--vision-cache-size N` CLI flag (default 20, 0 disables) (matches).
+- Null/empty-cache safety guards in the batch scheduler. Pure-text requests with zero tokenized prompt tokens are rejected before admission (VLM image/audio injection paths unaffected); `execute_decode_step` and `execute_batched_decode` no-op on empty `seq_ids`. Mirrors the upstream mlx-lm BatchKVCache extend/filter/merge null guards.
 
 ### Fixed
-- Auto-detect per-layer quantization bit overrides in `UnifiedLinear::from_weights_with_mode` and `FusedQKVLinear::from_weights_separate_with_mode`. New `infer_quantization_bits()` verifies the MLX invariant `packed_in * 32 == bits * num_groups * group_size` and infers the actual bit width from tensor shapes when the caller-supplied bits disagree. Enables qwen3.6-35b-a3b-4bit, which stores router-gate and shared-expert-gate at 8-bit while the rest of the model is 4-bit (#361).
-- Use additive f32 attention mask (0.0 attended, f32::MIN masked) in `prepare_inputs_for_multimodal` instead of the previous multiplicative INT32 0/1 mask. `mx.fast.scaled_dot_product_attention` treats non-bool masks as additive bias on pre-softmax scores, so the old form silently leaked padding tokens into the attention distribution whenever `attention_mask` contained a zero (#339, closes #337).
-- Mirror PR #326 conditional `embed_scale` to `TensorParallelGemma4Model::forward_impl`. Previously, `multiply_scalar` was applied unconditionally after `embed_tokens`, double-scaling text embeddings and incorrectly scaling image/audio features from VLM callers. Moved into the `None` arm only, matching `Gemma4TextModel::forward`. Added regression test asserting TP/non-TP logits match for both `input_embeddings` and `input_ids` paths (#338, closes #335).
-- Wrap every `cache.conv_state = Some(slice_axis(...))` assignment in `mlxcel_core::contiguous(&tail, false)` across mamba, mamba2, nemotron-h, and jamba, plus the two NemotronH fused-kernel paths. `slice_axis()` returns a lazy MLX `Slice` graph node that retains the source `padded_input` as a live input, causing per-step memory growth proportional to sequence length. 50-step shape-plateau regression test added per model (#340, closes #336).
-- Apply RMS norm BEFORE `embedding_projection` on the encoder-side dim in `Gemma4 Multimodal Embedder` (was previously AFTER, on the text-side `hidden_size`). Mirrors upstream mlx-vlm. Renamed field `post_projection_norm` → `pre_projection_norm`. **BREAKING** for pre-fix VLM checkpoints: re-download `mlx-community/gemma-4-*-it-4bit` to obtain the post-rename weights (#329).
-- Apply `sqrt(hidden_size)` `embed_scale` to text embeddings in `Gemma4VLModel::get_input_embeddings_with_audio` BEFORE merging vision/audio features, and make the scalar multiply in `Gemma4TextModel::forward` conditional on `input_embeddings` being `None`. Vision/audio features are already in language-model embedding space; double-scaling them degraded multimodal generation quality (#326, closes #317).
-- Implement proportional RoPE for Gemma 4 full-attention layers. Real Gemma 4 checkpoints declare `rope_type="proportional"` on full-attention and `rope_type="default"` on sliding-attention layers; the previous implementation silently dropped `rope_type` and normalized by the rotated-only slice instead of the full `head_dim`. New `mlxcel_core::rope_proportional` module with `compute_proportional_rope_freqs` and `apply_proportional_rope` matching the upstream slice/concat/fast_rope/re-splice pipeline. For head_dim=256, partial_rotary_factor=0.25, the two formulations differ by a factor-of-4 exponent shift (#332, closes #321).
-- Gemma 4 audio feature extractor: drop `+0.5` phase shift in Hann window so it uses the periodic form `w(i) = 0.5 - 0.5·cos(2π·i/N)` matching HuggingFace Gemma 4. Prepend `frame_length/2 (160)` zero samples before frame extraction for semicausal convention (first frame centered at t=0). Use `total_len` in `num_frames` calculation and correct `frame_size_for_unfold` to use `frame_length+1` only for non-HTK preemphasis. Restores the correct 100 frames for 1s 16 kHz audio with 10 ms hop (#327, closes #320).
-- Ensure `conv_input` cache slice is contiguous in GatedDeltaNet forward paths (Qwen 3.5, Kimi Linear, Qwen 3 Next). `mlxcel_core::slice()` calls `mlx::core::slice()` which creates a graph node holding source reference — without `contiguous()`, every cached entry holds the full `conv_input` buffer, preventing freeing and causing per-step memory growth proportional to sequence length. 50-step regression test added (#328, closes #323).
-- Default NemotronH `time_step_limit` to `(time_step_min.unwrap_or(0.0), time_step_max.unwrap_or(+inf))` unconditionally when absent. Changed from `(f32, f32)` to `Option<(f32, f32)>` so absent configs are distinguishable from explicit `(0.0, +inf)` sentinels. Matches upstream mlx-lm behavior (#330, closes #319).
+- Auto-detect per-layer quantization bit overrides in `UnifiedLinear::from_weights_with_mode` and `FusedQKVLinear::from_weights_separate_with_mode`. New `infer_quantization_bits()` verifies the MLX invariant `packed_in * 32 == bits * num_groups * group_size` and infers the actual bit width from tensor shapes when the caller-supplied bits disagree. Enables qwen3.6-35b-a3b-4bit, which stores router-gate and shared-expert-gate at 8-bit while the rest of the model is 4-bit.
+- Use additive f32 attention mask (0.0 attended, f32::MIN masked) in `prepare_inputs_for_multimodal` instead of the previous multiplicative INT32 0/1 mask. `mx.fast.scaled_dot_product_attention` treats non-bool masks as additive bias on pre-softmax scores, so the old form silently leaked padding tokens into the attention distribution whenever `attention_mask` contained a zero.
+- Mirror conditional `embed_scale` to `TensorParallelGemma4Model::forward_impl`. Previously, `multiply_scalar` was applied unconditionally after `embed_tokens`, double-scaling text embeddings and incorrectly scaling image/audio features from VLM callers. Moved into the `None` arm only, matching `Gemma4TextModel::forward`. Added regression test asserting TP/non-TP logits match for both `input_embeddings` and `input_ids` paths.
+- Wrap every `cache.conv_state = Some(slice_axis(...))` assignment in `mlxcel_core::contiguous(&tail, false)` across mamba, mamba2, nemotron-h, and jamba, plus the two NemotronH fused-kernel paths. `slice_axis()` returns a lazy MLX `Slice` graph node that retains the source `padded_input` as a live input, causing per-step memory growth proportional to sequence length. 50-step shape-plateau regression test added per model.
+- Apply RMS norm BEFORE `embedding_projection` on the encoder-side dim in `Gemma4 Multimodal Embedder` (was previously AFTER, on the text-side `hidden_size`). Mirrors upstream mlx-vlm. Renamed field `post_projection_norm` → `pre_projection_norm`. **BREAKING** for pre-fix VLM checkpoints: re-download `mlx-community/gemma-4-*-it-4bit` to obtain the post-rename weights.
+- Apply `sqrt(hidden_size)` `embed_scale` to text embeddings in `Gemma4VLModel::get_input_embeddings_with_audio` BEFORE merging vision/audio features, and make the scalar multiply in `Gemma4TextModel::forward` conditional on `input_embeddings` being `None`. Vision/audio features are already in language-model embedding space; double-scaling them degraded multimodal generation quality.
+- Implement proportional RoPE for Gemma 4 full-attention layers. Real Gemma 4 checkpoints declare `rope_type="proportional"` on full-attention and `rope_type="default"` on sliding-attention layers; the previous implementation silently dropped `rope_type` and normalized by the rotated-only slice instead of the full `head_dim`. New `mlxcel_core::rope_proportional` module with `compute_proportional_rope_freqs` and `apply_proportional_rope` matching the upstream slice/concat/fast_rope/re-splice pipeline. For head_dim=256, partial_rotary_factor=0.25, the two formulations differ by a factor-of-4 exponent shift.
+- Gemma 4 audio feature extractor: drop `+0.5` phase shift in Hann window so it uses the periodic form `w(i) = 0.5 - 0.5·cos(2π·i/N)` matching HuggingFace Gemma 4. Prepend `frame_length/2 (160)` zero samples before frame extraction for semicausal convention (first frame centered at t=0). Use `total_len` in `num_frames` calculation and correct `frame_size_for_unfold` to use `frame_length+1` only for non-HTK preemphasis. Restores the correct 100 frames for 1s 16 kHz audio with 10 ms hop.
+- Ensure `conv_input` cache slice is contiguous in GatedDeltaNet forward paths (Qwen 3.5, Kimi Linear, Qwen 3 Next). `mlxcel_core::slice()` calls `mlx::core::slice()` which creates a graph node holding source reference — without `contiguous()`, every cached entry holds the full `conv_input` buffer, preventing freeing and causing per-step memory growth proportional to sequence length. 50-step regression test added.
+- Default NemotronH `time_step_limit` to `(time_step_min.unwrap_or(0.0), time_step_max.unwrap_or(+inf))` unconditionally when absent. Changed from `(f32, f32)` to `Option<(f32, f32)>` so absent configs are distinguishable from explicit `(0.0, +inf)` sentinels. Matches upstream mlx-lm behavior.
 
 ### Changed
-- Replace Gemma 4 `ScaledLinear` wrapper with `UnifiedLinear` directly across both `Gemma4TextModel` and `Gemma4StageModel` (tensor-parallel path). New `per_layer_projection_scale: f32` field stores `(hidden_size as f32).powf(-0.5)` and is applied explicitly in `project_per_layer_inputs()` after the linear forward pass, preserving bit-identical math (#331, closes #322).
+- Replace Gemma 4 `ScaledLinear` wrapper with `UnifiedLinear` directly across both `Gemma4TextModel` and `Gemma4StageModel` (tensor-parallel path). New `per_layer_projection_scale: f32` field stores `(hidden_size as f32).powf(-0.5)` and is applied explicitly in `project_per_layer_inputs()` after the linear forward pass, preserving bit-identical math.
 
 ## [v0.0.23] - 2026-04-15
 
 ### Fixed
-- Render chat templates that use Python-style dict/string methods (#315). Extends minijinja's `unknown_method_callback` with shims for `.get`, `.items`, `.keys`, `.values`, `.strip`, `.lstrip`, `.rstrip`, `.startswith`, `.endswith`, `.split`, `.rsplit`, `.replace`, `.join`, `.upper`, `.lower`, `.title`, `.capitalize`, `.casefold`, `.swapcase`, `.find`, `.count`, `.is{digit,alpha,alnum,space,upper,lower}`. Previously rendering silently fell back to `to_prompt()`'s `User: ... Assistant:` format, and instruction-tuned models echoed `Assistant:` in a loop.
-- Pass `tools` as an empty iterable (not `None`) so `{% if tools is iterable and tools | length > 0 %}` guards work under minijinja. Fixes Qwen 3 Next, Nemotron-H, and Nemotron-NAS tool-free rendering (#315).
-- Strip HuggingFace `transformers`' `{% generation %}` / `{% endgeneration %}` extension markers during template preprocessing so SmolLM 3 parses cleanly (#315).
-- Apply the Gemma 4 structural-token stream filter and non-streaming cleanup unconditionally, not only when tool parsing is enabled, so plain chat responses no longer leak `<|channel>`, `<channel|>`, `<turn|>`, `<|turn>`, `<|tool_call>`, or `<tool_call|>` markers into content (#315).
-- Extend `clean_content_markers` with `<|channel>` / `<channel|>` / `<|tool_call>` / `<tool_call|>` so stray closing tags that Gemma 4 occasionally emits in non-thinking mode are stripped even without a matching open tag (#315).
+- Render chat templates that use Python-style dict/string methods. Extends minijinja's `unknown_method_callback` with shims for `.get`, `.items`, `.keys`, `.values`, `.strip`, `.lstrip`, `.rstrip`, `.startswith`, `.endswith`, `.split`, `.rsplit`, `.replace`, `.join`, `.upper`, `.lower`, `.title`, `.capitalize`, `.casefold`, `.swapcase`, `.find`, `.count`, `.is{digit,alpha,alnum,space,upper,lower}`. Previously rendering silently fell back to `to_prompt()`'s `User: ... Assistant:` format, and instruction-tuned models echoed `Assistant:` in a loop.
+- Pass `tools` as an empty iterable (not `None`) so `{% if tools is iterable and tools | length > 0 %}` guards work under minijinja. Fixes Qwen 3 Next, Nemotron-H, and Nemotron-NAS tool-free rendering.
+- Strip HuggingFace `transformers`' `{% generation %}` / `{% endgeneration %}` extension markers during template preprocessing so SmolLM 3 parses cleanly.
+- Apply the Gemma 4 structural-token stream filter and non-streaming cleanup unconditionally, not only when tool parsing is enabled, so plain chat responses no longer leak `<|channel>`, `<channel|>`, `<turn|>`, `<|turn>`, `<|tool_call>`, or `<tool_call|>` markers into content.
+- Extend `clean_content_markers` with `<|channel>` / `<channel|>` / `<|tool_call>` / `<tool_call|>` so stray closing tags that Gemma 4 occasionally emits in non-thinking mode are stripped even without a matching open tag.
 
 ### Added
-- `test_all_local_model_templates_render` ignored-by-default audit that renders every locally-available model against three canonical scenarios (simple user, system + user, multi-turn with `<think>` blocks). Current result: 85 models checked, 249/249 scenarios pass, 0 failures, 6 intentional template `raise_exception` rejections categorized separately (#315).
+- `test_all_local_model_templates_render` ignored-by-default audit that renders every locally-available model against three canonical scenarios (simple user, system + user, multi-turn with `<think>` blocks). Current result: 85 models checked, 249/249 scenarios pass, 0 failures, 6 intentional template `raise_exception` rejections categorized separately.
 
 ### Changed
-- Clean up pre-existing `cargo clippy --release -p mlxcel --lib` warnings (7 → 0): replace `unwrap()` after `is_some()` checks in `distributed/config.rs`, bind the MoE router via `if let` chain in the Gemma 4 TP path (`distributed/tensor_parallel/llama_runtime.rs`), collapse two character-identical QKV shard branches, auto-elide `'a` lifetimes, collapse a `thunderbolt_transport.rs` nested `if`, replace a manual `% != 0` with `is_multiple_of()` in NVFP4 sanitize, and drop a now-redundant `cache.as_deref_mut()` + `mut` annotation in Qwen 3.5 `GatedDeltaNet::forward` (#316).
-- Clean up pre-existing webpage `pnpm lint` / `tsc --noEmit` errors (20 / 4 warnings → 0 / 0): replace framer-motion wrapper `any`-typed props with `HTMLMotionProps`, `let` → `const` in `downloads.tsx`, swap `<img>` for `next/image`'s `<Image />` on the local Lablup logo, and rewrite `use-os.ts` to avoid synchronously setting state inside `useEffect` with proper `NavigatorUAData` / `WebGLDebugInfoExtension` typings (#316).
+- Clean up pre-existing `cargo clippy --release -p mlxcel --lib` warnings (7 → 0): replace `unwrap()` after `is_some()` checks in `distributed/config.rs`, bind the MoE router via `if let` chain in the Gemma 4 TP path (`distributed/tensor_parallel/llama_runtime.rs`), collapse two character-identical QKV shard branches, auto-elide `'a` lifetimes, collapse a `thunderbolt_transport.rs` nested `if`, replace a manual `% != 0` with `is_multiple_of()` in NVFP4 sanitize, and drop a now-redundant `cache.as_deref_mut()` + `mut` annotation in Qwen 3.5 `GatedDeltaNet::forward`.
+- Clean up pre-existing webpage `pnpm lint` / `tsc --noEmit` errors (20 / 4 warnings → 0 / 0): replace framer-motion wrapper `any`-typed props with `HTMLMotionProps`, `let` → `const` in `downloads.tsx`, swap `<img>` for `next/image`'s `<Image />` on the local Lablup logo, and rewrite `use-os.ts` to avoid synchronously setting state inside `useEffect` with proper `NavigatorUAData` / `WebGLDebugInfoExtension` typings.
 
 ## [v0.0.22] - 2026-04-13
 
 ### Added
-- Pipeline stage executor framework with per-family executors (#272)
-- Gemma 3 pipeline stage executor (#304)
-- Gemma 4 pipeline stage executor (#305)
-- Qwen3 pipeline stage executor (#306)
-- Qwen3.5 pipeline stage executor (#307)
-- GLM4-family pipeline stage executors (#308)
-- GLM MoE DSA pipeline stage executor (#310)
-- gpt-oss pipeline stage executor (#303)
-- In-process pipeline stage worker loop (#273)
-- CLI pipeline generate path (#274)
-- Server pipeline runtime integration (#275)
-- Pipeline transport lifecycle controls (#276)
-- TCP-backed remote pipeline stages (#288)
-- Thunderbolt transport backend for remote pipeline parallelism (#291)
-- Multi-machine validation for remote pipeline parallelism (#301)
+- Pipeline stage executor framework with per-family executors
+- Gemma 3 pipeline stage executor
+- Gemma 4 pipeline stage executor
+- Qwen3 pipeline stage executor
+- Qwen3.5 pipeline stage executor
+- GLM4-family pipeline stage executors
+- GLM MoE DSA pipeline stage executor
+- gpt-oss pipeline stage executor
+- In-process pipeline stage worker loop
+- CLI pipeline generate path
+- Server pipeline runtime integration
+- Pipeline transport lifecycle controls
+- TCP-backed remote pipeline stages
+- Thunderbolt transport backend for remote pipeline parallelism
+- Multi-machine validation for remote pipeline parallelism
 - bench_decode `--cooldown` and `--big-cooldown` for M5 Max thermal management
 - M5 Max benchmark refresh for 2026-04-13 (97 models, 88 pass; 8 multimodal models restored)
 
 ### Fixed
 - Tolerate stale `model.safetensors.index.json` in mlx-community repackaged quants (gemma3-4b, gemma3n-e2b/e4b, llama-4-scout-17b, mistral-small-3.1, molmo2)
 - Tolerate partial `text_config` (no `num_hidden_layers`) in single-rank tensor-parallel planning (LLaVA-1.5, LLaVA-Next-Mistral)
-- Prevent Gemma 4 special tokens from leaking into streaming content deltas (#312)
-- Complete remote pipeline lifecycle recovery (#290)
-- bench_decode single-model runs no longer truncate the day's full-suite CSV (#314, closes #313)
+- Prevent Gemma 4 special tokens from leaking into streaming content deltas
+- Complete remote pipeline lifecycle recovery
+- bench_decode single-model runs no longer truncate the day's full-suite CSV
 - Log lazy pipeline peer reconnects
 
 ### Changed
-- Generalize stage executor backends and remove legacy stage executor file (#302)
-- Transport-capable pipeline runtime seam (#287)
+- Generalize stage executor backends and remove legacy stage executor file
+- Transport-capable pipeline runtime seam
 
 ### Tests
-- Pipeline server smoke validation (#278)
-- Pipeline rollout real-model coverage (#277)
+- Pipeline server smoke validation
+- Pipeline rollout real-model coverage
 
 ### Docs
 - Remote pipeline usage examples
@@ -356,16 +356,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Paged KV cache substrate with batch scheduler integration
-- Native paged decode kernel paths for rotating and chunked caches (#260)
-- Paged compatibility for windowed caches (#256)
-- Default paged decode for supported server workers (#246)
-- Paged KV transfer observability (#258)
+- Native paged decode kernel paths for rotating and chunked caches
+- Paged compatibility for windowed caches
+- Default paged decode for supported server workers
+- Paged KV transfer observability
 - NVFP4 load-time dequantization for Gemma 4 nvfp4 checkpoints
 - F8_E4M3 / F8_E5M2 safetensors loading for nvfp4 checkpoints
-- Paged decode rollout benchmark matrix and eligibility tracking (#262)
+- Paged decode rollout benchmark matrix and eligibility tracking
 
 ### Changed
-- Unify model-owned sequence state with backend seam (#244)
+- Unify model-owned sequence state with backend seam
 - Vectorize batched decode positional metadata
 - CI: auto-promote pre-release to full release after successful builds
 
@@ -375,19 +375,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [v0.0.20] - 2026-04-10
 
 ### Added
-- In-process tensor parallel runtime for Llama (#235)
-- Tensor parallel support for Qwen2, Qwen3, and Qwen3.5 text models (#235)
-- Gemma 3 tensor-parallel runtime with tp4 parity stabilization (#235)
-- Gemma 4 tensor-parallel support (#235)
-- Dense TP support for ERNIE 4.5 and Hunyuan v1 models (#235)
-- Server batching support for tensor parallel runtimes (#235)
-- Tensor-parallel config wiring into CLI and server entrypoints (#235)
+- In-process tensor parallel runtime for Llama
+- Tensor parallel support for Qwen2, Qwen3, and Qwen3.5 text models
+- Gemma 3 tensor-parallel runtime with tp4 parity stabilization
+- Gemma 4 tensor-parallel support
+- Dense TP support for ERNIE 4.5 and Hunyuan v1 models
+- Server batching support for tensor parallel runtimes
+- Tensor-parallel config wiring into CLI and server entrypoints
 
 ### Fixed
-- Qwen 3.5 tensor-parallel parity on large CUDA models (#235)
+- Qwen 3.5 tensor-parallel parity on large CUDA models
 
 ### Changed
-- Expand tp4 parity coverage to larger models and server end-to-end tests (#235)
+- Expand tp4 parity coverage to larger models and server end-to-end tests
 
 ## [v0.0.19] - 2026-04-10
 
@@ -403,20 +403,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [v0.0.18] - 2026-04-08
 
 ### Added
-- GatherQMM CUDA implementation via upstream MLX upgrade to b98831ad (#226)
-- SM80 and naive QMM dispatch paths for non-Hopper CUDA GPUs (#226)
-- Gemma 4 CUDA support: all 7 variants (e2b, e4b, 26b, 31b in 4bit/8bit) (#227)
-- Qwen 3.5 CUDA support: 27b-4bit, 9b-bf16, 35b-MoE-4bit (#227)
+- GatherQMM CUDA implementation via upstream MLX upgrade to b98831ad
+- SM80 and naive QMM dispatch paths for non-Hopper CUDA GPUs
+- Gemma 4 CUDA support: all 7 variants (e2b, e4b, 26b, 31b in 4bit/8bit)
+- Qwen 3.5 CUDA support: 27b-4bit, 9b-bf16, 35b-MoE-4bit
 
 ### Fixed
-- Mixed-type bf16/float JIT compilation failures in CUDA binary_ops.cuh (#227)
-- Remove stale NO_GPU(BlockMaskedMM) override that conflicted with upstream implementation (#226)
-- Gemma 3-4b and Gemma 3n (e2b, e4b) recovered on CUDA via binary_ops fix (#227)
+- Mixed-type bf16/float JIT compilation failures in CUDA binary_ops.cuh
+- Remove stale NO_GPU(BlockMaskedMM) override that conflicted with upstream implementation
+- Gemma 3-4b and Gemma 3n (e2b, e4b) recovered on CUDA via binary_ops fix
 
 ### Changed
-- Upgrade MLX C++ upstream from 6a9a121d to b98831ad (#226)
-- Replace custom gather_qmv.cu with upstream integrated qmv.cu (#226)
-- Sync CUDA quantized.cpp with upstream SM80/naive dispatch paths (#226)
+- Upgrade MLX C++ upstream from 6a9a121d to b98831ad
+- Replace custom gather_qmv.cu with upstream integrated qmv.cu
+- Sync CUDA quantized.cpp with upstream SM80/naive dispatch paths
 
 ### Performance
 - GB10 CUDA: 14 models recovered from FAIL, 24 models improved >10%
@@ -425,54 +425,54 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [v0.0.17] - 2026-04-06
 
 ### Fixed
-- Resolve broadcast crash in Gemma 4 chunked prefill with undersized attention mask (#224)
+- Resolve broadcast crash in Gemma 4 chunked prefill with undersized attention mask
 
 ## [v0.0.16] - 2026-04-05
 
 ### Added
-- Audio input support for server chat completions endpoint (#217, #220)
-- Gemma 4 audio encoder and audio-language model support (#217, #218)
-- Metal 4 fused attention path (#197, #210)
-- OpenAI-compatible tool calling support (#212, #213)
-- M5 GPU acceleration experiments (#209)
-- M5 Neural Accelerator rollout research (#203)
+- Audio input support for server chat completions endpoint
+- Gemma 4 audio encoder and audio-language model support
+- Metal 4 fused attention path
+- OpenAI-compatible tool calling support
+- M5 GPU acceleration experiments
+- M5 Neural Accelerator rollout research
 
 ### Changed
-- Unify attention dispatch for Metal 4 path (#201)
+- Unify attention dispatch for Metal 4 path
 
 ### Fixed
-- Propagate client disconnection to BatchScheduler to prevent orphaned sequences (#219, #221)
-- Harden tool calling with input limits, parser improvements, and format handlers (#215, #216)
-- Remove eval() calls from qwen3_moe forward hot path (#211)
-- Resolve Gemma SDPA crash on M1 by reducing threadgroup memory for head_dim=256 (#208)
-- Update compiled.cpp patch for upstream MLX API change (#207)
-- Add str.split() support in chat template for Gemma 4 multi-turn (#206)
+- Propagate client disconnection to BatchScheduler to prevent orphaned sequences
+- Harden tool calling with input limits, parser improvements, and format handlers
+- Remove eval() calls from qwen3_moe forward hot path
+- Resolve Gemma SDPA crash on M1 by reducing threadgroup memory for head_dim=256
+- Update compiled.cpp patch for upstream MLX API change
+- Add str.split() support in chat template for Gemma 4 multi-turn
 
 ## [v0.0.15] - 2026-04-03
 
 ### Added
-- Gemma 4 text and VLM model support (#199)
-- User-facing warning when loading full-precision bf16 models (#195)
+- Gemma 4 text and VLM model support
+- User-facing warning when loading full-precision bf16 models
 - Download webpage with Next.js static site (EN/KO i18n)
 
 ### Changed
-- Extend bf16→f16 weight conversion to all Apple Silicon generations (#193)
-- Audit f32 upcasts and optimize MoE gate sigmoid for fp16 co-issue (#194)
-- Improve Metal 4 fused attention scaffolding with research documentation (#196)
-- Reuse cached MLX source for faster rebuilds (#200)
+- Extend bf16→f16 weight conversion to all Apple Silicon generations
+- Audit f32 upcasts and optimize MoE gate sigmoid for fp16 co-issue
+- Improve Metal 4 fused attention scaffolding with research documentation
+- Reuse cached MLX source for faster rebuilds
 
 ## [v0.0.14] - 2026-04-03
 
 ### Added
-- Logprobs support for chat completions and completions endpoints (#188)
-- Runtime Apple Silicon generation detection for hardware-specific optimizations (#161)
-- Prefill tile alignment for M5 Neural Accelerator (#162)
-- Batched speculative decode verification for NA utilization (#167)
-- Batched prefill in server mode (#169)
-- Layer pipelining with strategic async_eval (#170)
-- Metal 4 fused attention kernel scaffolding (#171)
-- KV cache INT8 quantization for memory savings (#172)
-- INT8 quantization optimization for M5 Neural Accelerator (#168)
+- Logprobs support for chat completions and completions endpoints
+- Runtime Apple Silicon generation detection for hardware-specific optimizations
+- Prefill tile alignment for M5 Neural Accelerator
+- Batched speculative decode verification for NA utilization
+- Batched prefill in server mode
+- Layer pipelining with strategic async_eval
+- Metal 4 fused attention kernel scaffolding
+- KV cache INT8 quantization for memory savings
+- INT8 quantization optimization for M5 Neural Accelerator
 - Multimodal chat template support for VLM image token placement
 - Apple Silicon precision hardware guide documentation
 
@@ -480,20 +480,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Centralize bf16→f16 weight conversion in shared VLM loading path
 - Skip bf16→f16 conversion for quantized models (restores +20% throughput)
 - Add compiled gelu_topk kernel matching Python mlx-lm `@mx.compile` pattern
-- Expand QKV projection fusion to GQA models (#164)
-- Expand compiled MLP fusion to non-quantized models (#166)
-- Fuse Q/K/V projections in Gemma v1 attention for faster decode (#183)
+- Expand QKV projection fusion to GQA models
+- Expand compiled MLP fusion to non-quantized models
+- Fuse Q/K/V projections in Gemma v1 attention for faster decode
 - Refactor AGENTS.md into focused reference docs (313→75 lines)
 
 ### Fixed
 - Auto-convert bf16 weights to f16 on M5 for Metal JIT compatibility
 - Skip add_special_tokens when prompt already contains BOS token (double-BOS fix)
-- Prevent NemotronH all-`<unk>` output on M5 Max by avoiding mixed float32/float16 ops (#187)
-- Prevent Nemotron-H/NAS GPU hang and state corruption on M5 Max (#186)
-- Trim NemotronH internal caches after padded prefill to prevent GPU hang (#184)
-- Fix PhiMoE expert activation from GeGLU to SwiGLU (#182)
-- Fix matmul outside compile boundary in FP MLP to fix output corruption (#181)
-- Replace gelu_approx power(x,3) with erf-based GELU to fix NaN in vision encoder (#179)
+- Prevent NemotronH all-`<unk>` output on M5 Max by avoiding mixed float32/float16 ops
+- Prevent Nemotron-H/NAS GPU hang and state corruption on M5 Max
+- Trim NemotronH internal caches after padded prefill to prevent GPU hang
+- Fix PhiMoE expert activation from GeGLU to SwiGLU
+- Fix matmul outside compile boundary in FP MLP to fix output corruption
+- Replace gelu_approx power(x,3) with erf-based GELU to fix NaN in vision encoder
 - Guard multimodal chat template to avoid garbled output on text-only VLMs
 - Skip compiled FP MLP for bfloat16 models
 - Patch MLX compiled kernel JIT to cast mixed bfloat16/float operands
@@ -503,9 +503,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [v0.0.13] - 2026-03-31
 
 ### Added
-- Mistral4 MLA (Multi-head Latent Attention) language model support (#144)
-- Molmo-Point VLM model support (#148)
-- NemotronSuper model support (upstream mlx-lm sync) (#131)
+- Mistral4 MLA (Multi-head Latent Attention) language model support
+- Molmo-Point VLM model support
+- NemotronSuper model support (upstream mlx-lm sync)
 - `sync-upstream` Claude Code command for tracking mlx-lm/mlx-vlm changes
 
 ### Changed
@@ -513,16 +513,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Apply MRoPE and position ID optimizations to Qwen3-VL-MoE
 - Fast-path single-token decode position IDs in Qwen3-VL
 - Vectorize Qwen3-VL interleaved MRoPE with `take_along_axis`
-- Optimize VLM vision encoding and sampling pipeline (#149)
+- Optimize VLM vision encoding and sampling pipeline
 - Use SDPA for NemotronH attention, boosting decode throughput 59%
 
 ### Fixed
-- Improve SSM/Mamba2 numerical precision with float32 dt computation (#133)
-- Improve GatedDelta numerical precision with float32 state (#132)
+- Improve SSM/Mamba2 numerical precision with float32 dt computation
+- Improve GatedDelta numerical precision with float32 state
 - Resolve Mamba/NemotronNAS output corruption with softplus overflow and fused norm grouping
-- Guard Qwen3.5 GatedDeltaNet state batch dimension mismatches (#145)
-- Use `h.shape` instead of `inputs.shape` for Ministral3 attn_scale (#146)
-- Document scalar offset invariant for Llama4 BatchKVCache compatibility (#147)
+- Guard Qwen3.5 GatedDeltaNet state batch dimension mismatches
+- Use `h.shape` instead of `inputs.shape` for Ministral3 attn_scale
+- Document scalar offset invariant for Llama4 BatchKVCache compatibility
 - Correct model_tests.md table placement and dedup nemotron entries
 
 ## [v0.0.12] - 2026-03-26

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,23 @@ Write commits, PR titles, and issue comments in **English**. Use Conventional Co
 - When modifying a function shared by multiple models, update the `// Used by: Model1, Model2, …` comment above it. See [`docs/code-guidelines.md`](docs/code-guidelines.md).
 - Do not introduce Python on the inference request path. Python is acceptable only for benchmarks and out-of-band tooling.
 
+### Cross-repository issue references
+
+`#NNN` auto-links to `lablup/mlxcel`, so use a bare `#NNN` **only** for issues and PRs in this repository. Any reference to another repository must be qualified so it resolves correctly and never leaks a private-repo number:
+
+- Upstream references are written `org/repo#NNN` — `ml-explore/mlx-lm#1240`, `Blaizzy/mlx-vlm#1181`, `ml-explore/mlx#3475`, `huggingface/transformers#NNN`.
+- `mlxcel-internal` (private) numbers must never appear anywhere — code comments, docs, commit subjects, or PR bodies. Map an internal reference to its public-equivalent PR/issue when one demonstrably exists; otherwise describe the change without a number.
+
+Pre-flight before pushing — review every bare 3+-digit reference you add:
+
+```bash
+git diff origin/main...HEAD | grep -nE '#[0-9]{3,}'
+# or, scoped and classified (advisory by default; STRICT=1 to gate):
+python3 scripts/ci/check_cross_repo_refs.py
+```
+
+CI runs the same check on every pull request (advisory).
+
 ### Adding a new model family
 
 See [`docs/adding-models.md`](docs/adding-models.md) for the full checklist. The short version: land one working checkpoint plus tests before broadening, mirror the `mlx-lm` / `mlx-vlm` directory shape where it helps, and update [`docs/supported-models.md`](docs/supported-models.md) plus the detection table in `src/models/detection.rs`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ path = "src/main.rs"
 name = "mlxcel-server"
 path = "src/bin/mlx_server.rs"
 
-# Perf benchmark harness for the speculative drafter pairings shipped by
-# epic #633 / issue #632. Captures no-drafter baseline tok/s and scaffolds
-# the speculative numerator rows that follow-up #666 will fill in. See
+# Perf benchmark harness for the speculative drafter pairings.
+# Captures no-drafter baseline tok/s and scaffolds
+# the speculative numerator rows that follow-up will fill in. See
 # `src/bin/speculative_bench.rs` for the module docs and `docs/model_tests.md`
-# (`Speculative drafters (epic #633)`) for the deferral matrix.
+# (`Speculative drafters`) for the deferral matrix.
 [[bin]]
 name = "speculative_bench"
 path = "src/bin/speculative_bench.rs"
@@ -44,7 +44,7 @@ metal = ["mlxcel-core/metal"]
 accelerate = ["mlxcel-core/accelerate"]
 cuda = ["mlxcel-core/cuda"]
 test-utils = []
-# Axis A "weight-load surgery" framework (Epic #363, issues #367 / #369 / #371).
+# Axis A "weight-load surgery" framework.
 #
 # On by default so production `mlxcel` and `mlxcel-server` binaries expose
 # the `--surgery <config.yaml>` flag without rebuilds. Bit-exactness with
@@ -91,7 +91,7 @@ thiserror = "2.0.11"
 # Cryptographic hashing (for vision feature cache keys)
 sha2 = "0.10"
 
-# Fast non-cryptographic-grade hashing for prompt prefix cache keys (issue #419).
+# Fast non-cryptographic-grade hashing for prompt prefix cache keys.
 # BLAKE3 is used only for in-process cache-key digests; no security boundary
 # depends on it.
 blake3 = "1.8"
@@ -126,12 +126,12 @@ path-clean = "1.0.1"
 minijinja = { version = "2.20", features = ["loop_controls", "fuel"] }
 # Used by `src/downloader/mod.rs::file_url` to percent-encode `repo_id` /
 # `revision` / `filename` path segments before composing the HF download URL
-# (issue #650, L1). Already transitively present via reqwest -> url; promoting
+# (L1). Already transitively present via reqwest -> url; promoting
 # to a direct dep so the downloader can call into it without depending on
 # reqwest's transitive re-export.
 percent-encoding = "2"
 
-# Structured outputs / constrained decoding (issue #550).
+# Structured outputs / constrained decoding.
 #
 # `llguidance` is the same library used by mlx-vlm upstream PR #1047 for the
 # JSON-schema response_format MVP. The Rust crate exposes `Matcher` /

--- a/debian/changelog
+++ b/debian/changelog
@@ -283,84 +283,84 @@ mlxcel (0.0.27-1~jammy1) jammy; urgency=medium
 
   * Feat: Speculative decoding Phase 2 — end-to-end Gemma 4 MTP and
     Qwen 3.5 DFlash drafter pipelines. Drafter trait + DrafterKind
-    enum + model_type auto-detection (#624); MaskedEmbedder for E2B/E4B
-    drafters (#627); drafter masks (bidirectional full + SWA) +
-    normalize_batched_shared_kv_states (#628); Gemma4AssistantDraftModel
-    4-layer drafter + pre/post projections (#626); DFlashDraftModel
-    5-layer drafter + DFlashAttention + DFlashKVCache (#635);
+    enum + model_type auto-detection; MaskedEmbedder for E2B/E4B
+    drafters; drafter masks (bidirectional full + SWA) +
+    normalize_batched_shared_kv_states; Gemma4AssistantDraftModel
+    4-layer drafter + pre/post projections; DFlashDraftModel
+    5-layer drafter + DFlashAttention + DFlashKVCache;
     Gemma 4 return_hidden / return_shared_kv / rollback_speculative_cache
-    target hooks (#625); Qwen 3.5 return_hidden + capture_layer_ids +
-    GDN-aware rollback_speculative_cache (#634)
-  * Feat: Speculative round loops — DFlash single-batch round loop
-    (#636), MtpGenerator single-batch round loop (#629), batched
-    DFlash round loop with continuous batching + GDN-aware rollback
-    (#637), batched MTP round loop with continuous batching +
-    left-padding normalization (#631)
+    target hooks; Qwen 3.5 return_hidden + capture_layer_ids +
+    GDN-aware rollback_speculative_cache
+  * Feat: Speculative round loops — DFlash single-batch round loop,
+    MtpGenerator single-batch round loop, batched
+    DFlash round loop with continuous batching + GDN-aware rollback,
+    batched MTP round loop with continuous batching +
+    left-padding normalization
   * Feat: CLI — --draft-kind {dflash,mtp} and --draft-block-size
-    flags (#630); test(speculative) greedy-parity + perf benchmarks
-    for drafter pairings (#632)
+    flags; test(speculative) greedy-parity + perf benchmarks
+    for drafter pairings
   * Feat: Server speculative dispatch — wire speculative dispatch
-    resolution and MtpTarget adapters (#666); wire real MaskedEmbedder
+    resolution and MtpTarget adapters; wire real MaskedEmbedder
     and make_drafter_masks for Gemma 4 assistant; wire speculative
-    dispatch into scheduler via B=1 bursts (#670); B>1 batched
-    speculative dispatch via MtpBatchedGenerator / DFlashBatchedGenerator
-    (#684); cancellation propagation through MtpGenerator and
-    DFlashGenerator (#681); thread token_history through speculative-burst
-    first sample (#682); logprobs support in speculative-burst (#686);
-    thinking-budget enforcement in speculative-burst (#687); wire
-    donate_finished_sequence_cache symmetric with classic path (#680)
-    and into the B>1 batched arm (#689); real-model byte-equality
-    end-to-end tests (#685); harden speculative drafter epic follow-ups
+    dispatch into scheduler via B=1 bursts; B>1 batched
+    speculative dispatch via MtpBatchedGenerator / DFlashBatchedGenerator;
+    cancellation propagation through MtpGenerator and
+    DFlashGenerator; thread token_history through speculative-burst
+    first sample; logprobs support in speculative-burst;
+    thinking-budget enforcement in speculative-burst; wire
+    donate_finished_sequence_cache symmetric with classic path
+    and into the B>1 batched arm; real-model byte-equality
+    end-to-end tests; harden speculative drafter epic follow-ups
   * Fix: DFlash drafter lazy-bind for upstream z-lab/Qwen3.5-4B-DFlash
-    checkpoint (#683); enable DFlash for Qwen 3.5 VLM text requests
-    (#694); avoid slow Gemma 4 MTP singleton bursts (#698); validate
+    checkpoint; enable DFlash for Qwen 3.5 VLM text requests;
+    avoid slow Gemma 4 MTP singleton bursts; validate
     trimmable cache and reserve last token in prefill for speculative
-    rollback safety (#612)
+    rollback safety
   * Perf: Qwen 3.5 DFlash decode-path greedy argmax optimization
   * Feat: OpenAI Responses API (Phase 1) — /v1/responses endpoint
     with conversation store, streaming events, reasoning-trace
     forwarding, response cancellation, and four new CLI flags on both
-    binaries (#622, #623)
+    binaries
   * Feat: APC block-level partial cache adoption in the scheduler —
     when APC is on, a prompt sharing the first N blocks with a cached
     entry but diverging at block N+1 now reuses blocks 0..N and
     re-prefills only from the divergence boundary via
     DetachedKVCache::trim_to / DetachedCacheSet::truncate_to (FP16,
     INT8, Turbo4, Turbo4Delegated sidecars). APC-off retains bit-exact
-    prior behaviour (#580, #607)
+    prior behaviour
   * Feat: Nemotron H Nano Omni audio modality — Parakeet/Conformer
     sound encoder, mel-spectrogram feature extractor, audio projector,
     interleaved audio+vision token merging at sound_context_token_id
-    in generate_vlm (#582, #609)
+    in generate_vlm
   * Feat: mlxcel download / mlxcel-server download per-file +
     aggregate progress bars with terminal-aware suppression, reqwest
-    streaming, and atomic tempfile rename (#648, #649); follow-up
+    streaming, and atomic tempfile rename; follow-up
     security hardening — plaintext HF_ENDPOINT + token warning
     (M1), client connect/read timeouts (M2), URL path percent-encoding
     for ?/#/% in filenames (L1), O_NOFOLLOW tempfile creation (L2),
     Result-based token ASCII handling (L3), stale .mlxcel-partial.*
     cleanup at start (L5), parallel HEAD with buffer_unordered(8)
-    (L6) (#650, #652)
+    (L6)
   * Feat: Server --max-kv-size flag (matching llama-server) and
-    tighter chat-completion response shape (#618)
+    tighter chat-completion response shape
   * Feat: Tokenizer multi-token think and tool-call sequence support
-    (#590, #613)
-  * Fix: MiniMax M2 parallel tool calling parser (#616); preserve
-    token positions when buffering parallel tool calls (#615); skip
-    tool→normal transition when tool_call_end is empty (#614);
+
+  * Fix: MiniMax M2 parallel tool calling parser; preserve
+    token positions when buffering parallel tool calls; skip
+    tool→normal transition when tool_call_end is empty;
     pop_prefixes in RadixTrie with correct immediate-prefix semantics
-    for the prompt cache (#617)
+    for the prompt cache
   * Fix: Close TOCTOU race in video allowlist by passing fd to
-    ffmpeg (#601, #611); Gemma 4 skip k_proj/v_proj/k_norm load for
-    KV-shared layers (#608); Nemotron H default time_step_limit to
-    (0.0, inf) regardless of time_step_min/max (#619); gated_delta
+    ffmpeg; Gemma 4 skip k_proj/v_proj/k_norm load for
+    KV-shared layers; Nemotron H default time_step_limit to
+    (0.0, inf) regardless of time_step_min/max; gated_delta
     zero-init y[dv_idx] when mask is false in masked Metal kernel
-    variants (#610); upstream-sync review follow-ups
+    variants; upstream-sync review follow-ups
   * Chore: clippy 1.93 — replace .map_or(false, ...) with
-    .is_some_and(...) in tokenizer (#651); test fixture adds
-    max_kv_size field to ServeArgs (#620)
+    .is_some_and(...) in tokenizer; test fixture adds
+    max_kv_size field to ServeArgs
   * CI: bump GitHub Actions to Node 24 runtime
-  * Docs: refresh README to match current code and benchmarks (#700);
+  * Docs: refresh README to match current code and benchmarks;
     update speculative decoding guidance
 
  -- Jeongkyu Shin <inureyes@gmail.com>  Sat, 16 May 2026 18:00:00 +0900
@@ -368,64 +368,63 @@ mlxcel (0.0.27-1~jammy1) jammy; urgency=medium
 mlxcel (0.0.26-1~jammy1) jammy; urgency=medium
 
   * Feat: TurboQuant KV cache — Walsh-Hadamard transform op + PolarQuant
-    Lloyd-Max codebook generator porting (#470, #472), KVCacheMode::Turbo4
-    symmetric (#476), Turbo4Asym Fp16-K + Turbo4-V (#474), Turbo3Asym
-    Fp16-K + Turbo3-V (#477), Turbo4Delegated FP16 hot tail + packed
-    turbo cold body (#479), TurboQuant + RotatingKVCache sliding window
-    B9, sparse-V dequant scaffolding (#480), Boundary-V layer protection
-    (#478), packed-aware PagedKvLayout (#482)
+    Lloyd-Max codebook generator porting, KVCacheMode::Turbo4
+    symmetric, Turbo4Asym Fp16-K + Turbo4-V, Turbo3Asym
+    Fp16-K + Turbo3-V, Turbo4Delegated FP16 hot tail + packed
+    turbo cold body, TurboQuant + RotatingKVCache sliding window
+    B9, sparse-V dequant scaffolding, Boundary-V layer protection,
+    packed-aware PagedKvLayout
   * Feat: --cache-type-k / --cache-type-v server flag parity with
-    llama-server for TurboQuant modes (#484)
-  * Feat: KV cache quantization for continuous batching (#545); unified
-    TurboQuant KV-cache CLI flags across mlxcel binaries (#567);
-    compressed dequant-SDPA paths (#562)
-  * Perf: Fused Sparse-V Metal kernel skipping per-thread SDPA (#505);
+    llama-server for TurboQuant modes
+  * Feat: KV cache quantization for continuous batching; unified
+    TurboQuant KV-cache CLI flags across mlxcel binaries;
+    compressed dequant-SDPA paths
+  * Perf: Fused Sparse-V Metal kernel skipping per-thread SDPA;
     precomputed Sparse-V kernel rescale dropping per-token threadgroup
-    barriers (#520); cold-V dequant cache + Metal kernel for
-    Turbo4Delegated (#525, #530); unified K storage dropping per-step K
-    concat (#527); steel-attention-envelope fused SDPA kernel (#531);
-    parallelized Pass 1 softmax in turbo4_delegated_steel_sdpa (#534);
-    delegated FP16 predecode compaction + lazy sidecars (#536, #537)
-  * Test: TurboQuant wikitext-2 PPL + NIAH quality gate (#475, #492,
-    #493); VLM B3 quality gates (PPL + NIAH + image-token kurtosis) for
-    #510; KV speed gate matrix on M1 Ultra and M5 Max (#509)
-  * Feat: Automatic Prefix Caching (APC) with hash blocks (#552)
+    barriers; cold-V dequant cache + Metal kernel for
+    Turbo4Delegated; unified K storage dropping per-step K
+    concat; steel-attention-envelope fused SDPA kernel;
+    parallelized Pass 1 softmax in turbo4_delegated_steel_sdpa;
+    delegated FP16 predecode compaction + lazy sidecars
+  * Test: TurboQuant wikitext-2 PPL + NIAH quality gate; VLM B3 quality gates (PPL + NIAH + image-token kurtosis) for;
+    KV speed gate matrix on M1 Ultra and M5 Max
+  * Feat: Automatic Prefix Caching (APC) with hash blocks
   * Feat: OpenAI-compatible response_format json_schema constrained
-    decoding via llguidance with schema size/depth/$ref limits (#550)
+    decoding via llguidance with schema size/depth/$ref limits
   * Feat: mlxcel download / mlxcel-server download HuggingFace
     subcommand with allow-list filter, atomic writes, and path-traversal
-    defense (#457, #486)
+    defense
   * Feat: /health endpoint exposes context_size and tool_call_parser
-    (#549)
-  * Feat: Paged scheduler dispatch on PagedKvLayout::cache_mode (#508);
-    thread-local generation stream and uniform-batch RoPE collapse (#556)
-  * Feat: Gemma 4 video support and VLM video input infrastructure
-    (#553); Youtu-VL model (#555); Nemotron H Nano Omni vision (#554);
-    video_url content blocks wired through chat completion handler
-    (#596); single-pass ffmpeg frame extraction with Drop guard (#597)
-  * Fix: Per-sequence MRoPE alignment for mixed VL+text batches (#558);
-    per-sequence per_layer_inputs for Gemma 4 E2B/E4B VLM (#561);
-    mixed-length batching for Gemma 4 (#560); relaxed cached-position
-    shape check in Qwen VL chunked prefill (#557); Qwen3.5-MoE batch
-    size validation on cached position_ids reuse (#559)
-  * Fix: Streamed detokenization for byte-fallback tokens (#570); top_p
-    filter for batched logits (#569); token queue timeout during long
-    prefills (#571); tool-call markup stripped from streamed
+
+  * Feat: Paged scheduler dispatch on PagedKvLayout::cache_mode;
+    thread-local generation stream and uniform-batch RoPE collapse
+  * Feat: Gemma 4 video support and VLM video input infrastructure;
+    Youtu-VL model; Nemotron H Nano Omni vision;
+    video_url content blocks wired through chat completion handler;
+    single-pass ffmpeg frame extraction with Drop guard
+  * Fix: Per-sequence MRoPE alignment for mixed VL+text batches;
+    per-sequence per_layer_inputs for Gemma 4 E2B/E4B VLM;
+    mixed-length batching for Gemma 4; relaxed cached-position
+    shape check in Qwen VL chunked prefill; Qwen3.5-MoE batch
+    size validation on cached position_ids reuse
+  * Fix: Streamed detokenization for byte-fallback tokens; top_p
+    filter for batched logits; token queue timeout during long
+    prefills; tool-call markup stripped from streamed
     delta.content covering Hermes <tool_call> and Mistral Nemo
-    [TOOL_CALLS] (#551, #576)
-  * Fix: TurboQuant batch cache offset merging (#564); Turbo3 split-flag
-    + ENV_LOCK race (#573)
-  * Fix: Gemma3-4B attention SIGABRT — sliding-window mask T_k mismatch
-    (#507); Qwen2 fused QKV bias preservation (#517);
-    nemotron-h-nano-omni post-merge validation gaps (#583)
+    [TOOL_CALLS]
+  * Fix: TurboQuant batch cache offset merging; Turbo3 split-flag
+    + ENV_LOCK race
+  * Fix: Gemma3-4B attention SIGABRT — sliding-window mask T_k mismatch;
+    Qwen2 fused QKV bias preservation;
+    nemotron-h-nano-omni post-merge validation gaps
   * Update: MLX upstream pin bumped twice — first to v0.32.0
-    (c9aa5605, #565), then to 84961223 covering CUDA QMM kernel split,
+    (c9aa5605), then to 84961223 covering CUDA QMM kernel split,
     JIT preamble rename, and AsStrided contiguity-flag fix (PRs #3443
     #3463 #3475)
-  * Docs: TurboQuant KV cache user guide and validated config matrix
-    (#485); mlx-lm version reference 0.31.2 → 0.31.3 (#606); M1 Ultra
-    benchmark refresh to 2026-05-08 (#577) and benchmarks-by-hardware.md
-    full M1 Ultra column resync (#578)
+  * Docs: TurboQuant KV cache user guide and validated config matrix;
+    mlx-lm version reference 0.31.2 → 0.31.3; M1 Ultra
+    benchmark refresh to 2026-05-08 and benchmarks-by-hardware.md
+    full M1 Ultra column resync
 
  -- Jeongkyu Shin <inureyes@gmail.com>  Sun, 10 May 2026 18:00:00 +0900
 

--- a/docs/benchmark_results/model_tests.md
+++ b/docs/benchmark_results/model_tests.md
@@ -62,7 +62,7 @@ The table below summarizes the current cross-hardware decode readings for select
 *Qwen3-0.6B on GB10 produced only 9 tokens before EOS at 2026-05-28; the 317.75 tok/s decode rate is from that short window and is not directly comparable to full-length runs.
 
 M1 Ultra column is from 2026-05-28 with mlxcel 0.1.0 / MLX pin commit `84961223` (post-0.32.0) / no cooldown, using the `mlxcel-bench-decode` same-process harness.
-M5 Max column reflects the canonical `model_tests_m5max.md` values (mlxcel 0.1.0 / MLX pin `84961223` / same-process `mlxcel-bench-decode` harness), confirmed by the 2026-05-27 full re-sweep within thermal variance, with issue #743 Phi-3.5, issue #744 Gemma dense, and issue #745 Jamba spot-check refreshes folded into the listed rows.
+M5 Max column reflects the canonical `model_tests_m5max.md` values (mlxcel 0.1.0 / MLX pin `84961223` / same-process `mlxcel-bench-decode` harness), confirmed by the 2026-05-27 full re-sweep within thermal variance, with Phi-3.5, Gemma dense, and Jamba spot-check refreshes folded into the listed rows.
 GB10 column is from 2026-05-28 with mlxcel 0.1.0 / MLX pin `84961223` / `--cooldown 0`, using the `mlxcel-bench-decode` same-process warm harness (PR `c9a77f2`).
 Both Apple Silicon columns are on mlxcel 0.1.0 with the same MLX pin and the same same-process harness, so the gap reflects pure hardware delta. M5 Max stays roughly 1.7x faster than M1 Ultra on the selected 16 rows (avg ~1.71x, median ~1.76x). The largest MoE rows still show the M5 Max advantage: gpt-oss-120b runs at 114.03 vs 61.19 tok/s (1.86x) and solar-open-100b runs at 65.36 vs 36.26 tok/s (1.80x).
 For Qwen2.5-0.5B the 4-bit row is the directly comparable cross-hardware figure: `qwen2.5-0.5b-bf16` fails warmup on M1 Ultra, and the bf16 variant runs only on M5 Max at 404.68 tok/s.
@@ -76,14 +76,14 @@ For Qwen2.5-0.5B the 4-bit row is the directly comparable cross-hardware figure:
 | Text models tested (M5 Max, 2026-05-27) | 94 pass, 2 partial, 2 fail (98 total) |
 | Text models tested (GB10, 2026-05-28) | 101 pass, 8 fail/skip (109 total) |
 | VLM models tested (GB10, 2026-05-28) | 38 pass, 0 image-path fail (38 measured) |
-| VLM models tested (M5 Max, 2026-05-27) | 38 valid VLM rows (full VLM re-sweep; `internvl3-1b` and `qwen2-vl-2b-4bit` image mode now ✅ per #747/#749) |
+| VLM models tested (M5 Max, 2026-05-27) | 38 valid VLM rows (full VLM re-sweep; `internvl3-1b` and `qwen2-vl-2b-4bit` image mode now ✅) |
 | VLM models tested (M1 Ultra, 2026-05-28) | 44 valid VLM rows (internvl3-1b, molmo-7b, qwen2-vl image mode, MiniCPM-V-4.6 now ✅) |
 | Beating mlx-lm on M1 Ultra (text, >=100%) | 35/74 (47%, 5-28 vs pinned 5-19 baseline) |
 | At 90%+ parity on M1 Ultra (text) | 64/74 (86%, 5-28 vs pinned 5-19 baseline) |
 | Average vs mlx-lm on M1 Ultra (text) | 97% decode speed (median 99%, 5-28 vs pinned 5-19 baseline) |
-| Beating mlx-lm on M5 Max (text, >=100%) | 27/67 (40%, 5-19 same-process vs 5-18 mlx-lm, with #743/#744/#745 spot-check refreshes) |
-| At 90%+ parity on M5 Max (text) | 62/67 (93%, 5-19 same-process vs 5-18 mlx-lm, with #743/#744/#745 spot-check refreshes) |
-| Average vs mlx-lm on M5 Max (text) | 98% decode speed (median 99%, 5-19 same-process vs 5-18 mlx-lm, with #743/#744/#745 spot-check refreshes) |
+| Beating mlx-lm on M5 Max (text, >=100%) | 27/67 (40%, 5-19 same-process vs 5-18 mlx-lm, with spot-check refreshes) |
+| At 90%+ parity on M5 Max (text) | 62/67 (93%, 5-19 same-process vs 5-18 mlx-lm, with spot-check refreshes) |
+| Average vs mlx-lm on M5 Max (text) | 98% decode speed (median 99%, 5-19 same-process vs 5-18 mlx-lm, with spot-check refreshes) |
 | Average vs mlx-vlm on M5 Max (VLM) | 100% decode speed (median 100%, 5-19 same-process vs 5-18 mlx-vlm; 17 pairs) |
 
 ## Generating Benchmarks

--- a/docs/benchmark_results/model_tests_m1ultra.md
+++ b/docs/benchmark_results/model_tests_m1ultra.md
@@ -11,8 +11,8 @@ Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra
 | **mlxcel version** | 0.1.0 |
 | **MLX version** | post-0.32.0 pin (commit 84961223, via mlxcel-core) |
 | **Bench harness** | `mlxcel-bench-decode` (model load, warmup, and measured pass in one process) |
-| **mlx-lm baseline** | 0.31.3 (dev checkout `references/mlx-lm` @ `df1d3f3` — "Fix Gemma 4 sanitize() not stripping KV projections for shared layers" #1240) |
-| **mlx-vlm baseline** | dev checkout `references/mlx-vlm` @ `d85ca4d` — "Compatibility bridge for non-VL models" #1181 |
+| **mlx-lm baseline** | 0.31.3 (dev checkout `references/mlx-lm` @ `df1d3f3` — "Fix Gemma 4 sanitize() not stripping KV projections for shared layers" ml-explore/mlx-lm#1240) |
+| **mlx-vlm baseline** | dev checkout `references/mlx-vlm` @ `d85ca4d` — "Compatibility bridge for non-VL models" Blaizzy/mlx-vlm#1181 |
 | **Test Prompt** | "Hello, how are you today?" (text) / "What is in this image?" (VLM) |
 | **Max Tokens** | 100 (measured pass); 20 (warmup pass, same process) |
 | **Test Date** | 2026-05-19 full sweep (baseline); 2026-05-28 full text + VLM re-benchmark on mlxcel 0.1.0 (`--cooldown 0`) |
@@ -110,11 +110,11 @@ Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra
 | qwen3_moe | Qwen3-30B-A3B-4bit | ✅ | 191.96 | 72.17 | **103%** | mlx-lm: 70.18 |
 | qwen3_5_moe | qwen3.5-35B-A3B-4bit | ✅ | 239.05 | 71.38 | 93% | mlx-lm: 76.44; Hybrid GatedDeltaNet + MoE (256 experts); only 34 tokens |
 | phimoe | Phi-3.5-MoE-instruct-4bit | ✅ | 112.10 | 77.71 | **112%** | mlx-lm: 69.28 |
-| solar_open | Solar-Open-100B-4bit | ✅ | 75.37 | 36.26 | **102%** | mlx-lm: 35.69; 128 experts, top-8; layer-eval skip (PR #724); 54GB |
+| solar_open | Solar-Open-100B-4bit | ✅ | 75.37 | 36.26 | **102%** | mlx-lm: 35.69; 128 experts, top-8; layer-eval skip; 54GB |
 | solar_open (int4) | Solar-Open-100B-int4 | ✅ | - | 11.55 | - | mlx-lm: fails to load; 128 experts, top-8; int4 quantization; 54GB |
 | olmoe | - | ⏳ | - | - | - | |
-| gpt_oss (20B) | gpt-oss-20b-MXFP4-Q4 | ✅ | 286.09 | 93.46 | **104%** | mlx-lm: 89.51; MXFP4 quantization; 32 experts; bf16 decode fix (PR #721) |
-| gpt_oss (120B) | gpt-oss-120b-4bit | ✅ | 114.12 | 61.19 | **106%** | mlx-lm: 57.58; 128 experts, top-4; 61GB model; bf16 decode fix (PR #721) |
+| gpt_oss (20B) | gpt-oss-20b-MXFP4-Q4 | ✅ | 286.09 | 93.46 | **104%** | mlx-lm: 89.51; MXFP4 quantization; 32 experts; bf16 decode fix |
+| gpt_oss (120B) | gpt-oss-120b-4bit | ✅ | 114.12 | 61.19 | **106%** | mlx-lm: 57.58; 128 experts, top-4; 61GB model; bf16 decode fix |
 
 ## DeepSeek Family
 
@@ -185,7 +185,7 @@ Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra
 |-------|------------|--------|---------|--------|------------|-------|
 | gemma3 | gemma-3-4b-it-4bit | ✅ | 241.77 | 87.01 | 93% | mlx-vlm: 93.79; SigLIP + AvgPool; 275 prompt, 16 gen |
 | gemma3n (E2B) | gemma-3n-E2B-it-4bit | ✅ | 771.21 | 72.83 | **122%** | mlx-vlm: 59.57; MobileNetV5 + MSFA; 273 prompt, 29 gen |
-| gemma3n (E4B bf16) | gemma-3n-E4B-it (bf16) | ✅ | 659.78 | 32.46 | 90% | mlx-vlm: 36.18; MobileNetV5 + MSFA; bf16 prefill path retune (PR #727); bf16; 273 prompt, 24 gen |
+| gemma3n (E4B bf16) | gemma-3n-E4B-it (bf16) | ✅ | 659.78 | 32.46 | 90% | mlx-vlm: 36.18; MobileNetV5 + MSFA; bf16 prefill path retune; bf16; 273 prompt, 24 gen |
 | gemma3n (E4B 4bit) | gemma-3n-E4B-it-4bit | ✅ | 492.52 | 57.50 | **115%** | mlx-vlm: 50.00; 273 prompt, 33 gen |
 | gemma4 (E2B 4bit) | gemma-4-e2b-it-4bit | ✅ | 732.53 | 106.92 | **110%** | mlx-vlm: 97.19; 274 prompt, 100 gen |
 | gemma4 (E2B 8bit) | gemma-4-e2b-it-8bit | ✅ | 724.08 | 81.98 | 90% | mlx-vlm: 91.06; 274 prompt, 100 gen |
@@ -213,20 +213,20 @@ Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra
 | internvl3 | InternVL3-1B | ✅ | 1902.58 | 228.83 | 87% | mlx-vlm: 264.40; InternViT + pixel-shuffle + Qwen2; 293 prompt, 8 gen |
 | nemotron-omni | Nemotron-3-Nano-Omni-30B-A3B-Reasoning-4bit | ✅ | 263.15 | 69.37 | - | mlx-vlm: FAIL; NEW (5-19); Mamba2+Transformer+MoE+Parakeet audio; 100 gen |
 | youtu-vl | youtu-vl-4b-instruct | ⚠️ | 408.21 | 24.47 | - | mlx-vlm: FAIL; NEW (5-19); only 1 gen token |
-| qwen2-vl | Qwen2-VL-2B-Instruct-4bit | ✅ | 788.00 | 124.99 | - | Custom ViT + MRoPE; VLM image mode fixed (#749); 100 gen |
+| qwen2-vl | Qwen2-VL-2B-Instruct-4bit | ✅ | 788.00 | 124.99 | - | Custom ViT + MRoPE; VLM image mode fixed; 100 gen |
 | qwen2.5-vl | Qwen2.5-VL-3B-Instruct-4bit | ✅ | 599.48 | 97.81 | - | Windowed ViT + MRoPE; 91 prompt, 46 gen; mlx-vlm requires PyTorch |
-| qwen3-vl | Qwen3-VL-2B-Instruct-4bit | ✅ | 766.49 | 162.21 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
-| qwen3-vl (4B) | Qwen3-VL-4B-Instruct-4bit | ✅ | 490.85 | 90.14 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
-| qwen3-vl (8B) | Qwen3-VL-8B-Instruct-4bit | ✅ | 313.03 | 62.62 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
-| qwen3-vl (32B) | Qwen3-VL-32B-Instruct-4bit | ✅ | 92.07 | 17.92 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE (PR #729); 100 gen |
-| qwen3-vl-moe | Qwen3-VL-30B-A3B-Instruct-4bit | ✅ | 296.81 | 40.88 | - | mlx-vlm: FAIL; MoE (128 experts) + DeepStack (PR #729); 100 gen |
+| qwen3-vl | Qwen3-VL-2B-Instruct-4bit | ✅ | 766.49 | 162.21 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE; 100 gen |
+| qwen3-vl (4B) | Qwen3-VL-4B-Instruct-4bit | ✅ | 490.85 | 90.14 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE; 100 gen |
+| qwen3-vl (8B) | Qwen3-VL-8B-Instruct-4bit | ✅ | 313.03 | 62.62 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE; 100 gen |
+| qwen3-vl (32B) | Qwen3-VL-32B-Instruct-4bit | ✅ | 92.07 | 17.92 | - | mlx-vlm: FAIL; DeepStack + vectorized MRoPE; 100 gen |
+| qwen3-vl-moe | Qwen3-VL-30B-A3B-Instruct-4bit | ✅ | 296.81 | 40.88 | - | mlx-vlm: FAIL; MoE (128 experts) + DeepStack; 100 gen |
 | qwen3.5-vl (0.8B) | qwen3.5-0.8B-4bit | ✅ | 946.46 | 233.81 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 53 gen |
 | qwen3.5-vl (2B) | qwen3.5-2B-4bit | ✅ | 546.64 | 172.92 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 58 gen |
 | qwen3.5-vl (4B) | qwen3.5-4B-4bit | ✅ | 332.57 | 100.46 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 30 gen |
 | qwen3.5-vl (9B 4bit) | qwen3.5-9B-4bit | ✅ | 196.03 | 74.05 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 62 gen |
 | qwen3.5-vl (9B bf16) | qwen3.5-9B (bf16) | ✅ | 279.39 | 32.74 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 78 gen; bf16 |
 | qwen3.5-vl (27B) | qwen3.5-27B-4bit | ✅ | 74.86 | 25.24 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet VLM; 57 prompt, 42 gen |
-| qwen3.5-vl-moe | qwen3.5-35B-A3B-4bit | ✅ | 274.14 | 70.22 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet + MoE VLM; 57 prompt, 47 gen; gated delta decode RMSNorm fix (PR #730) |
+| qwen3.5-vl-moe | qwen3.5-35B-A3B-4bit | ✅ | 274.14 | 70.22 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet + MoE VLM; 57 prompt, 47 gen; gated delta decode RMSNorm fix |
 | qwen3.6-vl-moe | qwen3.6-35B-A3B-4bit | ✅ | 274.13 | 66.80 | - | mlx-vlm: FAIL; Hybrid GatedDeltaNet + MoE VLM; 100 gen |
 | molmo-point | - | ⏳ | - | - | - | Molmo-Point (point detection); implemented but no MLX model available |
 
@@ -288,7 +288,7 @@ Source CSVs (same M1 Ultra host; mlxcel 0.1.0 measured 2026-05-28 with `--cooldo
 
 The mlx-lm / mlx-vlm baselines are the pinned 2026-05-19 reference checkout (the reference is fixed, so its decode on this host is stable); the mlxcel side is the 2026-05-28 full sweep. All sweeps use `--max-tokens 100` and the same `Hello, how are you today?` / `What is in this image?` prompts. `deepseek-v3-4bit` and `qwen3-next-480b-4bit` exceed the 128GB host on both sides; `minimax-m2-3bit` now fits and runs on the mlxcel side (32.62 tok/s) but mlx-lm still fails it, so it stays outside the comparable set.
 
-Numbers are decode tok/s. `mlxcel vs mlx-lm` is `mlxcel / mlx-lm` as a percentage; **bold** = mlxcel >= mlx-lm. `FAIL` cells are real load/runtime errors on that backend with this configuration. The mlx-lm checkout used here (`df1d3f3` — "Fix Gemma 4 sanitize() not stripping KV projections for shared layers" #1240) is newer than the M5 Max page's `ed1fca4`, so some FAIL categories differ.
+Numbers are decode tok/s. `mlxcel vs mlx-lm` is `mlxcel / mlx-lm` as a percentage; **bold** = mlxcel >= mlx-lm. `FAIL` cells are real load/runtime errors on that backend with this configuration. The mlx-lm checkout used here (`df1d3f3` — "Fix Gemma 4 sanitize() not stripping KV projections for shared layers" ml-explore/mlx-lm#1240) is newer than the M5 Max page's `ed1fca4`, so some FAIL categories differ.
 
 ### Aggregate (text)
 
@@ -515,9 +515,9 @@ Ran all 80 local models (45GB threshold) to verify text/image generation.
 | SentencePiece | `tokenizer.model` | Gemma, Llama 1/2, older models | `sentencepiece` |
 | Tiktoken | `*.tiktoken` | HunYuan MoE (13B) | Custom BPE (fancy-regex) |
 
-## TurboQuant KV cache — M1 Ultra speed gate readings (issue #509)
+## TurboQuant KV cache — M1 Ultra speed gate readings
 
-First dedicated M1 Ultra reading of the epic-#458 KV speed gate matrix.
+First dedicated M1 Ultra reading of the epic- KV speed gate matrix.
 Hardware: Apple M1 Ultra, 128 GB unified memory. Model:
 `Meta-Llama-3.1-8B-Instruct-4bit`. Date: 2026-04-29. Reproducer:
 `./scripts/bench_kv_cache.sh --modes fp16,int8,turbo4-asym,turbo4,turbo4-delegated --contexts 4096 --prefill-contexts 8192`.
@@ -555,7 +555,7 @@ modes ran the full 80 tokens.
 
 ### M1 Ultra reading
 
-Per epic #458 §"Cross-hardware regression", the M5 Max gates are tracking
+ §"Cross-hardware regression", the M5 Max gates are tracking
 only on pre-M3 hardware. The numbers above match that guidance: `turbo4`
 and `turbo4-asym` decode are well below the M5 gates on M1 Ultra, while
 `turbo4-delegated` prefill is bit-identical to FP16 because the cold pages
@@ -563,7 +563,7 @@ keep their FP16 representation and only the hot tail is packed.
 
 The decode regression is consistent with the L2-cache wall documented in
 `references/turboquant_plus/`. The fused Sparse-V Metal kernel that lands
-in #505 targets the per-thread skip path inside the SDPA inner loop and is
+ targets the per-thread skip path inside the SDPA inner loop and is
 expected to recover most of the M5 decode budget; the M1/M2 ceiling stays
 limited by L2 bandwidth and is documented but not gated.
 
@@ -572,7 +572,7 @@ limited by L2 bandwidth and is documented but not gated.
 - **`turbo4-delegated` is the only currently shipping mode that holds the
   prefill gate on M1 Ultra.** Use it when prefill latency matters more than
   the maximum compression ratio.
-- **`turbo4-asym` on M1 Ultra needs the #505 fused kernel** to be a viable
+- **`turbo4-asym` on M1 Ultra needs the fused kernel** to be a viable
   decode option. The graph-level path measured here pays a per-token
   dequant cost that the fused kernel folds into the SDPA inner loop.
 - **Avoid `turbo3` on M1 Ultra** for decode-bound workloads. The 3-bit
@@ -582,13 +582,12 @@ limited by L2 bandwidth and is documented but not gated.
   still delivers approximately 0.39× of the FP16 baseline KV footprint at the
   default boundary-v 2 on a 32-layer model, but the decode shortfall above
   makes `turbo4-delegated` the better practical choice on this generation
-  until the #505 fused kernel lands. Pick `fp16+turbo4` only if the memory
+  until the fused kernel lands. Pick `fp16+turbo4` only if the memory
   savings outweigh the per-token decode cost for your workload.
 
 ### Deferred
 
-- 32K decode reading (best-effort per epic; benefits from #505 fused kernel
-  before the gate is meaningful on any hardware).
+- 32K decode reading (best-effort per epic; benefits fused kernel before the gate is meaningful on any hardware).
 - Per-mode 16K decode (skipped for the initial run; M5 Max is the primary
   target for the 16K gate).
 - Multi-model expansion (Qwen 2.5, Gemma 3, etc.).

--- a/docs/benchmark_results/model_tests_m5max.md
+++ b/docs/benchmark_results/model_tests_m5max.md
@@ -89,8 +89,8 @@ Compatibility and performance testing for mlxcel models on **MacBook Pro M5 Max 
 | qwen3-30b-a3b | Qwen3-30B-A3B-4bit | ✅ | 414.20 | 156.15 | **2.20x** | 34 tokens |
 | qwen3-moe | Qwen3-MoE-30B-4bit | ✅ | 414.14 | 157.16 | **2.20x** | 34 tokens |
 | qwen3-vl (2B) | Qwen3-VL-2B-Instruct-4bit | ✅ | 1367.27 | 365.31 | **1.69x** | 58 tokens; text-only |
-| qwen3-vl (30B MoE) | Qwen3-VL-30B-A3B-Instruct-4bit | ✅ | 322.02 | 151.16 | **2.17x** | 35 tokens; text-only; #719 |
-| qwen3-vl (32B) | Qwen3-VL-32B-Instruct-4bit | ✅ | 119.55 | 27.51 | **1.33x** | 30 tokens; text-only; #719 |
+| qwen3-vl (30B MoE) | Qwen3-VL-30B-A3B-Instruct-4bit | ✅ | 322.02 | 151.16 | **2.17x** | 35 tokens; text-only |
+| qwen3-vl (32B) | Qwen3-VL-32B-Instruct-4bit | ✅ | 119.55 | 27.51 | **1.33x** | 30 tokens; text-only |
 | qwen3-next (480B) | Qwen3-Next-480B-4bit | ❌ | - | FAIL | - | SKIP:oom_estimate |
 | qwen3.5 (0.8B) | Qwen3.5-0.8B-4bit | ✅ | 2346.25 | 517.47 | **2.13x** | 29 tokens |
 | qwen3.5 (2B) | Qwen3.5-2B-4bit | ✅ | 1266.52 | 320.84 | **1.86x** | 19 tokens |
@@ -127,8 +127,8 @@ Compatibility and performance testing for mlxcel models on **MacBook Pro M5 Max 
 | minimax | MiniMax-M2-3bit | ✅ | 185.84 | 73.76 | - | 100 tokens |
 | mixtral | Mixtral-8x7B-Instruct-v0.1-4bit | ✅ | 83.19 | 65.20 | **1.22x** | 73 tokens |
 | gpt_oss (20B) | gpt-oss-20b-MXFP4-Q4 | ✅ | 960.63 | 172.33 | **1.94x** | 100 tokens |
-| gpt_oss (120B) | gpt-oss-120b-4bit | ✅ | 334.68 | 114.03 | **1.94x** | 78 tokens; issue #715 fix |
-| solar-open-100b | Solar-Open-100B-4bit | ✅ | 210.91 | 65.36 | **1.82x** | 100 tokens; issue #717 fix |
+| gpt_oss (120B) | gpt-oss-120b-4bit | ✅ | 334.68 | 114.03 | **1.94x** | 78 tokens |
+| solar-open-100b | Solar-Open-100B-4bit | ✅ | 210.91 | 65.36 | **1.82x** | 100 tokens |
 
 ## DeepSeek Family
 
@@ -178,13 +178,13 @@ Compatibility and performance testing for mlxcel models on **MacBook Pro M5 Max 
 | mistral-small | mistral-small-3.1-24b-4bit | ✅ | 90.62 | 41.41 | **1.31x** | 100 tokens |
 | molmo2 | molmo2-4b | ✅ | 540.64 | 64.09 | 1.07x | 33 tokens |
 | molmo-7b | molmo-7b | ✅ | 338.65 | 78.74 | - | 24 tokens; text spot-check |
-| internvl3 | internvl3-1b | ✅ | 8628.27 | 661.48 | - | 37 tokens; #747 |
+| internvl3 | internvl3-1b | ✅ | 8628.27 | 661.48 | - | 37 tokens |
 | smollm-135m | SmolLM-135M-Instruct-4bit | ✅ | 6058.41 | 905.24 | **2.22x** | 100 tokens |
 | smollm3-3b | SmolLM3-3B-4bit | ✅ | 2242.59 | 232.79 | **1.71x** | 46 tokens |
 | stablelm-1.6b | stablelm-2-1_6b-chat-4bit | ✅ | 2887.08 | 425.14 | **1.52x** | 59 tokens |
 | starcoder2-3b | starcoder2-3b-4bit | ✅ | 455.12 | 216.48 | **1.26x** | 100 tokens |
 | pixtral-12b | pixtral-12b-4bit | ✅ | 149.44 | 76.56 | **1.11x** | 100 tokens; text-only |
-| paligemma2-3b | paligemma2-3b (6-bit) | ✅ | 496.59 | 168.83 | - | 100 tokens; text-only; #744 |
+| paligemma2-3b | paligemma2-3b (6-bit) | ✅ | 496.59 | 168.83 | - | 100 tokens; text-only |
 
 ## VLM (image input) — full sweep
 
@@ -207,7 +207,7 @@ All entries use the VLM prompt 'What is in this image?' with
 | gemma4 (E2B 8bit) | gemma-4-e2b-it-8bit | ✅ | 2674.11 | 133.74 | **1.66x** | 43 tokens |
 | gemma4 (E4B 4bit) | gemma-4-e4b-it-4bit | ✅ | 2064.85 | 134.10 | **1.84x** | 29 tokens |
 | gemma4 (E4B 8bit) | gemma-4-e4b-it-8bit | ✅ | 1911.38 | 76.28 | **1.39x** | 12 tokens |
-| internvl3 (1B) | internvl3-1b | ✅ | 6482.30 | 601.50 | - | 8 tokens; #747 |
+| internvl3 (1B) | internvl3-1b | ✅ | 6482.30 | 601.50 | - | 8 tokens |
 | llama4 (Scout) | llama-4-scout-17b-4bit | ✅ | 398.13 | 48.33 | **1.52x** | 100 tokens |
 | llava-1.5-7b | llava-1.5-7b-4bit | ✅ | 3141.70 | 117.70 | **1.16x** | 100 tokens |
 | llava-interleave | llava-interleave-qwen-0.5b-bf16 | ✅ | 13171.77 | 343.53 | **1.27x** | 36 tokens |
@@ -222,8 +222,8 @@ All entries use the VLM prompt 'What is in this image?' with
 | qwen2-vl (2B) | qwen2-vl-2b-4bit | ✅ | 2485.82 | 247.21 | - | 12 tokens; EOS-terminate |
 | qwen2.5-vl (3B) | qwen2.5-vl-3b-4bit | ✅ | 1696.53 | 156.83 | **1.61x** | 22 tokens; EOS-terminate; fixed by #34 |
 | qwen3-vl (2B) | qwen3-vl-2b-4bit | ✅ | 934.98 | 281.37 | **1.65x** | 100 tokens |
-| qwen3-vl (30B MoE) | qwen3-vl-30b-a3b-4bit | ✅ | 436.81 | 56.38 | - | 45 tokens; #719 |
-| qwen3-vl (32B) | qwen3-vl-32b-4bit | ✅ | 117.14 | 19.65 | 1.05x | 100 tokens; #719 |
+| qwen3-vl (30B MoE) | qwen3-vl-30b-a3b-4bit | ✅ | 436.81 | 56.38 | - | 45 tokens |
+| qwen3-vl (32B) | qwen3-vl-32b-4bit | ✅ | 117.14 | 19.65 | 1.05x | 100 tokens |
 
 ## Summary Statistics
 
@@ -431,10 +431,10 @@ crash (`olmo-1b-4bit`). These are mlx-lm/mlx-vlm regressions in the
 development checkout under `references/`, not silent mlxcel wins.
 
 
-## Issue #722 FP32 Promotion Audit
+## FP32 Promotion Audit
 
 Short prompt A/B runs on 2026-05-18 used `origin/main` at `5ebc074` as the
-baseline and the issue #722 branch as the candidate. Each row used:
+baseline and the branch as the candidate. Each row used:
 
 ```text
 mlxcel generate -m models/<model> -p "Hello, how are you today?" -n 20 --profile --no-chat-template
@@ -444,7 +444,7 @@ The intent is a hot-path regression/impact check, not a replacement for the
 100-token full sweep above. The clearest gains are the MoE rows that still used
 the `nkh,nk->nh` expert combine contraction.
 
-| Model | main prefill tok/s | #722 prefill tok/s | main decode tok/s | #722 decode tok/s | Decode change |
+| Model | main prefill tok/s | prefill tok/s | main decode tok/s | decode tok/s | Decode change |
 |---|---:|---:|---:|---:|---:|
 | `glm4-flash-4bit` | 5.54 | 15.82 | 54.85 | 108.23 | **+97.3%** |
 | `solar-open-100b-4bit` | 9.51 | 7.98 | 17.04 | 42.72 | **+150.7%** |
@@ -463,7 +463,7 @@ the `nkh,nk->nh` expert combine contraction.
 Reading:
 
 - `glm4-flash-4bit` and `solar-open-100b-4bit` confirm the same FP32-promotion
-  class as #715 in remaining MoE expert-weight combines.
+  class as in remaining MoE expert-weight combines.
 - Qwen3/Qwen3.5/Qwen3.6 A3B, Qwen3-VL A3B, Mixtral, and gpt-oss are effectively
   guardrail-neutral in this short run. Their MoE combines now share the same
   dtype-preserving helper, but the previous contraction was not the dominant
@@ -473,17 +473,17 @@ Reading:
   the compiled activation, softcap, scalar-helper, or intentional-FP32 comments
   and tests added for this audit.
 
-## Issue #717 SolarOpen Decode Sync Audit
+## SolarOpen Decode Sync Audit
 
-Issue #722 removed the accidental FP32 expert-weight combine and raised
-`solar-open-100b-4bit` decode into the low 40 tok/s range, but #717 still missed
+ removed the accidental FP32 expert-weight combine and raised
+`solar-open-100b-4bit` decode into the low 40 tok/s range, but still missed
 the >=85% mlx-lm decode gate. The remaining SolarOpen-specific difference was
 the Rust implementation forcing `eval_all()` after every decoder layer. That is
 useful for multi-token prefill graph size control, but in single-token decode it
 adds 48 GPU synchronizations per generated token. mlx-lm does not synchronize at
 each layer in the decode path.
 
-The #717 branch keeps per-layer eval for prefill and skips it only when the input
+The branch keeps per-layer eval for prefill and skips it only when the input
 sequence length is one token. Validation used the same direct real-model command:
 
 ```text
@@ -492,22 +492,22 @@ mlxcel generate -m models/solar-open-100b-4bit -p "Hello, how are you today?" -n
 
 | Build | Prefill tok/s | Decode tok/s | vs mlx-lm 66.30 tok/s |
 |---|---:|---:|---:|
-| `origin/main` after #723 (`616c470`) | 9.19 | 41.35 | 62% |
-| #717 branch | 34.02 | 65.66 | **99%** |
+| `origin/main` after (`616c470`) | 9.19 | 41.35 | 62% |
+| branch | 34.02 | 65.66 | **99%** |
 
 This is +58.8% decode over current main and +298.4% over the original 16.48
 tok/s issue baseline. The issue acceptance gate (>=56 tok/s) is met.
 
-## Issue #720 Moderate Gap Triage
+## Moderate Gap Triage
 
-The four #720 rows were rechecked on the M5 Max after #722, #717, #718, and
-#719 had landed on `main`. The original `falcon-mamba` row used a generic chat
+The four rows were rechecked on the M5 Max after, and
+ had landed on `main`. The original `falcon-mamba` row used a generic chat
 prompt that exits after `<|im_end|>` in both mlxcel and mlx-lm, so the useful
 comparison uses a raw code prompt that generates the full 100-token budget.
 
 | Model | Triage | Refreshed mlxcel decode | mlx-lm decode | Result |
 |---|---|---:|---:|---:|
-| `glm4-flash-4bit` | Real regression fixed by the already-merged #722 MoE combine change | 111.09 | 108.32 | **103%** |
+| `glm4-flash-4bit` | Real regression fixed by the already-merged MoE combine change | 111.09 | 108.32 | **103%** |
 | `falcon-mamba-7b-4bit` | Measurement artifact from early EOS on the generic chat prompt | 94.49 | 94.32 | **100%** |
 | `starcoder2-3b-4bit` | Already fixed on current `main`; dense transformer row now matches mlx-lm | 214.85 | 213.95 | **100%** |
 | `qwen3.5-0.8b-4bit` | Real GatedDeltaNet decode overhead fixed here via fast RMSNorm q/k and gated norm paths | 535.43 | 555.43 | 96% |
@@ -551,7 +551,7 @@ increase and 96% of mlx-lm's 555.43 tok/s on the same prompt.
   similar can span ±15% across back-to-back runs because 100 tokens generate in
   under 300 ms).
 
-## TurboQuant KV cache — M5 Max results (epic #458)
+## TurboQuant KV cache — M5 Max results
 
 > Note: The 2026-04-26 benchmark run (`benchmarks/turbo_kv/2026-04-26_Mac.localdomain.csv`)
 > was performed on a development machine (`Mac.localdomain`), not on the
@@ -570,21 +570,21 @@ on the MLX graph execution path, not peak generation throughput.
 |---|---|---|---|---|
 | Meta-Llama-3.1-8B-Instruct-4bit | fp16 | 733.76 | 111,617 | baseline |
 | Meta-Llama-3.1-8B-Instruct-4bit | turbo4asym | 490.32 | 167,034 | **pass** |
-| Qwen2.5-1.5B-Instruct-4bit (superseded) | fp16 | 3205.54 | 25,550 | superseded — see #506 |
-| Qwen2.5-1.5B-Instruct-4bit (superseded) | turbo4asym | 2227.09 | 36,775 | superseded — see #506 |
+| Qwen2.5-1.5B-Instruct-4bit (superseded) | fp16 | 3205.54 | 25,550 | superseded — |
+| Qwen2.5-1.5B-Instruct-4bit (superseded) | turbo4asym | 2227.09 | 36,775 | superseded — |
 
-The Qwen2.5-1.5B-Instruct-4bit rows above are retained for historical reference. Issue #506 found that fixture collapses on raw wikitext without a chat template; the B3 gate now uses the base variant `Qwen2.5-1.5B-4bit`. Re-run pending.
+The Qwen2.5-1.5B-Instruct-4bit rows above are retained for historical reference. found that fixture collapses on raw wikitext without a chat template; the B3 gate now uses the base variant `Qwen2.5-1.5B-4bit`. Re-run pending.
 
 For the full interpretation and per-model recommendations see
 [`docs/turbo-kv-cache.md`](turbo-kv-cache.md).
 
-## TurboQuant KV cache — M5 Max speed gate readings (issue #509)
+## TurboQuant KV cache — M5 Max speed gate readings
 
-First dedicated M5 Max reading of the epic-#458 KV speed gate matrix.
+First dedicated M5 Max reading of the epic- KV speed gate matrix.
 Hardware: Apple M5 Max, 128 GB unified memory, macOS 26.4.1 (build 25E253).
 Model: `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` (local dir
 `models/llama-3.1-8b-4bit`). Date: 2026-05-03. Binary: mlxcel 0.0.25
-post-#511 (fused Sparse-V Metal kernel landed). Reproducer:
+post- (fused Sparse-V Metal kernel landed). Reproducer:
 
 ```bash
 ./scripts/bench_kv_cache.sh \
@@ -611,28 +611,28 @@ Full CSV at `benchmarks/turbo_kv/2026-05-03_Apple_M5_Max_llama-3.1-8b-4bit.csv`.
 | `int8`             |  72.79 | 0.719× | (no gate; tracking) | tracking |
 | `turbo4-asym`      |   9.15 | 0.090× | ≥0.97× | **fail** |
 | `turbo4`           |  20.76 | 0.205× | ≥0.93× | **fail** |
-| `turbo4-delegated` |  27.28 | 0.269× | ≥0.97× | **fail** (issue #521; partial fix landed) |
+| `turbo4-delegated` |  27.28 | 0.269× | ≥0.97× | **fail** (partial fix landed) |
 | `turbo3-asym`      |   6.36 | 0.063× | (tracking only) | tracking |
 
-Issue #521 (PR #525) caches the cold-V dequant graph across decode steps;
+ caches the cold-V dequant graph across decode steps;
 informal in-tree A/B (100-token decode at the same 4K prompt) measures
 `turbo4-delegated` at ~41 tok/s post-fix vs ~27 tok/s on v0.0.25, a ~1.5×
 decode speedup that scales sharply at longer contexts.
 
-**PR #529 Phase-1b (K-side unification, issue #527):** Removes `cold_keys` and
+** Phase-1b (K-side unification):** Removes `cold_keys` and
 the per-step `concat(cold_k, hot_k)` graph node. Informal A/B on M5 Max
 (3 warm runs each, `llama-3.1-8b-4bit`, 4109-token prompt, 100 generated
-tokens): fp16 baseline 101.5–102.7 tok/s; turbo4-delegated post-PR #529
+tokens): fp16 baseline 101.5–102.7 tok/s; turbo4-delegated post-
 43.0–43.7 tok/s (~0.43× FP16, up from ~0.41× pre-fix). The modest speedup is
 explained by `SliceUpdate::eval_gpu` semantics: MLX copies the full source
 buffer before writing the update region, so per-step K-side memory traffic is
 approximately conserved between the old concat layout and the new slice-update
 layout. The remaining cost is the V-side `concat(cold_v_dequant, hot_v)`
-graph node (Phase 2, issue #528).
+graph node (Phase 2).
 
-**Issue #528 Phase-2 (fused dequant + SDPA kernel):** Adds a Metal kernel
+** Phase-2 (fused dequant + SDPA kernel):** Adds a Metal kernel
 that reads the packed cold V indices directly inside the kernel, removing
-the PR-#525 `cold_v_dequant_cache` memo and the per-step
+the earlier `cold_v_dequant_cache` memo and the per-step
 `concat(cold_v_dequant, hot_v)` graph node. The dequantised cold V never
 materialises in global memory — V-memory budget stays at 4-bit packed.
 
@@ -645,24 +645,24 @@ Measured on `llama-3.1-8b-4bit`, 4109-token prompt, 100 generated tokens
 | `turbo4-delegated` default (no memo) | 29.60 | 0.291× | ≥0.97× — **fail** |
 | `turbo4-delegated` fused kernel (`MLXCEL_TURBO4_DELEGATED_FUSED=1`) | 18.90 | 0.186× | ≥0.97× — **fail** |
 
-Removing the PR-#525 memo (per the issue body's "creates dead state, must
+Removing the earlier memo (per the issue body's "creates dead state, must
 not remain" requirement) drops the legacy `update_and_fetch` route from
 ~0.43× to 0.29×. The fused kernel runs slower than the no-memo legacy
 route because the host pipeline now composes Q·K + softmax + cold-kernel +
 hot-matmul + sum out of many small MLX graph ops; the memo path could feed
 the dequantised cold V into a single steel-attention SDPA call. The
-0.97× M5 Max decode gate is **not cleared** by issue #528. Bringing the
+0.97× M5 Max decode gate is **not cleared**. Bringing the
 kernel inside the steel-attention envelope is left to follow-up work.
 
-**Issue #531 Phase-3 (steel-attention-envelope kernel, M5 Max measurement).**
-PR #532 lands `turbo4_delegated_steel_sdpa` — a JIT-compiled Metal kernel
+** Phase-3 (steel-attention-envelope kernel, M5 Max measurement).**
+ lands `turbo4_delegated_steel_sdpa` — a JIT-compiled Metal kernel
 that runs the entire post-Q·K SDPA inline (per-Q numerically stable
 softmax, cold-V dequant + weighted sum, hot-V FP16 weighted sum, all
 normalised against the same softmax denominator). Bit-parity is gate-1
 and was validated at PR-landing time (RMS < 5e-3 over 200 decode steps,
 two new parity tests in `cache::turbo_tests`). M5 Max throughput was
 deferred to a follow-up bench run because the kernel-author agent had no
-M5 Max access from PR #532's run.
+M5 Max access's run.
 
 Measured on `llama-3.1-8b-4bit`, 4109-token prompt, 100 generated tokens
 (`benchmarks/turbo_kv/2026-05-06_Apple_M5_Max_issue_531_steel_envelope.csv`):
@@ -670,50 +670,49 @@ Measured on `llama-3.1-8b-4bit`, 4109-token prompt, 100 generated tokens
 | Path | tok/s | × FP16 | gate |
 |---|---:|---:|---:|
 | `fp16` | 102.97 | 1.000× | baseline |
-| `turbo4-delegated` legacy `update_and_fetch + attention()` (env unset) | 29.60* | 0.291× | ≥0.97× — **fail** (issue #528 reading) |
-| `turbo4-delegated` cold-only fused kernel (`MLXCEL_TURBO4_DELEGATED_FUSED=1`, pre-#532) | 18.90* | 0.186× | ≥0.97× — **fail** (issue #528 reading) |
-| `turbo4-delegated` steel envelope (`MLXCEL_TURBO4_DELEGATED_FUSED=1`, post-#532) | 16.23 | 0.158× | ≥0.97× — **fail** |
+| `turbo4-delegated` legacy `update_and_fetch + attention()` (env unset) | 29.60* | 0.291× | ≥0.97× — **fail** (reading) |
+| `turbo4-delegated` cold-only fused kernel (`MLXCEL_TURBO4_DELEGATED_FUSED=1`, earlier) | 18.90* | 0.186× | ≥0.97× — **fail** (reading) |
+| `turbo4-delegated` steel envelope (`MLXCEL_TURBO4_DELEGATED_FUSED=1`, post-) | 16.23 | 0.158× | ≥0.97× — **fail** |
 
-`*` cross-referenced from the 2026-05-04 issue #528 CSV.
+`*` cross-referenced from the 2026-05-04 CSV.
 
 The steel envelope runs slower than both the cold-only fused kernel and
 the legacy fetch route. The likely cause is the kernel's single-thread-per-Q
 softmax + V accumulation pass — at decode time (`Tq=1`, `B=1`, `Hkv=8` on
 llama-3.1-8b) only 8 threads are dispatched per kernel call, each scanning
-the full T_total range serially. The PR #532 implementation note
+the full T_total range serially. The implementation note
 acknowledges this design ("single thread; T_total reads << kernel launch
 overhead, avoids threadgroup tree-reduction barriers") — the assumption
 held on M1 Ultra at parity contexts but breaks on M5 Max where the
 threadgroup tree-reduction would actually be faster than the serial scan.
 
-**Issue #534 readings (Pass 1 parallelization + cold-loop sparse cutoff on top
-of #532).** Issue #534 splits the kernel's Pass 1 (per-Q max + sum_exp) across
+** readings (Pass 1 parallelization + cold-loop sparse cutoff on top).** splits the kernel's Pass 1 (per-Q max + sum_exp) across
 all D threads of each threadgroup with a tree reduction. The follow-up in this
 PR also precomputes a score-space sparse-V cutoff
 `max + log(threshold * sum_exp)`, letting the cold loop reject fully-dead tokens
 before paying the exp + dequant cost. Pass 2's weighted-sum remains
-D-parallelized exactly as in #532. Measured on `llama-3.1-8b-4bit`,
+D-parallelized exactly as. Measured on `llama-3.1-8b-4bit`,
 4109-token prompt, 100 generated tokens
 (`benchmarks/turbo_kv/2026-05-06_Apple_M5_Max_issue_534_post_fix.csv`):
 
 | Path | tok/s | × FP16 | gate |
 |---|---:|---:|---:|
 | `fp16` | 103.28 | 1.000× | baseline |
-| `turbo4-delegated` steel envelope **pre-#534** (PR #533 reading) | 16.23 | 0.158× | ≥0.97× — **fail** |
-| `turbo4-delegated` steel envelope **post-#534** (this fix)        | 19.21 | 0.186× | ≥0.97× — **still fail** |
+| `turbo4-delegated` steel envelope **earlier** (reading) | 16.23 | 0.158× | ≥0.97× — **fail** |
+| `turbo4-delegated` steel envelope **post-** (this fix)        | 19.21 | 0.186× | ≥0.97× — **still fail** |
 
 Pass 1 parallelization plus the score-space cutoff nudges the steel envelope
-slightly past the issue #528 cold-only fused kernel at 4K (19.21 vs 18.90)
+slightly past the cold-only fused kernel at 4K (19.21 vs 18.90)
 but does not move the needle far enough to clear the 0.97× gate. The residual
 cost is in Pass 2's per-token T_total scan. A simdgroup broadcast experiment
-was also measured during #534 and regressed 4K decode, so it was not retained.
+was also measured during and regressed 4K decode, so it was not retained.
 The broader simdgroup-hybrid pattern from MLX upstream's
 `metal::steel::SDPA` (per-simdgroup `simd_max` / `simd_sum` plus
 per-simdgroup partial-sum accumulators in Pass 2) is the proposed next
 iteration; it would change the per-token per-thread T_total scan into a
 per-token per-simdgroup scan (4–8× fewer scans on M5 Max for D=128 / D=256).
 
-#### Post-#534 TurboQuant+ delegated FP16 working-set experiment (4K)
+#### Post- TurboQuant+ delegated FP16 working-set experiment (4K)
 
 Follow-up on 2026-05-07 after comparing `references/turboquant_plus`: the MLX
 delegated KVCache keeps FP16 K/V in an internal native cache and routes decode
@@ -729,11 +728,11 @@ without putting that cost in decode timing. Measured on `llama-3.1-8b-4bit`,
 | Path | tok/s | x FP16 | gate |
 |---|---:|---:|---:|
 | `fp16` | 105.23 | 1.000x | baseline |
-| `turbo4-delegated` steel envelope **post-#534** | 19.21 | 0.183x | >=0.97x — **fail** |
+| `turbo4-delegated` steel envelope **post-** | 19.21 | 0.183x | >=0.97x — **fail** |
 | `turbo4-delegated` FP16 fast path + pre-decode compact | 104.09 | 0.989x | >=0.97x — **pass** |
 
-The fast path is 5.4x faster than the post-#534 steel envelope at 4K and 3.5x
-faster than the legacy `update_and_fetch + attention()` reading from issue #528
+The fast path is 5.4x faster than the post- steel envelope at 4K and 3.5x
+faster than the legacy `update_and_fetch + attention` reading
 (29.60 tok/s). It clears the 0.97x gate because the one-time sidecar
 compaction is no longer charged to the first decode forward. This remains a
 speed-path experiment, not the compressed-only memory target, because the full
@@ -741,7 +740,7 @@ FP16 V working set is retained while the env var is enabled. The handoff is
 still visible in prefill timing for the decode-stage row: 2462.77 ms vs
 1271.07 ms for FP16 at 4K.
 
-#### Post-#536 lazy sidecar policy experiment (4K)
+#### Post- lazy sidecar policy experiment (4K)
 
 Follow-up on the pre-decode handoff: `MLXCEL_TURBO4_DELEGATED_FP16_SIDECARS=lazy`
 skips foreground packed sidecar folds during generation and compacts missing
@@ -768,7 +767,7 @@ FP16 is now ~211 ms at 4K instead of ~1194 ms.
 | `int8`             | 36.35 | 0.572× | 80 | (no gate; tracking) | tracking |
 | `turbo4-asym`      |  3.87 | 0.061× | 26 | ≥0.95× | **fail** |
 | `turbo4`           |  6.76 | 0.106× | 80 | ≥0.90× | **fail** |
-| `turbo4-delegated` |  3.41 | 0.054× | 21 | ≥0.95× | **fail** (issue #528 — see below) |
+| `turbo4-delegated` |  3.41 | 0.054× | 21 | ≥0.95× | **fail** (— see below) |
 | `turbo3-asym`      |  1.85 | 0.029× | 54 | (tracking only) | tracking |
 
 The repeated-paragraph prompt hits an EOS early on `fp16`, `turbo4-asym`,
@@ -776,7 +775,7 @@ The repeated-paragraph prompt hits an EOS early on `fp16`, `turbo4-asym`,
 computed over the actually generated tokens. `int8` and symmetric `turbo4`
 ran the full 80 tokens.
 
-#### Issue #528 16K reading (50-token decode, no EOS early-exit)
+#### 16K reading (50-token decode, no EOS early-exit)
 
 Measured on `llama-3.1-8b-4bit`, ~16065-token prompt
 (`benchmarks/turbo_kv/2026-05-04_Apple_M5_Max_issue_528_fused_delegated_sdpa.csv`):
@@ -787,14 +786,13 @@ Measured on `llama-3.1-8b-4bit`, ~16065-token prompt
 | `turbo4-delegated` default (no memo) | 6.03 | 0.081× | ≥0.95× — **fail** |
 | `turbo4-delegated` fused kernel | 5.12 | 0.069× | ≥0.95× — **fail** |
 
-Same shape as the 4K reading: removing the PR-#525 memo (issue #528
-requirement) regressed the legacy fetch path; the fused kernel is slower
+Same shape as the 4K reading: removing the earlier memo (requirement) regressed the legacy fetch path; the fused kernel is slower
 still. The gate is wider here because at 16K the dequant cost dominates;
 the per-step memo materialised ~52 MB / layer of FP16 cold V, which is
 gone, but the kernel cannot replace the steel-attention SDPA pipeline
 the memo enabled.
 
-#### Issue #531 16K reading (early-EOS at 19 generated tokens)
+#### 16K reading (early-EOS at 19 generated tokens)
 
 Measured on `llama-3.1-8b-4bit`, 16163-token prompt, 100 requested decode
 tokens (early EOS at 19 on both modes — same prompt shape early-exits FP16
@@ -805,31 +803,31 @@ fair). Same CSV as the 4K reading
 | Path | tok/s | Generated | × FP16 | gate |
 |---|---:|---:|---:|---:|
 | `fp16` | 63.94 | 19 | 1.000× | baseline |
-| `turbo4-delegated` steel envelope (post-#532) | 2.39 | 19 | 0.037× | ≥0.95× — **fail** |
+| `turbo4-delegated` steel envelope (post-) | 2.39 | 19 | 0.037× | ≥0.95× — **fail** |
 
 The 16K decode ratio (3.7% of FP16) is the gate's worst-case shortfall in
-the epic-#458 matrix to date, ~1.4× worse than the cold-only kernel
-reading from issue #528 (5.12 tok/s, 0.069× FP16). At 16K the per-token
+the epic- matrix to date, ~1.4× worse than the cold-only kernel
+reading (5.12 tok/s, 0.069× FP16). At 16K the per-token
 serial scan over T_total is ~16K reads × 8 threads, completely dwarfing
 the tens of milliseconds the FP16 attention path needs for the same step.
 
-#### Issue #534 16K reading (Pass 1 parallelization, early-EOS at 19–21 tokens)
+#### 16K reading (Pass 1 parallelization, early-EOS at 19–21 tokens)
 
-Same prompt shape as the issue #531 reading; FP16 early-exits at 19 and
-the post-#534 turbo4-delegated path at 21 (one extra token before EOS).
+Same prompt shape as the reading; FP16 early-exits at 19 and
+the post- turbo4-delegated path at 21 (one extra token before EOS).
 CSV: `benchmarks/turbo_kv/2026-05-06_Apple_M5_Max_issue_534_post_fix.csv`.
 
 | Path | tok/s | Generated | × FP16 | gate |
 |---|---:|---:|---:|---:|
 | `fp16` | 64.78 | 19 | 1.000× | baseline |
-| `turbo4-delegated` steel envelope **pre-#534** (PR #533) | 2.39 | 19 | 0.037× | ≥0.95× — **fail** |
-| `turbo4-delegated` steel envelope **post-#534** (this fix) | 2.99 | 21 | 0.046× | ≥0.95× — **still fail** |
+| `turbo4-delegated` steel envelope **earlier** | 2.39 | 19 | 0.037× | ≥0.95× — **fail** |
+| `turbo4-delegated` steel envelope **post-** (this fix) | 2.99 | 21 | 0.046× | ≥0.95× — **still fail** |
 
-The #534 fixes move the 16K ratio from 3.7% to 4.6% of FP16 (a 25% relative
+The fixes move the 16K ratio from 3.7% to 4.6% of FP16 (a 25% relative
 improvement) but do not clear the gate. The residual gap is in Pass 2; see the
 simdgroup-hybrid follow-up note in the 4K subsection above.
 
-#### Post-#534 TurboQuant+ delegated FP16 working-set experiment (16K)
+#### Post- TurboQuant+ delegated FP16 working-set experiment (16K)
 
 Same fast-path experiment as the 4K subsection, measured on the 16163-token
 prompt. Both modes early-exited at 19 generated tokens
@@ -838,7 +836,7 @@ prompt. Both modes early-exited at 19 generated tokens
 | Path | tok/s | Generated | x FP16 | gate |
 |---|---:|---:|---:|---:|
 | `fp16` | 65.55 | 19 | 1.000x | baseline |
-| `turbo4-delegated` steel envelope **post-#534** | 2.99 | 21 | 0.046x | >=0.95x — **fail** |
+| `turbo4-delegated` steel envelope **post-** | 2.99 | 21 | 0.046x | >=0.95x — **fail** |
 | `turbo4-delegated` FP16 fast path + pre-decode compact | 70.37 | 19 | 1.074x | >=0.95x — **pass** |
 
 This confirms the earlier fast-path bottleneck was the first-decode sidecar
@@ -848,7 +846,7 @@ decode uses the same unified FP16 K/V native-SDPA hot path as FP16 mode. The
 FP16-class rather than a stable speedup claim. The handoff cost moved into the
 decode-stage prefill timing: 11070.22 ms vs 7952.33 ms for FP16 at 16K.
 
-#### Post-#536 lazy sidecar policy experiment (16K)
+#### Post- lazy sidecar policy experiment (16K)
 
 Same lazy-sidecar experiment as the 4K subsection, measured on the 16163-token
 prompt with early EOS at 19 generated tokens
@@ -883,7 +881,7 @@ prefill commits.
 
 ### M5 Max reading
 
-The Turbo decode gates from epic #458 do **not** pass on the
+The Turbo decode gates do **not** pass on the
 v0.0.25 binary as of 2026-05-03, on any of the three Turbo modes. The
 shortfall is largest on `turbo4-asym` (~10× off the 4K gate) and smallest
 on `turbo4-delegated` (~3.6× off). Cross-checking against the 2026-04-29
@@ -900,7 +898,7 @@ default kernel-on path:
 | `turbo4`           | 20.76 | 20.68 | parity |
 | `turbo4-delegated` | 27.28 | 27.09 | parity |
 
-The fused Sparse-V Metal kernel from #511 is a measured regression vs.
+The fused Sparse-V Metal kernel is a measured regression vs.
 the graph reference for `turbo4-asym` on M5 Max — likely the per-thread
 skip path is paying more in kernel-launch and codebook-load overhead than
 it recovers from skipping below the `1e-6` threshold for an 8B-model
@@ -930,7 +928,7 @@ kernel is not a fix on its own.
   unpack saturates the Metal command-queue overhead; the wall-clock
   decode rate is only 0.063× of FP16 at 4K and degrades further at 16K.
 
-### Acceptance criteria status (issue #509)
+### Acceptance criteria status
 
 | Criterion | Status |
 |---|---|
@@ -938,7 +936,7 @@ kernel is not a fix on its own.
 | 16K decode reading on M5 Max (primary M5 Max gate cell) | done |
 | `turbo3-asym` reading on M5 Max (tracking only per epic) | done |
 | 32K decode reading | deferred — best-effort per epic; useful only after the kernel regression for `turbo4-asym` is investigated |
-| Cross-hardware consistency check vs. M1 Ultra (PR #515) | done — M5 Max numbers are 1.4–2.4× M1 Ultra on Turbo decode |
+| Cross-hardware consistency check vs. M1 Ultra | done — M5 Max numbers are 1.4–2.4× M1 Ultra on Turbo decode |
 | CSV committed under `benchmarks/turbo_kv/` | done |
 | Docs summary in `docs/model_tests_m5max.md` | done (this section) |
 | Failed-gate perf bug filed | follow-up — file an issue tracking (a) the `turbo4-asym` fused-kernel regression vs. graph fallback on M5 Max, and (b) the 0.27× ceiling on `turbo4-delegated` 4K decode |

--- a/examples/surgery/add_example.yaml
+++ b/examples/surgery/add_example.yaml
@@ -13,7 +13,7 @@
 # - Paths in this file are resolved relative to this YAML's parent
 #   directory.  Absolute paths are taken verbatim.
 # - `alpha` is optional and defaults to 1.0 when omitted.
-# - The first cut of `add` (#375 / axis A6) supports floating-point
+# - The first cut of `add` (axis A6) supports floating-point
 #   task vectors on floating-point base tensors only.  Quantized
 #   models can still apply addition to the matching `.scales` /
 #   `.biases` keys, or first dequantize via a future surgery op.

--- a/examples/surgery/interpolate_slerp_example.yaml
+++ b/examples/surgery/interpolate_slerp_example.yaml
@@ -1,4 +1,4 @@
-# SLERP-based model interpolation example (issue #378 / A9).
+# SLERP-based model interpolation example (A9).
 #
 # Blends every per-layer tensor of the base model with the
 # corresponding tensors from `model_a.safetensors` and

--- a/examples/surgery/prune_head_example.yaml
+++ b/examples/surgery/prune_head_example.yaml
@@ -1,4 +1,4 @@
-# Attention-head pruning example (Axis A, issue #376, A7).
+# Attention-head pruning example (Axis A, A7).
 #
 # Zeroes Q-head 3 and Q-head 7 of layer 12 in a Llama-family model.
 # The op interprets `head_ids` as **Q head ids** under the GQA-safe
@@ -8,8 +8,7 @@
 # silently kill more Q heads than the user asked for). See
 # `src/lib/mlxcel-surgery/src/ops/prune.rs` for the full policy.
 #
-# Use this YAML with the (in-progress) `--surgery` CLI flag (A4,
-# issue #371) or programmatically by passing the parsed pipeline as
+# Use this YAML with the (in-progress) `--surgery` CLI flag (A4, #) or programmatically by passing the parsed pipeline as
 # the `WeightTransform` argument to `load_text_weights`.
 #
 # Equivalent variants:

--- a/examples/surgery/replace_example.yaml
+++ b/examples/surgery/replace_example.yaml
@@ -1,4 +1,4 @@
-# Replace-op-only surgery config sample (issue #377).
+# Replace-op-only surgery config sample.
 #
 # Demonstrates substituting a base-model tensor with the equivalent
 # tensor from a donor safetensors file. The most common use case is

--- a/examples/surgery/scale_only.yaml
+++ b/examples/surgery/scale_only.yaml
@@ -1,5 +1,5 @@
 # Example surgery config: scale every attention output projection
-# weight by 1.2.  See `mlxcel-surgery` (issues #369 + #374) for the
+# weight by 1.2.  See `mlxcel-surgery` (+) for the
 # schema and operation semantics.
 #
 # Quantized-tensor handling:

--- a/scripts/bench_decode.sh
+++ b/scripts/bench_decode.sh
@@ -232,7 +232,7 @@ EOF
 # what the human comparing two benchmark runs wants.
 #
 # Single-model invocations get their own auto-named CSV so that ad-hoc
-# sanity runs cannot truncate the day's full-suite CSV (#313). The full-
+# sanity runs cannot truncate the day's full-suite CSV. The full-
 # suite path is reserved exclusively for `all` runs and for any caller
 # that explicitly passes --output.
 default_output_path() {

--- a/scripts/bench_kv_cache.sh
+++ b/scripts/bench_kv_cache.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# TurboQuant KV cache speed gate matrix runner (issue #509).
+# TurboQuant KV cache speed gate matrix runner.
 #
 # Sweeps the configured set of KVCacheModes against a model at the listed
 # decode contexts plus a prefill@8K reading. Thermal-aware sequential A/B
@@ -9,7 +9,7 @@
 #   - cooldown between measured runs and modes
 #   - record pmset thermal/performance warning state per run
 #
-# Acceptance gates per epic #458 (also issue #509):
+# Acceptance gates:
 #   Fp16-K + Turbo4-V (turbo4-asym): decode ≥0.97× FP16 @ 4K, ≥0.95× FP16 @ 16K
 #                                    prefill ≥1.00× FP16 @ 8K
 #   Symmetric Turbo4 (turbo4):       decode ≥0.93× FP16 @ 4K, ≥0.90× FP16 @ 16K
@@ -39,11 +39,11 @@ COOLDOWN_BETWEEN_MODES=60
 THERMAL_POLL_SECONDS=15
 
 # Decode contexts: prompt length seeded to ~target_tokens via repeated paragraph.
-# 4K, 16K, 32K decode + 8K prefill are the issue-#509 gate cells.
+# 4K, 16K, 32K decode + 8K prefill are the gate cells.
 DECODE_CONTEXTS=(4096 16384 32768)
 PREFILL_CONTEXTS=(8192)
 
-# Default mode sweep — covers the full epic-#458 gate matrix.
+# Default mode sweep — covers the full gate matrix.
 DEFAULT_MODES=(fp16 int8 turbo4-asym turbo4 turbo4-delegated turbo3-asym)
 MODES=()
 CONTEXTS_OVERRIDE=()

--- a/scripts/ci/check_cross_repo_refs.py
+++ b/scripts/ci/check_cross_repo_refs.py
@@ -30,7 +30,11 @@ import re
 import subprocess
 import sys
 
-BARE = re.compile(r"(?<![\w/])#([0-9]{3,})(?![0-9a-fA-F])")
+# Exclude a leading word char (a qualified `org/repo#NNN` and URL `…html#NNN`
+# anchors both have a word char right before `#`) but NOT a leading `/`, so a
+# bare ref written after a slash (a milestone label or an issue range, not an
+# actual `org/repo`) is still caught.
+BARE = re.compile(r"(?<!\w)#([0-9]{3,})(?![0-9a-fA-F])")
 # Lines naming an upstream project: a bare ref here is almost certainly an
 # unqualified upstream reference that should become org/repo#NNN.
 UPSTREAM = re.compile(

--- a/scripts/ci/check_cross_repo_refs.py
+++ b/scripts/ci/check_cross_repo_refs.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Flag bare ``#NNN`` issue/PR references (3+ digits) added in a diff.
+
+Rationale
+---------
+A bare ``#NNN`` auto-links to *this* repository (``lablup/mlxcel``) on GitHub.
+That is correct for same-repo references, but wrong for anything else:
+
+* References to **mlxcel-internal** (a private repository) must never appear in
+  the public tree — a public reader following them lands on an unrelated issue
+  or a 404, and it leaks internal planning.
+* References to upstream projects (``ml-explore/mlx-lm``, ``Blaizzy/mlx-vlm``,
+  ``ml-explore/mlx``, HuggingFace ``transformers`` …) should be written as
+  ``org/repo#NNN`` so they resolve as cross-repository links.
+
+This check lists every bare 3+-digit ``#NNN`` introduced on added lines so the
+author/reviewer can confirm each is a genuine ``lablup/mlxcel`` reference,
+qualify an upstream reference as ``org/repo#NNN``, or drop an internal one.
+``org/repo#NNN`` (already qualified) and corpus fixtures are ignored.
+
+Usage
+-----
+    scripts/ci/check_cross_repo_refs.py [BASE_REF]
+
+``BASE_REF`` defaults to ``$BASE_REF`` then ``origin/main``. Set ``STRICT=1`` to
+exit non-zero when any reference needs review (default is advisory: exit 0).
+"""
+import os
+import re
+import subprocess
+import sys
+
+BARE = re.compile(r"(?<![\w/])#([0-9]{3,})(?![0-9a-fA-F])")
+# Lines naming an upstream project: a bare ref here is almost certainly an
+# unqualified upstream reference that should become org/repo#NNN.
+UPSTREAM = re.compile(
+    r"mlx[-_]lm|mlx[-_]vlm|ml-explore|Blaizzy|transformers|hugging\s*face|"
+    r"\bupstream\b|sglang|llama\.cpp|pytorch",
+    re.IGNORECASE,
+)
+IGNORE_PREFIXES = ("tests/fixtures/", ".github/PULL_REQUEST_TEMPLATE.md")
+
+
+def diff_base() -> str:
+    base = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("BASE_REF", "origin/main")
+    mb = subprocess.run(
+        ["git", "merge-base", base, "HEAD"], capture_output=True, text=True
+    )
+    return mb.stdout.strip() or base
+
+
+def main() -> int:
+    base = diff_base()
+    diff = subprocess.run(
+        ["git", "diff", "--unified=0", f"{base}...HEAD"],
+        capture_output=True, text=True,
+    ).stdout
+
+    cur = None
+    upstream_hits, samerepo_hits = [], []
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            cur = line[6:]
+        elif line.startswith("+") and not line.startswith("+++") and cur:
+            if cur.startswith(IGNORE_PREFIXES):
+                continue
+            content = line[1:]
+            for m in BARE.finditer(content):
+                num = int(m.group(1))
+                hit = (cur, m.group(1), content.strip()[:110])
+                # >=1000 cannot be a lablup/mlxcel number (this repo is far below
+                # that), so it is always an upstream ref to qualify; below that,
+                # an upstream-naming line is upstream and the rest is same-repo.
+                if num >= 1000 or UPSTREAM.search(content):
+                    upstream_hits.append(hit)
+                else:
+                    samerepo_hits.append(hit)
+
+    if not upstream_hits and not samerepo_hits:
+        print("cross-repo-refs: OK — no bare 3+-digit '#NNN' added.")
+        return 0
+
+    print("cross-repo-refs: bare 3+-digit '#NNN' references were added.\n")
+    print(
+        "Policy: same-repo (lablup/mlxcel) refs use bare '#N'. Any reference to another\n"
+        "repository must be qualified as 'org/repo#NNN' (e.g. ml-explore/mlx-lm#1240,\n"
+        "Blaizzy/mlx-vlm#1181, ml-explore/mlx#3475). mlxcel-internal numbers must not appear.\n"
+    )
+    if upstream_hits:
+        print(f"Likely UPSTREAM (qualify as org/repo#NNN) — {len(upstream_hits)}:")
+        for f, n, c in upstream_hits:
+            print(f"  {f}: #{n}  | {c}")
+        print()
+    if samerepo_hits:
+        print(f"Verify each is a real lablup/mlxcel #N (else qualify/remove) — {len(samerepo_hits)}:")
+        for f, n, c in samerepo_hits:
+            print(f"  {f}: #{n}  | {c}")
+        print()
+
+    return 1 if os.environ.get("STRICT") == "1" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/audio/nemotron_h_nano_omni/config.rs
+++ b/src/audio/nemotron_h_nano_omni/config.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Nemotron H Nano Omni audio config — Parakeet flavour (issue #582).
+//! Nemotron H Nano Omni audio config — Parakeet flavour.
 //!
 //! Mirrors upstream
 //! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/config.py::AudioConfig`.

--- a/src/audio/nemotron_h_nano_omni/encoder_tests.rs
+++ b/src/audio/nemotron_h_nano_omni/encoder_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Synthetic-weight encoder tests for the Parakeet path (issue #582).
+//! Synthetic-weight encoder tests for the Parakeet path.
 //!
 //! These tests build a tiny `NemotronOmniSoundEncoder` from manually
 //! crafted weights and verify shape / dtype contracts. They do NOT
@@ -409,7 +409,7 @@ fn rel_position_first_row_matches_analytic_frequencies() {
 /// and verify the post-subsampling token count matches the
 /// configured-formula prediction.
 ///
-/// This is the integration regression guard for issue #582 CRITICAL
+/// This is the integration regression guard CRITICAL
 /// #2: the bug we are guarding against is a length/shape mismatch
 /// between what the prompt-expansion path expects (`subsampling_output_length(num_frames)`)
 /// and what the encoder actually emits.

--- a/src/audio/nemotron_h_nano_omni/mod.rs
+++ b/src/audio/nemotron_h_nano_omni/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Nemotron H Nano Omni audio modality (issue #582).
+//! Nemotron H Nano Omni audio modality.
 //!
 //! Faithful Rust port of upstream
 //! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/audio.py`

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -842,7 +842,7 @@ struct ServerArgs {
     #[arg(long = "chat-template-kwargs", value_name = "JSON")]
     chat_template_kwargs: Option<String>,
 
-    // Issue #424: cross-request prompt-prefix KV cache knobs.
+    // cross-request prompt-prefix KV cache knobs.
     /// Enable or disable the cross-request prompt-prefix KV cache (default: true).
     ///
     /// When disabled, the server performs no prefix-match lookup and no memory
@@ -904,7 +904,7 @@ struct ServerArgs {
     #[arg(long = "prompt-cache-min-prefix", value_name = "N")]
     prompt_cache_min_prefix: Option<usize>,
 
-    // Issue #552: Automatic Prefix Caching (APC) knobs.
+    // Automatic Prefix Caching (APC) knobs.
     /// Enable Automatic Prefix Caching (APC) with block-granularity hash chains
     /// (default: false).
     ///
@@ -951,7 +951,7 @@ struct ServerArgs {
     #[arg(long = "apc-hash", value_name = "ALGO")]
     apc_hash: Option<String>,
 
-    // Axis A weight-load surgery configuration (Epic #363, issue #371).
+    // Axis A weight-load surgery configuration.
     // Closed-repo references kept in a non-doc comment to avoid leaking
     // tracker URLs into `--help` text.
     /// Apply weight-load surgery configuration from a YAML file.
@@ -978,7 +978,7 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        // Subcommand-driven dispatch (issue #457). Currently only `download`
+        // Subcommand-driven dispatch. Currently only `download`
         // exists; future operational subcommands (e.g. cache inspection) can
         // be added to [`Commands`] without touching the legacy server-start
         // path.
@@ -1007,14 +1007,14 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
     // for the full precondition.
     args.turbo.apply_to_environment();
 
-    // Axis B Epic #362 (B7): apply `LLAMA_ARG_LANG_BIAS` env-var fallback
+    // Axis B (B7): apply `LLAMA_ARG_LANG_BIAS` env-var fallback
     // before resolving, so env-supplied values flow through the same
     // validation and normalization as CLI flags. CLI flag wins on conflict
     // (see `env_fallback_lang_bias` INFO log).
     env_fallback_lang_bias(&mut args.lang_bias);
-    // Issue #405 — env-var fallback for the byte-fragment opt-in flag.
+    // env-var fallback for the byte-fragment opt-in flag.
     env_fallback_lang_bias_include_byte_fragments(&mut args.lang_bias);
-    // Issue #410 — env-var fallback for the chat-template kwargs default.
+    // env-var fallback for the chat-template kwargs default.
     env_fallback_chat_template_kwargs(&mut args.chat_template_kwargs);
 
     // Env-var fallbacks for prompt-cache knobs. Detect explicit boolean flags
@@ -1029,14 +1029,14 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
     env_fallback_prompt_cache_ttl(&mut args.prompt_cache_ttl);
     env_fallback_prompt_cache_min_prefix(&mut args.prompt_cache_min_prefix);
 
-    // Issue #552 — env-var fallbacks for the APC knobs (parity with upstream
+    // env-var fallbacks for the APC knobs (parity with upstream
     // mlx-vlm `APC_*` env vars).
     env_fallback_apc_enabled(&mut args.apc_enabled, long_cli_flag_was_set("apc-enabled"));
     env_fallback_apc_block_size(&mut args.apc_block_size);
     env_fallback_apc_num_blocks(&mut args.apc_num_blocks);
     env_fallback_apc_hash(&mut args.apc_hash);
 
-    // Issue #484 (B11): env-var fallbacks for KV cache type split flags.
+    // (B11): env-var fallbacks for KV cache type split flags.
     // LLAMA_ARG_CACHE_TYPE_K / LLAMA_ARG_CACHE_TYPE_V are the canonical env
     // vars matching llama.cpp; the clap `env = "..."` attribute on the arg
     // also reads them directly, so these helpers are only needed when the CLI
@@ -1047,7 +1047,7 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
     // warn-on-conflict logic (e.g. if a separate MLXCEL_* alias is added).
     env_fallback_cache_type_k(&mut args.turbo.cache_type_k);
     env_fallback_cache_type_v(&mut args.turbo.cache_type_v);
-    // Issue #545: env-var fallbacks for the continuous-batching KV
+    // env-var fallbacks for the continuous-batching KV
     // quantization knobs. The flags themselves live in
     // `mlxcel::cli::batch_quant_args::BatchKvQuantArgs` (flattened above);
     // these helpers honor the warn-on-CLI-conflict pattern shared with the
@@ -1057,7 +1057,7 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
     env_fallback_kv_quant_scheme(&mut args.batch_quant.kv_quant_scheme);
     env_fallback_kv_skip_last_layer(&mut args.batch_quant.kv_skip_last_layer);
 
-    // Issue #630: env-var fallbacks for the speculative-decoding selector
+    // env-var fallbacks for the speculative-decoding selector
     // flags. `clap` already reads `LLAMA_ARG_DRAFT_KIND` /
     // `LLAMA_ARG_DRAFT_BLOCK_SIZE` via the `env = "..."` attr on each flag;
     // the helpers below layer the mlxcel-native `MLXCEL_DRAFT_KIND` /
@@ -1095,7 +1095,7 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         timeout: args.timeout,
         draft_model_path: args.model_draft,
         draft_max: args.draft,
-        // Issue #630: forward the speculative-decoding selector flags
+        // forward the speculative-decoding selector flags
         // resolved above via env-var fallbacks. Reconciliation into a
         // typed `DrafterKind` happens later, at the dispatch site.
         draft_kind: args.speculative.draft_kind,
@@ -1167,7 +1167,7 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         metrics_port: args.metrics_port,
         debug_pp_trace: args.debug_pp_trace,
         lang_bias_config,
-        // Issue #409: route through `env_fallback_reasoning_budget` so that
+        // route through `env_fallback_reasoning_budget` so that
         // CLI-vs-env precedence, unparseable-env handling, and the collision
         // INFO log are handled consistently with `mlxcel serve` and with the
         // other LLAMA_ARG_* env fallbacks. (Do NOT put `env = "..."` on the
@@ -1179,40 +1179,40 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
             v
         },
         chat_template_kwargs: args.chat_template_kwargs,
-        // Issue #424: prompt-cache knobs already resolved via env-var fallbacks above.
+        // prompt-cache knobs already resolved via env-var fallbacks above.
         prompt_cache_enabled: args.prompt_cache_enabled,
         prompt_cache_capacity_bytes: args.prompt_cache_capacity_bytes,
         prompt_cache_max_entries: args.prompt_cache_max_entries,
         prompt_cache_ttl_seconds: args.prompt_cache_ttl,
         prompt_cache_min_prefix: args.prompt_cache_min_prefix,
-        // Issue #552: APC knobs already resolved via env-var fallbacks above.
+        // APC knobs already resolved via env-var fallbacks above.
         apc_enabled: args.apc_enabled,
         apc_block_size: args.apc_block_size,
         apc_num_blocks: args.apc_num_blocks,
         apc_hash: args.apc_hash,
-        // Issue #484 (B11): KV cache type split flags already resolved via
+        // (B11): KV cache type split flags already resolved via
         // env-var fallbacks (and clap `env = "..."`) above.
         cache_type_k: args.turbo.cache_type_k,
         cache_type_v: args.turbo.cache_type_v,
         kv_cache_mode_legacy: args.turbo.kv_cache_mode,
-        // Issue #545: continuous-batching KV quantization knobs (flattened
+        // continuous-batching KV quantization knobs (flattened
         // from `BatchKvQuantArgs`).
         kv_bits: args.batch_quant.kv_bits,
         kv_group_size: args.batch_quant.kv_group_size,
         kv_quant_scheme: args.batch_quant.kv_quant_scheme,
         kv_skip_last_layer: args.batch_quant.kv_skip_last_layer,
-        // Issue #603: maximum KV cache size for plain (non-sliding) caches.
+        // maximum KV cache size for plain (non-sliding) caches.
         // clap reads `LLAMA_ARG_MAX_KV_SIZE` directly via the `env = ...`
         // attribute on the flag, so no separate env-fallback helper is needed.
         max_kv_size: args.max_kv_size,
-        // Issue #622: Responses API in-memory store limits. clap reads the
+        // Responses API in-memory store limits. clap reads the
         // matching `LLAMA_ARG_*` env vars directly via the `env = ...`
         // attributes on the flags.
         responses_store_max_entries: args.responses_store_max_entries,
         responses_store_ttl_secs: args.responses_store_ttl_secs,
         conversation_store_max_entries: args.conversation_store_max_entries,
         conversation_store_ttl_secs: args.conversation_store_ttl_secs,
-        // Issue #371 (A4): forward the surgery YAML path. clap reads
+        // (A4): forward the surgery YAML path. clap reads
         // `MLXCEL_SURGERY` directly via the `env = ...` attribute on
         // the flag, so no separate env-fallback helper is needed.
         #[cfg(feature = "surgery")]

--- a/src/bin/speculative_bench.rs
+++ b/src/bin/speculative_bench.rs
@@ -487,7 +487,7 @@ fn bench_one_pairing(p: &Pairing, prompt: &str, batch: usize, max_tokens: usize)
             p.kind,
             batch,
             p.block_size,
-            "DEFERRED to — needs MtpTarget for Gemma4Wrapper",
+            "DEFERRED — needs MtpTarget for Gemma4Wrapper",
         ),
         BenchKind::Dflash => Row::deferred(
             p.name,
@@ -495,7 +495,7 @@ fn bench_one_pairing(p: &Pairing, prompt: &str, batch: usize, max_tokens: usize)
             p.kind,
             batch,
             p.block_size,
-            "DEFERRED to — DFlash loader + public Qwen3NextCache API",
+            "DEFERRED — DFlash loader + public Qwen3NextCache API",
         ),
     }
 }
@@ -585,7 +585,7 @@ fn main() -> Result<()> {
                     args.kind,
                     args.batch,
                     args.block_size,
-                    "DEFERRED to — see module docs",
+                    "DEFERRED — see module docs",
                 ),
             }
         };

--- a/src/bin/speculative_bench.rs
+++ b/src/bin/speculative_bench.rs
@@ -13,17 +13,17 @@
 // limitations under the License.
 
 //! Perf benchmark harness for the speculative drafter pairings shipped by
-//! epic #633 (issue #632 / sub-9).
+//! (sub-9).
 //!
 //! ## Scope today
 //!
 //! Captures **no-drafter baseline** throughput numbers for the two reachable
 //! target models (`models/qwen3.5-4b-4bit`, `models/gemma-4-31b-it-4bit`).
 //! These numbers are the denominator of every "speedup vs no-drafter" cell
-//! in `docs/model_tests.md::Speculative drafters (epic #633)` and can be
+//! in `docs/model_tests.md::Speculative drafters` and can be
 //! captured today against real on-disk checkpoints.
 //!
-//! ## Scope deferred to #666
+//! ## Scope deferred to
 //!
 //! Speculative-decoding numerators (`--kind mtp` / `--kind dflash`) require:
 //!
@@ -35,14 +35,14 @@
 //!    (`forward_with_speculative_sinks`, `rollback_speculative_cache`) are
 //!    all public, but the trait adapter that wires them to
 //!    `prefill_and_seed` / `verify_forward` / `verify_finalize` is the work
-//!    explicitly deferred by PR #665.
+//!    explicitly deferred.
 //! 3. **A lazy-bind fix for `DFlashDrafter`**. The upstream
 //!    `z-lab/Qwen3.5-4B-DFlash` checkpoint omits `embed_tokens.weight`
 //!    because upstream Python binds to the target's `embed_tokens` at
 //!    `bind()` time, but the Rust loader currently requires the weight at
 //!    construction. See `tests/speculative_parity.rs` for the diagnostic.
 //!
-//! All three are scoped into follow-up #666. Until they land, this binary
+//! All three are scoped into follow-up. Until they land, this binary
 //! prints a clear `[DEFERRED]` row for the speculative paths instead of
 //! silently emitting fake numbers.
 //!
@@ -92,11 +92,11 @@ enum BenchKind {
     /// reachable today via `LanguageModel::forward`.
     None,
     /// MTP speculative path (Gemma 4 assistant). DEFERRED: requires
-    /// `MtpTarget` impl on `Gemma4Wrapper` (follow-up #666).
+    /// `MtpTarget` impl on `Gemma4Wrapper` (follow-up).
     Mtp,
     /// DFlash speculative path (Qwen 3.5 DFlash). DEFERRED: requires
     /// (a) public cache-construction API on `Qwen35Model` and (b) lazy-bind
-    /// fix on `DFlashDrafter` (follow-up #666).
+    /// fix on `DFlashDrafter` (follow-up).
     Dflash,
 }
 
@@ -113,10 +113,10 @@ impl std::fmt::Display for BenchKind {
 #[derive(Parser, Debug)]
 #[command(
     name = "speculative_bench",
-    about = "Speculative drafter perf benchmark (epic #633, issue #632).",
+    about = "Speculative drafter perf benchmark.",
     long_about = "Captures no-drafter baseline tok/s for the speculative \
                   target models. Speculative paths are scaffolded but \
-                  deferred to follow-up #666 — see the module docs."
+                  deferred to follow-up — see the module docs."
 )]
 struct Args {
     /// Path to the target model directory.
@@ -359,7 +359,7 @@ fn run_baseline(target_dir: &Path, prompt: &str, max_tokens: usize) -> Result<(f
 /// `docs/model_tests.md`.
 fn print_markdown_table(rows: &[Row]) {
     println!();
-    println!("### Speculative drafter perf table (epic #633, issue #632)");
+    println!("### Speculative drafter perf table");
     println!();
     println!("| Pairing | Kind | B | block_size | tok/s | speedup vs no-drafter | status |");
     println!("|---------|------|---|------------|-------|------------------------|--------|");
@@ -383,8 +383,8 @@ fn print_markdown_table(rows: &[Row]) {
         );
     }
     println!();
-    println!("Note: speculative rows are deferred to follow-up #666 — see");
-    println!("`docs/model_tests.md::Speculative drafters (epic #633)` for the");
+    println!("Note: speculative rows are deferred to follow-up — see");
+    println!("`docs/model_tests.md::Speculative drafters` for the");
     println!("wiring details. Baseline rows are real perf numbers captured on");
     println!("the host this binary ran on.");
 }
@@ -487,7 +487,7 @@ fn bench_one_pairing(p: &Pairing, prompt: &str, batch: usize, max_tokens: usize)
             p.kind,
             batch,
             p.block_size,
-            "DEFERRED to #666 — needs MtpTarget for Gemma4Wrapper",
+            "DEFERRED to — needs MtpTarget for Gemma4Wrapper",
         ),
         BenchKind::Dflash => Row::deferred(
             p.name,
@@ -495,7 +495,7 @@ fn bench_one_pairing(p: &Pairing, prompt: &str, batch: usize, max_tokens: usize)
             p.kind,
             batch,
             p.block_size,
-            "DEFERRED to #666 — DFlash loader + public Qwen3NextCache API",
+            "DEFERRED to — DFlash loader + public Qwen3NextCache API",
         ),
     }
 }
@@ -585,7 +585,7 @@ fn main() -> Result<()> {
                     args.kind,
                     args.batch,
                     args.block_size,
-                    "DEFERRED to #666 — see module docs",
+                    "DEFERRED to — see module docs",
                 ),
             }
         };

--- a/src/cli/speculative_args.rs
+++ b/src/cli/speculative_args.rs
@@ -17,8 +17,8 @@
 //! This module owns the single canonical clap definition for the
 //! `--draft-kind` and `--draft-block-size` flags that select between the
 //! classic [`SpeculativeGenerator`](mlxcel_core::speculative::SpeculativeGenerator),
-//! the MTP round-loop driver (`MtpGenerator`, sub-6 / #629), and the
-//! DFlash round-loop driver (`DFlashGenerator`, sub-12 / #636).
+//! the MTP round-loop driver (`MtpGenerator`, sub-6), and the
+//! DFlash round-loop driver (`DFlashGenerator`, sub-12).
 //!
 //! Every mlxcel binary that exposes a generation surface flattens
 //! [`SpeculativeArgs`] via `#[command(flatten)]`, which means:
@@ -162,7 +162,7 @@ pub fn default_block_size_for_kind(kind: DrafterKind) -> u32 {
         DrafterKind::Mtp => DEFAULT_MTP_BLOCK_SIZE,
         // DFlash and the future InternalMtp variant both share the
         // upstream-published 16-token default. InternalMtp's user-facing
-        // override surface lands in epic #647; for now its CLI knob
+        // override surface lands in for now its CLI knob
         // shares the DFlash default.
         DrafterKind::Dflash | DrafterKind::InternalMtp => DEFAULT_DFLASH_BLOCK_SIZE,
         // `DrafterKind` is `#[non_exhaustive]` so future variants force a

--- a/src/cli/speculative_args_tests.rs
+++ b/src/cli/speculative_args_tests.rs
@@ -52,7 +52,7 @@ fn parse_kind_returns_none_when_unset() {
 #[test]
 fn parse_kind_rejects_internal_mtp_with_helpful_error() {
     // internal-mtp is intentionally NOT user-selectable on the CLI; it is
-    // auto-detected from the target checkpoint (epic #647). The error
+    // auto-detected from the target checkpoint. The error
     // message must explain this so an operator typing the flag gets a
     // hint instead of "unknown value".
     let args = SpeculativeArgs {
@@ -107,7 +107,7 @@ fn default_block_size_for_dflash_is_16() {
 
 #[test]
 fn default_block_size_for_internal_mtp_shares_dflash_default() {
-    // InternalMtp's CLI surface lands in epic #647; for now we share the
+    // InternalMtp's CLI surface lands in for now we share the
     // DFlash 16-token default to keep the helper exhaustive.
     assert_eq!(
         default_block_size_for_kind(DrafterKind::InternalMtp),

--- a/src/cli/turbo_args.rs
+++ b/src/cli/turbo_args.rs
@@ -178,7 +178,7 @@ impl TurboKvCacheArgs {
     }
 }
 
-// ── Issue #484 (B11) — KV cache type split flags ─────────────────────────────
+// ── (B11) — KV cache type split flags ─────────────────────────────
 // (Comment kept in non-doc form for code-archeology only; the user-facing
 // help text intentionally omits closed-repo issue numbers.)
 

--- a/src/cli/turbo_args_tests.rs
+++ b/src/cli/turbo_args_tests.rs
@@ -25,7 +25,7 @@ use mlxcel_core::cache::KVCacheMode;
 use super::{TurboKvCacheArgs, resolve_kv_cache_mode};
 // `std::env::set_var` / `remove_var` are not thread-safe. Tests that touch
 // the process environment must serialize through the crate-wide
-// `ENV_LOCK` (issue #573) — a per-module lock would race with the env
+// `ENV_LOCK` — a per-module lock would race with the env
 // mutations in unrelated modules of the same test binary.
 use crate::test_support::env_lock::env_lock;
 
@@ -110,7 +110,7 @@ fn apply_to_environment_preserves_negative_inputs_for_runtime_clamping() {
     }
 }
 
-// Issue #573 Finding 1 — `--cache-type-k fp16 --cache-type-v turbo3` was
+// Finding 1 — `--cache-type-k fp16 --cache-type-v turbo3` was
 // rejected by the split-flag resolver even though the legacy
 // `--kv-cache-mode fp16+turbo3` shorthand worked, and the help text on all
 // three binaries advertises `fp16+turbo3` as a supported value. Pin the

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -916,10 +916,10 @@ fn run_generation_mode<M: LanguageModel>(
                 },
                 tracker = match resolved_kind {
                     DrafterKind::Mtp =>
-                        " (MtpGenerator round loop) and the per-target MtpTarget impls",
+                        "the MtpGenerator round loop and the per-target MtpTarget impls",
                     DrafterKind::Dflash =>
-                        " (DFlashGenerator round loop) and the per-target SpeculativeTarget impls",
-                    DrafterKind::InternalMtp => " sub-issues",
+                        "the DFlashGenerator round loop and the per-target SpeculativeTarget impls",
+                    DrafterKind::InternalMtp => "follow-up sub-issues",
                     _ => "follow-up speculative-decoding sub-issues",
                 },
             ));

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -383,7 +383,7 @@ fn resolve_cli_pipeline_assignments(
 ) -> Result<Vec<mlxcel::distributed::StageAssignment>> {
     // Use the model-aware profile builder so MoE expert variation and
     // Gemma 4 KV-shared adjacency are honoured by default. This drops the
-    // pre-#348 requirement for manual `--pp-layers` on those models.
+    // earlier requirement for manual `--pp-layers` on those models.
     let (assignments, report) =
         mlxcel::distributed::pipeline::resolve_in_process_stage_assignments_for_model(
             model_dir,
@@ -631,7 +631,7 @@ fn tokenize_prompt(
 /// the loaded tokenizer, or return an empty map when no language bias is
 /// active.
 ///
-/// The empty-map path is the **baseline bit-exact** contract for Epic #362
+/// The empty-map path is the **baseline bit-exact** contract
 /// Axis B — no disk I/O, no vocab scan, no sampling-path changes.
 ///
 /// # Errors
@@ -849,7 +849,7 @@ fn run_generation_mode<M: LanguageModel>(
     token_bias: TokenBiasMap,
 ) -> Result<(Vec<i32>, GenerationStats)> {
     let output = if let Some(ref draft_model_path) = args.model.draft_model {
-        // Issue #630: resolve the effective DrafterKind from
+        // resolve the effective DrafterKind from
         // (a) the explicit `--draft-kind` CLI flag, OR
         // (b) the drafter's `config.json::model_type` auto-detection.
         //
@@ -882,10 +882,10 @@ fn run_generation_mode<M: LanguageModel>(
             },
         );
 
-        // Issue #630: when the operator explicitly opted into MTP /
+        // when the operator explicitly opted into MTP /
         // DFlash via `--draft-kind`, we MUST dispatch to the kind-specific
         // generator. The concrete `MtpGenerator<T>` / `DFlashGenerator`
-        // round loops are wired in sub-6 / #629 and sub-12 / #636,
+        // round loops are wired in sub-6 and sub-12,
         // respectively, but those round loops require model-specific
         // `MtpTarget` / `SpeculativeTarget` impls that this offline CLI
         // path does not yet provide. Surface a clear, actionable error
@@ -898,7 +898,7 @@ fn run_generation_mode<M: LanguageModel>(
         // backward-compatible.
         if user_requested_explicit_kind {
             return Err(anyhow!(
-                "--draft-kind {kind} is plumbed end-to-end (issue #630) but \
+                "--draft-kind {kind} is plumbed end-to-end but \
                  the offline `mlxcel generate` path does not yet construct the \
                  kind-specific `{generator}` round loop on this target model. \
                  The runtime wiring lands in {tracker}. For now, omit \
@@ -916,10 +916,10 @@ fn run_generation_mode<M: LanguageModel>(
                 },
                 tracker = match resolved_kind {
                     DrafterKind::Mtp =>
-                        "issue #629 (MtpGenerator round loop) and the per-target MtpTarget impls",
+                        " (MtpGenerator round loop) and the per-target MtpTarget impls",
                     DrafterKind::Dflash =>
-                        "issue #636 (DFlashGenerator round loop) and the per-target SpeculativeTarget impls",
-                    DrafterKind::InternalMtp => "epic #647 sub-issues",
+                        " (DFlashGenerator round loop) and the per-target SpeculativeTarget impls",
+                    DrafterKind::InternalMtp => " sub-issues",
                     _ => "follow-up speculative-decoding sub-issues",
                 },
             ));
@@ -988,7 +988,7 @@ fn run_generation_mode<M: LanguageModel>(
 /// parsed, the file is missing, or any referenced donor checkpoint
 /// (`source*` field) cannot be located. Surfacing these errors *before*
 /// any model weights are touched mirrors the contract called out in
-/// issue #371 acceptance criterion (a).
+/// acceptance criterion (a).
 ///
 /// When the flag is absent, this is a no-op: the active-pipeline slot
 /// stays at `None` and the load path follows the bit-exact baseline.
@@ -1088,13 +1088,13 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
     let runtime = initialize_runtime();
     print_runtime_setup(&runtime);
 
-    // Axis A weight-load surgery (Epic #363, issue #371). Parse the
+    // Axis A weight-load surgery. Parse the
     // YAML and install the pipeline *before* any heavier validation
     // so a malformed / missing surgery config fails fast with a clear
     // error rather than being masked by an unrelated tensor-parallel
     // or pipeline-parallel diagnostic. When `--surgery` is absent this
     // is a no-op and the load path remains bit-exact identical to the
-    // pre-#371 baseline. This reads only the `--surgery` YAML path, never
+    // earlier baseline. This reads only the `--surgery` YAML path, never
     // the model directory, so it must stay ahead of the `-m` resolver below
     // — a malformed surgery config never triggers an auto-download.
     #[cfg(feature = "surgery")]
@@ -1117,7 +1117,7 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
 
     // Parse and validate language bias arguments early (before model load).
     // Empty/absent CLI flags resolve to `None`, which keeps the generation
-    // path bit-exact identical to the pre-B8 baseline (Epic #362 acceptance).
+    // path bit-exact identical to the pre-B8 baseline (acceptance).
     let lang_bias_config: Option<LangBiasConfig> = args
         .lang_bias
         .resolve()
@@ -1189,7 +1189,7 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
         } else {
             (String::new(), "conservative")
         };
-        // Issue #405 — emit byte_fragment_entries only when non-zero so the
+        // emit byte_fragment_entries only when non-zero so the
         // existing B9 field shape is preserved for Phase 1 configs.
         let byte_fragment_entries = token_bias.byte_fragment_len();
         if byte_fragment_entries > 0 {

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -154,7 +154,7 @@ fn sample_generate_args(model_path: PathBuf) -> crate::GenerateArgs {
         },
         lang_bias: mlxcel::lang_bias::LangBiasCliArgs::default(),
         speculative: mlxcel::cli::speculative_args::SpeculativeArgs::default(),
-        // Issue #371 (A4): default to None so existing tests stay on
+        // (A4): default to None so existing tests stay on
         // the bit-exact baseline load path; tests that need surgery
         // override this field explicitly.
         #[cfg(feature = "surgery")]
@@ -376,8 +376,7 @@ fn validate_pipeline_parallel_args_rejects_incompatible_modes() {
     assert!(validate_pipeline_parallel_args(&args).is_err());
     args.model.draft_model = None;
 
-    // Tensor parallelism + PP is now accepted (2D PP × TP composition landed
-    // via #346). Positive coverage for the 2D path lives in
+    // Tensor parallelism + PP is now accepted (2D PP × TP composition landed). Positive coverage for the 2D path lives in
     // `validate_pipeline_parallel_args_accepts_2d_pp_tp` below.
 
     fs::remove_dir_all(args.model.model).unwrap();
@@ -398,7 +397,7 @@ fn validate_pipeline_parallel_args_accepts_adapter() {
 
 #[test]
 fn validate_pipeline_parallel_args_accepts_2d_pp_tp() {
-    // Issue #346: the validator no longer rejects PP + TP.
+    // the validator no longer rejects PP + TP.
     let mut args = sample_generate_args(temp_model_dir("pp-tp-2d"));
     args.pipeline_parallel.pp_size = 2;
     args.tensor_parallel.tp_size = 2;

--- a/src/commands/generate_vlm.rs
+++ b/src/commands/generate_vlm.rs
@@ -192,7 +192,7 @@ pub(crate) fn compute_vlm_embeddings(
     target_fps: f64,
     tokenizer: &MlxcelTokenizer,
 ) -> Result<Option<InputEmbeddings>> {
-    // Handle video-only or video + image mode for Gemma4 (issue #553).
+    // Handle video-only or video + image mode for Gemma4.
     // Video and audio cannot coexist in this CLI surface yet — surface a
     // clean error rather than silently accept one.
     if !video_paths.is_empty() {
@@ -232,7 +232,7 @@ pub(crate) fn compute_vlm_embeddings(
     }
 
     // Nemotron H Nano Omni — audio-only or combined image + audio
-    // (issue #582). Mirrors the Gemma 4 dispatch above; the helper
+    // Mirrors the Gemma 4 dispatch above; the helper
     // handles both branches so a single match arm covers both modes.
     if let Some(audio) = audio_path
         && let LoadedModel::NemotronHNanoOmniVLM(nemotron_vl) = model
@@ -468,7 +468,7 @@ fn compute_gemma4_multimodal_embeddings(
 }
 
 /// Compute video embeddings (and optional preceding image embeddings)
-/// for the Gemma 4 VLM (issue #553).
+/// for the Gemma 4 VLM.
 ///
 /// Decodes each video via `mlxcel::video::load_video` (subprocess
 /// `ffmpeg`), processes frames through
@@ -690,7 +690,7 @@ fn expand_nemotron_h_nano_omni_audio_tokens(
 }
 
 /// Compute audio embeddings (with optional preceding images) for the
-/// Nemotron H Nano Omni VLM (issue #582).
+/// Nemotron H Nano Omni VLM.
 ///
 /// Mirrors upstream `_extract_sound_features` + `_merge_features`:
 /// 1. Loads the WAV via the shared `audio::load_wav_file` helper.

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -150,17 +150,17 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
     // for the full precondition.
     args.turbo.apply_to_environment();
 
-    // Axis B Epic #362 (B7): apply `LLAMA_ARG_LANG_BIAS` env-var fallback
+    // Axis B (B7): apply `LLAMA_ARG_LANG_BIAS` env-var fallback
     // before resolving, so env-supplied values flow through the same
     // validation path as CLI flags. CLI flag wins on conflict.
     env_fallback_lang_bias(&mut args.lang_bias);
-    // Issue #405 — env-var fallback for the byte-fragment opt-in flag.
+    // env-var fallback for the byte-fragment opt-in flag.
     env_fallback_lang_bias_include_byte_fragments(&mut args.lang_bias);
-    // Issue #409 — env-var fallback for the thinking-budget default.
+    // env-var fallback for the thinking-budget default.
     env_fallback_reasoning_budget(&mut args.reasoning_budget);
-    // Issue #410 — env-var fallback for the chat-template kwargs default.
+    // env-var fallback for the chat-template kwargs default.
     env_fallback_chat_template_kwargs(&mut args.chat_template_kwargs);
-    // Issue #424 — env-var fallbacks for prompt-cache knobs.
+    // env-var fallbacks for prompt-cache knobs.
     env_fallback_prompt_cache_enabled(
         &mut args.prompt_cache_enabled,
         long_cli_flag_was_set("prompt-cache-enabled"),
@@ -169,18 +169,18 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
     env_fallback_prompt_cache_max_entries(&mut args.prompt_cache_max_entries);
     env_fallback_prompt_cache_ttl(&mut args.prompt_cache_ttl);
     env_fallback_prompt_cache_min_prefix(&mut args.prompt_cache_min_prefix);
-    // Issue #552 — env-var fallbacks for the APC knobs.
+    // env-var fallbacks for the APC knobs.
     env_fallback_apc_enabled(&mut args.apc_enabled, long_cli_flag_was_set("apc-enabled"));
     env_fallback_apc_block_size(&mut args.apc_block_size);
     env_fallback_apc_num_blocks(&mut args.apc_num_blocks);
     env_fallback_apc_hash(&mut args.apc_hash);
-    // Issue #484 (B11): env-var fallbacks for KV cache type split flags.
+    // (B11): env-var fallbacks for KV cache type split flags.
     // The clap `env = "..."` attribute already reads these env vars; the
     // explicit calls below maintain the warn-on-conflict pattern used by
     // other LLAMA_ARG_* pairs.
     env_fallback_cache_type_k(&mut args.turbo.cache_type_k);
     env_fallback_cache_type_v(&mut args.turbo.cache_type_v);
-    // Issue #545: env-var fallbacks for the continuous-batching KV
+    // env-var fallbacks for the continuous-batching KV
     // quantization knobs. The flags themselves live in
     // `mlxcel::cli::batch_quant_args::BatchKvQuantArgs` (flattened on
     // `ServeArgs`); these helpers honor the warn-on-CLI-conflict pattern
@@ -190,7 +190,7 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
     env_fallback_kv_quant_scheme(&mut args.batch_quant.kv_quant_scheme);
     env_fallback_kv_skip_last_layer(&mut args.batch_quant.kv_skip_last_layer);
 
-    // Issue #630: env-var fallbacks for the speculative-decoding selector
+    // env-var fallbacks for the speculative-decoding selector
     // flags. `clap` already reads `LLAMA_ARG_DRAFT_KIND` /
     // `LLAMA_ARG_DRAFT_BLOCK_SIZE` via the `env = "..."` attr on each flag;
     // the helpers below layer the mlxcel-native `MLXCEL_DRAFT_KIND` /
@@ -199,7 +199,7 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
     env_fallback_draft_kind(&mut args.speculative.draft_kind);
     env_fallback_draft_block_size(&mut args.speculative.draft_block_size);
 
-    // Axis B Epic #362 (B8): resolve --lang-bias / --lang-bias-config early so
+    // Axis B (B8): resolve --lang-bias / --lang-bias-config early so
     // errors surface before the server starts. Empty resolution = None =
     // baseline bit-exact path.
     let lang_bias_config = args
@@ -221,7 +221,7 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         timeout: args.timeout,
         draft_model_path: args.draft_model,
         draft_max: args.draft_max,
-        // Issue #630: forward the speculative-decoding selector flags
+        // forward the speculative-decoding selector flags
         // resolved above via env-var fallbacks. Reconciliation into a
         // typed `DrafterKind` happens later, at the dispatch site.
         draft_kind: args.speculative.draft_kind,
@@ -295,40 +295,40 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         lang_bias_config,
         reasoning_budget: args.reasoning_budget,
         chat_template_kwargs: args.chat_template_kwargs,
-        // Issue #424: prompt-cache knobs already resolved via env-var fallbacks above.
+        // prompt-cache knobs already resolved via env-var fallbacks above.
         prompt_cache_enabled: args.prompt_cache_enabled,
         prompt_cache_capacity_bytes: args.prompt_cache_capacity_bytes,
         prompt_cache_max_entries: args.prompt_cache_max_entries,
         prompt_cache_ttl_seconds: args.prompt_cache_ttl,
         prompt_cache_min_prefix: args.prompt_cache_min_prefix,
-        // Issue #552: APC knobs already resolved via env-var fallbacks above.
+        // APC knobs already resolved via env-var fallbacks above.
         apc_enabled: args.apc_enabled,
         apc_block_size: args.apc_block_size,
         apc_num_blocks: args.apc_num_blocks,
         apc_hash: args.apc_hash,
-        // Issue #484 (B11): KV cache type split flags already resolved via
+        // (B11): KV cache type split flags already resolved via
         // env-var fallbacks (and clap `env = "..."`) above.
         cache_type_k: args.turbo.cache_type_k,
         cache_type_v: args.turbo.cache_type_v,
         kv_cache_mode_legacy: args.turbo.kv_cache_mode,
-        // Issue #545: continuous-batching KV quantization knobs (flattened
+        // continuous-batching KV quantization knobs (flattened
         // from `BatchKvQuantArgs`).
         kv_bits: args.batch_quant.kv_bits,
         kv_group_size: args.batch_quant.kv_group_size,
         kv_quant_scheme: args.batch_quant.kv_quant_scheme,
         kv_skip_last_layer: args.batch_quant.kv_skip_last_layer,
-        // Issue #603: maximum KV cache size for plain (non-sliding) caches.
+        // maximum KV cache size for plain (non-sliding) caches.
         // clap reads `LLAMA_ARG_MAX_KV_SIZE` directly via the `env = ...`
         // attribute on the flag, so no separate env-fallback helper is needed.
         max_kv_size: args.max_kv_size,
-        // Issue #622: Responses API in-memory store limits. clap reads the
+        // Responses API in-memory store limits. clap reads the
         // matching `LLAMA_ARG_*` env vars directly via the `env = ...`
         // attributes on the flags.
         responses_store_max_entries: args.responses_store_max_entries,
         responses_store_ttl_secs: args.responses_store_ttl_secs,
         conversation_store_max_entries: args.conversation_store_max_entries,
         conversation_store_ttl_secs: args.conversation_store_ttl_secs,
-        // Issue #371 (A4): forward the surgery YAML path. clap reads
+        // (A4): forward the surgery YAML path. clap reads
         // `MLXCEL_SURGERY` directly via the `env = ...` attribute on
         // the flag, so no separate env-fallback helper is needed.
         #[cfg(feature = "surgery")]

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -128,7 +128,7 @@ fn sample_args() -> crate::ServeArgs {
         responses_store_ttl_secs: 3600,
         conversation_store_max_entries: 256,
         conversation_store_ttl_secs: 3600,
-        // Issue #371 (A4): keep tests on the baseline path by default.
+        // (A4): keep tests on the baseline path by default.
         #[cfg(feature = "surgery")]
         surgery: None,
     }

--- a/src/distributed/cluster_init.rs
+++ b/src/distributed/cluster_init.rs
@@ -15,7 +15,7 @@
 //! Zero-config cluster bring-up for multi-machine pipeline-parallel runs.
 //!
 //! This module implements the intent-based launch path described in issue
-//! #342. The operator declares the desired number of stages with `--pp-auto N`
+//! The operator declares the desired number of stages with `--pp-auto N`
 //! on the coordinator, peers announce themselves (either explicitly via static
 //! seeds or opt-in via LAN discovery), and the coordinator:
 //!

--- a/src/distributed/kv_cache_serde/serialize.rs
+++ b/src/distributed/kv_cache_serde/serialize.rs
@@ -88,7 +88,7 @@ pub fn serialize_cache_state(state: &SerializableCacheState) -> Result<Vec<u8>> 
 /// Used by: prefill node when preparing cache state for transfer.
 pub fn extract_kv_cache_entry(cache: &mlxcel_core::cache::KVCache) -> SerializableCacheEntry {
     // Use `live_len() = offset - live_start` (not the monotonic `offset`) so
-    // this remains correct after issue #603's `trim_front` has advanced
+    // this remains correct after's `trim_front` has advanced
     // `live_start`. With `live_start == 0` this is bit-identical to slicing
     // at `cache.offset`.
     let live_len = cache.live_len();
@@ -183,7 +183,7 @@ pub fn serialize_sequence_cache_set(
         // Re-base the serialized offset to the live window length so the
         // receiving node restores `(offset=live_len, live_start=0)` —
         // equivalent in RoPE relative positions to the original
-        // `(offset, live_start)` pair, but without leaking the post-#603
+        // `(offset, live_start)` pair, but without leaking the post-
         // monotonic position through the wire format. With `live_start == 0`
         // this is bit-identical to recording `cache.offset` directly.
         layer_offsets.push(cache.live_len());

--- a/src/distributed/pipeline/cache_manager.rs
+++ b/src/distributed/pipeline/cache_manager.rs
@@ -249,7 +249,7 @@ impl fmt::Display for RejectionReason {
 impl RejectionReason {
     /// Short, low-cardinality label for metric dimensions and traces.
     ///
-    /// Used by: `/metrics` admission rejection counters (#350),
+    /// Used by: `/metrics` admission rejection counters,
     /// chrome-tracing rejection events.
     pub fn metric_label(&self) -> &'static str {
         match self {
@@ -262,7 +262,7 @@ impl RejectionReason {
 }
 
 /// Enriched OOM diagnostic produced by [`coordinated_admission_with_attribution`]
-/// (issue #350). Operators see which stage rejected, why, and where the
+/// Operators see which stage rejected, why, and where the
 /// offending stage's KV occupancy sits at the moment of rejection.
 ///
 /// Used by: server HTTP error path, `/metrics` counters, chrome-tracing
@@ -1013,7 +1013,7 @@ pub fn broadcast_2d_eviction(
 /// mutation is performed anywhere, mirroring the existing dry-run-then-
 /// commit contract.
 ///
-/// Used by: `/metrics` admission rejection pipeline (#350).
+/// Used by: `/metrics` admission rejection pipeline.
 pub fn coordinated_admission_with_attribution(
     managers: &mut [&mut PipelineCacheManager],
     req: &CacheAdmissionRequest,

--- a/src/distributed/pipeline/cache_manager_tests.rs
+++ b/src/distributed/pipeline/cache_manager_tests.rs
@@ -654,7 +654,7 @@ fn broadcast_2d_eviction_clears_all_slots() {
 }
 
 // -----------------------------------------------------------------------------
-// Issue #350: enriched OOM diagnostic via coordinated_admission_with_attribution.
+// enriched OOM diagnostic via coordinated_admission_with_attribution.
 // -----------------------------------------------------------------------------
 
 mod attribution {

--- a/src/distributed/pipeline/elastic.rs
+++ b/src/distributed/pipeline/elastic.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Elastic pipeline repartitioning state machine (issue #349).
+//! Elastic pipeline repartitioning state machine.
 //!
 //! Drives the `Idle → Draining → Rebalancing → Resuming → Idle` flow behind
 //! `--enable-elastic-pp`. The coordinator owns the state and emits
 //! [`RepartitionEvent`] values for every transition so the metrics/obervability
-//! layer (issue #350) can surface them. All RPC / network fan-out (drain fan
+//! layer can surface them. All RPC / network fan-out (drain fan
 //! out, probe polling, reload) is performed by [`ElasticRuntimeDriver`]
 //! implementations — this module is intentionally transport-agnostic so it
 //! can be unit-tested deterministically with fake drivers.
@@ -235,7 +235,7 @@ pub struct RepartitionEvent {
 /// Sink that receives [`RepartitionEvent`] values as they are emitted.
 ///
 /// The default wiring forwards events to the pipeline metrics subsystem
-/// (issue #350 adds counters + histograms). Tests can plug in a
+/// (adds counters + histograms). Tests can plug in a
 /// [`RecordingEventSink`] to capture emitted events for assertion.
 pub trait RepartitionEventSink: Send + Sync {
     fn record_event(&self, event: &RepartitionEvent);

--- a/src/distributed/pipeline/metrics.rs
+++ b/src/distributed/pipeline/metrics.rs
@@ -18,9 +18,8 @@
 //! the pipeline schedule. Metrics are collected per-step and can be
 //! aggregated for reporting.
 //!
-//! Also exposes counters/histograms for elastic repartition events (issue
-//! #349). The sink API is intentionally transport-agnostic — the Prometheus
-//! endpoint (#350) reads from [`RepartitionMetricsSnapshot`] while unit tests
+//! Also exposes counters/histograms for elastic repartition events. The sink API is intentionally transport-agnostic — the Prometheus
+//! endpoint reads from [`RepartitionMetricsSnapshot`] while unit tests
 //! inspect the raw [`RepartitionMetrics`] struct.
 //!
 //! Used by: pipeline schedule, pipeline execution loop, server metrics endpoint
@@ -326,7 +325,7 @@ impl fmt::Display for MetricsSummary {
 }
 
 // ---------------------------------------------------------------------------
-// Activation transfer latency histogram (#350)
+// Activation transfer latency histogram
 // ---------------------------------------------------------------------------
 
 /// Monotonic-merge histogram for activation transfer latency samples.
@@ -444,7 +443,7 @@ impl LatencyBuckets {
 }
 
 // ---------------------------------------------------------------------------
-// KV cache admission rejection counters (#350)
+// KV cache admission rejection counters
 // ---------------------------------------------------------------------------
 
 /// Counters for KV cache admission rejections, keyed by
@@ -494,7 +493,7 @@ pub struct AdmissionRejectionEntry {
 }
 
 // ---------------------------------------------------------------------------
-// Stage utilization snapshot (#350)
+// Stage utilization snapshot
 // ---------------------------------------------------------------------------
 
 /// Compact per-stage utilization snapshot intended for Prometheus rendering.
@@ -593,7 +592,7 @@ pub struct PipelineObservability {
     pub activation_latency: ActivationLatencyHistogram,
     /// KV cache admission rejection counters.
     pub admission_rejections: AdmissionRejectionCounters,
-    /// Elastic repartition event counters (issue #349 emission path).
+    /// Elastic repartition event counters (emission path).
     pub repartition: RepartitionMetrics,
     /// Rolling bubble ratio sample (best-effort; scheduler updates this when
     /// it closes out a pipeline step).
@@ -650,15 +649,15 @@ pub struct PipelineObservabilitySnapshot {
 }
 
 // ---------------------------------------------------------------------------
-// Elastic repartition counters (consumed by #350's /metrics endpoint)
+// Elastic repartition counters (consumed's /metrics endpoint)
 // ---------------------------------------------------------------------------
 
 /// Atomic counters + histogram totals for elastic repartition events.
 ///
 /// This is the low-level container the coordinator writes to; the
 /// Prometheus endpoint reads a [`RepartitionMetricsSnapshot`] to render
-/// stable text output. Used by: #349 elastic coordinator (writer),
-/// #350 Prometheus endpoint (reader).
+/// stable text output. Used by: elastic coordinator (writer),
+/// Prometheus endpoint (reader).
 #[derive(Debug, Default)]
 pub struct RepartitionMetrics {
     /// Total repartition events, partitioned by trigger kind + outcome.

--- a/src/distributed/pipeline/metrics.rs
+++ b/src/distributed/pipeline/metrics.rs
@@ -649,7 +649,7 @@ pub struct PipelineObservabilitySnapshot {
 }
 
 // ---------------------------------------------------------------------------
-// Elastic repartition counters (consumed's /metrics endpoint)
+// Elastic repartition counters (consumed by the /metrics endpoint)
 // ---------------------------------------------------------------------------
 
 /// Atomic counters + histogram totals for elastic repartition events.

--- a/src/distributed/pipeline/metrics_tests.rs
+++ b/src/distributed/pipeline/metrics_tests.rs
@@ -147,7 +147,7 @@ fn metrics_summary_display() {
 }
 
 // -----------------------------------------------------------------------------
-// Elastic repartition counters (issue #349 emission path, #350 read path).
+// Elastic repartition counters (emission path read path).
 // -----------------------------------------------------------------------------
 
 mod repartition {
@@ -251,7 +251,7 @@ mod repartition {
 }
 
 // -----------------------------------------------------------------------------
-// Issue #350: activation latency histogram, admission rejection counters,
+// activation latency histogram, admission rejection counters,
 // stage utilization registry, and the top-level PipelineObservability
 // aggregator.
 // -----------------------------------------------------------------------------

--- a/src/distributed/pipeline/mod.rs
+++ b/src/distributed/pipeline/mod.rs
@@ -65,7 +65,7 @@
 //! - [`PipelineMetrics`] — bubble ratio, utilization, latency breakdown
 //! - [`MetricsCollector`] — accumulates metrics across pipeline steps
 //!
-//! Elastic repartitioning (issue #349):
+//! Elastic repartitioning:
 //!
 //! - [`ElasticPpConfig`] — runtime configuration for `--enable-elastic-pp`
 //! - [`RepartitionCoordinator`] — drain → rebalance → resume state machine

--- a/src/distributed/pipeline/partition_profile.rs
+++ b/src/distributed/pipeline/partition_profile.rs
@@ -29,7 +29,7 @@
 //!   within a few percent for every production MoE model we ship.
 //! - It does not tune for hardware generations (M1 Ultra vs. M5 Max etc.).
 //!   The cost model is pure byte-count; hardware-specific calibration is
-//!   future work (explicitly out of scope for issue #348).
+//!   future work (explicitly out of scope).
 //!
 //! Used by: `resolve_in_process_stage_assignments`,
 //! `mlxcel-server` startup, CLI `mlxcel generate --pp-*`

--- a/src/distributed/pipeline/stage_executor/deepseek_v3.rs
+++ b/src/distributed/pipeline/stage_executor/deepseek_v3.rs
@@ -28,7 +28,7 @@
 //!   are stacked via the `sanitize_weights` helper on the full model weight
 //!   map. Auto-partitioner callers should note that expert-heavy layers carry
 //!   a larger parameter footprint than the dense head; that bookkeeping lives
-//!   on the partitioner (feeds sub-issue 7 / #348), not on the stage executor.
+//!   on the partitioner (feeds sub-issue 7), not on the stage executor.
 //! - **Multi-token-prediction (MTP) trailer layer** — the last entry of
 //!   `config.num_hidden_layers` is an MTP layer and is excluded from the
 //!   decoder stack. `DeepSeekV3Model::num_layers()` already reports the

--- a/src/distributed/pipeline/stage_executor/family_registry_tests.rs
+++ b/src/distributed/pipeline/stage_executor/family_registry_tests.rs
@@ -44,7 +44,7 @@ fn supported_families_names_are_unique() {
 
 #[test]
 fn new_issue_345_families_are_registered() {
-    // Explicitly confirm the five families added in issue #345 appear in
+    // Explicitly confirm the five families added appear in
     // the registry. This is a floor test: removing one of these without
     // bumping the pipeline capability protocol version would be a breaking
     // change for running multi-host deployments.
@@ -59,7 +59,7 @@ fn new_issue_345_families_are_registered() {
     ] {
         assert!(
             families.contains(&family),
-            "StageFamily::{family:?} must appear in supported_families() (regression for #345)",
+            "StageFamily::{family:?} must appear in supported_families() (regression)",
         );
     }
 }

--- a/src/distributed/pipeline/stage_executor/llama4.rs
+++ b/src/distributed/pipeline/stage_executor/llama4.rs
@@ -16,7 +16,7 @@
 //!
 //! This executor covers only the **text-only language tower** of Llama 4
 //! Scout. Vision encoder stage splitting is explicitly out of scope of
-//! issue #345 and of the parent epic #341; VLM inputs that require the
+//! and of the parent VLM inputs that require the
 //! vision tower should not be routed through this stage executor.
 //!
 //! Structural notes:

--- a/src/distributed/pipeline/stage_executor/mistral.rs
+++ b/src/distributed/pipeline/stage_executor/mistral.rs
@@ -40,7 +40,7 @@
 //! carry extra per-layer state (window masks, Llama-4 attention scaling,
 //! compressed latent attention, MoE routers) that requires its own stage
 //! executor. Issue tracker note: those families are follow-up work outside
-//! the scope of #345.
+//! the scope.
 
 use std::path::Path;
 

--- a/src/distributed/pipeline/stage_executor/mixtral.rs
+++ b/src/distributed/pipeline/stage_executor/mixtral.rs
@@ -22,7 +22,7 @@
 //! state beyond the KV cache, splitting between any two adjacent decoder
 //! layers is safe — stage boundaries behave identically to the Llama family.
 //!
-//! Expert-balance considerations (sub-issue 7 / #348): the auto-partitioner
+//! Expert-balance considerations: the auto-partitioner
 //! can treat each Mixtral layer as a uniform cost block because every layer
 //! carries the same expert count. MoE-specific weight accounting is not
 //! required here; it is surfaced via the `ModelProfile` layer cost, not via

--- a/src/distributed/pipeline/stage_executor/qwen35.rs
+++ b/src/distributed/pipeline/stage_executor/qwen35.rs
@@ -14,9 +14,8 @@
 
 //! Pipeline-parallel stage executor for Qwen 3.5.
 //!
-//! Speculative-decoding hooks (`forward_speculative`,
-//! `rollback_speculative_cache` — issue #634) are **NOT** propagated through
-//! this stage executor in epic #633's Phase 1. Rationale:
+//! Speculative-decoding hooks (`forward_speculative`, `rollback_speculative_cache` —) are **NOT** propagated through
+//! this stage executor's Phase 1. Rationale:
 //!
 //! - The DFlash drafter must run against a *single coherent* target. The
 //!   speculative round loop needs the verify-pass logits, per-layer hidden

--- a/src/distributed/pipeline/trace.rs
+++ b/src/distributed/pipeline/trace.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 //! Chrome-tracing compatible trace writer for pipeline-parallel scheduler
-//! actions (issue #350).
+//! actions.
 //!
 //! When `mlxcel-server --debug-pp-trace <file>` is passed the runtime
 //! constructs a [`PpTracer`] and hands it out as an `Arc` so every stage

--- a/src/distributed/tensor_parallel/inference_tests.rs
+++ b/src/distributed/tensor_parallel/inference_tests.rs
@@ -64,7 +64,7 @@ fn resolve_model_shard_plan_uses_text_config_layer_count() {
 fn resolve_model_shard_plan_tolerates_partial_text_config_when_single_rank() {
     // Regression: LLaVA-1.5 / LLaVA-Next ship a partial `text_config` that
     // doesn't include `num_hidden_layers` — the layer count is implied by
-    // the base model referenced via `_name_or_path`. PR #233's strict layer
+    // the base model referenced via `_name_or_path`.'s strict layer
     // detection was breaking the single-rank generate path for these models.
     // For tp_size=1 the layer count is never used downstream, so resolve
     // must tolerate a missing layer count and return a summary with

--- a/src/distributed/tensor_parallel/llama_runtime.rs
+++ b/src/distributed/tensor_parallel/llama_runtime.rs
@@ -947,7 +947,7 @@ impl TensorParallelGemma4Model {
         // double-scale text tokens and incorrectly scale image/audio features
         // that are already in the language-model embedding space.
         // See `Gemma4VLModel::get_input_embeddings_with_audio` in
-        // `src/vision/gemma4_vl.rs` and issue #317 / PR #326 for the non-TP
+        // `src/vision/gemma4_vl.rs` and for the non-TP
         // equivalent fix.
         let text_config = &self.ranks[0].text_model.config;
         let mut h = match input_embeddings {

--- a/src/distributed/tensor_parallel/llama_runtime_tests.rs
+++ b/src/distributed/tensor_parallel/llama_runtime_tests.rs
@@ -1547,10 +1547,10 @@ fn tensor_parallel_gemma4_matches_full_model_logits() {
     assert!(mlxcel_core::item_bool(&close));
 }
 
-/// Regression test for issue #335: TP Gemma4 must not double-apply embed_scale
+/// Regression test for TP Gemma4 must not double-apply embed_scale
 /// when `input_embeddings` is supplied.
 ///
-/// The non-TP path was fixed in PR #326 (issue #317). This test verifies that
+/// The non-TP path was fixed. This test verifies that
 /// `TensorParallelGemma4Model::forward_impl` applies the same conditional:
 /// `sqrt(hidden_size)` scale only for the `input_ids` path, not for the
 /// pre-merged `input_embeddings` path.

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! HuggingFace model repository downloader (issues #457, #648, #650).
+//! HuggingFace model repository downloader.
 //!
 //! Provides a single source of truth for downloading model snapshots from the
 //! HuggingFace Hub. Both the `mlxcel` CLI and the `mlxcel-server` binary call
@@ -28,7 +28,7 @@
 //! - **Token resolution order** — explicit `--token` > `HF_TOKEN` env >
 //!   `HUGGING_FACE_HUB_TOKEN` env > anonymous. Tokens are validated to be
 //!   pure printable-ASCII (no control chars) before they are used in an
-//!   `Authorization` header (issue #650, L3).
+//!   `Authorization` header (L3).
 //! - **Default destination** — the location-independent global store at
 //!   `${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>` (issue
 //!   #93), so a model downloaded once runs from any directory. `--local-dir`
@@ -40,12 +40,12 @@
 //!   is re-fetched and overwritten.
 //! - **Progress** — when stderr is a tty and progress is not suppressed via
 //!   env vars, per-file and aggregate `indicatif` progress bars render during
-//!   the actual byte stream (Path B2 direct reqwest streaming, issue #648).
+//!   the actual byte stream (Path B2 direct reqwest streaming).
 //!   When bars are suppressed (CI, piped output, `MLXCEL_NO_PROGRESS=1`,
 //!   `NO_COLOR=1`), one stdout line per file is emitted instead so CI logs
 //!   remain golden-text-stable.
 //!
-//! # Hardening (issue #650)
+//! # Hardening
 //!
 //! - **Plaintext-endpoint refusal** — if `HF_ENDPOINT` is set to a non-HTTPS
 //!   URL *and* a token is resolved, [`download_repo`] aborts with a clear
@@ -148,7 +148,7 @@ const SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
     .add(b'!')
     .add(b'$');
 
-/// Age threshold for `.mlxcel-partial.*` orphan cleanup (issue #650, L5).
+/// Age threshold for `.mlxcel-partial.*` orphan cleanup (L5).
 ///
 /// Younger partial files are left in place to avoid racing against a concurrent
 /// `mlxcel` process that is mid-download in the same destination directory.
@@ -235,7 +235,7 @@ impl DownloadOptions {
 /// Empty values from environment variables are treated as anonymous so that
 /// `HF_TOKEN=""` does not poison the request with a malformed `Authorization`
 /// header. Tokens containing non-ASCII bytes or ASCII control characters
-/// (issue #650, L3) are still returned here so the caller can produce a
+/// (L3) are still returned here so the caller can produce a
 /// targeted error message that names the env var or flag — see
 /// [`validate_token`] which is invoked at HTTP-client construction time.
 pub fn resolve_token(explicit: Option<&str>) -> Option<String> {
@@ -257,7 +257,7 @@ pub fn resolve_token(explicit: Option<&str>) -> Option<String> {
 }
 
 /// Reject HF tokens containing non-ASCII bytes or ASCII control characters
-/// (issue #650, L3). Returns the original token slice on success.
+/// (L3). Returns the original token slice on success.
 ///
 /// `HeaderValue::from_str` would also reject these values, but we want a
 /// domain-specific error message (mentions HF token, env var, control chars)
@@ -280,7 +280,7 @@ fn validate_token(token: &str) -> Result<&str> {
 /// Build a configured `hf-hub` [`Api`] honoring the resolved auth token.
 ///
 /// We keep `with_progress(false)` because progress is driven by our own
-/// indicatif bars (issue #648). hf-hub is used only for `info()` (manifest
+/// indicatif bars. hf-hub is used only for `info()` (manifest
 /// fetch) — the actual file bytes come from direct reqwest streaming.
 fn build_api(token: Option<String>) -> Result<Api> {
     let mut builder = ApiBuilder::from_env().with_progress(false);
@@ -311,7 +311,7 @@ fn hf_endpoint() -> String {
         .unwrap_or_else(|| "https://huggingface.co".to_string())
 }
 
-/// Env var that opts out of the M1 plaintext-endpoint refusal (issue #650).
+/// Env var that opts out of the M1 plaintext-endpoint refusal.
 ///
 /// When set to any non-empty value, [`require_secure_endpoint_for_token`]
 /// allows a `Bearer` token to be sent over a non-HTTPS endpoint. Intended
@@ -356,7 +356,7 @@ fn require_secure_endpoint_for_token(endpoint: &str, token: Option<&str>) -> Res
     ))
 }
 
-/// Best-effort cleanup of stale `.mlxcel-partial.*` orphans (issue #650, L5).
+/// Best-effort cleanup of stale `.mlxcel-partial.*` orphans (L5).
 ///
 /// Walks `local_dir` (non-recursive) and removes regular files whose basename
 /// starts with `.mlxcel-partial.` and whose last-modified timestamp is older
@@ -430,7 +430,7 @@ fn encode_path_segments(path: &str) -> String {
 /// Build the download URL for a single file in a HuggingFace repository.
 ///
 /// Every path segment of `repo_id`, `revision`, and `filename` is
-/// percent-encoded (issue #650, L1) so adversarial metadata containing `?`,
+/// percent-encoded (L1) so adversarial metadata containing `?`,
 /// `#`, or other reserved characters cannot smuggle a query string or
 /// fragment past the URL composition step. `endpoint` is treated as a
 /// trusted base URL (env-controlled by the operator) and is not re-encoded.
@@ -474,7 +474,7 @@ async fn stream_file(
     result
 }
 
-/// Open the partial-download tempfile in a symlink-safe way (issue #650, L2).
+/// Open the partial-download tempfile in a symlink-safe way (L2).
 ///
 /// On Unix we open with `O_CREAT | O_EXCL | O_NOFOLLOW` (translated by
 /// `OpenOptions`: `create_new(true)` provides `O_CREAT|O_EXCL`, and the
@@ -533,7 +533,7 @@ async fn stream_to_tempfile(
 ) -> Result<u64> {
     // Open the tempfile FIRST so that an adversary cannot pre-stage a symlink
     // at `tmp` between the HTTP response and the actual write. `O_NOFOLLOW`
-    // + `O_EXCL` fail closed on any pre-existing path (issue #650, L2).
+    // + `O_EXCL` fail closed on any pre-existing path (L2).
     let mut out = open_tempfile_no_symlink(tmp)
         .await
         .with_context(|| format!("Failed to create tempfile for {filename}"))?;
@@ -617,7 +617,7 @@ pub fn download_repo(opts: DownloadOptions) -> Result<()> {
     let endpoint = hf_endpoint();
 
     // M1 — refuse plaintext endpoints when a token would be sent over the
-    // wire (issue #650). A bearer token sent over `http://` exposes the
+    // wire. A bearer token sent over `http://` exposes the
     // long-lived credential to anyone on-path. The opt-out env var exists
     // for operators who genuinely run an HTTPS-terminated reverse proxy
     // in front of an internal HTTP mirror on a trusted network.
@@ -666,7 +666,7 @@ pub fn download_repo(opts: DownloadOptions) -> Result<()> {
     })?;
 
     // L5 — opportunistic cleanup of stale `.mlxcel-partial.*` orphans
-    // (issue #650). Best-effort: any I/O error here is logged but does
+    // Best-effort: any I/O error here is logged but does
     // not fail the download. Only files older than `PARTIAL_TEMPFILE_STALE_AGE`
     // are removed so concurrent in-flight downloads from a sibling process
     // are not disturbed.
@@ -693,7 +693,7 @@ pub fn download_repo(opts: DownloadOptions) -> Result<()> {
 
     // Build the reqwest client once and share across all file downloads.
     //
-    // Timeouts (issue #650, M2): `connect_timeout(10s)` aborts the TCP/TLS
+    // Timeouts (M2): `connect_timeout(10s)` aborts the TCP/TLS
     // handshake if a mirror is unreachable. `read_timeout(30s)` aborts when
     // the response body stalls for 30s — the correct semantics for a long
     // download where total elapsed time is unbounded but any 30s window of
@@ -701,7 +701,7 @@ pub fn download_repo(opts: DownloadOptions) -> Result<()> {
     // set because legitimate large weight files take more than the global
     // default.
     //
-    // Redirect downgrade defense (issue #650, M1 reinforcement): reqwest's
+    // Redirect downgrade defense (M1 reinforcement): reqwest's
     // default `remove_sensitive_headers` only strips `Authorization` on
     // cross-host redirects, NOT on same-host scheme downgrades. Without
     // `https_only(true)` a malicious HTTPS->HTTP 302 on the same host would
@@ -715,7 +715,7 @@ pub fn download_repo(opts: DownloadOptions) -> Result<()> {
     let client = rt.block_on(async {
         let mut headers = reqwest::header::HeaderMap::new();
         if let Some(ref tok) = token {
-            // L3 (issue #650): reject non-ASCII or control-char tokens with
+            // L3: reject non-ASCII or control-char tokens with
             // a domain-specific error instead of the panic that the prior
             // `.expect("token must be ASCII")` would produce. `validate_token`
             // also rejects more characters than `HeaderValue::from_str` would
@@ -744,7 +744,7 @@ pub fn download_repo(opts: DownloadOptions) -> Result<()> {
 
     // Build per-file sizes map for accurate bar lengths. `hf-hub 0.5` does
     // not expose per-file sizes in the manifest (Siblings only has `rfilename`),
-    // so we issue concurrent HEAD requests here. Issue #650, L6: previously
+    // so we issue concurrent HEAD requests here. L6: previously
     // sequential (N RTTs before the first byte streamed); now bounded-parallel
     // via `futures::stream::iter(...).buffer_unordered(8)` so total pre-stream
     // wallclock is roughly one RTT for a small repo. 8 is well below any HF

--- a/src/downloader/progress.rs
+++ b/src/downloader/progress.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Progress bar helpers for the mlxcel downloader (issue #648).
+//! Progress bar helpers for the mlxcel downloader.
 //!
 //! Wraps `indicatif::MultiProgress` with TTY detection and env-var opt-out so
 //! that CI logs and piped output remain clean plain-text while interactive

--- a/src/downloader/resolver_tests.rs
+++ b/src/downloader/resolver_tests.rs
@@ -23,7 +23,7 @@ use super::*;
 use std::fs;
 use std::path::{Path, PathBuf};
 // Env-var-sensitive tests must serialize through the crate-wide `ENV_LOCK`
-// (issue #573): Rust 2024's `set_var`/`remove_var` are `unsafe` because
+// Rust 2024's `set_var`/`remove_var` are `unsafe` because
 // libc's env block has no internal lock and concurrent mutation is UB.
 use crate::test_support::env_lock::env_lock;
 

--- a/src/downloader/store.rs
+++ b/src/downloader/store.rs
@@ -647,7 +647,7 @@ fn is_within(base: &Path, child: &Path) -> bool {
 mod tests {
     use super::*;
     // Env-var-sensitive tests must serialize through the crate-wide `ENV_LOCK`
-    // (issue #573): Rust 2024's `set_var`/`remove_var` are `unsafe` because
+    // Rust 2024's `set_var`/`remove_var` are `unsafe` because
     // libc's env block has no internal lock and concurrent mutation is UB.
     use crate::test_support::env_lock::env_lock;
 

--- a/src/downloader/tests.rs
+++ b/src/downloader/tests.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit tests for the HuggingFace snapshot downloader (issue #457).
+//! Unit tests for the HuggingFace snapshot downloader.
 
 use super::*;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 // Env-var-sensitive tests must serialize through the crate-wide `ENV_LOCK`
-// (issue #573); without it, two test threads can call `setenv`/`getenv`
+// without it, two test threads can call `setenv`/`getenv`
 // concurrently — undefined behavior under Rust 2024's unsafe env contract.
 use crate::test_support::env_lock::env_lock;
 
@@ -231,7 +231,7 @@ fn allow_list_handles_subdirectories() {
 }
 
 // ---------------------------------------------------------------------------
-// Path-traversal regression tests for security finding C1 on PR #486.
+// Path-traversal regression tests for security finding C1 on.
 //
 // A malicious HuggingFace repo (or MitM) can return a sibling whose
 // `rfilename` is `/etc/cron.d/evil` or `../../etc/passwd.json`. Before the
@@ -280,7 +280,7 @@ fn allow_list_still_accepts_normal_subdir_paths() {
 /// Live PoC: simulate a malicious `info.siblings` payload and assert that
 /// every adversarial `rfilename` is rejected by `is_wanted_file` before any
 /// IO can occur. This mirrors the exploit shape the security checker
-/// empirically verified on PR #486.
+/// empirically verified on.
 #[test]
 fn malicious_siblings_payload_is_filtered_out() {
     let malicious_siblings = vec![
@@ -500,7 +500,7 @@ fn live_download_smoke_test() {
 }
 
 // ---------------------------------------------------------------------------
-// Hardening tests (issue #650)
+// Hardening tests
 // ---------------------------------------------------------------------------
 
 /// L1 — Adversarial filenames containing reserved URL characters must be

--- a/src/lang_analyzer_tests.rs
+++ b/src/lang_analyzer_tests.rs
@@ -24,7 +24,7 @@ use mlxcel_core::lang_analyzer::{
     is_whitespace,
 };
 // Env-var-sensitive tests must serialize through the crate-wide `ENV_LOCK`
-// (issue #573); per-module locks race with env mutations in unrelated
+// per-module locks race with env mutations in unrelated
 // modules of the same test binary.
 use crate::test_support::env_lock::env_lock;
 
@@ -296,7 +296,7 @@ fn build_vocab_hash_differs_across_tokenizers() {
 fn version_constant_is_three() {
     // v1 → v2 bumped when classify switched from id_to_token to decode so
     // byte-level BPE tokenizers produce correct script assignments.
-    // v2 → v3 bumped (issue #405) when TokenScriptInfo gained the
+    // v2 → v3 bumped when TokenScriptInfo gained the
     // `is_byte_fragment` field and the opt-in byte-fragment classifier.
     assert_eq!(CURRENT_VERSION, 3, "CURRENT_VERSION must be 3");
 
@@ -793,7 +793,7 @@ fn b8_cxx_generator_with_token_bias_caches_map() {
 }
 
 // ============================================================================
-// Issue #589 — trimmable cache validation and last-token reservation
+// trimmable cache validation and last-token reservation
 // ============================================================================
 
 use mlxcel_core::cache::can_trim_prompt_cache;

--- a/src/lang_bias.rs
+++ b/src/lang_bias.rs
@@ -236,7 +236,7 @@ pub struct ExceptionYaml {
     pub include_numeric: bool,
     #[serde(default)]
     pub include_punctuation: bool,
-    /// Issue #405 — include byte-fragment tokens classified via UTF-8
+    /// include byte-fragment tokens classified via UTF-8
     /// start-byte analysis. Default: `false`.
     #[serde(default)]
     pub include_byte_fragments: bool,
@@ -695,7 +695,7 @@ unknown_field: value
         );
     }
 
-    /// Issue #405 — `--lang-bias-include-byte-fragments` flips the resolved
+    /// `--lang-bias-include-byte-fragments` flips the resolved
     /// `ExceptionConfig.include_byte_fragments` field and otherwise leaves the
     /// exception set identical to Phase 1 defaults.
     #[test]
@@ -717,7 +717,7 @@ unknown_field: value
         assert!(!config.exceptions.include_punctuation);
     }
 
-    /// Issue #405 — the CLI flag alone makes `is_active()` true so the
+    /// the CLI flag alone makes `is_active` true so the
     /// resolver runs even without any `--lang-bias` entries. This matters for
     /// operator workflows that only want to rebuild the cache with the
     /// byte-fragment pass enabled.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,7 @@ mod loading;
 mod model_metadata;
 
 // Crate-wide helpers for `#[cfg(test)]` paths. Provides the single shared
-// `ENV_LOCK` that every env-mutating test in this crate must acquire (issue
-// #573); see `test_support::env_lock` for the rationale. `pub(crate)` so
+// `ENV_LOCK` that every env-mutating test in this crate must acquire; see `test_support::env_lock` for the rationale. `pub(crate)` so
 // that test modules at any depth (e.g. `crate::server::cli_input::tests`)
 // can name it as `crate::test_support::env_lock`.
 #[cfg(test)]

--- a/src/lib/mlx-cpp/turbo/CMakeLists.txt
+++ b/src/lib/mlx-cpp/turbo/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# mlxcel TurboQuant fused kernel launchers (issue #505).
+# mlxcel TurboQuant fused kernel launchers.
 #
 # Currently only Sparse-V SDPA on Metal. The kernels themselves are runtime-
 # JIT-compiled via `mlx::core::fast::metal_kernel(...)`; this CMake target

--- a/src/lib/mlx-cpp/turbo/sparse_v_sdpa.cpp
+++ b/src/lib/mlx-cpp/turbo/sparse_v_sdpa.cpp
@@ -40,7 +40,7 @@ namespace {
 // and (D × RepeatCount) accumulator updates that the graph-level
 // `where(alive, V_dq, 0)` path still pays.
 //
-// Issue #520 — precomputed rescale.
+// precomputed rescale.
 //
 // The previous implementation derived `|y_hat[t]| = sqrt(Σ_d codebook[idx]²)`
 // per token via a `log2(Dim) + 2`-barrier threadgroup tree reduction over a
@@ -48,7 +48,7 @@ namespace {
 // `turbo4-asym` this reduction dominated decode latency: ~9 barriers per
 // cache token × 4 K tokens × 32 layers × ~32 threadgroups produced tens of
 // millions of `threadgroup_barrier` calls per decode step, making the kernel
-// 2.0× slower than the graph fallback (PR #519 A/B).
+// 2.0× slower than the graph fallback (A/B).
 //
 // Because `|y_hat|` is a pure function of the packed indices (themselves
 // fixed at quantize time), the entire rescale `rescale[t] = norm[t] / |y_hat[t]|`
@@ -94,7 +94,7 @@ constexpr const char* SPARSE_V_WEIGHTED_SUM_SOURCE = R"(
     }
 
     auto wt = weights + bhq * (uint)RepeatCount * t_count; // [Tq, Tk]
-    auto rs = rescale + bhkv * t_count;                     // [Tk] f16 (issue #520)
+    auto rs = rescale + bhkv * t_count;                     // [Tk] f16
     auto pk = packed + bhkv * t_count * (uint)(Dim / 2);    // [Tk, D/2]
 
     // Thresholds passed as a 1-element array so MLX accepts them as a regular
@@ -118,8 +118,8 @@ constexpr const char* SPARSE_V_WEIGHTED_SUM_SOURCE = R"(
     // and gate by per-Q attention weight.
     //
     // No threadgroup memory and no barriers in the inner loop — this is the
-    // entire point of issue #520. The previous tree-reduction body lived
-    // here; see git history for the pre-#520 form.
+    // entire point. The previous tree-reduction body lived
+    // here; see git history for the earlier form.
     for (uint t = 0; t < t_count; t++) {
         // Aliveness check: scan RepeatCount Q slots and short-circuit if all
         // are below threshold for this (b, h, t). For RepeatCount=1 (decode
@@ -134,7 +134,7 @@ constexpr const char* SPARSE_V_WEIGHTED_SUM_SOURCE = R"(
             }
         }
         if (!any_alive) {
-            // Per-thread skip — the speed gate of this kernel. With #520's
+            // Per-thread skip — the speed gate of this kernel. With's
             // precomputed rescale there is no in-flight threadgroup state to
             // synchronize against, so the skip is a clean continue without
             // any cross-thread divergence concerns.
@@ -153,7 +153,7 @@ constexpr const char* SPARSE_V_WEIGHTED_SUM_SOURCE = R"(
         }
 
         // Per-token rescale `norm[t] / max(|y_hat[t]|, 1e-10)` was computed
-        // on the host at quantize time (issue #520). Each thread loads the
+        // on the host at quantize time. Each thread loads the
         // same fp16 scalar; Apple's L1 / per-threadgroup cache coalesces the
         // broadcast so the bandwidth cost is effectively one read per
         // threadgroup per token.
@@ -200,7 +200,7 @@ struct SparseVKernelHolder {
             kernel = mlx::core::fast::metal_kernel(
                 "mlxcel_sparse_v_weighted_sum",
                 // Input names — must match the launcher's `inputs` vector
-                // order in `sparse_v_weighted_sum`. `rescale` (issue #520) is
+                // order in `sparse_v_weighted_sum`. `rescale` is
                 // the precomputed `norm[t] / |y_hat[t]|` fp16 sidecar that
                 // replaced the in-kernel `norms` + threadgroup tree
                 // reduction.
@@ -255,7 +255,7 @@ mlx::core::array sparse_v_weighted_sum(
     // below: {"weights", "rescale", "packed", "threshold", "codebook"}.
     std::vector<mlx::core::array> inputs = {
         attn_weights,   // [B*Hq, Tq, Tk]    f32
-        v_rescale,      // [B*Hkv, Tk]       f16  (issue #520 precompute)
+        v_rescale,      // [B*Hkv, Tk]       f16  (precompute)
         v_packed,       // [B*Hkv, Tk, D/2]  u8
         threshold_arr,  // [1]               f32
         codebook,       // [16]              f32

--- a/src/lib/mlx-cpp/turbo/sparse_v_sdpa.h
+++ b/src/lib/mlx-cpp/turbo/sparse_v_sdpa.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-// Fused Sparse-V SDPA kernel launcher for Turbo4Asym KV cache (issue #505).
+// Fused Sparse-V SDPA kernel launcher for Turbo4Asym KV cache.
 //
 // This header exposes a single C++ entry point that issues the runtime-JIT
 // Metal kernel via `mlx::core::fast::metal_kernel`. The kernel performs the
@@ -24,7 +24,7 @@
 //     out_pre[b, h, k] = Σ_t attn_weights[b, h, t]
 //                          * y_hat[t, k] * v_rescale[t]
 //             where v_rescale[t] = norm[t] / max(|y_hat[t]|, 1e-10)
-//             (precomputed at quantize time; issue #520) and the inner
+//             (precomputed at quantize time) and the inner
 //             loop short-circuits when attn_weights[b, h, t] < threshold.
 //
 // The caller (`mlxcel-core/cpp/mlx_cxx_bridge.cpp`) computes the FP32
@@ -46,7 +46,7 @@ namespace mlxcel::turbo {
 // - `attn_weights`: `[B*Hq, Tq, Tk]` FP32 — pre-flattened post-softmax weights.
 // - `v_packed`:     `[B*Hkv, Tk, D/2]` UINT8 — nibble-packed Turbo4 V indices.
 // - `v_rescale`:    `[B*Hkv, Tk]` FP16 — precomputed per-token rescale factor
-//   `norm[t] / max(|y_hat[t]|, 1e-10)`. Issue #520 promoted this from an
+//   `norm[t] / max(|y_hat[t]|, 1e-10)`. promoted this from an
 //   in-kernel threadgroup tree reduction to a one-time host-side precompute
 //   at quantize time; eliminates `log2(Dim) + 2` per-token threadgroup
 //   barriers and the kernel `tg_y_hat[Dim]` shared scratch.
@@ -68,7 +68,7 @@ namespace mlxcel::turbo {
 mlx::core::array sparse_v_weighted_sum(
     const mlx::core::array& attn_weights, // [B*Hq, Tq, Tk] f32
     const mlx::core::array& v_packed,      // [B*Hkv, Tk, D/2] u8
-    const mlx::core::array& v_rescale,     // [B*Hkv, Tk] f16 (issue #520)
+    const mlx::core::array& v_rescale,     // [B*Hkv, Tk] f16
     const mlx::core::array& codebook,      // [16] f32
     int dim,
     int n_rep,

--- a/src/lib/mlx-cpp/turbo/sparse_v_sdpa.metal
+++ b/src/lib/mlx-cpp/turbo/sparse_v_sdpa.metal
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 // Reference Metal source for the fused Sparse-V SDPA weighted-sum kernel
-// (issue #505; rescale precompute landed in #520).
+// (rescale precompute landed).
 //
 // This file is a faithful copy of the source string embedded in
 // `sparse_v_sdpa.cpp`. Keeping it as a standalone .metal file makes it
@@ -37,9 +37,7 @@
 // Inputs (per launch):
 //   weights     — [B*Hq, Tq, Tk] f32  : post-softmax attention weights
 //   rescale     — [B*Hkv, Tk]    f16  : precomputed `norm[t] / |y_hat[t]|`
-//                                       (issue #520; replaced the previous
-//                                       `norms` input + in-kernel tree
-//                                       reduction)
+//                                       (replaced the previous `norms` input + in-kernel tree reduction)
 //   packed      — [B*Hkv, Tk, D/2] u8 : nibble-packed V indices (2 per byte)
 //   codebook    — [16]           f32  : Lloyd-Max centroids
 //
@@ -56,7 +54,7 @@
 // Per-thread compute proceeds dim-by-dim over D, sweeping all Tq tokens
 // (RepeatCount) and accumulating the unrotated weighted sum.
 //
-// Issue #520 kernel-body change summary:
+// kernel-body change summary:
 //   - Removed `tg_y_hat[Dim]` shared scratch and `tg_norm[1]` broadcast.
 //   - Removed the `log2(Dim)`-step threadgroup tree reduction over `code²`.
 //   - Removed the `if (tg_d == 0) compute rescale; barrier; broadcast` chain.

--- a/src/lib/mlx-cpp/turbo/turbo4_delegated_sdpa.cpp
+++ b/src/lib/mlx-cpp/turbo/turbo4_delegated_sdpa.cpp
@@ -65,7 +65,7 @@ namespace {
 //    Two launchers, two test entries, no shared mutable state.
 //
 // If you change one kernel body, you must consider whether the other needs
-// the matching change. As of issue #528 the bodies are bit-identical.
+// the matching change. As the bodies are bit-identical.
 constexpr const char* TURBO4_DELEGATED_COLD_WEIGHTED_SUM_SOURCE = R"(
     auto d = thread_position_in_grid.x;
     auto n = thread_position_in_grid.z;
@@ -112,7 +112,7 @@ constexpr const char* TURBO4_DELEGATED_COLD_WEIGHTED_SUM_SOURCE = R"(
     // and gate by per-Q attention weight.
     //
     // No threadgroup memory and no barriers in the inner loop — the same
-    // discipline issue #520 introduced for the Sparse-V kernel applies here.
+    // discipline introduced for the Sparse-V kernel applies here.
     for (uint t = 0; t < t_count; t++) {
         bool any_alive = false;
         for (int r = 0; r < RepeatCount; r++) {
@@ -137,7 +137,7 @@ constexpr const char* TURBO4_DELEGATED_COLD_WEIGHTED_SUM_SOURCE = R"(
         }
 
         // Per-token rescale `norm[t] / max(|y_hat[t]|, 1e-10)` was computed
-        // on the host at quantize time (issue #520). Each thread loads the
+        // on the host at quantize time. Each thread loads the
         // same fp16 scalar; Apple's L1 / per-threadgroup cache coalesces the
         // broadcast so the bandwidth cost is effectively one read per
         // threadgroup per token.
@@ -242,15 +242,15 @@ inline Turbo4BulkDequantRotatedKernelHolder& get_turbo4_bulk_dequant_rotated_ker
     return holder;
 }
 
-} // namespace (cold-only kernel internals; #528)
+} // namespace (cold-only kernel internals)
 
-namespace {  // anonymous namespace for issue #531 steel-envelope kernel internals
+namespace {  // anonymous namespace steel-envelope kernel internals
 
 // =============================================================================
-// Issue #531 — Steel-attention-envelope fused SDPA kernel for Turbo4Delegated.
+// Steel-attention-envelope fused SDPA kernel for Turbo4Delegated.
 // =============================================================================
 //
-// The cold-V weighted-sum kernel above (#528) fixed the V-memory budget by
+// The cold-V weighted-sum kernel above fixed the V-memory budget by
 // reading packed 4-bit cold V directly inside the kernel. But the host-side
 // composition in `attention_turbo4_delegated_fused` still issues 14+ MLX
 // dispatches per decode step (Q·K, scale, mask add, softmax, slice cold,
@@ -335,18 +335,17 @@ constexpr const char* TURBO4_DELEGATED_STEEL_SDPA_SOURCE = R"(
     // -------------------------------------------------------------------------
     // Pass 1: per-Q max + sum_exp scan over the full T_total score range.
     //
-    // History: PR #532 ran this entire pass on thread 0 only and parked the
-    // other D-1 threads at a single barrier, citing issue #520 as precedent
+    // History: ran this entire pass on thread 0 only and parked the
+    // other D-1 threads at a single barrier, citing as precedent
     // for avoiding threadgroup tree-reduction barriers. That assumption held
-    // on M1 Ultra at parity contexts but failed by 6×–25× on M5 Max (PR
-    // #533) because the M5 Max GPU has higher thread occupancy and each
+    // on M1 Ultra at parity contexts but failed by 6×–25× on M5 Max because the M5 Max GPU has higher thread occupancy and each
     // idle thread now costs more in opportunity terms than the barrier
-    // chain itself. Issue #534 inverts the choice for this kernel: split
+    // chain itself. inverts the choice for this kernel: split
     // both Pass 1a (max) and Pass 1b (sum_exp) across all D threads with a
     // tree reduction. With D=128 and T_total=16K each thread reads 128
     // positions instead of 16K — a 128× cut in per-thread serial work.
     //
-    // Why issue #520's pattern still applies to `sparse_v_sdpa.cpp`: that
+    // Why's pattern still applies to `sparse_v_sdpa.cpp`: that
     // kernel does no pre-pass; it only does a single accumulation loop with
     // per-thread skip. There is no cross-thread dependency in that loop, so
     // there is no barrier to eliminate. Here we have an explicit reduction.
@@ -482,11 +481,11 @@ constexpr const char* TURBO4_DELEGATED_STEEL_SDPA_SOURCE = R"(
     uint nibble_shift = ((uint)d & 1u) * 4u;
 
     // Cold loop. Mirror the alive-skip discipline of the cold-only kernel
-    // (issue #528): if the post-softmax weight for this token is below the
+    // if the post-softmax weight for this token is below the
     // threshold for every Q slot, skip the dequant + rescale + accumulate
     // work entirely. We compare `exp_score > thresh * sum_exp` instead of
     // the equivalent `exp_score / sum_exp > thresh` to avoid a divide in the
-    // hot path — `sum_exp` is loop-invariant per r. Issue #534 follow-up:
+    // hot path — `sum_exp` is loop-invariant per r. follow-up:
     // make that comparison in score-space first so fully-dead tokens also
     // avoid the exp calls.
     bool threshold_enabled = thresh > 0.0f && isfinite(thresh);
@@ -740,7 +739,7 @@ mlx::core::array turbo4_delegated_bulk_dequant_rotated(
 }
 
 // =============================================================================
-// Issue #531 — Steel-attention-envelope fused SDPA launcher.
+// Steel-attention-envelope fused SDPA launcher.
 // =============================================================================
 //
 // Wraps the JIT-compiled `mlxcel_turbo4_delegated_steel_sdpa` kernel. The

--- a/src/lib/mlx-cpp/turbo/turbo4_delegated_sdpa.h
+++ b/src/lib/mlx-cpp/turbo/turbo4_delegated_sdpa.h
@@ -15,22 +15,20 @@
 #pragma once
 
 // Fused dequant + SDPA Metal kernel launcher for `KVCacheMode::Turbo4Delegated`
-// (issue #528, follow-up to issue #527's K-side unification).
+// (follow-up to's K-side unification).
 //
 // The Turbo4Delegated cache stores V in two regions:
 // - cold body — `[B, H_kv, T_cold, D/2]` u8 packed Turbo4 indices plus
-//   `[B, H_kv, T_cold, 1]` fp16 per-token kernel rescale (`norm/|y_hat|`,
-//   issue #520).
+//   `[B, H_kv, T_cold, 1]` fp16 per-token kernel rescale (`norm/|y_hat|`).
 // - hot ring — `[B, H_kv, T_hot, D]` fp16 plain V tokens (no rotation).
 //
-// Pre-#528 the read path materialised the full FP16 cold body (via
-// `dequantize_v_turbo4` plus a memo from PR #525) and then ran a graph-level
+// Pre- the read path materialised the full FP16 cold body (via `dequantize_v_turbo4` plus a memo) and then ran a graph-level
 // `concatenate(cold_v_dequant, hot_v, axis=2)` plus standard SDPA. The memo
 // alone consumed `[B, H_kv, cold_offset, D]` fp16 of working set, undoing the
-// 4-bit V compression that defines the mode. Issue #528 retires that memo.
+// 4-bit V compression that defines the mode. retires that memo.
 //
 // `turbo4_delegated_sdpa_cold_weighted_sum` mirrors the Sparse-V kernel
-// `sparse_v_weighted_sum` (issue #505 / #520) — runtime-JIT-compiled via
+// `sparse_v_weighted_sum` — runtime-JIT-compiled via
 // `mlx::core::fast::metal_kernel`, identical input layout, identical
 // "unrotated weighted sum" output contract. The host caller composes:
 //
@@ -38,7 +36,7 @@
 //
 // where `cold_pre` is what this launcher returns. The packed cold V is read
 // directly inside the kernel; the dequantised cold V is **never** written to
-// global memory. That is the whole point of issue #528.
+// global memory. That is the whole point.
 //
 // The hot-side weighted sum (`attn_hot @ hot_v`) is kept in the host MLX
 // graph (single small matmul, T_hot ≤ DELEGATED_HOT_MAX = 1024) — the per-
@@ -50,7 +48,7 @@
 // `mlx::core::Shape`, `mlx::core::float32`.
 //
 // Used by: `cpp/mlx_cxx_bridge.cpp::turbo4_delegated_cold_weighted_sum`,
-//          `cpp/mlx_cxx_bridge.cpp::turbo4_delegated_steel_sdpa` (issue #531).
+//          `cpp/mlx_cxx_bridge.cpp::turbo4_delegated_steel_sdpa`.
 
 #include <mlx/array.h>
 
@@ -69,7 +67,7 @@ namespace mlxcel::turbo {
 // - `v_packed_cold`:     `[B*Hkv, T_cold, D/2]` UINT8 — nibble-packed Turbo4
 //   V indices for the cold body.
 // - `v_rescale_cold`:    `[B*Hkv, T_cold]` FP16 — precomputed per-token
-//   rescale `norm[t] / max(|y_hat[t]|, 1e-10)` (issue #520).
+//   rescale `norm[t] / max(|y_hat[t]|, 1e-10)`.
 // - `codebook`:          `[16]` FP32 — Lloyd-Max centroids (4-bit).
 //
 // Template parameters (passed to the kernel as `int` template args):
@@ -94,7 +92,7 @@ namespace mlxcel::turbo {
 mlx::core::array turbo4_delegated_cold_weighted_sum(
     const mlx::core::array& attn_weights_cold,  // [B*Hq, Tq, T_cold] f32
     const mlx::core::array& v_packed_cold,      // [B*Hkv, T_cold, D/2] u8
-    const mlx::core::array& v_rescale_cold,     // [B*Hkv, T_cold] f16 (#520)
+    const mlx::core::array& v_rescale_cold,     // [B*Hkv, T_cold] f16
     const mlx::core::array& codebook,           // [16] f32
     int dim,
     int n_rep,
@@ -115,7 +113,7 @@ mlx::core::array turbo4_delegated_bulk_dequant_rotated(
     int dim);
 
 // Run the steel-attention-envelope fused SDPA kernel for Turbo4Delegated
-// (issue #531). One Metal dispatch performs the entire post-Q·K SDPA inline:
+// One Metal dispatch performs the entire post-Q·K SDPA inline:
 // numerically stable softmax over the full (cold + hot) score range, cold-V
 // dequant + weighted-sum from packed 4-bit storage, hot-V FP16 weighted-sum,
 // and per-Q normalisation. The kernel returns two FP32 buffers; the host
@@ -139,7 +137,7 @@ mlx::core::array turbo4_delegated_bulk_dequant_rotated(
 //   indices. May be empty (`T_cold == 0`) pre-fold; in that case pass a
 //   zero-shaped placeholder.
 // - `cold_rescale`:  `[B*Hkv, T_cold]` FP16 — precomputed per-token cold-V
-//   rescale `norm[t] / max(|y_hat[t]|, 1e-10)` (issue #520).
+//   rescale `norm[t] / max(|y_hat[t]|, 1e-10)`.
 // - `hot_v`:         `[B*Hkv, T_hot, D]` FP16 — plain FP16 hot V tokens. May
 //   be empty (`T_hot == 0`) immediately after a fold.
 // - `codebook`:      `[16]` FP32 — Lloyd-Max centroids.

--- a/src/lib/mlxcel-core/build.rs
+++ b/src/lib/mlxcel-core/build.rs
@@ -31,11 +31,11 @@ fn main() {
     let mut bridge = cxx_build::bridge("src/lib.rs");
     bridge
         .file("cpp/mlx_cxx_bridge.cpp")
-        // Issue #505: Fused Sparse-V SDPA kernel launcher. Lives under
+        // Fused Sparse-V SDPA kernel launcher. Lives under
         // `src/lib/mlx-cpp/turbo/` so the MLX-upstream-commit upgrade
         // checklist (CLAUDE.md) treats this directory as in-scope.
         .file("../mlx-cpp/turbo/sparse_v_sdpa.cpp")
-        // Issue #528: Fused Turbo4Delegated cold-V weighted-sum kernel
+        // Fused Turbo4Delegated cold-V weighted-sum kernel
         // launcher. Reads the packed cold V directly so the dequantised
         // FP16 cold body never materialises in global memory; the host
         // pairs this with a hot-V matmul to produce the final SDPA output.
@@ -120,12 +120,12 @@ fn main() {
     println!("cargo:rerun-if-changed=metal/fused_attention_metal4.metal");
     println!("cargo:rerun-if-changed=../mlx-cpp/CMakeLists.txt");
     println!("cargo:rerun-if-changed=../mlx-cpp/patches");
-    // Issue #505: Sparse-V fused-skip Metal kernel launchers.
+    // Sparse-V fused-skip Metal kernel launchers.
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/CMakeLists.txt");
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/sparse_v_sdpa.h");
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/sparse_v_sdpa.cpp");
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/sparse_v_sdpa.metal");
-    // Issue #528: Turbo4Delegated cold-V fused weighted-sum kernel launcher.
+    // Turbo4Delegated cold-V fused weighted-sum kernel launcher.
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/turbo4_delegated_sdpa.h");
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/turbo4_delegated_sdpa.cpp");
     println!("cargo:rerun-if-env-changed=MLX_CUDA_ARCHITECTURES");

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -2,8 +2,8 @@
 // Direct C++ bridge implementation for MLX via cxx
 
 #include "mlx_cxx_bridge.h"
-#include "sparse_v_sdpa.h"  // Issue #505: fused Sparse-V SDPA kernel.
-#include "turbo4_delegated_sdpa.h"  // Issue #528: fused Turbo4Delegated SDPA kernel.
+#include "sparse_v_sdpa.h"  // fused Sparse-V SDPA kernel.
+#include "turbo4_delegated_sdpa.h"  // fused Turbo4Delegated SDPA kernel.
 #include "mlx/ops.h"
 #include "mlx/transforms.h"
 #include "mlx/compile.h"
@@ -110,7 +110,7 @@ void synchronize_stream(const MlxStream& stream) {
     mlx::core::synchronize(stream.inner);
 }
 
-// Thread-local stream surface (issue #556 / mlx-vlm PR #1050).
+// Thread-local stream surface (mlx-vlm PR #1050).
 //
 // Each `ThreadLocalStream` registers a TLS slot keyed by a stream
 // index. When a different thread first calls
@@ -5997,7 +5997,7 @@ std::unique_ptr<MlxArray> fused_metal4_attention(
     ));
 }
 
-// Issue #505 — Fused Sparse-V SDPA Metal kernel launcher. Implementation in
+// Fused Sparse-V SDPA Metal kernel launcher. Implementation in
 // `src/lib/mlx-cpp/turbo/sparse_v_sdpa.cpp`; we forward the call here so the
 // new symbol shows up in the cxx-bridge ABI without bloating the bridge .cpp.
 std::unique_ptr<MlxArray> turbo_sparse_v_weighted_sum(
@@ -6019,12 +6019,12 @@ std::unique_ptr<MlxArray> turbo_sparse_v_weighted_sum(
     return std::make_unique<MlxArray>(std::move(out));
 }
 
-// Issue #528 — Fused Turbo4Delegated cold-V weighted-sum kernel launcher.
+// Fused Turbo4Delegated cold-V weighted-sum kernel launcher.
 // Implementation in `src/lib/mlx-cpp/turbo/turbo4_delegated_sdpa.cpp`; we
 // forward the call here so the new symbol shows up in the cxx-bridge ABI
 // without bloating the bridge .cpp. The unrotated cold weighted sum returned
 // here is paired with a host-side hot V matmul; the dequantised cold V never
-// materialises in global memory (the whole point of issue #528).
+// materialises in global memory (the whole point).
 std::unique_ptr<MlxArray> turbo4_delegated_cold_weighted_sum(
     const MlxArray& attn_weights_cold,
     const MlxArray& v_packed_cold,
@@ -6057,7 +6057,7 @@ std::unique_ptr<MlxArray> turbo4_delegated_bulk_dequant_rotated(
     return std::make_unique<MlxArray>(std::move(out));
 }
 
-// Issue #531 — Steel-attention-envelope fused Turbo4Delegated SDPA bridge.
+// Steel-attention-envelope fused Turbo4Delegated SDPA bridge.
 // Wraps the launcher in `src/lib/mlx-cpp/turbo/turbo4_delegated_sdpa.cpp` and
 // repackages the std::vector<mlx::core::array> return into the `cxx`-friendly
 // `Turbo4DelegatedSteelOutputs` struct (cxx does not directly model multiple
@@ -6118,7 +6118,7 @@ std::unique_ptr<MlxArray> loaded_weights_take(MlxLoadedWeights& w, size_t index)
     return std::move(w.arrays.at(index));
 }
 
-// Issue #531 — steel SDPA output takers. The cxx bridge does not directly
+// steel SDPA output takers. The cxx bridge does not directly
 // model destructuring a struct returned over the FFI boundary; we expose two
 // simple `move-out` accessors that the Rust caller invokes once each. After
 // both calls the struct's `unique_ptr` slots are empty (a second call would

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -34,8 +34,7 @@ struct MlxStream {
 // across threads gives every thread its own dedicated MLX stream
 // without any explicit coordination between them. Used by
 // `mlxcel-core` to back the generation stream of `BatchScheduler`,
-// `CxxGenerator`, and `SpeculativeGenerator` (issue #556 / upstream
-// MLX commit `728fab1` in mlx-vlm PR #1050).
+// `CxxGenerator`, and `SpeculativeGenerator` (upstream MLX commit `728fab1` in mlx-vlm PR #1050).
 struct MlxThreadLocalStream {
     mlx::core::ThreadLocalStream inner;
 
@@ -1674,13 +1673,13 @@ std::unique_ptr<MlxArray> fused_metal4_attention(
     bool use_metal4
 );
 
-// Issue #505 / #520 — Fused Sparse-V SDPA Metal kernel launcher.
+// Fused Sparse-V SDPA Metal kernel launcher.
 // Wraps `mlxcel::turbo::sparse_v_weighted_sum` so the cxx bridge can expose it
 // via the `turbo_sparse_v_weighted_sum` FFI symbol. Implementation lives in
 // `src/lib/mlx-cpp/turbo/sparse_v_sdpa.cpp`.
 //
 // `v_rescale` (4th argument) carries the precomputed per-token rescale
-// `norm[t] / |y_hat[t]|` introduced in issue #520. The previous kernel
+// `norm[t] / |y_hat[t]|` introduced. The previous kernel
 // computed this scalar per token via a threadgroup tree reduction; the
 // precompute moves that work to quantize time and removes the per-token
 // threadgroup barrier chain that dominated decode latency on M5 Max.
@@ -1693,7 +1692,7 @@ std::unique_ptr<MlxArray> turbo_sparse_v_weighted_sum(
     int32_t n_rep,
     float threshold);
 
-// Issue #528 — Fused Turbo4Delegated cold-V weighted-sum kernel launcher.
+// Fused Turbo4Delegated cold-V weighted-sum kernel launcher.
 // Wraps `mlxcel::turbo::turbo4_delegated_cold_weighted_sum` so the cxx bridge
 // can expose it via the `turbo4_delegated_cold_weighted_sum` FFI symbol.
 // Implementation lives in `src/lib/mlx-cpp/turbo/turbo4_delegated_sdpa.cpp`.
@@ -1702,8 +1701,7 @@ std::unique_ptr<MlxArray> turbo_sparse_v_weighted_sum(
 // host caller applies the inverse Turbo4 rotation to that result and adds
 // the hot-V matmul contribution to produce the final FP16 SDPA output. The
 // dequantised cold V never materialises in global memory — that property is
-// the reason this kernel exists (vs. the pre-#528 path which built an FP16
-// `cold_v_dequant` memo plus a per-step concat with hot V).
+// the reason this kernel exists (vs. the earlier path which built an FP16 `cold_v_dequant` memo plus a per-step concat with hot V).
 std::unique_ptr<MlxArray> turbo4_delegated_cold_weighted_sum(
     const MlxArray& attn_weights_cold,
     const MlxArray& v_packed_cold,
@@ -1722,7 +1720,7 @@ std::unique_ptr<MlxArray> turbo4_delegated_bulk_dequant_rotated(
     const MlxArray& codebook,
     int32_t dim);
 
-// Issue #531 — Steel-attention-envelope fused Turbo4Delegated SDPA launcher.
+// Steel-attention-envelope fused Turbo4Delegated SDPA launcher.
 // Wraps `mlxcel::turbo::turbo4_delegated_steel_sdpa`. Returns a pair of MLX
 // arrays (`out_cold_pre`, `out_hot`) that the host sums after applying the
 // linear inverse Turbo4 rotation to the cold output. The pair is exposed

--- a/src/lib/mlxcel-core/examples/wht_microbench.rs
+++ b/src/lib/mlxcel-core/examples/wht_microbench.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Walsh–Hadamard Transform microbenchmark for issue #470 (B0 spike,
-//! epic #458 — TurboQuant KV cache compression).
+//! Walsh–Hadamard Transform microbenchmark (B0 spike, — TurboQuant KV cache compression).
 //!
 //! This is the empirical evidence for the spike question:
 //!
@@ -172,7 +171,7 @@ fn synth_heavy_tail(shape: &[i32], seed: u64) -> UniquePtr<MlxArray> {
 }
 
 fn main() {
-    println!("=== WHT microbench (issue #470, B0 spike) ===");
+    println!("=== WHT microbench (B0 spike) ===");
     println!("fp16 along last axis, MLX hadamard_transform via mlxcel-core::ops::wht\n");
 
     println!(

--- a/src/lib/mlxcel-core/metal/fused_attention_metal4.metal
+++ b/src/lib/mlxcel-core/metal/fused_attention_metal4.metal
@@ -3,7 +3,7 @@
 // Experimental Metal 4 fused attention kernel scaffold.
 //
 // This file is intentionally kept separate from MLX upstream overlay kernels so
-// we can iterate on a mlxcel-specific TensorOps kernel body for issue #197.
+// we can iterate on a mlxcel-specific TensorOps kernel body.
 // Runtime wiring still lives in `cpp/mlx_cxx_bridge.cpp`.
 
 #include <metal_stdlib>

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -25,13 +25,13 @@
 //! method always returns FP16 tensors (dequantized on read), so the attention
 //! computation is unaffected.
 //!
-//! `KVCacheMode::Turbo4Asym` (issue #474, epic #458) keeps the K side as FP16
+//! `KVCacheMode::Turbo4Asym` keeps the K side as FP16
 //! and compresses the V side to 4-bit PolarQuant indices plus per-token norms,
 //! reducing total KV memory by ~26% at long context. The compressed V buffers
 //! live in dedicated sidecar fields (`v_packed`, `v_norms`) and the
 //! quantize/dequantize helpers in [`turbo::quant`] handle the math.
 //!
-//! `KVCacheMode::Turbo3Asym` (issue #477, epic #458) is the 3-bit sibling of
+//! `KVCacheMode::Turbo3Asym` is the 3-bit sibling of
 //! `Turbo4Asym` — same Fp16-K + asymmetric layout, but the V side uses the
 //! 8-centroid (3-bit) Lloyd-Max codebook and the 24-bit-grouped packing
 //! layout from [`turbo::pack3`]. Compression climbs to ~5.1× total KV
@@ -39,7 +39,7 @@
 //! V-reconstruction error. Symmetric Turbo3 is an explicit non-goal of
 //! this PR — see [`turbo::quant3`] for rationale.
 //!
-//! `KVCacheMode::Turbo4` (issue #476, epic #458) extends Turbo4Asym to a
+//! `KVCacheMode::Turbo4` extends Turbo4Asym to a
 //! **symmetric** 4-bit K + 4-bit V layout, reducing KV memory by ~73% at
 //! long context. The K side mirrors the V side bit-for-bit but uses an
 //! independent pair of sign vectors (see [`turbo::quant::K_SEED_OFFSET`]).
@@ -47,12 +47,12 @@
 //! [`turbo::allowlist`] module for the per-model allowlist that gates
 //! end-user opt-in.
 //!
-//! `KVCacheMode::Turbo4Delegated` (issue #479, epic #458) extends the
+//! `KVCacheMode::Turbo4Delegated` extends the
 //! asymmetric mode with a V-only hot/cold split that recovers 97–100% of FP16
 //! decode speed at long context. The K side is a single unified FP16 buffer
 //! that grows in lockstep with `offset` (identical shape contract to
 //! `KVCacheMode::Fp16`); only V is split into a packed cold body plus an FP16
-//! hot ring (issue #527). During prefill tokens accumulate in the standard
+//! hot ring. During prefill tokens accumulate in the standard
 //! FP16 `keys`/`values` buffers (zero overhead). On the first decode step the
 //! V hot body is "folded" into cold storage by quantizing it into packed
 //! Turbo4 in `v_packed`/`v_norms`. The K side does *not* move — it stays in
@@ -64,7 +64,7 @@
 //! `cold_offset += block`). SDPA always reads FP16: reads return
 //! `slice(keys, 0, offset)` for K and `concat(dequant(v_packed), hot_V)` for
 //! V. The K side has no per-step concat — that was the dominant residual
-//! cost vs FP16 mode (~7 ms/step at 4 K context, issue #527). See
+//! cost vs FP16 mode (~7 ms/step at 4 K context). See
 //! `references/turboquant_plus/README.md` §"MLX Framework Port" for the
 //! original architecture.
 //!
@@ -143,7 +143,7 @@ pub enum KVCacheMode {
     Int8,
     /// Asymmetric Fp16-K + Turbo4-V. K side stays in FP16; V side uses 4-bit
     /// PolarQuant with Walsh–Hadamard rotation for ~26% net KV memory savings
-    /// at long context. See issue #474 / epic #458.
+    /// at long context..
     Turbo4Asym,
     /// Asymmetric Fp16-K + Turbo3-V. K side stays in FP16; V side uses 3-bit
     /// PolarQuant with Walsh–Hadamard rotation for ~5.1× total KV memory
@@ -151,22 +151,19 @@ pub enum KVCacheMode {
     /// V-reconstruction error. The 3-bit packing is awkward (8 coords share
     /// 3 bytes / 24 bits — see [`turbo::pack3`]), so the dequant path runs
     /// a host round-trip rather than the 4-bit path's pure on-device unpack.
-    /// Symmetric Turbo3 is **not** offered in this mode (epic #458's
-    /// "Quality–compression tradeoff control" explicitly defers it). See
-    /// issue #477 / epic #458.
+    /// Symmetric Turbo3 is **not** offered in this mode ('s "Quality–compression tradeoff control" explicitly defers it). See
     Turbo3Asym,
     /// Symmetric Turbo4-K + Turbo4-V. Both K and V use 4-bit PolarQuant with
     /// independent Walsh–Hadamard rotations for ~73% net KV memory savings
     /// at long context. **Dangerous on dense Q4_K_M weights** — gated by
-    /// the per-model allowlist in [`turbo::allowlist`]. See issue #476 /
-    /// epic #458.
+    /// the per-model allowlist in [`turbo::allowlist`]. See
     Turbo4,
     /// Delegated hot/cold split on top of `Turbo4Asym`. Prefill stores raw
     /// FP16; on the first decode step the prefilled body is folded into cold
     /// storage (FP16 cold K + Turbo4 packed cold V); subsequent decode tokens
     /// flow through a small FP16 hot tail with zero-alloc slice-update. SDPA
     /// always reads FP16. Targets ≥97%-of-FP16 decode speed at 4K and ≥95%
-    /// at 16K on M5 Max. See issue #479 / epic #458.
+    /// at 16K on M5 Max..
     /// `MLXCEL_TURBO4_DELEGATED_FP16_FAST_PATH=1` keeps an FP16 V working set
     /// for native-SDPA decode while still maintaining packed sidecars.
     Turbo4Delegated,
@@ -183,7 +180,7 @@ impl std::str::FromStr for KVCacheMode {
             // ("fp16+turbo4") makes the asymmetric K/V split explicit, while
             // "turbo4-asym" is a shorter alias for scripts and tests.
             "turbo4-asym" | "fp16+turbo4" => Ok(Self::Turbo4Asym),
-            // Turbo3Asym (3-bit V, asymmetric only — issue #477). Same alias
+            // Turbo3Asym (3-bit V, asymmetric only —). Same alias
             // pattern as Turbo4Asym: "fp16+turbo3" is the canonical string,
             // "turbo3-asym" / "turbo3" are shorter forms used in scripts and
             // tests. There is intentionally no symmetric "turbo3" alias —
@@ -195,7 +192,7 @@ impl std::str::FromStr for KVCacheMode {
             // tests/scripts when readers benefit from the K/V symmetry being
             // spelled out.
             "turbo4" | "turbo4-sym" => Ok(Self::Turbo4),
-            // Delegated hot/cold split (B7, issue #479). Same K=FP16 +
+            // Delegated hot/cold split (B7). Same K=FP16 +
             // V=Turbo4 contract as Turbo4Asym but uses the delegated KVCache
             // architecture for decode speed at long context.
             "turbo4-delegated" | "fp16+turbo4-delegated" => Ok(Self::Turbo4Delegated),
@@ -295,7 +292,7 @@ pub(crate) const TURBO_DEFAULT_SEED: u32 = 0x7B4_70404; // "TUR" 0x474 + B2 issu
 /// and shared codebook used by the quantize/dequantize helpers in
 /// [`turbo::quant`]. The standard `values` field stays `None` in this mode.
 ///
-/// When `mode` is `KVCacheMode::Turbo4` (symmetric, issue #476), the K
+/// When `mode` is `KVCacheMode::Turbo4` (symmetric), the K
 /// buffers are *also* replaced by `k_packed` + `k_norms` sidecars; the
 /// `keys` field stays `None`. The same `turbo_params` instance carries an
 /// independent K-side sign-vector pair so the K and V quantization noise
@@ -305,8 +302,7 @@ pub(crate) const TURBO_DEFAULT_SEED: u32 = 0x7B4_70404; // "TUR" 0x474 + B2 issu
 /// `update`, `update_and_fetch`, `trim`, `nbytes`, and
 /// `bytes_per_reserved_token` methods dispatch over `mode` and support
 /// `KVCacheMode::Fp16`, `KVCacheMode::Int8`, `KVCacheMode::Turbo4Asym`
-/// (epic #458, issue #474), and `KVCacheMode::Turbo4` (epic #458,
-/// issue #476) without per-model branching.
+/// and `KVCacheMode::Turbo4` without per-model branching.
 pub struct KVCache {
     pub keys: Option<UniquePtr<MlxArray>>,
     pub values: Option<UniquePtr<MlxArray>>,
@@ -314,7 +310,7 @@ pub struct KVCache {
     /// position for new K/Q tokens and as the upper bound of the live window.
     /// Once a token has been written at position `p`, this value never
     /// decreases through any operation that preserves on-device K — in
-    /// particular `trim_front` (issue #603) increments [`Self::live_start`]
+    /// particular `trim_front` increments [`Self::live_start`]
     /// instead of decrementing `offset`, so the relative position
     /// `offset - i` between a cached K at monotonic slot `i` and a freshly
     /// rotated Q stays invariant after the live window is bounded.
@@ -329,7 +325,7 @@ pub struct KVCache {
     /// (see [`Self::trim_front`]).
     ///
     /// Together with `offset`, this preserves the RoPE invariant under
-    /// the `--max-kv-size` cap (issue #603): K stored at buffer slot `i` was
+    /// the `--max-kv-size` cap: K stored at buffer slot `i` was
     /// rotated at monotonic position `live_start + i` *at write time*, Q is
     /// rotated at the current monotonic `offset`, and attention sees the
     /// correct relative position `offset - (live_start + i)`.
@@ -344,13 +340,13 @@ pub struct KVCache {
     pub(crate) v_packed: Option<UniquePtr<MlxArray>>,
     // Turbo4Asym/Turbo4-mode V-side per-token norms: [B, H, L, 1] fp16
     pub(crate) v_norms: Option<UniquePtr<MlxArray>>,
-    // Turbo4-V precomputed kernel rescale `norm[t] / |y_hat[t]|` (issue #520).
+    // Turbo4-V precomputed kernel rescale `norm[t] / |y_hat[t]|`.
     // Same `[B, H, L, 1]` fp16 shape as `v_norms` and slice/concat/trimmed
     // lockstep with it. Populated only on Turbo4Asym / Turbo4 / Turbo4Delegated
     // updates — Turbo3Asym leaves this `None` because the 3-bit V kernel does
     // not exist. Consumed by `attention_sparse_v_turbo4_fused` to skip the
     // per-cache-token threadgroup tree reduction that previously dominated
-    // decode latency at 4 K context (PR #519 A/B; issue #520).
+    // decode latency at 4 K context (A/B).
     pub(crate) v_rescale: Option<UniquePtr<MlxArray>>,
     // Turbo4-mode (symmetric) K-side packed indices: [B, H, L, head_dim/2] u8
     pub(crate) k_packed: Option<UniquePtr<MlxArray>>,
@@ -365,7 +361,7 @@ pub struct KVCache {
     /// symmetric `Turbo4` mode the same params carry both V and K sign
     /// vectors (`signs1`/`signs2` for V, `k_signs1`/`k_signs2` for K).
     pub(crate) turbo_params: Option<turbo::TurboQuantParams>,
-    /// Cached PolarQuant params for `Turbo3Asym` (issue #477). The 3-bit
+    /// Cached PolarQuant params for `Turbo3Asym`. The 3-bit
     /// codebook (8 centroids) is incompatible with the 4-bit `turbo_params`
     /// codebook so a separate field is required. Lazily initialised on the
     /// first `Turbo3Asym` update once the V `head_dim` is known. Stays
@@ -377,7 +373,7 @@ pub struct KVCache {
     /// Number of tokens currently folded into cold V storage (Turbo4Delegated
     /// only).
     ///
-    /// **Issue #527** — K side is no longer split into hot/cold. The unified
+    /// **** — K side is no longer split into hot/cold. The unified
     /// `keys` buffer holds all `offset` tokens at FP16 (same contract as
     /// `KVCacheMode::Fp16`). Only V has a hot/cold split: the cold body lives
     /// in the packed `v_packed`/`v_norms`/`v_rescale` sidecars (length
@@ -433,8 +429,8 @@ impl KVCache {
     ///
     /// Use `KVCacheMode::Int8` to store accumulated keys/values in INT8 format.
     /// Use `KVCacheMode::Turbo4Asym` for asymmetric Fp16-K + Turbo4-V
-    /// compression (issue #474). Use `KVCacheMode::Turbo4` for symmetric
-    /// Turbo4-K + Turbo4-V compression (issue #476) — note that this mode
+    /// compression. Use `KVCacheMode::Turbo4` for symmetric
+    /// Turbo4-K + Turbo4-V compression — note that this mode
     /// is dangerous on dense Q4_K_M weights and must be gated by the
     /// per-model allowlist in [`turbo::allowlist`] before being exposed
     /// to end users. The `update_and_fetch` method will transparently
@@ -603,7 +599,7 @@ impl KVCache {
     /// drops the oldest `n` tokens, this returns `offset - live_start`
     /// rather than the monotonic `offset` so callers that build masks /
     /// allocate per-token sidecars (e.g., paged accounting, server gauges,
-    /// detach handles) see the post-trim length. Pre-#603 callers that never
+    /// detach handles) see the post-trim length. Pre- callers that never
     /// trim observe identical behaviour because `live_start == 0`.
     pub fn seq_len(&self) -> i32 {
         self.offset - self.live_start
@@ -623,7 +619,7 @@ impl KVCache {
     /// Slot `i` in the on-device buffer maps to monotonic position
     /// `live_start + i`; the next write lands at monotonic position
     /// `self.offset`, i.e. buffer slot `self.offset - self.live_start`.
-    /// Pre-#603 callers (those that never trim) see this equal to
+    /// Pre- callers (those that never trim) see this equal to
     /// `self.offset` because `live_start == 0`.
     #[inline]
     fn buffer_idx(&self) -> i32 {
@@ -655,8 +651,7 @@ impl KVCache {
     /// storage; scale factors are accumulated in a parallel `[B, H, L, 1]`
     /// buffer. In `KVCacheMode::Turbo4Asym` the K side stays FP16 while the V
     /// side is quantized to packed 4-bit indices plus per-token norms via
-    /// [`turbo::quant::quantize_v_turbo4`]. In `KVCacheMode::Turbo4` (issue
-    /// #476) **both** K and V are quantized via the symmetric Turbo4 path
+    /// [`turbo::quant::quantize_v_turbo4`]. In `KVCacheMode::Turbo4` **both** K and V are quantized via the symmetric Turbo4 path
     /// using independent sign-vector pairs. In `KVCacheMode::Fp16` this
     /// behaves identically to the original implementation.
     pub fn update(&mut self, new_keys: UniquePtr<MlxArray>, new_values: UniquePtr<MlxArray>) {
@@ -764,7 +759,7 @@ impl KVCache {
         let key_shape = ffi::array_shape(&k_int8);
         let new_seq_len = key_shape[2];
         // Use buffer-slot coordinates so `--max-kv-size` trim_front stays
-        // RoPE-correct (#603): `prev` is the slot where the next token is
+        // RoPE-correct: `prev` is the slot where the next token is
         // written, not the monotonic position.
         let prev = self.buffer_idx();
 
@@ -882,7 +877,6 @@ impl KVCache {
     /// [`turbo::quant::dequantize_v_turbo4`].
     ///
     /// Used by: `KVCache::update` dispatch when `mode == KVCacheMode::Turbo4Asym`
-    /// (epic #458, issue #474).
     fn update_turbo4_asym(
         &mut self,
         new_keys: UniquePtr<MlxArray>,
@@ -1026,7 +1020,6 @@ impl KVCache {
     /// 4-bit `turbo_params` is not perturbed.
     ///
     /// Used by: `KVCache::update` dispatch when `mode == KVCacheMode::Turbo3Asym`
-    /// (epic #458, issue #477).
     fn update_turbo3_asym(
         &mut self,
         new_keys: UniquePtr<MlxArray>,
@@ -1150,7 +1143,6 @@ impl KVCache {
     /// [`turbo::allowlist`] for the rationale.
     ///
     /// Used by: `KVCache::update` dispatch when `mode == KVCacheMode::Turbo4`
-    /// (epic #458, issue #476).
     fn update_turbo4_sym(
         &mut self,
         new_keys: UniquePtr<MlxArray>,
@@ -1309,7 +1301,6 @@ impl KVCache {
     }
 
     /// Turbo4Delegated update path — V-only hot/cold split with unified K
-    /// (issue #527).
     ///
     /// **Phase 1: prefill / single-token append into hot tail.** Tokens land
     /// directly in the FP16 `keys`/`values` buffers, identical to the
@@ -1334,7 +1325,7 @@ impl KVCache {
     /// — no K data movement). If the hot V ring ever exceeds
     /// [`turbo::DELEGATED_HOT_MAX`], an extra fold runs synchronously.
     ///
-    /// Layout of stored buffers in delegated mode (issue #527):
+    /// Layout of stored buffers in delegated mode:
     /// - `keys`: unified FP16 K buffer, `[B, H, k_capacity, K_dim]`. Visible
     ///   length is `offset` — same shape contract as `KVCacheMode::Fp16`.
     ///   No cold/hot split for K.
@@ -1347,7 +1338,7 @@ impl KVCache {
     /// - `v_norms`: cold V per-token norms, `[B, H, cold_capacity, 1]` fp16.
     ///
     /// Used by: `KVCache::update` dispatch when `mode == KVCacheMode::Turbo4Delegated`
-    /// (epic #458, issue #479; K unification: issue #527).
+    /// (K unification:).
     fn update_turbo4_delegated(
         &mut self,
         new_keys: UniquePtr<MlxArray>,
@@ -1378,7 +1369,7 @@ impl KVCache {
             self.fold_hot_to_cold_full();
             // After fold_hot_to_cold_full(), `values` is reset to a fresh hot
             // V ring of capacity = ceil_step(hot_threshold); `keys` is
-            // untouched (unified-K invariant, issue #527).
+            // untouched (unified-K invariant).
         }
 
         // K side: ensure the unified `keys` buffer can hold `offset + new_seq_len`.
@@ -1390,7 +1381,7 @@ impl KVCache {
         }
 
         // V side: ensure the hot V ring can hold `prev_hot + new_seq_len`.
-        // Hot ring is anchored at `hot_threshold` (issue #479) so the first
+        // Hot ring is anchored at `hot_threshold` so the first
         // decode-time allocation absorbs roughly one fold-period of tokens.
         let prev_hot = self.offset - self.cold_offset;
         let needed_v = prev_hot + new_seq_len;
@@ -1495,7 +1486,7 @@ impl KVCache {
     }
 
     /// Capacity (sequence dimension) of the unified `keys` buffer in
-    /// Turbo4Delegated mode (issue #527). Returns 0 when `keys` is None.
+    /// Turbo4Delegated mode. Returns 0 when `keys` is None.
     fn k_buffer_seq_len(&self) -> i32 {
         match self.keys.as_ref() {
             Some(k) => {
@@ -1511,7 +1502,7 @@ impl KVCache {
     }
 
     /// Capacity (sequence dimension) of the V hot ring `values` buffer in
-    /// Turbo4Delegated mode (issue #527). Returns 0 when `values` is None.
+    /// Turbo4Delegated mode. Returns 0 when `values` is None.
     fn v_hot_buffer_seq_len(&self) -> i32 {
         match self.values.as_ref() {
             Some(v) => {
@@ -1527,7 +1518,6 @@ impl KVCache {
     }
 
     /// Allocate (or grow) the unified FP16 K buffer for Turbo4Delegated mode
-    /// (issue #527).
     ///
     /// Capacity is rounded up to a multiple of `step`, identical to
     /// `update_fp16`'s growth policy. Existing visible `offset` K tokens are
@@ -1641,14 +1631,13 @@ impl KVCache {
         }
     }
 
-    /// Fold the entire FP16 V hot body into cold V storage (issue #527).
+    /// Fold the entire FP16 V hot body into cold V storage.
     ///
     /// Used for the prefill→decode transition: the V hot body is quantized
     /// into the packed `v_packed`/`v_norms`/`v_rescale` sidecars and the V
     /// hot ring is then re-allocated empty so subsequent decode tokens see a
     /// fresh ring. The K side does *not* move — the unified `keys` buffer
-    /// stays untouched (issue #527 unifies K storage and removes the cold/hot
-    /// split for K). `cold_offset` advances by `prev_hot`; the K data at
+    /// stays untouched (unifies K storage and removes the cold/hot split for K). `cold_offset` advances by `prev_hot`; the K data at
     /// positions `[0..cold_offset]` is logically the "cold K" but lives in
     /// the same buffer as the hot K tokens.
     ///
@@ -1686,7 +1675,7 @@ impl KVCache {
         // Reset the V hot ring to a freshly-allocated buffer sized for the
         // configured hot_threshold (rounded up to step). K is unified —
         // `keys` already holds all `offset` tokens at FP16 and is left
-        // untouched (issue #527).
+        // untouched.
         let b = hv_shape[0];
         let n_kv_heads = hv_shape[1];
         let v_head_dim = hv_shape[3];
@@ -1702,7 +1691,6 @@ impl KVCache {
 
     /// Fold the oldest `block` tokens of the V hot ring into cold V storage
     /// and shift the remaining hot V tokens left by `block` positions
-    /// (issue #527).
     ///
     /// The K side is unified — `keys[cold_offset..cold_offset+block]` already
     /// holds the K tokens that are logically being "folded". `cold_offset`
@@ -1762,7 +1750,7 @@ impl KVCache {
         // Append V into cold storage (which is non-empty here — the cold V
         // prefix was already populated by the prefill→decode full fold).
         // `cold_offset` advances by `block`; the K side is unified and needs
-        // no data movement (issue #527).
+        // no data movement.
         self.append_cold_block(&v_packed_new, &v_norms_new, &v_rescale_new, block);
 
         // Shift the remaining V hot tail [block..prev_hot] left into
@@ -1778,7 +1766,7 @@ impl KVCache {
         }
         // self.offset is unchanged: cold_offset += block, hot_len -= block.
         // The total length stays the same. K side is unaffected — `keys`
-        // already holds all `offset` tokens at FP16 (issue #527).
+        // already holds all `offset` tokens at FP16.
     }
 
     /// Fold an absolute `[start, start + block)` window from the unified FP16
@@ -1827,13 +1815,13 @@ impl KVCache {
 
     /// Append a `block`-token chunk to the cold V storage buffers, growing
     /// them (in `step`-sized increments) when the existing capacity does not
-    /// fit (issue #527: V-only — K is unified, no cold-K buffer to update).
+    /// fit (V-only — K is unified, no cold-K buffer to update).
     ///
     /// Inputs are the freshly-prepared cold V tensors:
     /// - `v_packed_block`:  `[B, H, block, V_dim/2]` u8   — appended to `v_packed`.
     /// - `v_norms_block`:   `[B, H, block, 1]`      fp16  — appended to `v_norms`.
     /// - `v_rescale_block`: `[B, H, block, 1]`      fp16  — appended to `v_rescale`
-    ///   (issue #520; precomputed Sparse-V kernel rescale, lockstep with `v_norms`).
+    ///   (precomputed Sparse-V kernel rescale, lockstep with `v_norms`).
     ///
     /// Updates `cold_offset` by `block`. Used by both the full prefill→decode
     /// fold and the steady-state per-block fold.
@@ -1944,7 +1932,7 @@ impl KVCache {
         ));
 
         self.cold_offset += block;
-        // Issue #528 retired the `cold_v_dequant_cache` memo: the fused
+        // retired the `cold_v_dequant_cache` memo: the fused
         // kernel reads packed cold V directly, so the cold body changing has
         // no host-side cached state to invalidate.
     }
@@ -2004,7 +1992,7 @@ impl KVCache {
         // After `self.offset -= n`, the live window length is
         // `self.offset - self.live_start`. Use that for the buffer-slot
         // slice upper bound so trim stays consistent under a non-zero
-        // `live_start` (issue #603 + speculative-decode rewind composing).
+        // `live_start` (+ speculative-decode rewind composing).
         // `live_start` stays at `0` for Turbo modes because `trim_front`
         // refuses to advance it for them, so the Turbo branches below that
         // still use `self.offset` continue to be correct.
@@ -2022,13 +2010,13 @@ impl KVCache {
             self.cold_offset = 0;
             // Clear turbo_params so the next quantize call rebuilds it from
             // scratch (required if the caller reuses this cache slot with a
-            // different head_dim). LOW-1 fix (#474). The 3-bit
-            // `turbo3_params` (issue #477) follows the same contract.
+            // different head_dim). LOW-1 fix. The 3-bit
+            // `turbo3_params` follows the same contract.
             self.turbo_params = None;
             self.turbo3_params = None;
-            // Issue #528 retired the cold-V dequant memo — nothing to drop.
+            // retired the cold-V dequant memo — nothing to drop.
         } else if self.mode == KVCacheMode::Turbo4Delegated {
-            // Issue #527: K is unified — slice `keys` to `self.offset` like
+            // K is unified — slice `keys` to `self.offset` like
             // `Fp16` mode. V hot ring trims to the new hot length first; cold
             // V sidecars trim only when the requested depth exceeded the hot
             // V tail (`cold_trim > 0`).
@@ -2085,7 +2073,7 @@ impl KVCache {
                         &[vr_shape[0], vr_shape[1], self.cold_offset, 1],
                     ));
                 }
-                // Issue #528 retired the cold-V dequant memo — nothing to
+                // retired the cold-V dequant memo — nothing to
                 // drop when the cold V body shrinks.
             }
             // Suppress unused-variable warnings in non-delegated branches.
@@ -2095,7 +2083,7 @@ impl KVCache {
             // The slice upper bound is the post-trim *live* window length
             // (`live_len_after`), not the monotonic `self.offset`. For
             // Turbo modes `live_start == 0` so `live_len_after == self.offset`
-            // and behaviour is bit-identical to the pre-#603 implementation.
+            // and behaviour is bit-identical to the earlier implementation.
             // Trim keys (always present except in Turbo4Asym pre-init).
             if let Some(ref k) = self.keys {
                 let k_shape = ffi::array_shape(k);
@@ -2136,7 +2124,7 @@ impl KVCache {
             // Trim Turbo4* V sidecars (per-token; speculative-decode rewinds
             // <1 block at a time so we never need to re-quantize a partial
             // block — the trimmed tail is already block-aligned in the buffer).
-            // `Turbo4Asym`, `Turbo4`, and `Turbo3Asym` (issue #477) all carry
+            // `Turbo4Asym`, `Turbo4`, and `Turbo3Asym` all carry
             // the V sidecars; only `Turbo4` (symmetric) additionally carries
             // the K-side sidecars.
             if matches!(
@@ -2159,7 +2147,7 @@ impl KVCache {
                         &[vn_shape[0], vn_shape[1], self.offset, 1],
                     ));
                 }
-                // v_rescale (issue #520): tracks v_norms lockstep. Turbo3Asym
+                // v_rescale: tracks v_norms lockstep. Turbo3Asym
                 // never populates v_rescale (3-bit V kernel does not exist),
                 // so the `if let Some(...)` guard handles that case.
                 if let Some(ref vr) = self.v_rescale {
@@ -2198,7 +2186,7 @@ impl KVCache {
     ///
     /// This is the dual of [`KVCache::trim`] (which removes the *newest* `n`
     /// entries for speculative-decode rewinds). `trim_front` is used by the
-    /// batch scheduler's `--max-kv-size` bound (issue #603) to cap the
+    /// batch scheduler's `--max-kv-size` bound to cap the
     /// memory footprint of a plain `KVCache` by evicting the oldest tokens
     /// once the live size exceeds the configured cap. Sliding-window models
     /// that already use [`RotatingKVCache`] manage their own circular
@@ -2247,8 +2235,7 @@ impl KVCache {
     /// slice `[0..self.offset]` continue to be correct.
     ///
     /// Used by: [`crate::cache::CachePool`] consumers that need to enforce
-    /// a max KV size on otherwise-unbounded `KVCache` instances (server
-    /// batch scheduler, issue #603).
+    /// a max KV size on otherwise-unbounded `KVCache` instances (server batch scheduler).
     pub fn trim_front(&mut self, n: i32) -> i32 {
         // Clamp against the live window length, not the monotonic offset:
         // the live window is what attention sees, and that is what we are
@@ -2339,7 +2326,7 @@ impl KVCache {
     /// reconstructed from the packed 4-bit indices + per-token norms.
     /// In `KVCacheMode::Turbo4` (symmetric) **both** K and V are reconstructed
     /// from packed 4-bit indices using independent sign-vector pairs.
-    /// In `KVCacheMode::Turbo4Delegated` (issue #527: K unified) returns
+    /// In `KVCacheMode::Turbo4Delegated` (K unified) returns
     /// `slice(keys, 0, offset)` for K (no concat — same shape contract as
     /// `Fp16` mode) and
     /// `[dequant(v_packed[:cold_offset]); hot_values[:hot_offset]]` for V.
@@ -2464,13 +2451,12 @@ impl KVCache {
         }
     }
 
-    /// Read path for `KVCacheMode::Turbo4Delegated` (issue #527: K unified;
-    /// issue #528: cold-V dequant memo retired).
+    /// Read path for `KVCacheMode::Turbo4Delegated` (K unified; cold-V dequant memo retired).
     ///
-    /// K is a single unified FP16 buffer (issue #527) — returns
+    /// K is a single unified FP16 buffer — returns
     /// `slice(keys, 0, offset)`, identical to `KVCacheMode::Fp16`. No
     /// per-step concat on the K side; that was the dominant residual cost
-    /// vs FP16 mode (~7 ms/step at 4 K context, issue #527).
+    /// vs FP16 mode (~7 ms/step at 4 K context).
     ///
     /// V still uses a packed cold body + FP16 hot ring: returns
     /// `concat(dequant(v_packed[:cold_offset]), hot_V)`. When
@@ -2479,10 +2465,10 @@ impl KVCache {
     /// `hot_offset() == 0` (just after a full fold with no decode token yet)
     /// this returns just the dequantized cold V body.
     ///
-    /// **Per-step cost (issue #528).** This fallback rebuilds the full
+    /// **Per-step cost.** This fallback rebuilds the full
     /// `dequantize_v_turbo4(v_packed[:cold_offset], v_norms[:cold_offset])`
-    /// graph on every call — the PR-#525 `cold_v_dequant_cache` memo was
-    /// retired by issue #528 because the fused kernel path
+    /// graph on every call — the earlier `cold_v_dequant_cache` memo was
+    /// retired because the fused kernel path
     /// ([`Self::update_and_turbo4_delegated_attention`]) reads packed cold V
     /// directly without ever materialising the FP16 cold V tensor. This
     /// fallback is now only reached on the prefill-shaped path (multi-token
@@ -2494,7 +2480,7 @@ impl KVCache {
     /// In that mode this read path returns `slice(values, 0, offset)` and never
     /// materializes cold V from packed sidecars.
     fn fetch_turbo4_delegated(&mut self) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
-        // K side (issue #527): unified buffer — same path as FP16 mode.
+        // K side: unified buffer — same path as FP16 mode.
         let k = self.keys.as_ref().expect("unified keys must exist");
         let ks = ffi::array_shape(k);
         let k_slice = ffi::slice(k, &[0, 0, 0, 0], &[ks[0], ks[1], self.offset, ks[3]]);
@@ -2533,8 +2519,7 @@ impl KVCache {
             );
         }
 
-        // Cold V dequant: rebuild from packed every call (issue #528 retired
-        // the memo). On the fused-attention decode path the kernel reads
+        // Cold V dequant: rebuild from packed every call (retired the memo). On the fused-attention decode path the kernel reads
         // `v_packed` directly — this fallback only runs for prefill-shaped
         // calls and unported call sites.
         let vp = self.v_packed.as_ref().expect("v_packed must exist");
@@ -2572,14 +2557,11 @@ impl KVCache {
     /// V-norm sidecars; the original FP16 values tensor is not stored.
     /// In Turbo4 (symmetric) mode this counts only the K- and V-side packed
     /// sidecars; both the FP16 keys and FP16 values tensors are absent.
-    /// In Turbo4Delegated mode (issue #527: K unified; issue #528: cold-V
-    /// dequant memo retired) this counts the unified FP16 K buffer (under
+    /// In Turbo4Delegated mode (K unified; cold-V dequant memo retired) this counts the unified FP16 K buffer (under
     /// `keys`, identical footprint to `Fp16` mode), the FP16 V hot ring
     /// (under `values`), and the packed cold V sidecars
     /// (`v_packed`/`v_norms`/`v_rescale`). There is no separate cold-K
-    /// buffer (issue #527 removed it) and no FP16 cold-V working set (issue
-    /// #528 replaced the PR-#525 memo with a fused kernel that reads packed
-    /// cold V directly). When `MLXCEL_TURBO4_DELEGATED_FP16_FAST_PATH=1`,
+    /// buffer (removed it) and no FP16 cold-V working set (replaced the earlier memo with a fused kernel that reads packed cold V directly). When `MLXCEL_TURBO4_DELEGATED_FP16_FAST_PATH=1`,
     /// `values` is instead a unified FP16 V working set and `nbytes()` counts
     /// both that buffer and the packed sidecars by design.
     /// In Turbo3Asym mode this counts the FP16 keys plus the 3-bit packed-V
@@ -2597,7 +2579,7 @@ impl KVCache {
         let vr_bytes = self.v_rescale.as_ref().map_or(0, |v| ffi::array_nbytes(v));
         let kp_bytes = self.k_packed.as_ref().map_or(0, |v| ffi::array_nbytes(v));
         let kn_bytes = self.k_norms.as_ref().map_or(0, |v| ffi::array_nbytes(v));
-        // Issue #528 retired the PR-#525 `cold_v_dequant_cache` memo: the
+        // retired the earlier `cold_v_dequant_cache` memo: the
         // fused kernel reads packed cold V directly so there is no longer a
         // FP16 cold-V working set to count here.
         k_bytes
@@ -2698,7 +2680,7 @@ impl KVCache {
     }
 
     /// Borrow the per-token V Sparse-V kernel rescale paired with
-    /// [`Self::v_packed`] (issue #520).
+    /// [`Self::v_packed`].
     ///
     /// Stores `norm[t] / max(|y_hat[t]|, 1e-10)` in fp16 — the exact value the
     /// fused kernel previously derived per-token via a threadgroup tree
@@ -2745,7 +2727,7 @@ impl KVCache {
     /// Used by: future model attention call sites that have been ported
     /// to the split-SDPA path. Standard call sites continue to use
     /// `cache.update_and_fetch(...)` followed by `attention(...)`.
-    /// Combined update + sparse-V attention dispatch (issue #505).
+    /// Combined update + sparse-V attention dispatch.
     ///
     /// The standard `update_and_fetch + attention()` pair pays the full V
     /// dequant cost inside `update_and_fetch` even when sparse-V is enabled.
@@ -2822,7 +2804,7 @@ impl KVCache {
         // For Turbo4Asym the packed shapes are:
         //   v_packed:  [B, H, capacity, D/2] u8
         //   v_norms:   [B, H, capacity, 1]   f16
-        //   v_rescale: [B, H, capacity, 1]   f16  (issue #520)
+        //   v_rescale: [B, H, capacity, 1]   f16
         // We slice axis 2 (the token axis) to [0, self.offset).
         let vp_shape = ffi::array_shape(v_packed_buf);
         let vn_shape = ffi::array_shape(v_norms_buf);
@@ -2843,7 +2825,7 @@ impl KVCache {
             &[vr_shape[0], vr_shape[1], self.offset, 1],
         );
 
-        // Prefer the fused Metal kernel path (issue #505 + #520) when
+        // Prefer the fused Metal kernel path (+) when
         // available. Falls through to the graph-level reference path on
         // non-macOS, when the kernel is disabled via
         // `MLXCEL_SPARSE_V_KERNEL=0`, or when the model uses a non-power-of-2
@@ -2852,7 +2834,7 @@ impl KVCache {
         // The fused kernel reads the precomputed `v_rescale` (norm/|y_hat|)
         // directly, eliminating the per-token threadgroup tree reduction
         // that previously dominated decode latency on M5 Max at 4 K context
-        // (issue #520). The graph fallback continues to use `v_norms` only.
+        // The graph fallback continues to use `v_norms` only.
         if let Some(out) = turbo::sparse_v::attention_sparse_v_turbo4_fused(
             q,
             k,
@@ -2949,7 +2931,7 @@ impl KVCache {
     }
 
     /// Returns `true` iff this cache is in `KVCacheMode::Turbo4Delegated` mode
-    /// and the fused dequant + SDPA decode path (issue #528) is reachable.
+    /// and the fused dequant + SDPA decode path is reachable.
     ///
     /// The fused kernel is Apple-Silicon-only (the runtime JIT requires Metal)
     /// and supports the Turbo4Delegated mode regardless of whether
@@ -2966,7 +2948,7 @@ impl KVCache {
         self.mode == KVCacheMode::Turbo4Delegated
     }
 
-    /// Combined update + Turbo4Delegated attention dispatch (issue #528).
+    /// Combined update + Turbo4Delegated attention dispatch.
     ///
     /// The standard `update_and_fetch + attention()` pair pays the full
     /// `dequantize_v_turbo4(v_packed[:cold_offset])` graph cost on every
@@ -3060,7 +3042,7 @@ impl KVCache {
         }
 
         // Slice the unified K buffer down to the visible token range
-        // [0, offset). Same shape contract as `KVCacheMode::Fp16` (issue #527).
+        // [0, offset). Same shape contract as `KVCacheMode::Fp16`.
         let k_buf = self
             .keys
             .as_ref()
@@ -3150,11 +3132,11 @@ impl KVCache {
             }
         }
 
-        // Issue #531 — Prefer the steel-attention-envelope kernel when
+        // Prefer the steel-attention-envelope kernel when
         // available. It collapses softmax + cold-V dequant + hot-V accum into
         // a single Metal dispatch, eliminating the per-step FFI / dispatch
         // overhead of the host composition path. The cold-only kernel from
-        // #528 remains as a fallback for the same correctness contract.
+        // remains as a fallback for the same correctness contract.
         if let Some(out) = turbo::sparse_v::attention_turbo4_delegated_steel(
             q,
             &k_slice,
@@ -3173,7 +3155,7 @@ impl KVCache {
 
         // Steel envelope unavailable (non-macOS, non-power-of-2 head_dim, or
         // `MLXCEL_SPARSE_V_KERNEL=0`). Try the cold-only fused composition
-        // (issue #528) before falling all the way back to the graph SDPA.
+        // before falling all the way back to the graph SDPA.
         // The cold-only path keeps the V-budget guarantee and is still
         // measurably faster than the full graph fallback for some
         // configurations.
@@ -3202,7 +3184,7 @@ impl KVCache {
         self.delegated_graph_attention(q, scale, mask)
     }
 
-    /// Graph-only Turbo4Delegated attention reference (issue #528 fallback).
+    /// Graph-only Turbo4Delegated attention reference (fallback).
     ///
     /// Computes attention against the **already-updated** Turbo4Delegated cache
     /// using the legacy compositional path:
@@ -3276,7 +3258,7 @@ impl Default for KVCache {
 /// (`[B, H, max_size, 1]` FP16); the `values` field stays `None`. K stays
 /// FP16 in the regular `keys` buffer.
 ///
-/// ## Block alignment invariant (B9, issue #481, epic #458)
+/// ## Block alignment invariant (B9)
 ///
 /// TurboQuant V quantization is **per-token**: each token's `head_dim` vector
 /// is rotated and quantized independently along the last axis. There is no
@@ -3290,7 +3272,7 @@ impl Default for KVCache {
 /// However, we still require `max_size` to be a multiple of
 /// [`turbo::BLOCK_SIZE`] (32) when `mode == Turbo4Asym` for two reasons:
 ///
-/// 1. **Future-proofing**: B5 (3-bit packing, issue #477) introduces 24-bit
+/// 1. **Future-proofing**: B5 (3-bit packing) introduces 24-bit
 ///    groups that span byte boundaries. A non-32-aligned ring would force
 ///    partial-block re-quantization on every wraparound. Locking the
 ///    invariant here means B5 only has to revisit pack/unpack, not the cache.
@@ -3333,7 +3315,7 @@ pub struct RotatingKVCache {
     /// Turbo4Asym-mode V-side per-token norms: `[B, H, max_size, 1]` fp16.
     pub(crate) v_norms: Option<UniquePtr<MlxArray>>,
     /// Turbo4-V precomputed Sparse-V kernel rescale `norm[t] / |y_hat[t]|`
-    /// (issue #520). Same shape and lockstep lifecycle as `v_norms`. See the
+    /// Same shape and lockstep lifecycle as `v_norms`. See the
     /// dense `KVCache::v_rescale` docs for the rationale.
     pub(crate) v_rescale: Option<UniquePtr<MlxArray>>,
     /// Cached PolarQuant params (sign vectors + codebook) for Turbo4Asym.
@@ -3440,30 +3422,30 @@ impl RotatingKVCache {
             KVCacheMode::Fp16 => self.update_and_fetch_fp16(new_keys, new_values),
             KVCacheMode::Int8 => {
                 // INT8 support for RotatingKVCache is not part of B9 / issue
-                // #481. Fall back to FP16 storage so the path is correct, even
+                // Fall back to FP16 storage so the path is correct, even
                 // if mis-configured. A future sub-issue can wire INT8 in.
                 self.update_and_fetch_fp16(new_keys, new_values)
             }
             KVCacheMode::Turbo4Asym => self.update_and_fetch_turbo4_asym(new_keys, new_values),
             KVCacheMode::Turbo4 => {
-                // Symmetric Turbo4 (issue #476) is not wired into RotatingKVCache
-                // by B9 / issue #481 (RotatingKVCache currently supports only
+                // Symmetric Turbo4 is not wired into RotatingKVCache
+                // by B9 / (RotatingKVCache currently supports only
                 // Fp16/Int8/Turbo4Asym). Fall back to FP16 so a mis-configured
                 // sliding-window model does not panic; a future sub-issue can
                 // wire symmetric K/V quantization in.
                 self.update_and_fetch_fp16(new_keys, new_values)
             }
             KVCacheMode::Turbo4Delegated => {
-                // Delegated hot/cold (issue #479) is not wired into RotatingKVCache
-                // by B7 / issue #479 (the delegated path targets dense caches).
+                // Delegated hot/cold is not wired into RotatingKVCache
+                // by B7 / (the delegated path targets dense caches).
                 // Fall back to FP16 so a mis-configured sliding-window model does
                 // not panic.
                 self.update_and_fetch_fp16(new_keys, new_values)
             }
             KVCacheMode::Turbo3Asym => {
-                // Turbo3Asym (issue #477) is not wired into RotatingKVCache in
+                // Turbo3Asym is not wired into RotatingKVCache in
                 // this PR — wraparound + 3-bit re-pack alignment requires its
-                // own analysis (mirrors B9 / issue #481 for Turbo4Asym). Fall
+                // own analysis (mirrors B9 / for Turbo4Asym). Fall
                 // back to FP16 so sliding-window models with `--kv-cache-mode
                 // fp16+turbo3` do not panic; a follow-up sub-issue can wire
                 // Turbo3 into the rotating path once dense Turbo3 is validated.
@@ -4016,7 +3998,7 @@ impl RotatingKVCache {
     }
 
     // -----------------------------------------------------------------------
-    // Turbo4Asym update path (B9, issue #481, epic #458)
+    // Turbo4Asym update path (B9)
     //
     // Storage layout when `mode == KVCacheMode::Turbo4Asym`:
     //   - keys     : [B, H, max_size, K_dim]    FP16 — same as Fp16 path
@@ -4374,7 +4356,7 @@ impl RotatingKVCache {
     /// Internal write position in the ring buffer.
     ///
     /// Mirrors Python `mlx_lm.models.cache.RotatingKVCache._idx`. Used by the
-    /// Gemma 4 MTP `rollback_speculative_cache` hook (issue #625) to compute
+    /// Gemma 4 MTP `rollback_speculative_cache` hook to compute
     /// `kv_len` for per-row tail zeroing of partial-accept verify passes.
     /// Equal to `self.offset` while the cache has not yet wrapped, and
     /// otherwise tracks the next physical write slot in the rotating buffer.
@@ -4398,7 +4380,7 @@ impl RotatingKVCache {
     /// `block_size - accepted - 1`, far below the sliding window's
     /// `max_size`).
     ///
-    /// Used by: Gemma 4 MTP `rollback_speculative_cache` (issue #625).
+    /// Used by: Gemma 4 MTP `rollback_speculative_cache`.
     pub fn trim(&mut self, n: i32) -> i32 {
         let n = if self.buffer_size > 0 {
             n.min(self.idx).min(self.offset)
@@ -4644,8 +4626,7 @@ impl ChunkedKVCache {
 /// 1. Downstream kernel and graph code (paged decode, fused RoPE, padded
 ///    SDPA) indexes per batch row directly. A scalar fallback would break
 ///    those callers silently.
-/// 2. It mirrors the upstream `mlx-vlm` PR #1110 fix pattern (issue #544 in
-///    this repo) for `BatchTurboQuantKVCache`. There, an "init-time scalar
+/// 2. It mirrors the upstream `mlx-vlm` PR #1110 fix pattern (in this repo) for `BatchTurboQuantKVCache`. There, an "init-time scalar
 ///    fast-path when all `left_padding` entries are equal" caused
 ///    `extend()` and `filter()` to crash later when the batch composition
 ///    changed mid-decode and the still-scalar `offset` was passed to
@@ -4672,7 +4653,7 @@ impl BatchedAttentionMetadata {
     ///
     /// Always emits per-row `Vec<i32>` arrays of length `caches.len()`,
     /// even when every cache has the same offset. See the struct-level docs
-    /// for the rationale (issue #544 / upstream `mlx-vlm` PR #1110).
+    /// for the rationale (upstream `mlx-vlm` PR #1110).
     pub fn from_kv_caches(
         caches: &[&mut KVCache],
         query_lens: &[i32],
@@ -4732,7 +4713,7 @@ impl BatchedAttentionMetadata {
     /// only to the caller-supplied `query_len` and `window_size` being the
     /// same for every batch row; per-row offsets are still read from each
     /// cache. **Do not** add a scalar fast-path here — see the
-    /// [`BatchedAttentionMetadata`] struct-level docs (issue #544) for
+    /// [`BatchedAttentionMetadata`] struct-level docs for
     /// why.
     pub fn uniform_kv_caches(
         caches: &[&mut KVCache],
@@ -4762,7 +4743,7 @@ impl BatchedAttentionMetadata {
     /// [`Self::uniform_kv_caches`]) should call this method in debug
     /// builds.
     ///
-    /// This mirrors the upstream `mlx-vlm` PR #1110 (issue #544) pattern of
+    /// This mirrors the upstream `mlx-vlm` PR #1110 pattern of
     /// keeping per-row offset state shape-stable across batch grow / shrink
     /// transitions. See the struct-level docs for the full rationale.
     ///
@@ -4795,7 +4776,7 @@ impl BatchedAttentionMetadata {
     /// the per-row vector shape.
     ///
     /// This is the mlxcel analogue of upstream `mlx-vlm` PR #1110's
-    /// `BatchTurboQuantKVCache.extend()` (issue #544): when the batch
+    /// `BatchTurboQuantKVCache.extend()`: when the batch
     /// scheduler grows the active batch by adopting one or more newly
     /// prefilled sequences, the resulting metadata must remain a per-row
     /// `Vec<i32>` even when both halves were uniform. The Python upstream
@@ -4810,7 +4791,7 @@ impl BatchedAttentionMetadata {
     /// rebuilds metadata from scratch on every step via
     /// [`Self::from_kv_caches`], which already preserves the invariant; this
     /// helper is provided as a stable seam for upcoming continuous-batching
-    /// fusion work and as a regression target for issue #544.
+    /// fusion work and as a regression target.
     pub fn extend(&mut self, other: &Self) -> Result<(), String> {
         self.assert_consistent()?;
         other.assert_consistent()?;
@@ -4824,7 +4805,7 @@ impl BatchedAttentionMetadata {
     /// Drop rows not in `indices`, preserving the per-row vector shape.
     ///
     /// The mlxcel analogue of upstream `mlx-vlm` PR #1110's
-    /// `BatchTurboQuantKVCache.filter()` (issue #544). Indexing is
+    /// `BatchTurboQuantKVCache.filter()`. Indexing is
     /// position-based: `indices[k] = i` means "row `i` of the current
     /// batch becomes row `k` of the filtered batch".
     ///
@@ -4834,7 +4815,7 @@ impl BatchedAttentionMetadata {
     /// inconsistent state).
     ///
     /// Used by: regression coverage for batch-shrink transitions
-    /// (issue #544); not yet wired into the live decode path because the
+    /// not yet wired into the live decode path because the
     /// scheduler currently rebuilds metadata each step rather than
     /// filtering in place. Provided as a stable seam for upcoming
     /// continuous-batching fusion work.
@@ -5388,7 +5369,7 @@ impl CachePool {
         // itself rather than by any individual `SequenceCacheSet`, so they
         // are not visible to the per-sequence `nbytes()` walk above. Add
         // them explicitly so admission-control sees the true KV footprint
-        // for paged Turbo4 deployments (#482).
+        // for paged Turbo4 deployments.
         let pool_sidecar_bytes: usize = self
             .paged_pool
             .as_ref()
@@ -5781,7 +5762,7 @@ mod tests {
         assert_eq!(to_f32(&visible), vec![3.0, 4.0, 5.0, 6.0, 7.0]);
     }
 
-    // Issue #603: `trim_front` drops the oldest `n` tokens from a KVCache's
+    // `trim_front` drops the oldest `n` tokens from a KVCache's
     // live window so the server scheduler can enforce a `--max-kv-size`
     // bound on otherwise unbounded plain `KVCache` instances.
     //
@@ -5906,7 +5887,7 @@ mod tests {
         assert_eq!(cache.live_start, 0);
     }
 
-    // Issue #603: `trim_front` must preserve the RoPE relative-position
+    // `trim_front` must preserve the RoPE relative-position
     // invariant after the live window is bounded — K at buffer slot `i`
     // was rotated at monotonic position `live_start + i` at write time,
     // and Q for the next decode step is rotated at the *current*
@@ -5961,7 +5942,7 @@ mod tests {
         assert_eq!(&v_data[..3], &[7.0, 8.0, 10.0]);
     }
 
-    // Issue #603 correctness regression test — RoPE relative-position
+    // correctness regression test — RoPE relative-position
     // invariant under `--max-kv-size`.
     //
     // Builds two caches that should produce identical attention outputs:
@@ -6832,7 +6813,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // Issue #544 regression coverage — TurboQuant continuous-batching
+    // regression coverage — TurboQuant continuous-batching
     // batch-grow / batch-shrink mid-decode.
     //
     // These tests mirror upstream `mlx-vlm` PR #1110's
@@ -6934,7 +6915,7 @@ mod tests {
         metadata.assert_consistent().unwrap();
     }
 
-    /// Issue #603 follow-up: `rope_offsets` live on the monotonic RoPE
+    /// follow-up: `rope_offsets` live on the monotonic RoPE
     /// position axis, but `kv_lens` must describe the visible cache window
     /// after `KVCache::trim_front` advances `live_start`.
     #[test]
@@ -6964,7 +6945,7 @@ mod tests {
     /// End-to-end batch grow + shrink sequence: start with one sequence,
     /// admit a second mid-decode (extend), then evict the first
     /// (filter_in_place). Per-row offsets must remain coherent throughout.
-    /// This is the strongest unit-level regression for issue #544.
+    /// This is the strongest unit-level regression.
     #[test]
     fn batched_metadata_extend_grow_then_shrink_preserves_per_row_state() {
         let mut cache_a = KVCache::new();
@@ -7105,7 +7086,7 @@ mod tests {
     /// scalar `cache.offset` semantics are identical, so the per-row
     /// metadata stays correct across modes — the property that makes
     /// the upstream Python crash impossible to reach in mlxcel's
-    /// architecture (issue #544).
+    /// architecture.
     #[test]
     fn batched_metadata_handles_mixed_mode_caches() {
         let mut fp16_cache = KVCache::new();

--- a/src/lib/mlxcel-core/src/cache/batch_quant.rs
+++ b/src/lib/mlxcel-core/src/cache/batch_quant.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Batch-aware quantized KV caches for continuous batching (issue #545).
+//! Batch-aware quantized KV caches for continuous batching.
 //!
 //! Mirrors upstream `mlx-vlm` PR #1030 (commit `b027538`) which added two
 //! batched-cache variants used by the Python continuous-batching server:
@@ -53,7 +53,7 @@
 //! regression tests in `mod tests` below — those tests are the entire
 //! current consumer set.
 //!
-//! This intentionally matches the pattern from PR #564 / issue #544 for
+//! This intentionally matches the pattern for
 //! [`super::BatchedAttentionMetadata::extend`] and
 //! [`super::BatchedAttentionMetadata::filter_in_place`]: a metadata-shaped
 //! API is added before any tensor-level integration so that the contract
@@ -80,9 +80,9 @@
 //! (see [`super::turbo::boundary`]), because the two policies overlap
 //! intentionally:
 //!
-//! - **Boundary-V** (issue #478) protects the first 2 *and* last 2 layers
+//! - **Boundary-V** protects the first 2 *and* last 2 layers
 //!   for `Turbo4*` modes. That mechanism stays unchanged.
-//! - **`skip_last_layer`** (issue #545) protects *only* the final layer
+//! - **`skip_last_layer`** protects *only* the final layer
 //!   and applies to every quantization scheme exposed via
 //!   [`KvQuantScheme`], including the new [`KvQuantScheme::Uniform`]
 //!   variant which is not covered by Boundary-V.
@@ -375,7 +375,7 @@ impl BatchKvQuantConfig {
 ///
 /// # Status: forward-looking stable seam (not on the live decode path)
 ///
-/// As of this PR (issue #545) **this struct is not instantiated by the
+/// As of this PR **this struct is not instantiated by the
 /// live decode path**. mlxcel's continuous-batching scheduler quantizes
 /// the KV cache by reading [`BatchKvQuantConfig`] directly and applying
 /// the per-layer [`KVCacheMode`] table from
@@ -386,8 +386,8 @@ impl BatchKvQuantConfig {
 /// This struct exists as a **forward-looking stable seam** that mirrors
 /// the upstream PR #1030 contract surface so future batch-aware tensor
 /// work has a stable Rust API to plug into without churning the public
-/// surface again. This intentionally matches the pattern from PR #564 /
-/// issue #544 for [`super::BatchedAttentionMetadata::extend`] and
+/// surface again. This intentionally matches the pattern from
+/// for [`super::BatchedAttentionMetadata::extend`] and
 /// [`super::BatchedAttentionMetadata::filter_in_place`].
 ///
 /// # Layer-mode policy
@@ -501,8 +501,7 @@ impl BatchQuantizedKVCache {
     ///    [`super::BatchedAttentionMetadata::assert_consistent`] —
     ///    callers that build instances by direct field assignment should
     ///    invoke this in debug builds to catch any future regression
-    ///    that re-introduces a uniformity-collapsing optimization (the
-    ///    PR #1110 hazard from issue #544).
+    ///    that re-introduces a uniformity-collapsing optimization (the PR #1110 hazard).
     /// 2. `caches` is non-empty. A batched cache with zero layers has
     ///    no transformer state to track and almost always indicates a
     ///    constructor bug (e.g., a model whose `n_layers` resolved to
@@ -694,13 +693,13 @@ impl BatchQuantizedKVCache {
 /// contract — but uses mlxcel's existing [`KVCacheMode::Turbo4Asym`]
 /// storage backend for each per-layer cache. Attention dispatch is via
 /// dequantize + standard SDPA — custom batch-aware Metal kernels are
-/// explicitly out of scope for issue #545 (the single-stream
+/// explicitly out of scope (the single-stream
 /// [`super::turbo::sparse_v`] kernels are not used here because they
 /// assume `B == 1`).
 ///
 /// # Status: forward-looking stable seam (not on the live decode path)
 ///
-/// As of this PR (issue #545) **this struct is not instantiated by the
+/// As of this PR **this struct is not instantiated by the
 /// live decode path**. The live continuous-batching decode path drives
 /// quantization through [`BatchKvQuantConfig`] +
 /// [`BatchKvQuantConfig::resolve_layer_modes`] applied directly to the
@@ -713,7 +712,7 @@ impl BatchQuantizedKVCache {
 /// dispatch (e.g., a fused batched TurboQuant attention kernel that
 /// wants a single struct holding `(per_layer_caches, left_padding,
 /// offset)`) has a stable Rust API to slot into. This intentionally
-/// matches the pattern from PR #564 / issue #544 for
+/// matches the pattern for
 /// [`super::BatchedAttentionMetadata::extend`] and
 /// [`super::BatchedAttentionMetadata::filter_in_place`].
 ///

--- a/src/lib/mlxcel-core/src/cache/detach.rs
+++ b/src/lib/mlxcel-core/src/cache/detach.rs
@@ -15,8 +15,7 @@
 //! Cross-sequence KV cache reuse: trim / detach / adopt primitives.
 //!
 //! This module extends [`super::KVCache`] and [`super::CachePool`] with the
-//! primitives required by the cross-request prompt prefix cache (epic #416,
-//! sub-issue #417):
+//! primitives required by the cross-request prompt prefix cache:
 //!
 //! * [`KVCache::trim_to`] — shrink the logical cache length to an exact value
 //!   while keeping the pre-allocated backing buffer around.
@@ -30,7 +29,7 @@
 //!
 //! Only the **dense** KV cache backend (`SequenceStateBackend::DenseKvCache`)
 //! is handled directly by this file. Paged sequences are handled by the
-//! parallel API surface in [`super::paged_detach`] (sub-issue #418); this
+//! parallel API surface in [`super::paged_detach`]; this
 //! module delegates through the shared `DetachedHandle` namespace so parking
 //! remains a single pool-level abstraction.
 //!
@@ -90,7 +89,7 @@ use super::{
 /// can rebuild [`crate::cache::turbo::TurboQuantParams`] without referring
 /// back to the originating `KVCache`.
 /// Turbo4 (symmetric) caches also carry packed-K + per-token K norms.
-/// Turbo4Delegated-mode caches (issue #479; K unified in issue #527) carry
+/// Turbo4Delegated-mode caches (K unified) carry
 /// the unified FP16 K buffer in `keys` (same shape contract as `Fp16` mode),
 /// the V-side cold/hot split state (`cold_offset`), and the configured
 /// hot-V fold threshold so the adopted cache resumes decoding from the same
@@ -101,7 +100,7 @@ use super::{
 /// `delegated_fp16_sidecar_policy` preserves the foreground compaction policy.
 /// Turbo3Asym-mode caches use the same `(keys, v_packed, v_norms)` triple
 /// as `Turbo4Asym` but the V buffer carries the 24-bit-grouped 3-bit indices
-/// (issue #477). The `mode` field on the handle preserves the bit-width
+/// The `mode` field on the handle preserves the bit-width
 /// distinction so adopt rebuilds the right `TurboQuantParams3` instance.
 pub struct DetachedKVCache {
     pub(super) keys: Option<UniquePtr<MlxArray>>,
@@ -113,7 +112,7 @@ pub struct DetachedKVCache {
     pub(super) val_scales: Option<UniquePtr<MlxArray>>,
     pub(super) v_packed: Option<UniquePtr<MlxArray>>,
     pub(super) v_norms: Option<UniquePtr<MlxArray>>,
-    /// Turbo4-V Sparse-V kernel rescale sidecar (issue #520). Lockstep with
+    /// Turbo4-V Sparse-V kernel rescale sidecar. Lockstep with
     /// `v_norms`; round-trips through detach/adopt so paged + prefix-cache
     /// reuse paths preserve the precomputed rescale.
     pub(super) v_rescale: Option<UniquePtr<MlxArray>>,
@@ -140,7 +139,7 @@ impl DetachedKVCache {
 
     /// Total byte footprint of the detached tensors (keys + values + INT8
     /// scales + Turbo4Asym v_packed/v_norms + Turbo4 symmetric
-    /// k_packed/k_norms). Issue #527: Turbo4Delegated caches no longer carry
+    /// k_packed/k_norms). Turbo4Delegated caches no longer carry
     /// a separate `cold_keys` tensor — the unified K buffer is already
     /// counted under `keys`.
     pub fn nbytes(&self) -> usize {
@@ -194,7 +193,7 @@ impl DetachedKVCache {
     /// This is the inert-side counterpart of [`KVCache::trim_to`] and is the
     /// load-bearing primitive that lets the scheduler adopt only the first
     /// `matched_len` tokens' worth of KV state when an Automatic Prefix
-    /// Caching (APC, issue #552) lookup returns a block-aligned matched
+    /// Caching (APC) lookup returns a block-aligned matched
     /// length shorter than the full cached entry. See server-side
     /// `try_adopt_cached_prefix` in `src/server/batch/scheduler.rs`.
     ///
@@ -203,8 +202,7 @@ impl DetachedKVCache {
     /// so a subsequent install + dequantize stays bit-identical to the
     /// already-trimmed live cache.
     ///
-    /// Used by: [`DetachedCacheSet::truncate_to`] (issue #580 — APC
-    /// block-level partial cache adoption in the scheduler).
+    /// Used by: [`DetachedCacheSet::truncate_to`] (— APC block-level partial cache adoption in the scheduler).
     pub fn trim_to(&mut self, new_len: i32) -> Result<(), String> {
         if new_len < 0 {
             return Err(format!(
@@ -412,7 +410,7 @@ impl KVCache {
     /// INT8 mode: the per-token scale buffers are trimmed in lock-step so
     /// subsequent `update_and_fetch` dequantization stays consistent.
     ///
-    /// Used by: prompt prefix cache reuse (#417), speculative decode rewinds,
+    /// Used by: prompt prefix cache reuse, speculative decode rewinds,
     /// server scheduler trim-to-exact-prefix paths.
     pub fn trim_to(&mut self, new_len: i32) -> Result<(), String> {
         if new_len < 0 {
@@ -452,7 +450,7 @@ impl KVCache {
     /// sidecars so lazy generation can skip foreground folds without donating
     /// a sidecar-incomplete prompt-cache entry.
     ///
-    /// Used by: prompt prefix cache detach/adopt (#417), cross-request reuse
+    /// Used by: prompt prefix cache detach/adopt, cross-request reuse
     /// handoff inside `CachePool::detach`.
     pub fn clone_handle(&mut self) -> DetachedKVCache {
         self.compact_turbo4_delegated_fp16_sidecars();
@@ -478,11 +476,11 @@ impl KVCache {
         };
         // Clear turbo_params on the source so the next quantize call rebuilds
         // it from scratch (required if the slot is reused with a different
-        // head_dim after detach). LOW-1 fix (#474). The 3-bit
-        // `turbo3_params` (issue #477) follows the same contract.
+        // head_dim after detach). LOW-1 fix. The 3-bit
+        // `turbo3_params` follows the same contract.
         self.turbo_params = None;
         self.turbo3_params = None;
-        // Issue #528 retired the cold-V dequant memo — nothing to drop on
+        // retired the cold-V dequant memo — nothing to drop on
         // the source.
         handle
     }
@@ -540,7 +538,7 @@ impl KVCache {
                 }
             }
         }
-        // Turbo3Asym (issue #477): rebuild the 3-bit params from v_packed
+        // Turbo3Asym: rebuild the 3-bit params from v_packed
         // shape. Inverse of `head_dim * 3 / 8`: head_dim = packed_dim * 8 / 3.
         // Mirrors the Turbo4 prebuild above so dequantize-only consumers see
         // a ready-to-go cache after install.
@@ -561,7 +559,7 @@ impl KVCache {
 }
 
 // ---------------------------------------------------------------------------
-// DetachedRotatingKVCache (B9, issue #481)
+// DetachedRotatingKVCache (B9)
 // ---------------------------------------------------------------------------
 
 /// Inert snapshot of a single [`RotatingKVCache`] (sliding-window cache) that
@@ -576,7 +574,7 @@ impl KVCache {
 /// state would silently fall back to "no wraparound yet" semantics.
 ///
 /// Used by: prompt prefix cache reuse for sliding-window models (Gemma 3/4,
-/// Ministral 3, GPT-OSS, RecurrentGemma, Exaone) under the same #416/#417
+/// Ministral 3, GPT-OSS, RecurrentGemma, Exaone) under the same
 /// architecture as the dense `DetachedKVCache`.
 pub struct DetachedRotatingKVCache {
     pub(super) keys: Option<UniquePtr<MlxArray>>,
@@ -590,7 +588,7 @@ pub struct DetachedRotatingKVCache {
     pub(super) val_scales: Option<UniquePtr<MlxArray>>,
     pub(super) v_packed: Option<UniquePtr<MlxArray>>,
     pub(super) v_norms: Option<UniquePtr<MlxArray>>,
-    /// Sparse-V rescale sidecar (issue #520) for rotating Turbo4Asym caches.
+    /// Sparse-V rescale sidecar for rotating Turbo4Asym caches.
     pub(super) v_rescale: Option<UniquePtr<MlxArray>>,
     pub(super) turbo_seed: u32,
 }
@@ -658,8 +656,7 @@ impl RotatingKVCache {
     /// tensors unchanged — including `v_packed` / `v_norms` for `Turbo4Asym`
     /// — so adopt is a zero-copy operation.
     ///
-    /// Used by: sliding-window prompt prefix cache detach/adopt (B9 of #481;
-    /// dense counterpart is [`KVCache::clone_handle`]).
+    /// Used by: sliding-window prompt prefix cache detach/adopt (B9; dense counterpart is [`KVCache::clone_handle`]).
     pub fn clone_handle(&mut self) -> DetachedRotatingKVCache {
         let handle = DetachedRotatingKVCache {
             keys: self.keys.take(),
@@ -676,7 +673,7 @@ impl RotatingKVCache {
             v_rescale: self.v_rescale.take(),
             turbo_seed: self.turbo_seed,
         };
-        // Mirror `KVCache::clone_handle` (LOW-1 from #474): clear cached
+        // Mirror `KVCache::clone_handle` (LOW-1): clear cached
         // turbo_params on the source so the next quantize call rebuilds them
         // from scratch (slot may be reused with a different head_dim).
         self.turbo_params = None;
@@ -737,7 +734,7 @@ impl RotatingKVCache {
 ///
 /// Produced by [`CachePool::detach`] and consumed by [`CachePool::adopt`].
 /// Only the dense backend is supported; paged sequences produce `None` on
-/// detach per sub-issue #418.
+/// detach.
 pub struct DetachedCacheSet {
     /// Per-layer detached caches, one per model layer.
     pub caches: Vec<DetachedKVCache>,
@@ -784,7 +781,7 @@ impl DetachedCacheSet {
     /// equal to the existing length is a no-op.
     ///
     /// The intended caller is the scheduler's `try_adopt_cached_prefix` when
-    /// an APC (issue #552) lookup returns a block-aligned `matched_len`
+    /// an APC lookup returns a block-aligned `matched_len`
     /// shorter than the candidate entry's full token length — i.e. the
     /// request and the cached entry agree on the first N blocks but diverge
     /// at block N+1. Truncating the detached set to `matched_len` before
@@ -797,7 +794,7 @@ impl DetachedCacheSet {
     /// the new length — the caller should drop the set rather than retry.
     ///
     /// Used by: [`crate::cache::CachePool::adopt`] callers that need
-    /// per-block partial adoption (issue #580).
+    /// per-block partial adoption.
     #[must_use = "truncate_to returns Err on partial failure; on error some layers are already trimmed and the set must be dropped, not retried"]
     pub fn truncate_to(&mut self, new_len: i32) -> Result<(), String> {
         if new_len < 0 {
@@ -913,15 +910,14 @@ impl CachePool {
     ///
     /// Returns `None` if:
     /// * `seq_id` is not currently active, or
-    /// * the sequence uses the paged backend (paged detach is #418's
-    ///   responsibility — this method deliberately rejects it).
+    /// * the sequence uses the paged backend (paged detach is's responsibility — this method deliberately rejects it).
     ///
     /// The caller is responsible for re-homing the detached set, either by
     /// passing it to [`CachePool::adopt`] or by parking it via
     /// [`CachePool::park_detached`]. Dropping the returned set releases the
     /// underlying MLX memory normally.
     ///
-    /// Used by: prompt prefix cache store (#418), scheduler request-boundary
+    /// Used by: prompt prefix cache store, scheduler request-boundary
     /// handoff.
     pub fn detach(&mut self, seq_id: SequenceId) -> Option<DetachedCacheSet> {
         // Peek first so we can refuse non-dense backends without destructive
@@ -965,7 +961,7 @@ impl CachePool {
     /// freed) to avoid leaks. Use [`CachePool::adopt_preserving`] when the
     /// caller wants the set back on failure.
     ///
-    /// Used by: prompt prefix cache re-entry (#418), scheduler fast-path
+    /// Used by: prompt prefix cache re-entry, scheduler fast-path
     /// when a new request reuses an existing prefix.
     pub fn adopt(
         &mut self,
@@ -987,7 +983,7 @@ impl CachePool {
         if detached.backend != SequenceStateBackend::DenseKvCache {
             return Err((
                 format!(
-                    "CachePool::adopt: backend {:?} is not supported (paged adopt is tracked in #418)",
+                    "CachePool::adopt: backend {:?} is not supported (paged adopt is tracked)",
                     detached.backend
                 ),
                 detached,

--- a/src/lib/mlxcel-core/src/cache/detach_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/detach_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit and property tests for `cache/detach.rs` (sub-issue #417).
+//! Unit and property tests for `cache/detach.rs`.
 //!
 //! Organised as:
 //! 1. `KVCache::trim_to` semantics (mid-buffer, trim-to-zero, error paths).
@@ -626,7 +626,7 @@ fn property_detach_adopt_decode_matches_fresh_prefill_int8_within_tolerance() {
 }
 
 // ---------------------------------------------------------------------------
-// DetachedKVCache::trim_to / DetachedCacheSet::truncate_to (issue #580)
+// DetachedKVCache::trim_to / DetachedCacheSet::truncate_to
 // ---------------------------------------------------------------------------
 
 /// Build a [`DetachedCacheSet`] with `num_layers` Fp16 layers, each carrying
@@ -859,7 +859,7 @@ fn detached_cache_set_truncate_to_negative_returns_error() {
 
 #[test]
 fn detached_cache_set_truncate_to_then_adopt_then_decode_matches_partial_prefill() {
-    // The key correctness property for issue #580: truncate the detached
+    // The key correctness property for truncate the detached
     // set to N tokens, adopt, then decode M more tokens. The resulting
     // cache state must equal a fresh prefill of the first N tokens followed
     // by the same M tokens — i.e. truncate is a faithful "rewind to N"

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -34,7 +34,7 @@ impl std::fmt::Display for PagedBlockId {
 /// main K and V buffers (`bytes_per_block`) and, when the cache mode is one of
 /// the Turbo4 variants, the per-block byte budget for the packed sidecars
 /// (`turbo_sidecar_bytes_per_block`). The dense `KVCache::nbytes` accounting
-/// in turbo modes always reflects packed storage; see B10 (issue #482).
+/// in turbo modes always reflects packed storage; see B10.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PagedKvLayout {
     pub num_layers: usize,
@@ -308,7 +308,7 @@ impl PagedSequenceState {
 /// `in_use` is retained as a derived mirror of `refcount > 0` so the existing
 /// `stats_for_sequences` and internal debug assertions stay backwards
 /// compatible with call sites that inspected the flag directly before
-/// refcounts were introduced (#418).
+/// refcounts were introduced.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PagedBlockRecord {
     layer_idx: usize,
@@ -397,7 +397,7 @@ impl PagedTurboPageSidecars {
 /// each [`super::SequenceCacheSet`]. In Turbo4 modes the pool also owns per-
 /// page sidecar MLX arrays (`v_packed`, `v_norms`, optionally `k_packed`,
 /// `k_norms`, `cold_keys`) so packed quantization state survives across
-/// detach/adopt round-trips and prefix-cache handoffs (issue #482).
+/// detach/adopt round-trips and prefix-cache handoffs.
 pub struct PagedBlockPool {
     layout: PagedKvLayout,
     next_block_id: u64,
@@ -584,7 +584,7 @@ impl PagedBlockPool {
 
     /// Current refcount of `block_id`, or `0` if the block is free or unknown.
     ///
-    /// Used by: paged detach/adopt invariants (#418), diagnostics.
+    /// Used by: paged detach/adopt invariants, diagnostics.
     pub fn refcount(&self, block_id: PagedBlockId) -> u32 {
         self.blocks
             .get(&block_id)
@@ -618,9 +618,9 @@ impl PagedBlockPool {
     /// list (and becomes eligible for recycling) only once the refcount
     /// reaches zero. Per-page Turbo4 sidecars (if any) are dropped at the same
     /// moment so a recycled block can never serve stale packed data to a new
-    /// sequence (#482).
+    /// sequence.
     ///
-    /// Used by: paged detach/adopt cleanup (#418), internal sequence tear-down.
+    /// Used by: paged detach/adopt cleanup, internal sequence tear-down.
     pub fn release_block(&mut self, block_id: PagedBlockId) -> Result<(), String> {
         let layer_idx = {
             let record = self
@@ -646,7 +646,7 @@ impl PagedBlockPool {
     }
 
     // -----------------------------------------------------------------------
-    // Turbo4 sidecar installation API (issue #482)
+    // Turbo4 sidecar installation API
     // -----------------------------------------------------------------------
 
     /// Install or replace the per-page packed-V tensor for `block_id`.

--- a/src/lib/mlxcel-core/src/cache/paged_detach.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Paged KV cache detach / adopt / park primitives (epic #416, sub-issue #418).
+//! Paged KV cache detach / adopt / park primitives.
 //!
 //! Mirrors the dense surface implemented in `cache/detach.rs` for the paged
 //! decode backend. Paged sequences carry two independent pieces of state:
@@ -92,7 +92,7 @@ pub struct DetachedPagedCacheSet {
     /// [`PagedBlockPool`] at detach time. Keyed by `PagedBlockId`. Empty for
     /// `Fp16`/`Int8` cache modes; on adopt the entries are reinstalled into
     /// the active pool so quantization state survives the round-trip
-    /// bit-identically (issue #482).
+    /// bit-identically.
     pub(super) v_packed_pages: HashMap<PagedBlockId, UniquePtr<MlxArray>>,
     pub(super) v_norms_pages: HashMap<PagedBlockId, UniquePtr<MlxArray>>,
     pub(super) k_packed_pages: HashMap<PagedBlockId, UniquePtr<MlxArray>>,
@@ -283,7 +283,7 @@ impl CachePool {
     /// any of them while the detached set is alive — the set is responsible
     /// for releasing those pins on adopt or explicit release.
     ///
-    /// Used by: prompt prefix cache store (#418), scheduler request-boundary
+    /// Used by: prompt prefix cache store, scheduler request-boundary
     /// handoff for `DecodeStorageBackend::Paged`.
     pub fn detach_paged(&mut self, seq_id: SequenceId) -> Option<DetachedPagedCacheSet> {
         {
@@ -352,7 +352,7 @@ impl CachePool {
 
         // Lift per-page Turbo4 sidecar tensors out of the pool so the round-
         // trip captures them losslessly. For non-Turbo4 modes every map stays
-        // empty and the dispatch below is a no-op (#482).
+        // empty and the dispatch below is a no-op.
         let mut v_packed_pages: HashMap<PagedBlockId, UniquePtr<MlxArray>> = HashMap::new();
         let mut v_norms_pages: HashMap<PagedBlockId, UniquePtr<MlxArray>> = HashMap::new();
         let mut k_packed_pages: HashMap<PagedBlockId, UniquePtr<MlxArray>> = HashMap::new();
@@ -413,7 +413,7 @@ impl CachePool {
     /// **and** release all block pins so the caller never has to hand-roll
     /// cleanup.
     ///
-    /// Used by: prompt prefix cache re-entry (#418), scheduler fast-path for
+    /// Used by: prompt prefix cache re-entry, scheduler fast-path for
     /// paged decode sequences.
     pub fn adopt_paged(
         &mut self,
@@ -498,7 +498,7 @@ impl CachePool {
         let created_at = detached.created_at;
         let retained_blocks = detached.retained_blocks.take();
         // Lift the per-page Turbo4 sidecars out of the detached set so we can
-        // reinstall them on the active pool below (#482). For Fp16/Int8
+        // reinstall them on the active pool below. For Fp16/Int8
         // round-trips every map is empty and the work below short-circuits.
         let v_packed_pages = std::mem::take(&mut detached.v_packed_pages);
         let v_norms_pages = std::mem::take(&mut detached.v_norms_pages);

--- a/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit + property tests for `cache/paged_detach.rs` (sub-issue #418).
+//! Unit + property tests for `cache/paged_detach.rs`.
 //!
 //! Organised as:
 //! 1. `PagedBlockPool` refcount plumbing (`retain_block` / `release_block`).

--- a/src/lib/mlxcel-core/src/cache/paged_turbo_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_turbo_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit tests for the Turbo4-aware paged KV layout (sub-issue #482, B10).
+//! Unit tests for the Turbo4-aware paged KV layout (B10).
 //!
 //! Organised as:
 //! 1. `PagedKvLayout` Turbo4 construction + validation.

--- a/src/lib/mlxcel-core/src/cache/sparse_v_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/sparse_v_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! MLX-using unit tests for the sparse-V dequant scaffold (issue #480).
+//! MLX-using unit tests for the sparse-V dequant scaffold.
 //!
 //! Pure-Rust env-var tests live inline in `cache/turbo/sparse_v.rs` so they
 //! still run when the Metal/CUDA features are off. The tests in this file
@@ -359,7 +359,7 @@ fn sparse_v_available_returns_false_for_turbo4_delegated() {
     // and hot-FP16 V. The current `sparse_v_attention` dispatcher only
     // handles a contiguous `0..self.offset` range, so delegated mode must
     // report `sparse_v_available == false` until the hot+cold composition
-    // pass lands. Regression guard for issue #505 narrowing.
+    // pass lands. Regression guard narrowing.
     let _guard = SparseVThresholdGuard::set("1e-6");
     let cache = super::KVCache::new_with_mode(super::KVCacheMode::Turbo4Delegated);
     assert!(
@@ -477,8 +477,7 @@ fn sparse_v_attention_returns_none_when_not_available() {
 ///
 /// The guard takes the crate-wide `ENV_LOCK` for its full lifetime so that
 /// `set_var`/`remove_var` calls cannot race with env mutations in any other
-/// `#[cfg(test)]` module of the same test binary (issue #573 — libc's env
-/// block has no internal lock).
+/// `#[cfg(test)]` module of the same test binary (— libc's env block has no internal lock).
 struct SparseVThresholdGuard {
     prev: Option<String>,
     // The lock guard outlives the env mutations: it is taken in `set` and
@@ -552,7 +551,7 @@ fn sparse_v_attention_threshold_default_keeps_quality() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #505 — fused Metal kernel correctness equivalence
+// fused Metal kernel correctness equivalence
 // ---------------------------------------------------------------------------
 
 /// Kernel-vs-graph numerical equivalence at threshold=0.
@@ -579,7 +578,7 @@ fn sparse_v_kernel_threshold_zero_matches_graph() {
     let (v_packed, v_norms, v_rescale) = turbo::quant::quantize_v_turbo4(&v_f16, &params);
 
     let scale = 1.0_f32 / (head_dim as f32).sqrt();
-    // Issue #520: the fused kernel now consumes the precomputed `v_rescale`
+    // the fused kernel now consumes the precomputed `v_rescale`
     // sidecar instead of `v_norms`. The graph fallback still consumes
     // `v_norms`. Both paths must produce identical output within FP16
     // round-off — that is the parity bound this test enforces.

--- a/src/lib/mlxcel-core/src/cache/turbo/allowlist.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/allowlist.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //! Per-model allowlist for **symmetric** `KVCacheMode::Turbo4`
-//! (issue #476, epic #458).
 //!
 //! # Why an allowlist?
 //!
@@ -104,7 +103,7 @@ pub static ALLOWED_SYMMETRIC_TURBO_FAMILIES: &[&str] = &[
     // initial list because mlxcel does not yet read the weight quantization
     // tier from `config.json` — adding a `model_type` entry would also
     // greenlight Q4_K_M variants of the same family, which is exactly what
-    // the safety story forbids. Re-evaluate when issue #485 (B12 docs)
+    // the safety story forbids. Re-evaluate when (B12 docs)
     // wires up a richer model-fingerprint lookup.
 ];
 

--- a/src/lib/mlxcel-core/src/cache/turbo/boundary.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/boundary.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Boundary-V layer protection (B6, issue #478, epic #458).
+//! Boundary-V layer protection (B6).
 //!
 //! TurboQuant+ measured that the first 2 and last 2 transformer layers'
 //! V quantization error contributes disproportionately to perplexity
@@ -39,9 +39,7 @@
 //!
 //! # Configuration
 //!
-//! - `MLXCEL_KV_BOUNDARY_V_LAYERS` env var (also accepted as
-//!   `MLXCEL_TURBO_BOUNDARY_V` for compatibility with the wording in
-//!   issue #478): integer count of boundary layers to protect on each
+//! - `MLXCEL_KV_BOUNDARY_V_LAYERS` env var (also accepted as `MLXCEL_TURBO_BOUNDARY_V` for compatibility with the wording): integer count of boundary layers to protect on each
 //!   end. Default `2`. Setting `0` disables the policy.
 //! - The count is clamped to `min(boundary, n_layers / 2)` so a
 //!   too-aggressive setting on a shallow model doesn't end up
@@ -158,7 +156,7 @@ pub fn is_boundary_layer(layer_idx: usize, n_layers: usize, boundary: i32) -> bo
 ///
 /// Used by: [`resolve_layer_mode`] — kept as a separate helper so the
 /// "boundary precision choice" is a single edit point if we later
-/// follow up with a true partial-V override (issue #478 follow-up).
+/// follow up with a true partial-V override (follow-up).
 #[inline]
 pub fn boundary_mode_for(nominal: KVCacheMode) -> KVCacheMode {
     match nominal {

--- a/src/lib/mlxcel-core/src/cache/turbo/codebook.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/codebook.rs
@@ -46,7 +46,7 @@
 //! pair during model initialisation. Results are cached in a `OnceLock`-backed
 //! `HashMap` so repeated calls are free.
 //!
-//! Used by: TurboQuant KV cache (B2 onward, epic #458)
+//! Used by: TurboQuant KV cache (B2 onward)
 
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
@@ -66,7 +66,7 @@ use std::sync::{Arc, OnceLock};
 /// shared with the dequantize-on-read path inside the cache, which references
 /// them once per layer/forward at minimal overhead.
 ///
-/// Used by: TurboQuant V-side quantize/dequantize (B2, epic #458).
+/// Used by: TurboQuant V-side quantize/dequantize (B2).
 #[derive(Clone, Debug)]
 pub struct Codebook {
     /// Sorted centroid values for `N(0, 1/d)`. Length = `2^bit_width`.
@@ -177,7 +177,7 @@ pub fn optimal_centroids(bit_width: u8, head_dim: u32) -> Vec<f32> {
 ///
 /// Same panic conditions as [`optimal_centroids`].
 ///
-/// Used by: TurboQuant V-side quantize/dequantize (B2, epic #458).
+/// Used by: TurboQuant V-side quantize/dequantize (B2).
 pub fn optimal_codebook(bit_width: u8, head_dim: u32) -> Codebook {
     assert!(bit_width > 0, "bit_width must be >= 1");
     assert!(
@@ -247,7 +247,7 @@ pub fn compute_centroids(bit_width: u8, head_dim: u32) -> Vec<f32> {
 ///
 /// Returns integer indices in `[0, n_centroids)`.
 ///
-/// Used by: unit tests; B2 quantization path (epic #458). On hot paths prefer
+/// Used by: unit tests; B2 quantization path. On hot paths prefer
 /// [`nearest_centroid_indices_with_boundaries`] (or use the [`Codebook`]
 /// returned by [`optimal_codebook`]) so the midpoint boundary array is only
 /// built once per `(bit_width, head_dim)` instead of per-call.
@@ -274,7 +274,7 @@ pub fn nearest_centroid_indices(values: &[f32], centroids: &[f32]) -> Vec<usize>
 /// `boundaries.len()` must equal `n_centroids - 1` (i.e., the boundary
 /// invariant established by [`Codebook::from_centroids`]).
 ///
-/// Used by: TurboQuant V-side quantize loop (B2, epic #458).
+/// Used by: TurboQuant V-side quantize loop (B2).
 pub fn nearest_centroid_indices_with_boundaries(
     values: &[f32],
     boundaries: &[f32],
@@ -650,7 +650,7 @@ mod tests {
 
     // -----------------------------------------------------------------------
     // Full fixture comparison — byte-for-byte against Python reference
-    // This is the acceptance-gate test required by epic #458.
+    // This is the acceptance-gate test required.
     // Reads tests/fixtures/turbo_codebooks/codebooks_hex.json and compares
     // every (b, d) pair from b ∈ {2,3,4}, d ∈ {64,80,96,128,192,256}.
     // -----------------------------------------------------------------------

--- a/src/lib/mlxcel-core/src/cache/turbo/mod.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! TurboQuant KV cache compression (epic #458).
+//! TurboQuant KV cache compression.
 //!
 //! This module is the entry point for all TurboQuant / PolarQuant components
 //! used by the KV cache compression pipeline. Sub-modules are added
@@ -20,13 +20,13 @@
 //!
 //! | Sub-module    | Sub-issue   | Status   | Description                          |
 //! |---------------|-------------|----------|--------------------------------------|
-//! | `codebook`    | B1 (#472)   | done     | Lloyd-Max centroid generator         |
-//! | `quant`       | B2/B4 (#474, #476) | done | V-side + K-side PolarQuant pipeline |
-//! | `pack3`       | B5 (#477)   | done     | 3-bit pack/unpack helpers (24-bit grouping) |
-//! | `quant3`      | B5 (#477)   | done     | 3-bit V-side PolarQuant pipeline (asymmetric only) |
-//! | `allowlist`   | B4 (#476)   | done     | Per-model symmetric Turbo4 gating    |
-//! | `boundary`    | B6 (#478)   | done     | First/last layer V protection policy |
-//! | `sparse_v`    | B8 (#480)   | done     | Attention-gated V-dequant scaffold   |
+//! | `codebook`    | B1   | done     | Lloyd-Max centroid generator         |
+//! | `quant`       | B2/B4 | done | V-side + K-side PolarQuant pipeline |
+//! | `pack3`       | B5   | done     | 3-bit pack/unpack helpers (24-bit grouping) |
+//! | `quant3`      | B5   | done     | 3-bit V-side PolarQuant pipeline (asymmetric only) |
+//! | `allowlist`   | B4   | done     | Per-model symmetric Turbo4 gating    |
+//! | `boundary`    | B6   | done     | First/last layer V protection policy |
+//! | `sparse_v`    | B8   | done     | Attention-gated V-dequant scaffold   |
 //! | (more to come)| B10–B12     | pending  | paged KV / docs / turbo2             |
 //!
 //! # Usage by downstream sub-issues
@@ -67,7 +67,7 @@ pub use quant::{
     BLOCK_SIZE, K_BIT_WIDTH, K_SEED_OFFSET, V_BIT_WIDTH,
 };
 
-/// Default hot-tail threshold for `KVCacheMode::Turbo4Delegated` (issue #479).
+/// Default hot-tail threshold for `KVCacheMode::Turbo4Delegated`.
 ///
 /// When the FP16 hot tail exceeds this many tokens, the oldest
 /// [`DELEGATED_FOLD_BLOCK`]-token block is folded into cold packed storage on

--- a/src/lib/mlxcel-core/src/cache/turbo/pack3.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/pack3.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! 3-bit pack/unpack helpers for `KVCacheMode::Turbo3Asym` (issue #477,
-//! epic #458).
+//! 3-bit pack/unpack helpers for `KVCacheMode::Turbo3Asym`.
 //!
 //! 3 bits do not divide a byte cleanly, so we pack **8 coordinates into 3
 //! bytes** (8 × 3 = 24 bits = 3 bytes). The cache calls into these helpers
@@ -237,7 +236,7 @@ mod tests {
 
     #[test]
     fn packed_bytes_matches_supported_head_dims() {
-        // Issue #477 spec: head_dim ∈ {64, 80, 96, 128, 192, 256} → bytes
+        // spec: head_dim ∈ {64, 80, 96, 128, 192, 256} → bytes
         // {24, 30, 36, 48, 72, 96}.
         assert_eq!(packed_bytes_per_token_3bit(64), 24);
         assert_eq!(packed_bytes_per_token_3bit(80), 30);
@@ -344,7 +343,7 @@ mod tests {
     }
 
     /// head_dim=80 (Mistral-class). 80 * 3 = 240 bits = exactly 30 bytes per
-    /// token; verifies the awkward but valid alignment from issue #477's
+    /// token; verifies the awkward but valid alignment's
     /// design notes.
     #[test]
     fn round_trip_per_token_head_dim_80() {

--- a/src/lib/mlxcel-core/src/cache/turbo/quant.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/quant.rs
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! TurboQuant K/V-side PolarQuant pipeline (B2 + B4, issues #474 and #476,
-//! epic #458).
+//! TurboQuant K/V-side PolarQuant pipeline (B2 + B4, and).
 //!
 //! Implements the per-token compression used by `KVCacheMode::Turbo4Asym`
 //! (V only) and `KVCacheMode::Turbo4` (both K and V):
 //!
 //! 1. Per-token L2 norm extraction.
 //! 2. Sign-flip × Walsh–Hadamard × sign-flip rotation (the structured fast
-//!    rotation `D2 · H · D1` from the TurboQuant+ reference). See B0 (#470)
+//!    rotation `D2 · H · D1` from the TurboQuant+ reference). See B0
 //!    for the WHT op.
 //! 3. Per-coordinate nearest-centroid lookup using the Lloyd-Max codebook
-//!    from B1 (#472).
+//!    from B1.
 //! 4. Nibble-packing of the 4-bit indices into a `[..., head_dim/2]` u8 buffer.
 //!
 //! The dequantize path is the exact inverse: unpack nibbles → centroid
@@ -68,7 +67,7 @@
 //! magnitude information; without it, the dequantized vector underestimates
 //! the original V by a few percent.
 //!
-//! Used by: `KVCacheMode::Turbo4Asym` V-cache update/read (B2, epic #458).
+//! Used by: `KVCacheMode::Turbo4Asym` V-cache update/read (B2).
 
 use std::sync::Arc;
 
@@ -86,8 +85,8 @@ use crate::ops::wht;
 pub const V_BIT_WIDTH: u8 = 4;
 
 /// K-side PolarQuant bit-width. Locked to 4 bits for symmetric `Turbo4`
-/// (issue #476). The K side is only quantized in symmetric mode; in
-/// `Turbo4Asym` (issue #474) the K side stays in FP16.
+/// The K side is only quantized in symmetric mode; in
+/// `Turbo4Asym` the K side stays in FP16.
 pub const K_BIT_WIDTH: u8 = 4;
 
 /// Seed offset added to the cache's `turbo_seed` before deriving the K-side
@@ -141,13 +140,13 @@ impl Lcg32 {
 /// runtime model and a deterministic seed. The codebook is fetched from the
 /// global `OnceLock`-backed cache so multiple caches share the centroids.
 ///
-/// In symmetric `Turbo4` mode (issue #476) the *same* params struct also
+/// In symmetric `Turbo4` mode the *same* params struct also
 /// carries an independent pair of K-side sign vectors (`k_signs1` /
 /// `k_signs2`) so K compression decorrelates from V. The codebook is
 /// re-used as the post-WHT coordinate distribution is identical for K and V.
 ///
 /// Used by: `KVCache::update_turbo4_asym` (cache.rs),
-/// `KVCache::update_turbo4_sym` (cache.rs, issue #476),
+/// `KVCache::update_turbo4_sym` (cache.rs),
 /// `turbo::quant::dequantize_v_turbo4` (this module),
 /// `turbo::quant::dequantize_k_turbo4` (this module).
 #[derive(Clone, Debug)]
@@ -242,7 +241,7 @@ pub fn generate_signs(len: usize, seed: u32) -> Arc<[f32]> {
 /// is shape `[B, H, T, D/2]` u8 (low nibble = even coord, high nibble = odd
 /// coord); the norm tensor is shape `[B, H, T, 1]` fp16.
 ///
-/// # Returns (issue #520, fused Sparse-V kernel rescale precompute)
+/// # Returns (fused Sparse-V kernel rescale precompute)
 ///
 /// `(v_packed, v_norms, v_rescale)` where the third element is a precomputed
 /// per-token rescale factor:
@@ -255,7 +254,7 @@ pub fn generate_signs(len: usize, seed: u32) -> Arc<[f32]> {
 /// per token by the previous fused kernel via a threadgroup tree reduction
 /// over `Dim` threads. Precomputing it at quantize time eliminates the
 /// per-cache-token threadgroup reduction (and its `log2(Dim) + 2` barrier
-/// chain) from the kernel hot path — see issue #520 for measurements.
+/// chain) from the kernel hot path — for measurements.
 ///
 /// V-side callers store `v_rescale` alongside `v_packed` / `v_norms` so the
 /// fused kernel (`turbo::sparse_v::attention_sparse_v_turbo4_fused`) can read
@@ -329,13 +328,13 @@ fn quantize_into_packed(
     //    correctness story dominates and a fully-fused on-GPU implementation
     //    is the natural follow-up (likely B7's delegated KVCache or B11+).
     //
-    //    TODO(#474 follow-up): replace this readback with an on-device
+    //    TODO(follow-up): replace this readback with an on-device
     //    nearest-centroid lookup (broadcast-compare against the 15 boundaries
     //    and reduce). The dequantize path was migrated to on-device unpacking
-    //    in PR #490 because it dominates decode latency (`O(visible_tokens)`
+    // because it dominates decode latency (`O(visible_tokens)`
     //    per layer per step). The quantize path is `O(new_tokens)` per layer
     //    per step — typically 1 token at decode — so the readback cost here
-    //    is dwarfed by dequantize and was deferred to keep PR #490 scoped.
+    //    is dwarfed by dequantize and was deferred to keep scoped.
     ffi::eval(&v_rot);
     let coord_count = (shape[0] * shape[1] * t * d) as usize;
     let v_rot_bytes = ffi::array_to_raw_bytes(&v_rot);
@@ -381,11 +380,10 @@ fn quantize_into_packed(
     let v_norms = ffi::astype(&norm_full, dtype::FLOAT16);
 
     // 6. Precompute the per-token rescale factor `norm[t] / max(|y_hat|, eps)`
-    //    consumed by the fused Sparse-V kernel (issue #520). The previous
+    //    consumed by the fused Sparse-V kernel. The previous
     //    kernel implementation derived this on-GPU per token via a
     //    `log2(Dim) + 2`-barrier threadgroup tree reduction, which dominated
-    //    decode latency on M5 Max at 4 K context for `turbo4-asym` (the kernel
-    //    was 2.0× slower than the graph fallback in PR #519's A/B). Because
+    //    decode latency on M5 Max at 4 K context for `turbo4-asym` (the kernel was 2.0× slower than the graph fallback's A/B). Because
     //    `|y_hat|` is a pure function of the packed indices and the codebook
     //    — both fixed at quantize time — we can compute it once here on the
     //    host and store the resulting fp16 scalar alongside `v_norms`.
@@ -447,7 +445,7 @@ fn quantize_into_packed(
 /// - `v_norms`:   `[B, H, T, 1]`   fp16 — per-token L2 norm of the *original*
 ///   V vector (used for rescaling on the graph dequantize path).
 /// - `v_rescale`: `[B, H, T, 1]`   fp16 — precomputed `norm[t] / |y_hat[t]|`
-///   used by the fused Sparse-V kernel (issue #520) to skip the per-token
+///   used by the fused Sparse-V kernel to skip the per-token
 ///   threadgroup tree reduction. See [`quantize_into_packed`] for details.
 ///
 /// Used by: `KVCache::update` (Turbo4Asym mode, Turbo4 mode, Turbo4Delegated
@@ -470,13 +468,11 @@ pub fn quantize_v_turbo4(
 ///
 /// Returns `(k_packed, k_norms)` analogous to [`quantize_v_turbo4`] but
 /// without the K-side rescale precompute — the symmetric-Turbo4 K-side has
-/// no analogue of the fused V-side kernel today (issue #476's K dequant runs
-/// on the standard graph path), so the precompute would be wasted work.
+/// no analogue of the fused V-side kernel today ('s K dequant runs on the standard graph path), so the precompute would be wasted work.
 /// Storage layout otherwise matches the V-side path bit-for-bit, so the cache
 /// layer can reuse the same packing/unpacking helpers.
 ///
-/// Used by: `KVCache::update` (Turbo4 symmetric mode, issue #476, epic
-/// #458).
+/// Used by: `KVCache::update` (Turbo4 symmetric mode).
 pub fn quantize_k_turbo4(
     k: &MlxArray,
     params: &TurboQuantParams,
@@ -667,7 +663,7 @@ pub fn dequantize_v_turbo4(
 /// portion of the cache (the same way the V-side path does in
 /// `KVCache::update_and_fetch`).
 ///
-/// Used by: `KVCache::update_and_fetch` (Turbo4 symmetric mode, issue #476).
+/// Used by: `KVCache::update_and_fetch` (Turbo4 symmetric mode).
 pub fn dequantize_k_turbo4(
     k_packed: &MlxArray,
     k_norms: &MlxArray,
@@ -703,7 +699,7 @@ pub fn dequantize_k_turbo4(
 /// (TurboQuant+ reports kurtosis ~900 → ~2.9 on Qwen3-1.7B K caches) on
 /// actual model weights.
 ///
-/// Used by: `tests/turbo_kv_e2e.rs` kurtosis sanity test (issue #475).
+/// Used by: `tests/turbo_kv_e2e.rs` kurtosis sanity test.
 // doc(hidden) keeps this out of the public rustdoc while still being visible
 // to external crates (including the integration test crate).
 #[doc(hidden)]

--- a/src/lib/mlxcel-core/src/cache/turbo/quant.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/quant.rs
@@ -80,7 +80,7 @@ use crate::ffi::MlxArray;
 use crate::ops::wht;
 
 /// V-side PolarQuant bit-width. Locked to 4 bits for `Turbo4Asym` and
-/// symmetric `Turbo4`. (B5/#477 will add 3-bit, but lives in its own
+/// symmetric `Turbo4`. (B5 will add 3-bit, but lives in its own
 /// variant.)
 pub const V_BIT_WIDTH: u8 = 4;
 

--- a/src/lib/mlxcel-core/src/cache/turbo/quant3.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/quant3.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! V-side 3-bit PolarQuant pipeline for `KVCacheMode::Turbo3Asym` (issue
-//! #477, epic #458).
+//! V-side 3-bit PolarQuant pipeline for `KVCacheMode::Turbo3Asym`.
 //!
 //! This module mirrors [`super::quant`] (the 4-bit pipeline used by
 //! `Turbo4Asym` / `Turbo4`) but uses a **3-bit** Lloyd-Max codebook and the
@@ -44,14 +43,14 @@
 //!
 //! # Asymmetric-only
 //!
-//! Issue #477 explicitly defers the symmetric `Turbo3` variant. Symmetric
-//! 3-bit on dense Q4_K_M weights is catastrophic per epic #458's
+//! explicitly defers the symmetric `Turbo3` variant. Symmetric
+//! 3-bit on dense Q4_K_M weights is catastrophic's
 //! "Quality–compression tradeoff control" section. This PR ships only
 //! `KVCacheMode::Turbo3Asym` (Fp16-K + Turbo3-V). The allowlist gating in
 //! [`super::allowlist`] does not apply because asymmetric Turbo* is always
 //! safe.
 //!
-//! Used by: `KVCache::update_turbo3_asym` (cache.rs, issue #477).
+//! Used by: `KVCache::update_turbo3_asym` (cache.rs).
 
 use std::sync::Arc;
 
@@ -73,7 +72,7 @@ pub const V_BIT_WIDTH_3: u8 = 3;
 /// Mirrors [`super::quant::TurboQuantParams`] but carries a 3-bit codebook
 /// (8 centroids) instead of 4-bit (16 centroids). The K-side sign vectors
 /// from the 4-bit struct are intentionally absent — symmetric Turbo3 is
-/// out of scope for issue #477 and the asymmetric path leaves K in FP16.
+/// out of scope and the asymmetric path leaves K in FP16.
 ///
 /// One instance is built per `KVCache` at construction time when the cache
 /// is in `KVCacheMode::Turbo3Asym` mode, parameterised by the V `head_dim`

--- a/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
@@ -602,7 +602,7 @@ pub fn attention_sparse_v_turbo4_fused(
     let v_packed_flat = ffi::reshape(v_packed, &[bhkv, tk, head_dim / 2]);
     // v_rescale graph shape is `[B, Hkv, Tk, 1]`. The kernel expects
     // `[B*Hkv, Tk]` — drop the trailing axis and flatten the first two.
-    // (Same memory layout as the previous `v_norms` plumbing; only the semantic content changed —.)
+    // (Same memory layout as the previous `v_norms` plumbing; only the semantic content changed.)
     let v_rescale_flat = ffi::reshape(v_rescale, &[bhkv, tk]);
     let codebook_vec: Vec<f32> = params.codebook.centroids.as_ref().to_vec();
     let codebook_arr = ffi::from_slice_f32(&codebook_vec, &[codebook_vec.len() as i32]);

--- a/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Sparse-V dequant — attention-gated V-side dequantization (issues #498,
-//! #505, epic #458).
+//! Sparse-V dequant — attention-gated V-side dequantization.
 //!
 //! At long context the post-softmax attention distribution is sparse: most
 //! KV positions receive a near-zero attention weight. The TurboQuant+ paper
@@ -24,12 +23,12 @@
 //!
 //! This module provides two execution paths for the sparse-V optimization:
 //!
-//! 1. **Graph-level reference path** (issue #498, [`attention_sparse_v_turbo4`]).
+//! 1. **Graph-level reference path** ([`attention_sparse_v_turbo4`]).
 //!    Computes attention scores, builds an alive mask, dequantizes V in full,
 //!    zeros dead rows, then runs `attn @ V_masked`. The V dequant kernel still
 //!    runs over the complete `[B, H, T, D]` tensor — this path is
 //!    correctness-only and does not deliver the `+22.8 %` throughput benefit.
-//! 2. **Fused Metal kernel path** (issue #505, [`attention_sparse_v_turbo4_fused`]).
+//! 2. **Fused Metal kernel path** ([`attention_sparse_v_turbo4_fused`]).
 //!    Dispatches the JIT-compiled `turbo_sparse_v_weighted_sum` Metal kernel,
 //!    which does the per-thread `if (attn_weight <= threshold) continue;` skip
 //!    inside the SDPA inner loop. This is the production speed path validated
@@ -51,8 +50,8 @@
 //! `dequant(...)` for every position because MLX evaluates both branches
 //! eagerly. The skip can only happen inside the Metal kernel where the
 //! `if (attn_weight < 1e-6f) continue;` predicate gates a single thread's
-//! work. Issue #498 established the graph scaffold and correctness gate;
-//! issue #505 landed the fused kernel that delivers the actual throughput
+//! work. established the graph scaffold and correctness gate;
+//! landed the fused kernel that delivers the actual throughput
 //! benefit.
 //!
 //! Used by: `KVCache::update_and_sparse_v_attention` (Turbo4Asym mode) when
@@ -160,7 +159,7 @@ pub fn kernel_enabled() -> bool {
 }
 
 /// Environment variable that opts callers into the fused Turbo4Delegated
-/// dequant + SDPA kernel path (issue #528). Default: kernel path is **off**;
+/// dequant + SDPA kernel path. Default: kernel path is **off**;
 /// callers route through the legacy `update_and_fetch + attention()` pair
 /// until follow-up work brings the fused pipeline inside the steel-attention
 /// envelope on M5 Max at the gate contexts.
@@ -213,9 +212,7 @@ fn parse_env_default_on(var_name: &str) -> bool {
 /// Mirrors the [`kernel_enabled`] caching pattern: the env var is parsed once
 /// per process and cached in a `OnceLock<bool>` so per-token, per-layer
 /// attention forwards pay only an atomic load instead of an env-table lookup
-/// (`std::env::var` allocates a fresh `String` and takes a process-wide lock,
-/// which is ~3,200 calls/sec/sequence on a 32-layer model — see the security
-/// review on PR #530).
+/// (`std::env::var` allocates a fresh `String` and takes a process-wide lock, which is ~3,200 calls/sec/sequence on a 32-layer model — see the security review on).
 ///
 /// Used by: per-model attention call sites (Llama 3, Qwen 3, ...) that want
 /// to opt into [`KVCache::update_and_turbo4_delegated_attention`] over the
@@ -377,7 +374,7 @@ pub fn compute_alive_mask(
 /// `[B, Hq, Tq, D]` FP16 attention output, the same shape and dtype as the
 /// standard SDPA path returns.
 ///
-/// Used by: tests under `cache/turbo_tests.rs` (issue #480 unit tests).
+/// Used by: tests under `cache/turbo_tests.rs` (unit tests).
 /// Production attention call sites continue to use the standard
 /// `attention()` path until the Metal kernel lands.
 #[allow(clippy::too_many_arguments)]
@@ -485,7 +482,7 @@ pub fn attention_sparse_v_turbo4(
     ffi::astype(&out_f32, dtype::FLOAT16)
 }
 
-/// Fused-skip Sparse-V SDPA path (issue #505, optimized by issue #520).
+/// Fused-skip Sparse-V SDPA path (optimized).
 ///
 /// Drops the explicit `dequantize_v_turbo4` step in favour of the fused
 /// Metal kernel `turbo_sparse_v_weighted_sum`, which does the per-thread
@@ -503,7 +500,7 @@ pub fn attention_sparse_v_turbo4(
 /// - `k`: `[B, Hkv, Tk, D]` key tensor (FP16) — Turbo4Asym keeps K in FP16.
 /// - `v_packed`: `[B, Hkv, Tk, D/2]` u8 — packed V indices.
 /// - `v_rescale`: `[B, Hkv, Tk, 1]` FP16 — precomputed per-token kernel
-///   rescale `norm[t] / max(|y_hat[t]|, 1e-10)`. Issue #520 moved this
+///   rescale `norm[t] / max(|y_hat[t]|, 1e-10)`. moved this
 ///   computation from a per-token threadgroup tree reduction inside the
 ///   kernel to a one-time host-side precompute at quantize time. The
 ///   value matches the kernel's previous on-the-fly `vn / yh_safe` exactly,
@@ -526,7 +523,7 @@ pub fn attention_sparse_v_turbo4(
 /// [`attention_sparse_v_turbo4`] (which still consumes `v_norms`) in that
 /// case.
 ///
-/// Used by: [`KVCache::sparse_v_attention`] (issue #505).
+/// Used by: [`KVCache::sparse_v_attention`].
 #[allow(clippy::too_many_arguments)]
 pub fn attention_sparse_v_turbo4_fused(
     q: &MlxArray,
@@ -605,8 +602,7 @@ pub fn attention_sparse_v_turbo4_fused(
     let v_packed_flat = ffi::reshape(v_packed, &[bhkv, tk, head_dim / 2]);
     // v_rescale graph shape is `[B, Hkv, Tk, 1]`. The kernel expects
     // `[B*Hkv, Tk]` — drop the trailing axis and flatten the first two.
-    // (Same memory layout as the previous `v_norms` plumbing; only the
-    // semantic content changed — see issue #520.)
+    // (Same memory layout as the previous `v_norms` plumbing; only the semantic content changed —.)
     let v_rescale_flat = ffi::reshape(v_rescale, &[bhkv, tk]);
     let codebook_vec: Vec<f32> = params.codebook.centroids.as_ref().to_vec();
     let codebook_arr = ffi::from_slice_f32(&codebook_vec, &[codebook_vec.len() as i32]);
@@ -634,12 +630,12 @@ pub fn attention_sparse_v_turbo4_fused(
     Some(ffi::astype(&post_d1, dtype::FLOAT16))
 }
 
-/// Fused dequant + SDPA path for `KVCacheMode::Turbo4Delegated` (issue #528).
+/// Fused dequant + SDPA path for `KVCacheMode::Turbo4Delegated`.
 ///
 /// The Turbo4Delegated cache stores V in two regions: a packed cold body
 /// (`[B, Hkv, T_cold, D/2]` u8 + `[B, Hkv, T_cold, 1]` fp16 rescale) and an
-/// FP16 hot ring (`[B, Hkv, T_hot, D]`). Pre-#528 the read path materialised
-/// the full FP16 cold body via `dequantize_v_turbo4` (memoised by PR #525)
+/// FP16 hot ring (`[B, Hkv, T_hot, D]`). Pre- the read path materialised
+/// the full FP16 cold body via `dequantize_v_turbo4` (memoised)
 /// and ran a graph-level `concat(cold_v_dequant, hot_v, axis=2)` plus
 /// standard SDPA. The memo's working set was `[B, Hkv, cold_offset, D]` fp16
 /// — at 4K context that is 50–100 MB per layer per sequence and undoes the
@@ -667,18 +663,18 @@ pub fn attention_sparse_v_turbo4_fused(
 /// At no point does the dequantised cold V exist as a tensor in global
 /// memory. The dequant is computed inside the kernel into thread-local
 /// registers and consumed by the weighted sum in the same dispatch — that
-/// is the whole point of issue #528.
+/// is the whole point.
 ///
 /// # Inputs
 ///
 /// - `q`: `[B, Hq, Tq, D]` query tensor (FP16 or FP32). Must already have
 ///   RoPE / Q-norm applied (matches the standard attention call contract).
 /// - `unified_k`: `[B, Hkv, T_total, D]` FP16 — the full unified K buffer
-///   (issue #527 unified the K side, dropping the cold/hot split for K).
+///   (unified the K side, dropping the cold/hot split for K).
 /// - `v_packed`: `[B, Hkv, T_cold, D/2]` u8 — packed cold V indices. May be
 ///   empty (`T_cold == 0`) on the very first decode step before any fold.
 /// - `v_rescale`: `[B, Hkv, T_cold, 1]` FP16 — precomputed per-token kernel
-///   rescale `norm[t] / max(|y_hat[t]|, 1e-10)` (issue #520). Same lockstep
+///   rescale `norm[t] / max(|y_hat[t]|, 1e-10)`. Same lockstep
 ///   shape as the Turbo4Asym path.
 /// - `hot_v`: `[B, Hkv, T_hot, D]` FP16 — plain FP16 hot V tokens. May be
 ///   empty (`T_hot == 0`) immediately after a full fold.
@@ -698,7 +694,7 @@ pub fn attention_sparse_v_turbo4_fused(
 /// `MLXCEL_SPARSE_V_KERNEL=0`). Callers should fall back to
 /// [`KVCache::update_and_fetch`] + `attention()` in that case.
 ///
-/// Used by: `KVCache::update_and_turbo4_delegated_attention` (issue #528).
+/// Used by: `KVCache::update_and_turbo4_delegated_attention`.
 #[allow(clippy::too_many_arguments)]
 pub fn attention_turbo4_delegated_fused(
     q: &MlxArray,
@@ -1015,7 +1011,7 @@ fn dequantize_v_turbo4_rotated_fused(
 }
 
 /// Steel-attention-envelope fused dequant + SDPA path for
-/// `KVCacheMode::Turbo4Delegated` (issue #531).
+/// `KVCacheMode::Turbo4Delegated`.
 ///
 /// Compresses the post-Q·K SDPA pipeline of [`attention_turbo4_delegated_fused`]
 /// from ~14 MLX dispatches into ~5: one Q·K matmul, one steel-envelope kernel
@@ -1037,8 +1033,7 @@ fn dequantize_v_turbo4_rotated_fused(
 /// `Some([B, Hq, Tq, D])` FP16 attention output, or `None` when the kernel
 /// path is gated off (non-macOS, non-power-of-2 head dim, or
 /// `MLXCEL_SPARSE_V_KERNEL=0`). Callers should fall back to
-/// [`attention_turbo4_delegated_fused`] (which still routes through the
-/// post-#528 cold-only kernel + host composition) or to
+/// [`attention_turbo4_delegated_fused`] (which still routes through the post- cold-only kernel + host composition) or to
 /// [`KVCache::delegated_graph_attention`] in that case.
 ///
 /// # Numerical equivalence
@@ -1054,7 +1049,7 @@ fn dequantize_v_turbo4_rotated_fused(
 /// verifies RMS < 5e-3 across at least two fold boundaries.
 ///
 /// Used by: [`KVCache::update_and_turbo4_delegated_attention`] when the steel
-/// envelope is preferred (issue #531).
+/// envelope is preferred.
 #[allow(clippy::too_many_arguments)]
 pub fn attention_turbo4_delegated_steel(
     q: &MlxArray,

--- a/src/lib/mlxcel-core/src/cache/turbo_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Integration tests for `KVCacheMode::Turbo4Asym` (issue #474, epic #458).
+//! Integration tests for `KVCacheMode::Turbo4Asym`.
 //!
 //! Covers:
 //! 1. Mode-string parsing (`fp16+turbo4`, `turbo4-asym`).
@@ -59,8 +59,8 @@ fn turbo4_asym_display_round_trip() {
 
 #[test]
 fn unknown_mode_string_errors() {
-    // "turbo2" is intentionally not a recognised alias — issue #477 is the
-    // 3-bit mode, and 2-bit (Turbo2) is an explicit non-goal of epic #458.
+    // "turbo2" is intentionally not a recognised alias — is the
+    // 3-bit mode, and 2-bit (Turbo2) is an explicit non-goal.
     let r: Result<KVCacheMode, _> = "turbo2".parse();
     assert!(r.is_err());
     let err = r.unwrap_err();
@@ -293,7 +293,7 @@ fn turbo4_asym_clone_handle_clears_turbo_params_on_source() {
     let _handle = cache.clone_handle();
 
     // Source cache must have turbo_params cleared after clone_handle so a
-    // fresh sequence can start with a clean slate (LOW-1 fix, #474).
+    // fresh sequence can start with a clean slate (LOW-1 fix).
     assert!(
         cache.turbo_params.is_none(),
         "clone_handle must clear turbo_params on source (LOW-1)"
@@ -495,7 +495,7 @@ fn turbo4_asym_nbytes_includes_v_sidecars_and_excludes_values() {
 }
 
 // ---------------------------------------------------------------------------
-// RotatingKVCache + Turbo4Asym (B9, issue #481)
+// RotatingKVCache + Turbo4Asym (B9)
 // ---------------------------------------------------------------------------
 
 /// Constructor must reject non-32-aligned `max_size` for `Turbo4Asym`.
@@ -843,7 +843,7 @@ fn rotating_turbo4_clone_handle_clears_turbo_params_on_source() {
 }
 
 // ---------------------------------------------------------------------------
-// Boundary-V (B6, issue #478) integration tests
+// Boundary-V (B6) integration tests
 // ---------------------------------------------------------------------------
 //
 // These integration tests cover the cache-side behavior of the boundary
@@ -1167,7 +1167,7 @@ fn turbo4_dequant_sdpa_matches_full_dequant_attention() {
 }
 
 // ===========================================================================
-// Turbo3Asym (issue #477, epic #458) — 3-bit V-side PolarQuant
+// Turbo3Asym — 3-bit V-side PolarQuant
 // ===========================================================================
 
 // ---------------------------------------------------------------------------
@@ -1330,7 +1330,7 @@ fn turbo3_asym_trim_to_zero_clears_all_buffers_and_params() {
     assert!(cache.v_packed.is_none());
     assert!(cache.v_norms.is_none());
     // turbo3_params must be cleared so the slot can be reused with a
-    // different head_dim (mirrors the LOW-1 fix from #474 for the 4-bit path).
+    // different head_dim (mirrors the LOW-1 fix for the 4-bit path).
     assert!(cache.turbo3_params.is_none());
 }
 
@@ -1683,12 +1683,12 @@ fn turbo3_asym_layer_modes_apply_boundary_upgrade() {
 // Turbo4Delegated decode helpers
 // ---------------------------------------------------------------------------
 //
-// The PR-#525 cold-V dequant memo tests that previously lived here were
-// retired by issue #528 — the fused dequant + SDPA Metal kernel reads packed
+// The earlier cold-V dequant memo tests that previously lived here were
+// retired — the fused dequant + SDPA Metal kernel reads packed
 // cold V directly so there is no host-side memo state to verify. The two
-// helpers below are still used by the issue #527 unified-K tests further
+// helpers below are still used by the unified-K tests further
 // down (`delegated_unified_k_*`, `delegated_nbytes_no_cold_k_buffer_after_fold`)
-// and the issue #528 fused-kernel parity test.
+// and the fused-kernel parity test.
 
 /// Build a Turbo4Delegated cache with a small hot threshold so folds are
 /// triggered after a handful of decode steps. The threshold is rounded up to
@@ -1715,10 +1715,10 @@ fn delegated_decode_run(cache: &mut KVCache, head_dim: i32, prefill_len: i32, de
 }
 
 // ---------------------------------------------------------------------------
-// Turbo4Delegated unified-K storage (issue #527)
+// Turbo4Delegated unified-K storage
 // ---------------------------------------------------------------------------
 //
-// Issue #527 unifies the K side of `KVCacheMode::Turbo4Delegated` into a
+// unifies the K side of `KVCacheMode::Turbo4Delegated` into a
 // single growing FP16 buffer (same shape contract as `KVCacheMode::Fp16`),
 // dropping the cold/hot split for K. These tests verify:
 // 1. `keys` is a single buffer that holds all `offset` tokens after folds.
@@ -1731,7 +1731,7 @@ fn delegated_decode_run(cache: &mut KVCache, head_dim: i32, prefill_len: i32, de
 /// After enough decode steps to trigger at least one fold, the unified `keys`
 /// buffer must hold all `offset` tokens (i.e. its shape's seq dim is at least
 /// `offset`) and SDPA-visible K from `update_and_fetch` must be the FP16
-/// slice `[0..offset]` — no separate cold-K buffer should exist (issue #527).
+/// slice `[0..offset]` — no separate cold-K buffer should exist.
 #[test]
 fn delegated_unified_k_buffer_grows_with_offset() {
     let head_dim = 64;
@@ -1748,7 +1748,7 @@ fn delegated_unified_k_buffer_grows_with_offset() {
 
     // The unified K buffer must hold at least `offset` tokens (capacity may
     // be rounded up to step). There must be no separate cold-K buffer
-    // (issue #527 removed the field).
+    // (removed the field).
     let keys = cache
         .keys
         .as_ref()
@@ -1772,7 +1772,7 @@ fn delegated_unified_k_buffer_grows_with_offset() {
     assert_eq!(
         k_out_shape,
         vec![1_i32, 1, total_offset + 1, head_dim],
-        "fetched K shape must be [B, H, offset, K_dim] (no cold/hot concat, issue #527)"
+        "fetched K shape must be [B, H, offset, K_dim] (no cold/hot concat)"
     );
     assert_eq!(
         ffi::array_dtype(&k_out),
@@ -1783,7 +1783,7 @@ fn delegated_unified_k_buffer_grows_with_offset() {
 
 /// `clone_handle` / `install_detached` must round-trip the unified K buffer
 /// bit-identically when the source has been through at least one fold
-/// (issue #527).  A subsequent decode step on the installed target must
+/// A subsequent decode step on the installed target must
 /// produce a K slice equal to the same step on the source before detach.
 #[test]
 fn delegated_clone_handle_preserves_unified_k_data() {
@@ -1859,7 +1859,7 @@ fn delegated_clone_handle_preserves_unified_k_data() {
 /// both caches perform, not a delegated-mode approximation).  V is
 /// *not* expected to match — V is still compressed in the delegated mode
 /// via `quantize_v_turbo4` and has bounded reconstruction error.
-/// Issue #527 unifies the K storage so that `Turbo4Delegated` uses the
+/// unifies the K storage so that `Turbo4Delegated` uses the
 /// same single growing FP16 buffer as `Fp16`, eliminating the per-step
 /// K concat entirely.
 #[test]
@@ -2213,9 +2213,8 @@ fn delegated_fp16_fast_path_survives_detach_adopt() {
 }
 
 /// `nbytes()` after a fold must reflect a single unified K buffer, not a
-/// hot ring + a separate cold K buffer (issue #527 removes the cold-K
-/// allocation).  V-side accounting (packed sidecars + dequant memo) must
-/// be unchanged from PR #525's contract.
+/// hot ring + a separate cold K buffer (removes the cold-K allocation).  V-side accounting (packed sidecars + dequant memo) must
+/// be unchanged's contract.
 #[test]
 fn delegated_nbytes_no_cold_k_buffer_after_fold() {
     let head_dim = 64;
@@ -2255,7 +2254,7 @@ fn delegated_nbytes_no_cold_k_buffer_after_fold() {
         cache.v_rescale.is_some(),
         "v_rescale must exist after a fold"
     );
-    // Issue #528 retired the PR-#525 cold-V dequant memo, so there is no
+    // retired the earlier cold-V dequant memo, so there is no
     // memo field to assert here. The packed cold V is consumed directly by
     // the fused kernel (`update_and_turbo4_delegated_attention`) without
     // ever being expanded to FP16 in global memory.
@@ -2275,11 +2274,11 @@ fn max_abs_diff(a: &ffi::MlxArray, b: &ffi::MlxArray) -> f32 {
 }
 
 // ---------------------------------------------------------------------------
-// Turbo4Delegated fused kernel parity (issue #528)
+// Turbo4Delegated fused kernel parity
 // ---------------------------------------------------------------------------
 //
 // The fused dequant + SDPA kernel (`update_and_turbo4_delegated_attention`)
-// must produce attention output that is RMS-equivalent to the pre-#528 path
+// must produce attention output that is RMS-equivalent to the earlier path
 // (`update_and_fetch` + standard SDPA on the `concat(cold_v_dequant, hot_v)`
 // tensor). The contract is RMS < 5e-3 over 200 decode steps spanning at least
 // three folds, matching the `sparse_v_kernel_threshold_zero_matches_graph`
@@ -2605,12 +2604,11 @@ fn delegated_dequant_sdpa_matches_reference_attention() {
     );
 }
 
-/// Steel-envelope vs cold-only fused composition parity (issue #531).
+/// Steel-envelope vs cold-only fused composition parity.
 ///
 /// `update_and_turbo4_delegated_attention` first tries the steel-envelope
-/// kernel (issue #531, single Metal dispatch covering softmax, cold-V dequant,
-/// and hot-V accumulate). On the same hardware where the cold-only fused
-/// composition path (issue #528) already produces correct output, the
+/// kernel (single Metal dispatch covering softmax, cold-V dequant, and hot-V accumulate). On the same hardware where the cold-only fused
+/// composition path already produces correct output, the
 /// steel-envelope path must produce numerically equivalent output (within
 /// FP16 round-off) — both paths funnel through the same MLX softmax algebra
 /// and the same Turbo4 inverse rotation; the only difference is whether the
@@ -2636,10 +2634,9 @@ fn delegated_steel_envelope_matches_cold_only_fused_over_200_steps() {
     let scale = 1.0 / (head_dim as f32).sqrt();
 
     // Cache A: drives `update_and_turbo4_delegated_attention`, which prefers
-    // the steel-envelope kernel on macOS + power-of-2 head_dim (issue #531
-    // wiring in `cache::update_and_turbo4_delegated_attention`).
+    // the steel-envelope kernel on macOS + power-of-2 head_dim (wiring in `cache::update_and_turbo4_delegated_attention`).
     let mut cache_steel = build_delegated_cache_with_small_threshold(32);
-    // Cache B: drives the cold-only fused composition (issue #528) directly
+    // Cache B: drives the cold-only fused composition directly
     // by calling `attention_turbo4_delegated_fused` after `update`. Bypasses
     // the wrapper so the steel envelope is not selected.
     let mut cache_cold_only = build_delegated_cache_with_small_threshold(32);
@@ -2662,7 +2659,7 @@ fn delegated_steel_envelope_matches_cold_only_fused_over_200_steps() {
         let v_b = ffi::copy(&v_a);
         let q = synth_kv_tensor(1, 1, 1, head_dim, 9000 + step as u32);
 
-        // Steel-envelope path (default after issue #531).
+        // Steel-envelope path (default after).
         let q_for_steel = ffi::copy(&q);
         let out_steel =
             cache_steel.update_and_turbo4_delegated_attention(&q_for_steel, k_a, v_a, scale, None);
@@ -2795,7 +2792,7 @@ fn delegated_steel_envelope_matches_cold_only_fused_over_200_steps() {
     );
 }
 
-/// Steel-envelope grouped-attention + additive-mask parity (issue #531).
+/// Steel-envelope grouped-attention + additive-mask parity.
 ///
 /// The 200-step parity tests above use `Hkv = Hq = 1` (no grouping) and no
 /// additive mask. Production decode call sites in `models/llama3.rs` and
@@ -2943,7 +2940,7 @@ fn delegated_steel_envelope_grouped_attention_with_mask_parity() {
     );
 }
 
-/// Graph-fallback parity (issue #528 / PR #530 security review HIGH-1).
+/// Graph-fallback parity (security review HIGH-1).
 ///
 /// `update_and_turbo4_delegated_attention` must always produce a sane
 /// attention output, even when the fused Metal kernel cannot dispatch
@@ -3056,7 +3053,7 @@ fn delegated_graph_fallback_matches_reference_attention() {
 
 /// Per-token V byte budget: the V-side memory footprint must stay at the
 /// 4-bit packed form (D/2 bytes plus one fp16 norm + one fp16 rescale per
-/// cold token, plus 2 bytes per hot fp16 dim). Issue #528 retired the FP16
+/// cold token, plus 2 bytes per hot fp16 dim). retired the FP16
 /// `cold_v_dequant_cache` so the only working set above the packed form is
 /// the small hot ring; cold V never goes above D/2 bytes per token in
 /// global memory.
@@ -3145,7 +3142,7 @@ fn delegated_per_token_v_budget_after_issue_528() {
         cache.nbytes() < visible_buffer_sum + memo_size_if_reintroduced,
         "nbytes()={} would tolerate a re-introduced FP16 cold-V memo of \
          {} bytes (visible buffer sum = {}); any value at or above \
-         {} indicates a likely PR-#525 cold-V memo regression",
+         {} indicates a likely earlier cold-V memo regression",
         cache.nbytes(),
         memo_size_if_reintroduced,
         visible_buffer_sum,
@@ -3154,7 +3151,7 @@ fn delegated_per_token_v_budget_after_issue_528() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #544 regression — TurboQuant continuous batching, batch grow / shrink
+// regression — TurboQuant continuous batching, batch grow / shrink
 // mid-decode.
 //
 // These tests use real `KVCache::update_and_fetch` calls in `Turbo4Asym`
@@ -3162,7 +3159,7 @@ fn delegated_per_token_v_budget_after_issue_528() {
 // extend / filter shape transitions that would happen in the scheduler
 // when a sequence is admitted into or evicted from an active batch.
 //
-// The acceptance criterion in issue #544 is: the per-row decode output is
+// The acceptance criterion is: the per-row decode output is
 // equivalent (RMS within tolerance) to running the same prompts
 // sequentially. We approximate that at the unit-test level by asserting
 // that the dequantized V tensor returned by `update_and_fetch` for each
@@ -3224,7 +3221,7 @@ fn turbo4_asym_sequential_decode_trace(
     traces
 }
 
-/// Issue #544 acceptance criterion (unit-level): a continuous-batching
+/// acceptance criterion (unit-level): a continuous-batching
 /// scenario where the batch composition changes mid-decode produces decode
 /// output equivalent (RMS within tolerance) to running the same prompts
 /// sequentially.
@@ -3305,7 +3302,7 @@ fn turbo4_asym_continuous_batching_grow_shrink_matches_sequential() {
         assert_eq!(
             metadata.rope_offsets,
             vec![prompt_len_a + 1, prompt_len_b],
-            "batch grow must keep per-row offsets correct (issue #544)"
+            "batch grow must keep per-row offsets correct"
         );
         assert_eq!(metadata.kv_lens, vec![prompt_len_a + 2, prompt_len_b + 1]);
         metadata.assert_consistent().unwrap();

--- a/src/lib/mlxcel-core/src/drafter/dflash/attention.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/attention.rs
@@ -322,7 +322,7 @@ mod tests {
         DFlashAttention::from_weights(&weights, "self_attn", &cfg, 64, 4).unwrap()
     }
 
-    /// Acceptance pin (issue #635):
+    /// Acceptance pin:
     ///
     /// > `DFlashAttention`: with a fixed ctx and prop input and a synthetic
     /// > cache, the cache after `update_and_fetch` contains ONLY context K/V

--- a/src/lib/mlxcel-core/src/drafter/dflash/cache.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/cache.rs
@@ -27,7 +27,7 @@
 //! 2. The drafter's `update_and_fetch` writes ONLY context K/V into the
 //!    cache; proposal K/V is concatenated post-hoc in the attention
 //!    forward. Encoding this constraint in the alias' documentation is
-//!    load-bearing for #635 acceptance.
+//!    load-bearing acceptance.
 
 use crate::layers::KVCache;
 

--- a/src/lib/mlxcel-core/src/drafter/dflash/drafter.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/drafter.rs
@@ -22,7 +22,7 @@
 //!
 //! The fully end-to-end DFlash round loop (target prefill → capture
 //! hiddens → drafter `draft_block` → target verify → rollback) lands
-//! in epic-#633 sub-12 (#636). This file ships only what the trait
+//! in epic- sub-12. This file ships only what the trait
 //! surface needs today.
 
 use crate::cache::KVCache;
@@ -74,7 +74,7 @@ pub struct DFlashDrafter {
     caches: Vec<KVCache>,
 
     /// Records whether `bind` has been called at least once. The DFlash
-    /// round-loop driver in sub-12 (#636) reads this flag to confirm
+    /// round-loop driver in sub-12 reads this flag to confirm
     /// the drafter is wired before invoking `draft_block`.
     bound: bool,
 }
@@ -386,7 +386,7 @@ impl Drafter for DFlashDrafter {
         }
         let inputs = ffi::from_slice_i32(&block, &[batch_size as i32, block_size as i32]);
 
-        // The model's forward already handles [B, L] inputs (issue #635); the
+        // The model's forward already handles [B, L] inputs; the
         // returned logits are [B, L, vocab].
         let logits = self.model.forward(&inputs, target_hidden, &mut self.caches);
 
@@ -418,7 +418,7 @@ impl Drafter for DFlashDrafter {
 /// Stochastic uses `fused_sample` per position over the `[1, vocab]`
 /// slice for that position.
 ///
-/// Used by: `DFlashDrafter::draft_block_batched` (issue #637).
+/// Used by: `DFlashDrafter::draft_block_batched`.
 fn sample_block_per_position_batched(
     logits: &MlxArray,
     batch_size: usize,
@@ -445,7 +445,7 @@ fn sample_block_per_position_batched(
         // materialize all token ids with one contiguous host copy. The old
         // row-by-row implementation performed `(B * (K - 1))` slice/eval/item
         // synchronizations per round, which showed up as a dominant short-run
-        // Qwen3.5-4B overhead in issue #692.
+        // Qwen3.5-4B overhead.
         let masked_logits = ffi::slice(
             logits,
             &[0_i32, 1_i32, 0_i32],
@@ -513,7 +513,6 @@ fn sample_block_per_position(
         // positions in one op and copy all token ids at once. This removes
         // the per-position slice/eval/item synchronization loop that made the
         // Qwen3.5-4B DFlash path slower than baseline for short generations
-        // (issue #692).
         let masked_logits = ffi::slice(
             logits,
             &[0_i32, 1_i32, 0_i32],
@@ -557,7 +556,7 @@ fn sample_block_per_position(
 /// `draft_tokens = draft_model.draft_block(...); verify_input =
 /// mx.concatenate([bonus, draft_tokens], axis=1)` pipeline. Stochastic
 /// sampling falls back to the scalar helper because stochastic DFlash parity
-/// is outside the hot path optimized by issue #692.
+/// is outside the hot path optimized.
 fn sample_block_per_position_array(
     logits: &MlxArray,
     block_size: usize,

--- a/src/lib/mlxcel-core/src/drafter/dflash/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Qwen 3.5 DFlash drafter (issue #635).
+//! Qwen 3.5 DFlash drafter.
 //!
 //! ## What this module ports
 //!
@@ -43,7 +43,7 @@
 //!   the concatenation of the target's hidden states at
 //!   `target_layer_ids = [1, 8, 15, 22, 29]`, projected through `fc`
 //!   from `5 * hidden_size` down to `hidden_size`. This pipeline is fed
-//!   by the Qwen 3.5 target hooks that landed in #654/#634.
+//!   by the Qwen 3.5 target hooks that landed.
 //! - **Mask-token block.** `block = [bonus, mask_id, mask_id, ...,
 //!   mask_id]` of shape `[B, block_size]`. The drafter runs ONE forward
 //!   and samples per position from `logits[:, 1 - block_size:]` —
@@ -64,11 +64,10 @@ pub mod drafter;
 pub mod layer;
 pub mod mlp;
 pub mod model;
-/// DFlash speculative-decoding round-loop driver (issue #636 / epic #633
-/// sub-12). B=1 only; batched DFlash lives in [`round_loop_batched`].
+/// DFlash speculative-decoding round-loop driver (sub-12). B=1 only; batched DFlash lives in [`round_loop_batched`].
 pub mod round_loop;
 /// DFlash speculative-decoding round-loop driver, B > 1 with continuous
-/// batching and per-row GDN-aware rollback (issue #637 / epic #633 sub-13).
+/// batching and per-row GDN-aware rollback (sub-13).
 pub mod round_loop_batched;
 
 pub use attention::DFlashAttention;

--- a/src/lib/mlxcel-core/src/drafter/dflash/model.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/model.rs
@@ -566,7 +566,7 @@ mod tests {
 
     /// A self-contained DFlash checkpoint that *does* ship its own
     /// `embed_tokens.weight` must eager-load it — no tombstone, no
-    /// regression to the pre-#675 behavior.
+    /// regression to the earlier behavior.
     #[test]
     fn from_weights_eager_loads_when_embed_tokens_present() {
         let mut weights = tiny_weights_without_embed();

--- a/src/lib/mlxcel-core/src/drafter/dflash/round_loop.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/round_loop.rs
@@ -573,8 +573,8 @@ impl DFlashGenerator {
     ///   round** (not per token) at the top of the round loop; when set,
     ///   the loop returns early with whatever tokens it has already
     ///   emitted. The server-side burst path passes `&seq.cancelled` so
-    ///   a client disconnect mid-burst stops occupying the worker thread
-    /// The offline CLI path passes
+    ///   a client disconnect mid-burst stops occupying the worker thread.
+    ///   The offline CLI path passes
     ///   `&AtomicBool::new(false)`.
     /// - `logprobs_config` — per-token log-probability capture control.
     ///   When [`LogprobsConfig::enabled`] is false the returned

--- a/src/lib/mlxcel-core/src/drafter/dflash/round_loop.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/round_loop.rs
@@ -16,7 +16,7 @@
 //!
 //! Rust port of upstream
 //! `references/mlx-vlm/mlx_vlm/generate.py::_dflash_rounds`
-//! (`mlx-vlm` HEAD, lines 856–942). Issue #636 / epic #633 sub-12.
+//! (`mlx-vlm` HEAD, lines 856–942). sub-12.
 //!
 //! ## What this module does
 //!
@@ -39,12 +39,12 @@
 //!    trims both KV caches (attention layers) AND replays the GDN state
 //!    to the accepted position (linear-attention layers). This dual
 //!    rollback is what distinguishes DFlash from the Gemma 4 MTP path
-//!    (sub-6 / #629) and from the classic `SpeculativeGenerator`.
+//!    (sub-6) and from the classic `SpeculativeGenerator`.
 //!
 //! ## Scope
 //!
 //! **B=1 only.** The batched DFlash round loop (B>1) lands in sub-13
-//! (#637); this module deliberately omits the per-row tail-zeroing and
+//! this module deliberately omits the per-row tail-zeroing and
 //! continuous-batching plumbing that the upstream
 //! `_dflash_rounds_batch` carries.
 //!
@@ -57,9 +57,7 @@
 //! hooks the round loop needs (verify forward, rollback, accepted-prefix
 //! hidden slice, last-token sampling), with associated types for the
 //! target's cache slice (`Cache`) and verify-output (`VerifyOut`). The
-//! binary side implements this trait once on `Qwen35Model` (#634 lands
-//! the `forward_speculative` / `rollback_speculative_cache` methods that
-//! the impl wraps) and the round loop becomes target-agnostic.
+//! binary side implements this trait once on `Qwen35Model` (lands the `forward_speculative` / `rollback_speculative_cache` methods that the impl wraps) and the round loop becomes target-agnostic.
 //!
 //! ## Greedy parity gate
 //!
@@ -94,7 +92,7 @@ pub const DEFAULT_BLOCK_SIZE: u32 = 16;
 /// `config.mask_token_id` from its own loaded `DFlashConfig`. This
 /// constant exists so binary-side CLI plumbing can plumb an override
 /// through the same numeric path the round loop would honor on a future
-/// `--draft-mask-id` flag (sub-7 / #630).
+/// `--draft-mask-id` flag (sub-7).
 pub const DEFAULT_MASK_TOKEN_ID: i32 = 248_070;
 
 /// Trait the round loop calls into for the target side of speculative
@@ -222,7 +220,7 @@ pub trait SpeculativeTarget {
     ///
     /// For Qwen 3.5 this delegates directly to
     /// `Qwen35Model::rollback_speculative_cache(caches, verify_out.gdn_states, accepted, block_size)`,
-    /// which already supports a per-row `accepted` slice (issue #634).
+    /// which already supports a per-row `accepted` slice.
     ///
     /// The default implementation delegates to [`Self::rollback_partial`]
     /// when `accepted.len() == 1` so single-row targets don't need a
@@ -289,7 +287,7 @@ pub struct DFlashGenerator {
     /// its own `DFlashConfig::mask_token_id` directly; this field
     /// exists so a future CLI override can be plumbed through a single
     /// numeric path without touching the drafter signature. Stored here
-    /// because a `--draft-mask-id` flag (planned in sub-7 / #630) would
+    /// because a `--draft-mask-id` flag (planned in sub-7) would
     /// configure the generator, not the drafter, to keep the drafter
     /// itself stateless wrt round-loop runtime options.
     #[allow(dead_code)]
@@ -365,7 +363,7 @@ impl DFlashGenerator {
 
     /// Consume the generator and return the boxed drafter handle.
     ///
-    /// Used by the server-side speculative burst path (issue #670) so a
+    /// Used by the server-side speculative burst path so a
     /// loaded drafter can be reused across multiple requests on the same
     /// worker thread without re-loading from disk. The caller is
     /// expected to [`Drafter::reset`] the returned handle before the
@@ -461,7 +459,7 @@ pub struct DFlashRunOutput {
     /// path forwards this (prepended with the first bonus's logprob,
     /// which the caller computes) to `finalize_burst_success` so
     /// speculative responses carry the same `TokenWithLogprobs` payload
-    /// as the classic decode path (issue #678).
+    /// as the classic decode path.
     pub logprobs: Vec<Option<crate::sampling::TokenLogprobData>>,
     /// Per-round accept counts for diagnostic logging and tests.
     pub accept_lens: Vec<u32>,
@@ -469,7 +467,7 @@ pub struct DFlashRunOutput {
     /// responsibility (the loop runs after prefill).
     pub stats: GenerationStats,
     /// Acceptance counters and per-phase timings for real-model
-    /// performance diagnosis (issue #692).
+    /// performance diagnosis.
     pub diagnostics: DFlashDiagnostics,
 }
 
@@ -576,7 +574,7 @@ impl DFlashGenerator {
     ///   the loop returns early with whatever tokens it has already
     ///   emitted. The server-side burst path passes `&seq.cancelled` so
     ///   a client disconnect mid-burst stops occupying the worker thread
-    ///   (issue #672). The offline CLI path passes
+    /// The offline CLI path passes
     ///   `&AtomicBool::new(false)`.
     /// - `logprobs_config` — per-token log-probability capture control.
     ///   When [`LogprobsConfig::enabled`] is false the returned
@@ -586,8 +584,7 @@ impl DFlashGenerator {
     ///   The round loop is greedy-only today, so the per-position logits
     ///   ARE the penalty-adjusted logits the classic decode path feeds
     ///   `compute_logprobs` — making the resulting logprobs
-    ///   byte-identical to the classic path for greedy sampling (issue
-    ///   #678).
+    ///   byte-identical to the classic path for greedy sampling.
     ///
     /// # Returns
     ///
@@ -681,7 +678,7 @@ impl DFlashGenerator {
             // disconnect mid-burst the server flips `seq.cancelled` and
             // this loop bails out with the tokens emitted so far rather
             // than running the full `max_tokens` budget and
-            // head-of-line-blocking the next request (issue #672).
+            // head-of-line-blocking the next request.
             if cancel.load(Ordering::Relaxed) {
                 break;
             }
@@ -728,7 +725,7 @@ impl DFlashGenerator {
 
             // ---- Argmax sample of target's per-position logits ----
             // Greedy at temp=0.0 / top_k=1 — the only mode this sub-issue
-            // gates parity on. Stochastic sampling for DFlash is sub-9 / #632.
+            // gates parity on. Stochastic sampling for DFlash is sub-9.
             let verify_logits = target.verify_logits(&verify_out);
             let phase_start = Instant::now();
             let target_tokens_arr = argmax_logits_to_array(verify_logits, bs as i32);
@@ -765,7 +762,7 @@ impl DFlashGenerator {
             // loop ⇒ the per-position verify logits ARE the
             // penalty-adjusted logits the classic decode path feeds
             // `compute_logprobs`, so these logprobs are byte-identical
-            // to the classic path for greedy sampling (issue #678).
+            // to the classic path for greedy sampling.
             let phase_start = Instant::now();
             let target_logprobs =
                 per_position_logprobs(verify_logits, &target_tokens, logprobs_config);
@@ -795,7 +792,7 @@ impl DFlashGenerator {
             // for every `i` (accepted draft tokens matched the target by
             // construction; the final entry is the target's bonus), so
             // `target_logprobs[i]` is the correct log-probability for
-            // `new_tokens[i]` (issue #678).
+            // `new_tokens[i]`.
             let mut hit_eos = false;
             for (i, tok) in new_tokens.iter().enumerate() {
                 self.generated_tokens.push(*tok);
@@ -912,7 +909,7 @@ impl DFlashGenerator {
 ///
 /// Equivalent to upstream `sampler(verify_out.logits)` with the greedy
 /// `sampler = argmax(axis=-1)`. Stochastic samplers are out of scope
-/// for this sub-issue (sub-9 / #632 covers stochastic DFlash parity).
+/// for this sub-issue (sub-9 covers stochastic DFlash parity).
 fn argmax_logits_to_array(logits: &MlxArray, seq_len: i32) -> UniquePtr<MlxArray> {
     let shape = ffi::array_shape(logits);
     debug_assert!(shape.len() == 3, "expected [1, seq_len, vocab] logits");
@@ -945,7 +942,7 @@ fn materialize_draft_and_target_tokens(
 
 /// Compute per-position [`crate::sampling::TokenLogprobData`] for a
 /// `[1, seq_len, vocab]` verify-logits tensor, one entry per position
-/// aligned 1:1 with `target_tokens` (issue #678).
+/// aligned 1:1 with `target_tokens`.
 ///
 /// The DFlash round loop is greedy-only today (`temperature == 0`, pure
 /// argmax — see [`argmax_logits_to_array`]), so the per-position verify
@@ -1626,7 +1623,7 @@ mod tests {
     }
 
     /// Pins the expected accept-len progression for 3 rounds at
-    /// block_size = 8 (the issue #636 acceptance criterion).
+    /// block_size = 8 (the acceptance criterion).
     #[test]
     fn round_loop_accept_lens_progress_pins_three_rounds_at_block_size_8() {
         // Round 1: drafter matches the first 1 position (accept 1).

--- a/src/lib/mlxcel-core/src/drafter/dflash/round_loop_batched.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/round_loop_batched.rs
@@ -17,13 +17,13 @@
 //!
 //! Rust port of upstream
 //! `references/mlx-vlm/mlx_vlm/generate.py::_dflash_rounds_batch`
-//! (`mlx-vlm` HEAD, lines 944-1098). Issue #637 / epic #633 sub-13.
+//! (`mlx-vlm` HEAD, lines 944-1098). sub-13.
 //!
 //! ## Scope
 //!
 //! **B >= 1, with continuous batching and per-row GDN-aware rollback.**
 //! The B = 1 fast path lives in the sibling
-//! [`crate::drafter::dflash::round_loop`] module (issue #636 / sub-12)
+//! [`crate::drafter::dflash::round_loop`] module (sub-12)
 //! and must NOT regress as a result of this implementation. The two
 //! drivers share the [`SpeculativeTarget`] trait and the
 //! [`speculative_walk`] helper; everything else is duplicated to keep
@@ -164,7 +164,7 @@ pub(crate) fn speculative_walk_batched(
 ///
 /// Mirrors upstream `sampler(verify_out.logits)` with the greedy
 /// `sampler = argmax(axis=-1)` — stochastic batched DFlash sampling is
-/// a follow-up (#632).
+/// a follow-up.
 fn argmax_logits_per_row(logits: &MlxArray, batch_size: i32, seq_len: i32) -> Vec<Vec<i32>> {
     let shape = ffi::array_shape(logits);
     debug_assert_eq!(shape.len(), 3, "expected [B, seq_len, vocab] logits");
@@ -267,8 +267,7 @@ impl DFlashBatchedGenerator {
 
     /// Consume the generator and return the boxed drafter handle.
     ///
-    /// Used by the server-side batched speculative burst path (issue
-    /// #674) so a loaded drafter can be reused across multiple batched
+    /// Used by the server-side batched speculative burst path so a loaded drafter can be reused across multiple batched
     /// bursts on the same worker thread without re-loading from disk.
     /// Mirrors [`super::round_loop::DFlashGenerator::into_drafter`] for
     /// the B > 1 driver.

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
@@ -136,7 +136,7 @@ impl DraftInner {
 /// `"sliding_attention"`). This matches the upstream Python dict layout
 /// `shared_kv_states[layer_type] = (K, V)`.
 ///
-/// Until issue #625 finalises the shape of `SharedKv::tensors`, this struct
+/// Until finalises the shape of `SharedKv::tensors`, this struct
 /// expects the tensor order `[k_full, v_full, k_swa, v_swa]` documented on
 /// [`SharedKv`].
 struct OwnedSharedKv {
@@ -650,7 +650,7 @@ impl Gemma4AssistantDraftModel {
         // The current `LanguageModel` trait does not expose `layer_types`
         // so the drafter falls back to the drafter's own text_config
         // layer_types (which mirror the target by construction on all four
-        // supported pairings). When #629 wires a richer round-loop API,
+        // supported pairings). When wires a richer round-loop API,
         // pass the target's actual layer_types in here.
         self.config.target_layer_types = self.config.text_config().layer_types.clone();
 
@@ -834,7 +834,7 @@ impl Drafter for Gemma4AssistantDraftModel {
         position: usize,
         left_padding: usize,
     ) -> Result<(), DrafterError> {
-        // Per issue #631 (batched MTP): when the round-loop is running B > 1
+        // (batched MTP): when the round-loop is running B > 1
         // with left-padded shared K/V, the drafter normalizes each row so
         // the cross-attention forward sees the simpler invariant: each
         // row's real keys occupy `[0, kv_valid_len)` and the tail is
@@ -952,7 +952,7 @@ impl Drafter for Gemma4AssistantDraftModel {
         block_size: usize,
         sampler: &SamplingConfig,
     ) -> Result<Vec<Vec<i32>>, DrafterError> {
-        // Batched autoregressive draft (issue #631). Performs `K-1` small
+        // Batched autoregressive draft. Performs `K-1` small
         // forwards with `[B, 1, ...]` shapes, sampling one token per row
         // each step. Mirrors the B = 1 path in [`Self::draft_block`] but
         // keeps the batch dim throughout.

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/tests.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/tests.rs
@@ -432,12 +432,12 @@ fn bind_rejects_target_without_embed_tokens_override() {
     }
 }
 
-// ── Centroid LM head (MaskedEmbedder, issue #627) ───────────────────────
+// ── Centroid LM head (MaskedEmbedder) ───────────────────────
 
 #[test]
 fn bind_accepts_centroid_lm_head_via_masked_embedder() {
     // E2B / E4B drafters: `use_ordered_embeddings=true` selects the centroid
-    // (MaskedEmbedder) LM head. With #627 and #628 merged, this path must
+    // (MaskedEmbedder) LM head. With and merged, this path must
     // now succeed — `bind()` constructs the real `MaskedEmbedder` from the
     // pre-built centroid head and sets `lm_head = Some(LmHead::Centroid(...))`.
     let mut cfg = make_test_config(2, true);
@@ -450,7 +450,7 @@ fn bind_accepts_centroid_lm_head_via_masked_embedder() {
     let target = MockLanguageModel::new(16, 64);
     model
         .bind(&target)
-        .expect("bind must succeed when MaskedEmbedder is wired in (#627)");
+        .expect("bind must succeed when MaskedEmbedder is wired in");
 }
 
 /// Full E-series Centroid path: `bind` → `set_shared_kv` → `draft_block`.
@@ -584,7 +584,7 @@ fn gemma4_assistant_drafter_is_object_safe_via_box_dyn() {
     assert_eq!(boxed.kind(), DrafterKind::Mtp);
 }
 
-// ── Batched draft path (issue #631) ──────────────────────────────────────
+// ── Batched draft path ──────────────────────────────────────
 
 /// `draft_block_batched` produces `B` rows of `block_size - 1` proposals
 /// each. Pins the shape contract.
@@ -696,7 +696,7 @@ fn draft_block_batched_rejects_call_before_set_shared_kv() {
 }
 
 /// `set_shared_kv` with `left_padding > 0` routes through the masks
-/// normalizer (issue #631). Pins the path: drafter accepts the call
+/// normalizer. Pins the path: drafter accepts the call
 /// without trying to forward through invalid shared K/V buffers.
 #[test]
 fn set_shared_kv_with_left_padding_routes_through_normalizer() {

--- a/src/lib/mlxcel-core/src/drafter/masked_embedder.rs
+++ b/src/lib/mlxcel-core/src/drafter/masked_embedder.rs
@@ -80,7 +80,7 @@ pub const DEFAULT_TOP_K: usize = 32;
 /// Weight key under which the centroid token ordering is stored in the
 /// assistant drafter checkpoint. Exposed as a constant so the
 /// [`sanitize_token_ordering`] hook and the `Gemma4AssistantDraftModel`
-/// (sub-3 / #626) can refer to the same name without drift.
+/// (sub-3) can refer to the same name without drift.
 pub const TOKEN_ORDERING_KEY: &str = "masked_embedding.token_ordering";
 
 /// Centroid-routed sparse softmax LM head.
@@ -249,8 +249,7 @@ impl MaskedEmbedder {
     /// - `hidden_states`: `[B, L, hidden_size]` in the model's native dtype
     ///   (bf16 or f16 on Apple Silicon).
     /// - `lm_head_weight`: `[vocab_size, hidden_size]`. Tied to the drafter's
-    ///   `embed_tokens.weight` by the caller (see `Gemma4AssistantDraftModel`
-    ///   in sub-3 / #626).
+    ///   `embed_tokens.weight` by the caller (see `Gemma4AssistantDraftModel` in sub-3).
     ///
     /// Returns `[B, L, vocab_size]` with the same dtype as `hidden_states`.
     /// Non-selected vocab positions are filled with `min(selected) - 1` so
@@ -780,7 +779,7 @@ mod tests {
 
     #[test]
     fn default_constants_match_canonical_gemma4_e2b_e4b_drafter() {
-        // Pins issue #627's canonical defaults (per Gemma4AssistantConfig:
+        // Pins's canonical defaults (per Gemma4AssistantConfig:
         // num_centroids=2048, centroid_intermediate_top_k=32). Changing
         // these in code without updating the README / config is a
         // regression source — this test fences that.

--- a/src/lib/mlxcel-core/src/drafter/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/mod.rs
@@ -1033,7 +1033,7 @@ mod tests {
                 assert!(!reason.is_empty(), "LoadFailed reason must not be empty");
             }
             DrafterError::NotYetImplemented { .. } => {
-                panic!("DFlash must NOT be NotYetImplemented after lands");
+                panic!("DFlash must NOT be NotYetImplemented after the drafter lands");
             }
             other => panic!("expected LoadFailed, got {other:?}"),
         }

--- a/src/lib/mlxcel-core/src/drafter/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Speculative drafter abstraction shared by both MTP and DFlash drafter
-//! families being ported from `mlx-vlm` (epic #633).
+//! families being ported from `mlx-vlm`.
 //!
 //! ## Why a trait?
 //!
@@ -36,8 +36,7 @@
 //!   trim.
 //!
 //! The [`Drafter`] trait defined here unifies these shapes behind a single
-//! interface so the round-loop drivers (sub-6 / #629 for MTP, sub-12 /
-//! #636 for DFlash) can drive any drafter uniformly. Each concrete drafter
+//! interface so the round-loop drivers (sub-6 for MTP, sub-12 for DFlash) can drive any drafter uniformly. Each concrete drafter
 //! overrides only the methods it actually needs and lets the trait's
 //! default no-ops cover the rest.
 //!
@@ -54,11 +53,11 @@
 //!
 //! The Rust port mirrors these constants and the [`resolve_drafter_kind`]
 //! reconciliation semantics exactly. A third variant
-//! [`DrafterKind::InternalMtp`] is added for the peer epic #647
-//! (Qwen 3.5 / 3.6 built-in MTP head) per the in-issue amendment on #624;
+//! [`DrafterKind::InternalMtp`] is added for the peer
+//! (Qwen 3.5 / 3.6 built-in MTP head) per the in-issue amendment on;
 //! see [`DrafterKind`] for details.
 //!
-//! ## Scope of this sub-issue (#624)
+//! ## Scope of this sub-issue
 //!
 //! This module ships **only** the trait, the kind enum, the auto-detector,
 //! and the [`load_drafter`] factory shell. The concrete drafter
@@ -66,9 +65,9 @@
 //!
 //! | Variant | Concrete impl | Wired by |
 //! |---------|---------------|----------|
-//! | [`DrafterKind::Mtp`] | `Gemma4AssistantDraftModel` | #626 |
-//! | [`DrafterKind::Dflash`] | `DFlashDraftModel` | #635 |
-//! | [`DrafterKind::InternalMtp`] | `InternalMtpDrafter` | #640 (epic #647) |
+//! | [`DrafterKind::Mtp`] | `Gemma4AssistantDraftModel` | |
+//! | [`DrafterKind::Dflash`] | `DFlashDraftModel` | |
+//! | [`DrafterKind::InternalMtp`] | `InternalMtpDrafter` | |
 //!
 //! Until those land, [`load_drafter`] returns a typed
 //! [`DrafterError::NotYetImplemented`] error pointing at the responsible
@@ -90,11 +89,11 @@ use std::sync::OnceLock;
 
 pub mod dflash;
 /// Concrete Gemma 4 MTP "assistant" drafter implementation. Wired into
-/// [`load_drafter`]'s `Mtp` arm in issue #626.
+/// [`load_drafter`]'s `Mtp` arm.
 pub mod gemma4_assistant;
 /// Centroid-routed sparse softmax LM head used by Gemma 4 E2B / E4B
 /// assistant drafters. Wired into `Gemma4AssistantDraftModel` in sub-3
-/// (#626) — landed here independently per issue #627 so the layer can
+/// — landed here independently so the layer can
 /// be unit-tested in isolation before integration.
 pub mod masked_embedder;
 
@@ -112,7 +111,7 @@ pub mod masked_embedder;
 ///   rollback).
 /// - `"internal-mtp"` — built-in MTP head carried by Qwen 3.5 / 3.6
 ///   checkpoints as `mtp.layers.0.*` weights; no separate drafter
-///   checkpoint required. Added for the peer epic #647.
+///   checkpoint required. Added for the peer.
 ///
 /// The enum is marked `#[non_exhaustive]` so adding new drafter shapes in
 /// follow-up epics does not break downstream `match` exhaustiveness
@@ -130,7 +129,7 @@ pub enum DrafterKind {
     Mtp,
     /// Built-in MTP head living inside the target checkpoint
     /// (`mtp.layers.0.*` weights on Qwen 3.5 / 3.6). Auto-detected by
-    /// checkpoint inspection in epic #647 sub-H (#645), not by drafter
+    /// checkpoint inspection sub-H, not by drafter
     /// `model_type`.
     InternalMtp,
 }
@@ -155,7 +154,7 @@ impl std::fmt::Display for DrafterKind {
 /// Parse a canonical drafter-kind name produced by [`DrafterKind::as_str`].
 ///
 /// Implemented via the standard [`std::str::FromStr`] trait so CLI flag
-/// parsing (sub-7 / #630) can use `"dflash".parse::<DrafterKind>()`
+/// parsing (sub-7) can use `"dflash".parse::<DrafterKind>()`
 /// directly. Returns [`DrafterError::UnknownKind`] when the string does
 /// not match any known variant.
 impl std::str::FromStr for DrafterKind {
@@ -178,7 +177,7 @@ impl std::str::FromStr for DrafterKind {
 /// build the "known kinds" hint in [`DrafterError::UnknownKind`].
 ///
 /// Mirrors upstream `KNOWN_DRAFTER_KINDS = {"dflash", "mtp"}` plus
-/// `"internal-mtp"` from the #624 amendment for peer epic #647.
+/// `"internal-mtp"` from the amendment for peer.
 pub const KNOWN_DRAFTER_KINDS: &[&str] = &["dflash", "mtp", "internal-mtp"];
 
 /// Default drafter kind selected when the drafter's `config.json` does not
@@ -247,7 +246,7 @@ pub enum DrafterError {
 
     /// Weight loading or model construction failed (missing key,
     /// quantization mismatch, etc.). Carries the underlying reason for
-    /// operator triage. Used by the DFlash drafter load path (#635).
+    /// operator triage. Used by the DFlash drafter load path.
     #[error("drafter load failed: {reason}")]
     LoadFailed { reason: String },
 
@@ -272,7 +271,7 @@ pub enum DrafterError {
     /// Failure while loading drafter weights (missing tensor, malformed
     /// safetensors, etc.). Used by the Gemma 4 assistant drafter
     /// [`Gemma4AssistantDraftModel::from_weights`](crate::drafter::gemma4_assistant::Gemma4AssistantDraftModel::from_weights)
-    /// path (#626). Sibling of [`Self::LoadFailed`], kept distinct so the
+    /// path. Sibling of [`Self::LoadFailed`], kept distinct so the
     /// two drafter families surface different operator hints.
     #[error("drafter weight load failed: {reason}")]
     WeightLoad { reason: String },
@@ -299,7 +298,7 @@ pub enum DrafterError {
 
     /// Drafter has a layer of the named layer-type but the round-loop did
     /// not supply matching shared K/V tensors. Typically means the target's
-    /// shared K/V capture (issue #625) and the drafter's `layer_types` field
+    /// shared K/V capture and the drafter's `layer_types` field
     /// are out of sync.
     #[error(
         "drafter layer needs shared K/V for layer_type {layer_type:?} but the round-loop \
@@ -452,7 +451,7 @@ pub fn resolve_drafter_kind(
 /// Borrowed (`&'a MlxArray`) rather than owned so the target retains
 /// ownership of its KV cache contents — the drafter is forbidden from
 /// mutating them in place. This is foundational scaffolding; the exact
-/// shape of the shared K/V transfer is finalised by sub-2 / #625 (Gemma 4
+/// shape of the shared K/V transfer is finalised by sub-2 (Gemma 4
 /// target-side speculative hooks). Until then, the slice carries the
 /// upstream `[k_full, v_full, k_swa, v_swa]` four-tensor convention
 /// (Gemma 4's last full-attention + last sliding-window-attention layer
@@ -461,7 +460,7 @@ pub fn resolve_drafter_kind(
 ///
 /// No-op for DFlash and InternalMtp (both have their own KV cache).
 pub struct SharedKv<'a> {
-    /// Borrowed shared K/V tensors from the target. Layout finalised by #625.
+    /// Borrowed shared K/V tensors from the target. Layout finalised.
     pub tensors: &'a [&'a MlxArray],
 }
 
@@ -700,7 +699,7 @@ pub trait Drafter {
     /// `out[r]` is the proposal sequence for row `r`, with length
     /// `block_size - 1` (DFlash) or `block_size` (MTP / InternalMtp).
     ///
-    /// **Issue #637 (DFlash B>1 path)**: implemented by `DFlashDrafter`.
+    /// ** (DFlash B>1 path)**: implemented by `DFlashDrafter`.
     /// MTP / InternalMtp drafters return [`DrafterError::DraftFailed`] by
     /// default — their batched paths land in their own respective sub-issues.
     ///
@@ -745,7 +744,7 @@ pub trait Drafter {
     ///   `references/mlx-lm/mlx_lm/models/qwen3_5.py:308-313`
     ///   (`weights.pop("lm_head.weight", None)` and friends).
     /// - **InternalMtp**: pass-through. The actual `mtp.*` extraction
-    ///   happens in epic #647 sub-B (#639) *before* the drafter sees
+    ///   happens sub-B *before* the drafter sees
     ///   the weight map.
     fn sanitize(&mut self, weights: &mut WeightMap) -> Result<(), DrafterError>;
 
@@ -766,11 +765,11 @@ pub type LoadedDrafter = (Box<dyn Drafter>, DrafterKind);
 /// Factory entrypoint: load a drafter from a model directory, reconciling
 /// the caller's optional `kind` with the drafter's `config.json`.
 ///
-/// The signature is final and downstream sub-issues (#626, #635, #640)
+/// The signature is final and downstream sub-issues
 /// fill in their concrete arms in this function. Until those arms land,
 /// each variant returns [`DrafterError::NotYetImplemented`] referencing
 /// the responsible sub-issue, so the round-loop driver and the CLI
-/// flag plumbing (sub-7 / #630) can wire against this signature today.
+/// flag plumbing (sub-7) can wire against this signature today.
 ///
 /// Auto-detection (`kind == None`) is delegated to
 /// [`resolve_drafter_kind`].
@@ -778,17 +777,17 @@ pub fn load_drafter(path: &Path, kind: Option<DrafterKind>) -> Result<LoadedDraf
     let resolved = resolve_drafter_kind(path, kind)?;
     match resolved {
         DrafterKind::Dflash => {
-            // Wired in by #635: load weights, sanitize, build the model,
+            // Wired in by load weights, sanitize, build the model,
             // hand back the boxed trait object.
             let drafter = dflash::drafter::DFlashDrafter::load(path)?;
             Ok((Box::new(drafter), resolved))
         }
         DrafterKind::Mtp => {
-            // Wired in by issue #626 — Gemma 4 MTP assistant drafter.
+            // Wired in — Gemma 4 MTP assistant drafter.
             let model = gemma4_assistant::Gemma4AssistantDraftModel::from_path(path)?;
             Ok((Box::new(model), resolved))
         }
-        // Remaining variant lands in peer epic #647 — returning a typed
+        // Remaining variant lands in peer — returning a typed
         // error rather than `unimplemented!()` here gives users an
         // actionable hint instead of a panic.
         DrafterKind::InternalMtp => Err(DrafterError::NotYetImplemented {
@@ -966,7 +965,7 @@ mod tests {
         // model_type == "gemma4_assistant" maps to Mtp, but the caller
         // explicitly asked for DFlash. Resolver MUST honor the explicit
         // choice (DFlash) and emit a `tracing::warn!` so the operator
-        // sees the mismatch. This pins the issue #624 acceptance
+        // sees the mismatch. This pins the acceptance
         // criterion verbatim: "when the caller passes
         // Some(DrafterKind::Dflash) but the model_type says
         // gemma4_assistant, the resolver returns Dflash and emits a
@@ -1021,8 +1020,7 @@ mod tests {
     fn load_drafter_dflash_fails_without_weights_with_typed_load_error() {
         // The stub `config.json` is present but no safetensors files
         // accompany it. `DFlashDrafter::load` must surface a typed
-        // `LoadFailed` (not `NotYetImplemented` — DFlash is wired in
-        // by #635). Pin this to make sure a future re-stub of the
+        // `LoadFailed` (not `NotYetImplemented` — DFlash is wired in). Pin this to make sure a future re-stub of the
         // `Dflash` arm cannot silently regress to `NotYetImplemented`.
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, None);
@@ -1035,7 +1033,7 @@ mod tests {
                 assert!(!reason.is_empty(), "LoadFailed reason must not be empty");
             }
             DrafterError::NotYetImplemented { .. } => {
-                panic!("DFlash must NOT be NotYetImplemented after #635 lands");
+                panic!("DFlash must NOT be NotYetImplemented after lands");
             }
             other => panic!("expected LoadFailed, got {other:?}"),
         }
@@ -1043,7 +1041,7 @@ mod tests {
 
     #[test]
     fn load_drafter_routes_mtp_to_gemma4_assistant() {
-        // The Mtp arm is wired by issue #626. With a fixture that has the
+        // The Mtp arm is wired. With a fixture that has the
         // gemma4_assistant `model_type` but no full text_config, the
         // factory should reach into Gemma4AssistantDraftModel::from_path
         // and fail at config parsing (no text_config) rather than the
@@ -1055,7 +1053,7 @@ mod tests {
         match err {
             DrafterError::NotYetImplemented { .. } => panic!(
                 "Mtp arm should no longer return NotYetImplemented; \
-                 issue #626 wired the concrete loader"
+ wired the concrete loader"
             ),
             DrafterError::ConfigParse { .. } | DrafterError::Config(_) => {
                 // Expected: factory got past the stub gate and into the
@@ -1087,7 +1085,7 @@ mod tests {
     /// adds a generic method or a Self-by-value method, this will fail
     /// to compile and fence the regression at the trait boundary
     /// instead of at every call site. This is the foundational
-    /// invariant the rest of epic #633 depends on.
+    /// invariant the rest depends on.
     #[test]
     fn drafter_trait_is_object_safe() {
         struct StubDrafter;

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -101,7 +101,7 @@ fn test_fast_rope_batched_matches_per_sequence_offsets() {
     assert!(item_bool(&close));
 }
 
-/// Uniform-batch fast path (issue #556 / mlx-vlm PR #1055): when every
+/// Uniform-batch fast path (mlx-vlm PR #1055): when every
 /// row shares the same RoPE offset, `fast_rope_batched` collapses to a
 /// single full-batch `fast_rope` call. The collapsed result must be
 /// bit-equivalent (within float tolerance) to the per-row slice / concat
@@ -837,7 +837,7 @@ fn test_compiled_gelu_topk_preserves_bf16_and_f16_dtype() {
 #[test]
 fn test_gelu_approx_bf16_negative_values() {
     // Verify gelu_approx does not produce NaN for negative bf16 inputs.
-    // This was the root cause of issue #174: Gemma3 VLM 0-token generation.
+    // This was the root cause of Gemma3 VLM 0-token generation.
     let x_f32 = from_slice_f32(&[-10.0, -5.0, -1.0, 0.0, 1.0, 5.0, 10.0], &[1, 7]);
     let x_bf16 = astype(&x_f32, crate::dtype::BFLOAT16);
 
@@ -1178,7 +1178,7 @@ fn bench_compiled_vs_uncompiled_swiglu() {
     }
 }
 
-/// Regression test for issue #323: conv_input cache slice must be contiguous.
+/// Regression test for conv_input cache slice must be contiguous.
 ///
 /// MLX's `slice()` returns a lazy view that retains a reference to the source
 /// array in the computation graph (`{a}` input). Without wrapping the slice
@@ -1279,7 +1279,7 @@ fn test_conv_state_slice_is_contiguous_after_fix() {
 }
 
 // =================================================================================
-// Walsh–Hadamard Transform (WHT) tests for issue #470 / epic #458 (TurboQuant).
+// Walsh–Hadamard Transform (WHT) tests (TurboQuant).
 //
 // The MLX `hadamard_transform` op (bridged in lib.rs:1645 and wrapped as
 // `mlxcel_core::wht` in ops.rs) is the foundational primitive for the

--- a/src/lib/mlxcel-core/src/generate.rs
+++ b/src/lib/mlxcel-core/src/generate.rs
@@ -641,7 +641,7 @@ pub struct CxxGenerator {
     /// This keeps dispatch and synchronization paired even if the
     /// generator is constructed on one thread (e.g. the request
     /// dispatcher) and run on another (e.g. the model worker), per
-    /// upstream `mlx-vlm` PR #1050 / mlxcel issue #556.
+    /// upstream `mlx-vlm` PR #1050 / mlxcel.
     generation_stream: Option<UniquePtr<MlxThreadLocalStream>>,
     /// KV cache quantization mode applied to all layer caches.
     /// Default: `KVCacheMode::Fp16` (no quantization).
@@ -656,7 +656,7 @@ pub struct CxxGenerator {
     /// language steering pay no per-token or per-call cost (see
     /// [`Self::compose_sampling`]).
     ///
-    /// Axis B / Epic #362: populated by B8 wiring for the CLI `generate`
+    /// Axis B / populated by B8 wiring for the CLI `generate`
     /// path; the server batch scheduler caches its own copy on `BatchScheduler`.
     token_bias: TokenBiasMap,
 }
@@ -679,7 +679,7 @@ impl CxxGenerator {
     /// small per-token quantization error.
     ///
     /// When `kv_cache_mode` is one of the `Turbo4*` variants, the
-    /// **Boundary-V** policy (B6, issue #478, epic #458) is applied: the
+    /// **Boundary-V** policy (B6) is applied: the
     /// first / last N transformer layers' caches are upgraded to
     /// `KVCacheMode::Fp16` to recover the per-layer V-quantization quality
     /// gap measured in `references/turboquant_plus/docs/papers/
@@ -778,7 +778,7 @@ impl CxxGenerator {
     /// Must call `reset_with_model` instead when the model uses internal caches
     /// (e.g. Gemma3, Jamba, Mamba, NemotronH, etc.) to ensure those are also reset.
     ///
-    /// Preserves the per-layer Boundary-V mode mapping (issue #478, epic #458)
+    /// Preserves the per-layer Boundary-V mode mapping
     /// computed at construction time: each layer's pre-existing
     /// `KVCacheMode` (which may differ from `self.kv_cache_mode` for
     /// boundary layers) is reused so quality protection survives a reset.
@@ -801,7 +801,7 @@ impl CxxGenerator {
     /// single-row caches are cleared.
     /// The kv_cache_mode is applied to the freshly created caches.
     ///
-    /// Honors the Boundary-V policy (issue #478): when `self.kv_cache_mode`
+    /// Honors the Boundary-V policy: when `self.kv_cache_mode`
     /// is one of the `Turbo4*` variants, the first / last N caches are
     /// re-resolved to `KVCacheMode::Fp16` instead of the nominal mode.
     /// The boundary count is read from `MLXCEL_KV_BOUNDARY_V_LAYERS` so a
@@ -826,7 +826,7 @@ impl CxxGenerator {
     /// Called from each generation entry point right after `ensure_model_caches`
     /// rebuilds caches from `model.make_caches()` (which always uses the
     /// default Fp16 mode). Centralizes the per-layer mode resolution so the
-    /// Boundary-V policy (issue #478) survives the entire generation lifecycle
+    /// Boundary-V policy survives the entire generation lifecycle
     /// including `reset_with_model` boundary cases.
     ///
     /// No-op when `self.kv_cache_mode == Fp16` — every layer is already FP16
@@ -890,7 +890,7 @@ impl CxxGenerator {
         // (which always uses the default Fp16 mode), so re-apply kv_cache_mode
         // afterwards when a non-default mode is configured.
         ensure_model_caches(&mut self.caches, model);
-        // Honor the Boundary-V policy (issue #478) when applying the
+        // Honor the Boundary-V policy when applying the
         // nominal mode to per-layer caches: the first/last N layers stay
         // at FP16 to recover the V-quantization quality gap.
         self.apply_kv_cache_mode_with_boundary_policy();
@@ -1172,7 +1172,7 @@ impl CxxGenerator {
 
         ensure_model_caches(&mut self.caches, model);
         // Re-apply kv_cache_mode in case ensure_model_caches rebuilt caches
-        // Honor the Boundary-V policy (issue #478) when applying the
+        // Honor the Boundary-V policy when applying the
         // nominal mode to per-layer caches: the first/last N layers stay
         // at FP16 to recover the V-quantization quality gap.
         self.apply_kv_cache_mode_with_boundary_policy();
@@ -1317,7 +1317,7 @@ impl CxxGenerator {
         seed_rng_if_needed(sampling);
         ensure_model_caches(&mut self.caches, model);
         // Re-apply kv_cache_mode in case ensure_model_caches rebuilt caches
-        // Honor the Boundary-V policy (issue #478) when applying the
+        // Honor the Boundary-V policy when applying the
         // nominal mode to per-layer caches: the first/last N layers stay
         // at FP16 to recover the V-quantization quality gap.
         self.apply_kv_cache_mode_with_boundary_policy();
@@ -1470,7 +1470,7 @@ impl CxxGenerator {
         // Ensure caches are initialized for this model.
         // Re-apply kv_cache_mode in case ensure_model_caches rebuilt caches.
         ensure_model_caches(&mut self.caches, model);
-        // Honor the Boundary-V policy (issue #478) when applying the
+        // Honor the Boundary-V policy when applying the
         // nominal mode to per-layer caches: the first/last N layers stay
         // at FP16 to recover the V-quantization quality gap.
         self.apply_kv_cache_mode_with_boundary_policy();
@@ -1613,8 +1613,7 @@ impl CxxGenerator {
     /// Returns `Vec<f32>` of length `prompt_tokens.len() - 1`, where entry `i`
     /// is `log P(prompt_tokens[i + 1] | prompt_tokens[..=i])` under the model.
     ///
-    /// This is the building block for offline perplexity evaluation (epic
-    /// #458 / issue #475 — the wikitext-2 PPL gate). Callers chunk the corpus
+    /// This is the building block for offline perplexity evaluation (— the wikitext-2 PPL gate). Callers chunk the corpus
     /// into windows of length `≤ context_len` and accumulate `-sum(logprobs) /
     /// total_target_tokens` across windows; `exp(mean_nll)` is the perplexity.
     ///
@@ -1631,10 +1630,10 @@ impl CxxGenerator {
     /// One forward pass over the entire `prompt_tokens` window, plus an
     /// `O(seq_len * vocab)` log-softmax + gather. Suitable for tractable
     /// window sizes (≤ 4 K) and small models. For larger contexts, batching
-    /// many independent windows would be a follow-up; epic #458's gate runs
+    /// many independent windows would be a follow-up;'s gate runs
     /// 20 windows × 4 K which fits in a single-pass-per-window budget on M-series.
     ///
-    /// Used by: `tests/turbo_kv_e2e.rs` wikitext-2 PPL harness (issue #475).
+    /// Used by: `tests/turbo_kv_e2e.rs` wikitext-2 PPL harness.
     pub fn evaluate_loglikelihoods<M: LanguageModel>(
         &mut self,
         model: &M,

--- a/src/lib/mlxcel-core/src/lang_analyzer/cache.rs
+++ b/src/lib/mlxcel-core/src/lang_analyzer/cache.rs
@@ -194,7 +194,7 @@ mod tests {
     // `mlxcel_core::test_support::env_lock`. Per-module locks would race
     // with env mutations in unrelated modules of the same test binary —
     // libc's env block has no internal lock and concurrent
-    // `setenv`/`getenv` is undefined behavior (issue #573).
+    // `setenv`/`getenv` is undefined behavior.
     use crate::test_support::env_lock::env_lock;
 
     // -----------------------------------------------------------------------
@@ -323,9 +323,9 @@ mod tests {
         );
     }
 
-    /// Issue #405 — a v2 cache file must auto-invalidate and rebuild to v3.
+    /// a v2 cache file must auto-invalidate and rebuild to v3.
     ///
-    /// Simulates a pre-#405 deployment: writes a cache file carrying the old
+    /// Simulates a earlier deployment: writes a cache file carrying the old
     /// `version = 2` tag and exercises `load_or_build` with `rebuild=false`.
     /// The old file must be discarded and a fresh v3 index written in its
     /// place. This is the key backward-compatibility guarantee for Phase 1

--- a/src/lib/mlxcel-core/src/lang_analyzer/mod.rs
+++ b/src/lib/mlxcel-core/src/lang_analyzer/mod.rs
@@ -226,7 +226,7 @@ use tokenizers::Tokenizer;
 /// - v2: classify via `decode` so byte-level BPE tokenizers (Qwen, GPT-2, LLaMA)
 ///   produce correct script assignments instead of defaulting every non-ASCII
 ///   token to Latin.
-/// - v3 (issue #405): adds optional byte-fragment classification for byte-level
+/// - v3: adds optional byte-fragment classification for byte-level
 ///   BPE tokenizers. Tokens that decode to `U+FFFD` (byte-fragment leaves) are
 ///   tagged via UTF-8 start-byte analysis and flagged with
 ///   [`TokenScriptInfo::is_byte_fragment`]. The index layout itself is
@@ -245,7 +245,7 @@ pub struct TokenScriptInfo {
     pub is_punctuation: bool,
     pub is_whitespace: bool,
     /// `true` when this token was classified via byte-fragment UTF-8 start-byte
-    /// analysis (issue #405), i.e. the decode path produced `U+FFFD` / empty
+    /// analysis, i.e. the decode path produced `U+FFFD` / empty
     /// and the token is a byte-level BPE leaf. Always `false` for tokens that
     /// classified via the Phase 1 decode path. Populated only when the vocab
     /// scan ran with byte-fragment analysis enabled; older v2 cache files lack
@@ -324,7 +324,7 @@ impl TokenLanguageIndex {
     ///    language filtering.
     /// 3. Classify using B2 helpers on the decoded string.
     /// 4. Set `is_special` from the tokenizer's added-tokens decoder.
-    /// 5. (Issue #405) If the tokenizer has a `ByteLevel` pre-tokenizer in its
+    /// 5. If the tokenizer has a `ByteLevel` pre-tokenizer in its
     ///    chain, run a second pass: for tokens that decoded to `U+FFFD` /
     ///    empty AND have no Phase 1 script, reverse-map the byte-level char
     ///    back to its raw byte and classify by UTF-8 start-byte range. See
@@ -378,7 +378,7 @@ impl TokenLanguageIndex {
             let mut is_punct = is_punctuation(&token_str);
             let is_ws = is_whitespace(&token_str);
 
-            // Issue #405 — byte-fragment second pass.
+            // byte-fragment second pass.
             //
             // Only runs when the tokenizer actually uses byte-level BPE and
             // when the Phase 1 decode path produced no script information.
@@ -445,7 +445,7 @@ impl TokenLanguageIndex {
 }
 
 // ============================================================================
-// Issue #405 — Byte-fragment CJK classification via UTF-8 start-byte analysis
+// Byte-fragment CJK classification via UTF-8 start-byte analysis
 // ============================================================================
 
 /// Return `true` if the tokenizer's pre-tokenizer chain contains a
@@ -552,7 +552,7 @@ fn reverse_byte_for_token(
 /// | `0xE0`          | Other   | Indic overflow — too ambiguous. |
 /// | `0xE0–0xE2`     | Other   | Devanagari / Thai span prefixes are 3-byte but the full start byte is always `0xE0` with a specific second-byte range; leave to the decode path. |
 /// | `0xE3`          | Hiragana| CJK Kana / Bopomofo (U+3040..U+312F live in `0xE3` space). Tagged as Hiragana because it catches the majority of kana fragment leaks on Qwen/GPT-2 tokenizers; Katakana-specific disambiguation would require continuation-byte analysis which is out of scope. |
-/// | `0xE4`–`0xE9`   | Han     | 3-byte start for CJK Unified Ideographs (U+4E00..U+9FFF). Also catches some Latin Extended Additional blocks — acceptable per issue #405 design (opt-in + operator metric). |
+/// | `0xE4`–`0xE9`   | Han     | 3-byte start for CJK Unified Ideographs (U+4E00..U+9FFF). Also catches some Latin Extended Additional blocks — acceptable design (opt-in + operator metric). |
 /// | `0xEA`–`0xED`   | Hangul  | 3-byte start for Hangul Syllables (U+AC00..U+D7AF). |
 /// | `0xEE`–`0xEF`   | Other   | Private Use Area / CJK Compatibility / specials. |
 /// | `0xF0`–`0xF4`   | Han     | 4-byte start for supplementary planes — dominated by CJK Extension B–F. Tagged as Han for consistency with the 3-byte Han range. |
@@ -688,7 +688,7 @@ pub struct ExceptionConfig {
     pub include_numeric: bool,
     /// If `true`, purely punctuation tokens are included.
     pub include_punctuation: bool,
-    /// If `true`, byte-fragment tokens (issue #405) participate in language
+    /// If `true`, byte-fragment tokens participate in language
     /// script matching via UTF-8 start-byte classification.
     ///
     /// Byte-level BPE tokenizers (Qwen, GPT-2, LLaMA, Mistral) represent
@@ -787,7 +787,7 @@ impl TokenLanguageIndex {
     /// 2. Special tokens are excluded unless `exceptions.include_special`.
     /// 3. Numeric tokens are excluded unless `exceptions.include_numeric`.
     /// 4. Punctuation tokens are excluded unless `exceptions.include_punctuation`.
-    /// 5. Byte-fragment tokens (issue #405) are excluded unless
+    /// 5. Byte-fragment tokens are excluded unless
     ///    `exceptions.include_byte_fragments`.
     /// 6. Tokens with no identified scripts (empty `scripts` field) never match.
     ///
@@ -816,7 +816,7 @@ impl TokenLanguageIndex {
                 if info.is_punctuation && !exceptions.include_punctuation {
                     return false;
                 }
-                // Issue #405 — byte-fragment tokens only participate when the
+                // byte-fragment tokens only participate when the
                 // opt-in flag is set. When disabled, behavior is bit-exact
                 // identical to Phase 1 regardless of what the vocab scan
                 // recorded.
@@ -837,7 +837,7 @@ impl TokenLanguageIndex {
     /// 1. Iterate `lang_bias.ordered` in order (index 0 = highest priority).
     /// 2. For each `(code, bias)`, resolve `tokens_for_language(code, policy, exceptions)`.
     /// 3. For each token id, insert `(id, bias)` into the map **only if not already
-    ///    present** — first-language-wins. Byte-fragment entries (issue #405)
+    ///    present** — first-language-wins. Byte-fragment entries
     ///    are inserted via `TokenBiasMap::insert_byte_fragment` so they can be
     ///    counted separately in the observability path.
     /// 4. Return the populated `TokenBiasMap`.
@@ -1604,7 +1604,7 @@ mod tests {
     // `mlxcel_core::test_support::env_lock`. Per-module locks would race
     // with env mutations in unrelated modules of the same test binary —
     // libc's env block has no internal lock and concurrent
-    // `setenv`/`getenv` is undefined behavior (issue #573).
+    // `setenv`/`getenv` is undefined behavior.
     use crate::test_support::env_lock::env_lock;
 
     fn resolve_mock_tokenizer_json(marker: &str) -> String {
@@ -1767,12 +1767,12 @@ mod tests {
     }
 
     // =========================================================================
-    // Issue #405 — Byte-fragment CJK classification (UTF-8 start-byte analysis)
+    // Byte-fragment CJK classification (UTF-8 start-byte analysis)
     // =========================================================================
 
     /// `classify_byte_start` honors the documented start-byte → Script table.
     ///
-    /// Covers the six anchor bytes called out in issue #405: `0xC2` (Latin
+    /// Covers the six anchor bytes called out in `0xC2` (Latin
     /// Extended), `0xE3` (Hiragana/Katakana/Bopomofo), `0xE4`/`0xE5` (Han),
     /// `0xEA` (Hangul), and `0xF0` (supplementary planes → Han). Also
     /// explicitly verifies that continuation bytes stay unclassified.
@@ -1924,7 +1924,7 @@ mod tests {
     /// With `include_byte_fragments = true`, byte-fragment tokens participate
     /// in language matching using their start-byte Script tag.
     ///
-    /// This is the core of the issue #405 contract: the ` 年` leak described
+    /// This is the core of the contract: the ` 年` leak described
     /// in the issue (`[74577, 112]` on Qwen2.5) classifies the leading
     /// fragment `74577` via its `0xE5`-family start byte and tags it as Han,
     /// so `zh=-inf` catches it.
@@ -2016,7 +2016,7 @@ mod tests {
 
     /// Phase 1 (decode-path) tokens with a real script must NEVER be tagged as
     /// byte-fragments — even when they co-exist in the same index. This guards
-    /// the "avoid double-counting" rule from issue #405.
+    /// the "avoid double-counting" rule.
     #[test]
     fn byte_fragment_does_not_override_phase1_classification() {
         // Merged-token Han (like `年` → id 7948 on Qwen2.5), added manually.
@@ -2217,7 +2217,7 @@ mod tests {
             index.tokens_for_language(LanguageCode::Zh, InclusionPolicy::Conservative, &ex_on);
         assert!(
             zh_on.contains(&2),
-            "flag on: byte-fragment Han token MUST be in zh (issue #405 leak caught): {zh_on:?}"
+            "flag on: byte-fragment Han token MUST be in zh (leak caught): {zh_on:?}"
         );
     }
 

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -3047,7 +3047,7 @@ mod tests {
         let window_size = 2_i32; // k_len > window, mask is required.
 
         let out = crate::causal_attention(&q, &k, &v, scale, 0.0, window_size);
-        // After PR #513, `create_causal_mask_with_window` caps T_k to
+        // After `create_causal_mask_with_window` caps T_k to
         // `window_size` when `q_len + offset > window`. The explicit-mask
         // reference must therefore receive K/V sliced to the last
         // `window_size` slots so its score tensor lines up with the mask —
@@ -3098,7 +3098,7 @@ mod tests {
             &[1, 1, 5, 4],
         );
         let scale = 0.5_f32;
-        // Use window_size=3 (not 2) so the post-PR-#513 cap path produces a
+        // Use window_size=3 (not 2) so the post-earlier cap path produces a
         // non-degenerate mask: with q_len=3, window=3, tril_offset = w - size
         // = 0, so q=0 attends to k=0. With window=2 the row-0 mask is fully
         // masked, which produces NaN under the now-correct semantics (a

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -33,8 +33,7 @@ mod ffi {
         /// Opaque wrapper for mlx::core::ThreadLocalStream.
         ///
         /// Holds a TLS handle that resolves to a per-thread `MlxStream`
-        /// on demand. Used by the generation stream owners (issue
-        /// #556) so dispatch and synchronization stay on the same
+        /// on demand. Used by the generation stream owners so dispatch and synchronization stay on the same
         /// per-thread stream.
         type MlxThreadLocalStream;
 
@@ -2071,10 +2070,9 @@ mod ffi {
             -> UniquePtr<MlxArray>;
 
         // -------------------------------------------------------------------
-        // Issue #505 / #520 — Fused Sparse-V SDPA Metal kernel.
+        // Fused Sparse-V SDPA Metal kernel.
         // -------------------------------------------------------------------
-        /// Fused-skip Sparse-V weighted sum (Turbo4Asym KV cache, issue #505;
-        /// optimized in #520).
+        /// Fused-skip Sparse-V weighted sum (Turbo4Asym KV cache, optimized).
         ///
         /// Runs a Metal kernel that computes
         ///   `out[b, h, q, d] = Σ_t attn_weights[b, h, q, t] * V_dq[b, h, t, d]`
@@ -2087,11 +2085,11 @@ mod ffi {
         /// - `attn_weights`: `[B*Hq, Tq, Tk]` FP32 — post-softmax weights.
         /// - `v_packed`:     `[B*Hkv, Tk, D/2]` UINT8 — nibble-packed indices.
         /// - `v_rescale`:    `[B*Hkv, Tk]` FP16 — precomputed per-token
-        ///   rescale `norm[t] / max(|y_hat[t]|, 1e-10)` (issue #520). The
+        ///   rescale `norm[t] / max(|y_hat[t]|, 1e-10)`. The
         ///   previous kernel implementation re-derived this on-GPU per token
         ///   via a `log2(Dim) + 2`-barrier threadgroup tree reduction; that
         ///   reduction dominated decode latency on M5 Max at 4 K context
-        ///   for `turbo4-asym` (PR #519 A/B). Precomputing eliminates the
+        ///   for `turbo4-asym` (A/B). Precomputing eliminates the
         ///   threadgroup barriers from the kernel hot path.
         /// - `codebook`:     `[16]` FP32 — Lloyd-Max centroids.
         /// - `dim`: head dimension `D`.
@@ -2114,15 +2112,15 @@ mod ffi {
         ) -> UniquePtr<MlxArray>;
 
         // -------------------------------------------------------------------
-        // Issue #528 — Fused Turbo4Delegated cold-V weighted-sum kernel.
+        // Fused Turbo4Delegated cold-V weighted-sum kernel.
         // -------------------------------------------------------------------
-        /// Fused Turbo4Delegated cold-V weighted sum (issue #528).
+        /// Fused Turbo4Delegated cold-V weighted sum.
         ///
         /// Runs a Metal kernel that computes
         ///   `out_cold[b, h, q, d] = Σ_t attn_cold[b, h, q, t] * V_dq[b, h, t, d]`
         /// over the cold token range, reading the packed Turbo4 V indices
         /// directly. The dequantised cold V never materialises in global
-        /// memory; that is the point of issue #528 (replaces the PR-#525
+        /// memory; that is the point (replaces the earlier
         /// `cold_v_dequant_cache` memo + per-step `concat(cold_v, hot_v)`).
         ///
         /// The output is unrotated — the caller must apply the inverse
@@ -2137,8 +2135,7 @@ mod ffi {
         /// - `v_packed_cold`:     `[B*Hkv, T_cold, D/2]` UINT8 — nibble-
         ///   packed Turbo4 indices for the cold body.
         /// - `v_rescale_cold`:    `[B*Hkv, T_cold]` FP16 — precomputed
-        ///   per-token rescale `norm[t] / max(|y_hat[t]|, 1e-10)` (same
-        ///   semantic content as the Sparse-V kernel rescale, issue #520).
+        ///   per-token rescale `norm[t] / max(|y_hat[t]|, 1e-10)` (same semantic content as the Sparse-V kernel rescale).
         /// - `codebook`:          `[16]` FP32 — Lloyd-Max centroids.
         /// - `dim`: head dimension `D`.
         /// - `n_rep`: `Hq / Hkv` (1 for non-grouped attention).
@@ -2179,7 +2176,7 @@ mod ffi {
             dim: i32,
         ) -> UniquePtr<MlxArray>;
 
-        // Issue #531 — Steel-attention-envelope fused Turbo4Delegated SDPA
+        // Steel-attention-envelope fused Turbo4Delegated SDPA
         // kernel launcher. One Metal dispatch performs the entire post-Q·K
         // SDPA inline (numerically stable softmax over T_total + cold-V
         // dequant + hot-V accumulation), returning two FP32 outputs that
@@ -2205,7 +2202,7 @@ mod ffi {
         //   cold V indices, or a 1-token zero placeholder when `T_cold == 0`
         //   (MLX `metal_kernel` rejects zero-shape buffers).
         // - `cold_rescale`:  `[B*Hkv, T_cold]` FP16 — precomputed per-token
-        //   cold-V rescale `norm[t] / max(|y_hat[t]|, 1e-10)` (issue #520).
+        //   cold-V rescale `norm[t] / max(|y_hat[t]|, 1e-10)`.
         // - `hot_v`:         `[B*Hkv, T_hot, D]` FP16 — plain FP16 hot V, or
         //   a 1-token zero placeholder when `T_hot == 0`.
         // - `codebook`:      `[16]` FP32 — Lloyd-Max centroids.
@@ -2279,7 +2276,7 @@ pub use ops::{concatenate, divide_scalar, multiply_scalar, stack, stack_owned, w
 pub use sampling::TokenBiasMap;
 // Re-export B9 observability counter accessors so the server `/metrics` handler
 // can read process-wide lang-bias counters without a struct dependency.
-// Includes the byte-fragment suppression counter added in issue #405.
+// Includes the byte-fragment suppression counter added.
 pub use sampling::{
     lang_bias_applied_total, lang_bias_byte_fragment_suppressions_total,
     lang_bias_tokens_suppressed_total,
@@ -2329,7 +2326,7 @@ fn use_bool_causal_mask_path() -> bool {
 /// the batch dimension and reuses MLX's scalar-offset fast kernel for each
 /// sequence, then concatenates the results back together.
 ///
-/// Uniform-batch fast path (issue #556 / upstream `mlx-vlm` PR #1055): when
+/// Uniform-batch fast path (upstream `mlx-vlm` PR #1055): when
 /// every row in `offsets` has the same value, the helper bypasses the
 /// per-row slice / concat loop and dispatches a single
 /// `fast_rope(x, ..., offsets[0])` call over the whole batch. RoPE is
@@ -2532,12 +2529,11 @@ pub mod sampling;
 // Speculative decoding
 pub mod speculative;
 
-// Drafter trait + DrafterKind enum + model_type auto-detection (issue #624,
-// epic #633). Foundational scaffolding for the Gemma 4 MTP and Qwen 3.5
-// DFlash drafter ports. Concrete drafter impls land in #626 / #635 / #640.
+// Drafter trait + DrafterKind enum + model_type auto-detection. Foundational scaffolding for the Gemma 4 MTP and Qwen 3.5
+// DFlash drafter ports. Concrete drafter impls land.
 // The existing classic `SpeculativeGenerator` above is unchanged — MTP and
 // DFlash are peer code paths, not replacements.
-// TODO(#629, #636): wrap the existing SpeculativeGenerator in a
+// TODO: wrap the existing SpeculativeGenerator in a
 // Drafter-trait adapter so the round-loop drivers can dispatch uniformly.
 pub mod drafter;
 
@@ -2566,8 +2562,7 @@ pub mod rope_proportional;
 pub mod lang_analyzer;
 
 // Crate-wide helpers for `#[cfg(test)]` paths. Provides the single shared
-// `ENV_LOCK` that every env-mutating test in this crate must acquire (issue
-// #573); see `test_support::env_lock` for the rationale. `pub(crate)` so
+// `ENV_LOCK` that every env-mutating test in this crate must acquire; see `test_support::env_lock` for the rationale. `pub(crate)` so
 // that test modules at any depth (e.g. `crate::lang_analyzer::cache::tests`)
 // can name it as `crate::test_support::env_lock`.
 #[cfg(test)]

--- a/src/lib/mlxcel-core/src/ops.rs
+++ b/src/lib/mlxcel-core/src/ops.rs
@@ -69,8 +69,7 @@ pub fn divide_scalar(a: &ffi::MlxArray, scalar: f32) -> UniquePtr<ffi::MlxArray>
     ffi::divide(a, &scalar_array)
 }
 
-/// Walsh–Hadamard Transform along the last axis (B0 spike for issue #470,
-/// epic #458 — TurboQuant KV cache compression).
+/// Walsh–Hadamard Transform along the last axis (B0 spike — TurboQuant KV cache compression).
 ///
 /// Applies an orthonormal Hadamard transform to the last axis of `x`, scaled by
 /// `1/sqrt(N)` where `N` is the size of the last axis. This is the "graph-only"
@@ -100,8 +99,7 @@ pub fn divide_scalar(a: &ffi::MlxArray, scalar: f32) -> UniquePtr<ffi::MlxArray>
 /// this path is unreachable in normal usage; the guard exists so future B2
 /// integration can rely on a sane error contract.)
 ///
-/// Used by: TurboQuant cache compression (planned: cache::turbo, sub-issues
-/// #472–#485 under epic #458).
+/// Used by: TurboQuant cache compression (planned: cache::turbo, sub-– under).
 pub fn wht(x: &ffi::MlxArray) -> UniquePtr<ffi::MlxArray> {
     let shape = ffi::array_shape(x);
     let last = shape.last().copied().unwrap_or(0);

--- a/src/lib/mlxcel-core/src/sampling.rs
+++ b/src/lib/mlxcel-core/src/sampling.rs
@@ -53,7 +53,7 @@ pub static LANG_BIAS_APPLIED_TOTAL: AtomicU64 = AtomicU64::new(0);
 pub static LANG_BIAS_TOKENS_SUPPRESSED_TOTAL: AtomicU64 = AtomicU64::new(0);
 
 /// Total sampling calls where the pre-bias top-1 token was both
-/// `-inf`-suppressed AND was a byte-fragment entry (issue #405).
+/// `-inf`-suppressed AND was a byte-fragment entry.
 ///
 /// Exposed via `/metrics` as
 /// `mlxcel_lang_bias_byte_fragment_suppressions_total`. This counter is a
@@ -81,7 +81,7 @@ pub fn lang_bias_tokens_suppressed_total() -> u64 {
 }
 
 /// Read the current value of
-/// `mlxcel_lang_bias_byte_fragment_suppressions_total` (issue #405).
+/// `mlxcel_lang_bias_byte_fragment_suppressions_total`.
 #[inline]
 pub fn lang_bias_byte_fragment_suppressions_total() -> u64 {
     LANG_BIAS_BYTE_FRAGMENT_SUPPRESSIONS_TOTAL.load(Ordering::Relaxed)
@@ -95,7 +95,7 @@ pub fn lang_bias_byte_fragment_suppressions_total() -> u64 {
 /// When empty, `apply_token_bias` short-circuits without any array operations,
 /// preserving bit-exact baseline behavior.
 ///
-/// Issue #405 — tokens that were classified via byte-fragment UTF-8 start-byte
+/// tokens that were classified via byte-fragment UTF-8 start-byte
 /// analysis are tracked in a separate set so the observability path can count
 /// how many suppressions originated from that opt-in classifier.
 #[derive(Debug, Clone, Default)]
@@ -124,7 +124,7 @@ impl TokenBiasMap {
         self.entries.insert(token_id, bias);
     }
 
-    /// Insert a bias and tag the token as a byte-fragment entry (issue #405).
+    /// Insert a bias and tag the token as a byte-fragment entry.
     ///
     /// Used by `TokenLanguageIndex::to_token_bias` when the opt-in
     /// `include_byte_fragments` flag is set. Equivalent to [`Self::insert`]
@@ -165,7 +165,7 @@ impl TokenBiasMap {
         self.byte_fragment_ids.contains(&token_id)
     }
 
-    /// Number of byte-fragment entries currently in the map (issue #405).
+    /// Number of byte-fragment entries currently in the map.
     ///
     /// Used by the tracing debug field `byte_fragment_entries` emitted
     /// alongside the B9 `lang_bias resolved` event.
@@ -248,7 +248,7 @@ pub fn sample_token_optimized(
             .is_some_and(|b| b.is_infinite() && b.is_sign_negative())
         {
             LANG_BIAS_TOKENS_SUPPRESSED_TOTAL.fetch_add(1, Ordering::Relaxed);
-            // Issue #405 — separate counter for suppressions that originated
+            // separate counter for suppressions that originated
             // from the opt-in byte-fragment classifier. Strict subset of the
             // total-suppressed counter above.
             if config.token_bias.is_byte_fragment(top_id) {
@@ -1002,7 +1002,7 @@ mod tests {
 
     #[test]
     fn top_p_filter_batched_equals_per_row() {
-        // Regression test for issue #546 (upstream mlx-vlm PR #1094, commit c7aaf2d).
+        // Regression test (upstream mlx-vlm PR #1094, commit c7aaf2d).
         //
         // Construct a [2, 6] logits tensor where the two rows have deliberately
         // different distributions so a buggy global sort would give wrong results.

--- a/src/lib/mlxcel-core/src/speculative/mod.rs
+++ b/src/lib/mlxcel-core/src/speculative/mod.rs
@@ -79,7 +79,7 @@ pub struct SpeculativeGenerator {
     draft_caches: Vec<KVCache>,
     generated_tokens: Vec<i32>,
     /// Thread-local generation stream — see `mlxcel_core::streams`
-    /// (issue #556). Resolves to a per-thread `MlxStream` on the
+    /// Resolves to a per-thread `MlxStream` on the
     /// worker thread that calls `generate`, so dispatch and
     /// synchronization stay paired even when the generator is moved
     /// across threads after construction.
@@ -772,7 +772,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Issue #589 — trimmable cache validation and last-token reservation
+    // trimmable cache validation and last-token reservation
     // ------------------------------------------------------------------
 
     /// All freshly-constructed KVCache entries must report `is_trimmable()`.

--- a/src/lib/mlxcel-core/src/speculative/mtp/generator.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/generator.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //! [`MtpGenerator`] — round-loop driver for Gemma 4 MTP speculative decoding
-//! (issue #629).
 //!
 //! Top-level lifecycle (single-batch path):
 //!
@@ -171,7 +170,7 @@ fn duration_ms(duration: Duration) -> f64 {
 /// Single-threaded by design. The MTP round-loop's drafter ↔ target
 /// dependence is too tight for the classic generator's
 /// `install_thread_local_default_stream` pattern to help. Future
-/// concurrency lands in #631 (batched MTP).
+/// concurrency lands (batched MTP).
 pub struct MtpGenerator<T: MtpTarget> {
     target: T,
     drafter: Box<dyn Drafter>,
@@ -223,7 +222,7 @@ impl<T: MtpTarget> MtpGenerator<T> {
 
     /// Consume the generator and return the boxed drafter handle.
     ///
-    /// Used by the server-side speculative burst path (issue #670) so a
+    /// Used by the server-side speculative burst path so a
     /// loaded drafter can be reused across multiple requests on the same
     /// worker thread without re-loading from disk. The caller is
     /// expected to [`Drafter::reset`] the returned handle before the
@@ -245,19 +244,19 @@ impl<T: MtpTarget> MtpGenerator<T> {
     ///   bonus.
     /// - `sampling`: sampling config. **Greedy parity requires
     ///   `temperature == 0`** — this is the load-bearing correctness
-    ///   gate of the MTP path (see issue #629).
+    ///   gate of the MTP path.
     /// - `token_history`: history-dependent-penalty context forwarded to
     ///   [`MtpTarget::prefill_and_seed`] for the first-bonus sample
     ///   (repetition / frequency / presence / DRY). The server burst
     ///   path passes `initial_token_history(&prompt, ..)` so the first
     ///   bonus is byte-identical to the classic decode path; callers
-    ///   with no penalty configured pass `&[]` (issue #677).
+    ///   with no penalty configured pass `&[]`.
     /// - `cancel`: cooperative-cancellation flag. Checked **once per
     ///   round** (not per token) at the top of the round loop; when set,
     ///   the generator returns early with whatever tokens it has already
     ///   emitted (at minimum the first bonus). The server-side burst
     ///   path passes `&seq.cancelled` so a client disconnect mid-burst
-    ///   stops occupying the worker thread (issue #672). The offline CLI
+    ///   stops occupying the worker thread. The offline CLI
     ///   path passes `&AtomicBool::new(false)`.
     /// - `logprobs_config`: per-token log-probability capture control.
     ///   When [`LogprobsConfig::enabled`] is false the returned logprobs
@@ -266,7 +265,7 @@ impl<T: MtpTarget> MtpGenerator<T> {
     ///   with the returned `tokens` vec. The server burst path forwards
     ///   this to `finalize_burst_success` so speculative responses carry
     ///   the same `TokenWithLogprobs` payload as the classic decode
-    ///   path (issue #678).
+    ///   path.
     ///
     /// # Returns
     ///
@@ -365,7 +364,7 @@ impl<T: MtpTarget> MtpGenerator<T> {
             // disconnect mid-burst the server flips `seq.cancelled` and
             // this loop bails out with the tokens emitted so far rather
             // than running the full `max_tokens` budget and
-            // head-of-line-blocking the next request (issue #672).
+            // head-of-line-blocking the next request.
             if cancel.load(Ordering::Relaxed) {
                 break;
             }
@@ -407,7 +406,7 @@ impl<T: MtpTarget> MtpGenerator<T> {
                     // Drafter failed — bail out cleanly. We've already
                     // emitted at least the seed bonus, so return what
                     // we have rather than panicking. Future hardening
-                    // (#632) can surface this through GenerationStats.
+                    // can surface this through GenerationStats.
                     let _ = e;
                     break;
                 }
@@ -455,7 +454,7 @@ impl<T: MtpTarget> MtpGenerator<T> {
             // for every `i` (accepted draft tokens matched the target by
             // construction; the final entry is the target's bonus), so
             // `target_logprobs[i]` is the correct log-probability for
-            // `walk.new_tokens[i]` (issue #678).
+            // `walk.new_tokens[i]`.
             for (i, &tok) in walk.new_tokens.iter().enumerate() {
                 emitted.push(tok);
                 if logprobs_config.enabled {
@@ -520,7 +519,7 @@ impl<T: MtpTarget> MtpGenerator<T> {
     /// Best-effort: the round-loop continues even if the drafter
     /// rejects the call (the next `draft_block` will fail closed and
     /// the outer loop bails out). Tests assert the slabs reach the
-    /// drafter; real-model integration (#632) gates on a stricter
+    /// drafter; real-model integration gates on a stricter
     /// error path via `GenerationStats.errors` or similar.
     fn set_shared_kv_from_verify(&mut self, verify_out: &MtpVerifyOutput) {
         let refs = verify_out.shared_kv_refs();

--- a/src/lib/mlxcel-core/src/speculative/mtp/mod.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Multi-Token Prediction (MTP) round-loop generator for the Gemma 4
-//! assistant drafter family (issue #629, epic #633).
+//! assistant drafter family.
 //!
 //! This module is a **peer** to [`crate::speculative::SpeculativeGenerator`],
 //! not an extension. The classic speculative path and the MTP path differ in

--- a/src/lib/mlxcel-core/src/speculative/mtp/round_loop_batched.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/round_loop_batched.rs
@@ -16,19 +16,19 @@
 //!
 //! Rust port of upstream
 //! `references/mlx-vlm/mlx_vlm/generate.py::_mtp_rounds_batch` (and the
-//! `_batch_cache_left_padding` helper). Issue #631 / epic #633 sub-7.
+//! `_batch_cache_left_padding` helper). sub-7.
 //!
 //! ## Scope
 //!
 //! **B > 1, with continuous batching and per-row early-EOS.** The B = 1
-//! fast path lives in the sibling [`super::generator`] module (#662 merged)
+//! fast path lives in the sibling [`super::generator`] module (merged)
 //! and must NOT regress as a result of this implementation. The two drivers
 //! share the [`MtpTarget`] trait surface and the [`speculative_walk_batched`]
 //! helper; everything else is duplicated to keep both hot paths obvious and
 //! optimal.
 //!
 //! Mirrors the design of the companion batched DFlash round-loop in
-//! [`crate::drafter::dflash::round_loop_batched`] (#663 merged):
+//! [`crate::drafter::dflash::round_loop_batched`] (merged):
 //!
 //! 1. **Active-rows-only `bs` computation.** Finished rows are frozen in
 //!    place and excluded from the per-round block-size minimum — otherwise
@@ -42,7 +42,7 @@
 //! 3. **Left-padding normalization on rebind.** Each round's drafter
 //!    rebind passes the per-row `left_padding[b]` so the drafter's
 //!    `set_shared_kv` can re-normalize via
-//!    [`crate::drafter::masks::normalize_batched_shared_kv_states`] (#657).
+//!    [`crate::drafter::masks::normalize_batched_shared_kv_states`].
 //! 4. **Per-row stop-token / max-tokens emission gate.** Rows that hit EOS
 //!    or saturate `max_new_tokens` remain in the batch (no cache filter)
 //!    but emit nothing further on subsequent rounds.
@@ -174,8 +174,7 @@ impl<T: MtpTarget> MtpBatchedGenerator<T> {
 
     /// Consume the generator and return the boxed drafter handle.
     ///
-    /// Used by the server-side batched speculative burst path (issue
-    /// #674) so a loaded drafter can be reused across multiple batched
+    /// Used by the server-side batched speculative burst path so a loaded drafter can be reused across multiple batched
     /// bursts on the same worker thread without re-loading from disk.
     /// The caller is expected to [`Drafter::reset`] the returned handle
     /// before the next burst so per-run drafter state is cleared. Mirrors
@@ -446,8 +445,8 @@ impl<T: MtpTarget> MtpBatchedGenerator<T> {
             // tokens. We accepted `accepted[r] + 1` positions per row;
             // the target trims by `bs - max(accepted) - 1` (global) and
             // per-row zeros the tails of rows with smaller accept counts.
-            // This is the per-row rollback contract from #655 (Gemma 4
-            // `rollback_speculative_cache`) and #657 (per-row mask
+            // This is the per-row rollback contract (Gemma 4
+            // `rollback_speculative_cache`) and (per-row mask
             // normalization).
             verify_out =
                 self.target

--- a/src/lib/mlxcel-core/src/speculative/mtp/target.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/target.rs
@@ -322,7 +322,7 @@ pub trait MtpTarget {
     fn eos_token_ids(&self) -> Vec<i32>;
 
     // ------------------------------------------------------------
-    // Batched MTP path (B > 1) —.
+    // Batched MTP path (B > 1).
     // ------------------------------------------------------------
     //
     // The trait carries default impls that error out so existing single-batch

--- a/src/lib/mlxcel-core/src/speculative/mtp/target.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/target.rs
@@ -21,10 +21,10 @@
 //!
 //! 1. A sink-aware verify forward that returns logits AND captures the
 //!    target's last-layer hidden + last full/SWA shared K/V slabs — this
-//!    is the Gemma 4 `forward_with_speculative_sinks` hook (#625).
+//!    is the Gemma 4 `forward_with_speculative_sinks` hook.
 //! 2. A per-sequence cache rollback that trims by `block_size - accepted - 1`
 //!    with per-row tail-zeroing for batched paths — this is the Gemma 4
-//!    `rollback_speculative_cache` hook (#625).
+//!    `rollback_speculative_cache` hook.
 //!
 //! Both hooks are Gemma-4-specific. Other model families (Llama, Qwen, …)
 //! do not implement them today. Surfacing them through a trait keeps
@@ -104,7 +104,7 @@ pub struct VerifyForwardOutput {
     /// Per-position log-probability data, aligned 1:1 with
     /// `target_tokens`. `None` when the caller's [`LogprobsConfig`] is
     /// disabled (zero-overhead path); `Some(vec)` with one entry per
-    /// verify position when logprobs are requested (issue #678). The
+    /// verify position when logprobs are requested. The
     /// round loop forwards the entries for *accepted* positions on to
     /// the burst's `finalize_burst_success` so speculative responses
     /// carry the same `TokenWithLogprobs` payload as the classic path.
@@ -228,7 +228,7 @@ pub trait MtpTarget {
     /// true it carries the first bonus's log-probability data computed
     /// from the same penalty-adjusted logits the bonus was sampled from
     /// — byte-identical to the classic decode path's first-token
-    /// logprobs (issue #678).
+    /// logprobs.
     ///
     /// **Cache state on return**: the target's per-sequence cache has
     /// `prompt.len()` entries (the prompt prefill). The bonus token is
@@ -279,7 +279,7 @@ pub trait MtpTarget {
     /// When disabled the impl MUST leave `VerifyForwardOutput::target_logprobs`
     /// as `None` (zero-overhead path); when enabled it populates one
     /// [`TokenLogprobData`] per verify position, aligned 1:1 with
-    /// `target_tokens` (issue #678).
+    /// `target_tokens`.
     fn verify_forward(
         &self,
         verify_input: &[i32],
@@ -322,7 +322,7 @@ pub trait MtpTarget {
     fn eos_token_ids(&self) -> Vec<i32>;
 
     // ------------------------------------------------------------
-    // Batched MTP path (B > 1) — issue #631.
+    // Batched MTP path (B > 1) —.
     // ------------------------------------------------------------
     //
     // The trait carries default impls that error out so existing single-batch
@@ -390,7 +390,7 @@ pub trait MtpTarget {
     /// The implementation MUST trim the caches by `block_size - max(accepted) - 1`
     /// (the global trim amount) and per-row zero the tail for rows whose
     /// accept count is below `max(accepted)`. This mirrors the Gemma 4
-    /// `Cache::zero_partial_accept_tail` hook (issue #655) and the
+    /// `Cache::zero_partial_accept_tail` hook and the
     /// `rollback_speculative_cache(..., accepted: &[i32], block_size)` API.
     #[allow(unused_variables)]
     fn verify_finalize_batched(
@@ -408,7 +408,7 @@ pub trait MtpTarget {
 }
 
 // ---------------------------------------------------------------------------
-// Batched MTP types (issue #631)
+// Batched MTP types
 // ---------------------------------------------------------------------------
 
 /// Output of [`MtpTarget::verify_forward_batched`] — per-row target argmax

--- a/src/lib/mlxcel-core/src/speculative/mtp/tests.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit tests for the MTP round-loop (issue #629).
+//! Unit tests for the MTP round-loop.
 //!
 //! Tests build a fixture `MtpTarget` (`MockMtpTarget`) and a fixture
 //! `Drafter` (`MockMtpDrafter`) that produce deterministic outputs.
@@ -20,9 +20,9 @@
 //! invariants against hand-computed expected outputs, without needing
 //! real Gemma 4 weights.
 //!
-//! The full real-model greedy parity check (#632) requires a real
+//! The full real-model greedy parity check requires a real
 //! Gemma 4 target + drafter pairing; we document this in the PR body
-//! and defer the on-hardware check to #632.
+//! and defer the on-hardware check to.
 
 use super::generator::MtpGenerator;
 use super::target::{MtpTarget, MtpVerifyOutput, VerifyCaptured, VerifyForwardOutput};
@@ -541,7 +541,7 @@ fn round_loop_rebinds_drafter_after_each_round() {
 
 // ----- Greedy parity gate (acceptance criterion) -----
 //
-// The full real-model greedy parity check (#632) requires the actual
+// The full real-model greedy parity check requires the actual
 // Gemma 4 target + drafter pairing. Here we exercise the
 // **structural** parity gate: with a synthetic target where the
 // drafter is ALWAYS perfect (returns argmax of the target), the

--- a/src/lib/mlxcel-core/src/streams.rs
+++ b/src/lib/mlxcel-core/src/streams.rs
@@ -18,14 +18,14 @@
 //! [`crate::speculative::SpeculativeGenerator`], and the server-side
 //! `BatchScheduler`) create a dedicated MLX stream up front and install
 //! it as the default for the worker thread that drives the generation
-//! loop. Until issue #556, that stream was a plain
+//! loop. Until that stream was a plain
 //! `mlx::core::new_stream(Device::gpu)` instance, which means every
 //! owner had to be constructed on the same thread that ran the loop —
 //! otherwise the stream would be "owned" by the wrong thread and any
 //! `synchronize()` call would target a different physical stream than
 //! the one that dispatched the work.
 //!
-//! Issue #556 / upstream `mlx-vlm` PR #1050 (commit `728fab1`)
+//! upstream `mlx-vlm` PR #1050 (commit `728fab1`)
 //! introduces `mlx::core::ThreadLocalStream`: a TLS-backed handle that
 //! resolves to a per-thread `Stream` on demand. The generation owners
 //! now hold a `ThreadLocalStream` and resolve it on the worker thread
@@ -153,10 +153,10 @@ impl Drop for DefaultStreamGuard {
 /// [`new_thread_local_generation_stream`] instead.
 ///
 /// Used by: external crates only; in-tree generation owners now use
-/// [`new_thread_local_generation_stream`] (issue #556).
+/// [`new_thread_local_generation_stream`].
 #[deprecated(
     since = "26.5.9",
-    note = "Use `new_thread_local_generation_stream` so dispatch and synchronization stay on the same per-thread stream (issue #556)."
+    note = "Use `new_thread_local_generation_stream` so dispatch and synchronization stay on the same per-thread stream."
 )]
 pub fn new_generation_stream() -> Option<UniquePtr<MlxStream>> {
     if ffi::is_gpu_available() {
@@ -171,10 +171,10 @@ pub fn new_generation_stream() -> Option<UniquePtr<MlxStream>> {
 ///
 /// Used together with the deprecated
 /// [`new_generation_stream`]. Prefer
-/// [`install_thread_local_default_stream`] in new code (issue #556).
+/// [`install_thread_local_default_stream`] in new code.
 #[deprecated(
     since = "26.5.9",
-    note = "Use `install_thread_local_default_stream` to bind the per-thread MLX stream (issue #556)."
+    note = "Use `install_thread_local_default_stream` to bind the per-thread MLX stream."
 )]
 pub fn install_default_stream(stream: Option<&UniquePtr<MlxStream>>) {
     if let Some(stream) = stream {

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -818,7 +818,7 @@ mod tests {
         assert_eq!(ref_shape, vec![8, 8]);
     }
 
-    // --- Sliding window mask shape regression tests (issue #507) -------------
+    // --- Sliding window mask shape regression tests -------------
 
     /// Gemma3-4B trigger: seq_len=4096, window=1024, offset=0.
     ///

--- a/src/lib/mlxcel-core/src/weights.rs
+++ b/src/lib/mlxcel-core/src/weights.rs
@@ -40,7 +40,7 @@ pub type ShardIndexResult = Result<Option<(Vec<String>, Option<u64>)>, String>;
 /// sanitization, before the model graph consumes it.
 ///
 /// This trait is the single insertion point for Axis A "weight-load
-/// surgery" (see Epic #363, issue #365). The consolidated text and VLM
+/// surgery". The consolidated text and VLM
 /// weight loaders accept an `Option<&dyn WeightTransform>`; when `None`,
 /// the load path is bit-exact identical to the pre-refactor behavior.
 ///

--- a/src/lib/mlxcel-surgery/Cargo.toml
+++ b/src/lib/mlxcel-surgery/Cargo.toml
@@ -17,17 +17,16 @@ default = []
 # `mlxcel::loading::vlm`.
 mlxcel-core = { path = "../mlxcel-core", default-features = false }
 
-# Public API surfaces serde-derived types (#369 builds on top by
-# adding `serde_yaml` for the YAML config schema).
+# Public API surfaces serde-derived types (builds on top by # adding `serde_yaml` for the YAML config schema).
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-# YAML configuration schema parser (#369). Pinned to the same version
+# YAML configuration schema parser. Pinned to the same version
 # the top-level `mlxcel` crate already uses to keep the dependency
 # graph small.
 serde_yaml = "0.9"
 
-# Glob-style tensor key patterns (#369). The same `globset` version is
+# Glob-style tensor key patterns. The same `globset` version is
 # transitively present via tracing-subscriber's fluent layer, so we
 # don't add a new transitive subtree here.
 globset = "0.4"

--- a/src/lib/mlxcel-surgery/src/config.rs
+++ b/src/lib/mlxcel-surgery/src/config.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! YAML configuration schema for Axis A weight-load surgery (#369).
+//! YAML configuration schema for Axis A weight-load surgery.
 //!
 //! Schema overview (see `examples/surgery/*.yaml` for full samples):
 //!
@@ -277,7 +277,7 @@ fn materialize_op(
             source,
             alpha,
         } => {
-            // A6 (#375) — concrete factory hook for `op: add`.
+            // A6 — concrete factory hook for `op: add`.
             // The compiled glob is built once here for validation and
             // then handed off to `AddOp::from_compiled` so the
             // operation does not re-parse it.

--- a/src/lib/mlxcel-surgery/src/error.rs
+++ b/src/lib/mlxcel-surgery/src/error.rs
@@ -67,7 +67,7 @@ pub enum SurgeryError {
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
 
-    /// A failure from the config layer (issue #369) or any
+    /// A failure from the config layer or any
     /// downstream that has chosen to surface its errors as
     /// `anyhow::Error`.
     #[error(transparent)]

--- a/src/lib/mlxcel-surgery/src/lib.rs
+++ b/src/lib/mlxcel-surgery/src/lib.rs
@@ -22,8 +22,8 @@
 //!   implements. Operations transform an in-memory [`WeightMap`] in
 //!   place.
 //! - [`SurgeryPipeline`] — an ordered collection of `SurgeryOp` that
-//!   itself implements [`mlxcel_core::weights::WeightTransform`] from
-//! (A1). Plugging a `SurgeryPipeline` into
+//!   itself implements [`mlxcel_core::weights::WeightTransform`]
+//!   (A1). Plugging a `SurgeryPipeline` into
 //!   `mlxcel::models::load_text_weights(path, Some(&pipeline))` (or
 //!   the VLM equivalent) is the entire integration surface with the
 //!   load path.

--- a/src/lib/mlxcel-surgery/src/lib.rs
+++ b/src/lib/mlxcel-surgery/src/lib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! `mlxcel-surgery` — Axis A "weight-load surgery" framework
-//! (Epic #363, issues #367 / #369 / A5–A9).
+//! (A5–A9).
 //!
 //! This crate is the structural fine-tuning machinery. It owns:
 //!
@@ -23,7 +23,7 @@
 //!   place.
 //! - [`SurgeryPipeline`] — an ordered collection of `SurgeryOp` that
 //!   itself implements [`mlxcel_core::weights::WeightTransform`] from
-//!   issue #365 (A1). Plugging a `SurgeryPipeline` into
+//! (A1). Plugging a `SurgeryPipeline` into
 //!   `mlxcel::models::load_text_weights(path, Some(&pipeline))` (or
 //!   the VLM equivalent) is the entire integration surface with the
 //!   load path.

--- a/src/lib/mlxcel-surgery/src/ops/add.rs
+++ b/src/lib/mlxcel-surgery/src/ops/add.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `AddOp` — task-vector addition (issue #375, axis A6).
+//! `AddOp` — task-vector addition (axis A6).
 //!
 //! For every tensor key in the in-memory `WeightMap` whose name
 //! matches the glob `pattern`, look up the same-named tensor in an

--- a/src/lib/mlxcel-surgery/src/ops/interpolate.rs
+++ b/src/lib/mlxcel-surgery/src/ops/interpolate.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `InterpolateOp` — Axis A operation #9 (issue #378).
+//! `InterpolateOp` — Axis A operation #9.
 //!
 //! Blends two donor checkpoints tensor-by-tensor and writes the
 //! result back into the base [`WeightMap`]. Supported methods:
@@ -51,7 +51,7 @@
 //!   precision when blending two bf16 checkpoints.
 //! - **Quantized layouts (`u8`/`u32`/integer-coded tensors)**:
 //!   interpolation is *not* defined on the packed quantized
-//!   representation. The first-cut policy (see issue #378 §"Scope")
+//!   representation. The first-cut policy (§"Scope")
 //!   is to require the base, source_a, and source_b to share the
 //!   exact same dtype. Any integer dtype encountered errors with a
 //!   clear message directing the user to either dequantize ahead of
@@ -147,7 +147,7 @@ pub struct InterpolateOp {
     /// Donor B safetensors path. Loaded on every `apply` call.
     source_b: PathBuf,
     /// Mixing ratio `t`. Validated to `[0.0, 1.0]` by the config
-    /// parser (#369); defended again here against direct construction.
+    /// parser; defended again here against direct construction.
     ratio: f32,
     /// Interpolation method (SLERP or LERP).
     method: InterpolateMethod,
@@ -452,7 +452,7 @@ fn slerp_in_f32(a: &MlxArray, b: &MlxArray, t: f32) -> UniquePtr<MlxArray> {
 
 #[cfg(test)]
 mod tests {
-    //! Unit tests covering the acceptance criteria in issue #378:
+    //! Unit tests covering the acceptance criteria in
     //!
     //! - (a-1) SLERP on a small known fixture.
     //! - (a-2) LERP on a small fixture.

--- a/src/lib/mlxcel-surgery/src/ops/mod.rs
+++ b/src/lib/mlxcel-surgery/src/ops/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Concrete [`crate::SurgeryOp`] implementations for Axis A
-//! (Epic #363, issues A5–A9).
+//! (issues A5–A9).
 //!
 //! The submodules in here each own a single operation. They share two
 //! conventions:

--- a/src/lib/mlxcel-surgery/src/ops/prune/mod.rs
+++ b/src/lib/mlxcel-surgery/src/ops/prune/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `PruneOp` — Axis A "Operation: Prune" (issue #376, Epic #363).
+//! `PruneOp` — Axis A "Operation: Prune".
 //!
 //! Zero-masks selected slices of model weight tensors at one of three
 //! structural granularities:

--- a/src/lib/mlxcel-surgery/src/ops/replace/mod.rs
+++ b/src/lib/mlxcel-surgery/src/ops/replace/mod.rs
@@ -14,7 +14,6 @@
 
 //! `ReplaceOp` — substitute base-model tensors with the matching
 //! tensors from an external donor `.safetensors` checkpoint
-//! (Epic #363 / issue #377).
 //!
 //! ## Semantics
 //!
@@ -36,7 +35,7 @@
 //!   All sibling shapes and dtypes must match between base and
 //!   donor, otherwise the op fails before mutating anything. This
 //!   enforces the "donor must share the exact quantization layout"
-//!   requirement from issue #377 with no implicit re-quantization.
+//!   requirement with no implicit re-quantization.
 //! - On any error, [`crate::SurgeryError`] is returned and the
 //!   underlying [`WeightMap`] is left unchanged ("atomic on
 //!   error").
@@ -321,7 +320,7 @@ const QUANT_SIBLING_SUFFIXES: &[&str] = &[".scales", ".biases"];
 
 /// Verify that `donor` is a drop-in substitute for `base` — same
 /// shape and same dtype. The exact-equality requirement keeps the
-/// issue #377 contract simple: no implicit re-quantization, no
+/// contract simple: no implicit re-quantization, no
 /// implicit precision conversion.
 ///
 /// Used by: [`ReplaceOp::apply`]

--- a/src/lib/mlxcel-surgery/src/ops/replace/tests.rs
+++ b/src/lib/mlxcel-surgery/src/ops/replace/tests.rs
@@ -14,7 +14,7 @@
 
 //! Unit tests for `ReplaceOp`.
 //!
-//! Covers issue #377 acceptance criterion (a):
+//! Covers acceptance criterion (a):
 //! - construction-time validation (wildcard count, empty inputs);
 //! - single-tensor replace;
 //! - multi-tensor replace via glob;

--- a/src/lib/mlxcel-surgery/src/ops/scale.rs
+++ b/src/lib/mlxcel-surgery/src/ops/scale.rs
@@ -14,7 +14,7 @@
 
 //! `ScaleOp` — multiply every matched tensor by a scalar factor.
 //!
-//! YAML shape (#369 — A3):
+//! YAML shape (— A3):
 //!
 //! ```yaml
 //! - op: scale

--- a/src/lib/mlxcel-surgery/src/pipeline.rs
+++ b/src/lib/mlxcel-surgery/src/pipeline.rs
@@ -14,7 +14,7 @@
 
 //! `SurgeryPipeline` — ordered collection of `SurgeryOp` that itself
 //! implements the [`mlxcel_core::weights::WeightTransform`] hook
-//! from issue #365 (A1).
+//! (A1).
 
 use mlxcel_core::weights::{WeightMap, WeightTransform};
 
@@ -25,7 +25,7 @@ use crate::{SharedSurgeryOp, SurgeryOp};
 /// `SurgeryPipeline` is the only public type that gets handed to the
 /// consolidated weight loaders. It is constructed either
 /// programmatically (`SurgeryPipeline::new()` followed by `push`) or
-/// by the config layer (issue #369), and then passed to
+/// by the config layer, and then passed to
 /// `mlxcel::models::load_text_weights(path, Some(&pipeline))` or the
 /// VLM equivalent.
 ///
@@ -34,8 +34,7 @@ use crate::{SharedSurgeryOp, SurgeryOp};
 /// every concurrent model loader without re-parsing the config.
 ///
 /// Used by: future `mlxcel::surgery` integration glue (CLI flag —
-/// A4), text and VLM consolidated loaders (via the WeightTransform
-/// hook from #365)
+/// A4), text and VLM consolidated loaders (via the WeightTransform hook)
 #[derive(Default, Clone)]
 pub struct SurgeryPipeline {
     ops: Vec<SharedSurgeryOp>,
@@ -88,7 +87,7 @@ impl WeightTransform for SurgeryPipeline {
 }
 
 /// Convenience constructor: build a pipeline from any iterator of
-/// shared ops. Useful for the config layer (issue #369) which yields
+/// shared ops. Useful for the config layer which yields
 /// ops one at a time as it parses YAML.
 impl FromIterator<SharedSurgeryOp> for SurgeryPipeline {
     fn from_iter<I: IntoIterator<Item = SharedSurgeryOp>>(iter: I) -> Self {

--- a/src/lib/mlxcel-surgery/tests/add_integration.rs
+++ b/src/lib/mlxcel-surgery/tests/add_integration.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! End-to-end integration test for `AddOp` (issue #375 — A6).
+//! End-to-end integration test for `AddOp` (— A6).
 //!
 //! Drives the full public surface — `SurgeryPipeline` constructed
 //! via `parse_config_file` and also directly via `push` — over a
@@ -23,7 +23,7 @@
 //! it lands, this integration test stands in for the "the pipeline
 //! integrates with the load path" acceptance criterion by exercising
 //! the same `WeightTransform::apply` entry point that the
-//! consolidated text/VLM loaders use (#365 / A1).
+//! consolidated text/VLM loaders use (A1).
 //!
 //! Used by: `cargo test -p mlxcel-surgery`.
 

--- a/src/lib/mlxcel-surgery/tests/interpolate_integration.rs
+++ b/src/lib/mlxcel-surgery/tests/interpolate_integration.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Integration test for the Axis A `InterpolateOp` (issue #378).
+//! Integration test for the Axis A `InterpolateOp`.
 //!
 //! Verifies the end-to-end flow that the consolidated weight loader
 //! will exercise once A4 wires the `--surgery` CLI flag: parse a
@@ -205,7 +205,7 @@ fn direct_interpolate_op_via_pipeline_loads_safetensors_from_disk() {
 #[test]
 fn pipeline_without_interpolate_op_leaves_weights_untouched() {
     // Acceptance (e): without the op in the pipeline, bit-exact to
-    // baseline (inherited from A4 / #365). An empty pipeline is the
+    // baseline (inherited from A4). An empty pipeline is the
     // strongest version of this guarantee.
     let pipeline = SurgeryPipeline::new();
     let mut weights = synth_base_zeros();
@@ -248,7 +248,7 @@ fn interpolate_op_surfaces_missing_donor_file_error() {
 
 #[test]
 fn yaml_parser_rejects_nonexistent_donor_at_parse_time() {
-    // The config layer (#369) refuses to construct a pipeline when
+    // The config layer refuses to construct a pipeline when
     // any donor file does not exist. This is the first line of
     // defense and means surgery never gets as far as touching
     // weights for a clearly-broken config.

--- a/src/lib/mlxcel-surgery/tests/prune_integration.rs
+++ b/src/lib/mlxcel-surgery/tests/prune_integration.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Integration tests for `mlxcel-surgery` PruneOp (issue #376).
+//! Integration tests for `mlxcel-surgery` PruneOp.
 //!
 //! These tests exercise the **public** API path that the rest of the
 //! workspace will use: parse a YAML file -> get a `SurgeryPipeline` ->
 //! invoke it through `WeightTransform::apply`. They replicate the
 //! load-pipeline integration without requiring a real model on disk
-//! (the actual end-to-end run against `mlx-community/Qwen2.5-0.5B-
-//! Instruct-4bit` happens via the CLI integration in #379 / A4).
+//! (the actual end-to-end run against `mlx-community/Qwen2.5-0.5B- Instruct-4bit` happens via the CLI integration / A4).
 
 use std::collections::HashMap;
 use std::io::Write;
@@ -227,8 +226,7 @@ operations:
 #[test]
 fn programmatic_pipeline_builder_works_without_yaml() {
     // Build a pipeline directly via `SurgeryPipeline::push` to prove
-    // the public API supports programmatic construction (the path
-    // used by tests in #378 / A4 until the CLI flag is wired).
+    // the public API supports programmatic construction (the path used by tests / A4 until the CLI flag is wired).
     let mut pipeline = SurgeryPipeline::new();
     let op = PruneOp::new(
         "model.layers.0.self_attn.*",

--- a/src/lib/mlxcel-surgery/tests/replace_integration.rs
+++ b/src/lib/mlxcel-surgery/tests/replace_integration.rs
@@ -16,7 +16,7 @@
 //! parser and the `SurgeryPipeline` `WeightTransform` hook.
 //!
 //! These tests exercise the public API surface a downstream caller
-//! (`mlxcel::models::load_text_weights` after lands the `--surgery` CLI flag) would use:
+//! (`mlxcel::models::load_text_weights` once the `--surgery` CLI flag lands) would use:
 //!
 //! ```text
 //! YAML -> parse_config_file -> SurgeryPipeline

--- a/src/lib/mlxcel-surgery/tests/replace_integration.rs
+++ b/src/lib/mlxcel-surgery/tests/replace_integration.rs
@@ -16,8 +16,7 @@
 //! parser and the `SurgeryPipeline` `WeightTransform` hook.
 //!
 //! These tests exercise the public API surface a downstream caller
-//! (`mlxcel::models::load_text_weights` after issue #371 lands the
-//! `--surgery` CLI flag) would use:
+//! (`mlxcel::models::load_text_weights` after lands the `--surgery` CLI flag) would use:
 //!
 //! ```text
 //! YAML -> parse_config_file -> SurgeryPipeline

--- a/src/loaded_model.rs
+++ b/src/loaded_model.rs
@@ -134,7 +134,7 @@ pub enum LoadedModel {
     Mamba2(models::Mamba2Model),
     Jamba(models::JambaModel),
     NemotronH(models::NemotronHModel),
-    /// Nemotron H Nano Omni — vision-capable variant (issue #554, vision-only).
+    /// Nemotron H Nano Omni — vision-capable variant (vision-only).
     NemotronHNanoOmniVLM(vision::NemotronHNanoOmniVlModel),
     NemotronNAS(models::NemotronNASModel),
     Step3p5(models::Step3p5Model),

--- a/src/loaded_model_capabilities.rs
+++ b/src/loaded_model_capabilities.rs
@@ -40,11 +40,11 @@ pub enum VlmRuntimeRef<'a> {
     Molmo(&'a vision::MolmoVLModel),
     Molmo2(&'a vision::Molmo2VLModel),
     MolmoPoint(&'a vision::MolmoPointVLModel),
-    /// Nemotron H Nano Omni vision runtime (issue #554, vision-only scope).
+    /// Nemotron H Nano Omni vision runtime (vision-only scope).
     NemotronHNanoOmni(&'a vision::NemotronHNanoOmniVlModel),
-    /// Youtu-VL runtime (issue #555).
+    /// Youtu-VL runtime.
     YoutuVL(&'a vision::YoutuVLModel),
-    /// InternVL (internvl_chat) runtime (issue #738).
+    /// InternVL (internvl_chat) runtime.
     InternVL(&'a vision::InternVLChatVLM),
     Standard(&'a vision::VisionModule),
 }
@@ -167,7 +167,7 @@ impl LoadedModel {
 
     /// Bind any pending MRoPE state (the per-row deltas just set by a Qwen
     /// VL `get_input_embeddings` pass) to a specific server sequence id so
-    /// the cached scalar can no longer leak across requests (issue #540).
+    /// the cached scalar can no longer leak across requests.
     ///
     /// This is a no-op for non-Qwen-VL models. The caller passes the id
     /// the scheduler already allocated for this request — the VLM runtime
@@ -185,7 +185,7 @@ impl LoadedModel {
     /// underlying Qwen VL text model. Used by the server preemption
     /// path so the entry survives the eviction (which releases the old
     /// sequence id) and can be reinstalled under the freshly allocated
-    /// id (issue #540 follow-up).
+    /// id (follow-up).
     ///
     /// Returns an empty snapshot for non-Qwen-VL models or when no
     /// entry exists for `seq_id`.
@@ -223,7 +223,7 @@ impl LoadedModel {
     /// projected by `get_input_embeddings_with_audio_and_cache`) to a
     /// specific server sequence id so a burst of Gemma 4 VLM requests
     /// in a single drain tick cannot have one row's prefill consume
-    /// another row's tensor (issue #543).
+    /// another row's tensor.
     ///
     /// This is a no-op for non-Gemma-4 models. The caller passes the
     /// id the scheduler already allocated for the request; the VLM
@@ -246,7 +246,7 @@ impl LoadedModel {
     /// allocated id — `prepare_request_vlm_embeddings` does not run
     /// again on re-prefill, so without the take/install round trip
     /// the re-prefill would observe `per_layer_inputs == None` and
-    /// produce wrong logits for E2B/E4B variants (issue #543).
+    /// produce wrong logits for E2B/E4B variants.
     ///
     /// Returns `None` for non-Gemma-4 models, the E1B variant, or
     /// when no entry exists for `seq_id`.

--- a/src/loading/vlm.rs
+++ b/src/loading/vlm.rs
@@ -128,7 +128,7 @@ pub(super) fn require_object_mut<'a>(
 /// remap which runs in the caller after we return). Surgery operations
 /// inspecting dtype therefore see the dtype the model graph will see.
 ///
-/// ## Active-pipeline fallback (issue #371 — A4)
+/// ## Active-pipeline fallback (— A4)
 ///
 /// When the explicit `transform` argument is `None` *and* the
 /// `surgery` feature is enabled *and* the CLI has installed an active
@@ -171,13 +171,13 @@ pub(crate) fn load_vlm_weights_common(
         }
     }
 
-    // Axis A weight-load surgery hook (Epic #363). Invoked with the
+    // Axis A weight-load surgery hook. Invoked with the
     // parsed config.json so transforms can inspect quantization or
     // structural metadata. When both `transform` and the active
     // surgery slot are absent, the hook is bypassed entirely and the
-    // load path matches the pre-#371 baseline bit-for-bit.
+    // load path matches the earlier baseline bit-for-bit.
     //
-    // Resolution order (issue #371, A4) mirrors `load_text_weights`:
+    // Resolution order (A4) mirrors `load_text_weights`:
     //   1. Explicit `transform` argument (test fixtures, programmatic).
     //   2. CLI-installed active pipeline (--surgery flag).
     //   3. Baseline — no transform applied.

--- a/src/loading/vlm_nemotron_h_nano_omni.rs
+++ b/src/loading/vlm_nemotron_h_nano_omni.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Nemotron H Nano Omni VLM loader (issues #554, #582).
+//! Nemotron H Nano Omni VLM loader.
 //!
 //! Constructs [`crate::vision::NemotronHNanoOmniVlModel`] from a HF
-//! `mlx-community` checkpoint. The vision path landed in #554; the
-//! audio path was added in #582 and only activates when the checkpoint
+//! `mlx-community` checkpoint. The vision path landed; the
+//! audio path was added and only activates when the checkpoint
 //! ships a `sound_config` block.
 //!
 //! Wire-up:
@@ -67,8 +67,8 @@ use crate::vision::processors::nemotron_h_nano_omni::{
 
 /// Strip audio-only weights when the checkpoint has no `sound_config`.
 ///
-/// Issue #554 dropped every `sound_*`/`audio_tower.*` weight at load
-/// time. Issue #582 keeps them when the checkpoint advertises a
+/// dropped every `sound_*`/`audio_tower.*` weight at load
+/// time. keeps them when the checkpoint advertises a
 /// `sound_config` (so the audio encoder can pick them up) and only
 /// strips them when audio is genuinely absent. This preserves
 /// backwards-compatibility for older Nemotron H Nano Omni snapshots
@@ -338,9 +338,9 @@ pub(crate) fn load_nemotron_h_nano_omni_vlm(model_path: &Path) -> Result<LoadedM
         .and_then(Value::as_i64)
         .unwrap_or(0) as i32;
 
-    // Parse audio config (issue #582). Audio is opt-in: when
+    // Parse audio config. Audio is opt-in: when
     // `sound_config` is absent the loader stays bit-for-bit identical
-    // to the issue-#554 path.
+    // to the issue- path.
     let audio_config = full_config
         .get("sound_config")
         .map(|value| -> Result<NemotronOmniAudioConfig> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,7 +218,7 @@ pub(crate) struct GenerateArgs {
     #[command(flatten)]
     pub(crate) speculative: SpeculativeArgs,
 
-    // Axis A weight-load surgery configuration (Epic #363, issue #371).
+    // Axis A weight-load surgery configuration.
     // The closed-repo references stay in this non-doc comment so the
     // user-facing `--help` block does not advertise tracker URLs (see
     // `tests/cli_help_consistency.rs::FORBIDDEN_SUBSTRINGS`).
@@ -1268,7 +1268,7 @@ pub(crate) struct ServeArgs {
     #[arg(long = "chat-template-kwargs", value_name = "JSON")]
     chat_template_kwargs: Option<String>,
 
-    // Issue #424: cross-request prompt-prefix KV cache knobs.
+    // cross-request prompt-prefix KV cache knobs.
     /// Enable or disable the cross-request prompt-prefix KV cache (default: true).
     ///
     /// When disabled, the server performs no prefix-match lookup and no memory
@@ -1313,7 +1313,7 @@ pub(crate) struct ServeArgs {
     #[arg(long = "prompt-cache-min-prefix", value_name = "N")]
     prompt_cache_min_prefix: Option<usize>,
 
-    // Issue #552: Automatic Prefix Caching (APC) knobs.
+    // Automatic Prefix Caching (APC) knobs.
     /// Enable Automatic Prefix Caching (APC) with block-granularity hash chains
     /// (default: false).
     ///
@@ -1359,7 +1359,7 @@ pub(crate) struct ServeArgs {
     #[arg(long = "apc-hash", value_name = "ALGO")]
     apc_hash: Option<String>,
 
-    // Axis A weight-load surgery configuration (Epic #363, issue #371).
+    // Axis A weight-load surgery configuration.
     // Closed-repo references kept in a non-doc comment to avoid leaking
     // tracker URLs into `--help` text.
     /// Apply weight-load surgery configuration from a YAML file.

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -185,7 +185,7 @@ fn generate_command_parses_tensor_parallel_flags() {
     assert_eq!(args.tensor_parallel.tp_lm_head_mode, "replicated");
 }
 
-// Issue #371 (A4): CLI argument-parsing tests for the `--surgery <FILE>`
+// (A4): CLI argument-parsing tests for the `--surgery <FILE>`
 // flag on the `generate` and `serve` subcommands. These tests only cover
 // the clap surface — they do not invoke the surgery pipeline or touch
 // any model weights. The end-to-end behavior is exercised by the
@@ -221,7 +221,7 @@ fn generate_command_accepts_surgery_flag_with_path() {
 #[test]
 fn generate_command_surgery_flag_defaults_to_none() {
     // Baseline path: omitting the flag yields `None`, which keeps the
-    // load path bit-exact with pre-#371 main (acceptance criterion (e)).
+    // load path bit-exact with earlier main (acceptance criterion (e)).
     let cli = Cli::try_parse_from(["mlxcel", "generate", "-m", "models/foo", "-p", "hello"])
         .expect("clap must accept generate without --surgery");
 

--- a/src/models/cohere2.rs
+++ b/src/models/cohere2.rs
@@ -179,7 +179,7 @@ impl Cohere2Attention {
         // Scaled dot-product attention
         let attn_out = if l > 1 {
             // Prefill: use mask. If a windowed mask was supplied for a
-            // sliding-window layer, post-PR-#513 it is shaped
+            // sliding-window layer, post-earlier it is shaped
             // `(l, window_size)` (capped). Plain `KVCache` returns
             // full-length K/V, so slice K/V to the last `window_size` slots
             // here, mirroring `causal_attention`'s internal slicing.

--- a/src/models/gemma3.rs
+++ b/src/models/gemma3.rs
@@ -1212,7 +1212,6 @@ impl mlxcel_core::generate::LanguageModel for Gemma3Wrapper {
         // intentionally empty/ignored. Reset the fallback slot before each
         // fresh CLI / benchmark generation so a second VLM prefill does not
         // reuse offsets from a previous run with a stale 4D attention mask
-        // (issue #731).
         self.reset_caches();
     }
 

--- a/src/models/gemma3n.rs
+++ b/src/models/gemma3n.rs
@@ -475,7 +475,7 @@ impl Gemma3nAttention {
             // For KV-shared layers, return slice view of filled portion only.
             // cache.keys is a pre-allocated buffer; we must slice to the live
             // window length (`live_len() = offset - live_start`) — NOT the
-            // monotonic `offset` — so this stays correct when issue #603's
+            // monotonic `offset` — so this stays correct when's
             // `--max-kv-size` trim_front advances `live_start`. With no trim
             // (`live_start == 0`) this is bit-identical to slicing at
             // `cache.offset`.
@@ -516,7 +516,7 @@ impl Gemma3nAttention {
         } else {
             // Single token or explicit mask path. If the caller supplied a
             // windowed mask and this layer is a sliding-window layer, the
-            // mask is shaped `(q_len, window_size)` post-PR-#513 cap. Plain
+            // mask is shaped `(q_len, window_size)` post-earlier cap. Plain
             // `KVCache` returns full-length K/V, so we must slice K/V to
             // match the capped mask, mirroring `causal_attention` internals.
             let k_shape = mlxcel_core::array_shape(&keys);

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -674,7 +674,7 @@ impl Cache {
     /// upstream Python `hasattr(c, "trim")` dispatch in
     /// `Gemma4 LanguageModel.rollback_speculative_cache`.
     ///
-    /// Used by: Gemma 4 MTP `rollback_speculative_cache` (issue #625).
+    /// Used by: Gemma 4 MTP `rollback_speculative_cache`.
     pub(crate) fn trim_speculative(&mut self, n: i32) -> i32 {
         match self {
             Self::Standard(cache) => cache.trim(n),
@@ -721,7 +721,7 @@ impl Cache {
     /// its monotonic offset and the next decode write overwrites the
     /// trimmed slot.
     ///
-    /// Used by: Gemma 4 MTP `rollback_speculative_cache` (issue #625).
+    /// Used by: Gemma 4 MTP `rollback_speculative_cache`.
     pub(crate) fn zero_partial_accept_tail(
         &mut self,
         valid_ends: &[i32],
@@ -1592,7 +1592,6 @@ pub struct Gemma4TextModel {
 }
 
 /// Output sinks for the Gemma 4 MTP speculative-decoding target hooks
-/// (issue #625).
 ///
 /// All fields are `Option` so callers that do not need a hook pay zero cost
 /// on the hot path — the `forward_with_speculative_sinks` consumer only
@@ -1616,8 +1615,8 @@ pub struct Gemma4TextModel {
 ///   per K and V: `[B, num_kv_heads, kv_len, head_dim]` in the model's
 ///   native dtype.
 ///
-/// Used by: future `Gemma4AssistantDraftModel` (issue #626) and
-/// `MtpGenerator` (issue #629).
+/// Used by: future `Gemma4AssistantDraftModel` and
+/// `MtpGenerator`.
 #[derive(Default)]
 pub struct Gemma4SpeculativeSinks {
     pub hidden_sink: Option<Vec<UniquePtr<MlxArray>>>,
@@ -1678,7 +1677,7 @@ impl Gemma4TextModel {
     }
 
     /// Forward pass with optional speculative-decoding hooks for the Gemma 4
-    /// MTP target path (issue #625).
+    /// MTP target path.
     ///
     /// When `sinks` is `None`, behaves exactly like [`Self::forward`] (zero
     /// overhead beyond the wrapping struct).
@@ -1719,7 +1718,7 @@ impl Gemma4TextModel {
         // `sqrt(hidden_size)` embed scale to the text portion *before*
         // merging. Scaling here would double-scale the text tokens and
         // incorrectly scale image/audio features that are already in the
-        // language-model embedding space. See issue #317.
+        // language-model embedding space..
         let mut h = if let Some(embeddings) = input_embeddings {
             mlxcel_core::copy(embeddings)
         } else {
@@ -1780,7 +1779,7 @@ impl Gemma4TextModel {
         let profile_layer_build = std::env::var("MLXCEL_PROFILE_LAYER_BUILD").is_ok();
         let profile_subops = std::env::var("MLXCEL_PROFILE_LAYER_SUBOPS").is_ok();
 
-        // Speculative-decoding capture (issue #625). The `capture_set` mirrors
+        // Speculative-decoding capture. The `capture_set` mirrors
         // upstream's `set(capture_layer_ids)`; when non-empty the
         // `hidden_sink` is appended to inside the loop at each matching idx,
         // otherwise the sink receives the final pre-norm `h` after the loop.
@@ -2173,7 +2172,7 @@ impl Gemma4Model {
     }
 
     /// Sink-aware variant of [`Self::forward_with_caches_and_embeddings`]
-    /// used by the Gemma 4 MTP target path (issue #625). Delegates the
+    /// used by the Gemma 4 MTP target path. Delegates the
     /// transformer pass to
     /// [`Gemma4TextModel::forward_with_speculative_sinks`] then applies
     /// the embedding tied LM head + optional final-logit softcap exactly
@@ -2769,7 +2768,7 @@ impl Gemma4StageModel {
 
 /// Wrapper for [`Gemma4Model`] that implements [`LanguageModel`] with
 /// per-`SequenceId` cache isolation so the server scheduler can run
-/// mixed-length batches correctly (issue #542).
+/// mixed-length batches correctly.
 ///
 /// Gemma 4's `Cache` enum (`KVCache | RotatingKVCache`) is a sliding-
 /// window-aware cache that the model owns internally — it cannot be
@@ -2934,12 +2933,11 @@ impl Gemma4Wrapper {
     /// `sqrt(hidden_size)` embed scale to text embeddings before merging in
     /// vision / audio features. Vision and audio features must NOT be scaled
     /// again since they are already in the language-model embedding space
-    /// (see issue #317).
     pub fn hidden_size(&self) -> usize {
         self.model.config.hidden_size
     }
 
-    /// Sink-aware forward used by the Gemma 4 MTP target path (issue #625).
+    /// Sink-aware forward used by the Gemma 4 MTP target path.
     ///
     /// Mirrors [`Self::forward_with_inputs_and_sequence_id`] but additionally
     /// captures the LAST decoder hidden state (or per-layer hidden states
@@ -2948,7 +2946,7 @@ impl Gemma4Wrapper {
     /// [`Gemma4SpeculativeSinks`]. Resolves to the per-`SequenceId` cache
     /// slot via [`ModelOwnedSequenceState::with_or_create_sequence_state`]
     /// — the same isolation the rest of Gemma 4 already uses for batched
-    /// decode (issue #542), so the speculative loop does not need to
+    /// decode, so the speculative loop does not need to
     /// allocate a side cache.
     ///
     /// When `sinks` is `None` and `capture_layer_ids` is `None`, this is
@@ -2956,8 +2954,8 @@ impl Gemma4Wrapper {
     /// optional final-logit softcap, zero allocation overhead beyond the
     /// `Option`s.
     ///
-    /// Used by: future `Gemma4AssistantDraftModel` consumer (issue #626) and
-    /// `MtpGenerator` (issue #629).
+    /// Used by: future `Gemma4AssistantDraftModel` consumer and
+    /// `MtpGenerator`.
     pub fn forward_with_speculative_sinks(
         &self,
         input_ids: &MlxArray,
@@ -2986,7 +2984,7 @@ impl Gemma4Wrapper {
     }
 
     /// Sink-aware forward against a **caller-owned** `[B, ...]` cache
-    /// vector (issue #674, batched MTP dispatch).
+    /// vector (batched MTP dispatch).
     ///
     /// Unlike [`Self::forward_with_speculative_sinks`], this variant does
     /// NOT resolve the cache through [`ModelOwnedSequenceState`] /
@@ -3075,7 +3073,7 @@ impl Gemma4Wrapper {
     }
 
     /// Allocate a fresh per-layer cache vector for a batched MTP burst
-    /// (issue #674). Every cache starts empty; the batched verify pass
+    /// Every cache starts empty; the batched verify pass
     /// grows them with a leading batch dim `B` once the first `[B, L]`
     /// prefill flows through
     /// [`Self::forward_with_speculative_sinks_explicit_cache`].
@@ -3092,7 +3090,7 @@ impl Gemma4Wrapper {
     }
 
     /// Rewind the per-sequence target KV caches after a Gemma 4 MTP
-    /// speculative-decoding round (issue #625). Mirrors the upstream Python
+    /// speculative-decoding round. Mirrors the upstream Python
     /// hook
     /// (`references/mlx-vlm/mlx_vlm/models/gemma4/language.py` lines
     /// 608-646) bit-for-bit:
@@ -3124,7 +3122,7 @@ impl Gemma4Wrapper {
     /// (e.g. mismatched batch shape between cache buffer and `accepted`,
     /// or rotating-cache write index that predates the verify pass).
     ///
-    /// Used by: future `MtpGenerator` Gemma 4 verify loop (issue #629).
+    /// Used by: future `MtpGenerator` Gemma 4 verify loop.
     pub fn rollback_speculative_cache(
         &self,
         seq_id: Option<SequenceId>,
@@ -3177,7 +3175,7 @@ impl Gemma4Wrapper {
     }
 
     /// Per-row tail-zero rollback against a **caller-owned** `[B, ...]`
-    /// cache vector (issue #674, batched MTP dispatch).
+    /// cache vector (batched MTP dispatch).
     ///
     /// Identical trim + per-row tail-zero logic as
     /// [`Self::rollback_speculative_cache`], but operates on an explicit
@@ -3366,7 +3364,7 @@ impl LanguageModel for Gemma4Wrapper {
         self.model.eos_token_ids.clone()
     }
 
-    /// Issue #542: Gemma 4 supports batched decode now that
+    /// Gemma 4 supports batched decode now that
     /// [`ModelOwnedSequenceState`] isolates per-`SequenceId` cache state.
     /// The vision wrapper's `forward_batched_with_context_and_ids`
     /// override (in `vision::Gemma4VLModel`) routes each row through

--- a/src/models/gemma4_mtp_target.rs
+++ b/src/models/gemma4_mtp_target.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! MTP target adapter for Gemma 4 (issue #666).
+//! MTP target adapter for Gemma 4.
 //!
 //! Glue layer that wires the binary-side
 //! [`crate::models::gemma4::Gemma4Wrapper`] (and its VLM variant
 //! [`crate::vision::Gemma4VLModel`]) to the
 //! [`mlxcel_core::speculative::mtp::target::MtpTarget`] trait defined in
-//! `mlxcel-core` (issue #662). The trait sits between the round-loop
+//! `mlxcel-core`. The trait sits between the round-loop
 //! driver [`mlxcel_core::speculative::mtp::MtpGenerator`] and the concrete
 //! Gemma 4 wrapper so the driver can stay in the core crate without
 //! pulling in `mlxcel`-binary types.
@@ -314,7 +314,7 @@ impl<'a> Gemma4MtpTargetAdapter<'a> {
 
     /// Compute per-position [`mlxcel_core::sampling::TokenLogprobData`]
     /// for a `[1, block_size, vocab]` verify-logits tensor, one entry
-    /// per position aligned 1:1 with `target_tokens` (issue #678).
+    /// per position aligned 1:1 with `target_tokens`.
     ///
     /// The verify forward is greedy-only today (`temperature == 0`,
     /// pure argmax — see [`Self::argmax_per_position`]), so the
@@ -398,12 +398,11 @@ impl<'a> MtpTarget for Gemma4MtpTargetAdapter<'a> {
         // `token_history` carries the history-dependent-penalty context
         // (repetition / frequency / presence / DRY) so the first bonus
         // is byte-identical to the classic decode path's first token
-        // (issue #677). `sample_token_optimized` returns
+        // `sample_token_optimized` returns
         // `(token_arr, adjusted_logits)`; `adjusted_logits` is the
         // penalty-adjusted `[1, vocab]` slice the bonus was sampled
         // from, and feeds `compute_logprobs` so the first-bonus logprob
         // is byte-identical to the classic path's first-token logprob
-        // (issue #678).
         let (token_arr, adjusted_logits) = sample_token_optimized(&logits, sampler, token_history);
         mlxcel_core::eval(&token_arr);
         let first_bonus = mlxcel_core::item_i32(&token_arr);
@@ -544,7 +543,7 @@ impl<'a> MtpTarget for Gemma4MtpTargetAdapter<'a> {
         // Per-position log-probability data, aligned 1:1 with
         // `target_tokens`. `None` (zero-overhead) when logprobs are
         // disabled; the round loop forwards the entries for accepted
-        // positions on to `finalize_burst_success` (issue #678).
+        // positions on to `finalize_burst_success`.
         let target_logprobs = logits.as_ref().and_then(|logits| {
             Self::per_position_logprobs(logits, &target_tokens, logprobs_config)
         });
@@ -736,7 +735,7 @@ impl<'a> MtpTarget for Gemma4VLMtpTargetAdapter<'a> {
 }
 
 // ===========================================================================
-// Batched MTP target adapter (B > 1) — issue #674
+// Batched MTP target adapter (B > 1)
 // ===========================================================================
 
 /// Drafter-requested capture-layer ids for the batched verify path.
@@ -750,7 +749,7 @@ impl<'a> MtpTarget for Gemma4VLMtpTargetAdapter<'a> {
 const BATCHED_CAPTURE_LAYER_IDS: Option<&[usize]> = None;
 
 /// Batched MTP target adapter binding a [`Gemma4Wrapper`] to a
-/// **caller-owned** `[B, ...]` cache vector (issue #674).
+/// **caller-owned** `[B, ...]` cache vector.
 ///
 /// ## Why this is a distinct struct from [`Gemma4MtpTargetAdapter`]
 ///
@@ -1093,11 +1092,7 @@ impl<'a> MtpTarget for Gemma4MtpBatchedTargetAdapter<'a> {
     // The B = 1 surface is required by the trait but never driven on the
     // batched adapter — the batched round-loop driver only calls the
     // `*_batched` methods. We panic rather than silently mis-routing so a
-    // wiring bug surfaces loudly in tests. (`token_history` is part of
-    // the B = 1 signature since issue #682 and `logprobs_config` since
-    // issue #678; the batched path's history-aware and logprobs-aware
-    // sampling is gated at the scheduler's window collector — see
-    // `prefill_and_seed_batched` below.)
+    // wiring bug surfaces loudly in tests. (`token_history` is part of the B = 1 signature since and `logprobs_config` since the batched path's history-aware and logprobs-aware sampling is gated at the scheduler's window collector — see `prefill_and_seed_batched` below.)
     fn prefill_and_seed(
         &self,
         _prompt_tokens: &[i32],
@@ -1389,8 +1384,8 @@ impl<'a> Gemma4VLMtpBatchedTargetAdapter<'a> {
 impl<'a> MtpTarget for Gemma4VLMtpBatchedTargetAdapter<'a> {
     // The B = 1 surface forwards to the inner batched adapter, whose B = 1
     // stubs panic — the batched VLM adapter is only ever driven through
-    // the `*_batched` methods. `token_history` (issue #682) and
-    // `logprobs_config` (issue #678) are forwarded verbatim so the
+    // the `*_batched` methods. `token_history` and
+    // `logprobs_config` are forwarded verbatim so the
     // signature matches the trait even though the inner panics.
     fn prefill_and_seed(
         &self,

--- a/src/models/gemma4_mtp_target_tests.rs
+++ b/src/models/gemma4_mtp_target_tests.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //! Structural unit tests for the Gemma 4 [`MtpTarget`] adapter
-//! (issue #666).
 //!
 //! These tests pin the adapter's **trait surface** without loading real
 //! Gemma 4 weights. The full on-hardware greedy-parity test for the
@@ -116,7 +115,7 @@ fn argmax_per_position_returns_one_id_per_position() {
 }
 
 // ===========================================================================
-// Batched MTP target adapter helper tests (issue #674)
+// Batched MTP target adapter helper tests
 //
 // These pin the pure-tensor helper methods of `Gemma4MtpBatchedTargetAdapter`
 // without loading real Gemma 4 weights. The full on-hardware B = 4

--- a/src/models/gemma4_tests.rs
+++ b/src/models/gemma4_tests.rs
@@ -14,7 +14,7 @@
 
 //! Unit tests for Gemma 4 configuration parsing and RoPE handling.
 //!
-//! These tests lock in the behavior described in GitHub issue #321:
+//! These tests lock in the behavior described in GitHub
 //!
 //! 1. Real Gemma 4 checkpoints declare `rope_type: "proportional"` on every
 //!    `full_attention` layer and `rope_type: "default"` on every
@@ -32,14 +32,14 @@ fn parse_text_config(json: serde_json::Value) -> TextConfig {
 }
 
 // -----------------------------------------------------------------
-// Issue #542: per-`SequenceId` cache isolation tests for `Gemma4Wrapper`.
+// per-`SequenceId` cache isolation tests for `Gemma4Wrapper`.
 //
 // These tests build a tiny synthetic Gemma 4 model (1 layer, hidden=4,
 // vocab=8, sliding-attention only) and verify that
 // `Gemma4Wrapper::forward_with_sequence_id` resolves to a distinct
 // per-sequence `Vec<Cache>` so a mixed-length batch cannot leak cache
-// state across rows. This is the runtime fix for issue #542 — the
-// per-row dispatch helper added in PR #560 only routes correctly if
+// state across rows. This is the runtime fix — the
+// per-row dispatch helper added only routes correctly if
 // the underlying wrapper isolates cache state per `SequenceId`.
 //
 // The fixture is duplicated from
@@ -231,7 +231,7 @@ mod cache_isolation {
             .collect()
     }
 
-    /// Issue #542: `Gemma4Wrapper` must declare `supports_batching == true`
+    /// `Gemma4Wrapper` must declare `supports_batching == true`
     /// so the server scheduler actually drives the batched-decode dispatch
     /// path that calls `forward_with_sequence_id` per row.
     #[test]
@@ -239,13 +239,13 @@ mod cache_isolation {
         let wrapper = build_wrapper();
         assert!(
             wrapper.supports_batching(),
-            "Gemma4Wrapper must support batching after issue #542 (server batched decode \
+            "Gemma4Wrapper must support batching after (server batched decode \
              requires per-`SequenceId` cache isolation, which the wrapper now provides via \
              ModelOwnedSequenceState<Cache>)"
         );
     }
 
-    /// Issue #542: `Gemma4Wrapper` must declare a `ModelOwned` sequence
+    /// `Gemma4Wrapper` must declare a `ModelOwned` sequence
     /// state layout so the cache pool allocates a placeholder
     /// (empty `Vec<KVCache>`) per sequence and the wrapper itself owns
     /// the real `Vec<Cache>` keyed on `SequenceId`. A `DenseKvCache`
@@ -275,11 +275,11 @@ mod cache_isolation {
         );
     }
 
-    /// Issue #542: per-`SequenceId` cache isolation. Two sequences with
+    /// per-`SequenceId` cache isolation. Two sequences with
     /// distinct `SequenceId`s must produce row-correct logits even when
     /// driven through the same wrapper instance back-to-back.
     ///
-    /// Prior to issue #542 the wrapper held a single `RefCell<Vec<Cache>>`
+    /// Prior to the wrapper held a single `RefCell<Vec<Cache>>`
     /// shared across every call, so seq B's first decode step would
     /// inherit seq A's KV state and produce wrong logits. After the
     /// fix, each `SequenceId` resolves to its own slot in
@@ -324,7 +324,7 @@ mod cache_isolation {
         let prefill_a_mixed = mlxcel_core::from_slice_i32(&[3, 4], &[1, 2]);
         let _ = mixed.forward_with_sequence_id(&prefill_a_mixed, Some(seq_a), &mut [], None);
 
-        // Prefill seq B: longer/different tokens [1, 2, 6] — issue #542
+        // Prefill seq B: longer/different tokens [1, 2, 6]
         // explicitly requires the case where the two prompts differ in
         // length. If cache state leaks, seq A's offset would be stomped.
         let prefill_b_mixed = mlxcel_core::from_slice_i32(&[1, 2, 6], &[1, 3]);
@@ -368,7 +368,7 @@ mod cache_isolation {
         reference.release_sequence_state_by_id(seq_a_ref);
     }
 
-    /// Issue #542 acceptance criterion 1: a batch of two Gemma 4
+    /// acceptance criterion 1: a batch of two Gemma 4
     /// requests with different prompt lengths produces output for each
     /// row that matches the unbatched baseline within tolerance.
     ///
@@ -392,7 +392,7 @@ mod cache_isolation {
         baseline.prepare_sequence_state(seq_a);
         baseline.prepare_sequence_state(seq_b);
 
-        // Different-length prompts: the explicit reproducer for issue #542.
+        // Different-length prompts: the explicit reproducer.
         let prompt_a = mlxcel_core::from_slice_i32(&[3, 4], &[1, 2]);
         let prompt_b = mlxcel_core::from_slice_i32(&[1, 2, 6], &[1, 3]);
         let _ = baseline.forward_with_sequence_id(&prompt_a, Some(seq_a), &mut [], None);
@@ -456,7 +456,7 @@ mod cache_isolation {
             assert!(
                 abs_err < 1e-3 || rel_err < 1e-3,
                 "row A logit[{i}] differs: batched={got} vs unbatched={want} \
-                 (abs={abs_err}, rel={rel_err}) — issue #542 acceptance criterion 1 \
+                 (abs={abs_err}, rel={rel_err}) — acceptance criterion 1 \
                  violated"
             );
         }
@@ -466,7 +466,7 @@ mod cache_isolation {
             assert!(
                 abs_err < 1e-3 || rel_err < 1e-3,
                 "row B logit[{i}] differs: batched={got} vs unbatched={want} \
-                 (abs={abs_err}, rel={rel_err}) — issue #542 acceptance criterion 1 \
+                 (abs={abs_err}, rel={rel_err}) — acceptance criterion 1 \
                  violated"
             );
         }
@@ -589,7 +589,7 @@ fn real_gemma4_e2b_text_config() -> serde_json::Value {
 
 #[test]
 fn gemma4_config_parses_real_checkpoint_rope_parameters() {
-    // The primary regression target for issue #321: make sure we can in fact
+    // The primary regression target for make sure we can in fact
     // read `rope_type` out of the real checkpoint config without erroring,
     // and that both per-layer-type entries deserialize correctly.
     let cfg = parse_text_config(real_gemma4_e2b_text_config());
@@ -627,7 +627,7 @@ fn gemma4_rope_parameters_rope_type_defaults_when_absent() {
 
 #[test]
 fn gemma4_proportional_rope_freqs_match_python_semantics() {
-    // Lock in the numerical semantics of issue #321 Case A:
+    // Lock in the numerical semantics Case A:
     //
     //   freqs[i] = base^(2 * i / head_dim)   for i in [0, rope_angles)
     //
@@ -638,7 +638,7 @@ fn gemma4_proportional_rope_freqs_match_python_semantics() {
     //
     // If this test regresses, it means the RoPE frequencies diverged from
     // upstream `mlx_vlm.models.gemma4.rope_utils.ProportionalRoPE`, which
-    // is exactly the hazard that motivated issue #321.
+    // is exactly the hazard that motivated.
     let head_dim = 256_i32;
     let prf = 0.25_f32;
     let base = 1_000_000.0_f32;
@@ -702,14 +702,14 @@ fn gemma4_proportional_rope_freqs_match_python_semantics() {
 }
 
 // -----------------------------------------------------------------
-// Issue #625: Gemma 4 MTP target hooks — `rollback_speculative_cache`
+// Gemma 4 MTP target hooks — `rollback_speculative_cache`
 // + sink-aware forward.
 //
 // The tests below cover the cache-rewind primitives in isolation
 // (`RotatingKVCache::trim` + `Cache::zero_partial_accept_tail`) and
 // then exercise the sink path end-to-end through the synthetic
 // 1-layer Gemma 4 fixture defined in the `cache_isolation` sub-module
-// above (the same fixture issue #542's batching tests use). The
+// above (the same fixture's batching tests use). The
 // sink-path test is gated on serial MLX execution because the
 // fixture's forward pass touches the global MLX runtime.
 mod mtp_hooks {

--- a/src/models/jamba.rs
+++ b/src/models/jamba.rs
@@ -697,7 +697,7 @@ impl JambaMambaMixer {
         // Wrap slice in contiguous() to force MLX to materialize a fresh,
         // independent buffer. Without this, the slice is a lazy view that
         // retains a reference to the full padded_input allocation, causing a
-        // memory leak proportional to the sequence length. (issue #336)
+        // memory leak proportional to the sequence length.
         if let Some(c) = cache.as_deref_mut() {
             let padded_shape = mlxcel_core::array_shape(&padded_input);
             let len = padded_shape[1] as usize;

--- a/src/models/jamba_tests.rs
+++ b/src/models/jamba_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Regression tests for Jamba conv_state contiguous fix (issue #336).
+//! Regression tests for Jamba conv_state contiguous fix.
 
 use mlxcel_core::utils::slice_axis;
 

--- a/src/models/kimi_linear.rs
+++ b/src/models/kimi_linear.rs
@@ -282,7 +282,7 @@ impl ShortConv1d {
         // Wrap slice in contiguous() to force MLX to materialize a fresh,
         // independent buffer. Without this, the slice is a lazy view that
         // retains a reference to the full conv_input allocation, causing a
-        // memory leak proportional to the sequence length. (issue #323)
+        // memory leak proportional to the sequence length.
         let n_keep = (self.kernel_size - 1) as i32;
         let conv_shape = mlxcel_core::array_shape(&conv_input);
         let total_len = conv_shape[1];

--- a/src/models/llama3.rs
+++ b/src/models/llama3.rs
@@ -199,7 +199,7 @@ impl Attention {
             (q, k, v)
         };
 
-        // Issue #505: Try the fused sparse-V SDPA path for the decode case
+        // Try the fused sparse-V SDPA path for the decode case
         // (l == 1) when the cache is Turbo4Asym and
         // `MLXCEL_SPARSE_V_THRESHOLD > 0`. Skipped on prefill (l > 1) —
         // the per-token skip only wins at long context, and prefill builds

--- a/src/models/mamba.rs
+++ b/src/models/mamba.rs
@@ -229,7 +229,7 @@ impl MambaBlock {
         // Wrap slice in contiguous() to force MLX to materialize a fresh,
         // independent buffer. Without this, the slice is a lazy view that
         // retains a reference to the full padded_input allocation, causing a
-        // memory leak proportional to the sequence length. (issue #336)
+        // memory leak proportional to the sequence length.
         if let Some(c) = cache {
             let n_keep = k - 1;
             let padded_shape = mlxcel_core::array_shape(&padded_input);

--- a/src/models/mamba2.rs
+++ b/src/models/mamba2.rs
@@ -474,7 +474,7 @@ impl Mamba2Block {
         // Wrap slice in contiguous() to force MLX to materialize a fresh,
         // independent buffer. Without this, the slice is a lazy view that
         // retains a reference to the full padded_input allocation, causing a
-        // memory leak proportional to the sequence length. (issue #336)
+        // memory leak proportional to the sequence length.
         if let Some(c) = cache {
             let n_keep = k - 1;
             let padded_shape = mlxcel_core::array_shape(&padded_input);

--- a/src/models/mamba2_tests.rs
+++ b/src/models/mamba2_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Regression tests for Mamba2 conv_state contiguous fix (issue #336).
+//! Regression tests for Mamba2 conv_state contiguous fix.
 
 use mlxcel_core::utils::slice_axis;
 

--- a/src/models/mamba_tests.rs
+++ b/src/models/mamba_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Regression tests for Mamba conv_state contiguous fix (issue #336).
+//! Regression tests for Mamba conv_state contiguous fix.
 
 use mlxcel_core::utils::slice_axis;
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -296,7 +296,7 @@ pub enum ModelType {
     Jamba,
     NemotronH,
     /// Nemotron H Nano Omni — vision-capable variant of `nemotron_h`
-    /// (issue #554). Audio support is tracked separately as a follow-up.
+    /// Audio support is tracked separately as a follow-up.
     NemotronHNanoOmniVLM,
     NemotronNAS,
 

--- a/src/models/nemotron_h.rs
+++ b/src/models/nemotron_h.rs
@@ -514,7 +514,7 @@ impl NemotronHMamba2Mixer {
         // Wrap slice in contiguous() to force MLX to materialize a fresh,
         // independent buffer. Without this, the slice is a lazy view that
         // retains a reference to the full padded_input allocation, causing a
-        // memory leak proportional to the sequence length. (issue #336)
+        // memory leak proportional to the sequence length.
         if let Some(c) = cache.as_deref_mut() {
             let padded_shape = mlxcel_core::array_shape(&padded_input);
             let len = padded_shape[1] as usize;
@@ -916,7 +916,7 @@ impl NemotronHMamba2Mixer {
 
         // The C++ fused kernel builds new_conv_state via slice(padded_input, ...)
         // which is a lazy alias. Wrap with contiguous() to materialize a compact
-        // buffer and drop the upstream padded_input graph reference. (issue #336)
+        // buffer and drop the upstream padded_input graph reference.
         cache.conv_state = Some(mlxcel_core::contiguous(&new_conv_state, false));
         cache.ssm_state = Some(new_ssm_state);
 
@@ -1834,7 +1834,7 @@ impl NemotronHModel {
         // The full-decode C++ kernel calls fused_mamba2_forward internally,
         // which builds conv states via slice(padded_input, ...) — a lazy alias.
         // Wrap each conv_state with contiguous() to materialize a compact buffer
-        // and drop the upstream padded_input graph reference. (issue #336)
+        // and drop the upstream padded_input graph reference.
         let mut mamba_idx = 0;
         for c in caches.iter_mut() {
             if let NemotronLayerCache::Mamba(mc) = c {
@@ -1893,7 +1893,7 @@ impl NemotronHModel {
 
     /// Run the full layer stack starting from a pre-computed hidden
     /// state. Used by the VLM path that produces multimodal embeddings
-    /// upstream of the text backbone (issue #554, Nemotron H Nano Omni).
+    /// upstream of the text backbone (Nemotron H Nano Omni).
     ///
     /// Used by: Nemotron H Nano Omni VLM
     pub fn forward_with_inputs_embeds(&self, inputs_embeds: &MlxArray) -> UniquePtr<MlxArray> {

--- a/src/models/nemotron_h_tests.rs
+++ b/src/models/nemotron_h_tests.rs
@@ -306,7 +306,7 @@ fn post_init_only_time_step_max_defaults_to_zero_inf() {
 /// Config with both time_step_min: 0.001 and time_step_max: 0.1 set, but no
 /// time_step_limit. This is the typical real-world Nemotron-H config. After
 /// post_init, time_step_limit must be (0.0, +inf), NOT (0.001, 0.1).
-/// Regression test for issue #604.
+/// Regression test.
 #[test]
 fn post_init_both_time_step_min_max_set_defaults_to_zero_inf() {
     let json = minimal_config_json(r#", "time_step_min": 0.001, "time_step_max": 0.1"#);
@@ -363,7 +363,7 @@ fn post_init_explicit_time_step_limit_is_preserved() {
 }
 
 // ---------------------------------------------------------------------------
-// conv_state contiguous regression (issue #336)
+// conv_state contiguous regression
 // ---------------------------------------------------------------------------
 
 /// Simulate 50 decode steps of conv-state update and assert the stored shape

--- a/src/models/olmo3.rs
+++ b/src/models/olmo3.rs
@@ -159,7 +159,7 @@ pub struct OLMo3Attention {
     pub rope_base: f32,
     pub is_sliding: bool,
     /// Sliding-window size for sliding layers (0 for full-attention layers).
-    /// Used to slice K/V to match the post-PR-#513 capped sliding mask.
+    /// Used to slice K/V to match the post-earlier capped sliding mask.
     pub window_size: i32,
 }
 
@@ -206,7 +206,7 @@ impl OLMo3Attention {
         // Scaled dot-product attention
         let attn_out = if l > 1 && mask.is_some() {
             // Prefill with mask. If this is a sliding layer the windowed
-            // mask is capped to `(l, window_size)` post-PR-#513. Plain
+            // mask is capped to `(l, window_size)` post-earlier. Plain
             // `KVCache` returns full-length K/V, so slice K/V to the last
             // `window_size` slots to match the mask.
             let k_shape = mlxcel_core::array_shape(&cache_k);

--- a/src/models/qwen2_vl.rs
+++ b/src/models/qwen2_vl.rs
@@ -504,7 +504,7 @@ pub struct Qwen2VLModel {
     norm: RMSNorm,
     lm_head: UnifiedLinear,
     _config: Qwen2VLConfig,
-    /// Per-sequence MRoPE state (issue #540 / mlx-vlm PR #1095). Each row
+    /// Per-sequence MRoPE state (mlx-vlm PR #1095). Each row
     /// in a server batch needs its own delta — the legacy fallback slot
     /// preserves CLI/single-row behavior when no `SequenceId` is plumbed.
     mrope_state: MRopeState,
@@ -552,7 +552,7 @@ impl Qwen2VLModel {
     }
 
     /// Set MRoPE state for a specific server-side sequence so the cached
-    /// per-sequence delta no longer leaks across requests (issue #540).
+    /// per-sequence delta no longer leaks across requests.
     pub fn set_mrope_state_for_sequence(
         &self,
         seq_id: SequenceId,
@@ -578,7 +578,7 @@ impl Qwen2VLModel {
     /// under `seq_id`. Called by the scheduler right after the vision
     /// wrapper's `get_input_embeddings` has populated the fallback slot,
     /// so subsequent decode steps for this sequence resolve the MRoPE
-    /// state by id instead of by leaky scalar (issue #540).
+    /// state by id instead of by leaky scalar.
     pub fn bind_mrope_state_to_sequence(&self, seq_id: SequenceId) {
         self.mrope_state.bind_fallback_to_sequence(seq_id);
     }
@@ -586,7 +586,7 @@ impl Qwen2VLModel {
     /// Remove and return the per-sequence MRoPE entry under `seq_id`
     /// without dropping the contained position-id tensor. Used by the
     /// server preemption path so the entry can survive an evict-and-
-    /// reallocate cycle (issue #540 follow-up).
+    /// reallocate cycle (follow-up).
     pub(crate) fn take_mrope_entry(
         &self,
         seq_id: SequenceId,
@@ -645,7 +645,7 @@ impl Qwen2VLModel {
                 // This matches upstream mlx-vlm PR #1048 (commit 1bf7742) which relaxed
                 // the equality guard to shape[-1] >= cache_offset + seq_length.
                 //
-                // Issue #541 (upstream mlx-vlm PR #1040, commit 58e2435): also validate
+                // (upstream mlx-vlm PR #1040, commit 58e2435): also validate
                 // pos_shape[1] == batch so sequential requests with different batch_sizes
                 // do not reuse stale position IDs and crash on broadcast_shapes.
                 let pos_shape = mlxcel_core::array_shape(stored_pos);

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -135,7 +135,7 @@ impl Attention {
         q = mlxcel_core::fast_rope(&q, self.rope_dims, false, self.rope_base, 1.0, offset);
         k = mlxcel_core::fast_rope(&k, self.rope_dims, false, self.rope_base, 1.0, offset);
 
-        // Issue #505: Try the fused sparse-V SDPA path for the decode case
+        // Try the fused sparse-V SDPA path for the decode case
         // (l == 1) when the cache is in Turbo4Asym mode
         // and `MLXCEL_SPARSE_V_THRESHOLD > 0`. Skipped on prefill (l > 1)
         // because the per-token skip only wins at long context — and

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -357,7 +357,7 @@ impl Qwen35GatedDeltaNet {
         // Wrap slice in contiguous() to force MLX to materialize a fresh,
         // independent buffer. Without this, the slice is a lazy view that
         // retains a reference to the full conv_input allocation, causing a
-        // memory leak proportional to the sequence length. (issue #323)
+        // memory leak proportional to the sequence length.
         if let Some(c) = cache.as_deref_mut() {
             let n_keep = (self.conv_kernel_size - 1) as i32;
             let conv_shape = mlxcel_core::array_shape(&conv_input);
@@ -462,18 +462,18 @@ impl Qwen35GatedDeltaNet {
     ///
     /// Mirrors the `gdn_sink` parameter in upstream
     /// `mlx-vlm/mlx_vlm/models/qwen3_5/language.py:Qwen3_5GatedDeltaNet`
-    /// (issue #634). The snapshot is captured *before* `gated_delta_update`
+    /// The snapshot is captured *before* `gated_delta_update`
     /// runs, holding the same per-step inputs and the pre-block recurrent
     /// state — exactly what is needed to replay the block over a truncated
     /// `[B, n]` slice during DFlash rollback.
     ///
-    /// Apple Silicon precision (issue #634, `docs/apple-silicon-precision.md`):
+    /// Apple Silicon precision (`docs/apple-silicon-precision.md`):
     /// captured `q/k/v/a/b/conv_input` retain their bf16/f16 dtype from the
     /// projections; `init_state`, when present, stays float32. The rollback
     /// path must preserve these dtypes to avoid numerical drift from the
     /// cold-pass reference the drafter was trained against.
     ///
-    /// Used by: `Qwen35Model::forward_speculative` (issue #634)
+    /// Used by: `Qwen35Model::forward_speculative`
     fn forward_hidden_internal_with_capture(
         &self,
         layer_idx: usize,
@@ -903,7 +903,7 @@ impl Qwen35DecoderLayer {
     /// linear-attention, also pushes a [`GdnRollbackSnapshot`] into
     /// `snapshot_sink`; attention layers behave identically to `forward`.
     ///
-    /// Issue #634: used by `Qwen35Model::forward_speculative` to drive the
+    /// used by `Qwen35Model::forward_speculative` to drive the
     /// DFlash drafter without duplicating the prefill / decode forward path.
     fn forward_with_capture(
         &self,
@@ -1035,7 +1035,7 @@ impl Qwen35DecoderLayer {
 ///   prev-conv-state + qkv. Used to recover the post-rollback `conv_state` window.
 /// - `layer_idx`: which decoder layer this snapshot belongs to (for replay).
 ///
-/// Dtype policy (issue #634, Apple Silicon precision rules — `docs/apple-silicon-precision.md`):
+/// Dtype policy (Apple Silicon precision rules — `docs/apple-silicon-precision.md`):
 /// the captured tensors retain the dtype produced by the verify-pass kernels
 /// (typically bf16 / f16 for activations; float32 for `init_state`). The rollback
 /// path must NOT promote them to float32, otherwise the rewound state diverges
@@ -1079,7 +1079,7 @@ pub struct Qwen35Model {
     pub(crate) config: Qwen35Config,
     /// Internal and per-sequence mixed cache state.
     sequence_state: ModelOwnedSequenceState<Qwen3NextCache>,
-    /// Per-sequence MRoPE state (issue #540 / mlx-vlm PR #1095). Each row
+    /// Per-sequence MRoPE state (mlx-vlm PR #1095). Each row
     /// in a server batch needs its own delta — the legacy fallback slot
     /// preserves CLI/single-row behavior when no `SequenceId` is plumbed.
     mrope_state: MRopeState,
@@ -1154,7 +1154,7 @@ impl Qwen35Model {
     }
 
     /// Construct a fresh heterogeneous cache vec for the DFlash
-    /// speculative round loop (issue #670).
+    /// speculative round loop.
     ///
     /// Distinct name from the trait
     /// [`LanguageModel::make_caches`] (which returns `Vec<KVCache>` —
@@ -1168,7 +1168,6 @@ impl Qwen35Model {
     /// Used by:
     /// [`crate::server::batch::speculative_burst::run_dflash_on_qwen35`]
     /// for both `Qwen35Model` and `Qwen35VLModel` text-only DFlash bursts
-    /// (issues #670 and #691).
     pub(crate) fn make_speculative_caches(&self) -> Vec<Qwen3NextCache> {
         self.make_internal_caches()
     }
@@ -1307,11 +1306,11 @@ impl Qwen35Model {
         // not only when cache_offset == 0.  During chunked prefill (cache_offset > 0)
         // the stored array is sliced to the needed window rather than recomputed.
         //
-        // Issue #540: the MRoPE entry is resolved per `SequenceId` so a row
+        // the MRoPE entry is resolved per `SequenceId` so a row
         // that just finished a VL prefill cannot poison a subsequent
         // text-only sequence's decode delta.
         //
-        // Issue #541 (upstream mlx-vlm PR #1040, commit 58e2435): also validate
+        // (upstream mlx-vlm PR #1040, commit 58e2435): also validate
         // pos_shape[1] == batch before reusing, matching the upstream Python check:
         //   self._position_ids.shape[1] == batch_size
         //   and self._position_ids.shape[-1] >= cache_offset + seq_length
@@ -1462,7 +1461,7 @@ impl Qwen35Model {
     }
 
     /// Set MRoPE state for a specific server-side sequence so the cached
-    /// per-sequence delta no longer leaks across requests (issue #540).
+    /// per-sequence delta no longer leaks across requests.
     pub fn set_mrope_state_for_sequence(
         &self,
         seq_id: SequenceId,
@@ -1483,7 +1482,7 @@ impl Qwen35Model {
     /// under `seq_id`. Called by the scheduler right after the vision
     /// wrapper's `get_input_embeddings` has populated the fallback slot,
     /// so subsequent decode steps for this sequence resolve the MRoPE
-    /// state by id instead of by leaky scalar (issue #540).
+    /// state by id instead of by leaky scalar.
     pub fn bind_mrope_state_to_sequence(&self, seq_id: SequenceId) {
         self.mrope_state.bind_fallback_to_sequence(seq_id);
     }
@@ -1491,7 +1490,7 @@ impl Qwen35Model {
     /// Remove and return the per-sequence MRoPE entry under `seq_id`
     /// without dropping the contained position-id tensor. Used by the
     /// server preemption path so the entry can survive an evict-and-
-    /// reallocate cycle (issue #540 follow-up).
+    /// reallocate cycle (follow-up).
     pub(crate) fn take_mrope_entry(
         &self,
         seq_id: SequenceId,
@@ -1513,7 +1512,7 @@ impl Qwen35Model {
     ///
     /// Returns `Some([3, batch, seq_len])` when `delta` is provided (VLM decode
     /// path), or `None` for text-only models where fast_rope handles positioning
-    /// internally. Issue #540 makes this static so the caller passes the
+    /// internally. makes this static so the caller passes the
     /// per-`SequenceId` delta resolved through `MRopeState::with_entry`.
     // Used by: forward_with_mrope_state
     fn compute_decode_position_ids_with_delta(
@@ -1574,7 +1573,7 @@ impl Qwen35Model {
     /// states at `capture_layer_ids` and per-GDN-layer rollback snapshots.
     ///
     /// This is the verify-pass hot path consumed by the DFlash drafter
-    /// round loop (epic #633, sub-12). It mirrors upstream
+    /// round loop (sub-12). It mirrors upstream
     /// `mlx-vlm/mlx_vlm/models/qwen3_5/language.py::LanguageModel.__call__`
     /// when called with `capture_layer_ids` set, with two changes:
     ///   1. `return_hidden` is implied by `capture_layer_ids.is_some()` —
@@ -1585,11 +1584,11 @@ impl Qwen35Model {
     ///      KV (attention) caches and GDN (linear-attention) caches to the
     ///      accepted position.
     ///
-    /// Apple Silicon precision (issue #634, `docs/apple-silicon-precision.md`):
+    /// Apple Silicon precision (`docs/apple-silicon-precision.md`):
     /// captured hidden tensors keep the verify-pass dtype (bf16/f16); GDN
     /// snapshot tensors keep their per-field dtype. Do not promote to f32.
     ///
-    /// Used by: DFlash drafter round loop (epic #633, sub-12).
+    /// Used by: DFlash drafter round loop (sub-12).
     pub fn forward_speculative(
         &self,
         input_ids: &MlxArray,
@@ -1678,7 +1677,7 @@ impl Qwen35Model {
     ///
     /// Mirrors upstream
     /// `mlx-vlm/mlx_vlm/models/qwen3_5/language.py::LanguageModel.rollback_speculative_cache`
-    /// (issue #634). Returns `max(accepted)`.
+    /// Returns `max(accepted)`.
     ///
     /// Arguments:
     ///   * `caches` — the per-layer cache slice the verify pass just mutated.
@@ -1696,12 +1695,12 @@ impl Qwen35Model {
     /// `accepted == block_size - 1`) keep both cache types as the verify-pass
     /// produced them.
     ///
-    /// Apple Silicon precision (issue #634, `docs/apple-silicon-precision.md`):
+    /// Apple Silicon precision (`docs/apple-silicon-precision.md`):
     /// GDN replay re-uses the captured `q/k/v/a/b` and `init_state` tensors
     /// at their original dtype (bf16/f16/float32 as captured). Do not promote
     /// to f32 — the drafter's reference forward stays in the activation dtype.
     ///
-    /// Used by: DFlash drafter round loop (epic #633, sub-12).
+    /// Used by: DFlash drafter round loop (sub-12).
     pub fn rollback_speculative_cache(
         &self,
         caches: &mut [Qwen3NextCache],
@@ -1876,9 +1875,9 @@ impl Qwen35Model {
 /// model.
 ///
 /// Bridges `Qwen35Model::forward_speculative` /
-/// `Qwen35Model::rollback_speculative_cache` (issue #634) to the
+/// `Qwen35Model::rollback_speculative_cache` to the
 /// drafter-side [`mlxcel_core::drafter::dflash::SpeculativeTarget`]
-/// trait (issue #636). This is what lets the
+/// trait. This is what lets the
 /// `DFlashGenerator` round loop call into the binary's concrete model
 /// type without mlxcel-core having to name `Qwen3NextCache` /
 /// `VerifyOutput` / `GdnRollbackSnapshot`.
@@ -1888,8 +1887,8 @@ impl Qwen35Model {
 /// instance methods on `Qwen35Model` without any extra allocation or
 /// state.
 ///
-/// Used by: DFlash B=1 round loop (issue #636); future B>1 round loop
-/// (issue #637) will provide a peer impl with batched accept slices.
+/// Used by: DFlash B=1 round loop; future B>1 round loop
+/// will provide a peer impl with batched accept slices.
 impl mlxcel_core::drafter::dflash::SpeculativeTarget for Qwen35Model {
     type Cache = super::qwen3_next::Qwen3NextCache;
     type VerifyOut = VerifyOutput;
@@ -1948,7 +1947,7 @@ impl mlxcel_core::drafter::dflash::SpeculativeTarget for Qwen35Model {
         // Delegates to the per-Qwen-3.5 rollback that combines KV
         // attention-cache trim with GDN linear-attention state replay.
         // For B = 1 the accepted slice is a single-element view; the
-        // batched B > 1 path uses `rollback_partial_batched` (#637).
+        // batched B > 1 path uses `rollback_partial_batched`.
         let _ = self.rollback_speculative_cache(
             caches,
             &verify_out.gdn_states,
@@ -1967,10 +1966,10 @@ impl mlxcel_core::drafter::dflash::SpeculativeTarget for Qwen35Model {
         // For B > 1 the rollback path uses the same `rollback_speculative_cache`
         // entrypoint with a multi-element `accepted` slice. The per-row
         // KV tail-zeroing and per-row GDN-state replay (with per-row
-        // conv_state slicing) already lives inside that method (issue #634);
+        // conv_state slicing) already lives inside that method;
         // we just thread the slice through.
         //
-        // Apple Silicon precision (issue #634, `docs/apple-silicon-precision.md`):
+        // Apple Silicon precision (`docs/apple-silicon-precision.md`):
         // both the KV per-row tail zero buffer and the GDN replay tensors
         // keep their captured dtype (bf16/f16 activations + float32
         // init_state); no f32 promotion.
@@ -2008,7 +2007,7 @@ impl mlxcel_core::drafter::dflash::SpeculativeTarget for Qwen35Model {
 /// `KVCache`. Used by [`Qwen35Model::rollback_speculative_cache`] for batched
 /// verify-pass rollback when rows accepted different numbers of tokens.
 ///
-/// Apple Silicon precision (issue #634): the zero buffer is built with the
+/// Apple Silicon precision: the zero buffer is built with the
 /// same dtype as the K/V tensors so no implicit f32 promotion happens.
 ///
 /// Used by: `Qwen35Model::rollback_speculative_cache`
@@ -2555,7 +2554,7 @@ impl LanguageModel for Qwen35Model {
     /// the DFlash drafter's lazy-bind path. The upstream
     /// `z-lab/Qwen3.5-4B-DFlash` checkpoint omits `embed_tokens.weight`
     /// and resolves it from this Qwen 3.5 target during
-    /// `mlxcel_core::drafter::Drafter::bind` (issue #675).
+    /// `mlxcel_core::drafter::Drafter::bind`.
     fn embed_tokens_module(&self) -> Option<UnifiedEmbedding> {
         Some(self.embed_tokens.clone_shared())
     }
@@ -2613,7 +2612,7 @@ impl LanguageModel for Qwen35Model {
 
     fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
         self.sequence_state.release_sequence_state(seq_id);
-        // Issue #540: drop the per-sequence MRoPE entry alongside the
+        // drop the per-sequence MRoPE entry alongside the
         // cache state so the map cannot grow as sequences cycle through.
         self.release_mrope_sequence(seq_id);
     }

--- a/src/models/qwen3_5_tests.rs
+++ b/src/models/qwen3_5_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit tests for the Qwen 3.5 DFlash speculative-decoding hooks (issue #634).
+//! Unit tests for the Qwen 3.5 DFlash speculative-decoding hooks.
 //!
 //! These tests cover the *standalone* helpers — `rebuild_with_zero_tail`,
 //! `zero_per_row_kv_tail`, and `sanitize_weights`'s MTP-stripping path — without
@@ -159,7 +159,7 @@ fn rebuild_with_zero_tail_no_op_when_start_equals_kv_len() {
 fn rebuild_with_zero_tail_preserves_input_dtype() {
     // Apple Silicon precision rule: the zeroed buffer must keep the original
     // KV dtype — promoting bf16/f16 to f32 here would silently corrupt the
-    // verify-pass path. (Issue #634, docs/apple-silicon-precision.md.)
+    // verify-pass path. (docs/apple-silicon-precision.md.)
     let data = vec![1.0_f32; 16];
     let tensor_f32 = mlxcel_core::from_slice_f32(&data, &[2, 2, 2, 2]);
     let tensor_bf16 = mlxcel_core::astype(&tensor_f32, dtype::BFLOAT16);
@@ -238,7 +238,7 @@ fn zero_per_row_kv_tail_no_op_on_empty_cache() {
 // ---------------------------------------------------------------------------
 // `sanitize_weights` MTP stripping — the acceptance criterion that Qwen 3.5
 // checkpoints' `mtp.*` weights are dropped without breaking the existing
-// load path. Issue #634 mirrors the mlx-lm / mlx-vlm behavior.
+// load path. mirrors the mlx-lm / mlx-vlm behavior.
 // ---------------------------------------------------------------------------
 
 #[test]

--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -315,7 +315,7 @@ impl GatedDeltaNet {
         // Wrap slice in contiguous() to force MLX to materialize a fresh,
         // independent buffer. Without this, the slice is a lazy view that
         // retains a reference to the full conv_input allocation, causing a
-        // memory leak proportional to the sequence length. (issue #323)
+        // memory leak proportional to the sequence length.
         if let Some(c) = cache.as_deref_mut() {
             let n_keep = (self.conv_kernel_size - 1) as i32;
             let conv_shape = mlxcel_core::array_shape(&conv_input);

--- a/src/models/qwen3_vl.rs
+++ b/src/models/qwen3_vl.rs
@@ -593,7 +593,7 @@ pub struct Qwen3VLModel {
     norm: RMSNorm,
     lm_head: UnifiedLinear,
     _config: Qwen3VLConfig,
-    /// Per-sequence MRoPE state (issue #540 / mlx-vlm PR #1095). Each row
+    /// Per-sequence MRoPE state (mlx-vlm PR #1095). Each row
     /// in a server batch needs its own delta — the legacy fallback slot
     /// preserves CLI/single-row behavior when no `SequenceId` is plumbed.
     mrope_state: MRopeState,
@@ -646,7 +646,7 @@ impl Qwen3VLModel {
     }
 
     /// Set MRoPE state for a specific server-side sequence so the cached
-    /// per-sequence delta no longer leaks across requests (issue #540).
+    /// per-sequence delta no longer leaks across requests.
     pub fn set_mrope_state_for_sequence(
         &self,
         seq_id: SequenceId,
@@ -672,7 +672,7 @@ impl Qwen3VLModel {
     /// under `seq_id`. Called by the scheduler right after the vision
     /// wrapper's `get_input_embeddings` has populated the fallback slot,
     /// so subsequent decode steps for this sequence resolve the MRoPE
-    /// state by id instead of by leaky scalar (issue #540).
+    /// state by id instead of by leaky scalar.
     pub fn bind_mrope_state_to_sequence(&self, seq_id: SequenceId) {
         self.mrope_state.bind_fallback_to_sequence(seq_id);
     }
@@ -680,7 +680,7 @@ impl Qwen3VLModel {
     /// Remove and return the per-sequence MRoPE entry under `seq_id`
     /// without dropping the contained position-id tensor. Used by the
     /// server preemption path so the entry can survive an evict-and-
-    /// reallocate cycle (issue #540 follow-up).
+    /// reallocate cycle (follow-up).
     pub(crate) fn take_mrope_entry(
         &self,
         seq_id: SequenceId,
@@ -817,7 +817,7 @@ impl Qwen3VLModel {
     }
 
     /// Internal forward path that takes an optional `SequenceId` so the
-    /// cached MRoPE state is resolved per row (issue #540).
+    /// cached MRoPE state is resolved per row.
     pub(crate) fn forward_for_sequence(
         &self,
         input_ids: &MlxArray,
@@ -854,7 +854,7 @@ impl Qwen3VLModel {
                 // This matches upstream mlx-vlm PR #1048 (commit 1bf7742) which relaxed
                 // the equality guard to shape[-1] >= cache_offset + seq_length.
                 //
-                // Issue #541 (upstream mlx-vlm PR #1040, commit 58e2435): also validate
+                // (upstream mlx-vlm PR #1040, commit 58e2435): also validate
                 // pos_shape[1] == batch so sequential requests with different batch_sizes
                 // do not reuse stale position IDs and crash on broadcast_shapes.
                 let pos_shape = mlxcel_core::array_shape(stored_pos);

--- a/src/models/qwen3_vl_moe.rs
+++ b/src/models/qwen3_vl_moe.rs
@@ -780,7 +780,7 @@ pub struct Qwen3VLMoeModel {
     norm: RMSNorm,
     lm_head: UnifiedLinear,
     _config: Qwen3VLMoeConfig,
-    /// Per-sequence MRoPE state (issue #540 / mlx-vlm PR #1095). Each row
+    /// Per-sequence MRoPE state (mlx-vlm PR #1095). Each row
     /// in a server batch needs its own delta — the legacy fallback slot
     /// preserves CLI/single-row behavior when no `SequenceId` is plumbed.
     mrope_state: MRopeState,
@@ -834,7 +834,7 @@ impl Qwen3VLMoeModel {
     }
 
     /// Set MRoPE state for a specific server-side sequence so the cached
-    /// per-sequence delta no longer leaks across requests (issue #540).
+    /// per-sequence delta no longer leaks across requests.
     pub fn set_mrope_state_for_sequence(
         &self,
         seq_id: SequenceId,
@@ -860,7 +860,7 @@ impl Qwen3VLMoeModel {
     /// under `seq_id`. Called by the scheduler right after the vision
     /// wrapper's `get_input_embeddings` has populated the fallback slot,
     /// so subsequent decode steps for this sequence resolve the MRoPE
-    /// state by id instead of by leaky scalar (issue #540).
+    /// state by id instead of by leaky scalar.
     pub fn bind_mrope_state_to_sequence(&self, seq_id: SequenceId) {
         self.mrope_state.bind_fallback_to_sequence(seq_id);
     }
@@ -868,7 +868,7 @@ impl Qwen3VLMoeModel {
     /// Remove and return the per-sequence MRoPE entry under `seq_id`
     /// without dropping the contained position-id tensor. Used by the
     /// server preemption path so the entry can survive an evict-and-
-    /// reallocate cycle (issue #540 follow-up).
+    /// reallocate cycle (follow-up).
     pub(crate) fn take_mrope_entry(
         &self,
         seq_id: SequenceId,
@@ -993,7 +993,7 @@ impl Qwen3VLMoeModel {
     }
 
     /// Internal forward path that takes an optional `SequenceId` so the
-    /// cached MRoPE state is resolved per row (issue #540).
+    /// cached MRoPE state is resolved per row.
     pub(crate) fn forward_for_sequence(
         &self,
         input_ids: &MlxArray,
@@ -1030,7 +1030,7 @@ impl Qwen3VLMoeModel {
                 // This matches upstream mlx-vlm PR #1048 (commit 1bf7742) which relaxed
                 // the equality guard to shape[-1] >= cache_offset + seq_length.
                 //
-                // Issue #541 (upstream mlx-vlm PR #1040, commit 58e2435): also validate
+                // (upstream mlx-vlm PR #1040, commit 58e2435): also validate
                 // pos_shape[1] == batch so sequential requests with different batch_sizes
                 // do not reuse stale position IDs and crash on broadcast_shapes.
                 let pos_shape = mlxcel_core::array_shape(stored_pos);

--- a/src/models/qwen_mrope_state.rs
+++ b/src/models/qwen_mrope_state.rs
@@ -14,7 +14,7 @@
 
 //! Per-sequence MRoPE state for Qwen VL families.
 //!
-//! Issue #540 / mlx-vlm PR #1095 (commit `e94b76`): when a single text-model
+//! mlx-vlm PR #1095 (commit `e94b76`): when a single text-model
 //! instance serves several sequences in a server (or a mixed batch with both
 //! VL and text-only rows), the cached MRoPE `rope_deltas` and the spatially
 //! computed `position_ids` must be tracked **per sequence**. A shared scalar
@@ -136,7 +136,7 @@ impl MRopeState {
     /// the server scheduler associates the MRoPE state computed by
     /// `set_fallback` (during the vision-encoder pass that did not yet
     /// know the sequence id) with the sequence that will eventually
-    /// consume it (issue #540).
+    /// consume it.
     ///
     /// If the fallback slot is empty (no VL prefill ran for this row),
     /// an empty entry is registered so subsequent decode steps see
@@ -157,7 +157,7 @@ impl MRopeState {
     /// dropping the contained `UniquePtr<MlxArray>`. Used by the server
     /// preemption path so the entry can be carried across the eviction
     /// (which releases the old sequence id) and reinstalled under the
-    /// freshly allocated id (issue #540 follow-up).
+    /// freshly allocated id (follow-up).
     ///
     /// Returns `None` when the map has no entry for `seq_id`.
     ///

--- a/src/models/qwen_mrope_state_tests.rs
+++ b/src/models/qwen_mrope_state_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Per-sequence MRoPE state tests for issue #540.
+//! Per-sequence MRoPE state tests.
 
 use super::{MRopeEntry, MRopeState};
 use mlxcel_core::cache::SequenceId;
@@ -57,7 +57,7 @@ fn fallback_clear_resets_entry() {
     });
 }
 
-/// Issue #540 invariant: per-sequence deltas must be isolated. Set the
+/// invariant: per-sequence deltas must be isolated. Set the
 /// fallback to a "VL-row" delta of 5, then register a text-only sequence
 /// with delta 0 — looking up either by seq id should yield delta=0, while
 /// a lookup with `None` still returns the fallback's delta=5.
@@ -112,7 +112,7 @@ fn release_drops_only_target_sequence() {
     });
 }
 
-/// Acceptance criterion #3 from issue #540 (unit-test variant): for a
+/// Acceptance criterion #3 (unit-test variant): for a
 /// contrived mixed batch where row 0 has delta=5 and row 1 has delta=0,
 /// the per-row delta tensor produced by stacking each sequence's entry
 /// is `[5, 0]`. We construct this by reading back each row's stored
@@ -206,7 +206,7 @@ fn text_only_request_does_not_inherit_vl_delta_after_bind() {
     });
 }
 
-/// Issue #540 follow-up: preemption regression coverage.
+/// follow-up: preemption regression coverage.
 ///
 /// The server preemption path evicts a victim sequence (releasing its old
 /// id), then re-allocates a fresh id and re-queues the same request. The

--- a/src/models/qwen_vl_position_tests.rs
+++ b/src/models/qwen_vl_position_tests.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Regression tests for chunked-prefill MRoPE position-IDs shape check (issues #539, #541).
+//! Regression tests for chunked-prefill MRoPE position-IDs shape check.
 //!
 //! These tests verify:
-//! - Issue #539: the sufficiency check (`shape[-1] >= cache_offset + seq_len`) correctly
+//! - the sufficiency check (`shape[-1] >= cache_offset + seq_len`) correctly
 //!   replaces the old strict-equality guard, allowing cached position_ids to be reused
 //!   across chunked-prefill passes without panicking on shape mismatch.
-//! - Issue #541: the batch-size check (`shape[1] == batch_size`) is validated alongside
+//! - the batch-size check (`shape[1] == batch_size`) is validated alongside
 //!   the seq-length check, so sequential requests with different batch_sizes do not reuse
 //!   stale position IDs and crash on broadcast_shapes.
 
@@ -39,7 +39,7 @@ fn make_position_ids(total_len: i32) -> mlxcel_core::UniquePtr<mlxcel_core::MlxA
 }
 
 /// Emulates the shape-check and slice logic from all Qwen VL text-model
-/// `forward_with_mrope_state` / `forward_impl` functions after issues #539 and #541.
+/// `forward_with_mrope_state` / `forward_impl` functions after and.
 ///
 /// Returns `Some(sliced_ids)` when the cached tensor is sufficient (matching both batch
 /// dimension and seq-length range), `None` otherwise.
@@ -50,7 +50,7 @@ fn try_reuse_position_ids(
     seq_len: i32,
 ) -> Option<mlxcel_core::UniquePtr<mlxcel_core::MlxArray>> {
     let pos_shape = mlxcel_core::array_shape(stored_pos);
-    // Issue #541: validate batch dimension (pos_shape[1]) in addition to seq-length
+    // validate batch dimension (pos_shape[1]) in addition to seq-length
     // sufficiency (pos_shape[2] >= cache_offset + seq_len), matching upstream Python:
     //   self._position_ids.shape[1] == batch_size
     //   and self._position_ids.shape[-1] >= cache_offset + seq_length
@@ -203,7 +203,7 @@ fn old_strict_equality_guard_would_reject_second_chunk() {
 }
 
 /// Verify that a cached [3, 1, 8] position_ids tensor is REJECTED when the next request
-/// has batch_size=2 (issue #541 regression guard).
+/// has batch_size=2 (regression guard).
 ///
 /// This covers the upstream mlx-vlm PR #1040 fix: sequential requests with different
 /// batch_sizes must not reuse stale position IDs, which would produce wrong RoPE

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -972,14 +972,14 @@ pub fn load_and_sanitize_weights<P: AsRef<std::path::Path>>(
 /// keep bf16 as-is since they may support it natively.
 ///
 /// The optional `transform` parameter is the Axis A "weight-load
-/// surgery" hook (Epic #363, issue #365). It is invoked *after* basic
+/// surgery" hook. It is invoked *after* basic
 /// sanitization (tied embeddings, NVFP4 dequant, KV-shared stripping)
 /// and *before* the Apple Silicon bf16 → f16 conversion, so any
 /// transform observes weights in the same layout the model graph would
 /// see them. When `transform` is `None` the call is bit-exact identical
 /// to the pre-refactor `load_and_sanitize_weights` path.
 ///
-/// ## Active-pipeline fallback (issue #371 — A4)
+/// ## Active-pipeline fallback (— A4)
 ///
 /// When the explicit `transform` parameter is `None` *and* the
 /// `surgery` feature is enabled *and* the CLI has installed an active
@@ -992,7 +992,7 @@ pub fn load_and_sanitize_weights<P: AsRef<std::path::Path>>(
 /// When no `--surgery` flag is provided the active-pipeline slot is
 /// `None`, the snapshot fast-path returns `None` (a single relaxed
 /// `OnceLock::get` load), and the load path is byte-for-byte identical
-/// to the pre-#371 baseline. The same is true at compile time on
+/// to the earlier baseline. The same is true at compile time on
 /// builds with `--no-default-features` (no `surgery` feature → the
 /// active-pipeline lookup is compiled out entirely).
 ///
@@ -1045,11 +1045,11 @@ pub fn load_text_weights<P: AsRef<std::path::Path>>(
                 .is_some();
     }
 
-    // Axis A weight-load surgery hook (Epic #363). Runs after sanitization
+    // Axis A weight-load surgery hook. Runs after sanitization
     // and before precision conversion so transforms observe weights in
     // their final tied/dequantized layout.
     //
-    // Resolution order (issue #371, A4):
+    // Resolution order (A4):
     //   1. Explicit `transform` argument — used as-is (test fixtures and
     //      future programmatic callers that want to bypass the global slot).
     //   2. `surgery` feature active + CLI-installed active pipeline —

--- a/src/models/sanitize_tests.rs
+++ b/src/models/sanitize_tests.rs
@@ -336,7 +336,7 @@ fn load_and_sanitize_weights_dequantizes_nvfp4_gemma4_checkpoint() {
 }
 
 // --- Tests for the consolidated `load_text_weights` entry point and the
-// optional `WeightTransform` hook introduced for Axis A (issue #365). ---
+// optional `WeightTransform` hook introduced for Axis A. ---
 
 /// Build a minimal text model fixture: tiny config.json with no
 /// quantization plus a single safetensors shard containing
@@ -391,7 +391,7 @@ fn load_text_weights_with_none_transform_matches_legacy_path() {
     // doubles as a regression guard against accidental divergence
     // between the alias and the new entry point.
     //
-    // Issue #371 (A4): the `load_text_weights(_, None)` call below
+    // (A4): the `load_text_weights(_, None)` call below
     // reads the process-global active-pipeline slot. Acquire
     // `env_lock` so a parallel test in `surgery_integration` can't
     // install a pipeline mid-test and leak it into the consolidated
@@ -475,7 +475,7 @@ fn load_text_weights_invokes_transform_when_supplied() {
     // transform the produced `WeightMap` must match the `None` path
     // bit-for-bit.
     //
-    // Issue #371 (A4): baseline call reads the active-pipeline slot,
+    // (A4): baseline call reads the active-pipeline slot,
     // so we need the same `env_lock` discipline as the other tests
     // touching `load_text_weights(_, None)`.
     #[cfg(feature = "surgery")]
@@ -545,7 +545,7 @@ fn load_text_weights_propagates_transform_error() {
     std::fs::remove_dir_all(&dir).unwrap();
 }
 
-// --- Integration tests for the Axis A `mlxcel-surgery` crate (#367).
+// --- Integration tests for the Axis A `mlxcel-surgery` crate.
 // Gated on the `surgery` feature so the default build still passes
 // without pulling the new crate into the dependency graph. ---
 
@@ -587,7 +587,7 @@ mod surgery_integration {
         // really does implement A1's `WeightTransform` trait at the
         // type level (the call would not type-check otherwise).
         //
-        // Issue #371 (A4): `load_text_weights(_, None)` reads the
+        // (A4): `load_text_weights(_, None)` reads the
         // process-global active-pipeline slot, so any test that calls
         // it must serialise on the same `env_lock` as the tests that
         // mutate the slot — otherwise a parallel mutator can leak a
@@ -630,7 +630,7 @@ mod surgery_integration {
         // not mutate weights), which proves that "no-op" semantics
         // hold end-to-end.
         //
-        // Issue #371: env_lock as in `empty_surgery_pipeline_*` — the
+        // env_lock as in `empty_surgery_pipeline_*` — the
         // baseline `load_text_weights(_, None)` reads the active slot.
         let _env_guard = crate::test_support::env_lock::env_lock();
 
@@ -719,12 +719,12 @@ mod surgery_integration {
     #[test]
     fn empty_yaml_config_pipeline_is_bit_exact_with_none() {
         // End-to-end YAML → SurgeryPipeline → load_text_weights(Some(&p))
-        // for the empty-config case. Demonstrates the issue #369
+        // for the empty-config case. Demonstrates the
         // acceptance criterion (e): when `operations: []`, the
         // produced pipeline behaves bit-exact identically to the
         // `transform = None` path.
         //
-        // Issue #371: baseline call needs env_lock — same rationale
+        // baseline call needs env_lock — same rationale
         // as `empty_surgery_pipeline_is_bit_exact_with_none`.
         let _env_guard = crate::test_support::env_lock::env_lock();
 
@@ -763,7 +763,7 @@ mod surgery_integration {
         // Acceptance criterion (b) — the parser returns a real
         // `SurgeryPipeline` that consumes through A1's hook, and
         // op-level errors propagate end-to-end. With all five Axis A
-        // ops now landed (#365 / A1 → #378 / A9), the canonical
+        // ops now landed (A1 → / A9), the canonical
         // op-level error to assert on is the "zero matches" condition
         // every real op emits when its glob does not select any
         // tensor. This test pins that error reaching the caller via
@@ -819,7 +819,7 @@ operations:
         // non-zero numerical check lives in the synthetic
         // WeightMap unit tests inside `mlxcel-surgery`.
         //
-        // Issue #371: the second `load_text_weights(_, None)` call
+        // the second `load_text_weights(_, None)` call
         // below consults the process-global active-pipeline slot, so
         // we must hold `env_lock` to keep parallel tests that touch
         // that slot from polluting our baseline read.
@@ -930,7 +930,7 @@ operations:
         }
     }
 
-    /// Issue #371 (A4): when the CLI installs an active pipeline via
+    /// (A4): when the CLI installs an active pipeline via
     /// `crate::surgery::set_active_pipeline`, the consolidated loader
     /// must pick it up for `load_text_weights(_, None)` callers. This
     /// is the integration glue that lets `mlxcel generate --surgery
@@ -951,7 +951,7 @@ operations:
         // None)`. The active-pipeline slot must be consulted because
         // the explicit `transform` is None, and the zero-match error
         // emitted by `ScaleOp::apply` must propagate out. All five
-        // Axis A ops (#365 / A1 → #378 / A9) are now real, so we use
+        // Axis A ops (A1 → / A9) are now real, so we use
         // the zero-match diagnostic — every real op emits one — as
         // the load-path-visible signal.
         let yaml = r#"version: 1
@@ -984,10 +984,9 @@ operations:
         std::fs::remove_dir_all(&dir_with_slot).unwrap();
     }
 
-    /// Issue #371 (A4): explicit `transform` argument takes precedence
+    /// (A4): explicit `transform` argument takes precedence
     /// over the active-pipeline slot. This is the contract callers
-    /// (e.g. future programmatic users and the existing #365/#367
-    /// integration tests) rely on to bypass the global slot.
+    /// (e.g. future programmatic users and the existing integration tests) rely on to bypass the global slot.
     #[test]
     fn explicit_transform_arg_wins_over_active_pipeline_slot() {
         let _env_guard = crate::test_support::env_lock::env_lock();
@@ -1028,7 +1027,7 @@ operations:
     }
 
     /// Write a Llama-shaped synthetic fixture suitable for a prune
-    /// end-to-end test (#376). The fixture sets `num_attention_heads=4`,
+    /// end-to-end test. The fixture sets `num_attention_heads=4`,
     /// `num_key_value_heads=4` (MHA so the test does not have to assert
     /// on GQA-skip semantics here), `hidden_size=32`, `head_dim=8`,
     /// `intermediate_size=64`, and one transformer block.
@@ -1136,7 +1135,7 @@ operations:
 
     #[test]
     fn prune_op_runs_through_load_text_weights() {
-        // Acceptance criterion (b) for #376 — a concrete PruneOp
+        // Acceptance criterion (b) — a concrete PruneOp
         // routed through the consolidated text-weight load path must
         // actually zero the right slice of the right tensor without
         // crashing or returning NaN/Inf. This is the end-to-end
@@ -1238,7 +1237,7 @@ operations:
 
     #[test]
     fn replace_yaml_swaps_targeted_tensor_through_load_text_weights() {
-        // Issue #377 acceptance criterion (b) — the real ReplaceOp,
+        // acceptance criterion (b) — the real ReplaceOp,
         // built from YAML, replaces the targeted base tensor with
         // the donor's content when invoked through A1's
         // `load_text_weights` hook. Untouched tensors stay
@@ -1246,7 +1245,7 @@ operations:
         // matching keys; A4's `--surgery` flag will route this
         // exact pipeline through the same loader path).
         //
-        // Issue #371: the baseline `load_text_weights(_, None)` call
+        // the baseline `load_text_weights(_, None)` call
         // below consults the process-global active-pipeline slot, so
         // we must hold `env_lock` to keep parallel tests that touch
         // that slot from polluting our baseline read.

--- a/src/multimodal/batched_dispatch.rs
+++ b/src/multimodal/batched_dispatch.rs
@@ -19,8 +19,8 @@
 //! [`LanguageModel::forward_batched_with_context_and_ids`] so each row of a
 //! batched call reaches the text model's seq-aware forward path with its
 //! own `seq_id`. Without the override, the trait default discards `seq_ids`
-//! before they reach the model — the bug fixed for Qwen VL by PR #558 and
-//! for Gemma 4 by issue #542.
+//! before they reach the model — the bug fixed for Qwen VL and
+//! for Gemma 4.
 //!
 //! The helper is generic over `M: LanguageModel` so families with different
 //! per-sequence state (Qwen MRoPE deltas, Gemma 4 sliding-window caches)
@@ -51,8 +51,8 @@ use mlxcel_core::{MlxArray, UniquePtr};
 ///
 /// Used by:
 /// - Qwen2VLModel, Qwen25VLModel, Qwen3VLModel, Qwen3VLMoeModel
-///   (Qwen VL families — fixed in PR #558 for issue #540).
-/// - Gemma4VLModel (Gemma 4 mixed-length batching — issue #542).
+///   (Qwen VL families — fixed).
+/// - Gemma4VLModel (Gemma 4 mixed-length batching —).
 ///
 /// Not used by Qwen35VLModel: that family's text model already implements
 /// a native batched-with-ids fast path (per-row dispatch and a true batched-

--- a/src/multimodal/gemma4_vl.rs
+++ b/src/multimodal/gemma4_vl.rs
@@ -68,7 +68,7 @@ pub enum PadSide {
 /// Returns `None` when the tensor has rank 0 or an empty leading axis.
 ///
 /// Used by: Gemma 4 mixed-length batching prep and — when
-/// extended for `per_layer_inputs` —.
+/// extended for `per_layer_inputs`.
 #[must_use]
 pub fn prompt_kwarg_row(
     v: &MlxArray,

--- a/src/multimodal/gemma4_vl.rs
+++ b/src/multimodal/gemma4_vl.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Gemma 4 VLM batching helpers (issue #542 / mlx-vlm PR #1127).
+//! Gemma 4 VLM batching helpers (mlx-vlm PR #1127).
 //!
 //! This module owns the **per-row prompt-kwarg alignment** helpers used
 //! when a batched VLM call ships a `[B, T_max, ...]` tensor (sequence-
@@ -25,16 +25,16 @@
 //!
 //! Per-row batched dispatch on `LanguageModel::forward_batched_with_context_and_ids`
 //! lives in [`super::batched_dispatch::forward_batched_with_seq_ids_dispatch`]
-//! and is shared with the Qwen VL families (PR #558). Both Qwen VL and
+//! and is shared with the Qwen VL families. Both Qwen VL and
 //! Gemma 4's vision wrappers route their override through that helper so
 //! mixed-length batches reach `forward_with_sequence_id` row-by-row with
-//! the correct `seq_id`. After issue #542's runtime fix landed in this
+//! the correct `seq_id`. After's runtime fix landed in this
 //! same PR, [`crate::vision::Gemma4VLModel::supports_batching`] returns
 //! `true` and the scheduler actually drives this batched path on
 //! Gemma 4.
 //!
 //! The kwarg-alignment helpers here are scoped narrow enough that issue
-//! #543 (Gemma 4 E4B/E2B `per_layer_inputs` alignment in batched prefill)
+//! (Gemma 4 E4B/E2B `per_layer_inputs` alignment in batched prefill)
 //! can extend them with the 4D `per_layer_inputs` shape without
 //! duplicating the row-slice / pad-to-max-length math.
 
@@ -67,8 +67,8 @@ pub enum PadSide {
 ///
 /// Returns `None` when the tensor has rank 0 or an empty leading axis.
 ///
-/// Used by: Gemma 4 mixed-length batching prep (issue #542) and — when
-/// extended for `per_layer_inputs` — issue #543.
+/// Used by: Gemma 4 mixed-length batching prep and — when
+/// extended for `per_layer_inputs` —.
 #[must_use]
 pub fn prompt_kwarg_row(
     v: &MlxArray,
@@ -107,14 +107,14 @@ pub fn prompt_kwarg_row(
 /// covers all sequence-aligned prompt kwargs the upstream fix touches:
 /// 2D (`attention_mask`, `position_ids`), 3D (`inputs_embeds`,
 /// `decoder_inputs_embeds`, `deepstack_visual_embeds`), and 4D
-/// (`per_layer_inputs`, the shape that issue #543 will exercise).
+/// (`per_layer_inputs`, the shape that will exercise).
 ///
 /// # Panics
 /// Panics if `v` has rank < 2 — sequence-aligned kwargs always have at
 /// least a `[B, T]` shape, so a smaller rank is a programmer error.
 ///
-/// Used by: Gemma 4 mixed-length batching prep (issue #542); designed
-/// for re-use by issue #543.
+/// Used by: Gemma 4 mixed-length batching prep; designed
+/// for re-use.
 #[must_use]
 pub fn pad_sequence_aligned_prompt_kwarg(
     v: &MlxArray,
@@ -153,8 +153,8 @@ pub fn pad_sequence_aligned_prompt_kwarg(
 /// kwargs (e.g. `pixel_values` shaped `[B, ...]`) should call
 /// [`prompt_kwarg_row`] directly and skip the padding step.
 ///
-/// Used by: Gemma 4 mixed-length batching prep (issue #542); re-used
-/// by issue #543 for `per_layer_inputs`.
+/// Used by: Gemma 4 mixed-length batching prep; re-used
+/// for `per_layer_inputs`.
 #[must_use]
 pub fn align_per_row_prompt_kwarg(
     v: &MlxArray,

--- a/src/multimodal/gemma4_vl_tests.rs
+++ b/src/multimodal/gemma4_vl_tests.rs
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit tests for the Gemma 4 mixed-length batching helpers (issue #542).
+//! Unit tests for the Gemma 4 mixed-length batching helpers.
 //!
 //! These tests cover two distinct surfaces:
 //!
 //! 1. The per-row prompt-kwarg alignment helpers ([`prompt_kwarg_row`],
 //!    [`pad_sequence_aligned_prompt_kwarg`], [`align_per_row_prompt_kwarg`]).
-//!    Issue #543 will extend the same helpers to handle Gemma 4 E4B/E2B
+//! will extend the same helpers to handle Gemma 4 E4B/E2B
 //!    `per_layer_inputs` (shape `[B, T, num_layers, hidden_per_layer]`),
 //!    so the 4D-shape coverage here is also forward-looking guard rails
 //!    for that follow-up.
 //!
 //! 2. The per-row batched dispatch helper
 //!    ([`forward_batched_with_seq_ids_dispatch`]). Mirrors the integration
-//!    tests added for Qwen VL in PR #558.
+//!    tests added for Qwen VL.
 
 use super::{
     PadSide, align_per_row_prompt_kwarg, forward_batched_with_seq_ids_dispatch,
@@ -86,7 +86,7 @@ fn prompt_kwarg_row_extracts_each_row_of_a_full_batch() {
 #[ignore = "requires serial MLX execution"]
 fn prompt_kwarg_row_handles_4d_per_layer_inputs_shape() {
     // 4D `per_layer_inputs`-shaped tensor `[B=2, T=3, L=2, H=4]`. Issue
-    // #543 will exercise this exact rank for Gemma 4 E4B/E2B.
+    // will exercise this exact rank for Gemma 4 E4B/E2B.
     let total = 2 * 3 * 2 * 4;
     let data: Vec<f32> = (0..total).map(|x| x as f32).collect();
     let v = mlxcel_core::from_slice_f32(&data, &[2, 3, 2, 4]);
@@ -194,8 +194,8 @@ fn pad_sequence_aligned_right_pads_3d_inputs_embeds() {
 #[ignore = "requires serial MLX execution"]
 fn pad_sequence_aligned_left_pads_4d_per_layer_inputs() {
     // 4D `per_layer_inputs`-shaped tensor `[1, T=2, L=2, H=2]`. Pad to T=3.
-    // This is the exact rank issue #543 will exercise — the helper must
-    // already produce correct output for this case so #543 only has to
+    // This is the exact rank will exercise — the helper must
+    // already produce correct output for this case so only has to
     // touch the call site (not re-derive the math).
     let data: Vec<f32> = (1..=8).map(|x| x as f32).collect();
     let v = mlxcel_core::from_slice_f32(&data, &[1, 2, 2, 2]);

--- a/src/multimodal/gemma4_vl_tests.rs
+++ b/src/multimodal/gemma4_vl_tests.rs
@@ -18,7 +18,7 @@
 //!
 //! 1. The per-row prompt-kwarg alignment helpers ([`prompt_kwarg_row`],
 //!    [`pad_sequence_aligned_prompt_kwarg`], [`align_per_row_prompt_kwarg`]).
-//! will extend the same helpers to handle Gemma 4 E4B/E2B
+//!    A follow-up will extend the same helpers to handle Gemma 4 E4B/E2B
 //!    `per_layer_inputs` (shape `[B, T, num_layers, hidden_per_layer]`),
 //!    so the 4D-shape coverage here is also forward-looking guard rails
 //!    for that follow-up.

--- a/src/multimodal/mod.rs
+++ b/src/multimodal/mod.rs
@@ -21,8 +21,8 @@
 //! Modules:
 //! - `batched_dispatch`: shared per-row batched dispatch helper used by every
 //!   vision wrapper that needs `forward_batched_with_context_and_ids` to route
-//!   each row through `forward_with_sequence_id` (PR #558 / issue #542).
-//! - `gemma4_vl`: Gemma 4 mixed-length batching helpers (issue #542)
+//!   each row through `forward_with_sequence_id`.
+//! - `gemma4_vl`: Gemma 4 mixed-length batching helpers
 //! - `phi4mm_prompt`: Phi4MM `<|image_N|>` normalization and audio guard
 //! - `phi4_siglip_prompt`: Phi4-SigLIP `<image>` placeholder handling
 //! - `minicpmo_prompt`: MiniCPM-o image placeholder expansion and bounds
@@ -31,7 +31,7 @@
 //! - `phi3v_prompt`: Phi3V image-tag normalization
 //! - `vlm_prompt`: generic image-token block expansion
 //! - `vlm_runtime`: image preprocessing and embedding preparation shared by CLI/server
-//! - `video`: generic VLM video frame extraction and FPS sampling (issue #553)
+//! - `video`: generic VLM video frame extraction and FPS sampling
 
 pub mod batched_dispatch;
 pub mod gemma4_vl;

--- a/src/multimodal/qwen_vl.rs
+++ b/src/multimodal/qwen_vl.rs
@@ -83,7 +83,7 @@ pub trait QwenVlRuntime {
 
     /// Bind the MRoPE state computed during embedding preparation to a
     /// specific `SequenceId` so the per-row delta cannot leak into other
-    /// requests' decode steps (issue #540 / mlx-vlm PR #1095).
+    /// requests' decode steps (mlx-vlm PR #1095).
     ///
     /// The default implementation is a no-op for runtimes that do not use
     /// MRoPE (in mlxcel today this trait only covers Qwen VL families that
@@ -119,10 +119,10 @@ pub trait QwenVlRuntime {
 
 /// Per-row batched dispatch helper. Re-exported for backwards
 /// compatibility with the Qwen VL wrappers that imported this symbol
-/// when the helper lived in this module (PR #558). The implementation
-/// now lives in [`super::batched_dispatch`] so Gemma 4 (issue #542) and
+/// when the helper lived in this module. The implementation
+/// now lives in [`super::batched_dispatch`] so Gemma 4 and
 /// the Qwen VL families share a single source of truth — see the
-/// duplication report flagged on PR #560 (M-2).
+/// duplication report flagged on (M-2).
 ///
 /// Used by: Qwen2VLModel, Qwen25VLModel, Qwen3VLModel, Qwen3VLMoeModel.
 pub use super::batched_dispatch::forward_batched_with_seq_ids_dispatch;

--- a/src/multimodal/qwen_vl_tests.rs
+++ b/src/multimodal/qwen_vl_tests.rs
@@ -112,7 +112,7 @@ fn insert_qwen_vl_image_tokens_supports_multiple_images() {
     );
 }
 
-// -- Issue #540: dispatch helper integration tests ----------------------
+// -- dispatch helper integration tests ----------------------
 //
 // Drives `forward_batched_with_seq_ids_dispatch` against a tiny stub
 // `LanguageModel` so we can assert that each row of a batched call

--- a/src/multimodal/video.rs
+++ b/src/multimodal/video.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Generic VLM video utilities (issue #553, perf follow-up #597).
+//! Generic VLM video utilities (perf follow-up).
 //!
 //! Translates the upstream Python `mlx_vlm/video_generate.py` pipeline into
 //! Rust so that any vision-language model can accept `--video` inputs through
@@ -30,7 +30,7 @@
 //! - We only need uniform frame sampling (no per-codec hot path), so the
 //!   subprocess overhead is amortised across all frames in a single invocation.
 //!
-//! ## Single-pass extraction (issue #597)
+//! ## Single-pass extraction
 //!
 //! [`load_video`] now invokes `ffmpeg` exactly **once** per video, streaming
 //! all sampled frames as a concatenated PNG sequence through stdout
@@ -41,7 +41,7 @@
 //! place before moving on to the next frame. Peak memory during extraction
 //! is bounded by approximately one decoded frame at a time.
 //!
-//! ## Resolution and duration caps (issue #597)
+//! ## Resolution and duration caps
 //!
 //! Before decoding, [`probe_video`] checks:
 //!
@@ -312,7 +312,7 @@ impl Drop for TempFile {
     }
 }
 
-// ─── VideoSource (issue #601): TOCTOU-safe video handle ─────────────────────
+// ─── VideoSource: TOCTOU-safe video handle ─────────────────────
 
 /// A video input that can be safely passed to `ffmpeg` / `ffprobe` without
 /// re-opening by path.
@@ -690,7 +690,7 @@ struct VideoMeta {
 /// - `MLXCEL_VIDEO_MAX_DURATION_SEC` — duration in seconds (default 600)
 ///
 /// Accepts a [`VideoSource`] so the resolver in `src/server/media.rs` can
-/// pass an opened fd (issue #601) instead of the canonical path. The fd
+/// pass an opened fd instead of the canonical path. The fd
 /// path closes the TOCTOU window between the resolver's `canonicalize`
 /// and ffmpeg's `open`.
 fn probe_video(source: &VideoSource, limits: &VideoLimits) -> Result<VideoMeta, VideoError> {
@@ -938,7 +938,7 @@ fn parse_rational(value: &str) -> Option<f64> {
 /// }).await??;
 /// ```
 ///
-/// # Path vs fd input (issue #601)
+/// # Path vs fd input
 ///
 /// This function operates on a [`Path`]. Server callers that source the
 /// video from an untrusted user request should instead use
@@ -969,8 +969,7 @@ pub fn load_video_with_limits(
 /// Decode a [`VideoSource`] into uniformly-sampled frames.
 ///
 /// Equivalent to [`load_video`] but accepts a [`VideoSource`] so the
-/// fd-backed variant (used by the chat-completion video resolver, issue
-/// #601) can pipe the file through `/dev/fd/N` instead of re-opening the
+/// fd-backed variant (used by the chat-completion video resolver) can pipe the file through `/dev/fd/N` instead of re-opening the
 /// canonical path. See [`VideoSource`] for the security rationale.
 pub fn load_video_source(
     source: &VideoSource,
@@ -1069,7 +1068,7 @@ fn uniform_indices(total_frames: usize, nframes: usize) -> Vec<usize> {
 /// presentation number `n` against each operand and outputs a frame when
 /// any equality holds. The `+` operator is a logical OR.
 ///
-/// ## Issue #601: fd-bearing source support
+/// ## fd-bearing source support
 ///
 /// Accepts a [`VideoSource`] so the resolver in `src/server/media.rs` can
 /// pass an opened fd instead of the canonical path. When the source is

--- a/src/multimodal/video_tests.rs
+++ b/src/multimodal/video_tests.rs
@@ -343,7 +343,7 @@ fn load_video_rejects_overlong_duration() {
 fn load_video_single_pass_produces_correct_frame_count() {
     // Verify that the single-pass implementation produces the expected
     // number of frames for a short synthetic video. This is the key
-    // regression test for the single-pass refactor (issue #597).
+    // regression test for the single-pass refactor.
     if !ffmpeg_available() {
         eprintln!("SKIP: ffmpeg not available");
         return;
@@ -564,10 +564,10 @@ fn video_limits_from_raw_parses_overrides_and_falls_back() {
     assert_eq!(fallback.max_png_frame_bytes, defaults.max_png_frame_bytes);
 }
 
-// ─── Issue #601: VideoSource fd path through ffmpeg ──────────────────────────
+// ─── VideoSource fd path through ffmpeg ──────────────────────────
 
 /// Verify `load_video_source` works against an opened file descriptor passed
-/// via `/dev/fd/N` (issue #601). This is the primary smoke test for the
+/// via `/dev/fd/N`. This is the primary smoke test for the
 /// fd-based pipeline: ffmpeg/ffprobe must accept `/dev/fd/N` as an input
 /// path on the project's supported platforms (Linux + macOS) and produce
 /// the same decoded frames as the path variant.
@@ -611,7 +611,7 @@ fn load_video_source_fd_variant_decodes_via_dev_fd_n() {
     let frames = frames_result.expect(
         "load_video_source must succeed against /dev/fd/N; if this fails the runtime ffmpeg \
          build does not honor /dev/fd/N as an input — investigate the ffmpeg version on the \
-         host or fall back to a different fd-passing strategy (issue #601)",
+         host or fall back to a different fd-passing strategy",
     );
     assert!(
         !frames.is_empty(),
@@ -654,7 +654,7 @@ fn load_video_source_fd_variant_matches_path_variant_frame_count() {
     let path_frames = load_video_with_limits(&video_path, Some(5.0), None, &limits)
         .expect("path-based load_video must succeed for synthetic video");
 
-    // Fd-based decode (the issue #601 path).
+    // Fd-based decode (the path).
     let std_file = std::fs::File::open(&video_path).expect("open synthetic video");
     let owned_fd = std::os::fd::OwnedFd::from(std_file);
     let canonical = std::fs::canonicalize(&video_path).expect("canonicalise");
@@ -728,7 +728,7 @@ fn video_source_fd_dev_fd_n_resolves_to_owned_file_description() {
     assert_eq!(
         buf, payload,
         "bytes read via /dev/fd/N must match the original fixture; this is the \
-         /dev/fd/N kernel contract that the issue #601 fix relies on"
+         /dev/fd/N kernel contract that the fix relies on"
     );
 
     drop(source); // closes the OwnedFd
@@ -801,7 +801,7 @@ fn bench_single_pass_768_frames() {
 
 // ─── Content-preservation tests (require ffmpeg) ─────────────────────────────
 //
-// Issue #598: These tests verify that load_video preserves pixel content, not
+// These tests verify that load_video preserves pixel content, not
 // just shape. They catch:
 //   - Wrong color channel order (BGR vs RGB)
 //   - Wrong sample timing (off-by-one in frame indexing)

--- a/src/multimodal/vlm_runtime.rs
+++ b/src/multimodal/vlm_runtime.rs
@@ -66,7 +66,7 @@ pub enum VlmPreparationSummary {
         audio_tokens: usize,
         total_tokens: usize,
     },
-    /// Issue #553: Gemma 4 expanded `<|video|>` placeholders for one or
+    /// Gemma 4 expanded `<|video|>` placeholders for one or
     /// more decoded videos. `frame_slots` is the total number of frames
     /// across all videos (each frame consumes
     /// `boi + image_token * num_soft_tokens_per_frame + eoi`).
@@ -100,7 +100,7 @@ pub enum VlmPreparationSummary {
         image_slots: usize,
         total_tokens: usize,
     },
-    /// Issue #582: Nemotron H Nano Omni expanded one or more audio
+    /// Nemotron H Nano Omni expanded one or more audio
     /// clip placeholders. `audio_clips` is the number of clips
     /// processed; `audio_tokens` is the post-subsampling encoder
     /// output token count fed into the merge step.
@@ -113,7 +113,7 @@ pub enum VlmPreparationSummary {
         image_blocks: usize,
         total_image_tokens: i32,
     },
-    /// Issue #738: InternVL expanded each `<image>`/`<IMG_CONTEXT>` placeholder
+    /// InternVL expanded each `<image>`/`<IMG_CONTEXT>` placeholder
     /// into `<img> + <IMG_CONTEXT> * (num_image_token * tiles) + </img>`.
     InternVL {
         image_blocks: usize,
@@ -894,7 +894,7 @@ pub fn expand_gemma4_image_tokens_pub(
 }
 
 /// Expand a Gemma 4 video token placeholder into per-frame
-/// `<boi> image_token * N <eoi>` runs (issue #553).
+/// `<boi> image_token * N <eoi>` runs.
 ///
 /// Mirrors the upstream Python `Gemma4Processor.__call__(videos=...)`
 /// expansion: every `video_token_id` in `prompt_tokens` is replaced by

--- a/src/multimodal/vlm_runtime_tests.rs
+++ b/src/multimodal/vlm_runtime_tests.rs
@@ -110,7 +110,7 @@ fn molmo_v1_image_input_idx_shifts_only_valid_positions_for_bos() {
     );
 }
 
-// -- Gemma 4 video token expansion (issue #553) ----------------------
+// -- Gemma 4 video token expansion ----------------------
 
 #[test]
 fn expand_gemma4_video_tokens_replaces_explicit_placeholder() {

--- a/src/sampling_observability_tests.rs
+++ b/src/sampling_observability_tests.rs
@@ -14,7 +14,7 @@
 
 //! B9 — Observability unit tests for `mlxcel_core::sampling`.
 //!
-//! Covers the acceptance criteria in GitHub issue #381:
+//! Covers the acceptance criteria in GitHub
 //!
 //! - `metric_not_incremented_when_bias_empty` — empty `TokenBiasMap` leaves
 //!   both counters at zero after N sampling calls.
@@ -197,7 +197,7 @@ fn tokens_suppressed_metric_increments_only_on_neg_inf_top1() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #405 — byte-fragment suppression counter
+// byte-fragment suppression counter
 // ---------------------------------------------------------------------------
 
 /// When a `-inf`-suppressed top-1 token was tagged via

--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -96,7 +96,7 @@ pub fn create_app(state: AppState) -> Router {
         .route("/v1/chat/completions", post(routes::chat_completions))
         .route("/v1/completions", post(routes::completions))
         .route("/v1/models", get(routes::list_models))
-        // Issue #622: Responses API (OpenAI /v1/responses surface).
+        // Responses API (OpenAI /v1/responses surface).
         .route("/v1/responses", post(routes::create_response))
         .route(
             "/v1/responses/:id",
@@ -109,7 +109,7 @@ pub fn create_app(state: AppState) -> Router {
             "/v1/messages/count_tokens",
             post(routes::anthropic_count_tokens),
         )
-        // Issue #552: prompt-cache observability endpoints (always mounted —
+        // prompt-cache observability endpoints (always mounted
         // the handlers return a stable "disabled" payload when the cache is
         // off so monitoring clients can poll without conditional logic).
         .route("/v1/cache/stats", get(routes::cache_stats))

--- a/src/server/batch/active.rs
+++ b/src/server/batch/active.rs
@@ -84,7 +84,7 @@ impl ActiveBatch {
 
     /// Capacity limit of the batch — the configured `max_batch_size`.
     ///
-    /// Issue #674: the speculative-burst scheduler uses this to decide
+    /// the speculative-burst scheduler uses this to decide
     /// whether to attempt a B > 1 batched burst window. The scheduler
     /// constructs `ActiveBatch::new(max_batch_size)`, so this accessor
     /// surfaces the same `max_batch_size` without storing it twice on

--- a/src/server/batch/mod.rs
+++ b/src/server/batch/mod.rs
@@ -33,7 +33,7 @@ pub(crate) mod scheduler;
 #[cfg(test)]
 mod scheduler_prompt_cache_tests;
 mod sequence;
-/// Issue #670: speculative-decoding burst driver. Folded into the
+/// speculative-decoding burst driver. Folded into the
 /// scheduler's `execute_prefill` dispatch when the worker's
 /// [`crate::server::SpeculativeDispatch`] is kind-specific and the
 /// per-request preconditions hold.

--- a/src/server/batch/observability.rs
+++ b/src/server/batch/observability.rs
@@ -73,7 +73,7 @@ pub struct BatchObservability {
     /// Times paged decode was requested but fell back to dense.
     pub decode_storage_fallbacks: AtomicU64,
 
-    // -- Epic #416 / issue #421: prompt-prefix cache --
+    // -- prompt-prefix cache --
     /// Cumulative count of successful prompt-cache adoptions (hits).
     pub prompt_cache_hits: AtomicU64,
     /// Cumulative count of prompt tokens that bypassed prefill because they
@@ -155,7 +155,7 @@ impl BatchObservability {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record a successful prompt-cache hit (epic #416 / issue #421).
+    /// Record a successful prompt-cache hit.
     ///
     /// `matched_tokens` is the number of leading tokens covered by the
     /// adopted detached KV cache — exactly the count subtracted from the
@@ -271,14 +271,14 @@ pub struct ObservabilitySnapshot {
     pub cache_pool_paged_bytes_reserved: u64,
     pub cache_pool_paged_bytes_in_use: u64,
     pub decode_storage_fallbacks: u64,
-    /// Epic #416 / issue #421: successful prompt-cache adoptions.
+    /// successful prompt-cache adoptions.
     pub prompt_cache_hits: u64,
-    /// Epic #416 / issue #421: tokens skipped due to cache hits (Σ
+    /// tokens skipped due to cache hits (Σ
     /// matched-prefix lengths across all hits).
     pub prompt_cache_hit_tokens: u64,
-    /// Epic #416 / issue #421: successful donate-back inserts.
+    /// successful donate-back inserts.
     pub prompt_cache_inserts: u64,
-    /// Epic #416 / issue #421: rejected donate-back inserts (oversized
+    /// rejected donate-back inserts (oversized
     /// entry, store disabled, prefix too short, …).
     pub prompt_cache_insert_rejects: u64,
 }

--- a/src/server/batch/queue.rs
+++ b/src/server/batch/queue.rs
@@ -105,7 +105,7 @@ impl PrefillQueue {
     /// `lane` priority lane for which `predicate` returns `true`, stopping
     /// at the first sequence that does not match.
     ///
-    /// Issue #674: used by the speculative-burst scheduler to assemble a
+    /// used by the speculative-burst scheduler to assemble a
     /// B > 1 batched-burst window. The caller dequeues the head sequence
     /// normally via [`Self::dequeue`], then calls this with the head's
     /// priority lane and a predicate that matches "speculative-eligible
@@ -521,7 +521,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // drain_matching_window (issue #674 — batched speculative burst)
+    // drain_matching_window (— batched speculative burst)
     // -----------------------------------------------------------------
 
     #[test]

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -129,7 +129,7 @@ pub struct BatchScheduler {
     // if construction and execution happen on different threads.
     // Currently constructed and run on the same thread; the TLS design
     // leaves room to separate them in the future if needed.
-    // See `mlxcel_core::streams` and issue #556.
+    // See `mlxcel_core::streams` and.
     generation_stream: Option<UniquePtr<MlxThreadLocalStream>>,
 
     // -- Request channel --
@@ -167,7 +167,7 @@ pub struct BatchScheduler {
     /// Decode-time sequence-state backend used by this scheduler.
     decode_storage_backend: DecodeStorageBackend,
 
-    /// Server-wide KV cache quantization mode (issue #484 / #508).
+    /// Server-wide KV cache quantization mode.
     ///
     /// When non-Fp16 the scheduler upgrades each newly-allocated sequence's
     /// per-layer `KVCache` to the configured mode (with Boundary-V policy
@@ -179,7 +179,7 @@ pub struct BatchScheduler {
     /// Defaults to [`KVCacheMode::Fp16`] (bit-exact baseline).
     kv_cache_mode: KVCacheMode,
 
-    /// Issue #545: server-wide batch KV quantization configuration.
+    /// server-wide batch KV quantization configuration.
     ///
     /// When [`BatchKvQuantConfig::is_enabled`] returns `true`, the
     /// scheduler resolves per-layer modes from this config (with the
@@ -189,7 +189,7 @@ pub struct BatchScheduler {
     /// (the default), the legacy path is bit-exact preserved.
     batch_kv_quant: BatchKvQuantConfig,
 
-    /// Issue #603: maximum KV cache size for plain (non-sliding) `KVCache`
+    /// maximum KV cache size for plain (non-sliding) `KVCache`
     /// instances managed by this scheduler's `CachePool`.
     ///
     /// When `Some(N)`, the scheduler enforces a hard cap on the **live KV
@@ -199,8 +199,7 @@ pub struct BatchScheduler {
     /// invoked on each cache whose `live_len()` exceeds `N`, dropping the
     /// oldest excess tokens. **Crucially, the cache's monotonic `offset`
     /// is never decremented** — `trim_front` advances `live_start` so
-    /// RoPE relative positions stay correct (issue #603, see
-    /// [`KVCache::trim_front`] for the position invariant).
+    /// RoPE relative positions stay correct (see [`KVCache::trim_front`] for the position invariant).
     ///
     /// Sliding-window models that manage their own internal
     /// `RotatingKVCache` go through a separate model-level code path and
@@ -225,7 +224,7 @@ pub struct BatchScheduler {
     /// when the scheduler (and thus this loaded model) is dropped.
     vision_caches: Rc<ModelVisionCaches>,
 
-    // -- Axis B / Epic #362 — language-bias token map --
+    // -- Axis B / — language-bias token map --
     /// Cached per-scheduler `TokenBiasMap` resolved once from the server-level
     /// `LangBiasConfig` at worker startup.
     ///
@@ -242,7 +241,7 @@ pub struct BatchScheduler {
     /// Empty map = bit-exact baseline path (no sampling change, no alloc).
     token_bias: TokenBiasMap,
 
-    // -- Issue #409 — thinking-token budget --
+    // -- — thinking-token budget --
     /// Server-wide default thinking-token budget. `None` means unrestricted.
     /// Per-request `thinking_budget_tokens` overrides this at enqueue time.
     reasoning_budget: Option<ThinkingBudget>,
@@ -252,7 +251,7 @@ pub struct BatchScheduler {
     /// regardless of any budget configuration.
     thinking_token_ids: Option<ThinkingTokenIds>,
 
-    // -- Epic #416 / issue #421: cross-request prompt-prefix KV cache --
+    // -- cross-request prompt-prefix KV cache --
     /// Shared store that hands out detached KV caches on prefix match and
     /// absorbs donated caches on sequence finish. `None` when the feature is
     /// disabled at config time so the hot path has zero overhead.
@@ -265,7 +264,7 @@ pub struct BatchScheduler {
     /// removed from the map on finish / error.
     prompt_cache_seq_ctx: std::collections::HashMap<SequenceId, PromptCacheRequestContext>,
 
-    /// Issue #666: resolved speculative-decoding dispatch shape.
+    /// resolved speculative-decoding dispatch shape.
     ///
     /// Defaults to [`crate::server::SpeculativeDispatch::Disabled`]
     /// (constructed by [`Self::with_config`]). When the scheduler is
@@ -288,14 +287,14 @@ pub struct BatchScheduler {
     /// still falls back to classic decode at request time. This is the
     /// minimum-viable architectural foundation; full B=1 / B>1 decode
     /// integration completes in the peer follow-up sketched in the
-    /// issue #666 implementation plan.
+    /// implementation plan.
     speculative_dispatch: crate::server::SpeculativeDispatch,
 
-    /// Issue #670: lazy-loaded drafter handle for the speculative burst
+    /// lazy-loaded drafter handle for the speculative burst
     /// path. Constructed empty alongside the dispatch; the drafter's
     /// weights are loaded from disk on the **first** speculative
     /// request and cached for subsequent requests on the same worker
-    /// (mandate 2 of issue #670). For
+    /// (mandate 2). For
     /// [`crate::server::SpeculativeDispatch::Disabled`] this slot stays
     /// empty for the worker's lifetime and the burst path is never
     /// entered.
@@ -322,7 +321,7 @@ impl BatchScheduler {
     ///
     /// Currently unused at the call site (`with_config` is what production
     /// constructs) but retained as a convenience for future tests/benches.
-    /// The scheduler API is `pub(crate)` after the issue #601 refactor so
+    /// The scheduler API is `pub(crate)` after the refactor so
     /// `dead_code` is silenced explicitly rather than dropped, keeping the
     /// preserved-behavior intent visible.
     #[allow(dead_code)]
@@ -419,12 +418,12 @@ impl BatchScheduler {
             kv_cache_mode: KVCacheMode::Fp16,
             batch_kv_quant: BatchKvQuantConfig::default(),
             max_kv_size: None,
-            // Issue #666: dispatch defaults to Disabled so the scheduler's
+            // dispatch defaults to Disabled so the scheduler's
             // hot path stays bit-exact for the non-speculative case. The
             // worker thread overrides this via `with_speculative_dispatch`
             // when the operator passed `--draft-model`.
             speculative_dispatch: crate::server::SpeculativeDispatch::Disabled,
-            // Issue #670: empty slot, populated lazily on the first
+            // empty slot, populated lazily on the first
             // speculative request when `speculative_dispatch` is
             // kind-specific. `with_speculative_dispatch` rebuilds this
             // slot from the dispatch passed by the worker.
@@ -434,14 +433,14 @@ impl BatchScheduler {
         }
     }
 
-    /// Attach the server-wide KV cache quantization mode (issue #484 / #508).
+    /// Attach the server-wide KV cache quantization mode.
     ///
     /// When `mode == KVCacheMode::Fp16` this builder is a no-op — every new
     /// sequence keeps the default Fp16 caches and the paged layout uses
     /// `PagedKvLayout::uniform`. For Turbo4 modes (`Turbo4Asym`, `Turbo4`,
     /// `Turbo4Delegated`) the scheduler additionally picks
     /// [`PagedKvLayout::uniform_with_mode`] so per-page sidecars are
-    /// reserved, preserving the cross-tenant isolation contract from #482.
+    /// reserved, preserving the cross-tenant isolation contract.
     pub fn with_kv_cache_mode(mut self, mode: KVCacheMode) -> Self {
         self.kv_cache_mode = mode;
         self
@@ -453,7 +452,6 @@ impl BatchScheduler {
     }
 
     /// Attach the server-wide batch KV quantization configuration
-    /// (issue #545).
     ///
     /// When `config.is_enabled()` returns `true`, every newly-allocated
     /// sequence's per-layer caches are upgraded from the default Fp16
@@ -473,7 +471,7 @@ impl BatchScheduler {
         self.batch_kv_quant
     }
 
-    /// Set the maximum KV cache size for plain (non-sliding) caches (issue #603).
+    /// Set the maximum KV cache size for plain (non-sliding) caches.
     ///
     /// When `max_kv_size.is_some()`, the scheduler advances `live_start` on
     /// every plain `KVCache` after each prefill chunk and each decode step
@@ -487,7 +485,7 @@ impl BatchScheduler {
     /// Turbo-quantized caches (`Turbo4Asym` / `Turbo4` / `Turbo4Delegated`
     /// / `Turbo3Asym`) are silently skipped by `KVCache::trim_front` — a
     /// warning is emitted here so the operator knows the combination is
-    /// unsupported. **Issue #603 H3**: the warning now inspects *both* the
+    /// unsupported. ** H3**: the warning now inspects *both* the
     /// legacy `kv_cache_mode` flag *and* the per-layer modes resolved
     /// from `batch_kv_quant` so the combination
     /// `--kv-bits=N --kv-quant-scheme=turboquant --max-kv-size=M` is
@@ -498,7 +496,7 @@ impl BatchScheduler {
         if max_kv_size.is_some() {
             // Legacy `--kv-cache-mode`-driven path.
             let legacy_is_turbo = Self::is_turbo_mode(self.kv_cache_mode);
-            // Issue #545 `--kv-bits` / `--kv-quant-scheme` path. When
+            // `--kv-bits` / `--kv-quant-scheme` path. When
             // batch KV quant is enabled, `base_mode()` reports the
             // effective per-layer mode driving the paged-layout
             // selection; we treat any Turbo base mode the same way as
@@ -530,7 +528,7 @@ impl BatchScheduler {
         self.max_kv_size
     }
 
-    /// Attach the resolved speculative-decoding dispatch (issue #666).
+    /// Attach the resolved speculative-decoding dispatch.
     ///
     /// Default (constructed by [`Self::with_config`]) is
     /// [`crate::server::SpeculativeDispatch::Disabled`], so callers that
@@ -570,7 +568,7 @@ impl BatchScheduler {
         mut self,
         dispatch: crate::server::SpeculativeDispatch,
     ) -> Self {
-        // Issue #670: rebuild the (still-empty) drafter slot to carry
+        // rebuild the (still-empty) drafter slot to carry
         // the path + kind from the new dispatch. The drafter weights
         // are NOT loaded here — `ensure_loaded` on the first
         // speculative request is what reads from disk.
@@ -587,14 +585,13 @@ impl BatchScheduler {
     }
 
     /// Whether the scheduler has a kind-specific speculative dispatch
-    /// configured (issue #666; issue #670 wired this into the actual
-    /// runtime dispatch).
+    /// configured (wired this into the actual runtime dispatch).
     ///
     /// Returns `true` when [`Self::speculative_dispatch`] is one of the
     /// kind-specific variants ([`crate::server::SpeculativeDispatch::Mtp`]
     /// or [`crate::server::SpeculativeDispatch::DFlash`]).
     ///
-    /// **Semantics (issue #670)**: a `true` return only means a
+    /// **Semantics**: a `true` return only means a
     /// speculative *path* is configured — the actual per-request
     /// decision happens inside [`Self::execute_prefill`] via
     /// [`super::speculative_burst::should_burst_for_sequence`], which
@@ -607,12 +604,11 @@ impl BatchScheduler {
     /// B-size of concurrent classic requests is independent of whether
     /// this gate fires for a speculative request.
     ///
-    /// Backwards compatibility: pre-#670 callers (the worker-startup
-    /// log and the integration tests in #669) used this method as a
+    /// Backwards compatibility: earlier callers (the worker-startup log and the integration tests) used this method as a
     /// "would we dispatch?" probe. The semantics remain compatible:
     /// `true` ↔ "speculative is on and a future request could enter
     /// the burst path"; `false` ↔ "every request takes the classic
-    /// path." The active-batch-size restriction was a pre-#670
+    /// path." The active-batch-size restriction was a earlier
     /// over-approximation that the burst design removes.
     pub fn should_dispatch_speculative(&self) -> bool {
         self.speculative_dispatch.is_kind_specific()
@@ -652,7 +648,7 @@ impl BatchScheduler {
     }
 
     /// Attach the server-wide thinking-token budget and resolved
-    /// `<think>` / `</think>` token ids (issue #409).
+    /// `<think>` / `</think>` token ids.
     ///
     /// `token_ids == None` means the model is non-thinking; the budget is
     /// then silently ignored for every sequence. Callers resolve the token
@@ -670,7 +666,6 @@ impl BatchScheduler {
     }
 
     /// Attach the shared prompt-prefix KV cache store
-    /// (epic #416 / issue #421).
     ///
     /// When `Some(..)`, the scheduler:
     /// * Looks up a longest-prefix match on each new request and calls
@@ -688,7 +683,7 @@ impl BatchScheduler {
     }
 
     /// Whether the installed prompt-cache store is currently accepting
-    /// lookups and inserts (scheduler-level gate for #424).
+    /// lookups and inserts (scheduler-level gate).
     #[inline]
     fn prompt_cache_active(&self) -> bool {
         self.prompt_cache
@@ -756,7 +751,7 @@ impl BatchScheduler {
             return None;
         }
 
-        // APC block-level partial adoption (issue #580). When APC clamps
+        // APC block-level partial adoption. When APC clamps
         // `matched_len` to a block boundary shorter than the cached entry's
         // full token length, the request diverged from the cached prefix at
         // the next block. Truncate the detached KV state to exactly
@@ -795,7 +790,7 @@ impl BatchScheduler {
                 );
                 self.batch_observability
                     .record_prompt_cache_hit(matched_len);
-                // Issue #423: also increment BatchMetrics Prometheus counters.
+                // also increment BatchMetrics Prometheus counters.
                 self.batch_metrics.record_prompt_cache_hit(matched_len);
                 // Update byte/entry gauges so /metrics reflects current state.
                 if let Some(ref store) = self.prompt_cache {
@@ -883,7 +878,7 @@ impl BatchScheduler {
         match store.insert(&key, entry) {
             Ok(()) => {
                 self.batch_observability.record_prompt_cache_insert();
-                // Issue #423: refresh byte/entry gauges after a successful insert.
+                // refresh byte/entry gauges after a successful insert.
                 self.batch_metrics
                     .update_prompt_cache_gauges(store.bytes(), store.len());
             }
@@ -899,7 +894,7 @@ impl BatchScheduler {
         }
     }
 
-    /// Apply issue #409 thinking-budget enforcement to a freshly sampled
+    /// Apply thinking-budget enforcement to a freshly sampled
     /// token for a single sequence.
     ///
     /// Returns the final token id to commit to the sequence (either the
@@ -930,7 +925,7 @@ impl BatchScheduler {
         final_id
     }
 
-    /// Issue #550: apply the structured-output mask (if any) to logits before
+    /// apply the structured-output mask (if any) to logits before
     /// sampling.
     ///
     /// Returns either the masked logits or `Err(_)` describing why the
@@ -956,7 +951,7 @@ impl BatchScheduler {
         Ok(masked)
     }
 
-    /// Issue #550: advance the matcher state by the just-sampled token.
+    /// advance the matcher state by the just-sampled token.
     ///
     /// Returns `Ok(())` on success, `Err(msg)` when `consume_token` fails or
     /// the matcher is in an error state. The caller transitions the sequence
@@ -973,7 +968,7 @@ impl BatchScheduler {
         guard.consume_token(token).map_err(|e| e.to_string())
     }
 
-    /// Issue #550: send a clean SSE error event and transition the sequence
+    /// send a clean SSE error event and transition the sequence
     /// to `Finished(Error(msg))`. Used by the structured-output path to
     /// abort cleanly when the matcher refuses to advance.
     fn abort_sequence_with_error(seq: Option<&mut SequenceInfo>, prefix: &str, msg: &str) {
@@ -1096,7 +1091,7 @@ impl BatchScheduler {
         let seq_id = self
             .cache_pool
             .allocate_with_layout(&self.model, layout_override)?;
-        // Issue #484 / #508: apply the configured KV cache mode (with
+        // apply the configured KV cache mode (with
         // Boundary-V policy for Turbo4 modes) to the freshly allocated
         // per-layer caches. `model.make_caches()` always returns Fp16
         // caches; this step upgrades them to the requested mode while
@@ -1114,15 +1109,15 @@ impl BatchScheduler {
     /// FP16 caches from `model.make_caches()`. For Turbo4 modes the
     /// per-layer mode is resolved via
     /// [`mlxcel_core::cache::turbo::resolve_layer_modes`] so boundary
-    /// layers stay FP16 (issue #478) for quality.
+    /// layers stay FP16 for quality.
     ///
-    /// Issue #545: when [`BatchKvQuantConfig::is_enabled`] returns
+    /// when [`BatchKvQuantConfig::is_enabled`] returns
     /// `true`, the per-layer mode table is sourced from
     /// [`BatchKvQuantConfig::resolve_layer_modes`] instead — that table
     /// honours the `skip_last_layer` policy, which is distinct from
     /// (and composes with) the existing Boundary-V mechanism.
     ///
-    /// Used by: [`Self::allocate_sequence_state`] (#508, #545).
+    /// Used by: [`Self::allocate_sequence_state`].
     fn apply_kv_cache_mode_to(&mut self, seq_id: SequenceId) {
         let Some(caches) = self.cache_pool.get_caches_mut(seq_id) else {
             return;
@@ -1135,7 +1130,7 @@ impl BatchScheduler {
         }
         let n_layers = caches.len();
 
-        // Issue #545: when the batched KV quant config is active, it
+        // when the batched KV quant config is active, it
         // takes precedence over the legacy `kv_cache_mode` path. The
         // resolved table already encodes the per-layer mode (with the
         // last-layer skip applied), so apply it directly.
@@ -1147,7 +1142,7 @@ impl BatchScheduler {
             return;
         }
 
-        // Legacy path (issue #484 / #508): nominal mode + Boundary-V
+        // Legacy path: nominal mode + Boundary-V
         // protection only.
         let nominal = self.kv_cache_mode;
         if nominal == KVCacheMode::Fp16 {
@@ -1175,7 +1170,7 @@ impl BatchScheduler {
         }
     }
 
-    /// Enforce the `--max-kv-size` cap on a sequence's KV caches (issue #603).
+    /// Enforce the `--max-kv-size` cap on a sequence's KV caches.
     ///
     /// Trims the oldest `live_len(cache) - max_kv_size` tokens from every
     /// plain `KVCache` layer whose live window exceeds the configured
@@ -1185,7 +1180,7 @@ impl BatchScheduler {
     /// `RotatingKVCache` and are never stored in the pool's
     /// `Vec<KVCache>`, so they are unaffected.
     ///
-    /// **Issue #603 H1**: `max_kv_size` has already been validated to fit
+    /// ** H1**: `max_kv_size` has already been validated to fit
     /// in `i32` by [`crate::server::cli_input::resolve_max_kv_size`], so
     /// the `i32::try_from` here is a defensive belt-and-suspenders fallback
     /// — it returns silently rather than panicking, because the validation
@@ -1194,7 +1189,7 @@ impl BatchScheduler {
     /// cap is enforced on the **live window** — the monotonic `offset`
     /// keeps growing past the cap by design.
     ///
-    /// **Issue #603 H2**: called from every cache-mutating path:
+    /// ** H2**: called from every cache-mutating path:
     /// [`Self::execute_full_prefill`], [`Self::start_chunked_prefill`],
     /// [`Self::continue_chunked_prefill`], [`Self::decode_single_step`],
     /// and [`Self::execute_batched_decode`].
@@ -1221,8 +1216,7 @@ impl BatchScheduler {
         for cache in caches {
             // `live_len() = offset - live_start`. We trim against the live
             // window length (what attention sees), not the monotonic
-            // `offset` (which keeps growing by design — see #603 RoPE
-            // invariant in `KVCache::trim_front`).
+            // `offset` (which keeps growing by design — RoPE invariant in `KVCache::trim_front`).
             let live_len = cache.live_len();
             // `checked_sub` so a future arithmetic regression cannot
             // silently wrap into a negative trim depth that produces a
@@ -1241,7 +1235,7 @@ impl BatchScheduler {
         }
 
         let num_layers = self.model.num_layers();
-        // Issue #545: prefer the batched KV quant config when active so
+        // prefer the batched KV quant config when active so
         // its `base_mode()` drives paged-layout selection (Turbo-aware
         // when scheme is TurboQuant, otherwise the legacy uniform path).
         let effective_mode = if self.batch_kv_quant.is_enabled() {
@@ -1249,11 +1243,11 @@ impl BatchScheduler {
         } else {
             self.kv_cache_mode
         };
-        // Issue #508: when a Turbo4 cache mode is configured, build a
-        // packed-aware paged layout (PR #502 / issue #482) so per-page
+        // when a Turbo4 cache mode is configured, build a
+        // packed-aware paged layout so per-page
         // sidecar accounting and detach/adopt round-trip work correctly.
         // Fp16/Int8 keep the historical `PagedKvLayout::uniform` path —
-        // bit-identical to pre-#508.
+        // bit-identical to earlier.
         let paged_layout = if Self::is_turbo_mode(effective_mode) {
             // The actual per-token packed sidecar size depends on the
             // model's V head_dim, which is not known to the scheduler
@@ -1287,20 +1281,20 @@ impl BatchScheduler {
 
     /// Whether the supplied KV cache mode requires Turbo*-aware paged
     /// layout (per-page sidecar storage on `PagedBlockPool`) and is
-    /// **incompatible** with the issue #603 `--max-kv-size` cap.
+    /// **incompatible** with the `--max-kv-size` cap.
     ///
     /// All Turbo modes carry per-token rotation state in their sidecars
     /// (`turbo_params` / `turbo3_params` / `v_packed` / `v_norms` /
     /// `cold_offset`) that `KVCache::trim_front` cannot safely truncate
-    /// from the head. Issue #603 H3: `Turbo3Asym` belongs in this set —
+    /// from the head. H3: `Turbo3Asym` belongs in this set
     /// the 3-bit V sidecars (`v_packed` with 24-bit groups + `v_norms`)
     /// have the same per-token contract as `Turbo4*`. Omitting it from
     /// this match silently allowed `--max-kv-size` + `fp16+turbo3` to ship
     /// without the operator-facing warning that the cap will not be
     /// honoured on the V side.
     ///
-    /// Used by: scheduler dispatch for sequence allocation (#508), the
-    /// `--max-kv-size` + Turbo combination warning (#603).
+    /// Used by: scheduler dispatch for sequence allocation, the
+    /// `--max-kv-size` + Turbo combination warning.
     #[inline]
     fn is_turbo_mode(mode: KVCacheMode) -> bool {
         matches!(
@@ -1426,7 +1420,7 @@ impl BatchScheduler {
             sampling.token_bias = self.token_bias.clone();
         }
 
-        // Epic #416 / issue #421: before allocating a fresh KV-cache slot,
+        // before allocating a fresh KV-cache slot,
         // probe the prompt-prefix cache for a reusable detached set. On a
         // hit, adopt under a brand-new SequenceId and record how many
         // leading tokens the prefill can skip. On a miss (which includes
@@ -1438,7 +1432,7 @@ impl BatchScheduler {
         // and video frame placeholders expand later inside
         // `prepare_request_vlm_embeddings`), so matching against it risks
         // reusing a KV slice built for a different media payload. Support
-        // for image-aware cache keys is tracked separately in issue #425.
+        // for image-aware cache keys is tracked separately.
         let is_multimodal = !images.is_empty() || !audio.is_empty() || !videos.is_empty();
         let ctx_ref = if is_multimodal {
             None
@@ -1450,7 +1444,7 @@ impl BatchScheduler {
                 Some((adopted_id, matched_len)) => (adopted_id, matched_len, matched_len),
                 None => {
                     // Miss or feature disabled → regular allocate.
-                    // Issue #423: count misses only when the cache is actually
+                    // count misses only when the cache is actually
                     // active (ctx_ref is Some) to avoid inflating the miss
                     // counter for multimodal or cache-disabled requests.
                     if ctx_ref.is_some() {
@@ -1490,7 +1484,7 @@ impl BatchScheduler {
             }
         };
 
-        // Issue #540 / mlx-vlm PR #1095: per-sequence MRoPE alignment.
+        // mlx-vlm PR #1095: per-sequence MRoPE alignment.
         //
         // The Qwen VL families compute the MRoPE position-id tensor and
         // `rope_deltas` scalar inside `prepare_request_vlm_embeddings`
@@ -1502,7 +1496,7 @@ impl BatchScheduler {
         // the call is a no-op for everything else.
         self.model.bind_qwen_vl_mrope_state_to_sequence(seq_id);
 
-        // Issue #543: per-sequence `per_layer_inputs` for Gemma 4
+        // per-sequence `per_layer_inputs` for Gemma 4
         // E2B/E4B. `prepare_request_vlm_embeddings` writes the
         // freshly projected tensor to the VL model's fallback slot;
         // this call drains the slot into a per-`SequenceId` map so a
@@ -1523,7 +1517,7 @@ impl BatchScheduler {
 
         let decode_state = StreamingDecodeState::new(&self.tokenizer, &prompt_tokens);
 
-        // Issue #409: resolve the effective thinking-token budget for this
+        // resolve the effective thinking-token budget for this
         // sequence from the per-request override + server default. The route
         // layer supplies `thinking_enter_block_on_start` as `true` when the
         // rendered prompt primes `<think>` (chat endpoints) and `false` for
@@ -1588,7 +1582,7 @@ impl BatchScheduler {
             token_history: Vec::new(),
             merged_eos: Vec::new(),
             thinking,
-            // Issue #550: forward the structured-output constraint built by
+            // forward the structured-output constraint built by
             // the route layer so the per-step sampling path can consult it.
             structured: options.structured.clone(),
         };
@@ -1708,7 +1702,7 @@ impl BatchScheduler {
             None => return,
         };
 
-        // Issue #670 / #674: speculative-decoding burst path.
+        // speculative-decoding burst path.
         //
         // Why: the existing speculative round loops
         // (`MtpGenerator::generate`, `DFlashGenerator::run`, plus their
@@ -1726,7 +1720,7 @@ impl BatchScheduler {
         // prefix — see
         // `speculative_burst::should_burst_for_sequence`).
         //
-        // Issue #674 adds the B>1 batched burst: when `max_batch_size >
+        // adds the B>1 batched burst: when `max_batch_size >
         // 1` and the dequeued head sequence is speculative-eligible, the
         // scheduler collects an equal-prompt-length window of additional
         // eligible requests and drives them all through the batched
@@ -1776,8 +1770,7 @@ impl BatchScheduler {
     }
 
     /// Attempt to handle the dequeued head sequence through the
-    /// speculative-decoding burst path (issue #670 B=1 / issue #674
-    /// batched B>1).
+    /// speculative-decoding burst path (B=1 / batched B>1).
     ///
     /// Returns:
     /// - `None` — a burst (B=1 or batched) handled the request(s)
@@ -1797,8 +1790,7 @@ impl BatchScheduler {
     /// [`super::queue::PrefillQueue::drain_matching_window`]). The
     /// batched MTP target adapter requires a rectangular `[B, L]`
     /// prefill, and equal-length prompts make the batched prefill
-    /// byte-identical to B separate B=1 prefills (acceptance item 1 of
-    /// issue #674). The window also requires matching `max_tokens` and
+    /// byte-identical to B separate B=1 prefills (acceptance item 1). The window also requires matching `max_tokens` and
     /// sampling config so the single per-window sampler / budget the
     /// batched round loop takes is correct for every row. B > 1 also
     /// applies [`super::speculative_burst::can_join_batched_burst_window`]
@@ -1925,7 +1917,7 @@ impl BatchScheduler {
                     // record its per-sequence metric — the batched
                     // analogue of the B=1 cleanup below.
                     //
-                    // Issue #688: `BatchedBurstRow` now carries the
+                    // `BatchedBurstRow` now carries the
                     // per-row prompt/committed token vectors and the
                     // healthy-finish flag, so the batched arm calls
                     // `donate_finished_sequence_cache` per row BEFORE
@@ -2019,7 +2011,7 @@ impl BatchScheduler {
                 }) => {
                     // Burst handled the full request lifecycle inline.
                     //
-                    // Issue #673: donate the finished sequence's KV
+                    // donate the finished sequence's KV
                     // cache back to the prompt-cache store BEFORE the
                     // `remove`/`release` below — `donate_finished_sequence_cache`
                     // both consumes the `prompt_cache_seq_ctx` entry and
@@ -2132,7 +2124,7 @@ impl BatchScheduler {
             return;
         }
 
-        // Epic #416 / issue #421: any sequence that adopted a cached prefix
+        // any sequence that adopted a cached prefix
         // cannot participate in the padded batched prefill path because the
         // KV-history offsets differ across sequences. Take the single-
         // sequence path for those so their `prefill_start_offset` is
@@ -2285,7 +2277,7 @@ impl BatchScheduler {
 
     /// Full-prompt prefill: process the entire prompt in one pass.
     ///
-    /// Epic #416 / issue #421: when `seq.prefill_start_offset > 0`, a
+    /// when `seq.prefill_start_offset > 0`, a
     /// prompt-cache hit has installed the first `prefill_start_offset` tokens
     /// of KV state on this sequence. Only the suffix tokens are fed to the
     /// model. The VLM-prefix path deliberately opts out of cache adoption at
@@ -2425,7 +2417,7 @@ impl BatchScheduler {
         };
         self.sync_sequence_storage(seq.seq_id);
 
-        // Issue #603 H2: enforce the `--max-kv-size` cap at the end of a
+        // H2: enforce the `--max-kv-size` cap at the end of a
         // full prefill before the sequence transitions to decode. A long
         // prompt can overshoot the cap during a single forward pass; without
         // this trim the first decode step would start with a too-wide live
@@ -2444,7 +2436,7 @@ impl BatchScheduler {
     /// Begin a chunked prefill: process the first chunk and store the
     /// sequence for continuation on subsequent ticks.
     ///
-    /// Epic #416 / issue #421: `seq.prefill_start_offset` skips over the
+    /// `seq.prefill_start_offset` skips over the
     /// leading tokens that the adopted prompt-cache entry already covers,
     /// so the first chunk starts *after* the cached prefix.
     fn start_chunked_prefill(&mut self, mut seq: SequenceInfo) {
@@ -2544,7 +2536,7 @@ impl BatchScheduler {
         }
         self.sync_sequence_storage(seq.seq_id);
 
-        // Issue #603 H2: enforce the `--max-kv-size` cap after each
+        // H2: enforce the `--max-kv-size` cap after each
         // prefill chunk so the live window cannot grow unbounded across
         // chunks of a long prompt. A 100k-token prompt with `--max-kv-size
         // 4096` would otherwise see the cap engage only after the entire
@@ -2654,7 +2646,7 @@ impl BatchScheduler {
         };
         self.sync_sequence_storage(seq.seq_id);
 
-        // Issue #603 H2: enforce the `--max-kv-size` cap after each
+        // H2: enforce the `--max-kv-size` cap after each
         // continuation chunk so a multi-chunk prefill stays bounded across
         // all chunks, not just at the very end. Cheap early-return when no
         // cap is configured.
@@ -2697,7 +2689,7 @@ impl BatchScheduler {
         mut token_history: Vec<i32>,
         needs_history: bool,
     ) {
-        // Issue #550: apply structured-output mask to the prefill logits
+        // apply structured-output mask to the prefill logits
         // before sampling the first token so the very first emitted token
         // already conforms to the schema.
         let logits_for_sampling = if let Some(constraint) = seq.structured.clone() {
@@ -2730,7 +2722,7 @@ impl BatchScheduler {
         mlxcel_core::eval(&first_token_arr);
         let sampled_first_token = mlxcel_core::item_i32(&first_token_arr);
 
-        // Issue #550: advance the matcher state with the just-sampled token.
+        // advance the matcher state with the just-sampled token.
         // If consume_token errors, transition the sequence to Finished(Error)
         // and surface a clean SSE error event rather than leaking
         // non-conforming output.
@@ -2751,14 +2743,14 @@ impl BatchScheduler {
             return;
         }
 
-        // Issue #409: thinking-budget override. Qwen3 chat templates prime
+        // thinking-budget override. Qwen3 chat templates prime
         // `<think>\n`, so the first prefill-completion token is already
         // inside the reasoning block when `enter_block_on_start == true`.
         let first_token = Self::apply_thinking_budget(&mut seq.thinking, sampled_first_token);
 
         seq.first_token_time = Some(Instant::now());
 
-        // Issue #409: if the budget fired and substituted the first token,
+        // if the budget fired and substituted the first token,
         // drop the logprob below (computed against the sampled token) so the
         // streamed metadata stays consistent with the emitted token text.
         let override_fired = first_token != sampled_first_token;
@@ -2804,7 +2796,7 @@ impl BatchScheduler {
         // Optionally compute logprobs for the first token. When the override
         // fired, the sampled token differs from the emitted `first_token`;
         // suppress logprob emission in that case to keep token text and
-        // logprob metadata consistent (issue #409).
+        // logprob metadata consistent.
         let token_lp = if override_fired {
             None
         } else {
@@ -2913,7 +2905,7 @@ impl BatchScheduler {
                 victim.generated_tokens.len()
             );
 
-            // Issue #540 follow-up: when the victim is a VL request the
+            // follow-up: when the victim is a VL request the
             // text model holds a per-sequence MRoPE entry under the old
             // seq id. `release_sequence_caches` below would drop it, but
             // `prepare_request_vlm_embeddings` does NOT re-run on
@@ -2925,7 +2917,7 @@ impl BatchScheduler {
             // an empty snapshot and the rebind is a no-op.
             let mrope_snapshot = self.model.take_qwen_vl_mrope_entry(victim.seq_id);
 
-            // Issue #543: same lifecycle invariant for Gemma 4 E2B/E4B
+            // same lifecycle invariant for Gemma 4 E2B/E4B
             // `per_layer_inputs`. The tensor is projected exactly once
             // by `prepare_request_vlm_embeddings` at enqueue time and
             // is consumed at prefill time; preemption-and-reallocate
@@ -2967,10 +2959,10 @@ impl BatchScheduler {
                     // Re-install the previously-saved MRoPE entry under
                     // the new seq id so re-prefill resolves the same
                     // per-row delta the original prefill computed
-                    // (issue #540 follow-up).
+                    // (follow-up).
                     self.model
                         .install_qwen_vl_mrope_entry(new_id, mrope_snapshot);
-                    // Issue #543: same for Gemma 4 `per_layer_inputs`.
+                    // same for Gemma 4 `per_layer_inputs`.
                     // The tensor is reused unchanged across re-prefill
                     // because both depend only on the request's
                     // input_ids (no decode-time updates).
@@ -3019,7 +3011,7 @@ impl BatchScheduler {
 
     /// Select the eviction victim based on the configured policy.
     ///
-    /// Issue #550 follow-up: sequences with an attached structured-output
+    /// follow-up: sequences with an attached structured-output
     /// constraint are excluded from the candidate set. Preemption resets
     /// `generated_tokens`, the streaming decoder, and the KV cache, but the
     /// `llguidance` matcher carries grammar progress that cannot be safely
@@ -3109,7 +3101,7 @@ impl BatchScheduler {
 
         let b = seq_ids.len();
 
-        // Issue #603: trim per-sequence plain KVCache layers before the batched
+        // trim per-sequence plain KVCache layers before the batched
         // forward pass so all sequences stay within the --max-kv-size bound.
         // Sliding-window (model-internal RotatingKVCache) and Turbo-quantized
         // caches are unaffected (trim_front returns 0 for Turbo modes).
@@ -3180,7 +3172,7 @@ impl BatchScheduler {
             let seq_logits =
                 mlxcel_core::slice(&logits, &[i as i32, 0, 0], &[i as i32 + 1, 1, i32::MAX]);
 
-            // Issue #550: when the sequence has a structured-output
+            // when the sequence has a structured-output
             // constraint, apply the schema mask to the per-sequence logits
             // before sampling. Failures here surface as a clean
             // FinishReason::Error rather than silent non-conforming output.
@@ -3210,7 +3202,7 @@ impl BatchScheduler {
             // Use cached token_history (incrementally maintained) instead of
             // rebuilding per step. Use cached merged_eos computed once at prefill.
             //
-            // Issue #550 follow-up: we capture `sampled` separately from
+            // follow-up: we capture `sampled` separately from
             // `final_id` so the structured-output matcher (below) can be
             // advanced by the *pre-override* token. The matcher's mask
             // describes which token ids are grammatically legal at this
@@ -3226,7 +3218,7 @@ impl BatchScheduler {
                     sample_token_optimized(&logits_for_sampling, &seq.sampling, &seq.token_history);
                 mlxcel_core::eval(&token_arr);
                 let sampled = mlxcel_core::item_i32(&token_arr);
-                // Issue #409: apply the thinking-budget override first so that
+                // apply the thinking-budget override first so that
                 // when the override fires (sampled != final_id) we can skip
                 // the log-softmax work entirely. The logprob metadata would
                 // be dropped anyway because the emitted `</think>` differs
@@ -3243,7 +3235,7 @@ impl BatchScheduler {
                 (sampled, final_id, lp)
             };
 
-            // Issue #550: advance the matcher state with the *pre-override*
+            // advance the matcher state with the *pre-override*
             // sampled token (`sampled_token`), not the post-override
             // `token_val`. The matcher derived its mask from the unaltered
             // logits, so feeding it `final_id` after a thinking-budget
@@ -3334,7 +3326,7 @@ impl BatchScheduler {
             *seq.generated_tokens.last().unwrap_or(&0)
         };
 
-        // Issue #603: trim the oldest tokens from plain KVCache layers so the
+        // trim the oldest tokens from plain KVCache layers so the
         // live window stays within the configured --max-kv-size bound before
         // each decode forward pass. Sliding-window layers are managed by the
         // model and bypass this pool path; Turbo-quantized caches silently skip
@@ -3355,7 +3347,7 @@ impl BatchScheduler {
         };
         self.sync_sequence_storage(seq_id);
 
-        // Issue #550: apply structured-output mask to per-step logits when
+        // apply structured-output mask to per-step logits when
         // the sequence has an attached constraint. Errors abort the
         // sequence cleanly rather than emitting non-conforming output.
         let constraint_clone = self
@@ -3384,7 +3376,7 @@ impl BatchScheduler {
         // and cached merged_eos (computed once during prefill) to avoid
         // per-step allocation and reconstruction overhead.
         //
-        // Issue #550 follow-up: we capture `sampled` separately from
+        // follow-up: we capture `sampled` separately from
         // `final_id`. The structured-output matcher (below) must be
         // advanced by the pre-override token because its mask was derived
         // from the unaltered logits; passing the post-override forced
@@ -3395,7 +3387,7 @@ impl BatchScheduler {
                 sample_token_optimized(&logits_for_sampling, &seq.sampling, &seq.token_history);
             mlxcel_core::eval(&token_arr);
             let sampled = mlxcel_core::item_i32(&token_arr);
-            // Issue #409: apply the thinking-budget override first so that
+            // apply the thinking-budget override first so that
             // when the override fires the log-softmax work is skipped — the
             // logprob metadata for the sampled token would be dropped anyway
             // (token text and logprob `token_id` must stay consistent), so
@@ -3409,7 +3401,7 @@ impl BatchScheduler {
             (sampled, final_id, lp)
         };
 
-        // Issue #550: advance the matcher state with the *pre-override*
+        // advance the matcher state with the *pre-override*
         // sampled token. See the parallel comment in
         // `execute_batched_decode` for why this must not be `token_val`.
         if let Some(constraint) = constraint_clone
@@ -3557,7 +3549,7 @@ impl BatchScheduler {
                 );
                 let _ = seq.response_tx.send(GenerateEvent::Done(result));
 
-                // Epic #416 / issue #421: donate the full KV cache back to
+                // donate the full KV cache back to
                 // the prompt-cache store on *healthy* finishes (Stop /
                 // Length / Cancelled) so the next turn of the same
                 // conversation can adopt it. `Finished(Error)` paths bypass

--- a/src/server/batch/scheduler_prompt_cache_tests.rs
+++ b/src/server/batch/scheduler_prompt_cache_tests.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Scheduler-facing prompt-prefix cache integration tests (epic #416 / issue
-//! #421).
+//! Scheduler-facing prompt-prefix cache integration tests.
 //!
 //! Full end-to-end adopt/donate coverage that exercises a real `LoadedModel`
 //! lives in the worker-thread integration tests; those need the server binary
 //! and are out of scope for `cargo test --lib`. The cases in this file isolate
-//! the **scheduler-visible invariants** that the #421 implementation adds and
+//! the **scheduler-visible invariants** that the implementation adds and
 //! that the store / key / entry data flow relies on:
 //!
 //! * Cache hit reports the matched prefix length and leaves the detached
@@ -343,7 +342,7 @@ fn batched_prefill_path_detects_adopted_sequences() {
 }
 
 // ---------------------------------------------------------------------------
-// APC block-level partial adoption (issue #580)
+// APC block-level partial adoption
 // ---------------------------------------------------------------------------
 
 const APC_BLOCK_SIZE: usize = 16;
@@ -394,7 +393,7 @@ fn make_text_key<'a>(
 
 #[test]
 fn apc_block_aligned_partial_match_truncates_to_block_boundary() {
-    // The headline property for issue #580: when a request shares the first
+    // The headline property for when a request shares the first
     // 32 tokens (= 2 blocks) of a 48-token cached entry but diverges at
     // token 32 (= start of block 2), the store's APC discriminator must
     // return matched_len == 32, NOT 48. This is the value the scheduler then
@@ -514,7 +513,7 @@ fn apc_full_match_yields_entry_length_matched_len_no_truncate_path() {
     // Sanity: when the request's first N tokens fully agree with all blocks
     // of the cached entry, matched_len equals the entry's full token length.
     // The scheduler then skips the truncate branch entirely (no work, no
-    // allocations). This is the bit-exact full-prefix path that pre-#580
+    // allocations). This is the bit-exact full-prefix path that earlier
     // already worked.
     let store = apc_on_test_store();
 
@@ -580,7 +579,7 @@ fn apc_disabled_lookup_ignores_block_divergence_returns_full_prefix() {
 
 #[test]
 fn scheduler_partial_adoption_synthetic_savings_match_expected_fraction() {
-    // Synthetic prefill-cost microbench for issue #580. We model the
+    // Synthetic prefill-cost microbench. We model the
     // scheduler's prefill workload as `prompt_tokens.len() - matched_len`
     // and confirm that block-aligned partial adoption recovers the
     // expected fraction of work compared to a cold prefill (matched_len 0).

--- a/src/server/batch/scheduler_tests.rs
+++ b/src/server/batch/scheduler_tests.rs
@@ -448,7 +448,7 @@ fn chunked_prefill_interleaving_pattern() {
 }
 
 // -------------------------------------------------------------------
-// VLM embedding guard routing tests (issue #738 server-prefill fixes)
+// VLM embedding guard routing tests (server-prefill fixes)
 // -------------------------------------------------------------------
 //
 // The two server-side guards added for InternVL (and all VLM image prefills)
@@ -793,7 +793,7 @@ fn auto_decode_storage_prefers_paged_only_for_supported_workers() {
 }
 
 // -------------------------------------------------------------------
-// Null / empty-cache safety tests (issue #324)
+// Null / empty-cache safety tests
 //
 // These tests cover the same transition edges that upstream mlx-lm
 // landed null-guards for in `mlx_lm/models/cache.py`:
@@ -992,7 +992,7 @@ fn test_merge_all_empty() {
 }
 
 // -------------------------------------------------------------------
-// Issue #508 — Server scheduler dispatch on PagedKvLayout::cache_mode
+// Server scheduler dispatch on PagedKvLayout::cache_mode
 // -------------------------------------------------------------------
 
 /// Reproduce the `is_turbo_mode` classification policy from
@@ -1020,10 +1020,10 @@ fn is_turbo_mode_classifies_turbo4_variants() {
 fn is_turbo_mode_excludes_fp16_int8_and_turbo3_today() {
     use mlxcel_core::cache::KVCacheMode;
     // Fp16 / Int8 must take the historical `PagedKvLayout::uniform` path
-    // (no per-page sidecar accounting). Bit-identical to pre-#508.
+    // (no per-page sidecar accounting). Bit-identical to earlier.
     assert!(!is_turbo_mode_policy(KVCacheMode::Fp16));
     assert!(!is_turbo_mode_policy(KVCacheMode::Int8));
-    // Turbo3Asym is a valid `KVCacheMode` (issue #477) but the paged
+    // Turbo3Asym is a valid `KVCacheMode` but the paged
     // data plane does not yet support per-page 3-bit sidecars; the
     // dispatch intentionally falls through to `PagedKvLayout::uniform`
     // so callers that pair `--kv-cache-mode fp16+turbo3` with paged
@@ -1066,7 +1066,7 @@ fn scheduler_paged_turbo_layout_arguments_are_valid() {
 }
 
 // -------------------------------------------------------------------
-// Issue #545 — Batched KV quantization config plumbing
+// Batched KV quantization config plumbing
 // -------------------------------------------------------------------
 //
 // These tests exercise the resolver in `cli_input.rs` and the per-layer
@@ -1167,7 +1167,7 @@ fn skip_last_layer_default_is_true_in_resolver() {
 }
 
 // -------------------------------------------------------------------
-// Issue #545 — Per-layer mode table for batched scheduler
+// Per-layer mode table for batched scheduler
 // -------------------------------------------------------------------
 
 /// The scheduler's `apply_kv_cache_mode_to` method reads the resolved
@@ -1185,9 +1185,8 @@ fn batch_kv_quant_per_layer_table_skips_last_layer_only() {
     .unwrap();
     let modes = cfg.resolve_layer_modes(40); // gemma-4-31b-class
     assert_eq!(modes.len(), 40);
-    // Issue #545: ONLY the last layer is skipped, NOT first 2 + last 2
-    // (that latter behaviour is the existing Boundary-V from #478, which
-    // is a separate orthogonal mechanism).
+    // ONLY the last layer is skipped, NOT first 2 + last 2
+    // (that latter behaviour is the existing Boundary-V, which is a separate orthogonal mechanism).
     assert_eq!(
         modes[0],
         mlxcel_core::cache::KVCacheMode::Int8,

--- a/src/server/batch/sequence.rs
+++ b/src/server/batch/sequence.rs
@@ -244,7 +244,7 @@ pub struct SequenceInfo {
     /// `prefill_chunk_size`.
     pub prefill_offset: usize,
 
-    // -- Epic #416 / issue #421: prompt prefix cache --
+    // -- prompt prefix cache --
     /// Token count from the head of `prompt_tokens` that was already present
     /// in the adopted KV cache. When `> 0`, prefill **skips** those leading
     /// tokens and feeds only `prompt_tokens[prefill_start_offset..]` to the
@@ -258,7 +258,7 @@ pub struct SequenceInfo {
     /// (e.g. chunked prefill continuation math) without affecting the stat.
     pub already_cached_tokens: usize,
 
-    // -- Issue #409: thinking-token budget --
+    // -- thinking-token budget --
     /// Per-sequence thinking-budget state. Drives forced `</think>` injection
     /// when the in-block token count reaches the configured cap. Set to
     /// [`crate::server::thinking_budget::ThinkingState::disabled`] when the
@@ -266,7 +266,7 @@ pub struct SequenceInfo {
     /// no budget, or when the server default is unbounded.
     pub(crate) thinking: ThinkingState,
 
-    // -- Issue #550: structured-output constraint --
+    // -- structured-output constraint --
     /// Optional `llguidance` matcher state for constrained decoding. When
     /// `Some(_)`, the scheduler computes a per-step token mask before sampling
     /// and consumes the sampled token after sampling so the partial output

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Speculative-decoding burst driver for the continuous-batching scheduler
-//! (issue #670, follow-up to #666 / PR #669).
+//! (follow-up to).
 //!
 //! ## Why a "burst" rather than per-tick dispatch
 //!
@@ -30,7 +30,7 @@
 //! and risks regressing the offline CLI path that still consumes
 //! `generate()` / `run()` end-to-end. That refactor is genuinely larger
 //! than this issue's scope; see the central architectural decision
-//! discussion in issue #670 ("Option A vs Option B").
+//! discussion ("Option A vs Option B").
 //!
 //! Instead, this module takes **Option B**: when the scheduler decides a
 //! sequence is speculative, it delegates the *entire* prefill + decode
@@ -106,17 +106,17 @@
 //! presence / DRY) are **not** a gate: the burst threads
 //! `initial_token_history(&prompt, ..)` into the first-bonus sample so a
 //! penalty-bearing request's first bonus is byte-identical to the
-//! classic decode path (issue #677).
+//! classic decode path.
 //!
 //! Logprobs are **not** a gate: the burst threads `logprobs_config`
 //! through `MtpGenerator::generate` / `DFlashGenerator::run` and emits
 //! `TokenWithLogprobs` events from `finalize_burst_success` — the same
-//! payload the classic decode path produces (issue #678).
+//! payload the classic decode path produces.
 //!
 //! Thinking-budget enforcement is **not** a gate: `finalize_burst_success`
 //! runs the same per-token `decide_override` + `observe` cycle as the
 //! classic path's `apply_thinking_budget`, injecting a forced `</think>`
-//! at the budget boundary (issue #679).
+//! at the budget boundary.
 //!
 //! Each declined request is logged with the gate reason (at `debug` for
 //! ordinary gates, and at `warn` for DFlash multimodal requests so operators
@@ -131,8 +131,7 @@
 //!
 //! ## Lazy-load model
 //!
-//! The drafter checkpoint is NOT read from disk at worker startup (issue #670,
-//! mandate 2). [`WorkerDrafterSlot`] holds the path and an `Option<Box<dyn
+//! The drafter checkpoint is NOT read from disk at worker startup (mandate 2). [`WorkerDrafterSlot`] holds the path and an `Option<Box<dyn
 //! Drafter>>` that starts as `None`. The first speculative request triggers
 //! [`WorkerDrafterSlot::ensure_loaded`], which calls
 //! [`mlxcel_core::drafter::load_drafter`] and stores the handle. Subsequent
@@ -167,7 +166,7 @@ use super::sequence::{FinishReason, SequenceInfo, SequenceState};
 /// the VLM wrapper delegates speculative hooks to its inner text backbone and
 /// allocates the same cache shape. This lets text-only requests against
 /// VLM-wrapped checkpoints run DFlash without opening the true multimodal tail
-/// path yet (issue #691).
+/// path yet.
 trait Qwen35DFlashTarget:
     LanguageModel
     + SpeculativeTarget<
@@ -195,7 +194,7 @@ impl Qwen35DFlashTarget for crate::vision::Qwen35VLModel {
 /// The scheduler thread is single-threaded (every request goes through
 /// the same MLX dispatch stream), so a simple `Option<Box<dyn Drafter>>`
 /// is sufficient — no atomic-once / `RwLock` is needed. The "lazy load"
-/// requirement from issue #670 (mandate 2) means: the drafter weights
+/// requirement (mandate 2) means: the drafter weights
 /// MUST NOT be read from disk at worker startup; the first speculative
 /// request triggers the load. Subsequent requests on the same worker
 /// reuse the loaded drafter.
@@ -315,18 +314,16 @@ impl WorkerDrafterSlot {
 ///    the leading tokens.
 ///
 /// History-dependent sampling penalties (repetition / frequency /
-/// presence / DRY) are **no longer** a gate (issue #677): the burst
+/// presence / DRY) are **no longer** a gate: the burst
 /// threads `initial_token_history(&prompt, ..)` into the first-bonus
 /// sample, so a penalty-bearing request's first bonus is byte-identical
 /// to the classic decode path.
 ///
-/// `logprobs_config.enabled` is likewise **no longer** a gate (issue
-/// #678): the burst threads `logprobs_config` through the round-loop
+/// `logprobs_config.enabled` is likewise **no longer** a gate: the burst threads `logprobs_config` through the round-loop
 /// drivers and emits `TokenWithLogprobs` events from
 /// `finalize_burst_success`, the same payload the classic path produces.
 ///
-/// Thinking-budget enforcement is likewise **no longer** a gate (issue
-/// #679): `finalize_burst_success` runs the same per-token
+/// Thinking-budget enforcement is likewise **no longer** a gate: `finalize_burst_success` runs the same per-token
 /// `decide_override` + `observe` cycle as the classic path's
 /// `apply_thinking_budget`, injecting a forced `</think>` at the budget
 /// boundary.
@@ -375,22 +372,19 @@ pub(crate) fn should_burst_for_sequence(
         return false;
     }
     // History-dependent sampling penalties (repetition / frequency /
-    // presence / DRY) are NO LONGER a decline-to-classic gate (issue
-    // #677). The burst now threads `initial_token_history(&prompt, ..)`
+    // presence / DRY) are NO LONGER a decline-to-classic gate. The burst now threads `initial_token_history(&prompt, ..)`
     // into the first-bonus sample via `MtpTarget::prefill_and_seed` /
     // `sample_token_optimized`, so a penalty-bearing request's first
     // bonus is byte-identical to the classic decode path. The
     // subsequent round-loop tokens come from the target's greedy
     // argmax, which carries no history dependence.
     //
-    // `logprobs_config.enabled` is likewise NO LONGER a gate (issue
-    // #678). The burst threads `logprobs_config` through
+    // `logprobs_config.enabled` is likewise NO LONGER a gate. The burst threads `logprobs_config` through
     // `MtpGenerator::generate` / `DFlashGenerator::run` and emits
     // `TokenWithLogprobs` events from `finalize_burst_success` — the
     // same payload the classic decode path produces.
     //
-    // Thinking-budget enforcement is likewise NO LONGER a gate (issue
-    // #679). `finalize_burst_success` runs the same per-token
+    // Thinking-budget enforcement is likewise NO LONGER a gate. `finalize_burst_success` runs the same per-token
     // `decide_override` + `observe` cycle the classic path's
     // `apply_thinking_budget` uses, injecting a forced `</think>` at the
     // budget boundary.
@@ -403,7 +397,7 @@ pub(crate) fn should_burst_for_sequence(
 /// the B = 1 burst path can emit per-token logprob payloads, but the
 /// batched MTP/DFlash round loops return token IDs only. Keeping
 /// logprobs-enabled requests out of B > 1 windows makes them fall back
-/// to the B = 1 burst, where issue #678's `TokenWithLogprobs` contract
+/// to the B = 1 burst, where's `TokenWithLogprobs` contract
 /// is preserved.
 pub(crate) fn can_join_batched_burst_window(seq: &SequenceInfo) -> bool {
     if seq.logprobs_config.enabled {
@@ -418,7 +412,7 @@ pub(crate) fn can_join_batched_burst_window(seq: &SequenceInfo) -> bool {
 
 /// Whether to force the Gemma 4 MTP B=1 burst path.
 ///
-/// Issue #693 real-model measurements showed the assistant drafter is not
+/// real-model measurements showed the assistant drafter is not
 /// profitable for single-request Gemma 4 31B serving: the upstream reference
 /// speedups are reported for B>1 windows, while the B=1 path spends an extra
 /// drafter forward per token at very low acceptance. Production therefore
@@ -454,7 +448,7 @@ pub(crate) fn mtp_batched_burst_enabled() -> bool {
 /// `batch_metrics.record_sequence_completed(tokens_generated)` call
 /// inside `finalize_completed`).
 ///
-/// Issue #673: the prompt + generated token vectors and the
+/// the prompt + generated token vectors and the
 /// `healthy_finish` flag are surfaced so the scheduler can call
 /// [`crate::server::batch::scheduler::BatchScheduler::donate_finished_sequence_cache`]
 /// for the burst path exactly as `finalize_completed` does for the
@@ -571,7 +565,7 @@ pub(crate) fn try_run_burst_b1(
                     seq_id,
                     tokens_generated: 0,
                     // Transition failure is an error outcome — no
-                    // healthy cache to donate (issue #673).
+                    // healthy cache to donate.
                     prompt_tokens: Vec::new(),
                     generated_tokens: Vec::new(),
                     healthy_finish: false,
@@ -581,10 +575,9 @@ pub(crate) fn try_run_burst_b1(
             // `finalize_burst_success` streams the tokens, classifies
             // the finish reason, and hands back the prompt + committed
             // token vectors so the scheduler can mirror the classic
-            // path's prompt-cache donate (issue #673). `logprobs` is
+            // path's prompt-cache donate. `logprobs` is
             // forwarded so a speculative response carries the same
             // `TokenWithLogprobs` payload as the classic decode path
-            // (issue #678).
             let finalized =
                 finalize_burst_success(ctx, seq, tokens, logprobs, prefill_time_ms, decode_time_ms);
             Ok(BurstFinalized {
@@ -619,7 +612,7 @@ pub(crate) fn try_run_burst_b1(
                 seq_id,
                 tokens_generated: 0,
                 // Error outcome: the KV cache is assumed tainted, so
-                // no donate (issue #673, mirrors the classic path's
+                // no donate (mirrors the classic path's
                 // `Finished(Error)` bypass in `finalize_completed`).
                 prompt_tokens: Vec::new(),
                 generated_tokens: Vec::new(),
@@ -638,7 +631,7 @@ struct BurstSuccess {
     /// `Option<TokenLogprobData>` per token, forwarded to
     /// `finalize_burst_success` which emits `TokenWithLogprobs` events
     /// so speculative responses carry the same logprob payload as the
-    /// classic decode path (issue #678).
+    /// classic decode path.
     logprobs: Vec<Option<TokenLogprobData>>,
     prefill_time_ms: f64,
     decode_time_ms: f64,
@@ -646,7 +639,7 @@ struct BurstSuccess {
 
 /// Outcome of [`finalize_burst_success`].
 ///
-/// Issue #673: in addition to the streamed token count (used for the
+/// in addition to the streamed token count (used for the
 /// Prometheus per-sequence histogram), this carries the data the
 /// scheduler needs to mirror the classic path's prompt-cache donate —
 /// the full prompt token stream, the tokens actually committed to the
@@ -815,20 +808,20 @@ fn run_mtp_burst(
     // empty vec otherwise — exactly what the classic decode path seeds
     // its first-token sample with (`scheduler.rs::finish_prefill`). This
     // is what makes the burst's first bonus byte-identical to the
-    // classic path for penalty-bearing requests (issue #677).
+    // classic path for penalty-bearing requests.
     let token_history = initial_token_history(&prompt, sampling.needs_token_history());
 
     // Cooperative-cancellation flag plumbed into the round-loop driver.
     // The burst owns the worker thread for its full lifetime; on a
     // client disconnect mid-burst the scheduler flips `seq.cancelled`
     // and the generator bails out after the current round instead of
-    // running the whole `max_tokens` budget (issue #672).
+    // running the whole `max_tokens` budget.
     let cancel: &AtomicBool = &seq.cancelled;
     // Per-token log-probability capture control. When enabled, the
     // generator returns one logprob entry per emitted token; the burst
     // forwards them through `finalize_burst_success` which emits
     // `TokenWithLogprobs` events so speculative responses carry the
-    // same payload as the classic decode path (issue #678).
+    // same payload as the classic decode path.
     let logprobs_config = seq.logprobs_config.clone();
     let (output, stats) = match ctx.model {
         LoadedModel::Gemma4(wrapper) => {
@@ -907,7 +900,7 @@ struct DriveMtpOutput {
     emitted: Vec<i32>,
     /// Per-token log-probability data, index-aligned 1:1 with
     /// [`Self::emitted`]. Empty when the caller's `LogprobsConfig` is
-    /// disabled (issue #678).
+    /// disabled.
     logprobs: Vec<Option<TokenLogprobData>>,
     recovered_drafter: Box<dyn Drafter>,
 }
@@ -927,17 +920,16 @@ struct DriveMtpOutput {
 /// to [`MtpGenerator::generate`] (then on to
 /// [`mlxcel_core::speculative::mtp::target::MtpTarget::prefill_and_seed`])
 /// for the first-bonus sample, so a penalty-bearing request's first
-/// bonus is byte-identical to the classic decode path (issue #677).
+/// bonus is byte-identical to the classic decode path.
 ///
 /// `cancel` is the cooperative-cancellation flag forwarded to
 /// [`MtpGenerator::generate`]; it is checked once per round so a
 /// disconnected client's burst stops occupying the worker thread
-/// (issue #672).
 ///
 /// `logprobs_config` is forwarded to [`MtpGenerator::generate`]; when
 /// enabled the returned [`DriveMtpOutput::logprobs`] carries one
 /// `Option<TokenLogprobData>` per emitted token, index-aligned with
-/// [`DriveMtpOutput::emitted`] (issue #678).
+/// [`DriveMtpOutput::emitted`].
 #[allow(clippy::too_many_arguments)]
 fn drive_mtp_generator<T>(
     target: T,
@@ -1043,20 +1035,20 @@ fn run_dflash_burst(
     // empty vec otherwise — exactly what the classic decode path seeds
     // its first-token sample with (`scheduler.rs::finish_prefill`). This
     // is what makes the burst's first bonus byte-identical to the
-    // classic path for penalty-bearing requests (issue #677).
+    // classic path for penalty-bearing requests.
     let token_history = initial_token_history(&prompt, sampling.needs_token_history());
 
     // Cooperative-cancellation flag plumbed into the round-loop driver.
     // The burst owns the worker thread for its full lifetime; on a
     // client disconnect mid-burst the scheduler flips `seq.cancelled`
     // and the generator bails out after the current round instead of
-    // running the whole `max_tokens` budget (issue #672).
+    // running the whole `max_tokens` budget.
     let cancel: &AtomicBool = &seq.cancelled;
     // Per-token log-probability capture control. When enabled, the
     // burst returns one logprob entry per emitted token; the burst
     // forwards them through `finalize_burst_success` which emits
     // `TokenWithLogprobs` events so speculative responses carry the
-    // same payload as the classic decode path (issue #678).
+    // same payload as the classic decode path.
     let logprobs_config = seq.logprobs_config.clone();
 
     // DFlash supports Qwen35 text models and Qwen35 VLM wrappers for
@@ -1121,15 +1113,13 @@ fn run_dflash_burst(
 /// `token_history` is the history-dependent-penalty context for the
 /// first-bonus sample (repetition / frequency / presence / DRY); it is
 /// forwarded to `sample_token_optimized` so a penalty-bearing request's
-/// first bonus is byte-identical to the classic decode path (issue
-/// #677). The round loop itself runs greedy at temp=0 today, so the
+/// first bonus is byte-identical to the classic decode path. The round loop itself runs greedy at temp=0 today, so the
 /// per-round target argmax is unaffected — only the first bonus reads
 /// the history.
 ///
 /// `cancel` is the cooperative-cancellation flag forwarded to
 /// [`DFlashGenerator::run`]; it is checked once per round so a
 /// disconnected client's burst stops occupying the worker thread
-/// (issue #672).
 ///
 /// `logprobs_config` controls per-token log-probability capture. When
 /// enabled, the returned `Vec<Option<TokenLogprobData>>` carries one
@@ -1137,7 +1127,6 @@ fn run_dflash_burst(
 /// the first-bonus logprob is computed here from the same
 /// penalty-adjusted logits the bonus was sampled from, and the
 /// round-loop tokens' logprobs come back in `DFlashRunOutput::logprobs`
-/// (issue #678).
 #[allow(clippy::too_many_arguments)]
 fn run_dflash_on_qwen35<T>(
     qwen: &T,
@@ -1197,14 +1186,13 @@ where
     );
     // `token_history` carries the history-dependent-penalty context
     // (repetition / frequency / presence / DRY) so the first bonus is
-    // byte-identical to the classic decode path's first token (issue
-    // #677). The subsequent round-loop tokens are produced by the
+    // byte-identical to the classic decode path's first token. The subsequent round-loop tokens are produced by the
     // target's greedy argmax inside `DFlashGenerator::run` (DFlash is
     // greedy-only today), which carries no history dependence.
     // `adjusted_logits` is the penalty-adjusted `[1, vocab]` slice the
     // bonus was sampled from; it feeds `compute_logprobs` so the
     // first-bonus logprob is byte-identical to the classic path's
-    // first-token logprob (issue #678).
+    // first-token logprob.
     let (first_bonus_arr, first_bonus_adjusted_logits) =
         mlxcel_core::sampling::sample_token_optimized(&last_logits, sampling, token_history);
     mlxcel_core::eval(&first_bonus_arr);
@@ -1316,7 +1304,7 @@ where
             // round loop returns an empty `output.logprobs` and
             // `first_bonus_lp` is `None`, so the burst's
             // `finalize_burst_success` falls through to plain `Token`
-            // events (issue #678).
+            // events.
             let logprobs: Vec<Option<TokenLogprobData>> = if logprobs_config.enabled {
                 let mut lp = Vec::with_capacity(output.logprobs.len() + 1);
                 lp.push(first_bonus_lp);
@@ -1333,7 +1321,7 @@ where
     }
 }
 
-/// Apply issue #409 thinking-budget enforcement to one burst-produced
+/// Apply thinking-budget enforcement to one burst-produced
 /// token, mirroring the classic decode path's
 /// `BatchScheduler::apply_thinking_budget` (`scheduler.rs`).
 ///
@@ -1394,7 +1382,7 @@ pub(crate) fn apply_burst_thinking_budget(
 /// `batch_metrics.record_sequence_completed(...)` so the Prometheus
 /// counters cover the burst path as well as the classic path, and uses
 /// the token vectors + flag to call `donate_finished_sequence_cache`
-/// (issue #673) exactly as `finalize_completed` does for the classic
+/// exactly as `finalize_completed` does for the classic
 /// path.
 fn finalize_burst_success(
     ctx: BurstContext<'_>,
@@ -1417,7 +1405,7 @@ fn finalize_burst_success(
     // one logprob entry per emitted token, index-aligned with `tokens`.
     // We emit `GenerateEvent::TokenWithLogprobs` in that case so a
     // speculative response carries the same payload as the classic
-    // decode path's `decode_single_step` (issue #678). The empty-vec
+    // decode path's `decode_single_step`. The empty-vec
     // case (logprobs disabled) falls through to plain `Token` events.
     let logprobs_enabled = seq.logprobs_config.enabled && !logprobs.is_empty();
 
@@ -1427,7 +1415,7 @@ fn finalize_burst_success(
             break;
         }
 
-        // Issue #409 / #679: thinking-budget enforcement, applied
+        // thinking-budget enforcement, applied
         // per-emitted-token. See [`apply_burst_thinking_budget`].
         // `override_fired` gates logprob emission below: when the
         // thinking-budget substituted a different token, the
@@ -1479,7 +1467,7 @@ fn finalize_burst_success(
         // still accurate.
         FinishReason::Stop
     };
-    // Issue #673: classify the finish for the prompt-cache donate gate
+    // classify the finish for the prompt-cache donate gate
     // BEFORE `finish_reason` is moved into `transition_to`. Mirrors the
     // `healthy` gate in `scheduler.rs::finalize_completed` — only
     // `Stop` / `Length` / `Cancelled` finishes donate their cache back.
@@ -1516,7 +1504,7 @@ fn finalize_burst_success(
     );
     let _ = seq.response_tx.send(GenerateEvent::Done(result));
     // Move the prompt + committed token vectors out of `seq` for the
-    // scheduler's prompt-cache donate (issue #673). `seq` is dropped
+    // scheduler's prompt-cache donate. `seq` is dropped
     // immediately after this — these are its last readers.
     FinalizeOutcome {
         tokens_generated,
@@ -1548,7 +1536,7 @@ fn emit_error_and_finalize(_ctx: BurstContext<'_>, seq: SequenceInfo, msg: &str)
 }
 
 // ===========================================================================
-// Batched burst (B > 1) — issue #674
+// Batched burst (B > 1)
 // ===========================================================================
 //
 // The B = 1 burst above runs the full prefill + decode lifecycle of ONE
@@ -1564,8 +1552,7 @@ fn emit_error_and_finalize(_ctx: BurstContext<'_>, seq: SequenceInfo, msg: &str)
 // The batched MTP target adapter forwards the `[B, max_prompt_len]`
 // prompt batch in one pass. With equal-length prompts the 2-D causal
 // masks broadcast cleanly across the batch and the result is
-// byte-identical to running B separate B = 1 prefills (acceptance item 1
-// of issue #674). The scheduler's window collector
+// byte-identical to running B separate B = 1 prefills (acceptance item 1). The scheduler's window collector
 // (`BatchScheduler::execute_speculative_burst`) therefore only groups
 // speculative-eligible requests of the *same prompt length* into one
 // batched window. A request whose prompt length differs from the window
@@ -1585,11 +1572,11 @@ fn emit_error_and_finalize(_ctx: BurstContext<'_>, seq: SequenceInfo, msg: &str)
 /// One finalized row of a batched burst — the per-row analogue of
 /// [`BurstFinalized`].
 ///
-/// Issue #674: originally `BatchedBurstFinalized.rows` carried only
+/// originally `BatchedBurstFinalized.rows` carried only
 /// `(seq_id, tokens_generated)`, so the scheduler's batched arm could
 /// release each row's cache slot and record its Prometheus metric, but
 /// it had no handle on the prompt / committed token vectors a
-/// prompt-cache donate needs. Issue #688 widens each row to the same
+/// prompt-cache donate needs. widens each row to the same
 /// donate-payload shape as the B = 1 [`BurstFinalized`] so the batched
 /// arm can call
 /// [`crate::server::batch::scheduler::BatchScheduler::donate_finished_sequence_cache`]
@@ -1710,8 +1697,7 @@ pub(crate) fn try_run_burst_batched(
                         &format!("State transition error: {err}"),
                     );
                     // Transition failure is an error outcome — no
-                    // healthy cache to donate (issue #688, mirrors the
-                    // B = 1 arm's transition-failure `BurstFinalized`).
+                    // healthy cache to donate (mirrors the B = 1 arm's transition-failure `BurstFinalized`).
                     finalized_rows.push(BatchedBurstRow {
                         seq_id,
                         tokens_generated: 0,
@@ -1729,7 +1715,6 @@ pub(crate) fn try_run_burst_batched(
                 // window-admission gate (`can_join_batched_burst_window`)
                 // rejects any logprobs-enabled request so it falls back
                 // to the B = 1 burst, which captures logprobs correctly
-                // (issue #678).
                 let finalized = finalize_burst_success(
                     ctx.reborrow(),
                     seq,
@@ -1741,7 +1726,6 @@ pub(crate) fn try_run_burst_batched(
                 // Surface the per-row prompt + committed token vectors
                 // and the healthy-finish flag so the scheduler can
                 // mirror the B = 1 arm's prompt-cache donate per row
-                // (issue #688).
                 finalized_rows.push(BatchedBurstRow {
                     seq_id,
                     tokens_generated: finalized.tokens_generated,
@@ -1772,9 +1756,7 @@ pub(crate) fn try_run_burst_batched(
                 let seq_id = seq.seq_id;
                 emit_error_and_finalize(ctx.reborrow(), seq, &msg);
                 // Error outcome: every row's KV cache is assumed
-                // tainted, so no donate — empty/false payload (issue
-                // #688, mirrors the B = 1 arm's `BurstOutcome::Error`
-                // `BurstFinalized`).
+                // tainted, so no donate — empty/false payload (mirrors the B = 1 arm's `BurstOutcome::Error` `BurstFinalized`).
                 finalized_rows.push(BatchedBurstRow {
                     seq_id,
                     tokens_generated: 0,
@@ -2190,7 +2172,7 @@ fn scalar_tokens_from_array(token_arr: &mlxcel_core::MlxArray, batch_size: usize
 ///
 /// ## History-dependent penalties are excluded from the batched window
 ///
-/// Issue #682 removed the `should_burst_for_sequence` decline gates for
+/// removed the `should_burst_for_sequence` decline gates for
 /// the four history-dependent penalty fields (`repetition_penalty`,
 /// `frequency_penalty`, `presence_penalty`, `dry_*`) — the **B=1** burst
 /// now threads `initial_token_history(&prompt, ..)` into its first-bonus
@@ -2217,8 +2199,7 @@ pub(crate) fn sampling_config_eq(a: &SamplingConfig, b: &SamplingConfig) -> bool
         && b.token_bias.is_empty()
         // The batched path's first-bonus sample uses an empty token
         // history; a penalty-bearing request must not join a batched
-        // window (it runs as a B=1 burst, which threads token history
-        // correctly since #682).
+        // window (it runs as a B=1 burst, which threads token history correctly since).
         && !a.needs_token_history()
         && !b.needs_token_history()
 }

--- a/src/server/batch/speculative_burst_tests.rs
+++ b/src/server/batch/speculative_burst_tests.rs
@@ -34,7 +34,7 @@
 //!   without it, the first `draft_block` call returns
 //!   [`DrafterError::BindNotCalled`] which the round loop silently
 //!   swallows, and the request finalizes with exactly one seed-bonus
-//!   token. The first PR-review cycle of #670 missed this because the
+//!   token. The first PR-review cycle missed this because the
 //!   real-model parity test was deferred to a CI hardware lane; cycle
 //!   2 ([this file]) pins the invariant with a fast-running mock test.
 //!
@@ -255,7 +255,7 @@ fn burst_declined_for_adopted_prompt_cache_prefix() {
 }
 
 // History-dependent sampling penalties are NO LONGER a decline-to-classic
-// gate (issue #677): the burst threads `initial_token_history(&prompt, ..)`
+// gate: the burst threads `initial_token_history(&prompt, ..)`
 // into the first-bonus sample, so a penalty-bearing request's first bonus
 // is byte-identical to the classic decode path. The four tests below
 // (formerly `burst_declined_for_{repetition,frequency,presence,dry}_penalty`)
@@ -273,7 +273,7 @@ fn burst_allowed_for_repetition_penalty() {
     assert!(
         should_burst_for_sequence(&dispatch, &seq),
         "repetition_penalty != 1.0 must NOT decline to classic — the burst \
-         now threads token_history into the first-bonus sample (issue #677)"
+         now threads token_history into the first-bonus sample"
     );
 }
 
@@ -285,7 +285,7 @@ fn burst_allowed_for_frequency_penalty() {
     assert!(
         should_burst_for_sequence(&dispatch, &seq),
         "frequency_penalty != 0.0 must NOT decline to classic — the burst \
-         now threads token_history into the first-bonus sample (issue #677)"
+         now threads token_history into the first-bonus sample"
     );
 }
 
@@ -297,7 +297,7 @@ fn burst_allowed_for_presence_penalty() {
     assert!(
         should_burst_for_sequence(&dispatch, &seq),
         "presence_penalty != 0.0 must NOT decline to classic — the burst \
-         now threads token_history into the first-bonus sample (issue #677)"
+         now threads token_history into the first-bonus sample"
     );
 }
 
@@ -309,12 +309,12 @@ fn burst_allowed_for_dry_penalty() {
     assert!(
         should_burst_for_sequence(&dispatch, &seq),
         "dry_multiplier != 0.0 must NOT decline to classic — the burst \
-         now threads token_history into the first-bonus sample (issue #677)"
+         now threads token_history into the first-bonus sample"
     );
 }
 
 // `logprobs_config.enabled` is NO LONGER a decline-to-classic gate
-// (issue #678): the burst threads `logprobs_config` through
+// the burst threads `logprobs_config` through
 // `MtpGenerator::generate` / `DFlashGenerator::run` and emits
 // `TokenWithLogprobs` events from `finalize_burst_success`. The test
 // below (formerly `burst_declined_when_logprobs_enabled`) now asserts
@@ -333,7 +333,7 @@ fn burst_allowed_when_logprobs_enabled() {
     assert!(
         should_burst_for_sequence(&dispatch, &seq),
         "logprobs_config.enabled=true must NOT decline to classic — the burst \
-         now threads logprobs through and emits TokenWithLogprobs (issue #678)"
+         now threads logprobs through and emits TokenWithLogprobs"
     );
 }
 
@@ -364,7 +364,7 @@ fn batched_window_rejects_logprobs_enabled_sequences() {
 }
 
 // Thinking-budget enforcement is NO LONGER a decline-to-classic gate
-// (issue #679): `finalize_burst_success` runs the same per-token
+// `finalize_burst_success` runs the same per-token
 // `decide_override` + `observe` cycle as the classic path's
 // `apply_thinking_budget`, injecting a forced `</think>` at the budget
 // boundary. The test below (formerly
@@ -390,7 +390,7 @@ fn burst_allowed_when_thinking_state_active() {
     assert!(
         should_burst_for_sequence(&dispatch, &seq),
         "thinking-budget enforcement must NOT decline to classic — the burst \
-         now injects forced </think> at the budget boundary (issue #679)"
+         now injects forced </think> at the budget boundary"
     );
 }
 
@@ -436,7 +436,7 @@ fn dummy_tensor() -> UniquePtr<MlxArray> {
 /// Deterministic synthetic [`mlxcel_core::sampling::TokenLogprobData`]
 /// for a token id — `logprob = -(token_id as f32) * 0.01`. The mock
 /// `MtpTarget` returns this from `prefill_and_seed` / `verify_forward`
-/// so the issue #678 logprobs-threading test can assert the *right*
+/// so the logprobs-threading test can assert the *right*
 /// logprob (the one keyed to a given token) reached
 /// `finalize_burst_success` unchanged. A real Gemma 4 / Qwen 3.5
 /// target computes the value from log-softmax of the verify logits;
@@ -458,7 +458,7 @@ struct MockMtpTarget {
     /// `token_history` slice the most recent `prefill_and_seed` call
     /// received. `None` until `prefill_and_seed` runs. Used by
     /// `drive_mtp_generator_round_loop_threads_token_history_into_prefill_and_seed`
-    /// to pin the issue #677 plumbing.
+    /// to pin the plumbing.
     seen_token_history: RefCell<Option<Vec<i32>>>,
 }
 
@@ -508,13 +508,13 @@ impl MtpTarget for MockMtpTarget {
         MtpVerifyOutput,
         Option<mlxcel_core::sampling::TokenLogprobData>,
     ) {
-        // Record what the generator handed us so the issue #677 test can
+        // Record what the generator handed us so the test can
         // assert the burst threaded the real token_history through.
         *self.seen_token_history.borrow_mut() = Some(token_history.to_vec());
         let seed = self.build_verify_output(1);
         // Synthetic first-bonus logprob: `None` when disabled; otherwise
         // a deterministic function of the token id (`synthetic_logprob`)
-        // so the issue #678 test can assert the right logprob reached
+        // so the test can assert the right logprob reached
         // the right token.
         let first_bonus_lp = logprobs_config
             .enabled
@@ -696,7 +696,7 @@ impl LanguageModel for MinimalLm {
 // =============================================================================
 // MTP bind regression — the CRITICAL test
 //
-// Cycle 1 of #670 / PR #671 shipped a `run_mtp_burst` that omitted
+// Cycle 1 / shipped a `run_mtp_burst` that omitted
 // `drafter.bind(target)` before `MtpGenerator::new`. The result: every
 // MTP burst request returned exactly one token (the seed bonus) because
 // the first `draft_block` call inside the round loop returned
@@ -856,13 +856,13 @@ fn drive_mtp_generator_round_loop_returns_only_seed_when_drafter_is_unbound() {
 }
 
 // =============================================================================
-// Cancellation propagation regression — issue #672
+// Cancellation propagation regression
 //
-// PR #671 (issue #670) landed Option-B speculative-burst dispatch but
+// landed Option-B speculative-burst dispatch but
 // `MtpGenerator::generate` / `DFlashGenerator::run` never inspected
 // `seq.cancelled`. A client that disconnected mid-burst would keep the
 // worker thread busy for the full `max_tokens` budget, wasting compute
-// AND head-of-line-blocking the next request. Issue #672 threads an
+// AND head-of-line-blocking the next request. threads an
 // `&AtomicBool` through both generator APIs, checked once per round.
 //
 // The test below pins the MTP side at the `MtpGenerator::generate`
@@ -922,7 +922,7 @@ fn drive_mtp_generator_round_loop_returns_only_seed_when_cancelled_before_first_
         "a pre-flagged cancellation flag must break the round loop before \
          the first draft_block call, leaving only the seed bonus. Got \
          {emitted:?} — the per-round cancel.load(..) check in \
-         MtpGenerator::generate may have regressed (issue #672)."
+         MtpGenerator::generate may have regressed."
     );
     assert_eq!(
         emitted[0], 100,
@@ -943,12 +943,12 @@ fn drive_mtp_generator_round_loop_returns_only_seed_when_cancelled_before_first_
 }
 
 // =============================================================================
-// History-dependent sampling penalties through the burst — issue #677
+// History-dependent sampling penalties through the burst
 //
-// PR #671 (issue #670) gated penalty-bearing requests
+// gated penalty-bearing requests
 // (repetition / frequency / presence / DRY) to the classic decode path
 // because the burst's first-bonus sample passed `&[]` for token_history.
-// Issue #677 threads `initial_token_history(&prompt, ..)` through
+// threads `initial_token_history(&prompt,..)` through
 // `MtpGenerator::generate` → `MtpTarget::prefill_and_seed` (and through
 // `sample_token_optimized` on the DFlash side), and removes the four
 // decline-to-classic gate predicates.
@@ -998,7 +998,7 @@ fn drive_mtp_generator_round_loop_threads_token_history_into_prefill_and_seed() 
     // The generator must have forwarded the caller's token_history
     // verbatim into `MtpTarget::prefill_and_seed` — if it dropped it (or
     // re-passed `&[]`), penalty-bearing requests would silently diverge
-    // from the classic decode path. This is the load-bearing issue #677
+    // from the classic decode path. This is the load-bearing
     // plumbing assertion.
     let seen = generator
         .target()
@@ -1009,16 +1009,16 @@ fn drive_mtp_generator_round_loop_threads_token_history_into_prefill_and_seed() 
     assert_eq!(
         seen, token_history,
         "MtpGenerator::generate must forward the caller's token_history \
-         into MtpTarget::prefill_and_seed unchanged (issue #677); got {seen:?}"
+         into MtpTarget::prefill_and_seed unchanged; got {seen:?}"
     );
 }
 
 // =============================================================================
-// Logprobs through the burst — issue #678
+// Logprobs through the burst
 //
-// PR #671 (issue #670) gated `logprobs_config.enabled` requests to the
+// gated `logprobs_config.enabled` requests to the
 // classic decode path because `finalize_burst_success` emitted plain
-// `Token(text)` events. Issue #678 threads `logprobs_config` through
+// `Token(text)` events. threads `logprobs_config` through
 // `MtpGenerator::generate` → `MtpTarget::prefill_and_seed` /
 // `verify_forward` (and through `DFlashGenerator::run` on the DFlash
 // side), returns a per-token `Vec<Option<TokenLogprobData>>` aligned
@@ -1055,7 +1055,7 @@ fn drive_mtp_generator_round_loop_threads_logprobs_through_to_emitted_tokens() {
     let prompt = vec![1, 2, 3];
     let sampling = SamplingConfig::greedy();
     let cancel = AtomicBool::new(false);
-    // Logprobs ENABLED — exercise the issue #678 capture path.
+    // Logprobs ENABLED — exercise the capture path.
     let logprobs_config = LogprobsConfig {
         enabled: true,
         top_k: 0,
@@ -1095,8 +1095,7 @@ fn drive_mtp_generator_round_loop_threads_logprobs_through_to_emitted_tokens() {
 
     // Every entry must be `Some` and carry the deterministic synthetic
     // logprob keyed to *that* token — proving the right logprob reached
-    // the right position through the round loop's walk + emit (issue
-    // #678).
+    // the right position through the round loop's walk + emit.
     for (i, (&tok, lp)) in emitted.iter().zip(logprobs.iter()).enumerate() {
         let lp = lp.as_ref().unwrap_or_else(|| {
             panic!("logprobs[{i}] must be Some for token {tok} when logprobs enabled")
@@ -1109,7 +1108,7 @@ fn drive_mtp_generator_round_loop_threads_logprobs_through_to_emitted_tokens() {
         assert_eq!(
             lp.logprob, expected.logprob,
             "logprobs[{i}].logprob for token {tok} must be the synthetic value \
-             threaded from the mock target (issue #678)"
+             threaded from the mock target"
         );
     }
 }
@@ -1190,11 +1189,11 @@ fn drive_mtp_generator_round_loop_returns_empty_logprobs_when_disabled() {
 // =============================================================================
 
 // =============================================================================
-// Thinking-budget enforcement through the burst — issue #679
+// Thinking-budget enforcement through the burst
 //
-// PR #671 (issue #670) gated requests with active thinking-budget
+// gated requests with active thinking-budget
 // enforcement to the classic decode path because the burst path never
-// implemented the forced `</think>` injection. Issue #679 has
+// implemented the forced `</think>` injection. has
 // `finalize_burst_success` run the same per-token `decide_override` +
 // `observe` cycle the classic path's `apply_thinking_budget` uses,
 // factored into the `apply_burst_thinking_budget` helper.
@@ -1270,7 +1269,7 @@ fn apply_burst_thinking_budget_injects_close_at_budget_boundary() {
     assert_eq!(
         t3, 101,
         "at the budget boundary the burst token must be replaced with the \
-         forced </think> close id (issue #679)"
+         forced </think> close id"
     );
     assert!(
         o3,
@@ -1338,7 +1337,7 @@ fn burst_module_exports_required_for_scheduler_integration_compile() {
 }
 
 // =============================================================================
-// Issue #673: `BurstFinalized` prompt-cache donate plumbing.
+// `BurstFinalized` prompt-cache donate plumbing.
 //
 // `try_run_burst_b1` returns a `BurstFinalized` whose `prompt_tokens`,
 // `generated_tokens`, and `healthy_finish` fields the scheduler feeds
@@ -1412,12 +1411,12 @@ fn burst_finalized_error_outcome_has_empty_donate_payload() {
 
 #[test]
 fn batched_burst_module_exports_required_for_scheduler_integration_compile() {
-    // Issue #674: the batched-burst entry point and its result type must
+    // the batched-burst entry point and its result type must
     // stay exported under their current names — `BatchScheduler::try_speculative_burst`
     // depends on both. A re-org that renames either breaks this at
     // compile time before runtime tests fire.
     let _ = std::mem::size_of::<super::speculative_burst::BatchedBurstFinalized>();
-    // Issue #688: the per-row payload type `BatchedBurstRow` is also
+    // the per-row payload type `BatchedBurstRow` is also
     // load-bearing — the scheduler's batched arm destructures it to feed
     // `donate_finished_sequence_cache`. A rename breaks this test at the
     // same time as the scheduler.
@@ -1433,7 +1432,7 @@ fn batched_burst_module_exports_required_for_scheduler_integration_compile() {
 }
 
 // =============================================================================
-// Issue #688: `BatchedBurstRow` prompt-cache donate plumbing.
+// `BatchedBurstRow` prompt-cache donate plumbing.
 //
 // `try_run_burst_batched` returns a `BatchedBurstFinalized` whose `rows`
 // each carry the same donate-payload shape as the B = 1 `BurstFinalized`
@@ -1551,7 +1550,7 @@ fn batched_burst_finalized_rows_preserve_per_row_donate_payloads() {
 }
 
 // =============================================================================
-// sampling_config_eq (issue #674 — batched-window admission predicate)
+// sampling_config_eq (— batched-window admission predicate)
 // =============================================================================
 
 #[test]
@@ -1662,7 +1661,7 @@ fn sampling_config_eq_requires_empty_token_bias_on_both_sides() {
 
 #[test]
 fn sampling_config_eq_excludes_history_dependent_penalty_configs() {
-    // Issue #682 lets penalty-bearing requests enter the burst path
+    // lets penalty-bearing requests enter the burst path
     // (the B=1 burst threads token history). But the BATCHED path
     // samples each row's first bonus with an empty token history, so
     // `sampling_config_eq` (the batched-window admission gate) must

--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -19,7 +19,7 @@
 //!
 //! Used by: routes/chat
 //!
-//! # Prefix stability guarantees (epic #416, issue #422)
+//! # Prefix stability guarantees
 //!
 //! When the prompt prefix cache is enabled, [`prepare_chat_request`]
 //! guarantees that rendering the same conversation across turns yields a
@@ -78,7 +78,7 @@ pub(crate) struct PreparedChatRequest {
     pub(crate) prompt: String,
     pub(crate) image_data: Vec<Vec<u8>>,
     pub(crate) audio_data: Vec<Vec<u8>>,
-    /// Resolved video items (issue #596, hardened by issue #601).
+    /// Resolved video items (hardened).
     ///
     /// Each entry holds:
     /// * a [`crate::multimodal::video::VideoSource`] handle that the
@@ -112,7 +112,7 @@ pub(super) fn log_once_sessions() -> &'static Mutex<HashSet<String>> {
 
 /// Legacy wrapper preserved for tests and any callers outside the hot
 /// route path. Delegates to [`prepare_chat_request_with_cache`] with
-/// the cache-enabled flag set to `false`, matching pre-#422 behavior.
+/// the cache-enabled flag set to `false`, matching earlier behavior.
 ///
 /// Production HTTP handlers (see `src/server/routes/chat.rs`) use the
 /// `_with_cache` variant directly so they can honor the installed
@@ -127,7 +127,7 @@ pub(crate) async fn prepare_chat_request(
 }
 
 /// Full variant of [`prepare_chat_request`] with explicit prompt-cache
-/// awareness (issue #422).
+/// awareness.
 ///
 /// When `prompt_cache_enabled` is `true` and the caller has not explicitly
 /// set `preserve_thinking` anywhere in the request, this function defaults
@@ -148,7 +148,7 @@ pub(crate) async fn prepare_chat_request_with_cache(
     let effective_tools = effective_tools(request);
     let merged_extra_body = request.merged_extra_body();
 
-    // Issue #410: resolve merged kwargs once up-front.
+    // resolve merged kwargs once up-front.
     //
     // Precedence: top-level `chat_template_kwargs` >
     // nested/flattened `extra_body.chat_template_kwargs` >
@@ -162,7 +162,7 @@ pub(crate) async fn prepare_chat_request_with_cache(
     );
     let mut merged_kwargs = merge_server_and_request(server_default_kwargs, &per_request_kwargs);
 
-    // Issue #422: default preserve_thinking=true when the prompt cache is on
+    // default preserve_thinking=true when the prompt cache is on
     // and no layer of the precedence chain set it. The per-request-kwargs
     // object already reflects top-level + flattened-SDK + nested-extra_body
     // + DashScope flat shape, and `merged_kwargs` folds in the server
@@ -272,14 +272,14 @@ fn has_tool_fields(request: &ChatCompletionRequest) -> bool {
 /// multi-turn tool-use conversations.
 ///
 /// Thin wrapper with `preserve_thinking=true` — used by tests that predate
-/// issue #410 and by any caller that does not want rolling-checkpoint
+/// and by any caller that does not want rolling-checkpoint
 /// stripping.
 #[cfg(test)]
 pub(super) fn build_raw_json_messages(request: &ChatCompletionRequest) -> serde_json::Value {
     build_raw_json_messages_with_thinking(request, true)
 }
 
-/// Issue #410: build raw JSON messages with optional rolling-checkpoint
+/// build raw JSON messages with optional rolling-checkpoint
 /// stripping of `<think>` blocks.
 ///
 /// When `preserve_thinking` is `true`, all `<think>...</think>` blocks reach
@@ -383,7 +383,7 @@ fn render_simple_fallback(messages: &[ChatMessage]) -> String {
     prompt
 }
 
-/// Issue #410: flatten request messages into [`ChatMessage`] with optional
+/// flatten request messages into [`ChatMessage`] with optional
 /// rolling-checkpoint stripping.
 ///
 /// See [`build_raw_json_messages_with_thinking`] for the stripping rules. The

--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -418,7 +418,7 @@ fn build_raw_json_messages_emits_empty_content_for_missing_field() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #410 — preserve_thinking plumbing through prepare_chat_request
+// preserve_thinking plumbing through prepare_chat_request
 // ---------------------------------------------------------------------------
 
 use crate::server::chat_template_kwargs::ChatTemplateKwargs;
@@ -926,7 +926,7 @@ async fn rolling_checkpoint_ignores_pseudo_user_tool_response_anchor() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #422 — prompt_cache_key and user field deserialization round-trips
+// prompt_cache_key and user field deserialization round-trips
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -1048,7 +1048,7 @@ fn session_key_collapses_to_anonymous_sentinel_without_hints() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #422 — preserve_thinking defaulting when prompt cache is enabled
+// preserve_thinking defaulting when prompt cache is enabled
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -1127,7 +1127,7 @@ async fn prompt_cache_on_respects_explicit_false_via_extra_body() {
 #[tokio::test]
 async fn prompt_cache_off_preserves_pre_422_behavior() {
     // When the cache flag is off, the defaulting must NOT run. With no
-    // explicit preserve_thinking the pre-#422 behavior (rolling-checkpoint
+    // explicit preserve_thinking the earlier behavior (rolling-checkpoint
     // strip) applies.
     let request = three_turn_request_with_think_blocks();
     let processor = ChatTemplateProcessor::with_template(dump_template());
@@ -1136,7 +1136,7 @@ async fn prompt_cache_off_preserves_pre_422_behavior() {
         .unwrap();
     assert!(
         !prepared.prompt.contains("<think>"),
-        "cache off → pre-#422 strip remains the default"
+        "cache off → earlier strip remains the default"
     );
 }
 
@@ -1267,7 +1267,7 @@ async fn preserve_thinking_defaulting_logs_per_distinct_session() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #422 — tool-call request still produces a correct cache key
+// tool-call request still produces a correct cache key
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -1320,7 +1320,7 @@ fn tool_call_message_history_round_trips_and_digests() {
 }
 
 // ---------------------------------------------------------------------------
-// PR #600 review fix (HIGH-1): temp-file lifetime tied to PreparedChatRequest
+// review fix (HIGH-1): temp-file lifetime tied to PreparedChatRequest
 // ---------------------------------------------------------------------------
 
 /// A `data:video/...;base64,...` URL produces a server-owned temp file that

--- a/src/server/chat_template.rs
+++ b/src/server/chat_template.rs
@@ -48,12 +48,12 @@ pub struct ChatTemplateProcessor {
     ///
     /// Mirrors upstream `TokenizerWrapper.apply_chat_template`'s
     /// `enable_thinking=self.has_thinking` default added in mlx-lm PR #1114
-    /// (issue #590). Plumbed in by `server::startup::resolve_chat_template`
+    /// Plumbed in by `server::startup::resolve_chat_template`
     /// from [`crate::tokenizer::ThinkingMarkers::has_thinking`] right after
     /// the tokenizer loads — so a thinking model defaults to `enable_thinking=true`
     /// while a non-thinking model defaults to `false`.
     ///
-    /// `false` is the conservative pre-#590 default and is kept for any
+    /// `false` is the conservative earlier default and is kept for any
     /// path that constructs a processor without a corresponding tokenizer
     /// (template-string overrides, `Default`, tests).
     default_enable_thinking: bool,
@@ -137,7 +137,7 @@ impl ChatTemplateProcessor {
     /// any think marker pair (single or multi token) — see
     /// [`crate::tokenizer::ThinkingMarkers::has_thinking`].
     ///
-    /// The default is `false` for backward compatibility with pre-#590
+    /// The default is `false` for backward compatibility with earlier
     /// behavior so callers that do not explicitly enable this still see the
     /// historic default; `server::startup` opts into the upstream-aligned
     /// default for thinking models.
@@ -156,7 +156,7 @@ impl ChatTemplateProcessor {
 
     /// Raw Jinja template source post-preprocessing.
     ///
-    /// Used by the prompt-cache key composer (epic #416 / issue #422) to hash
+    /// Used by the prompt-cache key composer to hash
     /// a stable identifier of the rendering pipeline into `template_sig`. The
     /// returned slice is the exact string used as the minijinja template, so
     /// any non-determinism that depends on template text will be captured.
@@ -336,7 +336,7 @@ impl ChatTemplateProcessor {
     /// under its original name (with a handful of canonical keys such as
     /// `enable_thinking` overriding our default context entries so templates
     /// that rely on those names see the operator-provided value). This is the
-    /// plumbing path used by issue #410's `preserve_thinking` feature and
+    /// plumbing path used's `preserve_thinking` feature and
     /// generalizes to any future kwarg a HuggingFace chat template expects.
     ///
     /// When a kwarg key duplicates an already-provided context entry
@@ -458,11 +458,9 @@ impl ChatTemplateProcessor {
 /// from kwargs overlay — a request cannot overwrite the canonical conversation
 /// or tool list by smuggling those keys through `chat_template_kwargs`.
 ///
-/// `enable_thinking` defaults to `default_enable_thinking` (issue #590,
-/// upstream PR #1114) — `true` when the underlying tokenizer recognizes a
+/// `enable_thinking` defaults to `default_enable_thinking` (upstream PR #1114) — `true` when the underlying tokenizer recognizes a
 /// think marker pair, `false` otherwise.  The default is overridable through
-/// `kwargs` (the same mechanism that lets issue #410's `preserve_thinking`
-/// reach the template).  Any other kwarg key — including future
+/// `kwargs` (the same mechanism that lets's `preserve_thinking` reach the template).  Any other kwarg key — including future
 /// template-specific hints — is passed through unchanged.
 fn build_template_context(
     messages: minijinja::Value,
@@ -485,7 +483,7 @@ fn build_template_context(
     );
     ctx.insert("tools", tools);
     // Tokenizer-derived default: `has_thinking` for thinking models, `false`
-    // otherwise (issue #590; upstream PR #1114). Overridden below by any
+    // otherwise (upstream PR #1114). Overridden below by any
     // matching kwarg from the request / server-default merge.
     ctx.insert(
         "enable_thinking",
@@ -1454,7 +1452,7 @@ TOOL
 
     #[test]
     fn test_apply_with_kwargs_exposes_preserve_thinking() {
-        // Issue #410: verify that kwargs reach the Jinja template under the
+        // verify that kwargs reach the Jinja template under the
         // provided names. The template branches on preserve_thinking to emit
         // a marker we can assert on.
         let template = r#"{% if preserve_thinking %}[KEEP]{% else %}[STRIP]{% endif %}{% for m in messages %}{{ m.content }}{% endfor %}"#;
@@ -1504,11 +1502,11 @@ TOOL
         assert!(out.contains("flag=42"));
     }
 
-    // -- enable_thinking default plumbing (issue #590) -----------------------
+    // -- enable_thinking default plumbing -----------------------
 
     #[test]
     fn default_enable_thinking_defaults_to_false_for_back_compat() {
-        // Pre-#590 behavior: a freshly constructed processor leaves
+        // Pre- behavior: a freshly constructed processor leaves
         // `enable_thinking` at `false` so callers that never opt in see the
         // historic default.
         let template = r#"{% if enable_thinking %}[THINK]{% else %}[NOTHINK]{% endif %}"#;
@@ -1529,7 +1527,7 @@ TOOL
 
     #[test]
     fn set_default_enable_thinking_flips_default_for_thinking_models() {
-        // Issue #590 / upstream PR #1114: when the tokenizer recognizes a
+        // upstream PR #1114: when the tokenizer recognizes a
         // think marker pair, the chat-template default flips to `true`. The
         // request must then render the THINK branch without setting any
         // kwarg.
@@ -1868,7 +1866,7 @@ TOOL
 
     #[test]
     fn patch_gemma4_generation_prompt_uses_default_enable_thinking_when_kwarg_absent() {
-        // Regression guard for HIGH-1 (PR #613 review): when the server startup
+        // Regression guard for HIGH-1 (review): when the server startup
         // hook sets `default_enable_thinking=true` for a Gemma 4 thinking model,
         // a request that arrives with empty kwargs must still trigger the
         // `<|channel>thought\n` priming. Before the fix, `kwargs.get("enable_thinking")`

--- a/src/server/chat_template_kwargs.rs
+++ b/src/server/chat_template_kwargs.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Shared chat-template kwargs plumbing (issue #410).
+//! Shared chat-template kwargs plumbing.
 //!
 //! Provides the generic `chat_template_kwargs` dictionary pass-through that
 //! matches llama.cpp's `--chat-template-kwargs` flag and vLLM's

--- a/src/server/chat_template_kwargs_tests.rs
+++ b/src/server/chat_template_kwargs_tests.rs
@@ -18,7 +18,7 @@ use super::{
     resolve_server_default_kwargs, strip_rolling_checkpoint, strip_think_block,
 };
 // Env-var fallback tests must serialize through the crate-wide `ENV_LOCK`
-// (issue #573); per-module locks race with env mutations in unrelated
+// per-module locks race with env mutations in unrelated
 // modules of the same test binary.
 use crate::test_support::env_lock::env_lock as lock_env;
 use serde_json::{Map, Value, json};
@@ -99,7 +99,7 @@ fn preserve_thinking_accessor_ignores_non_bool_values() {
 // Env-var fallback tests share both `LLAMA_ARG_CHAT_TEMPLATE_KWARGS` and
 // the process-wide env block. They serialize through the crate-wide
 // `ENV_LOCK` imported above — per-module locks would race with env
-// mutations in unrelated modules of the same test binary (issue #573).
+// mutations in unrelated modules of the same test binary.
 
 #[test]
 fn env_fallback_cli_none_takes_env() {

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -52,12 +52,12 @@ pub struct ServerStartupInput {
     pub timeout: u64,
     pub draft_model_path: Option<PathBuf>,
     pub draft_max: usize,
-    /// Issue #630: explicit drafter-kind override from `--draft-kind`.
+    /// explicit drafter-kind override from `--draft-kind`.
     /// `None` means "auto-detect from the drafter's `config.json`" when
     /// `draft_model_path` is supplied; otherwise the field is inert and
     /// the classic [`crate::SpeculativeGenerator`] path is used.
     pub draft_kind: Option<String>,
-    /// Issue #630: explicit draft-block-size override from
+    /// explicit draft-block-size override from
     /// `--draft-block-size`. `None` means "use the per-kind default"
     /// ([`crate::cli::speculative_args::default_block_size_for_kind`])
     /// once the kind has been resolved.
@@ -121,7 +121,7 @@ pub struct ServerStartupInput {
     /// Micro-batch size for in-process pipeline execution.
     pub pp_micro_batch_size: usize,
 
-    // Zero-config multi-machine pipeline bring-up (issue #342).
+    // Zero-config multi-machine pipeline bring-up.
     /// When set (>= 2), run the zero-config coordinator bring-up and populate
     /// `distributed_config` with a freshly emitted TOML.
     pub pp_auto: Option<u32>,
@@ -160,7 +160,7 @@ pub struct ServerStartupInput {
     pub max_image_height: u32,
     pub max_image_decode_alloc_bytes: u64,
 
-    // Elastic pipeline-parallel repartitioning (issue #349).
+    // Elastic pipeline-parallel repartitioning.
     /// Enable `--enable-elastic-pp`. Off by default.
     pub enable_elastic_pp: bool,
     /// Drain timeout seconds for elastic repartitioning.
@@ -170,7 +170,7 @@ pub struct ServerStartupInput {
     /// Cool-down seconds between memory-pressure triggers.
     pub elastic_pp_cool_down: u64,
 
-    // Observability (issue #350).
+    // Observability.
     /// Requested port for the Prometheus `/metrics` endpoint. `Some(p)`
     /// enables the endpoint; `p` is informational only in v1 because the
     /// endpoint is multiplexed onto the main HTTP port.
@@ -178,7 +178,7 @@ pub struct ServerStartupInput {
     /// Chrome-tracing JSON output path for the pipeline scheduler.
     pub debug_pp_trace: Option<PathBuf>,
 
-    /// Axis B Epic #362 (B8): already-resolved server-wide language-bias
+    /// Axis B (B8): already-resolved server-wide language-bias
     /// configuration, if the CLI provided `--lang-bias` / `--lang-bias-config`.
     ///
     /// The binary's `serve` command calls `LangBiasCliArgs::resolve()` before
@@ -189,7 +189,7 @@ pub struct ServerStartupInput {
     /// the env-var and CLI paths share a single normalization point.
     pub lang_bias_config: Option<LangBiasConfig>,
 
-    /// Issue #409: server-wide thinking-token budget for Qwen3-family models.
+    /// server-wide thinking-token budget for Qwen3-family models.
     ///
     /// Raw `i32` value preserving llama.cpp semantics:
     /// - `-1` (default) — unrestricted reasoning (bit-exact baseline).
@@ -203,7 +203,7 @@ pub struct ServerStartupInput {
     /// [`env_fallback_reasoning_budget`] before this struct is constructed.
     pub reasoning_budget: i32,
 
-    /// Issue #410: raw JSON string for the default chat-template kwargs.
+    /// raw JSON string for the default chat-template kwargs.
     ///
     /// Mirrors llama.cpp's `--chat-template-kwargs` flag and the
     /// `LLAMA_ARG_CHAT_TEMPLATE_KWARGS` env var. `None` or an empty string
@@ -218,7 +218,7 @@ pub struct ServerStartupInput {
     /// consistently.
     pub chat_template_kwargs: Option<String>,
 
-    // Issue #484 (B11): llama-server-compatible K/V cache type split flags.
+    // (B11): llama-server-compatible K/V cache type split flags.
     //
     // These hold the raw CLI strings from `--cache-type-k` / `--cache-type-v`
     // (and their env var aliases `LLAMA_ARG_CACHE_TYPE_K` /
@@ -246,7 +246,7 @@ pub struct ServerStartupInput {
     /// `None` means the flag was not provided (= default FP16).
     pub kv_cache_mode_legacy: Option<String>,
 
-    // Issue #424: prompt-prefix KV cache knobs.
+    // prompt-prefix KV cache knobs.
     // Each field stores the raw CLI/env value before normalization into
     // `PromptCacheConfig`. `None` on the `Option`-typed fields means "not
     // provided by the CLI flag"; defaults come from `PromptCacheConfig::default()`.
@@ -275,14 +275,14 @@ pub struct ServerStartupInput {
     /// Also accepts `MLXCEL_PROMPT_CACHE_MIN_PREFIX`.
     pub prompt_cache_min_prefix: Option<usize>,
 
-    // Issue #552: Automatic Prefix Caching (APC) knobs.
+    // Automatic Prefix Caching (APC) knobs.
     //
     // APC layers block-granularity hash chains on top of the existing
     // prompt-prefix cache so finer-grained reuse becomes possible. The
     // raw fields here are normalised into [`super::prompt_cache::ApcConfig`]
     // by [`build_prompt_cache_config`].
     /// `--apc-enabled`: master switch for APC. Defaults to `false` so
-    /// behaviour matches the pre-#552 server. Also accepts
+    /// behaviour matches the earlier server. Also accepts
     /// `APC_ENABLED` (parity with upstream `mlx-vlm`).
     pub apc_enabled: bool,
 
@@ -299,7 +299,7 @@ pub struct ServerStartupInput {
     /// compiled-in default (sha256)". Also accepts `APC_HASH`.
     pub apc_hash: Option<String>,
 
-    // Issue #545: continuous-batching KV quantization knobs.
+    // continuous-batching KV quantization knobs.
     //
     // These mirror the upstream `mlx-vlm` PR #1030 server CLI flags. The
     // raw fields are kept here in [`ServerStartupInput`] form so binaries
@@ -324,13 +324,11 @@ pub struct ServerStartupInput {
     /// flag without `--kv-bits` does not enable quantization on its own —
     /// `kv_bits` is the master switch.
     pub kv_quant_scheme: Option<String>,
-    /// `--kv-skip-last-layer` value. Defaults to `true` (the
-    /// gemma-4-31b-style last-layer skip is on by default per the
-    /// issue #545 acceptance criterion). Set to `false` to opt out
+    /// `--kv-skip-last-layer` value. Defaults to `true` (the gemma-4-31b-style last-layer skip is on by default per the acceptance criterion). Set to `false` to opt out
     /// for benchmarking.
     pub kv_skip_last_layer: bool,
 
-    // Issue #603: maximum KV cache size for plain (non-sliding) caches.
+    // maximum KV cache size for plain (non-sliding) caches.
     //
     // Mirrors upstream mlx-lm's `--max-kv-size` flag on `BatchGenerator`.
     // `0` (the default) preserves the legacy unbounded behaviour. Any
@@ -350,18 +348,18 @@ pub struct ServerStartupInput {
     /// `--max-kv-size` value (`0` = disabled, the default).
     pub max_kv_size: usize,
 
-    /// Issue #622: `--responses-store-max-entries` value (`0` disables
+    /// `--responses-store-max-entries` value (`0` disables
     /// the OpenAI Responses API response store entirely).
     pub responses_store_max_entries: usize,
-    /// Issue #622: `--responses-store-ttl-secs` value (`0` disables TTL).
+    /// `--responses-store-ttl-secs` value (`0` disables TTL).
     pub responses_store_ttl_secs: u64,
-    /// Issue #622: `--conversation-store-max-entries` value (`0` disables
+    /// `--conversation-store-max-entries` value (`0` disables
     /// the OpenAI Responses API conversation transcript store entirely).
     pub conversation_store_max_entries: usize,
-    /// Issue #622: `--conversation-store-ttl-secs` value (`0` disables TTL).
+    /// `--conversation-store-ttl-secs` value (`0` disables TTL).
     pub conversation_store_ttl_secs: u64,
 
-    /// Issue #371 (A4): path to a YAML weight-load surgery configuration.
+    /// (A4): path to a YAML weight-load surgery configuration.
     ///
     /// `None` (the default) keeps the server on the bit-exact baseline
     /// weight-load path — no surgery crate work, no observable
@@ -386,14 +384,14 @@ impl ServerStartupInput {
     ///
     /// Returns an error when any edge input has a malformed shape that we
     /// cannot reasonably paper over at runtime. Today the only hard-fail
-    /// input is `--chat-template-kwargs` (issue #410) because a malformed
+    /// input is `--chat-template-kwargs` because a malformed
     /// JSON object cannot be silently "ignored" without degrading into a
     /// confusing state where the operator thinks they configured kwargs but
     /// didn't.
     pub fn into_startup_config(self) -> anyhow::Result<ServerStartupConfig> {
         let resolution =
             resolve_prefill_chunk_size(self.prefill_chunk_size, self.batch_size, self.ubatch_size);
-        // Issue #409: resolve the server-wide thinking budget once, up-front.
+        // resolve the server-wide thinking budget once, up-front.
         // Invalid values are logged and treated as unbounded so the server
         // still starts (per-request errors are surfaced as 400s at the route).
         let reasoning_budget = match ThinkingBudget::from_raw_i32(self.reasoning_budget) {
@@ -409,15 +407,15 @@ impl ServerStartupInput {
                 None
             }
         };
-        // Issue #410: resolve the server-wide chat-template kwargs. Invalid
+        // resolve the server-wide chat-template kwargs. Invalid
         // JSON is a hard failure (see doc comment above) — return early with
         // a clear error that the binary will surface as an exit code.
         let chat_template_kwargs =
             resolve_server_default_kwargs(self.chat_template_kwargs.as_deref())
                 .map_err(|e| anyhow::anyhow!("--chat-template-kwargs: {e}"))?;
-        // Issue #424: build PromptCacheConfig from raw CLI/env-resolved values.
+        // build PromptCacheConfig from raw CLI/env-resolved values.
         // Any field left at `None` picks up the compiled-in default.
-        // Issue #552: layer APC config on top.
+        // layer APC config on top.
         let prompt_cache = build_prompt_cache_config(
             self.prompt_cache_enabled,
             self.prompt_cache_capacity_bytes,
@@ -431,7 +429,7 @@ impl ServerStartupInput {
         )
         .map_err(|e| anyhow::anyhow!("--apc-hash: {e}"))?;
 
-        // Issue #484 (B11): resolve the effective KV cache mode from split flags,
+        // (B11): resolve the effective KV cache mode from split flags,
         // legacy shorthand, or the default (FP16).
         let kv_cache_mode = resolve_kv_cache_mode(
             self.cache_type_k.as_deref(),
@@ -440,7 +438,7 @@ impl ServerStartupInput {
         )
         .map_err(|e| anyhow::anyhow!("KV cache mode error: {e}"))?;
 
-        // Issue #545: resolve the batch KV quantization config from the
+        // resolve the batch KV quantization config from the
         // new `--kv-bits` / `--kv-group-size` / `--kv-quant-scheme` /
         // `--kv-skip-last-layer` flags. When `kv_bits == 0` this falls
         // through to the disabled default which is bit-exact equivalent
@@ -453,7 +451,7 @@ impl ServerStartupInput {
         )
         .map_err(|e| anyhow::anyhow!("batch KV cache quant error: {e}"))?;
 
-        // Issue #603 H1: validate `--max-kv-size` bounds before we lower
+        // H1: validate `--max-kv-size` bounds before we lower
         // the raw `usize` into the semantic `Option<usize>` downstream.
         //
         // The scheduler casts this value to `i32` when computing
@@ -479,7 +477,7 @@ impl ServerStartupInput {
             timeout: self.timeout,
             draft_model_path: self.draft_model_path,
             draft_max: self.draft_max,
-            // Issue #630: forward the new speculative-decoding selector
+            // forward the new speculative-decoding selector
             // flags through the normalization step verbatim. Parsing the
             // raw `draft_kind` string into a `DrafterKind` and resolving
             // it against the drafter's `config.json` happens later, at
@@ -557,16 +555,16 @@ impl ServerStartupInput {
             prompt_cache,
             kv_cache_mode,
             batch_kv_quant,
-            // Issue #603: lower the raw `usize` (0 = disabled) into a
+            // lower the raw `usize` (0 = disabled) into a
             // semantic `Option<usize>` after `resolve_max_kv_size` has
             // validated upper and lower bounds (H1 fix).
             max_kv_size: resolved_max_kv_size,
-            // Issue #622: forward the Responses-API store limits.
+            // forward the Responses-API store limits.
             responses_store_max_entries: self.responses_store_max_entries,
             responses_store_ttl_secs: self.responses_store_ttl_secs,
             conversation_store_max_entries: self.conversation_store_max_entries,
             conversation_store_ttl_secs: self.conversation_store_ttl_secs,
-            // Issue #371 (A4): forward the surgery YAML path verbatim.
+            // (A4): forward the surgery YAML path verbatim.
             // start_server() parses the YAML and installs the pipeline
             // exactly once before spawning the model worker.
             #[cfg(feature = "surgery")]
@@ -575,7 +573,7 @@ impl ServerStartupInput {
     }
 }
 
-/// Issue #603 H1: validate `--max-kv-size` (and `LLAMA_ARG_MAX_KV_SIZE`)
+/// H1: validate `--max-kv-size` (and `LLAMA_ARG_MAX_KV_SIZE`)
 /// against the operational limits enforced by the scheduler.
 ///
 /// Returns:
@@ -635,7 +633,7 @@ pub use crate::cli::turbo_args::{
     env_fallback_cache_type_k, env_fallback_cache_type_v, resolve_kv_cache_mode,
 };
 
-// ── Issue #545 — batched KV-cache quantization knobs ─────────────────────────
+// ── — batched KV-cache quantization knobs ─────────────────────────
 
 /// Resolve the [`BatchKvQuantConfig`] from the raw CLI string fields.
 ///
@@ -687,7 +685,7 @@ pub fn resolve_batch_kv_quant_config(
 }
 
 /// Apply `LLAMA_ARG_KV_BITS` env var fallback to the raw `--kv-bits` CLI
-/// value (issue #545).
+/// value.
 ///
 /// Precedence rule: CLI flag beats env var.
 ///
@@ -725,7 +723,7 @@ pub fn env_fallback_kv_bits(value: &mut i32) {
 }
 
 /// Apply `LLAMA_ARG_KV_GROUP_SIZE` env var fallback to the raw
-/// `--kv-group-size` CLI value (issue #545).
+/// `--kv-group-size` CLI value.
 ///
 /// Same precedence rule as [`env_fallback_kv_bits`]. The CLI default is
 /// [`DEFAULT_KV_GROUP_SIZE`] (`64`); the env var only takes effect when
@@ -763,7 +761,7 @@ pub fn env_fallback_kv_group_size(value: &mut i32) {
 }
 
 /// Apply `LLAMA_ARG_KV_QUANT_SCHEME` env var fallback to the raw
-/// `--kv-quant-scheme` CLI value (issue #545).
+/// `--kv-quant-scheme` CLI value.
 ///
 /// Same precedence rule as [`env_fallback_cache_type_k`].
 pub fn env_fallback_kv_quant_scheme(value: &mut Option<String>) {
@@ -771,7 +769,7 @@ pub fn env_fallback_kv_quant_scheme(value: &mut Option<String>) {
 }
 
 /// Apply `LLAMA_ARG_KV_SKIP_LAST_LAYER` / `MLXCEL_KV_SKIP_LAST_LAYER` env
-/// var fallbacks to the raw `--kv-skip-last-layer` value (issue #545).
+/// var fallbacks to the raw `--kv-skip-last-layer` value.
 ///
 /// The CLI default is `true`. The env var only takes effect when the CLI
 /// value matches that default. Acceptable env values are
@@ -857,7 +855,7 @@ fn apply_optional_string_env_fallback(value: &mut Option<String>, key: &str, fla
 }
 
 /// Apply the `LLAMA_ARG_REASONING_BUDGET` env-var fallback to the raw CLI
-/// `--reasoning-budget` value (issue #409).
+/// `--reasoning-budget` value.
 ///
 /// Precedence rule (matches existing `LLAMA_ARG_*` precedence helpers):
 /// - CLI flag wins over env var.
@@ -900,7 +898,7 @@ pub fn env_fallback_lang_bias(args: &mut LangBiasCliArgs) {
 }
 
 /// Apply `LLAMA_ARG_LANG_BIAS_INCLUDE_BYTE_FRAGMENTS` env var fallback to the
-/// `include_byte_fragments` field (issue #405).
+/// `include_byte_fragments` field.
 ///
 /// Precedence rule: CLI flag beats env var, mirroring the B7 pattern for
 /// [`env_fallback_lang_bias`]. The env value is parsed permissively and
@@ -960,7 +958,7 @@ pub fn resolve_seed(seed: i64) -> Option<u64> {
     if seed < 0 { None } else { Some(seed as u64) }
 }
 
-// ── Issue #424 — prompt cache config resolution ──────────────────────────────
+// ── — prompt cache config resolution ──────────────────────────────
 
 /// Build a [`crate::server::prompt_cache::PromptCacheConfig`] from the raw
 /// values captured from CLI flags and env vars.
@@ -968,7 +966,7 @@ pub fn resolve_seed(seed: i64) -> Option<u64> {
 /// `None` for any numeric field falls back to the compiled-in default from
 /// [`crate::server::prompt_cache::PromptCacheConfig::default`].
 ///
-/// Issue #552: also accepts the APC knobs (`apc_enabled`, `apc_block_size`,
+/// also accepts the APC knobs (`apc_enabled`, `apc_block_size`,
 /// `apc_num_blocks`, `apc_hash`) and assembles them into the
 /// [`crate::server::prompt_cache::ApcConfig`] sub-struct. Returns an error
 /// when `apc_hash` is supplied but cannot be parsed.
@@ -1142,7 +1140,7 @@ pub fn env_fallback_prompt_cache_min_prefix(value: &mut Option<usize>) {
     );
 }
 
-// ── Issue #552 — Automatic Prefix Caching env-var fallbacks ─────────────────
+// ── — Automatic Prefix Caching env-var fallbacks ─────────────────
 //
 // Mirrors the upstream `mlx-vlm` env-var surface (`APC_ENABLED`,
 // `APC_BLOCK_SIZE`, `APC_NUM_BLOCKS`, `APC_HASH`) so operators migrating from

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -23,7 +23,7 @@ use super::{
 use crate::lang_bias::LangBiasCliArgs;
 // Tests that mutate env vars (via `EnvGuard` or directly) must acquire the
 // crate-wide `ENV_LOCK` *before* the guard so the lock outlives the
-// guard's `Drop` (which calls `remove_var`). See issue #573 — a per-module
+// guard's `Drop` (which calls `remove_var`). — a per-module
 // lock would race with env mutations in unrelated modules of the same
 // test binary.
 use crate::test_support::env_lock::env_lock;
@@ -43,7 +43,7 @@ fn sample_input() -> ServerStartupInput {
         timeout: 600,
         draft_model_path: Some(PathBuf::from("models/draft")),
         draft_max: 8,
-        // Issue #630: speculative-decoding selector flags default off
+        // speculative-decoding selector flags default off
         // (None = auto-detect at dispatch time when a drafter is set).
         draft_kind: None,
         draft_block_size: None,
@@ -116,34 +116,34 @@ fn sample_input() -> ServerStartupInput {
         lang_bias_config: None,
         reasoning_budget: -1,
         chat_template_kwargs: None,
-        // Issue #424: prompt-cache knobs — use defaults for the helper.
+        // prompt-cache knobs — use defaults for the helper.
         prompt_cache_enabled: true,
         prompt_cache_capacity_bytes: None,
         prompt_cache_max_entries: None,
         prompt_cache_ttl_seconds: None,
         prompt_cache_min_prefix: None,
-        // Issue #552: APC knobs — disabled by default.
+        // APC knobs — disabled by default.
         apc_enabled: false,
         apc_block_size: None,
         apc_num_blocks: None,
         apc_hash: None,
-        // Issue #484 (B11): KV cache type split flags — default to None (FP16).
+        // (B11): KV cache type split flags — default to None (FP16).
         cache_type_k: None,
         cache_type_v: None,
         kv_cache_mode_legacy: None,
-        // Issue #545: continuous-batching KV quantization knobs (off by default).
+        // continuous-batching KV quantization knobs (off by default).
         kv_bits: 0,
         kv_group_size: mlxcel_core::cache::DEFAULT_KV_GROUP_SIZE,
         kv_quant_scheme: None,
         kv_skip_last_layer: true,
-        // Issue #603: max KV cache size (0 = unbounded, the default).
+        // max KV cache size (0 = unbounded, the default).
         max_kv_size: 0,
-        // Issue #622: Responses API store defaults.
+        // Responses API store defaults.
         responses_store_max_entries: 1024,
         responses_store_ttl_secs: 3600,
         conversation_store_max_entries: 256,
         conversation_store_ttl_secs: 3600,
-        // Issue #371 (A4): default to None for baseline-path tests.
+        // (A4): default to None for baseline-path tests.
         #[cfg(feature = "surgery")]
         surgery_config_path: None,
     }
@@ -296,7 +296,7 @@ fn into_startup_config_propagates_pp_micro_batch_size() {
 }
 
 // -------------------------------------------------------------------------
-// Issue #410 — chat_template_kwargs normalization
+// chat_template_kwargs normalization
 // -------------------------------------------------------------------------
 
 #[test]
@@ -508,7 +508,7 @@ fn cli_overrides_env() {
 }
 
 // -------------------------------------------------------------------------
-// Issue #405 — LLAMA_ARG_LANG_BIAS_INCLUDE_BYTE_FRAGMENTS env-var fallback
+// LLAMA_ARG_LANG_BIAS_INCLUDE_BYTE_FRAGMENTS env-var fallback
 //
 // Mirrors the B7 tests above. The env-var fallback for the byte-fragment
 // opt-in is permissive about truthiness (accepts `true`/`false`/`1`/`0`) and
@@ -597,7 +597,7 @@ fn byte_fragments_env_var_unparseable_is_ignored() {
 }
 
 // -------------------------------------------------------------------------
-// Issue #424 — prompt-cache CLI/env config tests
+// prompt-cache CLI/env config tests
 // -------------------------------------------------------------------------
 
 /// Default construction of `ServerStartupInput` with prompt-cache defaults
@@ -892,7 +892,7 @@ fn prompt_cache_e2e_cli_capacity_bytes_flows_to_startup_config() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Issue #484 (B11) — resolve_kv_cache_mode tests
+// (B11) — resolve_kv_cache_mode tests
 //
 // These tests cover the K/V-to-KVCacheMode mapping logic: all supported pairs,
 // unsupported combinations, and legacy/split flag interaction.
@@ -1106,7 +1106,7 @@ fn into_startup_config_kv_cache_mode_unsupported_pair_errors() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Issue #484 (B11) — env-var fallback tests for LLAMA_ARG_CACHE_TYPE_K/V
+// (B11) — env-var fallback tests for LLAMA_ARG_CACHE_TYPE_K/V
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// `LLAMA_ARG_CACHE_TYPE_K` is applied when the CLI flag is absent.
@@ -1168,7 +1168,7 @@ fn cache_type_k_empty_env_var_is_ignored() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Issue #545 — env-var fallback tests for kv-bits / kv-group-size /
+// env-var fallback tests for kv-bits / kv-group-size /
 // kv-quant-scheme / kv-skip-last-layer (Fix 1, Fix 2)
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -1297,7 +1297,7 @@ fn kv_skip_last_layer_both_unparseable_keeps_cli_default() {
     );
 }
 
-// ── Issue #603 H1: `--max-kv-size` validation ───────────────────────────────
+// ── H1: `--max-kv-size` validation ───────────────────────────────
 
 #[test]
 fn resolve_max_kv_size_zero_is_disabled() {

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -57,7 +57,7 @@ impl std::str::FromStr for DecodeStorageBackend {
 
 /// Per-request metadata that the scheduler needs to compose a
 /// [`crate::server::prompt_cache::key::PromptCacheKey`] without re-running
-/// the chat template pipeline on the worker thread (epic #416 / issue #421).
+/// the chat template pipeline on the worker thread.
 ///
 /// Route handlers build this once — when
 /// [`crate::server::state::AppState::prompt_cache`] is installed — and hand
@@ -90,7 +90,7 @@ pub struct ServerGenerateOptions {
     pub priority: RequestPriority,
     /// Log probability configuration; disabled by default (zero overhead).
     pub logprobs: LogprobsConfig,
-    /// Issue #409: per-request thinking-token budget. `None` means "inherit
+    /// per-request thinking-token budget. `None` means "inherit
     /// whatever server default is configured"; `Some(budget)` explicitly sets
     /// a value for this request (including reverting to unbounded via
     /// the raw `-1` request value, which the routes translate to a sentinel
@@ -101,7 +101,7 @@ pub struct ServerGenerateOptions {
     /// scheduler sees a single effective value.
     pub reasoning_budget: ReasoningBudgetOverride,
 
-    /// Issue #409: whether the first generated token should be treated as
+    /// whether the first generated token should be treated as
     /// "already inside the `<think>` block" because the prompt primed it.
     ///
     /// `true` for chat endpoints (`/v1/chat/completions`) whose chat template
@@ -114,7 +114,7 @@ pub struct ServerGenerateOptions {
     /// reasoning tokens.
     pub thinking_enter_block_on_start: bool,
 
-    /// Epic #416 / issue #421: cache-key metadata the scheduler uses to look
+    /// cache-key metadata the scheduler uses to look
     /// up a stored prompt prefix and adopt its detached KV cache. `None` when
     /// the route did not install a
     /// [`crate::server::prompt_cache::PromptCacheStore`] (the feature flag is
@@ -122,7 +122,7 @@ pub struct ServerGenerateOptions {
     /// raw text-completion endpoints that do not render a chat template).
     pub prompt_cache_ctx: Option<PromptCacheRequestContext>,
 
-    /// Issue #550: optional structured-output constraint produced by
+    /// optional structured-output constraint produced by
     /// [`crate::server::structured::build_constraint_from_response_format`].
     ///
     /// `None` when the request did not supply a `response_format` of type
@@ -248,7 +248,7 @@ pub struct ServerConfig {
     pub default_dry_penalty_last_n: usize,
     pub draft_model_path: Option<PathBuf>,
     pub num_draft_tokens: usize,
-    /// Issue #630: raw `--draft-kind` override string from the CLI / env
+    /// raw `--draft-kind` override string from the CLI / env
     /// var (`LLAMA_ARG_DRAFT_KIND` / `MLXCEL_DRAFT_KIND`).
     ///
     /// `None` means the server should auto-detect the drafter kind from
@@ -261,7 +261,7 @@ pub struct ServerConfig {
     /// user-selectable) and the parse error must surface at the
     /// dispatch site where the operator-facing error message lives.
     pub draft_kind: Option<String>,
-    /// Issue #630: explicit `--draft-block-size` override. `None` means
+    /// explicit `--draft-block-size` override. `None` means
     /// "use the per-kind default" — `4` for MTP, `16` for DFlash. See
     /// [`crate::cli::speculative_args::default_block_size_for_kind`].
     pub draft_block_size: Option<u32>,
@@ -310,19 +310,19 @@ pub struct ServerConfig {
     /// multimodal embedder on subsequent turns. Default is
     /// [`DEFAULT_VISION_CACHE_SIZE`](crate::vision::feature_cache::DEFAULT_VISION_CACHE_SIZE).
     pub vision_cache_size: usize,
-    /// Axis B Epic #362 (B8): server-wide language bias configuration, if
+    /// Axis B (B8): server-wide language bias configuration, if
     /// resolved at startup from CLI flags or the `LLAMA_ARG_LANG_BIAS` env
     /// var. Every batch sequence inherits this same policy (Phase 1 single
     /// policy per batch; per-request overrides reserved for B12).
     pub lang_bias_config: Option<LangBiasConfig>,
 
-    /// Issue #409: server-wide default thinking-token budget for Qwen3-family
+    /// server-wide default thinking-token budget for Qwen3-family
     /// models. `None` = unrestricted reasoning (default, bit-exact baseline).
     /// Per-request `thinking_budget_tokens` overrides this value (including
     /// a per-request `-1` reverting to unbounded for that one request).
     pub reasoning_budget: Option<crate::server::thinking_budget::ThinkingBudget>,
 
-    /// Issue #410: server-wide default chat-template kwargs resolved from
+    /// server-wide default chat-template kwargs resolved from
     /// `--chat-template-kwargs` and/or `LLAMA_ARG_CHAT_TEMPLATE_KWARGS`.
     ///
     /// `None` means "no server-default kwargs"; per-request kwargs may still
@@ -332,16 +332,16 @@ pub struct ServerConfig {
     /// inherits the same precedence rules.
     pub chat_template_kwargs: Option<crate::server::chat_template_kwargs::ChatTemplateKwargs>,
 
-    /// Issue #419 / epic #416: cross-request prompt-prefix KV cache policy.
+    /// cross-request prompt-prefix KV cache policy.
     ///
     /// Defaults to the baseline policy (enabled with 2 GiB / 1024 entries /
     /// 1-hour TTL). When `enabled = false` the store is skipped entirely at
     /// startup so no memory is reserved. CLI/env parsing for the individual
-    /// fields is tracked separately in sub-issue #424; for now operators set
+    /// fields is tracked separately in for now operators set
     /// the policy via the Rust API or keep the default.
     pub prompt_cache: crate::server::prompt_cache::PromptCacheConfig,
 
-    /// Issue #484 (B11): server-wide KV cache mode.
+    /// (B11): server-wide KV cache mode.
     ///
     /// Resolved from `--cache-type-k`/`--cache-type-v` (llama-server split
     /// flags) or the legacy `--kv-cache-mode` shorthand.  Defaults to
@@ -350,7 +350,7 @@ pub struct ServerConfig {
     /// sequence in the batch sees the same KV quantization policy.
     pub kv_cache_mode: mlxcel_core::cache::KVCacheMode,
 
-    /// Issue #545: batch KV cache quantization configuration for the
+    /// batch KV cache quantization configuration for the
     /// continuous-batching scheduler.
     ///
     /// Resolved from the `--kv-bits`, `--kv-group-size`,
@@ -363,7 +363,7 @@ pub struct ServerConfig {
     /// `skip_last_layer == true`).
     pub batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig,
 
-    /// Issue #603: upper bound on the **live KV window** of plain
+    /// upper bound on the **live KV window** of plain
     /// (non-sliding) `KVCache` instances.
     ///
     /// Mirrors upstream mlx-lm's
@@ -427,7 +427,7 @@ impl Default for ServerConfig {
             default_dry_penalty_last_n: 0,
             draft_model_path: None,
             num_draft_tokens: 3,
-            // Issue #630: default to "auto-detect from drafter config"
+            // default to "auto-detect from drafter config"
             // when a drafter is supplied; the classic
             // `SpeculativeGenerator` path runs when no drafter is set.
             draft_kind: None,

--- a/src/server/conversation_store.rs
+++ b/src/server/conversation_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! In-memory conversation store for the OpenAI Responses API (issue #622).
+//! In-memory conversation store for the OpenAI Responses API.
 //!
 //! Phase 1 keeps a single ordered transcript per `conversation` id, holding
 //! both prior inputs and prior outputs. Each `POST /v1/responses` that

--- a/src/server/media.rs
+++ b/src/server/media.rs
@@ -36,14 +36,14 @@ use super::types::ChatCompletionRequest;
 use super::types::request::{InputAudio, VideoUrl};
 
 /// Resolved video request item produced by
-/// [`extract_chat_video_paths_with_allowlist`] (issue #601).
+/// [`extract_chat_video_paths_with_allowlist`].
 ///
 /// Carries:
 /// * the [`VideoSource`] handle that downstream consumers must pass to
 ///   [`crate::multimodal::video::load_video_source`]. The fd-backed variant
 ///   is what closes the TOCTOU race against an attacker swapping the
 ///   resolved file for a symlink between the resolver's `canonicalize`
-///   and ffmpeg's `open` (issue #601);
+///   and ffmpeg's `open`;
 /// * the optional per-video FPS override from
 ///   [`crate::server::types::request::VideoUrl::fps`];
 /// * an optional [`TempFile`] guard that owns the cleanup of any
@@ -88,7 +88,7 @@ impl ResolvedVideo {
     /// request preparation logging. Subprocesses must still consume the
     /// [`VideoSource`] via [`Self::source`], not the path — passing the
     /// path to ffmpeg would re-introduce the canonicalise → ffmpeg-open
-    /// TOCTOU window the fd-based design closed (issue #601).
+    /// TOCTOU window the fd-based design closed.
     #[allow(dead_code)]
     pub(crate) fn canonical_path(&self) -> &Path {
         self.source.canonical_path()
@@ -191,12 +191,12 @@ pub(crate) async fn try_extract_chat_image_data(
 
 /// Environment variable holding the comma-separated list of canonical
 /// directories permitted to be referenced via `file://` URIs and bare local
-/// paths in `video_url` content blocks (issue #596).
+/// paths in `video_url` content blocks.
 ///
 /// Empty or unset = fail-closed: every local-filesystem video reference is
 /// rejected. Operators must opt in explicitly to enable file uploads.
 ///
-/// Issue #601 closed the canonicalise → ffmpeg-open TOCTOU window by
+/// closed the canonicalise → ffmpeg-open TOCTOU window by
 /// passing an opened fd down to ffmpeg. The startup helper
 /// [`scan_insecure_allowlist_dirs`] still flags world- or group-writable
 /// allowlist directories because a writable allowlist directory remains
@@ -205,7 +205,7 @@ pub(crate) async fn try_extract_chat_image_data(
 pub(crate) const VIDEO_DIR_ALLOWLIST_ENV: &str = "MLXCEL_VIDEO_DIR_ALLOWLIST";
 
 /// Resolve `video_url` content blocks from a chat request to opened video
-/// handles (issue #553, wired up in #596, hardened in #601).
+/// handles (wired up, hardened).
 ///
 /// For `file://` and bare local paths the path is canonicalised and
 /// validated against the directory allowlist from
@@ -213,7 +213,7 @@ pub(crate) const VIDEO_DIR_ALLOWLIST_ENV: &str = "MLXCEL_VIDEO_DIR_ALLOWLIST";
 /// and the fd retained** (Unix only). The fd is what subprocesses ultimately
 /// read from — never the path — so the dominant TOCTOU window
 /// (canonicalise → allowlist check → metadata → open) is closed at the
-/// kernel level (issue #601). `O_NOFOLLOW` hardens the narrowed
+/// kernel level. `O_NOFOLLOW` hardens the narrowed
 /// metadata→open window further: a symlink swap that occurs in that
 /// microsecond gap causes the open to return `ELOOP` rather than silently
 /// following the swapped link.
@@ -306,7 +306,7 @@ pub(crate) fn video_dir_allowlist_from_env() -> Vec<PathBuf> {
 /// Used by the server startup hook to surface a `tracing::warn!` when an
 /// operator opts into the video-URL feature with a loose-mode directory.
 /// The resolver in this module canonicalises, stats, and then **opens**
-/// the file (issue #601), passing the fd down to ffmpeg via `/dev/fd/N`,
+/// the file, passing the fd down to ffmpeg via `/dev/fd/N`,
 /// so the canonicalise → ffmpeg-open TOCTOU race is closed at the kernel
 /// level. The startup warning remains as defence-in-depth: a writable
 /// upload directory is still an operator-policy red flag (anyone with
@@ -404,7 +404,7 @@ async fn resolve_video_url(video: &VideoUrl, allowlist: &[PathBuf]) -> Option<Re
 /// [`VideoSource`]. On non-Unix targets the resolver falls back to the
 /// path-only variant.
 ///
-/// This is the heart of the issue #601 TOCTOU fix: the resolver opens the
+/// This is the heart of the TOCTOU fix: the resolver opens the
 /// file once, retains the fd, and surrenders that fd (via `/dev/fd/N`) to
 /// every subsequent ffmpeg/ffprobe invocation. Even if an attacker swaps
 /// the underlying path for a symlink to `/etc/passwd` between this open
@@ -477,9 +477,9 @@ async fn open_video_source(canonical: &Path, original_url: &str) -> Option<Video
 }
 
 /// Resolve a bare local path or the path component of a `file://` URI to a
-/// canonical, allowlisted, regular video file (issue #596).
+/// canonical, allowlisted, regular video file.
 ///
-/// Async-friendly variant (#596 follow-up): uses `tokio::fs::canonicalize` and
+/// Async-friendly variant (follow-up): uses `tokio::fs::canonicalize` and
 /// `tokio::fs::metadata` so a slow disk or NFS mount cannot stall a Tokio
 /// worker thread. Each `.await` boundary lets the runtime schedule other
 /// requests while the lookup is in flight.
@@ -572,7 +572,7 @@ async fn decode_video_data_uri(url: &str) -> Option<(PathBuf, TempFile)> {
 }
 
 /// Fetch a remote video URL with size enforcement applied **incrementally**
-/// (issue #596 hardening).
+/// (hardening).
 ///
 /// Implementation note — buffer-then-check is a DoS vector. `response.bytes()`
 /// would read the entire response body into memory before we could enforce
@@ -657,7 +657,7 @@ fn infer_video_extension(metadata: &str) -> &str {
 /// must remain on disk (e.g., until ffmpeg has finished probing it).
 ///
 /// Returning the guard alongside the path is the fix for the temp-file leak
-/// reported during PR #600 review: every previous version returned a bare
+/// reported during review: every previous version returned a bare
 /// `PathBuf` and relied on no-one to call cleanup explicitly. With the guard
 /// in place a panic, an early-return error path, or a normal completion all
 /// converge on the same cleanup behaviour.

--- a/src/server/media_tests.rs
+++ b/src/server/media_tests.rs
@@ -231,7 +231,7 @@ async fn extract_chat_image_data_collects_images_across_messages() {
     assert_eq!(images, vec![b"hello".to_vec(), b"world".to_vec()]);
 }
 
-// -- Video URL handling (issue #553, security guard issue #596) -------
+// -- Video URL handling (security guard) -------
 
 /// Create a per-test sandbox under `std::env::temp_dir()` and return the
 /// canonicalised path. Returning the canonicalised form mirrors the runtime
@@ -375,7 +375,7 @@ async fn extract_chat_video_paths_rejects_non_video_local_file() {
     fs::remove_dir_all(sandbox).unwrap();
 }
 
-// -- Issue #596: path-traversal / sandbox guard --------------------------
+// -- path-traversal / sandbox guard --------------------------
 
 #[tokio::test]
 async fn extract_chat_video_paths_rejects_when_allowlist_empty() {
@@ -529,7 +529,7 @@ async fn extract_chat_video_paths_accepts_path_inside_allowlist() {
     fs::remove_dir_all(sandbox).unwrap();
 }
 
-// -- New tests for PR #600 review fixes ---------------------------------------
+// -- New tests review fixes ---------------------------------------
 
 /// MEDIUM-1 follow-through: the async refactor of
 /// `extract_chat_video_paths_with_allowlist` must still resolve a happy-path
@@ -689,9 +689,9 @@ fn scan_insecure_allowlist_dirs_flags_world_writable_directory() {
     fs::remove_dir_all(dir).unwrap();
 }
 
-// -- Issue #601: fd-based TOCTOU closure ----------------------------------
+// -- fd-based TOCTOU closure ----------------------------------
 
-/// Issue #601 regression test: the resolver retains a read-only fd on the
+/// regression test: the resolver retains a read-only fd on the
 /// originally-validated file, so an attacker who swaps the path for a
 /// symlink to `/etc/passwd` (or any other out-of-sandbox file) between
 /// resolution and consumption cannot trick the server into reading the
@@ -703,7 +703,7 @@ fn scan_insecure_allowlist_dirs_flags_world_writable_directory() {
 /// read `/etc/passwd`. Because we read from the open file description the
 /// resolver opened *before* the swap, we get the original bytes back.
 ///
-/// This test would FAIL on the pre-#601 path-based resolver: the path
+/// This test would FAIL on the earlier path-based resolver: the path
 /// returned by the resolver is itself the symlink target (after
 /// canonicalize) — opening it after the swap yields `/etc/passwd`. With
 /// the fd-based resolver, we hold the open file description before the
@@ -823,7 +823,7 @@ async fn extract_chat_video_paths_fd_survives_symlink_swap() {
     fs::remove_dir_all(decoy_dir).unwrap();
 }
 
-/// Issue #601: when the file is unlinked between resolution and use, the
+/// when the file is unlinked between resolution and use, the
 /// fd-based path must still surface the originally-validated bytes. This
 /// is the simpler companion to the symlink-swap test — same property,
 /// different attacker move (unlink vs swap).

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -41,7 +41,7 @@ pub(crate) enum ModelRequest {
         /// Raw audio bytes for audio-language models (empty for text/vision-only)
         audio: Vec<Vec<u8>>,
         /// Resolved video items with optional per-video FPS overrides
-        /// (issue #596, hardened in #601). Each entry carries a
+        /// (hardened). Each entry carries a
         /// [`crate::multimodal::video::VideoSource`] handle the worker
         /// passes to [`crate::multimodal::video::load_video_source`]. On
         /// Unix the handle is fd-backed: the resolver opened the file
@@ -105,11 +105,11 @@ pub struct ModelProvider {
     loaded: Arc<AtomicBool>,
     batch_metrics: Arc<BatchMetrics>,
     batch_observability: Arc<BatchObservability>,
-    /// Shared cross-request prompt-prefix KV cache (epic #416 / issue #419).
+    /// Shared cross-request prompt-prefix KV cache.
     /// `None` when the feature is disabled by config.
     prompt_cache: Option<Arc<crate::server::prompt_cache::PromptCacheStore>>,
     /// Bounded wait applied during the decode phase of `drain_generation_events*`
-    /// to detect a hung model worker (issue #548).
+    /// to detect a hung model worker.
     ///
     /// Resolved at startup from the `--timeout` CLI flag via
     /// [`validated_decode_hang_timeout`]. Constructors that do not receive a
@@ -170,7 +170,7 @@ impl ModelProvider {
     }
 
     /// Same as [`Self::new_with_server_config`] but also wires the
-    /// cross-request prompt-prefix KV cache store (epic #416 / issue #419).
+    /// cross-request prompt-prefix KV cache store.
     /// The legacy (`config.no_batch`) worker ignores the store because that
     /// path never calls the batch scheduler that manages the cache.
     pub fn new_with_server_config_and_prompt_cache(
@@ -183,11 +183,11 @@ impl ModelProvider {
     ) -> Result<Self> {
         // Validate `--timeout` once at construction time and stash it on the
         // provider so the same `Duration` is used by every drain loop. Issue
-        // #548: a value of 0 falls back to `DECODE_HANG_TIMEOUT` with a logged
+        // a value of 0 falls back to `DECODE_HANG_TIMEOUT` with a logged
         // warning so an operator typo never silently expires every request.
         let decode_hang_timeout = validated_decode_hang_timeout(config.timeout_seconds);
 
-        // Issue #666: resolve the speculative-decoding dispatch once
+        // resolve the speculative-decoding dispatch once
         // from the `ServerConfig::{draft_model_path, draft_kind,
         // draft_block_size}` fields. The resolution reads the drafter's
         // `config.json` so it must happen on the main thread before we
@@ -211,7 +211,7 @@ impl ModelProvider {
             // be able to observe it via the model provider handle.
             provider.prompt_cache = prompt_cache_store;
             provider.decode_hang_timeout = decode_hang_timeout;
-            // Issue #666: log a warning if the operator asked for
+            // log a warning if the operator asked for
             // speculative decoding but selected `--no-batch`. The legacy
             // sequential worker bypasses the BatchScheduler entirely so
             // the dispatch is inactive on this path.
@@ -246,7 +246,7 @@ impl ModelProvider {
                 prompt_cache_store,
                 config.kv_cache_mode,
                 config.batch_kv_quant,
-                // Issue #603: forward the --max-kv-size cap to the scheduler.
+                // forward the --max-kv-size cap to the scheduler.
                 config.max_kv_size,
                 speculative_dispatch,
                 batch_metrics,
@@ -347,11 +347,11 @@ impl ModelProvider {
     /// `vision_cache_size` maps directly to the `--vision-cache-size` CLI
     /// flag. `0` disables per-image vision feature caching entirely.
     ///
-    /// `lang_bias_config` is the Axis B / Epic #362 (B8) server-wide
+    /// `lang_bias_config` is the Axis B / (B8) server-wide
     /// language-bias configuration. Pass `None` for the baseline bit-exact
     /// path (no sampling changes, no tokenizer-vocab scan).
     ///
-    /// `reasoning_budget` (issue #409) is the server-wide default
+    /// `reasoning_budget` is the server-wide default
     /// thinking-token budget for Qwen3-family models. Pass `None` for
     /// unrestricted reasoning (bit-exact baseline); per-request
     /// `thinking_budget_tokens` still takes precedence.
@@ -390,7 +390,7 @@ impl ModelProvider {
             None,
             mlxcel_core::cache::KVCacheMode::Fp16,
             mlxcel_core::cache::BatchKvQuantConfig::default(),
-            None, // max_kv_size: unbounded (issue #603)
+            None, // max_kv_size: unbounded
             batch_metrics,
             batch_observability,
         )
@@ -399,7 +399,7 @@ impl ModelProvider {
     /// Full constructor variant that also accepts a shared prompt-prefix
     /// KV cache store.
     ///
-    /// Introduced by issue #419. `prompt_cache_store` is `None` when
+    /// Introduced. `prompt_cache_store` is `None` when
     /// [`crate::server::prompt_cache::PromptCacheConfig::enabled`] is
     /// `false`; in that case the feature is a total no-op.
     #[allow(clippy::too_many_arguments)]
@@ -420,13 +420,13 @@ impl ModelProvider {
         prompt_cache_store: Option<Arc<crate::server::prompt_cache::PromptCacheStore>>,
         kv_cache_mode: mlxcel_core::cache::KVCacheMode,
         batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig,
-        // Issue #603: maximum KV cache size for plain (non-sliding) caches.
+        // maximum KV cache size for plain (non-sliding) caches.
         // `None` preserves the legacy unbounded behaviour.
         max_kv_size: Option<usize>,
         batch_metrics: Arc<BatchMetrics>,
         batch_observability: Arc<BatchObservability>,
     ) -> Result<Self> {
-        // Issue #666: backward-compatible wrapper that defaults the
+        // backward-compatible wrapper that defaults the
         // speculative dispatch to `Disabled`. Callers wiring `--draft-model`
         // / `--draft-kind` use the `_with_speculative_dispatch` variant
         // below.
@@ -454,7 +454,7 @@ impl ModelProvider {
         )
     }
 
-    /// Issue #666: variant that also accepts the resolved
+    /// variant that also accepts the resolved
     /// [`crate::server::SpeculativeDispatch`].
     ///
     /// Use this from `new_with_server_config_and_prompt_cache` so the
@@ -514,9 +514,9 @@ impl ModelProvider {
             prompt_cache: prompt_cache_store.clone(),
             kv_cache_mode,
             batch_kv_quant,
-            // Issue #603: cap plain KVCache growth when configured.
+            // cap plain KVCache growth when configured.
             max_kv_size,
-            // Issue #666: forward the resolved speculative dispatch.
+            // forward the resolved speculative dispatch.
             speculative_dispatch,
         };
 
@@ -588,8 +588,8 @@ impl ModelProvider {
             prompt_cache: None,
             kv_cache_mode: mlxcel_core::cache::KVCacheMode::Fp16,
             batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig::default(),
-            max_kv_size: None, // issue #603: unbounded in minimal test path
-            // Issue #666: minimal test path has no drafter; the dispatch
+            max_kv_size: None, // unbounded in minimal test path
+            // minimal test path has no drafter; the dispatch
             // defaults to `Disabled` which short-circuits the scheduler
             // hot path to the classic decode loop.
             speculative_dispatch: crate::server::SpeculativeDispatch::Disabled,
@@ -683,12 +683,12 @@ impl ModelProvider {
     }
 
     /// Generate text with optional images, audio, and videos, returning the
-    /// full result (issue #596).
+    /// full result.
     ///
     /// Server video routes pass `videos` through here once the path-traversal
     /// guard in [`crate::server::media::extract_chat_video_paths`] has cleared
     /// each entry against `MLXCEL_VIDEO_DIR_ALLOWLIST`. Empty `videos` matches
-    /// pre-#596 behavior bit-for-bit.
+    /// earlier behavior bit-for-bit.
     ///
     /// Restricted to `pub(crate)` because the input type [`ResolvedVideo`] is
     /// crate-internal — it carries an [`crate::multimodal::video::VideoSource`]
@@ -813,7 +813,7 @@ impl ModelProvider {
     }
 
     /// Like [`Self::generate_streaming_with_logprobs_cancellable`] but also
-    /// forwards resolved video paths to the worker (issue #596). Empty
+    /// forwards resolved video paths to the worker. Empty
     /// `videos` is bit-exact with the no-video variant.
     ///
     /// `pub(crate)` for the same reason as
@@ -893,7 +893,7 @@ fn send_shutdown_signal(request_tx: &mpsc::Sender<ModelRequest>) -> bool {
 }
 
 /// Default timeout applied after the first generated token has been received
-/// to detect a hung model worker (issue #548).
+/// to detect a hung model worker.
 ///
 /// Once the prefill is complete and decoding has begun, each subsequent decode
 /// step should finish within a bounded wall-clock time. The model worker thread
@@ -921,8 +921,7 @@ pub(crate) const DECODE_HANG_TIMEOUT: Duration = Duration::from_secs(300);
 ///
 /// Returns the configured duration on success. Logs a warning and returns the
 /// fallback ([`DECODE_HANG_TIMEOUT`]) when the value is `0`, which would cause
-/// every request to time out instantly (issue #548 — "invalid timeout config
-/// values produce a clean log message").
+/// every request to time out instantly (— "invalid timeout config values produce a clean log message").
 ///
 /// Used by: `ModelProvider::new_with_server_config_and_prompt_cache` (the only
 /// constructor that receives a `ServerConfig`); other constructors default to
@@ -1007,7 +1006,7 @@ where
 }
 
 /// Core receive loop that distinguishes "prefill still running" from "hung
-/// model" (issue #548).
+/// model".
 ///
 /// Two-phase timeout strategy:
 ///
@@ -1049,7 +1048,7 @@ where
                 Err(mpsc::RecvTimeoutError::Timeout) => {
                     return Err(anyhow::anyhow!(
                         "model worker did not produce a token within {}s after decode started; \
-                         possible hang or crash (issue #548). \
+                         possible hang or crash. \
                          Increase --timeout if this model legitimately takes longer.",
                         decode_hang_timeout.as_secs()
                     ));

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -921,7 +921,7 @@ pub(crate) const DECODE_HANG_TIMEOUT: Duration = Duration::from_secs(300);
 ///
 /// Returns the configured duration on success. Logs a warning and returns the
 /// fallback ([`DECODE_HANG_TIMEOUT`]) when the value is `0`, which would cause
-/// every request to time out instantly (— "invalid timeout config values produce a clean log message").
+/// every request to time out instantly ("invalid timeout config values produce a clean log message").
 ///
 /// Used by: `ModelProvider::new_with_server_config_and_prompt_cache` (the only
 /// constructor that receives a `ServerConfig`); other constructors default to

--- a/src/server/model_provider_tests.rs
+++ b/src/server/model_provider_tests.rs
@@ -112,7 +112,7 @@ fn model_provider_relies_on_auto_traits_for_shared_state() {
     assert_send_sync::<ModelProvider>();
 }
 
-// ── validated_decode_hang_timeout tests (issue #548) ─────────────────────────
+// ── validated_decode_hang_timeout tests ─────────────────────────
 
 /// A non-zero timeout must be returned as-is without any warning.
 #[test]
@@ -132,12 +132,12 @@ fn validated_decode_hang_timeout_uses_fallback_when_timeout_is_zero() {
     assert_eq!(dur, DECODE_HANG_TIMEOUT);
 }
 
-// ── Long-prefill regression tests (issue #548) ───────────────────────────────
+// ── Long-prefill regression tests ───────────────────────────────
 
 /// Verifies that `drain_generation_events_impl` (the private core loop used by
 /// every drain function) does not apply any timeout during the prefill phase
 /// (before the first token arrives). A prompt with 32k tokens may take tens of
-/// seconds to prefill on real hardware; before issue #548 a coarse timeout was
+/// seconds to prefill on real hardware; before a coarse timeout was
 /// applied uniformly across both phases and would prematurely abort such
 /// requests.
 ///
@@ -181,7 +181,7 @@ fn drain_generation_events_impl_survives_long_prefill_before_first_token() {
     // without a timeout. If Phase 1 ever applied this 5 s as a recv_timeout
     // we would still pass — the meaningful regression to catch is a Phase-1
     // bound *shorter* than the 80 ms prefill, which is exactly what the
-    // pre-issue-#548 code did.
+    // pre-issue- code did.
     let mut received_tokens: Vec<String> = Vec::new();
     let mut final_result: Option<GenerationResult> = None;
 
@@ -211,7 +211,7 @@ fn drain_generation_events_impl_survives_long_prefill_before_first_token() {
     assert_eq!(result.finish_reason, "stop");
 }
 
-// ── Phase 2 decode hang regression test (issue #548) ─────────────────────────
+// ── Phase 2 decode hang regression test ─────────────────────────
 
 /// Verifies that `drain_generation_events_impl` correctly detects a Phase 2
 /// (decode phase) hang: once the first token has arrived, any subsequent wait

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -60,14 +60,14 @@ pub(crate) struct WorkerSchedulerConfig {
     /// Maximum number of cached post-projection image features per loaded
     /// VLM. `0` disables caching.
     pub vision_cache_size: usize,
-    /// Axis B Epic #362 (B8): optional server-wide language-bias config.
+    /// Axis B (B8): optional server-wide language-bias config.
     /// Resolved once on the worker thread into a `TokenBiasMap` after the
     /// tokenizer loads, and attached to the batch scheduler for the rest of
     /// the worker's lifetime.
     pub lang_bias_config: Option<mlxcel_core::lang_analyzer::LangBiasConfig>,
-    /// Issue #409: server-wide default thinking-token budget.
+    /// server-wide default thinking-token budget.
     pub reasoning_budget: Option<crate::server::thinking_budget::ThinkingBudget>,
-    /// Epic #416 / issue #419: cross-request prompt-prefix KV cache store.
+    /// cross-request prompt-prefix KV cache store.
     ///
     /// `None` when the feature is disabled by
     /// [`crate::server::prompt_cache::PromptCacheConfig::enabled`]. When
@@ -77,16 +77,16 @@ pub(crate) struct WorkerSchedulerConfig {
     ///
     /// Store handle passed to [`BatchScheduler::with_prompt_cache`] so the
     /// scheduler can adopt detached prefixes on cache hits and donate-back
-    /// finished sequences (epic #416 / issue #421).
+    /// finished sequences.
     pub prompt_cache: Option<Arc<crate::server::prompt_cache::PromptCacheStore>>,
-    /// Issue #484 (B11) / #508: server-wide KV cache quantization mode.
+    /// (B11) / server-wide KV cache quantization mode.
     ///
     /// Defaults to [`mlxcel_core::cache::KVCacheMode::Fp16`] (bit-exact
     /// baseline). When a Turbo4 variant is configured, the scheduler
     /// applies it to each new sequence's per-layer cache and picks the
-    /// Turbo4-aware paged layout (#482).
+    /// Turbo4-aware paged layout.
     pub kv_cache_mode: mlxcel_core::cache::KVCacheMode,
-    /// Issue #545: continuous-batching KV quantization configuration.
+    /// continuous-batching KV quantization configuration.
     ///
     /// When enabled (`bits > 0`), the scheduler resolves per-layer
     /// [`mlxcel_core::cache::KVCacheMode`] values from this config (with
@@ -95,7 +95,7 @@ pub(crate) struct WorkerSchedulerConfig {
     /// Defaults to a disabled config so existing deployments stay
     /// bit-exact.
     pub batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig,
-    /// Issue #603: maximum KV cache size for plain (non-sliding) caches.
+    /// maximum KV cache size for plain (non-sliding) caches.
     ///
     /// When `Some(N)`, the batch scheduler caps each per-sequence plain
     /// `KVCache` to `N` tokens by trimming the oldest entries once
@@ -103,7 +103,7 @@ pub(crate) struct WorkerSchedulerConfig {
     /// window and bypass this cap. `None` (the default) preserves the
     /// legacy unbounded behaviour.
     pub max_kv_size: Option<usize>,
-    /// Issue #666: resolved speculative-decoding dispatch shape.
+    /// resolved speculative-decoding dispatch shape.
     ///
     /// Constructed once at worker construction (or
     /// [`crate::server::SpeculativeDispatch::Disabled`] when the operator
@@ -205,7 +205,7 @@ pub(crate) fn spawn_model_worker_with_batch_config(
             tracing::info!("EOS tokens from config: {:?}", config_eos);
         }
 
-        // Axis B Epic #362 (B8): resolve the server-wide LangBiasConfig once,
+        // Axis B (B8): resolve the server-wide LangBiasConfig once,
         // after the tokenizer is available. Empty bias set or an HF-less
         // tokenizer yields an empty map — bit-exact baseline preserved.
         let token_bias = resolve_worker_token_bias(
@@ -232,7 +232,7 @@ pub(crate) fn spawn_model_worker_with_batch_config(
             } else {
                 "conservative"
             };
-            // Issue #405 — emit byte_fragment_entries only when non-zero so
+            // emit byte_fragment_entries only when non-zero so
             // the existing B9 field shape is preserved for Phase 1 configs.
             let byte_fragment_entries = token_bias.byte_fragment_len();
             if byte_fragment_entries > 0 {
@@ -273,7 +273,7 @@ pub(crate) fn spawn_model_worker_with_batch_config(
         } else {
             String::new()
         };
-        // Issue #666: log the resolved speculative dispatch once at
+        // log the resolved speculative dispatch once at
         // startup. This makes the operator-visible "which path is
         // active" explicit in the worker log without forcing the
         // scheduler to log per request.
@@ -292,26 +292,26 @@ pub(crate) fn spawn_model_worker_with_batch_config(
             sched_config.max_queue_depth,
         );
 
-        // Issue #670 / #674: speculative dispatch is wired end-to-end via
+        // speculative dispatch is wired end-to-end via
         // the burst path in `BatchScheduler::execute_prefill`. With
         // `max_batch_size > 1` the scheduler assembles an
         // equal-prompt-length window of concurrently-queued speculative
         // requests and drives them through the batched round-loop driver
         // (`MtpBatchedGenerator` / `DFlashBatchedGenerator`) in one tick
-        // — true B>1 batched speculative decoding (issue #674). A
+        // — true B>1 batched speculative decoding. A
         // speculative request whose prompt length, `max_tokens`, or
         // sampling config does not match the current window head, or
         // that arrives alone, still runs as a B=1 burst; in that case
         // the burst occupies the worker thread for its full duration and
         // concurrent classic-decode rows head-of-line-block behind it
-        // until it completes. The previous PR-#671 wording described the
-        // B=1-only behaviour; this reflects the #674 batched path.
+        // until it completes. The previous earlier wording described the
+        // B=1-only behaviour; this reflects the batched path.
         if sched_config.speculative_dispatch.is_kind_specific() && sched_config.max_batch_size > 1 {
             tracing::info!(
                 "Speculative decoding active ({}) with max_batch_size={}: \
                  concurrently-queued speculative requests that share a \
                  prompt length, max_tokens, and sampling config are driven \
-                 as a single B>1 batched burst (issue #674). A speculative \
+                 as a single B>1 batched burst. A speculative \
                  request that does not match the current window head, or \
                  that arrives alone, runs as a B=1 burst and head-of-line-\
                  blocks concurrent classic-decode rows for its full \
@@ -322,7 +322,7 @@ pub(crate) fn spawn_model_worker_with_batch_config(
             );
         }
 
-        // Issue #409: resolve the thinking-token id pair once, after the
+        // resolve the thinking-token id pair once, after the
         // tokenizer is loaded. For models without `<think>`/`</think>` tokens
         // (non-thinking models) this returns `None` and the scheduler silently
         // ignores any budget parameter (logging once per model load).
@@ -356,9 +356,9 @@ pub(crate) fn spawn_model_worker_with_batch_config(
         .with_prompt_cache(sched_config.prompt_cache)
         .with_kv_cache_mode(sched_config.kv_cache_mode)
         .with_batch_kv_quant(sched_config.batch_kv_quant)
-        // Issue #603: cap plain KVCache growth to --max-kv-size when set.
+        // cap plain KVCache growth to --max-kv-size when set.
         .with_max_kv_size(sched_config.max_kv_size)
-        // Issue #666: attach the resolved speculative dispatch so the
+        // attach the resolved speculative dispatch so the
         // scheduler can branch per-request once the round-loop dispatch
         // hook is wired in `decode_single_step`.
         .with_speculative_dispatch(sched_config.speculative_dispatch);
@@ -501,7 +501,7 @@ pub(crate) fn spawn_legacy_model_worker(
              (max_batch_size=1, prefill_chunk_size=disabled)"
         );
 
-        // Issue #409: resolve the thinking-token id pair once, after the
+        // resolve the thinking-token id pair once, after the
         // tokenizer is loaded. Mirrors the batched-worker path in
         // `spawn_model_worker_with_batch_config`. For models without
         // `<think>`/`</think>` tokens the helper returns `None` and the
@@ -631,7 +631,7 @@ pub(crate) fn prepare_request_vlm_embeddings(
         return Ok(None);
     }
 
-    // Issue #596: video inputs route to the Gemma 4 video embedding path,
+    // video inputs route to the Gemma 4 video embedding path,
     // mirroring the CLI dispatch in `commands/generate_vlm.rs::compute_vlm_embeddings`.
     // Combining --video with --audio is rejected upstream and at the route
     // layer; this branch additionally surfaces a clear error if those happen
@@ -822,7 +822,7 @@ fn prepare_gemma4_audio_embeddings(
     Ok(Some(embeddings))
 }
 
-/// Resolve `videos` into Gemma 4 video embeddings (issue #596).
+/// Resolve `videos` into Gemma 4 video embeddings.
 ///
 /// Mirrors the CLI's `compute_gemma4_video_embeddings` in
 /// `src/commands/generate_vlm.rs`: probes for ffmpeg, decodes each video into
@@ -867,7 +867,7 @@ fn prepare_request_video_embeddings(
     // Decode each video honoring the per-video FPS override when supplied;
     // otherwise fall back to `multimodal::video::DEFAULT_FPS`.
     //
-    // Issue #601: every `ResolvedVideo` carries a [`VideoSource`] handle —
+    // every `ResolvedVideo` carries a [`VideoSource`] handle
     // on Unix this is fd-backed, so the call to `load_video_source` reads
     // from the open file description the resolver already validated. ffmpeg
     // never re-opens the canonical path, so an attacker cannot win the
@@ -990,7 +990,7 @@ pub(crate) fn build_generation_result(
 /// Build a `GenerationResult` with prompt-prefix cache information.
 ///
 /// `cached_tokens` is the number of leading prompt tokens that were satisfied
-/// by the KV prefix cache (issue #423). Pass `0` for non-cached requests.
+/// by the KV prefix cache. Pass `0` for non-cached requests.
 pub(crate) fn build_generation_result_with_cache(
     text: String,
     prompt_tokens: usize,
@@ -1067,7 +1067,7 @@ impl StreamingDecodeState {
         self.completion_tokens += 1;
         self.all_ids.push(token_id as u32);
 
-        // --- Byte-fallback buffering (issue #547) ---
+        // --- Byte-fallback buffering ---
         // Tokenizers that use byte-fallback (e.g. Gemma variants with
         // `byte_fallback = true`) map each byte of a multi-byte UTF-8
         // character to an individual token in the form `<0xXX>`. When decoded
@@ -1233,7 +1233,7 @@ impl StreamingDecodeState {
     }
 
     /// Like [`finish`] but records how many prompt tokens were served from
-    /// the KV prefix cache (epic #416 / issue #423).
+    /// the KV prefix cache.
     pub(crate) fn finish_with_cache(
         self,
         start: Instant,

--- a/src/server/model_worker_tests.rs
+++ b/src/server/model_worker_tests.rs
@@ -177,7 +177,7 @@ fn parse_byte_fallback_token_rejects_leading_sign() {
     assert_eq!(parse_byte_fallback_token("<0xff>"), Some(0xff));
 }
 
-// ── Byte-fallback streaming regression tests (issue #547) ───────────────────
+// ── Byte-fallback streaming regression tests ───────────────────
 
 /// Helper: simulate streaming a sequence of tokens and collect the emitted
 /// chunks. Returns (chunks, final_text_from_finish).

--- a/src/server/prompt_cache/apc_integration_tests.rs
+++ b/src/server/prompt_cache/apc_integration_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! End-to-end integration tests for Automatic Prefix Caching (APC, #552).
+//! End-to-end integration tests for Automatic Prefix Caching (APC).
 //!
 //! These tests cover behavioural properties spanning multiple modules:
 //!
@@ -64,8 +64,7 @@ fn apc_chains_for_same_tokens_different_images_share_no_block() {
 
     let (key_a, _) = key_with(&tokens, mm_a);
     let (key_b, _) = key_with(&tokens, mm_b);
-    // Whole-prefix bucket digests must also differ (this is the existing
-    // bucket-level guarantee from issue #425).
+    // Whole-prefix bucket digests must also differ (this is the existing bucket-level guarantee).
     assert_ne!(key_a.digest(), key_b.digest());
 
     // Block-hash chain divergence: every single block must differ.

--- a/src/server/prompt_cache/apc_lookup.rs
+++ b/src/server/prompt_cache/apc_lookup.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Automatic Prefix Caching (APC, issue #552) — request-path helpers used by
+//! Automatic Prefix Caching (APC) — request-path helpers used by
 //! [`super::store::PromptCacheStore`].
 //!
 //! The store delegates two pieces of APC-specific logic here so its main file

--- a/src/server/prompt_cache/entry.rs
+++ b/src/server/prompt_cache/entry.rs
@@ -85,7 +85,7 @@ unsafe impl Sync for DetachedHolder {}
 ///   by the LRU / TTL policy).
 /// * `size_bytes` — cached byte footprint at insert time. We snapshot this
 ///   once instead of recomputing on every eviction pass.
-/// * `apc_block_hashes` — Automatic Prefix Caching (APC, issue #552)
+/// * `apc_block_hashes` — Automatic Prefix Caching (APC)
 ///   block-granularity hash chain over `tokens`. Populated only when APC
 ///   is enabled at insert time; `None` otherwise. The chain is computed
 ///   from `tokens`, the configured block size, the configured hash algo,

--- a/src/server/prompt_cache/key.rs
+++ b/src/server/prompt_cache/key.rs
@@ -92,7 +92,7 @@ impl fmt::Display for PromptCacheKeyDigest {
 }
 
 // ---------------------------------------------------------------------------
-// Multimodal digest (issue #425)
+// Multimodal digest
 // ---------------------------------------------------------------------------
 
 /// A 32-byte BLAKE3 digest of the multimodal (image + audio) content present
@@ -242,14 +242,14 @@ pub struct PromptCacheKey<'a> {
     pub model_id: &'a str,
     /// LoRA adapter identifier; `None` for the base model.
     pub lora_id: Option<&'a str>,
-    /// Chat-template signature. Full wiring is #422; for now any stable
+    /// Chat-template signature. Full wiring is; for now any stable
     /// digest of the template + tool-schema inputs is acceptable and will
     /// simply slot into this field.
     pub template_sig: &'a str,
     /// Caller-supplied tenancy / conversation scope. `None` means global.
     pub session_key: Option<&'a str>,
     /// Stable, order-preserving digest of all multimodal (image + audio)
-    /// content resolved from the request messages (issue #425).
+    /// content resolved from the request messages.
     ///
     /// Ensures two requests with the same text but different images produce
     /// different cache keys. Use [`MultimodalDigest::empty()`] for text-only
@@ -330,7 +330,7 @@ impl<'a> PromptCacheKey<'a> {
     ///     lora_id               (len-prefixed utf-8 bytes, empty if None)
     ///     template_sig          (len-prefixed utf-8 bytes)
     ///     session_key           (len-prefixed utf-8 bytes, empty if None)
-    ///     mm_digest             (32 raw bytes from MultimodalDigest, issue #425)
+    ///     mm_digest             (32 raw bytes from MultimodalDigest)
     ///     prefix_len            (u64 little-endian)
     ///     tokens[..prefix_len]  (each token as i32 little-endian)
     /// ```
@@ -338,14 +338,14 @@ impl<'a> PromptCacheKey<'a> {
     /// Length prefixes and the fixed `v2` tag keep the digest resistant to
     /// accidental collisions between fields with overlapping bytes, and make
     /// it safe to extend the schema later (new fields bump the version tag).
-    /// The version changed from `v1` to `v2` when issue #425 added `mm_digest`
+    /// The version changed from `v1` to `v2` when added `mm_digest`
     /// to prevent old v1 buckets from accidentally matching new multimodal keys.
     pub fn digest(&self) -> PromptCacheKeyDigest {
         let mut hasher = blake3::Hasher::new();
 
         // Domain separator so this digest cannot be reused from a different
         // hashing context accidentally.
-        // NOTE: bumped to v2 when mm_digest was added (issue #425) so that
+        // NOTE: bumped to v2 when mm_digest was added so that
         // stale v1 cache entries do not collide with new multimodal-aware keys.
         hasher.update(b"mlxcel:prompt-cache:v2");
 
@@ -360,7 +360,7 @@ impl<'a> PromptCacheKey<'a> {
             self.session_key.map(str::as_bytes).unwrap_or_default(),
         );
 
-        // Multimodal digest (issue #425): 32 raw bytes, already a BLAKE3 hash
+        // Multimodal digest: 32 raw bytes, already a BLAKE3 hash
         // so no length-prefix needed — the fixed size makes it unambiguous.
         hasher.update(self.mm_digest.as_bytes());
 
@@ -382,7 +382,7 @@ fn write_field(hasher: &mut blake3::Hasher, bytes: &[u8]) {
 }
 
 // ---------------------------------------------------------------------------
-// Session-key resolution (issue #422)
+// Session-key resolution
 // ---------------------------------------------------------------------------
 
 /// Sentinel bucket name used when neither a `prompt_cache_key` nor a `user`
@@ -399,7 +399,7 @@ pub const ANONYMOUS_SESSION_SENTINEL: &str = "__mlxcel_anon__";
 /// hints.
 ///
 /// Precedence (first non-empty wins):
-///   1. `prompt_cache_key` — explicit client hint (issue #422 addition).
+///   1. `prompt_cache_key` — explicit client hint (addition).
 ///   2. `user` — OpenAI-standard stable end-user identifier.
 ///   3. [`ANONYMOUS_SESSION_SENTINEL`] — shared fallback bucket.
 ///
@@ -425,7 +425,7 @@ pub fn resolve_session_key<'a>(
 }
 
 // ---------------------------------------------------------------------------
-// Template signature (issue #422)
+// Template signature
 // ---------------------------------------------------------------------------
 
 /// BLAKE3-based stable hash of the chat-template rendering pipeline inputs.
@@ -494,7 +494,7 @@ pub fn template_sig(
     hex
 }
 
-/// Compute a stable digest of the `tools` array (issue #422).
+/// Compute a stable digest of the `tools` array.
 ///
 /// The digest is **order-preserving**: reordering the tools list changes the
 /// output. This is intentional — HuggingFace chat templates iterate tools in

--- a/src/server/prompt_cache/key_tests.rs
+++ b/src/server/prompt_cache/key_tests.rs
@@ -146,7 +146,7 @@ fn token_order_matters() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #422 — session-key resolution
+// session-key resolution
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -188,7 +188,7 @@ fn resolve_session_key_all_empty_returns_sentinel() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #422 — template signature
+// template signature
 // ---------------------------------------------------------------------------
 
 fn sample_tool(name: &str) -> Tool {
@@ -365,7 +365,7 @@ fn template_sig_fits_into_prompt_cache_key() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #425 — multimodal digest
+// multimodal digest
 // ---------------------------------------------------------------------------
 
 /// Fake image bytes for testing — a minimal 1×1 PNG header stub.
@@ -504,7 +504,7 @@ fn hex_representation_of_multimodal_digest_is_64_chars() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #425 — integration: multimodal multi-turn prefix stability
+// integration: multimodal multi-turn prefix stability
 // ---------------------------------------------------------------------------
 
 #[test]

--- a/src/server/prompt_cache/lookup.rs
+++ b/src/server/prompt_cache/lookup.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Two-tier longest-prefix matcher (#420).
+//! Two-tier longest-prefix matcher.
 //!
 //! This module hosts the selection logic invoked by
 //! [`super::store::PromptCacheStore::lookup_longest_prefix`]. The actual
@@ -75,7 +75,7 @@ impl BestCandidate {
 /// * `tokens` — the incoming request's token prefix.
 /// * `min_len` — the minimum number of matching tokens required before
 ///   the candidate is even considered.
-/// * `apc_partial_allowed` — when `true` (issue #580), accept candidates
+/// * `apc_partial_allowed` — when `true`, accept candidates
 ///   whose stored token prefix is **not** fully contained in the request
 ///   (i.e. the request and the entry diverge somewhere inside the entry's
 ///   prefix). The reported `matched` field then carries the actual
@@ -118,7 +118,7 @@ where
         // token prefix is contained in the incoming prompt. If the request
         // diverged before the stored entry ended, adopting that entry would
         // import KV state for tokens the caller did not send — UNLESS APC
-        // partial adoption is enabled (issue #580), in which case the
+        // partial adoption is enabled, in which case the
         // store's caller will clamp the matched length to the longest
         // block-aligned consistent prefix and pass that to the model
         // worker's truncate path.

--- a/src/server/prompt_cache/metrics.rs
+++ b/src/server/prompt_cache/metrics.rs
@@ -14,7 +14,7 @@
 
 //! Pluggable metrics hooks for the prompt prefix cache store.
 //!
-//! Sub-issue #423 is responsible for wiring these hooks into
+//! is responsible for wiring these hooks into
 //! [`super::super::state::BatchMetrics`] / Prometheus counters. Until then a
 //! no-op default is supplied so the store can be constructed without any
 //! explicit metrics dependency (tests, unit benchmarks, etc.).
@@ -67,7 +67,7 @@ pub struct NoopPromptCacheMetrics;
 impl PromptCacheMetrics for NoopPromptCacheMetrics {}
 
 /// Lightweight atomic-counter implementation. Intended for tests and for
-/// ad-hoc diagnostics; #423 will add a real Prometheus-backed implementor.
+/// ad-hoc diagnostics will add a real Prometheus-backed implementor.
 #[derive(Debug, Default)]
 pub struct AtomicPromptCacheMetrics {
     pub inserts: AtomicU64,

--- a/src/server/prompt_cache/mod.rs
+++ b/src/server/prompt_cache/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Cross-request prompt-prefix KV cache (epic #416).
+//! Cross-request prompt-prefix KV cache.
 //!
 //! This module holds the shared, thread-safe store that retains detached
 //! KV caches keyed by `(model_id, lora_id, template_sig, session_key,
@@ -23,14 +23,14 @@
 //!
 //! ## Sub-issues
 //!
-//! * #417 — [`mlxcel_core::cache::DetachedCacheSet`] and the
+//! * — [`mlxcel_core::cache::DetachedCacheSet`] and the
 //!   [`mlxcel_core::cache::CachePool`] detach/adopt API (upstream).
-//! * #419 — this module, PromptCacheStore itself.
-//! * #420 — radix trie inside [`store::PromptCacheStore::lookup_longest_prefix`]
+//! * — this module, PromptCacheStore itself.
+//! * — radix trie inside [`store::PromptCacheStore::lookup_longest_prefix`]
 //!   (via [`trie`]).
-//! * #422 — full `template_sig` wiring.
-//! * #423 — metrics bridge to [`super::state::BatchMetrics`].
-//! * #424 — CLI/env wiring for [`PromptCacheConfig`].
+//! * — full `template_sig` wiring.
+//! * — metrics bridge to [`super::state::BatchMetrics`].
+//! * — CLI/env wiring for [`PromptCacheConfig`].
 //!
 //! Integration: [`super::startup`] constructs a shared `Arc<PromptCacheStore>`
 //! when [`PromptCacheConfig::enabled`] is true and installs it on both

--- a/src/server/prompt_cache/policy.rs
+++ b/src/server/prompt_cache/policy.rs
@@ -25,7 +25,7 @@ use super::block_hash::{ApcHashAlgo, DEFAULT_APC_BLOCK_SIZE};
 
 /// Runtime configuration for the prompt-prefix cache store.
 ///
-/// CLI/env parsing for these fields is tracked in sub-issue #424. Until then
+/// CLI/env parsing for these fields is tracked. Until then
 /// construct an instance via [`PromptCacheConfig::default`] or the explicit
 /// constructor and hand it to [`super::PromptCacheStore::with_config`].
 #[derive(Clone, Debug)]
@@ -49,13 +49,13 @@ pub struct PromptCacheConfig {
     /// to be inserted. Helps avoid polluting the cache with tiny prefixes
     /// that can't really amortize the detach/adopt overhead.
     pub min_prefix_tokens: usize,
-    /// Automatic Prefix Caching (APC) configuration (issue #552).
+    /// Automatic Prefix Caching (APC) configuration.
     ///
     /// APC is an additive, opt-in feature layered on top of the existing
     /// prompt-prefix cache. It computes block-granularity hash chains so
     /// finer-grained KV reuse becomes possible. When [`ApcConfig::enabled`]
     /// is `false` (the default) no extra work is done and behaviour is
-    /// identical to the pre-#552 store.
+    /// identical to the earlier store.
     pub apc: ApcConfig,
 }
 
@@ -174,7 +174,7 @@ impl Default for PromptCacheConfig {
 }
 
 /// Aggregate store statistics, intended for both tests and the metrics
-/// bridge tracked in sub-issue #423.
+/// bridge tracked.
 ///
 /// This is a pure snapshot: values are captured under the store's lock and
 /// returned by value so callers can release the lock immediately.

--- a/src/server/prompt_cache/prefix_matcher_tests.rs
+++ b/src/server/prompt_cache/prefix_matcher_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! #420 — two-tier longest-prefix matcher tests.
+//! two-tier longest-prefix matcher tests.
 //!
 //! Tests that exercise the exact-session vs cross-session fallback
 //! behaviour, the same-session tie-break preference, MRU disambiguation

--- a/src/server/prompt_cache/store.rs
+++ b/src/server/prompt_cache/store.rs
@@ -19,7 +19,7 @@
 //! `Arc<RwLock<Inner>>`: concurrent lookups take a read lock and match
 //! prefixes, while inserts/evictions take an exclusive write lock.
 //!
-//! The two-tier longest-prefix matcher (#420) lives in
+//! The two-tier longest-prefix matcher lives in
 //! [`super::lookup`]; this module wires the matcher into the store's
 //! locking + metrics discipline. See that module and
 //! [`super::trie`] for the lookup algorithm and data structure choice.
@@ -236,7 +236,7 @@ impl PromptCacheStore {
     }
 
     /// Build a store with a caller-supplied configuration and metrics
-    /// implementor. Sub-issue #423 uses this entry point to hand in the
+    /// implementor. uses this entry point to hand in the
     /// Prometheus / `BatchMetrics` bridge.
     pub fn with_metrics(config: PromptCacheConfig, metrics: Arc<dyn PromptCacheMetrics>) -> Self {
         Self {
@@ -342,7 +342,7 @@ impl PromptCacheStore {
     /// entry-count and byte-budget caps. Returns [`InsertError`] if the
     /// store is disabled or if the single entry is too large to ever fit.
     ///
-    /// When Automatic Prefix Caching (APC, issue #552) is enabled on this
+    /// When Automatic Prefix Caching (APC) is enabled on this
     /// store, the entry's APC block-hash chain is computed during insert
     /// from the entry's tokens, the configured block size, the configured
     /// hash algo, and the request's `MultimodalDigest` (carried by `key`).
@@ -389,7 +389,7 @@ impl PromptCacheStore {
             guard.evictions_lru = guard.evictions_lru.saturating_add(1);
         }
 
-        // APC integration (issue #552): when APC is on, fold the block-hash
+        // APC integration: when APC is on, fold the block-hash
         // chain into the entry. The chain is computed against the entry's
         // own token prefix and the request's mm_digest (carried by `key`),
         // so two entries with identical tokens but different multimodal
@@ -455,7 +455,7 @@ impl PromptCacheStore {
     /// Underlying lookup uses the per-`(model, lora, template)` radix
     /// trie from [`super::trie::RadixTrie`]: `O(L)` in the matched depth.
     ///
-    /// When Automatic Prefix Caching (APC, issue #552) is enabled, the
+    /// When Automatic Prefix Caching (APC) is enabled, the
     /// candidate selected by the trie / scan tier is additionally
     /// verified against the request's APC block-hash chain. The chain is
     /// computed from the request's tokens with the same block size, hash
@@ -497,13 +497,13 @@ impl PromptCacheStore {
         let best = {
             let guard = self.inner.read().expect("prompt cache inner lock");
             let min_len = guard.config.min_prefix_tokens;
-            // Issue #580: when APC is on, the trie / scan tiers may surface
+            // when APC is on, the trie / scan tiers may surface
             // candidates whose stored prefix is **not** fully contained in
             // the request. The block-hash discriminator below clamps the
             // resulting `matched` value to the last block boundary where
             // the chains agree. When APC is off, retain the legacy
             // whole-prefix-contained check inside both tiers so the
-            // pre-#580 hot path is bit-exact.
+            // earlier hot path is bit-exact.
             let apc_partial_allowed = guard.config.apc_enabled();
             let trie = match guard.tries.get(&sessionless) {
                 Some(t) => t,
@@ -702,7 +702,7 @@ fn select_best_by_scan(
         }
         // Compute the longest common prefix between the request tokens
         // and the entry's stored tokens. When APC partial adoption is
-        // enabled (issue #580) we surface candidates whose stored prefix
+        // enabled we surface candidates whose stored prefix
         // diverges inside the request — the caller will clamp the
         // matched length to a block boundary via the APC discriminator
         // before adopting. With APC off, the legacy "stored prefix must
@@ -758,7 +758,7 @@ fn select_best_by_scan(
 }
 
 /// Length of the longest common token prefix between `a` and `b`. Used by
-/// the APC partial-adoption scan path (issue #580) so a candidate whose
+/// the APC partial-adoption scan path so a candidate whose
 /// stored prefix diverges inside the request still surfaces with its
 /// actual common-prefix length, ready for the block-hash discriminator
 /// to clamp.

--- a/src/server/prompt_cache/store_tests.rs
+++ b/src/server/prompt_cache/store_tests.rs
@@ -532,7 +532,7 @@ fn clear_drops_everything() {
     assert_eq!(store.bytes(), 0);
 }
 
-// #420-specific two-tier matcher tests live in
+// specific two-tier matcher tests live in
 // `super::prefix_matcher_tests`; keeping them in a sibling test module
 // keeps this file focused on store-level invariants (insert/evict/lookup
 // mechanics) and cleanly below the 500-line code-file limit.

--- a/src/server/request_options.rs
+++ b/src/server/request_options.rs
@@ -42,9 +42,9 @@ pub(crate) struct RequestOptionOverrides {
     pub dry_sequence_breakers: Option<Vec<i32>>,
     pub stop_sequences: Option<Vec<String>>,
     pub priority: RequestPriority,
-    /// Issue #409: per-request thinking-token budget override.
+    /// per-request thinking-token budget override.
     pub reasoning_budget: ReasoningBudgetOverride,
-    /// Issue #409: whether the rendered prompt primes `<think>\n` (true for
+    /// whether the rendered prompt primes `<think>\n` (true for
     /// chat endpoints) vs. takes a free-form prompt (false for raw text
     /// completion endpoints).
     pub thinking_enter_block_on_start: bool,
@@ -94,7 +94,7 @@ pub(crate) fn build_server_generate_options(
         // Default unset; chat routes populate this when the prompt cache
         // store is installed (see `src/server/routes/chat.rs`).
         prompt_cache_ctx: None,
-        // Issue #550: defaults to `None` (unconstrained generation). Routes
+        // defaults to `None` (unconstrained generation). Routes
         // that handle `response_format` populate this after the helper
         // returns — see `chat.rs` and `completions.rs`.
         structured: None,

--- a/src/server/responses_store.rs
+++ b/src/server/responses_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! In-memory store for OpenAI Responses API objects (issue #622).
+//! In-memory store for OpenAI Responses API objects.
 //!
 //! Phase 1 keeps the store entirely in-process: a synchronous
 //! [`std::sync::RwLock`] guards a `HashMap<id, Entry>` with an LRU eviction

--- a/src/server/responses_translator.rs
+++ b/src/server/responses_translator.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Bidirectional translator between the OpenAI Responses API and the
-//! internal chat-completions request/response pipeline (issue #622).
+//! internal chat-completions request/response pipeline.
 //!
 //! ## Inbound
 //!

--- a/src/server/routes/cache.rs
+++ b/src/server/routes/cache.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Prompt-cache observability endpoints (issue #552).
+//! Prompt-cache observability endpoints.
 //!
 //! - `GET /v1/cache/stats` — returns a snapshot of the current cache state
 //!   (entries, byte footprint, hit/miss counters, APC config).
@@ -33,7 +33,7 @@ use crate::server::AppState;
 pub struct CacheStatsResponse {
     /// Whether the prompt-prefix cache is enabled at all.
     pub enabled: bool,
-    /// Whether APC (block-granularity hash chains, issue #552) is active.
+    /// Whether APC (block-granularity hash chains) is active.
     pub apc_enabled: bool,
     /// APC block size in tokens. Always reported even when APC is off so the
     /// configured value is visible.

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -68,7 +68,7 @@ pub(crate) fn structured_error_to_response(err: StructuredOutputError) -> ErrorR
     }
 }
 
-/// Build the per-request prompt-cache context (epic #416 / issue #421).
+/// Build the per-request prompt-cache context.
 ///
 /// Returns `None` when the store is not installed on `state`, signalling to
 /// the scheduler that no cache lookup or donate-back should run for this
@@ -201,7 +201,7 @@ pub async fn chat_completions(
         .into_response();
     }
 
-    // Issue #596: reject `video_url` content blocks early for models that do
+    // reject `video_url` content blocks early for models that do
     // not support video. Detected once at startup from `config.json` and
     // cached on `AppState.media_support`. Returning a 400 keeps the client
     // contract honest — silently dropping video frames would still consume
@@ -247,7 +247,7 @@ pub async fn chat_completions(
         .into_response();
     }
 
-    // Issue #409: validate thinking_budget_tokens early so malformed values
+    // validate thinking_budget_tokens early so malformed values
     // surface as 400 before any generation work begins.
     let effective_max_tokens = request
         .params
@@ -275,7 +275,7 @@ pub async fn chat_completions(
         }
     };
 
-    // Issue #550 + PR #575 H2: build the structured-output constraint up
+    // + H2: build the structured-output constraint up
     // front so any schema validation error surfaces as a 400 before
     // generation work starts. Grammar compilation can be ~hundreds of ms
     // and (worst case, before the size guard) hundreds of MB — running
@@ -340,7 +340,7 @@ async fn non_stream_chat_completion(
     let request_id = format!("chatcmpl-{}", uuid::Uuid::new_v4());
     let model_id = state.display_model_id().to_string();
 
-    // Issue #422: when the prompt-prefix cache is installed, enter the
+    // when the prompt-prefix cache is installed, enter the
     // prefix-stable rendering path so unset preserve_thinking defaults to
     // true. The store is built by startup.rs only when configured, so
     // `state.prompt_cache.is_some()` is the operator-visible flag here.
@@ -369,7 +369,7 @@ async fn non_stream_chat_completion(
     // counting ordinary content tokens as reasoning when the prompt
     // wasn't primed.
     options.thinking_enter_block_on_start = primed_open_thinking;
-    // Issue #550: attach the structured-output constraint built at the
+    // attach the structured-output constraint built at the
     // request boundary so the scheduler runs constrained sampling for this
     // sequence.
     options.structured = structured;
@@ -384,7 +384,7 @@ async fn non_stream_chat_completion(
     }
 
     // Generate (blocking call handled by model provider's worker thread).
-    // Issue #596: forward resolved video paths alongside images and audio.
+    // forward resolved video paths alongside images and audio.
     // For non-video models the route guard above already rejected the
     // request, so `prepared.videos` is always empty here unless the
     // model supports video.
@@ -503,7 +503,7 @@ async fn stream_chat_completion(
 
     let request_id = format!("chatcmpl-{}", uuid::Uuid::new_v4());
     let model_id = state.display_model_id().to_string();
-    // Issue #422: same prompt-cache flag as the non-streaming path so that
+    // same prompt-cache flag as the non-streaming path so that
     // both endpoints default preserve_thinking=true identically when the
     // cache is installed.
     let prompt_cache_enabled = state.prompt_cache.is_some();
@@ -536,7 +536,7 @@ async fn stream_chat_completion(
     // counting ordinary content tokens as reasoning when the prompt
     // wasn't primed.
     options.thinking_enter_block_on_start = primed_open_thinking;
-    // Issue #550: forward the constraint built at the request boundary so
+    // forward the constraint built at the request boundary so
     // streamed generation is also constrained.
     options.structured = structured;
 
@@ -565,7 +565,7 @@ async fn stream_chat_completion(
     };
     let tool_choice = request.tool_choice.clone();
 
-    // Issue #548: sse_channel also returns an SseKeepAlive that sends periodic
+    // sse_channel also returns an SseKeepAlive that sends periodic
     // SSE comment events. This prevents proxy/client idle-timeout disconnects
     // during long prefill phases (32k+ token prompts) where no token event is
     // emitted until the first generated token arrives.
@@ -955,7 +955,7 @@ pub(crate) fn build_generate_options(
             dry_sequence_breakers: params.dry_sequence_breakers.clone(),
             stop_sequences: params.stop.clone(),
             priority: RequestPriority::default(),
-            // Issue #409: the caller (non_stream_chat_completion /
+            // the caller (non_stream_chat_completion /
             // stream_chat_completion) sets `options.reasoning_budget`
             // explicitly after `build_generate_options` returns, so the
             // default here is just a placeholder.
@@ -1076,7 +1076,7 @@ mod tests {
         );
     }
 
-    // -- Issue #596: video_url block detection ---------------------------
+    // -- video_url block detection ---------------------------
 
     use crate::server::types::request::{ImageUrl, VideoUrl};
     use crate::server::types::{ContentPart, Message, MessageContent, Role, SamplingParams};

--- a/src/server/routes/completions.rs
+++ b/src/server/routes/completions.rs
@@ -123,7 +123,7 @@ pub async fn completions(
             .into_response();
     }
 
-    // Issue #409: validate thinking_budget_tokens early.
+    // validate thinking_budget_tokens early.
     let effective_max_tokens = request
         .params
         .max_tokens
@@ -150,7 +150,7 @@ pub async fn completions(
         }
     };
 
-    // Issue #550 + PR #575 H2: build the structured-output constraint up
+    // + H2: build the structured-output constraint up
     // front. Grammar compilation can be slow on adversarial schemas, so
     // we run it on `spawn_blocking` rather than blocking the Tokio
     // runtime thread. Returns `None` when no `response_format` was
@@ -206,13 +206,13 @@ async fn non_stream_completion(
     let mut options = build_generate_options(&request.params, &state.config);
     options.priority = priority;
     options.reasoning_budget = budget_override;
-    // Issue #409: `/v1/completions` takes a raw prompt just like `/completion`;
+    // `/v1/completions` takes a raw prompt just like `/completion`;
     // the request body is not routed through the chat template so the prompt
     // is not primed with `<think>\n`. Override the chat-oriented default from
     // `build_generate_options` so the scheduler waits for the model to emit
     // `<think>` itself before counting reasoning tokens.
     options.thinking_enter_block_on_start = false;
-    // Issue #550: forward structured-output constraint into the worker.
+    // forward structured-output constraint into the worker.
     options.structured = structured;
 
     // In the legacy format, `logprobs` is a number (top-k); 0 means return only
@@ -279,11 +279,11 @@ async fn stream_completion(
     let mut options = build_generate_options(&request.params, &state.config);
     options.priority = priority;
     options.reasoning_budget = budget_override;
-    // Issue #409: see non_stream_completion — raw-text endpoint, no
+    // see non_stream_completion — raw-text endpoint, no
     // `<think>\n` priming, so the scheduler must wait for the model to
     // emit `<think>` itself before counting reasoning tokens.
     options.thinking_enter_block_on_start = false;
-    // Issue #550: forward structured-output constraint into the worker.
+    // forward structured-output constraint into the worker.
     options.structured = structured;
 
     // Extract include_usage before request is moved into the closure
@@ -304,7 +304,7 @@ async fn stream_completion(
         };
     }
 
-    // Issue #548: sse_channel also returns an SseKeepAlive that sends periodic
+    // sse_channel also returns an SseKeepAlive that sends periodic
     // SSE comment events to prevent proxy/client idle-timeout disconnects
     // during long prefill phases.
     let (events, stream, cancelled, keepalive) = sse_channel(100);

--- a/src/server/routes/metrics.rs
+++ b/src/server/routes/metrics.rs
@@ -16,12 +16,12 @@
 //!
 //! This route is read-only and should remain separate from generation policy.
 //! Includes both server-level request counters and batch observability gauges,
-//! plus the pipeline-parallel families added by issue #350:
+//! plus the pipeline-parallel families added by
 //!
 //! - Per-stage utilization and bubble ratio.
 //! - Activation transfer latency histograms (p50/p95/p99 per stage pair).
 //! - KV cache admission rejection counters (labeled by stage + reason).
-//! - Elastic repartition event counters consumed from issue #349's emission
+//! - Elastic repartition event counters consumed's emission
 //!   path.
 
 use std::fmt::Write;
@@ -48,7 +48,7 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
     // B9 — read process-wide lang-bias observability counters.
     let lang_bias_applied = mlxcel_core::lang_bias_applied_total();
     let lang_bias_suppressed = mlxcel_core::lang_bias_tokens_suppressed_total();
-    // Issue #405 — byte-fragment suppression counter. Strict subset of
+    // byte-fragment suppression counter. Strict subset of
     // `lang_bias_suppressed`; tracks suppressions that came from the opt-in
     // byte-fragment classifier so operators can observe over-suppression.
     let lang_bias_byte_fragment = mlxcel_core::lang_bias_byte_fragment_suppressions_total();
@@ -58,7 +58,7 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
     let slots_available = slots_total.saturating_sub(active);
     let queue_depth = state.batch_metrics.queue_depth();
 
-    // Epic #416 / issue #423: prompt-prefix cache Prometheus counters
+    // prompt-prefix cache Prometheus counters
     let pc_hits = state
         .batch_metrics
         .prompt_cache_hits_total
@@ -169,7 +169,7 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
          # HELP mlxcel_lang_bias_tokens_suppressed_total Sampling steps where the pre-bias top-1 token was neg-inf suppressed\n\
          # TYPE mlxcel_lang_bias_tokens_suppressed_total counter\n\
          mlxcel_lang_bias_tokens_suppressed_total {lang_bias_suppressed}\n\
-         # HELP mlxcel_lang_bias_byte_fragment_suppressions_total Suppressions where the neg-inf top-1 token was classified via UTF-8 start-byte (issue #405)\n\
+         # HELP mlxcel_lang_bias_byte_fragment_suppressions_total Suppressions where the neg-inf top-1 token was classified via UTF-8 start-byte\n\
          # TYPE mlxcel_lang_bias_byte_fragment_suppressions_total counter\n\
          mlxcel_lang_bias_byte_fragment_suppressions_total {lang_bias_byte_fragment}\n\
          # HELP mlxcel_prompt_cache_hits_total Successful prompt-prefix cache adoptions\n\
@@ -311,7 +311,7 @@ fn append_pipeline_metrics(body: &mut String, snap: &PipelineObservabilitySnapsh
         );
     }
 
-    // --- Elastic repartition counters (issue #349 emission path) ---
+    // --- Elastic repartition counters (emission path) ---
     let _ = writeln!(
         body,
         "# HELP mlxcel_pp_repartition_events_total Total elastic pipeline repartition events\n\

--- a/src/server/routes/metrics.rs
+++ b/src/server/routes/metrics.rs
@@ -21,7 +21,7 @@
 //! - Per-stage utilization and bubble ratio.
 //! - Activation transfer latency histograms (p50/p95/p99 per stage pair).
 //! - KV cache admission rejection counters (labeled by stage + reason).
-//! - Elastic repartition event counters consumed's emission
+//! - Elastic repartition event counter emission
 //!   path.
 
 use std::fmt::Write;

--- a/src/server/routes/native_completion.rs
+++ b/src/server/routes/native_completion.rs
@@ -43,7 +43,7 @@ pub async fn native_completion(
     headers: HeaderMap,
     Json(request): Json<NativeCompletionRequest>,
 ) -> Response {
-    // Issue #550: the native `/completion` endpoint does not support
+    // the native `/completion` endpoint does not support
     // `response_format`. Reject up front with a clear 400 so the client
     // does not assume their schema was honored — the chat-completions
     // route is the supported path for constrained decoding.
@@ -66,7 +66,7 @@ pub async fn native_completion(
         }
     }
 
-    // Issue #409: validate thinking_budget_tokens early (semantics match
+    // validate thinking_budget_tokens early (semantics match
     // /v1/chat/completions but the cap is checked against n_predict).
     let effective_n_predict = request.n_predict.unwrap_or(state.config.default_max_tokens);
     let raw_budget = pick_budget_alias(
@@ -192,7 +192,7 @@ async fn stream_native_completion(
     options.reasoning_budget = budget_override;
     let prompt = request.prompt.clone();
 
-    // Issue #548: sse_channel also returns an SseKeepAlive for proxy
+    // sse_channel also returns an SseKeepAlive for proxy
     // idle-timeout prevention during long prefill phases.
     let (events, stream, cancelled, keepalive) = sse_channel(100);
     let finish_events = events.clone();
@@ -261,10 +261,10 @@ fn build_native_generate_options(
             dry_sequence_breakers: request.dry_sequence_breakers.clone(),
             stop_sequences: request.stop.clone(),
             priority: RequestPriority::default(),
-            // Issue #409: the caller fills this from the validated request
+            // the caller fills this from the validated request
             // body + server default after `build_native_options` returns.
             reasoning_budget: ReasoningBudgetOverride::default(),
-            // Issue #409: `/completion` takes a raw prompt; the caller is
+            // `/completion` takes a raw prompt; the caller is
             // responsible for priming `<think>` in the prompt if they want
             // in-block counting to start at the first decoded token.
             thinking_enter_block_on_start: false,

--- a/src/server/routes/responses.rs
+++ b/src/server/routes/responses.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! HTTP handlers for the OpenAI Responses API (issue #622).
+//! HTTP handlers for the OpenAI Responses API.
 //!
 //! Phase 1 endpoints:
 //!

--- a/src/server/speculative_dispatch.rs
+++ b/src/server/speculative_dispatch.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Server-side speculative-decoding dispatch resolution (issue #666).
+//! Server-side speculative-decoding dispatch resolution.
 //!
 //! When `mlxcel-server` is started with the `--draft-model` flag (plus the
 //! optional `--draft-kind` / `--draft-block-size` overrides from the
@@ -38,8 +38,7 @@
 //! fields into one of:
 //!
 //! - [`SpeculativeDispatch::Disabled`] — no `--draft-model`; classic decode
-//!   path runs (issue #380's [`crate::SpeculativeGenerator`] is itself NOT
-//!   used by the server today, only by the offline `mlxcel generate` path).
+//!   path runs ('s [`crate::SpeculativeGenerator`] is itself NOT used by the server today, only by the offline `mlxcel generate` path).
 //! - [`SpeculativeDispatch::Classic { .. }`] — `--draft-model` set,
 //!   `--draft-kind` unset, drafter's `config.json::model_type` resolves to
 //!   a kind that the server has not yet wired to its kind-specific round
@@ -252,7 +251,7 @@ impl SpeculativeDispatch {
         // - explicit MTP / DFlash → kind-specific generator
         // - auto-detected MTP / DFlash → kind-specific generator
         //   (the scheduler logs the auto-detect for visibility)
-        // - InternalMtp (peer epic #647) is auto-detected only and falls
+        // - InternalMtp (peer) is auto-detected only and falls
         //   back to the Classic path until it has a server-side round
         //   loop.
         match resolved_kind {

--- a/src/server/speculative_dispatch_tests.rs
+++ b/src/server/speculative_dispatch_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit tests for [`SpeculativeDispatch::resolve`] (issue #666).
+//! Unit tests for [`SpeculativeDispatch::resolve`].
 //!
 //! These tests pin the dispatch matrix without touching the MLX FFI:
 //! every test builds a minimal `ServerConfig` (defaults + selective

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -82,14 +82,14 @@ pub struct ServerStartupConfig {
     // Speculative decoding
     pub draft_model_path: Option<PathBuf>,
     pub draft_max: usize,
-    /// Issue #630: raw `--draft-kind` value. `None` means
+    /// raw `--draft-kind` value. `None` means
     /// "auto-detect from the drafter `config.json::model_type`" when
     /// `draft_model_path` is also supplied. Parsing into
     /// [`mlxcel_core::drafter::DrafterKind`] and reconciliation against
     /// the drafter config happens at the dispatch site via
     /// [`mlxcel_core::drafter::resolve_drafter_kind`].
     pub draft_kind: Option<String>,
-    /// Issue #630: explicit `--draft-block-size` override. `None` means
+    /// explicit `--draft-block-size` override. `None` means
     /// "use the per-kind default" — `4` for MTP, `16` for DFlash. See
     /// [`crate::cli::speculative_args::default_block_size_for_kind`].
     pub draft_block_size: Option<u32>,
@@ -165,7 +165,7 @@ pub struct ServerStartupConfig {
     /// Micro-batch size for in-process pipeline execution.
     pub pp_micro_batch_size: usize,
 
-    // Zero-config multi-machine pipeline bring-up (issue #342).
+    // Zero-config multi-machine pipeline bring-up.
     /// Zero-config coordinator intent: pipeline depth for `mlxcel-server --pp-auto N`.
     pub pp_auto: Option<u32>,
     /// Zero-config peer intent: `mlxcel-server --pp-peer` joins a running cluster.
@@ -212,7 +212,7 @@ pub struct ServerStartupConfig {
     /// Maximum decoder allocation budget passed to `image::Limits`.
     pub max_image_decode_alloc_bytes: u64,
 
-    // Elastic pipeline-parallel repartitioning (issue #349).
+    // Elastic pipeline-parallel repartitioning.
     /// When `true`, the runtime constructs the elastic repartition coordinator
     /// described in `docs_internal/architecture/elastic-pipeline-repartition-
     /// 20260418.md`. Off by default so existing deployments are unaffected.
@@ -226,7 +226,7 @@ pub struct ServerStartupConfig {
     /// same stage.
     pub elastic_pp_cool_down: u64,
 
-    // Observability (issue #350).
+    // Observability.
     /// Port operators requested for `/metrics`. Currently informational —
     /// the endpoint is multiplexed onto `port` because the server has a
     /// single HTTP listener.
@@ -235,12 +235,12 @@ pub struct ServerStartupConfig {
     /// actions. `Some(path)` constructs a `PpTracer`.
     pub debug_pp_trace: Option<PathBuf>,
 
-    /// Axis B Epic #362 (B8): server-wide language-bias configuration
+    /// Axis B (B8): server-wide language-bias configuration
     /// already resolved from CLI flags (B6) or the `LLAMA_ARG_LANG_BIAS`
     /// env-var path (B7). `None` preserves the bit-exact baseline path.
     pub lang_bias_config: Option<mlxcel_core::lang_analyzer::LangBiasConfig>,
 
-    /// Issue #409: server-wide default for the thinking-token budget.
+    /// server-wide default for the thinking-token budget.
     ///
     /// Normalized from the raw `i32` on [`super::ServerStartupInput`] via
     /// [`super::thinking_budget::ThinkingBudget::from_raw_i32`]. `None` means
@@ -251,14 +251,14 @@ pub struct ServerStartupConfig {
     /// to `None` and the budget is silently ignored.
     pub reasoning_budget: Option<super::thinking_budget::ThinkingBudget>,
 
-    /// Issue #410: server-wide default chat-template kwargs.
+    /// server-wide default chat-template kwargs.
     ///
     /// Parsed from the raw JSON string on [`super::ServerStartupInput`] via
     /// [`super::chat_template_kwargs::ChatTemplateKwargs::from_json_str`].
     /// `None` means no server defaults; per-request kwargs may still apply.
     pub chat_template_kwargs: Option<super::chat_template_kwargs::ChatTemplateKwargs>,
 
-    /// Issue #424: resolved prompt-prefix KV cache policy.
+    /// resolved prompt-prefix KV cache policy.
     ///
     /// Built from CLI flags and env vars via
     /// [`super::cli_input::build_prompt_cache_config`] inside
@@ -267,7 +267,7 @@ pub struct ServerStartupConfig {
     /// (enabled, 2 GiB cap, 1024 entries, 3600 s TTL, 32 token min).
     pub prompt_cache: super::prompt_cache::PromptCacheConfig,
 
-    /// Issue #484 (B11): resolved KV cache mode for per-sequence cache
+    /// (B11): resolved KV cache mode for per-sequence cache
     /// construction.
     ///
     /// Resolved from `--cache-type-k`/`--cache-type-v` (split flags,
@@ -280,7 +280,7 @@ pub struct ServerStartupConfig {
     /// Unsupported K/V combinations are rejected at startup.
     pub kv_cache_mode: mlxcel_core::cache::KVCacheMode,
 
-    /// Issue #545: resolved batch KV cache quantization configuration
+    /// resolved batch KV cache quantization configuration
     /// (uniform `mx.quantize` or TurboQuant variant) for the
     /// continuous-batching path.
     ///
@@ -294,7 +294,7 @@ pub struct ServerStartupConfig {
     /// quality on deep models such as gemma-4-31b.
     pub batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig,
 
-    /// Issue #603: maximum KV cache size for plain (non-sliding) KVCache
+    /// maximum KV cache size for plain (non-sliding) KVCache
     /// instances. `None` preserves the legacy unbounded behaviour.
     ///
     /// Resolved from `--max-kv-size` / `LLAMA_ARG_MAX_KV_SIZE`. See the
@@ -302,25 +302,25 @@ pub struct ServerStartupConfig {
     /// semantics.
     pub max_kv_size: Option<usize>,
 
-    /// Issue #622: maximum number of responses kept in the
+    /// maximum number of responses kept in the
     /// [`crate::server::responses_store::ResponsesStore`]. `0` disables
     /// response persistence entirely, in which case `GET /v1/responses/:id`
     /// and `previous_response_id` return 400. Resolved from
     /// `--responses-store-max-entries` / `LLAMA_ARG_RESPONSES_STORE_MAX_ENTRIES`.
     pub responses_store_max_entries: usize,
-    /// Issue #622: TTL (seconds) for in-memory response store entries.
+    /// TTL (seconds) for in-memory response store entries.
     /// `0` disables TTL (entries are evicted only by capacity pressure).
     /// Resolved from `--responses-store-ttl-secs` / `LLAMA_ARG_RESPONSES_STORE_TTL_SECS`.
     pub responses_store_ttl_secs: u64,
-    /// Issue #622: capacity cap for the conversation transcript store.
+    /// capacity cap for the conversation transcript store.
     /// `0` disables the store; requests referencing `conversation` still
     /// succeed but operate as if the transcript is empty.
     pub conversation_store_max_entries: usize,
-    /// Issue #622: TTL (seconds) for conversation transcripts. `0`
+    /// TTL (seconds) for conversation transcripts. `0`
     /// disables TTL.
     pub conversation_store_ttl_secs: u64,
 
-    /// Issue #371 (A4): resolved path to a YAML weight-load surgery
+    /// (A4): resolved path to a YAML weight-load surgery
     /// configuration. `None` keeps the bit-exact baseline load path.
     ///
     /// The path is parsed into a [`mlxcel_surgery::SurgeryPipeline`]
@@ -353,7 +353,7 @@ impl Default for ServerStartupConfig {
             timeout: 600,
             draft_model_path: None,
             draft_max: 16,
-            // Issue #630: speculative-decoding selector defaults.
+            // speculative-decoding selector defaults.
             // `draft_kind = None` means "auto-detect when a drafter is
             // supplied, otherwise inert"; `draft_block_size = None`
             // means "fall back to the per-kind default once the kind
@@ -570,7 +570,7 @@ pub(super) fn resolve_api_key(
 
 /// Walk the directories named in `MLXCEL_VIDEO_DIR_ALLOWLIST` once at
 /// startup and emit a `tracing::warn!` for any entry whose group or world
-/// write bits are set (issue #596 hardening / PR #600 follow-up).
+/// write bits are set (hardening / follow-up).
 ///
 /// Reads the env var via [`super::media::video_dir_allowlist_from_env`]
 /// and delegates the actual permission check to
@@ -578,7 +578,7 @@ pub(super) fn resolve_api_key(
 /// when the env var is empty/unset, so this runs as a no-op for operators
 /// who haven't opted into the feature.
 ///
-/// Issue #601 closed the dominant canonicalise → ffmpeg-open TOCTOU window
+/// closed the dominant canonicalise → ffmpeg-open TOCTOU window
 /// at the kernel level: every file open now uses `O_NOFOLLOW` (so a symlink
 /// swap in the metadata→open gap returns `ELOOP` instead of silently
 /// following the link), and subprocesses receive `/dev/fd/N` rather than a
@@ -600,7 +600,7 @@ pub(super) fn resolve_api_key(
 /// the server up with a loose-mode directory while they fix the
 /// permissions; the resolver itself is safe against the static path
 /// checks (canonicalise + allowlist prefix + regular-file + extension)
-/// and the issue #601 fd-passing + `O_NOFOLLOW` guarantee.
+/// and the fd-passing + `O_NOFOLLOW` guarantee.
 fn warn_on_insecure_video_allowlist() {
     let allowlist = super::media::video_dir_allowlist_from_env();
     if allowlist.is_empty() {
@@ -610,7 +610,7 @@ fn warn_on_insecure_video_allowlist() {
     {
         tracing::warn!(
             "{} is set but the O_NOFOLLOW + fd-passing security layer \
-             (issue #601) is only available on Unix (Linux, macOS). \
+ is only available on Unix (Linux, macOS). \
              On this platform the video resolver falls back to path-only \
              mode, which retains a residual TOCTOU window. Leave \
              MLXCEL_VIDEO_DIR_ALLOWLIST unset on non-Unix deployments.",
@@ -624,7 +624,7 @@ fn warn_on_insecure_video_allowlist() {
             tracing::warn!(
                 "Allowlist directory '{}' is world/group-writable. The dominant \
                  TOCTOU race against video resolution is closed at the kernel level \
-                 by the issue #601 O_NOFOLLOW + fd-passing fix, but a writable \
+                 by the O_NOFOLLOW + fd-passing fix, but a writable \
                  upload directory remains a policy red flag. Restrict permissions \
                  to 0750 or stricter.",
                 dir.display()
@@ -634,7 +634,7 @@ fn warn_on_insecure_video_allowlist() {
 }
 
 /// Inspect the model's `config.json` and decide which media inputs the chat
-/// handler should accept (issue #596).
+/// handler should accept.
 ///
 /// Failure modes are intentionally tolerant: if `config.json` is missing or
 /// the type cannot be determined, the loaded model would have failed earlier
@@ -756,7 +756,7 @@ pub(super) fn build_server_config(
         default_dry_penalty_last_n: resolve_dry_penalty_last_n(startup.dry_penalty_last_n),
         draft_model_path: startup.draft_model_path.clone(),
         num_draft_tokens: startup.draft_max,
-        // Issue #630: forward the speculative-decoding selector flags
+        // forward the speculative-decoding selector flags
         // verbatim. Reconciliation against the drafter `config.json`
         // and dispatch into `MtpGenerator` / `DFlashGenerator` / the
         // classic `SpeculativeGenerator` happens later inside the
@@ -786,13 +786,13 @@ pub(super) fn build_server_config(
         lang_bias_config: startup.lang_bias_config.clone(),
         reasoning_budget: startup.reasoning_budget,
         chat_template_kwargs: startup.chat_template_kwargs.clone(),
-        // Issue #424: wire the CLI/env-resolved policy through instead of
+        // wire the CLI/env-resolved policy through instead of
         // always using the compiled-in default.
         prompt_cache: startup.prompt_cache.clone(),
-        // Issue #484 (B11): wire the resolved KV cache mode through so the
+        // (B11): wire the resolved KV cache mode through so the
         // model worker can apply it when constructing per-sequence generators.
         kv_cache_mode: startup.kv_cache_mode,
-        // Issue #545: wire the resolved batch KV quant config through so
+        // wire the resolved batch KV quant config through so
         // the continuous-batching scheduler can apply per-layer modes
         // (with the last-layer skip) at sequence allocation time.
         batch_kv_quant: startup.batch_kv_quant,
@@ -840,7 +840,7 @@ fn warmup_model(model_provider: &ModelProvider) -> Result<()> {
             priority: crate::server::batch::RequestPriority::Normal,
             logprobs: Default::default(),
             reasoning_budget: Default::default(),
-            // Issue #409: warmup prompt is the raw literal "Hello", not a
+            // warmup prompt is the raw literal "Hello", not a
             // chat-templated prompt with `<think>\n` priming, so treat the
             // first token as not-yet-in-block.
             thinking_enter_block_on_start: false,
@@ -1175,7 +1175,7 @@ fn build_cluster_init_request(startup: &ServerStartupConfig) -> Result<ClusterIn
     })
 }
 
-/// Run the zero-config bring-up path (issue #342): resolve peers (static or
+/// Run the zero-config bring-up path: resolve peers (static or
 /// mDNS broadcast), emit a deterministic cluster TOML, and rewrite the
 /// startup config so the downstream distributed resolution path sees a
 /// normal `distributed_config` + `node_id` tuple.
@@ -1229,7 +1229,7 @@ async fn run_zero_config_bring_up(
         anyhow::ensure!(
             startup.distributed_config.is_some(),
             "--pp-peer currently requires --distributed-config pointing at the coordinator-emitted cluster TOML. \
-             Future work will remove this once the coordinator push-assigns stages (issue #342 follow-up)."
+             Future work will remove this once the coordinator push-assigns stages (follow-up)."
         );
         anyhow::ensure!(
             startup.node_id.is_some(),
@@ -1360,15 +1360,15 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
         max_decode_alloc_bytes: startup.max_image_decode_alloc_bytes,
     });
 
-    // Axis A weight-load surgery (Epic #363, issue #371). Install the
+    // Axis A weight-load surgery. Install the
     // pipeline *before* worker startup so the spawned model loader
     // thread observes it through the active-pipeline snapshot. When
     // `--surgery` is absent this is a no-op and the load path stays
-    // bit-exact with the pre-#371 baseline.
+    // bit-exact with the earlier baseline.
     #[cfg(feature = "surgery")]
     install_surgery_pipeline_for_server(&startup)?;
 
-    // Zero-config multi-machine pipeline bring-up (issue #342). Runs before
+    // Zero-config multi-machine pipeline bring-up. Runs before
     // the tensor-parallel / pipeline-parallel validators so the emitted TOML
     // passes through the existing distributed resolution path unchanged.
     let zero_config_plan = run_zero_config_bring_up(&mut startup).await?;
@@ -1496,7 +1496,7 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     )?;
     let tokenizer = crate::tokenizer::load_tokenizer(&startup.model_path)?;
 
-    // Issue #590: align the chat-template `enable_thinking` Jinja kwarg
+    // align the chat-template `enable_thinking` Jinja kwarg
     // default with upstream `TokenizerWrapper.apply_chat_template`'s
     // `enable_thinking=self.has_thinking` behavior. When the underlying
     // tokenizer recognizes a think marker pair (single-token `<think>` /
@@ -1523,7 +1523,7 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
                 .map(Vec::len)
                 .unwrap_or(0),
             "Tokenizer recognizes a think marker pair; defaulting \
-             chat_template kwarg `enable_thinking=true` (issue #590, \
+             chat_template kwarg `enable_thinking=true` (\
              upstream PR #1114)"
         );
         chat_template.set_default_enable_thinking(true);
@@ -1534,7 +1534,7 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     let batch_metrics = Arc::new(BatchMetrics::new());
     let batch_observability = Arc::new(BatchObservability::new());
 
-    // Issue #552: hybrid SSM / linear-attention models cannot use APC because
+    // hybrid SSM / linear-attention models cannot use APC because
     // their recurrent state cannot be reconstructed from a token-prefix hash.
     // Detect by reading model_type / architectures from config.json and
     // force-disable APC at runtime (the whole-prefix prompt cache is still
@@ -1552,9 +1552,9 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
         config.prompt_cache.apc.enabled = false;
     }
 
-    // Cross-request prompt-prefix KV cache store (epic #416 / issue #419).
+    // Cross-request prompt-prefix KV cache store.
     // Gated on the config flag so a disabled policy reserves zero memory.
-    // Issue #423: wire BatchMetrics into the store so hits/misses/evictions
+    // wire BatchMetrics into the store so hits/misses/evictions
     // are counted and exposed via /metrics.
     let prompt_cache_store = if config.prompt_cache.is_enabled() {
         let cache_metrics = Arc::new(crate::server::state::BatchMetricsCacheAdapter::new(
@@ -1572,7 +1572,7 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
             apc_enabled = config.prompt_cache.apc.enabled,
             apc_block_size = config.prompt_cache.apc.block_size,
             apc_hash = %config.prompt_cache.apc.hash,
-            "Prompt-prefix KV cache store enabled (epic #416 / issue #419 + APC #552)"
+            "Prompt-prefix KV cache store enabled (+ APC)"
         );
         Some(store)
     } else {
@@ -1580,7 +1580,7 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
         None
     };
 
-    // Issue #548: `--timeout` is validated inside `new_with_server_config_and_prompt_cache` and
+    // `--timeout` is validated inside `new_with_server_config_and_prompt_cache` and
     // the resolved `Duration` is stashed on `ModelProvider`, where it flows into the drain loops.
     // A zero value triggers a logged warning and falls back to the 300 s default.
     let model_provider = Arc::new(ModelProvider::new_with_server_config_and_prompt_cache(
@@ -1622,14 +1622,14 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
         Arc::new(crate::distributed::pipeline::PpTracer::new(path.clone()))
     });
 
-    // Issue #596: detect static media-input capabilities once at startup so
+    // detect static media-input capabilities once at startup so
     // the chat handler can short-circuit unsupported requests with a 400.
     let media_support = detect_model_media_support(&startup.model_path);
 
-    // Issue #596 hardening: scan the operator-provided
+    // hardening: scan the operator-provided
     // `MLXCEL_VIDEO_DIR_ALLOWLIST` directories for world/group-writable
     // entries. The technical TOCTOU race (attacker swaps the file between
-    // canonicalize and ffmpeg open) is now closed by issue #601's
+    // canonicalize and ffmpeg open) is now closed's
     // fd-passing fix in `media::extract_chat_video_paths_with_allowlist`,
     // but a loose-mode allowlist directory still violates operator-policy
     // hygiene and can re-enable the race if a future ffmpeg version
@@ -1637,7 +1637,7 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     // defence-in-depth.
     warn_on_insecure_video_allowlist();
 
-    // Issue #622: build the Responses-API stores from the resolved limits.
+    // build the Responses-API stores from the resolved limits.
     // `max_entries = 0` disables the store entirely; otherwise build with
     // the configured TTL (a TTL of 0 means "no TTL" which we map to a
     // very large duration so the sweep is a no-op).

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -796,7 +796,7 @@ pub(super) fn build_server_config(
         // the continuous-batching scheduler can apply per-layer modes
         // (with the last-layer skip) at sequence allocation time.
         batch_kv_quant: startup.batch_kv_quant,
-        // Issue #57/#603: forward the resolved per-slot context cap (optionally
+        // Issue #57: forward the resolved per-slot context cap (optionally
         // tightened by `--max-kv-size`) so the scheduler can apply a head-trim
         // policy to plain `KVCache` instances. `None` means no explicit
         // context or max-KV bound was configured.

--- a/src/server/startup_tests.rs
+++ b/src/server/startup_tests.rs
@@ -27,7 +27,7 @@ use crate::server::chat_template::ChatMessage;
 use crate::server::media::scan_insecure_allowlist_dirs;
 use crate::server::{DecodeStorageBackend, PipelineParallelRuntimeConfig};
 // Env-var-sensitive tests must serialize through the crate-wide `ENV_LOCK`
-// (issue #573); per-module locks race with env mutations in unrelated
+// per-module locks race with env mutations in unrelated
 // modules of the same test binary.
 use crate::test_support::env_lock::env_lock;
 
@@ -979,7 +979,7 @@ fn validate_tensor_parallel_startup_accepts_gemma4_multi_rank_runtime() {
 }
 
 // -------------------------------------------------------------------------
-// Issue #424 — prompt-cache startup integration tests
+// prompt-cache startup integration tests
 // -------------------------------------------------------------------------
 
 /// `build_server_config` with `enabled=false` produces a `ServerConfig`
@@ -1033,7 +1033,7 @@ fn build_server_config_propagates_prompt_cache_capacity() {
     assert_eq!(config.prompt_cache.capacity_bytes, CUSTOM_CAP);
 }
 
-// -- Issue #596: detect_model_media_support ----------------------------------
+// -- detect_model_media_support ----------------------------------
 
 /// `detect_model_media_support` reports `video=true` only when the
 /// `config.json` resolves to a Gemma 4 VLM. Other VLM types (e.g. plain
@@ -1103,7 +1103,7 @@ fn detect_model_media_support_text_only_disables_video() {
     std::fs::remove_dir_all(dir).unwrap();
 }
 
-// -- PR #600 review (MEDIUM-2): startup TOCTOU writability scan --------------
+// -- review (MEDIUM-2): startup TOCTOU writability scan --------------
 
 /// Unix-only: `scan_insecure_allowlist_dirs` reports a world-writable
 /// directory so the server's startup hook can warn the operator. The

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -87,7 +87,7 @@ pub struct BatchMetrics {
     /// Cumulative number of preemptive evictions.
     pub preemptions_total: AtomicU64,
 
-    // -- Epic #416 / issue #423: prompt-prefix cache Prometheus counters --
+    // -- prompt-prefix cache Prometheus counters --
     /// Cumulative successful prompt-cache adoptions (hits). Incremented by the
     /// scheduler's `try_adopt_cached_prefix` when an entry is adopted.
     pub prompt_cache_hits_total: AtomicU64,
@@ -168,7 +168,7 @@ impl BatchMetrics {
         self.preemptions_total.fetch_add(1, Ordering::Relaxed);
     }
 
-    // -- Prompt-prefix cache helpers (epic #416 / issue #423) --
+    // -- Prompt-prefix cache helpers --
 
     /// Record a prompt-cache hit and the number of tokens that were reused.
     ///
@@ -265,7 +265,7 @@ impl PromptCacheMetrics for BatchMetricsCacheAdapter {
 }
 
 /// Static media-input capability flags resolved once at server startup
-/// (issue #596). Used by HTTP handlers to short-circuit unsupported requests
+/// Used by HTTP handlers to short-circuit unsupported requests
 /// with a clear 400 before reaching the model worker.
 ///
 /// The flags reflect the model type detected from `config.json`, not the
@@ -289,7 +289,7 @@ pub struct AppState {
     pub tokenizer: Arc<MlxcelTokenizer>,
     /// Model directory path (for props/info).
     pub model_path: PathBuf,
-    /// Static media-input capability flags resolved once at startup (issue #596).
+    /// Static media-input capability flags resolved once at startup.
     pub media_support: ModelMediaSupport,
     /// Batch-level metrics (active sequences, queue depth) for admission
     /// control and status reporting.
@@ -298,24 +298,24 @@ pub struct AppState {
     pub batch_observability: Arc<BatchObservability>,
     /// Server metrics (request counts, token throughput).
     pub metrics: Arc<Metrics>,
-    /// Pipeline-parallel observability aggregator (issue #350). Always
+    /// Pipeline-parallel observability aggregator. Always
     /// present even on non-PP deployments — counters stay at zero.
     pub pp_observability: Arc<PipelineObservability>,
-    /// Optional chrome-tracing writer (issue #350, `--debug-pp-trace`).
+    /// Optional chrome-tracing writer (`--debug-pp-trace`).
     /// `None` when tracing is disabled.
     pub pp_tracer: Option<Arc<PpTracer>>,
-    /// Cross-request prompt-prefix KV cache (epic #416 / issue #419). `None`
+    /// Cross-request prompt-prefix KV cache. `None`
     /// when the feature is disabled via [`super::config::ServerConfig::prompt_cache`].
     /// The store is shared with [`ModelProvider`] so the worker thread can
     /// publish and adopt detached caches. HTTP handlers may only call
     /// read-only observation methods on this store.
     pub prompt_cache: Option<Arc<PromptCacheStore>>,
-    /// Issue #622: in-memory store backing `POST /v1/responses` with
+    /// in-memory store backing `POST /v1/responses` with
     /// `store=true`, `GET /v1/responses/:id`, and `previous_response_id`
     /// chaining. `None` when the operator passed
     /// `--responses-store-max-entries 0`.
     pub responses_store: Option<Arc<ResponsesStore>>,
-    /// Issue #622: in-memory conversation transcripts referenced by the
+    /// in-memory conversation transcripts referenced by the
     /// `conversation` field in Responses-API requests. `None` when the
     /// store is disabled.
     pub conversation_store: Option<Arc<ConversationStore>>,
@@ -382,7 +382,7 @@ impl AppState {
 
     /// Override the static media-support flags resolved at startup. Used by
     /// the startup pipeline to record whether the loaded model supports
-    /// `video_url` content blocks (issue #596).
+    /// `video_url` content blocks.
     #[must_use]
     pub fn with_media_support(mut self, support: ModelMediaSupport) -> Self {
         self.media_support = support;
@@ -398,7 +398,7 @@ impl AppState {
         self
     }
 
-    /// Attach the Responses-API in-memory response store (issue #622).
+    /// Attach the Responses-API in-memory response store.
     /// Pass `None` to disable response persistence (and reject any request
     /// that depends on it: `GET /v1/responses/:id`, `previous_response_id`).
     #[must_use]
@@ -407,7 +407,7 @@ impl AppState {
         self
     }
 
-    /// Attach the Responses-API conversation store (issue #622). Pass
+    /// Attach the Responses-API conversation store. Pass
     /// `None` to disable; requests referencing `conversation` will still
     /// be accepted but will not be replayed against the missing transcript.
     #[must_use]

--- a/src/server/state_tests.rs
+++ b/src/server/state_tests.rs
@@ -112,7 +112,7 @@ fn admission_control_rejects_when_queue_at_or_above_limit() {
 }
 
 // ------------------------------------------------------------------
-// Prompt-prefix cache integration (issue #419)
+// Prompt-prefix cache integration
 // ------------------------------------------------------------------
 
 /// `PromptCacheConfig` is wired onto `ServerConfig` with a sensible default
@@ -150,7 +150,7 @@ fn prompt_cache_store_is_send_sync_via_arc() {
 }
 
 // ------------------------------------------------------------------
-// Prompt-cache BatchMetrics counters (issue #423)
+// Prompt-cache BatchMetrics counters
 // ------------------------------------------------------------------
 
 #[test]

--- a/src/server/streaming.rs
+++ b/src/server/streaming.rs
@@ -111,7 +111,7 @@ pub(crate) struct BlockingSseSender {
 /// The `keepalive` value must be attached to the `Sse` response via
 /// `Sse::new(stream).keep_alive(keepalive.0)` in the route handler. This
 /// ensures proxy idle timeouts do not close the connection during long prefill
-/// phases before the first generated token arrives (issue #548).
+/// phases before the first generated token arrives.
 ///
 /// Used by: chat.rs, completions.rs, native_completion.rs
 pub(crate) fn sse_channel(

--- a/src/server/streaming_responses.rs
+++ b/src/server/streaming_responses.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! SSE encoder for the OpenAI Responses API (issue #622).
+//! SSE encoder for the OpenAI Responses API.
 //!
 //! Unlike `/v1/chat/completions` — which sends a single chat-completion-chunk
 //! shape on every `data:` line — the Responses API uses typed SSE events:

--- a/src/server/streaming_tests.rs
+++ b/src/server/streaming_tests.rs
@@ -194,7 +194,7 @@ fn completion_usage_chunk_has_empty_choices_and_populated_usage() {
     assert_eq!(json["usage"]["total_tokens"], 20);
 }
 
-// ── Cache-aware usage chunk tests (issue #423) ───────────────────────────────
+// ── Cache-aware usage chunk tests ───────────────────────────────
 
 /// `usage_with_cache` with `cache_enabled=true` must include
 /// `prompt_tokens_details.cached_tokens` in the final chunk.
@@ -296,7 +296,7 @@ fn sender_without_cancellation_token_does_not_panic_on_dropped_receiver() {
     sender.text("hello");
 }
 
-// ── Long-prefill keepalive regression tests (issue #548) ────────────────────
+// ── Long-prefill keepalive regression tests ────────────────────
 
 /// The SSE keepalive interval must be less than typical proxy idle timeouts
 /// (nginx 60 s, HAProxy 60 s, AWS ALB 60 s) so that long-prefill requests
@@ -314,7 +314,7 @@ const _: () = assert!(
 /// channel must remain open and operational. This test exercises the token
 /// queue flow without a real model: the sender holds the channel open while
 /// a background thread simulates the prefill delay before sending the first
-/// token. The receiver must not error out during the wait (issue #548).
+/// token. The receiver must not error out during the wait.
 #[test]
 fn long_prefill_channel_stays_open_before_first_token() {
     use std::thread;
@@ -356,7 +356,7 @@ fn long_prefill_channel_stays_open_before_first_token() {
 }
 
 // TODO: add a test that verifies the SSE keepalive comment frame is emitted
-// before the first event arrives (issue #548 LOW #2). This requires an axum
+// before the first event arrives (LOW #2). This requires an axum
 // integration test harness to drive `Sse::new(stream).keep_alive(...)` end-to-end
 // and read raw SSE frames from the response body. The existing unit-level
 // `payload_channel` tests cannot reach the axum `KeepAlive` layer. A suitable

--- a/src/server/structured.rs
+++ b/src/server/structured.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Issue #550: OpenAI-compatible `response_format: {"type": "json_schema", ...}`
+//! OpenAI-compatible `response_format: {"type": "json_schema",...}`
 //! support via constrained decoding.
 //!
 //! Mirrors the upstream mlx-vlm PR #1047 design but in pure Rust:
@@ -74,8 +74,7 @@ use crate::tokenizer::MlxcelTokenizer;
 
 /// Maximum serialized size (UTF-8 bytes) for a user-supplied JSON schema.
 ///
-/// 64 KiB is generous for hand-written schemas (the OpenAI examples that
-/// motivated issue #550 are all under 4 KiB) but small enough that an
+/// 64 KiB is generous for hand-written schemas (the OpenAI examples that motivated are all under 4 KiB) but small enough that an
 /// attacker cannot use the schema as a payload-size amplification vector
 /// against the grammar compiler.
 pub(crate) const MAX_SCHEMA_BYTES: usize = 64 * 1024;
@@ -136,7 +135,7 @@ pub enum StructuredOutputError {
 
     /// The active tokenizer is incompatible with `llguidance`. mlxcel's
     /// SentencePiece and Tiktoken backends do not yet expose a byte-level
-    /// vocabulary that `llguidance` can drive (issue #550 MVP scope).
+    /// vocabulary that `llguidance` can drive (MVP scope).
     #[error("tokenizer backend not supported for structured outputs: {0}")]
     UnsupportedTokenizer(String),
 
@@ -277,7 +276,7 @@ fn resolve_tok_env(serialized_bytes: &[u8]) -> Result<(TokenizerFingerprint, Tok
 // Per-request constraint
 // ---------------------------------------------------------------------------
 
-/// Per-request constrained-decoding state (issue #550).
+/// Per-request constrained-decoding state.
 ///
 /// One [`StructuredOutputConstraint`] is built per HTTP request that supplies
 /// a `response_format: {"type": "json_schema", ...}`. The scheduler keeps it
@@ -663,7 +662,7 @@ pub fn extract_json_schema_from_response_format(
         }
         "json_object" => Err(StructuredOutputError::InvalidRequest(
             "response_format type \"json_object\" is not supported; supply \
-             type=\"json_schema\" with a schema (issue #550)"
+             type=\"json_schema\" with a schema"
                 .to_string(),
         )),
         other => Err(StructuredOutputError::InvalidRequest(format!(

--- a/src/server/structured_tests.rs
+++ b/src/server/structured_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Tests for issue #550 structured-output preparation.
+//! Tests structured-output preparation.
 //!
 //! These tests focus on the request-shape parser and the basic Matcher
 //! lifecycle — they intentionally avoid running real model inference so they

--- a/src/server/thinking_budget.rs
+++ b/src/server/thinking_budget.rs
@@ -443,7 +443,7 @@ pub enum ThinkingDecision {
 mod tests {
     use super::*;
     // Env-var fallback tests must serialize through the crate-wide
-    // `ENV_LOCK` (issue #573); per-module locks race with env mutations
+    // `ENV_LOCK`; per-module locks race with env mutations
     // in unrelated modules of the same test binary.
     use crate::test_support::env_lock::env_lock;
 

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -403,7 +403,7 @@ mod tests {
         assert_eq!(result, "final");
     }
 
-    // -- Gemma 4 full-path parse tests (issue #311) --
+    // -- Gemma 4 full-path parse tests --
 
     #[test]
     fn gemma4_thinking_only() {

--- a/src/server/tool_calls/stream_filter.rs
+++ b/src/server/tool_calls/stream_filter.rs
@@ -197,7 +197,7 @@ enum DelimiterAction {
 ///   It is placed after the `<tag>` families so angle-bracket markers still
 ///   benefit from the tighter (shorter) partial-match window that `<` gives.
 ///
-/// TODO (#444): Consider extracting this into a startup-time configurable
+/// TODO: Consider extracting this into a startup-time configurable
 /// owned by the model worker so new reasoning families don't require a rebuild.
 const CHAT_DELIMITERS: &[(&str, DelimiterAction)] = &[
     // Qwen-style reasoning (Qwen3.x, Exaone4, Hunyuan, GLM4, Nemotron-H, SmolLM3, …)
@@ -214,7 +214,7 @@ const CHAT_DELIMITERS: &[(&str, DelimiterAction)] = &[
     ("<|think|>", DelimiterAction::Strip),
     ("<|turn>", DelimiterAction::Strip),
     ("<turn|>", DelimiterAction::Strip),
-    // Hermes / Qwen / DeepSeek tool call markers (issue #551).
+    // Hermes / Qwen / DeepSeek tool call markers.
     // Exit before enter so the closer is matched when both appear in one fragment.
     ("</tool_call>", DelimiterAction::ExitToolCall),
     ("<tool_call>", DelimiterAction::EnterToolCall),
@@ -862,7 +862,7 @@ mod tests {
         assert!(flushed.reasoning.is_none());
     }
 
-    // -- Qwen-style <think> / </think> reasoning (issue #444) --
+    // -- Qwen-style <think> / </think> reasoning --
 
     #[test]
     fn qwen_think_full_chunk() {
@@ -955,7 +955,7 @@ mod tests {
         assert_eq!(total_content, "content");
     }
 
-    // -- Gemma 4 regression guard (issue #444) --
+    // -- Gemma 4 regression guard --
 
     #[test]
     fn gemma4_regression_channel_reasoning_and_content() {
@@ -971,7 +971,7 @@ mod tests {
         assert!(!out.content.as_deref().unwrap_or("").contains("<channel|>"));
     }
 
-    // -- Hermes / Qwen / DeepSeek tool-call markup suppression (issue #551) --
+    // -- Hermes / Qwen / DeepSeek tool-call markup suppression --
 
     #[test]
     fn hermes_tool_call_only_suppressed() {
@@ -1109,7 +1109,7 @@ mod tests {
         );
     }
 
-    // -- Regression: Gemma 4 tool-call markers must not be confused with Hermes (issue #551) --
+    // -- Regression: Gemma 4 tool-call markers must not be confused with Hermes --
 
     #[test]
     fn gemma4_tool_call_not_confused_with_hermes() {
@@ -1192,7 +1192,7 @@ mod tests {
         );
     }
 
-    // -- Mistral Nemo `[TOOL_CALLS]` suppression (issue #551) --
+    // -- Mistral Nemo `[TOOL_CALLS]` suppression --
 
     #[test]
     fn mistral_nemo_tool_calls_marker_suppressed() {
@@ -1246,7 +1246,7 @@ mod tests {
         );
     }
 
-    // -- Token-position preservation for parallel tool calls (issue #592) --
+    // -- Token-position preservation for parallel tool calls --
     //
     // Upstream mlx-lm PR #1170 (commit aa4f880) fixed `_process_control_tokens`
     // so that matched tokens are re-emitted with `text=""` instead of being
@@ -1416,7 +1416,7 @@ mod tests {
     // bytes contributed to the matched delimiter — **not** merely 1 per
     // delimiter match.
     //
-    // This is the HIGH-1 fix from PR #615 review: the old code did
+    // This is the HIGH-1 fix review: the old code did
     // `suppressed_positions += 1` per match, which under-counted for
     // multi-token delimiters. The new code tracks per-fragment byte lengths
     // and counts how many fragments were consumed by each match.

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -150,7 +150,7 @@ pub enum ContentPart {
     /// and `http(s)` URLs)
     #[serde(rename = "image_url")]
     ImageUrl { image_url: ImageUrl },
-    /// Video URL content for VLMs that support video inputs (issue #553).
+    /// Video URL content for VLMs that support video inputs.
     /// Mirrors the `image_url` shape for symmetry. Accepts local paths,
     /// `file://...`, and (where the model supports it) `http(s)://...`.
     /// Frame extraction relies on `ffmpeg` being available on the server
@@ -171,7 +171,7 @@ pub struct ImageUrl {
     pub url: String,
 }
 
-/// Video URL reference (issue #553). Same wire shape as [`ImageUrl`] for
+/// Video URL reference. Same wire shape as [`ImageUrl`] for
 /// symmetry with the OpenAI vision content blocks.
 ///
 /// `fps` is an optional sampling rate. When omitted, the server falls
@@ -254,7 +254,7 @@ impl MessageContent {
         }
     }
 
-    /// Extract video URL references from multimodal content (issue #553).
+    /// Extract video URL references from multimodal content.
     pub fn video_urls(&self) -> Vec<VideoUrl> {
         match self {
             MessageContent::Text(_) => Vec::new(),
@@ -371,7 +371,7 @@ pub struct SamplingParams {
     /// Presence penalty (0.0 = disabled) - penalizes based on presence
     pub presence_penalty: Option<f32>,
 
-    // Issue #409: thinking-token budget (Qwen3-family reasoning cap).
+    // thinking-token budget (Qwen3-family reasoning cap).
     //
     // Three aliases accepted, first non-None wins (see
     // `thinking_budget::pick_budget_alias`). llama.cpp-compatible primary
@@ -425,7 +425,7 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub parallel_tool_calls: Option<bool>,
 
-    /// Issue #410: top-level `chat_template_kwargs` (llama.cpp shape).
+    /// top-level `chat_template_kwargs` (llama.cpp shape).
     ///
     /// A JSON object whose keys are forwarded as Jinja template kwargs when
     /// rendering the conversation. Primary shape; wins over nested
@@ -436,7 +436,7 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub chat_template_kwargs: Option<serde_json::Map<String, serde_json::Value>>,
 
-    /// Issue #410: nested `extra_body` compatibility (vLLM / manual callers).
+    /// nested `extra_body` compatibility (vLLM / manual callers).
     ///
     /// Some callers send an actual top-level `extra_body` object. Only the
     /// keys we currently recognize are read back out; unknown keys are
@@ -444,7 +444,7 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub extra_body: Option<serde_json::Map<String, serde_json::Value>>,
 
-    /// Issue #422: OpenAI-compatible prompt-cache key hint.
+    /// OpenAI-compatible prompt-cache key hint.
     ///
     /// Clients can send this to pin a conversation to a specific prompt-cache
     /// session bucket. When present it wins over the standard OpenAI `user`
@@ -460,7 +460,7 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub prompt_cache_key: Option<String>,
 
-    /// OpenAI-standard stable end-user identifier (issue #422).
+    /// OpenAI-standard stable end-user identifier.
     ///
     /// Used as a session-bucket fallback for the prompt-prefix cache when
     /// `prompt_cache_key` is not supplied. See
@@ -471,7 +471,7 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub user: Option<String>,
 
-    /// Issue #410: OpenAI SDK `extra_body={...}` flattened into the request root.
+    /// OpenAI SDK `extra_body={...}` flattened into the request root.
     ///
     /// The official OpenAI Python client merges `extra_body` into the top-level
     /// JSON object instead of emitting a nested `"extra_body": {...}` wrapper.
@@ -480,7 +480,7 @@ pub struct ChatCompletionRequest {
     #[serde(default, flatten)]
     pub extra_body_fields: serde_json::Map<String, serde_json::Value>,
 
-    /// Issue #550: OpenAI-compatible structured-output spec.
+    /// OpenAI-compatible structured-output spec.
     ///
     /// Accepts the OpenAI Chat Completions shape:
     ///
@@ -525,7 +525,7 @@ pub struct CompletionRequest {
     /// Number of top log-probability alternatives to return (legacy format: 0–5)
     #[serde(default)]
     pub logprobs: Option<u8>,
-    /// Issue #550: OpenAI-compatible structured-output spec; see the
+    /// OpenAI-compatible structured-output spec; see the
     /// matching field on [`ChatCompletionRequest`] for shape details.
     #[serde(default)]
     pub response_format: Option<serde_json::Value>,
@@ -554,7 +554,7 @@ impl ChatCompletionRequest {
         }
     }
 
-    /// Resolve the request-level `prompt_cache_key` (issue #422).
+    /// Resolve the request-level `prompt_cache_key`.
     ///
     /// Precedence (first non-empty wins):
     ///   1. Top-level `prompt_cache_key`.
@@ -588,7 +588,7 @@ impl ChatCompletionRequest {
         None
     }
 
-    /// Resolve the request-level OpenAI-standard `user` identifier (#422).
+    /// Resolve the request-level OpenAI-standard `user` identifier.
     ///
     /// Same precedence rules as [`Self::resolve_prompt_cache_key`]: top-level
     /// field, then flattened `extra_body`, then nested `extra_body`. Empty
@@ -656,7 +656,7 @@ impl ChatCompletionRequest {
             .collect()
     }
 
-    /// Extract all video URL references from messages (issue #553).
+    /// Extract all video URL references from messages.
     pub fn video_urls(&self) -> Vec<VideoUrl> {
         self.messages
             .iter()
@@ -705,7 +705,7 @@ pub struct NativeCompletionRequest {
     /// DRY sequence breaker token IDs
     pub dry_sequence_breakers: Option<Vec<i32>>,
 
-    // Issue #409: thinking-token budget (Qwen3-family reasoning cap).
+    // thinking-token budget (Qwen3-family reasoning cap).
     /// Primary / llama.cpp-compatible name for the reasoning-token cap.
     pub thinking_budget_tokens: Option<i32>,
     /// vLLM-compatible alias for `thinking_budget_tokens`.
@@ -713,7 +713,7 @@ pub struct NativeCompletionRequest {
     /// Qwen-official alias for `thinking_budget_tokens`.
     pub thinking_budget: Option<i32>,
 
-    /// Issue #550: structured-output `response_format` is **not** supported
+    /// structured-output `response_format` is **not** supported
     /// on the native llama-server `/completion` endpoint. The field is
     /// captured here only so the route can reject the request with a clear
     /// 400 instead of silently ignoring the schema and emitting

--- a/src/server/types/response.rs
+++ b/src/server/types/response.rs
@@ -516,7 +516,7 @@ pub struct SlotInfo {
 mod tests {
     use super::*;
 
-    // -- Usage serialization (issue #423) ------------------------------------
+    // -- Usage serialization ------------------------------------
 
     /// When `prompt_tokens_details` is `None` the field must be omitted from
     /// the JSON output entirely (wire compatibility for disabled-cache mode).

--- a/src/server/types/responses_request.rs
+++ b/src/server/types/responses_request.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! OpenAI Responses API request types (issue #622).
+//! OpenAI Responses API request types.
 //!
 //! Wire shape mirrors `openai-python` `response_create_params.py`. Phase 1
-//! supports the subset documented in the acceptance criteria of #622 —
+//! supports the subset documented in the acceptance criteria
 //! text input (string or typed item array), function tools, structured
 //! output via `text.format.json_schema`, `previous_response_id` and
 //! string-form `conversation` chaining, plus standard sampling overrides.

--- a/src/server/types/responses_response.rs
+++ b/src/server/types/responses_response.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! OpenAI Responses API response types (issue #622).
+//! OpenAI Responses API response types.
 //!
 //! Wire shape mirrors `openai-python` `response.py`. Phase 1 emits the
 //! discriminated union variants exercised by the acceptance criteria —

--- a/src/server/types/responses_stream.rs
+++ b/src/server/types/responses_stream.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Streaming events for the OpenAI Responses API (issue #622).
+//! Streaming events for the OpenAI Responses API.
 //!
 //! Wire shape:
 //!

--- a/src/surgery.rs
+++ b/src/surgery.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Axis A "weight-load surgery" CLI integration glue (Epic #363, issue
-//! #371 — A4).
+//! Axis A "weight-load surgery" CLI integration glue (— A4).
 //!
 //! This module owns the **active-pipeline slot**: a process-wide
 //! `Option<Arc<SurgeryPipeline>>` set by the CLI/server entry points
@@ -23,7 +22,7 @@
 //!
 //! ## Why a global slot
 //!
-//! The consolidated loaders introduced by A1 (issue #365) accept
+//! The consolidated loaders introduced by A1 accept
 //! `Option<&dyn WeightTransform>` so any caller can plug in a transform
 //! at load time. The CLI entry points (`mlxcel generate`, `mlxcel serve`,
 //! `mlxcel-server`) call `crate::load_model` (and friends), which in
@@ -48,9 +47,9 @@
 //!   loader, look up the slot, find `None`, and skip the transform hook
 //!   entirely.
 //! - The runtime call sequence is byte-for-byte identical to the
-//!   pre-#371 baseline.
+//!   earlier baseline.
 //!
-//! This satisfies the hard guarantee in #363 §5 (isolation table) and
+//! This satisfies the hard guarantee §5 (isolation table) and
 //! is exercised end-to-end by the integration test in
 //! `tests/surgery_cli.rs`.
 //!

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -58,7 +58,7 @@ impl MlxcelTokenizer {
     }
 
     /// Create a minimal tokenizer with byte-fallback support for regression tests
-    /// (issue #547). The vocabulary includes:
+    /// The vocabulary includes:
     ///
     /// - Tokens 0/1: `<BOS>` / `<EOS>` (special)
     /// - Token 2: `Hello` (regular ASCII)
@@ -140,7 +140,7 @@ impl MlxcelTokenizer {
     /// instance was constructed from a `tokenizer.json` file.
     ///
     /// `None` for SentencePiece or Tiktoken tokenizers. Used by Axis B
-    /// (#362) language steering to feed the tokenizer vocabulary into the
+    /// language steering to feed the tokenizer vocabulary into the
     /// [`mlxcel_core::lang_analyzer`] classifier.
     pub fn hf_tokenizer(&self) -> Option<&tokenizers::Tokenizer> {
         match self {
@@ -659,7 +659,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // ThinkingMarkers / infer_thinking_markers (issue #590)
+    // ThinkingMarkers / infer_thinking_markers
     //
     // We can't easily construct full `MlxcelTokenizer` instances backed by
     // real model files inside unit tests, so these cases build minimal HF
@@ -799,7 +799,7 @@ mod tests {
         assert_eq!(merged, markers);
     }
 
-    // -- issue #591: empty tool_call_end (Mistral-like tokenizers) --------
+    // -- empty tool_call_end (Mistral-like tokenizers) --------
 
     #[test]
     fn with_tool_call_markers_empty_end_skips_end_transition() {
@@ -864,7 +864,7 @@ mod tests {
         );
     }
 
-    // -- find_think_* / rfind_think_* via subseq helpers (#590) ----------
+    // -- find_think_* / rfind_think_* via subseq helpers ----------
     //
     // The `ThinkingMarkers::find_*` / `rfind_*` helpers are the Rust analogue
     // of upstream's `TokenizerWrapper.find_think_start` etc. These tests verify

--- a/src/tokenizer/thinking.rs
+++ b/src/tokenizer/thinking.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Multi-token think / tool-call sequence detection (issue #590).
+//! Multi-token think / tool-call sequence detection.
 //!
 //! Mirrors the upstream `mlx_lm.tokenizer_utils._infer_thinking()` helper and
 //! the `find_think_*` / `rfind_think_*` lookup methods on `TokenizerWrapper`

--- a/src/vision/encoders/nemotron_h_nano_omni.rs
+++ b/src/vision/encoders/nemotron_h_nano_omni.rs
@@ -16,7 +16,7 @@
 //!
 //! Faithful Rust port of
 //! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/vision.py`
-//! (issue #554, vision-only scope). The encoder is a Vision Transformer
+//! (vision-only scope). The encoder is a Vision Transformer
 //! with NVIDIA's RADIO patch generator: a learned `[CLS]` token (with
 //! optional teacher-tied registers), a 1D learned positional embedding,
 //! and a stack of pre-norm transformer blocks. Each block uses standard

--- a/src/vision/encoders/nemotron_h_nano_omni_tests.rs
+++ b/src/vision/encoders/nemotron_h_nano_omni_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Tests for the Nemotron H Nano Omni vision tower (issue #554).
+//! Tests for the Nemotron H Nano Omni vision tower.
 //!
 //! These tests build the encoder from synthetic, deterministic weights
 //! and confirm:

--- a/src/vision/feature_cache.rs
+++ b/src/vision/feature_cache.rs
@@ -17,7 +17,7 @@
 //! Stores post-projection image features keyed by image identity so the server
 //! can skip the vision tower + multimodal embedder on subsequent turns that
 //! reference the same image. Mirrors the upstream `VisionFeatureCache` that
-//! landed in mlx-vlm. See issue #325.
+//! landed in mlx-vlm..
 //!
 //! The cache is generic over a [`CloneableFeatures`] implementor so each VLM
 //! family can store the feature shape it actually needs (a single projected

--- a/src/vision/gemma3n_vl.rs
+++ b/src/vision/gemma3n_vl.rs
@@ -289,7 +289,7 @@ impl LanguageModel for Gemma3nVLModel {
             let pli = self
                 .take_per_layer_inputs(seq_id)
                 .expect("gemma3n VLM prefill: per_layer_inputs missing for this sequence");
-            // Issue #736: M5 tile-aligned prefill pads the token stream and
+            // M5 tile-aligned prefill pads the token stream and
             // merged embeddings to an NA tile length. The projected
             // per-layer tensor is produced before that generic padding step,
             // so align it here before Gemma3n's per-layer blend.

--- a/src/vision/gemma4_multimodal_embedder.rs
+++ b/src/vision/gemma4_multimodal_embedder.rs
@@ -15,8 +15,7 @@
 //! Gemma 4 multimodal embedder (vision and audio share the same shape).
 //!
 //! Pulled out of `gemma4_vl.rs` so that file stays under the project's
-//! 500-line hard cap (issue #543 added per-sequence `per_layer_inputs`
-//! plumbing alongside the existing VLM/audio code paths).
+//! 500-line hard cap (added per-sequence `per_layer_inputs` plumbing alongside the existing VLM/audio code paths).
 //!
 //! Both `embed_vision` and `embed_audio` on
 //! [`crate::vision::Gemma4VLModel`] use this module's

--- a/src/vision/gemma4_per_layer_inputs_state.rs
+++ b/src/vision/gemma4_per_layer_inputs_state.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Per-sequence `per_layer_inputs` state for Gemma 4 E2B/E4B VLM (issue
-//! #543).
+//! Per-sequence `per_layer_inputs` state for Gemma 4 E2B/E4B VLM.
 //!
 //! `Gemma4VLModel::get_input_embeddings_with_audio_and_cache` projects
 //! the Gemma 4 E2B/E4B `per_layer_inputs` tensor (shape `[1, T, L, h]`)
@@ -33,12 +32,12 @@
 //! prefill then `take()`s **the latest writer's** `per_layer_inputs`
 //! instead of its own — every subsequent request runs against the wrong
 //! per-layer projection. That is the production root cause behind issue
-//! #543; the upstream mlx-vlm PR #1123 fix is for a related
+//! the upstream mlx-vlm PR #1123 fix is for a related
 //! batched-concat shape mismatch that does not apply to mlxcel's
 //! sequential VLM prefill path.
 //!
 //! The container below mirrors [`crate::models::qwen_mrope_state::MRopeState`]
-//! (issue #540 / PR #558) so the scheduler wires both per-sequence
+//! so the scheduler wires both per-sequence
 //! states identically:
 //!
 //! - **Per-`SequenceId` map** is the primary slot; `bind_fallback_to_sequence`
@@ -106,7 +105,6 @@ impl Gemma4PerLayerInputsState {
     /// Move the fallback slot's contents into the per-sequence map under
     /// `seq_id`. Drains the fallback so the next request cannot inherit
     /// the previous row's tensor — this is the burst-enqueue race fix
-    /// from issue #543.
     ///
     /// If the fallback slot is empty (E1B variant or text-only request
     /// after a Gemma 4 VLM model load — `prepare_request_vlm_embeddings`

--- a/src/vision/gemma4_per_layer_inputs_state_tests.rs
+++ b/src/vision/gemma4_per_layer_inputs_state_tests.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //! Unit tests for the Gemma 4 per-layer-inputs per-sequence state container
-//! (issue #543).
 //!
 //! These cover the burst-enqueue race the container is designed to close:
 //! when 2+ Gemma 4 VLM requests are enqueued within one
@@ -112,7 +111,7 @@ fn bind_fallback_with_empty_slot_leaves_seq_absent() {
     );
 }
 
-/// Issue #543 root-cause regression: simulate the burst-enqueue race.
+/// root-cause regression: simulate the burst-enqueue race.
 ///
 /// `prepare_request_vlm_embeddings` writes the fallback slot once per
 /// request; the scheduler's bind step claims it before the next

--- a/src/vision/gemma4_vl.rs
+++ b/src/vision/gemma4_vl.rs
@@ -42,7 +42,7 @@ pub struct Gemma4VLModel {
     pub boa_token_id: i32,
     pub eoa_token_id: i32,
     /// Per-`SequenceId` storage for projected `per_layer_inputs`
-    /// (issue #543). Mirrors `MRopeState` (#540).
+    /// Mirrors `MRopeState`.
     per_layer_inputs_state: Gemma4PerLayerInputsState,
     _weight_backing: crate::models::Gemma4WeightBacking,
 }
@@ -106,7 +106,7 @@ impl Gemma4VLModel {
         self.get_input_embeddings_with_audio_and_cache(input_ids, images, None, None, None, None)
     }
 
-    /// Compute input embeddings from video features (issue #553).
+    /// Compute input embeddings from video features.
     ///
     /// Each [`processors::gemma4::Gemma4VideoFeatures`] supplies one
     /// `[1, 3, H, W]` tensor per sampled frame. We reuse the existing
@@ -206,7 +206,7 @@ impl Gemma4VLModel {
         // the language-model embedding space, so they must NOT be scaled
         // again. `Gemma4TextModel::forward` detects that we are passing
         // `input_embeddings` and skips its own embed scale to avoid
-        // double-scaling the text tokens. See issue #317.
+        // double-scaling the text tokens..
         let inputs_embeds = self.text_model.input_embeddings(input_ids);
         let inputs_embeds = mlxcel_core::multiply_scalar(
             &inputs_embeds,
@@ -334,7 +334,7 @@ impl Gemma4VLModel {
             result_embeds.inputs_embeds = scattered;
         }
 
-        // Issue #543: park the freshly projected tensor in the
+        // park the freshly projected tensor in the
         // container's fallback slot. The scheduler binds it to a
         // `SequenceId` right after `prepare_request_vlm_embeddings`
         // returns; legacy CLI/single-row callers consume it via
@@ -343,14 +343,14 @@ impl Gemma4VLModel {
         result_embeds
     }
 
-    // -- Per-sequence per_layer_inputs (issue #543) --------------------
+    // -- Per-sequence per_layer_inputs --------------------
     //
     // These thin wrappers route through `Gemma4PerLayerInputsState`. The
     // scheduler calls them via `LoadedModel::*` capability helpers (see
     // `loaded_model_capabilities.rs`) right after
     // `prepare_request_vlm_embeddings` so a burst of Gemma 4 VLM
     // requests cannot have one row's prefill consume another row's
-    // tensor. Mirrors the Qwen MRoPE binding flow from issue #540.
+    // tensor. Mirrors the Qwen MRoPE binding flow.
 
     /// Drain the container's fallback slot into the per-`SequenceId`
     /// map under `seq_id`. No-op when the slot is empty (E1B variant
@@ -391,10 +391,10 @@ impl Gemma4VLModel {
         }
     }
 
-    // -- Gemma 4 MTP speculative-decoding hooks (issue #625) --------------
+    // -- Gemma 4 MTP speculative-decoding hooks --------------
     //
-    // These pass-through methods give the future MTP drafter (issue #626) /
-    // generator (issue #629) the same opt-in sink + rollback surface on the
+    // These pass-through methods give the future MTP drafter /
+    // generator the same opt-in sink + rollback surface on the
     // VLM-wrapped Gemma 4 path as on the text-only path. The multimodal
     // prefill (image / audio merge into the input embeddings) is unchanged —
     // speculative decoding kicks in only AFTER the prefill tail, at which
@@ -414,7 +414,7 @@ impl Gemma4VLModel {
     /// case. Mirrors the `gemma4_vl.py` __call__ → text_model.__call__
     /// flow in `references/mlx-vlm`.
     ///
-    /// Used by: future Gemma 4 VLM MTP consumer (issue #629).
+    /// Used by: future Gemma 4 VLM MTP consumer.
     pub fn forward_with_speculative_sinks(
         &self,
         input_ids: &MlxArray,
@@ -499,7 +499,7 @@ impl LanguageModel for Gemma4VLModel {
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
         if let Some(embeds) = input_embeddings {
-            // Issue #543: prefer the per-`SequenceId` slot so each
+            // prefer the per-`SequenceId` slot so each
             // row of a burst-enqueued batch sees its own projection.
             // Fall back to the legacy fallback slot when there is no
             // `seq_id` (CLI/single-row) or the bind step did not run
@@ -560,7 +560,7 @@ impl LanguageModel for Gemma4VLModel {
     }
 
     fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
-        // Issue #543: drop the per-sequence `per_layer_inputs`
+        // drop the per-sequence `per_layer_inputs`
         // alongside the text model's per-sequence cache release so
         // the map cannot grow without bound across long-running
         // server sessions.
@@ -580,7 +580,7 @@ impl LanguageModel for Gemma4VLModel {
         false
     }
 
-    /// Issue #542: Gemma 4 supports batched decode now that the inner
+    /// Gemma 4 supports batched decode now that the inner
     /// [`crate::models::Gemma4Wrapper`] uses per-`SequenceId` cache
     /// isolation via `ModelOwnedSequenceState<Cache>`. The
     /// `forward_batched_with_context_and_ids` override below routes each
@@ -590,9 +590,9 @@ impl LanguageModel for Gemma4VLModel {
         true
     }
 
-    /// Issue #542: per-row batched dispatch with seq_ids so each row of a
+    /// per-row batched dispatch with seq_ids so each row of a
     /// mixed-length batch reaches the text model's seq-aware forward path
-    /// independently. Mirrors the Qwen VL fix in PR #558 and shares the
+    /// independently. Mirrors the Qwen VL fix and shares the
     /// same helper (`multimodal::batched_dispatch`).
     fn forward_batched_with_context_and_ids(
         &self,

--- a/src/vision/merge.rs
+++ b/src/vision/merge.rs
@@ -171,7 +171,7 @@ pub fn prepare_inputs_for_multimodal(
 ///
 /// Used by: LLaVA/Bunny, Aya Vision, Pixtral, Mistral3, Gemma3n,
 /// Qwen2/2.5/3/3.5-VL, Phi3V, Molmo2, Llama4, Nemotron H Nano Omni
-/// (vision + audio modalities, issues #554 and #582)
+/// (vision + audio modalities, and)
 pub fn merge_llava(
     image_token_index: i32,
     image_features: &MlxArray,

--- a/src/vision/nemotron_h_nano_omni_vl.rs
+++ b/src/vision/nemotron_h_nano_omni_vl.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Nemotron H Nano Omni vision-language model wrapper (issues #554, #582).
+//! Nemotron H Nano Omni vision-language model wrapper.
 //!
 //! Faithful Rust port of the multimodal path in
 //! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py`.
@@ -24,7 +24,7 @@
 //! - the multimodal projector (`mlp1`): `RMSNorm -> Linear -> ReLU² ->
 //!   Linear` with the upstream "pixel shuffle" downsample applied to
 //!   the patch grid before projection
-//! - **(issue #582)** an optional audio path:
+//! - **** an optional audio path:
 //!   `crate::audio::nemotron_h_nano_omni::{NemotronOmniSoundEncoder,
 //!   NemotronOmniSoundProjection, NemotronOmniFeatureExtractor}`,
 //!   wired only when `sound_config` is present in the released
@@ -130,7 +130,7 @@ impl NemotronHNanoOmniProjector {
 
 /// Top-level Nemotron H Nano Omni VLM.
 ///
-/// Issue #554 introduced this struct with vision-only scope; issue #582
+/// introduced this struct with vision-only scope;
 /// added the optional audio path (`audio` field set to `Some` when the
 /// checkpoint ships a `sound_config`).
 pub struct NemotronHNanoOmniVlModel {

--- a/src/vision/processors/gemma4.rs
+++ b/src/vision/processors/gemma4.rs
@@ -22,7 +22,7 @@
 //! same file: per-frame uniform sampling, aspect-ratio-preserving resize
 //! to a smaller per-frame token budget (default 70 soft tokens), rescale
 //! to `[0, 1]`, and concatenate channel-first frames into one
-//! `(N_total_frames, C, H, W)` tensor (issue #553).
+//! `(N_total_frames, C, H, W)` tensor.
 
 use image::DynamicImage;
 use image::imageops::FilterType;

--- a/src/vision/processors/gemma4_tests.rs
+++ b/src/vision/processors/gemma4_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit tests for the Gemma 4 image / video preprocessor (issue #553).
+//! Unit tests for the Gemma 4 image / video preprocessor.
 //!
 //! These tests use synthetic in-memory frames so they run on any
 //! platform without an actual video file or `ffmpeg` install.

--- a/src/vision/processors/nemotron_h_nano_omni.rs
+++ b/src/vision/processors/nemotron_h_nano_omni.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Nemotron H Nano Omni image preprocessor (issue #554).
+//! Nemotron H Nano Omni image preprocessor.
 //!
 //! Faithful Rust port of
 //! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/image_processing_nemotron_h_nano_omni.py`.

--- a/src/vision/processors/nemotron_h_nano_omni_tests.rs
+++ b/src/vision/processors/nemotron_h_nano_omni_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit tests for the Nemotron H Nano Omni image processor (issue #554).
+//! Unit tests for the Nemotron H Nano Omni image processor.
 
 use super::*;
 use image::{DynamicImage, RgbImage};

--- a/src/vision/qwen2_5_vl.rs
+++ b/src/vision/qwen2_5_vl.rs
@@ -247,7 +247,7 @@ impl LanguageModel for Qwen25VLModel {
         caches: &mut [KVCache],
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
-        // Issue #540: route through the per-sequence MRoPE path so the
+        // route through the per-sequence MRoPE path so the
         // cached scalar delta cannot leak across requests.
         self.text_model
             .forward_for_sequence(input_ids, None, caches, mask, seq_id)
@@ -269,7 +269,7 @@ impl LanguageModel for Qwen25VLModel {
         self.text_model.release_mrope_sequence(seq_id);
     }
 
-    /// Issue #540: per-row batched dispatch with seq_ids so each row's
+    /// per-row batched dispatch with seq_ids so each row's
     /// MRoPE state resolves correctly in mixed VL+text batches.
     fn forward_batched_with_context_and_ids(
         &self,

--- a/src/vision/qwen2_vl.rs
+++ b/src/vision/qwen2_vl.rs
@@ -209,7 +209,7 @@ impl LanguageModel for Qwen2VLModel {
         caches: &mut [KVCache],
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
-        // Issue #540: route through the per-sequence MRoPE path so the
+        // route through the per-sequence MRoPE path so the
         // cached scalar delta cannot leak across requests.
         self.text_model
             .forward_for_sequence(input_ids, None, caches, mask, seq_id)
@@ -231,7 +231,7 @@ impl LanguageModel for Qwen2VLModel {
         self.text_model.release_mrope_sequence(seq_id);
     }
 
-    /// Issue #540: per-row batched dispatch with seq_ids so each row's
+    /// per-row batched dispatch with seq_ids so each row's
     /// MRoPE state resolves correctly in mixed VL+text batches. The
     /// trait default discards `seq_ids` and falls through to
     /// `forward_batched`, which loops calling `forward()` without ids;

--- a/src/vision/qwen3_5_vl.rs
+++ b/src/vision/qwen3_5_vl.rs
@@ -86,13 +86,13 @@ impl Qwen35VLModel {
     /// Speculative-decode verify pass that mirrors the text model's
     /// [`Qwen35Model::forward_speculative`].
     ///
-    /// Issue #634: DFlash's drafter consumes per-layer hidden captures and
+    /// DFlash's drafter consumes per-layer hidden captures and
     /// per-GDN-layer rollback snapshots. The VLM wrapper exposes the same
     /// hooks so multimodal prefill + speculative tail can compose. The
     /// vision pathway runs in the standard prefill before this method is
     /// invoked, so the verify pass only needs the text-side caches.
     ///
-    /// Used by: DFlash drafter round loop (epic #633, sub-12).
+    /// Used by: DFlash drafter round loop (sub-12).
     pub fn forward_speculative(
         &self,
         input_ids: &MlxArray,
@@ -105,7 +105,7 @@ impl Qwen35VLModel {
 
     /// Rewind both attention and GDN caches to the accepted-prefix
     /// position. Delegates to the text model — the VLM wrapper holds no
-    /// cache state of its own (see issue #634).
+    /// cache state of its own.
     pub fn rollback_speculative_cache(
         &self,
         caches: &mut [Qwen3NextCache],
@@ -214,7 +214,7 @@ impl Qwen35VLModel {
 /// before the verify/rollback loop begins, so the round loop interacts
 /// only with the text backbone.
 ///
-/// Used by: DFlash B=1 round loop (issue #636).
+/// Used by: DFlash B=1 round loop.
 impl mlxcel_core::drafter::dflash::SpeculativeTarget for Qwen35VLModel {
     type Cache = crate::models::qwen3_next::Qwen3NextCache;
     type VerifyOut = crate::models::qwen3_5::VerifyOutput;
@@ -268,7 +268,7 @@ impl mlxcel_core::drafter::dflash::SpeculativeTarget for Qwen35VLModel {
         );
     }
 
-    /// Batched B > 1 rollback for the VLM wrapper. Issue #666 — overrides
+    /// Batched B > 1 rollback for the VLM wrapper. — overrides
     /// the trait default (which panics for B > 1) so the batched DFlash
     /// round loop can drive a Qwen 3.5 VLM target with batched-prefill
     /// served by the continuous-batching scheduler.
@@ -276,7 +276,7 @@ impl mlxcel_core::drafter::dflash::SpeculativeTarget for Qwen35VLModel {
     /// Mirrors the inner text-model `rollback_partial_batched`: the
     /// per-row K/V tail-zero and per-row GDN replay live inside
     /// `Qwen35Model::rollback_speculative_cache`, which already accepts a
-    /// multi-element `accepted` slice (issue #634).
+    /// multi-element `accepted` slice.
     fn rollback_partial_batched(
         &self,
         caches: &mut [Self::Cache],
@@ -340,7 +340,7 @@ impl LanguageModel for Qwen35VLModel {
         caches: &mut [KVCache],
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
-        // Issue #540: forward through the underlying Qwen3.5 model's
+        // forward through the underlying Qwen3.5 model's
         // seq-id-aware path so the per-sequence MRoPE entry resolves
         // for this specific request.
         mlxcel_core::generate::LanguageModel::forward_with_sequence_id(
@@ -385,7 +385,7 @@ impl LanguageModel for Qwen35VLModel {
         mlxcel_core::generate::LanguageModel::reset_runtime_state(&self.text_model);
     }
 
-    /// Issue #540: forward `seq_ids` to the underlying Qwen3.5 model so
+    /// forward `seq_ids` to the underlying Qwen3.5 model so
     /// each row's MRoPE state resolves correctly in mixed VL+text
     /// batches. `Qwen35Model::forward_batched_with_context_and_ids`
     /// already implements per-row dispatch and the batched-prefill fast
@@ -434,7 +434,7 @@ impl LanguageModel for Qwen35VLModel {
 
     /// Delegate to the inner text model so a DFlash drafter can lazy-bind
     /// the Qwen 3.5 embedding table even when the target is a VLM-wrapped
-    /// Qwen 3.5 checkpoint (issue #675). The vision tower owns no token
+    /// Qwen 3.5 checkpoint. The vision tower owns no token
     /// embedding of its own — token embedding always lives on the text
     /// model.
     fn embed_tokens_module(&self) -> Option<mlxcel_core::layers::UnifiedEmbedding> {

--- a/src/vision/qwen3_vl.rs
+++ b/src/vision/qwen3_vl.rs
@@ -283,7 +283,7 @@ impl LanguageModel for Qwen3VLModel {
         caches: &mut [KVCache],
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
-        // Issue #540: route through the per-sequence MRoPE path so the
+        // route through the per-sequence MRoPE path so the
         // cached scalar delta cannot leak across requests.
         self.text_model
             .forward_for_sequence(input_ids, None, caches, mask, seq_id)
@@ -305,7 +305,7 @@ impl LanguageModel for Qwen3VLModel {
         self.text_model.release_mrope_sequence(seq_id);
     }
 
-    /// Issue #540: per-row batched dispatch with seq_ids so each row's
+    /// per-row batched dispatch with seq_ids so each row's
     /// MRoPE state resolves correctly in mixed VL+text batches.
     fn forward_batched_with_context_and_ids(
         &self,

--- a/src/vision/qwen3_vl_moe.rs
+++ b/src/vision/qwen3_vl_moe.rs
@@ -221,7 +221,7 @@ impl LanguageModel for Qwen3VLMoeModel {
         caches: &mut [KVCache],
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
-        // Issue #540: route through the per-sequence MRoPE path so the
+        // route through the per-sequence MRoPE path so the
         // cached scalar delta cannot leak across requests.
         self.text_model
             .forward_for_sequence(input_ids, None, caches, mask, seq_id)
@@ -243,7 +243,7 @@ impl LanguageModel for Qwen3VLMoeModel {
         self.text_model.release_mrope_sequence(seq_id);
     }
 
-    /// Issue #540: per-row batched dispatch with seq_ids so each row's
+    /// per-row batched dispatch with seq_ids so each row's
     /// MRoPE state resolves correctly in mixed VL+text batches.
     fn forward_batched_with_context_and_ids(
         &self,

--- a/tests/chat_template_kwargs.rs
+++ b/tests/chat_template_kwargs.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Integration tests for issue #410 `chat_template_kwargs` / `preserve_thinking`.
+//! Integration tests `chat_template_kwargs` / `preserve_thinking`.
 //!
 //! The end-to-end tests spin up `mlxcel-server` against a real Qwen3-family
 //! model and exercise the HTTP `/v1/chat/completions` surface in all three
@@ -114,7 +114,7 @@ fn make_multi_turn_body(chat_template_kwargs: Option<serde_json::Value>) -> serd
     body
 }
 
-/// Issue #410 integration: per-request top-level `chat_template_kwargs.preserve_thinking=true`
+/// integration: per-request top-level `chat_template_kwargs.preserve_thinking=true`
 /// must produce a 200 response. The actual prompt-rendering correctness is
 /// covered by unit tests — this test only confirms that the server accepts
 /// the shape end-to-end without 4xx/5xx errors.

--- a/tests/cli_help_consistency.rs
+++ b/tests/cli_help_consistency.rs
@@ -20,8 +20,7 @@
 //!    binary flattens the same `TurboKvCacheArgs`, so the `--help` text
 //!    for `--cache-type-k`, `--cache-type-v`, `--kv-cache-mode`, and
 //!    `--turbo-boundary-v` MUST be identical across binaries.
-//! 2. **Speculative decoding** (`Speculative Decoding Options`, issue
-//!    #630) — every binary flattens the same `SpeculativeArgs`, so the
+//! 2. **Speculative decoding** (`Speculative Decoding Options`) — every binary flattens the same `SpeculativeArgs`, so the
 //!    `--help` text for `--draft-kind` and `--draft-block-size` MUST be
 //!    identical across binaries.
 //!
@@ -298,7 +297,7 @@ fn turbo_flag_signatures_match_across_binaries() {
     }
 }
 
-// ── Speculative decoding flag group (issue #630) ─────────────────────────────
+// ── Speculative decoding flag group ─────────────────────────────
 
 /// Heading set by `SpeculativeArgs` (`src/cli/speculative_args.rs`).
 const SPECULATIVE_HEADING: &str = "Speculative Decoding Options";

--- a/tests/distributed_integration.rs
+++ b/tests/distributed_integration.rs
@@ -571,7 +571,7 @@ async fn ci_concurrent_operations() {
 // ---------------------------------------------------------------------------
 //
 // These tests verify that the runtime plumbing for the 2D parallelism
-// introduced by issue #346 is wired end-to-end: config parsing, registry
+// introduced is wired end-to-end: config parsing, registry
 // lookups, 2D-aware routing, and the cache-manager admission grid.
 
 use mlxcel::distributed::config::ClusterConfig;

--- a/tests/fixtures/wikitext2_excerpt.txt
+++ b/tests/fixtures/wikitext2_excerpt.txt
@@ -11,10 +11,10 @@ Attribution: Wikipedia contributors, Salesforce AI Research
 Slice      : full test split (all 4358 rows concatenated)
 GPT-2 BPE tokens (tiktoken): 283287
 At PPL_CHUNK_LEN=4096 this yields 69 non-overlapping chunks,
-comfortably exceeding the 20-chunk requirement of the B3 quality gate (issue #492).
+comfortably exceeding the 20-chunk requirement of the B3 quality gate.
 
 This file is used as a fixture for the TurboQuant KV cache perplexity gate
-(tests/turbo_kv_e2e.rs, epic #458, issue #475 / #492).
+(tests/turbo_kv_e2e.rs).
 Any derivative use must retain this CC BY-SA 3.0 attribution.
 
  = Robert Boulter = 

--- a/tests/internvl_parity.rs
+++ b/tests/internvl_parity.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! InternVL (`internvl_chat`) real-model parity / smoke tests (issue #738).
+//! InternVL (`internvl_chat`) real-model parity / smoke tests.
 //!
 //! These tests are gated on the presence of `models/internvl3-1b`; they
 //! `eprintln!` + return when the model is absent, so they are inert in CI and

--- a/tests/lang_bias.rs
+++ b/tests/lang_bias.rs
@@ -424,7 +424,7 @@ fn scenario_b_suppresses_ja_zh() {
 ///   `c_hangul >= 0.05`.  When neither run produces Hangul, the ratio difference
 ///   is below the signal floor; we emit a diagnostic and skip the assertion.
 ///   Note: Conservative `ko` set = {Hangul, Han}, so `ko=+5` can be absorbed by
-///   Han tokens when no Hangul gradient exists —.
+///   Han tokens when no Hangul gradient exists.
 /// - When `a_hangul >= 0.01`, keep the multiplicative rule `c_hangul >= 1.2 * a_hangul`.
 #[test]
 #[ignore = "requires local model weights and the mlxcel binary"]
@@ -481,7 +481,7 @@ fn scenario_c_promotes_ko() {
                 "Scenario C: both a_hangul ({a_hangul:.4}) and c_hangul ({c_hangul:.4}) are \
                  below the signal floor (0.01 / 0.05). Skipping assertion. \
                  Note: Conservative ko set = {{Hangul, Han}}, so ko=+5 can be absorbed by Han \
-                 tokens when no Hangul gradient exists —."
+                 tokens when no Hangul gradient exists."
             );
         }
         return;
@@ -504,7 +504,7 @@ fn scenario_c_promotes_ko() {
 /// construction** when the feature works, because strict `ko=-inf` drives
 /// generated Hangul to zero while the baseline continuation (when present) has
 /// non-zero Hangul. Previously, both A and D measured identical prompt-echo
-/// Hangul, masking any difference —.
+/// Hangul, masking any difference.
 ///
 /// Asserts:
 /// - Hangul ratio in the generated continuation drops compared to scenario A.

--- a/tests/lang_bias.rs
+++ b/tests/lang_bias.rs
@@ -125,7 +125,7 @@ fn strip_prompt_echo<'a>(body: &'a str, prompt: &str) -> &'a str {
 /// contain no Hangul). Without stripping, the prompt-echo dominates the
 /// measurement and makes biased vs. baseline comparison unreliable.
 ///
-/// See issue #406 for the full analysis of the false-negative root cause.
+/// for the full analysis of the false-negative root cause.
 fn run_scenario_generated_only(
     model_path: &Path,
     prompts: &[String],
@@ -424,7 +424,7 @@ fn scenario_b_suppresses_ja_zh() {
 ///   `c_hangul >= 0.05`.  When neither run produces Hangul, the ratio difference
 ///   is below the signal floor; we emit a diagnostic and skip the assertion.
 ///   Note: Conservative `ko` set = {Hangul, Han}, so `ko=+5` can be absorbed by
-///   Han tokens when no Hangul gradient exists — see issue #406.
+///   Han tokens when no Hangul gradient exists —.
 /// - When `a_hangul >= 0.01`, keep the multiplicative rule `c_hangul >= 1.2 * a_hangul`.
 #[test]
 #[ignore = "requires local model weights and the mlxcel binary"]
@@ -481,7 +481,7 @@ fn scenario_c_promotes_ko() {
                 "Scenario C: both a_hangul ({a_hangul:.4}) and c_hangul ({c_hangul:.4}) are \
                  below the signal floor (0.01 / 0.05). Skipping assertion. \
                  Note: Conservative ko set = {{Hangul, Han}}, so ko=+5 can be absorbed by Han \
-                 tokens when no Hangul gradient exists — see issue #406."
+                 tokens when no Hangul gradient exists —."
             );
         }
         return;
@@ -504,7 +504,7 @@ fn scenario_c_promotes_ko() {
 /// construction** when the feature works, because strict `ko=-inf` drives
 /// generated Hangul to zero while the baseline continuation (when present) has
 /// non-zero Hangul. Previously, both A and D measured identical prompt-echo
-/// Hangul, masking any difference — see issue #406.
+/// Hangul, masking any difference —.
 ///
 /// Asserts:
 /// - Hangul ratio in the generated continuation drops compared to scenario A.
@@ -526,7 +526,7 @@ fn scenario_d_strict_ko_suppress_preserves_han() {
 
     // KO prompts: scenario D tests strict Hangul suppression under the natural
     // Korean-prompt use case. Generated-only measurement removes the prompt echo
-    // that caused the d_hangul == a_hangul false-negative (issue #406).
+    // that caused the d_hangul == a_hangul false-negative.
     let prompts = load_ko_prompts();
 
     let a = run_scenario_generated_only(&model_path, &prompts, &[]);

--- a/tests/pipeline_auto_partition_real_models.rs
+++ b/tests/pipeline_auto_partition_real_models.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Real-model regression tests for the auto-partitioner (issue #348).
+//! Real-model regression tests for the auto-partitioner.
 //!
 //! These tests require local model weights and the compiled `mlxcel`
 //! binary. They are `#[ignore]`-gated so the default CI run skips them;
@@ -21,7 +21,7 @@
 //!
 //! What the test verifies: the auto-partitioner now produces a valid
 //! 2-stage plan for Gemma 4 without any manual `--pp-layers` flag. Before
-//! issue #348, operators had to specify layer ranges by hand because the
+//! operators had to specify layer ranges by hand because the
 //! partitioner did not understand KV-shared layer adjacency.
 
 mod common;
@@ -45,7 +45,7 @@ fn run_generate(args: &[&str]) -> (bool, String, String) {
 /// Run `gemma-4-e2b-it-4bit` across 2 stages with zero manual partitioning
 /// and assert the generated output is non-empty.
 ///
-/// Without the issue #348 work, this invocation fails because the naive
+/// Without the work, this invocation fails because the naive
 /// partitioner cuts the model between a KV-shared source layer and its
 /// consumer, stranding the cache on the wrong stage. With the adjacency-
 /// aware partitioner the plan is valid by default and generation
@@ -83,7 +83,7 @@ fn gemma4_auto_partition_two_stage_no_manual_layers() {
     let single_body = extract_generated_body(&single_stdout).expect("missing single-stage body");
 
     // Auto-partition 2-stage path. No `--pp-layers`. This is the
-    // regression guard for issue #348 — before this sub-issue landed, the
+    // regression guard — before this sub-issue landed, the
     // same invocation required a manual layer specification.
     let (ok_pp, pp_stdout, pp_stderr) = run_generate(&[
         "generate",
@@ -101,7 +101,7 @@ fn gemma4_auto_partition_two_stage_no_manual_layers() {
     ]);
     assert!(
         ok_pp,
-        "auto-partition 2-stage generation failed (issue #348 regression):\n\
+        "auto-partition 2-stage generation failed (regression):\n\
          stdout: {pp_stdout}\nstderr: {pp_stderr}"
     );
     let pp_body = extract_generated_body(&pp_stdout).expect("missing 2-stage body");

--- a/tests/pipeline_ci_multi_stage_real_models.rs
+++ b/tests/pipeline_ci_multi_stage_real_models.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Multi-stage pipeline-parallel integration tests driven by the
-//! `pipeline-parallel-ci.yml` workflow (issue #344).
+//! `pipeline-parallel-ci.yml` workflow.
 //!
 //! These tests exist specifically so the CI harness has a stable,
 //! versioned entry point for:
@@ -31,7 +31,7 @@
 //! The tests that need model weights are `#[ignore]`d so `cargo test`
 //! defaults stay cheap; the partition and admission regressions run by
 //! default, which is how the heterogeneous-memory scenario from issue
-//! #344 becomes a true guardrail on every PR.
+//! becomes a true guardrail on every PR.
 
 mod common;
 
@@ -312,7 +312,7 @@ fn pipeline_multi_stage_three_host_real_model_parity() {
 
 /// Heterogeneous-memory partition regression.
 ///
-/// Scenario from the issue #344 acceptance list: stage 0 sits on a
+/// Scenario from the acceptance list: stage 0 sits on a
 /// memory-smaller machine, stage 1 sits on a memory-larger machine. The
 /// auto-partitioner must assign fewer layers to stage 0 than to stage 1
 /// and the resulting assignment must pass `validate_partition` +

--- a/tests/pipeline_elastic_repartition_real_models.rs
+++ b/tests/pipeline_elastic_repartition_real_models.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Real-model integration test for elastic pipeline repartitioning (#349).
+//! Real-model integration test for elastic pipeline repartitioning.
 //!
 //! This `#[ignore]`-gated test simulates an operator-initiated repartition on
 //! a running 2-stage cluster backed by a real model checkpoint. It:

--- a/tests/pipeline_lora_composition_real_models.rs
+++ b/tests/pipeline_lora_composition_real_models.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 // Parity integration test for pipeline parallelism composed with LoRA
-// adapters (issue #347). The test runs two generations — a single-process
+// adapters. The test runs two generations — a single-process
 // `--adapter` run and a two-stage `--pp-size 2 --adapter` run — and asserts
 // that the decoded token stream matches bit-for-bit. It is `#[ignore]`d
 // because it requires a published Llama checkpoint and a paired LoRA

--- a/tests/pipeline_observability_real_models.rs
+++ b/tests/pipeline_observability_real_models.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Real-model observability integration test (issue #350).
+//! Real-model observability integration test.
 //!
 //! This `#[ignore]`-gated test drives a simulated traffic workload through a
 //! 2-stage in-process pipeline observability aggregator, scrapes the
@@ -144,7 +144,7 @@ fn pp_observability_populates_all_four_metric_families() {
         .record(diag.stage_index, diag.reason.metric_label());
 
     // Repartition counters: drive one completed repartition event so the
-    // #349 emission path is also visible.
+    // emission path is also visible.
     let event = RepartitionEvent {
         trigger: mlxcel::distributed::pipeline::RepartitionTrigger::Explicit,
         to_state: RepartitionState::Idle,

--- a/tests/pipeline_remote_real_models.rs
+++ b/tests/pipeline_remote_real_models.rs
@@ -361,7 +361,7 @@ fn pipeline_remote_runtime_glm_moe_dsa_real_model_parity_and_cleanup() {
 }
 
 // ---------------------------------------------------------------------------
-// RDMA backend real-model coverage (issue #343)
+// RDMA backend real-model coverage
 // ---------------------------------------------------------------------------
 //
 // This test runs the full 2-stage remote pipeline over the RDMA-aware

--- a/tests/pipeline_stage_executor_real_models.rs
+++ b/tests/pipeline_stage_executor_real_models.rs
@@ -351,7 +351,7 @@ fn pipeline_stage_worker_loop_glm_moe_dsa_real_model_parity() {
     );
 }
 
-// Issue #345 families — stage executor parity against the non-PP reference
+// families — stage executor parity against the non-PP reference
 // path on a short prompt. Each test is gated behind `#[ignore]` because it
 // requires real model weights to be present under `models/`; operators can
 // opt in by downloading the listed HuggingFace MLX Community checkpoint.

--- a/tests/pp_tp_2d_real_models.rs
+++ b/tests/pp_tp_2d_real_models.rs
@@ -106,7 +106,7 @@ fn pp_tp_2x2_llama_real_model_parity() {
 /// This test only asserts that the validator does not reject the combination
 /// upfront; it does not run the model. It is kept in the non-ignored test
 /// surface because it is cheap and directly verifies the validator change
-/// required by issue #346.
+/// required.
 #[test]
 fn pp_tp_2d_validator_accepts_combination() {
     // Unlike the parity test above, this one does not require any model

--- a/tests/prompt_cache_e2e.rs
+++ b/tests/prompt_cache_e2e.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //! End-to-end integration test for the cross-request prompt-prefix KV cache
-//! (epic #416, sub-issue #426).
 //!
 //! This test boots a real `mlxcel-server` binary with the prompt-prefix
 //! cache enabled and drives it through the public OpenAI-compatible HTTP
@@ -58,7 +57,7 @@ const QWEN3_MODEL: &str = "qwen3-0.6b-4bit";
 const NUM_TURNS: usize = 5;
 
 /// Upper bound on turn-N prefill latency relative to turn-1 prefill latency.
-/// The spec (#426) calls for <= 1.3x. We keep the literal here so any
+/// The spec calls for <= 1.3x. We keep the literal here so any
 /// future tightening happens in one place.
 const PREFILL_LATENCY_UPPER_RATIO: f64 = 1.3;
 
@@ -143,7 +142,7 @@ async fn one_turn(
         "max_tokens": max_tokens,
         "temperature": 0.0,
         // Route through the session-key path so the prompt cache can bucket
-        // the turns together (issue #422 wiring).
+        // the turns together (wiring).
         "user": "prompt-cache-e2e-user",
     });
 
@@ -225,7 +224,7 @@ async fn multi_turn_chat_reports_cached_tokens_and_lowers_prefill_latency() {
 
     // Prompt cache explicitly enabled via CLI; small caps so we stay within
     // memory even on CI hosts. Dense decode storage is the only backend
-    // that can currently donate back to the store (issue #421 gate).
+    // that can currently donate back to the store (gate).
     let mut child = spawn_server(&[
         "--model",
         &model_str,
@@ -306,7 +305,7 @@ async fn multi_turn_chat_reports_cached_tokens_and_lowers_prefill_latency() {
 
     // ---------------------------------------------------------------
     // Assertion 1: wire contract — cached_tokens field present on every
-    // turn when the cache is enabled on the server (issue #423).
+    // turn when the cache is enabled on the server.
     // ---------------------------------------------------------------
     for (i, t) in turns.iter().enumerate() {
         assert!(

--- a/tests/prompt_cache_prefill_bench.rs
+++ b/tests/prompt_cache_prefill_bench.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 //
 //! Prefill-latency benchmark for the cross-request prompt-prefix KV cache
-//! (epic #416, sub-issue #426).
 //!
 //! This harness is intentionally test-shaped (not a Criterion bench) because
 //! the project does not yet depend on `criterion` and the spec explicitly

--- a/tests/rdma_transport_bench.rs
+++ b/tests/rdma_transport_bench.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! 2-node loopback activation-transfer benchmark harness for issue #343.
+//! 2-node loopback activation-transfer benchmark harness.
 //!
 //! Run with:
 //!   cargo test --release --test rdma_transport_bench rdma_vs_tcp_activation_transfer \

--- a/tests/speculative_dispatch.rs
+++ b/tests/speculative_dispatch.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Integration tests for the server-side speculative-decoding dispatch
-//! matrix (issue #666).
+//! matrix.
 //!
 //! These tests cover the **operator-facing dispatch contract** end-to-end:
 //! they build a `ServerConfig` exactly like `mlxcel-server`'s CLI plumbing
@@ -292,7 +292,7 @@ fn dispatch_reports_drafter_kind_for_kind_specific_variants() {
 }
 
 // =============================================================================
-// Tick-level dispatch (issue #670 — burst path)
+// Tick-level dispatch (— burst path)
 //
 // These tests pin the **runtime gating** of the speculative dispatch:
 // they cannot construct a real `BatchScheduler` from outside the crate
@@ -375,7 +375,7 @@ fn dispatch_classic_fallback_is_not_burstable() {
     // it stays on the historical `SpeculativeGenerator` dispatch
     // (which the server today doesn't expose; the scheduler falls
     // back to classic decode). This is the operator-facing
-    // backward-compat guarantee from #666 / PR #669.
+    // backward-compat guarantee /.
     //
     // We can't easily construct a `Classic` variant from outside
     // (auto-detect requires `model_type` field that resolves to

--- a/tests/speculative_parity.rs
+++ b/tests/speculative_parity.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Greedy-parity verification for speculative drafter pairings (epic #633,
-//! sub-9 / issue #632).
+//! Greedy-parity verification for speculative drafter pairings (sub-9).
 //!
 //! ## What this file pins
 //!
@@ -30,16 +29,14 @@
 //!   `models/Qwen3.5-4B-DFlash`, `block_size = 16`). The DFlash drafter
 //!   is loadable via `mlxcel_core::drafter::dflash::DFlashDrafter::load`
 //!   and the Qwen 3.5 text / VLM wrappers implement
-//!   `mlxcel_core::drafter::dflash::SpeculativeTarget` (PR #663 wired the
-//!   B>1 path too; issue #691 enables the VLM-wrapped text-only server
-//!   dispatch). The published upstream `z-lab/Qwen3.5-4B-DFlash`
-//!   checkpoint omits `embed_tokens.weight`; issue #675 ported upstream's
+//!   `mlxcel_core::drafter::dflash::SpeculativeTarget` (wired the B>1 path too; enables the VLM-wrapped text-only server dispatch). The published upstream `z-lab/Qwen3.5-4B-DFlash`
+//!   checkpoint omits `embed_tokens.weight`; ported upstream's
 //!   lazy-bind shape so the drafter loads with a tombstone and resolves
 //!   its embedding from the target during `Drafter::bind`. The
 //!   `greedy_parity_dflash_qwen35_4b` test runs the structural load +
-//!   bind pin *and* the issue #676 end-to-end byte-equality phase
+//!   bind pin *and* the end-to-end byte-equality phase
 //!   (`mlxcel-server` with vs without `--draft-kind dflash` at temp=0),
-//!   plus an issue #691 log assertion that the speculative server emitted
+//!   plus an log assertion that the speculative server emitted
 //!   `Speculative burst completed` instead of silently falling back.
 //!
 //! - **Gemma 4 31B + MTP assistant** (`models/gemma-4-31b-it-4bit` target,
@@ -49,8 +46,8 @@
 //!   `Gemma4Wrapper` exposes the underlying primitives
 //!   (`forward_with_speculative_sinks`, `rollback_speculative_cache`), and
 //!   the server-side MTP burst dispatch + `MtpTarget` adapter were wired
-//!   by issues #666 / #670 / #671. The `greedy_parity_mtp_gemma4_31b`
-//!   test runs the structural load pin *and* the issue #676 end-to-end
+//! The `greedy_parity_mtp_gemma4_31b`
+//!   test runs the structural load pin *and* the end-to-end
 //!   byte-equality phase (`mlxcel-server` with vs without `--draft-kind
 //!   mtp` at temp=0).
 //!
@@ -59,19 +56,18 @@
 //! - **Gemma 4 E2B / E4B** — drafter checkpoints (`gemma-4-E2B-it-assistant-bf16`,
 //!   `gemma-4-E4B-it-assistant-bf16`) are not on local disk and the E-family
 //!   pairings additionally depend on the centroid LM head integration tracked
-//!   by follow-up #660.
+//!   by follow-up.
 //! - **Gemma 4 26B-A4B** — drafter checkpoint (`gemma-4-26B-A4B-it-assistant-bf16`)
 //!   is not on local disk. Skipped pending checkpoint availability.
 //!
-//! ## End-to-end byte-equality (issue #676)
+//! ## End-to-end byte-equality
 //!
 //! `greedy_parity_dflash_qwen35_4b` and `greedy_parity_mtp_gemma4_31b` each
 //! run a two-phase check:
 //!
 //! 1. **Structural phase** (in-process): load the target, assert the model
 //!    variant, resolve the drafter kind, load the drafter, and — for
-//!    DFlash — `bind()` the drafter to the target (the issue #675
-//!    lazy-bind pin). The in-process models are then dropped and the MLX
+//!    DFlash — `bind()` the drafter to the target (the lazy-bind pin). The in-process models are then dropped and the MLX
 //!    memory cache cleared before phase 2.
 //! 2. **Byte-equality phase** (subprocess): spawn `mlxcel-server` twice
 //!    against the same target — once with `--model-draft --draft-kind
@@ -286,7 +282,7 @@ async fn server_round(
     }
 }
 
-/// Issue #676 byte-equality phase: spawn `mlxcel-server` twice against the
+/// byte-equality phase: spawn `mlxcel-server` twice against the
 /// same `target_path` — once speculative (drafter attached via
 /// `--model-draft --draft-kind --draft-block-size`), once drafter-less —
 /// and assert the `/v1/chat/completions` responses are byte-identical.
@@ -461,7 +457,7 @@ fn pairing_kind_resolution_matches_declaration() {
 
 /// Greedy parity for the Qwen 3.5 4B + DFlash pairing.
 ///
-/// **Status:** end-to-end byte-equality (issue #676).
+/// **Status:** end-to-end byte-equality.
 ///
 /// Two-phase test (see the module docstring):
 ///
@@ -470,14 +466,12 @@ fn pairing_kind_resolution_matches_declaration() {
 ///    `DrafterKind::Dflash`, loads the DFlash drafter against the
 ///    published upstream `z-lab/Qwen3.5-4B-DFlash` checkpoint — which
 ///    omits `embed_tokens.weight` — and `bind()`s it to the target,
-///    resolving `embed_tokens` lazily from the target (the issue #675
-///    pin). The in-process models are then dropped.
+///    resolving `embed_tokens` lazily from the target (the pin). The in-process models are then dropped.
 /// 2. **Byte-equality phase** (subprocess): spawns `mlxcel-server` with
 ///    `--model-draft --draft-kind dflash --draft-block-size 16` and again
 ///    without any `--draft-*` flag, submits the same fixed prompt to
 ///    `/v1/chat/completions` at `temperature = 0`, asserts the speculative
-///    server logged `Speculative burst completed` (issue #691: no silent
-///    fallback), and asserts the two responses are byte-identical.
+///    server logged `Speculative burst completed` (no silent fallback), and asserts the two responses are byte-identical.
 ///
 /// `#[ignore]`-gated as real-model heavy: it loads the Qwen 3.5 4B target
 /// + DFlash drafter and spawns `mlxcel-server` subprocesses. The CI
@@ -538,14 +532,14 @@ async fn greedy_parity_dflash_qwen35_4b() {
 
         // `load_drafter` constructs the full DFlashDrafter (weight loading
         // + sanitize). The upstream `z-lab/Qwen3.5-4B-DFlash` checkpoint
-        // does NOT ship `embed_tokens.weight`; issue #675 ported upstream's
+        // does NOT ship `embed_tokens.weight`; ported upstream's
         // lazy-bind shape so the loader builds an `embed_tokens = None`
-        // tombstone instead of failing. A `LoadFailed` here is a #675
+        // tombstone instead of failing. A `LoadFailed` here is a
         // regression.
         let (mut drafter, drafter_kind) =
             mlxcel_core::drafter::load_drafter(&draft_path, Some(DrafterKind::Dflash)).expect(
                 "DFlash drafter must load against the published z-lab/Qwen3.5-4B-DFlash \
-                 checkpoint (issue #675: embed_tokens.weight is absent and the loader \
+                 checkpoint (embed_tokens.weight is absent and the loader \
                  builds a lazy-bind tombstone instead of failing)",
             );
         assert_eq!(drafter_kind, DrafterKind::Dflash);
@@ -555,13 +549,12 @@ async fn greedy_parity_dflash_qwen35_4b() {
         );
 
         // `bind` resolves the drafter's `embed_tokens` from the target's
-        // embedding module (`LanguageModel::embed_tokens_module`,
-        // implemented by the Qwen 3.5 family — issue #675). A `BindFailed`
+        // embedding module (`LanguageModel::embed_tokens_module`, implemented by the Qwen 3.5 family —). A `BindFailed`
         // here means either the target does not expose
         // `embed_tokens_module` or the lazy-bind tombstone was not wired.
         drafter
             .bind(&loaded_target)
-            .expect("DFlash drafter must bind to the Qwen 3.5 target (issue #675 lazy-bind)");
+            .expect("DFlash drafter must bind to the Qwen 3.5 target (lazy-bind)");
         eprintln!(
             "[{}] Drafter bound to target; embed_tokens resolved via lazy-bind",
             pairing.name,
@@ -582,7 +575,7 @@ async fn greedy_parity_dflash_qwen35_4b() {
 
 /// Greedy parity for the Gemma 4 31B + MTP assistant pairing.
 ///
-/// **Status:** end-to-end byte-equality (issue #676).
+/// **Status:** end-to-end byte-equality.
 ///
 /// Two-phase test (see the module docstring):
 ///
@@ -598,7 +591,6 @@ async fn greedy_parity_dflash_qwen35_4b() {
 ///    `/v1/chat/completions` at `temperature = 0`, and asserts the two
 ///    responses are byte-identical. The server-side MTP burst dispatch
 ///    and the `MtpTarget` adapter for `Gemma4Wrapper` were wired by
-///    issues #666 / #670 / #671.
 ///
 /// Note on dtype: this pairing uses a 4-bit quantized target with a bf16
 /// drafter. The 4-bit target keeps bf16 scales/biases as-is per
@@ -683,7 +675,7 @@ async fn greedy_parity_mtp_gemma4_31b() {
     assert_server_byte_equality(pairing, &target_path, &draft_path).await;
 }
 
-/// Issue #674 acceptance item 1: a B = 4 batched MTP burst produces
+/// acceptance item 1: a B = 4 batched MTP burst produces
 /// per-row token streams that are **byte-identical** to running the
 /// B = 1 MTP burst in isolation on each row's prompt.
 ///
@@ -768,14 +760,9 @@ fn greedy_parity_mtp_gemma4_batched_b4_matches_b1() {
             .expect("drafter bind");
         let mut generator = MtpGenerator::new(adapter, drafter, block_size);
         // Offline test: greedy sampling needs no token history (issue
-        // #682's `token_history` parameter is `&[]` for a config where
+        //'s `token_history` parameter is `&[]` for a config where
         // `needs_token_history()` is false), no cooperative
-        // cancellation (issue #672 / PR #681 added the `cancel`
-        // parameter; the offline path passes a never-set flag, matching
-        // `src/commands/generate.rs`), and no logprobs (issue #678 / PR
-        // #686 added the `logprobs_config` parameter; this byte-parity
-        // test compares only token streams, so a disabled-default
-        // `LogprobsConfig` keeps the zero-overhead path).
+        // cancellation (added the `cancel` parameter; the offline path passes a never-set flag, matching `src/commands/generate.rs`), and no logprobs (added the `logprobs_config` parameter; this byte-parity test compares only token streams, so a disabled-default `LogprobsConfig` keeps the zero-overhead path).
         let no_cancel = std::sync::atomic::AtomicBool::new(false);
         let logprobs_config = mlxcel_core::sampling::LogprobsConfig::default();
         let (tokens, _logprobs, _stats) = generator.generate(

--- a/tests/speculative_parity.rs
+++ b/tests/speculative_parity.rs
@@ -45,8 +45,8 @@
 //!   `mlxcel_core::drafter::gemma4_assistant::Gemma4AssistantDraftModel::from_path`,
 //!   `Gemma4Wrapper` exposes the underlying primitives
 //!   (`forward_with_speculative_sinks`, `rollback_speculative_cache`), and
-//!   the server-side MTP burst dispatch + `MtpTarget` adapter were wired
-//! The `greedy_parity_mtp_gemma4_31b`
+//!   the server-side MTP burst dispatch + `MtpTarget` adapter were wired.
+//!   The `greedy_parity_mtp_gemma4_31b`
 //!   test runs the structural load pin *and* the end-to-end
 //!   byte-equality phase (`mlxcel-server` with vs without `--draft-kind
 //!   mtp` at temp=0).

--- a/tests/structured_outputs.rs
+++ b/tests/structured_outputs.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Integration test for issue #550 (`response_format: {"type": "json_schema", ...}`).
+//! Integration test (`response_format: {"type": "json_schema",...}`).
 //!
 //! These tests build a real `llguidance` matcher over a synthetic byte-level
 //! tokenizer and walk it through a known-conforming JSON output. Failures
@@ -312,7 +312,7 @@ fn extract_response_format_helper_round_trips() {
 }
 
 // ---------------------------------------------------------------------------
-// apply_structured_mask_to_logits — issue #550 follow-up
+// apply_structured_mask_to_logits — follow-up
 //
 // These tests exercise the additive-bias construction directly so the
 // vocab-size handling stays correct in both directions
@@ -551,7 +551,7 @@ fn apply_mask_returns_error_when_no_reachable_token_is_allowed() {
 }
 
 // ---------------------------------------------------------------------------
-// PR #575 H1 / L3: public error messages must NOT leak llguidance internals.
+// H1 / L3: public error messages must NOT leak llguidance internals.
 //
 // `verbose_errors: false` (configured in `build_json_schema_constraint`) plus
 // the `tracing::error!` redaction policy means that even when the schema is

--- a/tests/surgery_cli.rs
+++ b/tests/surgery_cli.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! End-to-end integration tests for the `--surgery <config.yaml>` CLI
-//! flag (Epic #363, issue #371 — A4).
+//! flag (— A4).
 //!
 //! These tests exercise the full plumbing from clap argument parsing
 //! through `crate::surgery::set_active_pipeline` into the consolidated

--- a/tests/thinking_budget.rs
+++ b/tests/thinking_budget.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Integration tests for issue #409 thinking-token budget.
+//! Integration tests thinking-token budget.
 //!
 //! The correctness tests spin up the `mlxcel-server` binary against a real
 //! Qwen3 model and verify the generation loop enforces the configured cap

--- a/tests/turbo_kv_e2e.rs
+++ b/tests/turbo_kv_e2e.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Quality gate for the TurboQuant KV cache compression (epic #458, B3 / issue #475).
+//! Quality gate for the TurboQuant KV cache compression (B3).
 //!
 //! Tests two quality dimensions for `KVCacheMode::Turbo4Asym` vs `KVCacheMode::Fp16`
 //! baseline on a curated set of small MLX models:
@@ -72,10 +72,10 @@
 //! Note: The B3 Qwen2.5-1.5B fixture uses the **base** (non-instruct) variant
 //! `Qwen2.5-1.5B-4bit`. The instruct variant collapses on raw wikitext without
 //! the chat template (`<|im_start|>user\n...<|im_end|>`), producing PPL ≈ 2×10⁷
-//! and NIAH=0/12 (see issue #506). This gate measures TurboQuant compression
+//! and NIAH=0/12. This gate measures TurboQuant compression
 //! quality, not chat performance, so the base model is the correct fixture.
 //!
-//! # VLM gates (issue #510)
+//! # VLM gates
 //!
 //! VLM gates run a smaller PPL+NIAH harness on text-only inputs because the
 //! prefill cost on a vision-aware checkpoint is dominated by the decoder, not
@@ -587,8 +587,7 @@ fn run_quality_gate(model_dir_name: &str) -> Option<(f64, f64, usize, usize)> {
 //
 // The instruct-tuned `Qwen2.5-1.5B-Instruct-4bit` collapses on raw wikitext
 // without the chat template, producing PPL ≈ 2×10⁷ and NIAH=0/12 — values
-// six orders of magnitude off a healthy ~10–15 baseline (see issue #506 and
-// issue #493 comment). The relative turbo4asym gate would still pass in that
+// six orders of magnitude off a healthy ~10–15 baseline (and comment). The relative turbo4asym gate would still pass in that
 // case (both fp16 and turbo degenerate together), making the test a
 // meaningless noise check rather than a real quality signal.
 //
@@ -610,7 +609,7 @@ fn test_qwen25_15b_quality_gate() {
         (QWEN25_15B_BASE_PPL_MIN..=QWEN25_15B_BASE_PPL_MAX).contains(&ppl_fp16),
         "Qwen2.5-1.5B base fp16 PPL {ppl_fp16:.4} is outside the healthy raw-wikitext \
          range [{QWEN25_15B_BASE_PPL_MIN:.1}, {QWEN25_15B_BASE_PPL_MAX:.1}]. \
-         This gate exists to catch the degenerate instruct-fixture behavior from issue #506."
+         This gate exists to catch the degenerate instruct-fixture behavior."
     );
     assert!(
         niah_baseline > 0,
@@ -830,7 +829,7 @@ fn apply_rotation_to_data(data: &[f32], seed: u32) -> Vec<f32> {
 /// validates that `turbo4_v_rotate` is numerically correct and that the rotation
 /// does not *increase* kurtosis.
 ///
-/// Used by: `tests/turbo_kv_e2e.rs` (issue #475 kurtosis sanity check).
+/// Used by: `tests/turbo_kv_e2e.rs` (kurtosis sanity check).
 #[test]
 #[ignore = "requires at least one non-quantized (bf16/fp16) model checkout: \
             qwen2.5-0.5b-bf16 preferred. Quantized 4bit models are rejected \
@@ -847,7 +846,7 @@ fn test_rotation_kurtosis_sanity() {
         "gemma3n-e4b-bf16",
         "Qwen2.5-7B-Instruct-4bit",
         "qwen2.5-7b-4bit",
-        // base model used by B3 quality gate since issue #506
+        // base model used by B3 quality gate since
         "Qwen2.5-1.5B-4bit",
         "Qwen2.5-1.5B-Instruct-4bit",
         "Meta-Llama-3.1-8B-Instruct-4bit",
@@ -899,7 +898,7 @@ fn test_rotation_kurtosis_sanity() {
 }
 
 // ---------------------------------------------------------------------------
-// VLM (multimodal) quality gates — issue #510
+// VLM (multimodal) quality gates
 // ---------------------------------------------------------------------------
 
 // VLM-specific PPL sizing.
@@ -1244,9 +1243,9 @@ fn measure_vlm_image_token_kurtosis(model_dir_name: &str) -> Option<(f64, f64, u
     Some((kurt_before, kurt_after, image_len))
 }
 
-/// VLM image-token K-side kurtosis sanity test (issue #510).
+/// VLM image-token K-side kurtosis sanity test.
 ///
-/// Issue #475 establishes that the WHT + sign-flip rotation drops K-side
+/// establishes that the WHT + sign-flip rotation drops K-side
 /// kurtosis on **text** activations (TurboQuant+ paper reports ~900 → ~2.9
 /// on Qwen3-1.7B). This test repeats the measurement on the **image-token**
 /// slice of the K cache for every locally-cached VLM checkpoint to confirm
@@ -1272,7 +1271,7 @@ fn measure_vlm_image_token_kurtosis(model_dir_name: &str) -> Option<(f64, f64, u
 fn test_vlm_image_token_kurtosis() {
     // Order matters: smaller checkpoints first so the soft-skip walk is fast
     // when only the larger ones are available; aya-vision-8b and gemma-4-e4b
-    // are both healthy 4-bit VLM fixtures shipped during the #517 follow-up.
+    // are both healthy 4-bit VLM fixtures shipped during the follow-up.
     let candidates = [
         "qwen2-vl-2b-4bit",
         "qwen2.5-vl-3b-4bit",
@@ -1302,7 +1301,7 @@ fn test_vlm_image_token_kurtosis() {
         return;
     }
 
-    eprintln!("\n  Summary: VLM image-token K-side kurtosis pre/post WHT rotation (issue #510)");
+    eprintln!("\n  Summary: VLM image-token K-side kurtosis pre/post WHT rotation");
     for (model_name, kurt_before, kurt_after, image_tokens) in &results {
         eprintln!(
             "    {model_name:<24} n={image_tokens:<5} before={kurt_before:>10.4} → after={kurt_after:>8.4} \
@@ -1336,9 +1335,9 @@ fn test_vlm_image_token_kurtosis() {
     }
 }
 
-/// VLM Turbo4Asym B3 quality gate — Qwen2-VL 2B, text-only path (issue #510).
+/// VLM Turbo4Asym B3 quality gate — Qwen2-VL 2B, text-only path.
 ///
-/// Surrogate for the Qwen2.5-VL 3B fixture suggested in #510: same Qwen-VL
+/// Surrogate for the Qwen2.5-VL 3B fixture suggested in same Qwen-VL
 /// architecture (insert/expand image tokens via mRoPE-aware runtime) at a
 /// smaller size that loads under typical M1 Ultra dev RAM. Gates the relative
 /// PPL increase ≤ [`PPL_GATE_REL`] and NIAH retrieval not regressing.
@@ -1370,11 +1369,11 @@ fn test_qwen2_vl_2b_quality_gate() {
     );
 }
 
-/// VLM Turbo4Asym B3 quality gate — Aya-Vision 8B, text-only path (issue #510).
+/// VLM Turbo4Asym B3 quality gate — Aya-Vision 8B, text-only path.
 ///
 /// Aya-Vision is a Cohere2-decoder + SigLIP vision tower checkpoint (the
 /// "Standard" VLM family in `LoadedModel::vlm_runtime`). Together with
-/// Qwen2-VL 2B this satisfies the "at least 2 VLM models" criterion in #510.
+/// Qwen2-VL 2B this satisfies the "at least 2 VLM models" criterion.
 #[test]
 #[ignore = "requires aya-vision-8b weights — \
             run with --release -- --ignored test_aya_vision_8b_quality_gate --nocapture"]

--- a/tests/vlm_concurrency.rs
+++ b/tests/vlm_concurrency.rs
@@ -14,7 +14,7 @@
 
 //! Ignored real-model VLM server concurrency smoke tests.
 //!
-//! Issue #731 fixed a Gemma 3n VLM race where the MobileNet/MSFA
+//! fixed a Gemma 3n VLM race where the MobileNet/MSFA
 //! `per_layer_inputs` tensor was parked in one model-wide fallback slot. A
 //! burst of two server requests could have one row consume the other's tensor
 //! or panic after the slot was drained. The test below runs the real HTTP

--- a/tests/wht_op.rs
+++ b/tests/wht_op.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! End-to-end integration test for the public `mlxcel_core::wht` op
-//! (issue #470, B0 spike for epic #458 — TurboQuant KV cache compression).
+//! (B0 spike — TurboQuant KV cache compression).
 //!
 //! This file exists deliberately at the top-level `tests/` directory rather
 //! than as a `#[cfg(test)] mod` inside `mlxcel-core`. The point is to prove
@@ -46,7 +46,7 @@ fn make_random_normal(shape: &[i32], seed: u64) -> UniquePtr<MlxArray> {
 }
 
 /// `wht` is reachable as `mlxcel_core::wht` from a consumer crate.
-/// (The acceptance criterion in #470 names `mlxcel-core::ops::wht(...)`;
+/// (The acceptance criterion names `mlxcel-core::ops::wht(...)`;
 /// we re-export at the crate root for ergonomics, mirroring `concatenate`,
 /// `multiply_scalar`, etc.)
 #[test]

--- a/tests/zero_config_cluster_init.rs
+++ b/tests/zero_config_cluster_init.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Integration tests for the zero-config multi-machine PP bring-up path
-//! introduced by issue #342.
+//! introduced.
 //!
 //! The `#[ignore]` test at the bottom drives the full coordinator +
 //! remote-stage pipeline against a real Llama 3.2 1B-4bit checkpoint. It


### PR DESCRIPTION
## Summary

Removes leaked `mlxcel-internal` (private repository) issue/PR references that accumulated in the public tree through the historical internal→public port workflow, which until 2026-05-20 kept internal numbers verbatim in code comments. A public reader following a bare three-digit reference lands on an unrelated `lablup/mlxcel` issue or a 404, and it exposes internal planning.

Closes #40.

## What changed

- **Removed** all bare references to mlxcel-internal across `src/`, `tests/`, `docs/`, `examples/`, `CHANGELOG.md`, and `debian/changelog`, plus `Cargo.toml`, the benchmark runner scripts, and a CI workflow comment (the issue's intent is that internal numbers appear *nowhere* in the public tree). References are classified by number range: same-repo references that resolve to real `lablup/mlxcel` issues/PRs are kept; private-repo references are removed, or the comment is rephrased to describe the change without a number.
- **Preserved** upstream references (`ml-explore/mlx-lm`, `Blaizzy/mlx-vlm`, `ml-explore/mlx`). The most prominent ones — the benchmark baseline citations the issue calls out — are qualified as `ml-explore/mlx-lm#1240` and `Blaizzy/mlx-vlm#1181`.
- **Left untouched**: the wikitext corpus fixture body (only its provenance header was cleaned, so the perplexity gate is unaffected) and the pull-request template's illustrative closing-keyword example.

## Regression guard

- `scripts/ci/check_cross_repo_refs.py` flags bare three-digit references added on a diff that are not qualified as `org/repo#NNN`, classifying each as likely-upstream (qualify) or same-repo (confirm). Numbers at or above 1000 are always treated as upstream because this repository is far below that.
- An advisory CI job runs it on every pull request; `STRICT=1` turns it into a gate for local pre-push use.
- `CONTRIBUTING.md` documents the policy and the pre-flight command.

## Verification

- `cargo check --workspace --all-targets --features metal,accelerate` — clean.
- `cargo test --lib --bins --features metal,accelerate` — pass.
- `cargo test --test cli_help_consistency` — 10/10 (the existing CLI-help substring guard).
- `cargo fmt --all -- --check` — clean.
- Whole-tree scan: 0 remaining private-repo references; 0 collateral whitespace damage.

## Notes

This is tech debt from prior ports, not introduced by any single change. About 30 upstream references on the lines touched here stay prose-qualified (the surrounding text names the upstream project) rather than `org/repo#`-qualified; the new guard surfaces them and full qualification can follow incrementally.
