### PR TITLE
perf: page-gather decode microbench and paged-attention ADR (#117)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,10 @@ Current GitHub-facing docs:
 8. `responses-api.md` — implemented `/v1/responses` subset and gaps.
 9. `adding-models.md` — contribution guide for new model architectures.
 
+## Architecture Decision Records
+
+`adr/` holds numbered Architecture Decision Records, one significant decision per file, immutable once Accepted. See `adr/README.md` for the index.
+
 Expected future layout examples:
 
 - `docs/en/...` and `docs/ko/...` for MkDocs/manual pages.

--- a/docs/adr/0001-paged-attention-gather-vs-fused-kernel.md
+++ b/docs/adr/0001-paged-attention-gather-vs-fused-kernel.md
@@ -90,6 +90,8 @@ Run it under `caffeinate -i` so the host does not idle-throttle the GPU mid-run,
 | 4 | 32768 | 32 | 0.00 | 2110 | 2947 | 6567 | 12089 | 15233 | 1817 | 2048 | 211 | 622 |
 | 4 | 32768 | 64 | 0.00 | 2289 | 3041 | 6695 | 13334 | 18431 | 1763 | 1761 | 193 | 705 |
 
+Reading the table: layout A's `gatherA_only` can exceed `gatherA_sdpa` at short context (batch 1 at 1024 tokens is ~600us vs ~380us) because timing the gather alone forces MLX to materialize the full contiguous K/V, while the gather-then-SDPA path lets MLX fuse the `take`, `reshape`, and `transpose` into the fused-SDPA read without ever materializing that intermediate. The decode-relevant cost is `gatherA_sdpa` and the `overheadA%` derived from it, not `gatherA_only`. That fusion is the main reason strategy (A) stays cheap at the common context lengths: the per-step gather does not pay for a separate full copy of the sequence KV.
+
 ## Consequences
 
 Phases 1 through 3 inherit the following from this decision:

--- a/docs/adr/0001-paged-attention-gather-vs-fused-kernel.md
+++ b/docs/adr/0001-paged-attention-gather-vs-fused-kernel.md
@@ -21,7 +21,7 @@ This ADR is backed by the synthetic op-level measurements in `examples/page_gath
 
 Adopt **(A) gather-then-SDPA** for Phases 1 through 5 (#118 through #122). Defer the **(B)** fused Metal paged-attention kernel to Phase 6 (#123), and build it only if the measured gather overhead at the target context lengths is material.
 
-Rationale: the microbench shows gather overhead stays under <!--FILL_CROSSOVER-->% of SDPA time below ~<!--FILL_CROSSOVER_CTX--> tokens of context. Below that crossover, the gather is dominated by the attention it feeds, so (A) is within noise of the fused-kernel lower bound while needing no new kernel. Above it, the gather copy starts to cost enough that (B) is worth its complexity, which is why (B) stays on the roadmap rather than being dropped.
+Rationale: the microbench shows gather overhead (layout A, measured against the contiguous-SDPA lower bound) stays under ~15% of SDPA time below ~4096 tokens of single-sequence context. Below that crossover the gather is dominated by the attention it feeds, so (A) is within noise of the fused-kernel lower bound while needing no new kernel. Overhead then grows with both context length and batch: single-sequence decode reaches ~56% at 16384 tokens and ~67% at 32768, and batched decode (batch 4) is already ~48% at 1024 tokens and runs 2x to 3x the contiguous SDPA cost past 4096. So (B) earns its complexity for long-context or batched serving, which is why it stays on the roadmap rather than being dropped; the concrete trigger for building it is single-sequence context past ~16384 tokens, or any sustained batched decode.
 
 ### Pool tensor layout
 
@@ -30,11 +30,11 @@ Two candidate per-layer pool layouts were measured:
 - Layout A: `[num_blocks, block_size, n_kv_heads, head_dim]`.
 - Layout B (head-split): `[n_kv_heads, num_blocks, block_size, head_dim]`.
 
-Both reach the same `[batch, n_kv_heads, ctx, head_dim]` SDPA input after one `take`, one `reshape`, and one `transpose`; they differ in the `take` axis (0 for A, 1 for B) and in the `slice_update` shape used to append a fresh block each step. The recommendation, finalized from the `take` and `slice_update` numbers in the Results table, is: <!--FILL_LAYOUT_DECISION-->
+Both reach the same `[batch, n_kv_heads, ctx, head_dim]` SDPA input after one `take`, one `reshape`, and one `transpose`; they differ in the `take` axis (0 for A, 1 for B) and in the `slice_update` shape used to append a fresh block each step. The recommendation, finalized from the `take` and `slice_update` numbers in the Results table, is **layout A**, `[num_blocks, block_size, n_kv_heads, head_dim]`. Its gather-then-SDPA step is on average 2.1x faster than head-split layout B (1.2x to 3.2x across the sweep): taking on axis 0 keeps each block's `[block_size, n_kv_heads, head_dim]` slab contiguous, and MLX folds the trailing `[0, 2, 1, 3]` transpose into the SDPA read. Layout B takes on axis 1 and needs a `[1, 0, 2, 3]` transpose across the leading head axis, a scattered pattern MLX does not fuse into SDPA as cheaply, so `gatherB_sdpa` runs from roughly 2x the contiguous baseline at 4096 tokens to more than 4x at 16384. Block-append cost is layout-insensitive (`slice_update` averages ~680us for A and ~700us for B, within noise), so it does not offset layout A's gather advantage.
 
 ### Block size
 
-Keep the existing default block size (32) unless the data argues otherwise. <!--FILL_BLOCK_SIZE_NOTE--> The tradeoff the sweep exercises is fragmentation against gather dispatch cost: a smaller block (16) cuts internal fragmentation (fewer wasted slots in the last partial block of each sequence) but raises the number of `take` indices and therefore the gather dispatch, while a larger block (64) does the reverse.
+Keep the existing default block size (32) unless the data argues otherwise. Block size has little effect on the gather-then-SDPA cost at a fixed context length: layout A overhead varies by only a few points across 16 / 32 / 64 (batch 1 at 4096 tokens is 12%, 15%, and 16% for blocks 16, 32, 64). The swept context lengths are exact multiples of every block size, so `frag%` is 0 throughout the Results table; in production the internal waste is at most one partial block per sequence, below `block_size / ctx`. The tradeoff the sweep exercises is fragmentation against gather dispatch cost: a smaller block (16) cuts internal fragmentation (fewer wasted slots in the last partial block of each sequence) but raises the number of `take` indices and therefore the gather dispatch, while a larger block (64) does the reverse.
 
 ## Microbench methodology and reproduce
 
@@ -61,13 +61,34 @@ Run it under `caffeinate -i` so the host does not idle-throttle the GPU mid-run,
 
 ## Results
 
-**Hardware:** <!--FILL_HARDWARE-->
+**Hardware:** Apple M1 Ultra (Mac Studio), 128 GB unified memory, macOS 26.5 (build 25F71). Built `--release --features metal,accelerate`. Each cell is the minimum of two full sweeps (the cooler run), 50 timed iterations after 20 warmup, dtype f16.
 
 | batch | ctx | block | frag% | contig_sdpa_us | gatherA_only_us | gatherA_sdpa_us | gatherB_only_us | gatherB_sdpa_us | sliceupd_A_us | sliceupd_B_us | overheadA% | overheadB% |
 |------:|----:|------:|------:|---------------:|----------------:|----------------:|----------------:|----------------:|--------------:|--------------:|-----------:|-----------:|
-| 1 | 1024 | 32 | 0.00 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _tbd_ |
-
-<!-- BENCH_RESULTS_PLACEHOLDER: orchestrator fills the measured table + hardware line here -->
+| 1 | 1024 | 16 | 0.00 | 333 | 598 | 382 | 767 | 533 | 327 | 320 | 14 | 60 |
+| 1 | 1024 | 32 | 0.00 | 341 | 627 | 375 | 747 | 452 | 303 | 304 | 10 | 33 |
+| 1 | 1024 | 64 | 0.00 | 303 | 575 | 336 | 676 | 405 | 294 | 302 | 11 | 34 |
+| 1 | 4096 | 16 | 0.00 | 341 | 618 | 383 | 895 | 661 | 320 | 320 | 12 | 94 |
+| 1 | 4096 | 32 | 0.00 | 333 | 612 | 385 | 910 | 662 | 317 | 321 | 15 | 99 |
+| 1 | 4096 | 64 | 0.00 | 335 | 598 | 390 | 902 | 661 | 321 | 321 | 16 | 97 |
+| 1 | 16384 | 16 | 0.00 | 455 | 716 | 692 | 1861 | 1829 | 397 | 434 | 52 | 302 |
+| 1 | 16384 | 32 | 0.00 | 437 | 733 | 686 | 1877 | 1843 | 426 | 424 | 57 | 322 |
+| 1 | 16384 | 64 | 0.00 | 437 | 727 | 691 | 1884 | 1853 | 441 | 425 | 58 | 324 |
+| 1 | 32768 | 16 | 0.00 | 646 | 986 | 1070 | 3322 | 3338 | 683 | 687 | 66 | 417 |
+| 1 | 32768 | 32 | 0.00 | 635 | 987 | 1074 | 3360 | 3395 | 679 | 697 | 69 | 435 |
+| 1 | 32768 | 64 | 0.00 | 646 | 983 | 1065 | 3413 | 3461 | 681 | 685 | 65 | 436 |
+| 4 | 1024 | 16 | 0.00 | 339 | 609 | 513 | 946 | 732 | 334 | 316 | 52 | 116 |
+| 4 | 1024 | 32 | 0.00 | 340 | 614 | 514 | 904 | 739 | 314 | 323 | 51 | 118 |
+| 4 | 1024 | 64 | 0.00 | 362 | 643 | 516 | 892 | 710 | 312 | 317 | 42 | 96 |
+| 4 | 4096 | 16 | 0.00 | 483 | 727 | 1186 | 1880 | 2511 | 432 | 433 | 146 | 420 |
+| 4 | 4096 | 32 | 0.00 | 490 | 724 | 1209 | 1903 | 2552 | 437 | 433 | 147 | 421 |
+| 4 | 4096 | 64 | 0.00 | 500 | 729 | 1197 | 1920 | 2228 | 436 | 444 | 140 | 346 |
+| 4 | 16384 | 16 | 0.00 | 940 | 1383 | 3446 | 5987 | 7371 | 1039 | 1047 | 267 | 684 |
+| 4 | 16384 | 32 | 0.00 | 1018 | 1379 | 3408 | 6051 | 7685 | 1203 | 1266 | 235 | 655 |
+| 4 | 16384 | 64 | 0.00 | 1513 | 1874 | 4503 | 9275 | 9108 | 1202 | 1284 | 198 | 502 |
+| 4 | 32768 | 16 | 0.00 | 1757 | 2090 | 6551 | 11371 | 14245 | 1792 | 1850 | 273 | 711 |
+| 4 | 32768 | 32 | 0.00 | 2110 | 2947 | 6567 | 12089 | 15233 | 1817 | 2048 | 211 | 622 |
+| 4 | 32768 | 64 | 0.00 | 2289 | 3041 | 6695 | 13334 | 18431 | 1763 | 1761 | 193 | 705 |
 
 ## Consequences
 

--- a/docs/adr/0001-paged-attention-gather-vs-fused-kernel.md
+++ b/docs/adr/0001-paged-attention-gather-vs-fused-kernel.md
@@ -1,0 +1,89 @@
+# ADR 0001: Paged-attention gather strategy and KV pool tensor layout
+
+**Status:** Accepted (2026-05-31). Part of epic #116 (unified paged KV cache), Phase 0 (#117).
+
+## Context
+
+Epic #116 introduces a unified paged KV store: one global pool of fixed-size physical KV blocks, indexed by a radix trie, with blocks shared (copy-on-write) across sequences that share a prefix. The decode step for a sequence then has to read KV from blocks that are scattered across the pool rather than laid out contiguously, because two sequences sharing a prefix point at the same physical blocks and a sequence's own blocks are allocated on demand as it grows.
+
+Two attention strategies can serve that scattered read:
+
+- **(A) gather-then-SDPA.** Use `take` to pull the sequence's physical blocks out of the pool by index, `reshape` + `transpose` them into the `[batch, n_kv_heads, ctx, head_dim]` shape the fused kernel expects, then call the existing fused `scaled_dot_product_attention`. This is a small delta from the current dense decode path and reuses only existing FFI. The risk is the extra gather copy on every decode step.
+- **(B) fused Metal paged-attention kernel.** A custom kernel, modeled on the fused Sparse-V SDPA kernel in `src/lib/mlx-cpp/turbo/sparse_v_sdpa.metal`, that takes a block table and reads scattered blocks directly inside the attention kernel, with no separate gather copy. This is the lower bound on decode cost but is a large, hard-to-tune piece of Metal to write and maintain.
+
+Apple unified memory changes the calculus relative to a discrete-GPU PagedAttention deployment. There is no host swap-out and no PCIe copy: KV blocks already live in memory the GPU addresses directly. The win the unified store is chasing is therefore memory sharing (one physical copy of a shared prefix) and prefill avoidance (reuse a cached prefix instead of recomputing it), not avoiding host transfers. That reframes the decode gather cost of strategy (A) as the main risk to quantify: if gathering scattered blocks per step is cheap relative to the SDPA it feeds, (A) captures the sharing and prefill wins without the cost of building (B).
+
+This ADR is backed by the synthetic op-level measurements in `examples/page_gather_microbench.rs`. The current decode path it compares against is `paged_decode_attention_dense_compat` (`src/lib/mlxcel-core/src/layers.rs`), which already materializes a dense per-sequence K/V before the fused SDPA. The pool itself is `PagedBlockPool` (`src/lib/mlxcel-core/src/cache/paged.rs`), whose block size is configurable (the `profile_paged_decode_kernel` example and the existing paged decode tooling default to 32).
+
+## Decision
+
+### Attention strategy
+
+Adopt **(A) gather-then-SDPA** for Phases 1 through 5 (#118 through #122). Defer the **(B)** fused Metal paged-attention kernel to Phase 6 (#123), and build it only if the measured gather overhead at the target context lengths is material.
+
+Rationale: the microbench shows gather overhead stays under <!--FILL_CROSSOVER-->% of SDPA time below ~<!--FILL_CROSSOVER_CTX--> tokens of context. Below that crossover, the gather is dominated by the attention it feeds, so (A) is within noise of the fused-kernel lower bound while needing no new kernel. Above it, the gather copy starts to cost enough that (B) is worth its complexity, which is why (B) stays on the roadmap rather than being dropped.
+
+### Pool tensor layout
+
+Two candidate per-layer pool layouts were measured:
+
+- Layout A: `[num_blocks, block_size, n_kv_heads, head_dim]`.
+- Layout B (head-split): `[n_kv_heads, num_blocks, block_size, head_dim]`.
+
+Both reach the same `[batch, n_kv_heads, ctx, head_dim]` SDPA input after one `take`, one `reshape`, and one `transpose`; they differ in the `take` axis (0 for A, 1 for B) and in the `slice_update` shape used to append a fresh block each step. The recommendation, finalized from the `take` and `slice_update` numbers in the Results table, is: <!--FILL_LAYOUT_DECISION-->
+
+### Block size
+
+Keep the existing default block size (32) unless the data argues otherwise. <!--FILL_BLOCK_SIZE_NOTE--> The tradeoff the sweep exercises is fragmentation against gather dispatch cost: a smaller block (16) cuts internal fragmentation (fewer wasted slots in the last partial block of each sequence) but raises the number of `take` indices and therefore the gather dispatch, while a larger block (64) does the reverse.
+
+## Microbench methodology and reproduce
+
+The bench is fully synthetic and op-level. It allocates fake K/V tensors with `zeros` (only timing matters, not values), loads no model, and times each decode-step body with a warmup loop followed by `synchronize_default()`, then a timed loop that evals each result, then a closing `synchronize_default()`. Per-call cost is the total timed wall time divided by the iteration count. This is the same eval-per-iteration harness used by `examples/bridge_overhead_microbench.rs`.
+
+Paths measured per `(batch, ctx, block_size)`:
+
+- `contig_sdpa`: fused SDPA over a contiguous per-sequence K/V. This is the lower bound and the effective cost of the current `paged_decode_attention_dense_compat` path.
+- `gatherA_only` / `gatherB_only`: the `take` + `reshape` + `transpose` of K and V for each layout, with no attention, to isolate gather cost.
+- `gatherA_sdpa` / `gatherB_sdpa`: the full gather-then-SDPA decode step for each layout.
+- `sliceupd_A` / `sliceupd_B`: the per-step append of one fresh block into the pool via `slice_update`, for each layout.
+
+To keep `reshape` valid when the block size does not divide the context length, the materialized length is padded to `ctx_pad = ceil(ctx / block) * block`, and every path (including the contiguous baseline) attends over `ctx_pad` keys so the comparison is apples to apples. The reported `frag%` is `(ctx_pad - ctx) / ctx * 100`, the internal fragmentation the block size induces. Block ids are assigned in reverse pool order over a pool sized at 2x the needed blocks, so the gather reads genuinely scattered (non-contiguous) physical ids.
+
+Sweep: context lengths 1024 / 4096 / 16384 / 32768, batch sizes 1 / 4, block sizes 16 / 32 / 64. Dimensions: `head_dim` 128, `q_heads` 32, `kv_heads` 8, dtype f16.
+
+Reproduce:
+
+```text
+cargo run --release --features metal,accelerate --example page_gather_microbench
+```
+
+Run it under `caffeinate -i` so the host does not idle-throttle the GPU mid-run, and let the machine cool between sweeps; Apple Silicon down-clocks under sustained load, so a hot machine inflates the larger-context rows. The numbers in the Results table are measured on the spike machine and reproduce by re-running.
+
+## Results
+
+**Hardware:** <!--FILL_HARDWARE-->
+
+| batch | ctx | block | frag% | contig_sdpa_us | gatherA_only_us | gatherA_sdpa_us | gatherB_only_us | gatherB_sdpa_us | sliceupd_A_us | sliceupd_B_us | overheadA% | overheadB% |
+|------:|----:|------:|------:|---------------:|----------------:|----------------:|----------------:|----------------:|--------------:|--------------:|-----------:|-----------:|
+| 1 | 1024 | 32 | 0.00 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _tbd_ |
+
+<!-- BENCH_RESULTS_PLACEHOLDER: orchestrator fills the measured table + hardware line here -->
+
+## Consequences
+
+Phases 1 through 3 inherit the following from this decision:
+
+- **Phase 1 (#118), global block-pool tensor storage:** the pool is stored in the layout chosen above, and block append uses the `slice_update` shape measured for that layout. No new kernel is needed for this phase.
+- **Phase 2 (#119), paged decode attention over real block tables:** decode reads blocks with `take` over the real block table, then `reshape` + `transpose` into the SDPA input, then the existing fused `scaled_dot_product_attention`. This is the `gatherA_sdpa` / `gatherB_sdpa` path the bench measured, so the decode hot path reuses only existing FFI (`take`, `reshape`, `transpose`, fused SDPA) and adds no new kernel in Phases 1 and 2.
+- **Phase 3 (#120), paged prefill into the block pool:** prefill writes into the same pool layout, so it inherits the append path and the layout's `slice_update` characteristics.
+
+The fused Metal paged-attention kernel (Phase 6, #123) stays deferred. The crossover context length above gives the downstream phases a concrete trigger: if real workloads run past it and the gather overhead shows up in end-to-end decode throughput, (B) is the planned next step, and the gather path built in Phases 1 and 2 remains the correctness reference and fallback for it.
+
+## References
+
+- Epic #116, unified KV cache.
+- Issue #117, this Phase 0 spike.
+- `examples/page_gather_microbench.rs`, the microbench backing this ADR.
+- `src/lib/mlx-cpp/turbo/sparse_v_sdpa.metal`, the fused-kernel model for strategy (B).
+- `src/lib/mlxcel-core/src/layers.rs`, `paged_decode_attention_dense_compat`, the current dense decode path.
+- `src/lib/mlxcel-core/src/cache/paged.rs`, `PagedBlockPool` and `PagedKvLayout`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,7 @@
+# Architecture Decision Records
+
+This directory holds Architecture Decision Records (ADRs) for mlxcel. Each ADR captures one significant decision, the context that forced it, and the consequences that follow. ADRs are numbered sequentially and are immutable once their status is Accepted: a later decision that changes course gets a new ADR that supersedes the old one rather than editing it in place.
+
+## Index
+
+- [ADR 0001: Paged-attention gather strategy and KV pool tensor layout](0001-paged-attention-gather-vs-fused-kernel.md). Accepted. Adopts gather-then-SDPA for the unified paged KV cache (epic #116) and records the pool tensor layout decision, backed by `examples/page_gather_microbench.rs`.

--- a/examples/page_gather_microbench.rs
+++ b/examples/page_gather_microbench.rs
@@ -46,8 +46,8 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use mlxcel_core::{
-    eval, fast_scaled_dot_product_attention, from_slice_i32, reshape, slice_update,
-    synchronize_default, take, transpose_axes, zeros, MlxArray, UniquePtr,
+    MlxArray, UniquePtr, eval, fast_scaled_dot_product_attention, from_slice_i32, reshape,
+    slice_update, synchronize_default, take, transpose_axes, zeros,
 };
 
 // MLX dtype ids (see src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp:50-51).

--- a/examples/page_gather_microbench.rs
+++ b/examples/page_gather_microbench.rs
@@ -106,6 +106,98 @@ fn per_call_us(total: Duration, iters: usize) -> f64 {
     (total.as_nanos() as f64 / iters as f64) / 1000.0
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    // --- parse_usize_list ---
+
+    #[test]
+    fn parse_usize_list_single() {
+        assert_eq!(parse_usize_list("42"), vec![42]);
+    }
+
+    #[test]
+    fn parse_usize_list_multi() {
+        assert_eq!(parse_usize_list("1,4,16"), vec![1, 4, 16]);
+    }
+
+    #[test]
+    fn parse_usize_list_whitespace() {
+        assert_eq!(parse_usize_list(" 8 , 32 , 64 "), vec![8, 32, 64]);
+    }
+
+    #[test]
+    fn parse_usize_list_trailing_comma() {
+        // A trailing comma produces an empty token that is filtered out.
+        assert_eq!(parse_usize_list("1,2,"), vec![1, 2]);
+    }
+
+    #[test]
+    fn parse_usize_list_empty() {
+        assert!(parse_usize_list("").is_empty());
+    }
+
+    // --- per_call_us ---
+
+    #[test]
+    fn per_call_us_round() {
+        // 10ms total / 10 iters = 1000us per call.
+        let total = Duration::from_millis(10);
+        assert!((per_call_us(total, 10) - 1000.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn per_call_us_fractional() {
+        // 1ms total / 4 iters = 250us per call.
+        let total = Duration::from_millis(1);
+        assert!((per_call_us(total, 4) - 250.0).abs() < 1e-6);
+    }
+
+    // --- ctx_pad / frag_pct math (inlined from run_config) ---
+
+    fn ctx_frag(ctx: usize, block: usize) -> (usize, f64) {
+        let nb = ctx.div_ceil(block);
+        let ctx_pad = nb * block;
+        let frag_pct = (ctx_pad - ctx) as f64 / ctx as f64 * 100.0;
+        (ctx_pad, frag_pct)
+    }
+
+    #[test]
+    fn ctx_pad_exact_multiple() {
+        // ctx=1024, block=32 → already aligned, 0% fragmentation.
+        let (pad, frag) = ctx_frag(1024, 32);
+        assert_eq!(pad, 1024);
+        assert!(frag.abs() < 1e-9);
+    }
+
+    #[test]
+    fn ctx_pad_non_multiple() {
+        // ctx=1000, block=32 → rounds up to 1024 (32 * 32), frag = 24/1000 * 100.
+        let (pad, frag) = ctx_frag(1000, 32);
+        assert_eq!(pad, 1024);
+        let expected = 24.0 / 1000.0 * 100.0;
+        assert!((frag - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ctx_pad_block_size_1() {
+        // block=1 always produces 0% frag.
+        let (pad, frag) = ctx_frag(777, 1);
+        assert_eq!(pad, 777);
+        assert!(frag.abs() < 1e-9);
+    }
+
+    #[test]
+    fn ctx_pad_ctx_equals_block() {
+        // ctx == block → exactly one block, 0% frag.
+        let (pad, frag) = ctx_frag(64, 64);
+        assert_eq!(pad, 64);
+        assert!(frag.abs() < 1e-9);
+    }
+}
+
 /// Human-readable line for a single measured body.
 fn fmt_per_call(label: &str, total: Duration, iters: usize) {
     println!(

--- a/examples/page_gather_microbench.rs
+++ b/examples/page_gather_microbench.rs
@@ -1,0 +1,463 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Synthetic op-level microbench for paged KV decode attention.
+//!
+//! Part of epic #116 (unified paged KV cache), Phase 0 spike (#117). This
+//! measures the decode-step cost of gathering scattered physical KV blocks on
+//! MLX so we can decide between two attention strategies for the paged store:
+//!
+//! * (A) gather-then-SDPA: use `take` + `reshape` + `transpose` to materialize
+//!   a contiguous per-sequence K/V from scattered blocks, then call the fused
+//!   `scaled_dot_product_attention`. Reuses existing FFI, no new kernel.
+//! * (B) a fused Metal paged-attention kernel that reads scattered blocks
+//!   directly with no gather copy.
+//!
+//! The bench is fully synthetic: it allocates fake K/V with `zeros` (values do
+//! not matter, only timing) and times three decode-step attention paths plus a
+//! per-step block-append (`slice_update`) across a sweep of context lengths,
+//! batch sizes, and block sizes. It loads no model. Output feeds ADR 0001
+//! (`docs/adr/0001-paged-attention-gather-vs-fused-kernel.md`): the gather
+//! overhead vs contiguous SDPA, and the `take`/`slice_update` cost of two pool
+//! tensor layouts, decide (A)-first and the pool layout.
+//!
+//! Reproduce (use `caffeinate -i` so the host does not idle-throttle the GPU
+//! mid-run, and let the machine run cool between sweeps for stable numbers):
+//!
+//! ```text
+//! caffeinate -i cargo run --release --features metal,accelerate \
+//!     --example page_gather_microbench
+//! ```
+//!
+//! Or via the wrapper: `scripts/run_page_gather_microbench.sh`.
+
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use mlxcel_core::{
+    eval, fast_scaled_dot_product_attention, from_slice_i32, reshape, slice_update,
+    synchronize_default, take, transpose_axes, zeros, MlxArray, UniquePtr,
+};
+
+// MLX dtype ids (see src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp:50-51).
+const F16: i32 = 9;
+
+#[derive(Parser, Debug)]
+#[command(name = "page_gather_microbench")]
+struct Args {
+    /// Per-head dimension.
+    #[arg(long, default_value = "128")]
+    head_dim: i32,
+
+    /// Number of query heads.
+    #[arg(long, default_value = "32")]
+    q_heads: i32,
+
+    /// Number of key/value heads (GQA groups).
+    #[arg(long, default_value = "8")]
+    kv_heads: i32,
+
+    /// Comma-separated batch sizes to sweep.
+    #[arg(long, default_value = "1,4")]
+    batch_sizes: String,
+
+    /// Comma-separated context lengths to sweep.
+    #[arg(long, default_value = "1024,4096,16384,32768")]
+    context_lengths: String,
+
+    /// Comma-separated block sizes to sweep.
+    #[arg(long, default_value = "16,32,64")]
+    block_sizes: String,
+
+    /// Warmup iterations per measured body.
+    #[arg(long, default_value = "20")]
+    warmup: usize,
+
+    /// Timed iterations per measured body.
+    #[arg(long, default_value = "50")]
+    iters: usize,
+}
+
+/// Parse a comma-separated list of `usize` (whitespace tolerant).
+fn parse_usize_list(s: &str) -> Vec<usize> {
+    s.split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(|t| {
+            t.parse::<usize>()
+                .unwrap_or_else(|_| panic!("invalid list value: {t:?}"))
+        })
+        .collect()
+}
+
+/// Per-call microseconds for a timed body.
+fn per_call_us(total: Duration, iters: usize) -> f64 {
+    (total.as_nanos() as f64 / iters as f64) / 1000.0
+}
+
+/// Human-readable line for a single measured body.
+fn fmt_per_call(label: &str, total: Duration, iters: usize) {
+    println!(
+        "  {:<26} total={:>8.2}ms  per_call={:>9.3}us  ({} iters)",
+        label,
+        total.as_secs_f64() * 1000.0,
+        per_call_us(total, iters),
+        iters
+    );
+}
+
+/// Eval two arrays built on the same step. `keep` is returned so `time_body`
+/// can eval it; `also` is evaled here so both outputs are forced. Used to time
+/// the gather of K and V together (both are needed before SDPA can run).
+fn eval_pair(keep: UniquePtr<MlxArray>, also: &MlxArray) -> UniquePtr<MlxArray> {
+    eval(also);
+    keep
+}
+
+/// Time a closure that builds an `MlxArray` per iteration. Warms up, then runs
+/// `iters` timed iterations. Each iteration evals its result; a single
+/// `synchronize_default()` brackets the timed region (matching the eval-per-iter
+/// pattern in `examples/bridge_overhead_microbench.rs`).
+fn time_body<F>(warmup: usize, iters: usize, mut body: F) -> Duration
+where
+    F: FnMut() -> UniquePtr<MlxArray>,
+{
+    for _ in 0..warmup {
+        let out = body();
+        eval(&out);
+    }
+    synchronize_default();
+    let start = Instant::now();
+    for _ in 0..iters {
+        let out = body();
+        eval(&out);
+    }
+    synchronize_default();
+    start.elapsed()
+}
+
+/// `scale = 1 / sqrt(head_dim)`.
+fn sdpa_scale(head_dim: i32) -> f32 {
+    1.0 / (head_dim as f32).sqrt()
+}
+
+/// Fused SDPA with a null mask. A single decode query attends to all visible
+/// keys, so no causal mask is needed.
+fn sdpa(q: &MlxArray, k: &MlxArray, v: &MlxArray, scale: f32) -> UniquePtr<MlxArray> {
+    // SAFETY: `fast_scaled_dot_product_attention` is a thin FFI wrapper over the
+    // MLX fast SDPA kernel. The null mask pointer is the documented "no mask"
+    // sentinel; q/k/v outlive the call.
+    unsafe { fast_scaled_dot_product_attention(q, k, v, scale, std::ptr::null()) }
+}
+
+/// One measured config row. Timings are stored as raw totals over `iters`
+/// iterations; per-call microseconds are derived at print time via
+/// `per_call_us` so there is no double division.
+struct Row {
+    batch: usize,
+    ctx: usize,
+    ctx_pad: usize,
+    block: usize,
+    frag_pct: f64,
+    iters: usize,
+    contig_sdpa: Duration,
+    gather_a_only: Duration,
+    gather_a_sdpa: Duration,
+    gather_b_only: Duration,
+    gather_b_sdpa: Duration,
+    sliceupd_a: Duration,
+    sliceupd_b: Duration,
+}
+
+impl Row {
+    fn contig_sdpa_us(&self) -> f64 {
+        per_call_us(self.contig_sdpa, self.iters)
+    }
+    fn gather_a_only_us(&self) -> f64 {
+        per_call_us(self.gather_a_only, self.iters)
+    }
+    fn gather_a_sdpa_us(&self) -> f64 {
+        per_call_us(self.gather_a_sdpa, self.iters)
+    }
+    fn gather_b_only_us(&self) -> f64 {
+        per_call_us(self.gather_b_only, self.iters)
+    }
+    fn gather_b_sdpa_us(&self) -> f64 {
+        per_call_us(self.gather_b_sdpa, self.iters)
+    }
+    fn sliceupd_a_us(&self) -> f64 {
+        per_call_us(self.sliceupd_a, self.iters)
+    }
+    fn sliceupd_b_us(&self) -> f64 {
+        per_call_us(self.sliceupd_b, self.iters)
+    }
+    fn overhead_a_pct(&self) -> f64 {
+        (self.gather_a_sdpa_us() - self.contig_sdpa_us()) / self.contig_sdpa_us() * 100.0
+    }
+    fn overhead_b_pct(&self) -> f64 {
+        (self.gather_b_sdpa_us() - self.contig_sdpa_us()) / self.contig_sdpa_us() * 100.0
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_config(
+    head_dim: i32,
+    q_heads: i32,
+    kv_heads: i32,
+    batch: usize,
+    ctx: usize,
+    block: usize,
+    warmup: usize,
+    iters: usize,
+) -> Row {
+    let d = head_dim;
+    let hq = q_heads;
+    let hkv = kv_heads;
+    let bs = block as i32;
+    let b = batch as i32;
+    let scale = sdpa_scale(head_dim);
+
+    // Blocks per sequence and the padded (block-aligned) context length. We
+    // attend over `ctx_pad` keys on every path so the comparison is apples to
+    // apples; `frag` is the internal fragmentation the block size induces.
+    let nb = ctx.div_ceil(block);
+    let ctx_pad = nb * block;
+    let frag_pct = (ctx_pad - ctx) as f64 / ctx as f64 * 100.0;
+    let t_pad = ctx_pad as i32;
+    let total_blocks = batch * nb;
+    // 2x slack forces scattered (non-contiguous) physical ids.
+    let pool_blocks = total_blocks * 2;
+
+    // Decode query: one new token per sequence.
+    let q = zeros(&[b, hq, 1, d], F16);
+
+    // Scattered, deterministic, unique block ids: reverse order over the pool.
+    let ids: Vec<i32> = (0..total_blocks)
+        .map(|i| (pool_blocks - 1 - i) as i32)
+        .collect();
+    let block_ids = from_slice_i32(&ids, &[total_blocks as i32]);
+
+    // Path 1 inputs: contiguous per-sequence K/V (the lower bound).
+    let kc = zeros(&[b, hkv, t_pad, d], F16);
+    let vc = zeros(&[b, hkv, t_pad, d], F16);
+
+    // Layout A pools: [num_blocks, block_size, n_kv_heads, head_dim].
+    let pool_k_a = zeros(&[pool_blocks as i32, bs, hkv, d], F16);
+    let pool_v_a = zeros(&[pool_blocks as i32, bs, hkv, d], F16);
+    let new_block_a = zeros(&[1, bs, hkv, d], F16);
+
+    // Layout B pools (head-split): [n_kv_heads, num_blocks, block_size, head_dim].
+    let pool_k_b = zeros(&[hkv, pool_blocks as i32, bs, d], F16);
+    let pool_v_b = zeros(&[hkv, pool_blocks as i32, bs, d], F16);
+    let new_block_b = zeros(&[hkv, 1, bs, d], F16);
+
+    // Pre-eval all inputs once so allocation/fill cost is not in the timed
+    // region (mirrors `bench_matmul_512` pre-evaling its inputs).
+    for arr in [
+        &q,
+        &block_ids,
+        &kc,
+        &vc,
+        &pool_k_a,
+        &pool_v_a,
+        &new_block_a,
+        &pool_k_b,
+        &pool_v_b,
+        &new_block_b,
+    ] {
+        eval(arr);
+    }
+    synchronize_default();
+
+    // Layout A gather: take(axis=0) + reshape + transpose for K and V.
+    // [pool, BS, Hkv, D] --take--> [total_blocks, BS, Hkv, D]
+    //   --reshape--> [B, T_pad, Hkv, D] --transpose--> [B, Hkv, T_pad, D].
+    let gather_a = |q: &MlxArray, attend: bool| -> UniquePtr<MlxArray> {
+        let kg = take(&pool_k_a, &block_ids, 0);
+        let kg = reshape(&kg, &[b, t_pad, hkv, d]);
+        let kg = transpose_axes(&kg, &[0, 2, 1, 3]);
+        let vg = take(&pool_v_a, &block_ids, 0);
+        let vg = reshape(&vg, &[b, t_pad, hkv, d]);
+        let vg = transpose_axes(&vg, &[0, 2, 1, 3]);
+        if attend {
+            sdpa(q, &kg, &vg, scale)
+        } else {
+            eval_pair(kg, &vg)
+        }
+    };
+
+    // Layout B gather (head-split): take(axis=1) + reshape + transpose.
+    // [Hkv, pool, BS, D] --take--> [Hkv, total_blocks, BS, D]
+    //   --reshape--> [Hkv, B, T_pad, D] --transpose--> [B, Hkv, T_pad, D].
+    let gather_b = |q: &MlxArray, attend: bool| -> UniquePtr<MlxArray> {
+        let kg = take(&pool_k_b, &block_ids, 1);
+        let kg = reshape(&kg, &[hkv, b, t_pad, d]);
+        let kg = transpose_axes(&kg, &[1, 0, 2, 3]);
+        let vg = take(&pool_v_b, &block_ids, 1);
+        let vg = reshape(&vg, &[hkv, b, t_pad, d]);
+        let vg = transpose_axes(&vg, &[1, 0, 2, 3]);
+        if attend {
+            sdpa(q, &kg, &vg, scale)
+        } else {
+            eval_pair(kg, &vg)
+        }
+    };
+
+    // Path 1: contiguous SDPA (baseline / lower bound).
+    let contig_sdpa = time_body(warmup, iters, || sdpa(&q, &kc, &vc, scale));
+    // Path 2 (layout A): gather-only, then gather + SDPA.
+    let gather_a_only = time_body(warmup, iters, || gather_a(&q, false));
+    let gather_a_sdpa = time_body(warmup, iters, || gather_a(&q, true));
+    // Path 3 (layout B): gather-only, then gather + SDPA.
+    let gather_b_only = time_body(warmup, iters, || gather_b(&q, false));
+    let gather_b_sdpa = time_body(warmup, iters, || gather_b(&q, true));
+    // Path 4: per-step block append (slice_update of one fresh block).
+    let sliceupd_a = time_body(warmup, iters, || {
+        slice_update(&pool_k_a, &new_block_a, &[0, 0, 0, 0], &[1, bs, hkv, d])
+    });
+    let sliceupd_b = time_body(warmup, iters, || {
+        slice_update(&pool_k_b, &new_block_b, &[0, 0, 0, 0], &[hkv, 1, bs, d])
+    });
+
+    Row {
+        batch,
+        ctx,
+        ctx_pad,
+        block,
+        frag_pct,
+        iters,
+        contig_sdpa,
+        gather_a_only,
+        gather_a_sdpa,
+        gather_b_only,
+        gather_b_sdpa,
+        sliceupd_a,
+        sliceupd_b,
+    }
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let batch_sizes = parse_usize_list(&args.batch_sizes);
+    let context_lengths = parse_usize_list(&args.context_lengths);
+    let block_sizes = parse_usize_list(&args.block_sizes);
+
+    println!("=== mlxcel page-gather microbench (epic #116 Phase 0 / #117) ===");
+    println!(
+        "head_dim={} q_heads={} kv_heads={} dtype=f16",
+        args.head_dim, args.q_heads, args.kv_heads
+    );
+    println!("warmup={} iters={}", args.warmup, args.iters);
+    println!("Tip: run under `caffeinate -i` and let the machine cool between sweeps.");
+    println!();
+
+    let mut rows: Vec<Row> = Vec::new();
+    for &batch in &batch_sizes {
+        for &ctx in &context_lengths {
+            for &block in &block_sizes {
+                println!("--- batch={batch} ctx={ctx} block={block} ---");
+                let row = run_config(
+                    args.head_dim,
+                    args.q_heads,
+                    args.kv_heads,
+                    batch,
+                    ctx,
+                    block,
+                    args.warmup,
+                    args.iters,
+                );
+                println!("  ctx_pad={} frag={:.2}%", row.ctx_pad, row.frag_pct);
+                fmt_per_call("contig_sdpa", row.contig_sdpa, row.iters);
+                fmt_per_call("gatherA_only", row.gather_a_only, row.iters);
+                fmt_per_call("gatherA_sdpa", row.gather_a_sdpa, row.iters);
+                fmt_per_call("gatherB_only", row.gather_b_only, row.iters);
+                fmt_per_call("gatherB_sdpa", row.gather_b_sdpa, row.iters);
+                fmt_per_call("sliceupd_A", row.sliceupd_a, row.iters);
+                fmt_per_call("sliceupd_B", row.sliceupd_b, row.iters);
+                println!(
+                    "  overheadA={:.1}%  overheadB={:.1}%",
+                    row.overhead_a_pct(),
+                    row.overhead_b_pct()
+                );
+                println!();
+                rows.push(row);
+            }
+        }
+    }
+
+    // Aligned human-readable summary table.
+    println!("=== summary (per-call microseconds) ===");
+    println!(
+        "{:>5} {:>7} {:>7} {:>5} {:>7} | {:>12} {:>12} {:>12} {:>12} {:>12} {:>11} {:>11} | {:>10} {:>10}",
+        "B",
+        "ctx",
+        "ctxpad",
+        "blk",
+        "frag%",
+        "contig_sdpa",
+        "gatherA_only",
+        "gatherA_sdpa",
+        "gatherB_only",
+        "gatherB_sdpa",
+        "sliceupd_A",
+        "sliceupd_B",
+        "overheadA%",
+        "overheadB%",
+    );
+    for r in &rows {
+        println!(
+            "{:>5} {:>7} {:>7} {:>5} {:>7.2} | {:>12.3} {:>12.3} {:>12.3} {:>12.3} {:>12.3} {:>11.3} {:>11.3} | {:>10.1} {:>10.1}",
+            r.batch,
+            r.ctx,
+            r.ctx_pad,
+            r.block,
+            r.frag_pct,
+            r.contig_sdpa_us(),
+            r.gather_a_only_us(),
+            r.gather_a_sdpa_us(),
+            r.gather_b_only_us(),
+            r.gather_b_sdpa_us(),
+            r.sliceupd_a_us(),
+            r.sliceupd_b_us(),
+            r.overhead_a_pct(),
+            r.overhead_b_pct(),
+        );
+    }
+    println!();
+
+    // Machine-readable CSV block (one line per config, each prefixed `CSV:`).
+    println!(
+        "CSV:batch,ctx,ctx_pad,block,frag_pct,contig_sdpa_us,gatherA_only_us,gatherA_sdpa_us,gatherB_only_us,gatherB_sdpa_us,sliceupd_a_us,sliceupd_b_us,overhead_a_pct,overhead_b_pct"
+    );
+    for r in &rows {
+        println!(
+            "CSV:{},{},{},{},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3}",
+            r.batch,
+            r.ctx,
+            r.ctx_pad,
+            r.block,
+            r.frag_pct,
+            r.contig_sdpa_us(),
+            r.gather_a_only_us(),
+            r.gather_a_sdpa_us(),
+            r.gather_b_only_us(),
+            r.gather_b_sdpa_us(),
+            r.sliceupd_a_us(),
+            r.sliceupd_b_us(),
+            r.overhead_a_pct(),
+            r.overhead_b_pct(),
+        );
+    }
+}

--- a/scripts/run_page_gather_microbench.sh
+++ b/scripts/run_page_gather_microbench.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run the page-gather decode microbench (epic #116 Phase 0 / #117).
+#
+# Times gather-then-SDPA vs contiguous SDPA across a context/batch/block-size
+# sweep to inform the paged-attention strategy and KV pool layout in
+# docs/adr/0001-paged-attention-gather-vs-fused-kernel.md.
+#
+# Usage:
+#   scripts/run_page_gather_microbench.sh                 # default sweep
+#   scripts/run_page_gather_microbench.sh --context-lengths 1024,4096
+#
+# Any extra arguments are forwarded to the example. Runs under `caffeinate -i`
+# so the host does not idle-throttle the GPU mid-run; let the machine cool
+# between sweeps for stable numbers.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+caffeinate -i cargo run --release --features metal,accelerate \
+  --example page_gather_microbench -- "$@"


### PR DESCRIPTION
## Summary

Phase 0 feasibility spike for epic #116 (unified paged KV cache). Adds a synthetic op-level microbench that measures the decode-time cost of gathering scattered physical KV blocks on MLX, plus an ADR that uses those measurements to choose the paged-attention strategy and the KV pool tensor layout for the downstream phases.

This PR delivers the code, the docs, and the ADR with empirical-value sentinels. The bench is run on the spike machine and the measured numbers fill the sentinels in a follow-up (the MLX C++ link is a long cold build, so compiling and running the bench is handled separately from authoring).

## What changed

- `examples/page_gather_microbench.rs`: new synthetic, op-level decode microbench (no model load). Times contiguous SDPA (lower bound, the effective cost of the current `paged_decode_attention_dense_compat` path), gather-then-SDPA for two candidate pool layouts, gather-only per layout (to isolate gather cost from attention), and the per-step `slice_update` block append per layout. Sweeps context lengths 1024/4096/16384/32768, batch 1/4, block 16/32/64 at D=128, Hq=32, Hkv=8, f16. Forces scattered reads via reverse-order block ids over a 2x-slack pool, pads context to a block-aligned `ctx_pad` so all paths compare apples to apples, and reports block-size internal fragmentation. Emits an aligned human-readable table and a `CSV:`-prefixed machine-readable block. Timing harness mirrors `examples/bridge_overhead_microbench.rs`.
- `docs/adr/0001-paged-attention-gather-vs-fused-kernel.md`: new ADR. Decides (A) gather-then-SDPA for Phases 1-5 (#118-#122), defers the (B) fused Metal paged-attention kernel to Phase 6 (#123), keeps the existing default block size, and selects the pool layout from the measured `take`/`slice_update` numbers. Empirical values are `<!--FILL_...-->` sentinels.
- `docs/adr/README.md`: new ADR index, establishing `docs/adr/`.
- `docs/README.md`: links the new ADR directory from the docs layout.
- `scripts/run_page_gather_microbench.sh`: wrapper that runs the bench under `caffeinate -i`.

## Test plan

- [ ] `cargo run --release --features metal,accelerate --example page_gather_microbench` (run on the spike machine; numbers fill the ADR sentinels).
- [ ] `cargo build --release --features metal,accelerate --example page_gather_microbench` compiles.

Closes #117
