### PR TITLE
feat: add physical block-pool K/V tensor storage to PagedBlockPool

### DIFF
--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -80,6 +80,9 @@ mod detach;
 mod paged;
 mod paged_detach;
 #[cfg(test)]
+#[path = "cache/paged_pool_tests.rs"]
+mod paged_pool_tests;
+#[cfg(test)]
 #[path = "cache/paged_turbo_tests.rs"]
 mod paged_turbo_tests;
 #[cfg(test)]
@@ -96,7 +99,7 @@ pub use batch_quant::{
 };
 pub use detach::{DetachedCacheSet, DetachedHandle, DetachedKVCache, DetachedRotatingKVCache};
 pub use paged::{
-    PagedBlockId, PagedBlockPool, PagedCacheStats, PagedKvLayout, PagedLayerState,
+    GatheredKv, PagedBlockId, PagedBlockPool, PagedCacheStats, PagedKvLayout, PagedLayerState,
     PagedSequenceState,
 };
 pub use paged_detach::DetachedPagedCacheSet;
@@ -5365,17 +5368,20 @@ impl CachePool {
     pub fn memory_usage_bytes(&self) -> usize {
         let active_bytes: usize = self.active.values().map(|s| s.nbytes()).sum();
         let parked_bytes: usize = self.detached.values().map(|d| d.nbytes()).sum();
-        // Per-page Turbo4 sidecars in the paged pool are owned by the pool
-        // itself rather than by any individual `SequenceCacheSet`, so they
-        // are not visible to the per-sequence `nbytes()` walk above. Add
-        // them explicitly so admission-control sees the true KV footprint
-        // for paged Turbo4 deployments.
-        let pool_sidecar_bytes: usize = self
+        // Per-page Turbo4 sidecars and physical main-K/V pool tensors in the
+        // paged pool are owned by the pool itself rather than by any individual
+        // `SequenceCacheSet`, so they are not visible to the per-sequence
+        // `nbytes()` walk above. Add them explicitly so admission-control sees
+        // the true KV footprint for paged deployments. The main-K/V pool
+        // tensors are lazily allocated, so this contributes 0 until a writer is
+        // wired (#120) and never perturbs the layout-derived scheduling budgets
+        // (`reserved_bytes`/`used_bytes`).
+        let pool_bytes: usize = self
             .paged_pool
             .as_ref()
-            .map(|pool| pool.turbo_sidecar_bytes())
+            .map(|pool| pool.turbo_sidecar_bytes() + pool.pool_tensor_bytes())
             .unwrap_or(0);
-        active_bytes + parked_bytes + pool_sidecar_bytes
+        active_bytes + parked_bytes + pool_bytes
     }
 
     pub fn append_paged_tokens(

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -390,14 +390,42 @@ impl PagedTurboPageSidecars {
     }
 }
 
+/// Inferred per-layer geometry of a physical main-K/V pool tensor.
+///
+/// `PagedKvLayout` only carries the per-block byte budget; the head count,
+/// head dim, and element dtype are not known until the first block is written.
+/// They are captured here on the first [`PagedBlockPool::write_block`] for the
+/// layer and then validated against on every subsequent write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PagedPoolMeta {
+    n_kv_heads: i32,
+    head_dim: i32,
+    /// MLX dtype code of the stored K/V (e.g. `dtype::FLOAT16`, `dtype::INT8`).
+    dtype: i32,
+    /// Number of physical block rows the current pool tensor can hold along
+    /// axis 0. Grown in chunks as new rows are assigned.
+    capacity_blocks: usize,
+}
+
 /// Physical block allocator shared across every active paged sequence.
 ///
-/// In `Fp16`/`Int8` modes the pool tracks block-table metadata only — the
-/// actual KV tensors live in dense [`super::KVCache`] placeholders attached to
-/// each [`super::SequenceCacheSet`]. In Turbo4 modes the pool also owns per-
-/// page sidecar MLX arrays (`v_packed`, `v_norms`, optionally `k_packed`,
-/// `k_norms`, `cold_keys`) so packed quantization state survives across
-/// detach/adopt round-trips and prefix-cache handoffs.
+/// The pool can own the physical main K and V tensors (layout A from
+/// ADR 0001: each block occupies `[block_size, n_kv_heads, head_dim]` and a
+/// layer's pool tensor is `[capacity_blocks, block_size, n_kv_heads, head_dim]`,
+/// separate tensors for K and V per layer). Storage is lazily allocated on the
+/// first [`PagedBlockPool::write_block`] for a layer, so an `Fp16`/`Int8`
+/// sequence that never writes (the current live flow, where dense
+/// [`super::KVCache`] placeholders still carry live K/V) adds zero tensor or
+/// row overhead. Removal of the dense placeholders from the live flow lands
+/// with the decode-read (#119) / prefill-write (#120) reader/writer switch;
+/// until then the pool storage added here is exercised only by unit tests.
+///
+/// In Turbo4 modes the pool also owns per-page sidecar MLX arrays (`v_packed`,
+/// `v_norms`, optionally `k_packed`, `k_norms`, `cold_keys`) so packed
+/// quantization state survives across detach/adopt round-trips and
+/// prefix-cache handoffs. INT8 quantization scales stay in the dense
+/// `DetachedKVCache` path; only the INT8 main K/V int-typed array flows
+/// through the pool.
 pub struct PagedBlockPool {
     layout: PagedKvLayout,
     next_block_id: u64,
@@ -407,16 +435,55 @@ pub struct PagedBlockPool {
     /// `Fp16`/`Int8` cache modes; populated by Turbo4 sequences via
     /// [`PagedBlockPool::install_turbo_sidecar`].
     turbo_sidecars: PagedTurboPageSidecars,
+    /// Per-layer physical K pool tensor (layout A). `None` until the first
+    /// write to that layer lazily allocates it.
+    pool_k: Vec<Option<UniquePtr<MlxArray>>>,
+    /// Per-layer physical V pool tensor (layout A). `None` until first write.
+    pool_v: Vec<Option<UniquePtr<MlxArray>>>,
+    /// Per-layer inferred geometry/capacity of the pool tensors. `None` until
+    /// first write.
+    pool_meta: Vec<Option<PagedPoolMeta>>,
+    /// Per-layer `block_id -> physical row` map keeping the pool tensors
+    /// compact. Global `PagedBlockId`s remain unique across layers; rows are
+    /// layer-local and assigned lazily on first write to a block.
+    block_rows: Vec<HashMap<PagedBlockId, usize>>,
+    /// Per-layer free row list. A row is pushed here when its block hits
+    /// refcount 0 and is reused by the next first-write to a fresh block.
+    free_rows: Vec<Vec<usize>>,
+    /// Per-layer monotonic next-row cursor for rows never yet handed out.
+    next_row: Vec<usize>,
 }
+
+/// Number of physical block rows the pool tensor grows by when a freshly
+/// assigned row exceeds the current capacity. Mirrors the chunked-growth
+/// discipline of the dense `KVCache` (which pre-allocates in steps) so an
+/// append is O(block) amortised rather than O(rows) on every write.
+const POOL_GROW_CHUNK_BLOCKS: usize = 32;
+
+/// Gathered visible K and V tensors for one layer, each shaped
+/// `[1, n_kv_heads, visible_len, head_dim]` (SDPA-ready). Returned by
+/// [`PagedBlockPool::gather_visible`].
+pub type GatheredKv = (UniquePtr<MlxArray>, UniquePtr<MlxArray>);
+
+/// A normalized layout-A slot update (`[1, n_slots, n_kv_heads, head_dim]`)
+/// paired with its `(n_slots, n_kv_heads, head_dim)` geometry.
+type NormalizedBlock = (UniquePtr<MlxArray>, (i32, i32, i32));
 
 impl PagedBlockPool {
     pub fn new(layout: PagedKvLayout) -> Self {
+        let num_layers = layout.num_layers;
         Self {
-            free_lists: vec![Vec::new(); layout.num_layers],
+            free_lists: vec![Vec::new(); num_layers],
             layout,
             next_block_id: 0,
             blocks: HashMap::new(),
             turbo_sidecars: PagedTurboPageSidecars::default(),
+            pool_k: (0..num_layers).map(|_| None).collect(),
+            pool_v: (0..num_layers).map(|_| None).collect(),
+            pool_meta: vec![None; num_layers],
+            block_rows: vec![HashMap::new(); num_layers],
+            free_rows: vec![Vec::new(); num_layers],
+            next_row: vec![0; num_layers],
         }
     }
 
@@ -616,9 +683,11 @@ impl PagedBlockPool {
 
     /// Drop one logical reference to `block_id`. The block returns to the free
     /// list (and becomes eligible for recycling) only once the refcount
-    /// reaches zero. Per-page Turbo4 sidecars (if any) are dropped at the same
-    /// moment so a recycled block can never serve stale packed data to a new
-    /// sequence.
+    /// reaches zero. Per-page Turbo4 sidecars (if any) and the block's main
+    /// K/V pool row (if assigned) are released at the same moment so a recycled
+    /// block can never serve stale data to a new sequence. The recycled row is
+    /// overwritten before any read, so it needs no zeroing — only to become
+    /// reusable.
     ///
     /// Used by: paged detach/adopt cleanup, internal sequence tear-down.
     pub fn release_block(&mut self, block_id: PagedBlockId) -> Result<(), String> {
@@ -641,6 +710,10 @@ impl PagedBlockPool {
         // Block has hit refcount 0 — drop any associated Turbo4 sidecars so
         // recycle-time aliasing cannot leak old packed contents.
         self.turbo_sidecars.forget(block_id);
+        // Free the main-K/V pool row, if one was assigned, so it can be reused.
+        if let Some(row) = self.block_rows[layer_idx].remove(&block_id) {
+            self.free_rows[layer_idx].push(row);
+        }
         self.free_lists[layer_idx].push(block_id);
         Ok(())
     }
@@ -809,6 +882,298 @@ impl PagedBlockPool {
             || self.turbo_sidecars.cold_keys.contains_key(&block_id)
     }
 
+    // -----------------------------------------------------------------------
+    // Physical main K/V pool storage (layout A)
+    // -----------------------------------------------------------------------
+
+    /// Write one block's worth of K/V into the layer's physical pool tensors.
+    ///
+    /// Routes both `Fp16` and `Int8` main K/V through pool storage (INT8 is
+    /// just an int-typed array to `slice_update`; quantization scales stay in
+    /// the dense path and are not touched here). The row for `block_id` is
+    /// assigned lazily on the first write (reusing a freed row when available),
+    /// and the pool tensor is grown in [`POOL_GROW_CHUNK_BLOCKS`] chunks when a
+    /// fresh row exceeds capacity. The write reassigns the pool tensor via
+    /// `slice_update` so MLX donates the buffer (O(block), per ADR 0001's
+    /// append discipline).
+    ///
+    /// Accepted `k_block` / `v_block` shapes (the same for both):
+    /// - `[1, n_kv_heads, n_slots, head_dim]` — the SDPA-style layout the
+    ///   attention path produces (primary convention), or
+    /// - `[n_slots, n_kv_heads, head_dim]` — the bare layout-A row slab.
+    ///
+    /// `slot_start` is the first slot within the block; `slot_start + n_slots`
+    /// must not exceed `block_size`. dtype/geometry are validated against the
+    /// layer's `PagedPoolMeta` (captured on the first write) on every call.
+    pub fn write_block(
+        &mut self,
+        block_id: PagedBlockId,
+        layer_idx: usize,
+        slot_start: usize,
+        k_block: &MlxArray,
+        v_block: &MlxArray,
+    ) -> Result<(), String> {
+        self.validate_layer(layer_idx)?;
+        if !self.blocks.contains_key(&block_id) {
+            return Err(format!("PagedBlockPool: unknown block {block_id}"));
+        }
+
+        // Normalize both inputs to a `[1, n_slots, n_kv_heads, head_dim]` slot
+        // update matching layout A, and extract (n_slots, n_kv_heads, head_dim).
+        let (k_slot, k_geom) = normalize_block_for_layout_a(k_block, "k_block")?;
+        let (v_slot, v_geom) = normalize_block_for_layout_a(v_block, "v_block")?;
+        if k_geom != v_geom {
+            return Err(format!(
+                "PagedBlockPool::write_block: K geometry {k_geom:?} does not match V geometry {v_geom:?}"
+            ));
+        }
+        let (n_slots, n_kv_heads, head_dim) = k_geom;
+        let k_dtype = ffi::array_dtype(k_block);
+        let v_dtype = ffi::array_dtype(v_block);
+        if k_dtype != v_dtype {
+            return Err(format!(
+                "PagedBlockPool::write_block: K dtype {k_dtype} does not match V dtype {v_dtype}"
+            ));
+        }
+
+        let block_size = self.layout.block_size as i32;
+        if n_slots <= 0 || slot_start as i32 + n_slots > block_size {
+            return Err(format!(
+                "PagedBlockPool::write_block: slot range [{slot_start}, {}) out of bounds for block_size {block_size}",
+                slot_start as i32 + n_slots
+            ));
+        }
+
+        // Capture or validate the layer's pool geometry.
+        match self.pool_meta[layer_idx] {
+            Some(meta) => {
+                if meta.n_kv_heads != n_kv_heads
+                    || meta.head_dim != head_dim
+                    || meta.dtype != k_dtype
+                {
+                    return Err(format!(
+                        "PagedBlockPool::write_block: layer {layer_idx} expects (n_kv_heads={}, head_dim={}, dtype={}); got (n_kv_heads={n_kv_heads}, head_dim={head_dim}, dtype={k_dtype})",
+                        meta.n_kv_heads, meta.head_dim, meta.dtype
+                    ));
+                }
+            }
+            None => {
+                let capacity = POOL_GROW_CHUNK_BLOCKS;
+                let shape = [capacity as i32, block_size, n_kv_heads, head_dim];
+                self.pool_k[layer_idx] = Some(ffi::zeros(&shape, k_dtype));
+                self.pool_v[layer_idx] = Some(ffi::zeros(&shape, k_dtype));
+                self.pool_meta[layer_idx] = Some(PagedPoolMeta {
+                    n_kv_heads,
+                    head_dim,
+                    dtype: k_dtype,
+                    capacity_blocks: capacity,
+                });
+            }
+        }
+
+        // Resolve (and grow for) the physical row for this block.
+        let row = self.assign_row(block_id, layer_idx)?;
+
+        // Reassign the pool tensors with the slot update so MLX donates the
+        // buffer (in-place append, O(block)).
+        let starts = [row as i32, slot_start as i32, 0, 0];
+        let stops = [
+            row as i32 + 1,
+            slot_start as i32 + n_slots,
+            n_kv_heads,
+            head_dim,
+        ];
+        let old_k = self.pool_k[layer_idx]
+            .take()
+            .expect("pool_k allocated above");
+        self.pool_k[layer_idx] = Some(ffi::slice_update(&old_k, &k_slot, &starts, &stops));
+        let old_v = self.pool_v[layer_idx]
+            .take()
+            .expect("pool_v allocated above");
+        self.pool_v[layer_idx] = Some(ffi::slice_update(&old_v, &v_slot, &starts, &stops));
+        Ok(())
+    }
+
+    /// Gather the visible K/V window for one layer of a sequence into the
+    /// SDPA-ready shape `[1, n_kv_heads, visible_len, head_dim]`.
+    ///
+    /// Builds the physical-row index array from the layer's `block_ids` (in
+    /// block-table order — works for fragmented / out-of-order rows), takes
+    /// those rows out of the pool on axis 0, flattens the block dimension,
+    /// slices the visible window `[logical_start, len)` (dropping any trimmed
+    /// prefix and trailing padding), and transposes into the fused-SDPA layout.
+    /// The result is byte-identical to the equivalent dense contiguous buffer's
+    /// visible slice. Returns `Ok(None)` when the layer has no visible tokens
+    /// or no pool storage yet.
+    pub fn gather_visible(
+        &self,
+        state: &PagedSequenceState,
+        layer_idx: usize,
+    ) -> Result<Option<GatheredKv>, String> {
+        let layer = state.layer(layer_idx).ok_or_else(|| {
+            format!(
+                "PagedBlockPool::gather_visible: layer {layer_idx} out of range for {} layers",
+                state.layers.len()
+            )
+        })?;
+        let visible_len = layer.visible_len();
+        if visible_len == 0 || layer.block_ids.is_empty() {
+            return Ok(None);
+        }
+
+        let (pool_k, pool_v) = match (
+            self.pool_k.get(layer_idx).and_then(|p| p.as_ref()),
+            self.pool_v.get(layer_idx).and_then(|p| p.as_ref()),
+        ) {
+            (Some(k), Some(v)) => (k, v),
+            _ => return Ok(None),
+        };
+        let meta = self.pool_meta[layer_idx]
+            .expect("pool_meta present whenever pool tensors are allocated");
+
+        // Map each block id (in block-table order) to its physical row.
+        let mut rows_i32 = Vec::with_capacity(layer.block_ids.len());
+        for block_id in &layer.block_ids {
+            let row = *self.block_rows[layer_idx].get(block_id).ok_or_else(|| {
+                format!(
+                    "PagedBlockPool::gather_visible: block {block_id} on layer {layer_idx} has no pool row (was it written?)"
+                )
+            })?;
+            rows_i32.push(row as i32);
+        }
+
+        let block_size = self.layout.block_size as i32;
+        let n_blocks = rows_i32.len() as i32;
+        let logical_start = layer.logical_start as i32;
+        let len = layer.len as i32;
+        if len > n_blocks * block_size {
+            return Err(format!(
+                "PagedBlockPool::gather_visible: layer {layer_idx} len {len} exceeds {n_blocks} blocks * block_size {block_size}"
+            ));
+        }
+
+        let idx = ffi::from_slice_i32(&rows_i32, &[n_blocks]);
+
+        let gather = |pool: &MlxArray| -> UniquePtr<MlxArray> {
+            // [n_blocks, block_size, H, D]
+            let gathered = ffi::take(pool, &idx, 0);
+            // [n_blocks * block_size, H, D]
+            let flat = ffi::reshape(
+                &gathered,
+                &[n_blocks * block_size, meta.n_kv_heads, meta.head_dim],
+            );
+            // [visible_len, H, D] — drop trimmed prefix and trailing padding.
+            let window = ffi::slice(
+                &flat,
+                &[logical_start, 0, 0],
+                &[len, meta.n_kv_heads, meta.head_dim],
+            );
+            // [1, visible_len, H, D]
+            let batched = ffi::reshape(
+                &window,
+                &[1, len - logical_start, meta.n_kv_heads, meta.head_dim],
+            );
+            // [1, H, visible_len, D]
+            ffi::transpose_axes(&batched, &[0, 2, 1, 3])
+        };
+
+        Ok(Some((gather(pool_k), gather(pool_v))))
+    }
+
+    /// Sum of every allocated physical main-K/V pool tensor (K and V, all
+    /// layers). Additive to the layout-derived scheduling budgets in
+    /// `reserved_bytes`/`used_bytes`, which are unchanged.
+    ///
+    /// Used by: `CachePool::memory_usage_bytes` to reflect the true pool
+    /// footprint once the live writer is wired (#120).
+    pub fn pool_tensor_bytes(&self) -> usize {
+        let sum = |pools: &[Option<UniquePtr<MlxArray>>]| -> usize {
+            pools
+                .iter()
+                .filter_map(|p| p.as_ref())
+                .map(|a| ffi::array_nbytes(a))
+                .sum()
+        };
+        sum(&self.pool_k) + sum(&self.pool_v)
+    }
+
+    /// Resolve the physical pool row for `block_id` on `layer_idx`, assigning
+    /// one lazily on first write (reusing a freed row when available) and
+    /// growing the pool tensors if the new row exceeds capacity.
+    fn assign_row(&mut self, block_id: PagedBlockId, layer_idx: usize) -> Result<usize, String> {
+        if let Some(&row) = self.block_rows[layer_idx].get(&block_id) {
+            return Ok(row);
+        }
+        let row = match self.free_rows[layer_idx].pop() {
+            Some(row) => row,
+            None => {
+                let row = self.next_row[layer_idx];
+                self.next_row[layer_idx] += 1;
+                row
+            }
+        };
+        if row
+            >= self.pool_meta[layer_idx]
+                .map(|m| m.capacity_blocks)
+                .unwrap_or(0)
+        {
+            self.grow_pool(layer_idx, row + 1)?;
+        }
+        self.block_rows[layer_idx].insert(block_id, row);
+        Ok(row)
+    }
+
+    /// Grow the layer's K and V pool tensors so they hold at least
+    /// `min_capacity` rows, rounding up to the next [`POOL_GROW_CHUNK_BLOCKS`]
+    /// multiple. Existing rows are copied into the larger buffer via
+    /// `slice_update`.
+    fn grow_pool(&mut self, layer_idx: usize, min_capacity: usize) -> Result<(), String> {
+        let meta = self.pool_meta[layer_idx].ok_or_else(|| {
+            format!("PagedBlockPool::grow_pool: layer {layer_idx} has no pool tensors")
+        })?;
+        if min_capacity <= meta.capacity_blocks {
+            return Ok(());
+        }
+        let new_capacity = min_capacity
+            .div_ceil(POOL_GROW_CHUNK_BLOCKS)
+            .saturating_mul(POOL_GROW_CHUNK_BLOCKS)
+            .max(POOL_GROW_CHUNK_BLOCKS);
+        let block_size = self.layout.block_size as i32;
+        let new_shape = [
+            new_capacity as i32,
+            block_size,
+            meta.n_kv_heads,
+            meta.head_dim,
+        ];
+        let copy_stops = [
+            meta.capacity_blocks as i32,
+            block_size,
+            meta.n_kv_heads,
+            meta.head_dim,
+        ];
+        let starts = [0, 0, 0, 0];
+
+        let old_k = self.pool_k[layer_idx]
+            .take()
+            .expect("pool_k present when meta present");
+        let mut new_k = ffi::zeros(&new_shape, meta.dtype);
+        new_k = ffi::slice_update(&new_k, &old_k, &starts, &copy_stops);
+        self.pool_k[layer_idx] = Some(new_k);
+
+        let old_v = self.pool_v[layer_idx]
+            .take()
+            .expect("pool_v present when meta present");
+        let mut new_v = ffi::zeros(&new_shape, meta.dtype);
+        new_v = ffi::slice_update(&new_v, &old_v, &starts, &copy_stops);
+        self.pool_v[layer_idx] = Some(new_v);
+
+        self.pool_meta[layer_idx] = Some(PagedPoolMeta {
+            capacity_blocks: new_capacity,
+            ..meta
+        });
+        Ok(())
+    }
+
     fn assert_turbo_mode(&self, op: &str) -> Result<(), String> {
         if !self.layout.is_turbo_mode() {
             return Err(format!(
@@ -880,5 +1245,37 @@ impl PagedBlockPool {
             ));
         }
         Ok(())
+    }
+}
+
+/// Normalize a write block into the layout-A slot update shape
+/// `[1, n_slots, n_kv_heads, head_dim]` and return its geometry
+/// `(n_slots, n_kv_heads, head_dim)`.
+///
+/// Accepts either the SDPA-style `[1, n_kv_heads, n_slots, head_dim]` (4D) or
+/// the bare layout-A `[n_slots, n_kv_heads, head_dim]` (3D). No dtype
+/// conversion is performed: `reshape`/`transpose_axes` preserve dtype, so an
+/// FP16 block stays FP16 and an INT8 block stays INT8.
+fn normalize_block_for_layout_a(block: &MlxArray, label: &str) -> Result<NormalizedBlock, String> {
+    let shape = ffi::array_shape(block);
+    match shape.as_slice() {
+        // [1, n_kv_heads, n_slots, head_dim] -> [1, n_slots, n_kv_heads, head_dim]
+        [batch, n_kv_heads, n_slots, head_dim] => {
+            if *batch != 1 {
+                return Err(format!(
+                    "PagedBlockPool::write_block: {label} 4D batch dim must be 1, got {batch} (shape {shape:?})"
+                ));
+            }
+            let slot = ffi::transpose_axes(block, &[0, 2, 1, 3]);
+            Ok((slot, (*n_slots, *n_kv_heads, *head_dim)))
+        }
+        // [n_slots, n_kv_heads, head_dim] -> [1, n_slots, n_kv_heads, head_dim]
+        [n_slots, n_kv_heads, head_dim] => {
+            let slot = ffi::reshape(block, &[1, *n_slots, *n_kv_heads, *head_dim]);
+            Ok((slot, (*n_slots, *n_kv_heads, *head_dim)))
+        }
+        _ => Err(format!(
+            "PagedBlockPool::write_block: {label} must be [1, n_kv_heads, n_slots, head_dim] or [n_slots, n_kv_heads, head_dim], got shape {shape:?}"
+        )),
     }
 }

--- a/src/lib/mlxcel-core/src/cache/paged_pool_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_pool_tests.rs
@@ -22,6 +22,7 @@
 //! 3. Partial final block gathers exactly `visible_len` tokens (no padding).
 //! 4. `logical_start > 0` (post-trim) gathers the correct visible window.
 //! 5. INT8 main K/V round-trips byte-identically (dtype preserved, no astype).
+//! 5b. FP16 main K/V round-trips byte-identically (dtype preserved, no astype).
 //! 6. `release_block` to refcount 0 frees and recycles a row with fresh data.
 //! 7. `pool_tensor_bytes` reflects allocated pool tensors.
 //! 8. Turbo4 sidecars coexist with main-K/V rows.
@@ -398,6 +399,73 @@ fn int8_main_kv_round_trips_byte_identically() {
     dense_v = ffi::slice_update(
         &dense_v,
         &make_int8_block(-40, 4),
+        &[0, 0, 4, 0],
+        &[1, H, 8, D],
+    );
+    assert_eq!(raw_bytes(&gv), raw_bytes(&dense_v));
+}
+
+// ---------------------------------------------------------------------------
+// 5b. FP16 main K/V round-trips byte-identically (dtype preserved, no astype)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fp16_main_kv_round_trips_byte_identically() {
+    // Build FP16 blocks by casting FP32 data through astype.  FP16 is exact
+    // through pure data-movement ops (take/reshape/slice/transpose), so a
+    // raw-byte comparison is meaningful and proves no silent dtype coercion.
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    pool.append_tokens(&mut state, 0, 8).unwrap(); // 2 blocks
+    let ids = state.layer(0).unwrap().block_ids.clone();
+
+    // Create FP16 blocks by casting known FP32 data.
+    let k0 = ffi::astype(&make_block(1.0, 4), dtype::FLOAT16);
+    let v0 = ffi::astype(&make_block(50.0, 4), dtype::FLOAT16);
+    let k1 = ffi::astype(&make_block(100.0, 4), dtype::FLOAT16);
+    let v1 = ffi::astype(&make_block(150.0, 4), dtype::FLOAT16);
+
+    pool.write_block(ids[0], 0, 0, &k0, &v0).unwrap();
+    pool.write_block(ids[1], 0, 0, &k1, &v1).unwrap();
+
+    let (gk, gv) = pool
+        .gather_visible(&state, 0)
+        .unwrap()
+        .expect("gather must return data");
+
+    // dtype must remain FLOAT16 — no astype coercion on the K/V path.
+    assert_eq!(ffi::array_dtype(&gk), dtype::FLOAT16);
+    assert_eq!(ffi::array_dtype(&gv), dtype::FLOAT16);
+    assert_eq!(ffi::array_shape(&gk), vec![1, H, 8, D]);
+
+    // Byte-identity vs a dense FP16 reference built the same way.
+    let mut dense_k = ffi::zeros(&[1, H, 8, D], dtype::FLOAT16);
+    dense_k = ffi::slice_update(
+        &dense_k,
+        &ffi::astype(&make_block(1.0, 4), dtype::FLOAT16),
+        &[0, 0, 0, 0],
+        &[1, H, 4, D],
+    );
+    dense_k = ffi::slice_update(
+        &dense_k,
+        &ffi::astype(&make_block(100.0, 4), dtype::FLOAT16),
+        &[0, 0, 4, 0],
+        &[1, H, 8, D],
+    );
+    assert_eq!(raw_bytes(&gk), raw_bytes(&dense_k));
+
+    let mut dense_v = ffi::zeros(&[1, H, 8, D], dtype::FLOAT16);
+    dense_v = ffi::slice_update(
+        &dense_v,
+        &ffi::astype(&make_block(50.0, 4), dtype::FLOAT16),
+        &[0, 0, 0, 0],
+        &[1, H, 4, D],
+    );
+    dense_v = ffi::slice_update(
+        &dense_v,
+        &ffi::astype(&make_block(150.0, 4), dtype::FLOAT16),
         &[0, 0, 4, 0],
         &[1, H, 8, D],
     );

--- a/src/lib/mlxcel-core/src/cache/paged_pool_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_pool_tests.rs
@@ -1,0 +1,605 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the physical main-K/V pool storage added to
+//! `PagedBlockPool` in #118 (Phase 1 of the unified paged KV cache, #116).
+//!
+//! Organised as:
+//! 1. write_block + gather_visible byte-identity vs a dense contiguous buffer
+//!    (the acceptance criterion).
+//! 2. Fragmented / out-of-order physical rows gather in block-table order.
+//! 3. Partial final block gathers exactly `visible_len` tokens (no padding).
+//! 4. `logical_start > 0` (post-trim) gathers the correct visible window.
+//! 5. INT8 main K/V round-trips byte-identically (dtype preserved, no astype).
+//! 6. `release_block` to refcount 0 frees and recycles a row with fresh data.
+//! 7. `pool_tensor_bytes` reflects allocated pool tensors.
+//! 8. Turbo4 sidecars coexist with main-K/V rows.
+
+use super::paged::{PagedBlockId, PagedBlockPool, PagedKvLayout, PagedSequenceState};
+use super::KVCacheMode;
+
+use crate::dtype;
+use crate::ffi;
+use crate::ffi::MlxArray;
+use cxx::UniquePtr;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const H: i32 = 2; // n_kv_heads
+const D: i32 = 3; // head_dim
+
+fn fp16_pool(block_size: usize, num_layers: usize) -> PagedBlockPool {
+    // bytes_per_block is only a scheduling budget; geometry is inferred from
+    // the first written block, so any positive multiple of block_size works.
+    let layout = PagedKvLayout::uniform(
+        num_layers,
+        block_size,
+        block_size * H as usize * D as usize * 2,
+    )
+    .unwrap();
+    PagedBlockPool::new(layout)
+}
+
+/// Deterministic `[1, H, n_slots, D]` FP32 block. Element value encodes
+/// `(base, head, slot, dim)` so any misplacement is caught exactly. FP32 round
+/// trips bit-exactly through MLX, so byte comparison is meaningful.
+fn make_block(base: f32, n_slots: i32) -> UniquePtr<MlxArray> {
+    let mut values = Vec::with_capacity((H * n_slots * D) as usize);
+    for head in 0..H {
+        for slot in 0..n_slots {
+            for dim in 0..D {
+                values.push(base + head as f32 * 1000.0 + slot as f32 * 10.0 + dim as f32 * 0.1);
+            }
+        }
+    }
+    ffi::from_slice_f32(&values, &[1, H, n_slots, D])
+}
+
+/// Same logical block as [`make_block`], emitted as the bare layout-A slab
+/// `[n_slots, H, D]` to exercise the 3D write convention.
+fn make_block_3d(base: f32, n_slots: i32) -> UniquePtr<MlxArray> {
+    // Build [1, H, n_slots, D] then transpose to [n_slots, H, D].
+    let four_d = make_block(base, n_slots);
+    let t = ffi::transpose_axes(&four_d, &[0, 2, 1, 3]); // [1, n_slots, H, D]
+    ffi::reshape(&t, &[n_slots, H, D])
+}
+
+/// Deterministic `[1, H, n_slots, D]` INT8 block.
+fn make_int8_block(base: i8, n_slots: i32) -> UniquePtr<MlxArray> {
+    let mut bytes = Vec::with_capacity((H * n_slots * D) as usize);
+    for head in 0..H {
+        for slot in 0..n_slots {
+            for dim in 0..D {
+                let v = base
+                    .wrapping_add((head as i8).wrapping_mul(7))
+                    .wrapping_add((slot as i8).wrapping_mul(3))
+                    .wrapping_add(dim as i8);
+                bytes.push(v as u8);
+            }
+        }
+    }
+    ffi::from_bytes(&bytes, &[1, H, n_slots, D], dtype::INT8)
+}
+
+/// Flatten any tensor to a row-major Vec<f32> (after an FP32 cast) so contents
+/// can be compared independent of stride. Mirrors `detach_tests::flatten_fp32`.
+fn flatten_fp32(arr: &MlxArray) -> Vec<f32> {
+    let a = ffi::astype(arr, dtype::FLOAT32);
+    ffi::eval(&a);
+    let bytes = ffi::array_to_raw_bytes(&a);
+    bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+/// Raw little-endian bytes of an evaluated tensor (no dtype cast). Used for the
+/// INT8 byte-identity check.
+fn raw_bytes(arr: &MlxArray) -> Vec<u8> {
+    ffi::eval(arr);
+    ffi::array_to_raw_bytes(arr)
+}
+
+/// Build the dense contiguous reference `[1, H, T, D]` by writing each
+/// `[1, H, n_slots, D]` block at its logical token offset, then return the
+/// visible slice `[0, 0, 0, visible_len]` as `[1, H, visible_len, D]`.
+fn dense_reference(
+    blocks: &[(UniquePtr<MlxArray>, usize)], // (block, slot_start within the dense buffer)
+    total_tokens: i32,
+    visible_start: i32,
+    visible_len: i32,
+) -> UniquePtr<MlxArray> {
+    let mut dense = ffi::zeros(&[1, H, total_tokens, D], dtype::FLOAT32);
+    for (block, offset) in blocks {
+        let shape = ffi::array_shape(block);
+        let n_slots = shape[2];
+        let starts = [0, 0, *offset as i32, 0];
+        let stops = [1, H, *offset as i32 + n_slots, D];
+        dense = ffi::slice_update(&dense, block, &starts, &stops);
+    }
+    ffi::slice(
+        &dense,
+        &[0, 0, visible_start, 0],
+        &[1, H, visible_start + visible_len, D],
+    )
+}
+
+// ---------------------------------------------------------------------------
+// 1. Acceptance: contiguous write -> gather is byte-identical to dense
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contiguous_gather_is_byte_identical_to_dense() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    // 3 full blocks => 12 tokens.
+    let n_blocks = 3i32;
+    let total = n_blocks * block_size as i32;
+    pool.append_tokens(&mut state, 0, total as usize).unwrap();
+    let block_ids = state.layer(0).unwrap().block_ids.clone();
+    assert_eq!(block_ids.len(), n_blocks as usize);
+
+    // Write each block with distinct data; collect the same data for the
+    // dense reference.
+    let mut dense_blocks: Vec<(UniquePtr<MlxArray>, usize)> = Vec::new();
+    for (b, &block_id) in block_ids.iter().enumerate() {
+        let k = make_block(100.0 + b as f32, block_size as i32);
+        let v = make_block(500.0 + b as f32, block_size as i32);
+        pool.write_block(block_id, 0, 0, &k, &v).unwrap();
+        dense_blocks.push((k, b * block_size));
+        // V reference handled separately below by re-deriving the same base.
+        let _ = v;
+    }
+
+    let (gk, gv) = pool
+        .gather_visible(&state, 0)
+        .unwrap()
+        .expect("gather must return data");
+    // Shape is [1, H, visible_len, D].
+    assert_eq!(ffi::array_shape(&gk), vec![1, H, total, D]);
+
+    let dense_k = dense_reference(&dense_blocks, total, 0, total);
+    assert_eq!(flatten_fp32(&gk), flatten_fp32(&dense_k));
+
+    // Rebuild dense V reference from the same value bases.
+    let mut dense_v_blocks: Vec<(UniquePtr<MlxArray>, usize)> = Vec::new();
+    for b in 0..n_blocks as usize {
+        dense_v_blocks.push((
+            make_block(500.0 + b as f32, block_size as i32),
+            b * block_size,
+        ));
+    }
+    let dense_v = dense_reference(&dense_v_blocks, total, 0, total);
+    assert_eq!(flatten_fp32(&gv), flatten_fp32(&dense_v));
+}
+
+// ---------------------------------------------------------------------------
+// 2. Fragmented / out-of-order physical rows gather in block-table order
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fragmented_rows_gather_in_block_table_order() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+
+    // Allocate three sequences' worth of blocks so rows interleave, then build
+    // ONE sequence whose block table references rows out of physical order.
+    // We acquire blocks by appending to three throwaway states, write into
+    // them in a scrambled order, and then assemble a sequence state by hand.
+    let mut s = PagedSequenceState::new(pool.layout());
+    pool.append_tokens(&mut s, 0, 3 * block_size).unwrap();
+    let ids = s.layer(0).unwrap().block_ids.clone(); // [b0, b1, b2] -> rows 0,1,2
+
+    // Write the THIRD block first, then first, then second, so the row
+    // assignment order (0,1,2 by acquisition) is decoupled from write order.
+    // Row assignment happens on first write, so writing in (b2, b0, b1) order
+    // assigns rows 0->b2, 1->b0, 2->b1.
+    pool.write_block(
+        ids[2],
+        0,
+        0,
+        &make_block(20.0, block_size as i32),
+        &make_block(70.0, block_size as i32),
+    )
+    .unwrap();
+    pool.write_block(
+        ids[0],
+        0,
+        0,
+        &make_block(10.0, block_size as i32),
+        &make_block(60.0, block_size as i32),
+    )
+    .unwrap();
+    pool.write_block(
+        ids[1],
+        0,
+        0,
+        &make_block(30.0, block_size as i32),
+        &make_block(80.0, block_size as i32),
+    )
+    .unwrap();
+
+    // The sequence's block table is in logical order [b0, b1, b2], whose
+    // physical rows are [1, 2, 0] — genuinely scattered.
+    let (gk, _gv) = pool
+        .gather_visible(&s, 0)
+        .unwrap()
+        .expect("gather must return data");
+
+    // Dense reference in block-table order: b0 (base 10), b1 (30), b2 (20).
+    let total = 3 * block_size as i32;
+    let dense_blocks = vec![
+        (make_block(10.0, block_size as i32), 0),
+        (make_block(30.0, block_size as i32), block_size),
+        (make_block(20.0, block_size as i32), 2 * block_size),
+    ];
+    let dense_k = dense_reference(&dense_blocks, total, 0, total);
+    assert_eq!(flatten_fp32(&gk), flatten_fp32(&dense_k));
+}
+
+// ---------------------------------------------------------------------------
+// 3. Partial final block gathers exactly visible_len (no padding leakage)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn partial_final_block_gathers_exactly_visible_len() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    // 6 tokens => 2 blocks, last block half-full (slots 0,1 valid; 2,3 pad).
+    pool.append_tokens(&mut state, 0, 6).unwrap();
+    let ids = state.layer(0).unwrap().block_ids.clone();
+    assert_eq!(ids.len(), 2);
+
+    // Block 0 full (4 slots), block 1 has 2 slots written.
+    pool.write_block(ids[0], 0, 0, &make_block(100.0, 4), &make_block(500.0, 4))
+        .unwrap();
+    pool.write_block(ids[1], 0, 0, &make_block(200.0, 2), &make_block(600.0, 2))
+        .unwrap();
+
+    let (gk, _gv) = pool
+        .gather_visible(&state, 0)
+        .unwrap()
+        .expect("gather must return data");
+    // Exactly 6 visible tokens, NOT 8.
+    assert_eq!(ffi::array_shape(&gk), vec![1, H, 6, D]);
+
+    // Dense reference: 6-wide buffer (no padding slots exist at all).
+    let dense_blocks = vec![(make_block(100.0, 4), 0), (make_block(200.0, 2), 4)];
+    let dense_k = dense_reference(&dense_blocks, 6, 0, 6);
+    assert_eq!(flatten_fp32(&gk), flatten_fp32(&dense_k));
+}
+
+// ---------------------------------------------------------------------------
+// 4. logical_start > 0 (post-trim) gathers the correct window
+// ---------------------------------------------------------------------------
+
+#[test]
+fn logical_start_offset_gathers_correct_window() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    // 12 tokens, 3 full blocks, all written.
+    pool.append_tokens(&mut state, 0, 12).unwrap();
+    let ids = state.layer(0).unwrap().block_ids.clone();
+    for (b, &id) in ids.iter().enumerate() {
+        pool.write_block(
+            id,
+            0,
+            0,
+            &make_block(100.0 + b as f32, 4),
+            &make_block(500.0 + b as f32, 4),
+        )
+        .unwrap();
+    }
+
+    // Simulate a sliding-window trim of the first 5 tokens: bump
+    // logical_start. (This is the post-trim state the decode path would see;
+    // gather must return tokens [5, 12) = 7 tokens.)
+    state.layer_mut(0).unwrap().logical_start = 5;
+    assert_eq!(state.layer(0).unwrap().visible_len(), 7);
+
+    let (gk, _gv) = pool
+        .gather_visible(&state, 0)
+        .unwrap()
+        .expect("gather must return data");
+    assert_eq!(ffi::array_shape(&gk), vec![1, H, 7, D]);
+
+    // Dense reference: full 12-wide buffer, sliced to the visible window [5,12).
+    let dense_blocks = vec![
+        (make_block(100.0, 4), 0),
+        (make_block(101.0, 4), 4),
+        (make_block(102.0, 4), 8),
+    ];
+    let dense_k = dense_reference(&dense_blocks, 12, 5, 7);
+    assert_eq!(flatten_fp32(&gk), flatten_fp32(&dense_k));
+}
+
+// ---------------------------------------------------------------------------
+// 5. INT8 main K/V round-trips byte-identically (dtype preserved)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn int8_main_kv_round_trips_byte_identically() {
+    let block_size = 4usize;
+    let layout =
+        PagedKvLayout::new_with_mode(block_size, vec![512], KVCacheMode::Int8, Vec::new()).unwrap();
+    let mut pool = PagedBlockPool::new(layout);
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    pool.append_tokens(&mut state, 0, 8).unwrap(); // 2 blocks
+    let ids = state.layer(0).unwrap().block_ids.clone();
+    pool.write_block(
+        ids[0],
+        0,
+        0,
+        &make_int8_block(1, 4),
+        &make_int8_block(50, 4),
+    )
+    .unwrap();
+    pool.write_block(
+        ids[1],
+        0,
+        0,
+        &make_int8_block(100, 4),
+        &make_int8_block(-40, 4),
+    )
+    .unwrap();
+
+    let (gk, gv) = pool
+        .gather_visible(&state, 0)
+        .unwrap()
+        .expect("gather must return data");
+    // dtype must remain INT8 (no astype on the K/V path).
+    assert_eq!(ffi::array_dtype(&gk), dtype::INT8);
+    assert_eq!(ffi::array_dtype(&gv), dtype::INT8);
+    assert_eq!(ffi::array_shape(&gk), vec![1, H, 8, D]);
+
+    // Byte-identity vs a dense INT8 buffer.
+    let mut dense_k = ffi::zeros(&[1, H, 8, D], dtype::INT8);
+    dense_k = ffi::slice_update(
+        &dense_k,
+        &make_int8_block(1, 4),
+        &[0, 0, 0, 0],
+        &[1, H, 4, D],
+    );
+    dense_k = ffi::slice_update(
+        &dense_k,
+        &make_int8_block(100, 4),
+        &[0, 0, 4, 0],
+        &[1, H, 8, D],
+    );
+    assert_eq!(raw_bytes(&gk), raw_bytes(&dense_k));
+
+    let mut dense_v = ffi::zeros(&[1, H, 8, D], dtype::INT8);
+    dense_v = ffi::slice_update(
+        &dense_v,
+        &make_int8_block(50, 4),
+        &[0, 0, 0, 0],
+        &[1, H, 4, D],
+    );
+    dense_v = ffi::slice_update(
+        &dense_v,
+        &make_int8_block(-40, 4),
+        &[0, 0, 4, 0],
+        &[1, H, 8, D],
+    );
+    assert_eq!(raw_bytes(&gv), raw_bytes(&dense_v));
+}
+
+// ---------------------------------------------------------------------------
+// 6. release_block to refcount 0 frees + recycles a row with fresh data
+// ---------------------------------------------------------------------------
+
+#[test]
+fn released_row_is_recycled_and_serves_fresh_data() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    // One block, written, then trimmed away (refcount -> 0, row freed).
+    pool.append_tokens(&mut state, 0, 4).unwrap();
+    let first_id = state.layer(0).unwrap().block_ids[0];
+    pool.write_block(first_id, 0, 0, &make_block(999.0, 4), &make_block(999.0, 4))
+        .unwrap();
+    let bytes_after_first = pool.pool_tensor_bytes();
+    assert!(bytes_after_first > 0);
+
+    pool.trim_tokens(&mut state, 0, 4).unwrap();
+    assert_eq!(pool.refcount(first_id), 0);
+    assert_eq!(state.layer(0).unwrap().block_ids.len(), 0);
+
+    // Re-acquire (recycles the freed block id AND its row) and write NEW data.
+    pool.append_tokens(&mut state, 0, 4).unwrap();
+    let second_id = state.layer(0).unwrap().block_ids[0];
+    assert_eq!(second_id, first_id, "block id should be recycled");
+    pool.write_block(second_id, 0, 0, &make_block(11.0, 4), &make_block(22.0, 4))
+        .unwrap();
+
+    // Pool tensor must not have grown (the row was reused, not appended).
+    assert_eq!(pool.pool_tensor_bytes(), bytes_after_first);
+
+    let (gk, gv) = pool
+        .gather_visible(&state, 0)
+        .unwrap()
+        .expect("gather must return data");
+    // Must serve the NEW data, with no stale bytes from the 999.0 write.
+    let dense_k = dense_reference(&[(make_block(11.0, 4), 0)], 4, 0, 4);
+    let dense_v = dense_reference(&[(make_block(22.0, 4), 0)], 4, 0, 4);
+    assert_eq!(flatten_fp32(&gk), flatten_fp32(&dense_k));
+    assert_eq!(flatten_fp32(&gv), flatten_fp32(&dense_v));
+}
+
+// ---------------------------------------------------------------------------
+// 7. pool_tensor_bytes reflects allocated pool tensors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pool_tensor_bytes_tracks_allocation() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 2);
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    // No writes yet: lazily-allocated pools stay None => zero bytes.
+    assert_eq!(pool.pool_tensor_bytes(), 0);
+
+    pool.append_tokens(&mut state, 0, 4).unwrap();
+    let id0 = state.layer(0).unwrap().block_ids[0];
+    pool.write_block(id0, 0, 0, &make_block(1.0, 4), &make_block(2.0, 4))
+        .unwrap();
+    // Layer 0 K and V pool tensors allocated at the grow chunk: 2 tensors *
+    // (32 blocks * 4 slots * H * D * 4 bytes).
+    let expected_layer0 = 2 * (32 * block_size as i32 * H * D * 4) as usize;
+    assert_eq!(pool.pool_tensor_bytes(), expected_layer0);
+
+    // Writing to layer 1 allocates an independent pair of pool tensors.
+    pool.append_tokens(&mut state, 1, 4).unwrap();
+    let id1 = state.layer(1).unwrap().block_ids[0];
+    pool.write_block(id1, 1, 0, &make_block(3.0, 4), &make_block(4.0, 4))
+        .unwrap();
+    assert_eq!(pool.pool_tensor_bytes(), 2 * expected_layer0);
+}
+
+// ---------------------------------------------------------------------------
+// 8. Turbo4 sidecars coexist with main-K/V rows
+// ---------------------------------------------------------------------------
+
+#[test]
+fn turbo4_sidecars_coexist_with_main_kv_rows() {
+    // Turbo4 pool: install a sidecar AND write the main K/V row for the same
+    // block; both must be independently retrievable, and release frees both.
+    let layout = PagedKvLayout::uniform_with_mode(1, 4, 128, KVCacheMode::Turbo4Asym, 16).unwrap();
+    let mut pool = PagedBlockPool::new(layout);
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    pool.append_tokens(&mut state, 0, 4).unwrap();
+    let id = state.layer(0).unwrap().block_ids[0];
+
+    // Main K/V row.
+    pool.write_block(id, 0, 0, &make_block(7.0, 4), &make_block(8.0, 4))
+        .unwrap();
+    // Turbo4 per-page sidecar on the same block.
+    pool.install_v_packed(
+        id,
+        ffi::from_slice_f32(&[1.0, 2.0, 3.0, 4.0], &[1, 1, 4, 1]),
+    )
+    .unwrap();
+
+    assert!(pool.v_packed_for(id).is_some());
+    assert!(pool.pool_tensor_bytes() > 0);
+    assert!(pool.turbo_sidecar_bytes() > 0);
+
+    // Gather still returns the main K/V independent of the sidecar.
+    let (gk, _gv) = pool
+        .gather_visible(&state, 0)
+        .unwrap()
+        .expect("gather must return data");
+    let dense_k = dense_reference(&[(make_block(7.0, 4), 0)], 4, 0, 4);
+    assert_eq!(flatten_fp32(&gk), flatten_fp32(&dense_k));
+
+    // Releasing the block to refcount 0 frees BOTH the sidecar and the row.
+    pool.release_sequence(&mut state).unwrap();
+    assert_eq!(pool.refcount(id), 0);
+    assert!(pool.v_packed_for(id).is_none());
+    assert_eq!(pool.turbo_sidecar_bytes(), 0);
+
+    // The freed row is reusable: a fresh block reuses it and the pool tensor
+    // does not grow.
+    let bytes_before_reuse = pool.pool_tensor_bytes();
+    pool.append_tokens(&mut state, 0, 4).unwrap();
+    let id2 = state.layer(0).unwrap().block_ids[0];
+    pool.write_block(id2, 0, 0, &make_block(9.0, 4), &make_block(10.0, 4))
+        .unwrap();
+    assert_eq!(pool.pool_tensor_bytes(), bytes_before_reuse);
+}
+
+// ---------------------------------------------------------------------------
+// 9. Write convention: the bare 3D [n_slots, H, D] slab is accepted too
+// ---------------------------------------------------------------------------
+
+#[test]
+fn write_accepts_bare_3d_block_layout() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+    let mut state = PagedSequenceState::new(pool.layout());
+    pool.append_tokens(&mut state, 0, 4).unwrap();
+    let id = state.layer(0).unwrap().block_ids[0];
+
+    // Write via the 3D convention; gather and compare to the 4D-built dense
+    // reference using the same value base.
+    pool.write_block(id, 0, 0, &make_block_3d(42.0, 4), &make_block_3d(84.0, 4))
+        .unwrap();
+    let (gk, gv) = pool
+        .gather_visible(&state, 0)
+        .unwrap()
+        .expect("gather must return data");
+    let dense_k = dense_reference(&[(make_block(42.0, 4), 0)], 4, 0, 4);
+    let dense_v = dense_reference(&[(make_block(84.0, 4), 0)], 4, 0, 4);
+    assert_eq!(flatten_fp32(&gk), flatten_fp32(&dense_k));
+    assert_eq!(flatten_fp32(&gv), flatten_fp32(&dense_v));
+}
+
+// ---------------------------------------------------------------------------
+// 10. Validation: shape/dtype mismatch and empty-window behaviour
+// ---------------------------------------------------------------------------
+
+#[test]
+fn write_rejects_geometry_mismatch_after_first_write() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+    let mut state = PagedSequenceState::new(pool.layout());
+    pool.append_tokens(&mut state, 0, 8).unwrap();
+    let ids = state.layer(0).unwrap().block_ids.clone();
+
+    pool.write_block(ids[0], 0, 0, &make_block(1.0, 4), &make_block(2.0, 4))
+        .unwrap();
+
+    // A second write with a different head_dim must be rejected.
+    let bad = ffi::from_slice_f32(&vec![0.0; (H * 4 * (D + 1)) as usize], &[1, H, 4, D + 1]);
+    let err = pool.write_block(ids[1], 0, 0, &bad, &bad).unwrap_err();
+    assert!(err.contains("head_dim") || err.contains("expects"), "{err}");
+}
+
+#[test]
+fn gather_returns_none_for_empty_layer() {
+    let block_size = 4usize;
+    let pool = fp16_pool(block_size, 1);
+    let state = PagedSequenceState::new(pool.layout());
+    // No tokens appended, no writes -> no visible window, no pool storage.
+    assert!(pool.gather_visible(&state, 0).unwrap().is_none());
+}
+
+#[test]
+fn write_rejects_unknown_block_and_oob_slot() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+    let bogus = PagedBlockId::from_raw(123_456);
+    let k = make_block(1.0, 4);
+    let err = pool.write_block(bogus, 0, 0, &k, &k).unwrap_err();
+    assert!(err.contains("unknown block"), "{err}");
+
+    // Known block, but slot range overruns block_size.
+    let mut state = PagedSequenceState::new(pool.layout());
+    pool.append_tokens(&mut state, 0, 4).unwrap();
+    let id = state.layer(0).unwrap().block_ids[0];
+    let two = make_block(1.0, 2);
+    let err = pool.write_block(id, 0, 3, &two, &two).unwrap_err();
+    assert!(err.contains("out of bounds"), "{err}");
+}


### PR DESCRIPTION
## Summary

Phase 1 of epic #116 (unified paged KV cache). Adds the physical main K/V tensor storage to `PagedBlockPool` plus the write/gather primitives, byte accounting, and unit tests, following layout A and the gather-then-SDPA strategy locked by ADR 0001 (`docs/adr/0001-paged-attention-gather-vs-fused-kernel.md`).

This is an additive capability that later phases consume. The live model/decode flow is intentionally not rewired here (decode-read is #119, prefill-write is #120, fused kernel is #123), per the project's integration rule that integration depending on later sub-issues is deferred to them. Net effect in live operation after this PR: pool tensors stay unallocated (no live writer wired yet), dense `KVCache` placeholders still carry live K/V, the existing paged decode path is byte-for-byte unchanged, and all existing paged tests pass. The new storage is exercised and proven only by the new unit tests, ready for #119/#120 to wire.

## What changed

- `src/lib/mlxcel-core/src/cache/paged.rs`
  - New per-layer physical pool state on `PagedBlockPool`: `pool_k` / `pool_v` (`Vec<Option<UniquePtr<MlxArray>>>`, layout A `[capacity_blocks, block_size, n_kv_heads, head_dim]`, separate K and V per layer), `pool_meta` (lazily-inferred `n_kv_heads`/`head_dim`/`dtype`/`capacity_blocks`), `block_rows` (per-layer `block_id -> row`), `free_rows`, `next_row`. `PagedBlockPool::new(layout)` signature is unchanged (tensors start `None`).
  - `write_block(block_id, layer_idx, slot_start, k_block, v_block)` — lazily allocates the layer pool on first write, assigns/looks up the layer-local row (reusing freed rows), grows in `POOL_GROW_CHUNK_BLOCKS` (32) chunks when a fresh row exceeds capacity, and writes via `slice_update` reassigning the pool tensor so MLX donates the buffer (O(block) append per ADR 0001). Accepts both `[1, n_kv_heads, n_slots, head_dim]` (SDPA-style, primary) and `[n_slots, n_kv_heads, head_dim]` (bare slab) block layouts; validates shape/dtype against captured geometry on every write.
  - `gather_visible(state, layer_idx)` — builds the physical-row index from the layer's block table (fragmented / out-of-order rows gather in block-table order), `take`s the rows, flattens, slices the visible `[logical_start, len)` window, and transposes into `[1, n_kv_heads, visible_len, head_dim]`, byte-identical to the equivalent dense contiguous buffer's visible slice. Returns `Ok(None)` for an empty layer.
  - `pool_tensor_bytes()` — sums `array_nbytes` over allocated `pool_k`/`pool_v`.
  - `release_block` now frees the main-K/V row (push to `free_rows`, remove from `block_rows`) in addition to the existing `turbo_sidecars.forget`.
  - No astype on the K/V path: dtype is preserved through `transpose_axes`/`reshape`/`slice_update`/`take`/`slice`. Fp16 stays Fp16, Int8 stays Int8. Int8 quantization scales stay in the dense path and are not touched.
  - Updated the `PagedBlockPool` doc comment to state the pool can now own physical main K/V storage (layout A) and that dense-placeholder removal lands with #119/#120.
- `src/lib/mlxcel-core/src/cache.rs`
  - Re-export the new `GatheredKv` type alias; wire the `paged_pool_tests` module.
  - `CachePool::memory_usage_bytes` adds `pool.pool_tensor_bytes()` additively next to `turbo_sidecar_bytes()`; the layout-derived `reserved_bytes`/`used_bytes`/`stats_for_sequences` budgets are unchanged.
- `src/lib/mlxcel-core/src/cache/paged_pool_tests.rs` (new) — 13 unit tests covering the acceptance criterion and all required cases.

## Test plan

- [x] `cargo check --lib -p mlxcel-core --features metal,accelerate` — clean
- [x] `cargo clippy --lib -p mlxcel-core --features metal,accelerate -- -D warnings` — clean
- [x] `cargo clippy -p mlxcel-core --tests --features metal,accelerate -- -D warnings` — clean
- [x] `cargo test --lib -p mlxcel-core cache::paged_pool --features metal,accelerate` — 13 passed
- [x] `cargo test --lib -p mlxcel-core cache::paged_turbo --features metal,accelerate` — 26 passed (existing `nbytes_*` budget assertions intact)
- [x] `cargo test --lib -p mlxcel-core cache::paged --features metal,accelerate` — 57 passed (detach round-trips intact)
- [x] `cargo fmt -p mlxcel-core --check` — clean

Closes #118
