### PR TITLE
feat: pooled paged decode read path over real block tables (#119)

### DIFF
--- a/src/lib/mlxcel-core/src/cache/paged_pool_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_pool_tests.rs
@@ -22,10 +22,10 @@
 //! 3. Partial final block gathers exactly `visible_len` tokens (no padding).
 //! 4. `logical_start > 0` (post-trim) gathers the correct visible window.
 //! 5. INT8 main K/V round-trips byte-identically (dtype preserved, no astype).
-//! 5b. FP16 main K/V round-trips byte-identically (dtype preserved, no astype).
-//! 6. `release_block` to refcount 0 frees and recycles a row with fresh data.
-//! 7. `pool_tensor_bytes` reflects allocated pool tensors.
-//! 8. Turbo4 sidecars coexist with main-K/V rows.
+//! 6. FP16 main K/V round-trips byte-identically (dtype preserved, no astype).
+//! 7. `release_block` to refcount 0 frees and recycles a row with fresh data.
+//! 8. `pool_tensor_bytes` reflects allocated pool tensors.
+//! 9. Turbo4 sidecars coexist with main-K/V rows.
 
 use super::paged::{PagedBlockId, PagedBlockPool, PagedKvLayout, PagedSequenceState};
 use super::KVCacheMode;

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -321,6 +321,440 @@ fn test_paged_decode_attention_rotating_compat_matches_fallback_after_wrap() {
     assert!(item_bool(&close));
 }
 
+// ---------------------------------------------------------------------------
+// Pooled paged decode (#119): parity vs the dense fallback baseline.
+//
+// `paged_decode_attention_pooled_fallback` gathers each sequence's visible K/V
+// from a `PagedBlockPool` (real, possibly fragmented physical block tables),
+// whereas `paged_decode_attention_dense_fallback` slices contiguous dense
+// buffers with identity metadata. Both feed the same fused SDPA, so for
+// identical K/V/q values the two outputs must match tightly. FP32 K/V/q is used
+// so the gather (pure take/reshape/slice/transpose) and the dense slice/concat
+// stay bit-exact and the only residual delta is SDPA float ordering.
+// ---------------------------------------------------------------------------
+
+/// Deterministic, seed-varying FP32 values in roughly `[-1, 1]`. Avoids an RNG
+/// dependency while giving every decode step a fresh, non-degenerate q/k/v.
+fn pooled_pseudo_f32(seed: u64, n: usize) -> Vec<f32> {
+    let mut s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        // xorshift64* step.
+        s ^= s >> 12;
+        s ^= s << 25;
+        s ^= s >> 27;
+        let bits = s.wrapping_mul(0x2545_F491_4F6C_DD1D);
+        // Map the top 24 bits to [-1, 1).
+        let unit = ((bits >> 40) as f32) / ((1u64 << 24) as f32); // [0, 1)
+        out.push(unit * 2.0 - 1.0);
+    }
+    out
+}
+
+/// Root-mean-square of the element-wise difference of two equal-length slices.
+fn pooled_rms(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "RMS operands must be equal length");
+    let sum_sq: f64 = a
+        .iter()
+        .zip(b.iter())
+        .map(|(x, y)| {
+            let d = (*x - *y) as f64;
+            d * d
+        })
+        .sum();
+    (sum_sq / a.len() as f64).sqrt() as f32
+}
+
+/// A `PagedKvLayout` whose per-block byte budget is a positive placeholder; the
+/// real geometry is inferred from the first written block.
+fn pooled_layout(
+    block_size: usize,
+    num_layers: usize,
+    n_kv_heads: i32,
+    head_dim: i32,
+) -> crate::cache::PagedKvLayout {
+    crate::cache::PagedKvLayout::uniform(
+        num_layers,
+        block_size,
+        block_size * n_kv_heads as usize * head_dim as usize * 2,
+    )
+    .unwrap()
+}
+
+/// 200-step decode acceptance test (issue #119 / epic #116 acceptance criterion).
+///
+/// Maintains one sequence in lockstep in (i) a `PagedBlockPool` and (ii) a
+/// contiguous dense `[1, H, T, D]` buffer, forcing the pool sequence onto
+/// NON-CONTIGUOUS physical rows by interleaving a spacer sequence's block
+/// writes between the target's. Each step appends one fresh token's K/V to both
+/// stores, picks a fresh pseudo-random `q [1, H, 1, D]`, runs the pooled and
+/// dense fallbacks, and asserts the RMS of their outputs stays < 5e-3.
+#[test]
+fn test_pooled_paged_decode_matches_dense_over_200_steps() {
+    use crate::cache::{PagedBlockPool, PagedSequenceState};
+
+    const STEPS: usize = 200;
+    let n_kv_heads: i32 = 4;
+    let head_dim: i32 = 8;
+    let block_size = 4usize;
+    let layer_idx = 0usize;
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    let mut pool = PagedBlockPool::new(pooled_layout(block_size, 1, n_kv_heads, head_dim));
+    let mut target = PagedSequenceState::new(pool.layout());
+    // Spacer sequence: its block writes are interleaved between the target's so
+    // the target's physical rows (assigned in first-write order) are scattered.
+    let mut spacer = PagedSequenceState::new(pool.layout());
+
+    // Growing dense reference buffer `[1, H, T, D]`, rebuilt each step at the
+    // exact visible length so the dense fallback's identity metadata lines up.
+    let mut dense_k: Option<UniquePtr<MlxArray>> = None;
+    let mut dense_v: Option<UniquePtr<MlxArray>> = None;
+
+    let mut max_rms = 0.0f32;
+    let mut prev_blocks = 0usize;
+
+    for step in 0..STEPS {
+        let t = step as i32; // logical token index being appended
+        let visible_len = t + 1;
+
+        // --- grow the pooled target by one token ---
+        pool.append_tokens(&mut target, layer_idx, 1).unwrap();
+        let block_ids = target.layer(layer_idx).unwrap().block_ids.clone();
+
+        // On every NEW target block boundary, first write a full spacer block so
+        // the spacer claims the next physical row, fragmenting the target rows.
+        if block_ids.len() > prev_blocks {
+            pool.append_tokens(&mut spacer, layer_idx, block_size)
+                .unwrap();
+            let spacer_ids = spacer.layer(layer_idx).unwrap().block_ids.clone();
+            let spacer_block = *spacer_ids.last().unwrap();
+            let spacer_seed = 0xCAFE_u64.wrapping_add(step as u64);
+            let sk = from_slice_f32(
+                &pooled_pseudo_f32(
+                    spacer_seed,
+                    (n_kv_heads * block_size as i32 * head_dim) as usize,
+                ),
+                &[1, n_kv_heads, block_size as i32, head_dim],
+            );
+            let sv = from_slice_f32(
+                &pooled_pseudo_f32(
+                    spacer_seed.wrapping_mul(3),
+                    (n_kv_heads * block_size as i32 * head_dim) as usize,
+                ),
+                &[1, n_kv_heads, block_size as i32, head_dim],
+            );
+            pool.write_block(spacer_block, layer_idx, 0, &sk, &sv)
+                .unwrap();
+            prev_blocks = block_ids.len();
+        }
+
+        // Write the target's single new token into its (last) block / slot.
+        let slot = (t as usize) % block_size;
+        let block_index = (t as usize) / block_size;
+        let target_block = block_ids[block_index];
+        let k_tok_vals = pooled_pseudo_f32(step as u64 + 1, (n_kv_heads * head_dim) as usize);
+        let v_tok_vals = pooled_pseudo_f32(
+            (step as u64 + 1).wrapping_mul(7),
+            (n_kv_heads * head_dim) as usize,
+        );
+        let k_tok = from_slice_f32(&k_tok_vals, &[1, n_kv_heads, 1, head_dim]);
+        let v_tok = from_slice_f32(&v_tok_vals, &[1, n_kv_heads, 1, head_dim]);
+        pool.write_block(target_block, layer_idx, slot, &k_tok, &v_tok)
+            .unwrap();
+
+        // --- grow the dense reference identically ---
+        dense_k = Some(match dense_k.take() {
+            None => k_tok,
+            Some(prev) => concatenate(&prev, &k_tok, 2),
+        });
+        dense_v = Some(match dense_v.take() {
+            None => v_tok,
+            Some(prev) => concatenate(&prev, &v_tok, 2),
+        });
+        let dk = dense_k.as_ref().unwrap();
+        let dv = dense_v.as_ref().unwrap();
+        assert_eq!(array_shape(dk), vec![1, n_kv_heads, visible_len, head_dim]);
+
+        // --- fresh query for this step ---
+        let q_vals = pooled_pseudo_f32(
+            (step as u64).wrapping_mul(0x1000_0001) + 13,
+            (n_kv_heads * head_dim) as usize,
+        );
+        let q = from_slice_f32(&q_vals, &[1, n_kv_heads, 1, head_dim]);
+
+        // --- pooled path ---
+        let states: [&PagedSequenceState; 1] = [&target];
+        let pooled_out = crate::layers::paged_decode_attention_pooled_fallback(
+            &q, &pool, &states, layer_idx, scale,
+        )
+        .unwrap();
+
+        // --- dense fallback (identity block table) ---
+        let metadata = crate::cache::PagedDecodeMetadata::from_visible_lengths(
+            &[visible_len],
+            block_size as i32,
+        )
+        .unwrap();
+        let cache_keys = vec![dk.as_ref().unwrap() as *const MlxArray];
+        let cache_values = vec![dv.as_ref().unwrap() as *const MlxArray];
+        let dense_out = crate::layers::paged_decode_attention_dense_fallback(
+            &q,
+            &cache_keys,
+            &cache_values,
+            &metadata,
+            scale,
+        )
+        .unwrap();
+
+        let p = flatten_f32_local(&pooled_out);
+        let d = flatten_f32_local(&dense_out);
+        let rms = pooled_rms(&p, &d);
+        assert!(
+            rms < 5e-3,
+            "step {step}: pooled vs dense RMS {rms} exceeded 5e-3"
+        );
+        max_rms = max_rms.max(rms);
+    }
+
+    // The target eventually spans ceil(200/4) = 50 blocks; assert its block ids
+    // are NON-CONTIGUOUS (spacer ids interleaved), which - since the pool
+    // assigns physical rows in first-write order - means the target's physical
+    // pool rows are genuinely fragmented, not a dense ascending run.
+    let target_ids = target.layer(layer_idx).unwrap().block_ids.clone();
+    assert_eq!(target_ids.len(), 50, "expected 50 target blocks");
+    let raws: Vec<u64> = target_ids.iter().map(|id| id.as_u64()).collect();
+    let min = *raws.iter().min().unwrap();
+    let max = *raws.iter().max().unwrap();
+    assert!(
+        (max - min + 1) as usize > raws.len(),
+        "target block ids {raws:?} are contiguous - fragmentation was not forced"
+    );
+
+    // Sanity: the run actually exercised a meaningful number of steps and the
+    // worst-case RMS is reported for the implementation summary.
+    assert!(
+        max_rms < 5e-3,
+        "max RMS {max_rms} over 200 steps exceeded 5e-3"
+    );
+    println!("test_pooled_paged_decode_matches_dense_over_200_steps: max RMS = {max_rms:e}");
+}
+
+/// Sliding-window parity: a sequence with `logical_start > 0` (post-trim) must
+/// gather/decode exactly the visible window and match the dense reference of
+/// just that window.
+#[test]
+fn test_pooled_paged_decode_sliding_window_via_logical_start() {
+    use crate::cache::{PagedBlockPool, PagedSequenceState};
+
+    let n_kv_heads: i32 = 4;
+    let head_dim: i32 = 8;
+    let block_size = 4usize;
+    let layer_idx = 0usize;
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    let mut pool = PagedBlockPool::new(pooled_layout(block_size, 1, n_kv_heads, head_dim));
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    // 12 tokens => 3 full blocks. Write each token with distinct pseudo-random
+    // K/V and keep a parallel dense `[1, H, 12, D]` buffer.
+    let total = 12i32;
+    let mut dense_k: Option<UniquePtr<MlxArray>> = None;
+    let mut dense_v: Option<UniquePtr<MlxArray>> = None;
+    for t in 0..total {
+        pool.append_tokens(&mut state, layer_idx, 1).unwrap();
+        let block_ids = state.layer(layer_idx).unwrap().block_ids.clone();
+        let slot = (t as usize) % block_size;
+        let block_index = (t as usize) / block_size;
+        let k_tok = from_slice_f32(
+            &pooled_pseudo_f32(t as u64 + 100, (n_kv_heads * head_dim) as usize),
+            &[1, n_kv_heads, 1, head_dim],
+        );
+        let v_tok = from_slice_f32(
+            &pooled_pseudo_f32(
+                (t as u64 + 100).wrapping_mul(11),
+                (n_kv_heads * head_dim) as usize,
+            ),
+            &[1, n_kv_heads, 1, head_dim],
+        );
+        pool.write_block(block_ids[block_index], layer_idx, slot, &k_tok, &v_tok)
+            .unwrap();
+        dense_k = Some(match dense_k.take() {
+            None => k_tok,
+            Some(prev) => concatenate(&prev, &k_tok, 2),
+        });
+        dense_v = Some(match dense_v.take() {
+            None => v_tok,
+            Some(prev) => concatenate(&prev, &v_tok, 2),
+        });
+    }
+
+    // Slide the window forward by 5 tokens (as `trim_tokens` would after a
+    // sliding-window eviction): visible window is now [5, 12) = 7 tokens.
+    let window_start = 5i32;
+    state.layer_mut(layer_idx).unwrap().logical_start = window_start as usize;
+    assert_eq!(state.layer(layer_idx).unwrap().visible_len(), 7);
+
+    let q = from_slice_f32(
+        &pooled_pseudo_f32(9999, (n_kv_heads * head_dim) as usize),
+        &[1, n_kv_heads, 1, head_dim],
+    );
+
+    // Pooled path gathers the [5, 12) window from the pool.
+    let states: [&PagedSequenceState; 1] = [&state];
+    let pooled_out =
+        crate::layers::paged_decode_attention_pooled_fallback(&q, &pool, &states, layer_idx, scale)
+            .unwrap();
+
+    // Dense reference: slice the full dense buffer to the visible window and run
+    // the dense fallback over just those 7 tokens with identity metadata.
+    let dk = dense_k.as_ref().unwrap();
+    let dv = dense_v.as_ref().unwrap();
+    let window_k = slice(
+        dk,
+        &[0, 0, window_start, 0],
+        &[1, n_kv_heads, total, head_dim],
+    );
+    let window_v = slice(
+        dv,
+        &[0, 0, window_start, 0],
+        &[1, n_kv_heads, total, head_dim],
+    );
+    let visible_len = total - window_start;
+    let metadata =
+        crate::cache::PagedDecodeMetadata::from_visible_lengths(&[visible_len], block_size as i32)
+            .unwrap();
+    let cache_keys = vec![window_k.as_ref().unwrap() as *const MlxArray];
+    let cache_values = vec![window_v.as_ref().unwrap() as *const MlxArray];
+    let dense_out = crate::layers::paged_decode_attention_dense_fallback(
+        &q,
+        &cache_keys,
+        &cache_values,
+        &metadata,
+        scale,
+    )
+    .unwrap();
+
+    let rms = pooled_rms(
+        &flatten_f32_local(&pooled_out),
+        &flatten_f32_local(&dense_out),
+    );
+    assert!(
+        rms < 5e-3,
+        "sliding-window pooled vs dense RMS {rms} exceeded 5e-3"
+    );
+}
+
+/// Batch parity: a 2-sequence batch with different kv_lens, pooled vs dense,
+/// exercising the batch-concat tail of both fallbacks.
+#[test]
+fn test_pooled_paged_decode_batch_of_two() {
+    use crate::cache::{PagedBlockPool, PagedSequenceState};
+
+    let n_kv_heads: i32 = 4;
+    let head_dim: i32 = 8;
+    let block_size = 4usize;
+    let layer_idx = 0usize;
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    let mut pool = PagedBlockPool::new(pooled_layout(block_size, 1, n_kv_heads, head_dim));
+
+    // Two sequences with different visible lengths (9 and 6 tokens). Build both
+    // in the pool and a dense buffer each.
+    let lens = [9i32, 6i32];
+    let mut states_owned: Vec<PagedSequenceState> = Vec::new();
+    let mut dense_ks: Vec<UniquePtr<MlxArray>> = Vec::new();
+    let mut dense_vs: Vec<UniquePtr<MlxArray>> = Vec::new();
+
+    for (seq, &len) in lens.iter().enumerate() {
+        let mut state = PagedSequenceState::new(pool.layout());
+        let mut dk: Option<UniquePtr<MlxArray>> = None;
+        let mut dv: Option<UniquePtr<MlxArray>> = None;
+        for t in 0..len {
+            pool.append_tokens(&mut state, layer_idx, 1).unwrap();
+            let block_ids = state.layer(layer_idx).unwrap().block_ids.clone();
+            let slot = (t as usize) % block_size;
+            let block_index = (t as usize) / block_size;
+            let seed = (seq as u64 + 1) * 1000 + t as u64;
+            let k_tok = from_slice_f32(
+                &pooled_pseudo_f32(seed, (n_kv_heads * head_dim) as usize),
+                &[1, n_kv_heads, 1, head_dim],
+            );
+            let v_tok = from_slice_f32(
+                &pooled_pseudo_f32(seed.wrapping_mul(13), (n_kv_heads * head_dim) as usize),
+                &[1, n_kv_heads, 1, head_dim],
+            );
+            pool.write_block(block_ids[block_index], layer_idx, slot, &k_tok, &v_tok)
+                .unwrap();
+            dk = Some(match dk.take() {
+                None => k_tok,
+                Some(prev) => concatenate(&prev, &k_tok, 2),
+            });
+            dv = Some(match dv.take() {
+                None => v_tok,
+                Some(prev) => concatenate(&prev, &v_tok, 2),
+            });
+        }
+        states_owned.push(state);
+        dense_ks.push(dk.unwrap());
+        dense_vs.push(dv.unwrap());
+    }
+
+    // Batched query `[2, H, 1, D]`.
+    let q = from_slice_f32(
+        &pooled_pseudo_f32(424242, (2 * n_kv_heads * head_dim) as usize),
+        &[2, n_kv_heads, 1, head_dim],
+    );
+
+    // Pooled path over both sequences.
+    let states: Vec<&PagedSequenceState> = states_owned.iter().collect();
+    let pooled_out =
+        crate::layers::paged_decode_attention_pooled_fallback(&q, &pool, &states, layer_idx, scale)
+            .unwrap();
+    assert_eq!(array_shape(&pooled_out), vec![2, n_kv_heads, 1, head_dim]);
+
+    // Dense fallback over the two dense buffers with identity metadata.
+    let metadata =
+        crate::cache::PagedDecodeMetadata::from_visible_lengths(&lens, block_size as i32).unwrap();
+    let cache_keys = vec![
+        dense_ks[0].as_ref().unwrap() as *const MlxArray,
+        dense_ks[1].as_ref().unwrap() as *const MlxArray,
+    ];
+    let cache_values = vec![
+        dense_vs[0].as_ref().unwrap() as *const MlxArray,
+        dense_vs[1].as_ref().unwrap() as *const MlxArray,
+    ];
+    let dense_out = crate::layers::paged_decode_attention_dense_fallback(
+        &q,
+        &cache_keys,
+        &cache_values,
+        &metadata,
+        scale,
+    )
+    .unwrap();
+
+    let rms = pooled_rms(
+        &flatten_f32_local(&pooled_out),
+        &flatten_f32_local(&dense_out),
+    );
+    assert!(
+        rms < 5e-3,
+        "batch-of-two pooled vs dense RMS {rms} exceeded 5e-3"
+    );
+}
+
+/// Flatten any tensor to a row-major `Vec<f32>` (after an FP32 cast). Local to
+/// these pooled tests; mirrors the pool-test `flatten_fp32` helper.
+fn flatten_f32_local(arr: &MlxArray) -> Vec<f32> {
+    let a = astype(arr, dtype::FLOAT32);
+    eval(&a);
+    let bytes = array_to_raw_bytes(&a);
+    bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
 #[test]
 fn test_rms_norm() {
     let x = ones(&[1, 4], dtype::FLOAT32);

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -2347,6 +2347,121 @@ pub fn paged_decode_attention_dense_fallback(
     Ok(result)
 }
 
+fn validate_pooled_paged_decode_inputs(
+    q: &MlxArray,
+    states: &[&crate::cache::PagedSequenceState],
+) -> Result<(), String> {
+    let q_shape = ffi::array_shape(q);
+    if q_shape.len() != 4 {
+        return Err(format!(
+            "pooled paged decode attention expected q rank 4, got shape {:?}",
+            q_shape
+        ));
+    }
+    if q_shape[2] != 1 {
+        return Err(format!(
+            "pooled paged decode attention only supports decode-only q_len == 1, got {}",
+            q_shape[2]
+        ));
+    }
+
+    let batch = q_shape[0].max(0) as usize;
+    if states.len() != batch {
+        return Err(format!(
+            "pooled paged decode attention expected {batch} sequence states, got {}",
+            states.len()
+        ));
+    }
+
+    Ok(())
+}
+
+/// Reference paged decode path that gathers K/V from the [`PagedBlockPool`].
+///
+/// This is the Phase 2 (#119) pooled read path of the unified paged KV cache
+/// (epic #116). It is the pooled analogue of [`paged_decode_attention_dense_fallback`],
+/// which stays the live decode path and the parity baseline this function is
+/// validated against. The two differ only in where the per-sequence visible
+/// K/V comes from: the dense fallback slices contiguous dense compatibility
+/// buffers, while this function calls [`crate::cache::PagedBlockPool::gather_visible`]
+/// to pull each sequence's physical blocks out of the pool by block-table order.
+/// Everything downstream — the per-batch `q` slice, the fused SDPA dispatch via
+/// [`attention_from_ptr`], and the axis-0 batch concat — is identical.
+///
+/// Per ADR 0001 (`docs/adr/0001-paged-attention-gather-vs-fused-kernel.md`) this
+/// is strategy option A, *gather-then-SDPA*: `gather_visible` builds a
+/// `take`/`reshape`/`transpose` MLX graph that MLX fuses into the fused-SDPA
+/// read, so the scattered-block gather adds no separate full-copy of the
+/// sequence KV at the common context lengths. The fused Metal paged-attention
+/// kernel (option B) is deferred to #123; this Rust path remains its correctness
+/// reference and fallback. Live model routing onto this path is #121 (it needs
+/// the pool to be populated by the #120 prefill writer and routed by the #121
+/// scheduler), so this function is additive machinery and the live decode path
+/// is unchanged until then.
+///
+/// The path handles full-attention and sliding-window sequences uniformly. In
+/// the paged model there is no ring-buffer wrap: the visible window is encoded
+/// entirely in the per-sequence block table plus `logical_start` (which
+/// `trim_tokens` advances as the window slides), so `gather_visible` returns
+/// exactly the `[logical_start, len)` window already shaped
+/// `[1, n_kv_heads, visible_len, head_dim]` (SDPA-ready). That is why there is
+/// no separate "rotating" pooled variant mirroring
+/// [`paged_decode_attention_rotating_fallback`].
+///
+/// `gather_visible` returning `Ok(None)` (no visible tokens, or the layer has no
+/// pool storage yet) is treated as an error here, because decode requires a
+/// non-empty visible window — the pooled analogue of the dense fallback's
+/// `kv_len > 0` precondition.
+pub fn paged_decode_attention_pooled_fallback(
+    q: &MlxArray,
+    pool: &crate::cache::PagedBlockPool,
+    states: &[&crate::cache::PagedSequenceState],
+    layer_idx: usize,
+    scale: f32,
+) -> Result<UniquePtr<MlxArray>, String> {
+    validate_pooled_paged_decode_inputs(q, states)?;
+
+    let q_shape = ffi::array_shape(q);
+    let batch = q_shape[0].max(0) as usize;
+    let mut outputs: Vec<UniquePtr<MlxArray>> = Vec::with_capacity(batch);
+
+    for (batch_idx, state) in states.iter().enumerate() {
+        let q_i = ffi::slice(
+            q,
+            &[batch_idx as i32, 0, 0, 0],
+            &[batch_idx as i32 + 1, i32::MAX, 1, i32::MAX],
+        );
+
+        let (key_visible, value_visible) =
+            pool.gather_visible(state, layer_idx)?.ok_or_else(|| {
+                format!(
+                    "pooled paged decode requires visible tokens for batch index {batch_idx} on layer {layer_idx}, but the pool gathered none"
+                )
+            })?;
+
+        outputs.push(unsafe {
+            attention_from_ptr(
+                &q_i,
+                &key_visible,
+                &value_visible,
+                scale,
+                std::ptr::null(),
+                0.0,
+                0,
+            )
+        });
+    }
+
+    let mut result = outputs
+        .drain(..1)
+        .next()
+        .ok_or_else(|| "pooled paged decode fallback received an empty batch".to_string())?;
+    for output in outputs {
+        result = crate::concatenate(&result, &output, 0);
+    }
+    Ok(result)
+}
+
 /// Native paged decode path over dense compatibility KV caches.
 ///
 /// The C++ bridge consumes the logical block table metadata and performs the


### PR DESCRIPTION
## Summary

Phase 2 of epic #116 (unified paged KV cache): the Rust pooled-decode read path. Adds `paged_decode_attention_pooled_fallback`, which gathers each sequence's visible K/V from `PagedBlockPool` (real, possibly fragmented physical block tables) instead of slicing dense compatibility buffers, following ADR 0001 strategy option A (gather-then-SDPA, reusing existing FFI with no new kernel). This is additive machinery consumed later by #121 (live scheduler wiring) and #123 (fused kernel); the live decode path stays byte-for-byte unchanged.

## What changed

- `src/lib/mlxcel-core/src/layers.rs`: new `pub fn paged_decode_attention_pooled_fallback(q, pool, states, layer_idx, scale)` plus a `validate_pooled_paged_decode_inputs` helper. It mirrors `paged_decode_attention_dense_fallback` exactly and differs only in the K/V source: per batch index it slices `q_i`, calls `PagedBlockPool::gather_visible` (which builds the `take`/`reshape`/`transpose` graph MLX fuses into the SDPA read), feeds the result into the identical `attention_from_ptr` fused-SDPA call, and concatenates the per-sequence outputs along axis 0. `gather_visible` already returns the `[1, n_kv_heads, visible_len, head_dim]` SDPA-ready window, so no reshape/transpose is needed at the call site. `Ok(None)` is mapped to an error (decode requires a non-empty window). The function carries a thorough doc comment: it is ADR option A, its parity baseline is `paged_decode_attention_dense_fallback`, it handles full-attention and sliding-window sequences uniformly (the visible window lives in the per-sequence block table + `logical_start`, so there is no ring-buffer wrap and no separate rotating pooled variant), and it is consumed by #121 and #123.
- `src/lib/mlxcel-core/src/ffi_tests.rs`: three parity tests alongside the existing dense-compat parity test, plus local helpers (`pooled_pseudo_f32`, `pooled_rms`, `pooled_layout`, `flatten_f32_local`).

No C++ was touched, and no model dispatch files were touched (see Scope boundary).

## Test plan

- [x] `cargo test --lib -p mlxcel-core test_pooled_paged_decode --features metal,accelerate` — 3 passed (sliding-window, batch-of-two, 200-step).
- [x] `test_pooled_paged_decode_matches_dense_over_200_steps` (the acceptance): 200-step lockstep decode of one sequence through the pool and a contiguous dense `[1,H,T,D]` buffer, with `H=4, D=8, block_size=4`. The target is forced onto non-contiguous physical rows by interleaving a spacer sequence's block writes (the pool assigns rows in first-write order, so the target lands on rows 0,2,4,...); the test asserts the target's block ids are non-contiguous (span 99 over 50 blocks) and that the pooled-vs-dense output RMS is `< 5e-3` every step. With FP32 K/V/q the two paths are bit-identical, so the measured **max RMS over 200 steps is 0**.
- [x] `test_pooled_paged_decode_sliding_window_via_logical_start`: a sequence with `logical_start > 0` (visible window `[5,12)`, 7 tokens) gathers/decodes the correct window and matches the dense reference of just that window (RMS `< 5e-3`).
- [x] `test_pooled_paged_decode_batch_of_two`: a 2-sequence batch with different kv_lens (9 and 6), pooled vs dense, exercises the batch concat (RMS `< 5e-3`).
- [x] `cargo clippy --all-targets --features metal,accelerate -- -D warnings` — clean (0 errors) from a cold clippy cache (matches the CI `verify-clippy` step).
- [x] `cargo fmt -p mlxcel-core -- --check` — clean.
- [x] Existing `test_paged_decode_attention_*` and `paged_pool_tests` suites still green (no regression).

## Scope boundary (deferred, intentionally NOT in this PR)

- **C++ `paged_decode_attention_dense_compat` / `_rotating_compat` (`cpp/mlx_cxx_bridge.cpp`) — NOT modified.** ADR option A reuses existing FFI with no new kernel; the Rust pooled path already builds the `take`->SDPA MLX graph that MLX fuses, so a non-fused C++ pool gather adds risk for ~no benefit. The native/fused C++ pooled kernel is explicitly **#123**.
- **Live model dispatch (`src/models/model_owned.rs`, `qwen3.rs`, `llama3.rs`, `gemma3.rs`, `llama4.rs`) — NOT modified.** Routing models to the pooled path requires the pool to be populated (prefill write = **#120**) and routed (scheduler unification = **#121**); wiring it now would be dead gated code. The existing dense/rotating decode path stays live and unchanged, so "supported models functionally unaffected" holds trivially.

The existing `paged_decode_attention_dense_fallback` / `_dense_compat` / `_rotating_*` functions stay as-is (the live dense path and this PR's parity baseline). `PagedDecodeMetadata` / `RotatingPagedDecodeMetadata` are only read (`from_visible_lengths`) by the tests.

Closes #119
