### PR TITLE
feat: transparent pool-backed KVCache + real-model paged parity test

### DIFF
--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -104,6 +104,9 @@ pub use paged::{
 };
 pub use paged_detach::DetachedPagedCacheSet;
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use crate::concatenate;
 use crate::dtype;
 use crate::ffi;
@@ -399,6 +402,55 @@ pub struct KVCache {
     /// Packed sidecar maintenance cadence for the opt-in delegated FP16 fast
     /// path. Ignored unless `delegated_fp16_fast_path` is true.
     pub(crate) delegated_fp16_sidecar_policy: turbo::DelegatedFp16SidecarPolicy,
+    /// Optional transparent pool backing.
+    ///
+    /// `None` for every dense cache (the default for all existing
+    /// constructors), so the dense `update`/`update_and_fetch` path and every
+    /// existing call site are byte-for-byte unchanged. When `Some`,
+    /// [`Self::update_and_fetch`] routes K/V writes into a shared
+    /// [`PagedBlockPool`] (via `write_prefill`) and reads the visible window
+    /// back (via `gather_visible`) instead of touching the dense `keys`/
+    /// `values` buffers. Built only by [`Self::new_paged`].
+    ///
+    /// This is the single-stream groundwork for the scheduler-driven paged KV
+    /// cache (#121): one sequence, one pool, caches visited sequentially per
+    /// layer, so the simple `Rc<RefCell<…>>` sharing is sound (see the Step-0
+    /// `Send` analysis in the introducing PR — `KVCache` is never required to
+    /// be `Send`/`Sync`).
+    pub(crate) paged_backing: Option<PagedBacking>,
+}
+
+/// Shared handle that makes one [`KVCache`] write/read through a pooled paged
+/// KV store instead of its own dense buffers.
+///
+/// All layers of a single sequence share the same `pool` and `state` handles
+/// (cheap `Rc` clones); `layer_idx` selects this cache's slice of the
+/// per-sequence [`PagedSequenceState`]. Interior mutability via `RefCell` is
+/// required because [`KVCache::update_and_fetch`] needs `&mut` access to both
+/// the pool (to append/allocate blocks) and the per-sequence state while the
+/// model only hands the cache out behind `&mut [KVCache]` one layer at a time.
+///
+/// # Why `Rc<RefCell<…>>` and not raw pointers
+///
+/// `KVCache` is not required to be `Send`/`Sync` anywhere in the tree (no
+/// `unsafe impl`, no `assert_send_sync::<KVCache>()`, and the only async-context
+/// `Vec<KVCache>` — the pipeline stage service — is built and driven entirely
+/// inside a single OS thread via `block_on` on a current-thread runtime, never
+/// crossing a `tokio::spawn` boundary). The safe shared-ownership form is
+/// therefore preferred over raw pointers.
+#[derive(Clone)]
+pub(crate) struct PagedBacking {
+    pub(crate) pool: Rc<RefCell<PagedBlockPool>>,
+    pub(crate) state: Rc<RefCell<PagedSequenceState>>,
+    pub(crate) layer_idx: usize,
+}
+
+impl std::fmt::Debug for PagedBacking {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PagedBacking")
+            .field("layer_idx", &self.layer_idx)
+            .finish_non_exhaustive()
+    }
 }
 
 impl KVCache {
@@ -425,6 +477,7 @@ impl KVCache {
             hot_threshold: turbo::DELEGATED_HOT_THRESHOLD,
             delegated_fp16_fast_path: turbo::delegated_fp16_fast_path_enabled(),
             delegated_fp16_sidecar_policy: turbo::delegated_fp16_sidecar_policy(),
+            paged_backing: None,
         }
     }
 
@@ -472,7 +525,44 @@ impl KVCache {
             hot_threshold: turbo::DELEGATED_HOT_THRESHOLD,
             delegated_fp16_fast_path: turbo::delegated_fp16_fast_path_enabled(),
             delegated_fp16_sidecar_policy: turbo::delegated_fp16_sidecar_policy(),
+            paged_backing: None,
         }
+    }
+
+    /// Create a transparently pool-backed empty KV cache for one layer.
+    ///
+    /// The returned cache is `KVCacheMode::Fp16` with default step size, but
+    /// instead of accumulating K/V in its own dense `keys`/`values` buffers it
+    /// writes new tokens into the shared [`PagedBlockPool`] (`write_prefill`)
+    /// and reads the visible window back (`gather_visible`) inside
+    /// [`Self::update_and_fetch`]. All other dense state (`offset`,
+    /// `live_start`, …) is still tracked so RoPE positions stay correct; the
+    /// `keys`/`values` buffers simply remain `None`.
+    ///
+    /// `pool` and `state` are shared (cheap `Rc` clones) across every layer of
+    /// the same sequence; `layer_idx` selects this cache's slice of the
+    /// per-sequence [`PagedSequenceState`]. This is the single-stream (`B == 1`)
+    /// verification path for the paged KV cache (#118/#119/#120) — the
+    /// scheduler-driven multi-sequence wiring is #121.
+    ///
+    /// # Panics / errors
+    ///
+    /// This constructor never fails. Geometry mismatches (wrong `layer_idx`,
+    /// non-`[1, n_kv_heads, n_new, head_dim]` K/V, `B != 1`) surface as a
+    /// panic from [`Self::update_and_fetch`] on first write, because the model
+    /// forward signature cannot return a `Result`.
+    pub fn new_paged(
+        pool: Rc<RefCell<PagedBlockPool>>,
+        state: Rc<RefCell<PagedSequenceState>>,
+        layer_idx: usize,
+    ) -> Self {
+        let mut cache = Self::new();
+        cache.paged_backing = Some(PagedBacking {
+            pool,
+            state,
+            layer_idx,
+        });
+        cache
     }
 
     /// Override the Turbo4Delegated hot-tail fold threshold for this cache.
@@ -2341,6 +2431,15 @@ impl KVCache {
         new_keys: UniquePtr<MlxArray>,
         new_values: UniquePtr<MlxArray>,
     ) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
+        // Transparent pool-backed path (`new_paged`). Writes the new K/V into
+        // the shared `PagedBlockPool` and returns the gathered visible window,
+        // so the model `forward` is unchanged. Returns early; the dense
+        // `self.update(...)` below is intentionally skipped so we never
+        // double-write or allocate dense buffers. See `new_paged`.
+        if self.paged_backing.is_some() {
+            return self.update_and_fetch_paged(&new_keys, &new_values);
+        }
+
         self.update(new_keys, new_values);
 
         // After `update`, the live window length equals `buffer_idx()` —
@@ -2452,6 +2551,88 @@ impl KVCache {
                 )
             }
         }
+    }
+
+    /// Transparent pool-backed `update_and_fetch` for single-stream
+    /// (`B == 1`) sequences created with [`Self::new_paged`].
+    ///
+    /// Appends the new K/V tokens to this layer's tail inside the shared
+    /// [`PagedBlockPool`] (`write_prefill` handles both bulk prefill and a
+    /// single decode token), advances the monotonic `offset`, and returns the
+    /// gathered visible window in the SDPA-ready shape
+    /// `[1, n_kv_heads, visible_len, head_dim]` — byte-identical to what the
+    /// dense Fp16 path would have returned. The dense `keys`/`values` buffers
+    /// stay `None`.
+    ///
+    /// `offset` is advanced by `n_new` here for the same reason
+    /// [`Self::update_fp16`] advances it: RoPE reads `cache.offset` *before*
+    /// the next step's `update_and_fetch`, so it must reflect the
+    /// pre-call position during RoPE and the post-call position afterward. The
+    /// paged `state.layers[layer_idx].len` is bumped in lockstep by
+    /// `write_prefill`, so with `live_start == 0` (no head-trim on this path)
+    /// `buffer_idx() == offset == state len`.
+    ///
+    /// # Panics
+    ///
+    /// Panics (with a descriptive message) if the backing is missing, the K/V
+    /// batch dim is not `1`, the pool `write_prefill`/`gather_visible` calls
+    /// fail (e.g. geometry mismatch), or the gather is unexpectedly empty after
+    /// a non-empty write. The model `forward` signature returns a plain tuple,
+    /// so there is no `Result` to thread these through; a misuse is a hard bug,
+    /// not a recoverable condition.
+    fn update_and_fetch_paged(
+        &mut self,
+        new_keys: &MlxArray,
+        new_values: &MlxArray,
+    ) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
+        let backing = self
+            .paged_backing
+            .clone()
+            .expect("update_and_fetch_paged called without paged backing");
+        let layer_idx = backing.layer_idx;
+
+        let k_shape = ffi::array_shape(new_keys);
+        assert_eq!(
+            k_shape.len(),
+            4,
+            "update_and_fetch_paged: K must be [1, n_kv_heads, n_new, head_dim], got shape {k_shape:?}"
+        );
+        assert_eq!(
+            k_shape[0], 1,
+            "update_and_fetch_paged: only single-stream (B == 1) is supported, got batch {} (shape {k_shape:?})",
+            k_shape[0]
+        );
+        let n_new = k_shape[2];
+        if n_new <= 0 {
+            // Nothing to append; gather whatever is currently visible (the
+            // gather expects to return a non-empty window only when tokens
+            // exist — mirror the dense early paths by returning the current
+            // visible slice).
+            let state = backing.state.borrow();
+            let pool = backing.pool.borrow();
+            return pool
+                .gather_visible(&state, layer_idx)
+                .expect("gather_visible failed on empty append")
+                .expect("gather_visible returned None for a zero-token update");
+        }
+
+        {
+            let mut pool = backing.pool.borrow_mut();
+            let mut state = backing.state.borrow_mut();
+            pool.write_prefill(&mut state, layer_idx, new_keys, new_values)
+                .expect("PagedBlockPool::write_prefill failed");
+        }
+
+        // Advance the monotonic write position. RoPE for the *next* step reads
+        // `cache.offset` before calling back into `update_and_fetch`, so this
+        // mirrors the dense `update_fp16` bump exactly.
+        self.offset += n_new;
+
+        let state = backing.state.borrow();
+        let pool = backing.pool.borrow();
+        pool.gather_visible(&state, layer_idx)
+            .expect("PagedBlockPool::gather_visible failed after write_prefill")
+            .expect("gather_visible returned None despite a non-empty write")
     }
 
     /// Read path for `KVCacheMode::Turbo4Delegated` (K unified; cold-V dequant memo retired).

--- a/tests/paged_real_model_parity.rs
+++ b/tests/paged_real_model_parity.rs
@@ -1,0 +1,183 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real-model end-to-end parity for the transparent pool-backed `KVCache`.
+//!
+//! Verifies that the paged KV cache primitives (#118 layout / #119 write /
+//! #120 read) actually work through a real model's `forward`. This is the
+//! single-stream (`B == 1`) groundwork for the scheduler-driven paged cache
+//! (#121): one sequence, one [`PagedBlockPool`], every layer's `KVCache`
+//! created with `KVCache::new_paged` so that — without touching the model
+//! `forward` at all — each layer transparently writes new K/V into the shared
+//! pool (`write_prefill`) and reads the visible window back
+//! (`gather_visible`).
+//!
+//! The strongest "it actually works" signal is *identical generation*: the
+//! greedy-decoded token sequence from a pool-backed run must exactly match a
+//! dense-cache run of the same prompt. As a secondary check the prefill
+//! last-position argmax is compared directly.
+//!
+//! # Running
+//!
+//! The test is `#[ignore]` so it never blocks `cargo test` on machines without
+//! the model checkout. Run it explicitly (it executes a real GPU forward, so
+//! prefer `--release`):
+//!
+//! ```text
+//! cargo test --test paged_real_model_parity --release \
+//!     --features metal,accelerate -- --ignored --nocapture
+//! ```
+//!
+//! It soft-skips (prints a notice and returns) when
+//! `models/qwen3-0.6b-4bit` is absent. Fetch it with:
+//!
+//! ```text
+//! ./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit
+//! ```
+
+mod common;
+use common::repo_model_dir;
+
+use mlxcel::{LanguageModel, initialize_runtime, load_model};
+use mlxcel_core::cache::{KVCache, PagedBlockPool, PagedKvLayout, PagedSequenceState};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Model directory name (present at `models/qwen3-0.6b-4bit`).
+const MODEL_DIR_NAME: &str = "qwen3-0.6b-4bit";
+
+/// Paged block size (tokens per physical block). Any positive value works;
+/// 32 keeps several blocks in play across the prompt + decode window so the
+/// gather path exercises multi-block stitching rather than a single block.
+const BLOCK_SIZE: usize = 32;
+
+/// Number of greedy decode steps to compare after prefill.
+const DECODE_STEPS: usize = 16;
+
+/// Fixed prompt token ids (kept small and deterministic — no tokenizer needed,
+/// so the test stays purely about cache parity). These are arbitrary valid ids
+/// in the Qwen3 vocab; identical bytes feed both the dense and paged runs.
+const PROMPT_TOKENS: &[i32] = &[
+    9707, 11, 358, 1079, 264, 4128, 1614, 13, 5209, 3291, 752, 911, 697, 7990, 13, 358,
+];
+
+/// Greedy argmax over the vocab at sequence position `pos` of a
+/// `[1, seq_len, vocab]` logits tensor. Mirrors the private
+/// `generate::logits_at_position` + `argmax_last_axis` idiom.
+fn greedy_token(logits: &mlxcel_core::MlxArray, pos: usize) -> i32 {
+    let shape = mlxcel_core::array_shape(logits);
+    let batch = shape[0];
+    let vocab = shape[2];
+    // [1, 1, vocab] at the requested position.
+    let at_pos = mlxcel_core::slice(logits, &[0, pos as i32, 0], &[batch, pos as i32 + 1, vocab]);
+    // [vocab] so argmax_last_axis collapses to a scalar.
+    let flat = mlxcel_core::reshape(&at_pos, &[vocab]);
+    mlxcel_core::eval(&flat);
+    mlxcel_core::item_i32(&mlxcel_core::argmax_last_axis(&flat))
+}
+
+/// Run prefill + `DECODE_STEPS` greedy decode steps against `caches`,
+/// returning the decoded token sequence (one entry per decode step).
+///
+/// `caches` is whatever the caller built — `model.make_caches()` for the dense
+/// run or a `Vec<KVCache>` of `new_paged(...)` for the paged run. The forward
+/// calls are byte-for-byte identical between the two; only the cache backing
+/// differs.
+fn run_generation(model: &mlxcel::LoadedModel, caches: &mut [KVCache]) -> Vec<i32> {
+    let prompt_len = PROMPT_TOKENS.len();
+
+    // ── Prefill ───────────────────────────────────────────────────────────
+    let prompt = mlxcel_core::from_slice_i32(PROMPT_TOKENS, &[1, prompt_len as i32]);
+    let mask = mlxcel_core::utils::create_causal_mask(prompt_len as i32, 0);
+    let prefill_logits = model.forward(&prompt, caches, Some(&mask));
+    mlxcel_core::eval(&prefill_logits);
+
+    let mut next = greedy_token(&prefill_logits, prompt_len - 1);
+
+    // ── Decode ────────────────────────────────────────────────────────────
+    let mut decoded = Vec::with_capacity(DECODE_STEPS);
+    for _ in 0..DECODE_STEPS {
+        decoded.push(next);
+        // Feed the just-sampled token back as a [1, 1] step (no mask on decode,
+        // matching the production single-token path).
+        let step_input = mlxcel_core::from_slice_i32(&[next], &[1, 1]);
+        let logits = model.forward(&step_input, caches, None);
+        mlxcel_core::eval(&logits);
+        next = greedy_token(&logits, 0);
+    }
+    decoded
+}
+
+/// Build a shared paged pool + per-sequence state and one `new_paged`
+/// `KVCache` per layer.
+///
+/// `bytes_per_block` only needs to be a positive multiple of `BLOCK_SIZE`: the
+/// pool infers the real `(n_kv_heads, head_dim)` geometry lazily from the first
+/// `write_prefill`, and `bytes_per_block` is used purely for the layout's
+/// scheduling-byte accounting. We still size it from the qwen3-0.6b-4bit
+/// geometry (8 KV heads × 128 head_dim × 2 bytes/fp16 = 2048 bytes/token) so
+/// the accounting is realistic.
+fn build_paged_caches(num_layers: usize) -> Vec<KVCache> {
+    const FP16_BYTES_PER_TOKEN: usize = 8 /* n_kv_heads */ * 128 /* head_dim */ * 2 /* fp16 */;
+    let bytes_per_block = BLOCK_SIZE * FP16_BYTES_PER_TOKEN;
+
+    let layout = PagedKvLayout::uniform(num_layers, BLOCK_SIZE, bytes_per_block)
+        .expect("uniform paged layout");
+    let pool = Rc::new(RefCell::new(PagedBlockPool::new(layout.clone())));
+    let state = Rc::new(RefCell::new(PagedSequenceState::new(&layout)));
+
+    (0..num_layers)
+        .map(|layer_idx| KVCache::new_paged(Rc::clone(&pool), Rc::clone(&state), layer_idx))
+        .collect()
+}
+
+/// Pool-backed `KVCache` must produce identical greedy generation to a dense
+/// cache on a real model — proving #118/#119/#120 work through `forward`.
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit and runs a real GPU forward; run with --ignored"]
+fn paged_kvcache_matches_dense_qwen3_06b() {
+    let model_dir = repo_model_dir(MODEL_DIR_NAME);
+    if !model_dir.exists() {
+        eprintln!(
+            "Skipping {MODEL_DIR_NAME}: model directory not found at {}.\n\
+             Fetch with: ./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit",
+            model_dir.display()
+        );
+        return;
+    }
+
+    let _runtime = initialize_runtime();
+    let (model, _tokenizer) = load_model(&model_dir).expect("load qwen3-0.6b-4bit");
+    let num_layers = model.num_layers();
+    eprintln!("\n=== paged vs dense KV cache parity: {MODEL_DIR_NAME} ({num_layers} layers) ===");
+
+    // ── Dense reference run ───────────────────────────────────────────────
+    let mut dense_caches = model.make_caches();
+    let dense_tokens = run_generation(&model, &mut dense_caches);
+    eprintln!("dense  decoded: {dense_tokens:?}");
+
+    // ── Pool-backed run ───────────────────────────────────────────────────
+    let mut paged_caches = build_paged_caches(num_layers);
+    let paged_tokens = run_generation(&model, &mut paged_caches);
+    eprintln!("paged  decoded: {paged_tokens:?}");
+
+    // The decisive parity signal: identical greedy generation.
+    assert_eq!(
+        paged_tokens, dense_tokens,
+        "pool-backed KVCache produced different greedy tokens than the dense cache\n\
+         dense: {dense_tokens:?}\npaged: {paged_tokens:?}"
+    );
+
+    eprintln!("OK: {DECODE_STEPS} decode steps identical between dense and pool-backed KV cache.");
+}


### PR DESCRIPTION
## Summary

Single-stream verification slice for the merged paged KV cache (epic #116, phases #118 layout / #119 write / #120 read): add a **transparent** pool-backed path to `KVCache` and a **real-model parity test** that proves those primitives actually work end-to-end through a real model's `forward`. This is the foundational, single-stream (`B == 1`) groundwork for the scheduler wiring tracked in #121. It is a verification slice only and intentionally carries no closing keyword, so merging it must not auto-close any issue.

It deliberately leaves the model `forward`, `generate.rs`, and all C++ untouched: a pool-backed cache is opt-in per `KVCache`, so `model.forward(&input, &mut caches, mask)` is unchanged and the existing dense path is byte-for-byte identical.

## What changed

`src/lib/mlxcel-core/src/cache.rs`

- New optional `KVCache::paged_backing: Option<PagedBacking>`, defaulted to `None` in **both** struct-literal constructors (`KVCache::new`, `KVCache::new_with_mode_and_seed`). Every other construction path (`new_with_mode`, `CachePool::adopt`, the detach/adopt round-trip) routes through those two, so all existing call sites are unchanged and the dense path is unaffected.
- `PagedBacking { pool: Rc<RefCell<PagedBlockPool>>, state: Rc<RefCell<PagedSequenceState>>, layer_idx }`. All layers of one sequence share the `pool`/`state` handles (cheap `Rc` clones); `layer_idx` selects this cache's slice of the per-sequence state. `RefCell` provides the `&mut` access `update_and_fetch` needs while the model only hands caches out behind `&mut [KVCache]` one layer at a time.
- `KVCache::new_paged(pool, state, layer_idx)` builds a pool-backed Fp16 cache.
- Single intercept at the top of `update_and_fetch` — the only cache method qwen3 calls for plain Fp16 prefill (`l > 1`) and decode (`l == 1`). When pool-backed it appends via `write_prefill` (works for bulk prefill and a single decode token), bumps `self.offset += n_new` exactly as the dense `update_fp16` does, and returns `gather_visible(...)`. The dense `self.update(...)` is skipped on this path so there is no double-write/allocate. K/V dtype is preserved (no `astype`).

`tests/paged_real_model_parity.rs` (new)

- `#[ignore]` integration test that soft-skips when `models/qwen3-0.6b-4bit` is absent. Runs the identical prefill + 16-step greedy decode loop against (a) a dense `model.make_caches()` and (b) a `Vec<KVCache>` of `new_paged(...)` sharing one `PagedBlockPool`, then asserts the two greedy token sequences are **identical** (and prints both). Identical generation is the decisive "it actually works through a real model" signal.

## Why `Rc<RefCell<…>>` and not raw pointers

`KVCache` is not required to be `Send`/`Sync` anywhere in the tree: there is no `unsafe impl Send for KVCache`, no `assert_send_sync::<KVCache>()`, and the only place a `Vec<KVCache>` lives in an async context (the pipeline stage service's `caches_by_request`) is built and driven entirely inside one OS thread via `block_on` on a `new_current_thread` runtime — it never crosses a `tokio::spawn` (multi-thread, `Send`-requiring) boundary. The safe shared-ownership form is therefore correct and preferred.

## Test plan

- [x] `cargo check --lib -p mlxcel-core --features metal,accelerate`
- [x] `cargo clippy --lib -p mlxcel-core --features metal,accelerate -- -D warnings` (warm and cold via `cargo clean -p mlxcel-core`)
- [x] `cargo check --tests -p mlxcel-core --features metal,accelerate`
- [x] `cargo clippy -p mlxcel-core --tests --features metal,accelerate -- -D warnings`
- [x] `cargo check --test paged_real_model_parity --features metal,accelerate`
- [x] `cargo clippy --test paged_real_model_parity --features metal,accelerate -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Real-model parity (GPU; not run here — requires `models/qwen3-0.6b-4bit`):

      cargo test --test paged_real_model_parity --release --features metal,accelerate -- --ignored --nocapture

