### PR TITLE
fix: split quantized fused MoE experts in gemma4_unified sanitize

### DIFF
--- a/src/loading/vlm_gemma_unified.rs
+++ b/src/loading/vlm_gemma_unified.rs
@@ -36,9 +36,11 @@ use super::{parse_vlm_config, read_sanitized_vlm_config};
 ///   `language_model.model.<x>` unless it already starts with
 ///   `language_model.model.`;
 /// * split fused MoE experts `…experts.gate_up_proj` into
-///   `…experts.switch_glu.gate_proj.weight` / `…up_proj.weight` (swap the last
-///   two axes, split the doubled dim in half) and rename
-///   `…experts.down_proj` → `…experts.switch_glu.down_proj.weight`;
+///   `…experts.switch_glu.gate_proj` / `…up_proj` and rename
+///   `…experts.down_proj` → `…experts.switch_glu.down_proj`. This handles
+///   both the non-quantized bare `.weight` and the quantized triplet
+///   (`.weight` + `.scales` + `.biases`); see
+///   [`split_fused_gate_up_component`] for the per-component axis handling;
 /// * drop `embed_audio*` when `has_audio` is false.
 pub(crate) fn sanitize_gemma4_unified_weights(
     raw: mlxcel_core::weights::WeightMap,
@@ -56,27 +58,25 @@ pub(crate) fn sanitize_gemma4_unified_weights(
             continue;
         }
 
-        // Fused MoE experts: split gate_up_proj, rename down_proj. Only the
-        // non-quantized `.weight` path is fused in upstream Gemma 4 Unified
-        // MoE checkpoints; quantized scales/biases follow the same split when
-        // present.
-        if key.ends_with("experts.gate_up_proj") {
-            let prefix = key.trim_end_matches("gate_up_proj");
-            // value: [num_experts, in, 2*ffn]; swap last two axes →
-            // [num_experts, 2*ffn, in], then split the doubled dim in half.
-            let swapped = mlxcel_core::transpose_axes(&value, &[0, 2, 1]);
-            let shape = mlxcel_core::array_shape(&swapped);
-            let doubled = shape[1];
-            let half = doubled / 2;
-            let gate = mlxcel_core::slice(&swapped, &[0, 0, 0], &[shape[0], half, shape[2]]);
-            let up = mlxcel_core::slice(&swapped, &[0, half, 0], &[shape[0], doubled, shape[2]]);
-            out.insert(format!("{prefix}switch_glu.gate_proj.weight"), gate);
-            out.insert(format!("{prefix}switch_glu.up_proj.weight"), up);
+        // Fused MoE experts: split `gate_up_proj`, rename `down_proj`. Both the
+        // non-quantized bare `.weight` and the quantized triplet (`.weight` +
+        // `.scales` + `.biases`) are handled: each present component is split
+        // along the output (doubled-FFN) axis at the same half boundary into
+        // `…switch_glu.gate_proj.<c>` (first half) and `…switch_glu.up_proj.<c>`
+        // (second half). MLX affine quantization groups along the input
+        // (contract) axis, so splitting the output axis partitions `weight`,
+        // `scales`, and `biases` cleanly with no group straddling and no
+        // dequantize/unpack — see [`split_fused_gate_up_component`].
+        if let Some((prefix, component)) = split_fused_moe_key(&key, "gate_up_proj") {
+            let (gate, up) = split_fused_gate_up_component(&value, component);
+            out.insert(format!("{prefix}switch_glu.gate_proj{component}"), gate);
+            out.insert(format!("{prefix}switch_glu.up_proj{component}"), up);
             continue;
         }
-        if key.ends_with("experts.down_proj") {
-            let prefix = key.trim_end_matches("down_proj");
-            out.insert(format!("{prefix}switch_glu.down_proj.weight"), value);
+        if let Some((prefix, component)) = split_fused_moe_key(&key, "down_proj") {
+            // `down_proj` is not doubled: rename each present component
+            // (`.weight` / `.scales` / `.biases`) under `switch_glu` unchanged.
+            out.insert(format!("{prefix}switch_glu.down_proj{component}"), value);
             continue;
         }
 
@@ -87,6 +87,82 @@ pub(crate) fn sanitize_gemma4_unified_weights(
     }
 
     out
+}
+
+/// Match a fused MoE expert key (`base` = `gate_up_proj` / `down_proj`) in both
+/// the non-quantized and quantized forms, returning `(prefix, component)` where
+/// `prefix` is everything up to and including `experts.` and `component` is the
+/// quantization-component suffix: `""` for the bare non-quantized tensor, or
+/// `".weight"` / `".scales"` / `".biases"` for one leg of a quantized triplet.
+///
+/// Examples (with `base = "gate_up_proj"`):
+/// * `…experts.gate_up_proj`         → `("…experts.", "")`
+/// * `…experts.gate_up_proj.weight`  → `("…experts.", ".weight")`
+/// * `…experts.gate_up_proj.scales`  → `("…experts.", ".scales")`
+/// * `…experts.gate_up_proj.biases`  → `("…experts.", ".biases")`
+fn split_fused_moe_key<'a>(key: &'a str, base: &str) -> Option<(&'a str, &'static str)> {
+    // Bare (non-quantized) tensor: `…experts.<base>`.
+    if let Some(prefix) = key.strip_suffix(base) {
+        if prefix.ends_with("experts.") {
+            return Some((prefix, ""));
+        }
+    }
+    // Quantized triplet legs: `…experts.<base>.<component>`.
+    for component in [".weight", ".scales", ".biases"] {
+        let needle = format!("{base}{component}");
+        if let Some(prefix) = key.strip_suffix(&needle) {
+            if prefix.ends_with("experts.") {
+                return Some((prefix, component));
+            }
+        }
+    }
+    None
+}
+
+/// Split one component of a fused `gate_up_proj` expert tensor along its output
+/// (doubled-FFN) axis into the gate (first half) and up (second half) legs.
+///
+/// Orientation:
+/// * The bare non-quantized `.weight` is stored `[num_experts, in, 2*ffn]`
+///   (the doubled FFN dim is the **last** axis). It is transposed to
+///   `[num_experts, 2*ffn, in]` so the doubled dim becomes the output axis 1,
+///   then sliced in half — matching the `Regular` `SwitchLinear` layout
+///   (`gather_mm` swaps the last two axes back at forward time).
+/// * Quantized components (`.weight` packed ints, `.scales`, `.biases`) are
+///   already stored in the post-transpose `[num_experts, 2*ffn, in/…]` layout
+///   that `gather_qmm(transpose=true)` consumes, with MLX affine grouping along
+///   the **last (input/contract)** axis. They are therefore split on axis 1
+///   directly — **no transpose**: transposing packed ints or per-group
+///   scales/biases would corrupt them, and slicing the independent output rows
+///   partitions `weight`/`scales`/`biases` at the identical half boundary with
+///   no group straddling. This mirrors the `mistral4` / `qwen3_5_moe` fused
+///   splits, which likewise slice the output axis of the already-`[E, out, in]`
+///   tensor without transposing.
+fn split_fused_gate_up_component(
+    value: &mlxcel_core::MlxArray,
+    component: &str,
+) -> (
+    mlxcel_core::UniquePtr<mlxcel_core::MlxArray>,
+    mlxcel_core::UniquePtr<mlxcel_core::MlxArray>,
+) {
+    use mlxcel_core::utils::slice_axis;
+
+    if component.is_empty() {
+        // Non-quantized: [num_experts, in, 2*ffn] → transpose to
+        // [num_experts, 2*ffn, in], then split the doubled (output) axis 1.
+        let swapped = mlxcel_core::transpose_axes(value, &[0, 2, 1]);
+        let half = mlxcel_core::array_shape(&swapped)[1] / 2;
+        let gate = slice_axis(&swapped, 1, 0, half);
+        let up = slice_axis(&swapped, 1, half, -1);
+        (gate, up)
+    } else {
+        // Quantized leg: already [num_experts, 2*ffn, in/…]; split the output
+        // axis 1 in place (group/packed axis is the last axis, left intact).
+        let half = mlxcel_core::array_shape(value)[1] / 2;
+        let gate = slice_axis(value, 1, 0, half);
+        let up = slice_axis(value, 1, half, -1);
+        (gate, up)
+    }
 }
 
 /// Normalize a single `gemma4_unified` weight key (prefix handling only).

--- a/src/loading/vlm_gemma_unified.rs
+++ b/src/loading/vlm_gemma_unified.rs
@@ -70,18 +70,30 @@ pub(crate) fn sanitize_gemma4_unified_weights(
         if let Some((prefix, component)) = split_fused_moe_key(&key, "gate_up_proj") {
             // The bare non-quantized key carries no suffix but emits `.weight`
             // (preserving the original behavior); quantized legs keep their own.
+            // Run the split keys through the same prefix normalization as every
+            // other tensor so a `model.`-prefixed checkpoint lands under
+            // `language_model.model.…` (idempotent for already-normalized keys).
             let suffix = emit_component_suffix(component);
             let (gate, up) = split_fused_gate_up_component(&value, component);
-            out.insert(format!("{prefix}switch_glu.gate_proj{suffix}"), gate);
-            out.insert(format!("{prefix}switch_glu.up_proj{suffix}"), up);
+            out.insert(
+                normalize_gemma4_unified_key(&format!("{prefix}switch_glu.gate_proj{suffix}")),
+                gate,
+            );
+            out.insert(
+                normalize_gemma4_unified_key(&format!("{prefix}switch_glu.up_proj{suffix}")),
+                up,
+            );
             continue;
         }
         if let Some((prefix, component)) = split_fused_moe_key(&key, "down_proj") {
             // `down_proj` is not doubled: rename each present component
             // (bare `.weight` / quantized `.weight` / `.scales` / `.biases`)
-            // under `switch_glu` unchanged.
+            // under `switch_glu` unchanged, then normalize the prefix as above.
             let suffix = emit_component_suffix(component);
-            out.insert(format!("{prefix}switch_glu.down_proj{suffix}"), value);
+            out.insert(
+                normalize_gemma4_unified_key(&format!("{prefix}switch_glu.down_proj{suffix}")),
+                value,
+            );
             continue;
         }
 

--- a/src/loading/vlm_gemma_unified.rs
+++ b/src/loading/vlm_gemma_unified.rs
@@ -68,15 +68,20 @@ pub(crate) fn sanitize_gemma4_unified_weights(
         // `scales`, and `biases` cleanly with no group straddling and no
         // dequantize/unpack — see [`split_fused_gate_up_component`].
         if let Some((prefix, component)) = split_fused_moe_key(&key, "gate_up_proj") {
+            // The bare non-quantized key carries no suffix but emits `.weight`
+            // (preserving the original behavior); quantized legs keep their own.
+            let suffix = emit_component_suffix(component);
             let (gate, up) = split_fused_gate_up_component(&value, component);
-            out.insert(format!("{prefix}switch_glu.gate_proj{component}"), gate);
-            out.insert(format!("{prefix}switch_glu.up_proj{component}"), up);
+            out.insert(format!("{prefix}switch_glu.gate_proj{suffix}"), gate);
+            out.insert(format!("{prefix}switch_glu.up_proj{suffix}"), up);
             continue;
         }
         if let Some((prefix, component)) = split_fused_moe_key(&key, "down_proj") {
             // `down_proj` is not doubled: rename each present component
-            // (`.weight` / `.scales` / `.biases`) under `switch_glu` unchanged.
-            out.insert(format!("{prefix}switch_glu.down_proj{component}"), value);
+            // (bare `.weight` / quantized `.weight` / `.scales` / `.biases`)
+            // under `switch_glu` unchanged.
+            let suffix = emit_component_suffix(component);
+            out.insert(format!("{prefix}switch_glu.down_proj{suffix}"), value);
             continue;
         }
 
@@ -102,21 +107,33 @@ pub(crate) fn sanitize_gemma4_unified_weights(
 /// * `…experts.gate_up_proj.biases`  → `("…experts.", ".biases")`
 fn split_fused_moe_key<'a>(key: &'a str, base: &str) -> Option<(&'a str, &'static str)> {
     // Bare (non-quantized) tensor: `…experts.<base>`.
-    if let Some(prefix) = key.strip_suffix(base) {
-        if prefix.ends_with("experts.") {
-            return Some((prefix, ""));
-        }
+    if let Some(prefix) = key.strip_suffix(base)
+        && prefix.ends_with("experts.")
+    {
+        return Some((prefix, ""));
     }
     // Quantized triplet legs: `…experts.<base>.<component>`.
     for component in [".weight", ".scales", ".biases"] {
         let needle = format!("{base}{component}");
-        if let Some(prefix) = key.strip_suffix(&needle) {
-            if prefix.ends_with("experts.") {
-                return Some((prefix, component));
-            }
+        if let Some(prefix) = key.strip_suffix(&needle)
+            && prefix.ends_with("experts.")
+        {
+            return Some((prefix, component));
         }
     }
     None
+}
+
+/// Map a matched component to the suffix written under `switch_glu`. The bare
+/// non-quantized tensor (matched `component == ""`) is emitted as `.weight` to
+/// preserve the original `switch_glu.<proj>.weight` naming; quantized legs keep
+/// their own `.weight` / `.scales` / `.biases` suffix verbatim.
+fn emit_component_suffix(component: &str) -> &str {
+    if component.is_empty() {
+        ".weight"
+    } else {
+        component
+    }
 }
 
 /// Split one component of a fused `gate_up_proj` expert tensor along its output

--- a/src/loading/vlm_gemma_unified_tests.rs
+++ b/src/loading/vlm_gemma_unified_tests.rs
@@ -206,6 +206,42 @@ fn unified_sanitize_splits_moe_switch_glu() {
 }
 
 #[test]
+fn unified_sanitize_moe_split_normalizes_model_prefix() {
+    // A `model.`-prefixed fused expert key must land under the normalized
+    // `language_model.model.…` namespace, like every other sanitized tensor —
+    // the split branch runs its output keys through `normalize_gemma4_unified_key`.
+    let mut raw = WeightMap::new();
+    raw.insert(
+        "model.language_model.layers.0.mlp.experts.gate_up_proj".to_string(),
+        mlxcel_core::ones(&[2, 3, 8], dtype::FLOAT32),
+    );
+    raw.insert(
+        "model.language_model.layers.0.mlp.experts.down_proj".to_string(),
+        mlxcel_core::ones(&[2, 4, 3], dtype::FLOAT32),
+    );
+
+    let out = sanitize_gemma4_unified_weights(raw, true);
+
+    // Split keys are normalized (no leftover raw `model.language_model.` prefix).
+    assert!(
+        out.contains_key("language_model.model.layers.0.mlp.experts.switch_glu.gate_proj.weight"),
+        "gate_proj split present under normalized prefix"
+    );
+    assert!(
+        out.contains_key("language_model.model.layers.0.mlp.experts.switch_glu.up_proj.weight"),
+        "up_proj split present under normalized prefix"
+    );
+    assert!(
+        out.contains_key("language_model.model.layers.0.mlp.experts.switch_glu.down_proj.weight"),
+        "down_proj renamed under normalized prefix"
+    );
+    assert!(
+        !out.keys().any(|k| k.starts_with("model.language_model.")),
+        "no raw model.language_model.* prefix should survive the split"
+    );
+}
+
+#[test]
 fn unified_sanitize_splits_quantized_moe_switch_glu() {
     // Quantized fused triplet: gate_up_proj.{weight,scales,biases} in the
     // [num_experts=2, 2*ffn=8, in/…] on-disk layout, plus a down_proj triplet.

--- a/src/loading/vlm_gemma_unified_tests.rs
+++ b/src/loading/vlm_gemma_unified_tests.rs
@@ -16,7 +16,90 @@
 
 use super::{normalize_gemma4_unified_key, sanitize_gemma4_unified_weights};
 use mlxcel_core::dtype;
+use mlxcel_core::utils::slice_axis;
 use mlxcel_core::weights::WeightMap;
+
+/// MLX affine-quantization parameters for the synthetic fused-MoE fixtures.
+const Q_BITS: i32 = 4;
+const Q_GROUP_SIZE: i32 = 32;
+
+/// Build a synthetic quantized fused `gate_up_proj` triplet in the on-disk
+/// layout the runtime expects: `weight`/`scales`/`biases` shaped
+/// `[num_experts, 2*ffn, …]` with MLX affine grouping along the **last**
+/// (input/contract) axis. The doubled output axis (`2*ffn`) is axis 1, which is
+/// the axis the sanitize split must partition.
+///
+/// Shapes for `(num_experts=e, doubled=2*ffn, in_features)` with `bits`/`gs`:
+/// * `weight`  (packed u32): `[e, 2*ffn, in_features * bits / 32]`
+/// * `scales`  (f32):        `[e, 2*ffn, in_features / gs]`
+/// * `biases`  (f32):        `[e, 2*ffn, in_features / gs]`
+///
+/// Values are deterministic but **distinct per output row** (and per expert) so
+/// that a wrong-axis or group-straddling split would change the dequantized
+/// result, making the equivalence gate non-vacuous.
+fn make_quantized_gate_up(
+    e: i32,
+    doubled: i32,
+    in_features: i32,
+) -> (
+    mlxcel_core::UniquePtr<mlxcel_core::MlxArray>,
+    mlxcel_core::UniquePtr<mlxcel_core::MlxArray>,
+    mlxcel_core::UniquePtr<mlxcel_core::MlxArray>,
+) {
+    let packed_cols = (in_features * Q_BITS / 32) as usize;
+    let groups = (in_features / Q_GROUP_SIZE) as usize;
+
+    let mut weight_data: Vec<u32> = Vec::with_capacity(e as usize * doubled as usize * packed_cols);
+    let mut scales_data: Vec<f32> = Vec::with_capacity(e as usize * doubled as usize * groups);
+    let mut biases_data: Vec<f32> = Vec::with_capacity(e as usize * doubled as usize * groups);
+
+    for ei in 0..e as u32 {
+        for r in 0..doubled as u32 {
+            // Distinct packed bit pattern per (expert, output-row, column).
+            for c in 0..packed_cols as u32 {
+                weight_data.push(0x1234_5678u32.wrapping_add(ei * 131 + r * 17 + c));
+            }
+            // Distinct, non-trivial scale/bias per (expert, output-row, group).
+            for g in 0..groups as u32 {
+                scales_data
+                    .push(0.05 + 0.01 * (ei as f32) + 0.001 * (r as f32) + 0.0003 * g as f32);
+                biases_data
+                    .push(-0.2 + 0.02 * (ei as f32) - 0.003 * (r as f32) + 0.0007 * g as f32);
+            }
+        }
+    }
+
+    let weight = mlxcel_core::from_slice_u32(&weight_data, &[e, doubled, packed_cols as i32]);
+    let scales = mlxcel_core::from_slice_f32(&scales_data, &[e, doubled, groups as i32]);
+    let biases = mlxcel_core::from_slice_f32(&biases_data, &[e, doubled, groups as i32]);
+    (weight, scales, biases)
+}
+
+/// Affine-dequantize a quantized triplet to full precision (f32).
+fn dequant(
+    weight: &mlxcel_core::MlxArray,
+    scales: &mlxcel_core::MlxArray,
+    biases: &mlxcel_core::MlxArray,
+) -> mlxcel_core::UniquePtr<mlxcel_core::MlxArray> {
+    unsafe {
+        mlxcel_core::dequantize(
+            weight,
+            scales,
+            biases as *const _,
+            Q_GROUP_SIZE,
+            Q_BITS,
+            "affine",
+        )
+    }
+}
+
+/// Max absolute difference between two arrays as an f32 scalar.
+fn max_abs_diff(a: &mlxcel_core::MlxArray, b: &mlxcel_core::MlxArray) -> f32 {
+    let diff = mlxcel_core::subtract(a, b);
+    let abs = mlxcel_core::abs(&diff);
+    let max = mlxcel_core::max_all(&abs);
+    mlxcel_core::item_f32(&max)
+}
 
 #[test]
 fn unified_key_normalization_prefixes() {
@@ -119,5 +202,127 @@ fn unified_sanitize_splits_moe_switch_glu() {
     assert!(
         out.contains_key("language_model.model.layers.0.mlp.experts.switch_glu.down_proj.weight"),
         "down_proj renamed under switch_glu"
+    );
+}
+
+#[test]
+fn unified_sanitize_splits_quantized_moe_switch_glu() {
+    // Quantized fused triplet: gate_up_proj.{weight,scales,biases} in the
+    // [num_experts=2, 2*ffn=8, in/…] on-disk layout, plus a down_proj triplet.
+    // `in_features = 64` ⇒ packed weight cols = 64*4/32 = 8, groups = 64/32 = 2.
+    let (gu_w, gu_s, gu_b) = make_quantized_gate_up(2, 8, 64);
+    let prefix = "language_model.model.layers.0.mlp.experts";
+
+    let mut raw = WeightMap::new();
+    raw.insert(format!("{prefix}.gate_up_proj.weight"), gu_w);
+    raw.insert(format!("{prefix}.gate_up_proj.scales"), gu_s);
+    raw.insert(format!("{prefix}.gate_up_proj.biases"), gu_b);
+    // down_proj triplet (renamed, not split): [num_experts=2, ffn=4, in_packed].
+    raw.insert(
+        format!("{prefix}.down_proj.weight"),
+        mlxcel_core::from_slice_u32(&vec![0u32; 2 * 4 * 8], &[2, 4, 8]),
+    );
+    raw.insert(
+        format!("{prefix}.down_proj.scales"),
+        mlxcel_core::ones(&[2, 4, 2], dtype::FLOAT32),
+    );
+    raw.insert(
+        format!("{prefix}.down_proj.biases"),
+        mlxcel_core::ones(&[2, 4, 2], dtype::FLOAT32),
+    );
+
+    let out = sanitize_gemma4_unified_weights(raw, true);
+
+    // Fused/bare keys must be gone for every component.
+    for comp in [".weight", ".scales", ".biases"] {
+        assert!(
+            !out.contains_key(&format!("{prefix}.gate_up_proj{comp}")),
+            "fused gate_up_proj{comp} should be split away"
+        );
+    }
+
+    // gate/up split: weight [2,4,8], scales/biases [2,4,2] (output axis halved).
+    for proj in ["gate_proj", "up_proj"] {
+        let w = out
+            .get(&format!("{prefix}.switch_glu.{proj}.weight"))
+            .unwrap_or_else(|| panic!("{proj}.weight present"));
+        let s = out
+            .get(&format!("{prefix}.switch_glu.{proj}.scales"))
+            .unwrap_or_else(|| panic!("{proj}.scales present"));
+        let b = out
+            .get(&format!("{prefix}.switch_glu.{proj}.biases"))
+            .unwrap_or_else(|| panic!("{proj}.biases present"));
+        assert_eq!(mlxcel_core::array_shape(w), vec![2, 4, 8], "{proj}.weight");
+        assert_eq!(mlxcel_core::array_shape(s), vec![2, 4, 2], "{proj}.scales");
+        assert_eq!(mlxcel_core::array_shape(b), vec![2, 4, 2], "{proj}.biases");
+    }
+
+    // down_proj triplet is renamed unchanged (no split).
+    for comp in [".weight", ".scales", ".biases"] {
+        assert!(
+            out.contains_key(&format!("{prefix}.switch_glu.down_proj{comp}")),
+            "down_proj{comp} renamed under switch_glu"
+        );
+        assert!(
+            !out.contains_key(&format!("{prefix}.down_proj{comp}")),
+            "original down_proj{comp} removed"
+        );
+    }
+}
+
+#[test]
+fn unified_sanitize_quantized_split_dequant_equivalence() {
+    // Numerical gate: splitting the quantized fused tensor along the output axis
+    // must be lossless and axis-aligned, i.e.
+    //     dequantize(split(W)) == split(dequantize(W))   (along output axis 1).
+    // This proves the sanitize split partitions weight/scales/biases at the same
+    // half boundary with no group straddling — without needing a real
+    // quantized-MoE gemma4_unified checkpoint.
+    let (gu_w, gu_s, gu_b) = make_quantized_gate_up(2, 8, 64);
+
+    // Reference: dequantize the FULL fused tensor, then split along axis 1.
+    let full = dequant(&gu_w, &gu_s, &gu_b); // [2, 8, 64]
+    let half = mlxcel_core::array_shape(&full)[1] / 2; // 4
+    let ref_gate = slice_axis(&full, 1, 0, half); // [2, 4, 64]
+    let ref_up = slice_axis(&full, 1, half, -1); // [2, 4, 64]
+
+    // Under test: run sanitize, then dequantize each split leg.
+    let prefix = "language_model.model.layers.0.mlp.experts";
+    let mut raw = WeightMap::new();
+    raw.insert(format!("{prefix}.gate_up_proj.weight"), gu_w);
+    raw.insert(format!("{prefix}.gate_up_proj.scales"), gu_s);
+    raw.insert(format!("{prefix}.gate_up_proj.biases"), gu_b);
+    let out = sanitize_gemma4_unified_weights(raw, true);
+
+    let gate = dequant(
+        out.get(&format!("{prefix}.switch_glu.gate_proj.weight"))
+            .unwrap(),
+        out.get(&format!("{prefix}.switch_glu.gate_proj.scales"))
+            .unwrap(),
+        out.get(&format!("{prefix}.switch_glu.gate_proj.biases"))
+            .unwrap(),
+    );
+    let up = dequant(
+        out.get(&format!("{prefix}.switch_glu.up_proj.weight"))
+            .unwrap(),
+        out.get(&format!("{prefix}.switch_glu.up_proj.scales"))
+            .unwrap(),
+        out.get(&format!("{prefix}.switch_glu.up_proj.biases"))
+            .unwrap(),
+    );
+
+    // Shapes match the reference split, and values are bit-identical (the split
+    // never touches the quantized data, only selects output rows).
+    assert_eq!(mlxcel_core::array_shape(&gate), vec![2, 4, 64]);
+    assert_eq!(mlxcel_core::array_shape(&up), vec![2, 4, 64]);
+    assert_eq!(
+        max_abs_diff(&gate, &ref_gate),
+        0.0,
+        "dequantize(split(gate)) must equal split(dequantize)(gate)"
+    );
+    assert_eq!(
+        max_abs_diff(&up, &ref_up),
+        0.0,
+        "dequantize(split(up)) must equal split(dequantize)(up)"
     );
 }


### PR DESCRIPTION
## Summary

Generalize the `gemma4_unified` fused-MoE expert split in `sanitize_gemma4_unified_weights` so it handles the quantized triplet (`.weight` + `.scales` + `.biases`), not just the bare non-quantized `.weight`. Previously the match guards required the exact key `…experts.gate_up_proj` / `…experts.down_proj`, so for a quantized MoE checkpoint none of the `.weight`/`.scales`/`.biases` legs matched, the split never fired, the fused tensors fell through to prefix normalization, and `switch_glu` construction could not find its per-projection quantized parts.

## What changed

- `src/loading/vlm_gemma_unified.rs`
  - `split_fused_moe_key` matches a fused expert key (`gate_up_proj` / `down_proj`) in both the bare form and each quantized component leg, returning the `experts.` prefix and the component suffix (`""` / `.weight` / `.scales` / `.biases`).
  - `split_fused_gate_up_component` splits each present component along the **output (doubled-FFN) axis** at the same half boundary into `switch_glu.gate_proj.<c>` (first half) and `switch_glu.up_proj.<c>` (second half); `down_proj` is renamed under `switch_glu` unchanged.
  - `emit_component_suffix` keeps the bare non-quantized path emitting `…switch_glu.<proj>.weight` (original naming) while quantized legs keep their own suffix.
  - Replaced the now-inaccurate "aspirational" comment with an accurate description of the implemented split and its orientation.
  - Both fused-MoE split branches now wrap their output keys in `normalize_gemma4_unified_key` so a `model.`-prefixed checkpoint's split expert tensors land under the normalized `language_model.model.…` namespace, consistent with every other sanitized tensor. The normalization is idempotent for already-normalized keys.
- `src/loading/vlm_gemma_unified_tests.rs`
  - Added a synthetic quantized fused fixture and shape/key assertions (`unified_sanitize_splits_quantized_moe_switch_glu`).
  - Added a numerical dequantize-equivalence gate (`unified_sanitize_quantized_split_dequant_equivalence`).
  - Added guard test `unified_sanitize_moe_split_normalizes_model_prefix` covering the `model.language_model.*` → `language_model.model.*` rewrite through the split path.

## Orientation (the layout-risk resolution)

- **Non-quantized** `.weight` is stored `[num_experts, in, 2*ffn]` (doubled dim is the **last** axis) and keeps the existing `transpose([0,2,1])` → split-axis-1 path.
- **Quantized** legs are already stored in the post-transpose `[num_experts, 2*ffn, in/…]` layout that `gather_qmm(transpose=true)` consumes, with MLX affine grouping along the **last (input/contract)** axis. They are split on the **output axis 1 directly, with no transpose** — transposing packed ints or per-group scales/biases would corrupt them, while slicing independent output rows partitions `weight`/`scales`/`biases` at the identical half boundary with no group straddling. This mirrors the `mistral4` (`src/models/mistral4.rs`) and `qwen3_5_moe` (`src/models/qwen3_5.rs`) fused splits, which likewise slice the output axis of the already-`[E, out, in]` tensor without transposing.

## Validation caveat

No real quantized-MoE `gemma4_unified` checkpoint exists yet for end-to-end validation. Correctness is proven via the synthetic dequantize-equivalence round-trip (`dequantize(split(W)) == split(dequantize(W))` along the output axis, asserted with max-abs-diff == 0.0 over a fixture with distinct per-output-row values so a wrong-axis or group-straddling split would fail) and by mirroring the `mistral4` / `qwen3_5_moe` precedent. The dense reference model (`gemma-4-12b-it-4bit`) and the non-quantized MoE path are unaffected (the existing non-quantized split test stays green).

## Test plan

- [x] `cargo test --lib unified_sanitize` — 6 passed (existing non-quant split + 2 new quantized tests including the dequant-equivalence gate + new normalize-prefix guard)
- [x] `cargo check --lib --tests` — clean
- [x] `cargo clippy --lib --tests -- -D warnings` — clean
- [x] `cargo fmt` — clean

Closes #155