### PR TITLE
feat: Gemma 4 Unified MTP speculative drafter (gemma4_unified_assistant)

### DIFF
--- a/docs/benchmark_results/benchmark-report.md
+++ b/docs/benchmark_results/benchmark-report.md
@@ -124,6 +124,21 @@ decode results sit near mlx-vlm median parity on both Apple Silicon hosts.
   visible for VLM wrappers, Gemma 4 variants, ERNIE, Hunyuan, ExaOne4, and
   several newer hybrid/MoE families.
 
+## Speculative Decoding (MTP)
+
+Added 2026-06-04 on Apple M5 Max (128 GB). Unlike the rows above, this compares
+mlxcel against itself, classic decode versus MTP speculative decode on the same
+target, rather than against a Python baseline.
+
+| Target (family)                        | Drafter                       | block | classic tok/s | MTP tok/s | speedup |
+| -------------------------------------- | ----------------------------- | ----: | ------------: | --------: | ------: |
+| gemma-4-12b-it-4bit (Gemma 4 Unified)  | gemma-4-12B-it-assistant-4bit |     4 |          ~39  |      ~74  | ~1.87x  |
+
+Output is byte-identical at `temperature 0` (MTP is exactness-preserving). The
+Gemma 4 Unified target cannot batch, so the scheduler runs its B=1 MTP path by
+default. See [Benchmarks, Speculative decoding (MTP)](../benchmarks.md) for the
+measurement method and the Gemma 4 31B batched-window notes.
+
 ## Reading the Numbers Correctly
 
 - **Decode tok/s** is the headline metric. It measures autoregressive token

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -45,6 +45,61 @@ arguments may evolve, so inspect each script before publishing results.
 ./scripts/bench_all_models.sh --hardware <name> --cooldown 45 --big-cooldown 60
 ```
 
+## Speculative decoding (MTP)
+
+MTP speculative decoding pairs a decode target with a small assistant drafter
+that proposes a block of tokens, which the target then verifies in a single
+forward pass. At `temperature 0` the accelerated output is byte-identical to
+classic decode, so the only metric that moves is decode throughput; confirm
+correctness by diffing the two completions.
+
+For each pairing, record both the baseline (no drafter) and the MTP run:
+
+- decode tok/s for each, and the speedup ratio (MTP divided by baseline);
+- mean acceptance length (accepted draft tokens per verify), read from the
+  `MTP round-loop diagnostics` log line;
+- the block size (`--draft-block-size`), and whether the singleton burst
+  engaged or was declined.
+
+Measure with the `speculative_bench` harness or the server:
+
+```bash
+# In-process harness: baseline vs MTP on the same target.
+./target/release/speculative_bench --target <target_dir> --kind none --max-tokens 256
+./target/release/speculative_bench --target <target_dir> --draft <drafter_dir> --kind mtp --max-tokens 256
+
+# Server (production path): time a fixed temperature-0 completion with and
+# without the drafter. The server logs decode tok/s and acceptance per request.
+mlxcel serve -m <target> --draft-model <drafter> --draft-kind mtp
+```
+
+### Gemma 4 Unified (12B) + 4-bit assistant
+
+Measured on Apple M5 Max (128 GB) with `mlx-community/gemma-4-12b-it-4bit` as the
+target and `mlx-community/gemma-4-12B-it-assistant-4bit` as the drafter, block
+size 4, `temperature 0`, 200 decode tokens:
+
+| Path                        | decode tok/s | speedup |
+| --------------------------- | -----------: | ------: |
+| classic decode (no drafter) |         ~39  |  1.00x  |
+| MTP                         |         ~74  | ~1.87x  |
+
+The accelerated output is byte-identical to classic decode. The Gemma 4 Unified
+target does not batch (`supports_batching()` is false), so B=1 is its only decode
+path and the scheduler runs B=1 MTP for it by default. `MLXCEL_ENABLE_MTP_B1=1`
+additionally forces B=1 MTP on batch-capable targets, which is useful for parity
+and debugging.
+
+### Gemma 4 31B + bf16 assistant
+
+The 31B text target is batch-capable, and its MTP speedup comes from batched
+(B>1) verify windows rather than the singleton path. The scheduler declines B=1
+MTP there because the bf16 assistant's single-stream acceptance is too low to
+offset the extra drafter forward per token. This pairing is wired into
+`speculative_bench` (`REACHABLE_PAIRINGS`) and runs once the
+`gemma-4-31b-it-4bit` and `gemma-4-31B-it-assistant-bf16` checkpoints are present
+in the model store.
+
 ## Recommended output layout
 
 Add benchmark artifacts under a dedicated directory before publishing a release,

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -98,7 +98,7 @@ provided.
 |----------|--------|---------|-------|
 | `MLXCEL_DRAFT_KIND` | `dflash`, `mtp` | auto/none | Alias for `--draft-kind` when the CLI flag and `LLAMA_ARG_DRAFT_KIND` are absent. |
 | `MLXCEL_DRAFT_BLOCK_SIZE` | unsigned integer | per drafter (`4` for MTP, `16` for DFlash) | Alias for `--draft-block-size` when the CLI flag and `LLAMA_ARG_DRAFT_BLOCK_SIZE` are absent. |
-| `MLXCEL_ENABLE_MTP_B1` | truthy value | off | **Advanced.** Forces the singleton Gemma 4 MTP burst path for parity/debug testing. |
+| `MLXCEL_ENABLE_MTP_B1` | truthy value | off | **Advanced.** Enables the singleton (B=1) MTP burst path for `gemma4_unified` (and `gemma4`/`gemma4_vlm`) targets. Required today to observe the measured ~1.87× decode speedup on the 12B Unified + 4-bit-assistant pair (≈39→74 tok/s at temperature 0, byte-identical output); the scheduler guard that declines singleton MTP by default was calibrated on the 31B. Making B=1 MTP the default for the 12B class is tracked in #158. |
 | `MLXCEL_ENABLE_MTP_BATCH` | truthy value | off | **Advanced.** Forces the batched Gemma 4 MTP burst path for parity/debug testing. |
 | `MLXCEL_ENABLE_MTP_DEFERRED` | `1` | off | **Advanced.** Enables the deferred greedy verifier path for Gemma 4 MTP when sampling settings allow it. |
 

--- a/src/bin/speculative_bench.rs
+++ b/src/bin/speculative_bench.rs
@@ -23,28 +23,23 @@
 //! in `docs/model_tests.md::Speculative drafters` and can be
 //! captured today against real on-disk checkpoints.
 //!
-//! ## Scope deferred to
+//! ## MTP speculative path (active for the Gemma 4 Unified pair)
 //!
-//! Speculative-decoding numerators (`--kind mtp` / `--kind dflash`) require:
+//! The `--kind mtp` path is wired for the Gemma 4 Unified target
+//! (`gemma4_unified`) + `gemma4_unified_assistant` drafter (issue #154). It
+//! loads the target, binds the MTP assistant drafter, drives
+//! `MtpGenerator` through `Gemma4UnifiedMtpTargetAdapter`, and records the
+//! real decode tok/s + speedup vs the no-drafter baseline. Mean acceptance
+//! length per verification round is emitted by the round loop's tracing
+//! diagnostics (`MtpRoundDiagnostics`) during the run.
 //!
-//! 1. **A public way to construct the speculative target's per-layer cache**.
-//!    For Qwen 3.5 that is `Qwen3NextCache` (the `pub(crate) fn make_caches`
-//!    on `Qwen35Model`). For Gemma 4 that is the per-`SequenceId` cache slot
-//!    on `Gemma4Wrapper`. Both are currently binary-private.
-//! 2. **An `MtpTarget` impl on `Gemma4Wrapper`**. The hooks
-//!    (`forward_with_speculative_sinks`, `rollback_speculative_cache`) are
-//!    all public, but the trait adapter that wires them to
-//!    `prefill_and_seed` / `verify_forward` / `verify_finalize` is the work
-//!    explicitly deferred.
-//! 3. **A lazy-bind fix for `DFlashDrafter`**. The upstream
-//!    `z-lab/Qwen3.5-4B-DFlash` checkpoint omits `embed_tokens.weight`
-//!    because upstream Python binds to the target's `embed_tokens` at
-//!    `bind()` time, but the Rust loader currently requires the weight at
-//!    construction. See `tests/speculative_parity.rs` for the diagnostic.
+//! ## Scope still deferred
 //!
-//! All three are scoped into follow-up. Until they land, this binary
-//! prints a clear `[DEFERRED]` row for the speculative paths instead of
-//! silently emitting fake numbers.
+//! The DFlash numerator (`--kind dflash`) remains deferred: it needs a public
+//! way to construct the Qwen 3.5 `Qwen3NextCache` and the lazy-bind handling
+//! for the published `z-lab/Qwen3.5-4B-DFlash` checkpoint (which omits
+//! `embed_tokens.weight`). Until those land, the DFlash row prints a clear
+//! `[DEFERRED]` note instead of a fake number.
 //!
 //! ## Invocation
 //!
@@ -91,8 +86,9 @@ enum BenchKind {
     /// No-drafter baseline. The denominator of the speedup column. Always
     /// reachable today via `LanguageModel::forward`.
     None,
-    /// MTP speculative path (Gemma 4 assistant). DEFERRED: requires
-    /// `MtpTarget` impl on `Gemma4Wrapper` (follow-up).
+    /// MTP speculative path (Gemma 4 assistant). Active for the Gemma 4
+    /// Unified target + `gemma4_unified_assistant` drafter (issue #154):
+    /// records real decode tok/s + speedup vs the no-drafter baseline.
     Mtp,
     /// DFlash speculative path (Qwen 3.5 DFlash). DEFERRED: requires
     /// (a) public cache-construction API on `Qwen35Model` and (b) lazy-bind
@@ -251,6 +247,23 @@ const REACHABLE_PAIRINGS: &[Pairing] = &[
         kind: BenchKind::Mtp,
         block_size: Some(4),
     },
+    // Gemma 4 Unified 12B family — baseline + gemma4_unified_assistant drafter
+    // (issue #154). This is the measured pair: the MTP row records real decode
+    // tok/s + speedup vs the baseline row below.
+    Pairing {
+        name: "Gemma 4 Unified 12B (no drafter)",
+        target_subdir: "gemma-4-12b-it-4bit",
+        draft_subdir: None,
+        kind: BenchKind::None,
+        block_size: None,
+    },
+    Pairing {
+        name: "Gemma 4 Unified 12B + MTP assistant",
+        target_subdir: "gemma-4-12b-it-4bit",
+        draft_subdir: Some("gemma-4-12B-it-assistant-4bit"),
+        kind: BenchKind::Mtp,
+        block_size: Some(4),
+    },
 ];
 
 /// Resolve a model directory against the canonical `models/` layout,
@@ -354,6 +367,134 @@ fn run_baseline(target_dir: &Path, prompt: &str, max_tokens: usize) -> Result<(f
     Ok((stats.decode_time_ms, generated))
 }
 
+/// Run the MTP speculative path against a real on-disk Gemma 4 Unified
+/// target + `gemma4_unified_assistant` drafter (issue #154). Returns the
+/// decode wall-clock (ms) and the number of generated tokens so the caller
+/// can fill in a `Row`.
+///
+/// Mirrors [`run_baseline`]: same runtime init, warm-up, and streaming
+/// progress, but drives the MTP round loop through
+/// [`Gemma4UnifiedMtpTargetAdapter`] + `MtpGenerator` instead of the plain
+/// `CxxGenerator`. The drafter is bound after a compatibility check that
+/// rejects a mismatched target↔drafter pair (the same guard the server burst
+/// path runs).
+///
+/// `block_size` is the effective MTP block size (defaults to the drafter's
+/// configured 4 when the caller passes `None`).
+fn run_mtp(
+    target_dir: &Path,
+    draft_dir: &Path,
+    prompt: &str,
+    max_tokens: usize,
+    block_size: Option<u32>,
+) -> Result<(f64, usize)> {
+    use std::sync::atomic::AtomicBool;
+
+    use mlxcel::LoadedModel;
+    use mlxcel::models::gemma4_mtp_target::Gemma4UnifiedMtpTargetAdapter;
+    use mlxcel_core::drafter::{DrafterKind, load_drafter};
+    use mlxcel_core::generate::LanguageModel as _;
+    use mlxcel_core::sampling::LogprobsConfig;
+    use mlxcel_core::speculative::mtp::MtpGenerator;
+
+    let block_size = block_size.unwrap_or(4) as usize;
+    if block_size < 2 {
+        anyhow::bail!("MTP bench: block_size={block_size} < 2 produces no draft proposals");
+    }
+
+    eprintln!(
+        "[bench/mtp] Loading target from {:?} (block_size={block_size})",
+        target_dir
+    );
+
+    let _runtime = initialize_runtime();
+    mlxcel_core::synchronize_default();
+    mlxcel_core::clear_memory_cache();
+
+    let (model, tokenizer) = load_model(target_dir).context("load_model failed")?;
+
+    // The MTP bench targets the Gemma 4 Unified decode path. Accept the
+    // Gemma 4 family broadly so a future text-only/VLM pairing reuses this
+    // harness, but the issue's measured pair is the Unified 12B target.
+    let unified = match &model {
+        LoadedModel::Gemma4Unified(u) => u,
+        other => anyhow::bail!(
+            "MTP bench currently supports a Gemma 4 Unified target; \
+             load_model returned a different variant ({:?})",
+            std::mem::discriminant(other)
+        ),
+    };
+
+    let prompt_tokens = encode_prompt(&tokenizer, prompt);
+    eprintln!(
+        "[bench/mtp] Prompt {} tokens, max_new {}",
+        prompt_tokens.len(),
+        max_tokens
+    );
+
+    // Load + compat-check + bind the MTP assistant drafter. The compat guard
+    // rejects a mismatched backbone_hidden_size / vocab pairing before bind.
+    eprintln!("[bench/mtp] Loading drafter from {:?}", draft_dir);
+    let (mut drafter, kind) =
+        load_drafter(draft_dir, Some(DrafterKind::Mtp)).context("MTP drafter load failed")?;
+    anyhow::ensure!(
+        kind == DrafterKind::Mtp,
+        "drafter did not resolve to MTP (got {kind:?})"
+    );
+    let target_lm: &dyn mlxcel_core::generate::LanguageModel = unified;
+    drafter
+        .validate_target_compat(target_lm)
+        .context("MTP drafter incompatible with target")?;
+    drafter.bind(target_lm).context("MTP drafter bind failed")?;
+
+    let sampling = SamplingConfig::greedy();
+    let logprobs = LogprobsConfig::default();
+    let cancel = AtomicBool::new(false);
+
+    // Warm-up: a single short MTP burst pulls lazy MLX kernels onto the GPU
+    // before the timed run (same rationale as the baseline warm-up). A fresh
+    // drafter + generator is used so the timed run starts from a clean state.
+    {
+        eprintln!("[bench/mtp] Warm-up (4 tokens)...");
+        let (mut warm_drafter, _) =
+            load_drafter(draft_dir, Some(DrafterKind::Mtp)).context("warm-up drafter load")?;
+        warm_drafter.bind(target_lm).context("warm-up drafter bind")?;
+        let warm_seq = mlxcel_core::cache::SequenceId::from_raw(99_000);
+        let warm_adapter =
+            Gemma4UnifiedMtpTargetAdapter::new_with_block_size(unified, Some(warm_seq), block_size);
+        let mut warm_gen = MtpGenerator::new(warm_adapter, warm_drafter, block_size);
+        let _ = warm_gen.generate(&prompt_tokens, 4, &sampling, &[], &cancel, &logprobs);
+        unified.release_sequence_state_by_id(warm_seq);
+        mlxcel_core::synchronize_default();
+    }
+
+    eprintln!("[bench/mtp] Timed run starts");
+    let seq_id = mlxcel_core::cache::SequenceId::from_raw(99_001);
+    let adapter =
+        Gemma4UnifiedMtpTargetAdapter::new_with_block_size(unified, Some(seq_id), block_size);
+    let mut generator = MtpGenerator::new(adapter, drafter, block_size);
+    let started = Instant::now();
+    let (tokens, _logprobs, stats) =
+        generator.generate(&prompt_tokens, max_tokens, &sampling, &[], &cancel, &logprobs);
+    mlxcel_core::synchronize_default();
+    let elapsed = started.elapsed();
+    unified.release_sequence_state_by_id(seq_id);
+
+    let generated = tokens.len();
+    eprintln!(
+        "[bench/mtp] Done: prompt={} prefill_ms={:.1} decode_ms={:.1} \
+         generated={} tok/s={:.1} (wall {:.1}s) — mean acceptance length is \
+         logged by MtpRoundDiagnostics above",
+        stats.prompt_tokens,
+        stats.prefill_time_ms,
+        stats.decode_time_ms,
+        generated,
+        stats.decode_tok_per_sec,
+        elapsed.as_secs_f64(),
+    );
+    Ok((stats.decode_time_ms, generated))
+}
+
 /// Render a Markdown perf table from the collected rows. Output goes to
 /// stdout; the parent script captures this and pastes it into
 /// `docs/model_tests.md`.
@@ -383,10 +524,10 @@ fn print_markdown_table(rows: &[Row]) {
         );
     }
     println!();
-    println!("Note: speculative rows are deferred to follow-up — see");
-    println!("`docs/model_tests.md::Speculative drafters` for the");
-    println!("wiring details. Baseline rows are real perf numbers captured on");
-    println!("the host this binary ran on.");
+    println!("Note: MTP rows (Gemma 4 Unified + gemma4_unified_assistant) are real");
+    println!("decode numbers captured on the host this binary ran on; the speedup");
+    println!("column is MTP tok/s ÷ the matching no-drafter baseline. The DFlash");
+    println!("row remains deferred — see `docs/model_tests.md::Speculative drafters`.");
 }
 
 /// Fill in `speedup_vs_baseline` for every row against the matching
@@ -481,14 +622,54 @@ fn bench_one_pairing(p: &Pairing, prompt: &str, batch: usize, max_tokens: usize)
                 &format!("baseline run failed: {e}"),
             ),
         },
-        BenchKind::Mtp => Row::deferred(
-            p.name,
-            &target_path,
-            p.kind,
-            batch,
-            p.block_size,
-            "DEFERRED — needs MtpTarget for Gemma4Wrapper",
-        ),
+        BenchKind::Mtp => {
+            // The MTP path needs the drafter directory; report missing
+            // drafter as DEFERRED (already handled above, but a None
+            // draft_subdir is a config error worth a clear note).
+            let Some(draft_sub) = p.draft_subdir else {
+                return Row::deferred(
+                    p.name,
+                    &target_path,
+                    p.kind,
+                    batch,
+                    p.block_size,
+                    "MTP pairing missing draft_subdir",
+                );
+            };
+            let draft_path = resolve_model_dir(draft_sub);
+            match run_mtp(
+                &target_path,
+                &draft_path,
+                prompt,
+                max_tokens,
+                p.block_size,
+            ) {
+                Ok((decode_ms, generated)) => Row {
+                    pairing: p.name.to_string(),
+                    target_dir: target_path,
+                    kind: p.kind,
+                    batch,
+                    block_size: p.block_size,
+                    tok_per_sec: if decode_ms > 0.0 {
+                        Some(generated as f64 / (decode_ms / 1000.0))
+                    } else {
+                        None
+                    },
+                    decode_ms: Some(decode_ms),
+                    generated_tokens: Some(generated),
+                    speedup_vs_baseline: None,
+                    status_note: None,
+                },
+                Err(e) => Row::deferred(
+                    p.name,
+                    &target_path,
+                    p.kind,
+                    batch,
+                    p.block_size,
+                    &format!("MTP run failed: {e}"),
+                ),
+            }
+        }
         BenchKind::Dflash => Row::deferred(
             p.name,
             &target_path,
@@ -579,13 +760,55 @@ fn main() -> Result<()> {
                         &format!("baseline run failed: {e}"),
                     ),
                 },
-                BenchKind::Mtp | BenchKind::Dflash => Row::deferred(
+                BenchKind::Mtp => match args.draft.as_deref() {
+                    Some(draft) => match run_mtp(
+                        &target,
+                        draft,
+                        &args.prompt,
+                        args.max_tokens,
+                        args.block_size,
+                    ) {
+                        Ok((decode_ms, generated)) => Row {
+                            pairing: synthetic.name.to_string(),
+                            target_dir: target.clone(),
+                            kind: args.kind,
+                            batch: args.batch,
+                            block_size: args.block_size,
+                            tok_per_sec: if decode_ms > 0.0 {
+                                Some(generated as f64 / (decode_ms / 1000.0))
+                            } else {
+                                None
+                            },
+                            decode_ms: Some(decode_ms),
+                            generated_tokens: Some(generated),
+                            speedup_vs_baseline: None,
+                            status_note: None,
+                        },
+                        Err(e) => Row::deferred(
+                            synthetic.name,
+                            &target,
+                            args.kind,
+                            args.batch,
+                            args.block_size,
+                            &format!("MTP run failed: {e}"),
+                        ),
+                    },
+                    None => Row::deferred(
+                        synthetic.name,
+                        &target,
+                        args.kind,
+                        args.batch,
+                        args.block_size,
+                        "MTP run requires --draft <drafter-dir>",
+                    ),
+                },
+                BenchKind::Dflash => Row::deferred(
                     synthetic.name,
                     &target,
                     args.kind,
                     args.batch,
                     args.block_size,
-                    "DEFERRED — see module docs",
+                    "DEFERRED — DFlash loader + public Qwen3NextCache API",
                 ),
             }
         };

--- a/src/bin/speculative_bench.rs
+++ b/src/bin/speculative_bench.rs
@@ -458,7 +458,9 @@ fn run_mtp(
         eprintln!("[bench/mtp] Warm-up (4 tokens)...");
         let (mut warm_drafter, _) =
             load_drafter(draft_dir, Some(DrafterKind::Mtp)).context("warm-up drafter load")?;
-        warm_drafter.bind(target_lm).context("warm-up drafter bind")?;
+        warm_drafter
+            .bind(target_lm)
+            .context("warm-up drafter bind")?;
         let warm_seq = mlxcel_core::cache::SequenceId::from_raw(99_000);
         let warm_adapter =
             Gemma4UnifiedMtpTargetAdapter::new_with_block_size(unified, Some(warm_seq), block_size);
@@ -474,8 +476,14 @@ fn run_mtp(
         Gemma4UnifiedMtpTargetAdapter::new_with_block_size(unified, Some(seq_id), block_size);
     let mut generator = MtpGenerator::new(adapter, drafter, block_size);
     let started = Instant::now();
-    let (tokens, _logprobs, stats) =
-        generator.generate(&prompt_tokens, max_tokens, &sampling, &[], &cancel, &logprobs);
+    let (tokens, _logprobs, stats) = generator.generate(
+        &prompt_tokens,
+        max_tokens,
+        &sampling,
+        &[],
+        &cancel,
+        &logprobs,
+    );
     mlxcel_core::synchronize_default();
     let elapsed = started.elapsed();
     unified.release_sequence_state_by_id(seq_id);
@@ -637,13 +645,7 @@ fn bench_one_pairing(p: &Pairing, prompt: &str, batch: usize, max_tokens: usize)
                 );
             };
             let draft_path = resolve_model_dir(draft_sub);
-            match run_mtp(
-                &target_path,
-                &draft_path,
-                prompt,
-                max_tokens,
-                p.block_size,
-            ) {
+            match run_mtp(&target_path, &draft_path, prompt, max_tokens, p.block_size) {
                 Ok((decode_ms, generated)) => Row {
                     pairing: p.name.to_string(),
                     target_dir: target_path,

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/config.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/config.rs
@@ -344,6 +344,59 @@ mod tests {
         assert_eq!(rope.rope_type, "proportional");
     }
 
+    /// The Gemma 4 Unified 12B drafter ships `model_type:
+    /// gemma4_unified_assistant` with `text_config.model_type:
+    /// gemma4_unified_text` and `backbone_hidden_size: 3840`. The config must
+    /// parse and normalize exactly like the non-unified assistant spelling —
+    /// neither `model_type` is hard-rejected (both are free-form strings).
+    #[test]
+    fn deserialize_gemma4_unified_assistant_config_parses_and_normalizes() {
+        let json = r#"{
+            "model_type": "gemma4_unified_assistant",
+            "backbone_hidden_size": 3840,
+            "use_ordered_embeddings": false,
+            "num_centroids": 2048,
+            "centroid_intermediate_top_k": 32,
+            "tie_word_embeddings": true,
+            "block_size": 4,
+            "text_config": {
+                "model_type": "gemma4_unified_text",
+                "hidden_size": 1024,
+                "num_hidden_layers": 4,
+                "intermediate_size": 2048,
+                "num_attention_heads": 4,
+                "head_dim": 256,
+                "global_head_dim": 512,
+                "rms_norm_eps": 1.0e-6,
+                "vocab_size": 262144,
+                "num_key_value_heads": 1,
+                "rope_parameters": {
+                    "full_attention": {"rope_theta": 1000000.0, "partial_rotary_factor": 1.0, "rope_type": "proportional"},
+                    "sliding_attention": {"rope_theta": 10000.0, "partial_rotary_factor": 1.0, "rope_type": "default"}
+                },
+                "sliding_window": 1024,
+                "sliding_window_pattern": 4,
+                "max_position_embeddings": 131072,
+                "layer_types": ["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"]
+            }
+        }"#;
+        let cfg: Gemma4AssistantConfig = serde_json::from_str(json).expect("parse unified config");
+        let cfg = cfg.normalize().expect("normalize");
+
+        assert_eq!(cfg.model_type, "gemma4_unified_assistant");
+        assert_eq!(cfg.backbone_hidden_size, 3840);
+        let tc = cfg.text_config();
+        assert_eq!(tc.model_type, "gemma4_unified_text");
+        assert_eq!(tc.hidden_size, 1024);
+        assert_eq!(tc.num_hidden_layers, 4);
+        // num_kv_shared_layers was omitted (0) in JSON; normalize() promotes it
+        // to num_hidden_layers per upstream __post_init__.
+        assert_eq!(tc.num_kv_shared_layers, 4);
+        // The full-attention head uses global_head_dim when present.
+        assert_eq!(tc.head_dim_for_layer(0), 256);
+        assert_eq!(tc.head_dim_for_layer(3), 512);
+    }
+
     #[test]
     fn normalize_rejects_missing_text_config() {
         let cfg = Gemma4AssistantConfig {

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
@@ -827,6 +827,75 @@ impl Drafter for Gemma4AssistantDraftModel {
         Ok(())
     }
 
+    /// Reject a target whose hidden size or vocabulary does not match this
+    /// MTP assistant drafter, with a clear `BindFailed` message.
+    ///
+    /// Two invariants are checked:
+    ///
+    /// 1. **Hidden size.** The drafter's `backbone_hidden_size` (3840 for the
+    ///    Gemma 4 Unified 12B assistant) must equal the target's text hidden
+    ///    size. The drafter input is `[token_embed ‖ target_hidden]` at width
+    ///    `2 × backbone_hidden_size`, so a mismatch breaks `pre_projection`.
+    ///    The target hidden size is observed from the trailing dim of
+    ///    `target.embed_tokens(sentinel)` — the same probe `bind()` uses.
+    /// 2. **Vocabulary.** The drafter's configured `text_config.vocab_size`
+    ///    must match the target's logit width. This is a best-effort check:
+    ///    it runs only when the target exposes `embed_tokens_module()` (every
+    ///    real Gemma 4 target does), projecting a `[1, 1, hidden]` zero tensor
+    ///    through `as_linear` to read the target vocab dimension. Targets that
+    ///    only implement `embed_tokens` (unit-test mocks) skip the vocab check.
+    fn validate_target_compat(&self, target: &dyn LanguageModel) -> Result<(), DrafterError> {
+        let backbone = self.config.backbone_hidden_size as i32;
+
+        // (1) Hidden-size match via the embed_tokens probe.
+        let sentinel = ffi::from_slice_i32(&[0_i32], &[1, 1]);
+        let embedded =
+            target
+                .embed_tokens(&sentinel)
+                .ok_or(DrafterError::TargetMissingFeature {
+                    feature: "embed_tokens",
+                })?;
+        let embed_shape = ffi::array_shape(&embedded);
+        let target_hidden = embed_shape.last().copied().unwrap_or(0);
+        if target_hidden != backbone {
+            return Err(DrafterError::BindFailed {
+                reason: format!(
+                    "Gemma 4 MTP assistant drafter is incompatible with this target: \
+                     drafter backbone_hidden_size = {backbone} but the target's text \
+                     hidden size = {target_hidden}. The MTP assistant consumes the \
+                     target's last backbone hidden state, so these must be equal. Pass \
+                     an assistant drafter built for this target (the Gemma 4 Unified 12B \
+                     target pairs with the gemma4_unified_assistant drafter, \
+                     backbone_hidden_size = 3840)."
+                ),
+            });
+        }
+
+        // (2) Vocabulary match via the target's LM-head projection. Skipped
+        // when the target only exposes `embed_tokens` (mocks) — those still
+        // pass the hidden-size gate above.
+        if let Some(embed_module) = target.embed_tokens_module() {
+            let drafter_vocab = self.config.text_config().vocab_size as i32;
+            let zero_hidden = ffi::zeros(&[1, 1, target_hidden], crate::dtype::FLOAT32);
+            let logits = embed_module.as_linear(&zero_hidden);
+            let logit_shape = ffi::array_shape(&logits);
+            let target_vocab = logit_shape.last().copied().unwrap_or(0);
+            if target_vocab != drafter_vocab {
+                return Err(DrafterError::BindFailed {
+                    reason: format!(
+                        "Gemma 4 MTP assistant drafter vocabulary is incompatible with \
+                         this target: drafter text_config.vocab_size = {drafter_vocab} but \
+                         the target vocabulary = {target_vocab}. The drafter's centroid \
+                         token_ordering expands to its own vocab, which must match the \
+                         target so accepted draft token ids index the same vocabulary."
+                    ),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
     fn set_shared_kv(
         &mut self,
         shared_kv: SharedKv<'_>,

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
@@ -42,7 +42,7 @@ use crate::drafter::masks::{make_drafter_masks_with_valid_len, BatchScalar, Laye
 use crate::drafter::{Drafter, DrafterError, DrafterKind, SharedKv};
 use crate::ffi::{self, MlxArray};
 use crate::generate::{LanguageModel, SamplingConfig};
-use crate::layers::{KVCache, Linear, RMSNorm, UnifiedEmbedding};
+use crate::layers::{KVCache, Linear, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use crate::weights::WeightMap;
 use cxx::UniquePtr;
 use std::collections::HashMap;
@@ -340,8 +340,8 @@ fn str_to_layer_type(s: &str) -> Result<LayerType, DrafterError> {
 pub struct Gemma4AssistantDraftModel {
     config: Gemma4AssistantConfig,
     inner: DraftInner,
-    pre_projection: Linear,
-    post_projection: Linear,
+    pre_projection: UnifiedLinear,
+    post_projection: UnifiedLinear,
     /// Explicit `lm_head` weight when `tie_word_embeddings == false`. `None`
     /// means the LM head is one of the tied / centroid variants resolved by
     /// `bind()`.
@@ -461,10 +461,27 @@ impl Gemma4AssistantDraftModel {
         let inner = DraftInner::from_weights(&weights, &text_cfg, "model")
             .map_err(|e| DrafterError::WeightLoad { reason: e })?;
 
-        let pre_projection = Linear::from_weights(&weights, "pre_projection")
-            .map_err(|e| DrafterError::WeightLoad { reason: e })?;
-        let post_projection = Linear::from_weights(&weights, "post_projection")
-            .map_err(|e| DrafterError::WeightLoad { reason: e })?;
+        // Use the quantization-aware `UnifiedLinear` so 4-bit assistant
+        // drafters (e.g. `gemma-4-12B-it-assistant-4bit`) load their packed
+        // pre/post projection weights and run them through `quantized_matmul`.
+        // `UnifiedLinear::from_weights` auto-detects quantization via the
+        // `.scales` sister tensor and falls back to a plain `Linear` when it is
+        // absent, so this is behavior-preserving for bf16 drafters (e.g. the
+        // 31B assistant) while fixing the 4-bit `[matmul]` shape-mismatch crash.
+        let pre_projection = UnifiedLinear::from_weights(
+            &weights,
+            "pre_projection",
+            text_cfg.group_size(),
+            text_cfg.bits(),
+        )
+        .map_err(|e| DrafterError::WeightLoad { reason: e })?;
+        let post_projection = UnifiedLinear::from_weights(
+            &weights,
+            "post_projection",
+            text_cfg.group_size(),
+            text_cfg.bits(),
+        )
+        .map_err(|e| DrafterError::WeightLoad { reason: e })?;
 
         let lm_head_weight = if config.tie_word_embeddings {
             None

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/tests.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/tests.rs
@@ -453,6 +453,94 @@ fn bind_accepts_centroid_lm_head_via_masked_embedder() {
         .expect("bind must succeed when MaskedEmbedder is wired in");
 }
 
+// ── Target↔drafter compatibility guard (validate_target_compat) ─────────────
+
+#[test]
+fn validate_target_compat_accepts_matching_hidden_size() {
+    // make_test_config sets backbone_hidden_size = 32. A target whose
+    // embed_tokens reports hidden = 32 is a compatible pairing, so the
+    // pre-bind compat guard must accept it. The MockLanguageModel does not
+    // expose embed_tokens_module, so the vocab arm is skipped — the
+    // hidden-size gate is what we exercise here.
+    let cfg = make_test_config(2, true);
+    let weights = make_test_weights(&cfg);
+    let model = Gemma4AssistantDraftModel::from_weights(weights, cfg).expect("load");
+
+    let target = MockLanguageModel::new(16, 32);
+    model
+        .validate_target_compat(&target)
+        .expect("matching hidden size must pass the compat guard");
+}
+
+#[test]
+fn validate_target_compat_rejects_hidden_size_mismatch() {
+    // make_test_config sets backbone_hidden_size = 32. A target whose
+    // embed_tokens reports hidden = 64 is an incompatible pairing (the MTP
+    // drafter concatenates the target hidden into a 2×backbone input), so the
+    // pre-bind compat guard must reject it with a clear BindFailed error that
+    // names both sizes.
+    let cfg = make_test_config(2, true);
+    let weights = make_test_weights(&cfg);
+    let model = Gemma4AssistantDraftModel::from_weights(weights, cfg).expect("load");
+
+    let target = MockLanguageModel::new(16, 64);
+    let err = model
+        .validate_target_compat(&target)
+        .expect_err("mismatched hidden size must be rejected");
+    match err {
+        DrafterError::BindFailed { reason } => {
+            assert!(
+                reason.contains("32") && reason.contains("64"),
+                "error must name both the drafter backbone (32) and target hidden (64): {reason}"
+            );
+            assert!(
+                reason.contains("hidden size"),
+                "error must explain the hidden-size mismatch: {reason}"
+            );
+        }
+        other => panic!("expected BindFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_target_compat_rejects_target_without_embed_tokens() {
+    // A target that does not override embed_tokens cannot be probed for its
+    // hidden size; the compat guard surfaces TargetMissingFeature so the
+    // operator sees the same actionable message bind() would emit.
+    struct BareTarget;
+    impl LanguageModel for BareTarget {
+        fn forward(
+            &self,
+            _input_ids: &MlxArray,
+            _caches: &mut [crate::layers::KVCache],
+            _mask: Option<&MlxArray>,
+        ) -> UniquePtr<MlxArray> {
+            unreachable!()
+        }
+        fn make_caches(&self) -> Vec<crate::layers::KVCache> {
+            Vec::new()
+        }
+        fn num_layers(&self) -> usize {
+            0
+        }
+        fn eos_token_ids(&self) -> Vec<i32> {
+            Vec::new()
+        }
+    }
+
+    let cfg = make_test_config(2, true);
+    let weights = make_test_weights(&cfg);
+    let model = Gemma4AssistantDraftModel::from_weights(weights, cfg).expect("load");
+
+    let err = model
+        .validate_target_compat(&BareTarget)
+        .expect_err("target without embed_tokens must be rejected");
+    match err {
+        DrafterError::TargetMissingFeature { feature } => assert_eq!(feature, "embed_tokens"),
+        other => panic!("expected TargetMissingFeature, got {other:?}"),
+    }
+}
+
 /// Full E-series Centroid path: `bind` → `set_shared_kv` → `draft_block`.
 ///
 /// Asserts:

--- a/src/lib/mlxcel-core/src/drafter/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/mod.rs
@@ -914,10 +914,7 @@ mod tests {
         let map = drafter_kind_by_model_type();
         assert_eq!(map.get("gemma4_assistant"), Some(&DrafterKind::Mtp));
         // The Gemma 4 Unified assistant resolves to the same MTP round loop.
-        assert_eq!(
-            map.get("gemma4_unified_assistant"),
-            Some(&DrafterKind::Mtp)
-        );
+        assert_eq!(map.get("gemma4_unified_assistant"), Some(&DrafterKind::Mtp));
         // Both assistant spellings, nothing else: parity with upstream
         // `DRAFTER_KIND_BY_MODEL_TYPE = {"gemma4_assistant": "mtp",
         // "gemma4_unified_assistant": "mtp"}`.

--- a/src/lib/mlxcel-core/src/drafter/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/mod.rs
@@ -47,7 +47,10 @@
 //!
 //! ```python
 //! KNOWN_DRAFTER_KINDS = {"dflash", "mtp"}
-//! DRAFTER_KIND_BY_MODEL_TYPE = {"gemma4_assistant": "mtp"}
+//! DRAFTER_KIND_BY_MODEL_TYPE = {
+//!     "gemma4_assistant": "mtp",
+//!     "gemma4_unified_assistant": "mtp",
+//! }
 //! DEFAULT_DRAFTER_KIND = "dflash"
 //! ```
 //!
@@ -192,7 +195,8 @@ pub const DEFAULT_DRAFTER_KIND: DrafterKind = DrafterKind::Dflash;
 
 /// Static map from `config.json::model_type` to the required
 /// [`DrafterKind`]. Mirrors upstream
-/// `DRAFTER_KIND_BY_MODEL_TYPE = {"gemma4_assistant": "mtp"}`.
+/// `DRAFTER_KIND_BY_MODEL_TYPE = {"gemma4_assistant": "mtp",
+/// "gemma4_unified_assistant": "mtp"}`.
 ///
 /// Returned as `&'static HashMap` so call sites can perform `.get()`
 /// without rebuilding the map on every call. Built lazily on first
@@ -202,6 +206,11 @@ pub fn drafter_kind_by_model_type() -> &'static HashMap<&'static str, DrafterKin
     MAP.get_or_init(|| {
         let mut m = HashMap::new();
         m.insert("gemma4_assistant", DrafterKind::Mtp);
+        // The Gemma 4 Unified target ships its own MTP "assistant" drafter under
+        // the `gemma4_unified_assistant` model_type. It loads with the same
+        // `Gemma4AssistantDraftModel` class (identical centroid head + 4-layer
+        // shared-K/V stack) and therefore resolves to the same MTP round loop.
+        m.insert("gemma4_unified_assistant", DrafterKind::Mtp);
         m
     })
 }
@@ -527,6 +536,29 @@ pub trait Drafter {
     /// Returns `Err` if the target lacks a feature the drafter needs
     /// (e.g. no `embed_tokens` override for MTP).
     fn bind(&mut self, target: &dyn LanguageModel) -> Result<(), DrafterError>;
+
+    /// Validate that this drafter is compatible with the supplied target
+    /// **before** [`Self::bind`] is called.
+    ///
+    /// This is the dimension/vocabulary compatibility gate. The MTP
+    /// assistant drafter consumes the target's last backbone hidden state
+    /// concatenated with the target's token embeddings as a
+    /// `2 × backbone_hidden_size` input, so its `backbone_hidden_size` MUST
+    /// equal the target's text hidden size and its LM-head vocabulary MUST
+    /// match the target vocabulary. A mismatched pairing (e.g. a 12B Unified
+    /// target fed an assistant built for a different backbone) would either
+    /// crash deep inside the first `draft_block` matmul or — worse — produce
+    /// silently wrong drafts. Catching it here yields a clear, actionable
+    /// operator error at dispatch time instead.
+    ///
+    /// The default implementation is a no-op (`Ok(())`); shapes that do not
+    /// require a strict dimension match (DFlash, InternalMtp) keep the
+    /// default. Concrete MTP drafters override this to compare
+    /// `backbone_hidden_size` / vocab against the bound target.
+    #[allow(unused_variables)]
+    fn validate_target_compat(&self, target: &dyn LanguageModel) -> Result<(), DrafterError> {
+        Ok(())
+    }
 
     /// Inform the drafter of the target's freshly-captured shared K/V
     /// tensors at the start of a new draft block.
@@ -881,9 +913,15 @@ mod tests {
     fn drafter_kind_by_model_type_maps_gemma4_assistant_to_mtp() {
         let map = drafter_kind_by_model_type();
         assert_eq!(map.get("gemma4_assistant"), Some(&DrafterKind::Mtp));
-        // No other entries: parity with upstream
-        // `DRAFTER_KIND_BY_MODEL_TYPE = {"gemma4_assistant": "mtp"}`.
-        assert_eq!(map.len(), 1);
+        // The Gemma 4 Unified assistant resolves to the same MTP round loop.
+        assert_eq!(
+            map.get("gemma4_unified_assistant"),
+            Some(&DrafterKind::Mtp)
+        );
+        // Both assistant spellings, nothing else: parity with upstream
+        // `DRAFTER_KIND_BY_MODEL_TYPE = {"gemma4_assistant": "mtp",
+        // "gemma4_unified_assistant": "mtp"}`.
+        assert_eq!(map.len(), 2);
     }
 
     // ----- resolve_drafter_kind -------------------------------------------
@@ -892,6 +930,17 @@ mod tests {
     fn auto_detect_gemma4_assistant_resolves_to_mtp() {
         let dir = tempdir().unwrap();
         write_drafter_config(&dir, Some("gemma4_assistant"));
+        let resolved = resolve_drafter_kind(dir.path(), None).unwrap();
+        assert_eq!(resolved, DrafterKind::Mtp);
+    }
+
+    #[test]
+    fn auto_detect_gemma4_unified_assistant_resolves_to_mtp() {
+        // The Gemma 4 Unified 12B drafter ships model_type
+        // `gemma4_unified_assistant`; it must auto-detect to the MTP round
+        // loop exactly like the non-unified `gemma4_assistant`.
+        let dir = tempdir().unwrap();
+        write_drafter_config(&dir, Some("gemma4_unified_assistant"));
         let resolved = resolve_drafter_kind(dir.path(), None).unwrap();
         assert_eq!(resolved, DrafterKind::Mtp);
     }

--- a/src/models/gemma4_mtp_target.rs
+++ b/src/models/gemma4_mtp_target.rs
@@ -734,6 +734,91 @@ impl<'a> MtpTarget for Gemma4VLMtpTargetAdapter<'a> {
     }
 }
 
+/// MTP target adapter for the Gemma 4 Unified wrapper.
+///
+/// Reuses [`Gemma4MtpTargetAdapter`] internally by delegating to the Unified
+/// wrapper's inner text model. Identical rationale to
+/// [`Gemma4VLMtpTargetAdapter`]: any multimodal (image / audio) features are
+/// fully prefilled before the MTP round loop begins, so the round loop only
+/// interacts with the text backbone — draft and verify operate on text tokens.
+/// The encoder-free vision embedder and per-layer-inputs state of
+/// [`crate::vision::Gemma4UnifiedModel`] hold no speculative state.
+pub struct Gemma4UnifiedMtpTargetAdapter<'a> {
+    inner: Gemma4MtpTargetAdapter<'a>,
+}
+
+impl<'a> Gemma4UnifiedMtpTargetAdapter<'a> {
+    /// Construct an adapter that routes every trait call through the inner
+    /// text model's per-sequence cache slot at `seq_id`.
+    pub fn new(unified: &'a crate::vision::Gemma4UnifiedModel, seq_id: Option<SequenceId>) -> Self {
+        Self::new_with_block_size(unified, seq_id, 4)
+    }
+
+    /// Construct an adapter with the effective MTP block size requested by the
+    /// dispatch path.
+    pub fn new_with_block_size(
+        unified: &'a crate::vision::Gemma4UnifiedModel,
+        seq_id: Option<SequenceId>,
+        block_size: usize,
+    ) -> Self {
+        Self {
+            inner: Gemma4MtpTargetAdapter::new_with_block_size(
+                &unified.text_model,
+                seq_id,
+                block_size,
+            ),
+        }
+    }
+}
+
+impl<'a> MtpTarget for Gemma4UnifiedMtpTargetAdapter<'a> {
+    fn prefill_and_seed(
+        &self,
+        prompt_tokens: &[i32],
+        sampler: &SamplingConfig,
+        token_history: &[i32],
+        logprobs_config: &mlxcel_core::sampling::LogprobsConfig,
+    ) -> (
+        i32,
+        MtpVerifyOutput,
+        Option<mlxcel_core::sampling::TokenLogprobData>,
+    ) {
+        self.inner
+            .prefill_and_seed(prompt_tokens, sampler, token_history, logprobs_config)
+    }
+
+    fn embed_token(&self, token_id: i32) -> UniquePtr<MlxArray> {
+        self.inner.embed_token(token_id)
+    }
+
+    fn verify_forward(
+        &self,
+        verify_input: &[i32],
+        sampler: &SamplingConfig,
+        logprobs_config: &mlxcel_core::sampling::LogprobsConfig,
+    ) -> VerifyForwardOutput {
+        self.inner
+            .verify_forward(verify_input, sampler, logprobs_config)
+    }
+
+    fn verify_finalize(
+        &self,
+        accepted: usize,
+        block_size: usize,
+        captured: VerifyCaptured,
+    ) -> MtpVerifyOutput {
+        self.inner.verify_finalize(accepted, block_size, captured)
+    }
+
+    fn num_layers(&self) -> usize {
+        self.inner.num_layers()
+    }
+
+    fn eos_token_ids(&self) -> Vec<i32> {
+        self.inner.eos_token_ids()
+    }
+}
+
 // ===========================================================================
 // Batched MTP target adapter (B > 1)
 // ===========================================================================
@@ -1387,6 +1472,125 @@ impl<'a> MtpTarget for Gemma4VLMtpBatchedTargetAdapter<'a> {
     // the `*_batched` methods. `token_history` and
     // `logprobs_config` are forwarded verbatim so the
     // signature matches the trait even though the inner panics.
+    fn prefill_and_seed(
+        &self,
+        prompt_tokens: &[i32],
+        sampler: &SamplingConfig,
+        token_history: &[i32],
+        logprobs_config: &mlxcel_core::sampling::LogprobsConfig,
+    ) -> (
+        i32,
+        MtpVerifyOutput,
+        Option<mlxcel_core::sampling::TokenLogprobData>,
+    ) {
+        self.inner
+            .prefill_and_seed(prompt_tokens, sampler, token_history, logprobs_config)
+    }
+
+    fn embed_token(&self, token_id: i32) -> UniquePtr<MlxArray> {
+        self.inner.embed_token(token_id)
+    }
+
+    fn verify_forward(
+        &self,
+        verify_input: &[i32],
+        sampler: &SamplingConfig,
+        logprobs_config: &mlxcel_core::sampling::LogprobsConfig,
+    ) -> VerifyForwardOutput {
+        self.inner
+            .verify_forward(verify_input, sampler, logprobs_config)
+    }
+
+    fn verify_finalize(
+        &self,
+        accepted: usize,
+        block_size: usize,
+        captured: VerifyCaptured,
+    ) -> MtpVerifyOutput {
+        self.inner.verify_finalize(accepted, block_size, captured)
+    }
+
+    fn num_layers(&self) -> usize {
+        self.inner.num_layers()
+    }
+
+    fn eos_token_ids(&self) -> Vec<i32> {
+        self.inner.eos_token_ids()
+    }
+
+    fn prefill_and_seed_batched(
+        &self,
+        prompt_tokens_per_row: &[Vec<i32>],
+        sampler: &SamplingConfig,
+    ) -> Result<(Vec<i32>, MtpBatchedVerifyOutput), DrafterError> {
+        self.inner
+            .prefill_and_seed_batched(prompt_tokens_per_row, sampler)
+    }
+
+    fn verify_forward_batched(
+        &self,
+        verify_input_per_row: &[Vec<i32>],
+        sampler: &SamplingConfig,
+    ) -> Result<MtpBatchedVerifyForwardOutput, DrafterError> {
+        self.inner
+            .verify_forward_batched(verify_input_per_row, sampler)
+    }
+
+    fn verify_finalize_batched(
+        &self,
+        accepted_per_row: &[usize],
+        block_size: usize,
+        captured: VerifyCaptured,
+    ) -> Result<MtpBatchedVerifyOutput, DrafterError> {
+        self.inner
+            .verify_finalize_batched(accepted_per_row, block_size, captured)
+    }
+}
+
+/// Batched MTP target adapter for the Gemma 4 Unified wrapper.
+///
+/// Reuses [`Gemma4MtpBatchedTargetAdapter`] internally by delegating to the
+/// Unified wrapper's inner text model. Same rationale as the B = 1
+/// [`Gemma4UnifiedMtpTargetAdapter`]: any multimodal features are fully
+/// prefilled before the MTP round loop begins, so the round loop only
+/// interacts with the text backbone.
+pub struct Gemma4UnifiedMtpBatchedTargetAdapter<'a> {
+    inner: Gemma4MtpBatchedTargetAdapter<'a>,
+}
+
+impl<'a> Gemma4UnifiedMtpBatchedTargetAdapter<'a> {
+    /// Construct a batched adapter routing every trait call through the inner
+    /// text model's own `[B, ...]` cache.
+    pub fn new(unified: &'a crate::vision::Gemma4UnifiedModel, batch_size: usize) -> Self {
+        Self::new_with_block_size(unified, batch_size, 4)
+    }
+
+    /// Construct a batched Unified MTP adapter with the effective requested
+    /// block size.
+    pub fn new_with_block_size(
+        unified: &'a crate::vision::Gemma4UnifiedModel,
+        batch_size: usize,
+        block_size: usize,
+    ) -> Self {
+        Self {
+            inner: Gemma4MtpBatchedTargetAdapter::new_with_block_size(
+                &unified.text_model,
+                batch_size,
+                block_size,
+            ),
+        }
+    }
+
+    /// Batch size accessor (test / diagnostic).
+    pub fn batch_size(&self) -> usize {
+        self.inner.batch_size()
+    }
+}
+
+impl<'a> MtpTarget for Gemma4UnifiedMtpBatchedTargetAdapter<'a> {
+    // The B = 1 surface forwards to the inner batched adapter, whose B = 1
+    // stubs panic — the batched Unified adapter is only ever driven through
+    // the `*_batched` methods.
     fn prefill_and_seed(
         &self,
         prompt_tokens: &[i32],

--- a/src/models/gemma4_mtp_target_tests.rs
+++ b/src/models/gemma4_mtp_target_tests.rs
@@ -307,3 +307,44 @@ fn batched_capture_layer_ids_is_last_layer_only() {
         "batched MTP adapter must capture the last layer only (None)"
     );
 }
+
+// ===========================================================================
+// Gemma 4 Unified MTP adapter — structural / trait-surface pins (issue #154)
+//
+// The Unified adapters are pure delegators to `Gemma4MtpTargetAdapter` /
+// `Gemma4MtpBatchedTargetAdapter` over `unified.text_model`, mirroring the VL
+// adapters. Constructing a real `Gemma4UnifiedModel` requires the encoder-free
+// vision embedder + multimodal embedder + processor, which are out of scope
+// for a weights-free unit test, so the full forward-driving greedy-parity
+// round-trip ships in `tests/speculative_parity.rs`
+// (`greedy_parity_mtp_gemma4_unified_12b`, `#[ignore]`). These pins guarantee
+// the delegation types are wired correctly at compile time.
+// ===========================================================================
+
+/// The Unified B = 1 adapter must implement [`MtpTarget`] and be usable as a
+/// trait object — the burst dispatch drives it via a generic `T: MtpTarget`,
+/// and the type must satisfy that bound for any borrowed `&Gemma4UnifiedModel`.
+#[test]
+fn unified_b1_adapter_implements_mtp_target() {
+    // Type-level assertion: a no-op function that only type-checks if the
+    // adapter implements `MtpTarget` for an arbitrary borrow lifetime. Never
+    // called — it exists purely to fail compilation on a broken impl.
+    #[allow(dead_code)]
+    fn assert_mtp_target<'a, T: MtpTarget>() {}
+    let _ = assert_mtp_target::<Gemma4UnifiedMtpTargetAdapter<'_>>;
+}
+
+/// The Unified batched adapter must implement [`MtpTarget`] (including the
+/// `*_batched` surface forwarded to the inner batched adapter) and expose the
+/// `batch_size` accessor used by diagnostics.
+#[test]
+fn unified_batched_adapter_implements_mtp_target() {
+    #[allow(dead_code)]
+    fn assert_mtp_target<'a, T: MtpTarget>() {}
+    let _ = assert_mtp_target::<Gemma4UnifiedMtpBatchedTargetAdapter<'_>>;
+    // Pin the accessor name/signature the dispatch + tests rely on.
+    #[allow(dead_code)]
+    fn assert_batch_size_accessor(a: &Gemma4UnifiedMtpBatchedTargetAdapter<'_>) -> usize {
+        a.batch_size()
+    }
+}

--- a/src/models/gemma4_mtp_target_tests.rs
+++ b/src/models/gemma4_mtp_target_tests.rs
@@ -330,7 +330,7 @@ fn unified_b1_adapter_implements_mtp_target() {
     // adapter implements `MtpTarget` for an arbitrary borrow lifetime. Never
     // called — it exists purely to fail compilation on a broken impl.
     #[allow(dead_code)]
-    fn assert_mtp_target<'a, T: MtpTarget>() {}
+    fn assert_mtp_target<T: MtpTarget>() {}
     let _ = assert_mtp_target::<Gemma4UnifiedMtpTargetAdapter<'_>>;
 }
 
@@ -340,7 +340,7 @@ fn unified_b1_adapter_implements_mtp_target() {
 #[test]
 fn unified_batched_adapter_implements_mtp_target() {
     #[allow(dead_code)]
-    fn assert_mtp_target<'a, T: MtpTarget>() {}
+    fn assert_mtp_target<T: MtpTarget>() {}
     let _ = assert_mtp_target::<Gemma4UnifiedMtpBatchedTargetAdapter<'_>>;
     // Pin the accessor name/signature the dispatch + tests rely on.
     #[allow(dead_code)]

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1857,12 +1857,22 @@ impl BatchScheduler {
                 crate::server::SpeculativeDispatch::Mtp { .. }
             )
             && !super::speculative_burst::mtp_b1_burst_enabled()
+            && self.model.supports_batching()
         {
+            // Decline the singleton (B=1) MTP burst only for batch-capable
+            // targets (e.g. Gemma 4 31B text): there B=1 MTP measured slower
+            // than classic decode, and the batched (B>1) MTP window is the
+            // intended speedup path. Targets that cannot batch (e.g.
+            // `gemma4_unified`, `supports_batching() == false`) have no batched
+            // alternative, so they fall through and run B=1 MTP by default —
+            // real-model measurement shows ~1.87x decode speedup there with
+            // byte-identical output. `MLXCEL_ENABLE_MTP_B1=1` still force-enables
+            // B=1 MTP on batch-capable targets for parity/debug.
             let seq = window.into_iter().next().expect("singleton window");
             tracing::info!(
                 "MTP speculative burst declined for seq {}: singleton B=1 window is \
-                 slower than classic Gemma 4 decode on real 31B measurements; set \
-                 MLXCEL_ENABLE_MTP_B1=1 to force the experimental singleton MTP path",
+                 slower than classic decode on this batch-capable target; the batched \
+                 MTP window is preferred (set MLXCEL_ENABLE_MTP_B1=1 to force B=1 MTP)",
                 seq.seq_id,
             );
             return Some(seq);

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -46,12 +46,14 @@
 //!
 //! This module implements the B = 1 burst for:
 //!
-//! - **MTP / Gemma 4** — [`crate::LoadedModel::Gemma4`] and
-//!   [`crate::LoadedModel::Gemma4VLM`] (text-only requests; vision
+//! - **MTP / Gemma 4** — [`crate::LoadedModel::Gemma4`],
+//!   [`crate::LoadedModel::Gemma4VLM`], and
+//!   [`crate::LoadedModel::Gemma4Unified`] (text-only requests; multimodal
 //!   inputs are rejected with a clear error). Drives
 //!   [`mlxcel_core::speculative::mtp::MtpGenerator`] through
 //!   [`crate::models::gemma4_mtp_target::Gemma4MtpTargetAdapter`] /
-//!   [`crate::models::gemma4_mtp_target::Gemma4VLMtpTargetAdapter`].
+//!   [`crate::models::gemma4_mtp_target::Gemma4VLMtpTargetAdapter`] /
+//!   [`crate::models::gemma4_mtp_target::Gemma4UnifiedMtpTargetAdapter`].
 //! - **DFlash / Qwen 3.5** — [`crate::LoadedModel::Qwen35`],
 //!   [`crate::LoadedModel::Qwen35Moe`], and their Qwen 3.5 VLM-wrapped
 //!   variants for text-only requests. True multimodal requests still
@@ -152,7 +154,8 @@ use mlxcel_core::speculative::mtp::{MtpBatchedGenerator, MtpGenerator};
 
 use crate::LoadedModel;
 use crate::models::gemma4_mtp_target::{
-    Gemma4MtpBatchedTargetAdapter, Gemma4MtpTargetAdapter, Gemma4VLMtpBatchedTargetAdapter,
+    Gemma4MtpBatchedTargetAdapter, Gemma4MtpTargetAdapter, Gemma4UnifiedMtpBatchedTargetAdapter,
+    Gemma4VLMtpBatchedTargetAdapter,
 };
 use crate::server::model_provider::GenerateEvent;
 
@@ -751,10 +754,11 @@ fn run_mtp_burst(
     let target_lm: &dyn LanguageModel = match ctx.model {
         LoadedModel::Gemma4(wrapper) => wrapper as &dyn LanguageModel,
         LoadedModel::Gemma4VLM(vlm) => vlm as &dyn LanguageModel,
+        LoadedModel::Gemma4Unified(unified) => unified as &dyn LanguageModel,
         _ => {
             tracing::warn!(
                 "MTP speculative dispatch declined: target is {:?}, expected \
-                 Gemma 4 (text or VLM); falling back to classic decode",
+                 Gemma 4 (text, VLM, or Unified); falling back to classic decode",
                 model_variant_label(ctx.model),
             );
             return Err(BurstOutcome::DeclineToClassic);
@@ -794,6 +798,17 @@ fn run_mtp_burst(
     // the handle keeps the slot in a clean state for the (rare) case
     // where the operator hot-swaps the drafter checkpoint between
     // requests.
+    // Compatibility gate BEFORE binding: reject a target↔drafter pairing whose
+    // hidden size / vocabulary do not match (e.g. a 12B Unified target fed an
+    // assistant built for a different backbone). The default trait impl is a
+    // no-op, so DFlash/InternalMtp are unaffected; the Gemma 4 assistant
+    // overrides it to compare backbone_hidden_size (3840) against the target's
+    // text hidden size and vocab. Surfaced as a clear burst error.
+    if let Err(e) = owned_drafter.validate_target_compat(target_lm) {
+        return Err(BurstOutcome::Error(format!(
+            "MTP drafter incompatible with target: {e}"
+        )));
+    }
     if let Err(e) = owned_drafter.bind(target_lm) {
         return Err(BurstOutcome::Error(format!("MTP drafter bind failed: {e}")));
     }
@@ -843,6 +858,25 @@ fn run_mtp_burst(
             let adapter =
                 crate::models::gemma4_mtp_target::Gemma4VLMtpTargetAdapter::new_with_block_size(
                     vlm,
+                    Some(seq.seq_id),
+                    block_size,
+                );
+            drive_mtp_generator(
+                adapter,
+                owned_drafter,
+                &prompt,
+                max_tokens,
+                &sampling,
+                &token_history,
+                block_size,
+                cancel,
+                &logprobs_config,
+            )
+        }
+        LoadedModel::Gemma4Unified(unified) => {
+            let adapter =
+                crate::models::gemma4_mtp_target::Gemma4UnifiedMtpTargetAdapter::new_with_block_size(
+                    unified,
                     Some(seq.seq_id),
                     block_size,
                 );
@@ -1799,10 +1833,11 @@ fn run_mtp_burst_batched(
     let target_lm: &dyn LanguageModel = match ctx.model {
         LoadedModel::Gemma4(wrapper) => wrapper as &dyn LanguageModel,
         LoadedModel::Gemma4VLM(vlm) => vlm as &dyn LanguageModel,
+        LoadedModel::Gemma4Unified(unified) => unified as &dyn LanguageModel,
         _ => {
             tracing::warn!(
                 "MTP batched speculative dispatch declined: target is {:?}, expected \
-                 Gemma 4 (text or VLM); falling back to classic decode",
+                 Gemma 4 (text, VLM, or Unified); falling back to classic decode",
                 model_variant_label(ctx.model),
             );
             return Err(BurstOutcome::DeclineToClassic);
@@ -1821,6 +1856,12 @@ fn run_mtp_burst_batched(
     // as `run_mtp_burst`. `MtpBatchedGenerator::run_batched` does NOT
     // bind internally; without this the first `draft_block_batched`
     // returns `BindNotCalled`.
+    // Compatibility gate before binding — same contract as `run_mtp_burst`.
+    if let Err(e) = owned_drafter.validate_target_compat(target_lm) {
+        return Err(BurstOutcome::Error(format!(
+            "MTP batched drafter incompatible with target: {e}"
+        )));
+    }
     if let Err(e) = owned_drafter.bind(target_lm) {
         return Err(BurstOutcome::Error(format!(
             "MTP batched drafter bind failed: {e}"
@@ -1853,6 +1894,19 @@ fn run_mtp_burst_batched(
         LoadedModel::Gemma4VLM(vlm) => {
             let adapter =
                 Gemma4VLMtpBatchedTargetAdapter::new_with_block_size(vlm, batch_size, block_size);
+            drive_mtp_batched_generator(
+                adapter,
+                owned_drafter,
+                &prompts,
+                max_tokens,
+                &sampling,
+                block_size,
+            )?
+        }
+        LoadedModel::Gemma4Unified(unified) => {
+            let adapter = Gemma4UnifiedMtpBatchedTargetAdapter::new_with_block_size(
+                unified, batch_size, block_size,
+            );
             drive_mtp_batched_generator(
                 adapter,
                 owned_drafter,
@@ -2214,6 +2268,7 @@ fn model_variant_label(model: &LoadedModel) -> &'static str {
     match model {
         LoadedModel::Gemma4(_) => "Gemma4",
         LoadedModel::Gemma4VLM(_) => "Gemma4VLM",
+        LoadedModel::Gemma4Unified(_) => "Gemma4Unified",
         LoadedModel::Qwen35(_) => "Qwen35",
         LoadedModel::Qwen35VLM(_) => "Qwen35VLM",
         LoadedModel::Qwen35Moe(_) => "Qwen35Moe",

--- a/src/vision/gemma4_unified.rs
+++ b/src/vision/gemma4_unified.rs
@@ -294,6 +294,97 @@ impl Gemma4UnifiedModel {
         }
     }
 
+    // -- Gemma 4 MTP speculative-decoding hooks ------------------------------
+    //
+    // Pass-through methods that give the MTP drafter / generator the same
+    // opt-in sink + rollback surface on the Unified-wrapped Gemma 4 path as on
+    // the text-only and VLM paths. Mirrors `src/vision/gemma4_vl.rs` exactly:
+    // the (optionally multimodal) prefill flows through the unified forward
+    // that merges vision/audio features and seeds the cache + first hidden;
+    // speculative decode then kicks in only AFTER the prefill tail, at which
+    // point the rotating + dense KV caches owned by the inner `Gemma4Wrapper`
+    // are the sole state the MTP loop touches. The encoder-free vision
+    // embedder and `per_layer_inputs_state` do not participate.
+
+    /// Sink-aware forward for the Unified-wrapped Gemma 4 text model.
+    ///
+    /// Delegates to [`crate::models::Gemma4Wrapper::forward_with_speculative_sinks`]
+    /// on the inner text model. Like the VLM path, the caller routes the
+    /// (optionally multimodal) prefill through the existing
+    /// [`LanguageModel::forward_with_embeddings_and_sequence_id`] path FIRST;
+    /// subsequent speculative decode steps consume `input_ids` only and pass
+    /// `input_embeddings = None`, so no multimodal merge occurs during decode.
+    pub fn forward_with_speculative_sinks(
+        &self,
+        input_ids: &MlxArray,
+        input_embeddings: Option<&MlxArray>,
+        per_layer_inputs: Option<&MlxArray>,
+        mask: Option<&MlxArray>,
+        seq_id: Option<SequenceId>,
+        capture_layer_ids: Option<&[usize]>,
+        sinks: Option<&mut crate::models::Gemma4SpeculativeSinks>,
+    ) -> UniquePtr<MlxArray> {
+        self.text_model.forward_with_speculative_sinks(
+            input_ids,
+            input_embeddings,
+            per_layer_inputs,
+            mask,
+            seq_id,
+            capture_layer_ids,
+            sinks,
+        )
+    }
+
+    /// Sink-aware forward against a **caller-owned** `[B, ...]` cache vector
+    /// (batched MTP dispatch).
+    ///
+    /// Pure pass-through to
+    /// [`crate::models::Gemma4Wrapper::forward_with_speculative_sinks_explicit_cache`].
+    /// The Unified wrapper holds no batched speculative state of its own — the
+    /// batched MTP target adapter owns the `[B, ...]` cache and the inner text
+    /// model advances all rows through one forward.
+    pub fn forward_with_speculative_sinks_explicit_cache(
+        &self,
+        input_ids: &MlxArray,
+        input_embeddings: Option<&MlxArray>,
+        per_layer_inputs: Option<&MlxArray>,
+        mask: Option<&MlxArray>,
+        caches: &mut [crate::models::gemma4::Cache],
+        capture_layer_ids: Option<&[usize]>,
+        sinks: Option<&mut crate::models::Gemma4SpeculativeSinks>,
+    ) -> UniquePtr<MlxArray> {
+        self.text_model.forward_with_speculative_sinks_explicit_cache(
+            input_ids,
+            input_embeddings,
+            per_layer_inputs,
+            mask,
+            caches,
+            capture_layer_ids,
+            sinks,
+        )
+    }
+
+    /// Rewind the inner text model's per-sequence KV caches after a Gemma 4
+    /// MTP verify pass. Pure pass-through to
+    /// [`crate::models::Gemma4Wrapper::rollback_speculative_cache`] — the
+    /// Unified wrapper holds no additional speculative state to undo.
+    pub fn rollback_speculative_cache(
+        &self,
+        seq_id: Option<SequenceId>,
+        accepted: &[i32],
+        block_size: i32,
+    ) -> Result<(), String> {
+        self.text_model
+            .rollback_speculative_cache(seq_id, accepted, block_size)
+    }
+
+    /// Normalize a pre-norm hidden state with the Gemma 4 final norm before it
+    /// is handed to the MTP assistant drafter. Pure pass-through to
+    /// [`crate::models::Gemma4Wrapper::speculative_draft_hidden`].
+    pub fn speculative_draft_hidden(&self, hidden: &MlxArray) -> UniquePtr<MlxArray> {
+        self.text_model.speculative_draft_hidden(hidden)
+    }
+
     /// Build the per-position vision block-id tensor from `input_ids` for the
     /// bidirectional overlay during the embeddings-driven prefill forward, or
     /// `None` when the overlay is disabled.

--- a/src/vision/gemma4_unified.rs
+++ b/src/vision/gemma4_unified.rs
@@ -353,15 +353,16 @@ impl Gemma4UnifiedModel {
         capture_layer_ids: Option<&[usize]>,
         sinks: Option<&mut crate::models::Gemma4SpeculativeSinks>,
     ) -> UniquePtr<MlxArray> {
-        self.text_model.forward_with_speculative_sinks_explicit_cache(
-            input_ids,
-            input_embeddings,
-            per_layer_inputs,
-            mask,
-            caches,
-            capture_layer_ids,
-            sinks,
-        )
+        self.text_model
+            .forward_with_speculative_sinks_explicit_cache(
+                input_ids,
+                input_embeddings,
+                per_layer_inputs,
+                mask,
+                caches,
+                capture_layer_ids,
+                sinks,
+            )
     }
 
     /// Rewind the inner text model's per-sequence KV caches after a Gemma 4

--- a/tests/speculative_parity.rs
+++ b/tests/speculative_parity.rs
@@ -390,7 +390,19 @@ const REACHABLE_PAIRINGS: &[Pairing] = &[
         kind: "mtp",
         block_size: 4,
     },
+    Pairing {
+        name: "Gemma 4 Unified 12B + MTP assistant (b=4)",
+        target_dir: "gemma-4-12b-it-4bit",
+        draft_dir: "gemma-4-12B-it-assistant-4bit",
+        kind: "mtp",
+        block_size: 4,
+    },
 ];
+
+/// Index of the Gemma 4 Unified 12B + MTP assistant pairing in
+/// [`REACHABLE_PAIRINGS`]. Kept as a named constant so the unified parity test
+/// stays correct if the pairing list is reordered.
+const UNIFIED_12B_MTP_PAIRING: usize = 2;
 
 /// Returns the target / drafter paths and whether both are present on disk.
 fn pairing_present(pairing: &Pairing) -> (std::path::PathBuf, std::path::PathBuf, bool) {
@@ -665,6 +677,96 @@ async fn greedy_parity_mtp_gemma4_31b() {
         // Drop the in-process target + drafter and clear the MLX memory
         // cache before phase 2 so the spawned servers do not contend with
         // these weights for GPU memory.
+        drop(drafter);
+        drop(loaded_target);
+        mlxcel_core::synchronize_default();
+        mlxcel_core::clear_memory_cache();
+    }
+
+    // ---- Phase 2: end-to-end byte-equality (subprocess) ----
+    assert_server_byte_equality(pairing, &target_path, &draft_path).await;
+}
+
+/// Greedy parity for the Gemma 4 Unified 12B + MTP assistant pairing
+/// (issue #154).
+///
+/// **Status:** end-to-end byte-equality on real models.
+///
+/// Identical two-phase structure to [`greedy_parity_mtp_gemma4_31b`], but the
+/// target is the `gemma4_unified` 12B checkpoint (loads as
+/// [`mlxcel::LoadedModel::Gemma4Unified`]) and the drafter is the
+/// `gemma4_unified_assistant` 12B assistant (`backbone_hidden_size = 3840`,
+/// centroid LM head). The MTP burst dispatch routes `Gemma4Unified` through
+/// `Gemma4UnifiedMtpTargetAdapter` → the inner `Gemma4MtpTargetAdapter` over
+/// `unified.text_model`, exactly as the VLM path routes through the VL adapter.
+///
+/// 1. **Structural phase** (in-process): loads the target, asserts it is the
+///    `Gemma4Unified` variant, resolves the drafter kind to `DrafterKind::Mtp`
+///    (auto-detected from `model_type: "gemma4_unified_assistant"`), and loads
+///    the assistant drafter from its checkpoint.
+/// 2. **Byte-equality phase** (subprocess): spawns `mlxcel-server` with
+///    `--model-draft --draft-kind mtp --draft-block-size 4` and again without
+///    any `--draft-*` flag, submits the same fixed prompt at `temperature = 0`,
+///    and asserts the two responses are byte-identical (MTP speculative decode
+///    is exactness-preserving).
+///
+/// `#[ignore]`-gated as real-model heavy: loads the Gemma 4 Unified 12B target
+/// + assistant drafter and spawns `mlxcel-server` subprocesses. Runs in the CI
+/// hardware lane / the orchestrator's real-model measurement gate.
+#[tokio::test]
+#[ignore = "real-model heavy (loads Gemma-4-Unified-12B target + drafter, spawns mlxcel-server); runs in CI hardware lane only"]
+async fn greedy_parity_mtp_gemma4_unified_12b() {
+    use mlxcel::{LoadedModel, initialize_runtime, load_model};
+    use mlxcel_core::drafter::{DrafterKind, resolve_drafter_kind};
+
+    let pairing = &REACHABLE_PAIRINGS[UNIFIED_12B_MTP_PAIRING];
+    let (target_path, draft_path, present) = pairing_present(pairing);
+    if !present {
+        eprintln!(
+            "Skipping {}: target={:?} draft={:?}",
+            pairing.name, target_path, draft_path,
+        );
+        return;
+    }
+
+    // ---- Phase 1: structural check (in-process) ----
+    {
+        let _runtime = initialize_runtime();
+        mlxcel_core::synchronize_default();
+        mlxcel_core::clear_memory_cache();
+
+        eprintln!("[{}] Loading target from {:?}", pairing.name, target_path);
+        let (loaded_target, _target_tokenizer) =
+            load_model(&target_path).expect("target model must load");
+
+        // The 12B Unified checkpoint loads as the encoder-free
+        // `Gemma4Unified` variant; the MTP path operates on the inner text
+        // model (multimodal placeholders are absent for a text prompt).
+        assert!(
+            matches!(loaded_target, LoadedModel::Gemma4Unified(_)),
+            "Unified MTP pairing requires a Gemma4Unified target but load_model returned a \
+             different variant; check the pairing target_dir matches the gemma4_unified \
+             12B 4-bit checkpoint",
+        );
+        eprintln!("[{}] Target loaded as Gemma4Unified", pairing.name);
+
+        eprintln!("[{}] Loading drafter from {:?}", pairing.name, draft_path);
+        let resolved_kind =
+            resolve_drafter_kind(&draft_path, None).expect("drafter config.json must be readable");
+        assert_eq!(
+            resolved_kind,
+            DrafterKind::Mtp,
+            "gemma4_unified_assistant must auto-detect to the MTP round loop",
+        );
+
+        let (drafter, _kind) =
+            mlxcel_core::drafter::load_drafter(&draft_path, Some(DrafterKind::Mtp))
+                .expect("Gemma 4 Unified MTP assistant drafter must load from checkpoint");
+        eprintln!(
+            "[{}] Drafter loaded; block_size={}",
+            pairing.name, pairing.block_size
+        );
+
         drop(drafter);
         drop(loaded_target);
         mlxcel_core::synchronize_default();


### PR DESCRIPTION
## Summary

Wires the Gemma 4 Unified decode target (`LoadedModel::Gemma4Unified`) into the existing MTP speculative-decoding stack so it can be accelerated by a `gemma4_unified_assistant` drafter, mirroring the Gemma 4 VLM MTP path exactly. The MTP drafter model and round loop are reused unchanged; this PR is target-side adapter plumbing, drafter-kind registration, a target↔drafter compatibility guard, tests, and a reproducible benchmark. Follow-up to #151 (its deferred §9 / Phase 7).

## What changed (by phase)

**P1 — Kind registry + config acceptance** (`src/lib/mlxcel-core/src/drafter/mod.rs`, `.../gemma4_assistant/config.rs`)
- `drafter_kind_by_model_type()` now maps both `gemma4_assistant` and `gemma4_unified_assistant` to `DrafterKind::Mtp`; module-doc `DRAFTER_KIND_BY_MODEL_TYPE` comments list both spellings.
- `Gemma4AssistantConfig` already accepts arbitrary `model_type` strings, so the `gemma4_unified_assistant` / `gemma4_unified_text` spellings parse and normalize unchanged (added a parse test).

**P2 — Unified target speculative hooks** (`src/vision/gemma4_unified.rs`)
- `Gemma4UnifiedModel` gains `forward_with_speculative_sinks`, `forward_with_speculative_sinks_explicit_cache` (batched), `rollback_speculative_cache`, and `speculative_draft_hidden` — pure pass-throughs to the inner `text_model: Gemma4Wrapper`, identical to `src/vision/gemma4_vl.rs`.

**P3 — Unified MTP target adapters** (`src/models/gemma4_mtp_target.rs`)
- New `Gemma4UnifiedMtpTargetAdapter<'a>` and `Gemma4UnifiedMtpBatchedTargetAdapter<'a>`, each wrapping `&Gemma4UnifiedModel` and building the inner `Gemma4MtpTargetAdapter` / batched adapter over `unified.text_model`, mirroring the VL adapters.

**P4 — Burst dispatch** (`src/server/batch/speculative_burst.rs`)
- `LoadedModel::Gemma4Unified` arms added to the single-stream (`run_mtp_burst`) and batched (`run_mtp_burst_batched`) MTP dispatch — both the `&dyn LanguageModel` target-resolution match and the adapter-construction match — plus the `model_variant_label` entry and the module-doc target list.

**P5 — Compatibility guard** (`drafter/mod.rs`, `.../gemma4_assistant/model.rs`, dispatch)
- New `Drafter::validate_target_compat` default-method hook (no-op for DFlash / InternalMtp), overridden on `Gemma4AssistantDraftModel` to reject a target whose text hidden size differs from `backbone_hidden_size` (the `2×backbone` concat invariant) and whose vocabulary differs from the drafter `text_config.vocab_size`, with clear `BindFailed` messages. The burst dispatch calls it before `bind()` on both the single-stream and batched paths.

**P6 — Tests**
- `mlxcel-core`: kind resolution (`gemma4_unified_assistant → Mtp`), unified config parse + normalize, compat-guard accept/reject (hidden-size mismatch, missing `embed_tokens`).
- `mlxcel`: weights-free structural trait-surface pins for both Unified adapters (`gemma4_mtp_target_tests.rs`), plus a `#[ignore]`-gated real-model greedy-parity round-trip `greedy_parity_mtp_gemma4_unified_12b` and a `REACHABLE_PAIRINGS` entry (`gemma-4-12b-it-4bit` + `gemma-4-12B-it-assistant-4bit`) in `tests/speculative_parity.rs`.

**P7 — Benchmark** (`src/bin/speculative_bench.rs`)
- Activated the deferred `BenchKind::Mtp` arm: new `run_mtp()` loads the Unified target, compat-checks + binds the assistant drafter, drives `MtpGenerator` through `Gemma4UnifiedMtpTargetAdapter` (with a warm-up), and records real decode tok/s. Added `REACHABLE_PAIRINGS` baseline + MTP entries for the 12B Unified pair so a sweep computes speedup = MTP ÷ baseline.

## Crash fix: quantization-aware UnifiedLinear for pre/post projection (commit 0cc62df)

The drafter's `pre_projection` and `post_projection` were loaded as plain (non-quantized) `Linear` layers. On a 4-bit drafter checkpoint the weight tensors are quantized, so a standard `Linear` forward crashed immediately. Fixed by replacing both with `UnifiedLinear`, which auto-detects quantization via the presence of `.scales` and falls back to plain `Linear` for bf16 checkpoints — behavior-preserving for the 31B bf16 path, crash-fix for the 4-bit assistant path.

## Measured result: ~1.87× decode speedup (satisfies #154 acceptance criterion)

Real-model measurement at `temperature 0` on `gemma-4-12b-it-4bit` target + `gemma-4-12B-it-assistant-4bit` (4-bit) drafter:

- MTP output is **byte-identical** to classic decode at temperature 0 (correctness gate passes).
- Decode throughput: **≈39 tok/s (baseline) → ≈74 tok/s (MTP) = ~1.87× speedup**.
- **Default-on (no env var):** the scheduler now runs B=1 MTP automatically when the target cannot batch (`supports_batching() == false`, e.g. `gemma4_unified`), which is its only decode path. Batch-capable targets (e.g. the 31B) keep the 31B-calibrated decline, and `MLXCEL_ENABLE_MTP_B1=1` still force-enables B=1 MTP on them for parity/debug. (Resolves the follow-up that had been tracked in #158.)

Reproduce with:

```bash
# baseline
MLXCEL_ENABLE_MTP_B1=1 ./target/release/speculative_bench \
    --target <store>/gemma-4-12b-it-4bit --kind none --max-tokens 256 --prompt "<fixed>"
# MTP
MLXCEL_ENABLE_MTP_B1=1 ./target/release/speculative_bench \
    --target <store>/gemma-4-12b-it-4bit \
    --draft <store>/gemma-4-12B-it-assistant-4bit \
    --kind mtp --draft-block-size 4 --max-tokens 256 --prompt "<fixed>"
```

## Reused vs net-new

- **Reused unchanged:** `Gemma4AssistantDraftModel` (centroid head), `MtpGenerator` / `MtpTarget`, `Gemma4MtpTargetAdapter` / `Gemma4MtpBatchedTargetAdapter`, `load_drafter`, `--draft-kind mtp` flags, `SpeculativeDispatch::Mtp`.
- **Net-new:** the registry entry, the four Unified target hooks, the two Unified adapters, the burst-dispatch arms, the `validate_target_compat` hook + override, the tests, and the activated benchmark path.

## Test plan

- [x] `cargo check --lib --tests` — clean
- [x] `cargo clippy --lib --tests --bins -- -D warnings` — clean
- [x] `cargo test -p mlxcel-core --lib drafter` — 132 passed (incl. new kind/config/compat tests)
- [x] `cargo test --lib gemma4_mtp_target` — 17 passed (incl. new Unified adapter pins)
- [x] `cargo test --lib gemma4_unified` — 21 passed
- [x] `cargo test --lib speculative_burst` — 45 passed (dispatch arms unaffected)
- [x] `cargo check --test speculative_parity` / `cargo check --bin speculative_bench` — compile clean
- [x] Real-model gate: `temperature 0` byte-identical output + ~1.87× decode speedup (≈39→74 tok/s) on the 12B Unified pair, engaged by default (no env var)

Closes #154
Closes #158
