### PR TITLE
perf: run B=1 MTP by default for all targets (incl. batch-capable 31B)

### DIFF
--- a/docs/benchmark_results/gemma4-mtp-speculative-decoding.md
+++ b/docs/benchmark_results/gemma4-mtp-speculative-decoding.md
@@ -1,0 +1,132 @@
+# Gemma 4 MTP speculative decoding
+
+How much each Gemma 4 variant benefits from MTP (multi-token prediction)
+speculative decoding, and why the answer depends heavily on hardware and on
+whether the target can batch. This consolidates external reference numbers, the
+behavior mlxcel ships today, and a local Apple Silicon measurement.
+
+## Summary
+
+| Target (mlxcel)                        | Drafter                          | M5 Max B=1 MTP        | mlxcel default        |
+| -------------------------------------- | -------------------------------- | --------------------- | --------------------- |
+| Gemma 4 Unified 12B (`gemma4_unified`) | `gemma-4-12B-it-assistant-4bit`  | ~1.87x (measured)       | **on** (B=1)  |
+| Gemma 4 31B (`gemma4`)                 | `gemma-4-31B-it-assistant-bf16`  | ~1.2 to 1.4x (measured) | **on** (B=1)  |
+| Gemma 4 26B-A4B MoE (`gemma4`)         | `gemma-4-26B-A4B-it-assistant`   | limited at B=1 (MoE)    | on (B=1)      |
+
+Both the 12B Unified and the 31B see a real B=1 MTP speedup on M5 Max (1.87x and
+~1.3x), and mlxcel now runs B=1 (single-request) MTP by default for every MTP
+target. `MLXCEL_ENABLE_MTP_B1=0` opts out, for lower-bandwidth Apple Silicon
+where the B=1 verify forward may not pay for itself. The batched B>1 path stays
+off by default (see the 31B section).
+
+## External reference statistics (datacenter GPU)
+
+The published Gemma 4 MTP numbers are measured on datacenter GPUs with batched
+serving runtimes (vLLM), not single-request Apple Silicon.
+
+- **H100 80GB, vLLM, `k=8` draft tokens, temperature 0** (jarvislabs):
+  - concurrency 1: 40.3 to 125.3 tok/s, **3.11x**; TPOT 24.4 ms to 8.0 ms.
+  - concurrency 16: 375 to 953 tok/s, **2.54x**.
+- A separate H100 run reports ~14 to ~27 tok/s, about **1.9x**.
+- Google advertises "up to 3x" with no quality loss. The drafter is the ~0.5B
+  `google/gemma-4-31B-it-assistant`, which shares the target KV cache and reads
+  its final-layer activations, keeping acceptance (~80%) stable as context
+  grows. Recommended draft tokens start at 4 and can rise to 8 while acceptance
+  holds.
+
+On the H100 the single-request case sees the *largest* gain, because the GPU is
+underutilized at concurrency 1 and verifying 8 draft positions in one forward is
+nearly free. That economics does not carry over to Apple Silicon (see below).
+
+## mlxcel on Apple Silicon
+
+### Gemma 4 Unified 12B (measured)
+
+Apple M5 Max (128 GB), `mlx-community/gemma-4-12b-it-4bit` target +
+`mlx-community/gemma-4-12B-it-assistant-4bit` drafter, block size 4,
+`temperature 0`, 200 decode tokens:
+
+| Path                        | decode tok/s | speedup |
+| --------------------------- | -----------: | ------: |
+| classic decode (no drafter) |         ~39  |  1.00x  |
+| MTP (B=1)                   |         ~74  | ~1.87x  |
+
+Output is byte-identical to classic decode. The Unified target cannot batch
+(`supports_batching() == false`), so B=1 is its only decode path and the
+scheduler runs B=1 MTP for it by default.
+
+### Gemma 4 31B (measured on M5 Max)
+
+The 31B target is batch-capable, so an earlier "B=1 is slower" calibration had
+mlxcel decline its singleton MTP burst by default. That no longer holds on this
+M5 Max: B=1 MTP with the bf16 assistant is measured **faster** than classic
+decode and stays byte-identical at `temperature 0`, so mlxcel now runs B=1 MTP
+for the 31B by default as well (`MLXCEL_ENABLE_MTP_B1=0` opts out).
+
+`models/gemma-4-31b-it-4bit` target + `mlx-community/gemma-4-31B-it-assistant-bf16`
+drafter (bf16, backbone 5376, 4 layers), block size 4, 160 decode tokens:
+
+| Prompt                          | classic tok/s | MTP B=1 tok/s | speedup | identical |
+| ------------------------------- | ------------: | ------------: | ------: | --------- |
+| explain speculative decoding    |         26.5  |         36.8  |  1.39x  | yes       |
+| Apple Silicon paragraph         |         26.1  |         33.5  |  1.29x  | yes       |
+| five data structures            |         25.5  |         30.7  |  1.20x  | yes       |
+
+The 31B gains roughly **1.2x to 1.4x** from B=1 MTP on M5 Max (an earlier
+single run reached 1.50x). That is well below the ~3x reported on an idle H100,
+because Apple Silicon decode is bandwidth-bound rather than compute-starved, but
+it is consistently above 1.0x, which is why B=1 MTP is now on by default for
+batch-capable targets too. Lower-bandwidth Apple Silicon, where the earlier
+"slower" calibration may still hold, can opt out with `MLXCEL_ENABLE_MTP_B1=0`.
+
+**B>1 (batched)** stays declined regardless: the batched MTP burst is not
+consistently faster than classic batched decode on the 31B and does not preserve
+greedy parity there yet (`MLXCEL_ENABLE_MTP_BATCH=1` forces the experimental
+path).
+
+### Gemma 4 26B-A4B (MoE)
+
+For the MoE variant, expert-weight loading at batch 1 dominates, so the drafter
+may not yield a speedup on platforms without strong parallelism. mlxcel keeps it
+on the classic path by default.
+
+## Why Apple Silicon differs from the H100 numbers
+
+The datacenter gains assume a compute-rich GPU that is idle at low concurrency,
+so the speculative verify is almost free and B=1 wins by ~3x. Apple Silicon
+decode is bound by unified-memory bandwidth, so the verify forward over several
+draft positions is not free and the gain is smaller: the 31B measures ~1.3x and
+the 12B Unified ~1.87x here, versus ~3x on an idle H100. The gain is real on
+both platforms; its size tracks how much spare compute the verify forward can
+use. Higher concurrency narrows it further, which is why the H100 number drops
+from 3.11x at one request to 2.54x at sixteen.
+
+The 12B Unified pair has the extra advantage that it cannot batch, so B=1 is its
+native path rather than a fallback, and its 4-bit assistant accepts enough tokens
+per round that one verify forward replaces two to three target forwards.
+
+## Reproduce
+
+```bash
+# Classic baseline (disable B=1 MTP).
+MLXCEL_ENABLE_MTP_B1=0 mlxcel serve -m models/gemma-4-31b-it-4bit --port 8094
+
+# B=1 MTP (on by default; pass an absolute --draft-model path or one already in
+# the model store).
+mlxcel serve -m models/gemma-4-31b-it-4bit \
+  --draft-model ~/.cache/mlxcel/models/mlx-community/gemma-4-31B-it-assistant-bf16 \
+  --draft-kind mtp --port 8095
+
+# Send the same temperature-0 completion to each and compare decode tok/s; at
+# temperature 0 the two outputs must be byte-identical.
+```
+
+See [Benchmarks, Speculative decoding (MTP)](../benchmarks.md) for the metadata
+to record and the `speculative_bench` harness shape.
+
+## Sources
+
+- [Gemma 4 MTP vs DFlash benchmark, H100 (jarvislabs)](https://jarvislabs.ai/blog/gemma-4-mtp-vs-dflash-benchmark)
+- [Speed-up Gemma 4 with Multi-Token Prediction (Google AI for Developers)](https://ai.google.dev/gemma/docs/mtp/overview)
+- [Accelerating Gemma 4 with multi-token prediction drafters (Google blog)](https://blog.google/innovation-and-ai/technology/developers-tools/multi-token-prediction-gemma-4/)
+- [google/gemma-4-31B-it-assistant (Hugging Face)](https://huggingface.co/google/gemma-4-31B-it-assistant)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -84,11 +84,11 @@ size 4, `temperature 0`, 200 decode tokens:
 | classic decode (no drafter) |         ~39  |  1.00x  |
 | MTP                         |         ~74  | ~1.87x  |
 
-The accelerated output is byte-identical to classic decode. The Gemma 4 Unified
-target does not batch (`supports_batching()` is false), so B=1 is its only decode
-path and the scheduler runs B=1 MTP for it by default. `MLXCEL_ENABLE_MTP_B1=1`
-additionally forces B=1 MTP on batch-capable targets, which is useful for parity
-and debugging.
+The accelerated output is byte-identical to classic decode. B=1 (single-request)
+MTP runs by default for every MTP target; the Gemma 4 Unified target cannot batch
+at all, so B=1 is also its only decode path. The batch-capable 31B + bf16
+assistant measures ~1.2 to 1.4x on the same host. Set `MLXCEL_ENABLE_MTP_B1=0` to
+opt out on hardware where the B=1 verify forward does not pay for itself.
 
 ### Gemma 4 31B + bf16 assistant
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -98,7 +98,7 @@ provided.
 |----------|--------|---------|-------|
 | `MLXCEL_DRAFT_KIND` | `dflash`, `mtp` | auto/none | Alias for `--draft-kind` when the CLI flag and `LLAMA_ARG_DRAFT_KIND` are absent. |
 | `MLXCEL_DRAFT_BLOCK_SIZE` | unsigned integer | per drafter (`4` for MTP, `16` for DFlash) | Alias for `--draft-block-size` when the CLI flag and `LLAMA_ARG_DRAFT_BLOCK_SIZE` are absent. |
-| `MLXCEL_ENABLE_MTP_B1` | truthy value | off | **Advanced.** Enables the singleton (B=1) MTP burst path for `gemma4_unified` (and `gemma4`/`gemma4_vlm`) targets. Required today to observe the measured ~1.87× decode speedup on the 12B Unified + 4-bit-assistant pair (≈39→74 tok/s at temperature 0, byte-identical output); the scheduler guard that declines singleton MTP by default was calibrated on the 31B. Making B=1 MTP the default for the 12B class is tracked in #158. |
+| `MLXCEL_ENABLE_MTP_B1` | `0`/`false`/`no`/`off` to disable | **on** | The singleton (B=1) MTP burst runs by default for all MTP targets (`gemma4_unified`, `gemma4`, `gemma4_vlm`). On Apple Silicon (M5 Max) it produces byte-identical output at temperature 0 with a measured ~1.87× speedup on the 12B Unified + 4-bit-assistant pair (≈39→74 tok/s) and ~1.2 to 1.4× on the 31B + bf16 assistant. Set to `0` to opt out, e.g. on lower-bandwidth Apple Silicon where the B=1 verify forward may not pay for itself. |
 | `MLXCEL_ENABLE_MTP_BATCH` | truthy value | off | **Advanced.** Forces the batched Gemma 4 MTP burst path for parity/debug testing. |
 | `MLXCEL_ENABLE_MTP_DEFERRED` | `1` | off | **Advanced.** Enables the deferred greedy verifier path for Gemma 4 MTP when sampling settings allow it. |
 

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1857,22 +1857,17 @@ impl BatchScheduler {
                 crate::server::SpeculativeDispatch::Mtp { .. }
             )
             && !super::speculative_burst::mtp_b1_burst_enabled()
-            && self.model.supports_batching()
         {
-            // Decline the singleton (B=1) MTP burst only for batch-capable
-            // targets (e.g. Gemma 4 31B text): there B=1 MTP measured slower
-            // than classic decode, and the batched (B>1) MTP window is the
-            // intended speedup path. Targets that cannot batch (e.g.
-            // `gemma4_unified`, `supports_batching() == false`) have no batched
-            // alternative, so they fall through and run B=1 MTP by default —
-            // real-model measurement shows ~1.87x decode speedup there with
-            // byte-identical output. `MLXCEL_ENABLE_MTP_B1=1` still force-enables
-            // B=1 MTP on batch-capable targets for parity/debug.
+            // B=1 (single-request) MTP runs by default for every MTP target
+            // (~1.87x on the 12B Unified pair, ~1.2 to 1.4x on the 31B, both
+            // byte-identical on M5 Max). This decline fires only when an operator
+            // opts out with `MLXCEL_ENABLE_MTP_B1=0`, e.g. on lower-bandwidth
+            // Apple Silicon where the B=1 verify forward may not pay for itself;
+            // the request then falls back to classic decode.
             let seq = window.into_iter().next().expect("singleton window");
             tracing::info!(
-                "MTP speculative burst declined for seq {}: singleton B=1 window is \
-                 slower than classic decode on this batch-capable target; the batched \
-                 MTP window is preferred (set MLXCEL_ENABLE_MTP_B1=1 to force B=1 MTP)",
+                "MTP B=1 speculative burst disabled for seq {} via MLXCEL_ENABLE_MTP_B1=0; \
+                 falling back to classic decode",
                 seq.seq_id,
             );
             return Some(seq);

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -413,19 +413,25 @@ pub(crate) fn can_join_batched_burst_window(seq: &SequenceInfo) -> bool {
     true
 }
 
-/// Whether to force the Gemma 4 MTP B=1 burst path.
+/// Whether the Gemma 4 MTP B=1 (single-request) burst path runs.
 ///
-/// real-model measurements showed the assistant drafter is not
-/// profitable for single-request Gemma 4 31B serving: the upstream reference
-/// speedups are reported for B>1 windows, while the B=1 path spends an extra
-/// drafter forward per token at very low acceptance. Production therefore
-/// routes singleton MTP requests through classic decode by default and keeps
-/// this override for parity/debug investigations.
+/// On by default. Apple Silicon (M5 Max) measurements show the assistant
+/// drafter is profitable for single-request Gemma 4 serving, with byte-identical
+/// output at `temperature 0`: ~1.87x on the 12B Unified pair and ~1.2 to 1.4x on
+/// the 31B + bf16 assistant. (The Unified target cannot batch at all, so B=1 is
+/// its only path; the 31B is batch-capable but its single-request window is
+/// still B=1.) The gain is smaller than the ~3x reported on an idle H100 because
+/// Apple Silicon decode is bandwidth-bound, but it stays above 1.0x.
+///
+/// Set `MLXCEL_ENABLE_MTP_B1=0` (or `false`/`no`/`off`) to opt out, e.g. on
+/// lower-bandwidth Apple Silicon where the B=1 verify forward may not pay for
+/// itself. The batched B>1 path is governed separately by
+/// [`mtp_batched_burst_enabled`] and stays off by default.
 pub(crate) fn mtp_b1_burst_enabled() -> bool {
     std::env::var("MLXCEL_ENABLE_MTP_B1")
         .ok()
-        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
-        .unwrap_or(false)
+        .map(|v| !matches!(v.as_str(), "0" | "false" | "FALSE" | "no" | "off"))
+        .unwrap_or(true)
 }
 
 /// Whether to force the Gemma 4 MTP B>1 batched burst path.


### PR DESCRIPTION
## Summary

Run the singleton (B=1) MTP speculative-decoding burst **by default for every MTP target**, including batch-capable ones such as Gemma 4 31B. Previously B=1 MTP was declined by default for batch-capable targets and gated behind `MLXCEL_ENABLE_MTP_B1`, based on an earlier "B=1 is slower" calibration.

## Why

Apple Silicon (M5 Max) measurement shows B=1 MTP is profitable, with **byte-identical output at `temperature 0`**:

| Target | Drafter | classic tok/s | MTP B=1 tok/s | speedup |
| ------ | ------- | ------------: | ------------: | ------: |
| Gemma 4 31B (`gemma4`) | `gemma-4-31B-it-assistant-bf16` | ~26 | ~31–37 | **~1.2–1.4x** |
| Gemma 4 Unified 12B (`gemma4_unified`) | `gemma-4-12B-it-assistant-4bit` | ~39 | ~74 | **~1.87x** |

The gain is smaller than the ~3x reported on an idle H100 (Apple Silicon decode is bandwidth-bound), but it is consistently above 1.0x.

## Change

- `mtp_b1_burst_enabled()` now defaults to **on**; `MLXCEL_ENABLE_MTP_B1=0` (or `false`/`no`/`off`) opts out, for lower-bandwidth Apple Silicon where the B=1 verify forward may not pay for itself.
- Dropped the `supports_batching()` gate from the scheduler decline, so the decline fires only when B=1 MTP is explicitly disabled.
- The batched **B>1** path is unchanged (still off by default; open greedy-parity gap on the 31B).

## Verification (real models, M5 Max)

- 31B, default (no env var): MTP burst engages → 36.6 tok/s; `MLXCEL_ENABLE_MTP_B1=0`: declines to classic → 26.6 tok/s; **1.38x**, output **byte-identical**.
- 12B Unified path unchanged (already default-on).
- `cargo fmt`/`clippy --lib`/`check` clean; release build links.

## Docs

- New report: `docs/benchmark_results/gemma4-mtp-speculative-decoding.md` (12B Unified, 31B, and external H100/vLLM reference numbers, with the hardware analysis).
- Updated `docs/environment-variables.md` (`MLXCEL_ENABLE_MTP_B1` is now default-on / opt-out) and `docs/benchmarks.md`.