### PR TITLE
docs: record measured 31B B>1 batched MTP numbers; align comments

### DIFF
--- a/docs/benchmark_results/gemma4-mtp-speculative-decoding.md
+++ b/docs/benchmark_results/gemma4-mtp-speculative-decoding.md
@@ -79,10 +79,25 @@ it is consistently above 1.0x, which is why B=1 MTP is now on by default for
 batch-capable targets too. Lower-bandwidth Apple Silicon, where the earlier
 "slower" calibration may still hold, can opt out with `MLXCEL_ENABLE_MTP_B1=0`.
 
-**B>1 (batched)** stays declined regardless: the batched MTP burst is not
-consistently faster than classic batched decode on the 31B and does not preserve
-greedy parity there yet (`MLXCEL_ENABLE_MTP_BATCH=1` forces the experimental
-path).
+#### B>1 (batched) stays off by default
+
+Forcing the batched burst with `MLXCEL_ENABLE_MTP_BATCH=1`, 4 concurrent
+requests, 160 tokens each, `temperature 0`:
+
+| Case                                   | classic agg tok/s | B>1 MTP agg tok/s | speedup | parity |
+| -------------------------------------- | ----------------: | ----------------: | ------: | ------ |
+| same-length window (true B>1 burst)    |              31.8 |              33.7 |  1.06x  | identical |
+| variable-length mix (realistic)        |              32.0 |              24.8 |  0.78x  | identical |
+
+The batched burst only groups requests that share a prompt length. A true
+same-length window is a marginal 1.06x. Once prompt lengths differ, the requests
+serialize into per-request B=1 bursts that head-of-line-block each other, so the
+realistic mixed case is **slower** (0.78x). Output stayed byte-identical to
+classic decode in both cases on M5 Max, so the earlier greedy-parity concern did
+not reproduce here, though it has not been exhaustively re-validated. Because the
+throughput is at best marginal and negative under realistic load, B>1 MTP stays
+off by default. The real bottleneck, variable-length batched bursts, is tracked
+as a follow-up.
 
 ### Gemma 4 26B-A4B (MoE)
 

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1880,13 +1880,19 @@ impl BatchScheduler {
             )
             && !super::speculative_burst::mtp_batched_burst_enabled()
         {
+            // The B>1 batched MTP burst is off by default because it is not
+            // consistently faster than classic batched decode on the 31B
+            // (M5 Max: ~1.06x for a same-length window, ~0.78x once prompt
+            // lengths differ and requests serialize into head-of-line-blocking
+            // B=1 bursts). M5 Max runs observed greedy parity holding at
+            // temperature 0. Set MLXCEL_ENABLE_MTP_BATCH=1 to force the path.
             let mut rejected_window = window;
             let head = rejected_window.remove(0);
             tracing::info!(
-                "MTP batched speculative burst declined for seq {}: current Gemma 4 \
-                 B>1 MTP validation does not preserve greedy parity on real 31B; \
-                 falling back to classic decode. Set MLXCEL_ENABLE_MTP_BATCH=1 to force \
-                 the experimental batched MTP path",
+                "MTP batched speculative burst declined for seq {}: B>1 MTP is not \
+                 consistently faster than classic batched decode on the 31B; falling \
+                 back to classic decode. Set MLXCEL_ENABLE_MTP_BATCH=1 to force the \
+                 experimental batched MTP path",
                 head.seq_id,
             );
             for sibling in rejected_window {

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -434,15 +434,25 @@ pub(crate) fn mtp_b1_burst_enabled() -> bool {
         .unwrap_or(true)
 }
 
-/// Whether to force the Gemma 4 MTP B>1 batched burst path.
+/// Whether to force the Gemma 4 MTP B>1 batched burst path. Off by default.
 ///
 /// Reference Gemma 4 MTP gets its advertised speedups from batched verify
-/// windows. The Rust path now preserves per-row cache positions / RoPE
-/// anchors after mixed accepts, but real 31B validation still shows the
-/// forced B>1 MTP burst is not consistently faster than classic batched
-/// decode. Keep the path available behind an explicit operator/debug flag
-/// while production falls back to the known-profitable classic scheduler
-/// path.
+/// windows, but on Apple Silicon (M5 Max, 31B + bf16 assistant, 4 concurrent
+/// requests, temperature 0) the forced B>1 burst is not worth enabling by
+/// default:
+/// - A true same-length batched burst is only ~1.06x faster than classic
+///   batched decode (aggregate ~33.7 vs ~31.8 tok/s).
+/// - The batched burst only groups requests that share a prompt length; a
+///   variable-length mix serializes into per-request B=1 bursts that
+///   head-of-line-block each other, so the realistic case is ~0.78x (slower).
+///   Variable-length batched bursts are the real bottleneck and a tracked
+///   follow-up.
+///
+/// Greedy parity: M5 Max runs (160 tokens, temperature 0) observed
+/// byte-identical output vs classic decode in both the same-length and
+/// variable-length cases, so parity held; it has not been exhaustively
+/// re-validated across longer generations / samplers, so the path stays behind
+/// this flag and production uses the classic scheduler.
 pub(crate) fn mtp_batched_burst_enabled() -> bool {
     std::env::var("MLXCEL_ENABLE_MTP_BATCH")
         .ok()


### PR DESCRIPTION
## Summary

Document the measured Gemma 4 31B B>1 (batched) MTP results on M5 Max and update the now-stale `mtp_batched_burst_enabled` / scheduler-decline comments to match.

## Measurements (M5 Max, 31B + bf16 assistant, 4 concurrent, temp 0)

| Case | classic agg tok/s | B>1 MTP agg tok/s | speedup | parity |
| ---- | ----------------: | ----------------: | ------: | ------ |
| same-length window (true B>1 burst) | 31.8 | 33.7 | 1.06x | identical |
| variable-length mix (realistic) | 32.0 | 24.8 | 0.78x | identical |

- A true same-length batched burst is only **~1.06x** faster than classic batched decode.
- The batched burst only groups requests that share a prompt length; a variable-length mix **serializes** into per-request B=1 bursts that head-of-line-block each other, so the realistic case is **~0.78x (slower)**.
- Output stayed **byte-identical** to classic decode in both cases, so the earlier greedy-parity concern did not reproduce here (not exhaustively re-validated).

## Conclusion

B>1 batched MTP stays **off by default** for throughput reasons (marginal at best, negative under realistic mixed-length load), not parity. The real bottleneck, variable-length batched bursts, is filed as a follow-up issue.

## Changes

- Rewrote the `mtp_batched_burst_enabled()` doc comment and the scheduler B>1 decline comment/log to the measured reality (comment/doc only, no behavior change).
- Added a B>1 results table to `docs/benchmark_results/gemma4-mtp-speculative-decoding.md`.