### PR TITLE
perf: support variable-length prompts in B>1 batched MTP bursts

### DIFF
--- a/docs/benchmark_results/gemma4-mtp-speculative-decoding.md
+++ b/docs/benchmark_results/gemma4-mtp-speculative-decoding.md
@@ -96,8 +96,9 @@ realistic mixed case is **slower** (0.78x). Output stayed byte-identical to
 classic decode in both cases on M5 Max, so the earlier greedy-parity concern did
 not reproduce here, though it has not been exhaustively re-validated. Because the
 throughput is at best marginal and negative under realistic load, B>1 MTP stays
-off by default. The real bottleneck, variable-length batched bursts, is tracked
-as a follow-up.
+off by default.
+
+Variable-length ragged batching is now available behind `MLXCEL_ENABLE_MTP_BATCH_RAGGED=1` (requires `MLXCEL_ENABLE_MTP_BATCH=1`). With this flag, requests with different prompt lengths form a single B>1 burst via left-padding to `max_prompt_len`, and greedy parity is confirmed on the 31B: every row's output is byte-identical to classic decode at temperature 0. Throughput measured ~0.94–1.13x vs classic batched decode across runs, which recovers the prior 0.78x serialization penalty but is not a consistent win. The flag stays off by default for this reason.
 
 ### Gemma 4 26B-A4B (MoE)
 

--- a/src/lib/mlxcel-core/src/drafter/masks.rs
+++ b/src/lib/mlxcel-core/src/drafter/masks.rs
@@ -616,10 +616,36 @@ fn make_swa_mask_with_local_offsets(
     kv_valid_len: &BatchScalar<'_>,
     dtype: i32,
 ) -> Option<UniquePtr<MlxArray>> {
+    // The shared K/V handed to the drafter is normalized so every row's valid
+    // keys occupy `[0, kv_valid_len[r])` in the **prefix-valid** frame (see
+    // `normalize_batched_shared_kv_states`). The SWA window distance must
+    // therefore be measured in that same frame: the bonus query is logically
+    // the last valid token, i.e. at position `kv_valid_len - 1`. The caller's
+    // `query_offset` is the drafter's **RoPE anchor** in the **padded** frame
+    // (`bonus_position = left_padding + kv_valid_len - 1`); using it directly
+    // for the SWA distance would inject a spurious `+left_padding` shift that
+    // over-masks the front keys of a left-padded (ragged batched MTP) row by
+    // exactly `left_padding`, breaking greedy parity for the most-padded row
+    // while leaving the others untouched.
+    //
+    // For every non-padded path the established invariant is `query_offset ==
+    // kv_valid_len - 1` (B = 1 decode, equal-length batched, rotating-cache
+    // slice), so deriving the SWA query position from `kv_valid_len - 1` is
+    // byte-identical there and only diverges (correctly) when `left_padding >
+    // 0`. `key_offset` stays 0 because the normalized keys start at logical 0.
+    //
+    // `query_offset` is now unused for the SWA distance; it is retained in the
+    // signature for symmetry with the full-attention path and potential future
+    // callers that pass already-valid-frame offsets.
+    let _ = query_offset;
     let key_offset = BatchScalar::Scalar(0);
-    match (query_offset, kv_valid_len) {
-        (BatchScalar::Scalar(q), BatchScalar::Scalar(v)) => {
-            let local_query = BatchScalar::Scalar((*q).min(kv_len));
+    match kv_valid_len {
+        BatchScalar::Scalar(v) => {
+            // Valid-frame query position: clamp `kv_valid_len - 1` into
+            // `[0, kv_len]` (the local K/V axis). The clamp matches the prior
+            // `min(.., kv_len)` behaviour and additionally floors at 0 so a
+            // degenerate `kv_valid_len == 0` cannot produce a negative offset.
+            let local_query = BatchScalar::Scalar((*v - 1).clamp(0, kv_len));
             let local_valid = BatchScalar::Scalar((*v).min(kv_len));
             bidirectional_swa_mask_with_key_offset(
                 query_len,
@@ -631,38 +657,9 @@ fn make_swa_mask_with_local_offsets(
                 dtype,
             )
         }
-        (BatchScalar::PerRow(q_arr), BatchScalar::Scalar(v)) => {
-            let local_query_arr = local_window_offset_array(q_arr, kv_len);
-            let local_query = BatchScalar::PerRow(&local_query_arr);
-            let local_valid = BatchScalar::Scalar((*v).min(kv_len));
-            bidirectional_swa_mask_with_key_offset(
-                query_len,
-                &local_query,
-                kv_len,
-                sliding_window,
-                Some(&local_valid),
-                &key_offset,
-                dtype,
-            )
-        }
-        (BatchScalar::Scalar(q), BatchScalar::PerRow(v_arr)) => {
-            let batch = ffi::array_shape(v_arr)[0];
-            let local_query_arr = scalar_batch_vector((*q).min(kv_len), batch);
-            let local_valid_arr = local_window_offset_array(v_arr, kv_len);
-            let local_query = BatchScalar::PerRow(&local_query_arr);
-            let local_valid = BatchScalar::PerRow(&local_valid_arr);
-            bidirectional_swa_mask_with_key_offset(
-                query_len,
-                &local_query,
-                kv_len,
-                sliding_window,
-                Some(&local_valid),
-                &key_offset,
-                dtype,
-            )
-        }
-        (BatchScalar::PerRow(q_arr), BatchScalar::PerRow(v_arr)) => {
-            let local_query_arr = local_window_offset_array(q_arr, kv_len);
+        BatchScalar::PerRow(v_arr) => {
+            // local_query[r] = clamp(kv_valid_len[r] - 1, 0, kv_len).
+            let local_query_arr = local_query_offset_array(v_arr, kv_len);
             let local_valid_arr = local_window_offset_array(v_arr, kv_len);
             let local_query = BatchScalar::PerRow(&local_query_arr);
             let local_valid = BatchScalar::PerRow(&local_valid_arr);
@@ -677,6 +674,21 @@ fn make_swa_mask_with_local_offsets(
             )
         }
     }
+}
+
+/// Per-row valid-frame SWA query offset: `clamp(kv_valid_len[r] - 1, 0, kv_len)`.
+///
+/// The bonus query is the last valid token, so its position relative to the
+/// normalized `[0, kv_valid_len)` key prefix is `kv_valid_len - 1`. The clamp
+/// floors at 0 (degenerate empty prefix) and caps at the local K/V axis
+/// length, matching [`local_window_offset_array`]'s upper bound.
+fn local_query_offset_array(kv_valid_len: &MlxArray, kv_len: i32) -> UniquePtr<MlxArray> {
+    let one = ffi::from_slice_i32(&[1], &[1]);
+    let minus_one = ffi::subtract(kv_valid_len, &one);
+    let zero = ffi::from_slice_i32(&[0], &[1]);
+    let kv_len_arr = ffi::from_slice_i32(&[kv_len], &[1]);
+    let floored = ffi::maximum(&minus_one, &zero);
+    ffi::minimum(&floored, &kv_len_arr)
 }
 
 fn local_window_offset_array(value: &MlxArray, kv_len: i32) -> UniquePtr<MlxArray> {
@@ -1206,6 +1218,113 @@ mod tests {
                 .is_none(),
             "SWA should be mask-free after mapping absolute position 9 to local offset 4",
         );
+    }
+
+    /// Ragged batched MTP greedy-parity regression (issue #161 / PR #162).
+    ///
+    /// When a B > 1 burst mixes prompt lengths, each row's shared K/V is
+    /// normalized (rolled left by `left_padding[r]`) so its valid keys occupy
+    /// `[0, kv_valid_len[r])` in the **prefix-valid** frame, while the drafter
+    /// query's RoPE anchor stays in the **padded** frame at `bonus_position[r]
+    /// = left_padding[r] + kv_valid_len[r] - 1` (so the query's RoPE phase
+    /// matches the baked keys' `+left_padding[r]` phase). The SWA mask distance,
+    /// however, is computed against the normalized keys at `[0, kv_valid_len)`,
+    /// so it MUST use the valid-frame query position `kv_valid_len[r] - 1`, NOT
+    /// the padded `bonus_position[r]`. Conflating the two over-masks the
+    /// most-left-padded (shortest) row's SWA layers by exactly `left_padding[r]`
+    /// keys — the bonus query can attend to ZERO valid keys, which is why the
+    /// shortest prompt emitted empty content and never hit EOS in the real-model
+    /// gate while the other rows were byte-identical.
+    ///
+    /// Numeric reproduction (the unit proxy for the 31B parity gate):
+    /// - kv_len (padded buffer width) = 8, sliding_window = 4.
+    /// - Row 0 (shortest, most padded): kv_valid_len = 3, left_padding = 5, so
+    ///   bonus_position = 5 + 3 - 1 = 7 = kv_len - 1. Its valid keys are [0, 3).
+    ///   Correct SWA distance uses query position kv_valid_len-1 = 2, so dist[k]
+    ///   = 2 - k and every valid key k in {0,1,2} is inside the window. With the
+    ///   bug (query position = 7) dist[k] = 7 - k, so `dist < window` (= 4)
+    ///   requires k > 3 while `k < kv_valid_len` requires k < 3 — an empty set,
+    ///   i.e. the bonus query attends to nothing.
+    /// - Row 1 (full length): kv_valid_len = 8, left_padding = 0, so
+    ///   bonus_position = 7 = kv_valid_len - 1 (the unaffected baseline).
+    ///
+    /// The test asserts row 0's three valid SWA keys are attended (bias 0.0) and
+    /// its padded tail is masked, which fails on the pre-fix code and passes
+    /// after the SWA query offset is derived from kv_valid_len.
+    #[test]
+    fn swa_mask_ragged_left_padding_attends_short_rows_valid_keys() {
+        let kv_len = 8_i32;
+        let query_len = 1_i32;
+        let sliding_window = 4_i32;
+
+        // Padded-frame RoPE anchors (bonus_position) — uniform max_len - 1.
+        let query_offsets = ffi::from_slice_i32(&[7, 7], &[2]);
+        let query_offset = BatchScalar::PerRow(&query_offsets);
+        // Per-row valid prefix lengths after K/V normalization.
+        let kv_valid_lens = ffi::from_slice_i32(&[3, 8], &[2]);
+        let kv_valid_len = BatchScalar::PerRow(&kv_valid_lens);
+
+        let k_swa = ffi::zeros(&[2, 1, kv_len, 1], dtype::FLOAT32);
+        let v_swa = ffi::zeros(&[2, 1, kv_len, 1], dtype::FLOAT32);
+
+        let mut shared: HashMap<LayerType, (&MlxArray, &MlxArray)> = HashMap::new();
+        shared.insert(LayerType::SlidingWindowAttention, (&k_swa, &v_swa));
+
+        let masks = make_drafter_masks_with_valid_len(
+            &shared,
+            query_len,
+            &query_offset,
+            sliding_window,
+            dtype::FLOAT32,
+            Some(&kv_valid_len),
+        );
+
+        let swa = masks
+            .get(&LayerType::SlidingWindowAttention)
+            .expect("SWA entry present")
+            .as_ref()
+            .expect("per-row SWA mask must materialise (kv_valid differs from kv_len)");
+        assert_eq!(
+            ffi::array_shape(swa),
+            vec![2, 1, query_len, kv_len],
+            "per-row SWA mask must be [B, 1, query_len, kv_len]",
+        );
+
+        // Row 0 (most padded): its three valid keys [0, 3) must be attended.
+        // Pre-fix these are all -inf because the padded query offset 7 pushes
+        // every valid key outside the window.
+        for k in 0..3 {
+            let v = mask_at_qk(swa, &[0, 0, 0, k]);
+            assert_eq!(
+                v, 0.0,
+                "row 0 (lp=5) valid SWA key {k} must be attended (0.0), got {v}",
+            );
+        }
+        // Row 0 padded tail [3, kv_len) must remain masked.
+        for k in 3..kv_len {
+            let v = mask_at_qk(swa, &[0, 0, 0, k]);
+            assert!(
+                v.is_infinite() && v < 0.0,
+                "row 0 padded SWA key {k} must be masked (-inf), got {v}",
+            );
+        }
+
+        // Row 1 (full length, lp=0) is the byte-identical baseline: with window
+        // 4 and query position 7 it attends keys {4,5,6,7} and masks {0,1,2,3}.
+        for k in 0..4 {
+            let v = mask_at_qk(swa, &[1, 0, 0, k]);
+            assert!(
+                v.is_infinite() && v < 0.0,
+                "row 1 SWA key {k} must be outside the window (-inf), got {v}",
+            );
+        }
+        for k in 4..kv_len {
+            let v = mask_at_qk(swa, &[1, 0, 0, k]);
+            assert_eq!(
+                v, 0.0,
+                "row 1 SWA key {k} must be inside the window (0.0), got {v}",
+            );
+        }
     }
 
     // ----- dtype preservation ----------------------------------------------

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -1023,7 +1023,11 @@ mod tests {
         let lp_mask = create_causal_mask_with_window_and_left_padding(6, 0, Some(8), &[0, 0]);
         let ref_shape = ffi::array_shape(&ref_mask);
         let lp_shape = ffi::array_shape(&lp_mask);
-        assert_eq!(ref_shape, vec![6, 6], "non-capped windowed mask is [size, size]");
+        assert_eq!(
+            ref_shape,
+            vec![6, 6],
+            "non-capped windowed mask is [size, size]"
+        );
         assert_eq!(
             ref_shape, lp_shape,
             "no-padding windowed left-padding mask must match plain windowed mask shape"
@@ -1057,10 +1061,13 @@ mod tests {
         // trigger sliding-window upper-bound masking (window >= size).
         // Row 0: left_padding=2 (real tokens at padded indices 2,3).
         // Row 1: left_padding=0 (all real).
-        let mask =
-            create_causal_mask_with_window_and_left_padding(4, 0, Some(4), &[2, 0]);
+        let mask = create_causal_mask_with_window_and_left_padding(4, 0, Some(4), &[2, 0]);
         let shape = ffi::array_shape(&mask);
-        assert_eq!(shape, vec![2, 1, 4, 4], "padded mask must be [B,1,size,total]");
+        assert_eq!(
+            shape,
+            vec![2, 1, 4, 4],
+            "padded mask must be [B,1,size,total]"
+        );
 
         // Helper to read cell [b,0,q,k].
         let cell = |b: i32, q: i32, k: i32| -> f32 {
@@ -1085,7 +1092,11 @@ mod tests {
         );
 
         // Row 1 (no padding): standard causal band, k=0 attended by q=0.
-        assert_eq!(cell(1, 0, 0), 0.0, "row1 q=0 -> k=0 must attend (no padding)");
+        assert_eq!(
+            cell(1, 0, 0),
+            0.0,
+            "row1 q=0 -> k=0 must attend (no padding)"
+        );
         assert!(
             cell(1, 0, 1).is_infinite() && cell(1, 0, 1) < 0.0,
             "row1 q=0 -> future k=1 must be -inf (causal)"
@@ -1101,8 +1112,7 @@ mod tests {
     #[test]
     fn windowed_left_padding_mask_matches_plain_left_padding_when_uncapped() {
         // size=5 <= window=8, offset=0 -> non-capped, upper bound inert.
-        let windowed =
-            create_causal_mask_with_window_and_left_padding(5, 0, Some(8), &[1, 0]);
+        let windowed = create_causal_mask_with_window_and_left_padding(5, 0, Some(8), &[1, 0]);
         let plain = create_causal_mask_with_left_padding(5, 0, &[1, 0]);
 
         let wshape = ffi::array_shape(&windowed);
@@ -1114,10 +1124,18 @@ mod tests {
         );
 
         let wcell = |b: i32, q: i32, k: i32| -> f32 {
-            ffi::item_f32(&ffi::slice(&windowed, &[b, 0, q, k], &[b + 1, 1, q + 1, k + 1]))
+            ffi::item_f32(&ffi::slice(
+                &windowed,
+                &[b, 0, q, k],
+                &[b + 1, 1, q + 1, k + 1],
+            ))
         };
         let pcell = |b: i32, q: i32, k: i32| -> f32 {
-            ffi::item_f32(&ffi::slice(&plain, &[b, 0, q, k], &[b + 1, 1, q + 1, k + 1]))
+            ffi::item_f32(&ffi::slice(
+                &plain,
+                &[b, 0, q, k],
+                &[b + 1, 1, q + 1, k + 1],
+            ))
         };
         for b in 0..2 {
             for q in 0..5 {
@@ -1243,7 +1261,8 @@ mod tests {
         let offset = 11_i32;
         let window = 8_i32;
         let total = size + offset; // 12
-        let mask = create_causal_mask_with_window_and_left_padding(size, offset, Some(window), &[5, 0]);
+        let mask =
+            create_causal_mask_with_window_and_left_padding(size, offset, Some(window), &[5, 0]);
         assert_eq!(
             ffi::array_shape(&mask),
             vec![2, 1, size, total],

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -203,6 +203,113 @@ pub fn create_causal_mask_with_left_padding(
     ffi::where_cond(&bool_out, &zeros_out, &neg_inf_out)
 }
 
+/// Create a sliding-window causal attention mask with per-sequence
+/// left-padding support.
+///
+/// This is the windowed counterpart of [`create_causal_mask_with_left_padding`]
+/// and the left-padding-aware counterpart of [`create_causal_mask_with_window`].
+/// It is used by the **ragged batched MTP prefill** path
+/// ([`crate::speculative::mtp`] via the Gemma 4 batched target adapter): when a
+/// B > 1 burst window mixes prompts of different lengths, every row is
+/// left-padded to `max_prompt_len` and the sliding-attention layers need a mask
+/// that (a) enforces the sliding-window causal band AND (b) prevents real query
+/// positions from attending to a row's leading padding keys.
+///
+/// # Arguments
+/// * `size` — Number of query tokens in the current step (the padded prompt
+///   width `max_prompt_len` for prefill).
+/// * `offset` — Tokens already in the KV buffer before this call. For a fresh
+///   prefill this is `0`. The total (uncapped) key length is `size + offset`.
+/// * `window` — Sliding window size. `None` collapses to
+///   [`create_causal_mask_with_left_padding`] (no windowing).
+/// * `left_padding` — Per-sequence number of leading padding tokens. Key
+///   positions `k < left_padding[b]` are masked for sequence `b`. When empty or
+///   all-zero the result is byte-identical to [`create_causal_mask_with_window`].
+///
+/// # Returns
+/// Additive mask (0 for attended positions, −∞ for masked positions).
+///
+/// # Shape note
+/// * **No padding** (`left_padding` empty or all-zero): same shape as
+///   [`create_causal_mask_with_window`] — `[size, T_k]` where
+///   `T_k = min(size + offset, window)`.
+/// * **With padding**: `[B, 1, size, T_k]` where `B = left_padding.len()`. The
+///   `[B, 1]` leading dims broadcast against a `[B, H, size, T_k]` score tensor.
+///
+/// # Capped-window caveat
+/// When `size + offset > window` the underlying [`RotatingKVCache`] caps the K
+/// axis to the most-recent `window` slots, which re-indexes key positions and
+/// makes the left-padding column filter non-trivial. The ragged batched MTP
+/// caller therefore restricts itself to `max_prompt_len <= window` (the
+/// non-capped regime) and declines the burst window otherwise, so this helper's
+/// left-padding filter is only ever exercised in the non-capped path. The
+/// implementation still asserts the non-capped precondition in debug builds.
+///
+/// Used by: ragged batched MTP prefill (Gemma 4 batched target adapter).
+#[must_use]
+pub fn create_causal_mask_with_window_and_left_padding(
+    size: i32,
+    offset: i32,
+    window: Option<i32>,
+    left_padding: &[i32],
+) -> UniquePtr<MlxArray> {
+    let no_padding = left_padding.is_empty() || left_padding.iter().all(|&p| p == 0);
+
+    // Fast path: no per-sequence padding -> identical to the windowed mask.
+    if no_padding {
+        return create_causal_mask_with_window(size, offset, window);
+    }
+
+    let uncapped_len = size + offset;
+
+    // The left-padding filter below assumes a non-capped key axis (column k maps
+    // 1:1 to logical key position k). The ragged batched MTP caller guarantees
+    // this by only forming ragged windows when `max_prompt_len <= window`.
+    debug_assert!(
+        window.map(|w| uncapped_len <= w).unwrap_or(true),
+        "create_causal_mask_with_window_and_left_padding: capped window \
+         (size + offset = {uncapped_len} > window) is unsupported; the caller \
+         must restrict ragged windows to the non-capped regime",
+    );
+
+    let total_len = uncapped_len;
+
+    // ── Windowed causal (band) base mask, [size, total_len] ─────────────────
+    let ones = ffi::ones(&[size, total_len], dtype::FLOAT32);
+    let mut band = ffi::tril(&ones, offset);
+    if let Some(w) = window {
+        // Enforce the sliding-window upper bound q <= k + window - 1, identical
+        // to the non-capped branch of `create_causal_mask_with_window`.
+        let upper_mask = ffi::triu(&ones, offset - w + 1);
+        band = ffi::multiply(&band, &upper_mask);
+    }
+
+    // ── Left-padding column filter ──────────────────────────────────────────
+    // For sequence `b`, key positions `k < left_padding[b]` are padding and must
+    // be masked. Build a [B, 1, 1, total_len] boolean (k >= lp[b]) and multiply
+    // with the band mask broadcast to [1, 1, size, total_len].
+    let b = left_padding.len() as i32;
+
+    let rinds_1d = ffi::arange_i32(0, total_len, 1);
+    let rinds = ffi::reshape(&rinds_1d, &[1, 1, 1, total_len]);
+    let lp_tensor = ffi::from_slice_i32(left_padding, &[b, 1, 1, 1]);
+    let lp_mask = ffi::greater_equal(&rinds, &lp_tensor);
+
+    let band_4d = ffi::reshape(&band, &[1, 1, size, total_len]);
+
+    let ones_lp = ffi::ones(&[b, 1, 1, total_len], dtype::FLOAT32);
+    let zeros_lp = ffi::zeros(&[b, 1, 1, total_len], dtype::FLOAT32);
+    let lp_mask_f32 = ffi::where_cond(&lp_mask, &ones_lp, &zeros_lp);
+
+    let combined = ffi::multiply(&band_4d, &lp_mask_f32);
+
+    // Convert the 0/1 float mask to an additive 0 / -inf mask.
+    let zeros_out = ffi::zeros(&[b, 1, size, total_len], dtype::FLOAT32);
+    let neg_inf_out = ffi::full_f32(&[b, 1, size, total_len], f32::NEG_INFINITY, dtype::FLOAT32);
+    let bool_out = ffi::greater(&combined, &zeros_out);
+    ffi::where_cond(&bool_out, &zeros_out, &neg_inf_out)
+}
+
 /// Create a boolean causal attention mask.
 /// Used by: same as `create_causal_mask` (experimental path)
 ///
@@ -892,5 +999,129 @@ mod tests {
         // q=3 attends to both cache keys
         assert_eq!(row3_col0, 0.0, "row3_col0 should be 0.0 (attend)");
         assert_eq!(row3_col1, 0.0, "row3_col1 should be 0.0 (attend)");
+    }
+
+    // --- Windowed left-padding mask (ragged batched MTP prefill) ----------
+
+    /// No-padding fast path must be byte-identical to the plain windowed mask.
+    #[test]
+    fn windowed_left_padding_mask_no_padding_matches_windowed() {
+        // Non-capped regime: size=6, offset=0, window=8 (>= size). No padding.
+        let ref_mask = create_causal_mask_with_window(6, 0, Some(8));
+        let lp_mask = create_causal_mask_with_window_and_left_padding(6, 0, Some(8), &[0, 0]);
+        let ref_shape = ffi::array_shape(&ref_mask);
+        let lp_shape = ffi::array_shape(&lp_mask);
+        assert_eq!(ref_shape, vec![6, 6], "non-capped windowed mask is [size, size]");
+        assert_eq!(
+            ref_shape, lp_shape,
+            "no-padding windowed left-padding mask must match plain windowed mask shape"
+        );
+
+        // Empty left_padding slice also collapses to the windowed mask.
+        let lp_empty = create_causal_mask_with_window_and_left_padding(6, 0, Some(8), &[]);
+        assert_eq!(ffi::array_shape(&lp_empty), ref_shape);
+
+        // Spot-check a couple of cells are identical (additive 0 / -inf).
+        for (q, k) in [(0_i32, 0_i32), (3, 0), (3, 3), (5, 1), (5, 5)] {
+            let a = ffi::item_f32(&ffi::slice(&ref_mask, &[q, k], &[q + 1, k + 1]));
+            let b = ffi::item_f32(&ffi::slice(&lp_mask, &[q, k], &[q + 1, k + 1]));
+            assert_eq!(
+                a.is_finite(),
+                b.is_finite(),
+                "cell ({q},{k}) finiteness must match: ref={a}, lp={b}"
+            );
+            if a.is_finite() {
+                assert_eq!(a, b, "cell ({q},{k}) value mismatch: ref={a}, lp={b}");
+            }
+        }
+    }
+
+    /// With per-row left-padding the mask is `[B, 1, size, total_len]` and the
+    /// padding columns are masked for the padded rows while remaining unmasked
+    /// for the non-padded row.
+    #[test]
+    fn windowed_left_padding_mask_masks_padding_columns() {
+        // B=2, size=4 (padded width), offset=0, window large enough not to
+        // trigger sliding-window upper-bound masking (window >= size).
+        // Row 0: left_padding=2 (real tokens at padded indices 2,3).
+        // Row 1: left_padding=0 (all real).
+        let mask =
+            create_causal_mask_with_window_and_left_padding(4, 0, Some(4), &[2, 0]);
+        let shape = ffi::array_shape(&mask);
+        assert_eq!(shape, vec![2, 1, 4, 4], "padded mask must be [B,1,size,total]");
+
+        // Helper to read cell [b,0,q,k].
+        let cell = |b: i32, q: i32, k: i32| -> f32 {
+            ffi::item_f32(&ffi::slice(&mask, &[b, 0, q, k], &[b + 1, 1, q + 1, k + 1]))
+        };
+
+        // Row 0 (left_padding=2): the first real query is at padded index q=2.
+        // It must NOT attend to padding keys k=0,1, but MUST attend to k=2.
+        assert!(
+            cell(0, 2, 0).is_infinite() && cell(0, 2, 0) < 0.0,
+            "row0 q=2 -> padding k=0 must be -inf"
+        );
+        assert!(
+            cell(0, 2, 1).is_infinite() && cell(0, 2, 1) < 0.0,
+            "row0 q=2 -> padding k=1 must be -inf"
+        );
+        assert_eq!(cell(0, 2, 0 + 2), 0.0, "row0 q=2 -> real k=2 must attend");
+        // Causal upper bound: q=2 must NOT see future k=3.
+        assert!(
+            cell(0, 2, 3).is_infinite() && cell(0, 2, 3) < 0.0,
+            "row0 q=2 -> future k=3 must be -inf (causal)"
+        );
+
+        // Row 1 (no padding): standard causal band, k=0 attended by q=0.
+        assert_eq!(cell(1, 0, 0), 0.0, "row1 q=0 -> k=0 must attend (no padding)");
+        assert!(
+            cell(1, 0, 1).is_infinite() && cell(1, 0, 1) < 0.0,
+            "row1 q=0 -> future k=1 must be -inf (causal)"
+        );
+    }
+
+    /// In the non-capped prefill regime (`offset == 0`, `size <= window`) the
+    /// sliding-window upper bound is inert, so for the real-token sub-block the
+    /// windowed left-padding mask is byte-identical to the plain (non-windowed)
+    /// left-padding mask. This is the exact invariant the ragged batched MTP
+    /// prefill relies on: a short prefix prefill within the window sees no
+    /// windowing effect, only causal + left-padding.
+    #[test]
+    fn windowed_left_padding_mask_matches_plain_left_padding_when_uncapped() {
+        // size=5 <= window=8, offset=0 -> non-capped, upper bound inert.
+        let windowed =
+            create_causal_mask_with_window_and_left_padding(5, 0, Some(8), &[1, 0]);
+        let plain = create_causal_mask_with_left_padding(5, 0, &[1, 0]);
+
+        let wshape = ffi::array_shape(&windowed);
+        let pshape = ffi::array_shape(&plain);
+        assert_eq!(wshape, vec![2, 1, 5, 5]);
+        assert_eq!(
+            wshape, pshape,
+            "non-capped windowed left-padding mask must share the plain shape"
+        );
+
+        let wcell = |b: i32, q: i32, k: i32| -> f32 {
+            ffi::item_f32(&ffi::slice(&windowed, &[b, 0, q, k], &[b + 1, 1, q + 1, k + 1]))
+        };
+        let pcell = |b: i32, q: i32, k: i32| -> f32 {
+            ffi::item_f32(&ffi::slice(&plain, &[b, 0, q, k], &[b + 1, 1, q + 1, k + 1]))
+        };
+        for b in 0..2 {
+            for q in 0..5 {
+                for k in 0..5 {
+                    let w = wcell(b, q, k);
+                    let p = pcell(b, q, k);
+                    assert_eq!(
+                        w.is_finite(),
+                        p.is_finite(),
+                        "cell ({b},{q},{k}) finiteness mismatch: windowed={w}, plain={p}"
+                    );
+                    if w.is_finite() {
+                        assert_eq!(w, p, "cell ({b},{q},{k}) value mismatch");
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -1124,4 +1124,84 @@ mod tests {
             }
         }
     }
+
+    /// Ragged batched MTP **verify-round** left-padding regression (issue #161 /
+    /// PR #162).
+    ///
+    /// Greedy parity for a variable-length B>1 burst requires that EVERY verify
+    /// round mask each row's resident `[0, left_padding[r])` prompt-padding keys
+    /// — not just the prefill. The padding K/V (token 0) is never evicted from
+    /// the unbounded full-attention cache, so a verify query at a nonzero cache
+    /// offset that attends those padding columns diverges from the row's
+    /// standalone B=1 run, and the divergence scales with `left_padding[r]`
+    /// (only the most-padded / shortest row breaks in the real-model gate).
+    ///
+    /// This pins the verify-frame mask the fixed `mask == None` forward path
+    /// builds: `create_causal_mask_with_left_padding(width, offset, left_padding)`
+    /// with `offset > 0` (cache already holds the padded prompt plus accepted
+    /// tokens) and a LARGE per-row padding gap. For the most-padded row the
+    /// leading `left_padding` key columns must be `-inf` and every real key
+    /// (the columns the standalone B=1 run would expose) must be `0.0`.
+    #[test]
+    fn left_padding_mask_masks_padding_in_verify_round_with_large_gap() {
+        // Verify round: width=2 query tokens, cache offset O=10 (e.g. padded
+        // prompt max_len=8 + 2 accepted), so the key axis is O+width=12.
+        // Row 0 (shortest / most padded): left_padding=6 — keys [0,6) are
+        //   prompt padding, real keys live at [6, 12).
+        // Row 1 (full length): left_padding=0 — every key is real.
+        let width = 2_i32;
+        let offset = 10_i32;
+        let total = width + offset; // 12
+        let mask = create_causal_mask_with_left_padding(width, offset, &[6, 0]);
+        assert_eq!(
+            ffi::array_shape(&mask),
+            vec![2, 1, width, total],
+            "verify left-padding mask must be [B, 1, width, offset+width]",
+        );
+
+        let cell = |b: i32, q: i32, k: i32| -> f32 {
+            ffi::item_f32(&ffi::slice(&mask, &[b, 0, q, k], &[b + 1, 1, q + 1, k + 1]))
+        };
+
+        // Row 0: the leading 6 padding columns must be masked for every query.
+        for q in 0..width {
+            for k in 0..6 {
+                let v = cell(0, q, k);
+                assert!(
+                    v.is_infinite() && v < 0.0,
+                    "row0 (lp=6) padding key {k} for query {q} must be -inf, got {v}",
+                );
+            }
+        }
+        // Row 0: real keys [6, offset) are in the causal past of both queries
+        // (query absolute positions are offset and offset+1) and must attend.
+        for q in 0..width {
+            for k in 6..offset {
+                let v = cell(0, q, k);
+                assert_eq!(
+                    v, 0.0,
+                    "row0 real key {k} for query {q} must attend (0.0), got {v}",
+                );
+            }
+        }
+        // Row 0: causal upper bound still holds for the appended query columns —
+        // query q (absolute offset+q) must not see future key offset+q+1.
+        assert!(
+            cell(0, 0, offset + 1).is_infinite() && cell(0, 0, offset + 1) < 0.0,
+            "row0 query 0 must not attend future key {}",
+            offset + 1,
+        );
+
+        // Row 1 (no padding): the same real-key columns are attended and no
+        // column is spuriously masked — the byte-identical baseline.
+        for q in 0..width {
+            for k in 0..=(offset + q) {
+                let v = cell(1, q, k);
+                assert_eq!(
+                    v, 0.0,
+                    "row1 (lp=0) key {k} for query {q} must attend (0.0), got {v}",
+                );
+            }
+        }
+    }
 }

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -236,16 +236,26 @@ pub fn create_causal_mask_with_left_padding(
 /// * **With padding**: `[B, 1, size, T_k]` where `B = left_padding.len()`. The
 ///   `[B, 1]` leading dims broadcast against a `[B, H, size, T_k]` score tensor.
 ///
-/// # Capped-window caveat
-/// When `size + offset > window` the underlying [`RotatingKVCache`] caps the K
-/// axis to the most-recent `window` slots, which re-indexes key positions and
-/// makes the left-padding column filter non-trivial. The ragged batched MTP
-/// caller therefore restricts itself to `max_prompt_len <= window` (the
-/// non-capped regime) and declines the burst window otherwise, so this helper's
-/// left-padding filter is only ever exercised in the non-capped path. The
-/// implementation still asserts the non-capped precondition in debug builds.
+/// # Full-key-axis precondition (not "size + offset <= window")
+/// The left-padding column filter assumes the K axis is the **full**
+/// `size + offset` (column `k` maps 1:1 to logical key position `k`). The
+/// sliding-window upper bound is enforced by an explicit `triu` band term, so
+/// `size + offset > window` is fully supported as long as the backing cache has
+/// not evicted/compacted any front keys. This is exactly the **MTP-buffered**
+/// sliding-cache regime: the `RotatingKVCache` rollback buffer (`buffer_size`)
+/// keeps the cache uncompacted up to a logical capacity of
+/// `window + buffer_size`, so the resident prompt padding at `[0, lp)` stays in
+/// the returned K and must keep being masked every verify step even once
+/// `size + offset > window`. (An earlier version asserted `size + offset <=
+/// window` and the Gemma 4 caller fell back to a padding-UNAWARE plain windowed
+/// mask above the window, which leaked the resident padding into the
+/// most-left-padded row and broke greedy parity.) The only unsupported case is a
+/// genuinely *compacted* axis (`actual_kv_len < size + offset`); the ragged
+/// caller never reaches buffer compaction in the eligible regime, and a
+/// compacted axis has already evicted the (oldest) padding so a plain windowed
+/// mask is padding-free there.
 ///
-/// Used by: ragged batched MTP prefill (Gemma 4 batched target adapter).
+/// Used by: ragged batched MTP prefill + verify (Gemma 4 batched target adapter).
 #[must_use]
 pub fn create_causal_mask_with_window_and_left_padding(
     size: i32,
@@ -262,16 +272,18 @@ pub fn create_causal_mask_with_window_and_left_padding(
 
     let uncapped_len = size + offset;
 
-    // The left-padding filter below assumes a non-capped key axis (column k maps
-    // 1:1 to logical key position k). The ragged batched MTP caller guarantees
-    // this by only forming ragged windows when `max_prompt_len <= window`.
-    debug_assert!(
-        window.map(|w| uncapped_len <= w).unwrap_or(true),
-        "create_causal_mask_with_window_and_left_padding: capped window \
-         (size + offset = {uncapped_len} > window) is unsupported; the caller \
-         must restrict ragged windows to the non-capped regime",
-    );
-
+    // Precondition: the **key axis is the full `size + offset`** (column k maps
+    // 1:1 to logical key position k), i.e. the backing cache has NOT evicted /
+    // compacted any front keys. The sliding-window upper bound is then enforced
+    // by the `triu` band term below, so `size + offset > window` is fully
+    // supported — this is the MTP-buffered sliding-cache regime, where the
+    // rollback buffer (`buffer_size`) keeps the cache uncompacted (logical
+    // capacity `window + buffer_size`) and the resident prompt padding at
+    // `[0, lp)` must keep being masked even though `size + offset > window`. The
+    // only unsupported case is a *compacted* axis (`actual_kv_len < size +
+    // offset`), which the ragged caller avoids: the eligible regime never
+    // reaches buffer compaction, and a compacted axis has already evicted the
+    // (oldest) padding so a plain windowed mask would be padding-free anyway.
     let total_len = uncapped_len;
 
     // ── Windowed causal (band) base mask, [size, total_len] ─────────────────
@@ -1202,6 +1214,78 @@ mod tests {
                     "row1 (lp=0) key {k} for query {q} must attend (0.0), got {v}",
                 );
             }
+        }
+    }
+
+    /// Ragged batched MTP **buffered sliding-cache** verify regression (issue
+    /// #161 / PR #162).
+    ///
+    /// The MTP rollback buffer keeps the sliding `RotatingKVCache` UNCOMPACTED
+    /// far past the bare `sliding_window` (logical capacity `window +
+    /// buffer_size`), so the resident prompt padding survives at columns
+    /// `[0, lp)` even when `size + offset > window`. The verify forward must
+    /// therefore use `create_causal_mask_with_window_and_left_padding` with the
+    /// FULL key axis (`size + offset`) in this regime — enforcing BOTH the
+    /// sliding-window band AND the `[0, lp)` padding filter. (The pre-fix gate
+    /// fell back to a padding-UNAWARE plain windowed mask once `size + offset >
+    /// window`, leaking the resident padding into the most-padded row.)
+    ///
+    /// This pins that, with `size + offset > window`, the most-padded row's
+    /// leading padding is masked, the in-window real keys attend, and keys
+    /// OLDER than the sliding window are excluded by the band.
+    #[test]
+    fn windowed_left_padding_mask_masks_padding_and_band_when_buffered_over_window() {
+        // Single verify query (width=1) at cache offset 11 (buffered: 7-token
+        // padded prompt + 4 accepted), window=8 -> size+offset=12 > window, but
+        // the buffered cache returns the full 12-key axis (no compaction).
+        // Row 0 (most padded): lp=5; row 1: lp=0.
+        let size = 1_i32;
+        let offset = 11_i32;
+        let window = 8_i32;
+        let total = size + offset; // 12
+        let mask = create_causal_mask_with_window_and_left_padding(size, offset, Some(window), &[5, 0]);
+        assert_eq!(
+            ffi::array_shape(&mask),
+            vec![2, 1, size, total],
+            "buffered windowed left-padding mask must keep the FULL [B,1,size,size+offset] axis",
+        );
+
+        let cell = |b: i32, k: i32| -> f32 {
+            ffi::item_f32(&ffi::slice(&mask, &[b, 0, 0, k], &[b + 1, 1, 1, k + 1]))
+        };
+
+        // The single query is at absolute position `offset` (= 11). Its
+        // sliding-window admits keys [offset - window + 1, offset] = [4, 11].
+        // Row 0 padding occupies [0, 5); the *intersection* of "real" and
+        // "in-window" is [5, 11].
+        for k in 0..5 {
+            let v = cell(0, k);
+            assert!(
+                v.is_infinite() && v < 0.0,
+                "row0 padding key {k} must be -inf, got {v}",
+            );
+        }
+        // Key 4 is real but OUTSIDE the sliding window (4 < offset-window+1 = 4?
+        // 11-8+1 = 4, so key 4 is the oldest in-window slot) -> attends. Keys
+        // [4, 11] attend; here [5, 11] are real+in-window (key 4 is padding-free
+        // only for row 1).
+        for k in 5..=offset {
+            let v = cell(0, k);
+            assert_eq!(v, 0.0, "row0 real in-window key {k} must attend, got {v}");
+        }
+
+        // Row 1 (no padding): the sliding-window band excludes keys older than
+        // `offset - window + 1` = 4, i.e. keys [0, 4) are -inf, [4, 11] attend.
+        for k in 0..(offset - window + 1) {
+            let v = cell(1, k);
+            assert!(
+                v.is_infinite() && v < 0.0,
+                "row1 out-of-window key {k} must be -inf (sliding band), got {v}",
+            );
+        }
+        for k in (offset - window + 1)..=offset {
+            let v = cell(1, k);
+            assert_eq!(v, 0.0, "row1 in-window key {k} must attend, got {v}");
         }
     }
 }

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -36,7 +36,8 @@ use mlxcel_core::layers::{
     compiled_gelu_mlp_fp16,
 };
 use mlxcel_core::utils::{
-    create_causal_mask, create_causal_mask_with_window, pipeline_hint, slice_axis,
+    create_causal_mask, create_causal_mask_with_left_padding, create_causal_mask_with_window,
+    create_causal_mask_with_window_and_left_padding, pipeline_hint, slice_axis,
 };
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
@@ -1754,6 +1755,7 @@ impl Gemma4TextModel {
             None,
             false,
             None,
+            None,
         )
     }
 
@@ -1794,6 +1796,7 @@ impl Gemma4TextModel {
         mut sinks: Option<&mut Gemma4SpeculativeSinks>,
         skip_final_norm: bool,
         bidirectional_block_ids: Option<&MlxArray>,
+        left_padding: Option<&[i32]>,
     ) -> UniquePtr<MlxArray> {
         // When `input_embeddings` is supplied (e.g. from the VLM path where
         // vision/audio features have already been merged into the embedding
@@ -1829,17 +1832,68 @@ impl Gemma4TextModel {
         } else if l > 1 {
             let global_offset = first_cache_offset(caches, "full_attention");
             let sliding_offset = first_cache_offset(caches, "sliding_attention");
-            let sliding_effective_offset =
-                sliding_offset.min((self.config.sliding_window as i32 - l).max(0));
+            let window = self.config.sliding_window as i32;
+            let sliding_effective_offset = sliding_offset.min((window - l).max(0));
 
-            (
-                Some(create_causal_mask(l, global_offset)),
-                Some(create_causal_mask_with_window(
-                    l,
-                    sliding_effective_offset,
-                    Some(self.config.sliding_window as i32),
-                )),
-            )
+            // Ragged batched MTP (variable-length B>1 burst) threads the per-row
+            // leading-padding column count so the verify forward masks each
+            // row's `[0, left_padding[r])` padding keys — exactly as the ragged
+            // prefill does. Without this the verify query attends the prompt's
+            // padding K/V (token 0), which is retained in the unbounded
+            // full-attention cache forever and breaks greedy parity for the
+            // most-left-padded row (the error scales with `left_padding[r]`).
+            //
+            // When `left_padding` is absent or all-zero (every non-ragged path,
+            // including the equal-length batched burst and ordinary decode) this
+            // is byte-identical to the plain causal / windowed masks below.
+            let has_padding = left_padding
+                .map(|lp| lp.iter().any(|&p| p > 0))
+                .unwrap_or(false);
+
+            if has_padding {
+                let lp = left_padding.expect("has_padding implies Some");
+                // Full attention never evicts the padding (unbounded KVCache), so
+                // it always needs the per-row left-padding column filter.
+                let global_mask = create_causal_mask_with_left_padding(l, global_offset, lp);
+                // The sliding (RotatingKVCache) cache only retains the padding
+                // while it has not yet wrapped past it. `sliding_offset + l <=
+                // window` is the non-capped condition (matching
+                // `create_causal_mask_with_window_and_left_padding`'s own
+                // precondition): the key axis is still the full
+                // `[0, sliding_offset + l)` and column k maps 1:1 to logical key
+                // position k, so the left-padding column filter is valid. The
+                // ragged-burst eligibility gate (`max_prompt_len <=
+                // sliding_window`) plus realistic generation lengths keep the
+                // SWA cache non-capped for the whole burst, so this branch is
+                // the one actually exercised. Once the cache wraps (capped
+                // regime), the oldest keys — the padding `[0, lp)` first — are
+                // evicted, so the plain windowed mask is padding-free and
+                // matches the row's standalone B=1 SWA window. (The narrow wrap
+                // transition `window < sliding_offset + l < window + lp`, where
+                // a residual padding tail briefly survives in the capped buffer,
+                // only occurs for pathologically long outputs that the eligible
+                // regime does not reach.)
+                let sliding_mask = if sliding_offset + l <= window {
+                    create_causal_mask_with_window_and_left_padding(
+                        l,
+                        sliding_effective_offset,
+                        Some(window),
+                        lp,
+                    )
+                } else {
+                    create_causal_mask_with_window(l, sliding_effective_offset, Some(window))
+                };
+                (Some(global_mask), Some(sliding_mask))
+            } else {
+                (
+                    Some(create_causal_mask(l, global_offset)),
+                    Some(create_causal_mask_with_window(
+                        l,
+                        sliding_effective_offset,
+                        Some(window),
+                    )),
+                )
+            }
         } else {
             (None, None)
         };
@@ -2297,6 +2351,7 @@ impl Gemma4Model {
             None,
             false,
             bidirectional_block_ids,
+            None,
         );
         let mut logits = self.text_model.embed_tokens.as_linear(&hidden);
         if let Some(cap) = self.config.final_logit_softcapping {
@@ -2314,6 +2369,7 @@ impl Gemma4Model {
     /// `sinks` is `None`.
     ///
     /// Used by: [`Gemma4Wrapper::forward_with_speculative_sinks`].
+    #[allow(clippy::too_many_arguments)]
     fn forward_with_caches_and_speculative_sinks(
         &self,
         input_ids: &MlxArray,
@@ -2323,6 +2379,7 @@ impl Gemma4Model {
         per_layer_inputs: Option<&MlxArray>,
         capture_layer_ids: Option<&[usize]>,
         sinks: Option<&mut Gemma4SpeculativeSinks>,
+        left_padding: Option<&[i32]>,
     ) -> UniquePtr<MlxArray> {
         let hidden = self.text_model.forward_with_speculative_sinks(
             input_ids,
@@ -2334,6 +2391,7 @@ impl Gemma4Model {
             sinks,
             false,
             None,
+            left_padding,
         );
         let mut logits = self.text_model.embed_tokens.as_linear(&hidden);
         if let Some(cap) = self.config.final_logit_softcapping {
@@ -2347,6 +2405,7 @@ impl Gemma4Model {
     /// Used by: Gemma 4 MTP deferred greedy verification, which needs the
     /// pre-norm hidden states and shared K/V slabs but can project only the
     /// positions required by the speculative walk.
+    #[allow(clippy::too_many_arguments)]
     fn forward_hidden_with_caches_and_speculative_sinks(
         &self,
         input_ids: &MlxArray,
@@ -2357,6 +2416,7 @@ impl Gemma4Model {
         capture_layer_ids: Option<&[usize]>,
         sinks: Option<&mut Gemma4SpeculativeSinks>,
         skip_final_norm: bool,
+        left_padding: Option<&[i32]>,
     ) -> UniquePtr<MlxArray> {
         self.text_model.forward_with_speculative_sinks(
             input_ids,
@@ -2368,6 +2428,7 @@ impl Gemma4Model {
             sinks,
             skip_final_norm,
             None,
+            left_padding,
         )
     }
 
@@ -3165,6 +3226,7 @@ impl Gemma4Wrapper {
                     per_layer_inputs,
                     capture_layer_ids,
                     sinks,
+                    None,
                 )
             },
         )
@@ -3189,6 +3251,7 @@ impl Gemma4Wrapper {
     /// projection.
     ///
     /// Used by: [`crate::models::gemma4_mtp_target::Gemma4MtpBatchedTargetAdapter`].
+    #[allow(clippy::too_many_arguments)]
     pub fn forward_with_speculative_sinks_explicit_cache(
         &self,
         input_ids: &MlxArray,
@@ -3198,6 +3261,7 @@ impl Gemma4Wrapper {
         caches: &mut [Cache],
         capture_layer_ids: Option<&[usize]>,
         sinks: Option<&mut Gemma4SpeculativeSinks>,
+        left_padding: Option<&[i32]>,
     ) -> UniquePtr<MlxArray> {
         self.model.forward_with_caches_and_speculative_sinks(
             input_ids,
@@ -3207,6 +3271,7 @@ impl Gemma4Wrapper {
             per_layer_inputs,
             capture_layer_ids,
             sinks,
+            left_padding,
         )
     }
 
@@ -3238,6 +3303,7 @@ impl Gemma4Wrapper {
                     capture_layer_ids,
                     sinks,
                     skip_final_norm,
+                    None,
                 )
             },
         )

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -3052,6 +3052,16 @@ impl Gemma4Wrapper {
         self.model.text_model.layers.len()
     }
 
+    /// Sliding-window size of the sliding-attention layers.
+    ///
+    /// Used by the ragged batched MTP target adapter to gate variable-length
+    /// prefill eligibility: ragged left-padded prefill is only admitted when
+    /// `max_prompt_len <= sliding_window` (the non-capped RotatingKVCache
+    /// regime), where the windowed left-padding mask is well-defined.
+    pub(crate) fn sliding_window_value(&self) -> usize {
+        self.model.config.sliding_window
+    }
+
     pub(crate) fn eos_token_ids_value(&self) -> Vec<i32> {
         self.model.eos_token_ids.clone()
     }

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -1827,74 +1827,80 @@ impl Gemma4TextModel {
             None
         };
 
+        // Ragged batched MTP (variable-length B>1 burst) threads the per-row
+        // leading-padding column count so EVERY verify step masks each row's
+        // `[0, left_padding[r])` resident prompt padding. Without this the
+        // verify query attends the prompt's padding K/V (token 0) and breaks
+        // greedy parity for the most-left-padded row (the error scales with
+        // `left_padding[r]`). This MUST be honoured for single-token decode
+        // steps (`l == 1`) too, not only multi-token verify blocks — the
+        // padding stays resident in both the unbounded full-attention cache and
+        // the MTP-buffered sliding cache, so an `l == 1` step that took the
+        // `mask == None` fast path would silently attend it.
+        let has_padding = left_padding
+            .map(|lp| lp.iter().any(|&p| p > 0))
+            .unwrap_or(false);
+
         let (global_mask, sliding_mask) = if let Some(mask) = mask {
             (Some(mlxcel_core::copy(mask)), Some(mlxcel_core::copy(mask)))
+        } else if has_padding {
+            // Resident prompt padding present (ragged burst). Build per-row
+            // left-padding-aware masks for ANY query width, including `l == 1`.
+            let global_offset = first_cache_offset(caches, "full_attention");
+            let sliding_offset = first_cache_offset(caches, "sliding_attention");
+            let window = self.config.sliding_window as i32;
+            let lp = left_padding.expect("has_padding implies Some");
+
+            // Full attention: unbounded KVCache keeps the padding at columns
+            // `[0, lp)` for the whole run; mask it with the plain left-padding
+            // causal mask sized to the full key axis (`l + global_offset`).
+            let global_mask = create_causal_mask_with_left_padding(l, global_offset, lp);
+
+            // Sliding attention: the MTP rollback buffer (`buffer_size`) keeps
+            // the cache *uncompacted* far past the bare `sliding_window` — its
+            // logical capacity is `sliding_window + buffer_size` — so the
+            // resident prompt padding survives at columns `[0, lp)` long after
+            // `sliding_offset + l > sliding_window`. The previous gate
+            // (`sliding_offset + l <= window` -> windowed-left-padding mask,
+            // else a padding-UNAWARE plain windowed mask) therefore stopped
+            // masking the padding exactly when it was still resident, leaking
+            // `lp` padding keys into the most-padded row's window every verify
+            // step. While the buffer has not compacted, the key axis is the full
+            // `[0, sliding_offset + l)` (no eviction), so the windowed
+            // left-padding mask — which enforces both the sliding-window band
+            // (`tril(offset)` ∩ `triu(offset - window + 1)`) AND the `[0, lp)`
+            // padding filter — is the correct mask for `sliding_offset + l >
+            // window` too. The eligible regime (`max_prompt_len <=
+            // sliding_window`, realistic output lengths) never reaches the
+            // buffer-compaction point, so the full key axis always holds; if the
+            // cache ever did compact, the oldest keys (padding first) would be
+            // evicted and `trim_mask_to_keys` would crop the mask to the
+            // surviving (padding-free) suffix.
+            let sliding_mask = create_causal_mask_with_window_and_left_padding(
+                l,
+                sliding_offset,
+                Some(window),
+                lp,
+            );
+            (Some(global_mask), Some(sliding_mask))
         } else if l > 1 {
+            // Non-ragged prefill / multi-token verify: derive both masks from
+            // the cache offsets (byte-identical to the pre-ragged behaviour).
             let global_offset = first_cache_offset(caches, "full_attention");
             let sliding_offset = first_cache_offset(caches, "sliding_attention");
             let window = self.config.sliding_window as i32;
             let sliding_effective_offset = sliding_offset.min((window - l).max(0));
-
-            // Ragged batched MTP (variable-length B>1 burst) threads the per-row
-            // leading-padding column count so the verify forward masks each
-            // row's `[0, left_padding[r])` padding keys — exactly as the ragged
-            // prefill does. Without this the verify query attends the prompt's
-            // padding K/V (token 0), which is retained in the unbounded
-            // full-attention cache forever and breaks greedy parity for the
-            // most-left-padded row (the error scales with `left_padding[r]`).
-            //
-            // When `left_padding` is absent or all-zero (every non-ragged path,
-            // including the equal-length batched burst and ordinary decode) this
-            // is byte-identical to the plain causal / windowed masks below.
-            let has_padding = left_padding
-                .map(|lp| lp.iter().any(|&p| p > 0))
-                .unwrap_or(false);
-
-            if has_padding {
-                let lp = left_padding.expect("has_padding implies Some");
-                // Full attention never evicts the padding (unbounded KVCache), so
-                // it always needs the per-row left-padding column filter.
-                let global_mask = create_causal_mask_with_left_padding(l, global_offset, lp);
-                // The sliding (RotatingKVCache) cache only retains the padding
-                // while it has not yet wrapped past it. `sliding_offset + l <=
-                // window` is the non-capped condition (matching
-                // `create_causal_mask_with_window_and_left_padding`'s own
-                // precondition): the key axis is still the full
-                // `[0, sliding_offset + l)` and column k maps 1:1 to logical key
-                // position k, so the left-padding column filter is valid. The
-                // ragged-burst eligibility gate (`max_prompt_len <=
-                // sliding_window`) plus realistic generation lengths keep the
-                // SWA cache non-capped for the whole burst, so this branch is
-                // the one actually exercised. Once the cache wraps (capped
-                // regime), the oldest keys — the padding `[0, lp)` first — are
-                // evicted, so the plain windowed mask is padding-free and
-                // matches the row's standalone B=1 SWA window. (The narrow wrap
-                // transition `window < sliding_offset + l < window + lp`, where
-                // a residual padding tail briefly survives in the capped buffer,
-                // only occurs for pathologically long outputs that the eligible
-                // regime does not reach.)
-                let sliding_mask = if sliding_offset + l <= window {
-                    create_causal_mask_with_window_and_left_padding(
-                        l,
-                        sliding_effective_offset,
-                        Some(window),
-                        lp,
-                    )
-                } else {
-                    create_causal_mask_with_window(l, sliding_effective_offset, Some(window))
-                };
-                (Some(global_mask), Some(sliding_mask))
-            } else {
-                (
-                    Some(create_causal_mask(l, global_offset)),
-                    Some(create_causal_mask_with_window(
-                        l,
-                        sliding_effective_offset,
-                        Some(window),
-                    )),
-                )
-            }
+            (
+                Some(create_causal_mask(l, global_offset)),
+                Some(create_causal_mask_with_window(
+                    l,
+                    sliding_effective_offset,
+                    Some(window),
+                )),
+            )
         } else {
+            // Ordinary single-token decode with no resident padding: the
+            // attention kernels derive their own causal / windowed masks.
             (None, None)
         };
 

--- a/src/models/gemma4_mtp_target.rs
+++ b/src/models/gemma4_mtp_target.rs
@@ -1177,25 +1177,51 @@ impl<'a> Gemma4MtpBatchedTargetAdapter<'a> {
         UniquePtr<MlxArray>,
         Vec<UniquePtr<MlxArray>>,
     ) {
-        self.batched_sink_forward_with_mask(input_arr, None)
+        // Verify rounds (and the equal-length prefill) take the `mask == None`
+        // path, where the forward derives both attention-family masks from the
+        // cache offsets. For a ragged burst the prompt's per-row leading
+        // padding is still resident in the shared cache, so we thread the
+        // stashed per-row `left_padding` so the verify forward masks each row's
+        // `[0, left_padding[r])` padding keys — without it the verify query
+        // attends the padding K/V and breaks greedy parity for the
+        // most-left-padded row. For the equal-length path `left_padding` is
+        // all-zero, so the forward takes its byte-identical plain-mask branch.
+        let left_padding: Vec<i32> = self
+            .left_padding
+            .borrow()
+            .iter()
+            .map(|&p| p as i32)
+            .collect();
+        let lp_ref: Option<&[i32]> = if left_padding.iter().any(|&p| p > 0) {
+            Some(&left_padding)
+        } else {
+            None
+        };
+        self.batched_sink_forward_with_mask(input_arr, None, lp_ref)
     }
 
     /// Sink-aware batched forward with an optional explicit attention mask.
     ///
-    /// `mask` is `None` for the equal-length path (the forward derives both the
-    /// full-attention and sliding-window causal masks from `offset == 0`). For
-    /// the ragged (variable-length) prefill the caller passes a single
-    /// **left-padding** causal mask: in the eligible regime
-    /// (`max_prompt_len <= sliding_window`, non-capped key axis) the windowed
-    /// left-padding mask is byte-identical to the plain left-padding mask, so
-    /// one `[B, 1, max_len, max_len]` mask is correct for *both* the
-    /// full-attention and sliding-window layers (the forward copies the single
-    /// mask into both slots). This equivalence is unit-tested in
+    /// `mask` is `None` for the equal-length path and for every verify round
+    /// (the forward derives both the full-attention and sliding-window causal
+    /// masks from the cache offsets). In the `mask == None` path, `left_padding`
+    /// (per-row leading padding columns) is threaded so the verify forward masks
+    /// each ragged row's resident `[0, left_padding[r])` padding keys; it is
+    /// `None` / all-zero for the equal-length path (byte-identical plain masks).
+    ///
+    /// For the ragged **prefill** the caller instead passes a single explicit
+    /// **left-padding** causal mask (with `left_padding == None`): in the
+    /// eligible regime (`max_prompt_len <= sliding_window`, non-capped key axis)
+    /// the windowed left-padding mask is byte-identical to the plain
+    /// left-padding mask, so one `[B, 1, max_len, max_len]` mask is correct for
+    /// *both* the full-attention and sliding-window layers (the forward copies
+    /// the single mask into both slots). This equivalence is unit-tested in
     /// `mlxcel_core::utils` (`windowed_left_padding_mask_matches_plain_left_padding_when_uncapped`).
     fn batched_sink_forward_with_mask(
         &self,
         input_arr: &MlxArray,
         mask: Option<&MlxArray>,
+        left_padding: Option<&[i32]>,
     ) -> (
         UniquePtr<MlxArray>,
         UniquePtr<MlxArray>,
@@ -1212,6 +1238,7 @@ impl<'a> Gemma4MtpBatchedTargetAdapter<'a> {
                 &mut caches,
                 BATCHED_CAPTURE_LAYER_IDS,
                 Some(&mut sinks),
+                left_padding,
             )
         };
 
@@ -1401,8 +1428,13 @@ impl<'a> Gemma4MtpBatchedTargetAdapter<'a> {
             &left_padding_i32,
         );
 
-        let (logits, hidden_full, shared_kv) =
-            self.batched_sink_forward_with_mask(&prompt_arr, Some(mask.as_ref().unwrap()));
+        let (logits, hidden_full, shared_kv) = self.batched_sink_forward_with_mask(
+            &prompt_arr,
+            Some(mask.as_ref().unwrap()),
+            // Prefill passes an explicit left-padding mask above, so the
+            // `mask == None` left-padding plumbing is not needed here.
+            None,
+        );
         self.enable_rotating_cache_buffer();
 
         // Every row's last real token sits at the shared padded index

--- a/src/models/gemma4_mtp_target.rs
+++ b/src/models/gemma4_mtp_target.rs
@@ -101,6 +101,20 @@ fn mtp_draft_position(kv_valid_len: usize) -> usize {
     kv_valid_len.saturating_sub(1)
 }
 
+/// Output of [`Gemma4MtpBatchedTargetAdapter::left_padded_input`].
+///
+/// Carries the left-padded `[B, max_len]` prefill tensor plus the per-row
+/// padding bookkeeping the ragged prefill seed needs:
+/// - `max_len`: padded prompt width (= `max(prompt_len)` across the window).
+/// - `left_padding[r]`: leading padding columns for row `r` (`max_len - L_r`).
+/// - `valid_len[r]`: row `r`'s real prompt length `L_r`.
+struct LeftPaddedPrefill {
+    arr: UniquePtr<MlxArray>,
+    max_len: usize,
+    left_padding: Vec<usize>,
+    valid_len: Vec<usize>,
+}
+
 /// Upstream mlx-vlm buffers Gemma 4 MTP rotating target caches by
 /// `max(32, min(128, max(configured, requested) * 8))` tokens. The Rust
 /// adapter receives the effective requested block size from the server-side
@@ -887,11 +901,21 @@ pub struct Gemma4MtpBatchedTargetAdapter<'a> {
     batch_size: usize,
     /// Buffered rotating-cache slack for MTP verify append + rollback.
     rotating_buffer_size: i32,
-    /// Per-row logical target cache lengths. The physical cache offset is
-    /// the global max after rollback, but shorter rows have their tails
-    /// zeroed and must pass their own valid length to the drafter masks and
-    /// RoPE anchor.
+    /// Per-row logical target cache lengths (= each row's `kv_valid_len`). The
+    /// physical cache offset is the global max after rollback, but shorter rows
+    /// have their tails zeroed and must pass their own valid length to the
+    /// drafter masks and RoPE anchor. For the equal-length path every entry
+    /// equals the shared prompt length; for the ragged (left-padded) path each
+    /// entry is the row's unpadded prompt length plus the tokens accepted so
+    /// far.
     positions: RefCell<Vec<usize>>,
+    /// Per-row left-padding extent in the shared K/V seq-len axis. `0` for every
+    /// row on the equal-length path; `max_prompt_len - prompt_len[r]` on the
+    /// ragged path, constant across the whole burst (the prompt's leading
+    /// padding is never trimmed). Threaded into every seed so the drafter rolls
+    /// each row's K/V into the prefix-valid layout and rotates queries in the
+    /// row's shifted frame.
+    left_padding: RefCell<Vec<usize>>,
 }
 
 impl<'a> Gemma4MtpBatchedTargetAdapter<'a> {
@@ -923,6 +947,7 @@ impl<'a> Gemma4MtpBatchedTargetAdapter<'a> {
             batch_size,
             rotating_buffer_size,
             positions: RefCell::new(vec![0; batch_size]),
+            left_padding: RefCell::new(vec![0; batch_size]),
         }
     }
 
@@ -976,6 +1001,69 @@ impl<'a> Gemma4MtpBatchedTargetAdapter<'a> {
         }
         let arr = mlxcel_core::from_slice_i32(&flat, &[expected_batch as i32, width as i32]);
         Ok((arr, width as i32))
+    }
+
+    /// Build a **left-padded** `[B, max_prompt_len]` i32 tensor from per-row
+    /// prompt slices of (possibly) different lengths, returning the padded
+    /// tensor plus per-row `(max_len, left_padding, valid_len)` metadata.
+    ///
+    /// Row `r` (length `L_r`) is placed at padded indices
+    /// `[max_len - L_r, max_len)`; the leading `left_padding[r] = max_len - L_r`
+    /// columns hold a padding token (`0`). Left-padding is the parity-preserving
+    /// layout: every real token in a row is shifted right by the same constant
+    /// `left_padding[r]`, so the proportional-RoPE phase applied uniformly across
+    /// the batch (scalar offset `0` → position == padded index) preserves every
+    /// intra-row relative position. The leading padding columns are masked out by
+    /// the caller-supplied left-padding attention mask, so they never affect any
+    /// real query's output, and each row's last real token lands at the shared
+    /// padded index `max_len - 1` (so the seed bonus is sampled from the uniform
+    /// last position, exactly as the equal-length path does).
+    ///
+    /// Returns `Err` on batch-size mismatch or an empty / zero-length row.
+    fn left_padded_input(
+        per_row: &[Vec<i32>],
+        expected_batch: usize,
+    ) -> Result<LeftPaddedPrefill, DrafterError> {
+        if per_row.len() != expected_batch {
+            return Err(DrafterError::DraftFailed {
+                reason: format!(
+                    "Gemma4 batched MTP target: expected {expected_batch} rows, got {}",
+                    per_row.len()
+                ),
+            });
+        }
+        if per_row.is_empty() {
+            return Err(DrafterError::DraftFailed {
+                reason: "Gemma4 batched MTP target: empty batch".to_string(),
+            });
+        }
+        let mut max_len = 0usize;
+        for (r, row) in per_row.iter().enumerate() {
+            if row.is_empty() {
+                return Err(DrafterError::DraftFailed {
+                    reason: format!("Gemma4 batched MTP target: prompt row {r} must be non-empty"),
+                });
+            }
+            max_len = max_len.max(row.len());
+        }
+
+        let mut flat: Vec<i32> = vec![0; expected_batch * max_len];
+        let mut left_padding: Vec<usize> = Vec::with_capacity(expected_batch);
+        let mut valid_len: Vec<usize> = Vec::with_capacity(expected_batch);
+        for (r, row) in per_row.iter().enumerate() {
+            let lp = max_len - row.len();
+            let base = r * max_len + lp;
+            flat[base..base + row.len()].copy_from_slice(row);
+            left_padding.push(lp);
+            valid_len.push(row.len());
+        }
+        let arr = mlxcel_core::from_slice_i32(&flat, &[expected_batch as i32, max_len as i32]);
+        Ok(LeftPaddedPrefill {
+            arr,
+            max_len,
+            left_padding,
+            valid_len,
+        })
     }
 
     /// Per-row argmax over a `[B, width, vocab]` logits tensor.
@@ -1050,6 +1138,30 @@ impl<'a> Gemma4MtpBatchedTargetAdapter<'a> {
         UniquePtr<MlxArray>,
         Vec<UniquePtr<MlxArray>>,
     ) {
+        self.batched_sink_forward_with_mask(input_arr, None)
+    }
+
+    /// Sink-aware batched forward with an optional explicit attention mask.
+    ///
+    /// `mask` is `None` for the equal-length path (the forward derives both the
+    /// full-attention and sliding-window causal masks from `offset == 0`). For
+    /// the ragged (variable-length) prefill the caller passes a single
+    /// **left-padding** causal mask: in the eligible regime
+    /// (`max_prompt_len <= sliding_window`, non-capped key axis) the windowed
+    /// left-padding mask is byte-identical to the plain left-padding mask, so
+    /// one `[B, 1, max_len, max_len]` mask is correct for *both* the
+    /// full-attention and sliding-window layers (the forward copies the single
+    /// mask into both slots). This equivalence is unit-tested in
+    /// `mlxcel_core::utils` (`windowed_left_padding_mask_matches_plain_left_padding_when_uncapped`).
+    fn batched_sink_forward_with_mask(
+        &self,
+        input_arr: &MlxArray,
+        mask: Option<&MlxArray>,
+    ) -> (
+        UniquePtr<MlxArray>,
+        UniquePtr<MlxArray>,
+        Vec<UniquePtr<MlxArray>>,
+    ) {
         let mut sinks = Gemma4SpeculativeSinks::with_hidden_and_shared_kv();
         let logits = {
             let mut caches = self.caches.borrow_mut();
@@ -1057,7 +1169,7 @@ impl<'a> Gemma4MtpBatchedTargetAdapter<'a> {
                 input_arr,
                 None,
                 None,
-                None,
+                mask,
                 &mut caches,
                 BATCHED_CAPTURE_LAYER_IDS,
                 Some(&mut sinks),
@@ -1171,6 +1283,155 @@ impl<'a> Gemma4MtpBatchedTargetAdapter<'a> {
             .wrapper
             .speculative_draft_hidden(hidden.as_ref().unwrap()))
     }
+
+    /// Variable-length-prompt (ragged) prefill + seed.
+    ///
+    /// Left-pads every row to `max_prompt_len`, runs one sink-aware forward
+    /// with a per-row left-padding causal mask, and emits per-row seed metadata
+    /// so each row's later verify rounds and drafter cross-attention stay
+    /// byte-identical to that row's standalone B = 1 run.
+    ///
+    /// ## Greedy-parity mechanism (left-padding uniform shift)
+    ///
+    /// Row `r` (length `L_r`) is placed at padded indices `[lp_r, max_len)`
+    /// with `lp_r = max_len - L_r`. Proportional RoPE is applied with a single
+    /// scalar offset (`0` at prefill), so a token at padded index `i` is rotated
+    /// to absolute position `i`. Every real token of row `r` is therefore
+    /// shifted right by the same constant `lp_r` versus a standalone run that
+    /// would place it at `[0, L_r)`. Because attention depends only on the
+    /// *relative* RoPE phase `q_pos - k_pos`, and both query and key of any
+    /// in-row pair carry the same `+lp_r` shift, every in-row relative phase —
+    /// and thus every attention score and every argmax — is preserved. The
+    /// left-padding mask blocks all real queries from attending to the leading
+    /// padding keys, so padding contributes nothing. In subsequent verify
+    /// rounds the shared physical cache offset is `max_len` for every row, so
+    /// each row's appended verify tokens land at absolute positions
+    /// `max_len + j`, again a uniform `+lp_r` shift versus the standalone
+    /// `L_r + j` — parity is preserved end-to-end.
+    ///
+    /// Consequently the seed's `kv_offset_per_row` and `bonus_position_per_row`
+    /// are **uniform** (`max_len` / `max_len - 1`, the padded frame), while
+    /// `left_padding_per_row[r] = lp_r` and `kv_valid_len_per_row[r] = L_r` are
+    /// per-row. The drafter's `set_shared_kv_batched` consumes the per-row
+    /// left-padding / valid-length to left-roll each row's shared K/V into the
+    /// prefix-valid layout (`normalize_batched_shared_kv_states`) and mask the
+    /// padded tail.
+    ///
+    /// ## Eligibility
+    ///
+    /// Restricted to `max_prompt_len <= sliding_window` (non-capped
+    /// RotatingKVCache regime). In that regime the windowed left-padding mask is
+    /// byte-identical to the plain left-padding mask, so the single mask passed
+    /// to the forward is correct for both full-attention and sliding-window
+    /// layers. Outside it, the function returns `Err(DrafterError::DraftFailed)`
+    /// so the burst driver declines the window and the scheduler re-enqueues the
+    /// rows for per-row B = 1 service.
+    fn prefill_and_seed_batched_ragged(
+        &self,
+        prompt_tokens_per_row: &[Vec<i32>],
+        sampler: &SamplingConfig,
+    ) -> Result<(Vec<i32>, MtpBatchedVerifyOutput), DrafterError> {
+        let LeftPaddedPrefill {
+            arr: prompt_arr,
+            max_len,
+            left_padding,
+            valid_len,
+        } = Self::left_padded_input(prompt_tokens_per_row, self.batch_size)?;
+
+        // Eligibility: only the non-capped sliding-window regime is supported.
+        let sliding_window = self.wrapper.sliding_window_value();
+        if sliding_window > 0 && max_len > sliding_window {
+            return Err(DrafterError::DraftFailed {
+                reason: format!(
+                    "Gemma4 ragged batched MTP prefill declined: max_prompt_len {max_len} \
+                     exceeds sliding_window {sliding_window} (capped RotatingKVCache regime is \
+                     not supported by the windowed left-padding mask); falling back to per-row \
+                     B=1 service"
+                ),
+            });
+        }
+
+        // Build the per-row left-padding causal mask `[B, 1, max_len, max_len]`.
+        // In the eligible non-capped regime this is correct for both the
+        // full-attention and sliding-window layers (proven equivalent to the
+        // windowed left-padding mask in `mlxcel_core::utils`).
+        let left_padding_i32: Vec<i32> = left_padding.iter().map(|&p| p as i32).collect();
+        let mask = mlxcel_core::utils::create_causal_mask_with_left_padding(
+            max_len as i32,
+            0,
+            &left_padding_i32,
+        );
+
+        let (logits, hidden_full, shared_kv) =
+            self.batched_sink_forward_with_mask(&prompt_arr, Some(mask.as_ref().unwrap()));
+        self.enable_rotating_cache_buffer();
+
+        // Every row's last real token sits at the shared padded index
+        // `max_len - 1` (left-padding right-aligns the prompts), so the seed
+        // bonus is sampled from the uniform last position — the same op
+        // sequence as the equal-length path. At temperature 0 each row's bonus
+        // is byte-identical to that row's standalone B = 1 seed.
+        let (token_arr, _) = sample_token_optimized(&logits, sampler, &[]);
+        mlxcel_core::eval(&token_arr);
+        let first_bonus_per_row = scalar_tokens_per_row(&token_arr, self.batch_size);
+
+        let next_hidden = self.last_position_draft_hidden(&hidden_full);
+
+        // Stash per-row logical valid lengths (= unpadded prompt lengths) and
+        // the constant per-row left-padding for the verify-round bookkeeping in
+        // `verify_finalize_batched`. The physical/padded anchors are uniform at
+        // `max_len`; only `kv_valid_len` and `left_padding` are per-row.
+        {
+            let mut positions = self.positions.borrow_mut();
+            *positions = valid_len.clone();
+        }
+        {
+            let mut lp = self.left_padding.borrow_mut();
+            *lp = left_padding.clone();
+        }
+        let seed = self.build_seed_metadata(next_hidden, shared_kv, &valid_len, &left_padding);
+        Ok((first_bonus_per_row, seed))
+    }
+
+    /// Assemble the per-row seed/finalize metadata from each row's logical
+    /// `kv_valid_len` and constant `left_padding`, using the uniform shifted-
+    /// frame formula that keeps both the equal-length and ragged paths
+    /// byte-identical to standalone B = 1 runs:
+    ///
+    /// - `kv_valid_len[r]` — count of real K/V entries (prompt + accepted).
+    /// - `left_padding[r]` — leading padding columns (constant per burst).
+    /// - `kv_offset[r] = left_padding[r] + kv_valid_len[r]` — physical/padded
+    ///   absolute offset (the drafter's RoPE frame for row `r`).
+    /// - `bonus_position[r] = kv_offset[r] - 1` — the row's frozen bonus anchor.
+    ///
+    /// For the equal-length path `left_padding[r] == 0`, so this reduces to
+    /// `kv_offset == kv_valid_len == positions[r]` and `bonus_position ==
+    /// positions[r] - 1` — exactly the legacy equal-length metadata.
+    fn build_seed_metadata(
+        &self,
+        next_hidden: UniquePtr<MlxArray>,
+        next_shared_kv: Vec<UniquePtr<MlxArray>>,
+        kv_valid_len: &[usize],
+        left_padding: &[usize],
+    ) -> MtpBatchedVerifyOutput {
+        let kv_offset_per_row: Vec<usize> = kv_valid_len
+            .iter()
+            .zip(left_padding)
+            .map(|(&valid, &lp)| lp + valid)
+            .collect();
+        let bonus_position_per_row: Vec<usize> = kv_offset_per_row
+            .iter()
+            .map(|&offset| mtp_draft_position(offset))
+            .collect();
+        MtpBatchedVerifyOutput {
+            next_hidden,
+            next_shared_kv,
+            kv_offset_per_row,
+            bonus_position_per_row,
+            kv_valid_len_per_row: kv_valid_len.to_vec(),
+            left_padding_per_row: left_padding.to_vec(),
+        }
+    }
 }
 
 impl<'a> MtpTarget for Gemma4MtpBatchedTargetAdapter<'a> {
@@ -1246,10 +1507,18 @@ impl<'a> MtpTarget for Gemma4MtpBatchedTargetAdapter<'a> {
         prompt_tokens_per_row: &[Vec<i32>],
         sampler: &SamplingConfig,
     ) -> Result<(Vec<i32>, MtpBatchedVerifyOutput), DrafterError> {
-        // Build the rectangular [B, L] prompt batch. `rectangular_input`
-        // rejects variable-length rows — the burst-window collector only
-        // groups equal-length prompts for the batched path (see the
-        // struct docstring).
+        // Route by prompt-length uniformity. Equal-length rows take the
+        // original rectangular [B, L] prefill (mask derived internally from
+        // offset 0); variable-length rows take the left-padding path.
+        let first_len = prompt_tokens_per_row.first().map(Vec::len).unwrap_or(0);
+        let is_ragged = prompt_tokens_per_row
+            .iter()
+            .any(|row| row.len() != first_len);
+        if is_ragged {
+            return self.prefill_and_seed_batched_ragged(prompt_tokens_per_row, sampler);
+        }
+
+        // Build the rectangular [B, L] prompt batch.
         let (prompt_arr, prompt_len) =
             Self::rectangular_input(prompt_tokens_per_row, self.batch_size)?;
 
@@ -1280,23 +1549,13 @@ impl<'a> MtpTarget for Gemma4MtpBatchedTargetAdapter<'a> {
             let mut positions = self.positions.borrow_mut();
             *positions = vec![prompt_len_usize; self.batch_size];
         }
-        let logical_positions = self.positions.borrow().clone();
-        let kv_offset_per_row = logical_positions.clone();
-        let bonus_position_per_row: Vec<usize> = logical_positions
-            .iter()
-            .map(|&pos| mtp_draft_position(pos))
-            .collect();
-        let kv_valid_len_per_row = logical_positions;
-        let left_padding_per_row = vec![0_usize; self.batch_size];
-
-        let seed = MtpBatchedVerifyOutput {
-            next_hidden,
-            next_shared_kv: shared_kv,
-            kv_offset_per_row,
-            bonus_position_per_row,
-            kv_valid_len_per_row,
-            left_padding_per_row,
-        };
+        {
+            let mut lp = self.left_padding.borrow_mut();
+            *lp = vec![0; self.batch_size];
+        }
+        let valid_len = self.positions.borrow().clone();
+        let left_padding = self.left_padding.borrow().clone();
+        let seed = self.build_seed_metadata(next_hidden, shared_kv, &valid_len, &left_padding);
         Ok((first_bonus_per_row, seed))
     }
 
@@ -1391,9 +1650,11 @@ impl<'a> MtpTarget for Gemma4MtpBatchedTargetAdapter<'a> {
         // Post-rollback per-row logical metadata. The physical cache offset
         // remains the global post-rollback max (used above for slicing the
         // captured K/V slabs), but each row advanced by its own
-        // accepted+bonus count. Thread those logical positions through so
-        // the drafter masks zeroed tails and rotates queries at the row's
-        // own bonus-token anchor.
+        // accepted+bonus count. `self.positions` tracks each row's logical
+        // valid length (`kv_valid_len`); advance it by `accepted + 1`. The
+        // constant per-row `left_padding` (0 for equal-length, `max_prompt_len
+        // - prompt_len[r]` for ragged) was stashed at prefill and persists
+        // unchanged — the prompt's leading padding is never trimmed.
         {
             let mut positions = self.positions.borrow_mut();
             if positions.len() != self.batch_size {
@@ -1403,26 +1664,15 @@ impl<'a> MtpTarget for Gemma4MtpBatchedTargetAdapter<'a> {
                 *row_pos += accepted + 1;
             }
         }
-        let logical_positions = self.positions.borrow().clone();
-        let kv_offset_per_row = logical_positions.clone();
-        let bonus_position_per_row: Vec<usize> = logical_positions
-            .iter()
-            .map(|&pos| mtp_draft_position(pos))
-            .collect();
-        // With equal-length prompts and uniform verify width there is no
-        // left-padding; the K/V valid length per row equals that row's
-        // logical post-rollback position in the prefix-valid layout.
-        let kv_valid_len_per_row = logical_positions;
-        let left_padding_per_row = vec![0_usize; self.batch_size];
-
-        Ok(MtpBatchedVerifyOutput {
-            next_hidden,
-            next_shared_kv,
-            kv_offset_per_row,
-            bonus_position_per_row,
-            kv_valid_len_per_row,
-            left_padding_per_row,
-        })
+        let kv_valid_len = self.positions.borrow().clone();
+        let left_padding = self.left_padding.borrow().clone();
+        // `build_seed_metadata` derives `kv_offset = left_padding + kv_valid_len`
+        // and `bonus_position = kv_offset - 1`, threading the row's shifted RoPE
+        // frame so the drafter masks zeroed tails and rotates queries at the
+        // row's own bonus anchor. For equal-length rows (`left_padding == 0`)
+        // this reduces to the legacy `kv_offset == kv_valid_len` metadata.
+        let out = self.build_seed_metadata(next_hidden, next_shared_kv, &kv_valid_len, &left_padding);
+        Ok(out)
     }
 }
 

--- a/src/models/gemma4_mtp_target.rs
+++ b/src/models/gemma4_mtp_target.rs
@@ -1735,7 +1735,8 @@ impl<'a> MtpTarget for Gemma4MtpBatchedTargetAdapter<'a> {
         // frame so the drafter masks zeroed tails and rotates queries at the
         // row's own bonus anchor. For equal-length rows (`left_padding == 0`)
         // this reduces to the legacy `kv_offset == kv_valid_len` metadata.
-        let out = self.build_seed_metadata(next_hidden, next_shared_kv, &kv_valid_len, &left_padding);
+        let out =
+            self.build_seed_metadata(next_hidden, next_shared_kv, &kv_valid_len, &left_padding);
         Ok(out)
     }
 }

--- a/src/models/gemma4_mtp_target.rs
+++ b/src/models/gemma4_mtp_target.rs
@@ -101,6 +101,38 @@ fn mtp_draft_position(kv_valid_len: usize) -> usize {
     kv_valid_len.saturating_sub(1)
 }
 
+/// Derive the per-row `(kv_offset, bonus_position)` anchors for a batched MTP
+/// seed/finalize from each row's logical `kv_valid_len` and constant
+/// `left_padding`, using the shifted-frame formula that keeps both the
+/// equal-length and ragged (left-padded) paths byte-identical to standalone
+/// B = 1 runs:
+///
+/// - `kv_offset[r] = left_padding[r] + kv_valid_len[r]` — the physical/padded
+///   absolute offset, i.e. the drafter's RoPE frame for row `r`. The shared
+///   K/V is baked at padded positions `[left_padding[r], kv_offset[r])`, so the
+///   drafter's query must rotate in the same `+left_padding[r]` shifted frame.
+/// - `bonus_position[r] = kv_offset[r] - 1` — the row's frozen bonus anchor
+///   (the last valid token's padded position).
+///
+/// For equal-length rows (`left_padding[r] == 0`) this reduces to
+/// `kv_offset == kv_valid_len` and `bonus_position == kv_valid_len - 1`,
+/// exactly the legacy equal-length metadata.
+fn seed_anchors_from_valid_len(
+    kv_valid_len: &[usize],
+    left_padding: &[usize],
+) -> (Vec<usize>, Vec<usize>) {
+    let kv_offset_per_row: Vec<usize> = kv_valid_len
+        .iter()
+        .zip(left_padding)
+        .map(|(&valid, &lp)| lp + valid)
+        .collect();
+    let bonus_position_per_row: Vec<usize> = kv_offset_per_row
+        .iter()
+        .map(|&offset| mtp_draft_position(offset))
+        .collect();
+    (kv_offset_per_row, bonus_position_per_row)
+}
+
 /// Output of [`Gemma4MtpBatchedTargetAdapter::left_padded_input`].
 ///
 /// Carries the left-padded `[B, max_len]` prefill tensor plus the per-row
@@ -873,19 +905,26 @@ const BATCHED_CAPTURE_LAYER_IDS: Option<&[usize]> = None;
 /// is released before the method returns, so no two borrows ever
 /// overlap.
 ///
-/// ## Scope: equal-length prompts within a burst window
+/// ## Scope: equal-length and variable-length prompts within a window
 ///
 /// `prefill_and_seed_batched` forwards the `[B, max_prompt_len]` prompt
-/// batch in one pass. When every row's prompt is the **same length**,
-/// the 2-D causal masks (`create_causal_mask(L, 0)`) broadcast cleanly
-/// across the batch and the result is byte-identical to running B
-/// separate B = 1 prefills. Variable-length prompts would need a per-row
-/// left-padding mask that the current Gemma 4 speculative forward does
-/// not build; the scheduler's burst-window collector
-/// ([`crate::server::batch::speculative_burst`]) only groups
-/// equal-length-prompt speculative requests into a batched window for
-/// this reason. The verify rounds are always uniform width (`block_size`
-/// per row) so they are unconditionally batched.
+/// batch in one pass. When every row's prompt is the **same length**, the
+/// 2-D causal masks (`create_causal_mask(L, 0)`) broadcast cleanly across
+/// the batch and the result is byte-identical to running B separate B = 1
+/// prefills.
+///
+/// **Variable-length (ragged)** prompts are handled by
+/// [`Self::prefill_and_seed_batched_ragged`] (routed automatically when the
+/// rows differ in length), gated upstream by the
+/// `MLXCEL_ENABLE_MTP_BATCH_RAGGED` opt-in. Each row is left-padded to
+/// `max_prompt_len` with a per-row left-padding causal mask; in the eligible
+/// non-capped regime (`max_prompt_len <= sliding_window`) that single mask is
+/// byte-identical to the windowed left-padding mask, so it is correct for both
+/// the full-attention and sliding-window layers. Greedy parity is preserved by
+/// the left-padding uniform per-row position shift (see that method's docs).
+/// The verify rounds are always uniform width (`block_size` per row) so they
+/// are unconditionally batched; the constant per-row `left_padding` stashed at
+/// prefill keeps every round in each row's shifted RoPE frame.
 pub struct Gemma4MtpBatchedTargetAdapter<'a> {
     /// Borrowed target wrapper. The wrapper owns its weights; this
     /// adapter owns the per-burst `[B, ...]` cache separately.
@@ -1414,15 +1453,8 @@ impl<'a> Gemma4MtpBatchedTargetAdapter<'a> {
         kv_valid_len: &[usize],
         left_padding: &[usize],
     ) -> MtpBatchedVerifyOutput {
-        let kv_offset_per_row: Vec<usize> = kv_valid_len
-            .iter()
-            .zip(left_padding)
-            .map(|(&valid, &lp)| lp + valid)
-            .collect();
-        let bonus_position_per_row: Vec<usize> = kv_offset_per_row
-            .iter()
-            .map(|&offset| mtp_draft_position(offset))
-            .collect();
+        let (kv_offset_per_row, bonus_position_per_row) =
+            seed_anchors_from_valid_len(kv_valid_len, left_padding);
         MtpBatchedVerifyOutput {
             next_hidden,
             next_shared_kv,

--- a/src/models/gemma4_mtp_target_tests.rs
+++ b/src/models/gemma4_mtp_target_tests.rs
@@ -348,3 +348,121 @@ fn unified_batched_adapter_implements_mtp_target() {
         a.batch_size()
     }
 }
+
+// ===========================================================================
+// Ragged (variable-length-prompt) batched MTP prefill helpers (issue #161)
+//
+// These pin the pure left-padding builder and the shifted-frame seed-anchor
+// formula without loading real Gemma 4 weights. The on-hardware greedy-parity
+// validation of the ragged forward ships behind the orchestrator's real-model
+// gate.
+// ===========================================================================
+
+/// `left_padded_input` right-aligns each row to `max_prompt_len`, reports the
+/// per-row left-padding (`max_len - L_r`) and valid length (`L_r`), and builds
+/// a `[B, max_len]` tensor.
+#[test]
+fn ragged_left_padded_input_right_aligns_rows() {
+    let _runtime = crate::initialize_runtime();
+    // Rows of length 2, 5, 3 -> max_len = 5.
+    let per_row = vec![vec![10, 11], vec![20, 21, 22, 23, 24], vec![30, 31, 32]];
+    let prefill =
+        Gemma4MtpBatchedTargetAdapter::left_padded_input(&per_row, 3).expect("left-padded");
+    assert_eq!(prefill.max_len, 5);
+    assert_eq!(prefill.left_padding, vec![3, 0, 2], "lp = max_len - L_r");
+    assert_eq!(prefill.valid_len, vec![2, 5, 3], "valid = L_r");
+    let shape = mlxcel_core::array_shape(prefill.arr.as_ref().unwrap());
+    assert_eq!(shape, vec![3, 5], "must build a [B, max_len] tensor");
+}
+
+/// The padded tensor places each row's real tokens at indices `[lp, max_len)`
+/// with the leading `lp` columns zeroed (the padding token id).
+#[test]
+fn ragged_left_padded_input_places_tokens_at_suffix() {
+    let _runtime = crate::initialize_runtime();
+    let per_row = vec![vec![7, 8], vec![1, 2, 3, 4]];
+    let prefill =
+        Gemma4MtpBatchedTargetAdapter::left_padded_input(&per_row, 2).expect("left-padded");
+    assert_eq!(prefill.max_len, 4);
+    assert_eq!(prefill.left_padding, vec![2, 0]);
+
+    // Read individual cells of the [2, 4] tensor.
+    let cell = |r: i32, c: i32| -> i32 {
+        let v = mlxcel_core::slice(prefill.arr.as_ref().unwrap(), &[r, c], &[r + 1, c + 1]);
+        let scalar = mlxcel_core::reshape(&v, &[]);
+        mlxcel_core::item_i32(&scalar)
+    };
+    // Row 0 (lp=2): [PAD, PAD, 7, 8].
+    assert_eq!(cell(0, 0), 0, "row0 leading pad");
+    assert_eq!(cell(0, 1), 0, "row0 leading pad");
+    assert_eq!(cell(0, 2), 7, "row0 first real token at index lp=2");
+    assert_eq!(cell(0, 3), 8);
+    // Row 1 (lp=0): [1, 2, 3, 4].
+    assert_eq!(cell(1, 0), 1);
+    assert_eq!(cell(1, 3), 4);
+}
+
+/// Empty / zero-length rows are rejected.
+#[test]
+fn ragged_left_padded_input_rejects_empty_row() {
+    let _runtime = crate::initialize_runtime();
+    let per_row = vec![vec![1, 2], vec![], vec![3]];
+    let msg = match Gemma4MtpBatchedTargetAdapter::left_padded_input(&per_row, 3) {
+        Ok(_) => panic!("empty row must be rejected"),
+        Err(e) => format!("{e}"),
+    };
+    assert!(
+        msg.contains("non-empty"),
+        "error must explain the non-empty requirement, got: {msg}"
+    );
+}
+
+/// Shifted-frame seed-anchor formula: `kv_offset = left_padding + kv_valid_len`,
+/// `bonus_position = kv_offset - 1`. This is the load-bearing per-row position
+/// derivation that keeps each ragged row in its own RoPE frame.
+#[test]
+fn ragged_seed_anchors_use_shifted_frame() {
+    // Ragged window: max_len = 5, rows of valid length 2, 5, 3 ->
+    // left_padding = [3, 0, 2].
+    let kv_valid_len = vec![2_usize, 5, 3];
+    let left_padding = vec![3_usize, 0, 2];
+    let (kv_offset, bonus_position) =
+        super::seed_anchors_from_valid_len(&kv_valid_len, &left_padding);
+    // Every row's physical/padded offset collapses to max_len = 5 at the seed.
+    assert_eq!(kv_offset, vec![5, 5, 5], "kv_offset = lp + valid (== max_len)");
+    assert_eq!(bonus_position, vec![4, 4, 4], "bonus = kv_offset - 1");
+}
+
+/// Equal-length rows (`left_padding == 0`) reduce to the legacy metadata:
+/// `kv_offset == kv_valid_len`, `bonus_position == kv_valid_len - 1`.
+#[test]
+fn ragged_seed_anchors_equal_length_reduces_to_legacy() {
+    let kv_valid_len = vec![7_usize, 7, 7];
+    let left_padding = vec![0_usize, 0, 0];
+    let (kv_offset, bonus_position) =
+        super::seed_anchors_from_valid_len(&kv_valid_len, &left_padding);
+    assert_eq!(kv_offset, vec![7, 7, 7]);
+    assert_eq!(bonus_position, vec![6, 6, 6]);
+}
+
+/// After a verify round, each row advances its logical valid length by its own
+/// `accepted + 1` while `left_padding` stays constant — so per-row anchors
+/// diverge correctly. Models the `verify_finalize_batched` bookkeeping.
+#[test]
+fn ragged_seed_anchors_track_per_row_round_advance() {
+    // Seed valid lengths (= unpadded prompt lengths) and constant lp.
+    let mut kv_valid_len = vec![2_usize, 5, 3];
+    let left_padding = vec![3_usize, 0, 2];
+    // Round 1 per-row accepts: row0 accepts 0, row1 accepts 3, row2 accepts 1.
+    let accepted = [0_usize, 3, 1];
+    for (v, a) in kv_valid_len.iter_mut().zip(accepted) {
+        *v += a + 1;
+    }
+    // Logical valid lengths now 3, 9, 5.
+    assert_eq!(kv_valid_len, vec![3, 9, 5]);
+    let (kv_offset, bonus_position) =
+        super::seed_anchors_from_valid_len(&kv_valid_len, &left_padding);
+    // Physical/padded offsets: lp + valid.
+    assert_eq!(kv_offset, vec![6, 9, 7]);
+    assert_eq!(bonus_position, vec![5, 8, 6]);
+}

--- a/src/models/gemma4_mtp_target_tests.rs
+++ b/src/models/gemma4_mtp_target_tests.rs
@@ -466,3 +466,357 @@ fn ragged_seed_anchors_track_per_row_round_advance() {
     assert_eq!(kv_offset, vec![6, 9, 7]);
     assert_eq!(bonus_position, vec![5, 8, 6]);
 }
+
+// ===========================================================================
+// END-TO-END ragged greedy parity (the real-generation proxy the parity gate
+// needs). Drives the *real* `Gemma4MtpBatchedTargetAdapter` — ragged prefill,
+// multi-round verify, per-row finalize/rollback, persisted per-row
+// `left_padding`/position bookkeeping — against the synthetic 1-layer Gemma 4
+// wrapper, and asserts the most-left-padded (shortest) row's GREEDILY GENERATED
+// token sequence (including its EOS stop) is byte-identical to that same row run
+// alone as B = 1.
+//
+// This is the unit proxy that the prior logit/mask-level tests missed: it
+// actually *generates* multiple tokens through the same prefill->verify->
+// finalize loop the round-loop driver uses (driven here target-only, i.e. a
+// perfect/full-accept drafter, so no drafter checkpoint is required), so any
+// per-row frame/position/EOS-retirement defect that flips the most-padded row's
+// argmax or drops its EOS surfaces as a sequence mismatch.
+// ===========================================================================
+
+/// Greedily extend `prompt` token-by-token through the *batched* adapter for a
+/// single row, stepping the real verify+finalize loop. Returns the emitted
+/// sequence (seed bonus first), stopping at the first `eos` token or after
+/// `max_new` tokens. The other rows are extended in lockstep but ignored.
+///
+/// `row` selects which batch row to read; the verify block width is 1 (pure
+/// autoregressive greedy), which still drives the real per-row mask /
+/// `left_padding` / position bookkeeping every round.
+fn batched_greedy_extend_row(
+    adapter: &Gemma4MtpBatchedTargetAdapter<'_>,
+    seed_bonuses: &[i32],
+    row: usize,
+    eos: i32,
+    max_new: usize,
+    sampler: &SamplingConfig,
+) -> Vec<i32> {
+    let batch = seed_bonuses.len();
+    let mut bonus_per_row = seed_bonuses.to_vec();
+    let mut emitted = vec![seed_bonuses[row]];
+    if emitted[0] == eos {
+        return emitted;
+    }
+    while emitted.len() < max_new {
+        // Width-1 verify block per row = [bonus].
+        let verify_input: Vec<Vec<i32>> = bonus_per_row.iter().map(|&b| vec![b]).collect();
+        let fwd = adapter
+            .verify_forward_batched(&verify_input, sampler)
+            .expect("batched verify forward");
+        // Per-row next greedy token (argmax at the single verify position).
+        let next_per_row: Vec<i32> = (0..batch)
+            .map(|r| fwd.target_tokens_per_row[r][0])
+            .collect();
+        // accepted = 0 for every row (no draft proposals); finalize advances
+        // each row by 1 and rolls back the (zero) speculative tail.
+        let _seed = adapter
+            .verify_finalize_batched(&vec![0usize; batch], 1, fwd.captured)
+            .expect("batched verify finalize");
+        let tok = next_per_row[row];
+        emitted.push(tok);
+        bonus_per_row = next_per_row;
+        if tok == eos {
+            break;
+        }
+    }
+    emitted
+}
+
+/// Standalone B = 1 analogue of [`batched_greedy_extend_row`] driving the
+/// single-row adapter's real verify+finalize loop.
+fn b1_greedy_extend(
+    adapter: &Gemma4MtpTargetAdapter<'_>,
+    seed_bonus: i32,
+    eos: i32,
+    max_new: usize,
+    sampler: &SamplingConfig,
+    logprobs: &mlxcel_core::sampling::LogprobsConfig,
+) -> Vec<i32> {
+    let mut bonus = seed_bonus;
+    let mut emitted = vec![seed_bonus];
+    if emitted[0] == eos {
+        return emitted;
+    }
+    while emitted.len() < max_new {
+        let vout = adapter.verify_forward(&[bonus], sampler, logprobs);
+        let next = vout.target_tokens[0];
+        let _seed = adapter.verify_finalize(0, 1, vout.captured);
+        emitted.push(next);
+        bonus = next;
+        if next == eos {
+            break;
+        }
+    }
+    emitted
+}
+
+/// Drive the full prefill + multi-round verify + finalize loop for BOTH rows of
+/// a large-length-gap ragged batch and the two standalone B = 1 runs, returning
+/// `(batched_short, std_short, batched_long, std_long)`. `eos` is the stop
+/// token threaded into every walk.
+fn run_ragged_vs_b1(
+    short_row: &[i32],
+    long_row: &[i32],
+    eos: i32,
+    max_new: usize,
+    layer_type: &str,
+) -> (Vec<i32>, Vec<i32>, Vec<i32>, Vec<i32>) {
+    let sampler = SamplingConfig::greedy();
+    let logprobs = mlxcel_core::sampling::LogprobsConfig::default();
+    let build = || crate::models::gemma4_tests::build_synthetic_wrapper_with_layer(layer_type);
+
+    // ---- Standalone B = 1 ground truth ----
+    let w_short = build();
+    let a_short = Gemma4MtpTargetAdapter::new(&w_short, None);
+    let (b_short, _, _) = a_short.prefill_and_seed(short_row, &sampler, &[], &logprobs);
+    let std_short = b1_greedy_extend(&a_short, b_short, eos, max_new, &sampler, &logprobs);
+
+    let w_long = build();
+    let a_long = Gemma4MtpTargetAdapter::new(&w_long, None);
+    let (b_long, _, _) = a_long.prefill_and_seed(long_row, &sampler, &[], &logprobs);
+    let std_long = b1_greedy_extend(&a_long, b_long, eos, max_new, &sampler, &logprobs);
+
+    // ---- Ragged B = 2: short row (cache consumed by its walk) ----
+    let w_batch = build();
+    let adapter = Gemma4MtpBatchedTargetAdapter::new(&w_batch, 2);
+    let (bonuses, _seed) = adapter
+        .prefill_and_seed_batched(&[short_row.to_vec(), long_row.to_vec()], &sampler)
+        .expect("ragged prefill");
+    let batched_short = batched_greedy_extend_row(&adapter, &bonuses, 0, eos, max_new, &sampler);
+
+    // Fresh adapter to extend the long row in isolation.
+    let w_batch2 = build();
+    let adapter2 = Gemma4MtpBatchedTargetAdapter::new(&w_batch2, 2);
+    let (bonuses2, _seed2) = adapter2
+        .prefill_and_seed_batched(&[short_row.to_vec(), long_row.to_vec()], &sampler)
+        .expect("ragged prefill");
+    let batched_long = batched_greedy_extend_row(&adapter2, &bonuses2, 1, eos, max_new, &sampler);
+
+    (batched_short, std_short, batched_long, std_long)
+}
+
+/// End-to-end MULTI-ROUND greedy parity for the most-left-padded row. A 2-row
+/// ragged batch with a large length gap must produce, for the SHORT (most-
+/// padded) row, a byte-identical multi-token greedy sequence to that short
+/// prompt run alone as B = 1. EOS is a sentinel the synthetic model never emits,
+/// so both paths run the full `max_new` rounds — this is the path where the
+/// documented failure mode ("verify-round perturbation accumulates and flips the
+/// most-padded row's greedy argmax") would surface as a sequence mismatch.
+#[test]
+fn ragged_end_to_end_greedy_parity_most_padded_row_multiround() {
+    let _runtime = crate::initialize_runtime();
+    for layer_type in ["sliding_attention", "full_attention"] {
+        // Large length gap: short row lp = 5, long row lp = 0.
+        let short_row: Vec<i32> = vec![2, 3];
+        let long_row: Vec<i32> = vec![4, 5, 6, 7, 2, 3, 1];
+        let max_new = 10usize;
+        // Sentinel EOS the degenerate fixture never produces, forcing
+        // full-length multi-round generation in every walk.
+        let eos = -1i32;
+
+        let (batched_short, std_short, batched_long, std_long) =
+            run_ragged_vs_b1(&short_row, &long_row, eos, max_new, layer_type);
+
+        eprintln!(
+            "E2E multiround [{layer_type}] short: standalone={std_short:?} \
+             batched={batched_short:?}; long: standalone={std_long:?} batched={batched_long:?}"
+        );
+
+        // Both paths must actually GENERATE multiple tokens (not stop at the
+        // seed), otherwise the multi-round parity assertion would be vacuous.
+        assert!(
+            std_short.len() >= 3,
+            "[{layer_type}] short-row multi-round walk must generate >= 3 tokens \
+             (got {std_short:?})"
+        );
+        // The load-bearing assertion: the most-left-padded row's multi-round
+        // greedy output is byte-identical batched-vs-standalone every step. The
+        // `full_attention` iteration is the one that exercises the unbounded
+        // KVCache verify-round left-padding mask (where the prompt padding is
+        // resident forever).
+        assert_eq!(
+            batched_short, std_short,
+            "[{layer_type}] SHORT (most-left-padded) row multi-round greedy \
+             sequence must be byte-identical to its standalone B = 1 run"
+        );
+        assert_eq!(
+            batched_long, std_long,
+            "[{layer_type}] LONG (lp == 0) control row multi-round greedy sequence \
+             must match standalone"
+        );
+    }
+}
+
+/// End-to-end EOS-STOP parity for the most-left-padded row: when the short row's
+/// standalone greedy decode hits EOS early, the batched ragged most-padded row
+/// must stop at the SAME position (not run to the cap emitting pad — the exact
+/// "empty + full token budget + no EOS" symptom the real 31B gate caught).
+///
+/// EOS is set to the token the synthetic model greedily emits first, so the
+/// short row's standalone decode is a known 1-token sequence ending in EOS; the
+/// ragged most-padded row must reproduce that EOS stop rather than continuing.
+#[test]
+fn ragged_end_to_end_greedy_parity_most_padded_row_hits_eos() {
+    let _runtime = crate::initialize_runtime();
+    let sampler = SamplingConfig::greedy();
+    let logprobs = mlxcel_core::sampling::LogprobsConfig::default();
+    let short_row: Vec<i32> = vec![2, 3];
+    let long_row: Vec<i32> = vec![4, 5, 6, 7, 2, 3, 1];
+    let max_new = 12usize;
+
+    // The token the model greedily emits first becomes EOS, so the short row's
+    // standalone greedy decode terminates on EOS within budget.
+    let w_probe = crate::models::gemma4_tests::build_synthetic_wrapper();
+    let a_probe = Gemma4MtpTargetAdapter::new(&w_probe, None);
+    let (probe_bonus, _, _) = a_probe.prefill_and_seed(&short_row, &sampler, &[], &logprobs);
+    let eos = probe_bonus;
+
+    let (batched_short, std_short, batched_long, std_long) =
+        run_ragged_vs_b1(&short_row, &long_row, eos, max_new, "sliding_attention");
+
+    eprintln!(
+        "E2E eos-stop eos={eos} short: standalone={std_short:?} batched={batched_short:?}; \
+         long: standalone={std_long:?} batched={batched_long:?}"
+    );
+
+    // The short row's standalone greedy decode must terminate on EOS within
+    // budget (a "known sequence ending in EOS"), not run to the cap.
+    assert!(
+        std_short.last() == Some(&eos) && std_short.len() < max_new,
+        "short row standalone greedy must end in EOS within budget (got {std_short:?})"
+    );
+    assert_eq!(
+        batched_short, std_short,
+        "SHORT (most-left-padded) row must reproduce the standalone EOS stop, not \
+         run to the token cap emitting pad"
+    );
+    assert_eq!(
+        batched_long, std_long,
+        "LONG (lp == 0) control row must match standalone EOS behaviour"
+    );
+}
+
+/// Hidden-state contamination probe — the most sensitive signal, immune to the
+/// synthetic fixture's degenerate argmax. After the ragged prefill, run several
+/// width-1 verify rounds so the shared cache offset grows past the prompt + its
+/// padding, then compare the most-left-padded row's captured verify hidden state
+/// against the standalone B = 1 run at the same logical step.
+///
+/// Note on the tolerance: exact bitwise equality is NOT achievable, because
+/// left-padding shifts every real token's *absolute* RoPE position by `lp`. RoPE
+/// is relative — `rotate(q, p_q) · rotate(k, p_k)` depends only on `p_q - p_k` —
+/// so the attention scores are mathematically identical, but the two absolute
+/// rotations round differently in fp, leaving a tiny (~1e-3) residual. A padding
+/// *contamination* bug, by contrast, makes the most-padded row attend `lp`
+/// spurious padding keys and perturbs the hidden by a LARGE amount (pre-fix this
+/// probe saw first-byte divergences, i.e. O(1) relative error). The tolerance
+/// below is loose enough to pass the unavoidable RoPE rounding yet far tighter
+/// than any contamination, so it is a real proxy for the greedy-parity gate.
+/// Runs for both attention families — `full_attention` exercises the unbounded
+/// KVCache (padding resident forever) and `sliding_attention` the MTP-buffered
+/// RotatingKVCache (padding resident until the buffer compacts).
+#[test]
+fn ragged_most_padded_row_verify_hidden_has_no_padding_contamination() {
+    let _runtime = crate::initialize_runtime();
+    let sampler = SamplingConfig::greedy();
+    let logprobs = mlxcel_core::sampling::LogprobsConfig::default();
+
+    // Read the most-padded row (row 0) hidden from a verify capture's
+    // `VerifyCaptured.tensors[0]` (`[B, width, hidden]`) as f32 values.
+    fn row0_hidden_f32(captured: &VerifyCaptured, width: i32, hidden: i32) -> Vec<f32> {
+        let h = captured
+            .tensors
+            .first()
+            .expect("verify capture carries hidden at index 0");
+        let row0 = mlxcel_core::slice(h.as_ref().unwrap(), &[0, 0, 0], &[1, width, hidden]);
+        let row0_f32 = mlxcel_core::astype(&row0, mlxcel_core::dtype::FLOAT32);
+        mlxcel_core::eval(&row0_f32);
+        let bytes = mlxcel_core::array_to_raw_bytes(&row0_f32);
+        bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
+
+    for layer_type in ["sliding_attention", "full_attention"] {
+        let build = || crate::models::gemma4_tests::build_synthetic_wrapper_with_layer(layer_type);
+        let short_row: Vec<i32> = vec![2, 3];
+        let long_row: Vec<i32> = vec![4, 5, 6, 7, 2, 3, 1];
+        let hidden_dim = 4i32; // synthetic fixture hidden_size.
+        // Walk a few rounds so the SWA cache offset grows past `sliding_window`
+        // (= 8) while the MTP rollback buffer (`buffer_size = 32`) keeps the
+        // prompt padding RESIDENT and uncompacted — the exact regime the
+        // ragged path hits on the real 31B and the one the pre-fix mask logic
+        // mis-handled. At this depth BOTH defects bite: the full-attention path
+        // (unbounded cache, padding resident forever) and the sliding path
+        // (buffered cache, `sliding_offset + l > window` yet padding resident).
+        let warmup_rounds = 4usize;
+
+        // ---- Standalone B = 1 short row ----
+        let w_short = build();
+        let a_short = Gemma4MtpTargetAdapter::new(&w_short, None);
+        let (mut b_short, _, _) = a_short.prefill_and_seed(&short_row, &sampler, &[], &logprobs);
+        for _ in 0..warmup_rounds {
+            let vout = a_short.verify_forward(&[b_short], &sampler, &logprobs);
+            b_short = vout.target_tokens[0];
+            let _ = a_short.verify_finalize(0, 1, vout.captured);
+        }
+        let std_capture = a_short.verify_forward(&[b_short], &sampler, &logprobs);
+        let std_h = row0_hidden_f32(&std_capture.captured, 1, hidden_dim);
+
+        // ---- Ragged B = 2, most-padded row (row 0) ----
+        let w_batch = build();
+        let adapter = Gemma4MtpBatchedTargetAdapter::new(&w_batch, 2);
+        let (bonuses, _seed) = adapter
+            .prefill_and_seed_batched(&[short_row.clone(), long_row.clone()], &sampler)
+            .expect("ragged prefill");
+        let mut bonus_per_row = bonuses;
+        for _ in 0..warmup_rounds {
+            let verify_input: Vec<Vec<i32>> = bonus_per_row.iter().map(|&b| vec![b]).collect();
+            let fwd = adapter
+                .verify_forward_batched(&verify_input, &sampler)
+                .expect("batched verify forward");
+            bonus_per_row = (0..2).map(|r| fwd.target_tokens_per_row[r][0]).collect();
+            let _ = adapter
+                .verify_finalize_batched(&[0usize, 0usize], 1, fwd.captured)
+                .expect("batched verify finalize");
+        }
+        let verify_input: Vec<Vec<i32>> = bonus_per_row.iter().map(|&b| vec![b]).collect();
+        let batched_capture = adapter
+            .verify_forward_batched(&verify_input, &sampler)
+            .expect("batched verify forward");
+        let batched_h = row0_hidden_f32(&batched_capture.captured, 1, hidden_dim);
+
+        // Max relative deviation across the hidden vector.
+        let max_rel = std_h
+            .iter()
+            .zip(&batched_h)
+            .map(|(&s, &b)| (s - b).abs() / s.abs().max(1e-3))
+            .fold(0.0f32, f32::max);
+        eprintln!(
+            "[{layer_type}] most-padded-row hidden max_rel_dev={max_rel:.6} std={std_h:?} batched={batched_h:?}"
+        );
+        // Measured on this fixture at `warmup_rounds = 4`: the pure RoPE-rounding
+        // residual (fix applied) is ~1.5e-5, while the pre-fix padding
+        // contamination is ~1.6e-4 (sliding, buffered) / ~2.8e-4 (full,
+        // unbounded) and grows with depth. An 8e-5 ceiling sits cleanly between
+        // them, so this assertion FAILS without the verify-round padding mask and
+        // PASSES with it — a real unit proxy for the 31B greedy-parity gate.
+        assert!(
+            max_rel < 8e-5,
+            "[{layer_type}] most-left-padded row verify hidden deviates from the \
+             standalone B = 1 run by max_rel={max_rel} — far above the ~1.5e-5 RoPE \
+             fp-rounding floor, indicating the row attends resident prompt padding \
+             (greedy-parity break)"
+        );
+    }
+}

--- a/src/models/gemma4_mtp_target_tests.rs
+++ b/src/models/gemma4_mtp_target_tests.rs
@@ -429,7 +429,11 @@ fn ragged_seed_anchors_use_shifted_frame() {
     let (kv_offset, bonus_position) =
         super::seed_anchors_from_valid_len(&kv_valid_len, &left_padding);
     // Every row's physical/padded offset collapses to max_len = 5 at the seed.
-    assert_eq!(kv_offset, vec![5, 5, 5], "kv_offset = lp + valid (== max_len)");
+    assert_eq!(
+        kv_offset,
+        vec![5, 5, 5],
+        "kv_offset = lp + valid (== max_len)"
+    );
     assert_eq!(bonus_position, vec![4, 4, 4], "bonus = kv_offset - 1");
 }
 

--- a/src/models/gemma4_tests.rs
+++ b/src/models/gemma4_tests.rs
@@ -31,6 +31,25 @@ fn parse_text_config(json: serde_json::Value) -> TextConfig {
     serde_json::from_value(json).expect("TextConfig must deserialize")
 }
 
+/// Re-export the tiny synthetic 1-layer Gemma 4 wrapper builder so sibling
+/// test modules (e.g. `gemma4_mtp_target_tests`) can drive the *real*
+/// speculative forward against a hermetic in-process model instead of
+/// requiring 31B checkpoints. The fixture is a single `sliding_attention`
+/// layer (hidden=4, vocab=8, `sliding_window=8`), exactly the model used by
+/// the cache-isolation tests below.
+pub(crate) fn build_synthetic_wrapper() -> super::Gemma4Wrapper {
+    cache_isolation::build_wrapper()
+}
+
+/// Like [`build_synthetic_wrapper`] but lets the caller pick the single layer's
+/// attention family (`"sliding_attention"` or `"full_attention"`). The
+/// full-attention variant is the one that exercises the *unbounded* KVCache
+/// verify-round left-padding mask (the sliding fixture alone cannot, since it
+/// only ever drives the windowed mask path).
+pub(crate) fn build_synthetic_wrapper_with_layer(layer_type: &str) -> super::Gemma4Wrapper {
+    cache_isolation::build_wrapper_with_layer(layer_type)
+}
+
 // -----------------------------------------------------------------
 // per-`SequenceId` cache isolation tests for `Gemma4Wrapper`.
 //
@@ -57,7 +76,7 @@ mod cache_isolation {
     use mlxcel_core::weights::WeightMap;
     use std::collections::HashMap;
 
-    fn make_test_gemma4_args() -> ModelArgs {
+    pub(super) fn make_test_gemma4_args_with_layer(layer_type: &str) -> ModelArgs {
         let mut rope_parameters: HashMap<String, Gemma4RopeParameters> = HashMap::new();
         rope_parameters.insert(
             "sliding_attention".to_string(),
@@ -104,7 +123,7 @@ mod cache_isolation {
                 "num_experts": null,
                 "top_k_experts": null,
                 "moe_intermediate_size": null,
-                "layer_types": ["sliding_attention"],
+                "layer_types": [layer_type],
                 "quantization": null
             }),
             eos_token_id: Some(serde_json::json!([1])),
@@ -216,7 +235,11 @@ mod cache_isolation {
     }
 
     pub(super) fn build_wrapper() -> Gemma4Wrapper {
-        let args = make_test_gemma4_args();
+        build_wrapper_with_layer("sliding_attention")
+    }
+
+    pub(super) fn build_wrapper_with_layer(layer_type: &str) -> Gemma4Wrapper {
+        let args = make_test_gemma4_args_with_layer(layer_type);
         let weights = make_test_gemma4_weight_map();
         Gemma4Wrapper::new(Gemma4Model::from_weights(&weights, &args).unwrap())
     }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -713,7 +713,7 @@ mod gemma3n_helpers_tests;
 
 #[cfg(test)]
 #[path = "gemma4_tests.rs"]
-mod gemma4_tests;
+pub(crate) mod gemma4_tests;
 
 #[cfg(test)]
 #[path = "llama4_helpers_tests.rs"]

--- a/src/server/batch/queue.rs
+++ b/src/server/batch/queue.rs
@@ -656,7 +656,11 @@ mod tests {
         });
         let ids: Vec<u64> = window.iter().map(|s| s.seq_id.as_u64()).collect();
         // 10 matches; 20 fails the length gate and scanning stops there.
-        assert_eq!(ids, vec![10], "ragged-off must stop at the first length mismatch");
+        assert_eq!(
+            ids,
+            vec![10],
+            "ragged-off must stop at the first length mismatch"
+        );
         assert_eq!(queue.len(), 2);
     }
 

--- a/src/server/batch/queue.rs
+++ b/src/server/batch/queue.rs
@@ -289,6 +289,20 @@ mod tests {
         make_test_sequence_with_priority(id_val, RequestPriority::Normal)
     }
 
+    /// Build a test `SequenceInfo` with a prompt of the requested length so
+    /// variable-length-window formation can be exercised.
+    fn make_test_sequence_with_prompt_len(
+        id_val: u64,
+        prompt_len: usize,
+    ) -> (SequenceInfo, mpsc::Receiver<GenerateEvent>) {
+        let (mut seq, rx) = make_test_sequence_with_priority(id_val, RequestPriority::Normal);
+        let prompt_tokens: Vec<i32> = (0..prompt_len as i32).map(|i| i + 1).collect();
+        let tokenizer = crate::tokenizer::MlxcelTokenizer::stub();
+        seq.decode_state = StreamingDecodeState::new(&tokenizer, &prompt_tokens);
+        seq.prompt_tokens = prompt_tokens;
+        (seq, rx)
+    }
+
     #[test]
     fn new_queue_is_empty() {
         let queue = PrefillQueue::new();
@@ -608,5 +622,100 @@ mod tests {
         let mut queue = PrefillQueue::new();
         let window = queue.drain_matching_window(RequestPriority::Low, 5, |_| true);
         assert!(window.is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // Variable-length (ragged) batched MTP window formation (issue #161)
+    //
+    // The scheduler's `try_speculative_burst` window predicate gates the
+    // prompt-length equality behind an `allow_ragged` flag:
+    //     (allow_ragged || candidate.prompt_tokens.len() == head_prompt_len)
+    //         && ...other matching checks...
+    // These tests pin that exact gating against `drain_matching_window`,
+    // which is the mechanism the scheduler drives.
+    // -----------------------------------------------------------------
+
+    /// With ragged disabled the length-equality gate keeps different-length
+    /// candidates out of the head's window (the legacy same-length behaviour).
+    #[test]
+    fn ragged_disabled_window_excludes_different_length_prompts() {
+        let mut queue = PrefillQueue::new();
+        let head_prompt_len = 4usize;
+        // Head-equivalent length 4; sibling 20 differs (length 7); sibling 30
+        // matches length 4 again but is behind 20, so FIFO scanning stops at 20.
+        let (s10, _r10) = make_test_sequence_with_prompt_len(10, 4);
+        let (s20, _r20) = make_test_sequence_with_prompt_len(20, 7);
+        let (s30, _r30) = make_test_sequence_with_prompt_len(30, 4);
+        queue.enqueue(s10).unwrap();
+        queue.enqueue(s20).unwrap();
+        queue.enqueue(s30).unwrap();
+
+        let allow_ragged = false;
+        let window = queue.drain_matching_window(RequestPriority::Normal, 10, |candidate| {
+            allow_ragged || candidate.prompt_tokens.len() == head_prompt_len
+        });
+        let ids: Vec<u64> = window.iter().map(|s| s.seq_id.as_u64()).collect();
+        // 10 matches; 20 fails the length gate and scanning stops there.
+        assert_eq!(ids, vec![10], "ragged-off must stop at the first length mismatch");
+        assert_eq!(queue.len(), 2);
+    }
+
+    /// With ragged enabled the length-equality gate is dropped, so
+    /// burst-eligible candidates of different prompt lengths all join one
+    /// window in FIFO order.
+    #[test]
+    fn ragged_enabled_window_groups_different_length_prompts() {
+        let mut queue = PrefillQueue::new();
+        let head_prompt_len = 4usize;
+        let (s10, _r10) = make_test_sequence_with_prompt_len(10, 4);
+        let (s20, _r20) = make_test_sequence_with_prompt_len(20, 7);
+        let (s30, _r30) = make_test_sequence_with_prompt_len(30, 2);
+        queue.enqueue(s10).unwrap();
+        queue.enqueue(s20).unwrap();
+        queue.enqueue(s30).unwrap();
+
+        let allow_ragged = true;
+        let window = queue.drain_matching_window(RequestPriority::Normal, 10, |candidate| {
+            allow_ragged || candidate.prompt_tokens.len() == head_prompt_len
+        });
+        let ids: Vec<u64> = window.iter().map(|s| s.seq_id.as_u64()).collect();
+        assert_eq!(
+            ids,
+            vec![10, 20, 30],
+            "ragged-on must group different-length candidates into one window"
+        );
+        // Confirm the lengths actually differ — a true ragged window.
+        let lens: Vec<usize> = window.iter().map(|s| s.prompt_tokens.len()).collect();
+        assert_eq!(lens, vec![4, 7, 2]);
+        assert!(queue.is_empty());
+    }
+
+    /// Even with ragged enabled, the *other* window constraints still apply.
+    /// Here the `max_tokens` mismatch (mirroring the scheduler's
+    /// `candidate.max_tokens == head_max_tokens` check) excludes a row whose
+    /// prompt length differs AND whose budget differs.
+    #[test]
+    fn ragged_enabled_window_still_honors_other_matching_checks() {
+        let mut queue = PrefillQueue::new();
+        let head_max_tokens = 100usize; // make_test_sequence default
+        let (s10, _r10) = make_test_sequence_with_prompt_len(10, 4);
+        let (mut s20, _r20) = make_test_sequence_with_prompt_len(20, 7);
+        s20.max_tokens = 200; // differs from head -> must be excluded
+        queue.enqueue(s10).unwrap();
+        queue.enqueue(s20).unwrap();
+
+        let allow_ragged = true;
+        let window = queue.drain_matching_window(RequestPriority::Normal, 10, |candidate| {
+            // Length gate dropped, but max_tokens equality still enforced.
+            (allow_ragged || candidate.prompt_tokens.len() == 4)
+                && candidate.max_tokens == head_max_tokens
+        });
+        let ids: Vec<u64> = window.iter().map(|s| s.seq_id.as_u64()).collect();
+        assert_eq!(
+            ids,
+            vec![10],
+            "ragged-on must still respect the non-length window checks"
+        );
+        assert_eq!(queue.len(), 1);
     }
 }

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1821,6 +1821,15 @@ impl BatchScheduler {
         // `ActiveBatch::new(max_batch_size)`).
         let max_batch_size = self.active_batch.max_size();
         let head_can_join_batched = super::speculative_burst::can_join_batched_burst_window(&seq);
+        // Ragged (variable-length-prompt) windows are gated behind a separate
+        // opt-in subordinate to `MLXCEL_ENABLE_MTP_BATCH`. When off (the
+        // default), the window collector keeps its original equal-prompt-length
+        // constraint so the validated same-length batched burst is unchanged.
+        // When on, the prompt-length equality is dropped and burst-eligible
+        // rows of different lengths join one window; the batched MTP adapter
+        // left-pads them to `max_prompt_len` and threads per-row positions /
+        // valid lengths so greedy parity is preserved.
+        let allow_ragged = super::speculative_burst::mtp_batched_ragged_window_enabled();
         let window: Vec<SequenceInfo> = if max_batch_size > 1 && head_can_join_batched {
             let head_prompt_len = seq.prompt_tokens.len();
             let head_max_tokens = seq.max_tokens;
@@ -1832,7 +1841,7 @@ impl BatchScheduler {
             let extra =
                 self.prefill_queue
                     .drain_matching_window(head_lane, max_extra, |candidate| {
-                        candidate.prompt_tokens.len() == head_prompt_len
+                        (allow_ragged || candidate.prompt_tokens.len() == head_prompt_len)
                             && candidate.max_tokens == head_max_tokens
                             && super::speculative_burst::sampling_config_eq(
                                 &candidate.sampling,

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -460,6 +460,45 @@ pub(crate) fn mtp_batched_burst_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// Whether to allow a B>1 batched MTP burst window to span rows with
+/// **different prompt lengths** (variable-length / ragged batched burst).
+///
+/// Off by default and strictly subordinate to [`mtp_batched_burst_enabled`]:
+/// even with `MLXCEL_ENABLE_MTP_BATCH=1`, ragged windows only form when
+/// `MLXCEL_ENABLE_MTP_BATCH_RAGGED=1` is *also* set. This keeps the validated
+/// same-length batched burst (the only batched path exercised on real-model
+/// greedy-parity runs to date) as the default behaviour of the
+/// `MLXCEL_ENABLE_MTP_BATCH` flag, and isolates the experimental ragged path
+/// behind its own opt-in.
+///
+/// ## Why a separate flag
+///
+/// The ragged path left-pads every row to `max_prompt_len` and relies on the
+/// left-padding *uniform per-row position shift* to preserve greedy parity:
+/// because every token in a given row (prefill prompt AND every later verify
+/// round) is shifted by the same constant `left_padding[row]` (equal to
+/// `max_prompt_len - prompt_len[row]`), all intra-row relative RoPE distances
+/// are preserved, so each row's argmax stream is byte-identical to its
+/// standalone B=1 run. The
+/// drafter already honours per-row `kv_valid_len` / `left_padding` /
+/// `position` metadata (`set_shared_kv_batched`), and the batched round loop
+/// already retires finished rows per-row. The remaining real-model-only
+/// unknown is the Gemma 4 left-padded prefill forward (mask + sink capture);
+/// keeping it behind this flag lets the orchestrator's real-model greedy-parity
+/// gate validate it without ever touching the production default path.
+///
+/// ## Eligibility constraint
+///
+/// Ragged windows additionally require `max_prompt_len <= sliding_window` (the
+/// non-capped RotatingKVCache regime) so the windowed left-padding mask is
+/// well-defined; the burst driver declines and re-enqueues otherwise.
+pub(crate) fn mtp_batched_ragged_window_enabled() -> bool {
+    std::env::var("MLXCEL_ENABLE_MTP_BATCH_RAGGED")
+        .ok()
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
 /// Successful burst outcome returned to the scheduler.
 ///
 /// The scheduler uses `tokens_generated` to update the per-request
@@ -1683,11 +1722,13 @@ pub(crate) struct BatchedBurstFinalized {
 /// kind, or the drafter load failed) — the scheduler then re-routes
 /// every rejected sequence through the classic non-speculative path.
 ///
-/// **Caller contract**: every sequence in `seqs` MUST already have
-/// passed [`should_burst_for_sequence`] AND have an identical
-/// `prompt_tokens.len()` (the batched MTP adapter requires a rectangular
-/// `[B, L]` prefill — see its docstring). The scheduler's window
-/// collector enforces both.
+/// **Caller contract**: every sequence in `seqs` MUST already have passed
+/// [`should_burst_for_sequence`]. For the DFlash dispatch and for the
+/// same-length MTP path, every `prompt_tokens.len()` MUST be identical (the
+/// rectangular `[B, L]` prefill requirement). Variable-length MTP windows are
+/// admitted only when [`mtp_batched_ragged_window_enabled`] is set; the MTP
+/// adapter then left-pads the rows to `max_prompt_len`. The scheduler's window
+/// collector enforces the matching length policy.
 //
 // `result_large_err`: the `Err` variant carries the full window so the
 // scheduler can route every rejected sequence into the classic prefill
@@ -1701,12 +1742,20 @@ pub(crate) fn try_run_burst_batched(
     let batch_size = seqs.len();
     debug_assert!(batch_size >= 2, "try_run_burst_batched requires B >= 2");
 
-    // Defensive: every row must have a non-empty prompt and all prompts
-    // must be the same length (the scheduler's window collector
-    // guarantees this; re-assert so a future caller bug fails loudly
-    // rather than corrupting a verify forward).
+    // Defensive: every row must have a non-empty prompt. Equal prompt length
+    // is required for every path EXCEPT the variable-length MTP window (gated
+    // by `MLXCEL_ENABLE_MTP_BATCH_RAGGED`), where the MTP adapter left-pads to
+    // `max_prompt_len`. DFlash never supports ragged prompts, so it keeps the
+    // strict equality. Re-asserting here makes a future window-collector bug
+    // fail loudly (re-enqueue via `Err`) rather than corrupting a verify
+    // forward.
+    let any_empty = seqs.iter().any(|s| s.prompt_tokens.is_empty());
     let prompt_len = seqs[0].prompt_tokens.len();
-    if prompt_len == 0 || seqs.iter().any(|s| s.prompt_tokens.len() != prompt_len) {
+    let ragged = seqs.iter().any(|s| s.prompt_tokens.len() != prompt_len);
+    let ragged_mtp_allowed = ragged
+        && matches!(ctx.dispatch, crate::server::SpeculativeDispatch::Mtp { .. })
+        && mtp_batched_ragged_window_enabled();
+    if any_empty || (ragged && !ragged_mtp_allowed) {
         return Err(seqs);
     }
 

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -1792,7 +1792,11 @@ pub(crate) fn try_run_burst_batched(
         && let Some(window_size) = ragged_target_sliding_window(ctx.model)
         && window_size > 0
     {
-        let max_prompt_len = seqs.iter().map(|s| s.prompt_tokens.len()).max().unwrap_or(0);
+        let max_prompt_len = seqs
+            .iter()
+            .map(|s| s.prompt_tokens.len())
+            .max()
+            .unwrap_or(0);
         if max_prompt_len > window_size {
             tracing::debug!(
                 max_prompt_len,
@@ -2485,8 +2489,14 @@ mod tests {
         // Gate arithmetic: a window whose longest prompt exceeds `sliding_window`
         // is the capped regime the pre-gate must decline; one within it is
         // eligible.
-        assert!(9 > window, "max_prompt_len 9 > window 8 must be declined (capped)");
-        assert!(8 <= window, "max_prompt_len 8 == window 8 is eligible (non-capped)");
+        assert!(
+            9 > window,
+            "max_prompt_len 9 > window 8 must be declined (capped)"
+        );
+        assert!(
+            8 <= window,
+            "max_prompt_len 8 == window 8 is eligible (non-capped)"
+        );
     }
 
     #[test]

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -2404,6 +2404,22 @@ mod tests {
         );
     }
 
+    /// The ragged-window flag is off by default (env var unset), so even with
+    /// `MLXCEL_ENABLE_MTP_BATCH=1` the validated same-length batched burst stays
+    /// the behaviour of that flag until the operator also opts into ragged.
+    #[test]
+    fn mtp_batched_ragged_window_flag_defaults_off() {
+        // Only assert the default when the env var is genuinely unset; some CI
+        // shells may export it. This keeps the test deterministic without
+        // mutating process-global env state from a parallel test.
+        if std::env::var("MLXCEL_ENABLE_MTP_BATCH_RAGGED").is_err() {
+            assert!(
+                !mtp_batched_ragged_window_enabled(),
+                "ragged window flag must default to off when unset"
+            );
+        }
+    }
+
     #[test]
     fn should_burst_for_sequence_rejects_disabled_dispatch() {
         let dispatch = crate::server::SpeculativeDispatch::Disabled;

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -499,6 +499,26 @@ pub(crate) fn mtp_batched_ragged_window_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// Sliding-window size of a ragged-capable Gemma 4 target, or `None` for any
+/// non-Gemma-4 model.
+///
+/// The ragged batched MTP prefill is only well-defined in the non-capped
+/// RotatingKVCache regime (`max_prompt_len <= sliding_window`); outside it the
+/// windowed left-padding mask is invalid and the adapter declines. That decline
+/// must be detected *before* the burst commits so the rows fall back cleanly to
+/// per-row classic decode (`Err(seqs)` re-enqueue) rather than surfacing a
+/// client-facing error mid-burst. The three ragged-eligible variants
+/// (`Gemma4`, `Gemma4VLM`, `Gemma4Unified`) all wrap a `Gemma4Wrapper`, so the
+/// window value is read uniformly via [`Gemma4Wrapper::sliding_window_value`].
+fn ragged_target_sliding_window(model: &LoadedModel) -> Option<usize> {
+    match model {
+        LoadedModel::Gemma4(wrapper) => Some(wrapper.sliding_window_value()),
+        LoadedModel::Gemma4VLM(vlm) => Some(vlm.text_model.sliding_window_value()),
+        LoadedModel::Gemma4Unified(unified) => Some(unified.text_model.sliding_window_value()),
+        _ => None,
+    }
+}
+
 /// Successful burst outcome returned to the scheduler.
 ///
 /// The scheduler uses `tokens_generated` to update the per-request
@@ -1759,6 +1779,31 @@ pub(crate) fn try_run_burst_batched(
         return Err(seqs);
     }
 
+    // Ragged-eligibility pre-gate. The ragged MTP prefill is only valid in the
+    // non-capped RotatingKVCache regime (`max_prompt_len <= sliding_window`);
+    // outside it `prefill_and_seed_batched_ragged` returns `Err`, but by then
+    // the burst has committed and that `Err` is mapped to a client-facing error
+    // (`emit_error_and_finalize`) for every row instead of a clean fallback. The
+    // scheduler's window collector does not know the model's sliding window, so
+    // it can form such a window. Detect it here, BEFORE committing, and decline
+    // via `Err(seqs)` so the scheduler re-enqueues every row for per-row B=1
+    // classic service (correct output) — matching the documented contract.
+    if ragged_mtp_allowed
+        && let Some(window_size) = ragged_target_sliding_window(ctx.model)
+        && window_size > 0
+    {
+        let max_prompt_len = seqs.iter().map(|s| s.prompt_tokens.len()).max().unwrap_or(0);
+        if max_prompt_len > window_size {
+            tracing::debug!(
+                max_prompt_len,
+                sliding_window = window_size,
+                batch_size,
+                "ragged batched MTP window declined: max_prompt_len exceeds                  sliding_window (capped RotatingKVCache regime is unsupported by the                  windowed left-padding mask); re-enqueueing rows for per-row B=1                  classic decode",
+            );
+            return Err(seqs);
+        }
+    }
+
     // Mark every row's prefill timer; do NOT transition state yet — the
     // burst may decline on the model variant, in which case the rows
     // fall back to the classic prefill path which itself transitions
@@ -2418,6 +2463,30 @@ mod tests {
                 "ragged window flag must default to off when unset"
             );
         }
+    }
+
+    /// `ragged_target_sliding_window` reads the Gemma 4 family's sliding window
+    /// (the synthetic fixture uses `sliding_window = 8`) and returns `None` for
+    /// non-Gemma-4 models. This is the value the ragged-eligibility pre-gate in
+    /// `try_run_burst_batched` compares `max_prompt_len` against to decline a
+    /// capped (`max_prompt_len > sliding_window`) window via `Err(seqs)` —
+    /// re-enqueueing for per-row B=1 classic decode instead of committing the
+    /// burst and erroring every row when the in-adapter prefill later declines.
+    #[test]
+    fn ragged_target_sliding_window_reads_gemma4_window() {
+        let _runtime = crate::initialize_runtime();
+        let wrapper = crate::models::gemma4_tests::build_synthetic_wrapper();
+        let model = LoadedModel::Gemma4(wrapper);
+
+        let window = ragged_target_sliding_window(&model)
+            .expect("Gemma4 is a ragged-capable target with a sliding window");
+        assert_eq!(window, 8, "synthetic Gemma4 fixture sliding_window is 8");
+
+        // Gate arithmetic: a window whose longest prompt exceeds `sliding_window`
+        // is the capped regime the pre-gate must decline; one within it is
+        // eligible.
+        assert!(9 > window, "max_prompt_len 9 > window 8 must be declined (capped)");
+        assert!(8 <= window, "max_prompt_len 8 == window 8 is eligible (non-capped)");
     }
 
     #[test]

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -306,6 +306,13 @@ pub(crate) fn spawn_model_worker_with_batch_config(
         // concurrent classic-decode rows head-of-line-block behind it
         // until it completes. The previous earlier wording described the
         // B=1-only behaviour; this reflects the batched path.
+        //
+        // Variable-length-prompt MTP bursts (different prompt lengths in one
+        // B>1 window) are implemented behind the `MLXCEL_ENABLE_MTP_BATCH_RAGGED`
+        // opt-in (subordinate to `MLXCEL_ENABLE_MTP_BATCH`): when enabled the
+        // MTP adapter left-pads the window to `max_prompt_len` (eligible while
+        // `max_prompt_len <= sliding_window`), preserving greedy parity via the
+        // left-padding uniform per-row position shift.
         if sched_config.speculative_dispatch.is_kind_specific() && sched_config.max_batch_size > 1 {
             tracing::info!(
                 "Speculative decoding active ({}) with max_batch_size={}: \
@@ -315,8 +322,9 @@ pub(crate) fn spawn_model_worker_with_batch_config(
                  request that does not match the current window head, or \
                  that arrives alone, runs as a B=1 burst and head-of-line-\
                  blocks concurrent classic-decode rows for its full \
-                 duration. Variable-length-prompt batched bursts are a \
-                 documented follow-up.",
+                 duration. Variable-length-prompt MTP batched bursts are \
+                 available behind MLXCEL_ENABLE_MTP_BATCH_RAGGED=1 (with \
+                 MLXCEL_ENABLE_MTP_BATCH=1).",
                 sched_config.speculative_dispatch.summary(),
                 sched_config.max_batch_size,
             );

--- a/src/vision/gemma4_unified.rs
+++ b/src/vision/gemma4_unified.rs
@@ -343,6 +343,7 @@ impl Gemma4UnifiedModel {
     /// The Unified wrapper holds no batched speculative state of its own — the
     /// batched MTP target adapter owns the `[B, ...]` cache and the inner text
     /// model advances all rows through one forward.
+    #[allow(clippy::too_many_arguments)]
     pub fn forward_with_speculative_sinks_explicit_cache(
         &self,
         input_ids: &MlxArray,
@@ -352,6 +353,7 @@ impl Gemma4UnifiedModel {
         caches: &mut [crate::models::gemma4::Cache],
         capture_layer_ids: Option<&[usize]>,
         sinks: Option<&mut crate::models::Gemma4SpeculativeSinks>,
+        left_padding: Option<&[i32]>,
     ) -> UniquePtr<MlxArray> {
         self.text_model
             .forward_with_speculative_sinks_explicit_cache(
@@ -362,6 +364,7 @@ impl Gemma4UnifiedModel {
                 caches,
                 capture_layer_ids,
                 sinks,
+                left_padding,
             )
     }
 


### PR DESCRIPTION
## Summary

Implements variable-length-prompt support for B>1 batched MTP speculative bursts (issue #161), behind a new `MLXCEL_ENABLE_MTP_BATCH_RAGGED` opt-in subordinate to `MLXCEL_ENABLE_MTP_BATCH`. Today the batched burst only groups concurrent requests whose prompt length is identical, so a variable-length mix serializes into head-of-line-blocking B=1 bursts (~0.78x). This lets burst-eligible rows of different prompt lengths form a single B>1 batched MTP burst, served via left-padding to `max_prompt_len`.

The production default path — including `MLXCEL_ENABLE_MTP_BATCH=1` alone — is unchanged: the validated same-length batched burst stays the default behaviour until the operator also sets the new ragged opt-in. This keeps the work strictly out of the production default while the orchestrator's real-model greedy-parity gate validates the on-hardware behaviour.

## Real-model validation (31B, M5 Max)

**Greedy parity: PASSED.** Four variable-length concurrent requests at temperature 0 form a single ragged B>1 burst and every row's output is byte-identical to classic decode. The previously-broken most-padded row (whose prompt padding was not masked on the single-token `l==1` verify path) now produces the correct output and hits EOS at the right position. The root fix was ensuring the resident prompt-padding mask is applied consistently on the single-token verify forward, not only on the multi-token path.

**Throughput: marginal and not a consistent win.** Measured ~0.94–1.13x vs classic batched decode across runs (confounded by short-row early-EOS). This recovers the prior variable-length serialization penalty (~0.78x) but is not a clear speedup, so `MLXCEL_ENABLE_MTP_BATCH_RAGGED` stays off by default. The issue's conditional default-on flip remains deferred pending a more definitive throughput measurement.

## Greedy-parity mechanism (the must-have)

Parity is preserved **by construction** via the left-padding *uniform per-row position shift*:

- Row `r` (length `L_r`) is left-padded to `max_len`, so its real tokens occupy padded indices `[lp_r, max_len)` with `lp_r = max_len - L_r`. Proportional RoPE is applied with a single scalar offset (`0` at prefill -> position == padded index), so every real token of row `r` is shifted right by the same constant `lp_r` versus a standalone B=1 run that would place it at `[0, L_r)`. Because attention depends only on the relative RoPE phase `q_pos - k_pos`, and both query and key of any in-row pair carry the same `+lp_r` shift, every in-row relative phase — and thus every attention score and every argmax — is preserved. The left-padding mask blocks every real query from attending to the leading padding keys.
- In subsequent verify rounds the shared physical cache offset is uniform for every row (unchanged from the same-length path), so each row's appended verify tokens carry the same `+lp_r` shift end-to-end.
- Seed/finalize metadata is unified through `seed_anchors_from_valid_len` / `build_seed_metadata` with the shifted-frame formula `kv_offset = left_padding + kv_valid_len`, `bonus_position = kv_offset - 1`. The drafter's `set_shared_kv_batched` (already per-row aware) normalizes each row's K/V to the prefix-valid layout via `kv_valid_len` + `left_padding`, and rotates its query at `position_per_row[r] = lp_r + kv_valid_len[r] - 1`. The `lp_r` cancels in every query-key difference, so the drafter's cross-attention relative phases are byte-identical to the same-length path. For equal-length rows (`left_padding == 0`) the formula reduces to the legacy `kv_offset == kv_valid_len` metadata exactly, so the same-length burst is byte-for-byte unchanged.

Net: the ragged path is parity-correct iff the existing same-length batched path is, modulo the prefill left-padding (proven correct) and a metadata shift (shown to cancel). It rides entirely on the same-length foundation the orchestrator already validates.

## CRITICAL fix: out-of-regime windows now fall back cleanly to classic

The capped-regime eligibility check (`max_prompt_len > sliding_window`) originally lived inside the committed batched burst, so when the burst was already in flight its `Err` surfaced as a client-facing `GenerateEvent::Error` to every row in the window rather than the documented per-row classic re-enqueue. Added `ragged_target_sliding_window()` and a pre-gate in `try_run_burst_batched` that returns `Err(seqs)` (clean re-enqueue) before committing the burst whenever a ragged-allowed window exceeds the target sliding window. Confirmed with a real 2576-token prompt (longer than the sliding window): HTTP 200, no error or crash. (Found by pr-reviewer; committed in `fcba29f`, unit-tested.)

## What changed

- `src/lib/mlxcel-core/src/utils.rs` — new `create_causal_mask_with_window_and_left_padding` helper (windowed counterpart of `create_causal_mask_with_left_padding`), restricted to the non-capped key-axis regime (`size + offset <= window`) via a debug assertion. Synthetic tests cover the no-padding fast path, per-row padding-column masking, the causal upper bound, and equivalence to the plain left-padding mask in the non-capped prefill regime.
- `src/server/batch/scheduler.rs` — relax the burst-window predicate (`drain_matching_window`) to drop the prompt-length equality when the ragged flag is on; all other window checks (lane, `max_tokens`, sampling, `can_join`) are unchanged.
- `src/server/batch/speculative_burst.rs` — new `mtp_batched_ragged_window_enabled` flag; `try_run_burst_batched` admits ragged windows only for the MTP dispatch under the flag (DFlash and the unflagged path keep strict equal-length and re-enqueue via `Err`); pre-gate for out-of-regime sliding-window fallback.
- `src/models/gemma4.rs` — new `sliding_window_value()` accessor for the ragged eligibility gate.
- `src/models/gemma4_mtp_target.rs` — left-padding prefill path: `left_padded_input` builder, `prefill_and_seed_batched_ragged` (routed automatically on length mismatch), `batched_sink_forward_with_mask` (passes the single left-padding mask, correct for both full-attention and sliding-window layers in the eligible regime), persisted per-row `left_padding` state threaded through `verify_finalize_batched`, and the unified `build_seed_metadata` / `seed_anchors_from_valid_len` formula. Eligibility is restricted to `max_prompt_len <= sliding_window`; outside it the adapter declines (`Err`) and the scheduler re-enqueues for per-row B=1 service.
- `src/server/model_worker.rs` — server-startup notice updated to document the opt-in.
- Synthetic tests in `queue.rs` (ragged window formation on/off), `gemma4_mtp_target_tests.rs` (padding builder, per-row position/anchor derivation), and `speculative_burst.rs` (flag default-off).

## Implemented vs deferred

- Implemented end-to-end behind `MLXCEL_ENABLE_MTP_BATCH_RAGGED`: ragged window formation, ragged left-padded prefill + per-row positions/mask, per-row accept/EOS/retire (the batched round loop and drafter were already per-row aware and are reused unchanged).
- Deferred (clean fallback, not half-wired): the capped-RotatingKVCache regime (`max_prompt_len > sliding_window`) is declined per-row rather than served, because the windowed left-padding mask is only validated in the non-capped regime. The default-on flip of `MLXCEL_ENABLE_MTP_BATCH` is explicitly out of scope (the issue marks it conditional/future); this stays behind the existing flag.

## Known follow-ups (not blocking)

**MEDIUM — fully-masked padding query rows may produce NaN.** When a row's prompt is the shortest in the window its first query positions are entirely padding (all keys masked). MLX SDPA currently returns finite values for fully-masked columns by convention, but this is not a guaranteed contract. The correct fix is to explicitly zero or skip those query rows rather than relying on the masked-column semantics. Not yet observed to cause incorrect output (the real-model parity gate passed), but is a latent correctness risk under future MLX updates.

**MEDIUM — target verify forward does not mask each row's per-row valid-length tail after mixed accepts.** After a round with mixed accept counts the rows have different numbers of newly accepted tokens appended. The verify forward does not yet mask the tail beyond each row's valid length. This is inherited from the validated same-length path (where all rows accept identically), but in the ragged case rows may diverge earlier. Not observed to affect output in the greedy parity runs, but is a correctness gap for future non-trivial mixed-accept sequences.

**LOW — latent off-by-one in the test-only `make_drafter_masks` wrapper.** The production drafter mask path is unaffected; this is isolated to the test helper. Tracked for a future test-cleanup pass.

## Test plan

- [x] `cargo check --lib --tests` (clean)
- [x] `cargo clippy --lib --tests -- -D warnings` (clean)
- [x] `cargo test -p mlxcel-core --lib utils::tests::windowed_left_padding` (3 passed)
- [x] `cargo test --lib gemma4_mtp_target` (23 passed, incl. 6 new ragged)
- [x] `cargo test --lib batch::queue` (23 passed, incl. 3 new ragged-window)
- [x] `cargo test --lib batch::speculative_burst` (46 passed, incl. ragged flag)
- [x] `cargo test -p mlxcel-core --lib round_loop_batched` (21 passed — existing batched parity unchanged)
- [x] `cargo test --lib scheduler` (160 passed — no regression)
- [x] Real-model 31B greedy-parity gate PASSED: 4 variable-length requests, every row byte-identical to classic decode at temperature 0 (including the previously-broken most-padded row)
- [x] Real-model out-of-regime fallback confirmed: 2576-token prompt returns HTTP 200, no error or crash

Closes #161