### PR TITLE
feat: back paged scheduler sequences with the shared KV block pool

### DIFF
--- a/src/distributed/kv_cache_serde/deserialize.rs
+++ b/src/distributed/kv_cache_serde/deserialize.rs
@@ -168,7 +168,11 @@ pub fn restore_into_sequence_cache_set(
     match (&state.paged_state, cache_set.backend) {
         (Some(serialized), mlxcel_core::cache::SequenceStateBackend::PagedKvCache) => {
             let runtime = serialized.to_runtime()?;
-            cache_set.paged = Some(runtime);
+            // `SequenceCacheSet::paged` is a shared `Rc<RefCell<…>>` so pool-backed
+            // sequences can alias one block table across their per-layer caches
+            // (#121). A deserialized sequence is freshly restored with no live
+            // caches yet, so it is the sole owner.
+            cache_set.paged = Some(std::rc::Rc::new(std::cell::RefCell::new(runtime)));
         }
         (Some(_), _) => {
             bail!("cannot restore paged state into a non-paged sequence cache set");

--- a/src/distributed/kv_cache_serde/serialize.rs
+++ b/src/distributed/kv_cache_serde/serialize.rs
@@ -211,6 +211,6 @@ pub fn serialize_sequence_cache_set(
         paged_state: cache_set
             .paged_state()
             .zip(cache_set.paged_layout())
-            .map(|(state, layout)| SerializablePagedSequenceState::from_runtime(state, layout)),
+            .map(|(state, layout)| SerializablePagedSequenceState::from_runtime(&state, layout)),
     }
 }

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -104,7 +104,7 @@ pub use paged::{
 };
 pub use paged_detach::DetachedPagedCacheSet;
 
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
 
 use crate::concatenate;
@@ -565,6 +565,19 @@ impl KVCache {
         cache
     }
 
+    /// Whether this cache writes/reads through a shared [`PagedBlockPool`]
+    /// (built via [`Self::new_paged`]) instead of its own dense buffers.
+    ///
+    /// The batched-decode dispatch in each transformer model uses this to skip
+    /// the native dense-pointer paged kernel (which reads `keys`/`values`, both
+    /// `None` here) and fall through to the per-sequence `update_and_fetch`
+    /// loop, whose pool intercept transparently writes to the pool and gathers
+    /// the visible window. See the model `forward_split_attention` dispatch.
+    #[inline]
+    pub fn is_paged_backed(&self) -> bool {
+        self.paged_backing.is_some()
+    }
+
     /// Override the Turbo4Delegated hot-tail fold threshold for this cache.
     ///
     /// Test-only entry point for the unit/integration tests in `turbo_tests.rs`
@@ -748,6 +761,18 @@ impl KVCache {
     /// using independent sign-vector pairs. In `KVCacheMode::Fp16` this
     /// behaves identically to the original implementation.
     pub fn update(&mut self, new_keys: UniquePtr<MlxArray>, new_values: UniquePtr<MlxArray>) {
+        // Transparent pool-backed path (`new_paged`): append straight into the
+        // shared `PagedBlockPool` instead of the dense buffers, mirroring the
+        // `update_and_fetch` intercept. This is reached by callers that write
+        // the cache without needing the gathered window back — notably the
+        // single-sequence fused causal prefill path (llama3), where the fused
+        // Metal kernel has already produced the attention output. Returns early
+        // so the dense `update_*` below never runs and no dense buffer is
+        // allocated. See `new_paged` / `write_paged`.
+        if self.paged_backing.is_some() {
+            self.write_paged(&new_keys, &new_values);
+            return;
+        }
         match self.mode {
             KVCacheMode::Int8 => self.update_int8(new_keys, new_values),
             KVCacheMode::Turbo4Asym => self.update_turbo4_asym(new_keys, new_values),
@@ -2068,6 +2093,14 @@ impl KVCache {
         if n <= 0 {
             return 0;
         }
+        // Pool-backed caches keep no dense `keys`/`values` buffers (#121); the
+        // block table is the authoritative store and is trimmed through the
+        // pool API (`CachePool::trim_paged_tokens` / `rewind_paged_tokens`),
+        // never the dense buffer slicing below (which would `unwrap` a `None`
+        // buffer). Treat a dense-side trim as a no-op for them.
+        if self.paged_backing.is_some() {
+            return 0;
+        }
         // Turbo4Delegated: hot-first trim. Tokens to remove from cold = max(0, n - hot_len).
         // We adjust cold_offset and offset, then fall through to the per-mode buffer slicing
         // logic below to keep the buffers consistent with the new offsets.
@@ -2339,6 +2372,16 @@ impl KVCache {
             return 0;
         }
 
+        // Pool-backed caches (#121) hold no dense head buffer to slice from the
+        // front, and advancing `live_start` here would desync the cache from the
+        // pool's authoritative block table (which the gather reads via the
+        // per-sequence state, not `live_start`). The `--max-kv-size` cap for
+        // paged sequences is a pool-side concern; treat the dense-side front
+        // trim as a no-op so it never silently diverges.
+        if self.paged_backing.is_some() {
+            return 0;
+        }
+
         // Only Fp16 and Int8 are supported; Turbo modes carry rotation
         // state in their sidecars that is not safe to truncate from the
         // head. `live_start` must remain `0` for those modes so the Turbo
@@ -2585,35 +2628,68 @@ impl KVCache {
         new_keys: &MlxArray,
         new_values: &MlxArray,
     ) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
+        // Append the new tokens (no-op for a zero-token call), then gather the
+        // full visible window. Splitting the write into `write_paged` lets the
+        // no-fetch `update` path reuse the exact same pool-append logic.
+        self.write_paged(new_keys, new_values);
+
         let backing = self
             .paged_backing
             .clone()
             .expect("update_and_fetch_paged called without paged backing");
+        let state = backing.state.borrow();
+        let pool = backing.pool.borrow();
+        pool.gather_visible(&state, backing.layer_idx)
+            .expect("PagedBlockPool::gather_visible failed for pool-backed cache")
+            .expect("gather_visible returned None for a pool-backed cache")
+    }
+
+    /// Pool-write half of the pool-backed cache path: append the new K/V
+    /// tokens to this layer's tail inside the shared [`PagedBlockPool`]
+    /// (`write_prefill` handles both bulk prefill and a single decode token)
+    /// and advance the monotonic `offset`.
+    ///
+    /// Shared by [`Self::update`] (no fetch) and
+    /// [`Self::update_and_fetch_paged`] (which gathers the visible window
+    /// afterward). A zero-token call is a no-op so callers can pass an empty
+    /// update without special-casing. The pool/state borrows are scoped tightly
+    /// to this method so they never nest with the gather in
+    /// `update_and_fetch_paged` or any scheduler-side borrow.
+    ///
+    /// `offset` is advanced by `n_new` for the same reason
+    /// [`Self::update_fp16`] advances it: RoPE reads `cache.offset` *before*
+    /// the next step's update, so it must reflect the pre-call position during
+    /// RoPE and the post-call position afterward. The paged
+    /// `state.layers[layer_idx].len` is bumped in lockstep by `write_prefill`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the backing is missing, the K/V batch dim is not `1`, or the
+    /// pool `write_prefill` fails (geometry mismatch). The model `forward`
+    /// signature returns plain tuples, so a misuse is a hard bug, not a
+    /// recoverable condition.
+    fn write_paged(&mut self, new_keys: &MlxArray, new_values: &MlxArray) {
+        let backing = self
+            .paged_backing
+            .clone()
+            .expect("write_paged called without paged backing");
         let layer_idx = backing.layer_idx;
 
         let k_shape = ffi::array_shape(new_keys);
         assert_eq!(
             k_shape.len(),
             4,
-            "update_and_fetch_paged: K must be [1, n_kv_heads, n_new, head_dim], got shape {k_shape:?}"
+            "write_paged: K must be [1, n_kv_heads, n_new, head_dim], got shape {k_shape:?}"
         );
         assert_eq!(
             k_shape[0], 1,
-            "update_and_fetch_paged: only single-stream (B == 1) is supported, got batch {} (shape {k_shape:?})",
+            "write_paged: only single-stream (B == 1) is supported, got batch {} (shape {k_shape:?})",
             k_shape[0]
         );
         let n_new = k_shape[2];
         if n_new <= 0 {
-            // Nothing to append; gather whatever is currently visible (the
-            // gather expects to return a non-empty window only when tokens
-            // exist — mirror the dense early paths by returning the current
-            // visible slice).
-            let state = backing.state.borrow();
-            let pool = backing.pool.borrow();
-            return pool
-                .gather_visible(&state, layer_idx)
-                .expect("gather_visible failed on empty append")
-                .expect("gather_visible returned None for a zero-token update");
+            // Nothing to append; leave the offset and pool untouched.
+            return;
         }
 
         {
@@ -2624,15 +2700,9 @@ impl KVCache {
         }
 
         // Advance the monotonic write position. RoPE for the *next* step reads
-        // `cache.offset` before calling back into `update_and_fetch`, so this
-        // mirrors the dense `update_fp16` bump exactly.
+        // `cache.offset` before calling back into the cache, so this mirrors
+        // the dense `update_fp16` bump exactly.
         self.offset += n_new;
-
-        let state = backing.state.borrow();
-        let pool = backing.pool.borrow();
-        pool.gather_visible(&state, layer_idx)
-            .expect("PagedBlockPool::gather_visible failed after write_prefill")
-            .expect("gather_visible returned None despite a non-empty write")
     }
 
     /// Read path for `KVCacheMode::Turbo4Delegated` (K unified; cold-V dequant memo retired).
@@ -5277,7 +5347,17 @@ pub struct SequenceCacheSet {
     /// Per-layer KV caches (one entry per model layer).
     pub caches: Vec<KVCache>,
     /// Paged block-table state when `backend == PagedKvCache`.
-    pub paged: Option<PagedSequenceState>,
+    ///
+    /// Wrapped in `Rc<RefCell<…>>` so a pool-backed sequence can share the
+    /// SAME state handle with every per-layer [`KVCache`] (each cache's
+    /// [`PagedBacking`] holds a cheap `Rc` clone). The pool-backed caches and
+    /// this set therefore observe one authoritative block table. Dense and
+    /// model-owned sequences leave this `None`. The interior mutability is only
+    /// ever exercised at request boundaries (allocate / sync / release) and
+    /// inside `update_and_fetch` during forward — never both at once — so the
+    /// borrows stay non-overlapping (see the borrow-discipline notes on the
+    /// `CachePool` paged methods).
+    pub paged: Option<Rc<RefCell<PagedSequenceState>>>,
     /// Unique identifier assigned by the pool.
     pub seq_id: SequenceId,
     /// Number of prompt tokens originally prefilled.
@@ -5294,7 +5374,7 @@ impl SequenceCacheSet {
         seq_id: SequenceId,
         backend: SequenceStateBackend,
         caches: Vec<KVCache>,
-        paged: Option<PagedSequenceState>,
+        paged: Option<Rc<RefCell<PagedSequenceState>>>,
         paged_layout: Option<PagedKvLayout>,
     ) -> Self {
         Self {
@@ -5327,7 +5407,7 @@ impl SequenceCacheSet {
             seq_id,
             SequenceStateBackend::PagedKvCache,
             Vec::new(),
-            Some(paged),
+            Some(Rc::new(RefCell::new(paged))),
             Some(paged_layout),
         )
     }
@@ -5350,28 +5430,42 @@ impl SequenceCacheSet {
             .paged
             .as_ref()
             .zip(self.paged_layout.as_ref())
-            .map_or(0, |(state, layout)| state.used_bytes(layout));
+            .map_or(0, |(state, layout)| state.borrow().used_bytes(layout));
         dense_bytes + paged_bytes
     }
 
-    pub fn paged_state(&self) -> Option<&PagedSequenceState> {
-        self.paged.as_ref()
+    /// Borrow this sequence's paged block-table state for reading.
+    ///
+    /// Returns a [`Ref`] guard; the borrow must be released before any code
+    /// path mutates the same state (e.g. `update_and_fetch` during forward or
+    /// `CachePool::sync_paged_state_with_*`). `None` for dense / model-owned
+    /// sequences.
+    pub fn paged_state(&self) -> Option<Ref<'_, PagedSequenceState>> {
+        self.paged.as_ref().map(|rc| rc.borrow())
     }
 
-    pub fn paged_state_mut(&mut self) -> Option<&mut PagedSequenceState> {
-        self.paged.as_mut()
+    /// Mutably borrow this sequence's paged block-table state.
+    ///
+    /// Returns a [`RefMut`] guard. See [`Self::paged_state`] for the borrow
+    /// discipline; never hold this across a call that re-borrows the same
+    /// state.
+    pub fn paged_state_mut(&mut self) -> Option<RefMut<'_, PagedSequenceState>> {
+        self.paged.as_ref().map(|rc| rc.borrow_mut())
     }
 
     pub fn paged_stats(&self) -> Option<PagedCacheStats> {
         self.paged
             .as_ref()
             .zip(self.paged_layout.as_ref())
-            .map(|(state, layout)| PagedCacheStats {
-                allocated_blocks: state.reserved_blocks(),
-                live_blocks: state.reserved_blocks(),
-                free_blocks: 0,
-                bytes_reserved: state.reserved_bytes(layout),
-                bytes_in_use: state.used_bytes(layout),
+            .map(|(state, layout)| {
+                let state = state.borrow();
+                PagedCacheStats {
+                    allocated_blocks: state.reserved_blocks(),
+                    live_blocks: state.reserved_blocks(),
+                    free_blocks: 0,
+                    bytes_reserved: state.reserved_bytes(layout),
+                    bytes_in_use: state.used_bytes(layout),
+                }
             })
     }
 
@@ -5392,7 +5486,15 @@ pub struct CachePool {
     next_id: AtomicU64,
     active: HashMap<SequenceId, SequenceCacheSet>,
     max_sequences: usize,
-    paged_pool: Option<PagedBlockPool>,
+    /// Shared paged block pool, lazily created on first paged allocation.
+    ///
+    /// Wrapped in `Rc<RefCell<…>>` so pool-backed [`KVCache`]s can hold a cheap
+    /// `Rc` clone and write/read the pool transparently from inside
+    /// `update_and_fetch` during forward, while the scheduler borrows the same
+    /// pool at request boundaries. The two never nest: the per-request pool
+    /// borrows here all drop before the model forward runs, and the forward's
+    /// `update_and_fetch` borrows drop before control returns to the scheduler.
+    paged_pool: Option<Rc<RefCell<PagedBlockPool>>>,
     /// Detached cache sets parked inside the pool during cross-request
     /// handoffs. See [`detach`] for the full design.
     detached: detach::DetachedMap,
@@ -5454,11 +5556,50 @@ impl CachePool {
                     "CachePool: paged backend requires a paged layout".to_string()
                 })?;
                 self.ensure_paged_pool(&paged_layout)?;
+                let state_rc = Rc::new(RefCell::new(PagedSequenceState::new(&paged_layout)));
+
+                // Build the per-layer caches. Pool-backed caches are wired only
+                // when BOTH hold:
+                //
+                //  * the model's NATURAL backend is the dense external KVCache
+                //    slice (`supports_batching()` transformers — qwen3 / llama3).
+                //    These actually read/write the caches handed to `forward`, so
+                //    pool-backing routes their `update_and_fetch` straight into
+                //    the shared `PagedBlockPool` (`write_prefill` + `gather_visible`).
+                //    Model-owned families (gemma3 / llama4 / qwen3_5) ignore the
+                //    caller's slice and drive their own `ModelOwnedSequenceState`;
+                //    the scheduler still routes them through the paged backend for
+                //    shadow block-table accounting (`sync_paged_state_with_lengths`),
+                //    so their placeholders stay dense — byte-identical to before.
+                //    Paged-natural test stubs likewise keep dense placeholders.
+                //
+                //  * the paged layout is Fp16. The pool-backed `update_and_fetch`
+                //    intercept stores raw Fp16 K/V (the #152-validated path);
+                //    Turbo4 paged layouts carry their own `cache_mode` and keep
+                //    the existing dense quantized path untouched.
+                let natural_backend = model.sequence_state_layout().backend;
+                let pool_backed = natural_backend == SequenceStateBackend::DenseKvCache
+                    && paged_layout.cache_mode == KVCacheMode::Fp16;
+                let caches = if pool_backed {
+                    let pool_rc = self
+                        .paged_pool
+                        .as_ref()
+                        .expect("paged pool exists after ensure_paged_pool")
+                        .clone();
+                    (0..paged_layout.num_layers)
+                        .map(|layer_idx| {
+                            KVCache::new_paged(pool_rc.clone(), state_rc.clone(), layer_idx)
+                        })
+                        .collect()
+                } else {
+                    model.make_caches()
+                };
+
                 SequenceCacheSet::with_backend(
                     id,
                     SequenceStateBackend::PagedKvCache,
-                    model.make_caches(),
-                    Some(PagedSequenceState::new(&paged_layout)),
+                    caches,
+                    Some(state_rc),
                     Some(paged_layout),
                 )
             }
@@ -5474,11 +5615,14 @@ impl CachePool {
         self.active.get_mut(&id)
     }
 
-    pub fn get_paged_state(&self, id: SequenceId) -> Option<&PagedSequenceState> {
+    pub fn get_paged_state(&self, id: SequenceId) -> Option<Ref<'_, PagedSequenceState>> {
         self.active.get(&id)?.paged_state()
     }
 
-    pub fn get_paged_state_mut(&mut self, id: SequenceId) -> Option<&mut PagedSequenceState> {
+    pub fn get_paged_state_mut(
+        &mut self,
+        id: SequenceId,
+    ) -> Option<RefMut<'_, PagedSequenceState>> {
         self.active.get_mut(&id)?.paged_state_mut()
     }
 
@@ -5522,11 +5666,14 @@ impl CachePool {
     ///
     /// This is a no-op if `id` is not currently active.
     pub fn release(&mut self, id: SequenceId) {
-        if let Some(mut sequence) = self.active.remove(&id) {
-            if let Some(pool) = self.paged_pool.as_mut() {
-                if let Some(state) = sequence.paged_state_mut() {
-                    let _ = pool.release_sequence(state);
-                }
+        if let Some(sequence) = self.active.remove(&id) {
+            // Borrow the pool and this sequence's state through their shared
+            // cells. The released sequence's pool-backed caches (if any) hold
+            // sibling `Rc` clones of `state`, but they are never forwarded at
+            // release time, so `borrow_mut` here cannot collide. Both borrows
+            // drop before `sequence` (and thus those caches) drop.
+            if let (Some(pool), Some(state)) = (self.paged_pool.as_ref(), sequence.paged.as_ref()) {
+                let _ = pool.borrow_mut().release_sequence(&mut state.borrow_mut());
             }
         }
     }
@@ -5560,9 +5707,40 @@ impl CachePool {
         let pool_bytes: usize = self
             .paged_pool
             .as_ref()
-            .map(|pool| pool.turbo_sidecar_bytes() + pool.pool_tensor_bytes())
+            .map(|pool| {
+                let pool = pool.borrow();
+                pool.turbo_sidecar_bytes() + pool.pool_tensor_bytes()
+            })
             .unwrap_or(0);
         active_bytes + parked_bytes + pool_bytes
+    }
+
+    /// Run `f` with mutable access to both the shared block pool and one
+    /// sequence's paged state, borrowing each cell exactly once.
+    ///
+    /// Centralizes the dual `borrow_mut` so the public paged-token mutators
+    /// keep tight, non-overlapping borrow scopes (the pool and the per-sequence
+    /// state are distinct `RefCell`s, so the two `borrow_mut`s never collide).
+    /// The closure must not re-borrow either cell.
+    fn with_pool_and_state<R>(
+        &self,
+        id: SequenceId,
+        f: impl FnOnce(&mut PagedBlockPool, &mut PagedSequenceState) -> Result<R, String>,
+    ) -> Result<R, String> {
+        let pool = self
+            .paged_pool
+            .as_ref()
+            .ok_or_else(|| "CachePool: paged backend is not initialized".to_string())?;
+        let state = self
+            .active
+            .get(&id)
+            .ok_or_else(|| format!("CachePool: sequence {id} not found"))?
+            .paged
+            .as_ref()
+            .ok_or_else(|| format!("CachePool: sequence {id} is not paged"))?;
+        let mut pool = pool.borrow_mut();
+        let mut state = state.borrow_mut();
+        f(&mut pool, &mut state)
     }
 
     pub fn append_paged_tokens(
@@ -5571,17 +5749,9 @@ impl CachePool {
         layer_idx: usize,
         token_count: usize,
     ) -> Result<(), String> {
-        let pool = self
-            .paged_pool
-            .as_mut()
-            .ok_or_else(|| "CachePool: paged backend is not initialized".to_string())?;
-        let state = self
-            .active
-            .get_mut(&id)
-            .ok_or_else(|| format!("CachePool: sequence {id} not found"))?
-            .paged_state_mut()
-            .ok_or_else(|| format!("CachePool: sequence {id} is not paged"))?;
-        pool.append_tokens(state, layer_idx, token_count)
+        self.with_pool_and_state(id, |pool, state| {
+            pool.append_tokens(state, layer_idx, token_count)
+        })
     }
 
     pub fn trim_paged_tokens(
@@ -5590,17 +5760,9 @@ impl CachePool {
         layer_idx: usize,
         token_count: usize,
     ) -> Result<usize, String> {
-        let pool = self
-            .paged_pool
-            .as_mut()
-            .ok_or_else(|| "CachePool: paged backend is not initialized".to_string())?;
-        let state = self
-            .active
-            .get_mut(&id)
-            .ok_or_else(|| format!("CachePool: sequence {id} not found"))?
-            .paged_state_mut()
-            .ok_or_else(|| format!("CachePool: sequence {id} is not paged"))?;
-        pool.trim_tokens(state, layer_idx, token_count)
+        self.with_pool_and_state(id, |pool, state| {
+            pool.trim_tokens(state, layer_idx, token_count)
+        })
     }
 
     pub fn rewind_paged_tokens(
@@ -5609,51 +5771,51 @@ impl CachePool {
         layer_idx: usize,
         token_count: usize,
     ) -> Result<usize, String> {
-        let pool = self
-            .paged_pool
-            .as_mut()
-            .ok_or_else(|| "CachePool: paged backend is not initialized".to_string())?;
-        let state = self
-            .active
-            .get_mut(&id)
-            .ok_or_else(|| format!("CachePool: sequence {id} not found"))?
-            .paged_state_mut()
-            .ok_or_else(|| format!("CachePool: sequence {id} is not paged"))?;
-        pool.rewind_tokens(state, layer_idx, token_count)
+        self.with_pool_and_state(id, |pool, state| {
+            pool.rewind_tokens(state, layer_idx, token_count)
+        })
     }
 
     pub fn paged_stats(&self) -> Option<PagedCacheStats> {
         let pool = self.paged_pool.as_ref()?;
+        // Collect the per-sequence borrows first, then hand `stats_for_sequences`
+        // plain references. The pool and each sequence state live in distinct
+        // `RefCell`s, so the pool borrow and these state borrows coexist.
+        let states: Vec<Ref<'_, PagedSequenceState>> = self
+            .active
+            .values()
+            .filter_map(|sequence| sequence.paged_state())
+            .collect();
         Some(
-            pool.stats_for_sequences(
-                self.active
-                    .values()
-                    .filter_map(|sequence| sequence.paged_state()),
-            ),
+            pool.borrow()
+                .stats_for_sequences(states.iter().map(|state| &**state)),
         )
     }
 
     pub fn paged_block_size(&self) -> Option<usize> {
         self.paged_pool
             .as_ref()
-            .map(|pool| pool.layout().block_size)
+            .map(|pool| pool.borrow().layout().block_size)
     }
 
     /// Read-only access to the underlying [`PagedBlockPool`].
     ///
-    /// Used by: tests and read-only diagnostics that need to peek at per-page
-    /// Turbo4 sidecar state without going through the higher-level
+    /// Returns a [`Ref`] guard; release it before any path that mutates the
+    /// pool. Used by: tests and read-only diagnostics that need to peek at
+    /// per-page Turbo4 sidecar state without going through the higher-level
     /// `CachePool` API.
-    pub fn paged_pool_ref(&self) -> Option<&PagedBlockPool> {
-        self.paged_pool.as_ref()
+    pub fn paged_pool_ref(&self) -> Option<Ref<'_, PagedBlockPool>> {
+        self.paged_pool.as_ref().map(|pool| pool.borrow())
     }
 
     /// Mutable access to the underlying [`PagedBlockPool`].
     ///
-    /// Used by: scheduler / model code that installs Turbo4 sidecar pages
-    /// directly on the pool, and by unit tests for the same purpose.
-    pub fn paged_pool_mut(&mut self) -> Option<&mut PagedBlockPool> {
-        self.paged_pool.as_mut()
+    /// Returns a [`RefMut`] guard tied to `&mut self`, so the compiler still
+    /// enforces exclusive pool access at the borrow site. Used by: scheduler /
+    /// model code that installs Turbo4 sidecar pages directly on the pool, and
+    /// by unit tests for the same purpose.
+    pub fn paged_pool_mut(&mut self) -> Option<RefMut<'_, PagedBlockPool>> {
+        self.paged_pool.as_ref().map(|pool| pool.borrow_mut())
     }
 
     /// Mirror the visible dense-cache offsets into the paged backend state for
@@ -5662,15 +5824,28 @@ impl CachePool {
     /// This keeps server decode/pre-fill lifecycle bookkeeping aligned while
     /// the actual model execution still runs on dense compatibility caches.
     pub fn sync_paged_state_with_dense(&mut self, id: SequenceId) -> Result<(), String> {
-        let sequence = self
-            .active
-            .get_mut(&id)
-            .ok_or_else(|| format!("CachePool: sequence {id} not found"))?;
-        let target_lens: Vec<usize> = sequence
-            .caches
-            .iter()
-            .map(|cache| cache.seq_len().max(0) as usize)
-            .collect();
+        let target_lens = {
+            let sequence = self
+                .active
+                .get(&id)
+                .ok_or_else(|| format!("CachePool: sequence {id} not found"))?;
+            // Pool-backed paged sequences are authoritative: `write_prefill`
+            // advances each layer's `len` in lockstep with the cache offset
+            // during forward, so mirroring the dense-cache lengths here is
+            // redundant — and the dense placeholder buffers are empty, so the
+            // mirror would trim the live block table to zero. Skip them.
+            // Model-owned families never reach this path; they override
+            // `sync_sequence_storage` to call `sync_paged_state_with_lengths`
+            // with their own model-owned cache lengths.
+            if sequence.caches.iter().any(|cache| cache.is_paged_backed()) {
+                return Ok(());
+            }
+            sequence
+                .caches
+                .iter()
+                .map(|cache| cache.seq_len().max(0) as usize)
+                .collect::<Vec<usize>>()
+        };
         self.sync_paged_state_with_lengths(id, &target_lens)
     }
 
@@ -5680,18 +5855,25 @@ impl CachePool {
         id: SequenceId,
         target_lens: &[usize],
     ) -> Result<(), String> {
-        let pool = match self.paged_pool.as_mut() {
+        let pool = match self.paged_pool.as_ref() {
             Some(pool) => pool,
             None => return Ok(()),
         };
-        let sequence = self
-            .active
-            .get_mut(&id)
-            .ok_or_else(|| format!("CachePool: sequence {id} not found"))?;
-        let state = match sequence.paged_state_mut() {
-            Some(state) => state,
-            None => return Ok(()),
+        let state_cell = match self.active.get(&id) {
+            Some(sequence) => match sequence.paged.as_ref() {
+                Some(state) => state,
+                None => return Ok(()),
+            },
+            None => return Err(format!("CachePool: sequence {id} not found")),
         };
+
+        // The pool and the per-sequence state live in distinct `RefCell`s, so
+        // both `borrow_mut`s coexist. For model-owned models (gemma3/llama4/
+        // qwen3_5) this is the authoritative length sync; for the pool-backed
+        // dense-natural path (qwen3/llama3) the lengths already match because
+        // `write_prefill` advanced them in lockstep, so the loop is a no-op.
+        let mut pool = pool.borrow_mut();
+        let mut state = state_cell.borrow_mut();
 
         if target_lens.len() != state.layers.len() {
             return Err(format!(
@@ -5704,9 +5886,9 @@ impl CachePool {
         for (layer_idx, target_len) in target_lens.iter().copied().enumerate() {
             let current_len = state.layers[layer_idx].len;
             if target_len > current_len {
-                pool.append_tokens(state, layer_idx, target_len - current_len)?;
+                pool.append_tokens(&mut state, layer_idx, target_len - current_len)?;
             } else if target_len < current_len {
-                pool.trim_tokens(state, layer_idx, current_len - target_len)?;
+                pool.trim_tokens(&mut state, layer_idx, current_len - target_len)?;
             }
         }
         Ok(())
@@ -5749,7 +5931,7 @@ impl CachePool {
             ));
         }
 
-        let mut existing = {
+        let existing = {
             let sequence = self
                 .active
                 .get_mut(&id)
@@ -5758,20 +5940,23 @@ impl CachePool {
         };
 
         self.ensure_paged_pool(&layout)?;
-        let pool = self
-            .paged_pool
-            .as_mut()
-            .expect("paged pool must exist after ensure_paged_pool");
-        if let Some(existing) = existing.as_mut() {
-            pool.release_sequence(existing)?;
+        {
+            let pool = self
+                .paged_pool
+                .as_ref()
+                .expect("paged pool must exist after ensure_paged_pool");
+            let mut pool = pool.borrow_mut();
+            if let Some(existing) = existing.as_ref() {
+                pool.release_sequence(&mut existing.borrow_mut())?;
+            }
+            pool.restore_sequence(&restored)?;
         }
-        pool.restore_sequence(&restored)?;
 
         let sequence = self
             .active
             .get_mut(&id)
             .ok_or_else(|| format!("CachePool: sequence {id} not found"))?;
-        sequence.paged = Some(restored);
+        sequence.paged = Some(Rc::new(RefCell::new(restored)));
         Ok(())
     }
 
@@ -5782,12 +5967,12 @@ impl CachePool {
 
     fn ensure_paged_pool(&mut self, layout: &PagedKvLayout) -> Result<(), String> {
         if let Some(pool) = self.paged_pool.as_ref() {
-            if pool.layout() != layout {
+            if pool.borrow().layout() != layout {
                 return Err("CachePool: paged layout mismatch for active paged backend".to_string());
             }
             return Ok(());
         }
-        self.paged_pool = Some(PagedBlockPool::new(layout.clone()));
+        self.paged_pool = Some(Rc::new(RefCell::new(PagedBlockPool::new(layout.clone()))));
         Ok(())
     }
 }
@@ -6462,6 +6647,43 @@ mod tests {
         }
     }
 
+    /// Paged sequence whose per-layer caches are dense placeholders driven by
+    /// the model (mirrors the gemma3 / llama4 model-owned + paged shape). Its
+    /// natural backend is `ModelOwned`, so the `allocate` pool-backed gate keeps
+    /// `make_caches()` dense — exercising the dense-length mirror path of
+    /// `sync_paged_state_with_dense` that #121 left in place for non-pool-backed
+    /// paged sequences.
+    struct ShadowDenseModel {
+        num_layers: usize,
+    }
+
+    impl crate::generate::LanguageModel for ShadowDenseModel {
+        fn forward(
+            &self,
+            _input_ids: &MlxArray,
+            _caches: &mut [KVCache],
+            _mask: Option<&MlxArray>,
+        ) -> UniquePtr<MlxArray> {
+            ffi::zeros(&[1], 0)
+        }
+
+        fn make_caches(&self) -> Vec<KVCache> {
+            (0..self.num_layers).map(|_| KVCache::new()).collect()
+        }
+
+        fn num_layers(&self) -> usize {
+            self.num_layers
+        }
+
+        fn eos_token_ids(&self) -> Vec<i32> {
+            vec![0]
+        }
+
+        fn sequence_state_layout(&self) -> SequenceStateLayout {
+            SequenceStateLayout::model_owned(self.num_layers)
+        }
+    }
+
     struct PagedModel {
         layout: PagedKvLayout,
     }
@@ -6823,7 +7045,8 @@ mod tests {
         pool.append_paged_tokens(id1, 0, 6).unwrap();
 
         let (first_block, second_block) = {
-            let layer = pool.get_paged_state(id1).unwrap().layer(0).unwrap();
+            let state = pool.get_paged_state(id1).unwrap();
+            let layer = state.layer(0).unwrap();
             assert_eq!(layer.len, 6);
             assert_eq!(layer.visible_len(), 6);
             assert_eq!(layer.reserved_blocks(), 2);
@@ -6855,7 +7078,8 @@ mod tests {
 
         assert_eq!(pool.rewind_paged_tokens(id1, 0, 2).unwrap(), 2);
         {
-            let layer = pool.get_paged_state(id1).unwrap().layer(0).unwrap();
+            let state = pool.get_paged_state(id1).unwrap();
+            let layer = state.layer(0).unwrap();
             assert_eq!(layer.len, 3);
             assert_eq!(layer.block_ids, vec![first_block]);
         }
@@ -6922,10 +7146,20 @@ mod tests {
 
     #[test]
     fn sync_paged_state_with_dense_cache_offsets_tracks_rewinds() {
-        let model = StubModel { num_layers: 1 };
+        // `ShadowDenseModel` is model-owned, so the `allocate` pool-backed gate
+        // keeps its caches dense — this is the path where the dense-length
+        // mirror is the authoritative length source (#121 keeps it for
+        // non-pool-backed paged sequences).
+        let model = ShadowDenseModel { num_layers: 1 };
         let mut pool = CachePool::new(4);
         let layout = SequenceStateLayout::paged_kv_cache(PagedKvLayout::uniform(1, 4, 4).unwrap());
         let id = pool.allocate_with_layout(&model, Some(layout)).unwrap();
+        // Sanity: this sequence must NOT be pool-backed, otherwise the dense
+        // mirror below would be (correctly) skipped.
+        assert!(
+            !pool.get_caches_mut(id).unwrap()[0].is_paged_backed(),
+            "model-owned paged sequence must keep dense placeholder caches"
+        );
 
         {
             let caches = pool.get_caches_mut(id).unwrap();
@@ -6942,6 +7176,37 @@ mod tests {
         }
         pool.sync_paged_state_with_dense(id).unwrap();
         assert_eq!(pool.get_paged_state(id).unwrap().layer(0).unwrap().len, 2);
+    }
+
+    #[test]
+    fn sync_paged_state_with_dense_skips_pool_backed_sequences() {
+        // A dense-natural Fp16 model gets pool-backed paged caches (#121). The
+        // pool is authoritative: `update` writes straight into it and advances
+        // `state.len` in lockstep, so `sync_paged_state_with_dense` must be a
+        // no-op and must NOT mirror (and thus zero out) the live block table
+        // from the empty dense placeholder buffers.
+        let model = StubModel { num_layers: 1 };
+        let mut pool = CachePool::new(4);
+        let layout = SequenceStateLayout::paged_kv_cache(PagedKvLayout::uniform(1, 4, 4).unwrap());
+        let id = pool.allocate_with_layout(&model, Some(layout)).unwrap();
+        assert!(
+            pool.get_caches_mut(id).unwrap()[0].is_paged_backed(),
+            "dense-natural Fp16 paged sequence must be pool-backed"
+        );
+
+        {
+            let caches = pool.get_caches_mut(id).unwrap();
+            let keys = ffi::from_slice_f32(&[1.0, 2.0, 3.0, 4.0], &[1, 1, 4, 1]);
+            let values = ffi::from_slice_f32(&[5.0, 6.0, 7.0, 8.0], &[1, 1, 4, 1]);
+            // Pool-backed `update` routes into the pool and bumps `state.len`.
+            caches[0].update(keys, values);
+        }
+        assert_eq!(pool.get_paged_state(id).unwrap().layer(0).unwrap().len, 4);
+
+        // The sync must leave the pool-driven length untouched (skip), rather
+        // than mirroring the empty dense buffers down to 0.
+        pool.sync_paged_state_with_dense(id).unwrap();
+        assert_eq!(pool.get_paged_state(id).unwrap().layer(0).unwrap().len, 4);
     }
 
     #[test]

--- a/src/lib/mlxcel-core/src/cache/paged_detach.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach.rs
@@ -45,7 +45,9 @@
 //! without any quantization loss on top of the one already introduced by the
 //! live cache.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 
@@ -273,6 +275,26 @@ impl ParkedCache {
     }
 }
 
+/// Take a shared paged-state handle by value, producing an owned
+/// [`PagedSequenceState`] for an inert detached set.
+///
+/// In the common case the handle is the sole owner (a dense-placeholder paged
+/// sequence, or a pool-backed sequence whose per-layer caches were already
+/// dropped) and `Rc::try_unwrap` hands back the inner value with no copy. When
+/// other `Rc` clones are still live — e.g. a pool-backed sequence detached
+/// while its caches still hold sibling handles (the #121 sub-step (b) radix
+/// path) — fall back to cloning the block table, which is cheap (`Vec<u64>` per
+/// layer) and behaviour-equivalent: the clone carries the identical block ids,
+/// and the originals are released without touching pool refcounts (dropping a
+/// `PagedSequenceState` does not release blocks). The detached set's refcount
+/// pins are taken separately by the caller via `retain_block`.
+fn into_owned_paged_state(state: Rc<RefCell<PagedSequenceState>>) -> PagedSequenceState {
+    match Rc::try_unwrap(state) {
+        Ok(cell) => cell.into_inner(),
+        Err(shared) => shared.borrow().clone(),
+    }
+}
+
 impl CachePool {
     /// Remove a paged-backed sequence from the active set and return it as an
     /// inert [`DetachedPagedCacheSet`].
@@ -301,10 +323,15 @@ impl CachePool {
             .paged_layout()
             .expect("paged sequences must carry a layout")
             .clone();
-        let paged_state = sequence
+        let paged_state_rc = sequence
             .paged
             .take()
             .expect("paged sequences must carry a paged state");
+        // Take the block table by value. For sub-step (a) paged sequences are
+        // dense-placeholder (refcount 1) so this never copies; the clone
+        // fallback inside the helper covers the forthcoming pool-backed detach
+        // (#121 sub-step b).
+        let paged_state = into_owned_paged_state(paged_state_rc);
 
         // Pin every block so the pool cannot recycle prefix pages out from
         // under us. Collect block ids for later release; this also serves as
@@ -316,7 +343,13 @@ impl CachePool {
             }
         }
 
-        if let Some(pool) = self.paged_pool.as_mut() {
+        // Pin under a single pool borrow, then drop it before any mutation of
+        // `self.active` (the rollback `insert` below). Pool and `active` are
+        // distinct fields, but keeping the borrow scoped avoids any future
+        // nesting hazard.
+        let pin_failed: Option<PagedBlockId> = if let Some(pool) = self.paged_pool.as_ref() {
+            let mut pool = pool.borrow_mut();
+            let mut failed = None;
             for &block_id in &retained {
                 // retain_block only fails if the block is unknown or already
                 // at refcount zero — neither should happen for a block that
@@ -335,13 +368,22 @@ impl CachePool {
                     for id in pinned_so_far.iter().rev() {
                         let _ = pool.release_block(*id);
                     }
-                    // Restore the original entry so the caller sees the
-                    // sequence as if detach had simply declined.
-                    sequence.paged = Some(paged_state);
-                    self.active.insert(seq_id, sequence);
-                    return None;
+                    failed = Some(block_id);
+                    break;
                 }
             }
+            failed
+        } else {
+            None
+        };
+
+        if pin_failed.is_some() {
+            // Restore the original entry so the caller sees the sequence as if
+            // detach had simply declined. The pool borrow above is already
+            // dropped here.
+            sequence.paged = Some(Rc::new(RefCell::new(paged_state)));
+            self.active.insert(seq_id, sequence);
+            return None;
         }
 
         let detached_caches: Vec<DetachedKVCache> = sequence
@@ -359,7 +401,8 @@ impl CachePool {
         let mut k_norms_pages: HashMap<PagedBlockId, UniquePtr<MlxArray>> = HashMap::new();
         let mut cold_keys_pages: HashMap<PagedBlockId, UniquePtr<MlxArray>> = HashMap::new();
         if paged_layout.is_turbo_mode() {
-            if let Some(pool) = self.paged_pool.as_mut() {
+            if let Some(pool) = self.paged_pool.as_ref() {
+                let mut pool = pool.borrow_mut();
                 for &block_id in &retained {
                     if let Some(t) = pool.take_v_packed(block_id) {
                         v_packed_pages.insert(block_id, t);
@@ -453,12 +496,19 @@ impl CachePool {
 
         // Validate layout compatibility with the active paged pool (if any).
         if let Some(pool) = self.paged_pool.as_ref() {
-            if pool.layout() != &detached.paged_layout {
+            let pool_block_size = {
+                let pool = pool.borrow();
+                if pool.layout() != &detached.paged_layout {
+                    Some(pool.layout().block_size)
+                } else {
+                    None
+                }
+            };
+            if let Some(pool_block_size) = pool_block_size {
                 return Err((
                     format!(
                         "CachePool::adopt_paged: paged layout mismatch (pool block_size={}, set block_size={})",
-                        pool.layout().block_size,
-                        detached.paged_layout.block_size
+                        pool_block_size, detached.paged_layout.block_size
                     ),
                     detached,
                 ));
@@ -519,7 +569,7 @@ impl CachePool {
         let id = SequenceId::from_raw(self.next_id.fetch_add(1, Ordering::Relaxed));
         let mut entry = SequenceCacheSet::paged(id, paged_layout.clone());
         entry.caches = live_caches;
-        entry.paged = Some(paged_state);
+        entry.paged = Some(Rc::new(RefCell::new(paged_state)));
         entry.backend = backend;
         entry.prompt_len = prompt_len;
         entry.current_offset = current_offset;
@@ -533,7 +583,8 @@ impl CachePool {
         // consumed the originals, so a failure here would otherwise drop
         // them silently.
         if paged_layout.is_turbo_mode() {
-            if let Some(pool) = self.paged_pool.as_mut() {
+            if let Some(pool) = self.paged_pool.as_ref() {
+                let mut pool = pool.borrow_mut();
                 for (block_id, t) in v_packed_pages {
                     if let Err(err) = pool.install_v_packed(block_id, t) {
                         eprintln!(
@@ -579,7 +630,8 @@ impl CachePool {
         // the invariant "refcount == number of active block_ids entries
         // owning the block".
         if let Some(blocks) = retained_blocks {
-            if let Some(pool) = self.paged_pool.as_mut() {
+            if let Some(pool) = self.paged_pool.as_ref() {
+                let mut pool = pool.borrow_mut();
                 for block_id in blocks {
                     if let Err(err) = pool.release_block(block_id) {
                         // Fatal: the pool now disagrees with the sequence
@@ -594,6 +646,9 @@ impl CachePool {
             }
         }
 
+        // The model hook must run with NO pool/state borrow held (it may, for
+        // model-owned families, touch the cache pool again). All `borrow_mut`s
+        // above are scoped to their `if let` blocks and already dropped here.
         model.prepare_sequence_state(id);
         // `detached.retained_blocks` is `None` now, so the `Drop` impl will
         // run quietly and not complain about leaked pins.
@@ -641,7 +696,8 @@ impl CachePool {
     /// blocks) — the function is idempotent.
     pub fn release_detached_paged(&mut self, mut detached: DetachedPagedCacheSet) {
         if let Some(blocks) = detached.retained_blocks.take() {
-            if let Some(pool) = self.paged_pool.as_mut() {
+            if let Some(pool) = self.paged_pool.as_ref() {
+                let mut pool = pool.borrow_mut();
                 for block_id in blocks {
                     if let Err(err) = pool.release_block(block_id) {
                         eprintln!(
@@ -687,7 +743,7 @@ impl CachePool {
         layout: &PagedKvLayout,
     ) -> Result<(), String> {
         if let Some(pool) = self.paged_pool.as_ref() {
-            if pool.layout() != layout {
+            if pool.borrow().layout() != layout {
                 return Err(
                     "CachePool::adopt_paged: paged layout mismatch for active paged backend"
                         .to_string(),
@@ -695,7 +751,7 @@ impl CachePool {
             }
             return Ok(());
         }
-        self.paged_pool = Some(PagedBlockPool::new(layout.clone()));
+        self.paged_pool = Some(Rc::new(RefCell::new(PagedBlockPool::new(layout.clone()))));
         Ok(())
     }
 }

--- a/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
@@ -119,15 +119,18 @@ fn write_prefill_for(
 ) -> Result<(), String> {
     let block_pool = pool
         .paged_pool
-        .as_mut()
+        .as_ref()
         .ok_or_else(|| "paged backend not initialized".to_string())?;
     let state = pool
         .active
-        .get_mut(&id)
+        .get(&id)
         .ok_or_else(|| format!("sequence {id} not found"))?
-        .paged_state_mut()
+        .paged
+        .as_ref()
         .ok_or_else(|| format!("sequence {id} is not paged"))?;
-    block_pool.write_prefill(state, layer_idx, k, v)
+    block_pool
+        .borrow_mut()
+        .write_prefill(&mut state.borrow_mut(), layer_idx, k, v)
 }
 
 /// Deterministic `[1, H, n_tokens, D]` FP32 prefill block whose per-token
@@ -570,7 +573,8 @@ fn paged_trim_to_releases_whole_blocks_past_n() {
     // Trim down to 4 tokens => exactly 1 block needed.
     let trimmed = pool.trim_paged_tokens(seq, 0, 5).unwrap();
     assert_eq!(trimmed, 5);
-    let layer = pool.get_paged_state(seq).unwrap().layer(0).unwrap();
+    let state = pool.get_paged_state(seq).unwrap();
+    let layer = state.layer(0).unwrap();
     assert_eq!(layer.len, 4);
     assert_eq!(layer.block_ids.len(), 1);
 }
@@ -596,7 +600,8 @@ fn paged_partial_block_trim_keeps_block_updates_logical_length() {
     assert_eq!(before_blocks.len(), 2);
 
     pool.trim_paged_tokens(seq, 0, 1).unwrap();
-    let layer = pool.get_paged_state(seq).unwrap().layer(0).unwrap();
+    let state = pool.get_paged_state(seq).unwrap();
+    let layer = state.layer(0).unwrap();
     assert_eq!(layer.len, 4);
     // Partial trim: still within the second block's span in token coords,
     // so reserved_blocks stays at 1 (the last block's worth of slots is
@@ -923,7 +928,7 @@ fn write_prefill_after_shared_prefix_adopt_allocates_only_suffix_blocks() {
     let (gk, gv) = pool
         .paged_pool_ref()
         .unwrap()
-        .gather_visible(state, 0)
+        .gather_visible(&state, 0)
         .unwrap()
         .expect("gather must return data");
     assert_eq!(

--- a/src/lib/mlxcel-core/src/cache/paged_turbo_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_turbo_tests.rs
@@ -372,14 +372,16 @@ fn detach_adopt_round_trip_turbo4_asym_preserves_sidecars() {
             .collect()
     };
     assert!(!block_ids.is_empty());
-    let pool_ref = pool.paged_pool_mut().unwrap();
-    for &block_id in &block_ids {
-        pool_ref
-            .install_v_packed(block_id, dummy_array(&[1.0, 2.0, 3.0, 4.0], &[1, 1, 4, 1]))
-            .unwrap();
-        pool_ref
-            .install_v_norms(block_id, dummy_array(&[0.5, 0.5, 0.5, 0.5], &[1, 1, 4, 1]))
-            .unwrap();
+    {
+        let mut pool_ref = pool.paged_pool_mut().unwrap();
+        for &block_id in &block_ids {
+            pool_ref
+                .install_v_packed(block_id, dummy_array(&[1.0, 2.0, 3.0, 4.0], &[1, 1, 4, 1]))
+                .unwrap();
+            pool_ref
+                .install_v_norms(block_id, dummy_array(&[0.5, 0.5, 0.5, 0.5], &[1, 1, 4, 1]))
+                .unwrap();
+        }
     }
 
     let detached = pool.detach_paged(id).expect("detach must succeed");
@@ -423,7 +425,7 @@ fn detach_adopt_round_trip_turbo4_sym_preserves_k_sidecars() {
 
     let block_id = pool.get_paged_state(id).unwrap().layers[0].block_ids[0];
     {
-        let pool_ref = pool.paged_pool_mut().unwrap();
+        let mut pool_ref = pool.paged_pool_mut().unwrap();
         pool_ref
             .install_v_packed(block_id, dummy_array(&[1.0, 2.0], &[1, 1, 2, 1]))
             .unwrap();
@@ -459,7 +461,7 @@ fn detach_adopt_round_trip_turbo4_delegated_preserves_cold_keys() {
 
     let block_id = pool.get_paged_state(id).unwrap().layers[0].block_ids[0];
     {
-        let pool_ref = pool.paged_pool_mut().unwrap();
+        let mut pool_ref = pool.paged_pool_mut().unwrap();
         pool_ref
             .install_v_packed(block_id, dummy_array(&[1.0, 2.0], &[1, 1, 2, 1]))
             .unwrap();
@@ -581,7 +583,7 @@ fn cache_pool_memory_usage_includes_pool_sidecars() {
     let block_id = pool.get_paged_state(id).unwrap().layers[0].block_ids[0];
     let baseline = pool.memory_usage_bytes();
     {
-        let pool_ref = pool.paged_pool_mut().unwrap();
+        let mut pool_ref = pool.paged_pool_mut().unwrap();
         pool_ref
             .install_v_packed(block_id, dummy_array(&[1.0, 2.0, 3.0, 4.0], &[1, 1, 4, 1]))
             .unwrap();

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -101,11 +101,13 @@ fn test_fast_rope_batched_matches_per_sequence_offsets() {
     assert!(item_bool(&close));
 }
 
-/// Uniform-batch fast path (mlx-vlm PR #1055): when every
-/// row shares the same RoPE offset, `fast_rope_batched` collapses to a
-/// single full-batch `fast_rope` call. The collapsed result must be
-/// bit-equivalent (within float tolerance) to the per-row slice / concat
-/// reference, otherwise the optimization would silently corrupt RoPE.
+/// When every row shares the same RoPE offset, `fast_rope_batched` must
+/// still produce the same result as the per-row slice / concat reference
+/// (the former uniform-batch fast path that collapsed to a single
+/// `fast_rope(full_tensor, ...)` call has been removed — see the
+/// regression test `test_fast_rope_batched_non_contiguous_t1_symmetric`
+/// for the reason).  This test uses a contiguous tensor so the bug does
+/// not manifest; it validates correctness of the per-row path itself.
 #[test]
 fn test_fast_rope_batched_uniform_offsets_match_per_row_path() {
     let x = from_slice_f32(
@@ -219,6 +221,53 @@ fn test_fast_rope_batched_uniform_zero_offsets_match_per_row_path() {
     let close = allclose(&actual, &expected, 1e-5, 1e-5);
     eval(&close);
     assert!(item_bool(&close));
+}
+
+/// Regression test for the non-contiguous T=1 stride-aliasing bug.
+///
+/// During batched decode (T=1) the attention key tensor arrives at
+/// `fast_rope_batched` as a transposed [B, n_heads, 1, D] tensor.  The
+/// transpose of [B, T=1, n_heads, D] sets `stride[batch] == stride[seq]`
+/// (both equal `n_heads * D`) because swapping a size-1 dimension leaves
+/// the physical layout unchanged.  MLX's `fast::rope` Metal kernel can
+/// confuse the batch stride for a sequence stride in this situation,
+/// applying position `offset + b` to batch-element `b` instead of
+/// `offset` for every `b`.
+///
+/// This test constructs such a non-contiguous tensor with symmetric inputs
+/// (batch row 0 == batch row 1) and uniform offsets, then asserts that
+/// `fast_rope_batched` outputs are also symmetric — i.e. both rows receive
+/// the same RoPE rotation.  The test should FAIL if the uniform-batch
+/// fast path (a single `fast_rope` on the full [B, n_heads, T, D] tensor)
+/// is re-enabled without first verifying it handles non-contiguous strides
+/// correctly.
+#[test]
+fn test_fast_rope_batched_non_contiguous_t1_symmetric() {
+    // Two identical rows — shape [2, 1, 2, 4] (B=2, T=1, n_heads=2, D=4).
+    let vals: Vec<f32> = (0..8).map(|i| i as f32).collect();
+    let row: Vec<f32> = vals.iter().chain(vals.iter()).cloned().collect(); // [row, row]
+    let x = from_slice_f32(&row, &[2, 1, 2, 4]);
+
+    // Transpose [B, T, n_heads, D] → [B, n_heads, T, D] = [2, 2, 1, 4].
+    // This is the decode-path layout.  After the transpose stride[batch]
+    // == stride[T] (both = n_heads * D = 8), replicating the production bug.
+    let x_t = transpose_axes(&x, &[0, 2, 1, 3]);
+
+    // Uniform offsets: both sequences are at position 16.
+    let result = fast_rope_batched(&x_t, 4, false, 10000.0, 1.0, &[16, 16]);
+    eval(&result);
+
+    // With symmetric inputs and equal offsets the output must be symmetric.
+    let r0 = slice(&result, &[0, 0, 0, 0], &[1, i32::MAX, i32::MAX, i32::MAX]);
+    let r1 = slice(&result, &[1, 0, 0, 0], &[2, i32::MAX, i32::MAX, i32::MAX]);
+    eval(&r0);
+    eval(&r1);
+    let close = allclose(&r0, &r1, 1e-5, 1e-5);
+    eval(&close);
+    assert!(
+        item_bool(&close),
+        "fast_rope_batched must give symmetric output for symmetric non-contiguous T=1 input"
+    );
 }
 
 #[test]

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -2321,25 +2321,25 @@ fn use_bool_causal_mask_path() -> bool {
 
 /// Apply RoPE to a batched tensor using independent per-sequence offsets.
 ///
-/// This keeps batched decode call sites on a vectorized metadata path even
-/// before a native array-offset RoPE kernel exists. The current helper slices
-/// the batch dimension and reuses MLX's scalar-offset fast kernel for each
-/// sequence, then concatenates the results back together.
+/// Slices the batch dimension and applies MLX's scalar-offset `fast_rope`
+/// kernel to each `[1, n_heads, T, D]` slice independently, then
+/// concatenates the results back together.  For `batch == 1` the slice /
+/// concat overhead is skipped via an early return.
 ///
-/// Uniform-batch fast path (upstream `mlx-vlm` PR #1055): when
-/// every row in `offsets` has the same value, the helper bypasses the
-/// per-row slice / concat loop and dispatches a single
-/// `fast_rope(x, ..., offsets[0])` call over the whole batch. RoPE is
-/// applied along the last (head) dimension and `mlx::core::fast::rope`'s
-/// scalar-offset overload broadcasts the same offset to every leading axis,
-/// so this is bit-equivalent to the per-row path while saving `(batch - 1)`
-/// `slice` calls and `(batch - 1)` `concatenate` calls. Mixed-offset batches
-/// continue to take the original per-row path. The collapse is purely
-/// per-call: it never caches a "the batch is uniform" assumption across
-/// decode steps, so a future step with non-uniform offsets transparently
-/// falls back to per-row dispatch (compare with the explicit per-row state
-/// invariant on [`crate::cache::BatchedAttentionMetadata`], which exists to
-/// prevent shape-changing storage state across batch grow / shrink).
+/// **Why there is no uniform-batch fast path**: when every offset in
+/// `offsets` is the same value one might expect to call `fast_rope(x, ...,
+/// offsets[0])` directly on the full `[B, n_heads, T, D]` tensor.  In
+/// practice the attention key/value tensors arrive here after a
+/// `transpose_axes([0,2,1,3])` from `[B, T, n_heads, D]`, which produces a
+/// non-contiguous tensor whose batch stride equals the sequence stride when
+/// `T == 1` (decode step).  MLX's `fast::rope` Metal kernel confuses these
+/// equal strides and assigns position `offset + b` to batch-element `b`
+/// instead of `offset` for all `b`, producing asymmetric K/V rotations and
+/// causing divergence between batch rows even for identical input tokens.
+/// The per-row path calls `fast_rope` with `B == 1`, where a single batch
+/// element cannot encounter inter-batch confusion regardless of strides.
+/// See `ffi_tests::test_fast_rope_batched_non_contiguous_t1_symmetric` and
+/// the paged batched B=2 parity regression.
 ///
 /// Used by: Llama3 batched decode, Qwen3 batched decode, Gemma3 batched decode, Llama4 batched decode
 pub fn fast_rope_batched(
@@ -2367,16 +2367,33 @@ pub fn fast_rope_batched(
         return ffi::fast_rope(x, dims, traditional, base, scale, offsets[0]);
     }
 
-    // Uniform-batch fast path: every row sees the same offset. Dispatch a
-    // single RoPE on the full batch and skip the slice / concat loop.
-    // `offsets.iter().all(...)` short-circuits, so the check itself is
-    // O(batch) integer comparisons — negligible compared to the
-    // `(batch - 1)` graph-node allocations the loop would otherwise
-    // perform.
-    let first_offset = offsets[0];
-    if offsets[1..].iter().all(|&o| o == first_offset) {
-        return ffi::fast_rope(x, dims, traditional, base, scale, first_offset);
-    }
+    // NOTE: The uniform-batch fast path (calling fast_rope on the full
+    // [B, n_heads, T, D] tensor in one shot) is intentionally DISABLED.
+    //
+    // Root cause: in the batched decode path the Q/K/V tensors arrive here
+    // already transposed from [B, T, n_heads, D] → [B, n_heads, T, D].
+    // When T == 1 (single decode token), the transpose produces a
+    // non-contiguous tensor whose strides satisfy
+    //   stride[batch_dim] == stride[sequence_dim]   (= n_heads * D)
+    // because swapping a size-1 dimension does not change the physical
+    // memory layout.  MLX's fast::rope Metal kernel distinguishes
+    // sequence position from batch position using the stride ratio; when
+    // these two strides are equal the kernel confuses the batch offset for
+    // an intra-sequence offset, assigning position `offset + b` to
+    // batch-element `b` instead of `offset` for all `b`.  The result is
+    // asymmetric K/V rotations across the batch even when every sequence
+    // receives the same input token at the same cache position.
+    //
+    // The existing unit test (`test_fast_rope_batched_uniform_offsets_match_per_row_path`)
+    // uses a directly-constructed contiguous [3, 1, 2, 4] tensor where all
+    // strides are distinct, so the bug does not manifest there.
+    //
+    // The per-row path below slices to [1, n_heads, T, D] for each batch
+    // element and calls fast_rope with B == 1.  With only one batch row the
+    // kernel can never confuse a batch offset for a sequence offset, so the
+    // non-contiguous strides are harmless.  See the paged batched B=2 parity
+    // regression: row 1 diverged from the dense reference when the uniform
+    // path was in effect.
 
     let rank = shape.len();
     let mut begin = vec![0; rank];

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -1084,7 +1084,7 @@ mod tests {
             cell(0, 2, 1).is_infinite() && cell(0, 2, 1) < 0.0,
             "row0 q=2 -> padding k=1 must be -inf"
         );
-        assert_eq!(cell(0, 2, 0 + 2), 0.0, "row0 q=2 -> real k=2 must attend");
+        assert_eq!(cell(0, 2, 2), 0.0, "row0 q=2 -> real k=2 must attend");
         // Causal upper bound: q=2 must NOT see future k=3.
         assert!(
             cell(0, 2, 3).is_infinite() && cell(0, 2, 3) < 0.0,

--- a/src/models/llama3.rs
+++ b/src/models/llama3.rs
@@ -313,6 +313,15 @@ impl Attention {
             if caches.iter().any(|cache| cache.mode != KVCacheMode::Fp16) {
                 return None;
             }
+            // Pool-backed caches (scheduler paged decode, #121) keep no dense
+            // `keys`/`values` buffers for the native paged kernel to read.
+            // Route them through the per-sequence `update_and_fetch` loop below,
+            // whose transparent pool intercept writes new K/V into the shared
+            // `PagedBlockPool` (`write_prefill`) and gathers the visible window
+            // back (`gather_visible`) — the #152-validated single-stream path.
+            if caches.iter().any(|cache| cache.is_paged_backed()) {
+                return None;
+            }
             let metadata =
                 PagedDecodeMetadata::from_attention_metadata(metadata, context.paged_block_size)
                     .ok()?;

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -257,6 +257,15 @@ impl Attention {
             if caches.iter().any(|cache| cache.mode != KVCacheMode::Fp16) {
                 return None;
             }
+            // Pool-backed caches (scheduler paged decode, #121) keep no dense
+            // `keys`/`values` buffers for the native paged kernel to read.
+            // Route them through the per-sequence `update_and_fetch` loop below,
+            // whose transparent pool intercept writes new K/V into the shared
+            // `PagedBlockPool` (`write_prefill`) and gathers the visible window
+            // back (`gather_visible`) — the #152-validated single-stream path.
+            if caches.iter().any(|cache| cache.is_paged_backed()) {
+                return None;
+            }
             let metadata =
                 PagedDecodeMetadata::from_attention_metadata(metadata, context.paged_block_size)
                     .ok()?;

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1269,10 +1269,19 @@ impl BatchScheduler {
             )
             .expect("valid paged Turbo4 decode layout")
         } else {
-            PagedKvLayout::uniform(
+            // Carry the actual cache mode so the pool-backing gate in
+            // `CachePool::allocate_with_layout` (`paged_layout.cache_mode ==
+            // Fp16`) pool-backs ONLY genuine Fp16 sequences. Int8 (and
+            // Turbo3Asym) keep their dense KV path — memory saving preserved —
+            // until the pool gains native quantized storage; these modes carry
+            // no per-page sidecars, so the sidecar budget is 0 (uniform_with_mode
+            // treats non-Turbo4 modes as sidecar-free).
+            PagedKvLayout::uniform_with_mode(
                 num_layers,
                 DEFAULT_PAGED_BLOCK_SIZE,
                 DEFAULT_PAGED_BLOCK_SIZE,
+                effective_mode,
+                0,
             )
             .expect("valid paged decode layout")
         };

--- a/src/server/batch/scheduler_tests.rs
+++ b/src/server/batch/scheduler_tests.rs
@@ -776,6 +776,32 @@ fn paged_decode_storage_falls_back_when_batching_is_unavailable() {
     );
 }
 
+/// Hybrid-SSM carve-out (#121): Mamba / Mamba2 / Jamba / NemotronH /
+/// NemotronNAS / RecurrentGemma / Qwen3Next / RWKV7 all keep their recurrent
+/// state in internal model-owned caches, so they override
+/// `supports_batching()` to `false` and never opt into the paged decode
+/// backend (`supports_paged_decode_backend()` keeps the trait default
+/// `false`). Either flag alone already forces the dense backend; this test
+/// pins the combined SSM profile — `supports_batching == false` AND
+/// `supports_paged_decode_backend == false` — across batch sizes so a future
+/// model edit cannot accidentally route a recurrent worker onto the paged
+/// path even if it is explicitly requested.
+#[test]
+fn hybrid_ssm_workers_never_use_paged_decode_backend() {
+    for batch in [2usize, 4, 16, 64] {
+        assert_eq!(
+            effective_decode_storage_backend(DecodeStorageBackend::Paged, batch, false, false),
+            DecodeStorageBackend::Dense,
+            "hybrid SSM (batch={batch}) must fall back to dense even when Paged is requested"
+        );
+        assert_eq!(
+            effective_decode_storage_backend(DecodeStorageBackend::Auto, batch, false, false),
+            DecodeStorageBackend::Dense,
+            "hybrid SSM (batch={batch}) must resolve Auto to dense"
+        );
+    }
+}
+
 #[test]
 fn auto_decode_storage_prefers_paged_only_for_supported_workers() {
     assert_eq!(

--- a/tests/paged_scheduler_parity.rs
+++ b/tests/paged_scheduler_parity.rs
@@ -1,0 +1,290 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real-model parity for the scheduler-driven paged KV cache (#121 sub-step a).
+//!
+//! #152 proved a hand-built pool-backed `KVCache` matches a dense cache through
+//! `forward`. This test goes one layer up: it drives the **scheduler's** paged
+//! allocation + cache path — [`CachePool::allocate_with_layout`] with the exact
+//! paged layout the scheduler builds (`sequence_state_layout_override`) — and
+//! confirms the resulting pool-backed caches generate the same greedy tokens as
+//! the scheduler's dense path (`CachePool::allocate` with the model's natural
+//! dense layout).
+//!
+//! # Why `CachePool` and not `BatchScheduler`
+//!
+//! `BatchScheduler::new` is `pub(crate)`, so an integration test (a separate
+//! crate) cannot construct one. `CachePool` is the scheduler's
+//! cache-management core: `allocate_with_layout(model, paged_override)` is
+//! exactly what `BatchScheduler::allocate_sequence_state` calls when
+//! `decode_storage_backend == Paged` and `max_batch_size > 1`, and
+//! `allocate(model)` is the dense path. Driving the model through the caches
+//! `CachePool` hands back therefore faithfully reproduces the scheduler's
+//! per-sequence paged path without standing up the async worker loop.
+//!
+//! # What each test covers
+//!
+//! * [`paged_scheduler_single_sequence_matches_dense`] — the scheduler's
+//!   **single-sequence** path. A lone request decodes via `decode_single_step`
+//!   (`scheduler.rs`: `if seq_ids.len() <= 1 { decode_single_step }`), i.e.
+//!   single-sequence `model.forward`, whose pool intercept (`update_and_fetch`
+//!   / `update`) writes to and gathers from the pool. This is the path the
+//!   task's single-sequence parity requirement targets.
+//! * [`paged_scheduler_batched_decode_matches_dense`] — the **batched** decode
+//!   wiring (`B == 2`) via `forward_batched_with_context_and_ids` + a paged
+//!   [`DecodeBatchContext`], exactly as `execute_batched_decode` dispatches it.
+//!   This exercises the per-model `is_paged_backed()` decode guard that routes
+//!   pool-backed caches through the per-sequence `update_and_fetch` loop instead
+//!   of the dense-pointer native kernel.
+//!
+//! # Running
+//!
+//! `#[ignore]` (loads qwen3-0.6b-4bit and runs a real GPU forward). Run with:
+//!
+//! ```text
+//! cargo test --test paged_scheduler_parity --release \
+//!     --features metal,accelerate -- --ignored --nocapture
+//! ```
+//!
+//! Soft-skips when `models/qwen3-0.6b-4bit` is absent. Fetch with:
+//!
+//! ```text
+//! ./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit
+//! ```
+
+mod common;
+use common::repo_model_dir;
+
+use mlxcel::{DecodeBatchContext, LanguageModel, initialize_runtime, load_model};
+use mlxcel_core::cache::{CachePool, PagedKvLayout, SequenceStateLayout};
+
+/// Model directory name (present at `models/qwen3-0.6b-4bit`).
+const MODEL_DIR_NAME: &str = "qwen3-0.6b-4bit";
+
+/// Paged block size (tokens per physical block) — matches the scheduler's
+/// `DEFAULT_PAGED_BLOCK_SIZE`.
+const BLOCK_SIZE: usize = 32;
+
+/// Number of greedy decode steps to compare after prefill.
+const DECODE_STEPS: usize = 16;
+
+/// Fixed prompt token ids (deterministic; no tokenizer needed). Identical bytes
+/// feed every run so the comparison is purely about the cache backend.
+const PROMPT_TOKENS: &[i32] = &[
+    9707, 11, 358, 1079, 264, 4128, 1614, 13, 5209, 3291, 752, 911, 697, 7990, 13, 358,
+];
+
+/// Greedy argmax over the vocab at sequence position `pos` of a
+/// `[batch, seq_len, vocab]` logits tensor, for batch row `row`.
+fn greedy_token(logits: &mlxcel_core::MlxArray, row: i32, pos: i32) -> i32 {
+    let shape = mlxcel_core::array_shape(logits);
+    let vocab = shape[2];
+    let at_pos = mlxcel_core::slice(logits, &[row, pos, 0], &[row + 1, pos + 1, vocab]);
+    let flat = mlxcel_core::reshape(&at_pos, &[vocab]);
+    mlxcel_core::eval(&flat);
+    mlxcel_core::item_i32(&mlxcel_core::argmax_last_axis(&flat))
+}
+
+/// The paged sequence-state layout the scheduler builds for the default Fp16 KV
+/// mode (`BatchScheduler::sequence_state_layout_override` → the non-Turbo
+/// `PagedKvLayout::uniform` branch with `DEFAULT_PAGED_BLOCK_SIZE`).
+fn scheduler_paged_layout(num_layers: usize) -> SequenceStateLayout {
+    SequenceStateLayout::paged_kv_cache(
+        PagedKvLayout::uniform(num_layers, BLOCK_SIZE, BLOCK_SIZE).expect("valid paged layout"),
+    )
+}
+
+/// Run prefill + `DECODE_STEPS` greedy decode steps via single-sequence
+/// `model.forward` (the scheduler's `execute_full_prefill` + `decode_single_step`
+/// path), returning the decoded token sequence.
+fn run_single_sequence(
+    model: &mlxcel::LoadedModel,
+    caches: &mut [mlxcel_core::cache::KVCache],
+) -> Vec<i32> {
+    let prompt_len = PROMPT_TOKENS.len() as i32;
+
+    let prompt = mlxcel_core::from_slice_i32(PROMPT_TOKENS, &[1, prompt_len]);
+    let mask = mlxcel_core::utils::create_causal_mask(prompt_len, 0);
+    let prefill_logits = model.forward(&prompt, caches, Some(&mask));
+    mlxcel_core::eval(&prefill_logits);
+
+    let mut next = greedy_token(&prefill_logits, 0, prompt_len - 1);
+
+    let mut decoded = Vec::with_capacity(DECODE_STEPS);
+    for _ in 0..DECODE_STEPS {
+        decoded.push(next);
+        let step_input = mlxcel_core::from_slice_i32(&[next], &[1, 1]);
+        let logits = model.forward(&step_input, caches, None);
+        mlxcel_core::eval(&logits);
+        next = greedy_token(&logits, 0, 0);
+    }
+    decoded
+}
+
+fn load_or_skip() -> Option<mlxcel::LoadedModel> {
+    let model_dir = repo_model_dir(MODEL_DIR_NAME);
+    if !model_dir.exists() {
+        eprintln!(
+            "Skipping {MODEL_DIR_NAME}: model directory not found at {}.\n\
+             Fetch with: ./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit",
+            model_dir.display()
+        );
+        return None;
+    }
+    let (model, _tokenizer) = load_model(&model_dir).expect("load qwen3-0.6b-4bit");
+    Some(model)
+}
+
+/// The scheduler's single-sequence paged path must match its dense path: a lone
+/// request allocates pool-backed caches (`decode_storage_backend == Paged`),
+/// prefills + decodes through them, and produces the same greedy tokens as the
+/// dense backend.
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit and runs a real GPU forward; run with --ignored"]
+fn paged_scheduler_single_sequence_matches_dense() {
+    let _runtime = initialize_runtime();
+    let Some(model) = load_or_skip() else {
+        return;
+    };
+    let num_layers = model.num_layers();
+    eprintln!(
+        "\n=== scheduler paged vs dense (single sequence): {MODEL_DIR_NAME} ({num_layers} layers) ==="
+    );
+
+    // Dense backend: scheduler `decode_storage_backend == Dense` → no layout
+    // override → `CachePool::allocate` with the model's natural dense layout.
+    let mut dense_pool = CachePool::new(2);
+    let dense_id = dense_pool.allocate(&model).expect("dense allocate");
+    assert!(
+        !dense_pool.get_caches_mut(dense_id).unwrap()[0].is_paged_backed(),
+        "dense backend must not pool-back caches"
+    );
+    let dense_tokens = run_single_sequence(&model, dense_pool.get_caches_mut(dense_id).unwrap());
+    eprintln!("dense  decoded: {dense_tokens:?}");
+
+    // Paged backend: scheduler `decode_storage_backend == Paged` +
+    // `max_batch_size > 1` → paged layout override → `allocate_with_layout`,
+    // which pool-backs the per-layer caches for this dense-natural Fp16 model.
+    let mut paged_pool = CachePool::new(2);
+    let paged_id = paged_pool
+        .allocate_with_layout(&model, Some(scheduler_paged_layout(num_layers)))
+        .expect("paged allocate");
+    assert!(
+        paged_pool
+            .get_caches_mut(paged_id)
+            .unwrap()
+            .iter()
+            .all(|c| c.is_paged_backed()),
+        "paged backend must pool-back every layer cache for a dense-natural Fp16 model"
+    );
+    let paged_tokens = run_single_sequence(&model, paged_pool.get_caches_mut(paged_id).unwrap());
+    eprintln!("paged  decoded: {paged_tokens:?}");
+
+    assert_eq!(
+        paged_tokens, dense_tokens,
+        "scheduler paged single-sequence path produced different greedy tokens than dense\n\
+         dense: {dense_tokens:?}\npaged: {paged_tokens:?}"
+    );
+    eprintln!(
+        "OK: {DECODE_STEPS} single-sequence decode steps identical between paged and dense backends."
+    );
+}
+
+/// The batched decode wiring (the #121 `is_paged_backed()` guard) must also
+/// match dense. Two identical pool-backed sequences are decoded together via
+/// `forward_batched_with_context_and_ids` + a paged `DecodeBatchContext` —
+/// exactly the dispatch `execute_batched_decode` performs — and both rows must
+/// reproduce the dense single-sequence reference.
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit and runs a real GPU forward; run with --ignored"]
+fn paged_scheduler_batched_decode_matches_dense() {
+    let _runtime = initialize_runtime();
+    let Some(model) = load_or_skip() else {
+        return;
+    };
+    if !model.supports_paged_decode_backend() {
+        eprintln!("Skipping: {MODEL_DIR_NAME} does not support the paged decode backend");
+        return;
+    }
+    let num_layers = model.num_layers();
+    let prompt_len = PROMPT_TOKENS.len() as i32;
+    eprintln!(
+        "\n=== scheduler paged batched decode (B=2) vs dense: {MODEL_DIR_NAME} ({num_layers} layers) ==="
+    );
+
+    // Dense single-sequence reference.
+    let mut dense_pool = CachePool::new(4);
+    let dense_id = dense_pool.allocate(&model).expect("dense allocate");
+    let dense_tokens = run_single_sequence(&model, dense_pool.get_caches_mut(dense_id).unwrap());
+    eprintln!("dense  decoded: {dense_tokens:?}");
+
+    // Two pool-backed paged sequences fed the identical prompt.
+    let mut paged_pool = CachePool::new(4);
+    let id0 = paged_pool
+        .allocate_with_layout(&model, Some(scheduler_paged_layout(num_layers)))
+        .expect("paged allocate 0");
+    let id1 = paged_pool
+        .allocate_with_layout(&model, Some(scheduler_paged_layout(num_layers)))
+        .expect("paged allocate 1");
+
+    // Prefill each sequence with the single-sequence forward (as
+    // `execute_full_prefill` does), seeding each sequence's pool blocks.
+    let prompt = mlxcel_core::from_slice_i32(PROMPT_TOKENS, &[1, prompt_len]);
+    let mask = mlxcel_core::utils::create_causal_mask(prompt_len, 0);
+    let mut next = [0i32; 2];
+    for (slot, id) in [id0, id1].into_iter().enumerate() {
+        let caches = paged_pool.get_caches_mut(id).unwrap();
+        let logits = model.forward(&prompt, caches, Some(&mask));
+        mlxcel_core::eval(&logits);
+        next[slot] = greedy_token(&logits, 0, prompt_len - 1);
+    }
+
+    // Batched greedy decode through the paged batched path.
+    let context = DecodeBatchContext::paged_with_native(BLOCK_SIZE as i32, true);
+    let mut batched: [Vec<i32>; 2] = [Vec::new(), Vec::new()];
+    for _ in 0..DECODE_STEPS {
+        batched[0].push(next[0]);
+        batched[1].push(next[1]);
+        let input = mlxcel_core::from_slice_i32(&[next[0], next[1]], &[2, 1]);
+        let logits = {
+            let mut batch_caches = paged_pool
+                .get_batch_caches_mut(&[id0, id1])
+                .expect("batch caches");
+            model.forward_batched_with_context_and_ids(
+                &input,
+                Some(&[id0, id1]),
+                &mut batch_caches,
+                None,
+                Some(&context),
+            )
+        };
+        mlxcel_core::eval(&logits);
+        next[0] = greedy_token(&logits, 0, 0);
+        next[1] = greedy_token(&logits, 1, 0);
+    }
+    eprintln!("paged0 decoded: {:?}", batched[0]);
+    eprintln!("paged1 decoded: {:?}", batched[1]);
+
+    assert_eq!(
+        batched[0], dense_tokens,
+        "batched paged row 0 diverged from dense reference"
+    );
+    assert_eq!(
+        batched[1], dense_tokens,
+        "batched paged row 1 diverged from dense reference"
+    );
+    eprintln!(
+        "OK: {DECODE_STEPS} batched (B=2) paged decode steps identical to the dense reference."
+    );
+}


### PR DESCRIPTION
## Summary

Sub-step (a) of #121 (epic #116): wire the live batch scheduler's paged decode backend onto the `PagedBlockPool` that #118–120 built and #152 proved through a real model. **Path A** — the pool rides inside the `KVCache`, so the `LanguageModel` trait and `forward` signature stay unchanged.

This is one of three sub-steps and does **not** close #121 — the radix adopt/donate + `try_adopt_cached_prefix` guard removal lands in sub-step (b), and the multi-model RMS sweep in sub-step (c).

## What changed

### Phase 1 — `CachePool` Rc<RefCell> refactor (behaviour-preserving)
- `CachePool.paged_pool` → `Option<Rc<RefCell<PagedBlockPool>>>` and `SequenceCacheSet.paged` → `Option<Rc<RefCell<PagedSequenceState>>>`, so a pool-backed sequence shares ONE authoritative block table across its per-layer caches (each cache's `PagedBacking` holds a cheap `Rc` clone of the same handles).
- Updated every access site — `allocate*`, `detach_paged`/`adopt_paged`/`release_detached_paged`/`park_*` (paged_detach.rs), `sync_paged_state_with_*`, `paged_stats`/`stats_for_sequences`, `restore_paged_state`, `ensure_paged_pool*`, `release`, and the `paged_pool_ref`/`paged_pool_mut`/`get_paged_state`/`paged_state` accessors (now hand out `Ref`/`RefMut` guards) — with tightly-scoped borrows. Request-boundary pool/state borrows never nest with the forward's `update_and_fetch` borrows; `adopt_paged` drops every pool borrow before the `prepare_sequence_state` callback.
- No behaviour change: the #118–120 detach/adopt/round-trip suites pass unchanged (adapted only for the `Ref`/`RefMut` type change).

### Phase 2 — live paged wiring
- `CachePool::allocate` builds pool-backed caches (`KVCache::new_paged`) for paged sequences whose model's **natural** backend is the dense external KVCache slice (qwen3/llama3) under an **Fp16** layout. Model-owned families (gemma3/llama4/qwen3_5, which drive their own `ModelOwnedSequenceState` and ignore the caller's caches) and Turbo4 layouts keep their existing dense placeholders — byte-identical to before.
- Added `KVCache::is_paged_backed()`. The qwen3/llama3 batched-decode dispatch returns `None` from its native-paged-kernel selection when any cache is pool-backed, falling through to the per-sequence `update_and_fetch` loop — the #152-validated pool path (`write_prefill` + `gather_visible`). The gemma3/llama4 shared dispatch helpers are untouched because those models never receive pool-backed caches.
- `KVCache::update` gained the same pool intercept as `update_and_fetch` (factored into a shared `write_paged`), so llama3's single-sequence **fused causal prefill** path — which calls `update` without a fetch — also writes to the pool. qwen3's single-sequence prefill already routes through `update_and_fetch`.
- `sync_paged_state_with_dense` skips pool-backed sequences (the pool is authoritative — `write_prefill` advances `state.len` in lockstep with the cache offset). `trim`/`trim_front` are dense-side no-ops for pool-backed caches (they would otherwise desync from / `unwrap` the absent dense buffers; paged trimming is a pool-API concern).
- **Hybrid-SSM carve-out**: confirmed already in place — `effective_decode_storage_backend` gates on `supports_paged_decode_backend()` (trait default `false`) and `supports_batching()` (which mamba/mamba2/jamba/nemotron_h/nemotron_nas/recurrent_gemma/qwen3_next/rwkv7 override to `false`); either flag forces the dense backend. Added a test pinning the combined SSM profile across batch sizes.

### Phase 3 — verification
- New `tests/paged_scheduler_parity.rs` (`#[ignore]`, skip-if-absent) drives the scheduler's paged allocation path via `CachePool::allocate_with_layout` (the exact API `BatchScheduler::allocate_sequence_state` calls for the paged backend) and asserts identical greedy tokens to the dense backend, for both the single-sequence path and a batched `B=2` decode (which exercises the `is_paged_backed()` decode guard). `BatchScheduler::new` is `pub(crate)`, so this `CachePool`-driven harness is the faithful constructible driver from an integration test.

### Drive-by
- Fixed a pre-existing `clippy::identity_op` in `src/lib/mlxcel-core/src/utils.rs` (`0 + 2` → `2`) that cold clippy fails on (from #162).

## Test plan

- [x] `cargo test --lib -p mlxcel-core --features metal,accelerate cache::` — 370 pass (incl. 2 new sync tests)
- [x] `cache::paged_detach` / `cache::detach` regression suites — unchanged, pass
- [x] `cargo test --lib --features metal,accelerate hybrid_ssm_workers_never_use_paged_decode_backend` — pass
- [x] `cargo clippy -p mlxcel-core --tests --features metal,accelerate -- -D warnings` (cold) — clean
- [x] `cargo clippy --lib --features metal,accelerate -- -D warnings` — clean
- [x] `cargo check --test paged_scheduler_parity --features metal,accelerate` — compiles
- [x] `cargo fmt --check` — clean

Real-model parity test (loads qwen3-0.6b-4bit on the GPU; run by the orchestrator):

```
cargo test --test paged_scheduler_parity --release --features metal,accelerate -- --ignored --nocapture
```

Part of #121


## Follow-up fixes (after the real-model parity run)

The orchestrator's `paged_scheduler_parity` real-model run surfaced two issues, now fixed on this branch (both crates cold-clippy clean; core regression 832 pass; scheduler/batch 173 pass; parity now passes for BOTH single-sequence and batched B=2 — qwen3-0.6b-4bit, 16 greedy tokens identical to dense):

### `fast_rope_batched` stride aliasing — pre-existing, affects dense batched decode too
Batched B=2 parity initially diverged (row 1 looped). Root cause: `fast_rope_batched`'s uniform-batch fast path collapsed to a single `fast_rope` over the full `[B, n_heads, T, D]` tensor. In T==1 batched decode the Q/K/V arrive transposed from `[B, T, n_heads, D]`, where swapping the size-1 sequence dim leaves `stride[batch] == stride[sequence]`; MLX's `fast::rope` kernel then rotates batch element `b` to position `offset + b` instead of `offset`. This silently corrupted RoPE for batch rows past the first even with identical offsets — a latent bug in **dense** batched decode (the function's existing callers) that the paged same-prompt test exposed. Fix: drop the uniform fast path, always go per-row (`B==1` cannot alias) + regression test `test_fast_rope_batched_non_contiguous_t1_symmetric`.

### Int8/Turbo3 paged → dense (pool-backing is Fp16-only)
The Fp16 pool-backing gate keyed on the layout's `cache_mode`, but the scheduler built Int8/Turbo3 paged layouts with `cache_mode = Fp16`, so those sequences were pool-backed and stored as Fp16 (correct output, lost Int8 memory saving). Fix: the scheduler now builds the non-Turbo4 paged layout with the real `effective_mode`, so the gate pool-backs only genuine Fp16 and Int8/Turbo3 keep their dense path. Pool-native quantized storage is a later phase.
