### PR TITLE
feat: unify radix prompt cache with paged block pool (sub-step b of #121)

### DIFF
--- a/src/lib/mlxcel-core/src/cache/paged_detach.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach.rs
@@ -556,20 +556,71 @@ impl CachePool {
         let k_norms_pages = std::mem::take(&mut detached.k_norms_pages);
         let cold_keys_pages = std::mem::take(&mut detached.cold_keys_pages);
 
-        // Reconstruct dense placeholder caches.
-        let mut live_caches: Vec<KVCache> = Vec::with_capacity(caches.len());
-        for detached_cache in caches {
-            let mut cache = KVCache::new_with_mode(detached_cache.mode);
-            cache
-                .install_detached(detached_cache)
-                .expect("freshly constructed KVCache is empty");
-            live_caches.push(cache);
-        }
-
         let id = SequenceId::from_raw(self.next_id.fetch_add(1, Ordering::Relaxed));
+        let state_rc = Rc::new(RefCell::new(paged_state));
+
+        // Decide pool-backing with the SAME gate `CachePool::allocate_with_layout`
+        // uses for a fresh paged allocation, so an adopted sequence is
+        // byte-identical in shape to one that allocated cold:
+        //
+        //  * the model's NATURAL backend is the dense external `KVCache` slice
+        //    (`supports_batching()` transformers — qwen3 / llama3), AND
+        //  * the paged layout is `Fp16`.
+        //
+        // When both hold, the live per-layer caches must be POOL-BACKED
+        // (`new_paged`) sharing the adopted block-table `state_rc` and the
+        // active pool. The block table already points at the pinned, refcounted
+        // pool blocks (detach captured it via `into_owned_paged_state` + pinned
+        // every block), so reads gather straight from the shared prefix pages
+        // with no copy. The empty `clone_handle` dense handles captured at
+        // detach time are intentionally ignored on this path — rebuilding dense
+        // caches from them (the pre-#121 behaviour) would hand the adopted
+        // sequence empty buffers and make it read garbage.
+        let pool_backed = model.sequence_state_layout().backend
+            == SequenceStateBackend::DenseKvCache
+            && paged_layout.cache_mode == KVCacheMode::Fp16;
+
+        let live_caches: Vec<KVCache> = if pool_backed {
+            let pool_rc = self
+                .paged_pool
+                .as_ref()
+                .expect("ensure_paged_pool_from_layout installed the pool above")
+                .clone();
+            // One pool-backed cache per layer, sharing the adopted block-table
+            // `state_rc`. Each cache's monotonic `offset` is restored from the
+            // detached handle (which `clone_handle` captured from the
+            // originating pool-backed cache at detach time) so RoPE positions
+            // for the post-adopt prefill/decode continue from the cached prefix
+            // length — a fresh `new_paged` cache would start at offset 0 and
+            // mis-rotate the suffix. The pool/state already hold the prefix
+            // K/V; only this dense-side offset bookkeeping needs carrying over.
+            caches
+                .into_iter()
+                .enumerate()
+                .map(|(layer_idx, handle)| {
+                    let mut cache =
+                        KVCache::new_paged(pool_rc.clone(), state_rc.clone(), layer_idx);
+                    cache.offset = handle.offset;
+                    cache
+                })
+                .collect()
+        } else {
+            // Dense-from-handles reconstruction (model-owned families, or any
+            // non-`Fp16` paged layout that keeps dense quantized placeholders).
+            let mut live = Vec::with_capacity(caches.len());
+            for detached_cache in caches {
+                let mut cache = KVCache::new_with_mode(detached_cache.mode);
+                cache
+                    .install_detached(detached_cache)
+                    .expect("freshly constructed KVCache is empty");
+                live.push(cache);
+            }
+            live
+        };
+
         let mut entry = SequenceCacheSet::paged(id, paged_layout.clone());
         entry.caches = live_caches;
-        entry.paged = Some(Rc::new(RefCell::new(paged_state)));
+        entry.paged = Some(state_rc);
         entry.backend = backend;
         entry.prompt_len = prompt_len;
         entry.current_offset = current_offset;

--- a/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
@@ -964,6 +964,368 @@ fn write_prefill_after_shared_prefix_adopt_allocates_only_suffix_blocks() {
     assert_eq!(flatten_fp32(&gv), flatten_fp32(&dense_v));
 }
 
+// ---------------------------------------------------------------------------
+// 10. Pool-backed radix round-trip (#121 sub-step b): the adopt path must
+//     reconstruct POOL-BACKED caches (not empty dense placeholders) for a
+//     dense-natural Fp16 paged sequence, and the adopted sequence must SHARE
+//     the cached prefix's physical blocks (stored once, no re-prefill).
+// ---------------------------------------------------------------------------
+
+/// Dense-natural stub model: its NATURAL sequence-state backend is the dense
+/// external `KVCache` slice (the trait default), so `allocate_with_layout` with
+/// an Fp16 paged layout POOL-BACKS it (`new_paged` caches) — exactly the shape
+/// a real `supports_batching` transformer (qwen3 / llama3) gets under paged
+/// decode. Contrast with `PagedStubModel`, whose natural backend is paged and
+/// therefore keeps dense placeholder caches.
+struct DenseNaturalStubModel {
+    num_layers: usize,
+    prepared: std::cell::RefCell<Vec<SequenceId>>,
+}
+
+impl DenseNaturalStubModel {
+    fn new(num_layers: usize) -> Self {
+        Self {
+            num_layers,
+            prepared: std::cell::RefCell::new(Vec::new()),
+        }
+    }
+
+    fn prepared_ids(&self) -> Vec<SequenceId> {
+        self.prepared.borrow().clone()
+    }
+}
+
+impl LanguageModel for DenseNaturalStubModel {
+    fn forward(
+        &self,
+        _input_ids: &MlxArray,
+        _caches: &mut [KVCache],
+        _mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        crate::ffi::zeros(&[1], 0)
+    }
+
+    fn make_caches(&self) -> Vec<KVCache> {
+        (0..self.num_layers).map(|_| KVCache::new()).collect()
+    }
+
+    fn num_layers(&self) -> usize {
+        self.num_layers
+    }
+
+    fn eos_token_ids(&self) -> Vec<i32> {
+        vec![0]
+    }
+
+    // Deliberately DOES NOT override `sequence_state_layout`: the trait default
+    // reports `SequenceStateBackend::DenseKvCache`, which is the natural backend
+    // the pool-backing gate keys on.
+
+    fn prepare_sequence_state(&self, seq_id: SequenceId) {
+        self.prepared.borrow_mut().push(seq_id);
+    }
+}
+
+/// 1-layer Fp16 paged layout sized for `[1, n_kv_heads, *, head_dim]` blocks.
+fn fp16_pool_layout(block_size: usize, n_kv_heads: i32, head_dim: i32) -> PagedKvLayout {
+    let bytes_per_block = block_size * n_kv_heads as usize * head_dim as usize * 2;
+    let layout = PagedKvLayout::uniform(1, block_size, bytes_per_block).unwrap();
+    assert_eq!(
+        layout.cache_mode,
+        KVCacheMode::Fp16,
+        "pool-backing requires an Fp16 paged layout"
+    );
+    layout
+}
+
+#[test]
+fn adopt_paged_reconstructs_pool_backed_caches_and_shares_prefix() {
+    let n_kv_heads = 2i32;
+    let head_dim = 3i32;
+    let block_size = 4usize;
+    let layout = fp16_pool_layout(block_size, n_kv_heads, head_dim);
+    let model = DenseNaturalStubModel::new(1);
+    let mut pool = CachePool::new(4);
+
+    // --- Allocate a POOL-BACKED paged sequence (dense-natural + Fp16). ---
+    let seed = pool
+        .allocate_with_layout(&model, Some(SequenceStateLayout::paged_kv_cache(layout)))
+        .unwrap();
+    assert!(
+        pool.get_caches_mut(seed).unwrap()[0].is_paged_backed(),
+        "dense-natural Fp16 paged sequence must be pool-backed at allocate time"
+    );
+
+    // --- Prefill an 8-token (2 whole blocks) prefix through the POOL-BACKED
+    //     cache's real `update_and_fetch` path (routes to `write_paged`, which
+    //     writes the pool blocks AND advances the cache's monotonic offset —
+    //     exactly what `model.forward` does). The returned gather is the
+    //     reference visible window. ---
+    let prefix_len = 8i32;
+    let prefix_k = prefill_block(1000.0, n_kv_heads, prefix_len, head_dim);
+    let prefix_v = prefill_block(5000.0, n_kv_heads, prefix_len, head_dim);
+    let reference = {
+        let caches = pool.get_caches_mut(seed).unwrap();
+        let (gk, gv) = caches[0].update_and_fetch(prefix_k, prefix_v);
+        (flatten_fp32(&gk), flatten_fp32(&gv))
+    };
+    assert_eq!(
+        pool.get_caches_mut(seed).unwrap()[0].offset,
+        prefix_len,
+        "prefill through the pool-backed cache advances its monotonic offset"
+    );
+    let prefix_blocks = pool
+        .get_paged_state(seed)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids
+        .clone();
+    assert_eq!(prefix_blocks.len(), 2, "8 tokens => 2 whole prefix blocks");
+    let live_before = pool.paged_stats().unwrap().live_blocks;
+    assert_eq!(
+        live_before, 2,
+        "only the 2 prefix blocks are live pre-detach"
+    );
+
+    // --- detach -> park -> adopt into a SECOND sequence (the radix path). ---
+    let detached = pool.detach_paged(seed).unwrap();
+    assert_eq!(detached.retained_block_count(), 2);
+    let handle = pool.park_detached_paged(detached);
+    let consumer = pool.adopt_parked_paged(&model, handle).unwrap();
+    assert_ne!(seed, consumer);
+    assert!(model.prepared_ids().contains(&consumer));
+
+    // (a) THE FIX: the adopted sequence's caches are POOL-BACKED. Before #121
+    //     sub-step (b) the adopt path rebuilt empty dense caches here, so the
+    //     adopted sequence would read garbage in a real model forward.
+    assert!(
+        pool.get_caches_mut(consumer).unwrap()[0].is_paged_backed(),
+        "adopt_paged must reconstruct POOL-BACKED caches for a pool-backed sequence"
+    );
+    // (a') the restored monotonic offset must equal the cached prefix length so
+    //      RoPE positions for the post-adopt prefill/decode are correct. A fresh
+    //      `new_paged` cache would report 0 here and mis-rotate the suffix.
+    assert_eq!(
+        pool.get_caches_mut(consumer).unwrap()[0].offset,
+        prefix_len,
+        "adopt must restore the cache offset to the cached prefix length"
+    );
+
+    // (b) the consumer SHARES the prefix's physical block ids (refcount-pinned
+    //     across the round-trip), not fresh copies.
+    let consumer_blocks = pool
+        .get_paged_state(consumer)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids
+        .clone();
+    assert_eq!(
+        consumer_blocks, prefix_blocks,
+        "adopted consumer must reuse the prefix block ids"
+    );
+
+    // (d) the prefix is stored ONCE — adoption did not allocate a second copy.
+    let live_after = pool.paged_stats().unwrap().live_blocks;
+    assert_eq!(
+        live_after, live_before,
+        "shared prefix must not double the live block count"
+    );
+
+    // (c) gather_visible on the adopted sequence returns the SAME K/V.
+    let adopted = {
+        let state = pool.get_paged_state(consumer).unwrap();
+        let (gk, gv) = pool
+            .paged_pool_ref()
+            .unwrap()
+            .gather_visible(&state, 0)
+            .unwrap()
+            .expect("consumer gather must return data");
+        (flatten_fp32(&gk), flatten_fp32(&gv))
+    };
+    assert_eq!(
+        adopted.0, reference.0,
+        "adopted K equals original (no copy)"
+    );
+    assert_eq!(
+        adopted.1, reference.1,
+        "adopted V equals original (no copy)"
+    );
+
+    // --- A block-aligned suffix [8, 14) prefilled through the consumer's
+    //     pool-backed cache allocates ONLY its own blocks; the shared prefix
+    //     blocks are untouched and the offset continues from 8. ---
+    let suffix_len = 6i32;
+    let suffix_k = prefill_block(2000.0, n_kv_heads, suffix_len, head_dim);
+    let suffix_v = prefill_block(6000.0, n_kv_heads, suffix_len, head_dim);
+    {
+        let caches = pool.get_caches_mut(consumer).unwrap();
+        let _ = caches[0].update_and_fetch(suffix_k, suffix_v);
+    }
+    assert_eq!(
+        pool.get_caches_mut(consumer).unwrap()[0].offset,
+        prefix_len + suffix_len,
+        "post-adopt suffix prefill continues the monotonic offset from the prefix"
+    );
+    let live_suffix = pool.paged_stats().unwrap().live_blocks;
+    assert_eq!(
+        live_suffix - live_after,
+        2,
+        "shared-prefix request allocates blocks only for its 6-token suffix"
+    );
+    let after_blocks = pool
+        .get_paged_state(consumer)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids
+        .clone();
+    assert_eq!(
+        &after_blocks[..2],
+        &prefix_blocks[..],
+        "prefix blocks unchanged"
+    );
+}
+
+#[test]
+fn pool_backed_sharers_cow_keeps_other_prefix_intact() {
+    // Two LIVE pool-backed sequences sharing a PARTIAL-tail prefix: a divergent
+    // suffix on one must copy-on-write the shared tail block, leaving the other
+    // sequence's prefix bit-identical. `CachePool::adopt_paged` is move-based
+    // (it cannot stand up two live aliasing sequences at once), so the sibling
+    // is constructed by aliasing the block table + `retain_block` — exactly the
+    // refcount>1 state two adopters of the same cached prefix would reach.
+    let n_kv_heads = 2i32;
+    let head_dim = 3i32;
+    let block_size = 4usize;
+    let layout = fp16_pool_layout(block_size, n_kv_heads, head_dim);
+    let model = DenseNaturalStubModel::new(1);
+    let mut pool = CachePool::new(4);
+
+    // --- Sequence A: pool-backed, 6-token prefix (2 blocks; tail half-full). ---
+    let seq_a = pool
+        .allocate_with_layout(
+            &model,
+            Some(SequenceStateLayout::paged_kv_cache(layout.clone())),
+        )
+        .unwrap();
+    assert!(pool.get_caches_mut(seq_a).unwrap()[0].is_paged_backed());
+    let prefix_len = 6i32;
+    let prefix_k = prefill_block(1000.0, n_kv_heads, prefix_len, head_dim);
+    let prefix_v = prefill_block(5000.0, n_kv_heads, prefix_len, head_dim);
+    write_prefill_for(&mut pool, seq_a, 0, &prefix_k, &prefix_v).unwrap();
+    let prefix_blocks = pool
+        .get_paged_state(seq_a)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids
+        .clone();
+    assert_eq!(prefix_blocks.len(), 2);
+    let tail_block = prefix_blocks[1];
+    assert_eq!(pool.paged_pool_ref().unwrap().refcount(tail_block), 1);
+
+    let reference = {
+        let state = pool.get_paged_state(seq_a).unwrap();
+        let (gk, gv) = pool
+            .paged_pool_ref()
+            .unwrap()
+            .gather_visible(&state, 0)
+            .unwrap()
+            .expect("A gather");
+        (flatten_fp32(&gk), flatten_fp32(&gv))
+    };
+
+    // --- Sequence B: pool-backed, aliases A's prefix block table + pins it
+    //     (the refcount>1 state two concurrent adopters of the same cached
+    //     prefix reach). ---
+    let seq_b = pool
+        .allocate_with_layout(&model, Some(SequenceStateLayout::paged_kv_cache(layout)))
+        .unwrap();
+    assert!(pool.get_caches_mut(seq_b).unwrap()[0].is_paged_backed());
+    {
+        let set = pool.get_mut(seq_b).unwrap();
+        let mut state = set.paged.as_ref().unwrap().borrow_mut();
+        let layer = state.layer_mut(0).unwrap();
+        layer.block_ids = prefix_blocks.clone();
+        layer.len = prefix_len as usize;
+        layer.logical_start = 0;
+    }
+    for &id in &prefix_blocks {
+        pool.paged_pool
+            .as_ref()
+            .unwrap()
+            .borrow_mut()
+            .retain_block(id)
+            .unwrap();
+    }
+    assert_eq!(
+        pool.paged_pool_ref().unwrap().refcount(tail_block),
+        2,
+        "both live sequences now share the partial tail block"
+    );
+    // B reads the identical prefix before any divergent write.
+    {
+        let state = pool.get_paged_state(seq_b).unwrap();
+        let (gk, gv) = pool
+            .paged_pool_ref()
+            .unwrap()
+            .gather_visible(&state, 0)
+            .unwrap()
+            .expect("B gather");
+        assert_eq!(flatten_fp32(&gk), reference.0);
+        assert_eq!(flatten_fp32(&gv), reference.1);
+    }
+
+    // --- Divergent 5-token suffix into A. positions [6, 11): the first suffix
+    //     slot lands in the SHARED partial tail (slots 2,3), so write_prefill
+    //     must copy-on-write the tail for A. ---
+    let suffix_k = prefill_block(2000.0, n_kv_heads, 5, head_dim);
+    let suffix_v = prefill_block(6000.0, n_kv_heads, 5, head_dim);
+    write_prefill_for(&mut pool, seq_a, 0, &suffix_k, &suffix_v).unwrap();
+
+    let a_tail = pool
+        .get_paged_state(seq_a)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids[1];
+    let b_tail = pool
+        .get_paged_state(seq_b)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids[1];
+    assert_ne!(
+        a_tail, tail_block,
+        "A wrote while the tail was shared, so it must fork a fresh copy"
+    );
+    assert_eq!(
+        b_tail, tail_block,
+        "B keeps the original tail block (not corrupted by A's suffix)"
+    );
+    assert_eq!(
+        pool.paged_pool_ref().unwrap().refcount(tail_block),
+        1,
+        "after A's COW fork the original tail is solely owned by B"
+    );
+
+    // --- B's prefix is bit-identical to before A's divergent write. ---
+    let b_after = {
+        let state = pool.get_paged_state(seq_b).unwrap();
+        let (gk, gv) = pool
+            .paged_pool_ref()
+            .unwrap()
+            .gather_visible(&state, 0)
+            .unwrap()
+            .expect("B gather after A suffix");
+        (flatten_fp32(&gk), flatten_fp32(&gv))
+    };
+    assert_eq!(b_after.0, reference.0, "B's prefix K intact after A's COW");
+    assert_eq!(b_after.1, reference.1, "B's prefix V intact after A's COW");
+}
+
 /// Free reference to DetachedPagedCacheSet to keep the import alive.
 #[allow(dead_code)]
 fn _type_alive() -> Option<DetachedPagedCacheSet> {

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -33,8 +33,8 @@ use std::sync::mpsc;
 use std::time::Instant;
 
 use mlxcel_core::cache::{
-    BatchKvQuantConfig, CachePool, DetachedCacheSet, KVCacheMode, PagedKvLayout, SequenceId,
-    SequenceStateBackend, SequenceStateLayout,
+    BatchKvQuantConfig, CachePool, KVCacheMode, PagedKvLayout, SequenceId, SequenceStateBackend,
+    SequenceStateLayout,
 };
 use mlxcel_core::generate::{
     DecodeBatchContext, DecodeStorageBackend as CoreDecodeStorageBackend, LanguageModel,
@@ -62,7 +62,7 @@ use crate::server::model_provider::model_worker::{
 };
 use crate::server::model_provider::{GenerateEvent, ModelRequest};
 use crate::server::prompt_cache::key::{MultimodalDigest, PromptCacheKey};
-use crate::server::prompt_cache::{CacheEntry, PromptCacheStore};
+use crate::server::prompt_cache::{CacheEntry, DetachedKvSet, PromptCacheStore};
 use crate::server::state::BatchMetrics;
 use crate::server::thinking_budget::{
     ThinkingBudget, ThinkingDecision, ThinkingState, ThinkingTokenIds,
@@ -721,22 +721,25 @@ impl BatchScheduler {
     /// Gating (all of these yield `None`, which maps to a cold prefill):
     /// * feature disabled at config time,
     /// * request carried no [`PromptCacheRequestContext`] (non-chat endpoint),
-    /// * scheduler configured with the paged decode backend (paged adoption
-    ///   through the store is deferred — the store's [`CacheEntry`] type
-    ///   currently only carries dense detached sets),
     /// * store miss / match shorter than `min_prefix_tokens`,
     /// * race with another worker that already consumed the entry,
-    /// * empty-tensor detached set (e.g. stored against an aborted seq),
-    /// * [`CachePool::adopt`] error (capacity, unsupported backend, …).
+    /// * empty detached set (e.g. stored against an aborted seq),
+    /// * backend mismatch (a `Dense` entry under the paged decode backend, or
+    ///   a `Paged` entry under the dense backend — the entry's KV shape cannot
+    ///   be installed into the active pool),
+    /// * [`CachePool::adopt`] / [`CachePool::adopt_paged`] error (capacity,
+    ///   layout mismatch, …).
+    ///
+    /// Both dense and paged entries are adopted in-place: dense via
+    /// [`CachePool::adopt`], paged via [`CachePool::adopt_paged`] (which shares
+    /// the cached prefix's refcounted pool blocks so the prefix is never
+    /// re-prefilled — #121 sub-step b).
     fn try_adopt_cached_prefix(
         &mut self,
         ctx: &PromptCacheRequestContext,
         tokens: &[i32],
     ) -> Option<(SequenceId, usize)> {
         if !self.prompt_cache_active() {
-            return None;
-        }
-        if self.decode_storage_backend == DecodeStorageBackend::Paged {
             return None;
         }
 
@@ -746,40 +749,77 @@ impl BatchScheduler {
         // `take_detached` is one-shot: it returns `None` if a racing lookup
         // already consumed this entry. The miss path is safe — the current
         // sequence just does a fresh prefill.
-        let mut detached = entry.take_detached()?;
-        if detached.caches.is_empty() || detached.caches.iter().all(|c| c.is_empty()) {
+        let detached = entry.take_detached()?;
+        if detached.is_empty() {
+            // A paged set drained on this path would leak its block pins via
+            // `Drop`; release them explicitly so the pool budget stays honest.
+            self.release_unused_detached(detached);
             return None;
         }
 
-        // APC block-level partial adoption. When APC clamps
-        // `matched_len` to a block boundary shorter than the cached entry's
-        // full token length, the request diverged from the cached prefix at
-        // the next block. Truncate the detached KV state to exactly
-        // `matched_len` so the adopted cache covers only the consistent
-        // prefix; the prefill loop will then re-prefill the divergent tail
-        // starting at `matched_len`. When `matched_len == detached.seq_len()`
-        // this branch is skipped, preserving the bit-exact full-prefix
-        // adoption path.
-        let detached_seq_len = detached.seq_len();
-        if matched_len < detached_seq_len as usize {
-            let target = matched_len as i32;
-            if let Err(err) = detached.truncate_to(target) {
-                tracing::warn!(
-                    "prompt-cache adopt: APC partial truncate to {target} failed ({err}); falling back to cold prefill"
-                );
-                return None;
-            }
-            tracing::debug!(
-                from = detached_seq_len,
-                to = target,
-                "prompt-cache adopt: APC partial adoption truncated detached cache to block boundary"
-            );
+        // Reject cross-backend adoption: the active decode backend determines
+        // the KV shape the model worker can install. Adopting the wrong variant
+        // would corrupt the sequence, so fall through to a cold prefill (and
+        // release any paged pins we took).
+        let backend_mismatch = matches!(
+            (&detached, self.decode_storage_backend),
+            (DetachedKvSet::Dense(_), DecodeStorageBackend::Paged)
+                | (DetachedKvSet::Paged(_), DecodeStorageBackend::Dense)
+        );
+        if backend_mismatch {
+            self.release_unused_detached(detached);
+            return None;
         }
 
-        match self
-            .cache_pool
-            .adopt(&self.model as &dyn LanguageModel, detached)
-        {
+        let adopt_result = match detached {
+            DetachedKvSet::Dense(mut dense) => {
+                // APC block-level partial adoption. When APC clamps
+                // `matched_len` to a block boundary shorter than the cached
+                // entry's full token length, the request diverged from the
+                // cached prefix at the next block. Truncate the detached KV
+                // state to exactly `matched_len` so the adopted cache covers
+                // only the consistent prefix; the prefill loop then re-prefills
+                // the divergent tail. When `matched_len == seq_len` this branch
+                // is skipped, preserving the bit-exact full-prefix path.
+                let detached_seq_len = dense.seq_len();
+                if matched_len < detached_seq_len as usize {
+                    let target = matched_len as i32;
+                    if let Err(err) = dense.truncate_to(target) {
+                        tracing::warn!(
+                            "prompt-cache adopt: APC partial truncate to {target} failed ({err}); falling back to cold prefill"
+                        );
+                        return None;
+                    }
+                    tracing::debug!(
+                        from = detached_seq_len,
+                        to = target,
+                        "prompt-cache adopt: APC partial adoption truncated detached cache to block boundary"
+                    );
+                }
+                self.cache_pool
+                    .adopt(&self.model as &dyn LanguageModel, dense)
+            }
+            DetachedKvSet::Paged(paged) => {
+                // APC block-hash partial adoption for paged entries is deferred
+                // (a later #121 sub-step): the paged store path matches the full
+                // stored prefix only. If a partial match somehow surfaces,
+                // decline rather than adopt an over-long prefix.
+                let paged_seq_len = paged.seq_len();
+                if matched_len < paged_seq_len {
+                    tracing::debug!(
+                        from = paged_seq_len,
+                        to = matched_len,
+                        "prompt-cache adopt: paged partial adoption not yet supported; releasing and falling back to cold prefill"
+                    );
+                    self.cache_pool.release_detached_paged(paged);
+                    return None;
+                }
+                self.cache_pool
+                    .adopt_paged(&self.model as &dyn LanguageModel, paged)
+            }
+        };
+
+        match adopt_result {
             Ok(adopted_id) => {
                 tracing::debug!(
                     seq_id = %adopted_id,
@@ -800,8 +840,26 @@ impl BatchScheduler {
                 Some((adopted_id, matched_len))
             }
             Err(err) => {
+                // `adopt_paged` already releases paged pins on its error path;
+                // `adopt` (dense) simply drops the buffers. Nothing to reclaim.
                 tracing::debug!("prompt-cache adopt failed ({err}); falling back to cold prefill");
                 None
+            }
+        }
+    }
+
+    /// Release a detached set the adopt path decided not to use.
+    ///
+    /// A dense set just drops its MLX buffers. A paged set additionally owns
+    /// refcount pins on physical pool blocks, which [`Drop`] cannot release on
+    /// its own (it has no pool handle) — so route it through
+    /// [`CachePool::release_detached_paged`] to return the pins and keep the
+    /// block budget accurate.
+    fn release_unused_detached(&mut self, detached: DetachedKvSet) {
+        match detached {
+            DetachedKvSet::Dense(_) => {}
+            DetachedKvSet::Paged(paged) => {
+                self.cache_pool.release_detached_paged(paged);
             }
         }
     }
@@ -812,9 +870,16 @@ impl BatchScheduler {
     /// The caller must invoke this **before** calling
     /// [`Self::release_sequence_caches`] — once release runs the underlying
     /// tensors are gone. Safe to call unconditionally; all the gating checks
-    /// (feature enabled, healthy finish, context present, dense backend)
+    /// (feature enabled, healthy finish, context present, detachable backend)
     /// live inside this method so the caller can keep its hot-path code
     /// simple.
+    ///
+    /// Both dense and paged sequences are donated: dense via
+    /// [`CachePool::detach`] (→ [`DetachedKvSet::Dense`]) and paged via
+    /// [`CachePool::detach_paged`] (→ [`DetachedKvSet::Paged`], which pins the
+    /// prefix's physical pool blocks so a later `adopt_paged` can share them).
+    /// `ModelOwned` sequences carry no detachable cross-request KV and are
+    /// skipped.
     fn donate_finished_sequence_cache(
         &mut self,
         seq_id: SequenceId,
@@ -836,24 +901,15 @@ impl BatchScheduler {
             None => return,
         };
 
-        // Only dense sequences can travel through the store's
-        // `DetachedCacheSet` (paged follow-up work).
         let backend = self
             .cache_pool
             .get_mut(seq_id)
             .map(|s| s.backend)
             .unwrap_or(SequenceStateBackend::ModelOwned);
-        if backend != SequenceStateBackend::DenseKvCache {
-            return;
-        }
-
-        let detached: DetachedCacheSet = match self.cache_pool.detach(seq_id) {
-            Some(d) => d,
-            None => return,
-        };
-        if detached.caches.is_empty() || detached.caches.iter().all(|c| c.is_empty()) {
-            // Nothing to cache: aborted before any prefill completed, or
-            // the model never populated the KV tensors.
+        // `ModelOwned` families (heterogeneous attention+recurrent caches, e.g.
+        // Qwen 3.5 / Gemma 4) carry no detachable cross-request KV. Skip before
+        // building the token vector so the burst donate stays a cheap no-op.
+        if backend == SequenceStateBackend::ModelOwned {
             return;
         }
 
@@ -868,11 +924,45 @@ impl BatchScheduler {
             Some(s) => s.clone(),
             None => return,
         };
+
+        // Detach into the backend-appropriate variant.
+        let kv_set: DetachedKvSet = match backend {
+            SequenceStateBackend::DenseKvCache => match self.cache_pool.detach(seq_id) {
+                Some(d) => DetachedKvSet::Dense(d),
+                None => return,
+            },
+            SequenceStateBackend::PagedKvCache => {
+                // `detach_paged` pins every physical prefix block, and those
+                // pins can only be returned through `release_detached_paged`
+                // (the set's `Drop` cannot). If the store would reject the
+                // entry for being shorter than `min_prefix_tokens`, screen the
+                // length BEFORE detaching so we never take pins we'd have to
+                // immediately release. The dense path needs no such screen — a
+                // rejected dense entry just drops its buffers.
+                if tokens.len() < store.min_prefix_tokens() {
+                    return;
+                }
+                match self.cache_pool.detach_paged(seq_id) {
+                    Some(p) => DetachedKvSet::Paged(p),
+                    None => return,
+                }
+            }
+            SequenceStateBackend::ModelOwned => return,
+        };
+
+        if kv_set.is_empty() {
+            // Nothing to cache: aborted before any prefill completed, or the
+            // model never populated the KV state. Release any paged pins we
+            // took so the pool budget stays honest.
+            self.release_unused_detached(kv_set);
+            return;
+        }
+
         // The `CacheEntry` takes ownership of `tokens` and the key borrows
         // from the same buffer. Build the entry first, then form the key
         // against `entry.tokens` so both reference the same contiguous
         // allocation without copying the vector.
-        let entry = CacheEntry::new(tokens, detached);
+        let entry = CacheEntry::new(tokens, kv_set);
         let key_tokens = entry.tokens.clone();
         let key = Self::compose_prompt_cache_key(&ctx, &key_tokens);
         match store.insert(&key, entry) {
@@ -883,8 +973,13 @@ impl BatchScheduler {
                     .update_prompt_cache_gauges(store.bytes(), store.len());
             }
             Err(err) => {
-                // Oversized / disabled / prefix-too-short — drop the entry
-                // so the detached buffers are freed.
+                // Oversized / disabled / prefix-too-short — `insert` drops the
+                // entry. For dense that frees the buffers; for a paged entry the
+                // length pre-screen above already filtered the common
+                // prefix-too-short case, but an oversized paged entry dropped
+                // here still leaks its block pins (its `Drop` warns). Returning
+                // store-declined paged pins to the pool is wired with the pool
+                // block-budget eviction work (#122).
                 tracing::debug!(
                     seq_id = %seq_id,
                     "prompt-cache donate-back skipped: {err:?}"
@@ -2047,17 +2142,17 @@ impl BatchScheduler {
                     // needs the cache slot still attached. This mirrors
                     // the classic path's `finalize_completed`, keeping
                     // the burst and classic donate paths symmetric. The
-                    // donate helper is hard-gated on a dense KV-cache
-                    // backend; the two burst-eligible model families
-                    // today — Qwen 3.5 (DFlash) and Gemma 4 (MTP) — are
-                    // both `SequenceStateBackend::ModelOwned` with
-                    // heterogeneous attention+recurrent caches that the
-                    // `DetachedCacheSet` handoff cannot represent, so the
-                    // donate is a guarded no-op for them — identical to
-                    // the classic path's no-op for those same families.
-                    // Wiring it in removes the structural asymmetry
-                    // between the two paths and future-proofs the burst
-                    // for any dense-KV-cache model that later becomes
+                    // donate helper detaches dense and paged backends but
+                    // skips `SequenceStateBackend::ModelOwned`; the two
+                    // burst-eligible model families today — Qwen 3.5
+                    // (DFlash) and Gemma 4 (MTP) — are both `ModelOwned`
+                    // with heterogeneous attention+recurrent caches that
+                    // the detach handoff cannot represent, so the donate is
+                    // a guarded no-op for them — identical to the classic
+                    // path's no-op for those same families. Wiring it in
+                    // removes the structural asymmetry between the two
+                    // paths and future-proofs the burst for any
+                    // dense/paged-KV model that later becomes
                     // burst-eligible.
                     self.donate_finished_sequence_cache(
                         seq_id,

--- a/src/server/batch/scheduler_prompt_cache_tests.rs
+++ b/src/server/batch/scheduler_prompt_cache_tests.rs
@@ -36,11 +36,13 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use mlxcel_core::cache::SequenceId;
+use mlxcel_core::cache::{CachePool, KVCache, PagedKvLayout, SequenceId, SequenceStateLayout};
+use mlxcel_core::generate::LanguageModel;
+use mlxcel_core::{MlxArray, UniquePtr};
 
 use crate::server::batch::BatchObservability;
 use crate::server::prompt_cache::{
-    ApcConfig, ApcHashAlgo, CacheEntry, PromptCacheConfig, PromptCacheStore,
+    ApcConfig, ApcHashAlgo, CacheEntry, DetachedKvSet, PromptCacheConfig, PromptCacheStore,
     key::{MultimodalDigest, PromptCacheKey},
 };
 
@@ -727,5 +729,128 @@ fn scheduler_partial_adoption_invariant_matched_len_is_block_aligned() {
             0,
             "matched_len {matched_len} for divergence at {divergence} must be block-aligned"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Paged entry round-trip through the store's CacheEntry (#121 sub-step b)
+//
+// The cross-request store now parks both dense and paged detached sets via the
+// `DetachedKvSet` union. These cases prove a real `DetachedPagedCacheSet` flows
+// through `CacheEntry::new` / `take_detached` one-shot semantics and that
+// `size_bytes` snapshots the paged set's byte footprint (eviction accounting).
+// ---------------------------------------------------------------------------
+
+/// Minimal paged-natural stub model so we can mint a real
+/// `DetachedPagedCacheSet` via `CachePool::detach_paged`.
+struct PagedStub {
+    layout: PagedKvLayout,
+}
+
+impl LanguageModel for PagedStub {
+    fn forward(
+        &self,
+        _input_ids: &MlxArray,
+        _caches: &mut [KVCache],
+        _mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        mlxcel_core::zeros(&[1], 0)
+    }
+
+    fn make_caches(&self) -> Vec<KVCache> {
+        (0..self.layout.num_layers)
+            .map(|_| KVCache::new())
+            .collect()
+    }
+
+    fn num_layers(&self) -> usize {
+        self.layout.num_layers
+    }
+
+    fn eos_token_ids(&self) -> Vec<i32> {
+        vec![0]
+    }
+
+    fn sequence_state_layout(&self) -> SequenceStateLayout {
+        SequenceStateLayout::paged_kv_cache(self.layout.clone())
+    }
+}
+
+#[test]
+fn paged_detached_set_round_trips_through_cache_entry() {
+    let layout = PagedKvLayout::uniform(2, 4, 128).unwrap();
+    let model = PagedStub {
+        layout: layout.clone(),
+    };
+    let mut pool = CachePool::new(4);
+
+    // Build a paged sequence with a populated block table (no MLX writes
+    // needed — `append_paged_tokens` grows the block table and reserves bytes).
+    let seq = pool.allocate(&model).unwrap();
+    pool.append_paged_tokens(seq, 0, 6).unwrap();
+    pool.append_paged_tokens(seq, 1, 8).unwrap();
+
+    let paged = pool.detach_paged(seq).expect("paged detach must succeed");
+    let expected_bytes = paged.nbytes();
+    assert!(
+        expected_bytes > 0,
+        "a populated paged set must report nonzero bytes"
+    );
+
+    // The union dispatches nbytes()/is_empty() to the paged arm.
+    let kv_set = DetachedKvSet::Paged(paged);
+    assert!(!kv_set.is_empty(), "a populated paged set is not empty");
+    assert_eq!(
+        kv_set.nbytes(),
+        expected_bytes,
+        "DetachedKvSet::nbytes dispatches to the paged set"
+    );
+
+    // CacheEntry snapshots size_bytes from the paged set for eviction
+    // accounting and stores the union behind its one-shot holder.
+    let tokens: Vec<i32> = (0..14).collect();
+    let entry = CacheEntry::new(tokens.clone(), kv_set);
+    assert_eq!(
+        entry.size_bytes, expected_bytes,
+        "size_bytes snapshots the paged set's nbytes"
+    );
+    assert_eq!(entry.tokens, tokens);
+    assert!(entry.has_detached());
+
+    // One-shot take returns the Paged variant; a second take is a miss.
+    let taken = entry.take_detached().expect("first take yields the set");
+    assert!(matches!(taken, DetachedKvSet::Paged(_)));
+    assert!(
+        entry.take_detached().is_none(),
+        "second take is a miss (one-shot)"
+    );
+    assert!(!entry.has_detached());
+
+    // The taken set still owns block pins; return them so the pool budget
+    // stays honest and the set's `Drop` does not warn.
+    if let DetachedKvSet::Paged(set) = taken {
+        pool.release_detached_paged(set);
+    }
+}
+
+#[test]
+fn empty_paged_detached_set_reports_empty() {
+    // A paged sequence with no appended tokens has an empty block table, so
+    // the union's variant-aware `is_empty()` must report it empty (the dense
+    // per-layer handles are empty by design for paged sets).
+    let layout = PagedKvLayout::uniform(1, 4, 128).unwrap();
+    let model = PagedStub {
+        layout: layout.clone(),
+    };
+    let mut pool = CachePool::new(4);
+    let seq = pool.allocate(&model).unwrap();
+    let paged = pool.detach_paged(seq).expect("paged detach must succeed");
+    let kv_set = DetachedKvSet::Paged(paged);
+    assert!(
+        kv_set.is_empty(),
+        "a paged set with no visible tokens / blocks must be reported empty"
+    );
+    if let DetachedKvSet::Paged(set) = kv_set {
+        pool.release_detached_paged(set);
     }
 }

--- a/src/server/prompt_cache/entry.rs
+++ b/src/server/prompt_cache/entry.rs
@@ -22,18 +22,79 @@
 use std::sync::Mutex;
 use std::time::Instant;
 
-use mlxcel_core::cache::DetachedCacheSet;
+use mlxcel_core::cache::{DetachedCacheSet, DetachedPagedCacheSet};
 
 use super::block_hash::ApcBlockHash;
 
-/// Send/Sync holder for a [`DetachedCacheSet`].
+/// A detached KV-cache set, one variant per decode-storage backend.
 ///
-/// The upstream type wraps `cxx::UniquePtr<MlxArray>` which is neither
-/// `Send` nor `Sync` because the underlying FFI buffer is an opaque C++
-/// pointer. The detach/adopt API explicitly guarantees that:
+/// * [`DetachedKvSet::Dense`] — the dense per-layer `KVCache` buffers
+///   produced by [`mlxcel_core::cache::CachePool::detach`].
+/// * [`DetachedKvSet::Paged`] — the paged block-table snapshot produced by
+///   [`mlxcel_core::cache::CachePool::detach_paged`]. For a pool-backed
+///   paged sequence the per-layer dense handles are EMPTY by design (the
+///   K/V lives in the shared `PagedBlockPool`); the set carries the block
+///   table plus a refcount pin on every physical block so a later
+///   `adopt_paged` can share the prefix without re-prefilling it.
 ///
-/// * Once `CachePool::detach` returns, the originating sequence no longer
-///   aliases the buffers (the pointers are moved, not cloned).
+/// This is the single payload the cross-request prompt-prefix store parks
+/// between a donate-back and a later adopt, so the radix store is unified
+/// across both backends (#121 sub-step b).
+//
+// The two variants differ substantially in size (the paged variant carries
+// several `HashMap`s of per-page sidecar tensors); boxing the larger arm
+// would add an allocation on the hot dense path, so we accept the size gap.
+#[allow(clippy::large_enum_variant)]
+pub enum DetachedKvSet {
+    /// Dense per-layer KV buffers (the [`SequenceStateBackend::DenseKvCache`]
+    /// backend).
+    ///
+    /// [`SequenceStateBackend::DenseKvCache`]: mlxcel_core::cache::SequenceStateBackend::DenseKvCache
+    Dense(DetachedCacheSet),
+    /// Paged block-table snapshot (the [`SequenceStateBackend::PagedKvCache`]
+    /// backend).
+    ///
+    /// [`SequenceStateBackend::PagedKvCache`]: mlxcel_core::cache::SequenceStateBackend::PagedKvCache
+    Paged(DetachedPagedCacheSet),
+}
+
+impl DetachedKvSet {
+    /// Total byte footprint of the detached set, dispatched per backend.
+    ///
+    /// Feeds [`CacheEntry::size_bytes`] so the store's byte-budget eviction
+    /// accounting is consistent across dense and paged entries.
+    pub fn nbytes(&self) -> usize {
+        match self {
+            DetachedKvSet::Dense(d) => d.nbytes(),
+            DetachedKvSet::Paged(p) => p.nbytes(),
+        }
+    }
+
+    /// Whether the set carries no reusable KV state.
+    ///
+    /// * Dense: the per-layer caches are absent or all empty (e.g. stored
+    ///   against a sequence aborted before any prefill completed).
+    /// * Paged: the per-layer dense handles are EMPTY by design, so we gate
+    ///   on the paged block table instead — a set is empty when it exposes no
+    ///   visible tokens or pins no physical blocks.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            DetachedKvSet::Dense(d) => d.caches.is_empty() || d.caches.iter().all(|c| c.is_empty()),
+            DetachedKvSet::Paged(p) => p.seq_len() == 0 || p.retained_block_count() == 0,
+        }
+    }
+}
+
+/// Send/Sync holder for a [`DetachedKvSet`].
+///
+/// Both variants wrap `cxx::UniquePtr<MlxArray>` (directly for dense, or in
+/// the paged variant's per-page sidecar maps) which is neither `Send` nor
+/// `Sync` because the underlying FFI buffer is an opaque C++ pointer. The
+/// detach/adopt API explicitly guarantees that:
+///
+/// * Once `CachePool::detach` / `detach_paged` returns, the originating
+///   sequence no longer aliases the buffers (the pointers are moved, and the
+///   paged block pins are refcounted, not cloned).
 /// * Each buffer is functional: any MLX operation produces a fresh array,
 ///   so even if adopt runs on a different OS thread than detach, there is
 ///   no concurrent read/write on the same pointer.
@@ -44,13 +105,14 @@ use super::block_hash::ApcBlockHash;
 /// most one thread is reading or moving the tensors. This combination is
 /// sufficient to satisfy the soundness obligations documented in
 /// `src/lib/mlxcel-core/src/cache/detach.rs` (the "INT8 preservation" and
-/// "Aliasing with `MLXCEL_ENABLE_DIRECT_PREFILL_CACHE_STORE`" sections).
-pub(crate) struct DetachedHolder {
-    inner: Option<DetachedCacheSet>,
+/// "Aliasing with `MLXCEL_ENABLE_DIRECT_PREFILL_CACHE_STORE`" sections) and
+/// the analogous discipline in `cache/paged_detach.rs`.
+pub(crate) struct DetachedKvSetHolder {
+    inner: Option<DetachedKvSet>,
 }
 
-impl DetachedHolder {
-    pub(crate) fn new(set: DetachedCacheSet) -> Self {
+impl DetachedKvSetHolder {
+    pub(crate) fn new(set: DetachedKvSet) -> Self {
         Self { inner: Some(set) }
     }
 
@@ -58,21 +120,21 @@ impl DetachedHolder {
         self.inner.is_some()
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn take(&mut self) -> Option<DetachedCacheSet> {
+    pub(crate) fn take(&mut self) -> Option<DetachedKvSet> {
         self.inner.take()
     }
 }
 
 // SAFETY: See the type-level doc-comment above. The detach/adopt API
-// moves buffer ownership rather than aliasing it, the holder sits behind a
-// Mutex inside `CacheEntry`, and each buffer is only touched by one thread
-// at a time (the worker thread at adopt time; no parallel MLX op is ever
-// issued against a parked tensor). This is the same discipline that
-// upstream `CachePool` uses for its own `DetachedMap`, which similarly
-// only guarantees "single-threaded access" at any given time.
-unsafe impl Send for DetachedHolder {}
-unsafe impl Sync for DetachedHolder {}
+// moves buffer ownership (and refcounts paged block pins) rather than
+// aliasing it, the holder sits behind a Mutex inside `CacheEntry`, and each
+// buffer is only touched by one thread at a time (the worker thread at adopt
+// time; no parallel MLX op is ever issued against a parked tensor). This is
+// the same discipline that upstream `CachePool` uses for its own
+// `DetachedMap`, which similarly only guarantees "single-threaded access" at
+// any given time.
+unsafe impl Send for DetachedKvSetHolder {}
+unsafe impl Sync for DetachedKvSetHolder {}
 
 /// A prompt-prefix cache entry.
 ///
@@ -94,7 +156,7 @@ unsafe impl Sync for DetachedHolder {}
 ///   trie/scan candidate selection.
 pub struct CacheEntry {
     pub tokens: Vec<i32>,
-    pub(crate) detached: Mutex<DetachedHolder>,
+    pub(crate) detached: Mutex<DetachedKvSetHolder>,
     pub last_used: Mutex<Instant>,
     pub size_bytes: usize,
     pub apc_block_hashes: Option<Vec<ApcBlockHash>>,
@@ -103,18 +165,19 @@ pub struct CacheEntry {
 impl CacheEntry {
     /// Build a new entry from a token prefix and its detached cache set.
     ///
-    /// `size_bytes` is captured from [`DetachedCacheSet::nbytes`] so the
-    /// store's byte-budget accounting is consistent even if the underlying
-    /// tensors are later adopted out of the entry.
+    /// `size_bytes` is captured from [`DetachedKvSet::nbytes`] so the
+    /// store's byte-budget accounting is consistent (across both dense and
+    /// paged backends) even if the underlying tensors are later adopted out
+    /// of the entry.
     ///
     /// The APC block-hash chain is left unset; callers that have APC
     /// enabled should attach it via [`CacheEntry::with_apc_block_hashes`]
     /// before inserting into the store.
-    pub fn new(tokens: Vec<i32>, detached: DetachedCacheSet) -> Self {
+    pub fn new(tokens: Vec<i32>, detached: DetachedKvSet) -> Self {
         let size_bytes = detached.nbytes();
         Self {
             tokens,
-            detached: Mutex::new(DetachedHolder::new(detached)),
+            detached: Mutex::new(DetachedKvSetHolder::new(detached)),
             last_used: Mutex::new(Instant::now()),
             size_bytes,
             apc_block_hashes: None,
@@ -151,7 +214,7 @@ impl CacheEntry {
     /// from any thread because the cache set is serialised through this
     /// entry's mutex; the actual adopt path must still run on the worker
     /// thread (or wherever the model's `CachePool` lives).
-    pub fn take_detached(&self) -> Option<DetachedCacheSet> {
+    pub fn take_detached(&self) -> Option<DetachedKvSet> {
         match self.detached.lock() {
             Ok(mut g) => g.take(),
             Err(poisoned) => poisoned.into_inner().take(),
@@ -215,7 +278,7 @@ impl CacheEntry {
         };
         Self {
             tokens,
-            detached: Mutex::new(DetachedHolder::new(detached)),
+            detached: Mutex::new(DetachedKvSetHolder::new(DetachedKvSet::Dense(detached))),
             last_used: Mutex::new(Instant::now()),
             size_bytes,
             apc_block_hashes: None,

--- a/src/server/prompt_cache/mod.rs
+++ b/src/server/prompt_cache/mod.rs
@@ -58,7 +58,7 @@ pub use apc_lookup::ApcStoreStats;
 pub use block_hash::{
     ApcBlockHash, ApcHashAlgo, BlockHashChain, DEFAULT_APC_BLOCK_SIZE, ParseApcHashError,
 };
-pub use entry::CacheEntry;
+pub use entry::{CacheEntry, DetachedKvSet};
 pub use hybrid_ssm::{
     HYBRID_SSM_MODEL_TYPES, detect_hybrid_ssm, detect_hybrid_ssm_from_path,
     is_hybrid_ssm_model_type,

--- a/src/server/prompt_cache/store.rs
+++ b/src/server/prompt_cache/store.rs
@@ -289,6 +289,19 @@ impl PromptCacheStore {
         self.inner.read().map(|g| g.config.max_entries).unwrap_or(0)
     }
 
+    /// Minimum prefix length (in tokens) an entry must reach to be insertable.
+    ///
+    /// Mirrors the [`PromptCacheConfig::min_prefix_tokens`] gate that
+    /// [`PromptCacheStore::insert`] enforces. Callers that must avoid taking
+    /// non-droppable resources (e.g. paged block pins) before an insert that
+    /// would be rejected can pre-screen against this value.
+    pub fn min_prefix_tokens(&self) -> usize {
+        self.inner
+            .read()
+            .map(|g| g.config.min_prefix_tokens)
+            .unwrap_or(0)
+    }
+
     /// Snapshot of the store's internal counters. Safe to call concurrently
     /// with inserts/lookups; values are captured under the read lock.
     pub fn stats(&self) -> PromptCacheStats {

--- a/tests/paged_prefix_share_parity.rs
+++ b/tests/paged_prefix_share_parity.rs
@@ -1,0 +1,300 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real-model parity for the unified radix prompt-prefix cache over the paged
+//! block pool (#121 sub-step b).
+//!
+//! Proves the headline behaviour of the sub-step: two requests sharing a prompt
+//! prefix store that prefix's KV **once** in the paged pool and the second
+//! request reuses it without re-prefilling — and still decodes bit-identically
+//! to a cold (no-cache) paged run.
+//!
+//! ## What it drives
+//!
+//! The radix-store + `CachePool` path the scheduler uses (`BatchScheduler::new`
+//! is `pub(crate)`, so an integration test drives its cache core directly, same
+//! as `paged_scheduler_parity`):
+//!
+//! 1. **Cold reference** — a pool-backed paged sequence prefills the FULL prompt
+//!    `[prefix + suffix]` and greedily decodes `DECODE_STEPS` tokens.
+//! 2. **Cached path** — sequence A prefills ONLY the shared `prefix`, then
+//!    `detach_paged` → a [`DetachedKvSet::Paged`] [`CacheEntry`] in a real
+//!    [`PromptCacheStore`]. A second request B looks the prefix up, `take_detached`
+//!    → `adopt_paged` (sharing A's refcount-pinned prefix blocks), prefills ONLY
+//!    its divergent `suffix` at the right offset, and greedily decodes.
+//!
+//! The cached decode must equal the cold decode, and B's block table must reuse
+//! A's prefix blocks (no second copy of the prefix).
+//!
+//! ## Running
+//!
+//! `#[ignore]` (loads qwen3-0.6b-4bit and runs real GPU forwards). Run with:
+//!
+//! ```text
+//! cargo test --test paged_prefix_share_parity --release \
+//!     --features metal,accelerate -- --ignored --nocapture
+//! ```
+//!
+//! Soft-skips when `models/qwen3-0.6b-4bit` is absent. Fetch with:
+//!
+//! ```text
+//! ./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit
+//! ```
+
+mod common;
+use common::repo_model_dir;
+
+use std::time::Duration;
+
+use mlxcel::server::prompt_cache::key::{MultimodalDigest, PromptCacheKey};
+use mlxcel::server::prompt_cache::{
+    CacheEntry, DetachedKvSet, PromptCacheConfig, PromptCacheStore,
+};
+use mlxcel::{LanguageModel, initialize_runtime, load_model};
+use mlxcel_core::cache::{CachePool, PagedKvLayout, SequenceStateLayout};
+
+/// Model directory name (present at `models/qwen3-0.6b-4bit`).
+const MODEL_DIR_NAME: &str = "qwen3-0.6b-4bit";
+
+/// Paged block size (tokens per physical block) — matches the scheduler's
+/// `DEFAULT_PAGED_BLOCK_SIZE`.
+const BLOCK_SIZE: usize = 32;
+
+/// Number of greedy decode steps to compare after prefill.
+const DECODE_STEPS: usize = 16;
+
+/// Shared prompt prefix — 40 tokens (> one 32-token block) so the prefix spans
+/// two physical blocks and the "stored once / no re-prefill" claim is concrete.
+/// Deterministic plausible ids; no tokenizer needed.
+const PREFIX_TOKENS: &[i32] = &[
+    9707, 11, 358, 1079, 264, 4128, 1614, 13, 5209, 3291, 752, 911, 697, 7990, 13, 358, 2776, 264,
+    10950, 17847, 13, 6771, 594, 1438, 419, 1495, 3019, 553, 3019, 11, 323, 1473, 697, 975, 13,
+    5209, 387, 2797, 624, 14374,
+];
+
+/// B's divergent suffix appended after the shared prefix.
+const SUFFIX_TOKENS: &[i32] = &[14582, 25, 3555, 374, 220, 17, 488, 220, 17, 30];
+
+/// Greedy argmax over the vocab at sequence position `pos` of a
+/// `[batch, seq_len, vocab]` logits tensor, for batch row `row`.
+fn greedy_token(logits: &mlxcel_core::MlxArray, row: i32, pos: i32) -> i32 {
+    let shape = mlxcel_core::array_shape(logits);
+    let vocab = shape[2];
+    let at_pos = mlxcel_core::slice(logits, &[row, pos, 0], &[row + 1, pos + 1, vocab]);
+    let flat = mlxcel_core::reshape(&at_pos, &[vocab]);
+    mlxcel_core::eval(&flat);
+    mlxcel_core::item_i32(&mlxcel_core::argmax_last_axis(&flat))
+}
+
+/// The paged layout the scheduler builds for the default Fp16 KV mode.
+fn scheduler_paged_layout(num_layers: usize) -> SequenceStateLayout {
+    SequenceStateLayout::paged_kv_cache(
+        PagedKvLayout::uniform(num_layers, BLOCK_SIZE, BLOCK_SIZE).expect("valid paged layout"),
+    )
+}
+
+/// Prefill `prefill` (logical positions `[offset, offset + prefill.len())`)
+/// through `caches`, then greedily decode `DECODE_STEPS` tokens. `offset == 0`
+/// is a cold full prefill; `offset > 0` continues after an adopted prefix.
+fn prefill_and_decode(
+    model: &mlxcel::LoadedModel,
+    caches: &mut [mlxcel_core::cache::KVCache],
+    prefill: &[i32],
+    offset: i32,
+) -> Vec<i32> {
+    let len = prefill.len() as i32;
+    let prompt = mlxcel_core::from_slice_i32(prefill, &[1, len]);
+    let mask = mlxcel_core::utils::create_causal_mask(len, offset);
+    let logits = model.forward(&prompt, caches, Some(&mask));
+    mlxcel_core::eval(&logits);
+
+    let mut next = greedy_token(&logits, 0, len - 1);
+    let mut decoded = Vec::with_capacity(DECODE_STEPS);
+    for _ in 0..DECODE_STEPS {
+        decoded.push(next);
+        let step_input = mlxcel_core::from_slice_i32(&[next], &[1, 1]);
+        let logits = model.forward(&step_input, caches, None);
+        mlxcel_core::eval(&logits);
+        next = greedy_token(&logits, 0, 0);
+    }
+    decoded
+}
+
+fn load_or_skip() -> Option<mlxcel::LoadedModel> {
+    let model_dir = repo_model_dir(MODEL_DIR_NAME);
+    if !model_dir.exists() {
+        eprintln!(
+            "Skipping {MODEL_DIR_NAME}: model directory not found at {}.\n\
+             Fetch with: ./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit",
+            model_dir.display()
+        );
+        return None;
+    }
+    let (model, _tokenizer) = load_model(&model_dir).expect("load qwen3-0.6b-4bit");
+    Some(model)
+}
+
+/// Sequence A stores its prefix in the radix store; sequence B adopts it via the
+/// paged pool, shares A's prefix blocks (no re-prefill), and decodes identically
+/// to a cold no-cache run of the same `prefix + suffix` prompt.
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit and runs real GPU forwards; run with --ignored"]
+fn paged_prefix_share_matches_cold_run() {
+    let _runtime = initialize_runtime();
+    let Some(model) = load_or_skip() else {
+        return;
+    };
+    let num_layers = model.num_layers();
+    let prefix_len = PREFIX_TOKENS.len() as i32;
+
+    let mut full_prompt = PREFIX_TOKENS.to_vec();
+    full_prompt.extend_from_slice(SUFFIX_TOKENS);
+
+    eprintln!(
+        "\n=== paged prefix-share parity: {MODEL_DIR_NAME} ({num_layers} layers, \
+         prefix={prefix_len}, suffix={}) ===",
+        SUFFIX_TOKENS.len()
+    );
+
+    // ---- COLD reference: full cold prefill (no cache) + decode. ----
+    let cold_tokens = {
+        let mut pool = CachePool::new(2);
+        let id = pool
+            .allocate_with_layout(&model, Some(scheduler_paged_layout(num_layers)))
+            .expect("cold paged allocate");
+        let caches = pool.get_caches_mut(id).unwrap();
+        prefill_and_decode(&model, caches, &full_prompt, 0)
+    };
+    eprintln!("cold   decoded: {cold_tokens:?}");
+
+    // ---- CACHED path through the real radix store. ----
+    let store = PromptCacheStore::with_config(PromptCacheConfig::new(
+        true,
+        1 << 30,
+        64,
+        Duration::from_secs(3600),
+        1,
+    ));
+    let mut pool = CachePool::new(4);
+
+    // A prefills ONLY the shared prefix (positions [0, prefix_len)).
+    let seq_a = pool
+        .allocate_with_layout(&model, Some(scheduler_paged_layout(num_layers)))
+        .expect("A paged allocate");
+    {
+        let caches = pool.get_caches_mut(seq_a).unwrap();
+        let prompt = mlxcel_core::from_slice_i32(PREFIX_TOKENS, &[1, prefix_len]);
+        let mask = mlxcel_core::utils::create_causal_mask(prefix_len, 0);
+        let logits = model.forward(&prompt, caches, Some(&mask));
+        mlxcel_core::eval(&logits);
+    }
+    let a_blocks = pool
+        .get_paged_state(seq_a)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids
+        .clone();
+    assert!(
+        a_blocks.len() >= 2,
+        "40-token prefix should span >= 2 blocks (got {})",
+        a_blocks.len()
+    );
+
+    // A finishes → donate: detach_paged → DetachedKvSet::Paged → store.
+    let set_a = pool.detach_paged(seq_a).expect("A detach_paged");
+    // The detached set pins every prefix block (refcount > 1: the set's block
+    // table + the detach refcount bump), so the pool cannot recycle the prefix.
+    assert_eq!(
+        pool.paged_pool_ref().unwrap().refcount(a_blocks[0]),
+        2,
+        "detached prefix block must be pinned (refcount > 1)"
+    );
+    let entry = CacheEntry::new(PREFIX_TOKENS.to_vec(), DetachedKvSet::Paged(set_a));
+    let insert_key = PromptCacheKey::new_full(
+        "qwen3",
+        None,
+        "tpl-v1",
+        Some("sess"),
+        MultimodalDigest::empty(),
+        PREFIX_TOKENS,
+    );
+    store.insert(&insert_key, entry).expect("store insert");
+
+    // B arrives with [prefix + suffix]; the store returns A's prefix entry.
+    let lookup_key = PromptCacheKey::new_full(
+        "qwen3",
+        None,
+        "tpl-v1",
+        Some("sess"),
+        MultimodalDigest::empty(),
+        &full_prompt,
+    );
+    let (hit_entry, matched_len) = store
+        .lookup_longest_prefix(&lookup_key, &full_prompt)
+        .expect("B must hit A's cached prefix");
+    assert_eq!(
+        matched_len,
+        PREFIX_TOKENS.len(),
+        "B must match the full stored prefix"
+    );
+    let detached_b = hit_entry
+        .take_detached()
+        .expect("first take yields the set");
+    let set_b = match detached_b {
+        DetachedKvSet::Paged(p) => p,
+        DetachedKvSet::Dense(_) => panic!("paged backend must store a paged set"),
+    };
+    let seq_b = pool.adopt_paged(&model, set_b).expect("B adopt_paged");
+
+    // B SHARES A's prefix blocks (the prefix is stored once, not re-prefilled).
+    let b_blocks = pool
+        .get_paged_state(seq_b)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids
+        .clone();
+    assert_eq!(
+        b_blocks, a_blocks,
+        "B must reuse A's prefix block ids (no re-prefill / second copy)"
+    );
+    // adopt transferred the pin onto B and released the detach bump → refcount 1.
+    assert_eq!(
+        pool.paged_pool_ref().unwrap().refcount(a_blocks[0]),
+        1,
+        "after adopt the prefix block is solely owned by B"
+    );
+
+    // B prefills ONLY its suffix at offset = prefix_len, then decodes.
+    let cached_tokens = {
+        let caches = pool.get_caches_mut(seq_b).unwrap();
+        assert!(
+            caches.iter().all(|c| c.is_paged_backed()),
+            "adopted B must have pool-backed caches"
+        );
+        prefill_and_decode(&model, caches, SUFFIX_TOKENS, prefix_len)
+    };
+    eprintln!("cached decoded: {cached_tokens:?}");
+
+    assert_eq!(
+        cached_tokens, cold_tokens,
+        "shared-prefix (adopted) decode must equal the cold no-cache run\n\
+         cold:   {cold_tokens:?}\ncached: {cached_tokens:?}"
+    );
+    eprintln!(
+        "OK: B reused A's {}-block prefix and decoded {DECODE_STEPS} tokens identically to cold.",
+        a_blocks.len()
+    );
+}


### PR DESCRIPTION
## Summary

Part of #121 — sub-step (b) of three. Sub-step (a) (pool-backed `KVCache` for paged Fp16 sequences) is already merged.

Unifies the cross-request radix prompt-prefix cache with the paged block pool so two requests sharing a prompt prefix store that prefix's KV **once** in the pool and the second request reuses it via paged adopt/donate instead of re-prefilling. The `try_adopt_cached_prefix` Paged guard is removed.

## Changes

### Store entry union (`src/server/prompt_cache/entry.rs`)
Replaces the dense-only `DetachedHolder` with an enum `DetachedKvSet { Dense(DetachedCacheSet), Paged(DetachedPagedCacheSet) }` plus a `DetachedKvSetHolder` Send/Sync newtype. `CacheEntry::new` / `take_detached` now carry either variant; `size_bytes` snapshots `DetachedKvSet::nbytes()` so byte-budget eviction accounting is backend-agnostic. The variant-aware `DetachedKvSet::is_empty()` gates a paged set on its block table / visible length (its dense per-layer handles are empty by design) rather than on the dense caches. `store.rs`/`lookup.rs` are unchanged (they work off `size_bytes` / `has_detached`). Added `PromptCacheStore::min_prefix_tokens()` for the donate-side screen below.

### Scheduler wiring (`src/server/batch/scheduler.rs`)
- `try_adopt_cached_prefix`: drops the `DecodeStorageBackend::Paged` early return and dispatches adoption on the union — `Dense => cache_pool.adopt`, `Paged => cache_pool.adopt_paged`. Skips (cold prefill) on a backend/variant mismatch, and on any skip path that took paged block pins it releases them via `release_detached_paged` (a paged set dropped on the floor would leak its pins). The empty check is variant-aware.
- `donate_finished_sequence_cache`: drops the dense-only rejection and detaches `Dense => detach`, `Paged => detach_paged`, still skipping `ModelOwned`. Short paged prefixes are length-screened against `min_prefix_tokens()` **before** detaching so the store never takes block pins it would only have to release.

### `adopt_paged` pool-backed reconstruction (`src/lib/mlxcel-core/src/cache/paged_detach.rs`) — key correctness change
`adopt_paged_preserving` previously rebuilt **dense** caches from the detached handles. For a pool-backed sequence those handles are empty (K/V lives in the pool), so the adopted sequence read garbage. It now decides pool-backing with the **same gate** `CachePool::allocate_with_layout` uses (`model.sequence_state_layout().backend == DenseKvCache && paged_layout.cache_mode == Fp16`); when pool-backed it rebuilds the per-layer caches with `KVCache::new_paged` sharing the adopted block-table `state_rc` + the active pool (the block table already points at the pinned, refcounted pool pages, so the prefix is read with no copy), and restores each cache's monotonic `offset` from its detached handle so post-adopt RoPE positions continue from the cached prefix length. Non-`Fp16` / model-owned paged sets keep the dense-from-handles path.

### Copy-on-write
Concurrent prefix-share COW is already provided by the pool (from #118/#120): once an adopted sequence shares blocks (refcount>1), the first write past the shared prefix forks the block. No new COW code — the adopt path just shares the blocks correctly.

## Tests

- `cache::paged_detach::tests::adopt_paged_reconstructs_pool_backed_caches_and_shares_prefix` — detach→park→adopt of a pool-backed sequence: adopted caches are pool-backed, restored offset == prefix length, shared block ids, `live_blocks` not doubled, `gather_visible` equals the original, and a suffix allocates only its own blocks.
- `cache::paged_detach::tests::pool_backed_sharers_cow_keeps_other_prefix_intact` — two live pool-backed sequences sharing a partial-tail prefix; a divergent suffix on one forks the shared tail (COW) while the other's prefix stays bit-identical.
- `server::batch::scheduler_prompt_cache_tests::paged_detached_set_round_trips_through_cache_entry` / `empty_paged_detached_set_reports_empty` — a real `DetachedKvSet::Paged` round-trips through `CacheEntry::new` / `take_detached` (one-shot) and `nbytes()` / `is_empty()` dispatch to the paged arm.
- `tests/paged_prefix_share_parity.rs` (`#[ignore]`, qwen3-0.6b-4bit, soft-skip) — sequence A stores its prefix in a real `PromptCacheStore`; sequence B looks it up, `adopt_paged`s it (reusing A's prefix blocks, refcount asserted across the handoff), prefills only its suffix and decodes **identically** to a cold no-cache run.

## Deferred (not in this sub-step)

- APC block-hash matching for paged entries (the `apc_block_hashes` path stays dense-only) — a later #121 sub-step.
- Releasing store-declined / evicted paged block pins under pool block-budget pressure — tracked by #122. (A paged entry that the store rejects as oversized, or later evicts, currently drops without returning its pool pins; `Drop` warns. The donate-side length pre-screen avoids the common prefix-too-short case.)
- Distributed serde of `DetachedPagedCacheSet` — tracked by #125.

## Validation

- `cargo check` (both crates, `--tests`), cold `cargo clean -p mlxcel-core && cargo clippy -p mlxcel-core --tests --features metal,accelerate -- -D warnings`, and root `cargo clippy --tests --features metal,accelerate -- -D warnings` are clean; `cargo fmt --check` passes.
- The metal-linked test binaries cannot be built in this sandbox (Metal toolchain absent), so the unit tests above and the real-model parity test are intended to be run by the orchestrator:
  - `cargo test --lib -p mlxcel-core --features metal,accelerate cache::paged_detach::tests`
  - `cargo test -p mlxcel --lib --features metal,accelerate server::batch::scheduler_prompt_cache_tests`
  - `cargo test --test paged_prefix_share_parity --release --features metal,accelerate -- --ignored --nocapture`


**Orchestrator verification (all green, M1 Ultra, metal+accelerate):** cold clippy clean (both crates); `cache::paged_detach` 21 passed (incl. `adopt_paged_reconstructs_pool_backed_caches_and_shares_prefix` + COW + offset); `scheduler_prompt_cache` 15 passed; full core regression 834 passed; and the real-model DoD `paged_prefix_share_matches_cold_run` PASSED — sequence B reused sequence A's 2-block prefix from the radix store and decoded 16 tokens identically to a cold no-cache run.
