### PR TITLE
fix: release paged KV block pins on prompt-cache evict/decline

### DIFF
--- a/src/lib/mlxcel-core/src/cache/paged_detach.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach.rs
@@ -743,17 +743,43 @@ impl CachePool {
     /// Release every refcount held by a detached paged set. Call this when the
     /// set is no longer needed and adopt is not going to run.
     ///
+    /// A detached set carries **two** pool references per block: the detach
+    /// pin in `retained_blocks`, and the origin sequence's original allocation,
+    /// which [`detach_paged`](CachePool::detach_paged) left in place when it
+    /// removed the sequence from `active` (the block table moved into the set
+    /// without a `release_sequence`). The adopt path releases the pin and lets
+    /// the new sequence inherit the allocation; this discard path has no
+    /// inheritor, so it must release BOTH — otherwise every block leaks at
+    /// refcount 1 and never returns to the pool's free list. `retained_blocks`
+    /// lists each block once (built 1:1 from the block table), and a set that
+    /// is still parked in the store is the sole owner of its blocks (sharing
+    /// only happens through `adopt_paged`, which consumes the set), so
+    /// releasing the pin once and the allocation once drives an unshared block
+    /// to refcount 0.
+    ///
     /// Safe to call on an already-released set (which carries no retained
-    /// blocks) — the function is idempotent.
+    /// blocks) — the `retained_blocks.take()` guard makes the whole body a
+    /// no-op so neither reference is released twice.
     pub fn release_detached_paged(&mut self, mut detached: DetachedPagedCacheSet) {
         if let Some(blocks) = detached.retained_blocks.take() {
             if let Some(pool) = self.paged_pool.as_ref() {
                 let mut pool = pool.borrow_mut();
-                for block_id in blocks {
-                    if let Err(err) = pool.release_block(block_id) {
+                // Release the detach pins.
+                for block_id in &blocks {
+                    if let Err(err) = pool.release_block(*block_id) {
                         eprintln!(
-                            "[mlxcel::cache::paged_detach] CachePool::release_detached_paged: failed to release block {block_id}: {err}"
+                            "[mlxcel::cache::paged_detach] CachePool::release_detached_paged: failed to release pin for block {block_id}: {err}"
                         );
+                    }
+                }
+                // Release the origin allocation the block table still carries.
+                for layer in &detached.paged_state.layers {
+                    for &block_id in &layer.block_ids {
+                        if let Err(err) = pool.release_block(block_id) {
+                            eprintln!(
+                                "[mlxcel::cache::paged_detach] CachePool::release_detached_paged: failed to release allocation for block {block_id}: {err}"
+                            );
+                        }
                     }
                 }
             }

--- a/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
@@ -25,7 +25,7 @@
 //!    `prefill(N+M)` under paged (dense placeholder equivalence).
 //! 7. INT8 round-trip under paged detach/adopt.
 
-use super::super::paged::{PagedBlockPool, PagedKvLayout, PagedSequenceState};
+use super::super::paged::{PagedBlockId, PagedBlockPool, PagedKvLayout, PagedSequenceState};
 use super::super::{
     CachePool, KVCache, KVCacheMode, SequenceId, SequenceStateBackend, SequenceStateLayout,
 };
@@ -390,6 +390,64 @@ fn detach_paged_prevents_block_recycling_while_pinned() {
 
     // Cleanup — release the pin explicitly.
     pool.release_detached_paged(detached);
+}
+
+#[test]
+fn release_detached_paged_returns_blocks_to_free_list() {
+    // Regression for the discard-path leak: `release_detached_paged` must
+    // release BOTH the detach pin and the origin sequence's allocation so every
+    // block reaches refcount 0 and returns to the free list. Previously only
+    // the pin was released, leaking each block at refcount 1.
+    let layout = default_layout();
+    let model = PagedStubModel::new(layout.clone());
+    let mut pool = CachePool::new(4);
+
+    let seq = pool.allocate(&model).unwrap();
+    pool.append_paged_tokens(seq, 0, 6).unwrap();
+    pool.append_paged_tokens(seq, 1, 8).unwrap();
+    let blocks: Vec<PagedBlockId> = (0..layout.num_layers)
+        .flat_map(|l| {
+            pool.get_paged_state(seq)
+                .unwrap()
+                .layer(l)
+                .unwrap()
+                .block_ids
+                .clone()
+        })
+        .collect();
+    assert!(!blocks.is_empty(), "appended tokens must allocate blocks");
+
+    let detached = pool.detach_paged(seq).unwrap();
+    for b in &blocks {
+        assert_eq!(
+            pool.paged_pool_ref().unwrap().refcount(*b),
+            2,
+            "a parked block holds the origin allocation plus the detach pin"
+        );
+    }
+
+    pool.release_detached_paged(detached);
+    for b in &blocks {
+        assert_eq!(
+            pool.paged_pool_ref().unwrap().refcount(*b),
+            0,
+            "discard must drive every block to refcount 0 (returned to the pool)"
+        );
+    }
+
+    // The reclaimed blocks must be recyclable by a fresh sequence.
+    let seq2 = pool.allocate(&model).unwrap();
+    pool.append_paged_tokens(seq2, 0, 4).unwrap();
+    let reused = pool
+        .get_paged_state(seq2)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids[0];
+    assert!(
+        blocks.contains(&reused),
+        "a freed block must be recycled by the next allocation"
+    );
 }
 
 #[test]

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -742,6 +742,10 @@ impl BatchScheduler {
         if !self.prompt_cache_active() {
             return None;
         }
+        // Return to the pool any paged pins a prior store op queued (an insert
+        // eviction, or a previous lookup's TTL / drained-shell sweep). The
+        // lookup below may sweep more; those drain on the next store touch.
+        self.drain_store_paged_releases();
 
         let store = self.prompt_cache.as_ref()?.clone();
         let key = Self::compose_prompt_cache_key(ctx, tokens);
@@ -864,6 +868,24 @@ impl BatchScheduler {
         }
     }
 
+    /// Return to the pool any paged block pins the prompt-cache store queued
+    /// for release. The store evicts (LRU / TTL) and declines (oversized)
+    /// paged entries but cannot return their pool pins — it holds no
+    /// `CachePool` handle — so it stashes them. The scheduler owns the pool,
+    /// so it drains the queue here and routes each set through
+    /// [`CachePool::release_detached_paged`]. Called from the store-touching
+    /// paths so pins are reclaimed promptly during serving; a cheap no-op when
+    /// the queue is empty (#122 sub-step a).
+    fn drain_store_paged_releases(&mut self) {
+        let store = match self.prompt_cache.as_ref() {
+            Some(s) if s.has_pending_paged_releases() => s.clone(),
+            _ => return,
+        };
+        for paged in store.drain_pending_paged_releases() {
+            self.cache_pool.release_detached_paged(paged);
+        }
+    }
+
     /// Donate a finished sequence's KV cache back to the store so future
     /// requests sharing a prefix can adopt it.
     ///
@@ -973,13 +995,12 @@ impl BatchScheduler {
                     .update_prompt_cache_gauges(store.bytes(), store.len());
             }
             Err(err) => {
-                // Oversized / disabled / prefix-too-short — `insert` drops the
-                // entry. For dense that frees the buffers; for a paged entry the
-                // length pre-screen above already filtered the common
-                // prefix-too-short case, but an oversized paged entry dropped
-                // here still leaks its block pins (its `Drop` warns). Returning
-                // store-declined paged pins to the pool is wired with the pool
-                // block-budget eviction work (#122).
+                // Oversized / disabled / prefix-too-short — `insert` declines
+                // the entry. For dense that frees the buffers; for a paged entry
+                // the store stashes its block pins on its pending-release queue
+                // (it has no `CachePool` handle), which the
+                // `drain_store_paged_releases()` below returns to the pool
+                // (#122 sub-step a).
                 tracing::debug!(
                     seq_id = %seq_id,
                     "prompt-cache donate-back skipped: {err:?}"
@@ -987,6 +1008,10 @@ impl BatchScheduler {
                 self.batch_observability.record_prompt_cache_insert_reject();
             }
         }
+        // Return to the pool any paged pins this insert's eviction / rejection
+        // paths queued: byte/entry-budget `enforce_caps` (LRU), idempotent
+        // replacement removal, or an oversized / disabled decline.
+        self.drain_store_paged_releases();
     }
 
     /// Apply thinking-budget enforcement to a freshly sampled

--- a/src/server/batch/scheduler_prompt_cache_tests.rs
+++ b/src/server/batch/scheduler_prompt_cache_tests.rs
@@ -36,13 +36,16 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use mlxcel_core::cache::{CachePool, KVCache, PagedKvLayout, SequenceId, SequenceStateLayout};
+use mlxcel_core::cache::{
+    CachePool, KVCache, PagedBlockId, PagedKvLayout, SequenceId, SequenceStateLayout,
+};
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::{MlxArray, UniquePtr};
 
 use crate::server::batch::BatchObservability;
 use crate::server::prompt_cache::{
-    ApcConfig, ApcHashAlgo, CacheEntry, DetachedKvSet, PromptCacheConfig, PromptCacheStore,
+    ApcConfig, ApcHashAlgo, CacheEntry, DetachedKvSet, InsertError, PromptCacheConfig,
+    PromptCacheStore,
     key::{MultimodalDigest, PromptCacheKey},
 };
 
@@ -853,4 +856,217 @@ fn empty_paged_detached_set_reports_empty() {
     if let DetachedKvSet::Paged(set) = kv_set {
         pool.release_detached_paged(set);
     }
+}
+
+// ---------------------------------------------------------------------------
+// #122 sub-step (a): paged pin-release plumbing.
+//
+// A paged `DetachedKvSet` pins pool blocks; its `Drop` only warns, so the
+// store's eviction / rejection paths (which have no `CachePool` handle) must
+// hand the set to the scheduler to release. These cover (1) the underlying
+// `release_detached_paged` fix that actually returns blocks to the pool, and
+// (2) the store queueing evicted / declined paged sets for that release.
+// ---------------------------------------------------------------------------
+
+/// Mint a real paged [`DetachedKvSet`] from a fresh sequence with `tokens`
+/// tokens appended to layer 0, returning the set plus that sequence's layer-0
+/// block ids so a test can assert pool refcounts across release. No MLX writes
+/// are needed — `append_paged_tokens` grows the block table directly.
+fn mint_paged_set(
+    pool: &mut CachePool,
+    model: &PagedStub,
+    tokens: usize,
+) -> (DetachedKvSet, Vec<PagedBlockId>) {
+    let seq = pool.allocate(model).unwrap();
+    pool.append_paged_tokens(seq, 0, tokens).unwrap();
+    let blocks = pool
+        .get_paged_state(seq)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids
+        .clone();
+    let paged = pool.detach_paged(seq).expect("detach_paged must succeed");
+    (DetachedKvSet::Paged(paged), blocks)
+}
+
+/// `release_detached_paged` on the discard path (no adopt) must drive every
+/// block to refcount 0 so it returns to the pool's free list. Regression for
+/// the pre-existing leak where only the detach pin was released, leaving the
+/// origin sequence's allocation dangling at refcount 1.
+#[test]
+fn release_detached_paged_reclaims_blocks_to_pool() {
+    let model = PagedStub {
+        layout: PagedKvLayout::uniform(1, 4, 128).unwrap(),
+    };
+    let mut pool = CachePool::new(4);
+    let (set, blocks) = mint_paged_set(&mut pool, &model, 6);
+    assert!(!blocks.is_empty(), "a 6-token prefix spans >= 1 block");
+    // Parked (detached, not adopted) → the set owns alloc + pin == refcount 2.
+    assert_eq!(
+        pool.paged_pool_ref().unwrap().refcount(blocks[0]),
+        2,
+        "a detached, un-adopted block holds alloc + pin"
+    );
+
+    if let DetachedKvSet::Paged(paged) = set {
+        pool.release_detached_paged(paged);
+    }
+    for b in &blocks {
+        assert_eq!(
+            pool.paged_pool_ref().unwrap().refcount(*b),
+            0,
+            "discard must return every block to the pool (refcount 0)"
+        );
+    }
+}
+
+/// An LRU-evicted paged entry must hand its block pins to the release queue
+/// (its `Drop` only warns), and draining + releasing them returns the blocks
+/// to the pool. Before the fix the evicted set dropped and leaked its pins.
+#[test]
+fn evicted_paged_entry_queues_pins_then_pool_reclaims() {
+    // max_entries = 1 so the second insert evicts the first (oldest = A).
+    let store = Arc::new(PromptCacheStore::with_config(PromptCacheConfig::new(
+        true,
+        1 << 30,
+        1,
+        Duration::from_secs(3600),
+        1,
+    )));
+    let model = PagedStub {
+        layout: PagedKvLayout::uniform(1, 4, 128).unwrap(),
+    };
+    let mut pool = CachePool::new(8);
+
+    let (set_a, blocks_a) = mint_paged_set(&mut pool, &model, 6);
+    let tokens_a: Vec<i32> = (0..16).collect();
+    store
+        .insert(
+            &make_key("m", "s", "tpl", &tokens_a),
+            CacheEntry::new(tokens_a.clone(), set_a),
+        )
+        .expect("insert A");
+    assert!(!store.has_pending_paged_releases(), "no eviction yet");
+
+    // Insert B (distinct digest) → A is evicted under max_entries = 1.
+    let (set_b, _blocks_b) = mint_paged_set(&mut pool, &model, 6);
+    let tokens_b: Vec<i32> = (100..120).collect();
+    store
+        .insert(
+            &make_key("m", "s", "tpl", &tokens_b),
+            CacheEntry::new(tokens_b.clone(), set_b),
+        )
+        .expect("insert B");
+
+    // A's pins are queued (not dropped + leaked).
+    assert!(
+        store.has_pending_paged_releases(),
+        "eviction queued A's pins"
+    );
+    let drained = store.drain_pending_paged_releases();
+    assert_eq!(drained.len(), 1, "exactly A's paged set is queued");
+    assert!(
+        !store.has_pending_paged_releases(),
+        "drain empties the queue"
+    );
+
+    for paged in drained {
+        pool.release_detached_paged(paged);
+    }
+    for b in &blocks_a {
+        assert_eq!(
+            pool.paged_pool_ref().unwrap().refcount(*b),
+            0,
+            "evicted A's blocks are reclaimed by the pool"
+        );
+    }
+
+    // Clean up B (still parked in the store) so its set does not warn on drop.
+    let (b_entry, _) = store
+        .lookup_longest_prefix(&make_key("m", "s", "tpl", &tokens_b), &tokens_b)
+        .expect("B still cached");
+    if let Some(DetachedKvSet::Paged(p)) = b_entry.take_detached() {
+        pool.release_detached_paged(p);
+    }
+}
+
+/// An oversized paged entry the store declines on insert must likewise queue
+/// its pins for release rather than dropping (and leaking) them.
+#[test]
+fn oversized_paged_entry_decline_queues_pins_then_pool_reclaims() {
+    // capacity_bytes = 1 so any populated paged set is oversized.
+    let store = Arc::new(PromptCacheStore::with_config(PromptCacheConfig::new(
+        true,
+        1,
+        32,
+        Duration::from_secs(3600),
+        1,
+    )));
+    let model = PagedStub {
+        layout: PagedKvLayout::uniform(1, 4, 128).unwrap(),
+    };
+    let mut pool = CachePool::new(4);
+    let (set, blocks) = mint_paged_set(&mut pool, &model, 6);
+    let tokens: Vec<i32> = (0..16).collect();
+    let err = store
+        .insert(
+            &make_key("m", "s", "tpl", &tokens),
+            CacheEntry::new(tokens.clone(), set),
+        )
+        .expect_err("tiny capacity must reject the entry");
+    assert!(
+        matches!(err, InsertError::OversizedEntry { .. }),
+        "expected an oversized rejection, got {err:?}"
+    );
+
+    assert!(
+        store.has_pending_paged_releases(),
+        "the decline queued the pins"
+    );
+    let drained = store.drain_pending_paged_releases();
+    assert_eq!(drained.len(), 1);
+    for paged in drained {
+        pool.release_detached_paged(paged);
+    }
+    for b in &blocks {
+        assert_eq!(
+            pool.paged_pool_ref().unwrap().refcount(*b),
+            0,
+            "the declined entry's blocks are reclaimed"
+        );
+    }
+}
+
+/// A dense eviction frees its buffers on drop and owns no pool pins, so it must
+/// never land in the paged release queue.
+#[test]
+fn dense_eviction_does_not_queue_paged_releases() {
+    let store = Arc::new(PromptCacheStore::with_config(PromptCacheConfig::new(
+        true,
+        1 << 30,
+        1,
+        Duration::from_secs(3600),
+        1,
+    )));
+    let tokens_a: Vec<i32> = (0..16).collect();
+    store
+        .insert(
+            &make_key("m", "s", "tpl", &tokens_a),
+            fake_entry(tokens_a.clone(), 4096),
+        )
+        .expect("insert dense A");
+    let tokens_b: Vec<i32> = (100..120).collect();
+    store
+        .insert(
+            &make_key("m", "s", "tpl", &tokens_b),
+            fake_entry(tokens_b.clone(), 4096),
+        )
+        .expect("insert dense B");
+
+    assert!(
+        !store.has_pending_paged_releases(),
+        "dense eviction queues no paged pins"
+    );
+    assert!(store.drain_pending_paged_releases().is_empty());
 }

--- a/src/server/prompt_cache/store.rs
+++ b/src/server/prompt_cache/store.rs
@@ -28,9 +28,11 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
+use mlxcel_core::cache::DetachedPagedCacheSet;
+
 use super::apc_lookup::{ApcStoreStats, apc_consistent_prefix_len};
 use super::block_hash::{ApcBlockHash, BlockHashChain};
-use super::entry::CacheEntry;
+use super::entry::{CacheEntry, DetachedKvSet, DetachedKvSetHolder};
 use super::key::{PromptCacheKey, PromptCacheKeyDigest};
 use super::metrics::{NoopPromptCacheMetrics, PromptCacheMetrics};
 use super::policy::{PromptCacheConfig, PromptCacheStats};
@@ -66,6 +68,13 @@ struct Inner {
     hits: u64,
     evictions_lru: u64,
     evictions_ttl: u64,
+    /// Paged detached sets that an eviction or rejection path removed from
+    /// the store but could not release: returning a paged set's pool block
+    /// pins requires a `CachePool` handle, which the store does not hold.
+    /// The scheduler drains this (`drain_pending_paged_releases`) and routes
+    /// each set through `CachePool::release_detached_paged`. Held as the
+    /// Send/Sync [`DetachedKvSetHolder`] so `Inner` stays `Send + Sync`.
+    pending_paged_releases: Vec<DetachedKvSetHolder>,
 }
 
 impl Inner {
@@ -81,6 +90,23 @@ impl Inner {
             hits: 0,
             evictions_lru: 0,
             evictions_ttl: 0,
+            pending_paged_releases: Vec::new(),
+        }
+    }
+
+    /// Extract `entry`'s detached set and, when it is a **paged** set holding
+    /// pool block pins, stash it on [`Inner::pending_paged_releases`] for the
+    /// scheduler to return to the pool. The store cannot release pins itself
+    /// (no `CachePool` handle), and a paged set's `Drop` only warns. A dense
+    /// set frees its MLX buffers when it drops here, so it is not queued.
+    /// Idempotent for already-drained (adopted) shells — `take_detached`
+    /// yields `None` and nothing is queued.
+    fn stash_paged_pins_for_release(&mut self, entry: &CacheEntry) {
+        if let Some(set) = entry.take_detached()
+            && matches!(set, DetachedKvSet::Paged(_))
+        {
+            self.pending_paged_releases
+                .push(DetachedKvSetHolder::new(set));
         }
     }
 
@@ -103,6 +129,12 @@ impl Inner {
     ) -> Option<(BucketKey, Arc<CacheEntry>)> {
         let slot = self.entries.remove(digest)?;
         self.total_bytes = self.total_bytes.saturating_sub(slot.entry.size_bytes);
+
+        // Return any un-adopted paged block pins this entry holds to the
+        // release queue before it drops (its `Drop` only warns). Covers every
+        // eviction path that funnels through here: LRU, TTL, drained-shell
+        // sweep, and idempotent-replacement removal.
+        self.stash_paged_pins_for_release(&slot.entry);
 
         let trie_empty = if let Some(trie) = self.tries.get_mut(&slot.sessionless) {
             trie.remove(&slot.entry.tokens, *digest);
@@ -302,6 +334,39 @@ impl PromptCacheStore {
             .unwrap_or(0)
     }
 
+    /// Whether any paged detached sets are waiting to have their pool block
+    /// pins released. Cheap read-lock check the scheduler uses to skip the
+    /// write-locked drain on the common (empty) path.
+    pub fn has_pending_paged_releases(&self) -> bool {
+        self.inner
+            .read()
+            .map(|g| !g.pending_paged_releases.is_empty())
+            .unwrap_or(false)
+    }
+
+    /// Drain the paged detached sets that eviction / rejection paths removed
+    /// from the store but could not release (the store holds no `CachePool`
+    /// handle). The caller — the scheduler, which owns the pool — must return
+    /// each set's pins via `CachePool::release_detached_paged`. Dense sets are
+    /// freed on drop and never queued, so every element is a paged set.
+    ///
+    /// The returned `DetachedPagedCacheSet` is not `Send`; call this on the
+    /// thread that owns the `CachePool` (the model worker) and release the
+    /// pins before yielding it.
+    pub fn drain_pending_paged_releases(&self) -> Vec<DetachedPagedCacheSet> {
+        let mut guard = match self.inner.write() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let mut out = Vec::with_capacity(guard.pending_paged_releases.len());
+        for mut holder in guard.pending_paged_releases.drain(..) {
+            if let Some(DetachedKvSet::Paged(paged)) = holder.take() {
+                out.push(paged);
+            }
+        }
+        out
+    }
+
     /// Snapshot of the store's internal counters. Safe to call concurrently
     /// with inserts/lookups; values are captured under the read lock.
     pub fn stats(&self) -> PromptCacheStats {
@@ -371,10 +436,15 @@ impl PromptCacheStore {
 
         let mut guard = self.inner.write().expect("prompt cache inner lock");
 
+        // Every decline path drops the by-value `entry`. For a paged entry that
+        // would leak its pool block pins (its `Drop` only warns), so stash them
+        // for the scheduler to release before returning the error.
         if !guard.config.is_enabled() {
+            guard.stash_paged_pins_for_release(&entry);
             return Err(InsertError::Disabled);
         }
         if key.effective_prefix_len() < guard.config.min_prefix_tokens {
+            guard.stash_paged_pins_for_release(&entry);
             return Err(InsertError::PrefixTooShort {
                 got: key.effective_prefix_len(),
                 min_required: guard.config.min_prefix_tokens,
@@ -382,6 +452,7 @@ impl PromptCacheStore {
         }
         if entry_bytes > guard.config.capacity_bytes {
             guard.rejections_oversized = guard.rejections_oversized.saturating_add(1);
+            guard.stash_paged_pins_for_release(&entry);
             let metrics = Arc::clone(&self.metrics);
             drop(guard);
             metrics.record_reject_oversized(entry_bytes);


### PR DESCRIPTION
## Summary

Sub-step (a) of #122 (block-budget admission, eviction, preemption). **Part of #122** — the budget/admission/eviction headline is sub-step (b); the `GET /v1/cache/stats` block fields are sub-step (c).

Fixes the deferred pin-release leak from #121 sub-step b: paged prompt-cache entries the store **evicts** (LRU / TTL / drained-shell / idempotent replacement) or **declines** (oversized / disabled / prefix-too-short) dropped their pool block pins instead of returning them. A `DetachedPagedCacheSet`'s `Drop` only warns — releasing its pins needs a `CachePool` handle, which the store does not hold — so those blocks leaked and never returned to the pool's free list.

While wiring this I found and fixed a **pre-existing leak in `CachePool::release_detached_paged` itself** (the function the existing adopt-skip path already used): it released only the detach pin, leaving the origin sequence's allocation dangling at refcount 1. The adopt path is fine (it transfers the allocation to the new sequence); only the discard path leaked.

## Changes

### `cache/paged_detach.rs` — `release_detached_paged` (core fix)
A detached set owns **two** pool refs per block: the detach pin (`retained_blocks`) and the origin allocation that `detach_paged` left in place when it removed the sequence from `active` without a `release_sequence`. The discard path now releases **both**, driving an unshared block to refcount 0 so it returns to the free list (verified `live=1, detached=2, released → 0`). A set parked in the store is the sole owner of its blocks — sharing only happens through `adopt_paged`, which consumes the set — so the double release is safe; the `retained_blocks.take()` guard keeps it idempotent.

### `prompt_cache/store.rs` — queue declined/evicted paged pins
The store can't release pool pins (no `CachePool` handle), so it stashes evicted/declined **paged** sets on a `pending_paged_releases` queue (held as the Send/Sync `DetachedKvSetHolder` so `Inner` stays `Send + Sync`). `remove_entry` (the chokepoint for LRU/TTL/drained/replacement) and the three `insert` decline paths stash the set via `take_detached`. New public `drain_pending_paged_releases()` / `has_pending_paged_releases()`. Dense sets free on drop and are never queued.

### `batch/scheduler.rs` — drain + release
New `drain_store_paged_releases()` drains the store's queue and returns each set's pins via `CachePool::release_detached_paged`. Called at the start of `try_adopt_cached_prefix` (covers prior lookups' TTL/drained sweeps) and the end of `donate_finished_sequence_cache` (covers this insert's eviction/decline), so during serving pins are reclaimed within one store op.

## Tests

- `cache::paged_detach::release_detached_paged_returns_blocks_to_free_list` (core) — detach → refcount 2 → release → refcount 0, and the freed block is recycled by the next allocation.
- `scheduler_prompt_cache_tests::release_detached_paged_reclaims_blocks_to_pool` — the discard refcount-0 invariant via `CachePool`.
- `…::evicted_paged_entry_queues_pins_then_pool_reclaims` — LRU eviction queues the set; drain + release reclaims its blocks.
- `…::oversized_paged_entry_decline_queues_pins_then_pool_reclaims` — oversized decline queues + reclaims.
- `…::dense_eviction_does_not_queue_paged_releases` — dense evictions queue nothing.

## Validation (orchestrator-run, M1 Ultra, metal+accelerate)

Cold `cargo clippy --tests` (both crates) clean; `cargo fmt --check` clean; core `cache::paged_detach` (22) + full core regression + `server::batch` (179) + `server::prompt_cache` (134) green.