### PR TITLE
feat: opt-in block budget for the paged KV pool

### DIFF
--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -5798,6 +5798,35 @@ impl CachePool {
             .map(|pool| pool.borrow().layout().block_size)
     }
 
+    /// Set (or clear, with `None`) the paged pool's global block budget — the
+    /// cap on distinct physical blocks the pool may allocate. Opt-in; `None`
+    /// (the default) leaves the pool unbounded. No-op when there is no paged
+    /// pool (dense-only configuration). The scheduler derives the value from
+    /// the configured / estimated KV byte budget (#122).
+    pub fn set_paged_block_budget(&self, max_blocks: Option<usize>) {
+        if let Some(pool) = self.paged_pool.as_ref() {
+            pool.borrow_mut().set_block_budget(max_blocks);
+        }
+    }
+
+    /// The paged pool's current block budget, or `None` when unbounded / no
+    /// paged pool.
+    pub fn paged_block_budget(&self) -> Option<usize> {
+        self.paged_pool
+            .as_ref()
+            .and_then(|pool| pool.borrow().block_budget())
+    }
+
+    /// Blocks still mintable before the paged budget is hit, or `None` when
+    /// unbounded / no paged pool. `Some(0)` means only freed-block reuse
+    /// remains — the admission gate should evict or queue before growing a
+    /// sequence.
+    pub fn free_paged_block_budget(&self) -> Option<usize> {
+        self.paged_pool
+            .as_ref()
+            .and_then(|pool| pool.borrow().free_block_budget())
+    }
+
     /// Read-only access to the underlying [`PagedBlockPool`].
     ///
     /// Returns a [`Ref`] guard; release it before any path that mutates the

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -452,6 +452,15 @@ pub struct PagedBlockPool {
     free_rows: Vec<Vec<usize>>,
     /// Per-layer monotonic next-row cursor for rows never yet handed out.
     next_row: Vec<usize>,
+    /// Optional cap on the total number of distinct physical blocks the pool
+    /// may allocate (summed across all layers). `None` = unbounded (the pool
+    /// lazily grows on demand, the historical behaviour). When `Some(max)`,
+    /// [`PagedBlockPool::acquire_block`] refuses to mint a NEW block once
+    /// `blocks.len() >= max` (reusing a freed block is always allowed, since it
+    /// adds no memory). This is the global KV block budget #122 admits and
+    /// evicts against; the scheduler sets it from the configured / estimated KV
+    /// byte budget divided by the per-block byte size.
+    block_budget: Option<usize>,
 }
 
 /// Number of physical block rows the pool tensor grows by when a freshly
@@ -484,11 +493,53 @@ impl PagedBlockPool {
             block_rows: vec![HashMap::new(); num_layers],
             free_rows: vec![Vec::new(); num_layers],
             next_row: vec![0; num_layers],
+            block_budget: None,
         }
     }
 
     pub fn layout(&self) -> &PagedKvLayout {
         &self.layout
+    }
+
+    /// Total distinct physical blocks the pool has ever allocated (live +
+    /// freed-but-retained rows). This is the figure the [`block_budget`] caps
+    /// and the proxy for the pool tensors' peak row count.
+    ///
+    /// [`block_budget`]: PagedBlockPool::block_budget
+    pub fn allocated_block_count(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Number of blocks currently held by at least one sequence / detached set
+    /// (refcount > 0).
+    pub fn live_block_count(&self) -> usize {
+        self.blocks.values().filter(|r| r.is_in_use()).count()
+    }
+
+    /// The current global block budget, or `None` when unbounded.
+    pub fn block_budget(&self) -> Option<usize> {
+        self.block_budget
+    }
+
+    /// Set (or clear, with `None`) the global cap on distinct physical blocks.
+    ///
+    /// Opt-in: the default is `None` (unbounded, the historical lazy-grow
+    /// behaviour). When set below the number already allocated the pool does not
+    /// shrink — it simply refuses to mint further new blocks until eviction
+    /// brings `allocated_block_count` back under the cap (freed rows are reused
+    /// without minting). The scheduler owns deriving the value from the KV byte
+    /// budget and reacting to the resulting allocation failures.
+    pub fn set_block_budget(&mut self, max_blocks: Option<usize>) {
+        self.block_budget = max_blocks;
+    }
+
+    /// Free physical blocks still mintable before the budget is hit, or `None`
+    /// when unbounded. `Some(0)` means a new block would be refused (only freed
+    /// blocks can be reused). Lets the scheduler gate admission before it tries
+    /// to grow a sequence.
+    pub fn free_block_budget(&self) -> Option<usize> {
+        self.block_budget
+            .map(|max| max.saturating_sub(self.blocks.len()))
     }
 
     /// Whether the pool's cache mode requires Turbo4 sidecar storage.
@@ -1394,6 +1445,17 @@ impl PagedBlockPool {
             );
             record.refcount = 1;
             return Ok(block_id);
+        }
+
+        // No freed block to reuse — minting a new one grows the pool, so it is
+        // subject to the global block budget (opt-in; `None` = unbounded).
+        if let Some(max) = self.block_budget {
+            if self.blocks.len() >= max {
+                return Err(format!(
+                    "PagedBlockPool: block budget exhausted ({} of {max} blocks allocated)",
+                    self.blocks.len()
+                ));
+            }
         }
 
         let block_id = PagedBlockId(self.next_block_id);

--- a/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
@@ -257,6 +257,73 @@ fn block_pool_double_release_errors_cleanly() {
 }
 
 // ---------------------------------------------------------------------------
+// 1b. Global block budget (#122 sub-step b1)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn block_budget_refuses_new_blocks_beyond_cap() {
+    let layout = PagedKvLayout::uniform(1, 4, 128).unwrap();
+    let mut pool = PagedBlockPool::new(layout.clone());
+    pool.set_block_budget(Some(3));
+    assert_eq!(pool.block_budget(), Some(3));
+
+    let mut state = PagedSequenceState::new(&layout);
+    // block_size 4 → 12 tokens = exactly 3 blocks, filling the budget.
+    pool.append_tokens(&mut state, 0, 12).unwrap();
+    assert_eq!(pool.allocated_block_count(), 3);
+    assert_eq!(pool.free_block_budget(), Some(0));
+
+    // A 4th block cannot be minted while at the cap.
+    let err = pool.append_tokens(&mut state, 0, 4).unwrap_err();
+    assert!(err.contains("budget exhausted"), "got: {err}");
+}
+
+#[test]
+fn block_budget_allows_reuse_of_freed_blocks_at_cap() {
+    let layout = PagedKvLayout::uniform(1, 4, 128).unwrap();
+    let mut pool = PagedBlockPool::new(layout.clone());
+    pool.set_block_budget(Some(2));
+
+    let mut a = PagedSequenceState::new(&layout);
+    pool.append_tokens(&mut a, 0, 8).unwrap(); // 2 blocks → at the cap
+    assert_eq!(pool.free_block_budget(), Some(0));
+    pool.release_sequence(&mut a).unwrap(); // both freed (refcount 0), rows retained
+
+    // A fresh sequence reuses the freed blocks without minting — allowed at cap.
+    let mut b = PagedSequenceState::new(&layout);
+    pool.append_tokens(&mut b, 0, 8).unwrap();
+    assert_eq!(
+        pool.allocated_block_count(),
+        2,
+        "freed blocks must be reused, not re-minted, when at the budget"
+    );
+}
+
+#[test]
+fn block_budget_none_is_unbounded() {
+    let layout = PagedKvLayout::uniform(1, 4, 128).unwrap();
+    let mut pool = PagedBlockPool::new(layout.clone());
+    assert_eq!(pool.block_budget(), None);
+    assert_eq!(pool.free_block_budget(), None);
+
+    let mut state = PagedSequenceState::new(&layout);
+    pool.append_tokens(&mut state, 0, 400).unwrap(); // 100 blocks, no cap
+    assert_eq!(pool.allocated_block_count(), 100);
+}
+
+#[test]
+fn free_block_budget_tracks_allocation() {
+    let layout = PagedKvLayout::uniform(1, 4, 128).unwrap();
+    let mut pool = PagedBlockPool::new(layout.clone());
+    pool.set_block_budget(Some(5));
+    let mut state = PagedSequenceState::new(&layout);
+    pool.append_tokens(&mut state, 0, 8).unwrap(); // 2 blocks
+    assert_eq!(pool.allocated_block_count(), 2);
+    assert_eq!(pool.live_block_count(), 2);
+    assert_eq!(pool.free_block_budget(), Some(3));
+}
+
+// ---------------------------------------------------------------------------
 // 2. CachePool detach / adopt happy path + edge cases
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Sub-step **b1** of #122 (block-budget admission, eviction, preemption). **Part of #122.** The paged pool previously grew without bound (`acquire_block` lazily minted rows on demand). This adds the budget *primitive* — opt-in, so default behaviour is unchanged — that the admission/eviction logic in b2 will enforce against.

## Changes

- **`PagedBlockPool`** gains `block_budget: Option<usize>` (default `None` = unbounded). `acquire_block` refuses to mint a **new** block once `allocated_block_count >= budget`; **reusing a freed block is always allowed** (it adds no memory), so the budget caps the pool tensors' peak row count without blocking recycling. New accessors: `allocated_block_count`, `live_block_count`, `block_budget`, `set_block_budget`, `free_block_budget` (mintable headroom; `Some(0)` = only reuse remains).
- **`CachePool`** pass-throughs: `set_paged_block_budget`, `paged_block_budget`, `free_paged_block_budget` (no-op without a paged pool) so the scheduler can set the budget and gate admission on the headroom.

## Scope

This is the budget mechanism only. **b2** derives the value from the configured / estimated KV byte budget (now accurate after #52 TIER 1/2: `available − weights − activation`), gates prefill admission on `free_paged_block_budget`, and on pressure evicts cold radix prefixes (pins release cleanly via #170) then falls back to the existing preemption. **b1 changes no default behaviour** — with `block_budget = None` the pool is byte-identical to before.

## Tests

4 new `PagedBlockPool` tests: the cap refuses new mints (`budget exhausted`), freed-block reuse is allowed at the cap (no re-mint), `None` is unbounded (100 blocks), and `free_block_budget` tracks allocation. 26 `paged_detach` tests pass.

## Validation

Cold `cargo clippy --tests` (both crates) clean; `cargo fmt --check` clean; full core regression green.