### PR TITLE
feat: paged KV block-budget admission gate and eviction

### DIFF
--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -5498,6 +5498,13 @@ pub struct CachePool {
     /// Detached cache sets parked inside the pool during cross-request
     /// handoffs. See [`detach`] for the full design.
     detached: detach::DetachedMap,
+    /// Paged block budget remembered across lazy pool creation. The pool is
+    /// built on the first paged allocation, which may happen after the
+    /// scheduler sets the budget, so the value is stored here and applied in
+    /// [`CachePool::ensure_paged_pool`] when the pool is born (and immediately
+    /// to a live pool in [`CachePool::set_paged_block_budget`]). `None` =
+    /// unbounded (the default).
+    paged_block_budget: Option<usize>,
 }
 
 impl CachePool {
@@ -5509,6 +5516,7 @@ impl CachePool {
             max_sequences,
             paged_pool: None,
             detached: HashMap::new(),
+            paged_block_budget: None,
         }
     }
 
@@ -5803,24 +5811,25 @@ impl CachePool {
     /// (the default) leaves the pool unbounded. No-op when there is no paged
     /// pool (dense-only configuration). The scheduler derives the value from
     /// the configured / estimated KV byte budget (#122).
-    pub fn set_paged_block_budget(&self, max_blocks: Option<usize>) {
+    pub fn set_paged_block_budget(&mut self, max_blocks: Option<usize>) {
+        self.paged_block_budget = max_blocks;
         if let Some(pool) = self.paged_pool.as_ref() {
             pool.borrow_mut().set_block_budget(max_blocks);
         }
     }
 
-    /// The paged pool's current block budget, or `None` when unbounded / no
-    /// paged pool.
+    /// The configured paged block budget, or `None` when unbounded. This is the
+    /// stored intent, so it is correct even before the pool is lazily created
+    /// (the value is applied to the pool on creation).
     pub fn paged_block_budget(&self) -> Option<usize> {
-        self.paged_pool
-            .as_ref()
-            .and_then(|pool| pool.borrow().block_budget())
+        self.paged_block_budget
     }
 
-    /// Blocks still mintable before the paged budget is hit, or `None` when
-    /// unbounded / no paged pool. `Some(0)` means only freed-block reuse
-    /// remains — the admission gate should evict or queue before growing a
-    /// sequence.
+    /// Blocks still **acquirable** before the paged budget is hit
+    /// (`budget − live`), or `None` when unbounded / no paged pool. `Some(0)`
+    /// means every budgeted block is in use; the admission gate must reclaim
+    /// (evict cold prefixes, then preempt) or defer. Eviction raises this even
+    /// though allocated rows are retained, because freed blocks are reusable.
     pub fn free_paged_block_budget(&self) -> Option<usize> {
         self.paged_pool
             .as_ref()
@@ -6001,7 +6010,11 @@ impl CachePool {
             }
             return Ok(());
         }
-        self.paged_pool = Some(Rc::new(RefCell::new(PagedBlockPool::new(layout.clone()))));
+        let mut pool = PagedBlockPool::new(layout.clone());
+        // Apply the budget remembered before the pool existed (set via
+        // `set_paged_block_budget` before the first paged allocation).
+        pool.set_block_budget(self.paged_block_budget);
+        self.paged_pool = Some(Rc::new(RefCell::new(pool)));
         Ok(())
     }
 }

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -533,13 +533,20 @@ impl PagedBlockPool {
         self.block_budget = max_blocks;
     }
 
-    /// Free physical blocks still mintable before the budget is hit, or `None`
-    /// when unbounded. `Some(0)` means a new block would be refused (only freed
-    /// blocks can be reused). Lets the scheduler gate admission before it tries
-    /// to grow a sequence.
+    /// Physical blocks still **acquirable** before the budget is hit, or `None`
+    /// when unbounded. This is `budget − live_block_count`: a fresh
+    /// `acquire_block` succeeds whenever fewer than `budget` blocks are live,
+    /// because it can either reuse a freed (allocated-but-not-live) block or
+    /// mint a new one while `allocated < budget`. Eviction / preemption that
+    /// drops a block's refcount to 0 therefore *raises* this figure even though
+    /// `allocated_block_count` is unchanged (the freed row is retained for
+    /// reuse). The scheduler gates prefill admission on this value and reclaims
+    /// (evict cold prefixes, then preempt) until it covers the sequence's need.
+    /// `Some(0)` means every budgeted block is in use — admission must reclaim
+    /// or defer.
     pub fn free_block_budget(&self) -> Option<usize> {
         self.block_budget
-            .map(|max| max.saturating_sub(self.blocks.len()))
+            .map(|max| max.saturating_sub(self.live_block_count()))
     }
 
     /// Whether the pool's cache mode requires Turbo4 sidecar storage.

--- a/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
@@ -323,6 +323,49 @@ fn free_block_budget_tracks_allocation() {
     assert_eq!(pool.free_block_budget(), Some(3));
 }
 
+#[test]
+fn free_block_budget_rises_when_blocks_are_freed() {
+    // free_block_budget is budget − LIVE, not budget − allocated: freeing a
+    // block restores acquirable headroom even though the row is retained for
+    // reuse. This is what lets eviction/preemption reclaim budget for admission.
+    let layout = PagedKvLayout::uniform(1, 4, 128).unwrap();
+    let mut pool = PagedBlockPool::new(layout.clone());
+    pool.set_block_budget(Some(4));
+    let mut state = PagedSequenceState::new(&layout);
+    pool.append_tokens(&mut state, 0, 16).unwrap(); // 4 blocks, all live
+    assert_eq!(pool.free_block_budget(), Some(0));
+
+    pool.release_sequence(&mut state).unwrap();
+    assert_eq!(pool.live_block_count(), 0);
+    assert_eq!(pool.allocated_block_count(), 4, "rows retained for reuse");
+    assert_eq!(
+        pool.free_block_budget(),
+        Some(4),
+        "freeing live blocks restores the full acquirable budget"
+    );
+}
+
+#[test]
+fn cache_pool_budget_set_before_pool_creation_applies_on_creation() {
+    // The scheduler may set the budget before the first paged allocation lazily
+    // creates the pool; CachePool stores the intent and applies it on creation.
+    let model = PagedStubModel::new(default_layout());
+    let mut pool = CachePool::new(4);
+    assert!(
+        pool.paged_pool_ref().is_none(),
+        "no pool before first allocate"
+    );
+    pool.set_paged_block_budget(Some(7));
+    assert_eq!(pool.paged_block_budget(), Some(7), "stored intent survives");
+
+    let _seq = pool.allocate(&model).unwrap(); // creates the paged pool
+    assert_eq!(
+        pool.paged_pool_ref().unwrap().block_budget(),
+        Some(7),
+        "the pre-set budget must apply when the pool is born"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 2. CachePool detach / adopt happy path + edge cases
 // ---------------------------------------------------------------------------

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1805,6 +1805,96 @@ impl BatchScheduler {
     }
 
     // ------------------------------------------------------------------
+    // Paged KV block-budget admission (#122 b2)
+    // ------------------------------------------------------------------
+
+    /// Estimate the pool blocks a sequence's prefill will pin: one block per
+    /// `block_size` prompt tokens, per layer. Returns 0 when there is no paged
+    /// pool (the budget gate is then a no-op for this model).
+    fn estimate_prefill_blocks(&self, prompt_len: usize) -> usize {
+        match self.cache_pool.paged_block_size() {
+            Some(block_size) if block_size > 0 => prompt_len
+                .div_ceil(block_size)
+                .saturating_mul(self.model.num_layers()),
+            _ => 0,
+        }
+    }
+
+    /// Reclaim paged pool blocks until at least `need` are acquirable, or no
+    /// further reclamation is possible. First evicts cold prompt-cache prefixes
+    /// (LRU; releasing their pins frees real blocks), then preempts running
+    /// sequences (which re-prefill on resume). Returns whether `need` blocks are
+    /// now acquirable.
+    fn reclaim_paged_blocks(&mut self, need: usize) -> bool {
+        let room = |pool: &CachePool| pool.free_paged_block_budget().is_none_or(|f| f >= need);
+        // 1. Evict cold cross-request prefixes; releasing their pins frees blocks.
+        if let Some(store) = self.prompt_cache.clone() {
+            while !room(&self.cache_pool) {
+                if store.evict_one_lru() == 0 {
+                    break; // nothing left to evict
+                }
+                self.drain_store_paged_releases();
+            }
+        }
+        if room(&self.cache_pool) {
+            return true;
+        }
+        // 2. Preempt running sequences (drop their KV; they re-prefill on resume).
+        while !room(&self.cache_pool) {
+            if !self.try_evict_for_preemption() {
+                break; // no preemptible victim left
+            }
+        }
+        room(&self.cache_pool)
+    }
+
+    /// Paged block-budget admission gate. Returns `Some(seq)` to proceed with
+    /// the prefill, or `None` when the sequence was deferred (re-queued for a
+    /// later tick once decodes free blocks) or rejected (it cannot fit the whole
+    /// budget). A no-op (`Some(seq)`) when no budget is configured.
+    fn admit_paged_prefill(&mut self, seq: SequenceInfo) -> Option<SequenceInfo> {
+        // Opt-in: no budget configured ⇒ admit (default unbounded behaviour).
+        let total = match self.cache_pool.paged_block_budget() {
+            Some(t) => t,
+            None => return Some(seq),
+        };
+        let need = self.estimate_prefill_blocks(seq.prompt_tokens.len());
+        if need == 0 {
+            return Some(seq); // model does not use the paged pool
+        }
+        // If it cannot fit the entire budget, reject — deferring forever would
+        // wedge the queue behind a request that can never run.
+        if need > total {
+            self.abort_sequence(
+                seq,
+                &format!(
+                    "prompt needs {need} KV blocks, exceeding the {total}-block KV cache budget"
+                ),
+            );
+            return None;
+        }
+        // Acquirable blocks (budget − live). `None` means the pool is not yet
+        // created (nothing allocated ⇒ the whole budget is free).
+        let free = self.cache_pool.free_paged_block_budget().unwrap_or(total);
+        if need <= free {
+            return Some(seq);
+        }
+        if self.reclaim_paged_blocks(need) {
+            return Some(seq);
+        }
+        // Still no room — defer to a later tick. Decodes in flight will free
+        // blocks as their sequences finish; this request retries then.
+        if let Err(rejected) = self.prefill_queue.enqueue(seq) {
+            self.prompt_cache_seq_ctx.remove(&rejected.seq_id);
+            self.release_sequence_caches(rejected.seq_id);
+            let _ = rejected.response_tx.send(GenerateEvent::Error(
+                "Server busy: prefill queue full".to_string(),
+            ));
+        }
+        None
+    }
+
+    // ------------------------------------------------------------------
     // Prefill execution (chunked or full)
     // ------------------------------------------------------------------
 
@@ -1827,6 +1917,18 @@ impl BatchScheduler {
         }
 
         let seq = match self.prefill_queue.dequeue() {
+            Some(s) => s,
+            None => return,
+        };
+
+        // #122 b2: paged KV block-budget admission gate. Opt-in — a no-op
+        // unless a budget is configured (`free_paged_block_budget()` is `None`
+        // otherwise). When the sequence would not fit, this evicts cold
+        // prompt-cache prefixes, then preempts running sequences, and as a last
+        // resort re-queues the sequence for a later tick (or rejects it if it
+        // can never fit the whole budget). Returning `None` means the sequence
+        // was deferred or rejected and this tick is done.
+        let seq = match self.admit_paged_prefill(seq) {
             Some(s) => s,
             None => return,
         };

--- a/src/server/batch/scheduler_prompt_cache_tests.rs
+++ b/src/server/batch/scheduler_prompt_cache_tests.rs
@@ -1070,3 +1070,88 @@ fn dense_eviction_does_not_queue_paged_releases() {
     );
     assert!(store.drain_pending_paged_releases().is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// #122 sub-step b2: on-demand LRU eviction reclaims paged block budget.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn evict_one_lru_drops_oldest_and_queues_paged_pins() {
+    let store = Arc::new(PromptCacheStore::with_config(PromptCacheConfig::new(
+        true,
+        1 << 30,
+        32,
+        Duration::from_secs(3600),
+        1,
+    )));
+    let model = PagedStub {
+        layout: PagedKvLayout::uniform(1, 4, 128).unwrap(),
+    };
+    let mut pool = CachePool::new(4);
+    let (set, blocks) = mint_paged_set(&mut pool, &model, 6);
+    let tokens: Vec<i32> = (0..16).collect();
+    store
+        .insert(
+            &make_key("m", "s", "tpl", &tokens),
+            CacheEntry::new(tokens.clone(), set),
+        )
+        .expect("insert");
+    assert_eq!(store.len(), 1);
+
+    // On-demand eviction drops the entry and queues its pins.
+    assert!(
+        store.evict_one_lru() > 0,
+        "evicting a real entry frees bytes"
+    );
+    assert_eq!(store.len(), 0);
+    assert!(store.has_pending_paged_releases());
+
+    for paged in store.drain_pending_paged_releases() {
+        pool.release_detached_paged(paged);
+    }
+    for b in &blocks {
+        assert_eq!(pool.paged_pool_ref().unwrap().refcount(*b), 0);
+    }
+    // A second eviction is a no-op (store empty).
+    assert_eq!(store.evict_one_lru(), 0);
+}
+
+#[test]
+fn evicting_cold_prefix_restores_paged_block_budget() {
+    // The reclaim tier-1 the scheduler runs under block pressure: evict a cold
+    // prompt-cache prefix and release its pins, raising the acquirable budget.
+    let store = Arc::new(PromptCacheStore::with_config(PromptCacheConfig::new(
+        true,
+        1 << 30,
+        32,
+        Duration::from_secs(3600),
+        1,
+    )));
+    let model = PagedStub {
+        layout: PagedKvLayout::uniform(1, 4, 128).unwrap(),
+    };
+    let mut pool = CachePool::new(4);
+    pool.set_paged_block_budget(Some(8));
+    let (set, blocks) = mint_paged_set(&mut pool, &model, 8); // 2 blocks, live
+    assert_eq!(blocks.len(), 2);
+    let free_before = pool.free_paged_block_budget().expect("budgeted");
+
+    let tokens: Vec<i32> = (0..16).collect();
+    store
+        .insert(
+            &make_key("m", "s", "tpl", &tokens),
+            CacheEntry::new(tokens.clone(), set),
+        )
+        .expect("insert");
+
+    assert!(store.evict_one_lru() > 0);
+    for paged in store.drain_pending_paged_releases() {
+        pool.release_detached_paged(paged);
+    }
+    let free_after = pool.free_paged_block_budget().expect("budgeted");
+    assert_eq!(
+        free_after,
+        free_before + 2,
+        "evicting the cold prefix reclaimed its 2 blocks into the budget"
+    );
+}

--- a/src/server/prompt_cache/store.rs
+++ b/src/server/prompt_cache/store.rs
@@ -739,6 +739,24 @@ impl PromptCacheStore {
         drained_freed + ttl_freed + cap_freed
     }
 
+    /// Evict the single least-recently-used entry on demand, returning the
+    /// bytes it freed (0 when the store is empty or disabled).
+    ///
+    /// Unlike [`Self::evict_if_needed`] (which only acts when a cap / TTL is
+    /// exceeded), this unconditionally drops the oldest entry. The scheduler
+    /// uses it to reclaim paged pool blocks under block-budget pressure: the
+    /// evicted entry's paged pins are routed to the pending-release queue
+    /// (drainable via [`Self::drain_pending_paged_releases`]), so the caller
+    /// frees the underlying blocks by releasing them. Returns 0 to signal
+    /// "nothing left to evict" so the caller can stop.
+    pub fn evict_one_lru(&self) -> usize {
+        let mut guard = match self.inner.write() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.evict_oldest()
+    }
+
     /// Drop every entry. Primarily for tests and shutdown paths.
     pub fn clear(&self) {
         let mut guard = self.inner.write().expect("prompt cache inner lock");


### PR DESCRIPTION
## Summary

Sub-step **b2** of #122 — the admission + eviction mechanism that enforces the b1 (#174) block budget. **Part of #122.** **Opt-in**: a no-op until a budget is configured (`free_paged_block_budget` is `None`), so default behaviour is unchanged and the per-prefill gate is one branch on the hot path.

## Changes

- **`CachePool`** stores the configured budget and applies it when the paged pool is **lazily created** (so `set_paged_block_budget` *before* the first paged allocation sticks); `paged_block_budget()` returns the stored intent. **`free_block_budget` is redefined as `budget − live`** (blocks *acquirable*: a fresh `acquire` reuses a freed block or mints a new one while `live < budget`), so eviction/preemption that drops refcounts *raises* it even though allocated rows are retained for reuse.
- **`PromptCacheStore::evict_one_lru()`** — drop the single LRU entry on demand, routing its paged pins to the pending-release queue so the caller frees the blocks.
- **`BatchScheduler`** gates each prefill (`admit_paged_prefill` in `execute_prefill`): estimate the prompt's block need (`ceil(prompt/block_size) × num_layers`); **admit** if it fits; **reject** if it exceeds the whole budget; otherwise **reclaim** — evict cold prompt-cache prefixes (releasing pins), then preempt running sequences (existing `try_evict_for_preemption`) — and admit if room was made, else **re-queue** for a later tick.

## Tests

6 new: `free = budget − live` after a free, budget surviving lazy pool creation, `evict_one_lru` dropping + queuing pins, cold-prefix eviction restoring the budget, plus the b1 cap tests. 28 `paged_detach` + 21 `scheduler_prompt_cache` + 181 `server::batch` pass.

**Testing note:** `BatchScheduler` is `pub(crate)` and not constructed in tests (the file mirrors its decision policy and unit-tests its primitives instead — the codebase's existing approach). The gate's building blocks are covered directly; the eviction tier-1 (cold-prefix → budget reclaimed) has an end-to-end CachePool+store test.

## Validation

Cold `cargo clippy --tests` (both crates) clean; `cargo fmt --check` clean; core regression + 181 `server::batch` + 21 `scheduler_prompt_cache` green.

## Scope

This is the enforcement mechanism. **Activation** — deriving the budget from a config knob and `--estimate-memory` (now accurate via #52) and calling `set_paged_block_budget` in the worker setup — is the next sub-step (b3). Until then the gate is dormant (budget `None`).