### PR TITLE
feat: wire paged KV block budget to a --kv-cache-budget knob

### DIFF
--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -141,6 +141,12 @@ enum Commands {
     Download(DownloadArgs),
 }
 
+/// clap value parser for `--kv-cache-budget`: a raw byte count or the literal
+/// `auto` (epic #116 #122 b3).
+fn parse_kv_cache_budget(s: &str) -> Result<mlxcel::memory_estimate::PagedBudgetDirective, String> {
+    s.parse()
+}
+
 #[derive(ClapArgs, Debug)]
 struct ServerArgs {
     /// Path to the model directory, or a HuggingFace `owner/name` repo-id.
@@ -315,6 +321,20 @@ struct ServerArgs {
         value_name = "N"
     )]
     max_kv_size: usize,
+
+    /// Paged KV-cache pool block budget — `auto` or a byte count (default: unbounded).
+    ///
+    /// Bounds the unified paged KV cache (epic #116): `auto` derives the cap
+    /// from the memory estimate, a raw byte count sets it explicitly. Only
+    /// affects pool-backed (Fp16) models under `--decode-storage-backend paged`.
+    /// Also reads `MLXCEL_KV_CACHE_BUDGET`.
+    #[arg(
+        long = "kv-cache-budget",
+        env = "MLXCEL_KV_CACHE_BUDGET",
+        value_name = "BYTES|auto",
+        value_parser = parse_kv_cache_budget
+    )]
+    kv_cache_budget: Option<mlxcel::memory_estimate::PagedBudgetDirective>,
 
     /// Maximum number of responses persisted by the OpenAI
     /// `/v1/responses` store (in-memory). `0` disables persistence
@@ -1205,6 +1225,9 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         // clap reads `LLAMA_ARG_MAX_KV_SIZE` directly via the `env = ...`
         // attribute on the flag, so no separate env-fallback helper is needed.
         max_kv_size: args.max_kv_size,
+        // paged KV pool block-budget directive (#122 b3); clap parses it into
+        // a `PagedBudgetDirective`, resolved to a block count on the worker.
+        kv_cache_budget: args.kv_cache_budget,
         // Responses API in-memory store limits. clap reads the
         // matching `LLAMA_ARG_*` env vars directly via the `env = ...`
         // attributes on the flags.

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -321,6 +321,10 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         // clap reads `LLAMA_ARG_MAX_KV_SIZE` directly via the `env = ...`
         // attribute on the flag, so no separate env-fallback helper is needed.
         max_kv_size: args.max_kv_size,
+        // paged KV pool block-budget directive (#122 b3). Already parsed by
+        // clap into a `PagedBudgetDirective` (`Bytes`/`Auto`); resolved to a
+        // block count on the worker thread.
+        kv_cache_budget: args.kv_cache_budget,
         // Responses API in-memory store limits. clap reads the
         // matching `LLAMA_ARG_*` env vars directly via the `env = ...`
         // attributes on the flags.

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -29,6 +29,7 @@ fn sample_args() -> crate::ServeArgs {
         n_parallel: 3,
         ctx_size: 8192,
         max_kv_size: 0,
+        kv_cache_budget: None,
         n_predict: 128,
         draft_model: Some(PathBuf::from("models/draft")),
         draft_max: 4,

--- a/src/execution/memory_estimate.rs
+++ b/src/execution/memory_estimate.rs
@@ -211,6 +211,42 @@ impl QuantHint {
     }
 }
 
+/// How an operator asked the paged KV pool's block budget to be sized
+/// (the `--kv-cache-budget` server knob, epic #116 #122 b3).
+///
+/// Resolved to a concrete block count by [`resolve_paged_block_budget`]
+/// once the model geometry is known. `None` (the flag absent) keeps the
+/// pool unbounded — the default, behaviour-preserving path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PagedBudgetDirective {
+    /// An explicit byte cap on the paged KV pool, converted to a block
+    /// count via the model's per-block byte cost. Raw bytes, matching the
+    /// other byte-valued server knobs (e.g. `--prompt-cache-capacity-bytes`).
+    Bytes(u64),
+    /// Derive the cap from [`estimate_total_memory`]: the unified-memory
+    /// headroom left for KV after weights, activation, and the allocator
+    /// safety factor (`--kv-cache-budget auto`).
+    Auto,
+}
+
+impl std::str::FromStr for PagedBudgetDirective {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let trimmed = s.trim();
+        if trimmed.eq_ignore_ascii_case("auto") {
+            return Ok(Self::Auto);
+        }
+        // A plain byte count. Human-readable suffixes (8GiB) are
+        // intentionally not parsed, to stay consistent with the other
+        // byte-valued server knobs which all take raw bytes.
+        trimmed
+            .parse::<u64>()
+            .map(Self::Bytes)
+            .map_err(|_| format!("expected a byte count or 'auto', got '{s}'"))
+    }
+}
+
 /// Full memory breakdown returned by [`estimate_total_memory`].
 ///
 /// All `_bytes` fields are absolute byte counts. `fits` is a
@@ -727,6 +763,113 @@ pub fn kv_cache_bytes_per_token(model_dir: &Path, int8_kv: bool, batch: u64) -> 
         .unwrap_or(0)
 }
 
+// ── Paged KV block-budget resolution (epic #116 #122 b3) ──────────────────────
+
+/// Real byte cost of a single paged KV block: `block_size` tokens of one
+/// layer's K+V at the pool's storage dtype.
+///
+/// The paged pool counts its budget in **per-layer blocks** — one block holds
+/// `block_size` tokens for a single layer of a single sequence (see
+/// `BatchScheduler::estimate_prefill_blocks`, which sizes a prefill as
+/// `ceil(prompt / block_size) × num_layers`). This is therefore the unit a
+/// byte budget must be divided by.
+///
+/// Derived from the same architecture-aware geometry as
+/// [`estimate_total_memory`]: the steady-state per-token KV rate
+/// ([`kv_cache_bytes_per_token`] at `batch = 1`) summed across attention
+/// layers, divided by `num_layers` to recover the per-layer rate, times
+/// `block_size`. For the pure-attention Fp16 models that are pool-backed today
+/// (Llama, Qwen3) every layer is a full-attention layer, so the division is
+/// exact. For sliding-window / hybrid / MLA models the marginal rate counts
+/// only the layers that grow, so dividing by the total layer count
+/// *under*-estimates the per-block cost — but those families keep dense caches
+/// and never touch the pool, so the figure is inert for them. If such a family
+/// is ever pool-backed, swap this for the per-layer K/V geometry directly.
+///
+/// Returns `None` when the architecture is unavailable or
+/// `num_layers` / `block_size` is zero.
+#[must_use]
+pub fn paged_block_bytes(
+    model_dir: &Path,
+    num_layers: usize,
+    block_size: usize,
+    kv_dtype_int8: bool,
+) -> Option<u64> {
+    if num_layers == 0 || block_size == 0 {
+        return None;
+    }
+    let per_token_all_layers = kv_cache_bytes_per_token(model_dir, kv_dtype_int8, 1);
+    let per_layer_per_token = per_token_all_layers / num_layers as u64;
+    if per_layer_per_token == 0 {
+        return None;
+    }
+    Some(per_layer_per_token.saturating_mul(block_size as u64))
+}
+
+/// Unified-memory headroom (bytes) available for the paged KV pool under the
+/// `--kv-cache-budget auto` policy.
+///
+/// Inverts the [`estimate_total_memory`] fit inequality. Recall that
+/// `total = headroom_factor × (weights + kv) + activation` (the allocator
+/// overhead is `(factor − 1) × (weights + kv)`); requiring `total ≤ available`
+/// and solving for the KV term gives
+/// `kv ≤ (available − activation) / factor − weights`. Returns the clamped
+/// non-negative headroom; `0` when the model leaves no room for KV.
+fn auto_kv_budget_bytes(est: &MemoryEstimate) -> u64 {
+    let factor = if est.headroom_factor.is_finite() && est.headroom_factor > 1.0 {
+        est.headroom_factor
+    } else {
+        1.0
+    };
+    let after_activation = est.available_bytes.saturating_sub(est.activation_bytes);
+    // `after_activation / factor` in f64; byte magnitudes (≤ ~10^12) sit far
+    // inside f64's exact-integer range, and factor ≥ 1.0 only shrinks the value.
+    let scaled = (after_activation as f64 / factor).floor();
+    let scaled = if scaled.is_finite() && scaled >= 0.0 {
+        scaled.min(u64::MAX as f64) as u64
+    } else {
+        0
+    };
+    scaled.saturating_sub(est.weights_bytes)
+}
+
+/// Resolve a [`PagedBudgetDirective`] into a concrete paged-block count for the
+/// server's `CachePool::set_paged_block_budget`.
+///
+/// `batch` is the server's configured active-sequence count (it scales the
+/// activation reserve under [`PagedBudgetDirective::Auto`]). `block_size` is
+/// the pool's block size (`DEFAULT_PAGED_BLOCK_SIZE`). Returns the number of
+/// blocks the pool may mint, or `None` when the model geometry is unavailable
+/// (the caller should then leave the pool unbounded). A returned `Some(0)`
+/// means the budget rounds below one block — the caller decides whether to
+/// reject that config or leave the pool unbounded; it must not install a zero
+/// budget, which would wedge every request.
+#[must_use]
+pub fn resolve_paged_block_budget(
+    model_dir: &Path,
+    num_layers: usize,
+    block_size: usize,
+    batch: u64,
+    kv_dtype_int8: bool,
+    directive: PagedBudgetDirective,
+) -> Option<usize> {
+    let per_block = paged_block_bytes(model_dir, num_layers, block_size, kv_dtype_int8)?;
+    let budget_bytes = match directive {
+        PagedBudgetDirective::Bytes(bytes) => bytes,
+        PagedBudgetDirective::Auto => {
+            let est = estimate_total_memory(
+                model_dir,
+                DEFAULT_CTX_LEN,
+                batch.max(1),
+                QuantHint::Default,
+                kv_dtype_int8,
+            );
+            auto_kv_budget_bytes(&est)
+        }
+    };
+    Some(usize::try_from(budget_bytes / per_block).unwrap_or(usize::MAX))
+}
+
 // ── Output formatting ─────────────────────────────────────────────────────────
 
 /// Format a byte count as a human-readable string (GiB, MiB, or exact bytes).
@@ -1194,5 +1337,178 @@ mod tests {
         assert_eq!(dims.hidden, 1024);
         assert_eq!(dims.intermediate, 4096); // 4 × hidden fallback
         assert_eq!(dims.vocab, 0); // no logit term when absent
+    }
+
+    // ── #122 b3: paged KV block-budget resolution ───────────────────────────
+
+    #[test]
+    fn paged_budget_directive_parses_auto_and_bytes() {
+        assert_eq!(
+            "auto".parse::<PagedBudgetDirective>().unwrap(),
+            PagedBudgetDirective::Auto,
+        );
+        assert_eq!(
+            "AUTO".parse::<PagedBudgetDirective>().unwrap(),
+            PagedBudgetDirective::Auto,
+        );
+        assert_eq!(
+            " 8589934592 ".parse::<PagedBudgetDirective>().unwrap(),
+            PagedBudgetDirective::Bytes(8_589_934_592),
+        );
+        assert!("8GiB".parse::<PagedBudgetDirective>().is_err());
+        assert!("-5".parse::<PagedBudgetDirective>().is_err());
+    }
+
+    #[test]
+    fn paged_block_bytes_matches_uniform_geometry() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_minimal_config(tmp.path());
+        // 32 layers, 8 kv heads, head_dim 128, fp16:
+        //   per-token (all layers) = 32 × 2 × 8 × 128 × 2 = 131072
+        //   per-layer per-token    = 131072 / 32 = 4096
+        //   per-block              = 4096 × 32 (block_size) = 131072
+        assert_eq!(paged_block_bytes(tmp.path(), 32, 32, false), Some(131_072));
+        // int8 halves the per-block cost.
+        assert_eq!(paged_block_bytes(tmp.path(), 32, 32, true), Some(65_536));
+    }
+
+    #[test]
+    fn paged_block_bytes_none_on_zero_or_missing_geometry() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_minimal_config(tmp.path());
+        assert_eq!(paged_block_bytes(tmp.path(), 0, 32, false), None);
+        assert_eq!(paged_block_bytes(tmp.path(), 32, 0, false), None);
+        // No config.json ⇒ no architecture ⇒ None.
+        let empty = tempfile::tempdir().unwrap();
+        assert_eq!(paged_block_bytes(empty.path(), 32, 32, false), None);
+    }
+
+    #[test]
+    fn resolve_block_budget_explicit_bytes_floors_to_block_count() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_minimal_config(tmp.path());
+        let per_block = paged_block_bytes(tmp.path(), 32, 32, false).unwrap(); // 131072
+        // Exactly 100 blocks.
+        assert_eq!(
+            resolve_paged_block_budget(
+                tmp.path(),
+                32,
+                32,
+                1,
+                false,
+                PagedBudgetDirective::Bytes(per_block * 100),
+            ),
+            Some(100),
+        );
+        // 100 blocks + a partial ⇒ floors to 100.
+        assert_eq!(
+            resolve_paged_block_budget(
+                tmp.path(),
+                32,
+                32,
+                1,
+                false,
+                PagedBudgetDirective::Bytes(per_block * 100 + per_block / 2),
+            ),
+            Some(100),
+        );
+        // Below one block ⇒ 0 (caller leaves the pool unbounded rather than
+        // installing a wedging zero budget).
+        assert_eq!(
+            resolve_paged_block_budget(
+                tmp.path(),
+                32,
+                32,
+                1,
+                false,
+                PagedBudgetDirective::Bytes(per_block - 1),
+            ),
+            Some(0),
+        );
+    }
+
+    #[test]
+    fn auto_kv_budget_inverts_the_fit_inequality() {
+        // factor × (weights + kv) + activation ≤ available, solved for kv.
+        let est = MemoryEstimate {
+            weights_bytes: 10_000_000_000,
+            kv_cache_bytes: 0,
+            runtime_headroom_bytes: 0,
+            activation_bytes: 1_000_000_000,
+            total_bytes: 0,
+            available_bytes: 25_000_000_000,
+            fits: true,
+            weights_source: WeightsSource::AnalyticalConfig,
+            kv_source: KvSource::Config,
+            kv_detail: String::new(),
+            headroom_factor: 1.20,
+            ctx_len: DEFAULT_CTX_LEN,
+            batch: 1,
+            quant: QuantHint::Default,
+            kv_dtype_int8: false,
+        };
+        // (25e9 − 1e9) / 1.2 − 10e9 = 20e9 − 10e9 = 10e9.
+        let budget = auto_kv_budget_bytes(&est);
+        assert_eq!(budget, 10_000_000_000);
+        // The result preserves the fit (with equality here).
+        let reconstructed =
+            (1.20_f64 * (est.weights_bytes + budget) as f64) as u64 + est.activation_bytes;
+        assert!(reconstructed <= est.available_bytes);
+    }
+
+    #[test]
+    fn auto_kv_budget_saturates_to_zero_when_overcommitted() {
+        let est = MemoryEstimate {
+            weights_bytes: 30_000_000_000,
+            kv_cache_bytes: 0,
+            runtime_headroom_bytes: 0,
+            activation_bytes: 1_000_000_000,
+            total_bytes: 0,
+            available_bytes: 16_000_000_000,
+            fits: false,
+            weights_source: WeightsSource::AnalyticalConfig,
+            kv_source: KvSource::Config,
+            kv_detail: String::new(),
+            headroom_factor: 1.20,
+            ctx_len: DEFAULT_CTX_LEN,
+            batch: 1,
+            quant: QuantHint::Default,
+            kv_dtype_int8: false,
+        };
+        assert_eq!(auto_kv_budget_bytes(&est), 0);
+    }
+
+    #[test]
+    fn resolve_block_budget_auto_scales_with_available_memory() {
+        let _env = crate::test_support::env_lock::env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        write_minimal_config(tmp.path());
+
+        let auto = || {
+            resolve_paged_block_budget(tmp.path(), 32, 32, 1, false, PagedBudgetDirective::Auto)
+                .unwrap()
+        };
+
+        let big = {
+            let _r = EnvRestore::set(MEMORY_LIMIT_ENV, "256GB");
+            auto()
+        };
+        let small = {
+            let _r = EnvRestore::set(MEMORY_LIMIT_ENV, "32GB");
+            auto()
+        };
+        // More available memory ⇒ strictly more acquirable KV blocks.
+        assert!(
+            big > small,
+            "256GB budget {big} should exceed 32GB budget {small}"
+        );
+        assert!(big > 0);
+
+        // A limit below the (~12 GB) weight footprint leaves no KV room ⇒ 0.
+        let starved = {
+            let _r = EnvRestore::set(MEMORY_LIMIT_ENV, "1GB");
+            auto()
+        };
+        assert_eq!(starved, 0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -607,6 +607,13 @@ impl Default for PipelineParallelOptions {
     }
 }
 
+/// clap value parser for `--kv-cache-budget`: a raw byte count or the
+/// literal `auto` (epic #116 #122 b3). Delegates to
+/// [`mlxcel::memory_estimate::PagedBudgetDirective`]'s `FromStr`.
+fn parse_kv_cache_budget(s: &str) -> Result<mlxcel::memory_estimate::PagedBudgetDirective, String> {
+    s.parse()
+}
+
 /// Server options
 #[derive(Args, Debug)]
 #[command(after_help = "\
@@ -789,6 +796,25 @@ pub(crate) struct ServeArgs {
         value_name = "N"
     )]
     max_kv_size: usize,
+
+    /// Paged KV-cache pool block budget — `auto` or a byte count (default: unbounded).
+    ///
+    /// Bounds the unified paged KV cache (epic #116) so the server evicts cold
+    /// cross-request prompt prefixes (then preempts running sequences) instead
+    /// of growing the pool without limit. `auto` derives the cap from the
+    /// memory estimate (`(available − weights − activation) / per-block bytes`);
+    /// a raw byte count (e.g. `8589934592` for 8 GiB) sets an explicit cap.
+    /// Only affects pool-backed (Fp16, dense-natural-backend) models — model-
+    /// owned / quantized families keep dense caches and ignore it. Requires
+    /// `--decode-storage-backend paged` to have any effect.
+    /// Also reads `MLXCEL_KV_CACHE_BUDGET`.
+    #[arg(
+        long = "kv-cache-budget",
+        env = "MLXCEL_KV_CACHE_BUDGET",
+        value_name = "BYTES|auto",
+        value_parser = parse_kv_cache_budget
+    )]
+    kv_cache_budget: Option<mlxcel::memory_estimate::PagedBudgetDirective>,
 
     /// Maximum number of responses persisted by the OpenAI
     /// `/v1/responses` store (in-memory). `0` disables persistence

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -85,7 +85,7 @@ fn should_align_prefill() -> bool {
     hw.has_neural_accelerator && hw.macos_supports_na
 }
 
-const DEFAULT_PAGED_BLOCK_SIZE: usize = 32;
+pub(crate) const DEFAULT_PAGED_BLOCK_SIZE: usize = 32;
 
 fn effective_decode_storage_backend(
     requested: DecodeStorageBackend,
@@ -526,6 +526,23 @@ impl BatchScheduler {
     /// Returns the configured maximum KV cache size (for tests).
     pub fn max_kv_size(&self) -> Option<usize> {
         self.max_kv_size
+    }
+
+    /// Install the paged KV block budget (epic #116 #122 b3).
+    ///
+    /// `Some(n)` caps the paged pool at `n` blocks — the admission gate in
+    /// [`Self::admit_paged_prefill`] then evicts cold prefixes / preempts to
+    /// stay within it. `None` (the default) keeps the pool unbounded, the
+    /// behaviour-preserving path. The block count is resolved from the
+    /// operator's `--kv-cache-budget` directive by
+    /// [`crate::memory_estimate::resolve_paged_block_budget`] on the worker
+    /// thread (where the model geometry is known). Only meaningful for
+    /// pool-backed (Fp16, dense-natural-backend) sequences; inert for
+    /// model-owned / quantized families that keep dense caches and never mint
+    /// pool blocks.
+    pub fn with_paged_block_budget(mut self, budget: Option<usize>) -> Self {
+        self.cache_pool.set_paged_block_budget(budget);
+        self
     }
 
     /// Attach the resolved speculative-decoding dispatch.

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -348,6 +348,12 @@ pub struct ServerStartupInput {
     /// `--max-kv-size` value (`0` = disabled, the default).
     pub max_kv_size: usize,
 
+    /// `--kv-cache-budget` directive (epic #116 #122 b3). `None` = unset
+    /// (unbounded paged pool, the default). Parsed at the clap layer into a
+    /// [`crate::memory_estimate::PagedBudgetDirective`] (`Bytes(n)` / `Auto`);
+    /// resolved to a concrete block count on the worker thread.
+    pub kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
+
     /// `--responses-store-max-entries` value (`0` disables
     /// the OpenAI Responses API response store entirely).
     pub responses_store_max_entries: usize,
@@ -559,6 +565,9 @@ impl ServerStartupInput {
             // semantic `Option<usize>` after `resolve_max_kv_size` has
             // validated upper and lower bounds (H1 fix).
             max_kv_size: resolved_max_kv_size,
+            // forward the paged KV block-budget directive verbatim (resolved
+            // to a block count on the worker thread).
+            kv_cache_budget: self.kv_cache_budget,
             // forward the Responses-API store limits.
             responses_store_max_entries: self.responses_store_max_entries,
             responses_store_ttl_secs: self.responses_store_ttl_secs,

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -138,6 +138,8 @@ fn sample_input() -> ServerStartupInput {
         kv_skip_last_layer: true,
         // max KV cache size (0 = unbounded, the default).
         max_kv_size: 0,
+        // paged KV pool block-budget directive (None = unbounded, the default).
+        kv_cache_budget: None,
         // Responses API store defaults.
         responses_store_max_entries: 1024,
         responses_store_ttl_secs: 3600,

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -398,6 +398,18 @@ pub struct ServerConfig {
     /// `[MAX_KV_SIZE_MIN, i32::MAX]`). If both are present, the lower value
     /// wins so the configured context window remains an upper bound.
     pub max_kv_size: Option<usize>,
+
+    /// Paged KV pool block-budget directive (epic #116 #122 b3,
+    /// `--kv-cache-budget`).
+    ///
+    /// `None` (the default) keeps the paged pool unbounded — the
+    /// behaviour-preserving path. `Some(Bytes)` / `Some(Auto)` is resolved to
+    /// a concrete block count on the worker thread (where the model geometry
+    /// is known) by [`crate::memory_estimate::resolve_paged_block_budget`] and
+    /// installed via
+    /// [`crate::server::batch::BatchScheduler::with_paged_block_budget`]. Only
+    /// meaningful for pool-backed (Fp16, dense-natural-backend) sequences.
+    pub kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
 }
 
 impl Default for ServerConfig {
@@ -451,6 +463,7 @@ impl Default for ServerConfig {
             kv_cache_mode: mlxcel_core::cache::KVCacheMode::Fp16,
             batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig::default(),
             max_kv_size: None,
+            kv_cache_budget: None,
         }
     }
 }

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -248,6 +248,8 @@ impl ModelProvider {
                 config.batch_kv_quant,
                 // forward the --max-kv-size cap to the scheduler.
                 config.max_kv_size,
+                // forward the --kv-cache-budget directive to the worker.
+                config.kv_cache_budget,
                 speculative_dispatch,
                 batch_metrics,
                 batch_observability,
@@ -391,6 +393,7 @@ impl ModelProvider {
             mlxcel_core::cache::KVCacheMode::Fp16,
             mlxcel_core::cache::BatchKvQuantConfig::default(),
             None, // max_kv_size: unbounded
+            None, // kv_cache_budget: unbounded
             batch_metrics,
             batch_observability,
         )
@@ -423,6 +426,9 @@ impl ModelProvider {
         // maximum KV cache size for plain (non-sliding) caches.
         // `None` preserves the legacy unbounded behaviour.
         max_kv_size: Option<usize>,
+        // paged KV pool block-budget directive (`--kv-cache-budget`).
+        // `None` keeps the pool unbounded.
+        kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
         batch_metrics: Arc<BatchMetrics>,
         batch_observability: Arc<BatchObservability>,
     ) -> Result<Self> {
@@ -448,6 +454,7 @@ impl ModelProvider {
             kv_cache_mode,
             batch_kv_quant,
             max_kv_size,
+            kv_cache_budget,
             crate::server::SpeculativeDispatch::Disabled,
             batch_metrics,
             batch_observability,
@@ -481,6 +488,7 @@ impl ModelProvider {
         kv_cache_mode: mlxcel_core::cache::KVCacheMode,
         batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig,
         max_kv_size: Option<usize>,
+        kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
         speculative_dispatch: crate::server::SpeculativeDispatch,
         batch_metrics: Arc<BatchMetrics>,
         batch_observability: Arc<BatchObservability>,
@@ -516,6 +524,9 @@ impl ModelProvider {
             batch_kv_quant,
             // cap plain KVCache growth when configured.
             max_kv_size,
+            // paged KV pool block-budget directive; resolved to a block count
+            // on the worker thread once the model geometry is known.
+            kv_cache_budget,
             // forward the resolved speculative dispatch.
             speculative_dispatch,
         };
@@ -588,7 +599,8 @@ impl ModelProvider {
             prompt_cache: None,
             kv_cache_mode: mlxcel_core::cache::KVCacheMode::Fp16,
             batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig::default(),
-            max_kv_size: None, // unbounded in minimal test path
+            max_kv_size: None,     // unbounded in minimal test path
+            kv_cache_budget: None, // unbounded in minimal test path
             // minimal test path has no drafter; the dispatch
             // defaults to `Disabled` which short-circuits the scheduler
             // hot path to the classic decode loop.

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -26,6 +26,7 @@ use std::time::Instant;
 
 use anyhow::{Result, anyhow};
 use image::{DynamicImage, ImageError, ImageReader};
+use mlxcel_core::generate::LanguageModel;
 
 use crate::LoadedModel;
 use crate::SamplingConfig;
@@ -103,6 +104,17 @@ pub(crate) struct WorkerSchedulerConfig {
     /// window and bypass this cap. `None` (the default) preserves the
     /// legacy unbounded behaviour.
     pub max_kv_size: Option<usize>,
+    /// paged KV pool block-budget directive (epic #116 #122 b3,
+    /// `--kv-cache-budget`).
+    ///
+    /// `None` (the default) keeps the paged pool unbounded — the
+    /// behaviour-preserving path. `Some(Bytes/Auto)` is resolved to a concrete
+    /// block count on this worker thread (where `model_path` + the loaded
+    /// model's geometry are both available) via
+    /// [`crate::memory_estimate::resolve_paged_block_budget`] and installed on
+    /// the scheduler's pool through
+    /// [`crate::server::batch::BatchScheduler::with_paged_block_budget`].
+    pub kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
     /// resolved speculative-decoding dispatch shape.
     ///
     /// Constructed once at worker construction (or
@@ -343,6 +355,17 @@ pub(crate) fn spawn_model_worker_with_batch_config(
             );
         }
 
+        // #122 b3: resolve the `--kv-cache-budget` directive into a paged
+        // block count now (the model's geometry is known) and install it on
+        // the scheduler's pool below. A no-op (unbounded) when the flag is
+        // unset. Computed before `model` is moved into `with_config`.
+        let paged_block_budget = resolve_worker_paged_block_budget(
+            &model_path,
+            &model,
+            sched_config.max_batch_size,
+            sched_config.kv_cache_budget,
+        );
+
         let mut scheduler = super::super::batch::BatchScheduler::with_config(
             model,
             tokenizer,
@@ -366,12 +389,69 @@ pub(crate) fn spawn_model_worker_with_batch_config(
         .with_batch_kv_quant(sched_config.batch_kv_quant)
         // cap plain KVCache growth to --max-kv-size when set.
         .with_max_kv_size(sched_config.max_kv_size)
+        // install the resolved paged KV block budget (epic #116 #122 b3).
+        .with_paged_block_budget(paged_block_budget)
         // attach the resolved speculative dispatch so the
         // scheduler can branch per-request once the round-loop dispatch
         // hook is wired in `decode_single_step`.
         .with_speculative_dispatch(sched_config.speculative_dispatch);
         scheduler.run();
     })
+}
+
+/// Resolve the operator's `--kv-cache-budget` directive into a concrete paged
+/// KV block count for this worker's scheduler pool (epic #116 #122 b3).
+///
+/// Returns `None` (leave the pool unbounded) when the flag is unset, the model
+/// geometry is unavailable, or the budget rounds below one block — in the last
+/// case a warning is logged rather than installing a zero budget that would
+/// reject every request. `batch` is the configured active-sequence count (it
+/// scales the activation reserve under [`PagedBudgetDirective::Auto`]).
+///
+/// [`PagedBudgetDirective::Auto`]: crate::memory_estimate::PagedBudgetDirective::Auto
+fn resolve_worker_paged_block_budget(
+    model_path: &std::path::Path,
+    model: &LoadedModel,
+    batch: usize,
+    directive: Option<crate::memory_estimate::PagedBudgetDirective>,
+) -> Option<usize> {
+    let directive = directive?;
+    let num_layers = model.num_layers();
+    let block_size = crate::server::batch::scheduler::DEFAULT_PAGED_BLOCK_SIZE;
+    // The paged pool stores Fp16; Int8 / Turbo sequences keep dense caches and
+    // ignore the budget, so the per-block cost is computed at Fp16.
+    let blocks = crate::memory_estimate::resolve_paged_block_budget(
+        model_path,
+        num_layers,
+        block_size,
+        batch.max(1) as u64,
+        false,
+        directive,
+    );
+    match blocks {
+        Some(n) if n > 0 => {
+            tracing::info!(
+                "Paged KV block budget: {n} blocks ({num_layers} layers, \
+                 {block_size}-token blocks)"
+            );
+            Some(n)
+        }
+        Some(_) => {
+            tracing::warn!(
+                "--kv-cache-budget resolves to 0 KV blocks at this configuration \
+                 (model too large for a meaningful paged budget at this batch / \
+                 available memory); leaving the paged pool unbounded"
+            );
+            None
+        }
+        None => {
+            tracing::warn!(
+                "--kv-cache-budget was set but the model's KV geometry is \
+                 unavailable; leaving the paged pool unbounded"
+            );
+            None
+        }
+    }
 }
 
 /// Resolve the worker-level Axis B `LangBiasConfig` into a concrete

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -302,6 +302,11 @@ pub struct ServerStartupConfig {
     /// semantics.
     pub max_kv_size: Option<usize>,
 
+    /// Paged KV pool block-budget directive (`--kv-cache-budget`). See the
+    /// corresponding field on [`crate::server::ServerConfig`] for full
+    /// semantics. `None` (the default) keeps the pool unbounded.
+    pub kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
+
     /// maximum number of responses kept in the
     /// [`crate::server::responses_store::ResponsesStore`]. `0` disables
     /// response persistence entirely, in which case `GET /v1/responses/:id`
@@ -431,6 +436,7 @@ impl Default for ServerStartupConfig {
             kv_cache_mode: mlxcel_core::cache::KVCacheMode::Fp16,
             batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig::default(),
             max_kv_size: None,
+            kv_cache_budget: None,
             responses_store_max_entries: 1024,
             responses_store_ttl_secs: 3600,
             conversation_store_max_entries: 256,
@@ -801,6 +807,9 @@ pub(super) fn build_server_config(
         // policy to plain `KVCache` instances. `None` means no explicit
         // context or max-KV bound was configured.
         max_kv_size,
+        // forward the paged KV block-budget directive verbatim; the worker
+        // resolves it to a concrete block count once the model is loaded.
+        kv_cache_budget: startup.kv_cache_budget,
     }
 }
 


### PR DESCRIPTION
## Summary

Sub-step **b3** of #122 activates the paged KV cache block-budget admission gate (built dormant in b1/b2) by deriving and installing a budget at server startup. A new `--kv-cache-budget` serve knob (env `MLXCEL_KV_CACHE_BUDGET`) takes either a raw byte cap or the literal `auto`; absent, the pool stays unbounded so the default path is byte-identical to before.

```
mlxcel serve -m qwen3 --decode-storage-backend paged --kv-cache-budget auto
mlxcel serve -m qwen3 --decode-storage-backend paged --kv-cache-budget 8589934592   # 8 GiB
```

## What changed

**Testable core** (`execution::memory_estimate`, +7 unit tests):

- `PagedBudgetDirective { Bytes(u64), Auto }` + `FromStr` (`auto` or a raw byte count).
- `paged_block_bytes()` — the real cost of one paged block (`block_size` tokens of one layer's K+V) from the architecture-aware KV geometry. Exact for the pure-attention Fp16 models that are pool-backed today.
- `auto_kv_budget_bytes()` — inverts the estimator's fit inequality `total = factor×(weights+kv) + activation ≤ available` for the KV term: `kv ≤ (available − activation)/factor − weights`.
- `resolve_paged_block_budget()` — directive → concrete block count.

**Wiring** — the directive threads through the standard config chain (mirroring `--max-kv-size`): `ServeArgs` / `mlx_server` → `ServerStartupInput` → `ServerStartupConfig` → `ServerConfig` → `WorkerSchedulerConfig`. It is resolved to a block count on the worker thread (where `model_path` and `model.num_layers()` are both known) and installed via `BatchScheduler::with_paged_block_budget` → `CachePool::set_paged_block_budget`. A budget that rounds below one block is downgraded to unbounded with a warning rather than wedging every request.

## Scope / behavior

- **Opt-in, default-unchanged.** No flag ⇒ `None` ⇒ unbounded pool ⇒ byte-identical to pre-b3.
- The gate is only meaningful for **pool-backed (Fp16, dense-natural-backend) sequences under `--decode-storage-backend paged`**; model-owned and quantized families keep dense caches and ignore it (documented in `--help`).
- The worker derivation is thin glue over the unit-tested core; `BatchScheduler` stays `pub(crate)` (same testing boundary as b2).

## Test plan

- `cargo build` (lib + both binaries, `metal,accelerate`) — clean
- **cold** `cargo clippy -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test` — `memory_estimate` 29 (7 new), `cli_input` 93, `startup` 45, `model_provider` 26, `serve` 13, `scheduler_prompt_cache` 21, `server::batch` 181 — all green
- Real binary: `--kv-cache-budget auto` parses; `8GiB` rejected with a clear error; `--help` documents the knob

Sub-step **c** (`GET /v1/cache/stats` block fields + E2E admit-under-pressure / no-leak) remains to finish #122.

Part of #122.
