### PR TITLE
feat: surface paged KV block budget in cache stats and metrics

### DIFF
--- a/src/server/batch/observability.rs
+++ b/src/server/batch/observability.rs
@@ -70,6 +70,10 @@ pub struct BatchObservability {
     pub cache_pool_paged_bytes_reserved: AtomicU64,
     /// Visible bytes currently in use across active paged sequences.
     pub cache_pool_paged_bytes_in_use: AtomicU64,
+    /// Configured paged KV block-budget cap (epic #116 #122). `0` means
+    /// unbounded (no `--kv-cache-budget` set) — the acquirable headroom under
+    /// a cap is `budget - blocks_live`.
+    pub cache_pool_paged_block_budget: AtomicU64,
     /// Times paged decode was requested but fell back to dense.
     pub decode_storage_fallbacks: AtomicU64,
 
@@ -114,6 +118,7 @@ impl BatchObservability {
             cache_pool_paged_blocks_free: AtomicU64::new(0),
             cache_pool_paged_bytes_reserved: AtomicU64::new(0),
             cache_pool_paged_bytes_in_use: AtomicU64::new(0),
+            cache_pool_paged_block_budget: AtomicU64::new(0),
             decode_storage_fallbacks: AtomicU64::new(0),
             prompt_cache_hits: AtomicU64::new(0),
             prompt_cache_hit_tokens: AtomicU64::new(0),
@@ -189,6 +194,7 @@ impl BatchObservability {
         cache_bytes: u64,
         paged_block_size: usize,
         paged_stats: Option<PagedCacheStats>,
+        paged_block_budget: u64,
     ) {
         self.current_batch_size.store(batch_size, Ordering::Relaxed);
         self.current_queue_depth
@@ -210,6 +216,8 @@ impl BatchObservability {
             .store(stats.bytes_reserved as u64, Ordering::Relaxed);
         self.cache_pool_paged_bytes_in_use
             .store(stats.bytes_in_use as u64, Ordering::Relaxed);
+        self.cache_pool_paged_block_budget
+            .store(paged_block_budget, Ordering::Relaxed);
     }
 
     // -- Snapshot for HTTP handlers --
@@ -238,6 +246,9 @@ impl BatchObservability {
                 .load(Ordering::Relaxed),
             cache_pool_paged_bytes_in_use: self
                 .cache_pool_paged_bytes_in_use
+                .load(Ordering::Relaxed),
+            cache_pool_paged_block_budget: self
+                .cache_pool_paged_block_budget
                 .load(Ordering::Relaxed),
             decode_storage_fallbacks: self.decode_storage_fallbacks.load(Ordering::Relaxed),
             prompt_cache_hits: self.prompt_cache_hits.load(Ordering::Relaxed),
@@ -270,6 +281,7 @@ pub struct ObservabilitySnapshot {
     pub cache_pool_paged_blocks_free: u64,
     pub cache_pool_paged_bytes_reserved: u64,
     pub cache_pool_paged_bytes_in_use: u64,
+    pub cache_pool_paged_block_budget: u64,
     pub decode_storage_fallbacks: u64,
     /// successful prompt-cache adoptions.
     pub prompt_cache_hits: u64,
@@ -359,6 +371,7 @@ mod tests {
                 bytes_reserved: 8192,
                 bytes_in_use: 6144,
             }),
+            64,
         );
         let snap = obs.snapshot();
         assert_eq!(snap.current_batch_size, 4);
@@ -371,6 +384,7 @@ mod tests {
         assert_eq!(snap.cache_pool_paged_blocks_free, 4);
         assert_eq!(snap.cache_pool_paged_bytes_reserved, 8192);
         assert_eq!(snap.cache_pool_paged_bytes_in_use, 6144);
+        assert_eq!(snap.cache_pool_paged_block_budget, 64);
     }
 
     #[test]

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1220,6 +1220,9 @@ impl BatchScheduler {
             self.cache_pool.memory_usage_bytes() as u64,
             paged_block_size,
             paged_stats,
+            // #122 c: surface the configured block-budget cap (0 = unbounded)
+            // so `/v1/cache/stats` and `/metrics` can report admission headroom.
+            self.cache_pool.paged_block_budget().unwrap_or(0) as u64,
         );
     }
 

--- a/src/server/prompt_cache/apc_integration_tests.rs
+++ b/src/server/prompt_cache/apc_integration_tests.rs
@@ -288,7 +288,11 @@ fn apc_stats_reflect_block_chain_after_inserts() {
         )
         .expect("insert B");
 
-    let resp = build_stats_response(Some(&store), &cfg);
+    let resp = build_stats_response(
+        Some(&store),
+        &cfg,
+        crate::server::routes::cache::PagedBlockStats::default(),
+    );
     assert!(resp.enabled);
     assert!(resp.apc_enabled);
     assert_eq!(resp.entries, 2);
@@ -335,7 +339,11 @@ fn apc_disabled_flow_still_works_but_apc_active_entries_is_zero() {
         .expect("lookup B hits");
     assert!(hit_b.apc_block_hashes().is_none(), "APC off -> no chain");
 
-    let resp = build_stats_response(Some(&store), &cfg);
+    let resp = build_stats_response(
+        Some(&store),
+        &cfg,
+        crate::server::routes::cache::PagedBlockStats::default(),
+    );
     assert!(resp.enabled);
     assert!(!resp.apc_enabled);
     assert_eq!(resp.entries, 2);

--- a/src/server/routes/cache.rs
+++ b/src/server/routes/cache.rs
@@ -27,6 +27,40 @@ use axum::{Json, extract::State};
 use serde::{Deserialize, Serialize};
 
 use crate::server::AppState;
+use crate::server::batch::ObservabilitySnapshot;
+
+/// Paged KV block-pool view for the cache-stats body (epic #116 #122 c).
+///
+/// Sourced from the batch observability snapshot so the HTTP body mirrors the
+/// Prometheus `mlxcel_cache_pool_paged_*` gauges. Defaults to all-zero (the
+/// "no paged pool" state), which lets route-level tests build a response
+/// without standing up a worker / scheduler.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct PagedBlockStats {
+    pub block_size: usize,
+    pub blocks_allocated: u64,
+    pub blocks_live: u64,
+    pub blocks_free: u64,
+    pub bytes_reserved: u64,
+    pub bytes_in_use: u64,
+    pub block_budget: u64,
+}
+
+impl PagedBlockStats {
+    /// Project the paged block-pool gauges out of a batch observability
+    /// snapshot.
+    pub(crate) fn from_observability(snap: &ObservabilitySnapshot) -> Self {
+        Self {
+            block_size: snap.cache_pool_paged_block_size,
+            blocks_allocated: snap.cache_pool_paged_blocks_allocated,
+            blocks_live: snap.cache_pool_paged_blocks_live,
+            blocks_free: snap.cache_pool_paged_blocks_free,
+            bytes_reserved: snap.cache_pool_paged_bytes_reserved,
+            bytes_in_use: snap.cache_pool_paged_bytes_in_use,
+            block_budget: snap.cache_pool_paged_block_budget,
+        }
+    }
+}
 
 /// Snapshot of cache state returned by `GET /v1/cache/stats`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -74,6 +108,29 @@ pub struct CacheStatsResponse {
     /// Number of entries that carry a populated APC block-hash chain.
     /// Always `0` when APC is disabled.
     pub apc_active_entries: usize,
+
+    // ── Paged KV block pool (epic #116 #122 c) ───────────────────────────────
+    // Sourced from the batch observability gauges (not the prompt-cache store),
+    // so these are meaningful even when the prompt cache is disabled. They
+    // mirror the `mlxcel_cache_pool_paged_*` Prometheus gauges.
+    /// Paged decode block size in tokens. `0` when paged decode is inactive
+    /// for this worker (dense backend), so a `0` cleanly marks "no paged pool".
+    pub paged_block_size: usize,
+    /// Paged KV blocks tracked by the allocator (rows minted into the pool).
+    pub paged_blocks_allocated: u64,
+    /// Paged KV blocks currently held by live sequences.
+    pub paged_blocks_live: u64,
+    /// Paged KV blocks freed and retained on the pool's free list for reuse.
+    pub paged_blocks_free: u64,
+    /// Reserved bytes across active paged sequences.
+    pub paged_bytes_reserved: u64,
+    /// Visible bytes currently in use across active paged sequences.
+    pub paged_bytes_in_use: u64,
+    /// Configured paged KV block-budget cap (`--kv-cache-budget`). `0` means
+    /// unbounded; otherwise the admission gate holds `paged_blocks_live` at or
+    /// below this, so `paged_block_budget - paged_blocks_live` is the
+    /// acquirable headroom before eviction / preemption kicks in.
+    pub paged_block_budget: u64,
 }
 
 /// Response for `POST /v1/cache/reset`.
@@ -90,9 +147,11 @@ pub struct CacheResetResponse {
 
 /// `GET /v1/cache/stats` — return a snapshot of cache statistics.
 pub async fn cache_stats(State(state): State<AppState>) -> Json<CacheStatsResponse> {
+    let paged = PagedBlockStats::from_observability(&state.batch_observability.snapshot());
     Json(build_stats_response(
         state.prompt_cache.as_deref(),
         &state.config.prompt_cache,
+        paged,
     ))
 }
 
@@ -111,6 +170,7 @@ pub async fn cache_reset(State(state): State<AppState>) -> Json<CacheResetRespon
 pub(crate) fn build_stats_response(
     store: Option<&crate::server::prompt_cache::PromptCacheStore>,
     cfg: &crate::server::prompt_cache::PromptCacheConfig,
+    paged: PagedBlockStats,
 ) -> CacheStatsResponse {
     let apc = &cfg.apc;
     match store {
@@ -141,6 +201,14 @@ pub(crate) fn build_stats_response(
                 total_blocks_stored: apc_stats.total_blocks_stored,
                 unique_block_hashes: apc_stats.unique_block_hashes,
                 apc_active_entries: apc_stats.apc_active_entries,
+                // Paged block-pool gauges are store-independent.
+                paged_block_size: paged.block_size,
+                paged_blocks_allocated: paged.blocks_allocated,
+                paged_blocks_live: paged.blocks_live,
+                paged_blocks_free: paged.blocks_free,
+                paged_bytes_reserved: paged.bytes_reserved,
+                paged_bytes_in_use: paged.bytes_in_use,
+                paged_block_budget: paged.block_budget,
             }
         }
         None => CacheStatsResponse {
@@ -162,6 +230,15 @@ pub(crate) fn build_stats_response(
             total_blocks_stored: 0,
             unique_block_hashes: 0,
             apc_active_entries: 0,
+            // Paged decode can run with the prompt cache disabled, so these
+            // still reflect the live pool even on the `None` branch.
+            paged_block_size: paged.block_size,
+            paged_blocks_allocated: paged.blocks_allocated,
+            paged_blocks_live: paged.blocks_live,
+            paged_blocks_free: paged.blocks_free,
+            paged_bytes_reserved: paged.bytes_reserved,
+            paged_bytes_in_use: paged.bytes_in_use,
+            paged_block_budget: paged.block_budget,
         },
     }
 }

--- a/src/server/routes/cache_tests.rs
+++ b/src/server/routes/cache_tests.rs
@@ -37,7 +37,7 @@ use crate::server::prompt_cache::{
     ApcConfig, ApcHashAlgo, CacheEntry, MultimodalDigest, PromptCacheConfig, PromptCacheKey,
     PromptCacheStore,
 };
-use crate::server::routes::cache::{CacheResetResponse, CacheStatsResponse};
+use crate::server::routes::cache::{CacheResetResponse, CacheStatsResponse, PagedBlockStats};
 
 fn enabled_store() -> Arc<PromptCacheStore> {
     let cfg = PromptCacheConfig::new(true, 1 << 20, 32, Duration::from_secs(3600), 4);
@@ -98,6 +98,13 @@ fn cache_stats_response_serializes_with_expected_keys() {
         total_blocks_stored: 6,
         unique_block_hashes: 5,
         apc_active_entries: 3,
+        paged_block_size: 32,
+        paged_blocks_allocated: 100,
+        paged_blocks_live: 80,
+        paged_blocks_free: 20,
+        paged_bytes_reserved: 65536,
+        paged_bytes_in_use: 49152,
+        paged_block_budget: 128,
     };
     let json = serde_json::to_string(&resp).expect("serialize");
     for key in [
@@ -119,6 +126,13 @@ fn cache_stats_response_serializes_with_expected_keys() {
         "\"total_blocks_stored\":6",
         "\"unique_block_hashes\":5",
         "\"apc_active_entries\":3",
+        "\"paged_block_size\":32",
+        "\"paged_blocks_allocated\":100",
+        "\"paged_blocks_live\":80",
+        "\"paged_blocks_free\":20",
+        "\"paged_bytes_reserved\":65536",
+        "\"paged_bytes_in_use\":49152",
+        "\"paged_block_budget\":128",
     ] {
         assert!(json.contains(key), "expected `{key}` in: {json}");
     }
@@ -205,6 +219,13 @@ fn cache_stats_response_disabled_payload_uses_zero_counters() {
         total_blocks_stored: 0,
         unique_block_hashes: 0,
         apc_active_entries: 0,
+        paged_block_size: 0,
+        paged_blocks_allocated: 0,
+        paged_blocks_live: 0,
+        paged_blocks_free: 0,
+        paged_bytes_reserved: 0,
+        paged_bytes_in_use: 0,
+        paged_block_budget: 0,
     };
     assert!(!resp.enabled);
     assert!(!resp.apc_enabled);
@@ -214,6 +235,77 @@ fn cache_stats_response_disabled_payload_uses_zero_counters() {
     assert_eq!(resp.total_blocks_stored, 0);
     assert_eq!(resp.unique_block_hashes, 0);
     assert_eq!(resp.apc_active_entries, 0);
+    // Paged pool defaults to all-zero when no worker reported gauges.
+    assert_eq!(resp.paged_block_size, 0);
+    assert_eq!(resp.paged_block_budget, 0);
+}
+
+#[test]
+fn build_stats_response_surfaces_paged_pool_independent_of_store() {
+    // The paged block-pool gauges come from observability, not the prompt
+    // cache, so they must appear whether or not a store is present (#122 c).
+    let paged = PagedBlockStats {
+        block_size: 32,
+        blocks_allocated: 200,
+        blocks_live: 150,
+        blocks_free: 50,
+        bytes_reserved: 131072,
+        bytes_in_use: 98304,
+        block_budget: 256,
+    };
+    let cfg = PromptCacheConfig::default();
+
+    // None store (prompt cache disabled) still reports the live paged pool.
+    let disabled = super::super::cache::build_stats_response(None, &cfg, paged);
+    assert!(!disabled.enabled);
+    assert_eq!(disabled.paged_block_size, 32);
+    assert_eq!(disabled.paged_blocks_live, 150);
+    assert_eq!(disabled.paged_block_budget, 256);
+    // Acquirable headroom under the cap = budget - live.
+    assert_eq!(
+        disabled.paged_block_budget - disabled.paged_blocks_live,
+        106
+    );
+
+    // With a live store the same paged values flow through unchanged.
+    let store = enabled_store();
+    let enabled = super::super::cache::build_stats_response(Some(store.as_ref()), &cfg, paged);
+    assert_eq!(enabled.paged_blocks_allocated, 200);
+    assert_eq!(enabled.paged_bytes_in_use, 98304);
+    assert_eq!(enabled.paged_block_budget, 256);
+}
+
+#[test]
+fn paged_block_stats_projects_from_observability_snapshot() {
+    // The full data path the handler uses: scheduler `update_gauges` →
+    // snapshot → `PagedBlockStats::from_observability` (#122 c).
+    use crate::server::batch::BatchObservability;
+    use mlxcel_core::cache::PagedCacheStats;
+
+    let obs = BatchObservability::new();
+    obs.update_gauges(
+        2,
+        0,
+        2,
+        4096,
+        32,
+        Some(PagedCacheStats {
+            allocated_blocks: 10,
+            live_blocks: 7,
+            free_blocks: 3,
+            bytes_reserved: 4096,
+            bytes_in_use: 2048,
+        }),
+        16, // block budget
+    );
+    let paged = PagedBlockStats::from_observability(&obs.snapshot());
+    assert_eq!(paged.block_size, 32);
+    assert_eq!(paged.blocks_allocated, 10);
+    assert_eq!(paged.blocks_live, 7);
+    assert_eq!(paged.blocks_free, 3);
+    assert_eq!(paged.bytes_reserved, 4096);
+    assert_eq!(paged.bytes_in_use, 2048);
+    assert_eq!(paged.block_budget, 16);
 }
 
 #[test]
@@ -241,7 +333,7 @@ fn hit_rate_handles_zero_lookups_without_nan() {
 #[test]
 fn build_stats_response_disabled_when_store_is_none() {
     let cfg = PromptCacheConfig::default();
-    let resp = super::super::cache::build_stats_response(None, &cfg);
+    let resp = super::super::cache::build_stats_response(None, &cfg, PagedBlockStats::default());
     assert!(!resp.enabled);
     assert!(!resp.apc_enabled);
     assert_eq!(resp.entries, 0);
@@ -261,7 +353,11 @@ fn build_stats_response_reflects_live_store() {
     let entry = CacheEntry::new_for_test(toks.clone(), 1024);
     store.insert(&key, entry).expect("insert");
 
-    let resp = super::super::cache::build_stats_response(Some(store.as_ref()), &cfg);
+    let resp = super::super::cache::build_stats_response(
+        Some(store.as_ref()),
+        &cfg,
+        PagedBlockStats::default(),
+    );
     assert!(resp.enabled);
     assert!(!resp.apc_enabled, "APC opt-in defaults to off");
     assert_eq!(resp.entries, 1);
@@ -298,7 +394,11 @@ fn build_stats_response_reflects_apc_blocks_when_enabled() {
         )
         .expect("insert b");
 
-    let resp = super::super::cache::build_stats_response(Some(store.as_ref()), &cfg);
+    let resp = super::super::cache::build_stats_response(
+        Some(store.as_ref()),
+        &cfg,
+        PagedBlockStats::default(),
+    );
     assert!(resp.enabled);
     assert!(resp.apc_enabled, "APC must be enabled in this fixture");
     assert_eq!(resp.entries, 2);
@@ -329,7 +429,11 @@ fn build_stats_response_apc_zero_when_disabled_with_inserts() {
             )
             .expect("insert");
     }
-    let resp = super::super::cache::build_stats_response(Some(store.as_ref()), &cfg);
+    let resp = super::super::cache::build_stats_response(
+        Some(store.as_ref()),
+        &cfg,
+        PagedBlockStats::default(),
+    );
     assert!(!resp.apc_enabled);
     assert_eq!(resp.entries, 3);
     assert_eq!(resp.apc_active_entries, 0);
@@ -371,7 +475,11 @@ fn apc_unique_block_hashes_reflects_dedup_potential() {
         )
         .expect("insert b");
 
-    let resp = super::super::cache::build_stats_response(Some(store.as_ref()), &cfg);
+    let resp = super::super::cache::build_stats_response(
+        Some(store.as_ref()),
+        &cfg,
+        PagedBlockStats::default(),
+    );
     assert_eq!(resp.entries, 2);
     assert_eq!(resp.apc_active_entries, 2);
     assert_eq!(resp.total_blocks_stored, 4);
@@ -446,6 +554,7 @@ async fn router_returns_stats_and_reset_with_correct_methods() {
         AxumJson(super::super::cache::build_stats_response(
             Some(s.store.as_ref()),
             s.cfg.as_ref(),
+            PagedBlockStats::default(),
         ))
     }
     async fn reset_handler(

--- a/src/server/routes/metrics.rs
+++ b/src/server/routes/metrics.rs
@@ -160,6 +160,9 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
          # HELP mlxcel_cache_pool_paged_bytes_in_use Visible bytes in use across paged sequences\n\
          # TYPE mlxcel_cache_pool_paged_bytes_in_use gauge\n\
          mlxcel_cache_pool_paged_bytes_in_use {paged_bytes_in_use}\n\
+         # HELP mlxcel_cache_pool_paged_block_budget Configured paged KV block-budget cap (0 = unbounded)\n\
+         # TYPE mlxcel_cache_pool_paged_block_budget gauge\n\
+         mlxcel_cache_pool_paged_block_budget {paged_block_budget}\n\
          # HELP mlxcel_decode_storage_fallbacks_total Number of paged decode fallback events\n\
          # TYPE mlxcel_decode_storage_fallbacks_total counter\n\
          mlxcel_decode_storage_fallbacks_total {decode_storage_fallbacks}\n\
@@ -207,6 +210,7 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
         paged_blocks_free = obs.cache_pool_paged_blocks_free,
         paged_bytes_reserved = obs.cache_pool_paged_bytes_reserved,
         paged_bytes_in_use = obs.cache_pool_paged_bytes_in_use,
+        paged_block_budget = obs.cache_pool_paged_block_budget,
         decode_storage_fallbacks = obs.decode_storage_fallbacks,
         pc_hits = pc_hits,
         pc_misses = pc_misses,


### PR DESCRIPTION
## Summary

Sub-step **c** — the **final piece of #122** (Phase 5: block-budget admission, eviction, preemption). b1/b2/b3 built the budget mechanism + activation; this surfaces the pool's block-level usage so operators can observe admission headroom and eviction under pressure.

## What changed

**`GET /v1/cache/stats`** gains seven paged block-pool fields:

| field | meaning |
|---|---|
| `paged_block_size` | block size in tokens (`0` = no paged pool) |
| `paged_blocks_allocated` | rows minted into the pool |
| `paged_blocks_live` | blocks held by live sequences |
| `paged_blocks_free` | freed blocks retained for reuse |
| `paged_bytes_reserved` / `paged_bytes_in_use` | byte footprint |
| `paged_block_budget` | configured cap (`0` = unbounded) |

Sourced from the batch observability snapshot (not the prompt-cache store), so they stay meaningful even with the prompt cache disabled — paged decode runs independently. `paged_block_budget - paged_blocks_live` is the acquirable headroom before eviction / preemption.

**`/metrics`** gains `mlxcel_cache_pool_paged_block_budget` — the one paged datum that wasn't already a gauge. Added through `BatchObservability` (recorded each scheduler tick from `CachePool::paged_block_budget`); the allocated / live / free block + byte gauges already existed.

## #122 completion

| task / acceptance criterion | where |
|---|---|
| Admit / queue on free-block count + preemption | b2 |
| LRU/TTL eviction releasing physical blocks | a + b2 |
| Recompute-on-preempt | pre-existing, wired b2 |
| Surface pool usage in `/v1/cache/stats` + Prometheus | **c (this PR)** |
| AC: evict cold prefixes & admit without OOM | b2 + b3, tested |
| AC: metrics report block-level usage | gauges + c |

## Test plan

- `cargo build` + **cold** `cargo clippy -D warnings` + `cargo fmt --all --check` — clean
- `cargo test`: routes::cache 17 (3 new), batch::observability 6 (budget assertion), batch::scheduler_prompt_cache 21, server::batch 181, prompt_cache::apc_integration 9 — all green
- New tests: `build_stats_response_surfaces_paged_pool_independent_of_store`, `paged_block_stats_projects_from_observability_snapshot`, serialization-key coverage for the seven fields; admit-under-pressure / no-leak via the existing `evicting_cold_prefix_restores_paged_block_budget`

Closes #122.
