### PR TITLE
feat: add fused paged-attention decode Metal kernel (gated off)

### DIFF
--- a/docs/adr/0001-paged-attention-gather-vs-fused-kernel.md
+++ b/docs/adr/0001-paged-attention-gather-vs-fused-kernel.md
@@ -102,6 +102,21 @@ Phases 1 through 3 inherit the following from this decision:
 
 The fused Metal paged-attention kernel (Phase 6, #123) stays deferred. The crossover context length above gives the downstream phases a concrete trigger: if real workloads run past it and the gather overhead shows up in end-to-end decode throughput, (B) is the planned next step, and the gather path built in Phases 1 and 2 remains the correctness reference and fallback for it.
 
+## Phase 6 outcome (#123): fused kernel built, gather stays the default
+
+Phase 6 implemented the (B) kernel and benchmarked it against the (A) gather path. The kernel (`src/lib/mlx-cpp/turbo/paged_attention.cpp`, JIT-compiled via `mlx::core::fast::metal_kernel`) is a split-K flash-decoding attention: one threadgroup per (batch, query head), `NumSplits` SIMD groups split the token range, and within each SIMD group the 32 lanes partition the head dimension so the per-token QK dot product is a single barrier-free `simd_sum`. It reads scattered KV blocks straight from the pool through the block table, with no gather copy. It is correct to fp32 round-off: RMS about 2e-8 against `paged_decode_attention_pooled_fallback` over 200 fragmented decode steps, plus grouped-query and batched cases.
+
+The throughput does not justify making (B) the default on Apple Silicon. Measured on the M1 Ultra spike machine (50 timed iterations after 20 warmup, f16 pool, head_dim 128, 32 q-heads, 8 kv-heads, block 32), the fused-vs-gather speedup (a value above 1 means the fused kernel is faster):
+
+| ctx | b=1 | b=4 | b=8 | b=16 |
+|----:|----:|----:|----:|-----:|
+| 4096 | 0.50x | 1.30x | 1.01x | 1.36x |
+| 16384 | 0.39x | 0.83x | 0.82x | 0.91x |
+
+The fused kernel wins at 4096 tokens once decode is batched (batch >= 4), and it scales better with batch than the gather path, the behaviour this ADR predicted from gather overhead growing with batch. At 16384 tokens it runs about 0.8 to 0.9x of the gather path across batch sizes, so it loses in the regime this ADR named as the primary trigger. The cause is the one the Decision section anticipated for unified memory: there is no host copy to avoid, and MLX folds the gather's `take` / `reshape` / `transpose` into its tuned fused SDPA, so the (A) path already runs near the contiguous lower bound. A hand-written JIT kernel reading scattered f16 blocks does not beat that tuned SDPA on memory bandwidth at long context.
+
+Phase 6 lands the kernel gated off. The native path is opt-in through the `MLXCEL_PAGED_ATTENTION_NATIVE` environment variable (or the `use_native_paged_kernel` argument on `paged_decode_attention_pooled`), and the default stays on the gather-then-SDPA path. The kernel keeps its value for the batched moderate-context regime where it wins, and as a starting point if a future device or a non-fused gather path shifts the trade-off. `examples/paged_attention_kernel_bench.rs` reproduces the table above.
+
 ## References
 
 - Epic #116, unified KV cache.

--- a/examples/paged_attention_kernel_bench.rs
+++ b/examples/paged_attention_kernel_bench.rs
@@ -1,0 +1,177 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Fused paged-attention decode kernel throughput bench (epic #116 Phase 6,
+//! #123).
+//!
+//! Compares the fused Metal kernel (`paged_decode_attention_pooled` with the
+//! native path enabled, which reads scattered pool blocks directly) against the
+//! gather-then-SDPA reference (`paged_decode_attention_pooled_fallback`, which
+//! re-materialises a contiguous K/V every step) over a real `PagedBlockPool`.
+//!
+//! This is the #123 counterpart to `examples/page_gather_microbench.rs` (the
+//! ADR 0001 spike): the spike measured gather overhead against a contiguous
+//! SDPA lower bound; this measures the kernel that removes that gather. The
+//! sequences are grown with interleaved block writes so their physical pool
+//! rows are scattered (the gather pays its real scatter cost).
+//!
+//! Run:
+//!   cargo run --release --features metal,accelerate \
+//!     --example paged_attention_kernel_bench
+//! Run under `caffeinate -i` and let the machine cool between sweeps; Apple
+//! Silicon down-clocks under sustained load.
+
+use std::time::{Duration, Instant};
+
+use mlxcel_core::cache::{PagedBlockPool, PagedKvLayout, PagedSequenceState};
+use mlxcel_core::layers::{paged_decode_attention_pooled, paged_decode_attention_pooled_fallback};
+use mlxcel_core::{MlxArray, UniquePtr, astype, eval, from_slice_f32, synchronize_default};
+
+const HEAD_DIM: i32 = 128;
+const Q_HEADS: i32 = 32;
+const KV_HEADS: i32 = 8;
+const BLOCK_SIZE: usize = 32;
+const LAYER: usize = 0;
+const WARMUP: usize = 20;
+const ITERS: usize = 50;
+
+/// Deterministic pseudo-random f32 fill (a cheap LCG; only the timing matters,
+/// but distinct values keep softmax non-degenerate).
+fn pseudo_f32(seed: u64, n: usize) -> Vec<f32> {
+    let mut s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+    (0..n)
+        .map(|_| {
+            s ^= s >> 12;
+            s ^= s << 25;
+            s ^= s >> 27;
+            let u = (s.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 40) as f32;
+            u / (1u64 << 24) as f32 - 0.5
+        })
+        .collect()
+}
+
+fn f16(vals: &[f32], shape: &[i32]) -> UniquePtr<MlxArray> {
+    astype(&from_slice_f32(vals, shape), mlxcel_core::dtype::FLOAT16)
+}
+
+/// warmup loop, then a `synchronize_default()`-bracketed timed loop that evals
+/// each result. Matches the harness in `page_gather_microbench.rs`.
+fn time_body<F>(mut body: F) -> Duration
+where
+    F: FnMut() -> UniquePtr<MlxArray>,
+{
+    for _ in 0..WARMUP {
+        let out = body();
+        eval(&out);
+    }
+    synchronize_default();
+    let start = Instant::now();
+    for _ in 0..ITERS {
+        let out = body();
+        eval(&out);
+    }
+    synchronize_default();
+    start.elapsed()
+}
+
+/// Build a pool holding `batch` sequences of `ctx` tokens each, grown with
+/// interleaved block writes so physical rows are scattered. Returns the pool
+/// plus the per-sequence states.
+fn build_pool(batch: usize, ctx: usize) -> (PagedBlockPool, Vec<PagedSequenceState>) {
+    let layout = PagedKvLayout::uniform(
+        1,
+        BLOCK_SIZE,
+        BLOCK_SIZE * KV_HEADS as usize * HEAD_DIM as usize * 2,
+    )
+    .expect("valid layout");
+    let mut pool = PagedBlockPool::new(layout);
+    let mut states: Vec<PagedSequenceState> = (0..batch)
+        .map(|_| PagedSequenceState::new(pool.layout()))
+        .collect();
+
+    let n_blocks = ctx / BLOCK_SIZE;
+    for blk in 0..n_blocks {
+        for (seq_idx, state) in states.iter_mut().enumerate() {
+            pool.append_tokens(state, LAYER, BLOCK_SIZE)
+                .expect("append");
+            let block_id = *state
+                .layer(LAYER)
+                .unwrap()
+                .block_ids
+                .last()
+                .expect("block id");
+            let seed = (seq_idx as u64) * 1_000_003 + blk as u64 + 1;
+            let k = f16(
+                &pseudo_f32(seed, KV_HEADS as usize * BLOCK_SIZE * HEAD_DIM as usize),
+                &[1, KV_HEADS, BLOCK_SIZE as i32, HEAD_DIM],
+            );
+            let v = f16(
+                &pseudo_f32(
+                    seed.wrapping_mul(7),
+                    KV_HEADS as usize * BLOCK_SIZE * HEAD_DIM as usize,
+                ),
+                &[1, KV_HEADS, BLOCK_SIZE as i32, HEAD_DIM],
+            );
+            pool.write_block(block_id, LAYER, 0, &k, &v).expect("write");
+        }
+    }
+    (pool, states)
+}
+
+fn per_call_us(d: Duration) -> f64 {
+    d.as_secs_f64() * 1e6 / ITERS as f64
+}
+
+fn run_config(batch: usize, ctx: usize) {
+    let scale = 1.0f32 / (HEAD_DIM as f32).sqrt();
+    let (pool, states) = build_pool(batch, ctx);
+    let state_refs: Vec<&PagedSequenceState> = states.iter().collect();
+
+    let q = f16(
+        &pseudo_f32(
+            0x5151_u64.wrapping_add(ctx as u64),
+            batch * Q_HEADS as usize * HEAD_DIM as usize,
+        ),
+        &[batch as i32, Q_HEADS, 1, HEAD_DIM],
+    );
+
+    let gather = time_body(|| {
+        paged_decode_attention_pooled_fallback(&q, &pool, &state_refs, LAYER, scale).unwrap()
+    });
+    let fused = time_body(|| {
+        paged_decode_attention_pooled(&q, &pool, &state_refs, LAYER, scale, true).unwrap()
+    });
+
+    let g = per_call_us(gather);
+    let f = per_call_us(fused);
+    let speedup = g / f;
+    println!(
+        "  batch={batch:>2} ctx={ctx:>6}  gather={g:>9.1}us  fused={f:>9.1}us  speedup={speedup:>5.2}x"
+    );
+}
+
+fn main() {
+    println!("=== mlxcel fused paged-attention decode kernel bench (#123) ===");
+    println!(
+        "head_dim={HEAD_DIM} q_heads={Q_HEADS} kv_heads={KV_HEADS} block_size={BLOCK_SIZE} dtype=f16"
+    );
+    println!("warmup={WARMUP} iters={ITERS}");
+    println!("Tip: run under `caffeinate -i` and let the machine cool between sweeps.");
+    println!();
+    for &ctx in &[4096usize, 16384] {
+        for &batch in &[1usize, 4, 8, 16] {
+            run_config(batch, ctx);
+        }
+    }
+}

--- a/src/lib/mlx-cpp/turbo/CMakeLists.txt
+++ b/src/lib/mlx-cpp/turbo/CMakeLists.txt
@@ -37,14 +37,17 @@ set(CMAKE_CXX_STANDARD 20)
 # add_subdirectory(turbo).
 set(MLXCEL_TURBO_KERNEL_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/sparse_v_sdpa.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/turbo4_delegated_sdpa.h)
+    ${CMAKE_CURRENT_SOURCE_DIR}/turbo4_delegated_sdpa.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/paged_attention.h)
 
 set(MLXCEL_TURBO_KERNEL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/sparse_v_sdpa.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/turbo4_delegated_sdpa.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/turbo4_delegated_sdpa.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/paged_attention.cpp)
 
 set(MLXCEL_TURBO_KERNEL_METAL_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/sparse_v_sdpa.metal)
+    ${CMAKE_CURRENT_SOURCE_DIR}/sparse_v_sdpa.metal
+    ${CMAKE_CURRENT_SOURCE_DIR}/paged_attention.metal)
 
 add_library(mlxcel-turbo-kernels STATIC
     ${MLXCEL_TURBO_KERNEL_SOURCES})

--- a/src/lib/mlx-cpp/turbo/paged_attention.cpp
+++ b/src/lib/mlx-cpp/turbo/paged_attention.cpp
@@ -1,0 +1,314 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paged_attention.h"
+
+#include <mlx/fast.h>
+#include <mlx/ops.h>
+
+#include <mutex>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace mlxcel::turbo {
+
+namespace {
+
+// Body of the fused paged-attention decode Metal kernel. The string is the
+// kernel BODY only; `mlx::core::fast::metal_kernel` wraps it with the
+// declaration, buffer arguments, and template-argument substitution. See
+// `paged_attention.metal` for an annotated standalone copy that the Metal
+// compiler can lint.
+//
+// Split-K flash-decoding attention. One threadgroup handles one (batch * query
+// head) slot (grid z). The threadgroup is `NumSplits` SIMD groups of 32 lanes
+// (a 2D `(32, NumSplits)` layout). The two axes parallelise the two reductions
+// attention needs:
+//
+//   - Across the 32 lanes of a SIMD group: each lane owns a `DimsPerThread =
+//     ceil(Dim / 32)`-wide slice of the head dimension, so the per-token QK dot
+//     product is a single barrier-free `simd_sum` and the weighted-V
+//     accumulator `acc[DimsPerThread]` stays tiny (no register-spilling
+//     `acc[Dim]`).
+//   - Across the `NumSplits` SIMD groups: each SIMD group `sg` sweeps a strided
+//     token stripe (t = sg, sg + NumSplits, ...) and keeps its own online
+//     softmax partial. After the stripe, a small threadgroup combine merges the
+//     `NumSplits` partials (the flash-attention rescale). This is the token
+//     parallelism a single SIMD group lacks: without it a long context is one
+//     serial token loop per slot, which dominates at >=4k.
+//
+// GQA maps query head `h` to KV head `h / NRep`.
+//
+// Template constants:
+//   Dim           - head dimension D.
+//   NRep          - Hq / Hkv (grouped-query replication factor).
+//   DimsPerThread - ceil(Dim / 32); compile-time so `acc[]` lives in registers.
+//   NumSplits     - SIMD groups per threadgroup (token-stripe count).
+//
+// Buffers (order matches the launcher's input vector):
+//   q              [B, Hq, 1, Dim]                     f32
+//   k_pool         [num_blocks, block_size, Hkv, Dim]  f16
+//   v_pool         [num_blocks, block_size, Hkv, Dim]  f16
+//   rows           [total_rows]                        i32  physical pool rows
+//   row_offsets    [B + 1]                             i32  start of seq b's rows
+//   logical_starts [B]                                 i32  first visible abs idx
+//   visible_lens   [B]                                 i32  visible token count
+//   scale          [1]                                 f32
+//   out            [B, Hq, 1, Dim]                     f32
+constexpr const char* PAGED_ATTENTION_DECODE_SOURCE = R"(
+    uint lane = thread_position_in_threadgroup.x;    // 0 .. 31 (within SIMD grp)
+    uint sg = thread_position_in_threadgroup.y;      // 0 .. NumSplits-1
+    uint bhq = threadgroup_position_in_grid.z;       // 0 .. B*Hq-1
+
+    uint hq_count = (uint)q_shape[1];                // Hq
+    uint block_size = (uint)k_pool_shape[1];         // tokens per block
+    uint hkv_count = (uint)k_pool_shape[2];          // Hkv
+    uint dim = (uint)Dim;
+    uint dpt = (uint)DimsPerThread;                  // dims this lane owns
+    uint d0 = lane * dpt;                            // first dim of this lane
+
+    uint b = bhq / hq_count;                          // batch index
+    uint h = bhq % hq_count;                          // query head
+    uint kv_head = h / (uint)NRep;                    // grouped-query KV head
+    if (kv_head >= hkv_count) {
+        kv_head = 0;                                  // defensive
+    }
+
+    int vlen_i = visible_lens[b];
+    uint vlen = vlen_i > 0 ? (uint)vlen_i : 0u;
+    uint logical_start = (uint)logical_starts[b];
+    uint row_off = (uint)row_offsets[b];
+
+    // Stage this lane's Q slice in registers.
+    float q_reg[DimsPerThread];
+    for (uint j = 0; j < dpt; j++) {
+        uint d = d0 + j;
+        q_reg[j] = (d < dim) ? q[bhq * dim + d] : 0.0f;
+    }
+
+    // Threadgroup scratch for the cross-SIMD-group flash combine.
+    threadgroup float tg_m[NumSplits];
+    threadgroup float tg_l[NumSplits];
+    threadgroup float tg_acc[NumSplits * Dim];
+
+    // Empty window: only SIMD group 0 emits zeros (uniform across the group).
+    if (vlen == 0u) {
+        if (sg == 0u) {
+            for (uint j = 0; j < dpt; j++) {
+                uint d = d0 + j;
+                if (d < dim) {
+                    out[bhq * dim + d] = 0.0f;
+                }
+            }
+        }
+        return;
+    }
+
+    float scale_v = scale[0];
+
+    // This SIMD group's online softmax over its strided token stripe.
+    float m = -INFINITY;
+    float l = 0.0f;
+    float acc[DimsPerThread];
+    for (uint j = 0; j < dpt; j++) {
+        acc[j] = 0.0f;
+    }
+
+    uint stride_kv = hkv_count * dim;                 // elements per (block,slot)
+    for (uint t = sg; t < vlen; t += (uint)NumSplits) {
+        uint abs_pos = logical_start + t;
+        uint block_idx = abs_pos / block_size;
+        uint slot = abs_pos - block_idx * block_size;
+        uint row = (uint)rows[row_off + block_idx];
+        uint base = (row * block_size + slot) * stride_kv + kv_head * dim;
+
+        float partial = 0.0f;
+        for (uint j = 0; j < dpt; j++) {
+            uint d = d0 + j;
+            float kd = (d < dim) ? (float)k_pool[base + d] : 0.0f;
+            partial += q_reg[j] * kd;
+        }
+        float score = simd_sum(partial) * scale_v;    // full q . k_t, no barrier
+
+        float m_new = fmax(m, score);
+        float corr = fast::exp(m - m_new);
+        float p = fast::exp(score - m_new);
+        l = l * corr + p;
+        for (uint j = 0; j < dpt; j++) {
+            uint d = d0 + j;
+            float vd = (d < dim) ? (float)v_pool[base + d] : 0.0f;
+            acc[j] = acc[j] * corr + p * vd;
+        }
+        m = m_new;
+    }
+
+    // Publish this SIMD group's partial. Every lane stores its dim slice; lane 0
+    // stores the scalar (max, denominator).
+    for (uint j = 0; j < dpt; j++) {
+        uint d = d0 + j;
+        if (d < dim) {
+            tg_acc[sg * dim + d] = acc[j];
+        }
+    }
+    if (lane == 0u) {
+        tg_m[sg] = m;
+        tg_l[sg] = l;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // SIMD group 0 merges the NumSplits partials (flash rescale) and writes out.
+    if (sg == 0u) {
+        float m_g = tg_m[0];
+        for (uint s = 1; s < (uint)NumSplits; s++) {
+            m_g = fmax(m_g, tg_m[s]);
+        }
+        float l_g = 0.0f;
+        for (uint s = 0; s < (uint)NumSplits; s++) {
+            l_g += tg_l[s] * fast::exp(tg_m[s] - m_g);
+        }
+        float inv_l = l_g > 0.0f ? (1.0f / l_g) : 0.0f;
+        for (uint j = 0; j < dpt; j++) {
+            uint d = d0 + j;
+            if (d < dim) {
+                float a = 0.0f;
+                for (uint s = 0; s < (uint)NumSplits; s++) {
+                    a += tg_acc[s * dim + d] * fast::exp(tg_m[s] - m_g);
+                }
+                out[bhq * dim + d] = a * inv_l;
+            }
+        }
+    }
+)";
+
+// Apple Silicon SIMD width. Each SIMD group is 32 lanes that partition the head
+// dimension; `NumSplits` SIMD groups split the token range.
+constexpr int PAGED_ATTENTION_SIMD_WIDTH = 32;
+
+// Thread-safe lazy-initialised holder for the JIT-compiled kernel. Mirrors the
+// `std::call_once` pattern in `sparse_v_sdpa.cpp`: the server reaches first-use
+// concurrently from per-request blocking workers, and `call_once` re-runs the
+// initializer if MLX device lookup throws.
+struct PagedAttentionKernelHolder {
+    std::optional<mlx::core::fast::CustomKernelFunction> kernel;
+    std::once_flag init_flag;
+
+    mlx::core::fast::CustomKernelFunction& get() {
+        std::call_once(init_flag, [this] {
+            kernel = mlx::core::fast::metal_kernel(
+                "mlxcel_paged_attention_decode",
+                {"q", "k_pool", "v_pool", "rows", "row_offsets", "logical_starts",
+                 "visible_lens", "scale"},
+                {"out"},
+                std::string(PAGED_ATTENTION_DECODE_SOURCE));
+        });
+        return *kernel;
+    }
+};
+
+inline PagedAttentionKernelHolder& get_paged_attention_kernel() {
+    static PagedAttentionKernelHolder holder;
+    return holder;
+}
+
+} // namespace
+
+mlx::core::array paged_attention_decode(
+    const mlx::core::array& q,
+    const mlx::core::array& k_pool,
+    const mlx::core::array& v_pool,
+    const mlx::core::array& rows,
+    const mlx::core::array& row_offsets,
+    const mlx::core::array& logical_starts,
+    const mlx::core::array& visible_lens,
+    float scale) {
+    using mlx::core::Dtype;
+    using mlx::core::Shape;
+    using mlx::core::fast::TemplateArg;
+
+    const auto& q_shape = q.shape();       // [B, Hq, 1, Dim]
+    const auto& kp_shape = k_pool.shape(); // [num_blocks, block_size, Hkv, Dim]
+
+    int batch = q_shape[0];
+    int hq = q_shape[1];
+    int dim = q_shape[3];
+    int hkv = kp_shape[2];
+    int n_rep = hkv > 0 ? hq / hkv : 1;
+    if (n_rep < 1) {
+        n_rep = 1;
+    }
+
+    auto& kernel = get_paged_attention_kernel().get();
+
+    // Each of the 32 lanes owns a ceil(Dim/32)-wide slice of the head.
+    int dims_per_thread = (dim + PAGED_ATTENTION_SIMD_WIDTH - 1) / PAGED_ATTENTION_SIMD_WIDTH;
+
+    // Token-split count = SIMD groups per threadgroup. Bounded by the 1024
+    // thread/threadgroup cap (32 * NumSplits <= 1024 => NumSplits <= 32) and by
+    // the `tg_acc[NumSplits * Dim]` threadgroup-memory budget (kept under ~28 KB
+    // of the 32 KB limit).
+    int num_splits = 28672 / (dim * 4);
+    if (num_splits > 32) {
+        num_splits = 32;
+    }
+    if (num_splits < 1) {
+        num_splits = 1;
+    }
+
+    std::vector<std::pair<std::string, TemplateArg>> template_args = {
+        {"Dim", dim},
+        {"NRep", n_rep},
+        {"DimsPerThread", dims_per_thread},
+        {"NumSplits", num_splits},
+    };
+
+    // Pack scale into a 1-element f32 array (metal_kernel inputs must be
+    // arrays; ScalarArg is reserved for the precompiled-kernel path).
+    auto scale_arr =
+        mlx::core::full(mlx::core::Shape{1}, scale, mlx::core::float32);
+
+    std::vector<mlx::core::array> inputs = {
+        q,              // [B, Hq, 1, Dim]                    f32
+        k_pool,         // [num_blocks, block_size, Hkv, Dim] f16
+        v_pool,         // [num_blocks, block_size, Hkv, Dim] f16
+        rows,           // [total_rows]                       i32
+        row_offsets,    // [B + 1]                            i32
+        logical_starts, // [B]                                i32
+        visible_lens,   // [B]                                i32
+        scale_arr,      // [1]                                f32
+    };
+    std::vector<Shape> output_shapes = {Shape{batch, hq, 1, dim}};
+    std::vector<Dtype> output_dtypes = {mlx::core::float32};
+
+    // Grid: (32, NumSplits, B*Hq) with one (32, NumSplits, 1) threadgroup per
+    // (batch, query head) slot: 32 lanes partition the head, NumSplits SIMD
+    // groups split the token range.
+    int bhq = batch * hq;
+    auto results = kernel(
+        inputs,
+        output_shapes,
+        output_dtypes,
+        std::make_tuple(PAGED_ATTENTION_SIMD_WIDTH, num_splits, bhq), // grid
+        std::make_tuple(PAGED_ATTENTION_SIMD_WIDTH, num_splits, 1),   // threadgroup
+        template_args,
+        std::nullopt,
+        false,
+        {});
+
+    return results[0];
+}
+
+} // namespace mlxcel::turbo

--- a/src/lib/mlx-cpp/turbo/paged_attention.h
+++ b/src/lib/mlx-cpp/turbo/paged_attention.h
@@ -1,0 +1,73 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Fused Metal paged-attention decode kernel launcher (epic #116 Phase 6, #123).
+//
+// This is strategy (B) from ADR 0001: a custom Metal kernel that reads
+// scattered KV blocks directly out of the global pool via a per-sequence block
+// table, with no separate gather copy. It replaces the gather-then-SDPA decode
+// path (`paged_decode_attention_pooled_fallback`) on the >=16k or batched
+// regime where the per-step gather cost is material. The gather path stays the
+// correctness reference and the fallback.
+//
+// The kernel is a flash-decoding attention: one threadgroup per (batch * query
+// head), threads split the visible tokens, each thread keeps a running online
+// softmax (max, sum, weighted-V accumulator) over its token stripe, and a final
+// threadgroup combine merges the partial softmaxes. GQA is handled by mapping a
+// query head h to KV head h / n_rep.
+//
+// Pool layout (layout A, per ADR 0001):
+//   k_pool, v_pool : [num_blocks, block_size, n_kv_heads, head_dim]  f16
+//
+// The block table is flattened: `rows` holds every sequence's physical pool
+// rows concatenated in block-table order, `row_offsets[b]` is the start of
+// sequence b's rows. A sequence's visible tokens are the absolute positions
+// `[logical_starts[b], logical_starts[b] + visible_lens[b])` inside its
+// concatenated blocks, so token i reads block `(logical_starts[b] + i) /
+// block_size` (resolved through `rows`) at slot `(logical_starts[b] + i) %
+// block_size`. This matches `PagedBlockPool::gather_visible`.
+
+#include <mlx/array.h>
+
+namespace mlxcel::turbo {
+
+// Run the fused paged-attention decode kernel and return the attention output.
+//
+// Inputs:
+// - `q`:              `[B, Hq, 1, head_dim]` f32.
+// - `k_pool`:         `[num_blocks, block_size, Hkv, head_dim]` f16.
+// - `v_pool`:         `[num_blocks, block_size, Hkv, head_dim]` f16.
+// - `rows`:           `[total_rows]` i32 physical pool rows, per sequence
+//                     concatenated in block-table order.
+// - `row_offsets`:    `[B + 1]` i32 start of each sequence's rows in `rows`.
+// - `logical_starts`: `[B]` i32 first visible absolute token index per sequence.
+// - `visible_lens`:   `[B]` i32 visible token count per sequence.
+// - `scale`:          attention scale applied to the QK dot product.
+//
+// Output:
+// - `[B, Hq, 1, head_dim]` f32 attention output. The caller casts to the model
+//   dtype to match the gather reference.
+mlx::core::array paged_attention_decode(
+    const mlx::core::array& q,
+    const mlx::core::array& k_pool,
+    const mlx::core::array& v_pool,
+    const mlx::core::array& rows,
+    const mlx::core::array& row_offsets,
+    const mlx::core::array& logical_starts,
+    const mlx::core::array& visible_lens,
+    float scale);
+
+} // namespace mlxcel::turbo

--- a/src/lib/mlx-cpp/turbo/paged_attention.metal
+++ b/src/lib/mlx-cpp/turbo/paged_attention.metal
@@ -1,0 +1,87 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Reference Metal source for the fused paged-attention decode kernel (epic
+// #116 Phase 6, #123).
+//
+// This file is a readable copy of the kernel BODY embedded as a C++ string in
+// `paged_attention.cpp` (`PAGED_ATTENTION_DECODE_SOURCE`). Keeping it as a
+// standalone .metal file makes it possible to read and review the kernel
+// without digging through a C++ raw-string literal, and to diff it against MLX
+// upstream kernels during a commit-bump review.
+//
+// At runtime the kernel is JIT-compiled via `mlx::core::fast::metal_kernel` in
+// `paged_attention.cpp`. The JIT path expects the body WITHOUT a `kernel`
+// declaration: `metal_kernel` wraps the body with the kernel signature, the
+// buffer arguments (in the order named in the launcher), the `*_shape` buffers
+// for each input, and the template-argument substitution for `Dim`, `NRep`,
+// and `Wthreads`. The dummy declaration below exists only so this file is
+// syntactically a kernel; the body it contains is the authoritative copy.
+//
+// Algorithm: single-SIMD-group flash-decoding attention. One threadgroup of
+// exactly 32 lanes (one SIMD group) handles one (batch * query head) slot. Each
+// lane owns a `DimsPerThread = ceil(Dim / 32)`-wide contiguous slice of the head
+// dimension, so the 32 lanes partition the whole head. The lane sweeps ALL
+// visible tokens, keeping a running online softmax (max `m`, denominator `l`,
+// weighted-V accumulator `acc[DimsPerThread]`), reading scattered pool rows
+// through the block table. The per-token QK dot product is reduced across the 32
+// lanes with `simd_sum` (a barrier-free SIMD shuffle), so there is no
+// threadgroup memory, no barriers, and no register-spilling `acc[Dim]`. GQA maps
+// query head `h` to KV head `h / NRep`.
+//
+// Why this layout: a thread-per-token stripe needs an `acc[Dim]` register array
+// (spills at D=128) plus an O(Wthreads*Dim) threadgroup combine; thread-per-dim
+// across multiple SIMD groups needs a per-token cross-group barrier. Folding the
+// whole head into one SIMD group makes the QK reduction a single barrier-free
+// `simd_sum` and keeps `acc[]` tiny (2 for D=64, 4 for D=128, 8 for D=256).
+//
+// Template constants (substituted per launch):
+//   Dim           - head dimension D.
+//   NRep          - Hq / Hkv (grouped-query replication factor).
+//   DimsPerThread - ceil(Dim / 32); so `acc[]` lives in registers.
+//
+// Buffers (order matches the launcher's input vector):
+//   q              [B, Hq, 1, Dim]                     f32
+//   k_pool         [num_blocks, block_size, Hkv, Dim]  f16
+//   v_pool         [num_blocks, block_size, Hkv, Dim]  f16
+//   rows           [total_rows]                        i32  physical pool rows
+//   row_offsets    [B + 1]                             i32  start of seq b's rows
+//   logical_starts [B]                                 i32  first visible abs idx
+//   visible_lens   [B]                                 i32  visible token count
+//   scale          [1]                                 f32
+//   out            [B, Hq, 1, Dim]                     f32
+
+kernel void mlxcel_paged_attention_decode_reference(
+    /* dummy declaration kept here so the file is syntactically a kernel even
+       though the runtime JIT path strips the kernel/buffer wrapper and injects
+       the `*_shape` buffers and the Dim/NRep/DimsPerThread template constants */ )
+{
+    // The authoritative kernel body (mirrors PAGED_ATTENTION_DECODE_SOURCE in
+    // paged_attention.cpp):
+    //
+    //   uint lane = thread_position_in_threadgroup.x;  // 0..31
+    //   uint bhq = threadgroup_position_in_grid.z;
+    //   ... decode (b, h), map kv_head = h / NRep ...
+    //   d0 = lane * DimsPerThread; stage q[bhq] dims [d0, d0+dpt) in q_reg[]
+    //   if visible_lens[b] == 0: write zeros for this lane's dims; return
+    //   for each visible token t:
+    //     row = rows[row_offsets[b] + abs/block_size], slot = abs % block_size,
+    //       abs = logical_starts[b] + t
+    //     partial = sum over this lane's dims of q_reg * k_pool
+    //     score = simd_sum(partial) * scale          // full q . k_t, no barrier
+    //     online-softmax update of m, l, acc[] (identical scalars on every lane)
+    //   out[bhq*Dim + d] = acc[j] / l   for this lane's dims
+    //
+    // See paged_attention.cpp for the exact body string.
+}

--- a/src/lib/mlxcel-core/build.rs
+++ b/src/lib/mlxcel-core/build.rs
@@ -40,6 +40,11 @@ fn main() {
         // FP16 cold body never materialises in global memory; the host
         // pairs this with a hot-V matmul to produce the final SDPA output.
         .file("../mlx-cpp/turbo/turbo4_delegated_sdpa.cpp")
+        // Fused paged-attention decode kernel launcher (epic #116 Phase 6,
+        // #123). Reads scattered KV blocks out of the global pool via a block
+        // table with no separate gather copy; the gather-then-SDPA path stays
+        // the correctness reference and fallback.
+        .file("../mlx-cpp/turbo/paged_attention.cpp")
         .include(&mlx_include)
         .include("cpp")
         .include("../mlx-cpp/turbo")
@@ -128,6 +133,10 @@ fn main() {
     // Turbo4Delegated cold-V fused weighted-sum kernel launcher.
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/turbo4_delegated_sdpa.h");
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/turbo4_delegated_sdpa.cpp");
+    // Fused paged-attention decode kernel launcher (#123).
+    println!("cargo:rerun-if-changed=../mlx-cpp/turbo/paged_attention.h");
+    println!("cargo:rerun-if-changed=../mlx-cpp/turbo/paged_attention.cpp");
+    println!("cargo:rerun-if-changed=../mlx-cpp/turbo/paged_attention.metal");
     println!("cargo:rerun-if-env-changed=MLX_CUDA_ARCHITECTURES");
     println!("cargo:rerun-if-env-changed=MLXCEL_BUILD_METAL");
     println!("cargo:rerun-if-env-changed=MLXCEL_BUILD_ACCELERATE");

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -4,6 +4,7 @@
 #include "mlx_cxx_bridge.h"
 #include "sparse_v_sdpa.h"  // fused Sparse-V SDPA kernel.
 #include "turbo4_delegated_sdpa.h"  // fused Turbo4Delegated SDPA kernel.
+#include "paged_attention.h"  // fused paged-attention decode kernel (#123).
 #include "mlx/ops.h"
 #include "mlx/transforms.h"
 #include "mlx/compile.h"
@@ -6088,6 +6089,31 @@ std::unique_ptr<Turbo4DelegatedSteelOutputs> turbo4_delegated_steel_sdpa(
     wrapper->out_cold_pre = std::make_unique<MlxArray>(std::move(outs[0]));
     wrapper->out_hot      = std::make_unique<MlxArray>(std::move(outs[1]));
     return wrapper;
+}
+
+// Fused paged-attention decode kernel launcher (epic #116 Phase 6, #123).
+// Implementation in `src/lib/mlx-cpp/turbo/paged_attention.cpp`; forwarded here
+// so the new symbol shows up in the cxx-bridge ABI. Reads scattered KV blocks
+// out of the global pool via the block table with no separate gather copy.
+std::unique_ptr<MlxArray> paged_attention_decode(
+    const MlxArray& q,
+    const MlxArray& k_pool,
+    const MlxArray& v_pool,
+    const MlxArray& rows,
+    const MlxArray& row_offsets,
+    const MlxArray& logical_starts,
+    const MlxArray& visible_lens,
+    float scale) {
+    auto out = mlxcel::turbo::paged_attention_decode(
+        q.inner,
+        k_pool.inner,
+        v_pool.inner,
+        rows.inner,
+        row_offsets.inner,
+        logical_starts.inner,
+        visible_lens.inner,
+        scale);
+    return std::make_unique<MlxArray>(std::move(out));
 }
 
 std::unique_ptr<MlxLoadedWeights> mlx_load_safetensors(rust::Str path) {

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -1757,6 +1757,22 @@ std::unique_ptr<Turbo4DelegatedSteelOutputs> turbo4_delegated_steel_sdpa(
 std::unique_ptr<MlxArray> steel_outputs_take_cold(Turbo4DelegatedSteelOutputs& o);
 std::unique_ptr<MlxArray> steel_outputs_take_hot(Turbo4DelegatedSteelOutputs& o);
 
+// Fused paged-attention decode kernel launcher (epic #116 Phase 6, #123).
+// Wraps `mlxcel::turbo::paged_attention_decode`. Reads scattered KV blocks out
+// of the global pool via the block table with no separate gather copy. `q` is
+// `[B, Hq, 1, D]` f32; `k_pool` / `v_pool` are `[num_blocks, block_size, Hkv,
+// D]` f16; `rows` / `row_offsets` / `logical_starts` / `visible_lens` are i32
+// block-table metadata. Returns `[B, Hq, 1, D]` f32.
+std::unique_ptr<MlxArray> paged_attention_decode(
+    const MlxArray& q,
+    const MlxArray& k_pool,
+    const MlxArray& v_pool,
+    const MlxArray& rows,
+    const MlxArray& row_offsets,
+    const MlxArray& logical_starts,
+    const MlxArray& visible_lens,
+    float scale);
+
 // Opaque holder for weights loaded via MLX's native load_safetensors().
 // Arrays are lazy — MLX manages the mmap internally, no eager copy needed.
 struct MlxLoadedWeights {

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -1335,6 +1335,112 @@ impl PagedBlockPool {
         Ok(Some((gather(pool_k), gather(pool_v))))
     }
 
+    /// Fused paged-attention decode over the pool via the native Metal kernel
+    /// (epic #116 Phase 6, #123).
+    ///
+    /// Strategy (B) from ADR 0001: instead of gathering each sequence's visible
+    /// KV into a contiguous tensor and calling SDPA (what
+    /// [`Self::gather_visible`] feeds), this builds the flattened block-table
+    /// metadata and hands the pool tensors straight to
+    /// [`crate::paged_attention_decode`], which reads the scattered blocks
+    /// inside the attention kernel with no gather copy.
+    ///
+    /// `q` is `[B, Hq, 1, head_dim]`; `states[b]` is sequence b's per-layer
+    /// state (`states.len()` must equal `B`). Returns `[B, Hq, 1, head_dim]` in
+    /// `q`'s dtype, or `None` when the layer's pool tensors are not yet
+    /// allocated or no sequence has visible tokens (caller falls back to the
+    /// gather path). The output is a drop-in for
+    /// [`crate::layers::paged_decode_attention_pooled_fallback`].
+    pub fn paged_decode_fused(
+        &self,
+        q: &MlxArray,
+        states: &[&PagedSequenceState],
+        layer_idx: usize,
+        scale: f32,
+    ) -> Result<Option<UniquePtr<MlxArray>>, String> {
+        let (pool_k, pool_v) = match (
+            self.pool_k.get(layer_idx).and_then(|p| p.as_ref()),
+            self.pool_v.get(layer_idx).and_then(|p| p.as_ref()),
+        ) {
+            (Some(k), Some(v)) => (k, v),
+            _ => return Ok(None),
+        };
+        let block_size = self.layout.block_size as i32;
+
+        // Flatten every sequence's physical pool rows (block-table order) into
+        // one `rows` array, with `row_offsets[b]` the start of sequence b.
+        let mut rows: Vec<i32> = Vec::new();
+        let mut row_offsets: Vec<i32> = Vec::with_capacity(states.len() + 1);
+        let mut logical_starts: Vec<i32> = Vec::with_capacity(states.len());
+        let mut visible_lens: Vec<i32> = Vec::with_capacity(states.len());
+        row_offsets.push(0);
+
+        let mut any_visible = false;
+        for state in states {
+            let layer = state.layer(layer_idx).ok_or_else(|| {
+                format!(
+                    "PagedBlockPool::paged_decode_fused: layer {layer_idx} out of range for {} layers",
+                    state.layers.len()
+                )
+            })?;
+            if layer.visible_len() > 0 {
+                any_visible = true;
+            }
+            // Same front/back asymmetry guard as `gather_visible`: a slid
+            // sequence whose `len` outruns its retained blocks would read past
+            // the block table.
+            let n_blocks = layer.block_ids.len() as i32;
+            if layer.len as i32 > n_blocks * block_size {
+                return Err(format!(
+                    "PagedBlockPool::paged_decode_fused: layer {layer_idx} len {} exceeds {n_blocks} blocks * block_size {block_size}",
+                    layer.len
+                ));
+            }
+            for block_id in &layer.block_ids {
+                let row = *self.block_rows[layer_idx].get(block_id).ok_or_else(|| {
+                    format!(
+                        "PagedBlockPool::paged_decode_fused: block {block_id} on layer {layer_idx} has no pool row (was it written?)"
+                    )
+                })?;
+                rows.push(row as i32);
+            }
+            row_offsets.push(rows.len() as i32);
+            logical_starts.push(layer.logical_start as i32);
+            visible_lens.push(layer.visible_len() as i32);
+        }
+
+        if !any_visible {
+            return Ok(None);
+        }
+
+        let n_states = states.len() as i32;
+        let rows_arr = ffi::from_slice_i32(&rows, &[rows.len() as i32]);
+        let off_arr = ffi::from_slice_i32(&row_offsets, &[n_states + 1]);
+        let ls_arr = ffi::from_slice_i32(&logical_starts, &[n_states]);
+        let vl_arr = ffi::from_slice_i32(&visible_lens, &[n_states]);
+
+        // The kernel reads Q and writes its output in f32 deterministically (it
+        // never re-specialises by dtype). Cast Q in and the result back to Q's
+        // dtype so the fused path is byte-comparable with the gather fallback.
+        let q_dtype = ffi::array_dtype(q);
+        let q_f32 = if q_dtype == crate::dtype::FLOAT32 {
+            None
+        } else {
+            Some(ffi::astype(q, crate::dtype::FLOAT32))
+        };
+        let q_in: &MlxArray = q_f32.as_deref().unwrap_or(q);
+
+        let out_f32 = ffi::paged_attention_decode(
+            q_in, pool_k, pool_v, &rows_arr, &off_arr, &ls_arr, &vl_arr, scale,
+        );
+        let out = if q_dtype == crate::dtype::FLOAT32 {
+            out_f32
+        } else {
+            ffi::astype(&out_f32, q_dtype)
+        };
+        Ok(Some(out))
+    }
+
     /// Sum of every allocated physical main-K/V pool tensor (K and V, all
     /// layers). Additive to the layout-derived scheduling budgets in
     /// `reserved_bytes`/`used_bytes`, which are unchanged.

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -589,6 +589,196 @@ fn test_pooled_paged_decode_matches_dense_over_200_steps() {
     println!("test_pooled_paged_decode_matches_dense_over_200_steps: max RMS = {max_rms:e}");
 }
 
+/// #123 fused-kernel parity: the native fused paged-attention decode kernel
+/// (`paged_decode_attention_pooled` with `use_native = true`) must match the
+/// gather-then-SDPA reference (`paged_decode_attention_pooled_fallback`) within
+/// RMS < 5e-3 over 200 fragmented decode steps. Uses the same fragmented-pool
+/// construction as `test_pooled_paged_decode_matches_dense_over_200_steps`, so
+/// the target's physical pool rows are genuinely scattered and the kernel
+/// exercises its block-table indexing rather than a contiguous run.
+#[test]
+fn test_fused_paged_decode_matches_gather_over_200_steps() {
+    use crate::cache::{PagedBlockPool, PagedSequenceState};
+
+    const STEPS: usize = 200;
+    let n_kv_heads: i32 = 4;
+    let head_dim: i32 = 8;
+    let block_size = 4usize;
+    let layer_idx = 0usize;
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    let mut pool = PagedBlockPool::new(pooled_layout(block_size, 1, n_kv_heads, head_dim));
+    let mut target = PagedSequenceState::new(pool.layout());
+    let mut spacer = PagedSequenceState::new(pool.layout());
+
+    let mut max_rms = 0.0f32;
+    let mut prev_blocks = 0usize;
+
+    for step in 0..STEPS {
+        let t = step as i32;
+
+        pool.append_tokens(&mut target, layer_idx, 1).unwrap();
+        let block_ids = target.layer(layer_idx).unwrap().block_ids.clone();
+
+        if block_ids.len() > prev_blocks {
+            pool.append_tokens(&mut spacer, layer_idx, block_size)
+                .unwrap();
+            let spacer_ids = spacer.layer(layer_idx).unwrap().block_ids.clone();
+            let spacer_block = *spacer_ids.last().unwrap();
+            let spacer_seed = 0xCAFE_u64.wrapping_add(step as u64);
+            let sk = from_slice_f32(
+                &pooled_pseudo_f32(
+                    spacer_seed,
+                    (n_kv_heads * block_size as i32 * head_dim) as usize,
+                ),
+                &[1, n_kv_heads, block_size as i32, head_dim],
+            );
+            let sv = from_slice_f32(
+                &pooled_pseudo_f32(
+                    spacer_seed.wrapping_mul(3),
+                    (n_kv_heads * block_size as i32 * head_dim) as usize,
+                ),
+                &[1, n_kv_heads, block_size as i32, head_dim],
+            );
+            pool.write_block(spacer_block, layer_idx, 0, &sk, &sv)
+                .unwrap();
+            prev_blocks = block_ids.len();
+        }
+
+        let slot = (t as usize) % block_size;
+        let block_index = (t as usize) / block_size;
+        let target_block = block_ids[block_index];
+        let k_tok = from_slice_f32(
+            &pooled_pseudo_f32(step as u64 + 1, (n_kv_heads * head_dim) as usize),
+            &[1, n_kv_heads, 1, head_dim],
+        );
+        let v_tok = from_slice_f32(
+            &pooled_pseudo_f32(
+                (step as u64 + 1).wrapping_mul(7),
+                (n_kv_heads * head_dim) as usize,
+            ),
+            &[1, n_kv_heads, 1, head_dim],
+        );
+        pool.write_block(target_block, layer_idx, slot, &k_tok, &v_tok)
+            .unwrap();
+
+        let q_vals = pooled_pseudo_f32(
+            (step as u64).wrapping_mul(0x1000_0001) + 13,
+            (n_kv_heads * head_dim) as usize,
+        );
+        let q = from_slice_f32(&q_vals, &[1, n_kv_heads, 1, head_dim]);
+
+        let states: [&PagedSequenceState; 1] = [&target];
+        let fused = crate::layers::paged_decode_attention_pooled(
+            &q, &pool, &states, layer_idx, scale, true,
+        )
+        .unwrap();
+        let gather = crate::layers::paged_decode_attention_pooled_fallback(
+            &q, &pool, &states, layer_idx, scale,
+        )
+        .unwrap();
+
+        let f = flatten_f32_local(&fused);
+        let g = flatten_f32_local(&gather);
+        let rms = pooled_rms(&f, &g);
+        assert!(
+            rms < 5e-3,
+            "step {step}: fused vs gather RMS {rms} exceeded 5e-3"
+        );
+        max_rms = max_rms.max(rms);
+    }
+
+    assert!(
+        max_rms < 5e-3,
+        "max RMS {max_rms} over 200 steps exceeded 5e-3"
+    );
+    println!("test_fused_paged_decode_matches_gather_over_200_steps: max RMS = {max_rms:e}");
+}
+
+/// #123 fused-kernel parity under grouped-query attention (Hq > Hkv) and
+/// batching (B = 2 with unequal visible lengths). Exercises the kernel's
+/// `kv_head = h / NRep` mapping and its per-batch `row_offsets` / `visible_lens`
+/// indexing, which the single-sequence NRep=1 test above does not cover. Two
+/// sequences are grown with interleaved token writes so their physical pool
+/// rows are scattered.
+#[test]
+fn test_fused_paged_decode_gqa_and_batched() {
+    use crate::cache::{PagedBlockPool, PagedSequenceState};
+
+    let n_kv_heads: i32 = 2; // Hkv
+    let n_q_heads: i32 = 8; // Hq -> NRep = 4
+    let head_dim: i32 = 8;
+    let block_size = 4usize;
+    let layer_idx = 0usize;
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    let mut pool = PagedBlockPool::new(pooled_layout(block_size, 1, n_kv_heads, head_dim));
+    let mut s0 = PagedSequenceState::new(pool.layout());
+    let mut s1 = PagedSequenceState::new(pool.layout());
+
+    let len0 = 10i32;
+    let len1 = 17i32;
+    let write_token =
+        |pool: &mut PagedBlockPool, state: &mut PagedSequenceState, t: i32, seed: u64| {
+            pool.append_tokens(state, layer_idx, 1).unwrap();
+            let ids = state.layer(layer_idx).unwrap().block_ids.clone();
+            let k = from_slice_f32(
+                &pooled_pseudo_f32(seed, (n_kv_heads * head_dim) as usize),
+                &[1, n_kv_heads, 1, head_dim],
+            );
+            let v = from_slice_f32(
+                &pooled_pseudo_f32(seed.wrapping_mul(7), (n_kv_heads * head_dim) as usize),
+                &[1, n_kv_heads, 1, head_dim],
+            );
+            pool.write_block(
+                ids[(t as usize) / block_size],
+                layer_idx,
+                (t as usize) % block_size,
+                &k,
+                &v,
+            )
+            .unwrap();
+        };
+
+    // Interleave the two sequences' writes so their rows fragment.
+    for t in 0..len0.max(len1) {
+        if t < len0 {
+            write_token(&mut pool, &mut s0, t, t as u64 + 1);
+        }
+        if t < len1 {
+            write_token(&mut pool, &mut s1, t, t as u64 + 5000);
+        }
+    }
+
+    let q0 = from_slice_f32(
+        &pooled_pseudo_f32(111, (n_q_heads * head_dim) as usize),
+        &[1, n_q_heads, 1, head_dim],
+    );
+    let q1 = from_slice_f32(
+        &pooled_pseudo_f32(222, (n_q_heads * head_dim) as usize),
+        &[1, n_q_heads, 1, head_dim],
+    );
+    let q = concatenate(&q0, &q1, 0);
+
+    let states: [&PagedSequenceState; 2] = [&s0, &s1];
+    let fused =
+        crate::layers::paged_decode_attention_pooled(&q, &pool, &states, layer_idx, scale, true)
+            .unwrap();
+    let gather =
+        crate::layers::paged_decode_attention_pooled_fallback(&q, &pool, &states, layer_idx, scale)
+            .unwrap();
+    assert_eq!(array_shape(&fused), vec![2, n_q_heads, 1, head_dim]);
+
+    let f = flatten_f32_local(&fused);
+    let g = flatten_f32_local(&gather);
+    let rms = pooled_rms(&f, &g);
+    assert!(
+        rms < 5e-3,
+        "GQA+batched fused vs gather RMS {rms} exceeded 5e-3"
+    );
+    println!("test_fused_paged_decode_gqa_and_batched: RMS = {rms:e}");
+}
+
 /// Sliding-window parity: a sequence with `logical_start > 0` (post-trim) must
 /// gather/decode exactly the visible window and match the dense reference of
 /// just that window.

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -2462,6 +2462,54 @@ pub fn paged_decode_attention_pooled_fallback(
     Ok(result)
 }
 
+/// Process-wide env override for the fused paged-attention kernel (#123).
+///
+/// `MLXCEL_PAGED_ATTENTION_NATIVE=1` (or `true` / `on` / `yes`) force-enables
+/// the native kernel regardless of the per-config `use_native_paged_kernel`
+/// flag, so operators can A/B the kernel without rebuilding. Read once and
+/// cached so the decode hot path never touches the environment.
+fn native_paged_kernel_env() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("MLXCEL_PAGED_ATTENTION_NATIVE")
+            .map(|v| {
+                matches!(
+                    v.trim(),
+                    "1" | "true" | "on" | "yes" | "TRUE" | "ON" | "YES"
+                )
+            })
+            .unwrap_or(false)
+    })
+}
+
+/// Gated pooled paged decode attention (epic #116 Phase 6, #123).
+///
+/// When the native kernel is enabled (the per-config `use_native_paged_kernel`
+/// flag or the `MLXCEL_PAGED_ATTENTION_NATIVE` env override), dispatches to the
+/// fused Metal kernel ([`crate::cache::PagedBlockPool::paged_decode_fused`]),
+/// which reads scattered pool blocks directly with no gather copy (ADR 0001
+/// strategy B). Otherwise, and whenever the kernel declines (the layer's pool
+/// tensors are not yet allocated, or no sequence has visible tokens), it falls
+/// back to [`paged_decode_attention_pooled_fallback`], the gather-then-SDPA
+/// reference. The two paths agree within RMS < 5e-3, so the gate is a pure
+/// performance switch with no behavioural change.
+pub fn paged_decode_attention_pooled(
+    q: &MlxArray,
+    pool: &crate::cache::PagedBlockPool,
+    states: &[&crate::cache::PagedSequenceState],
+    layer_idx: usize,
+    scale: f32,
+    use_native_paged_kernel: bool,
+) -> Result<UniquePtr<MlxArray>, String> {
+    if use_native_paged_kernel || native_paged_kernel_env() {
+        if let Some(out) = pool.paged_decode_fused(q, states, layer_idx, scale)? {
+            return Ok(out);
+        }
+    }
+    paged_decode_attention_pooled_fallback(q, pool, states, layer_idx, scale)
+}
+
 /// Native paged decode path over dense compatibility KV caches.
 ///
 /// The C++ bridge consumes the logical block table metadata and performs the

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -1155,6 +1155,27 @@ mod ffi {
             scale: f32,
         ) -> UniquePtr<MlxArray>;
 
+        /// Fused paged-attention decode Metal kernel (epic #116 Phase 6, #123).
+        ///
+        /// Reads scattered KV blocks directly out of the global pool via the
+        /// block table, with no separate gather copy. `q` is `[B, Hq, 1, D]`
+        /// f32; `k_pool` / `v_pool` are the layer's pool tensors
+        /// `[num_blocks, block_size, Hkv, D]` f16. The metadata are i32 arrays:
+        /// `rows` is every sequence's physical pool rows concatenated in
+        /// block-table order, `row_offsets` (`[B + 1]`) the start of each
+        /// sequence's rows, and `logical_starts` / `visible_lens` (`[B]`) bound
+        /// each sequence's visible window. Returns `[B, Hq, 1, D]` f32.
+        fn paged_attention_decode(
+            q: &MlxArray,
+            k_pool: &MlxArray,
+            v_pool: &MlxArray,
+            rows: &MlxArray,
+            row_offsets: &MlxArray,
+            logical_starts: &MlxArray,
+            visible_lens: &MlxArray,
+            scale: f32,
+        ) -> UniquePtr<MlxArray>;
+
         fn sdpa_supports_fast_path(
             q: &MlxArray,
             k: &MlxArray,


### PR DESCRIPTION
## Summary

Phase 6 of #116 implements the ADR 0001 strategy (B) fused Metal paged-attention decode kernel and benchmarks it against the strategy (A) gather-then-SDPA path. The kernel lands **gated off**: it is correct and available behind a flag, but the gather path stays the default on Apple Silicon because it is faster at long context.

## The kernel

`src/lib/mlx-cpp/turbo/paged_attention.cpp`, JIT-compiled via `mlx::core::fast::metal_kernel`, modeled on `sparse_v_sdpa.cpp`. It is a split-K flash-decoding attention:

- One threadgroup per `(batch, query head)`.
- `NumSplits` SIMD groups split the visible token range (token parallelism).
- The 32 lanes of each SIMD group partition the head dimension, so the per-token QK dot product is a single barrier-free `simd_sum` and the weighted-V accumulator stays in registers (no `acc[Dim]` spill).
- It reads scattered KV blocks straight from the pool through the block table, with no gather copy.

`PagedBlockPool::paged_decode_fused` builds the flattened block-table metadata and calls the kernel; `layers::paged_decode_attention_pooled` is the gated dispatcher.

## Correctness

`test_fused_paged_decode_matches_gather_over_200_steps` (single sequence, NRep=1) and `test_fused_paged_decode_gqa_and_batched` (Hq>Hkv, B=2 unequal lengths) compare the fused kernel against `paged_decode_attention_pooled_fallback` over fragmented pools. Max RMS is about **2e-8** (fp32 round-off), well inside the issue's 5e-3 bar.

## Throughput and why it is gated off

Bench (`examples/paged_attention_kernel_bench.rs`, M1 Ultra, f16 pool, head_dim 128, 32 q-heads, 8 kv-heads, block 32). Speedup above 1 means the fused kernel is faster:

| ctx | b=1 | b=4 | b=8 | b=16 |
|----:|----:|----:|----:|-----:|
| 4096 | 0.50x | 1.30x | 1.01x | 1.36x |
| 16384 | 0.39x | 0.83x | 0.82x | 0.91x |

The fused kernel wins at 4096 tokens once decode is batched, and scales better with batch than gather (the behaviour ADR 0001 predicted). At 16384 tokens it runs about 0.8 to 0.9x of the gather path. On unified memory there is no host copy to avoid, and MLX folds the gather's `take`/`reshape`/`transpose` into its tuned fused SDPA, so the gather path already runs near the contiguous lower bound. ADR 0001's Phase 6 outcome section records this.

The native path is opt-in through `MLXCEL_PAGED_ATTENTION_NATIVE` (or the `use_native_paged_kernel` argument); the default path is unchanged, so this PR carries zero risk to live decode.

## Test plan

- `cargo build -p mlxcel-core` + **cold** `cargo clippy -p mlxcel-core --lib --tests -D warnings` + example clippy + `cargo fmt --all --check`: clean
- `cargo test -p mlxcel-core --lib`: 843 pass (includes the 2 new fused tests; no regression)
- `cargo run --release --example paged_attention_kernel_bench`: reproduces the table

Closes #123.
