### PR TITLE
feat: hybrid-SSM cache carve-out tests and multimodal digest plumbing

### DIFF
--- a/src/lib/mlxcel-core/src/cache/detach_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/detach_tests.rs
@@ -402,6 +402,83 @@ fn cache_pool_detach_rejects_paged_backend() {
     assert_eq!(pool.active_count(), 1);
 }
 
+/// #124 SSM/hybrid carve-out: a recurrent model keeps its state in internal
+/// model-owned caches, so it overrides `supports_batching()` to `false`. The
+/// *default* `sequence_state_layout()` then maps it to
+/// `SequenceStateBackend::ModelOwned`, and a model-owned sequence must be
+/// rejected by BOTH detach paths: there is no detachable cross-request KV to
+/// donate. This is the load-bearing guarantee that keeps SSM/hybrid families
+/// (Mamba, Jamba, NemotronH, RWKV7, RecurrentGemma, Qwen3-Next, ...) out of the
+/// unified prompt-cache store: the store can never receive an entry for them,
+/// so every adopt attempt misses and decode output stays bit-identical to the
+/// dense path regardless of the requested decode backend.
+#[test]
+fn cache_pool_model_owned_recurrent_sequence_is_never_detachable() {
+    // Minimal stand-in for a recurrent / hybrid-SSM family. It only overrides
+    // `supports_batching()` to `false`; the `ModelOwned` layout is produced by
+    // the default `sequence_state_layout()` exactly as in production, so this
+    // pins the real mapping rather than a bespoke layout override.
+    struct RecurrentModel {
+        num_layers: usize,
+    }
+
+    impl LanguageModel for RecurrentModel {
+        fn forward(
+            &self,
+            _input_ids: &MlxArray,
+            _caches: &mut [KVCache],
+            _mask: Option<&MlxArray>,
+        ) -> UniquePtr<MlxArray> {
+            crate::ffi::zeros(&[1], 0)
+        }
+
+        fn make_caches(&self) -> Vec<KVCache> {
+            Vec::new()
+        }
+
+        fn num_layers(&self) -> usize {
+            self.num_layers
+        }
+
+        fn eos_token_ids(&self) -> Vec<i32> {
+            vec![0]
+        }
+
+        fn supports_batching(&self) -> bool {
+            false
+        }
+    }
+
+    let model = RecurrentModel { num_layers: 4 };
+
+    // The default layout maps `supports_batching() == false` to ModelOwned.
+    assert_eq!(
+        model.sequence_state_layout().backend,
+        crate::cache::SequenceStateBackend::ModelOwned,
+        "recurrent models must allocate model-owned sequence state"
+    );
+
+    let mut pool = CachePool::new(4);
+    let id = pool.allocate(&model).unwrap();
+    assert_eq!(
+        pool.get_mut(id).map(|s| s.backend),
+        Some(crate::cache::SequenceStateBackend::ModelOwned),
+        "allocated sequence must carry the ModelOwned backend"
+    );
+
+    // Neither detach path may produce a donatable set for a model-owned seq.
+    assert!(
+        pool.detach(id).is_none(),
+        "model-owned (recurrent) sequences must not be dense-detachable"
+    );
+    assert!(
+        pool.detach_paged(id).is_none(),
+        "model-owned (recurrent) sequences must not be paged-detachable"
+    );
+    // A rejected detach must leave the sequence active (no silent removal).
+    assert_eq!(pool.active_count(), 1);
+}
+
 #[test]
 fn cache_pool_adopt_respects_capacity_and_returns_preserving_set() {
     let model = RecordingModel::new(1);

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -61,7 +61,7 @@ use crate::server::model_provider::model_worker::{
     prepare_request_vlm_embeddings,
 };
 use crate::server::model_provider::{GenerateEvent, ModelRequest};
-use crate::server::prompt_cache::key::{MultimodalDigest, PromptCacheKey};
+use crate::server::prompt_cache::key::PromptCacheKey;
 use crate::server::prompt_cache::{CacheEntry, DetachedKvSet, PromptCacheStore};
 use crate::server::state::BatchMetrics;
 use crate::server::thinking_budget::{
@@ -716,12 +716,19 @@ impl BatchScheduler {
         ctx: &'a PromptCacheRequestContext,
         tokens: &'a [i32],
     ) -> PromptCacheKey<'a> {
+        // The digest is computed over the request's resolved image/audio bytes
+        // in the route layer (#124 step b). For text-only requests it is
+        // `MultimodalDigest::empty()`, so the key is byte-identical to the
+        // pre-#124 path. Today multimodal requests still bypass adopt/donate at
+        // the `is_multimodal` gate, so a non-empty digest only starts mattering
+        // once that gate is lifted (#124 step c); folding it in now keeps the
+        // bucket safe from a text↔image collision the moment sharing turns on.
         PromptCacheKey::new_full(
             ctx.model_id.as_str(),
             ctx.lora_id.as_deref(),
             ctx.template_sig.as_str(),
             Some(ctx.session_key.as_str()),
-            MultimodalDigest::empty(),
+            ctx.mm_digest,
             tokens,
         )
     }

--- a/src/server/batch/scheduler_tests.rs
+++ b/src/server/batch/scheduler_tests.rs
@@ -818,6 +818,69 @@ fn auto_decode_storage_prefers_paged_only_for_supported_workers() {
     );
 }
 
+/// #124 step b: the scheduler must fold the request context's multimodal
+/// digest into the composed prompt-cache key. This is the plumbing that lets a
+/// later step share image/audio prefixes without a text↔image bucket collision.
+/// Verified through the private `compose_prompt_cache_key` seam so we exercise
+/// the exact key the scheduler builds, not a hand-rolled copy.
+#[test]
+fn compose_prompt_cache_key_folds_request_multimodal_digest() {
+    use crate::server::config::PromptCacheRequestContext;
+    use crate::server::prompt_cache::key::{
+        MultimodalDigest, PromptCacheKey, multimodal_digest_from_vecs,
+    };
+
+    let tokens = [11_i32, 22, 33, 44];
+
+    let text_ctx = PromptCacheRequestContext {
+        model_id: "model".to_string(),
+        lora_id: None,
+        template_sig: "tpl".to_string(),
+        session_key: "sess".to_string(),
+        mm_digest: MultimodalDigest::empty(),
+    };
+    let image_a = PromptCacheRequestContext {
+        mm_digest: multimodal_digest_from_vecs(&[b"IMAGE-A".to_vec()], &[]),
+        ..text_ctx.clone()
+    };
+    let image_b = PromptCacheRequestContext {
+        mm_digest: multimodal_digest_from_vecs(&[b"IMAGE-B".to_vec()], &[]),
+        ..text_ctx.clone()
+    };
+
+    let k_text = super::BatchScheduler::compose_prompt_cache_key(&text_ctx, &tokens);
+    let k_image_a = super::BatchScheduler::compose_prompt_cache_key(&image_a, &tokens);
+    let k_image_b = super::BatchScheduler::compose_prompt_cache_key(&image_b, &tokens);
+
+    // Same tokens, text vs image: distinct buckets (no cross-modal collision).
+    assert_ne!(
+        k_text.digest(),
+        k_image_a.digest(),
+        "a text-only prefix must not collide with the same tokens carrying an image"
+    );
+    // Two different images, same tokens: distinct buckets.
+    assert_ne!(
+        k_image_a.digest(),
+        k_image_b.digest(),
+        "different image payloads must land in different buckets"
+    );
+    // Same image twice: identical bucket, the reuse the digest unlocks.
+    let k_image_a_again = super::BatchScheduler::compose_prompt_cache_key(&image_a, &tokens);
+    assert_eq!(k_image_a.digest(), k_image_a_again.digest());
+
+    // Text path stays byte-identical to building the key with an explicit empty
+    // digest, proving step b introduces zero behavior change for text requests.
+    let explicit_empty = PromptCacheKey::new_full(
+        "model",
+        None,
+        "tpl",
+        Some("sess"),
+        MultimodalDigest::empty(),
+        &tokens,
+    );
+    assert_eq!(k_text.digest(), explicit_empty.digest());
+}
+
 // -------------------------------------------------------------------
 // Null / empty-cache safety tests
 //

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -25,6 +25,7 @@ use crate::distributed::ShardConfig;
 use crate::distributed::TransportBackend;
 use crate::distributed::pipeline::RemotePipelineRuntimeConfig;
 use crate::server::batch::RequestPriority;
+use crate::server::prompt_cache::key::MultimodalDigest;
 use mlxcel_core::lang_analyzer::LangBiasConfig;
 use mlxcel_core::sampling::LogprobsConfig;
 
@@ -78,6 +79,18 @@ pub struct PromptCacheRequestContext {
     /// the scheduler can compose a [`crate::server::prompt_cache::key::PromptCacheKey`]
     /// on demand without reaching back into the route layer.
     pub session_key: String,
+    /// Stable digest of the request's resolved multimodal payload (image +
+    /// audio bytes), built by
+    /// [`crate::server::prompt_cache::key::multimodal_digest`] over the
+    /// post-resolution byte slices.
+    ///
+    /// [`MultimodalDigest::empty`] for text-only requests, so the composed
+    /// cache key stays byte-identical to the pre-#124 text path. Folding the
+    /// digest into the key is what lets a future multimodal-sharing step
+    /// (#124 step c) reuse image/audio prefixes without a text↔image bucket
+    /// collision; until that step lifts the scheduler's `is_multimodal` gate
+    /// the digest is carried but multimodal requests still take the cold path.
+    pub mm_digest: MultimodalDigest,
 }
 
 /// Bridge between server request params and `mlxcel-core` `SamplingConfig`.

--- a/src/server/prompt_cache/hybrid_ssm.rs
+++ b/src/server/prompt_cache/hybrid_ssm.rs
@@ -29,18 +29,46 @@
 //!
 //! ## Coverage
 //!
-//! The list below is authoritative. New hybrid families added in future MLX
-//! upstream syncs must be added here at the same time the model is wired in.
+//! [`HYBRID_SSM_MODEL_TYPES`] is authoritative. New hybrid families added in
+//! future MLX upstream syncs must be added there at the same time the model is
+//! wired in. The `all_hybrid_ssm_model_types_round_trip` test iterates the
+//! constant itself so the table below can never silently drift from it.
 //!
-//! | model_type        | Architecture                              |
-//! |-------------------|-------------------------------------------|
-//! | `jamba`           | Mamba + Transformer + MoE                 |
-//! | `mamba`           | Mamba 1                                   |
-//! | `mamba2`          | Mamba 2                                   |
-//! | `nemotron_h`      | Mamba2 + Attention + MLP/MoE              |
-//! | `gated_delta`     | Gated DeltaNet (Qwen3-Next family)        |
-//! | `kimi_linear`     | Kimi linear-attention hybrid              |
-//! | `qwen3_next`      | Full Attention + GatedDeltaNet + MoE      |
+//! | model_type             | Architecture                              |
+//! |------------------------|-------------------------------------------|
+//! | `jamba`                | Mamba + Transformer + MoE                 |
+//! | `mamba`                | Mamba 1                                   |
+//! | `mamba2`               | Mamba 2                                   |
+//! | `nemotron_h`           | Mamba2 + Attention + MLP/MoE              |
+//! | `gated_delta`          | Gated DeltaNet (Qwen3-Next family)        |
+//! | `kimi_linear`          | Kimi linear-attention hybrid              |
+//! | `qwen3_next`           | Full Attention + GatedDeltaNet + MoE      |
+//! | `falcon_mamba`         | Falcon Mamba (HF `model_type` alias)      |
+//! | `longcat_flash`        | LongCat-Flash linear hybrid               |
+//! | `longcat_flash_ngram`  | LongCat-Flash with n-gram speculation     |
+//! | `rwkv7`                | RWKV-7 recurrent                          |
+//! | `recurrent_gemma`      | Griffin (RecurrentGemma) local+recurrent  |
+//!
+//! ## Why this is safe under the unified paged cache (#124)
+//!
+//! Two independent mechanisms keep these families out of cross-request block
+//! sharing, so the unified paged store inherits the carve-out for free:
+//!
+//! 1. **APC opt-out (this module).** [`detect_hybrid_ssm`] runs at startup and
+//!    force-disables Automatic Prefix Caching, so no block-hash chain is ever
+//!    computed for a recurrent prompt.
+//! 2. **`ModelOwned` backend (the load-bearing guarantee).** Every family here
+//!    overrides `LanguageModel::supports_batching()` to `false`, which routes
+//!    the default `sequence_state_layout()` to
+//!    `SequenceStateBackend::ModelOwned`. A `ModelOwned` sequence is rejected by
+//!    both `CachePool::detach` and `CachePool::detach_paged` (they return
+//!    `None`), so the scheduler's donate-back path can never hand a recurrent
+//!    sequence to the prompt-cache store, so its store stays empty and every
+//!    adopt attempt misses. The same `supports_batching() == false` also forces
+//!    `effective_decode_storage_backend` to `Dense`, so `--decode-storage-backend
+//!    paged` is silently ignored for these models rather than corrupting their
+//!    recurrent state. The net effect is bit-identical output to the pre-epic
+//!    dense path regardless of the requested decode backend.
 //!
 //! ## Detection precedence
 //!

--- a/src/server/prompt_cache/hybrid_ssm_tests.rs
+++ b/src/server/prompt_cache/hybrid_ssm_tests.rs
@@ -35,6 +35,33 @@ fn known_hybrid_model_types_match() {
     }
 }
 
+/// Drift guard (#124): every entry in the authoritative
+/// [`HYBRID_SSM_MODEL_TYPES`] constant must be detected by both the bare
+/// `model_type` predicate and the full `config.json` detector. Iterating the
+/// constant itself means a future addition (or the alias rows in the module
+/// doc table) cannot fall out of sync with the detection logic. This is the
+/// unified-cache carve-out's first line of defence: if a recurrent family is
+/// in the list but not detected, APC would not be disabled for it.
+#[test]
+fn all_hybrid_ssm_model_types_round_trip() {
+    assert!(
+        !HYBRID_SSM_MODEL_TYPES.is_empty(),
+        "the hybrid-SSM carve-out list must not be empty"
+    );
+    for &mt in HYBRID_SSM_MODEL_TYPES {
+        assert!(
+            is_hybrid_ssm_model_type(mt),
+            "{mt} is in HYBRID_SSM_MODEL_TYPES but is_hybrid_ssm_model_type rejected it"
+        );
+        let cfg = json!({ "model_type": mt });
+        assert_eq!(
+            detect_hybrid_ssm(&cfg).as_deref(),
+            Some(mt),
+            "detect_hybrid_ssm must flag the top-level model_type {mt}"
+        );
+    }
+}
+
 #[test]
 fn case_and_whitespace_insensitive() {
     assert!(is_hybrid_ssm_model_type("JAMBA"));

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -31,7 +31,9 @@ use crate::server::batch::RequestPriority;
 use crate::server::chat_request::prepare_chat_request_with_cache;
 use crate::server::chat_template_kwargs::{extract_request_kwargs, merge_server_and_request};
 use crate::server::config::{PromptCacheRequestContext, ReasoningBudgetOverride};
-use crate::server::prompt_cache::key::{resolve_session_key, template_sig};
+use crate::server::prompt_cache::key::{
+    multimodal_digest_from_vecs, resolve_session_key, template_sig,
+};
 use crate::server::request_options::{RequestOptionOverrides, build_server_generate_options};
 use crate::server::streaming::sse_channel;
 use crate::server::structured::{StructuredOutputError, build_constraint_from_response_format};
@@ -75,9 +77,20 @@ pub(crate) fn structured_error_to_response(err: StructuredOutputError) -> ErrorR
 /// request. When `Some`, the caller fills `options.prompt_cache_ctx` with
 /// the returned value so the scheduler can compose a stable
 /// [`crate::server::prompt_cache::key::PromptCacheKey`] on its own thread.
+///
+/// `image_data` / `audio_data` are the **resolved** multimodal byte payloads
+/// (post base64-decode / file-read / URL-fetch) from
+/// [`prepare_chat_request_with_cache`]. They are folded into the key via a
+/// [`crate::server::prompt_cache::key::MultimodalDigest`] so a text-only prefix
+/// can never collide with an image/audio one. Text-only requests pass empty
+/// slices, which yields `MultimodalDigest::empty()` and a key byte-identical to
+/// the pre-#124 path. Callers must therefore build the context **after**
+/// preparing the request so the resolved bytes are available.
 fn build_prompt_cache_request_context(
     state: &AppState,
     request: &ChatCompletionRequest,
+    image_data: &[Vec<u8>],
+    audio_data: &[Vec<u8>],
 ) -> Option<PromptCacheRequestContext> {
     state.prompt_cache.as_ref()?;
     // Mirror the kwargs merge that `prepare_chat_request_with_cache` performs
@@ -100,11 +113,15 @@ fn build_prompt_cache_request_context(
     );
     let session_key =
         resolve_session_key(request.resolve_prompt_cache_key(), request.resolve_user()).to_string();
+    // Digest the resolved multimodal payload. Empty slices (text-only) hash to
+    // `MultimodalDigest::empty()`, leaving the composed key unchanged.
+    let mm_digest = multimodal_digest_from_vecs(image_data, audio_data);
     Some(PromptCacheRequestContext {
         model_id: state.display_model_id().to_string(),
         lora_id: None,
         template_sig: template_signature,
         session_key,
+        mm_digest,
     })
 }
 
@@ -345,7 +362,6 @@ async fn non_stream_chat_completion(
     // true. The store is built by startup.rs only when configured, so
     // `state.prompt_cache.is_some()` is the operator-visible flag here.
     let prompt_cache_enabled = state.prompt_cache.is_some();
-    let prompt_cache_ctx = build_prompt_cache_request_context(&state, &request);
     let prepared = prepare_chat_request_with_cache(
         &state.chat_template,
         &request,
@@ -354,6 +370,14 @@ async fn non_stream_chat_completion(
     )
     .await
     .map_err(|err| ErrorResponse::new(err.to_string(), "invalid_request_error"))?;
+    // Build the prompt-cache context AFTER preparation so the multimodal
+    // digest sees the resolved image/audio bytes.
+    let prompt_cache_ctx = build_prompt_cache_request_context(
+        &state,
+        &request,
+        &prepared.image_data,
+        &prepared.audio_data,
+    );
     let primed_open_thinking = is_prompt_primed_open_thinking(&prepared.prompt);
     let mut options = build_generate_options(&request.params, &state.config);
     options.priority = priority;
@@ -507,7 +531,6 @@ async fn stream_chat_completion(
     // both endpoints default preserve_thinking=true identically when the
     // cache is installed.
     let prompt_cache_enabled = state.prompt_cache.is_some();
-    let prompt_cache_ctx = build_prompt_cache_request_context(&state, &request);
     let prepared = prepare_chat_request_with_cache(
         &state.chat_template,
         &request,
@@ -521,6 +544,14 @@ async fn stream_chat_completion(
             return ErrorResponse::new(err.to_string(), "invalid_request_error").into_response();
         }
     };
+    // Build the prompt-cache context AFTER preparation so the multimodal
+    // digest sees the resolved image/audio bytes.
+    let prompt_cache_ctx = build_prompt_cache_request_context(
+        &state,
+        &request,
+        &prepared.image_data,
+        &prepared.audio_data,
+    );
     let primed_open_thinking = is_prompt_primed_open_thinking(&prepared.prompt);
     let mut options = build_generate_options(&request.params, &state.config);
     options.priority = priority;


### PR DESCRIPTION
## Summary

Foundation for #124 (Hybrid SSM exclusion and multimodal adopt policy under the unified cache). Implements steps **a** and **b** of the agreed decomposition; the VLM-sharing enablement is the separate step **c**.

### (a) Hybrid-SSM / recurrent carve-out: documented + regression-tested

The carve-out from cross-request block sharing is enforced by the sequence-state backend, not an ad-hoc check. A recurrent/hybrid family overrides `supports_batching()` to `false`, which routes the default `sequence_state_layout()` to `SequenceStateBackend::ModelOwned`. A `ModelOwned` sequence is rejected by both `CachePool::detach` and `CachePool::detach_paged` (both return `None`), so the scheduler can never donate it to the prompt-cache store, its store stays empty, and every adopt attempt misses. The same flag forces `effective_decode_storage_backend` to `Dense`, so `--decode-storage-backend paged` is silently ignored for these families and their decode output stays bit-identical to the dense path.

- `hybrid_ssm.rs` module doc now spells out this two-mechanism guarantee and completes the coverage table (previously 7 of the 12 authoritative `model_type` entries).
- New `cache_pool_model_owned_recurrent_sequence_is_never_detachable` (mlxcel-core) proves a model-owned recurrent sequence is non-detachable on both paths.
- New `all_hybrid_ssm_model_types_round_trip` iterates `HYBRID_SSM_MODEL_TYPES` itself so the list can never drift from the detector.

### (b) Multimodal digest plumbed into the prompt-cache key (behavior-neutral)

`PromptCacheRequestContext` gains an `mm_digest` field. The chat route builds the context **after** `prepare_chat_request_with_cache` so the digest is computed over the resolved (post base64 / file / URL) image and audio bytes, and `compose_prompt_cache_key` folds it into the bucket via `PromptCacheKey::new_full` instead of the hardcoded `MultimodalDigest::empty()`.

- Text-only requests hash to `MultimodalDigest::empty()`, so the composed key is byte-identical to the pre-change path.
- Multimodal requests still bypass adopt and donate at the scheduler's `is_multimodal` gate, so this step changes no runtime behavior. It only makes the key collision-safe so step c can lift that gate and share image/audio prefixes without a text/image bucket collision.
- New `compose_prompt_cache_key_folds_request_multimodal_digest` verifies, through the real key-composition seam, that text / image / different-image payloads land in distinct buckets and the text path matches an explicit empty digest.

## Validation

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --features metal,accelerate -- -D warnings` (cold): clean
- `cargo test --features metal,accelerate`: mlxcel 3048 passed, mlxcel-core 844 passed, 0 failed

## Follow-up

Step c (lift the `is_multimodal` gate, slice `InputEmbeddings` to the adopted suffix, keep MRoPE aligned, real-model VLM cold-vs-adopt parity) lands in a separate PR.

Part of #124