### PR TITLE
feat: opt-in VLM prompt-prefix cache sharing for multi-turn images

### DIFF
--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -286,6 +286,17 @@ struct ServerArgs {
     #[arg(long = "enable-preemption")]
     enable_preemption: bool,
 
+    /// Enable experimental VLM (image/audio) prompt-prefix cache sharing
+    /// (default off). When on, multimodal chat requests may adopt and donate
+    /// KV prefixes for multi-turn same-image conversations (the prefilled
+    /// suffix is the newly-appended text turn). Text-only and non-VLM behavior
+    /// is unchanged. Also reads `MLXCEL_ENABLE_VLM_PREFIX_CACHE` (true/false/1/0).
+    #[arg(
+        long = "enable-vlm-prefix-cache",
+        env = "MLXCEL_ENABLE_VLM_PREFIX_CACHE"
+    )]
+    enable_vlm_prefix_cache: bool,
+
     /// Preemption policy: "longest-first" (default) or "lowest-priority"
     #[arg(long = "preemption-policy", default_value = "longest-first")]
     preemption_policy: String,
@@ -1228,6 +1239,8 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         // paged KV pool block-budget directive (#122 b3); clap parses it into
         // a `PagedBudgetDirective`, resolved to a block count on the worker.
         kv_cache_budget: args.kv_cache_budget,
+        // experimental VLM prompt-prefix cache toggle (#124 step c).
+        enable_vlm_prefix_cache: args.enable_vlm_prefix_cache,
         // Responses API in-memory store limits. clap reads the
         // matching `LLAMA_ARG_*` env vars directly via the `env = ...`
         // attributes on the flags.

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -325,6 +325,8 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         // clap into a `PagedBudgetDirective` (`Bytes`/`Auto`); resolved to a
         // block count on the worker thread.
         kv_cache_budget: args.kv_cache_budget,
+        // experimental VLM prompt-prefix cache toggle (#124 step c).
+        enable_vlm_prefix_cache: args.enable_vlm_prefix_cache,
         // Responses API in-memory store limits. clap reads the
         // matching `LLAMA_ARG_*` env vars directly via the `env = ...`
         // attributes on the flags.

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -30,6 +30,7 @@ fn sample_args() -> crate::ServeArgs {
         ctx_size: 8192,
         max_kv_size: 0,
         kv_cache_budget: None,
+        enable_vlm_prefix_cache: false,
         n_predict: 128,
         draft_model: Some(PathBuf::from("models/draft")),
         draft_max: 4,

--- a/src/main.rs
+++ b/src/main.rs
@@ -762,6 +762,17 @@ pub(crate) struct ServeArgs {
     #[arg(long)]
     enable_preemption: bool,
 
+    /// Enable experimental VLM (image/audio) prompt-prefix cache sharing
+    /// (default off). When on, multimodal chat requests may adopt and donate
+    /// KV prefixes for multi-turn same-image conversations (the prefilled
+    /// suffix is the newly-appended text turn). Text-only and non-VLM behavior
+    /// is unchanged. Also reads `MLXCEL_ENABLE_VLM_PREFIX_CACHE` (true/false/1/0).
+    #[arg(
+        long = "enable-vlm-prefix-cache",
+        env = "MLXCEL_ENABLE_VLM_PREFIX_CACHE"
+    )]
+    enable_vlm_prefix_cache: bool,
+
     /// Preemption policy: "longest-first" (default) or "lowest-priority"
     ///
     /// Controls which active sequence is evicted when preemption is

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -87,6 +87,25 @@ fn should_align_prefill() -> bool {
 
 pub(crate) const DEFAULT_PAGED_BLOCK_SIZE: usize = 32;
 
+/// Decide whether a request may participate in experimental VLM prompt-prefix
+/// cache sharing (#124 step c).
+///
+/// Sharing is allowed only when all three hold:
+/// 1. the operator opted in (`--enable-vlm-prefix-cache`),
+/// 2. the request actually carries multimodal content, and
+/// 3. it has no video payload (video frame bytes are NOT folded into the
+///    request's multimodal digest, so a video prefix could collide with a
+///    different video in the same bucket).
+///
+/// Text-only requests and any request with video always return `false`,
+/// preserving the legacy cold-prefill path. Keeping the decision in one pure
+/// function lets the safety conditions be pinned by a unit test so a future
+/// edit cannot silently enable-by-default or allow video sharing.
+#[inline]
+fn vlm_prefix_sharing_allowed(enabled: bool, is_multimodal: bool, has_videos: bool) -> bool {
+    enabled && is_multimodal && !has_videos
+}
+
 fn effective_decode_storage_backend(
     requested: DecodeStorageBackend,
     max_batch_size: usize,
@@ -213,6 +232,17 @@ pub struct BatchScheduler {
     /// `--kv-quant-scheme=turboquant --max-kv-size=M` is flagged even
     /// when the legacy `--kv-cache-mode` flag is left at FP16.
     max_kv_size: Option<usize>,
+
+    /// Experimental VLM prompt-prefix cache sharing toggle (#124 step c,
+    /// `--enable-vlm-prefix-cache`).
+    ///
+    /// `false` (the default) keeps every multimodal request on the cold-prefill
+    /// path (the pre-#124 behavior). When `true`, a multimodal chat request may
+    /// adopt a previously donated KV prefix and donate its own, restricted to a
+    /// whole-entry match so the prefilled suffix is the newly-appended text
+    /// turn (multi-turn same-image conversations). Text-only and non-VLM
+    /// requests are unaffected either way.
+    enable_vlm_prefix_cache: bool,
 
     // -- Vision feature cache --
     /// Per-model vision feature cache bundle. Contains LRU caches for
@@ -418,6 +448,9 @@ impl BatchScheduler {
             kv_cache_mode: KVCacheMode::Fp16,
             batch_kv_quant: BatchKvQuantConfig::default(),
             max_kv_size: None,
+            // multimodal prefix-cache sharing stays off until the operator
+            // opts in via `with_vlm_prefix_cache` (#124 step c).
+            enable_vlm_prefix_cache: false,
             // dispatch defaults to Disabled so the scheduler's
             // hot path stays bit-exact for the non-speculative case. The
             // worker thread overrides this via `with_speculative_dispatch`
@@ -526,6 +559,18 @@ impl BatchScheduler {
     /// Returns the configured maximum KV cache size (for tests).
     pub fn max_kv_size(&self) -> Option<usize> {
         self.max_kv_size
+    }
+
+    /// Enable experimental VLM prompt-prefix cache sharing (#124 step c,
+    /// `--enable-vlm-prefix-cache`).
+    ///
+    /// Default off. When on, multimodal chat requests may adopt and donate KV
+    /// prefixes for multi-turn same-image conversations (whole-entry match, so
+    /// the prefilled suffix is the newly-appended text turn). Text-only and
+    /// non-VLM behavior is unchanged.
+    pub fn with_vlm_prefix_cache(mut self, enabled: bool) -> Self {
+        self.enable_vlm_prefix_cache = enabled;
+        self
     }
 
     /// Install the paged KV block budget (epic #116 #122 b3).
@@ -751,8 +796,18 @@ impl BatchScheduler {
     /// * backend mismatch (a `Dense` entry under the paged decode backend, or
     ///   a `Paged` entry under the dense backend — the entry's KV shape cannot
     ///   be installed into the active pool),
+    /// * `require_whole_entry` is set (multimodal sharing) and the match is
+    ///   shorter than the full stored entry (see below),
     /// * [`CachePool::adopt`] / [`CachePool::adopt_paged`] error (capacity,
     ///   layout mismatch, …).
+    ///
+    /// `require_whole_entry` is set for multimodal requests (#124 step c). It
+    /// forces a whole-entry match so the prefilled suffix is guaranteed to be
+    /// the newly-appended text turn: every image/audio placeholder token sits
+    /// inside the matched prefix (a different media payload lands in a
+    /// different digest bucket), so the suffix can safely run through the
+    /// token path. Text-only requests pass `false` and keep accepting partial
+    /// (APC block-aligned) matches.
     ///
     /// Both dense and paged entries are adopted in-place: dense via
     /// [`CachePool::adopt`], paged via [`CachePool::adopt_paged`] (which shares
@@ -762,6 +817,7 @@ impl BatchScheduler {
         &mut self,
         ctx: &PromptCacheRequestContext,
         tokens: &[i32],
+        require_whole_entry: bool,
     ) -> Option<(SequenceId, usize)> {
         if !self.prompt_cache_active() {
             return None;
@@ -774,6 +830,15 @@ impl BatchScheduler {
         let store = self.prompt_cache.as_ref()?.clone();
         let key = Self::compose_prompt_cache_key(ctx, tokens);
         let (entry, matched_len) = store.lookup_longest_prefix(&key, tokens)?;
+        // #124 step c: multimodal sharing requires the matched prefix to cover
+        // the ENTIRE stored entry. A partial (e.g. APC block-clamped) match
+        // could leave image/audio placeholder tokens in the suffix, which the
+        // token-path suffix prefill would mis-handle. Decline here (falling
+        // back to a cold prefill) before consuming anything; the entry stays
+        // available for a later exact match.
+        if require_whole_entry && matched_len < entry.tokens.len() {
+            return None;
+        }
         // `take_detached` is one-shot: it returns `None` if a racing lookup
         // already consumed this entry. The miss path is safe — the current
         // sequence just does a fresh prefill.
@@ -1576,6 +1641,48 @@ impl BatchScheduler {
             sampling.token_bias = self.token_bias.clone();
         }
 
+        let is_multimodal = !images.is_empty() || !audio.is_empty() || !videos.is_empty();
+
+        // Experimental VLM prompt-prefix cache sharing (#124 step c). Off by
+        // default; the operator opts in with `--enable-vlm-prefix-cache`. Video
+        // payloads are excluded because video frame bytes are not folded into
+        // the request's multimodal digest yet, so a video prefix could collide
+        // with a different one in the same bucket.
+        let vlm_sharing_ok = vlm_prefix_sharing_allowed(
+            self.enable_vlm_prefix_cache,
+            is_multimodal,
+            !videos.is_empty(),
+        );
+
+        // For VLM sharing the image/audio placeholder tokens must be expanded
+        // BEFORE probing the cache: `prepare_request_vlm_embeddings` rewrites
+        // `prompt_tokens` into the post-injection stream the KV cache is built
+        // over, and both the cache key (via the request's multimodal digest)
+        // and the matched-prefix length are computed against that stream. No
+        // sequence id exists yet, so a preparation error just aborts the
+        // request with nothing to clean up. `Some(_)` marks "prepared early";
+        // the inner value is the optional merged embeddings.
+        let prepared_early = if vlm_sharing_ok {
+            match prepare_request_vlm_embeddings(
+                &self.model,
+                &self.tokenizer,
+                &prompt,
+                &mut prompt_tokens,
+                &images,
+                &audio,
+                &videos,
+                Some(self.vision_caches.as_ref()),
+            ) {
+                Ok(emb) => Some(emb),
+                Err(err) => {
+                    let _ = response_tx.send(GenerateEvent::Error(err.to_string()));
+                    return;
+                }
+            }
+        } else {
+            None
+        };
+
         // before allocating a fresh KV-cache slot,
         // probe the prompt-prefix cache for a reusable detached set. On a
         // hit, adopt under a brand-new SequenceId and record how many
@@ -1583,61 +1690,81 @@ impl BatchScheduler {
         // feature-disabled, no ctx, and race paths), fall through to the
         // cold-allocation path below.
         //
-        // VLM / audio / video requests opt out of the cache path entirely:
-        // their pre-injection token stream is not self-describing (image
-        // and video frame placeholders expand later inside
-        // `prepare_request_vlm_embeddings`), so matching against it risks
-        // reusing a KV slice built for a different media payload. Support
-        // for image-aware cache keys is tracked separately.
-        let is_multimodal = !images.is_empty() || !audio.is_empty() || !videos.is_empty();
-        let ctx_ref = if is_multimodal {
+        // Text-only requests use the cache whenever the route attached a
+        // context. Multimodal requests opt in only under `vlm_sharing_ok`;
+        // when they do, the adopt is restricted to a whole-entry match
+        // (`require_whole_entry == is_multimodal`) so the prefilled suffix is
+        // guaranteed to be the newly-appended text turn: every image/audio
+        // token sits inside the matched prefix, and a different media payload
+        // lands in a different digest bucket. Multimodal requests with sharing
+        // off keep the legacy cold-prefill path (their pre-injection token
+        // stream is not self-describing).
+        let ctx_ref = if is_multimodal && !vlm_sharing_ok {
             None
         } else {
             options.prompt_cache_ctx.as_ref()
         };
-        let (seq_id, prefill_start_offset, already_cached_tokens) =
-            match ctx_ref.and_then(|ctx| self.try_adopt_cached_prefix(ctx, &prompt_tokens)) {
-                Some((adopted_id, matched_len)) => (adopted_id, matched_len, matched_len),
-                None => {
-                    // Miss or feature disabled → regular allocate.
-                    // count misses only when the cache is actually
-                    // active (ctx_ref is Some) to avoid inflating the miss
-                    // counter for multimodal or cache-disabled requests.
-                    if ctx_ref.is_some() {
-                        self.batch_metrics.record_prompt_cache_miss();
-                    }
-                    let seq_id = match self.allocate_sequence_state() {
-                        Ok(id) => id,
-                        Err(err) => {
-                            tracing::warn!("Cache pool allocation failed: {err}");
-                            let _ = response_tx
-                                .send(GenerateEvent::Error(format!("Server busy: {err}")));
-                            return;
-                        }
-                    };
-                    (seq_id, 0, 0)
+        let (seq_id, prefill_start_offset, already_cached_tokens) = match ctx_ref
+            .and_then(|ctx| self.try_adopt_cached_prefix(ctx, &prompt_tokens, is_multimodal))
+        {
+            Some((adopted_id, matched_len)) => (adopted_id, matched_len, matched_len),
+            None => {
+                // Miss or feature disabled → regular allocate.
+                // count misses only when the cache is actually
+                // active (ctx_ref is Some) to avoid inflating the miss
+                // counter for multimodal or cache-disabled requests.
+                if ctx_ref.is_some() {
+                    self.batch_metrics.record_prompt_cache_miss();
                 }
-            };
-
-        let vlm_embeddings = match prepare_request_vlm_embeddings(
-            &self.model,
-            &self.tokenizer,
-            &prompt,
-            &mut prompt_tokens,
-            &images,
-            &audio,
-            &videos,
-            Some(self.vision_caches.as_ref()),
-        ) {
-            Ok(emb) => emb,
-            Err(err) => {
-                // Clean up the context map so a donate-back won't fire for
-                // a sequence that never reached a healthy finish.
-                self.prompt_cache_seq_ctx.remove(&seq_id);
-                self.release_sequence_caches(seq_id);
-                let _ = response_tx.send(GenerateEvent::Error(err.to_string()));
-                return;
+                let seq_id = match self.allocate_sequence_state() {
+                    Ok(id) => id,
+                    Err(err) => {
+                        tracing::warn!("Cache pool allocation failed: {err}");
+                        let _ =
+                            response_tx.send(GenerateEvent::Error(format!("Server busy: {err}")));
+                        return;
+                    }
+                };
+                (seq_id, 0, 0)
             }
+        };
+
+        // Resolve the per-sequence input embeddings. On the VLM-sharing path
+        // the tokens were already expanded above; if a prefix was adopted
+        // (`prefill_start_offset > 0`) the remaining suffix is the appended
+        // text turn, so the full-prompt embeddings are dropped and the suffix
+        // runs through the token path (the adopted KV already holds the image
+        // rows, and the MRoPE / per-layer state bound below covers the suffix
+        // positions). Otherwise the request prepares embeddings here exactly as
+        // before.
+        let vlm_embeddings = match prepared_early {
+            Some(emb) => {
+                if prefill_start_offset > 0 {
+                    None
+                } else {
+                    emb
+                }
+            }
+            None => match prepare_request_vlm_embeddings(
+                &self.model,
+                &self.tokenizer,
+                &prompt,
+                &mut prompt_tokens,
+                &images,
+                &audio,
+                &videos,
+                Some(self.vision_caches.as_ref()),
+            ) {
+                Ok(emb) => emb,
+                Err(err) => {
+                    // Clean up the context map so a donate-back won't fire for
+                    // a sequence that never reached a healthy finish.
+                    self.prompt_cache_seq_ctx.remove(&seq_id);
+                    self.release_sequence_caches(seq_id);
+                    let _ = response_tx.send(GenerateEvent::Error(err.to_string()));
+                    return;
+                }
+            },
         };
 
         // mlx-vlm PR #1095: per-sequence MRoPE alignment.
@@ -1687,10 +1814,11 @@ impl BatchScheduler {
         // path can compose the insert key without reaching back into the
         // HTTP layer. Only stored when the feature is active and the
         // request actually carried a context — otherwise the map stays
-        // empty and the donate-back short-circuits. Multimodal requests
-        // opt out of the cache altogether (see above).
+        // empty and the donate-back short-circuits. Multimodal requests are
+        // stored only when VLM sharing is enabled (#124 step c); otherwise
+        // they keep opting out of the cache entirely.
         if self.prompt_cache_active()
-            && !is_multimodal
+            && (!is_multimodal || vlm_sharing_ok)
             && let Some(ctx) = options.prompt_cache_ctx.clone()
         {
             self.prompt_cache_seq_ctx.insert(seq_id, ctx);

--- a/src/server/batch/scheduler_tests.rs
+++ b/src/server/batch/scheduler_tests.rs
@@ -25,7 +25,7 @@ use std::time::Instant;
 use mlxcel_core::cache::SequenceId;
 use mlxcel_core::generate::SamplingConfig;
 
-use super::effective_decode_storage_backend;
+use super::{effective_decode_storage_backend, vlm_prefix_sharing_allowed};
 use crate::server::batch::active::ActiveBatch;
 use crate::server::batch::queue::PrefillQueue;
 use crate::server::batch::sequence::{
@@ -816,6 +816,24 @@ fn auto_decode_storage_prefers_paged_only_for_supported_workers() {
         effective_decode_storage_backend(DecodeStorageBackend::Auto, 1, true, true),
         DecodeStorageBackend::Dense
     );
+}
+
+/// #124 step c: the VLM prompt-prefix sharing gate must stay off by default,
+/// reject text-only requests, and never share a request that carries video
+/// (video bytes are not in the multimodal digest, so a video prefix could
+/// collide). Only an opted-in, image/audio (no-video) request is eligible.
+#[test]
+fn vlm_prefix_sharing_gate_pins_safety_conditions() {
+    // Default off: even a clean image request is ineligible when the operator
+    // did not pass --enable-vlm-prefix-cache.
+    assert!(!vlm_prefix_sharing_allowed(false, true, false));
+    // Text-only requests never share, opt-in or not.
+    assert!(!vlm_prefix_sharing_allowed(true, false, false));
+    assert!(!vlm_prefix_sharing_allowed(false, false, false));
+    // Video is excluded because its bytes are not folded into the digest.
+    assert!(!vlm_prefix_sharing_allowed(true, true, true));
+    // The one eligible case: opted in, multimodal, no video.
+    assert!(vlm_prefix_sharing_allowed(true, true, false));
 }
 
 /// #124 step b: the scheduler must fold the request context's multimodal

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -354,6 +354,11 @@ pub struct ServerStartupInput {
     /// resolved to a concrete block count on the worker thread.
     pub kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
 
+    /// `--enable-vlm-prefix-cache` (#124 step c). Default off. Enables
+    /// experimental VLM prompt-prefix cache sharing for multi-turn same-image
+    /// conversations; forwarded verbatim to the scheduler.
+    pub enable_vlm_prefix_cache: bool,
+
     /// `--responses-store-max-entries` value (`0` disables
     /// the OpenAI Responses API response store entirely).
     pub responses_store_max_entries: usize,
@@ -568,6 +573,8 @@ impl ServerStartupInput {
             // forward the paged KV block-budget directive verbatim (resolved
             // to a block count on the worker thread).
             kv_cache_budget: self.kv_cache_budget,
+            // forward the experimental VLM prefix-cache toggle (#124 step c).
+            enable_vlm_prefix_cache: self.enable_vlm_prefix_cache,
             // forward the Responses-API store limits.
             responses_store_max_entries: self.responses_store_max_entries,
             responses_store_ttl_secs: self.responses_store_ttl_secs,

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -140,6 +140,8 @@ fn sample_input() -> ServerStartupInput {
         max_kv_size: 0,
         // paged KV pool block-budget directive (None = unbounded, the default).
         kv_cache_budget: None,
+        // experimental VLM prefix-cache toggle off in tests (#124 step c).
+        enable_vlm_prefix_cache: false,
         // Responses API store defaults.
         responses_store_max_entries: 1024,
         responses_store_ttl_secs: 3600,

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -423,6 +423,11 @@ pub struct ServerConfig {
     /// [`crate::server::batch::BatchScheduler::with_paged_block_budget`]. Only
     /// meaningful for pool-backed (Fp16, dense-natural-backend) sequences.
     pub kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
+    /// `--enable-vlm-prefix-cache` (#124 step c). Default off. When on, the
+    /// scheduler permits VLM (image/audio) chat requests to adopt and donate
+    /// KV prefixes for multi-turn same-image conversations; text-only and
+    /// non-VLM behavior is unchanged.
+    pub enable_vlm_prefix_cache: bool,
 }
 
 impl Default for ServerConfig {
@@ -477,6 +482,7 @@ impl Default for ServerConfig {
             batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig::default(),
             max_kv_size: None,
             kv_cache_budget: None,
+            enable_vlm_prefix_cache: false,
         }
     }
 }

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -250,6 +250,8 @@ impl ModelProvider {
                 config.max_kv_size,
                 // forward the --kv-cache-budget directive to the worker.
                 config.kv_cache_budget,
+                // experimental VLM prompt-prefix cache toggle (#124 step c).
+                config.enable_vlm_prefix_cache,
                 speculative_dispatch,
                 batch_metrics,
                 batch_observability,
@@ -392,8 +394,9 @@ impl ModelProvider {
             None,
             mlxcel_core::cache::KVCacheMode::Fp16,
             mlxcel_core::cache::BatchKvQuantConfig::default(),
-            None, // max_kv_size: unbounded
-            None, // kv_cache_budget: unbounded
+            None,  // max_kv_size: unbounded
+            None,  // kv_cache_budget: unbounded
+            false, // enable_vlm_prefix_cache: off
             batch_metrics,
             batch_observability,
         )
@@ -429,6 +432,7 @@ impl ModelProvider {
         // paged KV pool block-budget directive (`--kv-cache-budget`).
         // `None` keeps the pool unbounded.
         kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
+        enable_vlm_prefix_cache: bool,
         batch_metrics: Arc<BatchMetrics>,
         batch_observability: Arc<BatchObservability>,
     ) -> Result<Self> {
@@ -455,6 +459,7 @@ impl ModelProvider {
             batch_kv_quant,
             max_kv_size,
             kv_cache_budget,
+            enable_vlm_prefix_cache,
             crate::server::SpeculativeDispatch::Disabled,
             batch_metrics,
             batch_observability,
@@ -489,6 +494,7 @@ impl ModelProvider {
         batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig,
         max_kv_size: Option<usize>,
         kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
+        enable_vlm_prefix_cache: bool,
         speculative_dispatch: crate::server::SpeculativeDispatch,
         batch_metrics: Arc<BatchMetrics>,
         batch_observability: Arc<BatchObservability>,
@@ -527,6 +533,8 @@ impl ModelProvider {
             // paged KV pool block-budget directive; resolved to a block count
             // on the worker thread once the model geometry is known.
             kv_cache_budget,
+            // experimental VLM prompt-prefix cache toggle (#124 step c).
+            enable_vlm_prefix_cache,
             // forward the resolved speculative dispatch.
             speculative_dispatch,
         };
@@ -599,8 +607,9 @@ impl ModelProvider {
             prompt_cache: None,
             kv_cache_mode: mlxcel_core::cache::KVCacheMode::Fp16,
             batch_kv_quant: mlxcel_core::cache::BatchKvQuantConfig::default(),
-            max_kv_size: None,     // unbounded in minimal test path
-            kv_cache_budget: None, // unbounded in minimal test path
+            max_kv_size: None,              // unbounded in minimal test path
+            kv_cache_budget: None,          // unbounded in minimal test path
+            enable_vlm_prefix_cache: false, // off in minimal test path
             // minimal test path has no drafter; the dispatch
             // defaults to `Disabled` which short-circuits the scheduler
             // hot path to the classic decode loop.

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -115,6 +115,15 @@ pub(crate) struct WorkerSchedulerConfig {
     /// the scheduler's pool through
     /// [`crate::server::batch::BatchScheduler::with_paged_block_budget`].
     pub kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
+    /// experimental VLM prompt-prefix cache toggle (#124 step c,
+    /// `--enable-vlm-prefix-cache`).
+    ///
+    /// `false` (the default) preserves the legacy cold-prefill behavior for
+    /// every multimodal request. When `true`, the scheduler permits VLM
+    /// (image/audio) chat requests to adopt and donate KV prefixes for
+    /// multi-turn same-image conversations. Text-only and non-VLM requests are
+    /// unaffected either way.
+    pub enable_vlm_prefix_cache: bool,
     /// resolved speculative-decoding dispatch shape.
     ///
     /// Constructed once at worker construction (or
@@ -391,6 +400,8 @@ pub(crate) fn spawn_model_worker_with_batch_config(
         .with_max_kv_size(sched_config.max_kv_size)
         // install the resolved paged KV block budget (epic #116 #122 b3).
         .with_paged_block_budget(paged_block_budget)
+        // experimental VLM prompt-prefix cache sharing (#124 step c).
+        .with_vlm_prefix_cache(sched_config.enable_vlm_prefix_cache)
         // attach the resolved speculative dispatch so the
         // scheduler can branch per-request once the round-loop dispatch
         // hook is wired in `decode_single_step`.

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -114,6 +114,9 @@ pub struct ServerStartupConfig {
     pub ubatch_size_provided: bool,
     /// Enable preemptive eviction when batch is full.
     pub enable_preemption: bool,
+    /// Enable experimental VLM prompt-prefix cache sharing (#124 step c,
+    /// `--enable-vlm-prefix-cache`). Default off; forwarded to the scheduler.
+    pub enable_vlm_prefix_cache: bool,
     /// Preemption policy string from CLI (parsed into enum at build_server_config).
     pub preemption_policy: String,
     /// Force the legacy sequential worker, bypassing the batch scheduler.
@@ -371,6 +374,7 @@ impl Default for ServerStartupConfig {
             batch_size_conflict: false,
             ubatch_size_provided: false,
             enable_preemption: false,
+            enable_vlm_prefix_cache: false,
             preemption_policy: "longest-first".to_string(),
             no_batch: false,
             max_batch_prefill: 1,
@@ -810,6 +814,8 @@ pub(super) fn build_server_config(
         // forward the paged KV block-budget directive verbatim; the worker
         // resolves it to a concrete block count once the model is loaded.
         kv_cache_budget: startup.kv_cache_budget,
+        // forward the experimental VLM prefix-cache toggle (#124 step c).
+        enable_vlm_prefix_cache: startup.enable_vlm_prefix_cache,
     }
 }
 


### PR DESCRIPTION
## Summary

Completes #124 (step c). With the foundation merged (#182: SSM carve-out + `mm_digest` plumbing), this wires the actual VLM (image/audio) prompt-prefix cache sharing behind a default-off flag.

`--enable-vlm-prefix-cache` (env `MLXCEL_ENABLE_VLM_PREFIX_CACHE`) lets multimodal chat requests adopt and donate KV prefixes for **multi-turn same-image conversations**. When enabled and the request carries image/audio with no video, the scheduler:

1. expands the image/audio placeholder tokens **before** probing the cache, so the key (via the request's multimodal digest) and the matched-prefix length are computed over the post-injection token stream the KV is built over;
2. restricts multimodal adoption to a **whole-entry match** (`require_whole_entry`), which guarantees the prefilled suffix is the newly-appended text turn: every image/audio token sits inside the matched prefix, and a different media payload lands in a different digest bucket;
3. on a hit, drops the full-prompt embeddings and runs the text suffix through the token path, with the bound MRoPE / per-layer state covering the suffix positions.

Video payloads are excluded because their frame bytes are not folded into the multimodal digest. The flag is plumbed from both `ServeArgs` paths through `ServerStartupInput`, `ServerConfig`, the model provider, and `WorkerSchedulerConfig` to `BatchScheduler::with_vlm_prefix_cache`.

## Safety: flag-off is byte-identical

With the flag off (the default), `vlm_prefix_sharing_allowed` returns `false` for every request, so `prepared_early` stays `None`, `ctx_ref`/`require_whole_entry`/the donate-context gate all reduce to the pre-#124 behavior, and the `prepare_request_vlm_embeddings` ordering is unchanged. Text-only and non-VLM requests are untouched either way.

## Verification

**Real-model parity (Qwen2-VL-2B-Instruct-4bit, the MRoPE case):** a multi-turn same-image conversation adopts the image prefix (`prompt-cache hit: adopted 108/124 tokens`) and produces output **byte-identical** to a cold full prefill, on both a short answer and a 400+ character generation. Text 2-turn adopt and the cold path were also confirmed working on the same server.

**Automated:**
- `vlm_prefix_sharing_gate_pins_safety_conditions` pins the gate (off by default, text-only rejected, video excluded, only opted-in image/audio eligible).
- `compose_prompt_cache_key_folds_request_multimodal_digest` (#182) covers the key.
- `cargo fmt --all -- --check`, cold `cargo clippy --all-targets --features metal,accelerate -- -D warnings`, and the full `mlxcel` lib suite (3049 passed, 0 failed) are green.

## Scope note

This first cut covers **multi-turn same-image continuation** via the whole-entry match. Cross-conversation system+image prefix sharing (partial match past the image tokens) needs a per-family placeholder-token boundary and is a clean follow-up; both stay behind this same flag.

Closes #124