### PR TITLE
feat: in-process paged KV serving-role handoff mechanism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,3 +196,7 @@ required-features = ["test-utils"]
 [[test]]
 name = "pipeline_e2e"
 required-features = ["test-utils"]
+
+[[test]]
+name = "paged_handoff_parity"
+required-features = ["test-utils"]

--- a/src/distributed/disaggregated/handoff_impl.rs
+++ b/src/distributed/disaggregated/handoff_impl.rs
@@ -1,0 +1,275 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cross-node paged KV handoff mechanism: the seam that joins the serde layer
+//! (`kv_cache_serde`) to the transport layer for disaggregated serving (#126).
+//!
+//! Before this module the two halves never referenced each other: the #125
+//! serde functions (`serialize_cache_pool_sequence` /
+//! `restore_into_cache_pool_sequence_anchored`) round-tripped a pool-backed
+//! paged sequence at the `CachePool` level, and the [`Transport`] trait moved
+//! raw bytes between nodes, but nothing wired one into the other. This module
+//! provides the three primitives a serving-role scheduler needs:
+//!
+//! 1. [`extract_sequence_handoff`] (prefill side): serialize a finished,
+//!    pool-backed sequence (dense metadata + paged block table + the referenced
+//!    pool block CONTENTS) into a single wire frame.
+//! 2. [`ingest_sequence_handoff`] (decode side): validate an incoming frame,
+//!    allocate a fresh pool-backed sequence, and reconstruct its KV on local
+//!    pool blocks, anchored to the decode model's real block geometry.
+//! 3. [`send_handoff_payload`] / [`recv_handoff_payload`]: the async
+//!    serde<->transport byte bridge over any [`Transport`].
+//!
+//! The decode-side anchor needs the local model's exact paged block geometry
+//! (`n_kv_heads`, `head_dim`, and the runtime KV dtype). Only `num_layers` and
+//! the block size are statically known; the KV dtype in particular is the
+//! model's runtime activation dtype (e.g. bf16 for a 4-bit checkpoint, not
+//! fp16), which no static accessor exposes. [`probe_block_geometry`] derives all
+//! three by running a single one-token forward through a throwaway pool-backed
+//! sequence and reading the gathered window's shape and dtype, model-agnostic
+//! and exact, with no per-model code.
+//!
+//! ## Scope
+//!
+//! Handoff applies only to pool-backed **Fp16 paged** sequences (the dense-
+//! natural-backend families wired to the shared pool: qwen3, llama3). Model-
+//! owned-state families and recurrent/hybrid SSM models keep dense or
+//! model-owned caches and are structurally excluded upstream
+//! (`supports_batching()` / the paged-backend gate), so they never reach this
+//! path. This is the in-process building block (B1) for the disaggregated
+//! serving role wiring; the CLI role switch and a real network transport land in
+//! later steps. The synchronous scaffolding [`HandoffProtocol`] trait
+//! (`prefill_scheduler`) is intentionally left for that wiring: it predates the
+//! async [`Transport`] and would force a `block_on`, so the async byte bridge
+//! here is the primitive the real serve loop should build on.
+//!
+//! [`HandoffProtocol`]: super::prefill_scheduler::HandoffProtocol
+
+use anyhow::{Result, anyhow, bail};
+use bytes::Bytes;
+
+use mlxcel_core::cache::{CachePool, PagedKvLayout, SequenceId, SequenceStateLayout};
+use mlxcel_core::generate::LanguageModel;
+
+use crate::distributed::kv_cache_serde::{
+    CacheIngestLimits, ExpectedBlockGeometry, SerializableSamplingState,
+    deserialize_cache_state_with_limits, restore_into_cache_pool_sequence_anchored,
+    serialize_cache_pool_sequence, serialize_cache_state,
+};
+use crate::distributed::transport::{Transport, TransportMessage};
+
+/// Tensor-id tag carried on the [`TransportMessage::TensorData`] frame that
+/// transports a serialized KV cache handoff. The receiver checks it so a
+/// mismatched message kind fails loudly instead of being mis-restored.
+pub const HANDOFF_TENSOR_ID: &str = "kv-cache-handoff";
+
+/// Build the pool-backed Fp16 paged layout for `num_layers` layers at
+/// `block_size` tokens per block, the same `PagedKvLayout::uniform` layout the
+/// batch scheduler builds for a dense-natural Fp16 sequence, so an allocated
+/// sequence is pool-backed and the handoff restore can materialize real pool
+/// blocks.
+fn handoff_paged_layout(num_layers: usize, block_size: usize) -> Result<SequenceStateLayout> {
+    let layout = PagedKvLayout::uniform(num_layers, block_size, block_size)
+        .map_err(|e| anyhow!("handoff: build paged layout: {e}"))?;
+    Ok(SequenceStateLayout::paged_kv_cache(layout))
+}
+
+/// Derive the decode model's exact per-layer paged KV block geometry by probing
+/// it once.
+///
+/// `ExpectedBlockGeometry` pins every transferred slab to the local model's real
+/// `(block_size, n_kv_heads, head_dim, dtype)` before a single pool block is
+/// acquired (see [`ExpectedBlockGeometry`]). The dims could be read from config,
+/// but the KV dtype is the model's runtime activation dtype and has no static
+/// accessor, so this runs a single one-token forward through a throwaway
+/// pool-backed sequence and reads the geometry straight off the gathered window
+/// (`[1, n_kv_heads, 1, head_dim]`) and its dtype. The throwaway pool is dropped
+/// before returning, so there is no lasting cache state; the model is borrowed
+/// immutably and its `forward` is pure with respect to the caches passed in, so
+/// the probe has no side effects on the caller's model.
+///
+/// Only valid for pool-backed Fp16 families (the handoff scope); callers must
+/// not probe a model-owned or recurrent model.
+pub fn probe_block_geometry(
+    model: &dyn LanguageModel,
+    block_size: usize,
+) -> Result<ExpectedBlockGeometry> {
+    let num_layers = model.num_layers();
+    let layout = handoff_paged_layout(num_layers, block_size)?;
+
+    let mut pool = CachePool::new(1);
+    let id = pool
+        .allocate_with_layout(model, Some(layout))
+        .map_err(|e| anyhow!("handoff geometry probe: allocate: {e}"))?;
+
+    // One-token forward writes layer 0's first pool block, establishing the
+    // pool's real geometry and dtype. Skip the forward (and release the slot)
+    // if the model is not pool-backed for this layout, so the failure is a clean
+    // error rather than a dense write the gather below cannot read.
+    let input = mlxcel_core::from_slice_i32(&[0_i32], &[1, 1]);
+    let mask = mlxcel_core::utils::create_causal_mask(1, 0);
+    let pool_backed = {
+        let caches = pool
+            .get_caches_mut(id)
+            .ok_or_else(|| anyhow!("handoff geometry probe: probe sequence vanished"))?;
+        if caches.iter().all(|c| c.is_paged_backed()) {
+            let logits = model.forward(&input, caches, Some(&mask));
+            mlxcel_core::eval(&logits);
+            true
+        } else {
+            false
+        }
+    };
+    if !pool_backed {
+        pool.release(id);
+        bail!(
+            "handoff geometry probe: model is not pool-backed for the Fp16 paged layout; \
+             only dense-natural Fp16 families support paged handoff"
+        );
+    }
+
+    let geometry = {
+        let block_pool = pool
+            .paged_pool_ref()
+            .ok_or_else(|| anyhow!("handoff geometry probe: paged pool missing"))?;
+        let seq = pool
+            .get(id)
+            .ok_or_else(|| anyhow!("handoff geometry probe: probe sequence vanished"))?;
+        let state = seq
+            .paged_state()
+            .ok_or_else(|| anyhow!("handoff geometry probe: probe sequence has no paged state"))?;
+        let (k, _v) = block_pool
+            .gather_visible(&state, 0)
+            .map_err(|e| anyhow!("handoff geometry probe: gather_visible: {e}"))?
+            .ok_or_else(|| anyhow!("handoff geometry probe: gather_visible returned no window"))?;
+        // `[1, n_kv_heads, visible_len, head_dim]`.
+        let shape = mlxcel_core::array_shape(&k);
+        if shape.len() != 4 {
+            bail!(
+                "handoff geometry probe: unexpected gathered window rank {} (shape {shape:?})",
+                shape.len()
+            );
+        }
+        ExpectedBlockGeometry {
+            num_layers,
+            block_size,
+            n_kv_heads: shape[1],
+            head_dim: shape[3],
+            dtype: mlxcel_core::array_dtype(&k),
+        }
+    };
+
+    pool.release(id);
+    Ok(geometry)
+}
+
+/// Prefill side: serialize a finished pool-backed sequence into a single wire
+/// frame ready for transport.
+///
+/// Captures the dense metadata, the paged block table, and the referenced pool
+/// block CONTENTS (via [`serialize_cache_pool_sequence`]), then encodes the
+/// whole `SerializableCacheState` to bytes. `token_history` is the sequence's
+/// prompt token ids (needed so the decode node can continue sampling with the
+/// same context); `sampling` carries the request's sampling parameters when the
+/// caller tracks them.
+pub fn extract_sequence_handoff(
+    cache_pool: &CachePool,
+    id: SequenceId,
+    sampling: Option<SerializableSamplingState>,
+    token_history: Vec<i32>,
+) -> Result<Vec<u8>> {
+    let state = serialize_cache_pool_sequence(cache_pool, id, sampling, token_history)?;
+    serialize_cache_state(&state)
+}
+
+/// Decode side: validate an incoming handoff frame and reconstruct the sequence
+/// on a fresh pool-backed slot, returning the new local sequence id.
+///
+/// Steps: reject oversized frames up front (`limits`), allocate a pool-backed
+/// Fp16 paged sequence for the local model, then restore the KV onto fresh pool
+/// blocks anchored to the local model's `geometry` (rejecting any slab that does
+/// not match the decode model before a pool block is acquired). On restore
+/// failure the freshly allocated slot is released so a rejected handoff leaves
+/// no leaked sequence or blocks.
+pub fn ingest_sequence_handoff(
+    cache_pool: &mut CachePool,
+    model: &dyn LanguageModel,
+    bytes: &[u8],
+    limits: &CacheIngestLimits,
+    geometry: &ExpectedBlockGeometry,
+    block_size: usize,
+) -> Result<SequenceId> {
+    let state = deserialize_cache_state_with_limits(bytes, limits)?;
+    let layout = handoff_paged_layout(model.num_layers(), block_size)?;
+    let seq_id = cache_pool
+        .allocate_with_layout(model, Some(layout))
+        .map_err(|e| anyhow!("handoff ingest: allocate decode sequence: {e}"))?;
+
+    if let Err(e) = restore_into_cache_pool_sequence_anchored(
+        &state,
+        cache_pool,
+        seq_id,
+        limits,
+        Some(geometry),
+    ) {
+        // Release the just-allocated slot so a rejected handoff does not leak a
+        // sequence (or any pool blocks the partial restore acquired).
+        cache_pool.release(seq_id);
+        return Err(e);
+    }
+
+    Ok(seq_id)
+}
+
+/// Async byte bridge (send): frame `payload` as a handoff [`TransportMessage`]
+/// and send it to `peer` over `transport`.
+pub async fn send_handoff_payload(
+    transport: &dyn Transport,
+    peer: &str,
+    payload: &[u8],
+) -> Result<()> {
+    let message = TransportMessage::TensorData {
+        tensor_id: HANDOFF_TENSOR_ID.to_string(),
+        shape: vec![payload.len()],
+        data: Bytes::copy_from_slice(payload),
+    };
+    transport.send(peer, message).await
+}
+
+/// Async byte bridge (receive): take the next inbound message from `transport`
+/// and return the sender address with the raw handoff payload, rejecting any
+/// message that is not a handoff frame.
+pub async fn recv_handoff_payload(transport: &dyn Transport) -> Result<(String, Vec<u8>)> {
+    let (from, message) = transport.recv().await?;
+    match message {
+        TransportMessage::TensorData {
+            tensor_id, data, ..
+        } => {
+            if tensor_id == HANDOFF_TENSOR_ID {
+                Ok((from, data.to_vec()))
+            } else {
+                bail!(
+                    "expected a '{HANDOFF_TENSOR_ID}' handoff frame, got TensorData('{tensor_id}')"
+                )
+            }
+        }
+        TransportMessage::Control { operation, .. } => {
+            bail!("expected a '{HANDOFF_TENSOR_ID}' handoff frame, got Control('{operation}')")
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "handoff_impl_tests.rs"]
+mod tests;

--- a/src/distributed/disaggregated/handoff_impl_tests.rs
+++ b/src/distributed/disaggregated/handoff_impl_tests.rs
@@ -1,0 +1,123 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the model-independent halves of the handoff mechanism: the
+//! async serde<->transport byte bridge. The real-model extract/probe/ingest
+//! parity (which loads a checkpoint and runs GPU forwards) lives in the
+//! `tests/paged_handoff_parity.rs` integration test.
+
+use bytes::Bytes;
+
+use super::{HANDOFF_TENSOR_ID, recv_handoff_payload, send_handoff_payload};
+use crate::distributed::mock_transport::{MockRouter, MockTransport, MockTransportConfig};
+use crate::distributed::transport::{Transport, TransportMessage};
+
+/// Stand up two in-process nodes sharing a [`MockRouter`].
+async fn two_nodes() -> (MockTransport, MockTransport) {
+    let router = MockRouter::new();
+    let prefill = MockTransport::new(
+        "prefill".to_string(),
+        router.clone(),
+        MockTransportConfig::default(),
+    )
+    .await;
+    let decode = MockTransport::new(
+        "decode".to_string(),
+        router.clone(),
+        MockTransportConfig::default(),
+    )
+    .await;
+    (prefill, decode)
+}
+
+#[test]
+fn handoff_payload_round_trips_over_mock_transport() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let (prefill, decode) = two_nodes().await;
+
+        // A representative serialized cache frame (opaque bytes for the bridge).
+        let payload: Vec<u8> = (0..4096_u32).map(|i| (i % 251) as u8).collect();
+
+        send_handoff_payload(&prefill, "decode", &payload)
+            .await
+            .expect("send handoff payload");
+        let (from, received) = recv_handoff_payload(&decode)
+            .await
+            .expect("recv handoff payload");
+
+        assert_eq!(from, "prefill", "sender address must be the prefill node");
+        assert_eq!(
+            received, payload,
+            "the decode node must receive the prefill bytes unchanged"
+        );
+    });
+}
+
+#[test]
+fn recv_handoff_payload_rejects_non_handoff_message() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let (prefill, decode) = two_nodes().await;
+
+        // A control message is not a handoff frame; the bridge must reject it
+        // rather than mis-restore it as a cache state.
+        prefill
+            .send(
+                "decode",
+                TransportMessage::Control {
+                    operation: "heartbeat".to_string(),
+                    payload: Bytes::from_static(b"ping"),
+                },
+            )
+            .await
+            .expect("send control");
+
+        let err = recv_handoff_payload(&decode)
+            .await
+            .expect_err("a control message must not be accepted as a handoff");
+        assert!(
+            err.to_string().contains(HANDOFF_TENSOR_ID),
+            "rejection should name the expected handoff frame, got: {err}"
+        );
+    });
+}
+
+#[test]
+fn recv_handoff_payload_rejects_mismatched_tensor_id() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let (prefill, decode) = two_nodes().await;
+
+        prefill
+            .send(
+                "decode",
+                TransportMessage::TensorData {
+                    tensor_id: "activations".to_string(),
+                    shape: vec![8],
+                    data: Bytes::from_static(b"notacache"),
+                },
+            )
+            .await
+            .expect("send foreign tensor");
+
+        let err = recv_handoff_payload(&decode)
+            .await
+            .expect_err("a foreign TensorData frame must be rejected");
+        assert!(
+            err.to_string().contains("activations"),
+            "rejection should name the offending tensor id, got: {err}"
+        );
+    });
+}

--- a/src/distributed/disaggregated/mod.rs
+++ b/src/distributed/disaggregated/mod.rs
@@ -30,6 +30,7 @@
 
 pub mod benchmark;
 pub mod decode_scheduler;
+pub mod handoff_impl;
 pub mod prefill_scheduler;
 pub mod request_router;
 pub mod serving;
@@ -43,6 +44,10 @@ pub use benchmark::{
 pub use decode_scheduler::{
     CompletionEvent, CompletionNotifier, CompletionReason, DecodeRequest, DecodeScheduler,
     DecodeSchedulerConfig, DecodeSequence, IngestionStats, SequenceStatus,
+};
+pub use handoff_impl::{
+    HANDOFF_TENSOR_ID, extract_sequence_handoff, ingest_sequence_handoff, probe_block_geometry,
+    recv_handoff_payload, send_handoff_payload,
 };
 pub use prefill_scheduler::{
     ChunkedPrefillCoordinator, HandoffProtocol, HandoffStatus, PrefillHandoff, PrefillRequest,

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -329,6 +329,18 @@ pub struct BatchScheduler {
     /// empty for the worker's lifetime and the burst path is never
     /// entered.
     speculative_drafter_slot: super::speculative_burst::WorkerDrafterSlot,
+
+    // -- Disaggregated serving-role handoff --
+    /// Cached decode-model paged block geometry for cross-node KV handoff
+    /// ([`crate::distributed::disaggregated::handoff_impl`]).
+    ///
+    /// Lazily probed on the first [`Self::ingest_sequence_handoff`] and reused
+    /// for every later restore, so the one-token geometry probe runs at most
+    /// once per worker. `None` until the first ingest. Wired to a live caller by
+    /// the disaggregated decode serving role (a later step); the hooks below are
+    /// the in-crate seam it builds on.
+    #[allow(dead_code)]
+    paged_handoff_geometry: Option<crate::distributed::kv_cache_serde::ExpectedBlockGeometry>,
 }
 
 impl BatchScheduler {
@@ -345,6 +357,61 @@ impl BatchScheduler {
         seq.prefill_start = Some(Instant::now());
         seed_rng_if_needed(&seq.sampling);
         Ok(())
+    }
+
+    // ── Disaggregated serving-role handoff hooks ─────────────────────────
+    //
+    // The in-crate seam that lets a serving-role worker move a finished
+    // pool-backed sequence's KV across nodes. The mechanism (serialize /
+    // anchored restore / one-token geometry probe) lives in
+    // `crate::distributed::disaggregated::handoff_impl` and is exercised
+    // byte-for-byte against real models by `tests/paged_handoff_parity.rs`.
+    // A live caller (the decode / prefill role serve loop) lands in a later
+    // step, so these stay `#[allow(dead_code)]` until then.
+
+    /// Prefill role: serialize sequence `seq_id`'s pool-backed KV into a single
+    /// wire frame for handoff to a decode node. `token_history` is the
+    /// sequence's prompt token ids (so the decode node continues with the same
+    /// context).
+    #[allow(dead_code)]
+    pub(crate) fn extract_sequence_handoff(
+        &self,
+        seq_id: SequenceId,
+        token_history: Vec<i32>,
+    ) -> anyhow::Result<Vec<u8>> {
+        crate::distributed::disaggregated::handoff_impl::extract_sequence_handoff(
+            &self.cache_pool,
+            seq_id,
+            None,
+            token_history,
+        )
+    }
+
+    /// Decode role: reconstruct a handed-off sequence from `bytes` onto a fresh
+    /// pool-backed slot, anchored to this worker model's real block geometry,
+    /// and return the new local sequence id. The geometry probe runs once on
+    /// the first call and is cached in `paged_handoff_geometry`.
+    #[allow(dead_code)]
+    pub(crate) fn ingest_sequence_handoff(&mut self, bytes: &[u8]) -> anyhow::Result<SequenceId> {
+        let geometry = match self.paged_handoff_geometry {
+            Some(geometry) => geometry,
+            None => {
+                let probed = crate::distributed::disaggregated::handoff_impl::probe_block_geometry(
+                    &self.model,
+                    DEFAULT_PAGED_BLOCK_SIZE,
+                )?;
+                self.paged_handoff_geometry = Some(probed);
+                probed
+            }
+        };
+        crate::distributed::disaggregated::handoff_impl::ingest_sequence_handoff(
+            &mut self.cache_pool,
+            &self.model,
+            bytes,
+            &crate::distributed::kv_cache_serde::CacheIngestLimits::default(),
+            &geometry,
+            DEFAULT_PAGED_BLOCK_SIZE,
+        )
     }
 
     /// Create a new batch scheduler, taking ownership of the model and channel.
@@ -463,6 +530,7 @@ impl BatchScheduler {
             speculative_drafter_slot: super::speculative_burst::WorkerDrafterSlot::from_dispatch(
                 &crate::server::SpeculativeDispatch::Disabled,
             ),
+            paged_handoff_geometry: None,
         }
     }
 

--- a/tests/paged_handoff_parity.rs
+++ b/tests/paged_handoff_parity.rs
@@ -1,0 +1,369 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real-model parity for the disaggregated serving-role KV handoff mechanism
+//! (#126 step B1).
+//!
+//! #125's `paged_kv_serialize_parity` proved the `CachePool`-level serde
+//! round-trip (serialize -> wire -> restore). This test goes one layer up to the
+//! serving-role HANDOFF mechanism that a disaggregated worker uses, and adds the
+//! transport hop, exercising the full path end to end:
+//!
+//! ```text
+//! prefill role:  prefill -> extract_sequence_handoff  (serialize to wire bytes)
+//!                                    |
+//!                          send_handoff_payload -> MockTransport -> recv_handoff_payload
+//!                                    |
+//! decode role:   probe_block_geometry + ingest_sequence_handoff (anchored restore)
+//!                                    |
+//!                          decode from the handed-off first token
+//! ```
+//!
+//! The decode-role output must be byte-identical to a single-node run, the
+//! decode model's geometry probe must anchor the restore, and block accounting
+//! after restore must match the originating node.
+//!
+//! ## Why free functions and not a `BatchScheduler`
+//!
+//! `BatchScheduler` is `pub(crate)`, so an integration test cannot construct
+//! one (same constraint as `paged_scheduler_parity`). The scheduler's
+//! `extract_sequence_handoff` / `ingest_sequence_handoff` methods are thin
+//! delegations to these `pub` `handoff_impl` functions, which carry all the
+//! logic; driving them over a `CachePool` + model faithfully reproduces the
+//! serving-role handoff without standing up the async worker loop.
+//!
+//! ## Running
+//!
+//! `#[ignore]` (loads a real checkpoint and runs real GPU forwards). Run with:
+//!
+//! ```text
+//! cargo test --test paged_handoff_parity --release \
+//!     --features metal,accelerate,test-utils -- --ignored --nocapture --test-threads=1
+//! ```
+//!
+//! Each case soft-skips when its model directory is absent. Fetch with:
+//!
+//! ```text
+//! ./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit
+//! ./target/release/mlxcel download mlx-community/Llama-3.2-1B-Instruct-4bit
+//! ```
+
+mod common;
+use common::repo_model_dir;
+
+use mlxcel::distributed::disaggregated::{
+    extract_sequence_handoff, ingest_sequence_handoff, probe_block_geometry, recv_handoff_payload,
+    send_handoff_payload,
+};
+use mlxcel::distributed::kv_cache_serde::CacheIngestLimits;
+use mlxcel::distributed::mock_transport::{MockRouter, MockTransport, MockTransportConfig};
+use mlxcel::{LanguageModel, initialize_runtime, load_model};
+use mlxcel_core::cache::{CachePool, PagedKvLayout, SequenceStateLayout};
+
+/// qwen3 checkpoint directory name (pool-backed family).
+const QWEN3_DIR: &str = "qwen3-0.6b-4bit";
+/// llama3 checkpoint directory name (pool-backed family).
+const LLAMA3_DIR: &str = "llama-3.2-1b-4bit";
+
+/// Paged block size (tokens per physical block), matching the scheduler's
+/// `DEFAULT_PAGED_BLOCK_SIZE`.
+const BLOCK_SIZE: usize = 32;
+
+/// Number of greedy decode steps to compare across the boundary.
+const DECODE_STEPS: usize = 16;
+
+/// A fixed ~50-token prompt (> one 32-token block, so the sequence spans two
+/// physical blocks and the block-content handoff is non-trivial). Deterministic
+/// plausible ids; no tokenizer needed.
+const PROMPT_TOKENS: &[i32] = &[
+    9707, 11, 358, 1079, 264, 4128, 1614, 13, 5209, 3291, 752, 911, 697, 7990, 13, 358, 2776, 264,
+    10950, 17847, 13, 6771, 594, 1438, 419, 1495, 3019, 553, 3019, 11, 323, 1473, 697, 975, 13,
+    5209, 387, 2797, 624, 14374, 14582, 25, 3555, 374, 220, 17, 488, 220, 17, 30,
+];
+
+/// Greedy argmax over the vocab at sequence position `pos` of a
+/// `[batch, seq_len, vocab]` logits tensor, for batch row `row`.
+fn greedy_token(logits: &mlxcel_core::MlxArray, row: i32, pos: i32) -> i32 {
+    let shape = mlxcel_core::array_shape(logits);
+    let vocab = shape[2];
+    let at_pos = mlxcel_core::slice(logits, &[row, pos, 0], &[row + 1, pos + 1, vocab]);
+    let flat = mlxcel_core::reshape(&at_pos, &[vocab]);
+    mlxcel_core::eval(&flat);
+    mlxcel_core::item_i32(&mlxcel_core::argmax_last_axis(&flat))
+}
+
+/// The paged layout the scheduler builds for the default Fp16 KV mode.
+fn scheduler_paged_layout(num_layers: usize) -> SequenceStateLayout {
+    SequenceStateLayout::paged_kv_cache(
+        PagedKvLayout::uniform(num_layers, BLOCK_SIZE, BLOCK_SIZE).expect("valid paged layout"),
+    )
+}
+
+/// Prefill `prompt` at offset 0 through `caches` and return the first greedy
+/// token (its argmax at the last prompt position).
+fn prefill_first_token(
+    model: &mlxcel::LoadedModel,
+    caches: &mut [mlxcel_core::cache::KVCache],
+    prompt: &[i32],
+) -> i32 {
+    let len = prompt.len() as i32;
+    let input = mlxcel_core::from_slice_i32(prompt, &[1, len]);
+    let mask = mlxcel_core::utils::create_causal_mask(len, 0);
+    let logits = model.forward(&input, caches, Some(&mask));
+    mlxcel_core::eval(&logits);
+    greedy_token(&logits, 0, len - 1)
+}
+
+/// Greedily decode `steps` tokens through `caches`, starting from `first`.
+fn decode_from(
+    model: &mlxcel::LoadedModel,
+    caches: &mut [mlxcel_core::cache::KVCache],
+    first: i32,
+    steps: usize,
+) -> Vec<i32> {
+    let mut next = first;
+    let mut decoded = Vec::with_capacity(steps);
+    for _ in 0..steps {
+        decoded.push(next);
+        let step_input = mlxcel_core::from_slice_i32(&[next], &[1, 1]);
+        let logits = model.forward(&step_input, caches, None);
+        mlxcel_core::eval(&logits);
+        next = greedy_token(&logits, 0, 0);
+    }
+    decoded
+}
+
+/// Gather one layer's visible K window directly from a sequence's pool and
+/// return its raw bytes, for cross-node KV-reconstruction parity checks.
+fn gather_layer_k_bytes(
+    cp: &CachePool,
+    id: mlxcel_core::cache::SequenceId,
+    layer: usize,
+) -> Vec<u8> {
+    let pool = cp.paged_pool_ref().expect("paged pool present");
+    let seq = cp.get(id).expect("sequence present");
+    let state = seq.paged_state().expect("paged state present");
+    let (k, _v) = pool
+        .gather_visible(&state, layer)
+        .expect("gather_visible ok")
+        .expect("gather_visible returned a window");
+    mlxcel_core::array_to_raw_bytes(&k)
+}
+
+fn load_or_skip(model_dir_name: &str, fetch_repo: &str) -> Option<mlxcel::LoadedModel> {
+    let model_dir = repo_model_dir(model_dir_name);
+    if !model_dir.exists() {
+        eprintln!(
+            "Skipping {model_dir_name}: model directory not found at {}.\n\
+             Fetch with: ./target/release/mlxcel download {fetch_repo}",
+            model_dir.display()
+        );
+        return None;
+    }
+    let (model, _tokenizer) =
+        load_model(&model_dir).unwrap_or_else(|e| panic!("load {model_dir_name}: {e:?}"));
+    Some(model)
+}
+
+/// Ship `bytes` from a prefill node to a decode node over an in-process
+/// `MockTransport` pair and return the bytes the decode node received. Proves
+/// the serde<->transport byte bridge moves the handoff frame unchanged.
+fn ship_over_mock_transport(bytes: &[u8]) -> Vec<u8> {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        let router = MockRouter::new();
+        let prefill = MockTransport::new(
+            "prefill".to_string(),
+            router.clone(),
+            MockTransportConfig::default(),
+        )
+        .await;
+        let decode = MockTransport::new(
+            "decode".to_string(),
+            router.clone(),
+            MockTransportConfig::default(),
+        )
+        .await;
+        send_handoff_payload(&prefill, "decode", bytes)
+            .await
+            .expect("send handoff payload");
+        let (from, received) = recv_handoff_payload(&decode)
+            .await
+            .expect("recv handoff payload");
+        assert_eq!(from, "prefill", "handoff sender must be the prefill node");
+        received
+    })
+}
+
+/// Single-node reference vs a prefill-role extract -> transport -> decode-role
+/// ingest handoff onto a fresh decode `CachePool`. The handoff must reproduce
+/// the reference decode exactly and reconstruct identical block accounting.
+fn assert_handoff_over_transport_parity(model: &mlxcel::LoadedModel, label: &str) {
+    let num_layers = model.num_layers();
+
+    eprintln!(
+        "\n=== paged serving-role handoff parity: {label} ({num_layers} layers, \
+         prompt={} tokens) ===",
+        PROMPT_TOKENS.len()
+    );
+
+    // ---- REFERENCE: single-node cold prefill + decode. ----
+    let (ref_first, ref_tokens) = {
+        let mut pool = CachePool::new(2);
+        let id = pool
+            .allocate_with_layout(model, Some(scheduler_paged_layout(num_layers)))
+            .expect("reference paged allocate");
+        let first = {
+            let caches = pool.get_caches_mut(id).unwrap();
+            prefill_first_token(model, caches, PROMPT_TOKENS)
+        };
+        let caches = pool.get_caches_mut(id).unwrap();
+        (first, decode_from(model, caches, first, DECODE_STEPS))
+    };
+    eprintln!("reference decoded: {ref_tokens:?}");
+
+    // ---- PREFILL ROLE: prefill the sequence, then extract a wire frame. ----
+    let mut origin = CachePool::new(2);
+    let id_o = origin
+        .allocate_with_layout(model, Some(scheduler_paged_layout(num_layers)))
+        .expect("origin paged allocate");
+    let origin_first = {
+        let caches = origin.get_caches_mut(id_o).unwrap();
+        assert!(
+            caches.iter().all(|c| c.is_paged_backed()),
+            "origin must be pool-backed (Fp16 paged)"
+        );
+        prefill_first_token(model, caches, PROMPT_TOKENS)
+    };
+    assert_eq!(
+        origin_first, ref_first,
+        "origin first-token logits (argmax) must match the single-node run"
+    );
+
+    // `extract_sequence_handoff` is the prefill-role scheduler hook's core:
+    // serialize the pool-backed sequence (metadata + block table + block
+    // CONTENTS) to a single wire frame.
+    let wire = extract_sequence_handoff(&origin, id_o, None, PROMPT_TOKENS.to_vec())
+        .expect("extract origin sequence handoff");
+
+    let origin_live = origin.paged_pool_ref().unwrap().live_block_count();
+    let origin_stats = origin.paged_stats();
+
+    // ---- TRANSPORT: ship the frame prefill node -> decode node. ----
+    let delivered = ship_over_mock_transport(&wire);
+    assert_eq!(
+        delivered, wire,
+        "the transport must deliver the handoff frame unchanged"
+    );
+
+    // ---- DECODE ROLE: probe local geometry, ingest, decode. ----
+    // `probe_block_geometry` derives the decode model's exact (n_kv_heads,
+    // head_dim, dtype) by a one-token probe, the anchor source the ingest hook
+    // caches on the scheduler.
+    let geometry = probe_block_geometry(model, BLOCK_SIZE).expect("probe decode geometry");
+    assert_eq!(
+        geometry.num_layers, num_layers,
+        "probed geometry layer count must match the model"
+    );
+
+    let mut decode = CachePool::new(2);
+    let id_d = ingest_sequence_handoff(
+        &mut decode,
+        model,
+        &delivered,
+        &CacheIngestLimits::default(),
+        &geometry,
+        BLOCK_SIZE,
+    )
+    .expect("ingest handed-off sequence");
+
+    // KV reconstruction parity: every layer's gathered visible window on the
+    // decode node must be byte-identical to the origin's. This is the headline
+    // handoff guarantee and localizes any per-layer content/offset drift before
+    // the (noisier) end-to-end decode comparison below.
+    for layer in 0..num_layers {
+        assert_eq!(
+            gather_layer_k_bytes(&decode, id_d, layer),
+            gather_layer_k_bytes(&origin, id_o, layer),
+            "{label}: layer {layer} restored visible K window differs from the origin"
+        );
+    }
+
+    // RoPE continuation: each restored cache's monotonic offset must equal the
+    // prefilled prompt length so the first decode token rotates at the right
+    // position.
+    {
+        let caches = decode.get_caches_mut(id_d).expect("decode caches");
+        for (layer, cache) in caches.iter().enumerate() {
+            assert_eq!(
+                cache.offset,
+                PROMPT_TOKENS.len() as i32,
+                "{label}: layer {layer} restored cache offset"
+            );
+        }
+    }
+
+    // Block accounting after restore matches the origin (no leak, no double-free).
+    assert_eq!(
+        decode.paged_pool_ref().unwrap().live_block_count(),
+        origin_live,
+        "decode-node live block count must match the origin"
+    );
+    assert_eq!(
+        decode.paged_stats(),
+        origin_stats,
+        "decode-node paged stats must match the origin"
+    );
+
+    // Continue decode on the decode node from the handed-off first token.
+    let handoff_tokens = {
+        let caches = decode.get_caches_mut(id_d).unwrap();
+        assert!(
+            caches.iter().all(|c| c.is_paged_backed()),
+            "restored decode sequence must be pool-backed"
+        );
+        decode_from(model, caches, origin_first, DECODE_STEPS)
+    };
+    eprintln!("handoff   decoded: {handoff_tokens:?}");
+
+    assert_eq!(
+        handoff_tokens, ref_tokens,
+        "serving-role handoff decode must equal the single-node run\n\
+         reference: {ref_tokens:?}\nhandoff:   {handoff_tokens:?}"
+    );
+    eprintln!(
+        "OK: {label} extracted, shipped over transport, and reconstructed the sequence; \
+         decoded {DECODE_STEPS} tokens identically to the single-node run."
+    );
+}
+
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit and runs real GPU forwards; run with --ignored"]
+fn paged_handoff_over_transport_matches_single_node_qwen3() {
+    let _runtime = initialize_runtime();
+    let Some(model) = load_or_skip(QWEN3_DIR, "mlx-community/Qwen3-0.6B-4bit") else {
+        return;
+    };
+    assert_handoff_over_transport_parity(&model, QWEN3_DIR);
+}
+
+#[test]
+#[ignore = "loads llama-3.2-1b-4bit and runs real GPU forwards; run with --ignored"]
+fn paged_handoff_over_transport_matches_single_node_llama3() {
+    let _runtime = initialize_runtime();
+    let Some(model) = load_or_skip(LLAMA3_DIR, "mlx-community/Llama-3.2-1B-Instruct-4bit") else {
+        return;
+    };
+    assert_handoff_over_transport_parity(&model, LLAMA3_DIR);
+}


### PR DESCRIPTION
## Summary

In-process building block for disaggregated serving-role KV handoff (#126 step B1). This wires the #125 paged KV serde layer to the transport layer, which previously never referenced each other in production, and proves the mechanism byte-identical against real models.

## What it adds

New `distributed::disaggregated::handoff_impl`:

- **`extract_sequence_handoff`** (prefill side) serializes a finished pool-backed sequence (dense metadata, paged block table, and the referenced pool block contents) into a single wire frame.
- **`ingest_sequence_handoff`** (decode side) validates an incoming frame, allocates a fresh pool-backed sequence, and reconstructs its KV onto local pool blocks anchored to the decode model's real block geometry, releasing the slot on restore failure so a rejected handoff leaks nothing.
- **`probe_block_geometry`** derives the decode model's exact `(n_kv_heads, head_dim, dtype)` with a one-token probe through a throwaway pool-backed sequence. This captures the runtime KV dtype (bf16 for a 4-bit checkpoint, not fp16), which no static model accessor exposes, with no per-model code.
- **`send_handoff_payload` / `recv_handoff_payload`** move a frame over any `Transport` as a tagged message (the async serde/transport bridge).

`BatchScheduler` gains thin `extract_sequence_handoff` / `ingest_sequence_handoff` hooks plus a probe-once geometry cache. These are additive (`#[allow(dead_code)]`): the live caller, a serving-role serve loop, lands in a later step, matching the additive-then-wired pattern used across this epic.

## Verification

Orchestrator-local (Metal cannot run on CI runners):

- **Real-model `tests/paged_handoff_parity.rs`** (requires `test-utils`): qwen3-0.6b (28 layers) and llama3-1b (16 layers) over the full prefill-extract, MockTransport wire, probe, decode-ingest path produce a **byte-identical** 16-token decode versus a single-node run.
- **In-crate `handoff_impl_tests.rs`**: transport bridge round-trip plus two rejection paths.
- Cold `clippy -D warnings` (`metal,accelerate`, with and without `test-utils`) and `fmt` clean.

```
cargo test --test paged_handoff_parity --release \
    --features metal,accelerate,test-utils -- --ignored --nocapture --test-threads=1
```

Correctness rests on #125's proven serialize/restore path plus the `Some(geometry)` anchor, which only rejects a mismatch and does not alter a valid restore.

## Design notes

- **Geometry anchor by runtime probe.** The dims are config-derivable but the KV dtype is the runtime activation dtype with no static accessor, so a single one-token probe reads the exact geometry off the gathered window. Model-agnostic and correct for bf16 checkpoints.
- **Async bridge primitive, not the sync trait.** The scaffolding `HandoffProtocol` trait is synchronous and `PrefillHandoff`-shaped, which fights the async `Transport` (it would force a `block_on`) and only covers the send half. The async byte bridge here is the primitive the real serve loop should build on.

Part of #126
