### PR TITLE
feat: disaggregated serving-mode plumbing and coordinator skeleton

### DIFF
--- a/src/distributed/disaggregated/coordinator.rs
+++ b/src/distributed/disaggregated/coordinator.rs
@@ -1,0 +1,150 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Serving-role coordinator skeleton for disaggregated paged KV handoff (#126
+//! B2a).
+//!
+//! A [`ServingCoordinator`] binds a node's [`ServingMode`] to a concrete
+//! [`Transport`] and the address of the peer it hands off to (a decode peer for
+//! a prefill node) or receives from (a prefill peer for a decode node). It is
+//! the seam between the local execution engine (the batch scheduler, which owns
+//! the model and the `CachePool`) and the cross-node transport: a prefill node
+//! extracts a finished sequence's KV and sends the frame to its decode peer; a
+//! decode node receives the frame and ingests it onto a fresh local pool slot.
+//!
+//! # Scope of this skeleton (B2a)
+//!
+//! This is the additive skeleton. It carries the serving mode and owns the
+//! transport seam through [`ServingCoordinator::send_handoff`] /
+//! [`ServingCoordinator::recv_handoff`] (thin role-aware wrappers over the
+//! [`super::handoff_impl`] async byte bridge, which already round-trips a
+//! serialized cache frame over any [`Transport`]). What it deliberately does
+//! NOT yet hold is a [`BatchScheduler`]: the scheduler-driving run loop (pull a
+//! finished prefill -> `extract_sequence_handoff` -> [`Self::send_handoff`] on
+//! the prefill side; [`Self::recv_handoff`] -> `ingest_sequence_handoff` ->
+//! decode -> emit on the decode side) is the next step (B2b), where the
+//! scheduler serving-role driver entry points land. Keeping the scheduler out
+//! of this skeleton lets it stay model-free and unit-testable over an in-process
+//! [`MockTransport`].
+//!
+//! The CLI/startup branch that constructs a coordinator for a non-hybrid
+//! `--node-role` is plumbed separately ([`ServingMode`] now threads from
+//! `--node-role` to the worker), but the live worker still runs the standard
+//! single-node scheduler loop: a coordinator only becomes the live serving path
+//! once B2b supplies the scheduler driver and B3 supplies a real network
+//! transport (the in-process [`MockTransport`] connects two roles only within a
+//! single process, which is how B2c exercises a real-model 2-role handoff).
+//!
+//! [`BatchScheduler`]: crate::server::batch::BatchScheduler
+//! [`MockTransport`]: crate::distributed::mock_transport::MockTransport
+//! [`Transport`]: crate::distributed::transport::Transport
+
+use anyhow::Result;
+
+use super::handoff_impl::{recv_handoff_payload, send_handoff_payload};
+use super::serving::ServingMode;
+use crate::distributed::transport::Transport;
+
+/// Binds a serving role to a transport and its handoff peer.
+///
+/// Constructed by the startup serving-role branch (for a `PrefillOnly` or
+/// `DecodeOnly` node) and, in tests, directly over a [`MockTransport`]. See the
+/// module docs for the B2a scope boundary.
+///
+/// [`MockTransport`]: crate::distributed::mock_transport::MockTransport
+pub struct ServingCoordinator {
+    /// The serving mode this coordinator drives. A coordinator is only
+    /// meaningful for a non-hybrid role (`PrefillOnly` / `DecodeOnly`); the
+    /// `Hybrid` and `Router` modes never construct one (hybrid serves locally,
+    /// router has no local KV to hand off).
+    mode: ServingMode,
+
+    /// The transport this node uses to move handoff frames. A
+    /// [`MockTransport`] for the in-process B2/B2c path, a real network
+    /// transport in B3.
+    ///
+    /// [`MockTransport`]: crate::distributed::mock_transport::MockTransport
+    transport: Box<dyn Transport>,
+
+    /// Address of the peer this node hands off to or receives from.
+    ///
+    /// For a prefill node this is the decode peer the extracted frame is sent
+    /// to. For a decode node this is the prefill peer it is paired with (the
+    /// inbound frame's sender is reported by the transport on receive, so a
+    /// decode node does not need the peer address to accept a handoff, but it
+    /// is retained for symmetric construction and the B3 control path).
+    peer: String,
+}
+
+impl std::fmt::Debug for ServingCoordinator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServingCoordinator")
+            .field("mode", &self.mode)
+            .field("peer", &self.peer)
+            .finish()
+    }
+}
+
+impl ServingCoordinator {
+    /// Build a coordinator for `mode` over `transport`, handing off to / pairing
+    /// with `peer`.
+    pub fn new(mode: ServingMode, transport: Box<dyn Transport>, peer: impl Into<String>) -> Self {
+        Self {
+            mode,
+            transport,
+            peer: peer.into(),
+        }
+    }
+
+    /// The serving mode this coordinator drives.
+    pub fn mode(&self) -> ServingMode {
+        self.mode
+    }
+
+    /// The address of the handoff peer.
+    pub fn peer(&self) -> &str {
+        &self.peer
+    }
+
+    /// Borrow the underlying transport (e.g. to inspect counters in a test or
+    /// to drive a stream in B3).
+    pub fn transport(&self) -> &dyn Transport {
+        &*self.transport
+    }
+
+    /// Prefill side: send an extracted handoff frame to the decode peer.
+    ///
+    /// `payload` is a serialized cache state produced by
+    /// [`super::handoff_impl::extract_sequence_handoff`] (the scheduler driver,
+    /// B2b, produces it). The frame is tagged so the receiver rejects a
+    /// mismatched message kind.
+    pub async fn send_handoff(&self, payload: &[u8]) -> Result<()> {
+        send_handoff_payload(&*self.transport, &self.peer, payload).await
+    }
+
+    /// Decode side: receive the next inbound handoff frame, returning the
+    /// sender address and the raw serialized cache bytes.
+    ///
+    /// The bytes are handed to the scheduler driver's `ingest_sequence_handoff`
+    /// (B2b), which validates and reconstructs them onto a fresh local pool
+    /// slot. A non-handoff transport message is rejected by the underlying
+    /// bridge rather than mis-restored.
+    pub async fn recv_handoff(&self) -> Result<(String, Vec<u8>)> {
+        recv_handoff_payload(&*self.transport).await
+    }
+}
+
+#[cfg(test)]
+#[path = "coordinator_tests.rs"]
+mod tests;

--- a/src/distributed/disaggregated/coordinator_tests.rs
+++ b/src/distributed/disaggregated/coordinator_tests.rs
@@ -1,0 +1,127 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the model-free [`ServingCoordinator`] skeleton: serving-mode
+//! binding and the transport seam (send/recv handoff) over an in-process
+//! [`MockTransport`]. The real-model 2-role drive (prefill -> extract -> wire ->
+//! ingest -> decode) lands with the scheduler driver (B2b) and is gated by the
+//! real-model integration test (B2c).
+
+use bytes::Bytes;
+
+use super::ServingCoordinator;
+use crate::distributed::disaggregated::serving::ServingMode;
+use crate::distributed::mock_transport::{MockRouter, MockTransport, MockTransportConfig};
+use crate::distributed::transport::TransportMessage;
+
+/// Stand up a prefill and a decode coordinator sharing one in-process router.
+/// The prefill node hands off to `"decode"`; the decode node is paired with
+/// `"prefill"`.
+async fn two_coordinators() -> (ServingCoordinator, ServingCoordinator) {
+    let router = MockRouter::new();
+    let prefill_transport = MockTransport::new(
+        "prefill".to_string(),
+        router.clone(),
+        MockTransportConfig::default(),
+    )
+    .await;
+    let decode_transport = MockTransport::new(
+        "decode".to_string(),
+        router.clone(),
+        MockTransportConfig::default(),
+    )
+    .await;
+    let prefill = ServingCoordinator::new(
+        ServingMode::PrefillOnly,
+        Box::new(prefill_transport),
+        "decode",
+    );
+    let decode = ServingCoordinator::new(
+        ServingMode::DecodeOnly,
+        Box::new(decode_transport),
+        "prefill",
+    );
+    (prefill, decode)
+}
+
+#[test]
+fn coordinator_binds_mode_and_peer() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let (prefill, decode) = two_coordinators().await;
+
+        assert_eq!(prefill.mode(), ServingMode::PrefillOnly);
+        assert_eq!(prefill.peer(), "decode");
+        assert_eq!(decode.mode(), ServingMode::DecodeOnly);
+        assert_eq!(decode.peer(), "prefill");
+    });
+}
+
+#[test]
+fn coordinator_round_trips_a_handoff_frame() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let (prefill, decode) = two_coordinators().await;
+
+        // An opaque serialized-cache stand-in; the coordinator seam moves bytes
+        // and does not interpret them (the scheduler driver does, in B2b).
+        let payload: Vec<u8> = (0..2048_u32).map(|i| (i % 251) as u8).collect();
+
+        prefill
+            .send_handoff(&payload)
+            .await
+            .expect("prefill coordinator sends the handoff frame");
+        let (from, received) = decode
+            .recv_handoff()
+            .await
+            .expect("decode coordinator receives the handoff frame");
+
+        assert_eq!(from, "prefill", "sender must be the prefill node");
+        assert_eq!(
+            received, payload,
+            "the decode coordinator must receive the prefill bytes unchanged"
+        );
+    });
+}
+
+#[test]
+fn coordinator_recv_rejects_non_handoff_frame() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let (prefill, decode) = two_coordinators().await;
+
+        // A control message is not a handoff frame; recv must reject it rather
+        // than surface it as cache bytes for the (B2b) ingest path.
+        prefill
+            .transport()
+            .send(
+                "decode",
+                TransportMessage::Control {
+                    operation: "heartbeat".to_string(),
+                    payload: Bytes::from_static(b"ping"),
+                },
+            )
+            .await
+            .expect("send control");
+
+        let err = decode
+            .recv_handoff()
+            .await
+            .expect_err("a control message must not be accepted as a handoff");
+        assert!(
+            err.to_string().contains(super::super::HANDOFF_TENSOR_ID),
+            "rejection should name the expected handoff frame, got: {err}"
+        );
+    });
+}

--- a/src/distributed/disaggregated/mod.rs
+++ b/src/distributed/disaggregated/mod.rs
@@ -29,6 +29,7 @@
 //!   prefill→decode boundary.
 
 pub mod benchmark;
+pub mod coordinator;
 pub mod decode_scheduler;
 pub mod handoff_impl;
 pub mod prefill_scheduler;
@@ -41,6 +42,7 @@ pub use benchmark::{
     DICrossoverEntry, PromptLengthAnalysis, format_di_report, run_di_benchmark,
     run_di_crossover_analysis, run_prompt_length_analysis,
 };
+pub use coordinator::ServingCoordinator;
 pub use decode_scheduler::{
     CompletionEvent, CompletionNotifier, CompletionReason, DecodeRequest, DecodeScheduler,
     DecodeSchedulerConfig, DecodeSequence, IngestionStats, SequenceStatus,

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -428,6 +428,15 @@ pub struct ServerConfig {
     /// KV prefixes for multi-turn same-image conversations; text-only and
     /// non-VLM behavior is unchanged.
     pub enable_vlm_prefix_cache: bool,
+    /// Serving role for disaggregated paged KV serving (#126 B2), derived from
+    /// `--node-role`. [`ServingMode::Hybrid`] (the default) is the single-node
+    /// path and is byte-identical to a server with no distributed flags.
+    /// `PrefillOnly` / `DecodeOnly` select the disaggregated serving role; the
+    /// worker carries the mode so the serving-role coordinator can be wired
+    /// onto the live scheduler in a later step (B2b).
+    ///
+    /// [`ServingMode`]: crate::distributed::disaggregated::ServingMode
+    pub serving_mode: crate::distributed::disaggregated::ServingMode,
 }
 
 impl Default for ServerConfig {
@@ -483,6 +492,7 @@ impl Default for ServerConfig {
             max_kv_size: None,
             kv_cache_budget: None,
             enable_vlm_prefix_cache: false,
+            serving_mode: crate::distributed::disaggregated::ServingMode::Hybrid,
         }
     }
 }

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -252,6 +252,8 @@ impl ModelProvider {
                 config.kv_cache_budget,
                 // experimental VLM prompt-prefix cache toggle (#124 step c).
                 config.enable_vlm_prefix_cache,
+                // disaggregated serving role from `--node-role` (#126 B2).
+                config.serving_mode,
                 speculative_dispatch,
                 batch_metrics,
                 batch_observability,
@@ -397,6 +399,8 @@ impl ModelProvider {
             None,  // max_kv_size: unbounded
             None,  // kv_cache_budget: unbounded
             false, // enable_vlm_prefix_cache: off
+            // serving_mode: single-node Hybrid (this wrapper has no --node-role).
+            crate::distributed::disaggregated::ServingMode::Hybrid,
             batch_metrics,
             batch_observability,
         )
@@ -433,6 +437,7 @@ impl ModelProvider {
         // `None` keeps the pool unbounded.
         kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
         enable_vlm_prefix_cache: bool,
+        serving_mode: crate::distributed::disaggregated::ServingMode,
         batch_metrics: Arc<BatchMetrics>,
         batch_observability: Arc<BatchObservability>,
     ) -> Result<Self> {
@@ -460,6 +465,7 @@ impl ModelProvider {
             max_kv_size,
             kv_cache_budget,
             enable_vlm_prefix_cache,
+            serving_mode,
             crate::server::SpeculativeDispatch::Disabled,
             batch_metrics,
             batch_observability,
@@ -495,6 +501,7 @@ impl ModelProvider {
         max_kv_size: Option<usize>,
         kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
         enable_vlm_prefix_cache: bool,
+        serving_mode: crate::distributed::disaggregated::ServingMode,
         speculative_dispatch: crate::server::SpeculativeDispatch,
         batch_metrics: Arc<BatchMetrics>,
         batch_observability: Arc<BatchObservability>,
@@ -535,6 +542,11 @@ impl ModelProvider {
             kv_cache_budget,
             // experimental VLM prompt-prefix cache toggle (#124 step c).
             enable_vlm_prefix_cache,
+            // disaggregated serving role from `--node-role` (#126 B2). The
+            // worker carries it so the serving-role coordinator can be wired
+            // onto the live scheduler later (B2b); `Hybrid` is the unchanged
+            // single-node path.
+            serving_mode,
             // forward the resolved speculative dispatch.
             speculative_dispatch,
         };
@@ -610,6 +622,8 @@ impl ModelProvider {
             max_kv_size: None,              // unbounded in minimal test path
             kv_cache_budget: None,          // unbounded in minimal test path
             enable_vlm_prefix_cache: false, // off in minimal test path
+            // minimal test path is single-node.
+            serving_mode: crate::distributed::disaggregated::ServingMode::Hybrid,
             // minimal test path has no drafter; the dispatch
             // defaults to `Disabled` which short-circuits the scheduler
             // hot path to the classic decode loop.

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -124,6 +124,18 @@ pub(crate) struct WorkerSchedulerConfig {
     /// multi-turn same-image conversations. Text-only and non-VLM requests are
     /// unaffected either way.
     pub enable_vlm_prefix_cache: bool,
+    /// disaggregated serving role for paged KV serving (#126 B2), derived from
+    /// `--node-role`.
+    ///
+    /// [`ServingMode::Hybrid`](crate::distributed::disaggregated::ServingMode::Hybrid)
+    /// (the default) is the single-node path: the worker runs the standard
+    /// scheduler loop, byte-identical to a server with no distributed flags.
+    /// `PrefillOnly` / `DecodeOnly` select a disaggregated serving role. The
+    /// worker carries the mode so a serving-role coordinator
+    /// ([`crate::distributed::disaggregated::ServingCoordinator`]) can drive the
+    /// scheduler over the B1 handoff hooks in a later step (B2b); until then
+    /// every mode runs the standard loop.
+    pub serving_mode: crate::distributed::disaggregated::ServingMode,
     /// resolved speculative-decoding dispatch shape.
     ///
     /// Constructed once at worker construction (or
@@ -406,6 +418,23 @@ pub(crate) fn spawn_model_worker_with_batch_config(
         // scheduler can branch per-request once the round-loop dispatch
         // hook is wired in `decode_single_step`.
         .with_speculative_dispatch(sched_config.speculative_dispatch);
+
+        // #126 B2: a non-hybrid `--node-role` selects a disaggregated serving
+        // role. The serving-role coordinator
+        // (`distributed::disaggregated::ServingCoordinator`) that drives this
+        // scheduler over the B1 handoff hooks lands in B2b, and a real network
+        // transport in B3; until then every role runs the standard single-node
+        // loop, so `Hybrid` and a misconfigured single node both keep serving
+        // rather than hanging. `Hybrid` (the default) is byte-identical to
+        // before.
+        if sched_config.serving_mode != crate::distributed::disaggregated::ServingMode::Hybrid {
+            tracing::info!(
+                serving_mode = %sched_config.serving_mode,
+                "Disaggregated serving role configured; running the standard \
+                 single-node scheduler loop (serving-role coordinator wiring \
+                 lands in a later step)"
+            );
+        }
         scheduler.run();
     })
 }

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -740,6 +740,17 @@ pub(super) fn build_server_config(
         startup.no_batch,
     );
     let max_kv_size = resolve_context_kv_cap(context_size, startup.max_kv_size);
+    // Derive the disaggregated serving role from `--node-role` (#126 B2). The
+    // role string was already validated in `resolve_distributed_startup`, so a
+    // parse failure here falls back to the single-node `Hybrid` default rather
+    // than erroring a second time. Absent `--node-role` is `Hybrid` (the
+    // byte-identical single-node path).
+    let serving_mode = startup
+        .node_role
+        .as_deref()
+        .and_then(|role| role.parse::<NodeRole>().ok())
+        .map(crate::distributed::disaggregated::ServingMode::from_node_role)
+        .unwrap_or(crate::distributed::disaggregated::ServingMode::Hybrid);
 
     ServerConfig {
         api_key,
@@ -816,6 +827,8 @@ pub(super) fn build_server_config(
         kv_cache_budget: startup.kv_cache_budget,
         // forward the experimental VLM prefix-cache toggle (#124 step c).
         enable_vlm_prefix_cache: startup.enable_vlm_prefix_cache,
+        // disaggregated serving role derived from `--node-role` (#126 B2).
+        serving_mode,
     }
 }
 


### PR DESCRIPTION
Part of #126 (epic #116). B2a of the disaggregated serving productionization: the additive plumbing and a model-free coordinator skeleton, with the live single-node path byte-unchanged.

## What

- **Thread the serving role from `--node-role` to the worker.** `build_server_config` derives a `ServingMode` (`Hybrid` when the flag is absent), carried on `ServerConfig` through the model-provider ladder to `WorkerSchedulerConfig`, mirroring the `kv_cache_budget` / `enable_vlm_prefix_cache` plumbing. The worker logs a non-hybrid role and runs the standard scheduler loop unchanged.
- **Add `ServingCoordinator`** (`distributed::disaggregated::coordinator`): binds a serving mode to a `dyn Transport` and its handoff peer, owning the transport seam (`send_handoff` / `recv_handoff`) over the B1 async byte bridge. It does not yet hold a `BatchScheduler`; the scheduler-driving run loop is the next step (B2b), which keeps this skeleton model-free and unit-testable over an in-process `MockTransport`.
- **3 unit tests**: mode/peer binding, handoff round-trip, non-handoff rejection.

## Scope (dormant, additive)

Mirrors B1's additive-then-wired pattern. The serving-role coordinator that drives the scheduler over the B1 handoff hooks lands in B2b; a real network transport in B3. Until then every role runs the standard single-node loop, so `Hybrid` (the default) and a misconfigured single node both keep serving rather than hanging. The in-process `MockTransport` connects two roles only within one process (`cfg(test, test-utils)`), which is how a real-model 2-role handoff is exercised in B2c.

`Hybrid` (the default) and every existing call site stay byte-identical: the new `ServerConfig` / `WorkerSchedulerConfig` field defaults to `Hybrid`, and every struct-literal and spread site already resolves to it.

## Verified

- lib and tests compile (`metal,accelerate`)
- coordinator unit tests pass; 1106 server lib tests pass (plumbing non-regressive)
- cold clippy `-D warnings` clean on `metal,accelerate` and `+test-utils`, `--all-targets`
- rustfmt clean