### PR TITLE
feat: disaggregated serving-role loops over a real TCP transport (B3a)

### DIFF
--- a/src/distributed/disaggregated/coordinator.rs
+++ b/src/distributed/disaggregated/coordinator.rs
@@ -50,11 +50,17 @@
 //! [`MockTransport`]: crate::distributed::mock_transport::MockTransport
 //! [`Transport`]: crate::distributed::transport::Transport
 
-use anyhow::Result;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use anyhow::{Context, Result};
+use mlxcel_core::generate::SamplingConfig;
 
 use super::handoff_impl::{recv_handoff_payload, send_handoff_payload};
 use super::serving::ServingMode;
 use crate::distributed::transport::Transport;
+use crate::server::batch::BatchScheduler;
+use crate::server::model_provider::GenerateEvent;
 
 /// Binds a serving role to a transport and its handoff peer.
 ///
@@ -143,6 +149,127 @@ impl ServingCoordinator {
     pub async fn recv_handoff(&self) -> Result<(String, Vec<u8>)> {
         recv_handoff_payload(&*self.transport).await
     }
+
+    /// Prefill role loop (#126 B3a): drain prefill requests, prefill each on
+    /// `scheduler`, and send the extracted handoff frame to the decode peer.
+    ///
+    /// Each request drives the standard full-prefill + extract entry
+    /// ([`BatchScheduler::prefill_text_request_for_handoff`]); the resulting
+    /// frame is shipped over the transport seam to the decode peer. A request
+    /// that finishes at prefill (immediate EOS) produces no frame: the prefill
+    /// node already emitted its terminal event on the request's own channel, so
+    /// there is nothing to hand off. The loop returns when the request channel
+    /// closes (a graceful drain).
+    ///
+    /// The scheduler is borrowed, not owned: a worker pairs its one scheduler
+    /// with the role loop, and the coordinator stays model-free so the transport
+    /// seam keeps its lightweight unit tests. The future is `!Send` (the
+    /// scheduler holds the per-process MLX cache pool), so a caller drives it on
+    /// a current-thread runtime (the worker thread, or a `LocalSet` in tests).
+    ///
+    /// `dead_code` is allowed until the worker flip wires the live caller (B3b);
+    /// the in-process two-node parity test drives it now.
+    #[allow(dead_code)]
+    pub(crate) async fn run_prefill_role(
+        &self,
+        scheduler: &mut BatchScheduler,
+        mut requests: tokio::sync::mpsc::Receiver<PrefillRoleRequest>,
+    ) -> Result<()> {
+        while let Some(req) = requests.recv().await {
+            let frame = scheduler.prefill_text_request_for_handoff(
+                req.prompt_tokens,
+                req.sampling,
+                req.max_tokens,
+                req.response_tx,
+                req.cancelled,
+            )?;
+            if let Some(bytes) = frame {
+                self.send_handoff(&bytes)
+                    .await
+                    .context("prefill role loop: send handoff frame to the decode peer")?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Decode role loop (#126 B3a): receive handoff frames from the prefill peer,
+    /// reconstruct each onto a fresh pool slot, and decode it to completion.
+    ///
+    /// Each iteration pairs the next inbound frame with the next coordination
+    /// metadata (the per-request budget, sampling policy, and client output
+    /// channel, which travel with the node holding the client connection rather
+    /// than inside the KV frame) and drives
+    /// [`BatchScheduler::ingest_handoff_as_active`] then
+    /// [`BatchScheduler::decode_handoff_until_idle`], which streams the decode
+    /// tokens out on the request's channel. The loop returns when the metadata
+    /// channel closes.
+    ///
+    /// Metadata is paired with frames in FIFO arrival order in this in-process
+    /// step; tagging frames with a request id for out-of-order delivery is a
+    /// later step (the router in a real two-process deployment). The future is
+    /// `!Send` for the same reason as [`Self::run_prefill_role`].
+    ///
+    /// `dead_code` is allowed until the worker flip wires the live caller (B3b);
+    /// the in-process two-node parity test drives it now.
+    #[allow(dead_code)]
+    pub(crate) async fn run_decode_role(
+        &self,
+        scheduler: &mut BatchScheduler,
+        mut handoffs: tokio::sync::mpsc::Receiver<DecodeRoleHandoff>,
+    ) -> Result<()> {
+        while let Some(meta) = handoffs.recv().await {
+            let (_from, bytes) = self
+                .recv_handoff()
+                .await
+                .context("decode role loop: receive handoff frame from the prefill peer")?;
+            scheduler
+                .ingest_handoff_as_active(&bytes, meta.max_tokens, meta.sampling, meta.response_tx)
+                .context("decode role loop: ingest handoff frame as an active sequence")?;
+            scheduler.decode_handoff_until_idle();
+        }
+        Ok(())
+    }
+}
+
+/// A prefill-role work item the serving-role prefill loop turns into a handoff.
+///
+/// Carries a request's raw parts; the disaggregated path is text-only over the
+/// pool-backed Fp16 families, so a request is fully described by its prompt
+/// token ids, sampling policy, and per-request token budget. `response_tx` is
+/// the channel the prefill node emits its first token on (the decode node emits
+/// the continuation); `cancelled` is the client's cancellation flag, polled by
+/// the scheduler to abort an orphaned sequence.
+pub struct PrefillRoleRequest {
+    /// The prompt token ids to prefill.
+    pub prompt_tokens: Vec<i32>,
+    /// Sampling policy for the request.
+    pub sampling: SamplingConfig,
+    /// Maximum tokens to generate (counted across the prefill first token and
+    /// the decode continuation).
+    pub max_tokens: usize,
+    /// Output channel for the prefill node's half of the stream (the first
+    /// sampled token).
+    pub response_tx: std::sync::mpsc::Sender<GenerateEvent>,
+    /// Client cancellation flag.
+    pub cancelled: Arc<AtomicBool>,
+}
+
+/// The per-request coordination metadata a decode node pairs with an inbound
+/// handoff frame.
+///
+/// The handoff frame carries the KV cache, the prompt token history, and the
+/// prefill node's generated token(s). The request's budget, sampling policy,
+/// and output stream stay with the node holding the client connection (the
+/// router in a real deployment, the test harness in this in-process step), so
+/// the decode loop supplies them alongside each frame.
+pub struct DecodeRoleHandoff {
+    /// Maximum tokens to generate (matches the originating request budget).
+    pub max_tokens: usize,
+    /// Sampling policy for the decode continuation.
+    pub sampling: SamplingConfig,
+    /// Output channel for the decode node's half of the stream (the
+    /// continuation after the prefill node's first token).
+    pub response_tx: std::sync::mpsc::Sender<GenerateEvent>,
 }
 
 #[cfg(test)]

--- a/src/distributed/disaggregated/mod.rs
+++ b/src/distributed/disaggregated/mod.rs
@@ -42,7 +42,7 @@ pub use benchmark::{
     DICrossoverEntry, PromptLengthAnalysis, format_di_report, run_di_benchmark,
     run_di_crossover_analysis, run_prompt_length_analysis,
 };
-pub use coordinator::ServingCoordinator;
+pub use coordinator::{DecodeRoleHandoff, PrefillRoleRequest, ServingCoordinator};
 pub use decode_scheduler::{
     CompletionEvent, CompletionNotifier, CompletionReason, DecodeRequest, DecodeScheduler,
     DecodeSchedulerConfig, DecodeSequence, IngestionStats, SequenceStatus,

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -506,6 +506,83 @@ impl BatchScheduler {
         Ok(Some(bytes))
     }
 
+    /// Prefill role (#126 B3a): build a queued text sequence from the raw request
+    /// parts the serving-role prefill loop carries, run a full prefill, and
+    /// extract the pool-backed KV as a handoff frame for a decode node.
+    ///
+    /// The disaggregated path is text-only over the pool-backed Fp16 families
+    /// (qwen3 / llama3), so this builds the minimal text sequence (no VLM
+    /// embeddings, prompt-prefix adoption, thinking budget, or structured
+    /// output) and reuses [`Self::prefill_request_for_handoff`] for the prefill
+    /// and extract. `response_tx` carries the first sampled token's text back to
+    /// the caller, which is the prefill node's half of the streamed output (the
+    /// decode node emits the continuation, mirroring the router's first-token +
+    /// decode-token merge). `cancelled` is the client's cancellation flag.
+    /// Returns `Ok(None)` when the request hit EOS at the first token, in which
+    /// case there is nothing to hand off.
+    ///
+    /// The empty-prompt and chunked-prefill guards run before a cache slot is
+    /// allocated, so a rejected request leaks no pool state. Chunked prefill of
+    /// an over-long prompt on the handoff path is not yet supported (deferred).
+    #[allow(dead_code)]
+    pub(crate) fn prefill_text_request_for_handoff(
+        &mut self,
+        prompt_tokens: Vec<i32>,
+        sampling: mlxcel_core::generate::SamplingConfig,
+        max_tokens: usize,
+        response_tx: mpsc::Sender<GenerateEvent>,
+        cancelled: Arc<AtomicBool>,
+    ) -> anyhow::Result<Option<Vec<u8>>> {
+        if prompt_tokens.is_empty() {
+            anyhow::bail!("prefill-role handoff: empty prompt has no tokens to prefill");
+        }
+        if self.prefill_chunk_size > 0 && prompt_tokens.len() > self.prefill_chunk_size {
+            anyhow::bail!(
+                "prefill-role handoff does not yet support chunked prefill \
+                 (prompt {} tokens > chunk size {})",
+                prompt_tokens.len(),
+                self.prefill_chunk_size
+            );
+        }
+        // Merge the model's configured stop tokens into the request sampling
+        // exactly as the single-node intake (`enqueue_request`) does, so the
+        // handoff prefill samples the first token identically.
+        let sampling = merge_config_stop_tokens(sampling, &self.config_eos);
+        let seq_id = self
+            .allocate_sequence_state()
+            .map_err(|e| anyhow::anyhow!("prefill-role handoff: allocate sequence: {e}"))?;
+        let decode_state = StreamingDecodeState::new(&self.tokenizer, &prompt_tokens);
+        let seq = SequenceInfo {
+            seq_id,
+            state: SequenceState::Queued,
+            prompt_tokens,
+            sampling,
+            max_tokens,
+            eos_token_ids: self.config_eos.clone(),
+            priority: RequestPriority::default(),
+            logprobs_config: mlxcel_core::sampling::LogprobsConfig::default(),
+            vlm_embeddings: None,
+            images: Vec::new(),
+            audio: Vec::new(),
+            generated_tokens: Vec::new(),
+            generated_text: String::new(),
+            decode_state,
+            prefill_offset: 0,
+            prefill_start_offset: 0,
+            already_cached_tokens: 0,
+            response_tx,
+            cancelled,
+            created_at: Instant::now(),
+            prefill_start: None,
+            first_token_time: None,
+            token_history: Vec::new(),
+            merged_eos: Vec::new(),
+            thinking: crate::server::thinking_budget::ThinkingState::disabled(),
+            structured: None,
+        };
+        self.prefill_request_for_handoff(seq)
+    }
+
     /// Decode role (#126 B2b): reconstruct a handed-off sequence onto a fresh pool
     /// slot and register it as a live decode sequence in the active batch, seeded
     /// with the prefill node's generated token(s) so the next decode step feeds

--- a/src/server/batch/serving_handoff_parity_tests.rs
+++ b/src/server/batch/serving_handoff_parity_tests.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Real-model parity for the serving-role KV handoff scheduler entries (#126
-//! B2b/B2c).
+//! B2b/B2c) and the disaggregated role loops over a real transport (#126 B3a).
 //!
 //! `tests/paged_handoff_parity.rs` proves the handoff at the `CachePool` + model
 //! level. This goes one layer up to the BatchScheduler serving-role entries that
@@ -23,6 +23,14 @@
 //! [`BatchScheduler::ingest_handoff_as_active`], and decodes the restored
 //! sequence. The decode token ids must be byte-identical to a single-node run of
 //! the same prompt through the same scheduler.
+//!
+//! [`serving_role_loop_parity_matches_single_node_qwen3`] goes one layer further:
+//! two independent schedulers run the [`ServingCoordinator::run_prefill_role`] /
+//! [`ServingCoordinator::run_decode_role`] loops over a real localhost
+//! [`TcpTransport`] (not the in-process MockTransport), the decode loop as a
+//! concurrent task. The prefill node streams the first token and the decode node
+//! streams the continuation, the same split a router merges for a client, so the
+//! concatenated text must match the single-node reference.
 //!
 //! This test is in-crate because `BatchScheduler` is `pub(crate)` and cannot be
 //! constructed from an integration test (same constraint noted in
@@ -47,9 +55,13 @@ use std::time::Instant;
 use mlxcel_core::generate::SamplingConfig;
 
 use super::BatchScheduler;
-use crate::distributed::disaggregated::ServingCoordinator;
 use crate::distributed::disaggregated::serving::ServingMode;
+use crate::distributed::disaggregated::{
+    DecodeRoleHandoff, PrefillRoleRequest, ServingCoordinator,
+};
 use crate::distributed::mock_transport::{MockRouter, MockTransport, MockTransportConfig};
+use crate::distributed::tcp_transport::{TcpTransport, TcpTransportConfig};
+use crate::distributed::transport::Transport;
 use crate::server::batch::BatchObservability;
 use crate::server::batch::sequence::{RequestPriority, SequenceInfo, SequenceState};
 use crate::server::config::{DecodeStorageBackend, PreemptionPolicy};
@@ -66,6 +78,12 @@ const DECODE_STEPS: usize = 16;
 
 /// A high per-request budget so neither run finishes before `DECODE_STEPS`.
 const MAX_TOKENS: usize = 64;
+
+/// Bounded token budget for the role-loop run (#126 B3a). Both the reference and
+/// the two-node handoff generate exactly this many tokens (the prefill first
+/// token plus the decode continuation), then stop on the length limit, so the
+/// comparison is deterministic and quick.
+const ROLE_LOOP_MAX_TOKENS: usize = 16;
 
 /// A fixed ~50-token prompt (> one 32-token block, so the sequence spans two
 /// physical blocks). Deterministic ids; matches `paged_handoff_parity`.
@@ -278,6 +296,184 @@ fn serving_handoff_parity_matches_single_node_qwen3() {
     eprintln!(
         "OK: prefill-role extracted, shipped over the coordinator transport, and the \
          decode-role reconstructed + decoded {DECODE_STEPS} tokens identically to the \
+         single-node run."
+    );
+}
+
+/// Drain a streamed generation channel into the concatenated token text,
+/// ignoring the terminal `Done` event. Panics on an error event so a failed
+/// generation surfaces loudly rather than as a silent text mismatch.
+fn collect_text(rx: &mpsc::Receiver<GenerateEvent>) -> String {
+    let mut text = String::new();
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            GenerateEvent::Token(t) | GenerateEvent::TokenWithLogprobs(t, _) => text.push_str(&t),
+            GenerateEvent::Done(_) => {}
+            GenerateEvent::Error(e) => panic!("unexpected generation error event: {e}"),
+        }
+    }
+    text
+}
+
+/// A TCP transport config bound to an ephemeral localhost port. Two of these in
+/// one process simulate a prefill node and a decode node over a real socket.
+fn loopback_tcp_config() -> TcpTransportConfig {
+    TcpTransportConfig {
+        bind_address: "127.0.0.1:0".to_string(),
+        ..TcpTransportConfig::default()
+    }
+}
+
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit (3x) and runs real GPU forwards; run with --ignored"]
+fn serving_role_loop_parity_matches_single_node_qwen3() {
+    let _runtime = crate::initialize_runtime();
+    let dir = repo_model_dir(QWEN3_DIR);
+    if !dir.exists() {
+        eprintln!(
+            "Skipping {QWEN3_DIR}: model directory not found at {}.\n\
+             Fetch with: ./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit",
+            dir.display()
+        );
+        return;
+    }
+
+    // ---- REFERENCE: single-node prefill + decode-to-idle, collecting the
+    // streamed text. The scheduler is dropped before the two nodes load. ----
+    let ref_text = {
+        let (model, sched_tokenizer) =
+            crate::load_model(&dir).unwrap_or_else(|e| panic!("load {QWEN3_DIR}: {e:?}"));
+        let seq_tokenizer = crate::tokenizer::load_tokenizer(&dir).expect("load tokenizer");
+        let config_eos = crate::read_eos_token_ids(&dir);
+        let mut sched = build_paged_scheduler(model, sched_tokenizer, config_eos);
+        let ref_id = sched
+            .allocate_sequence_state()
+            .expect("allocate reference sequence");
+        let (mut ref_seq, ref_rx) = make_request(ref_id, &seq_tokenizer);
+        ref_seq.max_tokens = ROLE_LOOP_MAX_TOKENS;
+        BatchScheduler::begin_prefill(&mut ref_seq).expect("begin reference prefill");
+        sched.execute_full_prefill(ref_seq);
+        sched.decode_handoff_until_idle();
+        let text = collect_text(&ref_rx);
+        assert!(!text.is_empty(), "reference run produced no text");
+        eprintln!("reference text: {text:?}");
+        text
+    };
+
+    // ---- TWO NODES: a prefill node and a decode node, each with its own model
+    // load and scheduler, connected over a real localhost TCP transport. ----
+    let (prefill_model, prefill_tokenizer) =
+        crate::load_model(&dir).unwrap_or_else(|e| panic!("load prefill node {QWEN3_DIR}: {e:?}"));
+    let (decode_model, decode_tokenizer) =
+        crate::load_model(&dir).unwrap_or_else(|e| panic!("load decode node {QWEN3_DIR}: {e:?}"));
+    let mut prefill_sched = build_paged_scheduler(
+        prefill_model,
+        prefill_tokenizer,
+        crate::read_eos_token_ids(&dir),
+    );
+    let mut decode_sched = build_paged_scheduler(
+        decode_model,
+        decode_tokenizer,
+        crate::read_eos_token_ids(&dir),
+    );
+
+    // The prefill node's first-token channel and the decode node's continuation
+    // channel; drained after the loops finish.
+    let (prefill_resp_tx, prefill_resp_rx) = mpsc::channel();
+    let (decode_resp_tx, decode_resp_rx) = mpsc::channel();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread tokio runtime");
+    let local = tokio::task::LocalSet::new();
+    rt.block_on(local.run_until(async move {
+        // Bind both transports on an ephemeral localhost port and cross-wire the
+        // peers from the actual bound addresses.
+        let decode_transport = TcpTransport::bind(loopback_tcp_config())
+            .await
+            .expect("bind decode transport");
+        let prefill_transport = TcpTransport::bind(loopback_tcp_config())
+            .await
+            .expect("bind prefill transport");
+        let decode_addr = decode_transport.local_addr().expect("decode local addr");
+        let prefill_addr = prefill_transport.local_addr().expect("prefill local addr");
+        let prefill_coord = ServingCoordinator::new(
+            ServingMode::PrefillOnly,
+            Box::new(prefill_transport),
+            decode_addr,
+        );
+        let decode_coord = ServingCoordinator::new(
+            ServingMode::DecodeOnly,
+            Box::new(decode_transport),
+            prefill_addr,
+        );
+
+        let (prefill_req_tx, prefill_req_rx) = tokio::sync::mpsc::channel::<PrefillRoleRequest>(4);
+        let (decode_meta_tx, decode_meta_rx) = tokio::sync::mpsc::channel::<DecodeRoleHandoff>(4);
+
+        // The decode node runs its role loop as a concurrent local task: it owns
+        // its coordinator + scheduler, blocks on the inbound frame, and decodes
+        // it when the prefill node ships it. The future is `!Send` (the scheduler
+        // holds the MLX pool), so it must be `spawn_local`.
+        let decode_task = tokio::task::spawn_local(async move {
+            decode_coord
+                .run_decode_role(&mut decode_sched, decode_meta_rx)
+                .await
+        });
+
+        // Hand the decode node its per-request coordination metadata, then feed
+        // the prefill request. Closing each channel makes its loop return after
+        // the single item.
+        decode_meta_tx
+            .send(DecodeRoleHandoff {
+                max_tokens: ROLE_LOOP_MAX_TOKENS,
+                sampling: SamplingConfig::greedy(),
+                response_tx: decode_resp_tx,
+            })
+            .await
+            .expect("send decode metadata");
+        drop(decode_meta_tx);
+        prefill_req_tx
+            .send(PrefillRoleRequest {
+                prompt_tokens: PROMPT_TOKENS.to_vec(),
+                sampling: SamplingConfig::greedy(),
+                max_tokens: ROLE_LOOP_MAX_TOKENS,
+                response_tx: prefill_resp_tx,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            })
+            .await
+            .expect("send prefill request");
+        drop(prefill_req_tx);
+
+        // Drive the prefill loop inline: it prefills the request and ships the
+        // extracted frame over TCP, which the decode task receives and decodes.
+        prefill_coord
+            .run_prefill_role(&mut prefill_sched, prefill_req_rx)
+            .await
+            .expect("prefill role loop");
+        decode_task
+            .await
+            .expect("join decode role task")
+            .expect("decode role loop");
+    }));
+
+    let first_token_text = collect_text(&prefill_resp_rx);
+    let continuation_text = collect_text(&decode_resp_rx);
+    let handoff_text = format!("{first_token_text}{continuation_text}");
+    eprintln!(
+        "handoff text: {handoff_text:?} \
+         (prefill first token: {first_token_text:?}, decode continuation: {continuation_text:?})"
+    );
+
+    assert_eq!(
+        handoff_text, ref_text,
+        "two-node role-loop handoff text must equal the single-node run\n\
+         reference: {ref_text:?}\nhandoff:   {handoff_text:?}"
+    );
+    eprintln!(
+        "OK: the prefill node prefilled and shipped the KV frame over localhost TCP, the decode \
+         node reconstructed and decoded it, and the concatenated stream is byte-identical to the \
          single-node run."
     );
 }


### PR DESCRIPTION
## Summary

Epic #116 step #126 **B3a**. Adds the prefill/decode serving-role loops that drive the disaggregated KV handoff over a transport, and proves them end to end over a real localhost TCP socket.

B2b landed the scheduler handoff entries (`prefill_request_for_handoff`, `ingest_handoff_as_active`, `decode_handoff_until_idle`) and B2c proved them over an in-process MockTransport. B3a wires those entries into role loops on `ServingCoordinator` and runs them over a real `TcpTransport`.

## Changes

- **`BatchScheduler::prefill_text_request_for_handoff`** (`src/server/batch/scheduler.rs`): builds a queued text sequence from raw request parts (prompt tokens, sampling, max_tokens, response channel, cancel flag) and reuses `prefill_request_for_handoff`. The empty-prompt and chunked-prefill guards run before allocation, so a rejected request leaks no pool state.
- **`ServingCoordinator::run_prefill_role` / `run_decode_role`** (`src/distributed/disaggregated/coordinator.rs`): async role loops. Prefill drains requests, prefills each, and ships the extracted frame to the decode peer; decode receives frames, ingests each onto a fresh pool slot, and decodes to completion, streaming tokens on the request channel. The scheduler is borrowed (the coordinator stays model-free for its transport unit tests); the futures are `!Send` (the scheduler owns the per-process MLX pool), so callers drive them on a current-thread runtime.
- **`PrefillRoleRequest` / `DecodeRoleHandoff`**: the per-request work item and decode coordination metadata. The KV frame carries the cache, prompt history, and generated tokens; the per-request budget, sampling, and output stream stay with the node holding the client connection.

## Verification

Real-model two-node parity test (`serving_role_loop_parity_matches_single_node_qwen3`, `#[ignore]`): a qwen3-0.6b prefill node and a separate decode node, each its own model and scheduler, connected over a real localhost `TcpTransport` (decode loop as a concurrent `spawn_local` task on a current-thread runtime). The prefill node emits the first token and the decode node the continuation, the same split a router merges for a client; the concatenated stream is **byte-identical** to a single-node run.

```
reference text: " \n\n###Answer: 4\n\n###Step 1: 2 + "
handoff text:   " \n\n###Answer: 4\n\n###Step 1: 2 + "
  (prefill first token: " \n\n", decode continuation: "###Answer: 4\n\n###Step 1: 2 + ")
```

Gate: cold clippy `-D warnings --all-targets` on both feature sets (`metal,accelerate` and `+test-utils`), fmt, and the lib unit suites (3081 passed, 0 failed).

## Scope / follow-up (B3b)

Additive only; no existing logic changed. The worker flip (a `--node-role prefill|decode` process drives a role loop) and the two-process `RequestRouter`/`StreamBridge` HTTP path are deferred to B3b, where `--prefill-peers`/`--decode-peers` supply the peer addresses a single process otherwise lacks. The role-loop futures and channels are shaped for that wiring.

Part of #126.
