### PR TITLE
feat: serving-role worker-flip mechanism + disaggregated peer CLI (B3b1)

### DIFF
--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -511,6 +511,16 @@ struct ServerArgs {
     #[arg(long, value_delimiter = ',', value_name = "ADDR")]
     peers: Vec<std::net::SocketAddr>,
 
+    /// Comma-separated prefill-node addresses a decode node receives handoffs
+    /// from (disaggregated serving, #126). Consumed when `--node-role decode`.
+    #[arg(long, value_delimiter = ',', value_name = "ADDR")]
+    prefill_peers: Vec<std::net::SocketAddr>,
+
+    /// Comma-separated decode-node addresses a prefill node hands off to
+    /// (disaggregated serving, #126). Consumed when `--node-role prefill`.
+    #[arg(long, value_delimiter = ',', value_name = "ADDR")]
+    decode_peers: Vec<std::net::SocketAddr>,
+
     /// Manual pipeline-parallel layer partition (e.g. "0-15,16-31")
     ///
     /// Specifies explicit layer ranges per pipeline stage. Each range is
@@ -1170,6 +1180,8 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         node_role: args.node_role,
         node_id: args.node_id,
         peers: args.peers,
+        prefill_peers: args.prefill_peers,
+        decode_peers: args.decode_peers,
         pp_layers: args.pp_layers,
         pp_micro_batch_size: args.pp_micro_batch_size,
         pp_auto: args.pp_auto,

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -265,6 +265,8 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         node_role: args.node_role,
         node_id: args.node_id,
         peers: args.peers,
+        prefill_peers: args.prefill_peers,
+        decode_peers: args.decode_peers,
         pp_layers: args.pp_layers,
         pp_micro_batch_size: args.pp_micro_batch_size,
         pp_auto: args.pp_auto,

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -73,6 +73,8 @@ fn sample_args() -> crate::ServeArgs {
         node_role: None,
         node_id: None,
         peers: vec![],
+        prefill_peers: vec![],
+        decode_peers: vec![],
         pp_layers: None,
         pp_micro_batch_size: 1,
         pp_auto: None,

--- a/src/distributed/disaggregated/coordinator.rs
+++ b/src/distributed/disaggregated/coordinator.rs
@@ -58,6 +58,7 @@ use mlxcel_core::generate::SamplingConfig;
 
 use super::handoff_impl::{recv_handoff_payload, send_handoff_payload};
 use super::serving::ServingMode;
+use crate::distributed::tcp_transport::{TcpTransport, TcpTransportConfig};
 use crate::distributed::transport::Transport;
 use crate::server::batch::BatchScheduler;
 use crate::server::model_provider::GenerateEvent;
@@ -270,6 +271,82 @@ pub struct DecodeRoleHandoff {
     /// Output channel for the decode node's half of the stream (the
     /// continuation after the prefill node's first token).
     pub response_tx: std::sync::mpsc::Sender<GenerateEvent>,
+}
+
+/// Drive the prefill serving role to completion on a fresh current-thread tokio
+/// runtime, binding the node's real TCP transport (#126 B3b1).
+///
+/// The model worker is a plain `std::thread` with no ambient tokio runtime, and
+/// the role-loop future is `!Send` (the scheduler owns the per-process MLX
+/// pool), so this builds a current-thread runtime and drives the loop on it via
+/// `block_on` (a current-thread runtime accepts a `!Send` future; the transport
+/// accept loop it spawns is `Send` and runs on the same runtime). `bind` is the
+/// node's own listener config, `peer` the decode node it hands off to, and
+/// `requests` the intake seam a networked request source feeds. When `ready` is
+/// set, the bound local address is reported once the listener is up so a caller
+/// that bound an ephemeral port can wire it as a peer (tests use this; the
+/// worker passes `None`).
+///
+/// `dead_code` is allowed until the worker flip wires the live caller (B3b2);
+/// the in-process two-node parity test drives it now.
+#[allow(dead_code)]
+pub(crate) fn serve_prefill_role_blocking(
+    bind: TcpTransportConfig,
+    peer: String,
+    scheduler: &mut BatchScheduler,
+    requests: tokio::sync::mpsc::Receiver<PrefillRoleRequest>,
+    ready: Option<std::sync::mpsc::Sender<String>>,
+) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("serve prefill role: build current-thread runtime")?;
+    runtime.block_on(async move {
+        let transport = TcpTransport::bind(bind)
+            .await
+            .context("serve prefill role: bind transport")?;
+        if let Some(ready) = ready {
+            let _ = ready.send(transport.local_addr()?);
+        }
+        let coordinator =
+            ServingCoordinator::new(ServingMode::PrefillOnly, Box::new(transport), peer);
+        coordinator.run_prefill_role(scheduler, requests).await
+    })
+}
+
+/// Drive the decode serving role to completion on a fresh current-thread tokio
+/// runtime, binding the node's real TCP transport (#126 B3b1).
+///
+/// The decode counterpart of [`serve_prefill_role_blocking`]: `peer` is the
+/// prefill node it is paired with and `handoffs` the per-request coordination
+/// metadata the decode loop pairs with inbound frames. See that function for the
+/// runtime and `ready` rationale.
+///
+/// `dead_code` is allowed until the worker flip wires the live caller (B3b2);
+/// the in-process two-node parity test drives it now.
+#[allow(dead_code)]
+pub(crate) fn serve_decode_role_blocking(
+    bind: TcpTransportConfig,
+    peer: String,
+    scheduler: &mut BatchScheduler,
+    handoffs: tokio::sync::mpsc::Receiver<DecodeRoleHandoff>,
+    ready: Option<std::sync::mpsc::Sender<String>>,
+) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("serve decode role: build current-thread runtime")?;
+    runtime.block_on(async move {
+        let transport = TcpTransport::bind(bind)
+            .await
+            .context("serve decode role: bind transport")?;
+        if let Some(ready) = ready {
+            let _ = ready.send(transport.local_addr()?);
+        }
+        let coordinator =
+            ServingCoordinator::new(ServingMode::DecodeOnly, Box::new(transport), peer);
+        coordinator.run_decode_role(scheduler, handoffs).await
+    })
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1000,6 +1000,16 @@ pub(crate) struct ServeArgs {
     #[arg(long, value_delimiter = ',', value_name = "ADDR")]
     peers: Vec<std::net::SocketAddr>,
 
+    /// Comma-separated prefill-node addresses a decode node receives handoffs
+    /// from (disaggregated serving, #126). Consumed when `--node-role decode`.
+    #[arg(long, value_delimiter = ',', value_name = "ADDR")]
+    prefill_peers: Vec<std::net::SocketAddr>,
+
+    /// Comma-separated decode-node addresses a prefill node hands off to
+    /// (disaggregated serving, #126). Consumed when `--node-role prefill`.
+    #[arg(long, value_delimiter = ',', value_name = "ADDR")]
+    decode_peers: Vec<std::net::SocketAddr>,
+
     /// Manual pipeline-parallel layer partition (e.g. "0-15,16-31")
     ///
     /// Specifies explicit layer ranges per pipeline stage. Each range is

--- a/src/server/batch/serving_handoff_parity_tests.rs
+++ b/src/server/batch/serving_handoff_parity_tests.rs
@@ -55,6 +55,9 @@ use std::time::Instant;
 use mlxcel_core::generate::SamplingConfig;
 
 use super::BatchScheduler;
+use crate::distributed::disaggregated::coordinator::{
+    serve_decode_role_blocking, serve_prefill_role_blocking,
+};
 use crate::distributed::disaggregated::serving::ServingMode;
 use crate::distributed::disaggregated::{
     DecodeRoleHandoff, PrefillRoleRequest, ServingCoordinator,
@@ -476,4 +479,95 @@ fn serving_role_loop_parity_matches_single_node_qwen3() {
          node reconstructed and decoded it, and the concatenated stream is byte-identical to the \
          single-node run."
     );
+}
+
+/// The prefill-role driver (#126 B3b1) builds its own current-thread runtime,
+/// binds a real localhost TCP listener, and drives the role loop to a clean
+/// return when its request intake closes. This exercises the worker-flip glue
+/// (runtime + bind + graceful drive) the model worker uses to run a serving
+/// role; the request-by-request handoff behaviour is covered by
+/// `serving_role_loop_parity_matches_single_node_qwen3`, and the real
+/// two-process path lands in B3b2. A closed intake makes the loop return before
+/// any model forward, so this is fast, single-threaded, and needs no second node.
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit to build a scheduler; run with --ignored"]
+fn serve_prefill_role_blocking_binds_then_returns_on_closed_intake() {
+    let _runtime = crate::initialize_runtime();
+    let dir = repo_model_dir(QWEN3_DIR);
+    if !dir.exists() {
+        eprintln!(
+            "Skipping {QWEN3_DIR}: model directory not found at {}.",
+            dir.display()
+        );
+        return;
+    }
+    let (model, tokenizer) =
+        crate::load_model(&dir).unwrap_or_else(|e| panic!("load {QWEN3_DIR}: {e:?}"));
+    let mut sched = build_paged_scheduler(model, tokenizer, crate::read_eos_token_ids(&dir));
+
+    // A closed intake makes the role loop drain nothing and return immediately,
+    // so the driver only exercises the runtime + bind + graceful-return glue.
+    let (requests_tx, requests_rx) = tokio::sync::mpsc::channel::<PrefillRoleRequest>(1);
+    drop(requests_tx);
+    let (ready_tx, ready_rx) = mpsc::channel();
+
+    serve_prefill_role_blocking(
+        loopback_tcp_config(),
+        "127.0.0.1:1".to_string(),
+        &mut sched,
+        requests_rx,
+        Some(ready_tx),
+    )
+    .expect("prefill role driver returns cleanly when the intake is closed");
+
+    let addr = ready_rx
+        .recv()
+        .expect("the prefill role driver reports its bound listener address");
+    assert!(
+        addr.starts_with("127.0.0.1:"),
+        "the driver bound a localhost listener, got {addr}"
+    );
+    eprintln!("OK: prefill-role driver bound {addr} and returned on a closed intake.");
+}
+
+/// The decode-role counterpart of
+/// [`serve_prefill_role_blocking_binds_then_returns_on_closed_intake`]: the same
+/// worker-flip glue, driving the decode role loop.
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit to build a scheduler; run with --ignored"]
+fn serve_decode_role_blocking_binds_then_returns_on_closed_intake() {
+    let _runtime = crate::initialize_runtime();
+    let dir = repo_model_dir(QWEN3_DIR);
+    if !dir.exists() {
+        eprintln!(
+            "Skipping {QWEN3_DIR}: model directory not found at {}.",
+            dir.display()
+        );
+        return;
+    }
+    let (model, tokenizer) =
+        crate::load_model(&dir).unwrap_or_else(|e| panic!("load {QWEN3_DIR}: {e:?}"));
+    let mut sched = build_paged_scheduler(model, tokenizer, crate::read_eos_token_ids(&dir));
+
+    let (handoffs_tx, handoffs_rx) = tokio::sync::mpsc::channel::<DecodeRoleHandoff>(1);
+    drop(handoffs_tx);
+    let (ready_tx, ready_rx) = mpsc::channel();
+
+    serve_decode_role_blocking(
+        loopback_tcp_config(),
+        "127.0.0.1:1".to_string(),
+        &mut sched,
+        handoffs_rx,
+        Some(ready_tx),
+    )
+    .expect("decode role driver returns cleanly when the intake is closed");
+
+    let addr = ready_rx
+        .recv()
+        .expect("the decode role driver reports its bound listener address");
+    assert!(
+        addr.starts_with("127.0.0.1:"),
+        "the driver bound a localhost listener, got {addr}"
+    );
+    eprintln!("OK: decode-role driver bound {addr} and returned on a closed intake.");
 }

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -116,6 +116,12 @@ pub struct ServerStartupInput {
     pub node_id: Option<String>,
     /// Comma-separated list of peer addresses (CLI shorthand).
     pub peers: Vec<SocketAddr>,
+    /// Prefill-node peers a decode node receives handoffs from (disaggregated
+    /// serving, #126).
+    pub prefill_peers: Vec<SocketAddr>,
+    /// Decode-node peers a prefill node hands off to (disaggregated serving,
+    /// #126).
+    pub decode_peers: Vec<SocketAddr>,
     /// Manual pipeline-parallel layer partition spec (e.g. "0-15,16-31").
     pub pp_layers: Option<String>,
     /// Micro-batch size for in-process pipeline execution.

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -86,6 +86,8 @@ fn sample_input() -> ServerStartupInput {
         node_role: None,
         node_id: None,
         peers: Vec::new(),
+        prefill_peers: Vec::new(),
+        decode_peers: Vec::new(),
         pp_layers: None,
         pp_micro_batch_size: 1,
         pp_auto: None,


### PR DESCRIPTION
## Summary

Epic #116 step #126 **B3b1** (foundation, foundation-first per the B3b plan). Adds the worker-flip mechanism that drives a disaggregated serving role loop on a real TCP transport, and the peer-list CLI for the two-process topology.

B3a proved the role loops over a real localhost transport in-process. B3b1 adds the glue a model worker needs to run a role loop on its own runtime, plus the CLI surface; **B3b2** wires the live worker flip + the `RequestRouter`/`StreamBridge` client path + the real two-process E2E.

## Changes

- **`--prefill-peers` / `--decode-peers`** (both binaries → `ServerStartupInput`): comma-delimited `SocketAddr` peer lists for the disaggregated topology, mirroring `--peers`.
- **`serve_prefill_role_blocking` / `serve_decode_role_blocking`** (`coordinator.rs`): build a fresh current-thread tokio runtime, bind the node's real `TcpTransport`, and drive the B3a role loop. The role-loop future is `!Send` (the scheduler owns the per-process MLX pool), so `block_on` runs it on the current thread while the `Send` transport accept loop runs on the same runtime. An optional ready channel reports the bound listener address (so a caller that bound an ephemeral port can wire it as a peer; the worker passes `None`).

## Scope (safe-dormant)

The model-worker non-hybrid branch stays dormant (`scheduler.run()`, so a single node serves normally, no broken client path). The live worker flip + the networked request intake + result routing land in **B3b2** with the Router/StreamBridge, which supply the client-facing path a live role loop needs. Additive only; no existing logic changed.

## Verification

- `serve_*_role_blocking_binds_then_returns_on_closed_intake` (`#[ignore]`): each driver builds its runtime, binds a real localhost listener (reports a `127.0.0.1:` address), and drives its role loop to a clean return on a closed intake. Single-threaded and fast — a `!Send` scheduler can't cross a `std::thread` and `serve_role` builds its own runtime, so the two-context handoff is B3b2's real two-process spawn.
- The B3a (`serving_role_loop_parity`) and B2b/B2c (`serving_handoff_parity`) real-model parity tests still pass unchanged (4/4 in the module).
- Gate: cold clippy `-D warnings --all-targets` both feature sets (`metal,accelerate` and `+test-utils`), fmt, lib unit tests (3081 passed).

Part of #126.
