### PR TITLE
feat: live 2-process disaggregated serving handoff (B3b2a)

### DIFF
--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -521,6 +521,13 @@ struct ServerArgs {
     #[arg(long, value_delimiter = ',', value_name = "ADDR")]
     decode_peers: Vec<std::net::SocketAddr>,
 
+    /// This node's own bind address (host:port) for the disaggregated
+    /// serving-role transport (#126). Required for a `--node-role prefill` or
+    /// `--node-role decode` node: the prefill node listens here for request
+    /// frames and the decode node for KV handoffs.
+    #[arg(long, value_name = "ADDR")]
+    serving_bind: Option<std::net::SocketAddr>,
+
     /// Manual pipeline-parallel layer partition (e.g. "0-15,16-31")
     ///
     /// Specifies explicit layer ranges per pipeline stage. Each range is
@@ -1182,6 +1189,7 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         peers: args.peers,
         prefill_peers: args.prefill_peers,
         decode_peers: args.decode_peers,
+        serving_bind: args.serving_bind,
         pp_layers: args.pp_layers,
         pp_micro_batch_size: args.pp_micro_batch_size,
         pp_auto: args.pp_auto,

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -267,6 +267,7 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         peers: args.peers,
         prefill_peers: args.prefill_peers,
         decode_peers: args.decode_peers,
+        serving_bind: args.serving_bind,
         pp_layers: args.pp_layers,
         pp_micro_batch_size: args.pp_micro_batch_size,
         pp_auto: args.pp_auto,

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -75,6 +75,7 @@ fn sample_args() -> crate::ServeArgs {
         peers: vec![],
         prefill_peers: vec![],
         decode_peers: vec![],
+        serving_bind: None,
         pp_layers: None,
         pp_micro_batch_size: 1,
         pp_auto: None,

--- a/src/distributed/disaggregated/coordinator.rs
+++ b/src/distributed/disaggregated/coordinator.rs
@@ -52,12 +52,17 @@
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::mpsc;
 
 use anyhow::{Context, Result};
 use mlxcel_core::generate::SamplingConfig;
 
 use super::handoff_impl::{recv_handoff_payload, send_handoff_payload};
 use super::serving::ServingMode;
+use super::serving_protocol::{
+    DecodeMetaFrame, PrefillRequestFrame, ResultFrame, ResultPhase, control_parts,
+    sampling_from_serializable,
+};
 use crate::distributed::tcp_transport::{TcpTransport, TcpTransportConfig};
 use crate::distributed::transport::Transport;
 use crate::server::batch::BatchScheduler;
@@ -230,6 +235,197 @@ impl ServingCoordinator {
         }
         Ok(())
     }
+
+    /// Live prefill role loop (#126 B3b2a): drive prefill from networked request
+    /// frames and return results over the network.
+    ///
+    /// Unlike [`Self::run_prefill_role`] (driven by an in-process channel for the
+    /// single-process parity test), this is the loop a real prefill worker runs:
+    /// requests arrive as [`PrefillRequestFrame`] control frames over the
+    /// transport, and the prefill node returns its first token to the request's
+    /// `reply_to` and forwards the KV handoff (a [`DecodeMetaFrame`] followed by
+    /// the KV frame) to the decode peer ([`Self::peer`]). A request that finishes
+    /// at prefill (immediate EOS) produces no handoff: its first-token result is
+    /// the whole stream and is marked done.
+    ///
+    /// The loop returns when the transport's inbound channel closes (shutdown).
+    /// A non-request control frame is logged and skipped. The future is `!Send`
+    /// (the scheduler holds the per-process MLX pool), so a caller drives it on a
+    /// current-thread runtime ([`serve_prefill_role_networked_blocking`]).
+    pub(crate) async fn run_prefill_role_networked(
+        &self,
+        scheduler: &mut BatchScheduler,
+    ) -> Result<()> {
+        loop {
+            let message = match self.transport.recv().await {
+                Ok((_from, message)) => message,
+                // Inbound channel closed: the node is shutting down. A graceful
+                // return rather than a hard error.
+                Err(_) => break,
+            };
+            let (operation, payload) = match control_parts(message) {
+                Ok(parts) => parts,
+                Err(e) => {
+                    tracing::warn!("prefill role: ignoring non-control frame: {e}");
+                    continue;
+                }
+            };
+            if operation != PrefillRequestFrame::OPERATION {
+                tracing::warn!(
+                    "prefill role: ignoring unexpected control op '{operation}' \
+                     (expected '{}')",
+                    PrefillRequestFrame::OPERATION
+                );
+                continue;
+            }
+            let request = PrefillRequestFrame::decode(&payload)
+                .context("prefill role: decode prefill request frame")?;
+
+            // Drive the standard full-prefill + extract entry, capturing the
+            // first token on a local channel so it can be returned over the wire.
+            let (token_tx, token_rx) = mpsc::channel();
+            let frame = scheduler.prefill_text_request_for_handoff(
+                request.prompt_tokens,
+                sampling_from_serializable(&request.sampling),
+                request.max_tokens as usize,
+                token_tx,
+                Arc::new(AtomicBool::new(false)),
+            )?;
+            let (tokens, done, error) = drain_generation_events(&token_rx);
+
+            // Return the prefill node's first token to the client. When prefill
+            // produced no handoff frame (immediate EOS), this first-token result
+            // is the entire stream, so mark it done.
+            let first_result = ResultFrame {
+                request_id: request.request_id,
+                phase: ResultPhase::FirstToken,
+                tokens,
+                done: done || frame.is_none(),
+                error,
+            };
+            self.transport
+                .send(&request.reply_to, first_result.encode()?)
+                .await
+                .context("prefill role: return the first token to reply_to")?;
+
+            // Forward the handoff to the decode peer: the coordination metadata
+            // first, then the KV frame (the decode loop reads them in that order).
+            if let Some(bytes) = frame {
+                let meta = DecodeMetaFrame {
+                    request_id: request.request_id,
+                    max_tokens: request.max_tokens,
+                    sampling: request.sampling,
+                    reply_to: request.reply_to,
+                };
+                self.transport
+                    .send(self.peer(), meta.encode()?)
+                    .await
+                    .context("prefill role: forward decode metadata to the decode peer")?;
+                self.send_handoff(&bytes)
+                    .await
+                    .context("prefill role: ship the KV handoff to the decode peer")?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Live decode role loop (#126 B3b2a): reconstruct networked handoffs and
+    /// return the continuation over the network.
+    ///
+    /// The decode counterpart of [`Self::run_prefill_role_networked`]: each
+    /// iteration reads the prefill node's [`DecodeMetaFrame`] then the KV frame,
+    /// reconstructs the sequence on a fresh pool slot, decodes it to completion,
+    /// and returns the continuation tokens to the metadata's `reply_to` (the
+    /// client). The decode node has no fixed handoff peer: it replies to whatever
+    /// address each request carries, so the merged client stream is the prefill
+    /// node's first token plus this continuation.
+    ///
+    /// The loop returns when the transport's inbound channel closes. The future
+    /// is `!Send` for the same reason as the prefill loop.
+    pub(crate) async fn run_decode_role_networked(
+        &self,
+        scheduler: &mut BatchScheduler,
+    ) -> Result<()> {
+        loop {
+            let message = match self.transport.recv().await {
+                Ok((_from, message)) => message,
+                Err(_) => break,
+            };
+            let (operation, payload) = match control_parts(message) {
+                Ok(parts) => parts,
+                Err(e) => {
+                    tracing::warn!("decode role: ignoring non-control frame before KV: {e}");
+                    continue;
+                }
+            };
+            if operation != DecodeMetaFrame::OPERATION {
+                tracing::warn!(
+                    "decode role: ignoring unexpected control op '{operation}' \
+                     (expected '{}')",
+                    DecodeMetaFrame::OPERATION
+                );
+                continue;
+            }
+            let meta =
+                DecodeMetaFrame::decode(&payload).context("decode role: decode metadata frame")?;
+
+            // The KV handoff frame follows its metadata frame on the wire.
+            let (_from, bytes) = self
+                .recv_handoff()
+                .await
+                .context("decode role: receive the KV handoff after its metadata")?;
+
+            let (token_tx, token_rx) = mpsc::channel();
+            scheduler
+                .ingest_handoff_as_active(
+                    &bytes,
+                    meta.max_tokens as usize,
+                    sampling_from_serializable(&meta.sampling),
+                    token_tx,
+                )
+                .context("decode role: ingest the handoff as an active sequence")?;
+            scheduler.decode_handoff_until_idle();
+            let (tokens, _done, error) = drain_generation_events(&token_rx);
+
+            let result = ResultFrame {
+                request_id: meta.request_id,
+                phase: ResultPhase::Continuation,
+                tokens,
+                done: true,
+                error,
+            };
+            self.transport
+                .send(&meta.reply_to, result.encode()?)
+                .await
+                .context("decode role: return the continuation to reply_to")?;
+        }
+        Ok(())
+    }
+}
+
+/// Drain a finished generation channel into its text pieces, terminal flag, and
+/// any error.
+///
+/// The serving-role scheduler entries
+/// ([`BatchScheduler::prefill_text_request_for_handoff`] /
+/// [`BatchScheduler::decode_handoff_until_idle`]) run synchronously to
+/// completion and emit their [`GenerateEvent`]s on a local channel before
+/// returning, so a non-blocking drain after the call collects the whole half of
+/// the stream.
+fn drain_generation_events(
+    rx: &mpsc::Receiver<GenerateEvent>,
+) -> (Vec<String>, bool, Option<String>) {
+    let mut tokens = Vec::new();
+    let mut done = false;
+    let mut error = None;
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            GenerateEvent::Token(t) | GenerateEvent::TokenWithLogprobs(t, _) => tokens.push(t),
+            GenerateEvent::Done(_) => done = true,
+            GenerateEvent::Error(e) => error = Some(e),
+        }
+    }
+    (tokens, done, error)
 }
 
 /// A prefill-role work item the serving-role prefill loop turns into a handoff.
@@ -346,6 +542,75 @@ pub(crate) fn serve_decode_role_blocking(
         let coordinator =
             ServingCoordinator::new(ServingMode::DecodeOnly, Box::new(transport), peer);
         coordinator.run_decode_role(scheduler, handoffs).await
+    })
+}
+
+/// Drive the prefill serving role over a real network transport on a fresh
+/// current-thread runtime, returning when the transport closes (#126 B3b2a).
+///
+/// The live counterpart of [`serve_prefill_role_blocking`]: instead of an
+/// in-process request channel, prefill requests arrive as
+/// [`PrefillRequestFrame`] control frames over the bound transport and results
+/// are returned over the network, so a model worker can run this directly. `bind`
+/// is the node's own role-transport listener, `decode_peer` the decode node it
+/// hands KV off to. When `ready` is set the bound local address is reported once
+/// the listener is up (tests learn an ephemeral port this way; the worker passes
+/// `None`).
+///
+/// [`PrefillRequestFrame`]: super::serving_protocol::PrefillRequestFrame
+pub(crate) fn serve_prefill_role_networked_blocking(
+    bind: TcpTransportConfig,
+    decode_peer: String,
+    scheduler: &mut BatchScheduler,
+    ready: Option<std::sync::mpsc::Sender<String>>,
+) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("serve prefill role: build current-thread runtime")?;
+    runtime.block_on(async move {
+        let transport = TcpTransport::bind(bind)
+            .await
+            .context("serve prefill role: bind transport")?;
+        if let Some(ready) = ready {
+            let _ = ready.send(transport.local_addr()?);
+        }
+        let coordinator =
+            ServingCoordinator::new(ServingMode::PrefillOnly, Box::new(transport), decode_peer);
+        coordinator.run_prefill_role_networked(scheduler).await
+    })
+}
+
+/// Drive the decode serving role over a real network transport on a fresh
+/// current-thread runtime (#126 B3b2a).
+///
+/// The live counterpart of [`serve_decode_role_blocking`]: handoff frames (a
+/// [`DecodeMetaFrame`] then the KV frame) arrive over the bound transport and the
+/// continuation is returned to each request's `reply_to`. A decode node has no
+/// fixed handoff peer (it replies per request), so the coordinator is built with
+/// an empty peer. See [`serve_prefill_role_networked_blocking`] for the runtime
+/// and `ready` rationale.
+///
+/// [`DecodeMetaFrame`]: super::serving_protocol::DecodeMetaFrame
+pub(crate) fn serve_decode_role_networked_blocking(
+    bind: TcpTransportConfig,
+    scheduler: &mut BatchScheduler,
+    ready: Option<std::sync::mpsc::Sender<String>>,
+) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("serve decode role: build current-thread runtime")?;
+    runtime.block_on(async move {
+        let transport = TcpTransport::bind(bind)
+            .await
+            .context("serve decode role: bind transport")?;
+        if let Some(ready) = ready {
+            let _ = ready.send(transport.local_addr()?);
+        }
+        let coordinator =
+            ServingCoordinator::new(ServingMode::DecodeOnly, Box::new(transport), String::new());
+        coordinator.run_decode_role_networked(scheduler).await
     })
 }
 

--- a/src/distributed/disaggregated/mod.rs
+++ b/src/distributed/disaggregated/mod.rs
@@ -35,6 +35,7 @@ pub mod handoff_impl;
 pub mod prefill_scheduler;
 pub mod request_router;
 pub mod serving;
+pub mod serving_protocol;
 pub mod stream_bridge;
 
 pub use benchmark::{
@@ -63,5 +64,9 @@ pub use request_router::{
 pub use serving::{
     DisaggregatedMetrics, DisaggregatedMetricsSnapshot, DisaggregatedServer,
     DisaggregatedServingConfig, HybridModeGuard, ServingMode,
+};
+pub use serving_protocol::{
+    DecodeMetaFrame, PrefillRequestFrame, ResultFrame, ResultPhase, control_parts,
+    sampling_from_serializable, sampling_to_serializable,
 };
 pub use stream_bridge::{StreamBridge, StreamBridgeError, StreamPhase, TokenEvent, TokenSource};

--- a/src/distributed/disaggregated/serving_protocol.rs
+++ b/src/distributed/disaggregated/serving_protocol.rs
@@ -1,0 +1,231 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Control-frame wire protocol for live disaggregated serving (#126 B3b2a).
+//!
+//! The KV cache itself rides a [`TransportMessage::TensorData`] handoff frame
+//! (see [`super::handoff_impl`]). This module adds the small JSON control frames
+//! that surround it so a request can flow client -> prefill node -> decode node
+//! -> client across real processes:
+//!
+//! 1. [`PrefillRequestFrame`] (`serve.prefill_request`): the client (a router,
+//!    or the test harness standing in for one) sends a request's prompt token
+//!    ids, sampling policy, token budget, and a `reply_to` address to a prefill
+//!    node.
+//! 2. [`DecodeMetaFrame`] (`serve.decode_meta`): the prefill node forwards the
+//!    per-request coordination metadata (budget, sampling, `reply_to`) to the
+//!    decode node, sent immediately before the KV handoff frame so the decode
+//!    node knows how to continue the sequence and where to return its tokens.
+//! 3. [`ResultFrame`] (`serve.result`): a node returns generated tokens to the
+//!    request's `reply_to`. The prefill node returns its
+//!    [`ResultPhase::FirstToken`]; the decode node returns the
+//!    [`ResultPhase::Continuation`]. The client concatenates the two halves, the
+//!    same split a [`StreamBridge`] merges in a full router deployment (B3b2b).
+//!
+//! All three are carried as [`TransportMessage::Control`] with a JSON payload,
+//! matching the existing convention of riding cache metadata inside JSON (the KV
+//! tensor bytes stay on the binary `TensorData` frame). The control payloads are
+//! tiny (token ids and sampling scalars), so JSON keeps them debuggable without
+//! a measurable cost.
+//!
+//! [`TransportMessage::TensorData`]: crate::distributed::transport::TransportMessage::TensorData
+//! [`TransportMessage::Control`]: crate::distributed::transport::TransportMessage::Control
+//! [`StreamBridge`]: super::stream_bridge::StreamBridge
+
+use anyhow::{Result, bail};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+use mlxcel_core::generate::SamplingConfig;
+
+use crate::distributed::kv_cache_serde::SerializableSamplingState;
+use crate::distributed::transport::TransportMessage;
+
+/// Control operation tag for a [`PrefillRequestFrame`].
+pub const OP_PREFILL_REQUEST: &str = "serve.prefill_request";
+/// Control operation tag for a [`DecodeMetaFrame`].
+pub const OP_DECODE_META: &str = "serve.decode_meta";
+/// Control operation tag for a [`ResultFrame`].
+pub const OP_RESULT: &str = "serve.result";
+
+/// A prefill-role work request a client (router) sends to a prefill node.
+///
+/// The disaggregated path is text-only over the pool-backed Fp16 families, so a
+/// request is fully described by its prompt token ids, sampling policy, and
+/// per-request token budget. `reply_to` is the listener address the node returns
+/// its [`ResultFrame`]s to (the router, or the test harness standing in for one),
+/// and `request_id` correlates the frames that belong to one request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrefillRequestFrame {
+    /// Correlates the request's frames (decode meta, results) across nodes.
+    pub request_id: u64,
+    /// Prompt token ids to prefill.
+    pub prompt_tokens: Vec<i32>,
+    /// Sampling policy for the request (mirrors the decode-relevant
+    /// [`SamplingConfig`] fields; see [`sampling_to_serializable`]).
+    pub sampling: SerializableSamplingState,
+    /// Maximum tokens to generate (counted across the prefill first token and
+    /// the decode continuation).
+    pub max_tokens: u64,
+    /// Listener address (`host:port`) the nodes return [`ResultFrame`]s to.
+    pub reply_to: String,
+}
+
+/// The per-request coordination metadata a prefill node forwards to a decode
+/// node, sent immediately before the KV handoff frame.
+///
+/// The KV handoff frame carries the cache, the prompt token history, and the
+/// prefill node's first generated token. The request's budget, sampling policy,
+/// and `reply_to` travel with the node holding the client connection, so the
+/// prefill node forwards them here for the decode node to continue with.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DecodeMetaFrame {
+    /// Correlates with the originating [`PrefillRequestFrame::request_id`].
+    pub request_id: u64,
+    /// Maximum tokens to generate (matches the originating request budget).
+    pub max_tokens: u64,
+    /// Sampling policy for the decode continuation.
+    pub sampling: SerializableSamplingState,
+    /// Listener address the decode node returns its [`ResultFrame`] to.
+    pub reply_to: String,
+}
+
+/// Which half of the generated stream a [`ResultFrame`] carries.
+///
+/// A disaggregated request's output is split: the prefill node samples the first
+/// token, the decode node generates the continuation. The client orders the two
+/// halves by phase before concatenating, the same split a [`StreamBridge`] merges
+/// in a full router deployment.
+///
+/// [`StreamBridge`]: super::stream_bridge::StreamBridge
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResultPhase {
+    /// The prefill node's first sampled token.
+    FirstToken,
+    /// The decode node's continuation (tokens after the first), ending the
+    /// stream.
+    Continuation,
+}
+
+/// Generated tokens a node returns to a request's `reply_to`.
+///
+/// `tokens` are the detokenized text pieces in order; `done` marks the terminal
+/// frame of the request (the decode node sets it on the continuation); `error`
+/// carries a generation error message instead of tokens when one occurred.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResultFrame {
+    /// Correlates with the originating [`PrefillRequestFrame::request_id`].
+    pub request_id: u64,
+    /// Which half of the stream this frame carries.
+    pub phase: ResultPhase,
+    /// Detokenized text pieces, in generation order.
+    pub tokens: Vec<String>,
+    /// `true` on the terminal frame of the request.
+    pub done: bool,
+    /// A generation error message, if the node hit one.
+    pub error: Option<String>,
+}
+
+macro_rules! json_control_frame {
+    ($ty:ty, $op:expr) => {
+        impl $ty {
+            /// The control operation tag this frame is carried under.
+            pub const OPERATION: &'static str = $op;
+
+            /// Encode this frame as a [`TransportMessage::Control`] ready to send.
+            pub fn encode(&self) -> Result<TransportMessage> {
+                let payload = serde_json::to_vec(self)?;
+                Ok(TransportMessage::Control {
+                    operation: Self::OPERATION.to_string(),
+                    payload: Bytes::from(payload),
+                })
+            }
+
+            /// Decode this frame from a control payload.
+            pub fn decode(payload: &[u8]) -> Result<Self> {
+                Ok(serde_json::from_slice(payload)?)
+            }
+        }
+    };
+}
+
+json_control_frame!(PrefillRequestFrame, OP_PREFILL_REQUEST);
+json_control_frame!(DecodeMetaFrame, OP_DECODE_META);
+json_control_frame!(ResultFrame, OP_RESULT);
+
+/// Split a [`TransportMessage::Control`] into its operation tag and payload,
+/// rejecting a [`TransportMessage::TensorData`] frame (which belongs on the KV
+/// handoff path, not the control path).
+pub fn control_parts(message: TransportMessage) -> Result<(String, Bytes)> {
+    match message {
+        TransportMessage::Control { operation, payload } => Ok((operation, payload)),
+        TransportMessage::TensorData { tensor_id, .. } => {
+            bail!("expected a control frame, got TensorData('{tensor_id}')")
+        }
+    }
+}
+
+/// Copy the decode-relevant fields of a live [`SamplingConfig`] into the
+/// serializable mirror carried on the wire.
+///
+/// The server-wide `token_bias` map is intentionally dropped: it is a node-local
+/// policy applied at sampling time, not a per-request handoff field, and both
+/// nodes resolve their own.
+pub fn sampling_to_serializable(config: &SamplingConfig) -> SerializableSamplingState {
+    SerializableSamplingState {
+        temperature: config.temperature,
+        top_k: config.top_k,
+        top_p: config.top_p,
+        min_p: config.min_p,
+        seed: config.seed,
+        repetition_penalty: config.repetition_penalty,
+        dry_multiplier: config.dry_multiplier,
+        dry_base: config.dry_base,
+        dry_allowed_length: config.dry_allowed_length,
+        dry_penalty_last_n: config.dry_penalty_last_n,
+        dry_sequence_breakers: config.dry_sequence_breakers.clone(),
+        frequency_penalty: config.frequency_penalty,
+        presence_penalty: config.presence_penalty,
+        stop_token_ids: config.stop_token_ids.clone(),
+    }
+}
+
+/// Reconstruct a live [`SamplingConfig`] from the serializable wire mirror.
+///
+/// The inverse of [`sampling_to_serializable`]; `token_bias` is left at its
+/// default (the receiving node applies its own server-wide bias, if any).
+pub fn sampling_from_serializable(state: &SerializableSamplingState) -> SamplingConfig {
+    SamplingConfig {
+        temperature: state.temperature,
+        top_k: state.top_k,
+        top_p: state.top_p,
+        min_p: state.min_p,
+        seed: state.seed,
+        repetition_penalty: state.repetition_penalty,
+        dry_multiplier: state.dry_multiplier,
+        dry_base: state.dry_base,
+        dry_allowed_length: state.dry_allowed_length,
+        dry_penalty_last_n: state.dry_penalty_last_n,
+        dry_sequence_breakers: state.dry_sequence_breakers.clone(),
+        frequency_penalty: state.frequency_penalty,
+        presence_penalty: state.presence_penalty,
+        stop_token_ids: state.stop_token_ids.clone(),
+        token_bias: Default::default(),
+    }
+}
+
+#[cfg(test)]
+#[path = "serving_protocol_tests.rs"]
+mod tests;

--- a/src/distributed/disaggregated/serving_protocol_tests.rs
+++ b/src/distributed/disaggregated/serving_protocol_tests.rs
@@ -1,0 +1,136 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the serving control-frame wire protocol (#126 B3b2a).
+//!
+//! Model-free: exercise the frame encode/decode round-trips, the control/tensor
+//! discrimination, and the sampling-config mirror, with no GPU or model load.
+
+use super::*;
+use crate::distributed::transport::TransportMessage;
+use bytes::Bytes;
+use mlxcel_core::generate::SamplingConfig;
+
+fn sample_sampling() -> SerializableSamplingState {
+    sampling_to_serializable(&SamplingConfig::greedy())
+}
+
+#[test]
+fn prefill_request_frame_round_trips_through_a_control_message() {
+    let frame = PrefillRequestFrame {
+        request_id: 7,
+        prompt_tokens: vec![1, 2, 3, 42],
+        sampling: sample_sampling(),
+        max_tokens: 64,
+        reply_to: "127.0.0.1:5555".to_string(),
+    };
+    let message = frame.encode().expect("encode prefill request");
+    let (op, payload) = control_parts(message).expect("control parts");
+    assert_eq!(op, OP_PREFILL_REQUEST);
+    assert_eq!(op, PrefillRequestFrame::OPERATION);
+
+    let decoded = PrefillRequestFrame::decode(&payload).expect("decode prefill request");
+    assert_eq!(decoded.request_id, 7);
+    assert_eq!(decoded.prompt_tokens, vec![1, 2, 3, 42]);
+    assert_eq!(decoded.max_tokens, 64);
+    assert_eq!(decoded.reply_to, "127.0.0.1:5555");
+}
+
+#[test]
+fn decode_meta_frame_round_trips_through_a_control_message() {
+    let frame = DecodeMetaFrame {
+        request_id: 11,
+        max_tokens: 32,
+        sampling: sample_sampling(),
+        reply_to: "127.0.0.1:6666".to_string(),
+    };
+    let message = frame.encode().expect("encode decode meta");
+    let (op, payload) = control_parts(message).expect("control parts");
+    assert_eq!(op, OP_DECODE_META);
+
+    let decoded = DecodeMetaFrame::decode(&payload).expect("decode decode meta");
+    assert_eq!(decoded.request_id, 11);
+    assert_eq!(decoded.max_tokens, 32);
+    assert_eq!(decoded.reply_to, "127.0.0.1:6666");
+}
+
+#[test]
+fn result_frame_round_trips_both_phases() {
+    let first = ResultFrame {
+        request_id: 3,
+        phase: ResultPhase::FirstToken,
+        tokens: vec![" Hello".to_string()],
+        done: false,
+        error: None,
+    };
+    let cont = ResultFrame {
+        request_id: 3,
+        phase: ResultPhase::Continuation,
+        tokens: vec![" world".to_string(), "!".to_string()],
+        done: true,
+        error: None,
+    };
+    for frame in [first, cont] {
+        let message = frame.encode().expect("encode result");
+        let (op, payload) = control_parts(message).expect("control parts");
+        assert_eq!(op, OP_RESULT);
+        let decoded = ResultFrame::decode(&payload).expect("decode result");
+        assert_eq!(decoded.request_id, frame.request_id);
+        assert_eq!(decoded.phase, frame.phase);
+        assert_eq!(decoded.tokens, frame.tokens);
+        assert_eq!(decoded.done, frame.done);
+    }
+}
+
+#[test]
+fn control_parts_rejects_a_tensor_data_frame() {
+    let message = TransportMessage::TensorData {
+        tensor_id: "kv-cache-handoff".to_string(),
+        shape: vec![4],
+        data: Bytes::from_static(&[0, 1, 2, 3]),
+    };
+    let err = control_parts(message).expect_err("a tensor frame is not a control frame");
+    assert!(
+        err.to_string().contains("TensorData"),
+        "error should name the offending frame kind, got: {err}"
+    );
+}
+
+#[test]
+fn sampling_round_trips_through_the_serializable_mirror() {
+    let mut config = SamplingConfig::greedy();
+    config.temperature = 0.7;
+    config.top_k = 40;
+    config.top_p = 0.95;
+    config.min_p = 0.05;
+    config.seed = Some(1234);
+    config.repetition_penalty = 1.1;
+    config.frequency_penalty = 0.2;
+    config.presence_penalty = 0.3;
+    config.stop_token_ids = vec![13, 14];
+    config.dry_sequence_breakers = vec![198];
+
+    let restored = sampling_from_serializable(&sampling_to_serializable(&config));
+
+    assert_eq!(restored.temperature, 0.7);
+    assert_eq!(restored.top_k, 40);
+    assert_eq!(restored.top_p, 0.95);
+    assert_eq!(restored.min_p, 0.05);
+    assert_eq!(restored.seed, Some(1234));
+    assert_eq!(restored.repetition_penalty, 1.1);
+    assert_eq!(restored.frequency_penalty, 0.2);
+    assert_eq!(restored.presence_penalty, 0.3);
+    assert_eq!(restored.stop_token_ids, vec![13, 14]);
+    assert_eq!(restored.dry_sequence_breakers, vec![198]);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1010,6 +1010,13 @@ pub(crate) struct ServeArgs {
     #[arg(long, value_delimiter = ',', value_name = "ADDR")]
     decode_peers: Vec<std::net::SocketAddr>,
 
+    /// This node's own bind address (host:port) for the disaggregated
+    /// serving-role transport (#126). Required for a `--node-role prefill` or
+    /// `--node-role decode` node: the prefill node listens here for request
+    /// frames and the decode node for KV handoffs.
+    #[arg(long, value_name = "ADDR")]
+    serving_bind: Option<std::net::SocketAddr>,
+
     /// Manual pipeline-parallel layer partition (e.g. "0-15,16-31")
     ///
     /// Specifies explicit layer ranges per pipeline stage. Each range is

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -122,6 +122,10 @@ pub struct ServerStartupInput {
     /// Decode-node peers a prefill node hands off to (disaggregated serving,
     /// #126).
     pub decode_peers: Vec<SocketAddr>,
+    /// This node's own serving-role transport bind address (disaggregated
+    /// serving, #126). `Some` enables the live prefill/decode role loop on a
+    /// non-hybrid node; `None` keeps the standard single-node scheduler loop.
+    pub serving_bind: Option<SocketAddr>,
     /// Manual pipeline-parallel layer partition spec (e.g. "0-15,16-31").
     pub pp_layers: Option<String>,
     /// Micro-batch size for in-process pipeline execution.
@@ -539,6 +543,9 @@ impl ServerStartupInput {
             node_role: self.node_role,
             node_id: self.node_id,
             peers: self.peers,
+            prefill_peers: self.prefill_peers,
+            decode_peers: self.decode_peers,
+            serving_bind: self.serving_bind,
             pp_layers: self.pp_layers,
             pp_micro_batch_size: self.pp_micro_batch_size,
             pp_auto: self.pp_auto,

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -88,6 +88,7 @@ fn sample_input() -> ServerStartupInput {
         peers: Vec::new(),
         prefill_peers: Vec::new(),
         decode_peers: Vec::new(),
+        serving_bind: None,
         pp_layers: None,
         pp_micro_batch_size: 1,
         pp_auto: None,

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -437,6 +437,16 @@ pub struct ServerConfig {
     ///
     /// [`ServingMode`]: crate::distributed::disaggregated::ServingMode
     pub serving_mode: crate::distributed::disaggregated::ServingMode,
+    /// Prefill-node peers a decode node receives handoffs from (disaggregated
+    /// serving, #126 B3b2a). Threaded to the worker for the live serving role.
+    pub prefill_peers: Vec<std::net::SocketAddr>,
+    /// Decode-node peers a prefill node hands off to (disaggregated serving,
+    /// #126 B3b2a). The first entry is the prefill node's KV handoff target.
+    pub decode_peers: Vec<std::net::SocketAddr>,
+    /// This node's own serving-role transport bind address (#126 B3b2a). `Some`
+    /// on a non-hybrid node enables the live prefill/decode role loop; `None`
+    /// keeps the standard single-node scheduler loop.
+    pub serving_bind: Option<std::net::SocketAddr>,
 }
 
 impl Default for ServerConfig {
@@ -493,6 +503,9 @@ impl Default for ServerConfig {
             kv_cache_budget: None,
             enable_vlm_prefix_cache: false,
             serving_mode: crate::distributed::disaggregated::ServingMode::Hybrid,
+            prefill_peers: Vec::new(),
+            decode_peers: Vec::new(),
+            serving_bind: None,
         }
     }
 }

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -254,6 +254,11 @@ impl ModelProvider {
                 config.enable_vlm_prefix_cache,
                 // disaggregated serving role from `--node-role` (#126 B2).
                 config.serving_mode,
+                // disaggregated serving-role network addresses (#126 B3b2a). The
+                // worker uses `decode_peers` + `serving_bind`; `--prefill-peers`
+                // stays in `ServerConfig` for the future dedicated router.
+                config.decode_peers.clone(),
+                config.serving_bind,
                 speculative_dispatch,
                 batch_metrics,
                 batch_observability,
@@ -401,6 +406,8 @@ impl ModelProvider {
             false, // enable_vlm_prefix_cache: off
             // serving_mode: single-node Hybrid (this wrapper has no --node-role).
             crate::distributed::disaggregated::ServingMode::Hybrid,
+            Vec::new(), // decode_peers: none (hybrid)
+            None,       // serving_bind: none (hybrid)
             batch_metrics,
             batch_observability,
         )
@@ -438,6 +445,8 @@ impl ModelProvider {
         kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
         enable_vlm_prefix_cache: bool,
         serving_mode: crate::distributed::disaggregated::ServingMode,
+        decode_peers: Vec<std::net::SocketAddr>,
+        serving_bind: Option<std::net::SocketAddr>,
         batch_metrics: Arc<BatchMetrics>,
         batch_observability: Arc<BatchObservability>,
     ) -> Result<Self> {
@@ -466,6 +475,8 @@ impl ModelProvider {
             kv_cache_budget,
             enable_vlm_prefix_cache,
             serving_mode,
+            decode_peers,
+            serving_bind,
             crate::server::SpeculativeDispatch::Disabled,
             batch_metrics,
             batch_observability,
@@ -502,6 +513,8 @@ impl ModelProvider {
         kv_cache_budget: Option<crate::memory_estimate::PagedBudgetDirective>,
         enable_vlm_prefix_cache: bool,
         serving_mode: crate::distributed::disaggregated::ServingMode,
+        decode_peers: Vec<std::net::SocketAddr>,
+        serving_bind: Option<std::net::SocketAddr>,
         speculative_dispatch: crate::server::SpeculativeDispatch,
         batch_metrics: Arc<BatchMetrics>,
         batch_observability: Arc<BatchObservability>,
@@ -547,6 +560,11 @@ impl ModelProvider {
             // onto the live scheduler later (B2b); `Hybrid` is the unchanged
             // single-node path.
             serving_mode,
+            // disaggregated serving-role network addresses (#126 B3b2a): the
+            // worker binds `serving_bind` and hands KV off to `decode_peers`
+            // when `serving_mode` is non-hybrid.
+            decode_peers,
+            serving_bind,
             // forward the resolved speculative dispatch.
             speculative_dispatch,
         };
@@ -624,6 +642,8 @@ impl ModelProvider {
             enable_vlm_prefix_cache: false, // off in minimal test path
             // minimal test path is single-node.
             serving_mode: crate::distributed::disaggregated::ServingMode::Hybrid,
+            decode_peers: Vec::new(), // single-node minimal test path
+            serving_bind: None,       // single-node minimal test path
             // minimal test path has no drafter; the dispatch
             // defaults to `Disabled` which short-circuits the scheduler
             // hot path to the classic decode loop.

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -136,6 +136,15 @@ pub(crate) struct WorkerSchedulerConfig {
     /// scheduler over the B1 handoff hooks in a later step (B2b); until then
     /// every mode runs the standard loop.
     pub serving_mode: crate::distributed::disaggregated::ServingMode,
+    /// disaggregated serving-role network addresses (#126 B3b2a).
+    ///
+    /// `serving_bind` is this node's own role-transport listener; `decode_peers`
+    /// holds the decode node a prefill worker hands KV off to (the first entry).
+    /// Empty / `None` on a `Hybrid` node, where the worker runs the standard
+    /// scheduler loop. (`--prefill-peers` is consumed by the future dedicated
+    /// router via `ServerConfig`, not by the worker, so it is not threaded here.)
+    pub decode_peers: Vec<std::net::SocketAddr>,
+    pub serving_bind: Option<std::net::SocketAddr>,
     /// resolved speculative-decoding dispatch shape.
     ///
     /// Constructed once at worker construction (or
@@ -419,24 +428,101 @@ pub(crate) fn spawn_model_worker_with_batch_config(
         // hook is wired in `decode_single_step`.
         .with_speculative_dispatch(sched_config.speculative_dispatch);
 
-        // #126 B2: a non-hybrid `--node-role` selects a disaggregated serving
-        // role. The serving-role coordinator
-        // (`distributed::disaggregated::ServingCoordinator`) that drives this
-        // scheduler over the B1 handoff hooks lands in B2b, and a real network
-        // transport in B3; until then every role runs the standard single-node
-        // loop, so `Hybrid` and a misconfigured single node both keep serving
-        // rather than hanging. `Hybrid` (the default) is byte-identical to
-        // before.
-        if sched_config.serving_mode != crate::distributed::disaggregated::ServingMode::Hybrid {
-            tracing::info!(
-                serving_mode = %sched_config.serving_mode,
-                "Disaggregated serving role configured; running the standard \
-                 single-node scheduler loop (serving-role coordinator wiring \
-                 lands in a later step)"
-            );
+        // #126 B3b2a: a non-hybrid `--node-role` runs the live disaggregated
+        // serving role rather than the standard single-node loop. The role loop
+        // binds this node's `--serving-bind` transport and drives prefill (or
+        // decode) over the B1 handoff hooks, returning only when the transport
+        // closes. A misconfigured role (no `--serving-bind`, or a prefill node
+        // without `--decode-peers`) logs an error and falls back to serving
+        // locally rather than hanging a half-configured node. `Hybrid` (the
+        // default) and `Router` run the standard loop, byte-identical to before
+        // (the dedicated router front lands in a later step).
+        use crate::distributed::disaggregated::ServingMode;
+        match sched_config.serving_mode {
+            ServingMode::PrefillOnly | ServingMode::DecodeOnly => {
+                if !run_disaggregated_serving_role(
+                    &mut scheduler,
+                    sched_config.serving_mode,
+                    sched_config.serving_bind,
+                    &sched_config.decode_peers,
+                ) {
+                    scheduler.run();
+                }
+            }
+            ServingMode::Hybrid | ServingMode::Router => scheduler.run(),
         }
-        scheduler.run();
     })
+}
+
+/// Drive the live disaggregated serving role for a non-hybrid worker (#126
+/// B3b2a).
+///
+/// Binds this node's `serving_bind` role transport and runs the prefill or
+/// decode role loop ([`serve_prefill_role_networked_blocking`] /
+/// [`serve_decode_role_networked_blocking`]), which returns when the transport
+/// closes. Returns `false` without starting a loop when the role is
+/// misconfigured (no `serving_bind`, or a prefill node with no `decode_peers`),
+/// so the caller falls back to the standard single-node scheduler loop rather
+/// than hanging a half-configured node. A role-loop error is logged before the
+/// worker exits.
+///
+/// [`serve_prefill_role_networked_blocking`]: crate::distributed::disaggregated::coordinator::serve_prefill_role_networked_blocking
+/// [`serve_decode_role_networked_blocking`]: crate::distributed::disaggregated::coordinator::serve_decode_role_networked_blocking
+fn run_disaggregated_serving_role(
+    scheduler: &mut crate::server::batch::BatchScheduler,
+    serving_mode: crate::distributed::disaggregated::ServingMode,
+    serving_bind: Option<std::net::SocketAddr>,
+    decode_peers: &[std::net::SocketAddr],
+) -> bool {
+    use crate::distributed::disaggregated::ServingMode;
+    use crate::distributed::disaggregated::coordinator::{
+        serve_decode_role_networked_blocking, serve_prefill_role_networked_blocking,
+    };
+    use crate::distributed::tcp_transport::TcpTransportConfig;
+
+    let Some(bind_addr) = serving_bind else {
+        tracing::error!(
+            serving_mode = %serving_mode,
+            "Disaggregated serving role requires --serving-bind; \
+             falling back to the single-node scheduler loop"
+        );
+        return false;
+    };
+    let bind = TcpTransportConfig {
+        bind_address: bind_addr.to_string(),
+        ..TcpTransportConfig::default()
+    };
+
+    let result = match serving_mode {
+        ServingMode::PrefillOnly => {
+            let Some(decode_peer) = decode_peers.first() else {
+                tracing::error!(
+                    "--node-role prefill requires --decode-peers (the decode node to \
+                     hand KV off to); falling back to the single-node scheduler loop"
+                );
+                return false;
+            };
+            tracing::info!(
+                bind = %bind_addr, decode_peer = %decode_peer,
+                "Starting the disaggregated prefill serving role"
+            );
+            serve_prefill_role_networked_blocking(bind, decode_peer.to_string(), scheduler, None)
+        }
+        ServingMode::DecodeOnly => {
+            tracing::info!(bind = %bind_addr, "Starting the disaggregated decode serving role");
+            serve_decode_role_networked_blocking(bind, scheduler, None)
+        }
+        // The caller only invokes this for a non-hybrid serving role.
+        ServingMode::Hybrid | ServingMode::Router => return false,
+    };
+
+    if let Err(e) = result {
+        tracing::error!(
+            serving_mode = %serving_mode,
+            "Disaggregated serving role loop exited with an error: {e:#}"
+        );
+    }
+    true
 }
 
 /// Resolve the operator's `--kv-cache-budget` directive into a concrete paged

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -162,6 +162,16 @@ pub struct ServerStartupConfig {
     pub node_id: Option<String>,
     /// Static peer addresses (CLI shorthand).
     pub peers: Vec<SocketAddr>,
+    /// Prefill-node peers a decode node receives handoffs from (disaggregated
+    /// serving, #126).
+    pub prefill_peers: Vec<SocketAddr>,
+    /// Decode-node peers a prefill node hands off to (disaggregated serving,
+    /// #126).
+    pub decode_peers: Vec<SocketAddr>,
+    /// This node's own serving-role transport bind address (disaggregated
+    /// serving, #126). `Some` enables the live prefill/decode role loop on a
+    /// non-hybrid node.
+    pub serving_bind: Option<SocketAddr>,
     /// Manual pipeline-parallel layer partition spec (e.g. "0-15,16-31").
     /// When `None`, auto-partition mode is used.
     pub pp_layers: Option<String>,
@@ -406,6 +416,9 @@ impl Default for ServerStartupConfig {
             node_role: None,
             node_id: None,
             peers: Vec::new(),
+            prefill_peers: Vec::new(),
+            decode_peers: Vec::new(),
+            serving_bind: None,
             pp_layers: None,
             pp_micro_batch_size: 1,
             pp_auto: None,
@@ -829,6 +842,12 @@ pub(super) fn build_server_config(
         enable_vlm_prefix_cache: startup.enable_vlm_prefix_cache,
         // disaggregated serving role derived from `--node-role` (#126 B2).
         serving_mode,
+        // disaggregated serving-role network addresses (#126 B3b2a): the
+        // worker uses these to bind its role transport and reach its handoff
+        // peer when `serving_mode` is non-hybrid.
+        prefill_peers: startup.prefill_peers.clone(),
+        decode_peers: startup.decode_peers.clone(),
+        serving_bind: startup.serving_bind,
     }
 }
 

--- a/tests/disaggregated_serving_e2e.rs
+++ b/tests/disaggregated_serving_e2e.rs
@@ -1,0 +1,296 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real two-process disaggregated serving handoff (#126 B3b2a).
+//!
+//! Spawns two real `mlxcel-server` processes, one `--node-role prefill` and one
+//! `--node-role decode`, cross-wired over TCP, and drives a request through the
+//! live worker-flip + networked wire protocol the way a router will in B3b2b:
+//! the test stands in for the router. It sends a [`PrefillRequestFrame`] to the
+//! prefill node, which prefills, returns its first token, and hands the KV off
+//! to the decode node over TCP; the decode node reconstructs the sequence and
+//! returns the continuation. The merged stream (prefill first token + decode
+//! continuation) must be byte-for-byte the single-node greedy output.
+//!
+//! The in-crate `serving_role_loop_parity_matches_single_node_qwen3` test proves
+//! the disaggregated role loops reproduce a single-node run for this prompt; this
+//! test proves the *live two-process path* (CLI flags -> config chain -> worker
+//! flip -> networked role loops across process boundaries) reproduces that same
+//! output. [`EXPECTED_SINGLE_NODE_TEXT`] is that single-node reference.
+//!
+//! `#[ignore]` (loads a real checkpoint twice and runs real GPU forwards across
+//! two processes) and soft-skips when the model or the built binary is absent.
+//! Run with:
+//!
+//! ```text
+//! cargo test --test disaggregated_serving_e2e --release \
+//!     --features metal,accelerate -- --ignored --nocapture
+//! ```
+//!
+//! Fetch the model with:
+//! `./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit`.
+//!
+//! [`PrefillRequestFrame`]: mlxcel::distributed::disaggregated::PrefillRequestFrame
+
+mod common;
+
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use common::{repo_binary_path, repo_model_dir};
+
+use mlxcel::SamplingConfig;
+use mlxcel::distributed::disaggregated::{
+    PrefillRequestFrame, ResultFrame, ResultPhase, control_parts, sampling_to_serializable,
+};
+use mlxcel::distributed::tcp_transport::{TcpTransport, TcpTransportConfig};
+use mlxcel::distributed::transport::Transport;
+
+/// qwen3 checkpoint directory name (a pool-backed Fp16 family, the handoff scope).
+const QWEN3_DIR: &str = "qwen3-0.6b-4bit";
+
+/// Tokens to generate (prefill first token + decode continuation). Matches the
+/// in-crate role-loop parity test so they verify the same reference.
+const MAX_TOKENS: u64 = 16;
+
+/// The fixed ~50-token prompt (> one 32-token block), identical to the in-crate
+/// serving parity tests so the greedy output is the same.
+const PROMPT_TOKENS: &[i32] = &[
+    9707, 11, 358, 1079, 264, 4128, 1614, 13, 5209, 3291, 752, 911, 697, 7990, 13, 358, 2776, 264,
+    10950, 17847, 13, 6771, 594, 1438, 419, 1495, 3019, 553, 3019, 11, 323, 1473, 697, 975, 13,
+    5209, 387, 2797, 624, 14374, 14582, 25, 3555, 374, 220, 17, 488, 220, 17, 30,
+];
+
+/// The single-node greedy continuation qwen3-0.6b-4bit produces for
+/// [`PROMPT_TOKENS`] over [`MAX_TOKENS`] tokens. This is the reference the
+/// in-crate `serving_role_loop_parity_matches_single_node_qwen3` test verifies
+/// the disaggregated role loops reproduce; the live two-process path must
+/// reproduce it byte-for-byte. Update both together if the model changes.
+const EXPECTED_SINGLE_NODE_TEXT: &str = " \n\n###Answer: 4\n\n###Step 1: 2 + ";
+
+/// Kills its child process on drop so a panicking assertion never leaks a
+/// spawned `mlxcel-server`.
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Reserve `n` distinct ephemeral localhost ports by binding them all at once
+/// (so two reservations cannot return the same port), then releasing them. A
+/// small window remains before a child rebinds them, acceptable for a test.
+fn reserve_ports(n: usize) -> Vec<u16> {
+    let listeners: Vec<TcpListener> = (0..n)
+        .map(|_| TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port"))
+        .collect();
+    listeners
+        .iter()
+        .map(|l| l.local_addr().expect("local addr").port())
+        .collect()
+    // `listeners` drop here, freeing the ports for the spawned servers.
+}
+
+fn spawn_role_server(args: &[&str]) -> ChildGuard {
+    ChildGuard(
+        Command::new(repo_binary_path("mlxcel-server"))
+            .args(args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn mlxcel-server"),
+    )
+}
+
+/// Poll-connect `addr` until it accepts (the node's role transport is bound,
+/// which happens after its model loads) or the deadline passes.
+async fn wait_for_listener(addr: &str, deadline: Instant) -> bool {
+    while Instant::now() < deadline {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    false
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "spawns two real mlxcel-server processes loading qwen3-0.6b-4bit; run with --ignored"]
+async fn disaggregated_two_process_handoff_matches_single_node() {
+    let model_dir = repo_model_dir(QWEN3_DIR);
+    if !model_dir.exists() {
+        eprintln!(
+            "Skipping {QWEN3_DIR}: model directory not found at {}.\n\
+             Fetch with: ./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit",
+            model_dir.display()
+        );
+        return;
+    }
+    let binary = repo_binary_path("mlxcel-server");
+    if !binary.exists() {
+        eprintln!(
+            "Skipping: mlxcel-server binary not found at {}.\n\
+             Build it with: cargo build --release --bin mlxcel-server --features metal,accelerate",
+            binary.display()
+        );
+        return;
+    }
+
+    let ports = reserve_ports(4);
+    let prefill_http = ports[0].to_string();
+    let decode_http = ports[1].to_string();
+    let prefill_serving_addr = format!("127.0.0.1:{}", ports[2]);
+    let decode_serving_addr = format!("127.0.0.1:{}", ports[3]);
+    let model_arg = model_dir.to_string_lossy().to_string();
+
+    // Spawn the decode node first so it is listening before the prefill node
+    // hands off to it. `--decode-storage-backend paged` + `--max-batch-size 2`
+    // select the pool-backed path the handoff requires.
+    let _decode = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &decode_http,
+        "--parallel",
+        "2",
+        "--max-batch-size",
+        "2",
+        "--decode-storage-backend",
+        "paged",
+        "--node-role",
+        "decode",
+        "--serving-bind",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+    let _prefill = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &prefill_http,
+        "--parallel",
+        "2",
+        "--max-batch-size",
+        "2",
+        "--decode-storage-backend",
+        "paged",
+        "--node-role",
+        "prefill",
+        "--serving-bind",
+        &prefill_serving_addr,
+        "--decode-peers",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+
+    // The test client stands in for the router: it binds its own transport so
+    // the nodes can return results to it via the request's `reply_to`.
+    let client = TcpTransport::bind(TcpTransportConfig {
+        bind_address: "127.0.0.1:0".to_string(),
+        ..TcpTransportConfig::default()
+    })
+    .await
+    .expect("bind client transport");
+    let reply_to = client.local_addr().expect("client local addr");
+
+    // Wait until both nodes' serving transports accept connections (model
+    // loaded + role transport bound). Generous deadline for two model loads.
+    let deadline = Instant::now() + Duration::from_secs(180);
+    assert!(
+        wait_for_listener(&decode_serving_addr, deadline).await,
+        "decode node serving transport never came up at {decode_serving_addr}"
+    );
+    assert!(
+        wait_for_listener(&prefill_serving_addr, deadline).await,
+        "prefill node serving transport never came up at {prefill_serving_addr}"
+    );
+
+    // Send the prefill request to the prefill node.
+    let request = PrefillRequestFrame {
+        request_id: 1,
+        prompt_tokens: PROMPT_TOKENS.to_vec(),
+        sampling: sampling_to_serializable(&SamplingConfig::greedy()),
+        max_tokens: MAX_TOKENS,
+        reply_to: reply_to.clone(),
+    };
+    client
+        .send(
+            &prefill_serving_addr,
+            request.encode().expect("encode prefill request"),
+        )
+        .await
+        .expect("send prefill request to the prefill node");
+
+    // Collect the prefill node's first-token result and the decode node's
+    // continuation result (the split a router merges for the client).
+    let mut first_token_text = String::new();
+    let mut continuation_text = String::new();
+    let mut seen_first = false;
+    let mut seen_continuation = false;
+    while !(seen_first && seen_continuation) {
+        let received = tokio::time::timeout(Duration::from_secs(120), client.recv()).await;
+        let (_from, message) = match received {
+            Ok(Ok(message)) => message,
+            Ok(Err(e)) => panic!("client transport recv failed: {e}"),
+            Err(_) => break,
+        };
+        let (_op, payload) = control_parts(message).expect("result is a control frame");
+        let frame = ResultFrame::decode(&payload).expect("decode result frame");
+        if let Some(err) = frame.error {
+            panic!("a serving node returned a generation error: {err}");
+        }
+        let text = frame.tokens.concat();
+        match frame.phase {
+            ResultPhase::FirstToken => {
+                first_token_text = text;
+                seen_first = true;
+            }
+            ResultPhase::Continuation => {
+                continuation_text = text;
+                seen_continuation = true;
+            }
+        }
+    }
+
+    assert!(
+        seen_first,
+        "did not receive the prefill node's first-token result"
+    );
+    assert!(
+        seen_continuation,
+        "did not receive the decode node's continuation result"
+    );
+
+    let merged = format!("{first_token_text}{continuation_text}");
+    eprintln!(
+        "two-process handoff text: {merged:?} \
+         (prefill first token {first_token_text:?}, decode continuation {continuation_text:?})"
+    );
+    assert_eq!(
+        merged, EXPECTED_SINGLE_NODE_TEXT,
+        "the live two-process disaggregated handoff must reproduce the single-node greedy output\n\
+         expected: {EXPECTED_SINGLE_NODE_TEXT:?}\n     got: {merged:?}"
+    );
+    eprintln!(
+        "OK: two real mlxcel-server processes (prefill + decode) handed a sequence off over TCP \
+         and reproduced the single-node output byte-for-byte."
+    );
+}


### PR DESCRIPTION
## Summary
B3b2a of the disaggregated serving productionization (epic #116, capstone #126). Wires the serving role end to end so two real `mlxcel-server` processes hand a sequence off over TCP and reproduce the single-node output byte-for-byte. The dedicated router HTTP front and 3-process client E2E land next in B3b2b.

## What this does
- **Wire protocol** (`serving_protocol.rs`): `PrefillRequestFrame` (client to prefill), `DecodeMetaFrame` (prefill to decode, precedes the KV frame), `ResultFrame` with FirstToken/Continuation phase (nodes to client). Carried as `TransportMessage::Control` + serde_json.
- **Networked role loops** (`coordinator.rs`): `run_{prefill,decode}_role_networked` read frames off the transport, drive the existing B2b scheduler entries, and return results to each request's `reply_to`; `serve_{prefill,decode}_role_networked_blocking` drivers build the runtime and bind the transport.
- **Config chain**: new `--serving-bind <addr>` flag on both binaries; `serving_bind` + `decode_peers` threaded from `ServerStartupInput` through `ServerConfig` and the provider ladder to `WorkerSchedulerConfig`. `prefill_peers` stays in `ServerConfig` (pub) for the future dedicated router.
- **Worker LIVE flip** (`model_worker.rs`): a non-hybrid worker binds its role transport and runs the role loop instead of `scheduler.run()`; a misconfigured role (no `--serving-bind`, or prefill with no `--decode-peers`) logs and falls back to the single-node loop rather than hanging.

## Design notes
- Result stays split (prefill first token + decode continuation to the client), matching the `StreamBridge.submit_first_token` / `submit_decode_token` contract the B3b2b router will merge.
- New `--serving-bind`: no existing flag gives a node its own role-transport listener (HTTP host:port feeds the cluster-control address).
- Decode intake is two frames (decode-meta control frame then KV frame), keeping the KV serde focused on KV.
- Additive only: the in-crate channel-driven role loops (B3a) and the single-node path are unchanged.

## Verification (orchestrator-local, the real metal gate)
- Cold clippy `-D warnings` both feature sets (`metal,accelerate` and `+test-utils`) `--all-targets`: clean
- `cargo fmt --check`: clean
- Protocol unit tests 5/5; in-crate B3a/B2c/B3b1 serving parity 4/4 unchanged
- **2-process spawn E2E** (`tests/disaggregated_serving_e2e.rs`): two real `mlxcel-server` processes hand off over TCP, merged output `" \n\n###Answer: 4\n\n###Step 1: 2 + "` is byte-identical to the single-node greedy reference
- Full lib suite: 3086 passed, 0 failed

Part of #126
