### PR TITLE
docs: unified paged KV cache + disaggregated serving (B3c)

### DIFF
--- a/docs/CONTINUOUS_BATCHING.md
+++ b/docs/CONTINUOUS_BATCHING.md
@@ -1,0 +1,114 @@
+# Continuous batching and disaggregated serving
+
+`mlxcel-server` (and `mlxcel serve`) runs a continuous-batching scheduler: it
+admits concurrent requests into a running batch, interleaves prefill and decode,
+and streams each request's tokens as they are produced. This document covers the
+batching scheduler, how it uses the paged KV cache, and the disaggregated
+serving roles that split prefill and decode across processes.
+
+## Continuous batching
+
+The scheduler keeps up to `--parallel` sequences active at once. Each step it
+either admits and prefills queued prompts (chunked at `--prefill-chunk-size` so a
+long prompt does not stall decode) or advances the active batch by one decode
+token, then streams the new tokens out. Relevant flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--parallel N` | Maximum active (in-flight) sequences. |
+| `--max-batch-size N` | Maximum sequences decoded together in one batched step. |
+| `--max-queue-depth N` | Maximum queued (not yet admitted) requests. |
+| `--prefill-chunk-size N` | Token chunk size for prefill; bounds prefill's effect on decode latency. |
+| `--enable-preemption` | Allow evicting a lower-priority sequence to admit a waiting one. |
+| `--no-batch` | Disable batching and serve sequentially (the legacy single worker). |
+
+### Paged decode and the prompt-prefix cache
+
+With `--decode-storage-backend paged`, decode state and the cross-request
+prompt-prefix cache share one refcounted, copy-on-write block pool. Concurrent
+requests that share a prompt prefix store that prefix's KV once and skip
+re-prefilling it. The mechanism, the memory and prefill-token savings, the
+measured decode throughput, and `--kv-cache-budget` are documented in
+[turbo-kv-cache.md](turbo-kv-cache.md#unified-paged-kv-cache). Paged decode is
+byte-identical to the dense backend; it is the storage backend the disaggregated
+roles below build on.
+
+## Disaggregated serving
+
+Prefill is compute-bound and decode is memory-bound, so a deployment can run them
+on separate processes (or machines) with a router in front. `--node-role`
+selects the role:
+
+- **`prefill`**: runs prompt prefill, samples the first token, and hands the
+  sequence's KV cache off to a decode node over TCP.
+- **`decode`**: receives the KV handoff, continues autoregressive decode, and
+  returns the continuation.
+- **`router`**: a model-free HTTP front (it loads only a tokenizer and chat
+  template, not model weights). It tokenizes the client request, routes it to a
+  prefill node, and merges the prefill node's first token with the decode node's
+  continuation into one SSE stream back to the client.
+- **absent (hybrid)**: single-node serving, byte-identical to a server started
+  with no distributed flags.
+
+Request flow (topology A): client HTTP request -> router -> prefill node (TCP)
+-> decode node (TCP) -> router merges the two halves -> client SSE.
+
+Networking flags:
+
+| Flag | Role | Purpose |
+|------|------|---------|
+| `--serving-bind <addr>` | prefill, decode, router | This node's own role-transport listener (`host:port`). |
+| `--decode-peers <addr,...>` | prefill | Decode node(s) a prefill node hands KV off to. |
+| `--prefill-peers <addr,...>` | router | Prefill node(s) the router routes requests to. |
+
+The handoff transfers the paged block contents (not just metadata) over the
+transport, so the decode node reconstructs the exact KV the prefill node built;
+see `src/distributed/kv_cache_serde/`. The disaggregated output is byte-identical
+to a single-node run, verified end to end by `tests/disaggregated_router_e2e.rs`
+(three real processes) and at the cache level by `tests/paged_handoff_parity.rs`.
+
+Implementation entry points: `src/server/router_front.rs` (the router front),
+`src/distributed/disaggregated/{coordinator,handoff_impl,serving_protocol}.rs`
+(the role loops and wire protocol), and `src/server/batch/` (the scheduler
+serving-role entries).
+
+### Example: three processes on localhost
+
+```bash
+# Decode node: receives KV handoffs on :8304.
+mlxcel-server -m models/<ckpt> --port 8302 \
+    --parallel 2 --max-batch-size 2 --decode-storage-backend paged \
+    --node-role decode --serving-bind 127.0.0.1:8304
+
+# Prefill node: prefills, hands off to the decode node.
+mlxcel-server -m models/<ckpt> --port 8301 \
+    --parallel 2 --max-batch-size 2 --decode-storage-backend paged \
+    --node-role prefill --serving-bind 127.0.0.1:8305 \
+    --decode-peers 127.0.0.1:8304
+
+# Router: model-free HTTP front on :8300.
+mlxcel-server -m models/<ckpt> --port 8300 \
+    --node-role router --serving-bind 127.0.0.1:8306 \
+    --prefill-peers 127.0.0.1:8305 --decode-peers 127.0.0.1:8304
+
+# Client talks only to the router.
+curl http://127.0.0.1:8300/v1/chat/completions \
+    -H 'content-type: application/json' \
+    -d '{"model":"m","messages":[{"role":"user","content":"What is 2 + 2?"}],"stream":true,"temperature":0}'
+```
+
+### Scope and limitations
+
+- Pool-backed Fp16 families only (the dense-natural backends such as qwen3 and
+  llama3). Model-owned-state families (gemma3, llama4, qwen3.5) and recurrent or
+  hybrid SSM models are excluded from the paged handoff.
+- Text-only. The router serves `/v1/chat/completions`; multimodal requests are
+  rejected by the router.
+- The router does not yet apply the chat stream filter that the single-node chat
+  route uses, so reasoning/tool-call markers pass through verbatim. Use a
+  non-reasoning prompt or `chat_template_kwargs.enable_thinking=false` for clean
+  content.
+- Co-locating the roles on one machine adds transport hops without the scaling
+  benefit of separate prefill and decode hardware, so a single-machine setup is
+  for validation. The throughput case for disaggregation is separate prefill and
+  decode pools under load.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,9 +19,10 @@ Current GitHub-facing docs:
 4. `supported-models.md` — maintained architecture/checkpoint support matrix.
 5. `architecture.md` — runtime architecture and major components.
 6. `distributed.md` — tensor/pipeline parallel setup and limitations.
-7. `turbo-kv-cache.md` — TurboQuant modes, quality/performance trade-offs, and flags.
-8. `responses-api.md` — implemented `/v1/responses` subset and gaps.
-9. `adding-models.md` — contribution guide for new model architectures.
+7. `turbo-kv-cache.md` — TurboQuant modes, the unified paged KV cache, quality/performance trade-offs, and flags.
+8. `CONTINUOUS_BATCHING.md` — continuous-batching scheduler, paged decode, and disaggregated prefill/decode/router serving.
+9. `responses-api.md` — implemented `/v1/responses` subset and gaps.
+10. `adding-models.md` — contribution guide for new model architectures.
 
 ## Architecture Decision Records
 

--- a/docs/turbo-kv-cache.md
+++ b/docs/turbo-kv-cache.md
@@ -121,9 +121,55 @@ family-specific fallback; do not silently pad without a quality test.
 
 The paged decode layout accepts TurboQuant modes through
 `PagedKvLayout::uniform_with_mode`. Server dispatch routes Turbo modes to the
-paged layout when `--decode-storage-backend paged` is selected. This is a wiring
-statement, not a blanket performance claim: validate concurrent-prefix behavior
-and throughput on real hardware before publishing numbers.
+paged layout when `--decode-storage-backend paged` is selected.
+
+### Unified paged KV cache
+
+Under `--decode-storage-backend paged`, the continuous-batching server keeps
+both the cross-request prompt-prefix cache and per-sequence decode state in one
+refcounted, copy-on-write block pool (epic #116). Two requests that share a
+prompt prefix store that prefix's KV blocks once: the second request adopts the
+first request's blocks by reference rather than re-prefilling them, and a block
+forks (copy-on-write) only when one sequence's content diverges from a shared
+block. Paged adopt and donate are supported for the pool-backed Fp16 families
+(the dense-natural backends such as qwen3 and llama3); model-owned-state families
+(gemma3, llama4, qwen3.5) and recurrent or hybrid SSM models keep dense or
+model-owned caches and stay out of the pool.
+
+The block pool can be bounded with `--kv-cache-budget <bytes|auto>` (env
+`MLXCEL_KV_CACHE_BUDGET`); the default is unbounded. Under a budget the scheduler
+evicts cold cached prefixes, then preempts, before rejecting a request.
+`GET /v1/cache/stats` reports paged block usage (block size, allocated, live,
+free, bytes reserved/in use, and the budget).
+
+### Measured payoff
+
+Numbers below are from an M1 Ultra with `models/qwen3-0.6b-4bit` (28 layers, 8 KV
+heads, head dim 128, runtime KV dtype bf16, so about 112 KiB of KV per token).
+
+**Memory saved per shared prefix.** A shared prefix of `P` tokens across `N`
+concurrent requests occupies one pool copy instead of `N`. KV bytes per token are
+`2 (K and V) * n_kv_heads * head_dim * num_layers * dtype_bytes`. A shared
+1024-token system prompt is about 112 MiB; with 8 concurrent requests the pool
+stores it once instead of eight times, saving roughly `7 * 112 MiB ≈ 784 MiB`.
+
+**Prefill tokens avoided.** Only the first of `N` requests sharing a `P`-token
+prefix prefills it; the other `N - 1` adopt the cached blocks and skip
+`(N - 1) * P` prefill-token forward passes. `tests/paged_prefix_share_parity.rs`
+confirms an adopting request decodes byte-identically to a cold run while
+skipping the shared prefill.
+
+**Decode throughput.** Paged decode is byte-identical to the dense backend
+(`tests/paged_scheduler_parity.rs`, RMS 0). The live batched path uses the native
+block-table decode kernel (`DecodeBatchContext::use_native_paged_kernel`, set by
+the scheduler); a gather-then-SDPA path is kept as a correctness reference. At
+batch 4 the native kernel runs at 276 tok/s for a 512-token prompt and 84 tok/s
+for a 4096-token prompt, versus 146 and 7.7 tok/s for the gather reference (1.9x
+and 10.9x). The gather reference degrades sharply with context because it
+re-materializes the visible window every step, which is why the live path uses
+the native kernel. The separate fused split-K Metal kernel
+(`MLXCEL_PAGED_ATTENTION_NATIVE`) is opt-in and stays off by default; see
+[ADR 0001](adr/0001-paged-attention-gather-vs-fused-kernel.md).
 
 ## Recommended starting points
 


### PR DESCRIPTION
## Summary
B3c, the final sub-step of #126 (epic #116 capstone): benchmarks and documentation for the unified paged KV cache and the disaggregated serving roles. The correctness and parity tasks for #126 landed across the earlier sub-issues and the B-track PRs (#186, #187, #189, #190, #191, #192, #193); this PR adds the measured payoff and brings the docs in line, closing the epic.

## What this does
- **`docs/turbo-kv-cache.md`**: a "Unified paged KV cache" section covering cross-request prefix reuse, copy-on-write block sharing, the `--kv-cache-budget` admission/eviction, and the `GET /v1/cache/stats` surface, plus a "Measured payoff" subsection with concrete numbers. States that paged adopt and donate are supported.
- **`docs/CONTINUOUS_BATCHING.md`** (new): the continuous-batching scheduler flags, how it uses paged decode, and the disaggregated `prefill`/`decode`/`router` roles (topology A) with the `--node-role` / `--serving-bind` / `--prefill-peers` / `--decode-peers` flags and a three-process localhost example.
- **`docs/README.md`**: index entry for the new doc.

## Benchmark numbers (M1 Ultra, `models/qwen3-0.6b-4bit`)
- Memory: a shared 1024-token prefix is ~112 MiB of KV; across 8 concurrent requests the pool stores it once instead of eight times, saving ~784 MiB.
- Prefill avoided: an adopting request skips the shared prefill and decodes byte-identically to a cold run (`tests/paged_prefix_share_parity.rs`).
- Decode throughput (batch 4): the live native block-table kernel runs at 276 tok/s (512-token prompt) and 84 tok/s (4096), versus 146 and 7.7 tok/s for the gather reference (1.9x and 10.9x). The gather reference degrades sharply with context, which is why the live path uses the native kernel.

## Notes
- `docs/model_tests*.md` and `docs/en/prompt_cache.md` named in the issue do not exist in the current flat docs layout; the unified-cache content lives in `turbo-kv-cache.md`.
- The issue's "remove the paged adopt/donate disabled note" task: no such note exists in the repo (it was never written), so the positive "supported" statement is added instead.
- Docs-only change; no code touched.

Closes #126
