### PR TITLE
feat(tool-calls): parse Qwen3-Coder XML tool-call format

### DIFF
--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -915,7 +915,7 @@ const QWEN3_CODER_MAX_PARAMS_PER_CALL: usize = 1024;
 /// the body: Qwen3-Coder emits `<parameter=key>val</parameter>` XML rather than a
 /// JSON object. The dispatcher runs this parser *after* [`try_functionary_v31`],
 /// which declines Qwen input because its non-JSON body fails the JSON-validity
-/// check — so functionary calls are never stolen, and zero-parameter Qwen calls
+/// check, so functionary calls are never stolen, and zero-parameter Qwen calls
 /// (an empty `<function=NAME></function>` body) are still handled here.
 ///
 /// The surrounding `<tool_call>` wrapper is not required: scanning for
@@ -1005,7 +1005,7 @@ fn extract_qwen_parameters(body: &str) -> String {
 
         // `break` (not `continue`) on a missing '>': a malformed `<parameter=`
         // prefix with no '>' anywhere left would otherwise re-match and rescan
-        // forever — the same O(N^2) guard as `extract_minimax_parameters`.
+        // forever: the same O(N^2) guard as `extract_minimax_parameters`.
         let Some(gt_pos) = remaining[after_tag..].find('>') else {
             break;
         };

--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -894,6 +894,165 @@ fn coerce_minimax_param(value: &str) -> serde_json::Value {
     serde_json::Value::String(value.to_string())
 }
 
+// Defensive caps mirroring the MiniMax M2 parser: bound parallel-call and
+// per-call parameter memory under adversarial model output.
+const QWEN3_CODER_MAX_CALLS: usize = 1024;
+const QWEN3_CODER_MAX_PARAMS_PER_CALL: usize = 1024;
+
+/// Try parsing the Qwen3-Coder XML tool-call format:
+///
+/// ```text
+/// <tool_call>
+/// <function=NAME>
+/// <parameter=KEY>
+/// VALUE
+/// </parameter>
+/// </function>
+/// </tool_call>
+/// ```
+///
+/// This shares the `<function=...>` opener with Functionary v3.1 but differs in
+/// the body: Qwen3-Coder emits `<parameter=key>val</parameter>` XML rather than a
+/// JSON object. The dispatcher runs this parser *after* [`try_functionary_v31`],
+/// which declines Qwen input because its non-JSON body fails the JSON-validity
+/// check — so functionary calls are never stolen, and zero-parameter Qwen calls
+/// (an empty `<function=NAME></function>` body) are still handled here.
+///
+/// The surrounding `<tool_call>` wrapper is not required: scanning for
+/// `<function=` naturally skips it, matching Qwen3-Coder variants that omit it.
+pub fn try_qwen3_coder(text: &str) -> Option<ToolCallParseResult> {
+    let fn_open = "<function=";
+    let fn_close = "</function>";
+
+    let fn_pos = text.find(fn_open)?;
+
+    // Capture any prose before the first tool call. Prefer the `<tool_call>`
+    // wrapper boundary when it precedes `<function=` so the wrapper tag itself
+    // never leaks into the user-visible content.
+    let boundary = match text.find("<tool_call>") {
+        Some(tc) if tc < fn_pos => tc,
+        _ => fn_pos,
+    };
+    let content = text[..boundary].trim().to_string();
+
+    let mut calls = Vec::new();
+    let mut remaining = &text[fn_pos..];
+
+    while let Some(start) = remaining.find(fn_open) {
+        let name_start = start + fn_open.len();
+        // if-let rather than `?` so a single malformed `<function=` opener
+        // without a closing '>' does not discard already-parsed calls.
+        let Some(name_end) = remaining[name_start..].find('>') else {
+            break;
+        };
+        let function_name = extract_quoted_name(&remaining[name_start..name_start + name_end]);
+
+        let body_start = name_start + name_end + 1; // skip '>'
+        let body = match remaining[body_start..].find(fn_close) {
+            Some(end_offset) => {
+                let b = &remaining[body_start..body_start + end_offset];
+                remaining = &remaining[body_start + end_offset + fn_close.len()..];
+                b
+            }
+            None => {
+                // No closing </function>: take the rest as the body.
+                let b = &remaining[body_start..];
+                remaining = "";
+                b
+            }
+        };
+
+        if !function_name.is_empty() {
+            let arguments = extract_qwen_parameters(body);
+            calls.push(ParsedToolCall {
+                name: function_name,
+                arguments,
+            });
+        }
+
+        if calls.len() >= QWEN3_CODER_MAX_CALLS {
+            break;
+        }
+    }
+
+    if calls.is_empty() {
+        return None;
+    }
+
+    Some(ToolCallParseResult {
+        format: Some(ToolCallFormat::Qwen3Coder),
+        tool_calls: calls,
+        content,
+    })
+}
+
+/// Parse all `<parameter=key>value</parameter>` tags inside a Qwen3-Coder
+/// `<function>` body into a JSON object string.
+///
+/// Mirrors [`extract_minimax_parameters`] but keys on the bare `<parameter=`
+/// opener (Qwen3-Coder) rather than `<parameter name=` (MiniMax M2). Values are
+/// stripped of one surrounding newline (the model pretty-prints each parameter
+/// on its own line) then trimmed, and typed via [`coerce_minimax_param`].
+fn extract_qwen_parameters(body: &str) -> String {
+    let param_open = "<parameter=";
+    let param_close = "</parameter>";
+
+    let mut pairs: Vec<(String, serde_json::Value)> = Vec::new();
+    let mut remaining = body;
+
+    while let Some(start) = remaining.find(param_open) {
+        let after_tag = start + param_open.len();
+
+        // `break` (not `continue`) on a missing '>': a malformed `<parameter=`
+        // prefix with no '>' anywhere left would otherwise re-match and rescan
+        // forever — the same O(N^2) guard as `extract_minimax_parameters`.
+        let Some(gt_pos) = remaining[after_tag..].find('>') else {
+            break;
+        };
+
+        let param_name = extract_quoted_name(&remaining[after_tag..after_tag + gt_pos]);
+
+        let value_start = after_tag + gt_pos + 1; // skip '>'
+        let raw_value = match remaining[value_start..].find(param_close) {
+            Some(end_offset) => {
+                let v = &remaining[value_start..value_start + end_offset];
+                remaining = &remaining[value_start + end_offset + param_close.len()..];
+                v
+            }
+            None => {
+                let v = &remaining[value_start..];
+                remaining = "";
+                v
+            }
+        };
+
+        // Strip a single leading/trailing newline (the model emits the value on
+        // its own line), then trim surrounding spaces.
+        let mut raw_value = raw_value;
+        if let Some(stripped) = raw_value.strip_prefix('\n') {
+            raw_value = stripped;
+        }
+        if let Some(stripped) = raw_value.strip_suffix('\n') {
+            raw_value = stripped;
+        }
+        let raw_value = raw_value.trim();
+
+        if !param_name.is_empty() {
+            pairs.push((param_name, coerce_minimax_param(raw_value)));
+        }
+
+        if pairs.len() >= QWEN3_CODER_MAX_PARAMS_PER_CALL {
+            break;
+        }
+    }
+
+    let mut map = serde_json::Map::with_capacity(pairs.len());
+    for (k, v) in pairs {
+        map.insert(k, v);
+    }
+    serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_else(|_| "{}".to_string())
+}
+
 /// Try parsing generic JSON format:
 /// `{"name": "fn", "arguments": {...}}` or `{"name": "fn", "parameters": {...}}`
 ///

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -147,11 +147,12 @@ pub fn parse_tool_calls(raw_output: &str, tools: Option<&[Tool]>) -> ToolCallPar
         formats::try_hermes,  // <tool_call> — Hermes/Qwen/DeepSeek
         formats::try_minimax_m2, // <invoke name=...><parameter name=...>...</parameter></invoke>
         formats::try_mistral_nemo, // [TOOL_CALLS]
-        formats::try_functionary_v31, // <function=name>
+        formats::try_functionary_v31, // <function=name>{json}
+        formats::try_qwen3_coder, // <function=name><parameter=key>val</parameter> — after v31, which declines non-JSON bodies
         formats::try_functionary_v32, // >>>name\n
-        formats::try_llama3,  // {"name": ..., "parameters": ...}
+        formats::try_llama3,      // {"name": ..., "parameters": ...}
         formats::try_generic_json, // {"name": ..., "arguments": ...}
-        formats::try_command_r, // Action: / Action Input: — least specific
+        formats::try_command_r,   // Action: / Action Input: — least specific
     ];
 
     for parser in parsers {
@@ -577,5 +578,107 @@ mod tests {
         let raw2 = "all thinking<channel|>";
         let result2 = parse_tool_calls(raw2, None);
         assert_eq!(result2.content, "");
+    }
+
+    // ----------------------------------------------------------------
+    // Qwen3-Coder XML tool-call format (issue: agentic clients break
+    // because tool calls land in `content` instead of `tool_calls`)
+    // ----------------------------------------------------------------
+
+    fn arg_obj(call: &crate::server::tool_calls::ParsedToolCall) -> serde_json::Value {
+        serde_json::from_str(&call.arguments).expect("arguments must be valid JSON")
+    }
+
+    #[test]
+    fn qwen3_coder_single_call_single_param() {
+        let output = "<tool_call>\n<function=get_weather>\n<parameter=location>\nSan Francisco\n</parameter>\n</function>\n</tool_call>";
+        let tools = vec![make_tool("get_weather")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+        assert_eq!(arg_obj(&result.tool_calls[0])["location"], "San Francisco");
+        // Pure tool-call response: no leaked content.
+        assert_eq!(result.content, "");
+    }
+
+    #[test]
+    fn qwen3_coder_single_call_multiple_params_with_type_coercion() {
+        let output = "<tool_call><function=search><parameter=query>rust async</parameter><parameter=limit>5</parameter><parameter=fuzzy>true</parameter></function></tool_call>";
+        let tools = vec![make_tool("search")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        let args = arg_obj(&result.tool_calls[0]);
+        assert_eq!(args["query"], "rust async");
+        assert_eq!(args["limit"], 5); // coerced to integer
+        assert_eq!(args["fuzzy"], true); // coerced to boolean
+    }
+
+    #[test]
+    fn qwen3_coder_multiple_calls_in_one_response() {
+        let output = "<tool_call><function=read_file><parameter=path>a.rs</parameter></function></tool_call><tool_call><function=read_file><parameter=path>b.rs</parameter></function></tool_call>";
+        let tools = vec![make_tool("read_file")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(arg_obj(&result.tool_calls[0])["path"], "a.rs");
+        assert_eq!(arg_obj(&result.tool_calls[1])["path"], "b.rs");
+    }
+
+    #[test]
+    fn qwen3_coder_value_with_whitespace_newlines_and_quotes() {
+        // A code-snippet parameter: internal whitespace, newlines, and quotes
+        // must survive into a valid JSON string.
+        let output = "<tool_call><function=write_file><parameter=path>main.rs</parameter><parameter=content>\nfn main() {\n    println!(\"hi\");\n}\n</parameter></function></tool_call>";
+        let tools = vec![make_tool("write_file")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        let args = arg_obj(&result.tool_calls[0]);
+        assert_eq!(args["path"], "main.rs");
+        assert_eq!(args["content"], "fn main() {\n    println!(\"hi\");\n}");
+    }
+
+    #[test]
+    fn qwen3_coder_empty_parameter_value() {
+        let output =
+            "<tool_call><function=set_note><parameter=text></parameter></function></tool_call>";
+        let tools = vec![make_tool("set_note")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        assert_eq!(arg_obj(&result.tool_calls[0])["text"], "");
+    }
+
+    #[test]
+    fn qwen3_coder_malformed_missing_closing_tags_keeps_prior_calls() {
+        // First call is well-formed; the second opener is truncated mid-stream.
+        // The good call must still be returned (no panic, no total discard).
+        let output = "<tool_call><function=read_file><parameter=path>a.rs</parameter></function></tool_call><tool_call><function=read_file";
+        let tools = vec![make_tool("read_file")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(arg_obj(&result.tool_calls[0])["path"], "a.rs");
+    }
+
+    #[test]
+    fn qwen3_coder_zero_parameter_call() {
+        // No `<parameter=` body at all — must still parse as a no-arg call,
+        // not fall through to raw content.
+        let output = "<tool_call><function=list_files></function></tool_call>";
+        let tools = vec![make_tool("list_files")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        assert_eq!(result.tool_calls[0].name, "list_files");
+        assert_eq!(result.tool_calls[0].arguments, "{}");
+    }
+
+    #[test]
+    fn qwen3_coder_does_not_regress_functionary_v31_json_body() {
+        // Functionary v3.1 shares the `<function=` opener but has a JSON body.
+        // It must still be claimed by the functionary parser, not mis-parsed
+        // by the Qwen3-Coder parser into empty args.
+        let output = r#"<function=get_weather>{"location": "Berlin"}</function>"#;
+        let tools = vec![make_tool("get_weather")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        assert_eq!(arg_obj(&result.tool_calls[0])["location"], "Berlin");
     }
 }

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -148,7 +148,7 @@ pub fn parse_tool_calls(raw_output: &str, tools: Option<&[Tool]>) -> ToolCallPar
         formats::try_minimax_m2, // <invoke name=...><parameter name=...>...</parameter></invoke>
         formats::try_mistral_nemo, // [TOOL_CALLS]
         formats::try_functionary_v31, // <function=name>{json}
-        formats::try_qwen3_coder, // <function=name><parameter=key>val</parameter> — after v31, which declines non-JSON bodies
+        formats::try_qwen3_coder, // <function=name><parameter=key>val</parameter> (after v31, which declines non-JSON bodies)
         formats::try_functionary_v32, // >>>name\n
         formats::try_llama3,      // {"name": ..., "parameters": ...}
         formats::try_generic_json, // {"name": ..., "arguments": ...}
@@ -660,7 +660,7 @@ mod tests {
 
     #[test]
     fn qwen3_coder_zero_parameter_call() {
-        // No `<parameter=` body at all — must still parse as a no-arg call,
+        // No `<parameter=` body at all: must still parse as a no-arg call,
         // not fall through to raw content.
         let output = "<tool_call><function=list_files></function></tool_call>";
         let tools = vec![make_tool("list_files")];

--- a/src/server/tool_calls/types.rs
+++ b/src/server/tool_calls/types.rs
@@ -49,6 +49,14 @@ pub enum ToolCallFormat {
     GenericJson,
     /// MiniMax M2: `<invoke name="fn_name"><parameter name="k">v</parameter></invoke>`
     MinimaxM2,
+    /// Qwen3-Coder: `<tool_call><function=name><parameter=key>val</parameter></function></tool_call>`
+    ///
+    /// Named for the family that introduced it (the format is spelled out in
+    /// the Qwen3-Coder chat template), and matches the parser name vLLM and
+    /// SGLang use (`--tool-call-parser qwen3_coder`). The parser keys on the
+    /// markup, not the model, so it also handles newer Qwen models that share
+    /// this template (Qwen3.5 / Qwen3.6).
+    Qwen3Coder,
 }
 
 /// Result of parsing model output for tool calls.


### PR DESCRIPTION
Fixes #204.

## Summary

Adds a parser for Qwen3-Coder's XML-attribute tool-call format so mlxcel emits structured `tool_calls` instead of returning the raw markup as `content`. Without this, every OpenAI-compatible agentic client (Cline, opencode, aider, Continue, Zoo Code) breaks with Qwen3-Coder.

Format:
```
<tool_call><function=NAME><parameter=KEY>VALUE</parameter></function></tool_call>
```

## Design

`try_qwen3_coder` is dispatched immediately **after** `try_functionary_v31`. Both key on the `<function=` opener, but functionary v3.1 declines Qwen input (its non-JSON body fails the JSON-validity check → returns `None`), so the two never steal each other's calls — and zero-parameter Qwen calls (empty `<function=NAME></function>` body) are still handled. Reuses the MiniMax M2 helpers (`extract_quoted_name`, `coerce_minimax_param`), defensive caps, and the O(N²) malformed-input guard.

Named to match the `qwen3_coder` parser vLLM/SGLang ship; the format is also used by newer Qwen models (Qwen3.5/3.6) that share the template.

## Tests

Single/multi parameter, multiple calls, whitespace/newline/quote values, empty values, malformed truncation, zero-parameter calls, plus a no-regression check that functionary v3.1 JSON bodies still parse. Full tool-call suite green (155 tests); clippy + fmt clean.