### PR TITLE
fix(chat-template): render request tools faithfully into the prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,8 +1902,10 @@ version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
 dependencies = [
+ "indexmap",
  "memo-map",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ mlxcel-surgery = { path = "src/lib/mlxcel-surgery", optional = true }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = "0.9"
 
 # Tensors & Models
@@ -123,7 +123,7 @@ base64 = "0.22"
 dirs = "6"
 glob = "0.3.2"
 path-clean = "1.0.1"
-minijinja = { version = "2.20", features = ["loop_controls", "fuel"] }
+minijinja = { version = "2.20", features = ["loop_controls", "fuel", "json", "preserve_order"] }
 # Used by `src/downloader/mod.rs::file_url` to percent-encode `repo_id` /
 # `revision` / `filename` path segments before composing the HF download URL
 # (L1). Already transitively present via reqwest -> url; promoting

--- a/src/server/chat_template.rs
+++ b/src/server/chat_template.rs
@@ -1012,7 +1012,7 @@ mod tests {
         // array into the prompt with `{{ tools | tojson }}`. The `tojson` filter
         // is gated behind minijinja's `json` feature; without it the template
         // fails to render and the processor falls back to a default template
-        // that drops the tools section entirely — so the model never learns
+        // that drops the tools section entirely, so the model never learns
         // which tools exist and stops emitting tool calls.
         let template = r#"{% if tools %}<tools>{{ tools | tojson }}</tools>{% endif %}
 {% for m in messages %}{{ m.content }}{% endfor %}"#;

--- a/src/server/chat_template.rs
+++ b/src/server/chat_template.rs
@@ -1007,6 +1007,75 @@ mod tests {
     }
 
     #[test]
+    fn test_tojson_filter_serializes_tools_into_prompt() {
+        // Regression: Qwen3-Coder's official chat template serializes the tools
+        // array into the prompt with `{{ tools | tojson }}`. The `tojson` filter
+        // is gated behind minijinja's `json` feature; without it the template
+        // fails to render and the processor falls back to a default template
+        // that drops the tools section entirely — so the model never learns
+        // which tools exist and stops emitting tool calls.
+        let template = r#"{% if tools %}<tools>{{ tools | tojson }}</tools>{% endif %}
+{% for m in messages %}{{ m.content }}{% endfor %}"#;
+
+        let processor = ChatTemplateProcessor::with_template(template.to_string());
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "hi".to_string(),
+        }];
+        let tools = vec![Tool {
+            tool_type: "function".to_string(),
+            function: crate::server::types::request::FunctionDefinition {
+                name: "get_weather".to_string(),
+                description: Some("Get weather".to_string()),
+                parameters: None,
+            },
+        }];
+
+        let result = processor.apply(&messages, Some(&tools)).unwrap();
+        // The custom `<tools>[...]` markup only survives if the real template
+        // rendered; a render-failure fallback would drop it. `[` confirms
+        // `tojson` emitted a JSON array rather than erroring on an unknown filter.
+        assert!(
+            result.contains("<tools>["),
+            "tojson must serialize the tools array into the prompt: {result}"
+        );
+        assert!(result.contains("get_weather"));
+    }
+
+    #[test]
+    fn test_tool_parameter_key_order_preserved_through_render() {
+        // Regression (Issue 7): serde_json's default `Map` is a `BTreeMap`,
+        // which alphabetizes object keys. Tool parameter schemas therefore
+        // rendered into the prompt in a DIFFERENT order than the client sent
+        // (e.g. grep's `pattern, include` became `include, pattern`), shifting
+        // Qwen3-Coder's tool-selection logits at temperature 0 and producing
+        // worse tool choices than mlx-serve (which preserves wire order). The
+        // `preserve_order` serde_json feature keeps insertion order.
+        //
+        // Deserialize from a wire JSON string with deliberately
+        // non-alphabetical keys so the test fails if BTreeMap sorting returns.
+        let tools: Vec<Tool> = serde_json::from_str(
+            r#"[{"type":"function","function":{"name":"grep","parameters":{"properties":{"pattern":{"type":"string"},"include":{"type":"string"}}}}}]"#,
+        )
+        .unwrap();
+
+        let template = r#"{{ tools | tojson }}"#;
+        let processor = ChatTemplateProcessor::with_template(template.to_string());
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "x".to_string(),
+        }];
+
+        let result = processor.apply(&messages, Some(&tools)).unwrap();
+        let pattern_idx = result.find("pattern").expect("pattern key present");
+        let include_idx = result.find("include").expect("include key present");
+        assert!(
+            pattern_idx < include_idx,
+            "tool parameter keys must render in wire order (pattern before include), got: {result}"
+        );
+    }
+
+    #[test]
     fn test_supports_tools_detection() {
         // Template that uses tools — rendering differs with/without tools
         let with_tools =


### PR DESCRIPTION
Fixes #205.

## Summary

Two fidelity bugs in the minijinja chat-template render path caused Qwen3-Coder agentic clients to misbehave once tool-call *output* parsing worked. Both are fixed by enabling JSON-related cargo features.

### 1. Missing `tojson` filter → tools section dropped
Qwen3-Coder's template uses `{{ tools | tojson }}`. The filter is gated behind minijinja's `json` feature, which was off, so the render failed and the fallback template omitted the tools section — the model never saw the tools and stopped emitting tool calls.

### 2. Alphabetized JSON keys → tool parameters reordered
`FunctionDefinition.parameters` is a `serde_json::Value`; serde_json and minijinja both default to sorted (BTreeMap) maps, so tool params rendered alphabetically instead of in wire order (`pattern, include` → `include, pattern`). At `temperature: 0` this deterministically shifts the model's tool selection. **Both** crates need `preserve_order` — the value passes through two sorted-map stages, so fixing only one is insufficient (verified by the key-order test).

## Fix
- `minijinja`: add features `json`, `preserve_order`
- `serde_json`: add feature `preserve_order`

The prompt-cache key digest is unaffected — `canonicalize_map` in `prompt_cache/key.rs` sorts keys explicitly, so it's invariant to the map's internal ordering (existing cache-key tests pass).

## Tests
Adds a `tojson` render test and a tool-parameter key-order test (non-alphabetical input must survive the render). Full lib suite green (3096 tests); clippy + fmt clean.