### PR TITLE
fix(chat-template): render assistant tool_calls.arguments as object on multi-turn

### DIFF
--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -334,8 +334,10 @@ fn build_raw_json_messages_with_thinking(
                 msg["tool_call_id"] = serde_json::Value::String(tool_call_id.clone());
             }
             if let Some(ref tool_calls) = m.tool_calls {
-                msg["tool_calls"] =
+                let mut tc_value =
                     serde_json::to_value(tool_calls).unwrap_or(serde_json::Value::Null);
+                normalize_tool_call_arguments(&mut tc_value);
+                msg["tool_calls"] = tc_value;
             }
 
             msg
@@ -343,6 +345,40 @@ fn build_raw_json_messages_with_thinking(
         .collect();
 
     serde_json::Value::Array(messages)
+}
+
+/// Normalize each tool call's `function.arguments` from a JSON-encoded string
+/// into a parsed object so dict-iterating chat templates can consume it.
+///
+/// The OpenAI wire format carries `arguments` as a JSON *string* (e.g.
+/// `"{\"path\":\"/foo\"}"`), and that's what agentic clients echo back on
+/// later turns. But the Qwen3-Coder / Qwen3.5 / Qwen3.6 chat templates iterate
+/// it with `tool_call.arguments|items`, which requires a mapping. Passing the
+/// raw string makes minijinja's `|items` fail ("cannot convert value into
+/// pairs"), the whole render falls back to a default template, and the
+/// resulting prompt diverges from the prior turn from the first token,
+/// silently degrading the model's multi-turn context and destroying
+/// prompt-cache prefix reuse (every tool turn re-prefills cold).
+///
+/// We replace `arguments` only when the string parses to a JSON **object**, so
+/// templates that expect a string (e.g. Gemma 4 via `tojson` / `string`) and
+/// malformed/scalar arguments are left untouched. Mirrors mlx-serve's
+/// `chat.zig` workaround.
+fn normalize_tool_call_arguments(tool_calls: &mut serde_json::Value) {
+    let serde_json::Value::Array(calls) = tool_calls else {
+        return;
+    };
+    for call in calls {
+        let Some(args) = call.pointer_mut("/function/arguments") else {
+            continue;
+        };
+        if let serde_json::Value::String(s) = args
+            && let Ok(parsed) = serde_json::from_str::<serde_json::Value>(s)
+            && parsed.is_object()
+        {
+            *args = parsed;
+        }
+    }
 }
 
 /// Flatten request messages into [`ChatMessage`], preserving all `<think>`

--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -360,10 +360,10 @@ fn build_raw_json_messages_with_thinking(
 /// silently degrading the model's multi-turn context and destroying
 /// prompt-cache prefix reuse (every tool turn re-prefills cold).
 ///
-/// We replace `arguments` only when the string parses to a JSON **object**, so
-/// templates that expect a string (e.g. Gemma 4 via `tojson` / `string`) and
-/// malformed/scalar arguments are left untouched. Mirrors mlx-serve's
-/// `chat.zig` workaround.
+/// We replace `arguments` only when the string parses to a JSON **object**;
+/// templates that serialize arguments via `tojson` then emit the original
+/// object shape, while malformed/scalar arguments stay strings for templates
+/// that treat them as text. Mirrors mlx-serve's `chat.zig` workaround.
 fn normalize_tool_call_arguments(tool_calls: &mut serde_json::Value) {
     let serde_json::Value::Array(calls) = tool_calls else {
         return;

--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -435,6 +435,122 @@ fn build_raw_json_messages_leaves_non_object_tool_call_arguments_as_string() {
 }
 
 #[test]
+fn build_raw_json_messages_leaves_json_scalar_or_array_arguments_as_string() {
+    // Only object-valued JSON strings are promoted to mappings. Other valid
+    // JSON shapes are still OpenAI wire-format strings from the request model's
+    // point of view and must survive byte-for-byte.
+    for arguments in ["[1,2]", "42", "true", "null", r#""quoted""#] {
+        let request = req_with_tool_call_arguments(arguments);
+        let raw = build_raw_json_messages(&request);
+        let args = &raw.as_array().unwrap()[0]["tool_calls"][0]["function"]["arguments"];
+        assert!(
+            args.is_string(),
+            "non-object JSON arguments must remain a string, got {args} for {arguments}"
+        );
+        assert_eq!(args.as_str().unwrap(), arguments);
+    }
+}
+
+#[tokio::test]
+async fn prepare_chat_request_renders_tool_call_arguments_as_mapping() {
+    // End-to-end regression for issue #209: the raw-template path must receive
+    // object-valued tool-call arguments as a mapping, otherwise templates that
+    // iterate with `arguments|items` fail and prepare_chat_request falls back
+    // to the simple "User:/Assistant:" prompt.
+    let request = request_with_messages(vec![
+        Message {
+            role: Role::User,
+            content: MessageContent::Text("Read a file".to_string()),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        },
+        Message {
+            role: Role::Assistant,
+            content: MessageContent::Text(String::new()),
+            name: None,
+            tool_call_id: None,
+            tool_calls: Some(vec![ToolCallInMessage {
+                id: "call_1".to_string(),
+                call_type: "function".to_string(),
+                function: ToolCallFunction {
+                    name: "read_file".to_string(),
+                    arguments: r#"{"path":"/foo","recursive":true}"#.to_string(),
+                },
+            }]),
+        },
+        Message {
+            role: Role::Tool,
+            content: MessageContent::Text("ok".to_string()),
+            name: None,
+            tool_call_id: Some("call_1".to_string()),
+            tool_calls: None,
+        },
+        Message {
+            role: Role::User,
+            content: MessageContent::Text("Continue".to_string()),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+        },
+    ]);
+    let processor = ChatTemplateProcessor::with_template(
+        r#"{% for message in messages %}
+{% if message.tool_calls is defined %}
+{% for tool_call in message.tool_calls %}
+TEMPLATE_OK:{{ tool_call.function.name }}
+{% for name, value in tool_call.function.arguments|items %}ARG:{{ name }}={{ value }};
+{% endfor %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% if add_generation_prompt %}Assistant:{% endif %}"#
+            .to_string(),
+    );
+
+    let prepared = prepare_chat_request(&processor, &request, None)
+        .await
+        .unwrap();
+    assert!(
+        prepared.prompt.contains("TEMPLATE_OK:read_file"),
+        "real template must render instead of falling back: {:?}",
+        prepared.prompt
+    );
+    assert!(
+        prepared.prompt.contains("ARG:path=/foo;"),
+        "object string arguments must be iterable as a mapping: {:?}",
+        prepared.prompt
+    );
+    assert!(
+        prepared.prompt.contains("ARG:recursive=true;"),
+        "boolean argument value must survive mapping normalization: {:?}",
+        prepared.prompt
+    );
+    assert!(
+        !prepared.prompt.contains("User: Read a file"),
+        "fallback prompt indicates the `|items` render still failed: {:?}",
+        prepared.prompt
+    );
+}
+
+#[tokio::test]
+async fn prepare_chat_request_tojson_templates_render_normalized_arguments() {
+    // Templates that serialize assistant tool-call arguments with `tojson`
+    // remain valid after normalization: they now emit the JSON object the
+    // assistant originally produced, rather than an escaped JSON string.
+    let request = req_with_tool_call_arguments(r#"{"path":"/foo","recursive":true}"#);
+    let processor = ChatTemplateProcessor::with_template(
+        r#"{% for message in messages %}{% for tool_call in message.tool_calls %}{{ tool_call.function.arguments | tojson }}{% endfor %}{% endfor %}"#
+            .to_string(),
+    );
+
+    let prepared = prepare_chat_request(&processor, &request, None)
+        .await
+        .unwrap();
+    assert_eq!(prepared.prompt, r#"{"path":"/foo","recursive":true}"#);
+}
+
+#[test]
 fn deserialize_tool_call_request_without_assistant_content() {
     // Issue #89: OpenAI-compatible clients omit `content` on the assistant
     // `tool_calls` message of a multi-turn tool loop. The follow-up request

--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -363,6 +363,77 @@ fn build_raw_json_messages_includes_tool_fields() {
     assert_eq!(arr[1]["role"].as_str().unwrap(), "tool");
 }
 
+/// Build a one-assistant-message request whose single tool call carries the
+/// given (wire-format string) `arguments`.
+fn req_with_tool_call_arguments(arguments: &str) -> ChatCompletionRequest {
+    ChatCompletionRequest {
+        model: "test".to_string(),
+        messages: vec![Message {
+            role: Role::Assistant,
+            content: MessageContent::Text(String::new()),
+            name: None,
+            tool_call_id: None,
+            tool_calls: Some(vec![ToolCallInMessage {
+                id: "call_1".to_string(),
+                call_type: "function".to_string(),
+                function: ToolCallFunction {
+                    name: "read_file".to_string(),
+                    arguments: arguments.to_string(),
+                },
+            }]),
+        }],
+        stream: false,
+        stream_options: None,
+        logprobs: None,
+        top_logprobs: None,
+        tools: None,
+        tool_choice: None,
+        parallel_tool_calls: None,
+        chat_template_kwargs: None,
+        extra_body: None,
+        prompt_cache_key: None,
+        user: None,
+        extra_body_fields: serde_json::Map::new(),
+        response_format: None,
+        params: SamplingParams::default(),
+    }
+}
+
+#[test]
+fn build_raw_json_messages_parses_tool_call_arguments_into_object() {
+    // Qwen3-Coder/3.5/3.6 templates do `tool_call.arguments|items`,
+    // which requires a dict. The OpenAI wire format echoes `arguments` back as
+    // a JSON-encoded STRING on later turns. Left as a string, minijinja's
+    // `|items` fails ("cannot convert value into pairs"), the render falls back
+    // to a default template, and the turn-2 prompt diverges from turn 1, which
+    // silently degrades multi-turn context and breaks prompt-cache prefix reuse
+    // (the real root cause of the "cache miss"). So an object-valued arguments
+    // string must be normalized to an object.
+    let request = req_with_tool_call_arguments(r#"{"path":"/foo","recursive":true}"#);
+    let raw = build_raw_json_messages(&request);
+    let args = &raw.as_array().unwrap()[0]["tool_calls"][0]["function"]["arguments"];
+    assert!(
+        args.is_object(),
+        "arguments must be normalized to an object so `|items` can iterate, got: {args}"
+    );
+    assert_eq!(args["path"].as_str().unwrap(), "/foo");
+    assert_eq!(args["recursive"], serde_json::json!(true));
+}
+
+#[test]
+fn build_raw_json_messages_leaves_non_object_tool_call_arguments_as_string() {
+    // Malformed / non-object arguments must stay a string so templates that do
+    // `| string` or `| tojson` (e.g. Gemma 4) still get a usable value.
+    let request = req_with_tool_call_arguments("not valid json");
+    let raw = build_raw_json_messages(&request);
+    let args = &raw.as_array().unwrap()[0]["tool_calls"][0]["function"]["arguments"];
+    assert!(
+        args.is_string(),
+        "malformed arguments must remain a string, got: {args}"
+    );
+    assert_eq!(args.as_str().unwrap(), "not valid json");
+}
+
 #[test]
 fn deserialize_tool_call_request_without_assistant_content() {
     // Issue #89: OpenAI-compatible clients omit `content` on the assistant

--- a/src/server/prompt_cache/apc_integration_tests.rs
+++ b/src/server/prompt_cache/apc_integration_tests.rs
@@ -202,6 +202,70 @@ fn apc_off_config() -> PromptCacheConfig {
     )
 }
 
+// Regression: a request that is a STRICT PREFIX of (shorter than) a
+// longer stored entry. Donate-back stores `[prompt + generated]`, so a later
+// request carrying only `[prompt]` is shorter than every stored entry. mlx-serve
+// reuses the shared prefix (95%+); mlxcel was observed returning cached=0 even
+// for a byte-identical resent prompt. The matching logic is fully harness-side,
+// so this must be unit-reproducible with no model.
+#[test]
+fn apc_on_partial_hits_when_request_is_strict_prefix_of_longer_entry() {
+    let store = PromptCacheStore::with_config(apc_on_config());
+
+    // Stored entry = prompt(48 tokens) + generated tail(16 tokens) = 64 tokens.
+    let prompt: Vec<i32> = (0..48).collect();
+    let mut stored = prompt.clone();
+    stored.extend(1000..1016);
+    let mm = multimodal_digest_from_vecs(&[], &[]);
+
+    store
+        .insert(
+            &PromptCacheKey::new_full("model", None, "tpl", None, mm, &stored),
+            CacheEntry::new_for_test(stored.clone(), 1024),
+        )
+        .expect("insert stored entry");
+
+    // Later request is just the prompt (shorter, an exact prefix of `stored`).
+    let req_key = PromptCacheKey::new_full("model", None, "tpl", None, mm, &prompt);
+    let hit = store.lookup_longest_prefix(&req_key, &prompt);
+
+    let (_, matched) = hit.expect(
+        "APC on: a request that is a strict prefix of a longer stored entry must \
+         partial-match the shared prefix (regression: returned cached=0)",
+    );
+    // prompt is 48 tokens = 3 full 16-token blocks; all three match `stored`.
+    assert_eq!(
+        matched, 48,
+        "expected the full 48-token shared prefix to be reused"
+    );
+}
+
+#[test]
+fn apc_off_misses_when_request_is_strict_prefix_of_longer_entry() {
+    // Documents the legacy whole-entry-contained gate: with APC OFF the same
+    // shape returns no match, because the stored entry is longer than the
+    // request. This is the behavior APC is supposed to rescue.
+    let store = PromptCacheStore::with_config(apc_off_config());
+
+    let prompt: Vec<i32> = (0..48).collect();
+    let mut stored = prompt.clone();
+    stored.extend(1000..1016);
+    let mm = multimodal_digest_from_vecs(&[], &[]);
+
+    store
+        .insert(
+            &PromptCacheKey::new_full("model", None, "tpl", None, mm, &stored),
+            CacheEntry::new_for_test(stored.clone(), 1024),
+        )
+        .expect("insert stored entry");
+
+    let req_key = PromptCacheKey::new_full("model", None, "tpl", None, mm, &prompt);
+    assert!(
+        store.lookup_longest_prefix(&req_key, &prompt).is_none(),
+        "APC off: a shorter request cannot whole-entry-match a longer stored entry"
+    );
+}
+
 #[test]
 fn apc_stores_independent_entries_for_same_tokens_different_images() {
     // The headline regression: two requests with identical tokens but


### PR DESCRIPTION
Fixes #209.

## Summary

On turn 2+ of a tool-using conversation, assistant `tool_calls.arguments` arrives as a JSON-encoded **string** (the OpenAI wire format). The Qwen3-Coder / Qwen3.5 / Qwen3.6 chat template iterates it with `tool_call.arguments|items`, which needs a mapping — so minijinja errors (`cannot convert value into pairs`), the render falls back to a default template, and the turn-2 prompt diverges from turn 1 at the first token. This silently degrades the model's multi-turn context **and** collapses prompt-prefix cache reuse (every tool turn re-prefills cold).

## Fix

`build_raw_json_messages_with_thinking` now normalizes each tool call's `function.arguments`: a string that parses to a JSON **object** is replaced with the parsed object; malformed/scalar values stay strings, and templates that serialize arguments with `tojson` emit the original JSON object shape. Mirrors mlx-serve's `chat.zig` workaround.

## Impact (Qwen3-Coder-30B-A3B, opencode, 2-turn)

- No more `Chat template render (raw) failed … cannot convert value into pairs` warning.
- Turn-2 prompt-cache reuse: **0/13,320 (0%) → 15,840/19,519 (81%)**; turn-2 wall time halved.
- Resolves the multi-turn "cache miss with byte-identical prefix" report (downstream symptom of this bug).

## Tests

- `build_raw_json_messages_parses_tool_call_arguments_into_object` (object-string → object)
- `build_raw_json_messages_leaves_non_object_tool_call_arguments_as_string` (malformed → string)
- `build_raw_json_messages_leaves_json_scalar_or_array_arguments_as_string` (valid non-object JSON → unchanged string)
- `prepare_chat_request_renders_tool_call_arguments_as_mapping` (production raw-template path with `arguments|items`, no fallback)
- `prepare_chat_request_tojson_templates_render_normalized_arguments` (`tojson` emits the normalized object shape)
- two store-level APC tests covering a request that is a strict prefix of a longer stored entry (the donate-back shape) — previously uncovered.

Full local validation: chat_request tests, APC integration tests, full `cargo test --lib --features metal,accelerate -- --test-threads=1`, clippy, fmt, and cargo-deny are green.
