### PR TITLE
fix: apply the chat stream filter to disaggregated router output

### DIFF
--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -74,7 +74,7 @@ use crate::distributed::tcp_transport::TcpTransport;
 use crate::distributed::transport::{Transport, TransportBackend};
 use crate::server::ChatTemplateProcessor;
 use crate::server::config::ServerConfig;
-use crate::server::tool_calls::stream_filter::StreamFilter;
+use crate::server::tool_calls::stream_filter::{FilterOutput, StreamFilter};
 use crate::server::types::request::ChatCompletionRequest;
 use crate::tokenizer::MlxcelTokenizer;
 
@@ -370,7 +370,7 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
         tokio::spawn(async move {
             let _ = chunk_tx.send(Ok(sse_event(&chat_chunk_initial(&request_id_str2, &model))));
 
-            let emit_filtered = |emit: crate::server::tool_calls::stream_filter::FilterOutput| {
+            let emit_filtered = |emit: FilterOutput| {
                 if let Some(reasoning) = emit.reasoning
                     && !reasoning.is_empty()
                 {
@@ -425,7 +425,7 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
         let mut reasoning = String::new();
         let mut rx = rx;
         {
-            let mut absorb = |emit: crate::server::tool_calls::stream_filter::FilterOutput| {
+            let mut absorb = |emit: FilterOutput| {
                 if let Some(r) = emit.reasoning {
                     reasoning.push_str(&r);
                 }

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -33,6 +33,17 @@
 //! the prefill and decode nodes can return their [`ResultFrame`]s to it. A
 //! background demux task (`spawn_result_demux`) routes each incoming frame to
 //! the per-request channel keyed by `request_id`.
+//!
+//! # Output filtering (issue #198)
+//!
+//! Every decode text piece (and the prefill first token) passes through the
+//! same [`StreamFilter`] the single-node chat route uses, so model-specific
+//! structural markers (`<think>`, `<|channel>`, tool-call delimiters, stray
+//! turn tokens) never leak to the client and thinking content is routed to
+//! `delta.reasoning_content`. Tool-call parsing (accumulate-then-parse into
+//! `tool_calls`) is NOT yet supported on the router path: the router emits
+//! `content` and `reasoning_content` only, and the filter suppresses
+//! tool-call delimiter markers.
 
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -63,6 +74,7 @@ use crate::distributed::tcp_transport::TcpTransport;
 use crate::distributed::transport::{Transport, TransportBackend};
 use crate::server::ChatTemplateProcessor;
 use crate::server::config::ServerConfig;
+use crate::server::tool_calls::stream_filter::StreamFilter;
 use crate::server::types::request::ChatCompletionRequest;
 use crate::tokenizer::MlxcelTokenizer;
 
@@ -289,6 +301,17 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
 
     let prompt = prepared.prompt;
 
+    // Stream filter (issue #198): mirror the single-node chat route, including
+    // the primed-open-thinking start state when the rendered prompt ends
+    // inside an open thinking block (enable_thinking=true templates), so the
+    // model's first emitted tokens route to `reasoning_content`.
+    let primed_open_thinking = super::routes::chat::is_prompt_primed_open_thinking(&prompt);
+    let stream_filter = if primed_open_thinking {
+        StreamFilter::new_primed_open_thinking()
+    } else {
+        StreamFilter::new()
+    };
+
     // Tokenize the rendered prompt. Match the worker's behavior: skip the
     // BOS special token when the prompt already starts with one.
     let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
@@ -343,18 +366,40 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
         let model = request.model.clone();
         let handoff_timeout = state.handoff_timeout;
 
+        let mut filter = stream_filter;
         tokio::spawn(async move {
             let _ = chunk_tx.send(Ok(sse_event(&chat_chunk_initial(&request_id_str2, &model))));
 
-            let result =
-                drive_handoff_result(&mut { rx }, &request_id_str2, handoff_timeout, |text| {
+            let emit_filtered = |emit: crate::server::tool_calls::stream_filter::FilterOutput| {
+                if let Some(reasoning) = emit.reasoning
+                    && !reasoning.is_empty()
+                {
+                    let _ = chunk_tx.send(Ok(sse_event(&chat_chunk_reasoning(
+                        &request_id_str2,
+                        &model,
+                        &reasoning,
+                    ))));
+                }
+                if let Some(content) = emit.content
+                    && !content.is_empty()
+                {
                     let _ = chunk_tx.send(Ok(sse_event(&chat_chunk_content(
                         &request_id_str2,
                         &model,
-                        text,
+                        &content,
                     ))));
+                }
+            };
+
+            let result =
+                drive_handoff_result(&mut { rx }, &request_id_str2, handoff_timeout, |text| {
+                    emit_filtered(filter.feed(text));
                 })
                 .await;
+
+            // Flush any text still buffered inside the filter (e.g. an
+            // unterminated partial delimiter match at end of stream).
+            emit_filtered(filter.flush());
 
             if let Err(e) = result {
                 let _ = chunk_tx.send(Ok(sse_event(&chat_chunk_error(
@@ -373,19 +418,34 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
             .keep_alive(KeepAlive::default())
             .into_response())
     } else {
-        // Non-streaming: collect all tokens then return a single JSON object.
+        // Non-streaming: collect all tokens (filtered) then return a single
+        // JSON object with `content` and, when present, `reasoning_content`.
+        let mut filter = stream_filter;
         let mut content = String::new();
+        let mut reasoning = String::new();
         let mut rx = rx;
-        let r = drive_handoff_result(&mut rx, &request_id_str, state.handoff_timeout, |text| {
-            content.push_str(text);
-        })
-        .await;
-        state.pending.lock().unwrap().remove(&request_id);
-        r?;
+        {
+            let mut absorb = |emit: crate::server::tool_calls::stream_filter::FilterOutput| {
+                if let Some(r) = emit.reasoning {
+                    reasoning.push_str(&r);
+                }
+                if let Some(c) = emit.content {
+                    content.push_str(&c);
+                }
+            };
+            let r = drive_handoff_result(&mut rx, &request_id_str, state.handoff_timeout, |text| {
+                absorb(filter.feed(text));
+            })
+            .await;
+            absorb(filter.flush());
+            state.pending.lock().unwrap().remove(&request_id);
+            r?;
+        }
         Ok(Json(chat_completion_json(
             &request_id_str,
             &request.model,
             &content,
+            &reasoning,
         ))
         .into_response())
     }
@@ -499,6 +559,20 @@ fn chat_chunk_content(id: &str, model: &str, text: &str) -> serde_json::Value {
     })
 }
 
+/// Streaming chunk carrying a reasoning (thinking) token.
+fn chat_chunk_reasoning(id: &str, model: &str, text: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "object": "chat.completion.chunk",
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "delta": {"reasoning_content": text},
+            "finish_reason": null
+        }]
+    })
+}
+
 /// Final streaming chunk with `finish_reason = "stop"`.
 fn chat_chunk_finish(id: &str, model: &str) -> serde_json::Value {
     serde_json::json!({
@@ -527,15 +601,25 @@ fn chat_chunk_error(id: &str, model: &str, msg: &str) -> serde_json::Value {
     })
 }
 
-/// Non-streaming response body.
-fn chat_completion_json(id: &str, model: &str, content: &str) -> serde_json::Value {
+/// Non-streaming response body. `reasoning_content` is included only when
+/// the filter routed any thinking text.
+fn chat_completion_json(
+    id: &str,
+    model: &str,
+    content: &str,
+    reasoning: &str,
+) -> serde_json::Value {
+    let mut message = serde_json::json!({"role": "assistant", "content": content});
+    if !reasoning.is_empty() {
+        message["reasoning_content"] = serde_json::Value::String(reasoning.to_string());
+    }
     serde_json::json!({
         "id": id,
         "object": "chat.completion",
         "model": model,
         "choices": [{
             "index": 0,
-            "message": {"role": "assistant", "content": content},
+            "message": message,
             "finish_reason": "stop"
         }]
     })

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -929,7 +929,7 @@ const OPEN_THINKING_SUFFIXES: &[&str] = &["<|channel>thought\n", "<think>\n"];
 ///   emitted token from the start (otherwise the state would wait for an
 ///   opening token that never appears because the prompt already contains
 ///   it).
-fn is_prompt_primed_open_thinking(prompt: &str) -> bool {
+pub(crate) fn is_prompt_primed_open_thinking(prompt: &str) -> bool {
     OPEN_THINKING_SUFFIXES
         .iter()
         .any(|suffix| prompt.ends_with(suffix))

--- a/tests/disaggregated_router_e2e.rs
+++ b/tests/disaggregated_router_e2e.rs
@@ -282,3 +282,226 @@ async fn disaggregated_router_streams_correct_output() {
     );
     eprintln!("OK: three-process disaggregated router reproduced the expected output via SSE.");
 }
+
+/// Parse an SSE body into concatenated `(content, reasoning_content)` deltas.
+fn parse_sse_deltas(body: &str) -> (String, String) {
+    let mut content = String::new();
+    let mut reasoning = String::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if let Some(data) = line.strip_prefix("data: ") {
+            if data == "[DONE]" {
+                continue;
+            }
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data) {
+                let delta = v
+                    .get("choices")
+                    .and_then(|c| c.get(0))
+                    .and_then(|c| c.get("delta"));
+                if let Some(text) = delta
+                    .and_then(|d| d.get("content"))
+                    .and_then(|t| t.as_str())
+                {
+                    content.push_str(text);
+                }
+                if let Some(text) = delta
+                    .and_then(|d| d.get("reasoning_content"))
+                    .and_then(|t| t.as_str())
+                {
+                    reasoning.push_str(text);
+                }
+            }
+        }
+    }
+    (content, reasoning)
+}
+
+/// Issue #198: a THINKING-ENABLED request through the disaggregated router
+/// must produce the same `content` / `reasoning_content` split as the
+/// single-node chat route, with no structural markers (`<think>`) leaking
+/// into either field.
+///
+/// Runs the single-node hybrid reference first (then kills it), so at most
+/// two model-loaded processes are resident at once alongside the router.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "spawns four real mlxcel-server processes loading qwen3-0.6b-4bit; run with --ignored"]
+async fn disaggregated_router_filters_thinking_output() {
+    let model_dir = repo_model_dir(QWEN3_DIR);
+    if !model_dir.exists() {
+        eprintln!("Skipping {QWEN3_DIR}: model directory not found");
+        return;
+    }
+    let binary = repo_binary_path("mlxcel-server");
+    if !binary.exists() {
+        eprintln!("Skipping: mlxcel-server binary not found");
+        return;
+    }
+    let model_arg = model_dir.to_string_lossy().to_string();
+    let request_body = serde_json::json!({
+        "model": "qwen3",
+        "messages": [{"role": "user", "content": "What is 2 + 2?"}],
+        "stream": true,
+        "temperature": 0.0,
+        "max_tokens": 32,
+        "chat_template_kwargs": {"enable_thinking": true}
+    });
+    let client = reqwest::Client::new();
+
+    // ---- Single-node hybrid reference ----
+    let (ref_content, ref_reasoning) = {
+        let ports = reserve_ports(1);
+        let hybrid_http = ports[0].to_string();
+        let _hybrid = spawn_role_server(&[
+            "-m",
+            &model_arg,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &hybrid_http,
+            "--no-warmup",
+        ]);
+        let deadline = Instant::now() + Duration::from_secs(240);
+        let health_url = format!("http://127.0.0.1:{hybrid_http}/health");
+        assert!(
+            wait_for_http_health(&health_url, deadline).await,
+            "hybrid reference server never became healthy at {health_url}"
+        );
+        let response = client
+            .post(format!(
+                "http://127.0.0.1:{hybrid_http}/v1/chat/completions"
+            ))
+            .json(&request_body)
+            .send()
+            .await
+            .expect("POST to hybrid reference");
+        assert!(response.status().is_success(), "hybrid returned an error");
+        let body = response.text().await.expect("read hybrid SSE body");
+        parse_sse_deltas(&body)
+        // _hybrid drops here, killing the reference server.
+    };
+    eprintln!(
+        "hybrid reference: content={ref_content:?} reasoning ({} chars)",
+        ref_reasoning.len()
+    );
+    assert!(
+        !ref_reasoning.is_empty(),
+        "thinking-enabled hybrid reference produced no reasoning_content; \
+         the parity comparison would be vacuous"
+    );
+
+    // ---- Three-process disaggregated router run ----
+    let ports = reserve_ports(6);
+    let prefill_http = ports[0].to_string();
+    let decode_http = ports[1].to_string();
+    let router_http = ports[2].to_string();
+    let prefill_serving_addr = format!("127.0.0.1:{}", ports[3]);
+    let decode_serving_addr = format!("127.0.0.1:{}", ports[4]);
+    let router_serving_addr = format!("127.0.0.1:{}", ports[5]);
+
+    let _decode = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &decode_http,
+        "--parallel",
+        "2",
+        "--max-batch-size",
+        "2",
+        "--decode-storage-backend",
+        "paged",
+        "--node-role",
+        "decode",
+        "--serving-bind",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+    let _prefill = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &prefill_http,
+        "--parallel",
+        "2",
+        "--max-batch-size",
+        "2",
+        "--decode-storage-backend",
+        "paged",
+        "--node-role",
+        "prefill",
+        "--serving-bind",
+        &prefill_serving_addr,
+        "--decode-peers",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+    let _router = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &router_http,
+        "--node-role",
+        "router",
+        "--serving-bind",
+        &router_serving_addr,
+        "--prefill-peers",
+        &prefill_serving_addr,
+        "--decode-peers",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+
+    let deadline = Instant::now() + Duration::from_secs(240);
+    assert!(
+        wait_for_tcp(&decode_serving_addr, deadline).await,
+        "decode node serving transport never came up"
+    );
+    assert!(
+        wait_for_tcp(&prefill_serving_addr, deadline).await,
+        "prefill node serving transport never came up"
+    );
+    let health_url = format!("http://127.0.0.1:{router_http}/health");
+    assert!(
+        wait_for_http_health(&health_url, deadline).await,
+        "router HTTP /health never returned 200"
+    );
+
+    let response = client
+        .post(format!(
+            "http://127.0.0.1:{router_http}/v1/chat/completions"
+        ))
+        .json(&request_body)
+        .send()
+        .await
+        .expect("POST to router");
+    assert!(response.status().is_success(), "router returned an error");
+    let body = response.text().await.expect("read router SSE body");
+    let (content, reasoning) = parse_sse_deltas(&body);
+    eprintln!(
+        "router: content={content:?} reasoning ({} chars)",
+        reasoning.len()
+    );
+
+    assert!(
+        !content.contains("<think>") && !content.contains("</think>"),
+        "thinking markers leaked into router content: {content:?}"
+    );
+    assert!(
+        !reasoning.contains("<think>") && !reasoning.contains("</think>"),
+        "thinking markers leaked into router reasoning_content"
+    );
+    assert_eq!(
+        reasoning, ref_reasoning,
+        "router reasoning_content does not match the single-node chat route"
+    );
+    assert_eq!(
+        content, ref_content,
+        "router content does not match the single-node chat route"
+    );
+    eprintln!("OK: router thinking-enabled output matches the single-node split.");
+}


### PR DESCRIPTION
Closes #198

## Problem

The disaggregated router (`src/server/router_front.rs`) forwarded the decode node's raw detokenized text directly into the SSE `delta.content`. For reasoning models or tool-calling prompts, model-specific structural markers (`<think>`, `<|channel>`, tool-call delimiters, stray turn tokens) leaked to the client, and thinking content was never routed to `reasoning_content`. This is why `tests/disaggregated_router_e2e.rs` only covered `enable_thinking=false`.

## Implementation

- The router's chat handler now instantiates the same `StreamFilter` the single-node chat route uses, including the primed-open-thinking start state when the rendered prompt ends inside an open thinking block (`is_prompt_primed_open_thinking`, now `pub(crate)`).
- Every text piece, including the prefill node's first token (which can be the first reasoning token), passes through the filter in both the streaming and non-streaming paths. Filtered content goes to `delta.content`, thinking content to `delta.reasoning_content` (new `chat_chunk_reasoning` helper). The filter is flushed after the handoff completes so buffered partial-delimiter text is not lost.
- The non-streaming response includes `message.reasoning_content` when the filter routed any thinking text.
- Tool-call parsing (accumulate-then-parse into `tool_calls`) is deferred and documented in the module docs: the router emits `content` and `reasoning_content` only; tool-call delimiter markers are suppressed by the filter.

## Verification (M1 Ultra, qwen3-0.6b-4bit, real 3-process E2E)

- New `disaggregated_router_filters_thinking_output`: runs a thinking-enabled request against a single-node hybrid reference first, then through the 3-process router (prefill + decode + router). The router's `reasoning_content` and `content` are byte-identical to the single-node chat route's split (96 reasoning chars on the test prompt), and no `<think>` markers appear in either field.
- Existing `disaggregated_router_streams_correct_output` (thinking disabled) still pins the byte-exact "2 + 2 = 4." output, confirming the filter is transparent for plain content.
- Cold clippy (`-D warnings`, both feature sets), `cargo fmt`.
