### PR TITLE
fix: support chunked-prefill prompts in the disaggregated serving handoff

### DIFF
--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -457,13 +457,14 @@ impl BatchScheduler {
     /// and released it and there is nothing to hand off.
     ///
     /// This is the "reuse then extract" factoring (option C): it drives the
-    /// standard [`Self::execute_full_prefill`] path verbatim, so first-token
-    /// sampling, structured output, thinking budget, and logprobs are byte-for-byte
-    /// identical to a single-node prefill, then lifts the finished sequence back
-    /// out of the active batch before any local decode step runs. The hot
-    /// [`Self::run`] loop is never touched. Speculative burst is bypassed (it would
-    /// complete the request locally, defeating the handoff), and chunked prefill of
-    /// an over-long prompt is not yet supported on this path (deferred).
+    /// standard [`Self::execute_full_prefill`] path (or, for prompts longer than
+    /// `--prefill-chunk-size`, the standard chunked-prefill path driven to
+    /// completion — issue #197) verbatim, so first-token sampling, structured
+    /// output, thinking budget, and logprobs are byte-for-byte identical to a
+    /// single-node prefill, then lifts the finished sequence back out of the
+    /// active batch before any local decode step runs. The hot [`Self::run`] loop
+    /// is never touched. Speculative burst is bypassed (it would complete the
+    /// request locally, defeating the handoff).
     ///
     /// [`finish_prefill`]: Self::finish_prefill
     #[allow(dead_code)]
@@ -471,13 +472,10 @@ impl BatchScheduler {
         &mut self,
         mut seq: SequenceInfo,
     ) -> anyhow::Result<Option<Vec<u8>>> {
-        if self.prefill_chunk_size > 0 && seq.prompt_tokens.len() > self.prefill_chunk_size {
-            anyhow::bail!(
-                "prefill-role handoff does not yet support chunked prefill \
-                 (prompt {} tokens > chunk size {})",
-                seq.prompt_tokens.len(),
-                self.prefill_chunk_size
-            );
+        // The serving-role intake is strictly sequential, so a chunked prefill
+        // left in progress would be a wiring bug; refuse rather than clobber it.
+        if self.chunked_prefill_seq.is_some() {
+            anyhow::bail!("prefill-role handoff: another chunked prefill is already in progress");
         }
         let seq_id = seq.seq_id;
         // The decode node restores the prompt context from `token_history`; the
@@ -487,10 +485,22 @@ impl BatchScheduler {
             self.abort_sequence(seq, &err);
             anyhow::bail!("prefill-role handoff: begin_prefill failed: {err}");
         }
-        // Reuse the standard full prefill: it samples the first token and
+        // Reuse the standard prefill machinery: it samples the first token and
         // transitions the sequence into the active batch (no speculative burst on
-        // the handoff path).
-        self.execute_full_prefill(seq);
+        // the handoff path). Long prompts take the same chunked path the run()
+        // loop uses, driven to completion here so the full prompt's KV is in the
+        // pool before extraction (issue #197); the final chunk samples the first
+        // token via finish_prefill exactly like a single-node chunked prefill.
+        // The handoff path is text-only, so the VLM-embeddings full-prefill
+        // exemption in execute_prefill's dispatch cannot apply.
+        if self.prefill_chunk_size > 0 && prompt_tokens.len() > self.prefill_chunk_size {
+            self.start_chunked_prefill(seq);
+            while self.chunked_prefill_seq.is_some() {
+                self.continue_chunked_prefill();
+            }
+        } else {
+            self.execute_full_prefill(seq);
+        }
         // Lift the just-prefilled sequence back out before any local decode runs.
         // If it finished at prefill (immediate EOS) it is already finalized and
         // released, so there is nothing to hand off.
@@ -521,9 +531,10 @@ impl BatchScheduler {
     /// Returns `Ok(None)` when the request hit EOS at the first token, in which
     /// case there is nothing to hand off.
     ///
-    /// The empty-prompt and chunked-prefill guards run before a cache slot is
-    /// allocated, so a rejected request leaks no pool state. Chunked prefill of
-    /// an over-long prompt on the handoff path is not yet supported (deferred).
+    /// The empty-prompt guard runs before a cache slot is allocated, so a
+    /// rejected request leaks no pool state. Prompts longer than
+    /// `--prefill-chunk-size` are prefilled in chunks by
+    /// [`Self::prefill_request_for_handoff`] (issue #197).
     #[allow(dead_code)]
     pub(crate) fn prefill_text_request_for_handoff(
         &mut self,
@@ -535,14 +546,6 @@ impl BatchScheduler {
     ) -> anyhow::Result<Option<Vec<u8>>> {
         if prompt_tokens.is_empty() {
             anyhow::bail!("prefill-role handoff: empty prompt has no tokens to prefill");
-        }
-        if self.prefill_chunk_size > 0 && prompt_tokens.len() > self.prefill_chunk_size {
-            anyhow::bail!(
-                "prefill-role handoff does not yet support chunked prefill \
-                 (prompt {} tokens > chunk size {})",
-                prompt_tokens.len(),
-                self.prefill_chunk_size
-            );
         }
         // Merge the model's configured stop tokens into the request sampling
         // exactly as the single-node intake (`enqueue_request`) does, so the

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -459,7 +459,7 @@ impl BatchScheduler {
     /// This is the "reuse then extract" factoring (option C): it drives the
     /// standard [`Self::execute_full_prefill`] path (or, for prompts longer than
     /// `--prefill-chunk-size`, the standard chunked-prefill path driven to
-    /// completion — issue #197) verbatim, so first-token sampling, structured
+    /// completion, issue #197) verbatim, so first-token sampling, structured
     /// output, thinking budget, and logprobs are byte-for-byte identical to a
     /// single-node prefill, then lifts the finished sequence back out of the
     /// active batch before any local decode step runs. The hot [`Self::run`] loop

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -508,12 +508,15 @@ impl BatchScheduler {
             return Ok(None);
         };
         let generated_tokens = seq.generated_tokens.clone();
-        let bytes = self.extract_sequence_handoff(seq_id, prompt_tokens, generated_tokens)?;
-        // The KV now belongs to the decode node: release the local caches and any
-        // per-sequence tracking without donating back (the prefix left this node).
+        let bytes = self.extract_sequence_handoff(seq_id, prompt_tokens, generated_tokens);
+        // Release the local caches and per-sequence tracking on BOTH outcomes:
+        // on success the KV now belongs to the decode node (no donate-back, the
+        // prefix left this node); on an extract error the sequence was already
+        // lifted out of the active batch, so skipping the release would leak
+        // its pool slot.
         self.prompt_cache_seq_ctx.remove(&seq_id);
         self.release_sequence_caches(seq_id);
-        Ok(Some(bytes))
+        Ok(Some(bytes?))
     }
 
     /// Prefill role (#126 B3a): build a queued text sequence from the raw request
@@ -546,6 +549,20 @@ impl BatchScheduler {
     ) -> anyhow::Result<Option<Vec<u8>>> {
         if prompt_tokens.is_empty() {
             anyhow::bail!("prefill-role handoff: empty prompt has no tokens to prefill");
+        }
+        // Admission cap for the network-facing intake: with chunked prefill
+        // supported (issue #197) the old chunk-size bail no longer bounds the
+        // accepted prompt, so an oversized PrefillRequestFrame could drive a
+        // multi-minute synchronous chunk loop on the node's only prefill
+        // worker. 1M tokens matches the CacheIngestLimits philosophy (far
+        // above any realistic context; the pool budget is the real bound).
+        const MAX_HANDOFF_PROMPT_TOKENS: usize = 1 << 20;
+        if prompt_tokens.len() > MAX_HANDOFF_PROMPT_TOKENS {
+            anyhow::bail!(
+                "prefill-role handoff: prompt of {} tokens exceeds the admission cap \
+                 ({MAX_HANDOFF_PROMPT_TOKENS})",
+                prompt_tokens.len()
+            );
         }
         // Merge the model's configured stop tokens into the request sampling
         // exactly as the single-node intake (`enqueue_request`) does, so the

--- a/src/server/batch/serving_handoff_parity_tests.rs
+++ b/src/server/batch/serving_handoff_parity_tests.rs
@@ -111,6 +111,18 @@ fn build_paged_scheduler(
     tokenizer: MlxcelTokenizer,
     config_eos: Vec<i32>,
 ) -> BatchScheduler {
+    // 512-token chunk size > the test prompt, so handoff prefills run whole.
+    build_paged_scheduler_with_chunk_size(model, tokenizer, config_eos, 512)
+}
+
+/// [`build_paged_scheduler`] with an explicit `prefill_chunk_size`, for the
+/// chunked-prefill handoff case (issue #197).
+fn build_paged_scheduler_with_chunk_size(
+    model: crate::LoadedModel,
+    tokenizer: MlxcelTokenizer,
+    config_eos: Vec<i32>,
+    prefill_chunk_size: usize,
+) -> BatchScheduler {
     let (_req_tx, req_rx) = mpsc::channel();
     BatchScheduler::with_config(
         model,
@@ -121,7 +133,7 @@ fn build_paged_scheduler(
         64, // max_queue_depth
         Arc::new(BatchMetrics::new()),
         Arc::new(BatchObservability::new()),
-        512,   // prefill_chunk_size (> prompt len, so full prefill)
+        prefill_chunk_size,
         false, // enable_preemption
         PreemptionPolicy::default(),
         1, // max_batch_prefill
@@ -300,6 +312,76 @@ fn serving_handoff_parity_matches_single_node_qwen3() {
         "OK: prefill-role extracted, shipped over the coordinator transport, and the \
          decode-role reconstructed + decoded {DECODE_STEPS} tokens identically to the \
          single-node run."
+    );
+}
+
+/// Issue #197: a handoff prefill of a prompt LONGER than `--prefill-chunk-size`
+/// must drive the standard chunked-prefill machinery to completion before
+/// extracting, and the decode node must continue byte-identically to a
+/// single-node run. The reference leg runs an UNCHUNKED full prefill through
+/// the same scheduler, so this also re-proves chunked == full prefill across
+/// the handoff boundary.
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit and runs real GPU forwards; run with --ignored"]
+fn serving_handoff_parity_chunked_prefill_matches_single_node_qwen3() {
+    let _runtime = crate::initialize_runtime();
+    let dir = repo_model_dir(QWEN3_DIR);
+    if !dir.exists() {
+        eprintln!("Skipping {QWEN3_DIR}: model directory not found");
+        return;
+    }
+    let (model, sched_tokenizer) =
+        crate::load_model(&dir).unwrap_or_else(|e| panic!("load {QWEN3_DIR}: {e:?}"));
+    let seq_tokenizer = crate::tokenizer::load_tokenizer(&dir).expect("load tokenizer");
+    let config_eos = crate::read_eos_token_ids(&dir);
+    // Chunk size 16 << the ~50-token prompt forces a 4-chunk handoff prefill.
+    let mut sched = build_paged_scheduler_with_chunk_size(model, sched_tokenizer, config_eos, 16);
+    assert!(
+        PROMPT_TOKENS.len() > 16,
+        "test prompt must exceed the chunk size for a chunked prefill"
+    );
+
+    // ---- REFERENCE: single-node UNCHUNKED prefill + decode. ----
+    let ref_id = sched
+        .allocate_sequence_state()
+        .expect("allocate reference sequence");
+    let (mut ref_seq, _ref_rx) = make_request(ref_id, &seq_tokenizer);
+    BatchScheduler::begin_prefill(&mut ref_seq).expect("begin reference prefill");
+    sched.execute_full_prefill(ref_seq);
+    let ref_tokens = drive_decode(&mut sched, ref_id);
+    assert_eq!(
+        ref_tokens.len(),
+        DECODE_STEPS,
+        "reference run should produce {DECODE_STEPS} tokens"
+    );
+    sched.active_batch.remove(ref_id);
+    sched.release_sequence_caches(ref_id);
+    eprintln!("reference decoded: {ref_tokens:?}");
+
+    // ---- HANDOFF: CHUNKED prefill -> extract -> wire -> ingest -> decode. ----
+    let prefill_id = sched
+        .allocate_sequence_state()
+        .expect("allocate handoff prefill sequence");
+    let (prefill_seq, _pfx_rx) = make_request(prefill_id, &seq_tokenizer);
+    let wire = sched
+        .prefill_request_for_handoff(prefill_seq)
+        .expect("chunked prefill-role extract")
+        .expect("chunked prefill produced a handoff frame (not an immediate EOS)");
+    let delivered = ship_over_coordinators(&wire);
+    let (resp_tx, _resp_rx) = mpsc::channel();
+    let decode_id = sched
+        .ingest_handoff_as_active(&delivered, MAX_TOKENS, SamplingConfig::greedy(), resp_tx)
+        .expect("decode-role ingest");
+    let handoff_tokens = drive_decode(&mut sched, decode_id);
+    eprintln!("chunked handoff decoded: {handoff_tokens:?}");
+
+    assert_eq!(
+        handoff_tokens, ref_tokens,
+        "chunked-prefill handoff decode must equal the single-node run"
+    );
+    eprintln!(
+        "OK: a 4-chunk handoff prefill extracted, shipped, and decoded {DECODE_STEPS} \
+         tokens identically to the unchunked single-node run."
     );
 }
 


### PR DESCRIPTION
Closes #197

## Problem

`BatchScheduler::prefill_request_for_handoff` and `prefill_text_request_for_handoff` rejected prompts longer than `--prefill-chunk-size`: the serving-role entry drove a single full prefill and then extracted, so it bailed on long prompts. This limited disaggregated serving to short prompts, while long prompts are exactly where prefill/decode disaggregation pays off.

## Implementation

- `prefill_request_for_handoff` now mirrors the `execute_prefill` dispatch: prompts longer than the chunk size go through the standard chunked machinery (`start_chunked_prefill` followed by `continue_chunked_prefill` driven to completion) instead of bailing. The final chunk samples the first token via `finish_prefill` exactly like a single-node chunked prefill (including the terminal-first-chunk handling from #179), so the full prompt's KV is in the pool before the handoff frame is serialized. Short prompts keep the existing `execute_full_prefill` path unchanged.
- The chunked-prefill guard in `prefill_text_request_for_handoff` is removed (it delegates to the now-chunk-capable entry). A defensive guard rejects entry while another chunked prefill is in progress (the serving-role intake is sequential, so this would be a wiring bug).
- The handoff path is text-only, so the VLM-embeddings full-prefill exemption in the normal dispatch cannot apply.

## Verification (M1 Ultra, qwen3-0.6b-4bit, real model)

- New `serving_handoff_parity_chunked_prefill_matches_single_node_qwen3`: a scheduler with `prefill_chunk_size = 16` prefills the ~50-token shared prompt in 4 chunks through `prefill_request_for_handoff`, ships the frame over the coordinator pair, ingests it, and decodes 16 tokens. The decode stream is byte-identical to an UNCHUNKED single-node run through the same scheduler, which also re-proves chunked == full prefill across the handoff boundary.
- All 5 serving-handoff parity tests green (the existing full-prefill handoff, role-loop TCP parity, and the bind/return smoke tests are unaffected).
- Cold clippy (`-D warnings`, both feature sets), `cargo fmt`.
