### PR TITLE
perf: stream decode continuation tokens per frame from the disaggregated decode role

### DIFF
--- a/src/distributed/disaggregated/coordinator.rs
+++ b/src/distributed/disaggregated/coordinator.rs
@@ -303,6 +303,7 @@ impl ServingCoordinator {
                 request_id: request.request_id,
                 phase: ResultPhase::FirstToken,
                 tokens,
+                start_sequence: 0,
                 done: done || frame.is_none(),
                 error,
             };
@@ -387,12 +388,47 @@ impl ServingCoordinator {
                     token_tx,
                 )
                 .context("decode role: ingest the handoff as an active sequence")?;
-            scheduler.decode_handoff_until_idle();
-            let (tokens, _done, error) = drain_generation_events(&token_rx);
 
+            // Stream the continuation incrementally (issue #199): after every
+            // decode tick, drain the tokens that tick produced and ship them
+            // as a non-terminal Continuation frame, so the client sees tokens
+            // during decode instead of after the whole generation finishes.
+            // The sends are awaited sequentially, so frames leave in order;
+            // `start_sequence` tags each frame's first token (1-based, the
+            // prefill first token is sequence 0) so the router can detect
+            // gaps or reordering on the wire.
+            let mut next_sequence: u64 = 1;
+            loop {
+                let active = scheduler.decode_handoff_step();
+                let (tokens, _done, error) = drain_generation_events(&token_rx);
+                if !tokens.is_empty() || error.is_some() {
+                    let frame_tokens = tokens.len() as u64;
+                    let result = ResultFrame {
+                        request_id: meta.request_id,
+                        phase: ResultPhase::Continuation,
+                        tokens,
+                        start_sequence: next_sequence,
+                        done: false,
+                        error,
+                    };
+                    self.transport
+                        .send(&meta.reply_to, result.encode()?)
+                        .await
+                        .context("decode role: stream a continuation frame to reply_to")?;
+                    next_sequence += frame_tokens;
+                }
+                if !active {
+                    break;
+                }
+            }
+
+            // Terminal frame: any stragglers emitted by the final
+            // finalize_completed pass, then `done`.
+            let (tokens, _done, error) = drain_generation_events(&token_rx);
             let result = ResultFrame {
                 request_id: meta.request_id,
                 phase: ResultPhase::Continuation,
+                start_sequence: if tokens.is_empty() { 0 } else { next_sequence },
                 tokens,
                 done: true,
                 error,
@@ -400,7 +436,7 @@ impl ServingCoordinator {
             self.transport
                 .send(&meta.reply_to, result.encode()?)
                 .await
-                .context("decode role: return the continuation to reply_to")?;
+                .context("decode role: return the terminal continuation frame to reply_to")?;
         }
         Ok(())
     }

--- a/src/distributed/disaggregated/coordinator.rs
+++ b/src/distributed/disaggregated/coordinator.rs
@@ -422,8 +422,9 @@ impl ServingCoordinator {
                 }
             }
 
-            // Terminal frame: any stragglers emitted by the final
-            // finalize_completed pass, then `done`.
+            // Terminal frame. The per-tick drain above runs after each
+            // finalize_completed, so this drain is normally empty; it exists
+            // as a defensive catch-all so no event can be dropped.
             let (tokens, _done, error) = drain_generation_events(&token_rx);
             let result = ResultFrame {
                 request_id: meta.request_id,

--- a/src/distributed/disaggregated/serving_protocol.rs
+++ b/src/distributed/disaggregated/serving_protocol.rs
@@ -132,6 +132,17 @@ pub struct ResultFrame {
     pub phase: ResultPhase,
     /// Detokenized text pieces, in generation order.
     pub tokens: Vec<String>,
+    /// Stream sequence number of the FIRST token in this frame (issue #199).
+    ///
+    /// The decode role streams its continuation incrementally as multiple
+    /// frames; the router uses this tag to detect gaps or reordering across
+    /// the transport. Numbering starts at 1 for the first continuation token
+    /// (sequence 0 is the prefill first token). `0` on frames that carry no
+    /// continuation position (the first-token result, terminal/error frames
+    /// without tokens, and frames from older senders via `serde(default)`),
+    /// which the receiver treats as "unchecked".
+    #[serde(default)]
+    pub start_sequence: u64,
     /// `true` on the terminal frame of the request.
     pub done: bool,
     /// A generation error message, if the node hit one.

--- a/src/distributed/disaggregated/serving_protocol_tests.rs
+++ b/src/distributed/disaggregated/serving_protocol_tests.rs
@@ -71,6 +71,7 @@ fn result_frame_round_trips_both_phases() {
         request_id: 3,
         phase: ResultPhase::FirstToken,
         tokens: vec![" Hello".to_string()],
+        start_sequence: 0,
         done: false,
         error: None,
     };
@@ -78,6 +79,7 @@ fn result_frame_round_trips_both_phases() {
         request_id: 3,
         phase: ResultPhase::Continuation,
         tokens: vec![" world".to_string(), "!".to_string()],
+        start_sequence: 1,
         done: true,
         error: None,
     };
@@ -89,8 +91,25 @@ fn result_frame_round_trips_both_phases() {
         assert_eq!(decoded.request_id, frame.request_id);
         assert_eq!(decoded.phase, frame.phase);
         assert_eq!(decoded.tokens, frame.tokens);
+        assert_eq!(decoded.start_sequence, frame.start_sequence);
         assert_eq!(decoded.done, frame.done);
     }
+}
+
+/// `start_sequence` is `serde(default)` so frames from senders predating
+/// issue #199 decode with the "unchecked" 0.
+#[test]
+fn result_frame_start_sequence_defaults_to_zero() {
+    let payload = serde_json::json!({
+        "request_id": 7,
+        "phase": "continuation",
+        "tokens": ["x"],
+        "done": true,
+        "error": null
+    });
+    let decoded: ResultFrame =
+        serde_json::from_slice(&serde_json::to_vec(&payload).unwrap()).expect("decode");
+    assert_eq!(decoded.start_sequence, 0);
 }
 
 #[test]

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -710,11 +710,27 @@ impl BatchScheduler {
     /// active batch has drained (each sequence reached its EOS or token budget).
     #[allow(dead_code)]
     pub(crate) fn decode_handoff_until_idle(&mut self) {
-        while !self.active_batch.is_empty() {
-            let ids = self.active_batch.sequence_ids();
-            self.execute_decode_step(&ids);
-            self.finalize_completed();
+        while self.decode_handoff_step() {}
+    }
+
+    /// One decode tick of the handoff drive loop (issue #199): run a single
+    /// `execute_decode_step` + `finalize_completed` over the active batch and
+    /// report whether any sequence remains. The networked decode role calls
+    /// this per tick so it can drain and ship newly produced tokens
+    /// incrementally instead of buffering the whole continuation.
+    ///
+    /// Returns `false` (without stepping) when the active batch is already
+    /// empty, so `while decode_handoff_step() {}` is exactly
+    /// [`Self::decode_handoff_until_idle`].
+    #[allow(dead_code)]
+    pub(crate) fn decode_handoff_step(&mut self) -> bool {
+        if self.active_batch.is_empty() {
+            return false;
         }
+        let ids = self.active_batch.sequence_ids();
+        self.execute_decode_step(&ids);
+        self.finalize_completed();
+        !self.active_batch.is_empty()
     }
 
     /// Create a new batch scheduler, taking ownership of the model and channel.

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -493,32 +493,50 @@ async fn drive_handoff_result(
         return Ok(());
     }
 
-    // Transition to the decode phase and wait for the continuation.
+    // Transition to the decode phase and consume the incrementally streamed
+    // continuation frames (issue #199) until the terminal `done` frame. The
+    // timeout applies per frame, so long generations keep streaming as long
+    // as the decode node makes progress.
     bridge
         .start_decode_stream()
         .map_err(|e| anyhow::anyhow!("stream bridge: {e}"))?;
 
-    let cont = tokio::time::timeout(handoff_timeout, rx.recv())
-        .await
-        .map_err(|_| anyhow::anyhow!("timed out waiting for the decode continuation"))?
-        .ok_or_else(|| anyhow::anyhow!("decode result channel closed before continuation"))?;
-
-    if let Some(e) = cont.error {
-        anyhow::bail!("decode node error: {e}");
-    }
     let mut seq: u64 = 1;
-    for text in &cont.tokens {
-        bridge
-            .submit_decode_token(&TokenEvent {
-                token_id: 0,
-                text: text.clone(),
-                sequence_number: seq,
-                source: TokenSource::Decode,
-                is_final: false,
-            })
-            .map_err(|e| anyhow::anyhow!("stream bridge: {e}"))?;
-        on_token(text);
-        seq += 1;
+    loop {
+        let cont = tokio::time::timeout(handoff_timeout, rx.recv())
+            .await
+            .map_err(|_| anyhow::anyhow!("timed out waiting for the decode continuation"))?
+            .ok_or_else(|| anyhow::anyhow!("decode result channel closed before continuation"))?;
+
+        if let Some(e) = cont.error {
+            anyhow::bail!("decode node error: {e}");
+        }
+        // Wire-level ordering check: a non-zero `start_sequence` must match
+        // the next expected position (frames could in principle reorder
+        // across pooled transport connections).
+        if cont.start_sequence != 0 && cont.start_sequence != seq {
+            anyhow::bail!(
+                "decode continuation frame out of order: expected sequence {seq}, \
+                 got {}",
+                cont.start_sequence
+            );
+        }
+        for text in &cont.tokens {
+            bridge
+                .submit_decode_token(&TokenEvent {
+                    token_id: 0,
+                    text: text.clone(),
+                    sequence_number: seq,
+                    source: TokenSource::Decode,
+                    is_final: false,
+                })
+                .map_err(|e| anyhow::anyhow!("stream bridge: {e}"))?;
+            on_token(text);
+            seq += 1;
+        }
+        if cont.done {
+            break;
+        }
     }
     bridge.finalize();
     Ok(())

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -365,6 +365,7 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
         let request_id_str2 = request_id_str.clone();
         let model = request.model.clone();
         let handoff_timeout = state.handoff_timeout;
+        let max_tokens = opts.max_tokens;
 
         let mut filter = stream_filter;
         tokio::spawn(async move {
@@ -391,11 +392,16 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
                 }
             };
 
-            let result =
-                drive_handoff_result(&mut { rx }, &request_id_str2, handoff_timeout, |text| {
+            let result = drive_handoff_result(
+                &mut { rx },
+                &request_id_str2,
+                handoff_timeout,
+                max_tokens,
+                |text| {
                     emit_filtered(filter.feed(text));
-                })
-                .await;
+                },
+            )
+            .await;
 
             // Flush any text still buffered inside the filter (e.g. an
             // unterminated partial delimiter match at end of stream).
@@ -433,9 +439,15 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
                     content.push_str(&c);
                 }
             };
-            let r = drive_handoff_result(&mut rx, &request_id_str, state.handoff_timeout, |text| {
-                absorb(filter.feed(text));
-            })
+            let r = drive_handoff_result(
+                &mut rx,
+                &request_id_str,
+                state.handoff_timeout,
+                opts.max_tokens,
+                |text| {
+                    absorb(filter.feed(text));
+                },
+            )
             .await;
             absorb(filter.flush());
             state.pending.lock().unwrap().remove(&request_id);
@@ -463,6 +475,7 @@ async fn drive_handoff_result(
     rx: &mut UnboundedReceiver<ResultFrame>,
     request_id_str: &str,
     handoff_timeout: Duration,
+    max_tokens: usize,
     mut on_token: impl FnMut(&str),
 ) -> Result<()> {
     let bridge = StreamBridge::new(request_id_str.to_string(), handoff_timeout);
@@ -511,9 +524,23 @@ async fn drive_handoff_result(
         if let Some(e) = cont.error {
             anyhow::bail!("decode node error: {e}");
         }
+        // The router set the request's token budget itself; do not trust the
+        // remote `done` flag to terminate the stream. A decode node that
+        // exceeds the budget (buggy or hostile) is cut off here, which also
+        // bounds the total frame count and, with the per-frame timeout, the
+        // total wall-clock time per request.
+        if seq as usize > max_tokens {
+            anyhow::bail!(
+                "decode node exceeded the request token budget ({max_tokens}) without \
+                 a terminal frame"
+            );
+        }
         // Wire-level ordering check: a non-zero `start_sequence` must match
         // the next expected position (frames could in principle reorder
-        // across pooled transport connections).
+        // across pooled transport connections). This is a liveness and
+        // debugging aid against benign loss or reordering, NOT a tamper
+        // defense: the transport is unauthenticated and the disaggregated
+        // deployment model assumes a trusted network segment.
         if cont.start_sequence != 0 && cont.start_sequence != seq {
             anyhow::bail!(
                 "decode continuation frame out of order: expected sequence {seq}, \

--- a/tests/disaggregated_serving_e2e.rs
+++ b/tests/disaggregated_serving_e2e.rs
@@ -244,8 +244,10 @@ async fn disaggregated_two_process_handoff_matches_single_node() {
     let mut first_token_text = String::new();
     let mut continuation_text = String::new();
     let mut seen_first = false;
-    let mut seen_continuation = false;
-    while !(seen_first && seen_continuation) {
+    let mut continuation_done = false;
+    let mut continuation_frames = 0usize;
+    let mut next_sequence: u64 = 1;
+    while !(seen_first && continuation_done) {
         let received = tokio::time::timeout(Duration::from_secs(120), client.recv()).await;
         let (_from, message) = match received {
             Ok(Ok(message)) => message,
@@ -257,15 +259,27 @@ async fn disaggregated_two_process_handoff_matches_single_node() {
         if let Some(err) = frame.error {
             panic!("a serving node returned a generation error: {err}");
         }
-        let text = frame.tokens.concat();
         match frame.phase {
             ResultPhase::FirstToken => {
-                first_token_text = text;
+                first_token_text = frame.tokens.concat();
                 seen_first = true;
             }
             ResultPhase::Continuation => {
-                continuation_text = text;
-                seen_continuation = true;
+                // Issue #199: the decode node streams the continuation as
+                // multiple per-tick frames; accumulate them and verify the
+                // wire sequence tags are contiguous.
+                if !frame.tokens.is_empty() {
+                    assert_eq!(
+                        frame.start_sequence, next_sequence,
+                        "continuation frame sequence gap"
+                    );
+                    next_sequence += frame.tokens.len() as u64;
+                    continuation_frames += 1;
+                }
+                continuation_text.push_str(&frame.tokens.concat());
+                if frame.done {
+                    continuation_done = true;
+                }
             }
         }
     }
@@ -275,8 +289,15 @@ async fn disaggregated_two_process_handoff_matches_single_node() {
         "did not receive the prefill node's first-token result"
     );
     assert!(
-        seen_continuation,
-        "did not receive the decode node's continuation result"
+        continuation_done,
+        "did not receive the decode node's terminal continuation frame"
+    );
+    // The incremental-streaming acceptance: a multi-token continuation must
+    // arrive as MULTIPLE frames (per decode tick), not one buffered frame.
+    assert!(
+        continuation_frames > 1,
+        "expected the continuation streamed across multiple frames, got \
+         {continuation_frames}"
     );
 
     let merged = format!("{first_token_text}{continuation_text}");


### PR DESCRIPTION
Closes #199

## Problem

`BatchScheduler::decode_handoff_until_idle` ran the decode loop to completion and the decode node returned all continuation tokens to the router in a single `ResultFrame{Continuation}`. The client got the prefill first token quickly but then waited for the FULL decode before any continuation token arrived, defeating incremental streaming.

## Implementation

- New `BatchScheduler::decode_handoff_step` runs one decode tick (`execute_decode_step` + `finalize_completed`) and reports whether sequences remain; `decode_handoff_until_idle` is now `while decode_handoff_step() {}` (behavior unchanged for the in-process paths).
- `run_decode_role_networked` drives the step loop and, after every tick, drains the newly produced tokens and ships them as a non-terminal `Continuation` frame, ending with a terminal `done` frame (which also carries any stragglers from the final finalize pass and the error, if any).
- `ResultFrame` gains `start_sequence` (`serde(default)`, so frames from older senders decode as the "unchecked" 0): the stream position of the frame's first token, 1-based for the decode continuation (the prefill first token is sequence 0). Sends are awaited sequentially so frames leave in order; the tag lets the receiver detect gaps or reordering across pooled transport connections.
- The router's `drive_handoff_result` consumes continuation frames in a loop until `done`, verifying `start_sequence` contiguity and forwarding each token through the existing `StreamBridge` ordering and the #198 stream filter. The handoff timeout now applies per frame, so long generations keep streaming as long as the decode node makes progress.

## Verification (M1 Ultra, qwen3-0.6b-4bit, real model)

- `disaggregated_two_process_handoff_matches_single_node` (2 real processes) updated to accumulate the streamed frames: asserts the continuation arrives as MULTIPLE frames (the incremental-streaming acceptance), verifies `start_sequence` contiguity across frames, and the merged text stays byte-identical to the single-node reference.
- Router E2E (3 real processes) both cases green and byte-identical: plain content pin and the #198 thinking split (filter + incremental frames compose).
- `serving_handoff_parity` suite 5/5 green (the in-process paths through `decode_handoff_until_idle` are behaviorally unchanged).
- New protocol unit tests: `start_sequence` round-trip and the `serde(default)` backward-compat decode.
- Cold clippy (`-D warnings`, both feature sets), `cargo fmt`.
