### PR TITLE
fix: guard empty-batch paged-decode fallbacks and absolute block indexing under logical_start > 0

### DIFF
--- a/src/distributed/kv_cache_serde/types.rs
+++ b/src/distributed/kv_cache_serde/types.rs
@@ -138,13 +138,16 @@ impl SerializablePagedSequenceState {
                     layer.len
                 );
             }
-            let visible_len = layer.len.saturating_sub(layer.logical_start);
-            let required_blocks = visible_len.div_ceil(layout.block_size);
+            // Absolute-position indexing (issue #196): the block table must
+            // cover the full absolute length, matching the pool-side
+            // `restore_sequence` gate so the wire boundary and the pool
+            // encode the same invariant.
+            let required_blocks = layer.len.div_ceil(layout.block_size);
             if layer.block_ids.len() < required_blocks {
                 anyhow::bail!(
-                    "paged layer {layer_idx} has {} blocks for visible length {}, requires at least {}",
+                    "paged layer {layer_idx} has {} blocks for length {}, requires at least {}",
                     layer.block_ids.len(),
-                    visible_len,
+                    layer.len,
                     required_blocks
                 );
             }

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -575,12 +575,19 @@ impl PagedBlockPool {
             return Ok(());
         }
 
-        let new_visible_len = layer.visible_len() + token_count;
-        let required_blocks = new_visible_len.div_ceil(self.layout.block_size);
+        // `block_ids` is indexed by ABSOLUTE position (`abs / block_size`),
+        // the convention `write_prefill` and `gather_visible` use, so the
+        // block count must cover the absolute length. With
+        // `logical_start == 0` this is identical to the old visible-length
+        // sizing; with `logical_start > 0` (a sliding-window owner,
+        // issue #196) visible-length sizing under-allocated and the next
+        // write indexed past the table.
+        let new_len = layer.len + token_count;
+        let required_blocks = new_len.div_ceil(self.layout.block_size);
         while layer.block_ids.len() < required_blocks {
             layer.block_ids.push(self.acquire_block(layer_idx)?);
         }
-        layer.len += token_count;
+        layer.len = new_len;
         Ok(())
     }
 
@@ -609,10 +616,22 @@ impl PagedBlockPool {
 
         layer.len -= trimmed;
         if layer.len == layer.logical_start {
+            // The back-trim consumed the whole visible window: the layer is
+            // logically empty, so reset to the origin and release everything
+            // (the old code only reset `logical_start`, which resurrected the
+            // slid-away prefix as visible, issue #196).
+            layer.len = 0;
             layer.logical_start = 0;
         }
 
-        let required_blocks = layer.visible_len().div_ceil(self.layout.block_size);
+        // `block_ids` is indexed by ABSOLUTE position; release only the tail
+        // blocks past the absolute length. Sizing by visible length here
+        // released tail blocks that still held visible tokens once
+        // `logical_start` crossed a block boundary (issue #196). Head blocks
+        // wholly before `logical_start` stay allocated; reclaiming them needs
+        // a block-base offset and is deferred until a sliding-window paged
+        // path exists.
+        let required_blocks = layer.len.div_ceil(self.layout.block_size);
         while layer.block_ids.len() > required_blocks {
             if let Some(block_id) = layer.block_ids.pop() {
                 self.release_block(block_id)?;
@@ -660,12 +679,14 @@ impl PagedBlockPool {
         }
 
         for (layer_idx, layer) in state.layers.iter().enumerate() {
-            let required_blocks = layer.visible_len().div_ceil(self.layout.block_size);
+            // Absolute-position indexing: the block table must cover the full
+            // absolute length, not just the visible window (issue #196).
+            let required_blocks = layer.len.div_ceil(self.layout.block_size);
             if layer.block_ids.len() < required_blocks {
                 return Err(format!(
-                    "PagedBlockPool: restored layer {layer_idx} has {} blocks for visible length {}, requires at least {}",
+                    "PagedBlockPool: restored layer {layer_idx} has {} blocks for length {}, requires at least {}",
                     layer.block_ids.len(),
-                    layer.visible_len(),
+                    layer.len,
                     required_blocks
                 ));
             }

--- a/src/lib/mlxcel-core/src/cache/paged_pool_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_pool_tests.rs
@@ -1107,3 +1107,106 @@ fn paged_block_byte_roundtrip_preserves_fp16() {
 fn paged_block_byte_roundtrip_preserves_bf16() {
     assert_byte_roundtrip_preserves_content(dtype::BFLOAT16);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #196: absolute block indexing under logical_start > 0
+// ---------------------------------------------------------------------------
+
+/// `write_prefill` after a sliding-window advance (`logical_start > 0`) must
+/// land the suffix on the correct ABSOLUTE blocks and round-trip through
+/// `gather_visible`.
+#[test]
+fn write_prefill_round_trips_with_logical_start() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    // Prefill 12 tokens cold (3 blocks), then slide the window forward by 5.
+    let k0 = make_block(100.0, 12);
+    let v0 = make_block(500.0, 12);
+    pool.write_prefill(&mut state, 0, &k0, &v0).unwrap();
+    state.layer_mut(0).unwrap().logical_start = 5;
+
+    // Write a 6-token suffix: absolute positions [12, 18) spanning blocks 3-4.
+    let k1 = make_block(112.0, 6);
+    let v1 = make_block(512.0, 6);
+    pool.write_prefill(&mut state, 0, &k1, &v1).unwrap();
+
+    let layer = state.layer(0).unwrap();
+    assert_eq!(layer.len, 18);
+    assert_eq!(layer.visible_len(), 13);
+    // Absolute sizing: ceil(18 / 4) = 5 blocks (visible-based sizing would
+    // have allocated only ceil(13 / 4) = 4 and written past the table).
+    assert_eq!(layer.block_ids.len(), 5);
+
+    let (gk, gv) = pool
+        .gather_visible(&state, 0)
+        .unwrap()
+        .expect("gather must return data");
+    assert_eq!(ffi::array_shape(&gk), vec![1, H, 13, D]);
+
+    // Dense reference: 18-token buffer (two writes), visible window [5, 18).
+    let dense_blocks = vec![(make_block(100.0, 12), 0), (make_block(112.0, 6), 12)];
+    let dense_k = dense_reference(&dense_blocks, 18, 5, 13);
+    let dense_blocks_v = vec![(make_block(500.0, 12), 0), (make_block(512.0, 6), 12)];
+    let dense_v = dense_reference(&dense_blocks_v, 18, 5, 13);
+    assert_eq!(flatten_fp32(&gk), flatten_fp32(&dense_k));
+    assert_eq!(flatten_fp32(&gv), flatten_fp32(&dense_v));
+}
+
+/// A back-trim with `logical_start` past a block boundary must NOT release
+/// tail blocks that still hold visible tokens (the old visible-length sizing
+/// released them, and `gather_visible` then failed).
+#[test]
+fn trim_preserves_visible_window_with_logical_start_past_block_boundary() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    let k0 = make_block(100.0, 12);
+    let v0 = make_block(500.0, 12);
+    pool.write_prefill(&mut state, 0, &k0, &v0).unwrap();
+    // logical_start (5) is past the first block boundary (4).
+    state.layer_mut(0).unwrap().logical_start = 5;
+
+    // Back-trim 2 tokens: len 12 -> 10, visible window [5, 10).
+    let trimmed = pool.trim_tokens(&mut state, 0, 2).unwrap();
+    assert_eq!(trimmed, 2);
+    let layer = state.layer(0).unwrap();
+    assert_eq!(layer.len, 10);
+    assert_eq!(layer.visible_len(), 5);
+    // Absolute sizing keeps ceil(10 / 4) = 3 blocks (visible-based sizing
+    // would have popped block 2, which holds positions 8 and 9).
+    assert_eq!(layer.block_ids.len(), 3);
+
+    let (gk, _gv) = pool
+        .gather_visible(&state, 0)
+        .unwrap()
+        .expect("gather must return data");
+    assert_eq!(ffi::array_shape(&gk), vec![1, H, 5, D]);
+    let dense_k = dense_reference(&[(make_block(100.0, 12), 0)], 12, 5, 5);
+    assert_eq!(flatten_fp32(&gk), flatten_fp32(&dense_k));
+}
+
+/// A back-trim that consumes the whole visible window empties the layer:
+/// origin reset, all blocks released, nothing left to gather.
+#[test]
+fn trim_to_logical_start_empties_the_layer() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size, 1);
+    let mut state = PagedSequenceState::new(pool.layout());
+
+    let k0 = make_block(100.0, 12);
+    let v0 = make_block(500.0, 12);
+    pool.write_prefill(&mut state, 0, &k0, &v0).unwrap();
+    state.layer_mut(0).unwrap().logical_start = 5;
+
+    // Trim the entire visible window (7 tokens).
+    let trimmed = pool.trim_tokens(&mut state, 0, 7).unwrap();
+    assert_eq!(trimmed, 7);
+    let layer = state.layer(0).unwrap();
+    assert_eq!(layer.len, 0);
+    assert_eq!(layer.logical_start, 0);
+    assert_eq!(layer.block_ids.len(), 0);
+    assert!(pool.gather_visible(&state, 0).unwrap().is_none());
+}

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -2511,3 +2511,44 @@ fn test_batch_quantized_kv_cache_make_mask_no_padding_multi_token() {
         "no-padding multi-token mask shape must be {expected_shape:?}, got {actual_shape:?}"
     );
 }
+
+/// Issue #195: the paged-decode attention fallbacks must reject an empty
+/// batch with a clean `Err` instead of panicking in `drain(..1)`.
+#[test]
+fn paged_decode_fallbacks_reject_an_empty_batch() {
+    use crate::cache::{
+        PagedBlockPool, PagedDecodeMetadata, PagedKvLayout, PagedSequenceState,
+        RotatingPagedDecodeMetadata,
+    };
+
+    // A valid 4-D decode query shape with batch == 0.
+    let q = zeros(&[0, 1, 1, 2], crate::dtype::FLOAT32);
+
+    let dense_meta = PagedDecodeMetadata::from_visible_lengths(&[], 2).unwrap();
+    let dense =
+        crate::layers::paged_decode_attention_dense_fallback(&q, &[], &[], &dense_meta, 1.0);
+    assert!(
+        dense.as_ref().is_err_and(|e| e.contains("empty batch")),
+        "dense fallback must reject batch == 0, got error {:?}",
+        dense.as_ref().err()
+    );
+
+    let rot_meta = RotatingPagedDecodeMetadata::from_parts(&[], &[], 2).unwrap();
+    let rotating =
+        crate::layers::paged_decode_attention_rotating_fallback(&q, &[], &[], &rot_meta, 1.0);
+    assert!(
+        rotating.as_ref().is_err_and(|e| e.contains("empty batch")),
+        "rotating fallback must reject batch == 0, got error {:?}",
+        rotating.as_ref().err()
+    );
+
+    let layout = PagedKvLayout::uniform(1, 2, 32).unwrap();
+    let pool = PagedBlockPool::new(layout);
+    let states: Vec<&PagedSequenceState> = Vec::new();
+    let pooled = crate::layers::paged_decode_attention_pooled_fallback(&q, &pool, &states, 0, 1.0);
+    assert!(
+        pooled.as_ref().is_err_and(|e| e.contains("empty batch")),
+        "pooled fallback must reject batch == 0, got error {:?}",
+        pooled.as_ref().err()
+    );
+}

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -2337,10 +2337,13 @@ pub fn paged_decode_attention_dense_fallback(
         });
     }
 
-    let mut result = outputs
-        .drain(..1)
-        .next()
-        .ok_or_else(|| "paged decode fallback received an empty batch".to_string())?;
+    // `drain(..1)` panics on an empty vec, so reject `batch == 0` explicitly
+    // with a clean error instead (issue #195).
+    if outputs.is_empty() {
+        return Err("paged decode fallback received an empty batch (batch == 0)".to_string());
+    }
+    let mut outputs = outputs.into_iter();
+    let mut result = outputs.next().expect("outputs is non-empty: checked above");
     for output in outputs {
         result = crate::concatenate(&result, &output, 0);
     }
@@ -2452,10 +2455,15 @@ pub fn paged_decode_attention_pooled_fallback(
         });
     }
 
-    let mut result = outputs
-        .drain(..1)
-        .next()
-        .ok_or_else(|| "pooled paged decode fallback received an empty batch".to_string())?;
+    // `drain(..1)` panics on an empty vec, so reject `batch == 0` explicitly
+    // with a clean error instead (issue #195).
+    if outputs.is_empty() {
+        return Err(
+            "pooled paged decode fallback received an empty batch (batch == 0)".to_string(),
+        );
+    }
+    let mut outputs = outputs.into_iter();
+    let mut result = outputs.next().expect("outputs is non-empty: checked above");
     for output in outputs {
         result = crate::concatenate(&result, &output, 0);
     }
@@ -2713,10 +2721,15 @@ pub fn paged_decode_attention_rotating_fallback(
         });
     }
 
-    let mut result = outputs
-        .drain(..1)
-        .next()
-        .ok_or_else(|| "rotating paged decode fallback received an empty batch".to_string())?;
+    // `drain(..1)` panics on an empty vec, so reject `batch == 0` explicitly
+    // with a clean error instead (issue #195).
+    if outputs.is_empty() {
+        return Err(
+            "rotating paged decode fallback received an empty batch (batch == 0)".to_string(),
+        );
+    }
+    let mut outputs = outputs.into_iter();
+    let mut result = outputs.next().expect("outputs is non-empty: checked above");
     for output in outputs {
         result = crate::concatenate(&result, &output, 0);
     }


### PR DESCRIPTION
Closes #195
Closes #196

Two small latent-correctness fixes in the paged KV machinery, batched as one PR (both are #116 carry-forwards with no live trigger today).

## #195: guard batch == 0 in the paged-decode attention fallbacks

The three fallbacks in `src/lib/mlxcel-core/src/layers.rs` (dense, pooled, rotating) ended with `outputs.drain(..1)`, which panics on an empty vec, making the trailing `ok_or_else` dead code. Each now rejects an empty batch with an explicit descriptive `Err` before consuming `outputs`; the three paths stay mirror-consistent. New unit test calls all three with `batch == 0` and asserts a clean error.

## #196: absolute block indexing under logical_start > 0

`gather_visible` and `write_prefill` index `block_ids` by ABSOLUTE position, but `append_tokens` and `trim_tokens` sized the table by VISIBLE length. With `logical_start == 0` (every current caller) the two agree; a sliding-window owner with `logical_start > 0` would hit under-allocated tables on write and lose visible tail blocks on trim. The absolute convention is now applied consistently:

- `append_tokens` sizes the table by the absolute length, so `write_prefill`'s absolute indexing is correct for `logical_start > 0`.
- `trim_tokens` releases only tail blocks past the absolute length (visible-length sizing released blocks still holding visible tokens once `logical_start` crossed a block boundary), and a back-trim that consumes the whole visible window now empties the layer cleanly (origin reset + all blocks released; the old reset resurrected the slid-away prefix as visible).
- `restore_sequence` validates the block table against the absolute length.
- Head blocks wholly before `logical_start` stay allocated; reclaiming them needs a block-base offset and is documented as deferred until a sliding-window paged path is wired.

New tests: `write_prefill` + gather round-trip with `logical_start > 0` (block-count and byte-level dense-reference assertions), a trim with `logical_start` past a block boundary preserving the visible window, and the empty-the-layer trim.

## Verification (M1 Ultra, real models)

- mlxcel-core lib suite 863/863 (includes all paged pool/detach/serde unit tests and the new ones).
- Real-model paged gates all green and byte-identical: `paged_real_model_parity`, `paged_scheduler_parity` (4), `paged_prefix_share_parity` (2), `paged_kv_serialize_parity` (2), `paged_handoff_parity` (2, with `test-utils`).
- Cold clippy (`-D warnings`, both feature sets), `cargo fmt`.
