### PR TITLE
feat: DiffusionGemma block-diffusion text generation (phase 1 of #217)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Current GitHub-facing docs:
 8. `CONTINUOUS_BATCHING.md` — continuous-batching scheduler, paged decode, and disaggregated prefill/decode/router serving.
 9. `responses-api.md` — implemented `/v1/responses` subset and gaps.
 10. `adding-models.md` — contribution guide for new model architectures.
+11. `block-diffusion.md` — DiffusionGemma block-diffusion generation: canvas denoising vs autoregressive, CLI flags, throughput, and phase 1 limitations.
 
 ## Architecture Decision Records
 

--- a/docs/block-diffusion.md
+++ b/docs/block-diffusion.md
@@ -1,0 +1,118 @@
+# Block-diffusion generation (DiffusionGemma)
+
+DiffusionGemma (`google/diffusiongemma-26B-A4B-it`) is a text generation model
+that uses block-diffusion rather than left-to-right autoregressive decoding. This
+page explains the generation mechanism, the CLI flags that control it, measured
+throughput, and current limitations.
+
+## How it works
+
+Autoregressive models predict one token at a time, each conditioned on all
+previous tokens. DiffusionGemma decodes a *canvas* of tokens at once through
+iterative denoising: the canvas starts as uniformly random token ids, and the
+model refines the whole block each step until tokens reach stable, high-confidence
+predictions and the step loop stops early or exhausts the step budget.
+
+The generation loop works as follows. First, the prompt is encoded into a
+read-only prefix stored in dense FP16 KV caches. Then, for each output block:
+
+1. A canvas is initialized from random token ids (seeded by `--seed` for
+   reproducibility) with length `min(max_canvas, max(remaining, min_canvas))`.
+2. Up to `--max-denoising-steps` denoising steps run. Each step embeds the
+   current canvas with a learned self-conditioning signal, attends bidirectionally
+   within the canvas while attending causally to the prefix, and uses the sampler
+   to accept new token predictions.
+3. After each step the stable-and-confident early stop checks whether the canvas
+   contents have been unchanged for `stability_threshold` consecutive steps. If
+   so, the block is committed and the loop moves on.
+4. The committed canvas is appended to the prefix and, if any output remains,
+   the next canvas block begins.
+
+### Samplers
+
+Two per-step acceptance samplers are available via `--diffusion-sampler`:
+
+- **`entropy-bound`** (default): For each canvas position, compute a per-token
+  entropy. Sort positions by ascending entropy. Accept positions in that order
+  until the running prefix sum of entropies exceeds `entropy_bound` (read from
+  the checkpoint's `generation_config`). At least one position is always accepted.
+  This reproduces the mlx-vlm reference `(cumsum - cummax) <= bound` rule.
+
+- **`confidence-threshold`**: Accept all unrevealed positions where the top-1
+  token probability exceeds `--diffusion-threshold` (default 0.9). If no
+  position qualifies, the highest-confidence unrevealed position is accepted
+  unconditionally so the loop always makes progress.
+
+## CLI flags
+
+All diffusion flags appear in the `mlxcel generate --help` output under the
+`Diffusion Options` heading. Autoregressive models ignore them entirely.
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--max-denoising-steps N` | checkpoint `generation_config` (typically 48) | Maximum denoising iterations per canvas block. Lower values trade quality for speed. |
+| `--diffusion-sampler entropy-bound\|confidence-threshold` | `entropy-bound` | Per-step token acceptance strategy. See above. |
+| `--diffusion-threshold FLOAT` | `0.9` | Confidence threshold for `confidence-threshold` sampler. |
+| `--diffusion-min-canvas-length N` | `64` | Shortest canvas for the generation tail. Prevents tiny final blocks. |
+| `--diffusion-max-canvas-length N` | model `canvas_length` (typically 256) | Cap on the per-block canvas length. |
+| `--diffusion-full-canvas` | off | Always allocate the model's full `canvas_length` per block. |
+| `--seed N` | unset (nondeterministic) | Seeds MLX's global RNG, which also controls canvas initialization. Two runs with the same seed and temperature 0 produce identical output. |
+
+## Throughput
+
+Per-step cost dominates throughput. The stable-and-confident early stop fires
+earlier when the model converges quickly, so tokens/sec varies with prompt and
+output difficulty.
+
+Measured on M1 Ultra with `diffusiongemma-26B-A4B-it-4bit`:
+
+- ~20 tok/s for short answers (64-token canvas, converging in about 12 of 48 steps)
+- ~8 tok/s for longer outputs requiring most of the 48-step budget on a 256-token canvas
+
+Per-step time on the same hardware: 254 ms/step for a 64-token canvas (103% of
+the mlx-vlm Python reference at 261 ms/step) and 651 ms/step for a 256-token
+canvas (96% of the reference at 626 ms/step).
+
+Model load: 13.5 GiB resident (4-bit quantized checkpoint, M1 Ultra).
+
+## Reproducibility
+
+Canvas noise is the main source of nondeterminism. Pass `--seed N` to seed MLX's
+global RNG before generation begins. Two runs with the same seed, same prompt, and
+`--max-tokens` produce the same commit stream at temperature 0. The seed also
+affects the autoregressive sampling path, so it is useful for both model families.
+
+The environment variable `MLXCEL_DIFFUSION_DEBUG_CANVAS=1` replaces all random
+canvas initialization with a fixed deterministic pattern. This is intended for
+cross-implementation parity testing against the Python reference; output is not
+useful for normal generation. See [Environment variables](environment-variables.md)
+for details.
+
+## Phase 1 limitations
+
+This is phase 1 of issue #217. The following are not yet supported:
+
+- **Image input**: DiffusionGemma's vision tower is loaded but not wired. Passing
+  `--image` raises an error with a note to wait for phase 2.
+- **Server mode**: `mlxcel serve` and `mlxcel-server` reject DiffusionGemma at
+  load time. Use `mlxcel generate` from the CLI.
+- **Tensor parallelism**: The TP planner has a placeholder arm for this family.
+
+## Usage example
+
+```
+mlxcel generate -m google/diffusiongemma-26B-A4B-it \
+  -p "Why is the sky blue?" \
+  --max-tokens 256 \
+  --seed 42
+```
+
+For a 4-bit quantized snapshot in the model store:
+
+```
+mlxcel generate -m diffusiongemma-26B-A4B-it-4bit \
+  -p "Explain TCP vs UDP in one paragraph." \
+  --max-tokens 512 \
+  --diffusion-sampler entropy-bound \
+  --max-denoising-steps 32
+```

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -154,6 +154,12 @@ recommended as normal deployment settings.
 | `MLXCEL_EXPERIMENTAL_BOOL_CAUSAL_MASK` | truthy enables | off | Enables an experimental boolean causal-mask path. |
 | `MLXCEL_PIPELINE_GRANULARITY` | `off`, `layer`, `block:N` | `off` | Inserts layer-boundary async-eval hints for pipeline experiments. |
 
+## Block-diffusion diagnostic variables
+
+| Variable | Values | Default | Purpose |
+|----------|--------|---------|---------|
+| `MLXCEL_DIFFUSION_DEBUG_CANVAS=1` | `1` enables | off | **Diagnostic.** Replaces all DiffusionGemma canvas random-noise initialization with a fixed deterministic pattern (`(i+1)*7919 + k*104729) % vocab_size`) and prints `DIFFUSION_COMMIT block=<n> ids=...` per committed block. Intended for cross-implementation parity testing against the mlx-vlm Python reference at temperature 0. Output is not suitable for normal generation. |
+
 ## Logging, profiling, and capture variables
 
 Most of these switches force synchronization or extra graph work and will change

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -8,7 +8,7 @@ runtime source of truth is the code, not this prose page:
 - loading policy: `src/model_metadata.rs`
 - VLM loading routes: `src/loading/vlm*.rs`
 
-As of v0.0.27, `ModelType` contains 92 variants: 70 text/non-VLM variants
+As of v0.1.4, `ModelType` contains 93 variants: 71 text/non-VLM variants
 and 22 VLM variants. These are architecture/runtime variants, not a guarantee
 that every checkpoint under a marketing family name is supported.
 
@@ -39,6 +39,20 @@ Implemented model families include:
 Many of these families have checkpoint-specific config or weight-layout
 requirements. If a checkpoint fails detection or loading, inspect its
 `config.json::model_type` first and compare it with `src/models/detection.rs`.
+
+## Block-diffusion text models
+
+| Family | `model_type` key | Notes |
+|--------|-----------------|-------|
+| DiffusionGemma | `diffusion_gemma` / `diffusion_gemma_text` | Block-diffusion on a Gemma 4 MoE backbone. Generates a canvas of tokens per block through iterative denoising rather than token-by-token left-to-right decoding. Phase 1: text-only CLI (`mlxcel generate`). Image input and server mode are not yet supported. See [Block-diffusion generation](block-diffusion.md). |
+
+DiffusionGemma uses a two-phase forward pass: an encoder prefill that caches the
+prompt into dense FP16 KV caches, then a canvas loop that attends bidirectionally
+within each output block while attending causally to the cached prefix.
+Load detection accepts `model_type: "diffusion_gemma"` (outer config) and
+`model_type: "diffusion_gemma_text"` (inner `text_config`).
+The fused MoE `gate_up_proj` weights are split at load time; vision-tower weights
+are skipped without error.
 
 ## Vision-language and multimodal variants
 

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -170,6 +170,14 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
     println!("Loading model from {model_path:?}...");
     let load_start = Instant::now();
     let (model, _tok_from_load) = load_model(&model_path)?;
+    if matches!(model, mlxcel::LoadedModel::DiffusionGemma(_)) {
+        // The REPL drives the autoregressive CxxGenerator loop; the
+        // block-diffusion engine is one-shot only in phase 1 of issue #217.
+        return Err(anyhow!(
+            "DiffusionGemma interactive chat is not supported yet; use a one-shot prompt: \
+             mlxcel generate -m <model> -p \"...\""
+        ));
+    }
     let tokenizer = load_tokenizer(&model_path)?;
     println!(
         "Model loaded in {:.2}s.",

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -679,7 +679,7 @@ fn build_cli_sampling_config(args: &GenerateArgs, stop_token_ids: Vec<i32>) -> S
         top_k: args.sampling.top_k,
         top_p: args.sampling.top_p,
         min_p: args.sampling.min_p,
-        seed: None,
+        seed: args.sampling.seed,
         repetition_penalty: args.sampling.repetition_penalty,
         dry_multiplier: args.sampling.dry_multiplier,
         dry_base: args.sampling.dry_base,
@@ -692,7 +692,7 @@ fn build_cli_sampling_config(args: &GenerateArgs, stop_token_ids: Vec<i32>) -> S
     })
 }
 
-fn print_generation_preamble(user_prompt: &str) -> Result<()> {
+pub(super) fn print_generation_preamble(user_prompt: &str) -> Result<()> {
     println!("Generating...");
     print!("{}", user_prompt);
     io::stdout().flush()?;
@@ -1037,7 +1037,7 @@ fn chat_options_from_args(args: &GenerateArgs) -> Result<crate::commands::ChatOp
         top_k: args.sampling.top_k,
         top_p: args.sampling.top_p,
         min_p: args.sampling.min_p,
-        seed: None,
+        seed: args.sampling.seed,
         repetition_penalty: args.sampling.repetition_penalty,
         dry_multiplier: args.sampling.dry_multiplier,
         dry_base: args.sampling.dry_base,
@@ -1290,6 +1290,18 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
         )?
     } else {
         let (model, _loaded_tokenizer) = load_generation_model(&args, preflight_estimate.as_ref())?;
+        // Block-diffusion models generate by canvas denoising, not
+        // autoregressive decoding: route them to the diffusion engine BEFORE
+        // the standard CxxGenerator loop (issue #217, phase 1).
+        if let mlxcel::LoadedModel::DiffusionGemma(diffusion_model) = &model {
+            return super::generate_diffusion::run_diffusion_generation(
+                diffusion_model,
+                &args,
+                &tokenizer,
+                &prompt_tokens,
+                &user_prompt,
+            );
+        }
         let vlm_embeddings = generate_vlm::compute_vlm_embeddings(
             &model,
             &mut prompt_tokens,

--- a/src/commands/generate_diffusion.rs
+++ b/src/commands/generate_diffusion.rs
@@ -1,0 +1,154 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! CLI driver for block-diffusion text generation (issue #217, phase 1).
+//!
+//! Thin bridge between the parsed [`crate::GenerateArgs`] flag surface and
+//! [`DiffusionGemmaModel::generate_diffusion_streaming`]: resolves the
+//! diffusion options, seeds the RNG, streams decoded text through the shared
+//! incremental detokenizer, and prints the generation stats.
+
+use anyhow::{Result, anyhow};
+use std::io::{self, Write as IoWrite};
+
+use mlxcel::models::DiffusionGemmaModel;
+use mlxcel::models::diffusion_gemma::{
+    DiffusionGenerateOptions, DiffusionGenerationStats, DiffusionSamplerKind,
+};
+use mlxcel::server::model_provider::model_worker::StreamingDecodeState;
+use mlxcel::tokenizer::MlxcelTokenizer;
+
+use super::generate::print_generation_preamble;
+use crate::GenerateArgs;
+
+fn parse_sampler_kind(name: &str) -> Result<DiffusionSamplerKind> {
+    match name {
+        "entropy-bound" => Ok(DiffusionSamplerKind::EntropyBound),
+        "confidence-threshold" => Ok(DiffusionSamplerKind::ConfidenceThreshold),
+        other => Err(anyhow!("Unsupported diffusion sampler: {other:?}")),
+    }
+}
+
+fn diffusion_options_from_args(args: &GenerateArgs) -> Result<DiffusionGenerateOptions> {
+    let diffusion = &args.generation.diffusion;
+    Ok(DiffusionGenerateOptions {
+        max_new_tokens: args.generation.max_tokens,
+        temperature: args.sampling.temp,
+        sampler: parse_sampler_kind(&diffusion.diffusion_sampler)?,
+        confidence_threshold: diffusion.diffusion_threshold,
+        max_denoising_steps: diffusion.max_denoising_steps,
+        min_canvas_length: diffusion.diffusion_min_canvas_length,
+        max_canvas_length: diffusion.diffusion_max_canvas_length,
+        full_canvas: diffusion.diffusion_full_canvas,
+        // Stop ids from generation_config.json (when present) join the
+        // checkpoint's embedded EOS set inside the engine.
+        extra_eos_token_ids: mlxcel::read_eos_token_ids(&args.model.model),
+        ..DiffusionGenerateOptions::default()
+    })
+}
+
+fn print_diffusion_stats(stats: &DiffusionGenerationStats, profile: bool) {
+    println!();
+    println!();
+    println!(
+        "[Generated {} tokens in {:.2}s = {:.2} tok/s]",
+        stats.generated_tokens, stats.generation_time_s, stats.generation_tps
+    );
+    if profile {
+        println!("[Diffusion Profile]");
+        println!(
+            "  Prompt: {} tokens in {:.3}s = {:.2} tok/s",
+            stats.prompt_tokens, stats.prompt_time_s, stats.prompt_tps
+        );
+        println!(
+            "  Canvas: {} tokens across {} blocks = {:.2} tok/s",
+            stats.canvas_tokens, stats.blocks, stats.canvas_tps
+        );
+        println!(
+            "  Denoising: {} steps, work {} tokens = {:.2} work tok/s",
+            stats.denoising_steps, stats.work_tokens, stats.work_tps
+        );
+        println!("  Finish reason: {:?}", stats.finish_reason);
+    }
+}
+
+/// Run one block-diffusion generation for the CLI `generate` flow.
+///
+/// Phase 1 is text-only; image/audio/video inputs are rejected with a clear
+/// error (phase 2).
+pub(crate) fn run_diffusion_generation(
+    model: &DiffusionGemmaModel,
+    args: &GenerateArgs,
+    tokenizer: &MlxcelTokenizer,
+    prompt_tokens: &[i32],
+    user_prompt: &str,
+) -> Result<()> {
+    if !args.generation.image.is_empty()
+        || args.generation.audio.is_some()
+        || !args.generation.video.is_empty()
+    {
+        return Err(anyhow!(
+            "DiffusionGemma image/audio/video input is not supported yet (phase 2 of issue \
+             #217); run with a text-only prompt"
+        ));
+    }
+    if args.model.draft_model.is_some() {
+        return Err(anyhow!(
+            "DiffusionGemma does not support speculative decoding (--draft-model); block \
+             diffusion already denoises whole canvases per step"
+        ));
+    }
+
+    let options = diffusion_options_from_args(args)?;
+    if let Some(seed) = args.sampling.seed {
+        mlxcel_core::random_seed(seed);
+    }
+
+    print_generation_preamble(user_prompt)?;
+
+    // Stream through the shared incremental detokenizer (byte-fallback
+    // safe); raw ids are collected in parallel so any held-back tail bytes
+    // can be flushed from a byte-exact full decode afterward.
+    let mut decode_state = StreamingDecodeState::new(tokenizer, prompt_tokens);
+    let mut generated_ids: Vec<u32> = Vec::with_capacity(options.max_new_tokens);
+    let mut streamed = String::new();
+    let mut stdout = io::stdout();
+
+    let stats = model
+        .generate_diffusion_streaming(prompt_tokens, &options, |token_id| {
+            generated_ids.push(token_id as u32);
+            if let Some(text) = decode_state.on_token(token_id, tokenizer) {
+                print!("{text}");
+                let _ = stdout.flush();
+                streamed.push_str(&text);
+            }
+            true
+        })
+        .map_err(|e| anyhow!("{e}"))?;
+
+    // Flush any tail the streaming view held back (e.g. a multi-byte char
+    // split across the final tokens).
+    let full_text = tokenizer.decode(&generated_ids, true).unwrap_or_default();
+    if let Some(tail) = full_text.strip_prefix(&streamed)
+        && !tail.is_empty()
+    {
+        print!("{tail}");
+        let _ = stdout.flush();
+    }
+
+    print_diffusion_stats(&stats, args.generation.profile);
+
+    mlxcel_core::clear_memory_cache();
+    Ok(())
+}

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -129,6 +129,7 @@ fn sample_generate_args(model_path: PathBuf) -> crate::GenerateArgs {
             estimate_memory: false,
             force_memory: false,
             turbo: mlxcel::cli::turbo_args::TurboKvCacheArgs::default(),
+            diffusion: crate::DiffusionCliOptions::default(),
         },
         sampling: crate::SamplingOptions {
             temp: 0.0,
@@ -140,6 +141,7 @@ fn sample_generate_args(model_path: PathBuf) -> crate::GenerateArgs {
             dry_base: 1.75,
             dry_allowed_length: 2,
             dry_penalty_last_n: 0,
+            seed: None,
         },
         pipeline_parallel: crate::PipelineParallelOptions {
             pp_size: 1,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod chat;
 pub(crate) mod detect;
 pub(crate) mod download;
 pub(crate) mod generate;
+mod generate_diffusion;
 mod generate_vlm;
 pub(crate) mod inspect;
 pub(crate) mod models;

--- a/src/distributed/tensor_parallel/inference.rs
+++ b/src/distributed/tensor_parallel/inference.rs
@@ -237,6 +237,10 @@ fn fallback_architecture(model_type: ModelType) -> &'static str {
         // MiniCPM-V 4.6 uses Qwen3.5 backbone; TP is not supported for VLM-kind
         // models and the loader refuses TP routing earlier. Return placeholder.
         ModelType::MiniCPMV46VLM => "minicpmv4_6",
+        // DiffusionGemma is not supported by tensor-parallel inference (the
+        // planner's supported-architecture validation rejects this string
+        // before any TP load is attempted).
+        ModelType::DiffusionGemma => "diffusion_gemma",
     }
 }
 

--- a/src/lib/mlx-cpp/CMakeLists.txt
+++ b/src/lib/mlx-cpp/CMakeLists.txt
@@ -26,9 +26,20 @@ function(mlx_apply_source_overlays mlx_source_dir)
   # `#3422 Speed up NAX split-K`, `#3419 Segmented mm nax kernel`). Removing
   # the patches keeps our build binary-equivalent to the upstream Python
   # wheel and simplifies future upstream syncs.
+  # steel/gemm/mma.h: cherry-pick of upstream `2414e5df` / `423b5149`
+  # ("Fix steel GEMM safe load offset", PRs #3560/#3565): the pinned commit
+  # (2026-05-09) reads `(off_x + j) * str_y` instead of `(off_y + j) * str_y`
+  # in BaseMMAFrag<T, 8, 8>::load_safe, so every edge-tile (non-tile-aligned)
+  # steel GEMM load reads the wrong rows — and, through strided views, can
+  # read uninitialized parent-buffer regions, which made non-tile-aligned
+  # multi-token forwards (e.g. DiffusionGemma canvas SDPA fallback at
+  # head_dim 256/512, issue #217) nondeterministically corrupt under
+  # allocator churn. Drop this overlay when the GIT_TAG moves to a commit at
+  # or after 2026-05-19.
   set(_metal_patch_files
       "mlx/backend/metal/compiled.cpp"
-      "mlx/backend/metal/kernels/utils.h")
+      "mlx/backend/metal/kernels/utils.h"
+      "mlx/backend/metal/kernels/steel/gemm/mma.h")
   foreach(_patch_file ${_metal_patch_files})
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/patches/${_patch_file}")
       configure_file(

--- a/src/lib/mlx-cpp/patches/mlx/backend/metal/kernels/steel/gemm/mma.h
+++ b/src/lib/mlx-cpp/patches/mlx/backend/metal/kernels/steel/gemm/mma.h
@@ -1,0 +1,1146 @@
+// Copyright © 2024 Apple Inc.
+
+#pragma once
+
+#include <metal_simdgroup>
+#include <metal_simdgroup_matrix>
+#include <metal_stdlib>
+
+#include "mlx/backend/metal/kernels/steel/defines.h"
+#include "mlx/backend/metal/kernels/steel/gemm/transforms.h"
+#include "mlx/backend/metal/kernels/steel/utils/integral_constant.h"
+
+using namespace metal;
+
+///////////////////////////////////////////////////////////////////////////////
+// MMA helper
+///////////////////////////////////////////////////////////////////////////////
+
+namespace mlx {
+namespace steel {
+
+template <typename T, int kFragRows_, int kFragCols_>
+struct BaseMMAFrag {
+  static_assert(
+      kFragRows_ == 8,
+      "Only 8 x 8 fragment matrices are currently supported");
+  static_assert(
+      kFragCols_ == 8,
+      "Only 8 x 8 fragment matrices are currently supported");
+};
+
+template <typename T>
+struct BaseMMAFrag<T, 8, 8> {
+  STEEL_CONST int kFragRows = 8;
+  STEEL_CONST int kFragCols = 8;
+
+  STEEL_CONST int kElemsPerFrag = (kFragRows * kFragCols) / 32;
+
+  STEEL_CONST int kElemRows = 1;
+  STEEL_CONST int kElemCols = 2;
+
+  static_assert(
+      kElemRows * kElemCols == kElemsPerFrag,
+      "MMAFrag shape is not consistent with MMAFrag size");
+
+  typedef metal::simdgroup_matrix<T, kFragRows, kFragCols> mat_type;
+  typedef metal::vec<T, kElemsPerFrag> frag_type;
+
+  METAL_FUNC static constexpr short2 get_coord(
+      ushort simd_lane_id [[thread_index_in_simdgroup]]) {
+    const short qid = simd_lane_id / 4;
+    const short fm = (qid & 4) + ((simd_lane_id / 2) % 4);
+    const short fn = (qid & 2) * 2 + (simd_lane_id % 2) * 2;
+    return short2{fn, fm};
+  }
+
+  template <typename SrcPtrType, typename StrX, typename StrY>
+  METAL_FUNC static constexpr void
+  load(thread frag_type& dst, SrcPtrType src, StrX str_x, StrY str_y) {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kElemRows; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < kElemCols; j++) {
+        dst[i * kElemCols + j] = static_cast<T>(src[i * str_x + j * str_y]);
+      }
+    }
+  }
+
+  template <
+      typename SrcPtrType,
+      typename StrX,
+      typename StrY,
+      typename LimX,
+      typename LimY,
+      typename OffX,
+      typename OffY>
+  METAL_FUNC static constexpr void load_safe(
+      thread frag_type& dst,
+      SrcPtrType src,
+      StrX str_x,
+      StrY str_y,
+      LimX lim_x,
+      LimY lim_y,
+      OffX off_x = Int<0>{},
+      OffY off_y = Int<0>{}) {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kElemRows; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < kElemCols; j++) {
+        if ((off_x + i) < lim_x && (off_y + j) < lim_y) {
+          dst[i * kElemCols + j] =
+              static_cast<T>(src[(off_x + i) * str_x + (off_y + j) * str_y]);
+        } else {
+          dst[i * kElemCols + j] = T(0);
+        }
+      }
+    }
+  }
+
+  template <typename DstPtrType, typename StrX, typename StrY>
+  METAL_FUNC static constexpr void
+  store(const thread frag_type& src, DstPtrType dst, StrX str_x, StrY str_y) {
+    using U = pointer_element_t<DstPtrType>;
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kElemRows; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < kElemCols; j++) {
+        dst[i * str_x + j * str_y] = static_cast<U>(src[i * kElemCols + j]);
+      }
+    }
+  }
+
+  template <
+      typename DstPtrType,
+      typename StrX,
+      typename StrY,
+      typename LimX,
+      typename LimY,
+      typename OffX,
+      typename OffY>
+  METAL_FUNC static constexpr void store_safe(
+      const thread frag_type& src,
+      DstPtrType dst,
+      StrX str_x,
+      StrY str_y,
+      LimX lim_x,
+      LimY lim_y,
+      OffX off_x = Int<0>{},
+      OffY off_y = Int<0>{}) {
+    using U = pointer_element_t<DstPtrType>;
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kElemRows; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < kElemCols; j++) {
+        if ((off_x + i) < lim_x && (off_y + j) < lim_y) {
+          dst[(off_x + i) * str_x + (off_y + j) * str_y] =
+              static_cast<U>(src[i * kElemCols + j]);
+        }
+      }
+    }
+  }
+
+  template <
+      typename DstPtrType,
+      typename StrX,
+      typename StrY,
+      typename StartX,
+      typename StopX,
+      typename StartY,
+      typename StopY,
+      typename OffX,
+      typename OffY>
+  METAL_FUNC static constexpr void store_slice(
+      const thread frag_type& src,
+      DstPtrType dst,
+      StrX str_x,
+      StrY str_y,
+      StartX start_x,
+      StopX stop_x,
+      StartY start_y,
+      StopY stop_y,
+      OffX off_x = Int<0>{},
+      OffY off_y = Int<0>{}) {
+    using U = pointer_element_t<DstPtrType>;
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kElemRows; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < kElemCols; j++) {
+        if ((off_x + i) < stop_x && (off_x + i) >= start_x &&
+            (off_y + j) < stop_y && (off_y + j) >= start_y) {
+          dst[(off_x + i) * str_x + (off_y + j) * str_y] =
+              static_cast<U>(src[i * kElemCols + j]);
+        }
+      }
+    }
+  }
+
+  METAL_FUNC static constexpr void mma(
+      thread frag_type& D,
+      thread frag_type& A,
+      thread frag_type& B,
+      thread frag_type& C) {
+    mat_type D_mat;
+    mat_type A_mat;
+    mat_type B_mat;
+    mat_type C_mat;
+
+    reinterpret_cast<thread frag_type&>(A_mat.thread_elements()) = A;
+    reinterpret_cast<thread frag_type&>(B_mat.thread_elements()) = B;
+    reinterpret_cast<thread frag_type&>(C_mat.thread_elements()) = C;
+
+    mma(D_mat, A_mat, B_mat, C_mat);
+
+    D = reinterpret_cast<thread frag_type&>(D_mat.thread_elements());
+  }
+
+  METAL_FUNC static constexpr void mma(
+      thread mat_type& D,
+      thread mat_type& A,
+      thread mat_type& B,
+      thread mat_type& C) {
+    simdgroup_multiply_accumulate(D, A, B, C);
+  }
+};
+
+template <
+    typename T,
+    int kTileRows_,
+    int kTileCols_,
+    class MMAFrag_ = BaseMMAFrag<T, 8, 8>>
+struct MMATile {
+  using MMAFrag_t = MMAFrag_;
+  using elem_type = T;
+  STEEL_CONST int kFragRows = MMAFrag_t::kFragRows;
+  STEEL_CONST int kFragCols = MMAFrag_t::kFragCols;
+  STEEL_CONST int kElemsPerFrag = MMAFrag_t::kElemsPerFrag;
+
+  STEEL_CONST int kTileRows = kTileRows_;
+  STEEL_CONST int kTileCols = kTileCols_;
+
+  STEEL_CONST int kRows = kTileRows * kFragRows;
+  STEEL_CONST int kCols = kTileCols * kFragCols;
+
+  STEEL_CONST int kNumFrags = kTileRows * kTileCols;
+  STEEL_CONST int kElemsPerTile = kNumFrags * kElemsPerFrag;
+
+  typedef typename MMAFrag_t::mat_type mat_type;
+  typedef typename MMAFrag_t::frag_type frag_type;
+
+  frag_type val_frags[kNumFrags] = {frag_type(0)};
+
+  METAL_FUNC MMATile() thread {}
+
+  METAL_FUNC constexpr void clear() {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kNumFrags; ++i) {
+      val_frags[i] = frag_type(0);
+    }
+  }
+
+  METAL_FUNC constexpr thread frag_type& frag_at(const short i, const short j) {
+    return val_frags[i * kTileCols + j];
+  }
+
+  METAL_FUNC constexpr const thread frag_type& frag_at(
+      const short i,
+      const short j) const {
+    return val_frags[i * kTileCols + j];
+  }
+
+  METAL_FUNC mat_type mat_at(const short i, const short j) {
+    mat_type val_mat;
+    STEEL_PRAGMA_UNROLL
+    for (short ii = 0; ii < kElemsPerFrag; ++ii) {
+      val_mat.thread_elements()[ii] = frag_at(i, j)[ii];
+    }
+    return val_mat;
+  }
+
+  METAL_FUNC thread elem_type* elems() {
+    return reinterpret_cast<thread elem_type*>(val_frags);
+  }
+
+  METAL_FUNC const thread elem_type* elems() const {
+    return reinterpret_cast<const thread elem_type*>(val_frags);
+  }
+
+  template <typename U, int w_x, int w_y, int str_x, int str_y>
+  METAL_FUNC void load(const threadgroup U* src) {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kTileRows; ++i) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < kTileCols; ++j) {
+        MMAFrag_t::load(
+            frag_at(i, j),
+            &(
+                src[(i * kFragRows) * w_x * str_x +
+                    (j * kFragCols) * w_y * str_y]),
+            Int<str_x>{},
+            Int<str_y>{});
+      }
+    }
+  }
+
+  template <typename U, int w_x, int w_y, int str_x, int str_y>
+  METAL_FUNC void store(threadgroup U* dst) const {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kTileRows; ++i) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < kTileCols; ++j) {
+        MMAFrag_t::store(
+            frag_at(i, j),
+            &(
+                dst[(i * kFragRows) * w_x * str_x +
+                    (j * kFragCols) * w_y * str_y]),
+            Int<str_x>{},
+            Int<str_y>{});
+      }
+    }
+  }
+
+  template <typename U, int w_x, int w_y>
+  METAL_FUNC void load(const device U* src, const int ld) {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kTileRows; ++i) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < kTileCols; ++j) {
+        MMAFrag_t::load(
+            frag_at(i, j),
+            &(src[(i * kFragRows) * w_x * ld + (j * kFragCols) * w_y]),
+            ld,
+            Int<1>{});
+      }
+    }
+  }
+
+  template <typename U, int w_x, int w_y>
+  METAL_FUNC void store(device U* dst, const int ld) const {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kTileRows; ++i) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < kTileCols; ++j) {
+        MMAFrag_t::store(
+            frag_at(i, j),
+            &(dst[(i * kFragRows) * w_x * ld + (j * kFragCols) * w_y]),
+            ld,
+            Int<1>{});
+      }
+    }
+  }
+
+  template <typename U, int w_x, int w_y>
+  METAL_FUNC void
+  load_safe(const device U* src, const int ld, const short2 src_tile_dims) {
+    STEEL_PRAGMA_UNROLL
+    for (int i = 0; i < kTileRows; ++i) {
+      STEEL_PRAGMA_UNROLL
+      for (int j = 0; j < kTileCols; ++j) {
+        MMAFrag_t::load_safe(
+            frag_at(i, j),
+            src,
+            ld,
+            Int<1>{},
+            src_tile_dims.y,
+            src_tile_dims.x,
+            (i * kFragRows) * w_x,
+            (j * kFragCols) * w_y);
+      }
+    }
+  }
+
+  template <typename U, int w_x, int w_y>
+  METAL_FUNC void
+  store_safe(device U* dst, const int ld, const short2 dst_tile_dims) const {
+    STEEL_PRAGMA_UNROLL
+    for (int i = 0; i < kTileRows; ++i) {
+      STEEL_PRAGMA_UNROLL
+      for (int j = 0; j < kTileCols; ++j) {
+        MMAFrag_t::store_safe(
+            frag_at(i, j),
+            dst,
+            ld,
+            Int<1>{},
+            dst_tile_dims.y,
+            dst_tile_dims.x,
+            (i * kFragRows) * w_x,
+            (j * kFragCols) * w_y);
+      }
+    }
+  }
+
+  template <typename U, int w_x, int w_y>
+  METAL_FUNC void store_slice(
+      device U* dst,
+      const int ld,
+      const short2 start,
+      const short2 stop) const {
+    STEEL_PRAGMA_UNROLL
+    for (int i = 0; i < kTileRows; ++i) {
+      STEEL_PRAGMA_UNROLL
+      for (int j = 0; j < kTileCols; ++j) {
+        MMAFrag_t::store_slice(
+            frag_at(i, j),
+            dst,
+            ld,
+            Int<1>{},
+            start.y,
+            stop.y,
+            start.x,
+            stop.x,
+            (i * kFragRows) * w_x,
+            (j * kFragCols) * w_y);
+      }
+    }
+  }
+};
+
+template <typename T, typename U, int M, int N, int K>
+METAL_FUNC void tile_matmad(
+    thread MMATile<T, M, N>& D,
+    thread MMATile<U, M, K>& A,
+    thread MMATile<U, K, N>& B,
+    thread MMATile<T, M, N>& C) {
+  STEEL_PRAGMA_UNROLL
+  for (short m = 0; m < M; ++m) {
+    STEEL_PRAGMA_UNROLL
+    for (short n = 0; n < N; ++n) {
+      short n_serp = (m % 2) ? (N - 1 - n) : n;
+      STEEL_PRAGMA_UNROLL
+      for (short k = 0; k < K; ++k) {
+        MMATile<T, M, N>::MMAFrag_t::mma(
+            D.frag_at(m, n_serp),
+            A.frag_at(m, k),
+            B.frag_at(k, n_serp),
+            C.frag_at(m, n_serp));
+      }
+    }
+  }
+}
+
+template <typename InT>
+struct TransformNone<complex64_t, InT> {
+  static METAL_FUNC complex64_t apply(complex64_t x) {
+    return x;
+  }
+  static METAL_FUNC complex64_t apply(complex64_t x, complex64_t) {
+    return x;
+  }
+};
+
+template <
+    typename T,
+    typename U,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN,
+    bool transpose_a,
+    bool transpose_b,
+    short lda_tgp,
+    short ldb_tgp,
+    typename AccumType = float,
+    typename Epilogue = TransformNone<U, AccumType>>
+struct BlockMMA {
+  // MMAFrag size
+  STEEL_CONST short kFragSize = 8;
+  using MMAFrag_acc_t = BaseMMAFrag<AccumType, kFragSize, kFragSize>;
+
+  // Warp tile simdgroup matrix strides along M
+  STEEL_CONST short TM_stride = kFragSize * WM;
+  // Warp tile simdgroup matrix strides along M
+  STEEL_CONST short TN_stride = kFragSize * WN;
+
+  // Warp tile size along M
+  STEEL_CONST short TM = BM / (kFragSize * WM);
+  // Warp tile size along N
+  STEEL_CONST short TN = BN / (kFragSize * WN);
+
+  // Threadgroup A strides
+  STEEL_CONST short A_str_m = transpose_a ? 1 : lda_tgp; // M
+  STEEL_CONST short A_str_k = transpose_a ? lda_tgp : 1; // K
+
+  // Threadgroup B strides
+  STEEL_CONST short B_str_k = transpose_b ? 1 : ldb_tgp; // K
+  STEEL_CONST short B_str_n = transpose_b ? ldb_tgp : 1; // N
+
+  // Threadgroup strides along K
+  STEEL_CONST short tile_stride_a = kFragSize * A_str_k;
+  STEEL_CONST short tile_stride_b = kFragSize * B_str_k;
+
+  // Simdgroup matrices
+  MMATile<AccumType, TM, 1, MMAFrag_acc_t> Atile;
+  MMATile<AccumType, 1, TN, MMAFrag_acc_t> Btile;
+  MMATile<AccumType, TM, TN, MMAFrag_acc_t> Ctile;
+
+  // Offsets within threadgroup
+  short sm;
+  short sn;
+
+  short As_offset;
+  short Bs_offset;
+
+  /* Constructor */
+  METAL_FUNC BlockMMA(
+      ushort simd_group_id [[simdgroup_index_in_threadgroup]],
+      ushort simd_lane_id [[thread_index_in_simdgroup]]) {
+    // Determine thread position in simdgroup matrix
+    short tm = kFragSize * (simd_group_id / WN);
+    short tn = kFragSize * (simd_group_id % WN);
+
+    short2 simd_coord = MMAFrag_acc_t::get_coord(simd_lane_id);
+    sm = simd_coord.y;
+    sn = simd_coord.x;
+
+    // Determine thread and simdgroup offset
+    As_offset = (tm + sm) * A_str_m + (sn)*A_str_k; // M, K
+    Bs_offset = (sm)*B_str_k + (tn + sn) * B_str_n; // K, N
+
+    sm += tm;
+    sn += tn;
+  }
+
+  /* (BM, BK) X (BK, BN) multiply accumulate function */
+  METAL_FUNC void mma(const threadgroup T* As, const threadgroup T* Bs) {
+    // Adjust for simdgroup and thread location
+    As += As_offset;
+    Bs += Bs_offset;
+
+    // Iterate over BK in blocks of kFragSize
+    STEEL_PRAGMA_UNROLL
+    for (short kk = 0; kk < BK; kk += kFragSize) {
+      simdgroup_barrier(mem_flags::mem_none);
+
+      Atile.template load<T, WM, 1, A_str_m, A_str_k>(As);
+
+      simdgroup_barrier(mem_flags::mem_none);
+
+      Btile.template load<T, 1, WN, B_str_k, B_str_n>(Bs);
+
+      simdgroup_barrier(mem_flags::mem_none);
+
+      tile_matmad(Ctile, Atile, Btile, Ctile);
+
+      // Progress to next simdgroup tile
+      As += tile_stride_a;
+      Bs += tile_stride_b;
+    }
+  }
+
+  /* Store results from simdgroup_matrix results into device memory */
+  METAL_FUNC void store_result(device U* D, const int ldd) {
+    // Apply epilogue
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(Ctile)::kElemsPerTile; i++) {
+      Ctile.elems()[i] = Epilogue::apply(Ctile.elems()[i]);
+    }
+
+    // Adjust for simdgroup and thread location
+    D += sm * ldd + sn;
+
+    Ctile.template store<U, WM, WN>(D, ldd);
+  }
+
+  METAL_FUNC void
+  store_result_slice(device U* D, const int ldd, short2 start, short2 stop) {
+    // Apply epilogue
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(Ctile)::kElemsPerTile; i++) {
+      Ctile.elems()[i] = Epilogue::apply(Ctile.elems()[i]);
+    }
+
+    D += sm * ldd + sn;
+    start -= short2(sn, sm);
+    stop -= short2(sn, sm);
+
+    // TODO: Check the start as well
+    if (stop.y <= 0 || stop.x <= 0) {
+      return;
+    }
+
+    Ctile.template store_slice<U, WM, WN>(D, ldd, start, stop);
+  }
+
+  METAL_FUNC void
+  store_result_safe(device U* D, const int ldd, short2 dst_tile_dims) {
+    // Apply epilogue
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(Ctile)::kElemsPerTile; i++) {
+      Ctile.elems()[i] = Epilogue::apply(Ctile.elems()[i]);
+    }
+
+    // Adjust for simdgroup and thread location
+    D += sm * ldd + sn;
+    dst_tile_dims -= short2(sn, sm);
+
+    if (dst_tile_dims.x <= 0 || dst_tile_dims.y <= 0)
+      return;
+
+    Ctile.template store_safe<U, WM, WN>(D, ldd, dst_tile_dims);
+  }
+
+  /* Apply epilogue */
+  template <typename UnaryEpilogue>
+  METAL_FUNC void apply_epilogue(thread const UnaryEpilogue& epilogue_op) {
+    // Loop over all simdgroup tiles
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(Ctile)::kElemsPerTile; i++) {
+      Ctile.elems()[i] = epilogue_op.apply(Ctile.elems()[i]);
+    }
+  }
+
+  /* Apply epilogue */
+  template <typename BinaryEpilogue>
+  METAL_FUNC void apply_epilogue(
+      const device U* C,
+      const int ldc,
+      const int fdc,
+      thread const BinaryEpilogue& epilogue_op) {
+    // Adjust for simdgroup and thread location
+    C += (sm)*ldc + (sn)*fdc;
+
+    // Loop over all simdgroup tiles
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < TM; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < TN; j++) {
+        // Get accumulated result and associated offset in C
+        thread auto& accum = Ctile.frag_at(i, j);
+        int offset_c = (i * TM_stride) * ldc + (j * TN_stride) * fdc;
+
+        // Apply epilogue
+        STEEL_PRAGMA_UNROLL
+        for (short k = 0; k < decltype(Ctile)::kElemsPerFrag; k++) {
+          accum[k] = epilogue_op.apply(accum[k], C[offset_c + k * fdc]);
+        }
+      }
+    }
+  }
+
+  /* Apply epilogue */
+  template <typename BinaryEpilogue>
+  METAL_FUNC void apply_epilogue_safe(
+      const device U* C,
+      const int ldc,
+      const int fdc,
+      short2 dst_tile_dims,
+      thread const BinaryEpilogue& epilogue_op) {
+    // Adjust for simdgroup and thread location
+    C += (sm)*ldc + (sn)*fdc;
+    dst_tile_dims -= short2(sn, sm);
+
+    if (dst_tile_dims.x <= 0 || dst_tile_dims.y <= 0)
+      return;
+
+    // Loop over all simdgroup tiles
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < TM; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < TN; j++) {
+        // Get accumulated result and associated offset in C
+        thread auto& accum = Ctile.frag_at(i, j);
+        int offset_c = (i * TM_stride) * ldc + (j * TN_stride) * fdc;
+
+        constexpr short kelems = decltype(Ctile)::kElemsPerFrag;
+
+        // Read C
+        U c_elems[kelems] = {0};
+
+        STEEL_PRAGMA_UNROLL
+        for (short k = 0; k < kelems; k++) {
+          if ((j * TN_stride + k) < dst_tile_dims.x) {
+            c_elems[k] = C[offset_c + k * fdc];
+          }
+        }
+
+        // Apply epilogue
+        STEEL_PRAGMA_UNROLL
+        for (short k = 0; k < kelems; k++) {
+          accum[k] = epilogue_op.apply(accum[k], c_elems[k]);
+        }
+      }
+    }
+  }
+
+  /* Store results from simdgroup_matrix results into device memory */
+  METAL_FUNC void store_result(
+      device U* D,
+      const int ldd,
+      const device U* C,
+      const int ldc,
+      const int fdc,
+      thread const Epilogue& epilogue_op) const {
+    // Adjust for simdgroup and thread location
+    C += (sm)*ldc + (sn)*fdc;
+    D += (sm)*ldd + sn;
+
+    constexpr short kelems = decltype(Ctile)::kElemsPerFrag;
+
+    // Loop over all simdgroup tiles
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < TM; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < TN; j++) {
+        // Get accumulated result and associated offset in C
+        thread const auto& accum = Ctile.frag_at(i, j);
+        int offset_c = (i * TM_stride) * ldc + (j * TN_stride) * fdc;
+        int offset_d = (i * TM_stride) * ldd + (j * TN_stride);
+
+        // Apply epilogue
+        STEEL_PRAGMA_UNROLL
+        for (short k = 0; k < kelems; k++) {
+          D[offset_d + k] = epilogue_op.apply(accum[k], C[offset_c + k * fdc]);
+        }
+      }
+    }
+  }
+
+  METAL_FUNC void store_result_safe(
+      device U* D,
+      const int ldd,
+      const device U* C,
+      const int ldc,
+      const int fdc,
+      short2 dst_tile_dims,
+      thread const Epilogue& epilogue_op) const {
+    // Adjust for simdgroup and thread location
+    C += (sm)*ldc + (sn)*fdc;
+    D += (sm)*ldd + sn;
+    dst_tile_dims -= short2(sn, sm);
+
+    if (dst_tile_dims.x <= 0 || dst_tile_dims.y <= 0)
+      return;
+
+    constexpr short kelems = decltype(Ctile)::kElemsPerFrag;
+
+    STEEL_PRAGMA_UNROLL
+    for (int i = 0; i < TM; i++) {
+      if (i * TM_stride < dst_tile_dims.y) {
+        STEEL_PRAGMA_UNROLL
+        for (int j = 0; j < TN; j++) {
+          // Get accumulated result and associated offset in C
+          thread const auto& accum = Ctile.frag_at(i, j);
+          int offset_c = (i * TM_stride) * ldc + (j * TN_stride) * fdc;
+          int offset_d = (i * TM_stride) * ldd + (j * TN_stride);
+
+          // Apply epilogue
+          STEEL_PRAGMA_UNROLL
+          for (short k = 0; k < kelems; k++) {
+            if ((j * TN_stride + k) < dst_tile_dims.x) {
+              D[offset_d + k] =
+                  epilogue_op.apply(accum[k], C[offset_c + k * fdc]);
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+template <
+    typename U,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN,
+    bool transpose_a,
+    bool transpose_b,
+    short lda_tgp,
+    short ldb_tgp,
+    typename AccumType,
+    typename Epilogue>
+struct BlockMMA<
+    complex64_t,
+    U,
+    BM,
+    BN,
+    BK,
+    WM,
+    WN,
+    transpose_a,
+    transpose_b,
+    lda_tgp,
+    ldb_tgp,
+    AccumType,
+    Epilogue> {
+  static_assert(
+      metal::is_same_v<AccumType, float>,
+      "BlockMMA<complex64_t,...> expects float accumulators");
+  static_assert(
+      metal::is_same_v<U, complex64_t>,
+      "For complex BlockMMA, U must be complex64_t; use a different epilogue for projections");
+  // MMAFrag size
+  STEEL_CONST short kFragSize = 8;
+  using MMAFrag_acc_t = BaseMMAFrag<AccumType, kFragSize, kFragSize>;
+
+  // Warp tile simdgroup matrix strides along M
+  STEEL_CONST short TM_stride = kFragSize * WM;
+  // Warp tile simdgroup matrix strides along M
+  STEEL_CONST short TN_stride = kFragSize * WN;
+
+  // Warp tile size along M
+  STEEL_CONST short TM = BM / (kFragSize * WM);
+  // Warp tile size along N
+  STEEL_CONST short TN = BN / (kFragSize * WN);
+
+  // Threadgroup A strides
+  STEEL_CONST short A_str_m = transpose_a ? 1 : lda_tgp; // M
+  STEEL_CONST short A_str_k = transpose_a ? lda_tgp : 1; // K
+
+  // Threadgroup B strides
+  STEEL_CONST short B_str_k = transpose_b ? 1 : ldb_tgp; // K
+  STEEL_CONST short B_str_n = transpose_b ? ldb_tgp : 1; // N
+
+  // Threadgroup strides along K
+  STEEL_CONST short tile_stride_a = kFragSize * A_str_k;
+  STEEL_CONST short tile_stride_b = kFragSize * B_str_k;
+
+  // When indexing complex as float[2]
+  STEEL_CONST short A_str_m_f = A_str_m * 2;
+  STEEL_CONST short A_str_k_f = A_str_k * 2;
+  STEEL_CONST short B_str_k_f = B_str_k * 2;
+  STEEL_CONST short B_str_n_f = B_str_n * 2;
+  STEEL_CONST short tile_stride_a_f = tile_stride_a * 2;
+  STEEL_CONST short tile_stride_b_f = tile_stride_b * 2;
+
+  // Accumulators (real/imag)
+  MMATile<AccumType, TM, TN, MMAFrag_acc_t> Ctile_r;
+  MMATile<AccumType, TM, TN, MMAFrag_acc_t> Ctile_i;
+
+  // Offsets within threadgroup
+  short sm, sn;
+  short As_offset, Bs_offset;
+
+  /* Constructor */
+  METAL_FUNC BlockMMA(
+      ushort simd_group_id [[simdgroup_index_in_threadgroup]],
+      ushort simd_lane_id [[thread_index_in_simdgroup]]) {
+    // Determine thread position in simdgroup matrix
+    short tm = kFragSize * (simd_group_id / WN);
+    short tn = kFragSize * (simd_group_id % WN);
+
+    short2 simd_coord = MMAFrag_acc_t::get_coord(simd_lane_id);
+    sm = simd_coord.y;
+    sn = simd_coord.x;
+
+    // Determine thread and simdgroup offset
+    As_offset = (tm + sm) * A_str_m + (sn)*A_str_k; // (M,K)
+    Bs_offset = (sm)*B_str_k + (tn + sn) * B_str_n; // (K,N)
+
+    sm += tm;
+    sn += tn;
+  }
+
+  /* Karatsuba MMA: 3 real MMAs per K-chunk */
+  METAL_FUNC void mma(
+      const threadgroup complex64_t* As,
+      const threadgroup complex64_t* Bs) {
+    // Adjust for simdgroup and thread location
+    As += As_offset;
+    Bs += Bs_offset;
+    threadgroup const float* As_f =
+        reinterpret_cast<threadgroup const float*>(As);
+    threadgroup const float* Bs_f =
+        reinterpret_cast<threadgroup const float*>(Bs);
+
+    // Iterate over BK in blocks of kFragSize
+    STEEL_PRAGMA_UNROLL
+    for (short kk = 0; kk < BK; kk += kFragSize) {
+      simdgroup_barrier(mem_flags::mem_none);
+
+      MMATile<AccumType, TM, 1, MMAFrag_acc_t> Ar, Ai;
+      Ar.template load<float, WM, 1, A_str_m_f, A_str_k_f>(As_f + 0);
+      Ai.template load<float, WM, 1, A_str_m_f, A_str_k_f>(As_f + 1);
+
+      simdgroup_barrier(mem_flags::mem_none);
+
+      MMATile<AccumType, 1, TN, MMAFrag_acc_t> Br, Bi;
+      Br.template load<float, 1, WN, B_str_k_f, B_str_n_f>(Bs_f + 0);
+      Bi.template load<float, 1, WN, B_str_k_f, B_str_n_f>(Bs_f + 1);
+
+      simdgroup_barrier(mem_flags::mem_none);
+
+      // P = Ar*Br ; Q = Ai*Bi ; R = (Ar+Ai)*(Br+Bi)
+      MMATile<AccumType, TM, TN, MMAFrag_acc_t> P, Q, R;
+
+      tile_matmad(P, Ar, Br, P);
+      tile_matmad(Q, Ai, Bi, Q);
+
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < decltype(Ar)::kElemsPerTile; ++i)
+        Ar.elems()[i] += Ai.elems()[i];
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < decltype(Br)::kElemsPerTile; ++i)
+        Br.elems()[i] += Bi.elems()[i];
+
+      tile_matmad(R, Ar, Br, R);
+
+      // C_r += P - Q ; C_i -= Q
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < decltype(Ctile_r)::kElemsPerTile; ++i) {
+        const auto p = P.elems()[i];
+        const auto q = Q.elems()[i];
+        const auto r = R.elems()[i];
+        Ctile_r.elems()[i] += (p - q);
+        Ctile_i.elems()[i] += (r - p - q);
+      }
+
+      // Progress to next simdgroup tile
+      As_f += tile_stride_a_f;
+      Bs_f += tile_stride_b_f;
+    }
+  }
+
+  /* Store results from simdgroup_matrix results into device memory */
+  METAL_FUNC void store_result(device U* D, const int ldd) {
+    // Adjust for simdgroup and thread location
+    D += sm * ldd + sn;
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < TM; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < TN; j++) {
+        thread const auto& r = Ctile_r.frag_at(i, j);
+        thread const auto& im = Ctile_i.frag_at(i, j);
+        int off = (i * TM_stride) * ldd + (j * TN_stride);
+        STEEL_PRAGMA_UNROLL
+        for (short k = 0; k < decltype(Ctile_r)::kElemsPerFrag; k++) {
+          D[off + k] = Epilogue::apply(complex64_t(r[k], im[k]));
+        }
+      }
+    }
+  }
+
+  METAL_FUNC void
+  store_result_slice(device U* D, const int ldd, short2 start, short2 stop) {
+    D += sm * ldd + sn;
+    start -= short2(sn, sm);
+    stop -= short2(sn, sm);
+
+    if (stop.y <= 0 || stop.x <= 0)
+      return;
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < TM; ++i) {
+      const int row = i * TM_stride;
+      if (row >= start.y && row < stop.y) {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < TN; ++j) {
+          const int off = row * ldd + (j * TN_stride);
+          thread const auto& r = Ctile_r.frag_at(i, j);
+          thread const auto& im = Ctile_i.frag_at(i, j);
+
+          STEEL_PRAGMA_UNROLL
+          for (short k = 0; k < decltype(Ctile_r)::kElemsPerFrag; ++k) {
+            const int col = j * TN_stride + k;
+            if (col >= start.x && col < stop.x) {
+              D[off + k] = Epilogue::apply(complex64_t(r[k], im[k]));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  METAL_FUNC void
+  store_result_safe(device U* D, const int ldd, short2 dst_tile_dims) {
+    D += sm * ldd + sn;
+    dst_tile_dims -= short2(sn, sm);
+    if (dst_tile_dims.x <= 0 || dst_tile_dims.y <= 0)
+      return;
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < TM; i++) {
+      if (i * TM_stride < dst_tile_dims.y) {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < TN; j++) {
+          int off = (i * TM_stride) * ldd + (j * TN_stride);
+          thread const auto& r = Ctile_r.frag_at(i, j);
+          thread const auto& im = Ctile_i.frag_at(i, j);
+          STEEL_PRAGMA_UNROLL
+          for (short k = 0; k < decltype(Ctile_r)::kElemsPerFrag; k++) {
+            if ((j * TN_stride + k) < dst_tile_dims.x) {
+              D[off + k] = Epilogue::apply(complex64_t(r[k], im[k]));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /* Apply epilogue */
+  template <typename UnaryEpilogue>
+  METAL_FUNC void apply_epilogue(thread const UnaryEpilogue& epilogue_op) {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(Ctile_r)::kElemsPerTile; i++) {
+      complex64_t out = epilogue_op.apply(
+          complex64_t(Ctile_r.elems()[i], Ctile_i.elems()[i]));
+      Ctile_r.elems()[i] = out.real;
+      Ctile_i.elems()[i] = out.imag;
+    }
+  }
+
+  /* Apply epilogue */
+  template <typename BinaryEpilogue>
+  METAL_FUNC void apply_epilogue(
+      const device U* C,
+      const int ldc,
+      const int fdc,
+      thread const BinaryEpilogue& epilogue_op) {
+    // Adjust for simdgroup and thread location
+    C += (sm)*ldc + (sn)*fdc;
+
+    // Loop over all simdgroup tiles
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < TM; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < TN; j++) {
+        // Get accumulated result and associated offset in Cr, Ci
+        thread auto& r = Ctile_r.frag_at(i, j);
+        thread auto& im = Ctile_i.frag_at(i, j);
+        int offset_c = (i * TM_stride) * ldc + (j * TN_stride) * fdc;
+
+        STEEL_PRAGMA_UNROLL
+        for (short k = 0; k < decltype(Ctile_r)::kElemsPerFrag; k++) {
+          complex64_t out = epilogue_op.apply(
+              complex64_t(r[k], im[k]), C[offset_c + k * fdc]);
+          r[k] = out.real;
+          im[k] = out.imag;
+        }
+      }
+    }
+  }
+
+  /* Apply epilogue */
+  template <typename BinaryEpilogue>
+  METAL_FUNC void apply_epilogue_safe(
+      const device U* C,
+      const int ldc,
+      const int fdc,
+      short2 dst_tile_dims,
+      thread const BinaryEpilogue& epilogue_op) {
+    // Adjust for simdgroup and thread location
+    C += (sm)*ldc + (sn)*fdc;
+    dst_tile_dims -= short2(sn, sm);
+
+    if (dst_tile_dims.x <= 0 || dst_tile_dims.y <= 0)
+      return;
+
+    // Loop over all simdgroup tiles
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < TM; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < TN; j++) {
+        // Get accumulated result and associated offset in Cr, Ci
+        thread auto& r = Ctile_r.frag_at(i, j);
+        thread auto& im = Ctile_i.frag_at(i, j);
+        int offset_c = (i * TM_stride) * ldc + (j * TN_stride) * fdc;
+
+        constexpr short kelems = decltype(Ctile_r)::kElemsPerFrag;
+        complex64_t tmp[kelems];
+
+        STEEL_PRAGMA_UNROLL
+        for (short k = 0; k < kelems; k++) {
+          if ((j * TN_stride + k) < dst_tile_dims.x &&
+              (i * TM_stride) < dst_tile_dims.y) {
+            tmp[k] = C[offset_c + k * fdc];
+          } else {
+            tmp[k] = complex64_t(0.0f, 0.0f);
+          }
+        }
+
+        // Apply epilogue
+        STEEL_PRAGMA_UNROLL
+        for (short k = 0; k < kelems; k++) {
+          complex64_t out = epilogue_op.apply(complex64_t(r[k], im[k]), tmp[k]);
+          r[k] = out.real;
+          im[k] = out.imag;
+        }
+      }
+    }
+  }
+
+  /* Store results from simdgroup_matrix results into device memory */
+  METAL_FUNC void store_result(
+      device U* D,
+      const int ldd,
+      const device U* C,
+      const int ldc,
+      const int fdc,
+      thread const Epilogue& epilogue_op) const {
+    // Adjust for simdgroup and thread location
+    C += (sm)*ldc + (sn)*fdc;
+    D += (sm)*ldd + sn;
+
+    constexpr short kelems = decltype(Ctile_r)::kElemsPerFrag;
+
+    // Loop over all simdgroup tiles
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < TM; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < TN; j++) {
+        // Get accumulated result and associated offset in Cr, Ci
+        thread const auto& r = Ctile_r.frag_at(i, j);
+        thread const auto& im = Ctile_i.frag_at(i, j);
+        int off_c = (i * TM_stride) * ldc + (j * TN_stride) * fdc;
+        int off_d = (i * TM_stride) * ldd + (j * TN_stride);
+
+        // Apply epilogue
+        STEEL_PRAGMA_UNROLL
+        for (short k = 0; k < kelems; k++) {
+          D[off_d + k] =
+              epilogue_op.apply(complex64_t(r[k], im[k]), C[off_c + k * fdc]);
+        }
+      }
+    }
+  }
+
+  METAL_FUNC void store_result_safe(
+      device U* D,
+      const int ldd,
+      const device U* C,
+      const int ldc,
+      const int fdc,
+      short2 dst_tile_dims,
+      thread const Epilogue& epilogue_op) const {
+    // Adjust for simdgroup and thread location
+    C += (sm)*ldc + (sn)*fdc;
+    D += (sm)*ldd + sn;
+    dst_tile_dims -= short2(sn, sm);
+
+    if (dst_tile_dims.x <= 0 || dst_tile_dims.y <= 0)
+      return;
+
+    constexpr short kelems = decltype(Ctile_r)::kElemsPerFrag;
+
+    STEEL_PRAGMA_UNROLL
+    for (int i = 0; i < TM; i++) {
+      if (i * TM_stride < dst_tile_dims.y) {
+        STEEL_PRAGMA_UNROLL
+        for (int j = 0; j < TN; j++) {
+          // Get accumulated result and associated offset in Cr, Ci
+          thread const auto& r = Ctile_r.frag_at(i, j);
+          thread const auto& im = Ctile_i.frag_at(i, j);
+          int off_c = (i * TM_stride) * ldc + (j * TN_stride) * fdc;
+          int off_d = (i * TM_stride) * ldd + (j * TN_stride);
+
+          // Apply epilogue
+          STEEL_PRAGMA_UNROLL
+          for (short k = 0; k < kelems; k++) {
+            if ((j * TN_stride + k) < dst_tile_dims.x) {
+              D[off_d + k] = epilogue_op.apply(
+                  complex64_t(r[k], im[k]), C[off_c + k * fdc]);
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+} // namespace steel
+} // namespace mlx

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -742,6 +742,39 @@ impl KVCache {
         self.offset - self.live_start
     }
 
+    /// Read-only view of the live K/V window without writing to the cache.
+    ///
+    /// Returns the `[B, n_kv_heads, live_len, head_dim]` slices of the dense
+    /// Fp16 buffers — exactly what [`Self::update_and_fetch`] would have
+    /// returned for a zero-token update, but as a `&self` accessor so callers
+    /// can concatenate the cached prefix with externally computed K/V
+    /// without mutating cache state.
+    ///
+    /// Returns `None` when the cache is empty, pool-backed (`new_paged`), or
+    /// not in plain `KVCacheMode::Fp16` — the only storage layout whose raw
+    /// buffers are directly attention-ready without dequantization.
+    ///
+    /// Used by: DiffusionGemma canvas (decoder-mode) attention (issue #217),
+    /// which reads the committed encoder prefix as a read-only context for
+    /// every denoising step.
+    pub fn visible_state(&self) -> Option<(UniquePtr<MlxArray>, UniquePtr<MlxArray>)> {
+        if self.mode != KVCacheMode::Fp16 || self.paged_backing.is_some() {
+            return None;
+        }
+        let keys = self.keys.as_ref()?;
+        let values = self.values.as_ref()?;
+        let live_len = self.buffer_idx();
+        if live_len <= 0 {
+            return None;
+        }
+        let ks = ffi::array_shape(keys);
+        let vs = ffi::array_shape(values);
+        Some((
+            ffi::slice(keys, &[0, 0, 0, 0], &[ks[0], ks[1], live_len, ks[3]]),
+            ffi::slice(values, &[0, 0, 0, 0], &[vs[0], vs[1], live_len, vs[3]]),
+        ))
+    }
+
     /// Get the allocated buffer size (sequence dimension)
     fn buffer_seq_len(&self) -> i32 {
         // In symmetric Turbo4 mode the `keys` field stays None and the

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -2552,3 +2552,37 @@ fn paged_decode_fallbacks_reject_an_empty_batch() {
         pooled.as_ref().err()
     );
 }
+/// Regression test for the steel GEMM safe-load (edge-tile) overlay
+/// (`mlx-cpp/patches/mlx/backend/metal/kernels/steel/gemm/mma.h`, upstream
+/// MLX PRs #3560/#3565: `BaseMMAFrag<T, 8, 8>::load_safe` indexed columns
+/// with `off_x` instead of `off_y`).
+///
+/// A non-tile-aligned fp32 GEMM (m=64, k=256, n=83) exercises edge-tile
+/// safe loads on the N axis; with the bug, the loader pulls the wrong rows
+/// and the result diverges wildly from a composite (multiply + sum)
+/// reference computed without steel GEMM. fp32 keeps the legitimate
+/// numerical gap tiny so the assertion threshold cleanly separates the two.
+#[test]
+fn steel_gemm_edge_tile_safe_load_matches_reference() {
+    crate::random_seed(31);
+    let a = unsafe { crate::random_normal(&[64, 256], crate::dtype::FLOAT32, std::ptr::null()) };
+    let b = unsafe { crate::random_normal(&[256, 83], crate::dtype::FLOAT32, std::ptr::null()) };
+    crate::eval(&a);
+    crate::eval(&b);
+
+    let gemm = crate::matmul(&a, &b);
+
+    // Composite reference: broadcast multiply + sum over K avoids the steel
+    // GEMM kernels entirely.
+    let a3 = crate::reshape(&a, &[64, 256, 1]);
+    let b3 = crate::reshape(&b, &[1, 256, 83]);
+    let reference = crate::sum_axis(&crate::multiply(&a3, &b3), 1, false);
+
+    let diff = crate::max_all(&crate::abs(&crate::subtract(&gemm, &reference)));
+    crate::eval(&diff);
+    let max_abs = crate::item_f32(&diff);
+    assert!(
+        max_abs < 1e-3,
+        "steel GEMM edge-tile result diverges from composite reference: max_abs = {max_abs}"
+    );
+}

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -368,6 +368,35 @@ impl UnifiedEmbedding {
             Self::Regular(e) => e.weight.as_ref().expect("non-null embedding weight"),
         }
     }
+
+    /// Return a float `[vocab_size, hidden_size]` weight usable as
+    /// `probs @ weight`.
+    ///
+    /// For quantized embeddings this dequantizes the packed table (callers
+    /// should do this once per generation call and reuse the result; for a
+    /// 262144 x 2816 fp16 table the transient is roughly 1.4 GiB). For
+    /// non-quantized embeddings this is a cheap lazy-array share of the
+    /// existing tensor.
+    ///
+    /// Used by: DiffusionGemma self-conditioning soft embeddings (issue #217).
+    /// The reference implementation measured `quantized_matmul(...,
+    /// transpose=false)` several times slower at this shape, hence the
+    /// dequantize-once approach.
+    pub fn dequantized_weight(&self) -> UniquePtr<MlxArray> {
+        match self {
+            Self::Regular(e) => ffi::copy(&e.weight),
+            Self::Quantized(e) => unsafe {
+                ffi::dequantize(
+                    &e.weight,
+                    &e.scales,
+                    e.biases_ptr(),
+                    e.group_size,
+                    e.bits,
+                    &e.mode,
+                )
+            },
+        }
+    }
 }
 
 /// RMS Normalization layer

--- a/src/loaded_model.rs
+++ b/src/loaded_model.rs
@@ -65,6 +65,10 @@ pub enum LoadedModel {
     // Sliding window models use wrappers that implement LanguageModel
     Gemma3(models::Gemma3Wrapper),
     Gemma4(models::Gemma4Wrapper),
+    /// DiffusionGemma block-diffusion text model (issue #217). The CLI
+    /// routes this family to the diffusion engine before the autoregressive
+    /// loop; the server rejects it (phase 3).
+    DiffusionGemma(models::DiffusionGemmaModel),
     // Vision-language models
     Gemma3VLM(vision::VisionLanguageModel),
     Gemma4VLM(vision::Gemma4VLModel),
@@ -174,6 +178,7 @@ macro_rules! delegate_language_model {
             LoadedModel::Gemma2(inner) => LanguageModel::$method(inner, $($arg),*),
             LoadedModel::Gemma3(inner) => LanguageModel::$method(inner, $($arg),*),
             LoadedModel::Gemma4(inner) => LanguageModel::$method(inner, $($arg),*),
+            LoadedModel::DiffusionGemma(inner) => LanguageModel::$method(inner, $($arg),*),
             LoadedModel::Gemma3VLM(inner) => LanguageModel::$method(inner, $($arg),*),
             LoadedModel::Gemma4VLM(inner) => LanguageModel::$method(inner, $($arg),*),
             LoadedModel::Gemma4Unified(inner) => LanguageModel::$method(inner, $($arg),*),

--- a/src/loading/nonstandard.rs
+++ b/src/loading/nonstandard.rs
@@ -47,6 +47,10 @@ pub(crate) fn try_load_nonstandard_model_from_dir(
         ModelType::Gemma3n => {
             Some(load_from_dir(path_str, models::Gemma3nModel::load).map(LoadedModel::Gemma3n)?)
         }
+        ModelType::DiffusionGemma => Some(
+            load_from_path(model_path, |path| models::DiffusionGemmaModel::load(path))
+                .map(LoadedModel::DiffusionGemma)?,
+        ),
         ModelType::Mamba => Some(
             super::load_pair_from_dir(path_str, |path| models::MambaModel::load(&path))
                 .map(LoadedModel::Mamba)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,6 +396,12 @@ pub(crate) struct GenerationOptions {
     // mlxcel serve, mlxcel-server) expose identical help text and flags.
     #[command(flatten)]
     pub(crate) turbo: TurboKvCacheArgs,
+
+    // Block-diffusion flag group (--max-denoising-steps,
+    // --diffusion-sampler, ...). Only affects diffusion models such as
+    // DiffusionGemma; autoregressive models ignore it.
+    #[command(flatten)]
+    pub(crate) diffusion: DiffusionCliOptions,
 }
 
 /// Arguments for the `mlxcel inspect` subcommand.
@@ -515,6 +521,76 @@ pub(crate) struct SamplingOptions {
     /// DRY lookback window size (0 = use full history)
     #[arg(long, default_value_t = 0, value_name = "N")]
     pub(crate) dry_penalty_last_n: usize,
+
+    /// Random seed for MLX's global RNG. Makes sampled generation
+    /// reproducible, including the random canvas noise of diffusion models
+    /// (e.g. DiffusionGemma). Unset = nondeterministic.
+    #[arg(long, value_name = "N")]
+    pub(crate) seed: Option<u64>,
+}
+
+/// Block-diffusion generation options.
+///
+/// These flags only affect diffusion models (e.g. DiffusionGemma); ordinary
+/// autoregressive models ignore them. They mirror the mlx-vlm diffusion
+/// flag surface.
+#[derive(Args, Debug)]
+#[command(next_help_heading = "Diffusion Options")]
+pub(crate) struct DiffusionCliOptions {
+    /// Maximum denoising steps per canvas block (diffusion models only;
+    /// default: the checkpoint's generation_config, typically 48)
+    #[arg(long = "max-denoising-steps", value_name = "N")]
+    pub(crate) max_denoising_steps: Option<usize>,
+
+    /// Per-step acceptance sampler for diffusion models
+    #[arg(
+        long = "diffusion-sampler",
+        value_name = "SAMPLER",
+        default_value = "entropy-bound",
+        value_parser = ["entropy-bound", "confidence-threshold"]
+    )]
+    pub(crate) diffusion_sampler: String,
+
+    /// Confidence threshold for `--diffusion-sampler confidence-threshold`
+    #[arg(
+        long = "diffusion-threshold",
+        value_name = "FLOAT",
+        default_value_t = 0.9
+    )]
+    pub(crate) diffusion_threshold: f32,
+
+    /// Smallest canvas allocated for the generation tail (diffusion only)
+    #[arg(
+        long = "diffusion-min-canvas-length",
+        value_name = "N",
+        default_value_t = 64
+    )]
+    pub(crate) diffusion_min_canvas_length: usize,
+
+    /// Cap on the per-block canvas length (diffusion only; default: the
+    /// model's canvas_length, typically 256)
+    #[arg(long = "diffusion-max-canvas-length", value_name = "N")]
+    pub(crate) diffusion_max_canvas_length: Option<usize>,
+
+    /// Always allocate the model's full canvas length per block (diffusion
+    /// only)
+    #[arg(long = "diffusion-full-canvas", default_value_t = false)]
+    pub(crate) diffusion_full_canvas: bool,
+}
+
+// Manual `Default` kept in lock-step with the `#[arg(default_value*)]`
+// attributes above, same contract as the parallelism option groups.
+impl Default for DiffusionCliOptions {
+    fn default() -> Self {
+        Self {
+            max_denoising_steps: None,
+            diffusion_sampler: "entropy-bound".to_string(),
+            diffusion_threshold: 0.9,
+            diffusion_min_canvas_length: 64,
+            diffusion_max_canvas_length: None,
+            diffusion_full_canvas: false,
+        }
+    }
 }
 
 /// Tensor-parallel options

--- a/src/model_metadata.rs
+++ b/src/model_metadata.rs
@@ -108,6 +108,7 @@ macro_rules! for_each_model_registration {
             Gemma2 => { kind: Text, directory: ConfigBacked, weight: Some(WeightLoadRoute::ConfigBacked), adapter: None, config_backed: { dir_loader: models::Gemma2Model::load, args: models::gemma2::ModelArgs, weight_builder: models::Gemma2Model::from_weights, wrap: LoadedModel::Gemma2 } };
             Gemma3 => { kind: Text, directory: ConfigBacked, weight: Some(WeightLoadRoute::ConfigBacked), adapter: None, config_backed: { dir_loader: models::Gemma3Model::load, args: models::gemma3::ModelArgs, weight_builder: models::Gemma3Model::from_weights, wrap: |m| LoadedModel::Gemma3(models::Gemma3Wrapper::new(m)) } };
             Gemma4 => { kind: Text, directory: ConfigBacked, weight: Some(WeightLoadRoute::ConfigBacked), adapter: None, config_backed: { dir_loader: models::Gemma4Model::load, args: models::gemma4::ModelArgs, weight_builder: models::Gemma4Model::from_weights, wrap: |m| LoadedModel::Gemma4(models::Gemma4Wrapper::new(m)) } };
+            DiffusionGemma => { kind: Text, directory: Nonstandard, weight: None, adapter: Some("DiffusionGemma cannot be loaded with LoRA adapters yet") };
             Gemma3VLM => { kind: Vlm, directory: Vlm, weight: None, adapter: Some("Gemma3 VLM cannot be loaded with LoRA adapters yet") };
             Gemma4VLM => { kind: Vlm, directory: Vlm, weight: None, adapter: Some("Gemma4 VLM cannot be loaded with LoRA adapters yet") };
             Gemma4Unified => { kind: Vlm, directory: Vlm, weight: None, adapter: Some("Gemma4 Unified cannot be loaded with LoRA adapters yet") };

--- a/src/models/detection.rs
+++ b/src/models/detection.rs
@@ -113,6 +113,11 @@ pub fn get_model_type(model_path: &Path) -> Result<ModelType> {
         } else {
             ModelType::Gemma4
         }),
+        // DiffusionGemma (block-diffusion on the Gemma 4 MoE backbone). The
+        // checkpoint always ships a vision tower, but phase 1 is text-only:
+        // the loader skips the vision weights, so detection is by model_type
+        // alone. `diffusion_gemma_text` is accepted for text-only exports.
+        "diffusion_gemma" | "diffusion_gemma_text" => Ok(ModelType::DiffusionGemma),
         // Gemma 4 Unified is always multimodal (text + vision [+ audio]); it
         // carries `vision_embedder.*` patch-projector weights rather than the
         // `vision_tower.*` ViT used by `gemma4`/Gemma4VLM, so it is detected by

--- a/src/models/diffusion_gemma/generate.rs
+++ b/src/models/diffusion_gemma/generate.rs
@@ -583,9 +583,10 @@ impl DiffusionGemmaModel {
         let mut reveal_mask = vec![false; canvas_len];
         let mut draft_canvas = mlxcel_core::copy(&current_canvas);
 
-        // Committed canvas: the argmax canvas of the LAST executed step
-        // (or, for the confidence sampler's all-revealed early exit, the
-        // fully revealed draft canvas).
+        // Committed canvas: the argmax canvas of the LAST executed step in
+        // EVERY exit path, matching the reference (its post-loop
+        // `current_canvas = argmax_canvas` overwrites the confidence
+        // sampler's draft assignment, which is dead code there).
         let mut commit = mlxcel_core::copy(&current_canvas);
 
         for cur_step in (1..=max_denoising_steps).rev() {
@@ -716,8 +717,8 @@ impl DiffusionGemmaModel {
                     }
 
                     if reveal_mask.iter().all(|&r| r) {
-                        // All positions revealed: commit the draft canvas.
-                        commit = mlxcel_core::copy(&draft_canvas);
+                        // All positions revealed: stop denoising. The commit
+                        // stays this step's argmax canvas, like the reference.
                         break;
                     }
 

--- a/src/models/diffusion_gemma/generate.rs
+++ b/src/models/diffusion_gemma/generate.rs
@@ -1,0 +1,762 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Block-diffusion generation engine for DiffusionGemma (issue #217).
+//!
+//! Mirrors `stream_diffusion_generate` in
+//! `references/mlx-vlm/mlx_vlm/generate/diffusion.py` for the batch-1,
+//! no-padding, dynamic-cache CLI case: per block, initialize a random
+//! canvas, denoise it for up to `max_denoising_steps` iterations under a
+//! linear temperature schedule with self-conditioning, accept positions via
+//! the entropy-bound (default) or confidence-threshold sampler, early-stop
+//! on a stable-and-confident canvas, then commit the block to the KV-cached
+//! prefix and stream its tokens.
+
+use super::{DiffusionGemmaModel, DiffusionStoppingConfig};
+use mlxcel_core::layers::KVCache;
+use mlxcel_core::{MlxArray, UniquePtr, dtype};
+use std::collections::VecDeque;
+use std::time::Instant;
+
+/// Default smallest canvas allocated for the tail of a generation.
+pub const DEFAULT_MIN_CANVAS_LENGTH: usize = 64;
+
+/// Default prompt prefill chunk size. Matches the chunked-prefill granularity
+/// the memory-estimation activation model assumes for bounded prefill.
+pub const DEFAULT_PREFILL_CHUNK_SIZE: usize = 512;
+
+/// Which per-step acceptance rule the denoising loop uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffusionSamplerKind {
+    /// Accept the largest low-entropy prefix whose summed entropy stays
+    /// within the checkpoint's `entropy_bound` (default).
+    EntropyBound,
+    /// Reveal positions whose denoiser-token probability clears a fixed
+    /// threshold; revealed positions keep their draft tokens.
+    ConfidenceThreshold,
+}
+
+/// Caller-facing options for one diffusion generation call.
+#[derive(Debug, Clone)]
+pub struct DiffusionGenerateOptions {
+    /// Maximum number of NEW tokens to generate (CLI `-n/--max-tokens`).
+    pub max_new_tokens: usize,
+    /// Denoiser sampling temperature (CLI `--temp`); `<= 0` means argmax.
+    pub temperature: f32,
+    pub sampler: DiffusionSamplerKind,
+    /// Confidence threshold for [`DiffusionSamplerKind::ConfidenceThreshold`].
+    pub confidence_threshold: f32,
+    /// Override for the checkpoint's `max_denoising_steps`.
+    pub max_denoising_steps: Option<usize>,
+    /// Smallest canvas allocated for the generation tail.
+    pub min_canvas_length: usize,
+    /// Optional cap on the per-block canvas length (clamped to the model's
+    /// `canvas_length`).
+    pub max_canvas_length: Option<usize>,
+    /// Always allocate the model's full `canvas_length` per block.
+    pub full_canvas: bool,
+    /// Extra stop ids (tokenizer / template / CLI stop ids) unioned with the
+    /// checkpoint EOS set.
+    pub extra_eos_token_ids: Vec<i32>,
+    /// Prompt prefill chunk size; prompts longer than this are prefilled in
+    /// chunks with the cache evaluated between chunks.
+    pub prefill_chunk_size: usize,
+}
+
+impl Default for DiffusionGenerateOptions {
+    fn default() -> Self {
+        Self {
+            max_new_tokens: 256,
+            temperature: 0.0,
+            sampler: DiffusionSamplerKind::EntropyBound,
+            confidence_threshold: 0.9,
+            max_denoising_steps: None,
+            min_canvas_length: DEFAULT_MIN_CANVAS_LENGTH,
+            max_canvas_length: None,
+            full_canvas: false,
+            extra_eos_token_ids: Vec::new(),
+            prefill_chunk_size: DEFAULT_PREFILL_CHUNK_SIZE,
+        }
+    }
+}
+
+/// Why a diffusion generation ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffusionFinishReason {
+    /// Hit `max_new_tokens`.
+    Length,
+    /// Hit an EOS / stop token.
+    Stop,
+    /// The streaming callback asked to stop.
+    Aborted,
+}
+
+/// Timing and work counters for one diffusion generation call.
+#[derive(Debug, Clone)]
+pub struct DiffusionGenerationStats {
+    pub prompt_tokens: usize,
+    pub prompt_time_s: f64,
+    pub prompt_tps: f64,
+    pub generated_tokens: usize,
+    pub generation_time_s: f64,
+    pub generation_tps: f64,
+    /// Total canvas positions denoised (sum of block canvas lengths).
+    pub canvas_tokens: usize,
+    /// Total denoising forward passes across all blocks.
+    pub denoising_steps: usize,
+    /// Total work = sum over blocks of `canvas_length * steps`.
+    pub work_tokens: usize,
+    pub canvas_tps: f64,
+    pub work_tps: f64,
+    pub blocks: usize,
+    pub finish_reason: DiffusionFinishReason,
+}
+
+// ---------------------------------------------------------------------------
+// Pure host-side helpers (unit-tested without a model)
+// ---------------------------------------------------------------------------
+
+/// Linear denoising temperature schedule:
+/// `tau = t_min + (t_max - t_min) * (cur_step / max_steps)`.
+/// `cur_step` counts DOWN from `max_steps` to 1, so the first iteration runs
+/// near `t_max` and the last near `t_min`.
+pub(crate) fn linear_schedule_temperature(
+    cur_step: usize,
+    max_steps: usize,
+    t_min: f32,
+    t_max: f32,
+) -> f32 {
+    t_min + (t_max - t_min) * (cur_step as f32 / max_steps as f32)
+}
+
+/// Entropy-bound acceptance count over ASCENDING-sorted entropies.
+///
+/// The reference rule `(cumsum - cummax) <= bound` over an ascending
+/// non-negative sequence reduces to "the sum of entropies strictly before
+/// rank `i` is `<= bound`", which is monotone, so acceptance is a prefix.
+/// Returns `max(1, count)` (at least one position is always accepted),
+/// or 0 for an empty input.
+pub(crate) fn entropy_bound_accept_count(sorted_entropies: &[f32], bound: f32) -> usize {
+    if sorted_entropies.is_empty() {
+        return 0;
+    }
+    let mut count = 0usize;
+    let mut prefix = 0.0f32;
+    for &entropy in sorted_entropies {
+        if prefix <= bound {
+            count += 1;
+            prefix += entropy;
+        } else {
+            break;
+        }
+    }
+    count.max(1)
+}
+
+/// Build the boolean acceptance mask for the entropy-bound sampler: accept
+/// the `k` lowest-entropy positions, with `k` from
+/// [`entropy_bound_accept_count`]. Stable ascending order (ties keep the
+/// lower position index, matching `mx.argsort`).
+pub(crate) fn entropy_bound_acceptance_mask(entropies: &[f32], bound: f32) -> Vec<bool> {
+    let mut order: Vec<usize> = (0..entropies.len()).collect();
+    order.sort_by(|&a, &b| {
+        entropies[a]
+            .partial_cmp(&entropies[b])
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let sorted: Vec<f32> = order.iter().map(|&i| entropies[i]).collect();
+    let accept = entropy_bound_accept_count(&sorted, bound);
+    let mut mask = vec![false; entropies.len()];
+    for &position in order.iter().take(accept) {
+        mask[position] = true;
+    }
+    mask
+}
+
+/// Confidence-threshold transfer mask
+/// (`_diffusion_confidence_transfer_mask` in the reference).
+///
+/// Accepts unrevealed positions whose confidence clears `threshold`; when
+/// none clears it but unrevealed positions remain, forces the single
+/// highest-confidence unrevealed position (first index on exact ties,
+/// matching `mx.argmax`). `force_all` accepts every unrevealed position.
+pub(crate) fn confidence_transfer_mask(
+    confidence: &[f32],
+    unrevealed: &[bool],
+    threshold: f32,
+    force_all: bool,
+) -> Vec<bool> {
+    debug_assert_eq!(confidence.len(), unrevealed.len());
+    if force_all {
+        return unrevealed.to_vec();
+    }
+    let mut mask: Vec<bool> = unrevealed
+        .iter()
+        .zip(confidence)
+        .map(|(&u, &c)| u && c >= threshold)
+        .collect();
+    let has_unrevealed = unrevealed.iter().any(|&u| u);
+    if has_unrevealed && !mask.iter().any(|&m| m) {
+        let mut best_index = None;
+        let mut best_confidence = f32::NEG_INFINITY;
+        for (i, (&u, &c)) in unrevealed.iter().zip(confidence).enumerate() {
+            if u && c > best_confidence {
+                best_confidence = c;
+                best_index = Some(i);
+            }
+        }
+        if let Some(i) = best_index {
+            mask[i] = true;
+        }
+    }
+    mask
+}
+
+/// Per-block canvas length rule:
+/// `full_canvas` always allocates the model canvas; otherwise
+/// `min(max_canvas, max(remaining, min_canvas))`.
+pub(crate) fn canvas_length_for(
+    remaining_tokens: usize,
+    min_canvas: usize,
+    max_canvas: usize,
+    model_canvas: usize,
+    full_canvas: bool,
+) -> usize {
+    if full_canvas {
+        model_canvas
+    } else {
+        max_canvas.min(remaining_tokens.max(min_canvas))
+    }
+}
+
+/// Deterministic debug canvas pattern (env `MLXCEL_DIFFUSION_DEBUG_CANVAS=1`):
+/// `token[i] = ((i + 1) * 7919 + k * 104729) % vocab_size`, where `i` is the
+/// 0-based canvas position and `k` the 0-based global randomization-call
+/// counter within one generate invocation.
+pub(crate) fn debug_canvas_pattern(length: usize, vocab_size: i64, k: i64) -> Vec<i32> {
+    (0..length as i64)
+        .map(|i| (((i + 1) * 7919 + k * 104_729) % vocab_size) as i32)
+        .collect()
+}
+
+/// Whether the deterministic debug canvas mode is active.
+pub fn diffusion_debug_canvas_enabled() -> bool {
+    std::env::var("MLXCEL_DIFFUSION_DEBUG_CANVAS")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
+/// Stability tracker mirroring `_diffusion_stable_and_confident`'s history
+/// semantics: the stability verdict is computed against the EXISTING history
+/// (only when it is already full), and the current canvas is appended
+/// afterward (evicting the oldest entry).
+pub(crate) struct StabilityTracker {
+    history: VecDeque<Vec<i32>>,
+    threshold: usize,
+}
+
+impl StabilityTracker {
+    pub(crate) fn new(threshold: usize) -> Self {
+        Self {
+            history: VecDeque::new(),
+            threshold,
+        }
+    }
+
+    /// Record one argmax canvas; returns true when the canvas equals every
+    /// entry of a FULL history (checked BEFORE this canvas is pushed).
+    pub(crate) fn observe(&mut self, canvas: &[i32]) -> bool {
+        let stable = self.history.len() == self.threshold
+            && self.history.iter().all(|previous| previous == canvas);
+        self.history.push_back(canvas.to_vec());
+        if self.history.len() > self.threshold {
+            self.history.pop_front();
+        }
+        stable
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Device <-> host helpers
+// ---------------------------------------------------------------------------
+
+fn to_vec_f32(array: &MlxArray) -> Vec<f32> {
+    mlxcel_core::eval(array);
+    let f32_array = if mlxcel_core::array_dtype(array) == dtype::FLOAT32 {
+        None
+    } else {
+        Some(mlxcel_core::astype(array, dtype::FLOAT32))
+    };
+    let source = f32_array
+        .as_ref()
+        .map(|a| a.as_ref().expect("non-null astype output"))
+        .unwrap_or(array);
+    mlxcel_core::eval(source);
+    mlxcel_core::array_to_raw_bytes(source)
+        .chunks_exact(4)
+        .map(|b| f32::from_ne_bytes(b.try_into().expect("4-byte f32 chunk")))
+        .collect()
+}
+
+fn to_vec_i32(array: &MlxArray) -> Vec<i32> {
+    let i32_array = if mlxcel_core::array_dtype(array) == dtype::INT32 {
+        None
+    } else {
+        Some(mlxcel_core::astype(array, dtype::INT32))
+    };
+    let source = i32_array
+        .as_ref()
+        .map(|a| a.as_ref().expect("non-null astype output"))
+        .unwrap_or(array);
+    mlxcel_core::eval(source);
+    mlxcel_core::array_to_raw_bytes(source)
+        .chunks_exact(4)
+        .map(|b| i32::from_ne_bytes(b.try_into().expect("4-byte i32 chunk")))
+        .collect()
+}
+
+fn bool_mask_array(mask: &[bool]) -> UniquePtr<MlxArray> {
+    let ints: Vec<i32> = mask.iter().map(|&m| i32::from(m)).collect();
+    let arr = mlxcel_core::from_slice_i32(&ints, &[1, ints.len() as i32]);
+    mlxcel_core::astype(&arr, dtype::BOOL)
+}
+
+/// Canvas randomization source. In normal mode draws uniform random ids in
+/// `[0, vocab)` from MLX's global RNG (seedable via `--seed`); in debug mode
+/// (`MLXCEL_DIFFUSION_DEBUG_CANVAS=1`) every call returns the deterministic
+/// pattern from [`debug_canvas_pattern`] with a per-invocation call counter.
+struct CanvasRng {
+    vocab_size: i32,
+    debug: bool,
+    calls: u64,
+}
+
+impl CanvasRng {
+    fn new(vocab_size: i32) -> Self {
+        Self {
+            vocab_size,
+            debug: diffusion_debug_canvas_enabled(),
+            calls: 0,
+        }
+    }
+
+    fn canvas(&mut self, length: usize) -> UniquePtr<MlxArray> {
+        let k = self.calls;
+        self.calls += 1;
+        if self.debug {
+            let ids = debug_canvas_pattern(length, self.vocab_size as i64, k as i64);
+            mlxcel_core::from_slice_i32(&ids, &[1, length as i32])
+        } else {
+            // SAFETY: null key selects MLX's global RNG state.
+            unsafe {
+                mlxcel_core::random_randint(
+                    0,
+                    self.vocab_size,
+                    &[1, length as i32],
+                    dtype::INT32,
+                    std::ptr::null(),
+                )
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+struct DenoiseOutcome {
+    /// Committed canvas ids for this block.
+    commit: UniquePtr<MlxArray>,
+    steps: usize,
+}
+
+impl DiffusionGemmaModel {
+    /// Stream one block-diffusion generation.
+    ///
+    /// `on_token` receives each emitted token id and returns `false` to
+    /// abort. EOS ids stop the generation WITHOUT being emitted. Mirrors
+    /// `stream_diffusion_generate` (batch-1, no padding, dynamic cache).
+    pub fn generate_diffusion_streaming<F: FnMut(i32) -> bool>(
+        &self,
+        prompt_tokens: &[i32],
+        options: &DiffusionGenerateOptions,
+        mut on_token: F,
+    ) -> Result<DiffusionGenerationStats, String> {
+        if prompt_tokens.is_empty() {
+            return Err("DiffusionGemma: prompt must contain at least one token".to_string());
+        }
+        if options.min_canvas_length == 0 {
+            return Err("diffusion min canvas length must be a positive integer".to_string());
+        }
+        if options.max_canvas_length == Some(0) {
+            return Err("diffusion max canvas length must be a positive integer".to_string());
+        }
+        if !(0.0..=1.0).contains(&options.confidence_threshold) {
+            return Err("diffusion threshold must be between 0 and 1".to_string());
+        }
+        if options.prefill_chunk_size == 0 {
+            return Err("prefill chunk size must be a positive integer".to_string());
+        }
+
+        let generation_config = &self.generation_config;
+        let max_denoising_steps = options
+            .max_denoising_steps
+            .unwrap_or(generation_config.max_denoising_steps)
+            .max(1);
+        let model_canvas = self.canvas_length.max(1);
+        let max_canvas = if options.full_canvas {
+            model_canvas
+        } else {
+            model_canvas.min(options.max_canvas_length.unwrap_or(model_canvas))
+        };
+        let min_canvas = max_canvas.min(options.min_canvas_length);
+        let max_new_tokens = options.max_new_tokens.max(1);
+        let vocab_size = self.text.config.vocab_size as i32;
+
+        let mut eos_ids = self.eos_token_ids.clone();
+        for &id in &options.extra_eos_token_ids {
+            if !eos_ids.contains(&id) {
+                eos_ids.push(id);
+            }
+        }
+
+        let mut caches: Vec<KVCache> = self.make_diffusion_caches();
+        let mut rng = CanvasRng::new(vocab_size);
+        let debug_mode = rng.debug;
+
+        // Prompt prefill (chunked for long prompts; batch-1 / no padding
+        // always holds on this path).
+        let prefill_start = Instant::now();
+        if prompt_tokens.len() > options.prefill_chunk_size {
+            for chunk in prompt_tokens.chunks(options.prefill_chunk_size) {
+                let ids = mlxcel_core::from_slice_i32(chunk, &[1, chunk.len() as i32]);
+                let _ = self.forward_encoder(&ids, &mut caches, None);
+                for cache in &caches {
+                    cache.eval_state();
+                }
+                mlxcel_core::clear_memory_cache();
+            }
+        } else {
+            let ids = mlxcel_core::from_slice_i32(prompt_tokens, &[1, prompt_tokens.len() as i32]);
+            let _ = self.forward_encoder(&ids, &mut caches, None);
+            for cache in &caches {
+                cache.eval_state();
+            }
+        }
+        let prompt_time_s = prefill_start.elapsed().as_secs_f64();
+        let generation_start = Instant::now();
+
+        // Float view of the embedding table for self-conditioning soft
+        // embeddings, dequantized ONCE per generate call (the reference
+        // measured quantized_matmul(transpose=false) several times slower).
+        let soft_embedding_table = self.text.embed_tokens.dequantized_weight();
+        let table_dtype = mlxcel_core::array_dtype(&soft_embedding_table);
+
+        let mut generated_tokens = 0usize;
+        let mut canvas_tokens = 0usize;
+        let mut denoising_steps = 0usize;
+        let mut work_tokens = 0usize;
+        let mut blocks = 0usize;
+        let mut stopped = false;
+        let mut finish_reason = DiffusionFinishReason::Length;
+        let mut pending_commit: Option<UniquePtr<MlxArray>> = None;
+
+        while generated_tokens < max_new_tokens && !stopped {
+            // Append the previous block's FULL committed canvas to the
+            // KV-cached prefix before denoising the next block.
+            if let Some(previous) = pending_commit.take() {
+                let _ = self.forward_encoder(&previous, &mut caches, None);
+            }
+
+            let remaining = max_new_tokens - generated_tokens;
+            let canvas_len = canvas_length_for(
+                remaining,
+                min_canvas,
+                max_canvas,
+                model_canvas,
+                options.full_canvas,
+            );
+
+            let outcome = self.denoise_block(
+                &caches,
+                canvas_len,
+                max_denoising_steps,
+                options,
+                &soft_embedding_table,
+                table_dtype,
+                &mut rng,
+            )?;
+            canvas_tokens += canvas_len;
+            denoising_steps += outcome.steps;
+            work_tokens += canvas_len * outcome.steps;
+
+            mlxcel_core::eval(&outcome.commit);
+            let commit_ids = to_vec_i32(&outcome.commit);
+            if debug_mode {
+                let rendered: Vec<String> = commit_ids.iter().map(|id| id.to_string()).collect();
+                eprintln!(
+                    "DIFFUSION_COMMIT block={} ids={}",
+                    blocks,
+                    rendered.join(",")
+                );
+            }
+            blocks += 1;
+
+            for &token_id in &commit_ids {
+                generated_tokens += 1;
+                if eos_ids.contains(&token_id) {
+                    stopped = true;
+                    finish_reason = DiffusionFinishReason::Stop;
+                    break;
+                }
+                if !on_token(token_id) {
+                    stopped = true;
+                    finish_reason = DiffusionFinishReason::Aborted;
+                    break;
+                }
+                if generated_tokens >= max_new_tokens {
+                    stopped = true;
+                    finish_reason = DiffusionFinishReason::Length;
+                    break;
+                }
+            }
+
+            if !stopped {
+                pending_commit = Some(outcome.commit);
+                mlxcel_core::clear_memory_cache();
+            }
+        }
+
+        let generation_time_s = generation_start.elapsed().as_secs_f64().max(1e-9);
+        Ok(DiffusionGenerationStats {
+            prompt_tokens: prompt_tokens.len(),
+            prompt_time_s,
+            prompt_tps: prompt_tokens.len() as f64 / prompt_time_s.max(1e-9),
+            generated_tokens,
+            generation_time_s,
+            generation_tps: generated_tokens as f64 / generation_time_s,
+            canvas_tokens,
+            denoising_steps,
+            work_tokens,
+            canvas_tps: canvas_tokens as f64 / generation_time_s,
+            work_tps: work_tokens as f64 / generation_time_s,
+            blocks,
+            finish_reason,
+        })
+    }
+
+    /// Denoise one canvas block. Returns the committed canvas ids and the
+    /// number of denoising forward passes executed.
+    #[allow(clippy::too_many_arguments)]
+    fn denoise_block(
+        &self,
+        caches: &[KVCache],
+        canvas_len: usize,
+        max_denoising_steps: usize,
+        options: &DiffusionGenerateOptions,
+        soft_embedding_table: &MlxArray,
+        table_dtype: i32,
+        rng: &mut CanvasRng,
+    ) -> Result<DenoiseOutcome, String> {
+        let generation_config = &self.generation_config;
+        let entropy_bound = generation_config.entropy_bound;
+        let stopping: Option<DiffusionStoppingConfig> = generation_config.stopping;
+        let mut tracker = stopping.map(|s| StabilityTracker::new(s.stability_threshold));
+
+        let mut current_canvas = rng.canvas(canvas_len);
+        let mut self_conditioning: Option<UniquePtr<MlxArray>> = None;
+        let mut steps = 0usize;
+
+        // Confidence-threshold sampler state.
+        let mut reveal_mask = vec![false; canvas_len];
+        let mut draft_canvas = mlxcel_core::copy(&current_canvas);
+
+        // Committed canvas: the argmax canvas of the LAST executed step
+        // (or, for the confidence sampler's all-revealed early exit, the
+        // fully revealed draft canvas).
+        let mut commit = mlxcel_core::copy(&current_canvas);
+
+        for cur_step in (1..=max_denoising_steps).rev() {
+            steps += 1;
+            let self_conditioning_ref = self_conditioning
+                .as_ref()
+                .map(|sc| sc.as_ref().expect("non-null self-conditioning embeddings"));
+            let logits = self.forward_canvas(&current_canvas, caches, self_conditioning_ref);
+            let logits = mlxcel_core::astype(&logits, dtype::FLOAT32);
+            let tau = linear_schedule_temperature(
+                cur_step,
+                max_denoising_steps,
+                generation_config.t_min,
+                generation_config.t_max,
+            );
+            let logits = mlxcel_core::multiply_scalar(&logits, 1.0 / tau);
+
+            let argmax_canvas =
+                mlxcel_core::astype(&mlxcel_core::argmax(&logits, -1, false), dtype::INT32);
+            commit = mlxcel_core::copy(&argmax_canvas);
+            if cur_step == 1 {
+                break;
+            }
+
+            let denoiser_canvas = if options.temperature <= 0.0 {
+                mlxcel_core::copy(&argmax_canvas)
+            } else {
+                let sampling_logits = if options.temperature != 1.0 {
+                    mlxcel_core::multiply_scalar(&logits, 1.0 / options.temperature)
+                } else {
+                    mlxcel_core::copy(&logits)
+                };
+                mlxcel_core::astype(
+                    &mlxcel_core::random_categorical(&sampling_logits, -1),
+                    dtype::INT32,
+                )
+            };
+
+            match options.sampler {
+                DiffusionSamplerKind::EntropyBound => {
+                    // probs / entropy / soft-embedding chain over the
+                    // schedule-divided f32 logits.
+                    let log_probs = mlxcel_core::subtract(
+                        &logits,
+                        &mlxcel_core::logsumexp_axis(&logits, -1, true),
+                    );
+                    let probs = mlxcel_core::exp(&log_probs);
+                    let entropy = mlxcel_core::negative(&mlxcel_core::sum_axis(
+                        &mlxcel_core::multiply(&probs, &log_probs),
+                        -1,
+                        false,
+                    ));
+                    let soft_embeddings = mlxcel_core::multiply_scalar(
+                        &mlxcel_core::matmul(
+                            &mlxcel_core::astype(&probs, table_dtype),
+                            soft_embedding_table,
+                        ),
+                        self.embed_scale,
+                    );
+
+                    let entropy_host = to_vec_f32(&entropy);
+                    let acceptance = entropy_bound_acceptance_mask(&entropy_host, entropy_bound);
+                    let condition = bool_mask_array(&acceptance);
+                    let accepted_canvas =
+                        mlxcel_core::where_cond(&condition, &denoiser_canvas, &current_canvas);
+                    let fresh = rng.canvas(canvas_len);
+                    current_canvas = mlxcel_core::where_cond(&condition, &accepted_canvas, &fresh);
+
+                    // Early stop: stable argmax history AND low mean entropy.
+                    if let (Some(tracker), Some(stop)) = (tracker.as_mut(), stopping.as_ref()) {
+                        let argmax_host = to_vec_i32(&argmax_canvas);
+                        if tracker.observe(&argmax_host) {
+                            let mean_entropy = entropy_host.iter().map(|&e| e as f64).sum::<f64>()
+                                / entropy_host.len().max(1) as f64;
+                            if mean_entropy < f64::from(stop.confidence_threshold) {
+                                break;
+                            }
+                        }
+                    }
+
+                    self_conditioning = Some(soft_embeddings);
+                }
+                DiffusionSamplerKind::ConfidenceThreshold => {
+                    // confidence = probability of the denoiser token.
+                    let token_logits = mlxcel_core::squeeze_axis(
+                        &mlxcel_core::take_along_axis(
+                            &logits,
+                            &mlxcel_core::expand_dims(&denoiser_canvas, -1),
+                            -1,
+                        ),
+                        -1,
+                    );
+                    let confidence = mlxcel_core::exp(&mlxcel_core::subtract(
+                        &token_logits,
+                        &mlxcel_core::logsumexp_axis(&logits, -1, false),
+                    ));
+                    let confidence_host = to_vec_f32(&confidence);
+                    let unrevealed: Vec<bool> = reveal_mask.iter().map(|&r| !r).collect();
+                    let transfer = confidence_transfer_mask(
+                        &confidence_host,
+                        &unrevealed,
+                        options.confidence_threshold,
+                        false,
+                    );
+
+                    let transfer_condition = bool_mask_array(&transfer);
+                    let accepted_canvas = mlxcel_core::where_cond(
+                        &transfer_condition,
+                        &denoiser_canvas,
+                        &draft_canvas,
+                    );
+                    let keep: Vec<bool> = reveal_mask
+                        .iter()
+                        .zip(&transfer)
+                        .map(|(&r, &t)| r || t)
+                        .collect();
+                    let keep_condition = bool_mask_array(&keep);
+                    let fresh = rng.canvas(canvas_len);
+                    current_canvas =
+                        mlxcel_core::where_cond(&keep_condition, &accepted_canvas, &fresh);
+                    draft_canvas = mlxcel_core::where_cond(
+                        &transfer_condition,
+                        &accepted_canvas,
+                        &draft_canvas,
+                    );
+                    for (revealed, &t) in reveal_mask.iter_mut().zip(&transfer) {
+                        *revealed = *revealed || t;
+                    }
+
+                    if reveal_mask.iter().all(|&r| r) {
+                        // All positions revealed: commit the draft canvas.
+                        commit = mlxcel_core::copy(&draft_canvas);
+                        break;
+                    }
+
+                    if let (Some(tracker), Some(stop)) = (tracker.as_mut(), stopping.as_ref()) {
+                        let argmax_host = to_vec_i32(&argmax_canvas);
+                        if tracker.observe(&argmax_host) {
+                            let log_probs = mlxcel_core::subtract(
+                                &logits,
+                                &mlxcel_core::logsumexp_axis(&logits, -1, true),
+                            );
+                            let probs = mlxcel_core::exp(&log_probs);
+                            let entropy = mlxcel_core::negative(&mlxcel_core::sum_axis(
+                                &mlxcel_core::multiply(&probs, &log_probs),
+                                -1,
+                                false,
+                            ));
+                            let mean_entropy =
+                                mlxcel_core::item_f32(&mlxcel_core::mean_all(&entropy));
+                            if f64::from(mean_entropy) < f64::from(stop.confidence_threshold) {
+                                break;
+                            }
+                        }
+                    }
+
+                    // Self-conditioning for the next step (the confidence
+                    // branch computes it from the same schedule-divided
+                    // logits via precise softmax).
+                    let probs = mlxcel_core::softmax_precise(&logits, -1);
+                    self_conditioning = Some(mlxcel_core::multiply_scalar(
+                        &mlxcel_core::matmul(
+                            &mlxcel_core::astype(&probs, table_dtype),
+                            soft_embedding_table,
+                        ),
+                        self.embed_scale,
+                    ));
+                }
+            }
+        }
+
+        Ok(DenoiseOutcome { commit, steps })
+    }
+}

--- a/src/models/diffusion_gemma/generate.rs
+++ b/src/models/diffusion_gemma/generate.rs
@@ -170,11 +170,11 @@ pub(crate) fn entropy_bound_accept_count(sorted_entropies: &[f32], bound: f32) -
 /// lower position index, matching `mx.argsort`).
 pub(crate) fn entropy_bound_acceptance_mask(entropies: &[f32], bound: f32) -> Vec<bool> {
     let mut order: Vec<usize> = (0..entropies.len()).collect();
-    order.sort_by(|&a, &b| {
-        entropies[a]
-            .partial_cmp(&entropies[b])
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    // `total_cmp` is a total order, so the stable sort never sees an
+    // inconsistent comparator (a NaN entropy would make `partial_cmp` return
+    // `None`); NaN sorts last and is therefore never accepted, which is the
+    // desired behavior for a maximally uncertain position.
+    order.sort_by(|&a, &b| entropies[a].total_cmp(&entropies[b]));
     let sorted: Vec<f32> = order.iter().map(|&i| entropies[i]).collect();
     let accept = entropy_bound_accept_count(&sorted, bound);
     let mut mask = vec![false; entropies.len()];

--- a/src/models/diffusion_gemma/mod.rs
+++ b/src/models/diffusion_gemma/mod.rs
@@ -258,6 +258,14 @@ impl ModelArgs {
 /// Affine quantization is per-output-row (weight `[E, out, packed_in]`,
 /// scales/biases `[E, out, in / group_size]`), so this split is numerically
 /// exact for the packed weight, scales, and biases alike.
+///
+/// The split is performed on HOST bytes, building pristine dense arrays via
+/// `from_bytes`. The obvious `slice` + `copy` graph route produces arrays
+/// that `gather_qmm` reads incorrectly on the pinned MLX (out-of-bounds
+/// style corruption that turns nondeterministic under allocator churn);
+/// gather_qmm with byte-identical rebuilt buffers is deterministic, so the
+/// host-side rebuild is load-bearing, not an optimization. This runs once
+/// per layer at load time.
 pub(crate) fn split_gate_up_tensor(
     tensor: &MlxArray,
     moe_dim: i32,
@@ -276,11 +284,54 @@ pub(crate) fn split_gate_up_tensor(
             2 * moe_dim
         ));
     }
-    let gate = mlxcel_core::slice(tensor, &[0, 0, 0], &[shape[0], moe_dim, shape[2]]);
-    let up = mlxcel_core::slice(tensor, &[0, moe_dim, 0], &[shape[0], 2 * moe_dim, shape[2]]);
-    // Materialize contiguous copies so the downstream gather_qmm sees plain
-    // row-major expert tensors rather than strided views.
-    Ok((mlxcel_core::copy(&gate), mlxcel_core::copy(&up)))
+    let dtype = mlxcel_core::array_dtype(tensor);
+    let element_size = match dtype {
+        d if d == dtype::UINT32 || d == dtype::INT32 || d == dtype::FLOAT32 => 4usize,
+        d if d == dtype::FLOAT16 || d == dtype::BFLOAT16 => 2usize,
+        other => {
+            return Err(format!(
+                "DiffusionGemma: unsupported fused gate_up dtype {other}"
+            ));
+        }
+    };
+    mlxcel_core::eval(tensor);
+    let bytes = mlxcel_core::array_to_raw_bytes(tensor);
+    let (num_experts, fused_rows, cols) = (shape[0] as usize, shape[1] as usize, shape[2] as usize);
+    let half_rows = moe_dim as usize;
+    let row_bytes = cols * element_size;
+    let expected = num_experts * fused_rows * row_bytes;
+    if bytes.len() != expected {
+        return Err(format!(
+            "DiffusionGemma: fused gate_up byte size mismatch (got {}, expected {expected})",
+            bytes.len()
+        ));
+    }
+    let half_bytes = half_rows * row_bytes;
+    let mut gate_bytes = Vec::with_capacity(num_experts * half_bytes);
+    let mut up_bytes = Vec::with_capacity(num_experts * half_bytes);
+    for expert in 0..num_experts {
+        let base = expert * fused_rows * row_bytes;
+        gate_bytes.extend_from_slice(&bytes[base..base + half_bytes]);
+        up_bytes.extend_from_slice(&bytes[base + half_bytes..base + 2 * half_bytes]);
+    }
+    let half_shape = [shape[0], moe_dim, shape[2]];
+    // 16-bit dtypes must go through the f16 constructor: the generic
+    // `from_bytes` path reads half the bytes for them (see
+    // `from_bytes_f16` docs / the #125 serde corruption fix).
+    let build = |data: &[u8]| -> UniquePtr<MlxArray> {
+        if dtype == dtype::BFLOAT16 {
+            mlxcel_core::from_bytes_f16(data, &half_shape, true)
+        } else if dtype == dtype::FLOAT16 {
+            mlxcel_core::from_bytes_f16(data, &half_shape, false)
+        } else {
+            mlxcel_core::from_bytes(data, &half_shape, dtype)
+        }
+    };
+    let gate = build(&gate_bytes);
+    let up = build(&up_bytes);
+    mlxcel_core::eval(&gate);
+    mlxcel_core::eval(&up);
+    Ok((gate, up))
 }
 
 /// Rewrite the checkpoint's fused expert tensors onto the key layout

--- a/src/models/diffusion_gemma/mod.rs
+++ b/src/models/diffusion_gemma/mod.rs
@@ -1,0 +1,669 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! DiffusionGemma block-diffusion text model (issue #217, phase 1).
+//!
+//! `google/diffusiongemma-26B-A4B-it` reuses the Gemma 4 26B-A4B MoE text
+//! backbone but generates by denoising a canvas of up to `canvas_length`
+//! tokens per block instead of autoregressive decoding. This module composes
+//! the existing [`crate::models::gemma4`] building blocks:
+//!
+//! * Encoder mode (prompt prefill + committed-block append): the standard
+//!   causal Gemma 4 forward writing dense Fp16 KV caches, with each layer's
+//!   output scalar taken from the checkpoint's per-layer ENCODER scalars.
+//! * Canvas (decoder) mode: the noisy canvas attends bidirectionally within
+//!   itself and to the cached encoder prefix (read-only), preceded by the
+//!   self-conditioning GeGLU module.
+//! * The block-diffusion generation engine lives in [`generate`].
+//!
+//! Reference: `references/mlx-vlm/mlx_vlm/models/diffusion_gemma/` and
+//! `references/mlx-vlm/mlx_vlm/generate/diffusion.py`.
+//!
+//! Phase 1 is text-only: the checkpoint's vision tower
+//! (`model.encoder.vision_tower.*`, `model.encoder.embed_vision.*`) is
+//! intentionally skipped at load time. Image input is phase 2; server
+//! serving is phase 3.
+
+mod generate;
+
+pub use generate::{
+    DiffusionGenerateOptions, DiffusionGenerationStats, DiffusionSamplerKind,
+    diffusion_debug_canvas_enabled,
+};
+
+use crate::models::gemma4::{
+    Gemma4TextModel, QuantizationArgs, RMSNormNoScale, RootQuantization, TextConfig, parse_eos_ids,
+};
+use mlxcel_core::generate::LanguageModel;
+use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedLinear};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr, dtype};
+use serde::Deserialize;
+use std::path::Path;
+
+/// Default EOS ids for the DiffusionGemma chat checkpoints (same set as
+/// Gemma 4: `<eos>`, `<end_of_turn>`, and the tool-call terminator).
+const DEFAULT_EOS_TOKEN_IDS: [i32; 3] = [1, 106, 50];
+
+/// Default canvas length when `config.json` omits `canvas_length`.
+const DEFAULT_CANVAS_LENGTH: usize = 256;
+
+// ---------------------------------------------------------------------------
+// Config parsing
+// ---------------------------------------------------------------------------
+
+/// Embedded `generation_config.sampler_config` object.
+#[derive(Debug, Clone, Deserialize)]
+struct SamplerConfigRaw {
+    #[serde(rename = "_cls_name", default)]
+    cls_name: Option<String>,
+    #[serde(default)]
+    entropy_bound: Option<f32>,
+}
+
+/// Raw embedded `generation_config` object inside `config.json`.
+#[derive(Debug, Clone, Default, Deserialize)]
+struct GenerationConfigRaw {
+    #[serde(default)]
+    confidence_threshold: Option<f32>,
+    #[serde(default)]
+    stability_threshold: Option<usize>,
+    #[serde(default)]
+    max_denoising_steps: Option<usize>,
+    #[serde(default)]
+    max_new_tokens: Option<usize>,
+    #[serde(default)]
+    t_min: Option<f32>,
+    #[serde(default)]
+    t_max: Option<f32>,
+    #[serde(default)]
+    sampler_config: Option<SamplerConfigRaw>,
+    #[serde(default)]
+    eos_token_id: Option<serde_json::Value>,
+}
+
+/// Early-stopping knobs (`_diffusion_stable_and_confident` in the
+/// reference). Present only when the checkpoint's `generation_config`
+/// carries at least one of the two keys; absent means no early stop.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DiffusionStoppingConfig {
+    /// Mean per-position entropy must fall below this for an early stop.
+    pub confidence_threshold: f32,
+    /// Number of consecutive identical argmax canvases required.
+    pub stability_threshold: usize,
+}
+
+/// Resolved generation configuration parsed from `config.json`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiffusionGenerationConfig {
+    pub max_denoising_steps: usize,
+    pub max_new_tokens: usize,
+    pub t_min: f32,
+    pub t_max: f32,
+    pub entropy_bound: f32,
+    pub stopping: Option<DiffusionStoppingConfig>,
+    pub eos_token_ids: Vec<i32>,
+}
+
+impl Default for DiffusionGenerationConfig {
+    fn default() -> Self {
+        Self {
+            max_denoising_steps: 48,
+            max_new_tokens: 256,
+            t_min: 0.4,
+            t_max: 0.8,
+            entropy_bound: 0.1,
+            stopping: None,
+            eos_token_ids: Vec::new(),
+        }
+    }
+}
+
+impl DiffusionGenerationConfig {
+    fn from_raw(raw: &GenerationConfigRaw) -> Result<Self, String> {
+        if let Some(sampler) = &raw.sampler_config
+            && let Some(name) = sampler.cls_name.as_deref()
+            && name != "EntropyBoundSamplerConfig"
+        {
+            return Err(format!(
+                "DiffusionGemma: unsupported sampler_config._cls_name {name:?} \
+                 (only EntropyBoundSamplerConfig is supported)"
+            ));
+        }
+        let stopping = if raw.confidence_threshold.is_some() || raw.stability_threshold.is_some() {
+            Some(DiffusionStoppingConfig {
+                confidence_threshold: raw.confidence_threshold.unwrap_or(0.005),
+                stability_threshold: raw.stability_threshold.unwrap_or(1),
+            })
+        } else {
+            None
+        };
+        Ok(Self {
+            max_denoising_steps: raw.max_denoising_steps.unwrap_or(48),
+            max_new_tokens: raw.max_new_tokens.unwrap_or(256),
+            t_min: raw.t_min.unwrap_or(0.4),
+            t_max: raw.t_max.unwrap_or(0.8),
+            entropy_bound: raw
+                .sampler_config
+                .as_ref()
+                .and_then(|s| s.entropy_bound)
+                .unwrap_or(0.1),
+            stopping,
+            eos_token_ids: parse_eos_ids(raw.eos_token_id.as_ref()),
+        })
+    }
+}
+
+/// Top-level `config.json` arguments for `model_type == "diffusion_gemma"`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelArgs {
+    pub model_type: String,
+    pub text_config: serde_json::Value,
+    #[serde(default)]
+    pub canvas_length: Option<usize>,
+    #[serde(default)]
+    pub eos_token_id: Option<serde_json::Value>,
+    #[serde(default)]
+    generation_config: Option<GenerationConfigRaw>,
+    #[serde(default)]
+    pub quantization: Option<RootQuantization>,
+}
+
+impl ModelArgs {
+    /// Parse and normalize the nested `text_config` into a Gemma 4
+    /// [`TextConfig`].
+    ///
+    /// The DiffusionGemma `text_config` is shape-identical to
+    /// `gemma-4-26b-a4b-it` but OMITS the presence-only flags that
+    /// checkpoint sets, so the serde defaults would silently disable two
+    /// structural features the weights require:
+    ///
+    /// * `attention_k_eq_v = true`: the 5 full-attention layers carry no
+    ///   `v_proj` weights (values are the RMSNormNoScale of the raw K
+    ///   projection), exactly like the upstream reference's
+    ///   `v_proj = None if not sliding` construction.
+    /// * `enable_moe_block = true`: every layer has the dual dense-MLP +
+    ///   MoE feed-forward.
+    ///
+    /// Both are forced here after parsing. The KV-sharing / per-layer-input
+    /// E-series features are explicitly zeroed because DiffusionGemma never
+    /// uses them.
+    pub fn text_args(&self) -> Result<TextConfig, String> {
+        let mut config: TextConfig = serde_json::from_value(self.text_config.clone())
+            .map_err(|e| format!("DiffusionGemma: failed to parse text_config: {e}"))?;
+        config.attention_k_eq_v = true;
+        config.enable_moe_block = true;
+        config.num_kv_shared_layers = 0;
+        config.use_double_wide_mlp = false;
+        config.vocab_size_per_layer_input = 0;
+        config.hidden_size_per_layer_input = 0;
+        if config.quantization.is_none()
+            && let Some(ref q) = self.quantization
+        {
+            config.quantization = Some(QuantizationArgs {
+                group_size: q.group_size,
+                bits: q.bits,
+            });
+        }
+        Ok(config)
+    }
+
+    pub fn generation_config(&self) -> Result<DiffusionGenerationConfig, String> {
+        match &self.generation_config {
+            Some(raw) => DiffusionGenerationConfig::from_raw(raw),
+            None => Ok(DiffusionGenerationConfig::default()),
+        }
+    }
+
+    pub fn canvas_length(&self) -> usize {
+        self.canvas_length.unwrap_or(DEFAULT_CANVAS_LENGTH)
+    }
+
+    /// EOS ids: union of the top-level `eos_token_id`, the embedded
+    /// generation_config `eos_token_id`, and the Gemma 4 defaults.
+    pub fn eos_token_ids(&self, generation: &DiffusionGenerationConfig) -> Vec<i32> {
+        let mut ids = parse_eos_ids(self.eos_token_id.as_ref());
+        for &id in &generation.eos_token_ids {
+            if !ids.contains(&id) {
+                ids.push(id);
+            }
+        }
+        if ids.is_empty() {
+            ids.extend_from_slice(&DEFAULT_EOS_TOKEN_IDS);
+        }
+        ids
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Weight remapping (fused gate_up experts -> gemma4 SwitchGeGLU layout)
+// ---------------------------------------------------------------------------
+
+/// Split a fused `gate_up` expert tensor `[num_experts, 2 * moe_dim, K]`
+/// along the OUTPUT axis into `(gate, up)` halves of `[num_experts, moe_dim,
+/// K]` each (gate first, then up, matching the reference
+/// `gate = gate_up[..., :moe]; up = gate_up[..., moe:]`).
+///
+/// Affine quantization is per-output-row (weight `[E, out, packed_in]`,
+/// scales/biases `[E, out, in / group_size]`), so this split is numerically
+/// exact for the packed weight, scales, and biases alike.
+pub(crate) fn split_gate_up_tensor(
+    tensor: &MlxArray,
+    moe_dim: i32,
+) -> Result<(UniquePtr<MlxArray>, UniquePtr<MlxArray>), String> {
+    let shape = mlxcel_core::array_shape(tensor);
+    if shape.len() != 3 {
+        return Err(format!(
+            "DiffusionGemma: fused gate_up tensor must be rank 3, got shape {shape:?}"
+        ));
+    }
+    if shape[1] != 2 * moe_dim {
+        return Err(format!(
+            "DiffusionGemma: fused gate_up output dim {} does not match 2 * moe_intermediate_size \
+             ({})",
+            shape[1],
+            2 * moe_dim
+        ));
+    }
+    let gate = mlxcel_core::slice(tensor, &[0, 0, 0], &[shape[0], moe_dim, shape[2]]);
+    let up = mlxcel_core::slice(tensor, &[0, moe_dim, 0], &[shape[0], 2 * moe_dim, shape[2]]);
+    // Materialize contiguous copies so the downstream gather_qmm sees plain
+    // row-major expert tensors rather than strided views.
+    Ok((mlxcel_core::copy(&gate), mlxcel_core::copy(&up)))
+}
+
+/// Rewrite the checkpoint's fused expert tensors onto the key layout
+/// `gemma4::Experts::from_weights` expects:
+///
+/// * `…experts.gate_up_proj.{weight,scales,biases}` is split along the
+///   output axis into `…experts.switch_glu.gate_proj.*` (rows `0..moe`) and
+///   `…experts.switch_glu.up_proj.*` (rows `moe..2*moe`).
+/// * `…experts.down_proj.*` is aliased to `…experts.switch_glu.down_proj.*`.
+fn remap_fused_expert_weights(
+    weights: &mut WeightMap,
+    num_layers: usize,
+    moe_dim: i32,
+) -> Result<(), String> {
+    for layer_idx in 0..num_layers {
+        let prefix = format!("model.decoder.layers.{layer_idx}.experts");
+        for suffix in ["weight", "scales", "biases"] {
+            let fused_key = format!("{prefix}.gate_up_proj.{suffix}");
+            if let Some(fused) = weights.remove(&fused_key) {
+                let (gate, up) = split_gate_up_tensor(&fused, moe_dim)
+                    .map_err(|e| format!("{e} (key: {fused_key})"))?;
+                weights.insert(format!("{prefix}.switch_glu.gate_proj.{suffix}"), gate);
+                weights.insert(format!("{prefix}.switch_glu.up_proj.{suffix}"), up);
+            }
+            let down_key = format!("{prefix}.down_proj.{suffix}");
+            if let Some(down) = weights.remove(&down_key) {
+                weights.insert(format!("{prefix}.switch_glu.down_proj.{suffix}"), down);
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Self-conditioning module
+// ---------------------------------------------------------------------------
+
+/// Self-conditioning GeGLU MLP (`model.decoder.self_conditioning.*`).
+///
+/// Mirrors `diffusion_gemma.language.SelfConditioning`:
+/// `signal = down_proj(gelu_approx(gate_proj(pre_norm(s))) * up_proj(pre_norm(s)))`
+/// and `output = RMSNormNoScale(inputs_embeds + signal)`.
+///
+/// The post-norm applies even when the soft-embedding signal is absent: a
+/// zero signal yields exactly `down_proj(gelu_approx(0) * 0) == 0` (no bias
+/// terms anywhere in the chain), so the `None` fast path skips the MLP but
+/// still normalizes.
+pub(crate) struct SelfConditioning {
+    pre_norm: RMSNorm,
+    post_norm: RMSNormNoScale,
+    gate_proj: UnifiedLinear,
+    up_proj: UnifiedLinear,
+    down_proj: UnifiedLinear,
+}
+
+impl SelfConditioning {
+    fn from_weights(
+        weights: &WeightMap,
+        config: &TextConfig,
+        prefix: &str,
+    ) -> Result<Self, String> {
+        let pre_norm_key = format!("{prefix}.pre_norm.weight");
+        let pre_norm_weight = weights
+            .get(&pre_norm_key)
+            .map(|w| mlxcel_core::copy(w))
+            .ok_or_else(|| format!("Weight not found: {pre_norm_key}"))?;
+        let group_size = config
+            .quantization
+            .as_ref()
+            .map(|q| q.group_size as i32)
+            .unwrap_or(64);
+        let bits = config
+            .quantization
+            .as_ref()
+            .map(|q| q.bits as i32)
+            .unwrap_or(4);
+        Ok(Self {
+            pre_norm: RMSNorm::new(pre_norm_weight, config.rms_norm_eps),
+            post_norm: RMSNormNoScale::new(config.hidden_size as i32, config.rms_norm_eps),
+            gate_proj: UnifiedLinear::from_weights(
+                weights,
+                &format!("{prefix}.gate_proj"),
+                group_size,
+                bits,
+            )?,
+            up_proj: UnifiedLinear::from_weights(
+                weights,
+                &format!("{prefix}.up_proj"),
+                group_size,
+                bits,
+            )?,
+            down_proj: UnifiedLinear::from_weights(
+                weights,
+                &format!("{prefix}.down_proj"),
+                group_size,
+                bits,
+            )?,
+        })
+    }
+
+    pub(crate) fn forward(
+        &self,
+        inputs_embeds: &MlxArray,
+        soft_embeddings: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        match soft_embeddings {
+            None => self.post_norm.forward(inputs_embeds),
+            Some(soft) => {
+                let soft = mlxcel_core::astype(soft, mlxcel_core::array_dtype(inputs_embeds));
+                let normed = self.pre_norm.forward(&soft);
+                let gate = self.gate_proj.forward(&normed);
+                let up = self.up_proj.forward(&normed);
+                let activated = mlxcel_core::compiled_geglu_approx_activation(&gate, &up);
+                let signal = self.down_proj.forward(&activated);
+                self.post_norm
+                    .forward(&mlxcel_core::add(inputs_embeds, &signal))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Model
+// ---------------------------------------------------------------------------
+
+/// DiffusionGemma block-diffusion text model.
+pub struct DiffusionGemmaModel {
+    pub(crate) text: Gemma4TextModel,
+    pub(crate) self_conditioning: SelfConditioning,
+    /// Per-layer ENCODER output scalars
+    /// (`model.encoder.language_model.layers.N.layer_scalar`).
+    pub(crate) encoder_layer_scalars: Vec<UniquePtr<MlxArray>>,
+    pub(crate) canvas_length: usize,
+    pub(crate) generation_config: DiffusionGenerationConfig,
+    pub(crate) eos_token_ids: Vec<i32>,
+    pub(crate) embed_scale: f32,
+    _weight_backing: super::sanitize::Gemma4WeightBacking,
+}
+
+impl DiffusionGemmaModel {
+    pub fn load<P: AsRef<Path>>(model_dir: P) -> Result<Self, String> {
+        let model_dir = model_dir.as_ref();
+        let config_path = model_dir.join("config.json");
+        let config_str = std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("Failed to read config.json: {e}"))?;
+        let config_str = crate::models::sanitize_config_json(&config_str);
+        let args: ModelArgs = serde_json::from_str(&config_str)
+            .map_err(|e| format!("Failed to parse config.json: {e}"))?;
+
+        let (mut weights, weight_backing) =
+            super::sanitize::load_diffusion_gemma_text_weights_with_backing(model_dir)?;
+        let mut model = Self::from_weights(&mut weights, &args)?;
+        model._weight_backing = weight_backing;
+        Ok(model)
+    }
+
+    /// Build the model from an already-loaded (and ownable) weight map.
+    ///
+    /// Takes `&mut` because the fused expert tensors are remapped in place
+    /// onto the gemma4 SwitchGeGLU key layout before construction.
+    pub fn from_weights(weights: &mut WeightMap, args: &ModelArgs) -> Result<Self, String> {
+        let config = args.text_args()?;
+        let moe_dim = config.moe_intermediate_size.ok_or_else(|| {
+            "DiffusionGemma: text_config.moe_intermediate_size is required".to_string()
+        })? as i32;
+        remap_fused_expert_weights(weights, config.num_hidden_layers, moe_dim)?;
+
+        let text = Gemma4TextModel::from_weights(weights, &config, "model.decoder")?;
+        let self_conditioning =
+            SelfConditioning::from_weights(weights, &config, "model.decoder.self_conditioning")?;
+
+        let mut encoder_layer_scalars = Vec::with_capacity(config.num_hidden_layers);
+        for layer_idx in 0..config.num_hidden_layers {
+            let key = format!("model.encoder.language_model.layers.{layer_idx}.layer_scalar");
+            let scalar = weights
+                .get(&key)
+                .map(|w| mlxcel_core::copy(w))
+                .ok_or_else(|| format!("Weight not found: {key}"))?;
+            encoder_layer_scalars.push(scalar);
+        }
+
+        let generation_config = args.generation_config()?;
+        let eos_token_ids = args.eos_token_ids(&generation_config);
+        let embed_scale = (config.hidden_size as f32).sqrt();
+
+        Ok(Self {
+            text,
+            self_conditioning,
+            encoder_layer_scalars,
+            canvas_length: args.canvas_length(),
+            generation_config,
+            eos_token_ids,
+            embed_scale,
+            _weight_backing: super::sanitize::Gemma4WeightBacking::default(),
+        })
+    }
+
+    pub fn config(&self) -> &TextConfig {
+        &self.text.config
+    }
+
+    pub fn generation_config(&self) -> &DiffusionGenerationConfig {
+        &self.generation_config
+    }
+
+    pub fn canvas_length(&self) -> usize {
+        self.canvas_length
+    }
+
+    /// Allocate one dense Fp16 [`KVCache`] per layer.
+    ///
+    /// Phase 1 intentionally uses dense Fp16 caches for BOTH layer families
+    /// (sliding behavior is enforced by masks / the canvas-side trim, exactly
+    /// like the offset-aligned dynamic cache in the reference). A
+    /// `RotatingKVCache` optimization and quantized KV modes are out of
+    /// scope for this phase.
+    pub fn make_diffusion_caches(&self) -> Vec<KVCache> {
+        (0..self.text.layers.len())
+            .map(|_| KVCache::new())
+            .collect()
+    }
+
+    /// Encoder-mode forward: causal prefill of `input_ids` into `caches`,
+    /// with each layer scaled by its ENCODER scalar.
+    ///
+    /// Returns the final pre-norm hidden state for the [`LanguageModel`]
+    /// trait path; the diffusion engine ignores it (only the KV-cache writes
+    /// matter — the reference never consumes the encoder hidden output, so
+    /// callers should not project it unless they need trait-compatible
+    /// logits).
+    pub(crate) fn forward_encoder(
+        &self,
+        input_ids: &MlxArray,
+        caches: &mut [KVCache],
+        mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        let embeds = self.text.embed_tokens.forward(input_ids);
+        let mut h = mlxcel_core::multiply_scalar(&embeds, self.embed_scale);
+
+        let shape = mlxcel_core::array_shape(&h);
+        let l = shape[1];
+        let offset = caches.first().map(|c| c.offset).unwrap_or(0);
+        let window = self.text.config.sliding_window as i32;
+
+        // Always build explicit dense-axis masks: the dense Fp16 caches keep
+        // the FULL key axis [0, offset + l), so the rotating-cache-shaped
+        // helpers (which cap the sliding mask to the window width) do not
+        // apply here.
+        let (global_mask, sliding_mask) = match mask {
+            Some(m) => (mlxcel_core::copy(m), mlxcel_core::copy(m)),
+            None => (
+                mlxcel_core::utils::create_causal_mask(l, offset),
+                dense_windowed_causal_mask(l, offset, window),
+            ),
+        };
+
+        for (i, layer) in self.text.layers.iter().enumerate() {
+            let local_mask = if layer.layer_type == "full_attention" {
+                &global_mask
+            } else {
+                &sliding_mask
+            };
+            h = layer.forward_encoder_with_scalar(
+                &h,
+                Some(local_mask),
+                &mut caches[i],
+                &self.encoder_layer_scalars[i],
+            );
+        }
+        h
+    }
+
+    /// Canvas (decoder-mode) forward: denoise one canvas against the
+    /// read-only encoder prefix in `caches` and return softcapped logits
+    /// `[1, canvas_len, vocab]`.
+    ///
+    /// `self_conditioning_embeddings` is the previous denoising step's soft
+    /// embedding signal (`softmax(logits) @ embed_table * embed_scale`), or
+    /// `None` on the first step (which still applies the self-conditioning
+    /// post-norm — never skip the module).
+    pub(crate) fn forward_canvas(
+        &self,
+        canvas_ids: &MlxArray,
+        caches: &[KVCache],
+        self_conditioning_embeddings: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        let embeds = self.text.embed_tokens.forward(canvas_ids);
+        let embeds = mlxcel_core::multiply_scalar(&embeds, self.embed_scale);
+        let mut h = self
+            .self_conditioning
+            .forward(&embeds, self_conditioning_embeddings);
+
+        let offset = caches.first().map(|c| c.offset).unwrap_or(0);
+        for (layer, cache) in self.text.layers.iter().zip(caches.iter()) {
+            let encoder_kv = cache.visible_state();
+            let encoder_kv_refs = encoder_kv.as_ref().map(|(k, v)| {
+                (
+                    k.as_ref().expect("non-null encoder keys") as &MlxArray,
+                    v.as_ref().expect("non-null encoder values") as &MlxArray,
+                )
+            });
+            h = layer.forward_canvas(&h, encoder_kv_refs, offset);
+        }
+
+        let h = self.text.norm.forward(&h);
+        let mut logits = self.text.embed_tokens.as_linear(&h);
+        if let Some(cap) = self.text.config.final_logit_softcapping {
+            logits = mlxcel_core::compiled_softcap(&logits, cap);
+        }
+        logits
+    }
+}
+
+/// Build a `[size, size + offset]` additive causal mask with a sliding-window
+/// lower bound over the FULL dense key axis.
+///
+/// Unlike [`mlxcel_core::utils::create_causal_mask_with_window`], this never
+/// caps the key axis to the window width: the diffusion encoder keeps every
+/// position resident in a dense [`KVCache`], so column `k` always maps to
+/// logical key position `k`. Query row `j` (logical position `offset + j`)
+/// may attend key `k` iff `k <= offset + j` (causal) and
+/// `k > offset + j - window` (window lower bound).
+pub(crate) fn dense_windowed_causal_mask(
+    size: i32,
+    offset: i32,
+    window: i32,
+) -> UniquePtr<MlxArray> {
+    let total_len = size + offset;
+    let ones = mlxcel_core::ones(&[size, total_len], dtype::FLOAT32);
+    let causal = mlxcel_core::tril(&ones, offset);
+    let band = mlxcel_core::triu(&ones, offset - window + 1);
+    let allowed = mlxcel_core::multiply(&causal, &band);
+
+    let zeros = mlxcel_core::zeros(&[size, total_len], dtype::FLOAT32);
+    let neg_inf = mlxcel_core::full_f32(&[size, total_len], f32::NEG_INFINITY, dtype::FLOAT32);
+    let cond = mlxcel_core::greater(&allowed, &zeros);
+    mlxcel_core::where_cond(&cond, &zeros, &neg_inf)
+}
+
+impl LanguageModel for DiffusionGemmaModel {
+    /// Honest minimal trait forward: an encoder-mode causal pass (writing
+    /// `caches`) followed by the final norm and tied-embedding logits. The
+    /// CLI routes diffusion models to the block-diffusion engine BEFORE the
+    /// autoregressive loop, so this exists for trait completeness (warmup,
+    /// tooling) rather than as a generation path.
+    fn forward(
+        &self,
+        input_ids: &MlxArray,
+        caches: &mut [KVCache],
+        mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        let hidden = self.forward_encoder(input_ids, caches, mask);
+        let hidden = self.text.norm.forward(&hidden);
+        let mut logits = self.text.embed_tokens.as_linear(&hidden);
+        if let Some(cap) = self.text.config.final_logit_softcapping {
+            logits = mlxcel_core::compiled_softcap(&logits, cap);
+        }
+        logits
+    }
+
+    fn make_caches(&self) -> Vec<KVCache> {
+        self.make_diffusion_caches()
+    }
+
+    fn num_layers(&self) -> usize {
+        self.text.layers.len()
+    }
+
+    fn eos_token_ids(&self) -> Vec<i32> {
+        self.eos_token_ids.clone()
+    }
+
+    /// Block-diffusion generation is a model-owned loop over a single
+    /// sequence; the batched/paged scheduler must never pick this model up.
+    fn supports_batching(&self) -> bool {
+        false
+    }
+
+    fn supports_padded_prefill(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/src/models/diffusion_gemma/tests.rs
+++ b/src/models/diffusion_gemma/tests.rs
@@ -1,0 +1,414 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the DiffusionGemma module: pure host-side helper
+//! functions, generation-config parsing (against a literal snippet of the
+//! real checkpoint config), the fused gate_up split arithmetic, and the
+//! dense-axis sliding-window mask.
+
+use super::generate::{
+    StabilityTracker, canvas_length_for, confidence_transfer_mask, debug_canvas_pattern,
+    entropy_bound_accept_count, entropy_bound_acceptance_mask, linear_schedule_temperature,
+};
+use super::*;
+
+// -------------------------------------------------------------------------
+// Entropy-bound sampler
+// -------------------------------------------------------------------------
+
+#[test]
+fn entropy_bound_accept_count_all_below_bound() {
+    // prefix sums before each rank: 0, 0.01, 0.03, 0.06 — all <= 0.1.
+    let sorted = [0.01, 0.02, 0.03, 0.02];
+    assert_eq!(entropy_bound_accept_count(&sorted, 0.1), 4);
+}
+
+#[test]
+fn entropy_bound_accept_count_none_below_except_forced_first() {
+    // Rank 0 always qualifies (prefix sum 0 <= bound); rank 1 has prefix
+    // 5.0 > 0.1, so exactly one position is accepted.
+    let sorted = [5.0, 6.0, 7.0];
+    assert_eq!(entropy_bound_accept_count(&sorted, 0.1), 1);
+}
+
+#[test]
+fn entropy_bound_accept_count_negative_bound_forces_one() {
+    let sorted = [0.5, 0.6];
+    assert_eq!(entropy_bound_accept_count(&sorted, -1.0), 1);
+}
+
+#[test]
+fn entropy_bound_accept_count_partial_prefix() {
+    // prefixes: 0, 0.05, 0.15 -> ranks 0 and 1 qualify (0 <= 0.1,
+    // 0.05 <= 0.1), rank 2 fails (0.15 > 0.1).
+    let sorted = [0.05, 0.10, 0.20];
+    assert_eq!(entropy_bound_accept_count(&sorted, 0.1), 2);
+}
+
+#[test]
+fn entropy_bound_accept_count_empty_is_zero() {
+    assert_eq!(entropy_bound_accept_count(&[], 0.1), 0);
+}
+
+#[test]
+fn entropy_bound_acceptance_mask_picks_lowest_entropy_positions() {
+    // Entropies (unsorted): positions 1 and 3 are the two lowest.
+    // sorted: [0.01 (pos 3), 0.02 (pos 1), 0.5 (pos 0), 0.9 (pos 2)]
+    // prefixes: 0, 0.01, 0.03 (> bound 0.02 at rank 2 -> accept 2).
+    let entropies = [0.5, 0.02, 0.9, 0.01];
+    let mask = entropy_bound_acceptance_mask(&entropies, 0.02);
+    assert_eq!(mask, vec![false, true, false, true]);
+}
+
+#[test]
+fn entropy_bound_acceptance_mask_ties_prefer_lower_index() {
+    // Exact ties: stable sort keeps position order, so with bound 0.0 only
+    // the forced first (lowest index among the minimum) is accepted.
+    let entropies = [0.3, 0.3, 0.3];
+    let mask = entropy_bound_acceptance_mask(&entropies, 0.0);
+    assert_eq!(mask, vec![true, false, false]);
+}
+
+// -------------------------------------------------------------------------
+// Confidence-threshold sampler
+// -------------------------------------------------------------------------
+
+#[test]
+fn confidence_transfer_mask_accepts_above_threshold() {
+    let confidence = [0.95, 0.5, 0.91];
+    let unrevealed = [true, true, true];
+    let mask = confidence_transfer_mask(&confidence, &unrevealed, 0.9, false);
+    assert_eq!(mask, vec![true, false, true]);
+}
+
+#[test]
+fn confidence_transfer_mask_forces_best_unrevealed_when_none_clear() {
+    let confidence = [0.2, 0.8, 0.5];
+    let unrevealed = [true, true, true];
+    let mask = confidence_transfer_mask(&confidence, &unrevealed, 0.9, false);
+    assert_eq!(mask, vec![false, true, false]);
+}
+
+#[test]
+fn confidence_transfer_mask_force_ignores_revealed_positions() {
+    // Highest raw confidence is revealed; force must pick the best among
+    // the unrevealed ones only.
+    let confidence = [0.99, 0.3, 0.6];
+    let unrevealed = [false, true, true];
+    let mask = confidence_transfer_mask(&confidence, &unrevealed, 0.9, false);
+    assert_eq!(mask, vec![false, false, true]);
+}
+
+#[test]
+fn confidence_transfer_mask_no_unrevealed_yields_empty_mask() {
+    let confidence = [0.1, 0.2];
+    let unrevealed = [false, false];
+    let mask = confidence_transfer_mask(&confidence, &unrevealed, 0.9, false);
+    assert_eq!(mask, vec![false, false]);
+}
+
+#[test]
+fn confidence_transfer_mask_force_all_returns_unrevealed() {
+    let confidence = [0.0, 0.0, 0.0];
+    let unrevealed = [true, false, true];
+    let mask = confidence_transfer_mask(&confidence, &unrevealed, 0.9, true);
+    assert_eq!(mask, vec![true, false, true]);
+}
+
+// -------------------------------------------------------------------------
+// Temperature schedule and stopping
+// -------------------------------------------------------------------------
+
+#[test]
+fn linear_schedule_first_and_last_step() {
+    // First iteration: cur_step == max_steps -> tau == t_max.
+    let first = linear_schedule_temperature(48, 48, 0.4, 0.8);
+    assert!((first - 0.8).abs() < 1e-6, "first tau {first}");
+    // Last executed step: cur_step == 1 -> t_min + range / max_steps.
+    let last = linear_schedule_temperature(1, 48, 0.4, 0.8);
+    let expected = 0.4 + (0.8 - 0.4) * (1.0 / 48.0);
+    assert!((last - expected).abs() < 1e-6, "last tau {last}");
+}
+
+#[test]
+fn stability_tracker_checks_history_before_pushing() {
+    // stability_threshold = 1: the FIRST observation can never be stable
+    // (history empty), the second identical one is stable.
+    let mut tracker = StabilityTracker::new(1);
+    assert!(!tracker.observe(&[1, 2, 3]));
+    assert!(tracker.observe(&[1, 2, 3]));
+    // A change resets stability.
+    assert!(!tracker.observe(&[1, 2, 4]));
+    assert!(tracker.observe(&[1, 2, 4]));
+}
+
+#[test]
+fn stability_tracker_threshold_two_needs_two_prior_matches() {
+    let mut tracker = StabilityTracker::new(2);
+    assert!(!tracker.observe(&[7]));
+    assert!(!tracker.observe(&[7]));
+    // History is now [7, 7] (full): the third identical canvas is stable.
+    assert!(tracker.observe(&[7]));
+}
+
+// -------------------------------------------------------------------------
+// Canvas length rule and debug pattern
+// -------------------------------------------------------------------------
+
+#[test]
+fn canvas_length_rule_matches_reference() {
+    // min(max_canvas, max(remaining, min_canvas))
+    assert_eq!(canvas_length_for(300, 64, 256, 256, false), 256);
+    assert_eq!(canvas_length_for(100, 64, 256, 256, false), 100);
+    assert_eq!(canvas_length_for(10, 64, 256, 256, false), 64);
+    // full_canvas always allocates the model canvas.
+    assert_eq!(canvas_length_for(10, 64, 128, 256, true), 256);
+}
+
+#[test]
+fn debug_canvas_pattern_matches_formula() {
+    let vocab = 262_144i64;
+    let block = debug_canvas_pattern(4, vocab, 0);
+    assert_eq!(block, vec![7919, 15838, 23757, 31676]);
+    let block_k2 = debug_canvas_pattern(2, vocab, 2);
+    let expected: Vec<i32> = (0..2i64)
+        .map(|i| (((i + 1) * 7919 + 2 * 104_729) % vocab) as i32)
+        .collect();
+    assert_eq!(block_k2, expected);
+}
+
+// -------------------------------------------------------------------------
+// Config parsing (literal snippet of the real checkpoint config.json)
+// -------------------------------------------------------------------------
+
+const REAL_CONFIG_SNIPPET: &str = r#"{
+  "architectures": ["DiffusionGemmaForBlockDiffusion"],
+  "model_type": "diffusion_gemma",
+  "canvas_length": 256,
+  "eos_token_id": [1, 106, 50],
+  "boi_token_id": 255999,
+  "eoi_token_id": 258882,
+  "image_token_id": 258880,
+  "tie_word_embeddings": true,
+  "vision_soft_tokens_per_image": 280,
+  "generation_config": {
+    "confidence_threshold": 0.005,
+    "eos_token_id": [1, 106, 50],
+    "max_denoising_steps": 48,
+    "max_new_tokens": 256,
+    "pad_token_id": 0,
+    "sampler_config": {
+      "_cls_name": "EntropyBoundSamplerConfig",
+      "entropy_bound": 0.1
+    },
+    "stability_threshold": 1,
+    "t_max": 0.8,
+    "t_min": 0.4
+  },
+  "quantization": {"group_size": 64, "bits": 4, "mode": "affine"},
+  "text_config": {
+    "attention_bias": false,
+    "attention_dropout": 0.0,
+    "bos_token_id": 2,
+    "dtype": "bfloat16",
+    "eos_token_id": 1,
+    "final_logit_softcapping": 30.0,
+    "global_head_dim": 512,
+    "head_dim": 256,
+    "hidden_activation": "gelu_pytorch_tanh",
+    "hidden_size": 2816,
+    "initializer_range": 0.02,
+    "intermediate_size": 2112,
+    "layer_types": [
+      "sliding_attention", "sliding_attention", "sliding_attention",
+      "sliding_attention", "sliding_attention", "full_attention",
+      "sliding_attention", "sliding_attention", "sliding_attention",
+      "sliding_attention", "sliding_attention", "full_attention",
+      "sliding_attention", "sliding_attention", "sliding_attention",
+      "sliding_attention", "sliding_attention", "full_attention",
+      "sliding_attention", "sliding_attention", "sliding_attention",
+      "sliding_attention", "sliding_attention", "full_attention",
+      "sliding_attention", "sliding_attention", "sliding_attention",
+      "sliding_attention", "sliding_attention", "full_attention"
+    ],
+    "max_position_embeddings": 262144,
+    "model_type": "diffusion_gemma_text",
+    "moe_intermediate_size": 704,
+    "num_attention_heads": 16,
+    "num_experts": 128,
+    "num_global_key_value_heads": 2,
+    "num_hidden_layers": 30,
+    "num_key_value_heads": 8,
+    "pad_token_id": 0,
+    "rms_norm_eps": 1e-06,
+    "rope_parameters": {
+      "full_attention": {
+        "partial_rotary_factor": 0.25,
+        "rope_theta": 1000000.0,
+        "rope_type": "proportional"
+      },
+      "sliding_attention": {
+        "rope_theta": 10000.0,
+        "rope_type": "default"
+      }
+    },
+    "sliding_window": 1024,
+    "tie_word_embeddings": true,
+    "top_k_experts": 8,
+    "use_bidirectional_attention": "vision",
+    "vocab_size": 262144
+  }
+}"#;
+
+#[test]
+fn parses_real_config_snippet() {
+    let args: ModelArgs = serde_json::from_str(REAL_CONFIG_SNIPPET).expect("config parses");
+    assert_eq!(args.model_type, "diffusion_gemma");
+    assert_eq!(args.canvas_length(), 256);
+
+    let generation = args.generation_config().expect("generation config");
+    assert_eq!(generation.max_denoising_steps, 48);
+    assert_eq!(generation.max_new_tokens, 256);
+    assert!((generation.t_min - 0.4).abs() < 1e-6);
+    assert!((generation.t_max - 0.8).abs() < 1e-6);
+    assert!((generation.entropy_bound - 0.1).abs() < 1e-6);
+    let stopping = generation.stopping.expect("stopping config present");
+    assert!((stopping.confidence_threshold - 0.005).abs() < 1e-6);
+    assert_eq!(stopping.stability_threshold, 1);
+
+    let eos = args.eos_token_ids(&generation);
+    assert_eq!(eos, vec![1, 106, 50]);
+}
+
+#[test]
+fn text_args_forces_structural_flags() {
+    let args: ModelArgs = serde_json::from_str(REAL_CONFIG_SNIPPET).expect("config parses");
+    let config = args.text_args().expect("text config parses");
+
+    // Shape parameters straight from the checkpoint.
+    assert_eq!(config.hidden_size, 2816);
+    assert_eq!(config.num_hidden_layers, 30);
+    assert_eq!(config.vocab_size, 262_144);
+    assert_eq!(config.sliding_window, 1024);
+    assert_eq!(config.head_dim, 256);
+    assert_eq!(config.global_head_dim, Some(512));
+    assert_eq!(config.num_attention_heads, 16);
+    assert_eq!(config.num_key_value_heads, 8);
+    assert_eq!(config.num_global_key_value_heads, Some(2));
+    assert_eq!(config.num_experts, Some(128));
+    assert_eq!(config.top_k_experts, Some(8));
+    assert_eq!(config.moe_intermediate_size, Some(704));
+    assert_eq!(config.intermediate_size, 2112);
+    assert_eq!(config.final_logit_softcapping, Some(30.0));
+    assert_eq!(config.layer_types.len(), 30);
+
+    // The checkpoint text_config OMITS these presence-only flags; the
+    // parser must force them because the weights require both: the 5
+    // full-attention layers ship without v_proj (k-eq-v values) and every
+    // layer carries the MoE branch.
+    assert!(config.attention_k_eq_v, "k-eq-v must be forced on");
+    assert!(config.enable_moe_block, "MoE branch must be forced on");
+    assert_eq!(config.num_kv_shared_layers, 0);
+    assert_eq!(config.hidden_size_per_layer_input, 0);
+
+    // Root quantization is inherited when text_config has none.
+    let quant = config.quantization.expect("quantization inherited");
+    assert_eq!(quant.group_size, 64);
+    assert_eq!(quant.bits, 4);
+}
+
+#[test]
+fn rejects_unknown_sampler_class() {
+    let mut value: serde_json::Value =
+        serde_json::from_str(REAL_CONFIG_SNIPPET).expect("config parses");
+    value["generation_config"]["sampler_config"]["_cls_name"] =
+        serde_json::Value::String("SomeOtherSamplerConfig".to_string());
+    let args: ModelArgs =
+        serde_json::from_value(value).expect("config with foreign sampler parses");
+    let err = args.generation_config().expect_err("must reject");
+    assert!(err.contains("SomeOtherSamplerConfig"), "error: {err}");
+}
+
+// -------------------------------------------------------------------------
+// Fused gate_up split arithmetic (synthetic shapes, no real tensors)
+// -------------------------------------------------------------------------
+
+#[test]
+fn split_gate_up_tensor_splits_output_axis() {
+    // [experts = 2, out = 4, k = 3]: rows 0..2 are the gate half, rows
+    // 2..4 the up half (gate first, matching the reference slicing).
+    let data: Vec<f32> = (0..24).map(|v| v as f32).collect();
+    let fused = mlxcel_core::from_slice_f32(&data, &[2, 4, 3]);
+    let (gate, up) = split_gate_up_tensor(&fused, 2).expect("split succeeds");
+    mlxcel_core::eval(&gate);
+    mlxcel_core::eval(&up);
+
+    assert_eq!(mlxcel_core::array_shape(&gate), vec![2, 2, 3]);
+    assert_eq!(mlxcel_core::array_shape(&up), vec![2, 2, 3]);
+
+    let at = |arr: &MlxArray, e: i32, o: i32, k: i32| -> f32 {
+        let scalar = mlxcel_core::slice(arr, &[e, o, k], &[e + 1, o + 1, k + 1]);
+        mlxcel_core::item_f32(&scalar)
+    };
+    // Expert 0: fused rows 0..4 hold values 0..12 (3 per row).
+    assert_eq!(at(&gate, 0, 0, 0), 0.0);
+    assert_eq!(at(&gate, 0, 1, 2), 5.0);
+    assert_eq!(at(&up, 0, 0, 0), 6.0);
+    assert_eq!(at(&up, 0, 1, 2), 11.0);
+    // Expert 1: fused rows hold values 12..24.
+    assert_eq!(at(&gate, 1, 0, 0), 12.0);
+    assert_eq!(at(&up, 1, 1, 2), 23.0);
+}
+
+#[test]
+fn split_gate_up_tensor_rejects_bad_shapes() {
+    let data: Vec<f32> = (0..12).map(|v| v as f32).collect();
+    let rank2 = mlxcel_core::from_slice_f32(&data, &[4, 3]);
+    assert!(split_gate_up_tensor(&rank2, 2).is_err());
+
+    let wrong_out = mlxcel_core::from_slice_f32(&data, &[2, 2, 3]);
+    assert!(split_gate_up_tensor(&wrong_out, 2).is_err());
+}
+
+// -------------------------------------------------------------------------
+// Dense-axis sliding-window mask (multi-token continuation at offset > 0)
+// -------------------------------------------------------------------------
+
+#[test]
+fn dense_windowed_mask_is_correct_for_multi_token_offset_forward() {
+    // 3 query tokens appended at offset 2000 with window 1024 over the FULL
+    // dense key axis [0, 2003): query j (logical position 2000 + j) may
+    // attend keys k with k <= 2000 + j and k > 976 + j.
+    let mask = dense_windowed_causal_mask(3, 2000, 1024);
+    mlxcel_core::eval(&mask);
+    assert_eq!(mlxcel_core::array_shape(&mask), vec![3, 2003]);
+
+    let at = |q: i32, k: i32| -> f32 {
+        let scalar = mlxcel_core::slice(&mask, &[q, k], &[q + 1, k + 1]);
+        mlxcel_core::item_f32(&scalar)
+    };
+    let blocked = |v: f32| v.is_infinite() && v < 0.0;
+
+    // Row 0 (logical 2000): window lower edge between k = 976 and 977.
+    assert!(blocked(at(0, 976)), "k 976 outside window for q 2000");
+    assert_eq!(at(0, 977), 0.0, "k 977 inside window for q 2000");
+    assert_eq!(at(0, 2000), 0.0, "self-attention allowed");
+    assert!(blocked(at(0, 2001)), "future key blocked (causality)");
+
+    // Row 2 (logical 2002): window shifts with the query position.
+    assert!(blocked(at(2, 978)), "k 978 outside window for q 2002");
+    assert_eq!(at(2, 979), 0.0, "k 979 inside window for q 2002");
+    assert_eq!(at(2, 2002), 0.0, "self-attention allowed");
+    assert!(blocked(at(1, 2002)), "row 1 cannot see row 2's key");
+}

--- a/src/models/diffusion_gemma/tests.rs
+++ b/src/models/diffusion_gemma/tests.rs
@@ -412,3 +412,77 @@ fn dense_windowed_mask_is_correct_for_multi_token_offset_forward() {
     assert_eq!(at(2, 2002), 0.0, "self-attention allowed");
     assert!(blocked(at(1, 2002)), "row 1 cannot see row 2's key");
 }
+
+// -------------------------------------------------------------------------
+// Real-model regression tests (issue #217; #[ignore], need the checkpoint)
+// -------------------------------------------------------------------------
+
+/// Determinism regression for the steel GEMM safe-load overlay
+/// (`src/lib/mlx-cpp/patches/mlx/backend/metal/kernels/steel/gemm/mma.h`,
+/// upstream MLX PRs #3560/#3565).
+///
+/// The DiffusionGemma canvas forward runs head_dim 256/512 SDPA through the
+/// unfused steel-GEMM path with non-tile-aligned key lengths, so the broken
+/// edge-tile loader read junk through strided views and the SAME 30-layer
+/// lazy graph produced different bytes run to run. Both forward modes must
+/// be byte-deterministic.
+///
+/// `cargo test --release --lib models::diffusion_gemma::tests::real_model_forward_determinism -- --ignored --nocapture`
+#[test]
+#[ignore]
+fn real_model_forward_determinism() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("models/diffusiongemma-26B-A4B-it-4bit");
+    if !dir.exists() {
+        eprintln!("skip: checkpoint not present");
+        return;
+    }
+    let model = DiffusionGemmaModel::load(&dir).expect("load");
+    // "Why is the sky blue?" through chat_template.jinja.
+    let prompt: Vec<i32> = vec![
+        2, 105, 2364, 107, 11355, 563, 506, 7217, 3730, 236881, 106, 107, 105, 4368, 107, 100,
+        45518, 107, 101,
+    ];
+    let ids = mlxcel_core::from_slice_i32(&prompt, &[1, prompt.len() as i32]);
+
+    // Warm the Metal buffer cache first: the historical failure modes (the
+    // steel GEMM safe-load typo and the strided split-weight gather_qmm
+    // reads) only turned nondeterministic once recycled buffers carried
+    // changing junk, so a fresh-process run could pass with the bug present.
+    {
+        let warm_ids = super::generate::debug_canvas_pattern(64, 262144, 1);
+        let warm = mlxcel_core::from_slice_i32(&warm_ids, &[1, 64]);
+        for _ in 0..3 {
+            let mut caches = model.make_diffusion_caches();
+            let h = model.forward_encoder(&warm, &mut caches, None);
+            mlxcel_core::eval(&h);
+        }
+    }
+    let canvas_ids = super::generate::debug_canvas_pattern(64, 262144, 0);
+    let canvas = mlxcel_core::from_slice_i32(&canvas_ids, &[1, 64]);
+
+    let run = || -> (Vec<u8>, Vec<u8>) {
+        let mut caches = model.make_diffusion_caches();
+        let hidden = model.forward_encoder(&ids, &mut caches, None);
+        let hidden = mlxcel_core::astype(&hidden, mlxcel_core::dtype::FLOAT32);
+        mlxcel_core::eval(&hidden);
+        let encoder_bytes = mlxcel_core::array_to_raw_bytes(&hidden);
+
+        let logits = model.forward_canvas(&canvas, &caches, None);
+        let logits = mlxcel_core::astype(&logits, mlxcel_core::dtype::FLOAT32);
+        mlxcel_core::eval(&logits);
+        let canvas_bytes = mlxcel_core::array_to_raw_bytes(&logits);
+        (encoder_bytes, canvas_bytes)
+    };
+
+    let (encoder_a, canvas_a) = run();
+    let (encoder_b, canvas_b) = run();
+    assert_eq!(
+        encoder_a, encoder_b,
+        "encoder forward must be byte-deterministic across runs"
+    );
+    assert_eq!(
+        canvas_a, canvas_b,
+        "canvas forward must be byte-deterministic across runs"
+    );
+}

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -257,7 +257,7 @@ impl ModelArgs {
     }
 }
 
-fn parse_eos_ids(value: Option<&serde_json::Value>) -> Vec<i32> {
+pub(crate) fn parse_eos_ids(value: Option<&serde_json::Value>) -> Vec<i32> {
     match value {
         Some(serde_json::Value::Number(n)) => {
             n.as_i64().map(|v| vec![v as i32]).unwrap_or_default()
@@ -1445,6 +1445,164 @@ impl Attention {
         cache.update_and_fetch(keys, values)
     }
 
+    /// DiffusionGemma canvas (decoder-mode) attention (issue #217, additive
+    /// seam). Mirrors `diffusion_gemma.language.Attention.__call__` with
+    /// `decoder=True`, line by line:
+    ///
+    /// * Q/K are projected, normed, and rotated at `offset` (the encoder
+    ///   length) through the SAME kernels the encoder path uses (the compiled
+    ///   proportional fused chain on full-attention layers, the op-at-a-time
+    ///   chain on sliding layers), so canvas numerics match the reference.
+    /// * `values_raw = v_proj(x)` when the layer has a v_proj (sliding
+    ///   layers), otherwise the raw K projection (`use_k_eq_v` full-attention
+    ///   layers); `values = v_norm(values_raw)`.
+    /// * The read-only `encoder_kv` prefix is concatenated in front of the
+    ///   canvas K/V. On sliding layers the prefix is first trimmed to the
+    ///   last `sliding_window - 1` positions (the upstream O(window) trim);
+    ///   with the trim applied, the no-padding decoder mask is `None`
+    ///   (canvas positions attend bidirectionally to everything that
+    ///   remains), so SDPA runs maskless with `self.scale` (1.0).
+    /// * The cache is NEVER updated; the canvas changes every denoising step.
+    pub(crate) fn forward_canvas(
+        &self,
+        x: &MlxArray,
+        encoder_kv: Option<(&MlxArray, &MlxArray)>,
+        offset: i32,
+    ) -> UniquePtr<MlxArray> {
+        let shape = mlxcel_core::array_shape(x);
+        let b = shape[0];
+        let l = shape[1];
+
+        let q_proj_out = match &self.projection {
+            AttentionProjection::Fused(proj) => {
+                let (q, _, _) = proj.forward(x);
+                q
+            }
+            AttentionProjection::Separate { q_proj, .. }
+            | AttentionProjection::KvShared { q_proj } => q_proj.forward(x),
+        };
+
+        let queries = if let Some(ref freqs) = self.proportional_rope_freqs {
+            let rotated_dims = 2
+                * ((self.proportional_partial_rotary_factor as f64 * self.head_dim as f64 / 2.0)
+                    .floor() as i32)
+                    .max(0);
+            mlxcel_core::compiled_q_path_proportional(
+                &q_proj_out,
+                &self.q_norm.weight,
+                freqs,
+                self.q_norm.eps,
+                self.n_heads,
+                self.head_dim,
+                rotated_dims,
+                offset,
+            )
+        } else {
+            let queries = mlxcel_core::reshape(&q_proj_out, &[b, l, self.n_heads, self.head_dim]);
+            let queries = self.q_norm.forward(&queries);
+            let queries = mlxcel_core::transpose_axes(&queries, &[0, 2, 1, 3]);
+            self.apply_rope(&queries, offset)
+        };
+
+        let (raw_keys, raw_values) = match &self.projection {
+            AttentionProjection::Fused(proj) => {
+                let (_, k, v) = proj.forward(x);
+                (k, Some(v))
+            }
+            AttentionProjection::Separate { k_proj, v_proj, .. } => {
+                let raw_keys = k_proj.forward(x);
+                let raw_values = if self.use_k_eq_v {
+                    None
+                } else {
+                    Some(
+                        v_proj
+                            .as_ref()
+                            .expect("Gemma4 attention expected v_proj for non-k_eq_v layer")
+                            .forward(x),
+                    )
+                };
+                (raw_keys, raw_values)
+            }
+            AttentionProjection::KvShared { .. } => {
+                unreachable!(
+                    "forward_canvas must not be called on a KV-shared layer; \
+                     DiffusionGemma forces num_kv_shared_layers == 0"
+                )
+            }
+        };
+
+        let k_norm = self
+            .k_norm
+            .as_ref()
+            .expect("k_norm must be Some for non-KV-shared layers");
+        let keys = if let Some(ref freqs) = self.proportional_rope_freqs {
+            let rotated_dims = 2
+                * ((self.proportional_partial_rotary_factor as f64 * self.head_dim as f64 / 2.0)
+                    .floor() as i32)
+                    .max(0);
+            mlxcel_core::compiled_q_path_proportional(
+                &raw_keys,
+                &k_norm.weight,
+                freqs,
+                k_norm.eps,
+                self.n_kv_heads,
+                self.head_dim,
+                rotated_dims,
+                offset,
+            )
+        } else {
+            let keys = mlxcel_core::reshape(&raw_keys, &[b, l, self.n_kv_heads, self.head_dim]);
+            let keys = k_norm.forward(&keys);
+            let keys = mlxcel_core::transpose_axes(&keys, &[0, 2, 1, 3]);
+            self.apply_rope(&keys, offset)
+        };
+
+        let raw_values_ref = raw_values
+            .as_ref()
+            .map(|values| values.as_ref().unwrap())
+            .unwrap_or_else(|| raw_keys.as_ref().unwrap());
+        let values = mlxcel_core::reshape(raw_values_ref, &[b, l, self.n_kv_heads, self.head_dim]);
+        let values = self.v_norm.forward(&values);
+        let values = mlxcel_core::transpose_axes(&values, &[0, 2, 1, 3]);
+
+        let (keys, values) = if let Some((encoder_keys, encoder_values)) = encoder_kv {
+            // Sliding layers: the canvas only sees the last
+            // `sliding_window - 1` encoder positions, so drop the
+            // out-of-window prefix before SDPA instead of scoring thousands
+            // of positions the (implicit) mask would zero anyway. Safe for
+            // the dense KVCache because offset == encoder_len always holds
+            // (no trailing-invalid slots).
+            let window_prefix = (self.window_size - 1).max(0);
+            let encoder_len = mlxcel_core::array_shape(encoder_keys)[2];
+            let (encoder_keys, encoder_values) =
+                if self.window_size > 0 && encoder_len > window_prefix && offset >= encoder_len {
+                    (
+                        slice_axis(encoder_keys, 2, encoder_len - window_prefix, encoder_len),
+                        slice_axis(encoder_values, 2, encoder_len - window_prefix, encoder_len),
+                    )
+                } else {
+                    (
+                        mlxcel_core::copy(encoder_keys),
+                        mlxcel_core::copy(encoder_values),
+                    )
+                };
+            (
+                mlxcel_core::concatenate(&encoder_keys, &keys, 2),
+                mlxcel_core::concatenate(&encoder_values, &values, 2),
+            )
+        } else {
+            (keys, values)
+        };
+
+        // Full bidirectional attention over [trimmed encoder prefix, canvas]:
+        // batch-1 with no padding means mask == None in the reference decoder
+        // mask builder. `window_size` 0 keeps the dispatch on the plain
+        // (non-windowed) SDPA path.
+        let attn_out =
+            mlxcel_core::layers::attention(&queries, &keys, &values, self.scale, None, 0.0, 0);
+        self.project_output(&attn_out, b, l)
+    }
+
     pub fn from_weights(
         weights: &WeightMap,
         config: &TextConfig,
@@ -1755,44 +1913,7 @@ impl DecoderLayer {
         let after_attn = mlxcel_core::add(x, &h_attn);
         timer.tick("attn_residual_add", &after_attn);
 
-        let ffn_out = if let (Some(router), Some(experts)) = (&self.router, &self.experts) {
-            let h1 = self.pre_feedforward_layernorm.forward(&after_attn);
-            timer.tick("pre_ffn_ln_shared_mlp", &h1);
-            let h1 = self.mlp.forward(&h1);
-            timer.tick("shared_mlp", &h1);
-            let h1 = self
-                .post_feedforward_layernorm_1
-                .as_ref()
-                .expect("Missing Gemma4 MoE post_feedforward_layernorm_1")
-                .forward(&h1);
-            timer.tick("post_shared_mlp_ln", &h1);
-
-            let (top_k_indices, top_k_weights) = router.forward(&after_attn);
-            timer.tick("router", &top_k_indices);
-            let h2 = self
-                .pre_feedforward_layernorm_2
-                .as_ref()
-                .expect("Missing Gemma4 MoE pre_feedforward_layernorm_2")
-                .forward(&after_attn);
-            timer.tick("pre_moe_ln", &h2);
-            let h2 = experts.forward(&h2, &top_k_indices, &top_k_weights);
-            timer.tick("experts", &h2);
-            let h2 = self
-                .post_feedforward_layernorm_2
-                .as_ref()
-                .expect("Missing Gemma4 MoE post_feedforward_layernorm_2")
-                .forward(&h2);
-            timer.tick("post_moe_ln", &h2);
-            let combined = mlxcel_core::add(&h1, &h2);
-            timer.tick("moe_shared_add", &combined);
-            combined
-        } else {
-            let h_norm = self.pre_feedforward_layernorm.forward(&after_attn);
-            timer.tick("pre_ffn_ln", &h_norm);
-            let out = self.mlp.forward(&h_norm);
-            timer.tick("mlp", &out);
-            out
-        };
+        let ffn_out = self.ffn_branch(&after_attn, &mut timer);
 
         let ffn_out = self.post_feedforward_layernorm.forward(&ffn_out);
         timer.tick("post_ffn_ln", &ffn_out);
@@ -1847,6 +1968,109 @@ impl DecoderLayer {
         let h = mlxcel_core::multiply(&h, &self.layer_scalar);
         timer.tick("layer_scalar", &h);
         (h, stored_kv)
+    }
+
+    /// Shared feed-forward stage: dense MLP branch plus (when present) the
+    /// MoE branch, combined exactly like the upstream Gemma 4 layer. Extracted
+    /// from [`Self::forward_with_profile`] verbatim so the DiffusionGemma
+    /// encoder/canvas forwards (issue #217) reuse the identical op sequence;
+    /// the hot autoregressive path calls this with its own timer and is
+    /// byte-identical to the pre-extraction code.
+    fn ffn_branch(&self, after_attn: &MlxArray, timer: &mut SubopTimer) -> UniquePtr<MlxArray> {
+        if let (Some(router), Some(experts)) = (&self.router, &self.experts) {
+            let h1 = self.pre_feedforward_layernorm.forward(after_attn);
+            timer.tick("pre_ffn_ln_shared_mlp", &h1);
+            let h1 = self.mlp.forward(&h1);
+            timer.tick("shared_mlp", &h1);
+            let h1 = self
+                .post_feedforward_layernorm_1
+                .as_ref()
+                .expect("Missing Gemma4 MoE post_feedforward_layernorm_1")
+                .forward(&h1);
+            timer.tick("post_shared_mlp_ln", &h1);
+
+            let (top_k_indices, top_k_weights) = router.forward(after_attn);
+            timer.tick("router", &top_k_indices);
+            let h2 = self
+                .pre_feedforward_layernorm_2
+                .as_ref()
+                .expect("Missing Gemma4 MoE pre_feedforward_layernorm_2")
+                .forward(after_attn);
+            timer.tick("pre_moe_ln", &h2);
+            let h2 = experts.forward(&h2, &top_k_indices, &top_k_weights);
+            timer.tick("experts", &h2);
+            let h2 = self
+                .post_feedforward_layernorm_2
+                .as_ref()
+                .expect("Missing Gemma4 MoE post_feedforward_layernorm_2")
+                .forward(&h2);
+            timer.tick("post_moe_ln", &h2);
+            let combined = mlxcel_core::add(&h1, &h2);
+            timer.tick("moe_shared_add", &combined);
+            combined
+        } else {
+            let h_norm = self.pre_feedforward_layernorm.forward(after_attn);
+            timer.tick("pre_ffn_ln", &h_norm);
+            let out = self.mlp.forward(&h_norm);
+            timer.tick("mlp", &out);
+            out
+        }
+    }
+
+    /// DiffusionGemma encoder-mode layer forward (issue #217, additive seam).
+    ///
+    /// Identical to [`Self::forward`] for a layer without per-layer inputs or
+    /// KV sharing, except the final output scalar is the caller-provided
+    /// `layer_scalar` (the checkpoint's per-layer ENCODER scalar at
+    /// `model.encoder.language_model.layers.N.layer_scalar`) instead of the
+    /// layer's stored decoder `layer_scalar`. Mirrors the
+    /// `layer_scalar` override parameter on the upstream
+    /// `diffusion_gemma.language.DecoderLayer.__call__`.
+    pub(crate) fn forward_encoder_with_scalar(
+        &self,
+        x: &MlxArray,
+        mask: Option<&MlxArray>,
+        cache: &mut dyn CacheInterface,
+        layer_scalar: &MlxArray,
+    ) -> UniquePtr<MlxArray> {
+        let mut timer = SubopTimer::new(false, usize::MAX);
+        let h_attn = self.input_layernorm.forward(x);
+        let (h_attn, _stored_kv) = self.self_attn.forward(&h_attn, mask, cache, None, None);
+        let h_attn = self.post_attention_layernorm.forward(&h_attn);
+        let after_attn = mlxcel_core::add(x, &h_attn);
+
+        let ffn_out = self.ffn_branch(&after_attn, &mut timer);
+        let ffn_out = self.post_feedforward_layernorm.forward(&ffn_out);
+        let after_ffn = mlxcel_core::add(&after_attn, &ffn_out);
+
+        mlxcel_core::multiply(&after_ffn, layer_scalar)
+    }
+
+    /// DiffusionGemma canvas (decoder-mode) layer forward (issue #217,
+    /// additive seam).
+    ///
+    /// The canvas hidden states attend bidirectionally within themselves and
+    /// to the read-only `encoder_kv` prefix (the cache is never written);
+    /// everything after attention is the standard Gemma 4 layer with the
+    /// layer's stored DECODER `layer_scalar`. Mirrors the upstream
+    /// `decoder=True` path of `diffusion_gemma.language.DecoderLayer`.
+    pub(crate) fn forward_canvas(
+        &self,
+        x: &MlxArray,
+        encoder_kv: Option<(&MlxArray, &MlxArray)>,
+        offset: i32,
+    ) -> UniquePtr<MlxArray> {
+        let mut timer = SubopTimer::new(false, usize::MAX);
+        let h_attn = self.input_layernorm.forward(x);
+        let h_attn = self.self_attn.forward_canvas(&h_attn, encoder_kv, offset);
+        let h_attn = self.post_attention_layernorm.forward(&h_attn);
+        let after_attn = mlxcel_core::add(x, &h_attn);
+
+        let ffn_out = self.ffn_branch(&after_attn, &mut timer);
+        let ffn_out = self.post_feedforward_layernorm.forward(&ffn_out);
+        let after_ffn = mlxcel_core::add(&after_attn, &ffn_out);
+
+        mlxcel_core::multiply(&after_ffn, &self.layer_scalar)
     }
 
     pub fn from_weights(

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -35,6 +35,7 @@ pub mod deepseek;
 pub mod deepseek_v2;
 pub mod deepseek_v3;
 pub mod deepseek_v32;
+pub mod diffusion_gemma;
 pub mod ernie4_5;
 pub mod ernie4_5_moe;
 pub mod exaone;
@@ -112,6 +113,7 @@ pub use deepseek_v2::DeepSeekV2Model;
 pub use deepseek_v3::DeepSeekV3Model;
 pub use deepseek_v32::DeepSeekV32Model;
 pub use detection::get_model_type;
+pub use diffusion_gemma::DiffusionGemmaModel;
 pub use ernie4_5::Ernie45Model;
 pub use ernie4_5_moe::Ernie45MoeModel;
 pub use exaone::ExaOneModel;
@@ -206,6 +208,7 @@ pub enum ModelType {
     Gemma2,          // Gemma 2
     Gemma3,          // Gemma 3 (text-only)
     Gemma4,          // Gemma 4 text-only route
+    DiffusionGemma,  // DiffusionGemma (block-diffusion on the Gemma 4 MoE backbone)
     Gemma3VLM,       // Gemma 3 VLM (vision-language)
     Gemma4VLM,       // Gemma 4 VLM (vision-language)
     Gemma4Unified,   // Gemma 4 Unified (encoder-free text + vision + audio)
@@ -340,6 +343,7 @@ pub const ALL_MODEL_TYPES: &[ModelType] = &[
     ModelType::Gemma2,
     ModelType::Gemma3,
     ModelType::Gemma4,
+    ModelType::DiffusionGemma,
     ModelType::Gemma3VLM,
     ModelType::Gemma4VLM,
     ModelType::Gemma4Unified,
@@ -481,6 +485,10 @@ impl ModelType {
             ModelType::Gemma3 => ("Gemma 3", "Gemma"),
             ModelType::Gemma3n => ("Gemma 3n", "Gemma"),
             ModelType::Gemma4 => ("Gemma 4", "Gemma"),
+            ModelType::DiffusionGemma => (
+                "DiffusionGemma (block-diffusion, Gemma 4 MoE backbone)",
+                "Gemma",
+            ),
             ModelType::RecurrentGemma => ("RecurrentGemma (Griffin: RGLRU + attention)", "Gemma"),
 
             // ----- Gemma VLM -----

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -872,6 +872,25 @@ pub(crate) fn load_gemma4_unified_weights_with_backing<P: AsRef<Path>>(
     load_gemma4_family_weights_with_backing(model_dir, is_gemma4_unified_weight)
 }
 
+/// Weight filter for the DiffusionGemma text path (issue #217, phase 1).
+///
+/// Keeps the decoder backbone (`model.decoder.*`: embed, layers, norm,
+/// self_conditioning) and the encoder's per-layer scalars
+/// (`model.encoder.language_model.*`). Everything else in the checkpoint
+/// (`model.encoder.vision_tower.*`, `model.encoder.embed_vision.*`) is the
+/// phase-2 vision front-end and is intentionally skipped without error.
+fn is_diffusion_gemma_text_weight(name: &str) -> bool {
+    name.starts_with("model.decoder.") || name.starts_with("model.encoder.language_model.")
+}
+
+/// Load the DiffusionGemma text-backbone weights (decoder + encoder layer
+/// scalars) with retained mmap backing, skipping the vision tower.
+pub(crate) fn load_diffusion_gemma_text_weights_with_backing<P: AsRef<Path>>(
+    model_dir: P,
+) -> Result<(mlxcel_core::weights::WeightMap, Gemma4WeightBacking), String> {
+    load_gemma4_family_weights_with_backing(model_dir, is_diffusion_gemma_text_weight)
+}
+
 /// Shared Gemma 4 family weight loader with a caller-supplied prefix filter.
 fn load_gemma4_family_weights_with_backing<P: AsRef<Path>, F>(
     model_dir: P,

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -161,6 +161,23 @@ pub(crate) struct WorkerSchedulerConfig {
     pub speculative_dispatch: crate::server::SpeculativeDispatch,
 }
 
+/// Refuse model families the server runtime cannot drive yet, with a clear
+/// actionable error instead of a confusing downstream failure.
+///
+/// DiffusionGemma (issue #217 phase 1) generates by model-owned block
+/// diffusion; the batched scheduler and the SSE serving path have no
+/// diffusion round loop yet (phase 3), so the worker rejects the load
+/// outright and points the operator at the CLI.
+fn server_unsupported_model_error(model_path: &std::path::Path) -> Option<anyhow::Error> {
+    match crate::models::get_model_type(model_path) {
+        Ok(crate::models::ModelType::DiffusionGemma) => Some(anyhow::anyhow!(
+            "DiffusionGemma (block diffusion) is not supported in server mode yet; use the CLI: \
+             mlxcel generate -m <model> -p \"...\""
+        )),
+        _ => None,
+    }
+}
+
 pub(crate) fn spawn_model_worker_with_batch_config(
     model_path: PathBuf,
     adapter_path: Option<PathBuf>,
@@ -175,7 +192,9 @@ pub(crate) fn spawn_model_worker_with_batch_config(
         tracing::info!("Model worker thread starting, loading model...");
 
         let load_start = Instant::now();
-        let result = if let Some(ref pipeline_runtime) = sched_config.pipeline_parallel_runtime {
+        let result = if let Some(err) = server_unsupported_model_error(&model_path) {
+            Err(err)
+        } else if let Some(ref pipeline_runtime) = sched_config.pipeline_parallel_runtime {
             match pipeline_runtime {
                 crate::server::PipelineParallelRuntimeConfig::InProcess {
                     layers,
@@ -662,7 +681,9 @@ pub(crate) fn spawn_legacy_model_worker(
         );
 
         let load_start = Instant::now();
-        let result = if tensor_parallel.tp_size > 1 {
+        let result = if let Some(err) = server_unsupported_model_error(&model_path) {
+            Err(err)
+        } else if tensor_parallel.tp_size > 1 {
             crate::load_model_with_tensor_parallel(
                 &model_path,
                 adapter_path.as_deref(),


### PR DESCRIPTION
## Summary

Adds phase 1 of DiffusionGemma support: text-only block-diffusion generation for `google/diffusiongemma-26B-A4B-it` (`model_type: "diffusion_gemma"`), integrated into the CLI `generate` flow. Phases 2 (image input) and 3 (server serving) remain open.

Part of #217

## What changed

- `src/models/diffusion_gemma/` (new): model module composing gemma4 building blocks. Encoder mode runs the standard causal Gemma 4 forward into dense Fp16 KV caches with each layer scaled by the checkpoint's per-layer ENCODER scalar (`model.encoder.language_model.layers.N.layer_scalar`); canvas mode embeds the noisy canvas, always applies the self-conditioning module (GeGLU MLP + RMSNormNoScale post-norm, zero-signal fast path on the first step), and attends bidirectionally to the read-only cached prefix with the upstream O(window) sliding-layer trim. Fused `experts.gate_up_proj` tensors are split along the output axis (gate rows first) onto the existing SwitchGeGLU key layout at load time; vision-tower weights are skipped without error.
- Generation engine (`diffusion_gemma/generate.rs`): mirrors mlx-vlm `stream_diffusion_generate` for batch-1 dynamic-cache generation: per-block canvas sizing `min(max_canvas, max(remaining, min_canvas))`, uniform-random canvas init, linear temperature schedule `t_min..t_max` over descending steps, entropy-bound sampler (host-side prefix rule over sorted entropies, equivalent to the reference `(cumsum - cummax) <= bound`) and confidence-threshold sampler (reveal mask + forced best position), stable-and-confident early stop with the reference's check-before-push history order, self-conditioning soft embeddings via a once-per-call dequantized embedding table, full-canvas commit and append, chunked prefill for long prompts, EOS stop without emission, and diffusion work stats. A deterministic debug mode (`MLXCEL_DIFFUSION_DEBUG_CANVAS=1`) replaces every canvas randomization with a fixed pattern and prints `DIFFUSION_COMMIT block=<n> ids=...` per block for cross-implementation parity gating at temperature 0.
- `src/models/gemma4.rs` (additive seams only; hot path byte-identical): `DecoderLayer::ffn_branch` extraction reused verbatim by `forward_with_profile`, new `DecoderLayer::forward_encoder_with_scalar`, new `DecoderLayer::forward_canvas`, new `Attention::forward_canvas` (same compiled proportional Q/K kernels as the encoder path, k-eq-v values on full-attention layers, maskless SDPA at scale 1.0), `parse_eos_ids` widened to pub(crate).
- `src/lib/mlxcel-core/src/cache.rs`: read-only `KVCache::visible_state()` accessor returning the live dense Fp16 K/V window without writing.
- `src/lib/mlxcel-core/src/layers.rs`: `UnifiedEmbedding::dequantized_weight()` for the soft-embedding matmul table.
- Registration: `ModelType::DiffusionGemma` keyed on `diffusion_gemma` / `diffusion_gemma_text` in detection, nonstandard directory loader, `LoadedModel::DiffusionGemma` variant + delegate arm, metadata/arch entries, TP planner placeholder arm. The `LanguageModel` impl is honest but minimal: encoder forward + norm + tied logits, dense Fp16 `make_caches`, `supports_batching() = false`.
- CLI (`src/main.rs`, `src/commands/`): new Diffusion Options flag group (`--max-denoising-steps`, `--diffusion-sampler entropy-bound|confidence-threshold`, `--diffusion-threshold`, `--diffusion-min-canvas-length`, `--diffusion-max-canvas-length`, `--diffusion-full-canvas`) plus `--seed` (seeds MLX's global RNG, also wired into the autoregressive sampling config). `run_generate_once` routes `LoadedModel::DiffusionGemma` to the new `generate_diffusion` driver (streaming via the shared incremental detokenizer, tail flush, stats output) BEFORE the autoregressive loop; the chat REPL rejects the family with a one-shot usage hint; image/audio/video inputs are rejected as phase 2.
- Server (`src/server/model_worker.rs`): both worker spawn paths reject the family at load time with "DiffusionGemma (block diffusion) is not supported in server mode yet; use the CLI: mlxcel generate -m <model> -p \"...\"".

## Test plan

- [x] `cargo test --lib models::diffusion_gemma` (23 new unit tests: entropy-bound acceptance count and mask incl. ties, confidence transfer mask incl. forced-best and force_all, temperature schedule endpoints, stability-tracker history-order semantics, canvas length rule, deterministic debug pattern, literal real-config parsing asserting the forced `attention_k_eq_v` / `enable_moe_block` flags, gate_up split arithmetic on synthetic shapes, dense windowed mask correctness for L>1 at offset>0)
- [x] `cargo test --lib models::gemma4` (existing gemma4 tests unchanged and green)
- [x] `cargo check --lib --tests` and `cargo check --bins`
- [x] `cargo clippy --lib --tests -- -D warnings` and `cargo clippy --bins -- -D warnings`
- [x] `cargo fmt`
- [x] `cargo test --test cli_help_consistency` and `cargo test --bin mlxcel` (flag defaults lock-step test included)

Real-model end-to-end verification on `models/diffusiongemma-26B-A4B-it-4bit` (coherent text + temperature-0 cross-implementation parity via the deterministic debug canvas mode) is performed by the orchestrator after this PR.


## Root cause work uncovered by the real-model gate (added after review of the first implementation)

The orchestrator's real-model verification found the canvas output garbled and nondeterministic (identical commands produced different tokens run to run), while the mlx-vlm Python reference was deterministic and correct on the same machine with the same checkpoint and even with the same MLX commit built from source. Bisection isolated two independent bugs, both fixed in this PR:

1. **Upstream MLX steel GEMM safe-load typo (cherry-picked overlay).** The pinned MLX commit (2026-05-09) indexes edge-tile columns with `off_x` instead of `off_y` in `BaseMMAFrag<T, 8, 8>::load_safe`, fixed upstream on 2026-05-18/19 (ml-explore/mlx PRs #3560/#3565). Every non-tile-aligned steel GEMM read wrong rows, and through strided views could read uninitialized parent-buffer regions, turning nondeterministic under allocator churn. DiffusionGemma hits this constantly: head_dim 256/512 SDPA routes around the fused attention kernel into steel GEMM with ragged key lengths. Carried as `patches/mlx/backend/metal/kernels/steel/gemm/mma.h`; drop on the next MLX bump. A new mlxcel-core unit test (`steel_gemm_edge_tile_safe_load_matches_reference`) pins the behavior.

2. **Graph-level slice+copy of fused expert weights is unsound as gather_qmm input.** With router indices, weights, and inputs byte-identical across runs, the first expert `gather_qmm` diverged run to run when the gate/up tensors came from `slice` + `copy`; rebuilding the same bytes into pristine dense arrays made the identical call byte-deterministic. Since every one of the 30 layers runs the MoE branch each denoising step, this single issue accounted for most of the canvas corruption. `split_gate_up_tensor` now splits on host bytes (per-expert row blocks, dtype-size aware, 16-bit dtypes through `from_bytes_f16`) once at load time. The Python reference never hits this because mlx-vlm keeps the fused gate_up projection and slices activations instead of weights.

The investigation also ruled out (with isolated experiments): the maskless fused SDPA kernel, in-graph KV-cache slices and concatenation, the compiled-op chains (`MLX_DISABLE_COMPILE` unchanged the symptom), mx eval/read-back synchronization, and threadgroup-limit violations reported by the Metal validation layer (validation instrumentation lowers pipeline limits; not a production defect). Production text models (qwen2.5, gemma-4-31b, gemma-4-26b-a4b) were re-verified deterministic and coherent after both fixes.

## Real-model verification results (M1 Ultra, models/diffusiongemma-26B-A4B-it-4bit)

- Determinism: three identical temperature-0 runs with the deterministic debug canvas produce byte-identical commit streams; the new `real_model_forward_determinism` regression test (with buffer-cache warmup, since the historical failure modes only appear under allocator churn) asserts byte-determinism of encoder and canvas forwards.
- Cross-implementation parity: with the same deterministic canvas pattern monkeypatched into mlx-vlm, the emitted token stream matches the Python reference exactly up to one near-tie whitespace token at position 14 (after which the sequences realign and continue identically); output text is the same Rayleigh-scattering explanation.
- Quality: coherent long-form output on multiple prompts (TCP/UDP explanation, haiku) at temperature 0 with seeded RNG.
- Performance: per-denoising-step time is at parity with the Python reference: 254 ms/step vs 261 ms/step on a 64-token canvas (103%), 651 ms/step vs 626 ms/step on a 256-token canvas (96%). Tokens/sec varies with the stable-and-confident early stop's trajectory (e.g. 20.0 tok/s for a 64-token answer converging in 12 steps; 8.2 tok/s for a 256-token canvas running the full 48 steps). Model load: 13.5 GiB resident.
