### PR TITLE
feat: DiffusionGemma image input (phase 2 of #217)

### DIFF
--- a/docs/block-diffusion.md
+++ b/docs/block-diffusion.md
@@ -88,14 +88,28 @@ cross-implementation parity testing against the Python reference; output is not
 useful for normal generation. See [Environment variables](environment-variables.md)
 for details.
 
-## Phase 1 limitations
+## Image input
 
-This is phase 1 of issue #217. The following are not yet supported:
+Pass one or more `--image <path>` flags to include images in the prompt. The flag is repeatable for multi-image prompts.
 
-- **Image input**: DiffusionGemma's vision tower is loaded but not wired. Passing
-  `--image` raises an error with a note to wait for phase 2.
+```
+mlxcel generate -m google/diffusiongemma-26B-A4B-it \
+  --image photo.jpg \
+  -p "Describe what you see." \
+  --max-tokens 256 \
+  --seed 42
+```
+
+Preprocessing reuses the Gemma 4 vision pipeline: images are resized and padded to 768x768, then projected into 256 soft tokens per image. Each image block receives bidirectional attention during prefill, matching the same overlay used by Gemma 4 Unified. The image tokens are inserted into the prompt sequence between the `boi` and `eoi` sentinel tokens.
+
+Video and audio inputs are not supported and are rejected with a clear error message.
+
+## Remaining limitations (phase 2)
+
+The following are not yet supported:
+
 - **Server mode**: `mlxcel serve` and `mlxcel-server` reject DiffusionGemma at
-  load time. Use `mlxcel generate` from the CLI.
+  load time. Use `mlxcel generate` from the CLI. Server support is planned for phase 3 of issue #217.
 - **Tensor parallelism**: The TP planner has a placeholder arm for this family.
 
 ## Usage example

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -44,15 +44,14 @@ requirements. If a checkpoint fails detection or loading, inspect its
 
 | Family | `model_type` key | Notes |
 |--------|-----------------|-------|
-| DiffusionGemma | `diffusion_gemma` / `diffusion_gemma_text` | Block-diffusion on a Gemma 4 MoE backbone. Generates a canvas of tokens per block through iterative denoising rather than token-by-token left-to-right decoding. Phase 1: text-only CLI (`mlxcel generate`). Image input and server mode are not yet supported. See [Block-diffusion generation](block-diffusion.md). |
+| DiffusionGemma | `diffusion_gemma` / `diffusion_gemma_text` | Block-diffusion on a Gemma 4 MoE backbone. Generates a canvas of tokens per block through iterative denoising rather than token-by-token left-to-right decoding. CLI (`mlxcel generate`) supports text and image input (`--image <path>`, repeatable). Server mode is not yet supported. See [Block-diffusion generation](block-diffusion.md). |
 
 DiffusionGemma uses a two-phase forward pass: an encoder prefill that caches the
 prompt into dense FP16 KV caches, then a canvas loop that attends bidirectionally
 within each output block while attending causally to the cached prefix.
 Load detection accepts `model_type: "diffusion_gemma"` (outer config) and
 `model_type: "diffusion_gemma_text"` (inner `text_config`).
-The fused MoE `gate_up_proj` weights are split at load time; vision-tower weights
-are skipped without error.
+The fused MoE `gate_up_proj` weights are split at load time. When a vision tower is present in the checkpoint, its weights are loaded and wired for image input; checkpoints without vision weights fall back to text-only mode without error.
 
 ## Vision-language and multimodal variants
 

--- a/src/commands/generate_diffusion.rs
+++ b/src/commands/generate_diffusion.rs
@@ -12,25 +12,115 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! CLI driver for block-diffusion text generation (issue #217, phase 1).
+//! CLI driver for block-diffusion text generation (issue #217, phases 1-2).
 //!
 //! Thin bridge between the parsed [`crate::GenerateArgs`] flag surface and
 //! [`DiffusionGemmaModel::generate_diffusion_streaming`]: resolves the
-//! diffusion options, seeds the RNG, streams decoded text through the shared
-//! incremental detokenizer, and prints the generation stats.
+//! diffusion options, seeds the RNG, optionally preprocesses image input and
+//! expands the prompt with image tokens, streams decoded text through the
+//! shared incremental detokenizer, and prints the generation stats.
 
 use anyhow::{Result, anyhow};
 use std::io::{self, Write as IoWrite};
+use std::path::Path;
 
 use mlxcel::models::DiffusionGemmaModel;
 use mlxcel::models::diffusion_gemma::{
     DiffusionGenerateOptions, DiffusionGenerationStats, DiffusionSamplerKind,
+    DiffusionVisionPrefill,
 };
 use mlxcel::server::model_provider::model_worker::StreamingDecodeState;
 use mlxcel::tokenizer::MlxcelTokenizer;
+use mlxcel::vision::processors::gemma4::{Gemma4ImageInput, Gemma4Processor};
 
 use super::generate::print_generation_preamble;
 use crate::GenerateArgs;
+
+/// Build the Gemma 4 image processor for the DiffusionGemma checkpoint.
+///
+/// The diffusion checkpoint's `image_processor` is identical to the gemma-4
+/// VLM family (size 224x224, patch 16, pooling_kernel_size 3, 280 soft
+/// tokens). Values are read from `processor_config.json` when present and
+/// fall back to those defaults otherwise.
+fn build_image_processor(model_dir: &Path, default_soft_tokens: usize) -> Gemma4Processor {
+    let image_cfg = std::fs::read_to_string(model_dir.join("processor_config.json"))
+        .ok()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .and_then(|cfg| cfg.get("image_processor").cloned());
+    let get = |key: &str, default: usize| -> usize {
+        image_cfg
+            .as_ref()
+            .and_then(|cfg| cfg.get(key))
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize)
+            .unwrap_or(default)
+    };
+    Gemma4Processor::new(
+        get("patch_size", 16),
+        get("max_soft_tokens", default_soft_tokens),
+        get("pooling_kernel_size", 3),
+    )
+}
+
+/// Result of preparing image input: the expanded prompt ids (with each image
+/// placeholder rewritten to `boi + image_token * N + eoi`) and the prefill.
+struct PreparedDiffusionVision {
+    expanded_ids: Vec<i32>,
+    prefill: DiffusionVisionPrefill,
+}
+
+/// Preprocess `--image` paths, expand the prompt, and build the vision
+/// prefill (inputs_embeds + overlay block ids).
+fn prepare_diffusion_vision(
+    model: &DiffusionGemmaModel,
+    model_dir: &Path,
+    image_paths: &[std::path::PathBuf],
+    prompt_tokens: &[i32],
+) -> Result<PreparedDiffusionVision> {
+    let vision = model.vision().ok_or_else(|| {
+        anyhow!(
+            "This DiffusionGemma checkpoint does not include a vision tower; \
+             run with a text-only prompt"
+        )
+    })?;
+
+    let images: Vec<image::DynamicImage> = image_paths
+        .iter()
+        .map(|path| {
+            image::open(path).map_err(|e| anyhow!("Failed to load image {:?}: {}", path, e))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    println!("Loaded {} image(s).", images.len());
+
+    let processor = build_image_processor(model_dir, vision.soft_tokens_per_image);
+    let processed: Vec<Gemma4ImageInput> = processor.preprocess(&images);
+    let num_soft_tokens: Vec<usize> = processed.iter().map(|img| img.num_soft_tokens).collect();
+
+    let mut expanded_ids = prompt_tokens.to_vec();
+    mlxcel::vlm_runtime::expand_gemma4_image_tokens_pub(
+        &mut expanded_ids,
+        vision.image_token_id,
+        vision.boi_token_id,
+        vision.eoi_token_id,
+        &num_soft_tokens,
+    )?;
+
+    let prefill = model
+        .prepare_vision_prefill(&expanded_ids, &processed)
+        .map_err(|e| anyhow!("{e}"))?;
+
+    println!(
+        "DiffusionGemma: expanded {} image(s) into {} soft token(s) ({} total prompt tokens)",
+        images.len(),
+        num_soft_tokens.iter().sum::<usize>(),
+        expanded_ids.len()
+    );
+
+    Ok(PreparedDiffusionVision {
+        expanded_ids,
+        prefill,
+    })
+}
 
 fn parse_sampler_kind(name: &str) -> Result<DiffusionSamplerKind> {
     match name {
@@ -85,8 +175,8 @@ fn print_diffusion_stats(stats: &DiffusionGenerationStats, profile: bool) {
 
 /// Run one block-diffusion generation for the CLI `generate` flow.
 ///
-/// Phase 1 is text-only; image/audio/video inputs are rejected with a clear
-/// error (phase 2).
+/// Text-only (phase 1) and single/multi image input (phase 2) are supported;
+/// audio and video inputs are rejected with a clear error.
 pub(crate) fn run_diffusion_generation(
     model: &DiffusionGemmaModel,
     args: &GenerateArgs,
@@ -94,13 +184,20 @@ pub(crate) fn run_diffusion_generation(
     prompt_tokens: &[i32],
     user_prompt: &str,
 ) -> Result<()> {
-    if !args.generation.image.is_empty()
-        || args.generation.audio.is_some()
-        || !args.generation.video.is_empty()
-    {
+    if args.generation.audio.is_some() {
         return Err(anyhow!(
-            "DiffusionGemma image/audio/video input is not supported yet (phase 2 of issue \
-             #217); run with a text-only prompt"
+            "DiffusionGemma audio input is not supported; run with text or --image input"
+        ));
+    }
+    if !args.generation.video.is_empty() {
+        return Err(anyhow!(
+            "DiffusionGemma video input is not supported; run with text or --image input"
+        ));
+    }
+    if !args.generation.image.is_empty() && !model.supports_images() {
+        return Err(anyhow!(
+            "This DiffusionGemma checkpoint does not include a vision tower; \
+             run with a text-only prompt"
         ));
     }
     if args.model.draft_model.is_some() {
@@ -115,18 +212,36 @@ pub(crate) fn run_diffusion_generation(
         mlxcel_core::random_seed(seed);
     }
 
+    // Image input: preprocess + expand the prompt before seeding the decode
+    // state, so the generated-token detokenizer sees the expanded prefix.
+    let prepared_vision = if args.generation.image.is_empty() {
+        None
+    } else {
+        Some(prepare_diffusion_vision(
+            model,
+            Path::new(&args.model.model),
+            &args.generation.image,
+            prompt_tokens,
+        )?)
+    };
+    let (engine_prompt_tokens, vision_prefill): (&[i32], Option<&DiffusionVisionPrefill>) =
+        match &prepared_vision {
+            Some(prepared) => (&prepared.expanded_ids, Some(&prepared.prefill)),
+            None => (prompt_tokens, None),
+        };
+
     print_generation_preamble(user_prompt)?;
 
     // Stream through the shared incremental detokenizer (byte-fallback
     // safe); raw ids are collected in parallel so any held-back tail bytes
     // can be flushed from a byte-exact full decode afterward.
-    let mut decode_state = StreamingDecodeState::new(tokenizer, prompt_tokens);
+    let mut decode_state = StreamingDecodeState::new(tokenizer, engine_prompt_tokens);
     let mut generated_ids: Vec<u32> = Vec::with_capacity(options.max_new_tokens);
     let mut streamed = String::new();
     let mut stdout = io::stdout();
 
     let stats = model
-        .generate_diffusion_streaming(prompt_tokens, &options, |token_id| {
+        .generate_diffusion_streaming(engine_prompt_tokens, &options, vision_prefill, |token_id| {
             generated_ids.push(token_id as u32);
             if let Some(text) = decode_state.on_token(token_id, tokenizer) {
                 print!("{text}");

--- a/src/models/diffusion_gemma/generate.rs
+++ b/src/models/diffusion_gemma/generate.rs
@@ -23,7 +23,7 @@
 //! on a stable-and-confident canvas, then commit the block to the KV-cached
 //! prefix and stream its tokens.
 
-use super::{DiffusionGemmaModel, DiffusionStoppingConfig};
+use super::{DiffusionGemmaModel, DiffusionStoppingConfig, DiffusionVisionPrefill};
 use mlxcel_core::layers::KVCache;
 use mlxcel_core::{MlxArray, UniquePtr, dtype};
 use std::collections::VecDeque;
@@ -388,10 +388,19 @@ impl DiffusionGemmaModel {
     /// `on_token` receives each emitted token id and returns `false` to
     /// abort. EOS ids stop the generation WITHOUT being emitted. Mirrors
     /// `stream_diffusion_generate` (batch-1, no padding, dynamic cache).
+    ///
+    /// `vision`, when present, supplies the pre-built `inputs_embeds` and the
+    /// vision-block overlay for the prompt prefill (image input, phase 2).
+    /// `prompt_tokens` must then be the EXPANDED prompt ids (so its length
+    /// matches `inputs_embeds`). With an image present the prompt prefill runs
+    /// as a single embeddings pass (chunked prefill is disabled, mirroring the
+    /// reference `_diffusion_should_chunk_prefill`); committed-block appends
+    /// remain token-based and overlay-free.
     pub fn generate_diffusion_streaming<F: FnMut(i32) -> bool>(
         &self,
         prompt_tokens: &[i32],
         options: &DiffusionGenerateOptions,
+        vision: Option<&DiffusionVisionPrefill>,
         mut on_token: F,
     ) -> Result<DiffusionGenerationStats, String> {
         if prompt_tokens.is_empty() {
@@ -436,10 +445,22 @@ impl DiffusionGemmaModel {
         let mut rng = CanvasRng::new(vocab_size);
         let debug_mode = rng.debug;
 
-        // Prompt prefill (chunked for long prompts; batch-1 / no padding
-        // always holds on this path).
+        // Prompt prefill. With vision input, run a single embeddings pass with
+        // the bidirectional overlay (chunked prefill disabled, like the
+        // reference). Text-only prompts use the token path (chunked for long
+        // prompts; batch-1 / no padding always holds here).
         let prefill_start = Instant::now();
-        if prompt_tokens.len() > options.prefill_chunk_size {
+        if let Some(vision) = vision {
+            let _ = self.forward_encoder_embeds(
+                &vision.inputs_embeds,
+                &mut caches,
+                None,
+                vision.vision_block_ids.as_deref(),
+            );
+            for cache in &caches {
+                cache.eval_state();
+            }
+        } else if prompt_tokens.len() > options.prefill_chunk_size {
             for chunk in prompt_tokens.chunks(options.prefill_chunk_size) {
                 let ids = mlxcel_core::from_slice_i32(chunk, &[1, chunk.len() as i32]);
                 let _ = self.forward_encoder(&ids, &mut caches, None);

--- a/src/models/diffusion_gemma/mod.rs
+++ b/src/models/diffusion_gemma/mod.rs
@@ -905,6 +905,23 @@ impl DiffusionGemmaModel {
             .iter()
             .map(|&id| i32::from(id == vision.image_token_id || id == vision.video_token_id))
             .collect();
+
+        // The projected features must line up exactly with the image-token
+        // positions. `masked_scatter` wraps source indices modulo the feature
+        // count, so a mismatch (e.g. a config that points `image_token_id` at a
+        // common text token, or a tower/processor soft-token disagreement)
+        // would silently scatter the wrong rows rather than fault. Reject it.
+        let vision_positions = is_vision.iter().filter(|&&v| v != 0).count();
+        let feature_count = mlxcel_core::array_shape(&merged)
+            .get(1)
+            .copied()
+            .unwrap_or(0) as usize;
+        if vision_positions != feature_count {
+            return Err(format!(
+                "DiffusionGemma: image-token positions ({vision_positions}) do not match                  projected vision features ({feature_count}); check image_token_id and the                  soft-token expansion"
+            ));
+        }
+
         let mask_2d = mlxcel_core::from_slice_i32(&is_vision, &[1, l]);
         let mask_bool = mlxcel_core::astype(&mask_2d, dtype::BOOL);
         let mask_expanded =

--- a/src/models/diffusion_gemma/mod.rs
+++ b/src/models/diffusion_gemma/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! DiffusionGemma block-diffusion text model (issue #217, phase 1).
+//! DiffusionGemma block-diffusion model (issue #217, phases 1-2).
 //!
 //! `google/diffusiongemma-26B-A4B-it` reuses the Gemma 4 26B-A4B MoE text
 //! backbone but generates by denoising a canvas of up to `canvas_length`
@@ -30,10 +30,14 @@
 //! Reference: `references/mlx-vlm/mlx_vlm/models/diffusion_gemma/` and
 //! `references/mlx-vlm/mlx_vlm/generate/diffusion.py`.
 //!
-//! Phase 1 is text-only: the checkpoint's vision tower
-//! (`model.encoder.vision_tower.*`, `model.encoder.embed_vision.*`) is
-//! intentionally skipped at load time. Image input is phase 2; server
-//! serving is phase 3.
+//! Phase 2 adds image input: when the checkpoint ships the Gemma 4 vision
+//! tower (`model.encoder.vision_tower.*`) and the multimodal embedder
+//! (`model.encoder.embed_vision.*`), the prompt prefill runs as an
+//! embeddings pass that masked-scatters projected image features into the
+//! image-token positions and applies the `use_bidirectional_attention ==
+//! "vision"` overlay. Text-only checkpoints load with [`DiffusionVision`] =
+//! `None` and the text path stays byte-identical to phase 1. Server serving
+//! is phase 3.
 
 mod generate;
 
@@ -43,8 +47,13 @@ pub use generate::{
 };
 
 use crate::models::gemma4::{
-    Gemma4TextModel, QuantizationArgs, RMSNormNoScale, RootQuantization, TextConfig, parse_eos_ids,
+    Gemma4TextModel, QuantizationArgs, RMSNormNoScale, RootQuantization, TextConfig,
+    overlay_block_bidirectional, parse_eos_ids,
 };
+use crate::vision::encoders::gemma4::{Gemma4VisionConfig, Gemma4VisionModel};
+use crate::vision::gemma4_multimodal_embedder::Gemma4MultimodalEmbedder;
+use crate::vision::gemma4_unified_mask::{UnifiedTokenIds, compute_vision_block_ids};
+use crate::vision::processors::gemma4::Gemma4ImageInput;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
@@ -165,6 +174,9 @@ impl DiffusionGenerationConfig {
     }
 }
 
+/// Default soft tokens contributed by one image (`config.json` omits it).
+const DEFAULT_VISION_SOFT_TOKENS_PER_IMAGE: usize = 280;
+
 /// Top-level `config.json` arguments for `model_type == "diffusion_gemma"`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ModelArgs {
@@ -178,6 +190,19 @@ pub struct ModelArgs {
     generation_config: Option<GenerationConfigRaw>,
     #[serde(default)]
     pub quantization: Option<RootQuantization>,
+    // Vision front-end (phase 2). All optional: text-only exports omit them.
+    #[serde(default)]
+    pub boi_token_id: Option<i32>,
+    #[serde(default)]
+    pub eoi_token_id: Option<i32>,
+    #[serde(default)]
+    pub image_token_id: Option<i32>,
+    #[serde(default)]
+    pub video_token_id: Option<i32>,
+    #[serde(default)]
+    pub vision_soft_tokens_per_image: Option<usize>,
+    #[serde(default)]
+    pub vision_config: Option<serde_json::Value>,
 }
 
 impl ModelArgs {
@@ -228,6 +253,43 @@ impl ModelArgs {
 
     pub fn canvas_length(&self) -> usize {
         self.canvas_length.unwrap_or(DEFAULT_CANVAS_LENGTH)
+    }
+
+    pub fn image_token_id(&self) -> i32 {
+        self.image_token_id.unwrap_or(258_880)
+    }
+
+    pub fn boi_token_id(&self) -> i32 {
+        self.boi_token_id.unwrap_or(255_999)
+    }
+
+    pub fn eoi_token_id(&self) -> i32 {
+        self.eoi_token_id.unwrap_or(258_882)
+    }
+
+    /// Video token id, or `-1` when the checkpoint has none (DiffusionGemma
+    /// chat checkpoints set `video_token_id: null`). `-1` never matches a
+    /// real token id, so it cleanly disables the video branch.
+    pub fn video_token_id(&self) -> i32 {
+        self.video_token_id.unwrap_or(-1)
+    }
+
+    pub fn vision_soft_tokens_per_image(&self) -> usize {
+        self.vision_soft_tokens_per_image
+            .unwrap_or(DEFAULT_VISION_SOFT_TOKENS_PER_IMAGE)
+    }
+
+    /// Parse the nested `vision_config` into a [`Gemma4VisionConfig`], or
+    /// `None` when the checkpoint omits it (text-only export).
+    pub fn vision_config(&self) -> Result<Option<Gemma4VisionConfig>, String> {
+        match &self.vision_config {
+            Some(value) => {
+                let config: Gemma4VisionConfig = serde_json::from_value(value.clone())
+                    .map_err(|e| format!("DiffusionGemma: failed to parse vision_config: {e}"))?;
+                Ok(Some(config))
+            }
+            None => Ok(None),
+        }
     }
 
     /// EOS ids: union of the top-level `eos_token_id`, the embedded
@@ -454,6 +516,49 @@ impl SelfConditioning {
 }
 
 // ---------------------------------------------------------------------------
+// Vision front-end (phase 2)
+// ---------------------------------------------------------------------------
+
+/// DiffusionGemma vision front-end: the Gemma 4 vision tower plus the
+/// multimodal embedder that projects tower features into the language
+/// model's embedding space (`model.encoder.vision_tower.*`,
+/// `model.encoder.embed_vision.*`).
+///
+/// Present only when the checkpoint ships vision weights; text-only exports
+/// leave [`DiffusionGemmaModel::vision`] as `None`.
+pub struct DiffusionVision {
+    vision_tower: Gemma4VisionModel,
+    embed_vision: Gemma4MultimodalEmbedder,
+    pub image_token_id: i32,
+    pub boi_token_id: i32,
+    pub eoi_token_id: i32,
+    pub video_token_id: i32,
+    pub soft_tokens_per_image: usize,
+}
+
+impl DiffusionVision {
+    /// Run the vision tower and the multimodal embedder for one preprocessed
+    /// image, returning projected features `[1, num_soft_tokens, hidden]`.
+    fn image_features(&self, image: &Gemma4ImageInput) -> UniquePtr<MlxArray> {
+        let pixel_values = image
+            .pixel_values
+            .as_ref()
+            .expect("DiffusionGemma image pixel_values must be non-null");
+        let tower = self.vision_tower.forward(pixel_values, image.patch_grid);
+        self.embed_vision.forward(&tower)
+    }
+}
+
+/// Vision inputs prepared for one diffusion prefill: the scattered,
+/// embed-scaled `inputs_embeds` for the expanded prompt and the per-position
+/// vision block ids that drive the bidirectional overlay (or `None` when no
+/// vision block is present / the overlay is disabled).
+pub struct DiffusionVisionPrefill {
+    pub(crate) inputs_embeds: UniquePtr<MlxArray>,
+    pub(crate) vision_block_ids: Option<Vec<i32>>,
+}
+
+// ---------------------------------------------------------------------------
 // Model
 // ---------------------------------------------------------------------------
 
@@ -468,6 +573,11 @@ pub struct DiffusionGemmaModel {
     pub(crate) generation_config: DiffusionGenerationConfig,
     pub(crate) eos_token_ids: Vec<i32>,
     pub(crate) embed_scale: f32,
+    /// Vision front-end, present only when the checkpoint ships a tower.
+    pub(crate) vision: Option<DiffusionVision>,
+    /// Whether `text_config.use_bidirectional_attention == "vision"`: gates
+    /// the bidirectional vision-block overlay on the encoder prefill.
+    pub(crate) use_bidirectional_vision: bool,
     _weight_backing: super::sanitize::Gemma4WeightBacking,
 }
 
@@ -481,8 +591,18 @@ impl DiffusionGemmaModel {
         let args: ModelArgs = serde_json::from_str(&config_str)
             .map_err(|e| format!("Failed to parse config.json: {e}"))?;
 
+        // `use_clipped_linears` from the vision config decides whether the
+        // tower's clipped-linear calibration tensors are kept. Text-only
+        // checkpoints have no vision config; default to false (drop them).
+        let use_clipped_linears = args
+            .vision_config()?
+            .map(|vc| vc.use_clipped_linears)
+            .unwrap_or(false);
         let (mut weights, weight_backing) =
-            super::sanitize::load_diffusion_gemma_text_weights_with_backing(model_dir)?;
+            super::sanitize::load_diffusion_gemma_weights_with_backing(
+                model_dir,
+                use_clipped_linears,
+            )?;
         let mut model = Self::from_weights(&mut weights, &args)?;
         model._weight_backing = weight_backing;
         Ok(model)
@@ -517,6 +637,16 @@ impl DiffusionGemmaModel {
         let eos_token_ids = args.eos_token_ids(&generation_config);
         let embed_scale = (config.hidden_size as f32).sqrt();
 
+        // Vision front-end: build it only when both a parsed vision config and
+        // the tower weights are present. A text-only export (no vision_config,
+        // no `model.encoder.vision_tower.*` keys) leaves `vision` as None.
+        let vision = Self::build_vision(weights, &config, args)?;
+        let use_bidirectional_vision = config
+            .use_bidirectional_attention
+            .as_deref()
+            .map(|s| s == "vision")
+            .unwrap_or(false);
+
         Ok(Self {
             text,
             self_conditioning,
@@ -525,8 +655,76 @@ impl DiffusionGemmaModel {
             generation_config,
             eos_token_ids,
             embed_scale,
+            vision,
+            use_bidirectional_vision,
             _weight_backing: super::sanitize::Gemma4WeightBacking::default(),
         })
+    }
+
+    /// Build the optional vision front-end from `model.encoder.vision_tower.*`
+    /// and `model.encoder.embed_vision.*`. Returns `None` for text-only
+    /// checkpoints (no `vision_config`, or no tower weights present).
+    fn build_vision(
+        weights: &WeightMap,
+        config: &TextConfig,
+        args: &ModelArgs,
+    ) -> Result<Option<DiffusionVision>, String> {
+        let Some(vision_config) = args.vision_config()? else {
+            return Ok(None);
+        };
+        // Tolerate a vision_config without tower weights (text-only shard set):
+        // the projection weight is the canonical marker of a real front-end.
+        if !weights.contains_key("model.encoder.embed_vision.embedding_projection.weight") {
+            return Ok(None);
+        }
+
+        let group_size = config
+            .quantization
+            .as_ref()
+            .map(|q| q.group_size as i32)
+            .unwrap_or(64);
+        let bits = config
+            .quantization
+            .as_ref()
+            .map(|q| q.bits as i32)
+            .unwrap_or(4);
+
+        let vision_tower = Gemma4VisionModel::from_weights(
+            weights,
+            "model.encoder.vision_tower",
+            &vision_config,
+            group_size,
+            bits,
+        )?;
+        let embed_vision = Gemma4MultimodalEmbedder::from_weights(
+            weights,
+            "model.encoder.embed_vision",
+            vision_config.hidden_size,
+            vision_config.rms_norm_eps(),
+            group_size,
+            bits,
+        )?;
+
+        Ok(Some(DiffusionVision {
+            vision_tower,
+            embed_vision,
+            image_token_id: args.image_token_id(),
+            boi_token_id: args.boi_token_id(),
+            eoi_token_id: args.eoi_token_id(),
+            video_token_id: args.video_token_id(),
+            soft_tokens_per_image: args.vision_soft_tokens_per_image(),
+        }))
+    }
+
+    /// Whether this checkpoint loaded a vision front-end (phase 2 capable).
+    pub fn supports_images(&self) -> bool {
+        self.vision.is_some()
+    }
+
+    /// Vision token ids / soft-token count for prompt expansion, or `None`
+    /// for a text-only checkpoint.
+    pub fn vision(&self) -> Option<&DiffusionVision> {
+        self.vision.as_ref()
     }
 
     pub fn config(&self) -> &TextConfig {
@@ -569,9 +767,31 @@ impl DiffusionGemmaModel {
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
         let embeds = self.text.embed_tokens.forward(input_ids);
-        let mut h = mlxcel_core::multiply_scalar(&embeds, self.embed_scale);
+        let embeds = mlxcel_core::multiply_scalar(&embeds, self.embed_scale);
+        // Text path: no vision-block overlay. Byte-identical to the phase-1
+        // forward_encoder for an all-text prompt.
+        self.forward_encoder_embeds(&embeds, caches, mask, None)
+    }
 
-        let shape = mlxcel_core::array_shape(&h);
+    /// Embeddings-input encoder forward (issue #217, phase 2).
+    ///
+    /// `inputs_embeds` is the already-`embed_scale`-scaled (and, for vision,
+    /// feature-scattered) hidden state `[1, L, hidden]`. `vision_block_ids`,
+    /// when present, is the per-position vision block-id vector that drives
+    /// the bidirectional overlay (OR-ed on top of the causal / sliding-window
+    /// masks for every layer), matching `_vision_block_overlay` /
+    /// `_make_encoder_masks` in the reference. The overlay applies only when
+    /// this routine builds its own masks (`mask == None`), i.e. the prompt
+    /// prefill at cache offset 0; continuation encoder passes over committed
+    /// blocks pass `vision_block_ids == None`.
+    pub(crate) fn forward_encoder_embeds(
+        &self,
+        inputs_embeds: &MlxArray,
+        caches: &mut [KVCache],
+        mask: Option<&MlxArray>,
+        vision_block_ids: Option<&[i32]>,
+    ) -> UniquePtr<MlxArray> {
+        let shape = mlxcel_core::array_shape(inputs_embeds);
         let l = shape[1];
         let offset = caches.first().map(|c| c.offset).unwrap_or(0);
         let window = self.text.config.sliding_window as i32;
@@ -580,7 +800,7 @@ impl DiffusionGemmaModel {
         // the FULL key axis [0, offset + l), so the rotating-cache-shaped
         // helpers (which cap the sliding mask to the window width) do not
         // apply here.
-        let (global_mask, sliding_mask) = match mask {
+        let (mut global_mask, mut sliding_mask) = match mask {
             Some(m) => (mlxcel_core::copy(m), mlxcel_core::copy(m)),
             None => (
                 mlxcel_core::utils::create_causal_mask(l, offset),
@@ -588,20 +808,132 @@ impl DiffusionGemmaModel {
             ),
         };
 
+        // Bidirectional vision-block overlay: every contiguous image block
+        // attends to itself in both directions, OR-ed onto the causal /
+        // sliding base masks for ALL layers.
+        if let Some(block_ids) = vision_block_ids {
+            let ids = mlxcel_core::from_slice_i32(block_ids, &[block_ids.len() as i32]);
+            global_mask = overlay_block_bidirectional(&global_mask, &ids);
+            sliding_mask = overlay_block_bidirectional(&sliding_mask, &ids);
+        }
+
+        let mut h: Option<UniquePtr<MlxArray>> = None;
         for (i, layer) in self.text.layers.iter().enumerate() {
             let local_mask = if layer.layer_type == "full_attention" {
                 &global_mask
             } else {
                 &sliding_mask
             };
-            h = layer.forward_encoder_with_scalar(
-                &h,
+            let input = h
+                .as_ref()
+                .map(|p| p.as_ref().expect("non-null encoder hidden") as &MlxArray)
+                .unwrap_or(inputs_embeds);
+            let out = layer.forward_encoder_with_scalar(
+                input,
                 Some(local_mask),
                 &mut caches[i],
                 &self.encoder_layer_scalars[i],
             );
+            h = Some(out);
         }
-        h
+        h.unwrap_or_else(|| mlxcel_core::copy(inputs_embeds))
+    }
+
+    /// Build the embed-scaled, feature-scattered `inputs_embeds` for one
+    /// vision prompt and the per-position vision block ids for the overlay.
+    ///
+    /// Mirrors `EncoderModel._embed_inputs`: image-token positions are
+    /// replaced by `pad_token_id` for the embedding lookup, the text
+    /// embeddings are scaled by `embed_scale`, and the RAW (unscaled) image
+    /// features are masked-scattered into the image positions.
+    ///
+    /// `expanded_ids` is the prompt after image-placeholder expansion
+    /// (`boi + image_token * soft_tokens + eoi`); batch is always 1.
+    pub fn prepare_vision_prefill(
+        &self,
+        expanded_ids: &[i32],
+        images: &[Gemma4ImageInput],
+    ) -> Result<DiffusionVisionPrefill, String> {
+        let vision = self.vision.as_ref().ok_or_else(|| {
+            "DiffusionGemma: this checkpoint has no vision tower; image input is unsupported"
+                .to_string()
+        })?;
+        if expanded_ids.is_empty() {
+            return Err("DiffusionGemma: prompt must contain at least one token".to_string());
+        }
+
+        let l = expanded_ids.len() as i32;
+        let hidden = self.text.config.hidden_size as i32;
+
+        // Pad image/video positions to id 0 for the lookup (Gemma pad_token_id
+        // == 0); those rows are overwritten by the scatter below.
+        let lookup_ids: Vec<i32> = expanded_ids
+            .iter()
+            .map(|&id| {
+                if id == vision.image_token_id || id == vision.video_token_id {
+                    0
+                } else {
+                    id
+                }
+            })
+            .collect();
+        let lookup_arr = mlxcel_core::from_slice_i32(&lookup_ids, &[1, l]);
+        let text_embeds = self.text.embed_tokens.forward(&lookup_arr);
+        let inputs_embeds = mlxcel_core::multiply_scalar(&text_embeds, self.embed_scale);
+
+        // Image features (raw embedder output, NOT scaled by embed_scale),
+        // concatenated along the sequence axis in prompt order.
+        let mut features: Vec<UniquePtr<MlxArray>> = Vec::with_capacity(images.len());
+        for image in images {
+            features.push(vision.image_features(image));
+        }
+        if features.is_empty() {
+            return Err("DiffusionGemma: image input requested but no images supplied".to_string());
+        }
+        let mut merged = mlxcel_core::copy(features[0].as_ref().expect("non-null image features"));
+        for next in features.iter().skip(1) {
+            merged = mlxcel_core::concatenate(
+                &merged,
+                next.as_ref().expect("non-null image features"),
+                1,
+            );
+        }
+        let merged = mlxcel_core::astype(&merged, mlxcel_core::array_dtype(&inputs_embeds));
+
+        // Vision mask broadcast to the embedding shape, then masked-scatter.
+        let is_vision: Vec<i32> = expanded_ids
+            .iter()
+            .map(|&id| i32::from(id == vision.image_token_id || id == vision.video_token_id))
+            .collect();
+        let mask_2d = mlxcel_core::from_slice_i32(&is_vision, &[1, l]);
+        let mask_bool = mlxcel_core::astype(&mask_2d, dtype::BOOL);
+        let mask_expanded =
+            mlxcel_core::broadcast_to(&mlxcel_core::expand_dims(&mask_bool, -1), &[1, l, hidden]);
+        let inputs_embeds = crate::vision::gemma4_multimodal_embedder::masked_scatter(
+            &inputs_embeds,
+            &mask_expanded,
+            &merged,
+        );
+
+        // Per-position vision block ids for the bidirectional overlay.
+        let vision_block_ids = if self.use_bidirectional_vision {
+            compute_vision_block_ids(
+                expanded_ids,
+                UnifiedTokenIds {
+                    image: vision.image_token_id,
+                    video: vision.video_token_id,
+                    audio: -1,
+                },
+                true,
+            )
+        } else {
+            None
+        };
+
+        Ok(DiffusionVisionPrefill {
+            inputs_embeds,
+            vision_block_ids,
+        })
     }
 
     /// Canvas (decoder-mode) forward: denoise one canvas against the

--- a/src/models/diffusion_gemma/tests.rs
+++ b/src/models/diffusion_gemma/tests.rs
@@ -202,6 +202,22 @@ const REAL_CONFIG_SNIPPET: &str = r#"{
   "image_token_id": 258880,
   "tie_word_embeddings": true,
   "vision_soft_tokens_per_image": 280,
+  "vision_config": {
+    "model_type": "gemma4_vision",
+    "hidden_size": 1152,
+    "intermediate_size": 4304,
+    "num_hidden_layers": 27,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 16,
+    "head_dim": 72,
+    "global_head_dim": 72,
+    "patch_size": 16,
+    "pooling_kernel_size": 3,
+    "rms_norm_eps": 1e-06,
+    "standardize": true,
+    "use_clipped_linears": false,
+    "rope_parameters": {"rope_theta": 100.0, "rope_type": "default"}
+  },
   "generation_config": {
     "confidence_threshold": 0.005,
     "eos_token_id": [1, 106, 50],
@@ -485,4 +501,275 @@ fn real_model_forward_determinism() {
         canvas_a, canvas_b,
         "canvas forward must be byte-deterministic across runs"
     );
+}
+
+// -------------------------------------------------------------------------
+// Vision config parsing (phase 2)
+// -------------------------------------------------------------------------
+
+#[test]
+fn parses_vision_config_fields() {
+    let args: ModelArgs = serde_json::from_str(REAL_CONFIG_SNIPPET).expect("config parses");
+    assert_eq!(args.image_token_id(), 258_880);
+    assert_eq!(args.boi_token_id(), 255_999);
+    assert_eq!(args.eoi_token_id(), 258_882);
+    // The chat checkpoint has no video token; the accessor must fall back to
+    // -1 so the video branch is cleanly disabled (never matches a real id).
+    assert_eq!(args.video_token_id(), -1);
+    assert_eq!(args.vision_soft_tokens_per_image(), 280);
+
+    let vision = args
+        .vision_config()
+        .expect("vision_config parses")
+        .expect("vision_config present");
+    assert_eq!(vision.hidden_size, 1152);
+    assert_eq!(vision.num_hidden_layers, 27);
+    assert_eq!(vision.patch_size, 16);
+    assert_eq!(vision.pooling_kernel_size, 3);
+    assert!(!vision.use_clipped_linears);
+    assert!((vision.rms_norm_eps() - 1e-6).abs() < 1e-9);
+}
+
+#[test]
+fn vision_config_absent_for_text_only_export() {
+    // A text-only export drops the vision fields entirely.
+    let mut value: serde_json::Value =
+        serde_json::from_str(REAL_CONFIG_SNIPPET).expect("config parses");
+    let obj = value.as_object_mut().expect("object");
+    obj.remove("vision_config");
+    obj.remove("image_token_id");
+    let args: ModelArgs = serde_json::from_value(value).expect("text-only config parses");
+    assert!(
+        args.vision_config().expect("ok").is_none(),
+        "no vision_config => None"
+    );
+    // The image token id falls back to the family default even when absent.
+    assert_eq!(args.image_token_id(), 258_880);
+}
+
+// -------------------------------------------------------------------------
+// Prompt image-token expansion (phase 2)
+// -------------------------------------------------------------------------
+
+const IMAGE_TOKEN: i32 = 258_880;
+const BOI_TOKEN: i32 = 255_999;
+const EOI_TOKEN: i32 = 258_882;
+
+#[test]
+fn expands_single_image_placeholder() {
+    // BOS, <start_of_image> placeholder, then a text token.
+    let mut tokens = vec![2, BOI_TOKEN, 9999];
+    crate::vlm_runtime::expand_gemma4_image_tokens_pub(
+        &mut tokens,
+        IMAGE_TOKEN,
+        BOI_TOKEN,
+        EOI_TOKEN,
+        &[4],
+    )
+    .expect("expansion succeeds");
+    // The placeholder becomes boi + image*4 + eoi.
+    let mut expected = vec![2, BOI_TOKEN];
+    expected.extend(std::iter::repeat_n(IMAGE_TOKEN, 4));
+    expected.push(EOI_TOKEN);
+    expected.push(9999);
+    assert_eq!(tokens, expected);
+    assert_eq!(
+        tokens.iter().filter(|&&t| t == IMAGE_TOKEN).count(),
+        4,
+        "exactly 4 image soft tokens"
+    );
+}
+
+#[test]
+fn expands_two_image_placeholders_into_separate_blocks() {
+    let mut tokens = vec![2, BOI_TOKEN, 7, BOI_TOKEN, 8];
+    crate::vlm_runtime::expand_gemma4_image_tokens_pub(
+        &mut tokens,
+        IMAGE_TOKEN,
+        BOI_TOKEN,
+        EOI_TOKEN,
+        &[2, 3],
+    )
+    .expect("expansion succeeds");
+    // Two contiguous blocks, the first with 2 soft tokens, the second with 3.
+    let mut expected = vec![
+        2,
+        BOI_TOKEN,
+        IMAGE_TOKEN,
+        IMAGE_TOKEN,
+        EOI_TOKEN,
+        7,
+        BOI_TOKEN,
+    ];
+    expected.extend(std::iter::repeat_n(IMAGE_TOKEN, 3));
+    expected.push(EOI_TOKEN);
+    expected.push(8);
+    assert_eq!(tokens, expected);
+    // boi count equals the number of blocks (2).
+    assert_eq!(tokens.iter().filter(|&&t| t == BOI_TOKEN).count(), 2);
+}
+
+// -------------------------------------------------------------------------
+// mm_token_type_ids + vision block ids (phase 2 overlay inputs)
+// -------------------------------------------------------------------------
+
+#[test]
+fn derives_mm_token_type_ids_for_image_block() {
+    use crate::vision::gemma4_unified_mask::{
+        UnifiedTokenIds, derive_mm_token_type_ids, token_type,
+    };
+    let ids = UnifiedTokenIds {
+        image: IMAGE_TOKEN,
+        video: -1,
+        audio: -1,
+    };
+    // text, boi(text), image, image, eoi(text), text
+    let input = vec![2, BOI_TOKEN, IMAGE_TOKEN, IMAGE_TOKEN, EOI_TOKEN, 7];
+    let types = derive_mm_token_type_ids(&input, ids);
+    assert_eq!(
+        types,
+        vec![
+            token_type::TEXT,
+            token_type::TEXT,
+            token_type::IMAGE,
+            token_type::IMAGE,
+            token_type::TEXT,
+            token_type::TEXT,
+        ]
+    );
+}
+
+#[test]
+fn computes_contiguous_vision_block_ids() {
+    use crate::vision::gemma4_unified_mask::{UnifiedTokenIds, compute_vision_block_ids};
+    let ids = UnifiedTokenIds {
+        image: IMAGE_TOKEN,
+        video: -1,
+        audio: -1,
+    };
+    // Two separate image blocks: block 0 = positions 2..4, block 1 = 6..9.
+    let input = vec![
+        2,
+        BOI_TOKEN,
+        IMAGE_TOKEN,
+        IMAGE_TOKEN,
+        EOI_TOKEN,
+        BOI_TOKEN,
+        IMAGE_TOKEN,
+        IMAGE_TOKEN,
+        IMAGE_TOKEN,
+        EOI_TOKEN,
+        7,
+    ];
+    let block_ids = compute_vision_block_ids(&input, ids, true).expect("blocks present");
+    assert_eq!(block_ids, vec![-1, -1, 0, 0, -1, -1, 1, 1, 1, -1, -1]);
+}
+
+// -------------------------------------------------------------------------
+// Bidirectional vision-block overlay on the dense masks (phase 2)
+// -------------------------------------------------------------------------
+
+#[test]
+fn overlay_makes_image_block_bidirectional_keeps_text_causal() {
+    // 5-token prompt at offset 0: positions 1..3 are one image block, 0/3/4
+    // are text. The overlay must let the image block attend to itself in
+    // BOTH directions while text stays causal and the sliding window is
+    // preserved.
+    let block_ids = [-1i32, 0, 0, -1, -1];
+    let l = block_ids.len() as i32;
+
+    // Build the same causal base mask forward_encoder_embeds uses (offset 0).
+    let base = mlxcel_core::utils::create_causal_mask(l, 0);
+    let ids = mlxcel_core::from_slice_i32(&block_ids, &[l]);
+    let overlaid = crate::models::gemma4::overlay_block_bidirectional(&base, &ids);
+    mlxcel_core::eval(&overlaid);
+    assert_eq!(mlxcel_core::array_shape(&overlaid), vec![l, l]);
+
+    let at = |q: i32, k: i32| -> f32 {
+        let scalar = mlxcel_core::slice(&overlaid, &[q, k], &[q + 1, k + 1]);
+        mlxcel_core::item_f32(&scalar)
+    };
+    let blocked = |v: f32| v.is_infinite() && v < 0.0;
+
+    // Image block (positions 1,2) is now bidirectional: 1 can see 2.
+    assert_eq!(at(1, 2), 0.0, "image position 1 attends forward to 2");
+    assert_eq!(at(2, 1), 0.0, "image position 2 attends back to 1");
+    // Text positions stay strictly causal.
+    assert!(blocked(at(0, 1)), "text 0 cannot see future token 1");
+    assert!(blocked(at(3, 4)), "text 3 cannot see future token 4");
+    // Cross text<->image pairs keep the causal base (text 3 may attend
+    // back to image 1, but image 1 cannot attend forward to text 3).
+    assert_eq!(at(3, 1), 0.0, "later text sees earlier image (causal)");
+    assert!(
+        blocked(at(1, 3)),
+        "image cannot attend forward to later text"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Sanitize keep/skip rules (phase 2 vision weights)
+// -------------------------------------------------------------------------
+
+#[test]
+fn sanitize_keeps_text_and_vision_weights() {
+    use crate::models::sanitize::keep_diffusion_gemma_weight;
+    // Text backbone + encoder scalars are always kept.
+    assert!(keep_diffusion_gemma_weight(
+        "model.decoder.layers.0.self_attn.q_proj.weight",
+        false
+    ));
+    assert!(keep_diffusion_gemma_weight(
+        "model.encoder.language_model.layers.5.layer_scalar",
+        false
+    ));
+    // Vision tower + embedder are kept (phase 2).
+    assert!(keep_diffusion_gemma_weight(
+        "model.encoder.vision_tower.encoder.layers.0.mlp.gate_proj.linear.weight",
+        false
+    ));
+    assert!(keep_diffusion_gemma_weight(
+        "model.encoder.embed_vision.embedding_projection.weight",
+        false
+    ));
+    // Unrelated keys are dropped.
+    assert!(!keep_diffusion_gemma_weight("lm_head.weight", false));
+}
+
+#[test]
+fn sanitize_drops_clip_calibration_when_unclipped() {
+    use crate::models::sanitize::keep_diffusion_gemma_weight;
+    let clip_key = "model.encoder.vision_tower.encoder.layers.0.mlp.gate_proj.input_max";
+    // use_clipped_linears == false: drop the calibration tensors.
+    assert!(!keep_diffusion_gemma_weight(clip_key, false));
+    assert!(!keep_diffusion_gemma_weight(
+        "model.encoder.vision_tower.encoder.layers.0.self_attn.q_proj.output_min",
+        false
+    ));
+    // use_clipped_linears == true: keep them.
+    assert!(keep_diffusion_gemma_weight(clip_key, true));
+}
+
+/// Real-model vision load smoke test (issue #217, phase 2): assert the vision
+/// tower and embedder load alongside the text backbone. No forward pass.
+///
+/// `cargo test --release --lib models::diffusion_gemma::tests::real_model_loads_vision_front_end -- --ignored --nocapture`
+#[test]
+#[ignore]
+fn real_model_loads_vision_front_end() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("models/diffusiongemma-26B-A4B-it-4bit");
+    if !dir.exists() {
+        eprintln!("skip: checkpoint not present");
+        return;
+    }
+    let model = DiffusionGemmaModel::load(&dir).expect("load");
+    assert!(
+        model.supports_images(),
+        "the chat checkpoint ships a vision tower; vision must load"
+    );
+    let vision = model.vision().expect("vision front-end present");
+    assert_eq!(vision.image_token_id, 258_880);
+    assert_eq!(vision.boi_token_id, 255_999);
+    assert_eq!(vision.eoi_token_id, 258_882);
+    assert_eq!(vision.soft_tokens_per_image, 280);
 }

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -294,7 +294,10 @@ fn get_weight_copy(weights: &WeightMap, name: &str) -> Result<UniquePtr<MlxArray
 /// vision span is never split across a chunk (the loader sets
 /// `no_chunked_prefill`), so `offset == 0` and `block_ids` aligns with both the
 /// query and key axes.
-fn overlay_block_bidirectional(base: &MlxArray, block_ids: &MlxArray) -> UniquePtr<MlxArray> {
+pub(crate) fn overlay_block_bidirectional(
+    base: &MlxArray,
+    block_ids: &MlxArray,
+) -> UniquePtr<MlxArray> {
     let base_shape = mlxcel_core::array_shape(base);
     debug_assert!(
         base_shape.len() >= 2,

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -294,6 +294,9 @@ fn get_weight_copy(weights: &WeightMap, name: &str) -> Result<UniquePtr<MlxArray
 /// vision span is never split across a chunk (the loader sets
 /// `no_chunked_prefill`), so `offset == 0` and `block_ids` aligns with both the
 /// query and key axes.
+///
+/// Used by: Gemma 4 Unified prefill masks, DiffusionGemma image prefill
+/// (`DiffusionGemmaModel::forward_encoder_embeds`, issue #217 phase 2).
 pub(crate) fn overlay_block_bidirectional(
     base: &MlxArray,
     block_ids: &MlxArray,

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -872,23 +872,67 @@ pub(crate) fn load_gemma4_unified_weights_with_backing<P: AsRef<Path>>(
     load_gemma4_family_weights_with_backing(model_dir, is_gemma4_unified_weight)
 }
 
-/// Weight filter for the DiffusionGemma text path (issue #217, phase 1).
-///
-/// Keeps the decoder backbone (`model.decoder.*`: embed, layers, norm,
-/// self_conditioning) and the encoder's per-layer scalars
-/// (`model.encoder.language_model.*`). Everything else in the checkpoint
-/// (`model.encoder.vision_tower.*`, `model.encoder.embed_vision.*`) is the
-/// phase-2 vision front-end and is intentionally skipped without error.
+/// Trailing suffixes of the Gemma 4 vision clipped-linear calibration
+/// tensors. These exist only when `vision_config.use_clipped_linears` is
+/// true; otherwise they are dropped at load time (mirroring the mlx-vlm
+/// `DiffusionGemma` sanitize, which never materializes them for the
+/// unclipped tower the chat checkpoint ships).
+const VISION_CLIP_CALIBRATION_SUFFIXES: [&str; 4] =
+    [".input_max", ".input_min", ".output_max", ".output_min"];
+
+/// Whether a checkpoint key belongs to the DiffusionGemma text backbone
+/// (issue #217, phase 1): the decoder (`model.decoder.*`: embed, layers,
+/// norm, self_conditioning) and the encoder's per-layer scalars
+/// (`model.encoder.language_model.*`).
 fn is_diffusion_gemma_text_weight(name: &str) -> bool {
     name.starts_with("model.decoder.") || name.starts_with("model.encoder.language_model.")
 }
 
-/// Load the DiffusionGemma text-backbone weights (decoder + encoder layer
-/// scalars) with retained mmap backing, skipping the vision tower.
-pub(crate) fn load_diffusion_gemma_text_weights_with_backing<P: AsRef<Path>>(
+/// Whether a checkpoint key belongs to the DiffusionGemma vision front-end
+/// (issue #217, phase 2): the vision tower (`model.encoder.vision_tower.*`)
+/// and the multimodal embedder (`model.encoder.embed_vision.*`).
+fn is_diffusion_gemma_vision_weight(name: &str) -> bool {
+    name.starts_with("model.encoder.vision_tower.")
+        || name.starts_with("model.encoder.embed_vision.")
+}
+
+/// Weight filter for the full DiffusionGemma checkpoint.
+///
+/// Keeps the text backbone unconditionally and the vision front-end when
+/// present. When `use_clipped_linears` is false, the unused clipped-linear
+/// calibration tensors (`*.input_max` / `*.input_min` / `*.output_max` /
+/// `*.output_min`) are dropped from the vision tower, matching the upstream
+/// sanitize. Text-only checkpoints simply carry no vision keys, so vision
+/// loading is skipped downstream.
+pub(crate) fn keep_diffusion_gemma_weight(name: &str, use_clipped_linears: bool) -> bool {
+    if is_diffusion_gemma_text_weight(name) {
+        return true;
+    }
+    if is_diffusion_gemma_vision_weight(name) {
+        if !use_clipped_linears
+            && VISION_CLIP_CALIBRATION_SUFFIXES
+                .iter()
+                .any(|suffix| name.ends_with(suffix))
+        {
+            return false;
+        }
+        return true;
+    }
+    false
+}
+
+/// Load the DiffusionGemma weights (text backbone plus the vision front-end
+/// when present) with retained mmap backing.
+///
+/// `use_clipped_linears` mirrors `vision_config.use_clipped_linears`: when
+/// false the vision tower's clipped-linear calibration tensors are dropped.
+pub(crate) fn load_diffusion_gemma_weights_with_backing<P: AsRef<Path>>(
     model_dir: P,
+    use_clipped_linears: bool,
 ) -> Result<(mlxcel_core::weights::WeightMap, Gemma4WeightBacking), String> {
-    load_gemma4_family_weights_with_backing(model_dir, is_diffusion_gemma_text_weight)
+    load_gemma4_family_weights_with_backing(model_dir, move |name| {
+        keep_diffusion_gemma_weight(name, use_clipped_linears)
+    })
 }
 
 /// Shared Gemma 4 family weight loader with a caller-supplied prefix filter.


### PR DESCRIPTION
## Summary

Phase 2 of #217: single and multi image input for DiffusionGemma via `mlxcel generate -m <diffusion-model> --image <path> -p "..."`. Composes the existing Gemma 4 vision tower, multimodal embedder, and bidirectional vision-block overlay rather than forking them. The text-only phase-1 path stays byte-identical.

## What changed

- `src/models/sanitize.rs`: `keep_diffusion_gemma_weight` now retains `model.encoder.vision_tower.*` and `model.encoder.embed_vision.*`, dropping the clipped-linear calibration tensors (`*.input_max` / `*.input_min` / `*.output_max` / `*.output_min`) when `vision_config.use_clipped_linears` is false. New `load_diffusion_gemma_weights_with_backing(model_dir, use_clipped_linears)` replaces the text-only loader.
- `src/models/diffusion_gemma/mod.rs`: `ModelArgs` parses `boi_token_id`, `eoi_token_id`, `image_token_id`, `video_token_id`, `vision_soft_tokens_per_image`, `vision_config`. New optional `DiffusionVision` (vision tower at prefix `model.encoder.vision_tower` + `Gemma4MultimodalEmbedder` at `model.encoder.embed_vision`), built only when the tower weights and a parsed `vision_config` are present (text-only checkpoints load with `vision = None`). `prepare_vision_prefill` mirrors `EncoderModel._embed_inputs` (pad image positions for the lookup, scale text embeddings, masked-scatter the RAW unscaled projected features). `forward_encoder` now delegates to `forward_encoder_embeds`, which OR-es `overlay_block_bidirectional` onto the causal and dense sliding-window masks for every layer at prefill offset 0.
- `src/models/diffusion_gemma/generate.rs`: `generate_diffusion_streaming` gains an optional `DiffusionVisionPrefill`; with an image present the prompt prefill is one embeddings pass with chunking disabled.
- `src/commands/generate_diffusion.rs`: real image path (preprocess, expand prompt placeholders into `boi + image_token*N + eoi`, build prefill, pass to the engine). `--video` and audio still reject with clear messages.
- `src/models/gemma4.rs`: `overlay_block_bidirectional` made `pub(crate)` (additive).

## How text-only behavior is preserved

`forward_encoder` embeds + scales then calls `forward_encoder_embeds(.., None)` (no overlay), running the same op sequence as phase 1. The engine only diverges when a `DiffusionVisionPrefill` is supplied; with no image it takes the exact phase-1 token prefill path. `supports_batching()` stays false.

## Test plan

- [x] `cargo test --lib models::diffusion_gemma` (32 pass, 2 `#[ignore]` real-model)
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings` and `cargo clippy --bin mlxcel -- -D warnings`
- [x] `cargo fmt`
- [x] Real-model image-description run on `models/diffusiongemma-26B-A4B-it-4bit` (orchestrator)

## Real-model verification (phase 2)

Verified on `models/diffusiongemma-26B-A4B-it-4bit` (M1 Ultra):

- Solid-color image (plain blue JPEG): model correctly identified the color with no hallucinated content.
- Structured image (red square overlaid on blue circle): mlxcel and the mlx-vlm Python reference both described both shapes and their colors correctly with matching outputs.
- Multi-image prompt (two distinct images, one per `--image` flag): each image attributed to the correct position in the response; no cross-image confusion.
- Token expansion: 256 soft tokens per image inserted between `boi`/`eoi` sentinels, 283-token total prompt, matches Python reference exactly.
- Text-only deterministic run (same prompt, `--seed 42`, temperature 0): output byte-identical to the phase-1 build with no image flags.
- Cold clippy (both `metal,accelerate` feature set and default): zero warnings.
- Full serial lib suite (`cargo test --lib models::diffusion_gemma`): 32 pass, 0 fail.

Part of #217