### PR TITLE
feat: serve DiffusionGemma block diffusion in mlxcel-server (phase 3 of #217)

### DIFF
--- a/docs/block-diffusion.md
+++ b/docs/block-diffusion.md
@@ -104,12 +104,31 @@ Preprocessing reuses the Gemma 4 vision pipeline: images are resized and padded 
 
 Video and audio inputs are not supported and are rejected with a clear error message.
 
-## Remaining limitations (phase 2)
+## Server mode
 
-The following are not yet supported:
+`mlxcel-server --model <diffusion-model>` (or `mlxcel serve -m <diffusion-model>`) loads the checkpoint and serves `/v1/chat/completions` and `/v1/completions`. Both streaming (SSE) and non-streaming responses are supported. Requests are served serially: DiffusionGemma cannot join the batch scheduler, so the server queues them in arrival order and processes one at a time. That is the intended design, not a temporary limitation.
 
-- **Server mode**: `mlxcel serve` and `mlxcel-server` reject DiffusionGemma at
-  load time. Use `mlxcel generate` from the CLI. Server support is planned for phase 3 of issue #217.
+Serve-level flags that affect diffusion models:
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--diffusion-sampler entropy-bound\|confidence-threshold` | `entropy-bound` | Per-step token acceptance strategy. |
+| `--diffusion-threshold FLOAT` | `0.9` | Confidence threshold; validated to `[0, 1]` at startup. |
+| `--max-denoising-steps N` | checkpoint default (typically 48) | Maximum denoising iterations per canvas block. |
+
+Image input follows the standard OpenAI `image_url` content part format. Requests that include video or audio are rejected with a clear error; the connection stays open and the next request is served normally.
+
+### Operational caveats
+
+The checkpoint is a thinking-channel model. The assistant fills a `reasoning_content` channel before writing the visible reply. A few practical consequences:
+
+- **Give requests enough `max_tokens`.** With a budget of 64 tokens a simple question may produce only reasoning, leaving `content` empty with `finish_reason: "length"`. A budget of 256 produces the full answer for most short prompts.
+- **Non-streaming responses omit reasoning.** The server's existing convention is to strip `reasoning_content` from non-streaming chat completions. Streaming responses carry it as `delta.reasoning_content`.
+- **`/v1/completions` works but raw prompts degrade.** The endpoint accepts un-templated text mechanically, but the model depends on its chat structure, so output quality degrades significantly. Prefer `/v1/chat/completions`.
+- **Cancellation resolution.** A cancelled request is aborted within at most one denoising step, not instantaneously.
+
+## Remaining limitations
+
 - **Tensor parallelism**: The TP planner has a placeholder arm for this family.
 
 ## Usage example

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -44,7 +44,7 @@ requirements. If a checkpoint fails detection or loading, inspect its
 
 | Family | `model_type` key | Notes |
 |--------|-----------------|-------|
-| DiffusionGemma | `diffusion_gemma` / `diffusion_gemma_text` | Block-diffusion on a Gemma 4 MoE backbone. Generates a canvas of tokens per block through iterative denoising rather than token-by-token left-to-right decoding. CLI (`mlxcel generate`) supports text and image input (`--image <path>`, repeatable). Server mode is not yet supported. See [Block-diffusion generation](block-diffusion.md). |
+| DiffusionGemma | `diffusion_gemma` / `diffusion_gemma_text` | Block-diffusion on a Gemma 4 MoE backbone. Generates a canvas of tokens per block through iterative denoising rather than token-by-token left-to-right decoding. CLI (`mlxcel generate`) supports text and image input (`--image <path>`, repeatable). Served in `mlxcel-server` (serial, batch-1 by design) via `/v1/chat/completions` and `/v1/completions`; image input follows the standard `image_url` content part format. See [Block-diffusion generation](block-diffusion.md). |
 
 DiffusionGemma uses a two-phase forward pass: an encoder prefill that caches the
 prompt into dense FP16 KV caches, then a canvas loop that attends bidirectionally

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -56,19 +56,6 @@ use mlxcel::server::{
 ///    `download` fetches a HuggingFace model snapshot using the same
 ///    downloader the `mlxcel` CLI uses. Server flags are
 ///    rejected when a subcommand is supplied.
-/// Clap value parser: an f32 in the closed interval [0, 1].
-///
-/// Used by: `--diffusion-threshold` (fail fast at startup instead of
-/// surfacing a per-request engine error under the confidence sampler).
-fn parse_unit_interval(s: &str) -> Result<f32, String> {
-    let v: f32 = s.parse().map_err(|e| format!("not a number: {e}"))?;
-    if (0.0..=1.0).contains(&v) {
-        Ok(v)
-    } else {
-        Err(format!("must be between 0 and 1, got {v}"))
-    }
-}
-
 #[derive(Parser, Debug)]
 #[command(
     name = "mlxcel-server",
@@ -140,6 +127,19 @@ struct Cli {
     /// `args_conflicts_with_subcommands = true` on the parent command).
     #[command(flatten)]
     server: ServerArgs,
+}
+
+/// Clap value parser: an f32 in the closed interval [0, 1].
+///
+/// Used by: `--diffusion-threshold` (fail fast at startup instead of
+/// surfacing a per-request engine error under the confidence sampler).
+fn parse_unit_interval(s: &str) -> Result<f32, String> {
+    let v: f32 = s.parse().map_err(|e| format!("not a number: {e}"))?;
+    if (0.0..=1.0).contains(&v) {
+        Ok(v)
+    } else {
+        Err(format!("must be between 0 and 1, got {v}"))
+    }
 }
 
 /// Subcommands supported by `mlxcel-server`.

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -297,6 +297,29 @@ struct ServerArgs {
     )]
     enable_vlm_prefix_cache: bool,
 
+    /// Maximum denoising steps per canvas block (diffusion models only;
+    /// default: the checkpoint's generation_config, typically 48)
+    #[arg(long = "max-denoising-steps", value_name = "N")]
+    max_denoising_steps: Option<usize>,
+
+    /// Per-step acceptance sampler for diffusion models (diffusion models only)
+    #[arg(
+        long = "diffusion-sampler",
+        value_name = "SAMPLER",
+        default_value = "entropy-bound",
+        value_parser = ["entropy-bound", "confidence-threshold"]
+    )]
+    diffusion_sampler: String,
+
+    /// Confidence threshold for `--diffusion-sampler confidence-threshold`
+    /// (diffusion models only)
+    #[arg(
+        long = "diffusion-threshold",
+        value_name = "FLOAT",
+        default_value_t = 0.9
+    )]
+    diffusion_threshold: f32,
+
     /// Preemption policy: "longest-first" (default) or "lowest-priority"
     #[arg(long = "preemption-policy", default_value = "longest-first")]
     preemption_policy: String,
@@ -1273,6 +1296,11 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         // the flag, so no separate env-fallback helper is needed.
         #[cfg(feature = "surgery")]
         surgery_config_path: args.surgery,
+        // serve-level block-diffusion knobs (#217 phase 3); diffusion models
+        // only.
+        max_denoising_steps: args.max_denoising_steps,
+        diffusion_sampler: args.diffusion_sampler.clone(),
+        diffusion_threshold: args.diffusion_threshold,
     })
 }
 

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -56,6 +56,19 @@ use mlxcel::server::{
 ///    `download` fetches a HuggingFace model snapshot using the same
 ///    downloader the `mlxcel` CLI uses. Server flags are
 ///    rejected when a subcommand is supplied.
+/// Clap value parser: an f32 in the closed interval [0, 1].
+///
+/// Used by: `--diffusion-threshold` (fail fast at startup instead of
+/// surfacing a per-request engine error under the confidence sampler).
+fn parse_unit_interval(s: &str) -> Result<f32, String> {
+    let v: f32 = s.parse().map_err(|e| format!("not a number: {e}"))?;
+    if (0.0..=1.0).contains(&v) {
+        Ok(v)
+    } else {
+        Err(format!("must be between 0 and 1, got {v}"))
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(
     name = "mlxcel-server",
@@ -316,7 +329,8 @@ struct ServerArgs {
     #[arg(
         long = "diffusion-threshold",
         value_name = "FLOAT",
-        default_value_t = 0.9
+        default_value_t = 0.9,
+        value_parser = parse_unit_interval
     )]
     diffusion_threshold: f32,
 

--- a/src/commands/generate_diffusion.rs
+++ b/src/commands/generate_diffusion.rs
@@ -27,63 +27,27 @@ use std::path::Path;
 use mlxcel::models::DiffusionGemmaModel;
 use mlxcel::models::diffusion_gemma::{
     DiffusionGenerateOptions, DiffusionGenerationStats, DiffusionSamplerKind,
-    DiffusionVisionPrefill,
+    DiffusionVisionPrefill, PreparedDiffusionImagePrompt,
 };
 use mlxcel::server::model_provider::model_worker::StreamingDecodeState;
 use mlxcel::tokenizer::MlxcelTokenizer;
-use mlxcel::vision::processors::gemma4::{Gemma4ImageInput, Gemma4Processor};
 
 use super::generate::print_generation_preamble;
 use crate::GenerateArgs;
 
-/// Build the Gemma 4 image processor for the DiffusionGemma checkpoint.
-///
-/// The diffusion checkpoint's `image_processor` is identical to the gemma-4
-/// VLM family (size 224x224, patch 16, pooling_kernel_size 3, 280 soft
-/// tokens). Values are read from `processor_config.json` when present and
-/// fall back to those defaults otherwise.
-fn build_image_processor(model_dir: &Path, default_soft_tokens: usize) -> Gemma4Processor {
-    let image_cfg = std::fs::read_to_string(model_dir.join("processor_config.json"))
-        .ok()
-        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
-        .and_then(|cfg| cfg.get("image_processor").cloned());
-    let get = |key: &str, default: usize| -> usize {
-        image_cfg
-            .as_ref()
-            .and_then(|cfg| cfg.get(key))
-            .and_then(|v| v.as_u64())
-            .map(|v| v as usize)
-            .unwrap_or(default)
-    };
-    Gemma4Processor::new(
-        get("patch_size", 16),
-        get("max_soft_tokens", default_soft_tokens),
-        get("pooling_kernel_size", 3),
-    )
-}
-
-/// Result of preparing image input: the expanded prompt ids (with each image
-/// placeholder rewritten to `boi + image_token * N + eoi`) and the prefill.
-struct PreparedDiffusionVision {
-    expanded_ids: Vec<i32>,
-    prefill: DiffusionVisionPrefill,
-}
-
 /// Preprocess `--image` paths, expand the prompt, and build the vision
 /// prefill (inputs_embeds + overlay block ids).
+///
+/// Loads the images from disk, then delegates the preprocessing / prompt
+/// expansion / prefill construction to the shared
+/// [`DiffusionGemmaModel::prepare_image_prompt`] helper so the CLI and the
+/// server diffusion worker share one image path.
 fn prepare_diffusion_vision(
     model: &DiffusionGemmaModel,
     model_dir: &Path,
     image_paths: &[std::path::PathBuf],
     prompt_tokens: &[i32],
-) -> Result<PreparedDiffusionVision> {
-    let vision = model.vision().ok_or_else(|| {
-        anyhow!(
-            "This DiffusionGemma checkpoint does not include a vision tower; \
-             run with a text-only prompt"
-        )
-    })?;
-
+) -> Result<PreparedDiffusionImagePrompt> {
     let images: Vec<image::DynamicImage> = image_paths
         .iter()
         .map(|path| {
@@ -92,34 +56,18 @@ fn prepare_diffusion_vision(
         .collect::<Result<Vec<_>>>()?;
     println!("Loaded {} image(s).", images.len());
 
-    let processor = build_image_processor(model_dir, vision.soft_tokens_per_image);
-    let processed: Vec<Gemma4ImageInput> = processor.preprocess(&images);
-    let num_soft_tokens: Vec<usize> = processed.iter().map(|img| img.num_soft_tokens).collect();
-
-    let mut expanded_ids = prompt_tokens.to_vec();
-    mlxcel::vlm_runtime::expand_gemma4_image_tokens_pub(
-        &mut expanded_ids,
-        vision.image_token_id,
-        vision.boi_token_id,
-        vision.eoi_token_id,
-        &num_soft_tokens,
-    )?;
-
-    let prefill = model
-        .prepare_vision_prefill(&expanded_ids, &processed)
+    let prepared = model
+        .prepare_image_prompt(model_dir, &images, prompt_tokens)
         .map_err(|e| anyhow!("{e}"))?;
 
     println!(
         "DiffusionGemma: expanded {} image(s) into {} soft token(s) ({} total prompt tokens)",
         images.len(),
-        num_soft_tokens.iter().sum::<usize>(),
-        expanded_ids.len()
+        prepared.num_soft_tokens.iter().sum::<usize>(),
+        prepared.expanded_ids.len()
     );
 
-    Ok(PreparedDiffusionVision {
-        expanded_ids,
-        prefill,
-    })
+    Ok(prepared)
 }
 
 fn parse_sampler_kind(name: &str) -> Result<DiffusionSamplerKind> {

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -342,6 +342,11 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         // the flag, so no separate env-fallback helper is needed.
         #[cfg(feature = "surgery")]
         surgery_config_path: args.surgery,
+        // serve-level block-diffusion knobs (#217 phase 3). Only diffusion
+        // models read them; autoregressive models ignore them.
+        max_denoising_steps: args.diffusion.max_denoising_steps,
+        diffusion_sampler: args.diffusion.diffusion_sampler,
+        diffusion_threshold: args.diffusion.diffusion_threshold,
     })
 }
 

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -136,6 +136,8 @@ fn sample_args() -> crate::ServeArgs {
         // (A4): keep tests on the baseline path by default.
         #[cfg(feature = "surgery")]
         surgery: None,
+        // serve-level diffusion knobs (#217 phase 3): engine defaults in tests.
+        diffusion: crate::DiffusionServeOptions::default(),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1538,6 +1538,60 @@ pub(crate) struct ServeArgs {
     #[cfg(feature = "surgery")]
     #[arg(long = "surgery", value_name = "FILE", env = "MLXCEL_SURGERY")]
     pub(crate) surgery: Option<PathBuf>,
+
+    // Block-diffusion serve-level flag group (--max-denoising-steps,
+    // --diffusion-sampler, --diffusion-threshold). Only affects diffusion
+    // models such as DiffusionGemma; autoregressive models ignore it. The flags
+    // set the per-request diffusion defaults for the single-stream worker loop.
+    #[command(flatten)]
+    pub(crate) diffusion: DiffusionServeOptions,
+}
+
+/// Serve-level block-diffusion options.
+///
+/// A focused subset of [`DiffusionCliOptions`] exposing only the knobs that
+/// the single-stream diffusion serving loop honors per request
+/// (`--diffusion-sampler`, `--diffusion-threshold`, `--max-denoising-steps`).
+/// They only affect diffusion models (e.g. DiffusionGemma); ordinary
+/// autoregressive models ignore them. Canvas-shaping flags from the generate
+/// CLI are intentionally not exposed in serve mode.
+#[derive(Args, Debug)]
+#[command(next_help_heading = "Diffusion Options")]
+pub(crate) struct DiffusionServeOptions {
+    /// Maximum denoising steps per canvas block (diffusion models only;
+    /// default: the checkpoint's generation_config, typically 48)
+    #[arg(long = "max-denoising-steps", value_name = "N")]
+    pub(crate) max_denoising_steps: Option<usize>,
+
+    /// Per-step acceptance sampler for diffusion models
+    #[arg(
+        long = "diffusion-sampler",
+        value_name = "SAMPLER",
+        default_value = "entropy-bound",
+        value_parser = ["entropy-bound", "confidence-threshold"]
+    )]
+    pub(crate) diffusion_sampler: String,
+
+    /// Confidence threshold for `--diffusion-sampler confidence-threshold`
+    /// (diffusion models only)
+    #[arg(
+        long = "diffusion-threshold",
+        value_name = "FLOAT",
+        default_value_t = 0.9
+    )]
+    pub(crate) diffusion_threshold: f32,
+}
+
+// Manual `Default` kept in lock-step with the `#[arg(default_value*)]`
+// attributes above, same contract as the other serve option groups.
+impl Default for DiffusionServeOptions {
+    fn default() -> Self {
+        Self {
+            max_denoising_steps: None,
+            diffusion_sampler: "entropy-bound".to_string(),
+            diffusion_threshold: 0.9,
+        }
+    }
 }
 
 fn main() -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -529,6 +529,19 @@ pub(crate) struct SamplingOptions {
     pub(crate) seed: Option<u64>,
 }
 
+/// Clap value parser: an f32 in the closed interval [0, 1].
+///
+/// Used by: `--diffusion-threshold` (fail fast at startup instead of
+/// surfacing a per-request engine error under the confidence sampler).
+fn parse_unit_interval(s: &str) -> Result<f32, String> {
+    let v: f32 = s.parse().map_err(|e| format!("not a number: {e}"))?;
+    if (0.0..=1.0).contains(&v) {
+        Ok(v)
+    } else {
+        Err(format!("must be between 0 and 1, got {v}"))
+    }
+}
+
 /// Block-diffusion generation options.
 ///
 /// These flags only affect diffusion models (e.g. DiffusionGemma); ordinary
@@ -555,7 +568,8 @@ pub(crate) struct DiffusionCliOptions {
     #[arg(
         long = "diffusion-threshold",
         value_name = "FLOAT",
-        default_value_t = 0.9
+        default_value_t = 0.9,
+        value_parser = parse_unit_interval
     )]
     pub(crate) diffusion_threshold: f32,
 
@@ -1577,7 +1591,8 @@ pub(crate) struct DiffusionServeOptions {
     #[arg(
         long = "diffusion-threshold",
         value_name = "FLOAT",
-        default_value_t = 0.9
+        default_value_t = 0.9,
+        value_parser = parse_unit_interval
     )]
     pub(crate) diffusion_threshold: f32,
 }

--- a/src/models/diffusion_gemma/generate.rs
+++ b/src/models/diffusion_gemma/generate.rs
@@ -72,6 +72,10 @@ pub struct DiffusionGenerateOptions {
     /// Prompt prefill chunk size; prompts longer than this are prefilled in
     /// chunks with the cache evaluated between chunks.
     pub prefill_chunk_size: usize,
+    /// Cooperative cancellation flag, polled once per denoising step so a
+    /// cancelled request aborts within one step (~0.6 s on a 256 canvas)
+    /// instead of finishing the whole block. `None` disables polling (CLI).
+    pub cancel: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 }
 
 impl Default for DiffusionGenerateOptions {
@@ -87,6 +91,7 @@ impl Default for DiffusionGenerateOptions {
             full_canvas: false,
             extra_eos_token_ids: Vec::new(),
             prefill_chunk_size: DEFAULT_PREFILL_CHUNK_SIZE,
+            cancel: None,
         }
     }
 }
@@ -380,6 +385,9 @@ struct DenoiseOutcome {
     /// Committed canvas ids for this block.
     commit: UniquePtr<MlxArray>,
     steps: usize,
+    /// True when `options.cancel` fired mid-block; the partial commit must
+    /// not be emitted.
+    aborted: bool,
 }
 
 impl DiffusionGemmaModel {
@@ -523,6 +531,11 @@ impl DiffusionGemmaModel {
             denoising_steps += outcome.steps;
             work_tokens += canvas_len * outcome.steps;
 
+            if outcome.aborted {
+                finish_reason = DiffusionFinishReason::Aborted;
+                break;
+            }
+
             mlxcel_core::eval(&outcome.commit);
             let commit_ids = to_vec_i32(&outcome.commit);
             if debug_mode {
@@ -611,6 +624,17 @@ impl DiffusionGemmaModel {
         let mut commit = mlxcel_core::copy(&current_canvas);
 
         for cur_step in (1..=max_denoising_steps).rev() {
+            if options
+                .cancel
+                .as_ref()
+                .is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed))
+            {
+                return Ok(DenoiseOutcome {
+                    commit,
+                    steps,
+                    aborted: true,
+                });
+            }
             steps += 1;
             let self_conditioning_ref = self_conditioning
                 .as_ref()
@@ -779,6 +803,10 @@ impl DiffusionGemmaModel {
             }
         }
 
-        Ok(DenoiseOutcome { commit, steps })
+        Ok(DenoiseOutcome {
+            commit,
+            steps,
+            aborted: false,
+        })
     }
 }

--- a/src/models/diffusion_gemma/mod.rs
+++ b/src/models/diffusion_gemma/mod.rs
@@ -42,8 +42,8 @@
 mod generate;
 
 pub use generate::{
-    DiffusionGenerateOptions, DiffusionGenerationStats, DiffusionSamplerKind,
-    diffusion_debug_canvas_enabled,
+    DiffusionFinishReason, DiffusionGenerateOptions, DiffusionGenerationStats,
+    DiffusionSamplerKind, diffusion_debug_canvas_enabled,
 };
 
 use crate::models::gemma4::{
@@ -53,7 +53,7 @@ use crate::models::gemma4::{
 use crate::vision::encoders::gemma4::{Gemma4VisionConfig, Gemma4VisionModel};
 use crate::vision::gemma4_multimodal_embedder::Gemma4MultimodalEmbedder;
 use crate::vision::gemma4_unified_mask::{UnifiedTokenIds, compute_vision_block_ids};
-use crate::vision::processors::gemma4::Gemma4ImageInput;
+use crate::vision::processors::gemma4::{Gemma4ImageInput, Gemma4Processor};
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
@@ -558,6 +558,21 @@ pub struct DiffusionVisionPrefill {
     pub(crate) vision_block_ids: Option<Vec<i32>>,
 }
 
+/// Result of preparing image input for one diffusion prompt: the expanded
+/// prompt ids (with each image placeholder rewritten to
+/// `boi + image_token * N + eoi`) and the matching vision prefill.
+///
+/// Shared by the CLI `generate` driver
+/// ([`crate::commands::generate_diffusion`]) and the server diffusion worker
+/// so the two surfaces preprocess images, expand the prompt, and build the
+/// prefill through one code path.
+pub struct PreparedDiffusionImagePrompt {
+    pub expanded_ids: Vec<i32>,
+    pub prefill: DiffusionVisionPrefill,
+    /// Soft-token count contributed by each input image (in prompt order).
+    pub num_soft_tokens: Vec<usize>,
+}
+
 // ---------------------------------------------------------------------------
 // Model
 // ---------------------------------------------------------------------------
@@ -950,6 +965,80 @@ impl DiffusionGemmaModel {
         Ok(DiffusionVisionPrefill {
             inputs_embeds,
             vision_block_ids,
+        })
+    }
+
+    /// Build the Gemma 4 image processor for this checkpoint.
+    ///
+    /// The DiffusionGemma `image_processor` is identical to the gemma-4 VLM
+    /// family (size 224x224, patch 16, pooling_kernel_size 3, 280 soft
+    /// tokens). Values are read from `processor_config.json` when present and
+    /// fall back to those defaults otherwise. Returns `None` for a text-only
+    /// checkpoint (no vision tower).
+    pub fn build_image_processor(&self, model_dir: &Path) -> Option<Gemma4Processor> {
+        let vision = self.vision.as_ref()?;
+        let image_cfg = std::fs::read_to_string(model_dir.join("processor_config.json"))
+            .ok()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .and_then(|cfg| cfg.get("image_processor").cloned());
+        let get = |key: &str, default: usize| -> usize {
+            image_cfg
+                .as_ref()
+                .and_then(|cfg| cfg.get(key))
+                .and_then(|v| v.as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(default)
+        };
+        Some(Gemma4Processor::new(
+            get("patch_size", 16),
+            get("max_soft_tokens", vision.soft_tokens_per_image),
+            get("pooling_kernel_size", 3),
+        ))
+    }
+
+    /// Preprocess decoded images, expand the prompt with image placeholder
+    /// tokens, and build the vision prefill.
+    ///
+    /// Shared by the CLI `generate` driver and the server diffusion worker:
+    /// both decode their images upstream (CLI from `--image` paths, server
+    /// from request bytes) and hand the [`image::DynamicImage`] values here.
+    /// Errors when the checkpoint has no vision tower or no images are
+    /// supplied.
+    pub fn prepare_image_prompt(
+        &self,
+        model_dir: &Path,
+        images: &[image::DynamicImage],
+        prompt_tokens: &[i32],
+    ) -> Result<PreparedDiffusionImagePrompt, String> {
+        let vision = self.vision.as_ref().ok_or_else(|| {
+            "This DiffusionGemma checkpoint does not include a vision tower; \
+             run with a text-only prompt"
+                .to_string()
+        })?;
+        if images.is_empty() {
+            return Err("DiffusionGemma: image input requested but no images supplied".to_string());
+        }
+        let processor = self
+            .build_image_processor(model_dir)
+            .ok_or_else(|| "DiffusionGemma: this checkpoint has no vision tower".to_string())?;
+        let processed: Vec<Gemma4ImageInput> = processor.preprocess(images);
+        let num_soft_tokens: Vec<usize> = processed.iter().map(|img| img.num_soft_tokens).collect();
+
+        let mut expanded_ids = prompt_tokens.to_vec();
+        crate::vlm_runtime::expand_gemma4_image_tokens_pub(
+            &mut expanded_ids,
+            vision.image_token_id,
+            vision.boi_token_id,
+            vision.eoi_token_id,
+            &num_soft_tokens,
+        )
+        .map_err(|e| format!("{e}"))?;
+
+        let prefill = self.prepare_vision_prefill(&expanded_ids, &processed)?;
+        Ok(PreparedDiffusionImagePrompt {
+            expanded_ids,
+            prefill,
+            num_soft_tokens,
         })
     }
 

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -398,6 +398,13 @@ pub struct ServerStartupInput {
     /// error before any model load begins.
     #[cfg(feature = "surgery")]
     pub surgery_config_path: Option<PathBuf>,
+
+    /// `--max-denoising-steps` (issue #217 phase 3). Diffusion models only.
+    pub max_denoising_steps: Option<usize>,
+    /// `--diffusion-sampler` (issue #217 phase 3). Diffusion models only.
+    pub diffusion_sampler: String,
+    /// `--diffusion-threshold` (issue #217 phase 3). Diffusion models only.
+    pub diffusion_threshold: f32,
 }
 
 impl ServerStartupInput {
@@ -598,6 +605,10 @@ impl ServerStartupInput {
             // exactly once before spawning the model worker.
             #[cfg(feature = "surgery")]
             surgery_config_path: self.surgery_config_path,
+            // serve-level diffusion knobs (#217 phase 3).
+            max_denoising_steps: self.max_denoising_steps,
+            diffusion_sampler: self.diffusion_sampler,
+            diffusion_threshold: self.diffusion_threshold,
         })
     }
 }

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -153,6 +153,10 @@ fn sample_input() -> ServerStartupInput {
         // (A4): default to None for baseline-path tests.
         #[cfg(feature = "surgery")]
         surgery_config_path: None,
+        // serve-level diffusion knobs (#217 phase 3): engine defaults in tests.
+        max_denoising_steps: None,
+        diffusion_sampler: "entropy-bound".to_string(),
+        diffusion_threshold: 0.9,
     }
 }
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -447,6 +447,16 @@ pub struct ServerConfig {
     /// on a non-hybrid node enables the live prefill/decode role loop; `None`
     /// keeps the standard single-node scheduler loop.
     pub serving_bind: Option<std::net::SocketAddr>,
+    /// `--max-denoising-steps` (issue #217 phase 3). Serve-level override for
+    /// the DiffusionGemma per-block denoising step cap; `None` keeps the
+    /// checkpoint default. Only diffusion models read it.
+    pub max_denoising_steps: Option<usize>,
+    /// `--diffusion-sampler` (issue #217 phase 3). `"entropy-bound"` (default)
+    /// or `"confidence-threshold"`. Only diffusion models read it.
+    pub diffusion_sampler: String,
+    /// `--diffusion-threshold` (issue #217 phase 3). Confidence threshold for
+    /// the confidence-threshold sampler. Only diffusion models read it.
+    pub diffusion_threshold: f32,
 }
 
 impl Default for ServerConfig {
@@ -506,6 +516,9 @@ impl Default for ServerConfig {
             prefill_peers: Vec::new(),
             decode_peers: Vec::new(),
             serving_bind: None,
+            max_denoising_steps: None,
+            diffusion_sampler: "entropy-bound".to_string(),
+            diffusion_threshold: 0.9,
         }
     }
 }

--- a/src/server/diffusion_worker.rs
+++ b/src/server/diffusion_worker.rs
@@ -301,7 +301,10 @@ fn handle_diffusion_request(
         return;
     }
 
-    let opts = diffusion_options_from_server(options, defaults, config_eos);
+    let mut opts = diffusion_options_from_server(options, defaults, config_eos);
+    // Per-step cooperative cancellation: a disconnected/cancelled client
+    // aborts within one denoising step instead of finishing the block.
+    opts.cancel = Some(cancelled.clone());
     if let Some(seed) = options.sampling.seed {
         mlxcel_core::random_seed(seed);
     }

--- a/src/server/diffusion_worker.rs
+++ b/src/server/diffusion_worker.rs
@@ -1,0 +1,351 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Single-stream (batch-1) serving loop for DiffusionGemma (issue #217,
+//! phase 3).
+//!
+//! DiffusionGemma generates by model-owned block diffusion, so it cannot join
+//! the batched/paged scheduler (`supports_batching() == false`). Instead the
+//! model worker thread, after loading a DiffusionGemma checkpoint, branches
+//! into [`run_diffusion_worker_loop`] which serves one request at a time off
+//! the same `mpsc` channel the batched worker uses. Requests therefore queue
+//! and are served serially: that IS the design (no in-flight concurrency > 1).
+//!
+//! The loop reuses the CLI generation path
+//! ([`DiffusionGemmaModel::generate_diffusion_streaming`]) plus the shared
+//! image-prompt helper ([`DiffusionGemmaModel::prepare_image_prompt`]) and the
+//! server's incremental detokenizer ([`StreamingDecodeState`]) so streaming
+//! SSE output, byte-fallback handling, and usage accounting match the
+//! autoregressive serving path.
+
+use std::path::Path;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc;
+use std::time::Instant;
+
+use crate::models::DiffusionGemmaModel;
+use crate::models::diffusion_gemma::{
+    DiffusionFinishReason, DiffusionGenerateOptions, DiffusionSamplerKind,
+};
+use crate::server::ServerGenerateOptions;
+use crate::server::model_provider::model_worker::{StreamingDecodeState, decode_request_images};
+use crate::server::model_provider::{GenerateEvent, GenerationResult, ModelRequest};
+use crate::tokenizer::MlxcelTokenizer;
+
+/// Serve-level diffusion knobs resolved once on the worker thread from the
+/// `--diffusion-sampler` / `--diffusion-threshold` / `--max-denoising-steps`
+/// flags. They set the per-request defaults for every diffusion generation
+/// served by this worker; they only affect diffusion models.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct DiffusionServeDefaults {
+    /// Per-step acceptance sampler (`--diffusion-sampler`).
+    pub sampler: DiffusionSamplerKind,
+    /// Confidence threshold for the confidence-threshold sampler
+    /// (`--diffusion-threshold`).
+    pub confidence_threshold: f32,
+    /// Optional override for the checkpoint's `max_denoising_steps`
+    /// (`--max-denoising-steps`).
+    pub max_denoising_steps: Option<usize>,
+}
+
+impl Default for DiffusionServeDefaults {
+    fn default() -> Self {
+        Self {
+            sampler: DiffusionSamplerKind::EntropyBound,
+            confidence_threshold: 0.9,
+            max_denoising_steps: None,
+        }
+    }
+}
+
+/// Parse the serve-level `--diffusion-sampler` flag value.
+///
+/// `entropy-bound` (the checkpoint default) and `confidence-threshold` are the
+/// only supported samplers; anything else is an error the caller surfaces as a
+/// warning before falling back to entropy-bound.
+pub(crate) fn parse_diffusion_sampler(name: &str) -> Result<DiffusionSamplerKind, String> {
+    match name {
+        "entropy-bound" => Ok(DiffusionSamplerKind::EntropyBound),
+        "confidence-threshold" => Ok(DiffusionSamplerKind::ConfidenceThreshold),
+        other => Err(format!("unsupported diffusion sampler: {other:?}")),
+    }
+}
+
+/// Error message sent for an audio/video diffusion request (unsupported in
+/// server mode, phase 3 scope).
+pub(crate) const AUDIO_VIDEO_UNSUPPORTED_MSG: &str =
+    "DiffusionGemma server mode does not support audio/video input yet";
+
+/// Decide whether a request must be rejected for carrying audio/video input.
+///
+/// Returns the rejection message when either modality is present (diffusion
+/// server mode is text + image only), or `None` when the request is servable.
+pub(crate) fn reject_audio_video(audio_present: bool, video_present: bool) -> Option<&'static str> {
+    if audio_present || video_present {
+        Some(AUDIO_VIDEO_UNSUPPORTED_MSG)
+    } else {
+        None
+    }
+}
+
+/// Map a [`DiffusionFinishReason`] to the server's `finish_reason` string.
+///
+/// The server's OpenAI-compatible response surface only carries `"stop"` and
+/// `"length"`; an aborted (client-cancelled) diffusion run maps to `"stop"`
+/// because the client has already disconnected and there is no distinct
+/// transport-level reason string for it.
+pub(crate) fn diffusion_finish_reason_str(reason: DiffusionFinishReason) -> &'static str {
+    match reason {
+        DiffusionFinishReason::Length => "length",
+        DiffusionFinishReason::Stop => "stop",
+        DiffusionFinishReason::Aborted => "stop",
+    }
+}
+
+/// Build the engine [`DiffusionGenerateOptions`] for one request from the
+/// server request options and the serve-level diffusion defaults.
+///
+/// `config_eos` is the model's `generation_config.json` EOS set; together with
+/// the request's `stop_token_ids` it forms the extra EOS union the engine adds
+/// on top of the model's own embedded EOS ids. Canvas-length knobs
+/// (`min/max canvas`, `full_canvas`) and the prefill chunk size keep their
+/// engine defaults: the server surface does not expose per-request canvas
+/// overrides.
+pub(crate) fn diffusion_options_from_server(
+    options: &ServerGenerateOptions,
+    defaults: &DiffusionServeDefaults,
+    config_eos: &[i32],
+) -> DiffusionGenerateOptions {
+    build_diffusion_options(
+        options.max_tokens,
+        options.sampling.temperature,
+        &options.sampling.stop_token_ids,
+        defaults,
+        config_eos,
+    )
+}
+
+/// Pure core of [`diffusion_options_from_server`] over primitive inputs, so the
+/// mapping is unit-testable without constructing a full
+/// [`ServerGenerateOptions`]. The extra-EOS field is the de-duplicated union of
+/// the request stop tokens and the model's `generation_config` EOS set; the
+/// engine unions the model's own embedded EOS ids on top of that.
+pub(crate) fn build_diffusion_options(
+    max_tokens: usize,
+    temperature: f32,
+    stop_token_ids: &[i32],
+    defaults: &DiffusionServeDefaults,
+    config_eos: &[i32],
+) -> DiffusionGenerateOptions {
+    let mut extra_eos: Vec<i32> = Vec::new();
+    for &id in stop_token_ids.iter().chain(config_eos) {
+        if !extra_eos.contains(&id) {
+            extra_eos.push(id);
+        }
+    }
+    DiffusionGenerateOptions {
+        max_new_tokens: max_tokens,
+        temperature,
+        sampler: defaults.sampler,
+        confidence_threshold: defaults.confidence_threshold,
+        max_denoising_steps: defaults.max_denoising_steps,
+        extra_eos_token_ids: extra_eos,
+        ..DiffusionGenerateOptions::default()
+    }
+}
+
+/// Serve DiffusionGemma block-diffusion generation one request at a time.
+///
+/// Drives the shared `mpsc` request channel: each `Generate` is tokenized,
+/// optionally image-prefilled, denoised through
+/// [`DiffusionGemmaModel::generate_diffusion_streaming`], and streamed back as
+/// `GenerateEvent::Token` / `GenerateEvent::Done`. A single failing request
+/// emits `GenerateEvent::Error` and the loop keeps serving; it returns only on
+/// `ModelRequest::Shutdown` or when the channel closes.
+pub(crate) fn run_diffusion_worker_loop(
+    model: &DiffusionGemmaModel,
+    tokenizer: &MlxcelTokenizer,
+    model_path: &Path,
+    request_rx: mpsc::Receiver<ModelRequest>,
+    defaults: DiffusionServeDefaults,
+    config_eos: &[i32],
+) {
+    tracing::info!(
+        "DiffusionGemma block-diffusion worker ready (single-stream, batch-1; \
+         sampler={:?}, max_denoising_steps={:?})",
+        defaults.sampler,
+        defaults.max_denoising_steps,
+    );
+
+    for request in request_rx {
+        match request {
+            ModelRequest::Shutdown => {
+                tracing::info!("DiffusionGemma worker received shutdown signal");
+                break;
+            }
+            ModelRequest::Generate {
+                prompt,
+                options,
+                images,
+                audio,
+                videos,
+                response_tx,
+                cancelled,
+            } => {
+                handle_diffusion_request(
+                    model,
+                    tokenizer,
+                    model_path,
+                    &defaults,
+                    config_eos,
+                    &prompt,
+                    &options,
+                    &images,
+                    &audio,
+                    &videos,
+                    &response_tx,
+                    &cancelled,
+                );
+            }
+        }
+    }
+}
+
+/// Handle one diffusion generation request end to end.
+///
+/// All failure paths send a single `GenerateEvent::Error` and return so one
+/// bad request never tears down the worker.
+#[allow(clippy::too_many_arguments)]
+fn handle_diffusion_request(
+    model: &DiffusionGemmaModel,
+    tokenizer: &MlxcelTokenizer,
+    model_path: &Path,
+    defaults: &DiffusionServeDefaults,
+    config_eos: &[i32],
+    prompt: &str,
+    options: &ServerGenerateOptions,
+    images: &[Vec<u8>],
+    audio: &[Vec<u8>],
+    videos: &[crate::server::media::ResolvedVideo],
+    response_tx: &mpsc::Sender<GenerateEvent>,
+    cancelled: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    // Audio / video are not supported in diffusion server mode (phase 3 scope).
+    if let Some(msg) = reject_audio_video(!audio.is_empty(), !videos.is_empty()) {
+        let _ = response_tx.send(GenerateEvent::Error(msg.to_string()));
+        return;
+    }
+
+    // Tokenize the already chat-templated prompt, mirroring the batched
+    // scheduler's add-special heuristic.
+    let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
+    let token_ids = match tokenizer.encode(prompt, add_special) {
+        Ok(ids) => ids,
+        Err(err) => {
+            let _ = response_tx.send(GenerateEvent::Error(format!("Tokenization error: {err}")));
+            return;
+        }
+    };
+    let prompt_tokens: Vec<i32> = token_ids.iter().map(|&x| x as i32).collect();
+
+    // Image input: decode the request bytes and run the shared phase-2 vision
+    // path (preprocess + token expansion + prefill).
+    let prepared = if images.is_empty() {
+        None
+    } else {
+        if !model.supports_images() {
+            let _ = response_tx.send(GenerateEvent::Error(
+                "This DiffusionGemma checkpoint does not include a vision tower; \
+                 send a text-only request"
+                    .to_string(),
+            ));
+            return;
+        }
+        let decoded = match decode_request_images(images) {
+            Ok(decoded) => decoded,
+            Err(err) => {
+                let _ =
+                    response_tx.send(GenerateEvent::Error(format!("Image decode error: {err}")));
+                return;
+            }
+        };
+        match model.prepare_image_prompt(model_path, &decoded, &prompt_tokens) {
+            Ok(prepared) => Some(prepared),
+            Err(err) => {
+                let _ = response_tx.send(GenerateEvent::Error(err));
+                return;
+            }
+        }
+    };
+
+    let (engine_prompt, vision_prefill) = match &prepared {
+        Some(prepared) => (prepared.expanded_ids.as_slice(), Some(&prepared.prefill)),
+        None => (prompt_tokens.as_slice(), None),
+    };
+
+    if engine_prompt.is_empty() {
+        let _ = response_tx.send(GenerateEvent::Error(
+            "Empty prompt: request has no input tokens to process".to_string(),
+        ));
+        return;
+    }
+
+    let opts = diffusion_options_from_server(options, defaults, config_eos);
+    if let Some(seed) = options.sampling.seed {
+        mlxcel_core::random_seed(seed);
+    }
+
+    let start = Instant::now();
+    let mut decode_state = StreamingDecodeState::new(tokenizer, engine_prompt);
+
+    // Stream each committed token, polling the cancellation flag in the engine
+    // callback (returning false aborts the denoising loop). A closed receiver
+    // (client gone) also aborts.
+    let result =
+        model.generate_diffusion_streaming(engine_prompt, &opts, vision_prefill, |token_id| {
+            if let Some(text) = decode_state.on_token(token_id, tokenizer)
+                && response_tx.send(GenerateEvent::Token(text)).is_err()
+            {
+                return false;
+            }
+            !cancelled.load(Ordering::Relaxed)
+        });
+
+    match result {
+        Ok(stats) => {
+            // Drain any byte-fallback tail held back by the streaming decoder,
+            // then build the usage/timing result and override the finish
+            // reason with the diffusion engine's verdict.
+            decode_state.flush(tokenizer);
+            let mut gen_result: GenerationResult = decode_state.finish_with_cache(
+                start,
+                engine_prompt.len(),
+                opts.max_new_tokens.max(1),
+                0,
+            );
+            gen_result.finish_reason = diffusion_finish_reason_str(stats.finish_reason).to_string();
+            let _ = response_tx.send(GenerateEvent::Done(gen_result));
+        }
+        Err(err) => {
+            let _ = response_tx.send(GenerateEvent::Error(err));
+        }
+    }
+
+    // Release the transient denoising allocations before the next request.
+    mlxcel_core::clear_memory_cache();
+}
+
+#[cfg(test)]
+#[path = "diffusion_worker_tests.rs"]
+mod tests;

--- a/src/server/diffusion_worker_tests.rs
+++ b/src/server/diffusion_worker_tests.rs
@@ -1,0 +1,116 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the model-free pieces of the DiffusionGemma serving loop:
+//! the server -> engine options mapping, audio/video rejection, sampler
+//! parsing, and finish-reason mapping.
+
+use super::*;
+use crate::models::diffusion_gemma::{DiffusionFinishReason, DiffusionSamplerKind};
+
+fn defaults() -> DiffusionServeDefaults {
+    DiffusionServeDefaults {
+        sampler: DiffusionSamplerKind::ConfidenceThreshold,
+        confidence_threshold: 0.75,
+        max_denoising_steps: Some(24),
+    }
+}
+
+#[test]
+fn build_diffusion_options_maps_core_fields_and_serve_defaults() {
+    let opts = build_diffusion_options(128, 0.7, &[], &defaults(), &[]);
+    assert_eq!(opts.max_new_tokens, 128);
+    assert_eq!(opts.temperature, 0.7);
+    assert_eq!(opts.sampler, DiffusionSamplerKind::ConfidenceThreshold);
+    assert_eq!(opts.confidence_threshold, 0.75);
+    assert_eq!(opts.max_denoising_steps, Some(24));
+    // Canvas knobs keep their engine defaults (not exposed at serve level).
+    assert_eq!(opts.min_canvas_length, 64);
+    assert_eq!(opts.max_canvas_length, None);
+    assert!(!opts.full_canvas);
+    assert_eq!(opts.prefill_chunk_size, 512);
+}
+
+#[test]
+fn build_diffusion_options_unions_stop_tokens_and_config_eos_dedup() {
+    // Request stop tokens come first, then config EOS, with duplicates removed
+    // while preserving first-seen order.
+    let opts = build_diffusion_options(64, 0.0, &[7, 50], &defaults(), &[1, 50, 106]);
+    assert_eq!(opts.extra_eos_token_ids, vec![7, 50, 1, 106]);
+}
+
+#[test]
+fn build_diffusion_options_defaults_apply_with_empty_eos() {
+    let opts = build_diffusion_options(32, 0.0, &[], &DiffusionServeDefaults::default(), &[]);
+    assert!(opts.extra_eos_token_ids.is_empty());
+    assert_eq!(opts.sampler, DiffusionSamplerKind::EntropyBound);
+    assert_eq!(opts.confidence_threshold, 0.9);
+    assert_eq!(opts.max_denoising_steps, None);
+}
+
+#[test]
+fn reject_audio_video_flags_unsupported_modalities() {
+    assert_eq!(reject_audio_video(false, false), None);
+    assert_eq!(
+        reject_audio_video(true, false),
+        Some(AUDIO_VIDEO_UNSUPPORTED_MSG)
+    );
+    assert_eq!(
+        reject_audio_video(false, true),
+        Some(AUDIO_VIDEO_UNSUPPORTED_MSG)
+    );
+    assert_eq!(
+        reject_audio_video(true, true),
+        Some(AUDIO_VIDEO_UNSUPPORTED_MSG)
+    );
+}
+
+#[test]
+fn parse_diffusion_sampler_accepts_known_samplers() {
+    assert_eq!(
+        parse_diffusion_sampler("entropy-bound"),
+        Ok(DiffusionSamplerKind::EntropyBound)
+    );
+    assert_eq!(
+        parse_diffusion_sampler("confidence-threshold"),
+        Ok(DiffusionSamplerKind::ConfidenceThreshold)
+    );
+    assert!(parse_diffusion_sampler("nonsense").is_err());
+}
+
+#[test]
+fn finish_reason_maps_to_server_strings() {
+    assert_eq!(
+        diffusion_finish_reason_str(DiffusionFinishReason::Length),
+        "length"
+    );
+    assert_eq!(
+        diffusion_finish_reason_str(DiffusionFinishReason::Stop),
+        "stop"
+    );
+    // An aborted (client-cancelled) run has no distinct server reason string;
+    // it maps to "stop".
+    assert_eq!(
+        diffusion_finish_reason_str(DiffusionFinishReason::Aborted),
+        "stop"
+    );
+}
+
+#[test]
+fn diffusion_serve_defaults_default_is_entropy_bound() {
+    let d = DiffusionServeDefaults::default();
+    assert_eq!(d.sampler, DiffusionSamplerKind::EntropyBound);
+    assert_eq!(d.confidence_threshold, 0.9);
+    assert_eq!(d.max_denoising_steps, None);
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -23,6 +23,7 @@ pub mod chat_template_kwargs;
 mod cli_input;
 mod config;
 pub mod conversation_store;
+pub(crate) mod diffusion_worker;
 mod media;
 pub mod model_provider;
 pub mod prompt_cache;

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -260,6 +260,10 @@ impl ModelProvider {
                 config.decode_peers.clone(),
                 config.serving_bind,
                 speculative_dispatch,
+                // serve-level diffusion knobs (#217 phase 3).
+                config.max_denoising_steps,
+                config.diffusion_sampler.clone(),
+                config.diffusion_threshold,
                 batch_metrics,
                 batch_observability,
             )?;
@@ -478,6 +482,11 @@ impl ModelProvider {
             decode_peers,
             serving_bind,
             crate::server::SpeculativeDispatch::Disabled,
+            // diffusion knobs default to the engine defaults in this
+            // speculative-dispatch-agnostic wrapper.
+            None,
+            "entropy-bound".to_string(),
+            0.9,
             batch_metrics,
             batch_observability,
         )
@@ -516,6 +525,9 @@ impl ModelProvider {
         decode_peers: Vec<std::net::SocketAddr>,
         serving_bind: Option<std::net::SocketAddr>,
         speculative_dispatch: crate::server::SpeculativeDispatch,
+        max_denoising_steps: Option<usize>,
+        diffusion_sampler: String,
+        diffusion_threshold: f32,
         batch_metrics: Arc<BatchMetrics>,
         batch_observability: Arc<BatchObservability>,
     ) -> Result<Self> {
@@ -567,6 +579,11 @@ impl ModelProvider {
             serving_bind,
             // forward the resolved speculative dispatch.
             speculative_dispatch,
+            // serve-level diffusion knobs (#217 phase 3); consumed only by the
+            // DiffusionGemma worker loop.
+            max_denoising_steps,
+            diffusion_sampler,
+            diffusion_threshold,
         };
 
         let worker_handle = model_worker::spawn_model_worker_with_batch_config(
@@ -648,6 +665,10 @@ impl ModelProvider {
             // defaults to `Disabled` which short-circuits the scheduler
             // hot path to the classic decode loop.
             speculative_dispatch: crate::server::SpeculativeDispatch::Disabled,
+            // minimal test path uses the engine diffusion defaults.
+            max_denoising_steps: None,
+            diffusion_sampler: "entropy-bound".to_string(),
+            diffusion_threshold: 0.9,
         };
 
         let worker_handle = model_worker::spawn_model_worker_with_batch_config(

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -159,23 +159,20 @@ pub(crate) struct WorkerSchedulerConfig {
     /// short-circuits in [`BatchScheduler::decode_single_step`] with no
     /// overhead.
     pub speculative_dispatch: crate::server::SpeculativeDispatch,
-}
-
-/// Refuse model families the server runtime cannot drive yet, with a clear
-/// actionable error instead of a confusing downstream failure.
-///
-/// DiffusionGemma (issue #217 phase 1) generates by model-owned block
-/// diffusion; the batched scheduler and the SSE serving path have no
-/// diffusion round loop yet (phase 3), so the worker rejects the load
-/// outright and points the operator at the CLI.
-fn server_unsupported_model_error(model_path: &std::path::Path) -> Option<anyhow::Error> {
-    match crate::models::get_model_type(model_path) {
-        Ok(crate::models::ModelType::DiffusionGemma) => Some(anyhow::anyhow!(
-            "DiffusionGemma (block diffusion) is not supported in server mode yet; use the CLI: \
-             mlxcel generate -m <model> -p \"...\""
-        )),
-        _ => None,
-    }
+    /// serve-level `--max-denoising-steps` override (diffusion models only).
+    ///
+    /// `None` (the default) keeps the checkpoint's `generation_config` step
+    /// cap. Only the DiffusionGemma worker loop reads it; autoregressive
+    /// models ignore it.
+    pub max_denoising_steps: Option<usize>,
+    /// serve-level `--diffusion-sampler` selection (diffusion models only).
+    ///
+    /// `"entropy-bound"` (default) or `"confidence-threshold"`; parsed once on
+    /// the worker thread. Ignored by non-diffusion models.
+    pub diffusion_sampler: String,
+    /// serve-level `--diffusion-threshold` for the confidence-threshold
+    /// sampler (diffusion models only). Ignored by non-diffusion models.
+    pub diffusion_threshold: f32,
 }
 
 pub(crate) fn spawn_model_worker_with_batch_config(
@@ -192,9 +189,7 @@ pub(crate) fn spawn_model_worker_with_batch_config(
         tracing::info!("Model worker thread starting, loading model...");
 
         let load_start = Instant::now();
-        let result = if let Some(err) = server_unsupported_model_error(&model_path) {
-            Err(err)
-        } else if let Some(ref pipeline_runtime) = sched_config.pipeline_parallel_runtime {
+        let result = if let Some(ref pipeline_runtime) = sched_config.pipeline_parallel_runtime {
             match pipeline_runtime {
                 crate::server::PipelineParallelRuntimeConfig::InProcess {
                     layers,
@@ -265,6 +260,38 @@ pub(crate) fn spawn_model_worker_with_batch_config(
         if !config_eos.is_empty() {
             tracing::info!("EOS tokens from config: {:?}", config_eos);
         }
+
+        // DiffusionGemma (issue #217 phase 3): block-diffusion models are
+        // model-owned single-stream generators (`supports_batching() == false`)
+        // and cannot join the BatchScheduler. Serve them on a dedicated
+        // batch-1 loop off the same request channel and return; all the
+        // scheduler-specific setup below is skipped.
+        let model = match model {
+            LoadedModel::DiffusionGemma(diffusion) => {
+                let sampler = crate::server::diffusion_worker::parse_diffusion_sampler(
+                    &sched_config.diffusion_sampler,
+                )
+                .unwrap_or_else(|err| {
+                    tracing::warn!("{err}; defaulting to entropy-bound");
+                    crate::models::diffusion_gemma::DiffusionSamplerKind::EntropyBound
+                });
+                let defaults = crate::server::diffusion_worker::DiffusionServeDefaults {
+                    sampler,
+                    confidence_threshold: sched_config.diffusion_threshold,
+                    max_denoising_steps: sched_config.max_denoising_steps,
+                };
+                crate::server::diffusion_worker::run_diffusion_worker_loop(
+                    &diffusion,
+                    &tokenizer,
+                    &model_path,
+                    request_rx,
+                    defaults,
+                    &config_eos,
+                );
+                return;
+            }
+            other => other,
+        };
 
         // Axis B (B8): resolve the server-wide LangBiasConfig once,
         // after the tokenizer is available. Empty bias set or an HF-less
@@ -681,9 +708,7 @@ pub(crate) fn spawn_legacy_model_worker(
         );
 
         let load_start = Instant::now();
-        let result = if let Some(err) = server_unsupported_model_error(&model_path) {
-            Err(err)
-        } else if tensor_parallel.tp_size > 1 {
+        let result = if tensor_parallel.tp_size > 1 {
             crate::load_model_with_tensor_parallel(
                 &model_path,
                 adapter_path.as_deref(),
@@ -730,6 +755,26 @@ pub(crate) fn spawn_legacy_model_worker(
         if !config_eos.is_empty() {
             tracing::info!("EOS tokens from config: {:?}", config_eos);
         }
+
+        // DiffusionGemma (issue #217 phase 3): serve the block-diffusion model
+        // on its dedicated batch-1 loop. The legacy worker has no serve-level
+        // diffusion flags wired in (like `--vision-cache-size`), so it uses the
+        // engine defaults; operators who need to tune the diffusion knobs use
+        // the default batched worker.
+        let model = match model {
+            LoadedModel::DiffusionGemma(diffusion) => {
+                crate::server::diffusion_worker::run_diffusion_worker_loop(
+                    &diffusion,
+                    &tokenizer,
+                    &model_path,
+                    request_rx,
+                    crate::server::diffusion_worker::DiffusionServeDefaults::default(),
+                    &config_eos,
+                );
+                return;
+            }
+            other => other,
+        };
 
         tracing::info!(
             "Starting legacy sequential worker \

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -353,6 +353,14 @@ pub struct ServerStartupConfig {
     /// trivial to construct.
     #[cfg(feature = "surgery")]
     pub surgery_config_path: Option<PathBuf>,
+
+    /// `--max-denoising-steps` (issue #217 phase 3). Serve-level diffusion
+    /// step-cap override; `None` keeps the checkpoint default.
+    pub max_denoising_steps: Option<usize>,
+    /// `--diffusion-sampler` (issue #217 phase 3).
+    pub diffusion_sampler: String,
+    /// `--diffusion-threshold` (issue #217 phase 3).
+    pub diffusion_threshold: f32,
 }
 
 impl Default for ServerStartupConfig {
@@ -460,6 +468,9 @@ impl Default for ServerStartupConfig {
             conversation_store_ttl_secs: 3600,
             #[cfg(feature = "surgery")]
             surgery_config_path: None,
+            max_denoising_steps: None,
+            diffusion_sampler: "entropy-bound".to_string(),
+            diffusion_threshold: 0.9,
         }
     }
 }
@@ -859,6 +870,11 @@ pub(super) fn build_server_config(
         prefill_peers: startup.prefill_peers.clone(),
         decode_peers: startup.decode_peers.clone(),
         serving_bind: startup.serving_bind,
+        // serve-level diffusion knobs (#217 phase 3); consumed only by the
+        // DiffusionGemma worker loop.
+        max_denoising_steps: startup.max_denoising_steps,
+        diffusion_sampler: startup.diffusion_sampler.clone(),
+        diffusion_threshold: startup.diffusion_threshold,
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 3 (final) of #217: a dedicated single-stream (batch-1) serving path for DiffusionGemma inside the existing model worker thread. DiffusionGemma generates by model-owned block diffusion (`supports_batching() == false`) and cannot join the BatchScheduler, so the worker loads the model normally and, when it is a DiffusionGemma checkpoint, branches into a new block-diffusion serving loop instead of constructing the scheduler. The loop serves `/v1/chat/completions` and `/v1/completions` for text and image requests, both streaming (SSE) and non-streaming, with request cancellation and accurate usage stats. Requests queue on the existing mpsc channel and are served serially: that is the design (no in-flight concurrency > 1).

## What changed

- `src/server/diffusion_worker.rs` (new): the batch-1 worker loop (`run_diffusion_worker_loop`) plus the testable pure helpers it uses (`diffusion_options_from_server` / `build_diffusion_options` for server-to-engine option mapping, `reject_audio_video`, `parse_diffusion_sampler`, and `diffusion_finish_reason_str`). The loop tokenizes the already chat-templated prompt, optionally runs the phase-2 vision prefill, denoises through `generate_diffusion_streaming`, streams each committed token via the server's incremental detokenizer (`StreamingDecodeState`), polls the cancellation flag in the engine callback, and emits a final `Done` with real usage/timings and a mapped finish reason. One bad request emits `Error` and the loop keeps serving.
- `src/server/model_worker.rs`: removed the load-time rejection helper `server_unsupported_model_error` and both its call sites; the batched and legacy (`--no-batch`) workers now branch into the diffusion loop after the model loads. Added the three serve-level diffusion fields to `WorkerSchedulerConfig`.
- `src/models/diffusion_gemma/mod.rs`: extracted the CLI vision-prep into shared `DiffusionGemmaModel::prepare_image_prompt` / `build_image_processor` (+ `PreparedDiffusionImagePrompt`), and re-exported `DiffusionFinishReason`. The CLI `generate` driver (`src/commands/generate_diffusion.rs`) now delegates to this helper and keeps working identically.
- Serve-level flags `--max-denoising-steps`, `--diffusion-sampler`, `--diffusion-threshold` threaded from `ServeArgs` (new `DiffusionServeOptions` group) and the `mlxcel-server` binary through `ServerStartupInput` -> `ServerStartupConfig` -> `ServerConfig` -> `WorkerSchedulerConfig` -> the worker loop. Help text documents that they only affect diffusion models.

## Options mapping (server -> engine)

| server param | engine option |
|---|---|
| `options.max_tokens` | `max_new_tokens` |
| `options.sampling.temperature` | `temperature` |
| `--diffusion-sampler` | `sampler` |
| `--diffusion-threshold` | `confidence_threshold` |
| `--max-denoising-steps` | `max_denoising_steps` |
| `options.sampling.stop_token_ids` + config EOS (deduped) | `extra_eos_token_ids` |
| `options.sampling.seed` | `mlxcel_core::random_seed(seed)` before generation |
| (not exposed at serve level) | `min/max canvas`, `full_canvas`, `prefill_chunk_size` keep engine defaults |

## Limitations (documented)

- No in-flight concurrency > 1: requests are served serially off the shared channel (by design).
- Audio/video requests are rejected per-request with a clear `Error` event.
- Logprobs are not produced (served without them); the diffusion engine has no per-token logprob surface.
- Finish reason maps to the server's existing strings: `Length -> "length"`, `Stop -> "stop"`, `Aborted -> "stop"` (the server response surface has no distinct cancelled-reason string).
- Scheduler-specific endpoints (cache stats, batch metrics) degrade to empty/zero for the diffusion worker; `GET /v1/models` and health endpoints are unchanged.

## Test plan

- [x] `cargo fmt`
- [x] `cargo check --lib --tests --bins --features metal,accelerate`
- [x] `cargo clippy --lib --tests --bins --features metal,accelerate -- -D warnings`
- [x] `cargo test --lib --features metal,accelerate server::diffusion_worker` (7 passed: options mapping, EOS union/dedup, audio/video rejection, sampler parse, finish-reason mapping, defaults)
- [x] `cargo test --lib --features metal,accelerate models::diffusion_gemma` (32 passed, no regressions)
- [x] `cargo test --lib --features metal,accelerate server::cli_input` and `cargo test --bin mlxcel ... serve` and `cargo test --bin mlxcel-server` (config threading + arg parsing green)
- [x] Live-server E2E on `models/diffusiongemma-26B-A4B-it-4bit` (orchestrator runs this; see Real-model verification below)

## Real-model verification (phase 3)

Live server on `models/diffusiongemma-26B-A4B-it-4bit`:

- `GET /v1/models` returns the model entry correctly.
- Chat completions non-streaming: reasoning to content channel transition confirmed, `finish_reason: stop`, usage token counts correct.
- Chat completions streaming (SSE): `delta.reasoning_content` carries the thinking channel; `delta.content` carries the final reply; `finish_reason: stop` on the closing chunk; usage counts match non-streaming.
- Base64 `image_url` request: 256 soft tokens expanded, model answered "a red square and a blue circle" correctly.
- Serve-level flags: `--diffusion-sampler confidence-threshold --diffusion-threshold 0.6` verified effective (178 tokens generated in 7.8 s wall clock).
- `POST /v1/completions`: mechanical-OK; raw un-templated prompts degrade as documented (the model depends on its chat structure), so chat completions are the recommended path.
- CLI deterministic text regression: output byte-identical across all three phases (md5 `c38559cc`).

Closes #217