### PR TITLE
fix: adopt partially matched paged prefixes instead of declining

### DIFF
--- a/src/lib/mlxcel-core/src/cache/paged_detach.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach.rs
@@ -843,7 +843,12 @@ impl CachePool {
             retained.retain(|id| !dropped.contains(id));
         }
         for handle in set.caches.iter_mut() {
-            handle.offset = handle.offset.min(target_tokens as i32);
+            // The adopted prefix is exactly `target_tokens` long; a freshly
+            // detached pool-backed handle always satisfies
+            // `offset == seq_len > target_tokens` here, so this is a clamp in
+            // practice and an explicit statement of intent either way.
+            debug_assert!(handle.offset >= target_tokens as i32);
+            handle.offset = target_tokens as i32;
         }
         set.current_offset = set.current_offset.min(target_tokens as i32);
         set.prompt_len = set.prompt_len.min(target_tokens);

--- a/src/lib/mlxcel-core/src/cache/paged_detach.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach.rs
@@ -46,7 +46,7 @@
 //! live cache.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
@@ -737,6 +737,119 @@ impl CachePool {
             None => Err(format!(
                 "CachePool::adopt_parked_paged: unknown handle {handle}"
             )),
+        }
+    }
+
+    /// Trim a detached paged set to `target_tokens` before adoption (#225).
+    ///
+    /// A partial prefix match (an APC block-clamped lookup, or a request that
+    /// diverges inside the stored entry) covers only `target_tokens` of the
+    /// set. The caller floors that value to the pool block size, so no
+    /// partially filled tail block survives the trim: the adopting sequence's
+    /// suffix re-prefill then starts on a fresh block and never mutates a
+    /// shared tail (no copy-on-write needed at adopt time).
+    ///
+    /// Every dropped tail block releases BOTH references this set holds (the
+    /// block-table allocation and the detach-time pin), mirroring
+    /// [`CachePool::release_detached_paged`]. Release failures are reported
+    /// after the trim finishes so the set's bookkeeping never goes
+    /// inconsistent halfway. The dense placeholder handles' offsets and the
+    /// set's bookkeeping lengths are clamped so the subsequent
+    /// [`CachePool::adopt_paged`] restores RoPE offsets at the trimmed length.
+    ///
+    /// Turbo4 layouts are rejected: their per-page sidecars are keyed by the
+    /// dropped blocks and no current caller trims them. Sliding-window states
+    /// (`logical_start > 0`) are rejected for the same reason `write_prefill`
+    /// assumes absolute indexing from zero.
+    pub fn trim_detached_paged_to(
+        &mut self,
+        set: &mut DetachedPagedCacheSet,
+        target_tokens: usize,
+    ) -> Result<(), String> {
+        if set.backend != SequenceStateBackend::PagedKvCache {
+            return Err(format!(
+                "CachePool::trim_detached_paged_to: expected paged backend, got {:?}",
+                set.backend
+            ));
+        }
+        if set.paged_layout.is_turbo_mode() {
+            return Err(
+                "CachePool::trim_detached_paged_to: Turbo4 sidecar trim is not supported".into(),
+            );
+        }
+        let block_size = set.paged_layout.block_size;
+        if block_size == 0 || !target_tokens.is_multiple_of(block_size) {
+            return Err(format!(
+                "CachePool::trim_detached_paged_to: target {target_tokens} is not a multiple of block size {block_size}"
+            ));
+        }
+        let seq_len = set.seq_len();
+        if target_tokens > seq_len {
+            return Err(format!(
+                "CachePool::trim_detached_paged_to: target {target_tokens} exceeds set length {seq_len}"
+            ));
+        }
+        if set
+            .paged_state
+            .layers
+            .iter()
+            .any(|layer| layer.logical_start != 0)
+        {
+            return Err(
+                "CachePool::trim_detached_paged_to: sliding-window state (logical_start > 0) is not supported"
+                    .into(),
+            );
+        }
+        if target_tokens == seq_len {
+            return Ok(());
+        }
+        if set.retained_blocks.is_none() {
+            return Err(
+                "CachePool::trim_detached_paged_to: set no longer owns its block pins".into(),
+            );
+        }
+        let pool = self
+            .paged_pool
+            .as_ref()
+            .ok_or("CachePool::trim_detached_paged_to: no active paged pool")?
+            .clone();
+
+        let keep_blocks = target_tokens / block_size;
+        let mut dropped: HashSet<PagedBlockId> = HashSet::new();
+        let mut first_err: Option<String> = None;
+        {
+            let mut pool = pool.borrow_mut();
+            for layer in set.paged_state.layers.iter_mut() {
+                while layer.block_ids.len() > keep_blocks {
+                    let block_id = layer
+                        .block_ids
+                        .pop()
+                        .expect("len > keep_blocks implies non-empty");
+                    dropped.insert(block_id);
+                    // Allocation reference carried by the block table, then the
+                    // detach pin from `retained_blocks`.
+                    for _ in 0..2 {
+                        if let Err(err) = pool.release_block(block_id) {
+                            first_err.get_or_insert(format!(
+                                "failed to release dropped block {block_id}: {err}"
+                            ));
+                        }
+                    }
+                }
+                layer.len = target_tokens;
+            }
+        }
+        if let Some(retained) = set.retained_blocks.as_mut() {
+            retained.retain(|id| !dropped.contains(id));
+        }
+        for handle in set.caches.iter_mut() {
+            handle.offset = handle.offset.min(target_tokens as i32);
+        }
+        set.current_offset = set.current_offset.min(target_tokens as i32);
+        set.prompt_len = set.prompt_len.min(target_tokens);
+        match first_err {
+            Some(err) => Err(format!("CachePool::trim_detached_paged_to: {err}")),
+            None => Ok(()),
         }
     }
 

--- a/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
@@ -1643,3 +1643,143 @@ fn trim_across_shared_blocks_releases_only_the_trimming_sequences_refs() {
 fn _type_alive() -> Option<DetachedPagedCacheSet> {
     None
 }
+
+// ---------------------------------------------------------------------------
+// 12. Partial prefix adoption (#225): trim a detached set to a block boundary
+//     and adopt only the matched prefix.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn trim_detached_paged_to_enables_partial_prefix_adoption() {
+    let n_kv_heads = 2i32;
+    let head_dim = 3i32;
+    let block_size = 4usize;
+    let layout = PagedKvLayout::uniform(
+        1,
+        block_size,
+        block_size * n_kv_heads as usize * head_dim as usize * 2,
+    )
+    .unwrap();
+    let model = PagedStubModel::new(layout.clone());
+    let mut pool = CachePool::new(4);
+
+    // Seed: 12 tokens = 3 whole blocks, distinct per-token values.
+    let seed = pool.allocate(&model).unwrap();
+    let full_len = 12i32;
+    let full_k = prefill_block(1000.0, n_kv_heads, full_len, head_dim);
+    let full_v = prefill_block(5000.0, n_kv_heads, full_len, head_dim);
+    write_prefill_for(&mut pool, seed, 0, &full_k, &full_v).unwrap();
+
+    let mut set = pool.detach_paged(seed).unwrap();
+    assert_eq!(set.seq_len(), 12);
+    let live_before = pool.paged_stats().unwrap().live_blocks;
+    assert_eq!(live_before, 3);
+
+    // A request matched only 10 tokens; the scheduler floors to 8 (2 blocks).
+    pool.trim_detached_paged_to(&mut set, 8).unwrap();
+    assert_eq!(set.seq_len(), 8);
+    assert_eq!(
+        pool.paged_stats().unwrap().live_blocks,
+        2,
+        "the dropped tail block must fully release (both pins)"
+    );
+
+    // Adopt the trimmed set and append a divergent 6-token suffix at 8.
+    let consumer = pool.adopt_paged(&model, set).unwrap();
+    {
+        let state = pool.get_paged_state(consumer).unwrap();
+        let layer = state.layer(0).unwrap();
+        assert_eq!(layer.block_ids.len(), 2);
+        assert_eq!(layer.len, 8);
+    }
+    let suffix_len = 6i32;
+    let suffix_k = prefill_block(2000.0, n_kv_heads, suffix_len, head_dim);
+    let suffix_v = prefill_block(6000.0, n_kv_heads, suffix_len, head_dim);
+    write_prefill_for(&mut pool, consumer, 0, &suffix_k, &suffix_v).unwrap();
+
+    // Gather must return the kept 8-token prefix plus the fresh suffix,
+    // byte-identical to the dense reference.
+    let total = 8 + suffix_len;
+    let state = pool.get_paged_state(consumer).unwrap();
+    let (gk, gv) = pool
+        .paged_pool_ref()
+        .unwrap()
+        .gather_visible(&state, 0)
+        .unwrap()
+        .expect("gather must return data");
+    let prefix8_k = {
+        let full = prefill_block(1000.0, n_kv_heads, full_len, head_dim);
+        crate::ffi::slice(&full, &[0, 0, 0, 0], &[1, n_kv_heads, 8, head_dim])
+    };
+    let prefix8_v = {
+        let full = prefill_block(5000.0, n_kv_heads, full_len, head_dim);
+        crate::ffi::slice(&full, &[0, 0, 0, 0], &[1, n_kv_heads, 8, head_dim])
+    };
+    let dense_k = dense_reference(
+        &[
+            (prefix8_k, 0),
+            (
+                prefill_block(2000.0, n_kv_heads, suffix_len, head_dim),
+                8usize,
+            ),
+        ],
+        n_kv_heads,
+        total,
+        head_dim,
+    );
+    let dense_v = dense_reference(
+        &[
+            (prefix8_v, 0),
+            (
+                prefill_block(6000.0, n_kv_heads, suffix_len, head_dim),
+                8usize,
+            ),
+        ],
+        n_kv_heads,
+        total,
+        head_dim,
+    );
+    assert_eq!(flatten_fp32(&gk), flatten_fp32(&dense_k));
+    assert_eq!(flatten_fp32(&gv), flatten_fp32(&dense_v));
+}
+
+#[test]
+fn trim_detached_paged_to_rejects_bad_targets() {
+    let n_kv_heads = 2i32;
+    let head_dim = 3i32;
+    let block_size = 4usize;
+    let layout = PagedKvLayout::uniform(
+        1,
+        block_size,
+        block_size * n_kv_heads as usize * head_dim as usize * 2,
+    )
+    .unwrap();
+    let model = PagedStubModel::new(layout.clone());
+    let mut pool = CachePool::new(4);
+
+    let seed = pool.allocate(&model).unwrap();
+    let full_k = prefill_block(1.0, n_kv_heads, 12, head_dim);
+    let full_v = prefill_block(2.0, n_kv_heads, 12, head_dim);
+    write_prefill_for(&mut pool, seed, 0, &full_k, &full_v).unwrap();
+    let mut set = pool.detach_paged(seed).unwrap();
+
+    // Not block aligned.
+    assert!(pool.trim_detached_paged_to(&mut set, 6).is_err());
+    // Beyond the stored length.
+    assert!(pool.trim_detached_paged_to(&mut set, 16).is_err());
+    // No-op full-length trim succeeds and changes nothing.
+    pool.trim_detached_paged_to(&mut set, 12).unwrap();
+    assert_eq!(set.seq_len(), 12);
+    assert_eq!(pool.paged_stats().unwrap().live_blocks, 3);
+
+    // The set still adopts cleanly afterwards.
+    let consumer = pool.adopt_paged(&model, set).unwrap();
+    assert_eq!(
+        pool.get_paged_state(consumer)
+            .unwrap()
+            .layer(0)
+            .unwrap()
+            .len,
+        12
+    );
+}

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -2127,7 +2127,7 @@ impl BatchScheduler {
         let (seq_id, prefill_start_offset, already_cached_tokens) = match ctx_ref
             .and_then(|ctx| self.try_adopt_cached_prefix(ctx, &prompt_tokens, is_multimodal))
         {
-            Some((adopted_id, matched_len)) => (adopted_id, matched_len, matched_len),
+            Some((adopted_id, adopted_len)) => (adopted_id, adopted_len, adopted_len),
             None => {
                 // Miss or feature disabled → regular allocate.
                 // count misses only when the cache is actually

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1251,6 +1251,10 @@ impl BatchScheduler {
             return None;
         }
 
+        // Length the adopted cache actually covers. The dense path truncates
+        // to exactly `matched_len`; the paged path floors to the pool block
+        // boundary (#225), so it reports its own value.
+        let mut adopted_len = matched_len;
         let adopt_result = match detached {
             DetachedKvSet::Dense(mut dense) => {
                 // APC block-level partial adoption. When APC clamps
@@ -1279,20 +1283,49 @@ impl BatchScheduler {
                 self.cache_pool
                     .adopt(&self.model as &dyn LanguageModel, dense)
             }
-            DetachedKvSet::Paged(paged) => {
-                // APC block-hash partial adoption for paged entries is deferred
-                // (a later #121 sub-step): the paged store path matches the full
-                // stored prefix only. If a partial match somehow surfaces,
-                // decline rather than adopt an over-long prefix.
+            DetachedKvSet::Paged(mut paged) => {
+                // Paged partial prefix adoption (#225). An APC block-clamped
+                // lookup (or a request that diverges inside the stored entry)
+                // matches only `matched_len` of the set. Floor that to the
+                // POOL block boundary: no partially filled tail block survives
+                // the trim, so the suffix re-prefill starts on a fresh block
+                // and never needs copy-on-write against a shared tail. A
+                // whole-entry match skips the trim and stays bit-exact with
+                // the pre-#225 path.
                 let paged_seq_len = paged.seq_len();
-                if matched_len < paged_seq_len {
+                let block_size = paged.layout().block_size.max(1);
+                let adoptable = if matched_len < paged_seq_len {
+                    (matched_len / block_size) * block_size
+                } else {
+                    paged_seq_len
+                };
+                let min_prefix = store.min_prefix_tokens().max(1);
+                if adoptable < min_prefix {
                     tracing::debug!(
                         from = paged_seq_len,
-                        to = matched_len,
-                        "prompt-cache adopt: paged partial adoption not yet supported; releasing and falling back to cold prefill"
+                        to = adoptable,
+                        "prompt-cache adopt: block-floored paged match below the minimum prefix; releasing and falling back to cold prefill"
                     );
                     self.cache_pool.release_detached_paged(paged);
                     return None;
+                }
+                if adoptable < paged_seq_len {
+                    if let Err(err) = self
+                        .cache_pool
+                        .trim_detached_paged_to(&mut paged, adoptable)
+                    {
+                        tracing::warn!(
+                            "prompt-cache adopt: paged partial trim to {adoptable} failed ({err}); falling back to cold prefill"
+                        );
+                        self.cache_pool.release_detached_paged(paged);
+                        return None;
+                    }
+                    tracing::debug!(
+                        from = paged_seq_len,
+                        to = adoptable,
+                        "prompt-cache adopt: paged partial adoption trimmed detached set to the pool block boundary"
+                    );
+                    adopted_len = adoptable;
                 }
                 self.cache_pool
                     .adopt_paged(&self.model as &dyn LanguageModel, paged)
@@ -1303,21 +1336,21 @@ impl BatchScheduler {
             Ok(adopted_id) => {
                 tracing::debug!(
                     seq_id = %adopted_id,
-                    matched = matched_len,
+                    matched = adopted_len,
                     total = tokens.len(),
-                    "prompt-cache hit: adopted {matched_len}/{} tokens",
+                    "prompt-cache hit: adopted {adopted_len}/{} tokens",
                     tokens.len()
                 );
                 self.batch_observability
-                    .record_prompt_cache_hit(matched_len);
+                    .record_prompt_cache_hit(adopted_len);
                 // also increment BatchMetrics Prometheus counters.
-                self.batch_metrics.record_prompt_cache_hit(matched_len);
+                self.batch_metrics.record_prompt_cache_hit(adopted_len);
                 // Update byte/entry gauges so /metrics reflects current state.
                 if let Some(ref store) = self.prompt_cache {
                     self.batch_metrics
                         .update_prompt_cache_gauges(store.bytes(), store.len());
                 }
-                Some((adopted_id, matched_len))
+                Some((adopted_id, adopted_len))
             }
             Err(err) => {
                 // `adopt_paged` already releases paged pins on its error path;

--- a/tests/paged_prefix_share_parity.rs
+++ b/tests/paged_prefix_share_parity.rs
@@ -321,3 +321,174 @@ fn paged_prefix_share_matches_cold_run_llama3() {
     };
     assert_prefix_share_parity(&model, LLAMA3_DIR, "llama3");
 }
+
+// ---------------------------------------------------------------------------
+// Partial prefix adoption (#225): APC-clamped match, floored to the pool block
+// boundary, trimmed, adopted, and decoded byte-identically to cold.
+// ---------------------------------------------------------------------------
+
+/// Tail stored after the shared prefix in A's entry (12 tokens). B shares the
+/// first 8 of them and then diverges, so the APC chain agrees through token 48
+/// (three 16-token APC blocks) and the scheduler floor lands at 32 (one pool
+/// block), exercising a real non-trivial floor (48 -> 32).
+const STORED_TAIL_TOKENS: &[i32] = &[14582, 25, 3555, 374, 220, 16, 488, 220, 18, 30, 6771, 594];
+
+/// B's continuation: same first 8 tail tokens, then divergent.
+const PARTIAL_SUFFIX_TOKENS: &[i32] = &[14582, 25, 3555, 374, 220, 16, 488, 220, 24, 11, 4226, 30];
+
+fn assert_partial_prefix_share_parity(
+    model: &mlxcel::LoadedModel,
+    label: &str,
+    cache_model_key: &str,
+) {
+    use mlxcel::server::prompt_cache::ApcConfig;
+
+    let num_layers = model.num_layers();
+
+    // Stored entry: prefix + tail = 52 tokens (2 pool blocks: 32 + 20).
+    let mut stored_tokens = PREFIX_TOKENS.to_vec();
+    stored_tokens.extend_from_slice(STORED_TAIL_TOKENS);
+    // B's request: shares the stored entry's first 48 tokens, then diverges.
+    let mut b_prompt = PREFIX_TOKENS.to_vec();
+    b_prompt.extend_from_slice(PARTIAL_SUFFIX_TOKENS);
+    assert_eq!(stored_tokens[..48], b_prompt[..48], "share 48 tokens");
+    assert_ne!(stored_tokens[48], b_prompt[48], "diverge at token 48");
+
+    eprintln!(
+        "\n=== paged PARTIAL prefix-share parity: {label} ({num_layers} layers, \
+         stored={}, request={}) ===",
+        stored_tokens.len(),
+        b_prompt.len()
+    );
+
+    // ---- COLD reference for B's full prompt. ----
+    let cold_tokens = {
+        let mut pool = CachePool::new(2);
+        let id = pool
+            .allocate_with_layout(model, Some(scheduler_paged_layout(num_layers)))
+            .expect("cold paged allocate");
+        let caches = pool.get_caches_mut(id).unwrap();
+        prefill_and_decode(model, caches, &b_prompt, 0)
+    };
+    eprintln!("cold    decoded: {cold_tokens:?}");
+
+    // ---- Store with APC enabled (16-token blocks, the server default). ----
+    // ApcConfig is #[non_exhaustive]; mutate a default instead of constructing.
+    let apc = {
+        let mut apc = ApcConfig::default();
+        apc.enabled = true;
+        apc
+    };
+    let store = PromptCacheStore::with_config(
+        PromptCacheConfig::new(true, 1 << 30, 64, Duration::from_secs(3600), 1).with_apc(apc),
+    );
+    let mut pool = CachePool::new(4);
+
+    // A prefills the full stored sequence and donates it.
+    let seq_a = pool
+        .allocate_with_layout(model, Some(scheduler_paged_layout(num_layers)))
+        .expect("A paged allocate");
+    {
+        let caches = pool.get_caches_mut(seq_a).unwrap();
+        let len = stored_tokens.len() as i32;
+        let prompt = mlxcel_core::from_slice_i32(&stored_tokens, &[1, len]);
+        let mask = mlxcel_core::utils::create_causal_mask(len, 0);
+        let logits = model.forward(&prompt, caches, Some(&mask));
+        mlxcel_core::eval(&logits);
+    }
+    let a_blocks = pool
+        .get_paged_state(seq_a)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids
+        .clone();
+    assert_eq!(a_blocks.len(), 2, "52 tokens = 2 pool blocks");
+    let set_a = pool.detach_paged(seq_a).expect("A detach_paged");
+    let entry = CacheEntry::new(stored_tokens.clone(), DetachedKvSet::Paged(set_a));
+    let insert_key = PromptCacheKey::new_full(
+        cache_model_key,
+        None,
+        "tpl-v1",
+        Some("sess"),
+        MultimodalDigest::empty(),
+        &stored_tokens,
+    );
+    store.insert(&insert_key, entry).expect("store insert");
+
+    // ---- B looks up: APC clamps the match to 48 (three 16-token blocks). ----
+    let lookup_key = PromptCacheKey::new_full(
+        cache_model_key,
+        None,
+        "tpl-v1",
+        Some("sess"),
+        MultimodalDigest::empty(),
+        &b_prompt,
+    );
+    let (hit_entry, matched_len) = store
+        .lookup_longest_prefix(&lookup_key, &b_prompt)
+        .expect("B must hit A's entry via the APC partial path");
+    assert_eq!(matched_len, 48, "APC must clamp the match to token 48");
+
+    // ---- Mirror the scheduler's #225 paged arm: floor to the pool block
+    //      boundary, trim, adopt. ----
+    let mut set_b = match hit_entry.take_detached().expect("first take") {
+        DetachedKvSet::Paged(p) => p,
+        DetachedKvSet::Dense(_) => panic!("paged backend must store a paged set"),
+    };
+    let adoptable = (matched_len / BLOCK_SIZE) * BLOCK_SIZE;
+    assert_eq!(adoptable, 32, "48 floors to one 32-token pool block");
+    pool.trim_detached_paged_to(&mut set_b, adoptable)
+        .expect("partial trim");
+    assert_eq!(set_b.seq_len(), adoptable);
+    let seq_b = pool.adopt_paged(model, set_b).expect("B adopt_paged");
+
+    // B keeps A's FIRST block (shared physical prefix), dropped the second.
+    let b_blocks = pool
+        .get_paged_state(seq_b)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids
+        .clone();
+    assert_eq!(b_blocks.len(), 1, "trimmed to one shared prefix block");
+    assert_eq!(b_blocks[0], a_blocks[0], "B must reuse A's first block");
+
+    // ---- B re-prefills everything past the adopted 32 tokens and decodes. ----
+    let cached_tokens = {
+        let caches = pool.get_caches_mut(seq_b).unwrap();
+        assert!(
+            caches.iter().all(|c| c.is_paged_backed()),
+            "adopted B must have pool-backed caches"
+        );
+        prefill_and_decode(model, caches, &b_prompt[adoptable..], adoptable as i32)
+    };
+    eprintln!("partial decoded: {cached_tokens:?}");
+
+    assert_eq!(
+        cached_tokens, cold_tokens,
+        "partial-prefix (trimmed + adopted) decode must equal the cold run\n\
+         cold:    {cold_tokens:?}\npartial: {cached_tokens:?}"
+    );
+    eprintln!("OK: B adopted a trimmed 32-token prefix and decoded identically to cold.");
+}
+
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit and runs real GPU forwards; run with --ignored"]
+fn paged_partial_prefix_share_matches_cold_run_qwen3() {
+    let _runtime = initialize_runtime();
+    let Some(model) = load_or_skip(QWEN3_DIR, "mlx-community/Qwen3-0.6B-4bit") else {
+        return;
+    };
+    assert_partial_prefix_share_parity(&model, QWEN3_DIR, "qwen3");
+}
+
+#[test]
+#[ignore = "loads llama-3.2-1b-4bit and runs real GPU forwards; run with --ignored"]
+fn paged_partial_prefix_share_matches_cold_run_llama3() {
+    let _runtime = initialize_runtime();
+    let Some(model) = load_or_skip(LLAMA3_DIR, "mlx-community/Llama-3.2-1B-Instruct-4bit") else {
+        return;
+    };
+    assert_partial_prefix_share_parity(&model, LLAMA3_DIR, "llama3");
+}


### PR DESCRIPTION
## Summary

Implements #225. `try_adopt_cached_prefix` declined every paged adoption whose `matched_len` fell short of the stored entry, so the default backend (auto resolves to paged under batching) never reused divergent-sibling prefixes, and with `--apc-enabled` the APC block clamp made even strict multiturn continuation miss (measured: multiturn cached tokens 11067 with APC off, 0 with APC on).

- The scheduler's paged arm now floors `matched_len` to the pool block boundary and trims the detached set before adopting. Flooring means no partially filled tail block survives, so the suffix re-prefill always starts on a fresh block and needs no copy-on-write against a shared tail. Whole-entry matches skip the trim and stay bit-exact with the old path.
- New `CachePool::trim_detached_paged_to`: releases BOTH references of every dropped tail block (the block-table allocation and the detach pin, mirroring `release_detached_paged`), clamps the dense-handle offsets and bookkeeping lengths so the subsequent adopt restores RoPE at the trimmed length, and rejects Turbo4 sidecar layouts and sliding-window (`logical_start > 0`) states. Release failures are collected and reported after the trim finishes so the set's bookkeeping never goes inconsistent halfway; the caller then releases the remaining pins and falls back to a cold prefill.
- The block-floored length is also screened against the store's `min_prefix_tokens` and reported as the adopted length in logs, observability, and the scheduler return value.

## Validation

- New real-model gates `paged_partial_prefix_share_parity` (qwen3 + llama3): a store with APC enabled clamps a 52-token entry match to 48 tokens, the scheduler mirror floors to 32, trims, adopts (B keeps A's first physical block, drops the second), re-prefills the rest, and decodes byte-identically to a cold run.
- New unit tests: the trim fully releases the dropped tail block (pool live count drops), the trimmed set adopts and gathers byte-identically against a dense reference, and misaligned or oversized targets are rejected.
- HTTP end-to-end (llama-3.2-1b, `--apc-enabled`, default paged backend, scripts/bench_memory_footprint.py): burst cached tokens 0 to 3648, seqshare 0 to 25536, multiturn 0 to 10976, matching the dense backend's numbers; seqshare footprint peak 1412 MiB vs 1507 MiB on dense; wall times within run noise.
- Existing whole-entry parity gates stay green and byte-identical: `paged_prefix_share_parity`, `paged_scheduler_parity`, `paged_real_model_parity`.
- 3150 server lib tests, 868 core lib tests (one pre-existing release-mode `pack3` should-panic failure also present on main, unrelated), cold clippy clean, fmt clean.

Concurrent siblings are still limited by the one-shot `take_detached` (only the first adopter wins); that is #227.

Closes #225