### PR TITLE
fix: account real paged pool bytes in the prompt-cache ledger and stats

### DIFF
--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -5834,19 +5834,10 @@ impl CachePool {
     }
 
     pub fn paged_stats(&self) -> Option<PagedCacheStats> {
-        let pool = self.paged_pool.as_ref()?;
-        // Collect the per-sequence borrows first, then hand `stats_for_sequences`
-        // plain references. The pool and each sequence state live in distinct
-        // `RefCell`s, so the pool borrow and these state borrows coexist.
-        let states: Vec<Ref<'_, PagedSequenceState>> = self
-            .active
-            .values()
-            .filter_map(|sequence| sequence.paged_state())
-            .collect();
-        Some(
-            pool.borrow()
-                .stats_for_sequences(states.iter().map(|state| &**state)),
-        )
+        // Pool-wide stats (#226): block counts and REAL slab bytes come from
+        // the pool itself, covering active sequences and parked prompt-cache
+        // pins alike, so no per-sequence borrows are needed anymore.
+        self.paged_pool.as_ref().map(|pool| pool.borrow().stats())
     }
 
     pub fn paged_block_size(&self) -> Option<usize> {
@@ -7335,8 +7326,8 @@ mod tests {
                 allocated_blocks: 3,
                 live_blocks: 3,
                 free_blocks: 0,
-                bytes_reserved: 384,
-                bytes_in_use: 288,
+                bytes_reserved: 0,
+                bytes_in_use: 0,
             })
         );
 
@@ -7347,8 +7338,8 @@ mod tests {
                 allocated_blocks: 4,
                 live_blocks: 4,
                 free_blocks: 0,
-                bytes_reserved: 512,
-                bytes_in_use: 352,
+                bytes_reserved: 0,
+                bytes_in_use: 0,
             })
         );
     }
@@ -7577,8 +7568,8 @@ mod tests {
                 allocated_blocks: 2,
                 live_blocks: 2,
                 free_blocks: 0,
-                bytes_reserved: 256,
-                bytes_in_use: 192,
+                bytes_reserved: 0,
+                bytes_in_use: 0,
             }
         );
         assert_eq!(pool.memory_usage_bytes(), 192);
@@ -7590,8 +7581,8 @@ mod tests {
                 allocated_blocks: 2,
                 live_blocks: 2,
                 free_blocks: 0,
-                bytes_reserved: 256,
-                bytes_in_use: 160,
+                bytes_reserved: 0,
+                bytes_in_use: 0,
             }
         );
 
@@ -7608,8 +7599,8 @@ mod tests {
                 allocated_blocks: 2,
                 live_blocks: 1,
                 free_blocks: 1,
-                bytes_reserved: 128,
-                bytes_in_use: 96,
+                bytes_reserved: 0,
+                bytes_in_use: 0,
             }
         );
 
@@ -7620,8 +7611,8 @@ mod tests {
                 allocated_blocks: 3,
                 live_blocks: 2,
                 free_blocks: 1,
-                bytes_reserved: 256,
-                bytes_in_use: 224,
+                bytes_reserved: 0,
+                bytes_in_use: 0,
             }
         );
 

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -728,8 +728,15 @@ impl PagedBlockPool {
         let bytes_reserved = self.pool_tensor_bytes();
         let bytes_in_use = (0..self.block_rows.len())
             .map(|layer_idx| {
-                self.block_rows[layer_idx].len()
-                    * self.real_block_bytes(layer_idx).unwrap_or_default()
+                let per_block = self.real_block_bytes(layer_idx);
+                // A layer with mapped rows must have written geometry; an
+                // unknown dtype silently zeroing its bytes would be a future
+                // regression, so surface it in debug builds.
+                debug_assert!(
+                    per_block.is_some() || self.block_rows[layer_idx].is_empty(),
+                    "layer {layer_idx} has mapped rows but no real block size"
+                );
+                self.block_rows[layer_idx].len() * per_block.unwrap_or_default()
             })
             .sum();
 

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -306,9 +306,8 @@ impl PagedSequenceState {
 /// `refcount == 0` and is not eligible for recycling as long as `refcount > 0`.
 ///
 /// `in_use` is retained as a derived mirror of `refcount > 0` so the existing
-/// `stats_for_sequences` and internal debug assertions stay backwards
-/// compatible with call sites that inspected the flag directly before
-/// refcounts were introduced.
+/// `stats` and internal debug assertions stay backwards compatible with call
+/// sites that inspected the flag directly before refcounts were introduced.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PagedBlockRecord {
     layer_idx: usize,
@@ -711,10 +710,7 @@ impl PagedBlockPool {
         Ok(())
     }
 
-    pub fn stats_for_sequences<'a>(
-        &self,
-        sequences: impl IntoIterator<Item = &'a PagedSequenceState>,
-    ) -> PagedCacheStats {
+    pub fn stats(&self) -> PagedCacheStats {
         let allocated_blocks = self.blocks.len();
         let free_blocks = self
             .blocks
@@ -722,14 +718,19 @@ impl PagedBlockPool {
             .filter(|record| !record.is_in_use())
             .count();
         let live_blocks = allocated_blocks.saturating_sub(free_blocks);
-        let states: Vec<&PagedSequenceState> = sequences.into_iter().collect();
-        let bytes_reserved = states
-            .iter()
-            .map(|state| state.reserved_bytes(&self.layout))
-            .sum();
-        let bytes_in_use = states
-            .iter()
-            .map(|state| state.used_bytes(&self.layout))
+        // Real pool memory, not the layout's nominal scheduling placeholder
+        // (#226): reserved = every allocated slab byte (capacity, including
+        // grow slack); in use = bytes of the rows mapped to a live block,
+        // which covers ACTIVE sequences and PARKED prompt-cache pins alike
+        // (release_block unmaps a row at refcount 0). The per-sequence
+        // nominal sums these replaced systematically under-reported
+        // (32 B/block) and missed parked retention entirely.
+        let bytes_reserved = self.pool_tensor_bytes();
+        let bytes_in_use = (0..self.block_rows.len())
+            .map(|layer_idx| {
+                self.block_rows[layer_idx].len()
+                    * self.real_block_bytes(layer_idx).unwrap_or_default()
+            })
             .sum();
 
         PagedCacheStats {
@@ -739,6 +740,18 @@ impl PagedBlockPool {
             bytes_reserved,
             bytes_in_use,
         }
+    }
+
+    /// REAL bytes one physical block of `layer_idx` occupies in the pool's K
+    /// and V slabs combined: `block_size x n_kv_heads x head_dim x
+    /// element_size x 2`. `None` until the layer's first write captures its
+    /// geometry (or for an unknown dtype). This is the actual memory cost a
+    /// pinned block imposes, unlike the layout's nominal `bytes_per_block`
+    /// scheduling placeholder (#226).
+    pub fn real_block_bytes(&self, layer_idx: usize) -> Option<usize> {
+        let meta = self.pool_meta.get(layer_idx).copied().flatten()?;
+        let esize = crate::dtype::size_bytes(meta.dtype)?;
+        Some(self.layout.block_size * meta.n_kv_heads as usize * meta.head_dim as usize * esize * 2)
     }
 
     /// Current refcount of `block_id`, or `0` if the block is free or unknown.

--- a/src/lib/mlxcel-core/src/cache/paged_detach.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach.rs
@@ -90,6 +90,11 @@ pub struct DetachedPagedCacheSet {
     /// `None` after successful adoption so `Drop` can run without triggering
     /// a leak warning.
     pub(super) retained_blocks: Option<Vec<PagedBlockId>>,
+    /// REAL bytes the pinned pool blocks occupy, captured from the pool's
+    /// per-layer geometry at detach time (#226). `None` when no layer had
+    /// pool-resident K/V (then [`Self::nbytes`] falls back to the layout's
+    /// nominal accounting).
+    pub(super) real_pool_bytes: Option<usize>,
     /// Per-page Turbo4 sidecar tensors lifted out of the originating
     /// [`PagedBlockPool`] at detach time. Keyed by `PagedBlockId`. Empty for
     /// `Fp16`/`Int8` cache modes; on adopt the entries are reinstalled into
@@ -172,7 +177,12 @@ impl DetachedPagedCacheSet {
     /// Turbo4 sidecar tensors carried directly by this set.
     pub fn nbytes(&self) -> usize {
         let dense: usize = self.caches.iter().map(|c| c.nbytes()).sum();
-        let paged: usize = self.paged_state.reserved_bytes(&self.paged_layout);
+        // Prefer the REAL pool bytes captured at detach time (#226); the
+        // layout-derived value is a nominal scheduling placeholder that
+        // under-reported pool-backed sets by orders of magnitude.
+        let paged: usize = self
+            .real_pool_bytes
+            .unwrap_or_else(|| self.paged_state.reserved_bytes(&self.paged_layout));
         let sidecars: usize = self.turbo_sidecar_bytes();
         dense + paged + sidecars
     }
@@ -267,10 +277,20 @@ pub(super) enum ParkedCache {
 }
 
 impl ParkedCache {
+    /// Bytes this parked set contributes to
+    /// [`CachePool::memory_usage_bytes`]. For paged sets the pool-resident
+    /// K/V bytes are EXCLUDED: `memory_usage_bytes` already adds the pool's
+    /// `pool_tensor_bytes()` (which physically contains the pinned blocks),
+    /// so counting the set's real pool bytes here again would double-count
+    /// (#226). Dense handles and lifted Turbo4 sidecars are owned by the set
+    /// itself and stay counted.
     pub(super) fn nbytes(&self) -> usize {
         match self {
             ParkedCache::Dense(set) => set.nbytes(),
-            ParkedCache::Paged(set) => set.nbytes(),
+            ParkedCache::Paged(set) => {
+                let dense: usize = set.caches.iter().map(|c| c.nbytes()).sum();
+                dense + set.turbo_sidecar_bytes()
+            }
         }
     }
 }
@@ -427,6 +447,27 @@ impl CachePool {
             }
         }
 
+        // Capture the REAL pool bytes the pinned blocks occupy (#226). The
+        // layout's nominal `bytes_per_block` is a scheduling placeholder, so
+        // accounting the set (and thus the prompt-cache ledger) with it made
+        // the capacity cap ineffective. Layers whose geometry was never
+        // written (no pool meta, e.g. an Int8 dense-compat sequence whose
+        // K/V live in the dense handles) contribute nothing here; if NO layer
+        // has real bytes the field stays `None` and `nbytes` falls back to
+        // the nominal value.
+        let real_pool_bytes: Option<usize> = self.paged_pool.as_ref().and_then(|pool| {
+            let pool = pool.borrow();
+            let mut total = 0usize;
+            let mut any = false;
+            for (layer_idx, layer) in paged_state.layers.iter().enumerate() {
+                if let Some(per_block) = pool.real_block_bytes(layer_idx) {
+                    total += layer.block_ids.len() * per_block;
+                    any = true;
+                }
+            }
+            any.then_some(total)
+        });
+
         Some(DetachedPagedCacheSet {
             caches: detached_caches,
             paged_state,
@@ -438,6 +479,7 @@ impl CachePool {
             detached_at: Instant::now(),
             origin_seq_id: sequence.seq_id,
             retained_blocks: Some(retained),
+            real_pool_bytes,
             v_packed_pages,
             v_norms_pages,
             k_packed_pages,
@@ -816,16 +858,19 @@ impl CachePool {
 
         let keep_blocks = target_tokens / block_size;
         let mut dropped: HashSet<PagedBlockId> = HashSet::new();
+        let mut dropped_real_bytes = 0usize;
         let mut first_err: Option<String> = None;
         {
             let mut pool = pool.borrow_mut();
-            for layer in set.paged_state.layers.iter_mut() {
+            for (layer_idx, layer) in set.paged_state.layers.iter_mut().enumerate() {
+                let per_block_real = pool.real_block_bytes(layer_idx).unwrap_or_default();
                 while layer.block_ids.len() > keep_blocks {
                     let block_id = layer
                         .block_ids
                         .pop()
                         .expect("len > keep_blocks implies non-empty");
                     dropped.insert(block_id);
+                    dropped_real_bytes += per_block_real;
                     // Allocation reference carried by the block table, then the
                     // detach pin from `retained_blocks`.
                     for _ in 0..2 {
@@ -838,6 +883,9 @@ impl CachePool {
                 }
                 layer.len = target_tokens;
             }
+        }
+        if let Some(real) = set.real_pool_bytes.as_mut() {
+            *real = real.saturating_sub(dropped_real_bytes);
         }
         if let Some(retained) = set.retained_blocks.as_mut() {
             retained.retain(|id| !dropped.contains(id));

--- a/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
@@ -638,14 +638,19 @@ fn park_paged_round_trip_accounts_bytes() {
     pool.append_paged_tokens(seq, 0, 8).unwrap();
     pool.append_paged_tokens(seq, 1, 4).unwrap();
     let detached = pool.detach_paged(seq).unwrap();
-    let expected_bytes = detached.nbytes();
-    assert!(expected_bytes > 0);
+    // The set's own ledger view (prompt-cache accounting) stays nonzero: with
+    // no real pool writes it falls back to the layout's nominal bytes.
+    assert!(detached.nbytes() > 0);
 
     let handle = pool.park_detached_paged(detached);
     assert_eq!(pool.parked_count(), 1);
-    assert_eq!(pool.parked_bytes(), expected_bytes);
+    // Pool-resident bytes are counted ONCE via `pool_tensor_bytes` inside
+    // `memory_usage_bytes` (#226); the parked walk no longer re-adds them.
+    // This sequence never wrote K/V, so the pool holds no slabs and the true
+    // physical footprint is zero.
+    assert_eq!(pool.parked_bytes(), 0);
     assert!(pool.peek_parked_paged(handle).is_some());
-    assert_eq!(pool.memory_usage_bytes(), expected_bytes);
+    assert_eq!(pool.memory_usage_bytes(), 0);
 
     // Dense peek must reject a paged handle.
     assert!(pool.peek_parked(handle).is_none());
@@ -1782,4 +1787,80 @@ fn trim_detached_paged_to_rejects_bad_targets() {
             .len,
         12
     );
+}
+
+// ---------------------------------------------------------------------------
+// 13. Real-bytes accounting (#226): detached sets and pool stats report the
+//     actual pool memory, not the layout's nominal placeholder.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn detached_paged_set_accounts_real_pool_bytes() {
+    let n_kv_heads = 2i32;
+    let head_dim = 3i32;
+    let block_size = 4usize;
+    let layout = PagedKvLayout::uniform(
+        1,
+        block_size,
+        block_size * n_kv_heads as usize * head_dim as usize * 2,
+    )
+    .unwrap();
+    let model = PagedStubModel::new(layout.clone());
+    let mut pool = CachePool::new(4);
+
+    // 12 tokens = 3 blocks, written in FP32 (tests write f32 blocks), so the
+    // REAL cost per block is block_size x H x D x 4 bytes x 2 (K+V) = 192.
+    let seq = pool.allocate(&model).unwrap();
+    let k = prefill_block(1.0, n_kv_heads, 12, head_dim);
+    let v = prefill_block(2.0, n_kv_heads, 12, head_dim);
+    write_prefill_for(&mut pool, seq, 0, &k, &v).unwrap();
+
+    let per_block_real = block_size * n_kv_heads as usize * head_dim as usize * 4 * 2;
+    assert_eq!(
+        pool.paged_pool_ref().unwrap().real_block_bytes(0),
+        Some(per_block_real)
+    );
+
+    // Pool stats are real: in_use covers the 3 mapped rows, reserved covers
+    // the full presized slab capacity.
+    let stats = pool.paged_stats().unwrap();
+    assert_eq!(stats.bytes_in_use, 3 * per_block_real);
+    assert_eq!(
+        stats.bytes_reserved,
+        pool.paged_pool_ref().unwrap().pool_tensor_bytes()
+    );
+    assert!(stats.bytes_reserved >= stats.bytes_in_use);
+
+    // The detached set's ledger bytes are the real pinned-pool bytes (the
+    // stub's dense handles are empty clone handles, so they contribute 0).
+    let mut set = pool.detach_paged(seq).unwrap();
+    assert_eq!(set.nbytes(), 3 * per_block_real);
+
+    // A partial trim (#225) shrinks the ledger by the dropped blocks.
+    pool.trim_detached_paged_to(&mut set, 8).unwrap();
+    assert_eq!(set.nbytes(), 2 * per_block_real);
+
+    pool.release_detached_paged(set);
+    // With every pin gone the rows unmap and in_use returns to zero;
+    // reserved keeps the allocated slabs (capacity is not shrunk).
+    let stats = pool.paged_stats().unwrap();
+    assert_eq!(stats.bytes_in_use, 0);
+    assert!(stats.bytes_reserved > 0);
+}
+
+#[test]
+fn detached_paged_set_without_pool_writes_falls_back_to_nominal_bytes() {
+    let layout = default_layout();
+    let model = PagedStubModel::new(layout.clone());
+    let mut pool = CachePool::new(4);
+
+    // Logical appends only: no pool tensor exists, so no real geometry was
+    // ever captured and the nominal layout accounting is the only signal.
+    let seq = pool.allocate(&model).unwrap();
+    pool.append_paged_tokens(seq, 0, 8).unwrap();
+    let set = pool.detach_paged(seq).unwrap();
+    let nominal = set.paged_state().reserved_bytes(set.layout());
+    assert!(nominal > 0);
+    assert_eq!(set.nbytes(), nominal);
+    pool.release_detached_paged(set);
 }

--- a/src/lib/mlxcel-core/src/dtype.rs
+++ b/src/lib/mlxcel-core/src/dtype.rs
@@ -28,3 +28,14 @@ pub const FLOAT32: i32 = 10;
 pub const FLOAT64: i32 = 11;
 pub const BFLOAT16: i32 = 12;
 pub const COMPLEX64: i32 = 13;
+
+/// Bytes per element for an MLX dtype code, or `None` for unknown codes.
+pub fn size_bytes(dtype: i32) -> Option<usize> {
+    match dtype {
+        BOOL | UINT8 | INT8 => Some(1),
+        UINT16 | INT16 | FLOAT16 | BFLOAT16 => Some(2),
+        UINT32 | INT32 | FLOAT32 => Some(4),
+        UINT64 | INT64 | FLOAT64 | COMPLEX64 => Some(8),
+        _ => None,
+    }
+}

--- a/src/server/routes/metrics.rs
+++ b/src/server/routes/metrics.rs
@@ -154,10 +154,10 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
          # HELP mlxcel_cache_pool_paged_blocks_free Paged KV blocks currently free for reuse\n\
          # TYPE mlxcel_cache_pool_paged_blocks_free gauge\n\
          mlxcel_cache_pool_paged_blocks_free {paged_blocks_free}\n\
-         # HELP mlxcel_cache_pool_paged_bytes_reserved Reserved bytes across paged sequences\n\
+         # HELP mlxcel_cache_pool_paged_bytes_reserved Real bytes of allocated paged pool slabs (capacity, including grow slack)\n\
          # TYPE mlxcel_cache_pool_paged_bytes_reserved gauge\n\
          mlxcel_cache_pool_paged_bytes_reserved {paged_bytes_reserved}\n\
-         # HELP mlxcel_cache_pool_paged_bytes_in_use Visible bytes in use across paged sequences\n\
+         # HELP mlxcel_cache_pool_paged_bytes_in_use Real bytes of pool rows mapped to live blocks (active sequences plus parked prompt-cache pins)\n\
          # TYPE mlxcel_cache_pool_paged_bytes_in_use gauge\n\
          mlxcel_cache_pool_paged_bytes_in_use {paged_bytes_in_use}\n\
          # HELP mlxcel_cache_pool_paged_block_budget Configured paged KV block-budget cap (0 = unbounded)\n\


### PR DESCRIPTION
## Summary

Implements #226. The prompt-cache ledger valued a pool-backed paged entry by the layout's nominal `bytes_per_block` placeholder (32 B/block): a 10.5k-token entry holding about 1.2 GiB of real KV was booked at 296 KB, so the 2 GiB capacity cap effectively never triggered and real retention was bounded only by TTL and max_entries.

- New `dtype::size_bytes` and `PagedBlockPool::real_block_bytes` expose the actual per-block cost (block_size x n_kv_heads x head_dim x element_size x 2) from the layer geometry captured on first write.
- `detach_paged` records the set's real pinned-pool bytes; `DetachedPagedCacheSet::nbytes` prefers them. Entries whose K/V never reached the pool (logical-only appends, Int8 dense-compat) keep the nominal fallback. `trim_detached_paged_to` (#225) shrinks the figure by the dropped blocks.
- `PagedBlockPool::stats` (renamed from `stats_for_sequences`; the per-sequence walk is gone) reports pool-wide REAL bytes: `bytes_reserved` = allocated slab capacity, `bytes_in_use` = rows mapped to live blocks. This covers active sequences and parked prompt-cache pins alike; the old per-sequence nominal sums under-reported by orders of magnitude and missed parked retention entirely.
- `memory_usage_bytes` no longer double-counts: parked paged sets contribute only their own dense handles and lifted Turbo4 sidecars, since `pool_tensor_bytes` already physically contains the pinned blocks.

## Validation

- New unit tests: real bytes captured at detach match the geometry product, pool stats report real reserved/in_use, a #225 partial trim shrinks the ledger, and never-written sets fall back to nominal accounting.
- Updated tests that asserted the old nominal semantics (append-only sequences now correctly report zero real pool bytes).
- E2E (llama-3.2-1b, `--prompt-cache-capacity-bytes 300000000`): three distinct ~3.8k-token prompts book 121 MiB each (real), `paged_bytes_in_use` tracks 121 / 242 / 242 MiB, and the third insert evicts the oldest entry (`evictions_lru` 1). Before this change the same three entries were booked at ~0.3 MB total and nothing ever evicted.
- Gates: core 869 lib tests (the single failure is the pre-existing release-mode `pack3` should_panic also failing on main), server 3150, prefix-share + scheduler real-model parity 8/8 byte-identical, cold clippy clean, fmt clean.

## Side finding (tracked in #227)

The real numbers made a behavioral hazard visible: with `--apc-enabled`, a small partial match (for example the ~30-token chat-template preamble shared by every request) takes the stored entry (one-shot `take_detached`) and trims it to one block, destroying thousands of tokens of cached KV to reuse 32 (observed live: `trimmed detached set from=3848 to=32`). Default APC-off configurations are unaffected because matches there require whole-entry containment. The non-consuming clone-and-pin adoption planned in #227 removes the hazard; a detailed comment is on that issue.

Closes #226