### PR TITLE
feat: non-consuming clone-and-pin paged adoption

### DIFF
--- a/src/lib/mlxcel-core/src/cache/detach.rs
+++ b/src/lib/mlxcel-core/src/cache/detach.rs
@@ -132,6 +132,48 @@ impl DetachedKVCache {
         self.offset
     }
 
+    /// Metadata-only copy of this handle for a non-consuming paged prefix
+    /// clone (#227), re-anchored at `offset_override`.
+    ///
+    /// Only valid for a handle that carries no tensors (the pool-backed Fp16
+    /// shape `clone_handle` produces: the live K/V lives in the shared block
+    /// pool, the handle only carries offset bookkeeping). Returns `None` when
+    /// any tensor field is populated, so a dense-compat set cannot be
+    /// shallow-cloned into aliased buffers.
+    pub(super) fn pool_backed_handle_clone(&self, offset_override: i32) -> Option<DetachedKVCache> {
+        if self.keys.is_some()
+            || self.values.is_some()
+            || self.key_scales.is_some()
+            || self.val_scales.is_some()
+            || self.v_packed.is_some()
+            || self.v_norms.is_some()
+            || self.v_rescale.is_some()
+            || self.k_packed.is_some()
+            || self.k_norms.is_some()
+        {
+            return None;
+        }
+        Some(DetachedKVCache {
+            keys: None,
+            values: None,
+            offset: offset_override,
+            step: self.step,
+            mode: self.mode,
+            key_scales: None,
+            val_scales: None,
+            v_packed: None,
+            v_norms: None,
+            v_rescale: None,
+            k_packed: None,
+            k_norms: None,
+            turbo_seed: self.turbo_seed,
+            cold_offset: 0,
+            hot_threshold: self.hot_threshold,
+            delegated_fp16_fast_path: self.delegated_fp16_fast_path,
+            delegated_fp16_sidecar_policy: self.delegated_fp16_sidecar_policy,
+        })
+    }
+
     /// Quantization mode of the detached cache.
     pub fn mode(&self) -> KVCacheMode {
         self.mode

--- a/src/lib/mlxcel-core/src/cache/paged_detach.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach.rs
@@ -162,6 +162,27 @@ impl DetachedPagedCacheSet {
         &self.caches
     }
 
+    /// Whether [`CachePool::clone_detached_paged_prefix`] can serve this set
+    /// (#227): a pool-backed Fp16 shape with no Turbo4 sidecars, absolute
+    /// indexing (no sliding-window `logical_start`), live block pins, and
+    /// metadata-only dense handles. Ineligible sets (e.g. dense-compat Int8
+    /// whose K/V lives in the handles) must go through the consuming take
+    /// path instead, which can still adopt them.
+    pub fn clone_eligible(&self) -> bool {
+        self.backend == SequenceStateBackend::PagedKvCache
+            && !self.paged_layout.is_turbo_mode()
+            && self.retained_blocks.is_some()
+            && self
+                .paged_state
+                .layers
+                .iter()
+                .all(|layer| layer.logical_start == 0)
+            && self
+                .caches
+                .iter()
+                .all(|handle| handle.pool_backed_handle_clone(0).is_some())
+    }
+
     /// Paged layout the set was captured under.
     pub fn layout(&self) -> &PagedKvLayout {
         &self.paged_layout

--- a/src/lib/mlxcel-core/src/cache/paged_detach.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach.rs
@@ -782,6 +782,156 @@ impl CachePool {
         }
     }
 
+    /// Build an adoptable copy of `set`'s first `target_tokens` WITHOUT
+    /// consuming the source (#227).
+    ///
+    /// The one-shot `take_detached` consume meant the first adopter destroyed
+    /// the stored entry: concurrent same-prefix siblings cold-prefilled, and
+    /// combined with the #225 trim a short partial match could gut a
+    /// multi-thousand-token entry. This clone leaves the source intact: the
+    /// copy references the SAME physical pool blocks, with every cloned block
+    /// retained twice (the clone's block-table allocation plus its detach-style
+    /// pin, the exact shape `detach_paged` produces), so a subsequent
+    /// [`CachePool::adopt_paged`] of the clone transfers ownership the same
+    /// way while the source keeps its own two references per block.
+    ///
+    /// `target_tokens` must be a positive multiple of the pool block size and
+    /// at most the set's length, so no partially filled tail block is shared
+    /// and the adopter's suffix re-prefill starts on a fresh block (full
+    /// shared blocks are never mutated; a fork would copy-on-write).
+    ///
+    /// Restrictions mirror [`CachePool::trim_detached_paged_to`]: Turbo4
+    /// sidecar layouts and sliding-window states are rejected, and so are
+    /// sets whose dense handles carry tensors (a dense-compat set cannot be
+    /// shallow-cloned without aliasing buffers).
+    pub fn clone_detached_paged_prefix(
+        &mut self,
+        set: &DetachedPagedCacheSet,
+        target_tokens: usize,
+    ) -> Result<DetachedPagedCacheSet, String> {
+        if set.backend != SequenceStateBackend::PagedKvCache {
+            return Err(format!(
+                "CachePool::clone_detached_paged_prefix: expected paged backend, got {:?}",
+                set.backend
+            ));
+        }
+        if set.paged_layout.is_turbo_mode() {
+            return Err(
+                "CachePool::clone_detached_paged_prefix: Turbo4 sidecar clone is not supported"
+                    .into(),
+            );
+        }
+        let block_size = set.paged_layout.block_size;
+        if block_size == 0 || target_tokens == 0 || !target_tokens.is_multiple_of(block_size) {
+            return Err(format!(
+                "CachePool::clone_detached_paged_prefix: target {target_tokens} is not a positive multiple of block size {block_size}"
+            ));
+        }
+        let seq_len = set.seq_len();
+        if target_tokens > seq_len {
+            return Err(format!(
+                "CachePool::clone_detached_paged_prefix: target {target_tokens} exceeds set length {seq_len}"
+            ));
+        }
+        if set
+            .paged_state
+            .layers
+            .iter()
+            .any(|layer| layer.logical_start != 0)
+        {
+            return Err(
+                "CachePool::clone_detached_paged_prefix: sliding-window state (logical_start > 0) is not supported"
+                    .into(),
+            );
+        }
+        if set.retained_blocks.is_none() {
+            return Err(
+                "CachePool::clone_detached_paged_prefix: source no longer owns its block pins"
+                    .into(),
+            );
+        }
+        let pool = self
+            .paged_pool
+            .as_ref()
+            .ok_or("CachePool::clone_detached_paged_prefix: no active paged pool")?
+            .clone();
+
+        // Metadata-only handle clones, re-anchored at the cloned length so a
+        // later adopt restores RoPE offsets at the adopted prefix boundary.
+        let caches: Vec<DetachedKVCache> = set
+            .caches
+            .iter()
+            .map(|h| h.pool_backed_handle_clone(target_tokens as i32))
+            .collect::<Option<Vec<_>>>()
+            .ok_or(
+                "CachePool::clone_detached_paged_prefix: dense handles carry tensors (non-pool-backed set)",
+            )?;
+
+        let keep_blocks = target_tokens / block_size;
+        let mut paged_state = PagedSequenceState::new(&set.paged_layout);
+        for (layer_idx, layer) in set.paged_state.layers.iter().enumerate() {
+            paged_state.layers[layer_idx].block_ids = layer.block_ids[..keep_blocks].to_vec();
+            paged_state.layers[layer_idx].len = target_tokens;
+        }
+        let retained: Vec<PagedBlockId> = paged_state
+            .layers
+            .iter()
+            .flat_map(|layer| layer.block_ids.iter().copied())
+            .collect();
+
+        // Pin every cloned block twice, with rollback on the first failure so
+        // a declined clone leaves the pool untouched.
+        {
+            let mut pool = pool.borrow_mut();
+            let mut pinned: Vec<PagedBlockId> = Vec::with_capacity(retained.len() * 2);
+            for &block_id in &retained {
+                for _ in 0..2 {
+                    if let Err(err) = pool.retain_block(block_id) {
+                        for &undo in pinned.iter().rev() {
+                            let _ = pool.release_block(undo);
+                        }
+                        return Err(format!(
+                            "CachePool::clone_detached_paged_prefix: failed to pin block {block_id}: {err}"
+                        ));
+                    }
+                    pinned.push(block_id);
+                }
+            }
+        }
+
+        let real_pool_bytes: Option<usize> = {
+            let pool = pool.borrow();
+            let mut total = 0usize;
+            let mut any = false;
+            for layer_idx in 0..paged_state.layers.len() {
+                if let Some(per_block) = pool.real_block_bytes(layer_idx) {
+                    total += keep_blocks * per_block;
+                    any = true;
+                }
+            }
+            any.then_some(total)
+        };
+
+        Ok(DetachedPagedCacheSet {
+            caches,
+            paged_state,
+            paged_layout: set.paged_layout.clone(),
+            backend: set.backend,
+            prompt_len: set.prompt_len.min(target_tokens),
+            current_offset: target_tokens as i32,
+            created_at: set.created_at,
+            detached_at: Instant::now(),
+            origin_seq_id: set.origin_seq_id,
+            retained_blocks: Some(retained),
+            real_pool_bytes,
+            v_packed_pages: HashMap::new(),
+            v_norms_pages: HashMap::new(),
+            k_packed_pages: HashMap::new(),
+            k_norms_pages: HashMap::new(),
+            cold_keys_pages: HashMap::new(),
+        })
+    }
+
     /// Trim a detached paged set to `target_tokens` before adoption (#225).
     ///
     /// A partial prefix match (an APC block-clamped lookup, or a request that

--- a/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach_tests.rs
@@ -1864,3 +1864,148 @@ fn detached_paged_set_without_pool_writes_falls_back_to_nominal_bytes() {
     assert_eq!(set.nbytes(), nominal);
     pool.release_detached_paged(set);
 }
+
+// ---------------------------------------------------------------------------
+// 14. Non-consuming clone-and-pin adoption (#227): clones share the source's
+//     physical blocks and the source survives for further borrowers.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clone_detached_paged_prefix_shares_blocks_and_preserves_source() {
+    let n_kv_heads = 2i32;
+    let head_dim = 3i32;
+    let block_size = 4usize;
+    let layout = PagedKvLayout::uniform(
+        1,
+        block_size,
+        block_size * n_kv_heads as usize * head_dim as usize * 2,
+    )
+    .unwrap();
+    let model = PagedStubModel::new(layout.clone());
+    let mut pool = CachePool::new(8);
+
+    // Source: 12 tokens = 3 blocks of distinct values.
+    let seed = pool.allocate(&model).unwrap();
+    let k = prefill_block(1000.0, n_kv_heads, 12, head_dim);
+    let v = prefill_block(5000.0, n_kv_heads, 12, head_dim);
+    write_prefill_for(&mut pool, seed, 0, &k, &v).unwrap();
+    let source = pool.detach_paged(seed).unwrap();
+    let source_blocks = source.paged_state().layer(0).unwrap().block_ids.clone();
+    // Detached source holds 2 references per block.
+    assert_eq!(pool.paged_pool_ref().unwrap().refcount(source_blocks[0]), 2);
+
+    // Borrower 1 clones the first 8 tokens (2 blocks).
+    let clone_a = pool.clone_detached_paged_prefix(&source, 8).unwrap();
+    assert_eq!(clone_a.seq_len(), 8);
+    assert_eq!(
+        clone_a.paged_state().layer(0).unwrap().block_ids,
+        source_blocks[..2].to_vec(),
+        "the clone must reference the SAME physical blocks"
+    );
+    // Source 2 refs + clone 2 refs.
+    assert_eq!(pool.paged_pool_ref().unwrap().refcount(source_blocks[0]), 4);
+    // Source untouched.
+    assert_eq!(source.seq_len(), 12);
+    assert_eq!(
+        source.paged_state().layer(0).unwrap().block_ids,
+        source_blocks
+    );
+
+    // Borrower 2 clones the whole entry concurrently.
+    let clone_b = pool.clone_detached_paged_prefix(&source, 12).unwrap();
+    assert_eq!(pool.paged_pool_ref().unwrap().refcount(source_blocks[0]), 6);
+
+    // Adopt clone A: its detach-style pin is released, the table ref stays.
+    let seq_a = pool.adopt_paged(&model, clone_a).unwrap();
+    assert_eq!(pool.paged_pool_ref().unwrap().refcount(source_blocks[0]), 5);
+
+    // The adopted borrower appends a divergent suffix on FRESH blocks and
+    // gathers prefix + suffix byte-identically to the dense reference.
+    let suffix = prefill_block(2000.0, n_kv_heads, 6, head_dim);
+    let suffix_v = prefill_block(6000.0, n_kv_heads, 6, head_dim);
+    write_prefill_for(&mut pool, seq_a, 0, &suffix, &suffix_v).unwrap();
+    {
+        let state = pool.get_paged_state(seq_a).unwrap();
+        let blocks = &state.layer(0).unwrap().block_ids;
+        assert_eq!(blocks.len(), 4, "2 shared prefix + 2 fresh suffix blocks");
+        assert_eq!(&blocks[..2], &source_blocks[..2]);
+        assert!(!source_blocks.contains(&blocks[2]));
+    }
+    let (gk, gv) = {
+        let state = pool.get_paged_state(seq_a).unwrap();
+        pool.paged_pool_ref()
+            .unwrap()
+            .gather_visible(&state, 0)
+            .unwrap()
+            .expect("gather must return data")
+    };
+    let prefix8 = |base: f32| {
+        let full = prefill_block(base, n_kv_heads, 12, head_dim);
+        crate::ffi::slice(&full, &[0, 0, 0, 0], &[1, n_kv_heads, 8, head_dim])
+    };
+    let dense_k = dense_reference(
+        &[
+            (prefix8(1000.0), 0),
+            (prefill_block(2000.0, n_kv_heads, 6, head_dim), 8usize),
+        ],
+        n_kv_heads,
+        14,
+        head_dim,
+    );
+    let dense_v = dense_reference(
+        &[
+            (prefix8(5000.0), 0),
+            (prefill_block(6000.0, n_kv_heads, 6, head_dim), 8usize),
+        ],
+        n_kv_heads,
+        14,
+        head_dim,
+    );
+    assert_eq!(flatten_fp32(&gk), flatten_fp32(&dense_k));
+    assert_eq!(flatten_fp32(&gv), flatten_fp32(&dense_v));
+
+    // The source's ledger view is unchanged; releasing everything drives the
+    // shared blocks back to zero with no leaks.
+    let per_block_real = block_size * n_kv_heads as usize * head_dim as usize * 4 * 2;
+    assert_eq!(source.nbytes(), 3 * per_block_real);
+    pool.release_detached_paged(clone_b);
+    assert_eq!(pool.paged_pool_ref().unwrap().refcount(source_blocks[0]), 3);
+    pool.release(seq_a);
+    assert_eq!(pool.paged_pool_ref().unwrap().refcount(source_blocks[0]), 2);
+    pool.release_detached_paged(source);
+    assert_eq!(pool.paged_pool_ref().unwrap().refcount(source_blocks[0]), 0);
+}
+
+#[test]
+fn clone_detached_paged_prefix_rejects_bad_targets() {
+    let n_kv_heads = 2i32;
+    let head_dim = 3i32;
+    let block_size = 4usize;
+    let layout = PagedKvLayout::uniform(
+        1,
+        block_size,
+        block_size * n_kv_heads as usize * head_dim as usize * 2,
+    )
+    .unwrap();
+    let model = PagedStubModel::new(layout.clone());
+    let mut pool = CachePool::new(4);
+
+    let seed = pool.allocate(&model).unwrap();
+    let k = prefill_block(1.0, n_kv_heads, 12, head_dim);
+    let v = prefill_block(2.0, n_kv_heads, 12, head_dim);
+    write_prefill_for(&mut pool, seed, 0, &k, &v).unwrap();
+    let source = pool.detach_paged(seed).unwrap();
+    let first_block = source.paged_state().layer(0).unwrap().block_ids[0];
+
+    // Misaligned, zero, and oversized targets are declined without pinning.
+    assert!(pool.clone_detached_paged_prefix(&source, 6).is_err());
+    assert!(pool.clone_detached_paged_prefix(&source, 0).is_err());
+    assert!(pool.clone_detached_paged_prefix(&source, 16).is_err());
+    assert_eq!(
+        pool.paged_pool_ref().unwrap().refcount(first_block),
+        2,
+        "declined clones must not leak pins"
+    );
+
+    pool.release_detached_paged(source);
+}

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -1236,66 +1236,70 @@ impl BatchScheduler {
         // matches. The one-shot take below destroyed the entry on first use;
         // combined with the #225 trim, a short partial match (even the
         // chat-template preamble) could gut a multi-thousand-token entry.
-        // `with_detached` returns:
-        //   None              -> entry already drained: fall through, the
-        //                        take below also yields None (cold prefill).
-        //   Some(None)        -> dense set: legacy take path below.
-        //   Some(Some(Err))   -> paged but clone-ineligible or below the
-        //                        minimum: cold prefill, entry untouched.
-        //   Some(Some(Ok));   -> adoptable clone, source preserved.
+        enum PagedCloneOutcome {
+            /// Adoptable clone built; the source entry stays in the store.
+            Cloned(Box<DetachedPagedCacheSet>, usize),
+            /// Cold prefill, entry untouched (below minimum, pin failure,
+            /// or cross-backend).
+            Decline(String),
+            /// Dense entry, or a clone-ineligible paged shape (dense-compat
+            /// handles, Turbo4, sliding-window): the consuming take path
+            /// below can still adopt those.
+            TakePath,
+        }
         let backend_is_paged = matches!(self.decode_storage_backend, DecodeStorageBackend::Paged);
         let min_prefix = store.min_prefix_tokens().max(1);
         let cache_pool = &mut self.cache_pool;
-        let clone_attempt: Option<Option<Result<(DetachedPagedCacheSet, usize), String>>> = entry
-            .with_detached(|set| match set {
-                DetachedKvSet::Paged(paged) if backend_is_paged => {
-                    let block_size = paged.layout().block_size.max(1);
-                    let seq_len = paged.seq_len();
-                    let adoptable = if matched_len < seq_len {
-                        (matched_len / block_size) * block_size
-                    } else {
-                        seq_len
-                    };
-                    if adoptable < min_prefix {
-                        return Some(Err(format!(
-                            "block-floored match {adoptable} below the minimum prefix {min_prefix}"
-                        )));
-                    }
-                    Some(
-                        cache_pool
-                            .clone_detached_paged_prefix(paged, adoptable)
-                            .map(|clone| (clone, adoptable)),
-                    )
+        // `with_detached` itself returns `None` for a drained shell; the take
+        // below then also yields `None` (cold prefill).
+        let clone_attempt: Option<PagedCloneOutcome> = entry.with_detached(|set| match set {
+            DetachedKvSet::Paged(paged) if backend_is_paged && paged.clone_eligible() => {
+                let block_size = paged.layout().block_size.max(1);
+                // Floor BOTH the partial and the whole-entry match to the
+                // pool block boundary: a donated entry's length
+                // (prompt + generated tokens) is almost never block-aligned,
+                // and the clone shares whole blocks only. The caller
+                // re-prefills everything past the adopted length, which
+                // re-covers the dropped partial tail.
+                let adoptable = (matched_len.min(paged.seq_len()) / block_size) * block_size;
+                if adoptable < min_prefix {
+                    return PagedCloneOutcome::Decline(format!(
+                        "block-floored match {adoptable} below the minimum prefix {min_prefix}"
+                    ));
                 }
-                // Paged entry under a dense decode backend: cross-backend
-                // adoption is invalid; decline without touching the entry.
-                DetachedKvSet::Paged(_) => {
-                    Some(Err("paged entry under a dense decode backend".into()))
+                match cache_pool.clone_detached_paged_prefix(paged, adoptable) {
+                    Ok(clone) => PagedCloneOutcome::Cloned(Box::new(clone), adoptable),
+                    Err(err) => PagedCloneOutcome::Decline(err),
                 }
-                DetachedKvSet::Dense(_) => None,
-            });
-        let cloned = match clone_attempt {
-            Some(Some(Ok((clone, adoptable)))) => {
-                adopted_len = adoptable;
-                Some(clone)
             }
-            Some(Some(Err(reason))) => {
+            // Paged entry under a dense decode backend: cross-backend
+            // adoption is invalid; decline without touching the entry
+            // (the old path took the set just to release it).
+            DetachedKvSet::Paged(_) if !backend_is_paged => {
+                PagedCloneOutcome::Decline("paged entry under a dense decode backend".into())
+            }
+            // Clone-ineligible paged shapes and dense entries.
+            DetachedKvSet::Paged(_) | DetachedKvSet::Dense(_) => PagedCloneOutcome::TakePath,
+        });
+        match clone_attempt {
+            Some(PagedCloneOutcome::Cloned(clone, adoptable)) => {
+                adopted_len = adoptable;
+                let adopt_result = self
+                    .cache_pool
+                    .adopt_paged(&self.model as &dyn LanguageModel, *clone);
+                return self.finish_prompt_cache_adopt(adopt_result, adopted_len, tokens.len());
+            }
+            Some(PagedCloneOutcome::Decline(reason)) => {
                 tracing::debug!(
                     "prompt-cache adopt: paged clone declined ({reason}); falling back to cold prefill (entry preserved)"
                 );
                 return None;
             }
-            Some(None) | None => None,
-        };
-        if let Some(clone) = cloned {
-            let adopt_result = self
-                .cache_pool
-                .adopt_paged(&self.model as &dyn LanguageModel, clone);
-            return self.finish_prompt_cache_adopt(adopt_result, adopted_len, tokens.len());
+            Some(PagedCloneOutcome::TakePath) | None => {}
         }
 
-        // Dense entries keep the legacy one-shot consume: their adoption
-        // copies buffers into the sequence, so the set genuinely moves.
+        // Dense entries (and clone-ineligible paged shapes) keep the legacy
+        // one-shot consume: their adoption genuinely moves buffers.
         // `take_detached` returns `None` if a racing lookup already consumed
         // this entry; the miss path is safe (fresh prefill).
         let detached = entry.take_detached()?;

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -33,8 +33,8 @@ use std::sync::mpsc;
 use std::time::Instant;
 
 use mlxcel_core::cache::{
-    BatchKvQuantConfig, CachePool, KVCacheMode, PagedKvLayout, SequenceId, SequenceStateBackend,
-    SequenceStateLayout,
+    BatchKvQuantConfig, CachePool, DetachedPagedCacheSet, KVCacheMode, PagedKvLayout, SequenceId,
+    SequenceStateBackend, SequenceStateLayout,
 };
 use mlxcel_core::generate::{
     DecodeBatchContext, DecodeStorageBackend as CoreDecodeStorageBackend, LanguageModel,
@@ -1226,9 +1226,78 @@ impl BatchScheduler {
         if require_whole_entry && matched_len < entry.tokens.len() {
             return None;
         }
-        // `take_detached` is one-shot: it returns `None` if a racing lookup
-        // already consumed this entry. The miss path is safe — the current
-        // sequence just does a fresh prefill.
+        // Length the adopted cache actually covers. The dense path truncates
+        // to exactly `matched_len`; the paged paths floor to the pool block
+        // boundary (#225), so they report their own value.
+        let mut adopted_len = matched_len;
+
+        // #227: pool-backed paged entries adopt by CLONE, leaving the stored
+        // entry intact for concurrent same-prefix siblings and deeper future
+        // matches. The one-shot take below destroyed the entry on first use;
+        // combined with the #225 trim, a short partial match (even the
+        // chat-template preamble) could gut a multi-thousand-token entry.
+        // `with_detached` returns:
+        //   None              -> entry already drained: fall through, the
+        //                        take below also yields None (cold prefill).
+        //   Some(None)        -> dense set: legacy take path below.
+        //   Some(Some(Err))   -> paged but clone-ineligible or below the
+        //                        minimum: cold prefill, entry untouched.
+        //   Some(Some(Ok));   -> adoptable clone, source preserved.
+        let backend_is_paged = matches!(self.decode_storage_backend, DecodeStorageBackend::Paged);
+        let min_prefix = store.min_prefix_tokens().max(1);
+        let cache_pool = &mut self.cache_pool;
+        let clone_attempt: Option<Option<Result<(DetachedPagedCacheSet, usize), String>>> = entry
+            .with_detached(|set| match set {
+                DetachedKvSet::Paged(paged) if backend_is_paged => {
+                    let block_size = paged.layout().block_size.max(1);
+                    let seq_len = paged.seq_len();
+                    let adoptable = if matched_len < seq_len {
+                        (matched_len / block_size) * block_size
+                    } else {
+                        seq_len
+                    };
+                    if adoptable < min_prefix {
+                        return Some(Err(format!(
+                            "block-floored match {adoptable} below the minimum prefix {min_prefix}"
+                        )));
+                    }
+                    Some(
+                        cache_pool
+                            .clone_detached_paged_prefix(paged, adoptable)
+                            .map(|clone| (clone, adoptable)),
+                    )
+                }
+                // Paged entry under a dense decode backend: cross-backend
+                // adoption is invalid; decline without touching the entry.
+                DetachedKvSet::Paged(_) => {
+                    Some(Err("paged entry under a dense decode backend".into()))
+                }
+                DetachedKvSet::Dense(_) => None,
+            });
+        let cloned = match clone_attempt {
+            Some(Some(Ok((clone, adoptable)))) => {
+                adopted_len = adoptable;
+                Some(clone)
+            }
+            Some(Some(Err(reason))) => {
+                tracing::debug!(
+                    "prompt-cache adopt: paged clone declined ({reason}); falling back to cold prefill (entry preserved)"
+                );
+                return None;
+            }
+            Some(None) | None => None,
+        };
+        if let Some(clone) = cloned {
+            let adopt_result = self
+                .cache_pool
+                .adopt_paged(&self.model as &dyn LanguageModel, clone);
+            return self.finish_prompt_cache_adopt(adopt_result, adopted_len, tokens.len());
+        }
+
+        // Dense entries keep the legacy one-shot consume: their adoption
+        // copies buffers into the sequence, so the set genuinely moves.
+        // `take_detached` returns `None` if a racing lookup already consumed
+        // this entry; the miss path is safe (fresh prefill).
         let detached = entry.take_detached()?;
         if detached.is_empty() {
             // A paged set drained on this path would leak its block pins via
@@ -1251,10 +1320,6 @@ impl BatchScheduler {
             return None;
         }
 
-        // Length the adopted cache actually covers. The dense path truncates
-        // to exactly `matched_len`; the paged path floors to the pool block
-        // boundary (#225), so it reports its own value.
-        let mut adopted_len = matched_len;
         let adopt_result = match detached {
             DetachedKvSet::Dense(mut dense) => {
                 // APC block-level partial adoption. When APC clamps
@@ -1332,14 +1397,24 @@ impl BatchScheduler {
             }
         };
 
+        self.finish_prompt_cache_adopt(adopt_result, adopted_len, tokens.len())
+    }
+
+    /// Shared tail of [`Self::try_adopt_cached_prefix`]: record hit metrics
+    /// and gauges on success, log and fall back to a cold prefill on failure.
+    fn finish_prompt_cache_adopt(
+        &mut self,
+        adopt_result: Result<SequenceId, String>,
+        adopted_len: usize,
+        total_tokens: usize,
+    ) -> Option<(SequenceId, usize)> {
         match adopt_result {
             Ok(adopted_id) => {
                 tracing::debug!(
                     seq_id = %adopted_id,
                     matched = adopted_len,
-                    total = tokens.len(),
-                    "prompt-cache hit: adopted {adopted_len}/{} tokens",
-                    tokens.len()
+                    total = total_tokens,
+                    "prompt-cache hit: adopted {adopted_len}/{total_tokens} tokens"
                 );
                 self.batch_observability
                     .record_prompt_cache_hit(adopted_len);

--- a/src/server/prompt_cache/entry.rs
+++ b/src/server/prompt_cache/entry.rs
@@ -123,6 +123,10 @@ impl DetachedKvSetHolder {
     pub(crate) fn take(&mut self) -> Option<DetachedKvSet> {
         self.inner.take()
     }
+
+    pub(crate) fn peek(&self) -> Option<&DetachedKvSet> {
+        self.inner.as_ref()
+    }
 }
 
 // SAFETY: See the type-level doc-comment above. The detach/adopt API
@@ -219,6 +223,21 @@ impl CacheEntry {
             Ok(mut g) => g.take(),
             Err(poisoned) => poisoned.into_inner().take(),
         }
+    }
+
+    /// Run `f` against the parked set WITHOUT consuming it (#227).
+    ///
+    /// Returns `None` when the set was already taken (a drained shell).
+    /// Used by the non-consuming clone-and-pin adoption path: the closure
+    /// clones pinned block references out of a paged set while the entry
+    /// stays live in the store for concurrent siblings and deeper future
+    /// matches. The entry lock is held for the duration of `f`.
+    pub fn with_detached<R>(&self, f: impl FnOnce(&DetachedKvSet) -> R) -> Option<R> {
+        let guard = match self.detached.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.peek().map(f)
     }
 
     /// Update the `last_used` timestamp. Called on every successful lookup

--- a/tests/paged_prefix_share_parity.rs
+++ b/tests/paged_prefix_share_parity.rs
@@ -614,3 +614,82 @@ fn paged_clone_and_pin_share_matches_cold_runs_llama3() {
     };
     assert_clone_and_pin_share_parity(&model, LLAMA3_DIR);
 }
+
+/// Whole-entry match with an UNALIGNED stored length (the multi-turn
+/// continuation case: donated entries carry prompt + generated tokens, which
+/// is almost never a multiple of the pool block size). The scheduler floors
+/// the adoptable length to the block boundary even for whole-entry matches;
+/// the re-prefill covers the dropped partial tail plus the new turn.
+#[test]
+#[ignore = "loads llama-3.2-1b-4bit and runs real GPU forwards; run with --ignored"]
+fn paged_clone_whole_entry_unaligned_floors_and_matches_cold_llama3() {
+    let _runtime = initialize_runtime();
+    let Some(model) = load_or_skip(LLAMA3_DIR, "mlx-community/Llama-3.2-1B-Instruct-4bit") else {
+        return;
+    };
+    let num_layers = model.num_layers();
+
+    // Stored entry: 52 tokens (NOT a multiple of BLOCK_SIZE = 32).
+    let mut stored_tokens = PREFIX_TOKENS.to_vec();
+    stored_tokens.extend_from_slice(STORED_TAIL_TOKENS);
+    assert_ne!(stored_tokens.len() % BLOCK_SIZE, 0);
+    // Continuation request: the stored stream plus a new turn, so the match
+    // covers the WHOLE entry (matched_len == seq_len == 52, unaligned).
+    let mut request = stored_tokens.clone();
+    request.extend_from_slice(SUFFIX_TOKENS);
+
+    let cold = {
+        let mut pool = CachePool::new(2);
+        let id = pool
+            .allocate_with_layout(&model, Some(scheduler_paged_layout(num_layers)))
+            .expect("cold paged allocate");
+        let caches = pool.get_caches_mut(id).unwrap();
+        prefill_and_decode(&model, caches, &request, 0)
+    };
+
+    let mut pool = CachePool::new(4);
+    let seq_a = pool
+        .allocate_with_layout(&model, Some(scheduler_paged_layout(num_layers)))
+        .expect("A paged allocate");
+    {
+        let caches = pool.get_caches_mut(seq_a).unwrap();
+        let len = stored_tokens.len() as i32;
+        let prompt = mlxcel_core::from_slice_i32(&stored_tokens, &[1, len]);
+        let mask = mlxcel_core::utils::create_causal_mask(len, 0);
+        let logits = model.forward(&prompt, caches, Some(&mask));
+        mlxcel_core::eval(&logits);
+    }
+    let set_a = pool.detach_paged(seq_a).expect("A detach_paged");
+    let entry = CacheEntry::new(stored_tokens.clone(), DetachedKvSet::Paged(set_a));
+
+    // Scheduler mirror: matched_len == seq_len (whole entry), floored.
+    let matched_len = stored_tokens.len();
+    let adoptable = (matched_len.min(stored_tokens.len()) / BLOCK_SIZE) * BLOCK_SIZE;
+    assert_eq!(adoptable, 32, "52 floors to one 32-token pool block");
+    let clone = entry
+        .with_detached(|set| match set {
+            DetachedKvSet::Paged(p) => {
+                assert!(p.clone_eligible());
+                pool.clone_detached_paged_prefix(p, adoptable)
+            }
+            DetachedKvSet::Dense(_) => panic!("expected a paged set"),
+        })
+        .expect("entry live")
+        .expect("clone must succeed for the floored whole-entry match");
+    let seq_b = pool.adopt_paged(&model, clone).expect("adopt clone");
+    let got = {
+        let caches = pool.get_caches_mut(seq_b).unwrap();
+        prefill_and_decode(&model, caches, &request[adoptable..], adoptable as i32)
+    };
+    assert_eq!(
+        got, cold,
+        "unaligned whole-entry continuation must decode identically to cold"
+    );
+
+    // Entry survived the whole-entry borrow.
+    assert!(
+        entry
+            .with_detached(|set| matches!(set, DetachedKvSet::Paged(_)))
+            .unwrap_or(false)
+    );
+}

--- a/tests/paged_prefix_share_parity.rs
+++ b/tests/paged_prefix_share_parity.rs
@@ -492,3 +492,125 @@ fn paged_partial_prefix_share_matches_cold_run_llama3() {
     };
     assert_partial_prefix_share_parity(&model, LLAMA3_DIR, "llama3");
 }
+
+// ---------------------------------------------------------------------------
+// Non-consuming clone-and-pin adoption (#227): one stored entry serves
+// multiple borrowers and survives them all.
+// ---------------------------------------------------------------------------
+
+fn assert_clone_and_pin_share_parity(model: &mlxcel::LoadedModel, label: &str) {
+    let num_layers = model.num_layers();
+    let prefix_len = PREFIX_TOKENS.len() as i32;
+
+    // Two divergent continuations of the same shared prefix.
+    let mut prompt_b = PREFIX_TOKENS.to_vec();
+    prompt_b.extend_from_slice(SUFFIX_TOKENS);
+    let mut prompt_c = PREFIX_TOKENS.to_vec();
+    prompt_c.extend_from_slice(PARTIAL_SUFFIX_TOKENS);
+
+    eprintln!("\n=== paged clone-and-pin share parity: {label} ({num_layers} layers) ===");
+
+    // Cold references.
+    let cold = |prompt: &[i32]| {
+        let mut pool = CachePool::new(2);
+        let id = pool
+            .allocate_with_layout(model, Some(scheduler_paged_layout(num_layers)))
+            .expect("cold paged allocate");
+        let caches = pool.get_caches_mut(id).unwrap();
+        prefill_and_decode(model, caches, prompt, 0)
+    };
+    let cold_b = cold(&prompt_b);
+    let cold_c = cold(&prompt_c);
+
+    // A prefills the shared prefix and donates it.
+    let mut pool = CachePool::new(8);
+    let seq_a = pool
+        .allocate_with_layout(model, Some(scheduler_paged_layout(num_layers)))
+        .expect("A paged allocate");
+    {
+        let caches = pool.get_caches_mut(seq_a).unwrap();
+        let prompt = mlxcel_core::from_slice_i32(PREFIX_TOKENS, &[1, prefix_len]);
+        let mask = mlxcel_core::utils::create_causal_mask(prefix_len, 0);
+        let logits = model.forward(&prompt, caches, Some(&mask));
+        mlxcel_core::eval(&logits);
+    }
+    let a_blocks = pool
+        .get_paged_state(seq_a)
+        .unwrap()
+        .layer(0)
+        .unwrap()
+        .block_ids
+        .clone();
+    let set_a = pool.detach_paged(seq_a).expect("A detach_paged");
+    let entry = CacheEntry::new(PREFIX_TOKENS.to_vec(), DetachedKvSet::Paged(set_a));
+
+    // The scheduler's #227 path: clone the matched prefix (floored to the
+    // pool block boundary) WITHOUT consuming the entry, adopt the clone.
+    let adoptable = (PREFIX_TOKENS.len() / BLOCK_SIZE) * BLOCK_SIZE; // 40 -> 32
+    let mut borrow = |prompt: &[i32]| -> Vec<i32> {
+        let clone = entry
+            .with_detached(|set| match set {
+                DetachedKvSet::Paged(p) => pool.clone_detached_paged_prefix(p, adoptable),
+                DetachedKvSet::Dense(_) => panic!("expected a paged set"),
+            })
+            .expect("entry must not be drained")
+            .expect("clone must succeed");
+        let seq = pool.adopt_paged(model, clone).expect("adopt clone");
+        let caches = pool.get_caches_mut(seq).unwrap();
+        let decoded = prefill_and_decode(model, caches, &prompt[adoptable..], adoptable as i32);
+        pool.release(seq);
+        decoded
+    };
+
+    let got_b = borrow(&prompt_b);
+    assert_eq!(
+        got_b, cold_b,
+        "borrower B (clone-adopted) must equal its cold run"
+    );
+    let got_c = borrow(&prompt_c);
+    assert_eq!(
+        got_c, cold_c,
+        "borrower C (clone-adopted, after B) must equal its cold run"
+    );
+
+    // The entry SURVIVED both borrowers: its set is still present and still
+    // pins the original prefix blocks.
+    let still_there = entry
+        .with_detached(|set| match set {
+            DetachedKvSet::Paged(p) => p.seq_len(),
+            DetachedKvSet::Dense(_) => 0,
+        })
+        .expect("entry must still hold its set after clone-based borrows");
+    assert_eq!(still_there, PREFIX_TOKENS.len());
+    assert!(
+        pool.paged_pool_ref().unwrap().refcount(a_blocks[0]) >= 2,
+        "the stored entry must still pin the shared prefix blocks"
+    );
+
+    // Cleanup: take and release the source set; everything returns to zero.
+    if let Some(DetachedKvSet::Paged(p)) = entry.take_detached() {
+        pool.release_detached_paged(p);
+    }
+    assert_eq!(pool.paged_pool_ref().unwrap().refcount(a_blocks[0]), 0);
+    eprintln!("OK: one stored entry served two borrowers byte-identically and survived.");
+}
+
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit and runs real GPU forwards; run with --ignored"]
+fn paged_clone_and_pin_share_matches_cold_runs_qwen3() {
+    let _runtime = initialize_runtime();
+    let Some(model) = load_or_skip(QWEN3_DIR, "mlx-community/Qwen3-0.6B-4bit") else {
+        return;
+    };
+    assert_clone_and_pin_share_parity(&model, QWEN3_DIR);
+}
+
+#[test]
+#[ignore = "loads llama-3.2-1b-4bit and runs real GPU forwards; run with --ignored"]
+fn paged_clone_and_pin_share_matches_cold_runs_llama3() {
+    let _runtime = initialize_runtime();
+    let Some(model) = load_or_skip(LLAMA3_DIR, "mlx-community/Llama-3.2-1B-Instruct-4bit") else {
+        return;
+    };
+    assert_clone_and_pin_share_parity(&model, LLAMA3_DIR);
+}


### PR DESCRIPTION
## Summary

Implements #227. `take_detached` is one-shot, so the first adopter consumed the stored entry: concurrent same-prefix siblings cold-prefilled (one adoption out of eight on the burst workload), and combined with #225's trim a short partial match (even the ~30-token chat-template preamble) could gut a multi-thousand-token entry down to one block (the hazard documented on this issue from the #226 measurement).

- Paged entries now adopt by CLONE. The scheduler's new path runs under the non-consuming `CacheEntry::with_detached` and calls `CachePool::clone_detached_paged_prefix`: an adoptable copy referencing the SAME physical blocks, pinned twice per block exactly as `detach_paged` would produce (with rollback on pin failure), metadata-only handle clones re-anchored at the adopted length, and real-bytes accounting carried over. The stored entry stays live for concurrent siblings and deeper future matches.
- Dense entries keep the legacy one-shot consume (their adoption genuinely moves buffers). Clone-ineligible paged sets (Turbo4 sidecars, tensor-carrying dense-compat handles, sliding-window states) decline to a cold prefill with the entry untouched. A paged entry under a dense decode backend declines without consuming, where the old path took the set and then released it.
- The #225 take-plus-trim arm remains as the defensive fallback behind the clone path.

## Measured effect (llama-3.2-1b, --apc-enabled, M1 Ultra)

| metric | before | after |
|---|---|---|
| burst (8 concurrent siblings) adoptions | 1 of 8 (3648 cached tokens) | 8 of 8 (29184) |
| burst-phase footprint peak | 2815 MiB (pre-#224) / 2081 (post) | 1630 MiB (v0.1.4 dense baseline: 1653) |
| burst phase wall | 11.8 s | 3.5 s |
| cannibalization repro: A's re-match depth after a divergent B | 32 tokens (entry gutted) | 3808 tokens (entry intact) |

## Validation

- Unit: clone shares the source's physical blocks with exact refcount choreography (2 source + 2 per clone; adopt releases the clone pin; full release returns to zero), divergent suffixes land on fresh blocks byte-identically against the dense reference, declined targets leak no pins.
- Real-model gates (qwen3 + llama3): new `paged_clone_and_pin_share` tests prove one stored entry serves two divergent borrowers byte-identically to cold runs and survives both; all existing prefix-share, partial-share, and scheduler parity gates stay green (6/6 byte-identical).
- Suites: core 873 lib tests (single failure is the pre-existing release-mode `pack3` should_panic on main), server 3150, cold clippy clean, fmt clean.

Closes #227