### PR TITLE
feat: enable Automatic Prefix Caching by default

### DIFF
--- a/docs/CONTINUOUS_BATCHING.md
+++ b/docs/CONTINUOUS_BATCHING.md
@@ -24,11 +24,15 @@ token, then streams the new tokens out. Relevant flags:
 
 ### Paged decode and the prompt-prefix cache
 
-With `--decode-storage-backend paged`, decode state and the cross-request
-prompt-prefix cache share one refcounted, copy-on-write block pool. Concurrent
-requests that share a prompt prefix store that prefix's KV once and skip
-re-prefilling it. The mechanism, the memory and prefill-token savings, the
-measured decode throughput, and `--kv-cache-budget` are documented in
+Decode state and the cross-request prompt-prefix cache share one refcounted,
+copy-on-write block pool (the default for batch-capable pool-backed families;
+`--decode-storage-backend dense` opts out). Concurrent requests that share a
+prompt prefix store that prefix's KV once and skip re-prefilling it: adoption
+is non-consuming (clone-and-pin), so one stored prefix serves any number of
+simultaneous borrowers, and Automatic Prefix Caching (on by default, disable
+with `--apc-enabled=false`) lets requests that diverge after a shared prefix
+reuse the common part. The mechanism, the measured memory and prefill-token
+savings, the decode throughput, and `--kv-cache-budget` are documented in
 [turbo-kv-cache.md](turbo-kv-cache.md#unified-paged-kv-cache). Paged decode is
 byte-identical to the dense backend; it is the storage backend the disaggregated
 roles below build on.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -87,10 +87,19 @@ These variables are applied when the corresponding CLI flag is absent.
 | `MLXCEL_PROMPT_CACHE_MAX_ENTRIES` | unsigned integer | `1024` | `--prompt-cache-max-entries` |
 | `MLXCEL_PROMPT_CACHE_TTL` | unsigned integer seconds | `3600` | `--prompt-cache-ttl` |
 | `MLXCEL_PROMPT_CACHE_MIN_PREFIX` | unsigned integer tokens | `32` | `--prompt-cache-min-prefix` |
+| `APC_ENABLED` | boolean | `true` | `--apc-enabled` |
+| `APC_BLOCK_SIZE` | unsigned integer tokens | `16` | `--apc-block-size` |
+| `APC_NUM_BLOCKS` | unsigned integer | derived from max entries | `--apc-num-blocks` |
+| `APC_HASH` | `sha256` or `blake3` | `sha256` | `--apc-hash` |
 
 `MLXCEL_PROMPT_CACHE_ENABLED` has higher precedence than the llama.cpp
 compatibility alias `LLAMA_ARG_CACHE_REUSE` when both are set and no CLI flag is
 provided.
+
+Automatic Prefix Caching is on by default; pass `--apc-enabled=false` or set
+`APC_ENABLED=false` to fall back to whole-prefix matching only (a stored prefix
+is then reusable only when it is fully contained in the new request). The
+`APC_*` names mirror the upstream `mlx-vlm` env surface.
 
 ## Speculative-decoding variables
 

--- a/docs/turbo-kv-cache.md
+++ b/docs/turbo-kv-cache.md
@@ -125,13 +125,26 @@ paged layout when `--decode-storage-backend paged` is selected.
 
 ### Unified paged KV cache
 
-Under `--decode-storage-backend paged`, the continuous-batching server keeps
-both the cross-request prompt-prefix cache and per-sequence decode state in one
-refcounted, copy-on-write block pool (epic #116). Two requests that share a
-prompt prefix store that prefix's KV blocks once: the second request adopts the
-first request's blocks by reference rather than re-prefilling them, and a block
-forks (copy-on-write) only when one sequence's content diverges from a shared
-block. Paged adopt and donate are supported for the pool-backed Fp16 families
+The continuous-batching server keeps both the cross-request prompt-prefix cache
+and per-sequence decode state in one refcounted, copy-on-write block pool
+(epic #116). The paged backend is the default for batch-capable pool-backed
+families (`--decode-storage-backend auto` resolves to paged when batching);
+`dense` forces the legacy per-sequence caches.
+
+Two requests that share a prompt prefix store that prefix's KV blocks once.
+Adoption is non-consuming clone-and-pin: a borrower clones pinned references to
+the matched prefix blocks, so the stored entry survives for concurrent siblings
+and for deeper future matches, and any number of in-flight requests can share
+one stored prefix simultaneously. Partial matches adopt too: with Automatic
+Prefix Caching (APC, on by default) the match is verified per 16-token hash
+block, floored to the 32-token pool block boundary, and the borrower
+re-prefills only its divergent suffix on fresh blocks (full shared blocks are
+never mutated; a shared partial tail forks copy-on-write). Cache entries are
+accounted at their REAL pool bytes, so `--prompt-cache-capacity-bytes`
+(default 2 GiB) genuinely bounds retention and the LRU eviction actually
+triggers.
+
+Paged adopt and donate are supported for the pool-backed Fp16 families
 (the dense-natural backends such as qwen3 and llama3); model-owned-state families
 (gemma3, llama4, qwen3.5) and recurrent or hybrid SSM models keep dense or
 model-owned caches and stay out of the pool.
@@ -158,6 +171,27 @@ prefix prefills it; the other `N - 1` adopt the cached blocks and skip
 `(N - 1) * P` prefill-token forward passes. `tests/paged_prefix_share_parity.rs`
 confirms an adopting request decodes byte-identically to a cold run while
 skipping the shared prefill.
+
+**End-to-end server footprint.** Whole-process physical footprint
+(`/usr/bin/footprint`) of `mlxcel serve` under fixed HTTP workloads
+(`scripts/bench_memory_footprint.py`, `models/llama-3.2-1b-4bit`, M1 Ultra,
+defaults, peak during the scenario phase):
+
+| scenario | v0.1.4 | current default | shared tokens |
+|---|---|---|---|
+| idle (weights only) | 957 MiB | 983 MiB | - |
+| 8 concurrent requests, shared ~3.7k-token system prompt | 1653 MiB | 1627 MiB | 29184 (all 8 adopt) |
+| same prefix, 8 sequential requests | 1650 MiB | 1413 MiB | 25536 |
+| one conversation, 8 turns | 2104 MiB | 1301 MiB | 10976 |
+| 32 distinct prompts (churn) | 1558 MiB | 2276 MiB | 1984 |
+
+v0.1.4 never engaged the prompt cache from the HTTP path (zero reuse), so its
+footprint is the no-cache floor. The current default matches or beats it on
+every sharing scenario while also skipping the shared prefill work (the
+8-way burst completes its request phase 3.4x faster). The churn number is
+higher because donated entries are now retained for future reuse; that
+retention is real memory governed by `--prompt-cache-capacity-bytes` and is
+released by LRU eviction at the cap.
 
 **Decode throughput.** Paged decode is byte-identical to the dense backend
 (`tests/paged_scheduler_parity.rs`, RMS 0). The live batched path uses the native

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -991,7 +991,7 @@ struct ServerArgs {
 
     // Automatic Prefix Caching (APC) knobs.
     /// Enable Automatic Prefix Caching (APC) with block-granularity hash chains
-    /// (default: false).
+    /// (default: true). Disable with `--apc-enabled=false`.
     ///
     /// APC layers on top of the existing prompt-prefix cache to enable
     /// finer-grained KV reuse with chained `(parent_hash, tokens, extra_hash)`
@@ -1003,7 +1003,7 @@ struct ServerArgs {
     /// Also reads `APC_ENABLED` (parity with upstream `mlx-vlm`).
     #[arg(
         long = "apc-enabled",
-        default_value_t = false,
+        default_value_t = true,
         value_name = "BOOL",
         num_args = 0..=1,
         require_equals = true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1487,18 +1487,23 @@ pub(crate) struct ServeArgs {
 
     // Automatic Prefix Caching (APC) knobs.
     /// Enable Automatic Prefix Caching (APC) with block-granularity hash chains
-    /// (default: false).
+    /// (default: true). Disable with `--apc-enabled=false`.
     ///
     /// APC layers on top of the existing prompt-prefix cache to enable
-    /// finer-grained KV reuse. When enabled on a hybrid SSM/attention model
-    /// (jamba, mamba, mamba2, nemotron_h, gated_delta, kimi_linear,
-    /// qwen3_next), APC is automatically disabled at runtime since SSM
-    /// state cannot be decomposed into hashable blocks.
+    /// finer-grained KV reuse: without it, a stored prefix is reusable only
+    /// when it is fully contained in the new request, so requests that share
+    /// a long system prompt but diverge afterwards never reuse KV. With the
+    /// non-consuming paged adoption a partial match shares the prefix blocks
+    /// without copying or destroying the stored entry, so APC is on by
+    /// default. When enabled on a hybrid SSM/attention model (jamba, mamba,
+    /// mamba2, nemotron_h, gated_delta, kimi_linear, qwen3_next), APC is
+    /// automatically disabled at runtime since SSM state cannot be
+    /// decomposed into hashable blocks.
     ///
     /// Also reads `APC_ENABLED` (parity with upstream `mlx-vlm`).
     #[arg(
         long = "apc-enabled",
-        default_value_t = false,
+        default_value_t = true,
         value_name = "BOOL",
         num_args = 0..=1,
         require_equals = true,

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -291,9 +291,10 @@ pub struct ServerStartupInput {
     // prompt-prefix cache so finer-grained reuse becomes possible. The
     // raw fields here are normalised into [`super::prompt_cache::ApcConfig`]
     // by [`build_prompt_cache_config`].
-    /// `--apc-enabled`: master switch for APC. Defaults to `false` so
-    /// behaviour matches the earlier server. Also accepts
-    /// `APC_ENABLED` (parity with upstream `mlx-vlm`).
+    /// `--apc-enabled`: master switch for APC. The serve binaries default
+    /// it to `true` (disable with `--apc-enabled=false`); this raw field just
+    /// carries whatever clap resolved. Also accepts `APC_ENABLED` (parity
+    /// with upstream `mlx-vlm`).
     pub apc_enabled: bool,
 
     /// `--apc-block-size`: tokens per APC block. `None` means "use the
@@ -1192,9 +1193,10 @@ pub fn env_fallback_prompt_cache_min_prefix(value: &mut Option<usize>) {
 /// Apply `APC_ENABLED` env var fallback to the raw `--apc-enabled` value.
 ///
 /// `cli_was_set` must be `true` when clap explicitly received the flag (i.e.
-/// the operator typed `--apc-enabled=true|false`); a default `false` from
-/// clap should be reported as `cli_was_set = false` so a `true` env value
-/// can still take effect.
+/// the operator typed `--apc-enabled` or `--apc-enabled=...`); a value that
+/// merely came from the compiled-in default must be reported as
+/// `cli_was_set = false` so the env var can still override it in either
+/// direction (the detection scans argv, not the default).
 pub fn env_fallback_apc_enabled(enabled: &mut bool, cli_was_set: bool) {
     const KEY: &str = "APC_ENABLED";
     if cli_was_set {

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -125,7 +125,8 @@ fn sample_input() -> ServerStartupInput {
         prompt_cache_max_entries: None,
         prompt_cache_ttl_seconds: None,
         prompt_cache_min_prefix: None,
-        // APC knobs — disabled by default.
+        // APC knobs — the fixture keeps APC off so existing whole-prefix
+        // expectations stay exact (the serve binaries default it ON).
         apc_enabled: false,
         apc_block_size: None,
         apc_num_blocks: None,

--- a/src/server/routes/cache_tests.rs
+++ b/src/server/routes/cache_tests.rs
@@ -359,7 +359,10 @@ fn build_stats_response_reflects_live_store() {
         PagedBlockStats::default(),
     );
     assert!(resp.enabled);
-    assert!(!resp.apc_enabled, "APC opt-in defaults to off");
+    assert!(
+        !resp.apc_enabled,
+        "the library-level ApcConfig default is off (the serve binaries default it on)"
+    );
     assert_eq!(resp.entries, 1);
     assert_eq!(resp.bytes, 1024);
     assert_eq!(resp.inserts, 1);


### PR DESCRIPTION
## Summary

Implements #228, the capstone of the memory-footprint issue set (#224, #225, #226, #227).

With non-consuming clone-and-pin adoption (#227) a partial match shares prefix blocks without copying or destroying the stored entry, and the real-bytes ledger (#226) makes `--prompt-cache-capacity-bytes` genuinely bound retention, so the reasons to keep APC opt-in are gone. Without APC, a stored prefix is reusable only when fully contained in the new request, which left the default server config unable to reuse KV across requests that share a system prompt but diverge afterwards (the central finding of the cross-version footprint measurement that produced this issue set).

- Both serve binaries (`mlxcel serve`, `mlx-server`) flip `--apc-enabled` to default true. Disable with `--apc-enabled=false`; the `APC_ENABLED` env fallback still applies when the flag is absent (the fallback keys on whether clap actually received the flag, not on the default value). Hybrid SSM models keep the automatic runtime disable.
- Docs: `turbo-kv-cache.md` now describes the default paged backend, clone-and-pin adoption, APC partial matching, real-bytes retention accounting, and a measured end-to-end footprint table; `CONTINUOUS_BATCHING.md` aligned.

## Measured (new defaults, no flags, llama-3.2-1b, M1 Ultra, phys-footprint peak during the scenario phase)

| scenario | v0.1.4 | new default | cached tokens |
|---|---|---|---|
| idle | 957 MiB | 983 MiB | - |
| 8 concurrent, shared ~3.7k-token prompt | 1653 MiB | 1627 MiB | 29184 (8/8 adopt), phase 3.4x faster |
| same prefix, 8 sequential | 1650 MiB | 1413 MiB | 25536 |
| multiturn, 8 turns | 2104 MiB | 1301 MiB | 10976 |
| churn, 32 distinct prompts | 1558 MiB | 2276 MiB | 1984 |

v0.1.4 never engaged the prompt cache from the HTTP path, so it is the no-cache floor; the new default matches or beats it on every sharing scenario while also skipping the shared prefill work. The churn growth is donated-entry retention, now real-bytes-accounted and bounded by the capacity cap (validated in #231: eviction triggers).

## Validation

- `cli_help_consistency` 10/10 (both binaries agree on the new default).
- Prefix-share parity suite 7/7 real-model byte-identical (whole, partial, clone-and-pin, unaligned whole-entry).
- Server lib 3150, cold clippy clean, fmt clean.
- Acceptance criteria: default `mlxcel serve` shows cached>0 on burst, seqshare, and multiturn (29184 / 25536 / 10976); shared-prefix scenario footprint at or below the v0.1.4 baseline; scenario walls all at or below v0.1.4 (burst 15.7 s vs 23.0, seqshare 14.0 vs 19.0, multiturn 13.0 vs 14.8); docs carry the measured table.

Closes #228