### PR TITLE
fix: enforce pack3 size contracts in release builds

### DIFF
--- a/src/lib/mlxcel-core/src/cache/turbo/pack3.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/pack3.rs
@@ -85,7 +85,7 @@ pub const V_BIT_WIDTH_3: u8 = 3;
 /// already validated `head_dim` against the supported grid before calling.
 #[inline]
 pub fn packed_bytes_per_token_3bit(head_dim: i32) -> i32 {
-    debug_assert!(
+    assert!(
         head_dim > 0 && (head_dim as usize).is_multiple_of(COORDS_PER_GROUP),
         "packed_bytes_per_token_3bit: head_dim must be a positive multiple of 8; \
          got {head_dim}"
@@ -107,14 +107,14 @@ pub fn packed_bytes_per_token_3bit(head_dim: i32) -> i32 {
 /// Used by: [`pack_3bit_per_token`] (per-row packing in the V-side quant
 /// pipeline).
 pub fn pack_3bit_indices(indices: &[u8], out: &mut [u8]) {
-    debug_assert!(
+    assert!(
         indices.len().is_multiple_of(COORDS_PER_GROUP),
         "pack_3bit_indices: index count ({}) must be a multiple of {}",
         indices.len(),
         COORDS_PER_GROUP
     );
     let n_groups = indices.len() / COORDS_PER_GROUP;
-    debug_assert_eq!(
+    assert_eq!(
         out.len(),
         n_groups * BYTES_PER_GROUP,
         "pack_3bit_indices: output buffer must be {} bytes, got {}",
@@ -145,14 +145,14 @@ pub fn pack_3bit_indices(indices: &[u8], out: &mut [u8]) {
 /// Used by: [`unpack_3bit_per_token`] (per-row unpacking on the V-side
 /// dequant path).
 pub fn unpack_3bit_indices(packed: &[u8], out: &mut [u8]) {
-    debug_assert!(
+    assert!(
         packed.len().is_multiple_of(BYTES_PER_GROUP),
         "unpack_3bit_indices: packed byte count ({}) must be a multiple of {}",
         packed.len(),
         BYTES_PER_GROUP
     );
     let n_groups = packed.len() / BYTES_PER_GROUP;
-    debug_assert_eq!(
+    assert_eq!(
         out.len(),
         n_groups * COORDS_PER_GROUP,
         "unpack_3bit_indices: output buffer must be {} bytes, got {}",
@@ -182,7 +182,7 @@ pub fn unpack_3bit_indices(packed: &[u8], out: &mut [u8]) {
 pub fn pack_3bit_per_token(indices: &[u8], head_dim: i32, total_tokens: usize) -> Vec<u8> {
     let bytes_per_token = packed_bytes_per_token_3bit(head_dim) as usize;
     let coords_per_token = head_dim as usize;
-    debug_assert_eq!(
+    assert_eq!(
         indices.len(),
         total_tokens * coords_per_token,
         "pack_3bit_per_token: index count mismatch"
@@ -209,7 +209,7 @@ pub fn pack_3bit_per_token(indices: &[u8], head_dim: i32, total_tokens: usize) -
 pub fn unpack_3bit_per_token(packed: &[u8], head_dim: i32, total_tokens: usize) -> Vec<u8> {
     let bytes_per_token = packed_bytes_per_token_3bit(head_dim) as usize;
     let coords_per_token = head_dim as usize;
-    debug_assert_eq!(
+    assert_eq!(
         packed.len(),
         total_tokens * bytes_per_token,
         "unpack_3bit_per_token: packed byte count mismatch"
@@ -249,7 +249,9 @@ mod tests {
     #[test]
     #[should_panic(expected = "must be a positive multiple of 8")]
     fn packed_bytes_rejects_non_multiple_of_8() {
-        // 7 is not a multiple of 8 → should panic in debug.
+        // 7 is not a multiple of 8 → must panic in every build profile: the
+        // contract sizes downstream packed buffers, and a release build that
+        // silently truncated (7 * 3 / 8 = 2) would mis-size them (#234).
         let _ = packed_bytes_per_token_3bit(7);
     }
 

--- a/src/lib/mlxcel-core/src/cache/turbo/pack3.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/pack3.rs
@@ -79,10 +79,11 @@ pub const V_BIT_WIDTH_3: u8 = 3;
 /// Compute the number of packed bytes needed to store `head_dim` 3-bit
 /// indices for one token.
 ///
-/// Panics in debug if `head_dim` is not a multiple of [`COORDS_PER_GROUP`]
-/// (8). The release-mode behaviour is to silently truncate to the nearest
-/// 8-coord boundary, which is wrong but safe — callers are expected to have
-/// already validated `head_dim` against the supported grid before calling.
+/// Panics in every build profile if `head_dim` is not a positive multiple of
+/// [`COORDS_PER_GROUP`] (8): the result sizes downstream packed buffers, so a
+/// silently truncated count must never escape (#234). Callers are expected to
+/// have validated `head_dim` against the supported grid before calling;
+/// `TurboQuantParams3::new` already enforces it at init.
 #[inline]
 pub fn packed_bytes_per_token_3bit(head_dim: i32) -> i32 {
     assert!(


### PR DESCRIPTION
## Summary

Implements #234. `packed_bytes_per_token_3bit` validated its positive-multiple-of-8 head_dim contract with `debug_assert!`, so release builds compiled the check out and returned a silently truncated byte count (`7 * 3 / 8 = 2`) that would mis-size every downstream packed buffer in the Turbo3 V-side quant pipeline. The sibling pack/unpack length contracts had the same shape: slice bounds checks still caught under-sized buffers, but a non-multiple input length silently dropped the tail group instead of failing.

All seven pack3 size-contract `debug_assert`s are promoted to always-on asserts (the masking of out-of-range index values stays as documented defensive behavior, unchanged). They are per-call or per-token integer comparisons next to the packing loops, so the cost is negligible against the packing work itself, and the contracts size buffers, so violations must fail loudly in every profile.

This also fixes the standing release-mode suite failure: `packed_bytes_rejects_non_multiple_of_8` is a `should_panic` test whose panic only existed in debug builds, so every `--release` run of the core suite (the profile used for Metal-gated local runs) failed on it.

## Validation

- `cargo test -p mlxcel-core --release --lib` passes 872/872 including the should_panic test; this was the suite's only failure.
- Turbo3 quant round-trip tests unchanged and green (no behavior change for valid dims).
- Cold clippy clean, fmt clean.

Closes #234