### PR TITLE
chore: add upstream attribution for ported third-party code

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -23,3 +23,39 @@ NOTICE file, as required by Apache License 2.0 Section 4(d):
 
     This product includes software developed by Tom Turney
     (https://github.com/TheTom/turboquant_plus).
+
+
+mlx-lm and mlx-vlm
+------------------
+
+Portions of mlxcel's model architectures, tokenizer handling, batch
+scheduler, and server API translators are ported from or mirror mlx-lm
+(https://github.com/ml-explore/mlx-lm), Copyright 2023 Apple Inc., and
+mlx-vlm (https://github.com/Blaizzy/mlx-vlm), Copyright 2025 Prince Canuma.
+Both are licensed under the MIT License. The MIT License requires that the
+copyright and permission notices be retained in substantial portions, so
+they are reproduced below:
+
+    MIT License
+
+    Copyright © 2023 Apple Inc. (mlx-lm)
+    Copyright © 2025 Prince Canuma (mlx-vlm)
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,25 @@
+mlxcel
+Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+
+This product includes software developed at Lablup Inc.
+
+------------------------------------------------------------------------
+Third-party attributions
+------------------------------------------------------------------------
+
+turboquant_plus
+---------------
+
+Portions of the TurboQuant KV cache implementation, under
+src/lib/mlxcel-core/src/cache/turbo/, are derived from turboquant_plus
+(https://github.com/TheTom/turboquant_plus), Copyright 2026 Tom Turney,
+licensed under the Apache License, Version 2.0.
+
+The following notice is carried forward verbatim from the turboquant_plus
+NOTICE file, as required by Apache License 2.0 Section 4(d):
+
+    turboquant_plus
+    Copyright 2026 Tom Turney
+
+    This product includes software developed by Tom Turney
+    (https://github.com/TheTom/turboquant_plus).

--- a/README.md
+++ b/README.md
@@ -242,6 +242,6 @@ Apache License 2.0 unless otherwise noted, see [LICENSE](LICENSE). Third-party a
 ## Acknowledgments
 
 - [MLX](https://github.com/ml-explore/mlx) — Apple's machine learning framework
-- [mlx-lm](https://github.com/ml-explore/mlx-lm) and [mlx-vlm](https://github.com/Blaizzy/mlx-vlm) — Python projects that guide model-family compatibility
+- [mlx-lm](https://github.com/ml-explore/mlx-lm) (MIT, Copyright 2023 Apple Inc.) and [mlx-vlm](https://github.com/Blaizzy/mlx-vlm) (MIT, Copyright 2025 Prince Canuma): Python projects whose model coverage and behavior mlxcel ports and mirrors. See [NOTICE](NOTICE).
 - [MLX Community](https://huggingface.co/mlx-community) — pre-converted MLX model checkpoints
 - [turboquant_plus](https://github.com/TheTom/turboquant_plus): TurboQuant KV cache compression algorithms ported in `src/lib/mlxcel-core/src/cache/turbo/` (Apache-2.0, Copyright 2026 Tom Turney). See [NOTICE](NOTICE).

--- a/README.md
+++ b/README.md
@@ -237,10 +237,11 @@ For security vulnerabilities, see [`SECURITY.md`](SECURITY.md) — do **not** fi
 
 ## License
 
-Apache License 2.0 unless otherwise noted — see [LICENSE](LICENSE).
+Apache License 2.0 unless otherwise noted, see [LICENSE](LICENSE). Third-party attributions carried forward under Apache-2.0 Section 4(d) are listed in [NOTICE](NOTICE).
 
 ## Acknowledgments
 
 - [MLX](https://github.com/ml-explore/mlx) — Apple's machine learning framework
 - [mlx-lm](https://github.com/ml-explore/mlx-lm) and [mlx-vlm](https://github.com/Blaizzy/mlx-vlm) — Python projects that guide model-family compatibility
 - [MLX Community](https://huggingface.co/mlx-community) — pre-converted MLX model checkpoints
+- [turboquant_plus](https://github.com/TheTom/turboquant_plus): TurboQuant KV cache compression algorithms ported in `src/lib/mlxcel-core/src/cache/turbo/` (Apache-2.0, Copyright 2026 Tom Turney). See [NOTICE](NOTICE).

--- a/docs/benchmark_results/model_tests.md
+++ b/docs/benchmark_results/model_tests.md
@@ -29,8 +29,8 @@ Current source-of-truth data lives in `benchmarks/`:
 | `metal_m1ultra_vlm_2026-06-12.csv` | M1 Ultra | 2026-06-12 (mlxcel 0.1.4, MLX pin a6ec712; full VLM re-benchmark, 49 measured rows) | VLM |
 | `metal_m1ultra_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlxcel 0.0.28, MLX commit 84961223; >65GB skipped) | Text |
 | `metal_m1ultra_vlm_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlxcel 0.0.28, MLX commit 84961223; >65GB skipped) | VLM |
-| `pylm_m1ultra_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlx-lm 0.31.3 baseline, `references/mlx-lm` @ `df1d3f3`; >65GB skipped) | Text |
-| `pylm_m1ultra_vlm_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlx-vlm baseline, `references/mlx-vlm` @ `d85ca4d`; >65GB skipped) | VLM |
+| `pylm_m1ultra_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlx-lm 0.31.3 baseline, https://github.com/ml-explore/mlx-lm @ `df1d3f3`; >65GB skipped) | Text |
+| `pylm_m1ultra_vlm_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlx-vlm baseline, https://github.com/Blaizzy/mlx-vlm @ `d85ca4d`; >65GB skipped) | VLM |
 | `cuda_gb10_2026-05-28.csv` | GB10 | 2026-05-28 (full text re-benchmark, mlxcel 0.1.0, MLX commit 84961223, warm same-process harness `c9a77f2`, `--cooldown 0`; 109 models, 8 fail/skip) | Text |
 | `cuda_gb10_vlm_2026-05-28.csv` | GB10 | 2026-05-28 (full VLM re-benchmark, mlxcel 0.1.0; 38 measured VLM rows, 0 image-path failures) | VLM |
 | `cuda_gb10_2026-05-19.csv` | GB10 | 2026-05-19 (mlxcel 0.0.27, MLX 0.31.2) | Text |

--- a/docs/benchmark_results/model_tests_m1ultra.md
+++ b/docs/benchmark_results/model_tests_m1ultra.md
@@ -11,8 +11,8 @@ Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra
 | **mlxcel version** | 0.1.4 |
 | **MLX version** | 0.32.0-dev pin (commit a6ec712, 2026-06-11 upstream main, via mlxcel-core) |
 | **Bench harness** | `mlxcel-bench-decode` (model load, warmup, and measured pass in one process) |
-| **mlx-lm baseline** | 0.31.3 (dev checkout `references/mlx-lm` @ `df1d3f3` — "Fix Gemma 4 sanitize() not stripping KV projections for shared layers" ml-explore/mlx-lm#1240) |
-| **mlx-vlm baseline** | dev checkout `references/mlx-vlm` @ `d85ca4d` — "Compatibility bridge for non-VL models" Blaizzy/mlx-vlm#1181 |
+| **mlx-lm baseline** | 0.31.3 (dev checkout https://github.com/ml-explore/mlx-lm @ `df1d3f3` — "Fix Gemma 4 sanitize() not stripping KV projections for shared layers" ml-explore/mlx-lm#1240) |
+| **mlx-vlm baseline** | dev checkout https://github.com/Blaizzy/mlx-vlm @ `d85ca4d` — "Compatibility bridge for non-VL models" Blaizzy/mlx-vlm#1181 |
 | **Test Prompt** | "Hello, how are you today?" (text) / "What is in this image?" (VLM) |
 | **Max Tokens** | 100 (measured pass); 20 (warmup pass, same process) |
 | **Test Date** | 2026-05-19 full sweep (baseline); 2026-05-28 full text + VLM re-benchmark on mlxcel 0.1.0 (`--cooldown 0`); 2026-06-12 full text + VLM re-benchmark on mlxcel 0.1.4 (MLX pin a6ec712, post issue #222 bump) |
@@ -305,8 +305,8 @@ Source CSVs (same M1 Ultra host; mlxcel 0.1.4 measured 2026-06-12 on the a6ec712
 
 - mlxcel: `benchmarks/metal_m1ultra_2026-06-12.csv`
 - mlxcel VLM: `benchmarks/metal_m1ultra_vlm_2026-06-12.csv`
-- mlx-lm: `benchmarks/pylm_m1ultra_2026-05-19.csv` (mlx-lm 0.31.3 dev checkout in `references/mlx-lm` @ `df1d3f3`)
-- mlx-vlm: `benchmarks/pylm_m1ultra_vlm_2026-05-19.csv` (mlx-vlm dev checkout in `references/mlx-vlm` @ `d85ca4d`)
+- mlx-lm: `benchmarks/pylm_m1ultra_2026-05-19.csv` (mlx-lm 0.31.3 dev checkout in https://github.com/ml-explore/mlx-lm @ `df1d3f3`)
+- mlx-vlm: `benchmarks/pylm_m1ultra_vlm_2026-05-19.csv` (mlx-vlm dev checkout in https://github.com/Blaizzy/mlx-vlm @ `d85ca4d`)
 
 The mlx-lm / mlx-vlm baselines are the pinned 2026-05-19 reference checkout (the reference is fixed, so its decode on this host is stable); the mlxcel side is the 2026-06-12 full sweep. All sweeps use `--max-tokens 100` and the same `Hello, how are you today?` / `What is in this image?` prompts. `deepseek-v3-4bit` and `qwen3-next-480b-4bit` exceed the 128GB host on both sides; `minimax-m2-3bit` fits and runs on the mlxcel side (33.14 tok/s) but mlx-lm still fails it, so it stays outside the comparable set. Models added in the 06-12 sweep (gemma-4-12b-it, the Gemma 4 QAT variants, diffusiongemma, MiniCPM-V-4.6, plus internvl3-1b and molmo-7b on the text path) have no Python baseline and carry "-" in the comparison columns.
 
@@ -601,7 +601,7 @@ and `turbo4-asym` decode are well below the M5 gates on M1 Ultra, while
 keep their FP16 representation and only the hot tail is packed.
 
 The decode regression is consistent with the L2-cache wall documented in
-`turboquant_plus/`. The fused Sparse-V Metal kernel that lands
+https://github.com/TheTom/turboquant_plus. The fused Sparse-V Metal kernel that lands
  targets the per-thread skip path inside the SDPA inner loop and is
 expected to recover most of the M5 decode budget; the M1/M2 ceiling stays
 limited by L2 bandwidth and is documented but not gated.

--- a/docs/benchmark_results/model_tests_m1ultra.md
+++ b/docs/benchmark_results/model_tests_m1ultra.md
@@ -601,7 +601,7 @@ and `turbo4-asym` decode are well below the M5 gates on M1 Ultra, while
 keep their FP16 representation and only the hot tail is packed.
 
 The decode regression is consistent with the L2-cache wall documented in
-`references/turboquant_plus/`. The fused Sparse-V Metal kernel that lands
+`turboquant_plus/`. The fused Sparse-V Metal kernel that lands
  targets the per-thread skip path inside the SDPA inner loop and is
 expected to recover most of the M5 decode budget; the M1/M2 ceiling stays
 limited by L2 bandwidth and is documented but not gated.

--- a/docs/benchmark_results/model_tests_m5max.md
+++ b/docs/benchmark_results/model_tests_m5max.md
@@ -10,7 +10,7 @@ Compatibility and performance testing for mlxcel models on **MacBook Pro M5 Max 
 | **OS** | macOS 26.4 (Tahoe) |
 | **mlxcel version** | 0.1.0 |
 | **MLX version** | 0.31.2 (via mlxcel-core; pinned commit `84961223`) |
-| **mlx-lm baseline** | 0.31.3 (dev checkout `references/mlx-lm`, commit `ed1fca4`) |
+| **mlx-lm baseline** | 0.31.3 (dev checkout https://github.com/ml-explore/mlx-lm, commit `ed1fca4`) |
 | **mlx-vlm baseline** | 0.4.4 |
 | **Test Prompt** | "Hello, how are you today?" (text) / "What is in this image?" (VLM) |
 | **Max Tokens** | 100 |
@@ -240,7 +240,7 @@ All entries use the VLM prompt 'What is in this image?' with
 Source CSVs (same M5 Max host, mlxcel 0.0.28 with `--cooldown 15 --big-cooldown 15`):
 
 - mlxcel: `benchmarks/metal_m5max_2026-05-19.csv`
-- mlx-lm: `benchmarks/pylm_m5max_2026-05-18.csv` (mlx-lm 0.31.3 dev checkout in `references/mlx-lm`)
+- mlx-lm: `benchmarks/pylm_m5max_2026-05-18.csv` (mlx-lm 0.31.3 dev checkout in https://github.com/ml-explore/mlx-lm)
 - mlxcel VLM: `benchmarks/metal_m5max_vlm_2026-05-19.csv`, `benchmarks/metal_m5max_vlm_2026-05-20.csv` (Gemma3n VLM entries)
 - mlx-vlm: `benchmarks/pylm_m5max_vlm_2026-05-18.csv` (mlx-vlm 0.4.4)
 

--- a/docs/benchmark_results/model_tests_m5max.md
+++ b/docs/benchmark_results/model_tests_m5max.md
@@ -714,7 +714,7 @@ per-token per-simdgroup scan (4–8× fewer scans on M5 Max for D=128 / D=256).
 
 #### Post- TurboQuant+ delegated FP16 working-set experiment (4K)
 
-Follow-up on 2026-05-07 after comparing `references/turboquant_plus`: the MLX
+Follow-up on 2026-05-07 after comparing `turboquant_plus`: the MLX
 delegated KVCache keeps FP16 K/V in an internal native cache and routes decode
 through native SDPA, while packed storage is compacted outside the hot path.
 mlxcel now has an opt-in analogue via

--- a/docs/turbo-kv-cache.md
+++ b/docs/turbo-kv-cache.md
@@ -5,6 +5,8 @@ The implementation is experimental in the sense that quality and speed vary by
 model family, cache mode, hardware, and server path. Use the default FP16 cache
 unless you have measured the target model and workload.
 
+The TurboQuant algorithms (PolarQuant rotation, Lloyd-Max codebooks, layer-aware V protection, sparse-V dequant) are a Rust port of [turboquant_plus](https://github.com/TheTom/turboquant_plus), Copyright 2026 Tom Turney, licensed under the Apache License 2.0. See the top-level [NOTICE](../NOTICE) file for the attribution carried forward under Apache-2.0 Section 4(d).
+
 Implementation entry points:
 
 - CLI flags: `src/cli/turbo_args.rs`

--- a/src/audio/attention.rs
+++ b/src/audio/attention.rs
@@ -14,7 +14,7 @@
 
 //! Gemma4 Conformer chunked local attention with relative position embeddings.
 //!
-//! Ported from: references/mlx-vlm/mlx_vlm/models/gemma4/audio.py (AudioAttention)
+//! Ported from: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4/audio.py (AudioAttention)
 //!
 //! Used by: Gemma4 audio encoder (ConformerBlock)
 

--- a/src/audio/encoder.rs
+++ b/src/audio/encoder.rs
@@ -15,7 +15,7 @@
 //! Gemma4 Conformer audio encoder.
 //!
 //! Architecture: SSCP -> 12x ConformerBlock -> output projection.
-//! Ported from: references/mlx-vlm/mlx_vlm/models/gemma4/audio.py
+//! Ported from: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4/audio.py
 //!
 //! Used by: Gemma4 VLM (audio modality)
 

--- a/src/audio/feature_extractor.rs
+++ b/src/audio/feature_extractor.rs
@@ -18,7 +18,7 @@
 //! (Universal Speech Model) preprocessing pipeline. Pure DSP -- no neural
 //! network weights involved.
 //!
-//! Ported from: references/mlx-vlm/mlx_vlm/models/gemma4/audio_feature_extractor.py
+//! Ported from: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4/audio_feature_extractor.py
 //!
 //! Used by: Gemma4 VLM (audio modality)
 

--- a/src/audio/nemotron_h_nano_omni/config.rs
+++ b/src/audio/nemotron_h_nano_omni/config.rs
@@ -15,7 +15,7 @@
 //! Nemotron H Nano Omni audio config — Parakeet flavour.
 //!
 //! Mirrors upstream
-//! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/config.py::AudioConfig`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/config.py (AudioConfig).
 //!
 //! Used by: Nemotron H Nano Omni audio modality.
 

--- a/src/audio/nemotron_h_nano_omni/encoder.rs
+++ b/src/audio/nemotron_h_nano_omni/encoder.rs
@@ -15,7 +15,7 @@
 //! Parakeet/Conformer encoder used by Nemotron H Nano Omni audio.
 //!
 //! Faithful Rust port of upstream
-//! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/audio.py`:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/audio.py:
 //! - `ParakeetEncoderSubsamplingConv2D` — depthwise/pointwise stack with
 //!   stride-2 reduction along the time axis.
 //! - `ParakeetEncoderRelPositionalEncoding` — Transformer-XL-style

--- a/src/audio/nemotron_h_nano_omni/encoder_tests.rs
+++ b/src/audio/nemotron_h_nano_omni/encoder_tests.rs
@@ -318,7 +318,7 @@ fn config_subsampling_output_matches_iteration_count() {
 /// Pins the relative-position vector for T=4 to the upstream-equivalent
 /// descending order `[3, 2, 1, 0, -1, -2, -3]` (mirrors
 /// `mx.arange(seq_length - 1, -seq_length, -1)` from
-/// `references/mlx-vlm/.../audio.py`).
+/// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/audio.py).
 ///
 /// This is the regression guard for the bug where the position vector
 /// was double-reversed into ascending order (`[-3, -2, -1, 0, 1, 2, 3]`),

--- a/src/audio/nemotron_h_nano_omni/feature_extractor.rs
+++ b/src/audio/nemotron_h_nano_omni/feature_extractor.rs
@@ -15,7 +15,7 @@
 //! Parakeet-style log-mel feature extractor for Nemotron H Nano Omni.
 //!
 //! Faithful Rust port of upstream
-//! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/audio.py::SoundFeatureExtractor`
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/audio.py (SoundFeatureExtractor)
 //! and the underlying `mlx_audio.dsp.stft / hanning / mel_filters` calls.
 //!
 //! Pipeline:

--- a/src/audio/nemotron_h_nano_omni/mod.rs
+++ b/src/audio/nemotron_h_nano_omni/mod.rs
@@ -15,7 +15,7 @@
 //! Nemotron H Nano Omni audio modality.
 //!
 //! Faithful Rust port of upstream
-//! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/audio.py`
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/audio.py
 //! covering:
 //! - [`feature_extractor::NemotronOmniFeatureExtractor`] — log-mel
 //!   spectrogram preprocessing (pure DSP, no network weights). Mirrors

--- a/src/audio/nemotron_h_nano_omni/projector.rs
+++ b/src/audio/nemotron_h_nano_omni/projector.rs
@@ -15,7 +15,7 @@
 //! `SoundProjection` — audio embedding to text hidden size projection.
 //!
 //! Faithful Rust port of upstream
-//! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/audio.py::SoundProjection`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/audio.py (SoundProjection).
 //!
 //! Architecture:
 //! `RMSNorm(hidden) -> Linear(hidden, projection_hidden) -> SquaredReLU

--- a/src/bin/speculative_bench.rs
+++ b/src/bin/speculative_bench.rs
@@ -71,7 +71,7 @@ use mlxcel::{LanguageModel, SamplingConfig, initialize_runtime, load_model};
 use mlxcel_core::generate::{CxxGenerator, GenerationStats};
 
 /// Default 17-token prompt that matches the upstream MTP perf-table conditions
-/// (`references/mlx-vlm/README.md`). Token count is approximate (depends on
+/// (https://github.com/Blaizzy/mlx-vlm/blob/main/README.md). Token count is approximate (depends on
 /// the tokenizer), but the prompt structure is the same: a short instruction
 /// + a moderately information-dense follow-on.
 const DEFAULT_PROMPT: &str =

--- a/src/cli/speculative_args.rs
+++ b/src/cli/speculative_args.rs
@@ -49,9 +49,9 @@ use mlxcel_core::drafter::{DrafterKind, KNOWN_DRAFTER_KINDS};
 /// Values match upstream:
 ///
 /// - **MTP** → `4` — the Gemma 4 MTP "assistant" draft block length used
-///   by `references/mlx-vlm/mlx_vlm/speculative/drafters/gemma4_assistant/config.py`.
+///   by https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/gemma4_assistant/config.py.
 /// - **DFlash** → `16` — the Qwen 3.5 DFlash drafter's `block_size`
-///   declared in `references/mlx-vlm/mlx_vlm/speculative/drafters/qwen3_dflash/config.py:31`.
+///   declared in https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/qwen3_dflash/config.py#L31.
 ///   Mirrors [`mlxcel_core::drafter::dflash::DEFAULT_BLOCK_SIZE`].
 pub const DEFAULT_MTP_BLOCK_SIZE: u32 = 4;
 pub const DEFAULT_DFLASH_BLOCK_SIZE: u32 = 16;

--- a/src/cli/speculative_args_tests.rs
+++ b/src/cli/speculative_args_tests.rs
@@ -99,7 +99,7 @@ fn default_block_size_for_mtp_is_4() {
 
 #[test]
 fn default_block_size_for_dflash_is_16() {
-    // Matches references/mlx-vlm/mlx_vlm/speculative/drafters/qwen3_dflash/config.py:31
+    // Matches https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/qwen3_dflash/config.py#L31
     // and DEFAULT_BLOCK_SIZE in mlxcel_core::drafter::dflash::round_loop.
     assert_eq!(default_block_size_for_kind(DrafterKind::Dflash), 16);
     assert_eq!(DEFAULT_DFLASH_BLOCK_SIZE, 16);

--- a/src/lib/mlx-cpp/turbo/sparse_v_sdpa.h
+++ b/src/lib/mlx-cpp/turbo/sparse_v_sdpa.h
@@ -31,8 +31,9 @@
 // attention scores → softmax pre-stage and then applies the inverse rotation
 // `D2·H·D1` *outside* the kernel on the smaller `[B, Hq, Tq, D]` output, so
 // the rotation cost is independent of T (the cache length). This matches the
-// "rotate after accumulation" pattern used in `references/mlx-vlm/mlx_vlm/
-// turboquant.py::_single_tile_value_weighted_sum_kernel`.
+// "rotate after accumulation" pattern used in
+// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/turboquant.py
+// (_single_tile_value_weighted_sum_kernel).
 //
 // Used by: `cpp/mlx_cxx_bridge.cpp` (`turbo_sparse_v_weighted_sum`).
 

--- a/src/lib/mlxcel-core/examples/wht_microbench.rs
+++ b/src/lib/mlxcel-core/examples/wht_microbench.rs
@@ -246,7 +246,7 @@ fn main() {
     } else {
         println!(
             "  -> graph-only WHT exceeds 5% budget. Consider custom Metal \
-             kernel (see references/turboquant_plus llama.cpp half4 butterfly).",
+             kernel (see turboquant_plus llama.cpp half4 butterfly).",
         );
     }
 }

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -65,7 +65,7 @@
 //! `slice(keys, 0, offset)` for K and `concat(dequant(v_packed), hot_V)` for
 //! V. The K side has no per-step concat — that was the dominant residual
 //! cost vs FP16 mode (~7 ms/step at 4 K context). See
-//! `turboquant_plus/README.md` §"MLX Framework Port" for the
+//! https://github.com/TheTom/turboquant_plus/blob/main/README.md §"MLX Framework Port" for the
 //! original architecture.
 //!
 //! Setting `MLXCEL_TURBO4_DELEGATED_FP16_FAST_PATH=1` switches this mode to a
@@ -131,7 +131,7 @@ fn direct_prefill_cache_store_enabled() -> bool {
 /// Check that all `KVCache` entries in `caches` support cache trimming.
 ///
 /// Mirrors the upstream mlx-lm `can_trim_prompt_cache` function
-/// (`mlx_lm/models/cache.py`). Speculative decoding requires a trimmable
+/// (https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/cache.py). Speculative decoding requires a trimmable
 /// cache so it can rewind cache entries after a draft-token rejection.
 ///
 /// All current `KVCache` mode variants (Fp16, Int8, Turbo4Asym, Turbo4,
@@ -594,7 +594,7 @@ impl KVCache {
     /// and the speed benchmarks. Production callers should leave the default
     /// [`turbo::DELEGATED_HOT_THRESHOLD`] in place; tuning this changes the
     /// fold cadence and therefore the speed/quality trade-off documented in
-    /// `turboquant_plus/README.md`. Setting `threshold <= 0` is
+    /// https://github.com/TheTom/turboquant_plus/blob/main/README.md. Setting `threshold <= 0` is
     /// rejected so the fold path stays well-defined.
     pub fn set_hot_threshold(&mut self, threshold: i32) {
         if threshold > 0 {
@@ -2382,7 +2382,7 @@ impl KVCache {
     /// 3. **Leaves `self.offset` unchanged** so RoPE for the next Q stays
     ///    rotated at the correct monotonic position.
     ///
-    /// Upstream `RotatingKVCache` (`mlx_lm/models/cache.py:410-510`) uses
+    /// Upstream `RotatingKVCache` (https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/cache.py#L410-L510) uses
     /// the same `offset` monotonic / `_idx` rotating split for the same
     /// reason; the names differ but the invariant is identical.
     ///
@@ -2894,7 +2894,7 @@ impl KVCache {
     /// tensors returned by the model's `forward` pass.
     ///
     /// Upstream mlx-lm evaluates `[c.state for c in cache]` after each
-    /// chunked-prefill step (see `mlx_lm/generate.py` ~line 583). This method
+    /// chunked-prefill step (see https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py ~line 583). This method
     /// mirrors that pattern: it calls `ffi::eval` on every non-`None` tensor
     /// field that contributes to the cache state (`keys`, `values`,
     /// `key_scales`, `val_scales`, `v_packed`, `v_norms`, `v_rescale`,

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -65,7 +65,7 @@
 //! `slice(keys, 0, offset)` for K and `concat(dequant(v_packed), hot_V)` for
 //! V. The K side has no per-step concat — that was the dominant residual
 //! cost vs FP16 mode (~7 ms/step at 4 K context). See
-//! `references/turboquant_plus/README.md` §"MLX Framework Port" for the
+//! `turboquant_plus/README.md` §"MLX Framework Port" for the
 //! original architecture.
 //!
 //! Setting `MLXCEL_TURBO4_DELEGATED_FP16_FAST_PATH=1` switches this mode to a
@@ -594,7 +594,7 @@ impl KVCache {
     /// and the speed benchmarks. Production callers should leave the default
     /// [`turbo::DELEGATED_HOT_THRESHOLD`] in place; tuning this changes the
     /// fold cadence and therefore the speed/quality trade-off documented in
-    /// `references/turboquant_plus/README.md`. Setting `threshold <= 0` is
+    /// `turboquant_plus/README.md`. Setting `threshold <= 0` is
     /// rejected so the fold path stays well-defined.
     pub fn set_hot_threshold(&mut self, threshold: i32) {
         if threshold > 0 {

--- a/src/lib/mlxcel-core/src/cache/turbo/allowlist.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/allowlist.rs
@@ -11,6 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Portions of this file are derived from turboquant_plus
+// (https://github.com/TheTom/turboquant_plus), Copyright 2026 Tom Turney,
+// licensed under the Apache License, Version 2.0. See the top-level NOTICE
+// file for the attribution carried forward under Apache-2.0 Section 4(d).
 
 //! Per-model allowlist for **symmetric** `KVCacheMode::Turbo4`
 //!

--- a/src/lib/mlxcel-core/src/cache/turbo/boundary.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/boundary.rs
@@ -23,7 +23,7 @@
 //! V quantization error contributes disproportionately to perplexity
 //! regression: keeping these 4 layers at higher precision recovers
 //! 37–91% of the quality gap at zero speed cost. See
-//! `turboquant_plus/docs/papers/layer-aware-v-compression.md`
+//! https://github.com/TheTom/turboquant_plus/blob/main/docs/papers/layer-aware-v-compression.md
 //! for the original measurements (LA-V7 policy: q8_0 boundary V, turbo
 //! middle V, K unchanged).
 //!

--- a/src/lib/mlxcel-core/src/cache/turbo/boundary.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/boundary.rs
@@ -11,6 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Portions of this file are derived from turboquant_plus
+// (https://github.com/TheTom/turboquant_plus), Copyright 2026 Tom Turney,
+// licensed under the Apache License, Version 2.0. See the top-level NOTICE
+// file for the attribution carried forward under Apache-2.0 Section 4(d).
 
 //! Boundary-V layer protection (B6).
 //!
@@ -18,7 +23,7 @@
 //! V quantization error contributes disproportionately to perplexity
 //! regression: keeping these 4 layers at higher precision recovers
 //! 37–91% of the quality gap at zero speed cost. See
-//! `references/turboquant_plus/docs/papers/layer-aware-v-compression.md`
+//! `turboquant_plus/docs/papers/layer-aware-v-compression.md`
 //! for the original measurements (LA-V7 policy: q8_0 boundary V, turbo
 //! middle V, K unchanged).
 //!

--- a/src/lib/mlxcel-core/src/cache/turbo/codebook.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/codebook.rs
@@ -27,7 +27,7 @@
 //! # Reference
 //!
 //! This is a pure-Rust port of
-//! `turboquant_plus/turboquant/codebook.py::optimal_centroids`.
+//! https://github.com/TheTom/turboquant_plus/blob/main/turboquant/codebook.py (optimal_centroids).
 //! The algorithm is:
 //!
 //! * `b = 1`: closed-form `±sqrt(2 / (π·d))`.

--- a/src/lib/mlxcel-core/src/cache/turbo/codebook.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/codebook.rs
@@ -11,6 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Portions of this file are derived from turboquant_plus
+// (https://github.com/TheTom/turboquant_plus), Copyright 2026 Tom Turney,
+// licensed under the Apache License, Version 2.0. See the top-level NOTICE
+// file for the attribution carried forward under Apache-2.0 Section 4(d).
 
 //! PolarQuant Lloyd-Max codebook generator.
 //!
@@ -22,7 +27,7 @@
 //! # Reference
 //!
 //! This is a pure-Rust port of
-//! `references/turboquant_plus/turboquant/codebook.py::optimal_centroids`.
+//! `turboquant_plus/turboquant/codebook.py::optimal_centroids`.
 //! The algorithm is:
 //!
 //! * `b = 1`: closed-form `±sqrt(2 / (π·d))`.

--- a/src/lib/mlxcel-core/src/cache/turbo/mod.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/mod.rs
@@ -11,6 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Portions of this file are derived from turboquant_plus
+// (https://github.com/TheTom/turboquant_plus), Copyright 2026 Tom Turney,
+// licensed under the Apache License, Version 2.0. See the top-level NOTICE
+// file for the attribution carried forward under Apache-2.0 Section 4(d).
 
 //! TurboQuant KV cache compression.
 //!
@@ -98,7 +103,7 @@ pub const DELEGATED_HOT_MAX: i32 = DELEGATED_HOT_THRESHOLD * 4;
 /// When enabled, the cache still builds packed cold V sidecars, but it keeps a
 /// unified FP16 V buffer and routes decode attention through native SDPA. This
 /// trades the compressed-only memory target for a speed reference path that
-/// mirrors `references/turboquant_plus`' delegated KVCache architecture.
+/// mirrors `turboquant_plus`' delegated KVCache architecture.
 pub const DELEGATED_FP16_FAST_PATH_ENV: &str = "MLXCEL_TURBO4_DELEGATED_FP16_FAST_PATH";
 
 static DELEGATED_FP16_FAST_PATH_ENABLED: OnceLock<bool> = OnceLock::new();

--- a/src/lib/mlxcel-core/src/cache/turbo/pack3.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/pack3.rs
@@ -11,6 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Portions of this file are derived from turboquant_plus
+// (https://github.com/TheTom/turboquant_plus), Copyright 2026 Tom Turney,
+// licensed under the Apache License, Version 2.0. See the top-level NOTICE
+// file for the attribution carried forward under Apache-2.0 Section 4(d).
 
 //! 3-bit pack/unpack helpers for `KVCacheMode::Turbo3Asym`.
 //!

--- a/src/lib/mlxcel-core/src/cache/turbo/quant.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/quant.rs
@@ -11,6 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Portions of this file are derived from turboquant_plus
+// (https://github.com/TheTom/turboquant_plus), Copyright 2026 Tom Turney,
+// licensed under the Apache License, Version 2.0. See the top-level NOTICE
+// file for the attribution carried forward under Apache-2.0 Section 4(d).
 
 //! TurboQuant K/V-side PolarQuant pipeline (B2 + B4, and).
 //!
@@ -34,7 +39,7 @@
 //! ([`K_SEED_OFFSET`]). This decorrelates the K and V quantization noise so
 //! that the inner product `Q · Kᵀ` in attention does not see additive bias
 //! from a shared rotation. This is the exact pattern the TurboQuant+
-//! reference uses (`seed + 500` in `references/turboquant_plus/turboquant/
+//! reference uses (`seed + 500` in `turboquant_plus/turboquant/
 //! kv_cache.py::KVCacheCompressor.__init__`).
 //!
 //! # Storage layout
@@ -55,7 +60,7 @@
 //! no block-level shared state in the quantize/dequantize algorithm itself.
 //! This matches TurboQuant+'s "turbo4 already uses block_size=128" semantics
 //! for `head_dim=128` (one norm per rotation group = one norm per V vector).
-//! See `references/turboquant_plus/docs/papers/block-size-experiment.md`.
+//! See `turboquant_plus/docs/papers/block-size-experiment.md`.
 //!
 //! # Numerical notes
 //!
@@ -91,7 +96,7 @@ pub const K_BIT_WIDTH: u8 = 4;
 
 /// Seed offset added to the cache's `turbo_seed` before deriving the K-side
 /// sign vectors. Matches the TurboQuant+ reference pattern
-/// (`references/turboquant_plus/turboquant/kv_cache.py::KVCacheCompressor`,
+/// (`turboquant_plus/turboquant/kv_cache.py::KVCacheCompressor`,
 /// which uses `seed + 500`). The exact value matters less than the property
 /// that K and V sign vectors are *independent* — see the module docstring
 /// for why this matters for attention quality.
@@ -307,7 +312,7 @@ fn quantize_into_packed(
     // norm below 1.0 *up* to 1.0, destroying direction information for
     // small-magnitude vectors. Use a `where` op so non-zero norms pass
     // through unchanged. Mirrors the Python reference at
-    // `references/turboquant_plus/turboquant/polar_quant.py:60`:
+    // `turboquant_plus/turboquant/polar_quant.py:60`:
     // `safe_norms = np.where(norms > 0, norms, 1.0)`.
     let zero = ffi::full_f32(&[1], 0.0, dtype::FLOAT32);
     let one = ffi::full_f32(&[1], 1.0, dtype::FLOAT32);
@@ -519,7 +524,7 @@ fn dequantize_from_packed(
 
     // 2. Norm correction: rescale y_hat to unit norm so the inverse rotation
     //    sees a unit vector. Mirrors the Python `if norm_correction` branch
-    //    in `references/turboquant_plus/turboquant/polar_quant.py`.
+    //    in `turboquant_plus/turboquant/polar_quant.py`.
     let y_hat_sq = ffi::multiply(&y_hat, &y_hat);
     let y_hat_sum_sq = ffi::sum_axis(&y_hat_sq, -1, true);
     let y_hat_norm = ffi::sqrt(&y_hat_sum_sq);

--- a/src/lib/mlxcel-core/src/cache/turbo/quant.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/quant.rs
@@ -39,8 +39,9 @@
 //! ([`K_SEED_OFFSET`]). This decorrelates the K and V quantization noise so
 //! that the inner product `Q · Kᵀ` in attention does not see additive bias
 //! from a shared rotation. This is the exact pattern the TurboQuant+
-//! reference uses (`seed + 500` in `turboquant_plus/turboquant/
-//! kv_cache.py::KVCacheCompressor.__init__`).
+//! reference uses (`seed + 500` in
+//! https://github.com/TheTom/turboquant_plus/blob/main/turboquant/kv_cache.py
+//! (KVCacheCompressor.__init__)).
 //!
 //! # Storage layout
 //!
@@ -60,7 +61,7 @@
 //! no block-level shared state in the quantize/dequantize algorithm itself.
 //! This matches TurboQuant+'s "turbo4 already uses block_size=128" semantics
 //! for `head_dim=128` (one norm per rotation group = one norm per V vector).
-//! See `turboquant_plus/docs/papers/block-size-experiment.md`.
+//! See https://github.com/TheTom/turboquant_plus/blob/main/docs/papers/block-size-experiment.md.
 //!
 //! # Numerical notes
 //!
@@ -96,7 +97,7 @@ pub const K_BIT_WIDTH: u8 = 4;
 
 /// Seed offset added to the cache's `turbo_seed` before deriving the K-side
 /// sign vectors. Matches the TurboQuant+ reference pattern
-/// (`turboquant_plus/turboquant/kv_cache.py::KVCacheCompressor`,
+/// (https://github.com/TheTom/turboquant_plus/blob/main/turboquant/kv_cache.py (KVCacheCompressor),
 /// which uses `seed + 500`). The exact value matters less than the property
 /// that K and V sign vectors are *independent* — see the module docstring
 /// for why this matters for attention quality.
@@ -312,7 +313,7 @@ fn quantize_into_packed(
     // norm below 1.0 *up* to 1.0, destroying direction information for
     // small-magnitude vectors. Use a `where` op so non-zero norms pass
     // through unchanged. Mirrors the Python reference at
-    // `turboquant_plus/turboquant/polar_quant.py:60`:
+    // https://github.com/TheTom/turboquant_plus/blob/main/turboquant/polar_quant.py#L60:
     // `safe_norms = np.where(norms > 0, norms, 1.0)`.
     let zero = ffi::full_f32(&[1], 0.0, dtype::FLOAT32);
     let one = ffi::full_f32(&[1], 1.0, dtype::FLOAT32);
@@ -524,7 +525,7 @@ fn dequantize_from_packed(
 
     // 2. Norm correction: rescale y_hat to unit norm so the inverse rotation
     //    sees a unit vector. Mirrors the Python `if norm_correction` branch
-    //    in `turboquant_plus/turboquant/polar_quant.py`.
+    //    in https://github.com/TheTom/turboquant_plus/blob/main/turboquant/polar_quant.py.
     let y_hat_sq = ffi::multiply(&y_hat, &y_hat);
     let y_hat_sum_sq = ffi::sum_axis(&y_hat_sq, -1, true);
     let y_hat_norm = ffi::sqrt(&y_hat_sum_sq);

--- a/src/lib/mlxcel-core/src/cache/turbo/quant3.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/quant3.rs
@@ -11,6 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Portions of this file are derived from turboquant_plus
+// (https://github.com/TheTom/turboquant_plus), Copyright 2026 Tom Turney,
+// licensed under the Apache License, Version 2.0. See the top-level NOTICE
+// file for the attribution carried forward under Apache-2.0 Section 4(d).
 
 //! V-side 3-bit PolarQuant pipeline for `KVCacheMode::Turbo3Asym`.
 //!

--- a/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
@@ -11,6 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Portions of this file are derived from turboquant_plus
+// (https://github.com/TheTom/turboquant_plus), Copyright 2026 Tom Turney,
+// licensed under the Apache License, Version 2.0. See the top-level NOTICE
+// file for the attribution carried forward under Apache-2.0 Section 4(d).
 
 //! Sparse-V dequant — attention-gated V-side dequantization.
 //!

--- a/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
@@ -21,7 +21,7 @@
 //!
 //! At long context the post-softmax attention distribution is sparse: most
 //! KV positions receive a near-zero attention weight. The TurboQuant+ paper
-//! [`docs/papers/sparse-v-dequant.md`] reports `~90%` sparsity at 32 K
+//! [https://github.com/TheTom/turboquant_plus/blob/main/docs/papers/sparse-v-dequant.md] reports `~90%` sparsity at 32 K
 //! context on a 35 B MoE model. Dequantizing those V vectors is wasted work.
 //! Skipping them on a fused Metal kernel yields `+22.8 %` decode at 32 K
 //! with no measurable PPL change.

--- a/src/lib/mlxcel-core/src/drafter/dflash/cache.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/cache.rs
@@ -14,7 +14,7 @@
 
 //! DFlash drafter K/V cache type alias.
 //!
-//! Upstream `mlx-vlm/speculative/drafters/qwen3_dflash/dflash.py` declares
+//! Upstream https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py declares
 //! `DFlashKVCache = KVCache` at the module bottom. The DFlash drafter
 //! reuses MLX-LM's stock `KVCache` shape and `update_and_fetch` semantics
 //! verbatim — no new cache layout is required.

--- a/src/lib/mlxcel-core/src/drafter/dflash/config.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/config.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! [`DFlashConfig`] — Rust port of upstream
-//! `references/mlx-vlm/mlx_vlm/speculative/drafters/qwen3_dflash/config.py`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/qwen3_dflash/config.py.
 //!
 //! Defaults mirror the published `z-lab/Qwen3.5-4B-DFlash` checkpoint:
 //!
@@ -41,7 +41,7 @@ use serde::{Deserialize, Serialize};
 /// Upstream DFlash default target-layer capture list.
 ///
 /// This is the default in
-/// `references/mlx-vlm/mlx_vlm/speculative/drafters/qwen3_dflash/config.py`
+/// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/qwen3_dflash/config.py
 /// for the original `z-lab/Qwen3.5-4B-DFlash` drafter. Runtime code should
 /// prefer the loaded checkpoint's [`DFlashConfig::target_layer_ids`]; this
 /// constant exists only as the config default / backwards-compatible fallback.

--- a/src/lib/mlxcel-core/src/drafter/dflash/drafter.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/drafter.rs
@@ -189,7 +189,7 @@ fn convert_bf16_to_f16_non_quantized(weights: &mut WeightMap) {
 impl Drafter for DFlashDrafter {
     fn bind(&mut self, target: &dyn LanguageModel) -> Result<(), DrafterError> {
         // Two embedding cases, mirroring upstream Python's lazy-bind shape
-        // (`references/mlx-vlm/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py`
+        // (https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py
         // lines 88, 92-108):
         //
         // 1. Lazy-bind checkpoint (the published `z-lab/Qwen3.5-4B-DFlash`):

--- a/src/lib/mlxcel-core/src/drafter/dflash/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/mod.rs
@@ -17,7 +17,7 @@
 //! ## What this module ports
 //!
 //! Rust port of upstream
-//! `references/mlx-vlm/mlx_vlm/speculative/drafters/qwen3_dflash/`:
+//! https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/speculative/drafters/qwen3_dflash:
 //!
 //! - [`config::DFlashConfig`] — the dataclass + JSON loader (config.py).
 //! - [`cache::DFlashKVCache`] — type alias for [`crate::layers::KVCache`]

--- a/src/lib/mlxcel-core/src/drafter/dflash/model.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/model.rs
@@ -71,7 +71,7 @@ pub struct DFlashDraftModel {
     /// checkpoint does NOT ship `embed_tokens.weight` — upstream Python
     /// sets `self.embed_tokens = None` at construction and binds it to
     /// the target's `embed_tokens` later via `bind()`
-    /// (`references/mlx-vlm/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py`,
+    /// (https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/qwen3_dflash/dflash.py,
     /// lines 88, 92-108). This field mirrors that shape:
     ///
     /// - `Some(_)` — a drafter checkpoint that *did* ship its own

--- a/src/lib/mlxcel-core/src/drafter/dflash/round_loop.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/round_loop.rs
@@ -15,7 +15,7 @@
 //! DFlash speculative-decoding round-loop driver (B=1).
 //!
 //! Rust port of upstream
-//! `references/mlx-vlm/mlx_vlm/generate.py::_dflash_rounds`
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/dflash.py (_dflash_rounds)
 //! (`mlx-vlm` HEAD, lines 856–942). sub-12.
 //!
 //! ## What this module does
@@ -387,7 +387,7 @@ impl DFlashGenerator {
 /// Greedy speculative walk for a single batch.
 ///
 /// Rust port of upstream
-/// `references/mlx-vlm/mlx_vlm/generate.py::_speculative_walk`.
+/// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/common.py (_speculative_walk).
 ///
 /// Given `draft_tokens` (the drafter's `K-1` proposals) and `target_tokens`
 /// (the target's per-position argmax across all `K` verify positions),

--- a/src/lib/mlxcel-core/src/drafter/dflash/round_loop_batched.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/round_loop_batched.rs
@@ -16,7 +16,7 @@
 //! batching).
 //!
 //! Rust port of upstream
-//! `references/mlx-vlm/mlx_vlm/generate.py::_dflash_rounds_batch`
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/dflash.py (_dflash_rounds_batch)
 //! (`mlx-vlm` HEAD, lines 944-1098). sub-13.
 //!
 //! ## Scope
@@ -78,7 +78,7 @@ use super::round_loop::SpeculativeTarget;
 /// Per-row speculative-decoding walk (B >= 1).
 ///
 /// Rust port of upstream
-/// `references/mlx-vlm/mlx_vlm/generate.py::_speculative_walk_batch`.
+/// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/common.py (_speculative_walk_batch).
 ///
 /// Given `draft_tokens` of shape `[B][K-1]` (per-row drafter proposals)
 /// and `target_tokens` of shape `[B][K]` (per-row target argmax over

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/config.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/config.rs
@@ -16,8 +16,8 @@
 //!
 //! Mirrors the upstream `Gemma4AssistantConfig` (HF-compatible, flattened) and
 //! its nested `TextConfig`. See
-//! `references/mlx-vlm/mlx_vlm/speculative/drafters/gemma4_assistant/config.py`
-//! and `references/mlx-vlm/mlx_vlm/models/gemma4/config.py`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/gemma4_assistant/config.py
+//! and https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4/config.py.
 //!
 //! The drafter `TextConfig` is intentionally a self-contained subset that lives
 //! inside `mlxcel-core`. The full Gemma 4 target `TextConfig` lives in

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/mod.rs
@@ -24,8 +24,8 @@
 //! - [`model`] — `Gemma4AssistantDraftModel` implementing
 //!   [`crate::drafter::Drafter`].
 //!
-//! Upstream reference: `references/mlx-vlm/mlx_vlm/speculative/drafters/
-//! gemma4_assistant/`.
+//! Upstream reference:
+//! https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/speculative/drafters/gemma4_assistant.
 
 pub mod config;
 pub mod layer;

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
@@ -16,7 +16,7 @@
 //! drafter.
 //!
 //! Mirrors
-//! `references/mlx-vlm/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py.
 //!
 //! ## Lifecycle
 //!
@@ -542,7 +542,7 @@ impl Gemma4AssistantDraftModel {
     ///   only on E-series drafters with the centroid LM head).
     ///
     /// Mirrors upstream `Gemma4AssistantDraftModel.sanitize` in
-    /// `references/mlx-vlm/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py`.
+    /// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py.
     pub fn sanitize_weights(weights: &mut WeightMap, config: &Gemma4AssistantConfig) {
         if config.tie_word_embeddings {
             weights.remove("lm_head.weight");

--- a/src/lib/mlxcel-core/src/drafter/masked_embedder.rs
+++ b/src/lib/mlxcel-core/src/drafter/masked_embedder.rs
@@ -14,7 +14,7 @@
 
 //! Centroid-routed sparse softmax LM head used by Gemma 4 **E2B / E4B**
 //! assistant drafters. Port of upstream
-//! `references/mlx-vlm/mlx_vlm/speculative/drafters/gemma4_assistant/masked_embedder.py`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/gemma4_assistant/masked_embedder.py.
 //!
 //! ## What it does
 //!

--- a/src/lib/mlxcel-core/src/drafter/masks.rs
+++ b/src/lib/mlxcel-core/src/drafter/masks.rs
@@ -18,7 +18,7 @@
 //! the end of the target's KV cache) over the target's last-layer K/V —
 //! bidirectionally for both full-attention and sliding-window layers. The
 //! masks here mirror the upstream Python reference at
-//! `references/mlx-vlm/mlx_vlm/speculative/drafters/gemma4_assistant/masks.py`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/gemma4_assistant/masks.py.
 //!
 //! ## Scope
 //!

--- a/src/lib/mlxcel-core/src/drafter/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/mod.rs
@@ -43,7 +43,7 @@
 //! ## Upstream reference
 //!
 //! This module ports the public surface of
-//! `references/mlx-vlm/mlx_vlm/speculative/drafters/__init__.py`:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/__init__.py:
 //!
 //! ```python
 //! KNOWN_DRAFTER_KINDS = {"dflash", "mtp"}
@@ -773,7 +773,7 @@ pub trait Drafter {
     /// - **DFlash**: drop the target's `mtp.*` keys when reusing a
     ///   Qwen 3.5 / 3.6 checkpoint that carries an internal MTP head
     ///   the runtime path is not going to use. Matches
-    ///   `references/mlx-lm/mlx_lm/models/qwen3_5.py:308-313`
+    ///   https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/qwen3_5.py#L308-L313
     ///   (`weights.pop("lm_head.weight", None)` and friends).
     /// - **InternalMtp**: pass-through. The actual `mtp.*` extraction
     ///   happens sub-B *before* the drafter sees

--- a/src/lib/mlxcel-core/src/generate.rs
+++ b/src/lib/mlxcel-core/src/generate.rs
@@ -682,7 +682,7 @@ impl CxxGenerator {
     /// **Boundary-V** policy (B6) is applied: the
     /// first / last N transformer layers' caches are upgraded to
     /// `KVCacheMode::Fp16` to recover the per-layer V-quantization quality
-    /// gap measured in `references/turboquant_plus/docs/papers/
+    /// gap measured in `turboquant_plus/docs/papers/
     /// layer-aware-v-compression.md`. The boundary count is read from the
     /// `MLXCEL_KV_BOUNDARY_V_LAYERS` env var (default 2; `0` disables) and
     /// clamped to `n_layers / 2`. For non-Turbo4 modes the policy is inert

--- a/src/lib/mlxcel-core/src/generate.rs
+++ b/src/lib/mlxcel-core/src/generate.rs
@@ -682,8 +682,9 @@ impl CxxGenerator {
     /// **Boundary-V** policy (B6) is applied: the
     /// first / last N transformer layers' caches are upgraded to
     /// `KVCacheMode::Fp16` to recover the per-layer V-quantization quality
-    /// gap measured in `turboquant_plus/docs/papers/
-    /// layer-aware-v-compression.md`. The boundary count is read from the
+    /// gap measured in
+    /// https://github.com/TheTom/turboquant_plus/blob/main/docs/papers/layer-aware-v-compression.md.
+    /// The boundary count is read from the
     /// `MLXCEL_KV_BOUNDARY_V_LAYERS` env var (default 2; `0` disables) and
     /// clamped to `n_layers / 2`. For non-Turbo4 modes the policy is inert
     /// — every layer's cache uses `kv_cache_mode` unchanged.

--- a/src/lib/mlxcel-core/src/rope_proportional.rs
+++ b/src/lib/mlxcel-core/src/rope_proportional.rs
@@ -14,7 +14,7 @@
 
 //! Proportional RoPE helper for Gemma 4 full-attention layers.
 //!
-//! The Gemma 4 reference (`mlx_lm/models/rope_utils.py`) defines a
+//! The Gemma 4 reference (https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/rope_utils.py) defines a
 //! `ProportionalRoPE` variant whose frequency exponents are normalized by the
 //! FULL head dimension (`dims`) rather than the rotated-only slice
 //! (`rotated_dims = int(dims * partial_rotary_factor // 2) * 2`). Only the

--- a/src/lib/mlxcel-core/src/speculative/mtp/mod.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/mod.rs
@@ -35,7 +35,7 @@
 //! ## Round-loop reference
 //!
 //! Mirrors the upstream Python `_mtp_rounds` and `_speculative_walk` in
-//! `references/mlx-vlm/mlx_vlm/generate.py` (lines 456-619).
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/mtp.py.
 //!
 //! ## Submodules
 //!

--- a/src/lib/mlxcel-core/src/speculative/mtp/round_loop_batched.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/round_loop_batched.rs
@@ -15,7 +15,7 @@
 //! MTP batched round-loop driver (B > 1, continuous batching).
 //!
 //! Rust port of upstream
-//! `references/mlx-vlm/mlx_vlm/generate.py::_mtp_rounds_batch` (and the
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/mtp.py (_mtp_rounds_batch) (and the
 //! `_batch_cache_left_padding` helper). sub-7.
 //!
 //! ## Scope

--- a/src/lib/mlxcel-core/src/speculative/mtp/walk.rs
+++ b/src/lib/mlxcel-core/src/speculative/mtp/walk.rs
@@ -15,7 +15,7 @@
 //! Single-batch exact-greedy speculative walk.
 //!
 //! Direct Rust port of `_speculative_walk` in
-//! `references/mlx-vlm/mlx_vlm/generate.py` lines 456-476:
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/mtp.py:
 //!
 //! ```python
 //! def _speculative_walk(draft_tokens, target_tokens, budget):
@@ -141,7 +141,7 @@ pub fn speculative_walk(draft_tokens: &[i32], target_tokens: &[i32], budget: usi
 /// Per-row exact-greedy speculative walk (B >= 1) for the batched MTP path.
 ///
 /// Mirrors upstream `_speculative_walk_batch` in
-/// `references/mlx-vlm/mlx_vlm/generate.py`. Given per-row drafter proposals
+/// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/mtp.py. Given per-row drafter proposals
 /// (`draft_tokens[r]` is row `r`'s `K-1` proposals) and per-row target argmax
 /// (`target_tokens[r]` is row `r`'s `K` argmax tokens), plus per-row budgets,
 /// produces:

--- a/src/loading/vlm_nemotron_h_nano_omni.rs
+++ b/src/loading/vlm_nemotron_h_nano_omni.rs
@@ -89,7 +89,7 @@ fn filter_out_audio_weights(weights: WeightMap, drop_audio: bool) -> WeightMap {
 }
 
 /// Mirror upstream `sanitize_audio_weights` from
-/// `references/.../nemotron_h_nano_omni/audio.py`:
+/// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/audio.py:
 /// - drop `sound_encoder.encoder.feature_extractor.*` (training-only),
 /// - drop `*.num_batches_tracked` BatchNorm scratch state,
 /// - transpose Conv1d weights from PyTorch `[O, I, K]` to MLX

--- a/src/loading/vlm_youtu_vl.rs
+++ b/src/loading/vlm_youtu_vl.rs
@@ -14,7 +14,7 @@
 
 //! Youtu-VL loader.
 //!
-//! Mirrors `references/mlx-vlm/mlx_vlm/models/youtu_vl/youtu_vl.py::Model.sanitize`
+//! Mirrors https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/youtu_vl/youtu_vl.py (Model.sanitize)
 //! and `Model.__init__` to translate a HuggingFace `model_type = "youtu_vl"`
 //! safetensors checkpoint into a fully-wired [`crate::vision::YoutuVLModel`].
 //!

--- a/src/models/diffusion_gemma/generate.rs
+++ b/src/models/diffusion_gemma/generate.rs
@@ -15,7 +15,7 @@
 //! Block-diffusion generation engine for DiffusionGemma (issue #217).
 //!
 //! Mirrors `stream_diffusion_generate` in
-//! `references/mlx-vlm/mlx_vlm/generate/diffusion.py` for the batch-1,
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/generate/diffusion.py for the batch-1,
 //! no-padding, dynamic-cache CLI case: per block, initialize a random
 //! canvas, denoise it for up to `max_denoising_steps` iterations under a
 //! linear temperature schedule with self-conditioning, accept positions via

--- a/src/models/diffusion_gemma/mod.rs
+++ b/src/models/diffusion_gemma/mod.rs
@@ -27,8 +27,8 @@
 //!   self-conditioning GeGLU module.
 //! * The block-diffusion generation engine lives in [`generate`].
 //!
-//! Reference: `references/mlx-vlm/mlx_vlm/models/diffusion_gemma/` and
-//! `references/mlx-vlm/mlx_vlm/generate/diffusion.py`.
+//! Reference: https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/models/diffusion_gemma and
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/generate/diffusion.py.
 //!
 //! Phase 2 adds image input: when the checkpoint ships the Gemma 4 vision
 //! tower (`model.encoder.vision_tower.*`) and the multimodal embedder

--- a/src/models/gated_delta.rs
+++ b/src/models/gated_delta.rs
@@ -19,7 +19,7 @@
 //!
 //! Used by: Qwen3Next, Qwen3.5, KimiLinear
 //!
-//! Reference: mlx-lm/mlx_lm/models/gated_delta.py
+//! Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/gated_delta.py
 
 use mlxcel_core::utils::{silu, softplus, stack_arrays};
 use mlxcel_core::{MlxArray, UniquePtr, dtype};

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -784,7 +784,7 @@ impl Cache {
 
     /// Per-row tail-zero of the rotating cache for partial-accept rows in a
     /// batched verify pass. Mirrors the Python `hasattr(c, "_idx")` branch in
-    /// `rollback_speculative_cache` (references/mlx-vlm/mlx_vlm/models/gemma4
+    /// `rollback_speculative_cache` (https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4
     /// /language.py lines 637-645):
     ///
     /// ```text
@@ -4129,7 +4129,7 @@ impl Gemma4Wrapper {
     /// Rewind the per-sequence target KV caches after a Gemma 4 MTP
     /// speculative-decoding round. Mirrors the upstream Python
     /// hook
-    /// (`references/mlx-vlm/mlx_vlm/models/gemma4/language.py` lines
+    /// (https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4/language.py lines
     /// 608-646) bit-for-bit:
     ///
     /// 1. `n = max(accepted) + 1`, `trim = block_size - n`.

--- a/src/models/gemma4_mtp_target.rs
+++ b/src/models/gemma4_mtp_target.rs
@@ -332,7 +332,7 @@ impl<'a> Gemma4MtpTargetAdapter<'a> {
     /// At temperature > 0 the caller is expected to override this with
     /// a real sampler; this helper handles only the greedy-parity path
     /// (`temperature == 0`). The MTP greedy-parity invariant
-    /// (referenced in `references/mlx-vlm`) requires the
+    /// (referenced in https://github.com/Blaizzy/mlx-vlm) requires the
     /// target tokens to match the target's own argmax extension, so for
     /// `temperature == 0` this is the load-bearing choice.
     ///

--- a/src/models/glm_moe_dsa.rs
+++ b/src/models/glm_moe_dsa.rs
@@ -18,7 +18,7 @@
 //! The key difference is that GLM MoE DSA uses `rope_parameters` dict
 //! instead of separate `rope_scaling` and `rope_theta` fields.
 //!
-//! Reference: mlx-lm/mlx_lm/models/glm_moe_dsa.py
+//! Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/glm_moe_dsa.py
 
 use crate::models::deepseek_v32::{self, DeepSeekV32Model};
 use mlxcel_core::generate::LanguageModel;

--- a/src/models/jamba.rs
+++ b/src/models/jamba.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Jamba: Hybrid Mamba + Transformer architecture for mlxcel-core
-// Reference: mlx-lm/mlx_lm/models/jamba.py
+// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/jamba.py
 //
 // Key features:
 // - Interleaved Mamba and Attention blocks (configurable pattern)

--- a/src/models/kimi_linear.rs
+++ b/src/models/kimi_linear.rs
@@ -20,7 +20,7 @@
 //! - Sparse MoE with grouped top-k routing (sigmoid/softmax)
 //! - Per-head MultiLinear projections for MLA
 //!
-//! Reference: mlx-lm/mlx_lm/models/kimi_linear.py
+//! Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/kimi_linear.py
 
 use crate::models::gated_delta::{gated_delta_update, scaled_fast_rms_norm_no_weight};
 use crate::models::switch_layers::SwitchGLU;

--- a/src/models/longcat_flash_ngram.rs
+++ b/src/models/longcat_flash_ngram.rs
@@ -21,7 +21,7 @@
 //! - NgramEmbedding with n-gram hash lookups (ngram variant)
 //! - CacheList per layer (2 KVCaches) + ArraysCache for ngram context
 //!
-//! Reference: mlx-lm/mlx_lm/models/longcat_flash.py, longcat_flash_ngram.py
+//! Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/longcat_flash.py, longcat_flash_ngram.py
 
 use crate::models::switch_layers::SwitchGLU;
 use mlxcel_core::dtype;

--- a/src/models/mamba.rs
+++ b/src/models/mamba.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Mamba (v1): SSM-based architecture for mlxcel-core
-// Reference: mlx-lm/mlx_lm/models/mamba.py
+// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/mamba.py
 
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};

--- a/src/models/mamba2.rs
+++ b/src/models/mamba2.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Mamba2: Multi-head SSM-based architecture for mlxcel-core
-// Reference: mlx-lm/mlx_lm/models/mamba2.py
+// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/mamba2.py
 
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{RMSNorm, UnifiedEmbedding, UnifiedLinear};

--- a/src/models/molmo.rs
+++ b/src/models/molmo.rs
@@ -32,7 +32,7 @@
 //! `att_proj` carries a bias (`qkv_bias: true`) and is 4-bit quantized; the
 //! `UnifiedLinear` loader picks up the optional `.bias` automatically.
 //!
-//! Reference: references/mlx-vlm/mlx_vlm/models/molmo/language.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/molmo/language.py
 
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedLinear};

--- a/src/models/molmo2.rs
+++ b/src/models/molmo2.rs
@@ -22,7 +22,7 @@
 //! - Dual embedding: base embedding (151936) + new_embedding (128)
 //! - RoPE theta=5000000
 //!
-//! Reference: references/mlx-vlm/mlx_vlm/models/molmo2/language.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/molmo2/language.py
 
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedLinear};

--- a/src/models/molmo_point.rs
+++ b/src/models/molmo_point.rs
@@ -21,7 +21,7 @@
 //! This module re-exports the Molmo2 text model components and adds the
 //! extended LM head needed for point prediction.
 //!
-//! Reference: references/mlx-vlm/mlx_vlm/models/molmo_point/language.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/molmo_point/language.py
 
 use mlxcel_core::layers::KVCache;
 use mlxcel_core::weights::WeightMap;

--- a/src/models/nemotron.rs
+++ b/src/models/nemotron.rs
@@ -14,7 +14,7 @@
 
 //! Nemotron model implementation using mlxcel-core
 //!
-//! Reference: mlx-lm/mlx_lm/models/nemotron.py
+//! Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/nemotron.py
 //!
 //! Key features:
 //! - NemotronLayerNorm1P: uses (weight + 1) instead of just weight

--- a/src/models/nemotron_h.rs
+++ b/src/models/nemotron_h.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Nemotron-H: NVIDIA's hybrid Mamba2+Transformer model for mlxcel-core
-// Reference: mlx-lm/mlx_lm/models/nemotron_h.py
+// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/nemotron_h.py
 //
 // Key features:
 // - Hybrid architecture with configurable block types (M/*/−/E)
@@ -231,7 +231,7 @@ pub struct NemotronHConfig {
     pub quantization: Option<Quantization>,
 
     /// Softplus initialization bounds retained for config-schema parity with
-    /// upstream `mlx_lm/models/nemotron_h.py`. They do NOT participate in the
+    /// upstream https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/nemotron_h.py. They do NOT participate in the
     /// `time_step_limit` default (which is always `(0.0, +inf)` when absent;
     /// see upstream PR #1026 / commit `6ddfdda`).
     #[serde(default)]

--- a/src/models/nemotron_nas.rs
+++ b/src/models/nemotron_nas.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Nemotron-NAS: NVIDIA's Neural Architecture Search model for mlxcel-core
-// Reference: mlx-lm/mlx_lm/models/nemotron-nas.py
+// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/nemotron-nas.py
 //
 // Key features:
 // - Per-layer configuration via block_configs (AttentionConfig, FFNConfig)

--- a/src/models/qwen2_vl.rs
+++ b/src/models/qwen2_vl.rs
@@ -18,7 +18,7 @@
 //! MRoPE uses 3D position IDs [T, H, W] for encoding spatial structure of vision tokens.
 //!
 //! Used by: Qwen2-VL
-//! Reference: references/mlx-vlm/mlx_vlm/models/qwen2_vl/language.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen2_vl/language.py
 
 use crate::models::qwen_mrope_state::MRopeState;
 use mlxcel_core::cache::SequenceId;

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -23,7 +23,7 @@
 //!
 //! Reuses from qwen3_next: Qwen3NextAttention, MLP, SparseMoeBlock, SwitchGLU, SwitchLinear
 //!
-//! Reference: mlx-lm/mlx_lm/models/qwen3_5.py
+//! Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/qwen3_5.py
 
 use crate::distributed::pipeline::LayerFilter;
 use crate::distributed::pipeline::StageExecutionOutput;
@@ -461,7 +461,7 @@ impl Qwen35GatedDeltaNet {
     /// per-layer snapshot suitable for `rollback_speculative_cache`.
     ///
     /// Mirrors the `gdn_sink` parameter in upstream
-    /// `mlx-vlm/mlx_vlm/models/qwen3_5/language.py:Qwen3_5GatedDeltaNet`
+    /// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen3_5/language.py (Qwen3_5GatedDeltaNet)
     /// The snapshot is captured *before* `gated_delta_update`
     /// runs, holding the same per-step inputs and the pre-block recurrent
     /// state — exactly what is needed to replay the block over a truncated
@@ -1061,7 +1061,7 @@ pub struct GdnRollbackSnapshot {
 /// `5 * hidden_size`-wide projection input. The `gdn_states` vector is ordered
 /// by layer index over linear-attention layers only (skipping full-attention
 /// layers), matching the per-position correspondence used by upstream
-/// `rollback_speculative_cache` in `mlx-vlm/mlx_vlm/models/qwen3_5/language.py`.
+/// `rollback_speculative_cache` in https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen3_5/language.py.
 ///
 /// Used by: DFlash round loop (sub-12), `Qwen35Model::rollback_speculative_cache`
 pub struct VerifyOutput {
@@ -1574,7 +1574,7 @@ impl Qwen35Model {
     ///
     /// This is the verify-pass hot path consumed by the DFlash drafter
     /// round loop (sub-12). It mirrors upstream
-    /// `mlx-vlm/mlx_vlm/models/qwen3_5/language.py::LanguageModel.__call__`
+    /// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen3_5/language.py (LanguageModel.__call__)
     /// when called with `capture_layer_ids` set, with two changes:
     ///   1. `return_hidden` is implied by `capture_layer_ids.is_some()` —
     ///      the upstream `return_hidden` flag is redundant on Qwen 3.5 since
@@ -1676,7 +1676,7 @@ impl Qwen35Model {
     /// position of the last accepted token after a DFlash verify-pass block.
     ///
     /// Mirrors upstream
-    /// `mlx-vlm/mlx_vlm/models/qwen3_5/language.py::LanguageModel.rollback_speculative_cache`
+    /// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen3_5/language.py (LanguageModel.rollback_speculative_cache)
     /// Returns `max(accepted)`.
     ///
     /// Arguments:

--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -23,7 +23,7 @@
 //! - Gated output in attention blocks (sigmoid gating)
 //! - Q/K normalization
 //!
-//! Reference: mlx-lm/mlx_lm/models/qwen3_next.py
+//! Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/qwen3_next.py
 
 #[path = "qwen3_next_helpers.rs"]
 mod helpers;
@@ -537,7 +537,7 @@ impl Qwen3NextAttention {
     /// scaled-dot-product attention through the per-query-position causal
     /// loop in [`Self::forward_hidden_with_position_ids_verify`], mirroring
     /// upstream `Qwen3_5Attention.__call__`'s `target_verify and L > 1`
-    /// branch (`mlx-vlm/mlx_vlm/models/qwen3_5/language.py`). This eliminates
+    /// branch (https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen3_5/language.py). This eliminates
     /// the batched-SDPA-vs-decode logit drift that flips speculative
     /// accept/reject decisions away from the drafter-less greedy pass.
     ///
@@ -720,7 +720,7 @@ impl Qwen3NextAttention {
     /// axis into `[B, H, L_q, D]`.
     ///
     /// Faithful port of upstream
-    /// `mlx-vlm/mlx_vlm/models/qwen3_5/language.py::Qwen3_5Attention.__call__`
+    /// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen3_5/language.py (Qwen3_5Attention.__call__)
     /// (`target_verify and L > 1` branch). This is the load-bearing fix for
     /// Qwen 3.5 MTP verification drift / sampling parity.
     fn attend_per_position(

--- a/src/models/qwen3_vl.rs
+++ b/src/models/qwen3_vl.rs
@@ -21,7 +21,7 @@
 //! - DeepStack visual feature injection in decoder layers
 //!
 //! Used by: Qwen3-VL
-//! Reference: references/mlx-vlm/mlx_vlm/models/qwen3_vl/language.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen3_vl/language.py
 
 use crate::models::qwen_mrope_state::MRopeState;
 use mlxcel_core::cache::SequenceId;

--- a/src/models/qwen3_vl_moe.rs
+++ b/src/models/qwen3_vl_moe.rs
@@ -25,7 +25,7 @@
 //! - mlp_only_layers: explicit list of dense layers
 //!
 //! Used by: Qwen3-VL-MoE
-//! Reference: references/mlx-vlm/mlx_vlm/models/qwen3_vl_moe/language.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen3_vl_moe/language.py
 
 use crate::models::qwen_mrope_state::MRopeState;
 use mlxcel_core::cache::SequenceId;

--- a/src/models/recurrent_gemma.rs
+++ b/src/models/recurrent_gemma.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Griffin (RecurrentGemma): Hybrid Mamba + Local Attention architecture for mlxcel-core
-// Reference: mlx-lm/mlx_lm/models/recurrent_gemma.py
+// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/recurrent_gemma.py
 //
 // Key features:
 // - Hybrid architecture with both recurrent (RGLRU) and local attention blocks

--- a/src/models/rwkv7.rs
+++ b/src/models/rwkv7.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // RWKV7: Recurrent neural network with time mixing and channel mixing
-// Reference: mlx-lm/mlx_lm/models/rwkv7.py
+// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/rwkv7.py
 
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{RMSNorm, UnifiedEmbedding, UnifiedLinear};

--- a/src/models/solar_open.rs
+++ b/src/models/solar_open.rs
@@ -22,7 +22,7 @@
 //! - 2 RMSNorm layers per block (input_layernorm, post_attention_layernorm)
 //! - Separate gate_proj/up_proj for experts (not fused gate_up_proj)
 //!
-//! Architecture reference: references/mlx-lm/mlx_lm/models/glm4_moe.py
+//! Architecture reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/glm4_moe.py
 //! Weight format: supports both MLX native and GPTQ (auto_round) quantization
 
 use mlxcel_core::generate::LanguageModel;

--- a/src/models/youtu_vl_lm.rs
+++ b/src/models/youtu_vl_lm.rs
@@ -14,7 +14,7 @@
 
 //! Youtu-VL language model (text backbone).
 //!
-//! Faithful port of `references/mlx-vlm/mlx_vlm/models/youtu_vl/language.py`.
+//! Faithful port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/youtu_vl/language.py.
 //!
 //! Architecture summary:
 //! - Multi-Latent Attention (MLA) — identical to DeepSeek-V3's MLA layout

--- a/src/models/youtu_vl_lm_config.rs
+++ b/src/models/youtu_vl_lm_config.rs
@@ -25,7 +25,7 @@ use crate::models::deepseek_v3;
 
 /// Youtu-VL text-side configuration.
 ///
-/// Mirrors `references/mlx-vlm/mlx_vlm/models/youtu_vl/config.py::TextConfig`.
+/// Mirrors https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/youtu_vl/config.py (TextConfig).
 /// MoE-related fields are kept for forward compatibility with possible larger
 /// variants but are not exercised by the standard `youtu_vl` checkpoint.
 #[derive(Debug, Clone, Deserialize)]

--- a/src/multimodal/video.rs
+++ b/src/multimodal/video.rs
@@ -14,7 +14,7 @@
 
 //! Generic VLM video utilities (perf follow-up).
 //!
-//! Translates the upstream Python `mlx_vlm/video_generate.py` pipeline into
+//! Translates the upstream Python https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/video_generate.py pipeline into
 //! Rust so that any vision-language model can accept `--video` inputs through
 //! the same code path used by `--image`. The module is intentionally
 //! decoder-agnostic at the Rust level: frame extraction is delegated to the

--- a/src/server/batch/scheduler_tests.rs
+++ b/src/server/batch/scheduler_tests.rs
@@ -982,7 +982,7 @@ fn compose_prompt_cache_key_folds_request_multimodal_digest() {
 // Null / empty-cache safety tests
 //
 // These tests cover the same transition edges that upstream mlx-lm
-// landed null-guards for in `mlx_lm/models/cache.py`:
+// landed null-guards for in https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/cache.py:
 //
 //   - `BatchKVCache.extend`: both inputs empty (offset == 0, no keys).
 //   - `BatchKVCache.extend`: one input empty, one populated.

--- a/src/vision/connectors/avg_pool.rs
+++ b/src/vision/connectors/avg_pool.rs
@@ -14,7 +14,7 @@
 
 //! Gemma3 AvgPool Multi-Modal Projector
 //!
-//! Port of references/mlx-vlm/mlx_vlm/models/gemma3/gemma3.py:13-51
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma3/gemma3.py#L13-L51
 //!
 //! Architecture:
 //! 1. Reshape + transpose vision features to spatial grid

--- a/src/vision/connectors/aya_vision.rs
+++ b/src/vision/connectors/aya_vision.rs
@@ -14,7 +14,7 @@
 
 //! Aya Vision Multi-Modal Projector (SwiGLU + PixelShuffle + LayerNorm)
 //!
-//! Port of references/mlx-vlm/mlx_vlm/models/aya_vision/aya_vision.py:AyaVisionMultiModalProjector
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/aya_vision/aya_vision.py (AyaVisionMultiModalProjector)
 //!
 //! Architecture:
 //!   pixel_shuffle(x) → LayerNorm → Linear(in, mid) → split → SiLU(gate) * x → Linear(mid/2, out)

--- a/src/vision/connectors/linear.rs
+++ b/src/vision/connectors/linear.rs
@@ -14,7 +14,7 @@
 
 //! Linear Multi-Modal Projector (single linear layer, no activation, no bias)
 //!
-//! Port of references/mlx-vlm/mlx_vlm/models/llama4/vision.py:Llama4MultiModalProjector
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/llama4/vision.py (Llama4MultiModalProjector)
 //!
 //! Architecture: Linear(vision_output_dim → text_hidden_size, bias=False)
 //!

--- a/src/vision/connectors/mistral3.rs
+++ b/src/vision/connectors/mistral3.rs
@@ -14,7 +14,7 @@
 
 //! Mistral 3 Multi-Modal Projector
 //!
-//! Port of references/mlx-vlm/mlx_vlm/models/mistral3/mistral3.py
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/mistral3/mistral3.py
 //!
 //! Architecture: RMSNorm → PatchMerger(unfold 2×2, Linear(4*D→D)) → Linear(D→H) → GELU → Linear(H→H)
 //!

--- a/src/vision/connectors/mlp.rs
+++ b/src/vision/connectors/mlp.rs
@@ -14,7 +14,7 @@
 
 //! LLaVA MLP Multi-Modal Projector
 //!
-//! Port of references/mlx-vlm/mlx_vlm/models/llava/llava.py:13-28
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/llava/llava.py#L13-L28
 //!
 //! Architecture: Linear(vision_hidden → text_hidden) → GELU → Linear(text_hidden → text_hidden)
 //!

--- a/src/vision/detection/rt_detr_v2/backbone.rs
+++ b/src/vision/detection/rt_detr_v2/backbone.rs
@@ -15,7 +15,7 @@
 //! ResNet-50-vd / ResNet-101-vd backbone for RT-DETRv2.
 //!
 //! Port of the backbone half of
-//! `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/vision.py`. Returns features at
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/rt_detr_v2/vision.py. Returns features at
 //! the strides selected by `out_features` (default stages 2/3/4 -> strides
 //! 8/16/32). The `vd` variant uses a 3-conv stem + 3x3 stride-2 maxpool and
 //! AvgPool-based downsampling shortcuts.

--- a/src/vision/detection/rt_detr_v2/config.rs
+++ b/src/vision/detection/rt_detr_v2/config.rs
@@ -17,7 +17,7 @@
 //! Mirrors the HuggingFace `RTDetrV2Config` schema
 //! (`transformers.models.rt_detr_v2.configuration_rt_detr_v2`) and the
 //! upstream mlx-vlm port in
-//! `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/config.py`. The HF
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/rt_detr_v2/config.py. The HF
 //! `config.json` stores backbone / hybrid-encoder / decoder fields flat at
 //! the top level; this module parses them into one [`RtDetrV2Config`] and
 //! exposes typed sub-views (`backbone()`, `encoder()`, `transformer()`).

--- a/src/vision/detection/rt_detr_v2/hybrid_encoder.rs
+++ b/src/vision/detection/rt_detr_v2/hybrid_encoder.rs
@@ -16,7 +16,7 @@
 //! FPN, bottom-up PAN.
 //!
 //! Port of the hybrid-encoder half of
-//! `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/vision.py`. All feature maps
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/rt_detr_v2/vision.py. All feature maps
 //! are NHWC. Output is `num_levels` feature maps at the original strides, all
 //! with `encoder_hidden_dim` channels.
 

--- a/src/vision/detection/rt_detr_v2/layers.rs
+++ b/src/vision/detection/rt_detr_v2/layers.rs
@@ -21,7 +21,7 @@
 //! `grid_sample` follows PyTorch `mode="bilinear", padding_mode="zeros",
 //! align_corners=False`, the exact semantics the upstream Metal kernel and its
 //! pure-MLX fallback implement (see
-//! `references/mlx-vlm/mlx_vlm/models/kernels.py::grid_sample`).
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/kernels.py (grid_sample)).
 
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
@@ -246,7 +246,7 @@ pub fn max_pool2d(x: &MlxArray, kernel: i32, stride: i32, pad: i32) -> UniquePtr
 
 /// Nearest-neighbour 2x upsample of an NHWC tensor along H and W.
 ///
-/// Matches `references/.../vision.py::_upsample_nearest_2x`:
+/// Matches https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/rt_detr_v2/vision.py (_upsample_nearest_2x):
 /// `broadcast x[:, :, None, :, None, :] -> (B, H, 2, W, 2, C)` then reshape.
 pub fn upsample_nearest_2x(x: &MlxArray) -> UniquePtr<MlxArray> {
     let shape = mlxcel_core::array_shape(x);
@@ -266,7 +266,7 @@ pub fn upsample_nearest_2x(x: &MlxArray) -> UniquePtr<MlxArray> {
 ///
 /// Returns `(B, gN, gM, C)`. This is a faithful Rust port of the pure-MLX
 /// fallback `_grid_sample_mlx` in
-/// `references/mlx-vlm/mlx_vlm/models/kernels.py`, which is numerically
+/// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/kernels.py, which is numerically
 /// identical to the upstream Metal kernel.
 pub fn grid_sample(x: &MlxArray, grid: &MlxArray) -> UniquePtr<MlxArray> {
     let xs = mlxcel_core::array_shape(x);

--- a/src/vision/detection/rt_detr_v2/mod.rs
+++ b/src/vision/detection/rt_detr_v2/mod.rs
@@ -15,7 +15,7 @@
 //! RT-DETRv2 real-time object-detection model.
 //!
 //! A full Rust port of the upstream mlx-vlm RT-DETRv2 model (PR #1195,
-//! `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/`). Architecture:
+//! https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/models/rt_detr_v2). Architecture:
 //!
 //! ```text
 //! Image (NHWC) -> ResNet-50/101-vd backbone (strides 8/16/32)

--- a/src/vision/detection/rt_detr_v2/model.rs
+++ b/src/vision/detection/rt_detr_v2/model.rs
@@ -16,7 +16,7 @@
 //! per-level decoder input projection -> encoder query selection -> deformable
 //! decoder.
 //!
-//! Port of `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/rt_detr_v2.py`.
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/rt_detr_v2/rt_detr_v2.py.
 
 use std::path::Path;
 

--- a/src/vision/detection/rt_detr_v2/predictor.rs
+++ b/src/vision/detection/rt_detr_v2/predictor.rs
@@ -14,7 +14,7 @@
 
 //! RT-DETRv2 postprocessing and predictor.
 //!
-//! Port of `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/generate.py`. The
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/rt_detr_v2/generate.py. The
 //! predictor runs the model on one image and decodes detections: it does a flat
 //! top-K over the `(queries x labels)` score space (so one query can yield
 //! multiple detections — matching `RTDetrImageProcessor.post_process_object_

--- a/src/vision/detection/rt_detr_v2/processor.rs
+++ b/src/vision/detection/rt_detr_v2/processor.rs
@@ -14,7 +14,7 @@
 
 //! RT-DETRv2 image preprocessing.
 //!
-//! Port of `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/processing_rt_detr_v2.py`:
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/rt_detr_v2/processing_rt_detr_v2.py:
 //! resize to `image_size` (bilinear), rescale by `rescale_factor` (1/255), and
 //! optionally normalize with `image_mean` / `image_std`. The default
 //! RT-DETRv2 preprocessor does NOT normalize (`do_normalize: false`); silently

--- a/src/vision/detection/rt_detr_v2/sanitize.rs
+++ b/src/vision/detection/rt_detr_v2/sanitize.rs
@@ -15,7 +15,7 @@
 //! HuggingFace -> MLX weight-key translation for RT-DETRv2.
 //!
 //! Mirrors the rename pipeline in
-//! `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/convert.py` (the single
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/rt_detr_v2/convert.py (the single
 //! source of truth upstream). Two transformations are applied per key:
 //!
 //!   1. Name rewrite: strip the `model.` prefix, then apply submodule-specific

--- a/src/vision/detection/rt_detr_v2/transformer.rs
+++ b/src/vision/detection/rt_detr_v2/transformer.rs
@@ -15,7 +15,7 @@
 //! RT-DETRv2 transformer: deformable-attention decoder, MLP heads, and the
 //! anchor priors used by encoder query selection.
 //!
-//! Port of `references/mlx-vlm/mlx_vlm/models/rt_detr_v2/transformer.py`.
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/rt_detr_v2/transformer.py.
 //! Multi-scale deformable attention samples each feature level via the shared
 //! bilinear `grid_sample` (see [`super::layers::grid_sample`]) and weighted-sums
 //! across levels with the softmaxed attention weights.

--- a/src/vision/encoders/gemma3n.rs
+++ b/src/vision/encoders/gemma3n.rs
@@ -21,7 +21,7 @@
 //!
 //! All spatial operations use NHWC layout (channels-last).
 //!
-//! Reference: references/mlx-vlm/mlx_vlm/models/gemma3n/vision.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma3n/vision.py
 
 #[path = "gemma3n_helpers.rs"]
 mod helpers;

--- a/src/vision/encoders/internvl.rs
+++ b/src/vision/encoders/internvl.rs
@@ -15,7 +15,7 @@
 //! InternViT Vision Encoder (InternVL family).
 //!
 //! Faithful port of
-//! `references/mlx-vlm/mlx_vlm/models/internvl_chat/vision.py`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/internvl_chat/vision.py.
 //!
 //! Architecture (per `vision_model.*` in `internvl3-1b`):
 //! - `VisionEmbeddings`: Conv2d patch embedding (3 -> hidden, k=14, s=14) +

--- a/src/vision/encoders/llama4.rs
+++ b/src/vision/encoders/llama4.rs
@@ -14,7 +14,7 @@
 
 //! Llama 4 Vision Encoder
 //!
-//! Port of references/mlx-vlm/mlx_vlm/models/llama4/vision.py
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/llama4/vision.py
 //!
 //! Architecture:
 //! - UnfoldConvolution (im2col patch embedding, not Conv2d)

--- a/src/vision/encoders/molmo.rs
+++ b/src/vision/encoders/molmo.rs
@@ -32,7 +32,7 @@
 //! This implementation targets the single-image / single-crop-batch inference
 //! path used by the CLI and server (`batch=1`).
 //!
-//! Reference: references/mlx-vlm/mlx_vlm/models/molmo/vision.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/molmo/vision.py
 
 use mlxcel_core::layers::{LayerNorm, Linear, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;

--- a/src/vision/encoders/molmo2.rs
+++ b/src/vision/encoders/molmo2.rs
@@ -20,7 +20,7 @@
 //! - Adapter: Attention pooling 2D + SwiGLU image projector
 //! - Layer selection: [-3, -9] = [22, 16] → concatenate → pool_dim = 2*1152
 //!
-//! Reference: references/mlx-vlm/mlx_vlm/models/molmo2/vision.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/molmo2/vision.py
 
 use mlxcel_core::layers::{LayerNorm, Linear};
 use mlxcel_core::weights::WeightMap;

--- a/src/vision/encoders/molmo_point.rs
+++ b/src/vision/encoders/molmo_point.rs
@@ -21,7 +21,7 @@
 //!   - MolmoPointPatchRope: 1D rotary for patch embeddings
 //!   - PadWithLearnedVector: "no more points" class embedding
 //!
-//! Reference: references/mlx-vlm/mlx_vlm/models/molmo_point/molmo_point.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/molmo_point/molmo_point.py
 
 use mlxcel_core::layers::Linear;
 use mlxcel_core::utils::slice_axis;

--- a/src/vision/encoders/nemotron_h_nano_omni.rs
+++ b/src/vision/encoders/nemotron_h_nano_omni.rs
@@ -15,7 +15,7 @@
 //! Nemotron H Nano Omni vision tower (RADIO v2.5-H).
 //!
 //! Faithful Rust port of
-//! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/vision.py`
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/vision.py
 //! (vision-only scope). The encoder is a Vision Transformer
 //! with NVIDIA's RADIO patch generator: a learned `[CLS]` token (with
 //! optional teacher-tied registers), a 1D learned positional embedding,
@@ -492,7 +492,7 @@ impl ViTPatchGenerator {
     /// `[batch, patch_h * patch_w, embed_dim]`.
     ///
     /// Mirrors upstream `_get_pos_embeddings` from
-    /// `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/vision.py`:
+    /// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/vision.py:
     /// 1. Fast path when runtime grid matches the stored table (no resize).
     /// 2. CPE mode: bilinear resize the (num_rows, num_cols) table to
     ///    (max_dim, max_dim) where `max_dim = max(patch_h, patch_w)`, then

--- a/src/vision/encoders/pixtral.rs
+++ b/src/vision/encoders/pixtral.rs
@@ -15,7 +15,7 @@
 //! Pixtral Vision Encoder
 //!
 //! Custom ViT with 2D RoPE and SwiGLU MLP for Mistral's Pixtral VLM.
-//! Port of references/mlx-vlm/mlx_vlm/models/pixtral/vision.py
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/pixtral/vision.py
 //!
 //! Architecture:
 //!   patch_conv (Conv2d, stride=patch_size) → ln_pre (RMSNorm)

--- a/src/vision/encoders/qwen2_5_vl.rs
+++ b/src/vision/encoders/qwen2_5_vl.rs
@@ -21,7 +21,7 @@
 //! - PatchMerger with RMSNorm
 //!
 //! Used by: Qwen2.5-VL
-//! Reference: references/mlx-vlm/mlx_vlm/models/qwen2_5_vl/vision.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen2_5_vl/vision.py
 
 use super::VisionEncoderOutput;
 use super::qwen2_vl::{VisionRotaryEmbedding, apply_rotary_pos_emb_vision, concat_many};

--- a/src/vision/encoders/qwen2_vl.rs
+++ b/src/vision/encoders/qwen2_vl.rs
@@ -21,7 +21,7 @@
 //! - PatchMerger for spatial downsampling + projection to text hidden size
 //!
 //! Used by: Qwen2-VL
-//! Reference: references/mlx-vlm/mlx_vlm/models/qwen2_vl/vision.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen2_vl/vision.py
 
 use super::VisionEncoderOutput;
 use mlxcel_core::layers::{LayerNorm, UnifiedLinear};

--- a/src/vision/encoders/qwen3_vl.rs
+++ b/src/vision/encoders/qwen3_vl.rs
@@ -23,7 +23,7 @@
 //! - Fused SDPA head-dim padding to match upstream MLX kernel preferences
 //!
 //! Used by: Qwen3-VL
-//! Reference: references/mlx-vlm/mlx_vlm/models/qwen3_vl/vision.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen3_vl/vision.py
 
 use super::qwen2_vl::{VisionRotaryEmbedding, apply_rotary_pos_emb_vision, concat_many};
 use mlxcel_core::layers::{LayerNorm, UnifiedLinear};

--- a/src/vision/encoders/siglip.rs
+++ b/src/vision/encoders/siglip.rs
@@ -15,7 +15,7 @@
 //! SigLIP/CLIP Vision Encoder
 //!
 //! Unified vision encoder supporting both SigLIP and CLIP architectures.
-//! Port of references/mlx-vlm/mlx_vlm/models/llava/vision.py
+//! Port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/llava/vision.py
 //!
 //! Architecture: VisionEmbeddings → [pre_layrnorm] → Encoder (N × EncoderLayer) → post_layernorm
 //! - VisionEmbeddings: Conv2d patch embedding + learned position embedding [+ CLS token for CLIP]

--- a/src/vision/encoders/youtu_vl.rs
+++ b/src/vision/encoders/youtu_vl.rs
@@ -14,7 +14,7 @@
 
 //! Youtu-VL vision encoder.
 //!
-//! Faithful port of `references/mlx-vlm/mlx_vlm/models/youtu_vl/vision.py`.
+//! Faithful port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/youtu_vl/vision.py.
 //!
 //! Architecture:
 //! - `embeddings.patch_embedding`: Linear projection over flattened patches
@@ -61,7 +61,7 @@ use rope::VisionRoPE;
 
 /// Youtu-VL vision encoder configuration.
 ///
-/// Mirrors `references/mlx-vlm/mlx_vlm/models/youtu_vl/config.py::VisionConfig`.
+/// Mirrors https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/youtu_vl/config.py (VisionConfig).
 #[derive(Debug, Clone, Deserialize)]
 pub struct YoutuVisionConfig {
     #[serde(default = "default_model_type")]

--- a/src/vision/gemma4_vl.rs
+++ b/src/vision/gemma4_vl.rs
@@ -412,7 +412,7 @@ impl Gemma4VLModel {
     /// subsequent speculative decode steps consume `input_ids` only and
     /// must pass `input_embeddings = None` exactly like the text-only
     /// case. Mirrors the `gemma4_vl.py` __call__ → text_model.__call__
-    /// flow in `references/mlx-vlm`.
+    /// flow in https://github.com/Blaizzy/mlx-vlm.
     ///
     /// Used by: future Gemma 4 VLM MTP consumer.
     ///

--- a/src/vision/internvl.rs
+++ b/src/vision/internvl.rs
@@ -15,7 +15,7 @@
 //! InternVL (`internvl_chat`) Vision-Language Model.
 //!
 //! Faithful port of
-//! `references/mlx-vlm/mlx_vlm/models/internvl_chat/internvl_chat.py`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/internvl_chat/internvl_chat.py.
 //!
 //! Composition (for `internvl3-1b`):
 //! - `vision_model` — [`InternVitVisionModel`] (non-quantized bf16, converted
@@ -111,7 +111,7 @@ impl InternVLConnector {
 }
 
 /// Pixel shuffle (spatial -> channel) port of
-/// `references/mlx-vlm/mlx_vlm/models/base.py:311-333`.
+/// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/base.py#L311-L333.
 ///
 /// Input `x`: `[B, N, C]` where `N = p*p` is a square patch grid.
 /// Output: `[B, N*r^2, C/r^2]` (for the default `r = 0.5`, `[B, 4N, C*4]`).

--- a/src/vision/merge.rs
+++ b/src/vision/merge.rs
@@ -30,8 +30,8 @@
 //!   (`0.0` at attended positions, `f32::MIN` at masked positions)
 //! - LLaVA-style merge keeps standard causal masking and returns `None`
 //!
-//! Reference: references/mlx-vlm/mlx_vlm/models/gemma3/gemma3.py:121-168
-//! Reference: references/mlx-vlm/mlx_vlm/models/llava/llava.py:85-111
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma3/gemma3.py#L121-L168
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/llava/llava.py#L85-L111
 
 use mlxcel_core::{MlxArray, UniquePtr};
 

--- a/src/vision/nemotron_h_nano_omni_vl.rs
+++ b/src/vision/nemotron_h_nano_omni_vl.rs
@@ -15,7 +15,7 @@
 //! Nemotron H Nano Omni vision-language model wrapper.
 //!
 //! Faithful Rust port of the multimodal path in
-//! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/nemotron_h_nano_omni.py.
 //! Composes:
 //! - the existing Nemotron-H text backbone
 //!   ([`crate::models::NemotronHModel`])
@@ -507,7 +507,7 @@ impl LanguageModel for NemotronHNanoOmniVlModel {
 /// Apply N stages of upstream `_get_output_length` (same kernel/stride
 /// per stage) on an int32 length tensor. Mirrors
 /// `_get_subsampling_output_length` from
-/// `references/.../nemotron_h_nano_omni/audio.py`.
+/// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/audio.py.
 fn subsampling_output_lengths(
     lengths: &MlxArray,
     kernel_size: i32,

--- a/src/vision/processors/gemma4.rs
+++ b/src/vision/processors/gemma4.rs
@@ -16,7 +16,7 @@
 //!
 //! Used by: Gemma4 VLM
 //!
-//! The image side mirrors `references/mlx-vlm/mlx_vlm/models/gemma4/processing_gemma4.py
+//! The image side mirrors https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4/processing_gemma4.py
 //! :Gemma4ImageProcessor`. The video side ([`process_videos`] +
 //! [`Gemma4VideoFeatures`]) mirrors `Gemma4VideoProcessor` from the
 //! same file: per-frame uniform sampling, aspect-ratio-preserving resize

--- a/src/vision/processors/internvl.rs
+++ b/src/vision/processors/internvl.rs
@@ -15,7 +15,7 @@
 //! InternVL (`internvl_chat`) image processor.
 //!
 //! Faithful port of
-//! `references/mlx-vlm/mlx_vlm/models/internvl_chat/processor.py`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/internvl_chat/processor.py.
 //!
 //! Dynamic tiling:
 //! 1. Pick the target aspect ratio (i, j) with `min_dynamic_patch <= i*j <=

--- a/src/vision/processors/molmo.rs
+++ b/src/vision/processors/molmo.rs
@@ -14,7 +14,7 @@
 
 //! Molmo v1 Image Processor.
 //!
-//! Mirrors `references/mlx-vlm/mlx_vlm/models/molmo/processing_molmo.py`:
+//! Mirrors https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/molmo/processing_molmo.py:
 //! a single global (resized) image plus overlapping high-res crops selected by
 //! `select_tiling`, each rearranged into 14x14 patches. It also produces the
 //! `image_input_idx` array (where each image patch's pooled feature lands in the

--- a/src/vision/processors/molmo2.rs
+++ b/src/vision/processors/molmo2.rs
@@ -20,7 +20,7 @@
 //! 3. Combine: [low_res, hi_res_crops...] → flatten to patches
 //! 4. Build pooling indices for 2D attention pooling
 //!
-//! Reference: references/mlx-vlm/mlx_vlm/models/molmo2/processing.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/molmo2/processing.py
 
 /// Molmo2 image processor configuration and state
 pub struct Molmo2Processor {

--- a/src/vision/processors/molmo_point.rs
+++ b/src/vision/processors/molmo_point.rs
@@ -18,7 +18,7 @@
 //! multi-scale overlapping crop preprocessing with the same parameters.
 //! This module re-exports the Molmo2 processor directly.
 //!
-//! Reference: references/mlx-vlm/mlx_vlm/models/molmo_point/image_processing.py
+//! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/molmo_point/image_processing.py
 
 /// Molmo-Point uses the same image processor as Molmo2.
 /// Re-export for clarity in the loading code.

--- a/src/vision/processors/nemotron_h_nano_omni.rs
+++ b/src/vision/processors/nemotron_h_nano_omni.rs
@@ -15,7 +15,7 @@
 //! Nemotron H Nano Omni image preprocessor.
 //!
 //! Faithful Rust port of
-//! `references/mlx-vlm/mlx_vlm/models/nemotron_h_nano_omni/image_processing_nemotron_h_nano_omni.py`.
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/nemotron_h_nano_omni/image_processing_nemotron_h_nano_omni.py.
 //! Produces channel-first `[1, 3, H, W]` float32 tensors normalized with the
 //! checkpoint-supplied mean/std, plus the pre-downsample patch grid that
 //! the multimodal projector uses to compute per-image token counts.

--- a/src/vision/processors/youtu_vl.rs
+++ b/src/vision/processors/youtu_vl.rs
@@ -14,8 +14,9 @@
 
 //! Youtu-VL image processor.
 //!
-//! Mirrors the contract that upstream `references/mlx-vlm/mlx_vlm/models/
-//! youtu_vl/vision.py::VisionModel.__call__` expects:
+//! Mirrors the contract that upstream
+//! https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/youtu_vl/vision.py
+//! (VisionModel.__call__) expects:
 //! - `pixel_values`: `[total_patches, patch_size**2 * channels]` flattened
 //!   patches, normalized with SigLIP statistics.
 //! - `spatial_shapes`: `[N, 2]` of `(h_patches, w_patches)` per image (no

--- a/src/vision/youtu_vl.rs
+++ b/src/vision/youtu_vl.rs
@@ -14,7 +14,7 @@
 
 //! Youtu-VL Vision-Language Model.
 //!
-//! Faithful port of `references/mlx-vlm/mlx_vlm/models/youtu_vl/youtu_vl.py`.
+//! Faithful port of https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/youtu_vl/youtu_vl.py.
 //!
 //! Composition:
 //! - `vision_tower` — `YoutuVLVisionEncoder` (SigLIP2-style with windowed

--- a/tests/fixtures/turbo_codebooks/generate_fixtures.py
+++ b/tests/fixtures/turbo_codebooks/generate_fixtures.py
@@ -28,7 +28,7 @@ from scipy import stats
 
 
 # ---------------------------------------------------------------------------
-# Reference implementation (verbatim from references/turboquant_plus/turboquant/codebook.py)
+# Reference implementation (verbatim from turboquant_plus/turboquant/codebook.py)
 # ---------------------------------------------------------------------------
 
 def optimal_centroids(bit_width: int, d: int) -> np.ndarray:

--- a/tests/fixtures/turbo_codebooks/generate_fixtures.py
+++ b/tests/fixtures/turbo_codebooks/generate_fixtures.py
@@ -28,7 +28,7 @@ from scipy import stats
 
 
 # ---------------------------------------------------------------------------
-# Reference implementation (verbatim from turboquant_plus/turboquant/codebook.py)
+# Reference implementation (verbatim from https://github.com/TheTom/turboquant_plus/blob/main/turboquant/codebook.py)
 # ---------------------------------------------------------------------------
 
 def optimal_centroids(bit_width: int, d: int) -> np.ndarray:


### PR DESCRIPTION
Closes #221

## Summary

mlxcel reuses third-party code that requires attribution under its license, but the repository carried no such attribution. This PR adds it. It covers two cases:

- **turboquant_plus** (Apache-2.0, Copyright 2026 Tom Turney): the TurboQuant KV cache under `src/lib/mlxcel-core/src/cache/turbo/` is a documented Rust port. This is the original scope of issue #221.
- **mlx-lm** (MIT, Copyright 2023 Apple Inc.) and **mlx-vlm** (MIT, Copyright 2025 Prince Canuma): mlxcel ports and mirrors model architectures, tokenizer handling, the batch scheduler, and server API translators from these projects across many files. MIT requires retaining the copyright and permission notices in substantial portions; the repo previously listed them only as a courtesy acknowledgment.

## Changes

- Add a top-level `NOTICE` file (the repository had none) with a "Third-party attributions" section:
  - turboquant_plus: states the derivation and carries forward the upstream Apache-2.0 NOTICE verbatim per Section 4(d).
  - mlx-lm + mlx-vlm: a grouped MIT block that names both projects and reproduces the MIT copyright and permission/warranty notice verbatim.
- Add a per-file derivation line alongside the existing Lablup header in the 8 ported `turbo/` sources (`codebook.rs`, `mod.rs`, `quant.rs`, `quant3.rs`, `pack3.rs`, `boundary.rs`, `allowlist.rs`, `sparse_v.rs`).
- Upgrade `README.md` acknowledgments: the mlx-lm/mlx-vlm bullet now states the MIT license and copyright and points at `NOTICE`; add a turboquant_plus bullet; the License section points at `NOTICE`.
- Add an attribution note in `docs/turbo-kv-cache.md`.
- Strip the local `references/` path prefix from every turboquant_plus pointer across sources, docs, and test fixtures (15 occurrences in 10 files), so they read `turboquant_plus/...`.
- Convert every in-repo path reference in comments and docs (turboquant_plus, mlx-lm, mlx-vlm) into a web-accessible GitHub URL tracking the upstream `main` branch (`blob/main/<path>` for files, `tree/main/<path>` for directories). Line references become `#L` anchors and Python symbol suffixes become a trailing `(Symbol)` annotation. Where upstream `main` has since moved a file, the URL targets the current location (mlx-vlm `mlx_vlm/generate.py` -> `mlx_vlm/speculative/{dflash,mtp,common}.py`). All ~94 generated URLs were validated to return HTTP 200.

## Notes

- Existing Apache-2.0 headers and license terms are unchanged; this is additive notice/metadata text only, no functional code change.
- Upstream NOTICE/LICENSE texts were read from the respective repositories and reproduced verbatim. mlx-lm and mlx-vlm ship no NOTICE file (MIT), so their LICENSE copyright + permission notices are what is retained.
- For turboquant_plus, `cache.rs`/`generate.rs` cite it only as a design reference (not ports), so the repo-level NOTICE and README cover them; their headers are left intact. The per-file mechanism is used only for the concentrated `turbo/` port. mlx-lm/mlx-vlm derivation is spread across many files of mixed port/mirror nature, so it is covered at the repository (NOTICE) level rather than per file.

## Acceptance criteria (issue #221)

- [x] The repository discloses that the TurboQuant KV cache code is derived from turboquant_plus, via a repository-level NOTICE and per-file derivation notices.
- [x] The attribution names the upstream project, its copyright holder (Tom Turney), and its Apache-2.0 license.
- [x] Existing Lablup copyright headers and Apache-2.0 license terms remain intact.
