### PR TITLE
feat: wire prompt-prefix KV cache into Anthropic Messages and Responses endpoints (#239)

### DIFF
--- a/src/server/anthropic_translator.rs
+++ b/src/server/anthropic_translator.rs
@@ -135,7 +135,16 @@ pub fn anthropic_request_to_chat(request: &AnthropicRequest) -> AnthropicTransla
         chat_template_kwargs: None,
         extra_body: None,
         prompt_cache_key: None,
-        user: None,
+        // Map the Anthropic `metadata.user_id` (stored untyped in `extra`) to
+        // the chat request's `user` so per-user prompt-cache isolation works on
+        // the Messages endpoint. Absent it, the session key falls back to the
+        // shared anonymous bucket, which still yields within-endpoint reuse.
+        user: request
+            .extra
+            .get("metadata")
+            .and_then(|m| m.get("user_id"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
         extra_body_fields: serde_json::Map::new(),
         response_format: None,
         params,
@@ -800,5 +809,23 @@ mod tests {
         assert!(!thinking_enabled(&req2));
         let req3 = parse_req(r#"{"model":"m","messages":[]}"#);
         assert!(!thinking_enabled(&req3));
+    }
+
+    #[test]
+    fn metadata_user_id_maps_to_chat_user() {
+        let req = parse_req(r#"{"model":"m","messages":[],"metadata":{"user_id":"u"}}"#);
+        let t = anthropic_request_to_chat(&req);
+        assert_eq!(t.chat_request.user.as_deref(), Some("u"));
+    }
+
+    #[test]
+    fn missing_metadata_user_id_leaves_chat_user_none() {
+        let req = parse_req(r#"{"model":"m","messages":[]}"#);
+        let t = anthropic_request_to_chat(&req);
+        assert_eq!(t.chat_request.user, None);
+        // metadata present but without user_id also yields None.
+        let req2 = parse_req(r#"{"model":"m","messages":[],"metadata":{"other":"x"}}"#);
+        let t2 = anthropic_request_to_chat(&req2);
+        assert_eq!(t2.chat_request.user, None);
     }
 }

--- a/src/server/routes/anthropic.rs
+++ b/src/server/routes/anthropic.rs
@@ -57,7 +57,9 @@ use crate::server::types::anthropic_stream::{
     AnthropicStreamEvent,
 };
 
-use super::chat::{MAX_TOOLS, build_generate_options, parse_priority_header};
+use super::chat::{
+    MAX_TOOLS, build_generate_options, build_prompt_cache_request_context, parse_priority_header,
+};
 
 /// POST /v1/messages
 pub async fn anthropic_messages(
@@ -163,6 +165,17 @@ async fn non_stream_messages(
     let mut options = build_generate_options(&translated.chat_request.params, &state.config);
     options.priority = priority;
     options.reasoning_budget = budget_override;
+    // Wire the cross-request prompt-prefix KV cache (epic #116) into the
+    // Anthropic Messages path, mirroring the chat-completions handler. Built
+    // after `prepare_chat_request_with_cache` so the digest sees the resolved
+    // multimodal bytes; text-only requests yield an empty digest and a key
+    // byte-identical to the chat path.
+    options.prompt_cache_ctx = build_prompt_cache_request_context(
+        &state,
+        &translated.chat_request,
+        &prepared.image_data,
+        &prepared.audio_data,
+    );
 
     let result = match state.model_provider.generate_with_media_and_videos(
         prepared.prompt,
@@ -268,6 +281,14 @@ async fn stream_messages(
     let mut options = build_generate_options(&translated.chat_request.params, &state.config);
     options.priority = priority;
     options.reasoning_budget = budget_override;
+    // Wire the prompt-prefix KV cache (epic #116) into the streaming Anthropic
+    // path too, before `options`/`prepared` move into the spawned task.
+    options.prompt_cache_ctx = build_prompt_cache_request_context(
+        &state,
+        &translated.chat_request,
+        &prepared.image_data,
+        &prepared.audio_data,
+    );
 
     let (sender, stream, cancelled, keepalive) = anthropic_sse_channel(128);
 

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -86,7 +86,7 @@ pub(crate) fn structured_error_to_response(err: StructuredOutputError) -> ErrorR
 /// slices, which yields `MultimodalDigest::empty()` and a key byte-identical to
 /// the pre-#124 path. Callers must therefore build the context **after**
 /// preparing the request so the resolved bytes are available.
-fn build_prompt_cache_request_context(
+pub(crate) fn build_prompt_cache_request_context(
     state: &AppState,
     request: &ChatCompletionRequest,
     image_data: &[Vec<u8>],

--- a/src/server/routes/responses.rs
+++ b/src/server/routes/responses.rs
@@ -58,7 +58,9 @@ use crate::server::types::responses_response::{
 };
 use crate::server::types::responses_stream::ResponseStreamEvent;
 
-use super::chat::{build_generate_options, parse_priority_header};
+use super::chat::{
+    build_generate_options, build_prompt_cache_request_context, parse_priority_header,
+};
 
 /// POST /v1/responses
 pub async fn create_response(
@@ -193,6 +195,17 @@ async fn non_stream_create_response(
     options.priority = priority;
     options.reasoning_budget = budget_override;
     options.structured = structured;
+    // Wire the cross-request prompt-prefix KV cache (epic #116) into the
+    // Responses path, mirroring the chat-completions handler. Built after
+    // `prepare_chat_request_with_cache` so the digest sees the resolved
+    // multimodal bytes; text-only requests yield a key byte-identical to the
+    // chat path.
+    options.prompt_cache_ctx = build_prompt_cache_request_context(
+        &state,
+        &translated.chat_request,
+        &prepared.image_data,
+        &prepared.audio_data,
+    );
 
     let result = state.model_provider.generate_with_media_and_videos(
         prepared.prompt,
@@ -290,6 +303,14 @@ async fn stream_create_response(
     options.priority = priority;
     options.reasoning_budget = budget_override;
     options.structured = structured;
+    // Wire the prompt-prefix KV cache (epic #116) into the streaming Responses
+    // path too, before `options`/`translated` move into the spawned task.
+    options.prompt_cache_ctx = build_prompt_cache_request_context(
+        &state,
+        &translated.chat_request,
+        &prepared.image_data,
+        &prepared.audio_data,
+    );
 
     let (sender, stream, cancelled, keepalive) = responses_sse_channel(128);
 


### PR DESCRIPTION
## Summary

Wire the cross-request prompt-prefix KV cache (epic #116) into the Anthropic Messages (`/v1/messages`) and Responses (`/v1/responses`) endpoints. It was previously wired only on `POST /v1/chat/completions`, so the other two API surfaces cold-prefilled the full conversation history on every turn even though the cache is enabled by default. Both endpoints already reuse the shared chat building blocks, so this reuses the existing helper rather than duplicating any key/digest logic.

## What changed

- `src/server/routes/chat.rs`: promoted `build_prompt_cache_request_context` from `fn` to `pub(crate) fn` (line 89). It stays in `chat.rs` (the helper is chat-shaped and route modules stay thin per `routes/mod.rs`); the two existing chat call sites are unchanged.
- `src/server/routes/anthropic.rs`: imported `build_prompt_cache_request_context` and set `options.prompt_cache_ctx` at both generate sites: the non-streaming handler (after the `priority`/`reasoning_budget` block, before `generate_with_media_and_videos`) and the streaming handler (before `options`/`prepared` move into the `spawn_blocking` closure). The third `prepare_chat_request_with_cache` site (`anthropic_count_tokens`) does not generate and is intentionally left untouched.
- `src/server/routes/responses.rs`: imported `build_prompt_cache_request_context` and set `options.prompt_cache_ctx` at both generate sites: the non-streaming handler (after the `priority`/`reasoning_budget`/`structured` block, before `generate_with_media_and_videos`) and the streaming handler (before `options`/`translated` move into the spawned task).
- `src/server/anthropic_translator.rs`: mapped the Anthropic `metadata.user_id` (stored untyped in `request.extra`) to the translated `chat_request.user` so per-user prompt-cache isolation works on the Messages endpoint. Without it the session key falls back to the shared anonymous bucket, which still yields within-endpoint multi-turn reuse. The Responses translator already maps `user` and `prompt_cache_key`, so no change was needed there. Added two focused unit tests covering the present and absent `metadata.user_id` cases.

## Notes

- Each context is built after `prepare_chat_request_with_cache` so the multimodal digest sees the resolved image/audio bytes, and before `options`/`prepared`/`translated` move into the generate call or spawned task. The byte vecs are passed by reference (`&prepared.image_data`). Text-only requests produce `MultimodalDigest::empty()`, keeping the key byte-identical to the existing chat path. For multimodal requests the scheduler still gates adoption behind `--enable-vlm-prefix-cache`, so setting the ctx unconditionally (matching the chat path) is correct.
- A single shared `build_prompt_cache_request_context` is now used by the chat, Anthropic, and Responses handlers, with no duplicated key/digest logic.

## Test plan

- [x] `cargo check -p mlxcel --lib` (compiles clean)
- [ ] Full build, clippy, targeted tests, and a real-model 2-turn server smoke (turn-2 prompt-cache hit on `/v1/messages`) are run by the orchestrator as the verification gate.

Closes #239
