### PR TITLE
feat: add Gemma 4 snapshot prompt-cache reuse

### DIFF
--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -3625,6 +3625,24 @@ pub struct RotatingKVCache {
     pub(crate) turbo_seed: u32,
 }
 
+/// Scalar state required to restore a [`RotatingKVCache`] snapshot.
+///
+/// The K/V tensors themselves travel separately through model-specific
+/// snapshot containers; this metadata preserves the rotating write position
+/// and buffered speculative-cache state so the next decode step writes to the
+/// same physical slot as the source cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RotatingKVCacheSnapshotState {
+    pub max_size: i32,
+    pub buffer_size: i32,
+    pub offset: i32,
+    pub start_position: i32,
+    pub idx: i32,
+    pub step: i32,
+    pub mode: KVCacheMode,
+    pub turbo_seed: u32,
+}
+
 impl RotatingKVCache {
     /// Create a new rotating KV cache with specified maximum size (FP16 mode).
     pub fn new(max_size: i32) -> Self {
@@ -4659,6 +4677,116 @@ impl RotatingKVCache {
     /// otherwise tracks the next physical write slot in the rotating buffer.
     pub fn buffer_write_idx(&self) -> i32 {
         self.idx
+    }
+
+    /// Return the scalar metadata needed to restore this rotating cache from
+    /// copied K/V tensors.
+    ///
+    /// Used by: Gemma 4 exact-prefix model-owned snapshot prompt-cache reuse.
+    pub fn snapshot_state(&self) -> RotatingKVCacheSnapshotState {
+        RotatingKVCacheSnapshotState {
+            max_size: self.max_size,
+            buffer_size: self.buffer_size,
+            offset: self.offset,
+            start_position: self.start_position,
+            idx: self.idx,
+            step: self.step,
+            mode: self.mode,
+            turbo_seed: self.turbo_seed,
+        }
+    }
+
+    /// Restore this cache from copied FP16 K/V tensors and scalar metadata.
+    ///
+    /// The current snapshot container captures only attention-ready FP16
+    /// tensors, so non-FP16 rotating-cache modes are rejected rather than
+    /// restoring an incomplete sidecar set.
+    ///
+    /// Used by: Gemma 4 exact-prefix model-owned snapshot prompt-cache reuse.
+    pub fn restore_fp16_snapshot_state(
+        &mut self,
+        state: RotatingKVCacheSnapshotState,
+        keys: Option<UniquePtr<MlxArray>>,
+        values: Option<UniquePtr<MlxArray>>,
+    ) -> Result<(), String> {
+        if state.mode != KVCacheMode::Fp16 {
+            return Err(format!(
+                "RotatingKVCache::restore_fp16_snapshot_state only supports FP16 snapshots; got {:?}",
+                state.mode
+            ));
+        }
+        if keys.is_some() != values.is_some() {
+            return Err(
+                "RotatingKVCache::restore_fp16_snapshot_state requires keys and values together"
+                    .into(),
+            );
+        }
+        if state.max_size <= 0 {
+            return Err(format!(
+                "RotatingKVCache::restore_fp16_snapshot_state requires positive max_size; got {}",
+                state.max_size
+            ));
+        }
+        if state.buffer_size < 0 {
+            return Err(format!(
+                "RotatingKVCache::restore_fp16_snapshot_state requires non-negative buffer_size; got {}",
+                state.buffer_size
+            ));
+        }
+        if state.offset < 0 || state.idx < 0 || state.start_position < 0 {
+            return Err(format!(
+                "RotatingKVCache::restore_fp16_snapshot_state requires non-negative offset/start/idx; got offset={}, start_position={}, idx={}",
+                state.offset, state.start_position, state.idx
+            ));
+        }
+        if state.step <= 0 {
+            return Err(format!(
+                "RotatingKVCache::restore_fp16_snapshot_state requires positive step; got {}",
+                state.step
+            ));
+        }
+
+        if let Some(keys_ref) = keys.as_ref().and_then(|a| a.as_ref()) {
+            let k_shape = ffi::array_shape(keys_ref);
+            if k_shape.len() < 3 {
+                return Err(format!(
+                    "RotatingKVCache::restore_fp16_snapshot_state expected rank-4 keys, got shape {:?}",
+                    k_shape
+                ));
+            }
+            let physical_len = k_shape[2];
+            if state.buffer_size > 0 {
+                if state.idx > physical_len {
+                    return Err(format!(
+                        "RotatingKVCache::restore_fp16_snapshot_state buffered idx {} exceeds physical length {}",
+                        state.idx, physical_len
+                    ));
+                }
+            } else if state.idx > state.max_size {
+                return Err(format!(
+                    "RotatingKVCache::restore_fp16_snapshot_state ring idx {} exceeds max_size {}",
+                    state.idx, state.max_size
+                ));
+            }
+        }
+
+        self.keys = keys;
+        self.values = values;
+        self.max_size = state.max_size;
+        self.buffer_size = state.buffer_size;
+        self.offset = state.offset;
+        self.start_position = state.start_position;
+        self.idx = state.idx;
+        self.step = state.step;
+        self.mode = KVCacheMode::Fp16;
+        self.key_scales = None;
+        self.val_scales = None;
+        self.v_packed = None;
+        self.v_norms = None;
+        self.v_rescale = None;
+        self.turbo_params = None;
+        self.turbo_seed = state.turbo_seed;
+        Ok(())
     }
 
     /// Trim the last `n` entries from the rotating cache by rewinding the

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -28,9 +28,12 @@ use crate::distributed::pipeline::LayerFilter;
 use crate::distributed::pipeline::StageExecutionOutput;
 use crate::distributed::pipeline::partial_loading::filter_weight_map;
 use crate::models::model_owned::ModelOwnedSequenceState;
+use crate::models::recurrent_snapshot::{push_i32, push_optional, restore_i32, restore_optional};
 use crate::models::switch_layers::{SwitchLinear, gather_sort};
-use mlxcel_core::cache::{SequenceId, SequenceStateLayout};
-use mlxcel_core::generate::LanguageModel;
+use mlxcel_core::cache::{
+    KVCacheMode, RotatingKVCacheSnapshotState, SequenceId, SequenceStateLayout,
+};
+use mlxcel_core::generate::{LanguageModel, ModelStateSnapshot};
 use mlxcel_core::layers::{
     FusedQKVLinear, KVCache, RMSNorm, RotatingKVCache, UnifiedEmbedding, UnifiedLinear,
     compiled_gelu_mlp_fp16,
@@ -736,6 +739,29 @@ impl CacheInterface for RotatingKVCache {
     }
 }
 
+fn kv_cache_mode_to_i32(mode: KVCacheMode) -> i32 {
+    match mode {
+        KVCacheMode::Fp16 => 0,
+        KVCacheMode::Int8 => 1,
+        KVCacheMode::Turbo4Asym => 2,
+        KVCacheMode::Turbo3Asym => 3,
+        KVCacheMode::Turbo4 => 4,
+        KVCacheMode::Turbo4Delegated => 5,
+    }
+}
+
+fn kv_cache_mode_from_i32(value: i32) -> Result<KVCacheMode, String> {
+    match value {
+        0 => Ok(KVCacheMode::Fp16),
+        1 => Ok(KVCacheMode::Int8),
+        2 => Ok(KVCacheMode::Turbo4Asym),
+        3 => Ok(KVCacheMode::Turbo3Asym),
+        4 => Ok(KVCacheMode::Turbo4),
+        5 => Ok(KVCacheMode::Turbo4Delegated),
+        other => Err(format!("unknown Gemma 4 cache snapshot mode tag {other}")),
+    }
+}
+
 pub enum Cache {
     Standard(KVCache),
     Rotating(RotatingKVCache),
@@ -754,6 +780,163 @@ impl Cache {
             Self::Standard(cache) => cache,
             Self::Rotating(cache) => cache,
         }
+    }
+
+    pub(crate) fn snapshot_into(
+        &self,
+        snapshot: &mut ModelStateSnapshot,
+        prefix: &str,
+    ) -> Result<(), String> {
+        match self {
+            Self::Standard(cache) => {
+                if cache.keys.is_none() && cache.values.is_none() {
+                    return Ok(());
+                }
+                if cache.keys.is_some() != cache.values.is_some() {
+                    return Err(format!(
+                        "Gemma 4 snapshot {prefix}: standard cache has only one of keys/values"
+                    ));
+                }
+                if cache.mode != KVCacheMode::Fp16 {
+                    return Err(format!(
+                        "Gemma 4 snapshot {prefix}: standard cache mode {:?} is not supported by model-state snapshots",
+                        cache.mode
+                    ));
+                }
+                push_optional(snapshot, format!("{prefix}.standard.keys"), &cache.keys);
+                push_optional(snapshot, format!("{prefix}.standard.values"), &cache.values);
+                push_i32(snapshot, format!("{prefix}.standard.offset"), cache.offset);
+                push_i32(
+                    snapshot,
+                    format!("{prefix}.standard.mode"),
+                    kv_cache_mode_to_i32(cache.mode),
+                );
+            }
+            Self::Rotating(cache) => {
+                if cache.keys.is_none() && cache.values.is_none() {
+                    return Ok(());
+                }
+                if cache.keys.is_some() != cache.values.is_some() {
+                    return Err(format!(
+                        "Gemma 4 snapshot {prefix}: rotating cache has only one of keys/values"
+                    ));
+                }
+                let state = cache.snapshot_state();
+                if state.mode != KVCacheMode::Fp16 {
+                    return Err(format!(
+                        "Gemma 4 snapshot {prefix}: rotating cache mode {:?} is not supported by model-state snapshots",
+                        state.mode
+                    ));
+                }
+                push_optional(snapshot, format!("{prefix}.rotating.keys"), &cache.keys);
+                push_optional(snapshot, format!("{prefix}.rotating.values"), &cache.values);
+                push_i32(
+                    snapshot,
+                    format!("{prefix}.rotating.max_size"),
+                    state.max_size,
+                );
+                push_i32(
+                    snapshot,
+                    format!("{prefix}.rotating.buffer_size"),
+                    state.buffer_size,
+                );
+                push_i32(snapshot, format!("{prefix}.rotating.offset"), state.offset);
+                push_i32(
+                    snapshot,
+                    format!("{prefix}.rotating.start_position"),
+                    state.start_position,
+                );
+                push_i32(snapshot, format!("{prefix}.rotating.idx"), state.idx);
+                push_i32(snapshot, format!("{prefix}.rotating.step"), state.step);
+                push_i32(
+                    snapshot,
+                    format!("{prefix}.rotating.mode"),
+                    kv_cache_mode_to_i32(state.mode),
+                );
+                push_i32(
+                    snapshot,
+                    format!("{prefix}.rotating.turbo_seed"),
+                    state.turbo_seed as i32,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn restore_from(
+        &mut self,
+        snapshot: &ModelStateSnapshot,
+        prefix: &str,
+    ) -> Result<(), String> {
+        match self {
+            Self::Standard(cache) => {
+                let keys = restore_optional(snapshot, format!("{prefix}.standard.keys"));
+                let values = restore_optional(snapshot, format!("{prefix}.standard.values"));
+                if keys.is_none() && values.is_none() {
+                    return Ok(());
+                }
+                if keys.is_some() != values.is_some() {
+                    return Err(format!(
+                        "Gemma 4 restore {prefix}: standard snapshot has only one of keys/values"
+                    ));
+                }
+                let mode = restore_i32(snapshot, format!("{prefix}.standard.mode"))
+                    .map(kv_cache_mode_from_i32)
+                    .transpose()?
+                    .unwrap_or(KVCacheMode::Fp16);
+                if mode != KVCacheMode::Fp16 {
+                    return Err(format!(
+                        "Gemma 4 restore {prefix}: standard snapshot mode {:?} is not supported",
+                        mode
+                    ));
+                }
+                cache.keys = keys;
+                cache.values = values;
+                cache.offset = restore_i32(snapshot, format!("{prefix}.standard.offset"))
+                    .unwrap_or(snapshot.token_len() as i32);
+                cache.mode = KVCacheMode::Fp16;
+            }
+            Self::Rotating(cache) => {
+                let keys = restore_optional(snapshot, format!("{prefix}.rotating.keys"));
+                let values = restore_optional(snapshot, format!("{prefix}.rotating.values"));
+                if keys.is_none() && values.is_none() {
+                    return Ok(());
+                }
+                if keys.is_some() != values.is_some() {
+                    return Err(format!(
+                        "Gemma 4 restore {prefix}: rotating snapshot has only one of keys/values"
+                    ));
+                }
+                let current = cache.snapshot_state();
+                let mode = restore_i32(snapshot, format!("{prefix}.rotating.mode"))
+                    .map(kv_cache_mode_from_i32)
+                    .transpose()?
+                    .unwrap_or(KVCacheMode::Fp16);
+                let state = RotatingKVCacheSnapshotState {
+                    max_size: restore_i32(snapshot, format!("{prefix}.rotating.max_size"))
+                        .unwrap_or(current.max_size),
+                    buffer_size: restore_i32(snapshot, format!("{prefix}.rotating.buffer_size"))
+                        .unwrap_or(0),
+                    offset: restore_i32(snapshot, format!("{prefix}.rotating.offset"))
+                        .unwrap_or(snapshot.token_len() as i32),
+                    start_position: restore_i32(
+                        snapshot,
+                        format!("{prefix}.rotating.start_position"),
+                    )
+                    .unwrap_or(0),
+                    idx: restore_i32(snapshot, format!("{prefix}.rotating.idx"))
+                        .unwrap_or(snapshot.token_len() as i32),
+                    step: restore_i32(snapshot, format!("{prefix}.rotating.step"))
+                        .unwrap_or(current.step),
+                    mode,
+                    turbo_seed: restore_i32(snapshot, format!("{prefix}.rotating.turbo_seed"))
+                        .map(|seed| seed as u32)
+                        .unwrap_or(current.turbo_seed),
+                };
+                cache.restore_fp16_snapshot_state(state, keys, values)?;
+            }
+        }
+        Ok(())
     }
 
     /// Trim the last `n` entries from this cache, dispatching to the
@@ -4455,6 +4638,56 @@ impl LanguageModel for Gemma4Wrapper {
 
     fn release_sequence_state_by_id(&self, seq_id: SequenceId) {
         self.sequence_state.release_sequence_state(seq_id);
+    }
+
+    fn supports_snapshot_reuse(&self) -> bool {
+        true
+    }
+
+    fn snapshot_sequence_state(
+        &self,
+        seq_id: SequenceId,
+        token_len: usize,
+    ) -> Option<ModelStateSnapshot> {
+        self.sequence_state
+            .with_sequence_state_ref(seq_id, |state| {
+                let mut snapshot = ModelStateSnapshot::new("gemma4", token_len);
+                for (idx, cache) in state.iter().enumerate() {
+                    if let Err(error) = cache.snapshot_into(&mut snapshot, &format!("layer{idx}")) {
+                        tracing::warn!(
+                            error,
+                            layer_idx = idx,
+                            "Gemma4 snapshot prompt-cache donation skipped"
+                        );
+                        return None;
+                    }
+                }
+                if snapshot.is_empty() {
+                    None
+                } else {
+                    Some(snapshot)
+                }
+            })
+            .flatten()
+    }
+
+    fn restore_sequence_state(
+        &self,
+        seq_id: SequenceId,
+        snapshot: &ModelStateSnapshot,
+    ) -> Result<(), String> {
+        if snapshot.family() != "gemma4" {
+            return Err(format!(
+                "cannot restore {} snapshot into Gemma 4",
+                snapshot.family()
+            ));
+        }
+        let mut state = self.model.make_caches();
+        for (idx, cache) in state.iter_mut().enumerate() {
+            cache.restore_from(snapshot, &format!("layer{idx}"))?;
+        }
+        self.sequence_state.replace_sequence_state(seq_id, state);
+        Ok(())
     }
 
     fn num_layers(&self) -> usize {

--- a/src/models/gemma4_tests.rs
+++ b/src/models/gemma4_tests.rs
@@ -725,6 +725,163 @@ fn gemma4_proportional_rope_freqs_match_python_semantics() {
 }
 
 // -----------------------------------------------------------------
+// Exact-prefix snapshot prompt-cache support for Gemma 4's model-owned
+// heterogeneous caches.
+mod snapshot_prompt_cache {
+    use crate::models::gemma4::Cache;
+    use mlxcel_core::cache::SequenceId;
+    use mlxcel_core::generate::{LanguageModel, ModelStateSnapshot};
+    use mlxcel_core::layers::{KVCache, RotatingKVCache};
+
+    fn token(value: f32) -> mlxcel_core::UniquePtr<mlxcel_core::MlxArray> {
+        mlxcel_core::from_slice_f32(&[value], &[1, 1, 1, 1])
+    }
+
+    fn to_vec_f32(arr: &mlxcel_core::MlxArray) -> Vec<f32> {
+        let arr_f32 = mlxcel_core::astype(arr, mlxcel_core::dtype::FLOAT32);
+        mlxcel_core::eval(&arr_f32);
+        mlxcel_core::array_to_raw_bytes(&arr_f32)
+            .chunks_exact(4)
+            .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .collect()
+    }
+
+    #[test]
+    #[ignore = "requires serial MLX execution"]
+    fn gemma4_snapshot_restores_standard_kv_cache() {
+        let mut source = Cache::Standard(KVCache::new());
+        if let Cache::Standard(cache) = &mut source {
+            let keys = mlxcel_core::from_slice_f32(&[1.0, 2.0, 3.0], &[1, 1, 3, 1]);
+            let values = mlxcel_core::from_slice_f32(&[10.0, 20.0, 30.0], &[1, 1, 3, 1]);
+            cache.update_and_fetch(keys, values);
+            assert_eq!(cache.seq_len(), 3);
+        }
+
+        let mut snapshot = ModelStateSnapshot::new("gemma4", 3);
+        source
+            .snapshot_into(&mut snapshot, "layer0")
+            .expect("standard cache snapshot must succeed");
+
+        let mut restored = Cache::Standard(KVCache::new());
+        restored
+            .restore_from(&snapshot, "layer0")
+            .expect("standard cache restore must succeed");
+
+        let Cache::Standard(restored_cache) = &restored else {
+            unreachable!()
+        };
+        assert_eq!(restored_cache.offset, 3);
+        assert_eq!(restored_cache.seq_len(), 3);
+        let keys = restored_cache.keys.as_ref().unwrap();
+        let values = restored_cache.values.as_ref().unwrap();
+        assert!(mlxcel_core::array_shape(keys)[2] >= 3);
+        assert!(mlxcel_core::array_shape(values)[2] >= 3);
+        let live_keys = mlxcel_core::slice(keys, &[0, 0, 0, 0], &[1, 1, 3, 1]);
+        let live_values = mlxcel_core::slice(values, &[0, 0, 0, 0], &[1, 1, 3, 1]);
+        assert_eq!(to_vec_f32(live_keys.as_ref().unwrap()), vec![1.0, 2.0, 3.0]);
+        assert_eq!(
+            to_vec_f32(live_values.as_ref().unwrap()),
+            vec![10.0, 20.0, 30.0]
+        );
+    }
+
+    #[test]
+    #[ignore = "requires serial MLX execution"]
+    fn gemma4_snapshot_restores_rotating_ring_metadata() {
+        let mut source = Cache::Rotating(RotatingKVCache::new(4));
+        if let Cache::Rotating(cache) = &mut source {
+            for i in 0..6 {
+                cache.update_and_fetch(token(i as f32), token((i * 10) as f32));
+            }
+            assert_eq!(cache.offset, 6);
+            assert_eq!(cache.visible_len(), 4);
+            assert_eq!(cache.logical_start(), 2);
+            assert_eq!(cache.buffer_write_idx(), 2);
+        }
+
+        let mut snapshot = ModelStateSnapshot::new("gemma4", 6);
+        source
+            .snapshot_into(&mut snapshot, "layer0")
+            .expect("rotating cache snapshot must succeed");
+
+        let mut restored = Cache::Rotating(RotatingKVCache::new(4));
+        restored
+            .restore_from(&snapshot, "layer0")
+            .expect("rotating cache restore must succeed");
+
+        let Cache::Rotating(restored_cache) = &restored else {
+            unreachable!()
+        };
+        assert_eq!(restored_cache.offset, 6);
+        assert_eq!(restored_cache.visible_len(), 4);
+        assert_eq!(restored_cache.logical_start(), 2);
+        assert_eq!(restored_cache.buffer_write_idx(), 2);
+
+        let (source_k, source_v) = match &mut source {
+            Cache::Rotating(cache) => cache.update_and_fetch(token(6.0), token(60.0)),
+            _ => unreachable!(),
+        };
+        let (restored_k, restored_v) = match &mut restored {
+            Cache::Rotating(cache) => cache.update_and_fetch(token(6.0), token(60.0)),
+            _ => unreachable!(),
+        };
+        assert_eq!(
+            mlxcel_core::array_shape(&source_k),
+            mlxcel_core::array_shape(&restored_k)
+        );
+        assert_eq!(
+            mlxcel_core::array_shape(&source_v),
+            mlxcel_core::array_shape(&restored_v)
+        );
+        assert_eq!(
+            to_vec_f32(source_k.as_ref().unwrap()),
+            to_vec_f32(restored_k.as_ref().unwrap())
+        );
+        assert_eq!(
+            to_vec_f32(source_v.as_ref().unwrap()),
+            to_vec_f32(restored_v.as_ref().unwrap())
+        );
+    }
+
+    #[test]
+    #[ignore = "requires serial MLX execution"]
+    fn gemma4_snapshot_reuse_restores_decode_logits() {
+        let source = super::build_synthetic_wrapper();
+        assert!(source.supports_snapshot_reuse());
+        let seq_a = SequenceId::from_raw(910);
+        source.prepare_sequence_state(seq_a);
+        let prompt = mlxcel_core::from_slice_i32(&[1, 2, 3], &[1, 3]);
+        let _ = source.forward_with_sequence_id(&prompt, Some(seq_a), &mut [], None);
+        let snapshot = source
+            .snapshot_sequence_state(seq_a, 3)
+            .expect("Gemma 4 wrapper must donate a non-empty snapshot");
+
+        let restored = super::build_synthetic_wrapper();
+        let seq_b = SequenceId::from_raw(911);
+        restored.prepare_sequence_state(seq_b);
+        restored
+            .restore_sequence_state(seq_b, &snapshot)
+            .expect("Gemma 4 wrapper must restore its own snapshot");
+
+        let decode = mlxcel_core::from_slice_i32(&[4], &[1, 1]);
+        let logits_source = source.forward_with_sequence_id(&decode, Some(seq_a), &mut [], None);
+        let logits_restored =
+            restored.forward_with_sequence_id(&decode, Some(seq_b), &mut [], None);
+        let source_vec = to_vec_f32(logits_source.as_ref().unwrap());
+        let restored_vec = to_vec_f32(logits_restored.as_ref().unwrap());
+        assert_eq!(source_vec.len(), restored_vec.len());
+        for (i, (&got, &want)) in restored_vec.iter().zip(source_vec.iter()).enumerate() {
+            let abs = (got - want).abs();
+            let rel = abs / want.abs().max(1.0);
+            assert!(
+                abs < 1e-3 || rel < 1e-3,
+                "logit[{i}] differs after Gemma 4 snapshot restore: restored={got}, source={want}, abs={abs}, rel={rel}"
+            );
+        }
+    }
+}
+
+// -----------------------------------------------------------------
 // Gemma 4 MTP target hooks — `rollback_speculative_cache`
 // + sink-aware forward.
 //

--- a/src/models/recurrent_snapshot.rs
+++ b/src/models/recurrent_snapshot.rs
@@ -21,6 +21,14 @@
 use mlxcel_core::generate::ModelStateSnapshot;
 use mlxcel_core::{MlxArray, UniquePtr};
 
+pub(crate) fn push_i32(snapshot: &mut ModelStateSnapshot, name: impl Into<String>, value: i32) {
+    let scalar = mlxcel_core::from_slice_i32(&[value], &[1]);
+    snapshot.push_tensor(
+        name,
+        scalar.as_ref().expect("from_slice_i32 returns an array"),
+    );
+}
+
 pub(crate) fn push_optional(
     snapshot: &mut ModelStateSnapshot,
     name: impl Into<String>,
@@ -36,4 +44,8 @@ pub(crate) fn restore_optional(
     name: impl AsRef<str>,
 ) -> Option<UniquePtr<MlxArray>> {
     snapshot.tensor(name.as_ref()).map(mlxcel_core::copy)
+}
+
+pub(crate) fn restore_i32(snapshot: &ModelStateSnapshot, name: impl AsRef<str>) -> Option<i32> {
+    snapshot.tensor(name.as_ref()).map(mlxcel_core::item_i32)
 }

--- a/src/vision/gemma4_unified.rs
+++ b/src/vision/gemma4_unified.rs
@@ -561,6 +561,34 @@ impl LanguageModel for Gemma4UnifiedModel {
         self.text_model.release_sequence_state_by_id(seq_id);
     }
 
+    fn supports_snapshot_reuse(&self) -> bool {
+        mlxcel_core::generate::LanguageModel::supports_snapshot_reuse(&self.text_model)
+    }
+
+    fn snapshot_sequence_state(
+        &self,
+        seq_id: SequenceId,
+        token_len: usize,
+    ) -> Option<mlxcel_core::generate::ModelStateSnapshot> {
+        mlxcel_core::generate::LanguageModel::snapshot_sequence_state(
+            &self.text_model,
+            seq_id,
+            token_len,
+        )
+    }
+
+    fn restore_sequence_state(
+        &self,
+        seq_id: SequenceId,
+        snapshot: &mlxcel_core::generate::ModelStateSnapshot,
+    ) -> Result<(), String> {
+        mlxcel_core::generate::LanguageModel::restore_sequence_state(
+            &self.text_model,
+            seq_id,
+            snapshot,
+        )
+    }
+
     fn num_layers(&self) -> usize {
         self.text_model.num_layers_value()
     }

--- a/src/vision/gemma4_vl.rs
+++ b/src/vision/gemma4_vl.rs
@@ -574,6 +574,39 @@ impl LanguageModel for Gemma4VLModel {
         self.text_model.release_sequence_state_by_id(seq_id);
     }
 
+    fn supports_snapshot_reuse(&self) -> bool {
+        // The vision wrapper owns no recurrent/text cache state of its own;
+        // the Gemma 4 text backbone carries the heterogeneous
+        // KVCache/RotatingKVCache slots. Delegate snapshot capability so
+        // VLM-wrapped checkpoints participate in the exact-prefix prompt
+        // cache just like the text model.
+        mlxcel_core::generate::LanguageModel::supports_snapshot_reuse(&self.text_model)
+    }
+
+    fn snapshot_sequence_state(
+        &self,
+        seq_id: SequenceId,
+        token_len: usize,
+    ) -> Option<mlxcel_core::generate::ModelStateSnapshot> {
+        mlxcel_core::generate::LanguageModel::snapshot_sequence_state(
+            &self.text_model,
+            seq_id,
+            token_len,
+        )
+    }
+
+    fn restore_sequence_state(
+        &self,
+        seq_id: SequenceId,
+        snapshot: &mlxcel_core::generate::ModelStateSnapshot,
+    ) -> Result<(), String> {
+        mlxcel_core::generate::LanguageModel::restore_sequence_state(
+            &self.text_model,
+            seq_id,
+            snapshot,
+        )
+    }
+
     fn num_layers(&self) -> usize {
         self.text_model.num_layers_value()
     }


### PR DESCRIPTION
## Summary
- Add exact-prefix model-state snapshots for Gemma 4 model-owned `Cache::{Standard, Rotating}` entries.
- Preserve rotating-cache scalar metadata (`max_size`, `buffer_size`, `offset`, `start_position`, `idx`, `step`, mode, seed) so restored sliding-window caches continue at the same physical write slot.
- Delegate snapshot donation/restore through the Gemma 4 VLM and Unified wrappers.
- Add serial MLX tests for standard KV, rotating ring metadata, and synthetic-wrapper decode-logit restore parity.

Closes #242

## Validation
- `cargo test --lib gemma4_snapshot -- --ignored --test-threads=1`
- `cargo build --bin mlxcel-server --bin mlxcel`
- `cargo clippy --all-targets -- -D warnings`
- Real checkpoint smoke: `target/debug/mlxcel-server -m models/gemma-4-26b-a4b-it-4bit --ctx-size 512 --prompt-cache-enabled=true --prompt-cache-min-prefix 1`; one `/v1/chat/completions` request with `prompt_cache_key=gemma4-issue-242-smoke` completed with `prompt_tokens=26`, `completion_tokens=1`, and `/v1/cache/stats` reported `snapshot_entries=1`, `snapshot_bytes=10568520`, `snapshot_lookups=1`, `snapshot_inserts=1`, `snapshot_rejections_oversized=0`.
