### PR TITLE
feat(models): add LFM2 and LFM2-MoE (lfm2, lfm2_moe)

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -34,6 +34,7 @@ Implemented model families include:
 - StarCoder2, StableLM, SmolLM3, Baichuan, MiniCPM, MiniCPM3, MiniMax,
   Ministral3, Mistral4, Nemotron, Nemotron-NAS, Step 3.5, MiMo
 - Mamba, Mamba2, RWKV7, Recurrent Gemma, Jamba, Nemotron-H
+- LFM2 and LFM2-MoE (Liquid Foundation Models: short-convolution and attention hybrid; the MoE variant routes through sigmoid-gated experts)
 - Kimi Linear, LongCat Flash, LongCat Flash N-gram
 - GPT-OSS
 

--- a/src/distributed/tensor_parallel/inference.rs
+++ b/src/distributed/tensor_parallel/inference.rs
@@ -210,6 +210,8 @@ fn fallback_architecture(model_type: ModelType) -> &'static str {
         ModelType::Mamba => "mamba",
         ModelType::Mamba2 => "mamba2",
         ModelType::Jamba => "jamba",
+        ModelType::Lfm2 => "lfm2",
+        ModelType::Lfm2Moe => "lfm2_moe",
         ModelType::NemotronH => "nemotron_h",
         ModelType::NemotronHNanoOmniVLM => "nemotron_h_nano_omni",
         ModelType::NemotronNAS => "nemotron_nas",

--- a/src/loaded_model.rs
+++ b/src/loaded_model.rs
@@ -139,6 +139,8 @@ pub enum LoadedModel {
     Mamba(models::MambaModel),
     Mamba2(models::Mamba2Model),
     Jamba(models::JambaModel),
+    Lfm2(models::Lfm2Model),
+    Lfm2Moe(models::Lfm2Model),
     NemotronH(models::NemotronHModel),
     /// Nemotron H Nano Omni — vision-capable variant (vision-only).
     NemotronHNanoOmniVLM(vision::NemotronHNanoOmniVlModel),
@@ -247,6 +249,8 @@ macro_rules! delegate_language_model {
             LoadedModel::Mamba(inner) => LanguageModel::$method(inner, $($arg),*),
             LoadedModel::Mamba2(inner) => LanguageModel::$method(inner, $($arg),*),
             LoadedModel::Jamba(inner) => LanguageModel::$method(inner, $($arg),*),
+            LoadedModel::Lfm2(inner) => LanguageModel::$method(inner, $($arg),*),
+            LoadedModel::Lfm2Moe(inner) => LanguageModel::$method(inner, $($arg),*),
             LoadedModel::NemotronH(inner) => LanguageModel::$method(inner, $($arg),*),
             LoadedModel::NemotronHNanoOmniVLM(inner) => LanguageModel::$method(inner, $($arg),*),
             LoadedModel::NemotronNAS(inner) => LanguageModel::$method(inner, $($arg),*),

--- a/src/loading/nonstandard.rs
+++ b/src/loading/nonstandard.rs
@@ -63,6 +63,14 @@ pub(crate) fn try_load_nonstandard_model_from_dir(
             super::load_pair_from_dir(path_str, |path| models::JambaModel::load(&path))
                 .map(LoadedModel::Jamba)?,
         ),
+        ModelType::Lfm2 => Some(
+            super::load_pair_from_dir(path_str, |path| models::Lfm2Model::load(&path))
+                .map(LoadedModel::Lfm2)?,
+        ),
+        ModelType::Lfm2Moe => Some(
+            super::load_pair_from_dir(path_str, |path| models::Lfm2Model::load(&path))
+                .map(LoadedModel::Lfm2Moe)?,
+        ),
         ModelType::NemotronH => Some(
             super::load_pair_from_dir(path_str, |path| models::NemotronHModel::load(&path))
                 .map(LoadedModel::NemotronH)?,

--- a/src/loading/special.rs
+++ b/src/loading/special.rs
@@ -80,6 +80,8 @@ fn special_weight_loader_kind(model_type: ModelType) -> Option<SpecialWeightLoad
         ModelType::Mamba
         | ModelType::Mamba2
         | ModelType::Jamba
+        | ModelType::Lfm2
+        | ModelType::Lfm2Moe
         | ModelType::NemotronNAS
         | ModelType::RecurrentGemma => Some(SpecialWeightLoaderKind::OwnedConfig),
         ModelType::NemotronH => Some(SpecialWeightLoaderKind::NemotronH),
@@ -157,6 +159,20 @@ pub(crate) fn try_load_special_model_from_weights(
                 models::jamba::JambaConfig,
                 models::JambaModel::from_weights,
                 LoadedModel::Jamba
+            ),
+            ModelType::Lfm2 => load_owned_model_from_config!(
+                config_str,
+                weights,
+                models::lfm2::ModelArgs,
+                models::Lfm2Model::from_weights,
+                LoadedModel::Lfm2
+            ),
+            ModelType::Lfm2Moe => load_owned_model_from_config!(
+                config_str,
+                weights,
+                models::lfm2::ModelArgs,
+                models::Lfm2Model::from_weights,
+                LoadedModel::Lfm2Moe
             ),
             ModelType::NemotronNAS => load_owned_model_from_config!(
                 config_str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1684,6 +1684,7 @@ const FAMILY_ORDER: &[&str] = &[
     "MoE (other)",
     "Mamba / SSM",
     "Hybrid",
+    "LFM2",
     "RWKV",
     "Specialized",
     "Llama VLM",

--- a/src/model_metadata.rs
+++ b/src/model_metadata.rs
@@ -182,6 +182,8 @@ macro_rules! for_each_model_registration {
             Mamba => { kind: Text, directory: Nonstandard, weight: Some(WeightLoadRoute::Special), adapter: None };
             Mamba2 => { kind: Text, directory: Nonstandard, weight: Some(WeightLoadRoute::Special), adapter: None };
             Jamba => { kind: Text, directory: Nonstandard, weight: Some(WeightLoadRoute::Special), adapter: None };
+            Lfm2 => { kind: Text, directory: Nonstandard, weight: Some(WeightLoadRoute::Special), adapter: None };
+            Lfm2Moe => { kind: Text, directory: Nonstandard, weight: Some(WeightLoadRoute::Special), adapter: None };
             NemotronH => { kind: Text, directory: Nonstandard, weight: Some(WeightLoadRoute::Special), adapter: None };
             NemotronHNanoOmniVLM => { kind: Vlm, directory: Vlm, weight: None, adapter: Some("Nemotron H Nano Omni VLM does not support adapter loading; use load_model() instead") };
             NemotronNAS => { kind: Text, directory: Nonstandard, weight: Some(WeightLoadRoute::Special), adapter: None };

--- a/src/models/detection.rs
+++ b/src/models/detection.rs
@@ -181,6 +181,8 @@ pub fn get_model_type(model_path: &Path) -> Result<ModelType> {
         "mamba" | "falcon_mamba" => Ok(ModelType::Mamba),
         "mamba2" => Ok(ModelType::Mamba2),
         "jamba" => Ok(ModelType::Jamba),
+        "lfm2" => Ok(ModelType::Lfm2),
+        "lfm2_moe" => Ok(ModelType::Lfm2Moe),
         "nemotron_h" => Ok(ModelType::NemotronH),
         "nemotron_h_nano_omni" | "nemotronh_nano_omni_reasoning_v3" => {
             Ok(ModelType::NemotronHNanoOmniVLM)

--- a/src/models/lfm2.rs
+++ b/src/models/lfm2.rs
@@ -1,0 +1,1027 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! LiquidAI LFM2 and LFM2-MoE (Liquid Foundation Models) implementation.
+//!
+//! LFM2 is a hybrid decoder. Each layer is EITHER a full-attention layer (when
+//! its index is in `full_attn_idxs`, derived from `layer_types == "full_attention"`)
+//! OR a gated short-convolution (`ShortConv`) layer; every layer then applies a
+//! SwiGLU feed-forward that is dense (`lfm2`) or sparse/MoE (`lfm2_moe`). The
+//! final norm is `embedding_norm` and the embeddings are tied
+//! (`embed_tokens.as_linear`).
+//!
+//! Both `model_type = "lfm2"` and `model_type = "lfm2_moe"` route here; the only
+//! structural difference is the per-layer feed-forward.
+//!
+//! Mirrored from the mlx-lm reference:
+//! - https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/lfm2.py
+//! - https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/lfm2_moe.py
+//!
+//! Correctness note (the load-bearing LFM2-MoE detail, upstream
+//! ml-explore/mlx-lm#1354): the sparse router is **sigmoid-gated, not
+//! softmax**. `routing_weights = sigmoid(gate(x))`; the optional `expert_bias`
+//! participates ONLY in top-k selection (`argpartition(routing_weights + bias)`),
+//! while the combine scores are gathered from the UNBIASED `routing_weights`.
+//!
+//! Because the short-convolution and attention layers both carry per-sequence
+//! recurrent/positional state, the model owns its mixed cache through
+//! [`ModelOwnedSequenceState`] (like Jamba / NemotronH) and reports
+//! `supports_batching() == false`.
+
+use mlxcel_core::generate::LanguageModel;
+use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
+use mlxcel_core::utils::{create_causal_mask, slice_axis, stack_arrays};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+use serde::Deserialize;
+use std::path::Path;
+
+use super::model_owned::ModelOwnedSequenceState;
+use super::recurrent_snapshot::{push_optional, restore_optional};
+use super::switch_layers::{SwitchGLU, moe_weighted_sum};
+
+// Configuration.
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelArgs {
+    pub model_type: String,
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+
+    pub norm_eps: f32,
+    pub conv_bias: bool,
+    #[serde(rename = "conv_L_cache")]
+    pub conv_l_cache: usize,
+
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f32,
+
+    /// Present in the dense `lfm2` config; the MoE config derives the indices
+    /// from `layer_types` instead.
+    #[serde(default)]
+    pub full_attn_idxs: Option<Vec<usize>>,
+
+    /// Present in the `lfm2_moe` config (`"conv"` / `"full_attention"`).
+    #[serde(default)]
+    pub layer_types: Option<Vec<String>>,
+
+    // MoE-only fields (absent for the dense `lfm2` checkpoint).
+    #[serde(default)]
+    pub intermediate_size: Option<usize>,
+    #[serde(default)]
+    pub moe_intermediate_size: Option<usize>,
+    #[serde(default)]
+    pub num_experts: Option<usize>,
+    #[serde(default)]
+    pub num_experts_per_tok: Option<usize>,
+    #[serde(default)]
+    pub num_dense_layers: Option<usize>,
+    #[serde(default)]
+    pub norm_topk_prob: Option<bool>,
+    #[serde(default)]
+    pub use_expert_bias: Option<bool>,
+    #[serde(default = "default_routed_scaling_factor")]
+    pub routed_scaling_factor: f32,
+
+    #[serde(default)]
+    pub eos_token_id: Option<serde_json::Value>,
+
+    #[serde(default)]
+    pub quantization: Option<Quantization>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Quantization {
+    pub group_size: i32,
+    pub bits: i32,
+}
+
+fn default_rope_theta() -> f32 {
+    1_000_000.0
+}
+
+fn default_routed_scaling_factor() -> f32 {
+    1.0
+}
+
+impl ModelArgs {
+    pub fn head_dim(&self) -> usize {
+        self.hidden_size / self.num_attention_heads
+    }
+
+    pub fn group_size(&self) -> i32 {
+        self.quantization
+            .as_ref()
+            .map(|q| q.group_size)
+            .unwrap_or(64)
+    }
+
+    pub fn bits(&self) -> i32 {
+        self.quantization.as_ref().map(|q| q.bits).unwrap_or(4)
+    }
+
+    /// Indices of the full-attention layers. Uses the explicit `full_attn_idxs`
+    /// when present (dense `lfm2`), otherwise derives them from `layer_types`
+    /// (`lfm2_moe`). Mirrors `ModelArgs.__post_init__` in the reference.
+    pub fn full_attn_idxs(&self) -> Vec<usize> {
+        if let Some(idxs) = &self.full_attn_idxs {
+            idxs.clone()
+        } else if let Some(types) = &self.layer_types {
+            types
+                .iter()
+                .enumerate()
+                .filter(|(_, t)| t.as_str() == "full_attention")
+                .map(|(i, _)| i)
+                .collect()
+        } else {
+            Vec::new()
+        }
+    }
+
+    pub fn is_attention_layer(&self, layer_idx: usize) -> bool {
+        self.full_attn_idxs().contains(&layer_idx)
+    }
+
+    /// Whether this checkpoint carries sparse-MoE feed-forward layers.
+    pub fn is_moe(&self) -> bool {
+        self.num_experts.is_some() && self.moe_intermediate_size.is_some()
+    }
+
+    /// Layers with index `< num_dense_layers` use a dense SwiGLU MLP; the rest
+    /// use the sparse-MoE block. For the dense `lfm2` checkpoint there are no
+    /// MoE layers, so this defaults to `num_hidden_layers` (every layer dense).
+    pub fn num_dense_layers(&self) -> usize {
+        self.num_dense_layers.unwrap_or(self.num_hidden_layers)
+    }
+
+    pub fn layer_is_moe(&self, layer_idx: usize) -> bool {
+        self.is_moe() && layer_idx >= self.num_dense_layers()
+    }
+
+    pub fn eos_token_ids(&self) -> Vec<i32> {
+        // LFM2 checkpoints use `<|im_end|>` (id 7) as EOS.
+        const DEFAULT_EOS: i32 = 7;
+        match &self.eos_token_id {
+            Some(serde_json::Value::Number(n)) => n
+                .as_i64()
+                .map(|v| vec![v as i32])
+                .unwrap_or(vec![DEFAULT_EOS]),
+            Some(serde_json::Value::Array(arr)) => {
+                let ids: Vec<i32> = arr
+                    .iter()
+                    .filter_map(|v| v.as_i64().map(|x| x as i32))
+                    .collect();
+                if ids.is_empty() {
+                    vec![DEFAULT_EOS]
+                } else {
+                    ids
+                }
+            }
+            _ => vec![DEFAULT_EOS],
+        }
+    }
+}
+
+// Attention (GQA with per-head Q/K RMSNorm before RoPE).
+
+struct Attention {
+    q_proj: UnifiedLinear,
+    k_proj: UnifiedLinear,
+    v_proj: UnifiedLinear,
+    out_proj: UnifiedLinear,
+    q_layernorm: RMSNorm,
+    k_layernorm: RMSNorm,
+    num_heads: i32,
+    num_kv_heads: i32,
+    head_dim: i32,
+    scale: f32,
+    rope_base: f32,
+}
+
+impl Attention {
+    fn from_weights(weights: &WeightMap, args: &ModelArgs, prefix: &str) -> Result<Self, String> {
+        let gs = args.group_size();
+        let bits = args.bits();
+        let head_dim = args.head_dim() as i32;
+
+        let q_proj = UnifiedLinear::from_weights(weights, &format!("{prefix}.q_proj"), gs, bits)?;
+        let k_proj = UnifiedLinear::from_weights(weights, &format!("{prefix}.k_proj"), gs, bits)?;
+        let v_proj = UnifiedLinear::from_weights(weights, &format!("{prefix}.v_proj"), gs, bits)?;
+        let out_proj =
+            UnifiedLinear::from_weights(weights, &format!("{prefix}.out_proj"), gs, bits)?;
+
+        let q_layernorm = RMSNorm::new(
+            get_weight_copy(weights, &format!("{prefix}.q_layernorm.weight"))?,
+            args.norm_eps,
+        );
+        let k_layernorm = RMSNorm::new(
+            get_weight_copy(weights, &format!("{prefix}.k_layernorm.weight"))?,
+            args.norm_eps,
+        );
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            out_proj,
+            q_layernorm,
+            k_layernorm,
+            num_heads: args.num_attention_heads as i32,
+            num_kv_heads: args.num_key_value_heads as i32,
+            head_dim,
+            scale: (head_dim as f32).powf(-0.5),
+            rope_base: args.rope_theta,
+        })
+    }
+
+    fn forward(
+        &self,
+        x: &MlxArray,
+        cache: &mut KVCache,
+        mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        let shape = mlxcel_core::array_shape(x);
+        let b = shape[0];
+        let l = shape[1];
+
+        let q = self.q_proj.forward(x);
+        let k = self.k_proj.forward(x);
+        let v = self.v_proj.forward(x);
+
+        let q = mlxcel_core::reshape(&q, &[b, l, self.num_heads, self.head_dim]);
+        let k = mlxcel_core::reshape(&k, &[b, l, self.num_kv_heads, self.head_dim]);
+        let v = mlxcel_core::reshape(&v, &[b, l, self.num_kv_heads, self.head_dim]);
+
+        // Per-head RMSNorm over head_dim, applied before transpose and RoPE.
+        let q = self.q_layernorm.forward(&q);
+        let k = self.k_layernorm.forward(&k);
+
+        let q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
+        let k = mlxcel_core::transpose_axes(&k, &[0, 2, 1, 3]);
+        let v = mlxcel_core::transpose_axes(&v, &[0, 2, 1, 3]);
+
+        let offset = cache.offset;
+        let q = mlxcel_core::fast_rope(&q, self.head_dim, false, self.rope_base, 1.0, offset);
+        let k = mlxcel_core::fast_rope(&k, self.head_dim, false, self.rope_base, 1.0, offset);
+
+        let (cache_k, cache_v) = cache.update_and_fetch(k, v);
+
+        let attn_out = if l > 1 && mask.is_none() {
+            mlxcel_core::causal_attention(&q, &cache_k, &cache_v, self.scale, 0.0, 0)
+        } else {
+            let mask_ptr = mask.map(|m| m as *const _).unwrap_or(std::ptr::null());
+            unsafe {
+                mlxcel_core::layers::attention_from_ptr(
+                    &q, &cache_k, &cache_v, self.scale, mask_ptr, 0.0, 0,
+                )
+            }
+        };
+
+        let attn_out = mlxcel_core::transpose_axes(&attn_out, &[0, 2, 1, 3]);
+        let attn_out = mlxcel_core::reshape(&attn_out, &[b, l, self.num_heads * self.head_dim]);
+        self.out_proj.forward(&attn_out)
+    }
+}
+
+// ShortConv (gated depthwise causal convolution mixer).
+
+struct ShortConv {
+    in_proj: UnifiedLinear,
+    out_proj: UnifiedLinear,
+    conv_weight: UniquePtr<MlxArray>,
+    conv_bias: Option<UniquePtr<MlxArray>>,
+    hidden_size: i32,
+    l_cache: i32,
+}
+
+impl ShortConv {
+    fn from_weights(weights: &WeightMap, args: &ModelArgs, prefix: &str) -> Result<Self, String> {
+        let gs = args.group_size();
+        let bits = args.bits();
+
+        let in_proj = UnifiedLinear::from_weights(weights, &format!("{prefix}.in_proj"), gs, bits)?;
+        let out_proj =
+            UnifiedLinear::from_weights(weights, &format!("{prefix}.out_proj"), gs, bits)?;
+        let conv_weight = get_weight_copy(weights, &format!("{prefix}.conv.weight"))?;
+        let conv_bias = weights
+            .get(&format!("{prefix}.conv.bias"))
+            .map(|w| mlxcel_core::copy(w));
+
+        Ok(Self {
+            in_proj,
+            out_proj,
+            conv_weight,
+            conv_bias,
+            hidden_size: args.hidden_size as i32,
+            l_cache: args.conv_l_cache as i32,
+        })
+    }
+
+    /// `BCx = in_proj(x)` → split into `B, C, x` → `Bx = B * x` → depthwise
+    /// causal Conv1d (kernel `L_cache`, left-padded by `L_cache - 1` on prefill
+    /// or prepended with the cached `L_cache - 1` time steps on decode) →
+    /// `y = C * conv_out` → `out_proj(y)`.
+    fn forward(
+        &self,
+        x: &MlxArray,
+        conv_state: &mut Option<UniquePtr<MlxArray>>,
+    ) -> UniquePtr<MlxArray> {
+        let h = self.hidden_size;
+        let bcx = self.in_proj.forward(x);
+
+        // Split along the last axis into B, C, x (each [batch, seq, hidden]).
+        let b_part = slice_axis(&bcx, -1, 0, h);
+        let c_part = slice_axis(&bcx, -1, h, 2 * h);
+        let x_part = slice_axis(&bcx, -1, 2 * h, 3 * h);
+
+        let bx = mlxcel_core::multiply(&b_part, &x_part);
+
+        // Prepend the cached tail (decode) or zero-pad by L_cache - 1 (prefill),
+        // so the kernel-size-`L_cache` depthwise conv stays causal.
+        let n_keep = self.l_cache - 1;
+        let bx_shape = mlxcel_core::array_shape(&bx);
+        let padded = match conv_state.as_ref().and_then(|s| s.as_ref()) {
+            Some(state) => mlxcel_core::concatenate(state, &bx, 1),
+            None => {
+                let pad = mlxcel_core::zeros(
+                    &[bx_shape[0], n_keep, bx_shape[2]],
+                    mlxcel_core::array_dtype(&bx),
+                );
+                mlxcel_core::concatenate(&pad, &bx, 1)
+            }
+        };
+
+        // Persist the last `L_cache - 1` time steps as the next conv state.
+        // `contiguous` forces a fresh buffer so the cached slice does not retain
+        // the full padded allocation (mirrors the Mamba conv-state handling).
+        let plen = mlxcel_core::array_shape(&padded)[1];
+        let tail = slice_axis(&padded, 1, plen - n_keep, plen);
+        *conv_state = Some(mlxcel_core::contiguous(&tail, false));
+
+        // Depthwise Conv1d (groups == hidden). Match the conv weight dtype to
+        // the (possibly bf16) activations; quantized checkpoints leave the
+        // non-quantized conv weight at its stored precision.
+        let in_dtype = mlxcel_core::array_dtype(&padded);
+        let conv_out = if mlxcel_core::array_dtype(&self.conv_weight) == in_dtype {
+            mlxcel_core::conv1d(&padded, &self.conv_weight, 1, 0, 1, h)
+        } else {
+            let w = mlxcel_core::astype(&self.conv_weight, in_dtype);
+            mlxcel_core::conv1d(&padded, &w, 1, 0, 1, h)
+        };
+        let conv_out = match &self.conv_bias {
+            Some(bias) => {
+                let bias = mlxcel_core::reshape(bias, &[1, 1, -1]);
+                mlxcel_core::add(&conv_out, &bias)
+            }
+            None => conv_out,
+        };
+
+        let y = mlxcel_core::multiply(&c_part, &conv_out);
+        self.out_proj.forward(&y)
+    }
+}
+
+// Dense SwiGLU MLP.
+
+struct MLP {
+    gate_proj: UnifiedLinear,
+    up_proj: UnifiedLinear,
+    down_proj: UnifiedLinear,
+}
+
+impl MLP {
+    fn from_weights(weights: &WeightMap, args: &ModelArgs, prefix: &str) -> Result<Self, String> {
+        let gs = args.group_size();
+        let bits = args.bits();
+        Ok(Self {
+            gate_proj: UnifiedLinear::from_weights(
+                weights,
+                &format!("{prefix}.gate_proj"),
+                gs,
+                bits,
+            )?,
+            up_proj: UnifiedLinear::from_weights(weights, &format!("{prefix}.up_proj"), gs, bits)?,
+            down_proj: UnifiedLinear::from_weights(
+                weights,
+                &format!("{prefix}.down_proj"),
+                gs,
+                bits,
+            )?,
+        })
+    }
+
+    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        let gate = self.gate_proj.forward(x);
+        let up = self.up_proj.forward(x);
+        let activated = mlxcel_core::compiled_swiglu_activation(&gate, &up);
+        self.down_proj.forward(&activated)
+    }
+}
+
+// Sparse MoE block (sigmoid-gated routing).
+
+struct Lfm2MoeSparseMoeBlock {
+    gate: UnifiedLinear,
+    switch_mlp: SwitchGLU,
+    expert_bias: Option<UniquePtr<MlxArray>>,
+    top_k: i32,
+    num_experts: i32,
+    norm_topk_prob: bool,
+    routed_scaling_factor: f32,
+}
+
+impl Lfm2MoeSparseMoeBlock {
+    fn from_weights(weights: &WeightMap, args: &ModelArgs, prefix: &str) -> Result<Self, String> {
+        let gs = args.group_size();
+        let bits = args.bits();
+
+        // The router stays a plain (possibly quantized) Linear. `UnifiedLinear`
+        // reconciles the per-tensor bit width from the tensor shapes, so the
+        // 8-bit gate is loaded correctly even when the checkpoint's top-level
+        // quantization advertises 4-bit experts.
+        let gate = UnifiedLinear::from_weights(weights, &format!("{prefix}.gate"), gs, bits)?;
+        let switch_mlp =
+            SwitchGLU::from_weights(weights, &format!("{prefix}.switch_mlp"), gs, bits)?;
+        let expert_bias = weights
+            .get(&format!("{prefix}.expert_bias"))
+            .map(|w| mlxcel_core::copy(w));
+
+        Ok(Self {
+            gate,
+            switch_mlp,
+            expert_bias,
+            top_k: args.num_experts_per_tok.unwrap_or(1) as i32,
+            num_experts: args.num_experts.unwrap_or(0) as i32,
+            norm_topk_prob: args.norm_topk_prob.unwrap_or(false),
+            routed_scaling_factor: args.routed_scaling_factor,
+        })
+    }
+
+    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        let orig_shape = mlxcel_core::array_shape(x);
+        let hidden_dim = orig_shape[orig_shape.len() - 1];
+
+        let x_flat = if orig_shape.len() > 2 {
+            let n: i32 = orig_shape[..orig_shape.len() - 1].iter().product();
+            mlxcel_core::reshape(x, &[n, hidden_dim])
+        } else {
+            mlxcel_core::copy(x)
+        };
+
+        // Sigmoid-gated routing (NOT softmax). See module note + mlx-lm #1354.
+        let routing_weights = mlxcel_core::sigmoid(&self.gate.forward(&x_flat));
+
+        let k = self.top_k;
+        let kth = self.num_experts - k;
+
+        // The expert_bias shifts only the SELECTION, never the gathered scores.
+        let selection = match &self.expert_bias {
+            Some(bias) => {
+                let rw_f32 = mlxcel_core::astype(&routing_weights, mlxcel_core::dtype::FLOAT32);
+                let bias_row = mlxcel_core::reshape(bias, &[1, self.num_experts]);
+                mlxcel_core::add(&rw_f32, &bias_row)
+            }
+            None => mlxcel_core::copy(&routing_weights),
+        };
+
+        let indices = mlxcel_core::argpartition(&selection, kth, -1);
+        let indices_shape = mlxcel_core::array_shape(&indices);
+        let topk_indices =
+            mlxcel_core::slice(&indices, &[0, kth], &[indices_shape[0], indices_shape[1]]);
+
+        // Gather scores from the UNBIASED routing weights at the selected experts.
+        let mut scores = mlxcel_core::take_along_axis(&routing_weights, &topk_indices, -1);
+
+        if self.norm_topk_prob {
+            let sum = mlxcel_core::sum_axis(&scores, -1, true);
+            let eps = mlxcel_core::full_f32(&[1], 1e-6, mlxcel_core::array_dtype(&sum));
+            let denom = mlxcel_core::add(&sum, &eps);
+            scores = mlxcel_core::divide(&scores, &denom);
+        }
+        if (self.routed_scaling_factor - 1.0).abs() > f32::EPSILON {
+            scores = mlxcel_core::multiply_scalar(&scores, self.routed_scaling_factor);
+        }
+
+        let expert_out = self.switch_mlp.forward(&x_flat, &topk_indices);
+        let result = moe_weighted_sum(&expert_out, &scores, mlxcel_core::array_dtype(&x_flat));
+
+        if orig_shape.len() > 2 {
+            mlxcel_core::reshape(&result, &orig_shape)
+        } else {
+            result
+        }
+    }
+}
+
+// Per-layer feed-forward (dense or sparse).
+
+enum FeedForward {
+    Dense(MLP),
+    Moe(Lfm2MoeSparseMoeBlock),
+}
+
+impl FeedForward {
+    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        match self {
+            FeedForward::Dense(mlp) => mlp.forward(x),
+            FeedForward::Moe(moe) => moe.forward(x),
+        }
+    }
+}
+
+// Per-layer token mixer (attention or short-conv).
+
+enum Mixer {
+    Attention(Attention),
+    Conv(ShortConv),
+}
+
+// Decoder layer: operator_norm → mixer → residual; ffn_norm → feed_forward → residual.
+
+struct Lfm2DecoderLayer {
+    mixer: Mixer,
+    feed_forward: FeedForward,
+    operator_norm: RMSNorm,
+    ffn_norm: RMSNorm,
+}
+
+impl Lfm2DecoderLayer {
+    fn is_attention(&self) -> bool {
+        matches!(self.mixer, Mixer::Attention(_))
+    }
+
+    fn make_cache(&self) -> Lfm2LayerCache {
+        match self.mixer {
+            Mixer::Attention(_) => Lfm2LayerCache::Attention(KVCache::new()),
+            Mixer::Conv(_) => Lfm2LayerCache::Conv(None),
+        }
+    }
+
+    fn forward(
+        &self,
+        x: &MlxArray,
+        cache: &mut Lfm2LayerCache,
+        mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        let normed = self.operator_norm.forward(x);
+        // `make_caches` builds the per-layer cache in lockstep with the mixer
+        // kind, so the cross combinations never occur.
+        let r = match (&self.mixer, cache) {
+            (Mixer::Attention(attn), Lfm2LayerCache::Attention(kv)) => {
+                attn.forward(&normed, kv, mask)
+            }
+            (Mixer::Conv(conv), Lfm2LayerCache::Conv(state)) => conv.forward(&normed, state),
+            _ => unreachable!("LFM2 layer cache kind does not match its mixer"),
+        };
+        let h = mlxcel_core::add(x, &r);
+
+        let normed = self.ffn_norm.forward(&h);
+        let ff = self.feed_forward.forward(&normed);
+        mlxcel_core::add(&h, &ff)
+    }
+
+    fn from_weights(
+        weights: &WeightMap,
+        args: &ModelArgs,
+        layer_idx: usize,
+    ) -> Result<Self, String> {
+        let prefix = format!("model.layers.{layer_idx}");
+
+        let mixer = if args.is_attention_layer(layer_idx) {
+            Mixer::Attention(Attention::from_weights(
+                weights,
+                args,
+                &format!("{prefix}.self_attn"),
+            )?)
+        } else {
+            Mixer::Conv(ShortConv::from_weights(
+                weights,
+                args,
+                &format!("{prefix}.conv"),
+            )?)
+        };
+
+        let feed_forward = if args.layer_is_moe(layer_idx) {
+            FeedForward::Moe(Lfm2MoeSparseMoeBlock::from_weights(
+                weights,
+                args,
+                &format!("{prefix}.feed_forward"),
+            )?)
+        } else {
+            FeedForward::Dense(MLP::from_weights(
+                weights,
+                args,
+                &format!("{prefix}.feed_forward"),
+            )?)
+        };
+
+        let operator_norm = RMSNorm::new(
+            get_weight_copy(weights, &format!("{prefix}.operator_norm.weight"))?,
+            args.norm_eps,
+        );
+        let ffn_norm = RMSNorm::new(
+            get_weight_copy(weights, &format!("{prefix}.ffn_norm.weight"))?,
+            args.norm_eps,
+        );
+
+        Ok(Self {
+            mixer,
+            feed_forward,
+            operator_norm,
+            ffn_norm,
+        })
+    }
+}
+
+// Per-layer cache: KV cache for attention layers, conv state for short-conv.
+
+pub enum Lfm2LayerCache {
+    Attention(KVCache),
+    /// Last `L_cache - 1` time steps of `Bx`, shape `[batch, L_cache - 1, hidden]`.
+    Conv(Option<UniquePtr<MlxArray>>),
+}
+
+impl Lfm2LayerCache {
+    fn offset(&self) -> i32 {
+        match self {
+            Lfm2LayerCache::Attention(kv) => kv.offset,
+            Lfm2LayerCache::Conv(_) => 0,
+        }
+    }
+
+    fn snapshot_into(
+        &self,
+        snapshot: &mut mlxcel_core::generate::ModelStateSnapshot,
+        prefix: &str,
+    ) {
+        match self {
+            Lfm2LayerCache::Attention(kv) => {
+                push_optional(snapshot, format!("{prefix}.attention.keys"), &kv.keys);
+                push_optional(snapshot, format!("{prefix}.attention.values"), &kv.values);
+            }
+            Lfm2LayerCache::Conv(state) => {
+                push_optional(snapshot, format!("{prefix}.conv.state"), state);
+            }
+        }
+    }
+
+    fn restore_from(&mut self, snapshot: &mlxcel_core::generate::ModelStateSnapshot, prefix: &str) {
+        match self {
+            Lfm2LayerCache::Attention(kv) => {
+                kv.keys = restore_optional(snapshot, format!("{prefix}.attention.keys"));
+                kv.values = restore_optional(snapshot, format!("{prefix}.attention.values"));
+                kv.offset = snapshot.token_len() as i32;
+            }
+            Lfm2LayerCache::Conv(state) => {
+                *state = restore_optional(snapshot, format!("{prefix}.conv.state"));
+            }
+        }
+    }
+}
+
+// LFM2 model.
+
+pub struct Lfm2Model {
+    config: ModelArgs,
+    embed_tokens: UnifiedEmbedding,
+    layers: Vec<Lfm2DecoderLayer>,
+    embedding_norm: RMSNorm,
+    eos_token_ids: Vec<i32>,
+    /// Model-owned mixed caches keyed by scheduler sequence id, plus a fallback
+    /// slot for CLI / benchmark paths.
+    sequence_state: ModelOwnedSequenceState<Lfm2LayerCache>,
+}
+
+impl Lfm2Model {
+    pub fn num_layers(&self) -> usize {
+        self.config.num_hidden_layers
+    }
+
+    pub fn make_caches(&self) -> Vec<Lfm2LayerCache> {
+        self.layers.iter().map(|l| l.make_cache()).collect()
+    }
+
+    fn forward_with_caches(
+        &self,
+        inputs: &MlxArray,
+        caches: &mut [Lfm2LayerCache],
+    ) -> UniquePtr<MlxArray> {
+        let mut h = self.embed_tokens.forward(inputs);
+
+        let shape = mlxcel_core::array_shape(&h);
+        let seq_len = shape[1];
+
+        // Single causal mask anchored on the first attention layer's offset.
+        // Short-conv layers stay causal via left-padding, so they need no mask
+        // in the single-sequence path.
+        let attn_offset = caches
+            .iter()
+            .find(|c| matches!(c, Lfm2LayerCache::Attention(_)))
+            .map(|c| c.offset())
+            .unwrap_or(0);
+        let attn_mask = if seq_len > 1 {
+            Some(create_causal_mask(seq_len, attn_offset))
+        } else {
+            None
+        };
+
+        for (layer, cache) in self.layers.iter().zip(caches.iter_mut()) {
+            let mask = if layer.is_attention() {
+                attn_mask.as_deref()
+            } else {
+                None
+            };
+            h = layer.forward(&h, cache, mask);
+        }
+
+        let h = self.embedding_norm.forward(&h);
+        self.embed_tokens.as_linear(&h)
+    }
+
+    pub fn load(model_path: &str) -> Result<(Self, ModelArgs), String> {
+        let model_dir = Path::new(model_path);
+        let config_path = model_dir.join("config.json");
+        let config_str = std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("Failed to read config.json: {e}"))?;
+        let config_str = crate::models::sanitize_config_json(&config_str);
+        let args: ModelArgs = serde_json::from_str(&config_str)
+            .map_err(|e| format!("Failed to parse config.json: {e}"))?;
+
+        let weights = crate::models::load_text_weights(model_dir, None)?;
+        let model = Self::from_weights(args.clone(), weights)?;
+        Ok((model, args))
+    }
+
+    /// Build from owned weights. Applies the LFM2 weight sanitize internally so
+    /// every load path (directory loader and the adapter/owned-weights route)
+    /// produces the same canonical layout.
+    pub fn from_weights(args: ModelArgs, weights: WeightMap) -> Result<Self, String> {
+        let weights = sanitize_weights(weights, &args);
+
+        let gs = args.group_size();
+        let bits = args.bits();
+
+        let embed_tokens =
+            UnifiedEmbedding::from_weights(&weights, "model.embed_tokens", gs, bits)?;
+
+        let mut layers = Vec::with_capacity(args.num_hidden_layers);
+        for i in 0..args.num_hidden_layers {
+            layers.push(Lfm2DecoderLayer::from_weights(&weights, &args, i)?);
+        }
+
+        let embedding_norm = RMSNorm::new(
+            get_weight_copy(&weights, "model.embedding_norm.weight")?,
+            args.norm_eps,
+        );
+
+        let internal_caches: Vec<Lfm2LayerCache> = layers.iter().map(|l| l.make_cache()).collect();
+        let eos_token_ids = args.eos_token_ids();
+
+        Ok(Self {
+            config: args,
+            embed_tokens,
+            layers,
+            embedding_norm,
+            eos_token_ids,
+            sequence_state: ModelOwnedSequenceState::new(internal_caches),
+        })
+    }
+}
+
+// Weight sanitize (mirrors the reference `sanitize`).
+//
+// 1. Depthwise conv weight orientation: PyTorch stores `[hidden, 1, L_cache]`;
+//    MLX/mlxcel wants `[hidden, L_cache, 1]`. The mlx-community checkpoints are
+//    already in MLX layout, so this is a no-op there but keeps raw HF exports
+//    loadable.
+// 2. Dense MLP rename `w1 → gate_proj`, `w2 → down_proj`, `w3 → up_proj`
+//    (the dense `lfm2` checkpoint stores the SwiGLU MLP as w1/w2/w3).
+// 3. MoE expert stacking `feed_forward.experts.{e}.{proj} → feed_forward.switch_mlp.{proj}`.
+//    The 4-bit mlx-community MoE checkpoint already ships the stacked
+//    `switch_mlp` tensors, so this only fires for non-pre-stacked exports.
+fn sanitize_weights(mut weights: WeightMap, args: &ModelArgs) -> WeightMap {
+    // 1. Conv weight orientation.
+    let conv_keys: Vec<String> = weights
+        .keys()
+        .filter(|k| k.contains("conv.conv.weight"))
+        .cloned()
+        .collect();
+    for k in conv_keys {
+        if let Some(v) = weights.get(&k) {
+            let shape = mlxcel_core::array_shape(v);
+            if shape.len() == 3 && shape[shape.len() - 1] > shape[1] {
+                let transposed = mlxcel_core::transpose_axes(v, &[0, 2, 1]);
+                weights.insert(k, transposed);
+            }
+        }
+    }
+
+    // 2. Dense MLP w1/w2/w3 → gate/down/up rename (covers weight + quantized
+    //    scales/biases by matching the `.feed_forward.wN.` key segment).
+    let rename = |key: &str| -> Option<String> {
+        for (old, new) in [
+            (".feed_forward.w1.", ".feed_forward.gate_proj."),
+            (".feed_forward.w2.", ".feed_forward.down_proj."),
+            (".feed_forward.w3.", ".feed_forward.up_proj."),
+        ] {
+            if key.contains(old) {
+                return Some(key.replace(old, new));
+            }
+        }
+        None
+    };
+    let to_rename: Vec<String> = weights
+        .keys()
+        .filter(|k| rename(k.as_str()).is_some())
+        .cloned()
+        .collect();
+    for key in to_rename {
+        if let Some(new_key) = rename(&key)
+            && let Some(v) = weights.remove(&key)
+        {
+            weights.insert(new_key, v);
+        }
+    }
+
+    // 3. MoE expert stacking (no-op for the pre-stacked mlx checkpoint).
+    if let Some(num_experts) = args.num_experts {
+        for l in 0..args.num_hidden_layers {
+            let prefix = format!("model.layers.{l}.feed_forward");
+            for proj in ["gate_proj", "up_proj", "down_proj"] {
+                let first = format!("{prefix}.experts.0.{proj}.weight");
+                if !weights.contains_key(&first) {
+                    continue;
+                }
+                for suffix in ["weight", "scales", "biases"] {
+                    let probe = format!("{prefix}.experts.0.{proj}.{suffix}");
+                    if !weights.contains_key(&probe) {
+                        continue;
+                    }
+                    let mut stacked: Vec<UniquePtr<MlxArray>> = Vec::with_capacity(num_experts);
+                    let mut complete = true;
+                    for e in 0..num_experts {
+                        match weights.remove(&format!("{prefix}.experts.{e}.{proj}.{suffix}")) {
+                            Some(w) => stacked.push(w),
+                            None => {
+                                complete = false;
+                                break;
+                            }
+                        }
+                    }
+                    if complete && !stacked.is_empty() {
+                        let joined = stack_arrays(&stacked, 0);
+                        weights.insert(format!("{prefix}.switch_mlp.{proj}.{suffix}"), joined);
+                    }
+                }
+            }
+        }
+    }
+
+    weights
+}
+
+fn get_weight_copy(weights: &WeightMap, name: &str) -> Result<UniquePtr<MlxArray>, String> {
+    weights
+        .get(name)
+        .map(|w| mlxcel_core::copy(w))
+        .ok_or_else(|| format!("Weight not found: {name}"))
+}
+
+// LanguageModel trait implementation.
+
+impl LanguageModel for Lfm2Model {
+    fn forward(
+        &self,
+        input: &MlxArray,
+        _caches: &mut [KVCache],
+        _mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        // LFM2 owns its mixed cache (KVCache + conv state); the external KV
+        // slice is unused. The fallback internal state covers CLI / benchmarks.
+        self.sequence_state
+            .with_sequence_state(None, |internal| self.forward_with_caches(input, internal))
+    }
+
+    fn make_caches(&self) -> Vec<KVCache> {
+        // Reset fallback internal caches for a fresh generation session.
+        self.sequence_state
+            .replace_internal(Lfm2Model::make_caches(self));
+        // Return placeholder KV caches for trait compatibility; the real caches
+        // are model-owned.
+        (0..self.config.num_hidden_layers)
+            .map(|_| KVCache::new())
+            .collect()
+    }
+
+    fn num_layers(&self) -> usize {
+        self.config.num_hidden_layers
+    }
+
+    fn eos_token_ids(&self) -> Vec<i32> {
+        self.eos_token_ids.clone()
+    }
+
+    fn supports_batching(&self) -> bool {
+        false // Hybrid short-conv state is not compatible with per-sequence KV isolation.
+    }
+
+    fn supports_padded_prefill(&self) -> bool {
+        false // Padding tokens corrupt the short-conv recurrent state.
+    }
+
+    fn prepare_sequence_state(&self, seq_id: mlxcel_core::cache::SequenceId) {
+        self.sequence_state
+            .prepare_sequence_state(seq_id, Lfm2Model::make_caches(self));
+    }
+
+    fn release_sequence_state_by_id(&self, seq_id: mlxcel_core::cache::SequenceId) {
+        self.sequence_state.release_sequence_state(seq_id);
+    }
+
+    fn forward_with_sequence_id(
+        &self,
+        input_ids: &MlxArray,
+        seq_id: Option<mlxcel_core::cache::SequenceId>,
+        _caches: &mut [KVCache],
+        _mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        self.sequence_state.with_or_create_sequence_state(
+            seq_id,
+            || Lfm2Model::make_caches(self),
+            |internal| self.forward_with_caches(input_ids, internal),
+        )
+    }
+
+    fn supports_snapshot_reuse(&self) -> bool {
+        true
+    }
+
+    fn snapshot_sequence_state(
+        &self,
+        seq_id: mlxcel_core::cache::SequenceId,
+        token_len: usize,
+    ) -> Option<mlxcel_core::generate::ModelStateSnapshot> {
+        self.sequence_state
+            .with_sequence_state_ref(seq_id, |state| {
+                let mut snapshot =
+                    mlxcel_core::generate::ModelStateSnapshot::new("lfm2", token_len);
+                for (idx, cache) in state.iter().enumerate() {
+                    cache.snapshot_into(&mut snapshot, &format!("layer{idx}"));
+                }
+                snapshot
+            })
+    }
+
+    fn restore_sequence_state(
+        &self,
+        seq_id: mlxcel_core::cache::SequenceId,
+        snapshot: &mlxcel_core::generate::ModelStateSnapshot,
+    ) -> Result<(), String> {
+        if snapshot.family() != "lfm2" {
+            return Err(format!(
+                "cannot restore {} snapshot into LFM2",
+                snapshot.family()
+            ));
+        }
+        let mut state = Lfm2Model::make_caches(self);
+        for (idx, cache) in state.iter_mut().enumerate() {
+            cache.restore_from(snapshot, &format!("layer{idx}"));
+        }
+        self.sequence_state.replace_sequence_state(seq_id, state);
+        Ok(())
+    }
+
+    fn trim_internal_caches(&self, excess: i32) {
+        if excess <= 0 {
+            return;
+        }
+        self.sequence_state.with_sequence_state(None, |internal| {
+            for cache in internal.iter_mut() {
+                match cache {
+                    Lfm2LayerCache::Attention(kv) => {
+                        kv.trim(excess);
+                    }
+                    Lfm2LayerCache::Conv(state) => {
+                        // The conv state is recurrent (not positional); it was
+                        // computed from padding tokens, so reset it.
+                        *state = None;
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/models/lfm2.rs
+++ b/src/models/lfm2.rs
@@ -482,7 +482,7 @@ impl Lfm2MoeSparseMoeBlock {
             mlxcel_core::copy(x)
         };
 
-        // Sigmoid-gated routing (NOT softmax). See module note + mlx-lm #1354.
+        // Sigmoid-gated routing (NOT softmax). See module note + ml-explore/mlx-lm#1354.
         let routing_weights = mlxcel_core::sigmoid(&self.gate.forward(&x_flat));
 
         let k = self.top_k;

--- a/src/models/lfm2_tests.rs
+++ b/src/models/lfm2_tests.rs
@@ -1,0 +1,211 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for LFM2 / LFM2-MoE config parsing and the config-derived layer
+//! typing and routing wiring.
+//!
+//! These cover the checkpoint-free surface: that the dense `lfm2` and sparse
+//! `lfm2_moe` `config.json` files deserialize into `ModelArgs`, that the
+//! full-attention layer indices derive correctly (explicit list for `lfm2`,
+//! `layer_types` for `lfm2_moe`), that dense-vs-MoE feed-forward selection
+//! follows `num_dense_layers`, and that the sigmoid-gating fields parse. The
+//! numeric correctness of the short-conv and the sigmoid-gated routing is
+//! validated end-to-end against real `mlx-community` checkpoints
+//! (`LFM2-350M-8bit`, `LFM2-8B-A1B-4bit`) and is not exercised here (no Metal
+//! device is assumed in unit tests).
+
+use super::lfm2::ModelArgs;
+
+/// A trimmed `LFM2-350M` (dense) config with the fields the loader reads.
+const LFM2_350M_CONFIG: &str = r#"{
+    "model_type": "lfm2",
+    "vocab_size": 65536,
+    "hidden_size": 1024,
+    "num_hidden_layers": 16,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 8,
+    "max_position_embeddings": 128000,
+    "norm_eps": 1e-05,
+    "conv_bias": false,
+    "conv_L_cache": 3,
+    "rope_theta": 1000000.0,
+    "full_attn_idxs": [2, 5, 8, 10, 12, 14],
+    "eos_token_id": 7,
+    "block_dim": 1024,
+    "block_ff_dim": 6656,
+    "quantization": { "group_size": 64, "bits": 8 }
+}"#;
+
+/// A trimmed `LFM2-8B-A1B` (MoE) config. `layer_types` drives the attention
+/// layer derivation; the MoE block fields drive sigmoid-gated routing.
+const LFM2_8B_MOE_CONFIG: &str = r#"{
+    "model_type": "lfm2_moe",
+    "vocab_size": 65536,
+    "hidden_size": 2048,
+    "intermediate_size": 7168,
+    "moe_intermediate_size": 1792,
+    "num_hidden_layers": 24,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "max_position_embeddings": 128000,
+    "norm_eps": 1e-05,
+    "conv_bias": false,
+    "conv_L_cache": 3,
+    "rope_theta": 1000000.0,
+    "num_dense_layers": 2,
+    "num_experts": 32,
+    "num_experts_per_tok": 4,
+    "norm_topk_prob": true,
+    "use_expert_bias": true,
+    "routed_scaling_factor": 1.0,
+    "eos_token_id": 7,
+    "layer_types": [
+        "conv", "conv", "full_attention", "conv", "conv", "conv",
+        "full_attention", "conv", "conv", "conv", "full_attention", "conv",
+        "conv", "conv", "full_attention", "conv", "conv", "conv",
+        "full_attention", "conv", "conv", "full_attention", "conv", "conv"
+    ],
+    "quantization": { "group_size": 64, "bits": 4 }
+}"#;
+
+#[test]
+fn lfm2_dense_config_parses() {
+    let args: ModelArgs = serde_json::from_str(LFM2_350M_CONFIG).expect("parse dense config");
+    assert_eq!(args.model_type, "lfm2");
+    assert_eq!(args.hidden_size, 1024);
+    assert_eq!(args.num_attention_heads, 16);
+    assert_eq!(args.num_key_value_heads, 8);
+    assert_eq!(args.num_hidden_layers, 16);
+    assert_eq!(args.conv_l_cache, 3);
+    assert!(!args.conv_bias);
+    assert_eq!(args.rope_theta, 1_000_000.0);
+    // head_dim derives from hidden/heads; the q/k layernorm weights are [64].
+    assert_eq!(args.head_dim(), 64);
+    assert_eq!(args.group_size(), 64);
+    assert_eq!(args.bits(), 8);
+    assert_eq!(args.eos_token_ids(), vec![7]);
+    // No MoE fields → a pure dense checkpoint.
+    assert!(!args.is_moe());
+}
+
+#[test]
+fn lfm2_dense_full_attn_idxs_are_explicit() {
+    let args: ModelArgs = serde_json::from_str(LFM2_350M_CONFIG).expect("parse dense config");
+    assert_eq!(args.full_attn_idxs(), vec![2, 5, 8, 10, 12, 14]);
+    for idx in 0..args.num_hidden_layers {
+        let expect_attention = [2, 5, 8, 10, 12, 14].contains(&idx);
+        assert_eq!(
+            args.is_attention_layer(idx),
+            expect_attention,
+            "layer {idx}"
+        );
+    }
+}
+
+#[test]
+fn lfm2_dense_every_layer_is_dense_ffn() {
+    let args: ModelArgs = serde_json::from_str(LFM2_350M_CONFIG).expect("parse dense config");
+    // The dense checkpoint has no experts, so no layer routes to MoE and the
+    // dense-layer boundary defaults to the full layer count.
+    assert_eq!(args.num_dense_layers(), args.num_hidden_layers);
+    for idx in 0..args.num_hidden_layers {
+        assert!(!args.layer_is_moe(idx), "layer {idx} must use a dense MLP");
+    }
+}
+
+#[test]
+fn lfm2_moe_config_parses_sigmoid_gating_fields() {
+    let args: ModelArgs = serde_json::from_str(LFM2_8B_MOE_CONFIG).expect("parse MoE config");
+    assert_eq!(args.model_type, "lfm2_moe");
+    assert_eq!(args.hidden_size, 2048);
+    assert_eq!(args.num_attention_heads, 32);
+    assert_eq!(args.head_dim(), 64);
+    assert_eq!(args.bits(), 4);
+    assert!(args.is_moe());
+    assert_eq!(args.num_experts, Some(32));
+    assert_eq!(args.num_experts_per_tok, Some(4));
+    assert_eq!(args.moe_intermediate_size, Some(1792));
+    assert_eq!(args.num_dense_layers, Some(2));
+    // The load-bearing sigmoid-gating switches.
+    assert_eq!(args.norm_topk_prob, Some(true));
+    assert_eq!(args.use_expert_bias, Some(true));
+    assert_eq!(args.routed_scaling_factor, 1.0);
+    assert_eq!(args.eos_token_ids(), vec![7]);
+}
+
+#[test]
+fn lfm2_moe_full_attn_idxs_derive_from_layer_types() {
+    let args: ModelArgs = serde_json::from_str(LFM2_8B_MOE_CONFIG).expect("parse MoE config");
+    // `full_attn_idxs` is absent, so the indices come from layer_types entries
+    // equal to "full_attention".
+    assert!(args.full_attn_idxs.is_none());
+    assert_eq!(args.full_attn_idxs(), vec![2, 6, 10, 14, 18, 21]);
+    assert!(args.is_attention_layer(2));
+    assert!(args.is_attention_layer(21));
+    assert!(!args.is_attention_layer(0));
+    assert!(!args.is_attention_layer(23));
+}
+
+#[test]
+fn lfm2_moe_feed_forward_selection_follows_num_dense_layers() {
+    let args: ModelArgs = serde_json::from_str(LFM2_8B_MOE_CONFIG).expect("parse MoE config");
+    assert_eq!(args.num_dense_layers(), 2);
+    // Layers 0 and 1 use a dense MLP; every later layer routes to the sparse
+    // MoE block, including the attention layer at index 2.
+    assert!(!args.layer_is_moe(0));
+    assert!(!args.layer_is_moe(1));
+    assert!(args.layer_is_moe(2));
+    assert!(args.is_attention_layer(2) && args.layer_is_moe(2));
+    assert!(args.layer_is_moe(23));
+}
+
+#[test]
+fn lfm2_conv_state_keep_length_invariant() {
+    // The per-layer conv cache holds the last `L_cache - 1` time steps of `Bx`
+    // (shape `[batch, L_cache - 1, hidden]`), which is what the depthwise
+    // kernel-size-`L_cache` causal conv needs prepended on decode.
+    let args: ModelArgs = serde_json::from_str(LFM2_350M_CONFIG).expect("parse dense config");
+    assert_eq!(args.conv_l_cache, 3);
+    assert_eq!(args.conv_l_cache - 1, 2);
+}
+
+#[test]
+fn lfm2_eos_token_id_handles_scalar_array_and_missing() {
+    // Scalar (the shape both shipped checkpoints use).
+    let scalar: ModelArgs = serde_json::from_str(LFM2_350M_CONFIG).expect("parse dense config");
+    assert_eq!(scalar.eos_token_ids(), vec![7]);
+
+    // Array form.
+    let array_cfg = LFM2_350M_CONFIG.replace("\"eos_token_id\": 7", "\"eos_token_id\": [7, 1]");
+    let array: ModelArgs = serde_json::from_str(&array_cfg).expect("parse array eos config");
+    assert_eq!(array.eos_token_ids(), vec![7, 1]);
+
+    // Missing → default `<|im_end|>` (id 7).
+    let no_eos = LFM2_350M_CONFIG.replace("\"eos_token_id\": 7,", "");
+    let missing: ModelArgs = serde_json::from_str(&no_eos).expect("parse no-eos config");
+    assert_eq!(missing.eos_token_ids(), vec![7]);
+}
+
+#[test]
+fn lfm2_unquantized_config_uses_quantization_defaults() {
+    // Drop the quantization block (a bf16 checkpoint) and confirm the defaults.
+    let no_quant = LFM2_350M_CONFIG.replace(
+        ",\n    \"quantization\": { \"group_size\": 64, \"bits\": 8 }",
+        "",
+    );
+    let args: ModelArgs = serde_json::from_str(&no_quant).expect("parse unquantized config");
+    assert!(args.quantization.is_none());
+    assert_eq!(args.group_size(), 64);
+    assert_eq!(args.bits(), 4);
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -60,6 +60,7 @@ pub mod internlm2;
 pub mod internlm3;
 pub mod jamba;
 pub mod kimi_linear;
+pub mod lfm2;
 pub mod llama3;
 pub mod llama4;
 pub mod longcat_flash_ngram;
@@ -138,6 +139,7 @@ pub use internlm2::InternLM2Model;
 pub use internlm3::InternLM3Model;
 pub use jamba::JambaModel;
 pub use kimi_linear::KimiLinearModel;
+pub use lfm2::Lfm2Model;
 pub use llama3::Llama3Model;
 pub use llama4::{Llama4CxxModel, Llama4Wrapper};
 pub use longcat_flash_ngram::LongcatFlashNgramModel;
@@ -311,6 +313,10 @@ pub enum ModelType {
     NemotronHNanoOmniVLM,
     NemotronNAS,
 
+    // Liquid Foundation Models (short-conv + attention hybrid)
+    Lfm2,
+    Lfm2Moe,
+
     // Kimi models
     KimiLinear,
 
@@ -436,6 +442,9 @@ pub const ALL_MODEL_TYPES: &[ModelType] = &[
     ModelType::NemotronH,
     ModelType::NemotronHNanoOmniVLM,
     ModelType::NemotronNAS,
+    // Liquid Foundation Models
+    ModelType::Lfm2,
+    ModelType::Lfm2Moe,
     // Kimi models
     ModelType::KimiLinear,
     // Longcat models
@@ -603,6 +612,10 @@ impl ModelType {
             // ----- Hybrid (Attention + SSM) -----
             ModelType::Jamba => ("Jamba (Mamba + Transformer + MoE)", "Hybrid"),
 
+            // ----- Liquid Foundation Models -----
+            ModelType::Lfm2 => ("LFM2 (short-conv + attention hybrid)", "LFM2"),
+            ModelType::Lfm2Moe => ("LFM2-MoE (sigmoid-gated experts)", "LFM2"),
+
             // ----- RWKV -----
             ModelType::Rwkv7 => ("RWKV v7", "RWKV"),
 
@@ -753,3 +766,7 @@ mod qwen3_5_tests;
 #[cfg(test)]
 #[path = "granite_tests.rs"]
 mod granite_tests;
+
+#[cfg(test)]
+#[path = "lfm2_tests.rs"]
+mod lfm2_tests;


### PR DESCRIPTION
## Summary

Port LiquidAI's Liquid Foundation Models: the dense `lfm2` and sparse `lfm2_moe` hybrids. Both `model_type` values route to a single `src/models/lfm2.rs`.

LFM2 is a hybrid decoder. Each layer is either a full-attention block (GQA with per-head Q/K RMSNorm applied before RoPE, scale `head_dim^-0.5`, no bias) or a gated depthwise short-convolution, followed by a SwiGLU feed-forward. Attention layers are those whose index is in `full_attn_idxs` (explicit for `lfm2`, derived from `layer_types == "full_attention"` for `lfm2_moe`). Embeddings are tied (`embed_tokens.as_linear`) and the final norm is `embedding_norm`. RoPE is non-traditional with base `rope_theta`.

The short-conv mixer computes `BCx = in_proj(x)`, splits into `B, C, x`, forms `Bx = B * x`, runs a depthwise causal Conv1d of kernel `conv_L_cache` (left-padded by `L_cache - 1` on prefill, or prepended with the cached `L_cache - 1` steps on decode), then `y = C * conv_out` and `out_proj(y)`. The per-layer conv cache holds the last `L_cache - 1` time steps of `Bx`.

## Sigmoid-gating correctness note

The `lfm2_moe` router is sigmoid-gated, not softmax (mirrors upstream ml-explore/mlx-lm#1354). `routing_weights = sigmoid(gate(x))`; when `use_expert_bias` is set the bias shifts only the top-k selection (`argpartition(routing_weights.astype(f32) + expert_bias)`), while the combine scores are gathered from the unbiased `routing_weights`, then renormalized when `norm_topk_prob` and scaled by `routed_scaling_factor`. Dense layers (index `< num_dense_layers`) use a plain SwiGLU MLP.

## Files changed

- `src/models/lfm2.rs` (new): config, attention, short-conv, dense MLP, sigmoid-gated MoE block, decoder layer, mixed cache enum, model, weight sanitize, and the `LanguageModel` impl (model-owned mixed cache via `ModelOwnedSequenceState`, `supports_batching() == false`, exact-prefix snapshot reuse).
- `src/models/lfm2_tests.rs` (new): checkpoint-free config and layer-typing tests.
- Registration: `src/models/detection.rs` (`lfm2`, `lfm2_moe`), `src/models/mod.rs` (`pub mod`/`pub use`, `ModelType::Lfm2`/`Lfm2Moe`, `ALL_MODEL_TYPES`, metadata, test mod), `src/model_metadata.rs` (Nonstandard + Special, adapter None), `src/loaded_model.rs` (enum variants + delegation arm), `src/loading/nonstandard.rs` (directory loaders), `src/loading/special.rs` (owned-config weight route), `src/distributed/tensor_parallel/inference.rs` (fallback architecture), `src/main.rs` (`FAMILY_ORDER`), `docs/supported-models.md`.

## Implementation notes for the reviewer

- Conv weight orientation: the reference transposes `[hidden, 1, L_cache]` to `[hidden, L_cache, 1]`. The mlx-community checkpoints already ship the `[hidden, L_cache, 1]` MLX layout, so the sanitize transpose is a no-op there but keeps raw HF exports loadable.
- Quantized experts: the 4-bit `LFM2-8B-A1B-4bit` checkpoint already ships the stacked `feed_forward.switch_mlp.{gate,up,down}_proj` tensors, loaded directly through `switch_layers::SwitchGLU`. The expert-stacking sanitize only fires for non-pre-stacked exports and never slices the packed quantized weights. The 8-bit router and 4-bit experts coexist because `UnifiedLinear` reconciles per-tensor bit width from the tensor shapes.
- Dense `lfm2` stores its MLP as `w1`/`w2`/`w3`; sanitize renames to `gate_proj`/`down_proj`/`up_proj` (including quantized scales/biases) so both checkpoints share one loader.
- The sanitize runs inside `from_weights`, so the directory load route and the owned-weights (adapter) route produce the same canonical layout.

## Test plan

- [x] `cargo check --release --features metal,accelerate --lib`
- [x] `cargo clippy --release --features metal,accelerate --lib -- -D warnings`
- [ ] Unit tests (`cargo test --release lfm2_tests`) and real-model generation are run by the orchestrator (no Metal device in the implementation environment).

Validation: pending orchestrator real-model gate on models/LFM2-350M-8bit and models/LFM2-8B-A1B-4bit.

Closes #246
