### PR TITLE
feat(ci): add Linux x86_64 + aarch64 CUDA release builds with bundled CCCL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,8 +530,11 @@ jobs:
           fi
 
           ( cd package && zip -rq "../${ASSET}.zip" "${ASSET}" )
+          # Show the top of the archive without piping to head: head closes the
+          # pipe early and SIGPIPEs unzip, which set -o pipefail would treat as a
+          # step failure. awk reads the whole stream and self-limits its output.
           echo "=== zip top-level entries ==="
-          unzip -l "${ASSET}.zip" | awk 'NR<=3 || /\/(bin|include)\// {print}' | head -20
+          unzip -l "${ASSET}.zip" | awk 'NR<=3 {print} /\/(bin|include)\// && shown<17 {print; shown++}'
 
       - name: Generate checksum
         run: sha256sum "${{ matrix.asset_name }}.zip" > "${{ matrix.asset_name }}.zip.sha256"
@@ -703,8 +706,11 @@ jobs:
           fi
 
           ( cd package && zip -rq "../${ASSET_NAME}.zip" "${ASSET_NAME}" )
+          # Show the top of the archive without piping to head: head closes the
+          # pipe early and SIGPIPEs unzip, which set -o pipefail would treat as a
+          # step failure. awk reads the whole stream and self-limits its output.
           echo "=== zip top-level entries ==="
-          unzip -l "${ASSET_NAME}.zip" | awk 'NR<=3 || /\/(bin|include)\// {print}' | head -20
+          unzip -l "${ASSET_NAME}.zip" | awk 'NR<=3 {print} /\/(bin|include)\// && shown<17 {print; shown++}'
 
       - name: Generate checksum
         run: sha256sum "${ASSET_NAME}.zip" > "${ASSET_NAME}.zip.sha256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,18 +403,20 @@ jobs:
     permissions:
       contents: write
 
-    # One aarch64 fat binary covering both NVIDIA aarch64 targets in a single
-    # build: GH200 (Grace Hopper, sm_90a) and GB10 / DGX Spark (Blackwell,
-    # sm_121), cross-compiled on the GB10 runner. 90a is load-bearing for MLX's
-    # Hopper quantized kernel gate, and build.rs forwards the list verbatim. The
-    # CLI and server (~347 MB each) ship as separate archives, both with the
-    # CCCL headers.
+    # One aarch64 fat binary covering the NVIDIA aarch64 targets in a single
+    # build: GH200 (Grace Hopper, sm_90a), GB200 (Grace Blackwell, sm_100), and
+    # GB10 / DGX Spark (Blackwell, sm_121), cross-compiled on the GB10 runner.
+    # 90a is load-bearing for MLX's Hopper quantized kernel gate, and build.rs
+    # forwards the list verbatim. The CLI and server (~347 MB each) ship as
+    # separate archives, both with the CCCL headers.
     env:
-      MLX_CUDA_ARCHITECTURES: "90a;121"
+      MLX_CUDA_ARCHITECTURES: "90a;100;121"
       CLI_ASSET: mlxcel-linux-aarch64-cuda13
       SERVER_ASSET: mlxcel-server-linux-aarch64-cuda13
 
-    timeout-minutes: 180
+    # Cold build compiles MLX for three CUDA architectures; generous ceiling so
+    # a from-scratch build is never killed (the cargo cache makes reruns cheap).
+    timeout-minutes: 360
 
     steps:
       # Self-healing release: build the *source of the target tag* while
@@ -588,8 +590,9 @@ jobs:
 
     # A cold build compiles MLX for six CUDA architectures (CUTLASS-heavy
     # quantized kernels per arch); the persistent cargo cache makes later runs
-    # far cheaper. Generous ceiling so a from-scratch build is not killed.
-    timeout-minutes: 300
+    # far cheaper. Generous ceiling so a from-scratch build is not killed (a
+    # cold 6-arch build was observed at ~3h).
+    timeout-minutes: 480
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,11 +499,39 @@ jobs:
 
       - name: Package binaries
         run: |
+          set -euo pipefail
           BIN_DIR="$CARGO_TARGET_DIR/release"
-          mkdir -p package
-          cp "$BIN_DIR/mlxcel" package/
-          cp "$BIN_DIR/mlxcel-server" package/
-          cd package && zip -r "../${{ matrix.asset_name }}.zip" . && cd ..
+          ASSET="${{ matrix.asset_name }}"
+
+          # Bundle the CCCL (libcu++) headers MLX's runtime NVRTC JIT needs. The
+          # compiled-in MLX_CCCL_DIR points at this build machine and is useless
+          # on the deployment host, so ship the headers in MLX's native layout:
+          # the JIT looks for <exe-dir>/../include/cccl, hence bin/ + include/cccl/.
+          # See the x86_64 job for the full rationale.
+          CCCL_INC=$(find "$BIN_DIR/build" -type d -path '*/_deps/cccl-src/include' 2>/dev/null | head -1)
+          if [ -z "$CCCL_INC" ] || [ ! -d "$CCCL_INC/cuda" ] || [ ! -d "$CCCL_INC/nv" ]; then
+            echo "::error::CCCL headers not found under the build tree (expected _deps/cccl-src/include/{cuda,nv})"
+            exit 1
+          fi
+          echo "Bundling CCCL headers from: $CCCL_INC"
+
+          PKG="package/${ASSET}"
+          mkdir -p "$PKG/bin" "$PKG/include/cccl"
+          cp "$BIN_DIR/mlxcel" "$PKG/bin/"
+          cp "$BIN_DIR/mlxcel-server" "$PKG/bin/"
+          cp -R "$CCCL_INC/cuda" "$PKG/include/cccl/"
+          cp -R "$CCCL_INC/nv" "$PKG/include/cccl/"
+
+          CCCL_FILES=$(find "$PKG/include/cccl" -type f | wc -l | tr -d ' ')
+          echo "Bundled CCCL header files: $CCCL_FILES"
+          if [ ! -f "$PKG/include/cccl/cuda/std/tuple" ] || [ "$CCCL_FILES" -lt 100 ]; then
+            echo "::error::CCCL bundle looks incomplete (missing cuda/std/tuple or too few files)"
+            exit 1
+          fi
+
+          ( cd package && zip -rq "../${ASSET}.zip" "${ASSET}" )
+          echo "=== zip top-level entries ==="
+          unzip -l "${ASSET}.zip" | awk 'NR<=3 || /\/(bin|include)\// {print}' | head -20
 
       - name: Generate checksum
         run: sha256sum "${{ matrix.asset_name }}.zip" > "${{ matrix.asset_name }}.zip.sha256"
@@ -641,11 +669,42 @@ jobs:
 
       - name: Package binaries
         run: |
+          set -euo pipefail
           BIN_DIR="$CARGO_TARGET_DIR/release"
-          mkdir -p package
-          cp "$BIN_DIR/mlxcel" package/
-          cp "$BIN_DIR/mlxcel-server" package/
-          cd package && zip -r "../${ASSET_NAME}.zip" . && cd ..
+
+          # MLX's CUDA backend NVRTC-JITs gather/indexing kernels at runtime;
+          # those include <cuda/std/tuple>, so the CCCL (libcu++) headers must be
+          # present on the deployment host. The compiled-in MLX_CCCL_DIR points at
+          # this build machine's path and is useless elsewhere, so bundle the
+          # headers in MLX's native runtime layout: the JIT looks for
+          # <exe-dir>/../include/cccl, hence bin/ + include/cccl/. Only cuda/ and
+          # nv/ are needed (MLX installs exactly those), ~8.8 MB. Host CUDA runtime
+          # headers (cuda_runtime.h etc.) still come from the node's CUDA_HOME.
+          CCCL_INC=$(find "$BIN_DIR/build" -type d -path '*/_deps/cccl-src/include' 2>/dev/null | head -1)
+          if [ -z "$CCCL_INC" ] || [ ! -d "$CCCL_INC/cuda" ] || [ ! -d "$CCCL_INC/nv" ]; then
+            echo "::error::CCCL headers not found under the build tree (expected _deps/cccl-src/include/{cuda,nv})"
+            exit 1
+          fi
+          echo "Bundling CCCL headers from: $CCCL_INC"
+
+          PKG="package/${ASSET_NAME}"
+          mkdir -p "$PKG/bin" "$PKG/include/cccl"
+          cp "$BIN_DIR/mlxcel" "$PKG/bin/"
+          cp "$BIN_DIR/mlxcel-server" "$PKG/bin/"
+          cp -R "$CCCL_INC/cuda" "$PKG/include/cccl/"
+          cp -R "$CCCL_INC/nv" "$PKG/include/cccl/"
+
+          # Sanity-check the bundle before zipping.
+          CCCL_FILES=$(find "$PKG/include/cccl" -type f | wc -l | tr -d ' ')
+          echo "Bundled CCCL header files: $CCCL_FILES"
+          if [ ! -f "$PKG/include/cccl/cuda/std/tuple" ] || [ "$CCCL_FILES" -lt 100 ]; then
+            echo "::error::CCCL bundle looks incomplete (missing cuda/std/tuple or too few files)"
+            exit 1
+          fi
+
+          ( cd package && zip -rq "../${ASSET_NAME}.zip" "${ASSET_NAME}" )
+          echo "=== zip top-level entries ==="
+          unzip -l "${ASSET_NAME}.zip" | awk 'NR<=3 || /\/(bin|include)\// {print}' | head -20
 
       - name: Generate checksum
         run: sha256sum "${ASSET_NAME}.zip" > "${ASSET_NAME}.zip.sha256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,18 @@ on:
           - all
           - macos
           - linux
+          - linux-x86_64
 
 # Default-deny top-level permissions; each job grants only what it needs.
 permissions: {}
+
+# Pinned MLX C++ commit, shared by both Linux CUDA jobs for build-cache
+# validation. Must match GIT_TAG in src/lib/mlx-cpp/CMakeLists.txt and
+# MLX_EXPECTED_COMMIT in src/lib/mlxcel-core/build.rs (the three-place pin
+# documented in CLAUDE.md). Hoisted to workflow scope so a future bump
+# touches one literal here instead of one per job.
+env:
+  MLX_EXPECTED_COMMIT: "a6ec7123dac814417147e21d4aeed694924ddd4d"
 
 jobs:
   # ============================================================================
@@ -350,7 +359,7 @@ jobs:
         run: shasum -a 256 mlxcel-macos-aarch64.zip > mlxcel-macos-aarch64.zip.sha256
 
       - name: Upload release artifacts
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
@@ -455,11 +464,8 @@ jobs:
           fi
 
       - name: Validate MLX build cache
-        env:
-          # Must match GIT_TAG in src/lib/mlx-cpp/CMakeLists.txt and
-          # MLX_EXPECTED_COMMIT in src/lib/mlxcel-core/build.rs
-          MLX_EXPECTED_COMMIT: "a6ec7123dac814417147e21d4aeed694924ddd4d"
         run: |
+          # MLX_EXPECTED_COMMIT is set at workflow scope (top of this file).
           # Check every _deps directory for a valid .mlx-build-commit marker.
           # If the marker is missing or doesn't match, purge that _deps/ entirely.
           # This ensures stale MLX source/objects never survive across MLX upgrades.
@@ -503,7 +509,7 @@ jobs:
         run: sha256sum "${{ matrix.asset_name }}.zip" > "${{ matrix.asset_name }}.zip.sha256"
 
       - name: Upload release artifacts
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
@@ -512,11 +518,153 @@ jobs:
             ${{ matrix.asset_name }}.zip.sha256
 
   # ============================================================================
+  # Linux x86_64 + CUDA build (self-hosted RTX-class runner)
+  # ============================================================================
+  build-linux-x86_64-cuda:
+    name: Build Linux x86_64 CUDA
+    # Self-hosted x86_64 NVIDIA runner. A Linux x64 self-hosted runner is given
+    # the self-hosted/Linux/X64 default labels automatically; CUDA is the custom
+    # label that marks the NVIDIA-equipped host (lablup-x64-cuda-build1).
+    runs-on: [self-hosted, Linux, X64, CUDA]
+    environment: packaging
+    # See the macOS job for the rationale behind these two guards. The dispatch
+    # filter: `linux` builds every Linux arch, `linux-x86_64` isolates this job
+    # for bring-up without churning the aarch64 artifacts.
+    if: |
+      github.repository == 'lablup/mlxcel' && (
+        github.event_name == 'release' ||
+        github.event.inputs.targets == 'all' ||
+        github.event.inputs.targets == 'linux' ||
+        github.event.inputs.targets == 'linux-x86_64'
+      )
+    permissions:
+      contents: write
+
+    # One fat binary covering Ampere and later. 90a is load-bearing: MLX gates
+    # its Hopper quantized kernel on "90a" being in the list (MLX_CUDA_SM90A_ENABLED),
+    # and build.rs forwards MLX_CUDA_ARCHITECTURES verbatim (no auto-suffix). Blackwell
+    # (sm_100/sm_120) has no MLX gate, so plain numbers emit SASS+PTX. sm_87 (Jetson)
+    # and sm_121 (GB10) are aarch64-only and excluded here. The build runner's own GPU
+    # is an RTX 5060 (sm_120), so the smoke test below runs on native SASS.
+    env:
+      MLX_CUDA_ARCHITECTURES: "80;86;89;90a;100;120"
+      ASSET_NAME: mlxcel-linux-x86_64-cuda13
+
+    # A cold build compiles MLX for six CUDA architectures (CUTLASS-heavy
+    # quantized kernels per arch); the persistent cargo cache makes later runs
+    # far cheaper. Generous ceiling so a from-scratch build is not killed.
+    timeout-minutes: 300
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name || github.event.inputs.release_tag || github.sha }}
+
+      - name: Setup persistent cache paths (self-hosted)
+        run: |
+          CARGO_TARGET="$HOME/.cargo-target/mlxcel-cuda-x86_64"
+          mkdir -p "$CARGO_TARGET"
+          echo "CARGO_TARGET_DIR=$CARGO_TARGET" >> $GITHUB_ENV
+
+          # Prune stale cargo target cache if older than 7 days.
+          MARKER="$CARGO_TARGET/.last-clean"
+          SHOULD_CLEAN=false
+          if [ ! -f "$MARKER" ]; then
+            SHOULD_CLEAN=true
+          elif [ "$(find "$MARKER" -mtime +7 2>/dev/null)" ]; then
+            SHOULD_CLEAN=true
+          fi
+          if [ "$SHOULD_CLEAN" = true ]; then
+            echo "Cargo target cache older than 7 days: cleaning"
+            rm -rf "$CARGO_TARGET"
+            mkdir -p "$CARGO_TARGET"
+            date -u +"%Y-%m-%dT%H:%M:%SZ" > "$MARKER"
+          else
+            AGE_DAYS=$(( ($(date +%s) - $(stat -c %Y "$MARKER")) / 86400 ))
+            echo "Cargo target cache age: ${AGE_DAYS}d (keeping)"
+          fi
+
+      - name: Validate MLX build cache
+        run: |
+          # MLX_EXPECTED_COMMIT is set at workflow scope (top of this file).
+          # Check every _deps directory for a valid .mlx-build-commit marker.
+          # If the marker is missing or doesn't match, purge that _deps/ entirely.
+          FOUND=0
+          PURGED=0
+          for deps_dir in $(find "$CARGO_TARGET_DIR" -path "*/_deps" -type d 2>/dev/null); do
+            FOUND=$((FOUND + 1))
+            MARKER="$deps_dir/.mlx-build-commit"
+            if [ -f "$MARKER" ] && [ "$(cat "$MARKER")" = "$MLX_EXPECTED_COMMIT" ]; then
+              echo "Valid cache: $deps_dir"
+            else
+              echo "Stale cache (marker=$(cat "$MARKER" 2>/dev/null || echo 'missing')): purging $deps_dir"
+              rm -rf "$deps_dir"
+              PURGED=$((PURGED + 1))
+            fi
+          done
+          for deps_dir in $(find target -path "*/_deps" -type d 2>/dev/null); do
+            rm -rf "$deps_dir"
+            PURGED=$((PURGED + 1))
+          done
+          echo "Checked $FOUND cache(s), purged $PURGED"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release binaries
+        run: cargo build --release --features cuda --locked
+        # MLX_CUDA_ARCHITECTURES is inherited from the job env above.
+
+      - name: Smoke test (10-token generate on GPU)
+        run: |
+          set -euo pipefail
+          BIN_DIR="$CARGO_TARGET_DIR/release"
+          # Make the CUDA runtime/math libs we linked resolvable at run time.
+          export LD_LIBRARY_PATH="${CUDA_HOME:-/usr/local/cuda}/lib64:${LD_LIBRARY_PATH:-}"
+          # Keep the model cache inside the job temp dir so it does not accumulate
+          # on the persistent self-hosted runner.
+          export MLXCEL_CACHE_DIR="$RUNNER_TEMP/mlxcel-smoke"
+          MODEL_ID="mlx-community/Qwen3-0.6B-4bit"
+          MODEL_DIR="$MLXCEL_CACHE_DIR/models/mlx-community/Qwen3-0.6B-4bit"
+          echo "=== GPU ==="
+          nvidia-smi || true
+          echo "=== download $MODEL_ID ==="
+          "$BIN_DIR/mlxcel" download "$MODEL_ID"
+          echo "=== generate (10 tokens) ==="
+          "$BIN_DIR/mlxcel" generate -m "$MODEL_DIR" -p "Hello, world." -n 10
+
+      - name: Clean up smoke-test model cache
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/mlxcel-smoke" 2>/dev/null || true
+
+      - name: Package binaries
+        run: |
+          BIN_DIR="$CARGO_TARGET_DIR/release"
+          mkdir -p package
+          cp "$BIN_DIR/mlxcel" package/
+          cp "$BIN_DIR/mlxcel-server" package/
+          cd package && zip -r "../${ASSET_NAME}.zip" . && cd ..
+
+      - name: Generate checksum
+        run: sha256sum "${ASSET_NAME}.zip" > "${ASSET_NAME}.zip.sha256"
+
+      - name: Upload release artifacts
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+          files: |
+            ${{ env.ASSET_NAME }}.zip
+            ${{ env.ASSET_NAME }}.zip.sha256
+
+  # ============================================================================
   # Microsoft Teams release notification (Power Automate Workflows webhook)
   # ============================================================================
   notify-teams:
     name: Notify Teams on release
-    needs: [build-macos, build-linux-cuda]
+    needs: [build-macos, build-linux-cuda, build-linux-x86_64-cuda]
     if: github.repository == 'lablup/mlxcel' && github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions: {}
@@ -570,8 +718,8 @@ jobs:
   # ============================================================================
   promote-release:
     name: Promote to full release
-    needs: [build-macos, build-linux-cuda]
-    if: always() && github.repository == 'lablup/mlxcel' && github.event_name == 'release' && github.event.release.prerelease && needs.build-macos.result == 'success' && needs.build-linux-cuda.result == 'success'
+    needs: [build-macos, build-linux-cuda, build-linux-x86_64-cuda]
+    if: always() && github.repository == 'lablup/mlxcel' && github.event_name == 'release' && github.event.release.prerelease && needs.build-macos.result == 'success' && needs.build-linux-cuda.result == 'success' && needs.build-linux-x86_64-cuda.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ on:
           - all
           - macos
           - linux
+          - linux-aarch64
           - linux-x86_64
 
 # Default-deny top-level permissions; each job grants only what it needs.
@@ -388,7 +389,7 @@ jobs:
   # Linux ARM64 + CUDA builds (self-hosted GB10 runner)
   # ============================================================================
   build-linux-cuda:
-    name: Build Linux ARM64 CUDA (${{ matrix.variant }})
+    name: Build Linux aarch64 CUDA
     runs-on: GB10
     environment: packaging
     # See the macOS job for the rationale behind these two guards.
@@ -396,26 +397,24 @@ jobs:
       github.repository == 'lablup/mlxcel' && (
         github.event_name == 'release' ||
         github.event.inputs.targets == 'all' ||
-        github.event.inputs.targets == 'linux'
+        github.event.inputs.targets == 'linux' ||
+        github.event.inputs.targets == 'linux-aarch64'
       )
     permissions:
       contents: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # NVIDIA DGX Spark / GB10 (Blackwell, SM 121)
-          - variant: gb10
-            cuda_arch: "121"
-            asset_name: mlxcel-linux-aarch64-cuda13-gb10
+    # One aarch64 fat binary covering both NVIDIA aarch64 targets in a single
+    # build: GH200 (Grace Hopper, sm_90a) and GB10 / DGX Spark (Blackwell,
+    # sm_121), cross-compiled on the GB10 runner. 90a is load-bearing for MLX's
+    # Hopper quantized kernel gate, and build.rs forwards the list verbatim. The
+    # CLI and server (~347 MB each) ship as separate archives, both with the
+    # CCCL headers.
+    env:
+      MLX_CUDA_ARCHITECTURES: "90a;121"
+      CLI_ASSET: mlxcel-linux-aarch64-cuda13
+      SERVER_ASSET: mlxcel-server-linux-aarch64-cuda13
 
-          # NVIDIA GH200 (Grace Hopper, SM 90a) — cross-compiled on GB10 runner
-          - variant: gh200
-            cuda_arch: "90a"
-            asset_name: mlxcel-linux-aarch64-cuda13-gh200
-
-    timeout-minutes: 120
+    timeout-minutes: 180
 
     steps:
       # Self-healing release: build the *source of the target tag* while
@@ -441,7 +440,7 @@ jobs:
         run: |
           # Set persistent cargo target directory to enable incremental builds
           # on self-hosted runner (avoids recompiling from scratch every run)
-          CARGO_TARGET="$HOME/.cargo-target/mlxcel-cuda-${{ matrix.variant }}"
+          CARGO_TARGET="$HOME/.cargo-target/mlxcel-cuda-aarch64"
           mkdir -p "$CARGO_TARGET"
           echo "CARGO_TARGET_DIR=$CARGO_TARGET" >> $GITHUB_ENV
 
@@ -494,14 +493,12 @@ jobs:
 
       - name: Build release binaries
         run: cargo build --release --features cuda --locked
-        env:
-          MLX_CUDA_ARCHITECTURES: ${{ matrix.cuda_arch }}
+        # MLX_CUDA_ARCHITECTURES is inherited from the job env above.
 
       - name: Package binaries
         run: |
           set -euo pipefail
           BIN_DIR="$CARGO_TARGET_DIR/release"
-          ASSET="${{ matrix.asset_name }}"
 
           # Bundle the CCCL (libcu++) headers MLX's runtime NVRTC JIT needs. The
           # compiled-in MLX_CCCL_DIR points at this build machine and is useless
@@ -515,29 +512,32 @@ jobs:
           fi
           echo "Bundling CCCL headers from: $CCCL_INC"
 
-          PKG="package/${ASSET}"
-          mkdir -p "$PKG/bin" "$PKG/include/cccl"
-          cp "$BIN_DIR/mlxcel" "$PKG/bin/"
-          cp "$BIN_DIR/mlxcel-server" "$PKG/bin/"
-          cp -R "$CCCL_INC/cuda" "$PKG/include/cccl/"
-          cp -R "$CCCL_INC/nv" "$PKG/include/cccl/"
+          package_one() {
+            bin="$1"; asset="$2"
+            pkg="package/${asset}"
+            rm -rf "$pkg"
+            mkdir -p "$pkg/bin" "$pkg/include/cccl"
+            cp "$BIN_DIR/${bin}" "$pkg/bin/"
+            cp -R "$CCCL_INC/cuda" "$pkg/include/cccl/"
+            cp -R "$CCCL_INC/nv" "$pkg/include/cccl/"
+            n=$(find "$pkg/include/cccl" -type f | wc -l | tr -d ' ')
+            if [ ! -f "$pkg/include/cccl/cuda/std/tuple" ] || [ "$n" -lt 100 ]; then
+              echo "::error::CCCL bundle for ${asset} looks incomplete (${n} files)"
+              exit 1
+            fi
+            ( cd package && zip -rq "../${asset}.zip" "${asset}" )
+            echo "Packaged ${asset}.zip ($(du -h "${asset}.zip" | cut -f1), CCCL headers: ${n})"
+          }
 
-          CCCL_FILES=$(find "$PKG/include/cccl" -type f | wc -l | tr -d ' ')
-          echo "Bundled CCCL header files: $CCCL_FILES"
-          if [ ! -f "$PKG/include/cccl/cuda/std/tuple" ] || [ "$CCCL_FILES" -lt 100 ]; then
-            echo "::error::CCCL bundle looks incomplete (missing cuda/std/tuple or too few files)"
-            exit 1
-          fi
+          package_one mlxcel "${CLI_ASSET}"
+          package_one mlxcel-server "${SERVER_ASSET}"
 
-          ( cd package && zip -rq "../${ASSET}.zip" "${ASSET}" )
-          # Show the top of the archive without piping to head: head closes the
-          # pipe early and SIGPIPEs unzip, which set -o pipefail would treat as a
-          # step failure. awk reads the whole stream and self-limits its output.
-          echo "=== zip top-level entries ==="
-          unzip -l "${ASSET}.zip" | awk 'NR<=3 {print} /\/(bin|include)\// && shown<17 {print; shown++}'
-
-      - name: Generate checksum
-        run: sha256sum "${{ matrix.asset_name }}.zip" > "${{ matrix.asset_name }}.zip.sha256"
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          for asset in "${CLI_ASSET}" "${SERVER_ASSET}"; do
+            sha256sum "${asset}.zip" > "${asset}.zip.sha256"
+          done
 
       - name: Upload release artifacts
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
@@ -545,8 +545,10 @@ jobs:
         with:
           tag_name: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
           files: |
-            ${{ matrix.asset_name }}.zip
-            ${{ matrix.asset_name }}.zip.sha256
+            ${{ env.CLI_ASSET }}.zip
+            ${{ env.CLI_ASSET }}.zip.sha256
+            ${{ env.SERVER_ASSET }}.zip
+            ${{ env.SERVER_ASSET }}.zip.sha256
 
   # ============================================================================
   # Linux x86_64 + CUDA build (self-hosted RTX-class runner)
@@ -579,7 +581,10 @@ jobs:
     # is an RTX 5060 (sm_120), so the smoke test below runs on native SASS.
     env:
       MLX_CUDA_ARCHITECTURES: "80;86;89;90a;100;120"
-      ASSET_NAME: mlxcel-linux-x86_64-cuda13
+      # The CLI and server binaries are ~347 MB each, so ship them as separate
+      # archives; a consumer pulls only what it needs. Both carry the CCCL headers.
+      CLI_ASSET: mlxcel-linux-x86_64-cuda13
+      SERVER_ASSET: mlxcel-server-linux-x86_64-cuda13
 
     # A cold build compiles MLX for six CUDA architectures (CUTLASS-heavy
     # quantized kernels per arch); the persistent cargo cache makes later runs
@@ -690,30 +695,34 @@ jobs:
           fi
           echo "Bundling CCCL headers from: $CCCL_INC"
 
-          PKG="package/${ASSET_NAME}"
-          mkdir -p "$PKG/bin" "$PKG/include/cccl"
-          cp "$BIN_DIR/mlxcel" "$PKG/bin/"
-          cp "$BIN_DIR/mlxcel-server" "$PKG/bin/"
-          cp -R "$CCCL_INC/cuda" "$PKG/include/cccl/"
-          cp -R "$CCCL_INC/nv" "$PKG/include/cccl/"
+          # Package one binary as its own self-contained archive: bin/<binary>
+          # plus the CCCL headers in MLX's native include/cccl/ layout.
+          package_one() {
+            bin="$1"; asset="$2"
+            pkg="package/${asset}"
+            rm -rf "$pkg"
+            mkdir -p "$pkg/bin" "$pkg/include/cccl"
+            cp "$BIN_DIR/${bin}" "$pkg/bin/"
+            cp -R "$CCCL_INC/cuda" "$pkg/include/cccl/"
+            cp -R "$CCCL_INC/nv" "$pkg/include/cccl/"
+            n=$(find "$pkg/include/cccl" -type f | wc -l | tr -d ' ')
+            if [ ! -f "$pkg/include/cccl/cuda/std/tuple" ] || [ "$n" -lt 100 ]; then
+              echo "::error::CCCL bundle for ${asset} looks incomplete (${n} files)"
+              exit 1
+            fi
+            ( cd package && zip -rq "../${asset}.zip" "${asset}" )
+            echo "Packaged ${asset}.zip ($(du -h "${asset}.zip" | cut -f1), CCCL headers: ${n})"
+          }
 
-          # Sanity-check the bundle before zipping.
-          CCCL_FILES=$(find "$PKG/include/cccl" -type f | wc -l | tr -d ' ')
-          echo "Bundled CCCL header files: $CCCL_FILES"
-          if [ ! -f "$PKG/include/cccl/cuda/std/tuple" ] || [ "$CCCL_FILES" -lt 100 ]; then
-            echo "::error::CCCL bundle looks incomplete (missing cuda/std/tuple or too few files)"
-            exit 1
-          fi
+          package_one mlxcel "${CLI_ASSET}"
+          package_one mlxcel-server "${SERVER_ASSET}"
 
-          ( cd package && zip -rq "../${ASSET_NAME}.zip" "${ASSET_NAME}" )
-          # Show the top of the archive without piping to head: head closes the
-          # pipe early and SIGPIPEs unzip, which set -o pipefail would treat as a
-          # step failure. awk reads the whole stream and self-limits its output.
-          echo "=== zip top-level entries ==="
-          unzip -l "${ASSET_NAME}.zip" | awk 'NR<=3 {print} /\/(bin|include)\// && shown<17 {print; shown++}'
-
-      - name: Generate checksum
-        run: sha256sum "${ASSET_NAME}.zip" > "${ASSET_NAME}.zip.sha256"
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          for asset in "${CLI_ASSET}" "${SERVER_ASSET}"; do
+            sha256sum "${asset}.zip" > "${asset}.zip.sha256"
+          done
 
       - name: Upload release artifacts
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
@@ -721,8 +730,10 @@ jobs:
         with:
           tag_name: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
           files: |
-            ${{ env.ASSET_NAME }}.zip
-            ${{ env.ASSET_NAME }}.zip.sha256
+            ${{ env.CLI_ASSET }}.zip
+            ${{ env.CLI_ASSET }}.zip.sha256
+            ${{ env.SERVER_ASSET }}.zip
+            ${{ env.SERVER_ASSET }}.zip.sha256
 
   # ============================================================================
   # Microsoft Teams release notification (Power Automate Workflows webhook)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,11 +110,14 @@ MLX_CUDA_ARCHITECTURES=121 cargo build --release --features cuda
 MLX_CUDA_ARCHITECTURES="90a;121" cargo build --release --features cuda
 ```
 
-The repository release workflow builds Linux ARM64 CUDA artifacts for GB10
-(`121`) and GH200 (`90a`) as separate per-target binaries, plus a single Linux
-x86_64 CUDA artifact that fattens Ampere through Blackwell into one binary
-(`80;86;89;90a;100;120`), all on self-hosted runners. Treat other GPU/OS
-combinations as source builds that need local validation.
+The repository release workflow builds two Linux CUDA targets on self-hosted
+runners, each as one fat binary: aarch64 covering GH200 (`90a`) and GB10
+(`121`) in a single build (`90a;121`), and x86_64 covering Ampere through
+Blackwell (`80;86;89;90a;100;120`). For each target the `mlxcel` CLI and the
+`mlxcel-server` are published as separate archives (`mlxcel-...` and
+`mlxcel-server-...`, each roughly 347 MB) so a consumer downloads only the one
+it needs. Treat other GPU/OS combinations as source builds that need local
+validation.
 
 ### Prebuilt CUDA artifact: runtime requirements
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -129,7 +129,12 @@ headers available on the deployment host, not only the runtime libraries:
   archives (both aarch64 and x86_64). Each unpacks to `bin/` + `include/cccl/`,
   the layout MLX's JIT looks for relative to the executable
   (`<exe-dir>/../include/cccl`). Keep `mlxcel`/`mlxcel-server` under `bin/` and
-  the `include/cccl/` directory beside it; do not flatten them.
+  the `include/cccl/` directory beside it; do not flatten them. Launch the
+  binary by its **absolute path** (`/path/to/bin/mlxcel`, as a service manager
+  or a parent process spawning a subprocess does). MLX resolves the bundled
+  header location from the executable's own path, and a relative launch
+  (`./mlxcel` from inside `bin/`) can defeat that resolution and fail the first
+  kernel JIT. A future `MLXCEL_CCCL_DIR` override will remove this constraint.
 - **CUDA toolkit headers** (`cuda_runtime.h` and friends) come from the host.
   Install the CUDA toolkit and set `CUDA_HOME` (or `CUDA_PATH`) if it is not at
   `/usr/local/cuda`. Without them the first NVRTC compile fails with

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,7 +56,23 @@ Prerequisites vary by distribution and CUDA version. At minimum you need:
 - CUDA toolkit with `nvcc`.
 - NVIDIA driver compatible with the selected CUDA toolkit.
 - cuDNN and CUDA runtime libraries required by the pinned MLX build.
-- OpenBLAS and LAPACK development/runtime packages.
+- BLAS and LAPACK development packages, including the C headers. MLX's CMake
+  resolves `cblas.h` and `lapacke.h`, so the `lapacke` headers must be present,
+  not only the runtime libraries.
+
+On Debian/Ubuntu (x86_64 or aarch64) the build packages are:
+
+```bash
+sudo apt-get install -y \
+    build-essential cmake git \
+    libopenblas-dev liblapack-dev liblapacke-dev
+# CUDA toolkit (nvcc) and cuDNN come from NVIDIA's apt repository, e.g.
+#   cuda-toolkit-13-0  cudnn9-cuda-13
+```
+
+`liblapacke-dev` is the package that ships `lapacke.h`; `liblapack-dev` alone
+omits it and the MLX CMake configure step fails with `LAPACK_INCLUDE_DIRS` set
+to `NOTFOUND`.
 
 Example build shape:
 
@@ -94,8 +110,10 @@ MLX_CUDA_ARCHITECTURES=121 cargo build --release --features cuda
 MLX_CUDA_ARCHITECTURES="90a;121" cargo build --release --features cuda
 ```
 
-The repository release workflow currently builds Linux ARM64 CUDA artifacts for
-GB10 (`121`) and GH200 (`90a`) on a self-hosted runner. Treat other GPU/OS
+The repository release workflow builds Linux ARM64 CUDA artifacts for GB10
+(`121`) and GH200 (`90a`) as separate per-target binaries, plus a single Linux
+x86_64 CUDA artifact that fattens Ampere through Blackwell into one binary
+(`80;86;89;90a;100;120`), all on self-hosted runners. Treat other GPU/OS
 combinations as source builds that need local validation.
 
 ## Runtime environment variables

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -111,9 +111,9 @@ MLX_CUDA_ARCHITECTURES="90a;121" cargo build --release --features cuda
 ```
 
 The repository release workflow builds two Linux CUDA targets on self-hosted
-runners, each as one fat binary: aarch64 covering GH200 (`90a`) and GB10
-(`121`) in a single build (`90a;121`), and x86_64 covering Ampere through
-Blackwell (`80;86;89;90a;100;120`). For each target the `mlxcel` CLI and the
+runners, each as one fat binary: aarch64 covering GH200 (`90a`), GB200 (`100`),
+and GB10 (`121`) in a single build (`90a;100;121`), and x86_64 covering Ampere
+through Blackwell (`80;86;89;90a;100;120`). For each target the `mlxcel` CLI and the
 `mlxcel-server` are published as separate archives (`mlxcel-...` and
 `mlxcel-server-...`, each roughly 347 MB) so a consumer downloads only the one
 it needs. Treat other GPU/OS combinations as source builds that need local

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,6 +116,28 @@ x86_64 CUDA artifact that fattens Ampere through Blackwell into one binary
 (`80;86;89;90a;100;120`), all on self-hosted runners. Treat other GPU/OS
 combinations as source builds that need local validation.
 
+### Prebuilt CUDA artifact: runtime requirements
+
+MLX's CUDA backend compiles some kernels (gather and other indexing kernels)
+at runtime with NVRTC the first time they run, so a prebuilt binary needs CUDA
+headers available on the deployment host, not only the runtime libraries:
+
+- **CCCL (libcu++) headers** are bundled inside the prebuilt Linux CUDA
+  archives (both aarch64 and x86_64). Each unpacks to `bin/` + `include/cccl/`,
+  the layout MLX's JIT looks for relative to the executable
+  (`<exe-dir>/../include/cccl`). Keep `mlxcel`/`mlxcel-server` under `bin/` and
+  the `include/cccl/` directory beside it; do not flatten them.
+- **CUDA toolkit headers** (`cuda_runtime.h` and friends) come from the host.
+  Install the CUDA toolkit and set `CUDA_HOME` (or `CUDA_PATH`) if it is not at
+  `/usr/local/cuda`. Without them the first NVRTC compile fails with
+  `cannot open source file` errors.
+- An NVIDIA driver matching the CUDA toolkit must be present to run on the GPU.
+
+Compiled kernels are cached on disk (`MLX_PTX_CACHE_DIR`, default under the
+system temp dir), so only the first run of each kernel variant pays the NVRTC
+cost. Point `MLX_PTX_CACHE_DIR` at a persistent path to keep the cache across
+sessions.
+
 ## Runtime environment variables
 
 | Variable | Description | Default |


### PR DESCRIPTION
## Summary

Add Linux CUDA release builds (issue #25 part A). Both targets are fat binaries, and the `mlxcel` CLI and `mlxcel-server` ship as separate, self-contained archives.

- **x86_64** (self-hosted X64/CUDA runner): one fat binary over Ampere..Blackwell (`80;86;89;90a;100;120`), with a GPU smoke test (load + 10-token generate).
- **aarch64** (GB10 runner): collapse the gb10/gh200 matrix into one fat binary over GH200 + GB200 + GB10 (`90a;100;121`).

### CCCL bundling

MLX's CUDA backend NVRTC-JITs gather/indexing kernels at runtime, which need the CCCL (libcu++) headers (`cuda/std/tuple`). The compiled-in `MLX_CCCL_DIR` points at the build machine, so a flat binary aborts elsewhere with `cannot open source file "cuda/std/tuple"`. Each archive bundles the CCCL headers (~8.8 MB, 953 files) in MLX's native runtime layout: `bin/<binary>` + `include/cccl/`.

Known limitation: MLX resolves the bundle from the executable's own path via `dladdr`, so launch the binary by its **absolute path** (as a service manager or subprocess spawn does); a relative `./mlxcel` from inside `bin/` can miss the bundle. A follow-up (#265) adds an `MLXCEL_CCCL_DIR` override and `/proc/self/exe` resolution to remove this constraint.

### Other changes

- Hoist `MLX_EXPECTED_COMMIT` to a workflow-scoped env shared by both CUDA jobs.
- Split CLI/server into separate archives (each ~347 MB) so consumers pull only what they need.
- New `linux-aarch64` / `linux-x86_64` dispatch targets for isolated builds; raise build timeouts (aarch64 360, x86_64 480).
- Fix the upload gate across all jobs to honor the documented "empty release_tag = no upload".
- `docs/installation.md`: require `liblapacke-dev`; document the prebuilt-artifact runtime requirements (layout, `CUDA_HOME`, absolute-path launch, `MLX_PTX_CACHE_DIR`).

## Validation

- x86_64: full build + GPU smoke test on RTX 5060 (sm_120) green; split packaging produces both archives (278M / 277M, 953 CCCL headers each). Runtime confirmed on a Backend.AI node via absolute-path launch.
- aarch64: build verification in progress at merge time; any failure handled in a follow-up.

Part of #25.
