### PR TITLE
perf(models): gate Mamba2 mixer eval boundary to M5 Max

### DIFF
--- a/src/lib/mlxcel-core/src/hardware.rs
+++ b/src/lib/mlxcel-core/src/hardware.rs
@@ -110,6 +110,21 @@ pub fn get_hardware() -> &'static HardwareCapabilities {
     HARDWARE_CAPABILITIES.get_or_init(detect_hardware)
 }
 
+/// True only on M5-class Apple Silicon whose Neural Accelerator is driven by
+/// the running macOS (Metal GPU Family 4).
+///
+/// This is the gate for M5-Max-specific numerical workarounds. The M5 Max NAx
+/// GEMM kernels can fuse a lazy float32/float16 graph into NaN within a single
+/// Metal command buffer; code that builds such graphs (the Mamba2/SSM mixers)
+/// forces an intermediate `eval` boundary, but only when this returns true. On
+/// every other chip that eval boundary is pure throughput loss, so it is
+/// skipped. See CLAUDE.md "Apple Silicon precision".
+#[inline]
+pub fn is_m5_neural_accelerator() -> bool {
+    let hw = get_hardware();
+    hw.has_neural_accelerator && hw.macos_supports_na
+}
+
 // ── Detection ─────────────────────────────────────────────────────────────────
 
 /// Detect hardware capabilities by querying the OS at runtime.

--- a/src/models/falcon_h1.rs
+++ b/src/models/falcon_h1.rs
@@ -413,10 +413,14 @@ impl FalconH1Mixer {
 
         let result = self.out_proj.forward(&y_gated);
 
-        // Materialize at a clean dtype boundary. The lazy SSM graph mixes
-        // float32/float16 nodes that can produce NaN when fused with downstream
-        // layers in one Metal command buffer on M5 Max (Metal GPU Family 4).
-        mlxcel_core::eval(&result);
+        // Materialize at a clean dtype boundary ONLY on M5 Max (Metal GPU
+        // Family 4): there the lazy float32/float16 SSM graph can fuse into NaN
+        // within one Metal command buffer. On every other chip this per-layer
+        // sync is pure decode-throughput loss (it blocks cross-layer
+        // pipelining), so skip it. CLAUDE.md "Apple Silicon precision".
+        if mlxcel_core::hardware::is_m5_neural_accelerator() {
+            mlxcel_core::eval(&result);
+        }
         result
     }
 

--- a/src/models/granitemoehybrid.rs
+++ b/src/models/granitemoehybrid.rs
@@ -448,10 +448,14 @@ impl GraniteMoeHybridMamba2Mixer {
 
         let result = self.out_proj.forward(&y_gated);
 
-        // Materialize at a clean dtype boundary. The lazy SSM graph mixes
-        // float32/float16 nodes that can produce NaN when fused with downstream
-        // layers in one Metal command buffer on M5 Max (Metal GPU Family 4).
-        mlxcel_core::eval(&result);
+        // Materialize at a clean dtype boundary ONLY on M5 Max (Metal GPU
+        // Family 4): there the lazy float32/float16 SSM graph can fuse into NaN
+        // within one Metal command buffer. On every other chip this per-layer
+        // sync is pure decode-throughput loss (it blocks cross-layer
+        // pipelining), so skip it. CLAUDE.md "Apple Silicon precision".
+        if mlxcel_core::hardware::is_m5_neural_accelerator() {
+            mlxcel_core::eval(&result);
+        }
         result
     }
 

--- a/src/models/plamo2.rs
+++ b/src/models/plamo2.rs
@@ -395,9 +395,14 @@ impl Plamo2Mamba {
         let gated = mlxcel_core::compiled_swiglu_activation(&z_flat, &y);
         let result = self.out_proj.forward(&gated);
 
-        // Materialize at a clean dtype boundary. The lazy SSM graph mixes
-        // float32/float16 nodes that can fuse into NaN downstream on M5 Max.
-        mlxcel_core::eval(&result);
+        // Materialize at a clean dtype boundary ONLY on M5 Max (Metal GPU
+        // Family 4): there the lazy float32/float16 SSM graph can fuse into NaN
+        // within one Metal command buffer. On every other chip this per-layer
+        // sync is pure decode-throughput loss (it blocks cross-layer
+        // pipelining), so skip it. CLAUDE.md "Apple Silicon precision".
+        if mlxcel_core::hardware::is_m5_neural_accelerator() {
+            mlxcel_core::eval(&result);
+        }
         result
     }
 


### PR DESCRIPTION
## Summary

While benchmarking the newly ported model families against `mlx-lm` on this M1 Ultra, the three Mamba2-SSM hybrids decoded **3-5x slower** than `mlx-lm` on identical checkpoints, while the dense / MoE / ShortConv families sat at parity. Root cause: every SSM mixer (`falcon_h1`, `granitemoehybrid`, `plamo2`) ended its forward with an **unconditional** `mlxcel_core::eval(&result)`.

That eval is an M5 Max (Metal GPU Family 4) numerical workaround. The M5 Max NAx GEMM kernels can fuse a lazy float32/float16 graph into NaN inside a single Metal command buffer, so the SSM mixers force a materialization boundary to split the graph. The boundary is correct on M5 Max but ran on **every** Apple Silicon. On non-M5 chips it is a per-layer GPU sync that serializes decode and blocks cross-layer pipelining, with no numerical benefit (those chips have no NAx kernels and never hit the fusion bug). Transformer / MoE / ShortConv layers build no such graph, so they were unaffected, which is exactly the observed pattern.

This also violated the repo's own rule (CLAUDE.md, "Apple Silicon precision"): *M5-specific code paths must gate on `hw.has_neural_accelerator && hw.macos_supports_na`.*

## Change

- `mlxcel-core/hardware.rs`: add `is_m5_neural_accelerator()` (`has_neural_accelerator && macos_supports_na`), the documented gate for M5-Max-only numerical workarounds. `get_hardware()` is `OnceLock`-cached, so the per-layer call is free.
- `falcon_h1.rs`, `granitemoehybrid.rs`, `plamo2.rs`: wrap the per-mixer `eval(&result)` in `if mlxcel_core::hardware::is_m5_neural_accelerator()`. M5 Max keeps the boundary (behaviour unchanged); every other chip skips it and lets the decode graph pipeline.

## Validation (M1 Ultra, 128 GB, macOS 26.5.1, MLX `a6ec712`)

Decode tok/s, `mlxcel-bench-decode` vs `mlx-lm` 0.31.3, raw prompt (no chat template), 100 tokens after a warmup pass, best-of-3 with cooldown, temp-0 greedy:

| Model | mlxcel before | mlxcel after | mlx-lm | after / mlx-lm |
|---|---|---|---|---|
| Falcon-H1-90M (`falcon_h1`) | 57 | ~180 | 288 | 0.62-0.76x |
| granite-4.0-h-tiny (`granitemoehybrid`) | 36 | 92 | 110 | 0.84x |
| plamo-2-1b (`plamo2`) | 76 | 108 | (mlx-lm needs torch) | n/a |

Greedy output is **byte-identical before and after** on every hybrid (e.g. plamo-2-1b still emits "...Paris is on the Île de la Cité"), confirming the eval was scheduling-only overhead here. `cargo fmt` clean; `cargo clippy -p mlxcel-core -- -D warnings` clean.

## Scope / follow-ups

- `nemotron_h` carries the same per-mixer eval **plus** a separate `needs_chunked_eval` / `eval_interval` strategy and a debug-timing path; gating it needs its own analysis and a 30B validation pass, so it is intentionally left out of this PR.
- Separately observed during the same sweep (not addressed here): `dots.llm1` decodes at ~0.51x of mlx-lm (a non-hybrid MoE / MLA path) and the dense `apertus` / `seed_oss` sit at ~0.83x. Tracked as future perf work.
