### PR TITLE
perf(models): gate nemotron_h Mamba2 per-mixer eval to M5 Max

### DIFF
--- a/src/models/nemotron_h.rs
+++ b/src/models/nemotron_h.rs
@@ -639,13 +639,16 @@ impl NemotronHMamba2Mixer {
         let y_normed = self.norm.forward(&y, Some(&gate));
         let result = self.out_proj.forward(&y_normed);
 
-        // Force evaluation of the Mamba layer output.
-        // On M5 Max (Metal GPU Family 4), the lazy computation graph from
-        // the SSM step contains mixed float32×float16 intermediate nodes
-        // that produce NaN when fused with downstream layers in a single
-        // Metal command buffer.  Materializing here splits the graph at a
-        // clean dtype boundary.
-        mlxcel_core::eval(&result);
+        // Materialize at a clean dtype boundary ONLY on M5 Max (Metal GPU
+        // Family 4): there the lazy float32/float16 SSM graph can fuse into NaN
+        // within one Metal command buffer. On every other chip this per-mixer
+        // sync is pure decode-throughput loss (it blocks cross-layer
+        // pipelining), so skip it. Decode never reaches the prefill chunked-eval
+        // path (`needs_chunked_eval` is `seq_len > 1`), so this is the only
+        // per-token eval to gate. CLAUDE.md "Apple Silicon precision".
+        if mlxcel_core::hardware::is_m5_neural_accelerator() {
+            mlxcel_core::eval(&result);
+        }
 
         result
     }


### PR DESCRIPTION
## Summary

Completes the M5-eval-gating sweep started in #266. `nemotron_h`'s Mamba2 mixer ended its Rust `forward` with an **unconditional** `mlxcel_core::eval(&result)`, the same M5 Max (Metal GPU Family 4) NaN-avoidance workaround #266 gated in `falcon_h1` / `granitemoehybrid` / `plamo2`. It was the last ungated instance. Now gated on `hardware::is_m5_neural_accelerator()`.

## Scope (important nuance)

Unlike the other three hybrids, nemotron_h single-token **decode does not run the Rust mixer body** — it dispatches to a fully-fused C++ path (`forward_fused` → `fused_mamba2_forward`) with no per-layer eval. So this eval only ever ran on the **prefill / fallback** path. Validated on M1 Ultra (`nemotron-h-30b-4bit`, 24-token prompt): prefill **188 → 197 tok/s**, decode unchanged (**55.1 → 54.9**, fused), greedy temp-0 output coherent and unchanged. M5 Max behaviour unchanged (gate returns true there; prefill keeps its separate `needs_chunked_eval` graph-bounding).

## The real decode gap is MoE-bound → #268

nemotron-h-30b decodes at 55 vs mlx-lm 92 tok/s (0.60×). Block profiling (`MLXCEL_PROFILE_BLOCKS=1`) shows the **23 MoE layers are ~60% of decode**, Mamba ~33% (already fused), attention ~7%. This is the same MoE decode path that makes `dots.llm1` lag (0.51×), so the decode gap is tracked in #268, not here.

Closes #267.