### PR TITLE
docs(benchmarks): MoE decode gap investigation (#268)

### DIFF
--- a/docs/benchmark_results/moe-decode-gap-investigation.md
+++ b/docs/benchmark_results/moe-decode-gap-investigation.md
@@ -1,0 +1,120 @@
+# MoE decode performance gap investigation (mlxcel vs mlx-lm)
+
+Apple M1 Ultra (128 GB, macOS 26.5.1), MLX commit `a6ec712`, mlx-lm 0.31.3.
+Decode throughput measured with `mlxcel-bench-decode` vs `scripts/bench_mlxlm.py`
+on identical checkpoints: raw continuation prompt, 100 tokens after a warmup
+pass, temp-0 greedy (so both runtimes emit identical tokens), best-of-3 with
+cooldown. This document consolidates issues #266, #267, #268, #269.
+
+## 1. Summary of the sweep
+
+| Family | Checkpoint | mlxcel | mlx-lm | ratio |
+|--------|-----------|-------:|-------:|------:|
+| llama (dense) | llama-3.1-8b-4bit | 109.3 | 109.4 | 1.00× |
+| granite (dense) | granite-3.3-2b | 184 | 186 | 0.99× |
+| lfm2-moe | LFM2-8B-A1B-4bit | 184 | 184 | 1.00× |
+| qwen3 (dense) | qwen3-8b-4bit | 75.3 | 83.8 | 0.90× |
+| apertus (dense) | Apertus-8B-2509-4bit | 70 | 85 | 0.83× |
+| seed_oss (dense) | Seed-OSS-36B-4bit | 17.1 | 20.3 | 0.84× |
+| nemotron-h (hybrid+MoE) | nemotron-h-30b-4bit | 55 | 92 | 0.60× |
+| qwen3_moe | qwen3-30b-a3b-4bit | 47.2 | 68.7 | 0.69× |
+| dots1 | dots.llm1.inst-mixed-4-6bit | 13.2 | 25.7 | 0.51× |
+
+Vanilla Llama/Granite dense is at parity. The gap grows with the number of
+*extra small ops per layer* a model runs on top of that baseline: QK-norm
+(qwen3), xIELU (apertus), and most of all the MoE router/combine/expert path.
+
+## 2. SSM hybrids: fixed (#266, #267)
+
+The three Mamba2 hybrids (falcon_h1, granitemoehybrid, plamo2) decoded 3-5×
+slower than mlx-lm because each SSM mixer forced an **unconditional**
+`eval(&result)` per layer, an M5-Max-NaN workaround that was never hardware
+gated. Gating it on `hardware::is_m5_neural_accelerator()` (PR #266) restored
+Falcon-H1 to ~3.8×, granite-h-tiny ~2.5×, plamo2 ~1.4× faster, output
+byte-identical. nemotron_h carried the same eval (PR #267), but its decode runs
+a fully-fused C++ path (`forward_fused`), so that gate only helped prefill;
+nemotron's decode gap is MoE (below).
+
+## 3. The MoE decode gap (#268): GPU-bound dtype/op overhead
+
+Profiled `qwen3-30b-a3b` (the fast-iterating MoE proxy) with the
+`mlxcel-gpu-profiling` hooks.
+
+- **Step 0 (pipeline):** `async_eval` (GPU) 20.3 ms/tok vs `forward` (Rust graph
+  build) 0.8 ms/tok → ~95% GPU-bound, not FFI/dispatch. `MLX_MAX_OPS_PER_BUFFER`
+  swept 100-1000 is flat → not command-buffer-gap bound.
+- **Step 1 (bandwidth):** ~3B active params at 4-bit ≈ 1.7 GB/tok; 47 tok/s ×
+  1.7 GB ≈ 80 GB/s effective ≈ 16-20% of M1 Ultra GEMV peak. The GPU is mostly
+  idle, spending its time on many small kernels rather than streaming weights.
+  (MoE per-expert GEMVs underutilize the GPU on both runtimes; mlxcel worse.)
+- **Step 2 (op-count diff), one decode token, 48 layers:**
+
+  | Op | mlxcel | mlx-lm | excess |
+  |----|------:|------:|------:|
+  | **AsType** | **773** | **0** | **+773** |
+  | Slice | 288 | 144 | +144 |
+  | Reshape | 435 | 336 | +99 |
+  | ExpandDims | 144 | 96 | +48 |
+  | QuantizedMatmul | 145 | 241 | −96 |
+  | total nodes | 3476 | 2505 | +971 |
+
+mlx-lm emits zero dtype conversions; mlxcel emits 773/token (~16/layer), ~80% of
+the node excess.
+
+### Why the AsType are not a quick fix
+
+Traced every candidate source:
+
+- The Rust hot path has ≤6 explicit `astype` (all in the KV-cache turbo module).
+- `quantized_linear_forward` (C++) calls `mlx::core::quantized_matmul` with no
+  astype; `multiply_scalar`/`divide_scalar` already build the scalar in the
+  input dtype.
+- `convert_quant_scales_bf16_to_f16` promotes **all** `.scales`/`.biases`
+  (including the quantized embedding) bf16→f16, and weights are bf16→f16 too, so
+  activations and quantized params are **consistently f16**: no per-op dtype
+  mismatch.
+- The compiled activations (`compiled_swiglu_activation`, GeGLU, GELU) end in
+  `astype(result, x.dtype())` but inside `mlx::core::compile`, so they fuse into
+  one kernel and appear as `Compiled` nodes, not AsType.
+- The fallback `rms_norm`/rope (which do cast) are not used; the model runs
+  `fast_rms_norm`/`fast_rope`.
+
+So the 773 AsType are diffuse MLX-internal type promotions (scalar/constant
+arithmetic), not a single dominant source, and per MLX's eval-time elementwise
+fusion they largely collapse into adjacent kernels. This is the same class as
+the prior Gemma3n bf16 decode-gap investigation, where removing the AsType excess
+measured only ~+2.6%; the static node count overstates GPU kernels.
+
+## 4. Dense gaps (#269): same overhead, milder
+
+apertus (0.83×) and seed_oss (0.84×) have no model-specific bug. llama-8b is at
+parity, qwen3-8b (QK-norm) is 0.90×, apertus (QK-norm + xIELU) 0.83×. mlxcel's
+xIELU is actually leaner than mlx-lm's (precomputed post-softplus scalars vs
+runtime `softplus` on GPU arrays). The residual tracks the per-layer extra
+small-op count, the same per-op execution overhead as the MoE case, just
+smaller. Subsumed by #268.
+
+## 5. Conclusion and realistic paths
+
+The remaining gap is a single underlying phenomenon: mlxcel's per-op execution
+overhead, amplified by op density. Vanilla dense ≈ parity; QK-norm/xIELU add a
+little; MoE (router + combine + per-expert gather, plus the diffuse AsType) adds
+the most. It is GPU-bound and the GPU is underutilized, but there is no single
+fusable lever, confirmed by exhausting the AsType sources and by the Gemma3n
+precedent.
+
+Closing it meaningfully requires a deliberate effort, not a one-line change:
+
+1. **Fused decode-MoE kernel**: collapse router scoring + top-k gather + the
+   per-expert gate/up/down + weighted-sum into fewer Metal dispatches so the GPU
+   stops idling between small kernels. Highest potential, largest effort
+   (Metal/MLX-level), validate RMS < 5e-3.
+2. **AsType reduction campaign**: eliminate the diffuse dtype promotions to keep
+   the whole decode graph in one dtype like mlx-lm. Low risk per change, but the
+   Gemma3n precedent caps the expected payoff (~few %); measure each step on
+   qwen3-30b-a3b (cheap, 16 GB).
+3. **Accept the gap** as the documented mlxcel characteristic on high-op-density
+   decode (simpler models already run at 0.9-1.0× of mlx-lm).
+
+Validation harness for any attempt: re-bench qwen3-30b-a3b per change, confirm on
+dots.llm1 + nemotron-h, greedy temp-0 output byte-identical.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -32,6 +32,11 @@ Use that report and its linked raw per-hardware tables for release notes,
 README updates, or capacity planning. This page should stay focused on
 methodology, required metadata, and caveats.
 
+Decode-gap investigations (root-cause analyses of where mlxcel trails the
+reference runtime) live alongside the snapshot:
+
+- [MoE decode gap investigation](benchmark_results/moe-decode-gap-investigation.md)
+
 ## Suggested benchmark commands
 
 The repository contains benchmark helper scripts under `scripts/`. The exact


### PR DESCRIPTION
## Summary

Documents the root-cause investigation behind the mlxcel vs mlx-lm decode-speed work this round, as a durable report under `docs/benchmark_results/` (linked from `docs/benchmarks.md`). It consolidates the perf sweep and the GPU-profiling analysis so a future fused-kernel effort can build on it.

## What's in the report

- **Sweep table** (M1 Ultra, decode tok/s, identical checkpoints, temp-0 greedy): vanilla dense (llama-8b, granite-2b) and lfm2-moe at parity; the gap grows with per-layer op density up to MoE (dots.llm1 0.51×).
- **SSM hybrids (#266/#267, already merged):** the per-mixer eval gate fix and the nemotron nuance (decode is C++-fused).
- **MoE gap (#268):** GPU profiling shows decode is ~95% GPU-bound, not at the memory wall (~16-20% bandwidth, GPU idle on small kernels), with **773 AsType ops/token vs mlx-lm's 0**. Every candidate source is traced and excluded (dtypes are consistently f16; the AsType are diffuse MLX-internal promotions that fuse at eval), matching the prior Gemma3n decode-gap class where AsType removal measured ~+2.6%.
- **Dense gaps (#269):** apertus/seed_oss have no model-specific bug; same overhead, milder. mlxcel's xIELU is already leaner than mlx-lm's.
- **Realistic fix paths:** a fused decode-MoE kernel (highest potential, largest effort) or an AsType-reduction campaign (low risk, capped payoff), plus a validation harness.

## Scope

Documentation only. Issues #268 and #269 stay open; the actual perf fix is scoped by section 5 of the report. References #266/#267 (merged).