### PR TITLE
perf(moe): 6-bit/mixed-bit fused decode-MoE; wire dots.llm1 (#268 step 2c)

### DIFF
--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -1377,7 +1377,7 @@ std::unique_ptr<MlxArray> fused_moe_expert_kernel(
     const MlxArray& down_w, const MlxArray& down_s, const MlxArray& down_b,
     const MlxArray& scores,       // [K] combine weights
     int32_t din, int32_t dff, int32_t k,
-    int32_t bits, int32_t group_size
+    int32_t gu_bits, int32_t d_bits, int32_t group_size
 );
 
 // Fused MoE forward: gate + switch_mlp + score weighting + optional shared expert

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_kernels.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_kernels.cpp
@@ -842,24 +842,52 @@ namespace {
         if (h >= Din) return;                            // uniform across the simdgroup
         uint e = indices[eslot];
 
-        constexpr uint vpw   = 32u / bits;
-        constexpr uint wmask = (1u << bits) - 1u;
-        constexpr uint Dff_p = Dff / vpw;
-        constexpr uint Gd    = Dff / group_size;
-
+        constexpr uint Gd = Dff / group_size;
         uint row = e * Din + h;
-        const device uint*  dwr = down_w + row * Dff_p;
         const device T*     dsr = down_s + row * Gd;
         const device T*     dbr = down_b + row * Gd;
         const device float* a   = act_g  + eslot * Dff;
         float d = 0.0f;
-        for (uint p = lane; p < Dff_p; p += 32u) {
-            uint base = p * vpw;
-            uint grp  = base / group_size;
-            float ds = (float)dsr[grp], db = (float)dbr[grp];
-            uint dpk = dwr[p];
-            for (uint j = 0; j < vpw; ++j) {
-                d += a[base + j] * ((float)((dpk >> (j * bits)) & wmask) * ds + db);
+
+        if (bits == 6) {
+            // Non-power-of-2: MLX packs 4 weights into 3 bytes (pack_factor 4,
+            // bytes_per_pack 3). Read the row as bytes; each lane owns whole
+            // packs. The 6-bit value layout matches MLX quantized.h qdot:
+            //   v0=b0&0x3f, v1=(b0>>6)|((b1&0x0f)<<2),
+            //   v2=(b1>>4)|((b2&0x03)<<4), v3=b2>>2.
+            constexpr uint packs = Dff / 4u;          // 4 values per pack
+            constexpr uint row_u32 = Dff * 3u / 16u;  // 3 bytes/pack -> uint32 cols
+            const device uchar* wb = (const device uchar*)(down_w + row * row_u32);
+            for (uint p = lane; p < packs; p += 32u) {
+                uint base = p * 4u;
+                uint grp  = base / group_size;
+                float ds = (float)dsr[grp], db = (float)dbr[grp];
+                uint b0 = wb[p * 3u], b1 = wb[p * 3u + 1u], b2 = wb[p * 3u + 2u];
+                uint v0 = b0 & 0x3fu;
+                uint v1 = (b0 >> 6) | ((b1 & 0x0fu) << 2);
+                uint v2 = (b1 >> 4) | ((b2 & 0x03u) << 4);
+                uint v3 = (b2 >> 2);
+                d += a[base + 0u] * ((float)v0 * ds + db);
+                d += a[base + 1u] * ((float)v1 * ds + db);
+                d += a[base + 2u] * ((float)v2 * ds + db);
+                d += a[base + 3u] * ((float)v3 * ds + db);
+            }
+        } else {
+            // Power-of-2 bits (4/8): vpw weights per 32-bit pack, clean shift.
+            // (When bits==6 this branch is dead-eliminated; the constexprs stay
+            // valid, just unused.)
+            constexpr uint vpw   = 32u / bits;
+            constexpr uint wmask = (1u << bits) - 1u;
+            constexpr uint Dff_p = Dff / vpw;
+            const device uint* dwr = down_w + row * Dff_p;
+            for (uint p = lane; p < Dff_p; p += 32u) {
+                uint base = p * vpw;
+                uint grp  = base / group_size;
+                float ds = (float)dsr[grp], db = (float)dbr[grp];
+                uint dpk = dwr[p];
+                for (uint j = 0; j < vpw; ++j) {
+                    d += a[base + j] * ((float)((dpk >> (j * bits)) & wmask) * ds + db);
+                }
             }
         }
         d = simd_sum(d);
@@ -920,7 +948,7 @@ std::unique_ptr<MlxArray> fused_moe_expert_kernel(
     const MlxArray& down_w, const MlxArray& down_s, const MlxArray& down_b,
     const MlxArray& scores,
     int32_t din, int32_t dff, int32_t k,
-    int32_t bits, int32_t group_size
+    int32_t gu_bits, int32_t d_bits, int32_t group_size
 ) {
     using namespace mlx::core;
     auto T = x.inner.dtype();
@@ -934,9 +962,15 @@ std::unique_ptr<MlxArray> fused_moe_expert_kernel(
         if (v >= 1 && v <= 32) sgy = v;
     }
     auto round_up = [](int n, int m) { return ((n + m - 1) / m) * m; };
-    std::vector<std::pair<std::string, mlx::core::fast::TemplateArg>> ta = {
+    // gate/up and down can carry different bit widths (e.g. dots.llm1: gate/up
+    // 4-bit, down 6-bit), so each kernel gets its own `bits` template arg.
+    std::vector<std::pair<std::string, mlx::core::fast::TemplateArg>> taA = {
         {"T", T}, {"K", k}, {"Din", din}, {"Dff", dff},
-        {"bits", bits}, {"group_size", group_size},
+        {"bits", gu_bits}, {"group_size", group_size},
+    };
+    std::vector<std::pair<std::string, mlx::core::fast::TemplateArg>> taB = {
+        {"T", T}, {"K", k}, {"Din", din}, {"Dff", dff},
+        {"bits", d_bits}, {"group_size", group_size},
     };
 
     // A) gate/up + swiglu -> act_g[K, Dff] (f32 for the down GEMV).
@@ -950,7 +984,7 @@ std::unique_ptr<MlxArray> fused_moe_expert_kernel(
         inA, { Shape{k, dff} }, { float32 },
         std::make_tuple(32, round_up(dff, sgy), k),
         std::make_tuple(32, sgy, 1),
-        ta, std::nullopt, false, {}
+        taA, std::nullopt, false, {}
     );
 
     // B) down * score -> partial[K, Din]; summed over K into [Din].
@@ -964,7 +998,7 @@ std::unique_ptr<MlxArray> fused_moe_expert_kernel(
         inB, { Shape{k, din} }, { T },
         std::make_tuple(32, round_up(din, sgy), k),
         std::make_tuple(32, sgy, 1),
-        ta, std::nullopt, false, {}
+        taB, std::nullopt, false, {}
     );
     auto summed = sum(rB[0], /*axis=*/0, /*keepdims=*/false);
     return std::make_unique<MlxArray>(std::move(summed));

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -1406,7 +1406,9 @@ mod ffi {
             next_state: &mut UniquePtr<MlxArray>,
         );
 
-        /// Fused MoE expert kernel for single-token decode (power-of-2 bits).
+        /// Fused MoE expert kernel for single-token decode. gate/up use
+        /// `gu_bits` (power-of-2: 4/8), down uses `d_bits` (4/8/6); group_size
+        /// is shared. Mixed widths support e.g. dots.llm1 (gate/up 4, down 6).
         #[allow(clippy::too_many_arguments)]
         fn fused_moe_expert_kernel(
             x: &MlxArray,
@@ -1424,7 +1426,8 @@ mod ffi {
             din: i32,
             dff: i32,
             k: i32,
-            bits: i32,
+            gu_bits: i32,
+            d_bits: i32,
             group_size: i32,
         ) -> UniquePtr<MlxArray>;
 

--- a/src/models/dots1.rs
+++ b/src/models/dots1.rs
@@ -399,9 +399,27 @@ impl Dots1MoE {
         let topk_scores = mlxcel_core::multiply(&topk_scores, &scale);
 
         // Routed experts: [n_tokens, top_k, hidden] -> weighted sum [n, hidden].
-        let expert_out = self.experts.forward(&x_flat, &topk_indices);
-        let mut result =
-            moe_weighted_sum(&expert_out, &topk_scores, mlxcel_core::array_dtype(&x_flat));
+        // Fused single-token decode kernel (#268) when MLXCEL_FUSED_MOE is set
+        // (dots.llm1 experts are gate/up 4-bit, down 6-bit); otherwise the
+        // SwitchGLU + moe_weighted_sum path, also the kernel's fallback.
+        let mut result = {
+            let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
+                && std::env::var("MLXCEL_FUSED_MOE").is_ok()
+            {
+                self.experts
+                    .forward_fused_kernel(&x_flat, &topk_indices, &topk_scores)
+                    .map(|out| mlxcel_core::reshape(&out, &[1, hidden_dim]))
+            } else {
+                None
+            };
+            match fused {
+                Some(out) => out,
+                None => {
+                    let expert_out = self.experts.forward(&x_flat, &topk_indices);
+                    moe_weighted_sum(&expert_out, &topk_scores, mlxcel_core::array_dtype(&x_flat))
+                }
+            }
+        };
 
         // Shared expert is always added.
         let shared_out = self.shared_experts.forward(&x_flat);

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -241,11 +241,11 @@ impl SwitchGLU {
         }
     }
 
-    /// Single-token decode via the fused MoE expert Metal kernel (#268 step 2b).
-    /// Returns None (caller falls back to `forward` + `moe_weighted_sum`) for
-    /// any unsupported config: non-power-of-2 bits (4/8 only), mismatched
-    /// bits/group_size across gate/up/down, the Regular variant, or a
-    /// non-single token `x`.
+    /// Single-token decode via the fused MoE expert Metal kernel (#268).
+    /// gate/up are 4/8-bit, down also handles 6-bit. Returns None (caller falls
+    /// back to `forward` + `moe_weighted_sum`) for any unsupported config:
+    /// gate/up not 4/8-bit or down not 4/6/8-bit, gate/up bits mismatch,
+    /// group_size mismatch, the Regular variant, or a non-single token `x`.
     pub fn forward_fused_kernel(
         &self,
         x: &MlxArray,
@@ -255,10 +255,14 @@ impl SwitchGLU {
         let (gw, gs, gb, ggs, gbits) = self.gate_proj.quantized_parts()?;
         let (uw, us, ub, ugs, ubits) = self.up_proj.quantized_parts()?;
         let (dw, ds, db, dgs, dbits) = self.down_proj.quantized_parts()?;
+        // gate/up power-of-2 (kernel A); down also handles 6-bit (kernel B).
         if gbits != 4 && gbits != 8 {
             return None;
         }
-        if gbits != ubits || gbits != dbits || ggs != ugs || ggs != dgs {
+        if dbits != 4 && dbits != 8 && dbits != 6 {
+            return None;
+        }
+        if gbits != ubits || ggs != ugs || ggs != dgs {
             return None;
         }
         let gw_shape = mlxcel_core::array_shape(gw);
@@ -267,6 +271,9 @@ impl SwitchGLU {
         }
         let dff = gw_shape[1];
         let din = gw_shape[2] * (32 / gbits);
+        if dbits == 6 && dff % 16 != 0 {
+            return None;
+        }
         let k = *mlxcel_core::array_shape(indices).last()?;
         let x_elems: i32 = mlxcel_core::array_shape(x).iter().product();
         if x_elems != din {
@@ -277,7 +284,7 @@ impl SwitchGLU {
         let sc_flat = mlxcel_core::reshape(scores, &[k]);
         Some(mlxcel_core::fused_moe_expert_kernel(
             &x_flat, &idx_flat, gw, gs, gb, uw, us, ub, dw, ds, db, &sc_flat, din, dff, k, gbits,
-            ggs,
+            dbits, ggs,
         ))
     }
 

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -230,11 +230,13 @@ impl SwitchGLU {
     /// Computes `sum_k scores[k] * down_k(silu(gate_k(x)) * up_k(x))` for the K
     /// selected experts as two all-cores Metal dispatches (gate/up+swiglu, then
     /// down+score), beating gather_qmm by ~3.5% on qwen3-30b-a3b with
-    /// byte-identical greedy output. Returns `None` (caller falls back to
-    /// `forward` + `moe_weighted_sum`) for any unsupported config: non-affine or
-    /// non-power-of-2 bits (4/8 only; 6-bit falls back), mismatched
-    /// bits/group_size across gate/up/down, missing biases, or a non-single-token
-    /// `x`. Gated by the caller (`MLXCEL_FUSED_MOE`).
+    /// byte-identical greedy output. gate/up are 4/8-bit; down also handles
+    /// 6-bit, so mixed widths like dots.llm1 (gate/up 4-bit, down 6-bit) are
+    /// supported. Returns `None` (caller falls back to `forward` +
+    /// `moe_weighted_sum`) for any unsupported config: non-affine, gate/up not
+    /// 4/8-bit or down not 4/6/8-bit, gate/up bits mismatch, group_size mismatch
+    /// across gate/up/down, missing biases, or a non-single-token `x`. Gated by
+    /// the caller (`MLXCEL_FUSED_MOE`).
     pub fn forward_fused_kernel(
         &self,
         x: &MlxArray,
@@ -244,17 +246,22 @@ impl SwitchGLU {
         let gate = self.gate_proj.quantized_parts()?;
         let up = self.up_proj.quantized_parts()?;
         let down = self.down_proj.quantized_parts()?;
+        // Kernel A (gate/up) is power-of-2 only; kernel B (down) also handles
+        // 6-bit. gate/up must match each other; down may differ (dots.llm1:
+        // gate/up 4-bit, down 6-bit). group_size is shared across all three.
         if gate.bits != 4 && gate.bits != 8 {
             return None;
         }
+        if down.bits != 4 && down.bits != 8 && down.bits != 6 {
+            return None;
+        }
         if gate.bits != up.bits
-            || gate.bits != down.bits
             || gate.group_size != up.group_size
             || gate.group_size != down.group_size
         {
             return None;
         }
-        if gate.mode != "affine" {
+        if gate.mode != "affine" || up.mode != "affine" || down.mode != "affine" {
             return None;
         }
         let gw_shape = mlxcel_core::array_shape(gate.weight.as_ref().unwrap());
@@ -263,6 +270,11 @@ impl SwitchGLU {
         }
         let dff = gw_shape[1];
         let din = gw_shape[2] * (32 / gate.bits);
+        // 6-bit down packs 4 weights into 3 bytes; the kernel reads the row as
+        // bytes and needs Dff divisible by 16 (whole uint32 columns).
+        if down.bits == 6 && dff % 16 != 0 {
+            return None;
+        }
         let k = *mlxcel_core::array_shape(indices).last()?;
         let x_elems: i32 = mlxcel_core::array_shape(x).iter().product();
         if x_elems != din {
@@ -288,6 +300,7 @@ impl SwitchGLU {
             dff,
             k,
             gate.bits,
+            down.bits,
             gate.group_size,
         ))
     }


### PR DESCRIPTION
## Summary

Step 2c of #268: extend the two-kernel fused decode-MoE (#276) to **6-bit and mixed bit widths**, and route **dots.llm1**'s MoE decode through it (it fell back before, being 4/6-bit mixed).

## What changed

The two-kernel split makes mixed widths natural — kernel A (gate/up + swiglu) and kernel B (down) each get their own `bits` template arg, so dots.llm1 (gate/up 4-bit, **down 6-bit**) needs only a 6-bit path in kernel B.

6-bit is not a power of 2: MLX packs 4 weights into 3 bytes (`pack_factor` 4, `bytes_per_pack` 3). The lane reads the down row as **bytes** and reconstructs the four 6-bit values with the bit layout taken from MLX `quantized.h` `qdot`:
```
v0 = b0 & 0x3f
v1 = (b0 >> 6) | ((b1 & 0x0f) << 2)
v2 = (b1 >> 4) | ((b2 & 0x03) << 4)
v3 = b2 >> 2
```

- FFI `fused_moe_expert_kernel` now takes `gu_bits` (gate/up, 4/8) + `d_bits` (down, 4/6/8) instead of one `bits`; `group_size` stays shared.
- Rust guards relax: gate/up must match each other and be 4/8-bit; down may be 4/6/8-bit; 6-bit down requires `Dff % 16 == 0` (whole uint32 columns).
- `dots1.rs` MoE forward dispatches to the fused kernel on single-token decode behind `MLXCEL_FUSED_MOE`, mirroring `qwen3_moe`.

## Validation (M1 Ultra, greedy temp-0)

- **dots.llm1** (the 6-bit path): output **byte-identical** to the SwitchGLU fallback. Decode **13.1 → 13.7 tok/s (+4.7%)**.
- **qwen3-30b-a3b**: byte-identical (no regression from the signature change).
- `cargo fmt --check` + `cargo clippy` clean.

Still off by default (`MLXCEL_FUSED_MOE`), single-token decode only.

## Scope

nemotron-h's MoE runs through the separate C++ full-forward path (`fused_moe_forward`), not the Rust `SwitchGLU`, so it is not wired here — a possible follow-up.

Refs #268.