### PR TITLE
perf(moe): wire qwen3_next fused decode-MoE (qwen3.5/3.6) (#268 step 3a)

### DIFF
--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -960,9 +960,7 @@ impl SwitchLinear {
     /// (weight, scales, biases, group_size, bits) for the affine-quantized
     /// variant; `None` for `Regular` (the fused MoE kernel needs quantized
     /// parts). The variant carries no `mode`: it is always affine here.
-    pub(crate) fn quantized_parts(
-        &self,
-    ) -> Option<(&MlxArray, &MlxArray, &MlxArray, i32, i32)> {
+    pub(crate) fn quantized_parts(&self) -> Option<(&MlxArray, &MlxArray, &MlxArray, i32, i32)> {
         match self {
             Self::Quantized {
                 weight,

--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -957,6 +957,24 @@ impl SwitchLinear {
         }
     }
 
+    /// (weight, scales, biases, group_size, bits) for the affine-quantized
+    /// variant; `None` for `Regular` (the fused MoE kernel needs quantized
+    /// parts). The variant carries no `mode`: it is always affine here.
+    pub(crate) fn quantized_parts(
+        &self,
+    ) -> Option<(&MlxArray, &MlxArray, &MlxArray, i32, i32)> {
+        match self {
+            Self::Quantized {
+                weight,
+                scales,
+                biases,
+                group_size,
+                bits,
+            } => Some((weight, scales, biases, *group_size, *bits)),
+            Self::Regular { .. } => None,
+        }
+    }
+
     pub(crate) fn from_weights(
         weights: &WeightMap,
         config: &Qwen3NextConfig,
@@ -1020,6 +1038,52 @@ impl SwitchGLU {
             let output = self.down_proj.forward(&activated, indices, false);
             mlxcel_core::squeeze_axis(&output, -2)
         }
+    }
+
+    /// Single-token decode via the fused MoE expert Metal kernel (#268).
+    /// gate/up are 4/8-bit, down also handles 6-bit. Returns `None` (caller
+    /// falls back to `forward` + `moe_weighted_sum`) for any unsupported config:
+    /// gate/up not 4/8-bit or down not 4/6/8-bit, gate/up bits mismatch,
+    /// group_size mismatch, the Regular variant, or a non-single-token `x`.
+    pub(crate) fn forward_fused_kernel(
+        &self,
+        x: &MlxArray,
+        indices: &MlxArray,
+        scores: &MlxArray,
+    ) -> Option<UniquePtr<MlxArray>> {
+        let (gw, gs, gb, ggs, gbits) = self.gate_proj.quantized_parts()?;
+        let (uw, us, ub, ugs, ubits) = self.up_proj.quantized_parts()?;
+        let (dw, ds, db, dgs, dbits) = self.down_proj.quantized_parts()?;
+        if gbits != 4 && gbits != 8 {
+            return None;
+        }
+        if dbits != 4 && dbits != 8 && dbits != 6 {
+            return None;
+        }
+        if gbits != ubits || ggs != ugs || ggs != dgs {
+            return None;
+        }
+        let gw_shape = mlxcel_core::array_shape(gw);
+        if gw_shape.len() != 3 {
+            return None;
+        }
+        let dff = gw_shape[1];
+        let din = gw_shape[2] * (32 / gbits);
+        if dbits == 6 && dff % 16 != 0 {
+            return None;
+        }
+        let k = *mlxcel_core::array_shape(indices).last()?;
+        let x_elems: i32 = mlxcel_core::array_shape(x).iter().product();
+        if x_elems != din {
+            return None;
+        }
+        let x_flat = mlxcel_core::reshape(x, &[din]);
+        let idx_flat = mlxcel_core::reshape(indices, &[k]);
+        let sc_flat = mlxcel_core::reshape(scores, &[k]);
+        Some(mlxcel_core::fused_moe_expert_kernel(
+            &x_flat, &idx_flat, gw, gs, gb, uw, us, ub, dw, ds, db, &sc_flat, din, dff, k, gbits,
+            dbits, ggs,
+        ))
     }
 
     pub(crate) fn gather_sort(
@@ -1122,13 +1186,31 @@ impl SparseMoeBlock {
             scores = mlxcel_core::divide(&scores, &sum);
         }
 
-        // Expert computation
-        let expert_out = self.experts.forward(&x_flat, &topk_indices);
-        let y = crate::models::switch_layers::moe_weighted_sum(
-            &expert_out,
-            &scores,
-            mlxcel_core::array_dtype(&x_flat),
-        );
+        // Expert computation. Fused single-token decode kernel (#268) behind
+        // MLXCEL_FUSED_MOE; otherwise SwitchGLU + moe_weighted_sum (also the
+        // kernel's fallback for unsupported configs).
+        let y = {
+            let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
+                && std::env::var("MLXCEL_FUSED_MOE").is_ok()
+            {
+                self.experts
+                    .forward_fused_kernel(&x_flat, &topk_indices, &scores)
+                    .map(|out| mlxcel_core::reshape(&out, &[1, hidden_dim]))
+            } else {
+                None
+            };
+            match fused {
+                Some(out) => out,
+                None => {
+                    let expert_out = self.experts.forward(&x_flat, &topk_indices);
+                    crate::models::switch_layers::moe_weighted_sum(
+                        &expert_out,
+                        &scores,
+                        mlxcel_core::array_dtype(&x_flat),
+                    )
+                }
+            }
+        };
 
         // Shared expert
         let shared_y = self.shared_expert.forward(&x_flat);


### PR DESCRIPTION
## Summary

Step 3a of #268: route **qwen3_next**'s MoE decode through the fused single-token kernel, covering **qwen3.5 / qwen3.6** (`qwen3_5_moe`) and qwen3_next itself. They went through a separate `SparseMoeBlock`/`SwitchGLU` copy that had no fused dispatch.

## What changed

qwen3_next carries its own `SwitchLinear`/`SwitchGLU` (distinct from `switch_layers` and `qwen3_moe`). This adds:
- `quantized_parts` accessor on `qwen3_next::SwitchLinear`,
- `forward_fused_kernel` on `qwen3_next::SwitchGLU` (mirrors `qwen3_moe`),
- the fused dispatch in `SparseMoeBlock::forward` on single-token decode behind `MLXCEL_FUSED_MOE`.

Experts are 4-bit affine — fully supported by the existing kernel, no kernel change.

## Result (qwen3.5-35b-a3b, M1 Ultra)

Decode **68.7 → 74.7 tok/s (+8.7%)**.

## Correctness — within f16 jitter class (not byte-identical)

Unlike qwen3_moe/dots (byte-identical on the prompts tested), qwen3.5/3.6 greedy output is **within the f16 jitter class**, not bit-exact. The fused kernel accumulates the GEMV in f32 with a different reduction order than `gather_qmm`'s tiling, perturbing the MoE block output by **abs RMS ~1e-4 (max ~4e-4, both < 5e-3)** — measured directly with temporary instrumentation. On a deep hybrid that is enough to flip a near-tie greedy token (~token 16 in tests); qwen3-30b happens not to hit one through 128 tokens. This is the design harness's documented "byte-identical **or** within f16 jitter class" allowance.

The rel_rms looks like ~1% only because the MoE block output is small-magnitude (~8e-3); the perturbation to the O(1) residual stream is ~1e-4, negligible.

`cargo fmt`/`clippy` clean. Off by default (`MLXCEL_FUSED_MOE`), single-token decode only.

## Scope

gemma4-26b (its own `Experts`/gather_sort path) and nemotron-h (C++ `fused_moe_forward`) are separate MoE paths — follow-ups.

Refs #268.