### PR TITLE
perf(moe): default-on MLXCEL_FUSED_MOE, validated on M5 (#282)

### DIFF
--- a/docs/benchmark_results/fused-moe-decode-kernel-design.md
+++ b/docs/benchmark_results/fused-moe-decode-kernel-design.md
@@ -117,7 +117,7 @@ greedy output byte-identical throughout):
    score -> `partial[K, Din]`, summed over K). Every GEMV output row is now an
    independent simdgroup across all cores, each weight read exactly once:
    **49.0 vs 47.3 tok/s, +3.5%** over gather_qmm. This is the shipped kernel
-   (`MLXCEL_FUSED_MOE`, off by default), `MLXCEL_FUSED_MOE_SGY` tunes simdgroups
+   (`MLXCEL_FUSED_MOE`, on by default as of #282), `MLXCEL_FUSED_MOE_SGY` tunes simdgroups
    per threadgroup (default 8).
 
 The win is modest because the expert GEMV is already a small, equally-efficient
@@ -140,21 +140,24 @@ runs it efficiently.
    and reconstructs with the `quantized.h` `qdot` bit layout.
 4. **Done** (#279 = qwen3_next/qwen3.5/3.6, #280 = squared-ReLU kernel preserved
    for nemotron-class behind `MLXCEL_FUSED_MOE_RELU2`, #281 = GeGLU/gemma4).
-5. **Open** (#282): validate the fused path on M5 (Neural Accelerator) and then
-   decide on flipping `MLXCEL_FUSED_MOE` on by default. `fused_moe_forward` has
-   a documented M5-Max mixed-dtype NaN workaround, and the new kernels have not
-   run on M5 yet.
+5. **Done** (#282): validated the fused path on M5 (Neural Accelerator) and
+   flipped `MLXCEL_FUSED_MOE` on by default. The documented M5-Max mixed-dtype
+   NaN risk does not materialize in the new kernels: across the wired MoE set the
+   greedy decode output is byte-identical or within the f16 jitter class with no
+   NaN, and decode is parity-to-faster (no regression). Per-layer kernel
+   execution on M5 was confirmed with a dispatch trace. See the M5 results below.
 
 ## Usage and flags
 
-The fused decode-MoE path is **off by default** and applies only to
+The fused decode-MoE path is **on by default** as of #282 and applies only to
 single-token decode with affine 4/8-bit gate/up and 4/6/8-bit down. Anything
 else (prefill, non-affine, unsupported bit widths, mismatched gate/up bits)
-falls back to the proven `gather_qmm` / `SwitchGLU` path automatically.
+falls back to the proven `gather_qmm` / `SwitchGLU` path automatically. Set
+`MLXCEL_FUSED_MOE=0` to force that fallback everywhere.
 
 | Env var | Default | Effect |
 |---------|---------|--------|
-| `MLXCEL_FUSED_MOE` | unset (off) | Set to enable the fused SwiGLU/GeGLU decode-MoE kernel. |
+| `MLXCEL_FUSED_MOE` | unset (on) | On by default. Set to `0` (also `false`/`off`/`no`, case-insensitive) to force the proven `gather_qmm` / `SwitchGLU` path; any other value, or leaving it unset, keeps the kernel on. |
 | `MLXCEL_FUSED_MOE_SGY` | 8 | Simdgroups per threadgroup (one output row each). Tune per hardware. |
 | `MLXCEL_FUSED_MOE_RELU2` | unset (off) | Enable the squared-ReLU (fc1/relu²/fc2) fused path used by nemotron-class experts. Correct but measured performance-neutral on nemotron-h; kept for a future MoE-dominated squared-ReLU model. |
 
@@ -174,6 +177,26 @@ baseline was: gemma4 wins most (small experts, and its compiled-SwitchGeGLU
 baseline was three `gather_qmm`), while nemotron-h barely moves because its
 decode is dominated by Mamba2 + attention.
 
+### Measured decode gains (M5 Max, `MLXCEL_FUSED_MOE=1`, #282)
+
+Validated on M5 Max (Neural Accelerator, macOS 26.5) against the true `gather_qmm`
+baseline (env unset, since `MLXCEL_FUSED_MOE=0` only began disabling the kernel in
+#282). Greedy temp-0; best-of-3 decode tok/s, dots.llm1 single-pass.
+
+| Model | activation | bits | decode tok/s | gain | greedy parity |
+|-------|-----------|------|-------------:|-----:|---------------|
+| gemma-4-26b-a4b-it | GeGLU | 4 | 133.9 → 142.2 | +6.2% | within f16 jitter class |
+| qwen3.5-35b-a3b | SwiGLU | 4 | 153.6 → 161.3 | +5.1% | within f16 jitter class |
+| qwen3-30b-a3b | SwiGLU | 4 | 60.5 → 61.7 | +1.9% | byte-identical |
+| dots.llm1 | SwiGLU | 4 + 6 | 14.1 → 14.0 | ~par | byte-identical |
+
+The M5 gains are smaller than M1 Ultra's but positive with no regression, and no
+run produced NaN or garbage. The Neural Accelerator narrows the gap because it
+already accelerates the baseline expert matmul, leaving less inter-kernel idle for
+the fusion to recover. Per-layer kernel execution on M5 was confirmed with a
+dispatch trace (30 / 40 / 48 / 61 dispatches per decode token for gemma4 /
+qwen3.5 / qwen3-30b / dots.llm1).
+
 **Parity caveat.** The kernel accumulates the GEMV in f32 with a different
 reduction order than `gather_qmm`'s tiling, so it is within the f16 jitter
 class (RMS < 5e-3), not bit-exact, for every model. Many models happen to be
@@ -184,7 +207,13 @@ the expected numerical consequence of the fusion.
 
 ### Models covered
 
-qwen3_moe and everything reusing its `SparseMoeBlock` (qwen2_moe/qwen1.5-moe,
-mixtral, olmoe, minimax, phimoe, qwen3_vl_moe, lfm2), dots.llm1, qwen3_next
-(qwen3.5/3.6), and gemma4 (GeGLU). nemotron-h's MoE runs through the separate
-C++ `fused_moe_forward` and is wired behind `MLXCEL_FUSED_MOE_RELU2` only.
+The fused single-token decode dispatch is wired into four model paths: qwen3_moe
+(Qwen3 MoE), qwen3_next (qwen3.5/3.6), dots.llm1 (mixed 4/6-bit), and gemma4
+(GeGLU). Other MoE families reuse the shared `SwitchGLU` for the expert matmul but
+were not wired with the fused decode dispatch, so they stay on `gather_qmm`
+regardless of `MLXCEL_FUSED_MOE`: qwen2_moe (qwen1.5-moe), mixtral, olmoe,
+minimax, phimoe, lfm2, and qwen3_vl_moe (it imports `SwitchGLU` from qwen3_moe but
+keeps its own non-fused MoE forward). Wiring those is a separate follow-up; the
+qwen1.5-moe row in the M1 table above was therefore measured on the `gather_qmm`
+fallback, not the kernel. nemotron-h's MoE runs through the separate C++
+`fused_moe_forward` and is wired behind `MLXCEL_FUSED_MOE_RELU2` only.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -168,6 +168,9 @@ recommended as normal deployment settings.
 | `MLXCEL_DISABLE_SINGLE_QUERY_MASKLESS` | truthy disables | maskless path on | Disables the single-query maskless attention path. |
 | `MLXCEL_EXPERIMENTAL_BOOL_CAUSAL_MASK` | truthy enables | off | Enables an experimental boolean causal-mask path. |
 | `MLXCEL_PIPELINE_GRANULARITY` | `off`, `layer`, `block:N` | `off` | Inserts layer-boundary async-eval hints for pipeline experiments. |
+| `MLXCEL_FUSED_MOE` | `0`/`false`/`off`/`no` disable; any other value or unset enables | on | Fused single-token decode-MoE kernel (#268), on by default since #282 (validated on M1 Ultra and M5). Set to `0` to force the proven `gather_qmm`/`SwitchGLU` path. Active for qwen3_moe, qwen3_next, dots.llm1, and gemma4 decode. |
+| `MLXCEL_FUSED_MOE_SGY` | `1`-`32` | `8` | Simdgroups per threadgroup for the fused decode-MoE kernel; tune per hardware. |
+| `MLXCEL_FUSED_MOE_RELU2` | presence enables | off | Enables the squared-ReLU fused MoE path for nemotron-class experts; performance-neutral on nemotron-h, kept for a future MoE-dominated squared-ReLU model. |
 
 ## Block-diffusion diagnostic variables
 

--- a/src/models/dots1.rs
+++ b/src/models/dots1.rs
@@ -404,7 +404,7 @@ impl Dots1MoE {
         // SwitchGLU + moe_weighted_sum path, also the kernel's fallback.
         let mut result = {
             let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
-                && std::env::var("MLXCEL_FUSED_MOE").is_ok()
+                && crate::models::switch_layers::fused_moe_enabled()
             {
                 self.experts
                     .forward_fused_kernel(&x_flat, &topk_indices, &topk_scores)

--- a/src/models/dots1.rs
+++ b/src/models/dots1.rs
@@ -399,9 +399,9 @@ impl Dots1MoE {
         let topk_scores = mlxcel_core::multiply(&topk_scores, &scale);
 
         // Routed experts: [n_tokens, top_k, hidden] -> weighted sum [n, hidden].
-        // Fused single-token decode kernel (#268) when MLXCEL_FUSED_MOE is set
-        // (dots.llm1 experts are gate/up 4-bit, down 6-bit); otherwise the
-        // SwitchGLU + moe_weighted_sum path, also the kernel's fallback.
+        // Fused single-token decode kernel (#268) on by default; MLXCEL_FUSED_MOE=0
+        // disables (dots.llm1 experts are gate/up 4-bit, down 6-bit); otherwise
+        // the SwitchGLU + moe_weighted_sum path, also the kernel's fallback.
         let mut result = {
             let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
                 && crate::models::switch_layers::fused_moe_enabled()

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -722,8 +722,9 @@ impl Experts {
         let x_flat = mlxcel_core::reshape(x, &[b * s, h]);
         let indices_flat = mlxcel_core::reshape(top_k_indices, &[b * s, k]);
 
-        // Fused single-token decode GeGLU kernel (#268) behind MLXCEL_FUSED_MOE;
-        // otherwise SwitchGeGLU + weighted combine (also the kernel's fallback).
+        // Fused single-token decode GeGLU kernel (#268) on by default
+        // (MLXCEL_FUSED_MOE=0 disables); otherwise SwitchGeGLU + weighted combine
+        // (also the kernel's automatic fallback).
         if b * s == 1
             && crate::models::switch_layers::fused_moe_enabled()
             && let Some(out) =

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -725,7 +725,7 @@ impl Experts {
         // Fused single-token decode GeGLU kernel (#268) behind MLXCEL_FUSED_MOE;
         // otherwise SwitchGeGLU + weighted combine (also the kernel's fallback).
         if b * s == 1
-            && std::env::var("MLXCEL_FUSED_MOE").is_ok()
+            && crate::models::switch_layers::fused_moe_enabled()
             && let Some(out) =
                 self.switch_geglu
                     .forward_fused_kernel(&x_flat, &indices_flat, top_k_weights)

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -403,9 +403,9 @@ impl SparseMoeBlock {
         }
 
         // Apply experts and weighted-sum. Fused single-token decode kernel
-        // (#268 step 2a) when MLXCEL_FUSED_MOE is set; otherwise the proven
-        // SwitchGLU + moe_weighted_sum path (also the fallback when the kernel
-        // does not support the config).
+        // (#268) on by default; MLXCEL_FUSED_MOE=0 forces the proven SwitchGLU +
+        // moe_weighted_sum path (also the automatic fallback when the kernel does
+        // not support the config).
         let result = {
             let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
                 && crate::models::switch_layers::fused_moe_enabled()

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -408,7 +408,7 @@ impl SparseMoeBlock {
         // does not support the config).
         let result = {
             let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
-                && std::env::var("MLXCEL_FUSED_MOE").is_ok()
+                && crate::models::switch_layers::fused_moe_enabled()
             {
                 self.experts
                     .forward_fused_kernel(&x_flat, &topk_indices, &scores)

--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -1189,7 +1189,7 @@ impl SparseMoeBlock {
         // kernel's fallback for unsupported configs).
         let y = {
             let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
-                && std::env::var("MLXCEL_FUSED_MOE").is_ok()
+                && crate::models::switch_layers::fused_moe_enabled()
             {
                 self.experts
                     .forward_fused_kernel(&x_flat, &topk_indices, &scores)

--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -1184,9 +1184,9 @@ impl SparseMoeBlock {
             scores = mlxcel_core::divide(&scores, &sum);
         }
 
-        // Expert computation. Fused single-token decode kernel (#268) behind
-        // MLXCEL_FUSED_MOE; otherwise SwitchGLU + moe_weighted_sum (also the
-        // kernel's fallback for unsupported configs).
+        // Expert computation. Fused single-token decode kernel (#268) on by
+        // default (MLXCEL_FUSED_MOE=0 disables); otherwise SwitchGLU +
+        // moe_weighted_sum (also the kernel's fallback for unsupported configs).
         let y = {
             let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
                 && crate::models::switch_layers::fused_moe_enabled()

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -25,6 +25,36 @@ use mlxcel_core::utils::slice_axis;
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr, dtype};
 
+/// Whether the fused single-token decode-MoE kernel (#268) is enabled.
+///
+/// Default-on as of #282: across the validated MoE set the kernel is
+/// byte-identical or within the documented f16 jitter class, never regresses
+/// decode, and gives a measured speedup on both M1 Ultra and M5 (Neural
+/// Accelerator) hardware. Set `MLXCEL_FUSED_MOE=0` (also `false`/`off`/`no`,
+/// case-insensitive) to force the proven `gather_qmm` / `SwitchGLU` path; any
+/// other value, or leaving it unset, keeps the kernel on.
+///
+/// This only chooses whether to *attempt* the kernel. Callers still fall back to
+/// `gather_qmm` automatically for any config the kernel does not support
+/// (non-affine, unsupported bit widths, mismatched gate/up bits, prefill).
+pub fn fused_moe_enabled() -> bool {
+    fused_moe_enabled_from(std::env::var("MLXCEL_FUSED_MOE").ok().as_deref())
+}
+
+/// Pure decision behind [`fused_moe_enabled`], split out so it can be unit-tested
+/// without mutating process-global environment state. `None` (unset) is on; an
+/// explicit `0`/`false`/`off`/`no` (case-insensitive, trimmed) is off; any other
+/// value is on.
+fn fused_moe_enabled_from(value: Option<&str>) -> bool {
+    match value {
+        Some(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
+        None => true,
+    }
+}
+
 /// Per-expert 3D linear layer (falls back to gather_mm for non-quantized models)
 /// Supports affine, mxfp4, nvfp4, and mxfp8 quantization modes.
 pub enum SwitchLinear {
@@ -473,5 +503,25 @@ mod tests {
 
         assert_eq!(mlxcel_core::array_shape(&out), vec![2, 4]);
         assert_eq!(mlxcel_core::array_dtype(&out), dtype::FLOAT16);
+    }
+
+    #[test]
+    fn fused_moe_enabled_defaults_on_and_respects_disable_values() {
+        // Unset -> on (default-on as of #282).
+        assert!(fused_moe_enabled_from(None));
+        // Explicit disable values (case-insensitive, trimmed) -> off.
+        for v in ["0", "false", "off", "no", "OFF", "False", " 0 ", "No"] {
+            assert!(
+                !fused_moe_enabled_from(Some(v)),
+                "{v:?} should disable the kernel"
+            );
+        }
+        // Any other value, including empty, -> on.
+        for v in ["1", "true", "on", "yes", "", "anything"] {
+            assert!(
+                fused_moe_enabled_from(Some(v)),
+                "{v:?} should keep the kernel on"
+            );
+        }
     }
 }

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -37,8 +37,14 @@ use mlxcel_core::{MlxArray, UniquePtr, dtype};
 /// This only chooses whether to *attempt* the kernel. Callers still fall back to
 /// `gather_qmm` automatically for any config the kernel does not support
 /// (non-affine, unsupported bit widths, mismatched gate/up bits, prefill).
+///
+/// The variable is read once and cached for the process lifetime.
 pub fn fused_moe_enabled() -> bool {
-    fused_moe_enabled_from(std::env::var("MLXCEL_FUSED_MOE").ok().as_deref())
+    // Cache the launch-time flag, mirroring the `OnceLock` env-gate convention
+    // used by other hot-path flags (e.g. gemma4's `mtp_divergent_fix_disabled`).
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED
+        .get_or_init(|| fused_moe_enabled_from(std::env::var("MLXCEL_FUSED_MOE").ok().as_deref()))
 }
 
 /// Pure decision behind [`fused_moe_enabled`], split out so it can be unit-tested


### PR DESCRIPTION
## Summary

Flips `MLXCEL_FUSED_MOE` to **on by default** for single-token decode-MoE, after validating the fused kernels on M5 Max (Neural Accelerator) hardware for the first time. The #268 series (#276/#278/#279/#280/#281) shipped these kernels off-by-default and only ever ran them on M1 Ultra; this enables them by default once confirmed clean on M5. Closes #282.

The fused path stays an env override: `MLXCEL_FUSED_MOE=0` (also `false`/`off`/`no`, case-insensitive) forces the proven `gather_qmm` / `SwitchGLU` path. This also fixes a latent bug. The previous gate was `std::env::var("MLXCEL_FUSED_MOE").is_ok()`, which is true whenever the variable is set, so `MLXCEL_FUSED_MOE=0` *enabled* the kernel instead of disabling it. A new `switch_layers::fused_moe_enabled()` helper centralizes the decision (default-on; an explicit falsey value disables) and all four call sites route through it.

## M5 validation (the core of this issue)

Apple M5 Max (Mac17,7, 128 GB, macOS 26.5.1; `is_m5_neural_accelerator()` returns true), release build with metal+accelerate, greedy temp-0, measured against the true `gather_qmm` baseline (env unset):

| Model | activation | bits | decode tok/s (off to on) | gain | greedy parity | kernel dispatched |
|---|---|---|---|---|---|---|
| gemma-4-26b-a4b-it | GeGLU | 4 | 133.9 to 142.2 | +6.2% | within f16 jitter, coherent | yes (30/tok) |
| qwen3.5-35b-a3b | SwiGLU | 4 | 153.6 to 161.3 | +5.1% | within f16 jitter, coherent | yes (40/tok) |
| qwen3-30b-a3b | SwiGLU | 4 | 60.5 to 61.7 | +1.9% | byte-identical | yes (48/tok) |
| dots.llm1 | SwiGLU | 4+6 | 14.1 to 14.0 | ~par | byte-identical | yes (61/tok) |

- No NaN and no garbage on any model. The documented M5-Max mixed-dtype NaN risk (in the separate C++ `fused_moe_forward`) does not materialize in the new `moe_gateup` / `moe_down` / GeGLU kernels, which cast scores to the activation dtype and accumulate in f32.
- No regression anywhere. Gains are smaller than M1 Ultra because the Neural Accelerator already accelerates the baseline expert matmul, leaving less inter-kernel idle for the fusion to recover.
- Kernel execution on M5 was confirmed per layer with a temporary dispatch trace (reverted before this commit), not merely inferred from output, because byte-identical parity alone cannot distinguish a real run from a silent fallback.
- M5 is clean with real gains, so the default is flipped for all hardware; no `is_m5_neural_accelerator()` gate is needed.

## Notable findings surfaced during validation

- `MLXCEL_FUSED_MOE=0` never disabled the kernel (the `.is_ok()` bug above). Fixed here, which is exactly the off switch the issue asked to preserve.
- qwen1.5-moe could not be validated: it loads as `qwen2_moe`, whose `SparseMoeBlock` was never wired with the fused dispatch, so it always falls back to `gather_qmm` (0 dispatches). Only four paths actually dispatch the kernel: qwen3_moe, qwen3_next, dots1, gemma4. mixtral, olmoe, minimax, phimoe, lfm2, and qwen3_vl_moe reuse `SwitchGLU` but are not wired. The doc's "Models covered" list overstated coverage and is corrected here. Wiring the remaining families is a separate follow-up.

## Changes

- `src/models/switch_layers.rs`: add `fused_moe_enabled()` (default-on; `0`/`false`/`off`/`no` disables) plus a `fused_moe_enabled_from` unit test.
- `src/models/{qwen3_moe,qwen3_next,dots1,gemma4}.rs`: route the decode-MoE gate through `fused_moe_enabled()` instead of `std::env::var("MLXCEL_FUSED_MOE").is_ok()`.
- `docs/benchmark_results/fused-moe-decode-kernel-design.md`: flags table now default-on, roadmap step 5 marked done, new M5 results section, corrected "Models covered".

## Testing

- M5 real-checkpoint validation on the four wired families (table above), all coherent with no NaN.
- Behavioral flip check on gemma4: default (unset) = 142.5 tok/s and produces the fused output; `MLXCEL_FUSED_MOE=0` = 133.4 tok/s and produces the `gather_qmm` baseline output; the two outputs differ as expected, confirming the flip and the fixed `=0` semantics.
- `cargo test --release switch_layers`, `cargo fmt`, `cargo clippy --release --features metal,accelerate -- -D warnings`.

Closes #282.
