### PR TITLE
perf(models): keep quantized models bf16 to fix M1 Ultra decode regression (#289)

### DIFF
--- a/src/models/granitemoehybrid_tests.rs
+++ b/src/models/granitemoehybrid_tests.rs
@@ -21,8 +21,8 @@
 //! `use_moe` follows `num_local_experts`, that the NoPE flag disables RoPE, that
 //! the Mamba2 inner dimensions and the `conv_dim` / `projection_size`
 //! derivations match the reference, and that the EOS default is the Granite
-//! `<|end_of_text|>` id (100257). The numeric correctness of the interleaved SSM
-//! + attention hybrid is validated end-to-end against the real
+//! `<|end_of_text|>` id (100257). The numeric correctness of the interleaved
+//! SSM + attention hybrid is validated end-to-end against the real
 //! `mlx-community/granite-4.0-h-350m-4bit` checkpoint and is not exercised here
 //! (no Metal device is assumed in unit tests).
 

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -1184,59 +1184,32 @@ pub fn load_text_weights<P: AsRef<std::path::Path>>(
         transform.apply(&mut weights, &cfg)?;
     }
 
-    // Convert bf16 → f16 on all Apple Silicon for performance.  No Apple GPU
-    // has native bf16 ALU, so f16 is strictly better.  For non-quantized models
-    // every bf16 tensor is promoted.  For quantized models the packed weights
-    // stay as-is, but the bf16 quantization scales/biases must still be promoted
-    // to f16: mlxcel's quantized dequant path reads f16 scales (f16-scale
-    // exports such as `mlx-community/granite-*` work), whereas the bf16 scales
-    // shipped by newer exports (Apertus-2509, Seed-OSS) dequantize to ~zero.
-    if should_convert_bf16_to_f16() && !is_bitnet {
-        if !is_quantized {
-            let had_bf16 = if keep_gemma3n_mlp_bf16 {
-                convert_bf16_weights_with_keep(&mut weights, gemma3n_language_mlp_bf16_key)
-            } else {
-                convert_bf16_weights(&mut weights)
-            };
-            if had_bf16 {
-                warn_bf16_precision();
-            }
+    // Convert bf16 → f16 on all Apple Silicon for performance. No Apple GPU has
+    // native bf16 ALU, so f16 is strictly better for non-quantized weights.
+    //
+    // Quantized models are intentionally left bf16. The quantized_matmul /
+    // gather_qmm kernels consume bf16 scales/biases natively and the activation
+    // path stays bf16, so the model is dtype-consistent. Promoting *only* the
+    // scales/biases to f16 (leaving activations bf16) created a dtype mismatch
+    // that regressed decode 33-41% on M1 Ultra for every bf16-scale checkpoint
+    // (qwen3, nemotron, gpt-oss, solar, ...; issue #289). Promoting *all*
+    // tensors to f16 instead corrupts models whose activations overflow f16
+    // (Apertus xIELU x^2, like BitNet's relu^2). The blank output once
+    // attributed to bf16 scales (Apertus-2509) was actually a separate xIELU
+    // read_scalar bf16 bug, fixed in the apertus loader; Apertus, Seed-OSS, and
+    // every other bf16-scale quant decode correctly with no scale promotion.
+    if should_convert_bf16_to_f16() && !is_bitnet && !is_quantized {
+        let had_bf16 = if keep_gemma3n_mlp_bf16 {
+            convert_bf16_weights_with_keep(&mut weights, gemma3n_language_mlp_bf16_key)
         } else {
-            // Promote bf16 quantization scales/biases to f16. This is a
-            // correctness normalization for the dequant kernels, not a
-            // precision-loss event, so it does not emit the bf16 warning (the
-            // model stays quantized).
-            convert_quant_scales_bf16_to_f16(&mut weights);
+            convert_bf16_weights(&mut weights)
+        };
+        if had_bf16 {
+            warn_bf16_precision();
         }
     }
 
     Ok(weights)
-}
-
-/// Promote bf16 quantization scales/biases to f16 in place, leaving the packed
-/// (uint32) weights and every other tensor untouched.  mlxcel's quantized
-/// dequant kernels require f16 scales/biases; checkpoints that ship them as
-/// bf16 otherwise dequantize to near-zero.  Returns true if any tensor changed.
-fn convert_quant_scales_bf16_to_f16(weights: &mut mlxcel_core::weights::WeightMap) -> bool {
-    let keys: Vec<String> = weights
-        .keys()
-        .filter(|k| k.ends_with(".scales") || k.ends_with(".biases"))
-        .cloned()
-        .collect();
-    let mut converted = false;
-    for k in keys {
-        let promoted = match weights.get(&k) {
-            Some(w) if mlxcel_core::array_dtype(w) == mlxcel_core::dtype::BFLOAT16 => {
-                Some(mlxcel_core::astype(w, mlxcel_core::dtype::FLOAT16))
-            }
-            _ => None,
-        };
-        if let Some(f16) = promoted {
-            weights.insert(k, f16);
-            converted = true;
-        }
-    }
-    converted
 }
 
 /// Returns true when bf16 tensors should be cast to f16 at load time.


### PR DESCRIPTION
## Summary

Fixes #289. The full M1 Ultra benchmark refresh (v0.1.4 → v0.2.1) surfaced a real, model-specific decode regression. Root cause: commit `d80f78721` (#260 "add Apertus") added `convert_quant_scales_bf16_to_f16` in `load_text_weights`, which promotes bf16 `.scales`/`.biases` → f16 for **all** quantized models. Promoting only the scales while activations stay bf16 creates a **bf16-activation × f16-scale dtype mismatch** in `quantized_matmul`/`gather_qmm`, regressing decode **33-41% on M1 Ultra** for every checkpoint shipping bf16 scales.

## Evidence (M1 Ultra, decode tok/s)

Control-gated, median-of-3 bisect (mixtral as a thermal control; M1 Ultra throttles under sustained load) — clean step at #260:

| commit | qwen3-30b-a3b | verdict |
|---|---|---|
| `926f9a45a` (#259) | 69.1 | good |
| `d80f78721` (#260) | 44.4 | **first bad** |

Run-over-run regressions (all **bf16**-scale): qwen3-30b-a3b 70→46, qwen3-moe 70→46, qwen3-0.6b 290→247, nemotron-h 91→53, nemotron-nas 90→51, gpt-oss-120b, solar-100b, minimax-m2, hunyuan-large, jamba, dots.llm1. Controls (**f16** scales) unchanged: mixtral 54→54, llama-3.1-8b 107→109, qwen2.5-7b 110→112, phi-4, starcoder2. The split matches the safetensors `.scales` dtype exactly. Not the fused-MoE kernel (`MLXCEL_FUSED_MOE` on/off identical) and not MLX (pin a6ec712 across the range).

## Fix

Leave quantized models fully bf16 (the pre-#260 fast path). The promotion was **not** needed for correctness:

- Apertus-2509 and Seed-OSS decode correctly with bf16 scales. The blank output once attributed to their bf16 scales was the **separate xIELU `read_scalar` bf16 bug**, fixed in the apertus loader (kept).
- Promoting *all* tensors to f16 instead **corrupts Apertus** (xIELU x² overflows f16, like BitNet's relu²), so "convert everything to f16" is not viable either.

## Validation (M1 Ultra, this branch)

- **Perf recovered:** qwen3-30b-a3b 46 → **84**, nemotron-h-30b 53 → **92** (≥ the v0.1.4 baseline).
- **Correctness preserved:** `tests/apertus_parity.rs` (real-model greedy " Paris,") passes; Seed-OSS, dots.llm1, granite-4.0-h hybrid, and lfm2 decode correctly under the fix.
- `cargo fmt --check`, `cargo clippy --release --all-targets -- -D warnings`, and `cargo test --release --lib sanitize` (83 passed) all green.

## Notes

- Also reflows one doc comment in `granitemoehybrid_tests.rs` so a wrapped `+` is not at a line start (pre-existing `clippy::doc_lazy_continuation` surfaced by `--all-targets`; unrelated to the fix, included to keep the lint gate green).
- Likely affects other Apple Silicon (the promotion fires on all Apple Silicon); magnitude may differ by generation. The M1 Ultra benchmark docs will be refreshed on the fixed binary separately.
