### PR TITLE
perf(moe): wire qwen2_moe to the fused decode-MoE kernel

### DIFF
--- a/docs/benchmark_results/fused-moe-decode-kernel-design.md
+++ b/docs/benchmark_results/fused-moe-decode-kernel-design.md
@@ -207,13 +207,14 @@ the expected numerical consequence of the fusion.
 
 ### Models covered
 
-The fused single-token decode dispatch is wired into four model paths: qwen3_moe
-(Qwen3 MoE), qwen3_next (qwen3.5/3.6), dots.llm1 (mixed 4/6-bit), and gemma4
-(GeGLU). Other MoE families reuse the shared `SwitchGLU` for the expert matmul but
-were not wired with the fused decode dispatch, so they stay on `gather_qmm`
-regardless of `MLXCEL_FUSED_MOE`: qwen2_moe (qwen1.5-moe), mixtral, olmoe,
-minimax, phimoe, lfm2, and qwen3_vl_moe (it imports `SwitchGLU` from qwen3_moe but
-keeps its own non-fused MoE forward). Wiring those is a separate follow-up; the
-qwen1.5-moe row in the M1 table above was therefore measured on the `gather_qmm`
-fallback, not the kernel. nemotron-h's MoE runs through the separate C++
-`fused_moe_forward` and is wired behind `MLXCEL_FUSED_MOE_RELU2` only.
+The fused single-token decode dispatch is wired into five model paths: qwen3_moe
+(Qwen3 MoE), qwen3_next (qwen3.5/3.6), dots.llm1 (mixed 4/6-bit), gemma4 (GeGLU),
+and qwen2_moe (qwen1.5-moe / Qwen2-MoE; migrated from its local `SwitchGLU` to the
+shared one, which gained a per-expert stacking loader for the `experts.{idx}`
+checkpoint layout). Other MoE families reuse the shared `SwitchGLU` for the expert
+matmul but were not wired with the fused decode dispatch, so they stay on
+`gather_qmm` regardless of `MLXCEL_FUSED_MOE`: mixtral, olmoe, minimax, phimoe,
+lfm2, and qwen3_vl_moe (it imports `SwitchGLU` from qwen3_moe but keeps its own
+non-fused MoE forward). Wiring those is a separate follow-up. nemotron-h's MoE runs
+through the separate C++ `fused_moe_forward` and is wired behind
+`MLXCEL_FUSED_MOE_RELU2` only.

--- a/src/models/qwen2_moe.rs
+++ b/src/models/qwen2_moe.rs
@@ -175,202 +175,6 @@ impl Attention {
     }
 }
 
-// SwitchLinear: Stacked expert weights for MoE.
-/// Stacked linear layers for MoE experts
-/// Weights shape: [num_experts, output_dim, input_dim_packed]
-/// Supports both quantized (gather_qmm) and non-quantized (gather_mm) forward paths.
-pub enum SwitchLinear {
-    Quantized {
-        weight: UniquePtr<MlxArray>,
-        scales: UniquePtr<MlxArray>,
-        biases: UniquePtr<MlxArray>,
-        group_size: i32,
-        bits: i32,
-        num_experts: usize,
-    },
-    Regular {
-        weight: UniquePtr<MlxArray>,
-        num_experts: usize,
-    },
-}
-
-impl SwitchLinear {
-    /// Return the number of experts this layer holds.
-    pub fn num_experts(&self) -> usize {
-        match self {
-            Self::Quantized { num_experts, .. } => *num_experts,
-            Self::Regular { num_experts, .. } => *num_experts,
-        }
-    }
-
-    /// Forward pass: gather_qmm for quantized weights, gather_mm for regular weights.
-    pub fn forward(
-        &self,
-        x: &MlxArray,
-        indices: &MlxArray,
-        sorted_indices: bool,
-    ) -> UniquePtr<MlxArray> {
-        match self {
-            Self::Quantized {
-                weight,
-                scales,
-                biases,
-                group_size,
-                bits,
-                ..
-            } => {
-                // SAFETY: weight/scales/biases are valid UniquePtr-owned MlxArray values.
-                unsafe {
-                    mlxcel_core::gather_qmm(
-                        x,
-                        weight,
-                        scales,
-                        biases.as_ref().unwrap() as *const _,
-                        std::ptr::null(), // lhs_indices
-                        indices as *const _,
-                        true, // transpose
-                        *group_size,
-                        *bits,
-                        sorted_indices,
-                        "affine",
-                    )
-                }
-            }
-            Self::Regular { weight, .. } => {
-                let wt = mlxcel_core::swap_axes(weight, -1, -2);
-                // SAFETY: wt and indices are valid MlxArray values in scope.
-                unsafe {
-                    mlxcel_core::gather_mm(
-                        x,
-                        &wt,
-                        std::ptr::null(),
-                        indices as *const _,
-                        sorted_indices,
-                    )
-                }
-            }
-        }
-    }
-}
-
-// SwitchGLU: SwiGLU with stacked expert weights.
-/// SwitchGLU: SwiGLU activation with stacked expert weights for MoE
-pub struct SwitchGLU {
-    pub gate_proj: SwitchLinear,
-    pub up_proj: SwitchLinear,
-    pub down_proj: SwitchLinear,
-}
-
-impl SwitchGLU {
-    /// Forward pass with kernel-fused SwiGLU activation
-    /// x: [n_tokens, hidden]
-    /// indices: [n_tokens, top_k]
-    /// Returns: [n_tokens, top_k, hidden]
-    pub fn forward(&self, x: &MlxArray, indices: &MlxArray) -> UniquePtr<MlxArray> {
-        let indices_shape = mlxcel_core::array_shape(indices);
-        let n_tokens = indices_shape[0];
-        let top_k = indices_shape[1];
-
-        // Check if we should use sorted_indices optimization (>= 64 tokens)
-        let total_elements = n_tokens * top_k;
-        let do_sort = total_elements >= 64;
-
-        // Expand x for broadcasting: [n_tokens, hidden] -> [n_tokens, 1, 1, hidden]
-        let x_expanded = mlxcel_core::expand_dims(x, -2);
-        let x_expanded = mlxcel_core::expand_dims(&x_expanded, -3);
-
-        if do_sort {
-            // Sort tokens by expert for better memory access
-            let (sorted_x, sorted_idx, inv_order) = self.gather_sort(&x_expanded, indices);
-
-            // Apply projections with sorted_indices=true
-            let x_gate = self.gate_proj.forward(&sorted_x, &sorted_idx, true);
-            let x_up = self.up_proj.forward(&sorted_x, &sorted_idx, true);
-
-            // Kernel-fused SwiGLU: silu(gate) * up
-            let activated = mlxcel_core::compiled_swiglu_activation(&x_gate, &x_up);
-
-            // Down projection
-            let output = self.down_proj.forward(&activated, &sorted_idx, true);
-
-            // Restore original order
-            self.scatter_unsort(&output, &inv_order, &indices_shape)
-        } else {
-            // Direct path without sorting
-            let x_gate = self.gate_proj.forward(&x_expanded, indices, false);
-            let x_up = self.up_proj.forward(&x_expanded, indices, false);
-
-            // Kernel-fused SwiGLU: silu(gate) * up
-            let activated = mlxcel_core::compiled_swiglu_activation(&x_gate, &x_up);
-
-            // Down projection
-            let output = self.down_proj.forward(&activated, indices, false);
-
-            // Squeeze: [n_tokens, top_k, 1, hidden] -> [n_tokens, top_k, hidden]
-            mlxcel_core::squeeze_axis(&output, -2)
-        }
-    }
-
-    /// Sort tokens by expert index for better memory access
-    fn gather_sort(
-        &self,
-        x: &MlxArray,
-        indices: &MlxArray,
-    ) -> (
-        UniquePtr<MlxArray>,
-        UniquePtr<MlxArray>,
-        UniquePtr<MlxArray>,
-    ) {
-        let indices_shape = mlxcel_core::array_shape(indices);
-        let top_k = indices_shape[indices_shape.len() - 1];
-
-        // Flatten indices: [n_tokens, top_k] -> [n_tokens * top_k]
-        let flat_indices = mlxcel_core::reshape(indices, &[-1]);
-
-        // Sort indices by expert
-        let order = mlxcel_core::argsort(&flat_indices, -1);
-        let inv_order = mlxcel_core::argsort(&order, -1);
-
-        // x is [n_tokens, 1, 1, hidden]
-        // Flatten: [n_tokens, 1, hidden]
-        let x_shape = mlxcel_core::array_shape(x);
-        let x_flat = mlxcel_core::reshape(x, &[x_shape[0], 1, x_shape[3]]);
-
-        // Divide order by top_k to get token indices
-        let top_k_arr = mlxcel_core::from_slice_i32(&[top_k], &[1]);
-        let token_indices = mlxcel_core::divide(&order, &top_k_arr);
-        let token_indices = mlxcel_core::astype(&token_indices, mlxcel_core::dtype::INT32);
-
-        // Take x rows in sorted order
-        let sorted_x = mlxcel_core::take(&x_flat, &token_indices, 0);
-
-        // Get sorted expert indices
-        let sorted_indices = mlxcel_core::take(&flat_indices, &order, 0);
-
-        (sorted_x, sorted_indices, inv_order)
-    }
-
-    /// Restore original order after sorted expert computation
-    fn scatter_unsort(
-        &self,
-        x: &MlxArray,
-        inv_order: &MlxArray,
-        orig_shape: &[i32],
-    ) -> UniquePtr<MlxArray> {
-        // x has shape [n_sorted, 1, hidden]
-        // Reorder by inv_order
-        let unsorted = mlxcel_core::take(x, inv_order, 0);
-
-        // Unflatten and squeeze
-        let x_shape = mlxcel_core::array_shape(&unsorted);
-        let n_tokens = orig_shape[0];
-        let top_k = orig_shape[1];
-
-        let reshaped = mlxcel_core::reshape(&unsorted, &[n_tokens, top_k, x_shape[1], x_shape[2]]);
-        mlxcel_core::squeeze_axis(&reshaped, 2)
-    }
-}
-
 // Shared Expert MLP.
 /// Standard MLP with SwiGLU activation for shared expert
 pub struct SharedExpertMLP {
@@ -395,7 +199,7 @@ impl SharedExpertMLP {
 /// Qwen2 MoE layer with sparse experts and shared expert
 pub struct SparseMoeBlock {
     pub router: UnifiedLinear,
-    pub experts: SwitchGLU,
+    pub experts: crate::models::switch_layers::SwitchGLU,
     pub shared_expert: SharedExpertMLP,
     pub shared_expert_gate: UnifiedLinear,
     pub num_experts: usize,
@@ -433,14 +237,32 @@ impl SparseMoeBlock {
         // Get corresponding scores
         let scores = mlxcel_core::take_along_axis(&gates, &topk_indices, -1);
 
-        // Apply experts
-        let expert_out = self.experts.forward(&x_flat, &topk_indices);
-
-        let expert_out_sum = crate::models::switch_layers::moe_weighted_sum(
-            &expert_out,
-            &scores,
-            mlxcel_core::array_dtype(&x_flat),
-        );
+        // Apply routed experts. Fused single-token decode kernel (#268) on by
+        // default; MLXCEL_FUSED_MOE=0 forces the proven SwitchGLU +
+        // moe_weighted_sum path (also the automatic fallback when the kernel does
+        // not support the config). The shared-expert path below is unchanged.
+        let expert_out_sum = {
+            let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
+                && crate::models::switch_layers::fused_moe_enabled()
+            {
+                self.experts
+                    .forward_fused_kernel(&x_flat, &topk_indices, &scores)
+                    .map(|out| mlxcel_core::reshape(&out, &[1, hidden_dim]))
+            } else {
+                None
+            };
+            match fused {
+                Some(out) => out,
+                None => {
+                    let expert_out = self.experts.forward(&x_flat, &topk_indices);
+                    crate::models::switch_layers::moe_weighted_sum(
+                        &expert_out,
+                        &scores,
+                        mlxcel_core::array_dtype(&x_flat),
+                    )
+                }
+            }
+        };
 
         // Compute shared expert output
         let shared_output = self.shared_expert.forward(&x_flat);
@@ -678,8 +500,12 @@ impl SparseMoeBlock {
         let moe_prefix = format!("{}.mlp", prefix);
 
         let router = load_quantized_linear(weights, &format!("{}.gate", moe_prefix), args)?;
-        let experts =
-            SwitchGLU::from_weights(weights, args, &format!("{}.switch_mlp", moe_prefix))?;
+        let experts = crate::models::switch_layers::SwitchGLU::from_weights(
+            weights,
+            &format!("{}.switch_mlp", moe_prefix),
+            args.group_size(),
+            args.bits(),
+        )?;
 
         // Load shared expert
         let shared_expert =
@@ -697,137 +523,6 @@ impl SparseMoeBlock {
             num_experts: args.num_experts,
             top_k: args.num_experts_per_tok,
         })
-    }
-}
-
-impl SwitchGLU {
-    /// Load SwitchGLU from weights
-    pub fn from_weights(
-        weights: &WeightMap,
-        args: &ModelArgs,
-        prefix: &str,
-    ) -> Result<Self, String> {
-        Ok(Self {
-            gate_proj: SwitchLinear::from_weights(weights, args, &format!("{}.gate_proj", prefix))?,
-            up_proj: SwitchLinear::from_weights(weights, args, &format!("{}.up_proj", prefix))?,
-            down_proj: SwitchLinear::from_weights(weights, args, &format!("{}.down_proj", prefix))?,
-        })
-    }
-}
-
-impl SwitchLinear {
-    /// Load SwitchLinear from weights, falling back to non-quantized when scales are absent.
-    ///
-    /// Supports both:
-    /// - Stacked format: `{prefix}.{weight,scales,biases}` with shape [num_experts, ...]
-    /// - Individual experts format: needs `experts_prefix` like `model.layers.{l}.mlp.experts`
-    pub fn from_weights(
-        weights: &WeightMap,
-        args: &ModelArgs,
-        prefix: &str,
-    ) -> Result<Self, String> {
-        // Try stacked format first (switch_mlp.gate_proj.weight, etc.)
-        let weight_name = format!("{}.weight", prefix);
-        if weights.contains_key(&weight_name) {
-            let weight = get_weight_copy(weights, &weight_name)?;
-            let scales_key = format!("{}.scales", prefix);
-            if weights.contains_key(&scales_key) {
-                let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());
-                let biases = get_weight_copy(weights, &format!("{}.biases", prefix))?;
-                let shape = mlxcel_core::array_shape(&weight);
-                let num_experts = shape[0] as usize;
-                return Ok(Self::Quantized {
-                    weight,
-                    scales,
-                    biases,
-                    group_size: args.group_size(),
-                    bits: args.bits(),
-                    num_experts,
-                });
-            } else {
-                let shape = mlxcel_core::array_shape(&weight);
-                let num_experts = shape[0] as usize;
-                return Ok(Self::Regular {
-                    weight,
-                    num_experts,
-                });
-            }
-        }
-
-        // Fall back to stacking individual experts
-        // prefix is like "model.layers.0.mlp.switch_mlp.gate_proj"
-        // Need to convert to "model.layers.0.mlp.experts.{idx}.gate_proj"
-        let proj_name = prefix
-            .rsplit('.')
-            .next()
-            .ok_or_else(|| format!("Invalid prefix: {}", prefix))?;
-        let base_prefix = prefix
-            .strip_suffix(&format!(".switch_mlp.{}", proj_name))
-            .ok_or_else(|| format!("Cannot parse prefix for experts format: {}", prefix))?;
-
-        let num_experts = args.num_experts;
-
-        // Check if individual experts are quantized by looking at the first one
-        let first_scales_key = format!("{}.experts.0.{}.scales", base_prefix, proj_name);
-        if weights.contains_key(&first_scales_key) {
-            // Stack weights from individual experts (quantized)
-            let expert_weights: Vec<_> = (0..num_experts)
-                .map(|e| {
-                    get_weight_copy(
-                        weights,
-                        &format!("{}.experts.{}.{}.weight", base_prefix, e, proj_name),
-                    )
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            let expert_scales: Vec<_> = (0..num_experts)
-                .map(|e| {
-                    get_weight_copy(
-                        weights,
-                        &format!("{}.experts.{}.{}.scales", base_prefix, e, proj_name),
-                    )
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            let expert_biases: Vec<_> = (0..num_experts)
-                .map(|e| {
-                    get_weight_copy(
-                        weights,
-                        &format!("{}.experts.{}.{}.biases", base_prefix, e, proj_name),
-                    )
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            // Stack along axis 0
-            let weight = mlxcel_core::stack_owned(&expert_weights, 0);
-            let scales = mlxcel_core::stack_owned(&expert_scales, 0);
-            let biases = mlxcel_core::stack_owned(&expert_biases, 0);
-
-            Ok(Self::Quantized {
-                weight,
-                scales,
-                biases,
-                group_size: args.group_size(),
-                bits: args.bits(),
-                num_experts,
-            })
-        } else {
-            // Stack weights from individual experts (non-quantized)
-            let expert_weights: Vec<_> = (0..num_experts)
-                .map(|e| {
-                    get_weight_copy(
-                        weights,
-                        &format!("{}.experts.{}.{}.weight", base_prefix, e, proj_name),
-                    )
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            let weight = mlxcel_core::stack_owned(&expert_weights, 0);
-            Ok(Self::Regular {
-                weight,
-                num_experts,
-            })
-        }
     }
 }
 

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -15,7 +15,7 @@
 //! Shared SwitchLinear / SwitchGLU for MoE models
 //!
 //! Used by: KimiLinear, LongcatFlashNgram, DeepSeekV3, DeepSeekV32, GLM4Moe,
-//!          GLM4MoeLite, ExaOneMoe, Mixtral, Qwen3Moe, PhiMoE, OLMoE, etc.
+//!          GLM4MoeLite, ExaOneMoe, Mixtral, Qwen2Moe, Qwen3Moe, PhiMoE, OLMoE, etc.
 //!
 //! SwitchLinear: per-expert 3D matmul (quantized via gather_qmm, regular via gather_mm)
 //! SwitchGLU: SwiGLU MLP routing through SwitchLinear
@@ -175,57 +175,137 @@ impl SwitchLinear {
         bits: i32,
         mode: &str,
     ) -> Result<Self, String> {
-        let weight = weights
-            .get(&format!("{}.weight", prefix))
-            .map(|w| mlxcel_core::copy(w))
-            .ok_or_else(|| format!("Missing weight: {}", prefix))?;
-
-        let scales_key = format!("{}.scales", prefix);
-        if weights.contains_key(&scales_key) {
-            // Quantized path
+        // Pre-stacked layout: `{prefix}.weight` (plus optional `.scales`/`.biases`)
+        // already holds every expert in one `[num_experts, ...]` tensor.
+        if let Some(weight) = weights.get(&format!("{}.weight", prefix)) {
+            let weight = mlxcel_core::copy(weight);
             let scales = weights
-                .get(&scales_key)
-                .map(|w| mlxcel_core::copy(w))
-                .unwrap();
+                .get(&format!("{}.scales", prefix))
+                .map(|w| mlxcel_core::copy(w));
             // biases may not exist for mxfp4/nvfp4/mxfp8 modes
             let biases = weights
                 .get(&format!("{}.biases", prefix))
                 .map(|w| mlxcel_core::copy(w));
+            return Ok(Self::from_stacked_parts(
+                weight, scales, biases, group_size, bits, mode,
+            ));
+        }
 
-            // Infer the actual bit width from the packed weight and scales shapes
-            // (group_size fixed): mixed-precision checkpoints such as dots.llm1
-            // quantize some expert projections at 6-bit while the model default is
-            // 4-bit, so the passed `bits` is only the default. The invariant is
-            // `packed_in * 32 == bits * num_groups * group_size`.
-            let w_shape = mlxcel_core::array_shape(&weight);
-            let s_shape = mlxcel_core::array_shape(&scales);
-            let packed_in = *w_shape.last().unwrap_or(&0);
-            let num_groups = *s_shape.last().unwrap_or(&0);
-            let denom = num_groups * group_size;
-            let effective_bits = if denom > 0 && (packed_in * 32) % denom == 0 {
-                let inferred = (packed_in * 32) / denom;
-                if (2..=8).contains(&inferred) {
-                    inferred
+        // Per-expert layout: `{root}.experts.{idx}.{proj}.{weight,scales,biases}`.
+        // Some mlx-lm checkpoints (e.g. Qwen2-MoE / Qwen1.5-MoE) ship the experts
+        // unstacked under `experts.{idx}` rather than as a single `switch_mlp`
+        // tensor. Stack them here so the gather paths see the same `[num_experts,
+        // ...]` layout as the pre-stacked checkpoints. This branch only runs when
+        // the pre-stacked tensor is absent, so it never changes behavior for an
+        // already-loadable checkpoint.
+        if let Some((weight, scales, biases)) = stack_individual_experts(weights, prefix) {
+            return Ok(Self::from_stacked_parts(
+                weight, scales, biases, group_size, bits, mode,
+            ));
+        }
+
+        Err(format!("Missing weight: {}", prefix))
+    }
+
+    /// Build a `SwitchLinear` from a stacked `[num_experts, ...]` weight (plus
+    /// optional scales/biases). Present scales select the quantized path and the
+    /// per-tensor bit width is inferred from the packed-weight and scales shapes;
+    /// absent scales select the non-quantized `Regular` path.
+    fn from_stacked_parts(
+        weight: UniquePtr<MlxArray>,
+        scales: Option<UniquePtr<MlxArray>>,
+        biases: Option<UniquePtr<MlxArray>>,
+        group_size: i32,
+        bits: i32,
+        mode: &str,
+    ) -> Self {
+        match scales {
+            Some(scales) => {
+                // Infer the actual bit width from the packed weight and scales
+                // shapes (group_size fixed): mixed-precision checkpoints such as
+                // dots.llm1 quantize some expert projections at 6-bit while the
+                // model default is 4-bit, so the passed `bits` is only the
+                // default. The invariant is `packed_in * 32 == bits * num_groups *
+                // group_size`.
+                let w_shape = mlxcel_core::array_shape(&weight);
+                let s_shape = mlxcel_core::array_shape(&scales);
+                let packed_in = *w_shape.last().unwrap_or(&0);
+                let num_groups = *s_shape.last().unwrap_or(&0);
+                let denom = num_groups * group_size;
+                let effective_bits = if denom > 0 && (packed_in * 32) % denom == 0 {
+                    let inferred = (packed_in * 32) / denom;
+                    if (2..=8).contains(&inferred) {
+                        inferred
+                    } else {
+                        bits
+                    }
                 } else {
                     bits
-                }
-            } else {
-                bits
-            };
+                };
 
-            Ok(Self::Quantized {
-                weight,
-                scales,
-                biases,
-                group_size,
-                bits: effective_bits,
-                mode: mode.to_string(),
-            })
-        } else {
-            // Non-quantized fallback
-            Ok(Self::Regular { weight })
+                Self::Quantized {
+                    weight,
+                    scales,
+                    biases,
+                    group_size,
+                    bits: effective_bits,
+                    mode: mode.to_string(),
+                }
+            }
+            None => Self::Regular { weight },
         }
     }
+}
+
+/// Stack per-expert projection tensors (`{root}.experts.{idx}.{proj}.{weight,
+/// scales,biases}`) into single `[num_experts, ...]` tensors, given a
+/// stacked-style `prefix` of the form `{root}.switch_mlp.{proj}`. Returns `None`
+/// when the prefix is not in that form or no `experts.0` weight exists, so the
+/// caller falls through to its own missing-weight error.
+///
+/// `scales`/`biases` are stacked only when expert 0 carries them, matching the
+/// quantized/regular split the stacked loader applies. Experts are gathered
+/// contiguously from index 0 until the first gap.
+///
+/// Used by: Qwen2Moe (Qwen1.5-MoE / Qwen2-MoE individual-expert checkpoints)
+fn stack_individual_experts(
+    weights: &WeightMap,
+    prefix: &str,
+) -> Option<(
+    UniquePtr<MlxArray>,
+    Option<UniquePtr<MlxArray>>,
+    Option<UniquePtr<MlxArray>>,
+)> {
+    // prefix: "{root}.switch_mlp.{proj}"  ->  experts at "{root}.experts.{idx}.{proj}"
+    let proj = prefix.rsplit('.').next()?;
+    let root = prefix.strip_suffix(&format!(".switch_mlp.{}", proj))?;
+    let expert_key = |idx: usize, leaf: &str| format!("{}.experts.{}.{}.{}", root, idx, proj, leaf);
+
+    if !weights.contains_key(&expert_key(0, "weight")) {
+        return None;
+    }
+    let has_scales = weights.contains_key(&expert_key(0, "scales"));
+    let has_biases = weights.contains_key(&expert_key(0, "biases"));
+
+    let mut stacked_weight = Vec::new();
+    let mut stacked_scales = Vec::new();
+    let mut stacked_biases = Vec::new();
+    let mut idx = 0;
+    while let Some(weight) = weights.get(&expert_key(idx, "weight")) {
+        stacked_weight.push(mlxcel_core::copy(weight));
+        if has_scales {
+            stacked_scales.push(mlxcel_core::copy(weights.get(&expert_key(idx, "scales"))?));
+        }
+        if has_biases {
+            stacked_biases.push(mlxcel_core::copy(weights.get(&expert_key(idx, "biases"))?));
+        }
+        idx += 1;
+    }
+
+    let weight = mlxcel_core::stack_owned(&stacked_weight, 0);
+    let scales = has_scales.then(|| mlxcel_core::stack_owned(&stacked_scales, 0));
+    let biases = has_biases.then(|| mlxcel_core::stack_owned(&stacked_biases, 0));
+    Some((weight, scales, biases))
 }
 
 pub struct SwitchGLU {
@@ -529,5 +609,78 @@ mod tests {
                 "{v:?} should keep the kernel on"
             );
         }
+    }
+
+    #[test]
+    fn switch_linear_stacks_individual_quantized_experts() {
+        // Per-expert affine 4-bit layout (Qwen1.5-MoE / Qwen2-MoE checkpoints):
+        // weight [out, in/8], scales/biases [out, in/group_size], stored under
+        // `experts.{idx}.gate_proj.*` instead of a stacked `switch_mlp` tensor.
+        let out = 4i32;
+        let group = 64i32;
+        let in_dim = 64i32; // a single quantization group
+        let packed_in = in_dim / 8; // 4-bit packs 8 weights per uint32 column
+        let num_groups = in_dim / group;
+        let root = "model.layers.0.mlp";
+
+        let mut weights = WeightMap::new();
+        for e in 0..3 {
+            weights.insert(
+                format!("{root}.experts.{e}.gate_proj.weight"),
+                mlxcel_core::from_slice_f32(
+                    &vec![0.0; (out * packed_in) as usize],
+                    &[out, packed_in],
+                ),
+            );
+            weights.insert(
+                format!("{root}.experts.{e}.gate_proj.scales"),
+                mlxcel_core::from_slice_f32(
+                    &vec![1.0; (out * num_groups) as usize],
+                    &[out, num_groups],
+                ),
+            );
+            weights.insert(
+                format!("{root}.experts.{e}.gate_proj.biases"),
+                mlxcel_core::from_slice_f32(
+                    &vec![0.0; (out * num_groups) as usize],
+                    &[out, num_groups],
+                ),
+            );
+        }
+
+        let sl =
+            SwitchLinear::from_weights(&weights, &format!("{root}.switch_mlp.gate_proj"), group, 4)
+                .expect("per-expert stacking should load through the shared loader");
+        let parts = sl
+            .quantized_parts()
+            .expect("stacked per-expert weights should yield a quantized SwitchLinear");
+        assert_eq!(
+            mlxcel_core::array_shape(parts.weight),
+            vec![3, out, packed_in]
+        );
+        assert_eq!(
+            parts.bits, 4,
+            "bits inferred from packed weight/scales shapes"
+        );
+        assert_eq!(parts.group_size, group);
+        assert_eq!(parts.mode, "affine");
+    }
+
+    #[test]
+    fn switch_linear_missing_weight_errors_without_stacked_or_individual() {
+        // Neither a stacked `switch_mlp` tensor nor `experts.{idx}` tensors exist.
+        // (`SwitchLinear` holds non-Debug MlxArray handles, so match on the Result
+        // rather than using `expect_err`.)
+        let weights = WeightMap::new();
+        let err = match SwitchLinear::from_weights(
+            &weights,
+            "model.layers.0.mlp.switch_mlp.gate_proj",
+            64,
+            4,
+        ) {
+            Ok(_) => panic!("absent experts must not load"),
+            Err(e) => e,
+        };
+        assert!(err.contains("Missing weight"), "unexpected error: {err}");
     }
 }


### PR DESCRIPTION
## Summary

Wire qwen2_moe (Qwen1.5-MoE / Qwen2-MoE) into the fused single-token decode-MoE Metal kernel (#268), mirroring qwen3_moe / dots1. For single-token decode with `MLXCEL_FUSED_MOE` on (the default), the routed-expert weighted sum runs through `experts.forward_fused_kernel`; the proven `gather_qmm` `SwitchGLU` + `moe_weighted_sum` path stays as the fallback for prefill, when the flag is off, and for any config the kernel does not support. The shared-expert (sigmoid-gated) addition is unchanged.

## Group-B correction to the issue

The issue assumed qwen2_moe's experts already used the shared `SwitchGLU` exposing `forward_fused_kernel`. That was wrong: qwen2_moe defined its own local `SwitchGLU` and `SwitchLinear` that exposed neither `forward_fused_kernel` nor `quantized_parts`, and the local `SwitchLinear::Quantized` had no `mode` field. So this is a Group-B migration (the same class as #301/#302/#303): migrate qwen2_moe to `crate::models::switch_layers::SwitchGLU`, then add the one-branch fused dispatch. The local `SwitchGLU` / `SwitchLinear` and their loaders are removed; a repo-wide grep confirmed nothing else referenced them.

## Weight-loading parity

The shared `SwitchLinear` loader was stacked-only (`{prefix}.weight` holding all experts), but the two checkpoint conventions differ: qwen3-moe ships experts pre-stacked under `switch_mlp`, while Qwen1.5-MoE / Qwen2-MoE ship them unstacked under `experts.{idx}.{proj}` (verified against the local `models/qwen1.5-moe-a2.7b-4bit` checkpoint, which is fully per-expert). The local qwen2_moe loader handled the per-expert layout via a stacking fallback; the shared loader did not, so loading qwen2_moe through it unchanged would have errored.

To preserve exactly which weights load, `SwitchLinear::from_weights_with_mode` gains a per-expert stacking fallback (`stack_individual_experts`) that converts a `{root}.switch_mlp.{proj}` prefix to `{root}.experts.{idx}.{proj}` and stacks contiguously from index 0. It runs only when the pre-stacked tensor is absent, so it never changes behavior for an already-loadable checkpoint, and it now also serves the other unstacked MoE families slated for migration. The per-tensor bit-width inference is shared across both paths; for qwen1.5-moe's uniform 4-bit it yields the same bits the local loader hardcoded (`args.bits()`), so there is no silent change to loaded weights, only a strictly more robust path for mixed-precision exports.

## What changed

- `src/models/qwen2_moe.rs`: `SparseMoeBlock.experts` now typed `crate::models::switch_layers::SwitchGLU`; construction calls the shared `SwitchGLU::from_weights(weights, "{moe}.switch_mlp", group_size, bits)`; the routed-expert sum in `SparseMoeBlock::forward` uses the fused-gated branch with a `moe_weighted_sum` fallback; local `SwitchGLU` / `SwitchLinear` definitions and loaders removed.
- `src/models/switch_layers.rs`: `from_weights_with_mode` refactored into a shared `from_stacked_parts` builder plus a new `stack_individual_experts` per-expert fallback; module `Used by:` doc updated to include Qwen2Moe; two unit tests added (per-expert quantized stacking, missing-weight error).
- `docs/benchmark_results/fused-moe-decode-kernel-design.md`: qwen2_moe moved from the not-wired list to the wired list.

## Test plan

- [x] `cargo check --lib --tests --features metal,accelerate`
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings` (clean)
- [ ] Real-checkpoint validation on `mlx-community/Qwen1.5-MoE-A2.7B-Chat-4bit`: confirm the kernel actually dispatches (not a silent fallback), temp-0 greedy parity vs `MLXCEL_FUSED_MOE=0` within the documented f16 jitter class (no NaN / no garbage), and decode tok/s fused-on vs off. Pending the orchestrator's verification step.

Closes #286
