### PR TITLE
perf(moe): wire qwen3_vl_moe to the fused decode-MoE kernel

### DIFF
--- a/docs/benchmark_results/fused-moe-decode-kernel-design.md
+++ b/docs/benchmark_results/fused-moe-decode-kernel-design.md
@@ -207,14 +207,14 @@ the expected numerical consequence of the fusion.
 
 ### Models covered
 
-The fused single-token decode dispatch is wired into six model paths: qwen3_moe
+The fused single-token decode dispatch is wired into seven model paths: qwen3_moe
 (Qwen3 MoE), qwen3_next (qwen3.5/3.6), dots.llm1 (mixed 4/6-bit), gemma4 (GeGLU),
 qwen2_moe (qwen1.5-moe / Qwen2-MoE; migrated from its local `SwitchGLU` to the
 shared one, which gained a per-expert stacking loader for the `experts.{idx}`
-checkpoint layout), and lfm2 (LFM2-MoE; sigmoid-routed, optional expert_bias and
-norm_topk_prob). Other MoE families reuse the shared `SwitchGLU` for the expert
-matmul but were not wired with the fused decode dispatch, so they stay on
-`gather_qmm` regardless of `MLXCEL_FUSED_MOE`: mixtral, olmoe, minimax, phimoe,
-and qwen3_vl_moe (it imports `SwitchGLU` from qwen3_moe but keeps its own
-non-fused MoE forward). nemotron-h's MoE runs through the separate C++
+checkpoint layout), lfm2 (LFM2-MoE; sigmoid-routed, optional expert_bias and
+norm_topk_prob), and qwen3_vl_moe (Qwen3-VL MoE; imports `SwitchGLU` from qwen3_moe,
+SwiGLU activation, text-only decode path). Other MoE families reuse the shared
+`SwitchGLU` for the expert matmul but were not wired with the fused decode dispatch,
+so they stay on `gather_qmm` regardless of `MLXCEL_FUSED_MOE`: mixtral, olmoe,
+minimax, and phimoe. nemotron-h's MoE runs through the separate C++
 `fused_moe_forward` and is wired behind `MLXCEL_FUSED_MOE_RELU2` only.

--- a/src/models/qwen3_vl_moe.rs
+++ b/src/models/qwen3_vl_moe.rs
@@ -601,14 +601,31 @@ impl SparseMoeBlock {
             scores = mlxcel_core::divide(&scores, &sum);
         }
 
-        // Apply experts - returns [n_tokens, k, hidden]
-        let expert_out = self.experts.forward(&x_flat, &topk_indices);
-
-        let result = crate::models::switch_layers::moe_weighted_sum(
-            &expert_out,
-            &scores,
-            mlxcel_core::array_dtype(&x_flat),
-        );
+        // Apply experts via fused single-token decode kernel when available,
+        // falling back to gather_qmm + weighted-sum for prefill and any
+        // unsupported bit-width config.
+        let result = {
+            let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
+                && crate::models::switch_layers::fused_moe_enabled()
+            {
+                self.experts
+                    .forward_fused_kernel(&x_flat, &topk_indices, &scores)
+                    .map(|out| mlxcel_core::reshape(&out, &[1, hidden_dim]))
+            } else {
+                None
+            };
+            match fused {
+                Some(out) => out,
+                None => {
+                    let expert_out = self.experts.forward(&x_flat, &topk_indices);
+                    crate::models::switch_layers::moe_weighted_sum(
+                        &expert_out,
+                        &scores,
+                        mlxcel_core::array_dtype(&x_flat),
+                    )
+                }
+            }
+        };
 
         // Reshape back to original shape
         if orig_shape.len() > 2 {


### PR DESCRIPTION
## Summary

Wires `qwen3_vl_moe`'s `SparseMoeBlock::forward` to the fused single-token decode-MoE kernel, matching the pattern already used by `qwen3_moe`, `qwen3_next`, `dots1`, `gemma4`, `qwen2_moe`, and `lfm2`.

## What changed

- `src/models/qwen3_vl_moe.rs`: replaced the unconditional `experts.forward + moe_weighted_sum` block with the gated fused-kernel branch. When `n_tokens == 1` and `fused_moe_enabled()` returns true, the block calls `SwitchGLU::forward_fused_kernel(&x_flat, &topk_indices, &scores)` (signature: `fn forward_fused_kernel(&self, x: &MlxArray, indices: &MlxArray, scores: &MlxArray) -> Option<UniquePtr<MlxArray>>`). The kernel returns `None` for any unsupported config (non-4/8-bit gate/up, non-4/6/8-bit down, group_size mismatch, or multi-token decode), and the `match` arm falls through to the original `forward + moe_weighted_sum` path. Prefill is unaffected. Activation is SwiGLU (act=0); no GeGLU or relu2 template is needed.
- `docs/benchmark_results/fused-moe-decode-kernel-design.md`: updated the "Models covered" section, moving `qwen3_vl_moe` from the unwired list to the wired list and updating the count from six to seven.

## Test plan

- [x] `cargo check --lib --tests --features metal,accelerate`: clean
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings`: clean
- [ ] Real-checkpoint validation on `mlx-community/Qwen3-VL-30B-A3B-4bit` (text-only decode, greedy temp-0 parity fused-on vs fused-off, tok/s measurement) is pending orchestrator.

Closes #306
