### PR TITLE
perf(moe): wire mixtral to the fused decode-MoE kernel

### DIFF
--- a/docs/benchmark_results/fused-moe-decode-kernel-design.md
+++ b/docs/benchmark_results/fused-moe-decode-kernel-design.md
@@ -207,14 +207,17 @@ the expected numerical consequence of the fusion.
 
 ### Models covered
 
-The fused single-token decode dispatch is wired into seven model paths: qwen3_moe
+The fused single-token decode dispatch is wired into eight model paths: qwen3_moe
 (Qwen3 MoE), qwen3_next (qwen3.5/3.6), dots.llm1 (mixed 4/6-bit), gemma4 (GeGLU),
 qwen2_moe (qwen1.5-moe / Qwen2-MoE; migrated from its local `SwitchGLU` to the
 shared one, which gained a per-expert stacking loader for the `experts.{idx}`
-checkpoint layout), lfm2 (LFM2-MoE; sigmoid-routed, optional expert_bias and
-norm_topk_prob), and qwen3_vl_moe (Qwen3-VL MoE; imports `SwitchGLU` from qwen3_moe,
-SwiGLU activation, text-only decode path). Other MoE families reuse the shared
-`SwitchGLU` for the expert matmul but were not wired with the fused decode dispatch,
-so they stay on `gather_qmm` regardless of `MLXCEL_FUSED_MOE`: mixtral, olmoe,
-minimax, and phimoe. nemotron-h's MoE runs through the separate C++
-`fused_moe_forward` and is wired behind `MLXCEL_FUSED_MOE_RELU2` only.
+checkpoint layout), mixtral (Mixtral 8x7B; SwiGLU, softmax-routed with no shared
+expert; migrated from its local `SwitchGLU` to the shared one, which gained an
+overridable projection-leaf-name loader for the `w1`/`w2`/`w3` checkpoint
+convention, mapping gate=w1, up=w3, down=w2), lfm2 (LFM2-MoE; sigmoid-routed,
+optional expert_bias and norm_topk_prob), and qwen3_vl_moe (Qwen3-VL MoE; imports
+`SwitchGLU` from qwen3_moe, SwiGLU activation, text-only decode path). Other MoE
+families reuse the shared `SwitchGLU` for the expert matmul but were not wired with
+the fused decode dispatch, so they stay on `gather_qmm` regardless of
+`MLXCEL_FUSED_MOE`: olmoe, minimax, and phimoe. nemotron-h's MoE runs through the
+separate C++ `fused_moe_forward` and is wired behind `MLXCEL_FUSED_MOE_RELU2` only.

--- a/docs/benchmark_results/fused-moe-decode-kernel-design.md
+++ b/docs/benchmark_results/fused-moe-decode-kernel-design.md
@@ -160,6 +160,7 @@ falls back to the proven `gather_qmm` / `SwitchGLU` path automatically. Set
 | `MLXCEL_FUSED_MOE` | unset (on) | On by default. Set to `0` (also `false`/`off`/`no`, case-insensitive) to force the proven `gather_qmm` / `SwitchGLU` path; any other value, or leaving it unset, keeps the kernel on. |
 | `MLXCEL_FUSED_MOE_SGY` | 8 | Simdgroups per threadgroup (one output row each). Tune per hardware. |
 | `MLXCEL_FUSED_MOE_RELU2` | unset (off) | Enable the squared-ReLU (fc1/relu²/fc2) fused path used by nemotron-class experts. Correct but measured performance-neutral on nemotron-h; kept for a future MoE-dominated squared-ReLU model. |
+| `MLXCEL_FUSED_MOE_MAX_DFF` | 4096 | Expert-intermediate (Dff) upper bound. Above it, `forward_fused_kernel` declines and the caller falls back to `gather_qmm`. The fused path wins only while `gather_qmm` underutilizes the GPU (small experts); for large experts `gather_qmm` already saturates and the extra dispatch plus global-memory activation staging is a net loss. M1 Ultra measurements: Dff 704..2560 gain +3.5% to +15.4%, Dff 6400 (phi-3.5-moe) loses 5.9%, Dff 14336 (mixtral) loses 21%. The break-even is hardware-dependent, so the bound is tunable. |
 
 ### Measured decode gains (M1 Ultra, `MLXCEL_FUSED_MOE=1`)
 
@@ -214,7 +215,10 @@ shared one, which gained a per-expert stacking loader for the `experts.{idx}`
 checkpoint layout), mixtral (Mixtral 8x7B; SwiGLU, softmax-routed with no shared
 expert; migrated from its local `SwitchGLU` to the shared one, which gained an
 overridable projection-leaf-name loader for the `w1`/`w2`/`w3` checkpoint
-convention, mapping gate=w1, up=w3, down=w2), lfm2 (LFM2-MoE; sigmoid-routed,
+convention, mapping gate=w1, up=w3, down=w2; Mixtral's expert intermediate is
+14336, above `MLXCEL_FUSED_MOE_MAX_DFF`, so the kernel declines and decode stays
+on `gather_qmm` (the migration removes duplication; the dispatch arms only if the
+bound is raised)), lfm2 (LFM2-MoE; sigmoid-routed,
 optional expert_bias and norm_topk_prob), and qwen3_vl_moe (Qwen3-VL MoE; imports
 `SwitchGLU` from qwen3_moe, SwiGLU activation, text-only decode path). Other MoE
 families reuse the shared `SwitchGLU` for the expert matmul but were not wired with

--- a/src/models/mixtral.rs
+++ b/src/models/mixtral.rs
@@ -21,6 +21,7 @@
 //! - RMSNorm normalization
 //! - No shared expert (unlike Llama 4)
 
+use crate::models::switch_layers::SwitchGLU;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
@@ -82,193 +83,6 @@ impl ModelArgs {
     }
 }
 
-// SwitchLinear: Stacked expert weights for MoE.
-/// Stacked linear layers for MoE experts
-/// Weights shape: [num_experts, output_dim, input_dim_packed]
-pub enum SwitchLinear {
-    Quantized {
-        weight: UniquePtr<MlxArray>,
-        scales: UniquePtr<MlxArray>,
-        biases: UniquePtr<MlxArray>,
-        group_size: i32,
-        bits: i32,
-        num_experts: usize,
-    },
-    Regular {
-        weight: UniquePtr<MlxArray>,
-    },
-}
-
-impl SwitchLinear {
-    /// Forward pass using gather_qmm for quantized or gather_mm for regular
-    /// x: [n_tokens, 1, 1, hidden] or [n_sorted, 1, hidden]
-    /// indices: [n_tokens, top_k] or [n_sorted] (flattened when sorted)
-    pub fn forward(
-        &self,
-        x: &MlxArray,
-        indices: &MlxArray,
-        sorted_indices: bool,
-    ) -> UniquePtr<MlxArray> {
-        match self {
-            Self::Quantized {
-                weight,
-                scales,
-                biases,
-                group_size,
-                bits,
-                ..
-            } => unsafe {
-                mlxcel_core::gather_qmm(
-                    x,
-                    weight,
-                    scales,
-                    biases
-                        .as_ref()
-                        .map(|b| b as *const _)
-                        .unwrap_or(std::ptr::null()),
-                    std::ptr::null(), // lhs_indices
-                    indices as *const _,
-                    true, // transpose
-                    *group_size,
-                    *bits,
-                    sorted_indices,
-                    "affine",
-                )
-            },
-            Self::Regular { weight } => {
-                let wt = mlxcel_core::swap_axes(weight, -1, -2);
-                unsafe {
-                    mlxcel_core::gather_mm(
-                        x,
-                        &wt,
-                        std::ptr::null(),
-                        indices as *const _,
-                        sorted_indices,
-                    )
-                }
-            }
-        }
-    }
-}
-
-// SwitchGLU: SwiGLU with stacked expert weights.
-/// SwitchGLU: SwiGLU activation with stacked expert weights for MoE
-pub struct SwitchGLU {
-    pub gate_proj: SwitchLinear,
-    pub up_proj: SwitchLinear,
-    pub down_proj: SwitchLinear,
-}
-
-impl SwitchGLU {
-    /// Forward pass with kernel-fused SwiGLU activation
-    /// x: [n_tokens, hidden]
-    /// indices: [n_tokens, top_k]
-    /// Returns: [n_tokens, top_k, hidden]
-    pub fn forward(&self, x: &MlxArray, indices: &MlxArray) -> UniquePtr<MlxArray> {
-        let indices_shape = mlxcel_core::array_shape(indices);
-        let n_tokens = indices_shape[0];
-        let top_k = indices_shape[1];
-
-        // Check if we should use sorted_indices optimization (>= 64 tokens)
-        let total_elements = n_tokens * top_k;
-        let do_sort = total_elements >= 64;
-
-        // Expand x for broadcasting: [n_tokens, hidden] -> [n_tokens, 1, 1, hidden]
-        let x_expanded = mlxcel_core::expand_dims(x, -2);
-        let x_expanded = mlxcel_core::expand_dims(&x_expanded, -3);
-
-        if do_sort {
-            // Sort tokens by expert for better memory access
-            let (sorted_x, sorted_idx, inv_order) = self.gather_sort(&x_expanded, indices);
-
-            // Apply projections with sorted_indices=true
-            let x_gate = self.gate_proj.forward(&sorted_x, &sorted_idx, true);
-            let x_up = self.up_proj.forward(&sorted_x, &sorted_idx, true);
-
-            // Kernel-fused SwiGLU: silu(gate) * up
-            let activated = mlxcel_core::compiled_swiglu_activation(&x_gate, &x_up);
-
-            // Down projection
-            let output = self.down_proj.forward(&activated, &sorted_idx, true);
-
-            // Restore original order
-            self.scatter_unsort(&output, &inv_order, &indices_shape)
-        } else {
-            // Direct path without sorting
-            let x_gate = self.gate_proj.forward(&x_expanded, indices, false);
-            let x_up = self.up_proj.forward(&x_expanded, indices, false);
-
-            // Kernel-fused SwiGLU: silu(gate) * up
-            let activated = mlxcel_core::compiled_swiglu_activation(&x_gate, &x_up);
-
-            // Down projection
-            let output = self.down_proj.forward(&activated, indices, false);
-
-            // Squeeze: [n_tokens, top_k, 1, hidden] -> [n_tokens, top_k, hidden]
-            mlxcel_core::squeeze_axis(&output, -2)
-        }
-    }
-
-    /// Sort tokens by expert index for better memory access
-    fn gather_sort(
-        &self,
-        x: &MlxArray,
-        indices: &MlxArray,
-    ) -> (
-        UniquePtr<MlxArray>,
-        UniquePtr<MlxArray>,
-        UniquePtr<MlxArray>,
-    ) {
-        let indices_shape = mlxcel_core::array_shape(indices);
-        let top_k = indices_shape[indices_shape.len() - 1];
-
-        // Flatten indices: [n_tokens, top_k] -> [n_tokens * top_k]
-        let flat_indices = mlxcel_core::reshape(indices, &[-1]);
-
-        // Sort indices by expert
-        let order = mlxcel_core::argsort(&flat_indices, -1);
-        let inv_order = mlxcel_core::argsort(&order, -1);
-
-        // x is [n_tokens, 1, 1, hidden]
-        // Flatten: [n_tokens, 1, hidden]
-        let x_shape = mlxcel_core::array_shape(x);
-        let x_flat = mlxcel_core::reshape(x, &[x_shape[0], 1, x_shape[3]]);
-
-        // Divide order by top_k to get token indices
-        let top_k_arr = mlxcel_core::from_slice_i32(&[top_k], &[1]);
-        let token_indices = mlxcel_core::divide(&order, &top_k_arr);
-        let token_indices = mlxcel_core::astype(&token_indices, mlxcel_core::dtype::INT32);
-
-        // Take x rows in sorted order
-        let sorted_x = mlxcel_core::take(&x_flat, &token_indices, 0);
-
-        // Get sorted expert indices
-        let sorted_indices = mlxcel_core::take(&flat_indices, &order, 0);
-
-        (sorted_x, sorted_indices, inv_order)
-    }
-
-    /// Restore original order after sorted expert computation
-    fn scatter_unsort(
-        &self,
-        x: &MlxArray,
-        inv_order: &MlxArray,
-        orig_shape: &[i32],
-    ) -> UniquePtr<MlxArray> {
-        // x has shape [n_sorted, 1, hidden]
-        // Reorder by inv_order
-        let unsorted = mlxcel_core::take(x, inv_order, 0);
-
-        // Unflatten and squeeze
-        let x_shape = mlxcel_core::array_shape(&unsorted);
-        let n_tokens = orig_shape[0];
-        let top_k = orig_shape[1];
-
-        let reshaped = mlxcel_core::reshape(&unsorted, &[n_tokens, top_k, x_shape[1], x_shape[2]]);
-        mlxcel_core::squeeze_axis(&reshaped, 2)
-    }
-}
-
 // Sparse MoE Block.
 /// Mixtral sparse mixture of experts layer
 pub struct SparseMoeBlock {
@@ -309,14 +123,35 @@ impl SparseMoeBlock {
         let topk_logits = mlxcel_core::take_along_axis(&logits, &topk_indices, -1);
         let scores = mlxcel_core::softmax(&topk_logits, -1);
 
-        // Apply experts - returns [n_tokens, k, hidden]
-        let expert_out = self.experts.forward(&x_flat, &topk_indices);
-
-        let result = crate::models::switch_layers::moe_weighted_sum(
-            &expert_out,
-            &scores,
-            mlxcel_core::array_dtype(&x_flat),
-        );
+        // Apply routed experts. Fused single-token decode kernel (#268) on by
+        // default; MLXCEL_FUSED_MOE=0 forces the proven SwitchGLU +
+        // moe_weighted_sum path (also the automatic fallback when the kernel
+        // does not support the config). Mixtral routes through softmax over the
+        // top-k logits with no shared expert and no renormalization, so `scores`
+        // already carries the full combine weights the kernel needs.
+        let result = {
+            let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
+                && crate::models::switch_layers::fused_moe_enabled()
+            {
+                self.experts
+                    .forward_fused_kernel(&x_flat, &topk_indices, &scores)
+                    .map(|out| mlxcel_core::reshape(&out, &[1, hidden_dim]))
+            } else {
+                None
+            };
+            match fused {
+                Some(out) => out,
+                None => {
+                    // Apply experts - returns [n_tokens, k, hidden]
+                    let expert_out = self.experts.forward(&x_flat, &topk_indices);
+                    crate::models::switch_layers::moe_weighted_sum(
+                        &expert_out,
+                        &scores,
+                        mlxcel_core::array_dtype(&x_flat),
+                    )
+                }
+            }
+        };
 
         // Reshape back to original shape
         if orig_shape.len() > 2 {
@@ -616,97 +451,25 @@ impl SparseMoeBlock {
             args.bits(),
         )?;
 
-        let experts = SwitchGLU::from_weights(weights, args, &format!("{}.experts", prefix))?;
+        // Mixtral stores its experts under the w1/w2/w3 convention at
+        // `{prefix}.experts.{idx}.{w1,w2,w3}.{weight,scales,biases}`, mapping
+        // gate=w1, up=w3, down=w2. The shared per-expert stacker keys off a
+        // `.switch_mlp` virtual prefix (identical to the Qwen2-MoE path) to find
+        // the `{prefix}.experts.{idx}` layout; the leaf names are passed in so
+        // the shared loader stays generic.
+        let experts = SwitchGLU::from_weights_with_proj_names(
+            weights,
+            &format!("{}.switch_mlp", prefix),
+            args.group_size(),
+            args.bits(),
+            ["w1", "w3", "w2"], // gate=w1, up=w3, down=w2
+        )?;
 
         Ok(Self {
             router,
             experts,
             num_experts_per_tok: args.num_experts_per_tok,
         })
-    }
-}
-
-impl SwitchGLU {
-    pub fn from_weights(
-        weights: &WeightMap,
-        args: &ModelArgs,
-        prefix: &str, // e.g., "model.layers.0.block_sparse_moe.experts"
-    ) -> Result<Self, String> {
-        let num_experts = args.num_local_experts;
-        Ok(Self {
-            gate_proj: SwitchLinear::from_weights(weights, num_experts, args, prefix, "w1")?,
-            up_proj: SwitchLinear::from_weights(weights, num_experts, args, prefix, "w3")?,
-            down_proj: SwitchLinear::from_weights(weights, num_experts, args, prefix, "w2")?,
-        })
-    }
-}
-
-impl SwitchLinear {
-    /// Load per-expert weights and stack them into a single tensor
-    /// Expected weight format: {prefix}.{expert_idx}.{weight_name}.{weight/scales/biases}
-    /// e.g., "model.layers.0.block_sparse_moe.experts.0.w1.weight"
-    pub fn from_weights(
-        weights: &WeightMap,
-        num_experts: usize,
-        args: &ModelArgs,
-        prefix: &str,
-        weight_name: &str,
-    ) -> Result<Self, String> {
-        // Load and stack weights from individual experts
-        let mut expert_weights = Vec::with_capacity(num_experts);
-
-        // Check if quantized by probing the first expert's scales key
-        let scales_probe = format!("{}.0.{}.scales", prefix, weight_name);
-        let is_quantized = weights.contains_key(&scales_probe);
-
-        if is_quantized {
-            let mut expert_scales = Vec::with_capacity(num_experts);
-            let mut expert_biases = Vec::with_capacity(num_experts);
-
-            for expert_idx in 0..num_experts {
-                let w = get_weight_copy(
-                    weights,
-                    &format!("{}.{}.{}.weight", prefix, expert_idx, weight_name),
-                )?;
-                let s = get_weight_copy(
-                    weights,
-                    &format!("{}.{}.{}.scales", prefix, expert_idx, weight_name),
-                )?;
-                let b = get_weight_copy(
-                    weights,
-                    &format!("{}.{}.{}.biases", prefix, expert_idx, weight_name),
-                )?;
-                expert_weights.push(w);
-                expert_scales.push(s);
-                expert_biases.push(b);
-            }
-
-            // Stack along axis 0: [num_experts, out_features, in_features_packed]
-            let weight = mlxcel_core::utils::stack_arrays(&expert_weights, 0);
-            let scales = mlxcel_core::utils::stack_arrays(&expert_scales, 0);
-            let biases = mlxcel_core::utils::stack_arrays(&expert_biases, 0);
-
-            Ok(Self::Quantized {
-                weight,
-                scales,
-                biases,
-                group_size: args.group_size(),
-                bits: args.bits(),
-                num_experts,
-            })
-        } else {
-            for expert_idx in 0..num_experts {
-                let w = get_weight_copy(
-                    weights,
-                    &format!("{}.{}.{}.weight", prefix, expert_idx, weight_name),
-                )?;
-                expert_weights.push(w);
-            }
-
-            // Stack along axis 0: [num_experts, out_features, in_features]
-            let weight = mlxcel_core::utils::stack_arrays(&expert_weights, 0);
-            Ok(Self::Regular { weight })
-        }
     }
 }
 

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -392,6 +392,21 @@ impl SwitchGLU {
         }
         let dff = gw_shape[1];
         let din = gw_shape[2] * (32 / gate.bits);
+        // Large experts: gather_qmm already saturates the GPU, so the two-kernel
+        // fused path's all-cores advantage disappears and its extra dispatch +
+        // global-memory activation staging becomes a net loss. Measured on M1
+        // Ultra: wins for small experts (Dff 704..2560: +3.5% to +15.4%), loses
+        // for large ones (phi-3.5-moe Dff 6400: -5.9%, mixtral Dff 14336: -21%).
+        // Decline above the break-even so the caller falls back to gather_qmm.
+        // The break-even is hardware-dependent, so the bound is env-tunable.
+        let max_dff = std::env::var("MLXCEL_FUSED_MOE_MAX_DFF")
+            .ok()
+            .and_then(|s| s.parse::<i32>().ok())
+            .filter(|v| *v > 0)
+            .unwrap_or(4096);
+        if dff > max_dff {
+            return None;
+        }
         // 6-bit down packs 4 weights into 3 bytes; the kernel reads the row as
         // bytes and needs Dff divisible by 16 (whole uint32 columns).
         if down.bits == 6 && dff % 16 != 0 {

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -267,7 +267,13 @@ impl SwitchLinear {
 /// quantized/regular split the stacked loader applies. Experts are gathered
 /// contiguously from index 0 until the first gap.
 ///
-/// Used by: Qwen2Moe (Qwen1.5-MoE / Qwen2-MoE individual-expert checkpoints)
+/// The expert leaf name comes from the `{proj}` segment of the prefix, so a
+/// caller that passes overridden leaf names (e.g. Mixtral's `w1`/`w2`/`w3` via
+/// `SwitchGLU::from_weights_with_proj_names`) loads from the matching expert
+/// keys without any name baked in here.
+///
+/// Used by: Qwen2Moe (Qwen1.5-MoE / Qwen2-MoE individual-expert checkpoints),
+///          Mixtral (`block_sparse_moe.experts.{idx}.{w1,w2,w3}` checkpoints)
 fn stack_individual_experts(
     weights: &WeightMap,
     prefix: &str,
@@ -427,22 +433,49 @@ impl SwitchGLU {
         group_size: i32,
         bits: i32,
     ) -> Result<Self, String> {
+        Self::from_weights_with_proj_names(
+            weights,
+            prefix,
+            group_size,
+            bits,
+            ["gate_proj", "up_proj", "down_proj"],
+        )
+    }
+
+    /// Like [`SwitchGLU::from_weights`], but with overridable projection leaf
+    /// names so checkpoints that do not use the `gate_proj`/`up_proj`/`down_proj`
+    /// convention can still load through the shared loader. `proj_names` is
+    /// `[gate, up, down]`, naming the per-projection leaf under `prefix`
+    /// (pre-stacked `{prefix}.{leaf}.weight`) or under the per-expert layout
+    /// `{root}.experts.{idx}.{leaf}` when `prefix` ends in `.switch_mlp`.
+    ///
+    /// Mixtral stores its experts under the `w1`/`w2`/`w3` convention, mapping
+    /// gate=`w1`, up=`w3`, down=`w2`; it passes those leaf names here so the
+    /// shared code stays generic (no checkpoint-specific names baked in).
+    pub fn from_weights_with_proj_names(
+        weights: &WeightMap,
+        prefix: &str,
+        group_size: i32,
+        bits: i32,
+        proj_names: [&str; 3],
+    ) -> Result<Self, String> {
+        let [gate_leaf, up_leaf, down_leaf] = proj_names;
         Ok(Self {
             gate_proj: SwitchLinear::from_weights(
                 weights,
-                &format!("{}.gate_proj", prefix),
+                &format!("{}.{}", prefix, gate_leaf),
                 group_size,
                 bits,
             )?,
             up_proj: SwitchLinear::from_weights(
                 weights,
-                &format!("{}.up_proj", prefix),
+                &format!("{}.{}", prefix, up_leaf),
                 group_size,
                 bits,
             )?,
             down_proj: SwitchLinear::from_weights(
                 weights,
-                &format!("{}.down_proj", prefix),
+                &format!("{}.{}", prefix, down_leaf),
                 group_size,
                 bits,
             )?,
@@ -664,6 +697,74 @@ mod tests {
         );
         assert_eq!(parts.group_size, group);
         assert_eq!(parts.mode, "affine");
+    }
+
+    #[test]
+    fn switch_glu_loads_overridden_proj_leaf_names() {
+        // Mixtral stores experts under the w1/w2/w3 convention at
+        // `{root}.experts.{idx}.{w1,w2,w3}.{weight,scales,biases}`, with
+        // gate=w1, up=w3, down=w2. The shared loader must find them when the
+        // leaf names are overridden (the `.switch_mlp` virtual prefix keys the
+        // per-expert stacker to the `{root}.experts.{idx}` layout, identical to
+        // the Qwen2-MoE path).
+        let out = 4i32;
+        let group = 64i32;
+        let in_dim = 64i32; // a single quantization group
+        let packed_in = in_dim / 8; // 4-bit packs 8 weights per uint32 column
+        let num_groups = in_dim / group;
+        let root = "model.layers.0.block_sparse_moe";
+
+        let mut weights = WeightMap::new();
+        for e in 0..3 {
+            for leaf in ["w1", "w2", "w3"] {
+                weights.insert(
+                    format!("{root}.experts.{e}.{leaf}.weight"),
+                    mlxcel_core::from_slice_f32(
+                        &vec![0.0; (out * packed_in) as usize],
+                        &[out, packed_in],
+                    ),
+                );
+                weights.insert(
+                    format!("{root}.experts.{e}.{leaf}.scales"),
+                    mlxcel_core::from_slice_f32(
+                        &vec![1.0; (out * num_groups) as usize],
+                        &[out, num_groups],
+                    ),
+                );
+                weights.insert(
+                    format!("{root}.experts.{e}.{leaf}.biases"),
+                    mlxcel_core::from_slice_f32(
+                        &vec![0.0; (out * num_groups) as usize],
+                        &[out, num_groups],
+                    ),
+                );
+            }
+        }
+
+        let glu = SwitchGLU::from_weights_with_proj_names(
+            &weights,
+            &format!("{root}.switch_mlp"),
+            group,
+            4,
+            ["w1", "w3", "w2"], // gate=w1, up=w3, down=w2
+        )
+        .expect("overridden leaf names should load the per-expert experts");
+
+        for proj in [&glu.gate_proj, &glu.up_proj, &glu.down_proj] {
+            let parts = proj
+                .quantized_parts()
+                .expect("stacked per-expert weights should yield a quantized SwitchLinear");
+            assert_eq!(
+                mlxcel_core::array_shape(parts.weight),
+                vec![3, out, packed_in]
+            );
+            assert_eq!(
+                parts.bits, 4,
+                "bits inferred from packed weight/scales shapes"
+            );
+            assert_eq!(parts.group_size, group);
+            assert_eq!(parts.mode, "affine");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Group B migration for the fused decode-MoE kernel (#268 series, default-on since #282), chain 4/6 under epic #307 and sibling to #286 (qwen2_moe). mixtral's MoE experts move from its local `SwitchGLU`/`SwitchLinear` to the shared `crate::models::switch_layers::SwitchGLU`, and `SparseMoeBlock::forward` gains the single-token decode fused-kernel dispatch.

## What changed

- `src/models/switch_layers.rs`: add `SwitchGLU::from_weights_with_proj_names(weights, prefix, group_size, bits, [gate, up, down])`. The default `from_weights` now delegates to it with the standard `["gate_proj", "up_proj", "down_proj"]` names, so every existing shared caller (qwen2_moe, mistral4, dots1, kimi_linear, minimax, longcat) is byte-for-byte unchanged. The per-expert stacker already derives the expert leaf name from the projection segment of the prefix, so overriding the leaf names is all that is needed; no checkpoint-specific strings live in the shared loader. Doc comment on `stack_individual_experts` updated to note the override path; new unit test `switch_glu_loads_overridden_proj_leaf_names` exercises the `w1`/`w2`/`w3` path.
- `src/models/mixtral.rs`: remove the local `SwitchGLU`/`SwitchLinear` (nothing else referenced them), point `SparseMoeBlock.experts` at the shared `SwitchGLU`, and load via `from_weights_with_proj_names(.., "{prefix}.switch_mlp", .., ["w1", "w3", "w2"])` (gate=w1, up=w3, down=w2). `SparseMoeBlock::forward` now tries `forward_fused_kernel` for single-token decode when `fused_moe_enabled()`, falling back to `experts.forward` + `moe_weighted_sum` otherwise. mixtral uses softmax over the top-k logits with no shared expert and no renorm, so `scores` already carries the full combine weights; everything else in the forward path is unchanged.
- `docs/benchmark_results/fused-moe-decode-kernel-design.md`: move mixtral into the wired "Models covered" list and document the `w1`/`w2`/`w3` mapping and the overridable-leaf-name loader.

## Weight-loading parity

The old local loader read `block_sparse_moe.experts.{idx}.{w1,w2,w3}.{weight,scales,biases}` for idx ascending and stacked them along axis 0 with `utils::stack_arrays`, with `gate_proj=w1`, `up_proj=w3`, `down_proj=w2`. The shared per-expert stacker reads the same keys (`{root}.experts.{idx}.{leaf}` where the `.switch_mlp` virtual prefix resolves `root` to `block_sparse_moe`, identical to the qwen2_moe path), in the same ascending index order, and stacks along axis 0 with `stack_owned`. Both stackers reduce to the same `ffi::stack(&ptrs, 0)` call, so the resulting `[num_experts, out, in_packed]` tensors are identical. Bits: the local loader hard-set `args.bits()`; the shared loader infers per-tensor bits from `(packed_in * 32) / (num_groups * group_size)`, which for Mixtral-8x7B-4bit (group_size 64) is `(512*32)/(64*64) = 4` for w1/w3 and `(1792*32)/(224*64) = 4` for w2, matching `args.bits()`. mode is `affine` (default), biases are present, so `quantized_parts()` is `Some` and the fused kernel qualifies.

## Test plan

- [x] `cargo check --lib --tests --features metal,accelerate`
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings` (clean; dead-code from the removed local structs would have failed `-D warnings`)
- [x] `cargo fmt -- --check`
- [ ] Real-checkpoint validation pending the orchestrator on `models/mixtral-8x7b-4bit`: greedy temp-0 output coherent and byte-identical or within the documented f16 jitter class vs `MLXCEL_FUSED_MOE=0`, no NaN, no garbage; decode tok/s fused-on vs off recorded with no regression. A wrong w1/w2/w3 mapping or a bits/shape mismatch would surface as garbage decode here.

Closes #301
