### PR TITLE
perf(moe): wire phimoe to the fused decode-MoE kernel

### DIFF
--- a/docs/benchmark_results/fused-moe-decode-kernel-design.md
+++ b/docs/benchmark_results/fused-moe-decode-kernel-design.md
@@ -208,7 +208,7 @@ the expected numerical consequence of the fusion.
 
 ### Models covered
 
-The fused single-token decode dispatch is wired into eight model paths: qwen3_moe
+The fused single-token decode dispatch is wired into nine model paths: qwen3_moe
 (Qwen3 MoE), qwen3_next (qwen3.5/3.6), dots.llm1 (mixed 4/6-bit), gemma4 (GeGLU),
 qwen2_moe (qwen1.5-moe / Qwen2-MoE; migrated from its local `SwitchGLU` to the
 shared one, which gained a per-expert stacking loader for the `experts.{idx}`
@@ -218,10 +218,15 @@ overridable projection-leaf-name loader for the `w1`/`w2`/`w3` checkpoint
 convention, mapping gate=w1, up=w3, down=w2; Mixtral's expert intermediate is
 14336, above `MLXCEL_FUSED_MOE_MAX_DFF`, so the kernel declines and decode stays
 on `gather_qmm` (the migration removes duplication; the dispatch arms only if the
-bound is raised)), lfm2 (LFM2-MoE; sigmoid-routed,
-optional expert_bias and norm_topk_prob), and qwen3_vl_moe (Qwen3-VL MoE; imports
-`SwitchGLU` from qwen3_moe, SwiGLU activation, text-only decode path). Other MoE
-families reuse the shared `SwitchGLU` for the expert matmul but were not wired with
-the fused decode dispatch, so they stay on `gather_qmm` regardless of
-`MLXCEL_FUSED_MOE`: olmoe, minimax, and phimoe. nemotron-h's MoE runs through the
+bound is raised)), lfm2 (LFM2-MoE; sigmoid-routed, optional expert_bias and
+norm_topk_prob), qwen3_vl_moe (Qwen3-VL MoE; imports `SwitchGLU` from qwen3_moe,
+SwiGLU activation, text-only decode path), and phimoe (Phi-3.5-MoE; migrated from
+its local `SwitchGLU`/`SwitchLinear` to the shared ones; checkpoints pre-stacked
+under `block_sparse_moe.switch_mlp.{gate,up,down}_proj`; `sanitize_weights` still
+handles the unstacked `experts.{i}.w1/w2/w3` layout for community checkpoints; the
+expert intermediate is 6400, above `MLXCEL_FUSED_MOE_MAX_DFF`, so like mixtral the
+kernel declines and decode stays on `gather_qmm`). Other MoE families reuse the
+shared `SwitchGLU` for the expert matmul but were not wired with the fused decode
+dispatch, so they stay on `gather_qmm` regardless of `MLXCEL_FUSED_MOE`: olmoe and
+minimax. nemotron-h's MoE runs through the
 separate C++ `fused_moe_forward` and is wired behind `MLXCEL_FUSED_MOE_RELU2` only.

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -992,6 +992,10 @@ mod dots1_tests;
 mod lfm2_tests;
 
 #[cfg(test)]
+#[path = "phimoe_tests.rs"]
+mod phimoe_tests;
+
+#[cfg(test)]
 #[path = "falcon_h1_tests.rs"]
 mod falcon_h1_tests;
 

--- a/src/models/phimoe.rs
+++ b/src/models/phimoe.rs
@@ -130,198 +130,11 @@ impl ModelArgs {
     }
 }
 
-// SwitchLinear: Stacked expert weights for MoE.
-/// Stacked linear layers for MoE experts
-/// Weights shape: [num_experts, output_dim, input_dim_packed]
-pub enum SwitchLinear {
-    Quantized {
-        weight: UniquePtr<MlxArray>,
-        scales: UniquePtr<MlxArray>,
-        biases: UniquePtr<MlxArray>,
-        group_size: i32,
-        bits: i32,
-    },
-    Regular {
-        weight: UniquePtr<MlxArray>,
-    },
-}
-
-impl SwitchLinear {
-    /// Forward pass using gather_qmm for quantized or gather_mm for regular
-    /// x: [n_tokens, 1, 1, hidden] or [n_sorted, 1, hidden]
-    /// indices: [n_tokens, top_k] or [n_sorted] (flattened when sorted)
-    pub fn forward(
-        &self,
-        x: &MlxArray,
-        indices: &MlxArray,
-        sorted_indices: bool,
-    ) -> UniquePtr<MlxArray> {
-        match self {
-            Self::Quantized {
-                weight,
-                scales,
-                biases,
-                group_size,
-                bits,
-            } => unsafe {
-                mlxcel_core::gather_qmm(
-                    x,
-                    weight,
-                    scales,
-                    biases
-                        .as_ref()
-                        .map(|b| b as *const _)
-                        .unwrap_or(std::ptr::null()),
-                    std::ptr::null(), // lhs_indices
-                    indices as *const _,
-                    true, // transpose
-                    *group_size,
-                    *bits,
-                    sorted_indices,
-                    "affine",
-                )
-            },
-            Self::Regular { weight } => {
-                let wt = mlxcel_core::swap_axes(weight, -1, -2);
-                unsafe {
-                    mlxcel_core::gather_mm(
-                        x,
-                        &wt,
-                        std::ptr::null(),
-                        indices as *const _,
-                        sorted_indices,
-                    )
-                }
-            }
-        }
-    }
-}
-
-// SwitchGLU: GLU with SiLU activation and stacked expert weights.
-/// SwitchGLU: GLU with SiLU activation (SwiGLU) for PhiMoE — hidden_act=silu per model config
-pub struct SwitchGLU {
-    pub gate_proj: SwitchLinear,
-    pub up_proj: SwitchLinear,
-    pub down_proj: SwitchLinear,
-}
-
-impl SwitchGLU {
-    /// Forward pass with SiLU activation (SwiGLU — hidden_act=silu per model config)
-    /// x: [n_tokens, hidden]
-    /// indices: [n_tokens, top_k]
-    /// Returns: [n_tokens, top_k, hidden]
-    pub fn forward(&self, x: &MlxArray, indices: &MlxArray) -> UniquePtr<MlxArray> {
-        let indices_shape = mlxcel_core::array_shape(indices);
-        let n_tokens = indices_shape[0];
-        let top_k = indices_shape[1];
-
-        // Check if we should use sorted_indices optimization (>= 64 tokens)
-        let total_elements = n_tokens * top_k;
-        let do_sort = total_elements >= 64;
-
-        // Expand x for broadcasting: [n_tokens, hidden] -> [n_tokens, 1, 1, hidden]
-        let x_expanded = mlxcel_core::expand_dims(x, -2);
-        let x_expanded = mlxcel_core::expand_dims(&x_expanded, -3);
-
-        if do_sort {
-            // Sort tokens by expert for better memory access
-            let (sorted_x, sorted_idx, inv_order) = self.gather_sort(&x_expanded, indices);
-
-            // Apply projections with sorted_indices=true
-            let x_gate = self.gate_proj.forward(&sorted_x, &sorted_idx, true);
-            let x_up = self.up_proj.forward(&sorted_x, &sorted_idx, true);
-
-            // Fused SwiGLU activation: compiled_swiglu_activation(gate, up) == silu(gate) * up
-            // Used by: PhiMoE (sorted expert dispatch path) — hidden_act=silu per config
-            let activated = mlxcel_core::compiled_swiglu_activation(&x_gate, &x_up);
-
-            // Down projection
-            let output = self.down_proj.forward(&activated, &sorted_idx, true);
-
-            // Restore original order
-            self.scatter_unsort(&output, &inv_order, &indices_shape)
-        } else {
-            // Direct path without sorting
-            let x_gate = self.gate_proj.forward(&x_expanded, indices, false);
-            let x_up = self.up_proj.forward(&x_expanded, indices, false);
-
-            // Fused SwiGLU activation: compiled_swiglu_activation(gate, up) == silu(gate) * up
-            // Used by: PhiMoE (unsorted expert dispatch path) — hidden_act=silu per config
-            let activated = mlxcel_core::compiled_swiglu_activation(&x_gate, &x_up);
-
-            // Down projection
-            let output = self.down_proj.forward(&activated, indices, false);
-
-            // Squeeze: [n_tokens, top_k, 1, hidden] -> [n_tokens, top_k, hidden]
-            mlxcel_core::squeeze_axis(&output, -2)
-        }
-    }
-
-    /// Sort tokens by expert index for better memory access
-    fn gather_sort(
-        &self,
-        x: &MlxArray,
-        indices: &MlxArray,
-    ) -> (
-        UniquePtr<MlxArray>,
-        UniquePtr<MlxArray>,
-        UniquePtr<MlxArray>,
-    ) {
-        let indices_shape = mlxcel_core::array_shape(indices);
-        let top_k = indices_shape[indices_shape.len() - 1];
-
-        // Flatten indices: [n_tokens, top_k] -> [n_tokens * top_k]
-        let flat_indices = mlxcel_core::reshape(indices, &[-1]);
-
-        // Sort indices by expert
-        let order = mlxcel_core::argsort(&flat_indices, -1);
-        let inv_order = mlxcel_core::argsort(&order, -1);
-
-        // x is [n_tokens, 1, 1, hidden]
-        // Flatten: [n_tokens, 1, hidden]
-        let x_shape = mlxcel_core::array_shape(x);
-        let x_flat = mlxcel_core::reshape(x, &[x_shape[0], 1, x_shape[3]]);
-
-        // Divide order by top_k to get token indices
-        let top_k_arr = mlxcel_core::from_slice_i32(&[top_k], &[1]);
-        let token_indices = mlxcel_core::divide(&order, &top_k_arr);
-        let token_indices = mlxcel_core::astype(&token_indices, mlxcel_core::dtype::INT32);
-
-        // Take x rows in sorted order
-        let sorted_x = mlxcel_core::take(&x_flat, &token_indices, 0);
-
-        // Get sorted expert indices
-        let sorted_indices = mlxcel_core::take(&flat_indices, &order, 0);
-
-        (sorted_x, sorted_indices, inv_order)
-    }
-
-    /// Restore original order after sorted expert computation
-    fn scatter_unsort(
-        &self,
-        x: &MlxArray,
-        inv_order: &MlxArray,
-        orig_shape: &[i32],
-    ) -> UniquePtr<MlxArray> {
-        // x has shape [n_sorted, 1, hidden]
-        // Reorder by inv_order
-        let unsorted = mlxcel_core::take(x, inv_order, 0);
-
-        // Unflatten and squeeze
-        let x_shape = mlxcel_core::array_shape(&unsorted);
-        let n_tokens = orig_shape[0];
-        let top_k = orig_shape[1];
-
-        let reshaped = mlxcel_core::reshape(&unsorted, &[n_tokens, top_k, x_shape[1], x_shape[2]]);
-        mlxcel_core::squeeze_axis(&reshaped, 2)
-    }
-}
-
 // Sparse MoE Block.
 /// PhiMoE sparse mixture of experts layer
 pub struct SparseMoeBlock {
     pub router: UnifiedLinear, // Router/gate network
-    pub experts: SwitchGLU,
+    pub experts: crate::models::switch_layers::SwitchGLU,
     pub num_experts_per_tok: usize,
 }
 
@@ -357,14 +170,29 @@ impl SparseMoeBlock {
         let topk_logits = mlxcel_core::take_along_axis(&logits, &topk_indices, -1);
         let scores = mlxcel_core::softmax(&topk_logits, -1);
 
-        // Apply experts - returns [n_tokens, k, hidden]
-        let expert_out = self.experts.forward(&x_flat, &topk_indices);
-
-        let result = crate::models::switch_layers::moe_weighted_sum(
-            &expert_out,
-            &scores,
-            mlxcel_core::array_dtype(&x_flat),
-        );
+        // Apply experts with optional fused single-token decode dispatch.
+        let result = {
+            let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
+                && crate::models::switch_layers::fused_moe_enabled()
+            {
+                self.experts
+                    .forward_fused_kernel(&x_flat, &topk_indices, &scores)
+                    .map(|out| mlxcel_core::reshape(&out, &[1, hidden_dim]))
+            } else {
+                None
+            };
+            match fused {
+                Some(out) => out,
+                None => {
+                    let expert_out = self.experts.forward(&x_flat, &topk_indices);
+                    crate::models::switch_layers::moe_weighted_sum(
+                        &expert_out,
+                        &scores,
+                        mlxcel_core::array_dtype(&x_flat),
+                    )
+                }
+            }
+        };
 
         // Reshape back to original shape
         if orig_shape.len() > 2 {
@@ -732,51 +560,18 @@ impl SparseMoeBlock {
             args.bits(),
         )?;
 
-        let experts = SwitchGLU::from_weights(weights, args, &format!("{}.switch_mlp", prefix))?;
+        let experts = crate::models::switch_layers::SwitchGLU::from_weights(
+            weights,
+            &format!("{}.switch_mlp", prefix),
+            args.group_size(),
+            args.bits(),
+        )?;
 
         Ok(Self {
             router,
             experts,
             num_experts_per_tok: args.num_experts_per_tok,
         })
-    }
-}
-
-impl SwitchGLU {
-    pub fn from_weights(
-        weights: &WeightMap,
-        args: &ModelArgs,
-        prefix: &str,
-    ) -> Result<Self, String> {
-        Ok(Self {
-            gate_proj: SwitchLinear::from_weights(weights, args, &format!("{}.gate_proj", prefix))?,
-            up_proj: SwitchLinear::from_weights(weights, args, &format!("{}.up_proj", prefix))?,
-            down_proj: SwitchLinear::from_weights(weights, args, &format!("{}.down_proj", prefix))?,
-        })
-    }
-}
-
-impl SwitchLinear {
-    pub fn from_weights(
-        weights: &WeightMap,
-        args: &ModelArgs,
-        prefix: &str,
-    ) -> Result<Self, String> {
-        let weight = get_weight_copy(weights, &format!("{}.weight", prefix))?;
-        let scales_key = format!("{}.scales", prefix);
-        if weights.contains_key(&scales_key) {
-            let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());
-            let biases = get_weight_copy(weights, &format!("{}.biases", prefix))?;
-            Ok(Self::Quantized {
-                weight,
-                scales,
-                biases,
-                group_size: args.group_size(),
-                bits: args.bits(),
-            })
-        } else {
-            Ok(Self::Regular { weight })
-        }
     }
 }
 

--- a/src/models/phimoe_tests.rs
+++ b/src/models/phimoe_tests.rs
@@ -1,0 +1,98 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for PhiMoE config parsing.
+//!
+//! These cover the checkpoint-free surface: config deserialization and the
+//! config-derived helper methods. Numeric correctness of the MoE forward pass
+//! is validated end-to-end against a real `mlx-community` checkpoint and is
+//! not exercised here (no Metal device is assumed in unit tests).
+
+use super::phimoe::ModelArgs;
+
+/// Trimmed config matching the `phi-3.5-moe-instruct` HuggingFace checkpoint
+/// at `mlx-community/Phi-3.5-MoE-instruct-4bit`.
+const PHI35_MOE_4BIT_CONFIG: &str = r#"{
+    "model_type": "phimoe",
+    "vocab_size": 32064,
+    "hidden_size": 4096,
+    "intermediate_size": 6400,
+    "num_hidden_layers": 32,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "num_local_experts": 16,
+    "num_experts_per_tok": 2,
+    "layer_norm_eps": 1e-5,
+    "rope_theta": 10000.0,
+    "quantization": { "group_size": 64, "bits": 4 }
+}"#;
+
+/// Unquantized (bf16) config to confirm the quantization defaults.
+const PHI35_MOE_BF16_CONFIG: &str = r#"{
+    "model_type": "phimoe",
+    "vocab_size": 32064,
+    "hidden_size": 4096,
+    "intermediate_size": 6400,
+    "num_hidden_layers": 32,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "num_local_experts": 16,
+    "num_experts_per_tok": 2,
+    "layer_norm_eps": 1e-5,
+    "rope_theta": 10000.0
+}"#;
+
+#[test]
+fn phimoe_4bit_config_parses() {
+    let args: ModelArgs =
+        serde_json::from_str(PHI35_MOE_4BIT_CONFIG).expect("parse 4-bit phimoe config");
+    assert_eq!(args.model_type, "phimoe");
+    assert_eq!(args.vocab_size, 32064);
+    assert_eq!(args.hidden_size, 4096);
+    assert_eq!(args.intermediate_size, 6400);
+    assert_eq!(args.num_hidden_layers, 32);
+    assert_eq!(args.num_attention_heads, 32);
+    assert_eq!(args.num_key_value_heads, 8);
+    assert_eq!(args.num_local_experts, 16);
+    assert_eq!(args.num_experts_per_tok, 2);
+    assert_eq!(args.layer_norm_eps, 1e-5);
+    assert_eq!(args.rope_theta, 10000.0);
+    assert_eq!(args.group_size(), 64);
+    assert_eq!(args.bits(), 4);
+}
+
+#[test]
+fn phimoe_head_dim_derives_correctly() {
+    let args: ModelArgs =
+        serde_json::from_str(PHI35_MOE_4BIT_CONFIG).expect("parse 4-bit phimoe config");
+    // 4096 hidden / 32 attention heads = 128 head_dim
+    assert_eq!(args.head_dim(), 128);
+}
+
+#[test]
+fn phimoe_num_kv_heads_accessor() {
+    let args: ModelArgs =
+        serde_json::from_str(PHI35_MOE_4BIT_CONFIG).expect("parse 4-bit phimoe config");
+    assert_eq!(args.num_kv_heads(), 8);
+}
+
+#[test]
+fn phimoe_unquantized_config_uses_quantization_defaults() {
+    let args: ModelArgs =
+        serde_json::from_str(PHI35_MOE_BF16_CONFIG).expect("parse bf16 phimoe config");
+    assert!(args.quantization.is_none());
+    // Defaults: group_size=64, bits=4
+    assert_eq!(args.group_size(), 64);
+    assert_eq!(args.bits(), 4);
+}


### PR DESCRIPTION
## Summary

- Removes PhiMoE's local `SwitchLinear` / `SwitchGLU` (plus `gather_sort` / `scatter_unsort` helpers) and retypes `SparseMoeBlock.experts` to the shared `crate::models::switch_layers::SwitchGLU`.
- Wires the single-token fused decode dispatch in `SparseMoeBlock::forward`, matching the pattern used by qwen3_moe, gemma4, and lfm2.
- Keeps `sanitize_weights` intact so unstacked `experts.{i}.w1/w2/w3` community checkpoints still stack correctly.

## What changed

- `src/models/phimoe.rs`: removed ~190 lines of local `SwitchLinear` / `SwitchGLU`; retypes `experts` field; updates `SparseMoeBlock::from_weights` to call shared `SwitchGLU::from_weights(weights, prefix+".switch_mlp", args.group_size(), args.bits())`; adds fused dispatch block in `SparseMoeBlock::forward`.
- `src/models/phimoe_tests.rs`: new file with four config-parsing tests (4-bit checkpoint, head_dim, num_kv_heads, unquantized defaults).
- `src/models/mod.rs`: registers `phimoe_tests`.
- `docs/benchmark_results/fused-moe-decode-kernel-design.md`: moves phimoe to the wired models list; count seven -> eight.

## Weight-loading parity note

Pre-stacked checkpoints (`mlx-community/Phi-3.5-MoE-instruct-4bit`) have weights under `block_sparse_moe.switch_mlp.{gate,up,down}_proj.{weight,scales,biases}`. The shared `SwitchGLU::from_weights` reads exactly those keys when called with prefix `{layer}.block_sparse_moe.switch_mlp`, so loading is identical to the old local implementation. The `sanitize_weights` stacking path for unstacked community checkpoints is untouched.

## Test plan

- [x] `cargo check --lib --tests --features metal,accelerate` passes
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings` passes (zero warnings)
- [ ] Real-checkpoint decode validation against `mlx-community/Phi-3.5-MoE-instruct-4bit` pending orchestrator (part of epic #307)

Closes #303
