### PR TITLE
fix(olmoe): apply q_norm/k_norm before the head reshape

### DIFF
--- a/src/models/olmoe.rs
+++ b/src/models/olmoe.rs
@@ -384,14 +384,17 @@ impl Attention {
         let k = self.k_proj.forward(x);
         let v = self.v_proj.forward(x);
 
+        // Apply Q/K normalization on the full projection BEFORE the head reshape.
+        // OLMoE normalizes over the whole num_heads*head_dim projection (the norm
+        // weight is hidden-sized), matching the upstream order; normalizing after
+        // the reshape would size-mismatch the weight against head_dim.
+        let q = self.q_norm.forward(&q);
+        let k = self.k_norm.forward(&k);
+
         // Reshape to [batch, seq_len, n_heads, head_dim]
         let q = mlxcel_core::reshape(&q, &[b, l, self.num_heads, self.head_dim]);
         let k = mlxcel_core::reshape(&k, &[b, l, self.num_kv_heads, self.head_dim]);
         let v = mlxcel_core::reshape(&v, &[b, l, self.num_kv_heads, self.head_dim]);
-
-        // Apply Q/K normalization BEFORE transpose
-        let q = self.q_norm.forward(&q);
-        let k = self.k_norm.forward(&k);
 
         // Transpose to [batch, n_heads, seq_len, head_dim]
         let mut q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);


### PR DESCRIPTION
OLMoE normalizes Q/K over the full num_heads*head_dim projection (the q_norm/k_norm weights are hidden-sized, 2048 for OLMoE-1B-7B), matching the upstream order where the RMSNorm runs on the q_proj/k_proj output before the head split. The code applied the norm after reshaping to `[batch, seq_len, heads, head_dim]`, so `rms_norm` received a 2048-element weight against a head_dim-wide (128) last dimension and aborted with `std::invalid_argument`; OLMoE-1B-7B was non-functional as a result. This moves q_norm/k_norm ahead of the head reshape. Validated on `mlx-community/OLMoE-1B-7B-0125-Instruct-4bit`: loads and generates coherent greedy temp-0 output (e.g. "What is the capital of France? Paris, France.") with no crash. The change is confined to olmoe.rs attention; no other model is affected. Found while validating epic #307 (#302 wires olmoe to the fused decode-MoE kernel, which could not be runtime-validated until this crash was fixed). Closes #316