### PR TITLE
perf(moe): implement the fused decode-MoE kernel on CUDA

### DIFF
--- a/docs/benchmark_results/fused-moe-decode-kernel-design.md
+++ b/docs/benchmark_results/fused-moe-decode-kernel-design.md
@@ -146,11 +146,19 @@ runs it efficiently.
    greedy decode output is byte-identical or within the f16 jitter class with no
    NaN, and decode is parity-to-faster (no regression). Per-layer kernel
    execution on M5 was confirmed with a dispatch trace. See the M5 results below.
+6. **Done** (#319): ported the kernel to the CUDA backend via
+   `mx.fast.cuda_kernel` (the `simd_sum` reduction becomes `__shfl_down_sync`,
+   precise `expf` for greedy parity), runtime-selected by `metal::is_available()`.
+   Before this the kernel was Metal-only and aborted on CUDA (`[metal_kernel] No
+   Metal back-end`) for the small-expert MoE models the dispatch selected; they
+   now run on the fused path, byte-identical and faster (qwen3-30b-a3b +55% on
+   GB10). fused stays default-on for both backends. See the GB10 results below.
 
 ## Usage and flags
 
-The fused decode-MoE path is **on by default** as of #282 and applies only to
-single-token decode with affine 4/8-bit gate/up and 4/6/8-bit down. Anything
+The fused decode-MoE path is **on by default** as of #282 (Metal) and #319
+(CUDA, via `mx.fast.cuda_kernel`), and applies only to single-token decode with
+affine 4/8-bit gate/up and 4/6/8-bit down. Anything
 else (prefill, non-affine, unsupported bit widths, mismatched gate/up bits)
 falls back to the proven `gather_qmm` / `SwitchGLU` path automatically. Set
 `MLXCEL_FUSED_MOE=0` to force that fallback everywhere.
@@ -160,7 +168,7 @@ falls back to the proven `gather_qmm` / `SwitchGLU` path automatically. Set
 | `MLXCEL_FUSED_MOE` | unset (on) | On by default. Set to `0` (also `false`/`off`/`no`, case-insensitive) to force the proven `gather_qmm` / `SwitchGLU` path; any other value, or leaving it unset, keeps the kernel on. |
 | `MLXCEL_FUSED_MOE_SGY` | 8 | Simdgroups per threadgroup (one output row each). Tune per hardware. |
 | `MLXCEL_FUSED_MOE_RELU2` | unset (off) | Enable the squared-ReLU (fc1/relu²/fc2) fused path used by nemotron-class experts. Correct but measured performance-neutral on nemotron-h; kept for a future MoE-dominated squared-ReLU model. |
-| `MLXCEL_FUSED_MOE_MAX_DFF` | 4096 | Expert-intermediate (Dff) upper bound. Above it, `forward_fused_kernel` declines and the caller falls back to `gather_qmm`. The fused path wins only while `gather_qmm` underutilizes the GPU (small experts); for large experts `gather_qmm` already saturates and the extra dispatch plus global-memory activation staging is a net loss. M1 Ultra measurements: Dff 704..2560 gain +3.5% to +15.4%, Dff 6400 (phi-3.5-moe) loses 5.9%, Dff 14336 (mixtral) loses 21%. The break-even is hardware-dependent, so the bound is tunable. |
+| `MLXCEL_FUSED_MOE_MAX_DFF` | 4096 | Expert-intermediate (Dff) upper bound. Above it, `forward_fused_kernel` declines and the caller falls back to `gather_qmm`. The fused path wins only while `gather_qmm` underutilizes the GPU (small experts); for large experts `gather_qmm` already saturates and the extra dispatch plus global-memory activation staging is a net loss. M1 Ultra measurements: Dff 704..2560 gain +3.5% to +15.4%, Dff 6400 (phi-3.5-moe) loses 5.9%, Dff 14336 (mixtral) loses 21%. On CUDA (GB10) the crossover is much higher, ~13-14k (Dff 768 +60%, 1792 +13%, 6400 +2%, 14336 -2%), so 4096 is conservative there but kept as the shared default. The break-even is hardware-dependent, so the bound is tunable. |
 
 ### Measured decode gains (M1 Ultra, `MLXCEL_FUSED_MOE=1`)
 
@@ -197,6 +205,43 @@ already accelerates the baseline expert matmul, leaving less inter-kernel idle f
 the fusion to recover. Per-layer kernel execution on M5 was confirmed with a
 dispatch trace (30 / 40 / 48 / 61 dispatches per decode token for gemma4 /
 qwen3.5 / qwen3-30b / dots.llm1).
+
+### Measured decode gains (GB10 / CUDA, `MLXCEL_FUSED_MOE=1`, #319)
+
+The kernel was ported to the CUDA backend via `mx.fast.cuda_kernel` (#319), the
+CUDA analogue of `metal_kernel`: the same two dispatches, with the `simd_sum`
+warp reduction expressed as `__shfl_down_sync` and a precise `expf` in the
+SwiGLU. `run_fused_moe_two_kernel` picks the cuda_kernel port when
+`metal::is_available()` is false. Before #319 the kernel was Metal-only, so the
+selected small-expert MoE models aborted on CUDA with `[metal_kernel] No Metal
+back-end`; they now run on the fused path. Greedy output is byte-identical to
+`gather_qmm` on qwen3-30b-a3b. Measured on GB10 (DGX Spark, CUDA 13.0) against
+the `gather_qmm` baseline (`MLXCEL_FUSED_MOE=0`):
+
+| Model | activation | bits | decode tok/s | gain | greedy parity |
+|-------|-----------|------|-------------:|-----:|---------------|
+| qwen3-30b-a3b | SwiGLU | 4 | 58.2 → 90.3 | **+55%** | byte-identical |
+| qwen3.5-35b-a3b | SwiGLU | 4 | 45.8 → 64.7 | +41% | within f16 jitter class |
+| lfm2-8b-a1b | SwiGLU | 4 | 140.9 → 158.2 | +13% | byte-identical |
+| qwen1.5-moe-a2.7b | SwiGLU | 4 | 113.0 → 124.7 | +10% | byte-identical |
+
+The CUDA gains are larger than Apple Silicon's: at batch=1 `gather_qmm` leaves
+more of the GB10 GPU idle, so the all-warps fused path (one warp per output row)
+recovers more. The break-even with expert size is also far higher than Metal's.
+Forcing the fused path past the cap (`MLXCEL_FUSED_MOE_MAX_DFF=20000`):
+
+| Dff | model | fused vs gather_qmm |
+|----:|-------|--------------------:|
+| 768 | qwen3-30b-a3b | +60% |
+| 1792 | lfm2-8b-a1b | +13% |
+| 6400 | phi-3.5-moe | +2% |
+| 14336 | mixtral | −2% |
+
+The CUDA crossover is ~13–14k (vs Metal's ~4096, where phi-3.5-moe already loses
+5.9%). The 4096 cap is therefore conservative on CUDA but kept as the shared
+default: the meaningful wins are all below it, and the 4096–14k range gains at
+most ~2% (phi-3.5-moe) while mixtral (14336) slightly prefers `gather_qmm`. CUDA
+users with mid-size experts can raise `MLXCEL_FUSED_MOE_MAX_DFF`.
 
 **Parity caveat.** The kernel accumulates the GEMV in f32 with a different
 reduction order than `gather_qmm`'s tiling, so it is within the f16 jitter

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -169,8 +169,9 @@ recommended as normal deployment settings.
 | `MLXCEL_DISABLE_SINGLE_QUERY_MASKLESS` | truthy disables | maskless path on | Disables the single-query maskless attention path. |
 | `MLXCEL_EXPERIMENTAL_BOOL_CAUSAL_MASK` | truthy enables | off | Enables an experimental boolean causal-mask path. |
 | `MLXCEL_PIPELINE_GRANULARITY` | `off`, `layer`, `block:N` | `off` | Inserts layer-boundary async-eval hints for pipeline experiments. |
-| `MLXCEL_FUSED_MOE` | `0`/`false`/`off`/`no` disable; any other value or unset enables | on | Fused single-token decode-MoE kernel (#268), on by default since #282 (validated on M1 Ultra and M5). Set to `0` to force the proven `gather_qmm`/`SwitchGLU` path. Active for qwen3_moe, qwen3_next, dots.llm1, and gemma4 decode. |
-| `MLXCEL_FUSED_MOE_SGY` | `1`-`32` | `8` | Simdgroups per threadgroup for the fused decode-MoE kernel; tune per hardware. |
+| `MLXCEL_FUSED_MOE` | `0`/`false`/`off`/`no` disable; any other value or unset enables | on | Fused single-token decode-MoE kernel (#268), on by default since #282 (Metal) and #319 (CUDA, via `mx.fast.cuda_kernel`); validated on M1 Ultra, M5, and GB10. Set to `0` to force the proven `gather_qmm`/`SwitchGLU` path. Active for qwen3_moe, qwen3_next, dots.llm1, gemma4, qwen2_moe, mixtral, phimoe, lfm2, qwen3_vl_moe, and olmoe decode. |
+| `MLXCEL_FUSED_MOE_SGY` | `1`-`32` | `8` | Simdgroups (Metal) / warps-per-block (CUDA) per threadgroup for the fused decode-MoE kernel; tune per hardware. |
+| `MLXCEL_FUSED_MOE_MAX_DFF` | positive int | `4096` | Expert-intermediate (Dff) upper bound for the fused path; above it the caller falls back to `gather_qmm`. The fused path wins only while `gather_qmm` underutilizes the GPU (small experts). The break-even is hardware-dependent: ~4096 on M1 Ultra, ~13-14k on GB10/CUDA. 4096 is the conservative shared default; raise it on CUDA for mid-size experts. |
 | `MLXCEL_FUSED_MOE_RELU2` | presence enables | off | Enables the squared-ReLU fused MoE path for nemotron-class experts; performance-neutral on nemotron-h, kept for a future MoE-dominated squared-ReLU model. |
 
 ## Block-diffusion diagnostic variables

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_kernels.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_kernels.cpp
@@ -1115,6 +1115,171 @@ namespace {
         return holder;
     }
 
+    // ---- CUDA ports of the two fused decode-MoE kernels (#268 step 2b). ----
+    // The Metal sources above are mx.fast.metal_kernel, which throws on the CUDA
+    // backend ("[metal_kernel] No Metal back-end"). These are the same
+    // computation in CUDA C++ for mx.fast.cuda_kernel: one warp (32 lanes,
+    // threadIdx.x) owns each output row (grid.y), striding the contraction dim
+    // and reduced with __shfl_down_sync instead of simd_sum. grid.z selects the
+    // expert slot. MLX injects the template args (T, K, Din, Dff, bits,
+    // group_size, act) as constexpr/using, and wraps these bodies as a
+    // __global__ with the named buffers as parameters, mirroring the Metal path.
+    // Selected at runtime by metal::is_available() in run_fused_moe_two_kernel.
+    static const char* MOE_GATEUP_CUDA_SOURCE = R"(
+        uint32_t lane  = threadIdx.x;                          // 0..31 (one warp)
+        uint32_t f     = blockIdx.y * blockDim.y + threadIdx.y; // output row 0..Dff-1
+        uint32_t eslot = blockIdx.z;                           // 0..K-1
+        if (f >= (uint32_t)Dff) return;                        // warp-uniform
+        uint32_t e = indices[eslot];
+
+        constexpr uint32_t vpw   = 32u / bits;
+        constexpr uint32_t wmask = (1u << bits) - 1u;
+        constexpr uint32_t Din_p = Din / vpw;
+        constexpr uint32_t G     = Din / group_size;
+
+        uint32_t row = e * Dff + f;
+        const uint32_t* gwr = gate_w + row * Din_p;
+        const T*        gsr = gate_s + row * G;
+        const T*        gbr = gate_b + row * G;
+        const uint32_t* uwr = up_w   + row * Din_p;
+        const T*        usr = up_s   + row * G;
+        const T*        ubr = up_b   + row * G;
+        float g = 0.0f, u = 0.0f;
+        for (uint32_t p = lane; p < Din_p; p += 32u) {
+            uint32_t base = p * vpw;
+            uint32_t grp  = base / group_size;
+            float gs = (float)gsr[grp], gb = (float)gbr[grp];
+            float us = (float)usr[grp], ub = (float)ubr[grp];
+            uint32_t gpk = gwr[p];
+            uint32_t upk = uwr[p];
+            for (uint32_t j = 0; j < vpw; ++j) {
+                float xv = (float)x[base + j];
+                g += xv * ((float)((gpk >> (j * bits)) & wmask) * gs + gb);
+                u += xv * ((float)((upk >> (j * bits)) & wmask) * us + ub);
+            }
+        }
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) {
+            g += __shfl_down_sync(0xffffffffu, g, o);
+            u += __shfl_down_sync(0xffffffffu, u, o);
+        }
+        if (lane == 0u) {
+            if (act == 1) {
+                // GeGLU (gelu tanh approx) * up (gemma4 experts).
+                float g3 = g * g * g;
+                float inner = 0.7978845608028654f * (g + 0.044715f * g3);
+                float gelu = 0.5f * g * (1.0f + tanhf(inner));
+                act_g[eslot * Dff + f] = gelu * u;
+            } else {
+                // SwiGLU (silu) * up. Precise expf (not __expf) to match the
+                // gather_qmm silu and hold greedy parity; it runs once per row
+                // on lane 0, so the cost is negligible against the GEMV.
+                act_g[eslot * Dff + f] = (g / (1.0f + expf(-g))) * u;
+            }
+        }
+    )";
+
+    static const char* MOE_DOWN_CUDA_SOURCE = R"(
+        uint32_t lane  = threadIdx.x;                          // 0..31 (one warp)
+        uint32_t h     = blockIdx.y * blockDim.y + threadIdx.y; // output row 0..Din-1
+        uint32_t eslot = blockIdx.z;                           // 0..K-1
+        if (h >= (uint32_t)Din) return;                        // warp-uniform
+        uint32_t e = indices[eslot];
+
+        constexpr uint32_t Gd = Dff / group_size;
+        uint32_t row = e * Din + h;
+        const T*     dsr = down_s + row * Gd;
+        const T*     dbr = down_b + row * Gd;
+        const float* a   = act_g  + eslot * Dff;
+        float d = 0.0f;
+
+        if (bits == 6) {
+            // 6-bit: MLX packs 4 weights into 3 bytes; read the row as bytes.
+            // Layout matches quantized.h qdot: v0=b0&0x3f,
+            // v1=(b0>>6)|((b1&0x0f)<<2), v2=(b1>>4)|((b2&0x03)<<4), v3=b2>>2.
+            constexpr uint32_t packs   = Dff / 4u;
+            constexpr uint32_t row_u32 = Dff * 3u / 16u;
+            const uint8_t* wb = reinterpret_cast<const uint8_t*>(down_w + row * row_u32);
+            for (uint32_t p = lane; p < packs; p += 32u) {
+                uint32_t base = p * 4u;
+                uint32_t grp  = base / group_size;
+                float ds = (float)dsr[grp], db = (float)dbr[grp];
+                uint32_t b0 = wb[p * 3u], b1 = wb[p * 3u + 1u], b2 = wb[p * 3u + 2u];
+                uint32_t v0 = b0 & 0x3fu;
+                uint32_t v1 = (b0 >> 6) | ((b1 & 0x0fu) << 2);
+                uint32_t v2 = (b1 >> 4) | ((b2 & 0x03u) << 4);
+                uint32_t v3 = (b2 >> 2);
+                d += a[base + 0u] * ((float)v0 * ds + db);
+                d += a[base + 1u] * ((float)v1 * ds + db);
+                d += a[base + 2u] * ((float)v2 * ds + db);
+                d += a[base + 3u] * ((float)v3 * ds + db);
+            }
+        } else {
+            // Power-of-2 bits (4/8): vpw weights per 32-bit pack.
+            constexpr uint32_t vpw   = 32u / bits;
+            constexpr uint32_t wmask = (1u << bits) - 1u;
+            constexpr uint32_t Dff_p = Dff / vpw;
+            const uint32_t* dwr = down_w + row * Dff_p;
+            for (uint32_t p = lane; p < Dff_p; p += 32u) {
+                uint32_t base = p * vpw;
+                uint32_t grp  = base / group_size;
+                float ds = (float)dsr[grp], db = (float)dbr[grp];
+                uint32_t dpk = dwr[p];
+                for (uint32_t j = 0; j < vpw; ++j) {
+                    d += a[base + j] * ((float)((dpk >> (j * bits)) & wmask) * ds + db);
+                }
+            }
+        }
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) d += __shfl_down_sync(0xffffffffu, d, o);
+        if (lane == 0u) {
+            out[eslot * Din + h] = (T)((float)scores[eslot] * d);
+        }
+    )";
+
+    struct MoeGateUpKernelHolderCuda {
+        std::optional<mlx::core::fast::CustomKernelFunction> kernel;
+        bool initialized = false;
+        mlx::core::fast::CustomKernelFunction& get() {
+            if (!initialized) {
+                kernel = mlx::core::fast::cuda_kernel(
+                    "moe_gateup_kernel_cu",
+                    {"x", "indices", "gate_w", "gate_s", "gate_b",
+                     "up_w", "up_s", "up_b"},
+                    {"act_g"},
+                    MOE_GATEUP_CUDA_SOURCE
+                );
+                initialized = true;
+            }
+            return *kernel;
+        }
+    };
+    static MoeGateUpKernelHolderCuda& get_moe_gateup_kernel_cuda() {
+        static MoeGateUpKernelHolderCuda holder;
+        return holder;
+    }
+
+    struct MoeDownKernelHolderCuda {
+        std::optional<mlx::core::fast::CustomKernelFunction> kernel;
+        bool initialized = false;
+        mlx::core::fast::CustomKernelFunction& get() {
+            if (!initialized) {
+                kernel = mlx::core::fast::cuda_kernel(
+                    "moe_down_kernel_cu",
+                    {"indices", "down_w", "down_s", "down_b", "act_g", "scores"},
+                    {"out"},
+                    MOE_DOWN_CUDA_SOURCE
+                );
+                initialized = true;
+            }
+            return *kernel;
+        }
+    };
+    static MoeDownKernelHolderCuda& get_moe_down_kernel_cuda() {
+        static MoeDownKernelHolderCuda holder;
+        return holder;
+    }
+
     // fc1 + relu² -> act_g[K, Dff] for the squared-ReLU MoE (nemotron-h: the
     // experts are fc1 -> relu² -> fc2, not SwiGLU). One simdgroup per output
     // row, simd_sum over the contraction dim; relu² = square(max(x, 0)) to
@@ -1222,8 +1387,13 @@ std::unique_ptr<MlxArray> run_fused_moe_two_kernel(
         {"bits", d_bits}, {"group_size", group_size},
     };
 
+    // mx.fast.metal_kernel throws on CUDA ("No Metal back-end"), so dispatch the
+    // cuda_kernel port there. metal::is_available() is false on a CUDA-only build.
+    const bool use_cuda = !mlx::core::metal::is_available();
+
     // A) gate/up + activation -> act_g[K, Dff] (f32 for the down GEMV).
-    auto& kA = get_moe_gateup_kernel().get();
+    auto& kA = use_cuda ? get_moe_gateup_kernel_cuda().get()
+                        : get_moe_gateup_kernel().get();
     std::vector<array> inA = {
         astype(x.inner, T), astype(indices.inner, uint32),
         gate_w.inner, astype(gate_s.inner, T), astype(gate_b.inner, T),
@@ -1237,7 +1407,8 @@ std::unique_ptr<MlxArray> run_fused_moe_two_kernel(
     );
 
     // B) down * score -> partial[K, Din]; summed over K into [Din].
-    auto& kB = get_moe_down_kernel().get();
+    auto& kB = use_cuda ? get_moe_down_kernel_cuda().get()
+                        : get_moe_down_kernel().get();
     std::vector<array> inB = {
         astype(indices.inner, uint32),
         down_w.inner, astype(down_s.inner, T), astype(down_b.inner, T),


### PR DESCRIPTION
## Summary

The fused single-token decode-MoE kernel (#268) was Metal-only (`mx.fast.metal_kernel`), so on the **CUDA backend** it threw `[metal_kernel] No Metal back-end` and aborted for every small-expert MoE the dispatch selected (qwen2_moe, qwen3_moe, lfm2, qwen3_vl_moe). Larger experts fell through the `dff > MLXCEL_FUSED_MOE_MAX_DFF` break-even to `gather_qmm` and survived, so the failure tracked expert size, not architecture.

This PR ports the kernel to CUDA instead of disabling it, so the affected models run **faster** on CUDA rather than merely working.

## What changed

Port both halves to `mx.fast.cuda_kernel` (the CUDA analogue of `metal_kernel`):
- Kernel A: gate/up GEMV + SwiGLU/GeGLU → `act_g[K, Dff]`.
- Kernel B: down GEMV × score → summed over K.
- One warp owns each output row; `simd_sum` becomes a `__shfl_down_sync` warp reduction; the quantized-affine dequant (4/8-bit gate/up, 4/6/8-bit down) is unchanged.
- `run_fused_moe_two_kernel` selects the cuda_kernel port when `metal::is_available()` is false. `no_cuda.cpp` / `no_metal.cpp` stub the unused side, so both link on either backend.
- Precise `expf` in the SwiGLU holds greedy parity.

Only `src/lib/mlxcel-core/cpp/mlx_cxx_kernels.cpp` changes; `fused_moe_enabled` stays default-on for both backends.

## Validation (GB10 / DGX Spark, CUDA 13.0)

Greedy **byte-identical** to the `gather_qmm` path on qwen3-30b-a3b.

| Model | gather_qmm | fused (CUDA) | speedup |
|---|---|---|---|
| qwen3-moe-4bit | 58.15 | 90.34 | 1.55x |
| qwen3.5-35b-a3b-4bit | 45.84 | 64.69 | 1.41x |
| lfm2-8b-a1b-4bit | 140.91 | 158.22 | 1.13x |
| qwen1.5-moe-a2.7b-4bit | 113.03 | 124.73 | 1.10x |

The previously-crashing MoE models now run at these fused rates by default (no env var).

Supersedes the earlier CUDA fused-off workaround. Relevant to the #307 fused-MoE wiring epic: the wired families now work on CUDA.

Closes #313
