### PR TITLE
docs(bench): mark glm-5/glm-5.1 on GB10 as not-tested, not failed

### DIFF
--- a/docs/benchmark_results/model_tests.md
+++ b/docs/benchmark_results/model_tests.md
@@ -84,7 +84,7 @@ For Qwen2.5-0.5B the 4-bit row is the directly comparable cross-hardware figure;
 | Supported model architectures | 89+ ModelType variants |
 | Text models tested (M1 Ultra, 2026-06-15) | 136 pass, 2 partial, 4 fail, 9 skip/non-standalone (151 dirs; adds apertus, seed-oss, dots.llm1, granite family, lfm2, plamo-2, falcon-h1, BitNet; diffusiongemma loads via #291) |
 | Text models tested (M5 Max, 2026-06-15) | 131 pass, 5 partial, 14 fail/skip (0.2.1 full sweep; post-sweep: qwen2.5-vl-3b-4bit fixed by re-download, oversized bf16 hunyuan dropped; neither a code regression) |
-| Text models tested (GB10, 2026-06-17) | 133 pass, 14 fail, 1 OOM-skip (148 total; 0.3.1 with the CUDA fused decode-MoE kernel #319 — 9 MoE models flipped FAIL→pass vs 0.3.0: 5 Qwen MoE + gemma-4-26b-a4b x2 + dots.llm1 + diffusiongemma) |
+| Text models tested (GB10, 2026-06-17) | 133 pass, 12 fail, 2 not-tested (glm-5/glm-5.1 weights not downloaded), 1 OOM-skip (148 total; 0.3.1 with the CUDA fused decode-MoE kernel #319 — 9 MoE models flipped FAIL→pass vs 0.3.0: 5 Qwen MoE + gemma-4-26b-a4b x2 + dots.llm1 + diffusiongemma) |
 | VLM models tested (GB10, 2026-06-17) | 53 measured image rows (0.3.1) |
 | VLM models tested (M5 Max, 2026-06-15) | 54 valid VLM rows (0.2.1 full VLM re-sweep; adds qwen3-vl-4b/8b, minicpm-v-4.6-bf16, nemotron-omni, youtu-vl; qwen2.5-vl-3b-4bit restored after re-download) |
 | VLM models tested (M1 Ultra, 2026-06-15) | 55 measured VLM rows (53 pass + 2 partial) |

--- a/docs/benchmark_results/model_tests_gb10.md
+++ b/docs/benchmark_results/model_tests_gb10.md
@@ -28,6 +28,7 @@ Compatibility and decode/prefill performance for mlxcel models on **NVIDIA GB10 
 
 - ✅ Pass: model loads and produces tokens within the configured budget
 - ❌ Fail: warmup/bench failure, OOM skip, or 0 tokens generated
+- ⚪ Not tested: model weights are not present in `models/` (not a code failure)
 
 Prefill/Decode are the measured-pass figures from `mlxcel-bench-decode`. Notes record an early-EOS token count (when a model stopped before 100) or the failure cause. Models are grouped by architecture family; VLM-capable models appear once under text (text-prompt pass) and again in the image-input table at the end.
 
@@ -185,8 +186,8 @@ Prefill/Decode are the measured-pass figures from `mlxcel-bench-decode`. Notes r
 | baichuan-m1-14b-4bit | ✅ | 74.32 | 22.36 | 7 tok |
 | ernie-4.5-0.3b-4bit | ✅ | 6384.30 | 654.97 |  |
 | glm4-flash-4bit | ✅ | 106.65 | 53.33 |  |
-| glm-5.1-4bit | ❌ | - | - | warmup failure |
-| glm-5-4bit | ❌ | - | - | warmup failure |
+| glm-5.1-4bit | ⚪ | - | - | not tested (weights not downloaded) |
+| glm-5-4bit | ⚪ | - | - | not tested (weights not downloaded) |
 | hunyuan-13b | ✅ | 18.78 | 14.80 |  |
 | hunyuan-1.8b-4bit | ✅ | 685.98 | 154.72 | 41 tok |
 | hunyuan-a13b-instruct-4bit | ✅ | 20.07 | 15.06 |  |
@@ -334,7 +335,8 @@ Models that accept image input and generated tokens under the `"What is in this 
 |--------|-------|
 | **Total text models attempted** | 148 |
 | **Pass (✅)** | 133 |
-| **Fail / 0-token (❌)** | 14 |
+| **Fail / 0-token (❌)** | 12 |
+| **Not tested (⚪, weights absent)** | 2 |
 | **OOM-skipped (capacity)** | 1 |
 | **VLM models measured (image input)** | 53 |
 
@@ -359,7 +361,8 @@ The 0.3.1 line ported the fused decode-MoE kernel to CUDA (#319). Nine MoE model
 ### Failing / skipped models (by cause)
 
 - **BitNet (ternary; fails CUDA warmup):** `bitnet-b1.58-2b-4t`, `bitnet-b1.58-2b-4t-4bit`
-- **Other model-specific failures:** `deepseek-v3-4bit`, `glm-5-4bit`, `glm-5.1-4bit`
+- **Other model-specific failures:** `deepseek-v3-4bit`
+- **Not tested (weights not downloaded, not a code failure):** `glm-5-4bit` (config only, no safetensors), `glm-5.1-4bit` (empty checkpoint dir)
 - **Not standalone text-gen models:** `docling-layout-heron-mlx-bf16` (document layout), `granite-speech-4.1-2b-nar-mlx` (speech)
 - **MTP/DFlash drafter checkpoints (need a target; not standalone):** `gemma-4-12b-it-assistant-4bit`, `gemma-4-31b-it-assistant-bf16`, `qwen3.5-27b-dflash`, `qwen3.5-4b-dflash`
 - **VLM warmup failure under image setup:** `qwen2.5-vl-3b` (bf16), `minicpm-v-4.6-mxfp4` (mxfp4; the bf16 variant passes)


### PR DESCRIPTION
The `glm-5-4bit` dir has only config files (no safetensors) and `glm-5.1-4bit` is an empty checkpoint dir, so their GB10 bench FAIL is a missing download, not a code failure. Reclassify both as **not tested** (new ⚪ legend marker), adjust counts (14 fail → 12 fail + 2 not-tested), and update the cross-hardware index status line.