### PR TITLE
fix(vlm): load non-affine VLM weights with the right quant mode and group_size

### DIFF
--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -191,7 +191,22 @@ impl QuantizedEmbedding {
         group_size: i32,
         bits: i32,
     ) -> Result<Self, String> {
-        Self::from_weights_with_mode(weights, prefix, group_size, bits, "affine")
+        // Auto-detect the quantization mode: affine stores zero-point biases,
+        // so their absence means a block-float scheme (mxfp4 / nvfp4 / mxfp8),
+        // distinguished by bits and group_size. This lets callers that do not
+        // thread an explicit mode (e.g. vision encoders, which always called
+        // this affine default) load non-affine weights correctly instead of
+        // aborting in quantized_matmul ("Biases must be provided for affine").
+        let mode = if weights.get(&format!("{}.biases", prefix)).is_some() {
+            "affine"
+        } else if bits == 8 {
+            "mxfp8"
+        } else if group_size == 16 {
+            "nvfp4"
+        } else {
+            "mxfp4"
+        };
+        Self::from_weights_with_mode(weights, prefix, group_size, bits, mode)
     }
 
     /// Load from weight map with explicit quantization mode
@@ -701,7 +716,22 @@ impl UnifiedLinear {
         group_size: i32,
         bits: i32,
     ) -> Result<Self, String> {
-        Self::from_weights_with_mode(weights, prefix, group_size, bits, "affine")
+        // Auto-detect the quantization mode: affine stores zero-point biases,
+        // so their absence means a block-float scheme (mxfp4 / nvfp4 / mxfp8),
+        // distinguished by bits and group_size. This lets callers that do not
+        // thread an explicit mode (e.g. vision encoders, which always called
+        // this affine default) load non-affine weights correctly instead of
+        // aborting in quantized_matmul ("Biases must be provided for affine").
+        let mode = if weights.get(&format!("{}.biases", prefix)).is_some() {
+            "affine"
+        } else if bits == 8 {
+            "mxfp8"
+        } else if group_size == 16 {
+            "nvfp4"
+        } else {
+            "mxfp4"
+        };
+        Self::from_weights_with_mode(weights, prefix, group_size, bits, mode)
     }
 
     /// Load from weight map with explicit quantization mode
@@ -734,23 +764,42 @@ impl UnifiedLinear {
             // biases may not exist for mxfp4/nvfp4/mxfp8 modes
             let biases = weights.get(&biases_name).map(|w| ffi::copy(w));
 
-            // Reconcile caller-supplied bits with actual tensor shapes. Models
-            // with per-layer quantization overrides (Qwen3.5/3.6 MoE gates)
-            // store gates at a different bit width from the rest of the model.
-            let effective_bits = if mode == "affine" {
+            // Reconcile caller-supplied quant params with the actual tensor
+            // shapes; mixed exports vary them per layer. For affine, bits are
+            // inferred with the trusted group_size (Qwen3.5/3.6 MoE gates). For
+            // the block-float modes bits are fixed by the mode, so reconcile
+            // group_size from the shapes instead: in_features = packed_in *
+            // (32/bits) = num_groups * group_size (e.g. minicpm-v-4.6 mxfp4
+            // stores some weights at group_size 32 while config says 64).
+            let (effective_bits, effective_group_size) = if mode == "affine" {
                 let w_shape = ffi::array_shape(&weight);
                 let s_shape = ffi::array_shape(&scales);
-                infer_quantization_bits(&w_shape, &s_shape, group_size, bits)
-                    .map_err(|e| format!("{} (prefix: {})", e, prefix))?
+                let eb = infer_quantization_bits(&w_shape, &s_shape, group_size, bits)
+                    .map_err(|e| format!("{} (prefix: {})", e, prefix))?;
+                (eb, group_size)
             } else {
-                bits
+                let w_shape = ffi::array_shape(&weight);
+                let s_shape = ffi::array_shape(&scales);
+                let egs = if w_shape.len() >= 2 && s_shape.len() >= 2 && bits > 0 {
+                    let packed_in = *w_shape.last().unwrap();
+                    let num_groups = *s_shape.last().unwrap();
+                    let in_features = packed_in * (32 / bits);
+                    if num_groups > 0 && in_features % num_groups == 0 {
+                        in_features / num_groups
+                    } else {
+                        group_size
+                    }
+                } else {
+                    group_size
+                };
+                (bits, egs)
             };
 
             let qweight = QuantizedWeight {
                 weight,
                 scales,
                 biases,
-                group_size,
+                group_size: effective_group_size,
                 bits: effective_bits,
                 mode: mode.to_string(),
             };


### PR DESCRIPTION
## Summary

Vision encoders (and any caller that does not thread an explicit quantization mode) load weights through `from_weights`, which hardcoded the **affine** mode. On block-float VLMs that aborts in `quantized_matmul` (`Biases must be provided for affine`) because mxfp4/nvfp4/mxfp8 weights carry no zero-point biases. minicpm-v-4.6-mxfp4 was the visible casualty.

Two reconciliations fix it:

1. **Mode auto-detect** in `QuantizedEmbedding::from_weights` and `UnifiedLinear::from_weights`: a `.biases` tensor means affine; its absence means a block-float scheme, distinguished by `bits` (8 → mxfp8) and `group_size` (16 → nvfp4, else mxfp4).
2. **group_size reconciliation** for block-float modes in `UnifiedLinear::from_weights_with_mode`. For affine, bits are inferred against the trusted `group_size` (unchanged). For block-float modes the bits are fixed by the mode, so `group_size` is derived from the shapes instead: `in_features = packed_in * (32/bits) = num_groups * group_size`. A mixed export such as minicpm-v-4.6-mxfp4 stores some weights at `group_size` 32 while `config.json` reports 64; the old loader passed 64 straight through and mismatched in the matmul.

## Verification (GB10, CUDA)

| Model | Before | After |
|-------|--------|-------|
| minicpm-v-4.6-mxfp4 (with image) | abort (`Biases must be provided for affine`, then group_size mismatch) | coherent description, **139.85 tok/s** decode |
| qwen2.5-7b-4bit (affine sanity) | 53 tok/s | 53 tok/s (path unchanged) |
| gpt-oss-20b-mxfp4 (block-float sanity) | 78 tok/s | 78 tok/s (inferred params equal passed) |

For affine models and correctly exported block-float models the inferred params equal the passed ones, so behavior is byte-identical.