### PR TITLE
docs(benchmarks): record fused decode-MoE gains for the newly wired MoE families

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ High-performance LLM/VLM inference runtime and server for Apple Silicon. The CLI
 ## New in v0.3.0
 
 - **Nine new model families.** BitNet b1.58 (1.58-bit ternary), IBM Granite dense and GraniteMoeHybrid, LFM2 / LFM2-MoE, Falcon-H1, PLaMo 2, Apertus, ByteDance Seed-OSS, and dots.llm1 MoE, on top of the existing Llama, Qwen, Gemma, and DeepSeek coverage.
-- **Faster MoE decode, on by default.** The fused decode-MoE Metal kernel beats the previous gather path on single-token decode (about 13% on gemma4) and is now enabled by default. Set `MLXCEL_FUSED_MOE=0` to disable.
+- **Faster MoE decode, on by default.** The fused decode-MoE Metal kernel beats the previous gather path on single-token decode (up to about 19% on Qwen3-VL 30B-A3B and 13% on Gemma 4, M1 Ultra) and is enabled by default across ten MoE families. It self-gates by expert size (`MLXCEL_FUSED_MOE_MAX_DFF`, default 4096): large-expert models such as Mixtral 8x7B and Phi-3.5-MoE keep the proven gather path with no regression. Set `MLXCEL_FUSED_MOE=0` to disable.
 - **Loads newer mixed-precision checkpoints.** mlxcel now reads per-layer mixed bit widths and bf16 quantization scales, so recent mlx-community exports (for example 8-bit embeddings under a 4-bit default) load correctly. A bf16-scale decode regression on M1 Ultra is also fixed.
 - **Linux CUDA release builds.** Prebuilt x86_64 and aarch64 CUDA artifacts ship with bundled CCCL headers and reuse JIT-compiled kernels across runs through a persistent PTX cache.
 
@@ -172,8 +172,14 @@ to a quantized-decode regression on bf16-scale checkpoints that mostly affected
 M1 Ultra). The M5 Max `mlx-lm` / `mlx-vlm` reference columns are retained from
 the earlier same-host campaign, so each ratio is mlxcel (2026-06-15) over that
 retained reference; a fresh same-host mlx-lm / mlx-vlm run validated that the
-reference is stable. M1 Ultra values are mlxcel-only capacity references.
-Absolute results depend on model family, quantization, prompt shape, decode
+reference is stable. M1 Ultra values are mlxcel-only capacity references. After
+that sweep the fused decode-MoE kernel was wired into more MoE families
+(qwen2_moe, lfm2, qwen3_vl_moe), so the Qwen3-VL 30B-A3B text-path M1 Ultra figure
+here is the refreshed post-wiring number (69 to 82 tok/s, +19%, `--profile`
+decode, median of 3); the M5 Max columns predate that wiring and are conservative
+for that row. Mixtral 8x7B stays on the gather path via the expert-size guard, so
+its figures are unchanged. Absolute results depend on model family, quantization,
+prompt shape, decode
 length, and hardware. See
 [Benchmark results](docs/benchmark_results/benchmark-report.md) and
 [Benchmarks](docs/benchmarks.md) for methodology and caveats.
@@ -195,7 +201,7 @@ length, and hardware. See
 | Mixtral 8x7B 4bit | 54 tok/s | 65 tok/s | 66 tok/s | 98% |
 | StarCoder2 3B 4bit | 166 tok/s | 216 tok/s | 215 tok/s | 100% |
 | Qwen3.5 0.8B 4bit | 230 tok/s | 504 tok/s | 545 tok/s | 92% |
-| Qwen3-VL 30B-A3B 4bit, text path | 69 tok/s | 151 tok/s | 147 tok/s | 103% |
+| Qwen3-VL 30B-A3B 4bit, text path | 82 tok/s | 151 tok/s | 147 tok/s | 103% |
 | Qwen3-VL 32B 4bit, text path | 21 tok/s | 27 tok/s | 29 tok/s | 93% |
 | GPT-OSS 120B 4bit | 58 tok/s | 114 tok/s | 110 tok/s | 104% |
 | Solar Open 100B 4bit | 33 tok/s | 65 tok/s | 66 tok/s | 98% |

--- a/benchmarks/metal_m1ultra_2026-06-17_fused_moe.csv
+++ b/benchmarks/metal_m1ultra_2026-06-17_fused_moe.csv
@@ -1,0 +1,7 @@
+model,model_path,prompt_tokens,generated_tokens,prefill_ms,prefill_tok_s,decode_ms,decode_tok_s,date,hardware,mlx_version,build_type,max_tokens,prompt
+qwen1.5-moe-a2.7b-4bit,models/qwen1.5-moe-a2.7b-4bit/,25,43,,,298.30,144.15,2026-06-17,Apple_M1_Ultra_128GB,0.3.0+d9f88e07b,release,100,"Hello, how are you today?"
+lfm2-8b-a1b-4bit,models/lfm2-8b-a1b-4bit/,17,37,,,217.11,170.42,2026-06-17,Apple_M1_Ultra_128GB,0.3.0+d9f88e07b,release,100,"Hello, how are you today?"
+qwen3-vl-30b-a3b-4bit,models/qwen3-vl-30b-a3b-4bit/,15,35,,,437.60,79.98,2026-06-17,Apple_M1_Ultra_128GB,0.3.0+d9f88e07b,release,100,"Hello, how are you today?"
+mixtral-8x7b-4bit,models/mixtral-8x7b-4bit/,15,76,,,1426.77,53.27,2026-06-17,Apple_M1_Ultra_128GB,0.3.0+d9f88e07b,release,100,"Hello, how are you today?"
+phi-3.5-moe-4bit,models/phi-3.5-moe-4bit/,10,100,,,1318.50,75.84,2026-06-17,Apple_M1_Ultra_128GB,0.3.0+d9f88e07b,release,100,"Hello, how are you today?"
+olmoe-1b-7b-0125-instruct-4bit,/Users/inureyes/.cache/mlxcel/models/mlx-community/OLMoE-1B-7B-0125-Instruct-4bit/,20,100,,,364.31,274.49,2026-06-17,Apple_M1_Ultra_128GB,0.3.0+d9f88e07b,release,100,"Hello, how are you today?"

--- a/docs/benchmark_results/fused-moe-decode-kernel-design.md
+++ b/docs/benchmark_results/fused-moe-decode-kernel-design.md
@@ -164,19 +164,32 @@ falls back to the proven `gather_qmm` / `SwitchGLU` path automatically. Set
 
 ### Measured decode gains (M1 Ultra, `MLXCEL_FUSED_MOE=1`)
 
+decode tok/s pairs are `MLXCEL_FUSED_MOE=0` (gather_qmm baseline) followed by the
+default fused path. The first four rows and nemotron-h are from the kernel
+development passes; qwen3-vl-30b-a3b, lfm2-8b-a1b, and qwen1.5-moe are from the
+`--profile` decode benchmark (prompt "Hello, how are you today?", 100 tokens,
+median of 3) added when those families were wired (epic #307).
+
 | Model | activation | bits | decode tok/s | gain | greedy parity |
 |-------|-----------|------|-------------:|-----:|---------------|
-| gemma-4-26b-a4b-it | GeGLU | 4 | 73.8 → 83.2 | **+13%** | byte-identical (use the chat template) |
+| qwen3-vl-30b-a3b (text path) | SwiGLU | 4 | 69.3 → 82.3 | **+18.8%** | within f16 jitter class |
+| gemma-4-26b-a4b-it | GeGLU | 4 | 73.8 → 83.2 | +13% | byte-identical (use the chat template) |
 | qwen3.5/3.6-35b-a3b | SwiGLU | 4 | 68.7 → 74.7 | +8.7% | within f16 jitter class |
 | dots.llm1 | SwiGLU | 4 + 6 | 13.1 → 13.7 | +4.7% | byte-identical |
 | qwen3-30b-a3b | SwiGLU | 4 | 47.3 → 49.0 | +3.5% | byte-identical |
-| qwen1.5-moe-a2.7b | SwiGLU | 4 | ~140 | ~par | byte-identical |
+| lfm2-8b-a1b (LFM2-MoE) | SwiGLU | 4 | 168.9 → 174.7 | +3.4% | byte-identical |
+| qwen1.5-moe-a2.7b | SwiGLU | 4 | 143.0 → 146.1 | +2.2% | within f16 jitter class |
 | nemotron-h-30b | relu² | 4 | 54.9 → 54.7 | ~0% | byte-identical (off the default path) |
 
-The gain tracks how MoE-dominated the decode is and how inefficient the
-baseline was: gemma4 wins most (small experts, and its compiled-SwitchGeGLU
-baseline was three `gather_qmm`), while nemotron-h barely moves because its
-decode is dominated by Mamba2 + attention.
+The gain tracks how MoE-dominated the decode is and how inefficient the baseline
+was: qwen3-vl-30b-a3b and gemma4 win most (small experts, MoE-dominated decode;
+gemma4's compiled-SwitchGeGLU baseline was three `gather_qmm`), while nemotron-h
+barely moves because its decode is dominated by Mamba2 + attention. Three wired
+families do not gain and stay on `gather_qmm`: mixtral (Dff 14336) and phi-3.5-moe
+(Dff 6400) sit above `MLXCEL_FUSED_MOE_MAX_DFF`, so the kernel declines and decode
+is unchanged (mixtral ~53 tok/s, phi-3.5-moe ~75 tok/s); olmoe (Dff 1024, top_k=8)
+dispatches but is perf-neutral (~272 tok/s on and off). All three remain within
+the f16 jitter class of their baselines, with no regression.
 
 ### Measured decode gains (M5 Max, `MLXCEL_FUSED_MOE=1`, #282)
 

--- a/docs/benchmark_results/model_tests_m1ultra.md
+++ b/docs/benchmark_results/model_tests_m1ultra.md
@@ -2,6 +2,8 @@
 
 Compatibility and performance testing for mlxcel models on **Mac Studio M1 Ultra 128GB**, with comparison against Python mlx-lm / mlx-vlm.
 
+> **2026-06-17 fused decode-MoE update.** After this 0.2.1 sweep, the fused decode-MoE kernel was wired into more MoE families (epic #307: qwen2_moe, lfm2, qwen3_vl_moe, mixtral, phi-3.5-moe, olmoe). On M1 Ultra the small-expert families gain on decode (qwen3-vl-30b-a3b text path 69 to 82 tok/s, +18.8%; lfm2-8b-a1b +3.4%; qwen1.5-moe +2.2%), while large-expert mixtral and phi-3.5-moe stay on gather_qmm via the `MLXCEL_FUSED_MOE_MAX_DFF` guard (decode unchanged) and olmoe is perf-neutral. The MoE rows in this dated sweep predate the wiring; the post-wiring decode numbers are in `benchmarks/metal_m1ultra_2026-06-17_fused_moe.csv` and [Fused decode-MoE kernel](fused-moe-decode-kernel-design.md).
+
 ## Test Environment
 
 | Item | Value |


### PR DESCRIPTION
Records the M1 Ultra decode measurements for the MoE families that epic #307 wired to the fused decode-MoE kernel, and refreshes the docs/README where those models appear. Methodology: `mlxcel generate --profile`, prompt "Hello, how are you today?", 100 tokens, `MLXCEL_FUSED_MOE` on vs off, median of 3 on Mac Studio M1 Ultra 128GB.

Measured decode (off to on):
- qwen3-vl-30b-a3b text path: 69.3 to 82.3 tok/s (+18.8%)
- lfm2-8b-a1b: 168.9 to 174.7 tok/s (+3.4%)
- qwen1.5-moe-a2.7b: 143.0 to 146.1 tok/s (+2.2%)
- mixtral-8x7b and phi-3.5-moe: unchanged; their large experts (Dff 14336 / 6400) sit above `MLXCEL_FUSED_MOE_MAX_DFF` (4096) so the kernel declines and decode stays on gather_qmm
- olmoe: perf-neutral (top_k=8)

Changes:
- `docs/benchmark_results/fused-moe-decode-kernel-design.md`: replace the qwen1.5-moe placeholder with the real numbers, add qwen3_vl_moe (now the biggest gain) and lfm2, and note the guard-fallback and neutral models.
- `README.md`: expand the fused-MoE performance highlight (coverage + the expert-size guard) and refresh the Qwen3-VL 30B-A3B M1 Ultra row (69 to 82 tok/s). The dated cross-host sweep predates the wiring and the M5 Max columns were not re-swept, so the change is documented inline as a post-sweep M1 Ultra refresh.
- `docs/benchmark_results/model_tests_m1ultra.md`: forward-pointer note (the 2026-06-15 / v0.2.1 dated rows are left intact, not rewritten).
- `benchmarks/metal_m1ultra_2026-06-17_fused_moe.csv`: new dated capture (decode column; single-shot `--profile` prefill omitted because it includes cold graph build).

Follows epic #307. No code changes.