### PR TITLE
fix(sampling): correct f16/bf16 logprobs crash and corruption (#340)

### DIFF
--- a/src/lib/mlxcel-core/src/sampling.rs
+++ b/src/lib/mlxcel-core/src/sampling.rs
@@ -713,7 +713,15 @@ pub fn compute_logprobs(
 
         // Use raw bytes to extract i32 token IDs from top_idx.
         let idx_bytes = ffi::array_to_raw_bytes(&top_idx);
-        let lp_bytes = ffi::array_to_raw_bytes(&top_lp);
+        // `top_lp` inherits the model logit dtype, which is f16/bf16 for
+        // quantized models (post-#289). `array_to_raw_bytes` dumps the buffer
+        // verbatim with no dtype conversion, so a hardcoded 4-byte stride
+        // overruns a 2-byte-per-element buffer and reinterprets the bytes as
+        // garbage. Cast to f32 first so the stride is valid and the values are
+        // correct, mirroring the dtype-aware selected-token path (`item_f32`).
+        let top_lp_f32 = ffi::astype(&top_lp, dtype::FLOAT32);
+        ffi::eval(&top_lp_f32);
+        let lp_bytes = ffi::array_to_raw_bytes(&top_lp_f32);
 
         // Build (token_id, logprob) pairs for only the top-k partition.
         let mut pairs: Vec<(i32, f32)> = (0..k_usize.min(idx_bytes.len() / 4))
@@ -1123,6 +1131,165 @@ mod tests {
         let result = compute_logprobs(&logits, 2, &config).expect("should return Some");
         // top_k is clamped to vocab size (3), so at most 3 alternatives
         assert_eq!(result.top_alternatives.len(), 3);
+    }
+
+    // -- f16 / bf16 logprobs regression coverage (issue #340) --
+    //
+    // Quantized models keep bf16 (and sometimes f16) logits post-#289, so the
+    // arrays reaching `compute_logprobs` are 2 bytes per element, not 4. These
+    // tests build the logit array at f16/bf16 from the SAME underlying f32
+    // values used for an f32 reference run, then assert the top-k and the
+    // selected-token logprobs come back as correct f32 values. The pre-fix code
+    // read the 2-byte top-k buffer with a hardcoded 4-byte stride, which either
+    // overran the slice (the reported server panic) or reinterpreted the bytes
+    // as garbage, so even a loose tolerance separates correct from broken.
+
+    // Build a `[1, vocab]` logit array at `target_dtype` from shared f32 values
+    // and run `compute_logprobs`. `target_dtype == dtype::FLOAT32` skips the
+    // cast so it doubles as the reference run.
+    fn logprobs_for_dtype(
+        values: &[f32],
+        selected_token: i32,
+        top_k: usize,
+        target_dtype: i32,
+    ) -> TokenLogprobData {
+        let f32_logits = ffi::from_slice_f32(values, &[1, values.len() as i32]);
+        let config = LogprobsConfig {
+            enabled: true,
+            top_k,
+        };
+        if target_dtype == dtype::FLOAT32 {
+            compute_logprobs(&f32_logits, selected_token, &config)
+                .expect("should return Some")
+        } else {
+            let logits = ffi::astype(&f32_logits, target_dtype);
+            compute_logprobs(&logits, selected_token, &config).expect("should return Some")
+        }
+    }
+
+    // Shared logit row for the dtype tests: 6 distinct logits. Descending
+    // logprob order by logit value is token 1 (3.0) > 3 (2.0) > 2 (1.0) >
+    // 0 (0.5) > 5 (0.0) > 4 (-1.0). Selecting token 4 (the lowest) lets the
+    // top-5 alternatives be the 5 highest, reproducing the `logprobs: 5`
+    // request that crashed the server.
+    const DTYPE_LOGITS: [f32; 6] = [0.5, 3.0, 1.0, 2.0, -1.0, 0.0];
+    const SELECTED_LOWEST: i32 = 4; // token with logit -1.0
+
+    // Assert a top-k run matches the f32 reference: same count, sorted
+    // descending, same top-token id, and per-value agreement within `tol`.
+    fn assert_top_k_matches_reference(
+        result: &TokenLogprobData,
+        reference: &TokenLogprobData,
+        tol: f32,
+    ) {
+        // (b) count matches the reference (and the requested k).
+        assert_eq!(
+            result.top_alternatives.len(),
+            reference.top_alternatives.len(),
+            "alternative count must match the f32 reference"
+        );
+        // (c) alternatives are sorted descending by logprob.
+        for w in result.top_alternatives.windows(2) {
+            assert!(
+                w[0].1 >= w[1].1,
+                "alternatives must be sorted descending: {:?}",
+                result.top_alternatives
+            );
+        }
+        // Identity of the top token matches the f32 reference.
+        assert_eq!(
+            result.top_alternatives[0].0, reference.top_alternatives[0].0,
+            "top alternative token id must match the f32 reference"
+        );
+        // (d) each logprob value matches the reference within tolerance. Match
+        // by token id rather than by position to stay robust to tie ordering.
+        for &(tok, lp) in &result.top_alternatives {
+            let ref_lp = reference
+                .top_alternatives
+                .iter()
+                .find(|&&(t, _)| t == tok)
+                .map(|&(_, lp)| lp)
+                .unwrap_or_else(|| panic!("token {tok} missing from f32 reference set"));
+            assert!(
+                (lp - ref_lp).abs() <= tol,
+                "logprob for token {tok} = {lp} differs from reference {ref_lp} by more than {tol}"
+            );
+        }
+    }
+
+    #[test]
+    fn compute_logprobs_top_k_bf16_no_panic_matches_f32() {
+        // Unit-level reproduction of the server crash: `top_k = 5` on bf16
+        // logits drives the identical top-k path the server hits. The pre-fix
+        // code panicked here ("range end index 12 out of range for slice of
+        // length 10"); the fix must return correct f32 values instead.
+        let reference =
+            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT32);
+        let result =
+            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::BFLOAT16);
+        assert_eq!(result.top_alternatives.len(), 5);
+        // bf16 has ~8 mantissa bits, so use a loose absolute tolerance.
+        assert_top_k_matches_reference(&result, &reference, 0.1);
+        // Highest-logprob alternative is token 1 (logit 3.0).
+        assert_eq!(result.top_alternatives[0].0, 1);
+    }
+
+    #[test]
+    fn compute_logprobs_top_k_f16_matches_f32() {
+        let reference =
+            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT32);
+        let result =
+            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT16);
+        assert_eq!(result.top_alternatives.len(), 5);
+        // f16 has ~10 mantissa bits, so a tighter tolerance still holds.
+        assert_top_k_matches_reference(&result, &reference, 0.03);
+        assert_eq!(result.top_alternatives[0].0, 1);
+    }
+
+    #[test]
+    fn compute_logprobs_top_k_f32_values_correct() {
+        // f32 reference path: the same top_k = 5 request must return exact
+        // values (the dtype cast is a no-op here). Guards that the shared
+        // helper and the f32 path agree before comparing dtype runs to it.
+        let reference =
+            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT32);
+        assert_eq!(reference.top_alternatives.len(), 5);
+        assert_top_k_matches_reference(&reference, &reference, 1e-5);
+        assert_eq!(reference.top_alternatives[0].0, 1);
+    }
+
+    #[test]
+    fn compute_logprobs_selected_token_bf16_matches_f32() {
+        // Selected-token path (top_k = 0) must stay correct on bf16. This path
+        // already uses `item_f32`; the test guards it against future refactors.
+        let reference =
+            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::FLOAT32);
+        let result =
+            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::BFLOAT16);
+        assert!(result.top_alternatives.is_empty());
+        assert_eq!(result.token_id, SELECTED_LOWEST);
+        assert!(
+            (result.logprob - reference.logprob).abs() <= 0.1,
+            "bf16 selected-token logprob {} differs from f32 reference {} by more than 0.1",
+            result.logprob,
+            reference.logprob
+        );
+    }
+
+    #[test]
+    fn compute_logprobs_selected_token_f16_matches_f32() {
+        let reference =
+            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::FLOAT32);
+        let result =
+            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::FLOAT16);
+        assert!(result.top_alternatives.is_empty());
+        assert_eq!(result.token_id, SELECTED_LOWEST);
+        assert!(
+            (result.logprob - reference.logprob).abs() <= 0.03,
+            "f16 selected-token logprob {} differs from f32 reference {} by more than 0.03",
+            result.logprob,
+            reference.logprob
+        );
     }
 
     // -- TokenBiasMap and apply_token_bias --

--- a/src/lib/mlxcel-core/src/sampling.rs
+++ b/src/lib/mlxcel-core/src/sampling.rs
@@ -677,11 +677,18 @@ pub fn compute_logprobs(
     let log_probs = ffi::log_softmax(adjusted_logits, -1);
     ffi::eval(&log_probs);
 
-    // Extract the log probability of the selected token.
+    // Extract the log probability of the selected token. `selected_lp_arr`
+    // inherits the model logit dtype (f16/bf16 for quantized models post-#289),
+    // and `item_f32` reads the element's raw bytes via MLX `item<float>()`
+    // without dtype conversion, so a 2-byte f16/bf16 element would be
+    // reinterpreted as garbage. Cast the single value to f32 first. Casting
+    // only this 1-element array (not the full-vocab `log_probs`) keeps the
+    // decode hot path cheap, matching the top-k boundary below.
     let idx = ffi::from_slice_i32(&[selected_token], &[1, 1]);
     let selected_lp_arr = ffi::take_along_axis(&log_probs, &idx, -1);
-    ffi::eval(&selected_lp_arr);
-    let selected_logprob = ffi::item_f32(&selected_lp_arr);
+    let selected_lp_f32 = ffi::astype(&selected_lp_arr, dtype::FLOAT32);
+    ffi::eval(&selected_lp_f32);
+    let selected_logprob = ffi::item_f32(&selected_lp_f32);
 
     // Compute top-k alternatives if requested.
     let top_alternatives = if config.top_k > 0 {

--- a/src/lib/mlxcel-core/src/sampling.rs
+++ b/src/lib/mlxcel-core/src/sampling.rs
@@ -1166,8 +1166,7 @@ mod tests {
             top_k,
         };
         if target_dtype == dtype::FLOAT32 {
-            compute_logprobs(&f32_logits, selected_token, &config)
-                .expect("should return Some")
+            compute_logprobs(&f32_logits, selected_token, &config).expect("should return Some")
         } else {
             let logits = ffi::astype(&f32_logits, target_dtype);
             compute_logprobs(&logits, selected_token, &config).expect("should return Some")
@@ -1230,10 +1229,8 @@ mod tests {
         // logits drives the identical top-k path the server hits. The pre-fix
         // code panicked here ("range end index 12 out of range for slice of
         // length 10"); the fix must return correct f32 values instead.
-        let reference =
-            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT32);
-        let result =
-            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::BFLOAT16);
+        let reference = logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT32);
+        let result = logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::BFLOAT16);
         assert_eq!(result.top_alternatives.len(), 5);
         // bf16 has ~8 mantissa bits, so use a loose absolute tolerance.
         assert_top_k_matches_reference(&result, &reference, 0.1);
@@ -1243,10 +1240,8 @@ mod tests {
 
     #[test]
     fn compute_logprobs_top_k_f16_matches_f32() {
-        let reference =
-            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT32);
-        let result =
-            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT16);
+        let reference = logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT32);
+        let result = logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT16);
         assert_eq!(result.top_alternatives.len(), 5);
         // f16 has ~10 mantissa bits, so a tighter tolerance still holds.
         assert_top_k_matches_reference(&result, &reference, 0.03);
@@ -1258,8 +1253,7 @@ mod tests {
         // f32 reference path: the same top_k = 5 request must return exact
         // values (the dtype cast is a no-op here). Guards that the shared
         // helper and the f32 path agree before comparing dtype runs to it.
-        let reference =
-            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT32);
+        let reference = logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 5, dtype::FLOAT32);
         assert_eq!(reference.top_alternatives.len(), 5);
         assert_top_k_matches_reference(&reference, &reference, 1e-5);
         assert_eq!(reference.top_alternatives[0].0, 1);
@@ -1269,10 +1263,8 @@ mod tests {
     fn compute_logprobs_selected_token_bf16_matches_f32() {
         // Selected-token path (top_k = 0) must stay correct on bf16. This path
         // already uses `item_f32`; the test guards it against future refactors.
-        let reference =
-            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::FLOAT32);
-        let result =
-            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::BFLOAT16);
+        let reference = logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::FLOAT32);
+        let result = logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::BFLOAT16);
         assert!(result.top_alternatives.is_empty());
         assert_eq!(result.token_id, SELECTED_LOWEST);
         assert!(
@@ -1285,10 +1277,8 @@ mod tests {
 
     #[test]
     fn compute_logprobs_selected_token_f16_matches_f32() {
-        let reference =
-            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::FLOAT32);
-        let result =
-            logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::FLOAT16);
+        let reference = logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::FLOAT32);
+        let result = logprobs_for_dtype(&DTYPE_LOGITS, SELECTED_LOWEST, 0, dtype::FLOAT16);
         assert!(result.top_alternatives.is_empty());
         assert_eq!(result.token_id, SELECTED_LOWEST);
         assert!(


### PR DESCRIPTION
## Summary

Fixes a server crash (`Abort trap: 6`) and a silent garbage-value bug when a `/v1/completions` or `/v1/chat/completions` request asks for `logprobs` against a model whose logits are f16 or bf16. After #289 keeps quantized models fully bf16, that is the common case: any `top_k >= 1` crashed the worker, and even `logprobs` without top-k returned a corrupt selected-token logprob.

## Root cause

`compute_logprobs()` in `src/lib/mlxcel-core/src/sampling.rs` reads log-probabilities out of MLX arrays on the host through two byte-level accessors that do not convert dtype, while the arrays inherit the model logit dtype (f16/bf16, 2 bytes per element, for quantized checkpoints post-#289):

1. Top-k path (crash): the alternatives were extracted with `ffi::array_to_raw_bytes(&top_lp)` plus a hardcoded 4-byte stride. `array_to_raw_bytes` dumps the buffer verbatim, so for f16/bf16 the buffer is `2*k` bytes while the loop reads it with a 4-byte stride bounded by the int32 index array (`k` elements). For `logprobs: 5` on bf16, `lp_bytes` is 10 bytes and the read `lp_bytes[8..12]` overruns, producing the reported panic `range end index 12 out of range for slice of length 10`. Even without an overrun, reinterpreting two f16 elements as one f32 yields garbage.

2. Selected-token path (silent corruption): the value was read with `ffi::item_f32`, which calls MLX `array::item<float>()`. Contrary to the original issue's assumption, `item<float>()` is not dtype-aware: it returns `*data<float>()`, reinterpreting the element's raw bytes as f32 with no conversion. On bf16 it read a 2-byte element as a 4-byte f32 and returned garbage (for example `6.9e-41` instead of `-4.5028`). This path is always on whenever `logprobs` is enabled, so it was wrong on every bf16 model, not just the top-k case. The f16/bf16 regression tests added here caught it; reasoning alone (as in the issue) missed it.

## Fix

Promote to f32 at the host-extraction boundary in both places, casting only the small arrays so the full-vocab `log_probs` stays in its native dtype and the decode hot path is unaffected:

- Top-k: `ffi::astype(&top_lp, dtype::FLOAT32)` (then `eval`) before `array_to_raw_bytes`, so the 4-byte stride is valid (`k` elements of f32).
- Selected token: `ffi::astype(&selected_lp_arr, dtype::FLOAT32)` (then `eval`) before `item_f32`, so the single value converts correctly.

This mirrors the established in-repo pattern (`generate.rs` and `rope_proportional.rs` both `astype` to f32 before raw-byte extraction). The int32 token-id read is left unchanged because indices really are 4 bytes, and no model weights or dtype policy elsewhere are changed. `ffi::item_f32` itself is left as-is to keep the change at the logprobs boundary; its byte-reinterpretation behavior on non-f32 arrays is a latent footgun worth a separate follow-up.

## Tests

The existing tests only built f32 logits via `ffi::from_slice_f32`, where the 4-byte stride was correct by accident, so they never exercised either bug. The new tests build f16 and bf16 logit arrays from the same underlying f32 values and assert the results match an f32 reference run within a dtype-appropriate tolerance (bf16 ~0.1, f16 ~0.03, f32 exact), covering both paths:

- `compute_logprobs_top_k_bf16_no_panic_matches_f32` — unit-level reproduction of the server crash: `top_k = 5` on bf16 drives the identical top-k path the server hits. Asserts no panic, correct alternative count, descending sort, matching top-token id, and per-value agreement with the f32 reference.
- `compute_logprobs_top_k_f16_matches_f32` — same for f16 with a tighter tolerance.
- `compute_logprobs_top_k_f32_values_correct` — f32 reference path, exact values, guards the shared helper and sort.
- `compute_logprobs_selected_token_bf16_matches_f32` and `compute_logprobs_selected_token_f16_matches_f32` — `top_k = 0` on bf16/f16; these reproduced the selected-token corruption (pre-fix they returned `~6.9e-41` / `~7.0e-41`) and now assert the logprob matches the f32 reference.

## Test plan

- [x] `cargo test -p mlxcel-core --release --lib sampling` — 37 passed, 0 failed (run by the orchestrator with warm release artifacts).

Closes #340
