### PR TITLE
docs(benchmarks): Gemma3n decode profile, no fusion justified (#329)

### DIFF
--- a/docs/benchmark_results/gemma3n-decode-profile.md
+++ b/docs/benchmark_results/gemma3n-decode-profile.md
@@ -1,0 +1,192 @@
+# Gemma3n decode profile: is a compiled fusion justified? (#329)
+
+Apple M1 Ultra (128 GB, macOS 26.5.0), MLX 0.31.2, mlx-vlm 0.4.4. Decode
+throughput measured with `mlxcel-bench-decode` (raw continuation prompt, 80-100
+tokens after a 20-token warmup, `caffeinate -i`, best-of-3 with the machine
+cool). Pipeline, op-count, and bandwidth data collected with the
+`mlxcel-gpu-profiling` hooks. This is the profile-first deliverable for #329;
+it follows the same method as `moe-decode-gap-investigation.md` and the prior
+Gemma3n bf16 decode-gap work.
+
+## Verdict
+
+No compiled fusion is justified for Gemma3n decode now. Three independent
+measurements say a small-op fusion would not help on M1 Ultra, and the one
+lever that does move decode is a scheduling knob, not a kernel:
+
+1. Decode is ~92% GPU-bound. The Rust graph-build step (`forward`), where any
+   FFI-crossing reduction would land, is ~7% of the token and is fully hidden
+   behind GPU execution. A fusion that only collapses FFI crossings (the
+   `MLXCEL_FUSED_QK_NORM` result on Qwen3, 1-3.4% slower on M1 Ultra) cannot win
+   here for the same reason.
+2. The decode-time overhead above pure weight streaming is dominated by
+   command-buffer dispatch gaps, not small-kernel compute. Raising
+   `MLX_MAX_OPS_PER_BUFFER` recovers +11-13% with zero code and zero risk; a
+   compiled fusion targets the wrong cost.
+3. The Gemma3n-specific fusions worth doing already shipped in #60 (fused MLP
+   bridge, compiled gelu_topk / GeGLU, stacked AltUp) and are already active on
+   M1 Ultra. The prior M5 investigation (the source of the
+   `mlxcel-gpu-profiling` skill) found no remaining fusion lever above ~2.6%.
+
+On top of that, mlxcel is already ahead of the only Python runtime that loads
+these multimodal checkpoints (mlx-vlm; mlx-lm cannot load them), so there is no
+parity gap pulling for a risky kernel.
+
+## 1. Decode baseline (text and VLM)
+
+Greedy, raw prompt, best-of-3, default `MLX_MAX_OPS_PER_BUFFER`.
+
+| Checkpoint | layers / kv-shared | mlxcel text | mlxcel VLM (image) | mlx-vlm text | mlx-vlm VLM | mlxcel / mlx-vlm |
+|------------|-------------------:|------------:|-------------------:|-------------:|------------:|-----------------:|
+| gemma3n-e2b-4bit | 30 / 10 | 83.1 | - | 68.9 | - | 1.21x |
+| gemma3n-e4b-4bit | 35 / 15 | 62.9 | 58.7 | 52.6 | 47.9 | 1.20x (text), 1.23x (VLM) |
+
+mlx-vlm numbers are wall-clock `(tokens-1)/(t_last - t_first)` from
+`mlx_vlm.stream_generate` (its `generation_tps` field is unreliable on a raw
+prompt). mlx-lm cannot load these checkpoints (`KeyError('model')` on the
+multimodal config), so mlx-vlm is the reference. mlxcel leads on both models and
+both modalities.
+
+## 2. Pipeline split: GPU-bound, not FFI-bound
+
+`MLXCEL_PROFILE_PIPELINE_DETAIL`, per decode token:
+
+| Checkpoint | reshape | forward (Rust graph build) | sample | async_eval (GPU) | item_wait | GPU share |
+|------------|--------:|---------------------------:|-------:|-----------------:|----------:|----------:|
+| e2b-4bit | 0.001 ms | 0.92 ms | 0.002 ms | 11.44 ms | 0.16 ms | ~92% |
+| e4b-4bit | 0.002 ms | 1.09 ms | 0.002 ms | 14.47 ms | 0.19 ms | ~92% |
+
+`forward` is the entire Rust-side graph construction, every `mlxcel_core::*` FFI
+call for the token. It overlaps the previous token's GPU work via `async_eval`
+lookahead, so its ~7% never appears on the critical path. This is the decisive
+test against an FFI-collapsing fusion: there is no FFI cost to collapse.
+
+## 3. Per-layer structure and where the GPU time goes
+
+Each Gemma3n decoder layer runs far more than a dense transformer block: AltUp
+predict/correct (4 parallel planes, a router norm + modality router matmul +
+small coefficient matmuls), a LAUREL branch (two linears + a norm), per-layer
+input gating (gate + projection + norm), four block norms plus q/k/v norms, and
+KV sharing on the back half of the stack. The one-decode-token graph for
+e4b-4bit is ~4209 nodes:
+
+| Op | count | Op | count | Op | count |
+|----|------:|----|------:|----|------:|
+| Broadcast | 442 | QuantizedMatmul | 433 | RMSNorm | 357 |
+| Add | 351 | Transpose | 320 | Slice | 315 |
+| Squeeze | 254 | AsType | 249 | Reshape | 222 |
+| Multiply | 205 | Full | 149 | ExpandDims | 144 |
+| Matmul | 105 | Tanh | 71 | RoPE | 55 |
+| SliceUpdate | 40 | Concatenate | 36 | ScaledDotProductAttention | 35 |
+
+The long `Compiled*` nodes in the same graph are the #60 fusions already in
+place: `CompiledBroadcast...Tanh...` is gelu_topk / GeGLU, the
+`CompiledMaximum...Erf...` chain is the gelu_topk cutoff, and
+`CompiledBroadcastBroadcastSubtractSquare` is the magnitude reduction. Most of
+the high-count ops are views (Transpose, Slice, Squeeze, Reshape, ExpandDims,
+Flatten) that carry no kernel, or cheap elementwise that MLX fuses at eval.
+
+To separate the streaming work from the structure, a synthetic graph of just the
+per-token quantized GEMVs (q/k/v/o, gate/up/down across all layers with the
+KV-shared layers skipping k/v, plus the tied LM head), distinct weights per
+layer, one `eval` per token:
+
+- Pure-GEMV streaming floor (e4b): 6.17 ms/token, 2472 MB streamed, 401 GB/s.
+- mlxcel e4b GPU time: 14.47 ms/token.
+
+So pure weight streaming is ~43% of GPU time; the other ~57% is structure: the
+norms, AltUp, LAUREL, per-layer gating, attention, dtype glue, and the dispatch
+gaps between all of it. The streamed-bytes accounting also shows decode never
+touches the heavy multimodal weights: of the 5.82 GB e4b file, 1.36 GB audio
+tower + 0.59 GB vision tower + 1.32 GB per-layer lookup embedding are not
+streamed per text token; the ~2.52 GB that is streamed matches the GEMV floor.
+
+## 4. The real lever is command-buffer batching, not fusion
+
+`MLX_MAX_OPS_PER_BUFFER` controls how many ops MLX batches before committing a
+command buffer (runtime, no rebuild). Sweeping it on Gemma3n:
+
+| MLX_MAX_OPS_PER_BUFFER | e2b-4bit | e4b-4bit |
+|------------------------|---------:|---------:|
+| default (unset) | 82.7 | 63.0 |
+| 100 | - | 67.4 |
+| 200 | - | 69.5 |
+| 1000 | 93.2 | 70.0 |
+| 2000 | 92.5 | 67.7 |
+
+A clean monotonic climb to a plateau near 1000, +12.7% on e2b and +11% on e4b.
+Per the profiling skill this response (GPU idle between kernels, fixed by
+coarser dispatch) is the signature of dispatch-gap binding, whose fix is
+batching or deeper command-buffer lookahead, not a fused kernel. It also at
+least partly explains the 57% structure overhead in section 3: a meaningful
+slice of it is GPU idle waiting on command-buffer commits.
+
+This is the one place Gemma3n differs from the MoE decode gap (#268), where the
+same sweep was flat. Gemma3n's higher op density per layer (AltUp 4-plane,
+LAUREL, per-layer inputs, dual norms) makes the default buffer size too small,
+so the GPU stalls at buffer boundaries. A compiled fusion would reduce the op
+count and therefore shrink some of these gaps, but the env knob already captures
+that benefit and more, for free, and a fusion of the small glue ops would not
+beat it.
+
+## 5. Text vs VLM: vision is a prefill cost only
+
+| e4b-4bit | prefill tok/s | decode tok/s |
+|----------|--------------:|-------------:|
+| text prompt | 98 | 63.0 |
+| image prompt | 483 | 58.7 |
+
+The vision tower runs once during prefill (the high image-prompt prefill tok/s
+reflects the image's many soft tokens processed in one pass). Decode is the same
+per-layer structure either way; the small VLM decode delta is the longer KV
+context after ingesting the image soft tokens (more K/V to read per step), which
+is KV bandwidth, not a fusable small-op hotspot. Any decode fusion target is
+identical with or without an image, and the vision path is not a decode
+bottleneck.
+
+## 6. Conclusion and when a fusion would become justified
+
+Close #329 with no compiled fusion. The decode profile shows no fusable
+small-kernel hotspot on M1 Ultra: decode is GPU-bound with FFI hidden, the
+worthwhile Gemma3n fusions already shipped in #60, mlxcel already leads mlx-vlm,
+and the residual overhead is dispatch-gap idle that a scheduling knob recovers
+better than any kernel could.
+
+A fusion would only become justified if a GPU trace (Xcode, the skill's Step 4)
+showed the GPU busy (not idle) inside a specific small-kernel chain whose summed
+compute time is large, after the dispatch-gap portion is removed. Today the
+evidence points the other way.
+
+Recommended follow-up, which is not a fusion and is out of scope for #329: make
+`MLX_MAX_OPS_PER_BUFFER` a Gemma3n-aware default around 1000, gated on hardware.
+It must be gated, because the prior M5 investigation found the default fastest
+on M5-class hardware (larger buffers were slower there); blindly raising it
+would regress M5. That needs a cross-hardware re-bench before it lands, so it
+belongs in its own issue.
+
+### Reproduce
+
+```bash
+# decode baseline (best-of-3, cool)
+for i in 1 2 3; do caffeinate -i ./target/release/mlxcel-bench-decode \
+  -m models/gemma3n-e4b-4bit -p "Hello, how are you today?" -n 100 \
+  --warmup-tokens 20 --no-chat-template 2>/dev/null | grep Decode:; done
+
+# pipeline split
+MLXCEL_PROFILE_PIPELINE=1 MLXCEL_PROFILE_PIPELINE_DETAIL=1 \
+  ./target/release/mlxcel-bench-decode -m models/gemma3n-e4b-4bit -p Hi \
+  -n 100 --warmup-tokens 20 --no-chat-template 2>&1 | grep PIPELINE
+
+# command-buffer sweep
+for OPS in 100 200 1000 2000; do MLX_MAX_OPS_PER_BUFFER=$OPS \
+  ./target/release/mlxcel-bench-decode -m models/gemma3n-e4b-4bit \
+  -p "Hello, how are you today?" -n 80 --warmup-tokens 20 \
+  --no-chat-template 2>/dev/null | grep Decode:; done
+
+# one-decode-token op histogram
+MLXCEL_EXPORT_DECODE_DOT=/tmp/g3n.dot ./target/release/mlxcel-bench-decode \
+  -m models/gemma3n-e4b-4bit -p Hi -n 3 --warmup-tokens 3 \
+  --no-chat-template >/dev/null 2>&1
+grep -oE 'label ="[A-Za-z0-9_]+' /tmp/g3n.dot | sed 's/label ="//' \
+  | sort | uniq -c | sort -rn | head -30
+```

--- a/docs/benchmark_results/gemma3n-decode-profile.md
+++ b/docs/benchmark_results/gemma3n-decode-profile.md
@@ -23,9 +23,13 @@ lever that does move decode is a scheduling knob, not a kernel:
    command-buffer dispatch gaps, not small-kernel compute. Raising
    `MLX_MAX_OPS_PER_BUFFER` recovers +11-13% with zero code and zero risk; a
    compiled fusion targets the wrong cost.
-3. The Gemma3n-specific fusions worth doing already shipped in #60 (fused MLP
-   bridge, compiled gelu_topk / GeGLU, stacked AltUp) and are already active on
-   M1 Ultra. The prior M5 investigation (the source of the
+3. The Gemma3n-specific fusions worth doing already shipped and run on M1 Ultra
+   off NA hardware: the stacked AltUp path (#60) and the compiled gelu_topk /
+   GeGLU activation kernels (landed before #60, reused by it). The #60 fused MLP
+   bridge is bf16-only, so the 4-bit MLP here runs gate/up/down as separate
+   `QuantizedMatmul` plus that compiled activation; extending the bridge to
+   quantized weights would only collapse the FFI crossings that point 1 shows
+   are hidden. The prior M5 investigation (the source of the
    `mlxcel-gpu-profiling` skill) found no remaining fusion lever above ~2.6%.
 
 On top of that, mlxcel is already ahead of the only Python runtime that loads
@@ -79,10 +83,13 @@ e4b-4bit is ~4209 nodes:
 | Matmul | 105 | Tanh | 71 | RoPE | 55 |
 | SliceUpdate | 40 | Concatenate | 36 | ScaledDotProductAttention | 35 |
 
-The long `Compiled*` nodes in the same graph are the #60 fusions already in
-place: `CompiledBroadcast...Tanh...` is gelu_topk / GeGLU, the
-`CompiledMaximum...Erf...` chain is the gelu_topk cutoff, and
-`CompiledBroadcastBroadcastSubtractSquare` is the magnitude reduction. Most of
+The long `Compiled*` nodes in the same graph are the compiled activation fusions
+already in place (gelu_topk / GeGLU, predating #60 and reused by it):
+`CompiledBroadcast...Tanh...` is gelu_topk / GeGLU, the `CompiledMaximum...Erf...`
+chain is the gelu_topk cutoff, and `CompiledBroadcastBroadcastSubtractSquare` is
+the magnitude reduction. The MLP gate/up/down are not bundled here because the
+#60 fused MLP bridge is bf16-only; on these 4-bit checkpoints they are the
+per-layer `QuantizedMatmul` nodes counted above. Most of
 the high-count ops are views (Transpose, Slice, Squeeze, Reshape, ExpandDims,
 Flatten) that carry no kernel, or cheap elementwise that MLX fuses at eval.
 
@@ -148,7 +155,8 @@ bottleneck.
 
 Close #329 with no compiled fusion. The decode profile shows no fusable
 small-kernel hotspot on M1 Ultra: decode is GPU-bound with FFI hidden, the
-worthwhile Gemma3n fusions already shipped in #60, mlxcel already leads mlx-vlm,
+worthwhile Gemma3n fusions already shipped (#60 and earlier), mlxcel already
+leads mlx-vlm,
 and the residual overhead is dispatch-gap idle that a scheduling knob recovers
 better than any kernel could.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -37,6 +37,7 @@ reference runtime) live alongside the snapshot:
 
 - [MoE decode gap investigation](benchmark_results/moe-decode-gap-investigation.md)
 - [Fused decode-MoE kernel: design and roadmap](benchmark_results/fused-moe-decode-kernel-design.md)
+- [Gemma3n decode profile: is a compiled fusion justified?](benchmark_results/gemma3n-decode-profile.md)
 
 ## Suggested benchmark commands
 


### PR DESCRIPTION
## Summary

Profile-first investigation for #329: profile Gemma3n decode, then add a compiled fusion only if the profile justifies one. It does not, so this PR ships the profiling finding as documentation and adds no kernel. A documented "no fusion justified" outcome is the result the issue explicitly calls for.

## Findings (Apple M1 Ultra, MLX 0.31.2, mlx-vlm 0.4.4)

- Decode is ~92% GPU-bound. The Rust graph-build step (`forward`), where an FFI-crossing fusion would land, is ~7% per token and fully hidden behind `async_eval`. A fusion that only collapses FFI crossings would regress here, the same outcome as `MLXCEL_FUSED_QK_NORM` on Qwen3 (1-3.4% slower on M1 Ultra).
- Decode tok/s: e2b-4bit 83.1, e4b-4bit 62.9 (text), 58.7 (image). mlxcel already leads mlx-vlm (68.9 / 52.6 / 47.9) by 1.20-1.23x, and mlx-lm cannot load these multimodal checkpoints, so there is no parity gap to chase.
- The worthwhile Gemma3n fusions already shipped in #60 (fused MLP bridge, compiled gelu_topk/GeGLU, stacked AltUp) and are active on M1 Ultra (`use_fused_decode_path()` is true on non-NA hardware).
- Pure weight streaming is ~43% of GPU time; the ~57% structure overhead is dominated by command-buffer dispatch gaps, not fusable kernel compute. Raising `MLX_MAX_OPS_PER_BUFFER` toward 1000 recovers +11-13% with no code (e2b 82.7 -> 93.2, e4b 63.0 -> 70.0). That is a scheduling knob, not a kernel, and must be hardware-gated because M5 regresses with larger buffers, so it belongs in a separate follow-up issue.
- Text vs VLM: the vision tower is a prefill cost only; decode is the same per-layer structure either way.

## What changed

- Add `docs/benchmark_results/gemma3n-decode-profile.md`: full numbers, pipeline split, one-decode-token op histogram, pure-GEMV streaming floor, command-buffer sweep, text-vs-VLM table, and reproduce commands.
- Link it from the "Decode-gap investigations" list in `docs/benchmarks.md`.

## Test plan

- [x] Decode best-of-3 (caffeinate, cool) on gemma3n-e2b/e4b-4bit via `mlxcel-bench-decode`.
- [x] Pipeline split via `MLXCEL_PROFILE_PIPELINE_DETAIL`; op histogram via `MLXCEL_EXPORT_DECODE_DOT`.
- [x] mlx-vlm reference via `mlx_vlm.stream_generate` (wall-clock).
- [x] Docs only; no code paths changed.

Closes #329
