### PR TITLE
perf(server): split batched prefill into compatible cohorts

### DIFF
--- a/src/server/batch/mod.rs
+++ b/src/server/batch/mod.rs
@@ -28,6 +28,7 @@
 
 mod active;
 pub mod observability;
+mod prefill_cohort;
 mod queue;
 pub(crate) mod scheduler;
 #[cfg(test)]

--- a/src/server/batch/prefill_cohort.rs
+++ b/src/server/batch/prefill_cohort.rs
@@ -1,0 +1,426 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cohort planning for batched prefill (#332).
+//!
+//! A collected prefill window can mix requests that the padded batched-prefill
+//! path supports with requests that it does not. Historically one incompatible
+//! request forced the *whole* window back to sequential prefill, wasting the
+//! eligible concurrent work. This module turns that all-or-nothing decision
+//! into a cohort split: the cold text requests that can share a single padded
+//! forward pass are grouped into a batched cohort, while incompatible requests
+//! (adopted prompt-cache prefixes, VLM / custom embeddings, length-incompatible
+//! rows on equal-length-only models) are routed to the offset-aware
+//! single-sequence path.
+//!
+//! The planner is a pure function over per-row classifications so its
+//! correctness invariants can be pinned by unit tests without a real model:
+//!
+//! - **Order preserving.** Concatenating the members of the returned cohorts in
+//!   order reproduces the input window order exactly. The window is drained in
+//!   priority order (high lane, then normal, then low; FIFO within a lane), so
+//!   preserving window order is exactly what keeps request priority / FIFO
+//!   fairness intact across cohort boundaries.
+//! - **Offset isolation.** A [`PrefillCohortKind::BatchedCold`] cohort contains
+//!   only rows flagged `is_cold`, i.e. rows with a zero KV-history offset and no
+//!   custom embeddings. The padded batched path assumes a zero cache offset for
+//!   every row, so this guarantees it never receives an adopted-prefix row whose
+//!   KV must resume at a non-zero offset.
+//! - **Contiguity.** Cold rows batch only where they are *contiguous* in the
+//!   window. A cold row separated from other cold rows by an incompatible row is
+//!   prefilled sequentially rather than reordered into a distant batch, so the
+//!   split never hoists a lower-priority request ahead of a higher-priority one.
+
+/// How a contiguous group of prefill-window rows is executed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrefillCohortKind {
+    /// Two or more cold text rows (zero KV-history offset, no custom
+    /// embeddings) that share a single padded batched-prefill forward pass.
+    BatchedCold,
+    /// Rows prefilled one at a time on the offset-aware single-sequence path:
+    /// adopted prompt-cache prefixes, VLM / custom-embedding rows, isolated
+    /// cold rows, and (on equal-length-only models) length-incompatible cold
+    /// rows.
+    Sequential,
+}
+
+/// A planned cohort: its execution kind and the window indices of its member
+/// rows, in priority (window) order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PrefillCohort {
+    pub kind: PrefillCohortKind,
+    pub members: Vec<usize>,
+}
+
+/// Per-row inputs to [`plan_prefill_cohorts`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PrefillRow {
+    /// Eligible for the padded batched path: zero KV-history offset AND no
+    /// custom / VLM embeddings. Adopted-prefix and embedding-bearing rows are
+    /// not cold.
+    pub is_cold: bool,
+    /// Prompt length in tokens. Only consulted for equal-length-only models
+    /// (`can_pad == false`), where a batched cohort must share one length.
+    pub prompt_len: usize,
+}
+
+/// Partition a priority-ordered prefill window into execution cohorts.
+///
+/// `can_batch` is the model-level `supports_batched_prefill()` capability and
+/// `can_pad` is `supports_padded_prefill()`. When `can_batch` is false the
+/// model cannot batch any prefill, so the whole window is one sequential cohort.
+///
+/// See the module documentation for the order-preservation, offset-isolation,
+/// and contiguity guarantees.
+pub(crate) fn plan_prefill_cohorts(
+    rows: &[PrefillRow],
+    can_batch: bool,
+    can_pad: bool,
+) -> Vec<PrefillCohort> {
+    let n = rows.len();
+    if n == 0 {
+        return Vec::new();
+    }
+
+    // Model cannot batch prefill at all: every row takes the single-sequence
+    // path, in window order. This reproduces the pre-cohort fallback.
+    if !can_batch {
+        return vec![PrefillCohort {
+            kind: PrefillCohortKind::Sequential,
+            members: (0..n).collect(),
+        }];
+    }
+
+    let mut cohorts: Vec<PrefillCohort> = Vec::new();
+    // Incompatible (or isolated-cold) rows seen since the last flush, kept in
+    // window order so the eventual Sequential cohort preserves priority.
+    let mut pending_seq: Vec<usize> = Vec::new();
+    let mut i = 0usize;
+    while i < n {
+        if !rows[i].is_cold {
+            pending_seq.push(i);
+            i += 1;
+            continue;
+        }
+
+        // Maximal contiguous run of cold rows starting at `i`.
+        let run_start = i;
+        while i < n && rows[i].is_cold {
+            i += 1;
+        }
+        let run: Vec<usize> = (run_start..i).collect();
+
+        // A run batches only when it has at least two rows AND the model can
+        // pad to a common length (or every row already shares one length, the
+        // only case an equal-length-only model can batch). Otherwise every row
+        // of the run falls through to the sequential path, in order.
+        let run_batches = run.len() >= 2 && (can_pad || all_equal_len(rows, &run));
+        if run_batches {
+            flush_sequential(&mut cohorts, &mut pending_seq);
+            cohorts.push(PrefillCohort {
+                kind: PrefillCohortKind::BatchedCold,
+                members: run,
+            });
+        } else {
+            pending_seq.extend(run);
+        }
+    }
+    flush_sequential(&mut cohorts, &mut pending_seq);
+    cohorts
+}
+
+/// Whether every indexed row shares the same prompt length.
+fn all_equal_len(rows: &[PrefillRow], idx: &[usize]) -> bool {
+    match idx.first() {
+        None => true,
+        Some(&first) => {
+            let len0 = rows[first].prompt_len;
+            idx.iter().all(|&j| rows[j].prompt_len == len0)
+        }
+    }
+}
+
+/// Emit the accumulated sequential rows (if any) as one ordered cohort.
+fn flush_sequential(cohorts: &mut Vec<PrefillCohort>, pending: &mut Vec<usize>) {
+    if pending.is_empty() {
+        return;
+    }
+    cohorts.push(PrefillCohort {
+        kind: PrefillCohortKind::Sequential,
+        members: std::mem::take(pending),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a window from `(is_cold, prompt_len)` tuples.
+    fn rows(spec: &[(bool, usize)]) -> Vec<PrefillRow> {
+        spec.iter()
+            .map(|&(is_cold, prompt_len)| PrefillRow {
+                is_cold,
+                prompt_len,
+            })
+            .collect()
+    }
+
+    /// Flatten the cohort plan back into the dispatch order of window indices.
+    fn dispatch_order(cohorts: &[PrefillCohort]) -> Vec<usize> {
+        cohorts
+            .iter()
+            .flat_map(|c| c.members.iter().copied())
+            .collect()
+    }
+
+    /// Every plan must dispatch each input row exactly once, in the original
+    /// window (priority) order. This is the fairness invariant: no row is
+    /// dropped, duplicated, or hoisted past a row that preceded it.
+    fn assert_order_preserved(rows: &[PrefillRow], cohorts: &[PrefillCohort]) {
+        let order = dispatch_order(cohorts);
+        let expected: Vec<usize> = (0..rows.len()).collect();
+        assert_eq!(
+            order, expected,
+            "cohort dispatch order must equal window order (priority preserved)"
+        );
+    }
+
+    /// A BatchedCold cohort must never contain a non-cold row. This is the
+    /// cache-offset-correctness guarantee: the padded batched path only ever
+    /// sees zero-offset rows, so an adopted prefix can never have its KV
+    /// resumed at the wrong position by being folded into a batch.
+    fn assert_batched_cohorts_are_cold(rows: &[PrefillRow], cohorts: &[PrefillCohort]) {
+        for cohort in cohorts {
+            if cohort.kind == PrefillCohortKind::BatchedCold {
+                assert!(
+                    cohort.members.len() >= 2,
+                    "a BatchedCold cohort must hold at least two rows"
+                );
+                for &idx in &cohort.members {
+                    assert!(
+                        rows[idx].is_cold,
+                        "row {idx} in a BatchedCold cohort must be cold (zero offset, no embeddings)"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn empty_window_yields_no_cohorts() {
+        let plan = plan_prefill_cohorts(&[], true, true);
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn all_cold_window_forms_one_batched_cohort() {
+        // No-regression: a window with no incompatible request batches exactly
+        // as before (every row in one padded batched pass).
+        let w = rows(&[(true, 10), (true, 20), (true, 30)]);
+        let plan = plan_prefill_cohorts(&w, true, true);
+        assert_eq!(
+            plan,
+            vec![PrefillCohort {
+                kind: PrefillCohortKind::BatchedCold,
+                members: vec![0, 1, 2],
+            }]
+        );
+        assert_order_preserved(&w, &plan);
+        assert_batched_cohorts_are_cold(&w, &plan);
+    }
+
+    #[test]
+    fn all_incompatible_window_is_one_sequential_cohort() {
+        // Every row adopted/VLM: each is handled on the single-sequence path,
+        // in order. No batched cohort exists, but no row is lost.
+        let w = rows(&[(false, 10), (false, 20), (false, 30)]);
+        let plan = plan_prefill_cohorts(&w, true, true);
+        assert_eq!(
+            plan,
+            vec![PrefillCohort {
+                kind: PrefillCohortKind::Sequential,
+                members: vec![0, 1, 2],
+            }]
+        );
+        assert_order_preserved(&w, &plan);
+        assert_batched_cohorts_are_cold(&w, &plan);
+    }
+
+    #[test]
+    fn mixed_cold_and_adopted_splits_into_cohorts() {
+        // The headline case: a window of cold rows followed by adopted-prefix
+        // rows splits into a batched cold cohort and a sequential cohort. The
+        // cold cohort runs batched even though the window contains incompatible
+        // requests, and the batched cohort holds only cold rows.
+        let w = rows(&[(true, 10), (true, 12), (false, 40), (false, 41)]);
+        let plan = plan_prefill_cohorts(&w, true, true);
+        assert_eq!(
+            plan,
+            vec![
+                PrefillCohort {
+                    kind: PrefillCohortKind::BatchedCold,
+                    members: vec![0, 1],
+                },
+                PrefillCohort {
+                    kind: PrefillCohortKind::Sequential,
+                    members: vec![2, 3],
+                },
+            ]
+        );
+        assert_order_preserved(&w, &plan);
+        assert_batched_cohorts_are_cold(&w, &plan);
+    }
+
+    #[test]
+    fn adopted_prefix_before_cold_keeps_priority_order() {
+        // A high-priority adopted row at the head must be dispatched before the
+        // lower-priority cold rows that follow, so the sequential cohort comes
+        // first in dispatch order.
+        let w = rows(&[(false, 50), (true, 10), (true, 11)]);
+        let plan = plan_prefill_cohorts(&w, true, true);
+        assert_eq!(
+            plan,
+            vec![
+                PrefillCohort {
+                    kind: PrefillCohortKind::Sequential,
+                    members: vec![0],
+                },
+                PrefillCohort {
+                    kind: PrefillCohortKind::BatchedCold,
+                    members: vec![1, 2],
+                },
+            ]
+        );
+        assert_order_preserved(&w, &plan);
+        assert_batched_cohorts_are_cold(&w, &plan);
+    }
+
+    #[test]
+    fn isolated_cold_row_between_incompatible_stays_sequential() {
+        // A lone cold row surrounded by incompatible rows cannot batch without
+        // reordering, so it joins the sequential cohort and order is preserved.
+        let w = rows(&[(false, 50), (true, 10), (false, 60)]);
+        let plan = plan_prefill_cohorts(&w, true, true);
+        assert_eq!(
+            plan,
+            vec![PrefillCohort {
+                kind: PrefillCohortKind::Sequential,
+                members: vec![0, 1, 2],
+            }]
+        );
+        assert_order_preserved(&w, &plan);
+        assert_batched_cohorts_are_cold(&w, &plan);
+    }
+
+    #[test]
+    fn two_separated_cold_runs_form_two_batches() {
+        // Cold runs split by an incompatible row form independent batches; the
+        // incompatible row is dispatched between them, preserving order.
+        let w = rows(&[(true, 10), (true, 11), (false, 40), (true, 12), (true, 13)]);
+        let plan = plan_prefill_cohorts(&w, true, true);
+        assert_eq!(
+            plan,
+            vec![
+                PrefillCohort {
+                    kind: PrefillCohortKind::BatchedCold,
+                    members: vec![0, 1],
+                },
+                PrefillCohort {
+                    kind: PrefillCohortKind::Sequential,
+                    members: vec![2],
+                },
+                PrefillCohort {
+                    kind: PrefillCohortKind::BatchedCold,
+                    members: vec![3, 4],
+                },
+            ]
+        );
+        assert_order_preserved(&w, &plan);
+        assert_batched_cohorts_are_cold(&w, &plan);
+    }
+
+    #[test]
+    fn single_cold_row_is_sequential_not_batched() {
+        // A cold cohort of one has no batching benefit and takes the single
+        // path (matching the pre-cohort single-request fast path).
+        let w = rows(&[(true, 10)]);
+        let plan = plan_prefill_cohorts(&w, true, true);
+        assert_eq!(
+            plan,
+            vec![PrefillCohort {
+                kind: PrefillCohortKind::Sequential,
+                members: vec![0],
+            }]
+        );
+        assert_order_preserved(&w, &plan);
+    }
+
+    #[test]
+    fn model_without_batched_prefill_is_all_sequential() {
+        // Even an all-cold window is fully sequential when the model does not
+        // support batched prefill.
+        let w = rows(&[(true, 10), (true, 20), (true, 30)]);
+        let plan = plan_prefill_cohorts(&w, false, true);
+        assert_eq!(
+            plan,
+            vec![PrefillCohort {
+                kind: PrefillCohortKind::Sequential,
+                members: vec![0, 1, 2],
+            }]
+        );
+        assert_order_preserved(&w, &plan);
+    }
+
+    #[test]
+    fn equal_length_only_model_batches_only_equal_lengths() {
+        // can_pad == false (equal-length-only model). A run of equal lengths
+        // batches; a run with mixed lengths falls back to sequential.
+        let equal = rows(&[(true, 16), (true, 16), (true, 16)]);
+        let plan_equal = plan_prefill_cohorts(&equal, true, false);
+        assert_eq!(
+            plan_equal,
+            vec![PrefillCohort {
+                kind: PrefillCohortKind::BatchedCold,
+                members: vec![0, 1, 2],
+            }]
+        );
+        assert_batched_cohorts_are_cold(&equal, &plan_equal);
+
+        let mixed = rows(&[(true, 16), (true, 24)]);
+        let plan_mixed = plan_prefill_cohorts(&mixed, true, false);
+        assert_eq!(
+            plan_mixed,
+            vec![PrefillCohort {
+                kind: PrefillCohortKind::Sequential,
+                members: vec![0, 1],
+            }]
+        );
+    }
+
+    #[test]
+    fn padded_model_batches_mixed_lengths() {
+        // can_pad == true: mixed lengths still batch (the padded path pads to
+        // the longest prompt). This is the qwen3 / llama3 path.
+        let w = rows(&[(true, 16), (true, 24)]);
+        let plan = plan_prefill_cohorts(&w, true, true);
+        assert_eq!(
+            plan,
+            vec![PrefillCohort {
+                kind: PrefillCohortKind::BatchedCold,
+                members: vec![0, 1],
+            }]
+        );
+        assert_batched_cohorts_are_cold(&w, &plan);
+    }
+}

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -3114,6 +3114,18 @@ impl BatchScheduler {
         let mut slots: Vec<Option<SequenceInfo>> = seqs.into_iter().map(Some).collect();
         for cohort in plan {
             match cohort.kind {
+                // Behavior note (#332): a cold row that previously fell back to
+                // *sequential* prefill (because the collected window held an
+                // incompatible sibling) now runs batched here. A padded batched
+                // forward (B > 1) is not bitwise-identical to single-sequence
+                // prefill on Metal, so such a row's greedy decode can differ
+                // from its old sequential output by an early near-tie token flip
+                // (the documented #203 / #325 / #326 jitter class). That is the
+                // intended effect of cohort splitting, not a correctness
+                // regression: the guarantee is that a cohort-split cold row
+                // decodes identically to the same row in an all-cold batched
+                // window of the same composition (pinned by
+                // scheduler_cohort_parity_tests).
                 PrefillCohortKind::BatchedCold => {
                     let group: Vec<SequenceInfo> = cohort
                         .members

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -77,6 +77,7 @@ use crate::vision::feature_cache::ModelVisionCaches;
 use crate::vlm_runtime::prepared_embedding_refs;
 
 use super::active::ActiveBatch;
+use super::prefill_cohort::{PrefillCohortKind, PrefillRow, plan_prefill_cohorts};
 use super::queue::PrefillQueue;
 use super::sequence::{
     BatchSchedulerAction, FinishReason, RequestPriority, SequenceInfo, SequenceState,
@@ -3059,18 +3060,24 @@ impl BatchScheduler {
     }
 
     /// Batched prefill: drain up to `max_batch_prefill` requests from the
-    /// prefill queue and process them in a single forward pass.
+    /// prefill queue and process eligible cold text rows in a single forward
+    /// pass.
     ///
-    /// Sequences are padded to the longest prompt in the batch (aligned to a
-    /// 32-token tile on M5+). Each sequence gets a per-sequence causal +
-    /// padding attention mask so padding tokens are excluded from attention.
-    ///
-    /// On any error the method falls back to sequential single-request prefill
-    /// for the remaining requests so no requests are lost.
+    /// The drained window can mix requests the padded batched path supports
+    /// (cold text: zero KV-history offset, no custom embeddings) with requests
+    /// it does not (adopted prompt-cache prefixes, VLM / custom embeddings).
+    /// #332: instead of falling the whole window back to sequential prefill
+    /// when it contains one incompatible request, the window is split into
+    /// cohorts ([`plan_prefill_cohorts`]). Cold cohorts run batched; everything
+    /// else takes the offset-aware single-sequence path. Cohorts are dispatched
+    /// in window order, and the queue dequeues in priority order, so request
+    /// priority / FIFO fairness is preserved across cohort boundaries.
     fn execute_batched_prefill(&mut self) {
         let batch_size = self.max_batch_prefill.min(self.prefill_queue.len());
 
-        // Collect up to `batch_size` requests from the queue.
+        // Collect up to `batch_size` requests from the queue. The queue
+        // dequeues in priority order (high lane, then normal, then low; FIFO
+        // within a lane), so `seqs` is already in priority order.
         let mut seqs: Vec<SequenceInfo> = Vec::with_capacity(batch_size);
         for _ in 0..batch_size {
             match self.prefill_queue.dequeue() {
@@ -3083,76 +3090,97 @@ impl BatchScheduler {
             return;
         }
 
-        // Single-request fast path: fall through to the regular prefill so
-        // there is no overhead for constructing a padded batch.
+        // Classify each row, then plan cohorts. A row is "cold" only when it
+        // has no VLM / custom embeddings AND no adopted prompt-cache prefix.
+        // That is exactly the precondition the padded batched path assumes (a
+        // zero cache offset for every row), so the planner's guarantee that a
+        // BatchedCold cohort holds only cold rows is what keeps cache offsets
+        // correct: an adopted prefix can never be folded into a batch and have
+        // its KV resumed at the wrong position.
+        let can_batch = self.model.supports_batched_prefill();
+        let can_pad = self.model.supports_padded_prefill();
+        let rows: Vec<PrefillRow> = seqs
+            .iter()
+            .map(|s| PrefillRow {
+                is_cold: s.vlm_embeddings.is_none() && s.prefill_start_offset == 0,
+                prompt_len: s.prompt_tokens.len(),
+            })
+            .collect();
+        let plan = plan_prefill_cohorts(&rows, can_batch, can_pad);
+
+        // Move sequences into index-addressable slots so each cohort can take
+        // ownership of exactly its members. Dispatching cohorts in plan order
+        // reproduces window (priority) order across the cohort boundaries.
+        let mut slots: Vec<Option<SequenceInfo>> = seqs.into_iter().map(Some).collect();
+        for cohort in plan {
+            match cohort.kind {
+                PrefillCohortKind::BatchedCold => {
+                    let group: Vec<SequenceInfo> = cohort
+                        .members
+                        .iter()
+                        .filter_map(|&i| slots[i].take())
+                        .collect();
+                    self.run_padded_batched_prefill(group);
+                }
+                PrefillCohortKind::Sequential => {
+                    for &i in &cohort.members {
+                        let Some(mut seq) = slots[i].take() else {
+                            continue;
+                        };
+                        if let Err(err) = Self::begin_prefill(&mut seq) {
+                            tracing::error!("Batched prefill state transition error: {err}");
+                            self.abort_sequence(seq, &err);
+                            continue;
+                        }
+                        self.execute_full_prefill(seq);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Run a single padded batched prefill over a cohort of cold text rows.
+    ///
+    /// Every sequence in `seqs` must be cold (zero KV-history offset, no custom
+    /// embeddings); [`plan_prefill_cohorts`] guarantees this, so the pipeline
+    /// below can assume a zero cache offset for every row. Sequences are padded
+    /// to the longest prompt in the cohort (aligned to a 32-token tile on M5+),
+    /// each with a per-sequence causal + padding mask, and run in one forward
+    /// pass. On any error the affected sequences fall back to the
+    /// single-sequence prefill path so no request is lost.
+    fn run_padded_batched_prefill(&mut self, mut seqs: Vec<SequenceInfo>) {
+        // Defensive: the planner only emits BatchedCold cohorts of >= 2 rows,
+        // but keep the empty / single cases correct if called directly.
+        if seqs.is_empty() {
+            return;
+        }
         if seqs.len() == 1 {
-            let seq = seqs.remove(0);
+            let mut seq = seqs.remove(0);
+            if let Err(err) = Self::begin_prefill(&mut seq) {
+                tracing::error!("Batched prefill state transition error: {err}");
+                self.abort_sequence(seq, &err);
+                return;
+            }
             self.execute_full_prefill(seq);
             return;
         }
 
-        // Most models only implement batched decode (`[B, 1]`) and do not
-        // support full-sequence prompt prefill via `forward_batched()`.
-        // Keep those on the single-sequence prefill path so correctness and
-        // the standard NAX-friendly prefill route are preserved.
-        if !self.model.supports_batched_prefill() {
-            tracing::debug!(
-                "batched prefill: falling back to sequential (model lacks full batched prefill)"
-            );
-            for mut seq in seqs {
-                if let Err(err) = Self::begin_prefill(&mut seq) {
-                    tracing::error!("Batched prefill state transition error: {err}");
-                    self.abort_sequence(seq, &err);
-                    continue;
-                }
-                self.execute_full_prefill(seq);
+        // Transition all sequences to Prefilling up front so every fallback
+        // below routes through `execute_full_prefill` from the correct state.
+        for seq in &mut seqs {
+            if let Err(err) = Self::begin_prefill(seq) {
+                tracing::error!("Batched prefill state transition error: {err}");
             }
-            return;
-        }
-
-        // Any VLM request cannot currently be batched (embeddings are
-        // per-sequence and would need separate handling). Fall back for the
-        // whole batch when any request carries VLM embeddings.
-        if seqs.iter().any(|s| s.vlm_embeddings.is_some()) {
-            tracing::debug!("batched prefill: falling back to sequential (VLM request in batch)");
-            for mut seq in seqs {
-                if let Err(err) = Self::begin_prefill(&mut seq) {
-                    tracing::error!("Batched prefill state transition error: {err}");
-                    self.abort_sequence(seq, &err);
-                    continue;
-                }
-                self.execute_full_prefill(seq);
-            }
-            return;
-        }
-
-        // any sequence that adopted a cached prefix
-        // cannot participate in the padded batched prefill path because the
-        // KV-history offsets differ across sequences. Take the single-
-        // sequence path for those so their `prefill_start_offset` is
-        // honored correctly; batched-prefill continues for the rest of
-        // this batch in the normal padded pipeline below.
-        if seqs.iter().any(|s| s.prefill_start_offset > 0) {
-            tracing::debug!(
-                "batched prefill: falling back to sequential (adopted prompt-cache prefix in batch)"
-            );
-            for mut seq in seqs {
-                if let Err(err) = Self::begin_prefill(&mut seq) {
-                    tracing::error!("Batched prefill state transition error: {err}");
-                    self.abort_sequence(seq, &err);
-                    continue;
-                }
-                self.execute_full_prefill(seq);
-            }
-            return;
         }
 
         let b = seqs.len();
         let max_len = seqs.iter().map(|s| s.prompt_tokens.len()).max().unwrap();
         let can_pad_prefill = self.model.supports_padded_prefill();
         if !can_pad_prefill && seqs.iter().any(|s| s.prompt_tokens.len() != max_len) {
+            // Should not happen for a planner-approved cohort (it only batches
+            // equal-length rows on equal-length-only models), but stay safe.
             tracing::debug!(
-                "batched prefill: falling back to sequential (model requires equal prompt lengths)"
+                "batched prefill: cohort fell back to sequential (model requires equal prompt lengths)"
             );
             for seq in seqs {
                 self.execute_full_prefill(seq);
@@ -3167,13 +3195,6 @@ impl BatchScheduler {
         };
 
         tracing::debug!("batched prefill: {} requests, padded to {}", b, padded_len);
-
-        // Transition all sequences to Prefilling.
-        for seq in &mut seqs {
-            if let Err(err) = Self::begin_prefill(seq) {
-                tracing::error!("Batched prefill state transition error: {err}");
-            }
-        }
 
         // Build padded input: [B, padded_len]
         let mut flat_tokens: Vec<i32> = Vec::with_capacity(b * padded_len);
@@ -4817,3 +4838,7 @@ mod tests;
 #[cfg(test)]
 #[path = "serving_handoff_parity_tests.rs"]
 mod serving_handoff_parity_tests;
+
+#[cfg(test)]
+#[path = "scheduler_cohort_parity_tests.rs"]
+mod scheduler_cohort_parity_tests;

--- a/src/server/batch/scheduler_cohort_parity_tests.rs
+++ b/src/server/batch/scheduler_cohort_parity_tests.rs
@@ -1,0 +1,292 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real-model parity tests for #332 batched-prefill cohort splitting.
+//!
+//! When a collected prefill window mixes cold text rows with an incompatible
+//! request (adopted prompt-cache prefix, VLM embeddings), the scheduler now
+//! splits the window into cohorts and runs the cold rows batched instead of
+//! falling the whole window back to sequential prefill. These tests confirm
+//! that the split does not change any request's decoded output versus the
+//! pre-cohort all-or-nothing sequential path: a cold row prefilled inside a
+//! batched cohort (alongside an incompatible sibling) must decode identically
+//! to the same row prefilled alone on the single-sequence path.
+//!
+//! The tests load a real qwen3 checkpoint and run GPU forwards, so they are
+//! `#[ignore]` and soft-skip when the model directory is absent.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p mlxcel --lib --release --features metal,accelerate \
+//!     scheduler_cohort_parity -- --ignored --nocapture --test-threads=1
+//! ```
+//!
+//! Fetch the model with:
+//! `./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::mpsc;
+use std::time::Instant;
+
+use mlxcel_core::cache::SequenceId;
+use mlxcel_core::generate::SamplingConfig;
+
+use super::BatchScheduler;
+use crate::server::batch::BatchObservability;
+use crate::server::batch::sequence::{RequestPriority, SequenceInfo, SequenceState};
+use crate::server::config::{DecodeStorageBackend, PreemptionPolicy};
+use crate::server::model_provider::GenerateEvent;
+use crate::server::model_provider::model_worker::StreamingDecodeState;
+use crate::server::state::BatchMetrics;
+use crate::tokenizer::MlxcelTokenizer;
+
+/// qwen3 checkpoint directory name (a dense family that opts into batched
+/// prefill and padded prefill, the scope of #332).
+const QWEN3_DIR: &str = "qwen3-0.6b-4bit";
+
+/// Greedy decode steps to compare per request. Short so the test is quick; the
+/// prefill first token plus this many decode tokens already exercises the
+/// batched-cohort forward and the per-row KV trim.
+const DECODE_STEPS: usize = 12;
+
+/// A high per-request budget so a request does not stop on the length limit
+/// before `DECODE_STEPS`.
+const MAX_TOKENS: usize = 64;
+
+/// A fixed prompt that decodes several tokens without an immediate EOS (the
+/// "what is 2 + 2?" prompt also used by the handoff parity tests).
+const PROMPT_A: &[i32] = &[
+    9707, 11, 358, 1079, 264, 4128, 1614, 13, 5209, 3291, 752, 911, 697, 7990, 13, 358, 2776, 264,
+    10950, 17847, 13, 6771, 594, 1438, 419, 1495, 3019, 553, 3019, 11, 323, 1473, 697, 975, 13,
+    5209, 387, 2797, 624, 14374, 14582, 25, 3555, 374, 220, 17, 488, 220, 17, 30,
+];
+
+/// A second, shorter prompt of a different length so the batched cohort pads
+/// the two rows to a common length and trims each back independently.
+const PROMPT_B: &[i32] = &[
+    9707, 11, 4332, 752, 264, 2805, 22692, 911, 279, 9396, 13, 5209, 387, 63594, 624,
+];
+
+/// A third prompt routed to the sequential cohort via a non-zero adopted-prefix
+/// offset, so the window is a genuine cold + incompatible mix.
+const PROMPT_C: &[i32] = &[
+    785, 6722, 315, 9625, 374, 264, 3283, 13, 22512, 752, 911, 432, 13,
+];
+
+/// `<CARGO_MANIFEST_DIR>/models/<name>` (the mlxcel crate root is the repo root).
+fn repo_model_dir(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("models")
+        .join(name)
+}
+
+/// Build a scheduler that can batch a prefill window of up to four cold rows in
+/// one pass (`max_batch_prefill = 4`) and hold the whole window in the active
+/// batch while decoding (`max_batch_size = 4`).
+fn build_cohort_scheduler(
+    model: crate::LoadedModel,
+    tokenizer: MlxcelTokenizer,
+    config_eos: Vec<i32>,
+) -> BatchScheduler {
+    let (_req_tx, req_rx) = mpsc::channel();
+    BatchScheduler::with_config(
+        model,
+        tokenizer,
+        config_eos,
+        req_rx,
+        4,  // max_batch_size
+        64, // max_queue_depth
+        Arc::new(BatchMetrics::new()),
+        Arc::new(BatchObservability::new()),
+        512, // prefill_chunk_size > prompts so prefills run whole
+        false,
+        PreemptionPolicy::default(),
+        4, // max_batch_prefill
+        DecodeStorageBackend::Paged,
+    )
+}
+
+/// Build a greedy request bound to `seq_id` with the given prompt and optional
+/// adopted-prefix offset. The response receiver is returned and must be kept
+/// alive so streamed tokens can be collected.
+fn make_seq(
+    seq_id: SequenceId,
+    tokenizer: &MlxcelTokenizer,
+    prompt_tokens: Vec<i32>,
+    prefill_start_offset: usize,
+) -> (SequenceInfo, mpsc::Receiver<GenerateEvent>) {
+    let (tx, rx) = mpsc::channel();
+    let decode_state = StreamingDecodeState::new(tokenizer, &prompt_tokens);
+    let seq = SequenceInfo {
+        seq_id,
+        state: SequenceState::Queued,
+        prompt_tokens,
+        sampling: SamplingConfig::greedy(),
+        max_tokens: MAX_TOKENS,
+        eos_token_ids: Vec::new(),
+        priority: RequestPriority::Normal,
+        logprobs_config: Default::default(),
+        vlm_embeddings: None,
+        images: Vec::new(),
+        audio: Vec::new(),
+        generated_tokens: Vec::new(),
+        generated_text: String::new(),
+        decode_state,
+        prefill_offset: 0,
+        prefill_start_offset,
+        already_cached_tokens: prefill_start_offset,
+        response_tx: tx,
+        cancelled: Arc::new(AtomicBool::new(false)),
+        created_at: Instant::now(),
+        prefill_start: None,
+        first_token_time: None,
+        token_history: Vec::new(),
+        sampler_state: None,
+        merged_eos: Vec::new(),
+        thinking: crate::server::thinking_budget::ThinkingState::disabled(),
+        structured: None,
+    };
+    (seq, rx)
+}
+
+/// Decode `seq_id` for up to `DECODE_STEPS` steps (or until it finishes), then
+/// drain its response channel into the concatenated output text. Collecting
+/// from the channel is robust to an early stop: a finished sequence is removed
+/// from the active batch, but the text it streamed is still in the channel.
+fn run_and_collect(
+    sched: &mut BatchScheduler,
+    seq_id: SequenceId,
+    rx: &mpsc::Receiver<GenerateEvent>,
+) -> String {
+    let mut steps = 0;
+    while steps < DECODE_STEPS && sched.active_batch.get_mut(seq_id).is_some() {
+        sched.execute_decode_step(&[seq_id]);
+        steps += 1;
+    }
+    let mut text = String::new();
+    while let Ok(ev) = rx.try_recv() {
+        match ev {
+            GenerateEvent::Token(t) | GenerateEvent::TokenWithLogprobs(t, _) => text.push_str(&t),
+            _ => {}
+        }
+    }
+    text
+}
+
+/// Release a sequence's pool state if it is still active (a finished sequence
+/// has already released its caches).
+fn cleanup(sched: &mut BatchScheduler, seq_id: SequenceId) {
+    if sched.active_batch.get_mut(seq_id).is_some() {
+        sched.active_batch.remove(seq_id);
+        sched.release_sequence_caches(seq_id);
+    }
+}
+
+/// Prefill one cold request alone on the single-sequence path (the pre-cohort
+/// behavior) and return its decoded output text. Releases the sequence so the
+/// pool is clean afterward.
+fn reference_text(
+    sched: &mut BatchScheduler,
+    tokenizer: &MlxcelTokenizer,
+    prompt: &[i32],
+) -> String {
+    let id = sched
+        .allocate_sequence_state()
+        .expect("allocate reference sequence");
+    let (mut seq, rx) = make_seq(id, tokenizer, prompt.to_vec(), 0);
+    BatchScheduler::begin_prefill(&mut seq).expect("begin reference prefill");
+    sched.execute_full_prefill(seq);
+    let text = run_and_collect(sched, id, &rx);
+    cleanup(sched, id);
+    text
+}
+
+#[test]
+#[ignore = "loads qwen3-0.6b-4bit and runs real GPU forwards; run with --ignored"]
+fn mixed_window_cold_cohort_matches_single_prefill_qwen3() {
+    let _runtime = crate::initialize_runtime();
+    let dir = repo_model_dir(QWEN3_DIR);
+    if !dir.exists() {
+        eprintln!(
+            "Skipping {QWEN3_DIR}: model directory not found at {}.\n\
+             Fetch with: ./target/release/mlxcel download mlx-community/Qwen3-0.6B-4bit",
+            dir.display()
+        );
+        return;
+    }
+    let (model, sched_tokenizer) =
+        crate::load_model(&dir).unwrap_or_else(|e| panic!("load {QWEN3_DIR}: {e:?}"));
+    let seq_tokenizer = crate::tokenizer::load_tokenizer(&dir).expect("load tokenizer");
+    let config_eos = crate::read_eos_token_ids(&dir);
+    let mut sched = build_cohort_scheduler(model, sched_tokenizer, config_eos);
+
+    // ---- REFERENCES: each cold prompt prefilled alone (single-sequence). ----
+    let ref_a = reference_text(&mut sched, &seq_tokenizer, PROMPT_A);
+    let ref_b = reference_text(&mut sched, &seq_tokenizer, PROMPT_B);
+    assert!(!ref_a.is_empty(), "reference A produced no output");
+    assert!(!ref_b.is_empty(), "reference B produced no output");
+
+    // ---- MIXED WINDOW: [cold A, cold B, adopted C]. ----
+    // The planner forms a batched cohort {A, B} (two cold rows of different
+    // lengths) and a sequential cohort {C}. C carries a non-zero
+    // prefill_start_offset, so it is incompatible with the padded batched path
+    // and is routed to the offset-aware single-sequence path in both the new
+    // (cohort) and old (all-sequential) behavior. Its presence is what forces a
+    // genuine cohort split rather than an all-cold batch.
+    let id_a = sched.allocate_sequence_state().expect("alloc A");
+    let id_b = sched.allocate_sequence_state().expect("alloc B");
+    let id_c = sched.allocate_sequence_state().expect("alloc C");
+    let (seq_a, rx_a) = make_seq(id_a, &seq_tokenizer, PROMPT_A.to_vec(), 0);
+    let (seq_b, rx_b) = make_seq(id_b, &seq_tokenizer, PROMPT_B.to_vec(), 0);
+    let (seq_c, rx_c) = make_seq(id_c, &seq_tokenizer, PROMPT_C.to_vec(), 1);
+
+    sched.prefill_queue.enqueue(seq_a).expect("enqueue A");
+    sched.prefill_queue.enqueue(seq_b).expect("enqueue B");
+    sched.prefill_queue.enqueue(seq_c).expect("enqueue C");
+    assert_eq!(
+        sched.prefill_queue.len(),
+        3,
+        "window should hold three rows"
+    );
+
+    // One call splits the window: {A, B} batched, {C} sequential.
+    sched.execute_batched_prefill();
+    assert!(
+        sched.prefill_queue.is_empty(),
+        "the whole window must be drained by the cohort dispatch"
+    );
+
+    let got_a = run_and_collect(&mut sched, id_a, &rx_a);
+    let got_b = run_and_collect(&mut sched, id_b, &rx_b);
+    let got_c = run_and_collect(&mut sched, id_c, &rx_c);
+
+    assert_eq!(
+        got_a, ref_a,
+        "cold row A batched in a mixed window must decode identically to the single-prefill reference"
+    );
+    assert_eq!(
+        got_b, ref_b,
+        "cold row B batched in a mixed window must decode identically to the single-prefill reference"
+    );
+    assert!(
+        !got_c.is_empty(),
+        "the adopted-prefix cohort row must still be prefilled and decode output (split handled every cohort)"
+    );
+
+    cleanup(&mut sched, id_a);
+    cleanup(&mut sched, id_b);
+    cleanup(&mut sched, id_c);
+}

--- a/src/server/batch/scheduler_cohort_parity_tests.rs
+++ b/src/server/batch/scheduler_cohort_parity_tests.rs
@@ -12,19 +12,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Real-model parity tests for #332 batched-prefill cohort splitting.
+//! Real-model parity test for #332 batched-prefill cohort splitting.
 //!
 //! When a collected prefill window mixes cold text rows with an incompatible
 //! request (adopted prompt-cache prefix, VLM embeddings), the scheduler now
 //! splits the window into cohorts and runs the cold rows batched instead of
-//! falling the whole window back to sequential prefill. These tests confirm
-//! that the split does not change any request's decoded output versus the
-//! pre-cohort all-or-nothing sequential path: a cold row prefilled inside a
-//! batched cohort (alongside an incompatible sibling) must decode identically
-//! to the same row prefilled alone on the single-sequence path.
+//! falling the whole window back to sequential prefill. This test pins the
+//! actual correctness property of that split: removing the incompatible row
+//! from the window must not perturb the cold rows' batched prefill. Concretely,
+//! a cold row prefilled inside a cohort-split window (`[cold A, cold B, adopted
+//! C]`, which the planner splits into a batched `{A, B}` cohort plus a
+//! sequential `{C}` cohort) must decode byte-for-byte identically to the same
+//! row in an all-cold batched window of the same composition (`[cold A,
+//! cold B]`, where no split happens). The split only lifts C onto the
+//! offset-aware single-sequence path; it leaves `{A, B}`'s padded batched
+//! forward untouched, so the two must agree exactly.
 //!
-//! The tests load a real qwen3 checkpoint and run GPU forwards, so they are
-//! `#[ignore]` and soft-skip when the model directory is absent.
+//! It deliberately does NOT compare a batched (B > 1) row against a
+//! single-prefill (B = 1) reference. Padded batched prefill is not
+//! bitwise-identical to single-sequence prefill on Metal: the batched pass pads
+//! short rows up to the cohort's longest prompt and runs a wider matmul, so f16
+//! rounding differs and an early near-tie greedy token can flip and cascade.
+//! That is the documented #203 / #325 / #326 jitter class, not a correctness
+//! bug, so asserting byte-identity of a batched row against a single-prefill
+//! row would be the wrong invariant. The single-prefill values are still
+//! computed and printed as a diagnostic (so the jitter is visible under
+//! `--nocapture`), but they are never asserted.
+//!
+//! Behavior note: a cold row that previously fell back to *sequential* prefill
+//! (because its window held an incompatible sibling) now runs batched. Its
+//! greedy decode can therefore differ from the old sequential output by the
+//! same jitter class. That is the intended effect of #332, not a regression.
+//!
+//! The test loads a real qwen3 checkpoint and runs GPU forwards, so it is
+//! `#[ignore]` and soft-skips when the model directory is absent.
 //!
 //! Run with:
 //! ```text
@@ -214,9 +235,54 @@ fn reference_text(
     text
 }
 
+/// Enqueue a window of `(prompt, prefill_start_offset)` rows, run a single
+/// [`BatchScheduler::execute_batched_prefill`] (which classifies the rows,
+/// plans cohorts, and dispatches them), then decode each row in window order
+/// and return the per-row decoded text.
+///
+/// Each row is decoded on its own with `execute_decode_step(&[id])`, so the
+/// only batched stage is the prefill. That isolates cohort-split prefill
+/// behavior as the single variable under test: a row's decode trajectory is
+/// driven purely by its own post-prefill KV cache, never by a sibling. All
+/// sequences are released afterward so the pool is clean for the next window.
+fn run_window(
+    sched: &mut BatchScheduler,
+    tokenizer: &MlxcelTokenizer,
+    window: &[(&[i32], usize)],
+) -> Vec<String> {
+    let mut ids = Vec::with_capacity(window.len());
+    let mut rxs = Vec::with_capacity(window.len());
+    for &(prompt, offset) in window {
+        let id = sched
+            .allocate_sequence_state()
+            .expect("allocate window sequence");
+        let (seq, rx) = make_seq(id, tokenizer, prompt.to_vec(), offset);
+        sched
+            .prefill_queue
+            .enqueue(seq)
+            .expect("enqueue window sequence");
+        ids.push(id);
+        rxs.push(rx);
+    }
+    // One call drains the whole window, splitting it into cohorts.
+    sched.execute_batched_prefill();
+    assert!(
+        sched.prefill_queue.is_empty(),
+        "the whole window must be drained by the cohort dispatch"
+    );
+    let mut outputs = Vec::with_capacity(window.len());
+    for (idx, &id) in ids.iter().enumerate() {
+        outputs.push(run_and_collect(sched, id, &rxs[idx]));
+    }
+    for &id in &ids {
+        cleanup(sched, id);
+    }
+    outputs
+}
+
 #[test]
 #[ignore = "loads qwen3-0.6b-4bit and runs real GPU forwards; run with --ignored"]
-fn mixed_window_cold_cohort_matches_single_prefill_qwen3() {
+fn mixed_window_cold_cohort_matches_all_cold_batched_qwen3() {
     let _runtime = crate::initialize_runtime();
     let dir = repo_model_dir(QWEN3_DIR);
     if !dir.exists() {
@@ -233,60 +299,77 @@ fn mixed_window_cold_cohort_matches_single_prefill_qwen3() {
     let config_eos = crate::read_eos_token_ids(&dir);
     let mut sched = build_cohort_scheduler(model, sched_tokenizer, config_eos);
 
-    // ---- REFERENCES: each cold prompt prefilled alone (single-sequence). ----
+    // ---- DIAGNOSTIC reference: each cold prompt prefilled alone (B = 1). ----
+    // NOT a load-bearing comparison. Padded batched prefill (B > 1) is not
+    // bitwise-identical to single-sequence prefill (B = 1) on Metal, so a
+    // batched row's greedy decode can flip an early near-tie token versus the
+    // single-prefill output (the #203 / #325 / #326 jitter class). These values
+    // are printed only so the jitter is visible under --nocapture.
     let ref_a = reference_text(&mut sched, &seq_tokenizer, PROMPT_A);
     let ref_b = reference_text(&mut sched, &seq_tokenizer, PROMPT_B);
     assert!(!ref_a.is_empty(), "reference A produced no output");
     assert!(!ref_b.is_empty(), "reference B produced no output");
 
-    // ---- MIXED WINDOW: [cold A, cold B, adopted C]. ----
-    // The planner forms a batched cohort {A, B} (two cold rows of different
-    // lengths) and a sequential cohort {C}. C carries a non-zero
-    // prefill_start_offset, so it is incompatible with the padded batched path
-    // and is routed to the offset-aware single-sequence path in both the new
-    // (cohort) and old (all-sequential) behavior. Its presence is what forces a
-    // genuine cohort split rather than an all-cold batch.
-    let id_a = sched.allocate_sequence_state().expect("alloc A");
-    let id_b = sched.allocate_sequence_state().expect("alloc B");
-    let id_c = sched.allocate_sequence_state().expect("alloc C");
-    let (seq_a, rx_a) = make_seq(id_a, &seq_tokenizer, PROMPT_A.to_vec(), 0);
-    let (seq_b, rx_b) = make_seq(id_b, &seq_tokenizer, PROMPT_B.to_vec(), 0);
-    let (seq_c, rx_c) = make_seq(id_c, &seq_tokenizer, PROMPT_C.to_vec(), 1);
-
-    sched.prefill_queue.enqueue(seq_a).expect("enqueue A");
-    sched.prefill_queue.enqueue(seq_b).expect("enqueue B");
-    sched.prefill_queue.enqueue(seq_c).expect("enqueue C");
-    assert_eq!(
-        sched.prefill_queue.len(),
-        3,
-        "window should hold three rows"
-    );
-
-    // One call splits the window: {A, B} batched, {C} sequential.
-    sched.execute_batched_prefill();
+    // ---- CONTROL: all-cold [A, B] batched window (no incompatible row). ----
+    // Both rows are cold, so the planner forms a single BatchedCold {A, B}
+    // cohort and performs NO split. This is the correct reference for the
+    // cohort path: it pins what {A, B}'s padded batched prefill produces when
+    // there is no C in the window to split off.
+    let all_cold = run_window(&mut sched, &seq_tokenizer, &[(PROMPT_A, 0), (PROMPT_B, 0)]);
+    let allcold_a = &all_cold[0];
+    let allcold_b = &all_cold[1];
     assert!(
-        sched.prefill_queue.is_empty(),
-        "the whole window must be drained by the cohort dispatch"
+        !allcold_b.is_empty(),
+        "all-cold batched B produced no output"
     );
 
-    let got_a = run_and_collect(&mut sched, id_a, &rx_a);
-    let got_b = run_and_collect(&mut sched, id_b, &rx_b);
-    let got_c = run_and_collect(&mut sched, id_c, &rx_c);
+    // ---- SUBJECT: mixed [cold A, cold B, adopted C] window (the #332 split). ----
+    // C carries a non-zero prefill_start_offset (an adopted prompt-cache
+    // prefix), so it is incompatible with the padded batched path. The planner
+    // forms BatchedCold {A, B} + Sequential {C}: the split lifts C onto the
+    // offset-aware single-sequence path but must NOT change {A, B}'s batched
+    // forward at all (C is prefilled in a separate cohort after {A, B} and
+    // never shares their forward pass or caches).
+    let mixed = run_window(
+        &mut sched,
+        &seq_tokenizer,
+        &[(PROMPT_A, 0), (PROMPT_B, 0), (PROMPT_C, 1)],
+    );
+    let mixed_a = &mixed[0];
+    let mixed_b = &mixed[1];
+    let mixed_c = &mixed[2];
 
+    eprintln!("--- #332 cohort parity (qwen3-0.6b-4bit) ---");
+    eprintln!("single  B (B=1, diagnostic):  {ref_b:?}");
+    eprintln!("allcold B (B=2 batched):      {allcold_b:?}");
+    eprintln!("mixed   B (B=2 cohort split): {mixed_b:?}");
+    eprintln!("single  A (B=1, diagnostic):  {ref_a:?}");
+    eprintln!("allcold A (B=2 batched):      {allcold_a:?}");
+    eprintln!("mixed   A (B=2 cohort split): {mixed_a:?}");
+    if mixed_b != &ref_b {
+        eprintln!(
+            "note: batched B (B=2) differs from single B (B=1) -> #203 jitter class \
+             (expected; the cohort property is batched-vs-batched, asserted below)."
+        );
+    }
+
+    // ---- LOAD-BEARING #332 invariant: cohort split == all-cold batched. ----
+    // Removing the incompatible row C from the window must not perturb the cold
+    // rows' batched prefill, so a cohort-split cold row must decode byte-for-
+    // byte identically to the same row in an all-cold batched window of the
+    // same composition. This is the real correctness property of the split, and
+    // unlike a batched-vs-single comparison it is not subject to the #203
+    // jitter class (both sides run the identical B = 2 padded forward).
     assert_eq!(
-        got_a, ref_a,
-        "cold row A batched in a mixed window must decode identically to the single-prefill reference"
+        mixed_a, allcold_a,
+        "cold row A in a cohort-split window must decode identically to the all-cold batched window"
     );
     assert_eq!(
-        got_b, ref_b,
-        "cold row B batched in a mixed window must decode identically to the single-prefill reference"
+        mixed_b, allcold_b,
+        "cold row B in a cohort-split window must decode identically to the all-cold batched window"
     );
     assert!(
-        !got_c.is_empty(),
+        !mixed_c.is_empty(),
         "the adopted-prefix cohort row must still be prefilled and decode output (split handled every cohort)"
     );
-
-    cleanup(&mut sched, id_a);
-    cleanup(&mut sched, id_b);
-    cleanup(&mut sched, id_c);
 }

--- a/src/server/batch/scheduler_prompt_cache_tests.rs
+++ b/src/server/batch/scheduler_prompt_cache_tests.rs
@@ -325,16 +325,18 @@ fn sequence_info_fields_transport_cache_hit_metadata() {
 }
 
 // ---------------------------------------------------------------------------
-// Batched prefill falls back to sequential when any adopted prefix is present
+// Batched prefill routes adopted-prefix rows to the sequential cohort
 // ---------------------------------------------------------------------------
 
 #[test]
 fn batched_prefill_path_detects_adopted_sequences() {
-    // The scheduler's `execute_batched_prefill` short-circuits to
-    // sequential prefill when *any* sequence in the batch has
-    // `prefill_start_offset > 0`. We assert the detection predicate here
-    // so any future refactor of the batched path can't regress the
-    // behavior silently.
+    // The scheduler's `execute_batched_prefill` classifies a row with
+    // `prefill_start_offset > 0` as not-cold, so #332 cohort splitting routes
+    // it to the offset-aware sequential path (instead of the padded batched
+    // path) while cold siblings still batch. We assert the detection predicate
+    // that drives that classification here so a future refactor of the batched
+    // path can't regress it silently. The full cohort plan (including order and
+    // offset isolation) is covered in `prefill_cohort::tests`.
     let mut offsets = [0_usize; 3];
     assert!(
         !offsets.iter().any(|&o| o > 0),


### PR DESCRIPTION
## Summary

Closes #332. When a collected prefill window held one incompatible request (unsupported model, any VLM embeddings, any adopted prompt-cache prefix, or length-incompatible rows on equal-length-only models), the batch scheduler fell the whole window back to sequential prefill, wasting eligible concurrent work. This splits the window into compatible cohorts so cold text rows still run batched while incompatible rows take their existing offset-aware handling.

## What changed

- New `src/server/batch/prefill_cohort.rs`: pure `plan_prefill_cohorts` planner that partitions a priority-ordered window into `BatchedCold` and `Sequential` cohorts, plus its types and unit tests. Order-preserving, offset-isolating, and contiguity-respecting by construction.
- `src/server/batch/scheduler.rs`: `execute_batched_prefill` now drains the window, classifies each row (cold = no VLM/custom embeddings AND zero adopted-prefix offset), plans cohorts, and dispatches them in window order. The padded batched forward pass moved verbatim into a new `run_padded_batched_prefill` helper. Cold cohorts run batched even when the window contains incompatible rows; adopted-prefix and embedding-bearing rows take `execute_full_prefill`.
- `src/server/batch/mod.rs`: declares the `prefill_cohort` module.
- `src/server/batch/scheduler_cohort_parity_tests.rs`: new `#[ignore]` real-model qwen3 parity test.
- `src/server/batch/scheduler_prompt_cache_tests.rs`: refreshed a now-stale comment about the old whole-window fallback.

## Correctness (cache offsets)

A row is classified cold only when it has no embeddings AND `prefill_start_offset == 0`, which is exactly the zero-offset precondition the padded batched path assumes. The planner guarantees a `BatchedCold` cohort contains only cold rows, so an adopted prefix can never be folded into a batch and have its KV resumed at the wrong offset; it always takes the offset-aware `execute_full_prefill`. The refactor also routes the single-request and equal-length-only paths through `begin_prefill`, tightening two latent paths that previously reached `execute_full_prefill` in the `Queued` state and would have failed the `Queued` to `Decoding` transition.

## Fairness

Cohorts dispatch in window order and the queue dequeues in priority order, so concatenating cohort members reproduces window order exactly (asserted by a unit test). Cold rows batch only where contiguous, so the split never hoists a lower-priority request ahead of a higher-priority one.

## Scope

Batched-prefill support is unchanged (qwen3 / llama3 / qwen3.5). No new dense families were added; that expansion is deferred until cohort splitting is measured, per the issue.

## Test plan

- [x] `cargo test --release -p mlxcel --lib --features metal,accelerate prefill_cohort::` (11 pure planner tests pass: order preservation, offset isolation, all-cold no-regression, all-incompatible, equal-length-only, contiguity).
- [x] `cargo check -p mlxcel --lib --tests` and `cargo clippy -p mlxcel --lib --tests -- -D warnings` clean.
- [ ] Orchestrator: full release build + `scheduler_cohort_parity_tests` against real qwen3 (`--ignored`), plus a mixed cold + prompt-cache-hit synthetic queue measuring prefill tok/s, TTFT, and head-of-line blocking vs the all-or-nothing fallback.
