### PR TITLE
docs(benchmarks): record GB10/CUDA fused QK-norm decode result (#326)

### DIFF
--- a/docs/benchmark_results/fused-qk-norm-decode-gb10.md
+++ b/docs/benchmark_results/fused-qk-norm-decode-gb10.md
@@ -1,0 +1,87 @@
+# Fused QKV+QK-norm+RoPE decode path on GB10 (CUDA)
+
+Validation of the generalized fused decode primitive (#326, merged in #341) on
+**NVIDIA GB10 / CUDA**. The primitive `FusedQKVLinear::forward_split_norm_rope_quantized`
+collapses the Qwen3 / Qwen3-MoE decode QKV projection, split, Q/K `RMSNorm`, and
+RoPE into one C++ call. It is **default-OFF** (opt-in via `MLXCEL_FUSED_QK_NORM=1`)
+because it cuts Rust<->C++ FFI crossings rather than MLX op count, and on M1 Ultra
+it already measured slower than the graph path. The merge left one open question:
+whether CUDA, with different op-dispatch cost, would be the per-backend win that
+justifies enabling it. This benchmark answers that question. It does not.
+
+## Environment
+
+| Item | Value |
+|------|-------|
+| **Hardware** | NVIDIA GB10 (DGX Spark), 122 GB unified LPDDR5x |
+| **OS** | Linux aarch64, kernel 6.17 |
+| **Backend** | CUDA 13.0, SM 12.1 |
+| **Build** | `MLX_CUDA_ARCHITECTURES=121 cargo build --release --features cuda` |
+| **mlxcel version** | 0.3.1 (HEAD includes #341) |
+| **MLX pin** | `a6ec7123` |
+| **Harness** | same-process `mlxcel-bench-decode`, warm prefill, `--no-chat-template` |
+| **Prompt** | narrative continuation: `"Once upon a time, in a small village nestled between two great mountains, there lived an old clockmaker who"` |
+| **Tokens** | 256 measured, 32 warmup |
+| **Method** | best-of-3, `MLXCEL_FUSED_QK_NORM=1` (fused) vs `=0` (graph / split) on the same binary |
+
+The continuation prompt with 256 tokens avoids the early-EOS short generations
+(9-34 tokens) that the chat-template prompt produces, so the decode rate is
+measured over enough steps to resolve the small per-op effect. The fused kernel
+JIT-compiles on first use: the first fused run of qwen3-0.6b read 248 tok/s cold,
+then 361-373 warm; best-of-3 reports the warm figure.
+
+## Decode throughput (tok/s, best-of-3)
+
+| Model | Role | fused ON | graph OFF | fused / graph |
+|-------|------|---------:|----------:|--------------:|
+| qwen3-0.6b-4bit | wired dense | 372.8 | 387.2 | 0.96x (-3.7%) |
+| qwen3-8b-4bit | wired dense | 52.6 | 52.4 | 1.00x (+0.4%) |
+| qwen3-30b-a3b-4bit | wired MoE | 83.8 | 90.7 | 0.92x (-7.6%) |
+| apertus-8b-2509-4bit | not wired (QK-norm) | 43.0 | 43.2 | 1.00x (flag inert) |
+| llama-3.1-8b-4bit | regression guard (no QK-norm) | 48.0 | 48.2 | 1.00x (flag inert) |
+
+The fused path is slower on every wired model, worst on the 48-layer MoE where
+the per-layer reorder accumulates. The two control models confirm the harness:
+apertus has Q/K norms but is not wired to the primitive, and llama has no QK-norm
+at all, so on both the flag is inert and the on/off delta is within run noise.
+That is the "regression guard shows no change" check: the change does not touch
+the common attention path.
+
+## Why fusion does not help here
+
+`forward_split_norm_rope_quantized` is not a single custom kernel. It assembles
+the same MLX ops as the graph path
+(`quantized_matmul -> slice -> reshape -> transpose -> fast::rms_norm -> fast::rope`)
+inside one C++ call. The GPU work is identical; only two things change: the
+Rust<->C++ FFI crossing count (about 14 down to 1) and the norm/transpose order
+(the fused path norms after the head transpose). Decode is GPU/bandwidth-bound
+(the MoE decode-gap study measured roughly 95% GPU-bound, not FFI/dispatch), so
+collapsing FFI calls buys nothing and norming the transposed layout costs a
+little. This is the same outcome as M1 Ultra (1-3.4% slower) and is consistent
+with M5 Max, which already prefers the split decode path for Gemma3n and where
+the Turbo4 kernel measured 2.0x slower than its graph fallback.
+
+## Correctness and determinism
+
+- **RMS < 5e-3** vs the graph reference is covered by the
+  `fused_qkv_split_norm_rope_standard_rmsnorm_matches_graph` unit test (the
+  reduction is over the transpose-invariant `head_dim` axis).
+- **Greedy temp-0 over 256 tokens:** qwen3-8b stays byte-identical to the graph
+  path; qwen3-0.6b and qwen3-30b diverge at a near-tie argmax after about 64-140
+  tokens into coherent, equal-quality continuations (`"the"` vs `"these"`,
+  `"world"` vs `"land"`).
+- **That divergence is not introduced by the fused path.** On CUDA the graph
+  path is itself non-deterministic run-to-run at temp-0: two graph runs of
+  qwen3-0.6b diverge after about 130 tokens, from non-deterministic GPU
+  floating-point reduction order. The fused path is deterministic run-to-run, so
+  it is more stable than the graph baseline and its divergence stays inside the
+  graph's own run-to-run envelope. The parity result is therefore documented
+  jitter, not a correctness regression.
+
+## Conclusion
+
+CUDA is not the per-backend win the fused QK-norm primitive was waiting for: on
+GB10 it is 3.7-7.6% slower on the wired models with no upside. The primitive
+stays default-OFF and ships as the shared building block for the deferred QK-norm
+families (#326). The graph / split path remains the decode default on every
+measured backend (M1 Ultra, M5 Max, GB10 / CUDA).

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -527,15 +527,23 @@ impl FusedQkNorm for GemmaRMSNorm {
 
 /// Whether the fused single-token decode QK-norm+RoPE kernel (#326) is enabled.
 ///
-/// Default-OFF (opt-in). The kernel is numerically correct (decode output is
-/// byte-identical to the graph path on Qwen3 / Qwen3-MoE; the reduction is over
-/// the transpose-invariant head_dim axis), but it cuts Rust<->C++ FFI crossings
-/// rather than MLX op count, so on M1 Ultra (fast FFI) it measured ~1-3.4%
+/// Default-OFF (opt-in). The primitive matches the graph path within RMS < 5e-3
+/// (the reduction is over the transpose-invariant head_dim axis), but it cuts
+/// Rust<->C++ FFI crossings rather than MLX op count, so it does not speed up the
+/// GPU/bandwidth-bound decode loop. On M1 Ultra (fast FFI) it measured ~1-3.4%
 /// SLOWER than the graph path (qwen3-0.6b 275 vs 284, qwen3-8b 82.3 vs 83.2
-/// tok/s). It ships as a reusable shared primitive for the deferred QK-norm
-/// families and is gated off by default pending a per-backend win (e.g. CUDA,
-/// where op-dispatch/FFI cost differs), mirroring the opt-in treatment of the
-/// neutral fused-relu2 MoE path (`MLXCEL_FUSED_MOE_RELU2`).
+/// tok/s). CUDA was the open per-backend question; on GB10 (SM 12.1) it is also
+/// slower (qwen3-0.6b 0.96x, qwen3-8b ~1.0x, qwen3-30b-a3b 0.92x fused/graph;
+/// see docs/benchmark_results/fused-qk-norm-decode-gb10.md). It ships as a
+/// reusable shared primitive for the deferred QK-norm families and stays gated
+/// off, mirroring the opt-in treatment of the neutral fused-relu2 MoE path
+/// (`MLXCEL_FUSED_MOE_RELU2`).
+///
+/// Greedy temp-0 is not byte-identical to the graph path over long generation:
+/// the two numerical paths can diverge at a near-tie argmax. This is not a
+/// regression. On CUDA the graph path is itself non-deterministic run-to-run
+/// (GPU FP-reduction order), while the fused path is deterministic, so its
+/// output stays inside the graph baseline's own run-to-run envelope.
 ///
 /// Set `MLXCEL_FUSED_QK_NORM=1` (also `true`/`on`/`yes`, case-insensitive,
 /// trimmed) to opt into the fused path in Qwen3 and Qwen3-MoE decode.


### PR DESCRIPTION
## Summary

Completes the deferred validation for #326 (generic fused QKV+RMSNorm+RoPE, merged in #341) by running the decode benchmark on the one backend it was never measured on: GB10 / CUDA.

The fused QK-norm decode primitive ships **default-OFF**. Its doc comment said it was gated off "pending a per-backend win (e.g. CUDA, where op-dispatch/FFI cost differs)". This PR answers that open question.

## Result: CUDA is not a per-backend win

Same binary, `MLXCEL_FUSED_QK_NORM=1` (fused) vs `=0` (graph/split), best-of-3, GB10 SM 12.1, `--no-chat-template` + 256 tokens so decode rate resolves the small per-op effect.

| Model | Role | fused ON | graph OFF | fused/graph |
|-------|------|---------:|----------:|------------:|
| qwen3-0.6b-4bit | wired dense | 372.8 | 387.2 | 0.96x |
| qwen3-8b-4bit | wired dense | 52.6 | 52.4 | 1.00x |
| qwen3-30b-a3b-4bit | wired MoE | 83.8 | 90.7 | 0.92x |
| apertus-8b-2509-4bit | not wired | 43.0 | 43.2 | flag inert |
| llama-3.1-8b-4bit | regression guard | 48.0 | 48.2 | flag inert |

Slower on every wired model, worst on the 48-layer MoE. The primitive assembles the same MLX ops as the graph path in one C++ call, so the GPU work is identical; it only cuts FFI crossings and norms after the head transpose. Decode is GPU/bandwidth-bound, so that buys nothing and the reorder costs a little. Same direction as M1 Ultra (1-3.4% slower) and consistent with M5 Max preferring the split path.

The two control models (apertus is QK-norm but not wired; llama has no QK-norm) show the flag is inert: the regression-guard check that common attention is untouched.

## Correctness / determinism

- RMS < 5e-3 vs graph reference: covered by the existing `fused_qkv_split_norm_rope_standard_rmsnorm_matches_graph` unit test.
- Greedy temp-0 over 256 tok: qwen3-8b byte-identical; qwen3-0.6b/30b diverge at a near-tie argmax into coherent equal-quality text. Not a fused-path regression: on CUDA the graph path is itself non-deterministic run-to-run, while the fused path is deterministic, so its divergence stays inside the graph baseline's own envelope.

## Changes

- New `docs/benchmark_results/fused-qk-norm-decode-gb10.md` (method, table, determinism analysis).
- Correct the `fused_qk_norm_enabled` doc comment: drop the stale "byte-identical" claim and the "pending a per-backend win (e.g. CUDA)" note, record the CUDA numbers.

No code behavior change. The flag stays default-OFF; the graph/split path remains the decode default on every measured backend (M1 Ultra, M5 Max, GB10/CUDA).