### PR TITLE
fix(server): surface reasoning_content on non-streaming chat

### DIFF
--- a/docs/block-diffusion.md
+++ b/docs/block-diffusion.md
@@ -123,7 +123,7 @@ Image input follows the standard OpenAI `image_url` content part format. Request
 The checkpoint is a thinking-channel model. The assistant fills a `reasoning_content` channel before writing the visible reply. A few practical consequences:
 
 - **Give requests enough `max_tokens`.** With a budget of 64 tokens a simple question may produce only reasoning, leaving `content` empty with `finish_reason: "length"`. A budget of 256 produces the full answer for most short prompts.
-- **Non-streaming responses omit reasoning.** The server's existing convention is to strip `reasoning_content` from non-streaming chat completions. Streaming responses carry it as `delta.reasoning_content`.
+- **Reasoning is surfaced on both paths.** Streaming responses carry it as `delta.reasoning_content`; non-streaming `/v1/chat/completions` responses include a `reasoning_content` field on the assistant message (present only when the model produced reasoning, omitted otherwise).
 - **`/v1/completions` works but raw prompts degrade.** The endpoint accepts un-templated text mechanically, but the model depends on its chat structure, so output quality degrades significantly. Prefer `/v1/chat/completions`.
 - **Cancellation resolution.** A cancelled request is aborted within at most one denoising step, not instantaneously.
 

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -85,6 +85,28 @@ Audio/video capability is model-specific. The server request types include
 must advertise support for the corresponding modality. Video frame extraction
 uses the system `ffmpeg`/`ffprobe` binaries at runtime.
 
+### Thinking default for `gemma4_unified`
+
+Gemma 4 Unified (`gemma4_unified`) ships `<|channel>` / `<channel|>` thinking
+markers in its tokenizer, so the server defaults `enable_thinking=true` for this
+family on startup, mirroring [ml-explore/mlx-lm#1114](https://github.com/ml-explore/mlx-lm).
+With thinking on, the model writes an internal scratchpad before the visible
+reply, so simple prompts spend more of the budget on reasoning than on the
+answer. A one-sentence answer can take roughly 275 completion tokens, and a
+default `max_tokens` of 64 to 80 may return an empty `content` with
+`finish_reason` of `length` because the whole budget went to thinking. Set
+`max_tokens` to at least 512 for this family, and higher for multi-sentence
+answers.
+
+The scratchpad is no longer dropped: it is surfaced as `reasoning_content` on
+both streaming responses (`delta.reasoning_content`) and non-streaming responses
+(a `reasoning_content` field on the assistant message, present only when the
+model produced reasoning). This applies to every thinking family, including
+Qwen-style `<think>` models. To turn thinking off, pass
+`chat_template_kwargs={"enable_thinking": false}` per request, or set the server
+default via `--chat-template-kwargs` or `LLAMA_ARG_CHAT_TEMPLATE_KWARGS`. A
+per-request value always wins over the server default.
+
 ## Quantization formats
 
 | Format | Status | Notes |

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -440,6 +440,15 @@ async fn non_stream_chat_completion(
 
     let cached_tokens = result.cached_tokens;
 
+    // Surface the thinking scratchpad as `reasoning_content`. This is additive:
+    // the `content` computation below (strip_unclosed_primed_thinking /
+    // clean_structural_tokens / tool-call parsing) is unchanged. Reusing the
+    // streaming `StreamFilter` here means streaming and non-streaming responses
+    // split reasoning from content identically. `None` for non-thinking models
+    // leaves the field absent, closing the dropped-reasoning gap for every
+    // thinking family at once (Qwen `<think>`, Gemma 4 `<|channel>`).
+    let reasoning = extract_reasoning_content(&result.text, primed_open_thinking);
+
     // Try to parse tool calls from the output
     if tool_calls::should_parse_tool_calls(&request) {
         let tools = request.tools.as_deref();
@@ -463,7 +472,8 @@ async fn non_stream_chat_completion(
                         result.completion_tokens,
                         logprobs,
                     )
-                    .with_cached_tokens(cached_tokens, prompt_cache_enabled),
+                    .with_cached_tokens(cached_tokens, prompt_cache_enabled)
+                    .with_reasoning_content(reasoning.clone()),
                 ));
             }
         }
@@ -483,7 +493,8 @@ async fn non_stream_chat_completion(
                 Some(result.finish_reason),
                 logprobs,
             )
-            .with_cached_tokens(cached_tokens, prompt_cache_enabled),
+            .with_cached_tokens(cached_tokens, prompt_cache_enabled)
+            .with_reasoning_content(reasoning.clone()),
         ));
     }
 
@@ -506,7 +517,8 @@ async fn non_stream_chat_completion(
             Some(result.finish_reason),
             logprobs,
         )
-        .with_cached_tokens(cached_tokens, prompt_cache_enabled),
+        .with_cached_tokens(cached_tokens, prompt_cache_enabled)
+        .with_reasoning_content(reasoning),
     ))
 }
 
@@ -962,6 +974,48 @@ fn strip_unclosed_primed_thinking(content: String, raw_output: &str, primed: boo
     String::new()
 }
 
+/// Extract the reasoning / thinking scratchpad from a completed generation by
+/// replaying the raw text through the same [`StreamFilter`] the streaming path
+/// uses (`stream_chat_completion` builds the identical filter at the SSE
+/// construction site). Reusing the filter is what guarantees streaming and
+/// non-streaming surface the same `reasoning_content`: the filter's state
+/// machine is deterministic over the concatenated input, so feeding the whole
+/// string in one `feed()` accumulates the same reasoning/content split as
+/// feeding it token-by-token (the parity is locked by a unit test).
+///
+/// `primed_open_thinking` selects the filter's start state. A prompt that
+/// primed an open thinking block (`<think>\n` for Qwen-style, or
+/// `<|channel>thought\n` for Gemma 4 `enable_thinking=true`) starts the filter
+/// inside `Thinking` so the leading generated tokens route to reasoning even
+/// though the opening marker lives in the prompt, not the output. This mirrors
+/// the non-streaming content path in [`strip_unclosed_primed_thinking`]: when
+/// the whole window is unclosed thinking, all of it becomes `reasoning` and the
+/// user-facing `content` is empty.
+///
+/// Returns `Some(reasoning)` when any reasoning text was captured, `None`
+/// otherwise (so the response omits `reasoning_content` for non-thinking
+/// models). Tool-call blocks are suppressed by the filter and never leak into
+/// reasoning; they are materialized by the parser path instead.
+fn extract_reasoning_content(raw_text: &str, primed_open_thinking: bool) -> Option<String> {
+    let mut filter = if primed_open_thinking {
+        StreamFilter::new_primed_open_thinking()
+    } else {
+        StreamFilter::new()
+    };
+    let mut reasoning = String::new();
+    if let Some(r) = filter.feed(raw_text).reasoning {
+        reasoning.push_str(&r);
+    }
+    if let Some(r) = filter.flush().reasoning {
+        reasoning.push_str(&r);
+    }
+    if reasoning.is_empty() {
+        None
+    } else {
+        Some(reasoning)
+    }
+}
+
 /// Build ServerGenerateOptions using request params with server config as defaults
 pub(crate) fn build_generate_options(
     params: &SamplingParams,
@@ -1105,6 +1159,134 @@ mod tests {
             strip_unclosed_primed_thinking(content.clone(), raw, false),
             content
         );
+    }
+
+    // -- extract_reasoning_content (non-streaming reasoning surface) --
+
+    #[test]
+    fn extract_reasoning_qwen_think_block() {
+        // Qwen-style: a closed <think>…</think> block before the answer. The
+        // reasoning is captured; the answer stays out of reasoning.
+        let raw = "<think>reasoning</think>the answer";
+        assert_eq!(
+            extract_reasoning_content(raw, false),
+            Some("reasoning".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_reasoning_qwen_primed_open() {
+        // enable_thinking=true primes `<think>\n` in the prompt, so the raw
+        // output starts mid-think with no opening marker. The filter must
+        // start in Thinking and route the leading tokens to reasoning until
+        // the close marker.
+        let raw = "reasoning</think>the answer";
+        assert_eq!(
+            extract_reasoning_content(raw, true),
+            Some("reasoning".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_reasoning_gemma4_channel_block() {
+        // Gemma 4: a full <|channel>…<channel|> block before the answer.
+        let raw = "<|channel>thought\ndeliberating<channel|>the answer";
+        assert_eq!(
+            extract_reasoning_content(raw, false),
+            Some("thought\ndeliberating".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_reasoning_gemma4_primed_all_thinking() {
+        // Gemma 4 enable_thinking=true primes `<|channel>thought\n`; if the
+        // model fills the whole window without ever emitting `<channel|>`, the
+        // entire generation is reasoning and the user-facing content is empty.
+        // Mirrors the content side (strip_unclosed_primed_thinking ->
+        // String::new()) and the parser's all-thinking branch.
+        let raw = "still deliberating about hash tables with no close marker";
+        assert_eq!(
+            extract_reasoning_content(raw, true),
+            Some("still deliberating about hash tables with no close marker".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_reasoning_none_for_plain_content() {
+        // A non-thinking model (no markers, not primed) yields no reasoning,
+        // so the response omits `reasoning_content`.
+        assert_eq!(
+            extract_reasoning_content("just a normal answer", false),
+            None
+        );
+    }
+
+    // -- streaming / non-streaming parity ---------------------------
+    //
+    // The non-streaming extractor feeds the whole generated string through the
+    // same StreamFilter the streaming path feeds token-by-token. This locks
+    // the equivalence: the accumulated (content, reasoning) split must be
+    // identical regardless of how the input is fragmented.
+
+    fn absorb(
+        out: crate::server::tool_calls::stream_filter::FilterOutput,
+        content: &mut String,
+        reasoning: &mut String,
+    ) {
+        if let Some(c) = out.content {
+            content.push_str(&c);
+        }
+        if let Some(r) = out.reasoning {
+            reasoning.push_str(&r);
+        }
+    }
+
+    fn split_whole(text: &str, primed: bool) -> (String, String) {
+        let mut f = if primed {
+            StreamFilter::new_primed_open_thinking()
+        } else {
+            StreamFilter::new()
+        };
+        let (mut content, mut reasoning) = (String::new(), String::new());
+        absorb(f.feed(text), &mut content, &mut reasoning);
+        absorb(f.flush(), &mut content, &mut reasoning);
+        (content, reasoning)
+    }
+
+    fn split_chunked(text: &str, primed: bool) -> (String, String) {
+        let mut f = if primed {
+            StreamFilter::new_primed_open_thinking()
+        } else {
+            StreamFilter::new()
+        };
+        let (mut content, mut reasoning) = (String::new(), String::new());
+        let mut buf = [0u8; 4];
+        for ch in text.chars() {
+            absorb(
+                f.feed(ch.encode_utf8(&mut buf)),
+                &mut content,
+                &mut reasoning,
+            );
+        }
+        absorb(f.flush(), &mut content, &mut reasoning);
+        (content, reasoning)
+    }
+
+    #[test]
+    fn reasoning_split_identical_whole_vs_chunked() {
+        let samples = [
+            ("<think>reasoning here</think>the answer", false),
+            ("<|channel>thought\ndeliberate<channel|>final answer", false),
+            ("still reasoning</think>then content", true),
+            ("unclosed thinking forever", true),
+        ];
+        for (text, primed) in samples {
+            assert_eq!(
+                split_whole(text, primed),
+                split_chunked(text, primed),
+                "whole-vs-chunked split must match for {text:?} (primed={primed})"
+            );
+        }
     }
 
     // -- video_url block detection ---------------------------

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -39,27 +39,27 @@ use crate::server::types::request::Tool;
 ///
 /// Used by: tool_calls::parser
 fn strip_thinking(text: &str) -> String {
-    // Prompt-primed Gemma 4: strip everything up to (and including) the first
-    // `<channel|>` when no opening `<|channel>` precedes it. Runs before the
-    // balanced-pair pass so subsequent `<|channel>...<channel|>` blocks (if
-    // any) still get handled uniformly.
-    let mut result = {
-        const CLOSE: &str = "<channel|>";
-        const OPEN: &str = "<|channel>";
-        match text.find(CLOSE) {
-            Some(close_pos) => {
-                let before_close = &text[..close_pos];
-                if before_close.contains(OPEN) {
-                    text.to_string()
-                } else {
-                    text[close_pos + CLOSE.len()..].to_string()
-                }
-            }
-            None => text.to_string(),
-        }
-    };
-
+    // (open, close) marker pairs by family: Qwen-style `<think>...</think>`
+    // and Gemma 4 `<|channel>...<channel|>`.
     let pairs: &[(&str, &str)] = &[("<think>", "</think>"), ("<|channel>", "<channel|>")];
+
+    // Prompt-primed pass: when a close marker appears with no opening marker
+    // before it, the generation prompt primed the open (Gemma 4
+    // `<|channel>thought\n` or a Qwen-style `<think>\n`), so the model output
+    // starts inside the block and carries only the close. Strip everything up
+    // to and including that first bare close, for both families. Runs before
+    // the balanced-pair pass so any later `open...close` blocks still get
+    // handled uniformly, and so a primed `</think>` close is stripped on the
+    // non-streaming path the same way `/v1/responses`, `/v1/anthropic`, and the
+    // streaming filter already handle it.
+    let mut result = text.to_string();
+    for &(open, close) in pairs {
+        if let Some(close_pos) = result.find(close)
+            && !result[..close_pos].contains(open)
+        {
+            result = result[close_pos + close.len()..].to_string();
+        }
+    }
     for &(open, close) in pairs {
         let mut new_result = String::with_capacity(result.len());
         let mut remaining = result.as_str();
@@ -402,6 +402,25 @@ mod tests {
         let input = "<think>think block</think><|channel>thought\nchannel block<channel|>final";
         let result = strip_thinking(input);
         assert_eq!(result, "final");
+    }
+
+    #[test]
+    fn strip_thinking_primed_qwen_close_only() {
+        // Prompt-primed `<think>\n`: the model output carries only the closing
+        // `</think>` (no opening `<think>`), so the close-only block must be
+        // stripped the same way the primed Gemma 4 `<channel|>` case is. This
+        // matches the responses/anthropic split and chat's streaming filter.
+        let input = "reasoning text</think>\n\nHello!";
+        let result = strip_thinking(input);
+        assert_eq!(result, "\n\nHello!");
+    }
+
+    #[test]
+    fn clean_structural_tokens_primed_qwen_close_only() {
+        // The full non-streaming content path: a primed `<think>` close-only
+        // output yields the clean answer, not the leaked reasoning + marker.
+        let cleaned = clean_structural_tokens("reasoning text</think>\n\nHello!");
+        assert_eq!(cleaned, "Hello!");
     }
 
     // -- Gemma 4 full-path parse tests --

--- a/src/server/types/response.rs
+++ b/src/server/types/response.rs
@@ -113,6 +113,14 @@ pub struct ChatChoice {
 pub struct ChatMessage {
     pub role: String,
     pub content: Option<String>,
+    /// Reasoning / thinking scratchpad surfaced for thinking models (Qwen-style
+    /// `<think>…</think>`, Gemma 4 `<|channel>thought…<channel|>`). Present only
+    /// when the model produced reasoning; omitted otherwise so non-thinking
+    /// responses keep the existing wire shape. Mirrors the OpenAI / vLLM
+    /// `reasoning_content` convention and matches the streaming path's
+    /// `delta.reasoning_content`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
     /// Tool calls made by the assistant (present when finish_reason is "tool_calls")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCallResponse>>,
@@ -191,6 +199,7 @@ impl ChatCompletionResponse {
                 message: ChatMessage {
                     role: "assistant".to_string(),
                     content: Some(content),
+                    reasoning_content: None,
                     tool_calls: None,
                 },
                 finish_reason,
@@ -237,6 +246,7 @@ impl ChatCompletionResponse {
                 message: ChatMessage {
                     role: "assistant".to_string(),
                     content: message_content,
+                    reasoning_content: None,
                     tool_calls: Some(tool_calls),
                 },
                 finish_reason: Some("tool_calls".to_string()),
@@ -265,6 +275,23 @@ impl ChatCompletionResponse {
             self.usage.prompt_tokens_details = Some(PromptTokensDetails {
                 cached_tokens: cached_tokens as u64,
             });
+        }
+        self
+    }
+
+    /// Attach reasoning / thinking scratchpad text to the first choice's
+    /// message as `reasoning_content`. `None` leaves the field absent (it is
+    /// `#[serde(skip_serializing_if = "Option::is_none")]`), so non-thinking
+    /// responses keep the existing wire shape. This is the non-streaming
+    /// counterpart to the streaming `delta.reasoning_content` chunks; both are
+    /// derived from the same `StreamFilter` so the two endpoints surface
+    /// identical reasoning. Chaining mirrors `with_cached_tokens`.
+    ///
+    /// Used by: chat.rs (non-streaming path)
+    #[must_use]
+    pub fn with_reasoning_content(mut self, reasoning: Option<String>) -> Self {
+        if let Some(choice) = self.choices.first_mut() {
+            choice.message.reasoning_content = reasoning;
         }
         self
     }
@@ -611,6 +638,57 @@ mod tests {
 
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["usage"]["prompt_tokens_details"]["cached_tokens"], 0);
+    }
+
+    // -- reasoning_content (thinking-scratchpad surface) --------
+
+    /// A plain response (no reasoning) must omit `reasoning_content` so the
+    /// wire shape is unchanged for non-thinking models.
+    #[test]
+    fn reasoning_content_absent_when_none() {
+        let resp = ChatCompletionResponse::new(
+            "id".to_string(),
+            "model".to_string(),
+            "the answer".to_string(),
+            10,
+            5,
+            Some("stop".to_string()),
+        )
+        .with_reasoning_content(None);
+
+        let json = serde_json::to_value(&resp).unwrap();
+        let message = &json["choices"][0]["message"];
+        assert!(
+            !message
+                .as_object()
+                .unwrap()
+                .contains_key("reasoning_content"),
+            "reasoning_content must be absent when None, got: {message}"
+        );
+        assert_eq!(message["content"], "the answer");
+    }
+
+    /// When reasoning is present, `with_reasoning_content` must surface it on
+    /// the first choice's message as `reasoning_content`.
+    #[test]
+    fn reasoning_content_present_when_some() {
+        let resp = ChatCompletionResponse::new(
+            "id".to_string(),
+            "model".to_string(),
+            "the answer".to_string(),
+            10,
+            5,
+            Some("stop".to_string()),
+        )
+        .with_reasoning_content(Some("let me think about hash tables".to_string()));
+
+        let json = serde_json::to_value(&resp).unwrap();
+        let message = &json["choices"][0]["message"];
+        assert_eq!(
+            message["reasoning_content"],
+            "let me think about hash tables"
+        );
+        assert_eq!(message["content"], "the answer");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`gemma-4-12b-it` (`model_type: gemma4_unified`) carries the `<|channel>` / `<channel|>` thinking markers, so on startup the server resolves a think-marker pair and defaults the `enable_thinking` chat-template kwarg to `true`, mirroring ml-explore/mlx-lm#1114. Per the maintainer decision this default stays as-is: the marker detection in `src/tokenizer/mod.rs` and `set_default_enable_thinking` in `src/server/startup.rs` are untouched. The real bug is that the non-streaming `/v1/chat/completions` response silently discarded the thinking scratchpad, so a verbose thinking model looked like it returned an empty or truncated answer at a normal `max_tokens`.

This surfaces the reasoning as `reasoning_content` on the non-streaming response, which closes the gap for every thinking family at once (qwen3 `<think>` and gemma4 `<|channel>`), and documents the thinking default plus a recommended higher `max_tokens` for gemma4_unified.

## What changed

- `src/server/types/response.rs`: add an optional `reasoning_content: Option<String>` to the response `ChatMessage` (`#[serde(skip_serializing_if = "Option::is_none")]`, so non-thinking responses keep their exact wire shape), matching the OpenAI/vLLM convention and the streaming `delta.reasoning_content`. Add a `with_reasoning_content` chained setter that mirrors `with_cached_tokens`.
- `src/server/routes/chat.rs`: add `extract_reasoning_content`, which replays the raw generation through the same `StreamFilter` the streaming path constructs, then wire it onto all three non-streaming return points (tool-calls, tools-enabled-no-calls, plain). The existing `content` computation (`strip_unclosed_primed_thinking` / `clean_structural_tokens` / tool-call parsing) is unchanged; reasoning is purely additive.
- `docs/supported-models.md`: document the gemma4_unified thinking default, the recommended `max_tokens` (at least 512), the `reasoning_content` surfacing on both streaming and non-streaming paths, and that per-request/CLI/env `enable_thinking=false` disables it.
- `docs/block-diffusion.md`: correct the stale claim that non-streaming responses strip `reasoning_content`.

## StreamFilter reuse (streaming / non-streaming parity)

Rather than write a new marker parser, `extract_reasoning_content` builds the same `StreamFilter` the streaming SSE path builds (primed-open vs fresh, keyed on `is_prompt_primed_open_thinking`), feeds the whole generated string once, calls `flush()`, and accumulates the `reasoning` pieces. The filter state machine is deterministic over the concatenated input, so feeding the whole string yields the same reasoning/content split as feeding it token-by-token. A unit test (`reasoning_split_identical_whole_vs_chunked`) locks this equivalence, which is what guarantees streaming and non-streaming surface identical reasoning. Per-request `chat_template_kwargs.enable_thinking`, `--chat-template-kwargs`, and `LLAMA_ARG_CHAT_TEMPLATE_KWARGS` precedence is untouched (`merge_server_and_request` unchanged).

## Real-model validation (gemma-4-12b-it-4bit, temperature 0)

Startup log confirms the intended default is preserved: `Tokenizer recognizes a think marker pair; defaulting chat_template kwarg enable_thinking=true (upstream PR #1114) think_start=Some("<|channel>thought") think_end=Some("<channel|>")`.

Prompt "What is a hash table? Answer in one sentence." at `max_tokens=400`, default thinking:

```
finish_reason: stop
completion_tokens: 275
has reasoning_content key: True
reasoning_content len: 980
reasoning_content (head): "*   Topic: Hash table. ... *Draft 1:* A hash table is a data structure that maps keys to values by using a hash function ..."
content: "A hash table is a data structure that maps keys to values by using a hash function to compute an index into an array, allowing for efficient data storage and retrieval."
```

Same prompt with `chat_template_kwargs={"enable_thinking": false}` (per-request precedence preserved):

```
finish_reason: stop
completion_tokens: 33
has reasoning_content key: False
content: "A hash table is a data structure that maps keys to values by using a hash function to compute an index into an array, allowing for efficient data retrieval and storage."
```

This also answers the issue open question 3: the over-thinking is marker-delimited (`<|channel>thought` ... `<channel|>`), since the filter captured the full 980-char block into `reasoning_content` while `content` holds only the answer (an empty `content` plus `finish_reason=length` at a tiny budget was the tokens being stripped as a marked thinking block, not leaked unmarked text).

## This fixes qwen3 too

qwen3-4b-4bit thinking request "What is 17 times 23? Answer in one sentence." at `max_tokens=512`, temperature 0:

```
finish_reason: stop
completion_tokens: 375
has reasoning_content key: True
reasoning_content len: 932
reasoning_content (head): " Okay, the user is asking for 17 multiplied by 23 ... 340 + 51 equals 391 ..."
content: "17 times 23 equals 391."
```

## Test plan

- [x] `cargo check --lib --tests --features metal,accelerate`
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings`
- [x] `cargo test -p mlxcel --lib --features metal,accelerate` for the new tests: `server::routes::chat::tests::extract_reasoning_*` (5), `server::routes::chat::tests::reasoning_split_identical_whole_vs_chunked`, `server::types::response::tests::reasoning_content_*` (2). All 8 pass.
- [x] `cargo fmt --check`
- [x] Real-model smoke on gemma-4-12b-it-4bit and qwen3-4b-4bit (above)

Closes #352
