### PR TITLE
perf(core): hardware-gated MLX_MAX_OPS_PER_BUFFER decode default

### DIFF
--- a/docs/benchmark_results/gemma3n-decode-profile.md
+++ b/docs/benchmark_results/gemma3n-decode-profile.md
@@ -172,6 +172,31 @@ on M5-class hardware (larger buffers were slower there); blindly raising it
 would regress M5. That needs a cross-hardware re-bench before it lands, so it
 belongs in its own issue.
 
+### Hardware-gated default (landed in #353)
+
+`apply_metal_ops_per_buffer_default` (`src/lib/mlxcel-core/src/hardware.rs`) now sets `MLX_MAX_OPS_PER_BUFFER=1000` at process start on pre-M5 Apple Silicon (`AppleSiliconGen` M1 through M4, Metal GPU family 3) when the variable is unset. M5+ (Neural Accelerator) and non-Apple (CUDA) are left on MLX's default, and an operator-set `MLX_MAX_OPS_PER_BUFFER` always wins. The CLI, server, and `mlxcel-bench-decode` binaries apply it before any MLX op.
+
+Cross-hardware basis for the gate:
+
+| Class | MLX_MAX_OPS_PER_BUFFER default | Source |
+|-------|--------------------------------|--------|
+| M1-M4 (no Neural Accelerator) | 1000 (auto) | M1 Ultra sweep in section 4 + re-bench below |
+| M5+ (Neural Accelerator) | MLX default (untouched) | gemma3n-decode-profile-m5max.md (#358): the sweep is flat on M5 Max, and the earlier M5 study recorded larger buffers as slower |
+| Non-Apple (CUDA, e.g. GB10) | MLX default (untouched) | Metal command-buffer knob, irrelevant off Apple GPUs |
+
+M1 Ultra re-bench with the gate active (2026-06-19, best-of-3, raw prompt, 80 tokens after a 20-token warmup, `caffeinate -i`):
+
+| Checkpoint | gated default (1000) | recorded section-4 default | gain |
+|------------|---------------------:|---------------------------:|-----:|
+| gemma3n-e2b-4bit | 92.5 | 82.7 | +11.9% |
+| gemma3n-e4b-4bit | 68.4 | 63.0 | +8.6% |
+
+The gate fires on this M1 Ultra (detected as `M1`) and reproduces the 1000-row throughput from section 4. An explicit low override is respected and collapses throughput to 67.7 (e2b) and 51.8 (e4b) at `MLX_MAX_OPS_PER_BUFFER=10`, confirming the lever direction and that operator settings win.
+
+Generalization: the gain concentrates in Gemma3n's high-op-density stack, but the cap is not Gemma3n-only. Dense qwen3-8b-4bit (86.1) and MoE qwen3-30b-a3b-4bit (89.0) also run faster at 1000 than at a starved cap (75.9 and 79.3 at ops=10), so the generation-wide pre-M5 gate does not regress them. The MoE decode-gap sweep (#268) was flat, consistent with the dispatch-gap binding being strongest where per-layer op density is highest. Section 4's sweep is monotonic up to the plateau near 1000 and regresses slightly at 2000, so 1000 sits at the knee.
+
+Not yet benched: GB10 (no access in the landing environment), recorded here as a follow-up. The gate leaves GB10 on MLX's default (it is non-Apple, CUDA), so it is unaffected until measured.
+
 ### Reproduce
 
 ```bash

--- a/src/bin/bench_decode.rs
+++ b/src/bin/bench_decode.rs
@@ -273,6 +273,13 @@ fn measured(
 
 fn main() -> Result<()> {
     let args = Args::parse();
+
+    // Match the production binaries: apply the hardware-gated
+    // MLX_MAX_OPS_PER_BUFFER default (#353) before any model/generator
+    // construction so decode benchmarks reflect the shipped default. A
+    // pre-set MLX_MAX_OPS_PER_BUFFER (manual sweep override) always wins.
+    mlxcel_core::hardware::apply_metal_ops_per_buffer_default();
+
     let kv_cache_mode = resolve_kv_cache_mode(
         args.turbo.cache_type_k.as_deref(),
         args.turbo.cache_type_v.as_deref(),

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -1088,6 +1088,11 @@ async fn main() -> anyhow::Result<()> {
     // the first-run kernel compilation is paid once per machine, not every boot.
     mlxcel_core::ensure_persistent_ptx_cache();
 
+    // Raise MLX_MAX_OPS_PER_BUFFER on pre-M5 Apple Silicon to close decode
+    // command-buffer dispatch-gap idle (#353). Hardware-gated, a no-op when the
+    // variable is already set, and must run before any MLX op.
+    mlxcel_core::hardware::apply_metal_ops_per_buffer_default();
+
     match cli.command {
         // Subcommand-driven dispatch. Currently only `download`
         // exists; future operational subcommands (e.g. cache inspection) can

--- a/src/lib/mlxcel-core/src/hardware.rs
+++ b/src/lib/mlxcel-core/src/hardware.rs
@@ -125,6 +125,63 @@ pub fn is_m5_neural_accelerator() -> bool {
     hw.has_neural_accelerator && hw.macos_supports_na
 }
 
+/// The `MLX_MAX_OPS_PER_BUFFER` default to apply for an Apple Silicon class, or
+/// `None` to leave MLX's built-in default in place.
+///
+/// `MLX_MAX_OPS_PER_BUFFER` caps how many ops MLX batches into one Metal command
+/// buffer before committing it. On pre-M5 Apple Silicon (Metal GPU family 3) the
+/// default cap is small enough that high-op-density decode (Gemma3n: AltUp
+/// 4-plane, LAUREL, per-layer input gating, dual norms) stalls the GPU at
+/// command-buffer boundaries; raising the cap to 1000 closes that dispatch-gap
+/// idle and recovers +11 to 13% decode throughput on M1 Ultra (see
+/// docs/benchmark_results/gemma3n-decode-profile.md, #329/#345).
+///
+/// The lever is hardware-specific, so it is gated:
+/// - M1 through M4 (no Neural Accelerator, Metal family 3): apply 1000.
+/// - M5+ (has Neural Accelerator): leave MLX's default. The same sweep is flat
+///   on M5 Max (within run-to-run noise, no plateau) and an earlier M5 study
+///   recorded larger buffers as slower, so raising it offers no gain and risks a
+///   regression (docs/benchmark_results/gemma3n-decode-profile-m5max.md, #358).
+/// - Unknown (non-Apple, e.g. CUDA): leave untouched; this is a Metal command
+///   buffer scheduling knob, irrelevant off Apple GPUs.
+///
+/// The gain is most pronounced on Gemma3n's dense high-op-density stack; the MoE
+/// decode sweep was flat (#268), so other families are expected neutral, not
+/// regressed. This is a default only: an explicit `MLX_MAX_OPS_PER_BUFFER` in the
+/// environment always wins (see [`apply_metal_ops_per_buffer_default`]).
+#[must_use]
+pub fn metal_ops_per_buffer_default(
+    gen: AppleSiliconGen,
+    has_neural_accelerator: bool,
+) -> Option<u32> {
+    if gen != AppleSiliconGen::Unknown && !has_neural_accelerator {
+        Some(1000)
+    } else {
+        None
+    }
+}
+
+/// Apply the hardware-gated [`metal_ops_per_buffer_default`] to the process
+/// environment, unless `MLX_MAX_OPS_PER_BUFFER` is already set.
+///
+/// Call this once, early in `main()`, before any MLX op runs and before spawning
+/// threads: MLX reads `MLX_MAX_OPS_PER_BUFFER` when it commits command buffers,
+/// and setting an environment variable is only sound while the process is
+/// effectively single-threaded. An operator-set `MLX_MAX_OPS_PER_BUFFER` (any
+/// value) is always respected.
+pub fn apply_metal_ops_per_buffer_default() {
+    if std::env::var_os("MLX_MAX_OPS_PER_BUFFER").is_some() {
+        return;
+    }
+    let hw = get_hardware();
+    if let Some(value) = metal_ops_per_buffer_default(hw.silicon_gen, hw.has_neural_accelerator) {
+        // Safe: mlxcel-core is edition 2021 (set_var is not `unsafe` here), and
+        // the documented contract requires callers to invoke this early in
+        // `main()`, before other threads or MLX touch the environment.
+        std::env::set_var("MLX_MAX_OPS_PER_BUFFER", value.to_string());
+    }
+}
+
 // ── Detection ─────────────────────────────────────────────────────────────────
 
 /// Detect hardware capabilities by querying the OS at runtime.
@@ -665,6 +722,38 @@ mod tests {
         assert!(!AppleSiliconGen::M4.has_neural_accelerator());
         assert!(AppleSiliconGen::M5.has_neural_accelerator());
         assert!(!AppleSiliconGen::Unknown.has_neural_accelerator());
+    }
+
+    #[test]
+    fn ops_per_buffer_default_gates_on_hardware_class() {
+        // Pre-M5 Apple Silicon (Metal family 3) raises the command-buffer op cap
+        // to close dispatch-gap idle (#329/#345). M5+ is flat (#358) and an
+        // earlier study saw it slower, so it stays on MLX's default; non-Apple
+        // (Unknown) is untouched.
+        assert_eq!(
+            metal_ops_per_buffer_default(AppleSiliconGen::M1, false),
+            Some(1000)
+        );
+        assert_eq!(
+            metal_ops_per_buffer_default(AppleSiliconGen::M2, false),
+            Some(1000)
+        );
+        assert_eq!(
+            metal_ops_per_buffer_default(AppleSiliconGen::M3, false),
+            Some(1000)
+        );
+        assert_eq!(
+            metal_ops_per_buffer_default(AppleSiliconGen::M4, false),
+            Some(1000)
+        );
+        assert_eq!(
+            metal_ops_per_buffer_default(AppleSiliconGen::M5, true),
+            None
+        );
+        assert_eq!(
+            metal_ops_per_buffer_default(AppleSiliconGen::Unknown, false),
+            None
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,10 @@ Environment Variables:
   MLXCEL_MEMORY_LIMIT    Soft MLX allocator memory cap (fails fast on overflow)
                            unset/\"0\"/\"none\", let MLX use its backend default (default)
                            \"32GB\", explicit limit (supports GB, MB, or bytes)
+  MLX_MAX_OPS_PER_BUFFER MLX command-buffer op cap (decode dispatch-gap lever)
+                           unset, auto-defaults to 1000 on pre-M5 Apple Silicon (M1-M4),
+                             MLX default on M5+ and non-Apple (hardware-gated, #353)
+                           explicit value always wins (manual override / sweeps)
 
 Tensor Parallel Runtime:
   Current multi-rank support: dense Llama, Qwen2/2.5, Qwen3, Qwen3.5 text, Gemma 3 text, Gemma 4 text, ERNIE 4.5, Hunyuan v1 Dense
@@ -1637,6 +1641,11 @@ fn main() -> anyhow::Result<()> {
     // Default the CUDA kernel JIT cache to a persistent, MLX-pin-scoped dir so
     // the first-run kernel compilation is paid once per machine, not every boot.
     mlxcel_core::ensure_persistent_ptx_cache();
+
+    // Raise MLX_MAX_OPS_PER_BUFFER on pre-M5 Apple Silicon to close decode
+    // command-buffer dispatch-gap idle (#353). Hardware-gated, a no-op when the
+    // variable is already set, and must run before any MLX op.
+    mlxcel_core::hardware::apply_metal_ops_per_buffer_default();
 
     match cli.command {
         Commands::Run(args) => commands::run_run(args),


### PR DESCRIPTION
## Problem

Follow-up to #329/#345 (the Gemma3n decode profile). That profile found raising `MLX_MAX_OPS_PER_BUFFER` from its default to ~1000 recovers +11 to 13% decode throughput on M1 Ultra (gemma3n-e2b 82.7 to 93.2, e4b 63.0 to 70.0) by closing command-buffer dispatch-gap idle on the high-op-density decode stack, with a plateau near 1000 and a slight regression at 2000. It deferred the change because the lever is hardware-specific: M5 must stay on its default (the earlier M5 study found larger buffers slower, and #358 later measured the M5 Max sweep as flat), so a single global default is unsafe.

## Change

`apply_metal_ops_per_buffer_default` (`src/lib/mlxcel-core/src/hardware.rs`) sets `MLX_MAX_OPS_PER_BUFFER=1000` at process start on pre-M5 Apple Silicon (`AppleSiliconGen` M1 through M4, no Neural Accelerator) when the variable is unset. M5+ (Neural Accelerator) and non-Apple (CUDA, e.g. GB10) are left on MLX's default. An operator-set `MLX_MAX_OPS_PER_BUFFER` (any value) always wins. The pure gate decision is `metal_ops_per_buffer_default(gen, has_neural_accelerator)` and is unit-tested. The applier is called at the top of `main()` in the CLI (`src/main.rs`), the server (`src/bin/mlx_server.rs`), and the decode bench (`src/bin/bench_decode.rs`), before any MLX op runs. The knob is documented in the CLI `--help` environment-variable list. mlxcel-core is edition 2021, so `set_var` is sound there given the documented early-call contract.

## Validation (M1 Ultra, 2026-06-19, best-of-3, raw prompt, 80 tokens after a 20-token warmup, caffeinate)

The gate fires on this M1 Ultra (detected as `M1`) and reproduces the section-4 1000-row throughput from the profile:

| Checkpoint | gated default (1000) | recorded #329 default | gain |
|------------|---------------------:|----------------------:|-----:|
| gemma3n-e2b-4bit | 92.5 | 82.7 | +11.9% |
| gemma3n-e4b-4bit | 68.4 | 63.0 | +8.6% |

An explicit low override is respected and collapses throughput to 67.7 (e2b) and 51.8 (e4b) at `MLX_MAX_OPS_PER_BUFFER=10`, confirming both the lever direction and that operator settings win.

Generalization (no regression on other families): dense qwen3-8b-4bit (86.1) and MoE qwen3-30b-a3b-4bit (89.0) also run faster at 1000 than at a starved cap (75.9 and 79.3 at ops=10), so the generation-wide pre-M5 gate does not regress them. The MoE decode-gap sweep (#268) was flat, consistent with the dispatch-gap binding being strongest where per-layer op density is highest.

## Acceptance criteria

- [x] A hardware-gated default that improves M1 Ultra decode with no M5 regression. M1-M4 gets 1000; M5+ is untouched, and #358 shows the M5 Max sweep flat.
- [~] Cross-hardware bench recorded. M1 Ultra (this re-bench) and M5 Max (#358 / `gemma3n-decode-profile-m5max.md`) are recorded in the profile docs. GB10 is not benched in this environment; the gate leaves GB10 (non-Apple, CUDA) on MLX's default, so it is unaffected until a follow-up bench.
- [x] The `MLX_MAX_OPS_PER_BUFFER` env var preserved as a manual override (respected when set, documented in CLI help).
- [x] A note on whether the gain is Gemma3n-specific or generalizes (added to the profile doc and summarized above).

Validated under the pinned toolchain (rust 1.93.1, matching CI): `cargo clippy --all-targets --features metal,accelerate -- -D warnings` clean for the root and `mlxcel-core`, 25 hardware unit tests pass, fmt clean.

Closes #353.
