### PR TITLE
feat(server): audio endpoint plumbing (multipart upload, binary response, WAV output)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -2055,6 +2056,23 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ toktrie_hf_tokenizers = "1.7"
 
 # HTTP Server
 tokio = { version = "1.52", features = ["full"] }
-axum = { version = "0.7", features = ["json", "macros"] }
+axum = { version = "0.7", features = ["json", "macros", "multipart"] }
 tokio-stream = "0.1"
 tokio-util = "0.7"
 futures = "0.3"

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,8 +22,9 @@ Current GitHub-facing docs:
 7. `turbo-kv-cache.md` — TurboQuant modes, the unified paged KV cache, quality/performance trade-offs, and flags.
 8. `CONTINUOUS_BATCHING.md` — continuous-batching scheduler, paged decode, and disaggregated prefill/decode/router serving.
 9. `responses-api.md` — implemented `/v1/responses` subset and gaps.
-10. `adding-models.md` — contribution guide for new model architectures.
-11. `block-diffusion.md` — DiffusionGemma block-diffusion generation: canvas denoising vs autoregressive, CLI flags, throughput, and phase 1 limitations.
+10. `audio-api.md` — implemented `/v1/audio` endpoints, Phase 1 501 behavior, and WAV encoding details.
+11. `adding-models.md` — contribution guide for new model architectures.
+12. `block-diffusion.md` — DiffusionGemma block-diffusion generation: canvas denoising vs autoregressive, CLI flags, throughput, and phase 1 limitations.
 
 ## Architecture Decision Records
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,12 @@ Important control surfaces:
 2. `src/server/startup.rs` resolves startup configuration, loads the model, and
    builds the Axum application.
 3. `src/server/app.rs` mounts routes such as `/v1/chat/completions`,
-   `/v1/completions`, `/v1/responses`, `/health`, and `/v1/models`.
+   `/v1/completions`, `/v1/responses`, `/health`, and `/v1/models`. The OpenAI
+   audio surface is also mounted (both `/v1`-prefixed and unversioned):
+   `/v1/audio/speech` (text-to-speech), `/v1/audio/transcriptions`, and
+   `/v1/audio/translations` (speech-to-text). These return a structured
+   `501 Not Implemented` until a speech model is wired into the audio-model
+   slot on `AppState`.
 4. Route handlers translate requests into internal generation work.
 5. `src/server/batch/` schedules batched decode when enabled.
 6. Streaming responses are emitted as SSE frames.

--- a/docs/audio-api.md
+++ b/docs/audio-api.md
@@ -1,0 +1,134 @@
+# OpenAI audio API (`/v1/audio`)
+
+`mlxcel serve` and `mlxcel-server` expose the three OpenAI-compatible audio endpoints: text-to-speech (`/v1/audio/speech`), transcription (`/v1/audio/transcriptions`), and translation (`/v1/audio/translations`).
+
+**Phase 1 status.** The HTTP plumbing (request parsing, multipart handling, binary response framing) is complete and all three routes are mounted. Until an audio model is registered via `AppState::with_audio_model`, every request returns a structured `501 Not Implemented` with error type `not_implemented`. This is by design: Phase 1 establishes the transport boundary; Phase 2 wires in a speech model.
+
+## Implemented endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/audio/speech` | Text-to-speech: JSON body in, binary WAV out. |
+| POST | `/v1/audio/transcriptions` | Speech-to-text: `multipart/form-data` in, JSON text out. |
+| POST | `/v1/audio/translations` | Speech-to-text with English output: same multipart shape as transcriptions. |
+
+Alias paths without the `/v1` prefix are also mounted: `/audio/speech`, `/audio/transcriptions`, `/audio/translations`.
+
+## Implementation source map
+
+| Module | Responsibility |
+|--------|----------------|
+| `src/server/audio_model.rs` | `AudioModelProvider` trait, input/output types, `AudioModelKind`, `AudioModelError`. |
+| `src/server/routes/audio.rs` | HTTP handlers, multipart parser, format resolution, binary/JSON response builders. |
+| `src/server/types/request.rs` | `AudioSpeechRequest`, `AudioTranscriptionRequest` (schema reference). |
+| `src/server/types/response.rs` | `AudioTranscriptionResponse`, `ErrorResponse` (including `not_implemented`). |
+| `src/audio/wav_writer.rs` | `encode_wav_pcm16`: `f32` PCM samples to RIFF WAV bytes. |
+| `src/server/app.rs` | Route registration and `AUDIO_MAX_UPLOAD_BYTES` (25 MiB) body-limit layer. |
+
+## POST /v1/audio/speech
+
+**Request body (JSON):**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `model` | string | yes | Identifier of the TTS model. Ignored until a model is loaded; any string is accepted. |
+| `input` | string | yes | Text to synthesize. |
+| `voice` | string | no | Named voice. Model-specific; forwarded as-is to the provider. |
+| `response_format` | string | no | Output container. Only `wav` is supported today; omitting the field defaults to `wav`. |
+| `speed` | float | no | Playback-speed multiplier. Forwarded to the provider; no range is enforced by the route layer. |
+
+**Success response (200):**
+
+Content-Type: `audio/wav`. Content-Disposition: `attachment; filename=speech.wav`. The body is a 44-byte RIFF WAV header followed by 16-bit little-endian PCM samples at the sample rate the provider returns.
+
+**Error responses:**
+
+| Status | Condition |
+|--------|-----------|
+| 400 | Unsupported `response_format` (any value other than `wav` or absent). |
+| 501 | No TTS model is registered. Body: `{"error":{"type":"not_implemented","message":"audio model kind not loaded: tts"}}` |
+| 503 | All inference slots are busy. |
+
+**Example (curl):**
+
+```sh
+curl -s -X POST http://localhost:8080/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"my-tts","input":"Hello world"}' \
+  --output speech.wav
+```
+
+## POST /v1/audio/transcriptions
+
+**Request body (`multipart/form-data`):**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `file` | file part | yes | Raw audio bytes. Any container the loaded provider can decode. |
+| `model` | text | no | STT model identifier. Forwarded to the provider. |
+| `language` | text | no | ISO-639-1 source-language hint (`en`, `ko`, etc.). |
+| `response_format` | text | no | `json` (default), `text`, or `verbose_json`. Any other non-empty value returns 400. |
+| `temperature` | text | no | Sampling temperature. Parsed as `f32`; non-numeric values return 400. |
+
+Unknown multipart parts are drained and ignored. The upload body limit is 25 MiB; larger uploads return 413.
+
+**Success responses:**
+
+- `json` (default): `{"text":"..."}` with `Content-Type: application/json`.
+- `text`: plain UTF-8 text with `Content-Type: text/plain`.
+- `verbose_json`: `{"text":"...","language":"...","duration":1.5}` with `Content-Type: application/json`. The `language` and `duration` fields are omitted when the provider does not return them.
+
+**Error responses:**
+
+| Status | Condition |
+|--------|-----------|
+| 400 | Malformed multipart, non-numeric `temperature`, or unsupported `response_format`. |
+| 413 | Upload body exceeds 25 MiB. |
+| 501 | No STT model is registered. Body: `{"error":{"type":"not_implemented","message":"audio model kind not loaded: stt"}}` |
+| 503 | All inference slots are busy. |
+
+**Example (curl):**
+
+```sh
+curl -s -X POST http://localhost:8080/v1/audio/transcriptions \
+  -F file=@recording.wav \
+  -F model=my-stt \
+  -F language=en \
+  -F response_format=json
+```
+
+## POST /v1/audio/translations
+
+Same multipart shape and field semantics as `/v1/audio/transcriptions`. The difference is that the loaded model is asked to output text in English regardless of the source language. The `501` message names `stt` (the same underlying capability direction).
+
+## Phase 1 boundaries
+
+The 501 response is returned **after** the request is fully parsed. This means:
+
+- A malformed multipart body returns 400, not 501, even when no model is loaded.
+- A `response_format` typo in a speech request returns 400 when a TTS model is loaded but 501 when none is loaded (the format is resolved after the model check).
+- The `file` field is required for transcriptions/translations; its absence returns 400 regardless of model state.
+
+This ordering lets callers distinguish broken requests from absent models without needing a loaded model.
+
+## Adding an audio model provider
+
+Implement `crate::server::AudioModelProvider` and register it at startup:
+
+```rust
+let state = AppState::new(...)
+    .with_audio_model(Some(Arc::new(MyProvider::new(...))));
+```
+
+A provider overrides only the direction(s) it supports (`transcribe` or `synthesize`) and reports capability via `supports(AudioModelKind)`. The default implementations for the unimplemented direction return `AudioModelError::KindNotLoaded`, which the route layer maps back to a 501.
+
+## WAV encoding
+
+The TTS route encodes `f32` PCM samples as a standard 44-byte RIFF WAV with 16-bit little-endian PCM data (`encode_wav_pcm16` in `src/audio/wav_writer.rs`). The encoder:
+
+- Clamps values outside `[-1.0, 1.0]` to the `i16` range (no wrapping).
+- Maps `NaN` to zero (silence).
+- Accepts multi-channel audio when samples are interleaved (`L, R, L, R, ...`).
+- Truncates at the maximum expressible 32-bit RIFF payload rather than producing a corrupt header.
+
+The output round-trips through the existing WAV reader (`load_wav_from_bytes`) within one 16-bit quantization step.

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -31,6 +31,7 @@ pub mod config;
 pub mod encoder;
 pub mod feature_extractor;
 pub mod nemotron_h_nano_omni;
+pub mod wav_writer;
 
 pub use config::AudioConfig;
 pub use encoder::AudioEncoder;
@@ -38,3 +39,4 @@ pub use feature_extractor::{
     AudioFeatureExtractor, AudioFeatureExtractorConfig, compute_audio_num_tokens, load_wav_file,
     load_wav_from_bytes,
 };
+pub use wav_writer::encode_wav_pcm16;

--- a/src/audio/wav_writer.rs
+++ b/src/audio/wav_writer.rs
@@ -1,0 +1,169 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Audio output encoding.
+//!
+//! Counterpart to the WAV reader in [`super::feature_extractor`]
+//! (`load_wav_file` / `load_wav_from_bytes` / `parse_wav`). This module turns
+//! `f32` PCM samples back into a self-contained byte stream so the server can
+//! return synthesized audio over HTTP. The encoded layout is the canonical
+//! 44-byte RIFF header followed by 16-bit little-endian PCM data, which the
+//! reader decodes through its fast `header[36..40] == b"data"` path.
+
+/// Number of bytes per encoded sample (16-bit PCM).
+const BYTES_PER_SAMPLE: u32 = 2;
+/// PCM bit depth produced by this encoder.
+const BITS_PER_SAMPLE: u16 = 16;
+/// WAV `audio_format` tag for integer PCM.
+const WAV_FORMAT_PCM: u16 = 1;
+
+/// Encode interleaved `f32` PCM samples as a canonical 16-bit little-endian
+/// RIFF WAV byte stream.
+///
+/// `samples` are amplitudes nominally in `[-1.0, 1.0]`; values outside the
+/// range are clamped to the representable `i16` window. For multi-channel
+/// audio (`channels > 1`) the samples must already be interleaved
+/// (`L, R, L, R, ...`). The scaling mirrors the reader's `i16 / 32768.0`
+/// decode, so an encode followed by `load_wav_from_bytes` round-trips within
+/// one quantization step.
+///
+/// Used by: server/routes/audio.rs (text-to-speech binary response)
+#[must_use]
+pub fn encode_wav_pcm16(samples: &[f32], sample_rate: u32, channels: u16) -> Vec<u8> {
+    let data_len = (samples.len() as u32).saturating_mul(BYTES_PER_SAMPLE);
+    let byte_rate = sample_rate
+        .saturating_mul(channels as u32)
+        .saturating_mul(BYTES_PER_SAMPLE);
+    let block_align = channels.saturating_mul(BITS_PER_SAMPLE / 8);
+    // 44-byte header (RIFF + fmt + data descriptors) plus the PCM payload.
+    let mut out = Vec::with_capacity(44 + data_len as usize);
+
+    // RIFF chunk descriptor.
+    out.extend_from_slice(b"RIFF");
+    out.extend_from_slice(&(36u32.saturating_add(data_len)).to_le_bytes());
+    out.extend_from_slice(b"WAVE");
+
+    // fmt sub-chunk.
+    out.extend_from_slice(b"fmt ");
+    out.extend_from_slice(&16u32.to_le_bytes()); // PCM fmt chunk size
+    out.extend_from_slice(&WAV_FORMAT_PCM.to_le_bytes());
+    out.extend_from_slice(&channels.to_le_bytes());
+    out.extend_from_slice(&sample_rate.to_le_bytes());
+    out.extend_from_slice(&byte_rate.to_le_bytes());
+    out.extend_from_slice(&block_align.to_le_bytes());
+    out.extend_from_slice(&BITS_PER_SAMPLE.to_le_bytes());
+
+    // data sub-chunk.
+    out.extend_from_slice(b"data");
+    out.extend_from_slice(&data_len.to_le_bytes());
+    for &sample in samples {
+        // Mirror the reader's `i16 / 32768.0` decode: scale by 32768, then
+        // clamp into the i16 range so a full-scale 1.0 saturates rather than
+        // wrapping to a negative value.
+        let scaled = (sample * 32768.0).round();
+        let clamped = scaled.clamp(i16::MIN as f32, i16::MAX as f32) as i16;
+        out.extend_from_slice(&clamped.to_le_bytes());
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::load_wav_from_bytes;
+    use std::f32::consts::PI;
+
+    /// Generate a unit-amplitude tone for round-trip checks.
+    fn tone(freq_hz: f32, num_samples: usize, sample_rate: u32) -> Vec<f32> {
+        (0..num_samples)
+            .map(|i| (2.0 * PI * freq_hz * i as f32 / sample_rate as f32).sin())
+            .collect()
+    }
+
+    #[test]
+    fn encode_then_read_round_trips_mono_samples() {
+        let sample_rate = 16_000;
+        let original = tone(440.0, 1_600, sample_rate);
+
+        let bytes = encode_wav_pcm16(&original, sample_rate, 1);
+        let (decoded, decoded_rate) =
+            load_wav_from_bytes(&bytes).expect("encoded WAV must read back");
+
+        assert_eq!(decoded_rate, sample_rate);
+        assert_eq!(decoded.len(), original.len());
+        // 16-bit quantization error is bounded by 1/32768 ~= 3.05e-5.
+        for (i, (&a, &b)) in original.iter().zip(decoded.iter()).enumerate() {
+            assert!(
+                (a - b).abs() < 1.0e-4,
+                "sample {i} diverged: encoded {a}, decoded {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn header_advertises_sample_rate_and_mono_channel() {
+        let bytes = encode_wav_pcm16(&[0.0, 0.25, -0.25], 24_000, 1);
+        assert_eq!(&bytes[0..4], b"RIFF");
+        assert_eq!(&bytes[8..12], b"WAVE");
+        assert_eq!(&bytes[36..40], b"data");
+        let rate = u32::from_le_bytes([bytes[24], bytes[25], bytes[26], bytes[27]]);
+        assert_eq!(rate, 24_000);
+        let channels = u16::from_le_bytes([bytes[22], bytes[23]]);
+        assert_eq!(channels, 1);
+        let bits = u16::from_le_bytes([bytes[34], bytes[35]]);
+        assert_eq!(bits, 16);
+    }
+
+    #[test]
+    fn full_scale_values_saturate_without_wrapping() {
+        // +1.0 would scale to 32768, which must clamp to i16::MAX (32767),
+        // not wrap to a large negative value.
+        let bytes = encode_wav_pcm16(&[1.0, -1.0], 8_000, 1);
+        let (decoded, _) = load_wav_from_bytes(&bytes).expect("WAV must read back");
+        assert!(
+            decoded[0] > 0.99,
+            "positive full scale wrapped: {}",
+            decoded[0]
+        );
+        assert!(
+            (decoded[1] + 1.0).abs() < 1.0e-4,
+            "negative full scale diverged: {}",
+            decoded[1]
+        );
+    }
+
+    #[test]
+    fn interleaved_stereo_round_trips_through_mono_downmix() {
+        // The reader averages channels into mono; duplicating L==R means the
+        // average equals the source so the duplicated channel still matches.
+        let sample_rate = 16_000;
+        let mono = tone(220.0, 512, sample_rate);
+        let mut interleaved = Vec::with_capacity(mono.len() * 2);
+        for &s in &mono {
+            interleaved.push(s);
+            interleaved.push(s);
+        }
+
+        let bytes = encode_wav_pcm16(&interleaved, sample_rate, 2);
+        let (decoded, decoded_rate) =
+            load_wav_from_bytes(&bytes).expect("stereo WAV must read back");
+
+        assert_eq!(decoded_rate, sample_rate);
+        assert_eq!(decoded.len(), mono.len());
+        for (&a, &b) in mono.iter().zip(decoded.iter()) {
+            assert!((a - b).abs() < 1.0e-4, "downmix diverged: {a} vs {b}");
+        }
+    }
+}

--- a/src/audio/wav_writer.rs
+++ b/src/audio/wav_writer.rs
@@ -27,6 +27,9 @@ const BYTES_PER_SAMPLE: u32 = 2;
 const BITS_PER_SAMPLE: u16 = 16;
 /// WAV `audio_format` tag for integer PCM.
 const WAV_FORMAT_PCM: u16 = 1;
+/// Largest PCM payload a 32-bit RIFF `data` length can describe. The 44-byte
+/// header is reserved so the total `RIFF` chunk size also fits in `u32`.
+const MAX_DATA_BYTES: u32 = u32::MAX - 44;
 
 /// Encode interleaved `f32` PCM samples as a canonical 16-bit little-endian
 /// RIFF WAV byte stream.
@@ -41,7 +44,14 @@ const WAV_FORMAT_PCM: u16 = 1;
 /// Used by: server/routes/audio.rs (text-to-speech binary response)
 #[must_use]
 pub fn encode_wav_pcm16(samples: &[f32], sample_rate: u32, channels: u16) -> Vec<u8> {
-    let data_len = (samples.len() as u32).saturating_mul(BYTES_PER_SAMPLE);
+    // A 32-bit RIFF `data` length caps a single WAV at roughly 4 GiB of PCM.
+    // Clamp the sample count to what that field can represent so the advertised
+    // length always matches the bytes actually written, even for pathological
+    // inputs. A larger payload cannot be expressed in a standard RIFF WAV, so
+    // truncating here keeps the output well-formed rather than corrupt.
+    let max_samples = (MAX_DATA_BYTES / BYTES_PER_SAMPLE) as usize;
+    let encoded = &samples[..samples.len().min(max_samples)];
+    let data_len = (encoded.len() as u32).saturating_mul(BYTES_PER_SAMPLE);
     let byte_rate = sample_rate
         .saturating_mul(channels as u32)
         .saturating_mul(BYTES_PER_SAMPLE);
@@ -67,10 +77,11 @@ pub fn encode_wav_pcm16(samples: &[f32], sample_rate: u32, channels: u16) -> Vec
     // data sub-chunk.
     out.extend_from_slice(b"data");
     out.extend_from_slice(&data_len.to_le_bytes());
-    for &sample in samples {
+    for &sample in encoded {
         // Mirror the reader's `i16 / 32768.0` decode: scale by 32768, then
         // clamp into the i16 range so a full-scale 1.0 saturates rather than
-        // wrapping to a negative value.
+        // wrapping to a negative value. NaN maps to 0 and infinities saturate
+        // because Rust's `f32 as i16` cast is saturating.
         let scaled = (sample * 32768.0).round();
         let clamped = scaled.clamp(i16::MIN as f32, i16::MAX as f32) as i16;
         out.extend_from_slice(&clamped.to_le_bytes());
@@ -141,6 +152,53 @@ mod tests {
             (decoded[1] + 1.0).abs() < 1.0e-4,
             "negative full scale diverged: {}",
             decoded[1]
+        );
+    }
+
+    #[test]
+    fn header_data_length_matches_payload() {
+        let bytes = encode_wav_pcm16(&[0.1_f32; 100], 16_000, 1);
+        let data_len = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
+        assert_eq!(data_len, 200, "data chunk advertises the PCM byte count");
+        assert_eq!(
+            bytes.len(),
+            44 + data_len,
+            "payload length matches the header"
+        );
+        let riff_len = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) as usize;
+        assert_eq!(riff_len, 36 + data_len, "RIFF size covers the body");
+    }
+
+    #[test]
+    fn pathological_floats_saturate_without_panicking() {
+        let bytes = encode_wav_pcm16(
+            &[f32::NAN, f32::INFINITY, f32::NEG_INFINITY, 5.0, -5.0],
+            8_000,
+            1,
+        );
+        let (decoded, _) = load_wav_from_bytes(&bytes).expect("pathological WAV must read back");
+        assert!(
+            decoded[0].abs() < 1.0e-4,
+            "NaN should encode to silence, got {}",
+            decoded[0]
+        );
+        assert!(
+            decoded[1] > 0.99,
+            "positive infinity should saturate high, got {}",
+            decoded[1]
+        );
+        assert!(
+            decoded[2] < -0.99,
+            "negative infinity should saturate low, got {}",
+            decoded[2]
+        );
+        assert!(
+            decoded[3] > 0.99,
+            "out-of-range positive should saturate high"
+        );
+        assert!(
+            decoded[4] < -0.99,
+            "out-of-range negative should saturate low"
         );
     }
 

--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -184,3 +184,184 @@ pub fn create_app(state: AppState) -> Router {
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::AUDIO_MAX_UPLOAD_BYTES;
+    use axum::{
+        Router,
+        body::Body,
+        extract::DefaultBodyLimit,
+        http::{Method, Request, StatusCode},
+        routing::post,
+    };
+    use tower::ServiceExt;
+
+    /// Build a minimal audio sub-router using stub handlers and the same
+    /// `DefaultBodyLimit` layer applied in `create_app`. Tests can call this
+    /// without constructing a real `AppState`.
+    fn audio_test_router() -> Router {
+        Router::new()
+            .route(
+                "/v1/audio/speech",
+                post(|| async { StatusCode::NO_CONTENT }),
+            )
+            .route(
+                "/v1/audio/transcriptions",
+                post(|| async { StatusCode::NO_CONTENT }),
+            )
+            .route(
+                "/v1/audio/translations",
+                post(|| async { StatusCode::NO_CONTENT }),
+            )
+            .route("/audio/speech", post(|| async { StatusCode::NO_CONTENT }))
+            .route(
+                "/audio/transcriptions",
+                post(|| async { StatusCode::NO_CONTENT }),
+            )
+            .route(
+                "/audio/translations",
+                post(|| async { StatusCode::NO_CONTENT }),
+            )
+            .layer(DefaultBodyLimit::max(AUDIO_MAX_UPLOAD_BYTES))
+    }
+
+    #[test]
+    fn audio_upload_limit_is_25_mib() {
+        assert_eq!(
+            AUDIO_MAX_UPLOAD_BYTES,
+            25 * 1024 * 1024,
+            "audio upload limit must be 25 MiB"
+        );
+    }
+
+    #[tokio::test]
+    async fn audio_speech_is_reachable_at_v1_path() {
+        let response = audio_test_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/audio/speech")
+                    .header("content-type", "application/json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "/v1/audio/speech must be mounted"
+        );
+    }
+
+    #[tokio::test]
+    async fn audio_transcriptions_is_reachable_at_v1_path() {
+        let response = audio_test_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/audio/transcriptions")
+                    .header("content-type", "multipart/form-data; boundary=x")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "/v1/audio/transcriptions must be mounted"
+        );
+    }
+
+    #[tokio::test]
+    async fn audio_translations_is_reachable_at_v1_path() {
+        let response = audio_test_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/audio/translations")
+                    .header("content-type", "multipart/form-data; boundary=x")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "/v1/audio/translations must be mounted"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_to_audio_speech_returns_method_not_allowed() {
+        // The route exists but only accepts POST. A 405 (not 404) confirms the
+        // path is registered.
+        let response = audio_test_router()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/v1/audio/speech")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn audio_alias_paths_are_reachable_without_v1_prefix() {
+        for path in [
+            "/audio/speech",
+            "/audio/transcriptions",
+            "/audio/translations",
+        ] {
+            let response = audio_test_router()
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri(path)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_ne!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "{path} alias must be mounted"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn body_limit_layer_enforces_upload_cap() {
+        // Use a small limit so the test does not allocate the full 25 MiB. The
+        // goal is confirming DefaultBodyLimit is wired onto the audio sub-router
+        // and that an over-limit body produces 413; the constant test covers the
+        // 25 MiB value separately.
+        const TEST_LIMIT: usize = 16;
+        let app = Router::new()
+            .route(
+                "/v1/audio/transcriptions",
+                post(|_body: axum::body::Bytes| async move { StatusCode::NO_CONTENT }),
+            )
+            .layer(DefaultBodyLimit::max(TEST_LIMIT));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/audio/transcriptions")
+                    .header("content-type", "multipart/form-data; boundary=x")
+                    .body(Body::from(vec![0u8; TEST_LIMIT + 1]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+}

--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -17,7 +17,7 @@
 use axum::{
     Json, Router,
     body::Body,
-    extract::State,
+    extract::{DefaultBodyLimit, State},
     http::{Request, StatusCode, header},
     middleware::{self, Next},
     response::{IntoResponse, Response},
@@ -86,6 +86,10 @@ async fn api_key_auth(
     }
 }
 
+/// Maximum request body size for audio upload endpoints. Overrides the Axum
+/// 2 MiB default because real audio uploads commonly exceed that threshold.
+const AUDIO_MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
+
 /// Create the Axum application router
 pub fn create_app(state: AppState) -> Router {
     let enable_slots = state.config.enable_slots_endpoint;
@@ -94,6 +98,20 @@ pub fn create_app(state: AppState) -> Router {
     // CORS policy (#244): restrict to the configured allow-list when set,
     // otherwise keep the historical permissive default.
     let cors = build_cors_layer(state.config.cors_allowed_origins.as_deref());
+
+    // Audio upload endpoints carry a larger body limit via a sub-router.
+    // Merging keeps the outer auth, CORS, and trace layers applying normally.
+    let audio_routes: Router<AppState> = Router::new()
+        .route("/v1/audio/speech", post(routes::audio_speech))
+        .route(
+            "/v1/audio/transcriptions",
+            post(routes::audio_transcriptions),
+        )
+        .route("/v1/audio/translations", post(routes::audio_translations))
+        .route("/audio/speech", post(routes::audio_speech))
+        .route("/audio/transcriptions", post(routes::audio_transcriptions))
+        .route("/audio/translations", post(routes::audio_translations))
+        .layer(DefaultBodyLimit::max(AUDIO_MAX_UPLOAD_BYTES));
 
     let mut app = Router::new()
         // OpenAI API endpoints
@@ -118,17 +136,9 @@ pub fn create_app(state: AppState) -> Router {
         // off so monitoring clients can poll without conditional logic).
         .route("/v1/cache/stats", get(routes::cache_stats))
         .route("/v1/cache/reset", post(routes::cache_reset))
-        // OpenAI audio API surface (speech synthesis + transcription/translation).
-        // Both the `/v1`-prefixed and unversioned forms are mounted.
-        .route("/v1/audio/speech", post(routes::audio_speech))
-        .route(
-            "/v1/audio/transcriptions",
-            post(routes::audio_transcriptions),
-        )
-        .route("/v1/audio/translations", post(routes::audio_translations))
-        .route("/audio/speech", post(routes::audio_speech))
-        .route("/audio/transcriptions", post(routes::audio_transcriptions))
-        .route("/audio/translations", post(routes::audio_translations))
+        // Audio routes (speech, transcriptions, translations) come from the
+        // sub-router that carries the larger body-limit layer.
+        .merge(audio_routes)
         // Aliases (some clients use these)
         .route("/chat/completions", post(routes::chat_completions))
         .route("/completions", post(routes::completions))

--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -118,6 +118,17 @@ pub fn create_app(state: AppState) -> Router {
         // off so monitoring clients can poll without conditional logic).
         .route("/v1/cache/stats", get(routes::cache_stats))
         .route("/v1/cache/reset", post(routes::cache_reset))
+        // OpenAI audio API surface (speech synthesis + transcription/translation).
+        // Both the `/v1`-prefixed and unversioned forms are mounted.
+        .route("/v1/audio/speech", post(routes::audio_speech))
+        .route(
+            "/v1/audio/transcriptions",
+            post(routes::audio_transcriptions),
+        )
+        .route("/v1/audio/translations", post(routes::audio_translations))
+        .route("/audio/speech", post(routes::audio_speech))
+        .route("/audio/transcriptions", post(routes::audio_transcriptions))
+        .route("/audio/translations", post(routes::audio_translations))
         // Aliases (some clients use these)
         .route("/chat/completions", post(routes::chat_completions))
         .route("/completions", post(routes::completions))

--- a/src/server/audio_model.rs
+++ b/src/server/audio_model.rs
@@ -1,0 +1,222 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Audio-model provider interface.
+//!
+//! This is the transport-agnostic seam between the HTTP audio routes and the
+//! speech models. The server surface (routes, request parsing, binary
+//! responses) depends only on the types defined here, so a speech-to-text
+//! provider and a text-to-speech provider can be wired in later without
+//! reworking the route layer.
+//!
+//! The two directions are intentionally split into separate methods with
+//! default "kind not loaded" implementations: a provider that only does one
+//! direction overrides just that method and reports its capability through
+//! [`AudioModelProvider::supports`]. Until a provider is registered the
+//! [`AppState`](crate::server::AppState) slot stays `None` and every audio
+//! route returns a structured `501 Not Implemented`.
+
+use thiserror::Error;
+
+/// The two audio-model directions the OpenAI audio API exposes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum AudioModelKind {
+    /// Speech-to-text: audio bytes in, text out
+    /// (`/audio/transcriptions`, `/audio/translations`).
+    Stt,
+    /// Text-to-speech: text in, waveform out (`/audio/speech`).
+    Tts,
+}
+
+impl AudioModelKind {
+    /// Stable lowercase identifier, used in error messages and logs.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AudioModelKind::Stt => "stt",
+            AudioModelKind::Tts => "tts",
+        }
+    }
+}
+
+impl std::fmt::Display for AudioModelKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Decoded request for the speech-to-text direction.
+///
+/// The audio arrives as the raw uploaded bytes (any container the provider
+/// understands, typically WAV); the provider owns decoding via the shared
+/// reader in [`crate::audio`].
+#[derive(Debug, Clone)]
+pub struct AudioTranscribeInput {
+    /// Raw bytes of the uploaded audio file.
+    pub audio: Vec<u8>,
+    /// Original upload filename, when the client supplied one.
+    pub filename: Option<String>,
+    /// Optional ISO-639-1 source-language hint.
+    pub language: Option<String>,
+    /// Optional sampling temperature forwarded to the model.
+    pub temperature: Option<f32>,
+    /// When `true`, translate the source audio to English
+    /// (`/audio/translations`) instead of transcribing in place
+    /// (`/audio/transcriptions`).
+    pub translate: bool,
+}
+
+/// Result of a speech-to-text request.
+#[derive(Debug, Clone)]
+pub struct AudioTranscribeOutput {
+    /// Recognized text.
+    pub text: String,
+    /// Detected or supplied language, surfaced in verbose responses.
+    pub language: Option<String>,
+    /// Source audio duration in seconds, surfaced in verbose responses.
+    pub duration_seconds: Option<f32>,
+}
+
+/// Decoded request for the text-to-speech direction.
+#[derive(Debug, Clone)]
+pub struct AudioSynthesizeInput {
+    /// Text to synthesize.
+    pub input: String,
+    /// Optional named voice.
+    pub voice: Option<String>,
+    /// Optional playback-speed multiplier.
+    pub speed: Option<f32>,
+}
+
+/// Result of a text-to-speech request: an `f32` PCM waveform the route encodes
+/// into the client's requested container (WAV today).
+#[derive(Debug, Clone)]
+pub struct AudioSynthesizeOutput {
+    /// Interleaved PCM samples in `[-1.0, 1.0]`.
+    pub samples: Vec<f32>,
+    /// Sample rate in Hz.
+    pub sample_rate: u32,
+    /// Channel count (`samples` is interleaved when this is `> 1`).
+    pub channels: u16,
+}
+
+/// Failure modes shared by both audio directions.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AudioModelError {
+    /// No model is loaded for the requested direction. Routes map this to a
+    /// `501 Not Implemented` response.
+    #[error("audio model kind not loaded: {0}")]
+    KindNotLoaded(AudioModelKind),
+    /// The loaded model failed while processing the request.
+    #[error("audio model inference failed: {0}")]
+    Inference(String),
+}
+
+/// Provider-facing interface implemented by the speech models.
+///
+/// A provider advertises the directions it can service through
+/// [`supports`](AudioModelProvider::supports) and overrides only the matching
+/// method. The unimplemented direction keeps the default body, which reports
+/// [`AudioModelError::KindNotLoaded`].
+pub trait AudioModelProvider: Send + Sync {
+    /// Whether this provider can service the given direction.
+    fn supports(&self, kind: AudioModelKind) -> bool;
+
+    /// Run speech-to-text. Default: the direction is not loaded.
+    fn transcribe(
+        &self,
+        _input: AudioTranscribeInput,
+    ) -> Result<AudioTranscribeOutput, AudioModelError> {
+        Err(AudioModelError::KindNotLoaded(AudioModelKind::Stt))
+    }
+
+    /// Run text-to-speech. Default: the direction is not loaded.
+    fn synthesize(
+        &self,
+        _input: AudioSynthesizeInput,
+    ) -> Result<AudioSynthesizeOutput, AudioModelError> {
+        Err(AudioModelError::KindNotLoaded(AudioModelKind::Tts))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_str_and_display_match() {
+        assert_eq!(AudioModelKind::Stt.as_str(), "stt");
+        assert_eq!(AudioModelKind::Tts.as_str(), "tts");
+        assert_eq!(AudioModelKind::Tts.to_string(), "tts");
+    }
+
+    #[test]
+    fn kind_not_loaded_error_names_the_kind() {
+        let err = AudioModelError::KindNotLoaded(AudioModelKind::Stt);
+        assert!(err.to_string().contains("audio model kind not loaded"));
+        assert!(err.to_string().contains("stt"));
+    }
+
+    /// A provider that only implements one direction keeps the default
+    /// "not loaded" body for the other, proving the two directions plug in
+    /// independently.
+    struct TtsOnly;
+    impl AudioModelProvider for TtsOnly {
+        fn supports(&self, kind: AudioModelKind) -> bool {
+            kind == AudioModelKind::Tts
+        }
+        fn synthesize(
+            &self,
+            input: AudioSynthesizeInput,
+        ) -> Result<AudioSynthesizeOutput, AudioModelError> {
+            Ok(AudioSynthesizeOutput {
+                samples: vec![0.0; input.input.len()],
+                sample_rate: 24_000,
+                channels: 1,
+            })
+        }
+    }
+
+    #[test]
+    fn default_transcribe_reports_kind_not_loaded() {
+        let provider = TtsOnly;
+        assert!(provider.supports(AudioModelKind::Tts));
+        assert!(!provider.supports(AudioModelKind::Stt));
+
+        let synth = provider
+            .synthesize(AudioSynthesizeInput {
+                input: "abc".to_string(),
+                voice: None,
+                speed: None,
+            })
+            .expect("tts-only provider synthesizes");
+        assert_eq!(synth.samples.len(), 3);
+
+        let err = provider
+            .transcribe(AudioTranscribeInput {
+                audio: vec![],
+                filename: None,
+                language: None,
+                temperature: None,
+                translate: false,
+            })
+            .expect_err("tts-only provider cannot transcribe");
+        assert!(matches!(
+            err,
+            AudioModelError::KindNotLoaded(AudioModelKind::Stt)
+        ));
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod anthropic_translator;
 pub mod app;
+pub mod audio_model;
 pub mod batch;
 mod chat_request;
 pub mod chat_template;
@@ -45,6 +46,10 @@ pub mod tool_calls;
 pub mod types;
 
 pub use app::create_app;
+pub use audio_model::{
+    AudioModelError, AudioModelKind, AudioModelProvider, AudioSynthesizeInput,
+    AudioSynthesizeOutput, AudioTranscribeInput, AudioTranscribeOutput,
+};
 pub use chat_template::ChatTemplateProcessor;
 pub use chat_template_kwargs::{
     ChatTemplateKwargs, ChatTemplateKwargsError, LLAMA_ARG_CHAT_TEMPLATE_KWARGS,

--- a/src/server/routes/audio.rs
+++ b/src/server/routes/audio.rs
@@ -1,0 +1,443 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! OpenAI-compatible audio endpoints.
+//!
+//! Three route families are exposed: `/audio/speech` (text-to-speech, JSON in,
+//! binary audio out), `/audio/transcriptions`, and `/audio/translations`
+//! (speech-to-text, `multipart/form-data` in, JSON out). This module only
+//! translates the HTTP request/response shape and admission; the model work
+//! lives behind the [`AudioModelProvider`](crate::server::audio_model::AudioModelProvider)
+//! seam in [`AppState::audio_model`]. While that slot is `None` every route
+//! returns a structured `501 Not Implemented` after parsing the request.
+
+use axum::{
+    Json,
+    body::Body,
+    extract::{Multipart, State, multipart::Field},
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+
+use crate::audio::encode_wav_pcm16;
+use crate::server::AppState;
+use crate::server::audio_model::{
+    AudioModelError, AudioModelKind, AudioSynthesizeInput, AudioTranscribeInput,
+    AudioTranscribeOutput,
+};
+use crate::server::types::{AudioSpeechRequest, AudioTranscriptionResponse, ErrorResponse};
+
+/// Resolved output container for a synthesized-audio response.
+#[derive(Debug)]
+struct AudioFormat {
+    /// `Content-Type` header value.
+    content_type: &'static str,
+    /// Filename extension used in `Content-Disposition`.
+    extension: &'static str,
+}
+
+/// POST /v1/audio/speech (text-to-speech).
+///
+/// Parses the JSON body, then returns a binary audio body when a TTS model is
+/// loaded or a structured `501 Not Implemented` while no model is wired in.
+pub async fn audio_speech(
+    State(state): State<AppState>,
+    Json(request): Json<AudioSpeechRequest>,
+) -> Response {
+    if !state.can_accept_request() {
+        return ErrorResponse::service_unavailable("All slots are busy. Please try again later.")
+            .into_response();
+    }
+
+    let Some(provider) = state.audio_model.clone() else {
+        return audio_kind_not_loaded(AudioModelKind::Tts).into_response();
+    };
+    if !provider.supports(AudioModelKind::Tts) {
+        return audio_kind_not_loaded(AudioModelKind::Tts).into_response();
+    }
+
+    // Resolve the container only once a model can actually serve the request,
+    // so the dominant pre-model response stays the structured 501 above.
+    let audio_format = match resolve_audio_format(request.response_format.as_deref()) {
+        Ok(format) => format,
+        Err(err) => return err.into_response(),
+    };
+
+    let input = AudioSynthesizeInput {
+        input: request.input,
+        voice: request.voice,
+        speed: request.speed,
+    };
+
+    let started = std::time::Instant::now();
+    let synth = tokio::task::spawn_blocking(move || provider.synthesize(input)).await;
+    let output = match synth {
+        Ok(Ok(output)) => output,
+        Ok(Err(err)) => return audio_model_error_response(err).into_response(),
+        Err(join_err) => {
+            tracing::error!("audio synthesis task panicked: {join_err}");
+            return ErrorResponse::new("audio synthesis failed", "server_error").into_response();
+        }
+    };
+    state
+        .metrics
+        .record_request(0, 0, started.elapsed().as_millis() as u64);
+
+    let body = encode_wav_pcm16(&output.samples, output.sample_rate, output.channels);
+    build_audio_response(&audio_format, body)
+}
+
+/// POST /v1/audio/transcriptions (speech-to-text, transcribe in place).
+pub async fn audio_transcriptions(State(state): State<AppState>, multipart: Multipart) -> Response {
+    transcribe(state, multipart, false).await
+}
+
+/// POST /v1/audio/translations (speech-to-text, translate to English).
+pub async fn audio_translations(State(state): State<AppState>, multipart: Multipart) -> Response {
+    transcribe(state, multipart, true).await
+}
+
+/// Shared speech-to-text flow for transcriptions and translations.
+async fn transcribe(state: AppState, multipart: Multipart, translate: bool) -> Response {
+    if !state.can_accept_request() {
+        return ErrorResponse::service_unavailable("All slots are busy. Please try again later.")
+            .into_response();
+    }
+
+    // Drive the multipart parser before consulting the model so malformed
+    // uploads surface as a structured 400 through the real request flow.
+    let form = match parse_transcription_multipart(multipart).await {
+        Ok(form) => form,
+        Err(err) => return err.into_response(),
+    };
+    tracing::debug!(
+        target: "mlxcel::audio",
+        requested_model = form.model.as_deref().unwrap_or(""),
+        translate,
+        "audio transcription request parsed"
+    );
+
+    let Some((audio, filename)) = form.file else {
+        return ErrorResponse::new(
+            "missing required 'file' part in multipart form-data",
+            "invalid_request_error",
+        )
+        .into_response();
+    };
+
+    let Some(provider) = state.audio_model.clone() else {
+        return audio_kind_not_loaded(AudioModelKind::Stt).into_response();
+    };
+    if !provider.supports(AudioModelKind::Stt) {
+        return audio_kind_not_loaded(AudioModelKind::Stt).into_response();
+    }
+
+    let response_format = form.response_format;
+    let input = AudioTranscribeInput {
+        audio,
+        filename,
+        language: form.language,
+        temperature: form.temperature,
+        translate,
+    };
+
+    let started = std::time::Instant::now();
+    let result = tokio::task::spawn_blocking(move || provider.transcribe(input)).await;
+    let output = match result {
+        Ok(Ok(output)) => output,
+        Ok(Err(err)) => return audio_model_error_response(err).into_response(),
+        Err(join_err) => {
+            tracing::error!("audio transcription task panicked: {join_err}");
+            return ErrorResponse::new("audio transcription failed", "server_error")
+                .into_response();
+        }
+    };
+    state
+        .metrics
+        .record_request(0, 0, started.elapsed().as_millis() as u64);
+
+    build_transcription_response(output, response_format.as_deref())
+}
+
+/// Fields extracted from a transcription/translation multipart form. The audio
+/// file is carried separately from the JSON-shaped scalar fields.
+#[derive(Default)]
+struct ParsedTranscriptionForm {
+    /// `(bytes, original filename)` of the uploaded audio.
+    file: Option<(Vec<u8>, Option<String>)>,
+    model: Option<String>,
+    language: Option<String>,
+    response_format: Option<String>,
+    temperature: Option<f32>,
+}
+
+/// Parse the STT `multipart/form-data` body: the `file` part plus the
+/// `model`, `language`, `response_format`, and `temperature` text fields.
+async fn parse_transcription_multipart(
+    mut multipart: Multipart,
+) -> Result<ParsedTranscriptionForm, ErrorResponse> {
+    let mut form = ParsedTranscriptionForm::default();
+    loop {
+        let field = match multipart.next_field().await {
+            Ok(Some(field)) => field,
+            Ok(None) => break,
+            Err(err) => {
+                return Err(ErrorResponse::new(
+                    format!("invalid multipart form-data: {err}"),
+                    "invalid_request_error",
+                ));
+            }
+        };
+
+        // Copy the part name to an owned value so the field body can be
+        // consumed below without an outstanding borrow.
+        let name = field.name().map(str::to_string);
+        match name.as_deref() {
+            Some("file") => {
+                let filename = field.file_name().map(str::to_string);
+                let bytes = field.bytes().await.map_err(|err| {
+                    ErrorResponse::new(
+                        format!("failed to read 'file' part: {err}"),
+                        "invalid_request_error",
+                    )
+                })?;
+                form.file = Some((bytes.to_vec(), filename));
+            }
+            Some("model") => form.model = Some(read_text_field(field).await?),
+            Some("language") => form.language = Some(read_text_field(field).await?),
+            Some("response_format") => form.response_format = Some(read_text_field(field).await?),
+            Some("temperature") => {
+                let raw = read_text_field(field).await?;
+                let trimmed = raw.trim();
+                if !trimmed.is_empty() {
+                    let value = trimmed.parse::<f32>().map_err(|_| {
+                        ErrorResponse::new(
+                            format!("invalid 'temperature' value: {raw}"),
+                            "invalid_request_error",
+                        )
+                    })?;
+                    form.temperature = Some(value);
+                }
+            }
+            // Drain unknown parts so the stream advances to the next field.
+            _ => {
+                let _ = field.bytes().await;
+            }
+        }
+    }
+    Ok(form)
+}
+
+/// Read a multipart field body as UTF-8 text.
+async fn read_text_field(field: Field<'_>) -> Result<String, ErrorResponse> {
+    field.text().await.map_err(|err| {
+        ErrorResponse::new(
+            format!("failed to read text field: {err}"),
+            "invalid_request_error",
+        )
+    })
+}
+
+/// Map a requested `response_format` to an output container. Only WAV is
+/// available today; other formats are an explicit follow-up.
+fn resolve_audio_format(requested: Option<&str>) -> Result<AudioFormat, ErrorResponse> {
+    match requested
+        .map(|value| value.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        None | Some("") | Some("wav") => Ok(AudioFormat {
+            content_type: "audio/wav",
+            extension: "wav",
+        }),
+        Some(other) => Err(ErrorResponse::new(
+            format!("response_format '{other}' is not supported; only 'wav' is available"),
+            "invalid_request_error",
+        )),
+    }
+}
+
+/// Build the binary audio response with the OpenAI attachment headers.
+fn build_audio_response(format: &AudioFormat, body: Vec<u8>) -> Response {
+    let disposition = format!("attachment; filename=speech.{}", format.extension);
+    match Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, format.content_type)
+        .header(header::CONTENT_DISPOSITION, disposition)
+        .body(Body::from(body))
+    {
+        Ok(response) => response,
+        Err(err) => {
+            tracing::error!("failed to build audio response: {err}");
+            ErrorResponse::new("failed to build audio response", "server_error").into_response()
+        }
+    }
+}
+
+/// Render a transcription result in the requested response format.
+fn build_transcription_response(
+    output: AudioTranscribeOutput,
+    response_format: Option<&str>,
+) -> Response {
+    match response_format
+        .map(|value| value.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("text") => (StatusCode::OK, output.text).into_response(),
+        Some("verbose_json") => Json(AudioTranscriptionResponse {
+            text: output.text,
+            language: output.language,
+            duration: output.duration_seconds,
+        })
+        .into_response(),
+        // `json` (the default) and any other value collapse to `{ "text": ... }`.
+        _ => Json(AudioTranscriptionResponse {
+            text: output.text,
+            language: None,
+            duration: None,
+        })
+        .into_response(),
+    }
+}
+
+/// Structured `501` reported when no model serves the requested audio
+/// direction.
+fn audio_kind_not_loaded(kind: AudioModelKind) -> ErrorResponse {
+    ErrorResponse::not_implemented(format!("audio model kind not loaded: {kind}"))
+}
+
+/// Convert an [`AudioModelError`] into the matching HTTP error response.
+fn audio_model_error_response(err: AudioModelError) -> ErrorResponse {
+    match err {
+        AudioModelError::KindNotLoaded(kind) => audio_kind_not_loaded(kind),
+        AudioModelError::Inference(message) => ErrorResponse::new(
+            format!("audio model inference failed: {message}"),
+            "server_error",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_format_defaults_to_wav() {
+        for input in [None, Some(""), Some("wav"), Some("WAV"), Some("  wav  ")] {
+            let format = resolve_audio_format(input).expect("wav-family format resolves");
+            assert_eq!(format.content_type, "audio/wav");
+            assert_eq!(format.extension, "wav");
+        }
+    }
+
+    #[test]
+    fn resolve_format_rejects_unsupported() {
+        let err = resolve_audio_format(Some("mp3")).expect_err("mp3 is not supported yet");
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert!(err.error.message.contains("mp3"));
+    }
+
+    #[test]
+    fn kind_not_loaded_is_501_with_phrase() {
+        for kind in [AudioModelKind::Stt, AudioModelKind::Tts] {
+            let err = audio_kind_not_loaded(kind);
+            assert_eq!(err.status, StatusCode::NOT_IMPLEMENTED);
+            assert_eq!(err.error.error_type, "not_implemented");
+            assert!(err.error.message.contains("audio model kind not loaded"));
+            assert!(err.error.message.contains(kind.as_str()));
+        }
+    }
+
+    #[test]
+    fn model_error_maps_kinds_and_inference() {
+        let inference = audio_model_error_response(AudioModelError::Inference("boom".into()));
+        assert_eq!(inference.error.error_type, "server_error");
+        assert!(inference.error.message.contains("boom"));
+
+        let not_loaded =
+            audio_model_error_response(AudioModelError::KindNotLoaded(AudioModelKind::Tts));
+        assert_eq!(not_loaded.status, StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[test]
+    fn audio_response_sets_binary_headers() {
+        let response = build_audio_response(
+            &AudioFormat {
+                content_type: "audio/wav",
+                extension: "wav",
+            },
+            vec![0, 1, 2, 3],
+        );
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        assert_eq!(content_type, "audio/wav");
+        let disposition = response
+            .headers()
+            .get(header::CONTENT_DISPOSITION)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        assert_eq!(disposition, "attachment; filename=speech.wav");
+    }
+
+    #[test]
+    fn transcription_format_selects_content_type() {
+        let make = || AudioTranscribeOutput {
+            text: "hello".to_string(),
+            language: Some("en".to_string()),
+            duration_seconds: Some(1.5),
+        };
+
+        let json = build_transcription_response(make(), None);
+        assert_eq!(json.status(), StatusCode::OK);
+        let json_ct = json
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        assert!(json_ct.contains("application/json"), "got {json_ct}");
+
+        let text = build_transcription_response(make(), Some("text"));
+        let text_ct = text
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        assert!(text_ct.contains("text/plain"), "got {text_ct}");
+    }
+
+    #[test]
+    fn minimal_transcription_serializes_to_text_only() {
+        let body = AudioTranscriptionResponse {
+            text: "hi".to_string(),
+            language: None,
+            duration: None,
+        };
+        let json = serde_json::to_value(&body).expect("serializes");
+        assert_eq!(json, serde_json::json!({ "text": "hi" }));
+    }
+
+    #[test]
+    fn speech_request_parses_with_optional_fields_defaulted() {
+        let req: AudioSpeechRequest =
+            serde_json::from_str(r#"{"model":"m","input":"hello"}"#).expect("parses");
+        assert_eq!(req.model, "m");
+        assert_eq!(req.input, "hello");
+        assert!(req.voice.is_none());
+        assert!(req.response_format.is_none());
+        assert!(req.speed.is_none());
+    }
+}

--- a/src/server/routes/audio.rs
+++ b/src/server/routes/audio.rs
@@ -172,7 +172,7 @@ async fn transcribe(state: AppState, multipart: Multipart, translate: bool) -> R
 
 /// Fields extracted from a transcription/translation multipart form. The audio
 /// file is carried separately from the JSON-shaped scalar fields.
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct ParsedTranscriptionForm {
     /// `(bytes, original filename)` of the uploaded audio.
     file: Option<(Vec<u8>, Option<String>)>,
@@ -285,6 +285,12 @@ fn build_audio_response(format: &AudioFormat, body: Vec<u8>) -> Response {
 }
 
 /// Render a transcription result in the requested response format.
+///
+/// Supported formats: `json` (the default, also matches `None` and empty
+/// string), `text`, and `verbose_json`. Any other non-empty value returns 400
+/// so callers catch typos rather than silently receiving a JSON body. This
+/// validation stays in this function rather than at the parse stage so that
+/// the 501 response from the no-model path dominates during Phase 1.
 fn build_transcription_response(
     output: AudioTranscribeOutput,
     response_format: Option<&str>,
@@ -293,6 +299,13 @@ fn build_transcription_response(
         .map(|value| value.trim().to_ascii_lowercase())
         .as_deref()
     {
+        // `json` and the absent/empty-string default both return the compact form.
+        None | Some("") | Some("json") => Json(AudioTranscriptionResponse {
+            text: output.text,
+            language: None,
+            duration: None,
+        })
+        .into_response(),
         Some("text") => (StatusCode::OK, output.text).into_response(),
         Some("verbose_json") => Json(AudioTranscriptionResponse {
             text: output.text,
@@ -300,12 +313,13 @@ fn build_transcription_response(
             duration: output.duration_seconds,
         })
         .into_response(),
-        // `json` (the default) and any other value collapse to `{ "text": ... }`.
-        _ => Json(AudioTranscriptionResponse {
-            text: output.text,
-            language: None,
-            duration: None,
-        })
+        Some(other) => ErrorResponse::new(
+            format!(
+                "response_format '{other}' is not supported; \
+                 supported formats are: json, text, verbose_json"
+            ),
+            "invalid_request_error",
+        )
         .into_response(),
     }
 }
@@ -330,6 +344,8 @@ fn audio_model_error_response(err: AudioModelError) -> ErrorResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::extract::FromRequest;
+    use axum::http::Request;
 
     #[test]
     fn resolve_format_defaults_to_wav() {
@@ -420,6 +436,65 @@ mod tests {
     }
 
     #[test]
+    fn transcription_unsupported_format_returns_bad_request() {
+        let make = || AudioTranscribeOutput {
+            text: "hello".to_string(),
+            language: Some("en".to_string()),
+            duration_seconds: Some(1.5),
+        };
+        for format in ["srt", "vtt"] {
+            let response = build_transcription_response(make(), Some(format));
+            assert_eq!(
+                response.status(),
+                StatusCode::BAD_REQUEST,
+                "format '{format}' should return 400"
+            );
+        }
+    }
+
+    #[test]
+    fn transcription_json_explicit_matches_none_default() {
+        let make = || AudioTranscribeOutput {
+            text: "hello".to_string(),
+            language: Some("en".to_string()),
+            duration_seconds: Some(1.5),
+        };
+        for fmt in [None, Some("json")] {
+            let response = build_transcription_response(make(), fmt);
+            assert_eq!(response.status(), StatusCode::OK);
+            let ct = response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default();
+            assert!(
+                ct.contains("application/json"),
+                "format {fmt:?} should yield JSON content type, got {ct}"
+            );
+        }
+    }
+
+    #[test]
+    fn transcription_verbose_json_returns_json_content_type() {
+        let output = AudioTranscribeOutput {
+            text: "bonjour".to_string(),
+            language: Some("fr".to_string()),
+            duration_seconds: Some(2.0),
+        };
+        let response = build_transcription_response(output, Some("verbose_json"));
+        assert_eq!(response.status(), StatusCode::OK);
+        let ct = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            ct.contains("application/json"),
+            "verbose_json should yield JSON content type, got {ct}"
+        );
+    }
+
+    #[test]
     fn minimal_transcription_serializes_to_text_only() {
         let body = AudioTranscriptionResponse {
             text: "hi".to_string(),
@@ -439,5 +514,148 @@ mod tests {
         assert!(req.voice.is_none());
         assert!(req.response_format.is_none());
         assert!(req.speed.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Multipart parser unit tests
+    // -----------------------------------------------------------------------
+
+    const BOUNDARY: &str = "testboundary1234";
+
+    /// Build a single text part (no filename, no Content-Type header).
+    fn text_part(name: &str, value: &[u8]) -> Vec<u8> {
+        let mut part = Vec::new();
+        part.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+        part.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"{name}\"\r\n").as_bytes(),
+        );
+        part.extend_from_slice(b"\r\n");
+        part.extend_from_slice(value);
+        part.extend_from_slice(b"\r\n");
+        part
+    }
+
+    /// Build a binary file part with Content-Disposition filename and Content-Type.
+    fn file_part(name: &str, filename: &str, content_type: &str, data: &[u8]) -> Vec<u8> {
+        let mut part = Vec::new();
+        part.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+        part.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"{name}\"; filename=\"{filename}\"\r\n")
+                .as_bytes(),
+        );
+        part.extend_from_slice(format!("Content-Type: {content_type}\r\n").as_bytes());
+        part.extend_from_slice(b"\r\n");
+        part.extend_from_slice(data);
+        part.extend_from_slice(b"\r\n");
+        part
+    }
+
+    /// The closing delimiter that terminates a multipart body.
+    fn end_boundary() -> Vec<u8> {
+        format!("--{BOUNDARY}--\r\n").into_bytes()
+    }
+
+    /// Wrap raw bytes in a POST request and extract a `Multipart` from it.
+    async fn make_multipart(body_bytes: Vec<u8>) -> Multipart {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/audio/transcriptions")
+            .header(
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={BOUNDARY}"),
+            )
+            .body(Body::from(body_bytes))
+            .unwrap();
+        Multipart::from_request(request, &()).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn multipart_parses_well_formed_form() {
+        let file_bytes = encode_wav_pcm16(&[0.0_f32, 0.1, -0.1], 16_000, 1);
+        let mut body = Vec::new();
+        body.extend(file_part("file", "clip.wav", "audio/wav", &file_bytes));
+        body.extend(text_part("model", b"test-stt-model"));
+        body.extend(text_part("language", b"en"));
+        body.extend(text_part("response_format", b"json"));
+        body.extend(text_part("temperature", b"0.5"));
+        body.extend(end_boundary());
+
+        let form = parse_transcription_multipart(make_multipart(body).await)
+            .await
+            .expect("well-formed form parses");
+        let (bytes, filename) = form.file.expect("file bytes captured");
+        assert_eq!(bytes, file_bytes, "file bytes round-trip");
+        assert_eq!(filename.as_deref(), Some("clip.wav"), "filename captured");
+        assert_eq!(form.model.as_deref(), Some("test-stt-model"));
+        assert_eq!(form.language.as_deref(), Some("en"));
+        assert_eq!(form.response_format.as_deref(), Some("json"));
+        let temp = form.temperature.expect("temperature captured");
+        assert!((temp - 0.5_f32).abs() < 1e-5, "expected 0.5, got {temp}");
+    }
+
+    #[tokio::test]
+    async fn multipart_empty_temperature_yields_none() {
+        let mut body = Vec::new();
+        body.extend(text_part("model", b"m"));
+        body.extend(text_part("temperature", b"  "));
+        body.extend(end_boundary());
+
+        let form = parse_transcription_multipart(make_multipart(body).await)
+            .await
+            .expect("empty temperature field parses without error");
+        assert!(
+            form.temperature.is_none(),
+            "whitespace-only temperature should be treated as not supplied"
+        );
+    }
+
+    #[tokio::test]
+    async fn multipart_invalid_temperature_returns_bad_request() {
+        let mut body = Vec::new();
+        body.extend(text_part("model", b"m"));
+        body.extend(text_part("temperature", b"not_a_number"));
+        body.extend(end_boundary());
+
+        let err = parse_transcription_multipart(make_multipart(body).await)
+            .await
+            .expect_err("non-numeric temperature should fail");
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert!(
+            err.error.message.contains("not_a_number"),
+            "error message should echo the bad value"
+        );
+    }
+
+    #[tokio::test]
+    async fn multipart_unknown_part_is_drained_and_ignored() {
+        let mut body = Vec::new();
+        body.extend(text_part("prompt", b"some caller-supplied hint"));
+        body.extend(text_part("model", b"my-model"));
+        body.extend(end_boundary());
+
+        let form = parse_transcription_multipart(make_multipart(body).await)
+            .await
+            .expect("unknown part should be drained without error");
+        assert_eq!(
+            form.model.as_deref(),
+            Some("my-model"),
+            "known parts after unknown part are still captured"
+        );
+    }
+
+    #[tokio::test]
+    async fn multipart_missing_file_part_yields_none() {
+        let mut body = Vec::new();
+        body.extend(text_part("model", b"m"));
+        body.extend(text_part("language", b"fr"));
+        body.extend(end_boundary());
+
+        let form = parse_transcription_multipart(make_multipart(body).await)
+            .await
+            .expect("form without file part still parses");
+        assert!(
+            form.file.is_none(),
+            "file field is None when the part is absent (caller enforces the 400)"
+        );
     }
 }

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -19,6 +19,7 @@
 //! `server/media.rs`, `server/streaming.rs`, and `server/model_worker.rs`.
 
 pub mod anthropic;
+pub mod audio;
 pub mod cache;
 pub mod chat;
 pub mod completions;
@@ -33,6 +34,7 @@ pub mod slots;
 pub mod tokenize;
 
 pub use anthropic::{anthropic_count_tokens, anthropic_messages};
+pub use audio::{audio_speech, audio_transcriptions, audio_translations};
 pub use cache::{cache_reset, cache_stats};
 pub use chat::chat_completions;
 pub use completions::completions;

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -25,6 +25,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use crate::distributed::pipeline::{PipelineObservability, PpTracer};
 use crate::tokenizer::MlxcelTokenizer;
 
+use super::audio_model::AudioModelProvider;
 use super::batch::BatchObservability;
 use super::conversation_store::ConversationStore;
 use super::prompt_cache::{PromptCacheStore, metrics::PromptCacheMetrics};
@@ -371,6 +372,10 @@ pub struct AppState {
     /// `conversation` field in Responses-API requests. `None` when the
     /// store is disabled.
     pub conversation_store: Option<Arc<ConversationStore>>,
+    /// Audio-model provider serving the `/audio/*` endpoints. `None` until a
+    /// speech-to-text or text-to-speech model is wired in; while it is `None`
+    /// the audio routes return a structured `501 Not Implemented`.
+    pub audio_model: Option<Arc<dyn AudioModelProvider>>,
 }
 
 impl AppState {
@@ -398,6 +403,7 @@ impl AppState {
             prompt_cache: None,
             responses_store: None,
             conversation_store: None,
+            audio_model: None,
         }
     }
 
@@ -429,6 +435,7 @@ impl AppState {
             prompt_cache: None,
             responses_store: None,
             conversation_store: None,
+            audio_model: None,
         }
     }
 
@@ -481,6 +488,14 @@ impl AppState {
     #[must_use]
     pub fn with_pp_tracer(mut self, tracer: Option<Arc<PpTracer>>) -> Self {
         self.pp_tracer = tracer;
+        self
+    }
+
+    /// Attach an audio-model provider serving the `/audio/*` endpoints. Pass
+    /// `None` to leave the routes returning a structured `501 Not Implemented`.
+    #[must_use]
+    pub fn with_audio_model(mut self, provider: Option<Arc<dyn AudioModelProvider>>) -> Self {
+        self.audio_model = provider;
         self
     }
 

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -739,6 +739,56 @@ pub struct DetokenizeRequest {
     pub tokens: Vec<i32>,
 }
 
+// ---------------------------------------------------------------------------
+// Audio API request types (OpenAI-compatible)
+// Used by: routes/audio.rs
+// ---------------------------------------------------------------------------
+
+/// Text-to-speech request (POST /v1/audio/speech).
+///
+/// JSON body mirroring the OpenAI `audio/speech` payload. The response is
+/// binary audio rather than JSON.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AudioSpeechRequest {
+    /// Identifier of the speech model to use.
+    pub model: String,
+    /// Text to synthesize into audio.
+    pub input: String,
+    /// Optional named voice.
+    #[serde(default)]
+    pub voice: Option<String>,
+    /// Optional output container (`wav` today; others are a follow-up).
+    #[serde(default)]
+    pub response_format: Option<String>,
+    /// Optional playback-speed multiplier.
+    #[serde(default)]
+    pub speed: Option<f32>,
+}
+
+/// Speech-to-text request fields (POST /v1/audio/transcriptions and
+/// /v1/audio/translations).
+///
+/// These arrive as `multipart/form-data`: the audio file is a separate part
+/// (parsed directly from the multipart stream, not this struct) while the
+/// remaining form fields populate this struct. Deriving `Deserialize` keeps
+/// the field naming aligned with the OpenAI JSON schema for documentation and
+/// future reuse.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct AudioTranscriptionRequest {
+    /// Identifier of the speech model to use.
+    #[serde(default)]
+    pub model: String,
+    /// Optional ISO-639-1 source-language hint.
+    #[serde(default)]
+    pub language: Option<String>,
+    /// Optional response container (`json`, `text`, `verbose_json`).
+    #[serde(default)]
+    pub response_format: Option<String>,
+    /// Optional sampling temperature.
+    #[serde(default)]
+    pub temperature: Option<f32>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -765,14 +765,15 @@ pub struct AudioSpeechRequest {
     pub speed: Option<f32>,
 }
 
-/// Speech-to-text request fields (POST /v1/audio/transcriptions and
+/// Speech-to-text request schema (POST /v1/audio/transcriptions and
 /// /v1/audio/translations).
 ///
-/// These arrive as `multipart/form-data`: the audio file is a separate part
-/// (parsed directly from the multipart stream, not this struct) while the
-/// remaining form fields populate this struct. Deriving `Deserialize` keeps
-/// the field naming aligned with the OpenAI JSON schema for documentation and
-/// future reuse.
+/// This struct mirrors the OpenAI transcription field schema for reference and
+/// future reuse. The live multipart handler parses the fields directly from the
+/// `multipart/form-data` stream and does not deserialize into this struct.
+/// `Deserialize` is derived to keep field naming aligned with the OpenAI JSON
+/// schema and to support JSON-based deserialization in tests or future contexts
+/// that do not use multipart upload.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct AudioTranscriptionRequest {
     /// Identifier of the speech model to use.
@@ -845,6 +846,33 @@ mod tests {
         assert_eq!(
             msg.content.image_urls(),
             vec!["data:image/png;base64,AAAA".to_string()]
+        );
+    }
+
+    #[test]
+    fn audio_transcription_request_deserializes_and_defaults() {
+        // All fields present: verify each is captured.
+        let full: AudioTranscriptionRequest = serde_json::from_str(
+            r#"{"model":"test-model","language":"en","response_format":"json","temperature":0.0}"#,
+        )
+        .expect("full form deserializes");
+        assert_eq!(full.model, "test-model");
+        assert_eq!(full.language.as_deref(), Some("en"));
+        assert_eq!(full.response_format.as_deref(), Some("json"));
+        assert_eq!(full.temperature, Some(0.0_f32));
+
+        // Omitted optional fields must default to None.
+        let minimal: AudioTranscriptionRequest =
+            serde_json::from_str(r#"{"model":"m"}"#).expect("minimal form deserializes");
+        assert_eq!(minimal.model, "m");
+        assert!(minimal.language.is_none(), "language defaults to None");
+        assert!(
+            minimal.response_format.is_none(),
+            "response_format defaults to None"
+        );
+        assert!(
+            minimal.temperature.is_none(),
+            "temperature defaults to None"
         );
     }
 }

--- a/src/server/types/response.rs
+++ b/src/server/types/response.rs
@@ -466,6 +466,20 @@ impl ErrorResponse {
             status: axum::http::StatusCode::SERVICE_UNAVAILABLE,
         }
     }
+
+    /// Build a `501 Not Implemented` error. Used by the audio endpoints to
+    /// report that no model is loaded for the requested audio direction while
+    /// the request itself parsed successfully.
+    pub fn not_implemented(message: impl Into<String>) -> Self {
+        Self {
+            error: ErrorDetail {
+                message: message.into(),
+                error_type: "not_implemented".into(),
+                code: None,
+            },
+            status: axum::http::StatusCode::NOT_IMPLEMENTED,
+        }
+    }
 }
 
 impl axum::response::IntoResponse for ErrorResponse {
@@ -509,6 +523,24 @@ pub struct TokenizeResponse {
 #[derive(Debug, Clone, Serialize)]
 pub struct DetokenizeResponse {
     pub content: String,
+}
+
+/// Transcription/translation response (POST /v1/audio/transcriptions and
+/// /v1/audio/translations).
+///
+/// The default `json` response format serializes to `{ "text": ... }`; the
+/// optional fields are populated only for `verbose_json` and are omitted
+/// otherwise.
+#[derive(Debug, Clone, Serialize)]
+pub struct AudioTranscriptionResponse {
+    /// Recognized text.
+    pub text: String,
+    /// Detected or supplied source language (verbose responses only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    /// Source audio duration in seconds (verbose responses only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<f32>,
 }
 
 /// Server properties response (GET /props)


### PR DESCRIPTION
## Summary

Phase 1 server plumbing for the OpenAI-compatible audio API surface (part of epic #363). This registers the speech and transcription/translation routes, parses their request shapes (JSON for text-to-speech, multipart/form-data for speech-to-text), and adds the audio-output WAV encoder. No speech model is implemented here; every audio route returns a structured HTTP 501 "audio model kind not loaded" until the model sub-issues land. The audio-model interface is deliberately generic so the speech-to-text and text-to-speech work plugs in without reworking the server surface.

## What changed

- Added the `multipart` axum feature and a multipart parser for the speech-to-text upload (the `file` part plus the `model`, `language`, `response_format`, and `temperature` fields) via `axum::extract::Multipart`.
- Registered six routes in `create_app` (`src/server/app.rs`): `/audio/speech`, `/audio/transcriptions`, and `/audio/translations`, each in both the unversioned and `/v1`-prefixed forms.
- Added `src/server/routes/audio.rs`: the JSON text-to-speech handler returns a binary `audio/wav` body with a `Content-Disposition: attachment; filename=speech.wav` header; the multipart speech-to-text handlers parse the upload and return OpenAI transcription JSON. All handlers reuse `state.can_accept_request()` admission control, the existing request metrics, and `ErrorResponse`.
- Added a generic audio-model seam in `src/server/audio_model.rs`: an `AudioModelKind { Stt, Tts }` enum plus an `AudioModelProvider` trait whose `transcribe` and `synthesize` methods default to a "kind not loaded" error, so each direction can be implemented independently. Added an `Option<Arc<dyn AudioModelProvider>>` slot to `AppState` (`None` in this phase) with a `with_audio_model` builder.
- Added request/response types in `src/server/types/`: `AudioSpeechRequest`, `AudioTranscriptionRequest`, and `AudioTranscriptionResponse`, plus an `ErrorResponse::not_implemented` (HTTP 501) constructor.
- Added `src/audio/wav_writer.rs` with `encode_wav_pcm16`, a PCM16 little-endian RIFF WAV encoder that is the counterpart to the existing reader. The reader is reused, not duplicated.
- Noted the new endpoint families in `docs/architecture.md`.

## Behavior in this phase

All six routes are mounted and reachable. The text-to-speech route parses its JSON body and the speech-to-text routes parse their multipart body through the real request flow; with no model loaded each returns a structured HTTP 501 with the message "audio model kind not loaded". The synthesize and transcribe code paths (binary WAV response, transcription JSON) are written and compile so the model sub-issues only need to supply an `AudioModelProvider`.

## Test plan

- [x] `cargo check --lib --tests --features metal,accelerate`
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `cargo test --lib --features metal,accelerate audio::wav_writer` (WAV encode round-trips through `load_wav_from_bytes`)
- [x] `cargo test --lib --features metal,accelerate server::audio_model`
- [x] `cargo test --lib --features metal,accelerate server::routes::audio`

Closes #364
