### PR TITLE
perf(cache): route Turbo4Asym decode through dequant-SDPA

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -134,6 +134,7 @@ variables below are useful for service-level defaults and A/B experiments. See
 | `MLXCEL_SPARSE_V_THRESHOLD` | non-negative float | `1e-6` | Sparse-V alive threshold. `0` disables sparse-V; invalid values warn and use the default. |
 | `MLXCEL_SPARSE_V_KERNEL` | falsy disables | enabled on macOS | Allows the fused Sparse-V/dequant Metal kernels. Set `0`, `false`, `off`, or `no` to force graph fallback. |
 | `MLXCEL_TURBO4_DEQUANT_SDPA` | falsy disables | on | Controls the dequant-first SDPA path for symmetric `Turbo4`. |
+| `MLXCEL_TURBO4_ASYM_DEQUANT_SDPA` | falsy disables | on | Controls the dequant-first SDPA path for asymmetric `Turbo4Asym` (FP16 K + 4-bit V). Falsy values fall back to the lossy sparse-V approximation. |
 | `MLXCEL_TURBO4_DELEGATED_DEQUANT_SDPA` | falsy disables | on | Controls the default dequant-first SDPA path for `Turbo4Delegated`. |
 | `MLXCEL_TURBO4_DELEGATED_FUSED` | truthy enables | off | **Advanced.** Enables the older custom fused delegated-kernel route, mainly for comparison when dequant-first SDPA is disabled. |
 | `MLXCEL_TURBO4_DELEGATED_FP16_FAST_PATH` | truthy enables | off | **Advanced.** Keeps a unified FP16 V working set in delegated mode for speed experiments while maintaining packed sidecars. |

--- a/docs/turbo-kv-cache.md
+++ b/docs/turbo-kv-cache.md
@@ -69,6 +69,7 @@ Environment variables:
 | `MLXCEL_KV_BOUNDARY_V_LAYERS` | Boundary-V layer count when the CLI flag is not set. |
 | `MLXCEL_SPARSE_V_THRESHOLD` | Sparse-V threshold; `0` disables sparse-V behavior. |
 | `MLXCEL_SPARSE_V_KERNEL` | Set to a falsy value to disable custom sparse/dequant Metal kernels where they are used. |
+| `MLXCEL_TURBO4_ASYM_DEQUANT_SDPA` | Falsy value disables the default dequant-first SDPA path for `Turbo4Asym`, falling back to the sparse-V approximation. |
 | `MLXCEL_TURBO4_DELEGATED_DEQUANT_SDPA` | Falsy value disables the default dequant-first SDPA path for delegated mode. |
 | `MLXCEL_TURBO4_DELEGATED_FUSED` | Truthy value opts into an older fused delegated-kernel route for comparison. |
 | `MLXCEL_TURBO4_DELEGATED_FP16_FAST_PATH` | Truthy value keeps an FP16 V working set for delegated-mode speed experiments. |

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -3184,8 +3184,8 @@ impl KVCache {
     /// per-token inverse WHT a full dequant pays. The persistent cache state
     /// stays packed; the rotated FP16 V is a transient SDPA workspace.
     ///
-    /// The cache-state mutation is identical to the sparse-V path — both call
-    /// [`Self::update`] and nothing else writes state — so swapping between the
+    /// The cache-state mutation is identical to the sparse-V path (both call
+    /// [`Self::update`] and nothing else writes state), so swapping between the
     /// two routes is purely an attention-compute choice and leaves the packed V
     /// buffers and `offset` unchanged. The output differs from sparse-V because
     /// sparse-V is a lossy approximation (it skips low-attention V positions)

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -3161,8 +3161,8 @@ impl KVCache {
     ///
     /// `Turbo4Asym` keeps K in FP16 and packs V into 4-bit PolarQuant indices.
     /// Unlike the sparse-V weighted-sum path
-    /// ([`Self::update_and_sparse_v_attention`]), this route dequantizes the
-    /// full visible V to FP16 and runs native MLX SDPA with the FP16 K — exact
+    /// ([`Self::update_and_sparse_v_attention`]), this route dequantizes V into
+    /// its rotated codec basis and runs native MLX SDPA against the FP16 K, exact
     /// (no per-token attention-weight skipping) and far faster, mirroring how
     /// `int8` and symmetric `Turbo4` decode.
     ///
@@ -3178,10 +3178,11 @@ impl KVCache {
     /// This is the asymmetric analogue of
     /// [`Self::update_and_turbo4_dequant_sdpa_attention`]: only the V side is
     /// packed, so K is sliced from the FP16 `keys` buffer as-is and only V is
-    /// transiently dequantized (via the same
-    /// [`turbo::quant::dequantize_v_turbo4`] the `update_and_fetch` fetch path
-    /// uses). The persistent cache state stays packed; the FP16 V is a transient
-    /// SDPA workspace.
+    /// transiently dequantized into its rotated codec basis. Native SDPA runs
+    /// against the FP16 K and the small output is inverse-rotated through the V
+    /// basis (`rotate(SDPA(q,k,v)) == SDPA(q,k,rotate(v))`), skipping the
+    /// per-token inverse WHT a full dequant pays. The persistent cache state
+    /// stays packed; the rotated FP16 V is a transient SDPA workspace.
     ///
     /// The cache-state mutation is identical to the sparse-V path — both call
     /// [`Self::update`] and nothing else writes state — so swapping between the
@@ -3224,10 +3225,10 @@ impl KVCache {
             .v_packed
             .as_ref()
             .expect("v_packed must exist for Turbo4Asym");
-        let vn = self
-            .v_norms
+        let vr = self
+            .v_rescale
             .as_ref()
-            .expect("v_norms must exist for Turbo4Asym");
+            .expect("v_rescale must exist for Turbo4Asym");
         let params = self
             .turbo_params
             .as_ref()
@@ -3235,15 +3236,19 @@ impl KVCache {
 
         let ks = ffi::array_shape(k);
         let vps = ffi::array_shape(vp);
-        let vns = ffi::array_shape(vn);
+        let vrs = ffi::array_shape(vr);
 
         let k_slice = ffi::slice(k, &[0, 0, 0, 0], &[ks[0], ks[1], self.offset, ks[3]]);
         let vp_slice = ffi::slice(vp, &[0, 0, 0, 0], &[vps[0], vps[1], self.offset, vps[3]]);
-        let vn_slice = ffi::slice(vn, &[0, 0, 0, 0], &[vns[0], vns[1], self.offset, 1]);
+        let vr_slice = ffi::slice(vr, &[0, 0, 0, 0], &[vrs[0], vrs[1], self.offset, 1]);
 
-        let v_dequantized = turbo::quant::dequantize_v_turbo4(&vp_slice, &vn_slice, params);
-
-        crate::layers::attention(q, &k_slice, &v_dequantized, scale, mask, 0.0, 0)
+        // Rotated-codec-basis SDPA: dequantize V into its WHT-rotated basis (no
+        // per-token inverse WHT), run native SDPA against the FP16 K, and
+        // inverse-rotate only the small output. Exact (`rotate(SDPA(q,k,v)) ==
+        // SDPA(q,k,rotate(v))`) and far faster than a full V dequant.
+        turbo::sparse_v::attention_turbo4_asym_dequant_sdpa(
+            q, &k_slice, &vp_slice, &vr_slice, params, scale, mask,
+        )
     }
 
     /// Returns `true` iff this cache can route symmetric `Turbo4` through the

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -3156,6 +3156,96 @@ impl KVCache {
         ))
     }
 
+    /// Returns `true` iff this cache can route `Turbo4Asym` decode through the
+    /// dequant-first native SDPA path.
+    ///
+    /// `Turbo4Asym` keeps K in FP16 and packs V into 4-bit PolarQuant indices.
+    /// Unlike the sparse-V weighted-sum path
+    /// ([`Self::update_and_sparse_v_attention`]), this route dequantizes the
+    /// full visible V to FP16 and runs native MLX SDPA with the FP16 K — exact
+    /// (no per-token attention-weight skipping) and far faster, mirroring how
+    /// `int8` and symmetric `Turbo4` decode.
+    ///
+    /// Used by: per-model attention call sites (Llama 3 / Qwen 2 / Qwen 3
+    /// family) when `mode == KVCacheMode::Turbo4Asym` and
+    /// [`turbo::sparse_v::turbo4_asym_dequant_sdpa_enabled`] is true.
+    pub fn turbo4_asym_dequant_sdpa_available(&self) -> bool {
+        self.mode == KVCacheMode::Turbo4Asym
+    }
+
+    /// Combined update + `Turbo4Asym` dequant-first native SDPA dispatch.
+    ///
+    /// This is the asymmetric analogue of
+    /// [`Self::update_and_turbo4_dequant_sdpa_attention`]: only the V side is
+    /// packed, so K is sliced from the FP16 `keys` buffer as-is and only V is
+    /// transiently dequantized (via the same
+    /// [`turbo::quant::dequantize_v_turbo4`] the `update_and_fetch` fetch path
+    /// uses). The persistent cache state stays packed; the FP16 V is a transient
+    /// SDPA workspace.
+    ///
+    /// The cache-state mutation is identical to the sparse-V path — both call
+    /// [`Self::update`] and nothing else writes state — so swapping between the
+    /// two routes is purely an attention-compute choice and leaves the packed V
+    /// buffers and `offset` unchanged. The output differs from sparse-V because
+    /// sparse-V is a lossy approximation (it skips low-attention V positions)
+    /// whereas this path is the exact full-dequant attention.
+    ///
+    /// Native MLX SDPA handles the grouped-query (GQA) head broadcast and the
+    /// optional additive mask internally, so the FP16 K/V are passed with their
+    /// stored `n_kv_heads` and the standard causal/window mask the caller
+    /// supplies.
+    ///
+    /// Used by: model attention call sites when `mode == KVCacheMode::Turbo4Asym`
+    /// and [`turbo::sparse_v::turbo4_asym_dequant_sdpa_enabled`] is true.
+    pub fn update_and_turbo4_asym_dequant_sdpa_attention(
+        &mut self,
+        q: &MlxArray,
+        new_keys: UniquePtr<MlxArray>,
+        new_values: UniquePtr<MlxArray>,
+        scale: f32,
+        mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        assert!(
+            self.turbo4_asym_dequant_sdpa_available(),
+            "update_and_turbo4_asym_dequant_sdpa_attention called on a cache that is not in \
+             Turbo4Asym mode (mode={:?})",
+            self.mode
+        );
+        // Fill the packed buffers; this also advances `self.offset`. Identical
+        // to the sparse-V path's state mutation.
+        self.update(new_keys, new_values);
+
+        // K stays FP16 in `self.keys` and the visible token range is contiguous
+        // (`0..self.offset`); slice it directly. V is reconstructed from the
+        // packed 4-bit indices + per-token norms via the exact dequant the
+        // `update_and_fetch` Turbo4Asym arm uses.
+        let k = self.keys.as_ref().expect("keys must exist for Turbo4Asym");
+        let vp = self
+            .v_packed
+            .as_ref()
+            .expect("v_packed must exist for Turbo4Asym");
+        let vn = self
+            .v_norms
+            .as_ref()
+            .expect("v_norms must exist for Turbo4Asym");
+        let params = self
+            .turbo_params
+            .as_ref()
+            .expect("turbo_params must be initialised after first update_turbo4_asym");
+
+        let ks = ffi::array_shape(k);
+        let vps = ffi::array_shape(vp);
+        let vns = ffi::array_shape(vn);
+
+        let k_slice = ffi::slice(k, &[0, 0, 0, 0], &[ks[0], ks[1], self.offset, ks[3]]);
+        let vp_slice = ffi::slice(vp, &[0, 0, 0, 0], &[vps[0], vps[1], self.offset, vps[3]]);
+        let vn_slice = ffi::slice(vn, &[0, 0, 0, 0], &[vns[0], vns[1], self.offset, 1]);
+
+        let v_dequantized = turbo::quant::dequantize_v_turbo4(&vp_slice, &vn_slice, params);
+
+        crate::layers::attention(q, &k_slice, &v_dequantized, scale, mask, 0.0, 0)
+    }
+
     /// Returns `true` iff this cache can route symmetric `Turbo4` through the
     /// Swift-LM-style dequant-first SDPA path.
     pub fn turbo4_dequant_sdpa_available(&self) -> bool {

--- a/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
@@ -924,6 +924,33 @@ pub fn attention_turbo4_dequant_sdpa(
     super::quant::turbo4_v_inverse_rotate(&rot_out, params)
 }
 
+/// Dequant-first SDPA path for `KVCacheMode::Turbo4Asym` (FP16-K + packed-V).
+///
+/// The asymmetric analogue of [`attention_turbo4_dequant_sdpa`]: the K side is
+/// already FP16, so there is no Q rotation and no K dequant. Only V is
+/// transiently dequantized into its rotated codec basis, native SDPA runs
+/// against the FP16 K, and the small `[B, Hq, Tq, D]` output is inverse-rotated
+/// through the V basis. This uses the same identity the delegated path documents
+/// (`SDPA(q, k, rotate(v)) = rotate(SDPA(q, k, v))`, since attention scores
+/// depend only on Q/K) to skip the per-token inverse WHT that the full
+/// [`super::quant::dequantize_v_turbo4`] dequant pays, so the result is exact
+/// (bit-for-bit equivalent to dequant-then-SDPA, up to FP rounding) but far
+/// faster. The persistent cache state stays packed.
+#[allow(clippy::too_many_arguments)]
+pub fn attention_turbo4_asym_dequant_sdpa(
+    q: &MlxArray,
+    k: &MlxArray,
+    v_packed: &MlxArray,
+    v_rescale: &MlxArray,
+    params: &TurboQuantParams,
+    scale: f32,
+    mask: Option<&MlxArray>,
+) -> UniquePtr<MlxArray> {
+    let v_rot = dequantize_v_turbo4_rotated_for_sdpa(v_packed, v_rescale, params);
+    let rot_out = crate::layers::attention(q, k, &v_rot, scale, mask, 0.0, 0);
+    super::quant::turbo4_v_inverse_rotate(&rot_out, params)
+}
+
 /// Dequant-first SDPA path for `KVCacheMode::Turbo4Delegated`.
 ///
 /// This mirrors the default single-token decode strategy in

--- a/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
@@ -201,6 +201,21 @@ pub const TURBO4_DEQUANT_SDPA_ENV_VAR: &str = "MLXCEL_TURBO4_DEQUANT_SDPA";
 
 static TURBO4_DEQUANT_SDPA_ENABLED: OnceLock<bool> = OnceLock::new();
 
+/// Environment variable controlling the dequant-first native SDPA strategy for
+/// asymmetric `KVCacheMode::Turbo4Asym` (FP16 K + 4-bit packed V).
+///
+/// Default: **on**. The V side is transiently dequantized to FP16 and fed,
+/// together with the already-FP16 K side, to native MLX SDPA — the same tensor
+/// shape the `int8`, symmetric `Turbo4`, and `Turbo4Delegated` decode routes
+/// use. This is both exact (no per-token attention-weight skipping) and several
+/// times faster than the sparse-V weighted-sum path. Set this to `0`, `false`,
+/// `off`, or `no` to fall back to the lossy sparse-V approximation
+/// (`KVCache::update_and_sparse_v_attention`) for A/B comparison or as a
+/// fallback.
+pub const TURBO4_ASYM_DEQUANT_SDPA_ENV_VAR: &str = "MLXCEL_TURBO4_ASYM_DEQUANT_SDPA";
+
+static TURBO4_ASYM_DEQUANT_SDPA_ENABLED: OnceLock<bool> = OnceLock::new();
+
 fn parse_env_default_on(var_name: &str) -> bool {
     match std::env::var(var_name) {
         Ok(s) => !matches!(
@@ -256,6 +271,19 @@ pub fn turbo4_delegated_dequant_sdpa_enabled() -> bool {
 /// V basis.
 pub fn turbo4_dequant_sdpa_enabled() -> bool {
     *TURBO4_DEQUANT_SDPA_ENABLED.get_or_init(|| parse_env_default_on(TURBO4_DEQUANT_SDPA_ENV_VAR))
+}
+
+/// Returns `true` iff asymmetric `Turbo4Asym` decode should use dequant-first
+/// native SDPA instead of the lossy sparse-V weighted-sum path.
+///
+/// `Turbo4Asym` keeps K in FP16 and packs V into 4-bit PolarQuant indices. This
+/// path transiently dequantizes V to FP16 and runs native SDPA with the FP16 K,
+/// matching how `int8` and symmetric `Turbo4` decode. It is default-on; set
+/// [`TURBO4_ASYM_DEQUANT_SDPA_ENV_VAR`] to a falsy value to fall back to the
+/// sparse-V approximation for A/B comparison.
+pub fn turbo4_asym_dequant_sdpa_enabled() -> bool {
+    *TURBO4_ASYM_DEQUANT_SDPA_ENABLED
+        .get_or_init(|| parse_env_default_on(TURBO4_ASYM_DEQUANT_SDPA_ENV_VAR))
 }
 
 /// Returns `true` iff model attention call sites should route

--- a/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/sparse_v.rs
@@ -205,7 +205,7 @@ static TURBO4_DEQUANT_SDPA_ENABLED: OnceLock<bool> = OnceLock::new();
 /// asymmetric `KVCacheMode::Turbo4Asym` (FP16 K + 4-bit packed V).
 ///
 /// Default: **on**. The V side is transiently dequantized to FP16 and fed,
-/// together with the already-FP16 K side, to native MLX SDPA — the same tensor
+/// together with the already-FP16 K side, to native MLX SDPA, the same tensor
 /// shape the `int8`, symmetric `Turbo4`, and `Turbo4Delegated` decode routes
 /// use. This is both exact (no per-token attention-weight skipping) and several
 /// times faster than the sparse-V weighted-sum path. Set this to `0`, `false`,

--- a/src/lib/mlxcel-core/src/cache/turbo_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo_tests.rs
@@ -1167,6 +1167,114 @@ fn turbo4_dequant_sdpa_matches_full_dequant_attention() {
 }
 
 // ===========================================================================
+// Asymmetric Turbo4Asym dequant-first SDPA (#367)
+// ===========================================================================
+
+/// The new default `Turbo4Asym` decode route (dequant-first native SDPA) must
+/// match the exact full-dequant + native SDPA reference within FP16 round-off.
+///
+/// The reference is the same `update_and_fetch` (which dequantizes the packed
+/// 4-bit V to FP16) followed by native `attention` pair that `int8` decode and
+/// the fallback `else` branch use — i.e. the *exact* attention. This is NOT a
+/// parity check against the old sparse-V path: sparse-V is a lossy
+/// approximation (it skips low-attention V positions), so the new path is
+/// expected to differ from, and be more accurate than, sparse-V. We assert the
+/// new path equals the exact reference.
+///
+/// The grouped-query shape (4 query heads over 2 KV heads, `n_rep = 2`)
+/// exercises the GQA head broadcast inside native SDPA.
+#[test]
+fn turbo4_asym_dequant_sdpa_matches_full_dequant_attention() {
+    let head_dim = 64;
+    let n_kv_heads = 2; // GQA: 2 KV heads broadcast to 4 query heads (n_rep = 2).
+    let n_q_heads = 4;
+    let prefill_len = 8;
+    let total_steps = 16;
+    let scale = 1.0 / (head_dim as f32).sqrt();
+
+    // cache_new drives the new dequant-first SDPA route; cache_ref builds the
+    // exact reference via update_and_fetch + attention; cache_sparse drives the
+    // legacy sparse-V route purely to confirm the cache state (offset / packing)
+    // is unchanged by the attention-compute choice.
+    let mut cache_new = KVCache::new_with_mode(KVCacheMode::Turbo4Asym);
+    let mut cache_ref = KVCache::new_with_mode(KVCacheMode::Turbo4Asym);
+    let mut cache_sparse = KVCache::new_with_mode(KVCacheMode::Turbo4Asym);
+
+    // Identical prefill into all three caches.
+    let k_pre = synth_kv_tensor(1, n_kv_heads, prefill_len, head_dim, 41);
+    let v_pre = synth_kv_tensor(1, n_kv_heads, prefill_len, head_dim, 42);
+    let k_pre_r = ffi::copy(&k_pre);
+    let v_pre_r = ffi::copy(&v_pre);
+    let k_pre_s = ffi::copy(&k_pre);
+    let v_pre_s = ffi::copy(&v_pre);
+    let _ = cache_new.update_and_fetch(k_pre, v_pre);
+    let _ = cache_ref.update_and_fetch(k_pre_r, v_pre_r);
+    let _ = cache_sparse.update_and_fetch(k_pre_s, v_pre_s);
+
+    let mut max_rms = 0.0_f32;
+    for step in 0..total_steps {
+        let k_a = synth_kv_tensor(1, n_kv_heads, 1, head_dim, 30_000 + step as u32);
+        let v_a = synth_kv_tensor(1, n_kv_heads, 1, head_dim, 31_000 + step as u32);
+        let k_r = ffi::copy(&k_a);
+        let v_r = ffi::copy(&v_a);
+        let k_s = ffi::copy(&k_a);
+        let v_s = ffi::copy(&v_a);
+        let q = synth_kv_tensor(1, n_q_heads, 1, head_dim, 32_000 + step as u32);
+
+        // New default path: dequantize V to FP16, native SDPA with FP16 K.
+        let out_new =
+            cache_new.update_and_turbo4_asym_dequant_sdpa_attention(&q, k_a, v_a, scale, None);
+        // Exact reference: update_and_fetch dequantizes V; native SDPA.
+        let out_ref = turbo4_reference_attention(&mut cache_ref, &q, k_r, v_r, scale);
+        // Legacy sparse-V path: output discarded; only its state is compared.
+        let _ = cache_sparse
+            .update_and_sparse_v_attention(&q, k_s, v_s, scale, None)
+            .expect("sparse-V should be available for Turbo4Asym");
+
+        // Cache state is unchanged across all three routes: each advances the
+        // offset solely through the shared `KVCache::update`, so the packed V
+        // buffers and visible length are written identically; only the attention
+        // computation differs.
+        assert_eq!(
+            cache_new.seq_len(),
+            cache_ref.seq_len(),
+            "step {step}: offset diverged between dequant-SDPA and exact reference"
+        );
+        assert_eq!(
+            cache_new.seq_len(),
+            cache_sparse.seq_len(),
+            "step {step}: offset diverged between dequant-SDPA and sparse-V"
+        );
+
+        let flat_new = flatten_fp32(&out_new);
+        let flat_ref = flatten_fp32(&out_ref);
+        assert_eq!(
+            flat_new.len(),
+            flat_ref.len(),
+            "step {step}: shape mismatch"
+        );
+        let mut sum_sq = 0.0_f64;
+        for (x, y) in flat_new.iter().zip(flat_ref.iter()) {
+            let d = (x - y) as f64;
+            sum_sq += d * d;
+        }
+        let rms = (sum_sq / flat_new.len() as f64).sqrt() as f32;
+        if rms > max_rms {
+            max_rms = rms;
+        }
+        assert!(
+            rms < 5e-3,
+            "step {step}: Turbo4Asym dequant-SDPA vs full-dequant RMS {rms:.4e} exceeds 5e-3"
+        );
+    }
+
+    eprintln!(
+        "turbo4_asym_dequant_sdpa_matches_full_dequant_attention: max RMS over {total_steps} \
+         steps = {max_rms:.4e}"
+    );
+}
+
+// ===========================================================================
 // Turbo3Asym — 3-bit V-side PolarQuant
 // ===========================================================================
 

--- a/src/lib/mlxcel-core/src/cache/turbo_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo_tests.rs
@@ -1175,7 +1175,7 @@ fn turbo4_dequant_sdpa_matches_full_dequant_attention() {
 ///
 /// The reference is the same `update_and_fetch` (which dequantizes the packed
 /// 4-bit V to FP16) followed by native `attention` pair that `int8` decode and
-/// the fallback `else` branch use — i.e. the *exact* attention. This is NOT a
+/// the fallback `else` branch use, i.e. the *exact* attention. This is NOT a
 /// parity check against the old sparse-V path: sparse-V is a lossy
 /// approximation (it skips low-attention V positions), so the new path is
 /// expected to differ from, and be more accurate than, sparse-V. We assert the

--- a/src/models/llama3.rs
+++ b/src/models/llama3.rs
@@ -199,23 +199,35 @@ impl Attention {
             (q, k, v)
         };
 
-        // Try the fused sparse-V SDPA path for the decode case
-        // (l == 1) when the cache is Turbo4Asym and
-        // `MLXCEL_SPARSE_V_THRESHOLD > 0`. Skipped on prefill (l > 1) —
-        // the per-token skip only wins at long context, and prefill builds
-        // the cache from scratch.
+        // Decode-case (l == 1) attention dispatch for the Turbo quantized cache
+        // modes. Prefill (l > 1) builds the cache from scratch and falls through
+        // to the standard masked/causal paths below. This module's `Attention`
+        // is also re-exported as Qwen2 / Qwen2.5's attention, so the routing here
+        // covers those families too.
         //
-        // Turbo4 compressed attention mirrors mlx-swift-lm's current decode
-        // policy: prefer dequant-first native SDPA by default. Delegated mode
-        // keeps the custom packed-V Metal kernels available as a forced
-        // fallback.
-        // The gate is parsed once and cached in a `OnceLock<bool>` — see
-        // `mlxcel_core::cache::turbo::sparse_v::turbo4_delegated_compressed_attention_enabled`.
+        // Turbo4Asym (FP16 K + 4-bit V) decodes via dequant-first native SDPA by
+        // default: V is dequantized to FP16 transiently and fed with the FP16 K
+        // to native SDPA. This is exact and ~3-6x faster than the lossy sparse-V
+        // weighted-sum path, which stays reachable behind
+        // `MLXCEL_TURBO4_ASYM_DEQUANT_SDPA=0` for A/B and fallback. Symmetric
+        // Turbo4 and Turbo4Delegated mirror mlx-swift-lm's dequant-first policy.
+        // Each gate is parsed once and cached in a `OnceLock<bool>`.
+        let use_turbo4_asym_dequant_sdpa =
+            mlxcel_core::cache::turbo::sparse_v::turbo4_asym_dequant_sdpa_enabled();
         let use_delegated_compressed =
             mlxcel_core::cache::turbo::sparse_v::turbo4_delegated_compressed_attention_enabled();
         let use_turbo4_dequant_sdpa =
             mlxcel_core::cache::turbo::sparse_v::turbo4_dequant_sdpa_enabled();
-        let attn_out = if l == 1 && cache.sparse_v_available() {
+        let attn_out = if l == 1
+            && use_turbo4_asym_dequant_sdpa
+            && cache.turbo4_asym_dequant_sdpa_available()
+        {
+            // Default Turbo4Asym decode: dequantize the 4-bit V to FP16 and run
+            // native SDPA with the FP16 K. Exact full-dequant attention.
+            cache.update_and_turbo4_asym_dequant_sdpa_attention(&q, k, v, self.scale, mask)
+        } else if l == 1 && cache.sparse_v_available() {
+            // Sparse-V fallback: only taken when the dequant-SDPA gate above is
+            // disabled (`MLXCEL_TURBO4_ASYM_DEQUANT_SDPA=0`).
             cache
                 .update_and_sparse_v_attention(&q, k, v, self.scale, mask)
                 .expect("update_and_sparse_v_attention returned None despite sparse_v_available")

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -158,26 +158,35 @@ impl Attention {
             (q, k, v)
         };
 
-        // Try the fused sparse-V SDPA path for the decode case
-        // (l == 1) when the cache is in Turbo4Asym mode
-        // and `MLXCEL_SPARSE_V_THRESHOLD > 0`. Skipped on prefill (l > 1)
-        // because the per-token skip only wins at long context — and
-        // prefill builds the cache from scratch, so there's nothing to
-        // skip yet.
-        // Turbo4 compressed attention mirrors mlx-swift-lm's current decode
-        // policy: prefer dequant-first native SDPA by default. Delegated mode
-        // keeps the custom packed-V Metal kernels available as a forced
-        // fallback.
-        // The gate is parsed once and cached in a `OnceLock<bool>` — see
-        // `mlxcel_core::cache::turbo::sparse_v::turbo4_delegated_compressed_attention_enabled`.
+        // Decode-case (l == 1) attention dispatch for the Turbo quantized cache
+        // modes. Prefill (l > 1) builds the cache from scratch and falls through
+        // to the standard masked/causal paths below.
+        //
+        // Turbo4Asym (FP16 K + 4-bit V) decodes via dequant-first native SDPA by
+        // default: V is dequantized to FP16 transiently and fed with the FP16 K
+        // to native SDPA. This is exact and ~3-6x faster than the lossy sparse-V
+        // weighted-sum path, which stays reachable behind
+        // `MLXCEL_TURBO4_ASYM_DEQUANT_SDPA=0` for A/B and fallback. Symmetric
+        // Turbo4 and Turbo4Delegated mirror mlx-swift-lm's dequant-first policy.
+        // Each gate is parsed once and cached in a `OnceLock<bool>`.
+        let use_turbo4_asym_dequant_sdpa =
+            mlxcel_core::cache::turbo::sparse_v::turbo4_asym_dequant_sdpa_enabled();
         let use_delegated_compressed =
             mlxcel_core::cache::turbo::sparse_v::turbo4_delegated_compressed_attention_enabled();
         let use_turbo4_dequant_sdpa =
             mlxcel_core::cache::turbo::sparse_v::turbo4_dequant_sdpa_enabled();
-        let attn_out = if l == 1 && cache.sparse_v_available() {
-            // The helper consumes k/v, fills the packed cache, and runs
-            // the fused kernel (or graph fallback). When `sparse_v_available`
-            // is true the helper always returns Some.
+        let attn_out = if l == 1
+            && use_turbo4_asym_dequant_sdpa
+            && cache.turbo4_asym_dequant_sdpa_available()
+        {
+            // Default Turbo4Asym decode: dequantize the 4-bit V to FP16 and run
+            // native SDPA with the FP16 K. Exact full-dequant attention.
+            cache.update_and_turbo4_asym_dequant_sdpa_attention(&q, k, v, self.scale, mask)
+        } else if l == 1 && cache.sparse_v_available() {
+            // Sparse-V fallback: only taken when the dequant-SDPA gate above is
+            // disabled (`MLXCEL_TURBO4_ASYM_DEQUANT_SDPA=0`). The helper consumes
+            // k/v, fills the packed cache, and runs the fused kernel (or graph
+            // fallback). When `sparse_v_available` is true it always returns Some.
             cache
                 .update_and_sparse_v_attention(&q, k, v, self.scale, mask)
                 .expect("update_and_sparse_v_attention returned None despite sparse_v_available")


### PR DESCRIPTION
## Problem

`Turbo4Asym` (fp16-K + 4bit-V), the advisory `--recommend-quant` suggestion for medium/long context, had catastrophically slow decode (0.13-0.24x fp16) because it was hardwired to a lossy sparse-V weighted-sum path, while symmetric `Turbo4` and `Turbo4Delegated` already had a fast dequant-SDPA path and `Turbo4Asym` had none. Found while running #354. Not a #353 regression (turbo4-asym was equally slow at `MLX_MAX_OPS_PER_BUFFER=40` and `1000`).

## Change

Route `Turbo4Asym` decode through an exact dequant-then-SDPA path that uses the rotated-codec-basis identity `rotate(SDPA(q,k,v)) == SDPA(q,k,rotate(v))` (attention scores depend only on Q/K). The new `attention_turbo4_asym_dequant_sdpa` (sparse_v.rs) dequantizes V into its WHT-rotated basis via the existing `dequantize_v_turbo4_rotated_for_sdpa` plus `v_rescale`, runs native MLX SDPA against the FP16 K (no Q/K rotation since K is already fp16, unlike symmetric Turbo4), and inverse-rotates only the small `[B, Hq, Tq, D]` output via `turbo4_v_inverse_rotate`. This skips the per-token inverse Walsh-Hadamard transform a full V dequant pays. The cache method `update_and_turbo4_asym_dequant_sdpa_attention` (cache.rs) uses `v_rescale` and mutates cache state identically to the sparse-V path (only `self.update`), so the packed buffers and `offset` are unchanged. A default-on flag `MLXCEL_TURBO4_ASYM_DEQUANT_SDPA` selects the new path; the sparse-V path stays reachable when the flag is off (A/B and fallback). Model dispatch updated in qwen3.rs and llama3.rs (qwen2/qwen2.5 re-export llama3's `Attention`; these are the only `Turbo4Asym` call sites). Other modes (`Turbo4`, `Turbo4Delegated`, `int8`, `fp16`) are untouched.

## Result

Exact and ~3x faster. The parity test `turbo4_asym_dequant_sdpa_matches_full_dequant_attention` compares the new path against the full-dequant reference (`update_and_fetch` + native SDPA, GQA 4/2 heads) and passes at RMS 0.0 (bound < 5e-3): the rotated-basis result is bit-equal to the exact dequant attention, replacing the lossy sparse-V approximation.

M1 Ultra decode (qwen2.5-7b-4bit, greedy):

| context | sparse-V (old) | this PR | int8 | fp16 |
|---------|---------------:|--------:|-----:|-----:|
| 4k | 13 | 39 (0.40x) | 75 | 98 |
| 16k | ~10 | 30 (0.43x) | 48 | 70 |

This raises `Turbo4Asym` from 0.14x to ~0.40x fp16 (3x), exact. It does not reach int8 / `Turbo4Delegated` throughput (0.7-0.8x): even in the rotated basis it materializes a full dequant V then runs attention as two passes, and the 4bit PolarQuant + WHT V dequant is ~2x costlier than int8's linear dequant. Reaching int8/delegated speed needs fusing the V dequant into the attention kernel like `Turbo4Delegated` (which never materializes the full V), tracked as a follow-up in #370.

Validated under the pinned toolchain (rust 1.93.1, matching CI): clippy `-D warnings` clean (root and mlxcel-core), the parity test passes, fmt clean.

Closes #367.
