### PR TITLE
feat(models): Whisper ASR speech-to-text for /v1/audio endpoints

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Current GitHub-facing docs:
 7. `turbo-kv-cache.md` — TurboQuant modes, the unified paged KV cache, quality/performance trade-offs, and flags.
 8. `CONTINUOUS_BATCHING.md` — continuous-batching scheduler, paged decode, and disaggregated prefill/decode/router serving.
 9. `responses-api.md` — implemented `/v1/responses` subset and gaps.
-10. `audio-api.md` — implemented `/v1/audio` endpoints, Phase 1 501 behavior, and WAV encoding details.
+10. `audio-api.md` — implemented `/v1/audio` endpoints: Whisper STT setup, request/response reference, WAV encoding details, and request validation order.
 11. `adding-models.md` — contribution guide for new model architectures.
 12. `block-diffusion.md` — DiffusionGemma block-diffusion generation: canvas denoising vs autoregressive, CLI flags, throughput, and phase 1 limitations.
 

--- a/docs/audio-api.md
+++ b/docs/audio-api.md
@@ -2,7 +2,7 @@
 
 `mlxcel serve` and `mlxcel-server` expose the three OpenAI-compatible audio endpoints: text-to-speech (`/v1/audio/speech`), transcription (`/v1/audio/transcriptions`), and translation (`/v1/audio/translations`).
 
-**Phase 1 status.** The HTTP plumbing (request parsing, multipart handling, binary response framing) is complete and all three routes are mounted. Until an audio model is registered via `AppState::with_audio_model`, every request returns a structured `501 Not Implemented` with error type `not_implemented`. This is by design: Phase 1 establishes the transport boundary; Phase 2 wires in a speech model.
+**Current status.** The HTTP plumbing (request parsing, multipart handling, binary response framing) is complete and all three routes are mounted. Speech-to-text (`/v1/audio/transcriptions` and `/v1/audio/translations`) is functional: load a Whisper checkpoint with the `-m` flag and the STT slot is populated automatically. Text-to-speech (`/v1/audio/speech`) has no model implementation yet and always returns a structured `501 Not Implemented`. Any route whose model kind is not loaded returns 501 after the request is fully parsed.
 
 ## Implemented endpoints
 
@@ -19,11 +19,32 @@ Alias paths without the `/v1` prefix are also mounted: `/audio/speech`, `/audio/
 | Module | Responsibility |
 |--------|----------------|
 | `src/server/audio_model.rs` | `AudioModelProvider` trait, input/output types, `AudioModelKind`, `AudioModelError`. |
+| `src/server/audio_worker.rs` | `AudioWorker` and `AudioEngine`: dedicated MLX-owning thread that loads and runs the audio model. |
+| `src/server/whisper_stt.rs` | `WhisperSttProvider`: wires the WAV reader and Whisper front-end to the `AudioModelProvider` seam. |
 | `src/server/routes/audio.rs` | HTTP handlers, multipart parser, format resolution, binary/JSON response builders. |
 | `src/server/types/request.rs` | `AudioSpeechRequest`, `AudioTranscriptionRequest` (schema reference). |
 | `src/server/types/response.rs` | `AudioTranscriptionResponse`, `ErrorResponse` (including `not_implemented`). |
 | `src/audio/wav_writer.rs` | `encode_wav_pcm16`: `f32` PCM samples to RIFF WAV bytes. |
+| `src/audio/whisper_mel.rs` | Log-mel front-end: STFT, Slaney mel filterbank, normalization, and 16 kHz resampler. |
 | `src/server/app.rs` | Route registration and `AUDIO_MAX_UPLOAD_BYTES` (25 MiB) body-limit layer. |
+
+## Whisper STT setup
+
+Pass a Whisper checkpoint directory to `-m`. The server detects `model_type: "whisper"` in `config.json` and populates the STT slot via `WhisperSttProvider`, which owns a dedicated worker thread for all MLX graph evaluation.
+
+```sh
+mlxcel-server -m models/whisper-base
+```
+
+Both the native MLX key layout and the HuggingFace `WhisperForConditionalGeneration` layout load without conversion. The checkpoint directory must contain `config.json`, one or more SafeTensors weight files, and `tokenizer.json`.
+
+Loading a Whisper checkpoint occupies the audio slot only; the server does not serve `/v1/chat/completions` or generation requests from that process. Chat and STT are separate server instances.
+
+**Supported audio input.** The `file` part must be a WAV file. Audio is decoded with the shared WAV reader, converted to mono, and resampled to 16 kHz before the log-mel front-end. Other container formats (MP3, FLAC, etc.) are not yet supported; the WAV reader returns an error for non-WAV input and the route returns 400.
+
+**Long audio.** Audio longer than 30 seconds is split into consecutive 30-second windows, each transcribed independently. The results are concatenated in order. Word-level timestamps, segment-level timestamps, and VAD-gated chunking are follow-ups.
+
+**Current limitations.** Non-quantized (fp16/f32) checkpoints only; quantized Whisper weights are not yet supported. Greedy decoding only; beam search is a follow-up.
 
 ## POST /v1/audio/speech
 
@@ -64,7 +85,7 @@ curl -s -X POST http://localhost:8080/v1/audio/speech \
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `file` | file part | yes | Raw audio bytes. Any container the loaded provider can decode. |
+| `file` | file part | yes | Raw WAV audio bytes. The current Whisper provider decodes WAV only; other container formats return 400. |
 | `model` | text | no | STT model identifier. Forwarded to the provider. |
 | `language` | text | no | ISO-639-1 source-language hint (`en`, `ko`, etc.). |
 | `response_format` | text | no | `json` (default), `text`, or `verbose_json`. Any other non-empty value returns 400. |
@@ -101,7 +122,7 @@ curl -s -X POST http://localhost:8080/v1/audio/transcriptions \
 
 Same multipart shape and field semantics as `/v1/audio/transcriptions`. The difference is that the loaded model is asked to output text in English regardless of the source language. The `501` message names `stt` (the same underlying capability direction).
 
-## Phase 1 boundaries
+## Request validation order
 
 The 501 response is returned **after** the request is fully parsed. This means:
 

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -8,9 +8,10 @@ runtime source of truth is the code, not this prose page:
 - loading policy: `src/model_metadata.rs`
 - VLM loading routes: `src/loading/vlm*.rs`
 
-As of v0.1.4, `ModelType` contains 93 variants: 71 text/non-VLM variants
-and 22 VLM variants. These are architecture/runtime variants, not a guarantee
-that every checkpoint under a marketing family name is supported.
+As of v0.1.4, `ModelType` contains 94 variants: 71 text/non-VLM variants,
+22 VLM variants, and a speech-to-text encoder-decoder (Whisper). These are
+architecture/runtime variants, not a guarantee that every checkpoint under a
+marketing family name is supported.
 
 ## Text and hybrid model families
 
@@ -106,6 +107,14 @@ Qwen-style `<think>` models. To turn thinking off, pass
 `chat_template_kwargs={"enable_thinking": false}` per request, or set the server
 default via `--chat-template-kwargs` or `LLAMA_ARG_CHAT_TEMPLATE_KWARGS`. A
 per-request value always wins over the server default.
+
+## Speech-to-text (ASR)
+
+mlxcel loads Whisper-style encoder-decoder ASR checkpoints (`model_type: "whisper"`) and serves them through the OpenAI audio endpoints. A convolutional audio encoder builds features from a 30-second log-mel window, and an autoregressive text decoder cross-attends to those features as it emits tokens, steered by the multilingual transcribe/translate task tokens.
+
+When the server's loaded checkpoint is detected as Whisper, the speech-to-text slot is populated and `POST /v1/audio/transcriptions` (transcribe in place) and `POST /v1/audio/translations` (translate to English) return the recognized text. Uploaded audio is decoded with the shared WAV reader, resampled to 16 kHz, and processed in consecutive 30-second windows. An explicit `language` hint is honored; otherwise the language is detected from the first decoder step. Token suppression follows the Whisper rules: `suppress_blank`, the non-speech symbol set, and `<|notimestamps|>`.
+
+This first port targets non-quantized (fp16/f32) checkpoints with greedy decoding, and the loader accepts both the native MLX and HuggingFace key layouts. Loading a Whisper checkpoint serves speech-to-text only; chat generation is not available in the same process. Beam search, word-level and segment timestamps, quantized checkpoints, and streaming transcription are follow-ups.
 
 ## Quantization formats
 

--- a/src/audio/feature_extractor.rs
+++ b/src/audio/feature_extractor.rs
@@ -302,7 +302,10 @@ impl AudioFeatureExtractor {
 
 /// Compute magnitude of real-valued FFT using simple DFT.
 /// Returns `[num_freq_bins]` magnitudes.
-fn real_fft_magnitude(input: &[f64], num_bins: usize) -> Vec<f64> {
+///
+/// Shared with the Whisper log-mel front-end in [`super::whisper_mel`], which
+/// squares the result to obtain the power spectrum.
+pub(crate) fn real_fft_magnitude(input: &[f64], num_bins: usize) -> Vec<f64> {
     let n = input.len();
     let mut magnitudes = Vec::with_capacity(num_bins);
     for k in 0..num_bins {

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -32,6 +32,7 @@ pub mod encoder;
 pub mod feature_extractor;
 pub mod nemotron_h_nano_omni;
 pub mod wav_writer;
+pub mod whisper_mel;
 
 pub use config::AudioConfig;
 pub use encoder::AudioEncoder;

--- a/src/audio/whisper_mel.rs
+++ b/src/audio/whisper_mel.rs
@@ -1,0 +1,322 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Log-mel front-end for the Whisper-style ASR encoder.
+//!
+//! This is the speech-recognition counterpart to the USM front-end in the
+//! sibling [`super::feature_extractor`] module. The two differ in their
+//! normalization and mel scale, so this file only adds the recognizer-specific
+//! parameters and reuses the shared DSP primitive
+//! ([`super::feature_extractor::real_fft_magnitude`]) for the per-frame
+//! transform.
+//!
+//! Pipeline (16 kHz mono input):
+//! 1. centered STFT with a 400-point periodic Hann window and a 160-sample hop
+//!    (reflect padding by `n_fft / 2`, trailing analysis frame dropped),
+//! 2. power spectrum (`|rfft|^2`) over the 201 retained frequency bins,
+//! 3. Slaney-scale, Slaney-normalized triangular mel projection,
+//! 4. `log10` with a global dynamic-range clamp and an affine rescale into the
+//!    encoder's expected range.
+
+use std::f64::consts::PI;
+
+use super::feature_extractor::real_fft_magnitude;
+
+/// Native sample rate the encoder expects.
+pub const WHISPER_SAMPLE_RATE: u32 = 16_000;
+/// STFT window / FFT size in samples (25 ms at 16 kHz).
+pub const WHISPER_N_FFT: usize = 400;
+/// STFT hop in samples (10 ms at 16 kHz).
+pub const WHISPER_HOP_LENGTH: usize = 160;
+/// Chunk length the encoder is trained on, in seconds.
+pub const WHISPER_CHUNK_LENGTH: usize = 30;
+/// Samples in one 30 s chunk.
+pub const WHISPER_N_SAMPLES: usize = WHISPER_CHUNK_LENGTH * WHISPER_SAMPLE_RATE as usize;
+/// Mel frames produced by one full 30 s chunk.
+pub const WHISPER_N_FRAMES: usize = WHISPER_N_SAMPLES / WHISPER_HOP_LENGTH;
+
+/// Periodic Hann window of length `n` (`0.5 - 0.5*cos(2*pi*i/n)`).
+///
+/// This matches the window used by the reference front-end (the periodic form,
+/// denominator `n`, identical to the window built inline by the sibling USM
+/// extractor).
+fn periodic_hann(n: usize) -> Vec<f32> {
+    (0..n)
+        .map(|i| (0.5 - 0.5 * (2.0 * PI * i as f64 / n as f64).cos()) as f32)
+        .collect()
+}
+
+fn hz_to_mel_slaney(freq: f64) -> f64 {
+    let f_sp = 200.0 / 3.0;
+    let min_log_hz = 1000.0;
+    let min_log_mel = min_log_hz / f_sp;
+    let logstep = (6.4f64).ln() / 27.0;
+    if freq >= min_log_hz {
+        min_log_mel + (freq / min_log_hz).ln() / logstep
+    } else {
+        freq / f_sp
+    }
+}
+
+fn mel_to_hz_slaney(mel: f64) -> f64 {
+    let f_sp = 200.0 / 3.0;
+    let min_log_hz = 1000.0;
+    let min_log_mel = min_log_hz / f_sp;
+    let logstep = (6.4f64).ln() / 27.0;
+    if mel >= min_log_mel {
+        min_log_hz * (logstep * (mel - min_log_mel)).exp()
+    } else {
+        f_sp * mel
+    }
+}
+
+/// Slaney-scale, Slaney-normalized triangular mel filterbank, stored row-major
+/// as `[n_freqs][n_mels]` (i.e. `filters.T` of the reference layout) so the mel
+/// projection is a plain `power[frame] . filters` dot product.
+fn whisper_mel_filters(n_mels: usize) -> Vec<f32> {
+    let n_freqs = WHISPER_N_FFT / 2 + 1; // 201
+    let f_max = WHISPER_SAMPLE_RATE as f64 / 2.0; // 8000
+
+    let all_freqs: Vec<f64> = (0..n_freqs)
+        .map(|i| i as f64 * f_max / (n_freqs as f64 - 1.0))
+        .collect();
+
+    let m_min = hz_to_mel_slaney(0.0);
+    let m_max = hz_to_mel_slaney(f_max);
+    let m_pts: Vec<f64> = (0..n_mels + 2)
+        .map(|i| m_min + (m_max - m_min) * i as f64 / (n_mels as f64 + 1.0))
+        .collect();
+    let f_pts: Vec<f64> = m_pts.iter().map(|&m| mel_to_hz_slaney(m)).collect();
+
+    let f_diff: Vec<f64> = (0..f_pts.len() - 1)
+        .map(|i| f_pts[i + 1] - f_pts[i])
+        .collect();
+
+    let mut bank = vec![0.0f32; n_freqs * n_mels];
+    for (freq_idx, &freq) in all_freqs.iter().enumerate() {
+        for mel in 0..n_mels {
+            // slopes[freq, pt] = f_pts[pt] - freq
+            let down = -(f_pts[mel] - freq) / f_diff[mel];
+            let up = (f_pts[mel + 2] - freq) / f_diff[mel + 1];
+            let mut val = down.min(up).max(0.0);
+            // Slaney normalization: 2 / (f_pts[mel+2] - f_pts[mel]).
+            let enorm = 2.0 / (f_pts[mel + 2] - f_pts[mel]);
+            val *= enorm;
+            bank[freq_idx * n_mels + mel] = val as f32;
+        }
+    }
+    bank
+}
+
+/// Reflect-pad `audio` by `pad` samples on each side (numpy `reflect`: the edge
+/// sample is not repeated). Falls back to clamped indices for inputs shorter
+/// than the pad width so very short clips do not panic.
+fn reflect_pad(audio: &[f32], pad: usize) -> Vec<f32> {
+    let n = audio.len();
+    let mut out = Vec::with_capacity(n + 2 * pad);
+    if n == 0 {
+        out.resize(2 * pad, 0.0);
+        return out;
+    }
+    // prefix: audio[1..=pad] reversed (clamped to available range)
+    for i in (1..=pad).rev() {
+        out.push(audio[i.min(n - 1)]);
+    }
+    out.extend_from_slice(audio);
+    // suffix: audio[n-1-pad .. n-1] reversed (clamped)
+    for i in 1..=pad {
+        let idx = (n - 1).saturating_sub(i);
+        out.push(audio[idx]);
+    }
+    out
+}
+
+/// Linear-interpolation resampler from `src_rate` to 16 kHz mono.
+///
+/// Linear interpolation is adequate for the recognizer's robustness; a
+/// polyphase/sinc resampler is a documented follow-up.
+pub fn resample_to_16k(samples: &[f32], src_rate: u32) -> Vec<f32> {
+    if src_rate == WHISPER_SAMPLE_RATE || samples.is_empty() {
+        return samples.to_vec();
+    }
+    let ratio = WHISPER_SAMPLE_RATE as f64 / src_rate as f64;
+    let out_len = ((samples.len() as f64) * ratio).round() as usize;
+    let mut out = Vec::with_capacity(out_len);
+    for i in 0..out_len {
+        let src_pos = i as f64 / ratio;
+        let left = src_pos.floor() as usize;
+        let frac = (src_pos - left as f64) as f32;
+        let a = samples[left.min(samples.len() - 1)];
+        let b = samples[(left + 1).min(samples.len() - 1)];
+        out.push(a + (b - a) * frac);
+    }
+    out
+}
+
+/// Compute the full Whisper log-mel spectrogram for a 16 kHz mono waveform.
+///
+/// Returns `(features, num_frames)` where `features` is row-major
+/// `[num_frames][n_mels]`. The dynamic-range clamp uses the global maximum over
+/// the whole utterance, matching the reference (so per-chunk slicing downstream
+/// stays consistent).
+pub fn log_mel_spectrogram(audio: &[f32], n_mels: usize) -> (Vec<f32>, usize) {
+    let n_freqs = WHISPER_N_FFT / 2 + 1;
+    let filters = whisper_mel_filters(n_mels);
+    let window = periodic_hann(WHISPER_N_FFT);
+
+    let padded = reflect_pad(audio, WHISPER_N_FFT / 2);
+    if padded.len() < WHISPER_N_FFT {
+        return (Vec::new(), 0);
+    }
+    let total_frames = 1 + (padded.len() - WHISPER_N_FFT) / WHISPER_HOP_LENGTH;
+    // The reference drops the trailing analysis frame.
+    let num_frames = total_frames.saturating_sub(1);
+    if num_frames == 0 {
+        return (Vec::new(), 0);
+    }
+
+    let mut features = vec![0.0f32; num_frames * n_mels];
+    let mut frame_buf = vec![0.0f64; WHISPER_N_FFT];
+
+    for frame_idx in 0..num_frames {
+        let start = frame_idx * WHISPER_HOP_LENGTH;
+        for i in 0..WHISPER_N_FFT {
+            frame_buf[i] = (padded[start + i] * window[i]) as f64;
+        }
+        // Power spectrum: square the shared DFT magnitude.
+        let mag = real_fft_magnitude(&frame_buf, n_freqs);
+        for mel in 0..n_mels {
+            let mut acc = 0.0f64;
+            for (freq, &m) in mag.iter().enumerate().take(n_freqs) {
+                acc += (m * m) * filters[freq * n_mels + mel] as f64;
+            }
+            features[frame_idx * n_mels + mel] = acc.max(1e-10).log10() as f32;
+        }
+    }
+
+    // Global dynamic-range clamp and affine rescale: max(x, max-8); (x+4)/4.
+    let global_max = features.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let floor = global_max - 8.0;
+    for v in &mut features {
+        let clamped = v.max(floor);
+        *v = (clamped + 4.0) / 4.0;
+    }
+
+    (features, num_frames)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tone(freq_hz: f64, duration_s: f64, sample_rate: u32) -> Vec<f32> {
+        let n = (duration_s * sample_rate as f64).round() as usize;
+        (0..n)
+            .map(|i| (2.0 * PI * freq_hz * i as f64 / sample_rate as f64).sin() as f32)
+            .collect()
+    }
+
+    #[test]
+    fn periodic_hann_endpoints() {
+        let w = periodic_hann(WHISPER_N_FFT);
+        assert_eq!(w.len(), WHISPER_N_FFT);
+        assert!(w[0].abs() < 1e-6, "periodic Hann starts at 0");
+        // Peak near the middle is ~1.0.
+        let mid = w[WHISPER_N_FFT / 2];
+        assert!(mid > 0.999, "periodic Hann peaks near 1.0, got {mid}");
+    }
+
+    #[test]
+    fn mel_filters_have_expected_shape_and_unit_scale() {
+        let n_mels = 80;
+        let fb = whisper_mel_filters(n_mels);
+        let n_freqs = WHISPER_N_FFT / 2 + 1;
+        assert_eq!(fb.len(), n_freqs * n_mels);
+        // Every filter must place some positive weight somewhere.
+        for mel in 0..n_mels {
+            let any_positive = (0..n_freqs).any(|f| fb[f * n_mels + mel] > 0.0);
+            assert!(any_positive, "mel filter {mel} is empty");
+        }
+        // DC bin carries no energy into the lowest non-edge filters.
+        assert!(fb[0] >= 0.0);
+    }
+
+    #[test]
+    fn frame_count_matches_reference_for_one_second() {
+        // 1 s at 16 kHz with hop 160 -> 100 frames after the trailing-frame drop.
+        let audio = tone(440.0, 1.0, WHISPER_SAMPLE_RATE);
+        let (features, frames) = log_mel_spectrogram(&audio, 80);
+        assert_eq!(frames, 100, "expected 100 frames, got {frames}");
+        assert_eq!(features.len(), frames * 80);
+    }
+
+    #[test]
+    fn full_chunk_yields_3000_frames() {
+        let audio = vec![0.0f32; WHISPER_N_SAMPLES];
+        let (_features, frames) = log_mel_spectrogram(&audio, 80);
+        assert_eq!(
+            frames, WHISPER_N_FRAMES,
+            "30 s chunk must yield 3000 frames"
+        );
+    }
+
+    #[test]
+    fn normalization_keeps_values_in_expected_band() {
+        let audio = tone(440.0, 0.5, WHISPER_SAMPLE_RATE);
+        let (features, _frames) = log_mel_spectrogram(&audio, 80);
+        // After max(x, max-8) and (x+4)/4 the dynamic range is exactly 2.0.
+        let max = features.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let min = features.iter().copied().fold(f32::INFINITY, f32::min);
+        assert!((max - min) <= 2.0 + 1e-3, "range {} exceeds 2.0", max - min);
+    }
+
+    #[test]
+    fn tone_energy_peaks_in_low_mel_bins() {
+        // 440 Hz energy should concentrate in the low mel bins.
+        let audio = tone(440.0, 1.0, WHISPER_SAMPLE_RATE);
+        let n_mels = 80;
+        let (features, frames) = log_mel_spectrogram(&audio, n_mels);
+        let mut energy = vec![0.0f64; n_mels];
+        for f in 0..frames {
+            for mel in 0..n_mels {
+                energy[mel] += features[f * n_mels + mel] as f64;
+            }
+        }
+        let peak = energy
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .map(|(i, _)| i)
+            .unwrap();
+        assert!(
+            peak < 25,
+            "440 Hz peak should fall in low mel bins, got {peak}"
+        );
+    }
+
+    #[test]
+    fn resample_is_identity_at_native_rate() {
+        let audio = tone(440.0, 0.1, WHISPER_SAMPLE_RATE);
+        let out = resample_to_16k(&audio, WHISPER_SAMPLE_RATE);
+        assert_eq!(out.len(), audio.len());
+    }
+
+    #[test]
+    fn resample_halves_length_from_32k() {
+        let audio = tone(440.0, 0.1, 32_000);
+        let out = resample_to_16k(&audio, 32_000);
+        // 32 kHz -> 16 kHz halves the sample count (within rounding).
+        assert!((out.len() as i64 - (audio.len() as i64 / 2)).abs() <= 1);
+    }
+}

--- a/src/audio/whisper_mel.rs
+++ b/src/audio/whisper_mel.rs
@@ -142,16 +142,43 @@ fn reflect_pad(audio: &[f32], pad: usize) -> Vec<f32> {
     out
 }
 
+/// Upper bound on the sample count a single resample may emit: one hour of
+/// 16 kHz audio.
+///
+/// Linear resampling expands the buffer by `16000 / src_rate`. The WAV reader
+/// accepts any non-zero declared sample rate, so a crafted-but-well-formed
+/// header claiming a tiny rate (e.g. 1 Hz) would otherwise size the output at
+/// `len * 16000`, turning a few hundred thousand input samples into hundreds of
+/// billions; the resulting `Vec` allocation aborts the process. Clamping the
+/// output keeps the allocation bounded. The HTTP upload is already capped at a
+/// few tens of MiB upstream, so a legitimate clip (sampled at >= 8 kHz) never
+/// approaches this ceiling.
+const MAX_RESAMPLED_SAMPLES: usize = WHISPER_SAMPLE_RATE as usize * 3600;
+
+/// Output sample count for a resample to 16 kHz, clamped to
+/// [`MAX_RESAMPLED_SAMPLES`]. Split out so the bound is unit-testable without
+/// allocating the (potentially large) output buffer.
+fn resampled_len(input_len: usize, src_rate: u32) -> usize {
+    if src_rate == WHISPER_SAMPLE_RATE {
+        return input_len;
+    }
+    let ratio = WHISPER_SAMPLE_RATE as f64 / src_rate as f64;
+    let projected = ((input_len as f64) * ratio).round() as usize;
+    projected.min(MAX_RESAMPLED_SAMPLES)
+}
+
 /// Linear-interpolation resampler from `src_rate` to 16 kHz mono.
 ///
 /// Linear interpolation is adequate for the recognizer's robustness; a
-/// polyphase/sinc resampler is a documented follow-up.
+/// polyphase/sinc resampler is a documented follow-up. The output length is
+/// bounded by [`MAX_RESAMPLED_SAMPLES`] so a tiny declared `src_rate` cannot
+/// trigger an unbounded allocation.
 pub fn resample_to_16k(samples: &[f32], src_rate: u32) -> Vec<f32> {
     if src_rate == WHISPER_SAMPLE_RATE || samples.is_empty() {
         return samples.to_vec();
     }
     let ratio = WHISPER_SAMPLE_RATE as f64 / src_rate as f64;
-    let out_len = ((samples.len() as f64) * ratio).round() as usize;
+    let out_len = resampled_len(samples.len(), src_rate);
     let mut out = Vec::with_capacity(out_len);
     for i in 0..out_len {
         let src_pos = i as f64 / ratio;
@@ -318,5 +345,15 @@ mod tests {
         let out = resample_to_16k(&audio, 32_000);
         // 32 kHz -> 16 kHz halves the sample count (within rounding).
         assert!((out.len() as i64 - (audio.len() as i64 / 2)).abs() <= 1);
+    }
+
+    #[test]
+    fn resampled_len_clamps_pathological_low_rate() {
+        // A near-zero declared rate would expand the buffer by ~16000x; the cap
+        // keeps the allocation bounded so a crafted WAV cannot abort the worker.
+        assert_eq!(resampled_len(10_000_000, 1), MAX_RESAMPLED_SAMPLES);
+        // Legitimate rates pass through unclamped.
+        assert_eq!(resampled_len(1_000, WHISPER_SAMPLE_RATE), 1_000); // identity
+        assert_eq!(resampled_len(1_000, 8_000), 2_000); // 8 kHz -> 16 kHz doubles
     }
 }

--- a/src/audio/whisper_mel.rs
+++ b/src/audio/whisper_mel.rs
@@ -348,6 +348,40 @@ mod tests {
     }
 
     #[test]
+    fn reflect_pad_empty_returns_zeros() {
+        // An empty waveform must not panic; the output is all zeros of length
+        // 2 * pad, satisfying the downstream `padded.len() >= WHISPER_N_FFT`
+        // check without reading out of bounds.
+        let pad = WHISPER_N_FFT / 2;
+        let out = reflect_pad(&[], pad);
+        assert_eq!(out.len(), 2 * pad);
+        assert!(out.iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn reflect_pad_shorter_than_pad_does_not_panic() {
+        // When the input is shorter than the pad width the clamped-index path
+        // is taken for both prefix and suffix. This is the edge case the HIGH
+        // security fix targets: a crafted very-short clip must not cause an
+        // index out of bounds.
+        let short = [0.5f32, -0.5];
+        let pad = WHISPER_N_FFT / 2; // 200
+        let out = reflect_pad(&short, pad);
+        assert_eq!(out.len(), short.len() + 2 * pad);
+        // All values must be in the valid sample range (no garbage).
+        assert!(out.iter().all(|&v| v.is_finite()));
+    }
+
+    #[test]
+    fn very_short_audio_returns_empty_spectrogram() {
+        // A clip too short to yield any frames after the trailing-frame drop
+        // must return (empty, 0) rather than panicking or producing garbage.
+        let (features, frames) = log_mel_spectrogram(&[0.0f32; 1], 80);
+        assert_eq!(frames, 0);
+        assert!(features.is_empty());
+    }
+
+    #[test]
     fn resampled_len_clamps_pathological_low_rate() {
         // A near-zero declared rate would expand the buffer by ~16000x; the cap
         // keeps the allocation bounded so a crafted WAV cannot abort the worker.

--- a/src/distributed/tensor_parallel/inference.rs
+++ b/src/distributed/tensor_parallel/inference.rs
@@ -251,6 +251,10 @@ fn fallback_architecture(model_type: ModelType) -> &'static str {
         // planner's supported-architecture validation rejects this string
         // before any TP load is attempted).
         ModelType::DiffusionGemma => "diffusion_gemma",
+        // Whisper is an ASR model served through the audio endpoints, never
+        // routed to tensor-parallel text inference; the loader rejects it
+        // earlier. Return a placeholder so the dispatch table stays total.
+        ModelType::Whisper => "whisper",
     }
 }
 

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -319,6 +319,14 @@ void eval(const MlxArray& arr) {
     const_cast<array&>(arr.inner).eval();
 }
 
+// Same as `eval`, but declared `-> Result<()>` on the Rust side so cxx wraps
+// the call in a try/catch and converts any thrown MLX exception into a Rust
+// `Err` instead of letting it cross the FFI boundary uncaught (which aborts the
+// process). The body is otherwise identical to `eval`.
+void try_eval(const MlxArray& arr) {
+    const_cast<array&>(arr.inner).eval();
+}
+
 void eval_all(rust::Slice<const MlxArray* const> arrays) {
     std::vector<array> arrs;
     arrs.reserve(arrays.size());

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -128,6 +128,9 @@ rust::Vec<uint8_t> array_to_raw_bytes(const MlxArray& arr);
 
 // Evaluation.
 void eval(const MlxArray& arr);
+// Fallible counterpart of `eval`; declared `-> Result<()>` in the bridge so cxx
+// catches any thrown MLX exception at the FFI boundary instead of aborting.
+void try_eval(const MlxArray& arr);
 void eval_all(rust::Slice<const MlxArray* const> arrays);
 
 // Element-wise binary operations.

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -154,6 +154,16 @@ mod ffi {
         /// Evaluate an array
         fn eval(arr: &MlxArray);
 
+        /// Evaluate an array, returning an error instead of throwing.
+        ///
+        /// Same effect as [`eval`], but any MLX C++ exception (missing stream,
+        /// shape mismatch, allocation failure) is caught at the FFI boundary and
+        /// surfaced as a Rust `Err` rather than an uncaught exception that
+        /// aborts the process. Off-worker callers that evaluate a graph on a
+        /// pool thread (the audio providers) use this so a failure becomes a
+        /// structured error.
+        fn try_eval(arr: &MlxArray) -> Result<()>;
+
         /// Evaluate multiple arrays at once
         unsafe fn eval_all(arrays: &[*const MlxArray]);
 

--- a/src/lib/mlxcel-core/src/streams.rs
+++ b/src/lib/mlxcel-core/src/streams.rs
@@ -39,8 +39,6 @@
 //! deployments where construction and execution can happen on
 //! different threads.
 
-use std::cell::RefCell;
-
 use crate::ffi;
 use crate::ffi::{MlxStream, MlxThreadLocalStream};
 use crate::UniquePtr;
@@ -56,7 +54,7 @@ use crate::UniquePtr;
 /// to bind its dedicated per-thread stream as the default for
 /// subsequent MLX dispatches on that thread.
 ///
-/// Used by: CxxGenerator, SpeculativeGenerator, BatchScheduler
+/// Used by: CxxGenerator, SpeculativeGenerator, BatchScheduler, AudioWorker
 pub fn new_thread_local_generation_stream() -> Option<UniquePtr<MlxThreadLocalStream>> {
     if ffi::is_gpu_available() {
         Some(ffi::new_thread_local_stream_gpu())
@@ -78,7 +76,7 @@ pub fn new_thread_local_generation_stream() -> Option<UniquePtr<MlxThreadLocalSt
 ///
 /// `None` is a safe no-op for CPU-only builds.
 ///
-/// Used by: CxxGenerator, SpeculativeGenerator, BatchScheduler
+/// Used by: CxxGenerator, SpeculativeGenerator, BatchScheduler, AudioWorker
 pub fn install_thread_local_default_stream(tls: Option<&UniquePtr<MlxThreadLocalStream>>) {
     if let Some(tls) = tls {
         let stream = ffi::stream_from_thread_local_stream(tls);
@@ -98,69 +96,14 @@ pub fn install_thread_local_default_stream(tls: Option<&UniquePtr<MlxThreadLocal
 /// `None` is a safe no-op (matches the CPU-only build path of
 /// [`new_thread_local_generation_stream`]).
 ///
-/// Used by: tests; runtime callers currently rely on the default
-/// stream being installed by [`install_thread_local_default_stream`]
-/// and on per-op `eval` calls for synchronization.
+/// Used by: AudioWorker (after each request); tests. Generation-loop callers
+/// rely on the default stream installed by
+/// [`install_thread_local_default_stream`] and on per-op `eval` for
+/// synchronization.
 pub fn synchronize_thread_local_stream(tls: Option<&UniquePtr<MlxThreadLocalStream>>) {
     if let Some(tls) = tls {
         ffi::synchronize_thread_local_stream(tls);
     }
-}
-
-thread_local! {
-    /// Lazily-created MLX default stream for threads that run MLX work outside
-    /// the dedicated generation worker loop.
-    ///
-    /// Created on first use per thread and reused on every later call, so a
-    /// reused thread that services many requests allocates exactly one MLX
-    /// stream rather than one per call. `None` on CPU-only builds.
-    static OFF_WORKER_DEFAULT_STREAM: RefCell<Option<UniquePtr<MlxThreadLocalStream>>> =
-        const { RefCell::new(None) };
-}
-
-/// Run `f` with the calling thread's MLX default stream installed, then
-/// synchronize that stream before returning `f`'s result.
-///
-/// MLX work is thread-affine: a thread must have a default stream installed
-/// before it constructs or evaluates any array, or MLX throws
-/// `There is no Stream(...)`, which, uncaught across the cxx FFI boundary,
-/// aborts the process. The dedicated generation worker threads install their
-/// stream once at the top of their loop via
-/// [`install_thread_local_default_stream`]. Work dispatched onto an arbitrary,
-/// reused thread (for example a `tokio::task::spawn_blocking` pool thread) has
-/// no such stream and must install one itself before touching MLX.
-///
-/// This helper makes that correct on a reused pool thread:
-///
-/// * the per-thread stream is created once and cached in a thread-local, so no
-///   stream is leaked per call;
-/// * it is re-installed as the default on every call, so an unrelated task that
-///   changed the thread's default stream in between cannot leave a stale
-///   binding; and
-/// * the stream is synchronized before the result is returned, so every
-///   dispatch issued inside `f` has completed and dispatch and synchronization
-///   stay paired on the same per-thread stream.
-///
-/// On CPU-only builds the cached handle is `None` and the call is a transparent
-/// pass-through (matching the no-op behavior of the helpers above).
-///
-/// Used by: server audio routes (speech-to-text / text-to-speech dispatch).
-pub fn with_thread_local_default_stream<T>(f: impl FnOnce() -> T) -> T {
-    OFF_WORKER_DEFAULT_STREAM.with(|cell| {
-        {
-            let mut slot = cell.borrow_mut();
-            if slot.is_none() {
-                *slot = new_thread_local_generation_stream();
-            }
-            install_thread_local_default_stream(slot.as_ref());
-        }
-        let result = f();
-        {
-            let slot = cell.borrow();
-            synchronize_thread_local_stream(slot.as_ref());
-        }
-        result
-    })
 }
 
 /// RAII guard that restores the calling thread's MLX default stream on drop.
@@ -328,26 +271,5 @@ mod tests {
         // Sanity: MLX is still usable.
         let arr = ffi::zeros(&[1, 1], crate::dtype::FLOAT32);
         ffi::eval(&arr);
-    }
-
-    /// `with_thread_local_default_stream` installs a default stream, runs the
-    /// closure (which dispatches and evaluates a real op), and synchronizes,
-    /// without panicking. A second call on the same thread must reuse the
-    /// cached per-thread handle and still succeed, proving the helper is
-    /// re-entrant across calls (the `spawn_blocking` reuse pattern).
-    ///
-    /// A [`DefaultStreamGuard`] restores the thread's previous default stream so
-    /// the mutation does not leak into other tests on this thread.
-    #[test]
-    fn with_thread_local_default_stream_runs_and_reuses() {
-        let _guard = DefaultStreamGuard::capture();
-        for _ in 0..2 {
-            let value = with_thread_local_default_stream(|| {
-                let arr = ffi::zeros(&[1, 1], crate::dtype::FLOAT32);
-                ffi::eval(&arr);
-                ffi::item_f32(&arr)
-            });
-            assert_eq!(value, 0.0);
-        }
     }
 }

--- a/src/lib/mlxcel-core/src/streams.rs
+++ b/src/lib/mlxcel-core/src/streams.rs
@@ -39,6 +39,8 @@
 //! deployments where construction and execution can happen on
 //! different threads.
 
+use std::cell::RefCell;
+
 use crate::ffi;
 use crate::ffi::{MlxStream, MlxThreadLocalStream};
 use crate::UniquePtr;
@@ -103,6 +105,62 @@ pub fn synchronize_thread_local_stream(tls: Option<&UniquePtr<MlxThreadLocalStre
     if let Some(tls) = tls {
         ffi::synchronize_thread_local_stream(tls);
     }
+}
+
+thread_local! {
+    /// Lazily-created MLX default stream for threads that run MLX work outside
+    /// the dedicated generation worker loop.
+    ///
+    /// Created on first use per thread and reused on every later call, so a
+    /// reused thread that services many requests allocates exactly one MLX
+    /// stream rather than one per call. `None` on CPU-only builds.
+    static OFF_WORKER_DEFAULT_STREAM: RefCell<Option<UniquePtr<MlxThreadLocalStream>>> =
+        const { RefCell::new(None) };
+}
+
+/// Run `f` with the calling thread's MLX default stream installed, then
+/// synchronize that stream before returning `f`'s result.
+///
+/// MLX work is thread-affine: a thread must have a default stream installed
+/// before it constructs or evaluates any array, or MLX throws
+/// `There is no Stream(...)`, which, uncaught across the cxx FFI boundary,
+/// aborts the process. The dedicated generation worker threads install their
+/// stream once at the top of their loop via
+/// [`install_thread_local_default_stream`]. Work dispatched onto an arbitrary,
+/// reused thread (for example a `tokio::task::spawn_blocking` pool thread) has
+/// no such stream and must install one itself before touching MLX.
+///
+/// This helper makes that correct on a reused pool thread:
+///
+/// * the per-thread stream is created once and cached in a thread-local, so no
+///   stream is leaked per call;
+/// * it is re-installed as the default on every call, so an unrelated task that
+///   changed the thread's default stream in between cannot leave a stale
+///   binding; and
+/// * the stream is synchronized before the result is returned, so every
+///   dispatch issued inside `f` has completed and dispatch and synchronization
+///   stay paired on the same per-thread stream.
+///
+/// On CPU-only builds the cached handle is `None` and the call is a transparent
+/// pass-through (matching the no-op behavior of the helpers above).
+///
+/// Used by: server audio routes (speech-to-text / text-to-speech dispatch).
+pub fn with_thread_local_default_stream<T>(f: impl FnOnce() -> T) -> T {
+    OFF_WORKER_DEFAULT_STREAM.with(|cell| {
+        {
+            let mut slot = cell.borrow_mut();
+            if slot.is_none() {
+                *slot = new_thread_local_generation_stream();
+            }
+            install_thread_local_default_stream(slot.as_ref());
+        }
+        let result = f();
+        {
+            let slot = cell.borrow();
+            synchronize_thread_local_stream(slot.as_ref());
+        }
+        result
+    })
 }
 
 /// RAII guard that restores the calling thread's MLX default stream on drop.
@@ -270,5 +328,26 @@ mod tests {
         // Sanity: MLX is still usable.
         let arr = ffi::zeros(&[1, 1], crate::dtype::FLOAT32);
         ffi::eval(&arr);
+    }
+
+    /// `with_thread_local_default_stream` installs a default stream, runs the
+    /// closure (which dispatches and evaluates a real op), and synchronizes,
+    /// without panicking. A second call on the same thread must reuse the
+    /// cached per-thread handle and still succeed, proving the helper is
+    /// re-entrant across calls (the `spawn_blocking` reuse pattern).
+    ///
+    /// A [`DefaultStreamGuard`] restores the thread's previous default stream so
+    /// the mutation does not leak into other tests on this thread.
+    #[test]
+    fn with_thread_local_default_stream_runs_and_reuses() {
+        let _guard = DefaultStreamGuard::capture();
+        for _ in 0..2 {
+            let value = with_thread_local_default_stream(|| {
+                let arr = ffi::zeros(&[1, 1], crate::dtype::FLOAT32);
+                ffi::eval(&arr);
+                ffi::item_f32(&arr)
+            });
+            assert_eq!(value, 0.0);
+        }
     }
 }

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -245,6 +245,19 @@ pub fn load_model(model_path: &Path) -> Result<(LoadedModel, MlxcelTokenizer)> {
     let model_path = resolve_model_dir(model_path);
     let model_path = model_path.as_path();
     let model_type = get_model_type(model_path)?;
+
+    // Whisper is an encoder-decoder ASR model, not a text generator. It is
+    // wired into the speech-to-text audio endpoints at server startup rather
+    // than the LanguageModel path, so fail clearly here instead of attempting
+    // a text-model load.
+    if model_type == ModelType::Whisper {
+        anyhow::bail!(
+            "Whisper is a speech-to-text model served through the /v1/audio/* \
+             endpoints, not a text-generation model. The mlxcel-server populates \
+             its speech-to-text slot from this checkpoint automatically."
+        );
+    }
+
     let path_str = model_path_str(model_path)?;
 
     let policy = if model_type == ModelType::Mistral3 {

--- a/src/model_metadata.rs
+++ b/src/model_metadata.rs
@@ -200,6 +200,7 @@ macro_rules! for_each_model_registration {
             Step3p5 => { kind: Text, directory: ConfigBacked, weight: Some(WeightLoadRoute::ConfigBacked), adapter: None, config_backed: { dir_loader: models::Step3p5Model::load, args: models::step3p5::Step3p5Config, weight_builder: models::Step3p5Model::from_weights, wrap: LoadedModel::Step3p5 } };
             Rwkv7 => { kind: Text, directory: Nonstandard, weight: Some(WeightLoadRoute::Special), adapter: None };
             RecurrentGemma => { kind: Text, directory: Nonstandard, weight: Some(WeightLoadRoute::Special), adapter: None };
+            Whisper => { kind: Text, directory: Nonstandard, weight: None, adapter: Some("Whisper ASR checkpoints are served through the /v1/audio/* endpoints, not text generation or adapter loading") };
         }
     };
 }

--- a/src/models/detection.rs
+++ b/src/models/detection.rs
@@ -218,6 +218,8 @@ pub fn get_model_type(model_path: &Path) -> Result<ModelType> {
         "molmo" => Ok(ModelType::MolmoVLM),
         "molmo2" => Ok(ModelType::Molmo2VLM),
         "molmo_point" => Ok(ModelType::MolmoPointVLM),
+        // Speech-to-text (encoder-decoder ASR).
+        "whisper" => Ok(ModelType::Whisper),
         _ => Err(anyhow::anyhow!(
             "Unsupported model type: {}",
             model_type_raw

--- a/src/models/detection_tests.rs
+++ b/src/models/detection_tests.rs
@@ -63,6 +63,31 @@ fn temp_path(name: &str) -> PathBuf {
 }
 
 #[test]
+fn whisper_model_type_is_detected() {
+    let model_dir = temp_path("whisper_asr");
+    fs::create_dir_all(&model_dir).unwrap();
+    fs::write(
+        model_dir.join("config.json"),
+        r#"{
+            "model_type": "whisper",
+            "num_mel_bins": 80,
+            "d_model": 384,
+            "encoder_attention_heads": 6,
+            "encoder_layers": 4,
+            "decoder_attention_heads": 6,
+            "decoder_layers": 4,
+            "vocab_size": 51865
+        }"#,
+    )
+    .unwrap();
+
+    let detected = super::detection::get_model_type(&model_dir).unwrap();
+    assert_eq!(detected, ModelType::Whisper);
+
+    fs::remove_dir_all(model_dir).unwrap();
+}
+
+#[test]
 fn gemma4_detection_stays_on_text_route_without_vision_weights() {
     let model_dir = temp_path("gemma4_text_route");
     fs::create_dir_all(&model_dir).unwrap();

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -113,6 +113,7 @@ pub mod solar_open;
 pub mod stablelm;
 pub mod starcoder2;
 pub mod step3p5;
+pub mod whisper;
 pub mod youtu_vl_lm;
 
 // Re-export model types
@@ -209,6 +210,7 @@ pub use solar_open::SolarOpenModel;
 pub use stablelm::StableLMModel;
 pub use starcoder2::StarCoder2Model;
 pub use step3p5::Step3p5Model;
+pub use whisper::WhisperModel;
 
 /// Supported model types
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -366,6 +368,9 @@ pub enum ModelType {
     // RNN models
     Rwkv7,
     RecurrentGemma,
+
+    // Speech-to-text (encoder-decoder ASR)
+    Whisper,
 }
 
 /// All `ModelType` variants, in declaration order. Used as the iteration
@@ -504,6 +509,8 @@ pub const ALL_MODEL_TYPES: &[ModelType] = &[
     // RNN models
     ModelType::Rwkv7,
     ModelType::RecurrentGemma,
+    // Speech-to-text
+    ModelType::Whisper,
 ];
 
 impl ModelType {
@@ -676,6 +683,9 @@ impl ModelType {
 
             // ----- RWKV -----
             ModelType::Rwkv7 => ("RWKV v7", "RWKV"),
+
+            // ----- Speech-to-text (ASR) -----
+            ModelType::Whisper => ("Whisper (encoder-decoder ASR)", "Speech-to-text"),
 
             // ----- Specialized / other small/text -----
             ModelType::StarCoder2 => ("StarCoder 2", "Specialized"),
@@ -866,6 +876,7 @@ mod metadata_tests {
             Step3p5,
             Rwkv7,
             RecurrentGemma,
+            Whisper,
         );
         for mt in variants {
             assert!(

--- a/src/models/whisper/decoder.rs
+++ b/src/models/whisper/decoder.rs
@@ -1,0 +1,122 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Whisper text decoder: token + learned positional embeddings, N blocks with
+//! masked self-attention and cross-attention to the encoder output, a final
+//! LayerNorm, and tied output logits.
+
+use mlxcel_core::layers::{Embedding, LayerNorm};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+use super::WhisperDims;
+use super::layers::{KvCache, ResidualAttentionBlock, additive_causal_mask};
+
+pub(crate) struct TextDecoder {
+    token_embedding: Embedding,
+    positional_embedding: UniquePtr<MlxArray>,
+    blocks: Vec<ResidualAttentionBlock>,
+    ln: LayerNorm,
+    n_state: i32,
+    dtype: i32,
+}
+
+impl TextDecoder {
+    pub(crate) fn from_weights(
+        weights: &WeightMap,
+        dims: &WhisperDims,
+        dtype: i32,
+    ) -> Result<Self, String> {
+        let token_embedding = Embedding::from_weights(weights, "decoder.token_embedding")?;
+        let positional_embedding = weights
+            .get("decoder.positional_embedding")
+            .map(|w| mlxcel_core::copy(w))
+            .ok_or_else(|| "Whisper weight not found: decoder.positional_embedding".to_string())?;
+
+        let mut blocks = Vec::with_capacity(dims.n_text_layer as usize);
+        for i in 0..dims.n_text_layer {
+            blocks.push(ResidualAttentionBlock::from_weights(
+                weights,
+                &format!("decoder.blocks.{i}"),
+                dims.n_text_head,
+                true,
+            )?);
+        }
+
+        let ln_weight = weights
+            .get("decoder.ln.weight")
+            .map(|w| mlxcel_core::copy(w))
+            .ok_or_else(|| "Whisper weight not found: decoder.ln.weight".to_string())?;
+        let ln_bias = weights.get("decoder.ln.bias").map(|w| mlxcel_core::copy(w));
+
+        Ok(Self {
+            token_embedding,
+            positional_embedding,
+            blocks,
+            ln: LayerNorm::new(ln_weight, ln_bias, 1e-5),
+            n_state: dims.n_text_state,
+            dtype,
+        })
+    }
+
+    /// Number of decoder layers (cache vectors are sized to this).
+    pub(crate) fn num_layers(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Run one decode call over `tokens` (`[batch, seq]`) attending to encoder
+    /// features `xa`. `offset` is the number of tokens already cached (i.e. the
+    /// position of the first token in this call). Returns logits
+    /// `[batch, seq, n_vocab]`.
+    pub(crate) fn forward(
+        &self,
+        tokens: &MlxArray,
+        xa: &MlxArray,
+        offset: i32,
+        self_caches: &mut [Option<KvCache>],
+        cross_caches: &mut [Option<KvCache>],
+    ) -> UniquePtr<MlxArray> {
+        let seq = mlxcel_core::array_shape(tokens)[1];
+
+        let emb = self.token_embedding.forward(tokens);
+        let pos = mlxcel_core::slice(
+            &self.positional_embedding,
+            &[offset, 0],
+            &[offset + seq, self.n_state],
+        );
+        let mut x = mlxcel_core::add(&emb, &pos);
+
+        // A causal mask is only needed for a multi-token prefill; a single new
+        // token attends to the whole cached history without masking.
+        let mask = if seq > 1 {
+            Some(additive_causal_mask(seq, self.dtype))
+        } else {
+            None
+        };
+        let mask_ref = mask.as_deref();
+
+        for (i, block) in self.blocks.iter().enumerate() {
+            x = block.forward(
+                &x,
+                Some(xa),
+                mask_ref,
+                &mut self_caches[i],
+                &mut cross_caches[i],
+            );
+        }
+
+        let x = self.ln.forward(&x);
+        self.token_embedding.as_linear(&x)
+    }
+}

--- a/src/models/whisper/decoding.rs
+++ b/src/models/whisper/decoding.rs
@@ -19,6 +19,8 @@
 //! Beam search, word-level timestamps, and temperature fallback are out of
 //! scope for this first port.
 
+use anyhow::{Result, anyhow};
+
 use mlxcel_core::{MlxArray, UniquePtr};
 
 use super::decoder::TextDecoder;
@@ -80,13 +82,18 @@ fn mask_array(data: &[f32], n_vocab: i32) -> UniquePtr<MlxArray> {
 
 /// Take the last-position logits, apply additive masks, and return the argmax
 /// token id.
+///
+/// This is the single point in the decode loop where the lazily-built MLX graph
+/// (encoder, decoder, masks, argmax) is forced. The evaluation is routed through
+/// the fallible [`mlxcel_core::try_eval`] wrapper so an MLX failure surfaces as
+/// an `Err` rather than an uncaught C++ exception that would abort the process.
 fn argmax_with_masks(
     logits: &MlxArray,
     pos: i32,
     n_vocab: i32,
     always_mask: &MlxArray,
     first_mask: Option<&MlxArray>,
-) -> i32 {
+) -> Result<i32> {
     let sliced = mlxcel_core::slice(logits, &[0, pos, 0], &[1, pos + 1, n_vocab]);
     let sliced = mlxcel_core::reshape(&sliced, &[1, n_vocab]);
     let mut l = mlxcel_core::astype(&sliced, mlxcel_core::dtype::FLOAT32);
@@ -95,7 +102,8 @@ fn argmax_with_masks(
         l = mlxcel_core::add(&l, first);
     }
     let idx = mlxcel_core::argmax(&l, -1, false);
-    mlxcel_core::item_i32(&idx)
+    mlxcel_core::try_eval(&idx).map_err(|e| anyhow!("Whisper logits evaluation failed: {e}"))?;
+    Ok(mlxcel_core::item_i32(&idx))
 }
 
 /// Detect the spoken language from a single `<|startoftranscript|>` decode step.
@@ -105,9 +113,9 @@ pub(crate) fn detect_language<'a>(
     audio_features: &MlxArray,
     tokenizer: &'a WhisperTokenizer,
     n_vocab: i32,
-) -> Option<&'a str> {
+) -> Result<Option<&'a str>> {
     if !tokenizer.multilingual {
-        return None;
+        return Ok(None);
     }
     let mut self_caches = empty_caches(decoder.num_layers());
     let mut cross_caches = empty_caches(decoder.num_layers());
@@ -115,12 +123,12 @@ pub(crate) fn detect_language<'a>(
     let logits = decoder.forward(&sot, audio_features, 0, &mut self_caches, &mut cross_caches);
 
     let lang_mask = mask_array(&build_language_mask(tokenizer, n_vocab), n_vocab);
-    let picked = argmax_with_masks(&logits, 0, n_vocab, &lang_mask, None);
-    tokenizer
+    let picked = argmax_with_masks(&logits, 0, n_vocab, &lang_mask, None)?;
+    Ok(tokenizer
         .language_ids
         .iter()
         .find(|(_, id)| *id == picked)
-        .map(|(code, _)| *code)
+        .map(|(code, _)| *code))
 }
 
 /// Greedily decode one 30 s segment of `audio_features` into token ids and the
@@ -133,11 +141,11 @@ pub(crate) fn transcribe_segment(
     n_text_ctx: i32,
     language: Option<&str>,
     translate: bool,
-) -> (Vec<i32>, Option<String>) {
+) -> Result<(Vec<i32>, Option<String>)> {
     // Resolve the language once (hint takes priority over detection).
     let resolved: Option<String> = match language {
         Some(code) => Some(code.to_string()),
-        None => detect_language(decoder, audio_features, tokenizer, n_vocab).map(str::to_string),
+        None => detect_language(decoder, audio_features, tokenizer, n_vocab)?.map(str::to_string),
     };
 
     let initial = tokenizer.initial_tokens(resolved.as_deref(), translate);
@@ -164,7 +172,7 @@ pub(crate) fn transcribe_segment(
         n_vocab,
         &always,
         Some(&first),
-    );
+    )?;
     let mut offset = initial.len() as i32;
 
     // `sample_len` mirrors the reference cap of n_text_ctx / 2.
@@ -182,10 +190,10 @@ pub(crate) fn transcribe_segment(
         );
         offset += 1;
         step += 1;
-        next = argmax_with_masks(&logits, 0, n_vocab, &always, None);
+        next = argmax_with_masks(&logits, 0, n_vocab, &always, None)?;
     }
 
-    (generated, resolved)
+    Ok((generated, resolved))
 }
 
 #[cfg(test)]

--- a/src/models/whisper/decoding.rs
+++ b/src/models/whisper/decoding.rs
@@ -1,0 +1,259 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Greedy decoding for the Whisper-style decoder, including token suppression
+//! (`suppress_blank`, non-speech tokens, the timestamp range) and first-step
+//! language detection.
+//!
+//! Beam search, word-level timestamps, and temperature fallback are out of
+//! scope for this first port.
+
+use mlxcel_core::{MlxArray, UniquePtr};
+
+use super::decoder::TextDecoder;
+use super::layers::KvCache;
+use super::tokenizer::WhisperTokenizer;
+
+/// Additive `[n_vocab]` mask (`0` keep / `-inf` suppress) applied at every step:
+/// the non-speech / task-token suppression set plus the whole timestamp range.
+pub(crate) fn build_suppression_mask(tokenizer: &WhisperTokenizer, n_vocab: i32) -> Vec<f32> {
+    let n = n_vocab as usize;
+    let mut mask = vec![0.0f32; n];
+    for &id in &tokenizer.suppress {
+        if (0..n_vocab).contains(&id) {
+            mask[id as usize] = f32::NEG_INFINITY;
+        }
+    }
+    // Suppress every timestamp token so the no-timestamps prompt is enforced.
+    for id in tokenizer.timestamp_begin..n_vocab {
+        mask[id as usize] = f32::NEG_INFINITY;
+    }
+    mask
+}
+
+/// Additive `[n_vocab]` mask applied only on the first generated step to forbid
+/// a leading blank/space or an immediate end-of-transcript.
+pub(crate) fn build_first_step_mask(tokenizer: &WhisperTokenizer, n_vocab: i32) -> Vec<f32> {
+    let mut mask = vec![0.0f32; n_vocab as usize];
+    if let Some(blank) = tokenizer.blank
+        && (0..n_vocab).contains(&blank)
+    {
+        mask[blank as usize] = f32::NEG_INFINITY;
+    }
+    if (0..n_vocab).contains(&tokenizer.eot) {
+        mask[tokenizer.eot as usize] = f32::NEG_INFINITY;
+    }
+    mask
+}
+
+/// Additive `[n_vocab]` mask that keeps only language tokens (`0`) and masks
+/// everything else (`-inf`), used for first-step language detection.
+pub(crate) fn build_language_mask(tokenizer: &WhisperTokenizer, n_vocab: i32) -> Vec<f32> {
+    let mut mask = vec![f32::NEG_INFINITY; n_vocab as usize];
+    for &(_, id) in &tokenizer.language_ids {
+        if (0..n_vocab).contains(&id) {
+            mask[id as usize] = 0.0;
+        }
+    }
+    mask
+}
+
+fn empty_caches(n: usize) -> Vec<Option<KvCache>> {
+    (0..n).map(|_| None).collect()
+}
+
+fn mask_array(data: &[f32], n_vocab: i32) -> UniquePtr<MlxArray> {
+    // Built in f32 to keep the masked logits numerically stable.
+    mlxcel_core::from_slice_f32(data, &[1, n_vocab])
+}
+
+/// Take the last-position logits, apply additive masks, and return the argmax
+/// token id.
+fn argmax_with_masks(
+    logits: &MlxArray,
+    pos: i32,
+    n_vocab: i32,
+    always_mask: &MlxArray,
+    first_mask: Option<&MlxArray>,
+) -> i32 {
+    let sliced = mlxcel_core::slice(logits, &[0, pos, 0], &[1, pos + 1, n_vocab]);
+    let sliced = mlxcel_core::reshape(&sliced, &[1, n_vocab]);
+    let mut l = mlxcel_core::astype(&sliced, mlxcel_core::dtype::FLOAT32);
+    l = mlxcel_core::add(&l, always_mask);
+    if let Some(first) = first_mask {
+        l = mlxcel_core::add(&l, first);
+    }
+    let idx = mlxcel_core::argmax(&l, -1, false);
+    mlxcel_core::item_i32(&idx)
+}
+
+/// Detect the spoken language from a single `<|startoftranscript|>` decode step.
+/// Returns `None` for English-only checkpoints (caller treats that as English).
+pub(crate) fn detect_language<'a>(
+    decoder: &TextDecoder,
+    audio_features: &MlxArray,
+    tokenizer: &'a WhisperTokenizer,
+    n_vocab: i32,
+) -> Option<&'a str> {
+    if !tokenizer.multilingual {
+        return None;
+    }
+    let mut self_caches = empty_caches(decoder.num_layers());
+    let mut cross_caches = empty_caches(decoder.num_layers());
+    let sot = mlxcel_core::from_slice_i32(&[tokenizer.sot], &[1, 1]);
+    let logits = decoder.forward(&sot, audio_features, 0, &mut self_caches, &mut cross_caches);
+
+    let lang_mask = mask_array(&build_language_mask(tokenizer, n_vocab), n_vocab);
+    let picked = argmax_with_masks(&logits, 0, n_vocab, &lang_mask, None);
+    tokenizer
+        .language_ids
+        .iter()
+        .find(|(_, id)| *id == picked)
+        .map(|(code, _)| *code)
+}
+
+/// Greedily decode one 30 s segment of `audio_features` into token ids and the
+/// language code that was used (hint, detected, or `en`).
+pub(crate) fn transcribe_segment(
+    decoder: &TextDecoder,
+    audio_features: &MlxArray,
+    tokenizer: &WhisperTokenizer,
+    n_vocab: i32,
+    n_text_ctx: i32,
+    language: Option<&str>,
+    translate: bool,
+) -> (Vec<i32>, Option<String>) {
+    // Resolve the language once (hint takes priority over detection).
+    let resolved: Option<String> = match language {
+        Some(code) => Some(code.to_string()),
+        None => detect_language(decoder, audio_features, tokenizer, n_vocab).map(str::to_string),
+    };
+
+    let initial = tokenizer.initial_tokens(resolved.as_deref(), translate);
+    let always = mask_array(&build_suppression_mask(tokenizer, n_vocab), n_vocab);
+    let first = mask_array(&build_first_step_mask(tokenizer, n_vocab), n_vocab);
+
+    let mut self_caches = empty_caches(decoder.num_layers());
+    let mut cross_caches = empty_caches(decoder.num_layers());
+
+    // Prefill the start-of-transcript prompt.
+    let init_arr = mlxcel_core::from_slice_i32(&initial, &[1, initial.len() as i32]);
+    let logits = decoder.forward(
+        &init_arr,
+        audio_features,
+        0,
+        &mut self_caches,
+        &mut cross_caches,
+    );
+
+    let mut generated: Vec<i32> = Vec::new();
+    let mut next = argmax_with_masks(
+        &logits,
+        initial.len() as i32 - 1,
+        n_vocab,
+        &always,
+        Some(&first),
+    );
+    let mut offset = initial.len() as i32;
+
+    // `sample_len` mirrors the reference cap of n_text_ctx / 2.
+    let max_new = n_text_ctx / 2;
+    let mut step = 0;
+    while next != tokenizer.eot && step < max_new && offset < n_text_ctx {
+        generated.push(next);
+        let tok = mlxcel_core::from_slice_i32(&[next], &[1, 1]);
+        let logits = decoder.forward(
+            &tok,
+            audio_features,
+            offset,
+            &mut self_caches,
+            &mut cross_caches,
+        );
+        offset += 1;
+        step += 1;
+        next = argmax_with_masks(&logits, 0, n_vocab, &always, None);
+    }
+
+    (generated, resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokenizers::Tokenizer;
+
+    fn synthetic() -> WhisperTokenizer {
+        let json = r#"{
+            "version": "1.0", "truncation": null, "padding": null,
+            "added_tokens": [
+                {"id": 4, "content": "<|endoftext|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 5, "content": "<|startoftranscript|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 6, "content": "<|en|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 7, "content": "<|ko|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 8, "content": "<|transcribe|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 9, "content": "<|translate|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 10, "content": "<|notimestamps|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 11, "content": "<|0.00|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true}
+            ],
+            "normalizer": null, "pre_tokenizer": null, "post_processor": null, "decoder": null,
+            "model": {"type": "BPE", "dropout": null, "unk_token": null, "continuing_subword_prefix": null, "end_of_word_suffix": null, "fuse_unk": false, "byte_fallback": false, "vocab": {"a": 0, " ": 1, "b": 2}, "merges": []}
+        }"#;
+        WhisperTokenizer::from_tokenizer(Tokenizer::from_bytes(json.as_bytes()).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn suppression_mask_blocks_specials_and_timestamps_but_not_eot() {
+        let tok = synthetic();
+        let n_vocab = 13;
+        let mask = build_suppression_mask(&tok, n_vocab);
+        assert_eq!(mask.len(), n_vocab as usize);
+        // Task / start tokens suppressed.
+        assert_eq!(mask[tok.sot as usize], f32::NEG_INFINITY);
+        assert_eq!(mask[tok.transcribe as usize], f32::NEG_INFINITY);
+        // Timestamp range suppressed (>= timestamp_begin = 11).
+        assert_eq!(mask[11], f32::NEG_INFINITY);
+        assert_eq!(mask[12], f32::NEG_INFINITY);
+        // End-of-transcript must remain selectable to stop decoding.
+        assert_eq!(mask[tok.eot as usize], 0.0);
+        // Plain text tokens stay open.
+        assert_eq!(mask[0], 0.0);
+    }
+
+    #[test]
+    fn first_step_mask_blocks_blank_and_eot() {
+        let tok = synthetic();
+        let n_vocab = 13;
+        let mask = build_first_step_mask(&tok, n_vocab);
+        assert_eq!(mask[tok.eot as usize], f32::NEG_INFINITY);
+        if let Some(blank) = tok.blank {
+            assert_eq!(mask[blank as usize], f32::NEG_INFINITY);
+        }
+        // A normal text token is left untouched.
+        assert_eq!(mask[0], 0.0);
+    }
+
+    #[test]
+    fn language_mask_keeps_only_language_tokens() {
+        let tok = synthetic();
+        let n_vocab = 13;
+        let en = tok.language_token("en").unwrap();
+        let ko = tok.language_token("ko").unwrap();
+        let mask = build_language_mask(&tok, n_vocab);
+        // Language tags are open (0.0); everything else is masked (-inf).
+        assert_eq!(mask[en as usize], 0.0);
+        assert_eq!(mask[ko as usize], 0.0);
+        assert_eq!(mask[0], f32::NEG_INFINITY); // "a", not a language tag
+        assert_eq!(mask[tok.sot as usize], f32::NEG_INFINITY);
+    }
+}

--- a/src/models/whisper/encoder.rs
+++ b/src/models/whisper/encoder.rs
@@ -1,0 +1,118 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Whisper audio encoder: two strided Conv1d stems, additive sinusoidal
+//! position embeddings, N self-attention transformer blocks, and a final
+//! LayerNorm.
+
+use mlxcel_core::layers::LayerNorm;
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+use super::WhisperDims;
+use super::layers::ResidualAttentionBlock;
+
+fn conv_weight(weights: &WeightMap, key: &str) -> Result<UniquePtr<MlxArray>, String> {
+    weights
+        .get(key)
+        .map(|w| mlxcel_core::copy(w))
+        .ok_or_else(|| format!("Whisper weight not found: {key}"))
+}
+
+/// Sinusoidal position table `[length, channels]`, matching the reference
+/// `sinusoids()`: `[sin(t * inv_ts) || cos(t * inv_ts)]`.
+fn sinusoids(length: usize, channels: usize) -> Vec<f32> {
+    let half = channels / 2;
+    let max_timescale = 10_000.0f64;
+    let log_increment = max_timescale.ln() / (half as f64 - 1.0).max(1.0);
+    let inv_timescales: Vec<f64> = (0..half)
+        .map(|i| (-log_increment * i as f64).exp())
+        .collect();
+    let mut out = vec![0.0f32; length * channels];
+    for t in 0..length {
+        for (i, &inv) in inv_timescales.iter().enumerate() {
+            let scaled = t as f64 * inv;
+            out[t * channels + i] = scaled.sin() as f32;
+            out[t * channels + half + i] = scaled.cos() as f32;
+        }
+    }
+    out
+}
+
+pub(crate) struct AudioEncoder {
+    conv1_weight: UniquePtr<MlxArray>,
+    conv1_bias: UniquePtr<MlxArray>,
+    conv2_weight: UniquePtr<MlxArray>,
+    conv2_bias: UniquePtr<MlxArray>,
+    positional: UniquePtr<MlxArray>,
+    blocks: Vec<ResidualAttentionBlock>,
+    ln_post: LayerNorm,
+}
+
+impl AudioEncoder {
+    pub(crate) fn from_weights(
+        weights: &WeightMap,
+        dims: &WhisperDims,
+        dtype: i32,
+    ) -> Result<Self, String> {
+        let positional_data = sinusoids(dims.n_audio_ctx as usize, dims.n_audio_state as usize);
+        let positional =
+            mlxcel_core::from_slice_f32(&positional_data, &[dims.n_audio_ctx, dims.n_audio_state]);
+        let positional = mlxcel_core::astype(&positional, dtype);
+
+        let mut blocks = Vec::with_capacity(dims.n_audio_layer as usize);
+        for i in 0..dims.n_audio_layer {
+            blocks.push(ResidualAttentionBlock::from_weights(
+                weights,
+                &format!("encoder.blocks.{i}"),
+                dims.n_audio_head,
+                false,
+            )?);
+        }
+
+        let ln_weight = conv_weight(weights, "encoder.ln_post.weight")?;
+        let ln_bias = weights
+            .get("encoder.ln_post.bias")
+            .map(|w| mlxcel_core::copy(w));
+
+        Ok(Self {
+            conv1_weight: conv_weight(weights, "encoder.conv1.weight")?,
+            conv1_bias: conv_weight(weights, "encoder.conv1.bias")?,
+            conv2_weight: conv_weight(weights, "encoder.conv2.weight")?,
+            conv2_bias: conv_weight(weights, "encoder.conv2.bias")?,
+            positional,
+            blocks,
+            ln_post: LayerNorm::new(ln_weight, ln_bias, 1e-5),
+        })
+    }
+
+    /// Encode a mel spectrogram `[batch, n_frames, n_mels]` into audio features
+    /// `[batch, n_audio_ctx, n_audio_state]`.
+    pub(crate) fn forward(&self, mel: &MlxArray) -> UniquePtr<MlxArray> {
+        // conv1: stride 1, pad 1. conv2: stride 2, pad 1. Both kernel 3.
+        let x = mlxcel_core::conv1d(mel, &self.conv1_weight, 1, 1, 1, 1);
+        let x = mlxcel_core::add(&x, &self.conv1_bias);
+        let x = mlxcel_core::gelu(&x);
+
+        let x = mlxcel_core::conv1d(&x, &self.conv2_weight, 2, 1, 1, 1);
+        let x = mlxcel_core::add(&x, &self.conv2_bias);
+        let x = mlxcel_core::gelu(&x);
+
+        let mut x = mlxcel_core::add(&x, &self.positional);
+        for block in &self.blocks {
+            x = block.forward(&x, None, None, &mut None, &mut None);
+        }
+        self.ln_post.forward(&x)
+    }
+}

--- a/src/models/whisper/layers.rs
+++ b/src/models/whisper/layers.rs
@@ -1,0 +1,242 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared transformer building blocks for the Whisper-style encoder-decoder.
+//!
+//! The encoder stacks self-attention-only blocks; the decoder stacks blocks
+//! that add a cross-attention sublayer attending to the encoder output. Both
+//! reuse the same [`MultiHeadAttention`] and [`ResidualAttentionBlock`] here,
+//! differing only in whether the cross-attention sublayer is present.
+
+use mlxcel_core::layers::{LayerNorm, Linear};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+/// Per-sublayer key/value cache. Holds `[batch, length, n_state]` tensors that
+/// are appended to (self-attention) or computed once (cross-attention).
+pub(crate) struct KvCache {
+    pub k: UniquePtr<MlxArray>,
+    pub v: UniquePtr<MlxArray>,
+}
+
+fn linear(weights: &WeightMap, prefix: &str) -> Result<Linear, String> {
+    Linear::from_weights(weights, prefix)
+}
+
+fn layer_norm(weights: &WeightMap, prefix: &str) -> Result<LayerNorm, String> {
+    let weight = weights
+        .get(&format!("{prefix}.weight"))
+        .map(|w| mlxcel_core::copy(w))
+        .ok_or_else(|| format!("Whisper weight not found: {prefix}.weight"))?;
+    let bias = weights
+        .get(&format!("{prefix}.bias"))
+        .map(|w| mlxcel_core::copy(w));
+    // Whisper uses the standard LayerNorm epsilon.
+    Ok(LayerNorm::new(weight, bias, 1e-5))
+}
+
+/// Build a `[length, length]` additive causal mask in `dtype` (0 on and below
+/// the diagonal, `-inf` above). Used only for the initial multi-token prefill;
+/// incremental single-token steps need no mask.
+pub(crate) fn additive_causal_mask(length: i32, dtype: i32) -> UniquePtr<MlxArray> {
+    let l = length as usize;
+    let mut data = vec![0.0f32; l * l];
+    for i in 0..l {
+        for j in (i + 1)..l {
+            data[i * l + j] = f32::NEG_INFINITY;
+        }
+    }
+    let mask = mlxcel_core::from_slice_f32(&data, &[length, length]);
+    mlxcel_core::astype(&mask, dtype)
+}
+
+/// Scaled dot-product attention over `[batch, len, n_state]` projections.
+///
+/// `mask`, when present, is added to the `[lq, lk]` logits before softmax.
+fn qkv_attention(
+    q: &MlxArray,
+    k: &MlxArray,
+    v: &MlxArray,
+    n_head: i32,
+    mask: Option<&MlxArray>,
+) -> UniquePtr<MlxArray> {
+    let q_shape = mlxcel_core::array_shape(q);
+    let k_shape = mlxcel_core::array_shape(k);
+    let batch = q_shape[0];
+    let lq = q_shape[1];
+    let n_state = q_shape[2];
+    let lk = k_shape[1];
+    let head_dim = n_state / n_head;
+    // The reference scales queries and keys each by head_dim^-0.25 so the
+    // product is divided by sqrt(head_dim).
+    let scale = (head_dim as f32).powf(-0.25);
+
+    // q -> [b, h, lq, hd]
+    let q = mlxcel_core::reshape(q, &[batch, lq, n_head, head_dim]);
+    let q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
+    let q = mlxcel_core::multiply_scalar(&q, scale);
+    // k -> [b, h, hd, lk]
+    let k = mlxcel_core::reshape(k, &[batch, lk, n_head, head_dim]);
+    let k = mlxcel_core::transpose_axes(&k, &[0, 2, 3, 1]);
+    let k = mlxcel_core::multiply_scalar(&k, scale);
+    // v -> [b, h, lk, hd]
+    let v = mlxcel_core::reshape(v, &[batch, lk, n_head, head_dim]);
+    let v = mlxcel_core::transpose_axes(&v, &[0, 2, 1, 3]);
+
+    let mut qk = mlxcel_core::matmul(&q, &k);
+    if let Some(mask) = mask {
+        qk = mlxcel_core::add(&qk, mask);
+    }
+    let weights = mlxcel_core::softmax_precise(&qk, -1);
+    let out = mlxcel_core::matmul(&weights, &v);
+    let out = mlxcel_core::transpose_axes(&out, &[0, 2, 1, 3]);
+    mlxcel_core::reshape(&out, &[batch, lq, n_state])
+}
+
+/// Multi-head attention with separate query/key/value/output projections.
+/// `key` has no bias in the Whisper architecture; the loader picks that up
+/// automatically because [`Linear`] treats `.bias` as optional.
+pub(crate) struct MultiHeadAttention {
+    n_head: i32,
+    query: Linear,
+    key: Linear,
+    value: Linear,
+    out: Linear,
+}
+
+impl MultiHeadAttention {
+    fn from_weights(weights: &WeightMap, prefix: &str, n_head: i32) -> Result<Self, String> {
+        Ok(Self {
+            n_head,
+            query: linear(weights, &format!("{prefix}.query"))?,
+            key: linear(weights, &format!("{prefix}.key"))?,
+            value: linear(weights, &format!("{prefix}.value"))?,
+            out: linear(weights, &format!("{prefix}.out"))?,
+        })
+    }
+
+    /// Self-attention. When `cache` is present, the freshly projected key/value
+    /// are appended to the cached history before attending.
+    fn self_attention(
+        &self,
+        x: &MlxArray,
+        mask: Option<&MlxArray>,
+        cache: &mut Option<KvCache>,
+    ) -> UniquePtr<MlxArray> {
+        let q = self.query.forward(x);
+        let k_new = self.key.forward(x);
+        let v_new = self.value.forward(x);
+        let (k, v) = match cache.take() {
+            Some(prev) => (
+                mlxcel_core::concatenate(&prev.k, &k_new, 1),
+                mlxcel_core::concatenate(&prev.v, &v_new, 1),
+            ),
+            None => (k_new, v_new),
+        };
+        let out = qkv_attention(&q, &k, &v, self.n_head, mask);
+        *cache = Some(KvCache { k, v });
+        self.out.forward(&out)
+    }
+
+    /// Cross-attention against the encoder output `xa`. Key/value are computed
+    /// once and reused across decode steps via `cache`.
+    fn cross_attention(
+        &self,
+        x: &MlxArray,
+        xa: &MlxArray,
+        cache: &mut Option<KvCache>,
+    ) -> UniquePtr<MlxArray> {
+        let q = self.query.forward(x);
+        let (k, v) = match cache.take() {
+            Some(prev) => (prev.k, prev.v),
+            None => (self.key.forward(xa), self.value.forward(xa)),
+        };
+        let out = qkv_attention(&q, &k, &v, self.n_head, None);
+        *cache = Some(KvCache { k, v });
+        self.out.forward(&out)
+    }
+}
+
+/// One pre-norm transformer block. Encoder blocks omit cross-attention; decoder
+/// blocks include it.
+pub(crate) struct ResidualAttentionBlock {
+    attn: MultiHeadAttention,
+    attn_ln: LayerNorm,
+    cross_attn: Option<MultiHeadAttention>,
+    cross_attn_ln: Option<LayerNorm>,
+    mlp1: Linear,
+    mlp2: Linear,
+    mlp_ln: LayerNorm,
+}
+
+impl ResidualAttentionBlock {
+    pub(crate) fn from_weights(
+        weights: &WeightMap,
+        prefix: &str,
+        n_head: i32,
+        cross_attention: bool,
+    ) -> Result<Self, String> {
+        let (cross_attn, cross_attn_ln) = if cross_attention {
+            (
+                Some(MultiHeadAttention::from_weights(
+                    weights,
+                    &format!("{prefix}.cross_attn"),
+                    n_head,
+                )?),
+                Some(layer_norm(weights, &format!("{prefix}.cross_attn_ln"))?),
+            )
+        } else {
+            (None, None)
+        };
+        Ok(Self {
+            attn: MultiHeadAttention::from_weights(weights, &format!("{prefix}.attn"), n_head)?,
+            attn_ln: layer_norm(weights, &format!("{prefix}.attn_ln"))?,
+            cross_attn,
+            cross_attn_ln,
+            mlp1: linear(weights, &format!("{prefix}.mlp1"))?,
+            mlp2: linear(weights, &format!("{prefix}.mlp2"))?,
+            mlp_ln: layer_norm(weights, &format!("{prefix}.mlp_ln"))?,
+        })
+    }
+
+    /// Forward pass.
+    ///
+    /// `self_cache` / `cross_cache` carry per-block decode state; pass `&mut None`
+    /// for the encoder (cacheless) path.
+    pub(crate) fn forward(
+        &self,
+        x: &MlxArray,
+        xa: Option<&MlxArray>,
+        mask: Option<&MlxArray>,
+        self_cache: &mut Option<KvCache>,
+        cross_cache: &mut Option<KvCache>,
+    ) -> UniquePtr<MlxArray> {
+        let normed = self.attn_ln.forward(x);
+        let y = self.attn.self_attention(&normed, mask, self_cache);
+        let mut x = mlxcel_core::add(x, &y);
+
+        if let (Some(cross_attn), Some(cross_attn_ln)) = (&self.cross_attn, &self.cross_attn_ln) {
+            let xa = xa.expect("decoder cross-attention requires encoder features");
+            let normed = cross_attn_ln.forward(&x);
+            let y = cross_attn.cross_attention(&normed, xa, cross_cache);
+            x = mlxcel_core::add(&x, &y);
+        }
+
+        let h = self.mlp_ln.forward(&x);
+        let h = self.mlp1.forward(&h);
+        let h = mlxcel_core::gelu(&h);
+        let h = self.mlp2.forward(&h);
+        mlxcel_core::add(&x, &h)
+    }
+}

--- a/src/models/whisper/mod.rs
+++ b/src/models/whisper/mod.rs
@@ -156,7 +156,11 @@ impl WhisperModel {
         translate: bool,
     ) -> Result<(String, Option<String>)> {
         let n_mels = self.dims.n_mels as usize;
-        let (mel, frames) = whisper_mel::log_mel_spectrogram(audio_16k, n_mels);
+        // Pad the waveform to a whole number of 30 s windows before the log-mel
+        // transform so the silent tail is normalized like trained silence rather
+        // than left at a raw 0.0 (see `pad_audio_to_window_multiple`).
+        let audio_padded = pad_audio_to_window_multiple(audio_16k);
+        let (mel, frames) = whisper_mel::log_mel_spectrogram(&audio_padded, n_mels);
         if frames == 0 {
             return Ok((String::new(), language.map(String::from)));
         }
@@ -193,8 +197,34 @@ impl WhisperModel {
     }
 }
 
-/// Copy one 30 s window of mel frames starting at `seek`, zero-padding the tail
-/// when the utterance ends mid-window. Output is row-major `[N_FRAMES][n_mels]`.
+/// Pad the waveform with trailing silence (zeros) up to a whole number of 30 s
+/// windows.
+///
+/// The padding is applied to the waveform, before the log-mel transform, so the
+/// silent tail flows through `log10` and the global-max clamp and lands at the
+/// same normalized log floor as trained silence. Zero-filling the mel frames
+/// directly (after normalization) would instead leave the tail at a raw `0.0`, a
+/// low-mid value the encoder reads as spurious broadband energy, which can
+/// degrade or hallucinate transcriptions of clips shorter than one window (under
+/// 30 s) where the padding dominates. An empty input stays empty; the caller
+/// short-circuits on zero frames.
+fn pad_audio_to_window_multiple(audio: &[f32]) -> Vec<f32> {
+    if audio.is_empty() {
+        return Vec::new();
+    }
+    let windows = audio.len().div_ceil(whisper_mel::WHISPER_N_SAMPLES);
+    let target = windows * whisper_mel::WHISPER_N_SAMPLES;
+    let mut padded = Vec::with_capacity(target);
+    padded.extend_from_slice(audio);
+    padded.resize(target, 0.0);
+    padded
+}
+
+/// Copy one 30 s window of mel frames starting at `seek`. The waveform is padded
+/// to a whole number of windows before the log-mel transform (see
+/// `pad_audio_to_window_multiple`), so in practice every window is full; the
+/// trailing zero-fill here is a safety net for any final-frame remainder. Output
+/// is row-major `[N_FRAMES][n_mels]`.
 fn padded_window(mel: &[f32], frames: usize, n_mels: usize, seek: usize) -> Vec<f32> {
     let mut out = vec![0.0f32; whisper_mel::WHISPER_N_FRAMES * n_mels];
     let avail = (frames - seek).min(whisper_mel::WHISPER_N_FRAMES);
@@ -327,5 +357,47 @@ mod tests {
         assert_eq!(&window[0..6], &[1.0, 1.0, 2.0, 2.0, 3.0, 3.0]);
         // Everything past the 3 available frames is zero-padded.
         assert!(window[6..].iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn pad_audio_rounds_up_to_window_multiple() {
+        assert!(pad_audio_to_window_multiple(&[]).is_empty());
+
+        let one = pad_audio_to_window_multiple(&vec![0.5f32; 100]);
+        assert_eq!(one.len(), whisper_mel::WHISPER_N_SAMPLES);
+        assert_eq!(one[0], 0.5);
+        assert_eq!(one[100], 0.0);
+
+        let two = pad_audio_to_window_multiple(&vec![0.1f32; whisper_mel::WHISPER_N_SAMPLES + 5]);
+        assert_eq!(two.len(), 2 * whisper_mel::WHISPER_N_SAMPLES);
+    }
+
+    #[test]
+    fn padded_audio_tail_sits_at_log_floor_not_zero() {
+        // A short tone padded to a full window must land its silent tail at the
+        // normalized log floor (the per-utterance minimum), not 0.0. Feeding 0.0
+        // would read as spurious broadband energy to the encoder.
+        let mut tone = vec![0.0f32; 8000]; // 0.5 s at 16 kHz
+        for (i, s) in tone.iter_mut().enumerate() {
+            *s = (2.0 * std::f32::consts::PI * 440.0 * i as f32 / 16_000.0).sin();
+        }
+        let padded = pad_audio_to_window_multiple(&tone);
+        assert_eq!(padded.len(), whisper_mel::WHISPER_N_SAMPLES);
+
+        let (mel, frames) = whisper_mel::log_mel_spectrogram(&padded, 80);
+        assert_eq!(frames, whisper_mel::WHISPER_N_FRAMES);
+
+        let global_min = mel.iter().copied().fold(f32::INFINITY, f32::min);
+        let last = &mel[(frames - 1) * 80..frames * 80];
+        for &v in last {
+            assert!(
+                (v - global_min).abs() < 1e-3,
+                "silent tail frame should sit at the log floor, got {v} vs floor {global_min}"
+            );
+        }
+        assert!(
+            global_min < -1e-2,
+            "log floor must differ from the 0.0 the buggy mel padding produced, got {global_min}"
+        );
     }
 }

--- a/src/models/whisper/mod.rs
+++ b/src/models/whisper/mod.rs
@@ -144,16 +144,21 @@ impl WhisperModel {
     ///
     /// Returns the concatenated text and the language code that was used. Audio
     /// longer than 30 s is processed in consecutive 30 s windows.
+    ///
+    /// Errors if MLX graph evaluation fails. The graph is evaluated through the
+    /// fallible [`mlxcel_core::try_eval`] boundary, so an MLX failure (for
+    /// example a shape or allocation error) is returned as `Err` instead of
+    /// aborting the process with an uncaught C++ exception.
     pub fn transcribe(
         &self,
         audio_16k: &[f32],
         language: Option<&str>,
         translate: bool,
-    ) -> (String, Option<String>) {
+    ) -> Result<(String, Option<String>)> {
         let n_mels = self.dims.n_mels as usize;
         let (mel, frames) = whisper_mel::log_mel_spectrogram(audio_16k, n_mels);
         if frames == 0 {
-            return (String::new(), language.map(String::from));
+            return Ok((String::new(), language.map(String::from)));
         }
 
         let mut text = String::new();
@@ -176,7 +181,7 @@ impl WhisperModel {
                 self.dims.n_text_ctx,
                 used_language.as_deref(),
                 translate,
-            );
+            )?;
             if used_language.is_none() {
                 used_language = detected;
             }
@@ -184,7 +189,7 @@ impl WhisperModel {
             seek += whisper_mel::WHISPER_N_FRAMES;
         }
 
-        (text, used_language)
+        Ok((text, used_language))
     }
 }
 

--- a/src/models/whisper/mod.rs
+++ b/src/models/whisper/mod.rs
@@ -1,0 +1,326 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Whisper-style encoder-decoder ASR model.
+//!
+//! Architecture: a convolutional + transformer audio encoder feeding an
+//! autoregressive text decoder whose blocks cross-attend to the encoder output.
+//! The decoder is steered by multilingual transcribe/translate task tokens.
+//!
+//! This first port targets non-quantized (fp16/f32) MLX checkpoints and greedy
+//! decoding. The weight loader also accepts the HuggingFace key layout so either
+//! export of a checkpoint loads. Quantized checkpoints, beam search, and
+//! word-level timestamps are tracked as follow-ups.
+
+mod decoder;
+mod decoding;
+mod encoder;
+pub mod layers;
+pub mod tokenizer;
+
+use std::path::Path;
+
+use anyhow::{Result, anyhow};
+use serde_json::Value;
+
+use mlxcel_core::weights::WeightMap;
+
+use crate::audio::whisper_mel;
+
+use decoder::TextDecoder;
+use encoder::AudioEncoder;
+use tokenizer::WhisperTokenizer;
+
+/// Encoder/decoder shape parameters. Mirrors the reference `ModelDimensions`
+/// and accepts both the native and HuggingFace config field names.
+#[derive(Debug, Clone)]
+pub struct WhisperDims {
+    pub n_mels: i32,
+    pub n_audio_ctx: i32,
+    pub n_audio_state: i32,
+    pub n_audio_head: i32,
+    pub n_audio_layer: i32,
+    pub n_vocab: i32,
+    pub n_text_ctx: i32,
+    pub n_text_state: i32,
+    pub n_text_head: i32,
+    pub n_text_layer: i32,
+}
+
+fn config_i32(config: &Value, keys: &[&str]) -> Option<i32> {
+    keys.iter()
+        .find_map(|k| config.get(*k).and_then(Value::as_i64))
+        .map(|v| v as i32)
+}
+
+impl WhisperDims {
+    /// Parse from a (sanitized) `config.json` value, accepting native MLX field
+    /// names or the HuggingFace `WhisperConfig` names.
+    pub fn from_config(config: &Value) -> Result<Self> {
+        let require = |keys: &[&str]| -> Result<i32> {
+            config_i32(config, keys)
+                .ok_or_else(|| anyhow!("Whisper config missing field(s): {keys:?}"))
+        };
+        let n_audio_state = require(&["n_audio_state", "d_model"])?;
+        let n_text_state =
+            config_i32(config, &["n_text_state", "d_model"]).unwrap_or(n_audio_state);
+        Ok(Self {
+            n_mels: config_i32(config, &["n_mels", "num_mel_bins"]).unwrap_or(80),
+            n_audio_ctx: config_i32(config, &["n_audio_ctx", "max_source_positions"])
+                .unwrap_or(1500),
+            n_audio_state,
+            n_audio_head: require(&["n_audio_head", "encoder_attention_heads"])?,
+            n_audio_layer: require(&["n_audio_layer", "encoder_layers"])?,
+            n_vocab: require(&["n_vocab", "vocab_size"])?,
+            n_text_ctx: config_i32(config, &["n_text_ctx", "max_target_positions"]).unwrap_or(448),
+            n_text_state,
+            n_text_head: require(&["n_text_head", "decoder_attention_heads"])?,
+            n_text_layer: require(&["n_text_layer", "decoder_layers"])?,
+        })
+    }
+}
+
+/// Loaded Whisper ASR model: audio encoder, text decoder, and resolved
+/// tokenizer. Holds MLX weight handles, so the owning provider serializes
+/// access and asserts thread-safety (see `crate::server::whisper_stt`).
+pub struct WhisperModel {
+    dims: WhisperDims,
+    dtype: i32,
+    encoder: AudioEncoder,
+    decoder: TextDecoder,
+    tokenizer: WhisperTokenizer,
+}
+
+impl WhisperModel {
+    /// Load a Whisper checkpoint directory (config.json + safetensors +
+    /// tokenizer.json).
+    pub fn load(model_path: &Path) -> Result<Self> {
+        let config_path = model_path.join("config.json");
+        let config_str = std::fs::read_to_string(&config_path)
+            .map_err(|e| anyhow!("Failed to read {config_path:?}: {e}"))?;
+        let config_str = super::sanitize_config_json(&config_str);
+        let config: Value = serde_json::from_str(&config_str)
+            .map_err(|e| anyhow!("Failed to parse Whisper config: {e}"))?;
+        let dims = WhisperDims::from_config(&config)?;
+
+        let mut weights = mlxcel_core::weights::load_weights_from_dir(model_path)
+            .map_err(|e| anyhow!("Failed to load Whisper weights: {e}"))?;
+        sanitize_whisper_weights(&mut weights);
+        // Apple Silicon precision policy: bf16 -> f16 for non-quantized weights.
+        let _ = super::convert_bf16_weights(&mut weights);
+
+        let dtype = weights
+            .get("decoder.token_embedding.weight")
+            .map(|w| mlxcel_core::array_dtype(w))
+            .unwrap_or(mlxcel_core::dtype::FLOAT16);
+
+        let encoder = AudioEncoder::from_weights(&weights, &dims, dtype)
+            .map_err(|e| anyhow!("Failed to build Whisper encoder: {e}"))?;
+        let decoder = TextDecoder::from_weights(&weights, &dims, dtype)
+            .map_err(|e| anyhow!("Failed to build Whisper decoder: {e}"))?;
+        let tokenizer = WhisperTokenizer::from_dir(model_path)?;
+
+        Ok(Self {
+            dims,
+            dtype,
+            encoder,
+            decoder,
+            tokenizer,
+        })
+    }
+
+    /// Transcribe (or translate) 16 kHz mono audio.
+    ///
+    /// Returns the concatenated text and the language code that was used. Audio
+    /// longer than 30 s is processed in consecutive 30 s windows.
+    pub fn transcribe(
+        &self,
+        audio_16k: &[f32],
+        language: Option<&str>,
+        translate: bool,
+    ) -> (String, Option<String>) {
+        let n_mels = self.dims.n_mels as usize;
+        let (mel, frames) = whisper_mel::log_mel_spectrogram(audio_16k, n_mels);
+        if frames == 0 {
+            return (String::new(), language.map(String::from));
+        }
+
+        let mut text = String::new();
+        let mut used_language: Option<String> = language.map(String::from);
+        let mut seek = 0usize;
+        while seek < frames {
+            let window = padded_window(&mel, frames, n_mels, seek);
+            let mel_arr = mlxcel_core::from_slice_f32(
+                &window,
+                &[1, whisper_mel::WHISPER_N_FRAMES as i32, n_mels as i32],
+            );
+            let mel_arr = mlxcel_core::astype(&mel_arr, self.dtype);
+            let features = self.encoder.forward(&mel_arr);
+
+            let (tokens, detected) = decoding::transcribe_segment(
+                &self.decoder,
+                &features,
+                &self.tokenizer,
+                self.dims.n_vocab,
+                self.dims.n_text_ctx,
+                used_language.as_deref(),
+                translate,
+            );
+            if used_language.is_none() {
+                used_language = detected;
+            }
+            text.push_str(&self.tokenizer.decode_text(&tokens));
+            seek += whisper_mel::WHISPER_N_FRAMES;
+        }
+
+        (text, used_language)
+    }
+}
+
+/// Copy one 30 s window of mel frames starting at `seek`, zero-padding the tail
+/// when the utterance ends mid-window. Output is row-major `[N_FRAMES][n_mels]`.
+fn padded_window(mel: &[f32], frames: usize, n_mels: usize, seek: usize) -> Vec<f32> {
+    let mut out = vec![0.0f32; whisper_mel::WHISPER_N_FRAMES * n_mels];
+    let avail = (frames - seek).min(whisper_mel::WHISPER_N_FRAMES);
+    for f in 0..avail {
+        let src = (seek + f) * n_mels;
+        let dst = f * n_mels;
+        out[dst..dst + n_mels].copy_from_slice(&mel[src..src + n_mels]);
+    }
+    out
+}
+
+/// Normalize checkpoint weight keys to the native layout used by this port.
+///
+/// MLX-native checkpoints already use the target keys and pass through
+/// unchanged. HuggingFace `WhisperForConditionalGeneration` exports use a
+/// different key scheme and a `[out, in, kernel]` Conv1d layout; those are
+/// remapped and the conv weights transposed to `[out, kernel, in]`.
+fn sanitize_whisper_weights(weights: &mut WeightMap) {
+    let is_hf = weights
+        .keys()
+        .any(|k| k.starts_with("model.") || k.contains("encoder.layers."));
+    if !is_hf {
+        return;
+    }
+
+    // Ordered so more specific patterns are applied before generic ones.
+    let key_map: &[(&str, &str)] = &[
+        (
+            "decoder.embed_positions.weight",
+            "decoder.positional_embedding",
+        ),
+        ("encoder.layer_norm.", "encoder.ln_post."),
+        ("decoder.layer_norm.", "decoder.ln."),
+        ("encoder.layers.", "encoder.blocks."),
+        ("decoder.layers.", "decoder.blocks."),
+        (".self_attn_layer_norm.", ".attn_ln."),
+        (".final_layer_norm.", ".mlp_ln."),
+        (".encoder_attn_layer_norm.", ".cross_attn_ln."),
+        (".fc1.", ".mlp1."),
+        (".fc2.", ".mlp2."),
+        (".self_attn.q_proj.", ".attn.query."),
+        (".self_attn.k_proj.", ".attn.key."),
+        (".self_attn.v_proj.", ".attn.value."),
+        (".self_attn.out_proj.", ".attn.out."),
+        (".encoder_attn.q_proj.", ".cross_attn.query."),
+        (".encoder_attn.k_proj.", ".cross_attn.key."),
+        (".encoder_attn.v_proj.", ".cross_attn.value."),
+        (".encoder_attn.out_proj.", ".cross_attn.out."),
+        ("decoder.embed_tokens.", "decoder.token_embedding."),
+    ];
+
+    let old_keys: Vec<String> = weights.keys().cloned().collect();
+    let mut remapped: WeightMap = WeightMap::with_capacity(old_keys.len());
+    for key in old_keys {
+        let Some(value) = weights.remove(&key) else {
+            continue;
+        };
+        let mut k = key.strip_prefix("model.").unwrap_or(&key).to_string();
+        // The encoder sinusoidal positions are recomputed, never loaded.
+        if k == "encoder.embed_positions.weight" {
+            continue;
+        }
+        for (from, to) in key_map {
+            if k.contains(from) {
+                k = k.replace(from, to);
+            }
+        }
+        // HuggingFace Conv1d weights are [out, in, kernel]; MLX wants
+        // [out, kernel, in].
+        let value = if (k == "encoder.conv1.weight" || k == "encoder.conv2.weight")
+            && mlxcel_core::array_ndim(&value) == 3
+        {
+            mlxcel_core::transpose_axes(&value, &[0, 2, 1])
+        } else {
+            value
+        };
+        remapped.insert(k, value);
+    }
+    *weights = remapped;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn dims_parse_native_fields() {
+        let cfg = json!({
+            "n_mels": 80, "n_audio_ctx": 1500, "n_audio_state": 384,
+            "n_audio_head": 6, "n_audio_layer": 4, "n_vocab": 51865,
+            "n_text_ctx": 448, "n_text_state": 384, "n_text_head": 6, "n_text_layer": 4
+        });
+        let dims = WhisperDims::from_config(&cfg).unwrap();
+        assert_eq!(dims.n_mels, 80);
+        assert_eq!(dims.n_audio_layer, 4);
+        assert_eq!(dims.n_vocab, 51865);
+        assert_eq!(dims.n_text_head, 6);
+    }
+
+    #[test]
+    fn dims_parse_huggingface_fields() {
+        let cfg = json!({
+            "num_mel_bins": 128, "max_source_positions": 1500, "d_model": 1280,
+            "encoder_attention_heads": 20, "encoder_layers": 32, "vocab_size": 51866,
+            "max_target_positions": 448, "decoder_attention_heads": 20, "decoder_layers": 32
+        });
+        let dims = WhisperDims::from_config(&cfg).unwrap();
+        assert_eq!(dims.n_mels, 128);
+        assert_eq!(dims.n_audio_state, 1280);
+        assert_eq!(dims.n_text_state, 1280);
+        assert_eq!(dims.n_audio_layer, 32);
+        assert_eq!(dims.n_vocab, 51866);
+    }
+
+    #[test]
+    fn dims_missing_required_field_errors() {
+        let cfg = json!({ "n_mels": 80 });
+        assert!(WhisperDims::from_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn padded_window_zero_pads_short_tail() {
+        let n_mels = 2;
+        let frames = 3;
+        // 3 frames of [1,1],[2,2],[3,3].
+        let mel = vec![1.0, 1.0, 2.0, 2.0, 3.0, 3.0];
+        let window = padded_window(&mel, frames, n_mels, 0);
+        assert_eq!(window.len(), whisper_mel::WHISPER_N_FRAMES * n_mels);
+        assert_eq!(&window[0..6], &[1.0, 1.0, 2.0, 2.0, 3.0, 3.0]);
+        // Everything past the 3 available frames is zero-padded.
+        assert!(window[6..].iter().all(|&v| v == 0.0));
+    }
+}

--- a/src/models/whisper/tokenizer.rs
+++ b/src/models/whisper/tokenizer.rs
@@ -1,0 +1,424 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Whisper-style byte-level BPE tokenizer plus the special-token vocabulary
+//! that drives the transcribe/translate task tokens, language tags, and
+//! decode-time token suppression.
+//!
+//! The byte-level BPE itself is loaded from the checkpoint's `tokenizer.json`;
+//! this module resolves the special token ids on top of it and precomputes the
+//! suppression sets.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use anyhow::{Result, anyhow};
+use tokenizers::Tokenizer;
+
+/// Language codes in their canonical Whisper order. The id of `<|{code}|>` is
+/// looked up against the loaded tokenizer; codes absent from a given checkpoint
+/// (e.g. English-only models) are simply skipped.
+pub(crate) const LANGUAGES: &[&str] = &[
+    "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar", "sv", "it",
+    "id", "hi", "fi", "vi", "he", "uk", "el", "ms", "cs", "ro", "da", "hu", "ta", "no", "th", "ur",
+    "hr", "bg", "lt", "la", "mi", "ml", "cy", "sk", "te", "fa", "lv", "bn", "sr", "az", "sl", "kn",
+    "et", "mk", "br", "eu", "is", "hy", "ne", "mn", "bs", "kk", "sq", "sw", "gl", "mr", "pa", "si",
+    "km", "sn", "yo", "so", "af", "oc", "ka", "be", "tg", "sd", "gu", "am", "yi", "lo", "uz", "fo",
+    "ht", "ps", "tk", "nn", "mt", "sa", "lb", "my", "bo", "tl", "mg", "as", "tt", "haw", "ln",
+    "ha", "ba", "jw", "su", "yue",
+];
+
+/// Special-token ids and suppression sets resolved against a checkpoint's BPE.
+pub(crate) struct WhisperTokenizer {
+    tokenizer: Tokenizer,
+    /// `<|startoftranscript|>`
+    pub sot: i32,
+    /// `<|endoftext|>` (end of transcript)
+    pub eot: i32,
+    /// `<|transcribe|>`
+    pub transcribe: i32,
+    /// `<|translate|>` (absent on English-only checkpoints)
+    pub translate: Option<i32>,
+    /// `<|notimestamps|>`
+    pub no_timestamps: i32,
+    /// First timestamp token `<|0.00|>`; everything `>=` this is a timestamp.
+    pub timestamp_begin: i32,
+    /// First token produced by encoding a single space (suppressed on the first
+    /// generated step). `None` if it could not be resolved.
+    pub blank: Option<i32>,
+    /// True when the checkpoint carries language tags (multilingual model).
+    pub multilingual: bool,
+    /// Resolved `(code, id)` pairs for every available language tag.
+    pub language_ids: Vec<(&'static str, i32)>,
+    /// Always-suppressed token ids (non-speech symbols plus the task/start
+    /// tokens). The timestamp range is suppressed separately.
+    pub suppress: Vec<i32>,
+}
+
+impl WhisperTokenizer {
+    /// Load the byte-level BPE from `<dir>/tokenizer.json` and resolve the
+    /// Whisper special tokens on top of it.
+    pub(crate) fn from_dir(model_path: &Path) -> Result<Self> {
+        let path = model_path.join("tokenizer.json");
+        let tokenizer = Tokenizer::from_file(&path)
+            .map_err(|e| anyhow!("Failed to load Whisper tokenizer from {path:?}: {e}"))?;
+        Self::from_tokenizer(tokenizer)
+    }
+
+    /// Resolve the special tokens against an already-built tokenizer.
+    pub(crate) fn from_tokenizer(tokenizer: Tokenizer) -> Result<Self> {
+        let tid = |s: &str| tokenizer.token_to_id(s).map(|v| v as i32);
+
+        let sot = tid("<|startoftranscript|>")
+            .ok_or_else(|| anyhow!("not a Whisper tokenizer: missing <|startoftranscript|>"))?;
+        let eot = tid("<|endoftext|>")
+            .ok_or_else(|| anyhow!("not a Whisper tokenizer: missing <|endoftext|>"))?;
+        let transcribe = tid("<|transcribe|>")
+            .ok_or_else(|| anyhow!("not a Whisper tokenizer: missing <|transcribe|>"))?;
+        let no_timestamps = tid("<|notimestamps|>")
+            .ok_or_else(|| anyhow!("not a Whisper tokenizer: missing <|notimestamps|>"))?;
+        let timestamp_begin = tid("<|0.00|>")
+            .ok_or_else(|| anyhow!("not a Whisper tokenizer: missing <|0.00|> timestamp token"))?;
+        let translate = tid("<|translate|>");
+
+        let language_ids: Vec<(&'static str, i32)> = LANGUAGES
+            .iter()
+            .filter_map(|&code| tid(&format!("<|{code}|>")).map(|id| (code, id)))
+            .collect();
+        let multilingual = !language_ids.is_empty();
+
+        let blank = encode_first(&tokenizer, " ");
+        let non_speech = non_speech_tokens(&tokenizer);
+        let suppress = build_suppress_set(
+            sot,
+            transcribe,
+            translate,
+            tid("<|startofprev|>"),
+            tid("<|startoflm|>"),
+            tid("<|nospeech|>").or_else(|| tid("<|nocaptions|>")),
+            &non_speech,
+        );
+
+        Ok(Self {
+            tokenizer,
+            sot,
+            eot,
+            transcribe,
+            translate,
+            no_timestamps,
+            timestamp_begin,
+            blank,
+            multilingual,
+            language_ids,
+            suppress,
+        })
+    }
+
+    /// Resolve the `<|{code}|>` language token id, if present.
+    pub(crate) fn language_token(&self, code: &str) -> Option<i32> {
+        self.language_ids
+            .iter()
+            .find(|(c, _)| *c == code)
+            .map(|(_, id)| *id)
+    }
+
+    /// The initial decoder prompt for the given language/task. Always ends with
+    /// `<|notimestamps|>` (timestamps are out of scope for this first port).
+    pub(crate) fn initial_tokens(&self, language: Option<&str>, translate: bool) -> Vec<i32> {
+        let mut tokens = vec![self.sot];
+        if self.multilingual {
+            if let Some(id) = language.and_then(|c| self.language_token(c)) {
+                tokens.push(id);
+            } else if let Some(id) = self.language_token("en") {
+                tokens.push(id);
+            }
+            let task = if translate {
+                self.translate.unwrap_or(self.transcribe)
+            } else {
+                self.transcribe
+            };
+            tokens.push(task);
+        }
+        tokens.push(self.no_timestamps);
+        tokens
+    }
+
+    /// Decode generated token ids into text, dropping special and timestamp
+    /// tokens (everything `>= eot`).
+    pub(crate) fn decode_text(&self, ids: &[i32]) -> String {
+        let text_ids: Vec<u32> = ids
+            .iter()
+            .filter(|&&t| t >= 0 && t < self.eot)
+            .map(|&t| t as u32)
+            .collect();
+        self.tokenizer.decode(&text_ids, true).unwrap_or_default()
+    }
+}
+
+/// Encode `text` and return its first token id (used for the blank/space token).
+fn encode_first(tokenizer: &Tokenizer, text: &str) -> Option<i32> {
+    tokenizer
+        .encode(text, false)
+        .ok()
+        .and_then(|e| e.get_ids().first().map(|&id| id as i32))
+}
+
+/// Best-effort reconstruction of the non-speech symbol suppression set: encode
+/// each punctuation/markup symbol and keep the ones that map to a single token,
+/// plus the music note glyphs.
+fn non_speech_tokens(tokenizer: &Tokenizer) -> Vec<i32> {
+    let symbols = [
+        "\"",
+        "#",
+        "(",
+        ")",
+        "*",
+        "+",
+        "/",
+        ":",
+        ";",
+        "<",
+        "=",
+        ">",
+        "@",
+        "[",
+        "\\",
+        "]",
+        "^",
+        "_",
+        "`",
+        "{",
+        "|",
+        "}",
+        "~",
+        "「",
+        "」",
+        "『",
+        "』",
+        "<<",
+        ">>",
+        "<<<",
+        ">>>",
+        "--",
+        "---",
+        "-(",
+        "-[",
+        "('",
+        "(\"",
+        "((",
+        "))",
+        "(((",
+        ")))",
+        "[[",
+        "]]",
+        "{{",
+        "}}",
+        "♪♪",
+        "♪♪♪",
+    ];
+    let miscellaneous = ["♩", "♪", "♫", "♬", "♭", "♮", "♯"];
+
+    let mut result: BTreeSet<i32> = BTreeSet::new();
+    if let Some(id) = encode_first(tokenizer, " -") {
+        result.insert(id);
+    }
+    if let Some(id) = encode_first(tokenizer, " '") {
+        result.insert(id);
+    }
+    for symbol in symbols.iter().chain(miscellaneous.iter()) {
+        let is_misc = miscellaneous.contains(symbol);
+        for candidate in [symbol.to_string(), format!(" {symbol}")] {
+            if let Ok(encoding) = tokenizer.encode(candidate, false) {
+                let ids = encoding.get_ids();
+                if (ids.len() == 1 || is_misc) && !ids.is_empty() {
+                    result.insert(ids[0] as i32);
+                }
+            }
+        }
+    }
+    result.into_iter().collect()
+}
+
+/// Combine the non-speech symbols with the task/start tokens into a single
+/// sorted, de-duplicated suppression list (the `"-1"` suppression policy).
+fn build_suppress_set(
+    sot: i32,
+    transcribe: i32,
+    translate: Option<i32>,
+    sot_prev: Option<i32>,
+    sot_lm: Option<i32>,
+    no_speech: Option<i32>,
+    non_speech: &[i32],
+) -> Vec<i32> {
+    let mut set: BTreeSet<i32> = non_speech.iter().copied().collect();
+    set.insert(sot);
+    set.insert(transcribe);
+    for id in [translate, sot_prev, sot_lm, no_speech]
+        .into_iter()
+        .flatten()
+    {
+        set.insert(id);
+    }
+    set.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic tokenizer that carries the Whisper special tokens as
+    /// added tokens, plus a tiny regular vocabulary, so the special-token
+    /// resolution can be exercised without a real checkpoint.
+    fn synthetic_tokenizer() -> Tokenizer {
+        let json = r#"{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [
+                {"id": 4, "content": "<|endoftext|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 5, "content": "<|startoftranscript|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 6, "content": "<|en|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 7, "content": "<|ko|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 8, "content": "<|transcribe|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 9, "content": "<|translate|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 10, "content": "<|notimestamps|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+                {"id": 11, "content": "<|0.00|>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true}
+            ],
+            "normalizer": null,
+            "pre_tokenizer": null,
+            "post_processor": null,
+            "decoder": null,
+            "model": {
+                "type": "BPE",
+                "dropout": null,
+                "unk_token": null,
+                "continuing_subword_prefix": null,
+                "end_of_word_suffix": null,
+                "fuse_unk": false,
+                "byte_fallback": false,
+                "vocab": {"a": 0, " ": 1, "b": 2},
+                "merges": []
+            }
+        }"#;
+        Tokenizer::from_bytes(json.as_bytes()).expect("synthetic tokenizer")
+    }
+
+    #[test]
+    fn language_table_is_complete_and_ordered() {
+        assert_eq!(LANGUAGES.len(), 100, "Whisper ships 100 language tags");
+        assert_eq!(LANGUAGES[0], "en");
+        assert_eq!(LANGUAGES[5], "ko");
+        assert!(LANGUAGES.contains(&"yue"));
+        assert!(LANGUAGES.contains(&"ja"));
+        // No duplicates.
+        let unique: BTreeSet<&&str> = LANGUAGES.iter().collect();
+        assert_eq!(unique.len(), LANGUAGES.len());
+    }
+
+    #[test]
+    fn resolves_special_tokens() {
+        // The tokenizers crate assigns added-token ids after the model vocab,
+        // so resolve the expected ids from the tokenizer rather than hardcoding.
+        let raw = synthetic_tokenizer();
+        let want = |s: &str| raw.token_to_id(s).map(|v| v as i32);
+        let sot = want("<|startoftranscript|>").unwrap();
+        let eot = want("<|endoftext|>").unwrap();
+        let transcribe = want("<|transcribe|>").unwrap();
+        let translate = want("<|translate|>");
+        let no_timestamps = want("<|notimestamps|>").unwrap();
+        let timestamp_begin = want("<|0.00|>").unwrap();
+        let en = want("<|en|>").unwrap();
+        let ko = want("<|ko|>").unwrap();
+
+        let tok = WhisperTokenizer::from_tokenizer(raw).expect("resolve");
+        assert_eq!(tok.sot, sot);
+        assert_eq!(tok.eot, eot);
+        assert_eq!(tok.transcribe, transcribe);
+        assert_eq!(tok.translate, translate);
+        assert_eq!(tok.no_timestamps, no_timestamps);
+        assert_eq!(tok.timestamp_begin, timestamp_begin);
+        assert!(tok.multilingual);
+        assert_eq!(tok.language_token("en"), Some(en));
+        assert_eq!(tok.language_token("ko"), Some(ko));
+        assert_eq!(tok.language_token("fr"), None);
+        assert_ne!(tok.sot, tok.eot);
+    }
+
+    #[test]
+    fn initial_tokens_follow_the_sot_sequence() {
+        let raw = synthetic_tokenizer();
+        let id = |s: &str| raw.token_to_id(s).unwrap() as i32;
+        let (sot, en, ko, tr, tl, nts) = (
+            id("<|startoftranscript|>"),
+            id("<|en|>"),
+            id("<|ko|>"),
+            id("<|transcribe|>"),
+            id("<|translate|>"),
+            id("<|notimestamps|>"),
+        );
+        let tok = WhisperTokenizer::from_tokenizer(raw).expect("resolve");
+        // transcribe, Korean hint
+        assert_eq!(
+            tok.initial_tokens(Some("ko"), false),
+            vec![sot, ko, tr, nts]
+        );
+        // translate task
+        assert_eq!(tok.initial_tokens(Some("ko"), true), vec![sot, ko, tl, nts]);
+        // unknown hint falls back to English
+        assert_eq!(
+            tok.initial_tokens(Some("zz"), false),
+            vec![sot, en, tr, nts]
+        );
+    }
+
+    #[test]
+    fn suppress_set_includes_task_and_start_tokens() {
+        let raw = synthetic_tokenizer();
+        let translate = raw.token_to_id("<|translate|>").unwrap() as i32;
+        let tok = WhisperTokenizer::from_tokenizer(raw).expect("resolve");
+        assert!(tok.suppress.contains(&tok.sot));
+        assert!(tok.suppress.contains(&tok.transcribe));
+        assert!(tok.suppress.contains(&translate));
+        // sorted and de-duplicated
+        let mut sorted = tok.suppress.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted, tok.suppress);
+    }
+
+    #[test]
+    fn build_suppress_set_is_sorted_union() {
+        let out = build_suppress_set(5, 8, Some(9), Some(50), None, Some(60), &[3, 1, 3]);
+        assert_eq!(out, vec![1, 3, 5, 8, 9, 50, 60]);
+    }
+
+    #[test]
+    fn decode_text_drops_special_and_timestamp_tokens() {
+        let tok = WhisperTokenizer::from_tokenizer(synthetic_tokenizer()).expect("resolve");
+        // Mix text tokens (ids below eot: "a"=0, "b"=2) with specials/timestamps.
+        let ids = vec![
+            tok.sot,
+            tok.transcribe,
+            tok.no_timestamps,
+            0,
+            2,
+            tok.timestamp_begin,
+        ];
+        let text = tok.decode_text(&ids);
+        assert!(
+            !text.contains("<|"),
+            "special tokens must not survive decode: {text:?}"
+        );
+    }
+}

--- a/src/server/audio_worker.rs
+++ b/src/server/audio_worker.rs
@@ -1,0 +1,343 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Single dedicated-thread worker for audio models.
+//!
+//! MLX work is thread-affine. The thread that creates a model's weight arrays
+//! must also be the thread that evaluates them, because loading initializes the
+//! full per-thread MLX scheduler context: the GPU stream this worker installs
+//! plus the CPU stream that decode-time ops and scalar readback resolve on. The
+//! generation path already follows this rule, every model is loaded and run on
+//! one owned thread by `BatchScheduler`, which installs a thread-local default
+//! stream once at the top of its loop. The audio path mirrors that here so a
+//! transcription (or future synthesis) request never evaluates an MLX graph on
+//! a thread that did not load the model. Evaluating on a foreign thread fails
+//! with `There is no Stream(cpu, 0) in current thread`.
+//!
+//! [`AudioWorker`] owns that thread. It installs a thread-local default stream,
+//! loads an [`AudioEngine`] on itself, then serves [`AudioCommand`]s from a
+//! channel one at a time. The HTTP routes only send a command and block for the
+//! reply, so the `spawn_blocking` pool thread that calls
+//! [`AudioWorker::transcribe`] or [`AudioWorker::synthesize`] does no MLX work.
+//!
+//! The worker is engine-agnostic. The speech-to-text provider supplies a
+//! Whisper engine today; the text-to-speech provider can supply its own engine
+//! over the same channel and thread-ownership pattern.
+
+use std::sync::Mutex;
+use std::sync::mpsc;
+use std::thread::{self, JoinHandle};
+
+use mlxcel_core::streams::{
+    install_thread_local_default_stream, new_thread_local_generation_stream,
+    synchronize_thread_local_stream,
+};
+
+use crate::server::audio_model::{
+    AudioModelError, AudioModelKind, AudioSynthesizeInput, AudioSynthesizeOutput,
+    AudioTranscribeInput, AudioTranscribeOutput,
+};
+
+/// Reported when a request cannot reach the worker thread because it has
+/// already exited (a load that failed late, or a panic mid-request).
+const WORKER_GONE: &str = "audio worker thread is no longer running";
+
+/// Model logic that runs exclusively on an [`AudioWorker`]'s dedicated thread.
+///
+/// Implementors hold MLX array handles directly, with no `Mutex` and no
+/// `unsafe impl Send`, because every call arrives on the single worker thread
+/// that constructed them. A provider that services only one direction overrides
+/// just that method and leaves the other with its default "kind not loaded"
+/// body.
+pub(crate) trait AudioEngine: 'static {
+    /// Run speech-to-text. Default: this engine does not transcribe.
+    fn transcribe(
+        &mut self,
+        _input: AudioTranscribeInput,
+    ) -> Result<AudioTranscribeOutput, AudioModelError> {
+        Err(AudioModelError::KindNotLoaded(AudioModelKind::Stt))
+    }
+
+    /// Run text-to-speech. Default: this engine does not synthesize.
+    fn synthesize(
+        &mut self,
+        _input: AudioSynthesizeInput,
+    ) -> Result<AudioSynthesizeOutput, AudioModelError> {
+        Err(AudioModelError::KindNotLoaded(AudioModelKind::Tts))
+    }
+}
+
+/// A unit of work plus the channel to reply on, handed to the worker thread.
+enum AudioCommand {
+    /// Speech-to-text request and its reply channel.
+    Transcribe {
+        input: AudioTranscribeInput,
+        respond: mpsc::Sender<Result<AudioTranscribeOutput, AudioModelError>>,
+    },
+    /// Text-to-speech request and its reply channel.
+    Synthesize {
+        input: AudioSynthesizeInput,
+        respond: mpsc::Sender<Result<AudioSynthesizeOutput, AudioModelError>>,
+    },
+    /// Graceful stop: break the loop so the thread can join.
+    Shutdown,
+}
+
+/// Owns a dedicated thread that loads and runs one [`AudioEngine`].
+///
+/// The handle is `Send + Sync` even though the engine and its MLX arrays are
+/// not, because the engine never leaves the worker thread: only command and
+/// reply values (all `Send`) cross the channel.
+#[derive(Debug)]
+pub(crate) struct AudioWorker {
+    /// Command channel to the worker thread. Wrapped in a `Mutex` so the
+    /// `AudioWorker` is `Sync` (an `mpsc::Sender` is `Send` but not `Sync`); the
+    /// lock is held only for the brief enqueue, not across inference.
+    sender: Mutex<mpsc::Sender<AudioCommand>>,
+    /// Join handle, taken in `Drop` after the loop is asked to stop.
+    handle: Option<JoinHandle<()>>,
+}
+
+impl AudioWorker {
+    /// Spawn the worker thread and block until the engine has loaded.
+    ///
+    /// `loader` runs on the worker thread, so every array it creates belongs to
+    /// that thread's MLX context. Returns `Err` if the thread cannot be spawned
+    /// or the engine fails to load, so the caller can leave the audio slot empty
+    /// and keep serving rather than aborting startup.
+    pub(crate) fn spawn<E, L>(thread_name: &str, loader: L) -> anyhow::Result<Self>
+    where
+        E: AudioEngine,
+        L: FnOnce() -> anyhow::Result<E> + Send + 'static,
+    {
+        let (command_tx, command_rx) = mpsc::channel::<AudioCommand>();
+        let (ready_tx, ready_rx) = mpsc::channel::<Result<(), String>>();
+
+        let handle = thread::Builder::new()
+            .name(thread_name.to_string())
+            .spawn(move || worker_loop(loader, command_rx, ready_tx))
+            .map_err(|e| anyhow::anyhow!("failed to spawn audio worker thread: {e}"))?;
+
+        match ready_rx.recv() {
+            Ok(Ok(())) => Ok(Self {
+                sender: Mutex::new(command_tx),
+                handle: Some(handle),
+            }),
+            Ok(Err(message)) => {
+                let _ = handle.join();
+                Err(anyhow::anyhow!(
+                    "audio worker failed to load model: {message}"
+                ))
+            }
+            Err(_) => {
+                let _ = handle.join();
+                Err(anyhow::anyhow!(
+                    "audio worker thread exited before reporting readiness"
+                ))
+            }
+        }
+    }
+
+    /// Send a transcription request to the worker and block for its reply.
+    pub(crate) fn transcribe(
+        &self,
+        input: AudioTranscribeInput,
+    ) -> Result<AudioTranscribeOutput, AudioModelError> {
+        let (respond, reply) = mpsc::channel();
+        self.dispatch(AudioCommand::Transcribe { input, respond })?;
+        match reply.recv() {
+            Ok(result) => result,
+            Err(_) => Err(AudioModelError::Inference(WORKER_GONE.to_string())),
+        }
+    }
+
+    /// Send a synthesis request to the worker and block for its reply.
+    pub(crate) fn synthesize(
+        &self,
+        input: AudioSynthesizeInput,
+    ) -> Result<AudioSynthesizeOutput, AudioModelError> {
+        let (respond, reply) = mpsc::channel();
+        self.dispatch(AudioCommand::Synthesize { input, respond })?;
+        match reply.recv() {
+            Ok(result) => result,
+            Err(_) => Err(AudioModelError::Inference(WORKER_GONE.to_string())),
+        }
+    }
+
+    /// Enqueue a command, releasing the sender lock before the caller blocks on
+    /// its reply channel so concurrent requests queue in the channel rather than
+    /// serialize on the lock.
+    fn dispatch(&self, command: AudioCommand) -> Result<(), AudioModelError> {
+        let sender = self
+            .sender
+            .lock()
+            .map_err(|_| AudioModelError::Inference("audio worker channel poisoned".to_string()))?;
+        sender
+            .send(command)
+            .map_err(|_| AudioModelError::Inference(WORKER_GONE.to_string()))
+    }
+}
+
+impl Drop for AudioWorker {
+    fn drop(&mut self) {
+        // Ask the loop to stop, then wait for the thread so the engine's MLX
+        // handles are dropped on the thread that created them. Both steps are
+        // best-effort: if the worker already exited, the send fails and the join
+        // observes the prior exit, neither of which should escape a destructor.
+        if let Ok(sender) = self.sender.lock() {
+            let _ = sender.send(AudioCommand::Shutdown);
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Body of the worker thread: install the stream, load the engine, then serve
+/// commands until asked to stop or the channel closes.
+fn worker_loop<E, L>(
+    loader: L,
+    commands: mpsc::Receiver<AudioCommand>,
+    ready: mpsc::Sender<Result<(), String>>,
+) where
+    E: AudioEngine,
+    L: FnOnce() -> anyhow::Result<E>,
+{
+    // (a) Install this thread's default MLX stream, exactly as
+    // `BatchScheduler::run` does before it touches any array.
+    let stream = new_thread_local_generation_stream();
+    install_thread_local_default_stream(stream.as_ref());
+
+    // (b) Load the engine on this thread so its weight arrays live in this
+    // thread's MLX context. Report the outcome so `spawn` can return it.
+    let mut engine = match loader() {
+        Ok(engine) => engine,
+        Err(err) => {
+            let _ = ready.send(Err(err.to_string()));
+            return;
+        }
+    };
+    if ready.send(Ok(())).is_err() {
+        // The constructor stopped waiting; there is nobody to serve.
+        return;
+    }
+    drop(ready);
+
+    // (c) Serve one command at a time. After each, synchronize so dispatch and
+    // synchronization stay paired on this thread's stream.
+    while let Ok(command) = commands.recv() {
+        match command {
+            AudioCommand::Transcribe { input, respond } => {
+                let result = engine.transcribe(input);
+                synchronize_thread_local_stream(stream.as_ref());
+                let _ = respond.send(result);
+            }
+            AudioCommand::Synthesize { input, respond } => {
+                let result = engine.synthesize(input);
+                synchronize_thread_local_stream(stream.as_ref());
+                let _ = respond.send(result);
+            }
+            AudioCommand::Shutdown => break,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Engine that performs a trivial MLX op on the worker thread, proving the
+    /// load-and-run-on-one-thread round-trip works end to end.
+    struct TrivialEngine;
+
+    impl AudioEngine for TrivialEngine {
+        fn transcribe(
+            &mut self,
+            input: AudioTranscribeInput,
+        ) -> Result<AudioTranscribeOutput, AudioModelError> {
+            // Dispatch and force-evaluate a tiny array on this (worker) thread.
+            // The fallible `try_eval` boundary keeps an MLX failure from
+            // aborting the process, mirroring the real Whisper decode path.
+            let arr = mlxcel_core::from_slice_f32(&[1.0_f32, 2.0, 3.0], &[3]);
+            mlxcel_core::try_eval(&arr)
+                .map_err(|e| AudioModelError::Inference(format!("eval failed: {e}")))?;
+            Ok(AudioTranscribeOutput {
+                text: format!("ok:{}", input.audio.len()),
+                language: input.language,
+                duration_seconds: None,
+            })
+        }
+    }
+
+    fn transcribe_input(len: usize, language: Option<&str>) -> AudioTranscribeInput {
+        AudioTranscribeInput {
+            audio: vec![0u8; len],
+            filename: None,
+            language: language.map(str::to_string),
+            temperature: None,
+            translate: false,
+        }
+    }
+
+    #[test]
+    fn worker_round_trip_runs_mlx_op_and_replies() {
+        let worker = AudioWorker::spawn("audio-test-roundtrip", || Ok(TrivialEngine))
+            .expect("worker spawns and engine loads");
+
+        let out = worker
+            .transcribe(transcribe_input(5, Some("en")))
+            .expect("transcribe round-trips");
+        assert_eq!(out.text, "ok:5");
+        assert_eq!(out.language.as_deref(), Some("en"));
+
+        // A second request reuses the same thread and the same installed stream.
+        let out2 = worker
+            .transcribe(transcribe_input(2, None))
+            .expect("second transcribe round-trips");
+        assert_eq!(out2.text, "ok:2");
+        assert!(out2.language.is_none());
+    }
+
+    #[test]
+    fn worker_surfaces_loader_failure() {
+        let result = AudioWorker::spawn::<TrivialEngine, _>("audio-test-loadfail", || {
+            Err(anyhow::anyhow!("synthetic load failure"))
+        });
+        let err = result.expect_err("loader failure propagates from spawn");
+        assert!(
+            err.to_string().contains("synthetic load failure"),
+            "expected the loader error to be surfaced, got: {err}"
+        );
+    }
+
+    #[test]
+    fn default_engine_reports_unsupported_direction() {
+        struct NoneEngine;
+        impl AudioEngine for NoneEngine {}
+
+        let worker = AudioWorker::spawn("audio-test-default", || Ok(NoneEngine))
+            .expect("worker spawns with a do-nothing engine");
+        let err = worker
+            .synthesize(AudioSynthesizeInput {
+                input: "hi".to_string(),
+                voice: None,
+                speed: None,
+            })
+            .expect_err("default synthesize is unsupported");
+        assert!(matches!(
+            err,
+            AudioModelError::KindNotLoaded(AudioModelKind::Tts)
+        ));
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -44,6 +44,7 @@ pub mod structured;
 pub mod thinking_budget;
 pub mod tool_calls;
 pub mod types;
+pub mod whisper_stt;
 
 pub use app::create_app;
 pub use audio_model::{

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -17,6 +17,7 @@
 pub mod anthropic_translator;
 pub mod app;
 pub mod audio_model;
+pub(crate) mod audio_worker;
 pub mod batch;
 mod chat_request;
 pub mod chat_template;

--- a/src/server/routes/audio.rs
+++ b/src/server/routes/audio.rs
@@ -81,7 +81,16 @@ pub async fn audio_speech(
     };
 
     let started = std::time::Instant::now();
-    let synth = tokio::task::spawn_blocking(move || provider.synthesize(input)).await;
+    // The provider evaluates an MLX graph, which is thread-affine: the blocking
+    // pool thread must have an MLX default stream installed before the first
+    // array op or MLX aborts the process. `with_thread_local_default_stream`
+    // installs (and synchronizes) a per-thread stream around the call. Applying
+    // it at this shared dispatch seam means the speech-to-text path and any
+    // future text-to-speech provider inherit the same protection.
+    let synth = tokio::task::spawn_blocking(move || {
+        mlxcel_core::streams::with_thread_local_default_stream(move || provider.synthesize(input))
+    })
+    .await;
     let output = match synth {
         Ok(Ok(output)) => output,
         Ok(Err(err)) => return audio_model_error_response(err).into_response(),
@@ -153,7 +162,15 @@ async fn transcribe(state: AppState, multipart: Multipart, translate: bool) -> R
     };
 
     let started = std::time::Instant::now();
-    let result = tokio::task::spawn_blocking(move || provider.transcribe(input)).await;
+    // Install (and synchronize) a per-thread MLX default stream around the
+    // provider call: the Whisper graph is evaluated on this blocking-pool
+    // thread and MLX requires a default stream to be installed first. See the
+    // matching comment in `audio_speech` for why this lives at the dispatch
+    // seam shared by both audio directions.
+    let result = tokio::task::spawn_blocking(move || {
+        mlxcel_core::streams::with_thread_local_default_stream(move || provider.transcribe(input))
+    })
+    .await;
     let output = match result {
         Ok(Ok(output)) => output,
         Ok(Err(err)) => return audio_model_error_response(err).into_response(),

--- a/src/server/routes/audio.rs
+++ b/src/server/routes/audio.rs
@@ -81,16 +81,12 @@ pub async fn audio_speech(
     };
 
     let started = std::time::Instant::now();
-    // The provider evaluates an MLX graph, which is thread-affine: the blocking
-    // pool thread must have an MLX default stream installed before the first
-    // array op or MLX aborts the process. `with_thread_local_default_stream`
-    // installs (and synchronizes) a per-thread stream around the call. Applying
-    // it at this shared dispatch seam means the speech-to-text path and any
-    // future text-to-speech provider inherit the same protection.
-    let synth = tokio::task::spawn_blocking(move || {
-        mlxcel_core::streams::with_thread_local_default_stream(move || provider.synthesize(input))
-    })
-    .await;
+    // The provider evaluates its MLX graph on its own dedicated, stream-
+    // initialized thread (see `crate::server::audio_worker`). This call only
+    // forwards the request over the worker's channel and blocks for the reply,
+    // so it does no MLX work itself, but it is still blocking, hence
+    // `spawn_blocking` to keep it off the async executor.
+    let synth = tokio::task::spawn_blocking(move || provider.synthesize(input)).await;
     let output = match synth {
         Ok(Ok(output)) => output,
         Ok(Err(err)) => return audio_model_error_response(err).into_response(),
@@ -162,15 +158,12 @@ async fn transcribe(state: AppState, multipart: Multipart, translate: bool) -> R
     };
 
     let started = std::time::Instant::now();
-    // Install (and synchronize) a per-thread MLX default stream around the
-    // provider call: the Whisper graph is evaluated on this blocking-pool
-    // thread and MLX requires a default stream to be installed first. See the
-    // matching comment in `audio_speech` for why this lives at the dispatch
-    // seam shared by both audio directions.
-    let result = tokio::task::spawn_blocking(move || {
-        mlxcel_core::streams::with_thread_local_default_stream(move || provider.transcribe(input))
-    })
-    .await;
+    // The provider evaluates the Whisper graph on its own dedicated, stream-
+    // initialized thread (see `crate::server::audio_worker`). This call only
+    // forwards the request over the worker's channel and blocks for the reply,
+    // so it does no MLX work itself, but it is still blocking, hence
+    // `spawn_blocking` to keep it off the async executor.
+    let result = tokio::task::spawn_blocking(move || provider.transcribe(input)).await;
     let output = match result {
         Ok(Ok(output)) => output,
         Ok(Err(err)) => return audio_model_error_response(err).into_response(),

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -1805,10 +1805,13 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
 
     // Speech-to-text wiring: when the loaded checkpoint is a Whisper-style ASR
     // model, populate the audio slot so `/v1/audio/transcriptions` and
-    // `/v1/audio/translations` are served. The chat ModelProvider load above is
-    // a no-op for this checkpoint (the worker logs and returns), matching the
-    // single-model "speech-to-text only" deployment; serving chat and STT
-    // simultaneously is out of scope.
+    // `/v1/audio/translations` are served. `WhisperSttProvider::load` hands the
+    // checkpoint path to its own dedicated worker thread, which loads the
+    // weights and evaluates every transcription on that one stream-initialized
+    // thread (MLX work is thread-affine); the load happens off this startup
+    // thread. The chat ModelProvider load above is a no-op for this checkpoint
+    // (the worker logs and returns), matching the single-model "speech-to-text
+    // only" deployment; serving chat and STT simultaneously is out of scope.
     let audio_model: Option<Arc<dyn crate::server::audio_model::AudioModelProvider>> =
         match crate::models::get_model_type(&startup.model_path) {
             Ok(crate::models::ModelType::Whisper) => {

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -1803,6 +1803,30 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
         )))
     };
 
+    // Speech-to-text wiring: when the loaded checkpoint is a Whisper-style ASR
+    // model, populate the audio slot so `/v1/audio/transcriptions` and
+    // `/v1/audio/translations` are served. The chat ModelProvider load above is
+    // a no-op for this checkpoint (the worker logs and returns), matching the
+    // single-model "speech-to-text only" deployment; serving chat and STT
+    // simultaneously is out of scope.
+    let audio_model: Option<Arc<dyn crate::server::audio_model::AudioModelProvider>> =
+        match crate::models::get_model_type(&startup.model_path) {
+            Ok(crate::models::ModelType::Whisper) => {
+                tracing::info!(
+                    "Detected Whisper speech-to-text checkpoint; loading audio model for \
+                     /v1/audio/transcriptions and /v1/audio/translations"
+                );
+                match crate::server::whisper_stt::WhisperSttProvider::load(&startup.model_path) {
+                    Ok(provider) => Some(Arc::new(provider)),
+                    Err(err) => {
+                        tracing::error!("Failed to load Whisper speech-to-text model: {err}");
+                        None
+                    }
+                }
+            }
+            _ => None,
+        };
+
     let state = AppState::with_observability(
         model_provider,
         config,
@@ -1816,7 +1840,8 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     .with_pp_tracer(pp_tracer)
     .with_prompt_cache(prompt_cache_store)
     .with_responses_store(responses_store)
-    .with_conversation_store(conversation_store);
+    .with_conversation_store(conversation_store)
+    .with_audio_model(audio_model);
     let app = create_app(state);
 
     if startup.port == 0 {

--- a/src/server/whisper_stt.rs
+++ b/src/server/whisper_stt.rs
@@ -18,42 +18,45 @@
 //! encoder-decoder model and exposes the result through the transport-agnostic
 //! audio-model seam consumed by `POST /v1/audio/transcriptions` and
 //! `POST /v1/audio/translations`.
+//!
+//! The Whisper model is loaded and every transcription is evaluated on one
+//! dedicated thread owned by an [`AudioWorker`]. MLX work is thread-affine, so
+//! loading the weights and evaluating the graph must happen on the same
+//! stream-initialized thread (see [`crate::server::audio_worker`]). This
+//! provider therefore holds no MLX handles itself; it only forwards requests
+//! over the worker's channel, which makes it trivially `Send + Sync`.
 
 use std::path::Path;
-use std::sync::Mutex;
 
 use crate::audio::load_wav_from_bytes;
 use crate::audio::whisper_mel;
 use crate::models::WhisperModel;
 use crate::server::audio_model::{
-    AudioModelError, AudioModelKind, AudioModelProvider, AudioTranscribeInput,
-    AudioTranscribeOutput,
+    AudioModelError, AudioModelKind, AudioModelProvider, AudioSynthesizeInput,
+    AudioSynthesizeOutput, AudioTranscribeInput, AudioTranscribeOutput,
 };
+use crate::server::audio_worker::{AudioEngine, AudioWorker};
 
-/// Speech-to-text provider holding a loaded Whisper model.
-///
-/// Each request is serialized through the `Mutex`, so the underlying MLX arrays
-/// are only ever touched by one thread at a time even though the route layer
-/// dispatches transcription on a blocking thread pool.
+/// Speech-to-text provider backed by a Whisper model on a dedicated worker
+/// thread.
 pub struct WhisperSttProvider {
-    model: Mutex<WhisperModel>,
+    worker: AudioWorker,
 }
 
-// SAFETY: `WhisperModel` owns MLX array handles (cxx `UniquePtr<MlxArray>`),
-// which are not automatically `Send`/`Sync`. Every access goes through the
-// `Mutex` above, so a handle is never dereferenced from more than one thread
-// concurrently. This mirrors the established holder pattern used by
-// `crate::server::prompt_cache::entry::ModelSnapshotHolder`.
-unsafe impl Send for WhisperSttProvider {}
-unsafe impl Sync for WhisperSttProvider {}
-
 impl WhisperSttProvider {
-    /// Load a Whisper checkpoint directory and build the provider.
+    /// Spawn the Whisper worker thread and load the checkpoint on it.
+    ///
+    /// The thread loads `config.json`, the safetensors weights, and the
+    /// tokenizer, then stays alive to serve transcription requests. Returns
+    /// `Err` if the worker thread cannot start or the checkpoint fails to load,
+    /// letting the server boot with the audio slot empty instead of aborting.
     pub fn load(model_path: &Path) -> anyhow::Result<Self> {
-        let model = WhisperModel::load(model_path)?;
-        Ok(Self {
-            model: Mutex::new(model),
-        })
+        let model_path = model_path.to_path_buf();
+        let worker = AudioWorker::spawn("whisper-stt", move || {
+            let model = WhisperModel::load(&model_path)?;
+            Ok(WhisperEngine { model })
+        })?;
+        Ok(Self { worker })
     }
 }
 
@@ -66,6 +69,35 @@ impl AudioModelProvider for WhisperSttProvider {
         &self,
         input: AudioTranscribeInput,
     ) -> Result<AudioTranscribeOutput, AudioModelError> {
+        self.worker.transcribe(input)
+    }
+
+    /// Whisper does not synthesize speech. The call still routes through the
+    /// worker so both audio directions share the one MLX-owning thread, and the
+    /// engine reports the unsupported direction. Routes gate on
+    /// [`supports`](Self::supports) first, so this is not reached in practice.
+    fn synthesize(
+        &self,
+        input: AudioSynthesizeInput,
+    ) -> Result<AudioSynthesizeOutput, AudioModelError> {
+        self.worker.synthesize(input)
+    }
+}
+
+/// Whisper [`AudioEngine`] confined to the worker thread that loaded it.
+///
+/// Holds the `WhisperModel` (and its MLX array handles) directly: it is only
+/// ever constructed and called on the single worker thread, so no `Mutex` or
+/// `unsafe impl Send` is needed.
+struct WhisperEngine {
+    model: WhisperModel,
+}
+
+impl AudioEngine for WhisperEngine {
+    fn transcribe(
+        &mut self,
+        input: AudioTranscribeInput,
+    ) -> Result<AudioTranscribeOutput, AudioModelError> {
         let (samples, sample_rate) = load_wav_from_bytes(&input.audio)
             .map_err(|e| AudioModelError::Inference(format!("WAV decode failed: {e}")))?;
         let audio_16k = whisper_mel::resample_to_16k(&samples, sample_rate);
@@ -75,11 +107,8 @@ impl AudioModelProvider for WhisperSttProvider {
         // matches the lowercase Whisper language tags.
         let hint = input.language.as_deref().map(str::to_ascii_lowercase);
 
-        let model = self
+        let (text, used_language) = self
             .model
-            .lock()
-            .map_err(|_| AudioModelError::Inference("speech-to-text model lock poisoned".into()))?;
-        let (text, used_language) = model
             .transcribe(&audio_16k, hint.as_deref(), input.translate)
             .map_err(|e| AudioModelError::Inference(format!("transcription failed: {e}")))?;
 

--- a/src/server/whisper_stt.rs
+++ b/src/server/whisper_stt.rs
@@ -79,7 +79,9 @@ impl AudioModelProvider for WhisperSttProvider {
             .model
             .lock()
             .map_err(|_| AudioModelError::Inference("speech-to-text model lock poisoned".into()))?;
-        let (text, used_language) = model.transcribe(&audio_16k, hint.as_deref(), input.translate);
+        let (text, used_language) = model
+            .transcribe(&audio_16k, hint.as_deref(), input.translate)
+            .map_err(|e| AudioModelError::Inference(format!("transcription failed: {e}")))?;
 
         Ok(AudioTranscribeOutput {
             text: text.trim().to_string(),

--- a/src/server/whisper_stt.rs
+++ b/src/server/whisper_stt.rs
@@ -1,0 +1,90 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Speech-to-text [`AudioModelProvider`] backed by the Whisper-style ASR model.
+//!
+//! Wires the shared WAV reader and the Whisper log-mel front-end to the
+//! encoder-decoder model and exposes the result through the transport-agnostic
+//! audio-model seam consumed by `POST /v1/audio/transcriptions` and
+//! `POST /v1/audio/translations`.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use crate::audio::load_wav_from_bytes;
+use crate::audio::whisper_mel;
+use crate::models::WhisperModel;
+use crate::server::audio_model::{
+    AudioModelError, AudioModelKind, AudioModelProvider, AudioTranscribeInput,
+    AudioTranscribeOutput,
+};
+
+/// Speech-to-text provider holding a loaded Whisper model.
+///
+/// Each request is serialized through the `Mutex`, so the underlying MLX arrays
+/// are only ever touched by one thread at a time even though the route layer
+/// dispatches transcription on a blocking thread pool.
+pub struct WhisperSttProvider {
+    model: Mutex<WhisperModel>,
+}
+
+// SAFETY: `WhisperModel` owns MLX array handles (cxx `UniquePtr<MlxArray>`),
+// which are not automatically `Send`/`Sync`. Every access goes through the
+// `Mutex` above, so a handle is never dereferenced from more than one thread
+// concurrently. This mirrors the established holder pattern used by
+// `crate::server::prompt_cache::entry::ModelSnapshotHolder`.
+unsafe impl Send for WhisperSttProvider {}
+unsafe impl Sync for WhisperSttProvider {}
+
+impl WhisperSttProvider {
+    /// Load a Whisper checkpoint directory and build the provider.
+    pub fn load(model_path: &Path) -> anyhow::Result<Self> {
+        let model = WhisperModel::load(model_path)?;
+        Ok(Self {
+            model: Mutex::new(model),
+        })
+    }
+}
+
+impl AudioModelProvider for WhisperSttProvider {
+    fn supports(&self, kind: AudioModelKind) -> bool {
+        kind == AudioModelKind::Stt
+    }
+
+    fn transcribe(
+        &self,
+        input: AudioTranscribeInput,
+    ) -> Result<AudioTranscribeOutput, AudioModelError> {
+        let (samples, sample_rate) = load_wav_from_bytes(&input.audio)
+            .map_err(|e| AudioModelError::Inference(format!("WAV decode failed: {e}")))?;
+        let audio_16k = whisper_mel::resample_to_16k(&samples, sample_rate);
+        let duration_seconds = audio_16k.len() as f32 / whisper_mel::WHISPER_SAMPLE_RATE as f32;
+
+        // The OpenAI API supplies an ISO-639-1 hint; normalize the case so it
+        // matches the lowercase Whisper language tags.
+        let hint = input.language.as_deref().map(str::to_ascii_lowercase);
+
+        let model = self
+            .model
+            .lock()
+            .map_err(|_| AudioModelError::Inference("speech-to-text model lock poisoned".into()))?;
+        let (text, used_language) = model.transcribe(&audio_16k, hint.as_deref(), input.translate);
+
+        Ok(AudioTranscribeOutput {
+            text: text.trim().to_string(),
+            language: used_language.or(hint),
+            duration_seconds: Some(duration_seconds),
+        })
+    }
+}


### PR DESCRIPTION
## Summary

Port a Whisper-style encoder-decoder ASR model (Phase 2 of the audio-endpoints epic #363) and wire it to the speech-to-text endpoints from #364. When the loaded checkpoint is detected as Whisper, the server populates its speech-to-text slot so POST /v1/audio/transcriptions transcribes in place and POST /v1/audio/translations translates to English.

## What changed

- src/audio/whisper_mel.rs (new): Whisper log-mel front-end (80/128 mel bins, n_fft 400, hop 160, 16 kHz, 30 s windows) with a Slaney-scale, Slaney-normalized filterbank and global-max log normalization; reuses the shared real_fft_magnitude primitive and adds 16 kHz linear resampling.
- src/models/whisper/ (new module: mod, layers, encoder, decoder, tokenizer, decoding): convolutional plus transformer audio encoder, autoregressive text decoder with cross-attention to the encoder output and tied logits, greedy decode with a KV cache, first-step language detection, and Whisper token suppression (suppress_blank, non-speech symbols, timestamp range). Accepts native MLX and HuggingFace key layouts; applies the bf16 to f16 conversion for non-quantized weights.
- src/models/detection.rs, src/models/mod.rs, src/model_metadata.rs: register model_type "whisper" as ModelType::Whisper in detection, the arch/list registry, metadata, and the load-policy table.
- src/loading/mod.rs, src/distributed/tensor_parallel/inference.rs: the text loader fails clearly for a Whisper checkpoint (ASR, not a generator) and the tensor-parallel dispatch table stays total.
- src/server/whisper_stt.rs (new): WhisperSttProvider implements AudioModelProvider for speech-to-text, serializing MLX access behind a mutex (matching the existing unsafe Send/Sync holder pattern).
- src/server/startup.rs: detect Whisper at startup and attach the provider via AppState::with_audio_model.
- docs/supported-models.md: add a Speech-to-text (ASR) section and update the variant count.

## Validation

Unit-tested here (cargo test --lib whisper, cargo clippy --lib --tests -D warnings, cargo fmt --check, all clean):

- mel front-end: frame counts (100 frames per 1 s, 3000 per 30 s), filterbank shape, periodic Hann window, normalization band, tone energy in low mel bins, resampling.
- tokenizer: special-token and language-tag resolution, sot-sequence ordering, suppression-set union, text decode dropping specials and timestamps.
- decoding: suppression, first-step, and language masks (keep eot, block specials and the timestamp range).
- model config: native and HuggingFace dimension parsing, padded-window zero-padding.
- detection and registry: model_type "whisper" resolves to ModelType::Whisper, arch-registry completeness.

Needs the real-checkpoint end-to-end run (release build, server, a real Whisper MLX checkpoint): the actual transcription and translation through POST /v1/audio/transcriptions and POST /v1/audio/translations, plus mlxcel list/arch output. These exercise the encoder/decoder MLX graph, which the unit tests do not run.

## Deferred (follow-ups)

- Beam search and temperature fallback.
- Word-level and segment timestamps.
- Quantized (4-bit/8-bit) checkpoints.
- Streaming transcription.
- Higher-quality (sinc/polyphase) resampling.
- FFT-based front-end (the current path reuses the shared naive DFT).

Closes #365
