### PR TITLE
feat(runtime): warn when a CPU-only build runs on an NVIDIA host (#326)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+# Convenience aliases.
+#
+# `cargo cuda` builds the CUDA backend with the `cuda` feature, so a plain
+# `cargo build` does not silently produce a CPU-only binary on an NVIDIA host
+# (the runtime warns when that happens; see docs/installation.md). The CUDA
+# architecture is auto-detected from `nvidia-smi`; override it with
+# `MLX_CUDA_ARCHITECTURES` (for example `MLX_CUDA_ARCHITECTURES=121` for GB10).
+[alias]
+cuda = "build --release --features cuda"

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ cd mlxcel
 cargo build --release --features metal,accelerate
 ```
 
-Linux/CUDA builds use the `cuda` feature and require the CUDA toolkit plus the system libraries used by MLX. See [Installation](docs/installation.md) for the detailed prerequisite matrix.
+Linux/CUDA builds use the `cuda` feature and require the CUDA toolkit plus the system libraries used by MLX. A plain `cargo build --release` on Linux omits the `cuda` feature and produces a CPU-only binary that still runs but silently executes MLX on the CPU at a fraction of GPU throughput, so always pass `--features cuda` on an NVIDIA host. See [Installation](docs/installation.md) for the detailed prerequisite matrix.
 
 ## Performance
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,6 +82,12 @@ cd mlxcel
 cargo build --release --features cuda
 ```
 
+> **CPU-only build footgun.** A plain `cargo build --release` on Linux uses the
+> default features (no `cuda`) and produces a CPU-only binary. It still loads and
+> generates, but silently runs MLX on the host CPU at a fraction of GPU
+> throughput (single-digit tok/s on GB10 instead of hundreds), so the mistake is
+> easy to miss. Always pass `--features cuda` on an NVIDIA host.
+
 If CUDA is not installed under `/usr/local/cuda`, set `CUDA_HOME`:
 
 ```bash

--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -216,10 +216,7 @@ fn should_warn_cpu_only_on_nvidia_host(
     cuda_build: bool,
     nvidia_host: bool,
 ) -> bool {
-    requested == RuntimeDevice::Gpu
-        && resolved == RuntimeDevice::Cpu
-        && !cuda_build
-        && nvidia_host
+    requested == RuntimeDevice::Gpu && resolved == RuntimeDevice::Cpu && !cuda_build && nvidia_host
 }
 
 /// Loud one-time startup warning for the CPU-only-build-on-NVIDIA-host footgun.

--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -84,6 +84,19 @@ pub fn initialize_runtime() -> RuntimeSetup {
         RuntimeDevice::Cpu
     };
 
+    // Footgun guard: a default `cargo build --release` on Linux omits the `cuda`
+    // feature and silently runs MLX on the CPU. If the user wanted the GPU but
+    // this CPU-only binary fell back to CPU on a host that has an NVIDIA GPU,
+    // say so loudly instead of crawling at a fraction of GPU speed.
+    if should_warn_cpu_only_on_nvidia_host(
+        requested_device,
+        device,
+        cfg!(feature = "cuda"),
+        nvidia_host_present(),
+    ) {
+        warn_cpu_only_on_nvidia_host();
+    }
+
     let wired_limit_bytes = if device.uses_gpu() {
         resolve_wired_limit()
     } else {
@@ -181,6 +194,45 @@ fn parse_runtime_device(value: &str) -> Option<RuntimeDevice> {
         "gpu" | "metal" => Some(RuntimeDevice::Gpu),
         _ => None,
     }
+}
+
+/// Detect an NVIDIA GPU without linking CUDA. The kernel driver exposes these
+/// paths whether or not this binary was built with the `cuda` feature, so a
+/// CPU-only build can still tell it is sitting on an NVIDIA host.
+fn nvidia_host_present() -> bool {
+    std::path::Path::new("/dev/nvidiactl").exists()
+        || std::path::Path::new("/proc/driver/nvidia/version").exists()
+}
+
+/// Whether to warn that a CPU-only build is wasting an NVIDIA GPU. True only
+/// when the GPU was wanted, the runtime fell back to CPU, this binary lacks the
+/// `cuda` feature (so it can never use the GPU), and an NVIDIA host is present.
+/// An explicit `MLXCEL_DEVICE=cpu` (`requested == Cpu`) suppresses the warning,
+/// and a `cuda`-capable build that fell back to CPU is a genuine no-GPU host,
+/// not the footgun.
+fn should_warn_cpu_only_on_nvidia_host(
+    requested: RuntimeDevice,
+    resolved: RuntimeDevice,
+    cuda_build: bool,
+    nvidia_host: bool,
+) -> bool {
+    requested == RuntimeDevice::Gpu
+        && resolved == RuntimeDevice::Cpu
+        && !cuda_build
+        && nvidia_host
+}
+
+/// Loud one-time startup warning for the CPU-only-build-on-NVIDIA-host footgun.
+fn warn_cpu_only_on_nvidia_host() {
+    eprintln!(
+        "warning: an NVIDIA GPU is present but this mlxcel binary was built \
+         without CUDA support, so it is running on the CPU (orders of magnitude \
+         slower).\n         \
+         Rebuild with the `cuda` feature: \
+         `MLX_CUDA_ARCHITECTURES=<arch> cargo build --release --features cuda` \
+         (or `cargo cuda`).\n         \
+         See docs/installation.md (Linux with CUDA)."
+    );
 }
 
 #[cfg(test)]

--- a/src/execution/runtime_tests.rs
+++ b/src/execution/runtime_tests.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{RuntimeDevice, parse_memory_size, parse_runtime_device, resolve_runtime_device};
+use super::{
+    RuntimeDevice, parse_memory_size, parse_runtime_device, resolve_runtime_device,
+    should_warn_cpu_only_on_nvidia_host,
+};
 
 #[test]
 fn parse_runtime_device_accepts_cpu() {
@@ -71,4 +74,19 @@ fn parse_memory_size_fractional_gb() {
 #[test]
 fn parse_memory_size_invalid() {
     assert_eq!(parse_memory_size("abc"), None);
+}
+
+#[test]
+fn warns_only_for_cpu_fallback_on_nvidia_host_without_cuda() {
+    use RuntimeDevice::{Cpu, Gpu};
+    // Footgun: wanted GPU, fell back to CPU, no cuda feature, NVIDIA host present.
+    assert!(should_warn_cpu_only_on_nvidia_host(Gpu, Cpu, false, true));
+    // cuda-capable build that fell back to CPU is a genuine no-GPU host, not the footgun.
+    assert!(!should_warn_cpu_only_on_nvidia_host(Gpu, Cpu, true, true));
+    // Genuine CPU-only Linux box (no NVIDIA device node): no nag.
+    assert!(!should_warn_cpu_only_on_nvidia_host(Gpu, Cpu, false, false));
+    // Explicit MLXCEL_DEVICE=cpu (requested == Cpu): respect the override.
+    assert!(!should_warn_cpu_only_on_nvidia_host(Cpu, Cpu, false, true));
+    // Already running on the GPU: nothing to warn about.
+    assert!(!should_warn_cpu_only_on_nvidia_host(Gpu, Gpu, false, true));
 }


### PR DESCRIPTION
## Why

A default `cargo build --release` on Linux uses the default features (`surgery` only), omits `cuda`, and produces a **CPU-only binary**. It still loads and generates, but silently runs MLX on the host CPU at single-digit tok/s, and the only hint is `Runtime device: CPU`. This bit a GB10 benchmarking session for #326 (0.13 tok/s before the mistake was caught) and is already flagged in `model_tests_gb10.md`.

## What

Three layers of prevention for the same footgun:

1. **Runtime warning (the real guard).** At startup, when the user wanted the GPU but a CPU-only binary fell back to CPU on a host that has an NVIDIA GPU, print a loud one-line warning pointing at the `--features cuda` rebuild. Fires every time the mistake happens, regardless of how the binary was built.
   - Detection uses the NVIDIA device nodes (`/dev/nvidiactl`, `/proc/driver/nvidia/version`), which the kernel driver exposes without linking CUDA, so a CPU-only build can still tell it is on an NVIDIA host.
   - An explicit `MLXCEL_DEVICE=cpu` suppresses it, and a `cuda`-capable build that fell back to CPU is a genuine no-GPU host, not the footgun.
   - The decision is a pure function (`should_warn_cpu_only_on_nvidia_host`) with a unit test.
2. **`cargo cuda` alias** (`.cargo/config.toml`) for the feature-correct build, so the right thing is one token.
3. **Docs**: the README build section and `installation.md` now call out the CPU-only footgun next to the build commands.

No behavior change on a correctly built GPU binary: the warning is gated to CPU-fallback-on-NVIDIA-without-cuda, and the `cuda`/Metal paths never reach it.

## Validation

- `should_warn_cpu_only_on_nvidia_host` unit test (5 cases: footgun fires; cuda build, no-NVIDIA host, explicit CPU, and on-GPU all stay quiet). Passes under `cargo test --release --features cuda --lib`.
- NVIDIA device-node detection confirmed present on the GB10 host.
- Compiles in both the `--features cuda` and default (CPU-only) configurations.

Follow-up to #326 / #357 (the GB10 fused QK-norm benchmark, where this footgun first showed up).