### PR TITLE
docs(cache): record #370 fused-V attempt regression, keep Turbo4Asym on dequant-SDPA

### DIFF
--- a/benchmarks/turbo_kv/2026-06-21_Apple_M1_Ultra_qwen2.5-7b-4bit_370_asym_fused_attempt.csv
+++ b/benchmarks/turbo_kv/2026-06-21_Apple_M1_Ultra_qwen2.5-7b-4bit_370_asym_fused_attempt.csv
@@ -1,0 +1,17 @@
+model,model_path,kv_cache_mode,context_target,stage,run_index,prompt_tokens,generated_tokens,prefill_ms,prefill_tok_s,decode_ms,decode_tok_s,thermal_start,thermal_end,hardware,date
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,fp16,4096,decode,1,4212,100,5640.63,746.73,1054.57,94.83,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,fp16,16384,decode,2,16758,100,26118.50,641.61,1450.25,68.95,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,fp16,32768,decode,3,33486,100,63177.48,530.03,1975.69,50.62,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,fp16,8192,prefill,4,8394,1,11951.53,702.34,0.00,800000.00,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-asym-steel,4096,decode,5,4212,100,6933.43,607.49,9360.65,10.68,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-asym-steel,16384,decode,6,16758,100,31469.02,532.52,22675.38,4.41,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-asym-steel,32768,decode,7,33486,100,74319.59,450.57,46565.93,2.15,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-asym-steel,8192,prefill,8,8394,1,14070.90,596.55,0.00,615384.62,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-delegated,4096,decode,9,4212,100,6977.28,603.67,1574.81,63.50,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-delegated,16384,decode,10,16758,100,31002.33,540.54,2067.12,48.38,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-delegated,32768,decode,11,33486,100,72613.25,461.16,2886.82,34.64,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-delegated,8192,prefill,12,8394,1,11626.70,721.96,0.00,631711.94,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-asym-dequant-sdpa,4096,decode,1,4212,100,6746.35,624.34,3495.24,28.61,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-asym-dequant-sdpa,16384,decode,2,16758,100,30899.14,542.35,4394.14,22.76,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-asym-dequant-sdpa,32768,decode,3,33486,100,72644.16,460.96,6872.78,14.55,none|none,none|none,Apple_M1_Ultra,2026-06-21
+qwen2.5-7b-4bit,models/qwen2.5-7b-4bit,turbo4-asym-dequant-sdpa,8192,prefill,4,8394,1,14005.08,599.35,0.00,558035.71,none|none,none|none,Apple_M1_Ultra,2026-06-21

--- a/docs/adr/0002-turbo-kv-split-dequant-vs-fused.md
+++ b/docs/adr/0002-turbo-kv-split-dequant-vs-fused.md
@@ -1,6 +1,6 @@
 # ADR 0002: Turbo KV decode is split dequant plus native SDPA, and the upstream sparse-V speedup does not carry over
 
-**Status:** Accepted (2026-06-20). Follows #369 (Turbo4Asym routed through dequant-SDPA), motivates #370 (fuse V dequant into the attention kernel). Backed by the 2026-06-19 sweep under `benchmarks/turbo_kv/` and the A/B measurements below.
+**Status:** Accepted (2026-06-20); amended 2026-06-21 with the #370 result. Follows #369 (Turbo4Asym routed through dequant-SDPA), motivated #370 (fuse V dequant into the attention kernel). Backed by the 2026-06-19 sweep under `benchmarks/turbo_kv/` and the A/B measurements below. The 2026-06-21 addendum records that the #370 fused-kernel lever did not pan out and why; the decision stands and is now measured on both ends.
 
 ## Context
 
@@ -45,7 +45,34 @@ On the four standard-attention sweep models every quantized KV mode decodes slow
 
 Keep dequant-SDPA (#369) as the `Turbo4Asym` decode default. Do not revive sparse-V as a speed path: it is exact and worth keeping as a runtime option and correctness reference, but its skip buys nothing in mlxcel's split design. Treat quantized KV as a memory-footprint trade, not a decode-speed feature; PR #376 aligns the `--recommend-quant` advisor, the `bench_kv_cache.sh` gates, and `docs/turbo-kv-cache.md` to that.
 
-The one lever that can beat the current 0.24x to 0.40x decode ceiling is **#370**: fuse the V dequant into the native SDPA kernel so V is never materialized and the dequant rides inside the fused scores plus softmax plus accumulate. That single change captures all three things the split design cannot: the long-context cache-bandwidth win, a sparse-V skip that actually removes hot-path work, and no materialize round-trip.
+The one lever that could in principle beat the current 0.24x to 0.40x decode ceiling is **#370**: fuse the V dequant into the attention kernel so V is never materialized and the dequant rides inside the scores plus softmax plus accumulate. That would capture all three things the split design cannot: the long-context cache-bandwidth win, a sparse-V skip that actually removes hot-path work, and no materialize round-trip. The 2026-06-21 addendum below records that mlxcel's only available fused kernel does not actually win, so this prediction did not hold.
+
+## Addendum (2026-06-21): the fused-kernel lever does not pan out (#370)
+
+#370 took the first route the issue proposed: route `Turbo4Asym` decode through the existing delegated steel-envelope kernel (`attention_turbo4_delegated_steel`). `Turbo4Asym` is structurally the all-cold case of `Turbo4Delegated` (FP16 K, every visible V token 4-bit packed, no hot FP16 tail), so the kernel serves it directly with `cold_offset = offset, hot_offset = 0`. The kernel fuses the cold-V dequant into the attention accumulate, never materializing the full V. Parity held: a 16-step `Turbo4Asym` decode through the steel kernel matched the dequant-SDPA reference at RMS < 5e-3 (threshold 0, no skip).
+
+The speed did not. M1 Ultra, `qwen2.5-7b-4bit`, decode tok/s (`benchmarks/turbo_kv/2026-06-21_Apple_M1_Ultra_qwen2.5-7b-4bit_370_asym_fused_attempt.csv`):
+
+| mode | 4K | 16K | 32K |
+|---|---|---|---|
+| fp16 | 94.83 (1.00x) | 68.95 (1.00x) | 50.62 (1.00x) |
+| turbo4-asym, dequant-SDPA (#369) | 28.61 (0.30x) | 22.76 (0.33x) | 14.55 (0.29x) |
+| turbo4-asym, steel fused (#370 attempt) | 10.68 (0.11x) | 4.41 (0.06x) | 2.15 (0.04x) |
+| turbo4-delegated | 63.50 (0.67x) | 48.38 (0.70x) | 34.64 (0.68x) |
+
+The fused kernel **regresses** asym decode 3x at 4K and 7x at 32K, the opposite of the goal. Two facts explain it:
+
+1. **The custom fused kernel is slower than native SDPA over a materialized V.** The steel envelope computes scores in graph, then does a two-pass online softmax and a per-token nibble-unpack plus codebook-lookup plus accumulate sweep over every cold token in one Metal dispatch. At 32K that hand-written sweep loses badly to MLX's optimized flash-attention GEMM running on a transiently materialized FP16 V. Materializing the rotated V and calling native SDPA, which is exactly what the dequant-SDPA path does, is the faster arrangement on this hardware.
+
+2. **`Turbo4Delegated`'s 0.66-0.80x does not come from the steel kernel.** The delegated decode path defaults to dequant-SDPA (`turbo4_delegated_dequant_sdpa_enabled()` is on by default; `update_and_turbo4_delegated_attention` returns from the dequant-SDPA branch before it ever reaches the steel try). The steel envelope is delegated's *slow fallback*, used only when dequant-SDPA is disabled. So the premise that motivated #370, that delegated is fast because it fuses V dequant into the kernel, was wrong: delegated is fast because it dequantizes only the cold body, keeps a hot FP16 ring, and hands the result to native SDPA.
+
+There is no fuse-into-native-SDPA option, because MLX's SDPA kernel consumes a dense V; feeding it packed V would mean modifying the upstream kernel. The mlxcel-side fused kernel is the only fusion available, and it is slower.
+
+### Decision (amended)
+
+Do not route `Turbo4Asym` through the fused kernel. `Turbo4Asym` stays on the exact dequant-SDPA path (#369), the simple full-precision-K option that quantizes every V token with no hot ring, at roughly 0.3-0.5x decode. For the fp16-K + 4-bit-V use case that wants speed, the recommended mode is **`Turbo4Delegated`**: about 4x V compression at 0.66-0.80x fp16 decode, via cold-only dequant-SDPA plus a hot FP16 ring. The `--recommend-quant` advisor already promotes `Turbo4Delegated` here (post-#376); no advisor change is needed.
+
+The remaining asym-versus-delegated decode gap (about 0.4x versus 0.7x) is the hot/cold split, not V-dequant fusion. Closing it would mean giving `Turbo4Asym` a hot ring, which is exactly what makes a cache `Turbo4Delegated`. Keeping the two modes distinct (delegated = fast with a hot ring, asym = simple and fully quantized) is the intended design, so the gap is left as is.
 
 ## Reproduce
 
@@ -69,7 +96,7 @@ Models: `qwen3-30b-a3b-4bit` (standard attention, cache-bound) and `qwen3.5-35b-
 
 - **Advisor and docs.** PR #376 frames Turbo KV as a memory trade and promotes `int8` and `turbo4-delegated` as the fast quantized picks. This ADR is the measured why.
 - **sparse-V kernel.** Kept as a runtime option (`MLXCEL_TURBO4_ASYM_DEQUANT_SDPA=0`) and the correctness reference for any future fused kernel, not recommended for speed.
-- **#370 carries the speed work.** When it lands, re-run the A/B above. The prediction is that a fused dequant-in-SDPA kernel is the first mlxcel path where the sparse-V skip and the long-context bandwidth win both show up, because it is the first path where V dequant stops being a negligible, separable slice.
+- **#370 closed without a fused asym path.** The fused-kernel attempt regressed asym decode 3-7x (see the 2026-06-21 addendum); the mlxcel-side fused kernel is slower than native SDPA over a materialized V, and delegated's speed comes from dequant-SDPA, not the steel envelope. The decision is to keep `Turbo4Asym` on dequant-SDPA and steer the fp16-K + 4-bit-V speed use case to `Turbo4Delegated`.
 
 ## References
 

--- a/docs/turbo-kv-cache.md
+++ b/docs/turbo-kv-cache.md
@@ -64,8 +64,10 @@ What the numbers say:
 - **`turbo4-asym` is the memory-and-exactness pick, not a speed pick.** K stays
   fp16 and the #369 dequant-SDPA path is parity-exact with the fp16 reference,
   but decode is ~0.2-0.4x. Reach for it when you need ~4x V compression with an
-  untouched K and accept the decode cost. The fused kernel that would close the
-  gap is tracked in #370.
+  untouched K and accept the decode cost. If you want speed at the same fp16-K +
+  4-bit-V trade, use `turbo4-delegated` (~0.7x) instead. #370 tried fusing the V
+  dequant into the attention kernel to close the gap and measured it a 3-7x
+  regression, not a win; see the 2026-06-21 addendum in ADR 0002.
 - **Symmetric `turbo4` maximizes compression and is the slowest;** use only on
   an allowlisted family (see below).
 - **`turbo3-asym` is near-unusable** (0.02-0.07x, about 0.4 tok/s at 32K). It
@@ -79,8 +81,10 @@ dequantizing a rotated, codebook-quantized cache every step. The upstream
 sparse-V skip that produces the +22.8% does not carry over to mlxcel, because
 mlxcel's Turbo decode is a split dequant plus native SDPA rather than a fused
 flash-attention; [ADR 0002](adr/0002-turbo-kv-split-dequant-vs-fused.md) records
-the measured A/B and names fused V dequant (#370) as the one lever that can beat
-the current decode ceiling.
+the measured A/B. Its 2026-06-21 addendum closes #370: routing asym through
+mlxcel's fused kernel regressed decode 3-7x, because the hand-written fused
+kernel is slower than native SDPA over a materialized V, so the split dequant
+plus native SDPA stays the fast arrangement.
 
 ## CLI and server flags
 

--- a/scripts/bench_kv_cache.sh
+++ b/scripts/bench_kv_cache.sh
@@ -22,7 +22,10 @@
 #   turbo4-asym:     decode 0.18-0.44x; prefill 0.61-0.92x. K stays fp16
 #                    (exact). The #369 dequant-SDPA path is for memory +
 #                    exactness, not speed, and MUST stay parity-exact vs the
-#                    graph SDPA reference (RMS ~0). Fused kernel tracked in #370.
+#                    graph SDPA reference (RMS ~0). #370 tried fusing the V
+#                    dequant into the steel kernel and measured a 3-7x decode
+#                    regression (ADR 0002 addendum), so asym stays on
+#                    dequant-SDPA; use turbo4-delegated for fp16-K speed.
 #   turbo4 (sym):    decode 0.10-0.27x; prefill 0.40-0.73x. Max compression,
 #                    quality-sensitive; allowlist families only.
 #   turbo3-asym:     decode 0.02-0.07x (near-unusable, 32K ~0.4 tok/s).


### PR DESCRIPTION
## Summary

#370 asked to fuse the `Turbo4Asym` V dequant into the attention kernel so it reaches int8/delegated decode speed (0.7-0.8x fp16), **or** to document that `Turbo4Delegated` is the recommended fast fp16-K + 4-bit-V mode with `Turbo4Asym` as the exact/simple fallback. I took the first route, benchmarked it on real hardware, and it does not work, so this PR lands the documented decision backed by the measurement.

## What was tried

`Turbo4Asym` is structurally the all-cold case of `Turbo4Delegated` (FP16 K, every visible V token 4-bit packed, no hot FP16 tail). So the attempt routed asym decode through the existing delegated steel-envelope fused kernel (`attention_turbo4_delegated_steel`) with `cold_offset = offset, hot_offset = 0`. The kernel fuses the cold-V dequant into the attention accumulate and never materializes V.

- **Parity held.** A 16-step `Turbo4Asym` decode through the steel kernel matched the dequant-SDPA reference at RMS < 5e-3 (threshold 0, no skip).
- **Speed regressed.** M1 Ultra, `qwen2.5-7b-4bit`, decode tok/s:

| mode | 4K | 16K | 32K |
|---|---|---|---|
| fp16 | 94.83 (1.00x) | 68.95 (1.00x) | 50.62 (1.00x) |
| turbo4-asym dequant-SDPA (#369) | 28.61 (0.30x) | 22.76 (0.33x) | 14.55 (0.29x) |
| **turbo4-asym steel (the #370 attempt)** | **10.68 (0.11x)** | **4.41 (0.06x)** | **2.15 (0.04x)** |
| turbo4-delegated | 63.50 (0.67x) | 48.38 (0.70x) | 34.64 (0.68x) |

The fused kernel makes asym **3x slower at 4K and 7x slower at 32K**.

## Why

1. The hand-written fused kernel (graph scores, two-pass online softmax, per-token nibble-unpack + codebook-lookup + accumulate sweep) is slower than materializing the rotated V and calling MLX's optimized native flash-attention. The split dequant + native SDPA is the faster arrangement on this hardware.
2. `Turbo4Delegated`'s 0.66-0.80x does **not** come from the steel kernel. The delegated decode path defaults to dequant-SDPA (`turbo4_delegated_dequant_sdpa_enabled()` is on by default and returns before the steel try); the steel envelope is delegated's slow fallback. The premise that motivated #370 (delegated is fast because it fuses V dequant into the kernel) was wrong.

There is no fuse-into-native-SDPA option, because MLX's SDPA consumes a dense V.

## Decision

Keep `Turbo4Asym` on the exact dequant-SDPA path (the simple, fully-quantized-V, untouched-K option at ~0.3-0.5x). For the fp16-K + 4-bit-V use case that wants speed, use `Turbo4Delegated` (~4x V compression at ~0.7x decode), which the `--recommend-quant` advisor already promotes (post-#376), so no advisor change is needed. The remaining asym-vs-delegated gap is the hot/cold split, not V-dequant fusion, and is left as-is by design.

## Changes

- ADR 0002: 2026-06-21 addendum recording the attempt, the measured regression, the root cause, and the amended decision.
- `docs/turbo-kv-cache.md`: point the fp16-K speed use case at `turbo4-delegated`; record the #370 outcome.
- `scripts/bench_kv_cache.sh`: update the stale "fused kernel tracked in #370" comment.
- `benchmarks/turbo_kv/2026-06-21_..._370_asym_fused_attempt.csv`: the committed measurement.

No code change: the fused-kernel wiring was reverted after the benchmark. Validation is the real-checkpoint benchmark above.

Closes #370