### PR TITLE
perf(server): bound the audio request queue and add a per-request timeout

### DIFF
--- a/docs/audio-api.md
+++ b/docs/audio-api.md
@@ -89,7 +89,8 @@ Content-Type: `audio/wav`. Content-Disposition: `attachment; filename=speech.wav
 |--------|-----------|
 | 400 | Unsupported `response_format` (any value other than `wav` or absent). |
 | 501 | No TTS model is registered. Body: `{"error":{"type":"not_implemented","message":"audio model kind not loaded: tts"}}` |
-| 503 | All inference slots are busy. |
+| 503 | All slots are busy: either the generation batch queue or the bounded audio worker queue (`--audio-queue-depth`) is full. |
+| 504 | The audio worker did not reply within the per-request timeout (`--audio-request-timeout-secs`). |
 
 **Example (curl):**
 
@@ -127,7 +128,8 @@ Unknown multipart parts are drained and ignored. The upload body limit is 25 MiB
 | 400 | Malformed multipart, non-numeric `temperature`, or unsupported `response_format`. |
 | 413 | Upload body exceeds 25 MiB. |
 | 501 | No STT model is registered. Body: `{"error":{"type":"not_implemented","message":"audio model kind not loaded: stt"}}` |
-| 503 | All inference slots are busy. |
+| 503 | All slots are busy: either the generation batch queue or the bounded audio worker queue (`--audio-queue-depth`) is full. |
+| 504 | The audio worker did not reply within the per-request timeout (`--audio-request-timeout-secs`). |
 
 **Example (curl):**
 
@@ -152,6 +154,16 @@ The 501 response is returned **after** the request is fully parsed. This means:
 - The `file` field is required for transcriptions/translations; its absence returns 400 regardless of model state.
 
 This ordering lets callers distinguish broken requests from absent models without needing a loaded model.
+
+## Queue bound and per-request timeout
+
+All audio requests serialize through one dedicated MLX-owning worker thread (the model weights are thread-affine, so the thread that loads them must also run them). Two server knobs bound that path so a burst or a stuck request cannot degrade availability:
+
+- **Queue bound** (`--audio-queue-depth`, env `MLXCEL_AUDIO_QUEUE_DEPTH`, default `8`). The worker's command channel is bounded. At most this many requests may wait behind the one in flight; the next request is rejected with a structured `503` ("All slots are busy") rather than queueing without bound. This caps queued memory: each queued speech-to-text command holds up to the 25 MiB per-request payload, so the default of `8` caps queued payload at roughly 200 MiB plus the one in flight. A `0` is clamped to at least one queued command (a zero-capacity rendezvous channel is not the admission behavior we want).
+
+- **Per-request timeout** (`--audio-request-timeout-secs`, env `MLXCEL_AUDIO_REQUEST_TIMEOUT_SECS`, default `120`). A caller blocks on the worker reply for at most this long, then returns a structured `504`. The timeout frees the caller's blocking thread; it does not cancel the in-flight model work on the worker (a single worker can only safely process one request at a time). When the worker eventually finishes, its reply is dropped silently. A `0` falls back to the default rather than timing out instantly.
+
+Both knobs apply to the shared worker, so they cover the STT (Whisper) and TTS (Kokoro) paths together.
 
 ## Adding an audio model provider
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -108,6 +108,15 @@ is then reusable only when it is fully contained in the new request). The
 `MLXCEL_ENABLE_VLM_PREFIX_CACHE` opts same-image multimodal follow-up turns into
 prompt-prefix sharing while leaving text-only prompt-cache behavior unchanged.
 
+## Server audio admission variables
+
+The OpenAI audio endpoints (`/v1/audio/speech`, `/v1/audio/transcriptions`, `/v1/audio/translations`) dispatch work to a single dedicated worker thread over a bounded command queue. These knobs bound that queue and the per-request reply wait, so a burst of requests cannot grow memory without bound (each queued speech-to-text command holds up to the 25 MiB per-request payload) and a stuck request does not block its caller forever.
+
+| Variable | Values | Default | CLI flag | Notes |
+|----------|--------|---------|----------|-------|
+| `MLXCEL_AUDIO_QUEUE_DEPTH` | unsigned integer | `8` | `--audio-queue-depth` | Bound on the audio worker command queue. When the queue is full, new audio requests get a structured `503` ("All slots are busy") instead of queueing without bound. A depth of `8` caps queued payload at roughly 200 MiB plus the one request in flight. A `0` is clamped to at least one queued command. |
+| `MLXCEL_AUDIO_REQUEST_TIMEOUT_SECS` | unsigned integer seconds | `120` | `--audio-request-timeout-secs` | Per-request reply timeout. A stuck or pathologically slow audio request frees its blocking thread and returns a structured `504` after this, instead of hanging. The timeout does not cancel the in-flight model work on the worker; it only frees the caller. A `0` falls back to the default rather than timing out instantly. |
+
 ## Speculative-decoding variables
 
 | Variable | Values | Default | Notes |

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -279,6 +279,30 @@ struct ServerArgs {
     #[arg(long = "max-queue-depth", default_value_t = 32)]
     max_queue_depth: usize,
 
+    /// Bound on the audio worker command queue; a full queue returns 503 (default: 8)
+    ///
+    /// Caps how many audio (speech-to-text / text-to-speech) requests may wait
+    /// behind the one in flight before admission is shed, so a burst cannot grow
+    /// memory without bound (each queued command holds the full audio payload).
+    /// A `0` clamps to at least one queued command.
+    #[arg(
+        long = "audio-queue-depth",
+        env = "MLXCEL_AUDIO_QUEUE_DEPTH",
+        default_value_t = 8
+    )]
+    audio_queue_depth: usize,
+
+    /// Per-request audio reply timeout in seconds; 0 falls back to the default (default: 120)
+    ///
+    /// A stuck or pathologically slow audio request frees its blocking thread
+    /// and returns a structured 504 after this, instead of hanging the worker.
+    #[arg(
+        long = "audio-request-timeout-secs",
+        env = "MLXCEL_AUDIO_REQUEST_TIMEOUT_SECS",
+        default_value_t = 120
+    )]
+    audio_request_timeout_secs: u64,
+
     /// Prefill chunk size in tokens (0 = disabled, default: 512)
     #[arg(long = "prefill-chunk-size", default_value_t = 512)]
     prefill_chunk_size: usize,
@@ -1219,6 +1243,8 @@ fn build_startup_input(mut args: ServerArgs) -> anyhow::Result<ServerStartupInpu
         max_batch_size: args.max_batch_size,
         no_batch: args.no_batch,
         max_queue_depth: args.max_queue_depth,
+        audio_queue_depth: args.audio_queue_depth,
+        audio_request_timeout_secs: args.audio_request_timeout_secs,
         prefill_chunk_size: args.prefill_chunk_size,
         batch_size: args.batch_size,
         ubatch_size: args.ubatch_size,

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -229,6 +229,8 @@ fn build_startup_input(mut args: crate::ServeArgs) -> anyhow::Result<ServerStart
         max_batch_size: args.max_batch_size,
         no_batch: args.no_batch,
         max_queue_depth: args.max_queue_depth,
+        audio_queue_depth: args.audio_queue_depth,
+        audio_request_timeout_secs: args.audio_request_timeout_secs,
         prefill_chunk_size: args.prefill_chunk_size,
         batch_size: args.batch_size,
         ubatch_size: args.ubatch_size,

--- a/src/commands/serve_tests.rs
+++ b/src/commands/serve_tests.rs
@@ -38,6 +38,8 @@ fn sample_args() -> crate::ServeArgs {
         max_batch_size: Some(4),
         no_batch: false,
         max_queue_depth: 32,
+        audio_queue_depth: 8,
+        audio_request_timeout_secs: 120,
         prefill_chunk_size: 512,
         batch_size: None,
         ubatch_size: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -827,6 +827,22 @@ pub(crate) struct ServeArgs {
     #[arg(long, default_value_t = 32)]
     max_queue_depth: usize,
 
+    /// Bound on the audio worker command queue; a full queue returns 503 (default: 8)
+    ///
+    /// Caps how many audio (speech-to-text / text-to-speech) requests may wait
+    /// behind the one in flight before admission is shed, so a burst cannot grow
+    /// memory without bound (each queued command holds the full audio payload).
+    /// A `0` clamps to at least one queued command.
+    #[arg(long, env = "MLXCEL_AUDIO_QUEUE_DEPTH", default_value_t = 8)]
+    audio_queue_depth: usize,
+
+    /// Per-request audio reply timeout in seconds; 0 falls back to the default (default: 120)
+    ///
+    /// A stuck or pathologically slow audio request frees its blocking thread
+    /// and returns a structured 504 after this, instead of hanging the worker.
+    #[arg(long, env = "MLXCEL_AUDIO_REQUEST_TIMEOUT_SECS", default_value_t = 120)]
+    audio_request_timeout_secs: u64,
+
     /// Prefill chunk size in tokens (0 = disabled, default: 512)
     ///
     /// When set, long prompts are broken into chunks of this size and

--- a/src/server/audio_model.rs
+++ b/src/server/audio_model.rs
@@ -123,6 +123,17 @@ pub enum AudioModelError {
     /// The loaded model failed while processing the request.
     #[error("audio model inference failed: {0}")]
     Inference(String),
+    /// The bounded audio worker queue was full at admission time. Routes map
+    /// this to the shared `503` "all slots are busy" envelope so a burst sheds
+    /// load instead of growing memory without bound.
+    #[error("audio worker queue is full")]
+    QueueFull,
+    /// The worker did not reply within the per-request timeout. Routes map this
+    /// to a `504 Gateway Timeout`: the upstream worker did not answer in time.
+    /// The in-flight MLX work is not cancelled; only the caller's blocking
+    /// thread is freed.
+    #[error("audio request timed out")]
+    Timeout,
 }
 
 /// Provider-facing interface implemented by the speech models.

--- a/src/server/audio_worker.rs
+++ b/src/server/audio_worker.rs
@@ -150,6 +150,15 @@ impl AudioWorker {
         // not the admission semantics we want, so clamp to at least one queued
         // command. A `0` from config therefore falls back to a usable bound.
         let capacity = queue_depth.max(1);
+        // A `Duration::ZERO` timeout would make `recv_timeout` return `Err(Timeout)`
+        // before the worker thread can ever reply, rejecting every request. Fall back
+        // to the documented default (120 s), mirroring the `queue_depth.max(1)` clamp
+        // above so the worker is correct regardless of what the caller passes.
+        let request_timeout = if request_timeout == Duration::ZERO {
+            Duration::from_secs(crate::server::config::DEFAULT_AUDIO_REQUEST_TIMEOUT_SECS)
+        } else {
+            request_timeout
+        };
         let (command_tx, command_rx) = mpsc::sync_channel::<AudioCommand>(capacity);
         let (ready_tx, ready_rx) = mpsc::channel::<Result<(), String>>();
 
@@ -647,5 +656,24 @@ mod tests {
             matches!(err, AudioModelError::Timeout),
             "expected Timeout, got: {err:?}"
         );
+    }
+
+    /// `Duration::ZERO` passed to `spawn` must not make every request time out
+    /// immediately. The guard inside `spawn` clamps it to the documented default
+    /// so a fast request still completes.
+    #[test]
+    fn zero_request_timeout_falls_back_to_default() {
+        let worker = AudioWorker::spawn("audio-test-zero-timeout", 8, Duration::ZERO, || {
+            Ok(TrivialEngine)
+        })
+        .expect("worker spawns with a zero timeout arg");
+
+        // If Duration::ZERO were used as-is, recv_timeout(ZERO) would return
+        // Err(Timeout) before the worker thread could reply. The guard inside
+        // spawn clamps it, so a fast request completes normally.
+        let out = worker
+            .transcribe(transcribe_input(4, None))
+            .expect("zero timeout falls back to default; fast request completes");
+        assert_eq!(out.text, "ok:4");
     }
 }

--- a/src/server/audio_worker.rs
+++ b/src/server/audio_worker.rs
@@ -38,6 +38,7 @@
 use std::sync::Mutex;
 use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 use mlxcel_core::streams::{
     install_thread_local_default_stream, new_thread_local_generation_stream,
@@ -101,10 +102,24 @@ enum AudioCommand {
 /// reply values (all `Send`) cross the channel.
 #[derive(Debug)]
 pub(crate) struct AudioWorker {
-    /// Command channel to the worker thread. Wrapped in a `Mutex` so the
-    /// `AudioWorker` is `Sync` (an `mpsc::Sender` is `Send` but not `Sync`); the
-    /// lock is held only for the brief enqueue, not across inference.
-    sender: Mutex<mpsc::Sender<AudioCommand>>,
+    /// Bounded command channel to the worker thread. Wrapped in a `Mutex` so the
+    /// `AudioWorker` is `Sync` (an `mpsc::SyncSender` is `Send` but not `Sync`);
+    /// the lock is held only for the brief enqueue, not across inference. The
+    /// channel is bounded (admission control): `dispatch` uses `try_send`, so a
+    /// full queue is rejected with [`AudioModelError::QueueFull`] rather than
+    /// growing memory without bound (each queued command holds the full audio
+    /// payload).
+    sender: Mutex<mpsc::SyncSender<AudioCommand>>,
+    /// Per-request reply timeout. `transcribe`/`synthesize` block on the reply
+    /// channel for at most this long, then return [`AudioModelError::Timeout`].
+    ///
+    /// The timeout frees the caller's blocking `spawn_blocking` thread and
+    /// returns a structured error; it does NOT cancel the in-flight MLX work on
+    /// the worker (a single worker can only safely process one request at a
+    /// time). When the worker eventually finishes, its reply send fails silently
+    /// because the reply receiver was already dropped. This is intentional and
+    /// matches the issue: a stuck request frees its thread instead of hanging.
+    request_timeout: Duration,
     /// Join handle, taken in `Drop` after the loop is asked to stop.
     handle: Option<JoinHandle<()>>,
 }
@@ -116,12 +131,26 @@ impl AudioWorker {
     /// that thread's MLX context. Returns `Err` if the thread cannot be spawned
     /// or the engine fails to load, so the caller can leave the audio slot empty
     /// and keep serving rather than aborting startup.
-    pub(crate) fn spawn<E, L>(thread_name: &str, loader: L) -> anyhow::Result<Self>
+    ///
+    /// `queue_depth` bounds the command channel: at most `queue_depth` requests
+    /// can wait behind the one in flight before admission is rejected with
+    /// [`AudioModelError::QueueFull`]. `request_timeout` bounds how long a caller
+    /// blocks for a reply before giving up with [`AudioModelError::Timeout`].
+    pub(crate) fn spawn<E, L>(
+        thread_name: &str,
+        queue_depth: usize,
+        request_timeout: Duration,
+        loader: L,
+    ) -> anyhow::Result<Self>
     where
         E: AudioEngine,
         L: FnOnce() -> anyhow::Result<E> + Send + 'static,
     {
-        let (command_tx, command_rx) = mpsc::channel::<AudioCommand>();
+        // A zero-capacity `sync_channel` is a rendezvous (no buffering), which is
+        // not the admission semantics we want, so clamp to at least one queued
+        // command. A `0` from config therefore falls back to a usable bound.
+        let capacity = queue_depth.max(1);
+        let (command_tx, command_rx) = mpsc::sync_channel::<AudioCommand>(capacity);
         let (ready_tx, ready_rx) = mpsc::channel::<Result<(), String>>();
 
         let handle = thread::Builder::new()
@@ -132,6 +161,7 @@ impl AudioWorker {
         match ready_rx.recv() {
             Ok(Ok(())) => Ok(Self {
                 sender: Mutex::new(command_tx),
+                request_timeout,
                 handle: Some(handle),
             }),
             Ok(Err(message)) => {
@@ -149,43 +179,60 @@ impl AudioWorker {
         }
     }
 
-    /// Send a transcription request to the worker and block for its reply.
+    /// Send a transcription request to the worker and block for its reply, up to
+    /// the per-request timeout.
     pub(crate) fn transcribe(
         &self,
         input: AudioTranscribeInput,
     ) -> Result<AudioTranscribeOutput, AudioModelError> {
         let (respond, reply) = mpsc::channel();
         self.dispatch(AudioCommand::Transcribe { input, respond })?;
-        match reply.recv() {
+        match reply.recv_timeout(self.request_timeout) {
             Ok(result) => result,
-            Err(_) => Err(AudioModelError::Inference(WORKER_GONE.to_string())),
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(AudioModelError::Timeout),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                Err(AudioModelError::Inference(WORKER_GONE.to_string()))
+            }
         }
     }
 
-    /// Send a synthesis request to the worker and block for its reply.
+    /// Send a synthesis request to the worker and block for its reply, up to the
+    /// per-request timeout.
     pub(crate) fn synthesize(
         &self,
         input: AudioSynthesizeInput,
     ) -> Result<AudioSynthesizeOutput, AudioModelError> {
         let (respond, reply) = mpsc::channel();
         self.dispatch(AudioCommand::Synthesize { input, respond })?;
-        match reply.recv() {
+        match reply.recv_timeout(self.request_timeout) {
             Ok(result) => result,
-            Err(_) => Err(AudioModelError::Inference(WORKER_GONE.to_string())),
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(AudioModelError::Timeout),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                Err(AudioModelError::Inference(WORKER_GONE.to_string()))
+            }
         }
     }
 
-    /// Enqueue a command, releasing the sender lock before the caller blocks on
-    /// its reply channel so concurrent requests queue in the channel rather than
-    /// serialize on the lock.
+    /// Enqueue a command without blocking, releasing the sender lock before the
+    /// caller blocks on its reply channel so concurrent requests queue in the
+    /// channel rather than serialize on the lock.
+    ///
+    /// `try_send` is the admission gate: a full bounded queue is rejected with
+    /// [`AudioModelError::QueueFull`] (load shedding) instead of blocking the
+    /// caller or letting queued payloads grow without bound. A disconnected
+    /// channel means the worker thread has gone, reported as before.
     fn dispatch(&self, command: AudioCommand) -> Result<(), AudioModelError> {
         let sender = self
             .sender
             .lock()
             .map_err(|_| AudioModelError::Inference("audio worker channel poisoned".to_string()))?;
-        sender
-            .send(command)
-            .map_err(|_| AudioModelError::Inference(WORKER_GONE.to_string()))
+        match sender.try_send(command) {
+            Ok(()) => Ok(()),
+            Err(mpsc::TrySendError::Full(_)) => Err(AudioModelError::QueueFull),
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                Err(AudioModelError::Inference(WORKER_GONE.to_string()))
+            }
+        }
     }
 }
 
@@ -195,6 +242,11 @@ impl Drop for AudioWorker {
         // handles are dropped on the thread that created them. Both steps are
         // best-effort: if the worker already exited, the send fails and the join
         // observes the prior exit, neither of which should escape a destructor.
+        //
+        // This is a blocking `SyncSender::send` (not `try_send`): on a full
+        // bounded queue it waits for capacity, which is correct here because the
+        // worker keeps draining commands, so a slot frees and the shutdown is
+        // delivered after the queued work.
         if let Ok(sender) = self.sender.lock() {
             let _ = sender.send(AudioCommand::Shutdown);
         }
@@ -357,8 +409,10 @@ mod tests {
 
     #[test]
     fn worker_round_trip_runs_mlx_op_and_replies() {
-        let worker = AudioWorker::spawn("audio-test-roundtrip", || Ok(TrivialEngine))
-            .expect("worker spawns and engine loads");
+        let worker = AudioWorker::spawn("audio-test-roundtrip", 8, Duration::from_secs(30), || {
+            Ok(TrivialEngine)
+        })
+        .expect("worker spawns and engine loads");
 
         let out = worker
             .transcribe(transcribe_input(5, Some("en")))
@@ -376,9 +430,12 @@ mod tests {
 
     #[test]
     fn worker_surfaces_loader_failure() {
-        let result = AudioWorker::spawn::<TrivialEngine, _>("audio-test-loadfail", || {
-            Err(anyhow::anyhow!("synthetic load failure"))
-        });
+        let result = AudioWorker::spawn::<TrivialEngine, _>(
+            "audio-test-loadfail",
+            8,
+            Duration::from_secs(30),
+            || Err(anyhow::anyhow!("synthetic load failure")),
+        );
         let err = result.expect_err("loader failure propagates from spawn");
         assert!(
             err.to_string().contains("synthetic load failure"),
@@ -391,8 +448,10 @@ mod tests {
         struct NoneEngine;
         impl AudioEngine for NoneEngine {}
 
-        let worker = AudioWorker::spawn("audio-test-default", || Ok(NoneEngine))
-            .expect("worker spawns with a do-nothing engine");
+        let worker = AudioWorker::spawn("audio-test-default", 8, Duration::from_secs(30), || {
+            Ok(NoneEngine)
+        })
+        .expect("worker spawns with a do-nothing engine");
         let err = worker
             .synthesize(AudioSynthesizeInput {
                 input: "hi".to_string(),
@@ -434,8 +493,10 @@ mod tests {
 
     #[test]
     fn worker_survives_engine_panic_and_keeps_serving() {
-        let worker = AudioWorker::spawn("audio-test-panic", || Ok(PanicEngine))
-            .expect("worker spawns and engine loads");
+        let worker = AudioWorker::spawn("audio-test-panic", 8, Duration::from_secs(30), || {
+            Ok(PanicEngine)
+        })
+        .expect("worker spawns and engine loads");
 
         // First request hits the panic path. The worker must recover and reply
         // with an `Inference` error, NOT die and surface `WORKER_GONE`. (The
@@ -465,5 +526,126 @@ mod tests {
             .expect("worker still serves after recovering from a panic");
         assert_eq!(out.text, "ok:4");
         assert_eq!(out.language.as_deref(), Some("en"));
+    }
+
+    /// A bounded command queue rejects admission once it is full. The single
+    /// worker is held busy on an in-flight request so the buffer never drains;
+    /// each buffered direct call returns via the per-request timeout and its
+    /// command stays buffered, so after `queue_depth` slots fill the next
+    /// admission is rejected with `QueueFull`.
+    #[test]
+    fn queue_full_returns_queuefull_error() {
+        // Engine that blocks the worker thread on the first request until the
+        // test opens the gate. Only the first pulled command reaches the gate;
+        // buffered commands are never pulled while the worker is blocked here.
+        struct BlockingEngine {
+            gate: Option<mpsc::Receiver<()>>,
+            started: mpsc::Sender<()>,
+        }
+        impl AudioEngine for BlockingEngine {
+            fn transcribe(
+                &mut self,
+                input: AudioTranscribeInput,
+            ) -> Result<AudioTranscribeOutput, AudioModelError> {
+                if let Some(gate) = self.gate.take() {
+                    let _ = self.started.send(());
+                    let _ = gate.recv();
+                }
+                Ok(AudioTranscribeOutput {
+                    text: format!("ok:{}", input.audio.len()),
+                    language: input.language,
+                    duration_seconds: None,
+                })
+            }
+        }
+
+        let (gate_tx, gate_rx) = mpsc::channel::<()>();
+        let (started_tx, started_rx) = mpsc::channel::<()>();
+
+        let queue_depth = 2;
+        let worker = AudioWorker::spawn(
+            "audio-test-queuefull",
+            queue_depth,
+            Duration::from_millis(150),
+            move || {
+                Ok(BlockingEngine {
+                    gate: Some(gate_rx),
+                    started: started_tx,
+                })
+            },
+        )
+        .expect("worker spawns and engine loads");
+
+        std::thread::scope(|scope| {
+            // Occupy the single worker with one in-flight request. This call
+            // gives up after the per-request timeout, but the worker stays busy
+            // inside the engine until the gate opens, so the buffer never drains.
+            scope.spawn(|| {
+                let _ = worker.transcribe(transcribe_input(1, None));
+            });
+
+            // Wait until the worker has pulled the in-flight request and is
+            // blocked in the engine: now the buffer is empty and the worker busy.
+            started_rx
+                .recv()
+                .expect("engine signals it began the in-flight request");
+
+            // Fill the bounded buffer, then prove the next admission is rejected.
+            let mut saw_queue_full = false;
+            for _ in 0..(queue_depth + 1) {
+                match worker.transcribe(transcribe_input(1, None)) {
+                    Err(AudioModelError::QueueFull) => {
+                        saw_queue_full = true;
+                        break;
+                    }
+                    // The slot filled; the command stays buffered. Keep going.
+                    Err(AudioModelError::Timeout) => continue,
+                    other => panic!("unexpected result while filling the queue: {other:?}"),
+                }
+            }
+            assert!(
+                saw_queue_full,
+                "a full bounded queue must reject admission with QueueFull"
+            );
+
+            // Open the gate so the worker drains and the scope thread can finish.
+            drop(gate_tx);
+        });
+    }
+
+    /// A request the worker cannot finish within the per-request timeout returns
+    /// `Timeout` (freeing the caller's blocking thread), not `WORKER_GONE`.
+    #[test]
+    fn request_timeout_returns_timeout_error() {
+        struct SlowEngine;
+        impl AudioEngine for SlowEngine {
+            fn transcribe(
+                &mut self,
+                input: AudioTranscribeInput,
+            ) -> Result<AudioTranscribeOutput, AudioModelError> {
+                // Sleep well past the worker's per-request timeout. This runs on
+                // the worker thread (a plain std thread, not async), so a
+                // blocking sleep is the right tool to model a slow request.
+                std::thread::sleep(Duration::from_millis(500));
+                Ok(AudioTranscribeOutput {
+                    text: format!("ok:{}", input.audio.len()),
+                    language: input.language,
+                    duration_seconds: None,
+                })
+            }
+        }
+
+        let worker = AudioWorker::spawn("audio-test-timeout", 8, Duration::from_millis(50), || {
+            Ok(SlowEngine)
+        })
+        .expect("worker spawns and engine loads");
+
+        let err = worker
+            .transcribe(transcribe_input(3, None))
+            .expect_err("a request slower than the timeout must error");
+        assert!(
+            matches!(err, AudioModelError::Timeout),
+            "expected Timeout, got: {err:?}"
+        );
     }
 }

--- a/src/server/cli_input.rs
+++ b/src/server/cli_input.rs
@@ -64,6 +64,12 @@ pub struct ServerStartupInput {
     pub draft_block_size: Option<u32>,
     pub max_batch_size: Option<usize>,
     pub max_queue_depth: usize,
+    /// Bound on the audio worker command queue (admission control), forwarded to
+    /// the audio providers via [`super::config::ServerConfig`].
+    pub audio_queue_depth: usize,
+    /// Per-request reply timeout (seconds) for the audio worker, forwarded to the
+    /// audio providers via [`super::config::ServerConfig`].
+    pub audio_request_timeout_secs: u64,
     pub prefill_chunk_size: usize,
     /// llama-server alias for `--prefill-chunk-size` (`--batch-size` / `-b`).
     ///
@@ -536,6 +542,8 @@ impl ServerStartupInput {
             draft_block_size: self.draft_block_size,
             max_batch_size: self.max_batch_size,
             max_queue_depth: self.max_queue_depth,
+            audio_queue_depth: self.audio_queue_depth,
+            audio_request_timeout_secs: self.audio_request_timeout_secs,
             prefill_chunk_size: resolution.prefill_chunk_size,
             batch_size_conflict: resolution.batch_size_conflict,
             ubatch_size_provided: resolution.ubatch_size_provided,

--- a/src/server/cli_input_tests.rs
+++ b/src/server/cli_input_tests.rs
@@ -49,6 +49,8 @@ fn sample_input() -> ServerStartupInput {
         draft_block_size: None,
         max_batch_size: Some(4),
         max_queue_depth: 32,
+        audio_queue_depth: 8,
+        audio_request_timeout_secs: 120,
         prefill_chunk_size: 512,
         batch_size: None,
         ubatch_size: None,

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -225,6 +225,18 @@ pub struct RemotePipelineStageConfig {
     pub transport_backend: TransportBackend,
 }
 
+/// Default bound for the audio worker command queue (admission control).
+///
+/// Each queued speech-to-text command can hold up to the 25 MiB per-request
+/// payload, so a depth of `8` caps queued payload at roughly 200 MiB plus the
+/// one request in flight, while still absorbing short bursts.
+pub const DEFAULT_AUDIO_QUEUE_DEPTH: usize = 8;
+
+/// Default per-request reply timeout (seconds) for the audio worker. Generous
+/// upper bound for a single bounded clip; a stuck request frees its blocking
+/// thread after this instead of hanging.
+pub const DEFAULT_AUDIO_REQUEST_TIMEOUT_SECS: u64 = 120;
+
 /// Server configuration derived from CLI-compatible startup arguments.
 ///
 /// Default values intentionally track `llama-server` behavior where practical
@@ -283,6 +295,16 @@ pub struct ServerConfig {
     pub max_batch_size: usize,
     /// Maximum number of requests waiting in the prefill queue.
     pub max_queue_depth: usize,
+    /// Bound on the audio worker command queue (admission control). When the
+    /// queue is full, new audio requests get a structured `503` instead of
+    /// growing memory without bound. A `0` clamps to at least one queued
+    /// command at the channel boundary. See [`DEFAULT_AUDIO_QUEUE_DEPTH`].
+    pub audio_queue_depth: usize,
+    /// Per-request reply timeout for the audio worker, in seconds. A stuck or
+    /// pathologically slow audio request frees its blocking thread and returns
+    /// a structured `504` after this. A `0` falls back to the default rather
+    /// than timing out instantly. See [`DEFAULT_AUDIO_REQUEST_TIMEOUT_SECS`].
+    pub audio_request_timeout_secs: u64,
     /// Number of tokens per prefill chunk. When 0, chunking is disabled and
     /// the full prompt is prefilled in a single pass.
     pub prefill_chunk_size: usize,
@@ -499,6 +521,8 @@ impl Default for ServerConfig {
             draft_block_size: None,
             max_batch_size: 1,
             max_queue_depth: 1024,
+            audio_queue_depth: DEFAULT_AUDIO_QUEUE_DEPTH,
+            audio_request_timeout_secs: DEFAULT_AUDIO_REQUEST_TIMEOUT_SECS,
             prefill_chunk_size: 512,
             enable_preemption: false,
             preemption_policy: PreemptionPolicy::default(),

--- a/src/server/kokoro_tts.rs
+++ b/src/server/kokoro_tts.rs
@@ -27,6 +27,7 @@
 
 use std::borrow::Cow;
 use std::path::Path;
+use std::time::Duration;
 
 use crate::models::KokoroModel;
 use crate::models::g2p;
@@ -74,9 +75,16 @@ impl KokoroTtsProvider {
     /// Returns `Err` if the worker thread cannot start or the checkpoint fails
     /// to load, letting the server boot with the audio slot empty instead of
     /// aborting.
-    pub fn load(model_path: &Path) -> anyhow::Result<Self> {
+    ///
+    /// `queue_depth` and `request_timeout` bound the shared worker's command
+    /// queue and per-request reply wait (admission control + timeout).
+    pub fn load(
+        model_path: &Path,
+        queue_depth: usize,
+        request_timeout: Duration,
+    ) -> anyhow::Result<Self> {
         let model_path = model_path.to_path_buf();
-        let worker = AudioWorker::spawn("kokoro-tts", move || {
+        let worker = AudioWorker::spawn("kokoro-tts", queue_depth, request_timeout, move || {
             let model = KokoroModel::load(&model_path)?;
             Ok(KokoroEngine { model })
         })?;

--- a/src/server/routes/audio.rs
+++ b/src/server/routes/audio.rs
@@ -348,6 +348,16 @@ fn audio_model_error_response(err: AudioModelError) -> ErrorResponse {
             format!("audio model inference failed: {message}"),
             "server_error",
         ),
+        // A full bounded queue reuses the shared 503 admission envelope so the
+        // audio path sheds load the same way the generation path does.
+        AudioModelError::QueueFull => {
+            ErrorResponse::service_unavailable("All slots are busy. Please try again later.")
+        }
+        // The worker did not reply in time; 504 names the upstream worker as the
+        // party that did not respond, distinct from a 503 admission rejection.
+        AudioModelError::Timeout => {
+            ErrorResponse::gateway_timeout("Audio request timed out. Please try again later.")
+        }
     }
 }
 
@@ -393,6 +403,16 @@ mod tests {
         let not_loaded =
             audio_model_error_response(AudioModelError::KindNotLoaded(AudioModelKind::Tts));
         assert_eq!(not_loaded.status, StatusCode::NOT_IMPLEMENTED);
+
+        // A full bounded queue maps to the shared 503 "server_busy" envelope.
+        let queue_full = audio_model_error_response(AudioModelError::QueueFull);
+        assert_eq!(queue_full.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(queue_full.error.error_type, "server_busy");
+
+        // A per-request timeout maps to a structured 504 "server_timeout".
+        let timeout = audio_model_error_response(AudioModelError::Timeout);
+        assert_eq!(timeout.status, StatusCode::GATEWAY_TIMEOUT);
+        assert_eq!(timeout.error.error_type, "server_timeout");
     }
 
     #[test]

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -106,6 +106,12 @@ pub struct ServerStartupConfig {
     // Batch scheduling
     pub max_batch_size: Option<usize>,
     pub max_queue_depth: usize,
+    /// Bound on the audio worker command queue (admission control). Forwarded to
+    /// [`super::config::ServerConfig::audio_queue_depth`].
+    pub audio_queue_depth: usize,
+    /// Per-request reply timeout for the audio worker, in seconds. Forwarded to
+    /// [`super::config::ServerConfig::audio_request_timeout_secs`].
+    pub audio_request_timeout_secs: u64,
     /// Prefill chunk size in tokens (0 = disabled).
     pub prefill_chunk_size: usize,
     /// Set when `--batch-size` and `--prefill-chunk-size` conflict; triggers a startup warning.
@@ -394,6 +400,8 @@ impl Default for ServerStartupConfig {
             draft_block_size: None,
             max_batch_size: None,
             max_queue_depth: 32,
+            audio_queue_depth: crate::server::config::DEFAULT_AUDIO_QUEUE_DEPTH,
+            audio_request_timeout_secs: crate::server::config::DEFAULT_AUDIO_REQUEST_TIMEOUT_SECS,
             prefill_chunk_size: 512,
             batch_size_conflict: false,
             ubatch_size_provided: false,
@@ -829,6 +837,8 @@ pub(super) fn build_server_config(
         draft_block_size: startup.draft_block_size,
         max_batch_size,
         max_queue_depth: startup.max_queue_depth,
+        audio_queue_depth: startup.audio_queue_depth,
+        audio_request_timeout_secs: startup.audio_request_timeout_secs,
         prefill_chunk_size: startup.prefill_chunk_size,
         enable_preemption: startup.enable_preemption,
         preemption_policy: parse_preemption_policy(&startup.preemption_policy),
@@ -1812,6 +1822,18 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     // thread. The chat ModelProvider load above is a no-op for this checkpoint
     // (the worker logs and returns), matching the single-model "speech-to-text
     // only" deployment; serving chat and STT simultaneously is out of scope.
+    // Audio admission bounds (#373). Read from the in-scope `config` before it is
+    // moved into `AppState`: a bounded command queue (queue depth) plus a
+    // per-request reply timeout, shared by the STT and TTS workers. A `0` timeout
+    // falls back to the default rather than timing out instantly; a `0` queue
+    // depth is clamped at the channel boundary inside `AudioWorker::spawn`.
+    let audio_queue_depth = config.audio_queue_depth;
+    let audio_request_timeout =
+        std::time::Duration::from_secs(if config.audio_request_timeout_secs == 0 {
+            crate::server::config::DEFAULT_AUDIO_REQUEST_TIMEOUT_SECS
+        } else {
+            config.audio_request_timeout_secs
+        });
     let audio_model: Option<Arc<dyn crate::server::audio_model::AudioModelProvider>> =
         match crate::models::get_model_type(&startup.model_path) {
             Ok(crate::models::ModelType::Whisper) => {
@@ -1819,7 +1841,11 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
                     "Detected Whisper speech-to-text checkpoint; loading audio model for \
                      /v1/audio/transcriptions and /v1/audio/translations"
                 );
-                match crate::server::whisper_stt::WhisperSttProvider::load(&startup.model_path) {
+                match crate::server::whisper_stt::WhisperSttProvider::load(
+                    &startup.model_path,
+                    audio_queue_depth,
+                    audio_request_timeout,
+                ) {
                     Ok(provider) => Some(Arc::new(provider)),
                     Err(err) => {
                         tracing::error!("Failed to load Whisper speech-to-text model: {err}");
@@ -1832,7 +1858,11 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
                     "Detected Kokoro text-to-speech checkpoint; loading audio model for \
                      /v1/audio/speech"
                 );
-                match crate::server::kokoro_tts::KokoroTtsProvider::load(&startup.model_path) {
+                match crate::server::kokoro_tts::KokoroTtsProvider::load(
+                    &startup.model_path,
+                    audio_queue_depth,
+                    audio_request_timeout,
+                ) {
                     Ok(provider) => Some(Arc::new(provider)),
                     Err(err) => {
                         tracing::error!("Failed to load Kokoro text-to-speech model: {err}");

--- a/src/server/types/response.rs
+++ b/src/server/types/response.rs
@@ -467,6 +467,21 @@ impl ErrorResponse {
         }
     }
 
+    /// Build a `504 Gateway Timeout` error. Used by the audio endpoints when the
+    /// dedicated worker thread does not reply within the configured per-request
+    /// timeout, so a stuck or pathologically slow request frees its blocking
+    /// thread and returns a structured error instead of hanging.
+    pub fn gateway_timeout(message: impl Into<String>) -> Self {
+        Self {
+            error: ErrorDetail {
+                message: message.into(),
+                error_type: "server_timeout".into(),
+                code: None,
+            },
+            status: axum::http::StatusCode::GATEWAY_TIMEOUT,
+        }
+    }
+
     /// Build a `501 Not Implemented` error. Used by the audio endpoints to
     /// report that no model is loaded for the requested audio direction while
     /// the request itself parsed successfully.

--- a/src/server/whisper_stt.rs
+++ b/src/server/whisper_stt.rs
@@ -27,6 +27,7 @@
 //! over the worker's channel, which makes it trivially `Send + Sync`.
 
 use std::path::Path;
+use std::time::Duration;
 
 use crate::audio::load_wav_from_bytes;
 use crate::audio::whisper_mel;
@@ -50,9 +51,16 @@ impl WhisperSttProvider {
     /// tokenizer, then stays alive to serve transcription requests. Returns
     /// `Err` if the worker thread cannot start or the checkpoint fails to load,
     /// letting the server boot with the audio slot empty instead of aborting.
-    pub fn load(model_path: &Path) -> anyhow::Result<Self> {
+    ///
+    /// `queue_depth` and `request_timeout` bound the shared worker's command
+    /// queue and per-request reply wait (admission control + timeout).
+    pub fn load(
+        model_path: &Path,
+        queue_depth: usize,
+        request_timeout: Duration,
+    ) -> anyhow::Result<Self> {
         let model_path = model_path.to_path_buf();
-        let worker = AudioWorker::spawn("whisper-stt", move || {
+        let worker = AudioWorker::spawn("whisper-stt", queue_depth, request_timeout, move || {
             let model = WhisperModel::load(&model_path)?;
             Ok(WhisperEngine { model })
         })?;


### PR DESCRIPTION
## Summary

Bounds the OpenAI audio worker queue and adds a per-request reply timeout so the network-facing audio path cannot grow memory without bound or hang a caller. Both fixes live in the shared `AudioWorker`, so they cover the Whisper STT and Kokoro TTS paths together. Surfaced by the PR #371 security review (two MEDIUM availability risks: head-of-line blocking through one worker, and unbounded memory growth from queued 25 MiB payloads).

## What changed

- `src/server/audio_worker.rs`: command channel switched from an unbounded `mpsc::channel` to a bounded `mpsc::sync_channel(queue_depth)`; `dispatch` uses `try_send` (full queue maps to the new `QueueFull` error); `transcribe`/`synthesize` use `recv_timeout(request_timeout)` (timeout maps to the new `Timeout` error). `spawn` gains `queue_depth` and `request_timeout` params and clamps a zero capacity to at least one queued command. `Drop` keeps a blocking shutdown send, which is correct because the worker keeps draining.
- `src/server/audio_model.rs`: two new `AudioModelError` variants, `QueueFull` and `Timeout`.
- `src/server/routes/audio.rs`: `audio_model_error_response` maps `QueueFull` to the shared `503` `server_busy` envelope and `Timeout` to a structured `504` `server_timeout`.
- `src/server/types/response.rs`: new `ErrorResponse::gateway_timeout` helper (`504`, `server_timeout`).
- `src/server/whisper_stt.rs`, `src/server/kokoro_tts.rs`: provider `load` takes `queue_depth` and `request_timeout` and forwards them to `AudioWorker::spawn`.
- Config plumbing mirrored on `max_queue_depth`: new `ServerConfig` fields `audio_queue_depth` (default 8) and `audio_request_timeout_secs` (default 120), wired through `ServerStartupInput`/`ServerStartupConfig`/`build_server_config` and read in the startup audio block (a `0` timeout falls back to the default). New flags `--audio-queue-depth` / `--audio-request-timeout-secs` and env vars `MLXCEL_AUDIO_QUEUE_DEPTH` / `MLXCEL_AUDIO_REQUEST_TIMEOUT_SECS` on both `mlxcel serve` and `mlxcel-server`.
- Tests: `queue_full_returns_queuefull_error` and `request_timeout_returns_timeout_error` (worker level, no real model, deterministic), plus route-level assertions that `QueueFull` is `503` and `Timeout` is `504`.
- Docs: new "Queue bound and per-request timeout" section and `504` rows in `docs/audio-api.md`; new "Server audio admission variables" section in `docs/environment-variables.md`.

## Test plan

- [x] `cargo check --lib --tests` (clean)
- [x] `cargo check --bins` (CLI arg-struct wiring compiles)
- [x] `cargo test --lib server::audio_worker` (6 passed, incl. the two new tests)
- [x] `cargo test --lib server::routes::audio` (16 passed)
- [x] `cargo test --lib server::config` and `cargo test --lib server::cli_input` and `cargo test --lib server::startup` (pass)
- [x] `cargo clippy --lib --tests -- -D warnings` and `cargo clippy --bins -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)

Closes #373
