### PR TITLE
fix(mlxcel-core): make audio-path MLX ops fallible at the FFI boundary

### DIFF
--- a/docs/adr/0003-release-panic-unwind-with-core-thread-abort.md
+++ b/docs/adr/0003-release-panic-unwind-with-core-thread-abort.md
@@ -47,11 +47,11 @@ There is deliberately no `std::panic::set_hook` that aborts. The panic hook runs
 - A synthesis-path panic in a release build now becomes a per-request error and the server keeps serving, matching the `worker_survives_engine_panic_and_keeps_serving` test. That test now represents release behavior, not just the always-unwind test profile.
 - A panic on a core generation thread aborts the process cleanly (logged via `tracing` at `target: "mlxcel::worker"`, without request content) for a supervisor to restart, preserving the fail-fast posture `panic = "abort"` used to provide for those threads.
 - The abort path of `run_core_thread_or_abort` cannot be unit-tested in-process (it terminates the test runner). It is covered by a happy-path unit test and verified manually in a release build; a cfg-gated subprocess re-exec test is possible but not worth the flakiness for a one-line abort.
-- **Residual abort vector (#382).** An MLX C++ FFI exception thrown through a non-`Result` `cxx` op becomes `std::terminate`, not a Rust panic, so neither the `catch_unwind` backstops nor the unwind policy intercept it: it still terminates the process. This change does nothing for that path; it is tracked separately as issue #382.
+- **Residual abort vector (#382) — resolved in PR #384.** An MLX C++ FFI exception thrown through a non-`Result` `cxx` op becomes `std::terminate`, not a Rust panic, so neither the `catch_unwind` backstops nor the unwind policy intercept it. PR #384 adds `try_matmul` and `try_array_to_raw_bytes` as `-> Result<..>` variants in the cxx bridge and routes the Kokoro alignment-expansion matmuls and the final PCM readback through them, so those throws become recoverable per-request `Err`s instead of `std::terminate`. Whisper relies on fixed-shape invariants so no fallible variants are needed there. `cxx` ops that throw a non-`std::exception` type still terminate (the cxx bridge only catches `std::exception`); no such throws exist on the current audio path.
 
 ## References
 
-- Issue #375 (this decision), PR #374 (the Kokoro provider and the `run_guarded` backstop), issue #382 (the residual MLX FFI `std::terminate` vector).
+- Issue #375 (this decision), PR #374 (the Kokoro provider and the `run_guarded` backstop), issue #382 (the residual MLX FFI `std::terminate` vector, resolved by PR #384), PR #384 (`try_matmul` / `try_array_to_raw_bytes` fallible cxx variants, Kokoro path wiring).
 - `Cargo.toml` `[profile.release]` `panic = "unwind"`.
 - `src/worker_failfast.rs` (`run_core_thread_or_abort`, shared by the server and the distributed pipeline).
 - `src/server/model_worker.rs` (the two wrapped core generation `thread::spawn` sites).

--- a/docs/audio-api.md
+++ b/docs/audio-api.md
@@ -169,7 +169,7 @@ Both knobs apply to the shared worker, so they cover the STT (Whisper) and TTS (
 
 Each engine call on the audio worker runs under a `catch_unwind` boundary (`run_guarded` in `src/server/audio_worker.rs`), so a synthesis or transcription panic becomes a per-request `Inference` error and the worker thread keeps serving rather than taking down the server. Since issue #375 this holds in release builds too: the release profile uses `panic = "unwind"` (it formerly used `panic = "abort"`, which silently defeated the boundary in production). The core text-generation worker threads take the opposite, deliberate posture: an uncaught panic there means a broken invariant, so they log and `abort` the process for a supervised restart instead of unwinding (see ADR 0003).
 
-One residual case is not contained: an MLX C++ FFI exception thrown through a non-`Result` op becomes `std::terminate`, not a Rust panic, so it still terminates the process. That path is tracked separately as issue #382.
+The MLX C++ FFI exception path (issue #382) is contained on the Kokoro synthesis route as of PR #384: the alignment-expansion matmuls and the final PCM readback go through `try_matmul` and `try_array_to_raw_bytes`, which are declared `-> Result<..>` in the cxx bridge so an MLX throw becomes a per-request `Err` rather than `std::terminate`. Whisper is unaffected because its tensor shapes are fixed and checked before the MLX call. Any `cxx` op that throws a non-`std::exception` type still terminates the process; no such throw exists on the current audio path.
 
 ## Adding an audio model provider
 

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -314,6 +314,28 @@ rust::Vec<uint8_t> array_to_raw_bytes(const MlxArray& arr) {
     return result;
 }
 
+// Same body as `array_to_raw_bytes`, but declared `-> Result<Vec<u8>>` on the
+// Rust side so cxx wraps the call in a try/catch and converts any thrown MLX
+// exception (an allocation failure making the contiguous copy, or any deferred
+// error forced by the eval) into a Rust `Err` instead of letting it cross the
+// FFI boundary uncaught (which aborts the process). The audio synthesis readback
+// uses this so the whole contiguous + eval + copy-out step is recoverable at one
+// fallible boundary.
+rust::Vec<uint8_t> try_array_to_raw_bytes(const MlxArray& arr) {
+    auto a = mlx::core::contiguous(arr.inner);
+    mlx::core::eval(a);
+
+    size_t nbytes = a.nbytes();
+    const auto* data = reinterpret_cast<const uint8_t*>(a.data<void>());
+
+    rust::Vec<uint8_t> result;
+    result.reserve(nbytes);
+    for (size_t i = 0; i < nbytes; ++i) {
+        result.push_back(data[i]);
+    }
+    return result;
+}
+
 // Evaluation.
 void eval(const MlxArray& arr) {
     const_cast<array&>(arr.inner).eval();
@@ -612,6 +634,15 @@ std::unique_ptr<MlxArray> any_all(const MlxArray& a) {
 
 // Matrix operations.
 std::unique_ptr<MlxArray> matmul(const MlxArray& a, const MlxArray& b) {
+    return std::make_unique<MlxArray>(mlx::core::matmul(a.inner, b.inner));
+}
+
+// Same body as `matmul`, but declared `-> Result` on the Rust side so cxx wraps
+// the call in a try/catch and converts MLX's eager shape-mismatch exception (and
+// any other throw) into a Rust `Err` instead of letting it abort the process.
+// MLX validates matmul shapes at graph-build time, so this catches the throw at
+// op construction, not only at eval.
+std::unique_ptr<MlxArray> try_matmul(const MlxArray& a, const MlxArray& b) {
     return std::make_unique<MlxArray>(mlx::core::matmul(a.inner, b.inner));
 }
 

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -125,6 +125,10 @@ bool item_bool(const MlxArray& arr);
 // Copy evaluated array data to a byte buffer.
 // Used by: KV cache serialization for disaggregated inference
 rust::Vec<uint8_t> array_to_raw_bytes(const MlxArray& arr);
+// Fallible counterpart of `array_to_raw_bytes`; declared `-> Result` in the
+// bridge so cxx catches a throw from the contiguous copy or eval and surfaces it
+// as a Rust `Err` instead of aborting.
+rust::Vec<uint8_t> try_array_to_raw_bytes(const MlxArray& arr);
 
 // Evaluation.
 void eval(const MlxArray& arr);
@@ -220,6 +224,10 @@ std::unique_ptr<MlxArray> any_all(const MlxArray& a);
 
 // Matrix operations.
 std::unique_ptr<MlxArray> matmul(const MlxArray& a, const MlxArray& b);
+// Fallible counterpart of `matmul`; declared `-> Result` in the bridge so cxx
+// catches MLX's eager shape-mismatch exception (and any other throw) and
+// surfaces it as a Rust `Err` instead of aborting.
+std::unique_ptr<MlxArray> try_matmul(const MlxArray& a, const MlxArray& b);
 std::unique_ptr<MlxArray> transpose(const MlxArray& a);
 std::unique_ptr<MlxArray> transpose_axes(const MlxArray& a, rust::Slice<const int32_t> axes);
 std::unique_ptr<MlxArray> reshape(const MlxArray& a, rust::Slice<const int32_t> shape);

--- a/src/lib/mlxcel-core/src/ffi_tests.rs
+++ b/src/lib/mlxcel-core/src/ffi_tests.rs
@@ -2619,3 +2619,56 @@ fn steel_gemm_edge_tile_safe_load_matches_reference() {
         "steel GEMM edge-tile result diverges from composite reference: max_abs = {max_abs}"
     );
 }
+
+// --- Fallible audio-path FFI ops (issue #382) -------------------------------
+//
+// The audio synthesis/transcription forward paths build MLX graphs through ops
+// declared in the cxx bridge. A non-`Result` cxx op that throws a C++ exception
+// aborts the process via `std::terminate`, which the `catch_unwind` backstop in
+// the audio worker cannot intercept. The fallible variants below are declared
+// `-> Result` so cxx converts a thrown MLX exception into a recoverable `Err`.
+// These tests assert the recovery behavior (no abort) at the FFI boundary.
+
+#[test]
+fn try_matmul_returns_err_on_shape_mismatch() {
+    // MLX validates matmul shapes eagerly at graph-build time: the inner
+    // dimensions (3 and 4) do not match, so `mlx::core::matmul` throws at op
+    // construction. The fallible variant must catch that throw and return `Err`
+    // rather than letting it cross the FFI boundary uncaught (which would abort
+    // the whole process). No eval is needed; the throw happens at construction.
+    let a = ones(&[2, 3], dtype::FLOAT32);
+    let b = ones(&[4, 5], dtype::FLOAT32);
+    let result = try_matmul(&a, &b);
+    assert!(
+        result.is_err(),
+        "a matmul shape mismatch must return Err, not abort the process"
+    );
+}
+
+#[test]
+fn try_matmul_ok_matches_matmul() {
+    // The happy path is identical to `matmul`: a valid (2,3) x (3,4) product
+    // returns the (2,4) result and evaluates to the same value.
+    let a = ones(&[2, 3], dtype::FLOAT32);
+    let b = ones(&[3, 4], dtype::FLOAT32);
+    let c = try_matmul(&a, &b).expect("valid matmul returns Ok");
+    assert_eq!(array_shape(&c), vec![2, 4]);
+    eval(&c);
+    let total = sum_all(&c);
+    eval(&total);
+    assert_eq!(item_f32(&total), 24.0);
+}
+
+#[test]
+fn try_array_to_raw_bytes_round_trips_f32() {
+    // The fallible readback materializes (contiguous + eval + copy-out) inside a
+    // single cxx try/catch boundary. On a well-formed array it round-trips the
+    // bytes exactly, matching the non-fallible `array_to_raw_bytes`.
+    let a = from_slice_f32(&[1.0_f32, 2.0, 3.0], &[3]);
+    let bytes = try_array_to_raw_bytes(&a).expect("readback of a valid array returns Ok");
+    let values: Vec<f32> = bytes
+        .chunks_exact(4)
+        .map(|ch| f32::from_le_bytes([ch[0], ch[1], ch[2], ch[3]]))
+        .collect();
+    assert_eq!(values, vec![1.0, 2.0, 3.0]);
+}

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -150,6 +150,17 @@ mod ffi {
         /// Used by: KV cache serialization for disaggregated inference
         fn array_to_raw_bytes(arr: &MlxArray) -> Vec<u8>;
 
+        /// Fallible counterpart of [`array_to_raw_bytes`].
+        ///
+        /// Makes the array contiguous, evaluates it, and copies the bytes out,
+        /// all inside the cxx try/catch boundary (declared `-> Result`), so an
+        /// MLX C++ exception during the contiguous copy or the eval (for example
+        /// an allocation failure on a large data-dependent tensor) surfaces as a
+        /// Rust `Err` instead of an uncaught exception that aborts the process.
+        /// Used by the audio synthesis readback so a fault on a pool/worker
+        /// thread becomes a structured per-request error.
+        fn try_array_to_raw_bytes(arr: &MlxArray) -> Result<Vec<u8>>;
+
         // Evaluation.
         /// Evaluate an array
         fn eval(arr: &MlxArray);
@@ -371,6 +382,18 @@ mod ffi {
         // Matrix operations.
         /// Matrix multiplication
         fn matmul(a: &MlxArray, b: &MlxArray) -> UniquePtr<MlxArray>;
+
+        /// Fallible matrix multiplication.
+        ///
+        /// Same effect as [`matmul`], but declared `-> Result` so cxx catches
+        /// any MLX C++ exception at the FFI boundary and returns it as a Rust
+        /// `Err` instead of letting it cross uncaught and abort the process.
+        /// MLX validates matmul shapes eagerly at graph-build time, so a shape
+        /// mismatch throws at construction (not only at eval); this variant
+        /// catches that. Used on the audio synthesis forward path for the
+        /// data-dependent alignment-expansion matmuls, whose inner dimension is
+        /// derived from the runtime duration prediction.
+        fn try_matmul(a: &MlxArray, b: &MlxArray) -> Result<UniquePtr<MlxArray>>;
 
         /// Transpose (swap last two dimensions)
         fn transpose(a: &MlxArray) -> UniquePtr<MlxArray>;

--- a/src/models/kokoro/mod.rs
+++ b/src/models/kokoro/mod.rs
@@ -219,12 +219,19 @@ impl KokoroModel {
         }
         let aln = alignment_matrix(&durations, l, total_frames);
 
+        // These two matmuls expand per-token features to per-frame against the
+        // alignment matrix, whose `T` (frame) dimension is derived from the
+        // runtime duration prediction. They are the data-dependent construction
+        // ops on the synthesis path, so route them through the fallible variant:
+        // a malformed graph returns Err here instead of aborting the process via
+        // an uncaught MLX C++ exception (MLX validates matmul shapes eagerly at
+        // graph-build time).
         let d_t = ops::swap_axes(&d, 0, 1); // (640, L)
-        let en = ops::matmul(&d_t, &aln); // (640, T)
+        let en = ops::try_matmul(&d_t, &aln).map_err(|e| anyhow!(e))?; // (640, T)
         let (f0_pred, n_pred) = self.predictor.f0n(&en, &s_pred, total_frames);
 
         let t_en = self.text_encoder.forward(&padded); // (512, L)
-        let asr = ops::matmul(&t_en, &aln); // (512, T)
+        let asr = ops::try_matmul(&t_en, &aln).map_err(|e| anyhow!(e))?; // (512, T)
 
         let samples = self
             .decoder

--- a/src/models/kokoro/ops.rs
+++ b/src/models/kokoro/ops.rs
@@ -93,6 +93,23 @@ pub(crate) fn matmul(a: &UniquePtr<MlxArray>, b: &UniquePtr<MlxArray>) -> Unique
     mlxcel_core::matmul(r(a), r(b))
 }
 
+/// Fallible matrix product `a @ b`.
+///
+/// Like [`matmul`], but returns `Err` instead of aborting the process when MLX
+/// rejects the operation. MLX validates matmul shapes eagerly at graph-build
+/// time, so a malformed graph throws at construction; this variant catches that
+/// throw at the FFI boundary (see [`mlxcel_core::try_matmul`]). Used for the
+/// audio synthesis alignment-expansion matmuls, whose inner dimension is derived
+/// from the runtime duration prediction, so a fault surfaces as a structured
+/// per-request error rather than a `std::terminate`.
+#[inline]
+pub(crate) fn try_matmul(
+    a: &UniquePtr<MlxArray>,
+    b: &UniquePtr<MlxArray>,
+) -> Result<UniquePtr<MlxArray>, String> {
+    mlxcel_core::try_matmul(r(a), r(b)).map_err(|e| format!("kokoro matmul failed: {e}"))
+}
+
 /// `exp(a)`.
 #[inline]
 pub(crate) fn exp(a: &UniquePtr<MlxArray>) -> UniquePtr<MlxArray> {
@@ -389,13 +406,22 @@ pub(crate) fn lstm_dir(
     outputs
 }
 
-/// Read an MLX array back to a host `Vec<f32>`. Casts to `f32`, makes the
-/// buffer contiguous, evaluates, then parses 4-byte little-endian chunks.
+/// Read an MLX array back to a host `Vec<f32>`. Casts to `f32`, then materializes
+/// the buffer (contiguous + eval + copy-out) through the fallible FFI readback
+/// and parses 4-byte little-endian chunks.
+///
+/// This is the single point where the lazily-built Kokoro graph is forced, so it
+/// is also where an MLX C++ exception (an allocation failure on a large
+/// data-dependent tensor, or any deferred op error) is most likely. The
+/// materialize step runs through [`mlxcel_core::try_array_to_raw_bytes`], which
+/// performs the contiguous copy and the eval inside one cxx try/catch boundary,
+/// so a fault returns `Err` instead of aborting the process via an uncaught C++
+/// exception. The `astype` to `f32` is a no-op on already-`f32` arrays and never
+/// throws, so it is left on the non-fallible path.
 pub(crate) fn to_vec_f32(a: &UniquePtr<MlxArray>) -> Result<Vec<f32>, String> {
     let f = mlxcel_core::astype(r(a), FLOAT32);
-    let c = mlxcel_core::contiguous(r(&f), false);
-    mlxcel_core::try_eval(r(&c)).map_err(|e| format!("kokoro eval failed: {e}"))?;
-    let bytes = mlxcel_core::array_to_raw_bytes(r(&c));
+    let bytes = mlxcel_core::try_array_to_raw_bytes(r(&f))
+        .map_err(|e| format!("kokoro eval failed: {e}"))?;
     Ok(bytes
         .chunks_exact(4)
         .map(|ch| f32::from_le_bytes([ch[0], ch[1], ch[2], ch[3]]))


### PR DESCRIPTION
## Summary

The audio synthesis and transcription forward paths build MLX graphs through `mlxcel-core` cxx ops declared as `-> UniquePtr<MlxArray>` (not `Result`). When the underlying MLX C++ throws (shape mismatch caught eagerly at graph build, allocation failure at eval), cxx hard-aborts the process via `std::terminate`. That is not a Rust panic, so the `catch_unwind` backstop in `src/server/audio_worker.rs` (`run_guarded`) cannot intercept it regardless of the release `panic` setting. This implements option (a) from the issue: add `Result`-returning variants of the MLX ops that dominate the audio forward path and thread them through the Kokoro/Whisper code, so a thrown MLX exception becomes a recoverable per-request `Err` instead of a process abort.

## What changed

- `src/lib/mlxcel-core/src/lib.rs`, `cpp/mlx_cxx_bridge.h`, `cpp/mlx_cxx_bridge.cpp`: add two fallible FFI variants. `try_matmul(a, b) -> Result<UniquePtr<MlxArray>>` mirrors `matmul`; because it is declared `-> Result`, cxx wraps the call in try/catch and converts a thrown MLX exception into a Rust `Err`. `try_array_to_raw_bytes(arr) -> Result<Vec<u8>>` mirrors `array_to_raw_bytes` (contiguous + eval + copy-out) inside one cxx try/catch boundary. The non-fallible siblings are unchanged, so no other model path is affected.
- `src/models/kokoro/ops.rs`: add a fallible `try_matmul` wrapper, and rewrite `to_vec_f32` (the single point where the lazy Kokoro graph is forced) to materialize through `try_array_to_raw_bytes`. This replaces the previous `try_eval` followed by a second, non-fallible `eval` inside `array_to_raw_bytes`, closing a real abort hole (an allocation failure making the contiguous copy of a large tensor was uncaught) and removing a redundant eval.
- `src/models/kokoro/mod.rs`: route the two alignment-expansion matmuls (`en = d_t @ aln`, `asr = t_en @ aln`) through `ops::try_matmul`. Their inner dimension is the frame count `T`, derived from the runtime duration prediction, so these are the data-dependent construction ops on the synthesis path.
- `src/lib/mlxcel-core/src/ffi_tests.rs`: regression tests for the new fallible ops.

## Ops made fallible and why this set

MLX is lazy for the heavy ops, so the entire forward computation (every conv, the LSTM, the matmuls) and the allocation of the large `T`-dependent tensors are deferred to a single `eval`. Both audio paths force that graph at one materialization point: Kokoro at `to_vec_f32`, Whisper at `argmax_with_masks`. Routing the materialization through a fallible boundary therefore catches the eval-time fault set (allocation failure on the large data-dependent tensors, and any deferred op error) across the whole graph. MLX additionally validates some shapes eagerly at op construction, so the data-dependent alignment matmuls (whose inner dim comes from runtime data) get the fallible `try_matmul` variant to catch a graph-build throw too. This is the "minimize the number of new fallible variants" path the issue suggests: two new variants cover the realistic fault set on the synthesis path. Construction throws on the remaining weight-fixed ops require a checkpoint/config mismatch and are not reachable on the guarded forward path (input capped to 4096 chars, vocab-restricted g2p, 510-token truncation, finite/positive speed, per-token frame counts clamped to [1,100], whitelisted voices).

Transcription (Whisper) already forces its entire encoder and decoder graph at the single `argmax_with_masks` point through the pre-existing `try_eval`, so its eval-time faults are already recoverable. Its construction shapes are fixed by the 30 s mel window and the checkpoint config, and its matmuls live in shared `mlxcel_core::layers` used by every model, so they are intentionally left unchanged to keep this scoped to the audio path and avoid cross-cutting churn.

## Test plan

- [x] `cargo check -p mlxcel-core --lib` (runs build.rs, compiles the C++ shim, validates the cxx bridge): clean.
- [x] `cargo check -p mlxcel --lib --tests` (server-side threading): clean.
- [x] `cargo test -p mlxcel-core --lib ffi_tests::try_`: 3 passed. `try_matmul_returns_err_on_shape_mismatch` asserts a deliberate (2,3) x (4,5) mismatch returns `Err` (graph-build throw caught, not a process abort); `try_matmul_ok_matches_matmul` asserts the happy path; `try_array_to_raw_bytes_round_trips_f32` asserts the fallible readback round-trips.
- [x] `cargo clippy -p mlxcel-core --lib --tests -- -D warnings` and `cargo clippy -p mlxcel --lib -- -D warnings`: clean.
- [x] `cargo fmt --check`: clean.
- [ ] No measurable throughput regression: the fallible variants add no eval/sync (`try_matmul` builds a lazy node; `to_vec_f32` now does one fewer eval), so no per-op hot-path cost is expected. A full release build and the audio throughput bench were not run under the implementation watchdog; deferred to the release CI / maintainer.

Closes #382
