### PR TITLE
feat(generate): wire MTP speculative decode into offline generate

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -81,6 +81,10 @@ Measure with the `speculative_bench` harness or the server:
 mlxcel serve -m <target> --draft-model <drafter> --draft-kind mtp
 ```
 
+The offline `mlxcel generate` command also supports the MTP round-loop path (issue #166) for Gemma 4 text, VLM, and Unified targets. Pass `--draft-model <drafter> --draft-kind mtp` explicitly; without `--draft-kind mtp` the command keeps the classic speculative path for backward compatibility even when the drafter auto-detects as MTP.
+
+Parity: at `temperature 0` with no repetition, frequency, presence, or DRY penalties, the offline MTP output matches the non-speculative path within the documented f16 / #203 batched-kernel jitter class (on some hardware, notably M1 Ultra, near-tie token choices can differ). When any sampling penalty is active, only the first bonus token samples from the penalized distribution; subsequent tokens in each verify window are accepted or rejected greedily, so non-greedy or penalized requests are not byte-identical to the non-speculative path. This matches the known limitation of the server burst path.
+
 ### Gemma 4 Unified (12B) + 4-bit assistant
 
 Measured on Apple M5 Max (128 GB) with `mlx-community/gemma-4-12b-it-4bit` as the

--- a/src/cli/speculative_args.rs
+++ b/src/cli/speculative_args.rs
@@ -86,6 +86,14 @@ pub struct SpeculativeArgs {
     /// classic non-MTP / non-DFlash `SpeculativeGenerator` path when a
     /// drafter is supplied without an explicit kind.
     ///
+    /// Parity note (offline `mlxcel generate` with `--draft-kind mtp`):
+    /// at temperature 0 with no sampling penalties the output matches the
+    /// non-speculative path (within the f16 / #203 jitter class). When any
+    /// repetition, frequency, presence, or DRY penalty is active, only the
+    /// first bonus token is penalized; subsequent tokens in each verify
+    /// window are greedy, so penalized requests are not byte-identical to
+    /// the non-speculative path.
+    ///
     /// Also read from `LLAMA_ARG_DRAFT_KIND` (and the mlxcel-native
     /// alias `MLXCEL_DRAFT_KIND`).
     #[arg(long = "draft-kind", env = "LLAMA_ARG_DRAFT_KIND", value_name = "KIND")]

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1154,7 +1154,7 @@ fn run_offline_mtp(
         .map_err(|e| anyhow!("MTP drafter bind failed: {e}"))?;
     println!("MTP drafter loaded and bound (block_size = {block_size}).");
 
-    // Inject the resolved token bias (CLI `--logit-bias` plus the model's
+    // Inject the resolved token bias (CLI `--lang-bias` plus the model's
     // reserved multimodal placeholder suppression from issue #350) into the
     // sampling config so the adapter applies the SAME bias the non-speculative
     // `CxxGenerator` path applies via `with_token_bias`. This is what keeps the

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1171,7 +1171,7 @@ fn run_offline_mtp(
     // Select the per-target adapter exactly as the server does, then drive the
     // round loop. `seq_id = None` selects the wrapper's internal single-sequence
     // fallback slot, the documented offline / single-row CLI usage.
-    let (tokens, stats) = match model {
+    let (mut tokens, mut stats) = match model {
         LoadedModel::Gemma4(wrapper) => drive_offline_mtp(
             Gemma4MtpTargetAdapter::new_with_block_size(wrapper, None, block_size),
             drafter,
@@ -1204,7 +1204,43 @@ fn run_offline_mtp(
         _ => unreachable!("non-MTP-capable target rejected by the variant gate above"),
     };
 
+    // issue #166: strip the terminal EOS / stop token so the offline MTP output
+    // is byte-identical to the non-speculative `mlxcel generate` path. The
+    // `MtpGenerator` pushes a token onto its `emitted` vec and THEN checks EOS,
+    // so its returned vector includes the terminal stop token. Both reference
+    // paths exclude it: `CxxGenerator::generate` breaks on EOS BEFORE pushing,
+    // and the server burst `finalize_burst_success` does the same. Without this,
+    // `decode_generated_text` (which decodes with skip_special_tokens = false)
+    // would render the leaked stop token (e.g. `<end_of_turn>`) and inflate the
+    // printed generated-token count by one. Use the SAME merged EOS set the
+    // generator used: the target's eos ids plus the sampling `stop_token_ids`.
+    let eos_tokens = merged_eos_token_ids(target_lm.eos_token_ids(), &sampling.stop_token_ids);
+    tokens = strip_trailing_eos(tokens, &eos_tokens);
+
+    // Realign the stats with the stripped output so the printed
+    // "[Generated N tokens ...]" line and tok/s match the non-speculative path,
+    // which counts EOS-excluded tokens.
+    stats.generated_tokens = tokens.len();
+    stats.decode_tok_per_sec = if stats.decode_time_ms > 0.0 {
+        tokens.len() as f64 / (stats.decode_time_ms / 1000.0)
+    } else {
+        0.0
+    };
+
     Ok((tokens, stats))
+}
+
+/// Truncate `tokens` at the first EOS / stop token so the returned vector
+/// excludes the terminal stop token, matching `CxxGenerator::generate` and the
+/// server burst `finalize_burst_success` (issue #166). The `MtpGenerator` never
+/// emits tokens after an EOS, so truncating at the first occurrence is
+/// equivalent to (and more robust than) dropping only a trailing one. An empty
+/// `eos_tokens` set is a no-op.
+fn strip_trailing_eos(mut tokens: Vec<i32>, eos_tokens: &[i32]) -> Vec<i32> {
+    if let Some(pos) = tokens.iter().position(|t| eos_tokens.contains(t)) {
+        tokens.truncate(pos);
+    }
+    tokens
 }
 
 /// Parse the `--surgery <FILE>` YAML configuration when supplied and

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -53,7 +53,7 @@ use mlxcel_core::sampling::{TokenBiasMap, sample_token_optimized};
 
 use mlxcel::cli::speculative_args::resolve_draft_block_size;
 use mlxcel::cli::turbo_args::resolve_kv_cache_mode;
-use mlxcel_core::drafter::{DrafterKind, resolve_drafter_kind};
+use mlxcel_core::drafter::{DrafterKind, load_drafter, resolve_drafter_kind};
 
 use super::generate_vlm;
 use crate::GenerateArgs;
@@ -839,8 +839,15 @@ fn generate_with_embeddings<M: LanguageModel>(
     ))
 }
 
-fn run_generation_mode<M: LanguageModel>(
-    model: &M,
+// Takes a concrete `&LoadedModel` (rather than a generic `M: LanguageModel`)
+// so the `--draft-kind mtp` branch can match the target's family and select the
+// matching per-target `MtpTarget` adapter (issue #166). Every inner call
+// (`generate_standard`, `generate_with_embeddings`, `SpeculativeGenerator::generate`)
+// stays generic over `LanguageModel`; `LoadedModel` implements that trait, so
+// the monomorphized code for the non-MTP paths is identical to the prior generic
+// form. The sole caller already passes `&LoadedModel`.
+fn run_generation_mode(
+    model: &mlxcel::LoadedModel,
     args: &GenerateArgs,
     prompt_tokens: &[i32],
     sampling_config: &SamplingConfig,
@@ -877,6 +884,34 @@ fn run_generation_mode<M: LanguageModel>(
         let block_size = resolve_draft_block_size(args.speculative.draft_block_size, resolved_kind);
         let user_requested_explicit_kind = explicit_kind.is_some();
 
+        // issue #166: when the operator explicitly passes `--draft-kind mtp`,
+        // drive the kind-specific `MtpGenerator` round loop here, reusing the
+        // SAME per-target `MtpTarget` adapters the server burst path uses
+        // (`src/models/gemma4_mtp_target.rs`). This runs BEFORE
+        // `load_model(draft_model_path)` because an MTP assistant is loaded as a
+        // `Drafter` (via `load_drafter`), not as a full `LoadedModel`. DFlash /
+        // InternalMtp explicit kinds and the auto-detect classic path are
+        // untouched and fall through below.
+        if should_route_offline_mtp(user_requested_explicit_kind, resolved_kind) {
+            if vlm_embeddings.is_some() {
+                return Err(anyhow!(
+                    "--draft-kind mtp does not support multimodal (image / audio / \
+                     video) input in the offline `mlxcel generate` path; rerun with \
+                     a text-only prompt, or omit --draft-model for multimodal \
+                     generation"
+                ));
+            }
+            return run_offline_mtp(
+                model,
+                draft_model_path,
+                prompt_tokens,
+                args.generation.max_tokens,
+                sampling_config,
+                block_size as usize,
+                token_bias,
+            );
+        }
+
         println!("Loading draft model from {:?}...", draft_model_path);
         let (draft_model, _draft_tokenizer) = load_model(draft_model_path)?;
         println!("Draft model loaded.");
@@ -890,20 +925,15 @@ fn run_generation_mode<M: LanguageModel>(
             },
         );
 
-        // when the operator explicitly opted into MTP /
-        // DFlash via `--draft-kind`, we MUST dispatch to the kind-specific
-        // generator. The concrete `MtpGenerator<T>` / `DFlashGenerator`
-        // round loops are wired in sub-6 and sub-12,
-        // respectively, but those round loops require model-specific
-        // `MtpTarget` / `SpeculativeTarget` impls that this offline CLI
-        // path does not yet provide. Surface a clear, actionable error
-        // that names the responsible sub-issue so an operator who passed
-        // `--draft-kind mtp` doesn't silently fall back to the classic
-        // path and miss the perf they were trying to validate. When
-        // `--draft-kind` was unset (auto-detect resolved to a kind),
-        // we instead log an info line and keep the classic path so the
-        // default `--draft-model some/dflash-drafter` workflow remains
-        // backward-compatible.
+        // MTP is handled above (issue #166). The remaining explicit kinds
+        // (DFlash, InternalMtp) still need their kind-specific round loops and
+        // per-target `SpeculativeTarget` impls wired into this offline path, so
+        // surface a clear, actionable error that names the responsible follow-up
+        // rather than silently falling back to the classic path (which would
+        // miss the perf the operator asked for). When `--draft-kind` was unset
+        // (auto-detect resolved to a kind), we instead log an info line and keep
+        // the classic path so the default `--draft-model some/dflash-drafter`
+        // workflow remains backward-compatible.
         if user_requested_explicit_kind {
             return Err(anyhow!(
                 "--draft-kind {kind} is plumbed end-to-end but \
@@ -986,6 +1016,195 @@ fn run_generation_mode<M: LanguageModel>(
     };
 
     Ok(output)
+}
+
+/// Routing gate for the offline MTP speculative path (issue #166).
+///
+/// Returns `true` only when the operator explicitly passed `--draft-kind mtp`
+/// (an auto-detected MTP shape with no explicit flag keeps the classic
+/// `SpeculativeGenerator` path for backward compatibility, matching the prior
+/// behavior). DFlash / InternalMtp explicit kinds return `false` and fall
+/// through to the deferred-error branch. Extracted as a pure function so the
+/// loop-construction decision is unit-testable without loading a model.
+fn should_route_offline_mtp(
+    user_requested_explicit_kind: bool,
+    resolved_kind: DrafterKind,
+) -> bool {
+    user_requested_explicit_kind && resolved_kind == DrafterKind::Mtp
+}
+
+/// Drive a constructed [`mlxcel_core::speculative::mtp::target::MtpTarget`]
+/// adapter through the [`mlxcel_core::speculative::mtp::MtpGenerator`] round
+/// loop and return the emitted tokens plus timing stats.
+///
+/// Mirrors the server burst driver
+/// (`src/server/batch/speculative_burst.rs::drive_mtp_generator`) minus the
+/// drafter-recovery / adaptive-policy bookkeeping the offline single-shot path
+/// does not need. The cooperative-cancel flag is always clear offline (there is
+/// no client to disconnect mid-generation) and logprob capture is disabled (the
+/// CLI prints decoded text, not per-token logprobs).
+fn drive_offline_mtp<T>(
+    adapter: T,
+    drafter: Box<dyn mlxcel_core::drafter::Drafter>,
+    prompt_tokens: &[i32],
+    max_tokens: usize,
+    sampling: &SamplingConfig,
+    token_history: &[i32],
+    block_size: usize,
+) -> (Vec<i32>, GenerationStats)
+where
+    T: mlxcel_core::speculative::mtp::target::MtpTarget,
+{
+    use std::sync::atomic::AtomicBool;
+
+    use mlxcel_core::sampling::LogprobsConfig;
+    use mlxcel_core::speculative::mtp::MtpGenerator;
+
+    let logprobs = LogprobsConfig::default();
+    let cancel = AtomicBool::new(false);
+    let mut generator = MtpGenerator::new(adapter, drafter, block_size);
+    let (tokens, _logprobs, stats) = generator.generate(
+        prompt_tokens,
+        max_tokens,
+        sampling,
+        token_history,
+        &cancel,
+        &logprobs,
+    );
+    (tokens, stats)
+}
+
+/// Construct and drive the MTP speculative round loop for the offline
+/// `mlxcel generate` path (issue #166).
+///
+/// Reuses the exact per-target adapters the server burst path selects
+/// (`src/models/gemma4_mtp_target.rs`) and the same `MtpGenerator` round-loop
+/// driver, so the offline path is byte-identical to the server's speculative
+/// output at temperature 0 and identical to the non-speculative offline path
+/// for the same target / prompt / `-n` (the MTP greedy-parity invariant: the
+/// loop accepts exactly the tokens the target would have produced greedily).
+///
+/// The drafter is loaded through [`load_drafter`] (an MTP assistant is a
+/// `Drafter`, not a full `LoadedModel`), compatibility-checked, then bound to
+/// the SAME concrete target the adapter wraps BEFORE the generator runs.
+/// [`MtpGenerator::generate`] does not bind internally, so the bind here is
+/// load-bearing: without it the first `draft_block` returns
+/// `DrafterError::BindNotCalled` and the loop emits only the seed bonus.
+///
+/// A target that is not MTP-capable returns a clear error instead of silently
+/// falling back, matching the issue's contract.
+fn run_offline_mtp(
+    model: &mlxcel::LoadedModel,
+    draft_model_path: &Path,
+    prompt_tokens: &[i32],
+    max_tokens: usize,
+    sampling_config: &SamplingConfig,
+    block_size: usize,
+    token_bias: TokenBiasMap,
+) -> Result<(Vec<i32>, GenerationStats)> {
+    use mlxcel::LoadedModel;
+    use mlxcel::models::gemma4_mtp_target::{
+        Gemma4MtpTargetAdapter, Gemma4UnifiedMtpTargetAdapter, Gemma4VLMtpTargetAdapter,
+    };
+
+    if block_size < 2 {
+        return Err(anyhow!(
+            "--draft-kind mtp with block_size={block_size} produces no draft \
+             proposals (need >= 2); pass --draft-block-size with a value >= 2"
+        ));
+    }
+
+    // Resolve the concrete target reference the drafter binds to, and reject any
+    // non-MTP-capable target. Mirrors the server burst dispatch
+    // (`run_mtp_burst`): bind to the same concrete Gemma 4 model the adapter
+    // wraps below. VLM / Unified wrappers expose their text backbone through the
+    // `LanguageModel` impl, so the compat check / bind see the text hidden size
+    // and vocab the assistant was trained against.
+    let target_lm: &dyn LanguageModel = match model {
+        LoadedModel::Gemma4(wrapper) => wrapper as &dyn LanguageModel,
+        LoadedModel::Gemma4VLM(vlm) => vlm as &dyn LanguageModel,
+        LoadedModel::Gemma4Unified(unified) => unified as &dyn LanguageModel,
+        _ => {
+            return Err(anyhow!(
+                "--draft-kind mtp is only supported for Gemma 4 (text, VLM, or \
+                 Unified) targets; the loaded target is not MTP-capable. Omit \
+                 --draft-kind to use the classic SpeculativeGenerator with your \
+                 --draft-model drafter."
+            ));
+        }
+    };
+
+    println!("Loading MTP drafter from {:?}...", draft_model_path);
+    let (mut drafter, kind) = load_drafter(draft_model_path, Some(DrafterKind::Mtp))
+        .map_err(|e| anyhow!("MTP drafter load failed: {e}"))?;
+    if kind != DrafterKind::Mtp {
+        return Err(anyhow!(
+            "drafter at {draft_model_path:?} did not resolve to an MTP drafter \
+             (got {kind})"
+        ));
+    }
+
+    // Compatibility gate BEFORE binding (rejects a mismatched
+    // backbone-hidden-size / vocab pairing), then bind.
+    drafter
+        .validate_target_compat(target_lm)
+        .map_err(|e| anyhow!("MTP drafter incompatible with target: {e}"))?;
+    drafter
+        .bind(target_lm)
+        .map_err(|e| anyhow!("MTP drafter bind failed: {e}"))?;
+    println!("MTP drafter loaded and bound (block_size = {block_size}).");
+
+    // Inject the resolved token bias (CLI `--logit-bias` plus the model's
+    // reserved multimodal placeholder suppression from issue #350) into the
+    // sampling config so the adapter applies the SAME bias the non-speculative
+    // `CxxGenerator` path applies via `with_token_bias`. This is what keeps the
+    // temp-0 output byte-identical to the non-speculative path: the adapter's
+    // `prefill_and_seed` / `verify_forward` read `sampler.token_bias`.
+    let mut sampling = sampling_config.clone();
+    sampling.token_bias = token_bias;
+
+    // History-dependent-penalty context for the first-bonus sample (mirrors the
+    // server burst path and the classic decode path's first-token seed). Empty
+    // when no repetition / frequency / presence / DRY penalty is configured.
+    let token_history = initial_token_history(prompt_tokens, sampling.needs_token_history());
+
+    // Select the per-target adapter exactly as the server does, then drive the
+    // round loop. `seq_id = None` selects the wrapper's internal single-sequence
+    // fallback slot, the documented offline / single-row CLI usage.
+    let (tokens, stats) = match model {
+        LoadedModel::Gemma4(wrapper) => drive_offline_mtp(
+            Gemma4MtpTargetAdapter::new_with_block_size(wrapper, None, block_size),
+            drafter,
+            prompt_tokens,
+            max_tokens,
+            &sampling,
+            &token_history,
+            block_size,
+        ),
+        LoadedModel::Gemma4VLM(vlm) => drive_offline_mtp(
+            Gemma4VLMtpTargetAdapter::new_with_block_size(vlm, None, block_size),
+            drafter,
+            prompt_tokens,
+            max_tokens,
+            &sampling,
+            &token_history,
+            block_size,
+        ),
+        LoadedModel::Gemma4Unified(unified) => drive_offline_mtp(
+            Gemma4UnifiedMtpTargetAdapter::new_with_block_size(unified, None, block_size),
+            drafter,
+            prompt_tokens,
+            max_tokens,
+            &sampling,
+            &token_history,
+            block_size,
+        ),
+        // Unreachable: the variant gate above already returned an error for any
+        // non-MTP-capable target. Kept for match exhaustiveness.
+        _ => unreachable!("non-MTP-capable target rejected by the variant gate above"),
+    };
+
+    Ok((tokens, stats))
 }
 
 /// Parse the `--surgery <FILE>` YAML configuration when supplied and

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -15,13 +15,38 @@
 use super::{
     apply_user_chat_template, cli_pipeline_requested, estimate_delta_label_and_bytes,
     generated_suffix, generation_stats_from_duration, memory_preflight_ctx_len,
-    resolve_cli_pipeline_assignments, resolve_cli_prompt, validate_pipeline_parallel_args,
-    validate_tensor_parallel_args,
+    resolve_cli_pipeline_assignments, resolve_cli_prompt, should_route_offline_mtp,
+    validate_pipeline_parallel_args, validate_tensor_parallel_args,
 };
 use mlxcel::server::chat_template::ChatTemplateProcessor;
+use mlxcel_core::drafter::DrafterKind;
 use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
+
+// issue #166: the offline MTP loop is constructed only when the operator
+// explicitly passes `--draft-kind mtp`. An auto-detected MTP shape (no explicit
+// flag) keeps the classic SpeculativeGenerator path, and DFlash / InternalMtp
+// explicit kinds fall through to the deferred-error branch. These pins guard the
+// routing decision without loading a model.
+#[test]
+fn should_route_offline_mtp_only_for_explicit_mtp() {
+    assert!(should_route_offline_mtp(true, DrafterKind::Mtp));
+}
+
+#[test]
+fn should_route_offline_mtp_rejects_auto_detected_mtp() {
+    // Auto-detect resolved to MTP but no explicit `--draft-kind`: stay on the
+    // classic path for backward compatibility.
+    assert!(!should_route_offline_mtp(false, DrafterKind::Mtp));
+}
+
+#[test]
+fn should_route_offline_mtp_rejects_other_explicit_kinds() {
+    assert!(!should_route_offline_mtp(true, DrafterKind::Dflash));
+    assert!(!should_route_offline_mtp(true, DrafterKind::InternalMtp));
+    assert!(!should_route_offline_mtp(false, DrafterKind::Dflash));
+}
 
 #[test]
 fn generation_stats_from_duration_uses_elapsed_time_for_decode_rate() {

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -16,7 +16,7 @@ use super::{
     apply_user_chat_template, cli_pipeline_requested, estimate_delta_label_and_bytes,
     generated_suffix, generation_stats_from_duration, memory_preflight_ctx_len,
     resolve_cli_pipeline_assignments, resolve_cli_prompt, should_route_offline_mtp,
-    validate_pipeline_parallel_args, validate_tensor_parallel_args,
+    strip_trailing_eos, validate_pipeline_parallel_args, validate_tensor_parallel_args,
 };
 use mlxcel::server::chat_template::ChatTemplateProcessor;
 use mlxcel_core::drafter::DrafterKind;
@@ -46,6 +46,38 @@ fn should_route_offline_mtp_rejects_other_explicit_kinds() {
     assert!(!should_route_offline_mtp(true, DrafterKind::Dflash));
     assert!(!should_route_offline_mtp(true, DrafterKind::InternalMtp));
     assert!(!should_route_offline_mtp(false, DrafterKind::Dflash));
+}
+
+// issue #166: the offline MTP loop must exclude the terminal EOS / stop token so
+// its output is byte-identical to the non-speculative `mlxcel generate` path,
+// which breaks on EOS BEFORE pushing. `strip_trailing_eos` enforces that without
+// loading a model.
+#[test]
+fn strip_trailing_eos_drops_terminal_stop_token() {
+    // Common temp-0 case: the generator leaked the terminal EOS at the end.
+    let tokens = vec![10, 20, 30, 2];
+    assert_eq!(strip_trailing_eos(tokens, &[2]), vec![10, 20, 30]);
+}
+
+#[test]
+fn strip_trailing_eos_leaves_output_without_eos_unchanged() {
+    // max_tokens stop (no EOS emitted): nothing to strip.
+    let tokens = vec![10, 20, 30];
+    assert_eq!(strip_trailing_eos(tokens, &[2]), vec![10, 20, 30]);
+}
+
+#[test]
+fn strip_trailing_eos_first_token_eos_yields_empty() {
+    // EOS as the only / first token truncates to an empty output, mirroring the
+    // server breaking at the first EOS occurrence.
+    assert_eq!(strip_trailing_eos(vec![2], &[2]), Vec::<i32>::new());
+    assert_eq!(strip_trailing_eos(vec![2, 10, 20], &[2]), Vec::<i32>::new());
+}
+
+#[test]
+fn strip_trailing_eos_empty_eos_set_is_noop() {
+    let tokens = vec![10, 20, 2, 30];
+    assert_eq!(strip_trailing_eos(tokens, &[]), vec![10, 20, 2, 30]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Wire the MTP speculative-decoding round loop into the offline `mlxcel generate` path. Previously `--draft-kind mtp` returned a deferred error for every target in the offline CLI; speculative decode only ran in the server burst path. The offline path now constructs and drives the same `MtpGenerator` round loop the server uses, reusing the same per-target `MtpTarget` adapters (`src/models/gemma4_mtp_target.rs`), so a one-shot CLI user gets the MTP speedup without standing up a server.

## What changed

- `src/commands/generate.rs`: `run_generation_mode` now takes a concrete `&LoadedModel` instead of a generic `M: LanguageModel`, so the `--draft-kind mtp` branch can match the target family and select the matching adapter. The sole caller already passes `&LoadedModel`, and every inner call (`generate_standard`, `generate_with_embeddings`, `SpeculativeGenerator::generate`) stays generic over `LanguageModel` (which `LoadedModel` implements), so the non-MTP monomorphized code is unchanged.
- New `run_offline_mtp`: resolves the concrete Gemma 4 target (text / VLM / Unified) the same way the server's `run_mtp_burst` does, loads the assistant via `load_drafter` (an MTP assistant is a `Drafter`, not a full `LoadedModel`), runs the compat check, binds the drafter to the same concrete target the adapter wraps (load-bearing: `MtpGenerator::generate` does not bind internally), then selects `Gemma4MtpTargetAdapter` / `Gemma4VLMtpTargetAdapter` / `Gemma4UnifiedMtpTargetAdapter` and drives the loop through `drive_offline_mtp`.
- Byte-identical parity: the resolved token bias (CLI `--logit-bias` plus the issue #350 multimodal-placeholder suppression that `run_generation_mode` already merges) is injected into `SamplingConfig.token_bias` so the adapter applies the SAME bias the non-speculative `CxxGenerator` applies via `with_token_bias`. The first-bonus sample also seeds the same history-dependent-penalty `token_history` as the classic decode path.
- Clear errors, no silent fallback: a non-MTP-capable target returns an actionable error, and a multimodal (`--image` / `--audio` / `--video`) request under `--draft-kind mtp` is rejected with guidance, mirroring the server's multimodal decline.
- Pure routing gate `should_route_offline_mtp` keeps the loop-construction decision unit-testable without loading a model.
- `src/commands/generate_tests.rs`: three model-free unit tests pin the routing gate.

## Preserved paths

The explicit `--draft-kind dflash` / internal-mtp branches keep their existing deferred error, and the auto-detect classic `SpeculativeGenerator` path (no explicit `--draft-kind`) is byte-for-byte unchanged. Only the explicit `--draft-kind mtp` branch now builds the real loop.

## Test plan

- [x] `cargo check -p mlxcel --bin mlxcel --features metal,accelerate`
- [x] `cargo test -p mlxcel --bin mlxcel --features metal,accelerate should_route_offline_mtp` (3 passed)
- [x] `cargo clippy -p mlxcel --bin mlxcel --features metal,accelerate --tests -- -D warnings` (clean)
- [x] `cargo fmt -p mlxcel -- --check` (clean)
- [ ] Real-model validation (deferred to the orchestrator, needs the release binary + multi-GB checkpoints): byte-identical temp-0 output and decode speedup, see below.

## Orchestrator validation (real models)

MTP speculative run (12B Unified pair):

`./target/release/mlxcel generate -m models/gemma-4-12b-it-4bit --draft-model models/gemma-4-12b-it-assistant-4bit --draft-kind mtp -p "Explain Apple Silicon's unified memory architecture in one short paragraph." -n 128`

Non-speculative baseline (must be byte-identical at temp 0, which is the default):

`./target/release/mlxcel generate -m models/gemma-4-12b-it-4bit -p "Explain Apple Silicon's unified memory architecture in one short paragraph." -n 128`

Same pattern for the 31B pair (`models/gemma-4-31b-it-4bit` + `models/gemma-4-31b-it-assistant-bf16`). The speedup is `baseline decode tok/s` vs the MTP run. Note: per the #203 jitter class, temp-0 classic-vs-MTP can show occasional word-level near-tie flips on some hardware; that is the same jitter the server path exhibits, not a wiring defect.

Closes #166
