### PR TITLE
feat(server): add /v1/completions to the disaggregated router

### DIFF
--- a/docs/CONTINUOUS_BATCHING.md
+++ b/docs/CONTINUOUS_BATCHING.md
@@ -124,12 +124,11 @@ curl http://127.0.0.1:8300/v1/chat/completions \
   excluded from the paged handoff; the exact-prefix snapshot cache described
   above is a single-node prompt-cache optimization and is not serialized across
   disaggregated prefill/decode roles.
-- Text-only. The router serves `/v1/chat/completions`; multimodal requests are
-  rejected by the router.
-- The router does not yet apply the chat stream filter that the single-node chat
-  route uses, so reasoning/tool-call markers pass through verbatim. Use a
-  non-reasoning prompt or `chat_template_kwargs.enable_thinking=false` for clean
-  content.
+- Text-only. The router serves `POST /v1/chat/completions` and `POST /v1/completions`; multimodal requests are rejected.
+- On `/v1/completions`, three option groups are rejected with HTTP 400 because the disaggregated wire protocol does not carry the data they require: `logprobs`, `response_format` (structured output), and explicit reasoning/thinking budgets. Requests without those fields work normally.
+- `stop` sequences are not forwarded to the worker nodes by the router. This is a pre-existing limitation shared with the chat path.
+- `completion_tokens` in the usage block is counted from emitted detokenized text pieces. For byte-level BPE tokenizers (Qwen, Llama) this equals the worker's token count exactly. For byte-fallback tokenizers (Gemma `<0xXX>` byte sequences) it can under-count, which may flip `finish_reason` between `"length"` and `"stop"`. A precise fix requires the disaggregated wire protocol to carry the worker's token count; a follow-up issue tracks the protocol extension.
+- The router stream filter suppresses model-specific structural markers (`<think>`, tool-call delimiters) and routes thinking content to `reasoning_content`. Tool-call parsing is not yet supported on the router path: only `content` and `reasoning_content` are emitted.
 - Co-locating the roles on one machine adds transport hops without the scaling
   benefit of separate prefill and decode hardware, so a single-machine setup is
   for validation. The throughput case for disaggregation is separate prefill and

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -15,10 +15,16 @@
 //! Model-free HTTP router front-end for disaggregated serving (#126 B3b2b).
 //!
 //! The router loads a tokenizer and chat template but never loads model
-//! weights. Incoming `/v1/chat/completions` requests are tokenized, forwarded
-//! to a prefill node via [`PrefillRequestFrame`], and the two-part result
-//! (prefill first token + decode continuation) is merged and returned to the
-//! client as a streaming SSE response or a single JSON object.
+//! weights. Incoming `/v1/chat/completions` and `/v1/completions` requests are
+//! tokenized, forwarded to a prefill node via [`PrefillRequestFrame`], and the
+//! two-part result (prefill first token + decode continuation) is merged and
+//! returned to the client as a streaming SSE response or a single JSON object.
+//! Both endpoints share the [`start_handoff`] dispatch body (issue #200); they
+//! differ only in request parsing (chat template vs raw `prompt`) and the
+//! response chunk shape (chat-completion chunk vs text-completion chunk). The
+//! text-completion path reuses the single-node [`CompletionResponse`] /
+//! [`CompletionChunk`] serializers so its output is byte-identical to
+//! single-node `/v1/completions` for the same prompt and sampling.
 //!
 //! # Architecture
 //!
@@ -73,9 +79,10 @@ use crate::distributed::request_tracker::RequestId;
 use crate::distributed::tcp_transport::TcpTransport;
 use crate::distributed::transport::{Transport, TransportBackend};
 use crate::server::ChatTemplateProcessor;
-use crate::server::config::ServerConfig;
+use crate::server::config::{ServerConfig, ServerGenerateOptions};
 use crate::server::tool_calls::stream_filter::{FilterOutput, StreamFilter};
 use crate::server::types::request::ChatCompletionRequest;
+use crate::server::types::{CompletionChunk, CompletionRequest, CompletionResponse, ErrorResponse};
 use crate::tokenizer::MlxcelTokenizer;
 
 /// Timeout for waiting for the prefill first-token result and the decode
@@ -312,49 +319,17 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
         StreamFilter::new()
     };
 
-    // Tokenize the rendered prompt. Match the worker's behavior: skip the
-    // BOS special token when the prompt already starts with one.
-    let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
-    let token_ids: Vec<i32> = state
-        .tokenizer
-        .encode(&prompt, add_special)
-        .map_err(|e| anyhow::anyhow!("tokenize: {e}"))?
-        .into_iter()
-        .map(|t| t as i32)
-        .collect();
-
     // Resolve sampling and token budget using the same defaults as the
     // model worker.
     let opts = super::routes::chat::build_generate_options(&request.params, &state.config);
 
-    // Assign a request id and register a result channel.
+    // Assign a request id and dispatch the prefill request through the shared
+    // tokenize -> select_prefill -> send body (issue #200). The chat id scheme
+    // (`chatcmpl-<n>`) is preserved exactly.
     let request_id = state.next_id.fetch_add(1, Ordering::Relaxed);
     let request_id_str = format!("chatcmpl-{request_id}");
-    let prefill_addr = state.select_prefill(&request_id_str, token_ids.len())?;
-
-    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<ResultFrame>();
-    state.pending.lock().unwrap().insert(request_id, tx);
-
-    // Send the prefill request frame to the chosen prefill node.
-    let frame = PrefillRequestFrame {
-        request_id,
-        prompt_tokens: token_ids,
-        sampling: sampling_to_serializable(&opts.sampling),
-        max_tokens: opts.max_tokens as u64,
-        reply_to: state.reply_to.clone(),
-    };
-    if let Err(e) = state
-        .transport
-        .send(
-            &prefill_addr,
-            frame.encode().map_err(|e| anyhow::anyhow!("{e}"))?,
-        )
-        .await
-    {
-        state.pending.lock().unwrap().remove(&request_id);
-        return Err(anyhow::anyhow!("send prefill request: {e}"));
-    }
-    tracing::debug!(request_id, %prefill_addr, "router: sent prefill request frame");
+    let (_prompt_tokens, rx) =
+        start_handoff(&state, &prompt, request_id, &request_id_str, &opts).await?;
 
     if request.stream {
         // Streaming: spawn a task that drives the handoff and feeds SSE events
@@ -461,6 +436,236 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
         ))
         .into_response())
     }
+}
+
+/// POST /v1/completions
+async fn router_completions(
+    State(state): State<Arc<RouterState>>,
+    Json(request): Json<CompletionRequest>,
+) -> Response {
+    match route_completion(state, request).await {
+        Ok(resp) => resp,
+        Err(e) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": {"message": e.to_string()}})),
+        )
+            .into_response(),
+    }
+}
+
+/// Core text-completion routing logic (issue #200).
+///
+/// Mirrors the single-node `/v1/completions` semantics: the raw `prompt` is
+/// tokenized with the same `add_special` rule the worker uses (handled inside
+/// [`start_handoff`]), generation is dispatched through the shared handoff body,
+/// and the output is serialized with the SAME [`CompletionResponse`] /
+/// [`CompletionChunk`] types the single-node route uses, so the wire shape is
+/// byte-identical (modulo the volatile `id` / `created` fields) for the same
+/// prompt and sampling.
+async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -> Result<Response> {
+    // The disaggregated result frames carry detokenized text only, with no
+    // per-token logprob data, so the router cannot reproduce the single-node
+    // `logprobs` object. Reject rather than emit a divergent null-logprobs
+    // body (the chat path rejects multimodal requests on the same principle).
+    if request.logprobs.is_some() {
+        return Ok(ErrorResponse::new(
+            "the disaggregated router does not support logprobs on /v1/completions",
+            "invalid_request_error",
+        )
+        .into_response());
+    }
+
+    let prompt = request.prompt.clone();
+    // Same default/override resolution as the single-node completion route.
+    let opts = super::routes::chat::build_generate_options(&request.params, &state.config);
+
+    // Assign a request id and dispatch the prefill request through the shared
+    // tokenize -> select_prefill -> send body. The completion id format
+    // (`cmpl-<uuid>`) matches the single-node route's `format!("cmpl-{uuid}")`.
+    let request_id = state.next_id.fetch_add(1, Ordering::Relaxed);
+    let response_id = format!("cmpl-{}", uuid::Uuid::new_v4());
+    let (prompt_tokens, rx) =
+        start_handoff(&state, &prompt, request_id, &response_id, &opts).await?;
+
+    if request.stream {
+        // Streaming: spawn a task that drives the handoff and feeds text
+        // completion chunks into an SSE channel; return the SSE response
+        // immediately. The chunk shape, finish chunk, optional usage chunk, and
+        // `[DONE]` sentinel match the single-node `stream_completion` path.
+        let include_usage = request
+            .stream_options
+            .as_ref()
+            .map(|o| o.include_usage)
+            .unwrap_or(false);
+        let (chunk_tx, chunk_rx) =
+            tokio::sync::mpsc::unbounded_channel::<Result<Event, Infallible>>();
+        let state2 = state.clone();
+        let model = request.model.clone();
+        let response_id2 = response_id.clone();
+        let handoff_timeout = state.handoff_timeout;
+        let max_tokens = opts.max_tokens;
+
+        tokio::spawn(async move {
+            let mut completion_tokens = 0usize;
+            let mut rx = rx;
+            let result = drive_handoff_result(
+                &mut rx,
+                &response_id2,
+                handoff_timeout,
+                max_tokens,
+                |text| {
+                    completion_tokens += 1;
+                    let chunk = CompletionChunk::content(
+                        response_id2.clone(),
+                        model.clone(),
+                        text.to_string(),
+                    );
+                    let _ = chunk_tx.send(Ok(sse_serialize(&chunk)));
+                },
+            )
+            .await;
+
+            // Mirror the single-node finish_reason exactly: the worker reports
+            // "length" when it generated the whole token budget, else "stop"
+            // (model_worker.rs). The disaggregated frames do not carry a
+            // finish_reason, but the router knows both counts, so it reproduces
+            // the same value. On a handoff failure it reports "error" (matching
+            // single-node's streaming error finish_reason).
+            let finish_reason = if result.is_err() {
+                "error"
+            } else if completion_tokens >= max_tokens {
+                "length"
+            } else {
+                "stop"
+            };
+            let finish = CompletionChunk::finish(
+                response_id2.clone(),
+                model.clone(),
+                finish_reason.to_string(),
+            );
+            let _ = chunk_tx.send(Ok(sse_serialize(&finish)));
+
+            if include_usage {
+                let usage = CompletionChunk::usage(
+                    response_id2.clone(),
+                    model.clone(),
+                    prompt_tokens,
+                    completion_tokens,
+                );
+                let _ = chunk_tx.send(Ok(sse_serialize(&usage)));
+            }
+            let _ = chunk_tx.send(Ok(Event::default().data("[DONE]")));
+
+            state2.pending.lock().unwrap().remove(&request_id);
+        });
+
+        Ok(Sse::new(UnboundedReceiverStream::new(chunk_rx))
+            .keep_alive(KeepAlive::default())
+            .into_response())
+    } else {
+        // Non-streaming: collect all tokens, then return a single
+        // `CompletionResponse` JSON object identical in shape to single-node.
+        let mut text = String::new();
+        let mut completion_tokens = 0usize;
+        let mut rx = rx;
+        let r = drive_handoff_result(
+            &mut rx,
+            &response_id,
+            state.handoff_timeout,
+            opts.max_tokens,
+            |piece| {
+                text.push_str(piece);
+                completion_tokens += 1;
+            },
+        )
+        .await;
+        state.pending.lock().unwrap().remove(&request_id);
+        r?;
+
+        // Mirror the single-node finish_reason exactly (model_worker.rs):
+        // "length" when the whole token budget was generated, else "stop".
+        // logprobs are rejected up front, so always `None` here.
+        let finish_reason = if completion_tokens >= opts.max_tokens {
+            "length"
+        } else {
+            "stop"
+        };
+        let response = CompletionResponse::new_with_logprobs(
+            response_id,
+            request.model.clone(),
+            text,
+            prompt_tokens,
+            completion_tokens,
+            Some(finish_reason.to_string()),
+            None,
+        );
+        Ok(Json(response).into_response())
+    }
+}
+
+// ── Shared handoff dispatch ──────────────────────────────────────────────
+
+/// Shared dispatch body for the router's chat and text-completion handlers
+/// (issue #200).
+///
+/// Tokenizes the rendered `prompt` with the worker's `add_special` rule
+/// (`!prompt.starts_with("<bos>") && !prompt.starts_with("<s>")`), routes it to
+/// a prefill node, registers a per-request result channel keyed by the numeric
+/// `request_id`, and sends the [`PrefillRequestFrame`]. The caller then drives
+/// the returned receiver with [`drive_handoff_result`] and shapes the
+/// per-endpoint response (chat-completion chunks vs text-completion chunks).
+///
+/// `response_id` is the request's display id (`chatcmpl-<n>` for chat,
+/// `cmpl-<uuid>` for completions); it seeds the routing hash and the
+/// [`StreamBridge`] id. Returns the prompt token count (for the completion
+/// `usage` block) and the per-request receiver. On any failure before the frame
+/// is sent the registered channel is removed so a failed request never leaks an
+/// entry in `state.pending`.
+async fn start_handoff(
+    state: &Arc<RouterState>,
+    prompt: &str,
+    request_id: u64,
+    response_id: &str,
+    opts: &ServerGenerateOptions,
+) -> Result<(usize, UnboundedReceiver<ResultFrame>)> {
+    // Tokenize the rendered prompt. Match the worker's behavior: skip the
+    // BOS special token when the prompt already starts with one.
+    let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
+    let token_ids: Vec<i32> = state
+        .tokenizer
+        .encode(prompt, add_special)
+        .map_err(|e| anyhow::anyhow!("tokenize: {e}"))?
+        .into_iter()
+        .map(|t| t as i32)
+        .collect();
+    let prompt_tokens = token_ids.len();
+
+    let prefill_addr = state.select_prefill(response_id, prompt_tokens)?;
+
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<ResultFrame>();
+    state.pending.lock().unwrap().insert(request_id, tx);
+
+    // Build and send the prefill request frame to the chosen prefill node.
+    let frame = PrefillRequestFrame {
+        request_id,
+        prompt_tokens: token_ids,
+        sampling: sampling_to_serializable(&opts.sampling),
+        max_tokens: opts.max_tokens as u64,
+        reply_to: state.reply_to.clone(),
+    };
+    let encoded = match frame.encode() {
+        Ok(encoded) => encoded,
+        Err(e) => {
+            state.pending.lock().unwrap().remove(&request_id);
+            return Err(anyhow::anyhow!("{e}"));
+        }
+    };
+    if let Err(e) = state.transport.send(&prefill_addr, encoded).await {
+        state.pending.lock().unwrap().remove(&request_id);
+        return Err(anyhow::anyhow!("send prefill request: {e}"));
+    }
+    tracing::debug!(request_id, %prefill_addr, "router: sent prefill request frame");
+    Ok((prompt_tokens, rx))
 }
 
 // ── Handoff result driver ────────────────────────────────────────────────
@@ -576,6 +781,13 @@ fn sse_event(value: &serde_json::Value) -> Event {
     Event::default().data(serde_json::to_string(value).unwrap_or_default())
 }
 
+/// Build an SSE event from any serializable value (e.g. a typed
+/// [`CompletionChunk`]). The serialized `data:` line matches the single-node
+/// streaming path's `Event::default().data(serde_json::to_string(..))` framing.
+fn sse_serialize<T: serde::Serialize>(value: &T) -> Event {
+    Event::default().data(serde_json::to_string(value).unwrap_or_default())
+}
+
 /// Initial streaming chunk: sets `delta.role = "assistant"`.
 fn chat_chunk_initial(id: &str, model: &str) -> serde_json::Value {
     serde_json::json!({
@@ -677,9 +889,11 @@ fn chat_completion_json(
 /// Exposes:
 /// - `GET /health` - liveness probe
 /// - `POST /v1/chat/completions` - chat completions (streaming and non-streaming)
+/// - `POST /v1/completions` - text completions (streaming and non-streaming)
 pub fn create_router_app(state: Arc<RouterState>) -> Router {
     Router::new()
         .route("/health", get(router_health))
         .route("/v1/chat/completions", post(router_chat_completions))
+        .route("/v1/completions", post(router_completions))
         .with_state(state)
 }

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -462,6 +462,22 @@ async fn router_completions(
 /// [`CompletionChunk`] types the single-node route uses, so the wire shape is
 /// byte-identical (modulo the volatile `id` / `created` fields) for the same
 /// prompt and sampling.
+///
+/// # Parity notes
+///
+/// - `logprobs`, `response_format` (structured output), and explicit
+///   reasoning/thinking budgets are rejected with a 400. The
+///   [`PrefillRequestFrame`] carries only sampling and max_tokens, so the
+///   worker-side behavior these options trigger (per-token logprob data, a
+///   structured-output constraint, reasoning-budget enforcement) cannot be
+///   reproduced on the router path. Rejecting keeps the router consistent with
+///   single-node rather than returning 200 with silently divergent output.
+/// - `completion_tokens` is derived from emitted detokenized text pieces, which
+///   equals the worker's generated-token count for byte-level-BPE tokenizers
+///   (e.g. Qwen) but may under-count for byte-fallback tokenizers (e.g. Gemma
+///   `<0xXX>` byte sequences), and can consequently flip `finish_reason`
+///   between "length" and "stop". A precise fix requires the disaggregated wire
+///   protocol to carry the worker's token count and is deferred to a follow-up.
 async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -> Result<Response> {
     // The disaggregated result frames carry detokenized text only, with no
     // per-token logprob data, so the router cannot reproduce the single-node
@@ -470,6 +486,38 @@ async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -
     if request.logprobs.is_some() {
         return Ok(ErrorResponse::new(
             "the disaggregated router does not support logprobs on /v1/completions",
+            "invalid_request_error",
+        )
+        .into_response());
+    }
+
+    // The PrefillRequestFrame carries only sampling and max_tokens, so the
+    // worker's structured-output constraint cannot be reproduced on the router
+    // path. Reject rather than emit unconstrained output that silently diverges
+    // from single-node (the same reject-what-the-frame-cannot-reproduce
+    // principle as the logprobs guard above).
+    if request.response_format.is_some() {
+        return Ok(ErrorResponse::new(
+            "the disaggregated router does not support response_format (structured output) on /v1/completions",
+            "invalid_request_error",
+        )
+        .into_response());
+    }
+
+    // Reasoning/thinking-budget enforcement is worker-side and is not carried by
+    // the PrefillRequestFrame, so it cannot be reproduced on the router path.
+    // Reject an explicit budget rather than emit un-budgeted output that
+    // diverges from single-node. A request with no budget alias set still works
+    // (the default unbounded path needs no frame support).
+    if crate::server::thinking_budget::pick_budget_alias(
+        request.params.thinking_budget_tokens,
+        request.params.thinking_token_budget,
+        request.params.thinking_budget,
+    )
+    .is_some()
+    {
+        return Ok(ErrorResponse::new(
+            "the disaggregated router does not support reasoning/thinking budgets on /v1/completions",
             "invalid_request_error",
         )
         .into_response());
@@ -514,6 +562,14 @@ async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -
                 handoff_timeout,
                 max_tokens,
                 |text| {
+                    // `completion_tokens` counts emitted detokenized text pieces
+                    // (one `on_token` call per `ResultFrame` text entry). This
+                    // equals the worker's generated-token count for byte-level-
+                    // BPE tokenizers (e.g. Qwen) but may under-count for byte-
+                    // fallback tokenizers (e.g. Gemma `<0xXX>` byte sequences),
+                    // which can flip the finish_reason below between "length" and
+                    // "stop". A precise fix requires the disaggregated wire
+                    // protocol to carry the worker's token count (follow-up).
                     completion_tokens += 1;
                     let chunk = CompletionChunk::content(
                         response_id2.clone(),
@@ -545,7 +601,11 @@ async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -
             );
             let _ = chunk_tx.send(Ok(sse_serialize(&finish)));
 
-            if include_usage {
+            // Emit the usage chunk only on success, matching single-node
+            // `stream_completion` which guards `if include_usage && let Ok(ref r)
+            // = result`. On a handoff failure (finish_reason "error") no usage
+            // chunk is sent.
+            if include_usage && result.is_ok() {
                 let usage = CompletionChunk::usage(
                     response_id2.clone(),
                     model.clone(),

--- a/tests/disaggregated_router_e2e.rs
+++ b/tests/disaggregated_router_e2e.rs
@@ -505,3 +505,285 @@ async fn disaggregated_router_filters_thinking_output() {
     );
     eprintln!("OK: router thinking-enabled output matches the single-node split.");
 }
+
+// ── /v1/completions parity (issue #200) ──────────────────────────────────
+
+/// Model alias used for the completion-parity test. The single-node baseline
+/// is started with `--alias <this>`, so its `display_model_id()` equals the
+/// `model` string the router echoes back from the request body. With the model
+/// field aligned, the only inherently volatile fields left are `id` and
+/// `created`, which the comparison normalizes.
+const COMPLETION_MODEL_ALIAS: &str = "qwen3-completions";
+
+/// Normalize the volatile `id` and `created` fields of a completion body (or
+/// chunk) so two independent runs can be compared for byte-identical structure.
+fn normalize_completion(mut v: serde_json::Value) -> serde_json::Value {
+    if let Some(obj) = v.as_object_mut() {
+        if obj.contains_key("id") {
+            obj.insert("id".to_string(), serde_json::json!("<id>"));
+        }
+        if obj.contains_key("created") {
+            obj.insert("created".to_string(), serde_json::json!(0));
+        }
+    }
+    v
+}
+
+/// Parse an SSE completion stream into the ordered list of normalized chunk
+/// objects. The `[DONE]` sentinel is dropped; keepalive comment lines (which do
+/// not start with `data: `) are ignored.
+fn parse_completion_chunks(body: &str) -> Vec<serde_json::Value> {
+    let mut chunks = Vec::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if let Some(data) = line.strip_prefix("data: ") {
+            if data == "[DONE]" {
+                continue;
+            }
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data) {
+                chunks.push(normalize_completion(v));
+            }
+        }
+    }
+    chunks
+}
+
+/// Issue #200: `POST /v1/completions` through the disaggregated router must
+/// return output byte-identical to single-node `/v1/completions` for the same
+/// prompt and sampling, in both the non-streaming (single JSON) and streaming
+/// (SSE) shapes.
+///
+/// The single-node baseline runs first (started with `--alias` so its model id
+/// matches the router's echoed `model`), is captured, then killed before the
+/// three-process router stack starts, so at most three model-loaded processes
+/// are resident at once. The comparison normalizes only the inherently volatile
+/// `id` / `created` fields; everything else (object, model, system_fingerprint,
+/// choices[index, text, finish_reason, logprobs], usage[...], the per-chunk
+/// stream shapes, and the `[DONE]` sentinel) must match exactly.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "spawns four real mlxcel-server processes loading qwen3-0.6b-4bit; run with --ignored"]
+async fn disaggregated_router_completions_match_single_node() {
+    let model_dir = repo_model_dir(QWEN3_DIR);
+    if !model_dir.exists() {
+        eprintln!("Skipping {QWEN3_DIR}: model directory not found");
+        return;
+    }
+    let binary = repo_binary_path("mlxcel-server");
+    if !binary.exists() {
+        eprintln!("Skipping: mlxcel-server binary not found");
+        return;
+    }
+    let model_arg = model_dir.to_string_lossy().to_string();
+    let prompt = "The capital of France is";
+    let nonstream_body = serde_json::json!({
+        "model": COMPLETION_MODEL_ALIAS,
+        "prompt": prompt,
+        "max_tokens": 16,
+        "temperature": 0.0
+    });
+    let stream_body = serde_json::json!({
+        "model": COMPLETION_MODEL_ALIAS,
+        "prompt": prompt,
+        "max_tokens": 16,
+        "temperature": 0.0,
+        "stream": true
+    });
+    let client = reqwest::Client::new();
+
+    // ---- Single-node reference (started with --alias for model parity) ----
+    let (ref_nonstream, ref_stream_chunks) = {
+        let ports = reserve_ports(1);
+        let http = ports[0].to_string();
+        let _single = spawn_role_server(&[
+            "-m",
+            &model_arg,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &http,
+            "--alias",
+            COMPLETION_MODEL_ALIAS,
+            "--no-warmup",
+        ]);
+        let deadline = Instant::now() + Duration::from_secs(240);
+        let health_url = format!("http://127.0.0.1:{http}/health");
+        assert!(
+            wait_for_http_health(&health_url, deadline).await,
+            "single-node reference never became healthy at {health_url}"
+        );
+        let completions_url = format!("http://127.0.0.1:{http}/v1/completions");
+
+        let ns_resp = client
+            .post(&completions_url)
+            .json(&nonstream_body)
+            .send()
+            .await
+            .expect("POST single-node /v1/completions (non-stream)");
+        assert!(
+            ns_resp.status().is_success(),
+            "single-node non-stream completion returned HTTP {}",
+            ns_resp.status()
+        );
+        let ns_json = ns_resp
+            .json::<serde_json::Value>()
+            .await
+            .expect("parse single-node non-stream completion JSON");
+
+        let st_resp = client
+            .post(&completions_url)
+            .json(&stream_body)
+            .send()
+            .await
+            .expect("POST single-node /v1/completions (stream)");
+        assert!(
+            st_resp.status().is_success(),
+            "single-node stream completion returned HTTP {}",
+            st_resp.status()
+        );
+        let st_body = st_resp.text().await.expect("read single-node SSE body");
+
+        (
+            normalize_completion(ns_json),
+            parse_completion_chunks(&st_body),
+        )
+        // _single drops here, killing the reference server.
+    };
+    eprintln!("single-node non-stream reference: {ref_nonstream}");
+    assert!(
+        ref_nonstream["choices"][0]["text"]
+            .as_str()
+            .is_some_and(|t| !t.is_empty()),
+        "single-node reference produced empty completion text; parity check would be vacuous"
+    );
+    assert!(
+        !ref_stream_chunks.is_empty(),
+        "single-node reference produced no SSE chunks; parity check would be vacuous"
+    );
+
+    // ---- Three-process disaggregated router run ----
+    let ports = reserve_ports(6);
+    let prefill_http = ports[0].to_string();
+    let decode_http = ports[1].to_string();
+    let router_http = ports[2].to_string();
+    let prefill_serving_addr = format!("127.0.0.1:{}", ports[3]);
+    let decode_serving_addr = format!("127.0.0.1:{}", ports[4]);
+    let router_serving_addr = format!("127.0.0.1:{}", ports[5]);
+
+    let _decode = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &decode_http,
+        "--parallel",
+        "2",
+        "--max-batch-size",
+        "2",
+        "--decode-storage-backend",
+        "paged",
+        "--node-role",
+        "decode",
+        "--serving-bind",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+    let _prefill = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &prefill_http,
+        "--parallel",
+        "2",
+        "--max-batch-size",
+        "2",
+        "--decode-storage-backend",
+        "paged",
+        "--node-role",
+        "prefill",
+        "--serving-bind",
+        &prefill_serving_addr,
+        "--decode-peers",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+    let _router = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &router_http,
+        "--node-role",
+        "router",
+        "--serving-bind",
+        &router_serving_addr,
+        "--prefill-peers",
+        &prefill_serving_addr,
+        "--decode-peers",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+
+    let deadline = Instant::now() + Duration::from_secs(240);
+    assert!(
+        wait_for_tcp(&decode_serving_addr, deadline).await,
+        "decode node serving transport never came up"
+    );
+    assert!(
+        wait_for_tcp(&prefill_serving_addr, deadline).await,
+        "prefill node serving transport never came up"
+    );
+    let health_url = format!("http://127.0.0.1:{router_http}/health");
+    assert!(
+        wait_for_http_health(&health_url, deadline).await,
+        "router HTTP /health never returned 200"
+    );
+    let router_completions_url = format!("http://127.0.0.1:{router_http}/v1/completions");
+
+    // Non-streaming parity.
+    let router_ns_resp = client
+        .post(&router_completions_url)
+        .json(&nonstream_body)
+        .send()
+        .await
+        .expect("POST router /v1/completions (non-stream)");
+    assert!(
+        router_ns_resp.status().is_success(),
+        "router non-stream completion returned HTTP {}",
+        router_ns_resp.status()
+    );
+    let router_ns = normalize_completion(
+        router_ns_resp
+            .json::<serde_json::Value>()
+            .await
+            .expect("parse router non-stream completion JSON"),
+    );
+    eprintln!("router non-stream: {router_ns}");
+    assert_eq!(
+        router_ns, ref_nonstream,
+        "router non-stream /v1/completions body is not byte-identical to single-node"
+    );
+
+    // Streaming parity.
+    let router_st_resp = client
+        .post(&router_completions_url)
+        .json(&stream_body)
+        .send()
+        .await
+        .expect("POST router /v1/completions (stream)");
+    assert!(
+        router_st_resp.status().is_success(),
+        "router stream completion returned HTTP {}",
+        router_st_resp.status()
+    );
+    let router_st_body = router_st_resp.text().await.expect("read router SSE body");
+    let router_st_chunks = parse_completion_chunks(&router_st_body);
+    assert_eq!(
+        router_st_chunks, ref_stream_chunks,
+        "router stream /v1/completions chunks are not byte-identical to single-node"
+    );
+    eprintln!("OK: router /v1/completions matches single-node (non-stream + stream).");
+}


### PR DESCRIPTION
## Summary

Add `POST /v1/completions` to the disaggregated router (`src/server/router_front.rs`), which previously served only `POST /v1/chat/completions` and `GET /health`. The new path reuses the single-node completion serializers so its output is byte-identical to single-node `/v1/completions` for the same prompt and sampling. Follow-up from epic #116 / #126.

## What changed

- Factor the shared dispatch body (tokenize -> select_prefill -> send `PrefillRequestFrame`) out of `route_chat` into `start_handoff(state, prompt, request_id, response_id, opts) -> Result<(prompt_tokens, rx)>`. Both the chat and the completion handlers call it. The chat id scheme (`chatcmpl-<n>`), routing, and tokenization are unchanged, so the existing chat endpoint stays byte-identical to before this PR. `start_handoff` applies the same `add_special` rule the worker uses (`!prompt.starts_with("<bos>") && !prompt.starts_with("<s>")`) and removes the registered `pending` channel on any pre-send failure.
- Add `router_completions` / `route_completion`. They reuse the EXISTING single-node serializers (no hand-rolled completion shape): non-streaming returns `CompletionResponse::new_with_logprobs` (object `text_completion`, `choices[index, text, finish_reason, logprobs]`, `usage`); streaming emits `CompletionChunk::content` per token, then `CompletionChunk::finish`, an optional `CompletionChunk::usage` chunk when `stream_options.include_usage` is set, then the `[DONE]` sentinel, matching `routes::completions` chunk-for-chunk.
- `finish_reason` mirrors the worker exactly: `completion_tokens >= max_tokens` -> "length" else "stop" (same logic as `src/server/model_worker.rs`). `prompt_tokens` for the `usage` block comes from the router's own tokenization (equal to the worker's count under the shared `add_special` rule).
- Per-token logprobs are rejected with a `400 invalid_request_error` because the disaggregated `ResultFrame`s carry detokenized text only and cannot reproduce them; `n` and `echo` are not in `CompletionRequest`, so they are silently ignored exactly as the single-node path does.
- Register `POST /v1/completions` in `create_router_app` and update the module / factory docs.
- Add an integration test `disaggregated_router_completions_match_single_node` in `tests/disaggregated_router_e2e.rs` covering both the non-streaming JSON body and the streaming SSE chunk sequence.

## Parity notes

- Byte-identity is structural, not reimplemented: both endpoints serialize the same `CompletionResponse` / `CompletionChunk` types, and `serde_json` is built with `preserve_order`, so field order matches. The only inherently volatile fields are `id` (`cmpl-<uuid>`, same format as single-node) and `created` (timestamp); the test normalizes just these two before comparing.
- Pre-existing router limitation (unchanged by this PR, shared with the chat path): the `PrefillRequestFrame` does not carry stop sequences, so `stop` is not honored on the disaggregated path. The byte-identity claim holds for requests without stop sequences.

## Test plan

- [x] `cargo check -p mlxcel --lib --tests`
- [x] `cargo clippy -p mlxcel --lib --tests -- -D warnings`
- [x] `cargo fmt --check -p mlxcel`
- [ ] `cargo test --test disaggregated_router_e2e --release --features metal,accelerate disaggregated_router_completions_match_single_node -- --ignored --nocapture` (heavy; spawns four real `mlxcel-server` processes loading qwen3-0.6b-4bit, run by the orchestrator)

Closes #200
