### PR TITLE
feat(router): drive multi-node disaggregated routing, health, and failover

### DIFF
--- a/docs/CONTINUOUS_BATCHING.md
+++ b/docs/CONTINUOUS_BATCHING.md
@@ -78,8 +78,39 @@ Networking flags:
 | Flag | Role | Purpose |
 |------|------|---------|
 | `--serving-bind <addr>` | prefill, decode, router | This node's own role-transport listener (`host:port`). |
-| `--decode-peers <addr,...>` | prefill, router | Decode node(s) a prefill node hands KV off to; routers also use these addresses for decode continuation routing. |
-| `--prefill-peers <addr,...>` | decode, router | Prefill node(s) accepted by a decode node and selected by a router. |
+| `--decode-peers <addr,...>` | prefill, router | On a router, the decode pool it balances; on a prefill node, the static fallback used only when the router does not pick a decode target for a request. |
+| `--prefill-peers <addr,...>` | decode, router | On a router, the prefill pool it balances; on a decode node, the prefill node(s) it accepts handoffs from. |
+
+### Multi-node routing, load balancing, and failover
+
+With more than one prefill or decode node, the router balances both pools
+(issue #201). For each request it picks a prefill node and, independently, a
+decode node, both round-robin across the nodes the registry currently considers
+online (the router has no live per-node load telemetry, so round-robin is the
+strategy that actually spreads load). The chosen decode node travels to the
+prefill node in the request frame's `decode_target` field, so the prefill node
+hands the KV cache to the router-balanced decode node rather than to its own
+`--decode-peers` config. The field is optional on the wire: a frame without it
+(an older router) leaves the prefill node on its config fallback, and an older
+prefill node ignores it and uses config, so mixed-version pools keep working.
+
+The router tracks node health and fails over without wedging:
+
+- A transport error when sending a request to a prefill node marks that node
+  unreachable, re-routes its in-flight requests, and retries the request on a
+  healthy node. When no prefill node is left, the request fails cleanly with an
+  error rather than hanging.
+- A background health monitor TCP-probes every peer's serving address on an
+  interval. A node that stops accepting connections is marked unreachable (so
+  routing skips it, including a dead decode node the router never sends to
+  directly), and a node that starts accepting again is restored to online.
+- Admission control runs before every dispatch: when the prefill queue is full
+  or no prefill node is available, the router returns HTTP 503 instead of
+  attempting a dispatch that cannot succeed.
+
+`GET /router/stats` reports the per-node dispatch counts for both pools, the
+registered nodes with their current health status, and the routing-metrics
+snapshot, so an operator can confirm the spread and see which nodes are down.
 
 The handoff transfers the paged block contents (not just metadata) over the
 transport, so the decode node reconstructs the exact KV the prefill node built;

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -136,6 +136,16 @@ request. `GET /router/stats` reports the per-node load spread and node health.
 See [continuous batching and disaggregated serving](CONTINUOUS_BATCHING.md#multi-node-routing-load-balancing-and-failover)
 for the flags and behavior.
 
+### Security and trust model
+
+The disaggregated role-transport connections (router to prefill, prefill to decode) carry no authentication or TLS, the same assumption the pipeline-parallelism transport already makes. The entire cluster, including the router's client-facing HTTP port and all internal role-transport ports, should run inside a trusted network segment or behind a network isolation boundary (VPC security group, firewall rule, or Kubernetes NetworkPolicy) that prevents untrusted callers from reaching the internal ports.
+
+Two specific operational notes for the multi-node routing surface:
+
+- `GET /router/stats` is mounted on the router's client-facing HTTP port and returns each registered peer's host:port address, current health status, and per-node request counts. This discloses internal cluster topology to any caller that can reach the router. Restrict the router's client port to the same trusted segment as the internal ports, or front the router with a reverse proxy that blocks `/router/stats` from external callers. The same trusted-segment assumption that already applies to the disaggregated transport covers this endpoint; no additional configuration is needed for a correctly segmented deployment.
+
+- A prefill node connects to the address in the `decode_target` field of the incoming request frame to deliver the KV cache handoff. Under the trusted-segment assumption this is safe: the router populates that field only from its own configured node registry, so the addresses are operator-controlled. A defense-in-depth allowlist (prefill nodes reject `decode_target` values outside their own `--decode-peers` set) is tracked as a follow-up.
+
 ## Common limitations
 
 - Distributed support is not uniform across model families.

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -125,6 +125,17 @@ The code shares the same cluster config, registry, transport, and metrics
 infrastructure as PP. Treat it as a topology-specific feature: run a live test
 with your traffic shape before publishing performance claims.
 
+A `--node-role router` front balances independent prefill and decode pools. It
+picks both the prefill node and the decode node per request (round-robin over
+the nodes the registry marks online), ships the chosen decode node to the
+prefill node in the request frame so the prefill hands off to the
+router-balanced decode node, marks unreachable peers down (via send-error
+detection and a background liveness probe) and fails over to healthy nodes, and
+applies admission control that returns HTTP 503 when no node can take the
+request. `GET /router/stats` reports the per-node load spread and node health.
+See [continuous batching and disaggregated serving](CONTINUOUS_BATCHING.md#multi-node-routing-load-balancing-and-failover)
+for the flags and behavior.
+
 ## Common limitations
 
 - Distributed support is not uniform across model families.

--- a/src/distributed/disaggregated/coordinator.rs
+++ b/src/distributed/disaggregated/coordinator.rs
@@ -298,7 +298,9 @@ impl ServingCoordinator {
 
             // Return the prefill node's first token to the client. When prefill
             // produced no handoff frame (immediate EOS), this first-token result
-            // is the entire stream, so mark it done.
+            // is the entire stream, so mark it done. A send failure here means
+            // the router/client went away; log and move to the next request
+            // rather than tearing down the worker loop that serves everyone.
             let first_result = ResultFrame {
                 request_id: request.request_id,
                 phase: ResultPhase::FirstToken,
@@ -307,29 +309,83 @@ impl ServingCoordinator {
                 done: done || frame.is_none(),
                 error,
             };
-            self.transport
+            if let Err(e) = self
+                .transport
                 .send(&request.reply_to, first_result.encode()?)
                 .await
-                .context("prefill role: return the first token to reply_to")?;
+            {
+                tracing::warn!(
+                    request_id = request.request_id,
+                    reply_to = %request.reply_to,
+                    "prefill role: failed to return the first token: {e}; dropping request"
+                );
+                continue;
+            }
 
-            // Forward the handoff to the decode peer: the coordination metadata
-            // first, then the KV frame (the decode loop reads them in that order).
+            // Forward the handoff to the decode node: the coordination metadata
+            // first, then the KV frame (the decode loop reads them in that
+            // order). The router picks the decode node and ships it in
+            // `decode_target` (issue #201); a frame without it (an older router)
+            // falls back to this node's statically configured `--decode-peers`
+            // peer. A handoff failure (e.g. a dead decode node) fails only this
+            // one request: the prefill loop logs it, tells the client so it does
+            // not wait for a continuation that never comes, and keeps serving the
+            // rest. The router's health monitor then marks the dead decode node
+            // down so later requests route elsewhere.
             if let Some(bytes) = frame {
+                let decode_peer = request
+                    .decode_target
+                    .as_deref()
+                    .filter(|addr| !addr.is_empty())
+                    .unwrap_or_else(|| self.peer())
+                    .to_string();
                 let meta = DecodeMetaFrame {
                     request_id: request.request_id,
                     max_tokens: request.max_tokens,
                     sampling: request.sampling,
-                    reply_to: request.reply_to,
+                    reply_to: request.reply_to.clone(),
                 };
-                self.transport
-                    .send(self.peer(), meta.encode()?)
-                    .await
-                    .context("prefill role: forward decode metadata to the decode peer")?;
-                self.send_handoff(&bytes)
-                    .await
-                    .context("prefill role: ship the KV handoff to the decode peer")?;
+                if let Err(e) = self.forward_handoff_to(&decode_peer, &meta, &bytes).await {
+                    tracing::warn!(
+                        request_id = request.request_id,
+                        decode_peer = %decode_peer,
+                        "prefill role: decode handoff failed: {e:#}; failing the request"
+                    );
+                    let err_result = ResultFrame {
+                        request_id: request.request_id,
+                        phase: ResultPhase::Continuation,
+                        tokens: Vec::new(),
+                        start_sequence: 0,
+                        done: true,
+                        error: Some(format!("decode handoff to {decode_peer} failed: {e}")),
+                    };
+                    let _ = self
+                        .transport
+                        .send(&request.reply_to, err_result.encode()?)
+                        .await;
+                }
             }
         }
+        Ok(())
+    }
+
+    /// Forward a request's decode handoff to a specific decode node: the
+    /// [`DecodeMetaFrame`] first, then the KV frame (the decode loop reads them
+    /// in that order). `decode_peer` is the router-chosen target (issue #201) or
+    /// this node's configured peer when the router did not specify one.
+    async fn forward_handoff_to(
+        &self,
+        decode_peer: &str,
+        meta: &DecodeMetaFrame,
+        bytes: &[u8],
+    ) -> Result<()> {
+        self.transport
+            .send(decode_peer, meta.encode()?)
+            .await
+            .context("prefill role: forward decode metadata to the decode node")?;
+        send_handoff_payload(&*self.transport, decode_peer, bytes)
+            .await
+            .context("prefill role: ship the KV handoff to the decode node")?;
         Ok(())
     }
 

--- a/src/distributed/disaggregated/request_router_tests.rs
+++ b/src/distributed/disaggregated/request_router_tests.rs
@@ -688,6 +688,142 @@ fn handle_node_failure_distributes_rerouted_requests() {
     );
 }
 
+// ── Router-driven decode selection (issue #201) ─────────────────────
+
+/// With round-robin decode routing (the strategy the router front uses), the
+/// router spreads decode selections across the decode pool instead of always
+/// picking the first node, so a router-chosen `decode_target` balances the
+/// decode pool just like the prefill pool.
+#[test]
+fn route_to_decode_round_robin_distributes_across_decode_nodes() {
+    let (registry, metrics, bp) = test_cluster();
+    let config = RouterConfig {
+        prefill_strategy: DisaggRoutingStrategy::RoundRobin,
+        decode_strategy: DisaggRoutingStrategy::RoundRobin,
+        ..Default::default()
+    };
+    let router = RequestRouter::new(config, registry, metrics, bp);
+
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for _ in 0..6 {
+        let req_id = RequestId::new();
+        router.route_to_prefill(req_id.clone(), 100).unwrap();
+        let decode = router.route_to_decode(&req_id).unwrap();
+        *counts.entry(decode).or_insert(0) += 1;
+    }
+
+    assert_eq!(
+        counts.len(),
+        2,
+        "expected both decode nodes used, got {counts:?}"
+    );
+    assert_eq!(counts.get("decode-0"), Some(&3));
+    assert_eq!(counts.get("decode-1"), Some(&3));
+}
+
+/// A prefill node marked `Unreachable` in the registry is skipped by
+/// `route_to_prefill`: all requests go to the surviving node. This is the
+/// registry-status mechanism the router front's transport-error path and health
+/// monitor drive.
+#[test]
+fn unreachable_prefill_node_is_skipped() {
+    let (registry, metrics, bp) = test_cluster();
+    registry.set_node_status("prefill-0", NodeStatus::Unreachable);
+    let config = RouterConfig {
+        prefill_strategy: DisaggRoutingStrategy::RoundRobin,
+        ..Default::default()
+    };
+    let router = RequestRouter::new(config, registry, metrics, bp);
+
+    for _ in 0..4 {
+        let req_id = RequestId::new();
+        let node = router.route_to_prefill(req_id, 100).unwrap();
+        assert_eq!(node, "prefill-1", "must skip the unreachable prefill node");
+    }
+}
+
+/// A decode node marked `Unreachable` is skipped by `route_to_decode`.
+#[test]
+fn unreachable_decode_node_is_skipped() {
+    let (registry, metrics, bp) = test_cluster();
+    registry.set_node_status("decode-0", NodeStatus::Unreachable);
+    let config = RouterConfig {
+        decode_strategy: DisaggRoutingStrategy::RoundRobin,
+        ..Default::default()
+    };
+    let router = RequestRouter::new(config, registry, metrics, bp);
+
+    for _ in 0..4 {
+        let req_id = RequestId::new();
+        router.route_to_prefill(req_id.clone(), 100).unwrap();
+        let decode = router.route_to_decode(&req_id).unwrap();
+        assert_eq!(decode, "decode-1", "must skip the unreachable decode node");
+    }
+}
+
+/// Admission control returns `Queue` when every prefill node is unreachable, so
+/// the router front rejects with HTTP 503 instead of attempting a doomed
+/// dispatch (issue #201). With at least one node available it returns `Accept`.
+#[test]
+fn apply_backpressure_queues_when_all_prefill_unreachable() {
+    let (registry, metrics, bp) = test_cluster();
+    let router = RequestRouter::new(RouterConfig::default(), registry.clone(), metrics, bp);
+
+    assert_eq!(router.apply_backpressure(), BackpressureAction::Accept);
+
+    registry.set_node_status("prefill-0", NodeStatus::Unreachable);
+    registry.set_node_status("prefill-1", NodeStatus::Unreachable);
+    assert_eq!(
+        router.apply_backpressure(),
+        BackpressureAction::Queue,
+        "all prefill nodes down must not be Accept"
+    );
+}
+
+/// The router-front failover sequence: send to a prefill node fails, so the
+/// node is marked unreachable and `handle_node_failure` re-routes its in-flight
+/// requests; a subsequent `route_to_prefill` then lands on the survivor. This
+/// is the unit-level mirror of `start_handoff`'s retry loop.
+#[test]
+fn failover_reroutes_to_survivor_after_marking_unreachable() {
+    let (registry, metrics, bp) = test_cluster();
+    let config = RouterConfig {
+        prefill_strategy: DisaggRoutingStrategy::RoundRobin,
+        ..Default::default()
+    };
+    let router = RequestRouter::new(config, registry.clone(), metrics, bp);
+
+    // First request lands on one of the two nodes (registry iteration order is
+    // not deterministic, so capture whichever it was rather than assuming).
+    let first = RequestId::new();
+    let failed_node = router.route_to_prefill(first.clone(), 100).unwrap();
+    let survivor = if failed_node == "prefill-0" {
+        "prefill-1"
+    } else {
+        "prefill-0"
+    };
+
+    // Simulate the send to the chosen node failing: mark it down and re-route.
+    registry.set_node_status(&failed_node, NodeStatus::Unreachable);
+    let (rerouted, failed) = router.handle_node_failure(&failed_node);
+    assert_eq!(
+        failed, 0,
+        "a healthy alternative exists, nothing should fail"
+    );
+    assert!(rerouted >= 1, "the in-flight request should be re-routed");
+
+    // The in-flight request must no longer point at the dead node.
+    let tracked = router.get_tracked_request(&first).unwrap();
+    assert_ne!(tracked.prefill_node.as_deref(), Some(failed_node.as_str()));
+
+    // Every fresh request now routes only to the survivor.
+    for _ in 0..3 {
+        let next = RequestId::new();
+        let node = router.route_to_prefill(next, 100).unwrap();
+        assert_eq!(node, survivor, "must route to the surviving node");
+    }
+}
+
 // ── Auto-purge on capacity ──────────────────────────────────────────
 
 #[test]

--- a/src/distributed/disaggregated/serving_protocol.rs
+++ b/src/distributed/disaggregated/serving_protocol.rs
@@ -80,6 +80,19 @@ pub struct PrefillRequestFrame {
     pub max_tokens: u64,
     /// Listener address (`host:port`) the nodes return [`ResultFrame`]s to.
     pub reply_to: String,
+    /// Router-chosen decode node (`host:port`) this prefill should hand the KV
+    /// cache off to (issue #201).
+    ///
+    /// When `Some`, the prefill node forwards the [`DecodeMetaFrame`] and KV
+    /// handoff to this address so the router balances the decode pool too.
+    /// When `None` (a frame from a router predating this field, decoded via
+    /// `serde(default)`), the prefill node falls back to its own statically
+    /// configured `--decode-peers` target. The optional encoding keeps an older
+    /// peer working: an old router omits the field and a new prefill falls back
+    /// to config; a new router populates it and an old prefill ignores the
+    /// unknown field and uses config.
+    #[serde(default)]
+    pub decode_target: Option<String>,
 }
 
 /// The per-request coordination metadata a prefill node forwards to a decode

--- a/src/distributed/disaggregated/serving_protocol_tests.rs
+++ b/src/distributed/disaggregated/serving_protocol_tests.rs
@@ -34,6 +34,7 @@ fn prefill_request_frame_round_trips_through_a_control_message() {
         sampling: sample_sampling(),
         max_tokens: 64,
         reply_to: "127.0.0.1:5555".to_string(),
+        decode_target: None,
     };
     let message = frame.encode().expect("encode prefill request");
     let (op, payload) = control_parts(message).expect("control parts");
@@ -45,6 +46,42 @@ fn prefill_request_frame_round_trips_through_a_control_message() {
     assert_eq!(decoded.prompt_tokens, vec![1, 2, 3, 42]);
     assert_eq!(decoded.max_tokens, 64);
     assert_eq!(decoded.reply_to, "127.0.0.1:5555");
+    assert_eq!(decoded.decode_target, None);
+}
+
+/// Issue #201: a router-chosen decode target round-trips through the frame so
+/// the prefill node forwards the KV handoff to the router-balanced decode node.
+#[test]
+fn prefill_request_frame_carries_router_chosen_decode_target() {
+    let frame = PrefillRequestFrame {
+        request_id: 9,
+        prompt_tokens: vec![5, 6],
+        sampling: sample_sampling(),
+        max_tokens: 16,
+        reply_to: "127.0.0.1:5555".to_string(),
+        decode_target: Some("127.0.0.1:7001".to_string()),
+    };
+    let message = frame.encode().expect("encode prefill request");
+    let (_op, payload) = control_parts(message).expect("control parts");
+    let decoded = PrefillRequestFrame::decode(&payload).expect("decode prefill request");
+    assert_eq!(decoded.decode_target.as_deref(), Some("127.0.0.1:7001"));
+}
+
+/// Issue #201: `decode_target` is `serde(default)` so a frame from a router
+/// predating the field (no `decode_target` key) decodes to `None`, and the
+/// prefill node falls back to its configured `--decode-peers` target.
+#[test]
+fn prefill_request_frame_decode_target_defaults_to_none() {
+    let payload = serde_json::json!({
+        "request_id": 4,
+        "prompt_tokens": [1, 2],
+        "sampling": sample_sampling(),
+        "max_tokens": 8,
+        "reply_to": "127.0.0.1:5555"
+    });
+    let decoded: PrefillRequestFrame =
+        serde_json::from_slice(&serde_json::to_vec(&payload).unwrap()).expect("decode");
+    assert_eq!(decoded.decode_target, None);
 }
 
 #[test]

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -50,6 +50,27 @@
 //! `tool_calls`) is NOT yet supported on the router path: the router emits
 //! `content` and `reasoning_content` only, and the filter suppresses
 //! tool-call delimiter markers.
+//!
+//! # Multi-node routing, health, and backpressure (issue #201)
+//!
+//! The router balances BOTH pools. It selects the prefill node with
+//! `route_to_prefill` and the decode node with `route_to_decode`, then ships the
+//! chosen decode node in [`PrefillRequestFrame`]'s `decode_target` so the prefill
+//! node hands the KV cache to the router-balanced decode node rather than its own
+//! static `--decode-peers` config (a frame without the field, from an older
+//! router, leaves the prefill node on its config fallback). Both pools use a
+//! round-robin strategy because the router has no live per-node load telemetry.
+//!
+//! Health and failover: a transport error when sending a prefill frame marks the
+//! node unreachable, re-routes its in-flight requests via `handle_node_failure`,
+//! and retries the request on a healthy node. A background [`spawn_health_monitor`]
+//! task probes every peer's liveness (TCP connect) so a dead decode node (which
+//! the router never sends to directly) is detected and skipped, and a recovered
+//! node is restored to online.
+//!
+//! Backpressure: every request first passes `apply_backpressure` admission
+//! control; when the prefill queue is full or no prefill node is available, the
+//! router returns HTTP 503 instead of dispatching.
 
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -70,8 +91,8 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use crate::distributed::backpressure::{BackpressureConfig, BackpressureMonitor};
 use crate::distributed::config::{ClusterConfig, ClusterMeta, NodeConfig, NodeResources, NodeRole};
 use crate::distributed::disaggregated::{
-    PrefillRequestFrame, RequestRouter, ResultFrame, RouterConfig, StreamBridge, TokenEvent,
-    TokenSource, control_parts, sampling_to_serializable,
+    BackpressureAction, DisaggRoutingStrategy, PrefillRequestFrame, RequestRouter, ResultFrame,
+    RouterConfig, StreamBridge, TokenEvent, TokenSource, control_parts, sampling_to_serializable,
 };
 use crate::distributed::metrics::ClusterMetrics;
 use crate::distributed::registry::{NodeRegistry, NodeStatus};
@@ -88,6 +109,14 @@ use crate::tokenizer::MlxcelTokenizer;
 /// Timeout for waiting for the prefill first-token result and the decode
 /// continuation from the serving nodes.
 const HANDOFF_TIMEOUT_SECS: u64 = 120;
+
+/// How often the background health monitor probes each registered serving peer
+/// for liveness (issue #201).
+const HEALTH_PROBE_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Per-probe TCP connect timeout for the health monitor. A peer that does not
+/// accept a connection within this window is treated as unreachable.
+const HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
 // ── Router state ─────────────────────────────────────────────────────────
 
@@ -119,6 +148,15 @@ pub struct RouterState {
     /// Prefill node addresses used as a fallback when the router returns an
     /// error (e.g. because all nodes appear loaded).
     pub prefill_fallback: Vec<SocketAddr>,
+
+    /// Per-node count of dispatched requests, keyed by prefill node id
+    /// (`prefill-<i>`). Exposed via `GET /router/stats` so an operator (and the
+    /// multi-node E2E) can see the load spread across the prefill pool.
+    pub prefill_hits: Mutex<HashMap<String, u64>>,
+
+    /// Per-node count of dispatched requests, keyed by decode node id
+    /// (`decode-<i>`). Exposed via `GET /router/stats`.
+    pub decode_hits: Mutex<HashMap<String, u64>>,
 
     /// Chat template processor for rendering the prompt.
     pub chat_template: Arc<ChatTemplateProcessor>,
@@ -190,8 +228,20 @@ impl RouterState {
             registry.set_node_status(&node.id, NodeStatus::Online);
         }
 
+        // The router has no live per-node load or memory telemetry from the
+        // worker pools, so the load-aware strategies (least-loaded /
+        // memory-aware) would all collapse to "pick the first node" and never
+        // balance. Round-robin is the strategy that actually spreads requests
+        // across both pools with only the registry's online/offline view, which
+        // is exactly what the router has. It picks both the prefill node and the
+        // router-chosen decode node (issue #201).
+        let router_config = RouterConfig {
+            prefill_strategy: DisaggRoutingStrategy::RoundRobin,
+            decode_strategy: DisaggRoutingStrategy::RoundRobin,
+            ..RouterConfig::default()
+        };
         let request_router = RequestRouter::new(
-            RouterConfig::default(),
+            router_config,
             registry.clone(),
             ClusterMetrics::new(),
             BackpressureMonitor::new(BackpressureConfig::default()),
@@ -207,6 +257,8 @@ impl RouterState {
             router: request_router,
             registry,
             prefill_fallback,
+            prefill_hits: Mutex::new(HashMap::new()),
+            decode_hits: Mutex::new(HashMap::new()),
             chat_template,
             tokenizer,
             config,
@@ -214,25 +266,92 @@ impl RouterState {
         })
     }
 
-    /// Resolve the prefill node address for a new request.
+    /// Select a prefill node for a request, returning both its registry id (when
+    /// the router picked one) and the address to send the frame to.
     ///
-    /// Tries the [`RequestRouter`] first; falls back to the first entry in
-    /// `prefill_fallback` on routing errors.
-    fn select_prefill(&self, request_id_str: &str, prompt_len: usize) -> Result<String> {
-        let rid = RequestId::from_string(request_id_str.to_string()).unwrap_or_default();
-        match self.router.route_to_prefill(rid, prompt_len) {
+    /// Tracks the request in the [`RequestRouter`] (so decode routing and
+    /// failover can find it) and applies the configured load-balancing strategy.
+    /// `allow_fallback` controls the degenerate path: on the first attempt it is
+    /// `true`, so a router with no usable registry entry still dispatches to the
+    /// first configured `--prefill-peers` address (`node_id` is then `None`,
+    /// since no registry node backs it). On a failover retry it is `false`: the
+    /// caller wants a real, routed, healthy node and treats "no node" as a clean
+    /// failure rather than re-sending to a possibly-dead static address.
+    fn select_prefill(
+        &self,
+        rid: &RequestId,
+        prompt_len: usize,
+        allow_fallback: bool,
+    ) -> Result<PrefillTarget> {
+        match self.router.route_to_prefill(rid.clone(), prompt_len) {
             Ok(node_id) => self
                 .registry
                 .get_node(&node_id)
-                .map(|n| n.config.address.to_string())
+                .map(|n| PrefillTarget {
+                    node_id: Some(node_id.clone()),
+                    addr: n.config.address.to_string(),
+                })
                 .ok_or_else(|| anyhow::anyhow!("routed prefill node {node_id} not in registry")),
-            Err(_) => self
+            Err(_) if allow_fallback => self
                 .prefill_fallback
                 .first()
-                .map(|a| a.to_string())
+                .map(|a| PrefillTarget {
+                    node_id: None,
+                    addr: a.to_string(),
+                })
                 .ok_or_else(|| anyhow::anyhow!("no prefill node available")),
+            Err(e) => Err(anyhow::anyhow!("no healthy prefill node: {e}")),
         }
     }
+
+    /// Select a decode node for an already-tracked request (router-driven decode
+    /// selection, issue #201). Returns the decode node's registry id and
+    /// address, or `None` when no decode node could be routed (no decode peers
+    /// registered, all unreachable, or the request is not tracked because the
+    /// prefill selection took the static fallback). A `None` here makes the
+    /// router omit `decode_target` so the prefill node falls back to its own
+    /// `--decode-peers` config.
+    fn select_decode(&self, rid: &RequestId) -> Option<DecodeTarget> {
+        match self.router.route_to_decode(rid) {
+            Ok(node_id) => self.registry.get_node(&node_id).map(|n| DecodeTarget {
+                node_id,
+                addr: n.config.address.to_string(),
+            }),
+            Err(_) => None,
+        }
+    }
+
+    /// Move a tracked request to a terminal phase so the router does not leak it.
+    ///
+    /// Derives the router's string request id from the response id (the same
+    /// derivation [`start_handoff`] uses) and marks the request completed or
+    /// failed. Terminal entries are purged by [`spawn_health_monitor`]; without
+    /// this the `Prefilling` / `Decoding` entry would live forever. A no-op when
+    /// the id cannot be reconstructed or the request was never tracked.
+    fn finalize_request(&self, response_id: &str, completed: bool) {
+        let Some(rid) = RequestId::from_string(response_id.to_string()) else {
+            return;
+        };
+        if completed {
+            let _ = self.router.mark_completed(&rid);
+        } else {
+            let _ = self.router.mark_failed(&rid, "router request failed");
+        }
+    }
+}
+
+/// A selected prefill node: its registry id (`None` when the static fallback
+/// address was used) and the address to send the [`PrefillRequestFrame`] to.
+struct PrefillTarget {
+    node_id: Option<String>,
+    addr: String,
+}
+
+/// A selected decode node: its registry id and the address the router puts in
+/// [`PrefillRequestFrame::decode_target`] for the prefill node to hand off to.
+struct DecodeTarget {
+    node_id: String,
+    addr: String,
 }
 
 // ── Background demux task ────────────────────────────────────────────────
@@ -264,11 +383,109 @@ pub fn spawn_result_demux(state: Arc<RouterState>) {
     });
 }
 
+// ── Background health monitor ────────────────────────────────────────────
+
+/// Spawn a background task that probes every registered serving peer for
+/// liveness and keeps the [`NodeRegistry`] status in sync (issue #201).
+///
+/// Each cycle TCP-connects to each node's serving address (the same address the
+/// router routes to). A node that does not accept a connection within
+/// [`HEALTH_PROBE_TIMEOUT`] is marked [`NodeStatus::Unreachable`], so
+/// `route_to_prefill` / `route_to_decode` skip it, and its in-flight requests
+/// are re-routed via [`RequestRouter::handle_node_failure`]. A previously
+/// unreachable node that starts accepting again is restored to
+/// [`NodeStatus::Online`]. This catches the cases the per-send transport-error
+/// path cannot: a decode node (which the router never sends to directly) dying,
+/// and a node recovering. The task also purges terminal tracked requests so the
+/// router's request map stays bounded.
+///
+/// Locking: `all_nodes()` returns a snapshot and releases the registry lock; no
+/// registry or request-map lock is held across the connect `await`.
+pub fn spawn_health_monitor(state: Arc<RouterState>) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(HEALTH_PROBE_INTERVAL).await;
+            for node in state.registry.all_nodes() {
+                let addr = node.config.address.to_string();
+                let alive = matches!(
+                    tokio::time::timeout(
+                        HEALTH_PROBE_TIMEOUT,
+                        tokio::net::TcpStream::connect(&addr),
+                    )
+                    .await,
+                    Ok(Ok(_))
+                );
+                match (alive, node.status) {
+                    (false, NodeStatus::Online) => {
+                        state
+                            .registry
+                            .set_node_status(&node.config.id, NodeStatus::Unreachable);
+                        let (rerouted, failed) = state.router.handle_node_failure(&node.config.id);
+                        tracing::warn!(
+                            node = %node.config.id, %addr, rerouted, failed,
+                            "router health: peer unreachable; marked it down"
+                        );
+                    }
+                    (true, NodeStatus::Unreachable) => {
+                        state
+                            .registry
+                            .set_node_status(&node.config.id, NodeStatus::Online);
+                        tracing::info!(
+                            node = %node.config.id, %addr,
+                            "router health: peer recovered; marked it online"
+                        );
+                    }
+                    _ => {}
+                }
+            }
+            // Bound the tracked-request map: drop terminal entries older than the
+            // router config's auto-purge age.
+            let purged = state
+                .router
+                .purge_terminal(state.router.config().auto_purge_age);
+            if purged > 0 {
+                tracing::debug!(purged, "router health: purged terminal tracked requests");
+            }
+        }
+    });
+}
+
 // ── HTTP handlers ─────────────────────────────────────────────────────────
 
 /// GET /health
 async fn router_health() -> &'static str {
     "ok"
+}
+
+/// GET /router/stats
+///
+/// Report the router's load distribution and routing metrics (issue #201): the
+/// per-node dispatch counts for the prefill and decode pools, the registered
+/// nodes with their current health status, and the [`RouterMetrics`] snapshot.
+/// An operator (and the multi-node E2E) uses this to confirm requests spread
+/// across the pools and that a failed node is marked unreachable.
+async fn router_stats(State(state): State<Arc<RouterState>>) -> Json<serde_json::Value> {
+    let prefill_hits = state.prefill_hits.lock().unwrap().clone();
+    let decode_hits = state.decode_hits.lock().unwrap().clone();
+    let nodes: Vec<serde_json::Value> = state
+        .registry
+        .all_nodes()
+        .into_iter()
+        .map(|n| {
+            serde_json::json!({
+                "id": n.config.id,
+                "role": n.config.role.to_string(),
+                "address": n.config.address.to_string(),
+                "status": n.status.to_string(),
+            })
+        })
+        .collect();
+    Json(serde_json::json!({
+        "metrics": state.router.metrics(),
+        "prefill_hits": prefill_hits,
+        "decode_hits": decode_hits,
+        "nodes": nodes,
+    }))
 }
 
 /// POST /v1/chat/completions
@@ -286,8 +503,45 @@ async fn router_chat_completions(
     }
 }
 
+/// Apply router-level admission control before dispatching (issue #201).
+///
+/// Consults [`RequestRouter::apply_backpressure`]. When the prefill queue is at
+/// capacity (`Reject`) or no prefill node is currently available (`Queue`, e.g.
+/// every prefill node is marked unreachable), the router has nowhere to send the
+/// request and no async queue to park it in, so it returns HTTP 503 instead of
+/// attempting a doomed dispatch. `Accept` returns `None` and the caller proceeds
+/// exactly as before, so the healthy path is unchanged.
+fn admission_reject(state: &RouterState) -> Option<Response> {
+    match state.router.apply_backpressure() {
+        BackpressureAction::Accept => None,
+        BackpressureAction::Queue => Some(service_unavailable(
+            "all serving nodes are at capacity or unreachable; retry shortly",
+        )),
+        BackpressureAction::Reject(reason) => Some(service_unavailable(&format!(
+            "router rejected request: {reason}"
+        ))),
+    }
+}
+
+/// Build an HTTP 503 JSON error response for a backpressure rejection.
+fn service_unavailable(message: &str) -> Response {
+    (
+        axum::http::StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": {"message": message, "type": "service_unavailable"}
+        })),
+    )
+        .into_response()
+}
+
 /// Core chat routing logic: tokenizes, sends to prefill, merges result.
 async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> Result<Response> {
+    // Admission control first: reject with 503 when the cluster cannot take the
+    // request (issue #201), before spending work on template rendering.
+    if let Some(resp) = admission_reject(&state) {
+        return Ok(resp);
+    }
+
     // Render the chat template and reject multimodal requests (the
     // disaggregated path is text-only for pool-backed Fp16 families).
     let prepared = super::chat_request::prepare_chat_request_with_cache(
@@ -382,6 +636,7 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
             // unterminated partial delimiter match at end of stream).
             emit_filtered(filter.flush());
 
+            let completed = result.is_ok();
             if let Err(e) = result {
                 let _ = chunk_tx.send(Ok(sse_event(&chat_chunk_error(
                     &request_id_str2,
@@ -393,6 +648,7 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
             let _ = chunk_tx.send(Ok(Event::default().data("[DONE]")));
 
             state2.pending.lock().unwrap().remove(&request_id);
+            state2.finalize_request(&request_id_str2, completed);
         });
 
         Ok(Sse::new(UnboundedReceiverStream::new(chunk_rx))
@@ -426,6 +682,7 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
             .await;
             absorb(filter.flush());
             state.pending.lock().unwrap().remove(&request_id);
+            state.finalize_request(&request_id_str, r.is_ok());
             r?;
         }
         Ok(Json(chat_completion_json(
@@ -479,6 +736,12 @@ async fn router_completions(
 ///   between "length" and "stop". A precise fix requires the disaggregated wire
 ///   protocol to carry the worker's token count and is deferred to a follow-up.
 async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -> Result<Response> {
+    // Admission control first: reject with 503 when the cluster cannot take the
+    // request (issue #201), before any per-request work.
+    if let Some(resp) = admission_reject(&state) {
+        return Ok(resp);
+    }
+
     // The disaggregated result frames carry detokenized text only, with no
     // per-token logprob data, so the router cannot reproduce the single-node
     // `logprobs` object. Reject rather than emit a divergent null-logprobs
@@ -617,6 +880,7 @@ async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -
             let _ = chunk_tx.send(Ok(Event::default().data("[DONE]")));
 
             state2.pending.lock().unwrap().remove(&request_id);
+            state2.finalize_request(&response_id2, result.is_ok());
         });
 
         Ok(Sse::new(UnboundedReceiverStream::new(chunk_rx))
@@ -640,6 +904,7 @@ async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -
         )
         .await;
         state.pending.lock().unwrap().remove(&request_id);
+        state.finalize_request(&response_id, r.is_ok());
         r?;
 
         // Mirror the single-node finish_reason exactly (model_worker.rs):
@@ -700,31 +965,121 @@ async fn start_handoff(
         .collect();
     let prompt_tokens = token_ids.len();
 
-    let prefill_addr = state.select_prefill(response_id, prompt_tokens)?;
+    // The router tracks the request under the string id derived from
+    // `response_id`, so `route_to_prefill` here and `route_to_decode` below
+    // operate on the same tracked entry.
+    let rid = RequestId::from_string(response_id.to_string()).unwrap_or_default();
+
+    // Pick the prefill node (tracks the request) and, when possible, the decode
+    // node too (issue #201). The router-chosen decode target rides the frame so
+    // the prefill node hands the KV cache to the router-balanced decode node
+    // instead of its own static `--decode-peers` config. A `None` decode target
+    // (no decode peer routable) leaves the prefill node on its config fallback.
+    let mut prefill = state.select_prefill(&rid, prompt_tokens, true)?;
+    let decode = state.select_decode(&rid);
 
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<ResultFrame>();
     state.pending.lock().unwrap().insert(request_id, tx);
 
-    // Build and send the prefill request frame to the chosen prefill node.
+    // Build the prefill request frame once; re-encode per send attempt so a
+    // failover retry can reuse it without requiring the transport message to be
+    // cloneable.
     let frame = PrefillRequestFrame {
         request_id,
         prompt_tokens: token_ids,
         sampling: sampling_to_serializable(&opts.sampling),
         max_tokens: opts.max_tokens as u64,
         reply_to: state.reply_to.clone(),
+        decode_target: decode.as_ref().map(|d| d.addr.clone()),
     };
-    let encoded = match frame.encode() {
-        Ok(encoded) => encoded,
-        Err(e) => {
-            state.pending.lock().unwrap().remove(&request_id);
-            return Err(anyhow::anyhow!("{e}"));
+
+    // Send to the prefill node, failing over to other healthy prefill nodes on a
+    // transport error. A send error means the node is unreachable, so mark it
+    // down in the registry (which makes `route_to_prefill` skip it), re-route any
+    // other in-flight requests it held via `handle_node_failure`, and re-select a
+    // healthy node for this request. Bounded by the prefill-node count so a fully
+    // dead pool fails the request cleanly instead of spinning. No registry / map
+    // lock is held across the `await`, mirroring the existing discipline.
+    let max_attempts = state
+        .registry
+        .nodes_with_role(NodeRole::Prefill)
+        .len()
+        .max(1);
+    let mut attempt = 0usize;
+    loop {
+        let encoded = match frame.encode() {
+            Ok(encoded) => encoded,
+            Err(e) => {
+                state.pending.lock().unwrap().remove(&request_id);
+                state.finalize_request(response_id, false);
+                return Err(anyhow::anyhow!("{e}"));
+            }
+        };
+        match state.transport.send(&prefill.addr, encoded).await {
+            Ok(()) => break,
+            Err(e) => {
+                attempt += 1;
+                if let Some(failed_id) = prefill.node_id.clone() {
+                    state
+                        .registry
+                        .set_node_status(&failed_id, NodeStatus::Unreachable);
+                    let (rerouted, failed) = state.router.handle_node_failure(&failed_id);
+                    tracing::warn!(
+                        node = %failed_id, addr = %prefill.addr, rerouted, failed,
+                        "router: prefill node send failed; marked unreachable: {e}"
+                    );
+                }
+                if attempt >= max_attempts {
+                    state.pending.lock().unwrap().remove(&request_id);
+                    state.finalize_request(response_id, false);
+                    return Err(anyhow::anyhow!(
+                        "send prefill request: no healthy prefill node after {attempt} attempt(s): {e}"
+                    ));
+                }
+                // Re-select a healthy prefill node (the failed one is now
+                // Unreachable, so the router skips it). No static fallback on
+                // retry: a doomed re-send to a dead config address is not a fix.
+                match state.select_prefill(&rid, prompt_tokens, false) {
+                    Ok(next) => prefill = next,
+                    Err(re) => {
+                        state.pending.lock().unwrap().remove(&request_id);
+                        state.finalize_request(response_id, false);
+                        return Err(anyhow::anyhow!(
+                            "send prefill request: {e}; no healthy prefill node to retry: {re}"
+                        ));
+                    }
+                }
+            }
         }
-    };
-    if let Err(e) = state.transport.send(&prefill_addr, encoded).await {
-        state.pending.lock().unwrap().remove(&request_id);
-        return Err(anyhow::anyhow!("send prefill request: {e}"));
     }
-    tracing::debug!(request_id, %prefill_addr, "router: sent prefill request frame");
+
+    // Count the dispatched request against the nodes actually used, for the
+    // `GET /router/stats` distribution view. Each lock is taken and released
+    // without crossing an await.
+    if let Some(id) = &prefill.node_id {
+        *state
+            .prefill_hits
+            .lock()
+            .unwrap()
+            .entry(id.clone())
+            .or_insert(0) += 1;
+    }
+    if let Some(d) = &decode {
+        *state
+            .decode_hits
+            .lock()
+            .unwrap()
+            .entry(d.node_id.clone())
+            .or_insert(0) += 1;
+        // Reflect the in-flight decode phase for the metrics snapshot.
+        let _ = state.router.mark_decoding(&rid, &d.node_id);
+    }
+    tracing::debug!(
+        request_id,
+        prefill = %prefill.addr,
+        decode = decode.as_ref().map(|d| d.addr.as_str()).unwrap_or("<config-fallback>"),
+        "router: sent prefill request frame"
+    );
     Ok((prompt_tokens, rx))
 }
 
@@ -948,11 +1303,14 @@ fn chat_completion_json(
 ///
 /// Exposes:
 /// - `GET /health` - liveness probe
+/// - `GET /router/stats` - per-node dispatch distribution, node health, and
+///   routing metrics (issue #201)
 /// - `POST /v1/chat/completions` - chat completions (streaming and non-streaming)
 /// - `POST /v1/completions` - text completions (streaming and non-streaming)
 pub fn create_router_app(state: Arc<RouterState>) -> Router {
     Router::new()
         .route("/health", get(router_health))
+        .route("/router/stats", get(router_stats))
         .route("/v1/chat/completions", post(router_chat_completions))
         .route("/v1/completions", post(router_completions))
         .with_state(state)

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -1658,6 +1658,7 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
             tokenizer_arc,
         )?);
         crate::server::router_front::spawn_result_demux(state.clone());
+        crate::server::router_front::spawn_health_monitor(state.clone());
         let app = crate::server::router_front::create_router_app(state);
         tracing::info!(
             host = %startup.host,

--- a/tests/disaggregated_router_e2e.rs
+++ b/tests/disaggregated_router_e2e.rs
@@ -787,3 +787,224 @@ async fn disaggregated_router_completions_match_single_node() {
     );
     eprintln!("OK: router /v1/completions matches single-node (non-stream + stream).");
 }
+
+// ── Multi-node routing, balancing, and failover (issue #201) ─────────────
+
+/// Spawn a `--node-role decode` server wired to its own serving address.
+fn spawn_decode(model_arg: &str, http: &str, serving_addr: &str) -> ChildGuard {
+    spawn_role_server(&[
+        "-m",
+        model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        http,
+        "--parallel",
+        "2",
+        "--max-batch-size",
+        "2",
+        "--decode-storage-backend",
+        "paged",
+        "--node-role",
+        "decode",
+        "--serving-bind",
+        serving_addr,
+        "--no-warmup",
+    ])
+}
+
+/// Spawn a `--node-role prefill` server wired to its serving address and a
+/// single configured decode peer (the router overrides the decode target per
+/// request via `decode_target`; the config peer is only the fallback).
+fn spawn_prefill(model_arg: &str, http: &str, serving_addr: &str, decode_peer: &str) -> ChildGuard {
+    spawn_role_server(&[
+        "-m",
+        model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        http,
+        "--parallel",
+        "2",
+        "--max-batch-size",
+        "2",
+        "--decode-storage-backend",
+        "paged",
+        "--node-role",
+        "prefill",
+        "--serving-bind",
+        serving_addr,
+        "--decode-peers",
+        decode_peer,
+        "--no-warmup",
+    ])
+}
+
+/// POST a non-streaming completion to the router and return `(status, text)`.
+async fn post_completion(
+    client: &reqwest::Client,
+    url: &str,
+    model: &str,
+    prompt: &str,
+) -> (reqwest::StatusCode, String) {
+    let resp = client
+        .post(url)
+        .json(&serde_json::json!({
+            "model": model, "prompt": prompt, "max_tokens": 8, "temperature": 0.0
+        }))
+        .send()
+        .await
+        .expect("POST /v1/completions");
+    let status = resp.status();
+    let text = if status.is_success() {
+        resp.json::<serde_json::Value>()
+            .await
+            .ok()
+            .and_then(|v| v["choices"][0]["text"].as_str().map(str::to_string))
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+    (status, text)
+}
+
+/// Issue #201, AC1 + AC2: with two prefill AND two decode nodes the router
+/// spreads requests across both pools (asserted via `GET /router/stats`
+/// per-node hit counters), and killing one prefill node does not wedge the
+/// router: subsequent requests still succeed by routing to the survivor.
+///
+/// Five processes: 2 decode + 2 prefill + 1 router. qwen3-0.6b-4bit is tiny, but
+/// this still loads four model copies, so it is `#[ignore]` and run explicitly
+/// by the gate, not in the default unit run.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "spawns five real mlxcel-server processes (2 prefill + 2 decode + router); run with --ignored"]
+async fn disaggregated_router_balances_and_survives_node_failure() {
+    let model_dir = repo_model_dir(QWEN3_DIR);
+    if !model_dir.exists() {
+        eprintln!("Skipping {QWEN3_DIR}: model directory not found");
+        return;
+    }
+    let binary = repo_binary_path("mlxcel-server");
+    if !binary.exists() {
+        eprintln!("Skipping: mlxcel-server binary not found");
+        return;
+    }
+    let model_arg = model_dir.to_string_lossy().to_string();
+
+    // Ports: [prefill0_http, prefill1_http, decode0_http, decode1_http,
+    //         router_http, prefill0_srv, prefill1_srv, decode0_srv,
+    //         decode1_srv, router_srv].
+    let ports = reserve_ports(10);
+    let prefill0_http = ports[0].to_string();
+    let prefill1_http = ports[1].to_string();
+    let decode0_http = ports[2].to_string();
+    let decode1_http = ports[3].to_string();
+    let router_http = ports[4].to_string();
+    let prefill0_srv = format!("127.0.0.1:{}", ports[5]);
+    let prefill1_srv = format!("127.0.0.1:{}", ports[6]);
+    let decode0_srv = format!("127.0.0.1:{}", ports[7]);
+    let decode1_srv = format!("127.0.0.1:{}", ports[8]);
+    let router_srv = format!("127.0.0.1:{}", ports[9]);
+
+    // Decode nodes first so they are ready before prefill hands off.
+    let _decode0 = spawn_decode(&model_arg, &decode0_http, &decode0_srv);
+    let _decode1 = spawn_decode(&model_arg, &decode1_http, &decode1_srv);
+    // Each prefill node configures decode0 as its static fallback; the router
+    // overrides the decode target per request, balancing both decode nodes.
+    let mut prefill0 = Some(spawn_prefill(
+        &model_arg,
+        &prefill0_http,
+        &prefill0_srv,
+        &decode0_srv,
+    ));
+    let _prefill1 = spawn_prefill(&model_arg, &prefill1_http, &prefill1_srv, &decode0_srv);
+    let _router = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &router_http,
+        "--node-role",
+        "router",
+        "--serving-bind",
+        &router_srv,
+        "--prefill-peers",
+        &format!("{prefill0_srv},{prefill1_srv}"),
+        "--decode-peers",
+        &format!("{decode0_srv},{decode1_srv}"),
+        "--no-warmup",
+    ]);
+
+    let deadline = Instant::now() + Duration::from_secs(240);
+    for addr in [&decode0_srv, &decode1_srv, &prefill0_srv, &prefill1_srv] {
+        assert!(
+            wait_for_tcp(addr, deadline).await,
+            "serving transport never came up at {addr}"
+        );
+    }
+    let health_url = format!("http://127.0.0.1:{router_http}/health");
+    assert!(
+        wait_for_http_health(&health_url, deadline).await,
+        "router HTTP /health never returned 200"
+    );
+
+    let client = reqwest::Client::new();
+    let completions_url = format!("http://127.0.0.1:{router_http}/v1/completions");
+    let stats_url = format!("http://127.0.0.1:{router_http}/router/stats");
+    let prompt = "The capital of France is";
+
+    // ---- AC1: distribution across both pools ----
+    for _ in 0..8 {
+        let (status, text) = post_completion(&client, &completions_url, "qwen3", prompt).await;
+        assert!(
+            status.is_success(),
+            "pre-failure request failed: HTTP {status}"
+        );
+        assert!(!text.is_empty(), "pre-failure request returned empty text");
+    }
+    let stats: serde_json::Value = client
+        .get(&stats_url)
+        .send()
+        .await
+        .expect("GET /router/stats")
+        .json()
+        .await
+        .expect("parse /router/stats");
+    eprintln!("router stats before failure: {stats}");
+    let prefill_hits = stats["prefill_hits"]
+        .as_object()
+        .expect("prefill_hits object");
+    let decode_hits = stats["decode_hits"]
+        .as_object()
+        .expect("decode_hits object");
+    let nonzero = |m: &serde_json::Map<String, serde_json::Value>| {
+        m.values().filter(|v| v.as_u64().unwrap_or(0) > 0).count()
+    };
+    assert_eq!(
+        nonzero(prefill_hits),
+        2,
+        "expected both prefill nodes to receive requests, got {prefill_hits:?}"
+    );
+    assert_eq!(
+        nonzero(decode_hits),
+        2,
+        "expected both decode nodes to receive requests, got {decode_hits:?}"
+    );
+
+    // ---- AC2: kill one prefill node; subsequent requests still succeed ----
+    drop(prefill0.take()); // ChildGuard::drop kills the process.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    for i in 0..6 {
+        let (status, text) = post_completion(&client, &completions_url, "qwen3", prompt).await;
+        assert!(
+            status.is_success(),
+            "post-failure request {i} failed: HTTP {status} (router wedged after node death)"
+        );
+        assert!(
+            !text.is_empty(),
+            "post-failure request {i} returned empty text"
+        );
+    }
+    eprintln!("OK: router balanced both pools and survived a prefill-node failure.");
+}

--- a/tests/disaggregated_serving_e2e.rs
+++ b/tests/disaggregated_serving_e2e.rs
@@ -230,6 +230,9 @@ async fn disaggregated_two_process_handoff_matches_single_node() {
         sampling: sampling_to_serializable(&SamplingConfig::greedy()),
         max_tokens: MAX_TOKENS,
         reply_to: reply_to.clone(),
+        // Single configured decode peer: let the prefill node use its
+        // `--decode-peers` fallback rather than a router-chosen target.
+        decode_target: None,
     };
     client
         .send(


### PR DESCRIPTION
## Summary

Make the disaggregated router actually balance independent prefill and decode pools, with health-driven failover and admission backpressure (issue #201). Before this change the router registered both pools but, with one prefill node, always returned it, and the decode node was chosen by the prefill node's own `--decode-peers` config rather than by the router, so the load-balancing, health, and failover machinery was never exercised.

## What changed

(1) Router-driven decode selection. PrefillRequestFrame gains an optional `decode_target: Option<String>` (`serde(default)`, in `src/distributed/disaggregated/serving_protocol.rs`). The router selects the prefill node with `route_to_prefill` and the decode node with `route_to_decode` (both round-robin, since the router has no live per-node load telemetry), and ships the chosen decode address in `decode_target`. The prefill role loop (`coordinator.rs::run_prefill_role_networked`) forwards the KV handoff to `decode_target` when present and falls back to its own `--decode-peers` config when absent, so a mixed-version pool keeps working: an older router omits the field and a new prefill falls back to config; a new router populates it and an older prefill ignores the unknown field.

(2) Health and failover. A transport error when sending a prefill frame marks the node `Unreachable` in the registry (so `route_to_prefill` / `route_to_decode` skip it), re-routes its in-flight requests via `handle_node_failure`, and retries the request on a healthy node, failing cleanly with an error when none remains. A background `spawn_health_monitor` task TCP-probes every peer's serving address on an interval so a dead decode node (which the router never sends to directly) is detected and skipped, and a recovered node is restored to `Online`. The prefill loop is now resilient: a failed first-token send or decode handoff fails only that one request (the client receives a terminal error frame instead of blocking) and the worker keeps serving the rest. Tracked requests reach a terminal phase on completion/failure and are purged by the monitor so request state does not leak.

(3) Backpressure. Every request passes `apply_backpressure` admission control before dispatch (`route_chat` / `route_completion`); on `Queue` or `Reject` the router returns HTTP 503 instead of attempting a send that cannot succeed.

(4) Observability. `GET /router/stats` reports per-node prefill/decode dispatch counts, node health, and the `RouterMetrics` snapshot.

(5) Docs. `docs/distributed.md` and the disaggregated section of `docs/CONTINUOUS_BATCHING.md` describe router-driven decode selection, health/failover, and backpressure.

Locking discipline is preserved: no registry, request-map, or pending-map lock is held across an await or send.

## Test plan

- [x] `cargo check --release -p mlxcel --lib --tests --features metal,accelerate` (clean)
- [x] `cargo test --release -p mlxcel --lib --features metal,accelerate distributed::disaggregated::request_router::tests` (25 passed)
- [x] `cargo test --release -p mlxcel --lib --features metal,accelerate distributed::disaggregated::serving_protocol::tests` (8 passed)
- [x] `cargo fmt --check -p mlxcel` (clean)
- [x] clippy clean for all changed files (the only clippy `-D warnings` failure is a pre-existing `mlxcel-core/build.rs:90` lint on `origin/main`, unrelated to this PR)
- [ ] heavy multi-node E2E (orchestrator): `cargo test --test disaggregated_router_e2e --release --features metal,accelerate -- --ignored --nocapture disaggregated_router_balances_and_survives_node_failure`
- [ ] existing parity E2E still green (orchestrator): `cargo test --test disaggregated_router_e2e --release --features metal,accelerate -- --ignored --nocapture disaggregated_router_completions_match_single_node`

Closes #201
