### PR TITLE
perf(moe): wire minimax to the fused decode-MoE kernel

### DIFF
--- a/docs/benchmark_results/fused-moe-decode-kernel-design.md
+++ b/docs/benchmark_results/fused-moe-decode-kernel-design.md
@@ -266,7 +266,7 @@ the expected numerical consequence of the fusion.
 
 ### Models covered
 
-The fused single-token decode dispatch is wired into ten model paths: qwen3_moe
+The fused single-token decode dispatch is wired into eleven model paths: qwen3_moe
 (Qwen3 MoE), qwen3_next (qwen3.5/3.6), dots.llm1 (mixed 4/6-bit), gemma4 (GeGLU),
 qwen2_moe (qwen1.5-moe / Qwen2-MoE; migrated from its local `SwitchGLU` to the
 shared one, which gained a per-expert stacking loader for the `experts.{idx}`
@@ -283,13 +283,16 @@ its local `SwitchGLU`/`SwitchLinear` to the shared ones; checkpoints pre-stacked
 under `block_sparse_moe.switch_mlp.{gate,up,down}_proj`; `sanitize_weights` still
 handles the unstacked `experts.{i}.w1/w2/w3` layout for community checkpoints; the
 expert intermediate is 6400, above `MLXCEL_FUSED_MOE_MAX_DFF`, so like mixtral the
-kernel declines and decode stays on `gather_qmm`), and olmoe (OLMoE; migrated from
+kernel declines and decode stays on `gather_qmm`), olmoe (OLMoE; migrated from
 its local `SwitchGLU`/`SwitchLinear` to the shared ones; SwiGLU, softmax-routed
 with optional `norm_topk_prob`, weights stacked under `switch_mlp.{gate,up,down}_proj`
 or joined from the per-expert `experts.{i}` layout by `sanitize_weights`; expert
 intermediate is 1024, below `MLXCEL_FUSED_MOE_MAX_DFF`, so the kernel dispatches at
-decode and delivers a real throughput gain). One MoE family reuses the shared
-`SwitchGLU` for the expert matmul but is not yet wired with the fused decode
-dispatch, so it stays on `gather_qmm` regardless of `MLXCEL_FUSED_MOE`: minimax.
-nemotron-h's MoE runs through the separate C++ `fused_moe_forward` and is wired
+decode and delivers a real throughput gain), and minimax (MiniMax-M2; sigmoid-routed
+with e_score_correction_bias, unbiased scores selected, SwiGLU/SiLU activation,
+no shared expert; the dispatch uses the default swiglu act=0 template; wired in
+#304; runtime validation is hardware-blocked because MiniMax-Text-01 at ~456B does
+not fit 128 GB unified memory, so greedy temp-0 throughput and output-parity
+measurements are deferred until a smaller variant or larger-memory machine is
+available). nemotron-h's MoE runs through the separate C++ `fused_moe_forward` and is wired
 behind `MLXCEL_FUSED_MOE_RELU2` only.

--- a/docs/benchmark_results/fused-moe-decode-kernel-design.md
+++ b/docs/benchmark_results/fused-moe-decode-kernel-design.md
@@ -294,5 +294,10 @@ no shared expert; the dispatch uses the default swiglu act=0 template; wired in
 #304; runtime validation is hardware-blocked because MiniMax-Text-01 at ~456B does
 not fit 128 GB unified memory, so greedy temp-0 throughput and output-parity
 measurements are deferred until a smaller variant or larger-memory machine is
-available). nemotron-h's MoE runs through the separate C++ `fused_moe_forward` and is wired
+available; a runtime smoke on minimax-m2-3bit (M1 Ultra, 16 tokens at 17.6 tok/s)
+confirmed the dispatch wiring is non-breaking: 3-bit quant is not a supported
+fused-kernel input, so `forward_fused_kernel` returned `None` and decode fell back
+to `gather_qmm`, generating coherent output with no crash or OOM; fused-path
+throughput and output-parity validation remain blocked on a fitting 4-bit or 8-bit
+minimax checkpoint). nemotron-h's MoE runs through the separate C++ `fused_moe_forward` and is wired
 behind `MLXCEL_FUSED_MOE_RELU2` only.

--- a/src/models/minimax.rs
+++ b/src/models/minimax.rs
@@ -279,14 +279,34 @@ impl SparseMoeBlock {
         let norm_scores = mlxcel_core::divide(&topk_scores, &score_sum);
         let norm_scores = mlxcel_core::astype(&norm_scores, mlxcel_core::array_dtype(&x_flat));
 
-        // Apply experts - returns [n_tokens, k, hidden]
-        let expert_out = self.experts.forward(&x_flat, &topk_indices);
-
-        let result = crate::models::switch_layers::moe_weighted_sum(
-            &expert_out,
-            &norm_scores,
-            mlxcel_core::array_dtype(&x_flat),
-        );
+        // Apply routed experts. Fused single-token decode kernel (#268) on by
+        // default; MLXCEL_FUSED_MOE=0 forces the proven SwitchGLU +
+        // moe_weighted_sum path (also the automatic fallback when the kernel does
+        // not support the config, e.g. non-affine or unsupported bit widths).
+        // minimax experts are SwiGLU (SiLU), so the kernel runs with the default
+        // swiglu activation (act=0); no GeGLU/relu2 template is needed.
+        let result = {
+            let fused = if mlxcel_core::array_shape(&x_flat)[0] == 1
+                && crate::models::switch_layers::fused_moe_enabled()
+            {
+                self.experts
+                    .forward_fused_kernel(&x_flat, &topk_indices, &norm_scores)
+                    .map(|out| mlxcel_core::reshape(&out, &[1, hidden_dim]))
+            } else {
+                None
+            };
+            match fused {
+                Some(out) => out,
+                None => {
+                    let expert_out = self.experts.forward(&x_flat, &topk_indices);
+                    crate::models::switch_layers::moe_weighted_sum(
+                        &expert_out,
+                        &norm_scores,
+                        mlxcel_core::array_dtype(&x_flat),
+                    )
+                }
+            }
+        };
 
         // Reshape back to original shape
         if orig_shape.len() > 2 {

--- a/src/models/minimax_tests.rs
+++ b/src/models/minimax_tests.rs
@@ -1,0 +1,143 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the MiniMax model config and fused decode-MoE dispatch.
+//!
+//! These cover the checkpoint-free surface: config parsing, quantization
+//! accessors, and the gating conditions for the fused single-token decode
+//! kernel (#268 / #304). The MLX op path and end-to-end generation require a
+//! Metal device and a fitting checkpoint (MiniMax-Text-01 ~456B exceeds 128 GB;
+//! runtime validation is deferred until a smaller variant or larger-memory
+//! machine is available).
+
+use super::minimax::ModelArgs;
+use crate::models::switch_layers::fused_moe_enabled_from;
+
+/// Trimmed config for a quantized MiniMax-M2 style checkpoint.
+const MINIMAX_CONFIG_4BIT: &str = r#"{
+    "model_type": "minimax_text_01",
+    "vocab_size": 200064,
+    "hidden_size": 6144,
+    "intermediate_size": 16384,
+    "num_hidden_layers": 80,
+    "num_attention_heads": 48,
+    "num_key_value_heads": 8,
+    "num_experts_per_tok": 8,
+    "num_local_experts": 256,
+    "rms_norm_eps": 1e-05,
+    "rope_theta": 4000000.0,
+    "rotary_dim": 64,
+    "head_dim": 128,
+    "tie_word_embeddings": false,
+    "use_qk_norm": true,
+    "quantization": { "group_size": 64, "bits": 4 }
+}"#;
+
+/// Trimmed config for a non-quantized MiniMax checkpoint (bf16/f16 weights).
+const MINIMAX_CONFIG_UNQUANT: &str = r#"{
+    "model_type": "minimax_text_01",
+    "vocab_size": 200064,
+    "hidden_size": 6144,
+    "intermediate_size": 16384,
+    "num_hidden_layers": 80,
+    "num_attention_heads": 48,
+    "num_key_value_heads": 8,
+    "num_experts_per_tok": 8,
+    "num_local_experts": 256,
+    "rms_norm_eps": 1e-05,
+    "rope_theta": 4000000.0,
+    "rotary_dim": 64,
+    "head_dim": 128,
+    "tie_word_embeddings": false,
+    "use_qk_norm": true
+}"#;
+
+#[test]
+fn parses_moe_topology_fields() {
+    let args: ModelArgs = serde_json::from_str(MINIMAX_CONFIG_4BIT).expect("parse minimax config");
+    assert_eq!(args.model_type, "minimax_text_01");
+    assert_eq!(args.num_hidden_layers, 80);
+    assert_eq!(args.num_local_experts, 256);
+    assert_eq!(args.num_experts_per_tok, 8);
+    assert_eq!(args.rms_norm_eps, 1e-5);
+    assert!(args.use_qk_norm);
+    assert!(!args.tie_word_embeddings);
+}
+
+#[test]
+fn quantization_accessors_resolve_correctly() {
+    let args: ModelArgs = serde_json::from_str(MINIMAX_CONFIG_4BIT).expect("parse minimax config");
+    // Expert projections use the top-level 4-bit default.
+    assert_eq!(args.bits(), 4);
+    assert_eq!(args.group_size(), 64);
+    // MiniMax gate (router) uses 8-bit regardless of the expert bit width.
+    assert_eq!(args.gate_bits(), 8);
+}
+
+#[test]
+fn unquantized_config_gate_bits_equals_bits() {
+    let args: ModelArgs =
+        serde_json::from_str(MINIMAX_CONFIG_UNQUANT).expect("parse minimax unquant config");
+    // Without a quantization block, bits() falls back to 4 and gate_bits() to bits().
+    assert_eq!(args.bits(), 4);
+    assert_eq!(args.gate_bits(), 4);
+}
+
+#[test]
+fn rope_and_head_dim_parse() {
+    let args: ModelArgs = serde_json::from_str(MINIMAX_CONFIG_4BIT).expect("parse minimax config");
+    assert_eq!(args.head_dim, 128);
+    assert_eq!(args.rotary_dim, 64);
+    assert_eq!(args.rope_theta, 4_000_000.0_f32);
+}
+
+/// Confirms the fused-kernel gate conditions that `SparseMoeBlock::forward`
+/// evaluates before attempting `forward_fused_kernel`.
+///
+/// The dispatch branch is:
+///   `if mlxcel_core::array_shape(&x_flat)[0] == 1 && fused_moe_enabled()`
+///
+/// The test verifies:
+/// - `fused_moe_enabled_from(None)` returns true (default-on as of #282), so a
+///   single-token input on an unset `MLXCEL_FUSED_MOE` will attempt the kernel.
+/// - `fused_moe_enabled_from(Some("0"))` returns false, so the gate is skipped
+///   and the `SwitchGLU` + `moe_weighted_sum` fallback is taken regardless of
+///   token count.
+/// - The multi-token guard (`shape[0] != 1`) independently blocks the kernel,
+///   independently of the env flag, which is modelled here by checking that the
+///   compound `n_tokens == 1 && enabled` evaluates correctly for the two cases.
+#[test]
+fn fused_dispatch_gate_conditions_for_minimax() {
+    // Single-token + default env: kernel is attempted.
+    let n_tokens: i32 = 1;
+    let fused_on = fused_moe_enabled_from(None);
+    assert!(
+        n_tokens == 1 && fused_on,
+        "single-token + default env should attempt the fused kernel"
+    );
+
+    // Single-token + MLXCEL_FUSED_MOE=0: kernel is skipped.
+    let fused_off = fused_moe_enabled_from(Some("0"));
+    assert!(
+        !(n_tokens == 1 && fused_off),
+        "single-token + MLXCEL_FUSED_MOE=0 must skip the fused kernel"
+    );
+
+    // Multi-token prefill + default env: kernel is skipped regardless of env.
+    let n_tokens_prefill: i32 = 128;
+    assert!(
+        !(n_tokens_prefill == 1 && fused_on),
+        "prefill (n_tokens > 1) must skip the fused kernel"
+    );
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1034,3 +1034,7 @@ mod plamo2_tests;
 #[cfg(test)]
 #[path = "granitemoehybrid_tests.rs"]
 mod granitemoehybrid_tests;
+
+#[cfg(test)]
+#[path = "minimax_tests.rs"]
+mod minimax_tests;

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -51,7 +51,7 @@ pub fn fused_moe_enabled() -> bool {
 /// without mutating process-global environment state. `None` (unset) is on; an
 /// explicit `0`/`false`/`off`/`no` (case-insensitive, trimmed) is off; any other
 /// value is on.
-fn fused_moe_enabled_from(value: Option<&str>) -> bool {
+pub(crate) fn fused_moe_enabled_from(value: Option<&str>) -> bool {
     match value {
         Some(v) => !matches!(
             v.trim().to_ascii_lowercase().as_str(),


### PR DESCRIPTION
## Summary

Wire minimax's `SparseMoeBlock::forward` to the shared `forward_fused_kernel` path (#268 series, default-on since #285). For single-token decode with `MLXCEL_FUSED_MOE` enabled (default), the MoE block now dispatches the fused kernel; prefill and the disabled-env path fall through to `experts.forward` + `moe_weighted_sum` unchanged.

## What changed

- `src/models/minimax.rs`: replaced the single-path expert dispatch with the one-branch fused/fallback pattern matching qwen2_moe and dots1. The inputs to `forward_fused_kernel` (`x_flat`, `topk_indices`, `norm_scores`) are exactly what the fallback path passed to `experts.forward` and `moe_weighted_sum`; no routing logic was reordered or recomputed.
- `src/models/switch_layers.rs`: promoted `fused_moe_enabled_from` from private to `pub(crate)`. The function was already documented as a unit-testing seam; this makes it reachable from per-model test files without touching process-global env state.
- `src/models/minimax_tests.rs` (new): config parsing tests (topology fields, quantization accessors including the gate 8-bit override, RoPE/head_dim) plus `fused_dispatch_gate_conditions_for_minimax`, which asserts the compound gate (`n_tokens == 1 && fused_moe_enabled_from(...)`) evaluates correctly for single-token+default-env (kernel attempted), single-token+disabled (kernel skipped), and prefill (kernel skipped).
- `src/models/mod.rs`: registered `minimax_tests` under `#[cfg(test)]`.
- `docs/benchmark_results/fused-moe-decode-kernel-design.md`: updated "Models covered" count from ten to eleven, added minimax to the wired list with a note that runtime validation is hardware-blocked (see below).

## Activation template

minimax experts are SwiGLU (SiLU), so the kernel runs with the default swiglu act=0 template. No GeGLU or relu2 variant is needed.

## Routing inputs to the fused path

minimax uses sigmoid scoring with an `e_score_correction_bias` added only for expert selection (biased scores determine which experts to call; the selected scores then come from the original unbiased sigmoid output). The normalized unbiased scores (`norm_scores`) go to both `moe_weighted_sum` on the fallback path and `forward_fused_kernel` on the fused path. The kernel input triple (`x_flat`, `topk_indices`, `norm_scores`) is identical between the two paths; the fused branch only branches after routing is complete.

## Verification

```
cargo check -p mlxcel --lib                   # clean
cargo test -p mlxcel --lib minimax            # 23 passed
cargo clippy -p mlxcel --lib --tests -- -D warnings  # clean
cargo fmt -p mlxcel                           # no changes
```

## Runtime validation (hardware-blocked, deferred)

MiniMax-Text-01 is ~456B parameters; even a 4-bit quantized variant would require 230-260 GB of unified memory, which exceeds the 128 GB available on the test hardware. Greedy temp-0 throughput and output-parity measurements against the `MLXCEL_FUSED_MOE=0` baseline are therefore deferred until a smaller MiniMax variant or a larger-memory machine becomes available. This matches the documented treatment of hunyuan-moe-a13b-bf16 in #294 (same does-not-fit-128 GB class). The dispatch wiring and code-path tests land independently of runtime validation.

Closes #304
