### PR TITLE
fix(router): use worker's authoritative token count for usage

### DIFF
--- a/src/distributed/disaggregated/coordinator.rs
+++ b/src/distributed/disaggregated/coordinator.rs
@@ -294,7 +294,17 @@ impl ServingCoordinator {
                 token_tx,
                 Arc::new(AtomicBool::new(false)),
             )?;
-            let (tokens, done, error) = drain_generation_events(&token_rx);
+            let drained = drain_generation_events(&token_rx);
+
+            // The prefill node's authoritative count of model tokens it
+            // generated for this request (issue #387). When it finished here
+            // (immediate EOS or a single-token budget) the terminal `Done`
+            // reports the exact count (0 or 1); when it produced a handoff and
+            // continues on the decode node, it sampled exactly one first token
+            // and emitted no `Done`, so the count is 1. Carrying this lets the
+            // router count a byte-fallback first token (which surfaces as no
+            // text piece) correctly instead of under-counting it.
+            let prefill_generated = drained.completion_tokens.unwrap_or(1);
 
             // Return the prefill node's first token to the client. When prefill
             // produced no handoff frame (immediate EOS), this first-token result
@@ -304,10 +314,11 @@ impl ServingCoordinator {
             let first_result = ResultFrame {
                 request_id: request.request_id,
                 phase: ResultPhase::FirstToken,
-                tokens,
+                tokens: drained.tokens,
                 start_sequence: 0,
-                done: done || frame.is_none(),
-                error,
+                done: drained.done || frame.is_none(),
+                error: drained.error,
+                generated_tokens: Some(prefill_generated),
             };
             if let Err(e) = self
                 .transport
@@ -358,6 +369,7 @@ impl ServingCoordinator {
                         start_sequence: 0,
                         done: true,
                         error: Some(format!("decode handoff to {decode_peer} failed: {e}")),
+                        generated_tokens: None,
                     };
                     let _ = self
                         .transport
@@ -454,18 +466,31 @@ impl ServingCoordinator {
             // prefill first token is sequence 0) so the router can detect
             // gaps or reordering on the wire.
             let mut next_sequence: u64 = 1;
+            // The decode node's authoritative count of model tokens it generated
+            // after the handoff (issue #387), accumulated from whichever tick's
+            // terminal `Done` event carries it. The decode `decode_state` is
+            // seeded with the prompt and the prefill node's first token, so this
+            // count covers only the decode continuation; the router adds the
+            // prefill node's first-token count for the request total.
+            let mut decode_generated: Option<u64> = None;
             loop {
                 let active = scheduler.decode_handoff_step();
-                let (tokens, _done, error) = drain_generation_events(&token_rx);
-                if !tokens.is_empty() || error.is_some() {
-                    let frame_tokens = tokens.len() as u64;
+                let drained = drain_generation_events(&token_rx);
+                if let Some(count) = drained.completion_tokens {
+                    decode_generated = Some(count);
+                }
+                if !drained.tokens.is_empty() || drained.error.is_some() {
+                    let frame_tokens = drained.tokens.len() as u64;
                     let result = ResultFrame {
                         request_id: meta.request_id,
                         phase: ResultPhase::Continuation,
-                        tokens,
+                        tokens: drained.tokens,
                         start_sequence: next_sequence,
                         done: false,
-                        error,
+                        error: drained.error,
+                        // Only the terminal frame carries the count; intermediate
+                        // continuation frames leave it None.
+                        generated_tokens: None,
                     };
                     self.transport
                         .send(&meta.reply_to, result.encode()?)
@@ -480,15 +505,25 @@ impl ServingCoordinator {
 
             // Terminal frame. The per-tick drain above runs after each
             // finalize_completed, so this drain is normally empty; it exists
-            // as a defensive catch-all so no event can be dropped.
-            let (tokens, _done, error) = drain_generation_events(&token_rx);
+            // as a defensive catch-all so no event can be dropped. The
+            // authoritative decode count rides this terminal frame even when the
+            // count's `Done` event arrived on an earlier tick.
+            let drained = drain_generation_events(&token_rx);
+            if let Some(count) = drained.completion_tokens {
+                decode_generated = Some(count);
+            }
             let result = ResultFrame {
                 request_id: meta.request_id,
                 phase: ResultPhase::Continuation,
-                start_sequence: if tokens.is_empty() { 0 } else { next_sequence },
-                tokens,
+                start_sequence: if drained.tokens.is_empty() {
+                    0
+                } else {
+                    next_sequence
+                },
+                tokens: drained.tokens,
                 done: true,
-                error,
+                error: drained.error,
+                generated_tokens: decode_generated,
             };
             self.transport
                 .send(&meta.reply_to, result.encode()?)
@@ -499,29 +534,58 @@ impl ServingCoordinator {
     }
 }
 
-/// Drain a finished generation channel into its text pieces, terminal flag, and
-/// any error.
+/// The result of draining a finished generation channel: the text pieces, the
+/// terminal flag, any error, and the worker's authoritative generated-token
+/// count when a terminal [`GenerateEvent::Done`] was emitted (issue #387).
+struct DrainedGeneration {
+    /// Detokenized text pieces, in generation order.
+    tokens: Vec<String>,
+    /// `true` when a terminal [`GenerateEvent::Done`] was seen.
+    done: bool,
+    /// A generation error message, if one was emitted.
+    error: Option<String>,
+    /// The worker's authoritative count of model tokens generated for this half
+    /// of the stream, taken from the terminal [`GenerateEvent::Done`]'s
+    /// [`GenerationResult::completion_tokens`]. `None` when this half ended
+    /// without a `Done` event (a prefill node that handed off mid-stream returns
+    /// its single first token without a `Done`).
+    ///
+    /// [`GenerationResult::completion_tokens`]: crate::server::model_provider::GenerationResult::completion_tokens
+    completion_tokens: Option<u64>,
+}
+
+/// Drain a finished generation channel into its text pieces, terminal flag, any
+/// error, and the authoritative generated-token count.
 ///
 /// The serving-role scheduler entries
 /// ([`BatchScheduler::prefill_text_request_for_handoff`] /
 /// [`BatchScheduler::decode_handoff_until_idle`]) run synchronously to
 /// completion and emit their [`GenerateEvent`]s on a local channel before
 /// returning, so a non-blocking drain after the call collects the whole half of
-/// the stream.
-fn drain_generation_events(
-    rx: &mpsc::Receiver<GenerateEvent>,
-) -> (Vec<String>, bool, Option<String>) {
+/// the stream. The terminal `Done` event carries the worker's true model-token
+/// count, which the caller forwards on the wire so the router can report exact
+/// usage even for byte-fallback tokenizers (issue #387).
+fn drain_generation_events(rx: &mpsc::Receiver<GenerateEvent>) -> DrainedGeneration {
     let mut tokens = Vec::new();
     let mut done = false;
     let mut error = None;
+    let mut completion_tokens = None;
     while let Ok(event) = rx.try_recv() {
         match event {
             GenerateEvent::Token(t) | GenerateEvent::TokenWithLogprobs(t, _) => tokens.push(t),
-            GenerateEvent::Done(_) => done = true,
+            GenerateEvent::Done(result) => {
+                done = true;
+                completion_tokens = Some(result.completion_tokens as u64);
+            }
             GenerateEvent::Error(e) => error = Some(e),
         }
     }
-    (tokens, done, error)
+    DrainedGeneration {
+        tokens,
+        done,
+        error,
+        completion_tokens,
+    }
 }
 
 /// A prefill-role work item the serving-role prefill loop turns into a handoff.

--- a/src/distributed/disaggregated/serving_protocol.rs
+++ b/src/distributed/disaggregated/serving_protocol.rs
@@ -136,7 +136,9 @@ pub enum ResultPhase {
 ///
 /// `tokens` are the detokenized text pieces in order; `done` marks the terminal
 /// frame of the request (the decode node sets it on the continuation); `error`
-/// carries a generation error message instead of tokens when one occurred.
+/// carries a generation error message instead of tokens when one occurred;
+/// `generated_tokens` carries the worker's authoritative model-token count for
+/// usage accounting (issue #387).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResultFrame {
     /// Correlates with the originating [`PrefillRequestFrame::request_id`].
@@ -160,6 +162,27 @@ pub struct ResultFrame {
     pub done: bool,
     /// A generation error message, if the node hit one.
     pub error: Option<String>,
+    /// The worker's authoritative count of model tokens this node generated for
+    /// the request (issue #387).
+    ///
+    /// The prefill node sets it on its [`ResultPhase::FirstToken`] frame (the
+    /// number of tokens it sampled: normally 1, or 0 on an immediate EOS at
+    /// prefill); the decode node sets it on its terminal
+    /// [`ResultPhase::Continuation`] frame (the number of tokens it generated
+    /// after the handoff). The router sums the per-node counts to report
+    /// `usage.completion_tokens`, which is exact even for byte-fallback
+    /// tokenizers (e.g. Gemma `<0xXX>` byte sequences) where counting emitted
+    /// detokenized text pieces under-counts: a single character can take several
+    /// model tokens yet surface as one text piece, and a byte-fallback first
+    /// token can surface as none.
+    ///
+    /// `None` on intermediate continuation frames (only the terminal frame
+    /// carries the decode total) and on frames from a sender predating this
+    /// field (decoded via `serde(default)`). When no frame in the stream carries
+    /// a count, the router falls back to counting emitted text pieces, so a
+    /// mixed-version cluster (an older prefill or decode node) keeps working.
+    #[serde(default)]
+    pub generated_tokens: Option<u64>,
 }
 
 macro_rules! json_control_frame {

--- a/src/distributed/disaggregated/serving_protocol_tests.rs
+++ b/src/distributed/disaggregated/serving_protocol_tests.rs
@@ -111,6 +111,7 @@ fn result_frame_round_trips_both_phases() {
         start_sequence: 0,
         done: false,
         error: None,
+        generated_tokens: Some(1),
     };
     let cont = ResultFrame {
         request_id: 3,
@@ -119,6 +120,7 @@ fn result_frame_round_trips_both_phases() {
         start_sequence: 1,
         done: true,
         error: None,
+        generated_tokens: Some(2),
     };
     for frame in [first, cont] {
         let message = frame.encode().expect("encode result");
@@ -130,7 +132,47 @@ fn result_frame_round_trips_both_phases() {
         assert_eq!(decoded.tokens, frame.tokens);
         assert_eq!(decoded.start_sequence, frame.start_sequence);
         assert_eq!(decoded.done, frame.done);
+        assert_eq!(decoded.generated_tokens, frame.generated_tokens);
     }
+}
+
+/// Issue #387: the worker's authoritative generated-token count round-trips
+/// through the result frame so the router can report exact usage for byte-
+/// fallback tokenizers instead of counting emitted text pieces.
+#[test]
+fn result_frame_carries_authoritative_generated_token_count() {
+    let frame = ResultFrame {
+        request_id: 21,
+        phase: ResultPhase::Continuation,
+        tokens: Vec::new(),
+        start_sequence: 0,
+        done: true,
+        error: None,
+        generated_tokens: Some(15),
+    };
+    let message = frame.encode().expect("encode result");
+    let (_op, payload) = control_parts(message).expect("control parts");
+    let decoded = ResultFrame::decode(&payload).expect("decode result");
+    assert_eq!(decoded.generated_tokens, Some(15));
+}
+
+/// Issue #387: `generated_tokens` is `serde(default)` so a frame from a sender
+/// predating the field (no `generated_tokens` key) decodes to `None`, which
+/// makes the router fall back to counting emitted text pieces in a mixed-version
+/// cluster.
+#[test]
+fn result_frame_generated_tokens_defaults_to_none() {
+    let payload = serde_json::json!({
+        "request_id": 8,
+        "phase": "continuation",
+        "tokens": ["x"],
+        "start_sequence": 1,
+        "done": true,
+        "error": null
+    });
+    let decoded: ResultFrame =
+        serde_json::from_slice(&serde_json::to_vec(&payload).unwrap()).expect("decode");
+    assert_eq!(decoded.generated_tokens, None);
 }
 
 /// `start_sequence` is `serde(default)` so frames from senders predating

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -621,12 +621,18 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
                 }
             };
 
+            // `frame_counted` is the emitted-piece fallback count; the resolved
+            // count below prefers the worker's authoritative model-token count
+            // (issue #387) so the finish_reason matches single-node even for
+            // byte-fallback tokenizers.
+            let mut frame_counted = 0usize;
             let result = drive_handoff_result(
                 &mut { rx },
                 &request_id_str2,
                 handoff_timeout,
                 max_tokens,
                 |text| {
+                    frame_counted += 1;
                     emit_filtered(filter.feed(text));
                 },
             )
@@ -637,6 +643,19 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
             emit_filtered(filter.flush());
 
             let completed = result.is_ok();
+            // Mirror single-node chat: "length" when the whole token budget was
+            // generated, else "stop". On a handoff failure finish as "stop"
+            // alongside the visible error delta emitted just above.
+            let finish_reason = match &result {
+                Ok(outcome) => {
+                    if resolve_completion_tokens(outcome, frame_counted, max_tokens) >= max_tokens {
+                        "length"
+                    } else {
+                        "stop"
+                    }
+                }
+                Err(_) => "stop",
+            };
             if let Err(e) = result {
                 let _ = chunk_tx.send(Ok(sse_event(&chat_chunk_error(
                     &request_id_str2,
@@ -644,7 +663,11 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
                     &e.to_string(),
                 ))));
             }
-            let _ = chunk_tx.send(Ok(sse_event(&chat_chunk_finish(&request_id_str2, &model))));
+            let _ = chunk_tx.send(Ok(sse_event(&chat_chunk_finish(
+                &request_id_str2,
+                &model,
+                finish_reason,
+            ))));
             let _ = chunk_tx.send(Ok(Event::default().data("[DONE]")));
 
             state2.pending.lock().unwrap().remove(&request_id);
@@ -661,7 +684,9 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
         let mut content = String::new();
         let mut reasoning = String::new();
         let mut rx = rx;
+        let finish_reason;
         {
+            let mut frame_counted = 0usize;
             let mut absorb = |emit: FilterOutput| {
                 if let Some(r) = emit.reasoning {
                     reasoning.push_str(&r);
@@ -676,6 +701,7 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
                 state.handoff_timeout,
                 opts.max_tokens,
                 |text| {
+                    frame_counted += 1;
                     absorb(filter.feed(text));
                 },
             )
@@ -683,13 +709,24 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
             absorb(filter.flush());
             state.pending.lock().unwrap().remove(&request_id);
             state.finalize_request(&request_id_str, r.is_ok());
-            r?;
+            let outcome = r?;
+            // Mirror single-node chat finish_reason: "length" when the whole
+            // token budget was generated, else "stop", using the worker's
+            // authoritative count when present (issue #387).
+            finish_reason = if resolve_completion_tokens(&outcome, frame_counted, opts.max_tokens)
+                >= opts.max_tokens
+            {
+                "length"
+            } else {
+                "stop"
+            };
         }
         Ok(Json(chat_completion_json(
             &request_id_str,
             &request.model,
             &content,
             &reasoning,
+            finish_reason,
         ))
         .into_response())
     }
@@ -729,12 +766,14 @@ async fn router_completions(
 ///   structured-output constraint, reasoning-budget enforcement) cannot be
 ///   reproduced on the router path. Rejecting keeps the router consistent with
 ///   single-node rather than returning 200 with silently divergent output.
-/// - `completion_tokens` is derived from emitted detokenized text pieces, which
-///   equals the worker's generated-token count for byte-level-BPE tokenizers
-///   (e.g. Qwen) but may under-count for byte-fallback tokenizers (e.g. Gemma
-///   `<0xXX>` byte sequences), and can consequently flip `finish_reason`
-///   between "length" and "stop". A precise fix requires the disaggregated wire
-///   protocol to carry the worker's token count and is deferred to a follow-up.
+/// - `completion_tokens` uses the worker's authoritative generated-token count
+///   carried over the wire ([`ResultFrame::generated_tokens`], issue #387),
+///   which is exact even for byte-fallback tokenizers (e.g. Gemma `<0xXX>` byte
+///   sequences) where counting emitted detokenized text pieces under-counts.
+///   `finish_reason` is derived from that authoritative count with the same
+///   `count >= max_tokens` formula the worker uses, so it matches single-node.
+///   Against a mixed-version cluster where a node predates the wire field, the
+///   router falls back to counting emitted text pieces (the prior behavior).
 async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -> Result<Response> {
     // Admission control first: reject with 503 when the cluster cannot take the
     // request (issue #201), before any per-request work.
@@ -817,7 +856,12 @@ async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -
         let max_tokens = opts.max_tokens;
 
         tokio::spawn(async move {
-            let mut completion_tokens = 0usize;
+            // `frame_counted` is the number of emitted detokenized text pieces
+            // (one `on_token` call per `ResultFrame` text entry). It is the
+            // fallback usage count when the wire carries no authoritative count
+            // (an older worker); the resolved `completion_tokens` below prefers
+            // the worker's true model-token count (issue #387).
+            let mut frame_counted = 0usize;
             let mut rx = rx;
             let result = drive_handoff_result(
                 &mut rx,
@@ -825,15 +869,7 @@ async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -
                 handoff_timeout,
                 max_tokens,
                 |text| {
-                    // `completion_tokens` counts emitted detokenized text pieces
-                    // (one `on_token` call per `ResultFrame` text entry). This
-                    // equals the worker's generated-token count for byte-level-
-                    // BPE tokenizers (e.g. Qwen) but may under-count for byte-
-                    // fallback tokenizers (e.g. Gemma `<0xXX>` byte sequences),
-                    // which can flip the finish_reason below between "length" and
-                    // "stop". A precise fix requires the disaggregated wire
-                    // protocol to carry the worker's token count (follow-up).
-                    completion_tokens += 1;
+                    frame_counted += 1;
                     let chunk = CompletionChunk::content(
                         response_id2.clone(),
                         model.clone(),
@@ -844,12 +880,22 @@ async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -
             )
             .await;
 
+            // Resolve the request's completion token count: prefer the worker's
+            // authoritative count carried over the wire (issue #387), which is
+            // exact even for byte-fallback tokenizers (e.g. Gemma `<0xXX>` byte
+            // sequences) where counting emitted text pieces under-counts; fall
+            // back to the emitted-piece count for an older worker.
+            let completion_tokens = match &result {
+                Ok(outcome) => resolve_completion_tokens(outcome, frame_counted, max_tokens),
+                Err(_) => frame_counted,
+            };
+
             // Mirror the single-node finish_reason exactly: the worker reports
             // "length" when it generated the whole token budget, else "stop"
-            // (model_worker.rs). The disaggregated frames do not carry a
-            // finish_reason, but the router knows both counts, so it reproduces
-            // the same value. On a handoff failure it reports "error" (matching
-            // single-node's streaming error finish_reason).
+            // (model_worker.rs). The router applies the same formula to the
+            // authoritative count, so it reproduces the single-node value. On a
+            // handoff failure it reports "error" (matching single-node's
+            // streaming error finish_reason).
             let finish_reason = if result.is_err() {
                 "error"
             } else if completion_tokens >= max_tokens {
@@ -890,7 +936,7 @@ async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -
         // Non-streaming: collect all tokens, then return a single
         // `CompletionResponse` JSON object identical in shape to single-node.
         let mut text = String::new();
-        let mut completion_tokens = 0usize;
+        let mut frame_counted = 0usize;
         let mut rx = rx;
         let r = drive_handoff_result(
             &mut rx,
@@ -899,14 +945,19 @@ async fn route_completion(state: Arc<RouterState>, request: CompletionRequest) -
             opts.max_tokens,
             |piece| {
                 text.push_str(piece);
-                completion_tokens += 1;
+                frame_counted += 1;
             },
         )
         .await;
         state.pending.lock().unwrap().remove(&request_id);
         state.finalize_request(&response_id, r.is_ok());
-        r?;
+        let outcome = r?;
 
+        // Prefer the worker's authoritative token count carried over the wire
+        // (issue #387), which is exact even for byte-fallback tokenizers where
+        // counting emitted text pieces under-counts; fall back to the emitted-
+        // piece count for an older worker.
+        let completion_tokens = resolve_completion_tokens(&outcome, frame_counted, opts.max_tokens);
         // Mirror the single-node finish_reason exactly (model_worker.rs):
         // "length" when the whole token budget was generated, else "stop".
         // logprobs are rejected up front, so always `None` here.
@@ -1085,20 +1136,66 @@ async fn start_handoff(
 
 // ── Handoff result driver ────────────────────────────────────────────────
 
+/// The authoritative generation outcome the router extracts from the result
+/// frames (issue #387), used to report `usage.completion_tokens` and to derive
+/// `finish_reason` without under-counting byte-fallback tokenizers.
+struct HandoffOutcome {
+    /// Sum of the per-node authoritative model-token counts the workers reported
+    /// (the prefill node's first token plus the decode node's continuation).
+    /// `None` when no frame carried a count, which happens only against a
+    /// mixed-version cluster running an older prefill or decode node that
+    /// predates the wire field; the caller then falls back to counting emitted
+    /// text pieces.
+    generated_tokens: Option<u64>,
+}
+
+/// Resolve a request's `completion_tokens` from the disaggregated result.
+///
+/// Prefers the worker's authoritative generated-token count carried over the
+/// wire (issue #387), which is exact even for byte-fallback tokenizers, and
+/// falls back to `frame_counted` (the number of emitted detokenized text pieces)
+/// when no node reported a count. The authoritative count is clamped to
+/// `max_tokens`: the router bounds generation to its own budget regardless of
+/// the remote `done` flag, so a larger reported count can only come from a buggy
+/// or hostile node and must not inflate the usage figure.
+fn resolve_completion_tokens(
+    outcome: &HandoffOutcome,
+    frame_counted: usize,
+    max_tokens: usize,
+) -> usize {
+    outcome
+        .generated_tokens
+        .map(|n| (n as usize).min(max_tokens))
+        .unwrap_or(frame_counted)
+}
+
 /// Consume the two-part disaggregated result (prefill first token + decode
-/// continuation), call `on_token` for every text piece in order, and return
-/// once the stream is finalized or an error occurs.
+/// continuation), call `on_token` for every text piece in order, and return the
+/// authoritative generation outcome once the stream is finalized (or an error
+/// occurs).
 ///
 /// Uses [`StreamBridge`] to enforce the prefill-decode phase ordering and
-/// detect sequence gaps.
+/// detect sequence gaps. The returned [`HandoffOutcome`] sums the worker-
+/// reported model-token counts so the caller reports exact usage (issue #387).
 async fn drive_handoff_result(
     rx: &mut UnboundedReceiver<ResultFrame>,
     request_id_str: &str,
     handoff_timeout: Duration,
     max_tokens: usize,
     mut on_token: impl FnMut(&str),
-) -> Result<()> {
+) -> Result<HandoffOutcome> {
     let bridge = StreamBridge::new(request_id_str.to_string(), handoff_timeout);
+
+    // Accumulate the per-node authoritative model-token counts (issue #387): the
+    // prefill first-token frame carries its count, the decode terminal frame
+    // carries the continuation count. Summing any frame that carries one is
+    // robust to which node ends the stream.
+    let mut generated_tokens: Option<u64> = None;
+    let mut add_count = |frame_count: Option<u64>| {
+        if let Some(n) = frame_count {
+            generated_tokens = Some(generated_tokens.unwrap_or(0) + n);
+        }
+    };
 
     // Wait for the prefill node's first-token result.
     let first = tokio::time::timeout(handoff_timeout, rx.recv())
@@ -1109,6 +1206,7 @@ async fn drive_handoff_result(
     if let Some(e) = first.error {
         anyhow::bail!("prefill node error: {e}");
     }
+    add_count(first.generated_tokens);
     if let Some(text) = first.tokens.first() {
         bridge
             .submit_first_token(&TokenEvent {
@@ -1123,7 +1221,7 @@ async fn drive_handoff_result(
     }
     if first.done {
         bridge.finalize();
-        return Ok(());
+        return Ok(HandoffOutcome { generated_tokens });
     }
 
     // Transition to the decode phase and consume the incrementally streamed
@@ -1144,6 +1242,7 @@ async fn drive_handoff_result(
         if let Some(e) = cont.error {
             anyhow::bail!("decode node error: {e}");
         }
+        add_count(cont.generated_tokens);
         // The router set the request's token budget itself; do not trust the
         // remote `done` flag to terminate the stream. A decode node that
         // exceeds the budget (buggy or hostile) is cut off here, which also
@@ -1186,7 +1285,7 @@ async fn drive_handoff_result(
         }
     }
     bridge.finalize();
-    Ok(())
+    Ok(HandoffOutcome { generated_tokens })
 }
 
 // ── Small JSON helpers ───────────────────────────────────────────────────
@@ -1245,8 +1344,10 @@ fn chat_chunk_reasoning(id: &str, model: &str, text: &str) -> serde_json::Value 
     })
 }
 
-/// Final streaming chunk with `finish_reason = "stop"`.
-fn chat_chunk_finish(id: &str, model: &str) -> serde_json::Value {
+/// Final streaming chunk carrying the request's `finish_reason` ("stop" or
+/// "length"); the router derives it from the worker's authoritative token count
+/// (issue #387) so it matches the single-node chat route.
+fn chat_chunk_finish(id: &str, model: &str, finish_reason: &str) -> serde_json::Value {
     serde_json::json!({
         "id": id,
         "object": "chat.completion.chunk",
@@ -1254,7 +1355,7 @@ fn chat_chunk_finish(id: &str, model: &str) -> serde_json::Value {
         "choices": [{
             "index": 0,
             "delta": {},
-            "finish_reason": "stop"
+            "finish_reason": finish_reason
         }]
     })
 }
@@ -1274,12 +1375,15 @@ fn chat_chunk_error(id: &str, model: &str, msg: &str) -> serde_json::Value {
 }
 
 /// Non-streaming response body. `reasoning_content` is included only when
-/// the filter routed any thinking text.
+/// the filter routed any thinking text. `finish_reason` ("stop" or "length")
+/// is derived from the worker's authoritative token count (issue #387) so it
+/// matches the single-node chat route.
 fn chat_completion_json(
     id: &str,
     model: &str,
     content: &str,
     reasoning: &str,
+    finish_reason: &str,
 ) -> serde_json::Value {
     let mut message = serde_json::json!({"role": "assistant", "content": content});
     if !reasoning.is_empty() {
@@ -1292,7 +1396,7 @@ fn chat_completion_json(
         "choices": [{
             "index": 0,
             "message": message,
-            "finish_reason": "stop"
+            "finish_reason": finish_reason
         }]
     })
 }
@@ -1315,3 +1419,7 @@ pub fn create_router_app(state: Arc<RouterState>) -> Router {
         .route("/v1/completions", post(router_completions))
         .with_state(state)
 }
+
+#[cfg(test)]
+#[path = "router_front_tests.rs"]
+mod tests;

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -1166,7 +1166,7 @@ fn resolve_completion_tokens(
     outcome
         .generated_tokens
         .map(|n| (n as usize).min(max_tokens))
-        .unwrap_or(frame_counted)
+        .unwrap_or(frame_counted.min(max_tokens))
 }
 
 /// Consume the two-part disaggregated result (prefill first token + decode
@@ -1193,7 +1193,7 @@ async fn drive_handoff_result(
     let mut generated_tokens: Option<u64> = None;
     let mut add_count = |frame_count: Option<u64>| {
         if let Some(n) = frame_count {
-            generated_tokens = Some(generated_tokens.unwrap_or(0) + n);
+            generated_tokens = Some(generated_tokens.unwrap_or(0).saturating_add(n));
         }
     };
 

--- a/src/server/router_front_tests.rs
+++ b/src/server/router_front_tests.rs
@@ -1,0 +1,98 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the disaggregated router front-end's usage accounting
+//! (issue #387).
+//!
+//! Model-free: exercise `resolve_completion_tokens`, the pure function that
+//! turns the worker's authoritative wire-carried token count (or the emitted-
+//! piece fallback) into the reported `usage.completion_tokens`.
+
+use super::*;
+
+/// When the worker reports an authoritative count, it is used verbatim even if
+/// it differs from the emitted-piece count. This is the byte-fallback case: a
+/// Gemma `<0xXX>` sequence produces fewer text pieces than model tokens, so the
+/// frame count under-counts and the authoritative count corrects it.
+#[test]
+fn prefers_authoritative_count_over_frame_count() {
+    let outcome = HandoffOutcome {
+        generated_tokens: Some(10),
+    };
+    // Three multi-byte characters surfaced as 3 text pieces, but the worker
+    // generated 10 model tokens (byte-fallback expansion).
+    assert_eq!(resolve_completion_tokens(&outcome, 3, 16), 10);
+}
+
+/// With no authoritative count on the wire (a mixed-version cluster running an
+/// older prefill or decode node), the router falls back to the emitted-piece
+/// count, preserving the prior behavior.
+#[test]
+fn falls_back_to_frame_count_when_no_authoritative_count() {
+    let outcome = HandoffOutcome {
+        generated_tokens: None,
+    };
+    assert_eq!(resolve_completion_tokens(&outcome, 7, 16), 7);
+}
+
+/// The authoritative count is clamped to `max_tokens`: the router bounds
+/// generation to its own budget, so a larger reported count (a buggy or hostile
+/// node) must not inflate the usage figure.
+#[test]
+fn clamps_authoritative_count_to_max_tokens() {
+    let outcome = HandoffOutcome {
+        generated_tokens: Some(9999),
+    };
+    assert_eq!(resolve_completion_tokens(&outcome, 4, 16), 16);
+}
+
+/// An authoritative count exactly at the budget is reported as-is and drives the
+/// "length" finish_reason (`count >= max_tokens`), matching single-node.
+#[test]
+fn authoritative_count_at_budget_is_length() {
+    let outcome = HandoffOutcome {
+        generated_tokens: Some(16),
+    };
+    let max_tokens = 16;
+    let completion_tokens = resolve_completion_tokens(&outcome, 16, max_tokens);
+    assert_eq!(completion_tokens, 16);
+    assert!(
+        completion_tokens >= max_tokens,
+        "should map to finish=length"
+    );
+}
+
+/// A byte-fallback under-count that would have flipped the finish_reason: the
+/// frame count (15) is below the budget (16) and would report "stop", but the
+/// authoritative count (16) correctly reports "length".
+#[test]
+fn authoritative_count_fixes_finish_reason_flip() {
+    let max_tokens = 16;
+    let frame_counted = 15; // emitted-piece under-count
+    let authoritative = HandoffOutcome {
+        generated_tokens: Some(16),
+    };
+    let no_count = HandoffOutcome {
+        generated_tokens: None,
+    };
+
+    let fixed = resolve_completion_tokens(&authoritative, frame_counted, max_tokens);
+    let legacy = resolve_completion_tokens(&no_count, frame_counted, max_tokens);
+
+    assert!(fixed >= max_tokens, "authoritative count reports length");
+    assert!(
+        legacy < max_tokens,
+        "frame-count fallback would have reported stop"
+    );
+}

--- a/src/server/router_front_tests.rs
+++ b/src/server/router_front_tests.rs
@@ -46,6 +46,18 @@ fn falls_back_to_frame_count_when_no_authoritative_count() {
     assert_eq!(resolve_completion_tokens(&outcome, 7, 16), 7);
 }
 
+/// When no authoritative count is available and the emitted-piece count exceeds
+/// `max_tokens` (which can happen for a hostile or buggy node in a mixed-version
+/// cluster), the fallback is clamped to `max_tokens` for uniform defensiveness.
+#[test]
+fn fallback_frame_count_clamped_to_max_tokens() {
+    let outcome = HandoffOutcome {
+        generated_tokens: None,
+    };
+    // Frame count exceeds the budget; the fallback must not report more than allowed.
+    assert_eq!(resolve_completion_tokens(&outcome, 9999, 16), 16);
+}
+
 /// The authoritative count is clamped to `max_tokens`: the router bounds
 /// generation to its own budget, so a larger reported count (a buggy or hostile
 /// node) must not inflate the usage figure.

--- a/tests/disaggregated_router_e2e.rs
+++ b/tests/disaggregated_router_e2e.rs
@@ -44,6 +44,20 @@ use common::{repo_binary_path, repo_model_dir};
 /// qwen3 checkpoint directory name (pool-backed Fp16, the handoff scope).
 const QWEN3_DIR: &str = "qwen3-0.6b-4bit";
 
+/// Gemma checkpoint directory name (issue #387). Gemma's SentencePiece
+/// tokenizer has `byte_fallback = true`, so a multi-byte character (e.g. the
+/// `é` in "café") is emitted as a `<0xXX>` byte sequence: several model tokens
+/// surfacing as one detokenized text piece. Counting emitted pieces would
+/// under-count those tokens, which is exactly what the authoritative wire count
+/// fixes. Fetch with:
+/// `./target/release/mlxcel download mlx-community/gemma-3-1b-it-4bit`.
+const GEMMA_DIR: &str = "gemma-3-1b-it-4bit";
+
+/// Model alias for the Gemma byte-fallback parity test (single-node baseline
+/// started with `--alias <this>` so its `display_model_id()` matches the router-
+/// echoed `model`).
+const GEMMA_MODEL_ALIAS: &str = "gemma-completions";
+
 /// Expected concatenated SSE content from the router for the test prompt.
 ///
 /// This is the single-node greedy reference: a hybrid `mlxcel-server` answers
@@ -786,6 +800,274 @@ async fn disaggregated_router_completions_match_single_node() {
         "router stream /v1/completions chunks are not byte-identical to single-node"
     );
     eprintln!("OK: router /v1/completions matches single-node (non-stream + stream).");
+}
+
+/// Issue #387: `POST /v1/completions` through the disaggregated router must
+/// report `usage.completion_tokens` and `finish_reason` identical to single-node
+/// for a BYTE-FALLBACK tokenizer (Gemma), not just byte-level-BPE (Qwen).
+///
+/// Gemma's SentencePiece tokenizer emits multi-byte characters as `<0xXX>` byte
+/// sequences: several model tokens that surface as a single detokenized text
+/// piece. The previous router counted emitted pieces, which under-counted those
+/// tokens and could flip `finish_reason` between "length" and "stop". With the
+/// worker's authoritative token count carried over the wire
+/// (`ResultFrame.generated_tokens`), the router reports the exact count.
+///
+/// The prompt forces the multi-byte `é` in "café" into the output so the byte-
+/// fallback path is actually exercised; the full body is compared byte-for-byte
+/// (normalizing only the volatile `id` / `created`), and `usage.completion_tokens`
+/// plus `finish_reason` are asserted explicitly for a clear failure message.
+///
+/// Gated like the other real-model tests: `#[ignore]` plus a checkpoint-presence
+/// guard that skips cleanly when the Gemma checkpoint is absent. Requires a
+/// byte-fallback checkpoint that also supports the pool-backed paged handoff.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "spawns four real mlxcel-server processes loading gemma-3-1b-it-4bit; run with --ignored"]
+async fn disaggregated_router_completions_match_single_node_byte_fallback() {
+    let model_dir = repo_model_dir(GEMMA_DIR);
+    if !model_dir.exists() {
+        eprintln!(
+            "Skipping {GEMMA_DIR}: model directory not found at {}.\n\
+             Fetch with: ./target/release/mlxcel download mlx-community/gemma-3-1b-it-4bit",
+            model_dir.display()
+        );
+        return;
+    }
+    let binary = repo_binary_path("mlxcel-server");
+    if !binary.exists() {
+        eprintln!("Skipping: mlxcel-server binary not found");
+        return;
+    }
+    let model_arg = model_dir.to_string_lossy().to_string();
+    // A prompt that forces the multi-byte `é` (a byte-fallback `<0xXX>`
+    // sequence) into the greedy continuation so the count fix is exercised.
+    let prompt = "Spell the French word for coffee. It is café. Repeat it:";
+    let nonstream_body = serde_json::json!({
+        "model": GEMMA_MODEL_ALIAS,
+        "prompt": prompt,
+        "max_tokens": 16,
+        "temperature": 0.0
+    });
+    let stream_body = serde_json::json!({
+        "model": GEMMA_MODEL_ALIAS,
+        "prompt": prompt,
+        "max_tokens": 16,
+        "temperature": 0.0,
+        "stream": true,
+        "stream_options": {"include_usage": true}
+    });
+    let client = reqwest::Client::new();
+
+    // ---- Single-node reference (started with --alias for model parity) ----
+    let (ref_nonstream, ref_stream_chunks) = {
+        let ports = reserve_ports(1);
+        let http = ports[0].to_string();
+        let _single = spawn_role_server(&[
+            "-m",
+            &model_arg,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &http,
+            "--alias",
+            GEMMA_MODEL_ALIAS,
+            "--no-warmup",
+        ]);
+        let deadline = Instant::now() + Duration::from_secs(240);
+        let health_url = format!("http://127.0.0.1:{http}/health");
+        assert!(
+            wait_for_http_health(&health_url, deadline).await,
+            "single-node Gemma reference never became healthy at {health_url}"
+        );
+        let completions_url = format!("http://127.0.0.1:{http}/v1/completions");
+
+        let ns_resp = client
+            .post(&completions_url)
+            .json(&nonstream_body)
+            .send()
+            .await
+            .expect("POST single-node /v1/completions (non-stream)");
+        assert!(
+            ns_resp.status().is_success(),
+            "single-node non-stream completion returned HTTP {}",
+            ns_resp.status()
+        );
+        let ns_json = ns_resp
+            .json::<serde_json::Value>()
+            .await
+            .expect("parse single-node non-stream completion JSON");
+
+        let st_resp = client
+            .post(&completions_url)
+            .json(&stream_body)
+            .send()
+            .await
+            .expect("POST single-node /v1/completions (stream)");
+        assert!(
+            st_resp.status().is_success(),
+            "single-node stream completion returned HTTP {}",
+            st_resp.status()
+        );
+        let st_body = st_resp.text().await.expect("read single-node SSE body");
+
+        (
+            normalize_completion(ns_json),
+            parse_completion_chunks(&st_body),
+        )
+        // _single drops here, killing the reference server.
+    };
+    eprintln!("single-node Gemma non-stream reference: {ref_nonstream}");
+    let ref_text = ref_nonstream["choices"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        !ref_text.is_empty(),
+        "single-node Gemma reference produced empty completion text; parity check would be vacuous"
+    );
+    // Guard the test's premise: the byte-fallback path is only exercised if the
+    // greedy output actually contains a multi-byte character.
+    assert!(
+        !ref_text.is_ascii(),
+        "single-node Gemma output {ref_text:?} is pure ASCII; the byte-fallback \
+         count path is not exercised. Adjust the prompt so the output contains a \
+         multi-byte character."
+    );
+
+    // ---- Three-process disaggregated router run ----
+    let ports = reserve_ports(6);
+    let prefill_http = ports[0].to_string();
+    let decode_http = ports[1].to_string();
+    let router_http = ports[2].to_string();
+    let prefill_serving_addr = format!("127.0.0.1:{}", ports[3]);
+    let decode_serving_addr = format!("127.0.0.1:{}", ports[4]);
+    let router_serving_addr = format!("127.0.0.1:{}", ports[5]);
+
+    let _decode = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &decode_http,
+        "--parallel",
+        "2",
+        "--max-batch-size",
+        "2",
+        "--decode-storage-backend",
+        "paged",
+        "--node-role",
+        "decode",
+        "--serving-bind",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+    let _prefill = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &prefill_http,
+        "--parallel",
+        "2",
+        "--max-batch-size",
+        "2",
+        "--decode-storage-backend",
+        "paged",
+        "--node-role",
+        "prefill",
+        "--serving-bind",
+        &prefill_serving_addr,
+        "--decode-peers",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+    let _router = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &router_http,
+        "--node-role",
+        "router",
+        "--serving-bind",
+        &router_serving_addr,
+        "--prefill-peers",
+        &prefill_serving_addr,
+        "--decode-peers",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+
+    let deadline = Instant::now() + Duration::from_secs(240);
+    assert!(
+        wait_for_tcp(&decode_serving_addr, deadline).await,
+        "decode node serving transport never came up"
+    );
+    assert!(
+        wait_for_tcp(&prefill_serving_addr, deadline).await,
+        "prefill node serving transport never came up"
+    );
+    let health_url = format!("http://127.0.0.1:{router_http}/health");
+    assert!(
+        wait_for_http_health(&health_url, deadline).await,
+        "router HTTP /health never returned 200"
+    );
+    let router_completions_url = format!("http://127.0.0.1:{router_http}/v1/completions");
+
+    // Non-streaming parity: usage.completion_tokens + finish_reason must match.
+    let router_ns_resp = client
+        .post(&router_completions_url)
+        .json(&nonstream_body)
+        .send()
+        .await
+        .expect("POST router /v1/completions (non-stream)");
+    assert!(
+        router_ns_resp.status().is_success(),
+        "router non-stream completion returned HTTP {}",
+        router_ns_resp.status()
+    );
+    let router_ns = normalize_completion(
+        router_ns_resp
+            .json::<serde_json::Value>()
+            .await
+            .expect("parse router non-stream completion JSON"),
+    );
+    eprintln!("router Gemma non-stream: {router_ns}");
+    assert_eq!(
+        router_ns["usage"]["completion_tokens"], ref_nonstream["usage"]["completion_tokens"],
+        "router usage.completion_tokens diverges from single-node for a byte-fallback tokenizer"
+    );
+    assert_eq!(
+        router_ns["choices"][0]["finish_reason"], ref_nonstream["choices"][0]["finish_reason"],
+        "router finish_reason diverges from single-node for a byte-fallback tokenizer"
+    );
+    assert_eq!(
+        router_ns, ref_nonstream,
+        "router non-stream /v1/completions body is not byte-identical to single-node (Gemma)"
+    );
+
+    // Streaming parity: the usage chunk and finish chunk must match too.
+    let router_st_resp = client
+        .post(&router_completions_url)
+        .json(&stream_body)
+        .send()
+        .await
+        .expect("POST router /v1/completions (stream)");
+    assert!(
+        router_st_resp.status().is_success(),
+        "router stream completion returned HTTP {}",
+        router_st_resp.status()
+    );
+    let router_st_body = router_st_resp.text().await.expect("read router SSE body");
+    let router_st_chunks = parse_completion_chunks(&router_st_body);
+    assert_eq!(
+        router_st_chunks, ref_stream_chunks,
+        "router stream /v1/completions chunks are not byte-identical to single-node (Gemma)"
+    );
+    eprintln!(
+        "OK: router /v1/completions matches single-node for a byte-fallback tokenizer \
+         (usage + finish_reason)."
+    );
 }
 
 // ── Multi-node routing, balancing, and failover (issue #201) ─────────────


### PR DESCRIPTION
## Summary

The disaggregated router derived `usage.completion_tokens` by counting emitted detokenized text pieces in its per-request `on_token` callback. That equals the worker's generated-token count for byte-level-BPE tokenizers (Qwen) but under-counts for byte-fallback tokenizers (Gemma), where a multi-byte character arrives as several `<0xXX>` model tokens but surfaces as one detokenized text piece (or none, for a byte-fallback first token). Because `finish_reason` derives from `completion_tokens >= max_tokens`, the under-count could also flip it between "length" and "stop", diverging from single-node.

This carries the worker's authoritative generated-token count over the serving wire protocol and has the router report it instead of frame-counting.

## What changed

- `src/distributed/disaggregated/serving_protocol.rs`: add `generated_tokens: Option<u64>` to `ResultFrame`, `#[serde(default)]` for backward compatibility (a node predating the field decodes to `None`; an older router ignores the unknown field).
- `src/distributed/disaggregated/coordinator.rs`: `drain_generation_events` now returns the worker's authoritative count from the terminal `GenerateEvent::Done`. The prefill node sets `generated_tokens` on its `FirstToken` frame (its true first-token count: 1 normally, 0 on immediate EOS); the decode node sets it on its terminal `Continuation` frame (its post-handoff count, accumulated across decode ticks). Intermediate continuation frames leave it `None`.
- `src/server/router_front.rs`: `drive_handoff_result` now returns a `HandoffOutcome` summing the per-node counts. `resolve_completion_tokens` prefers the authoritative total, clamps it to `max_tokens` (the router bounds generation to its own budget, so a larger reported count can only come from a buggy or hostile node), and falls back to the emitted-piece count when no frame carried one. `finish_reason` is derived from the authoritative count with the same `count >= max_tokens` formula the worker uses, so it matches single-node. Applies to `/v1/completions` (streaming and non-streaming) and `/v1/chat/completions` (the finish chunk and non-streaming body now carry the derived `finish_reason` instead of a hard-coded "stop").

## Backward compatibility

The wire change is additive and optional. In a mixed-version cluster, a frame from an older prefill or decode node arrives with `generated_tokens = None` (serde default), and the router transparently falls back to the previous frame-counting behavior. A new node's extra field is ignored by an older router.

## Test plan

- [x] `cargo check --lib --tests --features metal,accelerate` (exit 0)
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings` (exit 0)
- [x] `cargo test --lib --features metal,accelerate -- router_front::tests serving_protocol::tests` (15 passed): protocol round-trip with the new field present and absent; router resolution covering authoritative-vs-fallback selection, the `max_tokens` clamp, and the finish_reason-flip case.
- [ ] `tests/disaggregated_router_e2e.rs::disaggregated_router_completions_match_single_node_byte_fallback`: a new byte-fallback (Gemma) `/v1/completions` parity test asserting `usage.completion_tokens` and `finish_reason` match single-node. Gated behind `#[ignore]` plus a checkpoint-presence guard like the other real-model tests; not run in this environment (no Gemma checkpoint available). It requires a byte-fallback checkpoint that also supports the pool-backed paged handoff and must be run explicitly with `--ignored`.

Closes #387
