### PR TITLE
fix(server): preserve assistant reasoning field across turns

### DIFF
--- a/docs/responses-api.md
+++ b/docs/responses-api.md
@@ -101,8 +101,7 @@ Phase 1 supports these typed items:
 ]
 ```
 
-`developer` role is treated like `system`. Reasoning input items are accepted
-but are not fed back into the next prompt.
+`developer` role is treated like `system`. Reasoning input items are accepted and forwarded: the text content is buffered and attached to the parallel `reasoning` field of the following assistant turn. Chat templates that render `message.get('reasoning')` (such as Gemma 4) receive it there. The `preserve_thinking` kwarg controls whether the field survives the rolling-checkpoint strip: `false` (the default, unless the prompt cache is on) drops prior-turn reasoning along with any inline `<think>` blocks; `true` retains it.
 
 Message content parts reuse mlxcel's chat-completions content part types. This
 means `text`, `image_url`, `video_url`, and `input_audio` can deserialize, but

--- a/src/server/anthropic_translator.rs
+++ b/src/server/anthropic_translator.rs
@@ -85,6 +85,7 @@ pub fn anthropic_request_to_chat(request: &AnthropicRequest) -> AnthropicTransla
             content: MessageContent::Text(text),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         });
     }
@@ -176,6 +177,7 @@ fn append_message(out: &mut Vec<Message>, message: &AnthropicMessage) {
                 content: MessageContent::Text(text.clone()),
                 name: None,
                 tool_call_id: None,
+                reasoning: None,
                 tool_calls: None,
             });
         }
@@ -184,6 +186,7 @@ fn append_message(out: &mut Vec<Message>, message: &AnthropicMessage) {
             let mut image_parts: Vec<ContentPart> = Vec::new();
             let mut tool_calls: Vec<ToolCallInMessage> = Vec::new();
             let mut tool_results: Vec<Message> = Vec::new();
+            let mut reasoning_parts: Vec<String> = Vec::new();
 
             for block in blocks {
                 match block {
@@ -228,9 +231,22 @@ fn append_message(out: &mut Vec<Message>, message: &AnthropicMessage) {
                             ));
                         }
                     }
-                    AnthropicContentBlock::Thinking { .. } | AnthropicContentBlock::Unknown => {
-                        // Dropped: thinking traces and unknown blocks do not
-                        // feed back into the next prompt.
+                    AnthropicContentBlock::Thinking { thinking } => {
+                        // Forward extended-thinking traces from assistant turns
+                        // into the parallel `reasoning` field (issue #362) so
+                        // templates that render `message.get('reasoning')` see
+                        // prior thinking across turns. Thinking on non-assistant
+                        // turns is meaningless and ignored.
+                        if message.role == AnthropicRole::Assistant
+                            && let Some(text) = thinking.as_ref()
+                            && !text.is_empty()
+                        {
+                            reasoning_parts.push(text.clone());
+                        }
+                    }
+                    AnthropicContentBlock::Unknown => {
+                        // Dropped: unknown blocks do not feed back into the
+                        // next prompt.
                     }
                 }
             }
@@ -256,11 +272,17 @@ fn append_message(out: &mut Vec<Message>, message: &AnthropicMessage) {
                 } else {
                     MessageContent::Text(joined_text)
                 };
+                let reasoning = if reasoning_parts.is_empty() {
+                    None
+                } else {
+                    Some(reasoning_parts.join("\n"))
+                };
                 out.push(Message {
                     role,
                     content,
                     name: None,
                     tool_call_id: None,
+                    reasoning,
                     tool_calls: if tool_calls.is_empty() {
                         None
                     } else {
@@ -363,6 +385,7 @@ fn fold_system_messages(messages: &mut Vec<Message>) {
             content: MessageContent::Text(text),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         });
     }
@@ -494,6 +517,7 @@ fn tool_result_message(
         content: message_content,
         name: None,
         tool_call_id: tool_use_id.map(|s| s.to_string()),
+        reasoning: None,
         tool_calls: None,
     }
 }
@@ -768,6 +792,24 @@ mod tests {
         assert_eq!(calls[0].id, "toolu_1");
         assert_eq!(calls[0].function.name, "get_weather");
         assert_eq!(calls[0].function.arguments, r#"{"city":"SF"}"#);
+    }
+
+    #[test]
+    fn assistant_thinking_block_becomes_reasoning_field() {
+        // Issue #362: an Anthropic assistant `thinking` block is forwarded onto
+        // the internal message's parallel `reasoning` field for cross-API
+        // consistency, instead of being dropped.
+        let req = parse_req(
+            r#"{"model":"m","messages":[{"role":"assistant","content":[
+                {"type":"thinking","thinking":"step by step"},
+                {"type":"text","text":"the answer"}
+            ]}]}"#,
+        );
+        let t = anthropic_request_to_chat(&req);
+        let msg = &t.chat_request.messages[0];
+        assert!(matches!(msg.role, Role::Assistant));
+        assert_eq!(msg.content.text(), "the answer");
+        assert_eq!(msg.reasoning.as_deref(), Some("step by step"));
     }
 
     #[test]

--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -175,9 +175,12 @@ pub(crate) async fn prepare_chat_request_with_cache(
 
     let preserve_thinking = merged_kwargs.preserve_thinking();
 
-    let prompt = if has_tool_fields(request) {
-        // When messages contain tool_calls or tool_call_id, use raw JSON
-        // rendering so the Jinja2 template can access all fields.
+    let prompt = if has_tool_fields(request) || has_reasoning_fields(request) {
+        // When messages contain tool_calls / tool_call_id, or a parallel
+        // `reasoning` field (issue #362), use raw JSON rendering so the Jinja2
+        // template can access all fields. The typed `ChatMessage` path only
+        // carries role + content, so reasoning would otherwise be dropped
+        // before reaching templates that render `message.get('reasoning')`.
         let raw_messages = build_raw_json_messages_with_thinking(request, preserve_thinking);
         // Build the stripped ChatMessages in parallel so the fallback path can
         // use them without re-running strip_rolling_checkpoint.
@@ -267,6 +270,18 @@ fn has_tool_fields(request: &ChatCompletionRequest) -> bool {
         .any(|m| m.tool_call_id.is_some() || m.tool_calls.is_some())
 }
 
+/// Check if any message carries a non-empty `reasoning` field (issue #362).
+///
+/// Such requests must take the raw-JSON render path so the parallel reasoning
+/// reaches templates that read `message.get('reasoning')`; the typed
+/// [`ChatMessage`] path drops everything except role and content.
+fn has_reasoning_fields(request: &ChatCompletionRequest) -> bool {
+    request
+        .messages
+        .iter()
+        .any(|m| m.reasoning.as_ref().is_some_and(|r| !r.is_empty()))
+}
+
 /// Build raw JSON messages for template rendering, preserving all fields
 /// (including tool_calls, tool_call_id) so Jinja2 templates can iterate over
 /// multi-turn tool-use conversations.
@@ -315,8 +330,9 @@ fn build_raw_json_messages_with_thinking(
         .enumerate()
         .map(|(idx, m)| {
             // Strip think blocks from assistant messages before the checkpoint.
+            let stripped = strip_indices.contains(&idx);
             let raw_content = m.content.text();
-            let content = if strip_indices.contains(&idx) {
+            let content = if stripped {
                 strip_think_block(&raw_content).into_owned()
             } else {
                 raw_content
@@ -338,6 +354,28 @@ fn build_raw_json_messages_with_thinking(
                     serde_json::to_value(tool_calls).unwrap_or(serde_json::Value::Null);
                 normalize_tool_call_arguments(&mut tc_value);
                 msg["tool_calls"] = tc_value;
+            }
+
+            // Forward the parallel `reasoning` field (issue #362) so templates
+            // that render `message.get('reasoning')` (e.g. Gemma 4) see prior
+            // assistant thinking across turns. The decision mirrors the inline
+            // `<think>` handling exactly so the two channels stay consistent:
+            //
+            // - When this message is being stripped (preserve_thinking=false and
+            //   it sits before the rolling checkpoint), drop the reasoning field
+            //   too. Stripping the inline block while leaking the parallel field
+            //   would still feed prior thinking back into the prompt.
+            // - When preserve_thinking=true (or this is the retained latest
+            //   reply), forward the reasoning field, unless the content already
+            //   carries an inline `<think>` block. Forwarding it on top of an
+            //   inline block would double-inject the same reasoning into
+            //   templates that render both channels.
+            if !stripped
+                && let Some(reasoning) = m.reasoning.as_ref()
+                && !reasoning.is_empty()
+                && !content.contains("<think>")
+            {
+                msg["reasoning"] = serde_json::Value::String(reasoning.clone());
             }
 
             msg

--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -62,6 +62,7 @@ fn build_chat_messages_flattens_text_parts() {
         ]),
         name: None,
         tool_call_id: None,
+        reasoning: None,
         tool_calls: None,
     }]);
 
@@ -87,6 +88,7 @@ async fn prepare_chat_request_uses_template_output_and_extracts_images() {
         ]),
         name: None,
         tool_call_id: None,
+        reasoning: None,
         tool_calls: None,
     }]);
     let processor =
@@ -106,6 +108,7 @@ async fn prepare_chat_request_falls_back_to_simple_prompt_on_template_error() {
         content: MessageContent::Text("Hello".to_string()),
         name: None,
         tool_call_id: None,
+        reasoning: None,
         tool_calls: None,
     }]);
     let processor = ChatTemplateProcessor::with_template("{% if %}".to_string());
@@ -316,6 +319,7 @@ fn build_raw_json_messages_includes_tool_fields() {
                 content: MessageContent::Text(String::new()),
                 name: None,
                 tool_call_id: None,
+                reasoning: None,
                 tool_calls: Some(vec![ToolCallInMessage {
                     id: "call_123".to_string(),
                     call_type: "function".to_string(),
@@ -330,6 +334,7 @@ fn build_raw_json_messages_includes_tool_fields() {
                 content: MessageContent::Text("Sunny".to_string()),
                 name: None,
                 tool_call_id: Some("call_123".to_string()),
+                reasoning: None,
                 tool_calls: None,
             },
         ],
@@ -373,6 +378,7 @@ fn req_with_tool_call_arguments(arguments: &str) -> ChatCompletionRequest {
             content: MessageContent::Text(String::new()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: Some(vec![ToolCallInMessage {
                 id: "call_1".to_string(),
                 call_type: "function".to_string(),
@@ -463,6 +469,7 @@ async fn prepare_chat_request_renders_tool_call_arguments_as_mapping() {
             content: MessageContent::Text("Read a file".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -470,6 +477,7 @@ async fn prepare_chat_request_renders_tool_call_arguments_as_mapping() {
             content: MessageContent::Text(String::new()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: Some(vec![ToolCallInMessage {
                 id: "call_1".to_string(),
                 call_type: "function".to_string(),
@@ -484,6 +492,7 @@ async fn prepare_chat_request_renders_tool_call_arguments_as_mapping() {
             content: MessageContent::Text("ok".to_string()),
             name: None,
             tool_call_id: Some("call_1".to_string()),
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -491,6 +500,7 @@ async fn prepare_chat_request_renders_tool_call_arguments_as_mapping() {
             content: MessageContent::Text("Continue".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
     ]);
@@ -621,6 +631,7 @@ fn three_turn_request_with_think_blocks() -> ChatCompletionRequest {
             content: MessageContent::Text("What is 2+2?".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -630,6 +641,7 @@ fn three_turn_request_with_think_blocks() -> ChatCompletionRequest {
             ),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -637,6 +649,7 @@ fn three_turn_request_with_think_blocks() -> ChatCompletionRequest {
             content: MessageContent::Text("And 3+3?".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -644,6 +657,7 @@ fn three_turn_request_with_think_blocks() -> ChatCompletionRequest {
             content: MessageContent::Text("<think>\ncalc 3+3\n</think>\n\nSix.".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -651,6 +665,7 @@ fn three_turn_request_with_think_blocks() -> ChatCompletionRequest {
             content: MessageContent::Text("And 4+4?".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
     ])
@@ -806,6 +821,7 @@ async fn prefix_stability_across_turns_when_preserve_thinking_true() {
             content: MessageContent::Text("q1".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -813,6 +829,7 @@ async fn prefix_stability_across_turns_when_preserve_thinking_true() {
             content: MessageContent::Text("<think>think1</think>a1".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -820,6 +837,7 @@ async fn prefix_stability_across_turns_when_preserve_thinking_true() {
             content: MessageContent::Text("q2".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
     ];
@@ -831,6 +849,7 @@ async fn prefix_stability_across_turns_when_preserve_thinking_true() {
         content: MessageContent::Text("<think>think2</think>a2".to_string()),
         name: None,
         tool_call_id: None,
+        reasoning: None,
         tool_calls: None,
     });
     messages_t3.push(Message {
@@ -838,6 +857,7 @@ async fn prefix_stability_across_turns_when_preserve_thinking_true() {
         content: MessageContent::Text("q3".to_string()),
         name: None,
         tool_call_id: None,
+        reasoning: None,
         tool_calls: None,
     });
 
@@ -996,6 +1016,7 @@ async fn rolling_checkpoint_tolerates_tool_turn_in_middle() {
             content: MessageContent::Text("q1".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -1003,6 +1024,7 @@ async fn rolling_checkpoint_tolerates_tool_turn_in_middle() {
             content: MessageContent::Text("<think>plan</think>call tool".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -1010,6 +1032,7 @@ async fn rolling_checkpoint_tolerates_tool_turn_in_middle() {
             content: MessageContent::Text("q2".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -1017,6 +1040,7 @@ async fn rolling_checkpoint_tolerates_tool_turn_in_middle() {
             content: MessageContent::Text("tool-result".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
     ];
@@ -1063,6 +1087,7 @@ async fn rolling_checkpoint_ignores_pseudo_user_tool_response_anchor() {
             content: MessageContent::Text("q1".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -1070,6 +1095,7 @@ async fn rolling_checkpoint_ignores_pseudo_user_tool_response_anchor() {
             content: MessageContent::Text("<think>plan 1</think>a1".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -1077,6 +1103,7 @@ async fn rolling_checkpoint_ignores_pseudo_user_tool_response_anchor() {
             content: MessageContent::Text("q2".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -1084,6 +1111,7 @@ async fn rolling_checkpoint_ignores_pseudo_user_tool_response_anchor() {
             content: MessageContent::Text("<think>plan 2</think>a2".to_string()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
         Message {
@@ -1093,6 +1121,7 @@ async fn rolling_checkpoint_ignores_pseudo_user_tool_response_anchor() {
             ),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         },
     ];
@@ -1539,6 +1568,7 @@ async fn chat_request_drops_temp_files_on_completion() {
             }]),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         }],
         stream: false,
@@ -1586,5 +1616,176 @@ async fn chat_request_drops_temp_files_on_completion() {
     assert!(
         !temp_path.exists(),
         "temp file must be removed once PreparedChatRequest drops; remained at {temp_path:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #362: assistant `reasoning` field preserved across turns
+// ---------------------------------------------------------------------------
+
+/// Gemma-4-style template: renders `message.get('reasoning')` as a thought
+/// channel before each turn's content, so we can assert exactly when a prior
+/// reasoning trace reaches the prompt.
+fn reasoning_dump_template() -> String {
+    "{% for m in messages %}\
+{% set r = m.get('reasoning') %}\
+{% if r %}[REASON:{{ r }}]{% endif %}\
+[{{ m.role }}:{{ m.content }}]\
+{% endfor %}"
+        .to_string()
+}
+
+/// 2-turn conversation whose assistant reply carries reasoning in the parallel
+/// `reasoning` field (no inline `<think>` in its content), followed by a new
+/// user turn. Per the rolling checkpoint, the assistant turn is strictly
+/// before the latest user turn, so it is a "prior" turn for stripping.
+fn request_with_prior_assistant_reasoning() -> ChatCompletionRequest {
+    request_with_messages(vec![
+        Message {
+            role: Role::User,
+            content: MessageContent::Text("What is 2+2?".to_string()),
+            name: None,
+            tool_call_id: None,
+            reasoning: None,
+            tool_calls: None,
+        },
+        Message {
+            role: Role::Assistant,
+            content: MessageContent::Text("The answer is 4.".to_string()),
+            name: None,
+            tool_call_id: None,
+            reasoning: Some("compute 2+2=4".to_string()),
+            tool_calls: None,
+        },
+        Message {
+            role: Role::User,
+            content: MessageContent::Text("And 3+3?".to_string()),
+            name: None,
+            tool_call_id: None,
+            reasoning: None,
+            tool_calls: None,
+        },
+    ])
+}
+
+#[tokio::test]
+async fn assistant_reasoning_reaches_prompt_when_preserve_thinking_true() {
+    // preserve_thinking=true must forward the parallel reasoning field through
+    // the real raw-JSON render path into the rendered prompt (issue #362).
+    let mut request = request_with_prior_assistant_reasoning();
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "preserve_thinking".to_string(),
+        serde_json::Value::Bool(true),
+    );
+    request.chat_template_kwargs = Some(map);
+
+    let processor = ChatTemplateProcessor::with_template(reasoning_dump_template());
+    let prepared = prepare_chat_request(&processor, &request, None)
+        .await
+        .unwrap();
+
+    assert!(
+        prepared.prompt.contains("[REASON:compute 2+2=4]"),
+        "assistant reasoning must reach the prompt when preserve_thinking=true; got: {:?}",
+        prepared.prompt
+    );
+    assert!(prepared.prompt.contains("The answer is 4."));
+}
+
+#[tokio::test]
+async fn assistant_reasoning_stripped_when_preserve_thinking_false_default() {
+    // Default (preserve_thinking=false): a prior assistant turn's reasoning is
+    // stripped consistently with its inline <think> block, so it must not leak
+    // into the next prompt (issue #362).
+    let request = request_with_prior_assistant_reasoning();
+    let processor = ChatTemplateProcessor::with_template(reasoning_dump_template());
+    let prepared = prepare_chat_request(&processor, &request, None)
+        .await
+        .unwrap();
+
+    assert!(
+        !prepared.prompt.contains("compute 2+2=4"),
+        "prior reasoning must be stripped by default; got: {:?}",
+        prepared.prompt
+    );
+    assert!(
+        !prepared.prompt.contains("[REASON:"),
+        "no reasoning channel should render by default; got: {:?}",
+        prepared.prompt
+    );
+    // The visible answer is untouched by reasoning stripping.
+    assert!(prepared.prompt.contains("The answer is 4."));
+}
+
+#[tokio::test]
+async fn reasoning_not_double_injected_when_content_has_inline_think() {
+    // When the retained turn's content already carries an inline <think> block,
+    // the parallel reasoning field must not also be forwarded, or templates
+    // that render both channels would inject the same reasoning twice.
+    let request = request_with_messages(vec![
+        Message {
+            role: Role::User,
+            content: MessageContent::Text("What is 2+2?".to_string()),
+            name: None,
+            tool_call_id: None,
+            reasoning: None,
+            tool_calls: None,
+        },
+        Message {
+            role: Role::Assistant,
+            content: MessageContent::Text(
+                "<think>\ninline reasoning\n</think>\n\nThe answer is 4.".to_string(),
+            ),
+            name: None,
+            tool_call_id: None,
+            reasoning: Some("DUPLICATE_TRACE".to_string()),
+            tool_calls: None,
+        },
+    ]);
+    // preserve_thinking=true so the trailing assistant turn is retained.
+    let mut request = request;
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "preserve_thinking".to_string(),
+        serde_json::Value::Bool(true),
+    );
+    request.chat_template_kwargs = Some(map);
+
+    let processor = ChatTemplateProcessor::with_template(reasoning_dump_template());
+    let prepared = prepare_chat_request(&processor, &request, None)
+        .await
+        .unwrap();
+
+    // Inline block survives via content; the parallel reasoning channel is
+    // suppressed to avoid the duplicate.
+    assert!(
+        prepared.prompt.contains("inline reasoning"),
+        "inline <think> content must remain; got: {:?}",
+        prepared.prompt
+    );
+    assert!(
+        !prepared.prompt.contains("DUPLICATE_TRACE"),
+        "parallel reasoning must not be double-injected over inline <think>; got: {:?}",
+        prepared.prompt
+    );
+}
+
+#[test]
+fn reasoning_field_routes_request_through_raw_json_path() {
+    // A reasoning-bearing request (no tool fields) must still take the raw-JSON
+    // path so the reasoning reaches templates that read message.get('reasoning').
+    let request = request_with_prior_assistant_reasoning();
+    // preserve_thinking=true so the field is forwarded for the retained turns.
+    let raw = build_raw_json_messages(&request);
+    let arr = raw.as_array().expect("raw messages must be an array");
+    let assistant = arr
+        .iter()
+        .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("assistant"))
+        .expect("assistant message present");
+    assert_eq!(
+        assistant.get("reasoning").and_then(|r| r.as_str()),
+        Some("compute 2+2=4"),
+        "raw JSON assistant message must carry the reasoning field"
     );
 }

--- a/src/server/media_tests.rs
+++ b/src/server/media_tests.rs
@@ -35,6 +35,7 @@ fn build_chat_request(parts: Vec<ContentPart>) -> ChatCompletionRequest {
             content: MessageContent::Parts(parts),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         }],
         stream: false,
@@ -187,6 +188,7 @@ async fn extract_chat_image_data_collects_images_across_messages() {
                 content: MessageContent::Text("ignore".to_string()),
                 name: None,
                 tool_call_id: None,
+                reasoning: None,
                 tool_calls: None,
             },
             Message {
@@ -208,6 +210,7 @@ async fn extract_chat_image_data_collects_images_across_messages() {
                 ]),
                 name: None,
                 tool_call_id: None,
+                reasoning: None,
                 tool_calls: None,
             },
         ],

--- a/src/server/responses_translator.rs
+++ b/src/server/responses_translator.rs
@@ -373,6 +373,15 @@ fn input_items_to_messages(items: &[ResponseInputItem]) -> Vec<Message> {
                     reasoning: None,
                     tool_calls: None,
                 });
+                // A tool-output turn is not an assistant turn, so any buffered
+                // reasoning that was not consumed by the flush above (e.g.
+                // malformed input: Reasoning immediately followed by
+                // FunctionCallOutput with no preceding FunctionCall) must be
+                // cleared here. Without this, the buffered reasoning leaks onto
+                // the next assistant turn, violating the invariant that a
+                // reasoning item not followed by an assistant turn before the
+                // next turn boundary is dropped.
+                pending_reasoning = None;
             }
             ResponseInputItem::Reasoning { content } => {
                 // Buffer the reasoning text and attach it to the following
@@ -810,6 +819,112 @@ mod tests {
         assert_eq!(
             user.reasoning, None,
             "reasoning must not leak onto user turn"
+        );
+    }
+
+    #[test]
+    fn reasoning_does_not_leak_when_function_call_output_has_no_preceding_function_call() {
+        // Regression for the MEDIUM bug: a Reasoning item immediately followed
+        // by a FunctionCallOutput with no preceding FunctionCall (malformed
+        // input) must not attach the buffered reasoning to the next assistant
+        // turn. The FunctionCallOutput arm must clear pending_reasoning even
+        // when the tool-call flush is skipped.
+        use crate::server::types::responses_request::{
+            ReasoningContentPart, ResponseInputContent, ResponseInputItem, ResponseInputRole,
+        };
+        let items = vec![
+            ResponseInputItem::Reasoning {
+                content: vec![ReasoningContentPart {
+                    part_type: "reasoning_text".to_string(),
+                    text: "orphaned reasoning".to_string(),
+                }],
+            },
+            // No FunctionCall precedes this output, so pending_tool_calls is
+            // empty and the flush block that would consume pending_reasoning is
+            // skipped. The arm must still clear pending_reasoning.
+            ResponseInputItem::FunctionCallOutput {
+                call_id: "call_orphan".to_string(),
+                output: "result".to_string(),
+            },
+            ResponseInputItem::Message {
+                role: ResponseInputRole::Assistant,
+                content: ResponseInputContent::Text("answer".to_string()),
+                name: None,
+            },
+        ];
+        let req = make_request(ResponseInput::Items(items));
+        let translated = responses_request_to_chat(&req, None, None).unwrap();
+        let assistant = translated
+            .chat_request
+            .messages
+            .iter()
+            .find(|m| matches!(m.role, Role::Assistant))
+            .expect("assistant turn present");
+        assert_eq!(
+            assistant.reasoning, None,
+            "reasoning must not leak onto the assistant turn after a bare FunctionCallOutput"
+        );
+    }
+
+    #[test]
+    fn reasoning_attaches_to_function_call_turn_in_normal_tool_flow() {
+        // Confirms the normal Reasoning -> FunctionCall -> FunctionCallOutput
+        // flow is unaffected by the pending_reasoning = None fix: reasoning
+        // still attaches to the function-call assistant turn, not the tool
+        // turn, and the following message sees no reasoning.
+        use crate::server::types::responses_request::{
+            ReasoningContentPart, ResponseInputContent, ResponseInputItem, ResponseInputRole,
+        };
+        let items = vec![
+            ResponseInputItem::Message {
+                role: ResponseInputRole::User,
+                content: ResponseInputContent::Text("call a tool".to_string()),
+                name: None,
+            },
+            ResponseInputItem::Reasoning {
+                content: vec![ReasoningContentPart {
+                    part_type: "reasoning_text".to_string(),
+                    text: "I should call do_thing".to_string(),
+                }],
+            },
+            ResponseInputItem::FunctionCall {
+                call_id: "call_1".to_string(),
+                name: "do_thing".to_string(),
+                arguments: "{}".to_string(),
+            },
+            ResponseInputItem::FunctionCallOutput {
+                call_id: "call_1".to_string(),
+                output: "done".to_string(),
+            },
+            ResponseInputItem::Message {
+                role: ResponseInputRole::Assistant,
+                content: ResponseInputContent::Text("all done".to_string()),
+                name: None,
+            },
+        ];
+        let req = make_request(ResponseInput::Items(items));
+        let translated = responses_request_to_chat(&req, None, None).unwrap();
+        let msgs = &translated.chat_request.messages;
+
+        // The function-call flush produces an assistant turn that carries the
+        // reasoning; the later text assistant turn must not carry it.
+        let function_call_turn = msgs
+            .iter()
+            .find(|m| matches!(m.role, Role::Assistant) && m.tool_calls.is_some())
+            .expect("function-call assistant turn present");
+        assert_eq!(
+            function_call_turn.reasoning.as_deref(),
+            Some("I should call do_thing"),
+            "reasoning must attach to the function-call assistant turn"
+        );
+
+        let text_assistant_turn = msgs
+            .iter()
+            .find(|m| matches!(m.role, Role::Assistant) && m.tool_calls.is_none())
+            .expect("text assistant turn present");
+        assert_eq!(
+            text_assistant_turn.reasoning, None,
+            "reasoning must not leak onto the later text assistant turn"
         );
     }
 

--- a/src/server/responses_translator.rs
+++ b/src/server/responses_translator.rs
@@ -188,6 +188,7 @@ pub fn responses_request_to_chat(
             content: MessageContent::Text(instr.clone()),
             name: None,
             tool_call_id: None,
+            reasoning: None,
             tool_calls: None,
         });
     }
@@ -292,11 +293,15 @@ fn function_tools(tools: Option<&[ResponseTool]>) -> Option<Vec<Tool>> {
 ///
 /// `function_call` items become assistant messages with `tool_calls`;
 /// `function_call_output` items become tool messages with the matching
-/// `tool_call_id`. Reasoning items are dropped during conversion because
-/// downstream chat-template renderers don't expect them as turns.
+/// `tool_call_id`. A `reasoning` item is not emitted as its own turn; instead
+/// its text is buffered and attached to the parallel `reasoning` field of the
+/// following assistant turn (issue #362) so templates that read
+/// `message.get('reasoning')` see prior thinking. A reasoning item that is not
+/// followed by an assistant turn before the next turn boundary is dropped.
 fn input_items_to_messages(items: &[ResponseInputItem]) -> Vec<Message> {
     let mut out: Vec<Message> = Vec::new();
     let mut pending_tool_calls: Vec<ToolCallInMessage> = Vec::new();
+    let mut pending_reasoning: Option<String> = None;
 
     for item in items {
         match item {
@@ -305,6 +310,7 @@ fn input_items_to_messages(items: &[ResponseInputItem]) -> Vec<Message> {
                 content,
                 name,
             } => {
+                let converted_role = convert_role(*role);
                 // Flush any pending tool calls as an assistant turn
                 // before emitting the next role message.
                 if !pending_tool_calls.is_empty() {
@@ -313,16 +319,26 @@ fn input_items_to_messages(items: &[ResponseInputItem]) -> Vec<Message> {
                         content: MessageContent::Text(String::new()),
                         name: None,
                         tool_call_id: None,
+                        reasoning: pending_reasoning.take(),
                         tool_calls: Some(std::mem::take(&mut pending_tool_calls)),
                     });
                 }
+                let reasoning = if converted_role == Role::Assistant {
+                    pending_reasoning.take()
+                } else {
+                    None
+                };
                 out.push(Message {
-                    role: convert_role(*role),
+                    role: converted_role,
                     content: convert_content(content),
                     name: name.clone(),
                     tool_call_id: None,
+                    reasoning,
                     tool_calls: None,
                 });
+                // A turn boundary consumes any leftover reasoning so it cannot
+                // leak onto a later, unrelated assistant turn.
+                pending_reasoning = None;
             }
             ResponseInputItem::FunctionCall {
                 call_id,
@@ -345,6 +361,7 @@ fn input_items_to_messages(items: &[ResponseInputItem]) -> Vec<Message> {
                         content: MessageContent::Text(String::new()),
                         name: None,
                         tool_call_id: None,
+                        reasoning: pending_reasoning.take(),
                         tool_calls: Some(std::mem::take(&mut pending_tool_calls)),
                     });
                 }
@@ -353,13 +370,23 @@ fn input_items_to_messages(items: &[ResponseInputItem]) -> Vec<Message> {
                     content: MessageContent::Text(output.clone()),
                     name: None,
                     tool_call_id: Some(call_id.clone()),
+                    reasoning: None,
                     tool_calls: None,
                 });
             }
-            ResponseInputItem::Reasoning { .. } => {
-                // Phase 1: drop. Reasoning text from a prior turn does
-                // not feed back into the next prompt — the chat
-                // template handles thinking state automatically.
+            ResponseInputItem::Reasoning { content } => {
+                // Buffer the reasoning text and attach it to the following
+                // assistant turn (issue #362) so templates that render
+                // `message.get('reasoning')` see the model's prior thinking.
+                let text = content
+                    .iter()
+                    .map(|p| p.text.as_str())
+                    .filter(|t| !t.is_empty())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if !text.is_empty() {
+                    pending_reasoning = Some(text);
+                }
             }
         }
     }
@@ -370,6 +397,7 @@ fn input_items_to_messages(items: &[ResponseInputItem]) -> Vec<Message> {
             content: MessageContent::Text(String::new()),
             name: None,
             tool_call_id: None,
+            reasoning: pending_reasoning.take(),
             tool_calls: Some(pending_tool_calls),
         });
     }
@@ -738,6 +766,51 @@ mod tests {
             Role::User
         ));
         assert_eq!(translated.chat_request.messages[0].content.text(), "hello");
+    }
+
+    #[test]
+    fn reasoning_item_attaches_to_following_assistant_message() {
+        // Issue #362: a Responses `reasoning` item is not its own turn; its
+        // text rides on the parallel `reasoning` field of the next assistant
+        // message so reasoning-aware chat templates can render it.
+        use crate::server::types::responses_request::{
+            ReasoningContentPart, ResponseInputContent, ResponseInputItem, ResponseInputRole,
+        };
+        let items = vec![
+            ResponseInputItem::Message {
+                role: ResponseInputRole::User,
+                content: ResponseInputContent::Text("what is 2+2?".to_string()),
+                name: None,
+            },
+            ResponseInputItem::Reasoning {
+                content: vec![ReasoningContentPart {
+                    part_type: "reasoning_text".to_string(),
+                    text: "add 2 and 2".to_string(),
+                }],
+            },
+            ResponseInputItem::Message {
+                role: ResponseInputRole::Assistant,
+                content: ResponseInputContent::Text("4".to_string()),
+                name: None,
+            },
+        ];
+        let req = make_request(ResponseInput::Items(items));
+        let translated = responses_request_to_chat(&req, None, None).unwrap();
+        let msgs = &translated.chat_request.messages;
+        let assistant = msgs
+            .iter()
+            .find(|m| matches!(m.role, Role::Assistant))
+            .expect("assistant turn present");
+        assert_eq!(assistant.reasoning.as_deref(), Some("add 2 and 2"));
+        assert_eq!(assistant.content.text(), "4");
+        let user = msgs
+            .iter()
+            .find(|m| matches!(m.role, Role::User))
+            .expect("user turn present");
+        assert_eq!(
+            user.reasoning, None,
+            "reasoning must not leak onto user turn"
+        );
     }
 
     #[test]

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -1302,6 +1302,7 @@ mod tests {
                 content: MessageContent::Parts(parts),
                 name: None,
                 tool_call_id: None,
+                reasoning: None,
                 tool_calls: None,
             }],
             stream: false,

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -316,6 +316,19 @@ pub struct Message {
     /// Tool calls made by the assistant (multi-turn history)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCallInMessage>>,
+    /// Prior-turn assistant reasoning ("interleaved reasoning"), forwarded to
+    /// chat templates that render `message.get('reasoning')` (e.g. Gemma 4) so
+    /// the model can see its own thinking across turns (issue #362).
+    ///
+    /// Accepts both `reasoning` and the OpenAI-compatible `reasoning_content`
+    /// spelling via serde alias. The field is dropped from serialized output
+    /// when absent, keeping existing wire shapes unchanged.
+    #[serde(
+        default,
+        alias = "reasoning_content",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub reasoning: Option<String>,
 }
 
 /// Sampling parameters shared across endpoints
@@ -832,6 +845,47 @@ mod tests {
         let msg: Message = serde_json::from_str(json).unwrap();
         assert_eq!(msg.content.text(), "hello");
         assert!(matches!(msg.content, MessageContent::Text(_)));
+    }
+
+    #[test]
+    fn message_reasoning_field_and_alias_round_trip() {
+        // Issue #362: assistant `reasoning` is accepted under both the
+        // `reasoning` and OpenAI-compatible `reasoning_content` spellings, and
+        // its presence does not disturb the other fields.
+        let from_reasoning: Message = serde_json::from_str(
+            r#"{"role":"assistant","content":"hi","reasoning":"because 2+2=4"}"#,
+        )
+        .expect("`reasoning` must deserialize");
+        assert_eq!(from_reasoning.reasoning.as_deref(), Some("because 2+2=4"));
+        assert_eq!(from_reasoning.content.text(), "hi");
+
+        let from_alias: Message = serde_json::from_str(
+            r#"{"role":"assistant","content":"hi","reasoning_content":"alias text"}"#,
+        )
+        .expect("`reasoning_content` alias must deserialize");
+        assert_eq!(from_alias.reasoning.as_deref(), Some("alias text"));
+
+        // Absent reasoning leaves the field None while other fields still load.
+        let absent: Message =
+            serde_json::from_str(r#"{"role":"user","content":"q","name":"alice"}"#)
+                .expect("missing reasoning must deserialize");
+        assert_eq!(absent.reasoning, None);
+        assert_eq!(absent.name.as_deref(), Some("alice"));
+
+        // Serialize uses the canonical `reasoning` key and omits it when None.
+        let serialized = serde_json::to_string(&from_reasoning).unwrap();
+        assert!(
+            serialized.contains(r#""reasoning":"because 2+2=4""#),
+            "serialized form must carry reasoning: {serialized}"
+        );
+        let absent_serialized = serde_json::to_string(&absent).unwrap();
+        assert!(
+            !absent_serialized.contains("reasoning"),
+            "absent reasoning must be omitted from output: {absent_serialized}"
+        );
+        // Full round-trip preserves the value.
+        let round_trip: Message = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(round_trip.reasoning.as_deref(), Some("because 2+2=4"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

mlxcel-server dropped the assistant `reasoning` field on input, so prior-turn reasoning was lost in multi-turn interleaved-reasoning conversations. Chat templates that render `message.get('reasoning')` (e.g. Gemma 4) never received it. This is the input-side fix; the output side (streaming `reasoning_content`) was already complete.

## What changed

- `src/server/types/request.rs`: add `reasoning: Option<String>` to `Message`, accepting both `reasoning` and the OpenAI-compatible `reasoning_content` via `#[serde(alias = "reasoning_content")]`, omitted from output when absent.
- `src/server/chat_request.rs`: route requests carrying a non-empty reasoning field through the raw-JSON render path (the typed `ChatMessage` path only carries role + content). In `build_raw_json_messages_with_thinking`, forward `msg["reasoning"]` using the same decision applied to inline `<think>` blocks.
- `src/server/anthropic_translator.rs`: assistant `thinking` blocks are forwarded onto the parallel `reasoning` field instead of being dropped.
- `src/server/responses_translator.rs`: a Responses `reasoning` input item is buffered and attached to the following assistant turn's `reasoning` field; it does not leak across a turn boundary.
- Existing `Message` literals updated for the new field; tests added.

## preserve_thinking interaction and double-injection

- `preserve_thinking=false` (default): a prior assistant turn (before the rolling checkpoint) has both its inline `<think>` block and its parallel `reasoning` field dropped, so prior thinking is removed consistently and cannot leak into the next prompt.
- `preserve_thinking=true`: the reasoning field is forwarded for retained turns.
- Double-injection guard: when a retained turn's content already contains an inline `<think>` block, the parallel `reasoning` field is not also forwarded, so templates that render both channels never emit the same reasoning twice.

## Cross-API wiring

- Anthropic Messages and Responses translators both reconstruct assistant turns that reach the chat-template path, so both forward reasoning. The Anthropic `Text`-only message shape and tool-result messages have no reasoning to carry, so they are unaffected.

## Test plan

- [x] `cargo test --lib --features metal,accelerate -- server::chat_request:: server::types::request:: server::anthropic_translator:: server::responses_translator::` (109 passed)
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)

New tests: multi-turn render asserts reasoning reaches the prompt when `preserve_thinking=true` and is stripped by default; double-injection guard; raw-path routing; serde `reasoning`/`reasoning_content` round-trip; Anthropic and Responses forwarding.

Closes #362
