### PR TITLE
perf(models): profile apertus/seed_oss decode and trim xIELU op

### DIFF
--- a/src/models/apertus.rs
+++ b/src/models/apertus.rs
@@ -41,6 +41,8 @@ use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::OnceLock;
+use std::time::Instant;
 
 // Configuration.
 #[derive(Debug, Clone, Deserialize)]
@@ -140,23 +142,70 @@ fn apertus_xielu(
 ) -> UniquePtr<MlxArray> {
     let dtype = mlxcel_core::array_dtype(x);
 
-    // beta * x is shared by both branches.
-    let beta_x = mlxcel_core::multiply_scalar(x, beta);
-
-    // Positive branch: alpha_p * x^2 + beta * x.
+    // Positive-branch core: alpha_p * x^2.
     let x_sq = mlxcel_core::square(x);
-    let pos = mlxcel_core::add(&mlxcel_core::multiply_scalar(&x_sq, alpha_p), &beta_x);
+    let pos_core = mlxcel_core::multiply_scalar(&x_sq, alpha_p);
 
-    // Negative branch: (expm1(min(x, eps)) - x) * alpha_n + beta * x.
+    // Negative-branch core: (expm1(min(x, eps)) - x) * alpha_n.
     let eps_arr = mlxcel_core::full_f32(&[1], eps, dtype);
     let clamped = mlxcel_core::minimum(x, &eps_arr);
     let neg_core = mlxcel_core::subtract(&mlxcel_core::expm1(&clamped), x);
-    let neg = mlxcel_core::add(&mlxcel_core::multiply_scalar(&neg_core, alpha_n), &beta_x);
+    let neg_core = mlxcel_core::multiply_scalar(&neg_core, alpha_n);
 
-    // Select per element on x > 0.
+    // Select the per-element branch on x > 0, then add the shared `beta * x`
+    // once, outside the select. Both branches end in `+ beta * x`, so factoring
+    // that term out drops one elementwise add (and its kernel launch) per layer
+    // per token. The arithmetic is unchanged: the select only chooses which
+    // value `beta * x` is added to, so greedy temp-0 decode stays bit-identical.
     let zero_arr = mlxcel_core::full_f32(&[1], 0.0, dtype);
     let cond = mlxcel_core::greater(x, &zero_arr);
-    mlxcel_core::where_cond(&cond, &pos, &neg)
+    let selected = mlxcel_core::where_cond(&cond, &pos_core, &neg_core);
+    mlxcel_core::add(&selected, &mlxcel_core::multiply_scalar(x, beta))
+}
+
+// Decode profiling (env-gated, default-off).
+//
+// Mirrors the lightweight hooks in `src/models/nemotron_h.rs` and
+// `src/models/qwen3_moe.rs` for the dense apertus path. Both flags are read
+// once from the environment and cached, so the steady-state decode path pays
+// only an atomic load per token when profiling is disabled (the default).
+//
+// - `MLXCEL_PROFILE_BLOCKS`: attribute single-token decode wall-clock between
+//   the attention and MLP (xIELU) sub-blocks. Active profiling `eval()`s the
+//   sub-block outputs, which serializes the lazy graph; use only for analysis.
+// - `MLXCEL_PROFILE_FORWARD`: split single-token decode into graph-build versus
+//   GPU-eval time for the whole forward.
+
+fn profile_blocks_enabled() -> bool {
+    static FLAG: OnceLock<bool> = OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MLXCEL_PROFILE_BLOCKS").is_some())
+}
+
+fn profile_forward_enabled() -> bool {
+    static FLAG: OnceLock<bool> = OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MLXCEL_PROFILE_FORWARD").is_some())
+}
+
+/// Per-block decode timing accumulator. Constructed only when
+/// `MLXCEL_PROFILE_BLOCKS` is set for a single-token decode step.
+#[derive(Default)]
+struct BlockTiming {
+    attn_ns: u128,
+    mlp_ns: u128,
+}
+
+impl BlockTiming {
+    fn report(&self) {
+        let total = (self.attn_ns + self.mlp_ns).max(1);
+        eprintln!(
+            "[BLOCKS] attn:{:.3}ms({:.0}%) mlp:{:.3}ms({:.0}%) total:{:.3}ms",
+            self.attn_ns as f64 / 1e6,
+            self.attn_ns as f64 * 100.0 / total as f64,
+            self.mlp_ns as f64 / 1e6,
+            self.mlp_ns as f64 * 100.0 / total as f64,
+            total as f64 / 1e6,
+        );
+    }
 }
 
 // MLP (xIELU, no gate).
@@ -370,15 +419,40 @@ impl TransformerBlock {
         cache: &mut KVCache,
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
+        self.forward_timed(x, cache, mask, None)
+    }
+
+    /// Block forward with optional per-sub-block timing. The production path
+    /// passes `None`, which keeps the body identical to a plain forward (no
+    /// extra `eval()` or `Instant`). When `timing` is `Some`, the attention and
+    /// MLP outputs are `eval()`d to attribute wall-clock time to each.
+    fn forward_timed(
+        &self,
+        x: &MlxArray,
+        cache: &mut KVCache,
+        mask: Option<&MlxArray>,
+        mut timing: Option<&mut BlockTiming>,
+    ) -> UniquePtr<MlxArray> {
         // h = x + self_attn(attention_layernorm(x))
+        let attn_start = timing.as_ref().map(|_| Instant::now());
         let normed = self.attention_layernorm.forward(x);
         let attn_out = self.self_attn.forward(&normed, cache, mask);
         let h = mlxcel_core::add(x, &attn_out);
+        if let Some(t) = timing.as_mut() {
+            mlxcel_core::eval(&h);
+            t.attn_ns += attn_start.unwrap().elapsed().as_nanos();
+        }
 
         // out = h + mlp(feedforward_layernorm(h))
+        let mlp_start = timing.as_ref().map(|_| Instant::now());
         let normed = self.feedforward_layernorm.forward(&h);
         let ff_out = self.mlp.forward(&normed);
-        mlxcel_core::add(&h, &ff_out)
+        let out = mlxcel_core::add(&h, &ff_out);
+        if let Some(t) = timing.as_mut() {
+            mlxcel_core::eval(&out);
+            t.mlp_ns += mlp_start.unwrap().elapsed().as_nanos();
+        }
+        out
     }
 
     pub fn from_weights(
@@ -424,22 +498,50 @@ impl ApertusModel {
         caches: &mut [KVCache],
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
+        // Decode profiling is off by default: the cached flags resolve to two
+        // atomic loads and `array_shape` is only queried when a flag is set, so
+        // the steady-state decode path is unchanged.
+        let profiling = profile_blocks_enabled() || profile_forward_enabled();
+        let is_decode = profiling && mlxcel_core::array_shape(input_ids)[1] == 1;
+        let profile_blocks = is_decode && profile_blocks_enabled();
+        let profile_forward = is_decode && !profile_blocks;
+        let build_start = profile_forward.then(Instant::now);
+
         let mut h = self.embed_tokens.forward(input_ids);
+        let mut timing = profile_blocks.then(BlockTiming::default);
 
         let n = self.layers.len();
         for (i, layer) in self.layers.iter().enumerate() {
-            h = layer.forward(&h, &mut caches[i], mask);
+            h = layer.forward_timed(&h, &mut caches[i], mask, timing.as_mut());
             pipeline_hint(&h, i, n);
         }
 
         let h = self.norm.forward(&h);
 
         // No logit multiplier for Apertus.
-        if let Some(ref lm_head) = self.lm_head {
+        let logits = if let Some(ref lm_head) = self.lm_head {
             lm_head.forward(&h)
         } else {
             self.embed_tokens.as_linear(&h)
+        };
+
+        if let Some(t) = timing {
+            t.report();
         }
+        if let Some(start) = build_start {
+            let build_ms = start.elapsed().as_nanos() as f64 / 1e6;
+            let eval_start = Instant::now();
+            mlxcel_core::eval(&logits);
+            let eval_ms = eval_start.elapsed().as_nanos() as f64 / 1e6;
+            eprintln!(
+                "[FORWARD] build:{:.3}ms eval:{:.3}ms total:{:.3}ms",
+                build_ms,
+                eval_ms,
+                build_ms + eval_ms,
+            );
+        }
+
+        logits
     }
 
     pub fn make_caches(&self) -> Vec<KVCache> {

--- a/src/models/apertus_tests.rs
+++ b/src/models/apertus_tests.rs
@@ -204,3 +204,42 @@ fn xielu_formula_matches_hand_values() {
         "x=0 should be near zero: got {at_zero}"
     );
 }
+
+/// The MLX `apertus_xielu` path factors the shared `beta * x` term out of both
+/// branches and adds it once after the per-element select:
+///   `result = where(x > 0, alpha_p*x^2, (expm1(min(x,eps))-x)*alpha_n) + beta*x`
+/// rather than adding `beta * x` inside each branch. This mirrors that factored
+/// structure on scalars and asserts it equals the branch-local reference
+/// (`xielu_scalar`) bit-for-bit in f32, which is the algebraic guarantee behind
+/// "greedy temp-0 output unchanged": the select only chooses which value
+/// `beta * x` is added to, so factoring the add out cannot change any result.
+fn xielu_scalar_factored(x: f32, alpha_p_raw: f32, alpha_n_raw: f32, beta: f32, eps: f32) -> f32 {
+    let alpha_p = softplus(alpha_p_raw);
+    let alpha_n = beta + softplus(alpha_n_raw);
+    let core = if x > 0.0 {
+        alpha_p * x * x
+    } else {
+        let clamped = x.min(eps);
+        ((clamped.exp() - 1.0) - x) * alpha_n
+    };
+    core + beta * x
+}
+
+#[test]
+fn xielu_factored_beta_x_matches_branch_local() {
+    let beta = 0.5f32;
+    let eps = -1e-6f32;
+    let raw = (0.8f32.exp() - 1.0).ln();
+
+    // Across positive, negative, and zero inputs the factored form (beta * x
+    // added once after the select) must equal the branch-local form bit-for-bit.
+    for &x in &[-4.0f32, -1.0, -0.25, 0.0, 0.25, 1.0, 4.0, 12.5] {
+        let branch_local = xielu_scalar(x, raw, raw, beta, eps);
+        let factored = xielu_scalar_factored(x, raw, raw, beta, eps);
+        assert_eq!(
+            branch_local.to_bits(),
+            factored.to_bits(),
+            "factored xIELU diverged at x={x}: branch_local={branch_local}, factored={factored}"
+        );
+    }
+}

--- a/src/models/seed_oss.rs
+++ b/src/models/seed_oss.rs
@@ -43,6 +43,8 @@ use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
 use std::path::Path;
+use std::sync::OnceLock;
+use std::time::Instant;
 
 // Configuration.
 #[derive(Debug, Clone, Deserialize)]
@@ -119,6 +121,51 @@ impl ModelArgs {
 
     pub fn bits(&self) -> i32 {
         self.quantization.as_ref().map(|q| q.bits).unwrap_or(4)
+    }
+}
+
+// Decode profiling (env-gated, default-off).
+//
+// Mirrors the lightweight hooks in `src/models/nemotron_h.rs` and
+// `src/models/qwen3_moe.rs` for the dense seed_oss path. Both flags are read
+// once from the environment and cached, so the steady-state decode path pays
+// only an atomic load per token when profiling is disabled (the default).
+//
+// - `MLXCEL_PROFILE_BLOCKS`: attribute single-token decode wall-clock between
+//   the attention and MLP (SwiGLU) sub-blocks. Active profiling `eval()`s the
+//   sub-block outputs, which serializes the lazy graph; use only for analysis.
+// - `MLXCEL_PROFILE_FORWARD`: split single-token decode into graph-build versus
+//   GPU-eval time for the whole forward.
+
+fn profile_blocks_enabled() -> bool {
+    static FLAG: OnceLock<bool> = OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MLXCEL_PROFILE_BLOCKS").is_some())
+}
+
+fn profile_forward_enabled() -> bool {
+    static FLAG: OnceLock<bool> = OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MLXCEL_PROFILE_FORWARD").is_some())
+}
+
+/// Per-block decode timing accumulator. Constructed only when
+/// `MLXCEL_PROFILE_BLOCKS` is set for a single-token decode step.
+#[derive(Default)]
+struct BlockTiming {
+    attn_ns: u128,
+    mlp_ns: u128,
+}
+
+impl BlockTiming {
+    fn report(&self) {
+        let total = (self.attn_ns + self.mlp_ns).max(1);
+        eprintln!(
+            "[BLOCKS] attn:{:.3}ms({:.0}%) mlp:{:.3}ms({:.0}%) total:{:.3}ms",
+            self.attn_ns as f64 / 1e6,
+            self.attn_ns as f64 * 100.0 / total as f64,
+            self.mlp_ns as f64 / 1e6,
+            self.mlp_ns as f64 * 100.0 / total as f64,
+            total as f64 / 1e6,
+        );
     }
 }
 
@@ -308,15 +355,40 @@ impl TransformerBlock {
         cache: &mut KVCache,
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
+        self.forward_timed(x, cache, mask, None)
+    }
+
+    /// Block forward with optional per-sub-block timing. The production path
+    /// passes `None`, which keeps the body identical to a plain forward (no
+    /// extra `eval()` or `Instant`). When `timing` is `Some`, the attention and
+    /// MLP outputs are `eval()`d to attribute wall-clock time to each.
+    fn forward_timed(
+        &self,
+        x: &MlxArray,
+        cache: &mut KVCache,
+        mask: Option<&MlxArray>,
+        mut timing: Option<&mut BlockTiming>,
+    ) -> UniquePtr<MlxArray> {
         // h = x + self_attn(input_layernorm(x))
+        let attn_start = timing.as_ref().map(|_| Instant::now());
         let normed = self.input_layernorm.forward(x);
         let attn_out = self.self_attn.forward(&normed, cache, mask);
         let h = mlxcel_core::add(x, &attn_out);
+        if let Some(t) = timing.as_mut() {
+            mlxcel_core::eval(&h);
+            t.attn_ns += attn_start.unwrap().elapsed().as_nanos();
+        }
 
         // out = h + mlp(post_attention_layernorm(h))
+        let mlp_start = timing.as_ref().map(|_| Instant::now());
         let normed = self.post_attention_layernorm.forward(&h);
         let ff_out = self.mlp.forward(&normed);
-        mlxcel_core::add(&h, &ff_out)
+        let out = mlxcel_core::add(&h, &ff_out);
+        if let Some(t) = timing.as_mut() {
+            mlxcel_core::eval(&out);
+            t.mlp_ns += mlp_start.unwrap().elapsed().as_nanos();
+        }
+        out
     }
 }
 
@@ -337,22 +409,50 @@ impl SeedOssModel {
         caches: &mut [KVCache],
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
+        // Decode profiling is off by default: the cached flags resolve to two
+        // atomic loads and `array_shape` is only queried when a flag is set, so
+        // the steady-state decode path is unchanged.
+        let profiling = profile_blocks_enabled() || profile_forward_enabled();
+        let is_decode = profiling && mlxcel_core::array_shape(input_ids)[1] == 1;
+        let profile_blocks = is_decode && profile_blocks_enabled();
+        let profile_forward = is_decode && !profile_blocks;
+        let build_start = profile_forward.then(Instant::now);
+
         let mut h = self.embed_tokens.forward(input_ids);
+        let mut timing = profile_blocks.then(BlockTiming::default);
 
         let n = self.layers.len();
         for (i, layer) in self.layers.iter().enumerate() {
-            h = layer.forward(&h, &mut caches[i], mask);
+            h = layer.forward_timed(&h, &mut caches[i], mask, timing.as_mut());
             pipeline_hint(&h, i, n);
         }
 
         let h = self.norm.forward(&h);
 
         // No logit multiplier for Seed-OSS.
-        if let Some(ref lm_head) = self.lm_head {
+        let logits = if let Some(ref lm_head) = self.lm_head {
             lm_head.forward(&h)
         } else {
             self.embed_tokens.as_linear(&h)
+        };
+
+        if let Some(t) = timing {
+            t.report();
         }
+        if let Some(start) = build_start {
+            let build_ms = start.elapsed().as_nanos() as f64 / 1e6;
+            let eval_start = Instant::now();
+            mlxcel_core::eval(&logits);
+            let eval_ms = eval_start.elapsed().as_nanos() as f64 / 1e6;
+            eprintln!(
+                "[FORWARD] build:{:.3}ms eval:{:.3}ms total:{:.3}ms",
+                build_ms,
+                eval_ms,
+                build_ms + eval_ms,
+            );
+        }
+
+        logits
     }
 
     pub fn make_caches(&self) -> Vec<KVCache> {


### PR DESCRIPTION
## Summary

Characterizes the per-model dense decode overhead for `apertus` and `seed_oss` versus mlx-lm and recovers the one cheap, bit-exact lever found, satisfying all three acceptance criteria of #269. The headline result is that most of the gap reported in the issue was the bf16-scale quantized decode regression (#289), which #290 fixed after the issue was filed, so current `main` already sits at ~0.98x / ~1.0x of mlx-lm.

## Per-model characterization (M1 Ultra)

Measured with `mlxcel-bench-decode` (warmup pass + measured pass in one process, `--no-chat-template`, 100 decode tokens, temp-0 greedy), against the mlx-lm 0.31.3 baselines quoted in the issue.

- **apertus** (`Apertus-8B-Instruct-2509-4bit`): ~83.5 tok/s vs mlx-lm ~85 = **~0.98x** (the issue reported 0.83x at filing). Both apertus and seed_oss ship bf16 quant scales and were in the set regressed by #289; #290 ("keep quantized models bf16", merged 2026-06-15, after #269 was filed 2026-06-13) recovered the bulk of the gap.
- **seed_oss** (`Seed-OSS-36B-Instruct-4bit`): ~20.4 tok/s vs mlx-lm ~20.3 = **~1.0x** (the issue reported 0.84x at filing). seed_oss is a vanilla Llama dense and carries no model-specific lever beyond what #290 already recovered.
- **Where the remaining overhead is:** `MLXCEL_PROFILE_FORWARD` shows steady-state apertus decode is GPU-eval-bound, ~0.7ms host graph-build vs ~13ms GPU eval per token (host build is only ~5% of the step), so host-side op-count reductions have very limited headroom. `MLXCEL_PROFILE_BLOCKS` attributes the forced-serialized per-layer time as attn ~45% / xIELU MLP ~55% (apertus) and attn ~38% / SwiGLU MLP ~62% (seed_oss). This matches the project's prior finding that these gaps are diffuse per-op / kernel-launch overhead with no single high-value lever.

## What changed

- Adds an env-gated, default-off forward profiling hook to `src/models/apertus.rs` and `src/models/seed_oss.rs`, mirroring the existing hooks in `nemotron_h.rs` / `qwen3_moe.rs`: `MLXCEL_PROFILE_BLOCKS` attributes single-token decode wall-clock to the attention vs MLP sub-blocks, and `MLXCEL_PROFILE_FORWARD` splits the step into graph-build vs GPU-eval. Both flags are read once and cached in a `OnceLock`, and `array_shape` is only queried when a flag is set, so the steady-state decode path is unchanged (two atomic loads per token, no extra FFI calls or `eval()` when profiling is off).
- Recovers one cheap, bit-exact op in apertus xIELU (`apertus_xielu`): both branches end in `+ beta * x`, so that shared term is now added once after the per-element select instead of inside each branch, dropping one elementwise add (and its kernel launch) per layer per token. The select only chooses which value `beta * x` is added to, so the arithmetic is unchanged.
- Adds a CPU-only unit test `xielu_factored_beta_x_matches_branch_local` asserting the factored form equals the branch-local reference bit-for-bit in f32 across positive, negative, and zero inputs.

## Greedy temp-0 output unchanged (byte-identical)

Verified the production decode path (no profiling env vars) is byte-identical to the pre-change `main` binary for both models: apertus 500-byte continuation and seed_oss 308-byte continuation both `diff`-clean. The decode delta is within run-to-run noise (~83.3 -> ~83.5 tok/s on apertus), consistent with the GPU-eval-bound profile above.

## Recommended follow-up

A fused/compiled xIELU activation (a single `mx::core::compile` window or kernel over the ~12 elementwise ops) is the only remaining real lever for apertus, but it touches the C++ FFI bridge and risks f16 jitter, so it is intentionally out of scope here and should be a separate issue. Constant-hoisting the per-call `eps`/`zero` arrays in `apertus_xielu` was evaluated and rejected: it would need runtime-dtype-keyed caching to stay bit-identical and saves only host-side FFI calls, which the FORWARD profile shows are a negligible fraction of the step.

## Test plan

- [x] `cargo test --release -p mlxcel apertus_tests::` (9 passed, incl. new factoring test)
- [x] `cargo test --release -p mlxcel seed_oss_tests::` (7 passed)
- [x] `cargo clippy --features metal,accelerate -p mlxcel --lib --tests -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] apertus greedy temp-0 output byte-identical to baseline (500 bytes, diff-clean)
- [x] seed_oss greedy temp-0 output byte-identical to baseline (308 bytes, diff-clean)
- [x] apertus decode re-benchmarked before/after (~83.3 -> ~83.5 tok/s, within noise)
- [x] `MLXCEL_PROFILE_BLOCKS` and `MLXCEL_PROFILE_FORWARD` exercised on both models

Closes #269
