### PR TITLE
feat: add video input support for Gemma 4 Unified (gemma4_unified)

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -69,7 +69,7 @@ The fused MoE `gate_up_proj` weights are split at load time. When a vision tower
 Implemented VLM variants include:
 
 - Gemma 3 VL, Gemma 3n VL, Gemma 4 VL
-- Gemma 4 Unified (`gemma4_unified`): encoder-free text + image + audio. Patch-projection vision embedder and waveform-chunk audio path feed the shared Gemma 4 backbone, with blockwise bidirectional attention over image/video token spans during prefill. Video input is not yet supported.
+- Gemma 4 Unified (`gemma4_unified`): encoder-free text + image + audio + video. Patch-projection vision embedder and waveform-chunk audio path feed the shared Gemma 4 backbone, with blockwise bidirectional attention over image/video token spans during prefill. Video is handled as images-per-frame: frames are extracted with `ffmpeg` (uniform sampling, default 2.0 fps), patchified through the same vision embedder with a per-frame `vision_soft_tokens_per_video_frame` budget (70), and scattered into `video_token_id` placeholder spans. Available on both the CLI (`--video`) and the server (`video_url` content blocks). The prompt grows by ~70 soft tokens per sampled frame, so long clips at the default fps can exceed the model's 1024-token sliding window during single-pass prefill; lower `--fps` (or fewer frames) keeps a clip within the window.
 - Llama 4 VLM
 - LLaVA and LLaVA-Bunny
 - Aya Vision and PaliGemma

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -531,18 +531,22 @@ fn apply_user_chat_template(processor: &ChatTemplateProcessor, user_prompt: &str
         .unwrap_or_else(|_| user_prompt.to_string())
 }
 
-/// Apply chat template with image placeholders for VLM models.
+/// Apply chat template with image / video placeholders for VLM models.
 ///
 /// Creates multimodal content entries that Gemma3-style templates can
-/// render into `<start_of_image>` tokens (which are later expanded into
-/// full image-token blocks by `apply_image_token_blocks`).
+/// render into `<start_of_image>` / `<|video|>` markers (which are later
+/// expanded into full soft-token blocks by the per-family expansion
+/// helpers).
 ///
 /// Only used when the template explicitly handles `type == 'image'`
-/// content items. Templates without image support fall back to text-only.
+/// content items. Video content parts are only emitted when the template
+/// also handles `type == 'video'`. Templates without image support fall
+/// back to text-only.
 fn apply_vlm_chat_template(
     processor: &ChatTemplateProcessor,
     user_prompt: &str,
     num_images: usize,
+    num_videos: usize,
 ) -> String {
     // Only attempt multimodal rendering when the template handles image
     // content items.  Templates that don't (e.g. Vicuna, ChatML) would
@@ -551,10 +555,21 @@ fn apply_vlm_chat_template(
         return apply_user_chat_template(processor, user_prompt);
     }
 
-    // Build a multimodal content list: [{type: image}, ..., {type: text, text: prompt}]
+    // Build a multimodal content list:
+    // [{type: image}, ..., {type: video}, ..., {type: text, text: prompt}].
+    // Video items are only included when the template renders them (so the
+    // marker lands inside the user turn, alongside the question, instead of
+    // before it). Placing the video marker in the user turn matters: a video
+    // spliced before the user turn yields no grounded answer (issue #164).
+    let emit_video = num_videos > 0 && processor.supports_video_content();
     let mut content_parts: Vec<serde_json::Value> = Vec::new();
     for _ in 0..num_images {
         content_parts.push(serde_json::json!({"type": "image"}));
+    }
+    if emit_video {
+        for _ in 0..num_videos {
+            content_parts.push(serde_json::json!({"type": "video"}));
+        }
     }
     content_parts.push(serde_json::json!({"type": "text", "text": user_prompt}));
 
@@ -574,6 +589,7 @@ fn resolve_cli_prompt(
     no_chat_template: bool,
     processor: Option<&ChatTemplateProcessor>,
     num_images: usize,
+    num_videos: usize,
 ) -> String {
     if no_chat_template {
         return user_prompt.to_string();
@@ -582,8 +598,8 @@ fn resolve_cli_prompt(
     processor.map_or_else(
         || user_prompt.to_string(),
         |processor| {
-            if num_images > 0 {
-                apply_vlm_chat_template(processor, user_prompt, num_images)
+            if num_images > 0 || num_videos > 0 {
+                apply_vlm_chat_template(processor, user_prompt, num_images, num_videos)
             } else {
                 apply_user_chat_template(processor, user_prompt)
             }
@@ -596,6 +612,7 @@ fn load_cli_prompt(
     user_prompt: &str,
     no_chat_template: bool,
     num_images: usize,
+    num_videos: usize,
 ) -> String {
     let processor = if no_chat_template {
         None
@@ -610,7 +627,25 @@ fn load_cli_prompt(
         no_chat_template,
         processor.as_ref(),
         num_images,
+        num_videos,
     )
+}
+
+/// Number of `<|video|>` content parts to render into the CLI chat prompt.
+///
+/// Only the encoder-free `gemma4_unified` model expands a real `video_token_id`
+/// placeholder inside the user turn (issue #164); every other family (including
+/// the ViT-backed `gemma4` VLM, which splices video frames after BOS via a
+/// sentinel) keeps `0` so its prompt rendering is byte-for-byte unchanged. On
+/// any detection failure we conservatively return `0`.
+fn cli_video_content_part_count(model_path: &Path, num_videos: usize) -> usize {
+    if num_videos == 0 {
+        return 0;
+    }
+    match mlxcel::models::get_model_type(model_path) {
+        Ok(mlxcel::models::ModelType::Gemma4Unified) => num_videos,
+        _ => 0,
+    }
 }
 
 fn tokenize_prompt(
@@ -1413,6 +1448,7 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
         &user_prompt,
         args.generation.no_chat_template,
         args.generation.image.len(),
+        cli_video_content_part_count(&args.model.model, args.generation.video.len()),
     );
     let mut prompt_tokens = tokenize_prompt(&tokenizer, &prompt)?;
 

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use super::{
-    apply_user_chat_template, cli_pipeline_requested, estimate_delta_label_and_bytes,
-    generated_suffix, generation_stats_from_duration, memory_preflight_ctx_len,
-    resolve_cli_pipeline_assignments, resolve_cli_prompt, should_route_offline_mtp,
-    strip_trailing_eos, validate_pipeline_parallel_args, validate_tensor_parallel_args,
+    apply_user_chat_template, apply_vlm_chat_template, cli_pipeline_requested,
+    estimate_delta_label_and_bytes, generated_suffix, generation_stats_from_duration,
+    memory_preflight_ctx_len, resolve_cli_pipeline_assignments, resolve_cli_prompt,
+    should_route_offline_mtp, strip_trailing_eos, validate_pipeline_parallel_args,
+    validate_tensor_parallel_args,
 };
 use mlxcel::server::chat_template::ChatTemplateProcessor;
 use mlxcel_core::drafter::DrafterKind;
@@ -131,7 +132,7 @@ fn apply_user_chat_template_wraps_prompt_as_user_message() {
 fn resolve_cli_prompt_skips_template_when_disabled() {
     let processor = ChatTemplateProcessor::with_template("wrapped".to_string());
 
-    let prompt = resolve_cli_prompt("Hello", true, Some(&processor), 0);
+    let prompt = resolve_cli_prompt("Hello", true, Some(&processor), 0, 0);
 
     assert_eq!(prompt, "Hello");
 }
@@ -140,9 +141,50 @@ fn resolve_cli_prompt_skips_template_when_disabled() {
 fn resolve_cli_prompt_falls_back_on_template_errors() {
     let processor = ChatTemplateProcessor::with_template("{% if %}".to_string());
 
-    let prompt = resolve_cli_prompt("Hello", false, Some(&processor), 0);
+    let prompt = resolve_cli_prompt("Hello", false, Some(&processor), 0, 0);
 
     assert_eq!(prompt, "Hello");
+}
+
+#[test]
+fn vlm_chat_template_renders_video_content_part_in_user_turn() {
+    // A template that handles both image and video content items. The video
+    // marker must land alongside the text (inside the user turn), not before
+    // it — that placement is what lets the Gemma 4 Unified video path produce a
+    // grounded answer (issue #164).
+    let template = "user: {% for item in messages[0]['content'] %}\
+        {% if item['type'] == 'image' %}<IMG>\
+        {% elif item['type'] == 'video' %}<VID>\
+        {% elif item['type'] == 'text' %}{{ item['text'] }}\
+        {% endif %}{% endfor %}"
+        .to_string();
+    let processor = ChatTemplateProcessor::with_template(template);
+
+    // One video + the question: marker precedes the text within the turn.
+    let prompt = apply_vlm_chat_template(&processor, "Describe this video.", 0, 1);
+    assert_eq!(prompt, "user: <VID>Describe this video.");
+
+    // Image + video together render in image-then-video order.
+    let mixed = apply_vlm_chat_template(&processor, "Q", 1, 1);
+    assert_eq!(mixed, "user: <IMG><VID>Q");
+}
+
+#[test]
+fn vlm_chat_template_omits_video_when_template_lacks_video_support() {
+    // A template that handles images but NOT video must not emit a video
+    // content part (it would render the raw item as text). The ViT-backed
+    // gemma4 VLM path relies on this: it keeps its splice-after-BOS behavior.
+    let template = "user: {% for item in messages[0]['content'] %}\
+        {% if item['type'] == 'image' %}<IMG>\
+        {% elif item['type'] == 'text' %}{{ item['text'] }}\
+        {% endif %}{% endfor %}"
+        .to_string();
+    let processor = ChatTemplateProcessor::with_template(template);
+    assert!(!processor.supports_video_content());
+
+    // num_videos > 0 but the template has no video branch: no marker emitted.
+    let prompt = apply_vlm_chat_template(&processor, "Q", 0, 1);
+    assert_eq!(prompt, "user: Q");
 }
 
 #[test]

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -150,7 +150,7 @@ fn resolve_cli_prompt_falls_back_on_template_errors() {
 fn vlm_chat_template_renders_video_content_part_in_user_turn() {
     // A template that handles both image and video content items. The video
     // marker must land alongside the text (inside the user turn), not before
-    // it — that placement is what lets the Gemma 4 Unified video path produce a
+    // it. That placement is what lets the Gemma 4 Unified video path produce a
     // grounded answer (issue #164).
     let template = "user: {% for item in messages[0]['content'] %}\
         {% if item['type'] == 'image' %}<IMG>\

--- a/src/commands/generate_vlm.rs
+++ b/src/commands/generate_vlm.rs
@@ -210,6 +210,15 @@ pub(crate) fn compute_vlm_embeddings(
                 target_fps,
             );
         }
+        if let LoadedModel::Gemma4Unified(unified) = model {
+            return compute_gemma4_unified_video_embeddings(
+                unified,
+                prompt_tokens,
+                image_paths,
+                video_paths,
+                target_fps,
+            );
+        }
         return Err(anyhow::anyhow!(
             "--video input is currently only supported by Gemma4 VLMs"
         ));
@@ -671,6 +680,99 @@ fn compute_gemma4_video_embeddings(
 
     print_preparation_summary(VlmPreparationSummary::Gemma4Video {
         video_count: processed_videos.len(),
+        frame_slots: total_frames,
+        total_tokens: prompt_tokens.len(),
+    });
+
+    Ok(Some(embeddings))
+}
+
+/// Compute video embeddings (and optional preceding image embeddings)
+/// for the Gemma 4 Unified (encoder-free) model.
+///
+/// Decodes each video via `mlxcel::video::load_videos` (subprocess `ffmpeg`,
+/// default 2.0 fps), patchifies each frame through the encoder-free vision
+/// embedder with the per-frame `vision_soft_tokens_per_video_frame` budget,
+/// expands the prompt into per-frame `<boi> video_token*N <eoi>` runs, and
+/// scatters the per-frame soft tokens into `video_token_id` placeholders.
+/// Mirrors [`compute_gemma4_video_embeddings`] but routes through the unified
+/// model's `video_token_id` scatter instead of the ViT image path.
+fn compute_gemma4_unified_video_embeddings(
+    unified: &mlxcel::vision::Gemma4UnifiedModel,
+    prompt_tokens: &mut Vec<i32>,
+    image_paths: &[PathBuf],
+    video_paths: &[PathBuf],
+    target_fps: f64,
+) -> Result<Option<InputEmbeddings>> {
+    if !video::ffmpeg_available() {
+        return Err(anyhow::anyhow!(
+            "Video input requires `ffmpeg` on PATH. Install ffmpeg (e.g. `brew install ffmpeg` \
+             on macOS or `apt install ffmpeg` on Linux) and retry."
+        ));
+    }
+
+    // Decode the videos. `target_fps == 0` is rejected by `smart_nframes`,
+    // so guard here with a clean error.
+    let videos = video::load_videos(video_paths, Some(target_fps), None)
+        .map_err(|err| anyhow::anyhow!("Failed to load video(s): {}", err))?;
+    println!(
+        "Loaded {} video(s) ({} total frames after sampling).",
+        videos.len(),
+        videos.iter().map(Vec::len).sum::<usize>()
+    );
+
+    // Optional companion images (e.g. user passes both --image and --video).
+    let processed_images = if image_paths.is_empty() {
+        Vec::new()
+    } else {
+        let images: Vec<image::DynamicImage> = image_paths
+            .iter()
+            .map(|path| {
+                image::open(path)
+                    .map_err(|e| anyhow::anyhow!("Failed to load image {:?}: {}", path, e))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        println!("Loaded {} image(s).", images.len());
+        let processed = unified.processor.preprocess(&images);
+        let num_soft_tokens: Vec<usize> = processed.iter().map(|i| i.num_soft_tokens).collect();
+        mlxcel::vlm_runtime::expand_gemma4_image_tokens_pub(
+            prompt_tokens,
+            unified.image_token_id,
+            unified.boi_token_id,
+            unified.eoi_token_id,
+            &num_soft_tokens,
+        )?;
+        processed
+    };
+
+    // Patchify every frame of every video through the encoder-free embedder.
+    // Frames are kept flat (in video, then frame order) so the scatter sees
+    // them in the same order as the expanded video_token_id placeholders.
+    let mut video_frames: Vec<mlxcel::vision::processors::gemma4_unified::Gemma4UnifiedImageInput> =
+        Vec::new();
+    let mut video_frame_tokens: Vec<Vec<usize>> = Vec::with_capacity(videos.len());
+    for frames in &videos {
+        let processed = unified.processor.preprocess_video_frames(frames);
+        video_frame_tokens.push(processed.iter().map(|f| f.num_soft_tokens).collect());
+        video_frames.extend(processed);
+    }
+
+    mlxcel::vlm_runtime::expand_gemma4_unified_video_tokens(
+        prompt_tokens,
+        unified.video_token_id,
+        unified.boi_token_id,
+        unified.eoi_token_id,
+        &video_frame_tokens,
+    )?;
+
+    let total_frames: usize = video_frame_tokens.iter().map(Vec::len).sum();
+    let input_ids_arr =
+        mlxcel_core::from_slice_i32(prompt_tokens, &[1, prompt_tokens.len() as i32]);
+    let embeddings =
+        unified.get_input_embeddings_with_video(&input_ids_arr, &processed_images, &video_frames);
+
+    print_preparation_summary(VlmPreparationSummary::Gemma4Video {
+        video_count: videos.len(),
         frame_slots: total_frames,
         total_tokens: prompt_tokens.len(),
     });

--- a/src/loading/vlm_gemma_unified.rs
+++ b/src/loading/vlm_gemma_unified.rs
@@ -281,7 +281,7 @@ pub(crate) fn load_gemma4_unified(model_path: &Path) -> Result<LoadedModel> {
     )
     .map_err(|e| anyhow::anyhow!("Failed to load Gemma4 Unified vision projector: {}", e))?;
 
-    let processor = Gemma4UnifiedProcessor::new(
+    let mut processor = Gemma4UnifiedProcessor::new(
         vision_config.model_patch_size,
         vision_config.num_soft_tokens,
         unified_config
@@ -290,6 +290,7 @@ pub(crate) fn load_gemma4_unified(model_path: &Path) -> Result<LoadedModel> {
             .map(|a| a.audio_samples_per_token)
             .unwrap_or(640),
     );
+    processor.set_video_soft_tokens_per_frame(unified_config.vision_soft_tokens_per_video_frame);
 
     let mut model = Gemma4UnifiedModel::new(
         models::Gemma4Wrapper::new(text_model),

--- a/src/models/diffusion_gemma/tests.rs
+++ b/src/models/diffusion_gemma/tests.rs
@@ -706,6 +706,52 @@ fn overlay_makes_image_block_bidirectional_keeps_text_causal() {
     );
 }
 
+#[test]
+fn overlay_aligns_block_ids_to_windowed_key_axis() {
+    // issue #164: when seq_len > sliding_window the sliding base mask caps its
+    // key axis to the window (k < seq_len). The overlay must align the
+    // block ids to the trailing `k` keys (the rotating window) instead of
+    // reshaping the full-length id vector into the shorter key axis (which
+    // panicked with "Cannot reshape array of size N into shape (1, window)").
+    //
+    // Build an 8-query / 4-key base (window 4 over an 8-token sequence). Block
+    // ids cover the full 8 positions; one vision span sits at positions 5,6
+    // which are inside the windowed tail (logical keys [4, 8)).
+    let block_ids = [-1i32, -1, 0, 0, -1, 1, 1, -1];
+    let seq = block_ids.len() as i32; // 8
+    let window = 4i32;
+
+    // Capped sliding base: rows = seq (8), cols = window (4). Column k_c maps to
+    // logical key position (seq - window) + k_c = 4 + k_c.
+    let base = mlxcel_core::utils::create_causal_mask_with_window(seq, 0, Some(window));
+    assert_eq!(mlxcel_core::array_shape(&base), vec![seq, window]);
+
+    let ids = mlxcel_core::from_slice_i32(&block_ids, &[seq]);
+    let overlaid = crate::models::gemma4::overlay_block_bidirectional(&base, &ids);
+    mlxcel_core::eval(&overlaid);
+    // Shape preserved: the reshape no longer panics.
+    assert_eq!(mlxcel_core::array_shape(&overlaid), vec![seq, window]);
+
+    let at = |q: i32, k: i32| -> f32 {
+        let scalar = mlxcel_core::slice(&overlaid, &[q, k], &[q + 1, k + 1]);
+        mlxcel_core::item_f32(&scalar)
+    };
+    let blocked = |v: f32| v.is_infinite() && v < 0.0;
+
+    // The block at logical positions 5,6 maps to key columns 1,2 (5-4, 6-4).
+    // Query 5 attends FORWARD to logical key 6 (column 2): bidirectional.
+    assert_eq!(at(5, 2), 0.0, "vision query 5 attends forward to key 6");
+    // Query 6 attends back to logical key 5 (column 1): causal, already 0.
+    assert_eq!(at(6, 1), 0.0, "vision query 6 attends back to key 5");
+    // A text query (7) still cannot see a future key beyond its causal band;
+    // logical key 7 is column 3, query 7 row: causal allows it (7>=7), but a
+    // text query 5 to future text key 7 (column 3) stays blocked.
+    assert!(
+        blocked(at(5, 3)),
+        "vision query 5 cannot see future text key 7"
+    );
+}
+
 // -------------------------------------------------------------------------
 // Sanitize keep/skip rules (phase 2 vision weights)
 // -------------------------------------------------------------------------

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -313,10 +313,20 @@ pub(crate) fn overlay_block_bidirectional(
     let k = base_shape[base_shape.len() - 1];
 
     // Align the per-position block ids to the query (rows) and key (cols)
-    // axes. For single-chunk prefill q == k == seq_len; when the cache holds a
-    // prefix (offset > 0) the key axis is longer than the block-id vector, so
-    // the leading `k - q` key columns (the already-cached prefix) get id -1 and
-    // never participate in a same-block match.
+    // axes. For single-chunk prefill q == k == seq_len; two key-axis mismatches
+    // are handled:
+    // * `k > id_len` (cached prefix, offset > 0): the leading `k - id_len` key
+    //   columns are the already-cached prefix and get id -1 (left pad) so they
+    //   never participate in a same-block match.
+    // * `k < id_len` (sliding-window cap): when `seq_len > sliding_window`,
+    //   `create_causal_mask_with_window` caps the key axis to the last `k`
+    //   logical positions (the rotating window holds only the most recent `k`
+    //   keys). Column `k_c` then maps to logical key position
+    //   `(id_len - k) + k_c`, so align the key-side ids to the trailing `k`
+    //   block ids. Every vision span is at most one frame/image (≤ a few dozen
+    //   soft tokens) and so always fits inside the window; aligning to the tail
+    //   keeps each span's same-block match intact without leaking attention
+    //   outside the windowed key axis (issue #164).
     let ids_shape = mlxcel_core::array_shape(block_ids);
     let id_len = if ids_shape.is_empty() {
         1
@@ -326,9 +336,15 @@ pub(crate) fn overlay_block_bidirectional(
     let q_ids = mlxcel_core::reshape(block_ids, &[q, 1]);
     let k_ids = if k == id_len {
         mlxcel_core::reshape(block_ids, &[1, k])
+    } else if k < id_len {
+        // Sliding-window cap: take the trailing `k` block ids (the keys the
+        // rotating window retains).
+        let tail = mlxcel_core::slice(block_ids, &[id_len - k], &[id_len]);
+        mlxcel_core::reshape(&tail, &[1, k])
     } else {
-        // Pad the key-side ids on the left with -1 so cached-prefix columns
-        // are non-matching. pad_width is [(before, after)] per axis.
+        // Cached prefix (offset > 0): pad the key-side ids on the left with -1
+        // so cached-prefix columns are non-matching. pad_width is
+        // [(before, after)] per axis.
         let pad_before = (k - id_len).max(0);
         let padded = mlxcel_core::pad(block_ids, &[pad_before, 0], -1.0);
         mlxcel_core::reshape(&padded, &[1, k])

--- a/src/multimodal/vlm_runtime.rs
+++ b/src/multimodal/vlm_runtime.rs
@@ -1002,6 +1002,91 @@ pub fn expand_gemma4_video_tokens(
     Ok(())
 }
 
+/// Expand a Gemma 4 **Unified** video placeholder into per-frame
+/// `<boi> video_token * N <eoi>` runs.
+///
+/// Differs from [`expand_gemma4_video_tokens`] (the ViT-backed `gemma4` VLM
+/// path) in that each frame's soft tokens are `video_token_id`, not
+/// `image_token_id`: the encoder-free unified model scatters per-frame video
+/// features into `video_token_id` placeholder spans (issue #164). The boi/eoi
+/// framing per frame matches the upstream Gemma 4 processor, which emits
+/// `{boi}{video_token * n}{eoi}` per frame (see
+/// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4/processing_gemma4.py).
+///
+/// When the prompt already carries `video_token_id` placeholders (one per
+/// video, inserted by the chat template's `<|video|>`), each is replaced in
+/// prompt order by its video's per-frame runs. The replacement scan iterates
+/// the original token stream, so the `video_token_id` tokens introduced by the
+/// runs are not re-scanned. When the prompt has no placeholder (the basic CLI
+/// path), every video's runs are spliced in after the BOS token, mirroring the
+/// image-token fallback.
+///
+/// # Errors
+/// Returns `Err` if the prompt has a different number of `video_token_id`
+/// placeholders than the number of supplied videos.
+pub fn expand_gemma4_unified_video_tokens(
+    prompt_tokens: &mut Vec<i32>,
+    video_token_id: i32,
+    boi_token_id: i32,
+    eoi_token_id: i32,
+    soft_tokens_per_frame_per_video: &[Vec<usize>],
+) -> Result<()> {
+    if prompt_tokens.is_empty() || soft_tokens_per_frame_per_video.is_empty() {
+        return Ok(());
+    }
+
+    let placeholder_count = prompt_tokens
+        .iter()
+        .filter(|&&t| t == video_token_id)
+        .count();
+
+    let build_video_run = |frames: &[usize]| -> Vec<i32> {
+        let total_len: usize = frames.iter().map(|n| n + 2).sum();
+        let mut run = Vec::with_capacity(total_len);
+        for &n in frames {
+            run.push(boi_token_id);
+            run.extend(std::iter::repeat_n(video_token_id, n));
+            run.push(eoi_token_id);
+        }
+        run
+    };
+
+    if placeholder_count > 0 {
+        if placeholder_count != soft_tokens_per_frame_per_video.len() {
+            return Err(anyhow::anyhow!(
+                "Gemma4 Unified prompt has {} video placeholder(s) but {} video(s) were provided",
+                placeholder_count,
+                soft_tokens_per_frame_per_video.len()
+            ));
+        }
+        let mut runs = soft_tokens_per_frame_per_video.iter();
+        let mut expanded = Vec::with_capacity(prompt_tokens.len());
+        for &token in prompt_tokens.iter() {
+            if token == video_token_id {
+                let frames = runs
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("video run iterator drained early"))?;
+                expanded.extend(build_video_run(frames));
+            } else {
+                expanded.push(token);
+            }
+        }
+        *prompt_tokens = expanded;
+        return Ok(());
+    }
+
+    // No placeholder in prompt — splice all video runs in after BOS.
+    let bos = prompt_tokens[0];
+    let rest: Vec<i32> = prompt_tokens[1..].to_vec();
+    let mut expanded = vec![bos];
+    for frames in soft_tokens_per_frame_per_video {
+        expanded.extend(build_video_run(frames));
+    }
+    expanded.extend(rest);
+    *prompt_tokens = expanded;
+    Ok(())
+}
+
 /// Expand audio token placeholder in prompt tokens for server requests.
 ///
 /// Replaces the first `audio_token_id` with `boa + audio_token*N + eoa`.

--- a/src/multimodal/vlm_runtime.rs
+++ b/src/multimodal/vlm_runtime.rs
@@ -1075,7 +1075,7 @@ pub fn expand_gemma4_unified_video_tokens(
         return Ok(());
     }
 
-    // No placeholder in prompt — splice all video runs in after BOS.
+    // No placeholder in prompt: splice all video runs in after BOS.
     let bos = prompt_tokens[0];
     let rest: Vec<i32> = prompt_tokens[1..].to_vec();
     let mut expanded = vec![bos];

--- a/src/multimodal/vlm_runtime_tests.rs
+++ b/src/multimodal/vlm_runtime_tests.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use super::{
-    VlmPreparationSummary, expand_gemma4_video_tokens, format_molmo_v1_prompt_for_processor,
-    prepared_embedding_refs, shift_molmo_v1_image_input_idx_for_bos, should_prepare_vlm_embeddings,
+    VlmPreparationSummary, expand_gemma4_unified_video_tokens, expand_gemma4_video_tokens,
+    format_molmo_v1_prompt_for_processor, prepared_embedding_refs,
+    shift_molmo_v1_image_input_idx_for_bos, should_prepare_vlm_embeddings,
 };
 use crate::vision::merge::InputEmbeddings;
 use crate::vlm_prompt::{ImageTokenBlockAction, ImageTokenBlockStats};
@@ -169,5 +170,54 @@ fn expand_gemma4_video_tokens_no_op_when_videos_empty() {
     let mut prompt = vec![1, 7, 8];
     let original = prompt.clone();
     expand_gemma4_video_tokens(&mut prompt, 100, 200, 201, 202, &[]).unwrap();
+    assert_eq!(prompt, original);
+}
+
+// ── Gemma 4 Unified video token expansion (issue #164) ────────────────────────
+// Per-frame soft tokens are the VIDEO token id (not the image token id), framed
+// BOI video* EOI per frame. video_token_id = 100, boi = 201, eoi = 202.
+
+#[test]
+fn expand_gemma4_unified_video_tokens_splices_after_bos_when_no_placeholder() {
+    // CLI path: no <|video|> placeholder in the prompt, two frames of 2 soft
+    // tokens each spliced after BOS.
+    let mut prompt = vec![1, 7, 8];
+    let frames = vec![vec![2, 2]]; // one video, two frames
+    expand_gemma4_unified_video_tokens(&mut prompt, 100, 201, 202, &frames).unwrap();
+    assert_eq!(
+        prompt,
+        vec![
+            1, // BOS
+            201, 100, 100, 202, // frame 1: BOI video video EOI
+            201, 100, 100, 202, // frame 2: BOI video video EOI
+            7, 8,
+        ]
+    );
+}
+
+#[test]
+fn expand_gemma4_unified_video_tokens_replaces_placeholder() {
+    // Server/chat-template path: a single <|video|> (video_token_id=100)
+    // placeholder is replaced by its video's per-frame runs. The replacement
+    // scan does not re-expand the video tokens it just inserted.
+    let mut prompt = vec![1, 100, 7];
+    let frames = vec![vec![3]]; // one video, one frame of 3 soft tokens
+    expand_gemma4_unified_video_tokens(&mut prompt, 100, 201, 202, &frames).unwrap();
+    assert_eq!(prompt, vec![1, 201, 100, 100, 100, 202, 7]);
+}
+
+#[test]
+fn expand_gemma4_unified_video_tokens_errors_on_count_mismatch() {
+    let mut prompt = vec![1, 100, 100, 7]; // two placeholders
+    let frames = vec![vec![2]]; // only one video
+    let err = expand_gemma4_unified_video_tokens(&mut prompt, 100, 201, 202, &frames).unwrap_err();
+    assert!(err.to_string().contains("video placeholder"));
+}
+
+#[test]
+fn expand_gemma4_unified_video_tokens_no_op_when_videos_empty() {
+    let mut prompt = vec![1, 7, 8];
+    let original = prompt.clone();
+    expand_gemma4_unified_video_tokens(&mut prompt, 100, 201, 202, &[]).unwrap();
     assert_eq!(prompt, original);
 }

--- a/src/server/chat_template.rs
+++ b/src/server/chat_template.rs
@@ -309,6 +309,16 @@ impl ChatTemplateProcessor {
         self.template.contains("'image'") || self.template.contains("\"image\"")
     }
 
+    /// Check if the template handles multimodal content with video items.
+    ///
+    /// Returns true when the Jinja2 template iterates over content items and
+    /// checks for `type == 'video'`, as the Gemma 4 templates do (they emit a
+    /// `<|video|>` marker per video item). Templates without this pattern
+    /// expect `content` to be a plain string.
+    pub fn supports_video_content(&self) -> bool {
+        self.template.contains("'video'") || self.template.contains("\"video\"")
+    }
+
     /// Apply the chat template with raw JSON messages (for multimodal content).
     ///
     /// This allows passing messages with list-type content entries (e.g.,

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -1244,14 +1244,15 @@ fn prepare_request_video_embeddings(
 ) -> Result<Option<InputEmbeddings>> {
     use crate::multimodal::video;
 
+    // Encoder-free Gemma 4 Unified routes to its own video path (issue #164):
+    // per-frame patches scatter into video_token_id placeholders rather than
+    // through the ViT image tower.
+    if let LoadedModel::Gemma4Unified(unified) = model {
+        return prepare_gemma4_unified_video_embeddings(unified, prompt_tokens, images, videos);
+    }
+
     let gemma4_vl = match model {
         LoadedModel::Gemma4VLM(model) => model,
-        LoadedModel::Gemma4Unified(_) => {
-            return Err(anyhow!(
-                "video input is not yet supported for gemma4_unified models; \
-                 text and image (and image+audio) inputs are supported"
-            ));
-        }
         _ => {
             return Err(anyhow!(
                 "video inputs are only supported by Gemma 4 VLM models in this build"
@@ -1365,6 +1366,102 @@ fn prepare_request_video_embeddings(
         &processed_images,
         &processed_videos,
     );
+
+    Ok(Some(embeddings))
+}
+
+/// Resolve `videos` into Gemma 4 Unified (encoder-free) video embeddings.
+///
+/// Mirrors [`prepare_request_video_embeddings`]'s decode/ffmpeg handling and
+/// the CLI's `compute_gemma4_unified_video_embeddings`, but routes through the
+/// unified model's `video_token_id` scatter: each decoded frame is patchified
+/// at the per-frame `vision_soft_tokens_per_video_frame` budget, the prompt is
+/// expanded into per-frame `<boi> video_token*N <eoi>` runs, and the per-frame
+/// soft tokens scatter into `video_token_id` placeholders (issue #164).
+///
+/// `videos` carry [`crate::multimodal::video::VideoSource`] handles that are
+/// fd-backed on Unix, so `load_video_source` reads from the open file
+/// description the resolver already validated (no canonicalize → ffmpeg-open
+/// TOCTOU window).
+fn prepare_gemma4_unified_video_embeddings(
+    unified: &crate::vision::Gemma4UnifiedModel,
+    prompt_tokens: &mut Vec<i32>,
+    images: &[Vec<u8>],
+    videos: &[crate::server::media::ResolvedVideo],
+) -> Result<Option<InputEmbeddings>> {
+    use crate::multimodal::video;
+
+    if !video::ffmpeg_available() {
+        return Err(anyhow!(
+            "Video input requires `ffmpeg` on PATH. Install ffmpeg (e.g. `brew install ffmpeg` \
+             on macOS or `apt install ffmpeg` on Linux) and retry."
+        ));
+    }
+
+    // Decode each video honoring the per-video FPS override when supplied;
+    // otherwise fall back to `multimodal::video::DEFAULT_FPS` (2.0 fps).
+    let mut decoded_videos: Vec<Vec<image::DynamicImage>> = Vec::with_capacity(videos.len());
+    for resolved in videos.iter() {
+        let fps = resolved.fps.unwrap_or(video::DEFAULT_FPS);
+        let frames =
+            video::load_video_source(&resolved.source, Some(fps), None).map_err(|err| {
+                anyhow!(
+                    "Failed to load video {:?}: {}",
+                    resolved.source.canonical_path(),
+                    err
+                )
+            })?;
+        decoded_videos.push(frames);
+    }
+
+    let total_decoded_frames: usize = decoded_videos.iter().map(Vec::len).sum();
+    tracing::info!(
+        "Gemma4 Unified video request: decoded {} video(s) ({} total frames after sampling)",
+        decoded_videos.len(),
+        total_decoded_frames
+    );
+
+    // Optional companion images (e.g. user passes both image_url and video_url).
+    let processed_images = if images.is_empty() {
+        Vec::new()
+    } else {
+        let decoded_images = decode_request_images(images)?;
+        let processed = unified.processor.preprocess(&decoded_images);
+        let num_soft_tokens: Vec<usize> = processed.iter().map(|img| img.num_soft_tokens).collect();
+        crate::vlm_runtime::expand_gemma4_image_tokens_pub(
+            prompt_tokens,
+            unified.image_token_id,
+            unified.boi_token_id,
+            unified.eoi_token_id,
+            &num_soft_tokens,
+        )?;
+        processed
+    };
+
+    // Patchify every frame of every video. Frames stay flat in (video, frame)
+    // order so the scatter sees them in the same order as the expanded
+    // video_token_id placeholders.
+    let mut video_frames: Vec<crate::vision::processors::gemma4_unified::Gemma4UnifiedImageInput> =
+        Vec::with_capacity(total_decoded_frames);
+    let mut video_frame_tokens: Vec<Vec<usize>> = Vec::with_capacity(decoded_videos.len());
+    for frames in &decoded_videos {
+        let processed = unified.processor.preprocess_video_frames(frames);
+        video_frame_tokens.push(processed.iter().map(|f| f.num_soft_tokens).collect());
+        video_frames.extend(processed);
+    }
+
+    crate::vlm_runtime::expand_gemma4_unified_video_tokens(
+        prompt_tokens,
+        unified.video_token_id,
+        unified.boi_token_id,
+        unified.eoi_token_id,
+        &video_frame_tokens,
+    )?;
+
+    let input_ids_arr =
+        mlxcel_core::from_slice_i32(prompt_tokens, &[1, prompt_tokens.len() as i32]);
+    let embeddings =
+        unified.get_input_embeddings_with_video(&input_ids_arr, &processed_images, &video_frames);
 
     Ok(Some(embeddings))
 }

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -704,10 +704,11 @@ fn detect_model_media_support(model_path: &Path) -> ModelMediaSupport {
         }
     };
 
-    // Currently only Gemma 4 VLM consumes `video_url` content blocks. Mirror
-    // the dispatch in `commands/generate_vlm::compute_vlm_embeddings` and add
-    // new variants here when more video-capable models land.
-    let video = matches!(model_type, ModelType::Gemma4VLM);
+    // The ViT-backed Gemma 4 VLM and the encoder-free Gemma 4 Unified model
+    // both consume `video_url` content blocks (issue #164). Mirror the dispatch
+    // in `commands/generate_vlm::compute_vlm_embeddings` and add new variants
+    // here when more video-capable models land.
+    let video = matches!(model_type, ModelType::Gemma4VLM | ModelType::Gemma4Unified);
     if video {
         tracing::info!(
             "model_type={:?}: enabling video_url content block support",

--- a/src/server/startup_tests.rs
+++ b/src/server/startup_tests.rs
@@ -1075,6 +1075,28 @@ fn detect_model_media_support_recognises_gemma4_vlm() {
 }
 
 #[test]
+fn detect_model_media_support_recognises_gemma4_unified() {
+    // The encoder-free Gemma 4 Unified model consumes `video_url` content
+    // blocks (issue #164). `model_type=gemma4_unified` is detected by
+    // model_type alone (no vision-tower weight probe needed), so a minimal
+    // config is enough to assert the route guard will admit video requests.
+    let dir = temp_path("media-gemma4-unified");
+    let config = serde_json::json!({
+        "model_type": "gemma4_unified",
+        "text_config": { "model_type": "gemma4_unified_text" },
+        "vision_config": { "model_type": "gemma4_unified_vision" }
+    });
+    std::fs::write(dir.join("config.json"), config.to_string()).unwrap();
+
+    let support = detect_model_media_support(&dir);
+    assert!(
+        support.video,
+        "gemma4_unified must enable video_url content blocks, got {support:?}"
+    );
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
 fn detect_model_media_support_falls_back_for_missing_config() {
     let dir = temp_path("media-missing-config");
     // No config.json → get_model_type fails → fallback yields "no video".

--- a/src/vision/gemma4_unified.rs
+++ b/src/vision/gemma4_unified.rs
@@ -118,7 +118,7 @@ impl Gemma4UnifiedModel {
         input_ids: &MlxArray,
         images: &[Gemma4UnifiedImageInput],
     ) -> merge::InputEmbeddings {
-        self.get_input_embeddings_with_audio(input_ids, images, None, None)
+        self.merge_multimodal(input_ids, images, &[], None, None)
     }
 
     /// Compute merged input embeddings, optionally scattering audio frames.
@@ -126,6 +126,87 @@ impl Gemma4UnifiedModel {
         &self,
         input_ids: &MlxArray,
         images: &[Gemma4UnifiedImageInput],
+        audio_features: Option<&MlxArray>,
+        audio_mask: Option<&MlxArray>,
+    ) -> merge::InputEmbeddings {
+        self.merge_multimodal(input_ids, images, &[], audio_features, audio_mask)
+    }
+
+    /// Compute merged input embeddings, scattering per-frame video soft tokens
+    /// into `video_token_id` placeholders (optionally alongside companion
+    /// images). `video_frames` is the concatenation of every clip's frames in
+    /// prompt order; each frame is one [`Gemma4UnifiedImageInput`] capped at
+    /// the processor's `video_soft_tokens_per_frame` budget.
+    pub fn get_input_embeddings_with_video(
+        &self,
+        input_ids: &MlxArray,
+        images: &[Gemma4UnifiedImageInput],
+        video_frames: &[Gemma4UnifiedImageInput],
+    ) -> merge::InputEmbeddings {
+        self.merge_multimodal(input_ids, images, video_frames, None, None)
+    }
+
+    /// Project per-frame video patches into language-model hidden features.
+    ///
+    /// Encoder-free: each frame's patches run through the same patch projector
+    /// (`vision_embedder` + `embed_vision`) as images. Returns the per-frame
+    /// features concatenated along the token axis as `[1, total_soft_tokens,
+    /// hidden]`, trimmed to each frame's real (non-padding) soft-token count,
+    /// or `None` when `video_frames` is empty. The result is scattered into
+    /// `video_token_id` placeholders by [`Self::merge_multimodal`].
+    pub fn get_video_features(
+        &self,
+        video_frames: &[Gemma4UnifiedImageInput],
+    ) -> Option<UniquePtr<MlxArray>> {
+        self.project_vision_features(video_frames)
+    }
+
+    /// Project a set of patch inputs (images or video frames) into the LM
+    /// hidden space and concatenate them along the token axis.
+    ///
+    /// Returns `[1, total_soft_tokens, hidden]` in the projector's native
+    /// dtype (the caller casts to the text dtype before scattering), or `None`
+    /// when `inputs` is empty. Shared by the image and video scatter paths so
+    /// the per-input projection + trim loop lives in one place.
+    fn project_vision_features(
+        &self,
+        inputs: &[Gemma4UnifiedImageInput],
+    ) -> Option<UniquePtr<MlxArray>> {
+        if inputs.is_empty() {
+            return None;
+        }
+        let mut features = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            let patch_feat = self
+                .vision_embedder
+                .forward(&input.patches, &input.positions);
+            let projected = self.embed_vision.forward(&patch_feat);
+            // Keep only the real (non-padding) patch rows so the count aligns
+            // exactly with the placeholder tokens the processor emitted
+            // (`input.num_soft_tokens`). The padded rows sit at the tail
+            // (indices >= num_soft_tokens) and are dropped.
+            let shape = mlxcel_core::array_shape(&projected);
+            let real = (input.num_soft_tokens as i32).min(shape[0]);
+            let trimmed = mlxcel_core::slice(&projected, &[0, 0], &[real, shape[1]]);
+            // [real, hidden] -> [1, real, hidden].
+            features.push(mlxcel_core::reshape(&trimmed, &[1, real, shape[1]]));
+        }
+        if features.len() == 1 {
+            features.pop()
+        } else {
+            Some(crate::vision::encoders::qwen2_vl::concat_many(&features, 1))
+        }
+    }
+
+    /// Compute merged input embeddings for a text + image + video + audio
+    /// prompt. Image and video soft tokens scatter into their respective
+    /// placeholder ids; audio frames scatter last. Text/image/audio-only calls
+    /// pass empty slices / `None` so their behavior is unchanged.
+    fn merge_multimodal(
+        &self,
+        input_ids: &MlxArray,
+        images: &[Gemma4UnifiedImageInput],
+        video_frames: &[Gemma4UnifiedImageInput],
         audio_features: Option<&MlxArray>,
         audio_mask: Option<&MlxArray>,
     ) -> merge::InputEmbeddings {
@@ -143,39 +224,25 @@ impl Gemma4UnifiedModel {
         let per_layer_inputs = self.build_per_layer_inputs(input_ids, &inputs_embeds);
 
         // Encoder-free vision: project each image's patches, concat along the
-        // token axis, and scatter into image_token_id placeholders.
-        let mut result_embeds = if images.is_empty() {
-            merge::InputEmbeddings {
-                inputs_embeds: mlxcel_core::copy(&inputs_embeds),
-                attention_mask_4d: None,
-            }
-        } else {
-            let mut features = Vec::with_capacity(images.len());
-            for image in images {
-                let patch_feat = self
-                    .vision_embedder
-                    .forward(&image.patches, &image.positions);
-                let projected = self.embed_vision.forward(&patch_feat);
-                // Keep only the real (non-padding) patch rows so the count
-                // aligns exactly with the image placeholder tokens the
-                // processor emitted (`image.num_soft_tokens`). The padded rows
-                // sit at the tail (indices >= num_soft_tokens) and are dropped.
-                let shape = mlxcel_core::array_shape(&projected);
-                let real = (image.num_soft_tokens as i32).min(shape[0]);
-                let trimmed = mlxcel_core::slice(&projected, &[0, 0], &[real, shape[1]]);
-                // [real, hidden] -> [1, real, hidden].
-                features.push(mlxcel_core::reshape(&trimmed, &[1, real, shape[1]]));
-            }
-            let merged = if features.len() == 1 {
-                mlxcel_core::astype(
-                    features[0].as_ref().unwrap(),
-                    mlxcel_core::array_dtype(&inputs_embeds),
-                )
-            } else {
-                let cat = crate::vision::encoders::qwen2_vl::concat_many(&features, 1);
-                mlxcel_core::astype(&cat, mlxcel_core::array_dtype(&inputs_embeds))
-            };
-            merge::merge_llava(self.image_token_id, &merged, &inputs_embeds, input_ids)
+        // token axis, and scatter into image_token_id placeholders. Video
+        // frames follow the identical projection and scatter into
+        // video_token_id placeholders (issue #164). Each scatter runs on the
+        // running embeddings so image and video features coexist.
+        let dtype = mlxcel_core::array_dtype(&inputs_embeds);
+        let mut current = mlxcel_core::copy(&inputs_embeds);
+        if let Some(image_feats) = self.project_vision_features(images) {
+            let merged = mlxcel_core::astype(&image_feats, dtype);
+            current =
+                merge::merge_llava(self.image_token_id, &merged, &current, input_ids).inputs_embeds;
+        }
+        if let Some(video_feats) = self.project_vision_features(video_frames) {
+            let merged = mlxcel_core::astype(&video_feats, dtype);
+            current =
+                merge::merge_llava(self.video_token_id, &merged, &current, input_ids).inputs_embeds;
+        }
+        let mut result_embeds = merge::InputEmbeddings {
+            inputs_embeds: current,
+            attention_mask_4d: None,
         };
 
         // Audio: chunk-projected frames scattered into audio_token_id slots.

--- a/src/vision/gemma4_unified_config.rs
+++ b/src/vision/gemma4_unified_config.rs
@@ -119,6 +119,12 @@ pub struct Gemma4UnifiedConfig {
     #[serde(default)]
     pub audio_config: Option<Gemma4UnifiedAudioConfig>,
 
+    /// Soft tokens (patches) emitted per video frame. Smaller than the
+    /// per-image budget (`vision_config.num_soft_tokens`, 280) because a clip
+    /// supplies many frames. Default 70.
+    #[serde(default = "default_vision_soft_tokens_per_video_frame")]
+    pub vision_soft_tokens_per_video_frame: usize,
+
     #[serde(default = "default_image_token_id")]
     pub image_token_id: i32,
     #[serde(default = "default_audio_token_id")]
@@ -143,6 +149,9 @@ pub struct Gemma4UnifiedConfig {
     pub tie_word_embeddings: Option<bool>,
 }
 
+fn default_vision_soft_tokens_per_video_frame() -> usize {
+    70
+}
 fn default_image_token_id() -> i32 {
     258_880
 }

--- a/src/vision/gemma4_unified_config_tests.rs
+++ b/src/vision/gemma4_unified_config_tests.rs
@@ -141,6 +141,19 @@ fn eoa_token_index_fallback() {
 }
 
 #[test]
+fn vision_soft_tokens_per_video_frame_defaults_to_70() {
+    // The reference checkpoint omits the field; it must default to 70
+    // (issue #164). An explicit value overrides the default.
+    let cfg: Gemma4UnifiedConfig = serde_json::from_value(reference_config()).unwrap();
+    assert_eq!(cfg.vision_soft_tokens_per_video_frame, 70);
+
+    let mut value = reference_config();
+    value["vision_soft_tokens_per_video_frame"] = serde_json::json!(140);
+    let cfg2: Gemma4UnifiedConfig = serde_json::from_value(value).unwrap();
+    assert_eq!(cfg2.vision_soft_tokens_per_video_frame, 140);
+}
+
+#[test]
 fn token_ids_match_reference() {
     let cfg: Gemma4UnifiedConfig = serde_json::from_value(reference_config()).unwrap();
     assert_eq!(cfg.image_token_id, 258880);

--- a/src/vision/gemma4_unified_tests.rs
+++ b/src/vision/gemma4_unified_tests.rs
@@ -60,6 +60,20 @@ fn block_ids_video_counts_as_vision() {
 }
 
 #[test]
+fn block_ids_video_frames_separated_by_eoi_boi_are_distinct() {
+    // Two video frames, each framed as BOI video* EOI (the unified video
+    // expansion). The EOI/BOI between frames break the vision run, so each
+    // frame's video span is its own bidirectional block. Mirrors the per-frame
+    // boi/eoi framing produced by `expand_gemma4_unified_video_tokens`.
+    // BOI vid vid EOI BOI vid vid EOI
+    let input = vec![
+        255_999, 258_884, 258_884, 258_882, 255_999, 258_884, 258_884, 258_882,
+    ];
+    let block = compute_vision_block_ids(&input, IDS, true).expect("video present, no audio");
+    assert_eq!(block, vec![-1, 0, 0, -1, -1, 1, 1, -1]);
+}
+
+#[test]
 fn block_ids_disabled_when_audio_present() {
     // image + audio → fully causal (overlay disabled per issue §6).
     let input = vec![1, 258_880, 258_880, 258_881, 9];

--- a/src/vision/processors/gemma4_unified.rs
+++ b/src/vision/processors/gemma4_unified.rs
@@ -25,6 +25,13 @@ use image::DynamicImage;
 use image::imageops::FilterType;
 use mlxcel_core::{MlxArray, UniquePtr};
 
+/// Default soft-token budget per video frame. Mirrors upstream
+/// `Gemma4UnifiedConfig.vision_soft_tokens_per_video_frame` default of 70
+/// (https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4_unified/config.py#L101).
+/// Video frames carry a much smaller per-frame budget than still images
+/// (`num_soft_tokens`, 280) because a clip supplies many frames.
+pub const DEFAULT_VIDEO_SOFT_TOKENS_PER_FRAME: usize = 70;
+
 /// One preprocessed image for the Gemma 4 Unified vision embedder.
 pub struct Gemma4UnifiedImageInput {
     /// Flat patch matrix: `[num_soft_tokens, model_patch_size² · 3]` float32.
@@ -53,6 +60,11 @@ pub struct Gemma4UnifiedProcessor {
     pub model_patch_size: usize,
     /// Maximum soft tokens (patches) per image.
     pub num_soft_tokens: usize,
+    /// Maximum soft tokens (patches) per video frame. Smaller than
+    /// `num_soft_tokens` because a clip supplies many frames. Defaults to
+    /// [`DEFAULT_VIDEO_SOFT_TOKENS_PER_FRAME`]; the loader overrides it from
+    /// `vision_soft_tokens_per_video_frame` in the checkpoint config.
+    pub video_soft_tokens_per_frame: usize,
     /// Raw samples per audio frame/token.
     pub audio_samples_per_token: usize,
     /// Pixel rescale factor (1/255).
@@ -68,9 +80,16 @@ impl Gemma4UnifiedProcessor {
         Self {
             model_patch_size: model_patch_size.max(1),
             num_soft_tokens: num_soft_tokens.max(1),
+            video_soft_tokens_per_frame: DEFAULT_VIDEO_SOFT_TOKENS_PER_FRAME,
             audio_samples_per_token: audio_samples_per_token.max(1),
             rescale_factor: 1.0 / 255.0,
         }
+    }
+
+    /// Override the per-video-frame soft-token budget (config-driven). Clamped
+    /// to at least 1 so the patch loop always emits a row.
+    pub fn set_video_soft_tokens_per_frame(&mut self, value: usize) {
+        self.video_soft_tokens_per_frame = value.max(1);
     }
 
     /// Flat patch dimension (`model_patch_size² · 3`).
@@ -87,9 +106,37 @@ impl Gemma4UnifiedProcessor {
             .collect()
     }
 
+    /// Preprocess decoded video frames into per-frame patch inputs.
+    ///
+    /// Video is "images per frame": each decoded frame runs through the same
+    /// encoder-free patchify as a still image, but the per-frame soft-token
+    /// budget is capped at [`Self::video_soft_tokens_per_frame`] (70 by
+    /// default, from `vision_soft_tokens_per_video_frame`) rather than the
+    /// larger image budget [`Self::num_soft_tokens`]. Each returned
+    /// [`Gemma4UnifiedImageInput`] therefore has its `patches`/`positions`
+    /// padded to `video_soft_tokens_per_frame` rows with `num_soft_tokens`
+    /// equal to the real patch count for that frame.
+    pub fn preprocess_video_frames(&self, frames: &[DynamicImage]) -> Vec<Gemma4UnifiedImageInput> {
+        frames
+            .iter()
+            .map(|frame| self.patchify(frame, self.video_soft_tokens_per_frame))
+            .collect()
+    }
+
     fn preprocess_single(&self, image: &DynamicImage) -> Gemma4UnifiedImageInput {
+        self.patchify(image, self.num_soft_tokens)
+    }
+
+    /// Patchify one image (or video frame) into flat patch vectors plus grid
+    /// positions, capped and padded to `soft_token_cap` rows. Shared by the
+    /// image ([`Self::preprocess_single`]) and video
+    /// ([`Self::preprocess_video_frames`]) paths so the patch loop lives in one
+    /// place; only the soft-token budget differs.
+    fn patchify(&self, image: &DynamicImage, soft_token_cap: usize) -> Gemma4UnifiedImageInput {
+        let soft_token_cap = soft_token_cap.max(1);
         let rgb = image.to_rgb8();
-        let (target_h, target_w) = self.resize_dims(rgb.height() as usize, rgb.width() as usize);
+        let (target_h, target_w) =
+            self.resize_dims(rgb.height() as usize, rgb.width() as usize, soft_token_cap);
 
         let resized = if rgb.height() as usize == target_h && rgb.width() as usize == target_w {
             rgb
@@ -102,18 +149,18 @@ impl Gemma4UnifiedProcessor {
         let ps = self.model_patch_size;
         let grid_h = target_h / ps;
         let grid_w = target_w / ps;
-        let real_patches = (grid_h * grid_w).min(self.num_soft_tokens);
+        let real_patches = (grid_h * grid_w).min(soft_token_cap);
         let patch_dim = self.patch_dim();
 
-        // Pad row count up to num_soft_tokens; pad rows stay zero and get
+        // Pad row count up to soft_token_cap; pad rows stay zero and get
         // position -1 so the embedder contributes zero for them.
-        let mut patch_data = vec![0.0f32; self.num_soft_tokens * patch_dim];
-        let mut positions = vec![-1i32; self.num_soft_tokens * 2];
+        let mut patch_data = vec![0.0f32; soft_token_cap * patch_dim];
+        let mut positions = vec![-1i32; soft_token_cap * 2];
 
         let mut patch_idx = 0usize;
         'outer: for py in 0..grid_h {
             for px in 0..grid_w {
-                if patch_idx >= self.num_soft_tokens {
+                if patch_idx >= soft_token_cap {
                     break 'outer;
                 }
                 // Fill this patch's flat vector in (y, x, c) row-major order:
@@ -139,19 +186,23 @@ impl Gemma4UnifiedProcessor {
         Gemma4UnifiedImageInput {
             patches: mlxcel_core::from_slice_f32(
                 &patch_data,
-                &[self.num_soft_tokens as i32, patch_dim as i32],
+                &[soft_token_cap as i32, patch_dim as i32],
             ),
-            positions: mlxcel_core::from_slice_i32(&positions, &[self.num_soft_tokens as i32, 2]),
+            positions: mlxcel_core::from_slice_i32(&positions, &[soft_token_cap as i32, 2]),
             num_soft_tokens: real_patches,
         }
     }
 
     /// Aspect-ratio-preserving resize so the number of `model_patch_size`
-    /// patches stays at or below `num_soft_tokens` and each side is a multiple
+    /// patches stays at or below `max_patches` and each side is a multiple
     /// of `model_patch_size`.
-    fn resize_dims(&self, image_height: usize, image_width: usize) -> (usize, usize) {
+    fn resize_dims(
+        &self,
+        image_height: usize,
+        image_width: usize,
+        max_patches: usize,
+    ) -> (usize, usize) {
         let ps = self.model_patch_size;
-        let max_patches = self.num_soft_tokens;
         let target_px = max_patches as f64 * (ps * ps) as f64;
         let factor = (target_px / ((image_height * image_width).max(1) as f64)).sqrt();
 

--- a/src/vision/processors/gemma4_unified_tests.rs
+++ b/src/vision/processors/gemma4_unified_tests.rs
@@ -108,6 +108,74 @@ fn resize_respects_soft_token_budget() {
 }
 
 #[test]
+fn video_frames_use_per_frame_soft_token_budget() {
+    // Default video budget is DEFAULT_VIDEO_SOFT_TOKENS_PER_FRAME (70), smaller
+    // than the image budget (280). A large frame must not exceed it.
+    let proc = Gemma4UnifiedProcessor::new(48, 280, 640);
+    assert_eq!(
+        proc.video_soft_tokens_per_frame,
+        DEFAULT_VIDEO_SOFT_TOKENS_PER_FRAME
+    );
+    let big = solid_image(4096, 4096, [128, 128, 128]);
+    let frames = proc.preprocess_video_frames(std::slice::from_ref(&big));
+    assert_eq!(frames.len(), 1);
+    // Padded to the per-frame budget (70), not the image budget (280).
+    assert_eq!(
+        mlxcel_core::array_shape(&frames[0].patches),
+        vec![DEFAULT_VIDEO_SOFT_TOKENS_PER_FRAME as i32, 48 * 48 * 3]
+    );
+    assert_eq!(
+        mlxcel_core::array_shape(&frames[0].positions),
+        vec![DEFAULT_VIDEO_SOFT_TOKENS_PER_FRAME as i32, 2]
+    );
+    assert!(frames[0].num_soft_tokens <= DEFAULT_VIDEO_SOFT_TOKENS_PER_FRAME);
+    assert!(frames[0].num_soft_tokens > 0);
+}
+
+#[test]
+fn video_frames_patchify_each_frame_independently() {
+    // A small explicit budget makes the patch count deterministic: a 96x96
+    // frame on a 2x2 grid yields 4 real patches, padded to the budget (6).
+    let mut proc = Gemma4UnifiedProcessor::new(48, 280, 640);
+    proc.set_video_soft_tokens_per_frame(6);
+    assert_eq!(proc.video_soft_tokens_per_frame, 6);
+
+    let frame_a = solid_image(96, 96, [255, 0, 0]);
+    let frame_b = solid_image(96, 96, [0, 255, 0]);
+    let frames = proc.preprocess_video_frames(&[frame_a, frame_b]);
+    assert_eq!(frames.len(), 2);
+    for frame in &frames {
+        assert_eq!(frame.num_soft_tokens, 4);
+        assert_eq!(
+            mlxcel_core::array_shape(&frame.patches),
+            vec![6, 48 * 48 * 3]
+        );
+        assert_eq!(mlxcel_core::array_shape(&frame.positions), vec![6, 2]);
+        // Padding row (index 4, beyond the 4 real patches) carries position -1.
+        assert_eq!(read_i32_at(&frame.positions, &[4, 0]), -1);
+        assert_eq!(read_i32_at(&frame.positions, &[4, 1]), -1);
+    }
+    // First channel of frame A's first patch is 255/255 = 1.0 (red).
+    assert!((read_f32_at(&frames[0].patches, &[0, 0]) - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn image_path_unchanged_by_video_budget() {
+    // Setting the video budget must not affect the still-image path: a 96x96
+    // image on budget 6 still yields 4 real patches padded to 6 (regression
+    // guard for the shared patchify refactor).
+    let mut proc = Gemma4UnifiedProcessor::new(48, 6, 640);
+    proc.set_video_soft_tokens_per_frame(70);
+    let img = solid_image(96, 96, [255, 0, 0]);
+    let out = proc.preprocess(std::slice::from_ref(&img));
+    assert_eq!(out[0].num_soft_tokens, 4);
+    assert_eq!(
+        mlxcel_core::array_shape(&out[0].patches),
+        vec![6, 48 * 48 * 3]
+    );
+}
+
+#[test]
 fn audio_chunks_into_frames_with_mask() {
     let proc = Gemma4UnifiedProcessor::new(48, 280, 640);
     // 1.5 frames worth of samples → 2 frames; the second is zero-padded.


### PR DESCRIPTION
## Summary

Add video input support to the encoder-free Gemma 4 Unified (`gemma4_unified`) runtime, replacing the previous "video input is not yet supported" gate. Video is handled as images-per-frame: frames are extracted with `ffmpeg` (uniform sampling, default 2.0 fps via the shared `multimodal::video` module), patchified through the existing patch-projection vision embedder, and the per-frame soft tokens scatter into `video_token_id` placeholder spans, mirroring the image scatter. Works on both the CLI (`--video`) and the server (`video_url` content blocks).

## What changed

- **Processor (`src/vision/processors/gemma4_unified.rs`)**: factored the image patch loop into a shared `patchify(image, soft_token_cap)` and added `preprocess_video_frames`, which caps each frame at `vision_soft_tokens_per_video_frame` (70 by default) instead of the larger per-image budget (280). `resize_dims` now takes the cap as a parameter so image and video share one loop. New `DEFAULT_VIDEO_SOFT_TOKENS_PER_FRAME` constant and `set_video_soft_tokens_per_frame` setter.
- **Config (`src/vision/gemma4_unified_config.rs`)**: new `vision_soft_tokens_per_video_frame` field (default 70), wired into the processor by the loader (`src/loading/vlm_gemma_unified.rs`).
- **Model (`src/vision/gemma4_unified.rs`)**: factored the per-input project/trim/concat into `project_vision_features`; added `get_video_features` and `get_input_embeddings_with_video`; the image/video/audio scatters now run on the running embeddings inside a shared `merge_multimodal` core. The image/audio/text paths run the identical op sequence as before, so their output is unchanged.
- **Token expansion (`src/multimodal/vlm_runtime.rs`)**: new `expand_gemma4_unified_video_tokens` frames each frame as `<boi> video_token*N <eoi>` and either replaces a `<|video|>` placeholder in prompt order or splices after BOS when absent. Per-frame soft tokens use `video_token_id` (not `image_token_id`), matching the encoder-free scatter target.
- **CLI (`src/commands/generate.rs`, `generate_vlm.rs`)**: route `--video` for `Gemma4Unified` to a new `compute_gemma4_unified_video_embeddings`; render a `<|video|>` content part inside the user turn, gated to `gemma4_unified` (via `cli_video_content_part_count`) so the ViT-backed `gemma4` VLM path keeps its splice-after-BOS behavior byte-for-byte. New `ChatTemplateProcessor::supports_video_content`.
- **Server (`src/server/model_worker.rs`, `startup.rs`)**: removed the `Gemma4Unified` "not yet supported" gate and added `prepare_gemma4_unified_video_embeddings`; `detect_model_media_support` now advertises video for `gemma4_unified` so the route guard admits `video_url` requests. The server gets the `<|video|>` placeholder from the request content parts.
- **Mask fix (`src/models/gemma4.rs`)**: `overlay_block_bidirectional` panicked ("Cannot reshape array of size N into shape (1, window)") whenever a prefill exceeded the 1024-token sliding window, because the windowed base mask caps its key axis to the window while the block-id vector spans the full sequence. It now aligns the key-side ids to the trailing `window` positions the rotating cache retains. Each vision span is at most one frame and fits inside the window, so per-span bidirectional attention is preserved.
- **Docs (`docs/supported-models.md`)**: mark video as supported for `gemma4_unified` and document the frame budget / sliding-window caveat.

## Reused infra (no reinvention)

`multimodal::video` (`ffmpeg_available`, `load_videos`, `load_video_source`, `DEFAULT_FPS`) for decode and FPS; the existing `Gemma4UnifiedVisionEmbedder` + `Gemma4MultimodalEmbedder` patch projector; `merge::merge_llava` for the scatter (now keyed on `video_token_id`); the existing `gemma4_unified_mask` blockwise bidirectional builder (video tokens were already type 2 and treated as vision); `decode_request_images` and the server media resolver / fd-backed `VideoSource` for the server path.

## Validation (real model: `mlx-community/gemma-4-12b-it-4bit`, M1 Ultra)

CLI, grounded description (6 frames at `--fps 0.6`, 425 prompt tokens):

```
$ mlxcel generate -m models/gemma-4-12b-it-4bit --video car_video.mp4 --fps 0.6 -p "Describe this video." -n 100
The video shows a car accident in a parking lot. A black SUV is moving forward and hits a silver car parked in a space. The impact causes the front of the black SUV to crumple and the front of the silver car to be damaged. The black SUV then comes to a stop.
```

Server `/v1/chat/completions` with a `video_url` content part (startup log: `model_type=Gemma4Unified: enabling video_url content block support`):

```
The video shows a black minivan and a silver sedan parked in a parking lot. The black minivan is parked in a space and the silver sedan is parked in the space next to it...
```

Regressions on the same model are unaffected: text-only returns a correct short answer, and a single-image run returns "A solid, dark reddish-brown square." for a solid-red fixture.

### Known limitation (pre-existing, not introduced here)

The acceptance command at the default 2.0 fps on the 10s `car_video.mp4` yields 20 frames (1377 prompt tokens), which exceeds the model's 1024-token sliding window. Single-pass prefill of a sequence longer than the window degenerates to `<pad>` output because the rotating KV cache evicts the keys the earliest query rows need (their windowed mask row becomes all-masked, producing NaN that propagates). This reproduces with a text-only ~1700-token coherent prompt and is independent of the video path (text generation never touches the bidirectional overlay). It also reproduces on the existing `gemma4` VLM video path. Lowering `--fps` (or the frame count) keeps a clip within the window and yields a grounded description, as shown above. A proper fix (chunked prefill for sliding-window models) is a separate follow-up.

## Tests

Narrow unit tests added beside the code:

- Processor: `preprocess_video_frames` per-frame shape + soft-token count caps at `vision_soft_tokens_per_video_frame`; image path unchanged by the video budget.
- Config: `vision_soft_tokens_per_video_frame` defaults to 70 and honors an explicit value.
- Expansion: `expand_gemma4_unified_video_tokens` placeholder-replace, splice-after-BOS, count-mismatch error, empty no-op.
- Mask: video frame spans separated by `eoi`/`boi` get distinct bidirectional blocks; `overlay_block_bidirectional` aligns block ids to a windowed (capped) key axis without panicking.
- Prompt: the VLM chat template renders a `<|video|>` content part inside the user turn (image-then-video order) and omits it when the template lacks video support.
- Server: `detect_model_media_support` enables video for `gemma4_unified`.

## Test plan

- [x] `cargo build --release --features metal,accelerate -p mlxcel`
- [x] `cargo test --release -p mlxcel --lib gemma4_unified` (33 passed) and the new lib tests (38 passed for the combined filter)
- [x] `cargo test --release -p mlxcel --bin mlxcel` (125 passed; the one failure `tests::family_order_is_exhaustive` is pre-existing on `main` and unrelated: it flags `BitNet` missing from `FAMILY_ORDER`)
- [x] `cargo clippy --features metal,accelerate -p mlxcel --bins --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Real-model video generation (CLI) produces a grounded car-accident description
- [x] Server `/v1/chat/completions` video content part produces a grounded description
- [x] Text-only and single-image regressions on the same model

Closes #164
