### PR TITLE
fix(cli): add BitNet to FAMILY_ORDER so family_order_is_exhaustive passes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1716,6 +1716,7 @@ const FAMILY_ORDER: &[&str] = &[
     "LFM2",
     "PLaMo",
     "RWKV",
+    "BitNet",
     "Speech-to-text",
     "Text-to-speech",
     "Specialized",


### PR DESCRIPTION
The BitNet family was missing from the `mlxcel arch` family-ordering table (`FAMILY_ORDER` in `src/main.rs`), so the `family_order_is_exhaustive` guard test failed and BitNet sorted under the unknown-family fallback instead of its intended position. This was a pre-existing failure on `main`, surfaced as a follow-up while implementing #164 (PR #400 did not touch `src/main.rs`).

The fix adds `"BitNet"` after `"RWKV"`, placing it at the end of the distinctive text-family cluster (Falcon / LFM2 / PLaMo / RWKV) ahead of the speech and VLM sections, which matches BitNet b1.58 being a distinctive dense ternary family. The exact family string matches `ModelType::BitNet`'s metadata in `src/models/mod.rs`.

Verified: `family_order_is_exhaustive` and `family_order_has_no_orphans` both pass, and `mlxcel arch` now renders a `BitNet:` section with `BitNet b1.58 (ternary)`.

Closes #402