### PR TITLE
fix: harden sliding-window over-window prefill across models

### DIFF
--- a/src/distributed/tensor_parallel/llama_runtime.rs
+++ b/src/distributed/tensor_parallel/llama_runtime.rs
@@ -2757,11 +2757,17 @@ fn gemma3_masks(
     let sliding_mask = if rank0.sliding_window_pattern > 1 {
         let sliding_offset = gemma3_cache_offset(&mut rank0_caches[0]);
         let max_cache = rank0.sliding_window as i32;
-        let effective_offset = sliding_offset.min((max_cache - seq_len).max(0));
-        Some(mlxcel_core::utils::create_causal_mask_with_window(
+        // Mirror the single-process gemma3 `sliding_prefill_mask` (issue #401/#408):
+        // a fresh single-pass prefill longer than the window keeps every key (the
+        // RotatingKVCache returns all of them) and needs the full-width windowed
+        // mask, otherwise the clamped `(seq_len, window)` mask strands the earliest
+        // query rows with an all-(-inf) row and the broadcast crashes against the
+        // full key axis. The helper's else-branch is byte-identical to the prior
+        // `sliding_offset.min((max_cache - seq_len).max(0))` clamped construction.
+        Some(mlxcel_core::utils::create_sliding_window_prefill_mask(
             seq_len,
-            effective_offset,
-            Some(max_cache),
+            sliding_offset,
+            max_cache,
         ))
     } else {
         None

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -3461,7 +3461,14 @@ mod tests {
     }
 
     #[test]
-    fn causal_attention_window_bool_mask_matches_float_reference() {
+    fn causal_attention_multi_token_over_window_uses_full_windowed_mask() {
+        // Multi-token prefill (`q_len = 3`) whose key length (`k_len = 5`)
+        // exceeds the window. Before issue #408 `causal_attention` sliced K/V
+        // to the trailing `window_size` keys and used the clamped
+        // `(q_len, window_size)` mask, which strands the earliest query rows.
+        // The corrected behavior keeps all keys and builds the full
+        // `(q_len, k_len)` windowed-causal mask, so the reference must use the
+        // full K/V and `create_causal_mask_with_window_full`.
         let q = crate::from_slice_f32(
             &[
                 0.1, -0.2, 0.3, 0.4, 0.2, 0.0, -0.1, 0.5, -0.3, 0.1, 0.2, -0.4,
@@ -3483,26 +3490,22 @@ mod tests {
             &[1, 1, 5, 4],
         );
         let scale = 0.5_f32;
-        // Use window_size=3 (not 2) so the post-earlier cap path produces a
-        // non-degenerate mask: with q_len=3, window=3, tril_offset = w - size
-        // = 0, so q=0 attends to k=0. With window=2 the row-0 mask is fully
-        // masked, which produces NaN under the now-correct semantics (a
-        // query whose logical position predates every cache key).
-        let window_size = 3_i32;
+        // window_size=2 is the previously-degenerate case: under the old
+        // clamp+slice path query row 0 (logical position 0) had an all-`-inf`
+        // mask row and softmaxed to NaN. The full mask gives it its own
+        // window, so no row is fully masked.
+        let window_size = 2_i32;
 
         let out = crate::causal_attention(&q, &k, &v, scale, 0.0, window_size);
-        // See note in `causal_attention_single_query_window_respects_mask_when_needed`:
-        // the explicit-mask reference must slice K/V to the last `window_size`
-        // slots to line up with the post-cap mask shape `(q_len, window_size)`.
-        let mask_f = crate::utils::create_causal_mask_with_window(3, 2, Some(window_size));
-        let k_sliced = crate::slice(&k, &[0, 0, 5 - window_size, 0], &[1, 1, 5, 4]);
-        let v_sliced = crate::slice(&v, &[0, 0, 5 - window_size, 0], &[1, 1, 5, 4]);
+        // Reference: full key set + uncapped windowed mask over offset =
+        // k_len - q_len = 2.
+        let mask_full = crate::utils::create_causal_mask_with_window_full(3, 2, Some(window_size));
         let out_ref = attention(
             &q,
-            &k_sliced,
-            &v_sliced,
+            &k,
+            &v,
             scale,
-            Some(mask_f.as_ref().unwrap()),
+            Some(mask_full.as_ref().unwrap()),
             0.0,
             window_size,
         );
@@ -3511,9 +3514,21 @@ mod tests {
         let diff_abs = crate::abs(&diff);
         let diff_sum = crate::sum_all(&diff_abs);
         crate::eval(&diff_sum);
+        let total = crate::item_f32(&diff_sum);
         assert!(
-            crate::item_f32(&diff_sum) < 1e-5,
-            "bool-mask causal window path should match float-mask reference"
+            total.is_finite() && total < 1e-5,
+            "multi-token over-window causal attention should match the full \
+             windowed-mask reference (no NaN, no stranded rows); diff_sum = {total}"
+        );
+
+        // The output itself must be finite (the pre-#408 path produced NaN for
+        // the earliest query row under window_size=2).
+        let out_abs = crate::abs(out.as_ref().unwrap());
+        let out_sum = crate::sum_all(&out_abs);
+        crate::eval(&out_sum);
+        assert!(
+            crate::item_f32(&out_sum).is_finite(),
+            "multi-token over-window causal attention output must be finite"
         );
     }
 

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -2570,6 +2570,14 @@ pub fn fast_rope_batched(
 /// explicit mask array. Other hardware keeps using MLX's native causal SDPA
 /// entry point.
 ///
+/// Sliding-window handling splits by query length: a single-query decode
+/// (`q_len == 1`) slices K/V to the trailing `window_size` keys and uses the
+/// clamped `(1, window_size)` mask, while a multi-token prefill that exceeds
+/// the window (`q_len > 1 && k_len > window_size`) keeps all keys and builds a
+/// full-width windowed-causal mask over them. Slicing K/V for a multi-token
+/// prefill would strand the earliest query rows with an all-`-inf` row -> NaN
+/// (issue #401/#408); the windowed correctness instead comes from the mask.
+///
 /// Used by: Llama, Qwen, Mixtral, Gemma, Cohere, Phi, OLMo, Exaone, GLM4,
 /// MiniCPM, DeepSeek, Hunyuan, StarCoder2 and other causal prefill call sites
 pub fn causal_attention(
@@ -2593,13 +2601,25 @@ pub fn causal_attention(
     }
 
     if softcap > 0.0 || window_size > 0 {
-        // When the window is exceeded, slice K/V to the last `window_size`
-        // slots so they line up with the (q_len, window_size)-shaped mask
-        // produced by `create_causal_mask_with_window`. Production callers
-        // backed by `RotatingKVCache` already deliver K/V truncated to
-        // `max_size = window_size`; this branch keeps the wrapper
-        // self-consistent for any other caller (and for our own unit tests).
-        let (k_used, v_used, effective_k_len) = if needs_window_mask {
+        // A multi-token prefill that exceeds the window must NOT slice K/V to
+        // the trailing `window_size` keys: a fresh `RotatingKVCache` (and a
+        // dense `KVCache`) keep every prefill key, and a trailing slice strands
+        // the earliest query rows (logical position `< k_len - window_size`)
+        // with no visible key, producing an all-`-inf` softmax row -> NaN /
+        // `<pad>` (issue #401/#408). For that case build a full-width
+        // windowed-causal mask over ALL keys instead; windowed correctness
+        // comes from the mask, mirroring mlx-lm's `RotatingKVCache`. The
+        // single-query decode path (`q_len == 1`) keeps the trailing-window K/V
+        // slice fast path, byte-for-byte unchanged.
+        let over_window_prefill = needs_window_mask && q_len > 1;
+
+        let (k_used, v_used, effective_k_len) = if needs_window_mask && !over_window_prefill {
+            // Decode (`q_len == 1`) beyond the window: slice K/V to the last
+            // `window_size` keys so they line up with the (1, window_size) mask
+            // produced by `create_causal_mask_with_window`. Production callers
+            // backed by `RotatingKVCache` already deliver K/V truncated to
+            // `max_size = window_size`; this keeps the wrapper self-consistent
+            // for any other single-query caller.
             let k_shape = ffi::array_shape(k);
             let v_shape = ffi::array_shape(v);
             let start = k_len - window_size;
@@ -2621,7 +2641,15 @@ pub fn causal_attention(
         let v_ref: &MlxArray = v_used.as_deref().unwrap_or(v);
 
         let offset = (effective_k_len - q_len).max(0);
-        let mask = if softcap == 0.0 && use_bool_causal_mask_path() {
+        let mask = if over_window_prefill {
+            // Full-width windowed-causal mask over all `k_len` keys (same
+            // builder as the gemma3/gemma4 `sliding_prefill_mask`, issue #401).
+            // Only reached for the previously-degenerate `q_len > 1`,
+            // `k_len > window` case, so there is no decode bit-exactness
+            // constraint here; the experimental bool-mask path is intentionally
+            // bypassed (this case has no all-`-inf` rows left to reproduce).
+            utils::create_causal_mask_with_window_full(q_len, offset, Some(window_size))
+        } else if softcap == 0.0 && use_bool_causal_mask_path() {
             if window_size > 0 {
                 utils::create_causal_bool_mask_with_window(q_len, offset, Some(window_size))
             } else {

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -626,6 +626,45 @@ pub fn create_causal_mask_with_window_full(
     ffi::where_cond(&bool_mask, &zeros, &neg_inf)
 }
 
+/// Build the sliding-window attention mask for a multi-token prefill
+/// (`size > 1`), sized to the keys the cache actually returns.
+///
+/// A fresh single-pass prefill that exceeds the window is the degenerate case
+/// behind issue #401/#408: both [`RotatingKVCache`] (on its first prefill
+/// append) and a dense `KVCache` keep *every* prefill key, so the window must
+/// be enforced by the mask over the full key axis, not by capping the mask and
+/// dropping keys. For that case (`size > window && sliding_offset == 0`) this
+/// returns the uncapped [`create_causal_mask_with_window_full`] `[size, size]`
+/// mask. In every other case (within-window prefill, or a rolled-over rotating
+/// cache that already returns at most `window` keys) it returns the clamped
+/// [`create_causal_mask_with_window`] mask with the same
+/// `sliding_offset.min((window - size).max(0))` adjustment the per-model mask
+/// builders used before, so greedy output stays byte-identical there.
+///
+/// The `sliding_offset == 0` gate mirrors the gemma3 prior art: only a fresh
+/// prefill is guaranteed to hold all `size` keys; once a rotating cache has
+/// rolled over (`sliding_offset > 0`) it returns at most `window` keys and the
+/// clamped mask is the matching shape. Models whose attention layer slices K/V
+/// to the trailing window must slice to the mask's key dimension (not blindly
+/// to `window`) so they keep the full key set when this returns the full mask.
+///
+/// Used by: GptOss, Mellum, Exaone4, ExaoneMoE, Ministral3, Step3P5, Cohere2,
+/// Gemma3n, Baichuan sliding-window prefill mask construction.
+///
+/// [`RotatingKVCache`]: crate::cache::RotatingKVCache
+pub fn create_sliding_window_prefill_mask(
+    size: i32,
+    sliding_offset: i32,
+    window: i32,
+) -> UniquePtr<MlxArray> {
+    if size > window && sliding_offset == 0 {
+        create_causal_mask_with_window_full(size, 0, Some(window))
+    } else {
+        let effective_offset = sliding_offset.min((window - size).max(0));
+        create_causal_mask_with_window(size, effective_offset, Some(window))
+    }
+}
+
 /// Create a boolean causal attention mask with optional sliding window.
 /// Used by: same as `create_causal_mask_with_window` (experimental path)
 ///
@@ -1267,6 +1306,88 @@ mod tests {
                 );
                 if a.is_finite() {
                     assert_eq!(a, b, "cell ({q},{k}) value mismatch: full={a}, capped={b}");
+                }
+            }
+        }
+    }
+
+    // --- Sliding-window prefill mask selector (issue #408) ----------------
+
+    /// A fresh single-pass prefill (`sliding_offset == 0`) longer than the
+    /// window must select the uncapped full `[size, size]` mask, so no early
+    /// query row is stranded with an all-`-inf` row.
+    #[test]
+    fn sliding_window_prefill_mask_selects_full_when_fresh_over_window() {
+        let prefill = create_sliding_window_prefill_mask(4, 0, 2);
+        assert_eq!(
+            ffi::array_shape(&prefill),
+            vec![4, 4],
+            "fresh over-window prefill must use the full [size, size] mask"
+        );
+        let full = create_causal_mask_with_window_full(4, 0, Some(2));
+        let at =
+            |m: &MlxArray, q: i32, k: i32| ffi::item_f32(&ffi::slice(m, &[q, k], &[q + 1, k + 1]));
+        for q in 0..4 {
+            for k in 0..4 {
+                let a = at(&prefill, q, k);
+                let b = at(&full, q, k);
+                assert_eq!(a.is_finite(), b.is_finite(), "cell ({q},{k}) finiteness");
+                if a.is_finite() {
+                    assert_eq!(a, b, "cell ({q},{k}) value");
+                }
+            }
+            // No row is fully masked: each attends to at least its own key.
+            assert_eq!(at(&prefill, q, q), 0.0, "row {q} must attend to itself");
+        }
+    }
+
+    /// A rolled-over cache (`sliding_offset > 0`) keeps the clamped path,
+    /// byte-identical to the per-model `create_causal_mask_with_window`
+    /// construction it replaced (same `min((window - size).max(0))` clamp).
+    #[test]
+    fn sliding_window_prefill_mask_clamps_when_rolled_over() {
+        let window = 4;
+        let size = 2;
+        let sliding_offset = 9; // well past the window → clamped path
+        let prefill = create_sliding_window_prefill_mask(size, sliding_offset, window);
+        let effective_offset = sliding_offset.min((window - size).max(0));
+        let clamped = create_causal_mask_with_window(size, effective_offset, Some(window));
+        assert_eq!(
+            ffi::array_shape(&prefill),
+            ffi::array_shape(&clamped),
+            "rolled-over prefill must match the clamped mask shape"
+        );
+        let cols = ffi::array_shape(&prefill)[1];
+        let at =
+            |m: &MlxArray, q: i32, k: i32| ffi::item_f32(&ffi::slice(m, &[q, k], &[q + 1, k + 1]));
+        for q in 0..size {
+            for k in 0..cols {
+                let a = at(&prefill, q, k);
+                let b = at(&clamped, q, k);
+                assert_eq!(a.is_finite(), b.is_finite(), "cell ({q},{k}) finiteness");
+                if a.is_finite() {
+                    assert_eq!(a, b, "cell ({q},{k}) value");
+                }
+            }
+        }
+    }
+
+    /// A within-window fresh prefill (`size <= window`) selects the clamped
+    /// (here non-capped) mask, identical to `create_causal_mask_with_window`.
+    #[test]
+    fn sliding_window_prefill_mask_within_window_matches_capped_builder() {
+        let prefill = create_sliding_window_prefill_mask(3, 0, 8);
+        let capped = create_causal_mask_with_window(3, 0, Some(8));
+        assert_eq!(ffi::array_shape(&prefill), ffi::array_shape(&capped));
+        let at =
+            |m: &MlxArray, q: i32, k: i32| ffi::item_f32(&ffi::slice(m, &[q, k], &[q + 1, k + 1]));
+        for q in 0..3 {
+            for k in 0..3 {
+                let a = at(&prefill, q, k);
+                let b = at(&capped, q, k);
+                assert_eq!(a.is_finite(), b.is_finite(), "cell ({q},{k}) finiteness");
+                if a.is_finite() {
+                    assert_eq!(a, b, "cell ({q},{k}) value");
                 }
             }
         }

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -649,7 +649,7 @@ pub fn create_causal_mask_with_window_full(
 /// to `window`) so they keep the full key set when this returns the full mask.
 ///
 /// Used by: GptOss, Mellum, Exaone4, ExaoneMoE, Ministral3, Step3P5, Cohere2,
-/// Gemma3n, Baichuan sliding-window prefill mask construction.
+/// Gemma3n, Olmo3 sliding-window prefill mask construction.
 ///
 /// [`RotatingKVCache`]: crate::cache::RotatingKVCache
 pub fn create_sliding_window_prefill_mask(

--- a/src/models/cohere2.rs
+++ b/src/models/cohere2.rs
@@ -23,7 +23,7 @@
 
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{FusedQKVLinear, KVCache, LayerNorm, UnifiedEmbedding, UnifiedLinear};
-use mlxcel_core::utils::{create_causal_mask, create_causal_mask_with_window};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
@@ -178,16 +178,21 @@ impl Cohere2Attention {
 
         // Scaled dot-product attention
         let attn_out = if l > 1 {
-            // Prefill: use mask. If a windowed mask was supplied for a
-            // sliding-window layer, post-earlier it is shaped
-            // `(l, window_size)` (capped). Plain `KVCache` returns
-            // full-length K/V, so slice K/V to the last `window_size` slots
-            // here, mirroring `causal_attention`'s internal slicing.
+            // Prefill: use mask. A sliding-window layer's mask is either the
+            // clamped `(l, window_size)` mask or the full `(l, k_len)` mask for
+            // a fresh single-pass prefill that exceeds the window (issue #408).
+            // Plain `KVCache` returns full-length K/V, so slice K/V to the
+            // mask's key axis (not blindly to `window_size`): a full mask keeps
+            // every key, a clamped mask drops the oldest. Mirrors
+            // `causal_attention`'s internal handling.
             let k_shape = mlxcel_core::array_shape(&cache_k);
             let k_len = k_shape[2];
-            let (k_used, v_used) = if self.window_size > 0 && k_len > self.window_size {
+            let mask_klen = mask
+                .map(|m| *mlxcel_core::array_shape(m).last().unwrap_or(&k_len))
+                .unwrap_or(k_len);
+            let (k_used, v_used) = if self.window_size > 0 && k_len > mask_klen {
                 let v_shape = mlxcel_core::array_shape(&cache_v);
-                let start = k_len - self.window_size;
+                let start = k_len - mask_klen;
                 (
                     Some(mlxcel_core::slice(
                         &cache_k,
@@ -422,10 +427,14 @@ impl Cohere2Model {
             let swa_offset = caches[self.swa_idx].offset;
 
             let full = Some(create_causal_mask(l as i32, ga_offset));
-            let sliding = Some(create_causal_mask_with_window(
+            // Full-width windowed mask for a fresh single-pass prefill that
+            // exceeds the window; clamped mask otherwise. The attention layer
+            // slices K/V to the mask's key axis, so a full mask keeps all
+            // (dense `KVCache`) keys. See issue #408.
+            let sliding = Some(create_sliding_window_prefill_mask(
                 l as i32,
                 swa_offset,
-                Some(self.config.sliding_window as i32),
+                self.config.sliding_window as i32,
             ));
             (full, sliding)
         } else {
@@ -480,10 +489,14 @@ impl Cohere2Model {
             let swa_offset = caches[self.swa_idx].offset;
 
             let full = Some(create_causal_mask(l as i32, ga_offset));
-            let sliding = Some(create_causal_mask_with_window(
+            // Full-width windowed mask for a fresh single-pass prefill that
+            // exceeds the window; clamped mask otherwise. The attention layer
+            // slices K/V to the mask's key axis, so a full mask keeps all
+            // (dense `KVCache`) keys. See issue #408.
+            let sliding = Some(create_sliding_window_prefill_mask(
                 l as i32,
                 swa_offset,
-                Some(self.config.sliding_window as i32),
+                self.config.sliding_window as i32,
             ));
             (full, sliding)
         } else {

--- a/src/models/exaone4.rs
+++ b/src/models/exaone4.rs
@@ -22,7 +22,7 @@
 //! - Output-norm architecture: h = x + norm(attn_out), out = h + norm(mlp_out)
 
 use mlxcel_core::layers::{KVCache, RMSNorm, RotatingKVCache, UnifiedEmbedding, UnifiedLinear};
-use mlxcel_core::utils::{create_causal_mask, create_causal_mask_with_window};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
@@ -655,8 +655,10 @@ impl ExaOne4Model {
         // Create masks (cast to bfloat16 to match model weights dtype for SDPA)
         let mask_local = if self.sliding_window.is_some() {
             let max_cache = self.sliding_window.map(|w| w as i32).unwrap_or(i32::MAX);
-            let effective_offset = local_offset.min((max_cache - seq_len).max(0));
-            let mask = create_causal_mask_with_window(seq_len, effective_offset, Some(max_cache));
+            // Full-width windowed mask for a fresh single-pass prefill that
+            // exceeds the window (RotatingKVCache keeps all prefill keys),
+            // clamped mask otherwise. See issue #408.
+            let mask = create_sliding_window_prefill_mask(seq_len, local_offset, max_cache);
             Some(mlxcel_core::astype(&mask, mlxcel_core::dtype::BFLOAT16))
         } else {
             None

--- a/src/models/exaone_moe.rs
+++ b/src/models/exaone_moe.rs
@@ -684,13 +684,12 @@ impl ExaoneMoeModel {
                 .find(|c| matches!(c, AnyKVCache::Rotating(_)))
                 .map(|c| c.offset())
                 .unwrap_or(0);
-            // Clamp offset so mask shape matches RotatingKVCache output
+            // Full-width windowed mask for a fresh single-pass prefill that
+            // exceeds the window (RotatingKVCache keeps all prefill keys),
+            // clamped mask otherwise. See issue #408.
             let max_cache = self.window_size as i32;
-            let effective_swa_offset = swa_offset.min((max_cache - seq_len).max(0));
-            let swa_mask = Some(utils::create_causal_mask_with_window(
-                seq_len,
-                effective_swa_offset,
-                Some(max_cache),
+            let swa_mask = Some(utils::create_sliding_window_prefill_mask(
+                seq_len, swa_offset, max_cache,
             ));
 
             (global_mask, swa_mask)

--- a/src/models/gemma3n.rs
+++ b/src/models/gemma3n.rs
@@ -30,7 +30,7 @@ use crate::models::gemma3n_helpers::{
 };
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, Linear, RMSNorm, UnifiedEmbedding, UnifiedLinear};
-use mlxcel_core::utils::{create_causal_mask, create_causal_mask_with_window};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
@@ -514,16 +514,21 @@ impl Gemma3nAttention {
                 self.window_size,
             )
         } else {
-            // Single token or explicit mask path. If the caller supplied a
-            // windowed mask and this layer is a sliding-window layer, the
-            // mask is shaped `(q_len, window_size)` post-earlier cap. Plain
-            // `KVCache` returns full-length K/V, so we must slice K/V to
-            // match the capped mask, mirroring `causal_attention` internals.
+            // Single token or explicit mask path. A sliding-window layer's
+            // mask is either the clamped `(q_len, window_size)` mask or the
+            // full `(q_len, k_len)` mask for a fresh single-pass prefill that
+            // exceeds the window (issue #408). Plain `KVCache` returns
+            // full-length K/V, so slice K/V to the mask's key axis (not blindly
+            // to `window_size`): a full mask keeps every key, a clamped mask
+            // drops the oldest. Mirrors `causal_attention`'s internal handling.
             let k_shape = mlxcel_core::array_shape(&keys);
             let k_len = k_shape[2];
-            let (k_used, v_used) = if self.window_size > 0 && k_len > self.window_size {
+            let mask_klen = mask
+                .map(|m| *mlxcel_core::array_shape(m).last().unwrap_or(&k_len))
+                .unwrap_or(k_len);
+            let (k_used, v_used) = if self.window_size > 0 && k_len > mask_klen {
                 let v_shape = mlxcel_core::array_shape(&values);
-                let start = k_len - self.window_size;
+                let start = k_len - mask_klen;
                 (
                     Some(mlxcel_core::slice(
                         &keys,
@@ -1200,10 +1205,14 @@ impl Gemma3nLanguageModel {
             None
         };
         let sliding_mask = if l > 1 {
-            Some(create_causal_mask_with_window(
+            // Full-width windowed mask for a fresh single-pass prefill that
+            // exceeds the window; clamped mask otherwise. The attention layer
+            // slices K/V to the mask's key axis, so a full mask keeps every
+            // (dense `KVCache`) key. See issue #408.
+            Some(create_sliding_window_prefill_mask(
                 l,
                 sliding_offset,
-                Some(self.config.sliding_window as i32),
+                self.config.sliding_window as i32,
             ))
         } else {
             None
@@ -1373,10 +1382,14 @@ impl Gemma3nLanguageModel {
             None
         };
         let sliding_mask = if l > 1 {
-            Some(create_causal_mask_with_window(
+            // Full-width windowed mask for a fresh single-pass prefill that
+            // exceeds the window; clamped mask otherwise. The attention layer
+            // slices K/V to the mask's key axis, so a full mask keeps every
+            // (dense `KVCache`) key. See issue #408.
+            Some(create_sliding_window_prefill_mask(
                 l,
                 sliding_offset,
-                Some(self.config.sliding_window as i32),
+                self.config.sliding_window as i32,
             ))
         } else {
             None

--- a/src/models/gpt_oss.rs
+++ b/src/models/gpt_oss.rs
@@ -26,7 +26,7 @@
 //! Reference: mlx-lm gpt_oss.py
 
 use mlxcel_core::layers::{KVCache, RMSNorm, RotatingKVCache, UnifiedEmbedding, UnifiedLinear};
-use mlxcel_core::utils::{create_causal_mask, create_causal_mask_with_window};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
@@ -908,9 +908,11 @@ impl GptOssModel {
 
             let sliding_offset = caches[swa_idx].as_interface().offset();
             let max_cache = self.sliding_window as i32;
-            let effective_offset = sliding_offset.min((max_cache - seq_len).max(0));
+            // Full-width windowed mask for a fresh single-pass prefill that
+            // exceeds the window (RotatingKVCache keeps all prefill keys),
+            // clamped mask otherwise. See issue #408.
             let sliding_mask =
-                create_causal_mask_with_window(seq_len, effective_offset, Some(max_cache));
+                create_sliding_window_prefill_mask(seq_len, sliding_offset, max_cache);
 
             for (i, layer) in self.layers.iter().enumerate() {
                 let mask = if self.layer_types[i] == "full_attention" {
@@ -1240,9 +1242,10 @@ impl GptOssStageModel {
         let sliding_mask = if seq_len > 1 {
             self.first_layer_offset(caches, "sliding_attention")
                 .map(|offset| {
+                    // See issue #408: full-width windowed mask for a fresh
+                    // >window prefill, clamped otherwise.
                     let max_cache = self.sliding_window as i32;
-                    let effective_offset = offset.min((max_cache - seq_len).max(0));
-                    create_causal_mask_with_window(seq_len, effective_offset, Some(max_cache))
+                    create_sliding_window_prefill_mask(seq_len, offset, max_cache)
                 })
         } else {
             None

--- a/src/models/mellum.rs
+++ b/src/models/mellum.rs
@@ -35,7 +35,7 @@
 
 use crate::models::switch_layers::{SwitchGLU, fused_moe_enabled, moe_weighted_sum};
 use mlxcel_core::layers::{KVCache, RMSNorm, RotatingKVCache, UnifiedEmbedding, UnifiedLinear};
-use mlxcel_core::utils::{create_causal_mask, create_causal_mask_with_window};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
@@ -753,10 +753,12 @@ impl MellumModel {
         let mask_full = Some(create_causal_mask(seq_len, full_offset));
 
         let mask_sliding = sliding_idx.map(|idx| {
+            // Full-width windowed mask for a fresh single-pass prefill that
+            // exceeds the window (the RotatingKVCache keeps all prefill keys),
+            // clamped mask otherwise. See issue #408.
             let sliding_offset = caches[idx].as_interface().offset();
             let max_cache = self.sliding_window as i32;
-            let effective_offset = sliding_offset.min((max_cache - seq_len).max(0));
-            create_causal_mask_with_window(seq_len, effective_offset, Some(max_cache))
+            create_sliding_window_prefill_mask(seq_len, sliding_offset, max_cache)
         });
 
         self.forward(

--- a/src/models/ministral3.rs
+++ b/src/models/ministral3.rs
@@ -20,7 +20,7 @@
 //! - RotatingKVCache for sliding_attention layers
 
 use mlxcel_core::layers::{KVCache, RMSNorm, RotatingKVCache, UnifiedEmbedding, UnifiedLinear};
-use mlxcel_core::utils::{create_causal_mask, create_causal_mask_with_window};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
@@ -462,10 +462,11 @@ impl Ministral3Model {
         // Create masks
         let fa_mask = Some(create_causal_mask(seq_len, fa_offset));
         let swa_mask = swa_idx.map(|_| {
-            // Clamp offset so mask shape matches RotatingKVCache output
+            // Full-width windowed mask for a fresh single-pass prefill that
+            // exceeds the window (RotatingKVCache keeps all prefill keys),
+            // clamped mask otherwise. See issue #408.
             let max_cache = self.sliding_window.map(|w| w as i32).unwrap_or(i32::MAX);
-            let effective_offset = swa_offset.min((max_cache - seq_len).max(0));
-            create_causal_mask_with_window(seq_len, effective_offset, Some(max_cache))
+            create_sliding_window_prefill_mask(seq_len, swa_offset, max_cache)
         });
 
         // Compute Llama 4 attention scale using h.shape[1] (after embedding)

--- a/src/models/olmo3.rs
+++ b/src/models/olmo3.rs
@@ -24,7 +24,7 @@
 
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
-use mlxcel_core::utils::{create_causal_mask, create_causal_mask_with_window};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
@@ -205,15 +205,21 @@ impl OLMo3Attention {
 
         // Scaled dot-product attention
         let attn_out = if l > 1 && mask.is_some() {
-            // Prefill with mask. If this is a sliding layer the windowed
-            // mask is capped to `(l, window_size)` post-earlier. Plain
-            // `KVCache` returns full-length K/V, so slice K/V to the last
-            // `window_size` slots to match the mask.
+            // Prefill: use mask. A sliding-window layer's mask is either the
+            // clamped `(l, window_size)` mask or the full `(l, k_len)` mask for
+            // a fresh single-pass prefill that exceeds the window (issue #408).
+            // Plain `KVCache` returns full-length K/V, so slice K/V to the
+            // mask's key axis (not blindly to `window_size`): a full mask keeps
+            // every key, a clamped mask drops the oldest. Mirrors
+            // `causal_attention`'s internal handling.
             let k_shape = mlxcel_core::array_shape(&cache_k);
             let k_len = k_shape[2];
-            let (k_used, v_used) = if self.window_size > 0 && k_len > self.window_size {
+            let mask_klen = mask
+                .map(|m| *mlxcel_core::array_shape(m).last().unwrap_or(&k_len))
+                .unwrap_or(k_len);
+            let (k_used, v_used) = if self.window_size > 0 && k_len > mask_klen {
                 let v_shape = mlxcel_core::array_shape(&cache_v);
-                let start = k_len - self.window_size;
+                let start = k_len - mask_klen;
                 (
                     Some(mlxcel_core::slice(
                         &cache_k,
@@ -458,10 +464,14 @@ impl OLMo3Model {
             let swa_offset = caches[self.swa_idx].offset;
 
             let full = Some(create_causal_mask(l as i32, ga_offset));
-            let sliding = Some(create_causal_mask_with_window(
+            // Full-width windowed mask for a fresh single-pass prefill that
+            // exceeds the window; clamped mask otherwise. The attention layer
+            // slices K/V to the mask's key axis, so a full mask keeps every
+            // (dense `KVCache`) key. See issue #408.
+            let sliding = Some(create_sliding_window_prefill_mask(
                 l as i32,
                 swa_offset,
-                Some(self.config.sliding_window as i32),
+                self.config.sliding_window as i32,
             ));
             (full, sliding)
         } else {

--- a/src/models/step3p5.rs
+++ b/src/models/step3p5.rs
@@ -25,7 +25,7 @@
 
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, RotatingKVCache, UnifiedEmbedding, UnifiedLinear};
-use mlxcel_core::utils::{create_causal_mask, create_causal_mask_with_window};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
@@ -964,8 +964,11 @@ impl Step3p5Model {
 
         let swa_mask = if seq_len > 1 {
             self.swa_idx.map(|idx| {
+                // Full-width windowed mask for a fresh single-pass prefill that
+                // exceeds the window (RotatingKVCache keeps all prefill keys),
+                // clamped mask otherwise. See issue #408.
                 let offset = caches[idx].as_interface().offset();
-                create_causal_mask_with_window(seq_len, offset, Some(self.config.sliding_window))
+                create_sliding_window_prefill_mask(seq_len, offset, self.config.sliding_window)
             })
         } else {
             None


### PR DESCRIPTION
## Summary

A single-pass prefill longer than a model's sliding window degenerated to NaN / `<pad>` (or hard-crashed on a mask/key shape mismatch) on every sliding-window model except gemma3/gemma4. When `seq_len > window`, a fresh `RotatingKVCache` (and a dense `KVCache`) keep ALL prefill keys, but the shared `causal_attention` wrapper and the per-model prefill mask builders capped the windowed mask to `[seq_len, window]` and sliced K/V to the trailing `window` keys. That strands the earliest query rows (logical position `< seq_len - window`) with an all-`-inf` mask row that softmaxes to NaN; models that pass full K/V with a capped mask hit a hard `[broadcast_shapes]` crash instead. PR #405 fixed only gemma3/gemma4.

## Chosen approach: general fix + shared helper (no loud-guard fallback needed)

The general `causal_attention` fix landed cleanly and is bit-exact for every currently-correct path, so the loud-guard fallback was not required.

1. General fix in `causal_attention` (`src/lib/mlxcel-core/src/lib.rs`): for a multi-token prefill that exceeds the window (`q_len > 1 && k_len > window`), build the full-width windowed-causal mask over ALL keys via `create_causal_mask_with_window_full` instead of slicing K/V. The single-query decode path (`q_len == 1`) keeps the trailing-window K/V slice byte-for-byte; non-windowed callers (`window_size == 0`) and within-window prefills are untouched. This is the shared safety net and directly fixes baichuan (which reaches this path with `mask.is_none()`), and incidentally also fixes the tensor-parallel gemma4 path (which routes through `causal_attention`).

2. Shared helper `create_sliding_window_prefill_mask(size, sliding_offset, window)` (`src/lib/mlxcel-core/src/utils.rs`): selects the uncapped full mask for a fresh over-window prefill (`size > window && sliding_offset == 0`, the gemma3 prior-art gate) and the clamped mask otherwise. Its else-branch is byte-identical to the per-model `sliding_offset.min((window - size).max(0))` construction it replaces (the capped tril offset `window - size` is offset-independent, and the helper's non-capped triu is a no-op for `size <= window`), so greedy temp-0 output is unchanged for every non-degenerate case.

3. Per-model wiring of the helper into the prefill mask builders (see audit table). gemma3/gemma4 keep their #405 `sliding_prefill_mask` helpers as-is; #410 will consolidate them onto the shared helper.

4. Tensor-parallel gemma3 path (`src/distributed/tensor_parallel/llama_runtime.rs`, `gemma3_masks`): the TP path independently computed its own clamped offset and called `create_causal_mask_with_window`, so a TP gemma3 >window prefill hit the same NaN/crash as the single-process path. Replaced with `create_sliding_window_prefill_mask`, mirroring the single-process fix. TP gemma4 was incidentally fixed by the general `causal_attention` change in item 1.

## Per-model audit (every `RotatingKVCache` / `create_causal_mask_with_window` sliding-window caller)

| Model | Cache | Pre-fix `>window` prefill | Fix applied | How validated |
|-------|-------|----------------|-------------|---------------|
| gpt_oss | RotatingKVCache, full K/V | CRASH (mask `[N,128]` vs scores `[..,N,N]`) | helper at both mask sites (forward + pipeline stage) | real model, window 128 |
| mellum | RotatingKVCache, full K/V | CRASH (capped mask vs full K/V) | helper at prefill mask builder | unit test + code analysis (no local ckpt) |
| exaone4 | RotatingKVCache, full K/V (bf16 cast) | CRASH | helper (astype preserved) | unit test + analysis (local ckpt not sliding) |
| exaone_moe | RotatingKVCache, full K/V | CRASH | helper | unit test + analysis (no local ckpt) |
| ministral3 | RotatingKVCache, full K/V | CRASH | helper | unit test + analysis (local ckpt not sliding) |
| step3p5 | RotatingKVCache, full K/V | CRASH | helper | unit test + analysis (no local ckpt) |
| cohere2 | dense KVCache + model-level K/V slice | NaN (capped mask + trailing slice strands early rows) | helper + slice to mask key-axis (not blindly `window`) | unit test + analysis (window 4096, not quick to exceed) |
| gemma3n | dense KVCache + model-level K/V slice | NaN | helper at both mask sites + slice to mask key-axis | unit test + analysis |
| olmo3 | dense KVCache + model-level K/V slice | NaN (capped mask + trailing slice strands early rows) | helper + slice to mask key-axis (not blindly `window`) | unit test + analysis |
| baichuan | dense KVCache, prefill via `causal_attention(mask=None)` | NaN / shape issue | covered by the general `causal_attention` fix (no model edit) | unit test + analysis |
| tensor-parallel gemma3 | RotatingKVCache via `gemma3_masks` in `llama_runtime.rs` | NaN / CRASH (same clamped construction as single-process) | `create_sliding_window_prefill_mask` in `gemma3_masks` | logit-match test (`tensor_parallel_gemma3_matches_full_model_logits`) |
| tensor-parallel gemma4 | routes through `causal_attention` | NaN / CRASH | incidentally fixed by the general `causal_attention` fix (item 1 above) | covered by the general `causal_attention` fix |
| recurrent_gemma | KVCache, full causal mask, `window_size = 0` | unaffected (never caps; window not mask-enforced) | none | code analysis |
| diffusion_gemma | dense KVCache, `dense_windowed_causal_mask` (uncapped) | unaffected (already full windowed mask) | none | code analysis |
| gemma3 / gemma4 | RotatingKVCache, `sliding_prefill_mask` | already fixed by #405 | untouched | real model (gemma-4-12b) + existing tests |

ministral-3b-4bit and exaone4-1.2b-4bit ship with `sliding_window: null` (no windowed layers), so those local checkpoints do not exercise the windowed path; their fix rests on the unit test, the byte-identical helper proof, and the gpt-oss real-model result for the identical code shape.

## Real-model validation (M1 Ultra, `--temp 0`)

Bug existed on `main` (HEAD 346018a72), gpt-oss-20b-mxfp4, 298-token prompt (window 128):

```
exit=134
libc++abi: terminating due to uncaught exception of type std::invalid_argument:
[broadcast_shapes] Shapes (298,128) and (1,64,298,298) cannot be broadcast.
```

Same prompt on this branch:

```
...<|channel|>final<|message|>The bakery sits on the second hill, and the clock tower rings thirteen times at noon.
[Generated 90 tokens in 1.57s = 57.36 tok/s]
```

gemma-4-12b-it-4bit, ~1600-token prompt (window 1024), this branch (#405 not regressed):

```
The bakery is located on the second hill. At noon, the clock tower rings thirteen times as a joke that began two centuries ago.
```

Regression (byte-identical `main` vs this branch, generated text diffed):

- gpt-oss-20b short prompt (`<128`, prefill + decode): BYTE-IDENTICAL
- gemma-4-12b short prompt ("The capital of France is **Paris**."): BYTE-IDENTICAL
- qwen3-0.6b non-windowed ("Mercury / Venus / Earth"): BYTE-IDENTICAL

This confirms decode (`q_len == 1`), non-windowed (`window_size == 0`), and within-window prefill paths are unchanged; only the previously-degenerate `>window` prefill changed (crash/NaN -> coherent).

## Tests (fast, no model loads)

- `utils::tests::sliding_window_prefill_mask_selects_full_when_fresh_over_window` / `_clamps_when_rolled_over` / `_within_window_matches_capped_builder` (the selector's three regimes).
- `layers::tests::causal_attention_multi_token_over_window_uses_full_windowed_mask` (the `q_len > 1, k_len > window` case: finite, matches the full windowed-mask reference; the prior clamp+slice path produced NaN). Updated from the old test that asserted the now-removed sliced behavior.
- Existing decode/window tests, all `utils::tests` (30) and `layers::tests` (28), and gemma3/gemma4 `sliding_prefill_mask` tests still pass.
- `tensor_parallel_gemma3_matches_full_model_logits` validates the TP gemma3 mask path.

## Test plan

- [x] `cargo clippy --features metal,accelerate -p mlxcel-core -p mlxcel --lib --tests -- -D warnings` (clean)
- [x] `cargo test --release -p mlxcel-core sliding_window_prefill_mask` and `causal_attention` (all pass)
- [x] `cargo test --release -p mlxcel-core "utils::tests"` / `"layers::tests"` (30 / 28 pass)
- [x] `cargo test --release -p mlxcel sliding_prefill_mask` (gemma3/gemma4, 4 pass)
- [x] `cargo test --release -p mlxcel tensor_parallel_gemma3` (logit-match test passes)
- [x] real-model gpt-oss-20b `>window` (crash on main -> coherent here), gemma-4-12b `>window` coherent, byte-identical short/decode regression

## Known follow-ups

- #413 (pre-existing, out of scope here): dense-cache `offset > 0` rolled-over over-window path; in that case the cache already trims to `window` keys so the clamped mask is the correct shape, but this has not been confirmed safe under every model's K/V trimming logic.
- #410 consolidation: migrate gemma3/gemma4 `sliding_prefill_mask` onto the shared `create_sliding_window_prefill_mask`.
- recurrent_gemma applies its local-attention window via a full causal mask with `window_size = 0` (window not enforced by the mask); orthogonal to this issue, worth a separate look.

Closes #408