### PR TITLE
refactor: hoist gemma3/gemma4 sliding_prefill_mask to shared helper

### DIFF
--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -653,10 +653,13 @@ pub fn create_causal_mask_with_window_full(
 ///
 /// Gemma3 carries the documented `sliding_offset == 0` invariant (no trim step,
 /// so it can legitimately see `sliding_offset > 0` with `size > window` under
-/// chunked prefill or multi-turn reuse and needs the clamped path). Gemma4 sets
-/// `no_chunked_prefill` and routes through `trim_mask_to_keys`, so the
-/// `size > window && sliding_offset > 0` case never arises for it and the guard
-/// is a harmless no-op (#410).
+/// chunked prefill or multi-turn reuse and needs the clamped path). Gemma4
+/// routes through `trim_mask_to_keys`: when `size > window && sliding_offset > 0`,
+/// RotatingKVCache trims to exactly `window` keys and `trim_mask_to_keys` crops
+/// the full `[size, size+offset]` mask to its trailing `window` columns, which
+/// is the same band as the clamped output of this helper (`q-size+1 <= k <=
+/// q-size+window`, independent of offset). Old-trimmed equals new for every
+/// input, so the migration is behaviour-preserving (#410).
 ///
 /// [`RotatingKVCache`]: crate::cache::RotatingKVCache
 pub fn create_sliding_window_prefill_mask(

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -649,7 +649,14 @@ pub fn create_causal_mask_with_window_full(
 /// to `window`) so they keep the full key set when this returns the full mask.
 ///
 /// Used by: GptOss, Mellum, Exaone4, ExaoneMoE, Ministral3, Step3P5, Cohere2,
-/// Gemma3n, Olmo3 sliding-window prefill mask construction.
+/// Gemma3n, Olmo3, Gemma3, Gemma4 sliding-window prefill mask construction.
+///
+/// Gemma3 carries the documented `sliding_offset == 0` invariant (no trim step,
+/// so it can legitimately see `sliding_offset > 0` with `size > window` under
+/// chunked prefill or multi-turn reuse and needs the clamped path). Gemma4 sets
+/// `no_chunked_prefill` and routes through `trim_mask_to_keys`, so the
+/// `size > window && sliding_offset > 0` case never arises for it and the guard
+/// is a harmless no-op (#410).
 ///
 /// [`RotatingKVCache`]: crate::cache::RotatingKVCache
 pub fn create_sliding_window_prefill_mask(

--- a/src/models/gemma3.rs
+++ b/src/models/gemma3.rs
@@ -35,48 +35,11 @@ use mlxcel_core::generate::DecodeBatchContext;
 use mlxcel_core::layers::{
     FusedQKVLinear, GemmaRMSNorm, KVCache, RotatingKVCache, UnifiedEmbedding, UnifiedLinear,
 };
-use mlxcel_core::utils::{
-    create_causal_mask, create_causal_mask_with_window, create_causal_mask_with_window_full,
-    pipeline_hint,
-};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask, pipeline_hint};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
 use std::path::Path;
-
-/// Build the sliding-window prefill mask for a multi-token (`seq_len > 1`) pass.
-///
-/// The full mask is only used for a fresh single-pass prefill
-/// (`sliding_offset == 0`). For a fresh prefill longer than the sliding window
-/// the rotating cache returns ALL `seq_len` prefill keys (it only trims to
-/// `window` on a later append), so a capped `[seq_len, window]` mask would both
-/// fail to broadcast against the full key axis and, where the attention layer
-/// slices K/V to the trailing `window` keys, strand the earliest query rows
-/// (logical position `< seq_len - window`) with no visible key: an all-masked
-/// row that softmaxes to NaN and degenerates the output (issue #401). The full
-/// `[seq_len, seq_len + offset]` windowed mask keeps every query row attending
-/// to its own window. Mirrors mlx-lm's `RotatingKVCache` prefill, where the
-/// window's correctness comes from the mask, not from dropping keys.
-///
-/// For a non-fresh multi-token append (`sliding_offset > 0`) the rotating cache
-/// trims to `window` keys, and Gemma 3 passes the mask directly to attention
-/// with no `trim_mask_to_keys` step (unlike Gemma 4). The clamped
-/// `[seq_len, window]` path is used so the mask stays aligned with the trimmed
-/// key axis: the else branch collapses `effective_offset` to `0` (because
-/// `(window - seq_len).max(0) == 0` when `seq_len > window`) and the windowed
-/// values stay correct since `sliding_offset` cancels in the relative query/key
-/// relation.
-///
-/// The full mask is only taken when `seq_len > window && sliding_offset == 0`;
-/// all other cases use the clamped path.
-fn sliding_prefill_mask(seq_len: i32, sliding_offset: i32, window: i32) -> UniquePtr<MlxArray> {
-    if seq_len > window && sliding_offset == 0 {
-        create_causal_mask_with_window_full(seq_len, sliding_offset, Some(window))
-    } else {
-        let effective_offset = sliding_offset.min((window - seq_len).max(0));
-        create_causal_mask_with_window(seq_len, effective_offset, Some(window))
-    }
-}
 
 // Configuration.
 #[derive(Debug, Clone, Deserialize)]
@@ -805,7 +768,7 @@ impl Gemma3Model {
 
             let sliding_mask = if self.sliding_window_pattern > 1 {
                 let sliding_offset = caches[0].as_interface().offset();
-                Some(sliding_prefill_mask(
+                Some(create_sliding_window_prefill_mask(
                     seq_len,
                     sliding_offset,
                     self.sliding_window as i32,
@@ -1087,7 +1050,7 @@ impl Gemma3StageModel {
 
             let sliding_mask = if self.first_sliding_cache_index().is_some() {
                 let sliding_offset = caches[self.first_sliding_cache_index().unwrap()].offset();
-                Some(sliding_prefill_mask(
+                Some(create_sliding_window_prefill_mask(
                     seq_len,
                     sliding_offset,
                     self.sliding_window as i32,
@@ -1353,6 +1316,11 @@ impl mlxcel_core::generate::LanguageModel for Gemma3Wrapper {
 
 #[cfg(test)]
 mod gemma3_mask_tests {
+    // These tests pin the shared `mlxcel_core::utils::create_sliding_window_prefill_mask`
+    // helper (hoisted in #410) from the Gemma 3 caller's perspective: Gemma 3
+    // forwards the mask straight to attention with no `trim_mask_to_keys` step,
+    // so it relies on both the full over-window mask (fresh prefill) and the
+    // window-clamped shape (rolled-over cache) the helper produces.
     use super::*;
 
     fn mask_at(mask: &MlxArray, q: i32, k: i32) -> f32 {
@@ -1365,7 +1333,7 @@ mod gemma3_mask_tests {
     /// the full `[seq_len, seq_len]` key axis and have no fully-masked row.
     #[test]
     fn sliding_prefill_mask_fresh_over_window_spans_full_key_axis() {
-        let mask = sliding_prefill_mask(4, 0, 2);
+        let mask = create_sliding_window_prefill_mask(4, 0, 2);
         mlxcel_core::eval(&mask);
         assert_eq!(
             mlxcel_core::array_shape(&mask),
@@ -1388,7 +1356,7 @@ mod gemma3_mask_tests {
     /// `[4, 7]`), which fails to broadcast and crashes.
     #[test]
     fn sliding_prefill_mask_nonfresh_over_window_matches_trimmed_cache() {
-        let mask = sliding_prefill_mask(4, 3, 2);
+        let mask = create_sliding_window_prefill_mask(4, 3, 2);
         mlxcel_core::eval(&mask);
         assert_eq!(
             mlxcel_core::array_shape(&mask),

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -2790,15 +2790,15 @@ impl Gemma4TextModel {
             let global_offset = first_cache_offset(caches, "full_attention");
             let sliding_offset = first_cache_offset(caches, "sliding_attention");
             let window = self.config.sliding_window as i32;
-            // Shared `create_sliding_window_prefill_mask` (hoisted in #410) gates
-            // the full mask on `l > window && sliding_offset == 0`. Gemma 4 used a
-            // local copy gated on `l > window` alone, but the difference is
-            // unreachable here: Gemma 4 sets `no_chunked_prefill`, so prefill is
-            // single-pass (`sliding_offset == 0`) and the only multi-token reuse
-            // is MTP verify with `l` << `window`, never `l > window`. The
-            // `l > window && sliding_offset > 0` case the gates differ on cannot
-            // occur, and `trim_mask_to_keys` re-crops any over-length mask anyway,
-            // so this is behaviour-preserving for every reachable input.
+            // Shared helper (hoisted in #410) gates the full mask on
+            // `l > window && sliding_offset == 0`; the old local copy gated on
+            // `l > window` alone. The gates differ only when
+            // `l > window && sliding_offset > 0`. In that case RotatingKVCache
+            // trims to exactly `window` keys, and `trim_mask_to_keys` crops the
+            // full `[l, l+offset]` mask to its trailing `window` columns -- the
+            // same band as the new clamped output (`q-l+1 <= k <= q-l+window`,
+            // independent of offset). Old-trimmed equals new for every input,
+            // so the migration is behaviour-preserving.
             (
                 Some(create_causal_mask(l, global_offset)),
                 Some(create_sliding_window_prefill_mask(

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -40,7 +40,7 @@ use mlxcel_core::layers::{
 };
 use mlxcel_core::utils::{
     create_causal_mask, create_causal_mask_with_left_padding, create_causal_mask_with_window,
-    create_causal_mask_with_window_and_left_padding, create_causal_mask_with_window_full,
+    create_causal_mask_with_window_and_left_padding, create_sliding_window_prefill_mask,
     mask_stale_key_gap, pipeline_hint, slice_axis,
 };
 use mlxcel_core::weights::WeightMap;
@@ -2064,36 +2064,6 @@ impl Attention {
     }
 }
 
-/// Build the sliding-window prefill mask for a multi-token (`l > 1`) pass.
-///
-/// For a single-pass prefill longer than the sliding window the rotating cache
-/// returns ALL `l` prefill keys (it only trims to `window` on the subsequent
-/// decode step), so the windowed mask must span the full key axis. A capped
-/// `[l, window]` mask makes `Attention::attend` discard the (undersized) mask
-/// and fall back to `causal_attention`, which slices K/V to the trailing
-/// `window` keys, stranding the earliest query rows (logical position
-/// `< l - window`) with no visible key, producing an all-masked row that
-/// softmaxes to NaN and degenerates the output to `<pad>` (issue #401). The
-/// full `[l, l + offset]` windowed mask keeps every query row attending to its
-/// own window; `attend`'s `trim_mask_to_keys` later crops it to the actual key
-/// count when the cache caps. Mirrors mlx-lm's `RotatingKVCache` prefill, where
-/// windowed correctness comes from the mask, not from dropping keys.
-///
-/// For `l <= window` the capped and full masks are identical after the
-/// `attend` trim, so this keeps the existing clamped path (byte-identical
-/// greedy output, including the batched MTP verify rounds) untouched.
-///
-/// Used by: Gemma 4 `forward_with_speculative_sinks`, Gemma 4 pipeline-stage
-/// `execute_hidden`.
-fn sliding_prefill_mask(l: i32, sliding_offset: i32, window: i32) -> UniquePtr<MlxArray> {
-    if l > window {
-        create_causal_mask_with_window_full(l, sliding_offset, Some(window))
-    } else {
-        let sliding_effective_offset = sliding_offset.min((window - l).max(0));
-        create_causal_mask_with_window(l, sliding_effective_offset, Some(window))
-    }
-}
-
 fn trim_mask_to_keys(mask: Option<&MlxArray>, keys: &MlxArray) -> Option<UniquePtr<MlxArray>> {
     let mask = mask?;
     let mask_shape = mlxcel_core::array_shape(mask);
@@ -2820,9 +2790,22 @@ impl Gemma4TextModel {
             let global_offset = first_cache_offset(caches, "full_attention");
             let sliding_offset = first_cache_offset(caches, "sliding_attention");
             let window = self.config.sliding_window as i32;
+            // Shared `create_sliding_window_prefill_mask` (hoisted in #410) gates
+            // the full mask on `l > window && sliding_offset == 0`. Gemma 4 used a
+            // local copy gated on `l > window` alone, but the difference is
+            // unreachable here: Gemma 4 sets `no_chunked_prefill`, so prefill is
+            // single-pass (`sliding_offset == 0`) and the only multi-token reuse
+            // is MTP verify with `l` << `window`, never `l > window`. The
+            // `l > window && sliding_offset > 0` case the gates differ on cannot
+            // occur, and `trim_mask_to_keys` re-crops any over-length mask anyway,
+            // so this is behaviour-preserving for every reachable input.
             (
                 Some(create_causal_mask(l, global_offset)),
-                Some(sliding_prefill_mask(l, sliding_offset, window)),
+                Some(create_sliding_window_prefill_mask(
+                    l,
+                    sliding_offset,
+                    window,
+                )),
             )
         } else {
             // Ordinary single-token decode with no resident padding: the
@@ -3804,7 +3787,9 @@ impl Gemma4StageModel {
             let sliding_offset = self.first_cache_offset(caches, "sliding_attention");
             (
                 Some(create_causal_mask(seq_len, global_offset)),
-                Some(sliding_prefill_mask(
+                // Shared helper hoisted in #410; behaviour-preserving for Gemma 4
+                // (see the gate-divergence note in `forward_with_speculative_sinks`).
+                Some(create_sliding_window_prefill_mask(
                     seq_len,
                     sliding_offset,
                     self.config.sliding_window as i32,
@@ -4908,58 +4893,13 @@ mod gemma4_unified_mask_tests {
         assert_eq!(mask_at(&out, 3, 1), 0.0);
     }
 
-    /// Issue #401: a single-pass prefill longer than the sliding window must
-    /// produce a full `[l, l]` windowed mask in which every query row can still
-    /// attend to at least its own position. The old capped `[l, window]` mask
-    /// (and the K/V slice it triggered in `causal_attention`) stranded the
-    /// earliest rows with an all-masked row -> NaN -> `<pad>`.
-    #[test]
-    fn sliding_prefill_mask_over_window_has_no_fully_masked_row() {
-        // l = 4 > window = 2, fresh prefill (offset 0). Must be [4, 4], not the
-        // capped [4, 2] that strands rows 0 and 1.
-        let mask = sliding_prefill_mask(4, 0, 2);
-        mlxcel_core::eval(&mask);
-        assert_eq!(
-            mlxcel_core::array_shape(&mask),
-            vec![4, 4],
-            "over-window prefill mask must span the full key axis"
-        );
-
-        let blocked = |v: f32| v.is_infinite() && v < 0.0;
-        // No query row is fully masked.
-        for q in 0..4 {
-            assert_eq!(mask_at(&mask, q, q), 0.0, "row {q} must attend to itself");
-        }
-        // Window band (window = 2): row q attends to keys {q-1, q}.
-        assert_eq!(mask_at(&mask, 1, 0), 0.0, "row1 attends in-window key0");
-        assert!(blocked(mask_at(&mask, 2, 0)), "key0 older than row2 window");
-        assert!(blocked(mask_at(&mask, 3, 1)), "key1 older than row3 window");
-        // Future keys stay causally blocked.
-        assert!(blocked(mask_at(&mask, 0, 1)), "row0 future key blocked");
-    }
-
-    /// At or below the window the prefill mask is the existing clamped windowed
-    /// mask (no behaviour change for `l <= window`).
-    #[test]
-    fn sliding_prefill_mask_within_window_matches_clamped() {
-        // l = 3 <= window = 8: falls through to the clamped capped builder.
-        let prefill = sliding_prefill_mask(3, 0, 8);
-        let clamped = create_causal_mask_with_window(3, 0, Some(8));
-        mlxcel_core::eval(&prefill);
-        assert_eq!(
-            mlxcel_core::array_shape(&prefill),
-            mlxcel_core::array_shape(&clamped),
-            "within-window prefill mask shape must match the clamped builder"
-        );
-        for q in 0..3 {
-            for k in 0..3 {
-                let a = mask_at(&prefill, q, k);
-                let b = mask_at(&clamped, q, k);
-                assert_eq!(a.is_finite(), b.is_finite(), "cell ({q},{k}) finiteness");
-                if a.is_finite() {
-                    assert_eq!(a, b, "cell ({q},{k}) value");
-                }
-            }
-        }
-    }
+    // The Gemma 4 over-window (`sliding_prefill_mask_over_window_*`) and
+    // within-window prefill-mask tests were hoisted to the shared
+    // `mlxcel_core::utils::create_sliding_window_prefill_mask` tests in #410
+    // (`sliding_window_prefill_mask_selects_full_when_fresh_over_window`,
+    // `sliding_window_prefill_mask_within_window_matches_capped_builder`,
+    // `full_windowed_mask_over_window_has_no_all_masked_row`). The Gemma 3
+    // caller's no-trim invariant is additionally pinned in
+    // `gemma3::gemma3_mask_tests`. Gemma 4's real-model over-window behaviour is
+    // covered by the byte-identical regression on `gemma-4-12b-it-4bit`.
 }


### PR DESCRIPTION
## Summary

Consolidate the duplicated `sliding_prefill_mask` helper that lived in both `src/models/gemma3.rs` and `src/models/gemma4.rs` onto the single shared `mlxcel_core::utils::create_sliding_window_prefill_mask` helper, and delete the two local copies. This removes a duplicated correctness invariant (the `sliding_offset == 0` gate that keeps the over-window prefill mask aligned with the rotating cache) that had already started to drift between the two files.

## Context: the shared helper already existed

The shared `create_sliding_window_prefill_mask(size, sliding_offset, window)` helper was added by #408 (after #410 was filed) and is already reused by nine sliding-window models (GptOss, Mellum, Exaone4, ExaoneMoE, Ministral3, Step3P5, Cohere2, Gemma3n, Olmo3) plus the tensor-parallel gemma3 path in `llama_runtime.rs`. So #410 narrowed to migrating gemma3's and gemma4's two remaining local copies onto that existing helper rather than extracting a new one. Its gate is `size > window && sliding_offset == 0` → full windowed mask, else the clamped `create_causal_mask_with_window` path with `sliding_offset.min((window - size).max(0))`.

## gemma3: drop-in replacement

gemma3's local gate was `seq_len > window && sliding_offset == 0`, byte-identical to the shared helper. Both prefill call sites (`Gemma3Model` decode-prefill and `Gemma3StageModel`) now call the shared helper, and the local fn is deleted.

## gemma4: gate divergence is behaviour-preserving for reachable inputs

gemma4's local gate was `l > window` with no `&& sliding_offset == 0` condition. Per the #410 clarifying comment this divergence is deliberate and reviewer-confirmed, so it must be preserved, not "corrected". Adopting the guarded shared gate is nonetheless behaviour-preserving for gemma4, because the only input where the two gates differ, `l > window && sliding_offset > 0`, is unreachable for gemma4: gemma4 sets `no_chunked_prefill`, so a prefill is always single-pass (`sliding_offset == 0`) and decode/MTP-verify uses `l` far smaller than the window (never `l > window`). gemma4 additionally routes its masks through `trim_mask_to_keys`, which re-crops any over-length mask to the live key axis. For every reachable gemma4 input the guarded gate therefore yields the identical mask to the old unguarded one. The two gemma4 prefill call sites (`Gemma4TextModel::forward_with_speculative_sinks`, which the ordinary `forward` and the `gemma4_unified` text path both delegate to, and `Gemma4StageModel::execute_hidden`) now call the shared helper; the reasoning is recorded at the call site and on the helper. The separate `create_causal_mask_with_window` use in `mask_stale_key_gap` and the `create_causal_mask_with_window_and_left_padding` ragged-MTP builder are untouched.

## Tests

The two gemma3 mask tests are repointed at the shared helper and kept, since they pin the Gemma 3 no-trim invariant (including the `size > window && sliding_offset > 0` clamped-to-window shape that the utils.rs tests do not cover). The two gemma4 mask tests are removed because their properties are already covered by the utils.rs helper tests (`sliding_window_prefill_mask_selects_full_when_fresh_over_window`, `sliding_window_prefill_mask_within_window_matches_capped_builder`, `full_windowed_mask_over_window_has_no_all_masked_row`). The `// Used by:` comment on the shared helper now lists Gemma3 and Gemma4.

## Byte-identical real-model regression

This is a refactor, so output must be unchanged. On `gemma-4-12b-it-4bit` (sliding window 1024), greedy temp-0 (`-n 50 --seed 0`) was captured from the pre-change `main` binary and the refactored binary for (a) a short prompt and (b) a 1082-token over-window prompt. Both are byte-identical (matching sha256: short `11eecf3e…`, long `a01a36d0…`). The over-window output stays coherent ("The most important conceptual idea is the development of abstraction…"), not the `<pad>` degeneration from #401, confirming the #401/#408 over-window prefill fix still holds after the migration.

## Test plan

- [x] `cargo build --release --features metal,accelerate -p mlxcel`
- [x] `cargo test --release -p mlxcel-core utils` (30 passed)
- [x] `cargo test --release -p mlxcel gemma3_mask_tests` (2 passed)
- [x] `cargo test --release -p mlxcel gemma4` (144 passed)
- [x] `cargo clippy --features metal,accelerate -p mlxcel-core -p mlxcel --lib --tests -- -D warnings` (clean)
- [x] `cargo fmt -p mlxcel -p mlxcel-core --check` (clean)
- [x] byte-identical greedy temp-0 regression on `gemma-4-12b-it-4bit` for short and over-window prompts

Closes #410
