### PR TITLE
fix(models): dense-cache sliding-window prefill uses full mask over all retained keys (#413)

### DIFF
--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -566,7 +566,7 @@ pub fn create_causal_mask_with_window(
 
 /// Create a sliding-window causal mask sized to the *full* key axis, without
 /// the `min(size + offset, window)` cap applied by [`create_causal_mask_with_window`].
-/// Used by: Gemma 3, Gemma 4 single-pass prefill longer than the sliding window
+/// Used by: Gemma 3, Gemma 4 single-pass prefill longer than the sliding window, Cohere2/Gemma3n/Olmo3 dense over-window prefill (#413)
 ///
 /// # Arguments
 /// * `size` - Size of the query sequence
@@ -648,8 +648,8 @@ pub fn create_causal_mask_with_window_full(
 /// to the trailing window must slice to the mask's key dimension (not blindly
 /// to `window`) so they keep the full key set when this returns the full mask.
 ///
-/// Used by: GptOss, Mellum, Exaone4, ExaoneMoE, Ministral3, Step3P5, Cohere2,
-/// Gemma3n, Olmo3, Gemma3, Gemma4 sliding-window prefill mask construction.
+/// Used by: GptOss, Mellum, Exaone4, ExaoneMoE, Ministral3, Step3P5, Gemma3,
+/// Gemma4 sliding-window prefill mask construction.
 ///
 /// Gemma3 carries the documented `sliding_offset == 0` invariant (no trim step,
 /// so it can legitimately see `sliding_offset > 0` with `size > window` under
@@ -669,6 +669,36 @@ pub fn create_sliding_window_prefill_mask(
 ) -> UniquePtr<MlxArray> {
     if size > window && sliding_offset == 0 {
         create_causal_mask_with_window_full(size, 0, Some(window))
+    } else {
+        let effective_offset = sliding_offset.min((window - size).max(0));
+        create_causal_mask_with_window(size, effective_offset, Some(window))
+    }
+}
+
+/// Dense-`KVCache` variant of [`create_sliding_window_prefill_mask`].
+///
+/// A dense `KVCache` retains EVERY key (it never trims to `window`, unlike a
+/// `RotatingKVCache`). So an over-window prefill (`size > window`) must use the
+/// full windowed-causal mask over ALL `size + sliding_offset` retained keys at
+/// ANY offset, not only a fresh `sliding_offset == 0` prefill. The dense
+/// consumer slices K/V to the mask's key axis, so the full `[size, size +
+/// sliding_offset]` mask keeps every key and no early query row is stranded
+/// with an all-`-inf` row. For `size <= window` this is byte-identical to
+/// [`create_sliding_window_prefill_mask`] (same clamped builder + offset
+/// clamp), so greedy output for within-window prefills is unchanged.
+///
+/// The rotating-cache helper keeps the narrower `sliding_offset == 0` gate
+/// because once a `RotatingKVCache` has rolled over it returns at most `window`
+/// keys and the clamped mask is the matching shape. See issue #413.
+///
+/// Used by: Cohere2, Gemma3n, Olmo3 sliding-window prefill mask construction.
+pub fn create_sliding_window_prefill_mask_dense(
+    size: i32,
+    sliding_offset: i32,
+    window: i32,
+) -> UniquePtr<MlxArray> {
+    if size > window {
+        create_causal_mask_with_window_full(size, sliding_offset, Some(window))
     } else {
         let effective_offset = sliding_offset.min((window - size).max(0));
         create_causal_mask_with_window(size, effective_offset, Some(window))
@@ -1398,6 +1428,107 @@ mod tests {
                 assert_eq!(a.is_finite(), b.is_finite(), "cell ({q},{k}) finiteness");
                 if a.is_finite() {
                     assert_eq!(a, b, "cell ({q},{k}) value");
+                }
+            }
+        }
+    }
+
+    // --- Dense-cache sliding-window prefill mask selector (issue #413) -----
+
+    /// The in-scope fix: a dense `KVCache` over-window prefill at a non-zero
+    /// offset (`size > window && sliding_offset > 0`) must select the full
+    /// `[size, size + offset]` mask so every retained key stays visible and no
+    /// early query row is stranded all-`-inf` (the NaN/`<pad>` failure of the
+    /// old clamped path). Equals `create_causal_mask_with_window_full` exactly.
+    #[test]
+    fn sliding_window_prefill_mask_dense_full_when_rolled_over_window() {
+        let size = 4;
+        let offset = 3;
+        let window = 2;
+        let prefill = create_sliding_window_prefill_mask_dense(size, offset, window);
+        assert_eq!(
+            ffi::array_shape(&prefill),
+            vec![size, size + offset],
+            "dense over-window prefill must use the full [size, size + offset] mask"
+        );
+        let full = create_causal_mask_with_window_full(size, offset, Some(window));
+        let at =
+            |m: &MlxArray, q: i32, k: i32| ffi::item_f32(&ffi::slice(m, &[q, k], &[q + 1, k + 1]));
+        for q in 0..size {
+            for k in 0..(size + offset) {
+                let a = at(&prefill, q, k);
+                let b = at(&full, q, k);
+                assert_eq!(a.is_finite(), b.is_finite(), "cell ({q},{k}) finiteness");
+                if a.is_finite() {
+                    assert_eq!(a, b, "cell ({q},{k}) value");
+                }
+            }
+            // No query row is fully masked: each attends to its own logical
+            // key at column `q + offset`. This is the row the old clamped path
+            // left all-`-inf` for logical position `< size - window`.
+            assert_eq!(
+                at(&prefill, q, q + offset),
+                0.0,
+                "row {q} must attend to its own key at column {}",
+                q + offset
+            );
+        }
+    }
+
+    /// A fresh dense over-window prefill (`sliding_offset == 0`) is identical
+    /// to the rotating helper: both build the full `[size, size]` mask.
+    #[test]
+    fn sliding_window_prefill_mask_dense_matches_fresh_over_window() {
+        let dense = create_sliding_window_prefill_mask_dense(4, 0, 2);
+        let rotating = create_sliding_window_prefill_mask(4, 0, 2);
+        assert_eq!(
+            ffi::array_shape(&dense),
+            ffi::array_shape(&rotating),
+            "fresh over-window dense and rotating helpers must match shape"
+        );
+        let at =
+            |m: &MlxArray, q: i32, k: i32| ffi::item_f32(&ffi::slice(m, &[q, k], &[q + 1, k + 1]));
+        for q in 0..4 {
+            for k in 0..4 {
+                let a = at(&dense, q, k);
+                let b = at(&rotating, q, k);
+                assert_eq!(a.is_finite(), b.is_finite(), "cell ({q},{k}) finiteness");
+                if a.is_finite() {
+                    assert_eq!(a, b, "cell ({q},{k}) value");
+                }
+            }
+        }
+    }
+
+    /// For within-window prefills (`size <= window`) the dense helper is
+    /// byte-identical to the rotating helper, including the within-window
+    /// rolled-over (`size + sliding_offset > window`) clamped path. Greedy
+    /// output for within-window prefills is therefore unchanged.
+    #[test]
+    fn sliding_window_prefill_mask_dense_within_window_byte_identical() {
+        let at =
+            |m: &MlxArray, q: i32, k: i32| ffi::item_f32(&ffi::slice(m, &[q, k], &[q + 1, k + 1]));
+        for &(size, offset, window) in &[(3, 0, 8), (2, 9, 4)] {
+            let dense = create_sliding_window_prefill_mask_dense(size, offset, window);
+            let rotating = create_sliding_window_prefill_mask(size, offset, window);
+            assert_eq!(
+                ffi::array_shape(&dense),
+                ffi::array_shape(&rotating),
+                "({size},{offset},{window}) dense and rotating shapes must match"
+            );
+            let cols = ffi::array_shape(&dense)[1];
+            for q in 0..size {
+                for k in 0..cols {
+                    let a = at(&dense, q, k);
+                    let b = at(&rotating, q, k);
+                    assert_eq!(
+                        a.is_finite(),
+                        b.is_finite(),
+                        "({size},{offset},{window}) cell ({q},{k}) finiteness"
+                    );
+                    if a.is_finite() {
+                        assert_eq!(a, b, "({size},{offset},{window}) cell ({q},{k}) value");
+                    }
                 }
             }
         }

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -566,7 +566,7 @@ pub fn create_causal_mask_with_window(
 
 /// Create a sliding-window causal mask sized to the *full* key axis, without
 /// the `min(size + offset, window)` cap applied by [`create_causal_mask_with_window`].
-/// Used by: Gemma 3, Gemma 4 single-pass prefill longer than the sliding window, Cohere2/Gemma3n/Olmo3 dense over-window prefill (#413)
+/// Used by: Gemma 3, Gemma 4 single-pass prefill longer than the sliding window, Cohere2/Gemma3n/Olmo3 dense prefill (#413)
 ///
 /// # Arguments
 /// * `size` - Size of the query sequence
@@ -678,18 +678,33 @@ pub fn create_sliding_window_prefill_mask(
 /// Dense-`KVCache` variant of [`create_sliding_window_prefill_mask`].
 ///
 /// A dense `KVCache` retains EVERY key (it never trims to `window`, unlike a
-/// `RotatingKVCache`). So an over-window prefill (`size > window`) must use the
-/// full windowed-causal mask over ALL `size + sliding_offset` retained keys at
-/// ANY offset, not only a fresh `sliding_offset == 0` prefill. The dense
-/// consumer slices K/V to the mask's key axis, so the full `[size, size +
-/// sliding_offset]` mask keeps every key and no early query row is stranded
-/// with an all-`-inf` row. For `size <= window` this is byte-identical to
-/// [`create_sliding_window_prefill_mask`] (same clamped builder + offset
-/// clamp), so greedy output for within-window prefills is unchanged.
+/// `RotatingKVCache`), and the consumer slices K/V to the mask's key axis. So
+/// the correct prefill mask is ALWAYS the full `[size, size + sliding_offset]`
+/// windowed-causal mask over all retained keys, for every size/offset
+/// combination. There is no clamped branch: the full mask keeps every key and
+/// the window is enforced by the mask, not by physically dropping keys.
 ///
-/// The rotating-cache helper keeps the narrower `sliding_offset == 0` gate
-/// because once a `RotatingKVCache` has rolled over it returns at most `window`
-/// keys and the clamped mask is the matching shape. See issue #413.
+/// For the common within-window prefill (`size + sliding_offset <= window`)
+/// this is byte-identical to [`create_sliding_window_prefill_mask`]: the
+/// clamped builder takes its non-capped path and produces the same
+/// `tril(offset)` intersect `triu(offset - window + 1)` band over `[size,
+/// size + sliding_offset]`, so greedy output there is unchanged. The full mask
+/// fixes the two dense-cache degeneration cases the clamped path caused once
+/// the total exceeded the window:
+///
+/// 1. `size > window` (at any offset): the clamped `[size, window]` mask's
+///    `tril` diagonal `window - size < 0` stranded the earliest query rows
+///    (logical position `< size - window`) with an all-`-inf` row, which
+///    softmaxed to NaN and decoded to `<pad>`.
+/// 2. `size <= window && size + sliding_offset > window`: the clamped path's
+///    trailing-`window` K/V slice dropped the OLDEST in-window keys for the
+///    earliest query rows, silently narrowing their attention window
+///    (coherent-but-wrong output rather than NaN/`<pad>`).
+///
+/// The rotating-cache helper [`create_sliding_window_prefill_mask`] keeps the
+/// clamped path because a `RotatingKVCache` physically returns at most `window`
+/// keys once it has rolled over, so the clamped mask is the matching shape.
+/// See issue #413.
 ///
 /// Used by: Cohere2, Gemma3n, Olmo3 sliding-window prefill mask construction.
 pub fn create_sliding_window_prefill_mask_dense(
@@ -697,12 +712,7 @@ pub fn create_sliding_window_prefill_mask_dense(
     sliding_offset: i32,
     window: i32,
 ) -> UniquePtr<MlxArray> {
-    if size > window {
-        create_causal_mask_with_window_full(size, sliding_offset, Some(window))
-    } else {
-        let effective_offset = sliding_offset.min((window - size).max(0));
-        create_causal_mask_with_window(size, effective_offset, Some(window))
-    }
+    create_causal_mask_with_window_full(size, sliding_offset, Some(window))
 }
 
 /// Create a boolean causal attention mask with optional sliding window.
@@ -1475,6 +1485,67 @@ mod tests {
         }
     }
 
+    /// The adjacent latent fix: a within-window chunk (`size <= window`) whose
+    /// offset pushes the total past the window (`size + sliding_offset >
+    /// window`). The dense helper now returns the full `[size, size + offset]`
+    /// mask instead of the clamped `[size, window]` mask, so the earliest query
+    /// rows keep their OLDEST in-window keys instead of having them sliced away
+    /// (coherent-but-wrong output under the old clamped path, not NaN/`<pad>`).
+    #[test]
+    fn sliding_window_prefill_mask_dense_full_when_within_window_over_total() {
+        let size = 2;
+        let offset = 9;
+        let window = 4;
+        let prefill = create_sliding_window_prefill_mask_dense(size, offset, window);
+        assert_eq!(
+            ffi::array_shape(&prefill),
+            vec![size, size + offset],
+            "within-window over-total prefill must use the full [size, size + offset] mask, not the clamped [size, window]"
+        );
+        let full = create_causal_mask_with_window_full(size, offset, Some(window));
+        let at =
+            |m: &MlxArray, q: i32, k: i32| ffi::item_f32(&ffi::slice(m, &[q, k], &[q + 1, k + 1]));
+        for q in 0..size {
+            for k in 0..(size + offset) {
+                let a = at(&prefill, q, k);
+                let b = at(&full, q, k);
+                assert_eq!(a.is_finite(), b.is_finite(), "cell ({q},{k}) finiteness");
+                if a.is_finite() {
+                    assert_eq!(a, b, "cell ({q},{k}) value");
+                }
+            }
+        }
+        // Row 0 holds logical position offset=9; its full window is keys
+        // [6..=9]. The old clamped path sliced K/V to the trailing `window`=4
+        // keys and dropped key 6 (the oldest in-window key) for this row; the
+        // full mask now attends to it.
+        assert_eq!(
+            at(&prefill, 0, 6),
+            0.0,
+            "row 0 must attend oldest in-window key 6"
+        );
+        assert_eq!(at(&prefill, 0, 9), 0.0, "row 0 causal boundary key 9");
+        assert!(
+            !at(&prefill, 0, 5).is_finite(),
+            "row 0 key 5 is below the window"
+        );
+        assert!(
+            !at(&prefill, 0, 10).is_finite(),
+            "row 0 key 10 is in the future"
+        );
+        // Row 1 holds logical position 10; its window is keys [7..=10].
+        assert_eq!(
+            at(&prefill, 1, 7),
+            0.0,
+            "row 1 must attend oldest in-window key 7"
+        );
+        assert_eq!(at(&prefill, 1, 10), 0.0, "row 1 causal boundary key 10");
+        assert!(
+            !at(&prefill, 1, 6).is_finite(),
+            "row 1 key 6 is below the window"
+        );
+    }
+
     /// A fresh dense over-window prefill (`sliding_offset == 0`) is identical
     /// to the rotating helper: both build the full `[size, size]` mask.
     #[test]
@@ -1500,15 +1571,16 @@ mod tests {
         }
     }
 
-    /// For within-window prefills (`size <= window`) the dense helper is
-    /// byte-identical to the rotating helper, including the within-window
-    /// rolled-over (`size + sliding_offset > window`) clamped path. Greedy
-    /// output for within-window prefills is therefore unchanged.
+    /// For within-total prefills (`size + sliding_offset <= window`) the dense
+    /// helper is byte-identical to the rotating helper: the rotating clamped
+    /// builder takes its non-capped path there, so greedy output for the common
+    /// within-window prefill is unchanged. (The `size + sliding_offset > window`
+    /// cases now diverge on purpose and are covered by the dense-full tests.)
     #[test]
     fn sliding_window_prefill_mask_dense_within_window_byte_identical() {
         let at =
             |m: &MlxArray, q: i32, k: i32| ffi::item_f32(&ffi::slice(m, &[q, k], &[q + 1, k + 1]));
-        for &(size, offset, window) in &[(3, 0, 8), (2, 9, 4)] {
+        for &(size, offset, window) in &[(3, 0, 8), (3, 2, 8)] {
             let dense = create_sliding_window_prefill_mask_dense(size, offset, window);
             let rotating = create_sliding_window_prefill_mask(size, offset, window);
             assert_eq!(

--- a/src/models/cohere2.rs
+++ b/src/models/cohere2.rs
@@ -427,10 +427,10 @@ impl Cohere2Model {
             let swa_offset = caches[self.swa_idx].offset;
 
             let full = Some(create_causal_mask(l as i32, ga_offset));
-            // Full-width windowed mask for any over-window prefill (at any
-            // offset, not just a fresh one); clamped mask otherwise. The
-            // attention layer slices K/V to the mask's key axis, so a full mask
-            // keeps all (dense `KVCache`) keys. See issues #408, #413.
+            // Dense `KVCache` keeps every key, so the prefill mask is always
+            // the full windowed-causal mask over all retained keys; the
+            // attention layer slices K/V to the mask's key axis. The window is
+            // enforced by the mask, not by dropping keys. See issues #408, #413.
             let sliding = Some(create_sliding_window_prefill_mask_dense(
                 l as i32,
                 swa_offset,
@@ -489,10 +489,10 @@ impl Cohere2Model {
             let swa_offset = caches[self.swa_idx].offset;
 
             let full = Some(create_causal_mask(l as i32, ga_offset));
-            // Full-width windowed mask for any over-window prefill (at any
-            // offset, not just a fresh one); clamped mask otherwise. The
-            // attention layer slices K/V to the mask's key axis, so a full mask
-            // keeps all (dense `KVCache`) keys. See issues #408, #413.
+            // Dense `KVCache` keeps every key, so the prefill mask is always
+            // the full windowed-causal mask over all retained keys; the
+            // attention layer slices K/V to the mask's key axis. The window is
+            // enforced by the mask, not by dropping keys. See issues #408, #413.
             let sliding = Some(create_sliding_window_prefill_mask_dense(
                 l as i32,
                 swa_offset,

--- a/src/models/cohere2.rs
+++ b/src/models/cohere2.rs
@@ -23,7 +23,7 @@
 
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{FusedQKVLinear, KVCache, LayerNorm, UnifiedEmbedding, UnifiedLinear};
-use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask_dense};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
@@ -427,11 +427,11 @@ impl Cohere2Model {
             let swa_offset = caches[self.swa_idx].offset;
 
             let full = Some(create_causal_mask(l as i32, ga_offset));
-            // Full-width windowed mask for a fresh single-pass prefill that
-            // exceeds the window; clamped mask otherwise. The attention layer
-            // slices K/V to the mask's key axis, so a full mask keeps all
-            // (dense `KVCache`) keys. See issue #408.
-            let sliding = Some(create_sliding_window_prefill_mask(
+            // Full-width windowed mask for any over-window prefill (at any
+            // offset, not just a fresh one); clamped mask otherwise. The
+            // attention layer slices K/V to the mask's key axis, so a full mask
+            // keeps all (dense `KVCache`) keys. See issues #408, #413.
+            let sliding = Some(create_sliding_window_prefill_mask_dense(
                 l as i32,
                 swa_offset,
                 self.config.sliding_window as i32,
@@ -489,11 +489,11 @@ impl Cohere2Model {
             let swa_offset = caches[self.swa_idx].offset;
 
             let full = Some(create_causal_mask(l as i32, ga_offset));
-            // Full-width windowed mask for a fresh single-pass prefill that
-            // exceeds the window; clamped mask otherwise. The attention layer
-            // slices K/V to the mask's key axis, so a full mask keeps all
-            // (dense `KVCache`) keys. See issue #408.
-            let sliding = Some(create_sliding_window_prefill_mask(
+            // Full-width windowed mask for any over-window prefill (at any
+            // offset, not just a fresh one); clamped mask otherwise. The
+            // attention layer slices K/V to the mask's key axis, so a full mask
+            // keeps all (dense `KVCache`) keys. See issues #408, #413.
+            let sliding = Some(create_sliding_window_prefill_mask_dense(
                 l as i32,
                 swa_offset,
                 self.config.sliding_window as i32,

--- a/src/models/gemma3n.rs
+++ b/src/models/gemma3n.rs
@@ -30,7 +30,7 @@ use crate::models::gemma3n_helpers::{
 };
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, Linear, RMSNorm, UnifiedEmbedding, UnifiedLinear};
-use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask_dense};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
@@ -1205,11 +1205,11 @@ impl Gemma3nLanguageModel {
             None
         };
         let sliding_mask = if l > 1 {
-            // Full-width windowed mask for a fresh single-pass prefill that
-            // exceeds the window; clamped mask otherwise. The attention layer
-            // slices K/V to the mask's key axis, so a full mask keeps every
-            // (dense `KVCache`) key. See issue #408.
-            Some(create_sliding_window_prefill_mask(
+            // Full-width windowed mask for any over-window prefill (at any
+            // offset, not just a fresh one); clamped mask otherwise. The
+            // attention layer slices K/V to the mask's key axis, so a full mask
+            // keeps every (dense `KVCache`) key. See issues #408, #413.
+            Some(create_sliding_window_prefill_mask_dense(
                 l,
                 sliding_offset,
                 self.config.sliding_window as i32,
@@ -1382,11 +1382,11 @@ impl Gemma3nLanguageModel {
             None
         };
         let sliding_mask = if l > 1 {
-            // Full-width windowed mask for a fresh single-pass prefill that
-            // exceeds the window; clamped mask otherwise. The attention layer
-            // slices K/V to the mask's key axis, so a full mask keeps every
-            // (dense `KVCache`) key. See issue #408.
-            Some(create_sliding_window_prefill_mask(
+            // Full-width windowed mask for any over-window prefill (at any
+            // offset, not just a fresh one); clamped mask otherwise. The
+            // attention layer slices K/V to the mask's key axis, so a full mask
+            // keeps every (dense `KVCache`) key. See issues #408, #413.
+            Some(create_sliding_window_prefill_mask_dense(
                 l,
                 sliding_offset,
                 self.config.sliding_window as i32,

--- a/src/models/gemma3n.rs
+++ b/src/models/gemma3n.rs
@@ -1205,10 +1205,10 @@ impl Gemma3nLanguageModel {
             None
         };
         let sliding_mask = if l > 1 {
-            // Full-width windowed mask for any over-window prefill (at any
-            // offset, not just a fresh one); clamped mask otherwise. The
-            // attention layer slices K/V to the mask's key axis, so a full mask
-            // keeps every (dense `KVCache`) key. See issues #408, #413.
+            // Dense `KVCache` keeps every key, so the prefill mask is always
+            // the full windowed-causal mask over all retained keys; the
+            // attention layer slices K/V to the mask's key axis. The window is
+            // enforced by the mask, not by dropping keys. See issues #408, #413.
             Some(create_sliding_window_prefill_mask_dense(
                 l,
                 sliding_offset,
@@ -1382,10 +1382,10 @@ impl Gemma3nLanguageModel {
             None
         };
         let sliding_mask = if l > 1 {
-            // Full-width windowed mask for any over-window prefill (at any
-            // offset, not just a fresh one); clamped mask otherwise. The
-            // attention layer slices K/V to the mask's key axis, so a full mask
-            // keeps every (dense `KVCache`) key. See issues #408, #413.
+            // Dense `KVCache` keeps every key, so the prefill mask is always
+            // the full windowed-causal mask over all retained keys; the
+            // attention layer slices K/V to the mask's key axis. The window is
+            // enforced by the mask, not by dropping keys. See issues #408, #413.
             Some(create_sliding_window_prefill_mask_dense(
                 l,
                 sliding_offset,

--- a/src/models/olmo3.rs
+++ b/src/models/olmo3.rs
@@ -24,7 +24,7 @@
 
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
-use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
+use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask_dense};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 use serde::Deserialize;
@@ -464,11 +464,11 @@ impl OLMo3Model {
             let swa_offset = caches[self.swa_idx].offset;
 
             let full = Some(create_causal_mask(l as i32, ga_offset));
-            // Full-width windowed mask for a fresh single-pass prefill that
-            // exceeds the window; clamped mask otherwise. The attention layer
-            // slices K/V to the mask's key axis, so a full mask keeps every
-            // (dense `KVCache`) key. See issue #408.
-            let sliding = Some(create_sliding_window_prefill_mask(
+            // Full-width windowed mask for any over-window prefill (at any
+            // offset, not just a fresh one); clamped mask otherwise. The
+            // attention layer slices K/V to the mask's key axis, so a full mask
+            // keeps every (dense `KVCache`) key. See issues #408, #413.
+            let sliding = Some(create_sliding_window_prefill_mask_dense(
                 l as i32,
                 swa_offset,
                 self.config.sliding_window as i32,

--- a/src/models/olmo3.rs
+++ b/src/models/olmo3.rs
@@ -464,10 +464,10 @@ impl OLMo3Model {
             let swa_offset = caches[self.swa_idx].offset;
 
             let full = Some(create_causal_mask(l as i32, ga_offset));
-            // Full-width windowed mask for any over-window prefill (at any
-            // offset, not just a fresh one); clamped mask otherwise. The
-            // attention layer slices K/V to the mask's key axis, so a full mask
-            // keeps every (dense `KVCache`) key. See issues #408, #413.
+            // Dense `KVCache` keeps every key, so the prefill mask is always
+            // the full windowed-causal mask over all retained keys; the
+            // attention layer slices K/V to the mask's key axis. The window is
+            // enforced by the mask, not by dropping keys. See issues #408, #413.
             let sliding = Some(create_sliding_window_prefill_mask_dense(
                 l as i32,
                 swa_offset,


### PR DESCRIPTION
## Summary

Dense-`KVCache` sliding-window models (cohere2, gemma3n, olmo3) degenerated on prefills where the total key span exceeded the window. This makes their prefill mask construction unconditionally use the full windowed-causal mask over all retained keys, fixing both degeneration cases while leaving the rotating-cache models untouched.

## Root cause

A dense `KVCache` retains every key and the attention layer slices K/V to the mask's key axis, but these three models routed mask construction through `create_sliding_window_prefill_mask`, whose full-mask gate is `size > window && sliding_offset == 0` (a FRESH prefill only). Any other over-window or over-total case fell to the clamped `[size, window]` mask, which assumes the cache physically trimmed to `window` keys. For a dense cache that assumption is false, so the clamped mask is the wrong shape for the keys actually present. This is a latent degeneration, not a regression introduced by #412 / #408: the behavior is byte-identical to the pre-#408 path.

## The fix

A dense `KVCache` keeps every key, so the correct prefill mask is ALWAYS the full `[size, size + sliding_offset]` windowed-causal mask over all retained keys, for every size/offset combination. The new `create_sliding_window_prefill_mask_dense` helper is therefore an unconditional call to `create_causal_mask_with_window_full` (no clamped branch). The window is enforced by the mask, not by physically dropping keys.

For the common within-window prefill (`size + sliding_offset <= window`) this is byte-identical to `create_sliding_window_prefill_mask`: the clamped builder takes its non-capped path there and produces the same `tril(offset)` intersect `triu(offset - window + 1)` band over `[size, size + sliding_offset]`, so greedy output is unchanged.

## Both degeneration cases fixed (dense caches: cohere2 / gemma3n / olmo3)

1. Over-window (`size > window`, at any offset): the clamped `[size, window]` mask's `tril` diagonal `window - size < 0` stranded the earliest query rows (logical position `< size - window`) with an all-`-inf` row, which softmaxed to NaN and decoded to `<pad>`.
2. Within-window but over-total (`size <= window && size + sliding_offset > window`): the clamped path's trailing-`window` K/V slice dropped the OLDEST in-window keys for the earliest query rows, silently narrowing their attention window. This produced coherent-but-wrong output rather than NaN/`<pad>`, so it was harder to spot, but it is the same root cause.

Prefills with `size + sliding_offset <= window` remain byte-identical (greedy output unchanged). `RotatingKVCache` models (gpt_oss, mellum, exaone4, exaone_moe, ministral3, step3p5, gemma3, gemma4) and the gemma3 tensor-parallel path are untouched: they keep `create_sliding_window_prefill_mask` and its clamped path, because a rotating cache physically returns at most `window` keys once it has rolled over, so the clamped mask is the matching shape.

## What changed

- `create_sliding_window_prefill_mask_dense` in `src/lib/mlxcel-core/src/utils.rs` simplified to an unconditional full mask; doc comment rewritten to explain the dense-vs-rotating divergence and both fixed cases.
- Reroute / keep the five dense call sites on the dense helper: `src/models/cohere2.rs` (two forward variants), `src/models/gemma3n.rs` (two forward variants), `src/models/olmo3.rs` (one); call-site comments updated to describe the unconditional full mask.
- `Used by:` lines updated: `create_sliding_window_prefill_mask` no longer lists the dense models; `create_causal_mask_with_window_full` lists the dense prefill consumers.
- Rotating-cache call sites left untouched: `src/distributed/tensor_parallel/llama_runtime.rs` (gemma3 TP), gemma3.rs, gemma4.rs, gpt_oss.rs, mellum.rs, exaone4.rs, exaone_moe.rs, ministral3.rs, step3p5.rs.
- Tests in the `utils` test module: `sliding_window_prefill_mask_dense_full_when_rolled_over_window` (over-window NaN case) and `sliding_window_prefill_mask_dense_matches_fresh_over_window` (parity with the rotating helper for a fresh over-window prefill); `sliding_window_prefill_mask_dense_within_window_byte_identical` now covers within-total inputs `(3, 0, 8)` and `(3, 2, 8)`; new `sliding_window_prefill_mask_dense_full_when_within_window_over_total` pins the within-window over-total fix (full `[2, 11]` mask, not clamped `[2, 4]`; row 0 at logical position 9 attends to its oldest in-window key at column 6 that the clamped path dropped).

## Test plan

- [x] `cargo test --release -p mlxcel-core utils::` (34 passed, 0 failed; includes the four `sliding_window_prefill_mask_dense_*` tests)
- [x] `cargo check --lib` (root crate compiles with the rerouted call sites)
- [x] `cargo clippy --lib --tests -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)

Closes #413
