### PR TITLE
fix(models): size dense prefill masks from live_len under trim (#419)

### DIFF
--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -8144,6 +8144,97 @@ mod tests {
         metadata.assert_consistent().unwrap();
     }
 
+    /// Regression for #419: a dense `KVCache` multi-token continuation chunk
+    /// after a `--max-kv-size` `trim_front` must size its prefill mask from
+    /// `live_len()` (the key count the cache actually returns), not the
+    /// monotonic `offset`. The dense sliding-window models (cohere2, gemma3n,
+    /// olmo3) build their model-level prefill masks from the cache before the
+    /// chunk's `update_and_fetch`; under a trim (`live_start > 0`) a mask
+    /// sized from `offset` is wider than the returned K/V, so the attention
+    /// broadcast throws and the server aborts. This pins the cache invariant
+    /// the fix relies on so a regression back to `offset` is caught.
+    #[test]
+    fn kv_cache_continuation_mask_sizes_from_live_len_not_offset_after_trim() {
+        const H: i32 = 2;
+        const D: i32 = 4;
+
+        // Build a `[1, H, n, D]` Fp16-cache K/V tensor with arbitrary values;
+        // only the key axis (n) matters for this shape invariant.
+        let make_kv = |n: i32, base: f32| {
+            let count = (H * n * D) as usize;
+            let data: Vec<f32> = (0..count).map(|i| base + i as f32).collect();
+            ffi::from_slice_f32(&data, &[1, H, n, D])
+        };
+
+        let mut cache = KVCache::new();
+
+        // Prefill `n1` tokens, then trim the oldest `trimmed` (the
+        // `--max-kv-size` cap path) so the live window starts at
+        // `live_start > 0`.
+        let n1 = 8;
+        let trimmed = 3;
+        let _ = cache.update_and_fetch(make_kv(n1, 0.0), make_kv(n1, 100.0));
+        assert_eq!(cache.offset, n1);
+        assert_eq!(cache.live_start, 0);
+
+        assert_eq!(cache.trim_front(trimmed), trimmed);
+
+        // RoPE invariant: `offset` stays monotonic and `live_start` advances,
+        // so the visible window is `live_len = offset - live_start`, NOT
+        // `offset`.
+        assert_eq!(
+            cache.offset, n1,
+            "offset must stay monotonic after trim_front"
+        );
+        assert_eq!(cache.live_start, trimmed);
+        assert_eq!(cache.live_len(), n1 - trimmed);
+
+        // Snapshot what the model-level mask builder reads just before the
+        // continuation chunk's `update_and_fetch`.
+        let live_len_before = cache.live_len(); // correct mask width source
+        let offset_before = cache.offset; // buggy mask width source
+
+        // Continuation chunk of `m` tokens (the `l > 1` prefill path).
+        let m = 4;
+        let (cont_k, _cont_v) = cache.update_and_fetch(make_kv(m, 200.0), make_kv(m, 300.0));
+
+        // The cache returns only the live window plus the new tokens.
+        let returned_key_axis = ffi::array_shape(&cont_k)[2];
+        assert_eq!(
+            returned_key_axis,
+            live_len_before + m,
+            "Fp16 update_and_fetch must return live_len + new tokens"
+        );
+        assert_eq!(
+            returned_key_axis,
+            cache.live_len(),
+            "returned key axis must equal the post-update live window"
+        );
+        assert_ne!(
+            returned_key_axis,
+            offset_before + m,
+            "returned key axis must NOT equal offset + new tokens (the buggy assumption)"
+        );
+
+        // The correct (live_len-sized) prefill mask key axis matches the
+        // returned K/V key axis.
+        let correct_mask = crate::utils::create_causal_mask(m, live_len_before);
+        let correct_klen = *ffi::array_shape(&correct_mask).last().unwrap();
+        assert_eq!(
+            correct_klen, returned_key_axis,
+            "create_causal_mask(m, live_len) key axis must match the returned K/V"
+        );
+
+        // The buggy (offset-sized) mask is strictly wider than the returned
+        // K/V; that mismatch is what crashes the attention broadcast.
+        let buggy_mask = crate::utils::create_causal_mask(m, offset_before);
+        let buggy_klen = *ffi::array_shape(&buggy_mask).last().unwrap();
+        assert!(
+            buggy_klen > returned_key_axis,
+            "offset-sized mask ({buggy_klen}) must be wider than the returned K/V ({returned_key_axis})"
+        );
+    }
+
     /// End-to-end batch grow + shrink sequence: start with one sequence,
     /// admit a second mid-decode (extend), then evict the first
     /// (filter_in_place). Per-row offsets must remain coherent throughout.

--- a/src/models/cohere2.rs
+++ b/src/models/cohere2.rs
@@ -423,17 +423,28 @@ impl Cohere2Model {
 
         // Create masks for full and sliding attention
         let (full_mask, sliding_mask) = if l > 1 {
-            let ga_offset = caches[self.ga_idx].offset;
-            let swa_offset = caches[self.swa_idx].offset;
+            // Size the prefill masks from the cache's live window
+            // (`live_len() = offset - live_start`), not the monotonic
+            // `offset`. Under `--max-kv-size`, `trim_front` slices the buffer
+            // to the live window and advances `live_start` while `offset`
+            // keeps growing to preserve the RoPE relative positions, so
+            // `update_and_fetch` returns only `live_len` keys. A mask sized
+            // from `offset` would be wider than the returned K/V and break the
+            // attention broadcast. With no trim (`live_start == 0`),
+            // `live_len == offset`, so this is byte-identical to the untrimmed
+            // path. See issue #419.
+            let ga_live_len = caches[self.ga_idx].live_len();
+            let swa_live_len = caches[self.swa_idx].live_len();
 
-            let full = Some(create_causal_mask(l as i32, ga_offset));
-            // Dense `KVCache` keeps every key, so the prefill mask is always
-            // the full windowed-causal mask over all retained keys; the
-            // attention layer slices K/V to the mask's key axis. The window is
-            // enforced by the mask, not by dropping keys. See issues #408, #413.
+            let full = Some(create_causal_mask(l as i32, ga_live_len));
+            // Dense `KVCache` keeps every key in the live window, so the
+            // prefill mask is the full windowed-causal mask over the retained
+            // (live) keys; the attention layer slices K/V to the mask's key
+            // axis. The window is enforced by the mask, not by dropping keys.
+            // See issues #408, #413, #419.
             let sliding = Some(create_sliding_window_prefill_mask_dense(
                 l as i32,
-                swa_offset,
+                swa_live_len,
                 self.config.sliding_window as i32,
             ));
             (full, sliding)
@@ -485,17 +496,28 @@ impl Cohere2Model {
         let l = shape[1] as usize;
 
         let (full_mask, sliding_mask) = if l > 1 {
-            let ga_offset = caches[self.ga_idx].offset;
-            let swa_offset = caches[self.swa_idx].offset;
+            // Size the prefill masks from the cache's live window
+            // (`live_len() = offset - live_start`), not the monotonic
+            // `offset`. Under `--max-kv-size`, `trim_front` slices the buffer
+            // to the live window and advances `live_start` while `offset`
+            // keeps growing to preserve the RoPE relative positions, so
+            // `update_and_fetch` returns only `live_len` keys. A mask sized
+            // from `offset` would be wider than the returned K/V and break the
+            // attention broadcast. With no trim (`live_start == 0`),
+            // `live_len == offset`, so this is byte-identical to the untrimmed
+            // path. See issue #419.
+            let ga_live_len = caches[self.ga_idx].live_len();
+            let swa_live_len = caches[self.swa_idx].live_len();
 
-            let full = Some(create_causal_mask(l as i32, ga_offset));
-            // Dense `KVCache` keeps every key, so the prefill mask is always
-            // the full windowed-causal mask over all retained keys; the
-            // attention layer slices K/V to the mask's key axis. The window is
-            // enforced by the mask, not by dropping keys. See issues #408, #413.
+            let full = Some(create_causal_mask(l as i32, ga_live_len));
+            // Dense `KVCache` keeps every key in the live window, so the
+            // prefill mask is the full windowed-causal mask over the retained
+            // (live) keys; the attention layer slices K/V to the mask's key
+            // axis. The window is enforced by the mask, not by dropping keys.
+            // See issues #408, #413, #419.
             let sliding = Some(create_sliding_window_prefill_mask_dense(
                 l as i32,
-                swa_offset,
+                swa_live_len,
                 self.config.sliding_window as i32,
             ));
             (full, sliding)

--- a/src/models/gemma3n.rs
+++ b/src/models/gemma3n.rs
@@ -1195,23 +1195,34 @@ impl Gemma3nLanguageModel {
         let per_layer_inputs = self.get_per_layer_inputs(inputs);
         let per_layer_inputs = self.project_per_layer_inputs(&h, &per_layer_inputs);
 
-        // Create masks
-        let global_offset = caches[self.first_full_idx].offset;
-        let sliding_offset = caches[self.first_sliding_idx].offset;
+        // Create masks. Size them from the cache's live window
+        // (`live_len() = offset - live_start`), not the monotonic `offset`.
+        // Under `--max-kv-size`, `trim_front` slices the buffer to the live
+        // window and advances `live_start` while `offset` keeps growing to
+        // preserve the RoPE relative positions, so `update_and_fetch` returns
+        // only `live_len` keys. A mask sized from `offset` would be wider than
+        // the returned K/V and break the attention broadcast. The KV-shared
+        // attention layer already slices its K/V to `cache.live_len()` (see
+        // `Gemma3nAttention::forward`), so the model-level mask must use the
+        // same bound. With no trim (`live_start == 0`), `live_len == offset`,
+        // so this is byte-identical to the untrimmed path. See issue #419.
+        let global_live_len = caches[self.first_full_idx].live_len();
+        let sliding_live_len = caches[self.first_sliding_idx].live_len();
 
         let global_mask = if l > 1 {
-            Some(create_causal_mask(l, global_offset))
+            Some(create_causal_mask(l, global_live_len))
         } else {
             None
         };
         let sliding_mask = if l > 1 {
-            // Dense `KVCache` keeps every key, so the prefill mask is always
-            // the full windowed-causal mask over all retained keys; the
-            // attention layer slices K/V to the mask's key axis. The window is
-            // enforced by the mask, not by dropping keys. See issues #408, #413.
+            // Dense `KVCache` keeps every key in the live window, so the
+            // prefill mask is the full windowed-causal mask over the retained
+            // (live) keys; the attention layer slices K/V to the mask's key
+            // axis. The window is enforced by the mask, not by dropping keys.
+            // See issues #408, #413, #419.
             Some(create_sliding_window_prefill_mask_dense(
                 l,
-                sliding_offset,
+                sliding_live_len,
                 self.config.sliding_window as i32,
             ))
         } else {
@@ -1372,23 +1383,34 @@ impl Gemma3nLanguageModel {
         let _b = shape[0];
         let l = shape[1];
 
-        // Create masks
-        let global_offset = caches[self.first_full_idx].offset;
-        let sliding_offset = caches[self.first_sliding_idx].offset;
+        // Create masks. Size them from the cache's live window
+        // (`live_len() = offset - live_start`), not the monotonic `offset`.
+        // Under `--max-kv-size`, `trim_front` slices the buffer to the live
+        // window and advances `live_start` while `offset` keeps growing to
+        // preserve the RoPE relative positions, so `update_and_fetch` returns
+        // only `live_len` keys. A mask sized from `offset` would be wider than
+        // the returned K/V and break the attention broadcast. The KV-shared
+        // attention layer already slices its K/V to `cache.live_len()` (see
+        // `Gemma3nAttention::forward`), so the model-level mask must use the
+        // same bound. With no trim (`live_start == 0`), `live_len == offset`,
+        // so this is byte-identical to the untrimmed path. See issue #419.
+        let global_live_len = caches[self.first_full_idx].live_len();
+        let sliding_live_len = caches[self.first_sliding_idx].live_len();
 
         let global_mask = if l > 1 {
-            Some(create_causal_mask(l, global_offset))
+            Some(create_causal_mask(l, global_live_len))
         } else {
             None
         };
         let sliding_mask = if l > 1 {
-            // Dense `KVCache` keeps every key, so the prefill mask is always
-            // the full windowed-causal mask over all retained keys; the
-            // attention layer slices K/V to the mask's key axis. The window is
-            // enforced by the mask, not by dropping keys. See issues #408, #413.
+            // Dense `KVCache` keeps every key in the live window, so the
+            // prefill mask is the full windowed-causal mask over the retained
+            // (live) keys; the attention layer slices K/V to the mask's key
+            // axis. The window is enforced by the mask, not by dropping keys.
+            // See issues #408, #413, #419.
             Some(create_sliding_window_prefill_mask_dense(
                 l,
-                sliding_offset,
+                sliding_live_len,
                 self.config.sliding_window as i32,
             ))
         } else {

--- a/src/models/olmo3.rs
+++ b/src/models/olmo3.rs
@@ -460,17 +460,28 @@ impl OLMo3Model {
 
         // Create masks for full and sliding attention
         let (full_mask, sliding_mask) = if l > 1 {
-            let ga_offset = caches[self.ga_idx].offset;
-            let swa_offset = caches[self.swa_idx].offset;
+            // Size the prefill masks from the cache's live window
+            // (`live_len() = offset - live_start`), not the monotonic
+            // `offset`. Under `--max-kv-size`, `trim_front` slices the buffer
+            // to the live window and advances `live_start` while `offset`
+            // keeps growing to preserve the RoPE relative positions, so
+            // `update_and_fetch` returns only `live_len` keys. A mask sized
+            // from `offset` would be wider than the returned K/V and break the
+            // attention broadcast. With no trim (`live_start == 0`),
+            // `live_len == offset`, so this is byte-identical to the untrimmed
+            // path. See issue #419.
+            let ga_live_len = caches[self.ga_idx].live_len();
+            let swa_live_len = caches[self.swa_idx].live_len();
 
-            let full = Some(create_causal_mask(l as i32, ga_offset));
-            // Dense `KVCache` keeps every key, so the prefill mask is always
-            // the full windowed-causal mask over all retained keys; the
-            // attention layer slices K/V to the mask's key axis. The window is
-            // enforced by the mask, not by dropping keys. See issues #408, #413.
+            let full = Some(create_causal_mask(l as i32, ga_live_len));
+            // Dense `KVCache` keeps every key in the live window, so the
+            // prefill mask is the full windowed-causal mask over the retained
+            // (live) keys; the attention layer slices K/V to the mask's key
+            // axis. The window is enforced by the mask, not by dropping keys.
+            // See issues #408, #413, #419.
             let sliding = Some(create_sliding_window_prefill_mask_dense(
                 l as i32,
-                swa_offset,
+                swa_live_len,
                 self.config.sliding_window as i32,
             ));
             (full, sliding)


### PR DESCRIPTION
## Summary

The dense-`KVCache` sliding-window models (cohere2, gemma3n, olmo3) built their multi-token (`l > 1`) prefill attention masks from the cache's monotonic `offset`, for both the global mask (`create_causal_mask`) and the sliding mask (`create_sliding_window_prefill_mask_dense`). Under the server `--max-kv-size` path that assumption is wrong after a trim, and the mismatch aborts the whole server process. This sizes the masks from `cache.live_len()` instead, which is byte-identical on the common untrimmed path.

## The bug

`enforce_max_kv_size_for` (called in `continue_chunked_prefill`, among others) calls `KVCache::trim_front`, which physically slices the buffer to the live window and advances `live_start` while `offset` keeps growing monotonically (to preserve RoPE relative positions). `update_and_fetch` (Fp16 and Int8) then returns only the live window of `live_len = offset - live_start` keys, not `offset` keys. On a multi-token continuation chunk after at least one trim (`live_start > 0`), a mask sized from the monotonic `offset` is WIDER than the returned K/V, so the mask key axis and the K/V key axis disagree. MLX `broadcast_shapes` throws, the cxx bridge turns the C++ exception into `std::terminate`, and the server process ABORTS (not a recoverable per-request error).

Reproduced on `gemma3n-e2b-4bit` with `--max-kv-size 1024 --prefill-chunk-size 512` on a 2631-token prompt: crash on chunk 4 with `[broadcast_shapes] Shapes (512,2048) and (1,8,512,1536) cannot be broadcast`.

## What changed

- `src/models/cohere2.rs` (`forward_impl` and `forward_with_embeddings_impl`): build the global and sliding prefill masks from `caches[..].live_len()` instead of `caches[..].offset`.
- `src/models/gemma3n.rs` (both `forward` variants): same change for `global_mask` / `sliding_mask`; the comment notes consistency with the KV-shared attention layer, which already slices its K/V to `cache.live_len()`.
- `src/models/olmo3.rs` (`forward_impl`): same change for the global and sliding masks.
- `src/lib/mlxcel-core/src/cache.rs`: new cache-level regression test `kv_cache_continuation_mask_sizes_from_live_len_not_offset_after_trim`.

These `offset` reads were mask-only. RoPE keeps using each layer's own monotonic `cache.offset` (read internally by the attention layer); no positional / layer-forward path changed. `create_causal_mask`, `create_causal_mask_with_window_full`, `create_sliding_window_prefill_mask_dense`, `trim_front`, `update_and_fetch`, and the RotatingKVCache consumers are untouched.

## Why it is correct (and byte-identical when untrimmed)

For a query row `q` at monotonic abs position `offset + q`, the live key column `k` is at abs position `live_start + k`. The causal bound `live_start + k <= offset + q` reduces to `k <= q + (offset - live_start) = q + live_len`, which is exactly `create_causal_mask(l, live_len)`; the window bound reduces the same way. The mask key dim `l + live_len` then matches `update_and_fetch`'s returned `l + live_len`. When no trim has happened, `live_start == 0` so `live_len == offset` and the masks are bit-for-bit the same, so greedy output on the common path is unchanged.

## Test plan

- [x] `cargo test --release -p mlxcel-core --features metal,accelerate cache::` (402 passed, incl. the new `kv_cache_continuation_mask_sizes_from_live_len_not_offset_after_trim`)
- [x] `cargo check --lib --features metal,accelerate`
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings` (clean)
- [x] `cargo fmt --check`

Closes #419
