### PR TITLE
fix(models): size dense prefill masks from live_len for mistral4/nemotron_nas/qwen-vl under --max-kv-size (#421)

### DIFF
--- a/src/models/mistral4.rs
+++ b/src/models/mistral4.rs
@@ -634,10 +634,18 @@ impl Mistral4Model {
         let shape = mlxcel_core::array_shape(&h);
         let l = shape[1];
 
-        // Create causal mask for prefill
+        // Create causal mask for prefill. Size it from the cache's live
+        // window (`live_len() = offset - live_start`), not the monotonic
+        // `offset`. Under `--max-kv-size`, `trim_front` advances `live_start`
+        // while `offset` keeps growing for RoPE; `update_and_fetch` then
+        // returns only `live_len` keys, so an `offset`-sized mask would be
+        // wider than the live K/V and trip `broadcast_shapes`. With no trim
+        // (`live_start == 0`), `live_len == offset`, so this is byte-identical
+        // to the untrimmed path. The Llama-4 attention scale below keeps the
+        // monotonic `offset`. See issue #421 (mirrors #419/#420).
         let mask = if l > 1 {
-            let offset = caches[0].offset;
-            Some(create_causal_mask(l, offset))
+            let live_len = caches[0].live_len();
+            Some(create_causal_mask(l, live_len))
         } else {
             None
         };

--- a/src/models/nemotron_nas.rs
+++ b/src/models/nemotron_nas.rs
@@ -642,13 +642,20 @@ impl LanguageModel for NemotronNASModel {
     ) -> UniquePtr<MlxArray> {
         let mut h = self.embeddings.forward(input_ids);
 
-        // Create causal mask if not provided
+        // Create causal mask if not provided. Size it from the cache's live
+        // window (`live_len() = offset - live_start`), not the monotonic
+        // `offset`. Under `--max-kv-size`, `trim_front` advances `live_start`
+        // while `offset` keeps growing for RoPE; `update_and_fetch` then
+        // returns only `live_len` keys, so an `offset`-sized mask would be
+        // wider than the live K/V and trip `broadcast_shapes`. With no trim
+        // (`live_start == 0`), `live_len == offset`, so this is byte-identical
+        // to the untrimmed path. See issue #421 (mirrors #419/#420).
         let computed_mask = if mask.is_none() {
             let shape = array_shape(&h);
             let seq_len = shape[1];
-            let offset = caches.first().map(|c| c.offset).unwrap_or(0);
+            let live_len = caches.first().map(|c| c.live_len()).unwrap_or(0);
             if seq_len > 1 {
-                Some(create_causal_mask(seq_len, offset))
+                Some(create_causal_mask(seq_len, live_len))
             } else {
                 None
             }

--- a/src/models/qwen2_vl.rs
+++ b/src/models/qwen2_vl.rs
@@ -685,12 +685,21 @@ impl Qwen2VLModel {
             }
         });
 
-        // Create causal mask if needed
+        // Create causal mask if needed. Size it from the cache's live window
+        // (`live_len() = offset - live_start`), not the monotonic
+        // `cache_offset`. Under `--max-kv-size`, `trim_front` advances
+        // `live_start` while `offset` keeps growing; `update_and_fetch` then
+        // returns only `live_len` keys, so an `offset`-sized mask would be
+        // wider than the live K/V and trip `broadcast_shapes`. With no trim
+        // (`live_start == 0`), `live_len == cache_offset`, so this is
+        // byte-identical to the untrimmed path. `cache_offset` stays monotonic
+        // above because position_ids/RoPE need absolute positions. See issue
+        // #421 (mirrors #419/#420).
         let auto_mask;
         let mask = if mask.is_some() {
             mask
         } else {
-            auto_mask = mlxcel_core::utils::create_causal_mask(seq_len, cache_offset);
+            auto_mask = mlxcel_core::utils::create_causal_mask(seq_len, caches[0].live_len());
             Some(auto_mask.as_ref().unwrap() as &MlxArray)
         };
 

--- a/src/models/qwen3_vl.rs
+++ b/src/models/qwen3_vl.rs
@@ -890,12 +890,21 @@ impl Qwen3VLModel {
             }
         });
 
-        // Create causal mask if needed
+        // Create causal mask if needed. Size it from the cache's live window
+        // (`live_len() = offset - live_start`), not the monotonic
+        // `cache_offset`. Under `--max-kv-size`, `trim_front` advances
+        // `live_start` while `offset` keeps growing; `update_and_fetch` then
+        // returns only `live_len` keys, so an `offset`-sized mask would be
+        // wider than the live K/V and trip `broadcast_shapes`. With no trim
+        // (`live_start == 0`), `live_len == cache_offset`, so this is
+        // byte-identical to the untrimmed path. `cache_offset` stays monotonic
+        // above because position_ids/RoPE need absolute positions. See issue
+        // #421 (mirrors #419/#420).
         let auto_mask;
         let mask = if mask.is_some() {
             mask
         } else {
-            auto_mask = mlxcel_core::utils::create_causal_mask(seq_len, cache_offset);
+            auto_mask = mlxcel_core::utils::create_causal_mask(seq_len, caches[0].live_len());
             Some(auto_mask.as_ref().unwrap() as &MlxArray)
         };
 

--- a/src/models/qwen3_vl_moe.rs
+++ b/src/models/qwen3_vl_moe.rs
@@ -1083,12 +1083,21 @@ impl Qwen3VLMoeModel {
             }
         });
 
-        // Create causal mask if needed
+        // Create causal mask if needed. Size it from the cache's live window
+        // (`live_len() = offset - live_start`), not the monotonic
+        // `cache_offset`. Under `--max-kv-size`, `trim_front` advances
+        // `live_start` while `offset` keeps growing; `update_and_fetch` then
+        // returns only `live_len` keys, so an `offset`-sized mask would be
+        // wider than the live K/V and trip `broadcast_shapes`. With no trim
+        // (`live_start == 0`), `live_len == cache_offset`, so this is
+        // byte-identical to the untrimmed path. `cache_offset` stays monotonic
+        // above because position_ids/RoPE need absolute positions. See issue
+        // #421 (mirrors #419/#420).
         let auto_mask;
         let mask = if mask.is_some() {
             mask
         } else {
-            auto_mask = mlxcel_core::utils::create_causal_mask(seq_len, cache_offset);
+            auto_mask = mlxcel_core::utils::create_causal_mask(seq_len, caches[0].live_len());
             Some(auto_mask.as_ref().unwrap() as &MlxArray)
         };
 


### PR DESCRIPTION
## Summary

Completes the `offset` -> `live_len` prefill-mask migration started in #419 / PR #420, applying it to the five remaining dense `Vec<KVCache>` scheduler-pool models that still built their multi-token (`l > 1`) prefill causal mask from the cache's monotonic `offset`.

## The bug

Under the server `--max-kv-size` path, `enforce_max_kv_size_for` (`src/server/batch/scheduler.rs`) calls `KVCache::trim_front`, which advances `live_start` while `offset` keeps growing monotonically (the RoPE invariant). `KVCache::update_and_fetch` then returns only the live window of `live_len = offset - live_start` keys, not `offset` keys. A model-level mask sized from `offset` is therefore WIDER than the live K/V after a trim. MLX `broadcast_shapes` throws, and because the throw crosses the cxx FFI boundary as a non-`Result` C++ exception it reaches `std::terminate` and ABORTS the whole server process. This is a remote-triggerable full-server abort: one long prompt plus a multi-token continuation chunk crashes every session.

## The fix (mask-only)

For mask construction only, size the prefill causal mask from `cache.live_len()` (alias of `seq_len()`, both `= offset - live_start`) instead of `cache.offset`. RoPE, `position_ids`, and the Llama-4 attention scale keep reading the monotonic `offset`. With no trim (`live_start == 0`), `live_len == offset`, so greedy output on the normal untrimmed path is byte-identical.

## What changed

- `src/models/mistral4.rs`: `Mistral4Model::transformer_body` builds the prefill mask from `caches[0].live_len()`. The separate `let offset = caches[0].offset` that feeds the Llama-4 attention scale (`get_llama4_attn_scale`) is left monotonic and unchanged.
- `src/models/nemotron_nas.rs`: `LanguageModel::forward` no-mask branch (the server path) builds the mask from `caches.first().map(|c| c.live_len())`. The per-layer RoPE `offset` in the attention block is untouched.
- `src/models/qwen2_vl.rs`, `src/models/qwen3_vl.rs`, `src/models/qwen3_vl_moe.rs`: only the `auto_mask = create_causal_mask(seq_len, ...)` argument switches to `caches[0].live_len()`. The `cache_offset` variable stays `caches[0].offset` and continues to drive `position_ids` / MRoPE grid slicing and the deepstack `cache_offset == 0` checks, because position_ids and RoPE need absolute (monotonic) positions.

## Scope: confirmed affected vs excluded

The five models above each store attention K/V as a plain `Vec<KVCache>` in the scheduler pool, so `enforce_max_kv_size_for` trims them and the offset-sized mask is a live (remotely triggerable) bug. `nemotron_h` and `jamba` were investigated and EXCLUDED: they use `ModelOwnedSequenceState`, so `CachePool::get_caches_mut` returns an empty slice and the trim loop never runs against their attention caches. For them the offset-based mask is a latent inconsistency, not reachable via `--max-kv-size`, and is left unchanged. `glm4_moe_lite` and `minicpm3` already size from `seq_len()` and are the reference pattern.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --lib --features metal,accelerate` (compiles all five changed models)
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings` (clean)
- [x] `cargo test --release -p mlxcel-core --features metal,accelerate cache::` (402 passed) including the shared invariant guard `kv_cache_continuation_mask_sizes_from_live_len_not_offset_after_trim` (added in #420), which pins the trimmed-cache (`live_start > 0`) invariant these five models now rely on.

No per-model unit test is added: exercising each model's mask construction requires a fully loaded real checkpoint (heavy, not in CI), and the underlying primitive is already pinned by the shared cache-level invariant test above.

Real-model E2E validation status will be added by the orchestrator: nemotron_nas / qwen2_vl / qwen3_vl / qwen3_vl_moe validated locally under a small `--max-kv-size` with a multi-token continuation chunk; mistral4 (Mistral-Small-4-119B) validated when its checkpoint is available.

Closes #421
