### PR TITLE
fix(loading): route Mistral3-VLM mistral4 (MLA) text backbone to the Mistral4 loader (#423)

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -73,7 +73,7 @@ Implemented VLM variants include:
 - Llama 4 VLM
 - LLaVA and LLaVA-Bunny
 - Aya Vision and PaliGemma
-- Pixtral and Mistral 3 VLM wrappers
+- Pixtral and Mistral 3 VLM wrappers (Mistral 3 VLM supports both the standard Llama/Mistral text backbone and the Mistral4 MLA+MoE backbone; text generation is validated on both, image+text for the Mistral4 backbone is tracked in #425)
 - Qwen2-VL, Qwen2.5-VL, Qwen3-VL, Qwen3.5-VL, and Qwen3-VL MoE
 - Youtu-VL
 - MiniCPM-O

--- a/src/loading/vlm_pixtral.rs
+++ b/src/loading/vlm_pixtral.rs
@@ -32,6 +32,7 @@ use crate::vision;
 
 use super::llava::infer_llama_config_from_weights;
 use super::{load_vlm_weights_common, read_sanitized_vlm_config, strip_language_model_prefix};
+use crate::model_metadata::is_mistral4_config;
 
 struct PixtralFamilyContext {
     full_config: Value,
@@ -101,12 +102,49 @@ fn build_pixtral_family_context(model_path: &Path) -> Result<PixtralFamilyContex
     vision::encoders::pixtral::sanitize_pixtral_weights(&mut weights);
     models::sanitize_tied_embeddings(&mut weights, &full_config);
 
+    // `text_config_value` is the Llama-shaped view of the backbone config. It
+    // is only used below for scalar context fields (hidden_size, rms_norm_eps);
+    // those keys come straight from text_config and survive the Llama massaging
+    // (infer_llama_config_from_weights only fills missing fields and never
+    // touches rms_norm_eps; apply_mistral_attention_head_override is a no-op
+    // when q_proj weights are absent), so it stays correct on both branches.
     let text_config_value = build_mistral_text_config(&full_config, &weights)?;
-    let text_args: models::llama3::ModelArgs = serde_json::from_value(text_config_value.clone())
-        .map_err(|e| anyhow::anyhow!("Failed to parse text_config as Mistral: {}", e))?;
-    let text_model = models::Llama3Model::from_weights(&weights, &text_args)
-        .map(LoadedModel::Llama)
-        .map_err(|e| anyhow::anyhow!("Failed to load text model: {}", e))?;
+
+    // The Mistral3 VLM container wraps either a standard Llama/Mistral text
+    // backbone (q_proj) or a `mistral4` MLA + MoE backbone (q_a_proj /
+    // kv_a_proj_with_mqa / kv_b_proj, no q_proj). Route the MLA case to the
+    // Mistral4 loader, mirroring the text-only `load_llama_family_from_weights`
+    // path in `src/loading/mod.rs`; the Llama loader cannot find `q_proj` for an
+    // MLA backbone and fails with a weight-not-found error. The
+    // `language_model.` prefix is already stripped above, so the weights sit at
+    // the bare `model.layers...` namespace both loaders expect. See
+    // lablup/mlxcel#423.
+    let text_model = if is_mistral4_config(&full_config) {
+        // Build the Mistral4 args from the RAW text_config, not the
+        // Llama-massaged `text_config_value`: infer_llama_config_from_weights and
+        // apply_mistral_attention_head_override key off `q_proj` and can corrupt
+        // the MLA head layout. Inherit the top-level quantization block when
+        // text_config omits it so group_size/bits are present.
+        let mut mistral4_text_config = full_config
+            .get("text_config")
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Missing text_config for Mistral4 VLM backbone"))?;
+        inherit_quantization_if_missing(&mut mistral4_text_config, &full_config)?;
+        let text_args: models::mistral4::Mistral4Config =
+            serde_json::from_value(mistral4_text_config)
+                .map_err(|e| anyhow::anyhow!("Failed to parse text_config as Mistral4: {}", e))?;
+        models::mistral4::sanitize_weights(&mut weights, &text_args, "");
+        models::Mistral4Model::from_weights(&weights, &text_args)
+            .map(LoadedModel::Mistral4)
+            .map_err(|e| anyhow::anyhow!("Failed to load Mistral4 text model: {}", e))?
+    } else {
+        let text_args: models::llama3::ModelArgs =
+            serde_json::from_value(text_config_value.clone())
+                .map_err(|e| anyhow::anyhow!("Failed to parse text_config as Mistral: {}", e))?;
+        models::Llama3Model::from_weights(&weights, &text_args)
+            .map(LoadedModel::Llama)
+            .map_err(|e| anyhow::anyhow!("Failed to load text model: {}", e))?
+    };
 
     let vision_config_value = full_config
         .get("vision_config")

--- a/src/models/mistral4.rs
+++ b/src/models/mistral4.rs
@@ -908,6 +908,18 @@ impl LanguageModel for Mistral4Model {
         vec![2] // Mistral EOS token
     }
 
+    // VLM image path: VisionModule::get_input_embeddings calls this to obtain
+    // text-space token embeddings before splicing in projected image features
+    // (see src/vision/mod.rs). Mirror the no-`input_embeddings` branch of
+    // `forward_with_embeddings` below so the merge path and the plain forward
+    // path share the same embedding table. Without this override the trait
+    // default returns None and a Mistral4-backed Mistral3 VLM image request
+    // fails with "Text model must support embed_tokens for VLM". See
+    // lablup/mlxcel#423.
+    fn embed_tokens(&self, input_ids: &MlxArray) -> Option<UniquePtr<MlxArray>> {
+        Some(self.embed_tokens.forward(input_ids))
+    }
+
     fn forward_with_embeddings(
         &self,
         input_ids: &MlxArray,


### PR DESCRIPTION
## Summary

Mistral3 VLM containers (`Mistral3ForConditionalGeneration`) can wrap a `mistral4` (MLA + MoE) text backbone, but `build_pixtral_family_context` always loaded the text backbone through the Llama3 loader, which fails because an MLA backbone has no `q_proj`. This routes the `mistral4` case to the Mistral4 loader, unblocking `mlx-community/Mistral-Small-4-119B-2603-4bit`.

## Root cause

`build_pixtral_family_context` (`src/loading/vlm_pixtral.rs`) unconditionally parsed `text_config` as `models::llama3::ModelArgs` and built `models::Llama3Model::from_weights`, which expects standard attention weights (`q_proj`). For a `mistral4` backbone the attention is MLA (`q_a_proj` / `kv_a_proj_with_mqa` / `kv_b_proj`, no `q_proj`), so loading failed with `Weight not found: model.layers.0.self_attn.q_proj.weight`. The text-only path `load_llama_family_from_weights` (`src/loading/mod.rs`) already branches on `is_mistral4_config` and routes to `Mistral4Model::from_weights`; the VLM context builder lacked the equivalent branch.

## What changed

- `src/loading/vlm_pixtral.rs`: in `build_pixtral_family_context`, branch the text-backbone load on `is_mistral4_config(&full_config)`. The `mistral4` branch parses the raw `full_config["text_config"]` (with the top-level `quantization` block inherited via `inherit_quantization_if_missing` when absent) as `models::mistral4::Mistral4Config`, runs `models::mistral4::sanitize_weights(&mut weights, &args, "")`, and builds `models::Mistral4Model::from_weights(&weights, &args)` wrapped as `LoadedModel::Mistral4`, mirroring the text-only `load_llama_family_from_weights` path.
- The raw `text_config` is used for model construction rather than the Llama-massaged value from `build_mistral_text_config`, because `infer_llama_config_from_weights` and `apply_mistral_attention_head_override` key off `q_proj` and can corrupt the MLA config.
- Weights are already stripped of the `language_model.` prefix by `strip_language_model_prefix` before this point, so both loaders see the bare `model.layers...` namespace.
- The Llama path is unchanged for non-`mistral4` Mistral3 VLMs (Pixtral and standard Mistral text backbones). `text_config_value` is still built via `build_mistral_text_config` and used only for the scalar context fields (`hidden_size`, `rms_norm_eps`), which survive the Llama massaging on the `mistral4` path.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --lib --features metal,accelerate`
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings`
- [x] `cargo test --release --features metal,accelerate --lib loading::tests::is_mistral4` (2 passed)

A checkpoint-free unit test of the private routing branch is not practical (it needs a real model directory plus full model construction); the existing `is_mistral4_config` detection tests cover the predicate. Real-model load validation of `mlx-community/Mistral-Small-4-119B-2603-4bit` is performed by the orchestrator.

Closes #423
