### PR TITLE
feat: add N-gram loop detection with Gemma 4 family default-on

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -128,6 +128,31 @@ The OpenAI audio endpoints (`/v1/audio/speech`, `/v1/audio/transcriptions`, `/v1
 | `MLXCEL_ENABLE_MTP_BATCH` | truthy value | off | **Advanced.** Forces the batched Gemma 4 MTP burst path for parity/debug testing. Not governed by the adaptive policy (issue #333), which scopes to the validated, byte-identical B=1 path. |
 | `MLXCEL_ENABLE_MTP_DEFERRED` | `1` | off | **Advanced.** Enables the deferred greedy verifier path for Gemma 4 MTP when sampling settings allow it. |
 
+## Generation loop detection (issue #432)
+
+N-gram tail repetition detection ends a generation early when the raw generated token stream collapses into a short repeated pattern (a single token such as `様様様様`, or a short block such as `abcdabcd...`). It runs on the raw stream, so it also catches loops inside the reasoning/thought channel and tool-call JSON, not just the final answer. The wire `finish_reason` is `stop`, the same as vLLM. Sampling penalties (`repeat_penalty`, DRY) cannot recover once the logits collapse, which is why this is a stop condition rather than a logit reshaper.
+
+The detector mirrors vLLM's `SamplingParams` fields, with the same JSON names on the OpenAI chat surface:
+
+| Field | Meaning |
+|-------|---------|
+| `max_pattern_size` | Largest N-gram pattern size to scan. `0` (default) disables detection. |
+| `min_pattern_size` | Smallest N-gram pattern size to scan. `0` (default) is treated as `1`; clamped to `<= max_pattern_size`. |
+| `min_count` | Minimum consecutive repeats of a pattern that ends generation. Must be `>= 2`; any smaller value disables detection. |
+
+The preferred activation surface is engine-level: detection is **default-on for the Gemma 4 family with no configuration required**, so a downstream serving app needs no setup and end users see no toggle. The per-request fields and the global env var below are additional tuning surfaces, not the only way to turn it on.
+
+| Variable | Values | Default | Notes |
+|----------|--------|---------|-------|
+| `MLXCEL_LOOP_DETECTION` | `off`/`0`/`none`/`false`/`disabled`, `on`/`default`/`true`/`enabled`, or `MIN,MAX,COUNT` (also `MIN:MAX:COUNT`) | unset | Global operator override for any model. Unset lets the Gemma 4 family default-on apply (non-Gemma models stay disabled). `off` force-disables for every request, including the Gemma 4 family; `on` forces the recommended threshold `1,20,4` for every model; an explicit triple (e.g. `1,20,4`) sets exact values. A malformed value warns and is ignored. |
+
+Resolution precedence, highest first:
+
+1. **Explicit per-request fields.** If a chat request sets any of `max_pattern_size` / `min_pattern_size` / `min_count`, those values are used verbatim, including an explicit disable (`max_pattern_size=0`). A client never has to send anything; the fields are only for tuning or opting out.
+2. **Global override.** `MLXCEL_LOOP_DETECTION`, which an operator can use to force-enable, tune, or force-disable for any model.
+3. **Gemma 4 family default-on.** When the loaded model is in the Gemma 4 family (`Gemma4`, `Gemma4VLM`, `Gemma4Unified`), the conservative threshold `min_pattern_size=1, max_pattern_size=20, min_count=4` is applied unconditionally. This does not require tools or a structured-output request, so plain Gemma 4 chat is covered too. Detection only ends generation when a real repetition loop is present, so a conservative default-on for this family is low risk.
+4. **Disabled.** The default for every non-Gemma-4 model, preserving the exact baseline output.
+
 ## KV cache and TurboQuant variables
 
 Use CLI flags such as `--cache-type-k`, `--cache-type-v`, `--kv-cache-mode`,

--- a/docs/python-client.md
+++ b/docs/python-client.md
@@ -109,7 +109,7 @@ print(llm.chat(messages, max_tokens=128, temperature=0.3))
 
 ## Sampling parameters
 
-Generation methods accept OpenAI sampling fields directly: `max_tokens`, `temperature`, `top_p`, `stop`, `seed`, `presence_penalty`, `frequency_penalty`, `logit_bias`, and `response_format`. Server-specific knobs that are not part of the OpenAI schema (`top_k`, `min_p`, `repetition_penalty`, and DRY settings) are forwarded in the request body. You can also pass an explicit `extra_body={...}` for arbitrary server fields; values you set there win on conflict.
+Generation methods accept OpenAI sampling fields directly: `max_tokens`, `temperature`, `top_p`, `stop`, `seed`, `presence_penalty`, `frequency_penalty`, `logit_bias`, and `response_format`. Server-specific knobs that are not part of the OpenAI schema (`top_k`, `min_p`, `repetition_penalty`, DRY settings, and the vLLM-compatible loop-detection fields `max_pattern_size` / `min_pattern_size` / `min_count`) are forwarded in the request body. You can also pass an explicit `extra_body={...}` for arbitrary server fields; values you set there win on conflict.
 
 ```python
 llm.generate("Once upon a time", max_tokens=200, top_p=0.9, top_k=40, min_p=0.05)

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -110,6 +110,12 @@ Qwen-style `<think>` models. To turn thinking off, pass
 default via `--chat-template-kwargs` or `LLAMA_ARG_CHAT_TEMPLATE_KWARGS`. A
 per-request value always wins over the server default.
 
+### Loop-detection default-on for the Gemma 4 family
+
+Gemma 4 (31B Dense and 26B-A4B MoE, including the QAT 4-bit checkpoints) has an upstream, weights-level token-repetition collapse documented in [google-deepmind/gemma#622](https://github.com/google-deepmind/gemma/issues/622) and reproduced across other engines, including [vllm-project/vllm#40080](https://github.com/vllm-project/vllm/issues/40080). Generation can degenerate into a single repeated token (or short fragment) that fills the token budget, most often inside the thought channel. Tool declarations and `json_schema` structured-output requests amplify it, but it is not limited to those cases. Sampling penalties do not reliably recover it, because once the logits collapse the top-k candidates are themselves garbage.
+
+mlxcel applies vLLM-style N-gram loop detection to break this, default-on for the Gemma 4 family with no configuration required. For any model in the family (`Gemma4`, `Gemma4VLM`, `Gemma4Unified`), the engine applies the conservative threshold `min_pattern_size=1, max_pattern_size=20, min_count=4` by default; a degenerate run then ends early with `finish_reason` of `stop`. The default-on applies to plain Gemma 4 chat too, so a downstream serving app and its users need no setup and see no toggle. Detection only ends generation when a real repetition loop is present, so this conservative default is low risk. Every non-Gemma-4 model defaults to disabled (bit-exact baseline preserved). The behavior is still tunable on top of the default: a per-request override (the vLLM `max_pattern_size` / `min_pattern_size` / `min_count` fields, including `max_pattern_size=0` to opt out) wins, and a global operator override (`MLXCEL_LOOP_DETECTION`) can tune, force-enable for any model, or force-disable. See [Generation loop detection](environment-variables.md#generation-loop-detection-issue-432) for the field semantics and the full precedence order.
+
 ## Speech-to-text (ASR)
 
 mlxcel loads Whisper-style encoder-decoder ASR checkpoints (`model_type: "whisper"`) and serves them through the OpenAI audio endpoints. A convolutional audio encoder builds features from a 30-second log-mel window, and an autoregressive text decoder cross-attends to those features as it emits tokens, steered by the multilingual transcribe/translate task tokens.

--- a/src/distributed/disaggregated/serving_protocol.rs
+++ b/src/distributed/disaggregated/serving_protocol.rs
@@ -270,6 +270,10 @@ pub fn sampling_from_serializable(state: &SerializableSamplingState) -> Sampling
         presence_penalty: state.presence_penalty,
         stop_token_ids: state.stop_token_ids.clone(),
         token_bias: Default::default(),
+        // Loop detection is not yet serialized across the disaggregated
+        // prefill/decode handoff; the decode node keeps the disabled baseline.
+        // Wiring it into `SerializableSamplingState` is a follow-up.
+        loop_detection: Default::default(),
     }
 }
 

--- a/src/execution/sampling.rs
+++ b/src/execution/sampling.rs
@@ -19,7 +19,7 @@
 //! control plane so every entry point applies the same defaults.
 
 use crate::SamplingConfig;
-use mlxcel_core::TokenBiasMap;
+use mlxcel_core::{LoopDetectionConfig, TokenBiasMap};
 
 #[derive(Debug, Clone, PartialEq)]
 /// Fully resolved sampling knobs before conversion into `SamplingConfig`.
@@ -76,6 +76,11 @@ pub fn build_sampling_config(params: ResolvedSamplingParams) -> SamplingConfig {
             presence_penalty: params.presence_penalty,
             stop_token_ids: params.stop_token_ids,
             token_bias: TokenBiasMap::default(),
+            // Loop detection defaults to disabled here. The server control
+            // plane sets `sampling.loop_detection` after this helper returns,
+            // where the model family and the request's tools / response_format
+            // are visible (see `request_options::build_server_generate_options`).
+            loop_detection: LoopDetectionConfig::default(),
         }
     }
 }

--- a/src/execution/sampling.rs
+++ b/src/execution/sampling.rs
@@ -78,8 +78,8 @@ pub fn build_sampling_config(params: ResolvedSamplingParams) -> SamplingConfig {
             token_bias: TokenBiasMap::default(),
             // Loop detection defaults to disabled here. The server control
             // plane sets `sampling.loop_detection` after this helper returns,
-            // where the model family and the request's tools / response_format
-            // are visible (see `request_options::build_server_generate_options`).
+            // where the loaded model family is visible (see
+            // `request_options::build_server_generate_options`).
             loop_detection: LoopDetectionConfig::default(),
         }
     }

--- a/src/lib/mlxcel-core/src/generate.rs
+++ b/src/lib/mlxcel-core/src/generate.rs
@@ -34,6 +34,7 @@ use crate::generation_policy::{
 };
 use crate::hardware;
 use crate::layers::KVCache;
+use crate::loop_detection::{detect_repetition_loop, LoopDetectionConfig};
 use crate::sampling::{
     sample_token_optimized, sample_token_optimized_with_state, SamplerState, TokenBiasMap,
 };
@@ -684,6 +685,12 @@ pub struct SamplingConfig {
     /// Per-token additive logit bias applied before all history-based penalties.
     /// Empty (default) is a zero-overhead no-op that preserves bit-exact baseline.
     pub token_bias: TokenBiasMap,
+    /// N-gram tail repetition / loop detection. Disabled by default (all zero),
+    /// a zero-overhead no-op that preserves the bit-exact baseline for every
+    /// model that does not opt in (mirrors `token_bias` / `stop_token_ids`).
+    /// When enabled, the decode loops end generation early once the raw
+    /// generated stream collapses into a short repeated pattern.
+    pub loop_detection: LoopDetectionConfig,
 }
 
 impl Default for SamplingConfig {
@@ -704,6 +711,7 @@ impl Default for SamplingConfig {
             presence_penalty: 0.0,
             stop_token_ids: Vec::new(),
             token_bias: TokenBiasMap::default(),
+            loop_detection: LoopDetectionConfig::default(),
         }
     }
 }
@@ -727,6 +735,7 @@ impl SamplingConfig {
             presence_penalty: 0.0,
             stop_token_ids: Vec::new(),
             token_bias: TokenBiasMap::default(),
+            loop_detection: LoopDetectionConfig::default(),
         }
     }
 
@@ -1264,6 +1273,14 @@ impl CxxGenerator {
                 token_history.push(token_val);
             }
 
+            // Loop / repetition guard: end generation early when the raw
+            // generated stream collapses into a short repeated pattern (e.g.
+            // Gemma 4 token-repetition collapse). A disabled config (the
+            // default) short-circuits with zero overhead.
+            if detect_repetition_loop(&self.generated_tokens, &sampling.loop_detection) {
+                break;
+            }
+
             // Invoke callback; abort if it returns false
             if !on_token(token_val) {
                 break;
@@ -1458,6 +1475,14 @@ impl CxxGenerator {
                 token_history.push(token_val);
             }
 
+            // Loop / repetition guard: end generation early when the raw
+            // generated stream collapses into a short repeated pattern (e.g.
+            // Gemma 4 token-repetition collapse). A disabled config (the
+            // default) short-circuits with zero overhead.
+            if detect_repetition_loop(&self.generated_tokens, &sampling.loop_detection) {
+                break;
+            }
+
             if !on_token(token_val) {
                 break;
             }
@@ -1603,6 +1628,14 @@ impl CxxGenerator {
             self.generated_tokens.push(token_val);
             if needs_history {
                 token_history.push(token_val);
+            }
+
+            // Loop / repetition guard: end generation early when the raw
+            // generated stream collapses into a short repeated pattern (e.g.
+            // Gemma 4 token-repetition collapse). A disabled config (the
+            // default) short-circuits with zero overhead.
+            if detect_repetition_loop(&self.generated_tokens, &sampling.loop_detection) {
+                break;
             }
             // Periodic cache clearing (matches Python mlx-lm which clears every 256)
             if n % 256 == 0 && n > 0 {
@@ -1781,6 +1814,14 @@ impl CxxGenerator {
             self.generated_tokens.push(token_val);
             if needs_history {
                 token_history.push(token_val);
+            }
+
+            // Loop / repetition guard: end generation early when the raw
+            // generated stream collapses into a short repeated pattern (e.g.
+            // Gemma 4 token-repetition collapse). A disabled config (the
+            // default) short-circuits with zero overhead.
+            if detect_repetition_loop(&self.generated_tokens, &sampling.loop_detection) {
+                break;
             }
 
             // Periodic cache clearing (matches Python mlx-lm which clears every 256)

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -2406,6 +2406,9 @@ pub use ops::{concatenate, divide_scalar, multiply_scalar, stack, stack_owned, w
 
 // Re-export sampling primitives needed by generation-loop wiring (B8) and server layers.
 pub use sampling::TokenBiasMap;
+// Re-export N-gram loop-detection so the server control plane and CLI decode
+// loops can configure and run early-stop on degenerate token-repetition.
+pub use loop_detection::{detect_repetition_loop, LoopDetectionConfig};
 // Re-export B9 observability counter accessors so the server `/metrics` handler
 // can read process-wide lang-bias counters without a struct dependency.
 // Includes the byte-fragment suppression counter added.
@@ -2727,6 +2730,11 @@ pub mod generate;
 // Decode-loop setup helpers shared by standard and speculative generation.
 // Public so that the server batch scheduler can reuse seed/EOS/history helpers.
 pub mod generation_policy;
+
+// N-gram repetition / loop detection over the raw generated token stream.
+// Public so the server batch scheduler and CLI decode loops can end a
+// degenerate generation early (e.g. Gemma 4 token-repetition collapse).
+pub mod loop_detection;
 
 // Shared sampling and token-penalty policy helpers.
 // Public so that the server batch scheduler can perform step-level sampling.

--- a/src/lib/mlxcel-core/src/loop_detection.rs
+++ b/src/lib/mlxcel-core/src/loop_detection.rs
@@ -1,0 +1,153 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! N-gram repetition / loop detection over the raw generated token stream.
+//!
+//! Some checkpoints (e.g. the Gemma 4 family under tool or grammar-constrained
+//! decoding) can collapse into a degenerate loop where a single token or a
+//! short block repeats until the token budget is exhausted. Sampling penalties
+//! (`repetition_penalty`, DRY) reshape the probability distribution, but once
+//! the logits collapse the top-k candidates are themselves garbage, so
+//! distribution shaping cannot recover. The countermeasure here is the one vLLM
+//! exposes in `SamplingParams`: detect when a short pattern repeats at the tail
+//! of the stream and end generation early.
+//!
+//! This module is intentionally model-family agnostic. The policy for when to
+//! turn it on (per-request override, global operator override, family-specific
+//! auto-enable) lives in the server control plane, not here. The default is a
+//! zero-overhead no-op that preserves the bit-exact baseline for every model
+//! that does not opt in.
+
+/// Configuration for tail N-gram repetition detection.
+///
+/// Field names and semantics mirror vLLM's `SamplingParams` so the same JSON
+/// request fields work against either engine:
+///
+/// - `max_pattern_size` (default `0` = disabled): largest N-gram size to scan.
+/// - `min_pattern_size` (default `0`, treated as `1`): smallest N-gram size to
+///   scan; clamped to `1..=max_pattern_size`.
+/// - `min_count` (must be `>= 2`): how many consecutive repeats of a pattern at
+///   the tail trigger an early stop.
+///
+/// The all-zero `Default` is disabled, matching vLLM's opt-in default and the
+/// way [`crate::generate::SamplingConfig::token_bias`] /
+/// [`crate::generate::SamplingConfig::stop_token_ids`] keep an empty no-op
+/// baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct LoopDetectionConfig {
+    /// Largest N-gram pattern size to scan. `0` disables detection entirely.
+    pub max_pattern_size: usize,
+    /// Smallest N-gram pattern size to scan. `0` is treated as `1`.
+    pub min_pattern_size: usize,
+    /// Minimum consecutive repeats of a pattern that triggers an early stop.
+    /// Must be `>= 2`; any smaller value disables detection.
+    pub min_count: usize,
+}
+
+impl LoopDetectionConfig {
+    /// The disabled (zero-overhead, bit-exact baseline) configuration.
+    pub const fn disabled() -> Self {
+        Self {
+            max_pattern_size: 0,
+            min_pattern_size: 0,
+            min_count: 0,
+        }
+    }
+
+    /// Build a configuration from raw vLLM-style fields without normalization.
+    /// `is_enabled` and [`detect_repetition_loop`] apply the clamping rules.
+    pub const fn new(min_pattern_size: usize, max_pattern_size: usize, min_count: usize) -> Self {
+        Self {
+            max_pattern_size,
+            min_pattern_size,
+            min_count,
+        }
+    }
+
+    /// Returns `true` when the configuration can ever trigger.
+    ///
+    /// Detection requires a non-zero `max_pattern_size` and a `min_count` of at
+    /// least two repeats (a single occurrence is not a loop). When this returns
+    /// `false`, [`detect_repetition_loop`] short-circuits before touching the
+    /// token slice, preserving the zero-overhead baseline.
+    pub const fn is_enabled(&self) -> bool {
+        self.max_pattern_size > 0 && self.min_count >= 2
+    }
+
+    /// Smallest pattern size actually scanned: `0` becomes `1`, then clamped to
+    /// `1..=max_pattern_size`. Only meaningful when [`is_enabled`] is true, so
+    /// `max_pattern_size >= 1` holds and the clamp range is well-formed.
+    ///
+    /// [`is_enabled`]: Self::is_enabled
+    fn effective_min_pattern_size(&self) -> usize {
+        let requested = if self.min_pattern_size == 0 {
+            1
+        } else {
+            self.min_pattern_size
+        };
+        requested.clamp(1, self.max_pattern_size)
+    }
+}
+
+/// Returns `true` when the tail of `generated` is a short block repeated at
+/// least `cfg.min_count` times consecutively.
+///
+/// For each pattern size `p` in `min_pattern_size..=max_pattern_size`, the last
+/// `p * min_count` tokens are checked: they trigger when they equal a single
+/// `p`-length block `B` repeated `min_count` times (`tail == B·B·…·B`). The
+/// first `p` that matches wins. This catches single-token collapses (`p = 1`,
+/// e.g. `様様様様`) and short multi-token loops (`p = 2,3,…`, e.g.
+/// `abcdabcd…`).
+///
+/// The scan only runs when [`LoopDetectionConfig::is_enabled`] is true, so a
+/// model that does not opt in pays nothing beyond the cheap config check. The
+/// caller passes the raw generated token stream so loops inside reasoning /
+/// tool-call spans are caught, not just the final answer.
+///
+/// Used by: `CxxGenerator` decode loops (`generate.rs`), `BatchScheduler`
+/// decode sites (`server/batch/scheduler.rs`).
+pub fn detect_repetition_loop(generated: &[i32], cfg: &LoopDetectionConfig) -> bool {
+    if !cfg.is_enabled() {
+        return false;
+    }
+
+    let len = generated.len();
+    let count = cfg.min_count;
+    let min_p = cfg.effective_min_pattern_size();
+    let max_p = cfg.max_pattern_size;
+
+    for p in min_p..=max_p {
+        // `window` grows monotonically with `p`, so once it exceeds the stream
+        // length no larger `p` can fit either: stop scanning.
+        let window = match p.checked_mul(count) {
+            Some(w) => w,
+            None => break,
+        };
+        if len < window {
+            break;
+        }
+
+        let tail = &generated[len - window..];
+        let block = &tail[..p];
+        if tail.chunks_exact(p).all(|chunk| chunk == block) {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+#[path = "loop_detection_tests.rs"]
+mod tests;

--- a/src/lib/mlxcel-core/src/loop_detection.rs
+++ b/src/lib/mlxcel-core/src/loop_detection.rs
@@ -29,6 +29,21 @@
 //! zero-overhead no-op that preserves the bit-exact baseline for every model
 //! that does not opt in.
 
+/// Hard upper bound on the effective `max_pattern_size` actually scanned by
+/// [`detect_repetition_loop`], regardless of the configured value.
+///
+/// The per-decode-step scan cost grows with the largest pattern size it sweeps:
+/// for each `p` up to the maximum it checks the last `p * min_count` tokens, so
+/// an unbounded maximum makes the per-step work grow with the generated length
+/// (and the whole-generation cost grow super-linearly), letting an untrusted
+/// per-request `max_pattern_size` or the global-env override pin the worker
+/// thread. Both override surfaces are untrusted, so the value is capped here
+/// rather than at each entry point. The cap still covers every loop length that
+/// occurs in practice: real Gemma 4 collapses are 1-20 tokens, and vLLM-style
+/// detection targets short patterns, so 64 leaves a wide margin while keeping
+/// per-step work bounded.
+pub const MAX_EFFECTIVE_PATTERN_SIZE: usize = 64;
+
 /// Configuration for tail N-gram repetition detection.
 ///
 /// Field names and semantics mirror vLLM's `SamplingParams` so the same JSON
@@ -86,8 +101,11 @@ impl LoopDetectionConfig {
     }
 
     /// Smallest pattern size actually scanned: `0` becomes `1`, then clamped to
-    /// `1..=max_pattern_size`. Only meaningful when [`is_enabled`] is true, so
-    /// `max_pattern_size >= 1` holds and the clamp range is well-formed.
+    /// `1..=effective_max_pattern_size()`. The ceiling is the capped maximum (not
+    /// the raw `max_pattern_size`) so a huge configured maximum paired with a min
+    /// above the cap still yields a well-formed scan range. Only meaningful when
+    /// [`is_enabled`] is true, so `max_pattern_size >= 1` holds and the clamp
+    /// range is non-empty.
     ///
     /// [`is_enabled`]: Self::is_enabled
     fn effective_min_pattern_size(&self) -> usize {
@@ -96,7 +114,14 @@ impl LoopDetectionConfig {
         } else {
             self.min_pattern_size
         };
-        requested.clamp(1, self.max_pattern_size)
+        requested.clamp(1, self.effective_max_pattern_size())
+    }
+
+    /// Largest pattern size actually scanned: `max_pattern_size` capped at
+    /// [`MAX_EFFECTIVE_PATTERN_SIZE`]. This bounds the per-decode-step cost no
+    /// matter what a per-request or global override supplies.
+    fn effective_max_pattern_size(&self) -> usize {
+        self.max_pattern_size.min(MAX_EFFECTIVE_PATTERN_SIZE)
     }
 }
 
@@ -125,7 +150,7 @@ pub fn detect_repetition_loop(generated: &[i32], cfg: &LoopDetectionConfig) -> b
     let len = generated.len();
     let count = cfg.min_count;
     let min_p = cfg.effective_min_pattern_size();
-    let max_p = cfg.max_pattern_size;
+    let max_p = cfg.effective_max_pattern_size();
 
     for p in min_p..=max_p {
         // `window` grows monotonically with `p`, so once it exceeds the stream

--- a/src/lib/mlxcel-core/src/loop_detection_tests.rs
+++ b/src/lib/mlxcel-core/src/loop_detection_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{detect_repetition_loop, LoopDetectionConfig};
+use super::{detect_repetition_loop, LoopDetectionConfig, MAX_EFFECTIVE_PATTERN_SIZE};
 
 /// The conservative starting threshold the server applies for the Gemma 4
 /// amplifier case (`min_pattern_size=1, max_pattern_size=20, min_count=4`).
@@ -167,4 +167,64 @@ fn observed_cjk_collapse_shape_fires() {
     let mut stream: Vec<i32> = (100..160).collect();
     stream.extend(std::iter::repeat_n(255, 30));
     assert!(detect_repetition_loop(&stream, &recommended()));
+}
+
+// -- effective max_pattern_size cap (CPU-DoS guard) --
+//
+// `LoopDetectionConfig::new(1, <huge>, 2)` is exactly what BOTH untrusted
+// override surfaces produce: the per-request path (`loop_detection_from_request`,
+// from the OpenAI `max_pattern_size` chat field) and the global-env triple
+// (`MLXCEL_LOOP_DETECTION`). Neither clamps the value; the detector caps the
+// effective scan at `MAX_EFFECTIVE_PATTERN_SIZE`. These detector-level tests
+// therefore cover both override paths at once.
+
+#[test]
+fn huge_max_pattern_size_still_fires_and_terminates() {
+    // A per-request / global-env override with an unbounded max_pattern_size.
+    let cfg = LoopDetectionConfig::new(1, usize::MAX, 2);
+
+    // Still fires on a real short loop: a single token repeated many times.
+    let loop_stream = vec![9; 256];
+    assert!(detect_repetition_loop(&loop_stream, &cfg));
+
+    // Does NOT fire on a long strictly-increasing, non-repeating stream, and the
+    // scan terminates promptly (the cap bounds the work despite usize::MAX).
+    let non_repeating: Vec<i32> = (0..400).collect();
+    assert!(!detect_repetition_loop(&non_repeating, &cfg));
+}
+
+#[test]
+fn cap_bounds_detected_pattern_length() {
+    // Same huge max as the untrusted overrides; min set to the cap so only the
+    // capped pattern length is in range.
+    let cfg = LoopDetectionConfig::new(MAX_EFFECTIVE_PATTERN_SIZE, usize::MAX, 2);
+
+    // A pattern of length exactly MAX_EFFECTIVE_PATTERN_SIZE repeated min_count
+    // (2) times: this length is scanned, so it fires.
+    let block_at_cap: Vec<i32> = (0..MAX_EFFECTIVE_PATTERN_SIZE as i32).collect();
+    let mut at_cap = block_at_cap.clone();
+    at_cap.extend_from_slice(&block_at_cap);
+    assert!(detect_repetition_loop(&at_cap, &cfg));
+
+    // A pattern of length MAX_EFFECTIVE_PATTERN_SIZE + 1 repeated min_count (2)
+    // times: this length is beyond the cap and never scanned, so it does NOT
+    // fire even though the stream is a genuine two-times repeat.
+    let block_above_cap: Vec<i32> = (0..(MAX_EFFECTIVE_PATTERN_SIZE as i32 + 1)).collect();
+    let mut above_cap = block_above_cap.clone();
+    above_cap.extend_from_slice(&block_above_cap);
+    assert!(!detect_repetition_loop(&above_cap, &cfg));
+}
+
+#[test]
+fn min_pattern_size_above_cap_does_not_panic() {
+    // min_pattern_size well above the cap with a huge max_pattern_size: the min
+    // clamps down to the capped max, so the only scanned pattern size is the cap
+    // itself (p == MAX_EFFECTIVE_PATTERN_SIZE) and the range stays well-formed.
+    // A single-token loop shorter than that pattern's window
+    // (MAX_EFFECTIVE_PATTERN_SIZE * min_count) is below the scan window, so the
+    // detector breaks out without matching: it must return false without
+    // panicking (the guarantee here is no panic / well-formed range).
+    let cfg = LoopDetectionConfig::new(MAX_EFFECTIVE_PATTERN_SIZE + 100, usize::MAX, 2);
+    let single_token_loop = vec![3; MAX_EFFECTIVE_PATTERN_SIZE];
+    assert!(!detect_repetition_loop(&single_token_loop, &cfg));
 }

--- a/src/lib/mlxcel-core/src/loop_detection_tests.rs
+++ b/src/lib/mlxcel-core/src/loop_detection_tests.rs
@@ -1,0 +1,170 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{detect_repetition_loop, LoopDetectionConfig};
+
+/// The conservative starting threshold the server applies for the Gemma 4
+/// amplifier case (`min_pattern_size=1, max_pattern_size=20, min_count=4`).
+fn recommended() -> LoopDetectionConfig {
+    LoopDetectionConfig::new(1, 20, 4)
+}
+
+// -- enablement / disabled no-op --
+
+#[test]
+fn default_is_disabled() {
+    let cfg = LoopDetectionConfig::default();
+    assert!(!cfg.is_enabled());
+    assert_eq!(cfg, LoopDetectionConfig::disabled());
+}
+
+#[test]
+fn disabled_config_never_fires_even_on_obvious_loop() {
+    let stream = vec![7, 7, 7, 7, 7, 7, 7, 7];
+    assert!(!detect_repetition_loop(
+        &stream,
+        &LoopDetectionConfig::disabled()
+    ));
+    // max_pattern_size == 0 disables regardless of min_count.
+    assert!(!detect_repetition_loop(
+        &stream,
+        &LoopDetectionConfig::new(1, 0, 4)
+    ));
+}
+
+#[test]
+fn min_count_below_two_disables() {
+    let stream = vec![5, 5, 5, 5, 5, 5];
+    assert!(!LoopDetectionConfig::new(1, 20, 0).is_enabled());
+    assert!(!LoopDetectionConfig::new(1, 20, 1).is_enabled());
+    assert!(!detect_repetition_loop(
+        &stream,
+        &LoopDetectionConfig::new(1, 20, 1)
+    ));
+}
+
+// -- single-token loop boundary (p = 1) --
+
+#[test]
+fn single_token_loop_fires_at_exactly_min_count() {
+    let cfg = recommended(); // min_count = 4
+
+    // 3 repeats: below threshold, must not fire.
+    assert!(!detect_repetition_loop(&[9, 9, 9], &cfg));
+    // 3 repeats with unrelated prefix: still below threshold.
+    assert!(!detect_repetition_loop(&[1, 2, 9, 9, 9], &cfg));
+
+    // Exactly 4 repeats at the tail: fires.
+    assert!(detect_repetition_loop(&[9, 9, 9, 9], &cfg));
+    assert!(detect_repetition_loop(&[1, 2, 3, 9, 9, 9, 9], &cfg));
+
+    // 5 repeats: still fires (tail of 4 is all 9).
+    assert!(detect_repetition_loop(&[9, 9, 9, 9, 9], &cfg));
+}
+
+#[test]
+fn single_token_loop_requires_consecutive_tail() {
+    let cfg = recommended();
+    // Four 9s but interrupted: the tail is not four consecutive 9s.
+    assert!(!detect_repetition_loop(&[9, 9, 0, 9, 9], &cfg));
+    // Trailing non-loop token breaks the tail pattern.
+    assert!(!detect_repetition_loop(&[9, 9, 9, 9, 0], &cfg));
+}
+
+// -- multi-token loops (p = 2, 3) --
+
+#[test]
+fn two_token_loop_fires() {
+    let cfg = recommended();
+    // [3,4] repeated 4 times.
+    let stream = vec![3, 4, 3, 4, 3, 4, 3, 4];
+    assert!(detect_repetition_loop(&stream, &cfg));
+
+    // [3,4] repeated only 3 times: below min_count for p=2, and p=1 sees
+    // alternating tokens so it cannot fire either.
+    let below = vec![3, 4, 3, 4, 3, 4];
+    assert!(!detect_repetition_loop(&below, &cfg));
+}
+
+#[test]
+fn three_token_loop_fires_with_prefix() {
+    let cfg = recommended();
+    // unrelated prefix then [1,2,3] x4.
+    let stream = vec![8, 8, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3];
+    assert!(detect_repetition_loop(&stream, &cfg));
+}
+
+#[test]
+fn min_pattern_size_above_one_skips_single_token_loop() {
+    // Only scan p in 2..=3: a single-token loop must not trigger.
+    let cfg = LoopDetectionConfig::new(2, 3, 4);
+    assert!(!detect_repetition_loop(&[5, 5, 5, 5, 5, 5], &cfg));
+    // But a two-token loop still fires.
+    assert!(detect_repetition_loop(&[5, 6, 5, 6, 5, 6, 5, 6], &cfg));
+}
+
+// -- no false positives --
+
+#[test]
+fn non_repeating_stream_does_not_fire() {
+    let cfg = recommended();
+    let stream: Vec<i32> = (0..200).collect();
+    assert!(!detect_repetition_loop(&stream, &cfg));
+}
+
+#[test]
+fn empty_and_short_streams_do_not_fire() {
+    let cfg = recommended();
+    assert!(!detect_repetition_loop(&[], &cfg));
+    assert!(!detect_repetition_loop(&[1], &cfg));
+    assert!(!detect_repetition_loop(&[1, 1], &cfg));
+}
+
+#[test]
+fn natural_short_repeats_below_threshold_do_not_fire() {
+    let cfg = recommended();
+    // "the the the" style: token 42 appears 3 times, but not 4 in a row.
+    let stream = vec![10, 42, 11, 42, 12, 42, 13];
+    assert!(!detect_repetition_loop(&stream, &cfg));
+}
+
+// -- normalization rules --
+
+#[test]
+fn min_pattern_size_zero_treated_as_one() {
+    // min_pattern_size = 0 should behave like 1 and catch single-token loops.
+    let cfg = LoopDetectionConfig::new(0, 20, 4);
+    assert!(detect_repetition_loop(&[7, 7, 7, 7], &cfg));
+}
+
+#[test]
+fn min_pattern_size_clamped_to_max() {
+    // min_pattern_size (5) > max_pattern_size (3): clamp min down to 3 so the
+    // scan range stays well-formed (p in 3..=3) instead of being empty.
+    let cfg = LoopDetectionConfig::new(5, 3, 2);
+    // [1,2,3] repeated twice -> p=3 fires.
+    assert!(detect_repetition_loop(&[1, 2, 3, 1, 2, 3], &cfg));
+    // A two-token loop must not fire: p=2 is below the clamped min of 3, and
+    // [5,6,5,6,5,6] is not a single 3-token block repeated.
+    assert!(!detect_repetition_loop(&[5, 6, 5, 6, 5, 6], &cfg));
+}
+
+#[test]
+fn observed_cjk_collapse_shape_fires() {
+    // Mirrors the issue repro: a long clean prefix then a single garbage token
+    // (stand-in for `様`) repeating to fill the thinking budget.
+    let mut stream: Vec<i32> = (100..160).collect();
+    stream.extend(std::iter::repeat_n(255, 30));
+    assert!(detect_repetition_loop(&stream, &recommended()));
+}

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -4526,6 +4526,28 @@ impl BatchScheduler {
                 tracing::error!("State transition error: {err}");
             }
 
+            // Loop / repetition guard (issue #432): end early when the raw
+            // generated stream collapses into a short repeated pattern. Skip if
+            // the length limit already finished this sequence; the detector is
+            // a zero-overhead no-op when loop detection is disabled (default).
+            if !seq.state.is_finished()
+                && mlxcel_core::detect_repetition_loop(
+                    &seq.generated_tokens,
+                    &seq.sampling.loop_detection,
+                )
+            {
+                match seq
+                    .state
+                    .transition_to(SequenceState::Finished(FinishReason::RepetitionLoop))
+                {
+                    Ok(()) => tracing::info!(
+                        generated = seq.generated_tokens.len(),
+                        "loop detection: ending generation early (repetition loop)"
+                    ),
+                    Err(err) => tracing::error!("State transition error: {err}"),
+                }
+            }
+
             // Periodic cache clearing (matches Python mlx-lm which clears every 256)
             if seq.generated_tokens.len() % 256 == 0 {
                 mlxcel_core::clear_memory_cache();
@@ -4629,6 +4651,28 @@ impl BatchScheduler {
                     .transition_to(SequenceState::Finished(FinishReason::Length))
             {
                 tracing::error!("State transition error: {err}");
+            }
+
+            // Loop / repetition guard (issue #432): end early when the raw
+            // generated stream collapses into a short repeated pattern. Skip if
+            // the length limit already finished this sequence; the detector is
+            // a zero-overhead no-op when loop detection is disabled (default).
+            if !seq.state.is_finished()
+                && mlxcel_core::detect_repetition_loop(
+                    &seq.generated_tokens,
+                    &seq.sampling.loop_detection,
+                )
+            {
+                match seq
+                    .state
+                    .transition_to(SequenceState::Finished(FinishReason::RepetitionLoop))
+                {
+                    Ok(()) => tracing::info!(
+                        generated = seq.generated_tokens.len(),
+                        "loop detection: ending generation early (repetition loop)"
+                    ),
+                    Err(err) => tracing::error!("State transition error: {err}"),
+                }
             }
 
             // Periodic cache clearing (matches Python mlx-lm which clears every 256).
@@ -4799,6 +4843,28 @@ impl BatchScheduler {
             tracing::error!("State transition error: {err}");
         }
 
+        // Loop / repetition guard (issue #432): end early when the raw
+        // generated stream collapses into a short repeated pattern. Skip if the
+        // length limit already finished this sequence; the detector is a
+        // zero-overhead no-op when loop detection is disabled (default).
+        if !seq.state.is_finished()
+            && mlxcel_core::detect_repetition_loop(
+                &seq.generated_tokens,
+                &seq.sampling.loop_detection,
+            )
+        {
+            match seq
+                .state
+                .transition_to(SequenceState::Finished(FinishReason::RepetitionLoop))
+            {
+                Ok(()) => tracing::info!(
+                    generated = seq.generated_tokens.len(),
+                    "loop detection: ending generation early (repetition loop)"
+                ),
+                Err(err) => tracing::error!("State transition error: {err}"),
+            }
+        }
+
         // Periodic cache clearing (matches Python mlx-lm which clears every 256)
         if seq.generated_tokens.len() % 256 == 0 {
             mlxcel_core::clear_memory_cache();
@@ -4903,7 +4969,10 @@ impl BatchScheduler {
                 let healthy = matches!(
                     seq.state,
                     SequenceState::Finished(
-                        FinishReason::Stop | FinishReason::Length | FinishReason::Cancelled,
+                        FinishReason::Stop
+                            | FinishReason::Length
+                            | FinishReason::RepetitionLoop
+                            | FinishReason::Cancelled,
                     )
                 );
                 self.donate_finished_sequence_cache(

--- a/src/server/batch/sequence.rs
+++ b/src/server/batch/sequence.rs
@@ -126,6 +126,12 @@ pub enum FinishReason {
     Stop,
     /// `max_tokens` was reached.
     Length,
+    /// The N-gram loop detector tripped: the raw generated stream collapsed
+    /// into a short repeated pattern, so generation was ended early. Mapped to
+    /// the OpenAI `finish_reason` string `"stop"` (an early, non-error stop,
+    /// matching vLLM's behavior) by the completion result builder, which keys
+    /// the wire string off `completion_tokens < max_tokens`.
+    RepetitionLoop,
     /// The client disconnected or cancelled the request.
     Cancelled,
     /// An internal error occurred during generation.
@@ -141,7 +147,7 @@ impl SequenceState {
     /// Valid transitions:
     /// - `Queued -> Prefilling` (scheduler begins prefill)
     /// - `Prefilling -> Decoding` (prefill complete, enter decode loop)
-    /// - `Prefilling -> Finished(Stop | Length)` (completed on first token)
+    /// - `Prefilling -> Finished(Stop | Length | RepetitionLoop)` (completed on first token)
     /// - `Decoding -> Finished(*)` (normal completion)
     /// - `Decoding -> Queued` (preemptive eviction for re-prefill)
     /// - Any non-terminal state -> `Finished(Cancelled | Error)` (early abort)
@@ -152,6 +158,9 @@ impl SequenceState {
             (SequenceState::Prefilling, SequenceState::Decoding) => true,
             (SequenceState::Prefilling, SequenceState::Finished(FinishReason::Stop)) => true,
             (SequenceState::Prefilling, SequenceState::Finished(FinishReason::Length)) => true,
+            (SequenceState::Prefilling, SequenceState::Finished(FinishReason::RepetitionLoop)) => {
+                true
+            }
             (SequenceState::Decoding, SequenceState::Finished(_)) => true,
             // Preemptive eviction: a decoding sequence can be evicted and
             // re-queued for re-prefill.
@@ -400,6 +409,96 @@ mod tests {
                 .transition_to(SequenceState::Finished(FinishReason::Length))
                 .is_ok()
         );
+        assert!(matches!(
+            state,
+            SequenceState::Finished(FinishReason::Length)
+        ));
+    }
+
+    #[test]
+    fn valid_transition_decoding_to_finished_repetition_loop() {
+        let mut state = SequenceState::Decoding;
+        assert!(
+            state
+                .transition_to(SequenceState::Finished(FinishReason::RepetitionLoop))
+                .is_ok()
+        );
+        assert!(matches!(
+            state,
+            SequenceState::Finished(FinishReason::RepetitionLoop)
+        ));
+    }
+
+    #[test]
+    fn valid_transition_prefilling_to_finished_repetition_loop() {
+        let mut state = SequenceState::Prefilling;
+        assert!(
+            state
+                .transition_to(SequenceState::Finished(FinishReason::RepetitionLoop))
+                .is_ok()
+        );
+        assert!(matches!(
+            state,
+            SequenceState::Finished(FinishReason::RepetitionLoop)
+        ));
+    }
+
+    // -- decode-site loop-detection wiring --
+    //
+    // These replicate the exact guard the scheduler decode sites apply after
+    // pushing each token, driving the real `SequenceState` machine so the
+    // wiring (detector + transition), not just the pure helper, is exercised.
+
+    fn apply_loop_guard(
+        state: &mut SequenceState,
+        generated: &[i32],
+        cfg: &mlxcel_core::LoopDetectionConfig,
+    ) {
+        if !state.is_finished()
+            && mlxcel_core::detect_repetition_loop(generated, cfg)
+            && let Err(err) =
+                state.transition_to(SequenceState::Finished(FinishReason::RepetitionLoop))
+        {
+            panic!("unexpected transition error: {err}");
+        }
+    }
+
+    #[test]
+    fn degenerate_stream_finishes_with_repetition_loop() {
+        let cfg = mlxcel_core::LoopDetectionConfig::new(1, 20, 4);
+        let mut state = SequenceState::Decoding;
+        // Single-token collapse: token 5 repeated four times at the tail.
+        apply_loop_guard(&mut state, &[1, 2, 5, 5, 5, 5], &cfg);
+        assert!(matches!(
+            state,
+            SequenceState::Finished(FinishReason::RepetitionLoop)
+        ));
+    }
+
+    #[test]
+    fn below_threshold_stream_keeps_decoding() {
+        let cfg = mlxcel_core::LoopDetectionConfig::new(1, 20, 4);
+        let mut state = SequenceState::Decoding;
+        // Only three repeats: below min_count, sequence keeps decoding.
+        apply_loop_guard(&mut state, &[1, 2, 5, 5, 5], &cfg);
+        assert!(matches!(state, SequenceState::Decoding));
+    }
+
+    #[test]
+    fn disabled_loop_detection_keeps_decoding_on_obvious_loop() {
+        let cfg = mlxcel_core::LoopDetectionConfig::disabled();
+        let mut state = SequenceState::Decoding;
+        apply_loop_guard(&mut state, &[5, 5, 5, 5, 5, 5, 5, 5], &cfg);
+        assert!(matches!(state, SequenceState::Decoding));
+    }
+
+    #[test]
+    fn loop_guard_does_not_override_already_finished_length() {
+        let cfg = mlxcel_core::LoopDetectionConfig::new(1, 20, 4);
+        // Length limit fired first; the loop guard must not re-transition a
+        // finished sequence (the `is_finished()` precheck protects it).
+        let mut state = SequenceState::Finished(FinishReason::Length);
+        apply_loop_guard(&mut state, &[5, 5, 5, 5], &cfg);
         assert!(matches!(
             state,
             SequenceState::Finished(FinishReason::Length)

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -495,10 +495,11 @@ pub struct ServerConfig {
     pub loop_detection: Option<mlxcel_core::LoopDetectionConfig>,
 
     /// Whether the loaded model is in the Gemma 4 family (`Gemma4`,
-    /// `Gemma4VLM`, or `Gemma4Unified`), resolved once at startup. Gates the
-    /// loop-detection auto-enable for requests that carry the documented
-    /// amplifiers (tools or a `json_schema` response_format). Defaults to
-    /// `false` so non-Gemma-4 models keep the bit-exact baseline.
+    /// `Gemma4VLM`, or `Gemma4Unified`), resolved once at startup. Enables the
+    /// engine-level loop-detection default-on for the family, unconditionally:
+    /// it does not require tools or a `json_schema` response_format, so plain
+    /// Gemma 4 chat is covered too. Defaults to `false` so non-Gemma-4 models
+    /// keep the bit-exact baseline.
     pub model_is_gemma4_family: bool,
 }
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -485,6 +485,21 @@ pub struct ServerConfig {
     /// `--diffusion-threshold` (issue #217 phase 3). Confidence threshold for
     /// the confidence-threshold sampler. Only diffusion models read it.
     pub diffusion_threshold: f32,
+
+    /// Global N-gram loop-detection override (issue #432), resolved from the
+    /// `MLXCEL_LOOP_DETECTION` env var at startup. `None` means "operator did
+    /// not set a global override" so the per-family auto-enable policy applies;
+    /// `Some(cfg)` forces that configuration for every request (including an
+    /// explicitly disabled one), still overridable per-request. Precedence:
+    /// explicit request > this global override > family auto-enable > disabled.
+    pub loop_detection: Option<mlxcel_core::LoopDetectionConfig>,
+
+    /// Whether the loaded model is in the Gemma 4 family (`Gemma4`,
+    /// `Gemma4VLM`, or `Gemma4Unified`), resolved once at startup. Gates the
+    /// loop-detection auto-enable for requests that carry the documented
+    /// amplifiers (tools or a `json_schema` response_format). Defaults to
+    /// `false` so non-Gemma-4 models keep the bit-exact baseline.
+    pub model_is_gemma4_family: bool,
 }
 
 impl Default for ServerConfig {
@@ -550,6 +565,8 @@ impl Default for ServerConfig {
             max_denoising_steps: None,
             diffusion_sampler: "entropy-bound".to_string(),
             diffusion_threshold: 0.9,
+            loop_detection: None,
+            model_is_gemma4_family: false,
         }
     }
 }

--- a/src/server/request_options.rs
+++ b/src/server/request_options.rs
@@ -22,7 +22,16 @@ use super::{ServerConfig, ServerGenerateOptions};
 use crate::sampling::{ResolvedSamplingParams, build_sampling_config};
 use crate::server::batch::RequestPriority;
 use crate::server::config::ReasoningBudgetOverride;
+use mlxcel_core::LoopDetectionConfig;
 use mlxcel_core::sampling::LogprobsConfig;
+
+/// Conservative built-in loop-detection threshold (issue #432): scan
+/// single-token through 20-token tail patterns and end generation once any
+/// repeats four times. This is the engine-level default applied to the Gemma 4
+/// family (with no per-user configuration), and also the "force-enable"
+/// configuration for the `MLXCEL_LOOP_DETECTION` global override.
+pub(crate) const LOOP_DETECTION_RECOMMENDED: LoopDetectionConfig =
+    LoopDetectionConfig::new(1, 20, 4);
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct RequestOptionOverrides {
@@ -48,13 +57,69 @@ pub(crate) struct RequestOptionOverrides {
     /// chat endpoints) vs. takes a free-form prompt (false for raw text
     /// completion endpoints).
     pub thinking_enter_block_on_start: bool,
+    /// Explicit per-request loop-detection override (issue #432). `Some` when
+    /// the request set any of the vLLM `max_pattern_size` / `min_pattern_size`
+    /// / `min_count` fields; it then wins over the global override and the
+    /// family default-on. `None` lets the global override / family policy
+    /// decide.
+    pub loop_detection_request: Option<LoopDetectionConfig>,
+}
+
+/// Build a [`LoopDetectionConfig`] from the raw vLLM-style request fields.
+///
+/// Returns `None` when the request set none of the three fields (so the global
+/// override / family policy decides). Returns `Some` when any field is present,
+/// treating the request as authoritative, including an explicit disable
+/// (`max_pattern_size = 0`). Unset companions fall back to vLLM defaults (`0`),
+/// which the detector normalizes (`min_pattern_size 0 -> 1`, disabled when
+/// `max_pattern_size == 0` or `min_count < 2`).
+pub(crate) fn loop_detection_from_request(
+    max_pattern_size: Option<usize>,
+    min_pattern_size: Option<usize>,
+    min_count: Option<usize>,
+) -> Option<LoopDetectionConfig> {
+    if max_pattern_size.is_none() && min_pattern_size.is_none() && min_count.is_none() {
+        return None;
+    }
+    Some(LoopDetectionConfig::new(
+        min_pattern_size.unwrap_or(0),
+        max_pattern_size.unwrap_or(0),
+        min_count.unwrap_or(0),
+    ))
+}
+
+/// Resolve the effective loop-detection config for one request.
+///
+/// Precedence (highest first): explicit per-request override, global operator
+/// override (`MLXCEL_LOOP_DETECTION`, which may force-disable), the Gemma 4
+/// family engine-level default-on, otherwise disabled. The family default-on is
+/// unconditional (it does not require tools or a structured-output request);
+/// the issue selects this as the "Best" activation surface so a downstream
+/// serving app needs no configuration and end users see no toggle. Detection
+/// only ends generation when a real repetition loop is present, so a
+/// conservative default-on for this family is low risk.
+pub(crate) fn resolve_loop_detection(
+    request_override: Option<LoopDetectionConfig>,
+    global_override: Option<LoopDetectionConfig>,
+    family_default_on: bool,
+) -> LoopDetectionConfig {
+    if let Some(req) = request_override {
+        return req;
+    }
+    if let Some(global) = global_override {
+        return global;
+    }
+    if family_default_on {
+        return LOOP_DETECTION_RECOMMENDED;
+    }
+    LoopDetectionConfig::disabled()
 }
 
 pub(crate) fn build_server_generate_options(
     config: &ServerConfig,
     overrides: RequestOptionOverrides,
 ) -> ServerGenerateOptions {
-    let sampling = build_sampling_config(ResolvedSamplingParams {
+    let mut sampling = build_sampling_config(ResolvedSamplingParams {
         temperature: overrides.temperature.unwrap_or(config.default_temperature),
         top_k: overrides.top_k.unwrap_or(config.default_top_k),
         top_p: overrides.top_p.unwrap_or(config.default_top_p),
@@ -82,6 +147,17 @@ pub(crate) fn build_server_generate_options(
             .unwrap_or(config.default_presence_penalty),
         stop_token_ids: Vec::new(),
     });
+
+    // Loop-detection policy (issue #432) is resolved here, in the server
+    // control plane, where the loaded model family is visible. The Gemma 4
+    // family is default-on (engine-level, no per-user configuration); the
+    // shared `build_sampling_config` leaves the field disabled for everything
+    // else, preserving the bit-exact baseline.
+    sampling.loop_detection = resolve_loop_detection(
+        overrides.loop_detection_request,
+        config.loop_detection,
+        config.model_is_gemma4_family,
+    );
 
     ServerGenerateOptions {
         max_tokens: overrides.max_tokens.unwrap_or(config.default_max_tokens),

--- a/src/server/request_options_tests.rs
+++ b/src/server/request_options_tests.rs
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{RequestOptionOverrides, build_server_generate_options};
+use super::{
+    LOOP_DETECTION_RECOMMENDED, RequestOptionOverrides, build_server_generate_options,
+    loop_detection_from_request, resolve_loop_detection,
+};
 use crate::server::ServerConfig;
+use mlxcel_core::LoopDetectionConfig;
 
 #[test]
 fn build_server_generate_options_uses_server_defaults() {
@@ -61,6 +65,7 @@ fn build_server_generate_options_applies_request_overrides() {
             priority: crate::server::batch::RequestPriority::High,
             reasoning_budget: crate::server::config::ReasoningBudgetOverride::default(),
             thinking_enter_block_on_start: true,
+            loop_detection_request: None,
         },
     );
 
@@ -79,4 +84,149 @@ fn build_server_generate_options_applies_request_overrides() {
     assert_eq!(options.sampling.dry_penalty_last_n, 17);
     assert_eq!(options.sampling.dry_sequence_breakers, Vec::<i32>::new());
     assert_eq!(options.stop_sequences, Some(vec!["stop".to_string()]));
+}
+
+// -- loop detection (issue #432) --
+
+#[test]
+fn loop_detection_disabled_by_default_for_non_gemma() {
+    // Default config is a non-Gemma model: loop detection stays disabled so the
+    // bit-exact baseline is preserved.
+    let config = ServerConfig::default();
+    let options = build_server_generate_options(&config, RequestOptionOverrides::default());
+    assert!(!options.sampling.loop_detection.is_enabled());
+}
+
+#[test]
+fn loop_detection_from_request_none_when_no_fields() {
+    assert_eq!(loop_detection_from_request(None, None, None), None);
+}
+
+#[test]
+fn loop_detection_from_request_some_when_any_field_set() {
+    // Even an explicit disable (max_pattern_size = 0) is authoritative.
+    let only_disable = loop_detection_from_request(Some(0), None, None);
+    assert_eq!(only_disable, Some(LoopDetectionConfig::new(0, 0, 0)));
+    assert!(!only_disable.unwrap().is_enabled());
+
+    let full = loop_detection_from_request(Some(20), Some(1), Some(4));
+    assert_eq!(full, Some(LoopDetectionConfig::new(1, 20, 4)));
+}
+
+#[test]
+fn resolve_loop_detection_precedence() {
+    let req = LoopDetectionConfig::new(2, 5, 3);
+    let global = LoopDetectionConfig::new(1, 10, 6);
+
+    // Explicit request wins over everything, including the family default-on.
+    assert_eq!(
+        resolve_loop_detection(Some(req), Some(global), true),
+        req,
+        "explicit request beats global and family"
+    );
+
+    // Global override beats the family default-on (and may force-disable).
+    assert_eq!(resolve_loop_detection(None, Some(global), true), global);
+    let forced_off = LoopDetectionConfig::disabled();
+    assert_eq!(
+        resolve_loop_detection(None, Some(forced_off), true),
+        forced_off,
+        "operator can force-disable even for the Gemma 4 family"
+    );
+
+    // Gemma 4 family default-on applies unconditionally when nothing else is set.
+    assert_eq!(
+        resolve_loop_detection(None, None, true),
+        LOOP_DETECTION_RECOMMENDED
+    );
+
+    // Disabled baseline for non-family models when nothing applies.
+    assert_eq!(
+        resolve_loop_detection(None, None, false),
+        LoopDetectionConfig::disabled()
+    );
+}
+
+#[test]
+fn gemma4_family_auto_enables_by_default_without_amplifier() {
+    let config = ServerConfig {
+        model_is_gemma4_family: true,
+        ..Default::default()
+    };
+
+    // A plain Gemma 4 chat with no tools and no response_format still gets
+    // detection enabled by default (the "Best" engine-level activation surface).
+    let plain = build_server_generate_options(&config, RequestOptionOverrides::default());
+    assert_eq!(plain.sampling.loop_detection, LOOP_DETECTION_RECOMMENDED);
+    assert!(plain.sampling.loop_detection.is_enabled());
+}
+
+#[test]
+fn non_gemma4_family_stays_disabled_by_default() {
+    let config = ServerConfig::default(); // model_is_gemma4_family = false
+    let options = build_server_generate_options(&config, RequestOptionOverrides::default());
+    assert!(!options.sampling.loop_detection.is_enabled());
+}
+
+#[test]
+fn explicit_request_disable_overrides_family_default_on() {
+    let config = ServerConfig {
+        model_is_gemma4_family: true,
+        ..Default::default()
+    };
+
+    // A per-request explicit disable (max_pattern_size = 0) must win over the
+    // Gemma 4 family default-on.
+    let options = build_server_generate_options(
+        &config,
+        RequestOptionOverrides {
+            loop_detection_request: loop_detection_from_request(Some(0), None, None),
+            ..Default::default()
+        },
+    );
+    assert!(!options.sampling.loop_detection.is_enabled());
+}
+
+#[test]
+fn explicit_request_tune_overrides_family_default_on() {
+    let config = ServerConfig {
+        model_is_gemma4_family: true,
+        ..Default::default()
+    };
+
+    // A per-request tune wins over the family default-on threshold.
+    let tuned = loop_detection_from_request(Some(8), Some(2), Some(3));
+    let options = build_server_generate_options(
+        &config,
+        RequestOptionOverrides {
+            loop_detection_request: tuned,
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        options.sampling.loop_detection,
+        LoopDetectionConfig::new(2, 8, 3)
+    );
+}
+
+#[test]
+fn global_override_applies_to_non_gemma4() {
+    let config = ServerConfig {
+        loop_detection: Some(LOOP_DETECTION_RECOMMENDED),
+        ..Default::default()
+    };
+    let options = build_server_generate_options(&config, RequestOptionOverrides::default());
+    assert_eq!(options.sampling.loop_detection, LOOP_DETECTION_RECOMMENDED);
+}
+
+#[test]
+fn global_override_can_force_disable_gemma4() {
+    // An operator can globally force-disable even for the Gemma 4 family.
+    let config = ServerConfig {
+        model_is_gemma4_family: true,
+        loop_detection: Some(LoopDetectionConfig::disabled()),
+        ..Default::default()
+    };
+    let options = build_server_generate_options(&config, RequestOptionOverrides::default());
+    assert!(!options.sampling.loop_detection.is_enabled());
 }

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -1017,6 +1017,13 @@ fn extract_reasoning_content(raw_text: &str, primed_open_thinking: bool) -> Opti
 }
 
 /// Build ServerGenerateOptions using request params with server config as defaults
+///
+/// The explicit per-request loop-detection override is read from `params` (the
+/// vLLM `max_pattern_size` / `min_pattern_size` / `min_count` fields, issue
+/// #432). The Gemma 4 family default-on is applied engine-side from the loaded
+/// model type in
+/// [`crate::server::request_options::build_server_generate_options`], so callers
+/// pass no amplifier signal.
 pub(crate) fn build_generate_options(
     params: &SamplingParams,
     config: &ServerConfig,
@@ -1051,6 +1058,11 @@ pub(crate) fn build_generate_options(
             // scheduler matches the actual prompt tail (Qwen `<think>\n`,
             // Gemma 4 `<|channel>thought\n`, or neither).
             thinking_enter_block_on_start: false,
+            loop_detection_request: crate::server::request_options::loop_detection_from_request(
+                params.max_pattern_size,
+                params.min_pattern_size,
+                params.min_count,
+            ),
         },
     )
 }

--- a/src/server/routes/native_completion.rs
+++ b/src/server/routes/native_completion.rs
@@ -268,6 +268,11 @@ fn build_native_generate_options(
             // responsible for priming `<think>` in the prompt if they want
             // in-block counting to start at the first decoded token.
             thinking_enter_block_on_start: false,
+            // The native `/completion` endpoint has no per-request
+            // loop-detection field. The Gemma 4 family default-on and the
+            // global `MLXCEL_LOOP_DETECTION` override still apply engine-side
+            // via `resolve_loop_detection`.
+            loop_detection_request: None,
         },
     )
 }

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -895,7 +895,68 @@ pub(super) fn build_server_config(
         max_denoising_steps: startup.max_denoising_steps,
         diffusion_sampler: startup.diffusion_sampler.clone(),
         diffusion_threshold: startup.diffusion_threshold,
+        // Global loop-detection override (issue #432) from `MLXCEL_LOOP_DETECTION`.
+        // `None` means the per-family auto-enable policy applies.
+        loop_detection: resolve_loop_detection_env(),
+        // Whether the loaded model is in the Gemma 4 family, used to gate the
+        // loop-detection auto-enable on the documented amplifiers.
+        model_is_gemma4_family: detect_gemma4_family(&startup.model_path),
     }
+}
+
+/// Whether `model_path` loads a Gemma 4 family model (`Gemma4`, `Gemma4VLM`, or
+/// `Gemma4Unified`). Used to gate the issue #432 loop-detection auto-enable. A
+/// detection error (unreadable config) returns `false`, preserving the baseline.
+fn detect_gemma4_family(model_path: &Path) -> bool {
+    use crate::models::ModelType;
+    matches!(
+        crate::models::get_model_type(model_path),
+        Ok(ModelType::Gemma4 | ModelType::Gemma4VLM | ModelType::Gemma4Unified)
+    )
+}
+
+/// Parse the `MLXCEL_LOOP_DETECTION` global override (issue #432).
+///
+/// Accepted values (case-insensitive):
+/// - unset / empty: `None` (the per-family auto-enable policy applies).
+/// - `off` / `0` / `none` / `false` / `disabled`: force-disable for every
+///   request (`Some(disabled)`), still overridable per request.
+/// - `on` / `default` / `true` / `enabled`: force the recommended threshold
+///   (`min=1, max=20, count=4`).
+/// - `MIN,MAX,COUNT` or `MIN:MAX:COUNT`: an explicit triple, e.g. `1,20,4`.
+///
+/// A malformed value warns and returns `None` so a typo does not silently
+/// change generation behavior.
+fn resolve_loop_detection_env() -> Option<mlxcel_core::LoopDetectionConfig> {
+    let raw = std::env::var("MLXCEL_LOOP_DETECTION").ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    match trimmed.to_ascii_lowercase().as_str() {
+        "off" | "0" | "none" | "false" | "disabled" => {
+            return Some(mlxcel_core::LoopDetectionConfig::disabled());
+        }
+        "on" | "default" | "true" | "enabled" => {
+            return Some(crate::server::request_options::LOOP_DETECTION_RECOMMENDED);
+        }
+        _ => {}
+    }
+    let parts: Vec<&str> = trimmed.split([',', ':']).map(str::trim).collect();
+    if parts.len() == 3
+        && let (Ok(min), Ok(max), Ok(count)) = (
+            parts[0].parse::<usize>(),
+            parts[1].parse::<usize>(),
+            parts[2].parse::<usize>(),
+        )
+    {
+        return Some(mlxcel_core::LoopDetectionConfig::new(min, max, count));
+    }
+    tracing::warn!(
+        "MLXCEL_LOOP_DETECTION=\"{raw}\" is not valid; expected off/on or MIN,MAX,COUNT \
+         (e.g. 1,20,4). Ignoring."
+    );
+    None
 }
 
 fn initialize_server_logging(startup: &ServerStartupConfig) -> Result<()> {

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -898,8 +898,9 @@ pub(super) fn build_server_config(
         // Global loop-detection override (issue #432) from `MLXCEL_LOOP_DETECTION`.
         // `None` means the per-family auto-enable policy applies.
         loop_detection: resolve_loop_detection_env(),
-        // Whether the loaded model is in the Gemma 4 family, used to gate the
-        // loop-detection auto-enable on the documented amplifiers.
+        // Whether the loaded model is in the Gemma 4 family, used to turn on
+        // the loop-detection default-on for the family unconditionally (not
+        // gated on tools or a `json_schema` response_format).
         model_is_gemma4_family: detect_gemma4_family(&startup.model_path),
     }
 }

--- a/src/server/startup_tests.rs
+++ b/src/server/startup_tests.rs
@@ -18,9 +18,10 @@ use super::{
     MIN_PARALLEL_CONTEXT_SIZE, ServerStartupConfig, build_server_config,
     detect_model_media_support, effective_parallel_context_slots, resolve_api_key,
     resolve_chat_template, resolve_decode_storage_backend, resolve_default_max_tokens,
-    resolve_dry_penalty_last_n, resolve_parallel_context_size, resolve_remote_pipeline_topology,
-    resolve_tensor_parallel_runtime_support, validate_parallel_context_startup,
-    validate_pipeline_parallel_startup, validate_tensor_parallel_startup,
+    resolve_dry_penalty_last_n, resolve_loop_detection_env, resolve_parallel_context_size,
+    resolve_remote_pipeline_topology, resolve_tensor_parallel_runtime_support,
+    validate_parallel_context_startup, validate_pipeline_parallel_startup,
+    validate_tensor_parallel_startup,
 };
 use crate::distributed::{ClusterConfig, TransportBackend};
 use crate::server::chat_template::ChatMessage;
@@ -1167,4 +1168,92 @@ fn startup_passes_strict_allowlist_dir() {
 
     std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
     std::fs::remove_dir_all(dir).unwrap();
+}
+
+// -- MLXCEL_LOOP_DETECTION env parser (issue #432) --
+
+/// Run `resolve_loop_detection_env` with `MLXCEL_LOOP_DETECTION` temporarily
+/// set to `value` (or unset when `None`), then restore the original.
+fn with_loop_detection_env<F, R>(value: Option<&str>, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let _guard = env_lock();
+    let key = "MLXCEL_LOOP_DETECTION";
+    let prev = std::env::var_os(key);
+    // SAFETY: serialized via the crate-wide ENV_LOCK acquired above.
+    match value {
+        Some(v) => unsafe { std::env::set_var(key, v) },
+        None => unsafe { std::env::remove_var(key) },
+    }
+    let result = f();
+    // SAFETY: serialized via the crate-wide ENV_LOCK acquired above.
+    match prev {
+        Some(v) => unsafe { std::env::set_var(key, v) },
+        None => unsafe { std::env::remove_var(key) },
+    }
+    result
+}
+
+#[test]
+fn loop_detection_env_unset_returns_none() {
+    let result = with_loop_detection_env(None, resolve_loop_detection_env);
+    assert!(result.is_none());
+}
+
+#[test]
+fn loop_detection_env_off_keywords_force_disable() {
+    use mlxcel_core::LoopDetectionConfig;
+    for kw in &["off", "OFF", "0", "none", "false", "disabled"] {
+        let result = with_loop_detection_env(Some(kw), resolve_loop_detection_env);
+        assert!(
+            result.is_some(),
+            "expected Some(disabled) for keyword {kw:?}"
+        );
+        assert_eq!(
+            result.unwrap(),
+            LoopDetectionConfig::disabled(),
+            "expected disabled config for keyword {kw:?}"
+        );
+    }
+}
+
+#[test]
+fn loop_detection_env_on_keywords_force_recommended() {
+    use crate::server::request_options::LOOP_DETECTION_RECOMMENDED;
+    for kw in &["on", "ON", "default", "true", "enabled"] {
+        let result = with_loop_detection_env(Some(kw), resolve_loop_detection_env);
+        assert_eq!(
+            result,
+            Some(LOOP_DETECTION_RECOMMENDED),
+            "expected recommended config for keyword {kw:?}"
+        );
+    }
+}
+
+#[test]
+fn loop_detection_env_comma_triple_parsed() {
+    use mlxcel_core::LoopDetectionConfig;
+    let result = with_loop_detection_env(Some("2,30,5"), resolve_loop_detection_env);
+    assert_eq!(result, Some(LoopDetectionConfig::new(2, 30, 5)));
+}
+
+#[test]
+fn loop_detection_env_colon_triple_parsed() {
+    use mlxcel_core::LoopDetectionConfig;
+    let result = with_loop_detection_env(Some("1:20:4"), resolve_loop_detection_env);
+    assert_eq!(result, Some(LoopDetectionConfig::new(1, 20, 4)));
+}
+
+#[test]
+fn loop_detection_env_malformed_returns_none() {
+    let result = with_loop_detection_env(Some("not_a_valid_value"), resolve_loop_detection_env);
+    assert!(result.is_none());
+}
+
+#[test]
+fn loop_detection_env_wrong_field_count_returns_none() {
+    // Four fields is not a valid triple.
+    let result = with_loop_detection_env(Some("1,20,4,extra"), resolve_loop_detection_env);
+    assert!(result.is_none());
 }

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -384,6 +384,18 @@ pub struct SamplingParams {
     /// Presence penalty (0.0 = disabled) - penalizes based on presence
     pub presence_penalty: Option<f32>,
 
+    // vLLM-compatible N-gram repetition / loop detection. When any of the three
+    // is present the request is authoritative and overrides server defaults and
+    // family auto-enable (see `request_options::resolve_loop_detection`). Field
+    // names match vLLM's `SamplingParams` for client compatibility.
+    /// Largest N-gram pattern size to scan (`0` disables detection).
+    pub max_pattern_size: Option<usize>,
+    /// Smallest N-gram pattern size to scan (`0` is treated as `1`).
+    pub min_pattern_size: Option<usize>,
+    /// Minimum consecutive repeats of a pattern that ends generation early
+    /// (must be `>= 2`).
+    pub min_count: Option<usize>,
+
     // thinking-token budget (Qwen3-family reasoning cap).
     //
     // Three aliases accepted, first non-None wins (see


### PR DESCRIPTION
## Summary

Adds vLLM-style N-gram repetition / loop detection that ends a generation early when the raw generated token stream collapses into a short repeated pattern, and turns it on by default for the Gemma 4 family. This breaks the upstream, weights-level Gemma 4 token-repetition collapse (google-deepmind/gemma#622, vllm-project/vllm#40080) where generation degenerates into a single repeated token or short fragment that fills the token budget, most often inside the thought channel and amplified by tool declarations or grammar-constrained decoding. Sampling penalties (repeat_penalty, DRY) cannot recover once the logits collapse, so distribution shaping is not enough; this is a stop condition on the raw stream instead.

## Design

The detector is generic and model-family agnostic; the activation policy lives in the server control plane.

- `mlxcel-core` gains a `loop_detection` module: `LoopDetectionConfig` (vLLM field names `max_pattern_size` / `min_pattern_size` / `min_count`, all default `0` = disabled) and the pure, unit-testable `detect_repetition_loop(generated, cfg)`. For each pattern size `p` in `min_pattern_size..=max_pattern_size` it checks whether the last `p * min_count` tokens are a single `p`-length block repeated `min_count` times. This catches single-token loops (`p=1`) and short multi-token loops (`p=2,3,...`). It runs only when enabled, so a model that does not opt in pays nothing.
- `SamplingConfig` gains a `loop_detection: LoopDetectionConfig` field defaulting to a zero-overhead no-op, mirroring how `token_bias` / `stop_token_ids` preserve the bit-exact baseline.
- The detector is invoked at every decode stop site (the four decode loops in `generate.rs` and the three scheduler decode paths) right after each token is pushed to `generated_tokens`, alongside the existing eos/length checks, so it also catches loops inside the reasoning channel and tool-call JSON, not just the final answer. A new `FinishReason::RepetitionLoop` is added with its `SequenceState` transitions; the OpenAI wire `finish_reason` stays `"stop"` (an early, non-error stop, matching vLLM), and the scheduler logs an info line when it fires.

## Activation policy (issue "Preferred activation surface")

Default-on for the Gemma 4 family with no configuration required, implemented in `request_options::resolve_loop_detection` (the server request to SamplingConfig assembly), keyed off the loaded model type resolved once at startup (`ModelType::Gemma4 | Gemma4VLM | Gemma4Unified`). Precedence, highest first:

1. Explicit per-request fields (`max_pattern_size` / `min_pattern_size` / `min_count` on the OpenAI chat `SamplingParams`); a client may tune or disable (set `max_pattern_size=0`) but never has to send anything.
2. Global operator override `MLXCEL_LOOP_DETECTION` (off / on / `MIN,MAX,COUNT`), usable on any model to force-enable, tune, or force-disable.
3. Gemma 4 family default-on with the conservative built-in threshold `min_pattern_size=1, max_pattern_size=20, min_count=4`, unconditional (does not require tools or a structured-output request, so plain Gemma 4 chat is covered).
4. Disabled for every non-Gemma-4 model, preserving the exact baseline output.

## What changed

- `src/lib/mlxcel-core/src/loop_detection.rs` (new) + `loop_detection_tests.rs` (new): generic detector and config, with thorough unit tests.
- `src/lib/mlxcel-core/src/generate.rs`, `lib.rs`: `SamplingConfig.loop_detection` field, re-exports, and the detector call at all four decode loops.
- `src/server/batch/sequence.rs`: `FinishReason::RepetitionLoop` + transition-table entries + integration-style tests that drive the real scheduler guard to the new finish reason.
- `src/server/batch/scheduler.rs`: the loop guard at the three decode paths plus an info log when it fires; `RepetitionLoop` treated as a healthy cache-donation finish.
- `src/server/request_options.rs` (+ tests), `config.rs`, `startup.rs`: the resolution helper, the `loop_detection` global override (`MLXCEL_LOOP_DETECTION`), and the `model_is_gemma4_family` startup flag.
- `src/server/types/request.rs`, `src/server/routes/chat.rs`, `src/server/routes/native_completion.rs`, `src/execution/sampling.rs`, `src/distributed/disaggregated/serving_protocol.rs`: thread the new fields through the request and sampling-config surfaces (the disaggregated handoff keeps the disabled baseline; serializing the config across the prefill/decode split is a noted follow-up).
- `docs/environment-variables.md`, `docs/supported-models.md`: document the params, the default-on policy, the override surfaces, and the precedence.

## Test plan

- [x] `cargo test -p mlxcel-core --lib loop_detection::` (14 passed): detector boundaries (fires at exactly `min_count`, not before; multi-token loops; clamp / normalization; disabled no-op).
- [x] `cargo test --lib server::request_options` (12 passed): resolution precedence, family default-on without amplifier, non-Gemma disabled, per-request and global overrides.
- [x] `cargo test --lib server::batch::sequence` (30 passed): includes a deterministic integration test that drives the real scheduler stop guard (`detect_repetition_loop` + `transition_to`) to `FinishReason::RepetitionLoop`.
- [x] `cargo check --lib --tests` and `cargo clippy --lib --tests -- -D warnings` clean; `cargo fmt` applied.
- [x] Real-model smoke on `models/gemma-4-e2b-it-qat-4bit` (release `mlxcel-server`, `--jinja --parallel 1`):
  - (a) Family default-on, no per-request loop fields and no tools: a forced repeated tail ended early with `finish_reason=stop`, `completion_tokens=173` of 300, and the server logged `loop detection: ending generation early (repetition loop) generated=173`. A normal tool-laden generation completed coherently (no regression).
  - (b) Non-Gemma `models/qwen3-0.6b-4bit`, same prompt: detection disabled by default, ran to `finish_reason=length` (300 tokens), no firing. Baseline preserved.
  - (c) Gemma 4 with per-request `max_pattern_size: 0`: detection disabled even for the family, ran to `finish_reason=length` (300 tokens), no firing. Override precedence confirmed.

Closes #432
