### PR TITLE
feat: wire Nemotron-H Nano Omni input_audio into server chat audio

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -82,7 +82,7 @@ Implemented VLM variants include:
 - Moondream 3
 - Phi-3 Vision, Phi4MM, Phi4 SigLIP VLM
 - Molmo2 and Molmo-Point
-- Nemotron-H Nano Omni
+- Nemotron-H Nano Omni: ships a Conformer/Parakeet audio encoder and accepts spoken audio from the CLI with `--audio <path>`. Input audio is resampled to 16 kHz before the encoder. Server-side `input_audio` in `POST /v1/chat/completions` is also supported: the audio block is spliced inside the last user turn, before the `<|im_end|>` end-of-turn marker that the ChatML template uses (id 151 in the released checkpoint).
 
 Audio/video capability is model-specific. The server request types include
 `image_url`, `video_url`, and `input_audio` content blocks, but a loaded model

--- a/src/multimodal/vlm_runtime.rs
+++ b/src/multimodal/vlm_runtime.rs
@@ -1174,8 +1174,8 @@ pub fn expand_gemma4_audio_tokens_for_server(
 ///    place as `sound_start? + sound_context * N + sound_end?`.
 /// 2. Otherwise splice the block before the last end-of-turn token (the
 ///    Nemotron ChatML template closes every turn with `<|im_end|>`), so it
-///    lands inside the last user turn rather than the open assistant turn —
-///    placing it in the assistant turn forces an immediate EOS at prefill
+///    lands inside the last user turn rather than the open assistant turn.
+///    Placing it in the assistant turn forces an immediate EOS at prefill
 ///    (issue #437 class).
 /// 3. Failing that (no end-of-turn id, or none in the prompt), fall back to
 ///    inserting before the final token.

--- a/src/multimodal/vlm_runtime.rs
+++ b/src/multimodal/vlm_runtime.rs
@@ -1162,6 +1162,140 @@ pub fn expand_gemma4_audio_tokens_for_server(
     }
 }
 
+/// Place the Nemotron H Nano Omni sound-context block in the server prompt.
+///
+/// The server renders chat messages text-only (see
+/// `chat_request::build_chat_messages_with_thinking`, which keeps only
+/// `content.text()`), so an `input_audio` request produces a prompt with no
+/// `<so_embedding>` (`sound_context_token_id`) marker. This is the audio
+/// analogue of [`expand_gemma4_audio_tokens_for_server`]:
+///
+/// 1. If the rendered placeholder is present, wrap its first occurrence in
+///    place as `sound_start? + sound_context * N + sound_end?`.
+/// 2. Otherwise splice the block before the last end-of-turn token (the
+///    Nemotron ChatML template closes every turn with `<|im_end|>`), so it
+///    lands inside the last user turn rather than the open assistant turn —
+///    placing it in the assistant turn forces an immediate EOS at prefill
+///    (issue #437 class).
+/// 3. Failing that (no end-of-turn id, or none in the prompt), fall back to
+///    inserting before the final token.
+///
+/// Unlike the Gemma helper, the start/end framing tokens are emitted only when
+/// non-zero, matching the CLI expander `expand_nemotron_h_nano_omni_audio_tokens`
+/// (the released checkpoint surfaces no sound framing tokens, so both default to
+/// `0`, which means "no framing token in the stream").
+pub fn expand_nemotron_h_nano_omni_audio_tokens_for_server(
+    prompt_tokens: &mut Vec<i32>,
+    sound_context_token_id: i32,
+    sound_start_token_id: i32,
+    sound_end_token_id: i32,
+    num_audio_tokens: usize,
+    end_of_turn_token_id: Option<i32>,
+) {
+    let build_block = || {
+        let mut block = Vec::with_capacity(num_audio_tokens + 2);
+        if sound_start_token_id != 0 {
+            block.push(sound_start_token_id);
+        }
+        block.extend(std::iter::repeat_n(
+            sound_context_token_id,
+            num_audio_tokens,
+        ));
+        if sound_end_token_id != 0 {
+            block.push(sound_end_token_id);
+        }
+        block
+    };
+
+    // 1. Wrap a rendered `<so_embedding>` placeholder in place.
+    if prompt_tokens.contains(&sound_context_token_id) {
+        let mut expanded = Vec::with_capacity(prompt_tokens.len() + num_audio_tokens + 2);
+        let mut found = false;
+        for &token in prompt_tokens.iter() {
+            if token == sound_context_token_id && !found {
+                found = true;
+                expanded.extend(build_block());
+            } else {
+                expanded.push(token);
+            }
+        }
+        *prompt_tokens = expanded;
+        return;
+    }
+
+    // 2. Insert inside the last user turn (before its closing `<|im_end|>`).
+    if let Some(eot) = end_of_turn_token_id
+        && let Some(pos) = prompt_tokens.iter().rposition(|&token| token == eot)
+    {
+        prompt_tokens.splice(pos..pos, build_block());
+        return;
+    }
+
+    // 3. Last resort: insert before the final token.
+    let last = prompt_tokens.pop();
+    prompt_tokens.extend(build_block());
+    if let Some(tok) = last {
+        prompt_tokens.push(tok);
+    }
+}
+
+/// Expand Nemotron H Nano Omni image placeholders for the server path.
+///
+/// Mirrors the image-only runtime expansion in
+/// [`prepare_and_compute_vlm_embeddings`] (the `VlmRuntimeRef::NemotronHNanoOmni`
+/// arm) so a combined image + audio chat request produces the same image-token
+/// stream as an image-only request. When the text-only server prompt carries no
+/// `img_context_token_id` marker, one block per image is prepended; otherwise
+/// each placeholder is expanded in order. Framing tokens are emitted only when
+/// non-zero.
+pub fn expand_nemotron_h_nano_omni_image_tokens_for_server(
+    prompt_tokens: &mut Vec<i32>,
+    img_context_token_id: i32,
+    image_start_token_id: i32,
+    image_end_token_id: i32,
+    images: &[crate::vision::processors::nemotron_h_nano_omni::NemotronHNanoOmniImageInput],
+) {
+    let mut expanded = Vec::with_capacity(
+        prompt_tokens.len() + images.iter().map(|img| img.num_tokens + 2).sum::<usize>(),
+    );
+    let has_placeholder = prompt_tokens.contains(&img_context_token_id);
+
+    if !has_placeholder {
+        for image in images.iter() {
+            if image_start_token_id != 0 {
+                expanded.push(image_start_token_id);
+            }
+            for _ in 0..image.num_tokens {
+                expanded.push(img_context_token_id);
+            }
+            if image_end_token_id != 0 {
+                expanded.push(image_end_token_id);
+            }
+        }
+        expanded.extend_from_slice(prompt_tokens);
+    } else {
+        let mut image_idx = 0usize;
+        for &token in prompt_tokens.iter() {
+            if token == img_context_token_id && image_idx < images.len() {
+                let image = &images[image_idx];
+                if image_start_token_id != 0 {
+                    expanded.push(image_start_token_id);
+                }
+                for _ in 0..image.num_tokens {
+                    expanded.push(img_context_token_id);
+                }
+                if image_end_token_id != 0 {
+                    expanded.push(image_end_token_id);
+                }
+                image_idx += 1;
+            } else {
+                expanded.push(token);
+            }
+        }
+    }
+    *prompt_tokens = expanded;
+}
+
 #[cfg(test)]
 #[path = "vlm_runtime_tests.rs"]
 mod tests;

--- a/src/multimodal/vlm_runtime_tests.rs
+++ b/src/multimodal/vlm_runtime_tests.rs
@@ -15,8 +15,8 @@
 use super::{
     VlmPreparationSummary, expand_gemma4_audio_tokens_for_server,
     expand_gemma4_unified_video_tokens, expand_gemma4_video_tokens,
-    format_molmo_v1_prompt_for_processor, prepared_embedding_refs,
-    shift_molmo_v1_image_input_idx_for_bos, should_prepare_vlm_embeddings,
+    expand_nemotron_h_nano_omni_audio_tokens_for_server, format_molmo_v1_prompt_for_processor,
+    prepared_embedding_refs, shift_molmo_v1_image_input_idx_for_bos, should_prepare_vlm_embeddings,
 };
 use crate::vision::merge::InputEmbeddings;
 use crate::vlm_prompt::{ImageTokenBlockAction, ImageTokenBlockStats};
@@ -301,4 +301,104 @@ fn server_audio_falls_back_when_end_of_turn_absent_from_prompt() {
     let mut prompt = vec![2, 11, 8];
     expand_gemma4_audio_tokens_for_server(&mut prompt, AUDIO, BOA, EOA, 2, Some(EOT));
     assert_eq!(prompt, vec![2, 11, BOA, AUDIO, AUDIO, EOA, 8]);
+}
+
+// -- Nemotron H Nano Omni server audio token placement -----------------------
+//
+// Token ids mirror the released `nemotron-3-nano-omni-30b-a3b-reasoning-4bit`
+// checkpoint: `<so_embedding>` (sound_context) = 27, `<|im_start|>` = 10,
+// `<|im_end|>` = 11. The released checkpoint surfaces no sound framing tokens,
+// so sound_start / sound_end default to 0 (no framing token in the stream).
+const SO_CTX: i32 = 27; // sound_context_token_id (<so_embedding>)
+const IM_START: i32 = 10; // <|im_start|>
+const IM_END: i32 = 11; // <|im_end|> (Nemotron ChatML end-of-turn)
+
+#[test]
+fn nemotron_server_audio_inserts_inside_last_user_turn() {
+    // ChatML prompt with no rendered `<so_embedding>` (server flattens chat to
+    // text-only). The block must land before the user turn's closing
+    // `<|im_end|>`, not after the open assistant generation prompt, or the
+    // model EOSes at prefill (issue #437 class).
+    // [<|im_start|>, "user", text, <|im_end|>, <|im_start|>, "assistant", <think>]
+    let mut prompt = vec![IM_START, 100, 7, IM_END, IM_START, 101, 102];
+    expand_nemotron_h_nano_omni_audio_tokens_for_server(&mut prompt, SO_CTX, 0, 0, 3, Some(IM_END));
+    // No framing tokens (start/end == 0); three sound-context placeholders are
+    // spliced before the user-closing `<|im_end|>` at index 3.
+    assert_eq!(
+        prompt,
+        vec![
+            IM_START, 100, 7, SO_CTX, SO_CTX, SO_CTX, IM_END, IM_START, 101, 102
+        ]
+    );
+    // The block sits inside the user turn: every placeholder precedes the only
+    // `<|im_end|>`, and the assistant generation prefix is untouched at the end.
+    let im_end_pos = prompt.iter().position(|&t| t == IM_END).unwrap();
+    let last_ctx_pos = prompt.iter().rposition(|&t| t == SO_CTX).unwrap();
+    assert!(last_ctx_pos < im_end_pos);
+    assert_eq!(&prompt[prompt.len() - 3..], &[IM_START, 101, 102]);
+}
+
+#[test]
+fn nemotron_server_audio_targets_the_last_user_turn_in_multi_turn() {
+    // system / user1 / assistant1 / user2, then the assistant generation
+    // prompt. The block must go before the LAST `<|im_end|>` (closing user2).
+    // idx: 0       1   2     3       4   5     6       7   8     9       10  11   12
+    //     [im_st, sys, im_e, im_st, u1, im_e, im_st, a1, im_e, im_st, u2, im_e, im_st(gen)]
+    let mut prompt = vec![
+        IM_START, 200, IM_END, IM_START, 201, IM_END, IM_START, 202, IM_END, IM_START, 203, IM_END,
+        IM_START,
+    ];
+    expand_nemotron_h_nano_omni_audio_tokens_for_server(&mut prompt, SO_CTX, 0, 0, 2, Some(IM_END));
+    // The block is spliced before the last `<|im_end|>` (index 11), i.e. after
+    // user2's text (203), leaving every earlier turn boundary intact.
+    assert_eq!(
+        prompt,
+        vec![
+            IM_START, 200, IM_END, IM_START, 201, IM_END, IM_START, 202, IM_END, IM_START, 203,
+            SO_CTX, SO_CTX, IM_END, IM_START
+        ]
+    );
+}
+
+#[test]
+fn nemotron_server_audio_wraps_rendered_placeholder_in_place() {
+    // If a `<so_embedding>` marker is already rendered into the prompt (a chat
+    // template that preserved the audio part), the first occurrence is expanded
+    // in place into N placeholders, leaving the turn structure intact.
+    let mut prompt = vec![IM_START, 100, SO_CTX, IM_END, IM_START, 101];
+    expand_nemotron_h_nano_omni_audio_tokens_for_server(&mut prompt, SO_CTX, 0, 0, 3, Some(IM_END));
+    assert_eq!(
+        prompt,
+        vec![IM_START, 100, SO_CTX, SO_CTX, SO_CTX, IM_END, IM_START, 101]
+    );
+}
+
+#[test]
+fn nemotron_server_audio_emits_framing_tokens_when_nonzero() {
+    // A hypothetical checkpoint that surfaces sound_start / sound_end framing
+    // tokens wraps the placeholder run, matching the CLI expander's optional
+    // framing behaviour.
+    let mut prompt = vec![IM_START, 100, IM_END, IM_START, 101];
+    expand_nemotron_h_nano_omni_audio_tokens_for_server(
+        &mut prompt,
+        SO_CTX,
+        90,
+        91,
+        2,
+        Some(IM_END),
+    );
+    assert_eq!(
+        prompt,
+        vec![IM_START, 100, 90, SO_CTX, SO_CTX, 91, IM_END, IM_START, 101]
+    );
+}
+
+#[test]
+fn nemotron_server_audio_falls_back_before_last_token_without_end_of_turn() {
+    // No placeholder and no end-of-turn id resolved (non-ChatML tokenizer):
+    // keep the historical "before the final token" insertion as a last resort
+    // rather than dropping the audio block.
+    let mut prompt = vec![2, 100, 8];
+    expand_nemotron_h_nano_omni_audio_tokens_for_server(&mut prompt, SO_CTX, 0, 0, 2, None);
+    assert_eq!(prompt, vec![2, 100, SO_CTX, SO_CTX, 8]);
 }

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -972,7 +972,16 @@ pub(crate) fn prepare_request_vlm_embeddings(
         )? {
             return Ok(Some(embeddings));
         }
-        match prepare_gemma4_audio_embeddings(
+        if let Some(embeddings) = prepare_gemma4_audio_embeddings(
+            model,
+            prompt_tokens,
+            images,
+            audio,
+            end_of_turn_token_id,
+        )? {
+            return Ok(Some(embeddings));
+        }
+        match prepare_nemotron_h_nano_omni_audio_embeddings(
             model,
             prompt_tokens,
             images,
@@ -981,8 +990,9 @@ pub(crate) fn prepare_request_vlm_embeddings(
         )? {
             Some(embeddings) => return Ok(Some(embeddings)),
             None => {
-                // Model does not support audio (not Gemma4 or no audio tower).
-                // Log a warning and fall through to image-only or text-only paths.
+                // Model does not support audio (not Gemma4 / Nemotron H Nano
+                // Omni, or no audio tower). Log a warning and fall through to
+                // image-only or text-only paths.
                 tracing::warn!("Audio input provided but model does not support audio; ignoring");
             }
         }
@@ -1061,22 +1071,26 @@ pub(crate) fn prepare_request_vlm_embeddings(
     Ok(None)
 }
 
-/// Resolve the Gemma `<end_of_turn>` token id from the tokenizer.
+/// Resolve the per-family end-of-turn token id from the tokenizer.
 ///
 /// The server flattens chat messages to text-only, so an `input_audio` request
-/// produces a prompt with no `<|audio|>` marker. Knowing the `<end_of_turn>`
-/// id lets [`crate::vlm_runtime::expand_gemma4_audio_tokens_for_server`] place
-/// the audio block inside the last user turn instead of the model turn (issue
-/// #437). Returns `None` when the marker is not a single token in this
-/// tokenizer (non-Gemma tokenizers), in which case the caller keeps the legacy
-/// "before the final token" insertion.
+/// produces a prompt with no audio placeholder marker. Knowing the end-of-turn
+/// id lets the per-family server audio expanders
+/// ([`crate::vlm_runtime::expand_gemma4_audio_tokens_for_server`] and
+/// [`crate::vlm_runtime::expand_nemotron_h_nano_omni_audio_tokens_for_server`])
+/// place the audio block inside the last user turn instead of the assistant
+/// turn (issue #437). Returns `None` when no known marker is a single token in
+/// this tokenizer, in which case the caller keeps the legacy "before the final
+/// token" insertion.
 fn resolve_end_of_turn_token_id(tokenizer: &MlxcelTokenizer) -> Option<i32> {
-    // The end-of-turn marker differs across Gemma generations: Gemma 2/3 use
-    // "<end_of_turn>", while Gemma 4 renamed it to "<turn|>" (id 106, and
-    // "<|turn>" for start-of-turn). Try both so the audio block lands inside
-    // the last user turn on every Gemma checkpoint; "<end_of_turn>" is tried
-    // first because that is the value carried by the non-Gemma-4 templates.
-    const EOT_CANDIDATES: &[&str] = &["<end_of_turn>", "<turn|>"];
+    // The end-of-turn marker differs across families: Gemma 2/3 use
+    // "<end_of_turn>", Gemma 4 renamed it to "<turn|>" (id 106, with "<|turn>"
+    // for start-of-turn), and the Nemotron H Nano Omni ChatML template closes
+    // every turn with "<|im_end|>". Try them in order so the audio block lands
+    // inside the last user turn on every supported checkpoint; the Gemma
+    // markers are tried first so the Gemma audio path keeps resolving to its
+    // own marker even on a tokenizer that also defines "<|im_end|>".
+    const EOT_CANDIDATES: &[&str] = &["<end_of_turn>", "<turn|>", "<|im_end|>"];
     if let Some(hf) = tokenizer.hf_tokenizer() {
         for candidate in EOT_CANDIDATES {
             if let Some(id) = hf.token_to_id(candidate) {
@@ -1284,6 +1298,179 @@ fn prepare_gemma4_unified_audio_embeddings(
         &processed_images,
         Some(&audio_input.features),
         Some(&audio_input.mask),
+    );
+
+    Ok(Some(embeddings))
+}
+
+/// Process audio (and optionally images) for the Nemotron H Nano Omni VLM.
+///
+/// Mirrors the CLI builder `compute_nemotron_h_nano_omni_audio_embeddings` in
+/// `src/commands/generate_vlm.rs`: it runs the Parakeet feature extractor,
+/// derives the post-subsampling audio token count, places the sound-context
+/// block inside the last user turn, runs the encoder + projector via
+/// `extract_audio_features`, and scatters the audio rows through
+/// `get_input_embeddings_full`. The encoder forward is the model method, not a
+/// duplicate.
+///
+/// Returns `Ok(None)` when the model is not a Nemotron H Nano Omni VLM, or it
+/// was loaded without an audio bundle or `sound_context_token_id`, so the
+/// dispatch in [`prepare_request_vlm_embeddings`] falls through to the next
+/// audio handler / the "model does not support audio" warning.
+fn prepare_nemotron_h_nano_omni_audio_embeddings(
+    model: &LoadedModel,
+    prompt_tokens: &mut Vec<i32>,
+    images: &[Vec<u8>],
+    audio_data: &[Vec<u8>],
+    end_of_turn_token_id: Option<i32>,
+) -> Result<Option<InputEmbeddings>> {
+    use crate::audio;
+    use crate::audio::nemotron_h_nano_omni::NemotronOmniFeatureExtractor;
+
+    let nemotron_vl = match model {
+        LoadedModel::NemotronHNanoOmniVLM(vl) => vl,
+        _ => return Ok(None),
+    };
+
+    let bundle = match nemotron_vl.audio() {
+        Some(bundle) => bundle,
+        None => {
+            tracing::warn!(
+                "Nemotron H Nano Omni model was loaded without audio support; ignoring audio input"
+            );
+            return Ok(None);
+        }
+    };
+
+    let sound_context_token_id = match nemotron_vl.config.sound_context_token_id {
+        Some(id) => id,
+        None => {
+            tracing::warn!(
+                "Nemotron H Nano Omni model has no sound_context_token_id; ignoring audio input"
+            );
+            return Ok(None);
+        }
+    };
+
+    if audio_data.len() > 1 {
+        tracing::warn!(
+            "Multiple audio inputs provided ({}); only the first will be processed",
+            audio_data.len()
+        );
+    }
+
+    // Server passes inline payload bytes; decode the first clip.
+    let (samples, sample_rate) = audio::load_wav_from_bytes(&audio_data[0])
+        .map_err(|e| anyhow!("Failed to decode audio: {}", e))?;
+    tracing::info!(
+        "Audio input: {} samples at {} Hz ({:.1}s)",
+        samples.len(),
+        sample_rate,
+        samples.len() as f64 / sample_rate.max(1) as f64
+    );
+
+    // The Parakeet feature extractor is tied to the configured sampling rate
+    // (16 kHz for the released checkpoint). The CLI path hard-errors on a rate
+    // mismatch; `load_wav_from_bytes` returns native-rate samples, so resample
+    // to the expected rate before mel extraction so the encoder frame count
+    // matches the duration-derived placeholder count. The only resampler in
+    // core targets 16 kHz, so a checkpoint expecting a different rate is
+    // rejected with a clear error (preserving the CLI's hard-error contract).
+    let expected_rate = bundle.config.sampling_rate;
+    let samples = if sample_rate != expected_rate {
+        if expected_rate == 16_000 {
+            audio::whisper_mel::resample_to_16k(&samples, sample_rate)
+        } else {
+            return Err(anyhow!(
+                "Audio sample rate {} Hz does not match the model's expected {} Hz; \
+                 resample the audio before sending it.",
+                sample_rate,
+                expected_rate
+            ));
+        }
+    } else {
+        samples
+    };
+
+    // Run the feature extractor and derive the post-subsampling token count,
+    // mirroring the CLI builder. Single server clip, so `feature_lengths` has
+    // length 1.
+    let extractor = NemotronOmniFeatureExtractor::new(&bundle.config);
+    let extracted = extractor.extract_batch(&[&samples[..]]);
+    let num_frames = extracted.features_shape[1] as usize;
+    let total_frames = extracted
+        .feature_lengths
+        .first()
+        .copied()
+        .unwrap_or(num_frames as i32) as usize;
+    let num_audio_tokens = bundle.config.subsampling_output_length(total_frames).max(1);
+
+    // Place the sound-context block inside the last user turn (issue #437): the
+    // server prompt is text-only with no `<so_embedding>` marker, so the block
+    // is spliced before the user turn's closing `<|im_end|>`.
+    crate::vlm_runtime::expand_nemotron_h_nano_omni_audio_tokens_for_server(
+        prompt_tokens,
+        sound_context_token_id,
+        nemotron_vl.config.sound_start_token_id,
+        nemotron_vl.config.sound_end_token_id,
+        num_audio_tokens,
+        end_of_turn_token_id,
+    );
+
+    // Optional image branch (combined image + audio): preprocess and expand
+    // image tokens the same way the image-only runtime path does, so the merged
+    // stream matches an image-only request.
+    let processed_images = if !images.is_empty() {
+        let decoded_images = decode_request_images(images)?;
+        let processed = nemotron_vl.processor.preprocess_batch(&decoded_images);
+        crate::vlm_runtime::expand_nemotron_h_nano_omni_image_tokens_for_server(
+            prompt_tokens,
+            nemotron_vl.config.img_context_token_id,
+            nemotron_vl.config.image_start_token_id,
+            nemotron_vl.config.image_end_token_id,
+            &processed,
+        );
+        processed
+    } else {
+        Vec::new()
+    };
+
+    // Build encoder inputs: row-major f32 features, int32 attention mask and
+    // per-clip lengths (the encoder broadcasts the mask via `less`).
+    let audio_features_in = mlxcel_core::from_slice_f32(
+        &extracted.features,
+        &[
+            extracted.features_shape[0],
+            extracted.features_shape[1],
+            extracted.features_shape[2],
+        ],
+    );
+    let audio_attention_mask = mlxcel_core::from_slice_i32(
+        &extracted.attention_mask,
+        &[
+            extracted.attention_mask_shape[0],
+            extracted.attention_mask_shape[1],
+        ],
+    );
+    let feature_lengths = mlxcel_core::from_slice_i32(
+        &extracted.feature_lengths,
+        &[extracted.feature_lengths.len() as i32],
+    );
+
+    let audio_features = nemotron_vl
+        .extract_audio_features(
+            &audio_features_in,
+            Some(&audio_attention_mask),
+            Some(&feature_lengths),
+        )
+        .map_err(|e| anyhow!("Audio feature extraction failed: {}", e))?;
+
+    let input_ids_arr =
+        mlxcel_core::from_slice_i32(prompt_tokens, &[1, prompt_tokens.len() as i32]);
+    let embeddings = nemotron_vl.get_input_embeddings_full(
+        &input_ids_arr,
+        &processed_images,
+        Some(&audio_features),
     );
 
     Ok(Some(embeddings))

--- a/src/server/model_worker_tests.rs
+++ b/src/server/model_worker_tests.rs
@@ -547,3 +547,79 @@ fn resolve_end_of_turn_id_returns_none_when_no_marker_present() {
         "a tokenizer without <end_of_turn> or <turn|> must return None"
     );
 }
+
+/// Nemotron-H Nano Omni uses a ChatML template that closes every turn with
+/// `"<|im_end|>"` (id 151 in the released 30B checkpoint).  A tokenizer that
+/// registers only `"<|im_end|>"` and no Gemma marker must resolve to that id,
+/// because `"<|im_end|>"` is the last candidate in `EOT_CANDIDATES` and is
+/// reached after both Gemma entries return `None`.
+#[test]
+fn resolve_end_of_turn_id_handles_chatml_im_end_marker() {
+    // Nemotron tokenizer stub: "<|im_end|>" = id 151, no Gemma markers.
+    let tokenizer = stub_eot_tokenizer("<|im_end|>", 151);
+    assert_eq!(
+        resolve_end_of_turn_token_id(&tokenizer),
+        Some(151),
+        "Nemotron tokenizer must resolve <|im_end|> (id 151) as the end-of-turn id"
+    );
+}
+
+/// Build a minimal HuggingFace tokenizer stub with exactly two added special
+/// tokens.  Used to verify candidate ordering in
+/// `resolve_end_of_turn_token_id`: when the vocabulary contains both a Gemma
+/// marker and `"<|im_end|>"`, the function must return the first match in
+/// `EOT_CANDIDATES`, which is the Gemma one.
+fn stub_two_eot_tokenizer(
+    first_content: &str,
+    first_id: u32,
+    second_content: &str,
+    second_id: u32,
+) -> MlxcelTokenizer {
+    let json = format!(
+        r#"{{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [
+                {{"id": {first_id}, "content": "{first_content}", "single_word": false,
+                  "lstrip": false, "rstrip": false, "normalized": false, "special": true}},
+                {{"id": {second_id}, "content": "{second_content}", "single_word": false,
+                  "lstrip": false, "rstrip": false, "normalized": false, "special": true}}
+            ],
+            "normalizer": null,
+            "pre_tokenizer": null,
+            "post_processor": null,
+            "decoder": null,
+            "model": {{
+                "type": "BPE",
+                "dropout": null,
+                "unk_token": null,
+                "continuing_subword_prefix": null,
+                "end_of_word_suffix": null,
+                "fuse_unk": false,
+                "byte_fallback": false,
+                "vocab": {{"a": 0, "b": 1, "{first_content}": {first_id}, "{second_content}": {second_id}}},
+                "merges": []
+            }}
+        }}"#
+    );
+    let tokenizer = tokenizers::Tokenizer::from_bytes(json.as_bytes())
+        .expect("failed to build stub two-token EOT tokenizer");
+    MlxcelTokenizer::HuggingFace(tokenizer)
+}
+
+/// When a tokenizer contains both `"<end_of_turn>"` (Gemma) and `"<|im_end|>"`
+/// (ChatML), `resolve_end_of_turn_token_id` must return the Gemma marker
+/// because it appears first in `EOT_CANDIDATES`.  This guards against a future
+/// ordering change that would regress the Gemma audio path on any tokenizer
+/// that also happens to define `"<|im_end|>"`.
+#[test]
+fn resolve_end_of_turn_id_prefers_gemma_over_chatml() {
+    // Tokenizer with both markers: Gemma "<end_of_turn>" = id 107, ChatML "<|im_end|>" = id 151.
+    let tokenizer = stub_two_eot_tokenizer("<end_of_turn>", 107, "<|im_end|>", 151);
+    assert_eq!(
+        resolve_end_of_turn_token_id(&tokenizer),
+        Some(107),
+        "<end_of_turn> must win over <|im_end|> when both are present (candidate order)"
+    );
+}


### PR DESCRIPTION
## Summary

Make `POST /v1/chat/completions` with an `input_audio` content block work for a loaded Nemotron-H Nano Omni model. The server audio dispatch previously routed only to the two Gemma 4 paths, so a Nemotron-H Nano Omni model returned "model does not support audio". This is the Nemotron analogue of the Gemma 4 server-audio fix in #437 / PR #440: the model surface and the CLI builder already existed, only the server `input_audio` handler and the user-turn prompt placement were missing.

## What changed

- `src/server/model_worker.rs`: add `prepare_nemotron_h_nano_omni_audio_embeddings`, mirroring `prepare_gemma4_audio_embeddings`. It decodes the inline WAV via `audio::load_wav_from_bytes`, resamples to the model's configured 16 kHz rate (the Parakeet feature extractor is rate-tied; a checkpoint expecting a non-16k rate is rejected with a clear error, preserving the CLI path's hard-error contract), runs the Parakeet feature extractor, derives the post-subsampling token count via `subsampling_output_length`, runs the encoder/projector through the model's `extract_audio_features`, and scatters via `get_input_embeddings_full`. It returns `Ok(None)` for non-Nemotron / audio-less models so the dispatch falls through.
- `src/server/model_worker.rs`: wire the new handler into the `!audio.is_empty()` dispatch in `prepare_request_vlm_embeddings`, alongside the two Gemma 4 calls and before the "model does not support audio" warning.
- `src/server/model_worker.rs`: generalize `resolve_end_of_turn_token_id` to also recognize the Nemotron ChatML `<|im_end|>` marker (id 11), tried after the Gemma `<end_of_turn>` / `<turn|>` markers so the Gemma resolution is unchanged.
- `src/multimodal/vlm_runtime.rs`: add `expand_nemotron_h_nano_omni_audio_tokens_for_server`. The server flattens chat messages to text-only (`chat_request::build_chat_messages_with_thinking` keeps only `content.text()`), so the prompt carries no `<so_embedding>` marker; the sound-context block is spliced before the last end-of-turn token, landing inside the last user turn rather than the open assistant turn (which forces an immediate EOS at prefill, the #437 class). Start/end framing tokens are emitted only when non-zero, matching the CLI expander.
- `src/multimodal/vlm_runtime.rs`: add `expand_nemotron_h_nano_omni_image_tokens_for_server` so a combined image + audio request expands image tokens the same way the image-only runtime path does, instead of silently dropping images.
- `src/multimodal/vlm_runtime_tests.rs`: add five focused placement unit tests (user-turn insertion, multi-turn last-user-turn targeting, rendered-placeholder wrap, optional framing tokens, no-end-of-turn fallback).

## Placement mechanism (the subtle part)

The Nemotron-H Nano Omni chat template is ChatML-style: `<|im_start|>role\n...<|im_end|>\n`, with the audio placeholder rendered as `<so_embedding>` (token id 27 = `sound_context_token_id`) only when the message content is a sequence with audio parts. The server flattens to a plain-text string, so no `<so_embedding>` is rendered. The generation prompt is `<|im_start|>assistant\n<think>\n`, which has no closing `<|im_end|>`, so the last `<|im_end|>` in the token stream is always the one closing the last user turn. The new server expander resolves `<|im_end|>` (id 11) via the generalized `resolve_end_of_turn_token_id`, finds its last occurrence with `rposition`, and splices the sound block before it. The CLI expander's index-0 prepend would land before the system turn, so it is not reused for the server. The five unit tests confirm the block precedes the user-closing `<|im_end|>` and leaves the assistant generation prefix untouched, including the multi-turn case.

## Gemma / image / text paths unchanged

The Gemma 4 dispatch arm changed only from `match prepare_gemma4_audio_embeddings(...)` to an equivalent `if let Some(...) = prepare_gemma4_audio_embeddings(...)` early return; its inputs and behavior are identical. `resolve_end_of_turn_token_id` keeps the Gemma markers first, so Gemma tokenizers still resolve to their own marker. The new `<|im_end|>` candidate is only reachable for tokenizers without the Gemma markers, and the resolver's result is consumed only by the per-family audio fns, each of which returns `Ok(None)` for non-matching models. Image-only and video paths and all text-only paths are untouched; `chat_request.rs` and the prefix-cache logic are not modified.

## Test plan

- [x] `cargo check --bin mlxcel-server --features metal,accelerate`
- [x] `cargo check --bin mlxcel --features metal,accelerate`
- [x] `cargo test --lib --features metal,accelerate multimodal::vlm_runtime` (28 passed, incl. 5 new Nemotron placement tests and the 5 existing Gemma server-audio tests)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings`
- [ ] MANDATORY real-model server E2E (orchestrator): load `models/nemotron-3-nano-omni-30b-a3b-reasoning-4bit` (18GB, `sound_context_token_id: 27`) in `mlxcel-server`, `POST /v1/chat/completions` with an `input_audio` part, and confirm a coherent non-zero-token response that is conditioned on the audio (not "model does not support audio" and not an immediate EOS at prefill).

Per the #437 lesson, unit tests and code review are NOT sufficient for this class of server audio-placement change: a wrong placement passes unit tests and review but EOSes at prefill on a real model. The authoritative validation is the real-model server E2E above, which the orchestrator must run.

Closes #442


