### PR TITLE
chore: align mlxcel-core and mlxcel-surgery to the root crate (edition 2024, version 0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Docs
 - Finalize the per-backend `MLXCEL_FUSED_QK_NORM` default decision: CUDA (GB10) was measured and is also slower than the graph path, so the fused QK-norm decode path stays opt-in (default off) on every backend; `docs/environment-variables.md` updated to drop the CUDA-pending rationale and record the determinism nuance (#355).
 
+### Chore
+- Bump the `mlxcel-core` and `mlxcel-surgery` member crates to Rust edition 2024 and align their versions to the root crate at 0.3.3, per the release-versioning rule (#272).
+
 ## [v0.3.3] - 2026-06-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "mlxcel-core"
-version = "0.2.0"
+version = "0.3.3"
 dependencies = [
  "cmake",
  "cxx",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "mlxcel-surgery"
-version = "0.1.0"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "globset",

--- a/src/lib/mlxcel-core/Cargo.toml
+++ b/src/lib/mlxcel-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlxcel-core"
-version = "0.2.0"
-edition = "2021"
+version = "0.3.3"
+edition = "2024"
 description = "Low-level MLX building blocks for mlxcel"
 license = "Apache-2.0"
 

--- a/src/lib/mlxcel-core/examples/wht_microbench.rs
+++ b/src/lib/mlxcel-core/examples/wht_microbench.rs
@@ -37,7 +37,7 @@
 //! K-cache snapshot is found at `models/wht-bench-kv.safetensors`. Skipped
 //! silently if not present so this binary is hermetic.
 
-use mlxcel_core::{self, dtype, MlxArray, UniquePtr};
+use mlxcel_core::{self, MlxArray, UniquePtr, dtype};
 use std::time::Instant;
 
 const WARMUP_ITERS: usize = 8;

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -94,8 +94,8 @@ pub mod turbo;
 mod turbo_tests;
 
 pub use batch_quant::{
-    BatchKvQuantConfig, BatchQuantizedKVCache, BatchTurboQuantKVCache, KvQuantScheme,
-    DEFAULT_KV_GROUP_SIZE,
+    BatchKvQuantConfig, BatchQuantizedKVCache, BatchTurboQuantKVCache, DEFAULT_KV_GROUP_SIZE,
+    KvQuantScheme,
 };
 pub use detach::{DetachedCacheSet, DetachedHandle, DetachedKVCache, DetachedRotatingKVCache};
 pub use paged::{
@@ -784,11 +784,7 @@ impl KVCache {
         match buf {
             Some(k) => {
                 let shape = ffi::array_shape(k);
-                if shape.len() >= 3 {
-                    shape[2]
-                } else {
-                    0
-                }
+                if shape.len() >= 3 { shape[2] } else { 0 }
             }
             None => 0,
         }
@@ -1652,11 +1648,7 @@ impl KVCache {
         match self.keys.as_ref() {
             Some(k) => {
                 let s = ffi::array_shape(k);
-                if s.len() >= 3 {
-                    s[2]
-                } else {
-                    0
-                }
+                if s.len() >= 3 { s[2] } else { 0 }
             }
             None => 0,
         }
@@ -1668,11 +1660,7 @@ impl KVCache {
         match self.values.as_ref() {
             Some(v) => {
                 let s = ffi::array_shape(v);
-                if s.len() >= 3 {
-                    s[2]
-                } else {
-                    0
-                }
+                if s.len() >= 3 { s[2] } else { 0 }
             }
             None => 0,
         }
@@ -2006,11 +1994,7 @@ impl KVCache {
         let cold_cap = match &self.v_packed {
             Some(vp) => {
                 let s = ffi::array_shape(vp);
-                if s.len() >= 3 {
-                    s[2]
-                } else {
-                    0
-                }
+                if s.len() >= 3 { s[2] } else { 0 }
             }
             None => 0,
         };
@@ -3524,8 +3508,8 @@ impl KVCache {
         // WHT over every cold token on each graph fallback. It is the default
         // compressed path; set `MLXCEL_TURBO4_DELEGATED_DEQUANT_SDPA=0` to
         // compare against the custom steel/cold-only order below.
-        if turbo::sparse_v::turbo4_delegated_dequant_sdpa_enabled() {
-            if let Some(out) = turbo::sparse_v::attention_turbo4_delegated_dequant_sdpa(
+        if turbo::sparse_v::turbo4_delegated_dequant_sdpa_enabled()
+            && let Some(out) = turbo::sparse_v::attention_turbo4_delegated_dequant_sdpa(
                 q,
                 &k_slice,
                 v_packed_ref,
@@ -3536,9 +3520,9 @@ impl KVCache {
                 hot_offset,
                 scale,
                 mask,
-            ) {
-                return out;
-            }
+            )
+        {
+            return out;
         }
 
         // Prefer the steel-attention-envelope kernel when
@@ -3824,11 +3808,7 @@ impl RotatingKVCache {
         }
         if let Some(ref keys) = self.keys {
             let shape = ffi::array_shape(keys);
-            if shape.len() >= 3 {
-                shape[2]
-            } else {
-                0
-            }
+            if shape.len() >= 3 { shape[2] } else { 0 }
         } else {
             0
         }
@@ -4070,10 +4050,10 @@ impl RotatingKVCache {
         needed: i32,
         incoming: i32,
     ) {
-        if let Some(keys) = self.keys.as_ref() {
-            if needed <= ffi::array_shape(keys)[2] {
-                return;
-            }
+        if let Some(keys) = self.keys.as_ref()
+            && needed <= ffi::array_shape(keys)[2]
+        {
+            return;
         }
 
         let new_k_shape = ffi::array_shape(new_keys);

--- a/src/lib/mlxcel-core/src/cache/batch_quant.rs
+++ b/src/lib/mlxcel-core/src/cache/batch_quant.rs
@@ -626,28 +626,28 @@ impl BatchQuantizedKVCache {
         // here (see `BatchQuantizedKVCache.filter`, commit 2a55b80). We must
         // mirror that so `make_mask` continues to compute the correct
         // `total_len = n + idx` after a trim.
-        if let Some(&min_lp) = self.left_padding.iter().min() {
-            if min_lp > 0 {
-                for lp in &mut self.left_padding {
-                    *lp -= min_lp;
-                }
-                // Precondition: callers invoke `update_after_decode` (which
-                // advances `idx`) before `filter` whenever `left_padding` is
-                // nonzero, so `idx >= min_lp` holds here and `idx` stays
-                // non-negative. Mirrors upstream `self._idx -= min_lp`; a
-                // negative `idx` would make `make_mask` build a degenerate
-                // `total_len = n + idx`. The scheduler upholds this once these
-                // caches move onto the live decode path.
-                self.idx -= min_lp;
-                // The actual K/V tensor trim (slicing leading
-                // `min_lp` tokens out of each layer cache) is the
-                // scheduler's responsibility because it requires
-                // `cxx::UniquePtr<MlxArray>` operations on the live
-                // device-resident tensors. The metadata side is
-                // sufficient for the unit-test scenario, where we
-                // verify that the wrapper's bookkeeping matches the
-                // upstream Python invariant.
+        if let Some(&min_lp) = self.left_padding.iter().min()
+            && min_lp > 0
+        {
+            for lp in &mut self.left_padding {
+                *lp -= min_lp;
             }
+            // Precondition: callers invoke `update_after_decode` (which
+            // advances `idx`) before `filter` whenever `left_padding` is
+            // nonzero, so `idx >= min_lp` holds here and `idx` stays
+            // non-negative. Mirrors upstream `self._idx -= min_lp`; a
+            // negative `idx` would make `make_mask` build a degenerate
+            // `total_len = n + idx`. The scheduler upholds this once these
+            // caches move onto the live decode path.
+            self.idx -= min_lp;
+            // The actual K/V tensor trim (slicing leading
+            // `min_lp` tokens out of each layer cache) is the
+            // scheduler's responsibility because it requires
+            // `cxx::UniquePtr<MlxArray>` operations on the live
+            // device-resident tensors. The metadata side is
+            // sufficient for the unit-test scenario, where we
+            // verify that the wrapper's bookkeeping matches the
+            // upstream Python invariant.
         }
         Ok(())
     }
@@ -877,20 +877,20 @@ impl BatchTurboQuantKVCache {
         // Mirrors upstream Python `BatchQuantizedKVCache.filter`: also
         // decrement `_idx` by `min_lp` when padding is trimmed, so that
         // `make_mask` keeps computing the correct `total_len = n + idx`.
-        if let Some(&min_lp) = self.left_padding.iter().min() {
-            if min_lp > 0 {
-                for lp in &mut self.left_padding {
-                    *lp -= min_lp;
-                }
-                // Precondition: callers invoke `update_after_decode` (which
-                // advances `idx`) before `filter` whenever `left_padding` is
-                // nonzero, so `idx >= min_lp` holds here and `idx` stays
-                // non-negative. Mirrors upstream `self._idx -= min_lp`; a
-                // negative `idx` would make `make_mask` build a degenerate
-                // `total_len = n + idx`. The scheduler upholds this once these
-                // caches move onto the live decode path.
-                self.idx -= min_lp;
+        if let Some(&min_lp) = self.left_padding.iter().min()
+            && min_lp > 0
+        {
+            for lp in &mut self.left_padding {
+                *lp -= min_lp;
             }
+            // Precondition: callers invoke `update_after_decode` (which
+            // advances `idx`) before `filter` whenever `left_padding` is
+            // nonzero, so `idx >= min_lp` holds here and `idx` stays
+            // non-negative. Mirrors upstream `self._idx -= min_lp`; a
+            // negative `idx` would make `make_mask` build a degenerate
+            // `total_len = n + idx`. The scheduler upholds this once these
+            // caches move onto the live decode path.
+            self.idx -= min_lp;
         }
         Ok(())
     }

--- a/src/lib/mlxcel-core/src/cache/detach.rs
+++ b/src/lib/mlxcel-core/src/cache/detach.rs
@@ -584,16 +584,16 @@ impl KVCache {
         // shape. Inverse of `head_dim * 3 / 8`: head_dim = packed_dim * 8 / 3.
         // Mirrors the Turbo4 prebuild above so dequantize-only consumers see
         // a ready-to-go cache after install.
-        if self.mode == KVCacheMode::Turbo3Asym {
-            if let Some(p) = self.v_packed.as_ref() {
-                let shape = ffi::array_shape(p);
-                if shape.len() == 4 && shape[3] > 0 {
-                    let head_dim = (shape[3] as u32) * 8 / 3;
-                    self.turbo3_params = Some(super::turbo::quant3::TurboQuantParams3::new(
-                        head_dim,
-                        self.turbo_seed,
-                    ));
-                }
+        if self.mode == KVCacheMode::Turbo3Asym
+            && let Some(p) = self.v_packed.as_ref()
+        {
+            let shape = ffi::array_shape(p);
+            if shape.len() == 4 && shape[3] > 0 {
+                let head_dim = (shape[3] as u32) * 8 / 3;
+                self.turbo3_params = Some(super::turbo::quant3::TurboQuantParams3::new(
+                    head_dim,
+                    self.turbo_seed,
+                ));
             }
         }
         Ok(())
@@ -752,16 +752,16 @@ impl RotatingKVCache {
         // Pre-build turbo_params from v_packed shape if available so the
         // first dequantize-only consumer doesn't need to wait for an update
         // call (mirrors `KVCache::install_detached`).
-        if self.mode == KVCacheMode::Turbo4Asym {
-            if let Some(ref vp) = self.v_packed {
-                let shape = ffi::array_shape(vp);
-                if shape.len() == 4 && shape[3] > 0 {
-                    let head_dim = (shape[3] as u32) * 2;
-                    self.turbo_params = Some(super::turbo::TurboQuantParams::new(
-                        head_dim,
-                        self.turbo_seed,
-                    ));
-                }
+        if self.mode == KVCacheMode::Turbo4Asym
+            && let Some(ref vp) = self.v_packed
+        {
+            let shape = ffi::array_shape(vp);
+            if shape.len() == 4 && shape[3] > 0 {
+                let head_dim = (shape[3] as u32) * 2;
+                self.turbo_params = Some(super::turbo::TurboQuantParams::new(
+                    head_dim,
+                    self.turbo_seed,
+                ));
             }
         }
         Ok(())

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -1791,13 +1791,13 @@ impl PagedBlockPool {
 
         // No freed block to reuse — minting a new one grows the pool, so it is
         // subject to the global block budget (opt-in; `None` = unbounded).
-        if let Some(max) = self.block_budget {
-            if self.blocks.len() >= max {
-                return Err(format!(
-                    "PagedBlockPool: block budget exhausted ({} of {max} blocks allocated)",
-                    self.blocks.len()
-                ));
-            }
+        if let Some(max) = self.block_budget
+            && self.blocks.len() >= max
+        {
+            return Err(format!(
+                "PagedBlockPool: block budget exhausted ({} of {max} blocks allocated)",
+                self.blocks.len()
+            ));
         }
 
         let block_id = PagedBlockId(self.next_block_id);

--- a/src/lib/mlxcel-core/src/cache/paged_detach.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_detach.rs
@@ -276,15 +276,15 @@ impl Drop for DetachedPagedCacheSet {
         // own pins at drop time the caller forgot to return us to the pool;
         // warn so the leak is visible rather than silently burning block
         // budget forever.
-        if let Some(blocks) = self.retained_blocks.take() {
-            if !blocks.is_empty() {
-                eprintln!(
-                    "[mlxcel::cache::paged_detach] DetachedPagedCacheSet dropped with {} retained blocks (origin seq {}); \
+        if let Some(blocks) = self.retained_blocks.take()
+            && !blocks.is_empty()
+        {
+            eprintln!(
+                "[mlxcel::cache::paged_detach] DetachedPagedCacheSet dropped with {} retained blocks (origin seq {}); \
                      use CachePool::release_detached_paged or adopt_paged to release pins",
-                    blocks.len(),
-                    self.origin_seq_id
-                );
-            }
+                blocks.len(),
+                self.origin_seq_id
+            );
         }
     }
 }
@@ -441,29 +441,29 @@ impl CachePool {
         let mut k_packed_pages: HashMap<PagedBlockId, UniquePtr<MlxArray>> = HashMap::new();
         let mut k_norms_pages: HashMap<PagedBlockId, UniquePtr<MlxArray>> = HashMap::new();
         let mut cold_keys_pages: HashMap<PagedBlockId, UniquePtr<MlxArray>> = HashMap::new();
-        if paged_layout.is_turbo_mode() {
-            if let Some(pool) = self.paged_pool.as_ref() {
-                let mut pool = pool.borrow_mut();
-                for &block_id in &retained {
-                    if let Some(t) = pool.take_v_packed(block_id) {
-                        v_packed_pages.insert(block_id, t);
+        if paged_layout.is_turbo_mode()
+            && let Some(pool) = self.paged_pool.as_ref()
+        {
+            let mut pool = pool.borrow_mut();
+            for &block_id in &retained {
+                if let Some(t) = pool.take_v_packed(block_id) {
+                    v_packed_pages.insert(block_id, t);
+                }
+                if let Some(t) = pool.take_v_norms(block_id) {
+                    v_norms_pages.insert(block_id, t);
+                }
+                if paged_layout.cache_mode == KVCacheMode::Turbo4 {
+                    if let Some(t) = pool.take_k_packed(block_id) {
+                        k_packed_pages.insert(block_id, t);
                     }
-                    if let Some(t) = pool.take_v_norms(block_id) {
-                        v_norms_pages.insert(block_id, t);
+                    if let Some(t) = pool.take_k_norms(block_id) {
+                        k_norms_pages.insert(block_id, t);
                     }
-                    if paged_layout.cache_mode == KVCacheMode::Turbo4 {
-                        if let Some(t) = pool.take_k_packed(block_id) {
-                            k_packed_pages.insert(block_id, t);
-                        }
-                        if let Some(t) = pool.take_k_norms(block_id) {
-                            k_norms_pages.insert(block_id, t);
-                        }
-                    }
-                    if paged_layout.cache_mode == KVCacheMode::Turbo4Delegated {
-                        if let Some(t) = pool.take_cold_keys(block_id) {
-                            cold_keys_pages.insert(block_id, t);
-                        }
-                    }
+                }
+                if paged_layout.cache_mode == KVCacheMode::Turbo4Delegated
+                    && let Some(t) = pool.take_cold_keys(block_id)
+                {
+                    cold_keys_pages.insert(block_id, t);
                 }
             }
         }
@@ -696,43 +696,43 @@ impl CachePool {
         // constructed sequence. The detach-side `take_*` calls already
         // consumed the originals, so a failure here would otherwise drop
         // them silently.
-        if paged_layout.is_turbo_mode() {
-            if let Some(pool) = self.paged_pool.as_ref() {
-                let mut pool = pool.borrow_mut();
-                for (block_id, t) in v_packed_pages {
-                    if let Err(err) = pool.install_v_packed(block_id, t) {
-                        eprintln!(
-                            "[mlxcel::cache::paged_detach] adopt_paged: failed to reinstall v_packed for {block_id}: {err}"
-                        );
-                    }
+        if paged_layout.is_turbo_mode()
+            && let Some(pool) = self.paged_pool.as_ref()
+        {
+            let mut pool = pool.borrow_mut();
+            for (block_id, t) in v_packed_pages {
+                if let Err(err) = pool.install_v_packed(block_id, t) {
+                    eprintln!(
+                        "[mlxcel::cache::paged_detach] adopt_paged: failed to reinstall v_packed for {block_id}: {err}"
+                    );
                 }
-                for (block_id, t) in v_norms_pages {
-                    if let Err(err) = pool.install_v_norms(block_id, t) {
-                        eprintln!(
-                            "[mlxcel::cache::paged_detach] adopt_paged: failed to reinstall v_norms for {block_id}: {err}"
-                        );
-                    }
+            }
+            for (block_id, t) in v_norms_pages {
+                if let Err(err) = pool.install_v_norms(block_id, t) {
+                    eprintln!(
+                        "[mlxcel::cache::paged_detach] adopt_paged: failed to reinstall v_norms for {block_id}: {err}"
+                    );
                 }
-                for (block_id, t) in k_packed_pages {
-                    if let Err(err) = pool.install_k_packed(block_id, t) {
-                        eprintln!(
-                            "[mlxcel::cache::paged_detach] adopt_paged: failed to reinstall k_packed for {block_id}: {err}"
-                        );
-                    }
+            }
+            for (block_id, t) in k_packed_pages {
+                if let Err(err) = pool.install_k_packed(block_id, t) {
+                    eprintln!(
+                        "[mlxcel::cache::paged_detach] adopt_paged: failed to reinstall k_packed for {block_id}: {err}"
+                    );
                 }
-                for (block_id, t) in k_norms_pages {
-                    if let Err(err) = pool.install_k_norms(block_id, t) {
-                        eprintln!(
-                            "[mlxcel::cache::paged_detach] adopt_paged: failed to reinstall k_norms for {block_id}: {err}"
-                        );
-                    }
+            }
+            for (block_id, t) in k_norms_pages {
+                if let Err(err) = pool.install_k_norms(block_id, t) {
+                    eprintln!(
+                        "[mlxcel::cache::paged_detach] adopt_paged: failed to reinstall k_norms for {block_id}: {err}"
+                    );
                 }
-                for (block_id, t) in cold_keys_pages {
-                    if let Err(err) = pool.install_cold_keys(block_id, t) {
-                        eprintln!(
-                            "[mlxcel::cache::paged_detach] adopt_paged: failed to reinstall cold_keys for {block_id}: {err}"
-                        );
-                    }
+            }
+            for (block_id, t) in cold_keys_pages {
+                if let Err(err) = pool.install_cold_keys(block_id, t) {
+                    eprintln!(
+                        "[mlxcel::cache::paged_detach] adopt_paged: failed to reinstall cold_keys for {block_id}: {err}"
+                    );
                 }
             }
         }
@@ -743,19 +743,19 @@ impl CachePool {
         // now holds the original pin. Releasing the detach-side bump restores
         // the invariant "refcount == number of active block_ids entries
         // owning the block".
-        if let Some(blocks) = retained_blocks {
-            if let Some(pool) = self.paged_pool.as_ref() {
-                let mut pool = pool.borrow_mut();
-                for block_id in blocks {
-                    if let Err(err) = pool.release_block(block_id) {
-                        // Fatal: the pool now disagrees with the sequence
-                        // state. Surface loudly but do not unwind — unwinding
-                        // here would leave the new sequence in an even worse
-                        // state.
-                        eprintln!(
-                            "[mlxcel::cache::paged_detach] CachePool::adopt_paged: failed to drop detach pin on block {block_id}: {err}"
-                        );
-                    }
+        if let Some(blocks) = retained_blocks
+            && let Some(pool) = self.paged_pool.as_ref()
+        {
+            let mut pool = pool.borrow_mut();
+            for block_id in blocks {
+                if let Err(err) = pool.release_block(block_id) {
+                    // Fatal: the pool now disagrees with the sequence
+                    // state. Surface loudly but do not unwind — unwinding
+                    // here would leave the new sequence in an even worse
+                    // state.
+                    eprintln!(
+                        "[mlxcel::cache::paged_detach] CachePool::adopt_paged: failed to drop detach pin on block {block_id}: {err}"
+                    );
                 }
             }
         }
@@ -1098,25 +1098,25 @@ impl CachePool {
     /// blocks) — the `retained_blocks.take()` guard makes the whole body a
     /// no-op so neither reference is released twice.
     pub fn release_detached_paged(&mut self, mut detached: DetachedPagedCacheSet) {
-        if let Some(blocks) = detached.retained_blocks.take() {
-            if let Some(pool) = self.paged_pool.as_ref() {
-                let mut pool = pool.borrow_mut();
-                // Release the detach pins.
-                for block_id in &blocks {
-                    if let Err(err) = pool.release_block(*block_id) {
-                        eprintln!(
-                            "[mlxcel::cache::paged_detach] CachePool::release_detached_paged: failed to release pin for block {block_id}: {err}"
-                        );
-                    }
+        if let Some(blocks) = detached.retained_blocks.take()
+            && let Some(pool) = self.paged_pool.as_ref()
+        {
+            let mut pool = pool.borrow_mut();
+            // Release the detach pins.
+            for block_id in &blocks {
+                if let Err(err) = pool.release_block(*block_id) {
+                    eprintln!(
+                        "[mlxcel::cache::paged_detach] CachePool::release_detached_paged: failed to release pin for block {block_id}: {err}"
+                    );
                 }
-                // Release the origin allocation the block table still carries.
-                for layer in &detached.paged_state.layers {
-                    for &block_id in &layer.block_ids {
-                        if let Err(err) = pool.release_block(block_id) {
-                            eprintln!(
-                                "[mlxcel::cache::paged_detach] CachePool::release_detached_paged: failed to release allocation for block {block_id}: {err}"
-                            );
-                        }
+            }
+            // Release the origin allocation the block table still carries.
+            for layer in &detached.paged_state.layers {
+                for &block_id in &layer.block_ids {
+                    if let Err(err) = pool.release_block(block_id) {
+                        eprintln!(
+                            "[mlxcel::cache::paged_detach] CachePool::release_detached_paged: failed to release allocation for block {block_id}: {err}"
+                        );
                     }
                 }
             }

--- a/src/lib/mlxcel-core/src/cache/paged_pool_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_pool_tests.rs
@@ -34,8 +34,8 @@
 //! - `write_prefill` copy-on-write forks a shared partial tail block so two
 //!   sequences' suffixes never corrupt each other or the shared prefix.
 
-use super::paged::{PagedBlockId, PagedBlockPool, PagedKvLayout, PagedSequenceState};
 use super::KVCacheMode;
+use super::paged::{PagedBlockId, PagedBlockPool, PagedKvLayout, PagedSequenceState};
 
 use crate::dtype;
 use crate::ffi;

--- a/src/lib/mlxcel-core/src/cache/sparse_v_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/sparse_v_tests.rs
@@ -21,7 +21,7 @@
 
 use cxx::UniquePtr;
 
-use super::turbo::{self, sparse_v, TurboQuantParams};
+use super::turbo::{self, TurboQuantParams, sparse_v};
 use crate::dtype;
 use crate::ffi;
 use crate::ffi::MlxArray;

--- a/src/lib/mlxcel-core/src/cache/turbo/mod.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/mod.rs
@@ -53,23 +53,23 @@ pub mod quant3;
 pub mod sparse_v;
 
 pub use allowlist::{
-    is_symmetric_turbo_allowed, symmetric_turbo_warning_message, ALLOWED_SYMMETRIC_TURBO_FAMILIES,
+    ALLOWED_SYMMETRIC_TURBO_FAMILIES, is_symmetric_turbo_allowed, symmetric_turbo_warning_message,
 };
 pub use boundary::{
-    boundary_mode_for, boundary_v_layers_from_env, is_boundary_layer, parse_boundary_v_str,
-    resolve_boundary_count, resolve_layer_mode, resolve_layer_modes, BOUNDARY_V_ENV,
-    BOUNDARY_V_ENV_ALT, DEFAULT_BOUNDARY_V_LAYERS,
+    BOUNDARY_V_ENV, BOUNDARY_V_ENV_ALT, DEFAULT_BOUNDARY_V_LAYERS, boundary_mode_for,
+    boundary_v_layers_from_env, is_boundary_layer, parse_boundary_v_str, resolve_boundary_count,
+    resolve_layer_mode, resolve_layer_modes,
 };
 
 // Re-export the most commonly used entry points for convenience
 pub use codebook::{
-    compute_centroids, nearest_centroid_indices, nearest_centroid_indices_with_boundaries,
-    optimal_centroids, optimal_codebook, Codebook,
+    Codebook, compute_centroids, nearest_centroid_indices,
+    nearest_centroid_indices_with_boundaries, optimal_centroids, optimal_codebook,
 };
 pub use quant::{
-    dequantize_k_turbo4, dequantize_k_turbo4_rotated, dequantize_v_turbo4, generate_signs,
-    quantize_k_turbo4, quantize_v_turbo4, turbo4_k_rotate, turbo4_v_rotate, TurboQuantParams,
-    BLOCK_SIZE, K_BIT_WIDTH, K_SEED_OFFSET, V_BIT_WIDTH,
+    BLOCK_SIZE, K_BIT_WIDTH, K_SEED_OFFSET, TurboQuantParams, V_BIT_WIDTH, dequantize_k_turbo4,
+    dequantize_k_turbo4_rotated, dequantize_v_turbo4, generate_signs, quantize_k_turbo4,
+    quantize_v_turbo4, turbo4_k_rotate, turbo4_v_rotate,
 };
 
 /// Default hot-tail threshold for `KVCacheMode::Turbo4Delegated`.

--- a/src/lib/mlxcel-core/src/cache/turbo/quant.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/quant.rs
@@ -79,7 +79,7 @@ use std::sync::Arc;
 
 use cxx::UniquePtr;
 
-use super::codebook::{nearest_centroid_indices_with_boundaries, optimal_codebook, Codebook};
+use super::codebook::{Codebook, nearest_centroid_indices_with_boundaries, optimal_codebook};
 use crate::dtype;
 use crate::ffi;
 use crate::ffi::MlxArray;

--- a/src/lib/mlxcel-core/src/cache/turbo/quant3.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo/quant3.rs
@@ -61,7 +61,7 @@ use std::sync::Arc;
 
 use cxx::UniquePtr;
 
-use super::codebook::{nearest_centroid_indices_with_boundaries, optimal_codebook, Codebook};
+use super::codebook::{Codebook, nearest_centroid_indices_with_boundaries, optimal_codebook};
 use super::pack3::{pack_3bit_per_token, packed_bytes_per_token_3bit, unpack_3bit_per_token};
 use super::quant::generate_signs;
 use crate::dtype;

--- a/src/lib/mlxcel-core/src/cache/turbo_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/turbo_tests.rs
@@ -853,8 +853,8 @@ fn rotating_turbo4_clone_handle_clears_turbo_params_on_source() {
 mod boundary_v {
     use super::*;
     use crate::cache::turbo::boundary::{
-        is_boundary_layer, resolve_boundary_count, resolve_layer_mode, resolve_layer_modes,
-        DEFAULT_BOUNDARY_V_LAYERS,
+        DEFAULT_BOUNDARY_V_LAYERS, is_boundary_layer, resolve_boundary_count, resolve_layer_mode,
+        resolve_layer_modes,
     };
 
     /// The default count must be the LA-V7 boundary width (2) per the

--- a/src/lib/mlxcel-core/src/drafter/dflash/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/mod.rs
@@ -78,7 +78,7 @@ pub use layer::DFlashDecoderLayer;
 pub use mlp::DFlashMlp;
 pub use model::DFlashDraftModel;
 pub use round_loop::{
-    DFlashGenerator, DFlashRunOutput, SpeculativeTarget, DEFAULT_BLOCK_SIZE, DEFAULT_MASK_TOKEN_ID,
+    DEFAULT_BLOCK_SIZE, DEFAULT_MASK_TOKEN_ID, DFlashGenerator, DFlashRunOutput, SpeculativeTarget,
 };
 pub use round_loop_batched::{DFlashBatchedGenerator, DFlashBatchedRunOutput};
 

--- a/src/lib/mlxcel-core/src/drafter/dflash/round_loop.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/round_loop.rs
@@ -1460,9 +1460,9 @@ mod tests {
 
         let drafter = SyntheticDrafter::new(propose_fn);
         let lm = EmbedOnlyLm;
-        let mut gen = DFlashGenerator::with_drafter(Box::new(drafter), SamplingConfig::greedy());
+        let mut r#gen = DFlashGenerator::with_drafter(Box::new(drafter), SamplingConfig::greedy());
         // Round loop pulls block_size from the generator.
-        gen.block_size = block_size;
+        r#gen.block_size = block_size;
 
         // Build the initial hidden as a `[1, 1, concat_hidden_dim]` tensor.
         // The synthetic target's concat_hidden_for_drafter slices the
@@ -1471,7 +1471,7 @@ mod tests {
         // in the real pipeline).
         let first_hidden = ffi::zeros(&[1, 1, 5 * 8], crate::dtype::FLOAT32);
 
-        let out = gen
+        let out = r#gen
             .run(
                 &target,
                 &lm,
@@ -1510,7 +1510,7 @@ mod tests {
             SyntheticDrafter::new(|bonus, bs| (1..bs as i32).map(|s| bonus + s).collect())
                 .with_target_layer_ids(drafter_ids.clone());
         let lm = EmbedOnlyLm;
-        let mut gen = DFlashGenerator::new(
+        let mut r#gen = DFlashGenerator::new(
             Box::new(drafter),
             SamplingConfig::greedy(),
             4,
@@ -1518,7 +1518,7 @@ mod tests {
         );
         let first_hidden = ffi::zeros(&[1, 1, 5 * 8], crate::dtype::FLOAT32);
 
-        let _ = gen
+        let _ = r#gen
             .run(
                 &target,
                 &lm,
@@ -1752,7 +1752,7 @@ mod tests {
 
         let first_bonus = 100i32;
         let max_tokens = 33; // 1 first_bonus + 32 round-loop emissions
-                             // Build the reference greedy sequence.
+        // Build the reference greedy sequence.
         let mut reference: Vec<i32> = Vec::with_capacity(max_tokens);
         reference.push(first_bonus);
         for _ in 1..max_tokens {
@@ -1851,10 +1851,10 @@ mod tests {
         let mut caches: Vec<SyntheticCache> = (0..3).map(|_| SyntheticCache::default()).collect();
         let drafter = SyntheticDrafter::new(propose_fn);
         let lm = EmbedOnlyLm;
-        let mut gen = DFlashGenerator::with_drafter(Box::new(drafter), SamplingConfig::greedy());
-        gen.block_size = 8;
+        let mut r#gen = DFlashGenerator::with_drafter(Box::new(drafter), SamplingConfig::greedy());
+        r#gen.block_size = 8;
         let first_hidden = ffi::zeros(&[1, 1, 5 * 8], crate::dtype::FLOAT32);
-        let out = gen
+        let out = r#gen
             .run(
                 &target,
                 &lm,

--- a/src/lib/mlxcel-core/src/drafter/dflash/round_loop_batched.rs
+++ b/src/lib/mlxcel-core/src/drafter/dflash/round_loop_batched.rs
@@ -979,13 +979,13 @@ mod tests {
 
         let drafter = SyntheticBatchedDrafter::new(propose_fn);
         let lm = EmbedOnlyLm;
-        let mut gen =
+        let mut r#gen =
             DFlashBatchedGenerator::with_drafter(Box::new(drafter), SamplingConfig::greedy());
-        gen.block_size = block_size;
+        r#gen.block_size = block_size;
 
         let first_hidden = ffi::zeros(&[batch_size as i32, 1, 5 * 8], crate::dtype::FLOAT32);
 
-        let out = gen
+        let out = r#gen
             .run_batched(
                 &target,
                 &lm,

--- a/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
+++ b/src/lib/mlxcel-core/src/drafter/gemma4_assistant/model.rs
@@ -38,7 +38,7 @@
 use crate::drafter::gemma4_assistant::config::{DrafterTextConfig, Gemma4AssistantConfig};
 use crate::drafter::gemma4_assistant::layer::{DraftDecoderLayer, RopeOffset};
 use crate::drafter::masked_embedder::MaskedEmbedder;
-use crate::drafter::masks::{make_drafter_masks_with_valid_len, BatchScalar, LayerType};
+use crate::drafter::masks::{BatchScalar, LayerType, make_drafter_masks_with_valid_len};
 use crate::drafter::{Drafter, DrafterError, DrafterKind, SharedKv};
 use crate::ffi::{self, MlxArray};
 use crate::generate::{LanguageModel, SamplingConfig};

--- a/src/lib/mlxcel-core/src/drafter/masked_embedder.rs
+++ b/src/lib/mlxcel-core/src/drafter/masked_embedder.rs
@@ -376,11 +376,11 @@ impl MaskedEmbedder {
 /// lives — `"masked_embedding"` for the Gemma 4 assistant drafter.
 pub fn sanitize_token_ordering(weights: &mut WeightMap, prefix: &str) {
     let key = format!("{prefix}.token_ordering");
-    if let Some(arr) = weights.get(&key) {
-        if ffi::array_dtype(arr) != crate::dtype::INT32 {
-            let cast = ffi::astype(arr, crate::dtype::INT32);
-            weights.insert(key, cast);
-        }
+    if let Some(arr) = weights.get(&key)
+        && ffi::array_dtype(arr) != crate::dtype::INT32
+    {
+        let cast = ffi::astype(arr, crate::dtype::INT32);
+        weights.insert(key, cast);
     }
 }
 

--- a/src/lib/mlxcel-core/src/drafter/masks.rs
+++ b/src/lib/mlxcel-core/src/drafter/masks.rs
@@ -321,10 +321,11 @@ pub fn bidirectional_swa_mask_with_key_offset(
     let kv_valid_is_scalar = kv_valid_len.map(BatchScalar::is_scalar).unwrap_or(true);
     if let (BatchScalar::Scalar(qo), true, BatchScalar::Scalar(ko)) =
         (query_offset, kv_valid_is_scalar, key_offset)
+        && kv_len <= window
+        && *qo - *ko < window
+        && *ko + kv_len - (*qo + query_len) < window
     {
-        if kv_len <= window && *qo - *ko < window && *ko + kv_len - (*qo + query_len) < window {
-            return None;
-        }
+        return None;
     }
 
     // ----- materialisation -------------------------------------------------
@@ -373,8 +374,8 @@ pub fn bidirectional_swa_mask_with_key_offset(
             let q_range_1d = ffi::arange_i32(0, query_len, 1); // [query_len]
             let q_range = ffi::reshape(&q_range_1d, &[1, query_len]); // [1, query_len]
             let q_idx_2d = ffi::add(&qo_col, &q_range); // [B, query_len]
-                                                        // Reshape for the [B, query_len, kv_len] computation:
-                                                        //   q_idx -> [B, query_len, 1], k_idx -> [1, 1, kv_len].
+            // Reshape for the [B, query_len, kv_len] computation:
+            //   q_idx -> [B, query_len, 1], k_idx -> [1, 1, kv_len].
             let q_idx = ffi::reshape(&q_idx_2d, &[batch, query_len, 1]);
 
             let k_idx = match key_offset {
@@ -395,7 +396,7 @@ pub fn bidirectional_swa_mask_with_key_offset(
             // Per-row kv_valid_len tail-mask.
             let inside = apply_kv_valid_tail_batched(inside, &k_idx, kv_valid_len, batch);
             let bias_3d = build_bias_from_bool(&inside, dtype); // [B, query_len, kv_len]
-                                                                // Reshape to [B, 1, query_len, kv_len].
+            // Reshape to [B, 1, query_len, kv_len].
             Some(ffi::reshape(&bias_3d, &[batch, 1, query_len, kv_len]))
         }
     }

--- a/src/lib/mlxcel-core/src/drafter/mod.rs
+++ b/src/lib/mlxcel-core/src/drafter/mod.rs
@@ -300,9 +300,7 @@ pub enum DrafterError {
     /// Drafter encountered a layer with a `layer_type` string that does not
     /// map to any shared-K/V bucket the round-loop set up. The two known
     /// buckets are `"full_attention"` and `"sliding_attention"`.
-    #[error(
-        "drafter saw unknown layer_type {got:?}; expected full_attention or sliding_attention"
-    )]
+    #[error("drafter saw unknown layer_type {got:?}; expected full_attention or sliding_attention")]
     UnknownLayerType { got: String },
 
     /// Drafter has a layer of the named layer-type but the round-loop did

--- a/src/lib/mlxcel-core/src/generate.rs
+++ b/src/lib/mlxcel-core/src/generate.rs
@@ -34,9 +34,9 @@ use crate::generation_policy::{
 };
 use crate::hardware;
 use crate::layers::KVCache;
-use crate::loop_detection::{detect_repetition_loop, LoopDetectionConfig};
+use crate::loop_detection::{LoopDetectionConfig, detect_repetition_loop};
 use crate::sampling::{
-    sample_token_optimized, sample_token_optimized_with_state, SamplerState, TokenBiasMap,
+    SamplerState, TokenBiasMap, sample_token_optimized, sample_token_optimized_with_state,
 };
 use crate::streams::{install_thread_local_default_stream, new_thread_local_generation_stream};
 use crate::utils::{align_to_na_tile, create_padded_prefill_mask};
@@ -1200,10 +1200,10 @@ impl CxxGenerator {
                 } else {
                     None
                 };
-                if n == 0 {
-                    if let Ok(path) = std::env::var("MLXCEL_EXPORT_DECODE_DOT") {
-                        ffi::export_to_dot_pair(&path, &next_tok, &next_log);
-                    }
+                if n == 0
+                    && let Ok(path) = std::env::var("MLXCEL_EXPORT_DECODE_DOT")
+                {
+                    ffi::export_to_dot_pair(&path, &next_tok, &next_log);
                 }
                 // Optional Metal GPU capture of one warm decode token for
                 // per-kernel profiling vs mlx-lm. Fires at n==2 so
@@ -1211,18 +1211,18 @@ impl CxxGenerator {
                 // launched with `MTL_CAPTURE_ENABLED=1`; writes a `.gputrace`
                 // bundle to the given path, comparable with mlx-lm's
                 // `mx.metal.start_capture`.
-                if n == 2 {
-                    if let Ok(path) = std::env::var("MLXCEL_CAPTURE_DECODE") {
-                        ffi::metal_start_capture(&path);
-                        ffi::eval(&next_tok);
-                        ffi::metal_stop_capture();
-                        // Exit immediately so the GPU trace document finalizes
-                        // with exactly one captured decode token and no further
-                        // GPU work polluting it (mirrors mlx-lm's capture-script
-                        // lifecycle). Capture mode is a profiling-only path.
-                        eprintln!("[capture] wrote one decode token to {path}");
-                        std::process::exit(0);
-                    }
+                if n == 2
+                    && let Ok(path) = std::env::var("MLXCEL_CAPTURE_DECODE")
+                {
+                    ffi::metal_start_capture(&path);
+                    ffi::eval(&next_tok);
+                    ffi::metal_stop_capture();
+                    // Exit immediately so the GPU trace document finalizes
+                    // with exactly one captured decode token and no further
+                    // GPU work polluting it (mirrors mlx-lm's capture-script
+                    // lifecycle). Capture mode is a profiling-only path.
+                    eprintln!("[capture] wrote one decode token to {path}");
+                    std::process::exit(0);
                 }
                 if force_sync {
                     ffi::eval(&next_tok);
@@ -1292,11 +1292,14 @@ impl CxxGenerator {
             }
 
             // Move to next
-            if let (Some(ny), Some(nl)) = (next_y, next_logprobs) {
-                y = ny;
-                _logprobs = nl;
-            } else {
-                break;
+            match (next_y, next_logprobs) {
+                (Some(ny), Some(nl)) => {
+                    y = ny;
+                    _logprobs = nl;
+                }
+                _ => {
+                    break;
+                }
             }
 
             n += 1;
@@ -1492,11 +1495,14 @@ impl CxxGenerator {
                 ffi::clear_memory_cache();
             }
 
-            if let (Some(ny), Some(nl)) = (next_y, next_logprobs) {
-                y = ny;
-                _logprobs = nl;
-            } else {
-                break;
+            match (next_y, next_logprobs) {
+                (Some(ny), Some(nl)) => {
+                    y = ny;
+                    _logprobs = nl;
+                }
+                _ => {
+                    break;
+                }
             }
 
             n += 1;

--- a/src/lib/mlxcel-core/src/generation_policy.rs
+++ b/src/lib/mlxcel-core/src/generation_policy.rs
@@ -63,7 +63,7 @@ mod tests {
     };
     use crate::generate::{LanguageModel, SamplingConfig};
     use crate::layers::KVCache;
-    use crate::{dtype, ones, MlxArray, UniquePtr};
+    use crate::{MlxArray, UniquePtr, dtype, ones};
 
     struct DummyModel {
         layers: usize,

--- a/src/lib/mlxcel-core/src/hardware.rs
+++ b/src/lib/mlxcel-core/src/hardware.rs
@@ -151,10 +151,10 @@ pub fn is_m5_neural_accelerator() -> bool {
 /// environment always wins (see [`apply_metal_ops_per_buffer_default`]).
 #[must_use]
 pub fn metal_ops_per_buffer_default(
-    gen: AppleSiliconGen,
+    r#gen: AppleSiliconGen,
     has_neural_accelerator: bool,
 ) -> Option<u32> {
-    if gen != AppleSiliconGen::Unknown && !has_neural_accelerator {
+    if r#gen != AppleSiliconGen::Unknown && !has_neural_accelerator {
         Some(1000)
     } else {
         None
@@ -175,10 +175,14 @@ pub fn apply_metal_ops_per_buffer_default() {
     }
     let hw = get_hardware();
     if let Some(value) = metal_ops_per_buffer_default(hw.silicon_gen, hw.has_neural_accelerator) {
-        // Safe: mlxcel-core is edition 2021 (set_var is not `unsafe` here), and
-        // the documented contract requires callers to invoke this early in
-        // `main()`, before other threads or MLX touch the environment.
-        std::env::set_var("MLX_MAX_OPS_PER_BUFFER", value.to_string());
+        // SAFETY: set_var mutates the process-global environment and is unsound
+        // only if another thread reads or writes the environment concurrently.
+        // Per this function's documented contract, all in-tree callers invoke it
+        // once at the top of `main` right after CLI parsing (src/main.rs,
+        // src/bin/mlx_server.rs, src/bin/bench_decode.rs), before any model load,
+        // MLX op, or worker thread touches the environment, so no other thread is
+        // accessing it here.
+        unsafe { std::env::set_var("MLX_MAX_OPS_PER_BUFFER", value.to_string()) };
     }
 }
 
@@ -206,7 +210,7 @@ mod platform {
     use std::os::raw::{c_char, c_int, c_void};
 
     // sysctlbyname(3) is in <sys/sysctl.h> — link against libSystem automatically.
-    extern "C" {
+    unsafe extern "C" {
         fn sysctlbyname(
             name: *const c_char,
             oldp: *mut c_void,
@@ -396,8 +400,8 @@ fn parse_macos_version(version: &str) -> (u32, u32) {
 /// memory configuration.  Values are midpoints from Apple's published specs
 /// for the base chip variant at the given memory size.
 #[cfg(target_os = "macos")]
-fn estimate_bandwidth(gen: AppleSiliconGen, memory_gb: u32) -> f64 {
-    match gen {
+fn estimate_bandwidth(r#gen: AppleSiliconGen, memory_gb: u32) -> f64 {
+    match r#gen {
         AppleSiliconGen::M1 => {
             if memory_gb > 16 {
                 400.0 // M1 Max / Ultra
@@ -434,11 +438,7 @@ fn estimate_bandwidth(gen: AppleSiliconGen, memory_gb: u32) -> f64 {
         }
         AppleSiliconGen::M5 => {
             // Estimated; update once Apple publishes official specs.
-            if memory_gb > 64 {
-                1000.0
-            } else {
-                150.0
-            }
+            if memory_gb > 64 { 1000.0 } else { 150.0 }
         }
         AppleSiliconGen::Unknown => 0.0,
     }

--- a/src/lib/mlxcel-core/src/lang_analyzer/cache.rs
+++ b/src/lib/mlxcel-core/src/lang_analyzer/cache.rs
@@ -30,7 +30,7 @@ use std::path::PathBuf;
 
 use tokenizers::Tokenizer;
 
-use super::{LangAnalyzerError, TokenLanguageIndex, CURRENT_VERSION};
+use super::{CURRENT_VERSION, LangAnalyzerError, TokenLanguageIndex};
 
 /// Sub-directory under the mlxcel cache root that holds tokenizer index files.
 pub const CACHE_SUBDIR: &str = "tokenizer-scripts";
@@ -170,10 +170,8 @@ pub fn load_or_build(
 ) -> Result<TokenLanguageIndex, LangAnalyzerError> {
     let hash = TokenLanguageIndex::compute_vocab_hash(tokenizer_json_bytes);
 
-    if !rebuild {
-        if let Some(idx) = try_load(&hash) {
-            return Ok(idx);
-        }
+    if !rebuild && let Some(idx) = try_load(&hash) {
+        return Ok(idx);
     }
 
     let idx = TokenLanguageIndex::build(tokenizer, tokenizer_json_bytes)?;
@@ -252,9 +250,11 @@ mod tests {
         let override_dir = tmp.path().to_path_buf();
 
         let _guard = env_lock();
-        std::env::set_var("MLXCEL_CACHE_DIR", &override_dir);
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::set_var("MLXCEL_CACHE_DIR", &override_dir) };
         let path = cache_path("deadbeef12345678");
-        std::env::remove_var("MLXCEL_CACHE_DIR");
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::remove_var("MLXCEL_CACHE_DIR") };
         drop(_guard);
 
         assert!(
@@ -283,10 +283,12 @@ mod tests {
         let idx = build_test_index(&json);
 
         let _guard = env_lock();
-        std::env::set_var("MLXCEL_CACHE_DIR", tmp.path());
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::set_var("MLXCEL_CACHE_DIR", tmp.path()) };
         save(&idx).expect("save should succeed");
         let loaded = try_load(&idx.vocab_hash);
-        std::env::remove_var("MLXCEL_CACHE_DIR");
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::remove_var("MLXCEL_CACHE_DIR") };
         drop(_guard);
 
         let loaded = loaded.expect("try_load should return Some after save");
@@ -311,10 +313,12 @@ mod tests {
         idx.version = CURRENT_VERSION + 99; // future version — cache is stale
 
         let _guard = env_lock();
-        std::env::set_var("MLXCEL_CACHE_DIR", tmp.path());
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::set_var("MLXCEL_CACHE_DIR", tmp.path()) };
         save(&idx).expect("save should succeed");
         let result = try_load(&idx.vocab_hash);
-        std::env::remove_var("MLXCEL_CACHE_DIR");
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::remove_var("MLXCEL_CACHE_DIR") };
         drop(_guard);
 
         assert!(
@@ -342,7 +346,8 @@ mod tests {
         idx_v2.version = 2;
 
         let _guard = env_lock();
-        std::env::set_var("MLXCEL_CACHE_DIR", tmp.path());
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::set_var("MLXCEL_CACHE_DIR", tmp.path()) };
         save(&idx_v2).expect("save v2 cache");
 
         // `try_load` must refuse the v2 cache.
@@ -355,7 +360,8 @@ mod tests {
         // `load_or_build` must rebuild to the current version.
         let rebuilt =
             load_or_build(&tok, &json_bytes, false).expect("load_or_build should rebuild v2→v3");
-        std::env::remove_var("MLXCEL_CACHE_DIR");
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::remove_var("MLXCEL_CACHE_DIR") };
         drop(_guard);
 
         assert_eq!(
@@ -380,14 +386,16 @@ mod tests {
         let hash = "aabbccddeeff0011";
 
         let _guard = env_lock();
-        std::env::set_var("MLXCEL_CACHE_DIR", tmp.path());
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::set_var("MLXCEL_CACHE_DIR", tmp.path()) };
         let path = cache_path(hash);
         std::fs::create_dir_all(path.parent().unwrap()).expect("create dirs");
         std::fs::write(&path, b"not valid postcard data!!!").expect("write garbage");
         let result = try_load(hash);
         let path_still_exists = path.exists();
         let cache_dir = path.parent().unwrap().to_path_buf();
-        std::env::remove_var("MLXCEL_CACHE_DIR");
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::remove_var("MLXCEL_CACHE_DIR") };
         drop(_guard);
 
         assert!(
@@ -429,7 +437,8 @@ mod tests {
         let tok = make_tokenizer(&json);
 
         let _guard = env_lock();
-        std::env::set_var("MLXCEL_CACHE_DIR", tmp.path());
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::set_var("MLXCEL_CACHE_DIR", tmp.path()) };
 
         // First call — must build and save.
         let idx1 =
@@ -448,7 +457,8 @@ mod tests {
             .modified()
             .expect("mtime");
 
-        std::env::remove_var("MLXCEL_CACHE_DIR");
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::remove_var("MLXCEL_CACHE_DIR") };
         drop(_guard);
 
         assert_eq!(
@@ -475,7 +485,8 @@ mod tests {
         let tok = make_tokenizer(&json);
 
         let _guard = env_lock();
-        std::env::set_var("MLXCEL_CACHE_DIR", tmp.path());
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::set_var("MLXCEL_CACHE_DIR", tmp.path()) };
 
         // First call — build and save.
         let idx1 = load_or_build(&tok, &json_bytes, false).expect("first load_or_build");
@@ -496,7 +507,8 @@ mod tests {
             .modified()
             .expect("mtime");
 
-        std::env::remove_var("MLXCEL_CACHE_DIR");
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::remove_var("MLXCEL_CACHE_DIR") };
         drop(_guard);
 
         assert_eq!(
@@ -539,7 +551,8 @@ mod tests {
         let tok = Tokenizer::from_bytes(&json_bytes).expect("parse tokenizer");
 
         let _guard = env_lock();
-        std::env::set_var("MLXCEL_CACHE_DIR", tmp.path());
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::set_var("MLXCEL_CACHE_DIR", tmp.path()) };
 
         // First call — build and persist.
         let idx1 =
@@ -559,7 +572,8 @@ mod tests {
             .expect("second load_or_build on real tokenizer");
         let mtime2 = std::fs::metadata(&path).unwrap().modified().unwrap();
 
-        std::env::remove_var("MLXCEL_CACHE_DIR");
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::remove_var("MLXCEL_CACHE_DIR") };
         drop(_guard);
 
         assert_eq!(idx1.vocab_hash, idx2.vocab_hash);

--- a/src/lib/mlxcel-core/src/lang_analyzer/mod.rs
+++ b/src/lib/mlxcel-core/src/lang_analyzer/mod.rs
@@ -397,22 +397,20 @@ impl TokenLanguageIndex {
             // which would cause the exception-config filter to reject the
             // fragment even with `include_byte_fragments = true`.
             let mut is_byte_fragment = false;
-            if !is_special && scripts.is_empty() {
-                if let Some(reverse) = &byte_reverse {
-                    if token_str.is_empty() || token_str.chars().any(|c| c == '\u{FFFD}') {
-                        if let Some(raw_byte) = reverse_byte_for_token(tokenizer, id, reverse) {
-                            if let Some(script) = classify_byte_start(raw_byte) {
-                                scripts.push(script);
-                                is_byte_fragment = true;
-                                // U+FFFD-driven punctuation/numeric flags are
-                                // an artifact of the decode path, not the
-                                // token's real nature.
-                                is_num = false;
-                                is_punct = false;
-                            }
-                        }
-                    }
-                }
+            if !is_special
+                && scripts.is_empty()
+                && let Some(reverse) = &byte_reverse
+                && (token_str.is_empty() || token_str.chars().any(|c| c == '\u{FFFD}'))
+                && let Some(raw_byte) = reverse_byte_for_token(tokenizer, id, reverse)
+                && let Some(script) = classify_byte_start(raw_byte)
+            {
+                scripts.push(script);
+                is_byte_fragment = true;
+                // U+FFFD-driven punctuation/numeric flags are
+                // an artifact of the decode path, not the
+                // token's real nature.
+                is_num = false;
+                is_punct = false;
             }
 
             // Populate the inverted index. Exception flags do NOT exclude from
@@ -1437,7 +1435,7 @@ mod tests {
             InclusionPolicy::Conservative,
             &ExceptionConfig::default(),
         );
-        let bias = map.iter().find(|(&id, _)| id == 10).map(|(_, &b)| b);
+        let bias = map.iter().find(|&(&id, _)| id == 10).map(|(_, &b)| b);
         assert_eq!(
             bias,
             Some(3.0_f32),
@@ -1469,28 +1467,28 @@ mod tests {
             &ExceptionConfig::default(),
         );
         // Hangul token (id=20) present with +5.0
-        let ko_bias = map.iter().find(|(&id, _)| id == 20).map(|(_, &b)| b);
+        let ko_bias = map.iter().find(|&(&id, _)| id == 20).map(|(_, &b)| b);
         assert_eq!(
             ko_bias,
             Some(5.0_f32),
             "Hangul token bias mismatch: {ko_bias:?}"
         );
         // Han token (id=21) also claimed by ko (Conservative includes Han) with +5.0
-        let han_bias = map.iter().find(|(&id, _)| id == 21).map(|(_, &b)| b);
+        let han_bias = map.iter().find(|&(&id, _)| id == 21).map(|(_, &b)| b);
         assert_eq!(
             han_bias,
             Some(5.0_f32),
             "Han token (ko Conservative) bias mismatch: {han_bias:?}"
         );
         // Latin token (id=22) claimed by en with -3.5
-        let en_bias = map.iter().find(|(&id, _)| id == 22).map(|(_, &b)| b);
+        let en_bias = map.iter().find(|&(&id, _)| id == 22).map(|(_, &b)| b);
         assert_eq!(
             en_bias,
             Some(-3.5_f32),
             "Latin token bias mismatch: {en_bias:?}"
         );
         // Greek token (id=23) not in ko or en — absent
-        let el_bias = map.iter().find(|(&id, _)| id == 23).map(|(_, &b)| b);
+        let el_bias = map.iter().find(|&(&id, _)| id == 23).map(|(_, &b)| b);
         assert!(
             el_bias.is_none(),
             "Greek token should not appear for ko+en: {el_bias:?}"
@@ -1509,7 +1507,7 @@ mod tests {
             InclusionPolicy::Conservative,
             &ExceptionConfig::default(),
         );
-        let bias = map.iter().find(|(&id, _)| id == 30).map(|(_, &b)| b);
+        let bias = map.iter().find(|&(&id, _)| id == 30).map(|(_, &b)| b);
         assert_eq!(
             bias,
             Some(f32::NEG_INFINITY),
@@ -1586,9 +1584,9 @@ mod tests {
         );
 
         // Bias values are correct.
-        let bias_1: Vec<_> = map.iter().filter(|(&id, _)| id == 1).collect();
+        let bias_1: Vec<_> = map.iter().filter(|&(&id, _)| id == 1).collect();
         assert_eq!(bias_1[0].1, &-100.0_f32);
-        let bias_2: Vec<_> = map.iter().filter(|(&id, _)| id == 2).collect();
+        let bias_2: Vec<_> = map.iter().filter(|&(&id, _)| id == 2).collect();
         assert_eq!(bias_2[0].1, &2.0_f32);
 
         // The map is non-empty and has exactly 3 entries (ids 1, 2, 3).
@@ -1654,7 +1652,8 @@ mod tests {
         );
 
         let _guard = env_lock();
-        std::env::set_var("MLXCEL_CACHE_DIR", tmp.path());
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::set_var("MLXCEL_CACHE_DIR", tmp.path()) };
 
         // Call the resolver; it must NOT touch the cache for an empty bias set.
         let map = config
@@ -1668,7 +1667,8 @@ mod tests {
             .map(|rd| rd.count())
             .unwrap_or(0);
 
-        std::env::remove_var("MLXCEL_CACHE_DIR");
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::remove_var("MLXCEL_CACHE_DIR") };
         drop(_guard);
 
         assert!(
@@ -1706,6 +1706,7 @@ mod tests {
         };
 
         let _guard = env_lock();
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
         unsafe {
             std::env::set_var("MLXCEL_CACHE_DIR", tmp.path());
         }
@@ -1731,7 +1732,8 @@ mod tests {
             .ok()
             .and_then(|m| m.modified().ok());
 
-        std::env::remove_var("MLXCEL_CACHE_DIR");
+        // SAFETY: test-only; env mutation is serialized by the env_lock() guard held above.
+        unsafe { std::env::remove_var("MLXCEL_CACHE_DIR") };
         drop(_guard);
 
         assert!(
@@ -2090,9 +2092,9 @@ mod tests {
         // as a codepoint, which is 'å' (U+00E5).
         let char_e5 = '\u{00E5}'; // byte 0xE5 → 'å' in the GPT-2 alphabet
         let char_b4 = '\u{0174}'; // byte 0xB4 is NOT in the printable set,
-                                  // so it maps to the first free slot above 0x100.
-                                  // We don't need to compute the exact char here — we discover it at
-                                  // runtime from the reverse map so this test stays robust.
+        // so it maps to the first free slot above 0x100.
+        // We don't need to compute the exact char here — we discover it at
+        // runtime from the reverse map so this test stays robust.
 
         let reverse = build_byte_level_reverse_map();
         // Sanity: 0xE5 really is 'å' in the forward map.
@@ -2100,7 +2102,7 @@ mod tests {
         // Find whatever char maps to byte 0xB4 (continuation byte).
         let char_b4_actual = reverse
             .iter()
-            .find(|(_, &b)| b == 0xB4)
+            .find(|&(_, &b)| b == 0xB4)
             .map(|(&c, _)| c)
             .expect("byte 0xB4 must have a forward-map char");
         let _ = char_b4;

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -24,8 +24,8 @@
 use crate::ffi;
 use crate::ffi::MlxArray;
 use cxx::UniquePtr;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub use crate::cache::{ChunkedKVCache, KVCache, KVCacheMode, RotatingKVCache};
 
@@ -671,14 +671,14 @@ impl Linear {
         let mut result = ffi::matmul(x, &wt);
 
         // Apply runtime LoRA: result += (x @ A.T) @ B.T * scale
-        if let Some(ref lora) = self.lora {
-            if lora.active.get() {
-                let at = ffi::transpose(&lora.a);
-                let bt = ffi::transpose(&lora.b);
-                let lora_out = ffi::matmul(&ffi::matmul(x, &at), &bt);
-                let scaled = crate::multiply_scalar(&lora_out, lora.scale);
-                result = ffi::add(&result, &scaled);
-            }
+        if let Some(ref lora) = self.lora
+            && lora.active.get()
+        {
+            let at = ffi::transpose(&lora.a);
+            let bt = ffi::transpose(&lora.b);
+            let lora_out = ffi::matmul(&ffi::matmul(x, &at), &bt);
+            let scaled = crate::multiply_scalar(&lora_out, lora.scale);
+            result = ffi::add(&result, &scaled);
         }
 
         match &self.bias {
@@ -2719,10 +2719,10 @@ pub fn paged_decode_attention_pooled(
     scale: f32,
     use_native_paged_kernel: bool,
 ) -> Result<UniquePtr<MlxArray>, String> {
-    if use_native_paged_kernel || native_paged_kernel_env() {
-        if let Some(out) = pool.paged_decode_fused(q, states, layer_idx, scale)? {
-            return Ok(out);
-        }
+    if (use_native_paged_kernel || native_paged_kernel_env())
+        && let Some(out) = pool.paged_decode_fused(q, states, layer_idx, scale)?
+    {
+        return Ok(out);
     }
     paged_decode_attention_pooled_fallback(q, pool, states, layer_idx, scale)
 }

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -2236,11 +2236,11 @@ mod ffi {
 
         /// Quantize weights — scales
         fn quantize_weights_scales(w: &MlxArray, group_size: i32, bits: i32)
-            -> UniquePtr<MlxArray>;
+        -> UniquePtr<MlxArray>;
 
         /// Quantize weights — biases
         fn quantize_weights_biases(w: &MlxArray, group_size: i32, bits: i32)
-            -> UniquePtr<MlxArray>;
+        -> UniquePtr<MlxArray>;
 
         // -------------------------------------------------------------------
         // Fused Sparse-V SDPA Metal kernel.
@@ -2413,7 +2413,7 @@ mod ffi {
         /// outputs struct. After this call the struct's `out_cold_pre` slot
         /// is empty; calling again returns a null UniquePtr.
         fn steel_outputs_take_cold(o: Pin<&mut Turbo4DelegatedSteelOutputs>)
-            -> UniquePtr<MlxArray>;
+        -> UniquePtr<MlxArray>;
 
         /// Take (move out) the hot weighted sum from a steel SDPA outputs
         /// struct. After this call the struct's `out_hot` slot is empty.
@@ -2449,7 +2449,7 @@ pub use ops::{concatenate, divide_scalar, multiply_scalar, stack, stack_owned, w
 pub use sampling::TokenBiasMap;
 // Re-export N-gram loop-detection so the server control plane and CLI decode
 // loops can configure and run early-stop on degenerate token-repetition.
-pub use loop_detection::{detect_repetition_loop, LoopDetectionConfig};
+pub use loop_detection::{LoopDetectionConfig, detect_repetition_loop};
 // Re-export B9 observability counter accessors so the server `/metrics` handler
 // can read process-wide lang-bias counters without a struct dependency.
 // Includes the byte-fragment suppression counter added.
@@ -2495,7 +2495,13 @@ pub fn ensure_persistent_ptx_cache() {
     let scope = &commit[..commit.len().min(12)];
     let dir = root.join("cuda-ptx").join(scope);
     if std::fs::create_dir_all(&dir).is_ok() {
-        std::env::set_var("MLX_PTX_CACHE_DIR", &dir);
+        // SAFETY: set_var mutates the process-global environment and is unsound
+        // only under a concurrent getenv/setenv on another thread. Per this
+        // function's documented contract, all in-tree callers invoke it once at
+        // startup right after CLI parsing (src/main.rs, src/bin/mlx_server.rs),
+        // before the first CUDA NVRTC JIT compile, any model load, or any worker
+        // thread touches the environment, so no other thread is accessing it here.
+        unsafe { std::env::set_var("MLX_PTX_CACHE_DIR", &dir) };
     }
 }
 

--- a/src/lib/mlxcel-core/src/loop_detection_tests.rs
+++ b/src/lib/mlxcel-core/src/loop_detection_tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{detect_repetition_loop, LoopDetectionConfig, MAX_EFFECTIVE_PATTERN_SIZE};
+use super::{LoopDetectionConfig, MAX_EFFECTIVE_PATTERN_SIZE, detect_repetition_loop};
 
 /// The conservative starting threshold the server applies for the Gemma 4
 /// amplifier case (`min_pattern_size=1, max_pattern_size=20, min_count=4`).

--- a/src/lib/mlxcel-core/src/rope_proportional.rs
+++ b/src/lib/mlxcel-core/src/rope_proportional.rs
@@ -29,8 +29,8 @@
 //! Used by: Gemma4
 
 use crate::{
-    array_shape, compiled_proportional_rope, concatenate, copy, fast_rope_with_freqs,
-    from_slice_f32, slice, MlxArray, UniquePtr,
+    MlxArray, UniquePtr, array_shape, compiled_proportional_rope, concatenate, copy,
+    fast_rope_with_freqs, from_slice_f32, slice,
 };
 
 /// Compute the frequency table for proportional RoPE.

--- a/src/lib/mlxcel-core/src/sampling.rs
+++ b/src/lib/mlxcel-core/src/sampling.rs
@@ -809,10 +809,10 @@ impl SamplerState {
 
     /// Absorb a single newly appended token into the tracked structures.
     fn absorb_one(&mut self, token: i32) {
-        if self.track_seen {
-            if let Err(pos) = self.seen_sorted.binary_search(&token) {
-                self.seen_sorted.insert(pos, token);
-            }
+        if self.track_seen
+            && let Err(pos) = self.seen_sorted.binary_search(&token)
+        {
+            self.seen_sorted.insert(pos, token);
         }
         if self.track_counts {
             *self.counts.entry(token).or_insert(0) += 1;

--- a/src/lib/mlxcel-core/src/speculative/mod.rs
+++ b/src/lib/mlxcel-core/src/speculative/mod.rs
@@ -46,7 +46,7 @@ use crate::generate::{GenerationStats, LanguageModel, SamplingConfig};
 use crate::generation_policy::{initial_token_history, merged_eos_token_ids};
 use crate::hardware;
 use crate::layers::KVCache;
-use crate::sampling::{sample_token_optimized, TokenBiasMap};
+use crate::sampling::{TokenBiasMap, sample_token_optimized};
 use crate::streams::{install_thread_local_default_stream, new_thread_local_generation_stream};
 use crate::utils::{align_to_na_tile, create_padded_prefill_mask};
 use cxx::UniquePtr;

--- a/src/lib/mlxcel-core/src/streams.rs
+++ b/src/lib/mlxcel-core/src/streams.rs
@@ -39,9 +39,9 @@
 //! deployments where construction and execution can happen on
 //! different threads.
 
+use crate::UniquePtr;
 use crate::ffi;
 use crate::ffi::{MlxStream, MlxThreadLocalStream};
-use crate::UniquePtr;
 
 /// Create a thread-local generation stream bound to the GPU device.
 ///

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -545,12 +545,12 @@ pub fn create_causal_mask_with_window(
     // Apply sliding window upper-bound only when the mask is NOT capped.
     // In the capped path the column range is already the window; the upper
     // bound (q <= k + window - 1) is trivially satisfied.
-    if let Some(w) = window {
-        if uncapped_len <= w {
-            // Non-capped path: enforce window upper bound.
-            let upper_mask = ffi::triu(&ones, offset - w + 1);
-            mask = ffi::multiply(&mask, &upper_mask);
-        }
+    if let Some(w) = window
+        && uncapped_len <= w
+    {
+        // Non-capped path: enforce window upper bound.
+        let upper_mask = ffi::triu(&ones, offset - w + 1);
+        mask = ffi::multiply(&mask, &upper_mask);
     }
 
     // Convert to attention mask format: where mask=1 -> 0, where mask=0 -> -inf
@@ -743,11 +743,11 @@ pub fn create_causal_bool_mask_with_window(
     let ones = ffi::ones(&[size, total_len], dtype::FLOAT32);
     let mut mask = ffi::tril(&ones, tril_offset);
 
-    if let Some(w) = window {
-        if uncapped_len <= w {
-            let upper_mask = ffi::triu(&ones, offset - w + 1);
-            mask = ffi::multiply(&mask, &upper_mask);
-        }
+    if let Some(w) = window
+        && uncapped_len <= w
+    {
+        let upper_mask = ffi::triu(&ones, offset - w + 1);
+        mask = ffi::multiply(&mask, &upper_mask);
     }
 
     let zeros = ffi::zeros(&[size, total_len], dtype::FLOAT32);

--- a/src/lib/mlxcel-core/src/weights.rs
+++ b/src/lib/mlxcel-core/src/weights.rs
@@ -127,10 +127,10 @@ fn extract_shards_and_total_size(json: &str) -> Result<(Vec<String>, Option<u64>
     let mut seen = std::collections::HashSet::new();
     let mut shards = Vec::new();
     for value in weight_map.values() {
-        if let Some(s) = value.as_str() {
-            if seen.insert(s.to_string()) {
-                shards.push(s.to_string());
-            }
+        if let Some(s) = value.as_str()
+            && seen.insert(s.to_string())
+        {
+            shards.push(s.to_string());
         }
     }
 
@@ -246,14 +246,14 @@ pub fn weight_footprint_bytes<P: AsRef<Path>>(model_dir: P) -> Option<u64> {
     // 1. Try sharded index first, but only trust it if the loader would use the
     // same shard list. Repackaged mlx-community quants can ship stale upstream
     // indexes; using their metadata.total_size would over-reject preflight.
-    if let Ok(Some((shards, total_size))) = parse_shard_index_with_total_size(dir) {
-        if let Ok(paths) = validate_index_shards(dir, &shards) {
-            if let Some(total_size) = total_size {
-                return Some(total_size);
-            }
-            if let Some(total) = sum_safetensors_header_bytes(&paths) {
-                return Some(total);
-            }
+    if let Ok(Some((shards, total_size))) = parse_shard_index_with_total_size(dir)
+        && let Ok(paths) = validate_index_shards(dir, &shards)
+    {
+        if let Some(total_size) = total_size {
+            return Some(total_size);
+        }
+        if let Some(total) = sum_safetensors_header_bytes(&paths) {
+            return Some(total);
         }
     }
 
@@ -768,12 +768,16 @@ mod tests {
 
         let paths = collect_shard_paths(dir.path()).expect("should succeed");
         assert_eq!(paths.len(), 2);
-        assert!(paths
-            .iter()
-            .any(|p| p.file_name().unwrap() == "model-00001-of-00002.safetensors"));
-        assert!(paths
-            .iter()
-            .any(|p| p.file_name().unwrap() == "model-00002-of-00002.safetensors"));
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.file_name().unwrap() == "model-00001-of-00002.safetensors")
+        );
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.file_name().unwrap() == "model-00002-of-00002.safetensors")
+        );
     }
 
     #[test]

--- a/src/lib/mlxcel-surgery/Cargo.toml
+++ b/src/lib/mlxcel-surgery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mlxcel-surgery"
-version = "0.1.0"
-edition = "2021"
+version = "0.3.3"
+edition = "2024"
 description = "Weight-load surgery framework for mlxcel (structural fine-tuning)"
 license = "Apache-2.0"
 

--- a/src/lib/mlxcel-surgery/src/config.rs
+++ b/src/lib/mlxcel-surgery/src/config.rs
@@ -69,9 +69,9 @@ use std::sync::Arc;
 use globset::{Glob, GlobMatcher};
 use serde::Deserialize;
 
-use crate::ops::{InterpolateOp, ScaleOp};
 #[cfg(test)]
 use crate::WeightMap;
+use crate::ops::{InterpolateOp, ScaleOp};
 use crate::{SharedSurgeryOp, SurgeryError, SurgeryPipeline};
 
 /// The only schema version this parser understands. Bump when the

--- a/src/lib/mlxcel-surgery/src/lib.rs
+++ b/src/lib/mlxcel-surgery/src/lib.rs
@@ -53,8 +53,8 @@ pub mod ops;
 mod pipeline;
 
 pub use config::{
-    parse_config_file, parse_config_str, InterpolateMethod, OpSpec, PruneGranularity,
-    SurgeryConfig, SUPPORTED_SCHEMA_VERSION,
+    InterpolateMethod, OpSpec, PruneGranularity, SUPPORTED_SCHEMA_VERSION, SurgeryConfig,
+    parse_config_file, parse_config_str,
 };
 pub use error::SurgeryError;
 pub use ops::{AddOp, InterpolateOp, PruneOp, PruneSelector, ReplaceOp, ScaleOp};
@@ -103,8 +103,8 @@ mod tests {
     //! pipeline is invoked through A1's `WeightTransform` hook with
     //! no-op semantics yielding bit-exactness vs the `None` path.
 
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
 

--- a/src/lib/mlxcel-surgery/src/ops/add.rs
+++ b/src/lib/mlxcel-surgery/src/ops/add.rs
@@ -68,10 +68,10 @@ use std::path::{Path, PathBuf};
 
 use globset::{Glob, GlobMatcher};
 use mlxcel_core::dtype as mlx_dtype;
-use mlxcel_core::weights::{load_safetensors, WeightMap};
+use mlxcel_core::weights::{WeightMap, load_safetensors};
 use mlxcel_core::{
-    add as mlx_add, array_dtype, array_shape, astype, copy as mlx_copy, multiply_scalar, MlxArray,
-    UniquePtr,
+    MlxArray, UniquePtr, add as mlx_add, array_dtype, array_shape, astype, copy as mlx_copy,
+    multiply_scalar,
 };
 
 use crate::{SurgeryError, SurgeryOp};

--- a/src/lib/mlxcel-surgery/src/ops/add_apply_tests.rs
+++ b/src/lib/mlxcel-surgery/src/ops/add_apply_tests.rs
@@ -28,7 +28,7 @@ use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{array_dtype, astype};
 
 use super::add::AddOp;
-use super::add_test_helpers::{extract_f32, f32_tensor, mlx_f32, write_single_donor, OwnedTensor};
+use super::add_test_helpers::{OwnedTensor, extract_f32, f32_tensor, mlx_f32, write_single_donor};
 use crate::SurgeryOp;
 
 #[test]

--- a/src/lib/mlxcel-surgery/src/ops/add_test_helpers.rs
+++ b/src/lib/mlxcel-surgery/src/ops/add_test_helpers.rs
@@ -25,9 +25,9 @@
 use std::path::Path;
 
 use mlxcel_core::dtype as mlx_dtype;
-use mlxcel_core::{array_to_raw_bytes, eval, from_bytes, MlxArray, UniquePtr};
-use safetensors::tensor::Dtype as SafeTensorDtype;
+use mlxcel_core::{MlxArray, UniquePtr, array_to_raw_bytes, eval, from_bytes};
 use safetensors::View;
+use safetensors::tensor::Dtype as SafeTensorDtype;
 
 /// A `safetensors::View` impl over owned bytes — copied from the
 /// pattern used in `src/distributed/pipeline/partial_loading_adapter_tests.rs`.

--- a/src/lib/mlxcel-surgery/src/ops/interpolate.rs
+++ b/src/lib/mlxcel-surgery/src/ops/interpolate.rs
@@ -78,7 +78,7 @@
 use std::path::{Path, PathBuf};
 
 use globset::{Glob, GlobMatcher};
-use mlxcel_core::weights::{load_safetensors, WeightMap};
+use mlxcel_core::weights::{WeightMap, load_safetensors};
 use mlxcel_core::{MlxArray, UniquePtr};
 
 use crate::config::InterpolateMethod;

--- a/src/lib/mlxcel-surgery/src/ops/prune/tests/mod.rs
+++ b/src/lib/mlxcel-surgery/src/ops/prune/tests/mod.rs
@@ -71,8 +71,8 @@ pub(super) fn read_f32_2d(weights: &WeightMap, key: &str) -> (Vec<i32>, Vec<f32>
 // ============================================================
 
 use super::granularity::{
-    classify_attention_key, classify_mlp_key, extract_layer_index, key_has_dotted_segment,
-    AttentionRole, MlpRole,
+    AttentionRole, MlpRole, classify_attention_key, classify_mlp_key, extract_layer_index,
+    key_has_dotted_segment,
 };
 
 #[test]

--- a/src/lib/mlxcel-surgery/src/ops/replace/wildcard.rs
+++ b/src/lib/mlxcel-surgery/src/ops/replace/wildcard.rs
@@ -203,9 +203,10 @@ mod tests {
             Some(vec![])
         );
         assert!(p.match_with_captures("model.embed_tokens.bias").is_none());
-        assert!(p
-            .match_with_captures("xxmodel.embed_tokens.weight")
-            .is_none());
+        assert!(
+            p.match_with_captures("xxmodel.embed_tokens.weight")
+                .is_none()
+        );
         assert_eq!(p.original(), "model.embed_tokens.weight");
     }
 

--- a/src/lib/mlxcel-surgery/src/ops/scale_tests.rs
+++ b/src/lib/mlxcel-surgery/src/ops/scale_tests.rs
@@ -24,9 +24,9 @@
 //!   packed payload.
 
 use super::*;
-use mlxcel_core::dtype;
 use mlxcel_core::MlxArray;
 use mlxcel_core::UniquePtr;
+use mlxcel_core::dtype;
 use std::sync::Arc;
 
 /// Construct a tiny f32 tensor from a literal slice. The shape is

--- a/src/lib/mlxcel-surgery/tests/add_integration.rs
+++ b/src/lib/mlxcel-surgery/tests/add_integration.rs
@@ -32,10 +32,10 @@ use std::path::Path;
 
 use mlxcel_core::dtype as mlx_dtype;
 use mlxcel_core::weights::{WeightMap, WeightTransform};
-use mlxcel_core::{array_to_raw_bytes, eval, from_bytes, MlxArray, UniquePtr};
-use mlxcel_surgery::{parse_config_file, SurgeryPipeline};
-use safetensors::tensor::Dtype as SafeTensorDtype;
+use mlxcel_core::{MlxArray, UniquePtr, array_to_raw_bytes, eval, from_bytes};
+use mlxcel_surgery::{SurgeryPipeline, parse_config_file};
 use safetensors::View;
+use safetensors::tensor::Dtype as SafeTensorDtype;
 
 /// `safetensors::View` over owned bytes — same shape as the helper
 /// in `src/lib/mlxcel-surgery/src/ops/add.rs`. Duplicated here

--- a/src/lib/mlxcel-surgery/tests/interpolate_integration.rs
+++ b/src/lib/mlxcel-surgery/tests/interpolate_integration.rs
@@ -30,8 +30,8 @@ use std::io::Write;
 use std::path::Path;
 
 use mlxcel_surgery::{
-    parse_config_file, InterpolateMethod, InterpolateOp, SurgeryError, SurgeryPipeline, WeightMap,
-    WeightTransform,
+    InterpolateMethod, InterpolateOp, SurgeryError, SurgeryPipeline, WeightMap, WeightTransform,
+    parse_config_file,
 };
 
 /// Minimal safetensors writer producing a single-file checkpoint

--- a/src/lib/mlxcel-surgery/tests/prune_integration.rs
+++ b/src/lib/mlxcel-surgery/tests/prune_integration.rs
@@ -26,7 +26,7 @@ use std::io::Write;
 use mlxcel_core::dtype;
 use mlxcel_core::weights::{WeightMap, WeightTransform};
 use mlxcel_surgery::{
-    parse_config_file, parse_config_str, PruneOp, PruneSelector, SurgeryPipeline,
+    PruneOp, PruneSelector, SurgeryPipeline, parse_config_file, parse_config_str,
 };
 
 /// Build a Llama-style synthetic weight map for one layer with the

--- a/src/lib/mlxcel-surgery/tests/replace_integration.rs
+++ b/src/lib/mlxcel-surgery/tests/replace_integration.rs
@@ -28,7 +28,7 @@
 //! `SurgeryPipeline` builder, `ReplaceOp` produces a `WeightMap`
 //! with the targeted tensor replaced by the donor's tensor.
 
-use mlxcel_surgery::{parse_config_file, WeightMap, WeightTransform};
+use mlxcel_surgery::{WeightMap, WeightTransform, parse_config_file};
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/lib/mlxcel-surgery/tests/scale_integration.rs
+++ b/src/lib/mlxcel-surgery/tests/scale_integration.rs
@@ -29,7 +29,7 @@
 
 use mlxcel_core::weights::{WeightMap, WeightTransform};
 use mlxcel_core::{MlxArray, UniquePtr};
-use mlxcel_surgery::{parse_config_str, SurgeryPipeline};
+use mlxcel_surgery::{SurgeryPipeline, parse_config_str};
 
 /// Build a tiny synthetic 1-D f32 tensor from a literal slice.
 fn f32_tensor(values: &[f32]) -> UniquePtr<MlxArray> {


### PR DESCRIPTION
## Summary

Bring the two workspace member crates into line with the root `mlxcel` crate, which is already on Rust edition 2024 and version 0.3.3. `mlxcel-core` and `mlxcel-surgery` move from edition 2021 to 2024, and their `[package] version` fields move from 0.2.0 and 0.1.0 respectively to 0.3.3.

## Version sync to 0.3.3

Per the CLAUDE.md "Release versioning" rule, from v0.3.3 onward the member crates carry the same version as the root. This PR sets both `src/lib/mlxcel-core/Cargo.toml` and `src/lib/mlxcel-surgery/Cargo.toml` to `version = "0.3.3"`. The root depends on both members by path with no version requirement, so no dependency spec lines change; `cargo update -p mlxcel -p mlxcel-core -p mlxcel-surgery` refreshes `Cargo.lock` (only the two member version strings change there).

## Edition 2024 migration

The migration was driven by `cargo fix --edition` on each crate, then reviewed and hand-finished. The mechanical and manual touch points:

- `std::env::set_var` / `remove_var` become `unsafe` in edition 2024. The two runtime call sites are now wrapped in `unsafe { ... }` with an accurate SAFETY comment rather than the generic placeholder `cargo fix` inserts: `ensure_persistent_ptx_cache` (`src/lib/mlxcel-core/src/lib.rs`) and `apply_metal_ops_per_buffer_default` (`src/lib/mlxcel-core/src/hardware.rs`). Both functions are documented to run once at the very top of `main`, and all three in-tree callers (`src/main.rs`, `src/bin/mlx_server.rs`, `src/bin/bench_decode.rs`) invoke them right after `Cli::parse()`, before any model load, MLX op, or worker thread touches the process environment, so no other thread is concurrently reading or writing it. The stale "edition 2021 (set_var is not unsafe here)" comment in `hardware.rs` is replaced. The test-only sites in `lang_analyzer/cache.rs` and `lang_analyzer/mod.rs` already serialize env mutation through the existing `env_lock()` guard; they get the `unsafe` wrap plus a one-line test-only SAFETY note. The pre-wrapped `sparse_v_tests.rs` site is left as-is.
- `extern "C"` in `hardware.rs` becomes `unsafe extern "C"`.
- `gen` is a reserved keyword in 2024. It is escaped to `r#gen` at its sites: the `metal_ops_per_buffer_default` and `estimate_bandwidth` function parameters in `hardware.rs`, and local test variables in the dflash `round_loop.rs` / `round_loop_batched.rs`. `r#gen` keeps the churn minimal and the public parameter name unchanged for callers.
- Nested `if let` blocks collapse into 2024 let-chains where clippy's `collapsible_if` flagged them (29 sites across the cache, drafter, sampling, utils, weights, layers, generate, and lang_analyzer modules). `cargo fix` also applied the 2024 match-ergonomics binding fix (`|(&id, _)|` to `|&(&id, _)|`) and rewrote two `if let ... else { break }` loops into equivalent `match` forms for the changed temporary-scope rules.
- Both crates are reformatted under the 2024 style edition (rustfmt's `style_edition` defaults to the crate edition), which re-sorts imports (uppercase before lowercase) and wraps some macro arguments, so `cargo fmt --check` stays clean on CI.

## Test plan

- [x] `cargo check -p mlxcel-surgery --lib --tests`
- [x] `cargo check -p mlxcel-core --lib --tests --examples --features metal,accelerate`
- [x] `cargo clippy -p mlxcel-core --lib --tests --features metal,accelerate -- -D warnings`
- [x] `cargo clippy -p mlxcel-surgery --lib --tests -- -D warnings`
- [x] `cargo fmt -p mlxcel-core --check` and `cargo fmt -p mlxcel-surgery --check`

The CUDA path (`#[cfg(feature = "cuda")]` code, including the `ensure_persistent_ptx_cache` body) cannot be compiled on this macOS host, so the cuda-feature build and any release/whole-workspace verification are left for the reviewer/CI.

Closes #272
