### PR TITLE
refactor: redraw ComputeBackend as an inference-session engine and route the CLI through it

### DIFF
--- a/src/backend/experimental.rs
+++ b/src/backend/experimental.rs
@@ -28,20 +28,25 @@
 //! When a real engine arrives it will likely live in its own feature-gated
 //! crate and be constructed here.
 //!
-//! Note for the next implementer: [`ComputeBackend`] currently returns the
-//! concrete [`LoadedModel`], which is the MLX executor type. A genuinely
-//! non-MLX engine cannot construct a `LoadedModel`, so wiring one in will
-//! require either giving `LoadedModel` a non-MLX variant or evolving the trait
-//! to return an engine-neutral `Box<dyn LanguageModel>`. The concrete return
-//! type is deliberate for this seam-only step: the control plane pattern-matches
-//! concrete `LoadedModel` variants for multimodal dispatch, so an engine-neutral
-//! return would force a broad rework the issue scoped out.
+//! Note for the next implementer (issue #449): the CLI generation path now goes
+//! through [`ComputeBackend::create_session`], which returns a [`Session`]
+//! wrapping the engine-neutral
+//! [`InferenceSession`](mlxcel_core::session::InferenceSession) contract. A
+//! genuinely non-MLX engine implements that contract's token-level `prefill` /
+//! `decode_step` primitives in its own default-off crate and plugs in here.
+//! [`ComputeBackend::load_model`] still returns the concrete [`LoadedModel`] for
+//! the server batched path, because the batch scheduler pattern-matches its
+//! variants for multimodal dispatch; abstracting that path over a backend-owned
+//! KV representation is a later phase (ADR 0004), not part of the first non-MLX
+//! session.
 
 use std::path::Path;
 
 use anyhow::Result;
+use mlxcel_core::TokenBiasMap;
+use mlxcel_core::cache::KVCacheMode;
 
-use super::ComputeBackend;
+use super::{ComputeBackend, Session};
 use crate::LoadedModel;
 use crate::distributed::ShardConfig;
 use crate::tokenizer::MlxcelTokenizer;
@@ -91,5 +96,21 @@ impl ComputeBackend for ExperimentalBackend {
         _shard_config: &ShardConfig,
     ) -> Result<(LoadedModel, MlxcelTokenizer)> {
         not_implemented()
+    }
+
+    fn create_session(
+        &self,
+        _num_layers: usize,
+        _kv_cache_mode: KVCacheMode,
+        _token_bias: TokenBiasMap,
+    ) -> Result<Session> {
+        // No engine is wired in, so the scaffold cannot produce a session. The
+        // error mirrors the load-boundary stub: a session is the new contract a
+        // real non-MLX engine (issue #449) will satisfy here.
+        not_implemented()
+    }
+
+    fn supports_batched_serving(&self) -> bool {
+        false
     }
 }

--- a/src/backend/mlx.rs
+++ b/src/backend/mlx.rs
@@ -24,8 +24,11 @@
 use std::path::Path;
 
 use anyhow::Result;
+use mlxcel_core::TokenBiasMap;
+use mlxcel_core::cache::KVCacheMode;
+use mlxcel_core::session::MlxInferenceSession;
 
-use super::ComputeBackend;
+use super::{ComputeBackend, Session};
 use crate::LoadedModel;
 use crate::distributed::ShardConfig;
 use crate::loading;
@@ -76,5 +79,29 @@ impl ComputeBackend for MlxBackend {
         shard_config: &ShardConfig,
     ) -> Result<(LoadedModel, MlxcelTokenizer)> {
         loading::load_model_with_tensor_parallel(model_path, adapter_path, shard_config)
+    }
+
+    #[inline]
+    fn create_session(
+        &self,
+        num_layers: usize,
+        kv_cache_mode: KVCacheMode,
+        token_bias: TokenBiasMap,
+    ) -> Result<Session> {
+        // Wrap the existing `CxxGenerator` (inside `MlxInferenceSession`) with
+        // the same KV mode and token bias the CLI used before the seam, so the
+        // generation methods delegate verbatim and CLI output is byte-identical.
+        Ok(Session::mlx(
+            MlxInferenceSession::new_with_kv_mode(num_layers, kv_cache_mode)
+                .with_token_bias(token_bias),
+        ))
+    }
+
+    #[inline]
+    fn supports_batched_serving(&self) -> bool {
+        // MLX serves batched requests through the server `BatchScheduler` and
+        // the retained `load_model` path; that capability is unchanged by the
+        // single-sequence session.
+        true
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -24,23 +24,32 @@
 //! target is FuriosaAI's TCP / RNGD, whose `furiosa-opt` toolchain compiles to
 //! a virtual ISA and cannot route through MLX).
 //!
-//! This module introduces the seam and nothing else. A [`ComputeBackend`]
-//! abstracts the forward-execution engine at the model-load boundary: it
-//! produces the loaded forward executor ([`LoadedModel`], which is an
-//! `impl LanguageModel`) for a given model spec. It abstracts the *engine*,
-//! not individual ops.
+//! A [`ComputeBackend`] abstracts the forward-execution engine. It has two
+//! layers, drawn at the altitudes ADR 0004 settled on (issue #448):
 //!
-//! # Why the seam sits at model load, not at `forward()`
+//! - **Session layer (core, single sequence).** A backend produces an
+//!   inference [`Session`] that owns its own KV state and runs generation
+//!   token-in / token-out with on-device sampling. This is the contract the CLI
+//!   `generate` / `chat` paths consume and the one a future non-MLX backend
+//!   (issue #449, a separate default-off crate) implements. The MLX session
+//!   wraps the existing `CxxGenerator`, so the same decode loop and sampling
+//!   run and CLI output stays byte-identical.
+//! - **Extended layer (MLX-only, load boundary).** The server batch scheduler
+//!   does cross-sequence batched forward and owns [`LoadedModel`] directly, so
+//!   the load-boundary entry ([`ComputeBackend::load_model`], returning
+//!   `(LoadedModel, MlxcelTokenizer)`) is retained unchanged for
+//!   `src/server/model_worker.rs` and the scheduler. Batched serving is treated
+//!   as an MLX capability the single-sequence session does not cover yet (the
+//!   KV / batching abstraction ADR 0004 defers).
 //!
-//! The forward entry boundary (`LanguageModel::forward`, once per token in
-//! decode and once per chunk in prefill) is already the right contract: a
-//! non-MLX backend implements the *same* `LanguageModel` contract with a
-//! different engine behind it. The seam therefore lives one level up, at the
-//! point that decides which engine constructs the executor. It does NOT wrap
-//! `forward()` itself and is NOT an op-level abstraction. An op-level seam
-//! would lose MLX graph fusion and `mx.compile` and add real overhead in the
-//! inner loop. The MLX path keeps its concrete hot types (KV cache tensors,
-//! paged-KV blocks, prompt-cache detach / adopt) exposed and untouched.
+//! # Why the seam abstracts the *engine*, not individual ops
+//!
+//! An op-level seam (parametrizing every model over a tensor type) would lose
+//! MLX graph fusion and `mx.compile` and add real overhead in the inner loop,
+//! and it does not fit a graph-compiler backend's whole-graph model. So the
+//! session method runs the per-token forward internally and the MLX path keeps
+//! its concrete hot types (KV cache tensors, paged-KV blocks, prompt-cache
+//! detach / adopt) exposed and untouched.
 //!
 //! # Codegen equivalence when the optional backend is off (the default)
 //!
@@ -51,13 +60,19 @@
 //! environment read and no branch, and every [`Backend`] method is a
 //! single-arm `match` marked `#[inline]`. After inlining the dispatch folds
 //! away entirely: `select_backend().load_model(p)` lowers to a direct call to
-//! the existing MLX loader, identical to the pre-seam build. Shipping binaries
-//! (Apple Silicon, CUDA) compile no extra backend code because the optional
-//! `experimental-backend` module and enum variant are `cfg`-gated off.
+//! the existing MLX loader, and `backend.create_session(...).generate(...)`
+//! lowers to a direct call into the wrapped `CxxGenerator`, identical to the
+//! pre-seam build. The returned [`Session`] is itself a single-variant enum
+//! whose per-method `match` collapses the same way, so no runtime indirection
+//! is added on the generation hot path. Shipping binaries (Apple Silicon, CUDA)
+//! compile no extra backend code because the optional `experimental-backend`
+//! module and enum variant are `cfg`-gated off.
 
 use std::path::Path;
 
 use anyhow::Result;
+use mlxcel_core::TokenBiasMap;
+use mlxcel_core::cache::KVCacheMode;
 
 use crate::LoadedModel;
 use crate::distributed::ShardConfig;
@@ -66,20 +81,27 @@ use crate::tokenizer::MlxcelTokenizer;
 pub mod mlx;
 pub use mlx::MlxBackend;
 
+pub mod session;
+pub use session::Session;
+
 #[cfg(feature = "experimental-backend")]
 pub mod experimental;
 
 /// The forward-execution engine seam.
 ///
-/// A `ComputeBackend` produces the loaded forward executor for a model spec.
-/// The executor is a [`LoadedModel`], which implements the
-/// [`LanguageModel`](mlxcel_core::generate::LanguageModel) forward contract, so
-/// the backend abstracts *which engine* runs `forward()`, not individual ops.
+/// A `ComputeBackend` produces two things: a single-sequence inference
+/// [`Session`] for the CLI generation path ([`create_session`](Self::create_session)),
+/// and, for the server batched path, the loaded forward executor at the load
+/// boundary ([`load_model`](Self::load_model), returning [`LoadedModel`], which
+/// implements the [`LanguageModel`](mlxcel_core::generate::LanguageModel)
+/// forward contract). The backend abstracts *which engine* runs generation, not
+/// individual ops.
 ///
-/// The trait is drawn narrowly on purpose: it covers only the load boundary so
-/// that the MLX path's specialized hot paths (paged KV, prompt-cache detach /
-/// adopt, concrete cache tensors) are never forced through a generic
-/// interface. Those stay on the concrete MLX path behind [`MlxBackend`].
+/// The session method runs the per-token forward internally, and the load
+/// boundary keeps returning the concrete `LoadedModel`, so the MLX path's
+/// specialized hot paths (paged KV, prompt-cache detach / adopt, concrete cache
+/// tensors) are never forced through a generic op interface. Those stay on the
+/// concrete MLX path behind [`MlxBackend`].
 pub trait ComputeBackend {
     /// Stable identifier for diagnostics and logging (e.g. `"mlx"`).
     fn name(&self) -> &'static str;
@@ -102,6 +124,32 @@ pub trait ComputeBackend {
         adapter_path: Option<&Path>,
         shard_config: &ShardConfig,
     ) -> Result<(LoadedModel, MlxcelTokenizer)>;
+
+    /// Produce a single-sequence inference [`Session`] for an already-loaded
+    /// model (issue #448, ADR 0004).
+    ///
+    /// The session owns its own KV state and runs generation token-in /
+    /// token-out. `num_layers` and `kv_cache_mode` come from the loaded model;
+    /// `token_bias` is the pre-resolved language / suppression bias the CLI
+    /// threads in (empty is a zero-overhead no-op). A backend with no engine
+    /// wired in (the experimental scaffold) returns an error here.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the backend cannot construct a session.
+    fn create_session(
+        &self,
+        num_layers: usize,
+        kv_cache_mode: KVCacheMode,
+        token_bias: TokenBiasMap,
+    ) -> Result<Session>;
+
+    /// Whether this backend supports cross-sequence batched serving (the server
+    /// `BatchScheduler` path). The single-sequence [`Session`] never batches;
+    /// this advertises the backend-level capability the extended load-boundary
+    /// path provides. MLX returns `true`; a backend with no batched engine
+    /// returns `false`.
+    fn supports_batched_serving(&self) -> bool;
 }
 
 /// The compute backend selected for this process.
@@ -174,6 +222,34 @@ impl Backend {
             Backend::Experimental(b) => {
                 b.load_model_with_tensor_parallel(model_path, adapter_path, shard_config)
             }
+        }
+    }
+
+    /// Produce a single-sequence inference [`Session`] through the active
+    /// backend. Under default features the dispatch folds to a direct
+    /// [`MlxBackend::create_session`].
+    #[inline]
+    pub fn create_session(
+        &self,
+        num_layers: usize,
+        kv_cache_mode: KVCacheMode,
+        token_bias: TokenBiasMap,
+    ) -> Result<Session> {
+        match self {
+            Backend::Mlx(b) => b.create_session(num_layers, kv_cache_mode, token_bias),
+            #[cfg(feature = "experimental-backend")]
+            Backend::Experimental(b) => b.create_session(num_layers, kv_cache_mode, token_bias),
+        }
+    }
+
+    /// Whether the active backend supports cross-sequence batched serving.
+    #[inline]
+    #[must_use]
+    pub fn supports_batched_serving(&self) -> bool {
+        match self {
+            Backend::Mlx(b) => b.supports_batched_serving(),
+            #[cfg(feature = "experimental-backend")]
+            Backend::Experimental(b) => b.supports_batched_serving(),
         }
     }
 }

--- a/src/backend/session.rs
+++ b/src/backend/session.rs
@@ -1,0 +1,187 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The root-crate inference-session seam (issue #448, ADR 0004).
+//!
+//! [`Session`] is the value a [`ComputeBackend`](super::ComputeBackend)
+//! produces. It mirrors the [`Backend`](super::Backend) selection enum: a single
+//! [`Session::Mlx`] variant under default features, so every `match` over it
+//! collapses to its one arm. Each generation method is a single-arm `match`
+//! marked `#[inline]`, so the session dispatch folds away entirely at compile
+//! time and the CLI `generate` / `chat` paths call the wrapped
+//! [`MlxInferenceSession`] (and through it the existing `CxxGenerator`) with no
+//! runtime indirection added on the hot path. The per-token forward stays inside
+//! the session method; the concrete KV types are never type-erased.
+//!
+//! # Extension point for the non-MLX backend (issue #449)
+//!
+//! The compiler-family backend (OpenXLA / StableHLO, ADR 0004 Track B) lands in
+//! its own default-off crate. When it does, it implements the engine-neutral
+//! [`InferenceSession`](mlxcel_core::session::InferenceSession) contract in
+//! `mlxcel-core`, and this enum gains a `cfg`-gated variant wrapping it (or, if
+//! cross-crate generics over the streaming closure prove awkward, this seam
+//! becomes a `Box<dyn InferenceSession>` boundary that drives the object-safe
+//! `prefill` / `decode_step` primitives). It is left as a single MLX variant
+//! today because there is no second backend to wrap yet; over-engineering the
+//! dispatch now would add cost the default build pays for nothing.
+
+use mlxcel_core::MlxArray;
+use mlxcel_core::generate::{GenerationStats, LanguageModel, SamplingConfig};
+use mlxcel_core::session::{MlxInferenceSession, SessionCapabilities};
+
+/// The inference session selected for a load.
+///
+/// Under default features this enum has a single variant, [`Session::Mlx`].
+/// Because the dispatch is a single-arm `match`, the seam adds no runtime
+/// indirection: `session.generate(...)` inlines to the wrapped
+/// [`MlxInferenceSession::generate`], which delegates verbatim to the existing
+/// `CxxGenerator`.
+pub enum Session {
+    /// The MLX single-sequence session, wrapping `CxxGenerator`.
+    Mlx(MlxInferenceSession),
+}
+
+impl Session {
+    /// Wrap an [`MlxInferenceSession`] as the active session.
+    #[inline]
+    #[must_use]
+    pub fn mlx(session: MlxInferenceSession) -> Self {
+        Session::Mlx(session)
+    }
+
+    /// What this session can do, so the control plane can gate features.
+    #[inline]
+    #[must_use]
+    pub fn capabilities(&self) -> SessionCapabilities {
+        match self {
+            Session::Mlx(s) => s.capabilities(),
+        }
+    }
+
+    /// Reset generator-owned and model-owned caches for a fresh prefill.
+    #[inline]
+    pub fn reset_with_model<M: LanguageModel + ?Sized>(&mut self, model: &M) {
+        match self {
+            Session::Mlx(s) => s.reset_with_model(model),
+        }
+    }
+
+    /// Greedy / sampled generation.
+    #[inline]
+    pub fn generate<M: LanguageModel>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+        max_tokens: usize,
+        sampling: &SamplingConfig,
+    ) -> Vec<i32> {
+        match self {
+            Session::Mlx(s) => s.generate(model, prompt_tokens, max_tokens, sampling),
+        }
+    }
+
+    /// Streaming generation with a per-token callback (the closure stays
+    /// generic, preserving lookahead pipelining).
+    #[inline]
+    pub fn generate_streaming<M: LanguageModel, F: FnMut(i32) -> bool>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+        max_tokens: usize,
+        sampling: &SamplingConfig,
+        on_token: F,
+    ) -> Vec<i32> {
+        match self {
+            Session::Mlx(s) => {
+                s.generate_streaming(model, prompt_tokens, max_tokens, sampling, on_token)
+            }
+        }
+    }
+
+    /// Streaming generation seeded with pre-computed input embeddings (VLM /
+    /// audio prefill).
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub fn generate_streaming_with_embeddings<M: LanguageModel, F: FnMut(i32) -> bool>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+        input_embeddings: Option<&MlxArray>,
+        mask: Option<&MlxArray>,
+        max_tokens: usize,
+        sampling: &SamplingConfig,
+        on_token: F,
+    ) -> Vec<i32> {
+        match self {
+            Session::Mlx(s) => s.generate_streaming_with_embeddings(
+                model,
+                prompt_tokens,
+                input_embeddings,
+                mask,
+                max_tokens,
+                sampling,
+                on_token,
+            ),
+        }
+    }
+
+    /// Generation with profiling stats.
+    #[inline]
+    pub fn generate_with_stats<M: LanguageModel>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+        max_tokens: usize,
+        sampling: &SamplingConfig,
+    ) -> (Vec<i32>, GenerationStats) {
+        match self {
+            Session::Mlx(s) => s.generate_with_stats(model, prompt_tokens, max_tokens, sampling),
+        }
+    }
+
+    /// Embedding-prefill generation with profiling stats.
+    #[inline]
+    pub fn generate_with_stats_and_embeddings<M: LanguageModel>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+        input_embeddings: Option<&MlxArray>,
+        mask: Option<&MlxArray>,
+        max_tokens: usize,
+        sampling: &SamplingConfig,
+    ) -> (Vec<i32>, GenerationStats) {
+        match self {
+            Session::Mlx(s) => s.generate_with_stats_and_embeddings(
+                model,
+                prompt_tokens,
+                input_embeddings,
+                mask,
+                max_tokens,
+                sampling,
+            ),
+        }
+    }
+
+    /// Per-target-token log-likelihoods over the prompt window.
+    #[inline]
+    pub fn evaluate_loglikelihoods<M: LanguageModel>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+    ) -> Vec<f32> {
+        match self {
+            Session::Mlx(s) => s.evaluate_loglikelihoods(model, prompt_tokens),
+        }
+    }
+}

--- a/src/backend/tests.rs
+++ b/src/backend/tests.rs
@@ -19,6 +19,8 @@
 //! the real MLX loader.
 
 use super::*;
+use mlxcel_core::TokenBiasMap;
+use mlxcel_core::cache::KVCacheMode;
 
 /// Compile-time proof that the executor the seam yields implements the forward
 /// contract. Whatever the backend loads is a working forward executor.
@@ -69,4 +71,56 @@ fn seam_delegates_to_real_mlx_loader_on_missing_dir() {
             let _ = err.to_string();
         }
     }
+}
+
+#[test]
+fn mlx_backend_creates_a_session_and_advertises_batched_serving() {
+    // The session is constructed without loading a checkpoint (the wrapped
+    // `CxxGenerator` only allocates KV caches), so this stays fast and bridge
+    // light, like the existing `CxxGenerator::new` unit tests.
+    let backend = select_backend();
+    assert!(
+        backend.supports_batched_serving(),
+        "MLX serves batched requests via the retained load_model / scheduler path"
+    );
+    let session = backend
+        .create_session(4, KVCacheMode::Fp16, TokenBiasMap::new())
+        .expect("MLX backend must produce a single-sequence session");
+    // The single-sequence session does not batch, page, or speculate, but it
+    // accepts multimodal embedding prefill.
+    let caps = session.capabilities();
+    assert!(!caps.batched_serving);
+    assert!(!caps.paged_kv);
+    assert!(!caps.speculative_decode);
+    assert!(caps.multimodal);
+}
+
+#[test]
+fn mlx_session_threads_the_token_bias_through() {
+    let mut bias = TokenBiasMap::new();
+    bias.insert(5, -2.0);
+    let session = select_backend()
+        .create_session(2, KVCacheMode::Fp16, bias)
+        .expect("session creation must succeed");
+    match session {
+        Session::Mlx(s) => {
+            assert_eq!(s.token_bias().len(), 1);
+            assert!(s.token_bias().contains(5));
+        }
+    }
+}
+
+/// The experimental scaffold has no engine wired in, so it cannot produce a
+/// session. Compiled only under the optional feature; default builds carry none
+/// of it.
+#[cfg(feature = "experimental-backend")]
+#[test]
+fn experimental_backend_session_creation_errors() {
+    let backend = experimental::ExperimentalBackend::new();
+    assert!(!backend.supports_batched_serving());
+    let result = backend.create_session(4, KVCacheMode::Fp16, TokenBiasMap::new());
+    assert!(
+        result.is_err(),
+        "the experimental scaffold must report it has no session engine"
+    );
 }

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -27,8 +27,8 @@
 //!   `generate` applies),
 //! * sampling → [`build_sampling_config`] over [`ResolvedSamplingParams`] (the
 //!   same `SamplingConfig` assembly `generate` uses),
-//! * token generation → [`CxxGenerator::generate_streaming`] (the same
-//!   streaming decode loop the offline `generate` path drives),
+//! * token generation → [`Session::generate_streaming`] (which delegates to the
+//!   same `CxxGenerator` streaming decode loop the offline `generate` path drives),
 //! * incremental detokenization → [`StreamingDecodeState`] (the server's own
 //!   byte-fallback-safe streaming detokenizer, now shared).
 //!
@@ -61,7 +61,7 @@ use mlxcel::sampling::{ResolvedSamplingParams, build_sampling_config};
 use mlxcel::server::chat_template::{ChatMessage, ChatTemplateProcessor};
 use mlxcel::server::model_provider::model_worker::StreamingDecodeState;
 use mlxcel::tokenizer::{MlxcelTokenizer, load_tokenizer};
-use mlxcel::{CxxGenerator, LanguageModel, SamplingConfig, initialize_runtime, select_backend};
+use mlxcel::{LanguageModel, SamplingConfig, Session, initialize_runtime, select_backend};
 use mlxcel_core::cache::KVCacheMode;
 use mlxcel_core::sampling::TokenBiasMap;
 
@@ -149,7 +149,7 @@ enum SlashOutcome {
 /// `mlxcel run` verb (issue #95). Loads the model once, then loops: read a
 /// line (or a `"""` multiline block), interpret slash commands, render the
 /// accumulated conversation through the chat template, and stream the
-/// assistant reply token-by-token via the shared [`CxxGenerator`].
+/// assistant reply token-by-token via the shared inference [`Session`].
 ///
 /// # Errors
 ///
@@ -240,11 +240,16 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
     let mut output_suppression = TokenBiasMap::new();
     output_suppression.suppress_tokens(&model.output_suppressed_token_ids());
 
-    // One generator for the whole session. `generate_streaming` resets its KV
-    // cache per call, so re-rendering the full transcript each turn preserves
-    // context without forking the generation loop.
-    let mut generator = CxxGenerator::new_with_kv_mode(model.num_layers(), opts.kv_cache_mode)
-        .with_token_bias(output_suppression);
+    // One inference session for the whole chat (issue #448, ADR 0004). Under
+    // default features `select_backend()` folds to MLX and the session wraps the
+    // same `CxxGenerator`, so `generate_streaming` runs the identical loop and
+    // resets its KV cache per call; re-rendering the full transcript each turn
+    // preserves context without forking the generation loop.
+    let mut session = select_backend().create_session(
+        model.num_layers(),
+        opts.kv_cache_mode,
+        output_suppression,
+    )?;
 
     let mut editor = DefaultEditor::new()
         .map_err(|e| anyhow!("failed to initialize the interactive line editor: {e}"))?;
@@ -270,8 +275,8 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
                     }
                     SlashOutcome::Cleared => {
                         // `/clear` already reset the transcript; also drop any
-                        // generator-side state for a clean next prefill.
-                        generator.reset_with_model(&model);
+                        // session-side state for a clean next prefill.
+                        session.reset_with_model(&model);
                         continue;
                     }
                     SlashOutcome::Handled => continue,
@@ -286,7 +291,7 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
                 let prompt =
                     render_prompt(processor.as_ref(), &conversation, opts.no_chat_template);
                 let reply = stream_turn(
-                    &mut generator,
+                    &mut session,
                     &model,
                     &tokenizer,
                     &prompt,
@@ -531,10 +536,11 @@ fn concat_userassistant_fallback(conversation: &[ChatMessage]) -> String {
 ///
 /// Tokenization matches `generate::tokenize_prompt` (skip the extra BOS when
 /// the rendered prompt already embeds one). Generation goes through
-/// [`CxxGenerator::generate_streaming`] — the same loop the offline path uses —
-/// with a per-token callback that streams text via [`StreamingDecodeState`].
+/// [`Session::generate_streaming`] — which delegates to the same
+/// `CxxGenerator::generate_streaming` loop the offline path uses — with a
+/// per-token callback that streams text via [`StreamingDecodeState`].
 fn stream_turn<M: LanguageModel>(
-    generator: &mut CxxGenerator,
+    session: &mut Session,
     model: &M,
     tokenizer: &MlxcelTokenizer,
     prompt: &str,
@@ -558,7 +564,7 @@ fn stream_turn<M: LanguageModel>(
     let mut streamed = String::new();
     let mut stdout = io::stdout();
 
-    generator.generate_streaming(
+    session.generate_streaming(
         model,
         &prompt_tokens,
         max_tokens,

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -23,8 +23,7 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use mlxcel::{
-    CxxGenerator, GenerationStats, LanguageModel, RuntimeSetup, SamplingConfig,
-    SpeculativeGenerator,
+    GenerationStats, LanguageModel, RuntimeSetup, SamplingConfig, SpeculativeGenerator,
     distributed::{
         PipelineWorkerInput, RequestId,
         pipeline::{
@@ -821,18 +820,22 @@ fn generate_standard<M: LanguageModel>(
     profile: bool,
     kv_cache_mode: KVCacheMode,
     token_bias: TokenBiasMap,
-) -> (Vec<i32>, GenerationStats) {
-    // Axis B (B8): thread the resolved token-bias into the CxxGenerator. Empty
-    // map preserves bit-exact baseline via `CxxGenerator::compose_sampling`.
-    let mut generator = CxxGenerator::new_with_kv_mode(model.num_layers(), kv_cache_mode)
-        .with_token_bias(token_bias);
+) -> Result<(Vec<i32>, GenerationStats)> {
+    // Route generation through the inference-session seam (issue #448, ADR 0004).
+    // Under default features `select_backend()` folds to MLX and the session
+    // wraps the same `CxxGenerator`, so the delegated generation methods run the
+    // identical decode loop and CLI output is byte-identical. Axis B (B8): the
+    // resolved token-bias is threaded into the session; an empty map preserves
+    // bit-exact baseline via the generator's `compose_sampling`.
+    let mut session =
+        select_backend().create_session(model.num_layers(), kv_cache_mode, token_bias)?;
 
     if profile {
-        return generator.generate_with_stats(model, prompt_tokens, max_tokens, sampling_config);
+        return Ok(session.generate_with_stats(model, prompt_tokens, max_tokens, sampling_config));
     }
 
-    let _ = generator.generate(model, prompt_tokens, 1, sampling_config);
-    generator.reset_with_model(model);
+    let _ = session.generate(model, prompt_tokens, 1, sampling_config);
+    session.reset_with_model(model);
 
     let capture_path = std::env::var("MLXCEL_METAL_CAPTURE_PATH").ok();
     if let Some(ref path) = capture_path {
@@ -844,7 +847,7 @@ fn generate_standard<M: LanguageModel>(
     }
 
     let start_time = Instant::now();
-    let tokens = generator.generate(model, prompt_tokens, max_tokens, sampling_config);
+    let tokens = session.generate(model, prompt_tokens, max_tokens, sampling_config);
     let total_time = start_time.elapsed();
     let generated_len = tokens.len();
 
@@ -852,10 +855,10 @@ fn generate_standard<M: LanguageModel>(
         mlxcel_core::metal_stop_capture();
     }
 
-    (
+    Ok((
         tokens,
         generation_stats_from_duration(prompt_tokens.len(), generated_len, total_time),
-    )
+    ))
 }
 
 fn generate_with_embeddings<M: LanguageModel>(
@@ -868,13 +871,13 @@ fn generate_with_embeddings<M: LanguageModel>(
     kv_cache_mode: KVCacheMode,
     token_bias: TokenBiasMap,
 ) -> Result<(Vec<i32>, GenerationStats)> {
-    // Axis B (B8): same wiring as the text-only CxxGenerator path above.
-    let mut generator = CxxGenerator::new_with_kv_mode(model.num_layers(), kv_cache_mode)
-        .with_token_bias(token_bias);
+    // Axis B (B8): same session wiring as the text-only path above (issue #448).
+    let mut session =
+        select_backend().create_session(model.num_layers(), kv_cache_mode, token_bias)?;
     let (input_embeds, mask_ref) = prepared_embedding_refs(embeddings)?;
 
     if profile {
-        return Ok(generator.generate_with_stats_and_embeddings(
+        return Ok(session.generate_with_stats_and_embeddings(
             model,
             prompt_tokens,
             Some(input_embeds),
@@ -885,7 +888,7 @@ fn generate_with_embeddings<M: LanguageModel>(
     }
 
     let start_time = Instant::now();
-    let tokens = generator.generate_streaming_with_embeddings(
+    let tokens = session.generate_streaming_with_embeddings(
         model,
         prompt_tokens,
         Some(input_embeds),
@@ -1076,7 +1079,7 @@ fn run_generation_mode(
             args.generation.profile,
             kv_cache_mode,
             token_bias,
-        )
+        )?
     };
 
     Ok(output)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,12 +79,15 @@ pub use multimodal::{
     phi4mm_prompt, qwen_vl, video, vlm_prompt, vlm_runtime, youtu_vl_prompt,
 };
 
-// Re-export the compute-backend seam (issue #338). Control-plane callers in
-// both the library and the `mlxcel` / `mlxcel-server` binaries reach model
-// loading through `select_backend()` so the forward-execution engine is
-// chosen at one boundary. Under default features this folds to the single
-// MLX variant with no runtime dispatch.
-pub use backend::{Backend, ComputeBackend, MlxBackend, select_backend};
+// Re-export the compute-backend seam (issue #338, reframed to a session engine
+// in issue #448 / ADR 0004). Control-plane callers in both the library and the
+// `mlxcel` / `mlxcel-server` binaries reach model loading through
+// `select_backend()` so the forward-execution engine is chosen at one boundary.
+// The CLI generation path obtains a single-sequence `Session` from the backend;
+// the server batched path keeps using `load_model`. Under default features both
+// fold to the single MLX variant with no runtime dispatch.
+pub use backend::{Backend, ComputeBackend, MlxBackend, Session, select_backend};
+pub use mlxcel_core::session::{InferenceSession, MlxInferenceSession, SessionCapabilities};
 
 // Re-export split modules
 pub use loaded_model::LoadedModel;

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -2447,6 +2447,9 @@ pub use ops::{concatenate, divide_scalar, multiply_scalar, stack, stack_owned, w
 
 // Re-export sampling primitives needed by generation-loop wiring (B8) and server layers.
 pub use sampling::TokenBiasMap;
+// Re-export the inference-session contract (issue #448, ADR 0004) so the root
+// crate's compute-backend seam can construct and dispatch MLX sessions.
+pub use session::{InferenceSession, MlxInferenceSession, SessionCapabilities};
 // Re-export N-gram loop-detection so the server control plane and CLI decode
 // loops can configure and run early-stop on degenerate token-repetition.
 pub use loop_detection::{LoopDetectionConfig, detect_repetition_loop};
@@ -2773,6 +2776,11 @@ pub mod weights;
 
 // Token generation
 pub mod generate;
+
+// Inference-session contract (issue #448, ADR 0004). The engine-neutral
+// `InferenceSession` trait plus the MLX `MlxInferenceSession` that wraps
+// `CxxGenerator`. The CLI single-sequence paths drive generation through this.
+pub mod session;
 
 // Decode-loop setup helpers shared by standard and speculative generation.
 // Public so that the server batch scheduler can reuse seed/EOS/history helpers.

--- a/src/lib/mlxcel-core/src/session.rs
+++ b/src/lib/mlxcel-core/src/session.rs
@@ -1,0 +1,341 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The inference-session contract (issue #448, ADR 0004).
+//!
+//! PR #446 drew the compute-backend seam at the model-load boundary: a backend
+//! returned the concrete MLX [`LoadedModel`](crate) and the caller drove
+//! generation. ADR 0004 reframes that seam to the inference-session level,
+//! because the non-MLX targets we want (FuriosaAI, Tenstorrent, OpenXLA) are
+//! graph-compiler backends that keep KV state and sampling inside their own
+//! compiled graph and never produce an `MlxArray`.
+//!
+//! This module hosts the core contract. A backend produces an *inference
+//! session* that owns its own per-sequence KV state and runs generation
+//! token-in / token-out with on-device sampling. That is the single-sequence
+//! contract the CLI `generate` / `chat` paths consume and the contract a future
+//! non-MLX backend (issue #449, a separate default-off crate) will implement.
+//!
+//! Two layers live here:
+//!
+//! - [`InferenceSession`] is the engine-neutral, object-safe contract. It
+//!   exposes the conceptual token-level primitives ([`InferenceSession::prefill`]
+//!   and [`InferenceSession::decode_step`]) plus capability advertisement
+//!   ([`InferenceSession::capabilities`]). It is the shape a compiler-family
+//!   backend fills in.
+//! - [`MlxInferenceSession`] is the MLX implementation. It is a thin wrapper
+//!   around the existing [`CxxGenerator`]: every generation method delegates
+//!   verbatim to the matching `CxxGenerator` method, so the exact same decode
+//!   loop, KV optimizations, and sampling run whether a caller reaches them
+//!   directly or through the session. The per-token forward stays inside the
+//!   session (no per-op virtual dispatch), and the concrete hot types
+//!   ([`KVCache`](crate::layers::KVCache), the cache pool) are never type-erased.
+//!
+//! # Why the MLX session keeps fused entry points, not hand-rolled steps
+//!
+//! The CLI drives generation through [`CxxGenerator`]'s fused `generate_*`
+//! entry points. Those carry the pipelining, the prompt-cache reset, the
+//! Boundary-V KV policy, and the language-bias merge that make CLI output what
+//! it is. Re-expressing them as a hand-written `prefill` + `decode_step` loop
+//! would fork that logic and risk a behavior drift, so [`MlxInferenceSession`]
+//! delegates the fused methods verbatim and treats [`InferenceSession::prefill`]
+//! / [`InferenceSession::decode_step`] as the engine-neutral contract reserved
+//! for the compiler-family backend rather than the MLX fast path.
+//!
+//! # Single sequence only
+//!
+//! The session guarantees single-sequence generation. Cross-sequence batched
+//! serving stays an MLX capability driven by the server `BatchScheduler` through
+//! the retained `load_model` path (PR #446), not through this session. The
+//! [`SessionCapabilities`] a session advertises lets a caller gate on what a
+//! given backend supports; the MLX single-sequence session advertises only the
+//! single-sequence and multimodal-prefill capabilities it actually provides.
+
+use crate::cache::KVCacheMode;
+use crate::ffi::MlxArray;
+use crate::generate::{CxxGenerator, GenerationStats, LanguageModel, SamplingConfig};
+use crate::sampling::TokenBiasMap;
+
+/// Capabilities a backend inference session advertises so the control plane can
+/// gate features a given backend does not support yet.
+///
+/// These describe what the *session* (single-sequence engine) offers, not what
+/// the backend can do through other paths. The MLX backend, for example,
+/// supports cross-request batching through the server `BatchScheduler` and the
+/// `load_model` path, but its single-sequence [`MlxInferenceSession`] reports
+/// `batched_serving == false` because batching is not a property of this
+/// session. Backend-level batching support is advertised separately by the
+/// compute backend (see `ComputeBackend::supports_batched_serving` in the root
+/// crate).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SessionCapabilities {
+    /// The session can run more than one sequence in a single batched forward.
+    pub batched_serving: bool,
+    /// The session manages a paged KV block table and pool.
+    pub paged_kv: bool,
+    /// The session can run speculative (draft + verify) decode internally.
+    pub speculative_decode: bool,
+    /// The session accepts pre-computed input embeddings (image / audio / video
+    /// prefill) in addition to token ids.
+    pub multimodal: bool,
+}
+
+impl SessionCapabilities {
+    /// The conservative floor: a plain single-sequence engine with no batching,
+    /// paging, speculative decode, or multimodal prefill. This is the only
+    /// capability set the core session contract guarantees; richer backends
+    /// turn individual flags on.
+    #[must_use]
+    pub const fn single_sequence() -> Self {
+        Self {
+            batched_serving: false,
+            paged_kv: false,
+            speculative_decode: false,
+            multimodal: false,
+        }
+    }
+}
+
+/// The engine-neutral, single-sequence inference contract (ADR 0004).
+///
+/// A backend produces a session that owns its per-sequence KV state and runs
+/// generation token-in / token-out with sampling done on-device. The contract
+/// is intentionally object-safe (no generic method parameters, no closures in
+/// signatures) so a future backend can be held behind `Box<dyn
+/// InferenceSession>` if cross-crate dispatch ever needs it.
+///
+/// [`prefill`](Self::prefill) and [`decode_step`](Self::decode_step) define the
+/// conceptual token-level primitive shape a compiler-family backend (issue #449)
+/// implements directly: prefill the prompt, then advance one token per step with
+/// KV and sampling kept inside the backend. The MLX reference session
+/// ([`MlxInferenceSession`]) instead drives the CLI through its fused
+/// `generate_*` entry points (see the module docs), so on MLX these two methods
+/// return a reserved-contract error rather than a parallel decode loop.
+pub trait InferenceSession {
+    /// What this session can do, so the control plane can gate features.
+    fn capabilities(&self) -> SessionCapabilities;
+
+    /// Seed the session's KV state with the prompt tokens (conceptual contract).
+    ///
+    /// The error type is `String` to keep `mlxcel-core` free of an `anyhow`
+    /// dependency, matching the crate's other fallible entry points.
+    ///
+    /// # Errors
+    ///
+    /// Backends that do not expose token-level stepping (the MLX reference
+    /// session) return an error pointing at the fused generation entry points.
+    fn prefill(&mut self, token_ids: &[i32]) -> Result<(), String>;
+
+    /// Advance generation by one token given the previously emitted token, and
+    /// return the next sampled token id (conceptual contract).
+    ///
+    /// # Errors
+    ///
+    /// Backends that do not expose token-level stepping (the MLX reference
+    /// session) return an error pointing at the fused generation entry points.
+    fn decode_step(&mut self, token: i32) -> Result<i32, String>;
+}
+
+/// The MLX single-sequence inference session.
+///
+/// A behavior-preserving wrapper around [`CxxGenerator`]. Construction mirrors
+/// the generator (`new`, `new_with_kv_mode`, `with_token_bias`) and every
+/// generation method delegates verbatim, so output is byte-identical to calling
+/// the generator directly. The session owns the KV caches (inside the wrapped
+/// generator); the model is borrowed per call exactly as before, which keeps
+/// the existing call structure (speculative decode, VLM embeddings, suppressed
+/// tokens) untouched.
+pub struct MlxInferenceSession {
+    generator: CxxGenerator,
+}
+
+impl MlxInferenceSession {
+    /// Create a session with an FP16 KV cache (default), mirroring
+    /// [`CxxGenerator::new`].
+    #[must_use]
+    pub fn new(num_layers: usize) -> Self {
+        Self {
+            generator: CxxGenerator::new(num_layers),
+        }
+    }
+
+    /// Create a session with the given KV cache quantization mode, mirroring
+    /// [`CxxGenerator::new_with_kv_mode`].
+    #[must_use]
+    pub fn new_with_kv_mode(num_layers: usize, kv_cache_mode: KVCacheMode) -> Self {
+        Self {
+            generator: CxxGenerator::new_with_kv_mode(num_layers, kv_cache_mode),
+        }
+    }
+
+    /// Attach a pre-resolved token-bias map, mirroring
+    /// [`CxxGenerator::with_token_bias`]. An empty map is a zero-overhead no-op
+    /// that preserves bit-exact baseline behavior.
+    #[must_use]
+    pub fn with_token_bias(mut self, bias: TokenBiasMap) -> Self {
+        self.generator = self.generator.with_token_bias(bias);
+        self
+    }
+
+    /// The capabilities of the MLX single-sequence session: it does not batch,
+    /// page, or speculate internally, but it does accept multimodal embedding
+    /// prefill through the `*_with_embeddings` methods.
+    #[must_use]
+    pub fn capabilities(&self) -> SessionCapabilities {
+        SessionCapabilities {
+            multimodal: true,
+            ..SessionCapabilities::single_sequence()
+        }
+    }
+
+    /// Reset generator-owned and model-owned caches for a fresh prefill.
+    /// Delegates to [`CxxGenerator::reset_with_model`].
+    pub fn reset_with_model<M: LanguageModel + ?Sized>(&mut self, model: &M) {
+        self.generator.reset_with_model(model);
+    }
+
+    /// The cached token-bias map (used by tests to assert wiring).
+    #[must_use]
+    pub fn token_bias(&self) -> &TokenBiasMap {
+        self.generator.token_bias()
+    }
+
+    /// Greedy / sampled generation. Delegates verbatim to
+    /// [`CxxGenerator::generate`].
+    pub fn generate<M: LanguageModel>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+        max_tokens: usize,
+        sampling: &SamplingConfig,
+    ) -> Vec<i32> {
+        self.generator
+            .generate(model, prompt_tokens, max_tokens, sampling)
+    }
+
+    /// Streaming generation with a per-token callback. Delegates verbatim to
+    /// [`CxxGenerator::generate_streaming`]; the closure stays generic, so the
+    /// lookahead pipelining is preserved.
+    pub fn generate_streaming<M: LanguageModel, F: FnMut(i32) -> bool>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+        max_tokens: usize,
+        sampling: &SamplingConfig,
+        on_token: F,
+    ) -> Vec<i32> {
+        self.generator
+            .generate_streaming(model, prompt_tokens, max_tokens, sampling, on_token)
+    }
+
+    /// Streaming generation seeded with pre-computed input embeddings (VLM /
+    /// audio prefill). Delegates verbatim to
+    /// [`CxxGenerator::generate_streaming_with_embeddings`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn generate_streaming_with_embeddings<M: LanguageModel, F: FnMut(i32) -> bool>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+        input_embeddings: Option<&MlxArray>,
+        mask: Option<&MlxArray>,
+        max_tokens: usize,
+        sampling: &SamplingConfig,
+        on_token: F,
+    ) -> Vec<i32> {
+        self.generator.generate_streaming_with_embeddings(
+            model,
+            prompt_tokens,
+            input_embeddings,
+            mask,
+            max_tokens,
+            sampling,
+            on_token,
+        )
+    }
+
+    /// Generation with profiling stats. Delegates verbatim to
+    /// [`CxxGenerator::generate_with_stats`].
+    pub fn generate_with_stats<M: LanguageModel>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+        max_tokens: usize,
+        sampling: &SamplingConfig,
+    ) -> (Vec<i32>, GenerationStats) {
+        self.generator
+            .generate_with_stats(model, prompt_tokens, max_tokens, sampling)
+    }
+
+    /// Embedding-prefill generation with profiling stats. Delegates verbatim to
+    /// [`CxxGenerator::generate_with_stats_and_embeddings`].
+    pub fn generate_with_stats_and_embeddings<M: LanguageModel>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+        input_embeddings: Option<&MlxArray>,
+        mask: Option<&MlxArray>,
+        max_tokens: usize,
+        sampling: &SamplingConfig,
+    ) -> (Vec<i32>, GenerationStats) {
+        self.generator.generate_with_stats_and_embeddings(
+            model,
+            prompt_tokens,
+            input_embeddings,
+            mask,
+            max_tokens,
+            sampling,
+        )
+    }
+
+    /// Per-target-token log-likelihoods over the prompt window (perplexity
+    /// evaluation). Delegates verbatim to
+    /// [`CxxGenerator::evaluate_loglikelihoods`].
+    pub fn evaluate_loglikelihoods<M: LanguageModel>(
+        &mut self,
+        model: &M,
+        prompt_tokens: &[i32],
+    ) -> Vec<f32> {
+        self.generator.evaluate_loglikelihoods(model, prompt_tokens)
+    }
+}
+
+impl InferenceSession for MlxInferenceSession {
+    fn capabilities(&self) -> SessionCapabilities {
+        MlxInferenceSession::capabilities(self)
+    }
+
+    fn prefill(&mut self, _token_ids: &[i32]) -> Result<(), String> {
+        Err(RESERVED_STEP_CONTRACT.to_string())
+    }
+
+    fn decode_step(&mut self, _token: i32) -> Result<i32, String> {
+        Err(RESERVED_STEP_CONTRACT.to_string())
+    }
+}
+
+/// Message returned by the MLX session's conceptual token-level primitives.
+/// The CLI never hits this path (it drives the fused `generate_*` methods); it
+/// documents, for a reader or a future backend author, that `prefill` /
+/// `decode_step` are the engine-neutral contract a compiler-family backend
+/// (issue #449) fills in rather than the MLX fast path.
+const RESERVED_STEP_CONTRACT: &str = "MlxInferenceSession drives generation through its fused generate_* entry \
+     points (generate, generate_streaming, generate_with_stats, and the \
+     embedding-prefill variants); the token-level prefill / decode_step \
+     primitives are the engine-neutral contract reserved for the StableHLO/MLIR \
+     compiler-family backend (ADR 0004, issue #449) and are not the MLX path";
+
+#[cfg(test)]
+#[path = "session_tests.rs"]
+mod tests;

--- a/src/lib/mlxcel-core/src/session_tests.rs
+++ b/src/lib/mlxcel-core/src/session_tests.rs
@@ -1,0 +1,86 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Focused tests for the core inference-session contract. These do not load a
+//! real checkpoint (token-parity is owned by the CLI parity gate); they assert
+//! the capability advertisement, token-bias wiring, the object-safe trait
+//! contract, and that the conceptual token-level primitives report they are
+//! reserved for the compiler-family backend on MLX.
+
+use super::*;
+use crate::sampling::TokenBiasMap;
+
+/// Compile-time proof that the MLX session satisfies the object-safe contract,
+/// so a future backend can be held behind `Box<dyn InferenceSession>`.
+const _: () = {
+    fn _requires_session<T: InferenceSession>() {}
+    fn _check() {
+        _requires_session::<MlxInferenceSession>();
+    }
+    fn _object_safe(_s: &dyn InferenceSession) {}
+};
+
+#[test]
+fn single_sequence_caps_are_the_conservative_floor() {
+    let caps = SessionCapabilities::single_sequence();
+    assert!(!caps.batched_serving);
+    assert!(!caps.paged_kv);
+    assert!(!caps.speculative_decode);
+    assert!(!caps.multimodal);
+}
+
+#[test]
+fn mlx_session_advertises_single_sequence_plus_multimodal() {
+    let session = MlxInferenceSession::new(4);
+    let caps = session.capabilities();
+    // The single-sequence MLX session does not batch, page, or speculate
+    // internally, but it accepts multimodal embedding prefill.
+    assert!(!caps.batched_serving);
+    assert!(!caps.paged_kv);
+    assert!(!caps.speculative_decode);
+    assert!(caps.multimodal);
+}
+
+#[test]
+fn mlx_session_default_bias_is_empty() {
+    let session = MlxInferenceSession::new(4);
+    assert!(session.token_bias().is_empty());
+}
+
+#[test]
+fn mlx_session_with_token_bias_caches_map() {
+    let mut bias = TokenBiasMap::new();
+    bias.insert(3, -1.5);
+    let session = MlxInferenceSession::new_with_kv_mode(4, KVCacheMode::Fp16).with_token_bias(bias);
+    assert_eq!(session.token_bias().len(), 1);
+    assert!(session.token_bias().contains(3));
+}
+
+#[test]
+fn mlx_session_step_primitives_are_reserved_for_compiler_backend() {
+    let mut session = MlxInferenceSession::new(4);
+    let prefill = session.prefill(&[1, 2, 3]);
+    assert!(
+        prefill.is_err(),
+        "MLX prefill must report it is the reserved token-level contract"
+    );
+    let step = session.decode_step(7);
+    assert!(
+        step.is_err(),
+        "MLX decode_step must report it is the reserved token-level contract"
+    );
+    // The error names the fused entry points the CLI actually uses.
+    let msg = prefill.unwrap_err().to_string();
+    assert!(msg.contains("generate_streaming"), "error message: {msg}");
+}


### PR DESCRIPTION
## Summary

Redraw the compute-backend seam from PR #446 into the inference-session contract ADR 0004 settled on, and move the MLX CLI path behind it as a behavior-preserving refactor. PR #446 drew the boundary at model load and returned the concrete MLX `LoadedModel`; that altitude cannot host a graph-compiler backend (FuriosaAI, Tenstorrent, OpenXLA) that never produces an `MlxArray`. This adds the session layer for the CLI path while leaving the server batched path exactly as it was. MLX is the only real backend here; the result is byte-identical on the CLI.

## Layered contract

Core single-sequence session (the new contract): `mlxcel-core/src/session.rs` defines `InferenceSession`, an object-safe, engine-neutral trait that exposes capability advertisement (`capabilities`) plus the conceptual token-level primitives `prefill` / `decode_step`. That is the shape a future non-MLX backend (issue #449, a separate default-off crate) implements; this is the extension point left for it. The MLX implementation `MlxInferenceSession` wraps the existing `CxxGenerator`.

Extended layer (MLX-only, intentionally untouched): the server `BatchScheduler` keeps doing cross-sequence batched forward and owns `LoadedModel` directly through the retained `ComputeBackend::load_model(path) -> (LoadedModel, MlxcelTokenizer)` entry. `src/server/model_worker.rs` and the scheduler are not changed. Batched serving is advertised as an MLX backend capability that the single-sequence session does not cover yet (the deferred KV / batching abstraction per ADR 0004).

## What the MLX session wraps

`MlxInferenceSession` is a thin wrapper around `CxxGenerator`. Every generation method delegates verbatim to the matching `CxxGenerator` method in `src/lib/mlxcel-core/src/generate.rs`: `generate`, `generate_streaming`, `generate_streaming_with_embeddings`, `generate_with_stats`, `generate_with_stats_and_embeddings`, and `evaluate_loglikelihoods`. The decode loop is not rewritten and `CxxGenerator` internals and the `LanguageModel` trait are unchanged, so the exact same code runs. On MLX the `prefill` / `decode_step` primitives return a reserved-contract message, because the CLI drives the fused `generate_*` entry points and the granular stepping primitives are the contract for the compiler-family backend, not the MLX fast path.

## How byte-identical is guaranteed

By construction: the same `CxxGenerator` code runs whether a caller reaches it directly or through `Session` -> `MlxInferenceSession`. The session carries the same KV mode and the same pre-resolved token bias the CLI built before (empty map preserves the bit-exact baseline via `compose_sampling`), and the same sampling config and arguments flow through unchanged.

## How the dispatch folds under default features

`Session` is a single-variant enum (`Session::Mlx`). `select_backend()` folds to the single `Backend::Mlx` variant (PR #446), and every `Session` and `Backend` method is a single-arm `match` marked `#[inline]`. After inlining, `backend.create_session(...).generate(...)` lowers to a direct call into the wrapped `CxxGenerator` with no runtime indirection added on the generation hot path. The per-token forward stays inside the session method and `KVCache` is never type-erased. The `experimental-backend` module and enum variant stay `cfg`-gated off, so shipping Apple-Silicon and CUDA builds compile no extra backend code.

## What changed

- `src/lib/mlxcel-core/src/session.rs` (new): `SessionCapabilities`, the object-safe `InferenceSession` trait (`capabilities` / `prefill` / `decode_step`), and `MlxInferenceSession` wrapping `CxxGenerator` with verbatim-delegating generation methods.
- `src/lib/mlxcel-core/src/session_tests.rs` (new) and the `pub mod session` + re-export in `src/lib/mlxcel-core/src/lib.rs`.
- `src/backend/session.rs` (new): the root-crate `Session` enum (single `Mlx` variant) with inline single-arm dispatch over the generation methods.
- `src/backend/mod.rs`: `ComputeBackend` gains `create_session` and `supports_batched_serving`; the `Backend` enum dispatches both; module/trait docs updated to the two-layer contract. `load_model` and friends are unchanged.
- `src/backend/mlx.rs`: `MlxBackend::create_session` builds `Session::Mlx(MlxInferenceSession::new_with_kv_mode(...).with_token_bias(...))`; `supports_batched_serving` returns true.
- `src/backend/experimental.rs`: cfg-gated session stub returns the same `not_implemented()` error; `supports_batched_serving` returns false; forward-looking note updated to point at the session contract.
- `src/backend/tests.rs`: MLX backend resolves a session and advertises batched serving, threads the token bias through, and (under `experimental-backend`) the scaffold's session creation errors.
- `src/commands/generate.rs`: `generate_standard` and `generate_with_embeddings` obtain a `Session` from the backend instead of constructing `CxxGenerator`; `generate_standard` now returns `Result`. The offline draft-model load already routes through `select_backend().load_model`.
- `src/commands/chat.rs`: `run_chat` builds one session for the REPL; `stream_turn` and the `/clear` reset drive the session.
- `src/lib.rs`: re-export `Session`, `InferenceSession`, `MlxInferenceSession`, `SessionCapabilities`.

## Test plan

- [x] `cargo check --lib --features metal,accelerate`
- [x] `cargo check --bins --features metal,accelerate`
- [x] `cargo clippy --lib --tests --features metal,accelerate -- -D warnings`
- [x] `cargo clippy --lib --tests --features metal,accelerate,experimental-backend -- -D warnings`
- [x] `cargo test --lib --features metal,accelerate backend::` (5 passed)
- [x] `cargo test --lib --features metal,accelerate -p mlxcel-core session::` (5 passed)
- [x] `cargo fmt --check`
- [ ] Orchestrator owns the release build and the temp-0 greedy byte-identical parity gate on `llama-3.2-1b-4bit`.

Closes #448
