### PR TITLE
feat: int4 dequant-in-graph spike for Llama-3.2-1B (#449 Phase 2a)

### DIFF
--- a/spike/openxla/FINDINGS_phase2a.md
+++ b/spike/openxla/FINDINGS_phase2a.md
@@ -1,0 +1,153 @@
+# Phase 2a findings: int4 dequant-in-graph lowering, fusion, and correctness
+
+Issue #449 Phase 2a (the int4 comment on the issue). Scope: on the proven JAX
+harness, add a dequant-in-graph int4 path and characterize the lowering
+structure, whether XLA and IREE fuse the unpack/convert/scale into the matmul,
+and whether greedy coherence holds. Frontend-independent, so the JAX harness is
+the vehicle. The issue scoped 2a as no-perf; CUDA turned out to be available on
+this box, so a GPU correctness run is included (perf stays Phase 2b).
+
+## Verdict
+
+The dequant-in-graph int4 route is correct and stays coherent. The central
+question (does the compiler fuse the dequant into the matmul, or materialize a
+full fp32 weight first?) resolves the same way on every target tried: the
+dequantized fp32 weight is materialized, not fused into the matmul. So this naive
+route buys an 8x smaller weight to load and upload, but no matmul compute or
+bandwidth win on its own. A real int4 matmul win needs a recognized
+quantized-matmul fusion (which this pattern did not trigger) or a `custom_call`
+to an int4 GEMM. That is the Phase 2 finding the success bar depended on.
+
+## Quantization used
+
+Affine asymmetric int4, group size 64 along the contraction dim, packed 8 nibbles
+per uint32 (per group: scale + min). Applied to the 7 per-layer linear weights
+(q, k, v, o, gate, up, down); embedding and norms stay fp32. Representative of the
+mlx-community affine 4-bit scheme; exact format alignment with mlxcel's loader is
+a Phase 3 concern, not needed to characterize the route.
+
+- Layer-0 relative Frobenius error per weight: 0.090 to 0.097 (typical for 4-bit
+  round-to-nearest, no GPTQ).
+- One weight as a memory check: `down` is 67.1 MB fp32 to 8.4 MB packed int4 plus
+  per-group scales (about 1/64 of the fp32 size). The 8x storage shrink is the
+  real, target-independent win.
+
+## Correctness of the in-graph dequant
+
+Two paths over the SAME quantized weights: (a) dequant on the host then run the
+plain fp32 graph, (b) dequant inside the graph. Their prefill last-token logits
+agree to max abs diff 7.4e-5 with identical argmax. The in-graph unpack
+(shift + mask), convert, and scale reproduce the host dequant. This isolates "is
+the in-graph dequant correct" from "does quantization change the model".
+
+## Coherence
+
+int4 greedy continuation for the fixed prompt:
+
+```
+Here are three short tips for staying focused while working:
+
+1. **Set clear goals and deadlines**: Before starting your work, define what
+needs to be done and by when. Break down large tasks into smaller, manageable
+chunks, and set specific
+```
+
+Coherent and on-task. Versus the fp16 greedy run it agrees for the first 18
+tokens then diverges (30/48 tokens match overall), which is expected: 4-bit RTN
+changes the weights, so token-exactness with fp16 is not the bar; coherence is,
+and it holds.
+
+## StableHLO structure
+
+The exported int4 `decode_step` keeps the dequant as explicit standard ops, no
+custom op: `shift_right_logical` 112, `and` 112, `convert` 113 (= 16 layers x 7
+linears), feeding 145 `dot_general`, `custom_call` absent. Packed weights enter
+as `ui32` graph inputs. So the dequant is visible and separable in the graph,
+exactly the shape a later `custom_call`-to-int4-GEMM swap would replace.
+
+## The core question: fuse or materialize
+
+Isolated one int4 linear (`y = x @ dequant(packed, scale, min).T`, K=N=2048) so
+the optimized IR is readable. Findings per target:
+
+- **XLA, CPU.** The whole dequant and the dot land in a single `kLoop` fusion
+  (`%copy_dot_fusion` calling one `%fused_computation` that contains
+  shift-right-logical, and, convert, broadcast, multiply, add, then ROOT `dot`).
+  Fused at the HLO level. But inside the fusion the full `f32[2048,2048]` weight
+  is reconstructed (`add.0`, then `transpose.0`, then `copy.1`, all
+  `f32[2048,2048]`) before the dot consumes it. So the dot reads a full fp32
+  weight; no int4 bandwidth advantage on the matmul. Fused as one HLO op, but the
+  fp32 weight is materialized within it.
+
+- **IREE, CPU.** Two separate dispatches: `main_dispatch_2_elementwise_transpose`
+  carries `arith.shrui` + `arith.uitofp` + `arith.mulf` + `arith.addf` (the
+  unpack, convert, and scale), and `main_dispatch_3_vecmat` is the matmul. The
+  dequant dispatch writes a full f32 weight to memory; the vecmat reads it. Not
+  fused.
+
+- **IREE, CUDA (GB10).** Same split, because dispatch-region formation happens at
+  the target-independent flow level. The dumped CUDA executables are a separate
+  dequant kernel (`dispatch_2`: shrui, uitofp) and a separate `vecmat` kernel
+  (`dispatch_3`). Not fused on the GPU either.
+
+Net: out of the box, none of XLA-CPU, IREE-CPU, or IREE-CUDA produce a fused int4
+matmul that reads packed weights directly. XLA fuses the ops into one loop fusion
+but still rebuilds the fp32 weight inside it; IREE forms a distinct dequant
+dispatch that materializes the fp32 weight. The matmul always reads fp32. To get
+a real int4 matmul (bandwidth and memory on the GEMM itself) you need IREE's
+quantized-matmul / data-tiling fusion to recognize the pattern (this naive affine
+RTN pattern did not trigger it in 3.11) or a `custom_call` to a target int4 GEMM.
+The graph here is already shaped for that swap: the dequant feeding each
+`dot_general` is the exact subgraph a custom op would replace.
+
+## GPU run (enabled by CUDA on this box)
+
+CUDA is available here after all: GB10 is compute capability 12.1 (sm_121), and
+IREE 3.11 ships both the `cuda` compiler target and the `cuda` runtime driver.
+The exported int4 StableHLO compiles to CUDA and runs on the GB10:
+
+- The full int4 loop (prefill + decode) runs on the GB10 and is **token-exact
+  (48/48)** with the CPU int4 run, coherent. The acceleration path
+  (exported StableHLO to IREE-CUDA to GB10) works end to end.
+- Compile invocation: `--iree-hal-target-device=cuda` (default target; the
+  driver JITs PTX to sm_121 at load). Passing `--iree-cuda-target=sm_121`
+  explicitly is rejected by this build's device syntax with "missing GPU target";
+  the default-target path is the one that works.
+- Portability fix: prefill's range-slice cache write (`kcache.at[li, :Lp].set`)
+  lowers to `iree_linalg_ext.scatter`, which the CUDA backend rejects ("expected
+  indices to be equal to batch rank"). Rewriting the cache build as pad + stack
+  (a `dynamic_update_slice`) lowers cleanly on both CPU and CUDA and is
+  numerically identical. Decode's single-index write
+  (`kcache.at[li, cache_len].set`) was already fine. Worth recording for the
+  in-tree emitter: prefer dynamic-update-slice cache writes over range-slice
+  scatters for GPU portability.
+- No perf claim. The functional-call harness re-uploads all ~700 MB of weights as
+  graph inputs every decode step and syncs logits to host per token, so its
+  per-token time is upload-bound, not a throughput number. Real GPU numbers need
+  weights resident on-device, batching, and on-device sampling, which is Phase 2b.
+
+This also updates the Phase 1 "GPU blocked on aarch64+Blackwell" note: blocked for
+a CUDA jaxlib (still true, none on PyPI), but NOT blocked for execution, because
+IREE compiles the same StableHLO to CUDA and runs it on the GB10. Phase 2b can
+proceed on this box through the IREE-CUDA path.
+
+## Files
+
+`quant.py` (affine int4 pack/unpack), `model_int4.py` (dequant-in-graph
+prefill/decode), `run_phase2a.py` (quant error, in-graph vs host dequant,
+coherence, StableHLO op check), `fusion_probe.py` (XLA optimized HLO + IREE
+dispatch analysis on one linear), `gpu_iree.py` (compile to CUDA, run on GB10,
+token-match check). Artifacts in `artifacts/`:
+`decode_step_int4.stablehlo.mlir`, `qmatmul_xla_optimized.hlo`,
+`qmatmul.flow.mlir` (IREE dispatches), `*.cuda.vmfb`, `results_int4*.json`.
+
+## Recommendation
+
+Record dequant-in-graph as correct and coherent but not self-fusing: the matmul
+reads a materialized fp32 weight on every target tested, so int4 alone is a
+storage and weight-transfer win, not a GEMM win. For the Phase 2 success bar the
+route to a real int4 matmul is a `custom_call` to a target int4 GEMM (the graph
+is already shaped for it) or getting IREE's quantized-matmul fusion to recognize
+the pattern. Carry the dynamic-update-slice cache-write rule into whichever
+authoring frontend wins (#451). Defer throughput to Phase 2b, which is now
+runnable here via IREE-CUDA on the GB10.

--- a/spike/openxla/fusion_probe.py
+++ b/spike/openxla/fusion_probe.py
@@ -1,0 +1,89 @@
+"""Phase 2a core question: do XLA and IREE FUSE the int4 unpack/convert/scale
+into the matmul, or materialize a full fp32 weight first?
+
+Isolates one int4 linear (y = x @ dequant(packed,scale,wmin).T) so the optimized
+HLO and the IREE dispatch IR are small and readable, then characterizes fusion.
+"""
+import collections
+import re
+import subprocess
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax import export as jexport
+
+import model_int4 as Mi
+import quant as Q
+
+K, N, G = 2048, 2048, 64
+ART = "artifacts"
+IREE = ".venv/bin/iree-compile"
+
+
+def f(x, packed, scale, wmin):
+    W = Mi._dequant_ig((packed, scale, wmin), G)   # [N, K] dequantized in-graph
+    return x @ W.T                                  # [1, N]
+
+
+def main():
+    rng = np.random.default_rng(0)
+    W = rng.standard_normal((N, K)).astype(np.float32)
+    packed, scale, wmin = Q.quantize_affine_int4(W, G)
+    x = rng.standard_normal((1, K)).astype(np.float32)
+    args = (jnp.asarray(x), jnp.asarray(packed), jnp.asarray(scale), jnp.asarray(wmin))
+
+    # ---- XLA: optimized HLO ----
+    compiled = jax.jit(f).lower(*args).compile()
+    hlo = compiled.as_text()
+    open(f"{ART}/qmatmul_xla_optimized.hlo", "w").write(hlo)
+
+    # find fusion computations and whether dequant ops co-occur with the dot
+    fused = False
+    materialized_weight = False
+    for comp in re.split(r"\n\}\n", hlo):
+        has_dot = bool(re.search(r"\bdot\(", comp)) or "dot(" in comp
+        has_dequant = any(t in comp for t in ("shift-right-logical", "convert", "multiply"))
+        if has_dot and has_dequant:
+            fused = True
+    # a materialized f32 [N,K] weight buffer is the tell for non-fusion
+    if re.search(rf"f32\[{N},{K}\].*(fusion|convert|multiply)", hlo):
+        materialized_weight = True
+    dots = hlo.count(" dot(")
+    custom_matmul = bool(re.search(r"custom-call.*(matmul|dot|Eigen|gemm)", hlo, re.I))
+    print("=== XLA optimized HLO (single int4 linear) ===")
+    print(f"  dot instructions          : {dots}")
+    print(f"  matmul lowered to custom-call: {custom_matmul}")
+    print(f"  a fusion contains BOTH dequant ops AND the dot: {fused}")
+    print(f"  a full f32[{N},{K}] dequant weight is materialized: {materialized_weight}")
+
+    # ---- IREE: dispatch regions ----
+    exp = jexport.export(jax.jit(f))(*[jax.ShapeDtypeStruct(a.shape, a.dtype) for a in args])
+    open(f"{ART}/qmatmul.stablehlo.mlir", "w").write(exp.mlir_module())
+    proc = subprocess.run(
+        [IREE, "--iree-input-type=stablehlo", "--iree-hal-target-backends=llvm-cpu",
+         "--mlir-print-ir-after=iree-flow-form-dispatch-regions",
+         "--mlir-disable-threading", f"{ART}/qmatmul.stablehlo.mlir", "-o", f"{ART}/qmatmul.vmfb"],
+        capture_output=True, text=True)
+    disp = proc.stderr
+    open(f"{ART}/qmatmul_iree_dispatch.mlir", "w").write(disp)
+    n_regions = disp.count("flow.dispatch.region")
+    # within each dispatch region, does the matmul region also carry the unpack/convert?
+    regions = re.split(r"flow\.dispatch\.region", disp)
+    matmul_region_has_dequant = any(
+        ("linalg.matmul" in r or "linalg.mmt4d" in r or "linalg.generic" in r and "arith.mulf" in r)
+        and any(t in r for t in ("arith.shrui", "arith.uitofp", "arith.extui", "arith.sitofp"))
+        for r in regions)
+    has_matmul = any(t in disp for t in ("linalg.matmul", "linalg.mmt4d"))
+    # a separate dispatch producing a full [N,K] f32 tensor = materialized dequant
+    materialized_iree = bool(re.search(rf"tensor<{N}x{K}xf32>", disp))
+    print("\n=== IREE dispatch regions (single int4 linear) ===")
+    print(f"  flow.dispatch.region count : {n_regions}")
+    print(f"  matmul present (matmul/mmt4d): {has_matmul}")
+    print(f"  matmul dispatch also carries the int4 unpack/convert (fused): {matmul_region_has_dequant}")
+    print(f"  a full tensor<{N}x{K}xf32> dequant weight is materialized: {materialized_iree}")
+    print(f"\nwrote {ART}/qmatmul_xla_optimized.hlo, qmatmul_iree_dispatch.mlir, qmatmul.stablehlo.mlir")
+
+
+if __name__ == "__main__":
+    main()

--- a/spike/openxla/gpu_iree.py
+++ b/spike/openxla/gpu_iree.py
@@ -1,0 +1,118 @@
+"""Phase 2a (GPU): compile the int4 dequant-in-graph graphs to CUDA (sm_121) with
+IREE and run greedy decode on the GB10. Verifies the GPU path is numerically
+correct (token-match to the CPU int4 run) and times decode. Acceleration test
+enabled by CUDA being available on this box.
+"""
+import json
+import os
+import subprocess
+import time
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax import export as jexport
+from transformers import AutoTokenizer
+
+import model_jax as M
+import model_int4 as Mi
+
+MODEL = "models/Llama-3.2-1B-Instruct"
+MAX_SEQ = 256
+BUCKETS = [32, 64, 128, 256]
+EOS = {128001, 128008, 128009}
+SDS = jax.ShapeDtypeStruct
+ART = "artifacts"
+IREE = ".venv/bin/iree-compile"
+SM = "sm_121"
+
+
+def bucket(n):
+    return next(b for b in BUCKETS if n <= b)
+
+
+def compile_cuda(mlir, vmfb):
+    # Default cuda device target; PTX is JIT'd to the GB10 (sm_121) by the driver.
+    # Explicit --iree-cuda-target=sm_121 is rejected by this IREE build's device syntax.
+    cmd = [IREE, "--iree-input-type=stablehlo", "--iree-hal-target-device=cuda", mlir, "-o", vmfb]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+def main():
+    os.makedirs(ART, exist_ok=True)
+    tok = AutoTokenizer.from_pretrained(MODEL)
+    text = tok.apply_chat_template(
+        [{"role": "user", "content": "Give me three short tips for staying focused while working."}],
+        add_generation_prompt=True, tokenize=False)
+    ids = tok(text, add_special_tokens=False).input_ids
+    n = len(ids)
+    Lp = bucket(n)
+
+    cfg = M.load_config(MODEL)
+    L, nkv, d = cfg.n_layers, cfg.n_kv, cfg.head_dim
+    fp32 = M.load_params(MODEL, cfg)
+    qp = Mi.quantize_params(fp32)
+    prefill_i4, decode_i4 = Mi.make_int4_fns(cfg, MAX_SEQ)
+
+    qp_aval = jax.tree.map(lambda x: SDS(x.shape, x.dtype), qp)
+    exp_p = jexport.export(jax.jit(prefill_i4))(
+        qp_aval, SDS((Lp,), jnp.int32), SDS((Lp,), jnp.int32), SDS((), jnp.int32))
+    exp_d = jexport.export(jax.jit(decode_i4))(
+        qp_aval, SDS((), jnp.int32), SDS((), jnp.int32), SDS((), jnp.int32),
+        SDS((L, MAX_SEQ, nkv, d), jnp.float32), SDS((L, MAX_SEQ, nkv, d), jnp.float32))
+    open(f"{ART}/prefill_int4.stablehlo.mlir", "w").write(exp_p.mlir_module())
+    open(f"{ART}/decode_step_int4.stablehlo.mlir", "w").write(exp_d.mlir_module())
+
+    print("compiling int4 graphs to CUDA (GB10, sm_121 via driver PTX-JIT) ...")
+    compile_cuda(f"{ART}/prefill_int4.stablehlo.mlir", f"{ART}/prefill_int4.cuda.vmfb")
+    compile_cuda(f"{ART}/decode_step_int4.stablehlo.mlir", f"{ART}/decode_step_int4.cuda.vmfb")
+    print(f"  prefill.cuda.vmfb {os.path.getsize(f'{ART}/prefill_int4.cuda.vmfb')/1e3:.0f} KB | "
+          f"decode.cuda.vmfb {os.path.getsize(f'{ART}/decode_step_int4.cuda.vmfb')/1e3:.0f} KB")
+
+    from iree.runtime import load_vm_flatbuffer_file
+    mp = load_vm_flatbuffer_file(f"{ART}/prefill_int4.cuda.vmfb", driver="cuda")
+    md = load_vm_flatbuffer_file(f"{ART}/decode_step_int4.cuda.vmfb", driver="cuda")
+
+    leaves = [np.asarray(x) for x in jax.tree_util.tree_flatten(qp)[0]]
+    toks = np.zeros(Lp, np.int32); toks[:n] = np.array(ids, np.int32)
+    pos = np.arange(Lp, dtype=np.int32)
+
+    t0 = time.time()
+    out = mp.main(*leaves, toks, pos, np.asarray(n, np.int32))
+    logits = np.asarray(out[0].to_host()); kc, vc = out[1], out[2]
+    prefill_ms = (time.time() - t0) * 1e3
+
+    nxt = int(logits.argmax()); gen = [nxt]; clen = cur = n; tdec = []
+    for _ in range(47):
+        if nxt in EOS:
+            break
+        t0 = time.time()
+        out = md.main(*leaves, np.asarray(nxt, np.int32), np.asarray(cur, np.int32),
+                      np.asarray(clen, np.int32), kc, vc)
+        logits = np.asarray(out[0].to_host()); kc, vc = out[1], out[2]
+        tdec.append(time.time() - t0)
+        nxt = int(logits.argmax()); gen.append(nxt); clen += 1; cur += 1
+
+    steady = tdec[1:] if len(tdec) > 1 else tdec
+    gpu_text = tok.decode(gen)
+    print("\n=== int4 greedy on GB10 (IREE CUDA) ===")
+    print(repr(gpu_text))
+    cpu = json.load(open(f"{ART}/results_int4.json")) if os.path.exists(f"{ART}/results_int4.json") else None
+    if cpu:
+        a = cpu["int4_ids"]; m = min(len(a), len(gen))
+        agree = sum(int(a[i] == gen[i]) for i in range(m))
+        print(f"GPU int4 vs CPU int4 token match: {agree}/{m}"
+              + ("  (exact)" if agree == m else f"  first differ {next(i for i in range(m) if a[i]!=gen[i])}"))
+    print(f"GPU prefill: {prefill_ms:.0f} ms (incl. first-call JIT) | "
+          f"GPU decode: {np.mean(steady)*1e3:.1f} ms/tok over {len(steady)} steps")
+    print("  NOTE: not a throughput number. This functional harness re-uploads all "
+          "weights as graph\n  inputs every step and syncs logits to host per token; "
+          "real GPU perf needs resident\n  weights + batching + on-device sampling (Phase 2b). "
+          "GPU correctness is the result here.")
+    json.dump({"gpu_text": gpu_text, "gpu_ids": gen,
+               "gpu_decode_tok_s": float(1.0/np.mean(steady)) if steady else None},
+              open(f"{ART}/results_int4_gpu.json", "w"), indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/spike/openxla/model_int4.py
+++ b/spike/openxla/model_int4.py
@@ -1,0 +1,128 @@
+"""int4 dequant-in-graph variant of the Llama-3.2-1B decode/prefill graphs.
+
+The 7 per-layer linear weights (q,k,v,o,gate,up,down) are stored as packed int4
+plus per-group scale and min. Each weight is unpacked (shift + mask), converted
+to fp32, and dequantized (codes * scale + min) inside the graph, immediately
+before its `dot_general`. Embedding and norms stay fp32. This is the
+correctness-first int4 route; the spike characterizes whether XLA/IREE fuse the
+unpack/convert/scale into the matmul or materialize a full fp32 weight first.
+
+Reuses the structural pieces (RoPE, RMSNorm, mask, GQA) from model_jax so the
+only change versus the fp32 graph is the weight source.
+"""
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+import model_jax as M
+import quant as Q
+
+LINEARS = ("wq", "wk", "wv", "wo", "gate", "up", "down")
+
+
+def quantize_params(params, group=Q.GROUP):
+    """fp32 params -> int4 params: quantize the 7 linears, keep embed/norms fp32.
+    Each quantized weight becomes (packed, scale, wmin) as jnp arrays."""
+    import numpy as np
+    qp = {"embed": params["embed"], "final_norm": params["final_norm"], "layers": []}
+    for lp in params["layers"]:
+        ql = {"in_ln": lp["in_ln"], "post_ln": lp["post_ln"]}
+        for name in LINEARS:
+            W = np.asarray(lp[name], dtype=np.float32)
+            packed, scale, wmin = Q.quantize_affine_int4(W, group)
+            ql[name] = (jnp.asarray(packed), jnp.asarray(scale), jnp.asarray(wmin))
+        qp["layers"].append(ql)
+    return qp
+
+
+def dequantize_params(qp, group=Q.GROUP):
+    """int4 params -> fp32 params (the dequant-then-fp32 baseline; reuses the
+    plain model_jax graph). Mirrors the in-graph dequant exactly on the host."""
+    fp = {"embed": qp["embed"], "final_norm": qp["final_norm"], "layers": []}
+    for ql in qp["layers"]:
+        lp = {"in_ln": ql["in_ln"], "post_ln": ql["post_ln"]}
+        for name in LINEARS:
+            packed, scale, wmin = ql[name]
+            lp[name] = jnp.asarray(Q.dequantize_ref(
+                __import__("numpy").asarray(packed), __import__("numpy").asarray(scale),
+                __import__("numpy").asarray(wmin), group))
+        fp["layers"].append(lp)
+    return fp
+
+
+def _dequant_ig(qw, group):
+    """in-graph dequant of one packed int4 weight -> fp32 [out, in]."""
+    packed, scale, wmin = qw
+    out, ip8 = packed.shape
+    in_dim = ip8 * 8
+    shifts = jnp.arange(8, dtype=jnp.uint32) * 4
+    codes = (packed[:, :, None] >> shifts) & jnp.uint32(0xF)   # [out, in/8, 8]
+    codes = codes.reshape(out, in_dim).astype(jnp.float32)
+    scale_b = jnp.repeat(scale, group, axis=1)                 # [out, in]
+    wmin_b = jnp.repeat(wmin, group, axis=1)
+    return codes * scale_b + wmin_b
+
+
+def _lin(x, qw, group):
+    return x @ _dequant_ig(qw, group).T
+
+
+def make_int4_fns(cfg: M.Config, max_seq: int, group: int = Q.GROUP):
+    cos_t, sin_t = M.rope_tables(cfg, max_seq)
+    g, nq, nkv, d = cfg.group, cfg.n_q, cfg.n_kv, cfg.head_dim
+    NEG = jnp.float32(-1e30)
+
+    def mlp(h, ql):
+        return _lin(M._silu(_lin(h, ql["gate"], group)) * _lin(h, ql["up"], group), ql["down"], group)
+
+    def prefill(params, tokens, positions, real_len):
+        Lp = tokens.shape[0]
+        x = params["embed"][tokens]
+        cos, sin = cos_t[positions], sin_t[positions]
+        i = jnp.arange(Lp)[:, None]; j = jnp.arange(Lp)[None, :]
+        cmask = jnp.where(j <= i, 0.0, NEG).astype(jnp.float32)
+        pad = max_seq - Lp
+        kc_layers, vc_layers = [], []
+        for li, ql in enumerate(params["layers"]):
+            h = M._rms_norm(x, ql["in_ln"], cfg.eps)
+            q = _lin(h, ql["wq"], group).reshape(Lp, nq, d)
+            k = _lin(h, ql["wk"], group).reshape(Lp, nkv, d)
+            v = _lin(h, ql["wv"], group).reshape(Lp, nkv, d)
+            q = M._apply_rope(q, cos, sin); k = M._apply_rope(k, cos, sin)
+            # pad to MAX_SEQ + stack across layers (avoids a range-slice scatter
+            # that IREE's CUDA backend does not lower; dynamic_update_slice/pad do).
+            kc_layers.append(jnp.pad(k, ((0, pad), (0, 0), (0, 0))))
+            vc_layers.append(jnp.pad(v, ((0, pad), (0, 0), (0, 0))))
+            k_rep = jnp.repeat(k, g, axis=1); v_rep = jnp.repeat(v, g, axis=1)
+            scores = jnp.einsum("ihd,jhd->hij", q, k_rep) * cfg.scale + cmask[None]
+            attn = jax.nn.softmax(scores, axis=-1)
+            o = jnp.einsum("hij,jhd->ihd", attn, v_rep).reshape(Lp, nq * d)
+            x = x + _lin(o, ql["wo"], group)
+            x = x + mlp(M._rms_norm(x, ql["post_ln"], cfg.eps), ql)
+        xf = M._rms_norm(x, params["final_norm"], cfg.eps)
+        last = jax.lax.dynamic_slice_in_dim(xf, real_len - 1, 1, axis=0)[0]
+        return last @ params["embed"].T, jnp.stack(kc_layers, 0), jnp.stack(vc_layers, 0)
+
+    def decode_step(params, token, pos, cache_len, kcache, vcache):
+        x = params["embed"][token]
+        cos, sin = cos_t[pos][None], sin_t[pos][None]
+        valid = jnp.arange(max_seq) <= cache_len
+        kmask = jnp.where(valid, 0.0, NEG).astype(jnp.float32)
+        for li, ql in enumerate(params["layers"]):
+            h = M._rms_norm(x, ql["in_ln"], cfg.eps)
+            q = _lin(h, ql["wq"], group).reshape(1, nq, d)
+            k = _lin(h, ql["wk"], group).reshape(1, nkv, d)
+            v = _lin(h, ql["wv"], group).reshape(1, nkv, d)
+            q = M._apply_rope(q, cos, sin)[0]; k = M._apply_rope(k, cos, sin)[0]; v = v[0]
+            kcache = kcache.at[li, cache_len].set(k); vcache = vcache.at[li, cache_len].set(v)
+            k_rep = jnp.repeat(kcache[li], g, axis=1); v_rep = jnp.repeat(vcache[li], g, axis=1)
+            scores = jnp.einsum("hd,shd->hs", q, k_rep) * cfg.scale + kmask[None]
+            attn = jax.nn.softmax(scores, axis=-1)
+            o = jnp.einsum("hs,shd->hd", attn, v_rep).reshape(nq * d)
+            x = x + _lin(o, ql["wo"], group)
+            x = x + mlp(M._rms_norm(x, ql["post_ln"], cfg.eps), ql)
+        xf = M._rms_norm(x, params["final_norm"], cfg.eps)
+        return xf @ params["embed"].T, kcache, vcache
+
+    return prefill, decode_step

--- a/spike/openxla/quant.py
+++ b/spike/openxla/quant.py
@@ -1,0 +1,43 @@
+"""Affine asymmetric int4 group quantization (RTN), packed 8 nibbles per uint32.
+
+Representative of the mlx-community affine 4-bit scheme (group along the
+contraction dim; per-group scale + min). Exact format alignment with mlxcel's
+loader is a Phase 3 concern; this characterizes the dequant-in-graph route.
+"""
+import numpy as np
+
+GROUP = 64
+
+
+def quantize_affine_int4(W, group=GROUP):
+    """W: float32 [out, in] (in divisible by group and by 8).
+    Returns (packed uint32[out, in/8], scale f32[out, in/group], wmin f32[out, in/group])."""
+    out, ind = W.shape
+    ng = ind // group
+    Wg = W.reshape(out, ng, group)
+    wmin = Wg.min(axis=2)
+    wmax = Wg.max(axis=2)
+    scale = (wmax - wmin) / 15.0
+    scale = np.where(scale == 0.0, 1.0, scale)
+    codes = np.round((Wg - wmin[:, :, None]) / scale[:, :, None])
+    codes = np.clip(codes, 0, 15).astype(np.uint32).reshape(out, ind)
+    shifts = np.arange(8, dtype=np.uint32) * 4
+    packed = (codes.reshape(out, ind // 8, 8) << shifts).sum(axis=2).astype(np.uint32)
+    return packed, scale.astype(np.float32), wmin.astype(np.float32)
+
+
+def dequantize_ref(packed, scale, wmin, group=GROUP):
+    """numpy reference dequant (ground truth for the in-graph version)."""
+    out, ip8 = packed.shape
+    in_dim = ip8 * 8
+    shifts = np.arange(8, dtype=np.uint32) * 4
+    codes = (packed[:, :, None] >> shifts) & np.uint32(0xF)
+    codes = codes.reshape(out, in_dim).astype(np.float32)
+    return codes * np.repeat(scale, group, axis=1) + np.repeat(wmin, group, axis=1)
+
+
+def quant_error(W, packed, scale, wmin, group=GROUP):
+    Wq = dequantize_ref(packed, scale, wmin, group)
+    num = np.linalg.norm(W - Wq)
+    den = np.linalg.norm(W) + 1e-12
+    return float(num / den)  # relative Frobenius error

--- a/spike/openxla/run_phase2a.py
+++ b/spike/openxla/run_phase2a.py
@@ -1,0 +1,118 @@
+"""Phase 2a: int4 dequant-in-graph correctness + coherence on the JAX harness.
+
+1. Quantize the 7 per-layer linears to affine int4 (group 64), report error.
+2. Prove the in-graph dequant matches a host dequant-then-fp32 baseline.
+3. Greedy-decode with int4 weights, confirm coherence vs the fp16 run.
+4. Export the int4 decode_step to StableHLO and confirm the dequant ops are
+   present (bit unpack + convert + scale), separate from dot_general.
+"""
+import json
+import os
+import collections
+import re
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax import export as jexport
+from transformers import AutoTokenizer
+
+import model_jax as M
+import model_int4 as Mi
+import quant as Q
+
+MODEL = "models/Llama-3.2-1B-Instruct"
+MAX_SEQ = 256
+BUCKETS = [32, 64, 128, 256]
+EOS = {128001, 128008, 128009}
+SDS = jax.ShapeDtypeStruct
+ART = "artifacts"
+
+
+def bucket(n):
+    return next(b for b in BUCKETS if n <= b)
+
+
+def main():
+    os.makedirs(ART, exist_ok=True)
+    tok = AutoTokenizer.from_pretrained(MODEL)
+    text = tok.apply_chat_template(
+        [{"role": "user", "content": "Give me three short tips for staying focused while working."}],
+        add_generation_prompt=True, tokenize=False)
+    ids = tok(text, add_special_tokens=False).input_ids
+    n = len(ids)
+    Lp = bucket(n)
+
+    cfg = M.load_config(MODEL)
+    L, nkv, d = cfg.n_layers, cfg.n_kv, cfg.head_dim
+    fp32 = M.load_params(MODEL, cfg)
+
+    # 1. quantize + error
+    qp = Mi.quantize_params(fp32)
+    errs = {}
+    for name in Mi.LINEARS:
+        W = np.asarray(fp32["layers"][0][name], np.float32)
+        p, s, w = (np.asarray(x) for x in qp["layers"][0][name])
+        errs[name] = Q.quant_error(W, p, s, w)
+    print("=== int4 affine quant (group 64), layer-0 relative Frobenius error ===")
+    for k, v in errs.items():
+        print(f"  {k:5s}: {v:.4f}")
+    # packed-memory check on one weight
+    W0 = fp32["layers"][0]["down"]
+    packed0 = np.asarray(qp["layers"][0]["down"][0])
+    print(f"  down weight: fp32 {W0.nbytes/1e6:.1f} MB -> int4 packed {packed0.nbytes/1e6:.1f} MB "
+          f"+ scales (~1/{Q.GROUP} of fp32)")
+
+    # 2. in-graph dequant == host dequant-then-fp32
+    prefill_i4, decode_i4 = Mi.make_int4_fns(cfg, MAX_SEQ)
+    fp_from_q = Mi.dequantize_params(qp)
+    prefill_fp, decode_fp = M.make_fns(cfg, MAX_SEQ)
+    toks = np.zeros(Lp, np.int32); toks[:n] = np.array(ids, np.int32)
+    pos = np.arange(Lp, dtype=np.int32)
+    lo_ig, _, _ = jax.jit(prefill_i4)(qp, jnp.asarray(toks), jnp.asarray(pos), jnp.int32(n))
+    lo_fp, _, _ = jax.jit(prefill_fp)(fp_from_q, jnp.asarray(toks), jnp.asarray(pos), jnp.int32(n))
+    lo_ig, lo_fp = np.asarray(lo_ig), np.asarray(lo_fp)
+    print("\n=== in-graph dequant vs host dequant-then-fp32 (same weights, two paths) ===")
+    print(f"  logit abs diff: max={np.abs(lo_ig-lo_fp).max():.3e} mean={np.abs(lo_ig-lo_fp).mean():.3e}")
+    print(f"  argmax in-graph={int(lo_ig.argmax())} host={int(lo_fp.argmax())} match={int(lo_ig.argmax())==int(lo_fp.argmax())}")
+
+    # 3. greedy coherence with int4, compared to the fp16 run
+    pj, dj = jax.jit(prefill_i4), jax.jit(decode_i4)
+    logits, kc, vc = pj(qp, jnp.asarray(toks), jnp.asarray(pos), jnp.int32(n))
+    nxt = int(np.asarray(logits).argmax()); gen = [nxt]; clen = cur = n
+    for _ in range(47):
+        if nxt in EOS:
+            break
+        logits, kc, vc = dj(qp, jnp.int32(nxt), jnp.int32(cur), jnp.int32(clen), kc, vc)
+        nxt = int(np.asarray(logits).argmax()); gen.append(nxt); clen += 1; cur += 1
+    int4_text = tok.decode(gen)
+    print("\n=== int4 greedy continuation ===")
+    print(repr(int4_text))
+    fp16 = json.load(open(f"{ART}/results.json")) if os.path.exists(f"{ART}/results.json") else None
+    if fp16:
+        a = fp16["jax_ids"]; m = min(len(a), len(gen))
+        agree = sum(int(a[i] == gen[i]) for i in range(m))
+        fd = next((i for i in range(m) if a[i] != gen[i]), None)
+        print(f"int4 vs fp16 greedy: {agree}/{m} tokens agree"
+              + (f", first differ at {fd}" if fd is not None else " (identical)"))
+
+    # 4. export int4 decode_step StableHLO, confirm dequant ops present
+    qp_aval = jax.tree.map(lambda x: SDS(x.shape, x.dtype), qp)
+    exp = jexport.export(jax.jit(decode_i4))(
+        qp_aval, SDS((), jnp.int32), SDS((), jnp.int32), SDS((), jnp.int32),
+        SDS((L, MAX_SEQ, nkv, d), jnp.float32), SDS((L, MAX_SEQ, nkv, d), jnp.float32))
+    mlir = exp.mlir_module()
+    open(f"{ART}/decode_step_int4.stablehlo.mlir", "w").write(mlir)
+    ops = collections.Counter(re.findall(r"\b(?:stablehlo|chlo)\.([a-z_0-9]+)", mlir))
+    print("\n=== int4 decode_step StableHLO: dequant ops present and separate ===")
+    for op in ["shift_right_logical", "and", "convert", "dot_general", "broadcast_in_dim", "reshape", "multiply", "add"]:
+        print(f"  {op:20s}: {ops.get(op, 0)}")
+    print(f"  custom_call present: {'custom_call' in ops}  (dequant is plain ops, not a custom op)")
+    print(f"  uint32 inputs (packed weights) in signature: {'ui32' in mlir or 'i32' in mlir.split('->')[0]}")
+    json.dump({"quant_err_layer0": errs, "int4_text": int4_text, "int4_ids": gen},
+              open(f"{ART}/results_int4.json", "w"), indent=2)
+    print(f"\nwrote {ART}/decode_step_int4.stablehlo.mlir + results_int4.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
int4 dequant-in-graph for the OpenXLA spike, characterized on the JAX harness (#449 Phase 2a).

Affine int4 (group 64, packed 8 per uint32) on the 7 per-layer linears; the unpack, convert, and scale run in-graph before each `dot_general`, while embedding and norms stay fp32.

Findings:
- In-graph dequant matches a host dequant-then-fp32 baseline (max logit diff 7e-5); int4 greedy stays coherent; the emitted StableHLO carries the dequant as standard ops with no `custom_call`.
- Fuse question: none of XLA-CPU, IREE-CPU, or IREE-CUDA fuse the dequant into the matmul. XLA wraps both in one kLoop fusion but rebuilds the full fp32 weight inside it; IREE forms a separate dequant dispatch that materializes the fp32 weight on both CPU and CUDA. So int4 here is an 8x weight-storage win, not a matmul win; a real int4 matmul needs a `custom_call` to an int4 GEMM or a quantized-matmul fusion.
- CUDA is available on this box (GB10, sm_121). The int4 graphs compile to CUDA via IREE and run on the GB10 token-exact (48/48) with the CPU int4 run. Prefill needed a pad and stack cache write (`dynamic_update_slice`) to lower to the CUDA backend. No perf claim (the harness re-uploads weights each step); real GPU perf is Phase 2b.

Standalone under `spike/openxla/`, no effect on mlxcel crates or builds. Findings in `spike/openxla/FINDINGS_phase2a.md`.

Refs #449.