### PR TITLE
feat: Rust-native StableHLO emitter spike for Llama-3.2-1B (#451)

### DIFF
--- a/spike/rust-emitter/.gitignore
+++ b/spike/rust-emitter/.gitignore
@@ -1,0 +1,7 @@
+/target
+/out
+*.mlir
+*.vmfb
+__pycache__/
+*.pyc
+/python/_scratch

--- a/spike/rust-emitter/Cargo.toml
+++ b/spike/rust-emitter/Cargo.toml
@@ -1,0 +1,16 @@
+# Standalone spike. The empty [workspace] table makes this its own workspace
+# root so it never joins the mlxcel build graph (issue #451 hard constraint).
+[workspace]
+
+[package]
+name = "rust-emitter"
+version = "0.1.0"
+edition = "2021"
+description = "Rust-native StableHLO text emitter for Llama-3.2-1B (spike #451)"
+
+[[bin]]
+name = "emit"
+path = "src/main.rs"
+
+[profile.release]
+opt-level = 2

--- a/spike/rust-emitter/FINDINGS.md
+++ b/spike/rust-emitter/FINDINGS.md
@@ -1,0 +1,220 @@
+# Rust-native StableHLO emitter spike: findings (#451)
+
+Issue #451, ADR 0004. This evaluates a Rust-native StableHLO emitter as the
+compiler-family model-authoring path, parallel to the JAX-reference frontend that
+#449 validated. Same model (Llama-3.2-1B-Instruct), same bar (token-exact greedy
+vs HF temp-0), CPU target. Standalone under `spike/rust-emitter/`, touches no
+mlxcel crate and no file under `spike/openxla/`.
+
+## Verdict
+
+A Rust program that emits StableHLO **text** authors the Llama-3.2-1B
+`decode_step` and greedy-decodes **token-exact (48/48)** against the HF reference
+in `spike/openxla/artifacts/results.json`. The toolchain needed is only `cargo`
+plus the `iree-compile` / IREE runtime already required to run any StableHLO. No
+JAX, no `melior`, no MLIR/LLVM C++ build. The text-emission route is the
+lowest-weight authoring toolchain available on this aarch64 box and it reaches
+the same result #449 got from `jax.export`.
+
+The two authoring paths are complementary, and the recommendation below is to use
+both: the JAX reference as the executable oracle per architecture, and the Rust
+emitter as the production authoring path that owns the graph.
+
+## Toolchain choice: text emission, not melior
+
+The plan offered text emission first and `melior` (MLIR C++ bindings) only as a
+fallback, with the availability of the StableHLO dialect in the bindings on
+aarch64 flagged as itself a P0 risk. Text emission worked on the first
+end-to-end attempt, so `melior` was never needed and that risk never had to be
+taken. This matters: text emission means the authoring toolchain is a
+dependency-free Rust crate (the `Cargo.toml` pulls **zero** external crates) plus
+the IREE CLI. There is no native MLIR/LLVM build, no C++ toolchain, and no
+platform-specific dialect-registration question. The emitted `.mlir` is the same
+artifact `iree-compile` already consumes from the JAX path, so it slots into the
+existing compile/run pipeline unchanged.
+
+## P0: toolchain round-trip (the gate)
+
+A Rust-emitted single-op module
+
+```mlir
+func.func public @main(%a: tensor<4x8xf32>, %b: tensor<8x3xf32>) -> tensor<4x3xf32> {
+  %0 = stablehlo.dot_general %a, %b, contracting_dims = [1] x [0] : ... -> tensor<4x3xf32>
+  return %0 : tensor<4x3xf32>
+}
+```
+
+compiles with `iree-compile --iree-input-type=stablehlo
+--iree-hal-target-backends=llvm-cpu` and runs through the IREE runtime with an
+exact match (max abs diff 0.0) against `a @ b` in numpy. A second probe module
+exercised the op spellings not in the matmul, in particular
+`dynamic_update_slice` (which #449's JAX lowering never used; it emitted
+`scatter` for the KV write), a batched `dot_general`, `dynamic_slice`, static
+`slice`, and `reduce`. All parsed and compiled. The route stands up.
+
+## P1: full decode_step, token-exact
+
+`src/model.rs` emits the complete `decode_step` graph: embedding gather, decode
+key mask, 16 transformer layers (RMSNorm, GQA attention with llama3 RoPE, KV
+write/read, softmax, SwiGLU MLP), final norm, and the tied LM head. The function
+signature matches the JAX export exactly (146 weight tensors as individual inputs
+in the same alphabetical-within-layer order, each carrying its pytree-path
+`loc`, then `token`, `pos`, `cache_len`, `kcache`, `vcache`), so the same weight
+glue maps checkpoints to args.
+
+`python/run_decode.py` loads the real bf16 weights (upcast fp32), feeds them as
+graph inputs, and drives greedy decode. The prompt is streamed through
+`decode_step` (one token at a time, `cache_len = i`), which is identical to a
+batched prefill because the decode mask is `iota <= cache_len`. Result:
+
+```
+Here are three short tips for staying focused while working:
+
+1. **Set clear goals and priorities**: Before starting your work, define what
+needs to be accomplished and prioritize your tasks. This will help you stay
+focused on what's important and avoid
+
+token match vs HF temp-0: 48/48  (EXACT)
+```
+
+Identical to the #449 JAX result. Getting this required the exact numerics the
+plan called out: RoPE half-split (not interleaved), llama3 `inv_freq` scaling,
+additive mask with `-1e30`, GQA head `h` reading kv head `h/4`, attention scale
+`head_dim^-0.5`, fp32 compute over bf16 weights. The cos/sin tables are computed
+in Rust f64 then cast f32 (matching the JAX `np.cos(emb).astype(f32)`), baked as
+hex `dense` constants, and `dynamic_slice`d at `pos`; keeping the trig out of the
+graph removes any dependence on the runtime's transcendental precision.
+
+`prefill` (bucketed) was not separately emitted. Streaming the prompt through
+decode validates the same math; a standalone prefill graph is straightforward in
+the same builder and needs one new op (`stablehlo.gather` for the multi-token
+embedding lookup). It was out of scope once decode landed token-exact.
+
+### Emitted graph vs the JAX graph
+
+| | Rust emitter (decode) | JAX export (decode, #449) |
+|---|---|---|
+| distinct StableHLO op kinds | 20 | 23 |
+| `dot_general` (the matmuls) | 145 | 145 |
+| `custom_call` | 0 | 0 |
+| `f64` | 0 | 0 |
+| KV write op | `dynamic_update_slice` (32) | `scatter` (64) |
+| weight orientation | `dot_general` contracts stored `[out,in]` directly | `transpose` then `dot_general` |
+| total stablehlo ops | ~1376 | ~2044 |
+
+Same matmul count, no custom ops, no f64. The emitter's graph is smaller because
+it chooses leaner ops directly: `dynamic_update_slice` instead of `scatter`, and
+contracting the stored `[out,in]` weight in `dot_general` instead of inserting a
+`transpose` first. This is the graph-control point made concrete: the author
+picks each op, rather than accepting a framework's lowering.
+
+## Authoring-path comparison
+
+### Per-architecture authoring effort (lines, complexity)
+
+| | lines | role |
+|---|---|---|
+| JAX path (`spike/openxla/model_jax.py`) | ~230 | config + weight load + RoPE + **both** prefill and decode for one architecture |
+| Rust `src/builder.rs` | 419 | reusable StableHLO builder, architecture-independent, write once |
+| Rust `src/model.rs` | 324 | the decode graph for one architecture |
+| Rust `src/config.rs` + `src/rope.rs` | 113 | config + RoPE tables |
+
+The JAX file authors both graphs in ~230 readable, numpy-shaped lines. The Rust
+per-architecture model code is ~324 lines for decode alone (a prefill variant
+would push the architecture-specific total to roughly 550 to 650), on top of a
+419-line builder that is written once and amortized across every future
+architecture. So per architecture the Rust authoring code is roughly 1.5x to
+2.5x the JAX line count, and the math is spelled as explicit ops
+(`reduce` + `divide` for a mean, `reduce_max` + `subtract` + `exponential` +
+`reduce_sum` + `divide` for softmax, slice/negate/concatenate for RoPE
+half-split) rather than as `jnp.mean` / `jax.nn.softmax` / array slicing.
+
+### Maintainability and debuggability
+
+JAX authoring reads like the math and leans on the framework for shape
+inference, op selection, and lowering. A new architecture is a new ~200-line
+file. The cost is a standing JAX/jaxlib dependency and JAX expertise, and the
+emitted StableHLO is generated and opaque (you debug Python, not the graph).
+
+The Rust emitter is more verbose and hand-spells numerics, but it lives in the
+same language as the rest of mlxcel, debugs with Rust tooling, and keeps no
+Python/JAX runtime in the authoring path. The builder does result-type inference,
+so a wrong rank or shape is caught at emit time (the type string goes
+inconsistent and `iree-compile` rejects it) rather than silently. The honest
+caveat from building this: the path to zero numeric bugs ran through
+cross-checking every op spelling and shape against the JAX-emitted `.mlir` and
+validating token-exact. Authoring a brand-new architecture blind, without a
+reference graph to diff against, would be materially harder in the emitter than
+in JAX, because a wrong contracting dim or broadcast is a silent numeric error
+you chase at the IR level.
+
+### Graph control for int4 and custom_call
+
+This is where the emitter is clearly ahead, and it is the axis ADR 0004's Phase 2
+(4-bit) cares about most.
+
+- **int4 dequant-in-graph:** every matmul flows through one helper,
+  `Builder::linear`. Inserting an int4 path is a local edit there: emit
+  unpack + `convert` + scale + `dot_general`, and all 145 matmuls get it
+  uniformly. The author controls whether the dequant sits as separate ops (for
+  the compiler to fuse) or is shaped to encourage fusion. #449 flagged
+  "does XLA/IREE fuse dequant into the matmul" as the open Phase 2 question; the
+  emitter lets you author both shapes and measure, without fighting a framework
+  lowering.
+- **custom_call:** routing a matmul to a vendor int4 GEMM is just emitting a
+  different op string (`stablehlo.custom_call @target`) from the same helper. The
+  emitter already owns op selection, so a custom_call is additive and local. From
+  JAX, a custom_call needs primitive registration or `lax` plumbing, which is
+  more friction than emitting the op text.
+
+### Toolchain and build weight
+
+- **JAX path:** needs `jax` + `jaxlib` (hundreds of MB; on this aarch64 +
+  Blackwell box only the CPU fallback exists, no CUDA jaxlib on PyPI) plus the
+  `jax.export` serialization deps, then `iree-compile` to reach a runnable
+  artifact.
+- **Rust emitter:** needs `cargo` (already in the toolchain) and `iree-compile`
+  / IREE runtime (already required either way). The emitter itself has zero
+  external crate dependencies and no native build step. `melior` was not needed.
+  This is the lightest authoring toolchain of the options and the one most
+  aligned with mlxcel being a Rust project.
+
+## Recommendation for ADR 0004
+
+Adopt the Rust-native StableHLO **text** emitter as the production model-authoring
+path for the compiler family, and keep the JAX reference as the per-architecture
+**oracle**, not as the shipping authoring frontend.
+
+Rationale:
+
+1. **Graph control is the deciding axis for where this is going.** The next
+   milestone is 4-bit. Inserting int4 dequant nodes and routing to a vendor int4
+   `custom_call` are local, uniform edits in the emitter (one builder helper),
+   and the emitter lets you author the exact dequant shape you want to measure
+   for fusion. That control is the thing the JAX lowering does not give directly.
+2. **Toolchain lightness and language fit.** Authoring needs only `cargo` and the
+   IREE CLI that the runtime side needs anyway. No JAX/jaxlib, no `melior`, no
+   MLIR/LLVM C++ build, no Python in the authoring path. The emitter is a small
+   dependency-free Rust crate that lives next to the rest of mlxcel.
+3. **It meets the bar.** Token-exact 48/48, same as the JAX path, with a smaller,
+   custom-call-free, f64-free graph.
+
+Use the JAX reference the way this spike used it: as the executable specification
+and the token oracle when bringing up each new architecture. Author in JAX first
+to derive and verify the numerics fast in math-shaped code, then author the
+production graph in the Rust emitter and diff it against the JAX-emitted `.mlir`
+and the JAX/HF tokens. That keeps JAX's fast, readable correctness loop while
+shipping the emitter's control and toolchain-lightness. The per-architecture line
+cost (roughly 1.5x to 2.5x JAX, plus hand-spelled numerics) is the price, and the
+oracle workflow is what keeps that price from becoming a correctness risk.
+
+### Open items (not in this spike)
+
+- **prefill graph** in the emitter (needs `stablehlo.gather`); validated here by
+  streaming the prompt through decode.
+- **int4 path:** author dequant-in-graph and a `custom_call` variant from
+  `Builder::linear`, then measure fusion on a GPU-capable host (this box is CPU).
+- **GPU backend:** same `iree-compile` route with a CUDA target; not exercised
+  here (CPU only, per scope).
+- **second architecture:** confirm how much of `builder.rs` is reused versus
+  per-arch `model.rs` when the norm/activation/attention shape differs.

--- a/spike/rust-emitter/README.md
+++ b/spike/rust-emitter/README.md
@@ -1,0 +1,66 @@
+# Rust-native StableHLO emitter spike (#451)
+
+A standalone evaluation of authoring the compiler-family model graph from
+**Rust** instead of from a JAX reference. The Rust program emits StableHLO
+**text**, the existing `iree-compile` lowers it to a CPU vmfb, and the IREE
+runtime executes it. The target is the same Llama-3.2-1B-Instruct forward that
+issue #449 validated through `jax.export`, verified to the same bar:
+token-exact greedy decode against the HF transformers temp-0 reference.
+
+This is a parallel alternative to the #449 JAX-reference path, not a replacement
+of it. CPU target only. It builds and runs with **only** `cargo` plus the
+`iree-compile` / IREE runtime already present in `spike/openxla/.venv`. No JAX,
+no `melior`, no MLIR/LLVM C++ build.
+
+## Result
+
+- **P0 (toolchain gate):** Rust-emitted single `dot_general` compiles and runs
+  through IREE, exact match vs numpy. The text-emission route stands up.
+- **P1 (the real bar):** the full Rust-emitted `decode_step` greedy-decodes
+  **token-exact, 48/48**, against the HF reference in
+  `spike/openxla/artifacts/results.json`. Output text is identical.
+
+See `FINDINGS.md` for the toolchain choice, the authoring-path comparison
+(JAX-reference vs Rust-emitter), and the recommendation for ADR 0004.
+
+## Layout
+
+| path | what |
+|---|---|
+| `src/builder.rs` | SSA/type-tracking StableHLO text builder (one method per op). Architecture-independent, reused across graphs. |
+| `src/config.rs` | Llama-3.2-1B config constants. |
+| `src/rope.rs` | llama3 `inv_freq` and cos/sin tables (f64, then f32), byte-for-byte with the JAX reference. |
+| `src/model.rs` | Emits the full `decode_step` graph (head, 16 layers, tied head). |
+| `src/main.rs` | CLI: `emit p0 \| probe \| decode [out.mlir]`. |
+| `python/run_decode.py` | Loads real bf16 weights (upcast fp32), drives greedy decode through the compiled module, compares to the HF tokens. |
+| `validate.sh` | End-to-end driver: build, emit, compile, check. |
+
+## Run
+
+```bash
+# everything (P0 round-trip + P1 token-exact decode)
+./validate.sh
+
+# just the toolchain gate
+./validate.sh p0
+
+# emit only, inspect the StableHLO
+cargo run --release -- decode out/decode.mlir
+```
+
+`validate.sh` reuses `spike/openxla/.venv` for `iree-compile`, the IREE runtime,
+`torch`, `transformers`, and `safetensors`, and reads the weights from
+`spike/openxla/models/Llama-3.2-1B-Instruct`. Nothing here builds or imports any
+mlxcel crate (the `Cargo.toml` declares an empty `[workspace]` so it is its own
+workspace root).
+
+## How decode_step alone covers the prompt
+
+Only `decode_step` is emitted. The prompt is streamed through it one token at a
+time (`cache_len = i` for prompt token `i`). Because decode masks keys with
+`iota <= cache_len`, streaming the prompt is mathematically identical to a
+batched prefill: the same KV cache and the same position-`n-1` logits. The
+48/48 token match confirms the prompt was processed correctly. A separate
+bucketed `prefill` graph is straightforward additional work in the same builder
+(the one new op it needs is `stablehlo.gather` for the multi-token embedding
+lookup); it adds no new toolchain risk and was left out of this spike.

--- a/spike/rust-emitter/python/run_decode.py
+++ b/spike/rust-emitter/python/run_decode.py
@@ -1,0 +1,155 @@
+"""Validate the Rust-emitted decode_step StableHLO end to end.
+
+Loads the real bf16 Llama-3.2-1B weights (upcast fp32), feeds them as graph
+inputs, and drives a greedy loop entirely through decode_step: the prompt is
+streamed one token at a time (cache_len = i for prompt token i), then generation
+continues. Because decode masks keys with `iota <= cache_len`, streaming the
+prompt through decode is mathematically identical to a batched prefill, so this
+fully exercises decode_step and reaches the same tokens.
+
+Token target: spike/openxla/artifacts/results.json `hf_ids` (HF temp-0, 48 tok).
+
+Run via validate.sh, or directly:
+  .venv/bin/python run_decode.py --mlir decode.mlir
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+import numpy as np
+from safetensors import safe_open
+from transformers import AutoTokenizer
+import iree.runtime as rt
+
+REF = "/home/inureyes/Development/mlxcel/spike/openxla"
+MODEL = f"{REF}/models/Llama-3.2-1B-Instruct"
+IREE_COMPILE = f"{REF}/.venv/bin/iree-compile"
+RESULTS = f"{REF}/artifacts/results.json"
+
+N_LAYERS, MAX_SEQ, N_KV, HEAD_DIM = 16, 256, 8, 64
+EOS = {128001, 128008, 128009}
+PROMPT = "Give me three short tips for staying focused while working."
+MAX_NEW = 48
+
+
+def load_weights():
+    """Return the 146 weight arrays in the emitter's exact arg order:
+    embed, final_norm, then per layer [down, gate, in_ln, post_ln, up, wk, wo,
+    wq, wv]. Weights stay [out, in] (bf16 -> fp32), tied embedding."""
+    raw = {}
+    with safe_open(f"{MODEL}/model.safetensors", framework="pt") as f:
+        for k in f.keys():
+            raw[k] = f.get_tensor(k).float().numpy().astype(np.float32)
+    args = [raw["model.embed_tokens.weight"], raw["model.norm.weight"]]
+    for i in range(N_LAYERS):
+        p = f"model.layers.{i}."
+        args += [
+            raw[p + "mlp.down_proj.weight"],
+            raw[p + "mlp.gate_proj.weight"],
+            raw[p + "input_layernorm.weight"],
+            raw[p + "post_attention_layernorm.weight"],
+            raw[p + "mlp.up_proj.weight"],
+            raw[p + "self_attn.k_proj.weight"],
+            raw[p + "self_attn.o_proj.weight"],
+            raw[p + "self_attn.q_proj.weight"],
+            raw[p + "self_attn.v_proj.weight"],
+        ]
+    return args
+
+
+def compile_module(mlir_path, vmfb_path):
+    subprocess.run(
+        [IREE_COMPILE, "--iree-input-type=stablehlo",
+         "--iree-hal-target-backends=llvm-cpu", mlir_path, "-o", vmfb_path],
+        check=True,
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mlir", required=True)
+    ap.add_argument("--vmfb", default=None)
+    args = ap.parse_args()
+    vmfb = args.vmfb or (os.path.splitext(args.mlir)[0] + ".vmfb")
+
+    if not args.vmfb or not os.path.exists(vmfb):
+        print(f"compiling {args.mlir} -> {vmfb}")
+        compile_module(args.mlir, vmfb)
+
+    tok = AutoTokenizer.from_pretrained(MODEL)
+    msgs = [{"role": "user", "content": PROMPT}]
+    text = tok.apply_chat_template(msgs, add_generation_prompt=True, tokenize=False)
+    prompt_ids = tok(text, add_special_tokens=False).input_ids
+    n = len(prompt_ids)
+    print(f"prompt tokens = {n}")
+
+    t0 = time.time()
+    weights = load_weights()
+    print(f"loaded {len(weights)} weight tensors in {time.time()-t0:.1f}s")
+
+    cfg = rt.Config("local-task")
+    ctx = rt.SystemContext(config=cfg)
+    with open(vmfb, "rb") as f:
+        vm = rt.VmModule.from_flatbuffer(ctx.instance, f.read())
+    ctx.add_vm_module(vm)
+    main_fn = getattr(ctx.modules, vm.name).main
+
+    # Persist weights as device arrays once (the embedding alone is ~1 GB fp32;
+    # re-importing it every step dominates otherwise). KV cache also stays on
+    # device and is threaded back each step without a host round-trip.
+    device = cfg.device
+    dev_weights = [rt.asdevicearray(device, w) for w in weights]
+    kcache = rt.asdevicearray(
+        device, np.zeros((N_LAYERS, MAX_SEQ, N_KV, HEAD_DIM), np.float32))
+    vcache = rt.asdevicearray(
+        device, np.zeros((N_LAYERS, MAX_SEQ, N_KV, HEAD_DIM), np.float32))
+
+    def step(token, pos, clen, kc, vc):
+        outs = main_fn(*dev_weights,
+                       np.array(token, np.int32), np.array(pos, np.int32),
+                       np.array(clen, np.int32), kc, vc)
+        return outs[0], outs[1], outs[2]
+
+    # stream the prompt through decode (cache_len = i for prompt token i)
+    t0 = time.time()
+    logits = None
+    for i in range(n):
+        logits, kcache, vcache = step(prompt_ids[i], i, i, kcache, vcache)
+    prompt_ms = (time.time() - t0) * 1e3
+
+    # greedy generation
+    gen = []
+    next_tok = int(np.asarray(logits).argmax())
+    gen.append(next_tok)
+    clen = n
+    step_ms = []
+    for _ in range(MAX_NEW - 1):
+        if next_tok in EOS:
+            break
+        t0 = time.time()
+        logits, kcache, vcache = step(next_tok, clen, clen, kcache, vcache)
+        step_ms.append((time.time() - t0) * 1e3)
+        next_tok = int(np.asarray(logits).argmax())
+        gen.append(next_tok)
+        clen += 1
+
+    hf_ids = json.load(open(RESULTS))["hf_ids"]
+    m = min(len(gen), len(hf_ids))
+    matches = sum(int(gen[i] == hf_ids[i]) for i in range(m))
+    first_div = next((i for i in range(m) if gen[i] != hf_ids[i]), None)
+
+    print("\n=== Rust-emitted decode_step greedy continuation ===")
+    print(repr(tok.decode(gen)))
+    print(f"\nprompt stream: {prompt_ms:.0f} ms ({n} tok) | "
+          f"decode steady: {np.mean(step_ms[1:]) if len(step_ms) > 1 else float('nan'):.0f} ms/tok")
+    print(f"token match vs HF temp-0: {matches}/{m}"
+          + (f"  first divergence at {first_div}" if first_div is not None else "  (EXACT)"))
+    print("RESULT:", "TOKEN-EXACT PASS" if (matches == m == len(hf_ids)) else "MISMATCH")
+    sys.exit(0 if matches == m == len(hf_ids) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/spike/rust-emitter/src/builder.rs
+++ b/spike/rust-emitter/src/builder.rs
@@ -1,0 +1,421 @@
+//! Minimal StableHLO text builder.
+//!
+//! Tracks SSA value names and their tensor types, and exposes one method per
+//! StableHLO op we need. Each method emits one textual line into the function
+//! body and returns a typed `Val` handle, so the model code reads like ordinary
+//! tensor algebra while the builder owns name generation and type bookkeeping.
+//!
+//! The op spellings mirror exactly what `jax.export` emitted in
+//! `spike/openxla/artifacts/decode_step.stablehlo.mlir`, which `iree-compile`
+//! already parses as text, so every form here is known-good for that toolchain.
+
+use std::fmt::Write as _;
+
+/// Tensor type: shape plus element type ("f32" | "i32" | "i1").
+#[derive(Clone, Debug)]
+pub struct Ty {
+    pub shape: Vec<usize>,
+    pub elt: &'static str,
+}
+
+impl Ty {
+    pub fn new(shape: Vec<usize>, elt: &'static str) -> Self {
+        Ty { shape, elt }
+    }
+    pub fn f32(shape: Vec<usize>) -> Self {
+        Ty::new(shape, "f32")
+    }
+    pub fn scalar(elt: &'static str) -> Self {
+        Ty::new(vec![], elt)
+    }
+    pub fn render(&self) -> String {
+        if self.shape.is_empty() {
+            format!("tensor<{}>", self.elt)
+        } else {
+            let dims: Vec<String> = self.shape.iter().map(|d| d.to_string()).collect();
+            format!("tensor<{}x{}>", dims.join("x"), self.elt)
+        }
+    }
+}
+
+/// A typed SSA value handle (e.g. `%42 : tensor<2048xf32>`).
+#[derive(Clone, Debug)]
+pub struct Val {
+    pub name: String,
+    pub ty: Ty,
+}
+
+pub struct Builder {
+    body: String,
+    next: usize,
+}
+
+fn dims_list(d: &[usize]) -> String {
+    let parts: Vec<String> = d.iter().map(|x| x.to_string()).collect();
+    format!("[{}]", parts.join(", "))
+}
+
+/// f32 -> MLIR scalar hex literal (big-endian bit pattern), exact and unambiguous.
+pub fn f32_hex(x: f32) -> String {
+    format!("0x{:08X}", x.to_bits())
+}
+
+/// f32 slice -> MLIR dense blob hex (little-endian raw bytes), matching JAX output.
+pub fn f32_blob(data: &[f32]) -> String {
+    let mut s = String::with_capacity(data.len() * 8);
+    for &x in data {
+        for b in x.to_le_bytes() {
+            let _ = write!(s, "{:02X}", b);
+        }
+    }
+    s
+}
+
+impl Builder {
+    pub fn new() -> Self {
+        Builder {
+            body: String::new(),
+            next: 0,
+        }
+    }
+
+    pub fn body(&self) -> &str {
+        &self.body
+    }
+
+    fn fresh(&mut self) -> String {
+        let n = self.next;
+        self.next += 1;
+        format!("%{}", n)
+    }
+
+    fn line(&mut self, s: String) {
+        self.body.push_str("    ");
+        self.body.push_str(&s);
+        self.body.push('\n');
+    }
+
+    /// Construct a handle to an existing func argument (not emitted).
+    pub fn arg(idx: usize, ty: Ty) -> Val {
+        Val {
+            name: format!("%arg{}", idx),
+            ty,
+        }
+    }
+
+    // --- constants ---------------------------------------------------------
+
+    pub fn const_f32(&mut self, x: f32) -> Val {
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.constant dense<{}> : tensor<f32>",
+            r,
+            f32_hex(x)
+        ));
+        Val {
+            name: r,
+            ty: Ty::scalar("f32"),
+        }
+    }
+
+    pub fn const_i32(&mut self, v: i32) -> Val {
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.constant dense<{}> : tensor<i32>",
+            r, v
+        ));
+        Val {
+            name: r,
+            ty: Ty::scalar("i32"),
+        }
+    }
+
+    /// Dense f32 constant tensor from raw data (row-major), emitted as hex blob.
+    pub fn const_tensor_f32(&mut self, data: &[f32], shape: Vec<usize>) -> Val {
+        let ty = Ty::f32(shape);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.constant dense<\"0x{}\"> : {}",
+            r,
+            f32_blob(data),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    // --- structural --------------------------------------------------------
+
+    pub fn iota(&mut self, n: usize) -> Val {
+        let ty = Ty::new(vec![n], "i32");
+        let r = self.fresh();
+        self.line(format!("{} = stablehlo.iota dim = 0 : {}", r, ty.render()));
+        Val { name: r, ty }
+    }
+
+    pub fn reshape(&mut self, x: &Val, shape: Vec<usize>) -> Val {
+        let ty = Ty::new(shape, x.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.reshape {} : ({}) -> {}",
+            r,
+            x.name,
+            x.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn broadcast(&mut self, x: &Val, dims: &[usize], out_shape: Vec<usize>) -> Val {
+        let ty = Ty::new(out_shape, x.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.broadcast_in_dim {}, dims = {} : ({}) -> {}",
+            r,
+            x.name,
+            dims_list(dims),
+            x.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    /// Unused by decode today; kept for the int4 dequant path (int -> f32).
+    #[allow(dead_code)]
+    pub fn convert(&mut self, x: &Val, elt: &'static str) -> Val {
+        let ty = Ty::new(x.ty.shape.clone(), elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.convert {} : ({}) -> {}",
+            r,
+            x.name,
+            x.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    /// Static slice. `ranges` is (start, limit) per dim, stride 1.
+    pub fn slice(&mut self, x: &Val, ranges: &[(usize, usize)]) -> Val {
+        let shape: Vec<usize> = ranges.iter().map(|(s, l)| l - s).collect();
+        let ty = Ty::new(shape, x.ty.elt);
+        let parts: Vec<String> = ranges.iter().map(|(s, l)| format!("{}:{}", s, l)).collect();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.slice {} [{}] : ({}) -> {}",
+            r,
+            x.name,
+            parts.join(", "),
+            x.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn concatenate(&mut self, a: &Val, b: &Val, dim: usize) -> Val {
+        let mut shape = a.ty.shape.clone();
+        shape[dim] = a.ty.shape[dim] + b.ty.shape[dim];
+        let ty = Ty::new(shape, a.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.concatenate {}, {}, dim = {} : ({}, {}) -> {}",
+            r,
+            a.name,
+            b.name,
+            dim,
+            a.ty.render(),
+            b.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn dynamic_slice(&mut self, x: &Val, starts: &[&Val], sizes: Vec<usize>) -> Val {
+        let ty = Ty::new(sizes.clone(), x.ty.elt);
+        let names: Vec<String> = starts.iter().map(|v| v.name.clone()).collect();
+        let idx_tys: Vec<String> = starts.iter().map(|v| v.ty.render()).collect();
+        let sz: Vec<String> = sizes.iter().map(|s| s.to_string()).collect();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.dynamic_slice {}, {}, sizes = [{}] : ({}, {}) -> {}",
+            r,
+            x.name,
+            names.join(", "),
+            sz.join(", "),
+            x.ty.render(),
+            idx_tys.join(", "),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn dynamic_update_slice(&mut self, operand: &Val, update: &Val, starts: &[&Val]) -> Val {
+        let ty = operand.ty.clone();
+        let names: Vec<String> = starts.iter().map(|v| v.name.clone()).collect();
+        let idx_tys: Vec<String> = starts.iter().map(|v| v.ty.render()).collect();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.dynamic_update_slice {}, {}, {} : ({}, {}, {}) -> {}",
+            r,
+            operand.name,
+            update.name,
+            names.join(", "),
+            operand.ty.render(),
+            update.ty.render(),
+            idx_tys.join(", "),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    // --- elementwise -------------------------------------------------------
+
+    fn binary(&mut self, op: &str, a: &Val, b: &Val) -> Val {
+        let ty = a.ty.clone();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.{} {}, {} : {}",
+            r,
+            op,
+            a.name,
+            b.name,
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn add(&mut self, a: &Val, b: &Val) -> Val {
+        self.binary("add", a, b)
+    }
+    pub fn subtract(&mut self, a: &Val, b: &Val) -> Val {
+        self.binary("subtract", a, b)
+    }
+    pub fn multiply(&mut self, a: &Val, b: &Val) -> Val {
+        self.binary("multiply", a, b)
+    }
+    pub fn divide(&mut self, a: &Val, b: &Val) -> Val {
+        self.binary("divide", a, b)
+    }
+
+    fn unary(&mut self, op: &str, a: &Val) -> Val {
+        let ty = a.ty.clone();
+        let r = self.fresh();
+        self.line(format!("{} = stablehlo.{} {} : {}", r, op, a.name, ty.render()));
+        Val { name: r, ty }
+    }
+
+    pub fn negate(&mut self, a: &Val) -> Val {
+        self.unary("negate", a)
+    }
+    pub fn exponential(&mut self, a: &Val) -> Val {
+        self.unary("exponential", a)
+    }
+    pub fn rsqrt(&mut self, a: &Val) -> Val {
+        self.unary("rsqrt", a)
+    }
+
+    /// `compare DIR, a, b, SIGNED|FLOAT` -> i1 tensor of the same shape.
+    pub fn compare(&mut self, dir: &str, a: &Val, b: &Val, kind: &str) -> Val {
+        let ty = Ty::new(a.ty.shape.clone(), "i1");
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.compare {}, {}, {}, {} : ({}, {}) -> {}",
+            r,
+            dir,
+            a.name,
+            b.name,
+            kind,
+            a.ty.render(),
+            b.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn select(&mut self, pred: &Val, a: &Val, b: &Val) -> Val {
+        let ty = a.ty.clone();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.select {}, {}, {} : {}, {}",
+            r,
+            pred.name,
+            a.name,
+            b.name,
+            pred.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    // --- reductions --------------------------------------------------------
+
+    fn reduce(&mut self, applies: &str, x: &Val, dim: usize, init: &Val) -> Val {
+        let shape: Vec<usize> = x
+            .ty
+            .shape
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != dim)
+            .map(|(_, d)| *d)
+            .collect();
+        let ty = Ty::new(shape, x.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.reduce({} init: {}) applies stablehlo.{} across dimensions = [{}] : ({}, {}) -> {}",
+            r, x.name, init.name, applies, dim, x.ty.render(), init.ty.render(), ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn reduce_add(&mut self, x: &Val, dim: usize, init: &Val) -> Val {
+        self.reduce("add", x, dim, init)
+    }
+    pub fn reduce_max(&mut self, x: &Val, dim: usize, init: &Val) -> Val {
+        self.reduce("maximum", x, dim, init)
+    }
+
+    // --- dot_general -------------------------------------------------------
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn dot_general(
+        &mut self,
+        lhs: &Val,
+        rhs: &Val,
+        lhs_batch: &[usize],
+        rhs_batch: &[usize],
+        lhs_contract: &[usize],
+        rhs_contract: &[usize],
+        out_shape: Vec<usize>,
+    ) -> Val {
+        let ty = Ty::new(out_shape, "f32");
+        let r = self.fresh();
+        let batch = if lhs_batch.is_empty() && rhs_batch.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "batching_dims = {} x {}, ",
+                dims_list(lhs_batch),
+                dims_list(rhs_batch)
+            )
+        };
+        self.line(format!(
+            "{} = stablehlo.dot_general {}, {}, {}contracting_dims = {} x {} : ({}, {}) -> {}",
+            r,
+            lhs.name,
+            rhs.name,
+            batch,
+            dims_list(lhs_contract),
+            dims_list(rhs_contract),
+            lhs.ty.render(),
+            rhs.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    /// Convenience: y = x @ W^T for x:[K], W:[N,K] (weights stored [out,in]).
+    /// Contracts x dim 0 with W dim 1, yielding [N]. No transpose needed.
+    pub fn linear(&mut self, x: &Val, w: &Val) -> Val {
+        let n = w.ty.shape[0];
+        self.dot_general(x, w, &[], &[], &[0], &[1], vec![n])
+    }
+}

--- a/spike/rust-emitter/src/config.rs
+++ b/spike/rust-emitter/src/config.rs
@@ -1,0 +1,49 @@
+//! Llama-3.2-1B-Instruct config (matches spike/openxla/model_jax.py Config).
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub hidden: usize,
+    pub inter: usize,
+    pub n_layers: usize,
+    pub n_q: usize,
+    pub n_kv: usize,
+    pub head_dim: usize,
+    pub eps: f32,
+    pub rope_theta: f64,
+    pub vocab: usize,
+    // llama3 rope scaling
+    pub factor: f64,
+    pub low_freq_factor: f64,
+    pub high_freq_factor: f64,
+    pub orig_ctx: usize,
+}
+
+impl Config {
+    /// Hard-coded Llama-3.2-1B-Instruct values (config.json of the spike model).
+    pub fn llama_3_2_1b() -> Self {
+        Config {
+            hidden: 2048,
+            inter: 8192,
+            n_layers: 16,
+            n_q: 32,
+            n_kv: 8,
+            head_dim: 64,
+            eps: 1e-5,
+            rope_theta: 500000.0,
+            vocab: 128256,
+            factor: 32.0,
+            low_freq_factor: 1.0,
+            high_freq_factor: 4.0,
+            orig_ctx: 8192,
+        }
+    }
+
+    pub fn group(&self) -> usize {
+        self.n_q / self.n_kv
+    }
+
+    /// Attention scale head_dim^-0.5.
+    pub fn scale(&self) -> f32 {
+        (self.head_dim as f32).powf(-0.5)
+    }
+}

--- a/spike/rust-emitter/src/main.rs
+++ b/spike/rust-emitter/src/main.rs
@@ -1,0 +1,52 @@
+//! Rust-native StableHLO text emitter for Llama-3.2-1B (spike #451).
+//!
+//! Usage:
+//!   emit p0     [out.mlir]   single dot_general, toolchain round-trip gate (P0)
+//!   emit probe  [out.mlir]   syntax probe for the riskiest op forms
+//!   emit decode [out.mlir]   full Llama-3.2-1B decode_step (P1)
+
+mod builder;
+mod config;
+mod model;
+mod rope;
+
+use std::io::Write;
+
+fn p0_matmul() -> String {
+    // [4,8] x [8,3] -> [4,3], the minimal toolchain round-trip.
+    "module {\n  func.func public @main(%a: tensor<4x8xf32>, %b: tensor<8x3xf32>) -> tensor<4x3xf32> {\n    %0 = stablehlo.dot_general %a, %b, contracting_dims = [1] x [0] : (tensor<4x8xf32>, tensor<8x3xf32>) -> tensor<4x3xf32>\n    return %0 : tensor<4x3xf32>\n  }\n}\n".to_string()
+}
+
+fn probe() -> String {
+    // Exercises the op forms not covered by the plain matmul, especially
+    // dynamic_update_slice (JAX used scatter, so this spelling is novel here),
+    // a batched dot_general, dynamic_slice, and reduce.
+    "module {\n  func.func public @main(%cache: tensor<2x4x3xf32>, %upd: tensor<1x1x3xf32>, %idx: tensor<i32>, %q: tensor<2x4x5xf32>, %kv: tensor<6x2x5xf32>, %scores: tensor<8x7xf32>) -> (tensor<2x4x3xf32>, tensor<3x3xf32>, tensor<2x4x6xf32>, tensor<8xf32>) {\n    %c0 = stablehlo.constant dense<0> : tensor<i32>\n    %c1 = stablehlo.constant dense<1> : tensor<i32>\n    %0 = stablehlo.dynamic_update_slice %cache, %upd, %c1, %idx, %c0 : (tensor<2x4x3xf32>, tensor<1x1x3xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<2x4x3xf32>\n    %1 = stablehlo.dynamic_slice %cache, %c1, %c0, %c0, sizes = [1, 4, 3] : (tensor<2x4x3xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<1x4x3xf32>\n    %2 = stablehlo.reshape %1 : (tensor<1x4x3xf32>) -> tensor<4x3xf32>\n    %3 = stablehlo.slice %2 [1:4, 0:3] : (tensor<4x3xf32>) -> tensor<3x3xf32>\n    %init = stablehlo.constant dense<0.000000e+00> : tensor<f32>\n    %4 = stablehlo.reduce(%scores init: %init) applies stablehlo.add across dimensions = [1] : (tensor<8x7xf32>, tensor<f32>) -> tensor<8xf32>\n    %5 = stablehlo.dot_general %q, %kv, batching_dims = [0] x [1], contracting_dims = [2] x [2] : (tensor<2x4x5xf32>, tensor<6x2x5xf32>) -> tensor<2x4x6xf32>\n    return %0, %3, %5, %4 : tensor<2x4x3xf32>, tensor<3x3xf32>, tensor<2x4x6xf32>, tensor<8xf32>\n  }\n}\n".to_string()
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let kind = args.get(1).map(|s| s.as_str()).unwrap_or("decode");
+    let out = args.get(2);
+
+    let text = match kind {
+        "p0" => p0_matmul(),
+        "probe" => probe(),
+        "decode" => model::emit_decode(&config::Config::llama_3_2_1b()),
+        other => {
+            eprintln!("unknown kind: {other} (use p0 | probe | decode)");
+            std::process::exit(2);
+        }
+    };
+
+    match out {
+        Some(path) => {
+            let mut f = std::fs::File::create(path).expect("create output file");
+            f.write_all(text.as_bytes()).expect("write output");
+            eprintln!("wrote {} ({} bytes)", path, text.len());
+        }
+        None => {
+            print!("{text}");
+        }
+    }
+}

--- a/spike/rust-emitter/src/model.rs
+++ b/spike/rust-emitter/src/model.rs
@@ -1,0 +1,324 @@
+//! Emits the Llama-3.2-1B `decode_step` StableHLO module from Rust.
+//!
+//! Signature mirrors spike/openxla/model_jax.py `decode_step`:
+//!   main(params..., token, pos, cache_len, kcache, vcache)
+//!       -> (logits[V], kcache, vcache)
+//! Weights are individual tensor inputs in the same order JAX emitted
+//! (alphabetical within each layer), each carrying its pytree-path loc so the
+//! arg-to-weight mapping is self-documenting and reuses the JAX weight glue.
+
+use crate::builder::{Builder, Ty, Val};
+use crate::config::Config;
+use crate::rope;
+
+const MAX_SEQ: usize = 256;
+
+/// Per-layer weight handles (JAX alphabetical order: down, gate, in_ln,
+/// post_ln, up, wk, wo, wq, wv).
+struct LayerW {
+    down: Val,
+    gate: Val,
+    in_ln: Val,
+    post_ln: Val,
+    up: Val,
+    wk: Val,
+    wo: Val,
+    wq: Val,
+    wv: Val,
+}
+
+struct Args {
+    embed: Val,
+    final_norm: Val,
+    layers: Vec<LayerW>,
+    token: Val,
+    pos: Val,
+    cache_len: Val,
+    kcache: Val,
+    vcache: Val,
+}
+
+/// One (arg index, type, pytree-path loc) entry used to render the signature.
+struct ArgDecl {
+    ty: Ty,
+    loc: String,
+}
+
+fn build_arg_schema(c: &Config) -> (Vec<ArgDecl>, Args) {
+    let h = c.hidden;
+    let inter = c.inter;
+    let kv = c.n_kv * c.head_dim; // 512
+    let qd = c.n_q * c.head_dim; // 2048
+    let v = c.vocab;
+
+    let mut decls: Vec<ArgDecl> = Vec::new();
+    let mut idx = 0usize;
+    let mut take = |decls: &mut Vec<ArgDecl>, ty: Ty, loc: String| -> Val {
+        let val = Builder::arg(idx, ty.clone());
+        decls.push(ArgDecl { ty, loc });
+        idx += 1;
+        val
+    };
+
+    let embed = take(&mut decls, Ty::f32(vec![v, h]), "params['embed']".into());
+    let final_norm = take(&mut decls, Ty::f32(vec![h]), "params['final_norm']".into());
+
+    let mut layers = Vec::with_capacity(c.n_layers);
+    for li in 0..c.n_layers {
+        let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
+        let down = take(&mut decls, Ty::f32(vec![h, inter]), p("down"));
+        let gate = take(&mut decls, Ty::f32(vec![inter, h]), p("gate"));
+        let in_ln = take(&mut decls, Ty::f32(vec![h]), p("in_ln"));
+        let post_ln = take(&mut decls, Ty::f32(vec![h]), p("post_ln"));
+        let up = take(&mut decls, Ty::f32(vec![inter, h]), p("up"));
+        let wk = take(&mut decls, Ty::f32(vec![kv, h]), p("wk"));
+        let wo = take(&mut decls, Ty::f32(vec![qd, h]), p("wo"));
+        let wq = take(&mut decls, Ty::f32(vec![qd, h]), p("wq"));
+        let wv = take(&mut decls, Ty::f32(vec![kv, h]), p("wv"));
+        layers.push(LayerW {
+            down,
+            gate,
+            in_ln,
+            post_ln,
+            up,
+            wk,
+            wo,
+            wq,
+            wv,
+        });
+    }
+
+    let token = take(&mut decls, Ty::scalar("i32"), "token".into());
+    let pos = take(&mut decls, Ty::scalar("i32"), "pos".into());
+    let cache_len = take(&mut decls, Ty::scalar("i32"), "cache_len".into());
+    let kcache = take(
+        &mut decls,
+        Ty::f32(vec![c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
+        "kcache".into(),
+    );
+    let vcache = take(
+        &mut decls,
+        Ty::f32(vec![c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
+        "vcache".into(),
+    );
+
+    (
+        decls,
+        Args {
+            embed,
+            final_norm,
+            layers,
+            token,
+            pos,
+            cache_len,
+            kcache,
+            vcache,
+        },
+    )
+}
+
+fn render_signature(decls: &[ArgDecl]) -> String {
+    let parts: Vec<String> = decls
+        .iter()
+        .enumerate()
+        .map(|(i, d)| format!("%arg{}: {} loc(\"{}\")", i, d.ty.render(), d.loc))
+        .collect();
+    parts.join(", ")
+}
+
+/// Shared scalar/table constants, emitted once at the top of the body.
+struct Consts {
+    cos_table: Val,
+    sin_table: Val,
+    zero: Val,
+    one: Val,
+    neg_inf: Val,
+    neg_big: Val,
+    eps: Val,
+    hidden_f: Val,
+    scale: Val,
+    c0: Val,
+    layer_idx: Vec<Val>,
+}
+
+fn emit_consts(b: &mut Builder, c: &Config) -> Consts {
+    let (cos, sin) = rope::rope_tables(c, MAX_SEQ);
+    let cos_table = b.const_tensor_f32(&cos, vec![MAX_SEQ, c.head_dim]);
+    let sin_table = b.const_tensor_f32(&sin, vec![MAX_SEQ, c.head_dim]);
+    let zero = b.const_f32(0.0);
+    let one = b.const_f32(1.0);
+    let neg_inf = b.const_f32(f32::NEG_INFINITY);
+    let neg_big = b.const_f32(-1e30);
+    let eps = b.const_f32(c.eps);
+    let hidden_f = b.const_f32(c.hidden as f32);
+    let scale = b.const_f32(c.scale());
+    let c0 = b.const_i32(0);
+    let layer_idx: Vec<Val> = (0..c.n_layers).map(|i| b.const_i32(i as i32)).collect();
+    Consts {
+        cos_table,
+        sin_table,
+        zero,
+        one,
+        neg_inf,
+        neg_big,
+        eps,
+        hidden_f,
+        scale,
+        c0,
+        layer_idx,
+    }
+}
+
+/// RMSNorm: x * rsqrt(mean(x*x) + eps) * w, all over the single feature axis.
+fn rms_norm(b: &mut Builder, x: &Val, w: &Val, k: &Consts, hidden: usize) -> Val {
+    let sq = b.multiply(x, x);
+    let ssum = b.reduce_add(&sq, 0, &k.zero); // scalar
+    let mean = b.divide(&ssum, &k.hidden_f); // scalar
+    let meps = b.add(&mean, &k.eps);
+    let r = b.rsqrt(&meps);
+    let rb = b.broadcast(&r, &[], vec![hidden]);
+    let xr = b.multiply(x, &rb);
+    b.multiply(&xr, w)
+}
+
+/// HF half-split RoPE on x:[heads, d]; cos/sin are [d] for the position.
+fn apply_rope(b: &mut Builder, x: &Val, cos: &Val, sin: &Val, heads: usize, d: usize) -> Val {
+    let half = d / 2;
+    let cos_b = b.broadcast(cos, &[1], vec![heads, d]);
+    let sin_b = b.broadcast(sin, &[1], vec![heads, d]);
+    let xc = b.multiply(x, &cos_b);
+    let x1 = b.slice(x, &[(0, heads), (0, half)]);
+    let x2 = b.slice(x, &[(0, heads), (half, d)]);
+    let nx2 = b.negate(&x2);
+    let rh = b.concatenate(&nx2, &x1, 1);
+    let rs = b.multiply(&rh, &sin_b);
+    b.add(&xc, &rs)
+}
+
+/// Emit the complete decode_step module text.
+pub fn emit_decode(c: &Config) -> String {
+    let (decls, a) = build_arg_schema(c);
+    let mut b = Builder::new();
+    let k = emit_consts(&mut b, c);
+
+    let h = c.hidden;
+    let d = c.head_dim;
+    let nq = c.n_q;
+    let nkv = c.n_kv;
+    let g = c.group();
+
+    // --- head: embed gather, rope vectors, decode key mask ---
+    let emb_row = b.dynamic_slice(&a.embed, &[&a.token, &k.c0], vec![1, h]);
+    let mut x = b.reshape(&emb_row, vec![h]);
+
+    let cos_row = b.dynamic_slice(&k.cos_table, &[&a.pos, &k.c0], vec![1, d]);
+    let cos_vec = b.reshape(&cos_row, vec![d]);
+    let sin_row = b.dynamic_slice(&k.sin_table, &[&a.pos, &k.c0], vec![1, d]);
+    let sin_vec = b.reshape(&sin_row, vec![d]);
+
+    // mask: keys s valid iff s <= cache_len -> additive 0 / -1e30, shape [S]
+    let ii = b.iota(MAX_SEQ);
+    let clen_b = b.broadcast(&a.cache_len, &[], vec![MAX_SEQ]);
+    let valid = b.compare("LE", &ii, &clen_b, "SIGNED");
+    let zeros_s = b.broadcast(&k.zero, &[], vec![MAX_SEQ]);
+    let negs_s = b.broadcast(&k.neg_big, &[], vec![MAX_SEQ]);
+    let kmask = b.select(&valid, &zeros_s, &negs_s);
+
+    let mut kcache = a.kcache.clone();
+    let mut vcache = a.vcache.clone();
+
+    for li in 0..c.n_layers {
+        let lw = &a.layers[li];
+
+        // attention block
+        let hn = rms_norm(&mut b, &x, &lw.in_ln, &k, h);
+        let q = b.linear(&hn, &lw.wq);
+        let q = b.reshape(&q, vec![nq, d]);
+        let kk = b.linear(&hn, &lw.wk);
+        let kk = b.reshape(&kk, vec![nkv, d]);
+        let vv = b.linear(&hn, &lw.wv);
+        let vv = b.reshape(&vv, vec![nkv, d]);
+
+        let q = apply_rope(&mut b, &q, &cos_vec, &sin_vec, nq, d);
+        let kk = apply_rope(&mut b, &kk, &cos_vec, &sin_vec, nkv, d);
+
+        // write new K/V at [li, cache_len]
+        let k_upd = b.reshape(&kk, vec![1, 1, nkv, d]);
+        kcache = b.dynamic_update_slice(
+            &kcache,
+            &k_upd,
+            &[&k.layer_idx[li], &a.cache_len, &k.c0, &k.c0],
+        );
+        let v_upd = b.reshape(&vv, vec![1, 1, nkv, d]);
+        vcache = b.dynamic_update_slice(
+            &vcache,
+            &v_upd,
+            &[&k.layer_idx[li], &a.cache_len, &k.c0, &k.c0],
+        );
+
+        // read this layer's cache slabs [S, nkv, d]
+        let kl = b.slice(&kcache, &[(li, li + 1), (0, MAX_SEQ), (0, nkv), (0, d)]);
+        let kl = b.reshape(&kl, vec![MAX_SEQ, nkv, d]);
+        let vl = b.slice(&vcache, &[(li, li + 1), (0, MAX_SEQ), (0, nkv), (0, d)]);
+        let vl = b.reshape(&vl, vec![MAX_SEQ, nkv, d]);
+
+        // GQA scores via batched dot_general (q head h uses kv head h/g)
+        let q_r = b.reshape(&q, vec![nkv, g, d]); // head h = kv*g + grp
+        let scores = b.dot_general(&q_r, &kl, &[0], &[1], &[2], &[2], vec![nkv, g, MAX_SEQ]);
+        let scores = b.reshape(&scores, vec![nq, MAX_SEQ]);
+        let scale_b = b.broadcast(&k.scale, &[], vec![nq, MAX_SEQ]);
+        let scores = b.multiply(&scores, &scale_b);
+        let kmask_b = b.broadcast(&kmask, &[1], vec![nq, MAX_SEQ]);
+        let scores = b.add(&scores, &kmask_b);
+
+        // softmax over the key axis
+        let m = b.reduce_max(&scores, 1, &k.neg_inf);
+        let m_b = b.broadcast(&m, &[0], vec![nq, MAX_SEQ]);
+        let sh = b.subtract(&scores, &m_b);
+        let e = b.exponential(&sh);
+        let s = b.reduce_add(&e, 1, &k.zero);
+        let s_b = b.broadcast(&s, &[0], vec![nq, MAX_SEQ]);
+        let attn = b.divide(&e, &s_b);
+
+        // context: out[h,d] = sum_s attn[h,s] * vl[s, h/g, d]
+        let attn_r = b.reshape(&attn, vec![nkv, g, MAX_SEQ]);
+        let o = b.dot_general(&attn_r, &vl, &[0], &[1], &[2], &[0], vec![nkv, g, d]);
+        let o = b.reshape(&o, vec![nq, d]);
+        let o = b.reshape(&o, vec![nq * d]);
+        let attn_out = b.linear(&o, &lw.wo);
+        x = b.add(&x, &attn_out);
+
+        // MLP: down( silu(x@gate^T) * (x@up^T) )
+        let hn2 = rms_norm(&mut b, &x, &lw.post_ln, &k, h);
+        let gate = b.linear(&hn2, &lw.gate);
+        let up = b.linear(&hn2, &lw.up);
+        // silu(gate) = gate * sigmoid(gate), sigmoid(z) = 1/(1+exp(-z))
+        let neg = b.negate(&gate);
+        let ex = b.exponential(&neg);
+        let one_b = b.broadcast(&k.one, &[], vec![c.inter]);
+        let denom = b.add(&one_b, &ex);
+        let sig = b.divide(&one_b, &denom);
+        let silu = b.multiply(&gate, &sig);
+        let act = b.multiply(&silu, &up);
+        let down = b.linear(&act, &lw.down);
+        x = b.add(&x, &down);
+    }
+
+    // --- tail: final norm + tied LM head ---
+    let xf = rms_norm(&mut b, &x, &a.final_norm, &k, h);
+    let logits = b.linear(&xf, &a.embed); // [V]
+
+    let sig = render_signature(&decls);
+    let cache_ty = Ty::f32(vec![c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]).render();
+    let logits_ty = Ty::f32(vec![c.vocab]).render();
+    format!(
+        "module @decode_step {{\n  func.func public @main({sig}) -> ({logits_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {l}, {kc}, {vc} : {logits_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
+        sig = sig,
+        logits_ty = logits_ty,
+        cache_ty = cache_ty,
+        body = b.body(),
+        l = logits.name,
+        kc = kcache.name,
+        vc = vcache.name,
+    )
+}

--- a/spike/rust-emitter/src/rope.rs
+++ b/spike/rust-emitter/src/rope.rs
@@ -1,0 +1,64 @@
+//! RoPE tables, byte-for-byte with HF `_compute_llama3_parameters` and the JAX
+//! reference `llama3_inv_freq` / `rope_tables` in spike/openxla/model_jax.py.
+//!
+//! All math is done in f64 (matching numpy's default), then cos/sin are cast to
+//! f32 for the baked constant tables, exactly as the JAX path did
+//! (`jnp.asarray(np.cos(emb), jnp.float32)`). Keeping the trig in f64-then-f32
+//! rather than emitting in-graph `stablehlo.cosine` removes any dependence on the
+//! runtime's transcendental precision.
+
+use crate::config::Config;
+
+/// inv_freq[i], i in 0..head_dim/2, with llama3 scaling. Returns f64.
+pub fn llama3_inv_freq(c: &Config) -> Vec<f64> {
+    let half = c.head_dim / 2;
+    let mut inv = vec![0.0f64; half];
+    let low_wl = c.orig_ctx as f64 / c.low_freq_factor;
+    let high_wl = c.orig_ctx as f64 / c.high_freq_factor;
+    for i in 0..half {
+        // base = 1 / theta^((2i)/head_dim)
+        let exponent = (2 * i) as f64 / c.head_dim as f64;
+        let base = 1.0 / c.rope_theta.powf(exponent);
+        let wavelen = 2.0 * std::f64::consts::PI / base;
+
+        // inv = where(wavelen > low_wl, base/factor, base)
+        let mut v = if wavelen > low_wl {
+            base / c.factor
+        } else {
+            base
+        };
+        // smoothed = (1 - smooth) * inv/factor + smooth * inv
+        let smooth =
+            (c.orig_ctx as f64 / wavelen - c.low_freq_factor) / (c.high_freq_factor - c.low_freq_factor);
+        let smoothed = (1.0 - smooth) * v / c.factor + smooth * v;
+        // is_medium = !(wavelen < high_wl) && !(wavelen > low_wl)
+        let is_medium = !(wavelen < high_wl) && !(wavelen > low_wl);
+        if is_medium {
+            v = smoothed;
+        }
+        inv[i] = v;
+    }
+    inv
+}
+
+/// Build cos and sin tables of shape [max_seq, head_dim] as flat row-major f32.
+/// emb = concat([freqs, freqs], -1) where freqs = outer(pos, inv_freq).
+pub fn rope_tables(c: &Config, max_seq: usize) -> (Vec<f32>, Vec<f32>) {
+    let inv = llama3_inv_freq(c);
+    let half = c.head_dim / 2;
+    let d = c.head_dim;
+    let mut cos = vec![0.0f32; max_seq * d];
+    let mut sin = vec![0.0f32; max_seq * d];
+    for p in 0..max_seq {
+        for i in 0..half {
+            let angle = p as f64 * inv[i];
+            let (c_val, s_val) = (angle.cos() as f32, angle.sin() as f32);
+            // first half [0, half) and second half [half, d) are identical
+            cos[p * d + i] = c_val;
+            cos[p * d + half + i] = c_val;
+            sin[p * d + i] = s_val;
+            sin[p * d + half + i] = s_val;
+        }
+    }
+    (cos, sin)
+}

--- a/spike/rust-emitter/validate.sh
+++ b/spike/rust-emitter/validate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# End-to-end driver for the Rust StableHLO emitter spike (#451).
+#
+#   ./validate.sh            # P0 round-trip + full decode_step token check
+#   ./validate.sh p0         # P0 toolchain round-trip only
+#   ./validate.sh decode     # emit + compile + token-exact decode only
+#
+# Reuses the existing spike/openxla venv (iree-compile + iree runtime + torch +
+# transformers + safetensors). Nothing here builds or touches the mlxcel crates.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REF="/home/inureyes/Development/mlxcel/spike/openxla"
+PY="$REF/.venv/bin/python"
+IREE_COMPILE="$REF/.venv/bin/iree-compile"
+CARGO="${CARGO:-$HOME/.cargo/bin/cargo}"
+OUT="$HERE/out"
+mkdir -p "$OUT"
+
+mode="${1:-all}"
+
+echo "== build emitter =="
+( cd "$HERE" && "$CARGO" build --release )
+EMIT="$HERE/target/release/emit"
+
+p0() {
+  echo "== P0: single dot_general round-trip =="
+  "$EMIT" p0 "$OUT/p0.mlir"
+  "$IREE_COMPILE" --iree-input-type=stablehlo --iree-hal-target-backends=llvm-cpu \
+    "$OUT/p0.mlir" -o "$OUT/p0.vmfb"
+  "$PY" - "$OUT/p0.vmfb" <<'PY'
+import sys, numpy as np, iree.runtime as rt
+ctx = rt.SystemContext(config=rt.Config("local-task"))
+vm = rt.VmModule.from_flatbuffer(ctx.instance, open(sys.argv[1], "rb").read())
+ctx.add_vm_module(vm)
+fn = getattr(ctx.modules, vm.name).main
+rng = np.random.default_rng(0)
+a = rng.standard_normal((4, 8), dtype=np.float32); b = rng.standard_normal((8, 3), dtype=np.float32)
+ok = np.allclose(np.asarray(fn(a, b)), a @ b, atol=1e-5)
+print("P0 ROUND-TRIP:", "PASS" if ok else "FAIL"); sys.exit(0 if ok else 1)
+PY
+}
+
+decode() {
+  echo "== P1: full decode_step =="
+  "$EMIT" decode "$OUT/decode.mlir"
+  "$IREE_COMPILE" --iree-input-type=stablehlo --iree-hal-target-backends=llvm-cpu \
+    "$OUT/decode.mlir" -o "$OUT/decode.vmfb"
+  "$PY" "$HERE/python/run_decode.py" --mlir "$OUT/decode.mlir" --vmfb "$OUT/decode.vmfb"
+}
+
+case "$mode" in
+  p0) p0 ;;
+  decode) decode ;;
+  all) p0; decode ;;
+  *) echo "usage: validate.sh [p0|decode|all]"; exit 2 ;;
+esac


### PR DESCRIPTION
Rust-native StableHLO emitter, a parallel alternative authoring path to the JAX reference frontend validated in #449 Phase 1 (#451).

A dependency-free Rust crate emits the Llama-3.2-1B StableHLO as text; the existing `iree-compile` lowers it and the IREE runtime runs it. No Python in the authoring path, no `melior`, no MLIR/LLVM C++ build.

Results:
- P0 (toolchain gate): a Rust-emitted single `dot_general` compiles and runs through IREE, exact versus numpy.
- P1: the full Rust-emitted `decode_step` greedy-decodes token-exact (48/48) against the HF transformers temp-0 reference, same coherent text. 20 StableHLO op kinds, 145 `dot_general`, zero `custom_call`, zero f64. Validated with the real bf16 weights (independently re-run).
- Standalone `prefill` was not separately emitted (the one new op it needs is `stablehlo.gather`); decode token-exactness was the gate and it is met. A follow-up adds prefill.

Recommendation for the ADR 0004 authoring-frontend decision: adopt the Rust text emitter as the production authoring path and keep the JAX reference as the per-architecture oracle (author and verify in JAX, emit from Rust, diff against the JAX `.mlir` and tokens). The emitter wins on graph control (int4 dequant insertion and `custom_call` routing are local edits to one `Builder::linear` applied to all matmuls) and on toolchain weight (cargo plus iree-compile only).

Standalone under `spike/rust-emitter/` with its own empty `[workspace]` so it never joins the mlxcel build graph. Findings in `spike/rust-emitter/FINDINGS.md`.

Refs #451.