### PR TITLE
feat: GPU decode throughput for the OpenXLA spike on GB10 (#449 Phase 2b)

### DIFF
--- a/spike/openxla/FINDINGS_phase2b.md
+++ b/spike/openxla/FINDINGS_phase2b.md
@@ -1,0 +1,83 @@
+# Phase 2b findings: GPU decode throughput on the GB10
+
+Issue #449 Phase 2b (deferred from Phase 2a until a GPU host existed; CUDA turned
+out to be available on this box). Goal: real decode throughput for the exported
+StableHLO on the GB10, with the Phase 2a harness artifacts removed. CPU numbers
+through the same harness for comparison.
+
+## What changed from the Phase 2a GPU run
+
+Phase 2a reported a misleading GPU rate because the functional-call harness
+re-uploaded all weights as graph inputs every step and copied full logits to the
+host per token. Phase 2b fixes all three:
+
+- weights uploaded to the device ONCE as resident IREE device arrays,
+- on-device argmax (decode returns the next token id, so 4 bytes cross per step
+  instead of a 513 KB logits copy),
+- KV cache kept resident on the device across steps (the returned device buffers
+  are fed straight back in).
+
+Same IREE path for both targets (`--iree-hal-target-device=cuda` for the GB10,
+`--iree-hal-target-backends=llvm-cpu` for CPU); prefill runs once on CPU to seed
+the cache. Reference model Llama-3.2-1B, single sequence, greedy.
+
+## Numbers
+
+| variant | device | tok/s | ms/tok |
+|---|---|---|---|
+| int4 | GB10 | 4.0 | 252 |
+| int4 | CPU  | 0.8 | 1274 |
+| fp32 | GB10 | 5.5 | 182 |
+| fp32 | CPU  | 1.8 | 541 |
+
+All four stay coherent (same continuation prefix). Two findings fall out.
+
+### 1. With the harness fixed, the GPU beats the CPU
+
+int4 is 5x faster on the GB10 than on CPU, fp32 is 3x. The Phase 2a result where
+the GPU looked slower than CPU was entirely the weight-reupload and per-token
+logit-copy artifact, not the GB10. Resident weights plus on-device sampling is
+what a real backend does, and it is what makes the GPU win.
+
+### 2. int4 is SLOWER than fp32 on the GPU, confirming the Phase 2a fusion finding
+
+This is the important one. fp32 decode is 5.5 tok/s; int4 decode is 4.0 tok/s on
+the same GPU. int4 loses. The reason is exactly what the Phase 2a dispatch
+analysis predicted: the dequant is a separate kernel that materializes the full
+fp32 weight, and the matmul then reads that fp32 weight. So per step int4 does
+strictly more memory traffic than fp32 (read packed int4, write the fp32 weight,
+read the fp32 weight) plus an extra kernel launch, while fp32 just reads its
+weight once. Without dequant-matmul fusion, dequant-in-graph int4 buys an 8x
+smaller weight on disk and in device memory, but costs decode latency rather than
+saving it. The storage win is real; the compute and bandwidth win on the matmul
+is not, and will not appear until the dequant fuses into the GEMM (a `custom_call`
+to an int4 GEMM, or IREE's quantized-matmul fusion recognizing the pattern).
+
+## On the absolute numbers
+
+4 to 5.5 tok/s for a 1B model on a Blackwell-class GPU is low, and it is not a
+ceiling. Single-sequence decode is latency-bound: 145 tiny `dot_general` calls per
+token (batch 1, vec-by-matrix), each a separate kernel launch, with no CUDA-graph
+capture, no fused attention, and IREE's default CUDA codegen which is not tuned
+for batch-1 LLM decode. The point of Phase 2b is the relative result (GPU over
+CPU, and fp32 over unfused int4), not a tuned tok/s. Real throughput work
+(CUDA-graph capture, fused attention, batching when the session allows it) is
+backend-optimization territory beyond this spike.
+
+## Recommendation
+
+Carry two facts into the backend design. First, the export-route runs on the GB10
+through IREE-CUDA and clears the CPU comfortably once weights are resident and
+sampling is on-device, so the GPU path is viable. Second, do not ship
+dequant-in-graph int4 expecting a decode speedup: as measured it is slower than
+fp32 because the dequant does not fuse. int4 earns its place through weight
+storage and transfer (8x), and through a fused int4 GEMM (`custom_call` or a
+recognized quantized-matmul pattern), which is the next thing to prototype if
+int4 decode latency matters. Until then, fp32 (or bf16) resident weights are the
+faster single-sequence decode path on this GPU.
+
+## Files
+
+`phase2b_gpu.py` (resident weights, on-device argmax, CUDA and CPU through IREE),
+`artifacts/phase2b_perf.json` (the table), `artifacts/*_decode_argmax.*` (the
+exported on-device-sampling graphs and vmfbs).

--- a/spike/openxla/phase2b_gpu.py
+++ b/spike/openxla/phase2b_gpu.py
@@ -1,0 +1,134 @@
+"""Phase 2b: real GPU decode throughput on the GB10.
+
+Fixes the Phase 2a harness artifacts that made the GPU look slow:
+  - weights uploaded to the device ONCE (resident), not re-passed every step,
+  - on-device argmax (decode returns the next token id, so only 4 bytes cross
+    per step instead of a 513 KB logits copy),
+  - KV cache kept resident on the device across steps.
+Measures steady-state decode tok/s for int4 and fp32, on CUDA (GB10) and on CPU
+through the same IREE harness, prefilling on CPU to seed the cache.
+
+Run: JAX_PLATFORMS=cpu .venv/bin/python phase2b_gpu.py
+"""
+import json
+import os
+import subprocess
+import time
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax import export as jexport
+from transformers import AutoTokenizer
+
+import model_jax as M
+import model_int4 as Mi
+
+MODEL = "models/Llama-3.2-1B-Instruct"
+MAX_SEQ = 256
+BUCKETS = [32, 64, 128, 256]
+EOS = {128001, 128008, 128009}
+SDS = jax.ShapeDtypeStruct
+ART = "artifacts"
+IREE = ".venv/bin/iree-compile"
+STEPS = 40
+
+
+def bucket(n):
+    return next(b for b in BUCKETS if n <= b)
+
+
+def compile_iree(mlir, vmfb, driver):
+    backend = "--iree-hal-target-device=cuda" if driver == "cuda" else "--iree-hal-target-backends=llvm-cpu"
+    subprocess.run([IREE, "--iree-input-type=stablehlo", backend, mlir, "-o", vmfb],
+                   check=True, capture_output=True, text=True)
+
+
+def load_iree(vmfb, driver):
+    import iree.runtime as rt
+    config = rt.Config(driver)
+    ctx = rt.SystemContext(config=config)
+    vm = rt.VmModule.from_flatbuffer(ctx.instance, open(vmfb, "rb").read())
+    ctx.add_vm_module(vm)
+    fn = getattr(ctx.modules, vm.name).main
+    return fn, config.device, rt
+
+
+def decode_argmax_fn(decode_step):
+    def da(params, token, pos, clen, kc, vc):
+        logits, kc, vc = decode_step(params, token, pos, clen, kc, vc)
+        return jnp.argmax(logits).astype(jnp.int32), kc, vc
+    return da
+
+
+def run_variant(name, params, prefill, decode_step, cfg, toks, n, Lp, driver):
+    """Compile decode (on-device argmax) for `driver`, run with resident weights."""
+    L, nkv, d = cfg.n_layers, cfg.n_kv, cfg.head_dim
+    da = decode_argmax_fn(decode_step)
+    p_aval = jax.tree.map(lambda x: SDS(x.shape, x.dtype), params)
+    exp = jexport.export(jax.jit(da))(
+        p_aval, SDS((), jnp.int32), SDS((), jnp.int32), SDS((), jnp.int32),
+        SDS((L, MAX_SEQ, nkv, d), jnp.float32), SDS((L, MAX_SEQ, nkv, d), jnp.float32))
+    mlir = f"{ART}/{name}_decode_argmax.stablehlo.mlir"
+    vmfb = f"{ART}/{name}_decode_argmax.{driver}.vmfb"
+    open(mlir, "w").write(exp.mlir_module())
+    compile_iree(mlir, vmfb, driver)
+
+    # seed the cache with a CPU prefill (one-time), get the first token
+    logits, kc, vc = jax.jit(prefill)(params, jnp.asarray(toks), jnp.arange(Lp, dtype=jnp.int32), jnp.int32(n))
+    first = int(np.asarray(logits).argmax())
+    kc, vc = np.asarray(kc), np.asarray(vc)
+
+    fn, dev, rt = load_iree(vmfb, driver)
+    leaves = [rt.asdevicearray(dev, np.asarray(x)) for x in jax.tree_util.tree_flatten(params)[0]]
+    kc_d, vc_d = rt.asdevicearray(dev, kc), rt.asdevicearray(dev, vc)
+
+    tok, clen, pos, gen, times = first, n, n, [first], []
+    for step in range(STEPS + 3):  # 3 warmup
+        t0 = time.time()
+        out = fn(*leaves, np.int32(tok), np.int32(pos), np.int32(clen), kc_d, vc_d)
+        tok = int(np.asarray(out[0].to_host()))   # 4-byte token, the only host copy
+        kc_d, vc_d = out[1], out[2]                # cache stays resident
+        if step >= 3:
+            times.append(time.time() - t0)
+        gen.append(tok); clen += 1; pos += 1
+        if tok in EOS:
+            break
+    tps = 1.0 / np.mean(times) if times else float("nan")
+    return tps, np.mean(times) * 1e3, gen
+
+
+def main():
+    os.makedirs(ART, exist_ok=True)
+    tok = AutoTokenizer.from_pretrained(MODEL)
+    text = tok.apply_chat_template(
+        [{"role": "user", "content": "Give me three short tips for staying focused while working."}],
+        add_generation_prompt=True, tokenize=False)
+    ids = tok(text, add_special_tokens=False).input_ids
+    n = len(ids); Lp = bucket(n)
+    toks = np.zeros(Lp, np.int32); toks[:n] = np.array(ids, np.int32)
+
+    cfg = M.load_config(MODEL)
+    fp32 = M.load_params(MODEL, cfg)
+    qp = Mi.quantize_params(fp32)
+    prefill_fp, decode_fp = M.make_fns(cfg, MAX_SEQ)
+    prefill_i4, decode_i4 = Mi.make_int4_fns(cfg, MAX_SEQ)
+
+    variants = [
+        ("int4", qp, prefill_i4, decode_i4),
+        ("fp32", fp32, prefill_fp, decode_fp),
+    ]
+    rows = []
+    for name, params, pf, ds in variants:
+        for driver in ("cuda", "local-task"):
+            tps, ms, gen = run_variant(name, params, pf, ds, cfg, toks, n, Lp, driver)
+            where = "GB10" if driver == "cuda" else "CPU"
+            print(f"{name:5s} {where:4s}: {tps:6.1f} tok/s ({ms:6.1f} ms/tok)  "
+                  f"sample: {tok.decode(gen[:8])!r}")
+            rows.append({"variant": name, "device": where, "tok_s": round(tps, 1), "ms_tok": round(ms, 1)})
+    json.dump(rows, open(f"{ART}/phase2b_perf.json", "w"), indent=2)
+    print(f"\nresident weights + on-device argmax. wrote {ART}/phase2b_perf.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
GPU decode throughput for the OpenXLA spike on the GB10 (#449 Phase 2b, deferred from Phase 2a until a GPU host existed; CUDA is available on this box).

Removes the Phase 2a harness artifacts that made the GPU look slow: weights resident on the device (uploaded once), on-device argmax (4 bytes per step instead of a 513 KB logits copy), and the KV cache kept resident. Same IREE path for CUDA (GB10) and CPU.

Results (tok/s, single-sequence greedy, Llama-3.2-1B):

| variant | device | tok/s | ms/tok |
|---|---|---|---|
| int4 | GB10 | 4.0 | 252 |
| int4 | CPU  | 0.8 | 1274 |
| fp32 | GB10 | 5.5 | 182 |
| fp32 | CPU  | 1.8 | 541 |

Two findings:
- With the harness fixed, the GPU beats the CPU (5x int4, 3x fp32), so the Phase 2a "GPU slower" reading was the weight-reupload artifact, not the GB10.
- int4 is slower than fp32 on the GPU (4.0 vs 5.5), confirming the Phase 2a fusion result: the unfused dequant is a separate kernel that materializes the fp32 weight, so int4 does more memory traffic per step. dequant-in-graph int4 is a weight-storage win (8x), not a decode-latency win, until the dequant fuses into the GEMM (a `custom_call` to an int4 GEMM, or a recognized quantized-matmul pattern).

Absolute tok/s is low and not a ceiling (batch-1 decode, 145 tiny matmuls per token, untuned IREE CUDA codegen, no CUDA-graph capture); the relative results are the point.

Standalone under `spike/openxla/`, no effect on mlxcel crates or builds. Findings in `spike/openxla/FINDINGS_phase2b.md`.

Refs #449.