### PR TITLE
feat: emit Llama-3.2-1B prefill from the Rust StableHLO emitter (#451 follow-up)

### DIFF
--- a/spike/rust-emitter/FINDINGS.md
+++ b/spike/rust-emitter/FINDINGS.md
@@ -85,10 +85,21 @@ in Rust f64 then cast f32 (matching the JAX `np.cos(emb).astype(f32)`), baked as
 hex `dense` constants, and `dynamic_slice`d at `pos`; keeping the trig out of the
 graph removes any dependence on the runtime's transcendental precision.
 
-`prefill` (bucketed) was not separately emitted. Streaming the prompt through
-decode validates the same math; a standalone prefill graph is straightforward in
-the same builder and needs one new op (`stablehlo.gather` for the multi-token
-embedding lookup). It was out of scope once decode landed token-exact.
+### Bucketed prefill (follow-up to #451)
+
+`src/model.rs` `emit_prefill` now also emits the standalone bucketed `prefill`
+graph, matching the JAX `prefill` signature (`tokens[Lp]`, `positions[Lp]`,
+`real_len`; no input caches, zero-initialized internally; bucket `Lp = 64`). It
+reuses the same builder over an `[Lp]` sequence axis: a `[Lp,Lp]` causal mask
+(`j <= i`), the `[Lp]` KV block written with one `dynamic_update_slice` per
+layer, and the last logit sliced at `real_len-1`. Running the Rust-emitted
+`prefill` (first token) then `decode_step` (continuation) is **token-exact
+(48/48)** against the same HF reference. The one new op the prefill needs is
+`stablehlo.gather` (the multi-token embedding lookup `embed[tokens]`, plus the
+per-position cos/sin lookup), whose `dimension_numbers` and `slice_sizes` mirror
+the JAX-emitted `prefill.stablehlo.mlir`. The added builder ops are `gather`,
+`transpose` (one per layer, for the GQA context output), and `linear_seq` (the
+`[Lp, K]` activation matmul); decode stays token-exact 48/48 unchanged.
 
 ### Emitted graph vs the JAX graph
 
@@ -210,8 +221,8 @@ oracle workflow is what keeps that price from becoming a correctness risk.
 
 ### Open items (not in this spike)
 
-- **prefill graph** in the emitter (needs `stablehlo.gather`); validated here by
-  streaming the prompt through decode.
+- **prefill graph** in the emitter: done as a #451 follow-up (`emit_prefill`,
+  `stablehlo.gather`), token-exact 48/48 via Rust-emitted prefill + decode.
 - **int4 path:** author dequant-in-graph and a `custom_call` variant from
   `Builder::linear`, then measure fusion on a GPU-capable host (this box is CPU).
 - **GPU backend:** same `iree-compile` route with a CUDA target; not exercised

--- a/spike/rust-emitter/README.md
+++ b/spike/rust-emitter/README.md
@@ -19,6 +19,9 @@ no `melior`, no MLIR/LLVM C++ build.
 - **P1 (the real bar):** the full Rust-emitted `decode_step` greedy-decodes
   **token-exact, 48/48**, against the HF reference in
   `spike/openxla/artifacts/results.json`. Output text is identical.
+- **Prefill (#451 follow-up):** the Rust-emitted bucketed `prefill` graph
+  produces the first token and `decode_step` continues, also **token-exact,
+  48/48**. Prefill adds the multi-token embedding `stablehlo.gather`.
 
 See `FINDINGS.md` for the toolchain choice, the authoring-path comparison
 (JAX-reference vs Rust-emitter), and the recommendation for ADR 0004.
@@ -30,9 +33,10 @@ See `FINDINGS.md` for the toolchain choice, the authoring-path comparison
 | `src/builder.rs` | SSA/type-tracking StableHLO text builder (one method per op). Architecture-independent, reused across graphs. |
 | `src/config.rs` | Llama-3.2-1B config constants. |
 | `src/rope.rs` | llama3 `inv_freq` and cos/sin tables (f64, then f32), byte-for-byte with the JAX reference. |
-| `src/model.rs` | Emits the full `decode_step` graph (head, 16 layers, tied head). |
-| `src/main.rs` | CLI: `emit p0 \| probe \| decode [out.mlir]`. |
+| `src/model.rs` | Emits the full `decode_step` and bucketed `prefill` graphs (head, 16 layers, tied head). |
+| `src/main.rs` | CLI: `emit p0 \| probe \| decode \| prefill [out.mlir]`. |
 | `python/run_decode.py` | Loads real bf16 weights (upcast fp32), drives greedy decode through the compiled module, compares to the HF tokens. |
+| `python/run_prefill.py` | Runs Rust-emitted `prefill` (first token) then `decode_step` (continuation), compares to the HF tokens. |
 | `validate.sh` | End-to-end driver: build, emit, compile, check. |
 
 ## Run
@@ -44,8 +48,12 @@ See `FINDINGS.md` for the toolchain choice, the authoring-path comparison
 # just the toolchain gate
 ./validate.sh p0
 
+# token-exact prefill (first token) + decode (continuation)
+./validate.sh prefill
+
 # emit only, inspect the StableHLO
 cargo run --release -- decode out/decode.mlir
+cargo run --release -- prefill out/prefill.mlir
 ```
 
 `validate.sh` reuses `spike/openxla/.venv` for `iree-compile`, the IREE runtime,
@@ -54,13 +62,17 @@ cargo run --release -- decode out/decode.mlir
 mlxcel crate (the `Cargo.toml` declares an empty `[workspace]` so it is its own
 workspace root).
 
-## How decode_step alone covers the prompt
+## Two ways the prompt is covered
 
-Only `decode_step` is emitted. The prompt is streamed through it one token at a
-time (`cache_len = i` for prompt token `i`). Because decode masks keys with
-`iota <= cache_len`, streaming the prompt is mathematically identical to a
-batched prefill: the same KV cache and the same position-`n-1` logits. The
-48/48 token match confirms the prompt was processed correctly. A separate
-bucketed `prefill` graph is straightforward additional work in the same builder
-(the one new op it needs is `stablehlo.gather` for the multi-token embedding
-lookup); it adds no new toolchain risk and was left out of this spike.
+`decode_step` alone covers the prompt by streaming it one token at a time
+(`cache_len = i` for prompt token `i`); because decode masks keys with
+`iota <= cache_len`, that is mathematically identical to a batched prefill (same
+KV cache, same position-`n-1` logits), and `run_decode.py` confirms it 48/48.
+
+The standalone bucketed `prefill` graph (`emit_prefill`, the #451 follow-up)
+processes the whole padded prompt in one shot over an `[Lp]` sequence axis with a
+`[Lp,Lp]` causal mask, writes the `[Lp]` KV block per layer with one
+`dynamic_update_slice`, and slices the last logit at `real_len-1`. The one new op
+it needs is `stablehlo.gather` (the multi-token embedding lookup `embed[tokens]`,
+plus the per-position cos/sin lookup). `run_prefill.py` runs prefill for the
+first token and `decode_step` for the continuation, also 48/48.

--- a/spike/rust-emitter/python/run_prefill.py
+++ b/spike/rust-emitter/python/run_prefill.py
@@ -1,0 +1,161 @@
+"""Validate the Rust-emitted prefill + decode_step StableHLO end to end.
+
+Drives the autoregressive loop the way a real runtime would: the bucketed
+`prefill` graph processes the whole padded prompt at once and produces the first
+token, then `decode_step` continues greedily, threading the KV cache prefill
+populated. This exercises the Rust-emitted prefill graph specifically (the
+multi-token embedding `stablehlo.gather`, the [Lp,Lp] causal mask, the [Lp] KV
+block write, and the real_len-1 last-logit slice), not just decode streaming.
+
+Token target: spike/openxla/artifacts/results.json `hf_ids` (HF temp-0, 48 tok).
+
+Run via validate.sh, or directly:
+  .venv/bin/python run_prefill.py --prefill prefill.mlir --decode decode.mlir
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+import numpy as np
+from safetensors import safe_open
+from transformers import AutoTokenizer
+import iree.runtime as rt
+
+REF = "/home/inureyes/Development/mlxcel/spike/openxla"
+MODEL = f"{REF}/models/Llama-3.2-1B-Instruct"
+IREE_COMPILE = f"{REF}/.venv/bin/iree-compile"
+RESULTS = f"{REF}/artifacts/results.json"
+
+N_LAYERS, MAX_SEQ, N_KV, HEAD_DIM = 16, 256, 8, 64
+LP = 64  # prefill bucket (matches results.json `bucket`)
+EOS = {128001, 128008, 128009}
+PROMPT = "Give me three short tips for staying focused while working."
+MAX_NEW = 48
+
+
+def load_weights():
+    """Return the 146 weight arrays in the emitter's exact arg order:
+    embed, final_norm, then per layer [down, gate, in_ln, post_ln, up, wk, wo,
+    wq, wv]. Weights stay [out, in] (bf16 -> fp32), tied embedding. Identical to
+    run_decode.load_weights; prefill and decode share the same weight schema."""
+    raw = {}
+    with safe_open(f"{MODEL}/model.safetensors", framework="pt") as f:
+        for k in f.keys():
+            raw[k] = f.get_tensor(k).float().numpy().astype(np.float32)
+    args = [raw["model.embed_tokens.weight"], raw["model.norm.weight"]]
+    for i in range(N_LAYERS):
+        p = f"model.layers.{i}."
+        args += [
+            raw[p + "mlp.down_proj.weight"],
+            raw[p + "mlp.gate_proj.weight"],
+            raw[p + "input_layernorm.weight"],
+            raw[p + "post_attention_layernorm.weight"],
+            raw[p + "mlp.up_proj.weight"],
+            raw[p + "self_attn.k_proj.weight"],
+            raw[p + "self_attn.o_proj.weight"],
+            raw[p + "self_attn.q_proj.weight"],
+            raw[p + "self_attn.v_proj.weight"],
+        ]
+    return args
+
+
+def compile_module(mlir_path, vmfb_path):
+    subprocess.run(
+        [IREE_COMPILE, "--iree-input-type=stablehlo",
+         "--iree-hal-target-backends=llvm-cpu", mlir_path, "-o", vmfb_path],
+        check=True,
+    )
+
+
+def load_fn(ctx, vmfb_path):
+    with open(vmfb_path, "rb") as f:
+        vm = rt.VmModule.from_flatbuffer(ctx.instance, f.read())
+    ctx.add_vm_module(vm)
+    return getattr(ctx.modules, vm.name).main
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--prefill", required=True, help="prefill .mlir")
+    ap.add_argument("--decode", required=True, help="decode_step .mlir")
+    ap.add_argument("--prefill-vmfb", default=None)
+    ap.add_argument("--decode-vmfb", default=None)
+    args = ap.parse_args()
+    pre_vmfb = args.prefill_vmfb or (os.path.splitext(args.prefill)[0] + ".vmfb")
+    dec_vmfb = args.decode_vmfb or (os.path.splitext(args.decode)[0] + ".vmfb")
+
+    for mlir, vmfb in [(args.prefill, pre_vmfb), (args.decode, dec_vmfb)]:
+        if not os.path.exists(vmfb):
+            print(f"compiling {mlir} -> {vmfb}")
+            compile_module(mlir, vmfb)
+
+    tok = AutoTokenizer.from_pretrained(MODEL)
+    msgs = [{"role": "user", "content": PROMPT}]
+    text = tok.apply_chat_template(msgs, add_generation_prompt=True, tokenize=False)
+    prompt_ids = tok(text, add_special_tokens=False).input_ids
+    n = len(prompt_ids)
+    print(f"prompt tokens = {n} (bucket Lp = {LP})")
+    if n > LP:
+        sys.exit(f"prompt ({n}) exceeds bucket ({LP})")
+
+    t0 = time.time()
+    weights = load_weights()
+    print(f"loaded {len(weights)} weight tensors in {time.time()-t0:.1f}s")
+
+    cfg = rt.Config("local-task")
+    ctx = rt.SystemContext(config=cfg)
+    prefill_fn = load_fn(ctx, pre_vmfb)
+    decode_fn = load_fn(ctx, dec_vmfb)
+
+    device = cfg.device
+    dev_weights = [rt.asdevicearray(device, w) for w in weights]
+
+    # --- prefill: whole padded prompt in one shot ---
+    tokens = np.zeros(LP, np.int32)
+    tokens[:n] = prompt_ids                       # pad tail with token 0 (masked out)
+    positions = np.arange(LP, dtype=np.int32)     # 0..Lp-1; pads are causally masked
+    t0 = time.time()
+    outs = prefill_fn(*dev_weights, tokens, positions, np.array(n, np.int32))
+    logits, kcache, vcache = outs[0], outs[1], outs[2]
+    prefill_ms = (time.time() - t0) * 1e3
+
+    gen = [int(np.asarray(logits).argmax())]      # first token from prefill (pos n-1)
+    clen = n
+
+    # --- decode: continue greedily, threading prefill's KV cache ---
+    step_ms = []
+    next_tok = gen[0]
+    for _ in range(MAX_NEW - 1):
+        if next_tok in EOS:
+            break
+        t0 = time.time()
+        outs = decode_fn(*dev_weights,
+                         np.array(next_tok, np.int32), np.array(clen, np.int32),
+                         np.array(clen, np.int32), kcache, vcache)
+        logits, kcache, vcache = outs[0], outs[1], outs[2]
+        step_ms.append((time.time() - t0) * 1e3)
+        next_tok = int(np.asarray(logits).argmax())
+        gen.append(next_tok)
+        clen += 1
+
+    hf_ids = json.load(open(RESULTS))["hf_ids"]
+    m = min(len(gen), len(hf_ids))
+    matches = sum(int(gen[i] == hf_ids[i]) for i in range(m))
+    first_div = next((i for i in range(m) if gen[i] != hf_ids[i]), None)
+
+    print("\n=== Rust-emitted prefill + decode greedy continuation ===")
+    print(repr(tok.decode(gen)))
+    print(f"\nprefill: {prefill_ms:.0f} ms ({n} tok, bucket {LP}) | "
+          f"decode steady: {np.mean(step_ms[1:]) if len(step_ms) > 1 else float('nan'):.0f} ms/tok")
+    print(f"token match vs HF temp-0: {matches}/{m}"
+          + (f"  first divergence at {first_div}" if first_div is not None else "  (EXACT)"))
+    ok = matches == m == len(hf_ids)
+    print("RESULT:", "TOKEN-EXACT PASS" if ok else "MISMATCH")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/spike/rust-emitter/src/builder.rs
+++ b/spike/rust-emitter/src/builder.rs
@@ -179,6 +179,22 @@ impl Builder {
         Val { name: r, ty }
     }
 
+    /// Permute axes. `perm[k]` is the input axis that becomes output axis k.
+    pub fn transpose(&mut self, x: &Val, perm: &[usize]) -> Val {
+        let shape: Vec<usize> = perm.iter().map(|&p| x.ty.shape[p]).collect();
+        let ty = Ty::new(shape, x.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.transpose {}, dims = {} : ({}) -> {}",
+            r,
+            x.name,
+            dims_list(perm),
+            x.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
     /// Unused by decode today; kept for the int4 dequant path (int -> f32).
     #[allow(dead_code)]
     pub fn convert(&mut self, x: &Val, elt: &'static str) -> Val {
@@ -262,6 +278,28 @@ impl Builder {
             operand.ty.render(),
             update.ty.render(),
             idx_tys.join(", "),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    /// Row gather: `operand[N, M]` indexed by `indices[Lp, 1]` (i32) -> `[Lp, M]`.
+    /// This is the multi-token embedding lookup `embed[tokens]`; the
+    /// dimension_numbers and slice_sizes mirror the JAX-emitted `prefill`
+    /// `stablehlo.gather` in spike/openxla/artifacts/prefill.stablehlo.mlir.
+    pub fn gather(&mut self, operand: &Val, indices: &Val) -> Val {
+        let lp = indices.ty.shape[0];
+        let m = operand.ty.shape[1];
+        let ty = Ty::new(vec![lp, m], operand.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = \"stablehlo.gather\"({}, {}) <{{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, slice_sizes = array<i64: 1, {}>}}> : ({}, {}) -> {}",
+            r,
+            operand.name,
+            indices.name,
+            m,
+            operand.ty.render(),
+            indices.ty.render(),
             ty.render()
         ));
         Val { name: r, ty }
@@ -417,5 +455,14 @@ impl Builder {
     pub fn linear(&mut self, x: &Val, w: &Val) -> Val {
         let n = w.ty.shape[0];
         self.dot_general(x, w, &[], &[], &[0], &[1], vec![n])
+    }
+
+    /// Sequence-batched linear: y[L,N] = x[L,K] @ W^T for W:[N,K] (stored
+    /// [out,in]). Contracts the feature dim (x dim 1, W dim 1), keeps the [L]
+    /// row axis. The prefill analog of `linear` for `[Lp, ...]` activations.
+    pub fn linear_seq(&mut self, x: &Val, w: &Val) -> Val {
+        let l = x.ty.shape[0];
+        let n = w.ty.shape[0];
+        self.dot_general(x, w, &[], &[], &[1], &[1], vec![l, n])
     }
 }

--- a/spike/rust-emitter/src/main.rs
+++ b/spike/rust-emitter/src/main.rs
@@ -1,9 +1,10 @@
 //! Rust-native StableHLO text emitter for Llama-3.2-1B (spike #451).
 //!
 //! Usage:
-//!   emit p0     [out.mlir]   single dot_general, toolchain round-trip gate (P0)
-//!   emit probe  [out.mlir]   syntax probe for the riskiest op forms
-//!   emit decode [out.mlir]   full Llama-3.2-1B decode_step (P1)
+//!   emit p0      [out.mlir]   single dot_general, toolchain round-trip gate (P0)
+//!   emit probe   [out.mlir]   syntax probe for the riskiest op forms
+//!   emit decode  [out.mlir]   full Llama-3.2-1B decode_step (P1)
+//!   emit prefill [out.mlir]   full Llama-3.2-1B bucketed prefill
 
 mod builder;
 mod config;
@@ -33,8 +34,9 @@ fn main() {
         "p0" => p0_matmul(),
         "probe" => probe(),
         "decode" => model::emit_decode(&config::Config::llama_3_2_1b()),
+        "prefill" => model::emit_prefill(&config::Config::llama_3_2_1b()),
         other => {
-            eprintln!("unknown kind: {other} (use p0 | probe | decode)");
+            eprintln!("unknown kind: {other} (use p0 | probe | decode | prefill)");
             std::process::exit(2);
         }
     };

--- a/spike/rust-emitter/src/model.rs
+++ b/spike/rust-emitter/src/model.rs
@@ -13,6 +13,10 @@ use crate::rope;
 
 const MAX_SEQ: usize = 256;
 
+/// Bucketed padded prompt length for prefill. Fits the 46-token spike prompt
+/// (matches `bucket` in spike/openxla/artifacts/results.json).
+const PREFILL_LP: usize = 64;
+
 /// Per-layer weight handles (JAX alphabetical order: down, gate, in_ln,
 /// post_ln, up, wk, wo, wq, wv).
 struct LayerW {
@@ -313,6 +317,246 @@ pub fn emit_decode(c: &Config) -> String {
     let logits_ty = Ty::f32(vec![c.vocab]).render();
     format!(
         "module @decode_step {{\n  func.func public @main({sig}) -> ({logits_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {l}, {kc}, {vc} : {logits_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
+        sig = sig,
+        logits_ty = logits_ty,
+        cache_ty = cache_ty,
+        body = b.body(),
+        l = logits.name,
+        kc = kcache.name,
+        vc = vcache.name,
+    )
+}
+
+// ===========================================================================
+// prefill: bucketed multi-token prompt processing
+// ===========================================================================
+//
+// Signature mirrors spike/openxla/model_jax.py `prefill`:
+//   main(params..., tokens[Lp], positions[Lp], real_len)
+//       -> (last_logits[V], kcache, vcache)
+// Unlike decode, prefill takes NO input caches: it zero-initializes them and
+// returns the prompt's K/V written into the [0:Lp] block. The whole prompt is
+// processed at once over an [Lp] sequence axis with an [Lp,Lp] causal mask, and
+// the returned logit is the row at real_len-1 (the last real prompt token).
+
+/// Prefill arg handles. Weights are identical to decode (same order/locs); the
+/// trailing inputs are tokens/positions/real_len with no caches.
+struct PrefillArgs {
+    embed: Val,
+    final_norm: Val,
+    layers: Vec<LayerW>,
+    tokens: Val,
+    positions: Val,
+    real_len: Val,
+}
+
+fn build_prefill_arg_schema(c: &Config, lp: usize) -> (Vec<ArgDecl>, PrefillArgs) {
+    let h = c.hidden;
+    let inter = c.inter;
+    let kv = c.n_kv * c.head_dim; // 512
+    let qd = c.n_q * c.head_dim; // 2048
+    let v = c.vocab;
+
+    let mut decls: Vec<ArgDecl> = Vec::new();
+    let mut idx = 0usize;
+    let mut take = |decls: &mut Vec<ArgDecl>, ty: Ty, loc: String| -> Val {
+        let val = Builder::arg(idx, ty.clone());
+        decls.push(ArgDecl { ty, loc });
+        idx += 1;
+        val
+    };
+
+    let embed = take(&mut decls, Ty::f32(vec![v, h]), "params['embed']".into());
+    let final_norm = take(&mut decls, Ty::f32(vec![h]), "params['final_norm']".into());
+
+    let mut layers = Vec::with_capacity(c.n_layers);
+    for li in 0..c.n_layers {
+        let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
+        let down = take(&mut decls, Ty::f32(vec![h, inter]), p("down"));
+        let gate = take(&mut decls, Ty::f32(vec![inter, h]), p("gate"));
+        let in_ln = take(&mut decls, Ty::f32(vec![h]), p("in_ln"));
+        let post_ln = take(&mut decls, Ty::f32(vec![h]), p("post_ln"));
+        let up = take(&mut decls, Ty::f32(vec![inter, h]), p("up"));
+        let wk = take(&mut decls, Ty::f32(vec![kv, h]), p("wk"));
+        let wo = take(&mut decls, Ty::f32(vec![qd, h]), p("wo"));
+        let wq = take(&mut decls, Ty::f32(vec![qd, h]), p("wq"));
+        let wv = take(&mut decls, Ty::f32(vec![kv, h]), p("wv"));
+        layers.push(LayerW {
+            down,
+            gate,
+            in_ln,
+            post_ln,
+            up,
+            wk,
+            wo,
+            wq,
+            wv,
+        });
+    }
+
+    let tokens = take(&mut decls, Ty::new(vec![lp], "i32"), "tokens".into());
+    let positions = take(&mut decls, Ty::new(vec![lp], "i32"), "positions".into());
+    let real_len = take(&mut decls, Ty::scalar("i32"), "real_len".into());
+
+    (
+        decls,
+        PrefillArgs {
+            embed,
+            final_norm,
+            layers,
+            tokens,
+            positions,
+            real_len,
+        },
+    )
+}
+
+/// RMSNorm over a sequence: x:[Lp, H] -> per-row x * rsqrt(mean(x*x)+eps) * w.
+fn rms_norm_seq(b: &mut Builder, x: &Val, w: &Val, k: &Consts, lp: usize, hidden: usize) -> Val {
+    let sq = b.multiply(x, x);
+    let ssum = b.reduce_add(&sq, 1, &k.zero); // [Lp]
+    let hb = b.broadcast(&k.hidden_f, &[], vec![lp]);
+    let mean = b.divide(&ssum, &hb); // [Lp]
+    let epsb = b.broadcast(&k.eps, &[], vec![lp]);
+    let meps = b.add(&mean, &epsb);
+    let r = b.rsqrt(&meps); // [Lp]
+    let rb = b.broadcast(&r, &[0], vec![lp, hidden]); // [Lp, H]
+    let xr = b.multiply(x, &rb);
+    let wb = b.broadcast(w, &[1], vec![lp, hidden]); // [H] -> [Lp, H]
+    b.multiply(&xr, &wb)
+}
+
+/// HF half-split RoPE on x:[Lp, heads, d]; cos/sin are [Lp, d] (per position).
+fn apply_rope_seq(
+    b: &mut Builder,
+    x: &Val,
+    cos: &Val,
+    sin: &Val,
+    lp: usize,
+    heads: usize,
+    d: usize,
+) -> Val {
+    let half = d / 2;
+    let cos_b = b.broadcast(cos, &[0, 2], vec![lp, heads, d]); // [Lp,d] -> [Lp,heads,d]
+    let sin_b = b.broadcast(sin, &[0, 2], vec![lp, heads, d]);
+    let xc = b.multiply(x, &cos_b);
+    let x1 = b.slice(x, &[(0, lp), (0, heads), (0, half)]);
+    let x2 = b.slice(x, &[(0, lp), (0, heads), (half, d)]);
+    let nx2 = b.negate(&x2);
+    let rh = b.concatenate(&nx2, &x1, 2);
+    let rs = b.multiply(&rh, &sin_b);
+    b.add(&xc, &rs)
+}
+
+/// Emit the complete prefill module text.
+pub fn emit_prefill(c: &Config) -> String {
+    let lp = PREFILL_LP;
+    let (decls, a) = build_prefill_arg_schema(c, lp);
+    let mut b = Builder::new();
+    let k = emit_consts(&mut b, c);
+
+    let h = c.hidden;
+    let d = c.head_dim;
+    let nq = c.n_q;
+    let nkv = c.n_kv;
+    let g = c.group();
+
+    // --- head: embed gather, per-position rope vectors, [Lp,Lp] causal mask ---
+    let tok_idx = b.reshape(&a.tokens, vec![lp, 1]);
+    let mut x = b.gather(&a.embed, &tok_idx); // [Lp, H]
+
+    let pos_idx = b.reshape(&a.positions, vec![lp, 1]);
+    let cos = b.gather(&k.cos_table, &pos_idx); // [Lp, d]
+    let sin = b.gather(&k.sin_table, &pos_idx); // [Lp, d]
+
+    // causal mask [Lp, Lp]: query i attends key j iff j <= i -> additive 0/-1e30
+    let irow = b.iota(lp);
+    let row = b.broadcast(&irow, &[0], vec![lp, lp]); // entry[i,j] = i
+    let jcol = b.iota(lp);
+    let col = b.broadcast(&jcol, &[1], vec![lp, lp]); // entry[i,j] = j
+    let le = b.compare("LE", &col, &row, "SIGNED"); // j <= i
+    let zeros = b.broadcast(&k.zero, &[], vec![lp, lp]);
+    let negs = b.broadcast(&k.neg_big, &[], vec![lp, lp]);
+    let cmask = b.select(&le, &zeros, &negs); // [Lp, Lp]
+
+    // caches start as zeros; prefill writes the [0:Lp] block and returns them
+    let mut kcache = b.broadcast(&k.zero, &[], vec![c.n_layers, MAX_SEQ, nkv, d]);
+    let mut vcache = b.broadcast(&k.zero, &[], vec![c.n_layers, MAX_SEQ, nkv, d]);
+
+    for li in 0..c.n_layers {
+        let lw = &a.layers[li];
+
+        // attention block
+        let hn = rms_norm_seq(&mut b, &x, &lw.in_ln, &k, lp, h); // [Lp, H]
+        let q = b.linear_seq(&hn, &lw.wq); // [Lp, qd]
+        let q = b.reshape(&q, vec![lp, nq, d]);
+        let kk = b.linear_seq(&hn, &lw.wk); // [Lp, kv]
+        let kk = b.reshape(&kk, vec![lp, nkv, d]);
+        let vv = b.linear_seq(&hn, &lw.wv); // [Lp, kv]
+        let vv = b.reshape(&vv, vec![lp, nkv, d]);
+
+        let q = apply_rope_seq(&mut b, &q, &cos, &sin, lp, nq, d);
+        let kk = apply_rope_seq(&mut b, &kk, &cos, &sin, lp, nkv, d);
+
+        // write the whole [Lp] K/V block at [li, 0:Lp]
+        let k_upd = b.reshape(&kk, vec![1, lp, nkv, d]);
+        kcache = b.dynamic_update_slice(&kcache, &k_upd, &[&k.layer_idx[li], &k.c0, &k.c0, &k.c0]);
+        let v_upd = b.reshape(&vv, vec![1, lp, nkv, d]);
+        vcache = b.dynamic_update_slice(&vcache, &v_upd, &[&k.layer_idx[li], &k.c0, &k.c0, &k.c0]);
+
+        // GQA scores: q head (kv*g+grp) attends kv head kv. Layout [nkv,Lp_i,g,Lp_j]
+        // so it reshapes to [nq, Lp_i, Lp_j] without a transpose (head = kv*g+grp).
+        let q4 = b.reshape(&q, vec![lp, nkv, g, d]);
+        let scores = b.dot_general(&q4, &kk, &[1], &[1], &[3], &[2], vec![nkv, lp, g, lp]);
+        let scale_b = b.broadcast(&k.scale, &[], vec![nkv, lp, g, lp]);
+        let scores = b.multiply(&scores, &scale_b);
+        let cmask_b = b.broadcast(&cmask, &[1, 3], vec![nkv, lp, g, lp]);
+        let scores = b.add(&scores, &cmask_b);
+
+        // softmax over the key axis (Lp_j, dim 3)
+        let m = b.reduce_max(&scores, 3, &k.neg_inf); // [nkv, Lp, g]
+        let m_b = b.broadcast(&m, &[0, 1, 2], vec![nkv, lp, g, lp]);
+        let sh = b.subtract(&scores, &m_b);
+        let e = b.exponential(&sh);
+        let s = b.reduce_add(&e, 3, &k.zero); // [nkv, Lp, g]
+        let s_b = b.broadcast(&s, &[0, 1, 2], vec![nkv, lp, g, lp]);
+        let attn = b.divide(&e, &s_b); // [nkv, Lp, g, Lp]
+
+        // context: o[kv,i,grp,d] = sum_j attn[kv,i,grp,j] * vv[j,kv,d]
+        let o = b.dot_general(&attn, &vv, &[0], &[1], &[3], &[0], vec![nkv, lp, g, d]);
+        let o = b.transpose(&o, &[1, 0, 2, 3]); // [Lp, nkv, g, d]
+        let o = b.reshape(&o, vec![lp, nq * d]); // [Lp, nq*d], head-major
+        let attn_out = b.linear_seq(&o, &lw.wo); // [Lp, H]
+        x = b.add(&x, &attn_out);
+
+        // MLP: down( silu(x@gate^T) * (x@up^T) )
+        let hn2 = rms_norm_seq(&mut b, &x, &lw.post_ln, &k, lp, h);
+        let gate = b.linear_seq(&hn2, &lw.gate); // [Lp, inter]
+        let up = b.linear_seq(&hn2, &lw.up); // [Lp, inter]
+        let neg = b.negate(&gate);
+        let ex = b.exponential(&neg);
+        let one_b = b.broadcast(&k.one, &[], vec![lp, c.inter]);
+        let denom = b.add(&one_b, &ex);
+        let sig = b.divide(&one_b, &denom);
+        let silu = b.multiply(&gate, &sig);
+        let act = b.multiply(&silu, &up);
+        let down = b.linear_seq(&act, &lw.down); // [Lp, H]
+        x = b.add(&x, &down);
+    }
+
+    // --- tail: final norm, take the row at real_len-1, tied LM head ---
+    let xf = rms_norm_seq(&mut b, &x, &a.final_norm, &k, lp, h); // [Lp, H]
+    let one_i = b.const_i32(1);
+    let last_idx = b.subtract(&a.real_len, &one_i); // real_len - 1
+    let last_row = b.dynamic_slice(&xf, &[&last_idx, &k.c0], vec![1, h]); // [1, H]
+    let last = b.reshape(&last_row, vec![h]); // [H]
+    let logits = b.linear(&last, &a.embed); // [V]
+
+    let sig = render_signature(&decls);
+    let cache_ty = Ty::f32(vec![c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]).render();
+    let logits_ty = Ty::f32(vec![c.vocab]).render();
+    format!(
+        "module @prefill {{\n  func.func public @main({sig}) -> ({logits_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {l}, {kc}, {vc} : {logits_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
         sig = sig,
         logits_ty = logits_ty,
         cache_ty = cache_ty,

--- a/spike/rust-emitter/validate.sh
+++ b/spike/rust-emitter/validate.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # End-to-end driver for the Rust StableHLO emitter spike (#451).
 #
-#   ./validate.sh            # P0 round-trip + full decode_step token check
+#   ./validate.sh            # P0 round-trip + decode + prefill token checks
 #   ./validate.sh p0         # P0 toolchain round-trip only
 #   ./validate.sh decode     # emit + compile + token-exact decode only
+#   ./validate.sh prefill    # emit + compile + token-exact prefill->decode
 #
 # Reuses the existing spike/openxla venv (iree-compile + iree runtime + torch +
 # transformers + safetensors). Nothing here builds or touches the mlxcel crates.
@@ -49,9 +50,23 @@ decode() {
   "$PY" "$HERE/python/run_decode.py" --mlir "$OUT/decode.mlir" --vmfb "$OUT/decode.vmfb"
 }
 
+prefill() {
+  echo "== P1: full prefill -> decode =="
+  "$EMIT" prefill "$OUT/prefill.mlir"
+  "$EMIT" decode "$OUT/decode.mlir"
+  "$IREE_COMPILE" --iree-input-type=stablehlo --iree-hal-target-backends=llvm-cpu \
+    "$OUT/prefill.mlir" -o "$OUT/prefill.vmfb"
+  "$IREE_COMPILE" --iree-input-type=stablehlo --iree-hal-target-backends=llvm-cpu \
+    "$OUT/decode.mlir" -o "$OUT/decode.vmfb"
+  "$PY" "$HERE/python/run_prefill.py" \
+    --prefill "$OUT/prefill.mlir" --prefill-vmfb "$OUT/prefill.vmfb" \
+    --decode "$OUT/decode.mlir" --decode-vmfb "$OUT/decode.vmfb"
+}
+
 case "$mode" in
   p0) p0 ;;
   decode) decode ;;
-  all) p0; decode ;;
-  *) echo "usage: validate.sh [p0|decode|all]"; exit 2 ;;
+  prefill) prefill ;;
+  all) p0; decode; prefill ;;
+  *) echo "usage: validate.sh [p0|decode|prefill|all]"; exit 2 ;;
 esac


### PR DESCRIPTION
Follow-up to #451: the Rust-native StableHLO emitter now also emits the Llama-3.2-1B `prefill` graph. The #451 spike emitted `decode_step` token-exact but skipped standalone prefill; its findings noted the one missing op was `stablehlo.gather`.

- Prefill emits and compiles (iree-compile llvm-cpu, exit 0).
- Full Rust-emitted prefill + decode greedy-decodes token-exact (48/48) against the HF temp-0 reference; decode remains 48/48 after the shared-builder additions (independently re-run).
- The one new op was `stablehlo.gather` (the embedding lookup and the per-position cos/sin lookup), as #451 predicted. GQA needed one `transpose` per layer; the KV write uses `dynamic_update_slice` (not the range-slice scatter), so it stays GPU-portable.

All changes under `spike/rust-emitter/` (own empty `[workspace]`, no mlxcel build impact). `FINDINGS.md` and `README.md` updated to drop the stale "prefill not emitted" note.

Refs #451.