### PR TITLE
feat: scaffold the OpenXLA backend crate and seam (#449 Phase 3 M1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,7 @@ dependencies = [
  "minijinja",
  "mlxcel-core",
  "mlxcel-surgery",
+ "mlxcel-xla",
  "path-clean",
  "percent-encoding",
  "reqwest",
@@ -1978,6 +1979,13 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror",
+]
+
+[[package]]
+name = "mlxcel-xla"
+version = "0.3.3"
+dependencies = [
+ "mlxcel-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "src/lib/mlxcel-core", "src/lib/mlxcel-surgery"]
+members = [".", "src/lib/mlxcel-core", "src/lib/mlxcel-surgery", "src/lib/mlxcel-xla"]
 resolver = "2"
 
 [package]
@@ -56,6 +56,13 @@ test-utils = []
 # MLX) implements `ComputeBackend`. No kernels ship with this feature today; it
 # only lands the boundary.
 experimental-backend = []
+# OpenXLA / StableHLO compiler-family backend (issue #449, ADR 0004 Track B).
+#
+# Default OFF. Pulls in the `mlxcel-xla` crate and compiles the `crate::backend::xla`
+# module, the `Backend::Xla` / `Session::Xla` enum variants, and the
+# `MLXCEL_BACKEND=xla` selection arm. Apple-Silicon and CUDA shipping builds do
+# not enable it, so they compile none of it and the seam folds to MLX as before.
+xla-backend = ["dep:mlxcel-xla"]
 # Axis A "weight-load surgery" framework.
 #
 # On by default so production `mlxcel` and `mlxcel-server` binaries expose
@@ -77,6 +84,10 @@ mlxcel-core = { path = "src/lib/mlxcel-core", default-features = false }
 
 # Axis A weight-load surgery — opt-in via the `surgery` feature above.
 mlxcel-surgery = { path = "src/lib/mlxcel-surgery", optional = true }
+
+# OpenXLA / StableHLO compiler-family backend — opt-in via the `xla-backend`
+# feature below. Default OFF; never enters Apple-Silicon or CUDA shipping builds.
+mlxcel-xla = { path = "src/lib/mlxcel-xla", optional = true }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -87,6 +87,11 @@ pub use session::Session;
 #[cfg(feature = "experimental-backend")]
 pub mod experimental;
 
+#[cfg(feature = "xla-backend")]
+pub mod xla;
+#[cfg(feature = "xla-backend")]
+pub use xla::XlaBackend;
+
 /// The forward-execution engine seam.
 ///
 /// A `ComputeBackend` produces two things: a single-sequence inference
@@ -167,6 +172,10 @@ pub enum Backend {
     /// only; no kernels are wired in here).
     #[cfg(feature = "experimental-backend")]
     Experimental(experimental::ExperimentalBackend),
+    /// The OpenXLA / StableHLO compiler-family engine (issue #449), compiled
+    /// only under the `xla-backend` feature.
+    #[cfg(feature = "xla-backend")]
+    Xla(xla::XlaBackend),
 }
 
 impl Backend {
@@ -178,6 +187,8 @@ impl Backend {
             Backend::Mlx(b) => b.name(),
             #[cfg(feature = "experimental-backend")]
             Backend::Experimental(b) => b.name(),
+            #[cfg(feature = "xla-backend")]
+            Backend::Xla(b) => b.name(),
         }
     }
 
@@ -188,6 +199,8 @@ impl Backend {
             Backend::Mlx(b) => b.load_model(model_path),
             #[cfg(feature = "experimental-backend")]
             Backend::Experimental(b) => b.load_model(model_path),
+            #[cfg(feature = "xla-backend")]
+            Backend::Xla(b) => b.load_model(model_path),
         }
     }
 
@@ -202,6 +215,8 @@ impl Backend {
             Backend::Mlx(b) => b.load_model_with_adapter(model_path, adapter_path),
             #[cfg(feature = "experimental-backend")]
             Backend::Experimental(b) => b.load_model_with_adapter(model_path, adapter_path),
+            #[cfg(feature = "xla-backend")]
+            Backend::Xla(b) => b.load_model_with_adapter(model_path, adapter_path),
         }
     }
 
@@ -222,6 +237,10 @@ impl Backend {
             Backend::Experimental(b) => {
                 b.load_model_with_tensor_parallel(model_path, adapter_path, shard_config)
             }
+            #[cfg(feature = "xla-backend")]
+            Backend::Xla(b) => {
+                b.load_model_with_tensor_parallel(model_path, adapter_path, shard_config)
+            }
         }
     }
 
@@ -239,6 +258,8 @@ impl Backend {
             Backend::Mlx(b) => b.create_session(num_layers, kv_cache_mode, token_bias),
             #[cfg(feature = "experimental-backend")]
             Backend::Experimental(b) => b.create_session(num_layers, kv_cache_mode, token_bias),
+            #[cfg(feature = "xla-backend")]
+            Backend::Xla(b) => b.create_session(num_layers, kv_cache_mode, token_bias),
         }
     }
 
@@ -250,6 +271,8 @@ impl Backend {
             Backend::Mlx(b) => b.supports_batched_serving(),
             #[cfg(feature = "experimental-backend")]
             Backend::Experimental(b) => b.supports_batched_serving(),
+            #[cfg(feature = "xla-backend")]
+            Backend::Xla(b) => b.supports_batched_serving(),
         }
     }
 }
@@ -261,7 +284,7 @@ impl Backend {
 /// so the call inlines to a direct [`MlxBackend`] construction and the seam
 /// adds no runtime dispatch on the load path or, transitively, the hot
 /// `forward()` path.
-#[cfg(not(feature = "experimental-backend"))]
+#[cfg(not(any(feature = "experimental-backend", feature = "xla-backend")))]
 #[inline]
 #[must_use]
 pub fn select_backend() -> Backend {
@@ -275,14 +298,18 @@ pub fn select_backend() -> Backend {
 /// logic is compiled only under the feature, so default builds carry none of
 /// it. The seam currently has no non-MLX engine wired in, so any non-MLX
 /// selection still resolves to a scaffold that reports it is not implemented.
-#[cfg(feature = "experimental-backend")]
+#[cfg(any(feature = "experimental-backend", feature = "xla-backend"))]
 #[must_use]
 pub fn select_backend() -> Backend {
-    // The plug-in point for a future non-MLX backend. Until an engine is wired
-    // in (a separate hardware-feasibility gate must precede any kernel work),
-    // every selection but the explicit experimental opt-in falls back to MLX.
+    // The plug-in point for the optional non-MLX backends. Each opt-in arm is
+    // compiled only under its own feature; with neither feature this function is
+    // the const MLX form above. Any selection but an explicit opt-in falls back
+    // to MLX.
     match std::env::var("MLXCEL_BACKEND").ok().as_deref() {
+        #[cfg(feature = "experimental-backend")]
         Some("experimental") => Backend::Experimental(experimental::ExperimentalBackend::new()),
+        #[cfg(feature = "xla-backend")]
+        Some("xla") => Backend::Xla(xla::XlaBackend::new()),
         _ => Backend::Mlx(MlxBackend::new()),
     }
 }

--- a/src/backend/session.rs
+++ b/src/backend/session.rs
@@ -38,7 +38,11 @@
 
 use mlxcel_core::MlxArray;
 use mlxcel_core::generate::{GenerationStats, LanguageModel, SamplingConfig};
+#[cfg(feature = "xla-backend")]
+use mlxcel_core::session::InferenceSession;
 use mlxcel_core::session::{MlxInferenceSession, SessionCapabilities};
+#[cfg(feature = "xla-backend")]
+use mlxcel_xla::XlaInferenceSession;
 
 /// The inference session selected for a load.
 ///
@@ -50,6 +54,12 @@ use mlxcel_core::session::{MlxInferenceSession, SessionCapabilities};
 pub enum Session {
     /// The MLX single-sequence session, wrapping `CxxGenerator`.
     Mlx(MlxInferenceSession),
+    /// The OpenXLA / StableHLO compiler-family session (issue #449), compiled
+    /// only under the `xla-backend` feature. It owns its KV and samples
+    /// on-device, so it self-drives the engine-neutral prefill / decode_step
+    /// contract and ignores the threaded MLX model and sampling config (greedy).
+    #[cfg(feature = "xla-backend")]
+    Xla(XlaInferenceSession),
 }
 
 impl Session {
@@ -60,12 +70,22 @@ impl Session {
         Session::Mlx(session)
     }
 
+    /// Wrap an [`XlaInferenceSession`] as the active session.
+    #[cfg(feature = "xla-backend")]
+    #[inline]
+    #[must_use]
+    pub fn xla(session: XlaInferenceSession) -> Self {
+        Session::Xla(session)
+    }
+
     /// What this session can do, so the control plane can gate features.
     #[inline]
     #[must_use]
     pub fn capabilities(&self) -> SessionCapabilities {
         match self {
             Session::Mlx(s) => s.capabilities(),
+            #[cfg(feature = "xla-backend")]
+            Session::Xla(s) => s.capabilities(),
         }
     }
 
@@ -74,6 +94,11 @@ impl Session {
     pub fn reset_with_model<M: LanguageModel + ?Sized>(&mut self, model: &M) {
         match self {
             Session::Mlx(s) => s.reset_with_model(model),
+            #[cfg(feature = "xla-backend")]
+            Session::Xla(_s) => {
+                // The XLA session resets its own KV on the next prefill; the MLX
+                // model is not used by this engine.
+            }
         }
     }
 
@@ -88,6 +113,14 @@ impl Session {
     ) -> Vec<i32> {
         match self {
             Session::Mlx(s) => s.generate(model, prompt_tokens, max_tokens, sampling),
+            // The XLA session self-drives via prefill / decode_step and ignores
+            // the MLX model and the sampling config (greedy). It surfaces an
+            // empty result until the engine is wired in; the control plane uses
+            // the object-safe contract directly for error-visible paths.
+            #[cfg(feature = "xla-backend")]
+            Session::Xla(s) => s
+                .generate_greedy(prompt_tokens, max_tokens, &[])
+                .unwrap_or_default(),
         }
     }
 
@@ -106,6 +139,10 @@ impl Session {
             Session::Mlx(s) => {
                 s.generate_streaming(model, prompt_tokens, max_tokens, sampling, on_token)
             }
+            #[cfg(feature = "xla-backend")]
+            Session::Xla(s) => s
+                .generate_streaming_greedy(prompt_tokens, max_tokens, &[], on_token)
+                .unwrap_or_default(),
         }
     }
 
@@ -133,6 +170,13 @@ impl Session {
                 sampling,
                 on_token,
             ),
+            // The XLA session is single-sequence text; it has no multimodal
+            // capability, so it ignores the input embeddings and drives the token
+            // stream from the prompt ids.
+            #[cfg(feature = "xla-backend")]
+            Session::Xla(s) => s
+                .generate_streaming_greedy(prompt_tokens, max_tokens, &[], on_token)
+                .unwrap_or_default(),
         }
     }
 
@@ -147,6 +191,12 @@ impl Session {
     ) -> (Vec<i32>, GenerationStats) {
         match self {
             Session::Mlx(s) => s.generate_with_stats(model, prompt_tokens, max_tokens, sampling),
+            #[cfg(feature = "xla-backend")]
+            Session::Xla(s) => (
+                s.generate_greedy(prompt_tokens, max_tokens, &[])
+                    .unwrap_or_default(),
+                GenerationStats::default(),
+            ),
         }
     }
 
@@ -170,6 +220,12 @@ impl Session {
                 max_tokens,
                 sampling,
             ),
+            #[cfg(feature = "xla-backend")]
+            Session::Xla(s) => (
+                s.generate_greedy(prompt_tokens, max_tokens, &[])
+                    .unwrap_or_default(),
+                GenerationStats::default(),
+            ),
         }
     }
 
@@ -182,6 +238,10 @@ impl Session {
     ) -> Vec<f32> {
         match self {
             Session::Mlx(s) => s.evaluate_loglikelihoods(model, prompt_tokens),
+            // Perplexity evaluation is not part of the single-sequence XLA
+            // session; it returns no per-token scores.
+            #[cfg(feature = "xla-backend")]
+            Session::Xla(_s) => Vec::new(),
         }
     }
 }

--- a/src/backend/tests.rs
+++ b/src/backend/tests.rs
@@ -107,6 +107,10 @@ fn mlx_session_threads_the_token_bias_through() {
             assert_eq!(s.token_bias().len(), 1);
             assert!(s.token_bias().contains(5));
         }
+        #[cfg(feature = "xla-backend")]
+        Session::Xla(_) => {
+            unreachable!("select_backend defaults to MLX without MLXCEL_BACKEND=xla")
+        }
     }
 }
 
@@ -123,4 +127,39 @@ fn experimental_backend_session_creation_errors() {
         result.is_err(),
         "the experimental scaffold must report it has no session engine"
     );
+}
+
+/// The OpenXLA backend produces a single-sequence session whose token-level
+/// primitives report they are not wired to an engine yet (the Phase 3 M1
+/// scaffold). `load_model` is the MLX batched path and errors here. Compiled
+/// only under the optional `xla-backend` feature; default builds carry none of
+/// it.
+#[cfg(feature = "xla-backend")]
+#[test]
+fn xla_backend_creates_a_single_sequence_session_scaffold() {
+    let backend = XlaBackend::new();
+    assert_eq!(backend.name(), "xla");
+    assert!(!backend.supports_batched_serving());
+    assert!(
+        backend.load_model(std::path::Path::new("/tmp/x")).is_err(),
+        "the XLA backend drives generation through the session, not load_model"
+    );
+
+    let session = backend
+        .create_session(16, KVCacheMode::Fp16, TokenBiasMap::new())
+        .expect("xla session creation must succeed");
+    let caps = session.capabilities();
+    assert!(
+        !caps.batched_serving && !caps.paged_kv && !caps.speculative_decode && !caps.multimodal,
+        "the XLA session advertises the single-sequence floor"
+    );
+
+    match session {
+        Session::Xla(mut s) => {
+            // The self-contained drive loop surfaces the not-wired stub instead
+            // of panicking; real execution lands with the IREE FFI milestone.
+            assert!(s.generate_greedy(&[1, 2, 3], 4, &[]).is_err());
+        }
+        Session::Mlx(_) => unreachable!("XlaBackend::create_session yields an XLA session"),
+    }
 }

--- a/src/backend/xla.rs
+++ b/src/backend/xla.rs
@@ -1,0 +1,115 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! OpenXLA / StableHLO compute backend (issue #449, ADR 0004 Track B).
+//!
+//! Compiled only under the `xla-backend` feature, so Apple-Silicon and CUDA
+//! shipping builds never compile it. This is the real non-MLX engine slot the
+//! `experimental` scaffold reserved: it produces a [`Session`] backed by
+//! [`mlxcel_xla::XlaInferenceSession`], which fills in the engine-neutral
+//! `InferenceSession` contract (token-level `prefill` / `decode_step` with
+//! on-device sampling).
+//!
+//! # Why `load_model` is not the entry point here
+//!
+//! The MLX [`load_model`](ComputeBackend::load_model) boundary returns the
+//! concrete MLX [`LoadedModel`] for the server batched-serving path. The OpenXLA
+//! backend has no `LoadedModel`: it runs a compiled StableHLO graph and owns its
+//! KV and sampling inside the session, so it drives generation through
+//! [`create_session`](ComputeBackend::create_session) and the self-contained
+//! `prefill` / `decode_step` loop, and `load_model` returns an error pointing the
+//! caller at the session path. Threading the model directory and config into
+//! session creation (today `create_session` takes only `num_layers`) is part of
+//! the control-plane wiring milestone, together with the IREE execution path.
+
+use std::path::Path;
+
+use anyhow::Result;
+use mlxcel_core::TokenBiasMap;
+use mlxcel_core::cache::KVCacheMode;
+use mlxcel_xla::XlaInferenceSession;
+
+use super::{ComputeBackend, Session};
+use crate::LoadedModel;
+use crate::distributed::ShardConfig;
+use crate::tokenizer::MlxcelTokenizer;
+
+/// Handle for the OpenXLA / StableHLO compiler-family backend.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct XlaBackend;
+
+impl XlaBackend {
+    /// Construct the OpenXLA backend handle.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+fn load_unsupported<T>() -> Result<T> {
+    anyhow::bail!(
+        "the OpenXLA backend drives generation through its self-contained \
+         inference session (create_session, then prefill / decode_step), not the \
+         MLX load-boundary path; load_model is the MLX batched-serving entry and \
+         is not provided by this backend"
+    )
+}
+
+impl ComputeBackend for XlaBackend {
+    fn name(&self) -> &'static str {
+        "xla"
+    }
+
+    fn load_model(&self, _model_path: &Path) -> Result<(LoadedModel, MlxcelTokenizer)> {
+        load_unsupported()
+    }
+
+    fn load_model_with_adapter(
+        &self,
+        _model_path: &Path,
+        _adapter_path: &Path,
+    ) -> Result<(LoadedModel, MlxcelTokenizer)> {
+        load_unsupported()
+    }
+
+    fn load_model_with_tensor_parallel(
+        &self,
+        _model_path: &Path,
+        _adapter_path: Option<&Path>,
+        _shard_config: &ShardConfig,
+    ) -> Result<(LoadedModel, MlxcelTokenizer)> {
+        load_unsupported()
+    }
+
+    fn create_session(
+        &self,
+        num_layers: usize,
+        _kv_cache_mode: KVCacheMode,
+        _token_bias: TokenBiasMap,
+    ) -> Result<Session> {
+        // M1 scaffold: produce the session so the seam is exercisable. The model
+        // directory is not threaded through `create_session` yet (the MLX seam
+        // loads it via `load_model` first); wiring the model path and config into
+        // session creation lands with the IREE execution / CLI milestone, at
+        // which point `prefill` / `decode_step` bind to the compiled graphs.
+        let session = XlaInferenceSession::load(Path::new("."), num_layers)
+            .map_err(|e| anyhow::anyhow!(e))?;
+        Ok(Session::xla(session))
+    }
+
+    fn supports_batched_serving(&self) -> bool {
+        false
+    }
+}

--- a/src/lib/mlxcel-xla/Cargo.toml
+++ b/src/lib/mlxcel-xla/Cargo.toml
@@ -1,0 +1,24 @@
+# OpenXLA / StableHLO compiler-family inference backend for mlxcel (issue #449,
+# ADR 0004 Track B). Default-off: the root crate pulls this in only under the
+# `xla-backend` feature, so Apple-Silicon and CUDA shipping builds never compile
+# it. This crate is the home of the engine that fills in the engine-neutral
+# `InferenceSession` contract from mlxcel-core.
+#
+# M1 (this commit) is the crate + seam scaffold: the session implements the
+# contract and the self-contained greedy drive loop, but the actual graph
+# execution (the IREE runtime C API via FFI) is the next milestone, so
+# prefill / decode_step return a clear not-wired error.
+[package]
+name = "mlxcel-xla"
+version = "0.3.3"
+edition = "2024"
+description = "OpenXLA / StableHLO compiler-family inference backend for mlxcel (default-off)"
+repository = "https://github.com/lablup/mlxcel"
+license = "Apache-2.0"
+
+[dependencies]
+# The engine-neutral inference-session contract lives in mlxcel-core. This
+# depends on mlxcel-core only for that trait; a later refactor could extract the
+# contract to a leaf crate so the non-MLX backend does not compile MLX. The
+# default build is unaffected either way (this crate is off unless `xla-backend`).
+mlxcel-core = { path = "../mlxcel-core" }

--- a/src/lib/mlxcel-xla/src/lib.rs
+++ b/src/lib/mlxcel-xla/src/lib.rs
@@ -1,0 +1,212 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! OpenXLA / StableHLO compiler-family inference backend (issue #449, ADR 0004
+//! Track B). Default-off: the root crate compiles this only under the
+//! `xla-backend` feature, so Apple-Silicon and CUDA shipping builds never touch
+//! it.
+//!
+//! This crate hosts [`XlaInferenceSession`], the engine that fills in the
+//! engine-neutral [`InferenceSession`](mlxcel_core::session::InferenceSession)
+//! contract for the StableHLO/MLIR compiler family. The validated route (issue
+//! #449 Phase 0 to 2b) is: a model is authored once as a StableHLO graph (the
+//! Rust emitter, issue #451, or the JAX reference), `iree-compile` lowers
+//! `prefill` and a single-token `decode_step` to a vmfb, and the IREE runtime
+//! executes them with weights resident and sampling (argmax) on-device, so a
+//! step returns a token id rather than logits.
+//!
+//! # Milestone state
+//!
+//! This is the crate + seam scaffold (Phase 3 M1). It wires the session into the
+//! `ComputeBackend` seam and implements the self-contained greedy drive loop
+//! ([`XlaInferenceSession::generate_greedy`] /
+//! [`XlaInferenceSession::generate_streaming_greedy`]) over the object-safe
+//! [`InferenceSession::prefill`] / [`InferenceSession::decode_step`] primitives.
+//! The actual graph execution (the IREE runtime C API via FFI, loading the vmfb
+//! and uploading weights) is the next milestone, so [`InferenceSession::prefill`]
+//! and [`InferenceSession::decode_step`] return [`NOT_WIRED`] for now. Nothing in
+//! the default build depends on this crate.
+
+use std::path::{Path, PathBuf};
+
+use mlxcel_core::session::{InferenceSession, SessionCapabilities};
+
+/// Error returned by the scaffold's token-level primitives until the IREE
+/// execution path is wired in (Phase 3, the milestone after this one).
+pub const NOT_WIRED: &str = "the OpenXLA inference session is a crate and seam scaffold (issue #449 \
+     Phase 3 M1); graph execution through the IREE runtime C API is the next \
+     milestone, so prefill / decode_step are not bound to an engine yet";
+
+/// The single-sequence OpenXLA inference session.
+///
+/// Owns its per-sequence KV state and runs generation token-in / token-out with
+/// on-device sampling, the shape ADR 0004 reserves for a compiler-family backend.
+/// In this milestone it holds the load inputs and the drive loop; the compiled
+/// graphs, resident weights, device handles, and live KV land with the execution
+/// milestone.
+pub struct XlaInferenceSession {
+    model_path: PathBuf,
+    num_layers: usize,
+}
+
+impl XlaInferenceSession {
+    /// Prepare a session for a model directory.
+    ///
+    /// In a later milestone this compiles or loads the exported `prefill` and
+    /// `decode_step` vmfbs and uploads the (optionally int4) weights to the
+    /// device. For now it records the inputs so the seam wiring is exercisable.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session cannot be prepared (none in this
+    /// milestone).
+    pub fn load(model_path: &Path, num_layers: usize) -> Result<Self, String> {
+        Ok(Self {
+            model_path: model_path.to_path_buf(),
+            num_layers,
+        })
+    }
+
+    /// Layer count the session was loaded with.
+    #[must_use]
+    pub fn num_layers(&self) -> usize {
+        self.num_layers
+    }
+
+    /// The model directory backing this session.
+    #[must_use]
+    pub fn model_path(&self) -> &Path {
+        &self.model_path
+    }
+
+    /// Self-contained greedy generation over the object-safe contract.
+    ///
+    /// Seeds KV with the prompt prefix, then advances one token per step until an
+    /// EOS id or the token budget. This is the drive-path the control plane uses
+    /// for a backend whose session owns its KV and samples on-device, so it does
+    /// not thread an MLX model. Sampling is greedy (argmax inside `decode_step`).
+    ///
+    /// # Errors
+    ///
+    /// Propagates the `prefill` / `decode_step` error (currently [`NOT_WIRED`]),
+    /// or errors on an empty prompt.
+    pub fn generate_greedy(
+        &mut self,
+        prompt_tokens: &[i32],
+        max_new_tokens: usize,
+        eos_token_ids: &[i32],
+    ) -> Result<Vec<i32>, String> {
+        self.generate_streaming_greedy(prompt_tokens, max_new_tokens, eos_token_ids, |_| true)
+    }
+
+    /// Self-contained greedy generation with a per-token callback.
+    ///
+    /// Invokes `on_token` with each newly generated token; returning `false`
+    /// stops generation (the token that triggered the stop is still included).
+    ///
+    /// # Errors
+    ///
+    /// Propagates the `prefill` / `decode_step` error (currently [`NOT_WIRED`]),
+    /// or errors on an empty prompt.
+    pub fn generate_streaming_greedy<F: FnMut(i32) -> bool>(
+        &mut self,
+        prompt_tokens: &[i32],
+        max_new_tokens: usize,
+        eos_token_ids: &[i32],
+        mut on_token: F,
+    ) -> Result<Vec<i32>, String> {
+        if prompt_tokens.is_empty() {
+            return Err("XLA generation requires a non-empty prompt".to_string());
+        }
+        // Seed KV with all but the last prompt token; the last token is the first
+        // input to decode_step, which returns the first generated token. This
+        // keeps decode_step's "given the previously emitted token" contract exact
+        // and avoids double-counting the last prompt token in the cache.
+        let split = prompt_tokens.len() - 1;
+        self.prefill(&prompt_tokens[..split])?;
+        let mut current = prompt_tokens[split];
+        let mut out = Vec::with_capacity(max_new_tokens);
+        for _ in 0..max_new_tokens {
+            let next = self.decode_step(current)?;
+            out.push(next);
+            let keep_going = on_token(next);
+            if !keep_going || eos_token_ids.contains(&next) {
+                break;
+            }
+            current = next;
+        }
+        Ok(out)
+    }
+}
+
+impl InferenceSession for XlaInferenceSession {
+    fn capabilities(&self) -> SessionCapabilities {
+        SessionCapabilities::single_sequence()
+    }
+
+    fn prefill(&mut self, _token_ids: &[i32]) -> Result<(), String> {
+        Err(NOT_WIRED.to_string())
+    }
+
+    fn decode_step(&mut self, _token: i32) -> Result<i32, String> {
+        Err(NOT_WIRED.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session() -> XlaInferenceSession {
+        XlaInferenceSession::load(Path::new("/tmp/xla-model"), 16).unwrap()
+    }
+
+    #[test]
+    fn capabilities_are_single_sequence() {
+        let c = session().capabilities();
+        assert!(!c.batched_serving);
+        assert!(!c.paged_kv);
+        assert!(!c.speculative_decode);
+        assert!(!c.multimodal);
+    }
+
+    #[test]
+    fn load_records_inputs() {
+        let s = session();
+        assert_eq!(s.num_layers(), 16);
+        assert_eq!(s.model_path(), Path::new("/tmp/xla-model"));
+    }
+
+    #[test]
+    fn token_primitives_report_not_wired() {
+        let mut s = session();
+        assert_eq!(s.prefill(&[1, 2, 3]).unwrap_err(), NOT_WIRED);
+        assert_eq!(s.decode_step(1).unwrap_err(), NOT_WIRED);
+    }
+
+    #[test]
+    fn greedy_surfaces_the_stub_error_not_a_panic() {
+        let mut s = session();
+        assert_eq!(
+            s.generate_greedy(&[1, 2, 3], 8, &[2]).unwrap_err(),
+            NOT_WIRED
+        );
+    }
+
+    #[test]
+    fn empty_prompt_is_rejected() {
+        let mut s = session();
+        assert!(s.generate_greedy(&[], 8, &[2]).is_err());
+    }
+}


### PR DESCRIPTION
Phase 3 M1 (#449): the default-off `mlxcel-xla` crate and the compute-backend seam wiring, the first step of integrating the OpenXLA / StableHLO backend behind the #448 inference-session contract.

- New crate `mlxcel-xla` provides `XlaInferenceSession`: it implements the engine-neutral `InferenceSession` contract (`capabilities` / `prefill` / `decode_step`) plus the self-contained greedy drive loop (`generate_greedy` / `generate_streaming_greedy`) a backend that owns its KV and samples on-device uses instead of threading an MLX model.
- The seam gains a `cfg`-gated `Backend::Xla` / `Session::Xla` behind a new `xla-backend` feature; `select_backend` recognizes `MLXCEL_BACKEND=xla`, mirroring the `experimental` scaffold. `XlaBackend::load_model` errors (the OpenXLA path drives generation through the session, not the MLX load boundary).
- Execution is stubbed: `prefill` / `decode_step` return a clear not-wired error so the drive loop surfaces it rather than panicking. Binding the IREE runtime C API (load the compiled StableHLO vmfb, run prefill / decode_step) is the next milestone, together with threading the model directory through session creation.

Verified: the default build is unaffected (`mlxcel-xla` is an optional dep gated off, not compiled), `cargo check --features xla-backend` builds the lib and tests, fmt and clippy are clean, and the crate plus seam unit tests pass.

Refs #449.