### PR TITLE
feat: prove Rust to IREE FFI on aarch64 via the prebuilt dist (#449 Phase 3 M2)

### DIFF
--- a/spike/iree-ffi/.gitignore
+++ b/spike/iree-ffi/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.vmfb
+iree-dist/

--- a/spike/iree-ffi/Cargo.toml
+++ b/spike/iree-ffi/Cargo.toml
@@ -1,0 +1,12 @@
+# FFI-gate spike (issue #449 Phase 3 M2): prove Rust can drive IREE execution on
+# this aarch64 box via the prebuilt iree-dist runtime, with no IREE source build.
+# Standalone: own [workspace] so it never joins the mlxcel build graph.
+[package]
+name = "iree-ffi-gate"
+version = "0.0.1"
+edition = "2024"
+
+[workspace]
+
+[build-dependencies]
+cc = "1"

--- a/spike/iree-ffi/FINDINGS.md
+++ b/spike/iree-ffi/FINDINGS.md
@@ -1,0 +1,87 @@
+# FFI gate findings: running IREE from Rust on aarch64 (issue #449 Phase 3 M2)
+
+## Verdict
+
+The gate passes. A Rust program drives IREE execution of a compiled vmfb on this
+aarch64 box (`spark-101`, GB10) and gets the correct result, using only the
+**prebuilt IREE distribution, with no IREE source build**. So the substrate the
+`mlxcel-xla` backend needs is feasible and cheap: download one tarball, build a
+thin C shim, FFI to it. The earlier worry (build libIREE from source for aarch64)
+is avoided.
+
+```
+IREE via Rust FFI: a + b = [11.0, 22.0, 33.0, 44.0]
+FFI GATE: PASS
+```
+
+## The substrate
+
+IREE publishes `iree-dist-<ver>-linux-aarch64.tar.xz` on GitHub releases (85 MB).
+It contains everything needed:
+
+- `lib/` static libs, including the single bundled `libiree_runtime_unified.a`
+  (plus `libflatcc_*.a`),
+- `include/iree/runtime/*.h` and the HAL headers (the C API),
+- `bin/iree-compile` (compiles StableHLO to a vmfb matching this runtime).
+
+So the pip `iree-base-runtime` (Python-only `.abi3.so`, no linkable C lib or
+headers) is not the path; the release dist is.
+
+## Architecture (this is the M2 shape)
+
+A thin C shim (`iree_gate.c`) calls the IREE runtime C API and exposes a flat C
+ABI; Rust FFIs to that, so Rust never binds the IREE runtime structs directly.
+`mlxcel-xla` will use the same split: a C shim over the runtime, a Rust FFI, with
+the shim loading the prefill / decode_step vmfbs (the #451 emitter output) and the
+weights and running the token loop.
+
+The runtime call sequence used:
+
+```
+instance_options_initialize / use_all_available_drivers / instance_create
+  -> instance_try_create_default_device("local-task")
+  -> session_create_with_device
+  -> session_append_bytecode_module_from_file(vmfb)
+  -> call_initialize_by_name("module.main")
+  -> hal_buffer_view_allocate_buffer_copy (inputs)
+  -> call_inputs_push_back_buffer_view ; call_invoke
+  -> call_outputs_pop_front_buffer_view ; hal_device_transfer_d2h (read output)
+```
+
+## Two non-obvious requirements (the time sinks, recorded for M2)
+
+1. **The dist leaves the system allocator to the application.** Its
+   `iree_allocator_system()` is compiled out unless `IREE_ALLOCATOR_SYSTEM_CTL`
+   is defined, so the shim defines a libc malloc / calloc / realloc / free control
+   function and points `IREE_ALLOCATOR_SYSTEM_CTL` at it before the IREE headers.
+
+2. **Linking the static runtime needs a specific order and set** (GNU ld is
+   single-pass, left to right):
+   - the shim object first (it references IREE),
+   - `--whole-archive libiree_runtime_unified.a --no-whole-archive` so the
+     `local-task` HAL driver registration objects are not dropped (otherwise
+     `try_create_default_device` finds no device),
+   - then a `--start-group` of `libflatcc_runtime.a` + `libflatcc_parsing.a`
+     (vmfb/flatbuffer parsing), `-lgcc` (the aarch64 outline-atomics
+     `__aarch64_ldadd4_acq_rel` etc.), `-lm` (CPU-kernel math: `expf`, `tanh`,
+     `erf`, ...), `-lpthread`, `-ldl`.
+
+   `build.rs` emits these as ordered `cargo:rustc-link-arg`s so they land after
+   the cc-linked shim.
+
+## What this means for M2 / Phase 3
+
+- `mlxcel-xla` gains a C shim + `build.rs` of this shape, with the IREE dist as a
+  build input (download to a known path, or vendor, set via an env var like
+  `IREE_DIST`). Pin one dist version and use its `iree-compile` for the emitter
+  output so the vmfb and runtime match.
+- The shim grows from "run add" to: load the prefill and decode vmfbs, upload the
+  (int4 or fp16) weights as resident device buffers once, and run prefill /
+  decode_step with on-device argmax (the Phase 2b pattern), returning a token id.
+- CPU (`local-task`) is proven here; the dist also has the `cuda` driver, so the
+  same shim runs on the GB10 by selecting the cuda device (Phase 2b showed the
+  GPU path works through IREE).
+
+## Reproduce
+
+See `README.md`.

--- a/spike/iree-ffi/README.md
+++ b/spike/iree-ffi/README.md
@@ -1,0 +1,40 @@
+# IREE-from-Rust FFI gate (issue #449 Phase 3 M2)
+
+Proves Rust can drive IREE execution of a compiled vmfb on aarch64 via the
+prebuilt IREE distribution, with no IREE source build. The substrate the
+`mlxcel-xla` backend needs. See `FINDINGS.md` for the verdict and the linking
+recipe.
+
+Standalone (own `[workspace]`); not part of the mlxcel build.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `iree_gate.c` | C shim over the IREE runtime C API (libc system allocator + run a vmfb). |
+| `build.rs` | Compiles the shim against the dist headers, links `libiree_runtime_unified.a` + flatcc + libgcc + libm. |
+| `src/main.rs` | Rust FFI to the shim; runs `add.vmfb` and checks `a + b`. |
+| `add.mlir` | Trivial StableHLO (`add`) used as the test graph. |
+
+## Reproduce
+
+```bash
+# 1. Get the prebuilt IREE dist for aarch64 (runtime libs + headers + iree-compile).
+cd /tmp
+curl -sSL -o iree-dist.tar.xz \
+  https://github.com/iree-org/iree/releases/download/iree-3.12.0rc20260626/iree-dist-3.12.0rc20260626-linux-aarch64.tar.xz
+mkdir -p iree-dist && tar xf iree-dist.tar.xz -C iree-dist
+export IREE_DIST=/tmp/iree-dist
+
+# 2. Compile the test graph to a vmfb with the dist's iree-compile.
+cd <this dir>
+"$IREE_DIST/bin/iree-compile" --iree-input-type=stablehlo \
+  --iree-hal-target-device=local --iree-hal-local-target-device-backends=llvm-cpu \
+  add.mlir -o add.vmfb
+
+# 3. Build + run the Rust FFI gate.
+cargo run --release -- add.vmfb
+# -> "FFI GATE: PASS (Rust drove an IREE vmfb on aarch64 via the prebuilt runtime)"
+```
+
+`IREE_DIST` must point at the extracted dist (it has `include/`, `lib/`, `bin/`).

--- a/spike/iree-ffi/add.mlir
+++ b/spike/iree-ffi/add.mlir
@@ -1,0 +1,4 @@
+func.func @main(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4xf32> {
+  %0 = stablehlo.add %a, %b : tensor<4xf32>
+  return %0 : tensor<4xf32>
+}

--- a/spike/iree-ffi/build.rs
+++ b/spike/iree-ffi/build.rs
@@ -1,0 +1,47 @@
+// Compile the C shim against the prebuilt IREE dist headers and link the single
+// bundled runtime static lib. Point IREE_DIST at the extracted
+// iree-dist-<ver>-linux-aarch64 tree (it has include/, lib/, bin/).
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let dist = env::var("IREE_DIST").expect("set IREE_DIST to the extracted iree-dist tree");
+    let dist = PathBuf::from(dist);
+    let include = dist.join("include");
+    let lib = dist.join("lib");
+
+    println!("cargo:rerun-if-changed=iree_gate.c");
+    println!("cargo:rerun-if-env-changed=IREE_DIST");
+
+    cc::Build::new()
+        .file("iree_gate.c")
+        .include(&include)
+        .compile("iree_gate");
+
+    println!("cargo:rustc-link-search=native={}", lib.display());
+    // Emit all of the IREE link bits as ordered link-args so they land AFTER the
+    // shim (which the cc crate links first and which references IREE symbols),
+    // and so libgcc lands AFTER the runtime archive: the aarch64 outline-atomics
+    // helpers (__aarch64_ldadd4_acq_rel, __aarch64_cas8_rel, ...) the runtime
+    // uses are defined in libgcc, and ld is single-pass left-to-right.
+    //
+    // --whole-archive keeps the HAL driver registration objects (local-task)
+    // that try_create_default_device needs from being dropped as unreferenced.
+    println!("cargo:rustc-link-arg=-Wl,--whole-archive");
+    println!("cargo:rustc-link-arg=-l:libiree_runtime_unified.a");
+    println!("cargo:rustc-link-arg=-Wl,--no-whole-archive");
+    // The unified archive references flatcc (vmfb/flatbuffer parsing) and the
+    // aarch64 outline-atomics in libgcc. Wrap them in a group so ld re-scans to
+    // resolve any cross-references regardless of order.
+    // flatcc (vmfb parsing), libgcc (aarch64 outline atomics), libm (CPU kernel
+    // math: expf/tanh/erf/...), and pthread/dl all sit after the runtime archive
+    // because the unified archive references them; the group lets ld re-scan.
+    println!("cargo:rustc-link-arg=-Wl,--start-group");
+    println!("cargo:rustc-link-arg=-l:libflatcc_runtime.a");
+    println!("cargo:rustc-link-arg=-l:libflatcc_parsing.a");
+    println!("cargo:rustc-link-arg=-lgcc");
+    println!("cargo:rustc-link-arg=-lm");
+    println!("cargo:rustc-link-arg=-lpthread");
+    println!("cargo:rustc-link-arg=-ldl");
+    println!("cargo:rustc-link-arg=-Wl,--end-group");
+}

--- a/spike/iree-ffi/iree_gate.c
+++ b/spike/iree-ffi/iree_gate.c
@@ -1,0 +1,129 @@
+// Minimal C shim over the IREE runtime C API: load a vmfb and invoke
+// module.main with two [n]f32 inputs, returning the [n]f32 output. This is the
+// FFI-gate proof (issue #449 Phase 3 M2) and the shape the mlxcel-xla backend
+// will use: a thin C shim over the prebuilt IREE runtime, with Rust calling a
+// flat C ABI rather than binding the runtime structs directly.
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// The iree-dist build leaves the system allocator to the application (its
+// iree_allocator_system() is gated on IREE_ALLOCATOR_SYSTEM_CTL). Point it at a
+// libc malloc/free control function, defined below, before the IREE headers.
+#define IREE_ALLOCATOR_SYSTEM_CTL iree_gate_libc_ctl
+
+#include <iree/runtime/api.h>
+#include <iree/hal/buffer_view_util.h>
+#include <iree/hal/buffer_transfer.h>
+
+// libc-backed implementation of the system allocator control function.
+iree_status_t iree_gate_libc_ctl(void* self, iree_allocator_command_t command,
+                                 const void* params, void** inout_ptr) {
+  (void)self;
+  switch (command) {
+    case IREE_ALLOCATOR_COMMAND_MALLOC:
+    case IREE_ALLOCATOR_COMMAND_CALLOC:
+    case IREE_ALLOCATOR_COMMAND_REALLOC: {
+      const iree_allocator_alloc_params_t* p =
+          (const iree_allocator_alloc_params_t*)params;
+      iree_host_size_t len = p->byte_length ? p->byte_length : 1;
+      void* ptr = NULL;
+      if (command == IREE_ALLOCATOR_COMMAND_CALLOC) {
+        ptr = calloc(1, len);
+      } else if (command == IREE_ALLOCATOR_COMMAND_REALLOC) {
+        ptr = realloc(*inout_ptr, len);
+      } else {
+        ptr = malloc(len);
+      }
+      if (!ptr) return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED);
+      *inout_ptr = ptr;
+      return iree_ok_status();
+    }
+    case IREE_ALLOCATOR_COMMAND_FREE:
+      free(*inout_ptr);
+      return iree_ok_status();
+    default:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  }
+}
+
+#define GATE_CHECK(expr)                                                 \
+  do {                                                                   \
+    iree_status_t _s = (expr);                                          \
+    if (!iree_status_is_ok(_s)) {                                       \
+      int _c = (int)iree_status_code(_s);                               \
+      fprintf(stderr, "iree_gate: %s failed (status %d)\n", #expr, _c); \
+      iree_status_ignore(_s);                                           \
+      return _c ? _c : 1;                                               \
+    }                                                                    \
+  } while (0)
+
+// Returns 0 on success; a,b and out are host arrays of n f32.
+int iree_gate_run_add(const char* vmfb_path, const float* a, const float* b,
+                      int32_t n, float* out) {
+  iree_runtime_instance_options_t inst_opts;
+  iree_runtime_instance_options_initialize(&inst_opts);
+  iree_runtime_instance_options_use_all_available_drivers(&inst_opts);
+  iree_runtime_instance_t* instance = NULL;
+  GATE_CHECK(iree_runtime_instance_create(&inst_opts, iree_allocator_system(),
+                                          &instance));
+
+  iree_hal_device_t* device = NULL;
+  GATE_CHECK(iree_runtime_instance_try_create_default_device(
+      instance, iree_make_cstring_view("local-task"), &device));
+
+  iree_runtime_session_options_t sess_opts;
+  iree_runtime_session_options_initialize(&sess_opts);
+  iree_runtime_session_t* session = NULL;
+  GATE_CHECK(iree_runtime_session_create_with_device(
+      instance, &sess_opts, device,
+      iree_runtime_instance_host_allocator(instance), &session));
+
+  GATE_CHECK(
+      iree_runtime_session_append_bytecode_module_from_file(session, vmfb_path));
+
+  iree_runtime_call_t call;
+  GATE_CHECK(iree_runtime_call_initialize_by_name(
+      session, iree_make_cstring_view("module.main"), &call));
+
+  iree_hal_allocator_t* allocator =
+      iree_runtime_session_device_allocator(session);
+  iree_hal_buffer_params_t params = {
+      .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+      .access = IREE_HAL_MEMORY_ACCESS_ALL,
+      .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
+  };
+  iree_hal_dim_t shape[1] = {(iree_hal_dim_t)n};
+  iree_host_size_t bytes = (iree_host_size_t)n * sizeof(float);
+
+  iree_hal_buffer_view_t* arg0 = NULL;
+  GATE_CHECK(iree_hal_buffer_view_allocate_buffer_copy(
+      device, allocator, 1, shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+      IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
+      iree_make_const_byte_span(a, bytes), &arg0));
+  iree_hal_buffer_view_t* arg1 = NULL;
+  GATE_CHECK(iree_hal_buffer_view_allocate_buffer_copy(
+      device, allocator, 1, shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+      IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
+      iree_make_const_byte_span(b, bytes), &arg1));
+
+  GATE_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call, arg0));
+  GATE_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call, arg1));
+
+  GATE_CHECK(iree_runtime_call_invoke(&call, 0));
+
+  iree_hal_buffer_view_t* ret = NULL;
+  GATE_CHECK(iree_runtime_call_outputs_pop_front_buffer_view(&call, &ret));
+  GATE_CHECK(iree_hal_device_transfer_d2h(
+      device, iree_hal_buffer_view_buffer(ret), 0, out, bytes,
+      IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout()));
+
+  iree_hal_buffer_view_release(arg0);
+  iree_hal_buffer_view_release(arg1);
+  iree_hal_buffer_view_release(ret);
+  iree_runtime_call_deinitialize(&call);
+  iree_runtime_session_release(session);
+  iree_hal_device_release(device);
+  iree_runtime_instance_release(instance);
+  return 0;
+}

--- a/spike/iree-ffi/src/main.rs
+++ b/spike/iree-ffi/src/main.rs
@@ -1,0 +1,37 @@
+// FFI-gate proof: call the C shim (which uses the IREE runtime C API) to run a
+// vmfb, confirming Rust can drive IREE execution on this aarch64 box via the
+// prebuilt iree-dist, with no IREE source build. This is the substrate the
+// mlxcel-xla backend (issue #449 Phase 3) needs.
+use std::ffi::CString;
+use std::os::raw::{c_char, c_float, c_int};
+
+unsafe extern "C" {
+    fn iree_gate_run_add(
+        vmfb_path: *const c_char,
+        a: *const c_float,
+        b: *const c_float,
+        n: c_int,
+        out: *mut c_float,
+    ) -> c_int;
+}
+
+fn main() {
+    let vmfb = std::env::args().nth(1).unwrap_or_else(|| "add.vmfb".to_string());
+    let cpath = CString::new(vmfb.clone()).expect("vmfb path");
+    let a = [1.0f32, 2.0, 3.0, 4.0];
+    let b = [10.0f32, 20.0, 30.0, 40.0];
+    let mut out = [0.0f32; 4];
+
+    let rc = unsafe {
+        iree_gate_run_add(cpath.as_ptr(), a.as_ptr(), b.as_ptr(), 4, out.as_mut_ptr())
+    };
+    assert_eq!(rc, 0, "iree_gate_run_add failed (status {rc}) on {vmfb}");
+
+    let expected = [11.0f32, 22.0, 33.0, 44.0];
+    println!("IREE via Rust FFI: a + b = {out:?}");
+    assert!(
+        out.iter().zip(expected).all(|(g, e)| (g - e).abs() < 1e-5),
+        "mismatch: got {out:?} expected {expected:?}"
+    );
+    println!("FFI GATE: PASS (Rust drove an IREE vmfb on aarch64 via the prebuilt runtime)");
+}


### PR DESCRIPTION
FFI-gate spike (#449 Phase 3 M2): proves Rust can drive IREE execution of a compiled vmfb on this aarch64 box using only the prebuilt IREE distribution, with no IREE source build. This confirms the substrate `mlxcel-xla` needs and de-risks M2.

- A thin C shim (`iree_gate.c`) calls the IREE runtime C API and exposes a flat C ABI; Rust FFIs to it (the M2 architecture). Result: `a + b = [11, 22, 33, 44]`, `FFI GATE: PASS`.
- The prebuilt `iree-dist-<ver>-linux-aarch64.tar.xz` (85 MB) ships the runtime static libs (`libiree_runtime_unified.a`), the C API headers, and `iree-compile`. The pip `iree-base-runtime` (Python `.abi3.so` only, no linkable C lib/headers) is not the path.
- Two non-obvious requirements recorded in `FINDINGS.md`: the dist leaves the system allocator to the application (the shim provides a libc control function), and the static link needs `--whole-archive` on the unified runtime (so the `local-task` HAL driver registration survives) plus a `--start-group` of flatcc, `libgcc` (aarch64 outline atomics), and `libm` (CPU-kernel math).

Standalone under `spike/iree-ffi/` (own empty `[workspace]`); no effect on mlxcel crates or builds. Next: wire this shim into `mlxcel-xla` to load the #451-emitted prefill/decode vmfbs and weights and run the token loop.

Refs #449.