### PR TITLE
feat: run the OpenXLA backend on CUDA (GB10) via a source-built IREE runtime (#449)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,10 +17,54 @@ use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-env-changed=IREE_DIST");
+    println!("cargo:rerun-if-env-changed=IREE_CUDA_HOME");
 
     // The feature env is set for this crate's own enabled features; `xla-iree`
     // becomes `CARGO_FEATURE_XLA_IREE`.
     if env::var_os("CARGO_FEATURE_XLA_IREE").is_none() {
+        return;
+    }
+
+    // CUDA mode (GB10): link the source-built cuda-enabled IREE runtime instead
+    // of the prebuilt dist (mutually exclusive; IREE_CUDA_HOME wins). The
+    // source-built `libiree_runtime_unified.a` already bundles the cuda driver
+    // impl + local-task, so whole-archive only it (re-linking the separate cuda
+    // impl libs would multiply-define their objects); the cuda registration
+    // wrapper (driver_module.c.o, pulled by the shim's explicit register call),
+    // IREE's vendored printf (the unified printf.c.o needs vsnprintf_), and flatcc
+    // go in a group. The cuda driver dlopens libcuda at runtime (no -lcuda).
+    if let Ok(home) = env::var("IREE_CUDA_HOME") {
+        let b = PathBuf::from(home).join("build");
+        let unified = b.join("runtime/src/iree/runtime/libiree_runtime_unified.a");
+        assert!(
+            unified.exists(),
+            "IREE_CUDA_HOME build is missing {} (run the runtime build first)",
+            unified.display()
+        );
+        for d in [
+            "runtime/src/iree/runtime",
+            "runtime/src/iree/hal/drivers/cuda/registration",
+            "build_tools/third_party/flatcc",
+            "build_tools/third_party/printf",
+        ] {
+            println!("cargo:rustc-link-search=native={}", b.join(d).display());
+        }
+        for arg in [
+            "-Wl,--whole-archive",
+            "-l:libiree_runtime_unified.a",
+            "-Wl,--no-whole-archive",
+            "-Wl,--start-group",
+            "-l:libiree_hal_drivers_cuda_registration_registration.a",
+            "-l:libprintf_printf.a",
+            "-l:libflatcc_parsing.a",
+            "-lgcc",
+            "-lm",
+            "-lpthread",
+            "-ldl",
+            "-Wl,--end-group",
+        ] {
+            println!("cargo:rustc-link-arg={arg}");
+        }
         return;
     }
 

--- a/spike/iree-ffi/build.rs
+++ b/spike/iree-ffi/build.rs
@@ -5,13 +5,61 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
+    println!("cargo:rerun-if-changed=iree_gate.c");
+    println!("cargo:rerun-if-env-changed=IREE_DIST");
+    println!("cargo:rerun-if-env-changed=IREE_CUDA_HOME");
+
+    // CUDA experiment (GB10): build against a source-built cuda-enabled IREE
+    // runtime instead of the CPU/vulkan prebuilt dist. Set IREE_CUDA_HOME to the
+    // iree-cuda dir (it has src/ and build/). Headers are split across the source
+    // (src/runtime/src) and the build (build/runtime/src, generated flatcc/config),
+    // and the cuda driver is separate libs registered explicitly in the shim.
+    if let Ok(home) = env::var("IREE_CUDA_HOME") {
+        let home = PathBuf::from(home);
+        let src_inc = home.join("src/runtime/src");
+        let bld_inc = home.join("build/runtime/src");
+        cc::Build::new()
+            .file("iree_gate.c")
+            .include(&src_inc)
+            .include(&bld_inc)
+            .define("XLA_GATE_CUDA", None)
+            .compile("iree_gate");
+
+        let b = home.join("build");
+        for d in [
+            "runtime/src/iree/runtime",
+            "runtime/src/iree/hal/drivers/cuda/registration",
+            "build_tools/third_party/flatcc",
+            "build_tools/third_party/printf",
+        ] {
+            println!("cargo:rustc-link-search=native={}", b.join(d).display());
+        }
+        // The unified archive already bundles the cuda driver impl + local-task,
+        // so whole-archive only it (re-linking the cuda impl libs would multiply-
+        // define their objects). The cuda registration wrapper (just
+        // driver_module.c.o, pulled by the explicit register call), IREE's
+        // vendored printf (vsnprintf_/vfctprintf the unified printf.c.o needs),
+        // and flatcc go in a group. The cuda driver dlopens libcuda at runtime,
+        // so no link-time -lcuda.
+        println!("cargo:rustc-link-arg=-Wl,--whole-archive");
+        println!("cargo:rustc-link-arg=-l:libiree_runtime_unified.a");
+        println!("cargo:rustc-link-arg=-Wl,--no-whole-archive");
+        println!("cargo:rustc-link-arg=-Wl,--start-group");
+        println!("cargo:rustc-link-arg=-l:libiree_hal_drivers_cuda_registration_registration.a");
+        println!("cargo:rustc-link-arg=-l:libprintf_printf.a");
+        println!("cargo:rustc-link-arg=-l:libflatcc_parsing.a");
+        println!("cargo:rustc-link-arg=-lgcc");
+        println!("cargo:rustc-link-arg=-lm");
+        println!("cargo:rustc-link-arg=-lpthread");
+        println!("cargo:rustc-link-arg=-ldl");
+        println!("cargo:rustc-link-arg=-Wl,--end-group");
+        return;
+    }
+
     let dist = env::var("IREE_DIST").expect("set IREE_DIST to the extracted iree-dist tree");
     let dist = PathBuf::from(dist);
     let include = dist.join("include");
     let lib = dist.join("lib");
-
-    println!("cargo:rerun-if-changed=iree_gate.c");
-    println!("cargo:rerun-if-env-changed=IREE_DIST");
 
     cc::Build::new()
         .file("iree_gate.c")

--- a/spike/iree-ffi/iree_gate.c
+++ b/spike/iree-ffi/iree_gate.c
@@ -15,6 +15,13 @@
 #include <iree/runtime/api.h>
 #include <iree/hal/buffer_view_util.h>
 #include <iree/hal/buffer_transfer.h>
+#ifdef XLA_GATE_CUDA
+// CUDA experiment (GB10): the prebuilt dist has no cuda driver, so this builds
+// against a source-built cuda-enabled IREE runtime (build.rs cuda mode defines
+// XLA_GATE_CUDA). The unified runtime bundles only local-task; the cuda driver
+// is a separate lib, registered explicitly below.
+#include <iree/hal/drivers/cuda/registration/driver_module.h>
+#endif
 
 // libc-backed implementation of the system allocator control function.
 iree_status_t iree_gate_libc_ctl(void* self, iree_allocator_command_t command,
@@ -212,6 +219,15 @@ static iree_status_t xla_llama_create_impl(
     const int32_t* weight_ranks, const int64_t* weight_dims, int32_t vocab) {
   c->vocab = vocab;
   c->n_weights = n_weights;
+
+#ifdef XLA_GATE_CUDA
+  // Register the CUDA driver so use_all_available_drivers exposes it for a
+  // device_uri of "cuda" (GB10). Non-fatal; CUDA is initialized only when a
+  // cuda device is created.
+  iree_status_t cu_reg =
+      iree_hal_cuda_driver_module_register(iree_hal_driver_registry_default());
+  if (!iree_status_is_ok(cu_reg)) iree_status_ignore(cu_reg);
+#endif
 
   iree_runtime_instance_options_t inst_opts;
   iree_runtime_instance_options_initialize(&inst_opts);

--- a/src/execution/runtime.rs
+++ b/src/execution/runtime.rs
@@ -87,13 +87,20 @@ pub fn initialize_runtime() -> RuntimeSetup {
     // Footgun guard: a default `cargo build --release` on Linux omits the `cuda`
     // feature and silently runs MLX on the CPU. If the user wanted the GPU but
     // this CPU-only binary fell back to CPU on a host that has an NVIDIA GPU,
-    // say so loudly instead of crawling at a fraction of GPU speed.
-    if should_warn_cpu_only_on_nvidia_host(
-        requested_device,
-        device,
-        cfg!(feature = "cuda"),
-        nvidia_host_present(),
-    ) {
+    // say so loudly instead of crawling at a fraction of GPU speed. The OpenXLA
+    // backend (issue #449) is the exception: it drives inference through IREE,
+    // not MLX, and can run on the GPU via its own device (MLXCEL_XLA_DEVICE),
+    // so the MLX-CPU-fallback message would be misleading there.
+    let xla_backend_selected =
+        cfg!(feature = "xla-backend") && std::env::var("MLXCEL_BACKEND").as_deref() == Ok("xla");
+    if !xla_backend_selected
+        && should_warn_cpu_only_on_nvidia_host(
+            requested_device,
+            device,
+            cfg!(feature = "cuda"),
+            nvidia_host_present(),
+        )
+    {
         warn_cpu_only_on_nvidia_host();
     }
 

--- a/src/lib/mlxcel-xla/README.md
+++ b/src/lib/mlxcel-xla/README.md
@@ -36,18 +36,51 @@ MLXCEL_BACKEND=xla ./target/release/mlxcel generate \
   -m <Llama-3.2-1B-Instruct dir> -p "..." -n 48
 ```
 
-CPU (`local-task`) is the proven M2 path, token-exact (48/48) vs the HF temp-0
+CPU (`local-task`) is the proven path, token-exact (48/48) vs the HF temp-0
 reference. `MLXCEL_XLA_DEVICE` selects the HAL device (default `local-task`).
 
-### Scope / limits (M2)
+### CUDA (GPU) build
+
+The prebuilt dist is CPU/Vulkan only (no CUDA driver, and its `iree-compile` has
+no CUDA codegen). The CUDA path therefore uses a **source-built cuda-enabled IREE
+runtime** plus a **cuda-capable `iree-compile`**, version-matched to each other.
+It is a separate, mutually-exclusive build mode (set `IREE_CUDA_HOME` instead of
+`IREE_DIST`).
+
+```bash
+# 1. Build the IREE *runtime* from source at the version your iree-compile uses
+#    (runtime only -> no LLVM; skip the third_party/llvm-project submodule):
+git clone --depth 1 --branch <iree-tag> https://github.com/iree-org/iree.git src
+git -C src -c submodule."third_party/llvm-project".update=none \
+    submodule update --init --recursive --depth 1
+cmake -S src -B build -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release \
+  -DIREE_BUILD_COMPILER=OFF -DIREE_HAL_DRIVER_DEFAULTS=OFF \
+  -DIREE_HAL_DRIVER_LOCAL_TASK=ON -DIREE_HAL_DRIVER_LOCAL_SYNC=ON \
+  -DIREE_HAL_DRIVER_CUDA=ON -DCUDAToolkit_ROOT=/usr/local/cuda
+make -C build -j"$(nproc)" iree_runtime_unified
+
+# 2. Point the build at it; provide a cuda-capable iree-compile (matching version).
+export IREE_CUDA_HOME=/abs/path/to/that/iree   # the dir holding src/ and build/
+export IREE_CUDA_COMPILE=/abs/path/to/iree-compile   # cuda codegen, version-matched
+cargo build --release --features xla-iree
+
+# 3. Run on the GPU.
+MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=cuda ./target/release/mlxcel generate \
+  -m <Llama-3.2-1B-Instruct dir> -p "..." -n 48
+```
+
+Validated on a GB10 (Grace-Blackwell, sm_121): token-exact 48/48, ~5 tok/s
+(~2.6x the CPU path). Vulkan via the prebuilt dist does **not** work on the GB10
+(IREE's Vulkan allocator vs NVIDIA's unified memory), so CUDA is the GPU path.
+
+### Scope / limits
 
 - The bundled graphs are authored for **Llama-3.2-1B-Instruct** specifically;
   `load` verifies `config.json` matches and errors otherwise.
 - Prompt length is capped at the prefill bucket (`MAX_SEQ = 256` tokens).
 - Greedy sampling only; text-only (no VLM / draft).
-- **GPU:** the prebuilt aarch64 dist registers `local-sync` / `local-task` /
-  `vulkan` drivers but **no CUDA**, so a GPU device needs a CUDA/Vulkan-enabled
-  runtime; M2 runs on CPU.
+- Single-sequence (batch-1). Throughput needs batched graphs + a multi-sequence
+  session, a separate milestone.
 
 ## File map
 

--- a/src/lib/mlxcel-xla/build.rs
+++ b/src/lib/mlxcel-xla/build.rs
@@ -22,9 +22,44 @@ use std::path::PathBuf;
 fn main() {
     println!("cargo:rerun-if-changed=csrc/xla_iree.c");
     println!("cargo:rerun-if-env-changed=IREE_DIST");
+    println!("cargo:rerun-if-env-changed=IREE_CUDA_HOME");
+    println!("cargo:rerun-if-env-changed=IREE_CUDA_COMPILE");
+    // cfg used by src/iree.rs to select the cuda iree-compile / device behavior.
+    println!("cargo:rustc-check-cfg=cfg(xla_iree_cuda)");
 
     // Only build the native shim under the `iree` feature.
     if env::var_os("CARGO_FEATURE_IREE").is_none() {
+        return;
+    }
+
+    // CUDA mode (GB10): build against a source-built cuda-enabled IREE runtime
+    // (IREE_CUDA_HOME, the iree-cuda dir with src/ and build/) instead of the
+    // prebuilt CPU/vulkan dist. Mutually exclusive with the IREE_DIST path: the
+    // runtime version differs and the dist's iree-compile has no cuda codegen, so
+    // vmfbs are compiled by a separate cuda-capable iree-compile
+    // (IREE_CUDA_COMPILE, baked here / overridable at runtime). The runtime link
+    // recipe lives in the root build.rs (link-args don't propagate); it reads
+    // IREE_CUDA_HOME the same way. Headers are split across the source tree
+    // (src/runtime/src) and the build tree (build/runtime/src, generated).
+    if let Ok(home) = env::var("IREE_CUDA_HOME") {
+        let home = PathBuf::from(home);
+        let src_inc = home.join("src/runtime/src");
+        let bld_inc = home.join("build/runtime/src");
+        assert!(
+            src_inc.join("iree/runtime/api.h").exists(),
+            "IREE_CUDA_HOME={} is not an iree source+build tree (missing src/runtime/src/iree/runtime/api.h)",
+            home.display()
+        );
+        cc::Build::new()
+            .file("csrc/xla_iree.c")
+            .include(&src_inc)
+            .include(&bld_inc)
+            .define("XLA_GATE_CUDA", None)
+            .compile("xla_iree");
+        println!("cargo:rustc-cfg=xla_iree_cuda");
+        if let Ok(ic) = env::var("IREE_CUDA_COMPILE") {
+            println!("cargo:rustc-env=MLXCEL_XLA_IREE_COMPILE={ic}");
+        }
         return;
     }
 

--- a/src/lib/mlxcel-xla/csrc/xla_iree.c
+++ b/src/lib/mlxcel-xla/csrc/xla_iree.c
@@ -31,6 +31,13 @@
 #include <iree/runtime/api.h>
 #include <iree/hal/buffer_view_util.h>
 #include <iree/hal/buffer_transfer.h>
+#ifdef XLA_GATE_CUDA
+// CUDA mode (GB10): built against a source-built cuda-enabled IREE runtime
+// (build.rs cuda mode defines XLA_GATE_CUDA). The unified runtime bundles the
+// cuda driver impl + local-task, but the registration wrapper is separate, so
+// the driver is registered explicitly below.
+#include <iree/hal/drivers/cuda/registration/driver_module.h>
+#endif
 
 // libc-backed implementation of the system allocator control function.
 iree_status_t iree_xla_libc_ctl(void* self, iree_allocator_command_t command,
@@ -150,6 +157,15 @@ static iree_status_t xla_llama_create_impl(
     const char* decode_vmfb, int32_t n_weights, const float* const* weight_data,
     const int32_t* weight_ranks, const int64_t* weight_dims) {
   c->n_weights = n_weights;
+
+#ifdef XLA_GATE_CUDA
+  // Register the CUDA driver so use_all_available_drivers exposes it for a
+  // device_uri of "cuda" (GB10). Non-fatal; CUDA is initialized only when a
+  // cuda device is actually created.
+  iree_status_t cu_reg =
+      iree_hal_cuda_driver_module_register(iree_hal_driver_registry_default());
+  if (!iree_status_is_ok(cu_reg)) iree_status_ignore(cu_reg);
+#endif
 
   iree_runtime_instance_options_t inst_opts;
   iree_runtime_instance_options_initialize(&inst_opts);

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -162,6 +162,9 @@ fn verify_config(model_dir: &Path) -> Result<(), String> {
 
 /// Locate the IREE distribution: a runtime `IREE_DIST` override first, else the
 /// path baked at build time (the dist whose runtime is linked into this binary).
+/// Only the dist (CPU/vulkan) build uses this; the cuda build links a source-built
+/// runtime and takes its iree-compile from `MLXCEL_XLA_IREE_COMPILE` instead.
+#[cfg(not(xla_iree_cuda))]
 fn iree_dist() -> Result<PathBuf, String> {
     if let Ok(d) = std::env::var("IREE_DIST") {
         return Ok(PathBuf::from(d));
@@ -172,20 +175,54 @@ fn iree_dist() -> Result<PathBuf, String> {
     }
 }
 
-/// iree-compile target flags for a HAL device. M2 ships the CPU path; the
-/// prebuilt aarch64 dist registers only local (CPU) and vulkan drivers, not
-/// CUDA, so a GPU device needs a CUDA/Vulkan-enabled runtime (a follow-up).
+/// The `iree-compile` binary used to lower the bundled graphs to vmfbs. In the
+/// cuda build the source-built runtime ships no compiler, so a cuda-capable
+/// iree-compile (version-matched to that runtime) is required via
+/// `MLXCEL_XLA_IREE_COMPILE` (runtime env, else baked at build); in the dist
+/// build it is the dist's own `bin/iree-compile`.
+fn iree_compile_bin() -> Result<PathBuf, String> {
+    if let Ok(ic) = std::env::var("MLXCEL_XLA_IREE_COMPILE") {
+        return Ok(PathBuf::from(ic));
+    }
+    if let Some(ic) = option_env!("MLXCEL_XLA_IREE_COMPILE") {
+        return Ok(PathBuf::from(ic));
+    }
+    #[cfg(xla_iree_cuda)]
+    {
+        Err("the cuda build needs a cuda-capable iree-compile: set \
+             MLXCEL_XLA_IREE_COMPILE to one matching the source runtime version \
+             (e.g. the pip iree-compile)"
+            .to_string())
+    }
+    #[cfg(not(xla_iree_cuda))]
+    {
+        let ic = iree_dist()?.join("bin/iree-compile");
+        if !ic.exists() {
+            return Err(format!(
+                "iree-compile not found at {} (set IREE_DIST to a valid dist)",
+                ic.display()
+            ));
+        }
+        Ok(ic)
+    }
+}
+
+/// iree-compile target flags for a HAL device. `local-task`/`local-sync` -> the
+/// CPU (llvm-cpu) target; `cuda` -> the CUDA target (only usable in a cuda
+/// build, whose runtime registers the cuda driver and whose iree-compile has
+/// cuda codegen).
 fn target_flags(device: &str) -> Result<&'static [&'static str], String> {
-    if device.starts_with("local") {
+    if device == "cuda" {
+        Ok(&["--iree-hal-target-device=cuda"])
+    } else if device.starts_with("local") {
         Ok(&[
             "--iree-hal-target-device=local",
             "--iree-hal-local-target-device-backends=llvm-cpu",
         ])
     } else {
         Err(format!(
-            "the OpenXLA backend M2 path runs on CPU (device \"local-task\"); device \
-             {device:?} needs a CUDA/Vulkan-enabled IREE runtime, which the prebuilt \
-             dist does not register"
+            "unsupported OpenXLA device {device:?}; use \"local-task\" (CPU) or, in a \
+             cuda build, \"cuda\""
         ))
     }
 }
@@ -204,6 +241,9 @@ fn compile_one(
     for f in flags {
         f.hash(&mut h);
     }
+    // Include the compiler path so a cuda vmfb is never reused for a cpu build
+    // (or across iree-compile versions) just because the graph text matches.
+    iree_compile.to_string_lossy().hash(&mut h);
     let key = h.finish();
     let mlir_path = cache.join(format!("{tag}-{key:016x}.mlir"));
     let vmfb_path = cache.join(format!("{tag}-{key:016x}.vmfb"));
@@ -230,11 +270,10 @@ fn compile_one(
 
 /// Compile the bundled prefill + decode graphs for `device`.
 fn compile_vmfbs(device: &str) -> Result<(PathBuf, PathBuf), String> {
-    let dist = iree_dist()?;
-    let iree_compile = dist.join("bin/iree-compile");
+    let iree_compile = iree_compile_bin()?;
     if !iree_compile.exists() {
         return Err(format!(
-            "iree-compile not found at {} (set IREE_DIST to a valid dist)",
+            "iree-compile not found at {}",
             iree_compile.display()
         ));
     }


### PR DESCRIPTION
## Summary

The OpenXLA backend (issue #449) now runs on the GB10 GPU. `MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=cuda mlxcel generate` drives Llama-3.2-1B through IREE on CUDA, **token-exact (48/48)** vs HF temp-0 at **~5 tok/s** (~2.6x the CPU path).

### Why a source build

- The prebuilt IREE dist is CPU/Vulkan only: no cuda driver, and its `iree-compile` has no cuda codegen.
- **Vulkan via the dist does not work on the GB10**: IREE's Vulkan allocator cannot allocate against NVIDIA's Grace-Blackwell unified memory.
- So CUDA is the GPU path, using a **source-built cuda-enabled IREE runtime** plus a **cuda-capable `iree-compile`**, version-matched. It is a separate, mutually-exclusive build mode keyed on `IREE_CUDA_HOME`, so the merged CPU (`IREE_DIST`) path and CI (which build neither) are unchanged.

### What changed

- `mlxcel-xla/build.rs`: cuda mode (`IREE_CUDA_HOME`) compiles the shim against the source runtime headers with `XLA_GATE_CUDA` and bakes the cuda `iree-compile` path (`IREE_CUDA_COMPILE`, overridable at runtime via `MLXCEL_XLA_IREE_COMPILE`).
- `csrc/xla_iree.c`: registers the cuda driver explicitly (guarded by `XLA_GATE_CUDA`; the unified runtime bundles only the local-task registration).
- root `build.rs`: the cuda runtime link recipe (the source unified archive already bundles the cuda driver impl, so whole-archive it alone + the registration wrapper + IREE's vendored printf + flatcc; the cuda driver dlopens libcuda, so no link-time `-lcuda`).
- `src/iree.rs`: cuda target flags, cuda `iree-compile` sourcing, and the compiler path in the vmfb cache key.
- `runtime.rs`: suppress the MLX CPU-fallback footgun warning when the XLA backend is selected (it drives inference through IREE, not MLX, so the message is misleading).
- `spike/iree-ffi`: the same cuda mode that proved the path token-exact before it was productized.
- README: the source-runtime build recipe.

### How to run (local)

```
# build the cuda-enabled IREE runtime from source (runtime only, no LLVM) — see the crate README
export IREE_CUDA_HOME=/path/to/iree   IREE_CUDA_COMPILE=/path/to/cuda/iree-compile
cargo build --release --features xla-iree
MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=cuda ./target/release/mlxcel generate -m <llama-3.2-1b> -p "..." -n 48
```

### Scope

- Still Llama-3.2-1B, prompts capped at the 256-token bucket, greedy, **single-sequence (batch-1)**. Throughput needs batched graphs + a multi-sequence session, a follow-up.
- The cuda runtime build is a local artifact (not committed); the recipe is in the README.

### Validation

- dist (CPU) mode still builds (no regression); cuda mode builds, links, and runs end to end on the GB10 at ~5 tok/s.
- default and `xla-backend` builds, `cargo fmt --check`, and `cargo clippy` (default `-D warnings` + `xla-backend`) are clean; `cargo test --features xla-backend --lib backend::` 6/6.

Refs #449.
