### PR TITLE
feat: ragged continuous-batching decode graph (#449 M3 Stage 2a-i)

### DIFF
--- a/spike/iree-ffi/FINDINGS_ragged.md
+++ b/spike/iree-ffi/FINDINGS_ragged.md
@@ -1,0 +1,88 @@
+# Ragged (continuous-batching) decode graph (#449 M3 Stage 2a-i)
+
+The first half of Stage 2: a **ragged** `decode_step` where each row carries its
+OWN position and length, so sequences of different lengths share one batch. This
+is the graph mechanic continuous batching needs. Validated by
+reference-equivalence: every ragged slot reproduces its independent single-seq
+stream, token-exact, on CPU and CUDA.
+
+Verdict: **PASS.** The ragged graph is correct and lowers/runs on both targets;
+a sequence's output is invariant to its batch-mates and their lengths. The
+per-row KV-write unroll costs only a few percent over the uniform-B graph.
+
+Scope note: this is 2a-i (the graph). The admit/evict scheduler with staggered
+arrival and slot recycling (2a-ii) is the remaining Stage 2a piece; here all
+slots are admitted at t=0 and stepped together at their own positions.
+
+## What was built (all in the spike)
+
+| Piece | Where |
+|-------|-------|
+| Ragged graph | `rust-emitter` `model.rs::emit_decode_ragged` + CLI `decode-ragged[-argmax] <B>`. Per-row `pos[B]`/`cache_len[B]`; RoPE cos/sin per-row gather `[B,d]` by `pos[B]`; key mask per-row `[B,S]` (valid iff `s <= cache_len[b]`); KV write unrolled per row, each at its own `pos[b]`. Attention contractions + LM head identical to uniform-B; the per-row mask carries the raggedness. |
+| Shim | `iree_gate.c`: `xla_llama_decode_ragged` (token/pos/cache_len as `[B]` arrays, threads rank-5 KV). Prefill-into-slot via a host KV mirror: `xla_llama_ragged_reset` + `xla_llama_prefill_slot` (single-seq prefill, d2h into mirror slot r) + `xla_llama_commit` (h2d mirror -> resident rank-5 KV). Reuses the scalar prefill vmfb. |
+| Driver | `src/bin/llama_ragged.rs`: Phase 1 captures one single-seq reference per prompt; Phase 2 prefills the prompts into slots and runs ragged decode; asserts each slot == its reference. |
+
+## The one hard problem, resolved
+
+Each row writes its new K/V at its own `pos[b]`, so the uniform-B single
+shared-offset `dynamic_update_slice` no longer applies. Resolved with the
+per-row `dynamic_update_slice` unroll (primary plan from the design): for each
+layer, `B` writes, row r writing `[1,1,1,nkv,d]` at `[r, li, pos[r], 0, 0]`
+(constant row/layer offsets, dynamic `pos[r]`). This uses the CUDA-proven
+`dynamic_update_slice` (scatter stays avoided per the Phase 2a caveat). It lowers
+and runs on both targets; graph size and compile time are fine (see below).
+
+## Validation: reference-equivalence
+
+Continuous batching has no single reference, so the gate is: B prompts of
+DIFFERENT lengths (truncations of the 46-token reference prompt), each run
+independently through the single-seq path to get its greedy stream, then run
+together in one ragged batch (each slot at its own position). Every slot's stream
+must match its independent reference, proving per-row state is correct and a
+sequence is unaffected by its batch-mates.
+
+| Device | B | Prompt lengths | Result | ragged ms/step | agg tok/s | vs uniform-B ms/step |
+|--------|---|----------------|--------|----------------|-----------|----------------------|
+| CPU `local-task` | 4 | 46,43,40,37 | 4/4 slots 48/48 EXACT | 115.2 | 34.7 | 110.0 (+4.7%) |
+| CUDA GB10 | 4 | 46,43,40,37 | 4/4 slots 48/48 EXACT | 89.2 | 44.8 | 87.5 (+1.9%) |
+| CUDA GB10 | 8 | 46,43,40,37,34,31,28,25 | 8/8 slots 48/48 EXACT | 95.7 | 83.6 | 89.0 (+7.5%) |
+
+## Findings
+
+- **Ragged decode is correct.** Eight sequences of eight different lengths in one
+  batch each reproduce their independent single-seq stream exactly. Per-row
+  pos/cache_len/mask and the per-row KV write are all right; batch membership and
+  peer lengths do not perturb a sequence.
+- **The per-row KV-write unroll is cheap.** B*L `dynamic_update_slice`s per step
+  (e.g. 128 at B=8) add only ~2% (B=4) to ~7.5% (B=8) over the uniform-B graph,
+  and IREE lowers them fine on CPU and CUDA. Compile time stayed small (B=4 ~7.5s
+  CPU, ~5s CUDA).
+- **CPU validation is reference-bound, not graph-bound.** Phase 1 runs B
+  single-seq references sequentially; at ~0.45 s/step that dominates CPU runtime
+  for large B (B=8 CPU exceeds a few minutes). It is a harness cost, not a ragged
+  graph cost; CUDA references are ~2.5x faster, so the B sweep runs there.
+
+## Next (2a-ii)
+
+The admit/evict scheduler: a request queue, slot allocation, mid-stream prefill
+into a freed slot (refresh the device KV to the mirror, prefill the slot, re-commit),
+eviction on EOS, and slot recycling. Validation extends to staggered arrival
+(a request's stream must match its reference regardless of when it joined or which
+peers came and went). Then 2b productizes the engine into `mlxcel-xla`. See
+`spike/openxla/STAGE2_DESIGN.md`.
+
+## Reproduce
+
+```bash
+cd spike/iree-ffi
+# CPU: compile prefill + single-seq decode + ragged decode, then run.
+EMIT=../rust-emitter/target/release/emit; IC=./iree-dist/bin/iree-compile
+F="--iree-input-type=stablehlo --iree-hal-target-device=local --iree-hal-local-target-device-backends=llvm-cpu"
+$EMIT prefill-argmax p.mlir && $IC $F p.mlir -o p.vmfb
+$EMIT decode-argmax s.mlir  && $IC $F s.mlir -o s.vmfb
+$EMIT decode-ragged-argmax 4 r.mlir && $IC $F r.mlir -o r.vmfb
+IREE_DIST=./iree-dist cargo run --release --bin llama_ragged -- \
+  --batch 4 --device local-task --prefill p.vmfb --sdecode s.vmfb --decode r.vmfb
+# CUDA: build with IREE_CUDA_HOME, compile with the pip cuda iree-compile
+# (--iree-hal-target-device=cuda), run with --device cuda and the .cuda.vmfb graphs.
+```

--- a/spike/iree-ffi/iree_gate.c
+++ b/spike/iree-ffi/iree_gate.c
@@ -154,8 +154,16 @@ typedef struct xla_ctx {
   iree_hal_buffer_view_t** weights;  // resident weights, uploaded once
   iree_hal_buffer_view_t* kcache;    // threaded KV (set by prefill, advanced by decode)
   iree_hal_buffer_view_t* vcache;
-  iree_hal_buffer_view_t* kcache_b;  // rank-5 batched KV [B,L,S,nkv,d] (uniform-B decode)
+  iree_hal_buffer_view_t* kcache_b;  // rank-5 batched KV [B,L,S,nkv,d] (uniform-B/ragged decode)
   iree_hal_buffer_view_t* vcache_b;
+  // Ragged (continuous-batching) host KV mirror: per-slot single-seq prefills are
+  // assembled here, then committed (h2d) into kcache_b/vcache_b. rg_dims is the
+  // rank-4 single-seq KV shape [L,S,nkv,d]; rg_per = its element count.
+  int32_t rg_bsz;
+  float* rg_mk;
+  float* rg_mv;
+  iree_host_size_t rg_per;
+  iree_hal_dim_t rg_dims[4];
   int32_t vocab;
 } xla_ctx;
 
@@ -571,8 +579,153 @@ int xla_llama_decode_batch(xla_ctx* c, int32_t bsz, const int32_t* tokens,
   return 0;
 }
 
+// ===========================================================================
+// Ragged continuous-batching decode (#449 M3 Stage 2a). Each slot carries its
+// OWN position/length, so sequences of different lengths share the batch. The
+// per-slot prompt KV is built by running the single-seq prefill into a host
+// mirror (one slot at a time), then committed (h2d) into the resident rank-5 KV
+// the ragged decode threads. decode_ragged takes token/pos/cache_len as [B]
+// arrays (per row) instead of the uniform-B scalars.
+// ===========================================================================
+
+// Reset the ragged state for a batch of `bsz` slots (drops any mirror + KV).
+int xla_llama_ragged_reset(xla_ctx* c, int32_t bsz) {
+  c->rg_bsz = bsz;
+  free(c->rg_mk);
+  c->rg_mk = NULL;
+  free(c->rg_mv);
+  c->rg_mv = NULL;
+  c->rg_per = 0;
+  if (c->kcache_b) {
+    iree_hal_buffer_view_release(c->kcache_b);
+    c->kcache_b = NULL;
+  }
+  if (c->vcache_b) {
+    iree_hal_buffer_view_release(c->vcache_b);
+    c->vcache_b = NULL;
+  }
+  return 0;
+}
+
+// Prefill one prompt into mirror slot `slot` and report its first token. Runs the
+// single-seq prefill (reusing the scalar prefill vmfb) and copies its rank-4 KV
+// into the host mirror; call xla_llama_commit once all slots are filled.
+int xla_llama_prefill_slot(xla_ctx* c, int32_t slot, const int32_t* tokens,
+                           int32_t lp, const int32_t* positions, int32_t real_len,
+                           int32_t* out_first) {
+  int rc = xla_llama_prefill(c, tokens, lp, positions, real_len, out_first);
+  if (rc != 0) return rc;
+  if (iree_hal_buffer_view_shape_rank(c->kcache) != 4) {
+    fprintf(stderr, "xla_llama_prefill_slot: expected rank-4 single-seq KV\n");
+    return 1;
+  }
+  iree_host_size_t per = iree_hal_buffer_view_element_count(c->kcache);
+  if (!c->rg_mk) {
+    c->rg_per = per;
+    for (int32_t i = 0; i < 4; i++) {
+      c->rg_dims[i] = iree_hal_buffer_view_shape_dim(c->kcache, i);
+    }
+    c->rg_mk = (float*)calloc((size_t)c->rg_bsz * per, sizeof(float));
+    c->rg_mv = (float*)calloc((size_t)c->rg_bsz * per, sizeof(float));
+    if (!c->rg_mk || !c->rg_mv) return 1;
+  }
+  GATE_CHECK(iree_hal_device_transfer_d2h(
+      c->device, iree_hal_buffer_view_buffer(c->kcache), 0,
+      c->rg_mk + (size_t)slot * per, per * sizeof(float),
+      IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout()));
+  GATE_CHECK(iree_hal_device_transfer_d2h(
+      c->device, iree_hal_buffer_view_buffer(c->vcache), 0,
+      c->rg_mv + (size_t)slot * per, per * sizeof(float),
+      IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout()));
+  iree_hal_buffer_view_release(c->kcache);
+  c->kcache = NULL;
+  iree_hal_buffer_view_release(c->vcache);
+  c->vcache = NULL;
+  return 0;
+}
+
+// Upload the host mirror into the resident rank-5 KV the ragged decode threads.
+int xla_llama_commit(xla_ctx* c) {
+  if (!c->rg_mk) {
+    fprintf(stderr, "xla_llama_commit: no slots prefilled\n");
+    return 1;
+  }
+  iree_hal_dim_t shape5[5] = {(iree_hal_dim_t)c->rg_bsz, c->rg_dims[0],
+                              c->rg_dims[1], c->rg_dims[2], c->rg_dims[3]};
+  if (c->kcache_b) {
+    iree_hal_buffer_view_release(c->kcache_b);
+    c->kcache_b = NULL;
+  }
+  if (c->vcache_b) {
+    iree_hal_buffer_view_release(c->vcache_b);
+    c->vcache_b = NULL;
+  }
+  iree_host_size_t bytes = (iree_host_size_t)c->rg_bsz * c->rg_per * sizeof(float);
+  GATE_CHECK(xla_alloc_bv(c, 5, shape5, IREE_HAL_ELEMENT_TYPE_FLOAT_32, c->rg_mk,
+                          bytes, &c->kcache_b));
+  GATE_CHECK(xla_alloc_bv(c, 5, shape5, IREE_HAL_ELEMENT_TYPE_FLOAT_32, c->rg_mv,
+                          bytes, &c->vcache_b));
+  return 0;
+}
+
+// Ragged decode_step: token[B], pos[B], cache_len[B] (per row), rank-5 KV ->
+// token[B]; advances the resident rank-5 KV in place.
+int xla_llama_decode_ragged(xla_ctx* c, int32_t bsz, const int32_t* tokens,
+                            const int32_t* pos, const int32_t* cache_len,
+                            int32_t* out_tokens) {
+  iree_runtime_call_t call;
+  GATE_CHECK(iree_runtime_call_initialize_by_name(
+      c->session, iree_make_cstring_view("decode_step.main"), &call));
+  for (int32_t i = 0; i < c->n_weights; i++) {
+    GATE_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call,
+                                                              c->weights[i]));
+  }
+  iree_hal_dim_t vshape[1] = {(iree_hal_dim_t)bsz};
+  iree_host_size_t vbytes = (iree_host_size_t)bsz * sizeof(int32_t);
+  iree_hal_buffer_view_t* tok_bv = NULL;
+  iree_hal_buffer_view_t* pos_bv = NULL;
+  iree_hal_buffer_view_t* len_bv = NULL;
+  GATE_CHECK(xla_alloc_bv(c, 1, vshape, IREE_HAL_ELEMENT_TYPE_INT_32, tokens,
+                          vbytes, &tok_bv));
+  GATE_CHECK(xla_alloc_bv(c, 1, vshape, IREE_HAL_ELEMENT_TYPE_INT_32, pos, vbytes,
+                          &pos_bv));
+  GATE_CHECK(xla_alloc_bv(c, 1, vshape, IREE_HAL_ELEMENT_TYPE_INT_32, cache_len,
+                          vbytes, &len_bv));
+  GATE_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call, tok_bv));
+  GATE_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call, pos_bv));
+  GATE_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call, len_bv));
+  GATE_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call, c->kcache_b));
+  GATE_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call, c->vcache_b));
+
+  GATE_CHECK(iree_runtime_call_invoke(&call, 0));
+
+  iree_hal_buffer_view_t* logits = NULL;
+  iree_hal_buffer_view_t* kc = NULL;
+  iree_hal_buffer_view_t* vc = NULL;
+  GATE_CHECK(iree_runtime_call_outputs_pop_front_buffer_view(&call, &logits));
+  GATE_CHECK(iree_runtime_call_outputs_pop_front_buffer_view(&call, &kc));
+  GATE_CHECK(iree_runtime_call_outputs_pop_front_buffer_view(&call, &vc));
+  iree_hal_buffer_view_t* old_k = c->kcache_b;
+  iree_hal_buffer_view_t* old_v = c->vcache_b;
+  c->kcache_b = kc;
+  c->vcache_b = vc;
+
+  GATE_CHECK(xla_read_tokens_batch(c, bsz, logits, out_tokens));
+
+  iree_hal_buffer_view_release(logits);
+  iree_hal_buffer_view_release(tok_bv);
+  iree_hal_buffer_view_release(pos_bv);
+  iree_hal_buffer_view_release(len_bv);
+  iree_runtime_call_deinitialize(&call);
+  iree_hal_buffer_view_release(old_k);
+  iree_hal_buffer_view_release(old_v);
+  return 0;
+}
+
 void xla_llama_free(xla_ctx* c) {
   if (!c) return;
+  free(c->rg_mk);
+  free(c->rg_mv);
   if (c->weights) {
     for (int32_t i = 0; i < c->n_weights; i++) {
       if (c->weights[i]) iree_hal_buffer_view_release(c->weights[i]);

--- a/spike/iree-ffi/src/bin/llama_ragged.rs
+++ b/spike/iree-ffi/src/bin/llama_ragged.rs
@@ -1,0 +1,363 @@
+//! Stage 2a of the #449 throughput milestone: validate the ragged
+//! (continuous-batching) decode graph by reference-equivalence.
+//!
+//! Continuous batching has no single reference, so this drives two paths over
+//! the SAME weights:
+//!   Phase 1 (references): for each of B prompts of DIFFERENT lengths
+//!     (truncations of the reference prompt), run the single-seq prefill +
+//!     decode to capture its independent greedy token stream.
+//!   Phase 2 (ragged batch): prefill the B prompts into B slots at their own
+//!     lengths, commit the rank-5 KV, then run the ragged decode in lockstep
+//!     (every slot steps together, but each at its OWN position/length).
+//! The gate: every slot's stream must match its independent single-seq
+//! reference. That proves a sequence's output is invariant to which peers share
+//! its batch, i.e. the per-row pos/cache_len/mask and the per-row KV write are
+//! all correct. Throughput is reported as B * steps / wall.
+//!
+//! Two IREE sessions are used (one module can hold only one @decode_step): a
+//! single-seq decode vmfb for Phase 1 and the ragged decode vmfb for Phase 2.
+//! Weights are loaded once and uploaded to each session.
+//!
+//! Run (after compiling prefill + single-seq decode + ragged decode vmfbs):
+//!   IREE_DIST=.../iree-dist cargo run --release --bin llama_ragged -- \
+//!     --batch 4 --prefill prefill.vmfb --sdecode decode.vmfb --decode dr4.vmfb
+//!   # CUDA: build with IREE_CUDA_HOME, run with --device cuda + the .cuda.vmfb graphs.
+
+use std::ffi::CString;
+use std::fs::File;
+use std::os::raw::{c_char, c_int};
+use std::path::{Path, PathBuf};
+
+use memmap2::Mmap;
+use safetensors::{Dtype, SafeTensors};
+
+#[repr(C)]
+struct XlaCtx {
+    _private: [u8; 0],
+}
+
+unsafe extern "C" {
+    fn xla_llama_create(
+        device: *const c_char,
+        prefill: *const c_char,
+        decode: *const c_char,
+        n_weights: c_int,
+        weight_data: *const *const f32,
+        weight_ranks: *const c_int,
+        weight_dims: *const i64,
+        vocab: c_int,
+    ) -> *mut XlaCtx;
+    // single-seq path (Phase 1 references)
+    fn xla_llama_prefill(
+        c: *mut XlaCtx,
+        tokens: *const c_int,
+        lp: c_int,
+        positions: *const c_int,
+        real_len: c_int,
+        out_token: *mut c_int,
+    ) -> c_int;
+    fn xla_llama_decode(
+        c: *mut XlaCtx,
+        token: c_int,
+        pos: c_int,
+        cache_len: c_int,
+        out_token: *mut c_int,
+    ) -> c_int;
+    // ragged path (Phase 2)
+    fn xla_llama_ragged_reset(c: *mut XlaCtx, bsz: c_int) -> c_int;
+    fn xla_llama_prefill_slot(
+        c: *mut XlaCtx,
+        slot: c_int,
+        tokens: *const c_int,
+        lp: c_int,
+        positions: *const c_int,
+        real_len: c_int,
+        out_first: *mut c_int,
+    ) -> c_int;
+    fn xla_llama_commit(c: *mut XlaCtx) -> c_int;
+    fn xla_llama_decode_ragged(
+        c: *mut XlaCtx,
+        bsz: c_int,
+        tokens: *const c_int,
+        pos: *const c_int,
+        cache_len: *const c_int,
+        out_tokens: *mut c_int,
+    ) -> c_int;
+    fn xla_llama_free(c: *mut XlaCtx);
+}
+
+const N_LAYERS: usize = 16;
+const VOCAB: i32 = 128256;
+const LP: usize = 256; // prefill bucket (== MAX_SEQ; emitter PREFILL_LP)
+const MAX_NEW: usize = 48;
+const EOS: [i32; 3] = [128001, 128008, 128009];
+
+fn weight_names() -> Vec<String> {
+    let mut names = vec![
+        "model.embed_tokens.weight".to_string(),
+        "model.norm.weight".to_string(),
+    ];
+    for i in 0..N_LAYERS {
+        let p = format!("model.layers.{i}.");
+        for suf in [
+            "mlp.down_proj.weight",
+            "mlp.gate_proj.weight",
+            "input_layernorm.weight",
+            "post_attention_layernorm.weight",
+            "mlp.up_proj.weight",
+            "self_attn.k_proj.weight",
+            "self_attn.o_proj.weight",
+            "self_attn.q_proj.weight",
+            "self_attn.v_proj.weight",
+        ] {
+            names.push(format!("{p}{suf}"));
+        }
+    }
+    names
+}
+
+fn bf16_to_f32(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(2)
+        .map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16))
+        .collect()
+}
+
+fn read_int_array(path: &Path, key: &str) -> Vec<i32> {
+    let v: serde_json::Value =
+        serde_json::from_reader(File::open(path).expect("open json")).expect("parse json");
+    v[key]
+        .as_array()
+        .unwrap_or_else(|| panic!("{key} not an array in {}", path.display()))
+        .iter()
+        .map(|x| x.as_i64().expect("int") as i32)
+        .collect()
+}
+
+fn arg(flag: &str, default: &str) -> String {
+    let args: Vec<String> = std::env::args().collect();
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// Pad a prompt of length `n` into an `LP`-sized token buffer.
+fn padded(prompt: &[i32], n: usize) -> Vec<i32> {
+    let mut t = vec![0i32; LP];
+    t[..n].copy_from_slice(&prompt[..n]);
+    t
+}
+
+fn main() {
+    let here = env!("CARGO_MANIFEST_DIR");
+    let ref_dir = PathBuf::from(here).join("../openxla");
+    let model = arg(
+        "--model",
+        ref_dir
+            .join("models/Llama-3.2-1B-Instruct")
+            .to_str()
+            .unwrap(),
+    );
+    let prefill_vmfb = arg("--prefill", "prefill.vmfb");
+    let sdecode_vmfb = arg("--sdecode", "decode.vmfb"); // single-seq decode (references)
+    let rdecode_vmfb = arg("--decode", "decode_ragged.vmfb"); // ragged decode (batch)
+    let device = arg("--device", "local-task");
+    let bsz: usize = arg("--batch", "4")
+        .parse()
+        .expect("--batch must be an integer");
+    assert!(bsz >= 1, "--batch must be >= 1");
+
+    let prompt_ids = read_int_array(&ref_dir.join("artifacts/prompt_ids.json"), "prompt_ids");
+    let full = prompt_ids.len();
+    // B prompts of distinct lengths: truncations of the reference prompt.
+    let lens: Vec<usize> = (0..bsz)
+        .map(|r| ((full as i32) - (r as i32) * 3).max(8) as usize)
+        .collect();
+    let positions: Vec<i32> = (0..LP as i32).collect();
+    println!(
+        "device = {device}, batch = {bsz}, prompt lengths = {lens:?} (full = {full}, bucket {LP})"
+    );
+
+    // --- load weights once (bf16 -> f32) ---
+    let t0 = std::time::Instant::now();
+    let st_path = Path::new(&model).join("model.safetensors");
+    let file = File::open(&st_path).expect("open safetensors");
+    let mmap = unsafe { Mmap::map(&file).expect("mmap safetensors") };
+    let st = SafeTensors::deserialize(&mmap).expect("parse safetensors");
+    let names = weight_names();
+    let mut bufs: Vec<Vec<f32>> = Vec::with_capacity(names.len());
+    let mut ranks: Vec<c_int> = Vec::with_capacity(names.len());
+    let mut dims: Vec<i64> = Vec::with_capacity(names.len() * 4);
+    for name in &names {
+        let t = st
+            .tensor(name)
+            .unwrap_or_else(|_| panic!("missing weight {name}"));
+        assert_eq!(t.dtype(), Dtype::BF16, "{name} dtype {:?}", t.dtype());
+        let shape = t.shape();
+        ranks.push(shape.len() as c_int);
+        let mut d4 = [0i64; 4];
+        for (k, &s) in shape.iter().enumerate() {
+            d4[k] = s as i64;
+        }
+        dims.extend_from_slice(&d4);
+        bufs.push(bf16_to_f32(t.data()));
+    }
+    let ptrs: Vec<*const f32> = bufs.iter().map(|b| b.as_ptr()).collect();
+    println!(
+        "loaded {} weights ({:.1} GB f32) in {:.1}s",
+        names.len(),
+        bufs.iter().map(|b| b.len()).sum::<usize>() as f64 * 4.0 / 1e9,
+        t0.elapsed().as_secs_f64()
+    );
+
+    let c_dev = CString::new(device.clone()).unwrap();
+    let c_pre = CString::new(prefill_vmfb).unwrap();
+    let create = |decode_vmfb: &str| -> *mut XlaCtx {
+        let c_dec = CString::new(decode_vmfb).unwrap();
+        let ctx = unsafe {
+            xla_llama_create(
+                c_dev.as_ptr(),
+                c_pre.as_ptr(),
+                c_dec.as_ptr(),
+                names.len() as c_int,
+                ptrs.as_ptr(),
+                ranks.as_ptr(),
+                dims.as_ptr(),
+                VOCAB,
+            )
+        };
+        assert!(!ctx.is_null(), "xla_llama_create returned null");
+        ctx
+    };
+
+    // === Phase 1: single-seq references, one per prompt length ===
+    let ctx1 = create(&sdecode_vmfb);
+    let mut refs: Vec<Vec<i32>> = Vec::with_capacity(bsz);
+    for &n in &lens {
+        let tokens = padded(&prompt_ids, n);
+        let mut first = 0i32;
+        let rc = unsafe {
+            xla_llama_prefill(
+                ctx1,
+                tokens.as_ptr(),
+                LP as c_int,
+                positions.as_ptr(),
+                n as c_int,
+                &mut first,
+            )
+        };
+        assert_eq!(rc, 0, "ref prefill failed (status {rc})");
+        let mut stream = vec![first];
+        let mut clen = n as i32;
+        let mut next = first;
+        for _ in 0..(MAX_NEW - 1) {
+            if EOS.contains(&next) {
+                break;
+            }
+            let mut nt = 0i32;
+            let rc = unsafe { xla_llama_decode(ctx1, next, clen, clen, &mut nt) };
+            assert_eq!(rc, 0, "ref decode failed (status {rc})");
+            stream.push(nt);
+            clen += 1;
+            next = nt;
+        }
+        refs.push(stream);
+    }
+    unsafe { xla_llama_free(ctx1) };
+    println!("phase 1: captured {} single-seq references", refs.len());
+
+    // === Phase 2: ragged batch, all slots stepped together (ragged positions) ===
+    let ctx2 = create(&rdecode_vmfb);
+    assert_eq!(unsafe { xla_llama_ragged_reset(ctx2, bsz as c_int) }, 0);
+    let mut firsts = vec![0i32; bsz];
+    for (r, &n) in lens.iter().enumerate() {
+        let tokens = padded(&prompt_ids, n);
+        let rc = unsafe {
+            xla_llama_prefill_slot(
+                ctx2,
+                r as c_int,
+                tokens.as_ptr(),
+                LP as c_int,
+                positions.as_ptr(),
+                n as c_int,
+                &mut firsts[r],
+            )
+        };
+        assert_eq!(rc, 0, "prefill_slot {r} failed (status {rc})");
+    }
+    assert_eq!(unsafe { xla_llama_commit(ctx2) }, 0, "commit failed");
+
+    let steps = MAX_NEW - 1;
+    let mut streams: Vec<Vec<i32>> = firsts.iter().map(|&f| vec![f]).collect();
+    let mut cur = firsts.clone();
+    let mut clen: Vec<i32> = lens.iter().map(|&n| n as i32).collect();
+    let t0 = std::time::Instant::now();
+    for _ in 0..steps {
+        let pos = clen.clone(); // pos[r] == cache_len[r] in decode
+        let mut out = vec![0i32; bsz];
+        let rc = unsafe {
+            xla_llama_decode_ragged(
+                ctx2,
+                bsz as c_int,
+                cur.as_ptr(),
+                pos.as_ptr(),
+                clen.as_ptr(),
+                out.as_mut_ptr(),
+            )
+        };
+        assert_eq!(rc, 0, "decode_ragged failed (status {rc})");
+        for r in 0..bsz {
+            streams[r].push(out[r]);
+        }
+        cur = out;
+        for v in clen.iter_mut() {
+            *v += 1;
+        }
+    }
+    let secs = t0.elapsed().as_secs_f64();
+    unsafe { xla_llama_free(ctx2) };
+
+    // === compare each slot's stream to its independent single-seq reference ===
+    let mut all_ok = true;
+    for r in 0..bsz {
+        let rf = &refs[r];
+        let st = &streams[r];
+        let m = rf.len(); // compare up to the reference length (ragged runs to MAX_NEW)
+        let matches = (0..m).filter(|&i| st.get(i) == rf.get(i)).count();
+        let first_ok = firsts[r] == rf[0];
+        let ok = matches == m && first_ok;
+        all_ok &= ok;
+        let div = (0..m).find(|&i| st.get(i) != rf.get(i));
+        println!(
+            "slot {r} (len {:>3}): {matches}/{m} match{}{}",
+            lens[r],
+            if first_ok {
+                ""
+            } else {
+                "  [first-token mismatch]"
+            },
+            match div {
+                Some(i) => format!("  first divergence @ {i}"),
+                None => "  (EXACT)".to_string(),
+            }
+        );
+    }
+
+    let agg_tok_s = (bsz * steps) as f64 / secs;
+    println!(
+        "\nragged decode: {:.1} ms/step | aggregate {agg_tok_s:.2} tok/s ({bsz}x, {steps} steps)",
+        secs * 1e3 / steps as f64
+    );
+    println!(
+        "RESULT: {}",
+        if all_ok {
+            "REFERENCE-EXACT PASS"
+        } else {
+            "MISMATCH"
+        }
+    );
+    println!("RAGGED\tdevice={device}\tB={bsz}\tagg_tok_s={agg_tok_s:.3}\tpass={all_ok}");
+    std::process::exit(if all_ok { 0 } else { 1 });
+}

--- a/spike/openxla/STAGE2_DESIGN.md
+++ b/spike/openxla/STAGE2_DESIGN.md
@@ -1,0 +1,199 @@
+# Stage 2 design: continuous batching for the OpenXLA/IREE backend (#449 M3)
+
+Status: Proposed (2026-06-28). Follows Stage 1 (uniform-B batched decode, PR #462).
+Graduates to an ADR (a follow-up to ADR 0004) when productization (2b/2c) lands.
+
+## Goal
+
+Move the XLA/IREE backend from single-sequence (and Stage 1's uniform-B lockstep)
+to real continuous batching: sequences of different lengths that join and leave a
+shared batch at different times, so the device stays full under a request stream.
+Stage 1 proved batching is the throughput lever here (CPU 31x, CUDA 39x aggregate,
+token-exact). Stage 2 turns that into a servable multi-sequence engine.
+
+## Decisions (resolved 2026-06-28)
+
+1. **Spike-first.** Validate the ragged decode graph + a minimal scheduler in the
+   spike (2a) before productizing into `mlxcel-xla` (2b+). Mirrors Stage 1 and
+   de-risks the one genuinely new graph problem (ragged KV write).
+2. **Common `BatchEngine` trait.** The server drives one backend-neutral batching
+   contract; both the MLX `BatchScheduler` and the new XLA engine satisfy it, so
+   the server is backend-agnostic. (This is the cross-backend batching seam ADR
+   0004 deferred.)
+3. **Contiguous per-slot KV first.** Extend Stage 1's rank-5 `[B,L,S,nkv,d]` to
+   recycled slots. Paged-KV is a later capacity optimization (2d), not in the
+   first servable cut.
+
+## Background: the existing server seam (what we build on)
+
+The server is already backend-neutral at the request level, which makes decision
+2 cheap:
+
+- `ModelRequest` (`src/server/model_provider.rs:35`, `pub(crate) enum`):
+  `Generate { prompt, options, images, audio, videos, response_tx:
+  mpsc::Sender<GenerateEvent>, cancelled: Arc<AtomicBool> }` or `Shutdown`.
+  No MLX types: prompt + options + multimodal bytes + a streaming channel + a
+  cancel flag.
+- `GenerateEvent`: `Token | TokenWithLogprobs | Done(GenerationResult) | Error`.
+- `ModelProvider` holds `request_tx: mpsc::Sender<ModelRequest>` and a worker
+  thread. It spawns either the MLX `BatchScheduler` (`scheduler.rs`, `run(&mut
+  self)` pulling `request_rx: mpsc::Receiver<ModelRequest>`) or the legacy
+  sequential worker. The HTTP handlers send a `ModelRequest` and read
+  `GenerateEvent`s off `response_tx`.
+
+So the worker contract is already "own a model + KV/scheduling, consume
+`ModelRequest`, stream `GenerateEvent` per request." The MLX `BatchScheduler` IS
+this. The XLA engine becomes an alternative worker of the same shape.
+
+`InferenceSession` (`mlxcel-core/src/session.rs`) is intentionally single-sequence
+and is NOT extended here. ADR 0004 keeps batching out of that trait; Stage 2 adds a
+separate, server-level batching seam, consistent with how MLX already works.
+
+## 2a (spike): the ragged continuous decode graph
+
+The single decode graph gains per-row state. Versus Stage 1's uniform-B:
+
+| Aspect | Stage 1 (uniform-B) | Stage 2 (ragged) |
+|--------|---------------------|------------------|
+| `pos` | scalar (shared) | `[B] i32` (per row) |
+| `cache_len` | scalar (shared) | `[B] i32` (per row) |
+| RoPE cos/sin | one `[d]` broadcast | per-row gather `[B, d]` from the table by `pos[B]` |
+| key mask | shared `[S]` | per-row `[B, S]`: valid iff `s <= cache_len[b]` |
+| KV write | one `dynamic_update_slice`/layer at the shared offset | per-row offset (see below) |
+| attention `dot_general` | two-batch-dim | unchanged (mask carries the raggedness) |
+
+The expensive part (the GQA score/context contractions and the LM head) is
+unchanged; only the cheap head/mask/write change. RoPE per-row uses the same
+gather primitive Stage 1 already uses for embedding.
+
+### The one hard problem: ragged KV write
+
+Each row writes its new K/V at its own `pos[b]`, so Stage 1's single shared-offset
+`dynamic_update_slice` no longer applies. Options:
+
+- **(A) per-row `dynamic_update_slice` unroll (primary).** For each layer, unroll
+  `B_max` writes: slice row b's new K/V to `[1,1,1,nkv,d]`, slice `pos[b]` to a
+  scalar, `dynamic_update_slice(kcache, upd_b, [b, li, pos[b], 0, 0])`. Uses the
+  CUDA-proven `dynamic_update_slice` (Stage 1 + M2). Cost: `B_max * L` update ops
+  per step (e.g. 32*16 = 512), so graph size and compile time must be measured.
+- **(B) scatter (alternative to test).** One scatter per layer writing all rows at
+  `pos[B]`. Cleaner if it lowers, but Phase 2a found IREE-CUDA rejected the scatter
+  that range-slice writes lowered to, so this needs an explicit lowering check
+  before relying on it.
+
+2a validates (A); if graph size is a problem, evaluate (B) or a hybrid.
+
+### Static shape with a varying active count
+
+The graph is compiled for a fixed `B_max`. Fewer than `B_max` sequences may be
+active, so inactive slots are masked (a slot's `cache_len[b]` and a dummy token
+make its row a harmless no-op whose output is discarded). One graph, no
+recompilation as the batch fills and drains.
+
+Stage 1 constraint carried forward: the untuned IREE-CUDA codegen is non-monotonic
+(B=16 was a reproducible 12x cliff; B=8/24/64 fine). So `B_max` must be chosen from
+empirically good values, and 2a re-measures the chosen `B_max` for the ragged
+graph. Bucketed `B_max` (a few graphs) stays a 2d option.
+
+### Prefill
+
+Separate prefill first: a new request runs the existing prefill graph, and its KV
+is written into a free slot (positions `0..prompt_len`), after which the slot joins
+the decode batch. Chunked prefill (prefill tokens riding in a decode step) is a 2d
+utilization optimization, not in the first cut.
+
+### KV layout
+
+Contiguous per-slot, `[B_max, L, S_max, nkv, d]` f32, slots recycled on evict.
+Memory at B_max=32, S_max=2048: ~4.3 GB (k+v), comfortable on GB10 unified memory
+next to the ~4.9 GB f32 weights. S_max=8192 would be ~17 GB, which is where paged-KV
+(2d) earns its complexity.
+
+### 2a validation
+
+Continuous batching has no single reference, so:
+
+1. **Correctness (the strong gate):** run N distinct prompts (varied lengths) each
+   independently through the single-seq path to capture reference token streams.
+   Then drive them through the continuous harness with staggered arrival and a
+   given `B_max`, and assert each request's output stream EXACTLY matches its
+   independent reference. This proves a sequence's output is invariant to which
+   peers share its batch and when it joined or others left (ragged state, masking,
+   slot recycling all correct).
+2. **Throughput:** sustained tok/s under a saturating request stream (queue always
+   full) versus the single-seq baseline, on CPU then CUDA.
+
+Harness: extend the Stage 1 `llama_batch` driver into a small scheduler that owns
+`B_max` slots, a FIFO queue, and an admit/decode/evict loop, plus the shim
+functions for per-row prefill-into-slot and ragged decode.
+
+## 2b (productize the engine): `XlaBatchEngine` in `mlxcel-xla`
+
+A multi-sequence engine that owns `B_max` slots, the rank-5 KV, the batched +
+prefill vmfbs, and the admit/decode/evict loop. It exposes a backend-neutral,
+request-level mechanics API (submit a prompt + sampling/limit params, pump a step,
+receive per-slot token/finish events, cancel a slot). No dependency on server
+types (it is a lib crate). Contiguous KV, fixed `B_max`, greedy first (sampling
+parity is a follow-up). Shipped with a CLI/bench entry so it is provable without
+the server.
+
+## 2c (server integration): the common `BatchEngine` trait
+
+Constraint: `ModelRequest`/`GenerateEvent` live in the server binary; `mlxcel-xla`
+is a lib, so it cannot implement a trait written over those types directly. So:
+
+- Define `trait BatchEngine: Send` at the server seam (where `ModelRequest`
+  lives): `fn run(&mut self)` consuming the `mpsc::Receiver<ModelRequest>` given at
+  construction and streaming `GenerateEvent`s per request. (Shutdown via
+  `ModelRequest::Shutdown`, cancel via the request's `cancelled` flag.)
+- MLX `BatchScheduler` `impl BatchEngine` (it already has `run(&mut self)` and
+  `request_rx`; near-zero change).
+- A server-side `XlaServeWorker` `impl BatchEngine` translates `ModelRequest`
+  to/from the `mlxcel-xla` engine mechanics API and pumps its loop. The engine
+  mechanics stay in the lib; only the thin adapter touches server types.
+- `ModelProvider` constructs and spawns the right worker by backend
+  (`select_backend()` / `ComputeBackend::supports_batched_serving()`), holding a
+  `Box<dyn BatchEngine>`. The HTTP path is unchanged.
+
+This gives the server one batching contract (decision 2) without moving core
+server types or destabilizing the MLX path. If we later want `mlxcel-xla` to
+implement the trait itself, promoting the neutral request/event types + the trait
+into `mlxcel-core` is a clean follow-up, but it is not required for 2c.
+
+`XlaBackend::supports_batched_serving()` flips to true once 2c lands; today it is
+false and the server uses the single-seq session path for XLA.
+
+## 2d (optimizations, post-first-cut)
+
+- **Paged-KV** (block table): memory efficiency, long context, more concurrent
+  sequences. Needs block-wise gather/scatter in the graph (IREE-CUDA lowering must
+  be validated, given the Phase 2a scatter caveat).
+- **Chunked prefill / mixed batches:** prefill tokens riding in a decode step for
+  higher utilization and smoother latency.
+- **Bucketed `B_max`** to cut idle-slot waste when underfull (pick known-good B
+  values to dodge codegen cliffs).
+- Sampling beyond greedy; config.json-driven multi-architecture emit.
+
+## Risks and open questions
+
+- **Graph size of the per-row KV-write unroll** (`B_max * L` updates). Measure
+  compile time and per-step cost in 2a; fall back to scatter or a hybrid if needed.
+- **IREE-CUDA codegen non-monotonicity** at the ragged graph's shapes. Re-sweep
+  `B_max` for the ragged graph; do not assume Stage 1's good points transfer.
+- **Inactive-slot masking correctness** (a half-full batch must match a full one
+  for the active rows). Covered by the 2a reference-equivalence gate.
+- **Trait altitude**: `run`-loop trait (proposed) vs a finer submit/step/poll trait.
+  The run-loop matches the existing MLX scheduler exactly; a finer trait would
+  force refactoring the MLX loop. Proposed: run-loop now, revisit only if a finer
+  seam is needed.
+
+## Staged plan
+
+- **2a** spike: ragged decode graph (per-row pos/cache_len/mask, ragged KV write),
+  minimal scheduler harness, reference-equivalence + throughput validation, CPU
+  then CUDA.
+- **2b** productize: `XlaBatchEngine` in `mlxcel-xla` (contiguous KV, fixed B_max,
+  greedy), CLI/bench.
+- **2c** integrate: `BatchEngine` trait, MLX `impl`, `XlaServeWorker` adapter,
+  `ModelProvider` selection, flip `supports_batched_serving`.
+- **2d** optimize: paged-KV, chunked prefill, bucketed B_max, sampling.

--- a/spike/rust-emitter/src/main.rs
+++ b/spike/rust-emitter/src/main.rs
@@ -9,6 +9,8 @@
 //!   emit prefill-argmax  [out.mlir]   prefill ending in on-device argmax
 //!   emit decode-batch        <B> [out]   uniform-B batched decode (logits)
 //!   emit decode-batch-argmax <B> [out]   uniform-B batched decode, on-device argmax
+//!   emit decode-ragged        <B> [out]  continuous-batching decode (logits)
+//!   emit decode-ragged-argmax <B> [out]  continuous-batching decode, on-device argmax
 
 mod builder;
 mod config;
@@ -35,7 +37,7 @@ fn main() {
 
     // Batched kinds take the batch size in args[2]; the output path then shifts
     // to args[3]. All other kinds keep the output path at args[2].
-    let is_batch = kind.starts_with("decode-batch");
+    let is_batch = kind.starts_with("decode-batch") || kind.starts_with("decode-ragged");
     let bsz = if is_batch {
         match args.get(2).and_then(|s| s.parse::<usize>().ok()) {
             Some(b) if b >= 1 => b,
@@ -59,10 +61,13 @@ fn main() {
         "prefill-argmax" => model::emit_prefill(&cfg, true),
         "decode-batch" => model::emit_decode_batched(&cfg, bsz, false),
         "decode-batch-argmax" => model::emit_decode_batched(&cfg, bsz, true),
+        "decode-ragged" => model::emit_decode_ragged(&cfg, bsz, false),
+        "decode-ragged-argmax" => model::emit_decode_ragged(&cfg, bsz, true),
         other => {
             eprintln!(
                 "unknown kind: {other} (use p0 | probe | decode | prefill | \
-                 decode-argmax | prefill-argmax | decode-batch | decode-batch-argmax)"
+                 decode-argmax | prefill-argmax | decode-batch | decode-batch-argmax | \
+                 decode-ragged | decode-ragged-argmax)"
             );
             std::process::exit(2);
         }

--- a/spike/rust-emitter/src/model.rs
+++ b/spike/rust-emitter/src/model.rs
@@ -617,6 +617,290 @@ pub fn emit_decode_batched(c: &Config, bsz: usize, sample: bool) -> String {
 }
 
 // ===========================================================================
+// ragged decode: continuous-batching decode_step (#449 M3 Stage 2a)
+// ===========================================================================
+//
+// Like the uniform-B graph, but each row carries its OWN position and length, so
+// sequences of different lengths can share the batch (the continuous-batching
+// requirement). Versus uniform-B: `pos` and `cache_len` are `[B]` (per row);
+// RoPE cos/sin are a per-row gather `[B, d]` from the table by `pos[B]`; the key
+// mask is per-row `[B, S]` (valid iff `s <= cache_len[b]`); and the KV write is
+// unrolled per row, each row writing its new K/V at its own `pos[b]` (the shared-
+// offset `dynamic_update_slice` no longer applies). The attention contractions
+// and the LM head are identical to uniform-B; the per-row mask carries the
+// raggedness.
+
+struct RaggedArgs {
+    embed: Val,
+    final_norm: Val,
+    layers: Vec<LayerW>,
+    token: Val,     // [B] i32
+    pos: Val,       // [B] i32 (per row)
+    cache_len: Val, // [B] i32 (per row)
+    kcache: Val,    // [B, L, MAX_SEQ, nkv, d]
+    vcache: Val,
+}
+
+fn build_ragged_arg_schema(c: &Config, bsz: usize) -> (Vec<ArgDecl>, RaggedArgs) {
+    let h = c.hidden;
+    let inter = c.inter;
+    let kv = c.n_kv * c.head_dim; // 512
+    let qd = c.n_q * c.head_dim; // 2048
+    let v = c.vocab;
+
+    let mut decls: Vec<ArgDecl> = Vec::new();
+    let mut idx = 0usize;
+    let mut take = |decls: &mut Vec<ArgDecl>, ty: Ty, loc: String| -> Val {
+        let val = Builder::arg(idx, ty.clone());
+        decls.push(ArgDecl { ty, loc });
+        idx += 1;
+        val
+    };
+
+    let embed = take(&mut decls, Ty::f32(vec![v, h]), "params['embed']".into());
+    let final_norm = take(&mut decls, Ty::f32(vec![h]), "params['final_norm']".into());
+
+    let mut layers = Vec::with_capacity(c.n_layers);
+    for li in 0..c.n_layers {
+        let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
+        let down = take(&mut decls, Ty::f32(vec![h, inter]), p("down"));
+        let gate = take(&mut decls, Ty::f32(vec![inter, h]), p("gate"));
+        let in_ln = take(&mut decls, Ty::f32(vec![h]), p("in_ln"));
+        let post_ln = take(&mut decls, Ty::f32(vec![h]), p("post_ln"));
+        let up = take(&mut decls, Ty::f32(vec![inter, h]), p("up"));
+        let wk = take(&mut decls, Ty::f32(vec![kv, h]), p("wk"));
+        let wo = take(&mut decls, Ty::f32(vec![qd, h]), p("wo"));
+        let wq = take(&mut decls, Ty::f32(vec![qd, h]), p("wq"));
+        let wv = take(&mut decls, Ty::f32(vec![kv, h]), p("wv"));
+        layers.push(LayerW {
+            down,
+            gate,
+            in_ln,
+            post_ln,
+            up,
+            wk,
+            wo,
+            wq,
+            wv,
+        });
+    }
+
+    let token = take(&mut decls, Ty::new(vec![bsz], "i32"), "token".into());
+    let pos = take(&mut decls, Ty::new(vec![bsz], "i32"), "pos".into());
+    let cache_len = take(&mut decls, Ty::new(vec![bsz], "i32"), "cache_len".into());
+    let kcache = take(
+        &mut decls,
+        Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
+        "kcache".into(),
+    );
+    let vcache = take(
+        &mut decls,
+        Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
+        "vcache".into(),
+    );
+
+    (
+        decls,
+        RaggedArgs {
+            embed,
+            final_norm,
+            layers,
+            token,
+            pos,
+            cache_len,
+            kcache,
+            vcache,
+        },
+    )
+}
+
+/// HF half-split RoPE on x:[B, heads, d]; cos/sin are per-row `[B, d]` (each
+/// row's own position), broadcast over the head axis.
+fn apply_rope_ragged(
+    b: &mut Builder,
+    x: &Val,
+    cos: &Val,
+    sin: &Val,
+    bsz: usize,
+    heads: usize,
+    d: usize,
+) -> Val {
+    let half = d / 2;
+    let cos_b = b.broadcast(cos, &[0, 2], vec![bsz, heads, d]); // [B,d] -> [B,heads,d]
+    let sin_b = b.broadcast(sin, &[0, 2], vec![bsz, heads, d]);
+    let xc = b.multiply(x, &cos_b);
+    let x1 = b.slice(x, &[(0, bsz), (0, heads), (0, half)]);
+    let x2 = b.slice(x, &[(0, bsz), (0, heads), (half, d)]);
+    let nx2 = b.negate(&x2);
+    let rh = b.concatenate(&nx2, &x1, 2);
+    let rs = b.multiply(&rh, &sin_b);
+    b.add(&xc, &rs)
+}
+
+/// Emit the ragged (continuous-batching) `decode_step` module for a static batch
+/// size `bsz`. With `sample`, ends in a per-row on-device argmax returning `[B]`
+/// token ids; otherwise returns `[B, V]` logits.
+pub fn emit_decode_ragged(c: &Config, bsz: usize, sample: bool) -> String {
+    let (decls, a) = build_ragged_arg_schema(c, bsz);
+    let mut b = Builder::new();
+    let k = emit_consts(&mut b, c);
+    // Constant row indices 0..bsz for the per-row KV-write dim-0 offsets.
+    let row_idx: Vec<Val> = (0..bsz).map(|i| b.const_i32(i as i32)).collect();
+
+    let h = c.hidden;
+    let d = c.head_dim;
+    let nq = c.n_q;
+    let nkv = c.n_kv;
+    let g = c.group();
+
+    // --- head: per-row embed gather, per-row rope gather, per-row key mask ---
+    let tok_idx = b.reshape(&a.token, vec![bsz, 1]);
+    let mut x = b.gather(&a.embed, &tok_idx); // [B, H]
+
+    // each row's rope vectors come from its own position: gather [B,d] by pos[B]
+    let pos_idx = b.reshape(&a.pos, vec![bsz, 1]);
+    let cos = b.gather(&k.cos_table, &pos_idx); // [B, d]
+    let sin = b.gather(&k.sin_table, &pos_idx); // [B, d]
+
+    // per-row key mask [B,S]: key s valid for row b iff s <= cache_len[b]
+    let ii = b.iota(MAX_SEQ); // [S]
+    let ii_b = b.broadcast(&ii, &[1], vec![bsz, MAX_SEQ]); // entry[b,s] = s
+    let clen_b = b.broadcast(&a.cache_len, &[0], vec![bsz, MAX_SEQ]); // entry[b,s] = cache_len[b]
+    let valid = b.compare("LE", &ii_b, &clen_b, "SIGNED");
+    let zeros = b.broadcast(&k.zero, &[], vec![bsz, MAX_SEQ]);
+    let negs = b.broadcast(&k.neg_big, &[], vec![bsz, MAX_SEQ]);
+    let kmask = b.select(&valid, &zeros, &negs); // [B, S]
+
+    let mut kcache = a.kcache.clone();
+    let mut vcache = a.vcache.clone();
+
+    for li in 0..c.n_layers {
+        let lw = &a.layers[li];
+
+        let hn = rms_norm_seq(&mut b, &x, &lw.in_ln, &k, bsz, h); // [B, H]
+        let q = b.linear_seq(&hn, &lw.wq);
+        let q = b.reshape(&q, vec![bsz, nq, d]);
+        let kk = b.linear_seq(&hn, &lw.wk);
+        let kk = b.reshape(&kk, vec![bsz, nkv, d]);
+        let vv = b.linear_seq(&hn, &lw.wv);
+        let vv = b.reshape(&vv, vec![bsz, nkv, d]);
+
+        let q = apply_rope_ragged(&mut b, &q, &cos, &sin, bsz, nq, d);
+        let kk = apply_rope_ragged(&mut b, &kk, &cos, &sin, bsz, nkv, d);
+
+        // per-row KV write: row r writes its [1,1,1,nkv,d] K/V at [r, li, pos[r]].
+        // `r` indexes the row consts AND the slice ranges (r, r+1), so a plain
+        // iterator does not fit; keep the range loop.
+        #[allow(clippy::needless_range_loop)]
+        for r in 0..bsz {
+            let pos_r = b.slice(&a.pos, &[(r, r + 1)]); // [1]
+            let pos_r = b.reshape(&pos_r, vec![]); // scalar i32 offset
+            let kk_r = b.slice(&kk, &[(r, r + 1), (0, nkv), (0, d)]);
+            let kk_upd = b.reshape(&kk_r, vec![1, 1, 1, nkv, d]);
+            kcache = b.dynamic_update_slice(
+                &kcache,
+                &kk_upd,
+                &[&row_idx[r], &k.layer_idx[li], &pos_r, &k.c0, &k.c0],
+            );
+            let vv_r = b.slice(&vv, &[(r, r + 1), (0, nkv), (0, d)]);
+            let vv_upd = b.reshape(&vv_r, vec![1, 1, 1, nkv, d]);
+            vcache = b.dynamic_update_slice(
+                &vcache,
+                &vv_upd,
+                &[&row_idx[r], &k.layer_idx[li], &pos_r, &k.c0, &k.c0],
+            );
+        }
+
+        // read this layer's cache slabs [B, S, nkv, d]
+        let kl = b.slice(
+            &kcache,
+            &[(0, bsz), (li, li + 1), (0, MAX_SEQ), (0, nkv), (0, d)],
+        );
+        let kl = b.reshape(&kl, vec![bsz, MAX_SEQ, nkv, d]);
+        let vl = b.slice(
+            &vcache,
+            &[(0, bsz), (li, li + 1), (0, MAX_SEQ), (0, nkv), (0, d)],
+        );
+        let vl = b.reshape(&vl, vec![bsz, MAX_SEQ, nkv, d]);
+
+        // GQA scores (identical to uniform-B); only the mask below is per-row.
+        let q_r = b.reshape(&q, vec![bsz, nkv, g, d]);
+        let scores = b.dot_general(
+            &q_r,
+            &kl,
+            &[0, 1],
+            &[0, 2],
+            &[3],
+            &[3],
+            vec![bsz, nkv, g, MAX_SEQ],
+        );
+        let scores = b.reshape(&scores, vec![bsz, nq, MAX_SEQ]);
+        let scale_b = b.broadcast(&k.scale, &[], vec![bsz, nq, MAX_SEQ]);
+        let scores = b.multiply(&scores, &scale_b);
+        let kmask_b = b.broadcast(&kmask, &[0, 2], vec![bsz, nq, MAX_SEQ]); // [B,S] -> [B,nq,S]
+        let scores = b.add(&scores, &kmask_b);
+
+        let m = b.reduce_max(&scores, 2, &k.neg_inf);
+        let m_b = b.broadcast(&m, &[0, 1], vec![bsz, nq, MAX_SEQ]);
+        let sh = b.subtract(&scores, &m_b);
+        let e = b.exponential(&sh);
+        let s = b.reduce_add(&e, 2, &k.zero);
+        let s_b = b.broadcast(&s, &[0, 1], vec![bsz, nq, MAX_SEQ]);
+        let attn = b.divide(&e, &s_b);
+
+        let attn_r = b.reshape(&attn, vec![bsz, nkv, g, MAX_SEQ]);
+        let o = b.dot_general(
+            &attn_r,
+            &vl,
+            &[0, 1],
+            &[0, 2],
+            &[3],
+            &[1],
+            vec![bsz, nkv, g, d],
+        );
+        let o = b.reshape(&o, vec![bsz, nq, d]);
+        let o = b.reshape(&o, vec![bsz, nq * d]);
+        let attn_out = b.linear_seq(&o, &lw.wo);
+        x = b.add(&x, &attn_out);
+
+        let hn2 = rms_norm_seq(&mut b, &x, &lw.post_ln, &k, bsz, h);
+        let gate = b.linear_seq(&hn2, &lw.gate);
+        let up = b.linear_seq(&hn2, &lw.up);
+        let neg = b.negate(&gate);
+        let ex = b.exponential(&neg);
+        let one_b = b.broadcast(&k.one, &[], vec![bsz, c.inter]);
+        let denom = b.add(&one_b, &ex);
+        let sig = b.divide(&one_b, &denom);
+        let silu = b.multiply(&gate, &sig);
+        let act = b.multiply(&silu, &up);
+        let down = b.linear_seq(&act, &lw.down);
+        x = b.add(&x, &down);
+    }
+
+    let xf = rms_norm_seq(&mut b, &x, &a.final_norm, &k, bsz, h);
+    let logits = b.linear_seq(&xf, &a.embed); // [B, V]
+    let (out_val, out_ty) = if sample {
+        let tok = b.argmax_batched(&logits);
+        (tok.name, Ty::new(vec![bsz], "i32").render())
+    } else {
+        (logits.name, Ty::f32(vec![bsz, c.vocab]).render())
+    };
+
+    let sig = render_signature(&decls);
+    let cache_ty = Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]).render();
+    format!(
+        "module @decode_step {{\n  func.func public @main({sig}) -> ({out_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {l}, {kc}, {vc} : {out_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
+        sig = sig,
+        out_ty = out_ty,
+        cache_ty = cache_ty,
+        body = b.body(),
+        l = out_val,
+        kc = kcache.name,
+        vc = vcache.name,
+    )
+}
+
+// ===========================================================================
 // prefill: bucketed multi-token prompt processing
 // ===========================================================================
 //


### PR DESCRIPTION
## Summary

The first half of Stage 2 (#449 M3): a **ragged** `decode_step` where each row carries its OWN position and length, so sequences of different lengths can share one batch. This is the graph mechanic continuous batching needs. Validated by reference-equivalence, token-exact on CPU and CUDA.

Scope: this is **2a-i (the graph)**. The admit/evict scheduler with staggered arrival and slot recycling (2a-ii) is the remaining Stage 2a piece. **Spike-only** (`spike/`, outside the Cargo workspace), so CI is unaffected.

## What is in it

- **Emitter** `emit_decode_ragged` (CLI `decode-ragged[-argmax] <B>`): per-row `pos[B]`/`cache_len[B]`; RoPE cos/sin as a per-row gather `[B,d]` by `pos[B]`; key mask per-row `[B,S]` (valid iff `s <= cache_len[b]`); the KV write unrolled per row, each row writing at its own `pos[b]` via `dynamic_update_slice` (constant row/layer offsets, dynamic `pos[r]`; scatter stays avoided per the Phase 2a CUDA caveat). The attention contractions and the LM head are identical to the uniform-B graph; the per-row mask carries the raggedness.
- **Shim** `xla_llama_decode_ragged` (token/pos/cache_len as `[B]` arrays, threads the rank-5 KV) plus a host-KV-mirror prefill path: `xla_llama_ragged_reset`, `xla_llama_prefill_slot` (single-seq prefill, d2h into the mirror slot), `xla_llama_commit` (h2d the mirror into the resident rank-5 KV). Reuses the scalar prefill vmfb.
- **Driver** `src/bin/llama_ragged.rs`: Phase 1 captures one single-seq reference per prompt; Phase 2 prefills B different-length prompts into slots and runs the ragged decode with each slot at its own position; asserts each slot's stream matches its reference.

## Validation (reference-equivalence)

Continuous batching has no single reference, so the gate is: B prompts of DIFFERENT lengths (truncations of the 46-token reference prompt), each run independently through the single-seq path, then run together in one ragged batch. Every slot must match its independent reference, proving per-row state is correct and a sequence is unaffected by its batch-mates.

| Device | B | Prompt lengths | Result | ragged ms/step | agg tok/s | vs uniform-B |
|--------|---|----------------|--------|----------------|-----------|--------------|
| CPU `local-task` | 4 | 46,43,40,37 | 4/4 slots 48/48 EXACT | 115 | 34.7 | +4.7% |
| CUDA GB10 | 4 | 46,43,40,37 | 4/4 slots 48/48 EXACT | 89 | 44.8 | +1.9% |
| CUDA GB10 | 8 | 46,43,40,37,34,31,28,25 | 8/8 slots 48/48 EXACT | 96 | 83.6 | +7.5% |

## Findings

- **Ragged decode is correct.** Eight sequences of eight different lengths in one batch each reproduce their independent single-seq stream exactly; per-row pos/cache_len/mask and the per-row KV write are all right.
- **The per-row KV-write unroll is cheap.** `B*L` `dynamic_update_slice`s per step add only ~2% (B=4) to ~7.5% (B=8) over uniform-B, and lower fine on CPU and CUDA (compile ~5-7.5s).
- CPU large-B validation is reference-bound (Phase 1 runs B single-seq references sequentially), a harness cost, not a graph cost; the B sweep runs on CUDA.

Full tables in `spike/iree-ffi/FINDINGS_ragged.md`; the full Stage 2 plan in `spike/openxla/STAGE2_DESIGN.md`.

## Reproduce

```bash
cd spike/iree-ffi
EMIT=../rust-emitter/target/release/emit; IC=./iree-dist/bin/iree-compile
F="--iree-input-type=stablehlo --iree-hal-target-device=local --iree-hal-local-target-device-backends=llvm-cpu"
$EMIT prefill-argmax p.mlir && $IC $F p.mlir -o p.vmfb
$EMIT decode-argmax s.mlir  && $IC $F s.mlir -o s.vmfb
$EMIT decode-ragged-argmax 4 r.mlir && $IC $F r.mlir -o r.vmfb
IREE_DIST=./iree-dist cargo run --release --bin llama_ragged -- \
  --batch 4 --device local-task --prefill p.vmfb --sdecode s.vmfb --decode r.vmfb
```

## Next

2a-ii: the admit/evict scheduler (request queue, mid-stream prefill into a freed slot, eviction on EOS, slot recycling, staggered-arrival validation). Then 2b productizes the engine into `mlxcel-xla`.

Refs #449
