### PR TITLE
feat: serve the OpenXLA backend through the continuous-batching engine (#449 M3 Stage 2c)

### DIFF
--- a/src/backend/xla.rs
+++ b/src/backend/xla.rs
@@ -113,6 +113,9 @@ impl ComputeBackend for XlaBackend {
     }
 
     fn supports_batched_serving(&self) -> bool {
-        false
+        // The OpenXLA backend serves through the continuous-batching engine
+        // (issue #449 M3 Stage 2c) once real IREE execution is compiled in. Without
+        // `xla-iree` there is no engine to batch with, so it reports false.
+        cfg!(feature = "xla-iree")
     }
 }

--- a/src/lib/mlxcel-xla/README.md
+++ b/src/lib/mlxcel-xla/README.md
@@ -95,12 +95,31 @@ contiguous per-slot KV.
 
 The engine is backend-neutral at the request level (`submit` a prompt + budget,
 `pump` a step, read per-request `EngineEvent`s, `cancel`); it holds no server
-types, so the Stage 2c `BatchEngine` trait + server adapter wrap it unchanged.
-`XlaBackend::supports_batched_serving()` stays `false` until 2c wires it into the
-server.
+types, so the server adapter wraps it unchanged.
 
-Prove it without the server with the reference-equivalence + throughput example
-(every request's batched stream must equal its independent single-seq reference):
+### Serving (Stage 2c)
+
+On an `xla-iree` build, `mlxcel-server` serves through this engine when
+`MLXCEL_BACKEND=xla` is selected: a server-side `XlaServeWorker` adapts the engine
+to the server's backend-neutral `BatchEngine` contract (the MLX scheduler
+implements the same contract), so the HTTP path is unchanged.
+
+```bash
+MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=cuda ./target/release/mlxcel-server \
+  -m <Llama-3.2-1B-Instruct dir> --port 8080
+# then POST /v1/completions as usual.
+```
+
+The serve path is greedy and text-only (the engine's nature): it honors
+`max_tokens` and the model's EOS ids, but serves greedily regardless of sampling
+parameters (logged once). Requests it cannot serve faithfully are rejected with a
+clear error rather than served wrong: logprobs, structured / JSON-schema output,
+and multimodal inputs. Stop strings are not enforced yet. `--max-batch-size` maps
+to the engine's bundled `B_max` (`>= 8` -> 8, else 4).
+
+Prove the engine without the server with the reference-equivalence + throughput
+example (every request's batched stream must equal its independent single-seq
+reference):
 
 ```bash
 # CPU (prebuilt dist):

--- a/src/server/batch/mod.rs
+++ b/src/server/batch/mod.rs
@@ -46,6 +46,11 @@ mod sequence;
 pub(crate) mod speculative_burst;
 #[cfg(test)]
 mod speculative_burst_tests;
+/// OpenXLA / IREE serve worker (issue #449 M3 Stage 2c): adapts the
+/// `mlxcel-xla` continuous-batching engine to the [`BatchEngine`] contract.
+/// Behind `xla-iree` (real IREE execution); the MLX serving path is unaffected.
+#[cfg(feature = "xla-iree")]
+pub(crate) mod xla_worker;
 
 pub use active::ActiveBatch;
 pub use observability::{BatchObservability, ObservabilitySnapshot};
@@ -54,3 +59,37 @@ pub use scheduler::BatchScheduler;
 pub use sequence::{
     BatchSchedulerAction, FinishReason, RequestPriority, SequenceInfo, SequenceState,
 };
+#[cfg(feature = "xla-iree")]
+pub(crate) use xla_worker::XlaServeWorker;
+
+/// Backend-neutral batching contract for a model worker (issue #449 M3 Stage 2c,
+/// the cross-backend batching seam ADR 0004 deferred).
+///
+/// A worker owns its model plus KV/scheduling, consumes [`ModelRequest`]s off the
+/// `request_rx` it was constructed with, and streams [`GenerateEvent`]s per request
+/// until it receives [`ModelRequest::Shutdown`]. The MLX [`BatchScheduler`] and the
+/// OpenXLA [`XlaServeWorker`] both satisfy it, so `ModelProvider` drives either
+/// backend through one contract.
+///
+/// Each worker is constructed and run entirely on its own thread (the worker
+/// functions in `model_worker.rs` build it inside `thread::spawn`), so it is never
+/// moved across threads and needs no `Send` bound. That matters for the OpenXLA
+/// worker, whose IREE context is thread-affine (`!Send`) by design.
+///
+/// [`ModelRequest`]: crate::server::model_provider::ModelRequest
+/// [`ModelRequest::Shutdown`]: crate::server::model_provider::ModelRequest::Shutdown
+/// [`GenerateEvent`]: crate::server::model_provider::GenerateEvent
+pub(crate) trait BatchEngine {
+    /// Run the worker's serve loop to completion (until shutdown). Called once,
+    /// on the worker thread.
+    fn serve(&mut self);
+}
+
+impl BatchEngine for BatchScheduler {
+    fn serve(&mut self) {
+        // Forward to the scheduler's existing inherent run loop. Method-call
+        // syntax resolves to the inherent `BatchScheduler::run` (inherent methods
+        // shadow trait methods), so the MLX serving behavior is unchanged.
+        self.run();
+    }
+}

--- a/src/server/batch/xla_worker.rs
+++ b/src/server/batch/xla_worker.rs
@@ -1,0 +1,337 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! OpenXLA / IREE serve worker (issue #449 M3 Stage 2c).
+//!
+//! [`XlaServeWorker`] adapts the `mlxcel-xla` continuous-batching engine
+//! ([`XlaBatchEngine`]) to the server's [`BatchEngine`](super::BatchEngine)
+//! contract, so `ModelProvider` drives the OpenXLA backend through the same
+//! request/event seam as the MLX [`BatchScheduler`](super::BatchScheduler). The
+//! serve loop drains [`ModelRequest`]s, tokenizes each prompt, submits it to the
+//! engine, pumps the engine one step at a time, and maps each per-request
+//! [`EngineEvent`] back to a [`GenerateEvent`] on that request's channel, reusing
+//! the server's [`StreamingDecodeState`] for byte-fallback-safe detokenization.
+//!
+//! Scope: the OpenXLA engine is greedy (argmax) and text-only, so this path
+//! honors `max_tokens` and the model's EOS ids but serves greedily regardless of
+//! the request's sampling parameters (logged once). Requests that need features
+//! the engine cannot provide are rejected with a clear error rather than served
+//! wrong: logprobs (no logit readback), structured / JSON-schema output (no
+//! constraint masking), and multimodal inputs (text-only). Stop strings are not
+//! enforced yet (EOS + `max_tokens` terminate); that is a follow-up.
+//!
+//! Compiled only under `xla-iree` (real IREE execution). The MLX serving path is
+//! untouched.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::time::Instant;
+
+use mlxcel_xla::{EngineEvent, FinishReason as XlaFinishReason, XlaBatchEngine};
+
+use super::BatchEngine;
+use crate::server::ServerGenerateOptions;
+use crate::server::model_provider::model_worker::StreamingDecodeState;
+use crate::server::model_provider::{GenerateEvent, ModelRequest};
+use crate::tokenizer::MlxcelTokenizer;
+
+/// Per-active-request state, keyed by the engine's request id.
+struct ServeState {
+    response_tx: mpsc::Sender<GenerateEvent>,
+    cancelled: Arc<AtomicBool>,
+    detok: StreamingDecodeState,
+    start: Instant,
+    prompt_token_count: usize,
+    max_tokens: usize,
+}
+
+/// Server-side worker that serves requests through the OpenXLA continuous-batching
+/// engine. Built and run on a single worker thread (see
+/// `model_worker::spawn_xla_model_worker`).
+pub(crate) struct XlaServeWorker {
+    engine: XlaBatchEngine,
+    tokenizer: MlxcelTokenizer,
+    request_rx: mpsc::Receiver<ModelRequest>,
+    /// Active requests, keyed by the engine req id `submit` returned.
+    states: HashMap<u64, ServeState>,
+    shutdown: bool,
+    warned_sampling: bool,
+    warned_stop: bool,
+}
+
+impl XlaServeWorker {
+    pub(crate) fn new(
+        engine: XlaBatchEngine,
+        tokenizer: MlxcelTokenizer,
+        request_rx: mpsc::Receiver<ModelRequest>,
+    ) -> Self {
+        Self {
+            engine,
+            tokenizer,
+            request_rx,
+            states: HashMap::new(),
+            shutdown: false,
+            warned_sampling: false,
+            warned_stop: false,
+        }
+    }
+
+    /// Validate, tokenize, and submit one `Generate` request, or send a terminal
+    /// `Error` / empty `Done` when it cannot be served as submitted.
+    fn admit(
+        &mut self,
+        prompt: String,
+        options: ServerGenerateOptions,
+        images: Vec<Vec<u8>>,
+        audio: Vec<Vec<u8>>,
+        videos: Vec<crate::server::media::ResolvedVideo>,
+        response_tx: mpsc::Sender<GenerateEvent>,
+        cancelled: Arc<AtomicBool>,
+    ) {
+        // Reject what the engine genuinely cannot serve, rather than serve it wrong.
+        if !images.is_empty() || !audio.is_empty() || !videos.is_empty() {
+            let _ = response_tx.send(GenerateEvent::Error(
+                "the OpenXLA backend is text-only; multimodal inputs are not supported".to_string(),
+            ));
+            return;
+        }
+        if options.logprobs.enabled {
+            let _ = response_tx.send(GenerateEvent::Error(
+                "the OpenXLA backend does not support logprobs (greedy argmax, no logit readback)"
+                    .to_string(),
+            ));
+            return;
+        }
+        if options.structured.is_some() {
+            let _ = response_tx.send(GenerateEvent::Error(
+                "the OpenXLA backend does not support structured / JSON-schema output".to_string(),
+            ));
+            return;
+        }
+
+        // Greedy regardless of sampling params, and stop strings are not enforced
+        // yet; warn once each so operators are not surprised, then serve.
+        if !self.warned_sampling {
+            tracing::warn!(
+                "the OpenXLA backend serves greedily (argmax); request sampling parameters \
+                 (temperature/top_p/top_k/penalties) are ignored on this backend"
+            );
+            self.warned_sampling = true;
+        }
+        if !self.warned_stop
+            && options
+                .stop_sequences
+                .as_ref()
+                .is_some_and(|s| !s.is_empty())
+        {
+            tracing::warn!(
+                "the OpenXLA backend does not enforce stop strings yet; generation stops on EOS \
+                 or max_tokens only"
+            );
+            self.warned_stop = true;
+        }
+
+        let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
+        let token_ids = match self.tokenizer.encode(&prompt, add_special) {
+            Ok(ids) => ids,
+            Err(err) => {
+                let _ =
+                    response_tx.send(GenerateEvent::Error(format!("Tokenization error: {err}")));
+                return;
+            }
+        };
+        let prompt_tokens: Vec<i32> = token_ids.iter().map(|&x| x as i32).collect();
+
+        // A zero token budget asks for no generation: return an empty result so the
+        // route still sees usage counts, without touching the engine.
+        if options.max_tokens == 0 {
+            let detok = StreamingDecodeState::new(&self.tokenizer, &prompt_tokens);
+            let result = detok.finish(Instant::now(), prompt_tokens.len(), 0);
+            let _ = response_tx.send(GenerateEvent::Done(result));
+            return;
+        }
+
+        let detok = StreamingDecodeState::new(&self.tokenizer, &prompt_tokens);
+        match self.engine.submit(&prompt_tokens, options.max_tokens) {
+            Ok(req_id) => {
+                self.states.insert(
+                    req_id,
+                    ServeState {
+                        response_tx,
+                        cancelled,
+                        detok,
+                        start: Instant::now(),
+                        prompt_token_count: prompt_tokens.len(),
+                        max_tokens: options.max_tokens,
+                    },
+                );
+            }
+            Err(err) => {
+                let _ = response_tx.send(GenerateEvent::Error(format!(
+                    "OpenXLA submit failed: {err}"
+                )));
+            }
+        }
+    }
+
+    fn handle(&mut self, req: ModelRequest) {
+        match req {
+            ModelRequest::Generate {
+                prompt,
+                options,
+                images,
+                audio,
+                videos,
+                response_tx,
+                cancelled,
+            } => self.admit(
+                prompt,
+                options,
+                images,
+                audio,
+                videos,
+                response_tx,
+                cancelled,
+            ),
+            ModelRequest::Shutdown => self.shutdown = true,
+        }
+    }
+
+    /// Pull requests off the channel. When `block` is set (the engine is idle so
+    /// there is nothing else to do), block for the first one; then drain any more
+    /// that are already queued without blocking.
+    fn drain_incoming(&mut self, block: bool) {
+        if block {
+            match self.request_rx.recv() {
+                Ok(req) => self.handle(req),
+                // Sender dropped: treat as shutdown.
+                Err(_) => {
+                    self.shutdown = true;
+                    return;
+                }
+            }
+        }
+        loop {
+            match self.request_rx.try_recv() {
+                Ok(req) => self.handle(req),
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.shutdown = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Drop any requests whose client cancelled, freeing their engine slots. A
+    /// cancelled request emits no further events (the caller initiated it).
+    fn evict_cancelled(&mut self) {
+        let ids: Vec<u64> = self
+            .states
+            .iter()
+            .filter(|(_, s)| s.cancelled.load(Ordering::Relaxed))
+            .map(|(&id, _)| id)
+            .collect();
+        for id in ids {
+            self.engine.cancel(id);
+            self.states.remove(&id);
+        }
+    }
+
+    /// Map one engine step's events onto the per-request channels.
+    fn dispatch(&mut self, events: Vec<EngineEvent>) {
+        for ev in events {
+            match ev {
+                EngineEvent::Token { req_id, token } => {
+                    if let Some(state) = self.states.get_mut(&req_id)
+                        && let Some(piece) = state.detok.on_token(token, &self.tokenizer)
+                    {
+                        let _ = state.response_tx.send(GenerateEvent::Token(piece));
+                    }
+                }
+                EngineEvent::Finished { req_id, reason } => {
+                    if let Some(state) = self.states.remove(&req_id) {
+                        let ServeState {
+                            response_tx,
+                            mut detok,
+                            start,
+                            prompt_token_count,
+                            max_tokens,
+                            ..
+                        } = state;
+                        detok.flush(&self.tokenizer);
+                        let mut result = detok.finish(start, prompt_token_count, max_tokens);
+                        // The engine knows the authoritative reason; prefer it over
+                        // the count-based inference in `finish`.
+                        result.finish_reason = match reason {
+                            XlaFinishReason::Stop => "stop",
+                            XlaFinishReason::Length => "length",
+                        }
+                        .to_string();
+                        let _ = response_tx.send(GenerateEvent::Done(result));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Send a terminal `Error` to every in-flight request (used when the engine
+    /// fails fatally) and clear them.
+    fn fail_all(&mut self, msg: &str) {
+        for (_, state) in self.states.drain() {
+            let _ = state
+                .response_tx
+                .send(GenerateEvent::Error(msg.to_string()));
+        }
+    }
+}
+
+impl BatchEngine for XlaServeWorker {
+    fn serve(&mut self) {
+        tracing::info!(
+            "OpenXLA serve worker starting (continuous batching, B_max={}, greedy)",
+            self.engine.b_max()
+        );
+        loop {
+            self.evict_cancelled();
+
+            // If the engine has no work, block for the next request so the thread
+            // does not spin; otherwise pick up any newly queued requests and pump.
+            let block = self.engine.is_idle() && !self.shutdown;
+            self.drain_incoming(block);
+            self.evict_cancelled();
+
+            if self.engine.is_idle() {
+                if self.shutdown {
+                    break;
+                }
+                // Idle but not shutdown (e.g. everything drained was cancelled or a
+                // zero-budget request): loop and block again.
+                continue;
+            }
+
+            match self.engine.pump() {
+                Ok(events) => self.dispatch(events),
+                Err(err) => {
+                    tracing::error!("OpenXLA engine step failed: {err}");
+                    self.fail_all(&format!("OpenXLA engine step failed: {err}"));
+                    break;
+                }
+            }
+        }
+        tracing::info!("OpenXLA serve worker stopped");
+    }
+}

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -197,6 +197,29 @@ impl ModelProvider {
         let speculative_dispatch = crate::server::SpeculativeDispatch::resolve(config)
             .map_err(|e| anyhow::anyhow!("Speculative decoding dispatch resolution failed: {e}"))?;
 
+        // OpenXLA backend (issue #449 M3 Stage 2c): when `MLXCEL_BACKEND=xla` is
+        // selected on an `xla-iree` build, serve through the continuous-batching
+        // XLA engine instead of the MLX scheduler. The MLX path below is the
+        // default and is unaffected. The XLA engine is greedy and owns its own
+        // KV/scheduling, so most scheduler config (`no_batch`, preemption,
+        // speculative dispatch, prompt cache) does not apply; `max_batch_size`
+        // maps to the engine's bundled slot count.
+        #[cfg(feature = "xla-iree")]
+        if std::env::var("MLXCEL_BACKEND").ok().as_deref() == Some("xla") {
+            if config.no_batch {
+                tracing::warn!(
+                    "--no-batch is ignored by the OpenXLA backend; it serves through the \
+                     continuous-batching engine"
+                );
+            }
+            let b_max = xla_serve_b_max(config.max_batch_size);
+            let mut provider =
+                Self::new_with_xla_worker(model_path, b_max, batch_metrics, batch_observability)?;
+            provider.prompt_cache = prompt_cache_store;
+            provider.decode_hang_timeout = decode_hang_timeout;
+            return Ok(provider);
+        }
+
         if config.no_batch {
             let mut provider = Self::new_with_legacy_worker(
                 model_path,
@@ -308,6 +331,51 @@ impl ModelProvider {
             worker_model_id,
             metrics_clone,
             obs_clone,
+        );
+
+        Ok(Self {
+            request_tx,
+            model_id,
+            created_at,
+            loaded,
+            batch_metrics,
+            batch_observability,
+            prompt_cache: None,
+            decode_hang_timeout: DECODE_HANG_TIMEOUT,
+            _worker_handle: worker_handle,
+        })
+    }
+
+    /// Create and start a model provider backed by the OpenXLA / IREE
+    /// continuous-batching engine (issue #449 M3 Stage 2c).
+    ///
+    /// Spawns [`spawn_xla_model_worker`](model_worker::spawn_xla_model_worker),
+    /// which builds the engine + tokenizer on the worker thread and serves through
+    /// the [`BatchEngine`](crate::server::batch::BatchEngine) contract. The batch
+    /// metrics/observability handles are held for the provider API surface but the
+    /// XLA worker does not populate the MLX scheduler metrics.
+    #[cfg(feature = "xla-iree")]
+    pub(crate) fn new_with_xla_worker(
+        model_path: PathBuf,
+        b_max: usize,
+        batch_metrics: Arc<BatchMetrics>,
+        batch_observability: Arc<BatchObservability>,
+    ) -> Result<Self> {
+        let model_id = model_path
+            .file_name()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let created_at = chrono::Utc::now().timestamp();
+        let (request_tx, request_rx) = mpsc::channel::<ModelRequest>();
+        let loaded = Arc::new(AtomicBool::new(false));
+
+        let worker_handle = model_worker::spawn_xla_model_worker(
+            model_path,
+            b_max,
+            request_rx,
+            loaded.clone(),
+            model_id.clone(),
         );
 
         Ok(Self {
@@ -1013,6 +1081,16 @@ pub(crate) fn validated_decode_hang_timeout(timeout_seconds: u64) -> Duration {
         return DECODE_HANG_TIMEOUT;
     }
     Duration::from_secs(timeout_seconds)
+}
+
+/// Map the server's `--max-batch-size` to one of the OpenXLA engine's bundled
+/// slot counts (issue #449 M3 Stage 2c): the largest bundled `B_max` that does
+/// not exceed the request, defaulting to the smallest. The engine compiles one
+/// ragged graph per slot count, so the server picks from the bundled set rather
+/// than any value.
+#[cfg(feature = "xla-iree")]
+fn xla_serve_b_max(max_batch_size: usize) -> usize {
+    if max_batch_size >= 8 { 8 } else { 4 }
 }
 
 /// Drain `response_rx`, forwarding decoded tokens to `on_token` and applying

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -30,6 +30,9 @@ use mlxcel_core::generate::LanguageModel;
 
 use crate::LoadedModel;
 use crate::SamplingConfig;
+// The backend-neutral serve contract (#449 M3 Stage 2c). The MLX scheduler and the
+// OpenXLA worker are both driven through `BatchEngine::serve`.
+use crate::server::batch::BatchEngine;
 use crate::server::batch::BatchObservability;
 use crate::server::media::{ImageInputLimits, current_image_input_limits};
 use crate::server::state::BatchMetrics;
@@ -518,10 +521,10 @@ pub(crate) fn spawn_model_worker_with_batch_config(
                         sched_config.serving_bind,
                         &sched_config.decode_peers,
                     ) {
-                        scheduler.run();
+                        scheduler.serve();
                     }
                 }
-                ServingMode::Hybrid | ServingMode::Router => scheduler.run(),
+                ServingMode::Hybrid | ServingMode::Router => scheduler.serve(),
             }
         })
     })
@@ -859,7 +862,67 @@ pub(crate) fn spawn_legacy_model_worker(
                 crate::server::DecodeStorageBackend::Dense,
             )
             .with_reasoning_budget(reasoning_budget, thinking_ids);
-            scheduler.run();
+            scheduler.serve();
+        })
+    })
+}
+
+/// Spawn the OpenXLA / IREE serve worker (issue #449 M3 Stage 2c).
+///
+/// Parallel to [`spawn_legacy_model_worker`], but for the OpenXLA backend: it
+/// builds the `mlxcel-xla` continuous-batching engine and a standalone tokenizer
+/// inside the worker thread (so loading does not block the server start, same as
+/// the MLX path), marks the model loaded, then drives the
+/// [`XlaServeWorker`](crate::server::batch::XlaServeWorker) through the
+/// [`BatchEngine`](crate::server::batch::BatchEngine) contract. `b_max` is one of
+/// the engine's bundled slot counts; the HAL device is read from
+/// `MLXCEL_XLA_DEVICE` (default `local-task`), matching the single-sequence path.
+#[cfg(feature = "xla-iree")]
+pub(crate) fn spawn_xla_model_worker(
+    model_path: PathBuf,
+    b_max: usize,
+    request_rx: mpsc::Receiver<ModelRequest>,
+    loaded: Arc<AtomicBool>,
+    worker_model_id: String,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        // Same fail-fast posture as the MLX workers (issue #375): abort the
+        // process on an uncaught panic rather than unwinding away a serve thread.
+        run_core_thread_or_abort("model-worker-xla", move || {
+            let device =
+                std::env::var("MLXCEL_XLA_DEVICE").unwrap_or_else(|_| "local-task".to_string());
+            tracing::info!(
+                "Model worker thread starting (OpenXLA continuous batching, B_max={b_max}, \
+                 device={device}), loading model..."
+            );
+
+            let load_start = Instant::now();
+            let tokenizer = match crate::tokenizer::load_tokenizer(&model_path) {
+                Ok(t) => t,
+                Err(err) => {
+                    tracing::error!("Failed to load tokenizer for the OpenXLA backend: {err}");
+                    return;
+                }
+            };
+            let engine = match mlxcel_xla::XlaBatchEngine::load(&model_path, b_max, &device) {
+                Ok(engine) => engine,
+                Err(err) => {
+                    tracing::error!("Failed to load the OpenXLA engine: {err}");
+                    return;
+                }
+            };
+            let load_elapsed = load_start.elapsed();
+            tracing::info!(
+                worker_model_id = %worker_model_id,
+                load_seconds = load_elapsed.as_secs_f64(),
+                "OpenXLA model {worker_model_id} loaded in {:.3}s (B_max={b_max}, device={device})",
+                load_elapsed.as_secs_f64(),
+            );
+            loaded.store(true, Ordering::Release);
+
+            let mut worker =
+                crate::server::batch::XlaServeWorker::new(engine, tokenizer, request_rx);
+            worker.serve();
         })
     })
 }


### PR DESCRIPTION
## Summary

Stage 2c of the OpenXLA/IREE throughput milestone (#449 M3): wire the Stage 2b `XlaBatchEngine` (PR #469) into `mlxcel-server` so the OpenXLA backend is **servable**, not just CLI. With `MLXCEL_BACKEND=xla` on an `xla-iree` build, requests are served through the continuous-batching engine. The MLX serving path is unchanged.

Until now the server only ran MLX: it always built a `BatchScheduler` from an MLX `LoadedModel` (the XLA backend's `load_model()` errors), so `MLXCEL_BACKEND=xla` never reached the server. This PR adds the first non-MLX serving worker.

## What's here

- **`BatchEngine` trait** (`src/server/batch/mod.rs`): the backend-neutral serve contract (the cross-backend batching seam ADR 0004 deferred). A worker owns its model + KV/scheduling, consumes `ModelRequest`s, and streams `GenerateEvent`s until `Shutdown`. The MLX `BatchScheduler` and the new `XlaServeWorker` both implement it; the MLX worker spawn sites now dispatch through `serve()`, which forwards to the scheduler's existing `run` loop (behavior unchanged).
- **`XlaServeWorker`** (`src/server/batch/xla_worker.rs`, `#[cfg(feature = "xla-iree")]`): drains `ModelRequest`s, tokenizes prompts, submits to the engine, pumps it one step at a time, and maps each per-request `EngineEvent` back to a `GenerateEvent`, reusing the server's `StreamingDecodeState` for byte-fallback-safe detokenization. Polls the cancel flag; blocks on `recv` when idle.
- **`ModelProvider` routing** (`model_provider.rs`): `MLXCEL_BACKEND=xla` spawns the XLA worker (`new_with_xla_worker` / `spawn_xla_model_worker`, which build the engine + tokenizer on the worker thread, same async-load posture as the MLX path); `--max-batch-size` maps to the engine's bundled `B_max` (`>= 8` -> 8, else 4); the HAL device comes from `MLXCEL_XLA_DEVICE`.
- **`XlaBackend::supports_batched_serving()`** returns `true` under `xla-iree`.

## Scope (the engine is greedy + text-only by nature)

Honors `max_tokens` and the model's EOS ids; serves greedily regardless of sampling parameters (logged once). Rejects what it cannot serve faithfully, with a clear error rather than wrong output: **logprobs** (no logit readback), **structured / JSON-schema output** (no constraint masking), and **multimodal** inputs (text-only). **Stop strings** are not enforced yet (EOS + `max_tokens` terminate). So this is a reference/experimental serving path, gated behind `xla-iree`.

## Validation (E2E on GB10, CUDA)

Server started with `MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=cuda` + Llama-3.2-1B:

- **Token-exact**: `/v1/completions` for `"The capital of France is"` returns `" Paris. The Eiffel Tower is located in Paris. The Louvre Museum is also located in"`, identical to the `--no-chat-template` CLI reference (same engine, same greedy).
- **Continuous batching**: 3 concurrent prompts each served correctly through `B_max=4` ("Jupiter ... gas giant", "4", "small village ... Tuscany").
- **Streaming**: SSE chunks concatenate to the same text.
- **Option rejection**: a `logprobs` request returns `error: ... the OpenXLA backend does not support logprobs ...`.
- **Usage / finish_reason** correct (`prompt_tokens`, `completion_tokens`, `length`/`stop`).

**MLX serving path unchanged**: default build compiles with the XLA worker absent; `serve()` is a verbatim forward to the scheduler's `run`; `cargo clippy -D warnings` clean (default + `xla-iree`); scheduler tests green.

Refs #449 (epic). Follows #469 (Stage 2b), #468/#466 (2a), #462 (Stage 1). Next: Stage 2d (paged-KV, chunked prefill, sampling, stop strings).
