### PR TITLE
feat: default output token cap follows llama.cpp (resolve -1 to context window)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ mlxcel run
 
 `generate`, `serve`, and `inspect` take the same model argument via `-m`, a HuggingFace `owner/name` repo-id (auto-downloaded into the store and reused after), a bare name (resolved as `mlx-community/<name>`), or an existing local path. `mlxcel run` is a thin wrapper over `mlxcel generate` and shares its sampling and generation flags.
 
+Output length follows llama.cpp: with no `-n/--max-tokens` (default `-1`), `generate` / `run` keep generating until the model emits an end-of-sequence token or fills its context window. The server's `--n-predict` default (`-1`) behaves the same per request. Pass an explicit `-n N` (or `--n-predict N`) to cap output at exactly `N` tokens.
+
 ```bash
-# One-off generation.
+# One-off generation (omit -n to run until EOS / context window; -n N caps it).
 mlxcel generate -m Qwen3.5-0.8B-4bit -p "Hello, world!" -n 100
 
 # OpenAI-compatible server (mlxcel serve is the subcommand equivalent).

--- a/src/cli/max_tokens.rs
+++ b/src/cli/max_tokens.rs
@@ -1,0 +1,132 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared `-n/--max-tokens` resolution for the CLI generation paths.
+//!
+//! llama.cpp's default `n_predict = -1` means "generate until EOS or until the
+//! model context window (`n_ctx`) is full". mlxcel mirrors that: the
+//! `-n/--max-tokens` flag (and the server `--n-predict`) defaults to `-1`,
+//! which [`parse_max_tokens`] folds into the [`UNLIMITED_MAX_TOKENS`] sentinel.
+//! The generation paths then resolve the sentinel against the loaded model's
+//! context window via [`resolve_unlimited_max_tokens`]. An explicit
+//! non-negative `-n N` is always kept verbatim.
+//!
+//! The context window itself is read from the checkpoint's `config.json` by
+//! [`crate::read_model_context_window`]; when that is unavailable the caller
+//! falls back to [`DEFAULT_CONTEXT_WINDOW_FALLBACK`] so the budget stays
+//! bounded.
+
+/// Sentinel stored in `max_tokens` fields meaning "no explicit cap; resolve to
+/// the model context window at generation time".
+///
+/// Chosen as `usize::MAX` so an unresolved sentinel that ever leaked into an
+/// allocation or loop bound would fail loudly rather than silently behave as a
+/// plausible token budget.
+pub const UNLIMITED_MAX_TOKENS: usize = usize::MAX;
+
+/// Context window used when a checkpoint's `config.json` exposes no context
+/// length. Matches the historical `mlxcel serve` default so behavior stays
+/// bounded and predictable for checkpoints that omit `max_position_embeddings`.
+pub const DEFAULT_CONTEXT_WINDOW_FALLBACK: usize = 4096;
+
+/// clap `value_parser` for the `-n/--max-tokens` (and server `--n-predict`)
+/// flag.
+///
+/// Accepts any integer. A negative value (canonically `-1`, llama.cpp's
+/// "unlimited" spelling) maps to [`UNLIMITED_MAX_TOKENS`]; a non-negative value
+/// is taken verbatim as the token budget.
+pub fn parse_max_tokens(s: &str) -> Result<usize, String> {
+    let raw: i64 = s.trim().parse().map_err(|_| {
+        format!("invalid max-tokens value '{s}': expected an integer (-1 = unlimited)")
+    })?;
+    if raw < 0 {
+        Ok(UNLIMITED_MAX_TOKENS)
+    } else {
+        Ok(raw as usize)
+    }
+}
+
+/// Resolve a (possibly sentinel) token budget against a model context window.
+///
+/// * An explicit budget (anything other than [`UNLIMITED_MAX_TOKENS`]) is
+///   returned unchanged, so a user who passed `-n N` always gets exactly `N`.
+/// * The sentinel resolves to `context_window - prompt_len`, clamped to at
+///   least 1 so a prompt that already fills the window still emits a token.
+///
+/// Callers must pass a non-zero `context_window` (use
+/// [`DEFAULT_CONTEXT_WINDOW_FALLBACK`] when the model exposes none); a zero
+/// window would otherwise collapse the unlimited budget to a single token.
+pub fn resolve_unlimited_max_tokens(
+    requested: usize,
+    context_window: usize,
+    prompt_len: usize,
+) -> usize {
+    if requested != UNLIMITED_MAX_TOKENS {
+        return requested;
+    }
+    context_window.saturating_sub(prompt_len).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_negative_is_unlimited_sentinel() {
+        assert_eq!(parse_max_tokens("-1"), Ok(UNLIMITED_MAX_TOKENS));
+        assert_eq!(parse_max_tokens("-42"), Ok(UNLIMITED_MAX_TOKENS));
+    }
+
+    #[test]
+    fn parse_non_negative_is_verbatim() {
+        assert_eq!(parse_max_tokens("0"), Ok(0));
+        assert_eq!(parse_max_tokens("256"), Ok(256));
+        assert_eq!(parse_max_tokens(" 128 "), Ok(128));
+    }
+
+    #[test]
+    fn parse_rejects_non_integer() {
+        assert!(parse_max_tokens("abc").is_err());
+        assert!(parse_max_tokens("1.5").is_err());
+        assert!(parse_max_tokens("").is_err());
+    }
+
+    #[test]
+    fn explicit_budget_ignores_context_window() {
+        // A concrete `-n 50` is honored verbatim regardless of window/prompt.
+        assert_eq!(resolve_unlimited_max_tokens(50, 4096, 100), 50);
+        assert_eq!(resolve_unlimited_max_tokens(0, 4096, 100), 0);
+    }
+
+    #[test]
+    fn unlimited_resolves_to_window_minus_prompt() {
+        assert_eq!(
+            resolve_unlimited_max_tokens(UNLIMITED_MAX_TOKENS, 4096, 96),
+            4000
+        );
+    }
+
+    #[test]
+    fn unlimited_clamps_to_at_least_one() {
+        // Prompt at or beyond the window still yields one token, never zero.
+        assert_eq!(
+            resolve_unlimited_max_tokens(UNLIMITED_MAX_TOKENS, 4096, 4096),
+            1
+        );
+        assert_eq!(
+            resolve_unlimited_max_tokens(UNLIMITED_MAX_TOKENS, 4096, 9000),
+            1
+        );
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,5 +22,6 @@
 //! one place.
 
 pub mod batch_quant_args;
+pub mod max_tokens;
 pub mod speculative_args;
 pub mod turbo_args;

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -57,6 +57,9 @@ use anyhow::{Result, anyhow};
 use rustyline::DefaultEditor;
 use rustyline::error::ReadlineError;
 
+use mlxcel::cli::max_tokens::{
+    DEFAULT_CONTEXT_WINDOW_FALLBACK, UNLIMITED_MAX_TOKENS, resolve_unlimited_max_tokens,
+};
 use mlxcel::sampling::{ResolvedSamplingParams, build_sampling_config};
 use mlxcel::server::chat_template::{ChatMessage, ChatTemplateProcessor};
 use mlxcel::server::model_provider::model_worker::StreamingDecodeState;
@@ -185,6 +188,21 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
         load_start.elapsed().as_secs_f64()
     );
 
+    // llama.cpp parity (issue #476): the default unlimited `-n -1` caps each
+    // reply at the model context window instead of a fixed number, so chat turns
+    // run until EOS or the window fills. Read the window once; `stream_turn`
+    // computes the per-turn budget (window - rendered prompt) so a growing
+    // transcript never overruns the context. An explicit `-n N` is honored
+    // verbatim every turn.
+    let context_window =
+        mlxcel::read_model_context_window(&model_path).unwrap_or(DEFAULT_CONTEXT_WINDOW_FALLBACK);
+    if opts.max_tokens == UNLIMITED_MAX_TOKENS {
+        println!(
+            "Per-turn output: unlimited (-1) -> until EOS or the model context window \
+             ({context_window} tokens)."
+        );
+    }
+
     // Same chat-template discovery as `generate`'s `load_cli_prompt`. `None`
     // (no template, or `--no-chat-template`) falls back to raw-text turns.
     let processor = if opts.no_chat_template {
@@ -297,6 +315,7 @@ pub fn run_chat(opts: ChatOptions) -> Result<()> {
                     &tokenizer,
                     &prompt,
                     opts.max_tokens,
+                    context_window,
                     &sampling_config,
                 )?;
 
@@ -546,6 +565,7 @@ fn stream_turn<M: LanguageModel>(
     tokenizer: &MlxcelTokenizer,
     prompt: &str,
     max_tokens: usize,
+    context_window: usize,
     sampling_config: &SamplingConfig,
 ) -> Result<String> {
     let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
@@ -555,6 +575,12 @@ fn stream_turn<M: LanguageModel>(
         .iter()
         .map(|&x| x as i32)
         .collect();
+
+    // llama.cpp parity (issue #476): an unlimited `-n -1` becomes the remaining
+    // context (window minus this turn's rendered prompt) so the reply runs until
+    // EOS or the window fills; an explicit `-n N` is used verbatim. Resolved
+    // before the allocation below so the sentinel never reaches `with_capacity`.
+    let max_tokens = resolve_unlimited_max_tokens(max_tokens, context_window, prompt_tokens.len());
 
     // Stream display through the shared incremental detokenizer (byte-fallback
     // safe), accumulating exactly what was printed. The raw generated ids are

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -253,6 +253,30 @@ fn memory_preflight_ctx_len(prompt_tokens: usize, max_tokens: usize) -> u64 {
     u64::try_from(total).unwrap_or(u64::MAX)
 }
 
+/// Resolve a possibly-unlimited `-n/--max-tokens` value against the model's
+/// context window (issue #476, llama.cpp parity).
+///
+/// The unlimited sentinel (`-n -1`) becomes `context_window - prompt_len` (read
+/// from the checkpoint `config.json`, falling back to the shared default when
+/// the model exposes no context length). An explicit `-n N` is returned
+/// unchanged. A one-line note is printed when the unlimited default resolves so
+/// the effective cap stays visible to the operator.
+fn resolve_cli_max_tokens(requested: usize, model_dir: &Path, prompt_len: usize) -> usize {
+    use mlxcel::cli::max_tokens::{
+        DEFAULT_CONTEXT_WINDOW_FALLBACK, UNLIMITED_MAX_TOKENS, resolve_unlimited_max_tokens,
+    };
+    if requested != UNLIMITED_MAX_TOKENS {
+        return requested;
+    }
+    let window =
+        mlxcel::read_model_context_window(model_dir).unwrap_or(DEFAULT_CONTEXT_WINDOW_FALLBACK);
+    let resolved = resolve_unlimited_max_tokens(requested, window, prompt_len);
+    println!(
+        "Max tokens: unlimited (-1) -> {resolved} (model context window {window}, prompt {prompt_len})"
+    );
+    resolved
+}
+
 /// Run the `--estimate-memory` preflight for `mlxcel generate`.
 ///
 /// Returns `Some(estimate)` when the user passed `--estimate-memory`
@@ -1552,6 +1576,17 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
         usize::from(args.generation.audio.is_some()),
     );
     let mut prompt_tokens = tokenize_prompt(&tokenizer, &prompt)?;
+
+    // llama.cpp parity (issue #476): resolve an unlimited `-n -1` into a
+    // concrete budget (model context window minus the rendered prompt) now, so
+    // every downstream consumer (the memory preflight below, plus the standard /
+    // VLM / speculative / XLA / pipeline generators) reads a plain usize. An
+    // explicit `-n N` passes through unchanged.
+    args.generation.max_tokens = resolve_cli_max_tokens(
+        args.generation.max_tokens,
+        &args.model.model,
+        prompt_tokens.len(),
+    );
 
     // Memory preflight (issue #56). Runs after prompt rendering/tokenization so
     // long prompts are included in the KV-cache budget, but still before the

--- a/src/commands/run_tests.rs
+++ b/src/commands/run_tests.rs
@@ -148,6 +148,29 @@ fn run_shares_generate_sampling_and_generation_flags() {
 }
 
 #[test]
+fn run_default_max_tokens_is_unlimited_sentinel() {
+    // llama.cpp parity (issue #476): omitting `-n` defaults to `-1` (unlimited),
+    // which clap folds into the sentinel; the generation paths later resolve it
+    // to the model context window. An explicit `-n N` stays verbatim.
+    let args = parse_run(&["mlxcel", "run", "mlx-community/Qwen3-4B-4bit", "-p", "x"]);
+    assert_eq!(
+        args.into_generate_args().generation.max_tokens,
+        mlxcel::cli::max_tokens::UNLIMITED_MAX_TOKENS
+    );
+
+    let explicit = parse_run(&[
+        "mlxcel",
+        "run",
+        "mlx-community/Qwen3-4B-4bit",
+        "-p",
+        "x",
+        "-n",
+        "256",
+    ]);
+    assert_eq!(explicit.into_generate_args().generation.max_tokens, 256);
+}
+
+#[test]
 fn run_accepts_adapter_flag() {
     let args = parse_run(&[
         "mlxcel",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,5 +93,6 @@ pub use mlxcel_core::session::{InferenceSession, MlxInferenceSession, SessionCap
 pub use loaded_model::LoadedModel;
 pub use loaded_model_capabilities::VlmRuntimeRef;
 pub use loading::{
-    load_model, load_model_with_adapter, load_model_with_tensor_parallel, read_eos_token_ids,
+    context_window_from_config, load_model, load_model_with_adapter,
+    load_model_with_tensor_parallel, read_eos_token_ids, read_model_context_window,
 };

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -287,6 +287,51 @@ pub fn read_eos_token_ids(model_dir: &Path) -> Vec<i32> {
     parse_eos_token_ids(&config)
 }
 
+/// Read the model's context window from `config.json`.
+///
+/// Mirrors llama.cpp's `n_ctx_train`: the value generation treats as the upper
+/// bound when no explicit token budget is given (`-n -1` / `--n-predict -1`).
+/// Vision-language checkpoints nest the language-model config under
+/// `text_config`, so that object is consulted first, then the top level.
+///
+/// Returns `None` when `config.json` is missing/unreadable or exposes no
+/// context length; callers fall back to
+/// [`crate::cli::max_tokens::DEFAULT_CONTEXT_WINDOW_FALLBACK`].
+pub fn read_model_context_window(model_dir: &Path) -> Option<usize> {
+    let config_path = resolve_model_dir(model_dir).join("config.json");
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let config: serde_json::Value = parse_model_config(&content).ok()?;
+    context_window_from_config(&config)
+}
+
+/// Pure extraction of the context window from a parsed `config.json` value.
+///
+/// Split out from [`read_model_context_window`] so the key precedence (and the
+/// VLM `text_config` nesting) can be unit-tested without touching the
+/// filesystem.
+pub fn context_window_from_config(config: &serde_json::Value) -> Option<usize> {
+    const KEYS: [&str; 3] = [
+        "max_position_embeddings",
+        "n_positions",
+        "max_sequence_length",
+    ];
+    let mut candidates: Vec<&serde_json::Value> = Vec::with_capacity(2);
+    if let Some(text) = config.get("text_config") {
+        candidates.push(text);
+    }
+    candidates.push(config);
+    for obj in candidates {
+        for key in KEYS {
+            if let Some(value) = obj.get(key).and_then(serde_json::Value::as_u64)
+                && value > 0
+            {
+                return usize::try_from(value).ok();
+            }
+        }
+    }
+    None
+}
+
 /// Load a model from a directory (or file — parent directory will be used)
 pub fn load_model(model_path: &Path) -> Result<(LoadedModel, MlxcelTokenizer)> {
     let model_path = resolve_model_dir(model_path);

--- a/src/loading/tests.rs
+++ b/src/loading/tests.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use super::{
-    Qwen35VlmKind, conv1d_weight_is_channel_last, conv2d_weight_is_channel_last, model_path_str,
-    parse_eos_token_ids, qwen35_vlm_kind, read_eos_token_ids, require_qwen35_vlm_kind,
-    resolve_model_dir,
+    Qwen35VlmKind, context_window_from_config, conv1d_weight_is_channel_last,
+    conv2d_weight_is_channel_last, model_path_str, parse_eos_token_ids, qwen35_vlm_kind,
+    read_eos_token_ids, read_model_context_window, require_qwen35_vlm_kind, resolve_model_dir,
 };
 use crate::model_metadata::{
     DirectoryLoadRoute, ModelCapabilities, ModelKind, ModelLoadPolicy, WeightLoadRoute,
@@ -56,6 +56,76 @@ fn parse_eos_token_ids_supports_number_arrays() {
 fn parse_eos_token_ids_ignores_invalid_entries() {
     let config = json!({ "eos_token_id": [7, "bad", null, 9] });
     assert_eq!(parse_eos_token_ids(&config), vec![7, 9]);
+}
+
+#[test]
+fn context_window_reads_top_level_max_position_embeddings() {
+    let config = json!({ "max_position_embeddings": 32768 });
+    assert_eq!(context_window_from_config(&config), Some(32768));
+}
+
+#[test]
+fn context_window_prefers_nested_text_config_for_vlm() {
+    // VLM layout: the language-model context length lives under `text_config`.
+    let config = json!({
+        "text_config": { "max_position_embeddings": 131072 },
+        "max_position_embeddings": 4096
+    });
+    assert_eq!(context_window_from_config(&config), Some(131072));
+}
+
+#[test]
+fn context_window_falls_back_to_top_level_when_text_config_lacks_key() {
+    let config = json!({
+        "text_config": { "hidden_size": 2048 },
+        "max_position_embeddings": 8192
+    });
+    assert_eq!(context_window_from_config(&config), Some(8192));
+}
+
+#[test]
+fn context_window_supports_alternate_keys() {
+    assert_eq!(
+        context_window_from_config(&json!({ "n_positions": 2048 })),
+        Some(2048)
+    );
+    assert_eq!(
+        context_window_from_config(&json!({ "max_sequence_length": 16384 })),
+        Some(16384)
+    );
+}
+
+#[test]
+fn context_window_is_none_when_absent_or_zero() {
+    assert_eq!(
+        context_window_from_config(&json!({ "hidden_size": 4096 })),
+        None
+    );
+    assert_eq!(
+        context_window_from_config(&json!({ "max_position_embeddings": 0 })),
+        None
+    );
+}
+
+#[test]
+fn read_model_context_window_returns_none_for_missing_file() {
+    let missing_dir = temp_path("missing_config_json");
+    assert_eq!(read_model_context_window(&missing_dir), None);
+}
+
+#[test]
+fn read_model_context_window_reads_config_json() {
+    let model_dir = temp_path("context_window_config");
+    fs::create_dir_all(&model_dir).unwrap();
+    fs::write(
+        model_dir.join("config.json"),
+        r#"{ "max_position_embeddings": 40960 }"#,
+    )
+    .unwrap();
+
+    assert_eq!(read_model_context_window(&model_dir), Some(40960));
+
+    fs::remove_dir_all(model_dir).unwrap();
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,8 +347,20 @@ pub(crate) struct GenerationOptions {
     #[arg(long, value_name = "FLOAT", default_value_t = 2.0)]
     pub(crate) fps: f64,
 
-    /// Maximum number of tokens to generate
-    #[arg(short = 'n', long, default_value_t = 100, value_name = "N")]
+    /// Maximum number of tokens to generate.
+    ///
+    /// Defaults to `-1` (unlimited), matching llama.cpp: generation runs until
+    /// the model emits an end-of-sequence token or fills its context window.
+    /// Pass an explicit `-n N` to cap output at exactly `N` tokens. Internally
+    /// `-1` is stored as a sentinel and resolved to `context_window - prompt`
+    /// once the model is loaded.
+    #[arg(
+        short = 'n',
+        long,
+        default_value = "-1",
+        value_parser = mlxcel::cli::max_tokens::parse_max_tokens,
+        value_name = "N"
+    )]
     pub(crate) max_tokens: usize,
 
     /// Enable profiling mode with detailed timing breakdown

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -585,12 +585,29 @@ pub(super) fn resolve_elastic_pp_config(startup: &ServerStartupConfig) -> Option
     Some(cfg)
 }
 
-pub(super) fn resolve_default_max_tokens(n_predict: i32) -> usize {
-    if n_predict < 0 {
-        4096
-    } else {
-        n_predict as usize
+/// Resolve the per-request default token budget applied when a request omits
+/// `max_tokens` / `n_predict`.
+///
+/// llama-server parity (issue #476): a negative `--n-predict` (`-1`, the
+/// default) means "generate until the context window is full". It resolves to
+/// the effective per-slot context window — an explicit `--ctx-size` (already
+/// divided across slots into `per_slot_context_size`) when set, otherwise the
+/// model's `max_position_embeddings` read from `config.json`, with the
+/// historical 4096 used only when neither is available. A non-negative
+/// `--n-predict N` is taken verbatim.
+pub(super) fn resolve_default_max_tokens(
+    n_predict: i32,
+    per_slot_context_size: usize,
+    model_path: &Path,
+) -> usize {
+    if n_predict >= 0 {
+        return n_predict as usize;
     }
+    if per_slot_context_size > 0 {
+        return per_slot_context_size;
+    }
+    crate::read_model_context_window(model_path)
+        .unwrap_or(crate::cli::max_tokens::DEFAULT_CONTEXT_WINDOW_FALLBACK)
 }
 
 pub(super) fn resolve_dry_penalty_last_n(value: i32) -> usize {
@@ -818,7 +835,11 @@ pub(super) fn build_server_config(
         default_min_p: startup.min_p,
         default_repetition_penalty: startup.repeat_penalty,
         default_repetition_context_size: startup.repeat_last_n,
-        default_max_tokens: resolve_default_max_tokens(startup.n_predict),
+        default_max_tokens: resolve_default_max_tokens(
+            startup.n_predict,
+            context_size,
+            &startup.model_path,
+        ),
         default_seed: startup.seed,
         default_frequency_penalty: startup.frequency_penalty,
         default_presence_penalty: startup.presence_penalty,

--- a/src/server/startup_tests.rs
+++ b/src/server/startup_tests.rs
@@ -40,8 +40,14 @@ fn temp_path(name: &str) -> PathBuf {
 
 #[test]
 fn resolve_default_max_tokens_matches_server_policy() {
-    assert_eq!(resolve_default_max_tokens(-1), 4096);
-    assert_eq!(resolve_default_max_tokens(128), 128);
+    let missing = std::path::Path::new("/nonexistent/mlxcel/model/dir");
+    // Explicit budget passes through unchanged regardless of context window.
+    assert_eq!(resolve_default_max_tokens(128, 0, missing), 128);
+    assert_eq!(resolve_default_max_tokens(128, 8192, missing), 128);
+    // Unlimited (-1) with an explicit per-slot context size uses that window.
+    assert_eq!(resolve_default_max_tokens(-1, 8192, missing), 8192);
+    // Unlimited with no context size and an unreadable config falls back to 4096.
+    assert_eq!(resolve_default_max_tokens(-1, 0, missing), 4096);
 }
 
 #[test]
@@ -141,7 +147,10 @@ fn build_server_config_applies_normalized_startup_values() {
     assert_eq!(config.default_min_p, 0.05);
     assert_eq!(config.default_repetition_penalty, 1.2);
     assert_eq!(config.default_repetition_context_size, 96);
-    assert_eq!(config.default_max_tokens, 4096);
+    // n_predict = -1 (unlimited) resolves to the per-slot context window:
+    // ctx_size 2048 / 3 slots = 682 (issue #476). The startup model_path here is
+    // empty so no config.json is read; the explicit --ctx-size drives the value.
+    assert_eq!(config.default_max_tokens, 682);
     assert_eq!(config.default_seed, Some(7));
     assert_eq!(config.default_presence_penalty, 0.4);
     assert_eq!(config.default_frequency_penalty, 0.3);


### PR DESCRIPTION
## Summary
The CLI defaulted `-n/--max-tokens` to **100** and `mlxcel serve` resolved `-1` to a flat **4096**, so output looked truncated to users coming from llama.cpp. llama.cpp defaults `n_predict = -1` ("generate until EOS or the context window fills"), identically for `llama-cli` and `llama-server`.

This makes all three entry points match llama.cpp:

| entry point | llama.cpp analog | before | after |
|---|---|---|---|
| `mlxcel run` / `generate` | `llama-cli` | 100 | `-1` → context window − prompt |
| `mlxcel serve` / `mlxcel-server` | `llama-server` | `-1` → 4096 | `-1` → per-slot context window |

Generation still stops at EOS; the context window is only the upper bound. An explicit `-n N` / `--n-predict N` (N >= 0) is always honored verbatim.

## Changes
- **New `cli::max_tokens` module**: `UNLIMITED_MAX_TOKENS` sentinel, `DEFAULT_CONTEXT_WINDOW_FALLBACK` (4096), a `parse_max_tokens` clap `value_parser` (so `-n -1` parses), and a pure `resolve_unlimited_max_tokens(requested, context_window, prompt_len)`.
- **New `read_model_context_window` / `context_window_from_config`** next to `read_eos_token_ids` in the loading module: reads `max_position_embeddings` from `config.json`, prefers the VLM `text_config` nesting, supports alternate keys, and returns `None` (→ fallback) when absent.
- **CLI**: `-n/--max-tokens` default `100` → `-1`. `run_generate_once` resolves the sentinel right after prompt tokenization (before the memory preflight, so every downstream generator — standard / VLM / speculative / XLA / pipeline / diffusion — reads a plain `usize`). The chat REPL resolves per turn inside `stream_turn` against the model context window.
- **Server**: `resolve_default_max_tokens` resolves `-1` to the effective per-slot context window (an explicit `--ctx-size`, else the model's `max_position_embeddings`), keeping the 4096 fallback.

## Tests
- `cli::max_tokens`: sentinel parser (negative → unlimited, non-negative verbatim, rejects non-integer), resolver (explicit passthrough, window − prompt, clamp ≥ 1).
- loading: `context_window_from_config` (top-level, VLM `text_config` precedence, top-level fallback, alternate keys, missing/zero → `None`) and `read_model_context_window` file read / missing-file.
- server: `resolve_default_max_tokens` new signature; `build_server_config` now yields `default_max_tokens = 682` (ctx 2048 / 3 slots) for the `-1` default.
- CLI: `run` default parses to the unlimited sentinel; explicit `-n 256` stays 256.

## Validation
Real checkpoint (`qwen3-0.6b-4bit`, debug binary):
- Default (no `-n`): `Max tokens: unlimited (-1) -> 40943 (model context window 40960, prompt 17)` and stopped at EOS after 1 token (not the 40943 cap).
- `-n 5`: capped at exactly 5 tokens.

`cargo fmt --check`, `cargo clippy --all-targets --features metal,accelerate -D warnings`, and the targeted unit tests all pass.

Closes #476