### PR TITLE
feat: enforce stop strings on the OpenXLA serve path (#449 M3 Stage 2d)

### DIFF
--- a/src/server/batch/mod.rs
+++ b/src/server/batch/mod.rs
@@ -46,6 +46,12 @@ mod sequence;
 pub(crate) mod speculative_burst;
 #[cfg(test)]
 mod speculative_burst_tests;
+/// Streaming-safe stop-string matcher (issue #449 M3 Stage 2d). Pure logic with
+/// no device state, so it is always compiled and unit-tested in ordinary
+/// `cargo test`; only the `xla-iree` serve worker consumes it today, so its
+/// items read as dead code when that feature is off.
+#[cfg_attr(not(feature = "xla-iree"), allow(dead_code))]
+mod stop_matcher;
 /// OpenXLA / IREE serve worker (issue #449 M3 Stage 2c): adapts the
 /// `mlxcel-xla` continuous-batching engine to the [`BatchEngine`] contract.
 /// Behind `xla-iree` (real IREE execution); the MLX serving path is unaffected.

--- a/src/server/batch/stop_matcher.rs
+++ b/src/server/batch/stop_matcher.rs
@@ -1,0 +1,347 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Streaming-safe stop-string matcher (issue #449 M3 Stage 2d).
+//!
+//! [`StopMatcher`] turns the post-hoc truncation semantics of
+//! [`apply_stop_sequences`](crate::server::anthropic_translator::apply_stop_sequences)
+//! into an incremental, streaming-safe form: text arrives one decoded piece at a
+//! time, and the matcher decides how much is safe to emit *now* versus how much
+//! must be held back because it could still turn out to be the start of a stop
+//! string at the next piece.
+//!
+//! A stop string can straddle token boundaries (e.g. `"STOP"` arriving as
+//! `"ST"` then `"OP"`), so any suffix of the text seen so far that is a proper
+//! prefix of some stop string is ambiguous and is withheld until the next piece
+//! resolves it. When a stop string fully matches, the matcher reports a stop and
+//! the emitted text ends just before the match, so the stop string itself and
+//! everything after it never reach the client. This matches `apply_stop_sequences`
+//! (earliest match wins; the stop string is excluded), proven by an equivalence
+//! test below.
+//!
+//! The matcher is pure (no IREE / device state), so it lives outside the
+//! `xla-iree` cfg gate and its unit tests run in an ordinary `cargo test`. The
+//! OpenXLA serve worker ([`XlaServeWorker`](super::xla_worker)) drives it; nothing
+//! else does today, but it is backend-neutral by construction.
+
+/// The result of feeding one decoded piece to a [`StopMatcher`].
+pub(crate) struct StopChunk {
+    /// Text that is safe to emit to the client now. May be empty when the whole
+    /// piece is held back as a potential stop-string prefix.
+    pub emit: String,
+    /// `true` once a stop string has fully matched. The caller should emit
+    /// [`StopChunk::emit`] (the text up to the match) and then finalize the
+    /// request with a `stop` finish reason; the matcher will produce nothing
+    /// further.
+    pub stopped: bool,
+}
+
+/// Incremental stop-string matcher for one in-flight request.
+///
+/// Construct with the request's stop strings; feed each decoded piece through
+/// [`push`](StopMatcher::push); on natural end of generation (EOS / length) call
+/// [`flush`](StopMatcher::flush) to release any held-back tail (which, by
+/// definition, did not complete a stop string).
+pub(crate) struct StopMatcher {
+    /// Non-empty stop strings. Empty stop strings are dropped at construction
+    /// (they would match everywhere and carry no meaning), mirroring
+    /// `apply_stop_sequences`.
+    stops: Vec<String>,
+    /// Decoded text received but not yet emitted: the ambiguous tail that could
+    /// still become a stop-string prefix. Always empty when `stops` is empty.
+    pending: String,
+    /// Running total of bytes emitted to the client. The emitted text is always a
+    /// prefix of the full decoded text, so the worker can truncate its decode
+    /// buffer to this length to obtain the (stop-truncated) result text.
+    emitted_len: usize,
+}
+
+impl StopMatcher {
+    /// Build a matcher from the request's stop strings, dropping empty ones.
+    pub(crate) fn new<I, S>(stops: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let stops: Vec<String> = stops
+            .into_iter()
+            .map(Into::into)
+            .filter(|s| !s.is_empty())
+            .collect();
+        Self {
+            stops,
+            pending: String::new(),
+            emitted_len: 0,
+        }
+    }
+
+    /// Whether any stop string is configured. When `false`, [`push`](Self::push)
+    /// is a pass-through and the request behaves exactly as it did before stop
+    /// strings were enforced.
+    pub(crate) fn is_active(&self) -> bool {
+        !self.stops.is_empty()
+    }
+
+    /// Total bytes emitted so far. Because emitted text is a prefix of the full
+    /// decoded text, the worker truncates its decode buffer to this length to get
+    /// the result text after a stop-string match.
+    pub(crate) fn emitted_len(&self) -> usize {
+        self.emitted_len
+    }
+
+    /// Feed one newly decoded piece. Returns the text to emit now and whether a
+    /// stop string matched.
+    pub(crate) fn push(&mut self, piece: &str) -> StopChunk {
+        // No stop strings: emit verbatim, nothing is ever held.
+        if self.stops.is_empty() {
+            self.emitted_len += piece.len();
+            return StopChunk {
+                emit: piece.to_string(),
+                stopped: false,
+            };
+        }
+
+        self.pending.push_str(piece);
+
+        // Earliest full match across all stop strings wins (same rule as
+        // `apply_stop_sequences`). Everything from the match onward is dropped.
+        if let Some(idx) = self.earliest_full_match() {
+            let emit = self.pending[..idx].to_string();
+            self.emitted_len += emit.len();
+            self.pending.clear();
+            return StopChunk {
+                emit,
+                stopped: true,
+            };
+        }
+
+        // No full match: hold back the longest suffix that is a proper prefix of
+        // some stop string (it might complete on the next piece), emit the rest.
+        let hold = self.longest_partial_suffix();
+        let cut = self.pending.len() - hold;
+        let emit = self.pending[..cut].to_string();
+        self.emitted_len += emit.len();
+        self.pending.drain(..cut);
+        StopChunk {
+            emit,
+            stopped: false,
+        }
+    }
+
+    /// Release any held-back tail at the natural end of generation. Because the
+    /// tail never completed a stop string, it is real output and must be emitted.
+    pub(crate) fn flush(&mut self) -> String {
+        let out = std::mem::take(&mut self.pending);
+        self.emitted_len += out.len();
+        out
+    }
+
+    /// Byte index of the earliest full stop-string occurrence in `pending`, if
+    /// any. Ties (two stops matching at the same index) resolve to that shared
+    /// index, which is all the caller needs for truncation.
+    fn earliest_full_match(&self) -> Option<usize> {
+        let mut best: Option<usize> = None;
+        for s in &self.stops {
+            if let Some(i) = self.pending.find(s.as_str()) {
+                best = Some(best.map_or(i, |b| b.min(i)));
+            }
+        }
+        best
+    }
+
+    /// Length (in bytes) of the longest suffix of `pending` that equals a
+    /// non-empty proper prefix of some stop string. Such a suffix is ambiguous:
+    /// the following piece could complete the stop string, so it must be held.
+    ///
+    /// Returns `0` when no suffix is a stop-string prefix. Callers invoke this
+    /// only after [`earliest_full_match`](Self::earliest_full_match) returns
+    /// `None`, so a full stop string is never present in `pending` and the
+    /// considered prefixes are strictly shorter than their stop string.
+    fn longest_partial_suffix(&self) -> usize {
+        let mut max_hold = 0;
+        for s in &self.stops {
+            // Candidate prefix lengths are char boundaries of `s` below its full
+            // length; check longest first and keep the first (largest) match.
+            let upper = (s.len() - 1).min(self.pending.len());
+            let mut pl = upper;
+            while pl > max_hold {
+                if s.is_char_boundary(pl) && self.pending.ends_with(&s[..pl]) {
+                    max_hold = pl;
+                    break;
+                }
+                pl -= 1;
+            }
+        }
+        max_hold
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::anthropic_translator::apply_stop_sequences;
+
+    /// Drive a matcher over `pieces` and return everything it emitted (including
+    /// the flushed tail when generation was not stopped by a match).
+    fn run(stops: &[&str], pieces: &[&str]) -> (String, bool) {
+        let mut m = StopMatcher::new(stops.iter().map(|s| s.to_string()));
+        let mut out = String::new();
+        let mut stopped = false;
+        for p in pieces {
+            let chunk = m.push(p);
+            out.push_str(&chunk.emit);
+            if chunk.stopped {
+                stopped = true;
+                break;
+            }
+        }
+        if !stopped {
+            out.push_str(&m.flush());
+        }
+        assert_eq!(
+            out.len(),
+            m.emitted_len(),
+            "emitted_len must track total emitted bytes"
+        );
+        (out, stopped)
+    }
+
+    #[test]
+    fn no_stops_is_passthrough() {
+        let (out, stopped) = run(&[], &["hello ", "world"]);
+        assert_eq!(out, "hello world");
+        assert!(!stopped);
+        let mut m = StopMatcher::new(Vec::<String>::new());
+        assert!(!m.is_active());
+        assert_eq!(m.push("x").emit, "x");
+    }
+
+    #[test]
+    fn empty_stop_strings_are_dropped() {
+        let m = StopMatcher::new(vec![String::new(), "".to_string()]);
+        assert!(!m.is_active());
+    }
+
+    #[test]
+    fn stop_within_single_piece() {
+        let (out, stopped) = run(&["STOP"], &["hello STOP world"]);
+        assert_eq!(out, "hello ");
+        assert!(stopped);
+    }
+
+    #[test]
+    fn stop_split_across_pieces() {
+        let (out, stopped) = run(&["STOP"], &["hel", "lo ", "ST", "OP", " trailing"]);
+        assert_eq!(out, "hello ");
+        assert!(stopped);
+    }
+
+    #[test]
+    fn partial_false_alarm_is_flushed() {
+        // "ST" looks like the start of "STOP" but resolves to "STxy".
+        let (out, stopped) = run(&["STOP"], &["ST", "xy"]);
+        assert_eq!(out, "STxy");
+        assert!(!stopped);
+    }
+
+    #[test]
+    fn held_tail_flushed_on_natural_end() {
+        // Ends mid-prefix; no completion, so the tail is real output.
+        let (out, stopped) = run(&["STOP"], &["hello ST"]);
+        assert_eq!(out, "hello ST");
+        assert!(!stopped);
+    }
+
+    #[test]
+    fn earliest_of_multiple_stops_wins() {
+        let (out, stopped) = run(&["world", "STOP"], &["a STOP b world"]);
+        assert_eq!(out, "a ");
+        assert!(stopped);
+    }
+
+    #[test]
+    fn stop_at_very_start_emits_nothing() {
+        let (out, stopped) = run(&["STOP"], &["STOP rest"]);
+        assert_eq!(out, "");
+        assert!(stopped);
+    }
+
+    #[test]
+    fn overlapping_repeats_match_first_occurrence() {
+        // "aa" with input "aaa" fed one char at a time matches at index 0.
+        let (out, stopped) = run(&["aa"], &["a", "a", "a"]);
+        assert_eq!(out, "");
+        assert!(stopped);
+        assert_eq!(apply_stop_sequences("aaa", Some(&["aa".to_string()])).0, "");
+    }
+
+    #[test]
+    fn unicode_stop_string() {
+        let (out, stopped) = run(&["café"], &["a ca", "fé b"]);
+        assert_eq!(out, "a ");
+        assert!(stopped);
+    }
+
+    #[test]
+    fn unicode_partial_does_not_split_codepoint() {
+        // Feeding a multibyte char that is a stop prefix then diverging must not
+        // panic on a non-boundary slice and must flush the real text.
+        let (out, stopped) = run(&["→end"], &["x→", "y"]);
+        assert_eq!(out, "x→y");
+        assert!(!stopped);
+    }
+
+    /// The streamed result must equal `apply_stop_sequences` on the whole text,
+    /// for every chunking. This ties the incremental matcher to the established
+    /// truncation semantics.
+    #[test]
+    fn matches_apply_stop_sequences_for_all_chunkings() {
+        let cases: &[(&str, &[&str])] = &[
+            ("hello STOP world", &["STOP"]),
+            ("no match here", &["STOP"]),
+            ("end at THE END now", &["THE END"]),
+            ("pick earliest: B then A", &["A", "B"]),
+            ("aaa", &["aa"]),
+            ("café au lait", &["au"]),
+            ("trailing prefix ST", &["STOP"]),
+            ("", &["STOP"]),
+        ];
+        for (text, stops) in cases {
+            let owned: Vec<String> = stops.iter().map(|s| s.to_string()).collect();
+            let expected = apply_stop_sequences(text, Some(&owned)).0;
+
+            // Whole string in one piece.
+            let (whole, _) = run(stops, &[text]);
+            assert_eq!(whole, expected, "whole-string chunking: {text:?}");
+
+            // Char-by-char.
+            let chars: Vec<String> = text.chars().map(|c| c.to_string()).collect();
+            let char_refs: Vec<&str> = chars.iter().map(String::as_str).collect();
+            let (per_char, _) = run(stops, &char_refs);
+            assert_eq!(per_char, expected, "char-by-char chunking: {text:?}");
+
+            // Byte-pair-ish split at each char boundary.
+            for split in 1..text.chars().count() {
+                let idx: usize = text
+                    .char_indices()
+                    .nth(split)
+                    .map(|(i, _)| i)
+                    .unwrap_or(text.len());
+                let (a, b) = text.split_at(idx);
+                let (two, _) = run(stops, &[a, b]);
+                assert_eq!(two, expected, "two-piece split at {split} of {text:?}");
+            }
+        }
+    }
+}

--- a/src/server/batch/xla_worker.rs
+++ b/src/server/batch/xla_worker.rs
@@ -23,14 +23,19 @@
 //! [`EngineEvent`] back to a [`GenerateEvent`] on that request's channel, reusing
 //! the server's [`StreamingDecodeState`] for byte-fallback-safe detokenization.
 //!
-//! Scope: text-only. This path honors `max_tokens`, the model's EOS ids, and
-//! sampling (temperature / top-k / top-p / min-p / seed, #449 M3 Stage 2d); the
+//! Scope: text-only. This path honors `max_tokens`, the model's EOS ids,
+//! sampling (temperature / top-k / top-p / min-p / seed, #449 M3 Stage 2d), and
+//! stop strings (#449 M3 Stage 2d): a [`StopMatcher`] withholds any decoded tail
+//! that could begin a stop string and ends the request at the earliest full
+//! match, excluding the stop string and everything after it from the output
+//! (the same rule as
+//! [`apply_stop_sequences`](crate::server::anthropic_translator::apply_stop_sequences),
+//! applied incrementally so it is safe across token boundaries). The
 //! history-based penalties (repetition / frequency / presence / DRY) are not
 //! applied (logged once). Requests that need features the engine cannot provide
 //! are rejected with a clear error rather than served wrong: logprobs (no logit
 //! readback), structured / JSON-schema output (no constraint masking), and
-//! multimodal inputs (text-only). Stop strings are not enforced yet (EOS +
-//! `max_tokens` terminate); that is a follow-up.
+//! multimodal inputs (text-only).
 //!
 //! Compiled only under `xla-iree` (real IREE execution). The MLX serving path is
 //! untouched.
@@ -44,6 +49,7 @@ use std::time::Instant;
 use mlxcel_xla::{EngineEvent, FinishReason as XlaFinishReason, SampleParams, XlaBatchEngine};
 
 use super::BatchEngine;
+use super::stop_matcher::StopMatcher;
 use crate::server::ServerGenerateOptions;
 use crate::server::model_provider::model_worker::StreamingDecodeState;
 use crate::server::model_provider::{GenerateEvent, ModelRequest};
@@ -54,6 +60,9 @@ struct ServeState {
     response_tx: mpsc::Sender<GenerateEvent>,
     cancelled: Arc<AtomicBool>,
     detok: StreamingDecodeState,
+    /// Streaming-safe stop-string matcher. Inactive (a pass-through) when the
+    /// request set no stop strings, so those requests stream exactly as before.
+    stop: StopMatcher,
     start: Instant,
     prompt_token_count: usize,
     max_tokens: usize,
@@ -70,7 +79,6 @@ pub(crate) struct XlaServeWorker {
     states: HashMap<u64, ServeState>,
     shutdown: bool,
     warned_penalties: bool,
-    warned_stop: bool,
 }
 
 impl XlaServeWorker {
@@ -86,7 +94,6 @@ impl XlaServeWorker {
             states: HashMap::new(),
             shutdown: false,
             warned_penalties: false,
-            warned_stop: false,
         }
     }
 
@@ -123,9 +130,10 @@ impl XlaServeWorker {
             return;
         }
 
-        // Sampling: temperature / top-k / top-p / min-p / seed are honored; the
-        // history-based penalties (repetition / frequency / presence / DRY) and stop
-        // strings are not, so warn once each when a request asks for them.
+        // Sampling: temperature / top-k / top-p / min-p / seed are honored; stop
+        // strings are enforced below by a per-request `StopMatcher`. The
+        // history-based penalties (repetition / frequency / presence / DRY) are
+        // not applied, so warn once when a request asks for them.
         let sampling = &options.sampling;
         let params = SampleParams {
             temperature: sampling.temperature,
@@ -144,18 +152,6 @@ impl XlaServeWorker {
                  repetition / frequency / presence penalties and DRY are ignored"
             );
             self.warned_penalties = true;
-        }
-        if !self.warned_stop
-            && options
-                .stop_sequences
-                .as_ref()
-                .is_some_and(|s| !s.is_empty())
-        {
-            tracing::warn!(
-                "the OpenXLA backend does not enforce stop strings yet; generation stops on EOS \
-                 or max_tokens only"
-            );
-            self.warned_stop = true;
         }
 
         let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
@@ -190,6 +186,7 @@ impl XlaServeWorker {
                         response_tx,
                         cancelled,
                         detok,
+                        stop: StopMatcher::new(options.stop_sequences.unwrap_or_default()),
                         start: Instant::now(),
                         prompt_token_count: prompt_tokens.len(),
                         max_tokens: options.max_tokens,
@@ -273,10 +270,30 @@ impl XlaServeWorker {
         for ev in events {
             match ev {
                 EngineEvent::Token { req_id, token } => {
-                    if let Some(state) = self.states.get_mut(&req_id)
-                        && let Some(piece) = state.detok.on_token(token, &self.tokenizer)
-                    {
-                        let _ = state.response_tx.send(GenerateEvent::Token(piece));
+                    // Decode the token, run it through the request's stop matcher,
+                    // and emit only what is safe to stream. `Some(keep)` means a
+                    // stop string matched: finalize the request keeping `keep`
+                    // bytes (everything already streamed, before the stop string).
+                    let stop_keep = {
+                        let Some(state) = self.states.get_mut(&req_id) else {
+                            continue;
+                        };
+                        let Some(piece) = state.detok.on_token(token, &self.tokenizer) else {
+                            continue;
+                        };
+                        if state.stop.is_active() {
+                            let chunk = state.stop.push(&piece);
+                            if !chunk.emit.is_empty() {
+                                let _ = state.response_tx.send(GenerateEvent::Token(chunk.emit));
+                            }
+                            chunk.stopped.then(|| state.stop.emitted_len())
+                        } else {
+                            let _ = state.response_tx.send(GenerateEvent::Token(piece));
+                            None
+                        }
+                    };
+                    if let Some(keep) = stop_keep {
+                        self.finalize_stop(req_id, keep);
                     }
                 }
                 EngineEvent::Finished { req_id, reason } => {
@@ -284,11 +301,19 @@ impl XlaServeWorker {
                         let ServeState {
                             response_tx,
                             mut detok,
+                            mut stop,
                             start,
                             prompt_token_count,
                             max_tokens,
                             ..
                         } = state;
+                        // Release any tail held back as a potential stop-string
+                        // prefix; ending on EOS/length means it never completed
+                        // one, so it is real output and must be streamed first.
+                        let tail = stop.flush();
+                        if !tail.is_empty() {
+                            let _ = response_tx.send(GenerateEvent::Token(tail));
+                        }
                         detok.flush(&self.tokenizer);
                         let mut result = detok.finish(start, prompt_token_count, max_tokens);
                         // The engine knows the authoritative reason; prefer it over
@@ -302,6 +327,29 @@ impl XlaServeWorker {
                     }
                 }
             }
+        }
+    }
+
+    /// Finalize a request that matched a stop string: free its engine slot and
+    /// send a terminal `Done` whose text is truncated to `keep_bytes` (the bytes
+    /// already streamed, i.e. everything before the stop string). The matcher
+    /// withheld the stop string and everything after it, so the non-streaming
+    /// result matches what was streamed; the finish reason is `stop`.
+    fn finalize_stop(&mut self, req_id: u64, keep_bytes: usize) {
+        self.engine.cancel(req_id);
+        if let Some(state) = self.states.remove(&req_id) {
+            let ServeState {
+                response_tx,
+                detok,
+                start,
+                prompt_token_count,
+                max_tokens,
+                ..
+            } = state;
+            let mut result =
+                detok.finish_truncated(keep_bytes, start, prompt_token_count, max_tokens);
+            result.finish_reason = "stop".to_string();
+            let _ = response_tx.send(GenerateEvent::Done(result));
         }
     }
 
@@ -319,7 +367,7 @@ impl XlaServeWorker {
 impl BatchEngine for XlaServeWorker {
     fn serve(&mut self) {
         tracing::info!(
-            "OpenXLA serve worker starting (continuous batching, B_max={}, sampling)",
+            "OpenXLA serve worker starting (continuous batching, B_max={}, sampling, stop strings)",
             self.engine.b_max()
         );
         loop {

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -2085,6 +2085,33 @@ impl StreamingDecodeState {
             cached_tokens,
         )
     }
+
+    /// Like [`finish`](Self::finish) but truncates the accumulated text to
+    /// `keep_bytes` first.
+    ///
+    /// The OpenXLA serve worker (issue #449 M3 Stage 2d) uses this when a stop
+    /// string matches: streaming already stopped at `keep_bytes` (the stop
+    /// string and everything after it were withheld), so truncating here keeps
+    /// the non-streaming `result.text` consistent with what was streamed.
+    /// `keep_bytes` counts whole emitted pieces and so lands on a char boundary;
+    /// it is floored to the nearest boundary defensively rather than panicking.
+    #[cfg(feature = "xla-iree")]
+    pub(crate) fn finish_truncated(
+        mut self,
+        keep_bytes: usize,
+        start: Instant,
+        prompt_token_count: usize,
+        max_tokens: usize,
+    ) -> GenerationResult {
+        if keep_bytes < self.generated_text.len() {
+            let mut cut = keep_bytes;
+            while cut > 0 && !self.generated_text.is_char_boundary(cut) {
+                cut -= 1;
+            }
+            self.generated_text.truncate(cut);
+        }
+        self.finish_with_cache(start, prompt_token_count, max_tokens, 0)
+    }
 }
 
 /// Find the byte position after the last non-U+FFFD character.


### PR DESCRIPTION
## Summary

Stage 2d follow-up of the OpenXLA/IREE milestone (#449 M3): the serve path (Stage 2c plus 2d-sampling) terminated only on EOS or `max_tokens` and **warned that stop strings were ignored**. This enforces them **streaming-safely**, so the OpenXLA backend honors the OpenAI `stop` parameter the same way it already honors sampling.

## What's here

- **`stop_matcher.rs`** (new): a pure `StopMatcher` that turns the post-hoc truncation of `apply_stop_sequences` into an incremental, streaming-safe form. It buffers decoded text, withholds any suffix that could be the start of a stop string (so a stop string split across tokens, e.g. `"STOP"` arriving as `"ST"` then `"OP"`, is still caught), and ends the request at the **earliest** full match, excluding the stop string and everything after it. It has no device state, so it is always compiled and unit-tested; the `xla-iree` worker is its only consumer today, so a scoped `allow(dead_code)` covers the feature-off build.
- **`StreamingDecodeState::finish_truncated`** (`xla-iree` only): truncates the non-streaming `result.text` to the bytes already streamed (the emitted text is always a prefix of the decode buffer), keeping streaming and non-streaming consistent. The MLX path's `finish` is untouched.
- **`XlaServeWorker`**: builds a per-request matcher from `options.stop_sequences`, routes each decoded piece through it, and on a match frees the engine slot (`cancel`) and sends a terminal `Done` with finish reason `stop`. On a natural end (EOS or length) it flushes the held tail first, since that tail never completed a stop string and is therefore real output. Requests with no stop strings take an `is_active()` fast path and stream byte-for-byte as before.

## Semantics

Matches `apply_stop_sequences` (the rule the Anthropic route already uses): the earliest match across all stop strings wins, and the stop string is excluded from the output. A unit test feeds the same text through the matcher in **every** chunking (whole, char-by-char, each two-piece split) and asserts the result equals `apply_stop_sequences` on the whole string.

## Validation

- **Unit tests** (run in ordinary `cargo test`, no feature needed): 12 `stop_matcher` tests covering single-piece, split-across-pieces, partial false-alarm, earliest-of-multiple, duplicate, at-start, unicode, non-boundary safety, and the `apply_stop_sequences` equivalence sweep.
- **E2E on GB10 CUDA** (`/v1/completions`, greedy; stop strings derived from the deterministic no-stop baseline so the expected truncation is exact):
  - single-word, multi-word (token-spanning), and duplicate (earliest-wins) stops truncate exactly, report `finish_reason=stop`, and exclude the stop string;
  - multiple stop strings resolve to the earliest across the set;
  - a non-occurring stop leaves output unchanged (full text, `length`);
  - **streaming**: concatenated deltas equal the truncation and the stop string never leaks (proves the cross-token buffering);
  - **3 concurrent** requests with distinct stops each truncate independently (per-slot matcher isolation under continuous batching).
- `cargo fmt` and `cargo clippy -D warnings` are clean (default no-feature lib plus tests, and `--features xla-iree` lib); `mlxcel-server` builds and links with `xla-iree`; the `server::` lib suite (1222 tests) passes.

The MLX serving path is unchanged (no trait or scheduler changes); default and CI builds compile with the XLA worker absent.

## Scope / non-goals

Enforces stop strings on the OpenXLA serve path. Still not applied on this backend: repetition / frequency / presence penalties and DRY (warned once); logprobs, structured output, and multimodal (rejected). On-device sampling, paged-KV, and chunked prefill remain later Stage 2d/2e follow-ups.

Refs #449 (epic). Follows #471 (Stage 2d sampling), #470 (Stage 2c serving), and #469/#468/#466/#462.
