### PR TITLE
feat: history-based penalties on the OpenXLA serve path (#449 M3 Stage 2d)

### DIFF
--- a/src/lib/mlxcel-xla/src/batch.rs
+++ b/src/lib/mlxcel-xla/src/batch.rs
@@ -81,6 +81,11 @@ struct Slot {
     params: SampleParams,
     /// PRNG state, advanced by each sample; seeded at admit for reproducibility.
     rng: u64,
+    /// Token history for history-based penalties: the prompt followed by every
+    /// generated token (matching mlxcel-core's `initial_token_history` window).
+    /// Empty when the request enables no penalty, so greedy requests carry no
+    /// per-slot history cost.
+    history: Vec<i32>,
 }
 
 /// A queued, not-yet-admitted request.
@@ -318,7 +323,19 @@ impl XlaBatchEngine {
             };
             let logits = self.engine.prefill_slot_logits(s, &p.prompt)?;
             let mut rng = resolve_seed(&p.params, p.req_id);
-            let first = sample(&logits, &p.params, &mut rng);
+            // History-based penalties see the prompt plus generated tokens (the
+            // same window mlxcel-core seeds via `initial_token_history`). Build it
+            // only when a penalty is active; greedy requests keep it empty.
+            let needs_history = p.params.needs_penalties();
+            let mut history = if needs_history {
+                p.prompt.clone()
+            } else {
+                Vec::new()
+            };
+            let first = sample(&logits, &p.params, &history, &mut rng);
+            if needs_history {
+                history.push(first);
+            }
             events.push(EngineEvent::Token {
                 req_id: p.req_id,
                 token: first,
@@ -331,6 +348,7 @@ impl XlaBatchEngine {
                 cap: p.cap,
                 params: p.params,
                 rng,
+                history,
             };
             if let Some(reason) = finish_reason(slot.produced, slot.cap, first, &eos) {
                 // Finished at its first token: leave the slot free for the next admit.
@@ -367,7 +385,10 @@ impl XlaBatchEngine {
         for (s, slot_opt) in self.sched.slots.iter_mut().enumerate() {
             if let Some(slot) = slot_opt.as_mut() {
                 let row = &logits[s * vocab..(s + 1) * vocab];
-                let nt = sample(row, &slot.params, &mut slot.rng);
+                let nt = sample(row, &slot.params, &slot.history, &mut slot.rng);
+                if slot.params.needs_penalties() {
+                    slot.history.push(nt);
+                }
                 slot.cur = nt;
                 slot.cache_len += 1;
                 slot.produced += 1;
@@ -495,6 +516,7 @@ mod tests {
             cap: p.cap,
             params: p.params,
             rng: 0,
+            history: Vec::new(),
         });
         assert!(s.any_active());
         assert!(s.cancel(id));

--- a/src/lib/mlxcel-xla/src/sampler.rs
+++ b/src/lib/mlxcel-xla/src/sampler.rs
@@ -20,19 +20,28 @@
 //! argmax, identical to the on-device argmax the greedy graphs produced (the same
 //! logits, the same max), so greedy output is token-exact across the switch.
 //!
-//! Supported: temperature, top-k, top-p (nucleus), min-p, and a seeded PRNG for
-//! reproducibility. Repetition / frequency / presence penalties and DRY are not
-//! applied here (the server warns once when requested).
+//! Supported: history-based penalties (repetition, frequency, presence, DRY)
+//! applied to the logits first, then temperature, top-k, top-p (nucleus), min-p,
+//! and a seeded PRNG for reproducibility. The penalty math mirrors the MLX path
+//! (`mlxcel-core::sampling`): same order (repetition, then DRY, then
+//! frequency/presence), same per-token formulas, so the two backends penalize
+//! identically for the same history.
 //!
 //! Cost note: a non-greedy step softmaxes and sorts the full vocabulary per active
 //! row on the host. That is acceptable for this reference backend (it is a small
 //! fraction of the decode matmuls), not a tuned sampler.
 
+use std::collections::HashMap;
+
 /// Sampling parameters for one request. Greedy is the default
 /// ([`SampleParams::greedy`]); a non-zero `temperature` enables stochastic
 /// sampling. `top_k == 0`, `top_p >= 1.0`, and `min_p == 0.0` each disable that
-/// filter.
-#[derive(Debug, Clone, Copy)]
+/// filter. The history-based penalties are off at their identity values
+/// (`repetition_penalty == 1.0`, the rest `0`), matching the MLX defaults.
+///
+/// Not `Copy` because `dry_sequence_breakers` owns a `Vec`; each slot keeps its
+/// own clone.
+#[derive(Debug, Clone)]
 pub struct SampleParams {
     /// Softmax temperature; `<= 0.0` means greedy (argmax).
     pub temperature: f32,
@@ -46,10 +55,30 @@ pub struct SampleParams {
     /// PRNG seed for reproducibility; `None` lets the engine derive a
     /// deterministic per-request seed.
     pub seed: Option<u64>,
+    /// Repetition penalty over the unique seen tokens (`1.0` = disabled): a seen
+    /// token's logit is divided by this when positive, multiplied when negative.
+    pub repetition_penalty: f32,
+    /// OpenAI-style frequency penalty: subtract `frequency_penalty * count` from a
+    /// token's logit (`0.0` = disabled).
+    pub frequency_penalty: f32,
+    /// OpenAI-style presence penalty: subtract this once from any token that
+    /// appeared at all (`0.0` = disabled).
+    pub presence_penalty: f32,
+    /// DRY multiplier (`0.0` = disabled). When positive, tokens that would extend
+    /// a repeated suffix are penalized.
+    pub dry_multiplier: f32,
+    /// DRY exponential base (penalty grows as `dry_base^(match_len - allowed)`).
+    pub dry_base: f32,
+    /// DRY minimum match length before a penalty applies.
+    pub dry_allowed_length: usize,
+    /// DRY lookback window in tokens (`0` = the whole history).
+    pub dry_penalty_last_n: usize,
+    /// Token ids that break DRY suffix matching (e.g. newlines, punctuation).
+    pub dry_sequence_breakers: Vec<i32>,
 }
 
 impl SampleParams {
-    /// Greedy (argmax) sampling: temperature 0, no filters.
+    /// Greedy (argmax) sampling: temperature 0, no filters, no penalties.
     #[must_use]
     pub fn greedy() -> Self {
         Self {
@@ -58,13 +87,35 @@ impl SampleParams {
             top_p: 1.0,
             min_p: 0.0,
             seed: None,
+            repetition_penalty: 1.0,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
+            dry_multiplier: 0.0,
+            dry_base: 1.75,
+            dry_allowed_length: 2,
+            dry_penalty_last_n: 0,
+            dry_sequence_breakers: Vec::new(),
         }
     }
 
     /// Whether this samples greedily (argmax), i.e. temperature is non-positive.
+    /// Note: greedy still applies penalties first when any are enabled, so the
+    /// argmax is taken over the penalized logits.
     #[must_use]
     pub fn is_greedy(&self) -> bool {
         self.temperature <= 0.0
+    }
+
+    /// Whether any history-based penalty is enabled. When `false`, sampling needs
+    /// no token history and runs exactly as it did before penalties existed.
+    /// Mirrors `mlxcel-core`'s `needs_token_history` gate (any non-identity
+    /// penalty value; `dry_multiplier` only counts when strictly positive).
+    #[must_use]
+    pub fn needs_penalties(&self) -> bool {
+        self.repetition_penalty != 1.0
+            || self.frequency_penalty != 0.0
+            || self.presence_penalty != 0.0
+            || self.dry_multiplier > 0.0
     }
 }
 
@@ -96,15 +147,151 @@ fn argmax(logits: &[f32]) -> i32 {
     best as i32
 }
 
-/// Sample a token id from `logits` under `params`, advancing the PRNG `rng`.
+/// Divide the logit of each unique seen token by `penalty` when positive,
+/// multiply when negative. Mirrors `mlxcel-core`'s `apply_repetition_penalty`
+/// (a deduplicated set of seen ids, one op per unique token).
+fn apply_repetition(logits: &mut [f32], history: &[i32], penalty: f32) {
+    let mut seen: Vec<i32> = history.to_vec();
+    seen.sort_unstable();
+    seen.dedup();
+    for t in seen {
+        if t >= 0 && (t as usize) < logits.len() {
+            let l = logits[t as usize];
+            logits[t as usize] = if l > 0.0 { l / penalty } else { l * penalty };
+        }
+    }
+}
+
+/// Subtract `frequency * count + presence` from each seen token's logit. Mirrors
+/// `mlxcel-core`'s `apply_frequency_presence_penalty`.
+fn apply_frequency_presence(logits: &mut [f32], history: &[i32], frequency: f32, presence: f32) {
+    let mut counts: HashMap<i32, usize> = HashMap::new();
+    for &t in history {
+        *counts.entry(t).or_insert(0) += 1;
+    }
+    for (t, c) in counts {
+        if t >= 0 && (t as usize) < logits.len() {
+            logits[t as usize] -= frequency * c as f32 + presence;
+        }
+    }
+}
+
+/// Penalize tokens that would extend a repeated suffix (DRY). For each earlier
+/// occurrence of the last token, extend the backward match (stopping at a sequence
+/// breaker); when the match exceeds `dry_allowed_length`, penalize the token that
+/// followed that occurrence by `dry_multiplier * dry_base^(match_len - allowed)`,
+/// keeping the largest penalty per token. Mirrors `mlxcel-core`'s
+/// `apply_dry_penalty`.
+fn apply_dry(logits: &mut [f32], history: &[i32], params: &SampleParams) {
+    let hlen = history.len();
+    if hlen < 2 {
+        return;
+    }
+    let window: &[i32] = if params.dry_penalty_last_n == 0 {
+        history
+    } else {
+        &history[hlen.saturating_sub(params.dry_penalty_last_n)..]
+    };
+    let wlen = window.len();
+    if wlen < 2 {
+        return;
+    }
+
+    let mut positions: HashMap<i32, Vec<usize>> = HashMap::new();
+    for (i, &t) in window.iter().enumerate() {
+        positions.entry(t).or_default().push(i);
+    }
+
+    let last = window[wlen - 1];
+    let mut penalties: HashMap<i32, f32> = HashMap::new();
+    if let Some(pos_list) = positions.get(&last) {
+        for &pos in pos_list {
+            if pos >= wlen - 1 {
+                continue;
+            }
+            let mut match_len = 1usize;
+            let mut p1 = pos;
+            let mut p2 = wlen - 1;
+            while p1 > 0 && p2 > 0 {
+                p1 -= 1;
+                p2 -= 1;
+                if params.dry_sequence_breakers.contains(&window[p1]) {
+                    break;
+                }
+                if window[p1] == window[p2] {
+                    match_len += 1;
+                } else {
+                    break;
+                }
+            }
+            if match_len > params.dry_allowed_length {
+                let next_pos = pos + 1;
+                if next_pos < wlen {
+                    let next_token = window[next_pos];
+                    let penalty = params.dry_multiplier
+                        * params
+                            .dry_base
+                            .powi((match_len - params.dry_allowed_length) as i32);
+                    let entry = penalties.entry(next_token).or_insert(0.0);
+                    if penalty > *entry {
+                        *entry = penalty;
+                    }
+                }
+            }
+        }
+    }
+    for (t, pen) in penalties {
+        if t >= 0 && (t as usize) < logits.len() {
+            logits[t as usize] -= pen;
+        }
+    }
+}
+
+/// Apply every enabled history-based penalty to `logits` in place, in the same
+/// order as the MLX path: repetition, then DRY, then frequency/presence.
+fn apply_penalties(logits: &mut [f32], params: &SampleParams, history: &[i32]) {
+    if history.is_empty() {
+        return;
+    }
+    if params.repetition_penalty != 1.0 {
+        apply_repetition(logits, history, params.repetition_penalty);
+    }
+    if params.dry_multiplier > 0.0 {
+        apply_dry(logits, history, params);
+    }
+    if params.frequency_penalty != 0.0 || params.presence_penalty != 0.0 {
+        apply_frequency_presence(
+            logits,
+            history,
+            params.frequency_penalty,
+            params.presence_penalty,
+        );
+    }
+}
+
+/// Sample a token id from `logits` under `params` given the request's prior
+/// `history` (prompt + tokens generated so far), advancing the PRNG `rng`.
 ///
-/// Greedy short-circuits to argmax. Otherwise: temperature-scaled stable softmax,
-/// then top-k, top-p, and min-p filtering, then a categorical draw. Falls back to
-/// argmax if filtering leaves nothing with positive mass.
-pub(crate) fn sample(logits: &[f32], params: &SampleParams, rng: &mut u64) -> i32 {
+/// History-based penalties are applied to a local copy of the logits first, so
+/// greedy too picks the argmax of the penalized logits. Then greedy
+/// short-circuits to argmax; otherwise temperature-scaled stable softmax, then
+/// top-k, top-p, and min-p filtering, then a categorical draw. Falls back to
+/// argmax if filtering leaves nothing with positive mass. When no penalty is
+/// enabled (or the history is empty) the logits are used as-is with no copy, so
+/// greedy stays token-exact with the on-device argmax.
+pub(crate) fn sample(logits: &[f32], params: &SampleParams, history: &[i32], rng: &mut u64) -> i32 {
     if logits.is_empty() {
         return 0;
     }
+    let penalized: Vec<f32>;
+    let logits: &[f32] = if params.needs_penalties() && !history.is_empty() {
+        let mut v = logits.to_vec();
+        apply_penalties(&mut v, params, history);
+        penalized = v;
+        &penalized
+    } else {
+        logits
+    };
     if params.is_greedy() {
         return argmax(logits);
     }
@@ -173,6 +360,7 @@ pub(crate) fn sample(logits: &[f32], params: &SampleParams, rng: &mut u64) -> i3
 mod tests {
     use super::*;
 
+    /// Sampling params with the given temperature / top-k / top-p and no penalties.
     fn params(temperature: f32, top_k: usize, top_p: f32) -> SampleParams {
         SampleParams {
             temperature,
@@ -180,6 +368,18 @@ mod tests {
             top_p,
             min_p: 0.0,
             seed: Some(42),
+            ..SampleParams::greedy()
+        }
+    }
+
+    /// Greedy params with the given history-based penalties (deterministic, so the
+    /// penalized argmax is exactly assertable).
+    fn penalized(repetition: f32, frequency: f32, presence: f32) -> SampleParams {
+        SampleParams {
+            repetition_penalty: repetition,
+            frequency_penalty: frequency,
+            presence_penalty: presence,
+            ..SampleParams::greedy()
         }
     }
 
@@ -187,9 +387,9 @@ mod tests {
     fn greedy_is_argmax() {
         let logits = [0.1, 0.5, 0.3, 9.0, 0.2];
         let mut rng = 1;
-        assert_eq!(sample(&logits, &SampleParams::greedy(), &mut rng), 3);
+        assert_eq!(sample(&logits, &SampleParams::greedy(), &[], &mut rng), 3);
         // temperature 0 short-circuits regardless of filters
-        assert_eq!(sample(&logits, &params(0.0, 0, 1.0), &mut rng), 3);
+        assert_eq!(sample(&logits, &params(0.0, 0, 1.0), &[], &mut rng), 3);
     }
 
     #[test]
@@ -198,7 +398,7 @@ mod tests {
         let mut rng = 7;
         // top_k=1 leaves only the max, so sampling is deterministic = argmax.
         for _ in 0..16 {
-            assert_eq!(sample(&logits, &params(1.0, 1, 1.0), &mut rng), 1);
+            assert_eq!(sample(&logits, &params(1.0, 1, 1.0), &[], &mut rng), 1);
         }
     }
 
@@ -208,7 +408,7 @@ mod tests {
         let run = || {
             let mut rng = 12345u64;
             (0..32)
-                .map(|_| sample(&logits, &params(1.0, 0, 1.0), &mut rng))
+                .map(|_| sample(&logits, &params(1.0, 0, 1.0), &[], &mut rng))
                 .collect::<Vec<_>>()
         };
         assert_eq!(run(), run());
@@ -220,13 +420,116 @@ mod tests {
         let logits = [10.0, 0.0, 0.0, 0.0];
         let mut rng = 99;
         for _ in 0..16 {
-            assert_eq!(sample(&logits, &params(1.0, 0, 0.5), &mut rng), 0);
+            assert_eq!(sample(&logits, &params(1.0, 0, 0.5), &[], &mut rng), 0);
         }
     }
 
     #[test]
     fn empty_logits_is_safe() {
         let mut rng = 1;
-        assert_eq!(sample(&[], &SampleParams::greedy(), &mut rng), 0);
+        assert_eq!(sample(&[], &SampleParams::greedy(), &[], &mut rng), 0);
+    }
+
+    #[test]
+    fn needs_penalties_matches_identity_values() {
+        assert!(!SampleParams::greedy().needs_penalties());
+        assert!(penalized(1.1, 0.0, 0.0).needs_penalties());
+        assert!(penalized(0.8, 0.0, 0.0).needs_penalties());
+        assert!(penalized(1.0, 0.5, 0.0).needs_penalties());
+        assert!(penalized(1.0, 0.0, 0.5).needs_penalties());
+        let mut d = SampleParams::greedy();
+        d.dry_multiplier = 0.8;
+        assert!(d.needs_penalties());
+    }
+
+    #[test]
+    fn repetition_penalty_divides_positive_seen_logit() {
+        let mut rng = 1;
+        let logits = [2.0, 1.4, 0.5];
+        // Empty history: nothing to penalize, argmax stays token 0.
+        assert_eq!(sample(&logits, &penalized(2.0, 0.0, 0.0), &[], &mut rng), 0);
+        // Token 0 seen: its 2.0 logit halves to 1.0 < 1.4, so greedy moves to token 1.
+        assert_eq!(
+            sample(&logits, &penalized(2.0, 0.0, 0.0), &[0], &mut rng),
+            1
+        );
+    }
+
+    #[test]
+    fn repetition_penalty_multiplies_negative_seen_logit() {
+        let mut v = [-1.0f32, 0.5];
+        apply_repetition(&mut v, &[0, 0], 2.0); // dedup -> one application
+        assert_eq!(v[0], -2.0); // negative logit is multiplied
+        assert_eq!(v[1], 0.5);
+    }
+
+    #[test]
+    fn frequency_presence_penalty_subtracts_count_and_presence() {
+        let mut v = [0.0f32, 0.0, 0.0];
+        // token 1 appears twice, token 2 once.
+        apply_frequency_presence(&mut v, &[1, 1, 2], 0.5, 0.25);
+        assert!((v[1] - -(0.5 * 2.0 + 0.25)).abs() < 1e-6); // -1.25
+        assert!((v[2] - -(0.5 * 1.0 + 0.25)).abs() < 1e-6); // -0.75
+        assert_eq!(v[0], 0.0);
+    }
+
+    #[test]
+    fn dry_penalizes_followup_after_suffix_match() {
+        // history a b c a b (0 1 2 0 1); last token b's earlier occurrence at idx 1
+        // back-matches "a b" (len 2) > allowed 1, so the follow token c is penalized
+        // by dry_multiplier * dry_base^(2 - 1) = 1.0 * 2.0 = 2.0.
+        let mut v = [0.0f32; 3];
+        let history = [0, 1, 2, 0, 1];
+        let p = SampleParams {
+            dry_multiplier: 1.0,
+            dry_base: 2.0,
+            dry_allowed_length: 1,
+            ..SampleParams::greedy()
+        };
+        apply_dry(&mut v, &history, &p);
+        assert!((v[2] - -2.0).abs() < 1e-6, "v={v:?}");
+        assert_eq!(v[0], 0.0);
+        assert_eq!(v[1], 0.0);
+    }
+
+    #[test]
+    fn dry_sequence_breaker_stops_the_match() {
+        // Same history, but token a (0) is a sequence breaker, so the back-match
+        // breaks before reaching length 2 and nothing is penalized.
+        let mut v = [0.0f32; 3];
+        let history = [0, 1, 2, 0, 1];
+        let p = SampleParams {
+            dry_multiplier: 1.0,
+            dry_base: 2.0,
+            dry_allowed_length: 1,
+            dry_sequence_breakers: vec![0],
+            ..SampleParams::greedy()
+        };
+        apply_dry(&mut v, &history, &p);
+        assert_eq!(v, [0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn greedy_argmax_is_taken_over_penalized_logits() {
+        let logits = [3.0, 2.0];
+        let mut rng = 1;
+        // Greedy with no penalty keeps token 0 even if it is in history.
+        assert_eq!(sample(&logits, &SampleParams::greedy(), &[0], &mut rng), 0);
+        // Repetition penalty halves token 0 (3.0 -> 1.5 < 2.0), flipping greedy.
+        assert_eq!(
+            sample(&logits, &penalized(2.0, 0.0, 0.0), &[0], &mut rng),
+            1
+        );
+    }
+
+    #[test]
+    fn no_penalty_ignores_history() {
+        // With every penalty at its identity value, history must not change output.
+        let logits = [3.0, 2.0, 1.0];
+        let mut rng = 1;
+        assert_eq!(
+            sample(&logits, &params(0.0, 0, 1.0), &[0, 0, 1, 2], &mut rng),
+            0
+        );
     }
 }

--- a/src/server/batch/xla_worker.rs
+++ b/src/server/batch/xla_worker.rs
@@ -24,18 +24,18 @@
 //! the server's [`StreamingDecodeState`] for byte-fallback-safe detokenization.
 //!
 //! Scope: text-only. This path honors `max_tokens`, the model's EOS ids,
-//! sampling (temperature / top-k / top-p / min-p / seed, #449 M3 Stage 2d), and
-//! stop strings (#449 M3 Stage 2d): a [`StopMatcher`] withholds any decoded tail
-//! that could begin a stop string and ends the request at the earliest full
-//! match, excluding the stop string and everything after it from the output
-//! (the same rule as
+//! sampling (temperature / top-k / top-p / min-p / seed, #449 M3 Stage 2d), the
+//! history-based penalties (repetition / frequency / presence / DRY, #449 M3
+//! Stage 2d, applied host-side in the engine's sampler with the same math and
+//! order as the MLX path), and stop strings (#449 M3 Stage 2d): a
+//! [`StopMatcher`] withholds any decoded tail that could begin a stop string and
+//! ends the request at the earliest full match, excluding the stop string and
+//! everything after it from the output (the same rule as
 //! [`apply_stop_sequences`](crate::server::anthropic_translator::apply_stop_sequences),
-//! applied incrementally so it is safe across token boundaries). The
-//! history-based penalties (repetition / frequency / presence / DRY) are not
-//! applied (logged once). Requests that need features the engine cannot provide
-//! are rejected with a clear error rather than served wrong: logprobs (no logit
-//! readback), structured / JSON-schema output (no constraint masking), and
-//! multimodal inputs (text-only).
+//! applied incrementally so it is safe across token boundaries). Requests that
+//! need features the engine cannot provide are rejected with a clear error rather
+//! than served wrong: logprobs (no logit readback), structured / JSON-schema
+//! output (no constraint masking), and multimodal inputs (text-only).
 //!
 //! Compiled only under `xla-iree` (real IREE execution). The MLX serving path is
 //! untouched.
@@ -78,7 +78,6 @@ pub(crate) struct XlaServeWorker {
     /// Active requests, keyed by the engine req id `submit` returned.
     states: HashMap<u64, ServeState>,
     shutdown: bool,
-    warned_penalties: bool,
 }
 
 impl XlaServeWorker {
@@ -93,7 +92,6 @@ impl XlaServeWorker {
             request_rx,
             states: HashMap::new(),
             shutdown: false,
-            warned_penalties: false,
         }
     }
 
@@ -130,10 +128,11 @@ impl XlaServeWorker {
             return;
         }
 
-        // Sampling: temperature / top-k / top-p / min-p / seed are honored; stop
-        // strings are enforced below by a per-request `StopMatcher`. The
+        // Sampling: temperature / top-k / top-p / min-p / seed and the
         // history-based penalties (repetition / frequency / presence / DRY) are
-        // not applied, so warn once when a request asks for them.
+        // honored; stop strings are enforced below by a per-request `StopMatcher`.
+        // The penalty math runs host-side in the engine's sampler and mirrors the
+        // MLX path, so the two backends penalize identically for the same history.
         let sampling = &options.sampling;
         let params = SampleParams {
             temperature: sampling.temperature,
@@ -141,18 +140,15 @@ impl XlaServeWorker {
             top_p: sampling.top_p,
             min_p: sampling.min_p,
             seed: sampling.seed,
+            repetition_penalty: sampling.repetition_penalty,
+            frequency_penalty: sampling.frequency_penalty,
+            presence_penalty: sampling.presence_penalty,
+            dry_multiplier: sampling.dry_multiplier,
+            dry_base: sampling.dry_base,
+            dry_allowed_length: sampling.dry_allowed_length,
+            dry_penalty_last_n: sampling.dry_penalty_last_n,
+            dry_sequence_breakers: sampling.dry_sequence_breakers.clone(),
         };
-        let uses_penalties = sampling.repetition_penalty != 1.0
-            || sampling.frequency_penalty != 0.0
-            || sampling.presence_penalty != 0.0
-            || sampling.dry_multiplier != 0.0;
-        if uses_penalties && !self.warned_penalties {
-            tracing::warn!(
-                "the OpenXLA backend applies temperature / top-k / top-p / min-p only; \
-                 repetition / frequency / presence penalties and DRY are ignored"
-            );
-            self.warned_penalties = true;
-        }
 
         let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
         let token_ids = match self.tokenizer.encode(&prompt, add_special) {


### PR DESCRIPTION
## Summary

Stage 2d follow-up of the OpenXLA/IREE milestone (#449 M3): the serve path honored temperature / top-k / top-p / min-p / seed and stop strings, but warned that the history-based penalties were ignored. This applies them host-side in the engine's sampler, mirroring the MLX path's math and order, so the OpenXLA backend honors `repetition_penalty`, `frequency_penalty`, `presence_penalty`, and DRY.

## What's here

- **`sampler.rs`**: `SampleParams` gains the penalty fields (and `needs_penalties()`); it is now `Clone` rather than `Copy` because DRY owns a `Vec` of sequence breakers. New `apply_repetition` / `apply_frequency_presence` / `apply_dry` mirror `mlxcel-core`'s `apply_repetition_penalty` / `apply_frequency_presence_penalty` / `apply_dry_penalty` token for token, and `apply_penalties` runs them in the same order as the MLX path (repetition, then DRY, then frequency/presence). `sample()` now takes the request's token history and penalizes a local copy of the logits before doing anything else, so greedy too picks the argmax of the penalized logits. When no penalty is enabled (or the history is empty) the logits are used as-is with no copy, so greedy stays token-exact with the on-device argmax.
- **`batch.rs`**: each `Slot` tracks its token history, seeded from the prompt (matching `mlxcel-core`'s `initial_token_history`) and appended with every generated token, but only when a penalty is active. `pump` passes the slot's history to `sample()` at prefill and decode. Greedy requests keep an empty history, so they carry no per-slot cost.
- **`xla_worker.rs`**: populate the penalty fields from `options.sampling` and remove the penalty warn-once path.

## Semantics

The four penalties match `mlxcel-core` exactly: repetition divides a seen token's positive logit by the penalty (multiplies when negative) over the unique seen set; frequency/presence subtract `frequency * count + presence`; DRY penalizes the token that would extend a repeated suffix by `dry_multiplier * dry_base^(match_len - allowed_length)`, stopping the back-match at a sequence breaker. The penalty history is the prompt plus generated tokens, the same window the MLX path uses.

## Validation

- **Unit tests** (`cargo test -p mlxcel-xla`, no feature needed): 14 sampler tests, including the repetition divide/multiply rule, the frequency/presence formula, the DRY suffix match and its sequence-breaker stop, that greedy takes the argmax over the penalized logits, and that an all-identity config ignores history. 23 tests total in the crate.
- **E2E on GB10 CUDA** (`/v1/completions`):
  - greedy with penalties off is **token-exact** with the pre-penalty baseline (the refactor does not disturb greedy);
  - `repetition_penalty`, `frequency_penalty`, and `presence_penalty` each change the output;
  - DRY is a **no-op on non-repetitive output** and **breaks a repeated suffix** when one exists;
  - same seed + temperature + penalty is reproducible; a different seed diverges;
  - a fully looping greedy output (the token "go" 48/48) is broken by `frequency_penalty=2.0` (down to a max word frequency of 3, coherent text) and by DRY.
- `cargo fmt` and `cargo clippy -D warnings` clean (default, `mlxcel-xla` with `iree`, and `mlxcel --features xla-iree`); `mlxcel-server` builds and links with `xla-iree`.

The MLX serving path is unchanged (no trait / scheduler changes); default and CI builds compile with the XLA worker absent.

## Scope / non-goals

Applies repetition / frequency / presence / DRY on the OpenXLA serve path, host-side. Still not on this backend: logprobs, structured output, multimodal (rejected). On-device sampling (the penalties run on the host logits readback), paged-KV, and chunked prefill remain later Stage 2d/2e follow-ups.

Refs #449 (epic). Follows #478 (Stage 2d stop strings), #471 (Stage 2d sampling), #470/#469/#468/#466/#462.
