### PR TITLE
feat: emit the OpenXLA graphs from config.json at load (#449 M3 Stage 2d)

### DIFF
--- a/src/lib/mlxcel-xla/Cargo.toml
+++ b/src/lib/mlxcel-xla/Cargo.toml
@@ -25,7 +25,7 @@ build = "build.rs"
 # Real IREE execution. Off by default so `--features xla-backend` stays buildable
 # in CI (no IREE dist). When on, build.rs compiles csrc/xla_iree.c and links the
 # prebuilt IREE runtime (IREE_DIST must point at the extracted dist).
-iree = ["dep:safetensors", "dep:memmap2", "dep:serde_json"]
+iree = ["dep:safetensors", "dep:memmap2"]
 
 [dependencies]
 # The engine-neutral inference-session contract lives in mlxcel-core. This
@@ -38,8 +38,9 @@ mlxcel-core = { path = "../mlxcel-core" }
 # feature, where the session uploads the real weights to the device.
 safetensors = { version = "0.4", optional = true }
 memmap2 = { version = "0.9", optional = true }
-# config.json shape check (the bundled graphs are authored for one architecture).
-serde_json = { version = "1", optional = true }
+# config.json parsing: the emitter reads model dimensions from it to generate the
+# graphs at load (always compiled with the crate), and the iree path also uses it.
+serde_json = { version = "1" }
 
 [build-dependencies]
 cc = "1"

--- a/src/lib/mlxcel-xla/assets/llama-3.2-1b/config.json
+++ b/src/lib/mlxcel-xla/assets/llama-3.2-1b/config.json
@@ -1,0 +1,37 @@
+{
+  "architectures": [
+    "LlamaForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 128000,
+  "eos_token_id": 128009,
+  "head_dim": 64,
+  "hidden_act": "silu",
+  "hidden_size": 2048,
+  "initializer_range": 0.02,
+  "intermediate_size": 8192,
+  "max_position_embeddings": 131072,
+  "mlp_bias": false,
+  "model_type": "llama",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 16,
+  "num_key_value_heads": 8,
+  "pad_token_id": 128004,
+  "pretraining_tp": 1,
+  "rms_norm_eps": 1e-05,
+  "rope_scaling": {
+    "factor": 32.0,
+    "high_freq_factor": 4.0,
+    "low_freq_factor": 1.0,
+    "original_max_position_embeddings": 8192,
+    "rope_type": "llama3"
+  },
+  "rope_theta": 500000.0,
+  "tie_word_embeddings": true,
+  "torch_dtype": "bfloat16",
+  "transformers_version": "4.52.0.dev0",
+  "unsloth_fixed": true,
+  "use_cache": true,
+  "vocab_size": 128256
+}

--- a/src/lib/mlxcel-xla/src/emitter/builder.rs
+++ b/src/lib/mlxcel-xla/src/emitter/builder.rs
@@ -1,0 +1,589 @@
+//! Minimal StableHLO text builder.
+//!
+//! Tracks SSA value names and their tensor types, and exposes one method per
+//! StableHLO op we need. Each method emits one textual line into the function
+//! body and returns a typed `Val` handle, so the model code reads like ordinary
+//! tensor algebra while the builder owns name generation and type bookkeeping.
+//!
+//! The op spellings mirror exactly what `jax.export` emitted in
+//! `spike/openxla/artifacts/decode_step.stablehlo.mlir`, which `iree-compile`
+//! already parses as text, so every form here is known-good for that toolchain.
+
+use std::fmt::Write as _;
+
+/// Tensor type: shape plus element type ("f32" | "i32" | "i1").
+#[derive(Clone, Debug)]
+pub struct Ty {
+    pub shape: Vec<usize>,
+    pub elt: &'static str,
+}
+
+impl Ty {
+    pub fn new(shape: Vec<usize>, elt: &'static str) -> Self {
+        Ty { shape, elt }
+    }
+    pub fn f32(shape: Vec<usize>) -> Self {
+        Ty::new(shape, "f32")
+    }
+    pub fn scalar(elt: &'static str) -> Self {
+        Ty::new(vec![], elt)
+    }
+    pub fn render(&self) -> String {
+        if self.shape.is_empty() {
+            format!("tensor<{}>", self.elt)
+        } else {
+            let dims: Vec<String> = self.shape.iter().map(|d| d.to_string()).collect();
+            format!("tensor<{}x{}>", dims.join("x"), self.elt)
+        }
+    }
+}
+
+/// A typed SSA value handle (e.g. `%42 : tensor<2048xf32>`).
+#[derive(Clone, Debug)]
+pub struct Val {
+    pub name: String,
+    pub ty: Ty,
+}
+
+pub struct Builder {
+    body: String,
+    next: usize,
+}
+
+fn dims_list(d: &[usize]) -> String {
+    let parts: Vec<String> = d.iter().map(|x| x.to_string()).collect();
+    format!("[{}]", parts.join(", "))
+}
+
+/// f32 -> MLIR scalar hex literal (big-endian bit pattern), exact and unambiguous.
+pub fn f32_hex(x: f32) -> String {
+    format!("0x{:08X}", x.to_bits())
+}
+
+/// f32 slice -> MLIR dense blob hex (little-endian raw bytes), matching JAX output.
+pub fn f32_blob(data: &[f32]) -> String {
+    let mut s = String::with_capacity(data.len() * 8);
+    for &x in data {
+        for b in x.to_le_bytes() {
+            let _ = write!(s, "{:02X}", b);
+        }
+    }
+    s
+}
+
+impl Builder {
+    pub fn new() -> Self {
+        Builder {
+            body: String::new(),
+            next: 0,
+        }
+    }
+
+    pub fn body(&self) -> &str {
+        &self.body
+    }
+
+    fn fresh(&mut self) -> String {
+        let n = self.next;
+        self.next += 1;
+        format!("%{}", n)
+    }
+
+    fn line(&mut self, s: String) {
+        self.body.push_str("    ");
+        self.body.push_str(&s);
+        self.body.push('\n');
+    }
+
+    /// Construct a handle to an existing func argument (not emitted).
+    pub fn arg(idx: usize, ty: Ty) -> Val {
+        Val {
+            name: format!("%arg{}", idx),
+            ty,
+        }
+    }
+
+    // --- constants ---------------------------------------------------------
+
+    pub fn const_f32(&mut self, x: f32) -> Val {
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.constant dense<{}> : tensor<f32>",
+            r,
+            f32_hex(x)
+        ));
+        Val {
+            name: r,
+            ty: Ty::scalar("f32"),
+        }
+    }
+
+    pub fn const_i32(&mut self, v: i32) -> Val {
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.constant dense<{}> : tensor<i32>",
+            r, v
+        ));
+        Val {
+            name: r,
+            ty: Ty::scalar("i32"),
+        }
+    }
+
+    /// Dense f32 constant tensor from raw data (row-major), emitted as hex blob.
+    pub fn const_tensor_f32(&mut self, data: &[f32], shape: Vec<usize>) -> Val {
+        let ty = Ty::f32(shape);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.constant dense<\"0x{}\"> : {}",
+            r,
+            f32_blob(data),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    // --- structural --------------------------------------------------------
+
+    pub fn iota(&mut self, n: usize) -> Val {
+        let ty = Ty::new(vec![n], "i32");
+        let r = self.fresh();
+        self.line(format!("{} = stablehlo.iota dim = 0 : {}", r, ty.render()));
+        Val { name: r, ty }
+    }
+
+    pub fn reshape(&mut self, x: &Val, shape: Vec<usize>) -> Val {
+        let ty = Ty::new(shape, x.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.reshape {} : ({}) -> {}",
+            r,
+            x.name,
+            x.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn broadcast(&mut self, x: &Val, dims: &[usize], out_shape: Vec<usize>) -> Val {
+        let ty = Ty::new(out_shape, x.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.broadcast_in_dim {}, dims = {} : ({}) -> {}",
+            r,
+            x.name,
+            dims_list(dims),
+            x.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    /// Permute axes. `perm[k]` is the input axis that becomes output axis k.
+    pub fn transpose(&mut self, x: &Val, perm: &[usize]) -> Val {
+        let shape: Vec<usize> = perm.iter().map(|&p| x.ty.shape[p]).collect();
+        let ty = Ty::new(shape, x.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.transpose {}, dims = {} : ({}) -> {}",
+            r,
+            x.name,
+            dims_list(perm),
+            x.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    /// Unused by decode today; kept for the int4 dequant path (int -> f32).
+    #[allow(dead_code)]
+    pub fn convert(&mut self, x: &Val, elt: &'static str) -> Val {
+        let ty = Ty::new(x.ty.shape.clone(), elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.convert {} : ({}) -> {}",
+            r,
+            x.name,
+            x.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    /// Static slice. `ranges` is (start, limit) per dim, stride 1.
+    pub fn slice(&mut self, x: &Val, ranges: &[(usize, usize)]) -> Val {
+        let shape: Vec<usize> = ranges.iter().map(|(s, l)| l - s).collect();
+        let ty = Ty::new(shape, x.ty.elt);
+        let parts: Vec<String> = ranges.iter().map(|(s, l)| format!("{}:{}", s, l)).collect();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.slice {} [{}] : ({}) -> {}",
+            r,
+            x.name,
+            parts.join(", "),
+            x.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn concatenate(&mut self, a: &Val, b: &Val, dim: usize) -> Val {
+        let mut shape = a.ty.shape.clone();
+        shape[dim] = a.ty.shape[dim] + b.ty.shape[dim];
+        let ty = Ty::new(shape, a.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.concatenate {}, {}, dim = {} : ({}, {}) -> {}",
+            r,
+            a.name,
+            b.name,
+            dim,
+            a.ty.render(),
+            b.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn dynamic_slice(&mut self, x: &Val, starts: &[&Val], sizes: Vec<usize>) -> Val {
+        let ty = Ty::new(sizes.clone(), x.ty.elt);
+        let names: Vec<String> = starts.iter().map(|v| v.name.clone()).collect();
+        let idx_tys: Vec<String> = starts.iter().map(|v| v.ty.render()).collect();
+        let sz: Vec<String> = sizes.iter().map(|s| s.to_string()).collect();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.dynamic_slice {}, {}, sizes = [{}] : ({}, {}) -> {}",
+            r,
+            x.name,
+            names.join(", "),
+            sz.join(", "),
+            x.ty.render(),
+            idx_tys.join(", "),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn dynamic_update_slice(&mut self, operand: &Val, update: &Val, starts: &[&Val]) -> Val {
+        let ty = operand.ty.clone();
+        let names: Vec<String> = starts.iter().map(|v| v.name.clone()).collect();
+        let idx_tys: Vec<String> = starts.iter().map(|v| v.ty.render()).collect();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.dynamic_update_slice {}, {}, {} : ({}, {}, {}) -> {}",
+            r,
+            operand.name,
+            update.name,
+            names.join(", "),
+            operand.ty.render(),
+            update.ty.render(),
+            idx_tys.join(", "),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    /// Row gather: `operand[N, M]` indexed by `indices[Lp, 1]` (i32) -> `[Lp, M]`.
+    /// This is the multi-token embedding lookup `embed[tokens]`; the
+    /// dimension_numbers and slice_sizes mirror the JAX-emitted `prefill`
+    /// `stablehlo.gather` in spike/openxla/artifacts/prefill.stablehlo.mlir.
+    pub fn gather(&mut self, operand: &Val, indices: &Val) -> Val {
+        let lp = indices.ty.shape[0];
+        let m = operand.ty.shape[1];
+        let ty = Ty::new(vec![lp, m], operand.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = \"stablehlo.gather\"({}, {}) <{{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, slice_sizes = array<i64: 1, {}>}}> : ({}, {}) -> {}",
+            r,
+            operand.name,
+            indices.name,
+            m,
+            operand.ty.render(),
+            indices.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    // --- elementwise -------------------------------------------------------
+
+    fn binary(&mut self, op: &str, a: &Val, b: &Val) -> Val {
+        let ty = a.ty.clone();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.{} {}, {} : {}",
+            r,
+            op,
+            a.name,
+            b.name,
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn add(&mut self, a: &Val, b: &Val) -> Val {
+        self.binary("add", a, b)
+    }
+    pub fn subtract(&mut self, a: &Val, b: &Val) -> Val {
+        self.binary("subtract", a, b)
+    }
+    pub fn multiply(&mut self, a: &Val, b: &Val) -> Val {
+        self.binary("multiply", a, b)
+    }
+    pub fn divide(&mut self, a: &Val, b: &Val) -> Val {
+        self.binary("divide", a, b)
+    }
+
+    fn unary(&mut self, op: &str, a: &Val) -> Val {
+        let ty = a.ty.clone();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.{} {} : {}",
+            r,
+            op,
+            a.name,
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn negate(&mut self, a: &Val) -> Val {
+        self.unary("negate", a)
+    }
+    pub fn exponential(&mut self, a: &Val) -> Val {
+        self.unary("exponential", a)
+    }
+    pub fn rsqrt(&mut self, a: &Val) -> Val {
+        self.unary("rsqrt", a)
+    }
+
+    /// `compare DIR, a, b, SIGNED|FLOAT` -> i1 tensor of the same shape.
+    pub fn compare(&mut self, dir: &str, a: &Val, b: &Val, kind: &str) -> Val {
+        let ty = Ty::new(a.ty.shape.clone(), "i1");
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.compare {}, {}, {}, {} : ({}, {}) -> {}",
+            r,
+            dir,
+            a.name,
+            b.name,
+            kind,
+            a.ty.render(),
+            b.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn select(&mut self, pred: &Val, a: &Val, b: &Val) -> Val {
+        let ty = a.ty.clone();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.select {}, {}, {} : {}, {}",
+            r,
+            pred.name,
+            a.name,
+            b.name,
+            pred.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    // --- reductions --------------------------------------------------------
+
+    fn reduce(&mut self, applies: &str, x: &Val, dim: usize, init: &Val) -> Val {
+        let shape: Vec<usize> =
+            x.ty.shape
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| *i != dim)
+                .map(|(_, d)| *d)
+                .collect();
+        let ty = Ty::new(shape, x.ty.elt);
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.reduce({} init: {}) applies stablehlo.{} across dimensions = [{}] : ({}, {}) -> {}",
+            r, x.name, init.name, applies, dim, x.ty.render(), init.ty.render(), ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    pub fn reduce_add(&mut self, x: &Val, dim: usize, init: &Val) -> Val {
+        self.reduce("add", x, dim, init)
+    }
+    pub fn reduce_max(&mut self, x: &Val, dim: usize, init: &Val) -> Val {
+        self.reduce("maximum", x, dim, init)
+    }
+
+    /// On-device argmax over a `[V]` vector -> scalar `i32` index (the first
+    /// index of the max, numpy/jax semantics). Mirrors the JAX/IREE-emitted
+    /// argmax reducer in `spike/openxla/artifacts/fp32_decode_argmax.stablehlo.mlir`:
+    /// a two-operand `stablehlo.reduce` over (values, iota indices) whose body
+    /// keeps the larger value (or NaN), tie-breaking to the lower index. This is
+    /// the Phase 2b on-device sampling: the graph returns a token id, so a decode
+    /// step ships 4 bytes back instead of a `[V]` logits copy. The reducer block
+    /// args are named (not `%argN` / `%N`) so they never collide with the
+    /// function args or the builder's SSA counter.
+    pub fn argmax(&mut self, logits: &Val) -> Val {
+        let v = logits.ty.shape[0];
+        let vf = Ty::f32(vec![v]).render();
+        let vi = Ty::new(vec![v], "i32").render();
+        let c0 = self.fresh();
+        self.line(format!("{c0} = stablehlo.constant dense<0> : tensor<i32>"));
+        let ninf = self.fresh();
+        self.line(format!(
+            "{ninf} = stablehlo.constant dense<0xFF800000> : tensor<f32>"
+        ));
+        let iota = self.fresh();
+        self.line(format!("{iota} = stablehlo.iota dim = 0 : {vi}"));
+        let res = self.fresh();
+        self.line(format!(
+            "{res}:2 = stablehlo.reduce({l} init: {ninf}), ({iota} init: {c0}) across dimensions = [0] : ({vf}, {vi}, tensor<f32>, tensor<i32>) -> (tensor<f32>, tensor<i32>)",
+            l = logits.name
+        ));
+        self.argmax_reducer_block();
+        Val {
+            name: format!("{res}#1"),
+            ty: Ty::scalar("i32"),
+        }
+    }
+
+    /// Batched on-device argmax over `[B, V]` -> `[B] i32`: the per-row argmax
+    /// index (first-max, numpy/jax tie-break). Same reducer as `argmax`, here
+    /// reducing the last axis of a 2-D logits tensor; the index iota is `[B, V]`
+    /// with each row `0..V-1` (`iota dim = 1`). Returns the index result (`#1`)
+    /// as a `[B] i32`. This is the batched-decode sampling tail: each step ships
+    /// `B` token ids (`4*B` bytes) back instead of a `[B, V]` logits copy.
+    pub fn argmax_batched(&mut self, logits: &Val) -> Val {
+        let bsz = logits.ty.shape[0];
+        let v = logits.ty.shape[1];
+        let bvf = Ty::f32(vec![bsz, v]).render();
+        let bvi = Ty::new(vec![bsz, v], "i32").render();
+        let bf = Ty::f32(vec![bsz]).render();
+        let bi = Ty::new(vec![bsz], "i32").render();
+        let c0 = self.fresh();
+        self.line(format!("{c0} = stablehlo.constant dense<0> : tensor<i32>"));
+        let ninf = self.fresh();
+        self.line(format!(
+            "{ninf} = stablehlo.constant dense<0xFF800000> : tensor<f32>"
+        ));
+        let iota = self.fresh();
+        self.line(format!("{iota} = stablehlo.iota dim = 1 : {bvi}"));
+        let res = self.fresh();
+        self.line(format!(
+            "{res}:2 = stablehlo.reduce({l} init: {ninf}), ({iota} init: {c0}) across dimensions = [1] : ({bvf}, {bvi}, tensor<f32>, tensor<i32>) -> ({bf}, {bi})",
+            l = logits.name
+        ));
+        self.argmax_reducer_block();
+        Val {
+            name: format!("{res}#1"),
+            ty: Ty::new(vec![bsz], "i32"),
+        }
+    }
+
+    /// The shared `stablehlo.reduce` reducer region for argmax (scalar or
+    /// batched): keep the larger value (NaN-propagating), tie-break to the lower
+    /// index. The block operates on scalars regardless of the reduced rank, so
+    /// the same body serves both. Block args are named (not `%argN`/`%N`) so they
+    /// never collide with the function args or the builder's SSA counter.
+    fn argmax_reducer_block(&mut self) {
+        self.line(
+            "reducer(%amv_l: tensor<f32>, %amv_r: tensor<f32>) (%ami_l: tensor<i32>, %ami_r: tensor<i32>) {"
+                .to_string(),
+        );
+        let gt = self.fresh();
+        self.line(format!(
+            "  {gt} = stablehlo.compare GT, %amv_l, %amv_r, FLOAT : (tensor<f32>, tensor<f32>) -> tensor<i1>"
+        ));
+        let nan = self.fresh();
+        self.line(format!(
+            "  {nan} = stablehlo.compare NE, %amv_l, %amv_l, FLOAT : (tensor<f32>, tensor<f32>) -> tensor<i1>"
+        ));
+        let gt_nan = self.fresh();
+        self.line(format!(
+            "  {gt_nan} = stablehlo.or {gt}, {nan} : tensor<i1>"
+        ));
+        let eq = self.fresh();
+        self.line(format!(
+            "  {eq} = stablehlo.compare EQ, %amv_l, %amv_r, FLOAT : (tensor<f32>, tensor<f32>) -> tensor<i1>"
+        ));
+        let lt = self.fresh();
+        self.line(format!(
+            "  {lt} = stablehlo.compare LT, %ami_l, %ami_r, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>"
+        ));
+        let eq_lt = self.fresh();
+        self.line(format!("  {eq_lt} = stablehlo.and {eq}, {lt} : tensor<i1>"));
+        let idx_pred = self.fresh();
+        self.line(format!(
+            "  {idx_pred} = stablehlo.or {gt_nan}, {eq_lt} : tensor<i1>"
+        ));
+        let mv = self.fresh();
+        self.line(format!(
+            "  {mv} = stablehlo.select {gt_nan}, %amv_l, %amv_r : tensor<i1>, tensor<f32>"
+        ));
+        let mi = self.fresh();
+        self.line(format!(
+            "  {mi} = stablehlo.select {idx_pred}, %ami_l, %ami_r : tensor<i1>, tensor<i32>"
+        ));
+        self.line(format!(
+            "  stablehlo.return {mv}, {mi} : tensor<f32>, tensor<i32>"
+        ));
+        self.line("}".to_string());
+    }
+
+    // --- dot_general -------------------------------------------------------
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn dot_general(
+        &mut self,
+        lhs: &Val,
+        rhs: &Val,
+        lhs_batch: &[usize],
+        rhs_batch: &[usize],
+        lhs_contract: &[usize],
+        rhs_contract: &[usize],
+        out_shape: Vec<usize>,
+    ) -> Val {
+        let ty = Ty::new(out_shape, "f32");
+        let r = self.fresh();
+        let batch = if lhs_batch.is_empty() && rhs_batch.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "batching_dims = {} x {}, ",
+                dims_list(lhs_batch),
+                dims_list(rhs_batch)
+            )
+        };
+        self.line(format!(
+            "{} = stablehlo.dot_general {}, {}, {}contracting_dims = {} x {} : ({}, {}) -> {}",
+            r,
+            lhs.name,
+            rhs.name,
+            batch,
+            dims_list(lhs_contract),
+            dims_list(rhs_contract),
+            lhs.ty.render(),
+            rhs.ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    /// Convenience: y = x @ W^T for x:[K], W:[N,K] (weights stored [out,in]).
+    /// Contracts x dim 0 with W dim 1, yielding [N]. No transpose needed.
+    pub fn linear(&mut self, x: &Val, w: &Val) -> Val {
+        let n = w.ty.shape[0];
+        self.dot_general(x, w, &[], &[], &[0], &[1], vec![n])
+    }
+
+    /// Sequence-batched linear: y[L,N] = x[L,K] @ W^T for W:[N,K] (stored
+    /// [out,in]). Contracts the feature dim (x dim 1, W dim 1), keeps the [L]
+    /// row axis. The prefill analog of `linear` for `[Lp, ...]` activations.
+    pub fn linear_seq(&mut self, x: &Val, w: &Val) -> Val {
+        let l = x.ty.shape[0];
+        let n = w.ty.shape[0];
+        self.dot_general(x, w, &[], &[], &[1], &[1], vec![l, n])
+    }
+}

--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -1,0 +1,159 @@
+//! Llama-architecture emitter config. The hard-coded [`Config::llama_3_2_1b`]
+//! matches spike/openxla/model_jax.py; [`Config::from_json`] reads the same shape
+//! from any Llama checkpoint's `config.json` (issue #449 M3 Stage 2d).
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub hidden: usize,
+    pub inter: usize,
+    pub n_layers: usize,
+    pub n_q: usize,
+    pub n_kv: usize,
+    pub head_dim: usize,
+    pub eps: f32,
+    pub rope_theta: f64,
+    pub vocab: usize,
+    // llama3 rope scaling
+    pub factor: f64,
+    pub low_freq_factor: f64,
+    pub high_freq_factor: f64,
+    pub orig_ctx: usize,
+}
+
+impl Config {
+    /// Hard-coded Llama-3.2-1B-Instruct values (config.json of the spike model).
+    pub fn llama_3_2_1b() -> Self {
+        Config {
+            hidden: 2048,
+            inter: 8192,
+            n_layers: 16,
+            n_q: 32,
+            n_kv: 8,
+            head_dim: 64,
+            eps: 1e-5,
+            rope_theta: 500000.0,
+            vocab: 128256,
+            factor: 32.0,
+            low_freq_factor: 1.0,
+            high_freq_factor: 4.0,
+            orig_ctx: 8192,
+        }
+    }
+
+    /// Build a [`Config`] from a model's `config.json` text.
+    ///
+    /// Scope (Stage A): the Llama architecture with llama3 RoPE scaling, which is
+    /// what the emitter encodes. Configs the emitter cannot yet reproduce are
+    /// rejected with a clear error rather than silently mis-emitted: a non-`llama`
+    /// `model_type`, attention bias (e.g. Qwen2), untied embeddings, or a missing
+    /// / non-`llama3` `rope_scaling`.
+    pub fn from_json_str(s: &str) -> Result<Self, String> {
+        let v: serde_json::Value =
+            serde_json::from_str(s).map_err(|e| format!("parse config.json: {e}"))?;
+
+        let model_type = v.get("model_type").and_then(serde_json::Value::as_str);
+        if model_type != Some("llama") {
+            return Err(format!(
+                "the OpenXLA emitter currently supports the Llama architecture only; \
+                 config.json model_type = {model_type:?} (Qwen / Gemma / others are a follow-up)"
+            ));
+        }
+        if v.get("attention_bias").and_then(serde_json::Value::as_bool) == Some(true) {
+            return Err(
+                "the OpenXLA emitter does not yet support attention bias (e.g. Qwen2); \
+                 config.json attention_bias = true"
+                    .to_string(),
+            );
+        }
+        if v.get("tie_word_embeddings")
+            .and_then(serde_json::Value::as_bool)
+            != Some(true)
+        {
+            return Err("the OpenXLA emitter assumes tied word embeddings; \
+                 config.json tie_word_embeddings != true"
+                .to_string());
+        }
+
+        let u = |k: &str| -> Result<usize, String> {
+            v.get(k)
+                .and_then(serde_json::Value::as_u64)
+                .map(|x| x as usize)
+                .ok_or_else(|| format!("config.json missing integer `{k}`"))
+        };
+        let f = |k: &str| -> Result<f64, String> {
+            v.get(k)
+                .and_then(serde_json::Value::as_f64)
+                .ok_or_else(|| format!("config.json missing number `{k}`"))
+        };
+
+        let hidden = u("hidden_size")?;
+        let n_q = u("num_attention_heads")?;
+        // head_dim is explicit in recent configs; otherwise it is hidden / heads.
+        let head_dim = v
+            .get("head_dim")
+            .and_then(serde_json::Value::as_u64)
+            .map(|x| x as usize)
+            .unwrap_or(hidden / n_q.max(1));
+
+        let scaling = v.get("rope_scaling").ok_or_else(|| {
+            "the OpenXLA emitter encodes llama3 RoPE scaling; config.json has no \
+             `rope_scaling` (plain-RoPE Llama is a follow-up)"
+                .to_string()
+        })?;
+        let rope_type = scaling
+            .get("rope_type")
+            .or_else(|| scaling.get("type"))
+            .and_then(serde_json::Value::as_str);
+        if rope_type != Some("llama3") {
+            return Err(format!(
+                "the OpenXLA emitter encodes llama3 RoPE scaling; config.json \
+                 rope_scaling.rope_type = {rope_type:?} (only `llama3` is supported)"
+            ));
+        }
+        let sf = |k: &str| -> Result<f64, String> {
+            scaling
+                .get(k)
+                .and_then(serde_json::Value::as_f64)
+                .ok_or_else(|| format!("config.json rope_scaling missing number `{k}`"))
+        };
+        let orig_ctx = scaling
+            .get("original_max_position_embeddings")
+            .and_then(serde_json::Value::as_u64)
+            .map(|x| x as usize)
+            .ok_or_else(|| {
+                "config.json rope_scaling missing `original_max_position_embeddings`".to_string()
+            })?;
+
+        Ok(Config {
+            hidden,
+            inter: u("intermediate_size")?,
+            n_layers: u("num_hidden_layers")?,
+            n_q,
+            n_kv: u("num_key_value_heads")?,
+            head_dim,
+            eps: f("rms_norm_eps")? as f32,
+            rope_theta: f("rope_theta")?,
+            vocab: u("vocab_size")?,
+            factor: sf("factor")?,
+            low_freq_factor: sf("low_freq_factor")?,
+            high_freq_factor: sf("high_freq_factor")?,
+            orig_ctx,
+        })
+    }
+
+    /// Read and parse a model's `config.json` from its directory.
+    pub fn from_json(model_dir: &std::path::Path) -> Result<Self, String> {
+        let p = model_dir.join("config.json");
+        let s = std::fs::read_to_string(&p).map_err(|e| format!("read {}: {e}", p.display()))?;
+        Self::from_json_str(&s).map_err(|e| format!("{}: {e}", p.display()))
+    }
+
+    pub fn group(&self) -> usize {
+        self.n_q / self.n_kv
+    }
+
+    /// Attention scale head_dim^-0.5.
+    pub fn scale(&self) -> f32 {
+        (self.head_dim as f32).powf(-0.5)
+    }
+}

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -1,0 +1,88 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Rust-native StableHLO text emitter (issue #449 M3 Stage 2d, config.json-driven
+//! emit). Ported verbatim from the issue #451 spike `spike/rust-emitter`, then
+//! given a [`Config::from_json`](config::Config::from_json) reader so the engine
+//! generates its prefill / decode / ragged-decode graphs from a model's
+//! `config.json` at load, instead of being pinned to the bundled Llama-3.2-1B
+//! `.mlir` assets.
+//!
+//! Scope: the Llama architecture (RMSNorm, SwiGLU MLP, llama3 RoPE scaling, no
+//! attention bias, tied embeddings). The `Config` is parameterized by dimensions,
+//! so any Llama-architecture checkpoint (any size) emits correctly; genuinely
+//! different architectures (e.g. Qwen2 QKV bias, Gemma GeGLU / softcap) are a
+//! follow-up that extends the emitter and `from_json`.
+//!
+//! Pure Rust (no IREE), so it compiles and is unit-tested without the `iree`
+//! feature; only the IREE engine consumes it. The bundled `.mlir` assets remain
+//! as the byte-exact regression fixtures the test below checks the emitter against
+//! (the spike that generated them produces identical output, proven here).
+
+mod builder;
+mod config;
+mod model;
+mod rope;
+
+pub(crate) use config::Config;
+pub(crate) use model::{emit_decode, emit_decode_ragged, emit_prefill};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONFIG_JSON: &str = include_str!("../../assets/llama-3.2-1b/config.json");
+    const PREFILL: &str = include_str!("../../assets/llama-3.2-1b/prefill.mlir");
+    const DECODE: &str = include_str!("../../assets/llama-3.2-1b/decode.mlir");
+    const PREFILL_LOGITS: &str = include_str!("../../assets/llama-3.2-1b/prefill_logits.mlir");
+    const RAGGED_B4: &str = include_str!("../../assets/llama-3.2-1b/decode_ragged_logits_b4.mlir");
+    const RAGGED_B8: &str = include_str!("../../assets/llama-3.2-1b/decode_ragged_logits_b8.mlir");
+
+    /// The whole point of Stage A: a `Config` parsed from the real
+    /// Llama-3.2-1B-Instruct `config.json` emits every bundled graph
+    /// byte-for-byte. This proves the load-time emit path reproduces the assets
+    /// the engine shipped with, so switching from `include_str!` to emit-at-load
+    /// cannot change the compiled graphs for this model.
+    #[test]
+    fn from_json_reproduces_bundled_assets_byte_for_byte() {
+        let c = Config::from_json_str(CONFIG_JSON).expect("parse Llama-3.2-1B config.json");
+        assert_eq!(emit_prefill(&c, true), PREFILL, "prefill.mlir (argmax)");
+        assert_eq!(emit_decode(&c, true), DECODE, "decode.mlir (argmax)");
+        assert_eq!(
+            emit_prefill(&c, false),
+            PREFILL_LOGITS,
+            "prefill_logits.mlir"
+        );
+        assert_eq!(
+            emit_decode_ragged(&c, 4, false),
+            RAGGED_B4,
+            "decode_ragged_logits_b4.mlir"
+        );
+        assert_eq!(
+            emit_decode_ragged(&c, 8, false),
+            RAGGED_B8,
+            "decode_ragged_logits_b8.mlir"
+        );
+    }
+
+    /// `from_json` reads the same values the spike hard-coded, so it emits
+    /// identically to the in-code `llama_3_2_1b()` reference.
+    #[test]
+    fn from_json_matches_hardcoded_reference_config() {
+        let from = Config::from_json_str(CONFIG_JSON).expect("parse");
+        let hard = Config::llama_3_2_1b();
+        assert_eq!(emit_prefill(&from, false), emit_prefill(&hard, false));
+        assert_eq!(emit_decode(&from, true), emit_decode(&hard, true));
+    }
+}

--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -1,0 +1,1148 @@
+//! Emits the Llama-3.2-1B `decode_step` StableHLO module from Rust.
+//!
+//! Signature mirrors spike/openxla/model_jax.py `decode_step`:
+//!   main(params..., token, pos, cache_len, kcache, vcache)
+//!       -> (logits[V], kcache, vcache)
+//! Weights are individual tensor inputs in the same order JAX emitted
+//! (alphabetical within each layer), each carrying its pytree-path loc so the
+//! arg-to-weight mapping is self-documenting and reuses the JAX weight glue.
+
+use super::builder::{Builder, Ty, Val};
+use super::config::Config;
+use super::rope;
+
+const MAX_SEQ: usize = 256;
+
+/// Bucketed padded prompt length for prefill. Set to MAX_SEQ so the one bucket
+/// covers any prompt the cache holds (e.g. the ~103-token Llama-3.2 chat-template
+/// prompt), not just the 46-token spike prompt. KV for real positions is
+/// identical to a smaller bucket (padding positions are causally masked), so the
+/// generated tokens are unchanged.
+const PREFILL_LP: usize = MAX_SEQ;
+
+/// Per-layer weight handles (JAX alphabetical order: down, gate, in_ln,
+/// post_ln, up, wk, wo, wq, wv).
+struct LayerW {
+    down: Val,
+    gate: Val,
+    in_ln: Val,
+    post_ln: Val,
+    up: Val,
+    wk: Val,
+    wo: Val,
+    wq: Val,
+    wv: Val,
+}
+
+struct Args {
+    embed: Val,
+    final_norm: Val,
+    layers: Vec<LayerW>,
+    token: Val,
+    pos: Val,
+    cache_len: Val,
+    kcache: Val,
+    vcache: Val,
+}
+
+/// One (arg index, type, pytree-path loc) entry used to render the signature.
+struct ArgDecl {
+    ty: Ty,
+    loc: String,
+}
+
+fn build_arg_schema(c: &Config) -> (Vec<ArgDecl>, Args) {
+    let h = c.hidden;
+    let inter = c.inter;
+    let kv = c.n_kv * c.head_dim; // 512
+    let qd = c.n_q * c.head_dim; // 2048
+    let v = c.vocab;
+
+    let mut decls: Vec<ArgDecl> = Vec::new();
+    let mut idx = 0usize;
+    let mut take = |decls: &mut Vec<ArgDecl>, ty: Ty, loc: String| -> Val {
+        let val = Builder::arg(idx, ty.clone());
+        decls.push(ArgDecl { ty, loc });
+        idx += 1;
+        val
+    };
+
+    let embed = take(&mut decls, Ty::f32(vec![v, h]), "params['embed']".into());
+    let final_norm = take(&mut decls, Ty::f32(vec![h]), "params['final_norm']".into());
+
+    let mut layers = Vec::with_capacity(c.n_layers);
+    for li in 0..c.n_layers {
+        let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
+        let down = take(&mut decls, Ty::f32(vec![h, inter]), p("down"));
+        let gate = take(&mut decls, Ty::f32(vec![inter, h]), p("gate"));
+        let in_ln = take(&mut decls, Ty::f32(vec![h]), p("in_ln"));
+        let post_ln = take(&mut decls, Ty::f32(vec![h]), p("post_ln"));
+        let up = take(&mut decls, Ty::f32(vec![inter, h]), p("up"));
+        let wk = take(&mut decls, Ty::f32(vec![kv, h]), p("wk"));
+        let wo = take(&mut decls, Ty::f32(vec![qd, h]), p("wo"));
+        let wq = take(&mut decls, Ty::f32(vec![qd, h]), p("wq"));
+        let wv = take(&mut decls, Ty::f32(vec![kv, h]), p("wv"));
+        layers.push(LayerW {
+            down,
+            gate,
+            in_ln,
+            post_ln,
+            up,
+            wk,
+            wo,
+            wq,
+            wv,
+        });
+    }
+
+    let token = take(&mut decls, Ty::scalar("i32"), "token".into());
+    let pos = take(&mut decls, Ty::scalar("i32"), "pos".into());
+    let cache_len = take(&mut decls, Ty::scalar("i32"), "cache_len".into());
+    let kcache = take(
+        &mut decls,
+        Ty::f32(vec![c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
+        "kcache".into(),
+    );
+    let vcache = take(
+        &mut decls,
+        Ty::f32(vec![c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
+        "vcache".into(),
+    );
+
+    (
+        decls,
+        Args {
+            embed,
+            final_norm,
+            layers,
+            token,
+            pos,
+            cache_len,
+            kcache,
+            vcache,
+        },
+    )
+}
+
+fn render_signature(decls: &[ArgDecl]) -> String {
+    let parts: Vec<String> = decls
+        .iter()
+        .enumerate()
+        .map(|(i, d)| format!("%arg{}: {} loc(\"{}\")", i, d.ty.render(), d.loc))
+        .collect();
+    parts.join(", ")
+}
+
+/// Shared scalar/table constants, emitted once at the top of the body.
+struct Consts {
+    cos_table: Val,
+    sin_table: Val,
+    zero: Val,
+    one: Val,
+    neg_inf: Val,
+    neg_big: Val,
+    eps: Val,
+    hidden_f: Val,
+    scale: Val,
+    c0: Val,
+    layer_idx: Vec<Val>,
+}
+
+fn emit_consts(b: &mut Builder, c: &Config) -> Consts {
+    let (cos, sin) = rope::rope_tables(c, MAX_SEQ);
+    let cos_table = b.const_tensor_f32(&cos, vec![MAX_SEQ, c.head_dim]);
+    let sin_table = b.const_tensor_f32(&sin, vec![MAX_SEQ, c.head_dim]);
+    let zero = b.const_f32(0.0);
+    let one = b.const_f32(1.0);
+    let neg_inf = b.const_f32(f32::NEG_INFINITY);
+    let neg_big = b.const_f32(-1e30);
+    let eps = b.const_f32(c.eps);
+    let hidden_f = b.const_f32(c.hidden as f32);
+    let scale = b.const_f32(c.scale());
+    let c0 = b.const_i32(0);
+    let layer_idx: Vec<Val> = (0..c.n_layers).map(|i| b.const_i32(i as i32)).collect();
+    Consts {
+        cos_table,
+        sin_table,
+        zero,
+        one,
+        neg_inf,
+        neg_big,
+        eps,
+        hidden_f,
+        scale,
+        c0,
+        layer_idx,
+    }
+}
+
+/// RMSNorm: x * rsqrt(mean(x*x) + eps) * w, all over the single feature axis.
+fn rms_norm(b: &mut Builder, x: &Val, w: &Val, k: &Consts, hidden: usize) -> Val {
+    let sq = b.multiply(x, x);
+    let ssum = b.reduce_add(&sq, 0, &k.zero); // scalar
+    let mean = b.divide(&ssum, &k.hidden_f); // scalar
+    let meps = b.add(&mean, &k.eps);
+    let r = b.rsqrt(&meps);
+    let rb = b.broadcast(&r, &[], vec![hidden]);
+    let xr = b.multiply(x, &rb);
+    b.multiply(&xr, w)
+}
+
+/// HF half-split RoPE on x:[heads, d]; cos/sin are [d] for the position.
+fn apply_rope(b: &mut Builder, x: &Val, cos: &Val, sin: &Val, heads: usize, d: usize) -> Val {
+    let half = d / 2;
+    let cos_b = b.broadcast(cos, &[1], vec![heads, d]);
+    let sin_b = b.broadcast(sin, &[1], vec![heads, d]);
+    let xc = b.multiply(x, &cos_b);
+    let x1 = b.slice(x, &[(0, heads), (0, half)]);
+    let x2 = b.slice(x, &[(0, heads), (half, d)]);
+    let nx2 = b.negate(&x2);
+    let rh = b.concatenate(&nx2, &x1, 1);
+    let rs = b.multiply(&rh, &sin_b);
+    b.add(&xc, &rs)
+}
+
+/// Emit the complete decode_step module text. With `sample`, the graph ends in
+/// an on-device argmax and returns the next token id (`tensor<i32>`, the Phase
+/// 2b pattern); otherwise it returns the raw `[V]` logits.
+pub fn emit_decode(c: &Config, sample: bool) -> String {
+    let (decls, a) = build_arg_schema(c);
+    let mut b = Builder::new();
+    let k = emit_consts(&mut b, c);
+
+    let h = c.hidden;
+    let d = c.head_dim;
+    let nq = c.n_q;
+    let nkv = c.n_kv;
+    let g = c.group();
+
+    // --- head: embed gather, rope vectors, decode key mask ---
+    let emb_row = b.dynamic_slice(&a.embed, &[&a.token, &k.c0], vec![1, h]);
+    let mut x = b.reshape(&emb_row, vec![h]);
+
+    let cos_row = b.dynamic_slice(&k.cos_table, &[&a.pos, &k.c0], vec![1, d]);
+    let cos_vec = b.reshape(&cos_row, vec![d]);
+    let sin_row = b.dynamic_slice(&k.sin_table, &[&a.pos, &k.c0], vec![1, d]);
+    let sin_vec = b.reshape(&sin_row, vec![d]);
+
+    // mask: keys s valid iff s <= cache_len -> additive 0 / -1e30, shape [S]
+    let ii = b.iota(MAX_SEQ);
+    let clen_b = b.broadcast(&a.cache_len, &[], vec![MAX_SEQ]);
+    let valid = b.compare("LE", &ii, &clen_b, "SIGNED");
+    let zeros_s = b.broadcast(&k.zero, &[], vec![MAX_SEQ]);
+    let negs_s = b.broadcast(&k.neg_big, &[], vec![MAX_SEQ]);
+    let kmask = b.select(&valid, &zeros_s, &negs_s);
+
+    let mut kcache = a.kcache.clone();
+    let mut vcache = a.vcache.clone();
+
+    for li in 0..c.n_layers {
+        let lw = &a.layers[li];
+
+        // attention block
+        let hn = rms_norm(&mut b, &x, &lw.in_ln, &k, h);
+        let q = b.linear(&hn, &lw.wq);
+        let q = b.reshape(&q, vec![nq, d]);
+        let kk = b.linear(&hn, &lw.wk);
+        let kk = b.reshape(&kk, vec![nkv, d]);
+        let vv = b.linear(&hn, &lw.wv);
+        let vv = b.reshape(&vv, vec![nkv, d]);
+
+        let q = apply_rope(&mut b, &q, &cos_vec, &sin_vec, nq, d);
+        let kk = apply_rope(&mut b, &kk, &cos_vec, &sin_vec, nkv, d);
+
+        // write new K/V at [li, cache_len]
+        let k_upd = b.reshape(&kk, vec![1, 1, nkv, d]);
+        kcache = b.dynamic_update_slice(
+            &kcache,
+            &k_upd,
+            &[&k.layer_idx[li], &a.cache_len, &k.c0, &k.c0],
+        );
+        let v_upd = b.reshape(&vv, vec![1, 1, nkv, d]);
+        vcache = b.dynamic_update_slice(
+            &vcache,
+            &v_upd,
+            &[&k.layer_idx[li], &a.cache_len, &k.c0, &k.c0],
+        );
+
+        // read this layer's cache slabs [S, nkv, d]
+        let kl = b.slice(&kcache, &[(li, li + 1), (0, MAX_SEQ), (0, nkv), (0, d)]);
+        let kl = b.reshape(&kl, vec![MAX_SEQ, nkv, d]);
+        let vl = b.slice(&vcache, &[(li, li + 1), (0, MAX_SEQ), (0, nkv), (0, d)]);
+        let vl = b.reshape(&vl, vec![MAX_SEQ, nkv, d]);
+
+        // GQA scores via batched dot_general (q head h uses kv head h/g)
+        let q_r = b.reshape(&q, vec![nkv, g, d]); // head h = kv*g + grp
+        let scores = b.dot_general(&q_r, &kl, &[0], &[1], &[2], &[2], vec![nkv, g, MAX_SEQ]);
+        let scores = b.reshape(&scores, vec![nq, MAX_SEQ]);
+        let scale_b = b.broadcast(&k.scale, &[], vec![nq, MAX_SEQ]);
+        let scores = b.multiply(&scores, &scale_b);
+        let kmask_b = b.broadcast(&kmask, &[1], vec![nq, MAX_SEQ]);
+        let scores = b.add(&scores, &kmask_b);
+
+        // softmax over the key axis
+        let m = b.reduce_max(&scores, 1, &k.neg_inf);
+        let m_b = b.broadcast(&m, &[0], vec![nq, MAX_SEQ]);
+        let sh = b.subtract(&scores, &m_b);
+        let e = b.exponential(&sh);
+        let s = b.reduce_add(&e, 1, &k.zero);
+        let s_b = b.broadcast(&s, &[0], vec![nq, MAX_SEQ]);
+        let attn = b.divide(&e, &s_b);
+
+        // context: out[h,d] = sum_s attn[h,s] * vl[s, h/g, d]
+        let attn_r = b.reshape(&attn, vec![nkv, g, MAX_SEQ]);
+        let o = b.dot_general(&attn_r, &vl, &[0], &[1], &[2], &[0], vec![nkv, g, d]);
+        let o = b.reshape(&o, vec![nq, d]);
+        let o = b.reshape(&o, vec![nq * d]);
+        let attn_out = b.linear(&o, &lw.wo);
+        x = b.add(&x, &attn_out);
+
+        // MLP: down( silu(x@gate^T) * (x@up^T) )
+        let hn2 = rms_norm(&mut b, &x, &lw.post_ln, &k, h);
+        let gate = b.linear(&hn2, &lw.gate);
+        let up = b.linear(&hn2, &lw.up);
+        // silu(gate) = gate * sigmoid(gate), sigmoid(z) = 1/(1+exp(-z))
+        let neg = b.negate(&gate);
+        let ex = b.exponential(&neg);
+        let one_b = b.broadcast(&k.one, &[], vec![c.inter]);
+        let denom = b.add(&one_b, &ex);
+        let sig = b.divide(&one_b, &denom);
+        let silu = b.multiply(&gate, &sig);
+        let act = b.multiply(&silu, &up);
+        let down = b.linear(&act, &lw.down);
+        x = b.add(&x, &down);
+    }
+
+    // --- tail: final norm + tied LM head, then optional on-device argmax ---
+    let xf = rms_norm(&mut b, &x, &a.final_norm, &k, h);
+    let logits = b.linear(&xf, &a.embed); // [V]
+    let (out_val, out_ty) = if sample {
+        let tok = b.argmax(&logits);
+        (tok.name, Ty::scalar("i32").render())
+    } else {
+        (logits.name, Ty::f32(vec![c.vocab]).render())
+    };
+
+    let sig = render_signature(&decls);
+    let cache_ty = Ty::f32(vec![c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]).render();
+    format!(
+        "module @decode_step {{\n  func.func public @main({sig}) -> ({out_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {l}, {kc}, {vc} : {out_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
+        sig = sig,
+        out_ty = out_ty,
+        cache_ty = cache_ty,
+        body = b.body(),
+        l = out_val,
+        kc = kcache.name,
+        vc = vcache.name,
+    )
+}
+
+// ===========================================================================
+// batched decode: uniform-B (lockstep) static batched decode_step (#449 M3)
+// ===========================================================================
+//
+// Stage 1 of the throughput milestone. All B sequences advance in lockstep at
+// the SAME position, so `pos`, `cache_len`, and the key mask are shared scalars/
+// vectors broadcast over the batch; only the token, the activations, and the KV
+// cache carry a leading batch dim B. This turns each decode matmul from a
+// batch-1 GEMV (bandwidth/launch-bound on the GPU) into a GEMM that reuses each
+// weight across B rows. Signature mirrors `decode_step` with B prepended:
+//   main(params..., token[B], pos, cache_len, kcache[B,L,S,nkv,d], vcache[...])
+//       -> (token[B] | logits[B,V], kcache, vcache)
+// Weights and their pytree-path locs are identical to the single-seq decode.
+
+struct BatchedArgs {
+    embed: Val,
+    final_norm: Val,
+    layers: Vec<LayerW>,
+    token: Val,     // [B] i32
+    pos: Val,       // scalar i32 (shared across the batch)
+    cache_len: Val, // scalar i32 (shared across the batch)
+    kcache: Val,    // [B, L, MAX_SEQ, nkv, d]
+    vcache: Val,
+}
+
+fn build_batched_arg_schema(c: &Config, bsz: usize) -> (Vec<ArgDecl>, BatchedArgs) {
+    let h = c.hidden;
+    let inter = c.inter;
+    let kv = c.n_kv * c.head_dim; // 512
+    let qd = c.n_q * c.head_dim; // 2048
+    let v = c.vocab;
+
+    let mut decls: Vec<ArgDecl> = Vec::new();
+    let mut idx = 0usize;
+    let mut take = |decls: &mut Vec<ArgDecl>, ty: Ty, loc: String| -> Val {
+        let val = Builder::arg(idx, ty.clone());
+        decls.push(ArgDecl { ty, loc });
+        idx += 1;
+        val
+    };
+
+    let embed = take(&mut decls, Ty::f32(vec![v, h]), "params['embed']".into());
+    let final_norm = take(&mut decls, Ty::f32(vec![h]), "params['final_norm']".into());
+
+    let mut layers = Vec::with_capacity(c.n_layers);
+    for li in 0..c.n_layers {
+        let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
+        let down = take(&mut decls, Ty::f32(vec![h, inter]), p("down"));
+        let gate = take(&mut decls, Ty::f32(vec![inter, h]), p("gate"));
+        let in_ln = take(&mut decls, Ty::f32(vec![h]), p("in_ln"));
+        let post_ln = take(&mut decls, Ty::f32(vec![h]), p("post_ln"));
+        let up = take(&mut decls, Ty::f32(vec![inter, h]), p("up"));
+        let wk = take(&mut decls, Ty::f32(vec![kv, h]), p("wk"));
+        let wo = take(&mut decls, Ty::f32(vec![qd, h]), p("wo"));
+        let wq = take(&mut decls, Ty::f32(vec![qd, h]), p("wq"));
+        let wv = take(&mut decls, Ty::f32(vec![kv, h]), p("wv"));
+        layers.push(LayerW {
+            down,
+            gate,
+            in_ln,
+            post_ln,
+            up,
+            wk,
+            wo,
+            wq,
+            wv,
+        });
+    }
+
+    let token = take(&mut decls, Ty::new(vec![bsz], "i32"), "token".into());
+    let pos = take(&mut decls, Ty::scalar("i32"), "pos".into());
+    let cache_len = take(&mut decls, Ty::scalar("i32"), "cache_len".into());
+    let kcache = take(
+        &mut decls,
+        Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
+        "kcache".into(),
+    );
+    let vcache = take(
+        &mut decls,
+        Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
+        "vcache".into(),
+    );
+
+    (
+        decls,
+        BatchedArgs {
+            embed,
+            final_norm,
+            layers,
+            token,
+            pos,
+            cache_len,
+            kcache,
+            vcache,
+        },
+    )
+}
+
+/// HF half-split RoPE on x:[B, heads, d]; cos/sin are a single [d] vector for
+/// the shared (lockstep) position, broadcast across the batch.
+fn apply_rope_batched(
+    b: &mut Builder,
+    x: &Val,
+    cos: &Val,
+    sin: &Val,
+    bsz: usize,
+    heads: usize,
+    d: usize,
+) -> Val {
+    let half = d / 2;
+    let cos_b = b.broadcast(cos, &[2], vec![bsz, heads, d]); // [d] -> [B,heads,d]
+    let sin_b = b.broadcast(sin, &[2], vec![bsz, heads, d]);
+    let xc = b.multiply(x, &cos_b);
+    let x1 = b.slice(x, &[(0, bsz), (0, heads), (0, half)]);
+    let x2 = b.slice(x, &[(0, bsz), (0, heads), (half, d)]);
+    let nx2 = b.negate(&x2);
+    let rh = b.concatenate(&nx2, &x1, 2);
+    let rs = b.multiply(&rh, &sin_b);
+    b.add(&xc, &rs)
+}
+
+/// Emit the uniform-B batched `decode_step` module text for a static batch size
+/// `bsz`. With `sample`, the graph ends in a per-row on-device argmax and
+/// returns `[B]` token ids; otherwise it returns `[B, V]` logits.
+pub fn emit_decode_batched(c: &Config, bsz: usize, sample: bool) -> String {
+    let (decls, a) = build_batched_arg_schema(c, bsz);
+    let mut b = Builder::new();
+    let k = emit_consts(&mut b, c);
+
+    let h = c.hidden;
+    let d = c.head_dim;
+    let nq = c.n_q;
+    let nkv = c.n_kv;
+    let g = c.group();
+
+    // --- head: per-row embed gather, shared rope vectors, shared key mask ---
+    let tok_idx = b.reshape(&a.token, vec![bsz, 1]);
+    let mut x = b.gather(&a.embed, &tok_idx); // [B, H]
+
+    // pos is shared (lockstep), so cos/sin are one [d] vector for every row.
+    let cos_row = b.dynamic_slice(&k.cos_table, &[&a.pos, &k.c0], vec![1, d]);
+    let cos_vec = b.reshape(&cos_row, vec![d]);
+    let sin_row = b.dynamic_slice(&k.sin_table, &[&a.pos, &k.c0], vec![1, d]);
+    let sin_vec = b.reshape(&sin_row, vec![d]);
+
+    // shared key mask [S]: key s valid iff s <= cache_len -> additive 0 / -1e30
+    let ii = b.iota(MAX_SEQ);
+    let clen_b = b.broadcast(&a.cache_len, &[], vec![MAX_SEQ]);
+    let valid = b.compare("LE", &ii, &clen_b, "SIGNED");
+    let zeros_s = b.broadcast(&k.zero, &[], vec![MAX_SEQ]);
+    let negs_s = b.broadcast(&k.neg_big, &[], vec![MAX_SEQ]);
+    let kmask = b.select(&valid, &zeros_s, &negs_s);
+
+    let mut kcache = a.kcache.clone();
+    let mut vcache = a.vcache.clone();
+
+    for li in 0..c.n_layers {
+        let lw = &a.layers[li];
+
+        // attention block (RMSNorm over H reuses the [N,H] seq variant, N=B)
+        let hn = rms_norm_seq(&mut b, &x, &lw.in_ln, &k, bsz, h); // [B, H]
+        let q = b.linear_seq(&hn, &lw.wq); // [B, qd]
+        let q = b.reshape(&q, vec![bsz, nq, d]);
+        let kk = b.linear_seq(&hn, &lw.wk); // [B, kv]
+        let kk = b.reshape(&kk, vec![bsz, nkv, d]);
+        let vv = b.linear_seq(&hn, &lw.wv); // [B, kv]
+        let vv = b.reshape(&vv, vec![bsz, nkv, d]);
+
+        let q = apply_rope_batched(&mut b, &q, &cos_vec, &sin_vec, bsz, nq, d);
+        let kk = apply_rope_batched(&mut b, &kk, &cos_vec, &sin_vec, bsz, nkv, d);
+
+        // write new K/V at [:, li, cache_len] across all B rows
+        let k_upd = b.reshape(&kk, vec![bsz, 1, 1, nkv, d]);
+        kcache = b.dynamic_update_slice(
+            &kcache,
+            &k_upd,
+            &[&k.c0, &k.layer_idx[li], &a.cache_len, &k.c0, &k.c0],
+        );
+        let v_upd = b.reshape(&vv, vec![bsz, 1, 1, nkv, d]);
+        vcache = b.dynamic_update_slice(
+            &vcache,
+            &v_upd,
+            &[&k.c0, &k.layer_idx[li], &a.cache_len, &k.c0, &k.c0],
+        );
+
+        // read this layer's cache slabs [B, S, nkv, d]
+        let kl = b.slice(
+            &kcache,
+            &[(0, bsz), (li, li + 1), (0, MAX_SEQ), (0, nkv), (0, d)],
+        );
+        let kl = b.reshape(&kl, vec![bsz, MAX_SEQ, nkv, d]);
+        let vl = b.slice(
+            &vcache,
+            &[(0, bsz), (li, li + 1), (0, MAX_SEQ), (0, nkv), (0, d)],
+        );
+        let vl = b.reshape(&vl, vec![bsz, MAX_SEQ, nkv, d]);
+
+        // GQA scores: batch over (B, kv head). q head kv*g+grp attends kv head
+        // kv. Output [B, nkv, g, S] reshapes to [B, nq, S] (head = kv*g+grp).
+        let q_r = b.reshape(&q, vec![bsz, nkv, g, d]);
+        let scores = b.dot_general(
+            &q_r,
+            &kl,
+            &[0, 1],
+            &[0, 2],
+            &[3],
+            &[3],
+            vec![bsz, nkv, g, MAX_SEQ],
+        );
+        let scores = b.reshape(&scores, vec![bsz, nq, MAX_SEQ]);
+        let scale_b = b.broadcast(&k.scale, &[], vec![bsz, nq, MAX_SEQ]);
+        let scores = b.multiply(&scores, &scale_b);
+        let kmask_b = b.broadcast(&kmask, &[2], vec![bsz, nq, MAX_SEQ]);
+        let scores = b.add(&scores, &kmask_b);
+
+        // softmax over the key axis (dim 2)
+        let m = b.reduce_max(&scores, 2, &k.neg_inf); // [B, nq]
+        let m_b = b.broadcast(&m, &[0, 1], vec![bsz, nq, MAX_SEQ]);
+        let sh = b.subtract(&scores, &m_b);
+        let e = b.exponential(&sh);
+        let s = b.reduce_add(&e, 2, &k.zero); // [B, nq]
+        let s_b = b.broadcast(&s, &[0, 1], vec![bsz, nq, MAX_SEQ]);
+        let attn = b.divide(&e, &s_b); // [B, nq, S]
+
+        // context: o[b,h,d] = sum_s attn[b,h,s] * vl[b,s,h/g,d]
+        let attn_r = b.reshape(&attn, vec![bsz, nkv, g, MAX_SEQ]);
+        let o = b.dot_general(
+            &attn_r,
+            &vl,
+            &[0, 1],
+            &[0, 2],
+            &[3],
+            &[1],
+            vec![bsz, nkv, g, d],
+        );
+        let o = b.reshape(&o, vec![bsz, nq, d]);
+        let o = b.reshape(&o, vec![bsz, nq * d]);
+        let attn_out = b.linear_seq(&o, &lw.wo); // [B, H]
+        x = b.add(&x, &attn_out);
+
+        // MLP: down( silu(x@gate^T) * (x@up^T) )
+        let hn2 = rms_norm_seq(&mut b, &x, &lw.post_ln, &k, bsz, h);
+        let gate = b.linear_seq(&hn2, &lw.gate); // [B, inter]
+        let up = b.linear_seq(&hn2, &lw.up); // [B, inter]
+        let neg = b.negate(&gate);
+        let ex = b.exponential(&neg);
+        let one_b = b.broadcast(&k.one, &[], vec![bsz, c.inter]);
+        let denom = b.add(&one_b, &ex);
+        let sig = b.divide(&one_b, &denom);
+        let silu = b.multiply(&gate, &sig);
+        let act = b.multiply(&silu, &up);
+        let down = b.linear_seq(&act, &lw.down); // [B, H]
+        x = b.add(&x, &down);
+    }
+
+    // --- tail: final norm + tied LM head -> [B, V], optional per-row argmax ---
+    let xf = rms_norm_seq(&mut b, &x, &a.final_norm, &k, bsz, h); // [B, H]
+    let logits = b.linear_seq(&xf, &a.embed); // [B, V]
+    let (out_val, out_ty) = if sample {
+        let tok = b.argmax_batched(&logits);
+        (tok.name, Ty::new(vec![bsz], "i32").render())
+    } else {
+        (logits.name, Ty::f32(vec![bsz, c.vocab]).render())
+    };
+
+    let sig = render_signature(&decls);
+    let cache_ty = Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]).render();
+    format!(
+        "module @decode_step {{\n  func.func public @main({sig}) -> ({out_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {l}, {kc}, {vc} : {out_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
+        sig = sig,
+        out_ty = out_ty,
+        cache_ty = cache_ty,
+        body = b.body(),
+        l = out_val,
+        kc = kcache.name,
+        vc = vcache.name,
+    )
+}
+
+// ===========================================================================
+// ragged decode: continuous-batching decode_step (#449 M3 Stage 2a)
+// ===========================================================================
+//
+// Like the uniform-B graph, but each row carries its OWN position and length, so
+// sequences of different lengths can share the batch (the continuous-batching
+// requirement). Versus uniform-B: `pos` and `cache_len` are `[B]` (per row);
+// RoPE cos/sin are a per-row gather `[B, d]` from the table by `pos[B]`; the key
+// mask is per-row `[B, S]` (valid iff `s <= cache_len[b]`); and the KV write is
+// unrolled per row, each row writing its new K/V at its own `pos[b]` (the shared-
+// offset `dynamic_update_slice` no longer applies). The attention contractions
+// and the LM head are identical to uniform-B; the per-row mask carries the
+// raggedness.
+
+struct RaggedArgs {
+    embed: Val,
+    final_norm: Val,
+    layers: Vec<LayerW>,
+    token: Val,     // [B] i32
+    pos: Val,       // [B] i32 (per row)
+    cache_len: Val, // [B] i32 (per row)
+    kcache: Val,    // [B, L, MAX_SEQ, nkv, d]
+    vcache: Val,
+}
+
+fn build_ragged_arg_schema(c: &Config, bsz: usize) -> (Vec<ArgDecl>, RaggedArgs) {
+    let h = c.hidden;
+    let inter = c.inter;
+    let kv = c.n_kv * c.head_dim; // 512
+    let qd = c.n_q * c.head_dim; // 2048
+    let v = c.vocab;
+
+    let mut decls: Vec<ArgDecl> = Vec::new();
+    let mut idx = 0usize;
+    let mut take = |decls: &mut Vec<ArgDecl>, ty: Ty, loc: String| -> Val {
+        let val = Builder::arg(idx, ty.clone());
+        decls.push(ArgDecl { ty, loc });
+        idx += 1;
+        val
+    };
+
+    let embed = take(&mut decls, Ty::f32(vec![v, h]), "params['embed']".into());
+    let final_norm = take(&mut decls, Ty::f32(vec![h]), "params['final_norm']".into());
+
+    let mut layers = Vec::with_capacity(c.n_layers);
+    for li in 0..c.n_layers {
+        let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
+        let down = take(&mut decls, Ty::f32(vec![h, inter]), p("down"));
+        let gate = take(&mut decls, Ty::f32(vec![inter, h]), p("gate"));
+        let in_ln = take(&mut decls, Ty::f32(vec![h]), p("in_ln"));
+        let post_ln = take(&mut decls, Ty::f32(vec![h]), p("post_ln"));
+        let up = take(&mut decls, Ty::f32(vec![inter, h]), p("up"));
+        let wk = take(&mut decls, Ty::f32(vec![kv, h]), p("wk"));
+        let wo = take(&mut decls, Ty::f32(vec![qd, h]), p("wo"));
+        let wq = take(&mut decls, Ty::f32(vec![qd, h]), p("wq"));
+        let wv = take(&mut decls, Ty::f32(vec![kv, h]), p("wv"));
+        layers.push(LayerW {
+            down,
+            gate,
+            in_ln,
+            post_ln,
+            up,
+            wk,
+            wo,
+            wq,
+            wv,
+        });
+    }
+
+    let token = take(&mut decls, Ty::new(vec![bsz], "i32"), "token".into());
+    let pos = take(&mut decls, Ty::new(vec![bsz], "i32"), "pos".into());
+    let cache_len = take(&mut decls, Ty::new(vec![bsz], "i32"), "cache_len".into());
+    let kcache = take(
+        &mut decls,
+        Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
+        "kcache".into(),
+    );
+    let vcache = take(
+        &mut decls,
+        Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
+        "vcache".into(),
+    );
+
+    (
+        decls,
+        RaggedArgs {
+            embed,
+            final_norm,
+            layers,
+            token,
+            pos,
+            cache_len,
+            kcache,
+            vcache,
+        },
+    )
+}
+
+/// HF half-split RoPE on x:[B, heads, d]; cos/sin are per-row `[B, d]` (each
+/// row's own position), broadcast over the head axis.
+fn apply_rope_ragged(
+    b: &mut Builder,
+    x: &Val,
+    cos: &Val,
+    sin: &Val,
+    bsz: usize,
+    heads: usize,
+    d: usize,
+) -> Val {
+    let half = d / 2;
+    let cos_b = b.broadcast(cos, &[0, 2], vec![bsz, heads, d]); // [B,d] -> [B,heads,d]
+    let sin_b = b.broadcast(sin, &[0, 2], vec![bsz, heads, d]);
+    let xc = b.multiply(x, &cos_b);
+    let x1 = b.slice(x, &[(0, bsz), (0, heads), (0, half)]);
+    let x2 = b.slice(x, &[(0, bsz), (0, heads), (half, d)]);
+    let nx2 = b.negate(&x2);
+    let rh = b.concatenate(&nx2, &x1, 2);
+    let rs = b.multiply(&rh, &sin_b);
+    b.add(&xc, &rs)
+}
+
+/// Emit the ragged (continuous-batching) `decode_step` module for a static batch
+/// size `bsz`. With `sample`, ends in a per-row on-device argmax returning `[B]`
+/// token ids; otherwise returns `[B, V]` logits.
+pub fn emit_decode_ragged(c: &Config, bsz: usize, sample: bool) -> String {
+    let (decls, a) = build_ragged_arg_schema(c, bsz);
+    let mut b = Builder::new();
+    let k = emit_consts(&mut b, c);
+    // Constant row indices 0..bsz for the per-row KV-write dim-0 offsets.
+    let row_idx: Vec<Val> = (0..bsz).map(|i| b.const_i32(i as i32)).collect();
+
+    let h = c.hidden;
+    let d = c.head_dim;
+    let nq = c.n_q;
+    let nkv = c.n_kv;
+    let g = c.group();
+
+    // --- head: per-row embed gather, per-row rope gather, per-row key mask ---
+    let tok_idx = b.reshape(&a.token, vec![bsz, 1]);
+    let mut x = b.gather(&a.embed, &tok_idx); // [B, H]
+
+    // each row's rope vectors come from its own position: gather [B,d] by pos[B]
+    let pos_idx = b.reshape(&a.pos, vec![bsz, 1]);
+    let cos = b.gather(&k.cos_table, &pos_idx); // [B, d]
+    let sin = b.gather(&k.sin_table, &pos_idx); // [B, d]
+
+    // per-row key mask [B,S]: key s valid for row b iff s <= cache_len[b]
+    let ii = b.iota(MAX_SEQ); // [S]
+    let ii_b = b.broadcast(&ii, &[1], vec![bsz, MAX_SEQ]); // entry[b,s] = s
+    let clen_b = b.broadcast(&a.cache_len, &[0], vec![bsz, MAX_SEQ]); // entry[b,s] = cache_len[b]
+    let valid = b.compare("LE", &ii_b, &clen_b, "SIGNED");
+    let zeros = b.broadcast(&k.zero, &[], vec![bsz, MAX_SEQ]);
+    let negs = b.broadcast(&k.neg_big, &[], vec![bsz, MAX_SEQ]);
+    let kmask = b.select(&valid, &zeros, &negs); // [B, S]
+
+    let mut kcache = a.kcache.clone();
+    let mut vcache = a.vcache.clone();
+
+    for li in 0..c.n_layers {
+        let lw = &a.layers[li];
+
+        let hn = rms_norm_seq(&mut b, &x, &lw.in_ln, &k, bsz, h); // [B, H]
+        let q = b.linear_seq(&hn, &lw.wq);
+        let q = b.reshape(&q, vec![bsz, nq, d]);
+        let kk = b.linear_seq(&hn, &lw.wk);
+        let kk = b.reshape(&kk, vec![bsz, nkv, d]);
+        let vv = b.linear_seq(&hn, &lw.wv);
+        let vv = b.reshape(&vv, vec![bsz, nkv, d]);
+
+        let q = apply_rope_ragged(&mut b, &q, &cos, &sin, bsz, nq, d);
+        let kk = apply_rope_ragged(&mut b, &kk, &cos, &sin, bsz, nkv, d);
+
+        // per-row KV write: row r writes its [1,1,1,nkv,d] K/V at [r, li, pos[r]].
+        // `r` indexes the row consts AND the slice ranges (r, r+1), so a plain
+        // iterator does not fit; keep the range loop.
+        #[allow(clippy::needless_range_loop)]
+        for r in 0..bsz {
+            let pos_r = b.slice(&a.pos, &[(r, r + 1)]); // [1]
+            let pos_r = b.reshape(&pos_r, vec![]); // scalar i32 offset
+            let kk_r = b.slice(&kk, &[(r, r + 1), (0, nkv), (0, d)]);
+            let kk_upd = b.reshape(&kk_r, vec![1, 1, 1, nkv, d]);
+            kcache = b.dynamic_update_slice(
+                &kcache,
+                &kk_upd,
+                &[&row_idx[r], &k.layer_idx[li], &pos_r, &k.c0, &k.c0],
+            );
+            let vv_r = b.slice(&vv, &[(r, r + 1), (0, nkv), (0, d)]);
+            let vv_upd = b.reshape(&vv_r, vec![1, 1, 1, nkv, d]);
+            vcache = b.dynamic_update_slice(
+                &vcache,
+                &vv_upd,
+                &[&row_idx[r], &k.layer_idx[li], &pos_r, &k.c0, &k.c0],
+            );
+        }
+
+        // read this layer's cache slabs [B, S, nkv, d]
+        let kl = b.slice(
+            &kcache,
+            &[(0, bsz), (li, li + 1), (0, MAX_SEQ), (0, nkv), (0, d)],
+        );
+        let kl = b.reshape(&kl, vec![bsz, MAX_SEQ, nkv, d]);
+        let vl = b.slice(
+            &vcache,
+            &[(0, bsz), (li, li + 1), (0, MAX_SEQ), (0, nkv), (0, d)],
+        );
+        let vl = b.reshape(&vl, vec![bsz, MAX_SEQ, nkv, d]);
+
+        // GQA scores (identical to uniform-B); only the mask below is per-row.
+        let q_r = b.reshape(&q, vec![bsz, nkv, g, d]);
+        let scores = b.dot_general(
+            &q_r,
+            &kl,
+            &[0, 1],
+            &[0, 2],
+            &[3],
+            &[3],
+            vec![bsz, nkv, g, MAX_SEQ],
+        );
+        let scores = b.reshape(&scores, vec![bsz, nq, MAX_SEQ]);
+        let scale_b = b.broadcast(&k.scale, &[], vec![bsz, nq, MAX_SEQ]);
+        let scores = b.multiply(&scores, &scale_b);
+        let kmask_b = b.broadcast(&kmask, &[0, 2], vec![bsz, nq, MAX_SEQ]); // [B,S] -> [B,nq,S]
+        let scores = b.add(&scores, &kmask_b);
+
+        let m = b.reduce_max(&scores, 2, &k.neg_inf);
+        let m_b = b.broadcast(&m, &[0, 1], vec![bsz, nq, MAX_SEQ]);
+        let sh = b.subtract(&scores, &m_b);
+        let e = b.exponential(&sh);
+        let s = b.reduce_add(&e, 2, &k.zero);
+        let s_b = b.broadcast(&s, &[0, 1], vec![bsz, nq, MAX_SEQ]);
+        let attn = b.divide(&e, &s_b);
+
+        let attn_r = b.reshape(&attn, vec![bsz, nkv, g, MAX_SEQ]);
+        let o = b.dot_general(
+            &attn_r,
+            &vl,
+            &[0, 1],
+            &[0, 2],
+            &[3],
+            &[1],
+            vec![bsz, nkv, g, d],
+        );
+        let o = b.reshape(&o, vec![bsz, nq, d]);
+        let o = b.reshape(&o, vec![bsz, nq * d]);
+        let attn_out = b.linear_seq(&o, &lw.wo);
+        x = b.add(&x, &attn_out);
+
+        let hn2 = rms_norm_seq(&mut b, &x, &lw.post_ln, &k, bsz, h);
+        let gate = b.linear_seq(&hn2, &lw.gate);
+        let up = b.linear_seq(&hn2, &lw.up);
+        let neg = b.negate(&gate);
+        let ex = b.exponential(&neg);
+        let one_b = b.broadcast(&k.one, &[], vec![bsz, c.inter]);
+        let denom = b.add(&one_b, &ex);
+        let sig = b.divide(&one_b, &denom);
+        let silu = b.multiply(&gate, &sig);
+        let act = b.multiply(&silu, &up);
+        let down = b.linear_seq(&act, &lw.down);
+        x = b.add(&x, &down);
+    }
+
+    let xf = rms_norm_seq(&mut b, &x, &a.final_norm, &k, bsz, h);
+    let logits = b.linear_seq(&xf, &a.embed); // [B, V]
+    let (out_val, out_ty) = if sample {
+        let tok = b.argmax_batched(&logits);
+        (tok.name, Ty::new(vec![bsz], "i32").render())
+    } else {
+        (logits.name, Ty::f32(vec![bsz, c.vocab]).render())
+    };
+
+    let sig = render_signature(&decls);
+    let cache_ty = Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]).render();
+    format!(
+        "module @decode_step {{\n  func.func public @main({sig}) -> ({out_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {l}, {kc}, {vc} : {out_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
+        sig = sig,
+        out_ty = out_ty,
+        cache_ty = cache_ty,
+        body = b.body(),
+        l = out_val,
+        kc = kcache.name,
+        vc = vcache.name,
+    )
+}
+
+// ===========================================================================
+// prefill: bucketed multi-token prompt processing
+// ===========================================================================
+//
+// Signature mirrors spike/openxla/model_jax.py `prefill`:
+//   main(params..., tokens[Lp], positions[Lp], real_len)
+//       -> (last_logits[V], kcache, vcache)
+// Unlike decode, prefill takes NO input caches: it zero-initializes them and
+// returns the prompt's K/V written into the [0:Lp] block. The whole prompt is
+// processed at once over an [Lp] sequence axis with an [Lp,Lp] causal mask, and
+// the returned logit is the row at real_len-1 (the last real prompt token).
+
+/// Prefill arg handles. Weights are identical to decode (same order/locs); the
+/// trailing inputs are tokens/positions/real_len with no caches.
+struct PrefillArgs {
+    embed: Val,
+    final_norm: Val,
+    layers: Vec<LayerW>,
+    tokens: Val,
+    positions: Val,
+    real_len: Val,
+}
+
+fn build_prefill_arg_schema(c: &Config, lp: usize) -> (Vec<ArgDecl>, PrefillArgs) {
+    let h = c.hidden;
+    let inter = c.inter;
+    let kv = c.n_kv * c.head_dim; // 512
+    let qd = c.n_q * c.head_dim; // 2048
+    let v = c.vocab;
+
+    let mut decls: Vec<ArgDecl> = Vec::new();
+    let mut idx = 0usize;
+    let mut take = |decls: &mut Vec<ArgDecl>, ty: Ty, loc: String| -> Val {
+        let val = Builder::arg(idx, ty.clone());
+        decls.push(ArgDecl { ty, loc });
+        idx += 1;
+        val
+    };
+
+    let embed = take(&mut decls, Ty::f32(vec![v, h]), "params['embed']".into());
+    let final_norm = take(&mut decls, Ty::f32(vec![h]), "params['final_norm']".into());
+
+    let mut layers = Vec::with_capacity(c.n_layers);
+    for li in 0..c.n_layers {
+        let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
+        let down = take(&mut decls, Ty::f32(vec![h, inter]), p("down"));
+        let gate = take(&mut decls, Ty::f32(vec![inter, h]), p("gate"));
+        let in_ln = take(&mut decls, Ty::f32(vec![h]), p("in_ln"));
+        let post_ln = take(&mut decls, Ty::f32(vec![h]), p("post_ln"));
+        let up = take(&mut decls, Ty::f32(vec![inter, h]), p("up"));
+        let wk = take(&mut decls, Ty::f32(vec![kv, h]), p("wk"));
+        let wo = take(&mut decls, Ty::f32(vec![qd, h]), p("wo"));
+        let wq = take(&mut decls, Ty::f32(vec![qd, h]), p("wq"));
+        let wv = take(&mut decls, Ty::f32(vec![kv, h]), p("wv"));
+        layers.push(LayerW {
+            down,
+            gate,
+            in_ln,
+            post_ln,
+            up,
+            wk,
+            wo,
+            wq,
+            wv,
+        });
+    }
+
+    let tokens = take(&mut decls, Ty::new(vec![lp], "i32"), "tokens".into());
+    let positions = take(&mut decls, Ty::new(vec![lp], "i32"), "positions".into());
+    let real_len = take(&mut decls, Ty::scalar("i32"), "real_len".into());
+
+    (
+        decls,
+        PrefillArgs {
+            embed,
+            final_norm,
+            layers,
+            tokens,
+            positions,
+            real_len,
+        },
+    )
+}
+
+/// RMSNorm over a sequence: x:[Lp, H] -> per-row x * rsqrt(mean(x*x)+eps) * w.
+fn rms_norm_seq(b: &mut Builder, x: &Val, w: &Val, k: &Consts, lp: usize, hidden: usize) -> Val {
+    let sq = b.multiply(x, x);
+    let ssum = b.reduce_add(&sq, 1, &k.zero); // [Lp]
+    let hb = b.broadcast(&k.hidden_f, &[], vec![lp]);
+    let mean = b.divide(&ssum, &hb); // [Lp]
+    let epsb = b.broadcast(&k.eps, &[], vec![lp]);
+    let meps = b.add(&mean, &epsb);
+    let r = b.rsqrt(&meps); // [Lp]
+    let rb = b.broadcast(&r, &[0], vec![lp, hidden]); // [Lp, H]
+    let xr = b.multiply(x, &rb);
+    let wb = b.broadcast(w, &[1], vec![lp, hidden]); // [H] -> [Lp, H]
+    b.multiply(&xr, &wb)
+}
+
+/// HF half-split RoPE on x:[Lp, heads, d]; cos/sin are [Lp, d] (per position).
+fn apply_rope_seq(
+    b: &mut Builder,
+    x: &Val,
+    cos: &Val,
+    sin: &Val,
+    lp: usize,
+    heads: usize,
+    d: usize,
+) -> Val {
+    let half = d / 2;
+    let cos_b = b.broadcast(cos, &[0, 2], vec![lp, heads, d]); // [Lp,d] -> [Lp,heads,d]
+    let sin_b = b.broadcast(sin, &[0, 2], vec![lp, heads, d]);
+    let xc = b.multiply(x, &cos_b);
+    let x1 = b.slice(x, &[(0, lp), (0, heads), (0, half)]);
+    let x2 = b.slice(x, &[(0, lp), (0, heads), (half, d)]);
+    let nx2 = b.negate(&x2);
+    let rh = b.concatenate(&nx2, &x1, 2);
+    let rs = b.multiply(&rh, &sin_b);
+    b.add(&xc, &rs)
+}
+
+/// Emit the complete prefill module text. With `sample`, the graph ends in an
+/// on-device argmax and returns the first token id (`tensor<i32>`); otherwise it
+/// returns the raw `[V]` logits at `real_len-1`.
+pub fn emit_prefill(c: &Config, sample: bool) -> String {
+    let lp = PREFILL_LP;
+    let (decls, a) = build_prefill_arg_schema(c, lp);
+    let mut b = Builder::new();
+    let k = emit_consts(&mut b, c);
+
+    let h = c.hidden;
+    let d = c.head_dim;
+    let nq = c.n_q;
+    let nkv = c.n_kv;
+    let g = c.group();
+
+    // --- head: embed gather, per-position rope vectors, [Lp,Lp] causal mask ---
+    let tok_idx = b.reshape(&a.tokens, vec![lp, 1]);
+    let mut x = b.gather(&a.embed, &tok_idx); // [Lp, H]
+
+    let pos_idx = b.reshape(&a.positions, vec![lp, 1]);
+    let cos = b.gather(&k.cos_table, &pos_idx); // [Lp, d]
+    let sin = b.gather(&k.sin_table, &pos_idx); // [Lp, d]
+
+    // causal mask [Lp, Lp]: query i attends key j iff j <= i -> additive 0/-1e30
+    let irow = b.iota(lp);
+    let row = b.broadcast(&irow, &[0], vec![lp, lp]); // entry[i,j] = i
+    let jcol = b.iota(lp);
+    let col = b.broadcast(&jcol, &[1], vec![lp, lp]); // entry[i,j] = j
+    let le = b.compare("LE", &col, &row, "SIGNED"); // j <= i
+    let zeros = b.broadcast(&k.zero, &[], vec![lp, lp]);
+    let negs = b.broadcast(&k.neg_big, &[], vec![lp, lp]);
+    let cmask = b.select(&le, &zeros, &negs); // [Lp, Lp]
+
+    // caches start as zeros; prefill writes the [0:Lp] block and returns them
+    let mut kcache = b.broadcast(&k.zero, &[], vec![c.n_layers, MAX_SEQ, nkv, d]);
+    let mut vcache = b.broadcast(&k.zero, &[], vec![c.n_layers, MAX_SEQ, nkv, d]);
+
+    for li in 0..c.n_layers {
+        let lw = &a.layers[li];
+
+        // attention block
+        let hn = rms_norm_seq(&mut b, &x, &lw.in_ln, &k, lp, h); // [Lp, H]
+        let q = b.linear_seq(&hn, &lw.wq); // [Lp, qd]
+        let q = b.reshape(&q, vec![lp, nq, d]);
+        let kk = b.linear_seq(&hn, &lw.wk); // [Lp, kv]
+        let kk = b.reshape(&kk, vec![lp, nkv, d]);
+        let vv = b.linear_seq(&hn, &lw.wv); // [Lp, kv]
+        let vv = b.reshape(&vv, vec![lp, nkv, d]);
+
+        let q = apply_rope_seq(&mut b, &q, &cos, &sin, lp, nq, d);
+        let kk = apply_rope_seq(&mut b, &kk, &cos, &sin, lp, nkv, d);
+
+        // write the whole [Lp] K/V block at [li, 0:Lp]
+        let k_upd = b.reshape(&kk, vec![1, lp, nkv, d]);
+        kcache = b.dynamic_update_slice(&kcache, &k_upd, &[&k.layer_idx[li], &k.c0, &k.c0, &k.c0]);
+        let v_upd = b.reshape(&vv, vec![1, lp, nkv, d]);
+        vcache = b.dynamic_update_slice(&vcache, &v_upd, &[&k.layer_idx[li], &k.c0, &k.c0, &k.c0]);
+
+        // GQA scores: q head (kv*g+grp) attends kv head kv. Layout [nkv,Lp_i,g,Lp_j]
+        // so it reshapes to [nq, Lp_i, Lp_j] without a transpose (head = kv*g+grp).
+        let q4 = b.reshape(&q, vec![lp, nkv, g, d]);
+        let scores = b.dot_general(&q4, &kk, &[1], &[1], &[3], &[2], vec![nkv, lp, g, lp]);
+        let scale_b = b.broadcast(&k.scale, &[], vec![nkv, lp, g, lp]);
+        let scores = b.multiply(&scores, &scale_b);
+        let cmask_b = b.broadcast(&cmask, &[1, 3], vec![nkv, lp, g, lp]);
+        let scores = b.add(&scores, &cmask_b);
+
+        // softmax over the key axis (Lp_j, dim 3)
+        let m = b.reduce_max(&scores, 3, &k.neg_inf); // [nkv, Lp, g]
+        let m_b = b.broadcast(&m, &[0, 1, 2], vec![nkv, lp, g, lp]);
+        let sh = b.subtract(&scores, &m_b);
+        let e = b.exponential(&sh);
+        let s = b.reduce_add(&e, 3, &k.zero); // [nkv, Lp, g]
+        let s_b = b.broadcast(&s, &[0, 1, 2], vec![nkv, lp, g, lp]);
+        let attn = b.divide(&e, &s_b); // [nkv, Lp, g, Lp]
+
+        // context: o[kv,i,grp,d] = sum_j attn[kv,i,grp,j] * vv[j,kv,d]
+        let o = b.dot_general(&attn, &vv, &[0], &[1], &[3], &[0], vec![nkv, lp, g, d]);
+        let o = b.transpose(&o, &[1, 0, 2, 3]); // [Lp, nkv, g, d]
+        let o = b.reshape(&o, vec![lp, nq * d]); // [Lp, nq*d], head-major
+        let attn_out = b.linear_seq(&o, &lw.wo); // [Lp, H]
+        x = b.add(&x, &attn_out);
+
+        // MLP: down( silu(x@gate^T) * (x@up^T) )
+        let hn2 = rms_norm_seq(&mut b, &x, &lw.post_ln, &k, lp, h);
+        let gate = b.linear_seq(&hn2, &lw.gate); // [Lp, inter]
+        let up = b.linear_seq(&hn2, &lw.up); // [Lp, inter]
+        let neg = b.negate(&gate);
+        let ex = b.exponential(&neg);
+        let one_b = b.broadcast(&k.one, &[], vec![lp, c.inter]);
+        let denom = b.add(&one_b, &ex);
+        let sig = b.divide(&one_b, &denom);
+        let silu = b.multiply(&gate, &sig);
+        let act = b.multiply(&silu, &up);
+        let down = b.linear_seq(&act, &lw.down); // [Lp, H]
+        x = b.add(&x, &down);
+    }
+
+    // --- tail: final norm, take the row at real_len-1, tied LM head ---
+    let xf = rms_norm_seq(&mut b, &x, &a.final_norm, &k, lp, h); // [Lp, H]
+    let one_i = b.const_i32(1);
+    let last_idx = b.subtract(&a.real_len, &one_i); // real_len - 1
+    let last_row = b.dynamic_slice(&xf, &[&last_idx, &k.c0], vec![1, h]); // [1, H]
+    let last = b.reshape(&last_row, vec![h]); // [H]
+    let logits = b.linear(&last, &a.embed); // [V]
+    let (out_val, out_ty) = if sample {
+        let tok = b.argmax(&logits);
+        (tok.name, Ty::scalar("i32").render())
+    } else {
+        (logits.name, Ty::f32(vec![c.vocab]).render())
+    };
+
+    let sig = render_signature(&decls);
+    let cache_ty = Ty::f32(vec![c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]).render();
+    format!(
+        "module @prefill {{\n  func.func public @main({sig}) -> ({out_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {l}, {kc}, {vc} : {out_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
+        sig = sig,
+        out_ty = out_ty,
+        cache_ty = cache_ty,
+        body = b.body(),
+        l = out_val,
+        kc = kcache.name,
+        vc = vcache.name,
+    )
+}

--- a/src/lib/mlxcel-xla/src/emitter/rope.rs
+++ b/src/lib/mlxcel-xla/src/emitter/rope.rs
@@ -1,0 +1,65 @@
+//! RoPE tables, byte-for-byte with HF `_compute_llama3_parameters` and the JAX
+//! reference `llama3_inv_freq` / `rope_tables` in spike/openxla/model_jax.py.
+//!
+//! All math is done in f64 (matching numpy's default), then cos/sin are cast to
+//! f32 for the baked constant tables, exactly as the JAX path did
+//! (`jnp.asarray(np.cos(emb), jnp.float32)`). Keeping the trig in f64-then-f32
+//! rather than emitting in-graph `stablehlo.cosine` removes any dependence on the
+//! runtime's transcendental precision.
+
+use super::config::Config;
+
+/// inv_freq[i], i in 0..head_dim/2, with llama3 scaling. Returns f64.
+pub fn llama3_inv_freq(c: &Config) -> Vec<f64> {
+    let half = c.head_dim / 2;
+    let mut inv = vec![0.0f64; half];
+    let low_wl = c.orig_ctx as f64 / c.low_freq_factor;
+    let high_wl = c.orig_ctx as f64 / c.high_freq_factor;
+    for (i, slot) in inv.iter_mut().enumerate() {
+        // base = 1 / theta^((2i)/head_dim)
+        let exponent = (2 * i) as f64 / c.head_dim as f64;
+        let base = 1.0 / c.rope_theta.powf(exponent);
+        let wavelen = 2.0 * std::f64::consts::PI / base;
+
+        // inv = where(wavelen > low_wl, base/factor, base)
+        let mut v = if wavelen > low_wl {
+            base / c.factor
+        } else {
+            base
+        };
+        // smoothed = (1 - smooth) * inv/factor + smooth * inv
+        let smooth = (c.orig_ctx as f64 / wavelen - c.low_freq_factor)
+            / (c.high_freq_factor - c.low_freq_factor);
+        let smoothed = (1.0 - smooth) * v / c.factor + smooth * v;
+        // is_medium = high_wl <= wavelen <= low_wl (wavelen is finite, so this is
+        // the same as the JAX `!(wavelen < high_wl) && !(wavelen > low_wl)`).
+        let is_medium = wavelen >= high_wl && wavelen <= low_wl;
+        if is_medium {
+            v = smoothed;
+        }
+        *slot = v;
+    }
+    inv
+}
+
+/// Build cos and sin tables of shape [max_seq, head_dim] as flat row-major f32.
+/// emb = concat([freqs, freqs], -1) where freqs = outer(pos, inv_freq).
+pub fn rope_tables(c: &Config, max_seq: usize) -> (Vec<f32>, Vec<f32>) {
+    let inv = llama3_inv_freq(c);
+    let half = c.head_dim / 2;
+    let d = c.head_dim;
+    let mut cos = vec![0.0f32; max_seq * d];
+    let mut sin = vec![0.0f32; max_seq * d];
+    for p in 0..max_seq {
+        for i in 0..half {
+            let angle = p as f64 * inv[i];
+            let (c_val, s_val) = (angle.cos() as f32, angle.sin() as f32);
+            // first half [0, half) and second half [half, d) are identical
+            cos[p * d + i] = c_val;
+            cos[p * d + half + i] = c_val;
+            sin[p * d + i] = s_val;
+            sin[p * d + half + i] = s_val;
+        }
+    }
+    (cos, sin)
+}

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -16,14 +16,15 @@
 //! feature.
 //!
 //! [`IreeLlama`] is the safe Rust owner of the C shim (`csrc/xla_iree.c`). On
-//! [`IreeLlama::load`] it (1) checks the model's `config.json` matches the
-//! architecture the bundled StableHLO graphs were authored for, (2) compiles the
-//! bundled `prefill` / `decode_step` graphs (which end in an on-device argmax,
-//! the #451 emitter output) to vmfbs with the dist's `iree-compile`, cached by
-//! content hash, (3) loads the bf16 weights as f32 in the emitter's arg order,
-//! and (4) hands all of it to the shim, which keeps the weights resident on the
-//! device and threads the KV cache across steps. Then [`IreeLlama::prefill`] /
-//! [`IreeLlama::decode`] are token-in / token-out.
+//! [`IreeLlama::load`] it (1) reads the model's `config.json` into an emitter
+//! [`Config`], (2) emits the `prefill` / `decode_step` StableHLO graphs from that
+//! config (the #451 emitter, ending in an on-device argmax) and compiles them to
+//! vmfbs with the dist's `iree-compile`, cached by content hash, (3) loads the
+//! bf16 weights as f32 in the emitter's arg order, and (4) hands all of it to the
+//! shim, which keeps the weights resident on the device and threads the KV cache
+//! across steps. Then [`IreeLlama::prefill`] / [`IreeLlama::decode`] are token-in
+//! / token-out. Emitting from config (issue #449 M3 Stage 2d) replaced the bundled
+//! Llama-3.2-1B `.mlir` assets, so any Llama-architecture checkpoint loads.
 //!
 //! Proven token-exact against the HF temp-0 reference in
 //! `spike/openxla/artifacts/results.json` before being vendored from the
@@ -40,13 +41,9 @@ use std::process::Command;
 use memmap2::Mmap;
 use safetensors::{Dtype, SafeTensors};
 
-/// Llama-3.2-1B-Instruct shape the bundled graphs are authored for.
-const N_LAYERS: usize = 16;
-/// Vocabulary size the bundled graphs emit logits over (#449 M3 Stage 2d): the
-/// logits prefill returns `[VOCAB]` and the ragged decode `[B, VOCAB]`. Matches
-/// the `vocab_size` `verify_config` checks.
-const VOCAB: usize = 128256;
-/// Prefill bucket baked into the bundled `prefill` graph (`tensor<256xi32>`,
+use crate::emitter::{Config, emit_decode, emit_decode_ragged, emit_prefill};
+
+/// Prefill bucket baked into the emitted `prefill` graph (`tensor<256xi32>`,
 /// == MAX_SEQ, so it covers any prompt the 256-slot KV cache holds).
 pub const PREFILL_LP: usize = 256;
 
@@ -108,48 +105,20 @@ unsafe extern "C" {
     fn xla_llama_free(c: *mut XlaCtx);
 }
 
-/// The single-sequence graphs (on-device argmax variant), bundled as crate assets.
-/// Used by [`IreeLlama`]; `iree-compile` turns these into vmfbs that match the
-/// linked runtime.
-const PREFILL_MLIR: &str = include_str!("../assets/llama-3.2-1b/prefill.mlir");
-const DECODE_MLIR: &str = include_str!("../assets/llama-3.2-1b/decode.mlir");
-
-/// The LOGITS prefill graph (#449 M3 Stage 2d): same as `prefill` but returns the
-/// `[vocab]` logit distribution instead of the argmax token, so the batched engine
-/// can sample the first token on the host. Used by [`IreeRaggedLlama`].
-const PREFILL_LOGITS_MLIR: &str = include_str!("../assets/llama-3.2-1b/prefill_logits.mlir");
-
-/// Ragged (continuous-batching) decode graphs, one bundled per supported slot
-/// count (#449 M3 Stage 2b/2d). Each is a fixed-`B_max` `@decode_step` taking
-/// per-row `token[B]`/`pos[B]`/`cache_len[B]` and the rank-5 KV, returning the
-/// `[B, vocab]` LOGITS (the engine samples per row on the host). The batched engine
-/// picks one by `b_max`; adding a slot count means regenerating the asset (see the
-/// assets README) and extending this table.
-const DECODE_RAGGED_LOGITS_B4_MLIR: &str =
-    include_str!("../assets/llama-3.2-1b/decode_ragged_logits_b4.mlir");
-const DECODE_RAGGED_LOGITS_B8_MLIR: &str =
-    include_str!("../assets/llama-3.2-1b/decode_ragged_logits_b8.mlir");
-
-/// The slot counts (`B_max`) the bundled ragged graphs cover.
+/// The slot counts (`B_max`) the serve worker maps a request's batch size to. The
+/// ragged decode graph for the chosen `b_max` is emitted from the model config at
+/// load (any `b_max` is emittable; the worker selects from this set).
 pub(crate) const RAGGED_B_VALUES: &[usize] = &[4, 8];
 
-/// The bundled ragged decode graph for `b_max`, or `None` if unsupported.
-fn ragged_decode_mlir(b_max: usize) -> Option<&'static str> {
-    match b_max {
-        4 => Some(DECODE_RAGGED_LOGITS_B4_MLIR),
-        8 => Some(DECODE_RAGGED_LOGITS_B8_MLIR),
-        _ => None,
-    }
-}
-
-/// The 146 weight names in the emitter's exact arg order: embed, final_norm,
-/// then per layer down, gate, in_ln, post_ln, up, wk, wo, wq, wv.
-fn weight_names() -> Vec<String> {
+/// The weight names in the emitter's exact arg order: embed, final_norm, then per
+/// layer down, gate, in_ln, post_ln, up, wk, wo, wq, wv. The layer count comes
+/// from the model config so the order matches the emitted graph's args.
+fn weight_names(cfg: &Config) -> Vec<String> {
     let mut names = vec![
         "model.embed_tokens.weight".to_string(),
         "model.norm.weight".to_string(),
     ];
-    for i in 0..N_LAYERS {
+    for i in 0..cfg.n_layers {
         let p = format!("model.layers.{i}.");
         for suf in [
             "mlp.down_proj.weight",
@@ -174,47 +143,6 @@ fn bf16_to_f32(bytes: &[u8]) -> Vec<f32> {
         .chunks_exact(2)
         .map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16))
         .collect()
-}
-
-/// Verify `config.json` matches the architecture the bundled graphs encode. The
-/// graphs hard-code Llama-3.2-1B-Instruct dimensions; a different model would
-/// silently produce wrong shapes, so this fails loudly instead.
-fn verify_config(model_dir: &Path) -> Result<(), String> {
-    let p = model_dir.join("config.json");
-    let s = std::fs::read_to_string(&p).map_err(|e| format!("read {}: {e}", p.display()))?;
-    let v: serde_json::Value =
-        serde_json::from_str(&s).map_err(|e| format!("parse {}: {e}", p.display()))?;
-    let want = [
-        ("num_hidden_layers", 16u64),
-        ("hidden_size", 2048),
-        ("intermediate_size", 8192),
-        ("num_attention_heads", 32),
-        ("num_key_value_heads", 8),
-        ("head_dim", 64),
-        ("vocab_size", 128256),
-    ];
-    for (k, w) in want {
-        let got = v.get(k).and_then(serde_json::Value::as_u64);
-        if got != Some(w) {
-            return Err(format!(
-                "the OpenXLA backend's bundled graphs are authored for \
-                 Llama-3.2-1B-Instruct (issue #449 M2): config.json `{k}` = {got:?}, \
-                 expected {w} ({})",
-                p.display()
-            ));
-        }
-    }
-    if v.get("tie_word_embeddings")
-        .and_then(serde_json::Value::as_bool)
-        != Some(true)
-    {
-        return Err(format!(
-            "the OpenXLA backend's bundled Llama-3.2-1B graph assumes tied word \
-             embeddings (config.json `tie_word_embeddings` != true, {})",
-            p.display()
-        ));
-    }
-    Ok(())
 }
 
 /// Locate the IREE distribution: a runtime `IREE_DIST` override first, else the
@@ -349,16 +277,24 @@ fn compile_pair(
     Ok((pre, dec))
 }
 
-/// Compile the bundled argmax prefill + single-token decode graphs for `device`.
-fn compile_vmfbs(device: &str) -> Result<(PathBuf, PathBuf), String> {
-    compile_pair(device, PREFILL_MLIR, "prefill", DECODE_MLIR, "decode")
+/// Emit and compile the argmax prefill + single-token decode graphs for `cfg` on
+/// `device` (the single-sequence engine's on-device-argmax pair). The graph text
+/// is emitted from the model config, so `compile_one`'s text-hash cache keys a
+/// distinct vmfb per architecture.
+fn compile_vmfbs(device: &str, cfg: &Config) -> Result<(PathBuf, PathBuf), String> {
+    let prefill = emit_prefill(cfg, true);
+    let decode = emit_decode(cfg, true);
+    compile_pair(device, &prefill, "prefill", &decode, "decode")
 }
 
-/// Load the 146 weights bf16 -> f32 in the emitter's arg order, returning the
-/// owned f32 buffers (kept alive until the shim copies them) plus the flat
-/// (ptr, rank, dims) arrays the C ABI takes.
+/// Load the weights bf16 -> f32 in the emitter's arg order, returning the owned
+/// f32 buffers (kept alive until the shim copies them) plus the flat (ptr, rank,
+/// dims) arrays the C ABI takes. `cfg` fixes the layer count and weight order.
 #[allow(clippy::type_complexity)]
-fn load_weights(model_dir: &Path) -> Result<(Vec<Vec<f32>>, Vec<c_int>, Vec<i64>), String> {
+fn load_weights(
+    model_dir: &Path,
+    cfg: &Config,
+) -> Result<(Vec<Vec<f32>>, Vec<c_int>, Vec<i64>), String> {
     let st_path = model_dir.join("model.safetensors");
     let file = File::open(&st_path).map_err(|e| format!("open {}: {e}", st_path.display()))?;
     // Safety: the file is read-only for the lifetime of the mmap below.
@@ -366,7 +302,7 @@ fn load_weights(model_dir: &Path) -> Result<(Vec<Vec<f32>>, Vec<c_int>, Vec<i64>
         unsafe { Mmap::map(&file) }.map_err(|e| format!("mmap {}: {e}", st_path.display()))?;
     let st = SafeTensors::deserialize(&mmap).map_err(|e| format!("parse safetensors: {e}"))?;
 
-    let names = weight_names();
+    let names = weight_names(cfg);
     let mut bufs: Vec<Vec<f32>> = Vec::with_capacity(names.len());
     let mut ranks: Vec<c_int> = Vec::with_capacity(names.len());
     let mut dims: Vec<i64> = Vec::with_capacity(names.len() * 4);
@@ -403,11 +339,12 @@ fn path_cstring(p: &Path) -> Result<CString, String> {
 /// ([`IreeRaggedLlama`]) engines, which differ only in which decode vmfb they pass.
 fn create_ctx(
     model_dir: &Path,
+    cfg: &Config,
     device: &str,
     prefill_vmfb: &Path,
     decode_vmfb: &Path,
 ) -> Result<*mut XlaCtx, String> {
-    let (bufs, ranks, dims) = load_weights(model_dir)?;
+    let (bufs, ranks, dims) = load_weights(model_dir, cfg)?;
     let ptrs: Vec<*const f32> = bufs.iter().map(|b| b.as_ptr()).collect();
     let c_dev = CString::new(device).map_err(|_| "device has interior nul".to_string())?;
     let c_pre = path_cstring(prefill_vmfb)?;
@@ -448,9 +385,9 @@ impl IreeLlama {
     /// (`"local-task"` for CPU). Compiles the bundled graphs, uploads the
     /// weights resident, and readies the prefill / decode calls.
     pub fn load(model_dir: &Path, device: &str) -> Result<Self, String> {
-        verify_config(model_dir)?;
-        let (prefill_vmfb, decode_vmfb) = compile_vmfbs(device)?;
-        let ctx = create_ctx(model_dir, device, &prefill_vmfb, &decode_vmfb)?;
+        let cfg = Config::from_json(model_dir)?;
+        let (prefill_vmfb, decode_vmfb) = compile_vmfbs(device, &cfg)?;
+        let ctx = create_ctx(model_dir, &cfg, device, &prefill_vmfb, &decode_vmfb)?;
         Ok(Self { ctx })
     }
 
@@ -544,6 +481,9 @@ impl Drop for IreeLlama {
 pub struct IreeRaggedLlama {
     ctx: *mut XlaCtx,
     b_max: usize,
+    /// Vocabulary size (logits per row), from the model config; the readback
+    /// buffers and the per-row logits slice are sized by it.
+    vocab: usize,
 }
 
 impl IreeRaggedLlama {
@@ -553,29 +493,35 @@ impl IreeRaggedLlama {
     /// graph for `b_max`, uploads the weights resident, and sizes the batch.
     /// `b_max` must be one of the bundled graphs ([`RAGGED_B_VALUES`]).
     pub fn load(model_dir: &Path, device: &str, b_max: usize) -> Result<Self, String> {
-        verify_config(model_dir)?;
-        let decode_mlir = ragged_decode_mlir(b_max).ok_or_else(|| {
-            format!(
-                "the OpenXLA batched engine has bundled ragged decode graphs for \
-                 B_max {RAGGED_B_VALUES:?}; {b_max} is not one of them (regenerate an \
-                 asset to add it; see the assets README)"
-            )
-        })?;
+        let cfg = Config::from_json(model_dir)?;
+        if !RAGGED_B_VALUES.contains(&b_max) {
+            return Err(format!(
+                "the OpenXLA serve worker selects B_max from {RAGGED_B_VALUES:?}; \
+                 {b_max} is not one of them"
+            ));
+        }
+        // Emit the logits prefill + the ragged decode graph for this model + b_max.
+        let prefill_mlir = emit_prefill(&cfg, false);
+        let decode_mlir = emit_decode_ragged(&cfg, b_max, false);
         let (prefill_vmfb, decode_vmfb) = compile_pair(
             device,
-            PREFILL_LOGITS_MLIR,
+            &prefill_mlir,
             "prefill_logits",
-            decode_mlir,
+            &decode_mlir,
             &format!("decode_ragged_logits_b{b_max}"),
         )?;
-        let ctx = create_ctx(model_dir, device, &prefill_vmfb, &decode_vmfb)?;
+        let ctx = create_ctx(model_dir, &cfg, device, &prefill_vmfb, &decode_vmfb)?;
         // Safety: ctx is a fresh valid context from create_ctx; free it on error.
         let rc = unsafe { xla_llama_ragged_reset(ctx, b_max as c_int) };
         if rc != 0 {
             unsafe { xla_llama_free(ctx) };
             return Err(format!("xla_llama_ragged_reset failed (status {rc})"));
         }
-        Ok(Self { ctx, b_max })
+        Ok(Self {
+            ctx,
+            b_max,
+            vocab: cfg.vocab,
+        })
     }
 
     /// The fixed slot count this engine was compiled for.
@@ -588,7 +534,7 @@ impl IreeRaggedLlama {
     /// flat `[b_max * vocab]` logits by this.
     #[must_use]
     pub fn vocab(&self) -> usize {
-        VOCAB
+        self.vocab
     }
 
     /// Seed slot `slot` with `prompt` (1..=[`PREFILL_LP`] tokens) and return its
@@ -612,9 +558,9 @@ impl IreeRaggedLlama {
         let mut tokens = vec![0i32; PREFILL_LP];
         tokens[..prompt.len()].copy_from_slice(prompt);
         let positions: Vec<c_int> = (0..PREFILL_LP as c_int).collect();
-        let mut logits = vec![0f32; VOCAB];
-        // Safety: input buffers outlive the call; `logits` has VOCAB elements, which
-        // the shim fills; the shim also writes the slot's KV device-side.
+        let mut logits = vec![0f32; self.vocab];
+        // Safety: input buffers outlive the call; `logits` has self.vocab elements,
+        // which the shim fills; the shim also writes the slot's KV device-side.
         let rc = unsafe {
             xla_llama_prefill_slot_logits(
                 self.ctx,
@@ -623,7 +569,7 @@ impl IreeRaggedLlama {
                 PREFILL_LP as c_int,
                 positions.as_ptr(),
                 prompt.len() as c_int,
-                VOCAB as c_int,
+                self.vocab as c_int,
                 logits.as_mut_ptr(),
             )
         };
@@ -651,9 +597,9 @@ impl IreeRaggedLlama {
                 self.b_max
             ));
         }
-        let mut logits = vec![0f32; self.b_max * VOCAB];
+        let mut logits = vec![0f32; self.b_max * self.vocab];
         // Safety: the three input slices are length b_max == bsz; `logits` has
-        // b_max*VOCAB elements, which the shim fills; the shim threads its rank-5 KV.
+        // b_max*self.vocab elements, which the shim fills; it threads its rank-5 KV.
         let rc = unsafe {
             xla_llama_decode_ragged_logits(
                 self.ctx,
@@ -661,7 +607,7 @@ impl IreeRaggedLlama {
                 tokens.as_ptr(),
                 pos.as_ptr(),
                 cache_len.as_ptr(),
-                VOCAB as c_int,
+                self.vocab as c_int,
                 logits.as_mut_ptr(),
             )
         };

--- a/src/lib/mlxcel-xla/src/lib.rs
+++ b/src/lib/mlxcel-xla/src/lib.rs
@@ -66,6 +66,16 @@ mod batch;
 #[cfg_attr(not(feature = "iree"), allow(dead_code))]
 mod sampler;
 
+// Rust-native StableHLO emitter (#449 M3 Stage 2d, ported from the #451 spike).
+// Pure Rust; present under `iree` (the engine emits its graphs from config.json at
+// load) and under `test` (the byte-exact regression runs without the IREE
+// runtime). A faithful port keeps some entry points the production path does not
+// call (uniform-B batched emit, the hard-coded reference config), so dead_code is
+// allowed module-wide.
+#[cfg(any(feature = "iree", test))]
+#[allow(dead_code)]
+mod emitter;
+
 #[cfg(feature = "iree")]
 pub use batch::{EngineEvent, FinishReason, XlaBatchEngine, XlaReferenceEngine};
 #[cfg(feature = "iree")]


### PR DESCRIPTION
## Summary

Stage A of config.json-driven multi-architecture emit (#449 M3 Stage 2d). The OpenXLA engine compiled bundled Llama-3.2-1B `.mlir` assets and a hardcoded `verify_config` rejected every other model. This ports the #451 StableHLO emitter into `mlxcel-xla` and emits the prefill / decode / ragged-decode graphs from the model's `config.json` **at load**, so any Llama-architecture checkpoint (any size) runs. The C shim already derives KV geometry from the emitted graph's buffers, so nothing downstream is pinned to one model.

This is the foundation; genuinely different architectures (Qwen2 QKV bias, Gemma GeGLU / softcap) are Stage B, which extends the emitter and `from_json`.

## What's here

- **`src/emitter/`** (ported from `spike/rust-emitter`): `config` / `rope` / `builder` / `model` as a pure-Rust library (no IREE), compiled under `iree` or `test`. The `emit_prefill` / `emit_decode` / `emit_decode_ragged` functions already take a `&Config`.
- **`Config::from_json`**: reads the Llama config fields (dims, `rms_norm_eps`, `rope_theta`, `vocab_size`, and the llama3 `rope_scaling` sub-object). It rejects configs the emitter cannot yet reproduce, with a clear Stage-B error: a non-`llama` `model_type`, `attention_bias` (e.g. Qwen2), untied embeddings, or a missing / non-`llama3` `rope_scaling`.
- **`iree.rs`**: builds a `Config` from `config.json` at load and emits the graphs (replacing the `include_str!` assets and `verify_config`); `weight_names` (layer count) and the ragged engine's `vocab` readback are config-driven. `compile_one`'s text-hash cache keys a distinct vmfb per architecture automatically.
- **`serde_json`** becomes a normal dependency (the emitter parses `config.json`).
- The bundled `.mlir` assets remain only as the byte-exact regression fixtures.

## Why this is end-to-end correct for other Llama sizes

The C shim (`csrc/xla_iree.c`) captures the rank-5 KV geometry (`rg_dims`, per-slot byte size `rg_per`) from the first prefill's output buffer, not from hardcoded constants. So the KV layout flows config.json -> emitted graph -> vmfb -> prefill KV buffer -> shim, and the device-side slot write (Stage 2b) is correct for any dimensions.

## Validation

- **Byte-exact unit test** (`cargo test -p mlxcel-xla`, no feature needed): a `Config` parsed from the real Llama-3.2-1B-Instruct `config.json` emits all five bundled graphs (`prefill`, `decode`, `prefill_logits`, `decode_ragged_logits_b4`, `decode_ragged_logits_b8`) byte-for-byte. So switching from `include_str!` to emit-at-load cannot change the compiled graphs for that model. 25 tests total in the crate.
- **E2E on GB10 CUDA** (`/v1/completions`): the served greedy output is **token-exact** with the pre-emit baseline, and stop strings / penalties / sampling all still work on the emitted graph (the whole Stage 2d stack is unaffected).
- `cargo fmt` and `cargo clippy -D warnings` clean (no-feature lib + tests, `mlxcel-xla --features iree --all-targets`, `mlxcel --lib --features xla-iree`); `mlxcel-server` builds and links with `xla-iree`.

The MLX serving path is unchanged; default and CI builds compile with the XLA backend absent.

## Scope / non-goals

Llama architecture only (RMSNorm, SwiGLU, llama3 RoPE scaling, no attention bias, tied embeddings); unsupported configs are rejected with a clear error. Stage B adds Qwen2 (plain RoPE + QKV bias) and validates on `Qwen2.5-0.5B-bf16`. No second bf16 Llama is available locally, so a different-size Llama is exercised by the byte-exact emit path rather than an additional E2E.

Refs #449 (epic). Follows #479 (penalties), #478 (stop strings), #471 (sampling), #470/#469/#468/#466/#462.
