### PR TITLE
feat: serve Qwen2 on the OpenXLA path (plain RoPE + QKV bias) (#449 M3 Stage 2d)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,3 +249,12 @@ required-features = ["test-utils"]
 [[example]]
 name = "xla_batch_bench"
 required-features = ["xla-iree"]
+
+# Token-exactness gate vs an external greedy oracle (#449 M3 Stage 2d, Stage B).
+# Drives the single-sequence OpenXLA engine over a prompt and asserts its greedy
+# token stream equals a reference captured from HF transformers, proving the
+# emitted graph computes the architecture correctly (the Qwen2 QKV-bias + plain
+# RoPE gate). Needs real IREE execution, so it builds only under `xla-iree`.
+[[example]]
+name = "xla_oracle_check"
+required-features = ["xla-iree"]

--- a/examples/xla_oracle_check.rs
+++ b/examples/xla_oracle_check.rs
@@ -1,0 +1,125 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Token-exactness gate for the OpenXLA/IREE engine against an EXTERNAL greedy
+//! oracle (issue #449 M3 Stage 2d, Stage B). Where `xla_batch_bench` proves the
+//! batched engine matches its own single-sequence path (internal consistency),
+//! this proves the single-sequence path matches a reference captured from a
+//! trusted implementation (HF transformers), so the emitted StableHLO graph
+//! computes the architecture itself correctly. This is the gate that catches a
+//! wrong-but-self-consistent graph, e.g. a misplaced Qwen2 QKV bias or a wrong
+//! RoPE table.
+//!
+//! The oracle JSON (see `spike/openxla/qwen_oracle.py`) holds `prompt_ids` and
+//! `ref_token_ids`, the pure next-token-argmax trajectory for N steps with NO
+//! EOS stop. This driver runs the engine's greedy generation for exactly N
+//! tokens (empty EOS set, so it never stops early) and asserts an exact match.
+//!
+//! Build needs the `xla-iree` feature (real IREE execution).
+//!
+//! ```bash
+//! # 1) capture the oracle (HF transformers, fp32):
+//! python spike/openxla/qwen_oracle.py /models/qwen2.5-0.5b-bf16 /tmp/qwen.json \
+//!   "The capital of France is" 40
+//! # 2) check the OpenXLA engine against it on CUDA (GB10):
+//! IREE_CUDA_HOME=... IREE_CUDA_COMPILE=... cargo run --release --features xla-iree \
+//!   --example xla_oracle_check -- --model /models/qwen2.5-0.5b-bf16 \
+//!   --oracle /tmp/qwen.json --device cuda
+//! ```
+
+use std::path::PathBuf;
+
+use mlxcel_xla::XlaReferenceEngine;
+
+fn arg(flag: &str, default: &str) -> String {
+    let args: Vec<String> = std::env::args().collect();
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// Read an `[int, ...]` array under `key` from a JSON file.
+fn read_int_array(path: &std::path::Path, key: &str) -> Vec<i32> {
+    let s =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let v: serde_json::Value =
+        serde_json::from_str(&s).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+    v[key]
+        .as_array()
+        .unwrap_or_else(|| panic!("{key} is not an array in {}", path.display()))
+        .iter()
+        .map(|x| x.as_i64().expect("int element") as i32)
+        .collect()
+}
+
+fn main() {
+    let model = PathBuf::from(arg("--model", "/home/inureyes/models/qwen2.5-0.5b-bf16"));
+    let oracle = PathBuf::from(arg("--oracle", "/tmp/qwen_oracle.json"));
+    let device = {
+        let a = arg("--device", "");
+        if !a.is_empty() {
+            a
+        } else {
+            std::env::var("MLXCEL_XLA_DEVICE").unwrap_or_else(|_| "local-task".to_string())
+        }
+    };
+
+    let prompt_ids = read_int_array(&oracle, "prompt_ids");
+    let reference = read_int_array(&oracle, "ref_token_ids");
+    assert!(!prompt_ids.is_empty(), "oracle prompt_ids is empty");
+    assert!(!reference.is_empty(), "oracle ref_token_ids is empty");
+
+    println!(
+        "model = {}\ndevice = {device}, prompt = {} tokens, reference = {} tokens",
+        model.display(),
+        prompt_ids.len(),
+        reference.len(),
+    );
+
+    let mut eng = XlaReferenceEngine::load(&model, &device).expect("load reference engine");
+    // Empty EOS set: generate exactly reference.len() tokens with no early stop,
+    // matching the oracle's no-EOS-stop argmax trajectory so the streams are
+    // directly comparable position for position.
+    let got = eng
+        .generate(&prompt_ids, reference.len(), &[])
+        .expect("greedy generate");
+
+    let ok = got == reference;
+    if !ok {
+        let m = got.len().min(reference.len());
+        let div = (0..m).find(|&j| got[j] != reference[j]);
+        println!(
+            "MISMATCH: got {} tokens, ref {} tokens, first divergence at {div:?}",
+            got.len(),
+            reference.len(),
+        );
+        if let Some(j) = div {
+            let lo = j.saturating_sub(2);
+            let hi = (j + 3).min(m);
+            println!("  ref[{lo}..{hi}] = {:?}", &reference[lo..hi]);
+            println!("  got[{lo}..{hi}] = {:?}", &got[lo..hi]);
+        }
+    }
+    println!(
+        "RESULT: {}",
+        if ok {
+            "TOKEN-EXACT PASS (OpenXLA greedy == HF oracle)"
+        } else {
+            "MISMATCH"
+        }
+    );
+    std::process::exit(if ok { 0 } else { 1 });
+}

--- a/spike/openxla/qwen_oracle.py
+++ b/spike/openxla/qwen_oracle.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Greedy HF reference for Qwen2.5-0.5B: the external oracle for the OpenXLA
+Stage B token-exactness gate. Loads the bf16 checkpoint as fp32 (the exact
+widening the XLA path does on its weights), encodes a prompt, and records the
+pure next-token-argmax trajectory for N steps WITHOUT stopping on EOS, so the
+Rust side can reproduce exactly N tokens and diff. First generated token is the
+argmax after the FULL prompt, matching XlaReferenceEngine's prefill_first."""
+
+import json
+import sys
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+model_dir = sys.argv[1]
+out_path = sys.argv[2]
+prompt = sys.argv[3] if len(sys.argv) > 3 else "The capital of France is"
+n_new = int(sys.argv[4]) if len(sys.argv) > 4 else 40
+
+tok = AutoTokenizer.from_pretrained(model_dir)
+model = AutoModelForCausalLM.from_pretrained(model_dir, torch_dtype=torch.float32)
+model.eval()
+
+prompt_ids = tok(prompt, return_tensors="pt").input_ids  # [1, L]
+ids = prompt_ids.clone()
+ref = []
+with torch.no_grad():
+    for _ in range(n_new):
+        logits = model(ids).logits[:, -1, :]  # [1, V]
+        nxt = int(torch.argmax(logits, dim=-1).item())
+        ref.append(nxt)
+        ids = torch.cat([ids, torch.tensor([[nxt]])], dim=1)
+
+out = {
+    "prompt_text": prompt,
+    "prompt_ids": prompt_ids[0].tolist(),
+    "ref_token_ids": ref,
+}
+with open(out_path, "w") as f:
+    json.dump(out, f)
+print(f"prompt_ids ({len(out['prompt_ids'])}):", out["prompt_ids"])
+print(f"ref_token_ids ({len(ref)}):", ref)
+print("decoded continuation:", tok.decode(ref))

--- a/src/lib/mlxcel-xla/assets/qwen2.5-0.5b/README.md
+++ b/src/lib/mlxcel-xla/assets/qwen2.5-0.5b/README.md
@@ -1,0 +1,14 @@
+# Qwen2.5-0.5B-Instruct config fixture (#449 M3 Stage 2d, Stage B)
+
+`config.json` is the real Qwen2.5-0.5B-Instruct config, kept as the fixture for
+the `Config::from_json` parse test (`emitter/mod.rs`). It is the Qwen2 architecture
+the OpenXLA backend serves: `model_type` `qwen2`, **plain RoPE** (no `rope_scaling`,
+`rope_theta = 1e6`), a **q/k/v projection bias** (`o_proj` and the MLP have none),
+and tied word embeddings.
+
+Unlike the Llama-3.2-1B directory, no `.mlir` graphs are committed here: the engine
+emits the prefill / decode / ragged-decode graphs from this config at load (the
+Stage A emit-at-load path), so the Qwen graphs are generated, not bundled. The
+emitter's Qwen-specific surface (the QKV-bias adds and the plain-RoPE table) is
+covered by the structural tests in `emitter/mod.rs`, and the end-to-end token
+exactness is validated on GB10 against the model's own greedy reference.

--- a/src/lib/mlxcel-xla/assets/qwen2.5-0.5b/config.json
+++ b/src/lib/mlxcel-xla/assets/qwen2.5-0.5b/config.json
@@ -1,0 +1,27 @@
+{
+    "architectures": [
+        "Qwen2ForCausalLM"
+    ],
+    "attention_dropout": 0.0,
+    "bos_token_id": 151643,
+    "eos_token_id": 151645,
+    "hidden_act": "silu",
+    "hidden_size": 896,
+    "initializer_range": 0.02,
+    "intermediate_size": 4864,
+    "max_position_embeddings": 32768,
+    "max_window_layers": 21,
+    "model_type": "qwen2",
+    "num_attention_heads": 14,
+    "num_hidden_layers": 24,
+    "num_key_value_heads": 2,
+    "rms_norm_eps": 1e-06,
+    "rope_theta": 1000000.0,
+    "sliding_window": 32768,
+    "tie_word_embeddings": true,
+    "torch_dtype": "bfloat16",
+    "transformers_version": "4.43.1",
+    "use_cache": true,
+    "use_sliding_window": false,
+    "vocab_size": 151936
+}

--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -1,6 +1,27 @@
-//! Llama-architecture emitter config. The hard-coded [`Config::llama_3_2_1b`]
-//! matches spike/openxla/model_jax.py; [`Config::from_json`] reads the same shape
-//! from any Llama checkpoint's `config.json` (issue #449 M3 Stage 2d).
+//! Emitter config for the Llama-family architectures the OpenXLA backend serves.
+//! The hard-coded [`Config::llama_3_2_1b`] matches spike/openxla/model_jax.py;
+//! [`Config::from_json`] reads the same shape from a checkpoint's `config.json`
+//! (issue #449 M3 Stage 2d). Stage A covered the Llama architecture (llama3 RoPE,
+//! no attention bias); Stage B adds Qwen2 (plain RoPE + QKV bias), so the config
+//! carries the two architecture switches the emitter branches on: the RoPE kind
+//! and whether q/k/v projections have a bias.
+
+/// How the RoPE inverse-frequency table is computed. Both kinds share the
+/// `outer(pos, inv_freq)` table build (see [`rope`](super::rope)); they differ
+/// only in `inv_freq`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum RopeScaling {
+    /// Plain RoPE: `inv_freq[i] = 1 / theta^(2i/head_dim)` (Qwen2, and plain-RoPE
+    /// Llama without a `rope_scaling` block).
+    Plain,
+    /// Llama3 RoPE scaling, byte-for-byte with HF `_compute_llama3_parameters`.
+    Llama3 {
+        factor: f64,
+        low_freq_factor: f64,
+        high_freq_factor: f64,
+        orig_ctx: usize,
+    },
+}
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -13,11 +34,11 @@ pub struct Config {
     pub eps: f32,
     pub rope_theta: f64,
     pub vocab: usize,
-    // llama3 rope scaling
-    pub factor: f64,
-    pub low_freq_factor: f64,
-    pub high_freq_factor: f64,
-    pub orig_ctx: usize,
+    /// RoPE inverse-frequency scheme (Stage B: `Plain` for Qwen2).
+    pub rope: RopeScaling,
+    /// q/k/v projections carry a bias (Qwen2). `o_proj` never does, and the MLP
+    /// projections never do, so this single switch covers the architecture delta.
+    pub qkv_bias: bool,
 }
 
 impl Config {
@@ -33,44 +54,61 @@ impl Config {
             eps: 1e-5,
             rope_theta: 500000.0,
             vocab: 128256,
-            factor: 32.0,
-            low_freq_factor: 1.0,
-            high_freq_factor: 4.0,
-            orig_ctx: 8192,
+            rope: RopeScaling::Llama3 {
+                factor: 32.0,
+                low_freq_factor: 1.0,
+                high_freq_factor: 4.0,
+                orig_ctx: 8192,
+            },
+            qkv_bias: false,
         }
     }
 
     /// Build a [`Config`] from a model's `config.json` text.
     ///
-    /// Scope (Stage A): the Llama architecture with llama3 RoPE scaling, which is
-    /// what the emitter encodes. Configs the emitter cannot yet reproduce are
-    /// rejected with a clear error rather than silently mis-emitted: a non-`llama`
-    /// `model_type`, attention bias (e.g. Qwen2), untied embeddings, or a missing
-    /// / non-`llama3` `rope_scaling`.
+    /// Scope: the Llama and Qwen2 architectures (RMSNorm, SwiGLU MLP, GQA, tied
+    /// embeddings). Llama uses llama3 RoPE scaling and no attention bias; Qwen2
+    /// uses plain RoPE and a q/k/v projection bias. Configs the emitter cannot yet
+    /// reproduce are rejected with a clear error rather than silently mis-emitted:
+    /// an unsupported `model_type`, untied embeddings, a `llama` checkpoint with
+    /// `attention_bias`, or a `rope_scaling` whose `rope_type` is not `llama3`.
     pub fn from_json_str(s: &str) -> Result<Self, String> {
         let v: serde_json::Value =
             serde_json::from_str(s).map_err(|e| format!("parse config.json: {e}"))?;
 
         let model_type = v.get("model_type").and_then(serde_json::Value::as_str);
-        if model_type != Some("llama") {
-            return Err(format!(
-                "the OpenXLA emitter currently supports the Llama architecture only; \
-                 config.json model_type = {model_type:?} (Qwen / Gemma / others are a follow-up)"
-            ));
-        }
-        if v.get("attention_bias").and_then(serde_json::Value::as_bool) == Some(true) {
-            return Err(
-                "the OpenXLA emitter does not yet support attention bias (e.g. Qwen2); \
-                 config.json attention_bias = true"
-                    .to_string(),
-            );
-        }
+        // Qwen2 always has a q/k/v projection bias (the HF `Qwen2Attention` hard-
+        // codes `bias=True`), and it is not a `config.json` field, so it is keyed
+        // off the architecture rather than read.
+        let qkv_bias = match model_type {
+            Some("llama") => {
+                // A `llama` checkpoint with attention bias would need the same bias
+                // emit Qwen2 uses, but that pairing is untested here, so reject it
+                // rather than emit an unvalidated graph.
+                if v.get("attention_bias").and_then(serde_json::Value::as_bool) == Some(true) {
+                    return Err(
+                        "the OpenXLA emitter does not support a `llama` checkpoint with \
+                         attention_bias = true (only Qwen2 carries a q/k/v bias here)"
+                            .to_string(),
+                    );
+                }
+                false
+            }
+            Some("qwen2") => true,
+            other => {
+                return Err(format!(
+                    "the OpenXLA emitter supports the Llama and Qwen2 architectures; \
+                     config.json model_type = {other:?} (Gemma / others are a follow-up)"
+                ));
+            }
+        };
+
         if v.get("tie_word_embeddings")
             .and_then(serde_json::Value::as_bool)
             != Some(true)
         {
             return Err("the OpenXLA emitter assumes tied word embeddings; \
-                 config.json tie_word_embeddings != true"
+                 config.json tie_word_embeddings != true (untied LM head is a follow-up)"
                 .to_string());
         }
 
@@ -95,34 +133,44 @@ impl Config {
             .map(|x| x as usize)
             .unwrap_or(hidden / n_q.max(1));
 
-        let scaling = v.get("rope_scaling").ok_or_else(|| {
-            "the OpenXLA emitter encodes llama3 RoPE scaling; config.json has no \
-             `rope_scaling` (plain-RoPE Llama is a follow-up)"
-                .to_string()
-        })?;
-        let rope_type = scaling
-            .get("rope_type")
-            .or_else(|| scaling.get("type"))
-            .and_then(serde_json::Value::as_str);
-        if rope_type != Some("llama3") {
-            return Err(format!(
-                "the OpenXLA emitter encodes llama3 RoPE scaling; config.json \
-                 rope_scaling.rope_type = {rope_type:?} (only `llama3` is supported)"
-            ));
-        }
-        let sf = |k: &str| -> Result<f64, String> {
-            scaling
-                .get(k)
-                .and_then(serde_json::Value::as_f64)
-                .ok_or_else(|| format!("config.json rope_scaling missing number `{k}`"))
+        // rope_scaling is optional: absent -> plain RoPE (Qwen2.5, plain Llama);
+        // present -> only the llama3 scheme is supported (Stage A).
+        let rope = match v.get("rope_scaling") {
+            None | Some(serde_json::Value::Null) => RopeScaling::Plain,
+            Some(scaling) => {
+                let rope_type = scaling
+                    .get("rope_type")
+                    .or_else(|| scaling.get("type"))
+                    .and_then(serde_json::Value::as_str);
+                if rope_type != Some("llama3") {
+                    return Err(format!(
+                        "the OpenXLA emitter supports plain RoPE and llama3 RoPE scaling; \
+                         config.json rope_scaling.rope_type = {rope_type:?} (e.g. yarn is a \
+                         follow-up)"
+                    ));
+                }
+                let sf = |k: &str| -> Result<f64, String> {
+                    scaling
+                        .get(k)
+                        .and_then(serde_json::Value::as_f64)
+                        .ok_or_else(|| format!("config.json rope_scaling missing number `{k}`"))
+                };
+                let orig_ctx = scaling
+                    .get("original_max_position_embeddings")
+                    .and_then(serde_json::Value::as_u64)
+                    .map(|x| x as usize)
+                    .ok_or_else(|| {
+                        "config.json rope_scaling missing `original_max_position_embeddings`"
+                            .to_string()
+                    })?;
+                RopeScaling::Llama3 {
+                    factor: sf("factor")?,
+                    low_freq_factor: sf("low_freq_factor")?,
+                    high_freq_factor: sf("high_freq_factor")?,
+                    orig_ctx,
+                }
+            }
         };
-        let orig_ctx = scaling
-            .get("original_max_position_embeddings")
-            .and_then(serde_json::Value::as_u64)
-            .map(|x| x as usize)
-            .ok_or_else(|| {
-                "config.json rope_scaling missing `original_max_position_embeddings`".to_string()
-            })?;
 
         Ok(Config {
             hidden,
@@ -134,10 +182,8 @@ impl Config {
             eps: f("rms_norm_eps")? as f32,
             rope_theta: f("rope_theta")?,
             vocab: u("vocab_size")?,
-            factor: sf("factor")?,
-            low_freq_factor: sf("low_freq_factor")?,
-            high_freq_factor: sf("high_freq_factor")?,
-            orig_ctx,
+            rope,
+            qkv_bias,
         })
     }
 

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -19,11 +19,13 @@
 //! `config.json` at load, instead of being pinned to the bundled Llama-3.2-1B
 //! `.mlir` assets.
 //!
-//! Scope: the Llama architecture (RMSNorm, SwiGLU MLP, llama3 RoPE scaling, no
-//! attention bias, tied embeddings). The `Config` is parameterized by dimensions,
-//! so any Llama-architecture checkpoint (any size) emits correctly; genuinely
-//! different architectures (e.g. Qwen2 QKV bias, Gemma GeGLU / softcap) are a
-//! follow-up that extends the emitter and `from_json`.
+//! Scope: the Llama and Qwen2 architectures (RMSNorm, SwiGLU MLP, GQA, tied
+//! embeddings). The `Config` is parameterized by dimensions, so any checkpoint of
+//! a supported architecture (any size) emits correctly. The two architecture
+//! switches the emitter branches on are the RoPE kind (llama3 scaling for Llama,
+//! plain for Qwen2) and whether the q/k/v projections carry a bias (Qwen2, Stage
+//! B); other architectures (e.g. Gemma GeGLU / softcap) are a follow-up that
+//! extends the emitter and `from_json`.
 //!
 //! Pure Rust (no IREE), so it compiles and is unit-tested without the `iree`
 //! feature; only the IREE engine consumes it. The bundled `.mlir` assets remain
@@ -40,6 +42,7 @@ pub(crate) use model::{emit_decode, emit_decode_ragged, emit_prefill};
 
 #[cfg(test)]
 mod tests {
+    use super::config::RopeScaling;
     use super::*;
 
     const CONFIG_JSON: &str = include_str!("../../assets/llama-3.2-1b/config.json");
@@ -48,6 +51,38 @@ mod tests {
     const PREFILL_LOGITS: &str = include_str!("../../assets/llama-3.2-1b/prefill_logits.mlir");
     const RAGGED_B4: &str = include_str!("../../assets/llama-3.2-1b/decode_ragged_logits_b4.mlir");
     const RAGGED_B8: &str = include_str!("../../assets/llama-3.2-1b/decode_ragged_logits_b8.mlir");
+    const QWEN_CONFIG_JSON: &str = include_str!("../../assets/qwen2.5-0.5b/config.json");
+
+    fn occurs(haystack: &str, needle: &str) -> usize {
+        haystack.matches(needle).count()
+    }
+
+    /// Arg count of an emitted module = the number of `loc("...")` markers, since
+    /// the signature renders exactly one per func argument and the body carries
+    /// none.
+    fn arg_count(mlir: &str) -> usize {
+        occurs(mlir, "loc(\"")
+    }
+
+    /// A tiny Qwen2-shaped config (plain RoPE + QKV bias) for the structural emit
+    /// tests: small dims keep the emitted text tiny while exercising every
+    /// bias-bearing path. `qkv_bias` is the only difference from the Llama-shaped
+    /// counterpart, so a with/without diff isolates exactly the bias surface.
+    fn qwen_like(qkv_bias: bool) -> Config {
+        Config {
+            hidden: 8,
+            inter: 16,
+            n_layers: 2,
+            n_q: 2,
+            n_kv: 1,
+            head_dim: 4,
+            eps: 1e-6,
+            rope_theta: 1_000_000.0,
+            vocab: 10,
+            rope: RopeScaling::Plain,
+            qkv_bias,
+        }
+    }
 
     /// The whole point of Stage A: a `Config` parsed from the real
     /// Llama-3.2-1B-Instruct `config.json` emits every bundled graph
@@ -84,5 +119,170 @@ mod tests {
         let hard = Config::llama_3_2_1b();
         assert_eq!(emit_prefill(&from, false), emit_prefill(&hard, false));
         assert_eq!(emit_decode(&from, true), emit_decode(&hard, true));
+    }
+
+    /// Stage B: the real Qwen2.5-0.5B `config.json` parses to the Qwen2
+    /// architecture switches (plain RoPE + QKV bias) and the right dimensions.
+    #[test]
+    fn from_json_parses_qwen2_architecture() {
+        let c = Config::from_json_str(QWEN_CONFIG_JSON).expect("parse Qwen2.5-0.5B config.json");
+        assert!(c.qkv_bias, "Qwen2 carries a q/k/v projection bias");
+        assert_eq!(c.rope, RopeScaling::Plain, "Qwen2.5-0.5B uses plain RoPE");
+        assert_eq!(c.hidden, 896);
+        assert_eq!(c.inter, 4864);
+        assert_eq!(c.n_layers, 24);
+        assert_eq!(c.n_q, 14);
+        assert_eq!(c.n_kv, 2);
+        assert_eq!(c.head_dim, 64, "no explicit head_dim -> hidden / n_q");
+        assert_eq!(c.vocab, 151936);
+        assert_eq!(c.rope_theta, 1_000_000.0);
+        assert_eq!(c.eps, 1e-6);
+    }
+
+    /// A non-Llama/Qwen2 architecture, untied embeddings, and an unsupported
+    /// `rope_scaling` are each rejected with a clear message rather than
+    /// mis-emitted.
+    #[test]
+    fn from_json_rejects_unsupported_configs() {
+        let gemma = r#"{"model_type":"gemma2","tie_word_embeddings":true,"hidden_size":8,
+            "num_attention_heads":2,"intermediate_size":16,"num_hidden_layers":2,
+            "num_key_value_heads":1,"rms_norm_eps":1e-6,"rope_theta":1e4,"vocab_size":10}"#;
+        assert!(
+            Config::from_json_str(gemma)
+                .unwrap_err()
+                .contains("model_type")
+        );
+
+        let untied = r#"{"model_type":"qwen2","tie_word_embeddings":false,"hidden_size":8,
+            "num_attention_heads":2,"intermediate_size":16,"num_hidden_layers":2,
+            "num_key_value_heads":1,"rms_norm_eps":1e-6,"rope_theta":1e4,"vocab_size":10}"#;
+        assert!(
+            Config::from_json_str(untied)
+                .unwrap_err()
+                .contains("tie_word_embeddings")
+        );
+
+        let yarn = r#"{"model_type":"qwen2","tie_word_embeddings":true,"hidden_size":8,
+            "num_attention_heads":2,"intermediate_size":16,"num_hidden_layers":2,
+            "num_key_value_heads":1,"rms_norm_eps":1e-6,"rope_theta":1e4,"vocab_size":10,
+            "rope_scaling":{"rope_type":"yarn","factor":4.0}}"#;
+        assert!(
+            Config::from_json_str(yarn)
+                .unwrap_err()
+                .contains("rope_type")
+        );
+    }
+
+    /// Turning on `qkv_bias` adds exactly the three q/k/v projection biases per
+    /// layer to every graph kind, and the adds that consume them: the single-token
+    /// decode adds one `stablehlo.add` per bias; the seq graphs (prefill / batched
+    /// / ragged) add a broadcast + an add per bias. A with/without diff over an
+    /// otherwise-identical config isolates exactly the bias surface, so nothing
+    /// else in the graph shifted.
+    #[test]
+    fn qkv_bias_adds_three_biases_per_layer_to_every_graph() {
+        let with = qwen_like(true);
+        let without = qwen_like(false);
+        let nl = with.n_layers;
+
+        // single-token decode: +3*L args, +3*L adds, no extra broadcasts.
+        let d_with = emit_decode(&with, false);
+        let d_without = emit_decode(&without, false);
+        assert_eq!(
+            arg_count(&d_with) - arg_count(&d_without),
+            3 * nl,
+            "decode args"
+        );
+        assert_eq!(
+            occurs(&d_with, "stablehlo.add ") - occurs(&d_without, "stablehlo.add "),
+            3 * nl,
+            "decode bias adds"
+        );
+        assert_eq!(
+            occurs(&d_with, "broadcast_in_dim"),
+            occurs(&d_without, "broadcast_in_dim"),
+            "single-token bias is shape-matched, so no extra broadcast"
+        );
+
+        // seq graphs: +3*L args, +3*L adds, +3*L broadcasts.
+        let seq = [
+            (
+                emit_prefill(&with, false),
+                emit_prefill(&without, false),
+                "prefill",
+            ),
+            (
+                super::model::emit_decode_batched(&with, 4, false),
+                super::model::emit_decode_batched(&without, 4, false),
+                "batched",
+            ),
+            (
+                emit_decode_ragged(&with, 4, false),
+                emit_decode_ragged(&without, 4, false),
+                "ragged",
+            ),
+        ];
+        for (g_with, g_without, name) in seq {
+            assert_eq!(
+                arg_count(&g_with) - arg_count(&g_without),
+                3 * nl,
+                "{name} args"
+            );
+            assert_eq!(
+                occurs(&g_with, "stablehlo.add ") - occurs(&g_without, "stablehlo.add "),
+                3 * nl,
+                "{name} bias adds"
+            );
+            assert_eq!(
+                occurs(&g_with, "broadcast_in_dim") - occurs(&g_without, "broadcast_in_dim"),
+                3 * nl,
+                "{name} bias broadcasts"
+            );
+        }
+    }
+
+    /// The q/k/v bias args are appended after `wv` in k/q/v order for every layer,
+    /// matching `weight_names` in `iree.rs` so the loaded weight buffers line up
+    /// with the emitted graph args.
+    #[test]
+    fn qkv_bias_args_follow_wv_in_k_q_v_order() {
+        let c = qwen_like(true);
+        let mlir = emit_decode(&c, false);
+        for li in 0..c.n_layers {
+            let at = |k: &str| {
+                mlir.find(&format!("params['layers'][{li}]['{k}']"))
+                    .unwrap_or_else(|| panic!("layer {li} missing {k}"))
+            };
+            let (wv, bk, bq, bv) = (at("wv"), at("bk"), at("bq"), at("bv"));
+            assert!(
+                wv < bk && bk < bq && bq < bv,
+                "layer {li}: expected wv < bk < bq < bv arg order"
+            );
+        }
+    }
+
+    /// The Llama path is bias-free: no bias args leak onto a `qkv_bias = false`
+    /// architecture (the guard that keeps Llama byte-identical).
+    #[test]
+    fn llama_graph_has_no_qkv_bias_args() {
+        let mlir = emit_decode(&Config::llama_3_2_1b(), true);
+        assert!(!mlir.contains("['bq']"));
+        assert!(!mlir.contains("['bk']"));
+        assert!(!mlir.contains("['bv']"));
+    }
+
+    /// Plain RoPE base frequencies are the textbook `1 / theta^(2i/head_dim)`
+    /// (Qwen2), distinct from the llama3-scaled table.
+    #[test]
+    fn plain_rope_inv_freq_is_theta_power_series() {
+        let c = qwen_like(true); // theta 1e6, head_dim 4 -> half = 2
+        let inv = super::rope::inv_freq(&c);
+        assert_eq!(inv.len(), 2);
+        assert!((inv[0] - 1.0).abs() < 1e-12, "i=0 -> theta^0 = 1");
+        let theta = 1_000_000.0f64;
+        assert!(
+            (inv[1] - 1.0 / theta.powf(2.0 / 4.0)).abs() < 1e-12,
+            "i=1 -> theta^(-1/2)"
+        );
     }
 }

--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -1,11 +1,14 @@
-//! Emits the Llama-3.2-1B `decode_step` StableHLO module from Rust.
+//! Emits the `decode_step` / `prefill` StableHLO modules for the supported
+//! Llama-family architectures (Llama, Qwen2) from Rust.
 //!
 //! Signature mirrors spike/openxla/model_jax.py `decode_step`:
 //!   main(params..., token, pos, cache_len, kcache, vcache)
 //!       -> (logits[V], kcache, vcache)
 //! Weights are individual tensor inputs in the same order JAX emitted
 //! (alphabetical within each layer), each carrying its pytree-path loc so the
-//! arg-to-weight mapping is self-documenting and reuses the JAX weight glue.
+//! arg-to-weight mapping is self-documenting and reuses the JAX weight glue. For
+//! a `qkv_bias` architecture (Qwen2) the per-layer q/k/v projection biases follow
+//! the layer's weights (see [`take_layer_weights`]).
 
 use super::builder::{Builder, Ty, Val};
 use super::config::Config;
@@ -21,7 +24,9 @@ const MAX_SEQ: usize = 256;
 const PREFILL_LP: usize = MAX_SEQ;
 
 /// Per-layer weight handles (JAX alphabetical order: down, gate, in_ln,
-/// post_ln, up, wk, wo, wq, wv).
+/// post_ln, up, wk, wo, wq, wv). `bk`/`bq`/`bv` are the q/k/v projection biases,
+/// present only for an architecture with `qkv_bias` (Qwen2); `None` for Llama,
+/// where the bias add emits no op so the graph is byte-identical to before.
 struct LayerW {
     down: Val,
     gate: Val,
@@ -32,6 +37,9 @@ struct LayerW {
     wo: Val,
     wq: Val,
     wv: Val,
+    bk: Option<Val>,
+    bq: Option<Val>,
+    bv: Option<Val>,
 }
 
 struct Args {
@@ -51,60 +59,121 @@ struct ArgDecl {
     loc: String,
 }
 
-fn build_arg_schema(c: &Config) -> (Vec<ArgDecl>, Args) {
+/// Append one (type, pytree-path loc) arg, returning a handle to it. `idx` is the
+/// running arg counter; sharing it across every graph kind keeps arg numbering
+/// identical to the hand-written builders this replaced.
+fn take_arg(decls: &mut Vec<ArgDecl>, idx: &mut usize, ty: Ty, loc: String) -> Val {
+    let val = Builder::arg(*idx, ty.clone());
+    decls.push(ArgDecl { ty, loc });
+    *idx += 1;
+    val
+}
+
+/// Append layer `li`'s weights (and, for `qkv_bias`, its q/k/v biases) in the one
+/// canonical order every graph kind shares, so the emitted arg order matches
+/// `weight_names` in `iree.rs` exactly. JAX-alphabetical weights (down, gate,
+/// in_ln, post_ln, up, wk, wo, wq, wv), then — when `c.qkv_bias` — the k/q/v
+/// projection biases (alphabetical, matching the wk<wq<wv weight order). The
+/// biases are rank-1: `bk`/`bv` are `[n_kv*head_dim]`, `bq` is `[n_q*head_dim]`.
+fn take_layer_weights(decls: &mut Vec<ArgDecl>, idx: &mut usize, c: &Config, li: usize) -> LayerW {
     let h = c.hidden;
     let inter = c.inter;
-    let kv = c.n_kv * c.head_dim; // 512
-    let qd = c.n_q * c.head_dim; // 2048
+    let kv = c.n_kv * c.head_dim;
+    let qd = c.n_q * c.head_dim;
+    let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
+    let down = take_arg(decls, idx, Ty::f32(vec![h, inter]), p("down"));
+    let gate = take_arg(decls, idx, Ty::f32(vec![inter, h]), p("gate"));
+    let in_ln = take_arg(decls, idx, Ty::f32(vec![h]), p("in_ln"));
+    let post_ln = take_arg(decls, idx, Ty::f32(vec![h]), p("post_ln"));
+    let up = take_arg(decls, idx, Ty::f32(vec![inter, h]), p("up"));
+    let wk = take_arg(decls, idx, Ty::f32(vec![kv, h]), p("wk"));
+    let wo = take_arg(decls, idx, Ty::f32(vec![qd, h]), p("wo"));
+    let wq = take_arg(decls, idx, Ty::f32(vec![qd, h]), p("wq"));
+    let wv = take_arg(decls, idx, Ty::f32(vec![kv, h]), p("wv"));
+    let (bk, bq, bv) = if c.qkv_bias {
+        let bk = take_arg(decls, idx, Ty::f32(vec![kv]), p("bk"));
+        let bq = take_arg(decls, idx, Ty::f32(vec![qd]), p("bq"));
+        let bv = take_arg(decls, idx, Ty::f32(vec![kv]), p("bv"));
+        (Some(bk), Some(bq), Some(bv))
+    } else {
+        (None, None, None)
+    };
+    LayerW {
+        down,
+        gate,
+        in_ln,
+        post_ln,
+        up,
+        wk,
+        wo,
+        wq,
+        wv,
+        bk,
+        bq,
+        bv,
+    }
+}
+
+/// Add an optional q/k/v projection bias to a single-token `[K]` projection (the
+/// single-sequence decode path). When the bias is absent (Llama) this emits no op
+/// and returns the projection unchanged.
+fn add_proj_bias(b: &mut Builder, x: Val, bias: &Option<Val>) -> Val {
+    match bias {
+        Some(bias) => b.add(&x, bias),
+        None => x,
+    }
+}
+
+/// Add an optional q/k/v projection bias to `[N, K]` projections (the prefill /
+/// batched / ragged paths): the `[K]` bias broadcasts over the leading row axis.
+/// No-op (and no emitted op) when the bias is absent.
+fn add_proj_bias_seq(b: &mut Builder, x: Val, bias: &Option<Val>, n: usize, k: usize) -> Val {
+    match bias {
+        Some(bias) => {
+            let bb = b.broadcast(bias, &[1], vec![n, k]);
+            b.add(&x, &bb)
+        }
+        None => x,
+    }
+}
+
+fn build_arg_schema(c: &Config) -> (Vec<ArgDecl>, Args) {
+    let h = c.hidden;
     let v = c.vocab;
 
     let mut decls: Vec<ArgDecl> = Vec::new();
     let mut idx = 0usize;
-    let mut take = |decls: &mut Vec<ArgDecl>, ty: Ty, loc: String| -> Val {
-        let val = Builder::arg(idx, ty.clone());
-        decls.push(ArgDecl { ty, loc });
-        idx += 1;
-        val
-    };
 
-    let embed = take(&mut decls, Ty::f32(vec![v, h]), "params['embed']".into());
-    let final_norm = take(&mut decls, Ty::f32(vec![h]), "params['final_norm']".into());
+    let embed = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::f32(vec![v, h]),
+        "params['embed']".into(),
+    );
+    let final_norm = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::f32(vec![h]),
+        "params['final_norm']".into(),
+    );
 
     let mut layers = Vec::with_capacity(c.n_layers);
     for li in 0..c.n_layers {
-        let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
-        let down = take(&mut decls, Ty::f32(vec![h, inter]), p("down"));
-        let gate = take(&mut decls, Ty::f32(vec![inter, h]), p("gate"));
-        let in_ln = take(&mut decls, Ty::f32(vec![h]), p("in_ln"));
-        let post_ln = take(&mut decls, Ty::f32(vec![h]), p("post_ln"));
-        let up = take(&mut decls, Ty::f32(vec![inter, h]), p("up"));
-        let wk = take(&mut decls, Ty::f32(vec![kv, h]), p("wk"));
-        let wo = take(&mut decls, Ty::f32(vec![qd, h]), p("wo"));
-        let wq = take(&mut decls, Ty::f32(vec![qd, h]), p("wq"));
-        let wv = take(&mut decls, Ty::f32(vec![kv, h]), p("wv"));
-        layers.push(LayerW {
-            down,
-            gate,
-            in_ln,
-            post_ln,
-            up,
-            wk,
-            wo,
-            wq,
-            wv,
-        });
+        layers.push(take_layer_weights(&mut decls, &mut idx, c, li));
     }
 
-    let token = take(&mut decls, Ty::scalar("i32"), "token".into());
-    let pos = take(&mut decls, Ty::scalar("i32"), "pos".into());
-    let cache_len = take(&mut decls, Ty::scalar("i32"), "cache_len".into());
-    let kcache = take(
+    let token = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "token".into());
+    let pos = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "pos".into());
+    let cache_len = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "cache_len".into());
+    let kcache = take_arg(
         &mut decls,
+        &mut idx,
         Ty::f32(vec![c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
         "kcache".into(),
     );
-    let vcache = take(
+    let vcache = take_arg(
         &mut decls,
+        &mut idx,
         Ty::f32(vec![c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
         "vcache".into(),
     );
@@ -242,10 +311,13 @@ pub fn emit_decode(c: &Config, sample: bool) -> String {
         // attention block
         let hn = rms_norm(&mut b, &x, &lw.in_ln, &k, h);
         let q = b.linear(&hn, &lw.wq);
+        let q = add_proj_bias(&mut b, q, &lw.bq);
         let q = b.reshape(&q, vec![nq, d]);
         let kk = b.linear(&hn, &lw.wk);
+        let kk = add_proj_bias(&mut b, kk, &lw.bk);
         let kk = b.reshape(&kk, vec![nkv, d]);
         let vv = b.linear(&hn, &lw.wv);
+        let vv = add_proj_bias(&mut b, vv, &lw.bv);
         let vv = b.reshape(&vv, vec![nkv, d]);
 
         let q = apply_rope(&mut b, &q, &cos_vec, &sin_vec, nq, d);
@@ -364,58 +436,46 @@ struct BatchedArgs {
 
 fn build_batched_arg_schema(c: &Config, bsz: usize) -> (Vec<ArgDecl>, BatchedArgs) {
     let h = c.hidden;
-    let inter = c.inter;
-    let kv = c.n_kv * c.head_dim; // 512
-    let qd = c.n_q * c.head_dim; // 2048
     let v = c.vocab;
 
     let mut decls: Vec<ArgDecl> = Vec::new();
     let mut idx = 0usize;
-    let mut take = |decls: &mut Vec<ArgDecl>, ty: Ty, loc: String| -> Val {
-        let val = Builder::arg(idx, ty.clone());
-        decls.push(ArgDecl { ty, loc });
-        idx += 1;
-        val
-    };
 
-    let embed = take(&mut decls, Ty::f32(vec![v, h]), "params['embed']".into());
-    let final_norm = take(&mut decls, Ty::f32(vec![h]), "params['final_norm']".into());
+    let embed = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::f32(vec![v, h]),
+        "params['embed']".into(),
+    );
+    let final_norm = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::f32(vec![h]),
+        "params['final_norm']".into(),
+    );
 
     let mut layers = Vec::with_capacity(c.n_layers);
     for li in 0..c.n_layers {
-        let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
-        let down = take(&mut decls, Ty::f32(vec![h, inter]), p("down"));
-        let gate = take(&mut decls, Ty::f32(vec![inter, h]), p("gate"));
-        let in_ln = take(&mut decls, Ty::f32(vec![h]), p("in_ln"));
-        let post_ln = take(&mut decls, Ty::f32(vec![h]), p("post_ln"));
-        let up = take(&mut decls, Ty::f32(vec![inter, h]), p("up"));
-        let wk = take(&mut decls, Ty::f32(vec![kv, h]), p("wk"));
-        let wo = take(&mut decls, Ty::f32(vec![qd, h]), p("wo"));
-        let wq = take(&mut decls, Ty::f32(vec![qd, h]), p("wq"));
-        let wv = take(&mut decls, Ty::f32(vec![kv, h]), p("wv"));
-        layers.push(LayerW {
-            down,
-            gate,
-            in_ln,
-            post_ln,
-            up,
-            wk,
-            wo,
-            wq,
-            wv,
-        });
+        layers.push(take_layer_weights(&mut decls, &mut idx, c, li));
     }
 
-    let token = take(&mut decls, Ty::new(vec![bsz], "i32"), "token".into());
-    let pos = take(&mut decls, Ty::scalar("i32"), "pos".into());
-    let cache_len = take(&mut decls, Ty::scalar("i32"), "cache_len".into());
-    let kcache = take(
+    let token = take_arg(
         &mut decls,
+        &mut idx,
+        Ty::new(vec![bsz], "i32"),
+        "token".into(),
+    );
+    let pos = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "pos".into());
+    let cache_len = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "cache_len".into());
+    let kcache = take_arg(
+        &mut decls,
+        &mut idx,
         Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
         "kcache".into(),
     );
-    let vcache = take(
+    let vcache = take_arg(
         &mut decls,
+        &mut idx,
         Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
         "vcache".into(),
     );
@@ -499,10 +559,13 @@ pub fn emit_decode_batched(c: &Config, bsz: usize, sample: bool) -> String {
         // attention block (RMSNorm over H reuses the [N,H] seq variant, N=B)
         let hn = rms_norm_seq(&mut b, &x, &lw.in_ln, &k, bsz, h); // [B, H]
         let q = b.linear_seq(&hn, &lw.wq); // [B, qd]
+        let q = add_proj_bias_seq(&mut b, q, &lw.bq, bsz, nq * d);
         let q = b.reshape(&q, vec![bsz, nq, d]);
         let kk = b.linear_seq(&hn, &lw.wk); // [B, kv]
+        let kk = add_proj_bias_seq(&mut b, kk, &lw.bk, bsz, nkv * d);
         let kk = b.reshape(&kk, vec![bsz, nkv, d]);
         let vv = b.linear_seq(&hn, &lw.wv); // [B, kv]
+        let vv = add_proj_bias_seq(&mut b, vv, &lw.bv, bsz, nkv * d);
         let vv = b.reshape(&vv, vec![bsz, nkv, d]);
 
         let q = apply_rope_batched(&mut b, &q, &cos_vec, &sin_vec, bsz, nq, d);
@@ -643,58 +706,56 @@ struct RaggedArgs {
 
 fn build_ragged_arg_schema(c: &Config, bsz: usize) -> (Vec<ArgDecl>, RaggedArgs) {
     let h = c.hidden;
-    let inter = c.inter;
-    let kv = c.n_kv * c.head_dim; // 512
-    let qd = c.n_q * c.head_dim; // 2048
     let v = c.vocab;
 
     let mut decls: Vec<ArgDecl> = Vec::new();
     let mut idx = 0usize;
-    let mut take = |decls: &mut Vec<ArgDecl>, ty: Ty, loc: String| -> Val {
-        let val = Builder::arg(idx, ty.clone());
-        decls.push(ArgDecl { ty, loc });
-        idx += 1;
-        val
-    };
 
-    let embed = take(&mut decls, Ty::f32(vec![v, h]), "params['embed']".into());
-    let final_norm = take(&mut decls, Ty::f32(vec![h]), "params['final_norm']".into());
+    let embed = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::f32(vec![v, h]),
+        "params['embed']".into(),
+    );
+    let final_norm = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::f32(vec![h]),
+        "params['final_norm']".into(),
+    );
 
     let mut layers = Vec::with_capacity(c.n_layers);
     for li in 0..c.n_layers {
-        let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
-        let down = take(&mut decls, Ty::f32(vec![h, inter]), p("down"));
-        let gate = take(&mut decls, Ty::f32(vec![inter, h]), p("gate"));
-        let in_ln = take(&mut decls, Ty::f32(vec![h]), p("in_ln"));
-        let post_ln = take(&mut decls, Ty::f32(vec![h]), p("post_ln"));
-        let up = take(&mut decls, Ty::f32(vec![inter, h]), p("up"));
-        let wk = take(&mut decls, Ty::f32(vec![kv, h]), p("wk"));
-        let wo = take(&mut decls, Ty::f32(vec![qd, h]), p("wo"));
-        let wq = take(&mut decls, Ty::f32(vec![qd, h]), p("wq"));
-        let wv = take(&mut decls, Ty::f32(vec![kv, h]), p("wv"));
-        layers.push(LayerW {
-            down,
-            gate,
-            in_ln,
-            post_ln,
-            up,
-            wk,
-            wo,
-            wq,
-            wv,
-        });
+        layers.push(take_layer_weights(&mut decls, &mut idx, c, li));
     }
 
-    let token = take(&mut decls, Ty::new(vec![bsz], "i32"), "token".into());
-    let pos = take(&mut decls, Ty::new(vec![bsz], "i32"), "pos".into());
-    let cache_len = take(&mut decls, Ty::new(vec![bsz], "i32"), "cache_len".into());
-    let kcache = take(
+    let token = take_arg(
         &mut decls,
+        &mut idx,
+        Ty::new(vec![bsz], "i32"),
+        "token".into(),
+    );
+    let pos = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::new(vec![bsz], "i32"),
+        "pos".into(),
+    );
+    let cache_len = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::new(vec![bsz], "i32"),
+        "cache_len".into(),
+    );
+    let kcache = take_arg(
+        &mut decls,
+        &mut idx,
         Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
         "kcache".into(),
     );
-    let vcache = take(
+    let vcache = take_arg(
         &mut decls,
+        &mut idx,
         Ty::f32(vec![bsz, c.n_layers, MAX_SEQ, c.n_kv, c.head_dim]),
         "vcache".into(),
     );
@@ -779,10 +840,13 @@ pub fn emit_decode_ragged(c: &Config, bsz: usize, sample: bool) -> String {
 
         let hn = rms_norm_seq(&mut b, &x, &lw.in_ln, &k, bsz, h); // [B, H]
         let q = b.linear_seq(&hn, &lw.wq);
+        let q = add_proj_bias_seq(&mut b, q, &lw.bq, bsz, nq * d);
         let q = b.reshape(&q, vec![bsz, nq, d]);
         let kk = b.linear_seq(&hn, &lw.wk);
+        let kk = add_proj_bias_seq(&mut b, kk, &lw.bk, bsz, nkv * d);
         let kk = b.reshape(&kk, vec![bsz, nkv, d]);
         let vv = b.linear_seq(&hn, &lw.wv);
+        let vv = add_proj_bias_seq(&mut b, vv, &lw.bv, bsz, nkv * d);
         let vv = b.reshape(&vv, vec![bsz, nkv, d]);
 
         let q = apply_rope_ragged(&mut b, &q, &cos, &sin, bsz, nq, d);
@@ -925,51 +989,42 @@ struct PrefillArgs {
 
 fn build_prefill_arg_schema(c: &Config, lp: usize) -> (Vec<ArgDecl>, PrefillArgs) {
     let h = c.hidden;
-    let inter = c.inter;
-    let kv = c.n_kv * c.head_dim; // 512
-    let qd = c.n_q * c.head_dim; // 2048
     let v = c.vocab;
 
     let mut decls: Vec<ArgDecl> = Vec::new();
     let mut idx = 0usize;
-    let mut take = |decls: &mut Vec<ArgDecl>, ty: Ty, loc: String| -> Val {
-        let val = Builder::arg(idx, ty.clone());
-        decls.push(ArgDecl { ty, loc });
-        idx += 1;
-        val
-    };
 
-    let embed = take(&mut decls, Ty::f32(vec![v, h]), "params['embed']".into());
-    let final_norm = take(&mut decls, Ty::f32(vec![h]), "params['final_norm']".into());
+    let embed = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::f32(vec![v, h]),
+        "params['embed']".into(),
+    );
+    let final_norm = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::f32(vec![h]),
+        "params['final_norm']".into(),
+    );
 
     let mut layers = Vec::with_capacity(c.n_layers);
     for li in 0..c.n_layers {
-        let p = |k: &str| format!("params['layers'][{}]['{}']", li, k);
-        let down = take(&mut decls, Ty::f32(vec![h, inter]), p("down"));
-        let gate = take(&mut decls, Ty::f32(vec![inter, h]), p("gate"));
-        let in_ln = take(&mut decls, Ty::f32(vec![h]), p("in_ln"));
-        let post_ln = take(&mut decls, Ty::f32(vec![h]), p("post_ln"));
-        let up = take(&mut decls, Ty::f32(vec![inter, h]), p("up"));
-        let wk = take(&mut decls, Ty::f32(vec![kv, h]), p("wk"));
-        let wo = take(&mut decls, Ty::f32(vec![qd, h]), p("wo"));
-        let wq = take(&mut decls, Ty::f32(vec![qd, h]), p("wq"));
-        let wv = take(&mut decls, Ty::f32(vec![kv, h]), p("wv"));
-        layers.push(LayerW {
-            down,
-            gate,
-            in_ln,
-            post_ln,
-            up,
-            wk,
-            wo,
-            wq,
-            wv,
-        });
+        layers.push(take_layer_weights(&mut decls, &mut idx, c, li));
     }
 
-    let tokens = take(&mut decls, Ty::new(vec![lp], "i32"), "tokens".into());
-    let positions = take(&mut decls, Ty::new(vec![lp], "i32"), "positions".into());
-    let real_len = take(&mut decls, Ty::scalar("i32"), "real_len".into());
+    let tokens = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::new(vec![lp], "i32"),
+        "tokens".into(),
+    );
+    let positions = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::new(vec![lp], "i32"),
+        "positions".into(),
+    );
+    let real_len = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "real_len".into());
 
     (
         decls,
@@ -1064,10 +1119,13 @@ pub fn emit_prefill(c: &Config, sample: bool) -> String {
         // attention block
         let hn = rms_norm_seq(&mut b, &x, &lw.in_ln, &k, lp, h); // [Lp, H]
         let q = b.linear_seq(&hn, &lw.wq); // [Lp, qd]
+        let q = add_proj_bias_seq(&mut b, q, &lw.bq, lp, nq * d);
         let q = b.reshape(&q, vec![lp, nq, d]);
         let kk = b.linear_seq(&hn, &lw.wk); // [Lp, kv]
+        let kk = add_proj_bias_seq(&mut b, kk, &lw.bk, lp, nkv * d);
         let kk = b.reshape(&kk, vec![lp, nkv, d]);
         let vv = b.linear_seq(&hn, &lw.wv); // [Lp, kv]
+        let vv = add_proj_bias_seq(&mut b, vv, &lw.bv, lp, nkv * d);
         let vv = b.reshape(&vv, vec![lp, nkv, d]);
 
         let q = apply_rope_seq(&mut b, &q, &cos, &sin, lp, nq, d);

--- a/src/lib/mlxcel-xla/src/emitter/rope.rs
+++ b/src/lib/mlxcel-xla/src/emitter/rope.rs
@@ -1,5 +1,7 @@
-//! RoPE tables, byte-for-byte with HF `_compute_llama3_parameters` and the JAX
-//! reference `llama3_inv_freq` / `rope_tables` in spike/openxla/model_jax.py.
+//! RoPE tables. The llama3 path is byte-for-byte with HF
+//! `_compute_llama3_parameters` and the JAX reference `llama3_inv_freq` /
+//! `rope_tables` in spike/openxla/model_jax.py; the plain path (Qwen2, #449 M3
+//! Stage B) is the textbook `1 / theta^(2i/d)`.
 //!
 //! All math is done in f64 (matching numpy's default), then cos/sin are cast to
 //! f32 for the baked constant tables, exactly as the JAX path did
@@ -7,14 +9,45 @@
 //! rather than emitting in-graph `stablehlo.cosine` removes any dependence on the
 //! runtime's transcendental precision.
 
-use super::config::Config;
+use super::config::{Config, RopeScaling};
 
-/// inv_freq[i], i in 0..head_dim/2, with llama3 scaling. Returns f64.
-pub fn llama3_inv_freq(c: &Config) -> Vec<f64> {
+/// inv_freq[i], i in 0..head_dim/2, in f64. Dispatches on the config's RoPE
+/// scheme: plain RoPE (Qwen2) or llama3 scaling (Llama-3.x).
+pub fn inv_freq(c: &Config) -> Vec<f64> {
+    match &c.rope {
+        RopeScaling::Plain => plain_inv_freq(c),
+        RopeScaling::Llama3 {
+            factor,
+            low_freq_factor,
+            high_freq_factor,
+            orig_ctx,
+        } => llama3_inv_freq(c, *factor, *low_freq_factor, *high_freq_factor, *orig_ctx),
+    }
+}
+
+/// Plain RoPE base frequencies: `inv_freq[i] = 1 / theta^((2i)/head_dim)`.
+fn plain_inv_freq(c: &Config) -> Vec<f64> {
+    let half = c.head_dim / 2;
+    (0..half)
+        .map(|i| {
+            let exponent = (2 * i) as f64 / c.head_dim as f64;
+            1.0 / c.rope_theta.powf(exponent)
+        })
+        .collect()
+}
+
+/// llama3-scaled base frequencies. Returns f64.
+fn llama3_inv_freq(
+    c: &Config,
+    factor: f64,
+    low_freq_factor: f64,
+    high_freq_factor: f64,
+    orig_ctx: usize,
+) -> Vec<f64> {
     let half = c.head_dim / 2;
     let mut inv = vec![0.0f64; half];
-    let low_wl = c.orig_ctx as f64 / c.low_freq_factor;
-    let high_wl = c.orig_ctx as f64 / c.high_freq_factor;
+    let low_wl = orig_ctx as f64 / low_freq_factor;
+    let high_wl = orig_ctx as f64 / high_freq_factor;
     for (i, slot) in inv.iter_mut().enumerate() {
         // base = 1 / theta^((2i)/head_dim)
         let exponent = (2 * i) as f64 / c.head_dim as f64;
@@ -23,14 +56,14 @@ pub fn llama3_inv_freq(c: &Config) -> Vec<f64> {
 
         // inv = where(wavelen > low_wl, base/factor, base)
         let mut v = if wavelen > low_wl {
-            base / c.factor
+            base / factor
         } else {
             base
         };
         // smoothed = (1 - smooth) * inv/factor + smooth * inv
-        let smooth = (c.orig_ctx as f64 / wavelen - c.low_freq_factor)
-            / (c.high_freq_factor - c.low_freq_factor);
-        let smoothed = (1.0 - smooth) * v / c.factor + smooth * v;
+        let smooth =
+            (orig_ctx as f64 / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor);
+        let smoothed = (1.0 - smooth) * v / factor + smooth * v;
         // is_medium = high_wl <= wavelen <= low_wl (wavelen is finite, so this is
         // the same as the JAX `!(wavelen < high_wl) && !(wavelen > low_wl)`).
         let is_medium = wavelen >= high_wl && wavelen <= low_wl;
@@ -45,7 +78,7 @@ pub fn llama3_inv_freq(c: &Config) -> Vec<f64> {
 /// Build cos and sin tables of shape [max_seq, head_dim] as flat row-major f32.
 /// emb = concat([freqs, freqs], -1) where freqs = outer(pos, inv_freq).
 pub fn rope_tables(c: &Config, max_seq: usize) -> (Vec<f32>, Vec<f32>) {
-    let inv = llama3_inv_freq(c);
+    let inv = inv_freq(c);
     let half = c.head_dim / 2;
     let d = c.head_dim;
     let mut cos = vec![0.0f32; max_seq * d];

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -24,7 +24,9 @@
 //! shim, which keeps the weights resident on the device and threads the KV cache
 //! across steps. Then [`IreeLlama::prefill`] / [`IreeLlama::decode`] are token-in
 //! / token-out. Emitting from config (issue #449 M3 Stage 2d) replaced the bundled
-//! Llama-3.2-1B `.mlir` assets, so any Llama-architecture checkpoint loads.
+//! Llama-3.2-1B `.mlir` assets, so any checkpoint of a supported architecture
+//! loads: Llama (any size) and Qwen2 (plain RoPE + q/k/v bias; Stage B), the
+//! latter adding its bias tensors to `weight_names` to match the emitted graph.
 //!
 //! Proven token-exact against the HF temp-0 reference in
 //! `spike/openxla/artifacts/results.json` before being vendored from the
@@ -111,8 +113,10 @@ unsafe extern "C" {
 pub(crate) const RAGGED_B_VALUES: &[usize] = &[4, 8];
 
 /// The weight names in the emitter's exact arg order: embed, final_norm, then per
-/// layer down, gate, in_ln, post_ln, up, wk, wo, wq, wv. The layer count comes
-/// from the model config so the order matches the emitted graph's args.
+/// layer down, gate, in_ln, post_ln, up, wk, wo, wq, wv, and — for a `qkv_bias`
+/// architecture (Qwen2) — the k/q/v projection biases. The layer count and the
+/// presence of biases come from the model config so the order matches the emitted
+/// graph's args (`take_layer_weights` in `emitter/model.rs`).
 fn weight_names(cfg: &Config) -> Vec<String> {
     let mut names = vec![
         "model.embed_tokens.weight".to_string(),
@@ -132,6 +136,17 @@ fn weight_names(cfg: &Config) -> Vec<String> {
             "self_attn.v_proj.weight",
         ] {
             names.push(format!("{p}{suf}"));
+        }
+        // Qwen2 q/k/v projection biases, appended per layer in the same k/q/v
+        // order `take_layer_weights` adds them to the emitted graph args.
+        if cfg.qkv_bias {
+            for suf in [
+                "self_attn.k_proj.bias",
+                "self_attn.q_proj.bias",
+                "self_attn.v_proj.bias",
+            ] {
+                names.push(format!("{p}{suf}"));
+            }
         }
     }
     names


### PR DESCRIPTION
## Summary

Stage B of config.json-driven multi-architecture emit (#449 M3 Stage 2d). Stage A (#480) made the OpenXLA engine emit its StableHLO graphs from `config.json` at load but accepted only the Llama architecture. This adds **Qwen2**, whose only deltas from Llama are **plain RoPE** (no `rope_scaling`) and a **q/k/v projection bias** (`o_proj` and the MLP have none). Both are now config-driven, so any Qwen2 checkpoint emits and runs.

## What changed

- **`emitter/config.rs`** — a `RopeScaling` enum (`Plain` | `Llama3{...}`) and a `qkv_bias` flag. `from_json` accepts `model_type: "qwen2"` (`qkv_bias = true`), treats an absent `rope_scaling` as plain RoPE, keeps the tied-embedding requirement, and rejects untested combos (unsupported `model_type`, untied embeddings, non-`llama3` scaling, a `llama` checkpoint with `attention_bias`) with a clear Stage-B/C message.
- **`emitter/rope.rs`** — `inv_freq` dispatches on the scheme: plain is `1/theta^(2i/d)`, llama3 is unchanged, so the Llama table stays byte-identical.
- **`emitter/model.rs`** — a shared `take_layer_weights` orders the per-layer weights and biases identically across the single / batched / ragged / prefill graphs, so the emitted arg order always matches `weight_names`. The bias is added after the q/k/v linear (a vector add for single-token decode, a broadcast-add for the seq paths). The no-bias path emits no extra op, so Llama is byte-identical.
- **`iree.rs`** — `weight_names` appends `self_attn.{k,q,v}_proj.bias` per layer in the same k/q/v order the schema takes them, so the loaded weight buffers line up with the emitted graph args.
- **Assets / harness** — a `qwen2.5-0.5b/config.json` fixture, an `xla_oracle_check` example (token-exactness gate vs an external oracle), and `spike/openxla/qwen_oracle.py` (the HF reference generator).

## Validation

| Gate | Result |
|------|--------|
| `cargo test -p mlxcel-xla` | 31 pass: 6 new Qwen2 tests (parse, rejection, per-graph bias adds, k/q/v arg order, bias-free Llama, plain-RoPE table) + the Llama **byte-exact regression** intact |
| clippy `-D warnings` | clean: no-feature, `--features iree`, `mlxcel --features xla-iree` |
| E2E token-exact vs HF transformers (GB10 CUDA, Qwen2.5-0.5B-bf16) | **PASS** — 40/40 greedy tokens match the fp32 HF reference |
| E2E reference-equivalence (ragged b4/b8) | **PASS** — B=4 4.5x, B=8 4.8x over sequential |

The token-exact-vs-HF gate is the architecture-correctness proof: it confirms the emitted graph computes Qwen2 itself correctly end to end (bias placement, plain-RoPE table, GQA grouping for 14q/2kv), not just self-consistency. `n_q * head_dim = hidden = 896` for Qwen2.5, so the emitter's existing square-`wo` convention holds.

## Compatibility

No breaking changes. Llama-3.2-1B and other Llama sizes behave identically (byte-exact). Default and CI builds compile with the XLA backend absent; the new example is gated behind `xla-iree`.

Refs #449.
