### PR TITLE
feat: load sharded and f16/f32 checkpoints on the OpenXLA path (#449 M3 Stage 2d)

### DIFF
--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -20,7 +20,10 @@
 //! [`Config`], (2) emits the `prefill` / `decode_step` StableHLO graphs from that
 //! config (the #451 emitter, ending in an on-device argmax) and compiles them to
 //! vmfbs with the dist's `iree-compile`, cached by content hash, (3) loads the
-//! bf16 weights as f32 in the emitter's arg order, and (4) hands all of it to the
+//! weights as f32 (widening bf16 / f16, or copying f32) in the emitter's arg
+//! order, from either a single-file `model.safetensors` or a sharded checkpoint
+//! (via its `model.safetensors.index.json`, which is how the big untied models
+//! ship), and (4) hands all of it to the
 //! shim, which keeps the weights resident on the device and threads the KV cache
 //! across steps. Then [`IreeLlama::prefill`] / [`IreeLlama::decode`] are token-in
 //! / token-out. Emitting from config (issue #449 M3 Stage 2d) replaced the bundled
@@ -47,6 +50,7 @@ use memmap2::Mmap;
 use safetensors::{Dtype, SafeTensors};
 
 use crate::emitter::{Config, emit_decode, emit_decode_ragged, emit_prefill};
+use crate::weights::{bf16_to_f32, f16_to_f32, f32_le_to_f32};
 
 /// Prefill bucket baked into the emitted `prefill` graph (`tensor<256xi32>`,
 /// == MAX_SEQ, so it covers any prompt the 256-slot KV cache holds).
@@ -160,14 +164,6 @@ fn weight_names(cfg: &Config) -> Vec<String> {
         }
     }
     names
-}
-
-/// bf16 little-endian bytes -> f32 (bf16 is the high 16 bits of f32).
-fn bf16_to_f32(bytes: &[u8]) -> Vec<f32> {
-    bytes
-        .chunks_exact(2)
-        .map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16))
-        .collect()
 }
 
 /// Locate the IREE distribution: a runtime `IREE_DIST` override first, else the
@@ -312,44 +308,107 @@ fn compile_vmfbs(device: &str, cfg: &Config) -> Result<(PathBuf, PathBuf), Strin
     compile_pair(device, &prefill, "prefill", &decode, "decode")
 }
 
+/// Map each needed weight name to the safetensors file that holds it, in the same
+/// order as `names`. A single-file checkpoint (`model.safetensors` present) maps
+/// every name to that one file; a sharded checkpoint (no `model.safetensors`, only
+/// `model-0000k-of-...safetensors` shards) reads `model.safetensors.index.json`'s
+/// `weight_map`. The big untied models (e.g. Llama-3.1-8B) ship sharded, so this
+/// is what lets them load. A model dir that has BOTH a `model.safetensors` and an
+/// index uses the single file (the index then just points back at it).
+fn resolve_weight_shards(model_dir: &Path, names: &[String]) -> Result<Vec<PathBuf>, String> {
+    let single = model_dir.join("model.safetensors");
+    if single.exists() {
+        return Ok(vec![single; names.len()]);
+    }
+    let index = model_dir.join("model.safetensors.index.json");
+    let text = std::fs::read_to_string(&index).map_err(|e| {
+        format!(
+            "no model.safetensors and no readable model.safetensors.index.json in {}: {e}",
+            model_dir.display()
+        )
+    })?;
+    let v: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| format!("parse {}: {e}", index.display()))?;
+    let map = v
+        .get("weight_map")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| format!("{}: missing object `weight_map`", index.display()))?;
+    names
+        .iter()
+        .map(|name| {
+            map.get(name)
+                .and_then(serde_json::Value::as_str)
+                .map(|f| model_dir.join(f))
+                .ok_or_else(|| format!("{}: weight_map has no entry for `{name}`", index.display()))
+        })
+        .collect()
+}
+
 /// Load the weights bf16 -> f32 in the emitter's arg order, returning the owned
 /// f32 buffers (kept alive until the shim copies them) plus the flat (ptr, rank,
 /// dims) arrays the C ABI takes. `cfg` fixes the layer count and weight order.
+///
+/// Single-file and sharded checkpoints both load: [`resolve_weight_shards`] maps
+/// each weight to its file, and the weights are read shard by shard (each shard
+/// mmap'd exactly once, its tensors copied out as owned f32) and placed back into
+/// the emitter's arg order by index, so the buffers line up with the graph args
+/// regardless of how the checkpoint was split.
 #[allow(clippy::type_complexity)]
 fn load_weights(
     model_dir: &Path,
     cfg: &Config,
 ) -> Result<(Vec<Vec<f32>>, Vec<c_int>, Vec<i64>), String> {
-    let st_path = model_dir.join("model.safetensors");
-    let file = File::open(&st_path).map_err(|e| format!("open {}: {e}", st_path.display()))?;
-    // Safety: the file is read-only for the lifetime of the mmap below.
-    let mmap =
-        unsafe { Mmap::map(&file) }.map_err(|e| format!("mmap {}: {e}", st_path.display()))?;
-    let st = SafeTensors::deserialize(&mmap).map_err(|e| format!("parse safetensors: {e}"))?;
-
     let names = weight_names(cfg);
-    let mut bufs: Vec<Vec<f32>> = Vec::with_capacity(names.len());
-    let mut ranks: Vec<c_int> = Vec::with_capacity(names.len());
-    let mut dims: Vec<i64> = Vec::with_capacity(names.len() * 4);
-    for name in &names {
-        let t = st.tensor(name).map_err(|e| format!("weight {name}: {e}"))?;
-        if t.dtype() != Dtype::BF16 {
-            return Err(format!(
-                "weight {name} dtype {:?}, expected BF16",
-                t.dtype()
-            ));
+    let shard_paths = resolve_weight_shards(model_dir, &names)?;
+
+    // Group weight indices by shard so each shard file is opened/mmap'd once; the
+    // results are placed by index, preserving the emitter's arg order.
+    let mut by_shard: std::collections::BTreeMap<&Path, Vec<usize>> =
+        std::collections::BTreeMap::new();
+    for (i, p) in shard_paths.iter().enumerate() {
+        by_shard.entry(p.as_path()).or_default().push(i);
+    }
+
+    let n = names.len();
+    let mut bufs: Vec<Vec<f32>> = vec![Vec::new(); n];
+    let mut ranks: Vec<c_int> = vec![0; n];
+    let mut dims: Vec<i64> = vec![0; n * 4];
+    for (shard, idxs) in by_shard {
+        let file = File::open(shard).map_err(|e| format!("open {}: {e}", shard.display()))?;
+        // Safety: the file is read-only for the lifetime of the mmap below.
+        let mmap =
+            unsafe { Mmap::map(&file) }.map_err(|e| format!("mmap {}: {e}", shard.display()))?;
+        let st = SafeTensors::deserialize(&mmap)
+            .map_err(|e| format!("parse {}: {e}", shard.display()))?;
+        for &i in &idxs {
+            let name = &names[i];
+            let t = st
+                .tensor(name)
+                .map_err(|e| format!("weight {name} in {}: {e}", shard.display()))?;
+            // Widen to f32 (the graph's weight dtype). bf16 and f16 are the common
+            // checkpoint dtypes; f32 is a passthrough. The widening is exact for
+            // all three, so it matches HF's f32 reference.
+            let data = match t.dtype() {
+                Dtype::BF16 => bf16_to_f32(t.data()),
+                Dtype::F16 => f16_to_f32(t.data()),
+                Dtype::F32 => f32_le_to_f32(t.data()),
+                other => {
+                    return Err(format!(
+                        "weight {name} dtype {other:?}, expected BF16/F16/F32 \
+                         (a quantized checkpoint must be dequantized first)"
+                    ));
+                }
+            };
+            let shape = t.shape();
+            if shape.len() > 4 {
+                return Err(format!("weight {name} rank {} > 4", shape.len()));
+            }
+            ranks[i] = shape.len() as c_int;
+            for (k, &s) in shape.iter().enumerate() {
+                dims[i * 4 + k] = s as i64;
+            }
+            bufs[i] = data;
         }
-        let shape = t.shape();
-        if shape.len() > 4 {
-            return Err(format!("weight {name} rank {} > 4", shape.len()));
-        }
-        ranks.push(shape.len() as c_int);
-        let mut d4 = [0i64; 4];
-        for (k, &s) in shape.iter().enumerate() {
-            d4[k] = s as i64;
-        }
-        dims.extend_from_slice(&d4);
-        bufs.push(bf16_to_f32(t.data()));
     }
     Ok((bufs, ranks, dims))
 }

--- a/src/lib/mlxcel-xla/src/lib.rs
+++ b/src/lib/mlxcel-xla/src/lib.rs
@@ -66,6 +66,13 @@ mod batch;
 #[cfg_attr(not(feature = "iree"), allow(dead_code))]
 mod sampler;
 
+// Safetensors weight-dtype widening (#449 M3 Stage 2d). Pure Rust bf16/f16 -> f32
+// converters; present under `iree` (the loader widens weights with them) and under
+// `test` (the f16 conversion is unit-tested without the IREE runtime).
+#[cfg(any(feature = "iree", test))]
+#[cfg_attr(not(feature = "iree"), allow(dead_code))]
+mod weights;
+
 // Rust-native StableHLO emitter (#449 M3 Stage 2d, ported from the #451 spike).
 // Pure Rust; present under `iree` (the engine emits its graphs from config.json at
 // load) and under `test` (the byte-exact regression runs without the IREE

--- a/src/lib/mlxcel-xla/src/weights.rs
+++ b/src/lib/mlxcel-xla/src/weights.rs
@@ -1,0 +1,118 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Widen safetensors weight bytes to f32 (the dtype the emitted StableHLO graphs
+//! take), for the IREE loader (issue #449 M3 Stage 2d). bf16 and f16 are the
+//! common checkpoint dtypes; f32 is a passthrough. Every conversion is exact
+//! (f32 represents every bf16/f16 value), so the widened weights match HF's own
+//! f32 cast, which the token-exact oracle gate depends on.
+
+/// bf16 little-endian bytes -> f32 (bf16 is the high 16 bits of f32).
+pub(crate) fn bf16_to_f32(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(2)
+        .map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16))
+        .collect()
+}
+
+/// One IEEE 754 half (f16) -> f32. The arithmetic forms are exact: a normal's
+/// `1 + mant/1024` is a dyadic with denominator 2^10 and the `2^(exp-15)` / `2^-24`
+/// scales are exact powers of two, so the widening is bit-for-bit.
+pub(crate) fn half_to_f32(h: u16) -> f32 {
+    let sign = if h >> 15 == 1 { -1.0 } else { 1.0 };
+    let exp = (h >> 10) & 0x1f;
+    let mant = (h & 0x3ff) as f32;
+    match exp {
+        0 => sign * mant * 2f32.powi(-24),           // zero / subnormal
+        0x1f if mant == 0.0 => sign * f32::INFINITY, // +/- inf
+        0x1f => f32::NAN,                            // nan
+        _ => sign * (1.0 + mant / 1024.0) * 2f32.powi(exp as i32 - 15), // normal
+    }
+}
+
+/// f16 little-endian bytes -> f32, via a 65536-entry `u16 -> f32` lookup table.
+/// The table is built once (every f16 bit pattern, exact) and then each element
+/// is a single index, so widening a multi-GB checkpoint is memory-bound rather
+/// than arithmetic-bound (an 8B-param checkpoint otherwise spends minutes in
+/// per-element `powi`).
+pub(crate) fn f16_to_f32(bytes: &[u8]) -> Vec<f32> {
+    let table: Vec<f32> = (0..=u16::MAX).map(half_to_f32).collect();
+    bytes
+        .chunks_exact(2)
+        .map(|c| table[u16::from_le_bytes([c[0], c[1]]) as usize])
+        .collect()
+}
+
+/// f32 little-endian bytes -> f32 (a plain reinterpret, for f32 checkpoints).
+pub(crate) fn f32_le_to_f32(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// f16 widening is exact against `f32 as` for representative values: zero, one,
+    /// a fraction, a negative, the max normal, and a subnormal.
+    #[test]
+    fn half_to_f32_matches_reference_values() {
+        // (f16 bits, expected f32) pairs.
+        let cases: [(u16, f32); 7] = [
+            (0x0000, 0.0),            // +0
+            (0x8000, -0.0),           // -0
+            (0x3c00, 1.0),            // 1.0
+            (0x3800, 0.5),            // 0.5
+            (0xc000, -2.0),           // -2.0
+            (0x7bff, 65504.0),        // max normal f16
+            (0x0001, 2f32.powi(-24)), // smallest positive subnormal
+        ];
+        for (bits, want) in cases {
+            let got = half_to_f32(bits);
+            assert_eq!(got, want, "f16 {bits:#06x} -> {got} != {want}");
+        }
+    }
+
+    /// inf / nan f16 encodings widen to f32 inf / nan.
+    #[test]
+    fn half_to_f32_handles_inf_and_nan() {
+        assert!(half_to_f32(0x7c00).is_infinite() && half_to_f32(0x7c00) > 0.0);
+        assert!(half_to_f32(0xfc00).is_infinite() && half_to_f32(0xfc00) < 0.0);
+        assert!(half_to_f32(0x7e00).is_nan());
+    }
+
+    /// The byte converters round-trip a little-endian buffer of two values.
+    #[test]
+    fn f16_byte_buffer_widens_both_lanes() {
+        // 1.0 (0x3c00) then -2.0 (0xc000), little-endian.
+        let bytes = [0x00, 0x3c, 0x00, 0xc0];
+        assert_eq!(f16_to_f32(&bytes), vec![1.0, -2.0]);
+    }
+
+    /// bf16 widening keeps the high 16 bits (1.0 -> 0x3f80).
+    #[test]
+    fn bf16_byte_buffer_widens() {
+        let bytes = [0x80, 0x3f]; // bf16 1.0, little-endian
+        assert_eq!(bf16_to_f32(&bytes), vec![1.0]);
+    }
+
+    /// f32 passthrough reinterprets 4-byte lanes.
+    #[test]
+    fn f32_passthrough_reinterprets() {
+        let bytes = 1.5f32.to_le_bytes();
+        assert_eq!(f32_le_to_f32(&bytes), vec![1.5]);
+    }
+}


### PR DESCRIPTION
## Summary

The OpenXLA weight loader read only a single-file `model.safetensors` and accepted only BF16, so the big checkpoints could not load: they ship as multi-file **shards**, and most (e.g. Llama-3.1-8B) store **F16**, not BF16. With untied LM heads now supported (#482), this is the remaining gap before those models run. Part of #449 M3 Stage 2d.

## What changed (`mlxcel-xla`)

- **Sharded loading** (`iree.rs`): when `model.safetensors` is absent, `resolve_weight_shards` reads `model.safetensors.index.json`'s `weight_map` to find each weight's shard. `load_weights` groups the needed weights by shard, mmaps each shard exactly once, and places the results back into the emitter's arg order by index, so the positional weight→arg binding is unchanged. A dir with both a single file and an index uses the single file.
- **Dtype widening** (new `weights` module): widens BF16 / F16 to f32 (or copies f32). Exact for all three (f32 represents every BF16/F16 value), so it matches HF's own f32 cast. F16 goes through a 65536-entry lookup table built from `half_to_f32`, so widening a multi-GB checkpoint is memory-bound rather than spending minutes in per-element `powi`.

## Validation

**Unit (`cargo test -p mlxcel-xla`, 38 pass):** the `weights` conversions against reference f16 values (zero, normal, subnormal, max normal, inf, nan) plus bf16 and f32 lanes.

**E2E, CUDA on GB10:**

| Gate | Model | Result |
|---|---|---|
| Split-equivalence | Qwen2.5-0.5B, 2-shard copy (same weights, no single file) | TOKEN-EXACT vs single-file oracle |
| Genuine | Llama-3.1-8B (F16, 4 shards, untied, llama3 RoPE) | TOKEN-EXACT vs HF fp32 oracle |

The split-equivalence isolates the shard-read logic on a fast model; the Llama-3.1-8B run exercises sharding + F16 + the untied head at 8B scale together.

## Notes

- Quantized checkpoints (4bit/8bit) are still rejected with a clear message (dequantization is a separate concern).
- Stacked on #482 conceptually but branched from `main` (independent of the untied diff; this PR only touches the loader).

Refs #449.
