### PR TITLE
feat: serve Gemma2 on the OpenXLA path (single-sequence) (#449 M3 Stage 2d)

### DIFF
--- a/src/lib/mlxcel-xla/src/emitter/builder.rs
+++ b/src/lib/mlxcel-xla/src/emitter/builder.rs
@@ -356,6 +356,9 @@ impl Builder {
     pub fn rsqrt(&mut self, a: &Val) -> Val {
         self.unary("rsqrt", a)
     }
+    pub fn tanh(&mut self, a: &Val) -> Val {
+        self.unary("tanh", a)
+    }
 
     /// `compare DIR, a, b, SIGNED|FLOAT` -> i1 tensor of the same shape.
     pub fn compare(&mut self, dir: &str, a: &Val, b: &Val, kind: &str) -> Val {

--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -60,6 +60,21 @@ pub struct Config {
     /// an unquantized bf16/f16/f32 checkpoint). The graph itself is unchanged (it
     /// runs in f32); the loader dequantizes the packed weights at load.
     pub quantization: Option<QuantConfig>,
+    /// Gemma2 architecture switch. When true the emitter scales the input
+    /// embeddings by `sqrt(hidden)`, uses `(1 + weight)` RMSNorm, a GeGLU
+    /// (`gelu_tanh`) MLP, a post-norm on each sublayer (four norms per layer), and
+    /// attention / final logit soft-capping; `o_proj` is non-square
+    /// (`n_q*head_dim != hidden`). Llama / Qwen2 keep their existing path.
+    pub gemma2: bool,
+    /// Gemma2 query pre-attention scale base: the attention score scale is
+    /// `query_pre_attn_scalar^-0.5` (Gemma2; can differ from `head_dim`). `None`
+    /// uses `head_dim^-0.5` (Llama / Qwen2).
+    pub query_pre_attn_scalar: Option<f64>,
+    /// Gemma2 attention logit soft-cap: `softcap * tanh(scores / softcap)` on the
+    /// pre-mask scores. `None` for Llama / Qwen2.
+    pub attn_logit_softcap: Option<f32>,
+    /// Gemma2 final logit soft-cap on the LM-head logits. `None` for Llama / Qwen2.
+    pub final_logit_softcap: Option<f32>,
 }
 
 impl Config {
@@ -84,6 +99,10 @@ impl Config {
             qkv_bias: false,
             tie_word_embeddings: true,
             quantization: None,
+            gemma2: false,
+            query_pre_attn_scalar: None,
+            attn_logit_softcap: None,
+            final_logit_softcap: None,
         }
     }
 
@@ -101,6 +120,7 @@ impl Config {
             serde_json::from_str(s).map_err(|e| format!("parse config.json: {e}"))?;
 
         let model_type = v.get("model_type").and_then(serde_json::Value::as_str);
+        let gemma2 = model_type == Some("gemma2");
         // Qwen2 always has a q/k/v projection bias (the HF `Qwen2Attention` hard-
         // codes `bias=True`), and it is not a `config.json` field, so it is keyed
         // off the architecture rather than read.
@@ -119,10 +139,11 @@ impl Config {
                 false
             }
             Some("qwen2") => true,
+            Some("gemma2") => false,
             other => {
                 return Err(format!(
-                    "the OpenXLA emitter supports the Llama and Qwen2 architectures; \
-                     config.json model_type = {other:?} (Gemma / others are a follow-up)"
+                    "the OpenXLA emitter supports the Llama, Qwen2, and Gemma2 architectures; \
+                     config.json model_type = {other:?} (other Gemma variants are a follow-up)"
                 ));
             }
         };
@@ -213,6 +234,26 @@ impl Config {
             }
         };
 
+        // Gemma2 logit soft-caps and the query pre-attention scale base (read only
+        // for a gemma2 checkpoint; the scale defaults to `head_dim` if absent).
+        let (query_pre_attn_scalar, attn_logit_softcap, final_logit_softcap) = if gemma2 {
+            (
+                Some(
+                    v.get("query_pre_attn_scalar")
+                        .and_then(serde_json::Value::as_f64)
+                        .unwrap_or(head_dim as f64),
+                ),
+                v.get("attn_logit_softcapping")
+                    .and_then(serde_json::Value::as_f64)
+                    .map(|x| x as f32),
+                v.get("final_logit_softcapping")
+                    .and_then(serde_json::Value::as_f64)
+                    .map(|x| x as f32),
+            )
+        } else {
+            (None, None, None)
+        };
+
         Ok(Config {
             hidden,
             inter: u("intermediate_size")?,
@@ -227,6 +268,10 @@ impl Config {
             qkv_bias,
             tie_word_embeddings,
             quantization,
+            gemma2,
+            query_pre_attn_scalar,
+            attn_logit_softcap,
+            final_logit_softcap,
         })
     }
 
@@ -241,8 +286,19 @@ impl Config {
         self.n_q / self.n_kv
     }
 
-    /// Attention scale head_dim^-0.5.
+    /// Attention score scale. Llama / Qwen2 use `head_dim^-0.5`; Gemma2 uses
+    /// `query_pre_attn_scalar^-0.5` (computed in f64 to match HF, since it can
+    /// differ from `head_dim`). The Llama / Qwen2 branch is unchanged.
     pub fn scale(&self) -> f32 {
-        (self.head_dim as f32).powf(-0.5)
+        match self.query_pre_attn_scalar {
+            Some(q) => q.powf(-0.5) as f32,
+            None => (self.head_dim as f32).powf(-0.5),
+        }
+    }
+
+    /// Gemma2 input-embedding normalizer `sqrt(hidden)` (computed in f64 then
+    /// narrowed, matching HF's `hidden_size**0.5` cast to the activation dtype).
+    pub fn embed_normalizer(&self) -> f32 {
+        (self.hidden as f64).sqrt() as f32
     }
 }

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -19,14 +19,15 @@
 //! `config.json` at load, instead of being pinned to the bundled Llama-3.2-1B
 //! `.mlir` assets.
 //!
-//! Scope: the Llama and Qwen2 architectures (RMSNorm, SwiGLU MLP, GQA, tied or
-//! untied embeddings). The `Config` is parameterized by dimensions, so any
-//! checkpoint of a supported architecture (any size) emits correctly. The
-//! architecture switches the emitter branches on are the RoPE kind (llama3 scaling
-//! for Llama, plain for Qwen2), whether the q/k/v projections carry a bias (Qwen2,
-//! Stage B), and whether the LM head is tied to the token embedding or a separate
-//! `lm_head.weight` (untied, e.g. Llama-3.1-8B); other architectures (e.g. Gemma
-//! GeGLU / softcap) are a follow-up that extends the emitter and `from_json`.
+//! Scope: the Llama, Qwen2, and Gemma2 architectures. The `Config` is
+//! parameterized by dimensions, so any checkpoint of a supported architecture (any
+//! size) emits correctly. The architecture switches the emitter branches on are
+//! the RoPE kind (llama3 scaling for Llama, plain for Qwen2 / Gemma2), whether the
+//! q/k/v projections carry a bias (Qwen2), whether the LM head is tied or a
+//! separate `lm_head.weight` (untied, e.g. Llama-3.1-8B), and the `gemma2` switch
+//! (embedding scale, `(1+w)` RMSNorm, GeGLU, a four-norm layer, attention / final
+//! logit soft-cap, non-square `o_proj`). Gemma2 is single-sequence only so far;
+//! the batched / ragged serve graphs are a follow-up.
 //!
 //! Pure Rust (no IREE), so it compiles and is unit-tested without the `iree`
 //! feature; only the IREE engine consumes it. The bundled `.mlir` assets remain
@@ -84,6 +85,10 @@ mod tests {
             qkv_bias,
             tie_word_embeddings: true,
             quantization: None,
+            gemma2: false,
+            query_pre_attn_scalar: None,
+            attn_logit_softcap: None,
+            final_logit_softcap: None,
         }
     }
 
@@ -142,16 +147,17 @@ mod tests {
         assert_eq!(c.eps, 1e-6);
     }
 
-    /// A non-Llama/Qwen2 architecture and an unsupported `rope_scaling` are each
-    /// rejected with a clear message rather than mis-emitted. (Untied embeddings
-    /// are no longer rejected; see `from_json_accepts_untied_embeddings`.)
+    /// A non-Llama/Qwen2/Gemma2 architecture and an unsupported `rope_scaling` are
+    /// each rejected with a clear message rather than mis-emitted. (Untied
+    /// embeddings and Gemma2 are no longer rejected; see
+    /// `from_json_accepts_untied_embeddings` / `from_json_parses_gemma2`.)
     #[test]
     fn from_json_rejects_unsupported_configs() {
-        let gemma = r#"{"model_type":"gemma2","tie_word_embeddings":true,"hidden_size":8,
+        let gemma3 = r#"{"model_type":"gemma3","tie_word_embeddings":true,"hidden_size":8,
             "num_attention_heads":2,"intermediate_size":16,"num_hidden_layers":2,
             "num_key_value_heads":1,"rms_norm_eps":1e-6,"rope_theta":1e4,"vocab_size":10}"#;
         assert!(
-            Config::from_json_str(gemma)
+            Config::from_json_str(gemma3)
                 .unwrap_err()
                 .contains("model_type")
         );
@@ -165,6 +171,30 @@ mod tests {
                 .unwrap_err()
                 .contains("rope_type")
         );
+    }
+
+    /// Gemma2 parses to its architecture switches: the soft-caps, the query
+    /// pre-attention scale, plain RoPE, and the `gemma2` structural flag. Uses the
+    /// Gemma2-9B values, where `query_pre_attn_scalar` (224) differs from `head_dim`
+    /// (256), so the scale must come from the former, not the latter.
+    #[test]
+    fn from_json_parses_gemma2() {
+        let g = r#"{"model_type":"gemma2","hidden_size":3584,"num_attention_heads":16,
+            "num_key_value_heads":8,"head_dim":256,"intermediate_size":14336,
+            "num_hidden_layers":42,"rms_norm_eps":1e-6,"rope_theta":1e4,"vocab_size":256000,
+            "query_pre_attn_scalar":224,"attn_logit_softcapping":50.0,
+            "final_logit_softcapping":30.0,"hidden_activation":"gelu_pytorch_tanh"}"#;
+        let c = Config::from_json_str(g).expect("gemma2 parses");
+        assert!(c.gemma2);
+        assert_eq!(c.rope, RopeScaling::Plain);
+        assert_eq!(c.query_pre_attn_scalar, Some(224.0));
+        assert_eq!(c.attn_logit_softcap, Some(50.0));
+        assert_eq!(c.final_logit_softcap, Some(30.0));
+        assert_eq!(c.head_dim, 256, "explicit head_dim (!= hidden/n_q)");
+        assert!(c.tie_word_embeddings, "Gemma2 ties embeddings by default");
+        // The scale is query_pre_attn_scalar^-0.5 (224), NOT head_dim^-0.5 (256).
+        assert_eq!(c.scale(), (224.0f64.powf(-0.5)) as f32);
+        assert_ne!(c.scale(), (256.0f32).powf(-0.5), "must not use head_dim");
     }
 
     /// Untied embeddings are supported (issue #449 M3 Stage 2d): `from_json` reads

--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -44,6 +44,11 @@ struct LayerW {
     bk: Option<Val>,
     bq: Option<Val>,
     bv: Option<Val>,
+    /// Gemma2 pre/post feed-forward norms (`None` for Llama / Qwen2). Gemma2 wraps
+    /// each sublayer in a pre- and a post-norm: `post_ln` becomes the POST-attn
+    /// norm, `pre_ff_ln` the pre-MLP norm, `post_ff_ln` the post-MLP norm.
+    pre_ff_ln: Option<Val>,
+    post_ff_ln: Option<Val>,
 }
 
 struct Args {
@@ -120,7 +125,10 @@ fn take_layer_weights(decls: &mut Vec<ArgDecl>, idx: &mut usize, c: &Config, li:
     let post_ln = take_arg(decls, idx, Ty::f32(vec![h]), p("post_ln"));
     let up = take_arg(decls, idx, Ty::f32(vec![inter, h]), p("up"));
     let wk = take_arg(decls, idx, Ty::f32(vec![kv, h]), p("wk"));
-    let wo = take_arg(decls, idx, Ty::f32(vec![qd, h]), p("wo"));
+    // o_proj maps `[n_q*head_dim]` -> `[hidden]`, so its weight is `[h, qd]` (HF's
+    // `[out, in]`). For Llama / Qwen2 `qd == h`, so this renders the same square
+    // type as before (byte-identical); Gemma2 is genuinely non-square.
+    let wo = take_arg(decls, idx, Ty::f32(vec![h, qd]), p("wo"));
     let wq = take_arg(decls, idx, Ty::f32(vec![qd, h]), p("wq"));
     let wv = take_arg(decls, idx, Ty::f32(vec![kv, h]), p("wv"));
     let (bk, bq, bv) = if c.qkv_bias {
@@ -130,6 +138,15 @@ fn take_layer_weights(decls: &mut Vec<ArgDecl>, idx: &mut usize, c: &Config, li:
         (Some(bk), Some(bq), Some(bv))
     } else {
         (None, None, None)
+    };
+    // Gemma2's two extra per-layer norms, appended after the q/k/v biases slot in
+    // the same order `weight_names` lists them (pre then post feed-forward).
+    let (pre_ff_ln, post_ff_ln) = if c.gemma2 {
+        let pre = take_arg(decls, idx, Ty::f32(vec![h]), p("pre_ff_ln"));
+        let post = take_arg(decls, idx, Ty::f32(vec![h]), p("post_ff_ln"));
+        (Some(pre), Some(post))
+    } else {
+        (None, None)
     };
     LayerW {
         down,
@@ -144,6 +161,8 @@ fn take_layer_weights(decls: &mut Vec<ArgDecl>, idx: &mut usize, c: &Config, li:
         bk,
         bq,
         bv,
+        pre_ff_ln,
+        post_ff_ln,
     }
 }
 
@@ -292,6 +311,58 @@ fn rms_norm(b: &mut Builder, x: &Val, w: &Val, k: &Consts, hidden: usize) -> Val
     b.multiply(&xr, w)
 }
 
+/// Gemma2 `(1 + weight)` norm scale (`weight + 1` over the `[hidden]` feature
+/// axis). Gemma stores the RMSNorm weight offset by one, so the gemma2 paths pass
+/// `gemma_norm_w(...)` where Llama / Qwen2 pass the raw weight.
+fn gemma_norm_w(b: &mut Builder, w: &Val, k: &Consts, hidden: usize) -> Val {
+    let one = b.broadcast(&k.one, &[], vec![hidden]);
+    b.add(w, &one)
+}
+
+/// The RMSNorm weight to feed `rms_norm`: `1 + w` for Gemma2, the raw `w`
+/// otherwise. A `Val` clone is just a handle copy (no emitted op), so the
+/// Llama / Qwen2 graphs are unchanged.
+fn norm_w(b: &mut Builder, w: &Val, c: &Config, k: &Consts, hidden: usize) -> Val {
+    if c.gemma2 {
+        gemma_norm_w(b, w, k, hidden)
+    } else {
+        w.clone()
+    }
+}
+
+/// Gemma2 `gelu_pytorch_tanh` activation, elementwise over `x` (any shape):
+/// `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))`.
+fn gelu_tanh(b: &mut Builder, x: &Val) -> Val {
+    let shape = x.ty.shape.clone();
+    let bc = |b: &mut Builder, v: f32, shape: &[usize]| {
+        let c = b.const_f32(v);
+        b.broadcast(&c, &[], shape.to_vec())
+    };
+    let c0 = bc(b, (2.0f64 / std::f64::consts::PI).sqrt() as f32, &shape);
+    let c1 = bc(b, 0.044715, &shape);
+    let half = bc(b, 0.5, &shape);
+    let one = bc(b, 1.0, &shape);
+    let x2 = b.multiply(x, x);
+    let x3 = b.multiply(&x2, x);
+    let c1x3 = b.multiply(&c1, &x3);
+    let inner1 = b.add(x, &c1x3);
+    let inner = b.multiply(&c0, &inner1);
+    let t = b.tanh(&inner);
+    let onept = b.add(&one, &t);
+    let hx = b.multiply(&half, x);
+    b.multiply(&hx, &onept)
+}
+
+/// Gemma2 logit soft-cap, elementwise over `x`: `cap * tanh(x / cap)`.
+fn softcap(b: &mut Builder, x: &Val, cap: f32) -> Val {
+    let shape = x.ty.shape.clone();
+    let capc = b.const_f32(cap);
+    let capb = b.broadcast(&capc, &[], shape);
+    let xd = b.divide(x, &capb);
+    let t = b.tanh(&xd);
+    b.multiply(&t, &capb)
+}
+
 /// HF half-split RoPE on x:[heads, d]; cos/sin are [d] for the position.
 fn apply_rope(b: &mut Builder, x: &Val, cos: &Val, sin: &Val, heads: usize, d: usize) -> Val {
     let half = d / 2;
@@ -323,6 +394,12 @@ pub fn emit_decode(c: &Config, sample: bool) -> String {
     // --- head: embed gather, rope vectors, decode key mask ---
     let emb_row = b.dynamic_slice(&a.embed, &[&a.token, &k.c0], vec![1, h]);
     let mut x = b.reshape(&emb_row, vec![h]);
+    // Gemma2 scales the input embeddings by sqrt(hidden).
+    if c.gemma2 {
+        let norm = b.const_f32(c.embed_normalizer());
+        let nb = b.broadcast(&norm, &[], vec![h]);
+        x = b.multiply(&x, &nb);
+    }
 
     let cos_row = b.dynamic_slice(&k.cos_table, &[&a.pos, &k.c0], vec![1, d]);
     let cos_vec = b.reshape(&cos_row, vec![d]);
@@ -344,7 +421,8 @@ pub fn emit_decode(c: &Config, sample: bool) -> String {
         let lw = &a.layers[li];
 
         // attention block
-        let hn = rms_norm(&mut b, &x, &lw.in_ln, &k, h);
+        let in_ln_w = norm_w(&mut b, &lw.in_ln, c, &k, h);
+        let hn = rms_norm(&mut b, &x, &in_ln_w, &k, h);
         let q = b.linear(&hn, &lw.wq);
         let q = add_proj_bias(&mut b, q, &lw.bq);
         let q = b.reshape(&q, vec![nq, d]);
@@ -384,6 +462,11 @@ pub fn emit_decode(c: &Config, sample: bool) -> String {
         let scores = b.reshape(&scores, vec![nq, MAX_SEQ]);
         let scale_b = b.broadcast(&k.scale, &[], vec![nq, MAX_SEQ]);
         let scores = b.multiply(&scores, &scale_b);
+        // Gemma2 attention logit soft-cap, applied to the scaled scores before the mask.
+        let scores = match c.attn_logit_softcap {
+            Some(cap) => softcap(&mut b, &scores, cap),
+            None => scores,
+        };
         let kmask_b = b.broadcast(&kmask, &[1], vec![nq, MAX_SEQ]);
         let scores = b.add(&scores, &kmask_b);
 
@@ -402,28 +485,65 @@ pub fn emit_decode(c: &Config, sample: bool) -> String {
         let o = b.reshape(&o, vec![nq, d]);
         let o = b.reshape(&o, vec![nq * d]);
         let attn_out = b.linear(&o, &lw.wo);
+        // Gemma2: post-attention norm on the sublayer output before the residual.
+        let attn_out = if c.gemma2 {
+            let w = norm_w(&mut b, &lw.post_ln, c, &k, h);
+            rms_norm(&mut b, &attn_out, &w, &k, h)
+        } else {
+            attn_out
+        };
         x = b.add(&x, &attn_out);
 
-        // MLP: down( silu(x@gate^T) * (x@up^T) )
-        let hn2 = rms_norm(&mut b, &x, &lw.post_ln, &k, h);
+        // MLP. Pre-MLP norm: Llama / Qwen2 use post_attention_layernorm; Gemma2
+        // uses pre_feedforward_layernorm (post_attention_layernorm became the
+        // post-attn norm above). Activation: SwiGLU (silu) vs Gemma2 GeGLU (gelu).
+        let pre_mlp = if c.gemma2 {
+            lw.pre_ff_ln.as_ref().expect("gemma2 pre_ff_ln")
+        } else {
+            &lw.post_ln
+        };
+        let pre_mlp_w = norm_w(&mut b, pre_mlp, c, &k, h);
+        let hn2 = rms_norm(&mut b, &x, &pre_mlp_w, &k, h);
         let gate = b.linear(&hn2, &lw.gate);
         let up = b.linear(&hn2, &lw.up);
-        // silu(gate) = gate * sigmoid(gate), sigmoid(z) = 1/(1+exp(-z))
-        let neg = b.negate(&gate);
-        let ex = b.exponential(&neg);
-        let one_b = b.broadcast(&k.one, &[], vec![c.inter]);
-        let denom = b.add(&one_b, &ex);
-        let sig = b.divide(&one_b, &denom);
-        let silu = b.multiply(&gate, &sig);
-        let act = b.multiply(&silu, &up);
+        let act = if c.gemma2 {
+            gelu_tanh(&mut b, &gate)
+        } else {
+            // silu(gate) = gate * sigmoid(gate), sigmoid(z) = 1/(1+exp(-z))
+            let neg = b.negate(&gate);
+            let ex = b.exponential(&neg);
+            let one_b = b.broadcast(&k.one, &[], vec![c.inter]);
+            let denom = b.add(&one_b, &ex);
+            let sig = b.divide(&one_b, &denom);
+            b.multiply(&gate, &sig)
+        };
+        let act = b.multiply(&act, &up);
         let down = b.linear(&act, &lw.down);
+        // Gemma2: post-MLP norm before the residual.
+        let down = if c.gemma2 {
+            let w = norm_w(
+                &mut b,
+                lw.post_ff_ln.as_ref().expect("gemma2 post_ff_ln"),
+                c,
+                &k,
+                h,
+            );
+            rms_norm(&mut b, &down, &w, &k, h)
+        } else {
+            down
+        };
         x = b.add(&x, &down);
     }
 
-    // --- tail: final norm + LM head (tied embed or untied lm_head), then
-    // optional on-device argmax ---
-    let xf = rms_norm(&mut b, &x, &a.final_norm, &k, h);
+    // --- tail: final norm + LM head (tied embed or untied lm_head), Gemma2 final
+    // logit soft-cap, then optional on-device argmax ---
+    let final_w = norm_w(&mut b, &a.final_norm, c, &k, h);
+    let xf = rms_norm(&mut b, &x, &final_w, &k, h);
     let logits = b.linear(&xf, head_weight(&a.embed, &a.lm_head)); // [V]
+    let logits = match c.final_logit_softcap {
+        Some(cap) => softcap(&mut b, &logits, cap),
+        None => logits,
+    };
     let (out_val, out_ty) = if sample {
         let tok = b.argmax(&logits);
         (tok.name, Ty::scalar("i32").render())
@@ -1140,6 +1260,12 @@ pub fn emit_prefill(c: &Config, sample: bool) -> String {
     // --- head: embed gather, per-position rope vectors, [Lp,Lp] causal mask ---
     let tok_idx = b.reshape(&a.tokens, vec![lp, 1]);
     let mut x = b.gather(&a.embed, &tok_idx); // [Lp, H]
+    // Gemma2 scales the input embeddings by sqrt(hidden).
+    if c.gemma2 {
+        let norm = b.const_f32(c.embed_normalizer());
+        let nb = b.broadcast(&norm, &[], vec![lp, h]);
+        x = b.multiply(&x, &nb);
+    }
 
     let pos_idx = b.reshape(&a.positions, vec![lp, 1]);
     let cos = b.gather(&k.cos_table, &pos_idx); // [Lp, d]
@@ -1163,7 +1289,8 @@ pub fn emit_prefill(c: &Config, sample: bool) -> String {
         let lw = &a.layers[li];
 
         // attention block
-        let hn = rms_norm_seq(&mut b, &x, &lw.in_ln, &k, lp, h); // [Lp, H]
+        let in_ln_w = norm_w(&mut b, &lw.in_ln, c, &k, h);
+        let hn = rms_norm_seq(&mut b, &x, &in_ln_w, &k, lp, h); // [Lp, H]
         let q = b.linear_seq(&hn, &lw.wq); // [Lp, qd]
         let q = add_proj_bias_seq(&mut b, q, &lw.bq, lp, nq * d);
         let q = b.reshape(&q, vec![lp, nq, d]);
@@ -1189,6 +1316,11 @@ pub fn emit_prefill(c: &Config, sample: bool) -> String {
         let scores = b.dot_general(&q4, &kk, &[1], &[1], &[3], &[2], vec![nkv, lp, g, lp]);
         let scale_b = b.broadcast(&k.scale, &[], vec![nkv, lp, g, lp]);
         let scores = b.multiply(&scores, &scale_b);
+        // Gemma2 attention logit soft-cap on the scaled scores before the mask.
+        let scores = match c.attn_logit_softcap {
+            Some(cap) => softcap(&mut b, &scores, cap),
+            None => scores,
+        };
         let cmask_b = b.broadcast(&cmask, &[1, 3], vec![nkv, lp, g, lp]);
         let scores = b.add(&scores, &cmask_b);
 
@@ -1206,31 +1338,67 @@ pub fn emit_prefill(c: &Config, sample: bool) -> String {
         let o = b.transpose(&o, &[1, 0, 2, 3]); // [Lp, nkv, g, d]
         let o = b.reshape(&o, vec![lp, nq * d]); // [Lp, nq*d], head-major
         let attn_out = b.linear_seq(&o, &lw.wo); // [Lp, H]
+        // Gemma2: post-attention norm before the residual.
+        let attn_out = if c.gemma2 {
+            let w = norm_w(&mut b, &lw.post_ln, c, &k, h);
+            rms_norm_seq(&mut b, &attn_out, &w, &k, lp, h)
+        } else {
+            attn_out
+        };
         x = b.add(&x, &attn_out);
 
-        // MLP: down( silu(x@gate^T) * (x@up^T) )
-        let hn2 = rms_norm_seq(&mut b, &x, &lw.post_ln, &k, lp, h);
+        // MLP. Pre-MLP norm: Llama / Qwen2 use post_attention_layernorm; Gemma2
+        // uses pre_feedforward_layernorm. Activation: SwiGLU (silu) vs GeGLU (gelu).
+        let pre_mlp = if c.gemma2 {
+            lw.pre_ff_ln.as_ref().expect("gemma2 pre_ff_ln")
+        } else {
+            &lw.post_ln
+        };
+        let pre_mlp_w = norm_w(&mut b, pre_mlp, c, &k, h);
+        let hn2 = rms_norm_seq(&mut b, &x, &pre_mlp_w, &k, lp, h);
         let gate = b.linear_seq(&hn2, &lw.gate); // [Lp, inter]
         let up = b.linear_seq(&hn2, &lw.up); // [Lp, inter]
-        let neg = b.negate(&gate);
-        let ex = b.exponential(&neg);
-        let one_b = b.broadcast(&k.one, &[], vec![lp, c.inter]);
-        let denom = b.add(&one_b, &ex);
-        let sig = b.divide(&one_b, &denom);
-        let silu = b.multiply(&gate, &sig);
-        let act = b.multiply(&silu, &up);
+        let act = if c.gemma2 {
+            gelu_tanh(&mut b, &gate)
+        } else {
+            let neg = b.negate(&gate);
+            let ex = b.exponential(&neg);
+            let one_b = b.broadcast(&k.one, &[], vec![lp, c.inter]);
+            let denom = b.add(&one_b, &ex);
+            let sig = b.divide(&one_b, &denom);
+            b.multiply(&gate, &sig)
+        };
+        let act = b.multiply(&act, &up);
         let down = b.linear_seq(&act, &lw.down); // [Lp, H]
+        // Gemma2: post-MLP norm before the residual.
+        let down = if c.gemma2 {
+            let w = norm_w(
+                &mut b,
+                lw.post_ff_ln.as_ref().expect("gemma2 post_ff_ln"),
+                c,
+                &k,
+                h,
+            );
+            rms_norm_seq(&mut b, &down, &w, &k, lp, h)
+        } else {
+            down
+        };
         x = b.add(&x, &down);
     }
 
     // --- tail: final norm, take the row at real_len-1, LM head (tied embed or
-    // untied lm_head) ---
-    let xf = rms_norm_seq(&mut b, &x, &a.final_norm, &k, lp, h); // [Lp, H]
+    // untied lm_head), Gemma2 final logit soft-cap ---
+    let final_w = norm_w(&mut b, &a.final_norm, c, &k, h);
+    let xf = rms_norm_seq(&mut b, &x, &final_w, &k, lp, h); // [Lp, H]
     let one_i = b.const_i32(1);
     let last_idx = b.subtract(&a.real_len, &one_i); // real_len - 1
     let last_row = b.dynamic_slice(&xf, &[&last_idx, &k.c0], vec![1, h]); // [1, H]
     let last = b.reshape(&last_row, vec![h]); // [H]
     let logits = b.linear(&last, head_weight(&a.embed, &a.lm_head)); // [V]
+    let logits = match c.final_logit_softcap {
+        Some(cap) => softcap(&mut b, &logits, cap),
+        None => logits,
+    };
     let (out_val, out_ty) = if sample {
         let tok = b.argmax(&logits);
         (tok.name, Ty::scalar("i32").render())

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -163,6 +163,16 @@ fn weight_names(cfg: &Config) -> Vec<String> {
                 names.push(format!("{p}{suf}"));
             }
         }
+        // Gemma2 has two extra per-layer norms (pre/post feed-forward), appended
+        // in the same order `take_layer_weights` takes their graph args.
+        if cfg.gemma2 {
+            for suf in [
+                "pre_feedforward_layernorm.weight",
+                "post_feedforward_layernorm.weight",
+            ] {
+                names.push(format!("{p}{suf}"));
+            }
+        }
     }
     names
 }
@@ -630,6 +640,14 @@ impl IreeRaggedLlama {
     /// `b_max` must be one of the bundled graphs ([`RAGGED_B_VALUES`]).
     pub fn load(model_dir: &Path, device: &str, b_max: usize) -> Result<Self, String> {
         let cfg = Config::from_json(model_dir)?;
+        // The ragged (batched serve) emitter does not yet implement the Gemma2
+        // forward (soft-caps, the four-norm structure, GeGLU); only the single-
+        // sequence path does. Reject Gemma2 here rather than serve a wrong graph.
+        if cfg.gemma2 {
+            return Err("the OpenXLA serve path does not yet support Gemma2 \
+                 (use the single-sequence CLI; batched Gemma2 is a follow-up)"
+                .to_string());
+        }
         if !RAGGED_B_VALUES.contains(&b_max) {
             return Err(format!(
                 "the OpenXLA serve worker selects B_max from {RAGGED_B_VALUES:?}; \


### PR DESCRIPTION
## Summary

Adds the **Gemma2** architecture to the emitter and `from_json`, so Gemma2 checkpoints run on the OpenXLA single-sequence path (CLI / oracle). Part of #449 M3 Stage 2d.

All Gemma2 behavior is gated on a `gemma2` switch, so **Llama / Qwen2 graphs stay byte-identical** (the bundled-asset test still passes).

## Gemma2 vs Llama / Qwen2

- input embeddings scaled by `sqrt(hidden)`;
- RMSNorm uses `(1 + weight)`;
- GeGLU MLP (`gelu_pytorch_tanh`) instead of SwiGLU;
- four norms per layer: `post_attention_layernorm` becomes a POST-attention norm, `pre/post_feedforward_layernorm` wrap the MLP;
- attention + final logit soft-capping (`cap * tanh(x/cap)`);
- query scale `query_pre_attn_scalar^-0.5` (can differ from `head_dim`, e.g. 224 vs 256 on 9B);
- non-square `o_proj` (`n_q*head_dim != hidden`): `wo` is `[h, qd]` (HF's `[out, in]`), which renders the same square type for Llama / Qwen2 (unchanged).

`weight_names` adds the two extra Gemma2 norms; the builder gains `tanh`. The batched / ragged serve graphs are **not yet** Gemma2-aware, so the ragged engine rejects Gemma2 with a clear error (single-sequence only for now; sliding-window attention is also deferred — a no-op for prompts under the 4096 window).

## Validation

**Unit (`cargo test -p mlxcel-xla`, 42 pass):** `from_json` parses Gemma2 (soft-caps, the query scale from `query_pre_attn_scalar` **not** `head_dim`, plain RoPE, tied embeddings); the bundled Llama-3.2-1B graphs stay byte-for-byte identical.

**E2E, CUDA on GB10**, on `gemma2-2b-4bit` (loaded via the 4bit dequant + the new Gemma2 emitter), greedy vs HF fp32 oracle (same weights dequantized offline):

| Prompt | Result |
|---|---|
| "Roses are red, violets are blue, sugar is sweet and so are" | **TOKEN-EXACT 12/12** |
| "The first man to walk on the Moon was Neil" | **TOKEN-EXACT 10/10** |
| "The capital of France is" | diverges at a **0.004-logit near-tie** (XLA's pick is HF's #2; coherent " **Paris**") |

So the architecture is correct: XLA's logits match HF to ~0.004 and reproduce HF's argmax except at sub-0.01 near-ties, which are the inherent limit of the `tanh` in GeGLU / soft-caps (IREE `tanh` vs PyTorch `tanh` accumulated over the layers).

Refs #449.
