### PR TITLE
refactor: share the seq MLP across serve graphs, complete Gemma2 batched serving (#449 M3 Stage 2d)

### DIFF
--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -363,6 +363,52 @@ fn softcap(b: &mut Builder, x: &Val, cap: f32) -> Val {
     b.multiply(&t, &capb)
 }
 
+/// The seq-shaped (`[n, H]`) per-layer MLP plus its surrounding norms, shared by
+/// every multi-row graph (prefill, ragged decode). Llama / Qwen2: a pre-MLP
+/// `post_attention_layernorm` then SwiGLU. Gemma2: a pre-MLP
+/// `pre_feedforward_layernorm`, GeGLU, and a post-MLP `post_feedforward_layernorm`.
+/// Returns the residual already added (`x + down`). For a non-Gemma2 config it
+/// emits exactly the op sequence the graphs carried inline, so their text is
+/// byte-identical. Writing it once is the lever that makes a new architecture's
+/// MLP delta (here, GeGLU + the two FF norms) reach every serve graph at once.
+fn seq_mlp(b: &mut Builder, c: &Config, lw: &LayerW, k: &Consts, x: &Val, n: usize) -> Val {
+    let h = c.hidden;
+    let pre_mlp = if c.gemma2 {
+        lw.pre_ff_ln.as_ref().expect("gemma2 pre_ff_ln")
+    } else {
+        &lw.post_ln
+    };
+    let pre_mlp_w = norm_w(b, pre_mlp, c, k, h);
+    let hn2 = rms_norm_seq(b, x, &pre_mlp_w, k, n, h);
+    let gate = b.linear_seq(&hn2, &lw.gate);
+    let up = b.linear_seq(&hn2, &lw.up);
+    let act = if c.gemma2 {
+        gelu_tanh(b, &gate)
+    } else {
+        let neg = b.negate(&gate);
+        let ex = b.exponential(&neg);
+        let one_b = b.broadcast(&k.one, &[], vec![n, c.inter]);
+        let denom = b.add(&one_b, &ex);
+        let sig = b.divide(&one_b, &denom);
+        b.multiply(&gate, &sig)
+    };
+    let act = b.multiply(&act, &up);
+    let down = b.linear_seq(&act, &lw.down);
+    let down = if c.gemma2 {
+        let w = norm_w(
+            b,
+            lw.post_ff_ln.as_ref().expect("gemma2 post_ff_ln"),
+            c,
+            k,
+            h,
+        );
+        rms_norm_seq(b, &down, &w, k, n, h)
+    } else {
+        down
+    };
+    b.add(x, &down)
+}
+
 /// HF half-split RoPE on x:[heads, d]; cos/sin are [d] for the position.
 fn apply_rope(b: &mut Builder, x: &Val, cos: &Val, sin: &Val, heads: usize, d: usize) -> Val {
     let half = d / 2;
@@ -980,6 +1026,12 @@ pub fn emit_decode_ragged(c: &Config, bsz: usize, sample: bool) -> String {
     // --- head: per-row embed gather, per-row rope gather, per-row key mask ---
     let tok_idx = b.reshape(&a.token, vec![bsz, 1]);
     let mut x = b.gather(&a.embed, &tok_idx); // [B, H]
+    // Gemma2 scales the input embeddings by sqrt(hidden).
+    if c.gemma2 {
+        let norm = b.const_f32(c.embed_normalizer());
+        let nb = b.broadcast(&norm, &[], vec![bsz, h]);
+        x = b.multiply(&x, &nb);
+    }
 
     // each row's rope vectors come from its own position: gather [B,d] by pos[B]
     let pos_idx = b.reshape(&a.pos, vec![bsz, 1]);
@@ -1001,7 +1053,8 @@ pub fn emit_decode_ragged(c: &Config, bsz: usize, sample: bool) -> String {
     for li in 0..c.n_layers {
         let lw = &a.layers[li];
 
-        let hn = rms_norm_seq(&mut b, &x, &lw.in_ln, &k, bsz, h); // [B, H]
+        let in_ln_w = norm_w(&mut b, &lw.in_ln, c, &k, h);
+        let hn = rms_norm_seq(&mut b, &x, &in_ln_w, &k, bsz, h); // [B, H]
         let q = b.linear_seq(&hn, &lw.wq);
         let q = add_proj_bias_seq(&mut b, q, &lw.bq, bsz, nq * d);
         let q = b.reshape(&q, vec![bsz, nq, d]);
@@ -1064,6 +1117,11 @@ pub fn emit_decode_ragged(c: &Config, bsz: usize, sample: bool) -> String {
         let scores = b.reshape(&scores, vec![bsz, nq, MAX_SEQ]);
         let scale_b = b.broadcast(&k.scale, &[], vec![bsz, nq, MAX_SEQ]);
         let scores = b.multiply(&scores, &scale_b);
+        // Gemma2 attention logit soft-cap on the scaled scores before the mask.
+        let scores = match c.attn_logit_softcap {
+            Some(cap) => softcap(&mut b, &scores, cap),
+            None => scores,
+        };
         let kmask_b = b.broadcast(&kmask, &[0, 2], vec![bsz, nq, MAX_SEQ]); // [B,S] -> [B,nq,S]
         let scores = b.add(&scores, &kmask_b);
 
@@ -1088,24 +1146,28 @@ pub fn emit_decode_ragged(c: &Config, bsz: usize, sample: bool) -> String {
         let o = b.reshape(&o, vec![bsz, nq, d]);
         let o = b.reshape(&o, vec![bsz, nq * d]);
         let attn_out = b.linear_seq(&o, &lw.wo);
+        // Gemma2: post-attention norm before the residual.
+        let attn_out = if c.gemma2 {
+            let w = norm_w(&mut b, &lw.post_ln, c, &k, h);
+            rms_norm_seq(&mut b, &attn_out, &w, &k, bsz, h)
+        } else {
+            attn_out
+        };
         x = b.add(&x, &attn_out);
 
-        let hn2 = rms_norm_seq(&mut b, &x, &lw.post_ln, &k, bsz, h);
-        let gate = b.linear_seq(&hn2, &lw.gate);
-        let up = b.linear_seq(&hn2, &lw.up);
-        let neg = b.negate(&gate);
-        let ex = b.exponential(&neg);
-        let one_b = b.broadcast(&k.one, &[], vec![bsz, c.inter]);
-        let denom = b.add(&one_b, &ex);
-        let sig = b.divide(&one_b, &denom);
-        let silu = b.multiply(&gate, &sig);
-        let act = b.multiply(&silu, &up);
-        let down = b.linear_seq(&act, &lw.down);
-        x = b.add(&x, &down);
+        // MLP + its norms (SwiGLU, or Gemma2 GeGLU with pre/post FF norms),
+        // shared with the prefill graph.
+        x = seq_mlp(&mut b, c, lw, &k, &x, bsz);
     }
 
-    let xf = rms_norm_seq(&mut b, &x, &a.final_norm, &k, bsz, h);
+    let final_w = norm_w(&mut b, &a.final_norm, c, &k, h);
+    let xf = rms_norm_seq(&mut b, &x, &final_w, &k, bsz, h);
     let logits = b.linear_seq(&xf, head_weight(&a.embed, &a.lm_head)); // [B, V]
+    // Gemma2 final logit soft-cap (per row; argmax-invariant but kept for exactness).
+    let logits = match c.final_logit_softcap {
+        Some(cap) => softcap(&mut b, &logits, cap),
+        None => logits,
+    };
     let (out_val, out_ty) = if sample {
         let tok = b.argmax_batched(&logits);
         (tok.name, Ty::new(vec![bsz], "i32").render())
@@ -1347,43 +1409,9 @@ pub fn emit_prefill(c: &Config, sample: bool) -> String {
         };
         x = b.add(&x, &attn_out);
 
-        // MLP. Pre-MLP norm: Llama / Qwen2 use post_attention_layernorm; Gemma2
-        // uses pre_feedforward_layernorm. Activation: SwiGLU (silu) vs GeGLU (gelu).
-        let pre_mlp = if c.gemma2 {
-            lw.pre_ff_ln.as_ref().expect("gemma2 pre_ff_ln")
-        } else {
-            &lw.post_ln
-        };
-        let pre_mlp_w = norm_w(&mut b, pre_mlp, c, &k, h);
-        let hn2 = rms_norm_seq(&mut b, &x, &pre_mlp_w, &k, lp, h);
-        let gate = b.linear_seq(&hn2, &lw.gate); // [Lp, inter]
-        let up = b.linear_seq(&hn2, &lw.up); // [Lp, inter]
-        let act = if c.gemma2 {
-            gelu_tanh(&mut b, &gate)
-        } else {
-            let neg = b.negate(&gate);
-            let ex = b.exponential(&neg);
-            let one_b = b.broadcast(&k.one, &[], vec![lp, c.inter]);
-            let denom = b.add(&one_b, &ex);
-            let sig = b.divide(&one_b, &denom);
-            b.multiply(&gate, &sig)
-        };
-        let act = b.multiply(&act, &up);
-        let down = b.linear_seq(&act, &lw.down); // [Lp, H]
-        // Gemma2: post-MLP norm before the residual.
-        let down = if c.gemma2 {
-            let w = norm_w(
-                &mut b,
-                lw.post_ff_ln.as_ref().expect("gemma2 post_ff_ln"),
-                c,
-                &k,
-                h,
-            );
-            rms_norm_seq(&mut b, &down, &w, &k, lp, h)
-        } else {
-            down
-        };
-        x = b.add(&x, &down);
+        // MLP + its norms (SwiGLU, or Gemma2 GeGLU with pre/post FF norms),
+        // shared with the ragged-decode graph.
+        x = seq_mlp(&mut b, c, lw, &k, &x, lp);
     }
 
     // --- tail: final norm, take the row at real_len-1, LM head (tied embed or

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -640,14 +640,6 @@ impl IreeRaggedLlama {
     /// `b_max` must be one of the bundled graphs ([`RAGGED_B_VALUES`]).
     pub fn load(model_dir: &Path, device: &str, b_max: usize) -> Result<Self, String> {
         let cfg = Config::from_json(model_dir)?;
-        // The ragged (batched serve) emitter does not yet implement the Gemma2
-        // forward (soft-caps, the four-norm structure, GeGLU); only the single-
-        // sequence path does. Reject Gemma2 here rather than serve a wrong graph.
-        if cfg.gemma2 {
-            return Err("the OpenXLA serve path does not yet support Gemma2 \
-                 (use the single-sequence CLI; batched Gemma2 is a follow-up)"
-                .to_string());
-        }
         if !RAGGED_B_VALUES.contains(&b_max) {
             return Err(format!(
                 "the OpenXLA serve worker selects B_max from {RAGGED_B_VALUES:?}; \


### PR DESCRIPTION
## Summary

**Window A foundation step.** The per-layer MLP (with its norms) was inlined separately in the prefill and ragged-decode graphs, so an architecture's MLP delta (e.g. Gemma2's GeGLU + the two feed-forward norms) had to be written in each. This extracts it into one `seq_mlp` helper that both call — so a **new architecture's MLP is written once and reaches every serve graph** — and uses it to **complete Gemma2 on the serve (continuous-batching) path**. Part of #449 M3 Stage 2d.

## What changed

- **`seq_mlp` helper** (`emitter/model.rs`): the seq-shaped per-layer MLP + its norms (SwiGLU, or Gemma2 GeGLU + pre/post feed-forward norms), shared by prefill and ragged decode. It emits the exact op sequence the graphs carried inline for a non-Gemma2 config, so the bundled Llama-3.2-1B assets stay **byte-for-byte identical**.
- **Gemma2 on the ragged graph**: embedding scale, `(1+w)` in/post-attention norms, attention logit soft-cap, the shared GeGLU MLP, final logit soft-cap — mirroring the single-sequence path. The ragged engine no longer rejects Gemma2, so `MLXCEL_BACKEND=xla mlxcel-server` serves Gemma2.

## Validation

- **Unit (42 pass):** the Llama-3.2-1B prefill / ragged graphs are byte-for-byte identical after the extraction (asset test), so Llama / Qwen2 are unaffected.
- **E2E, CUDA on GB10:** `xla_batch_bench` on `gemma2-2b-4bit` (8 requests, B_max=4, continuous batching with mid-stream admit / slot recycling) is **REFERENCE-EXACT** — every request's served stream matches its independent single-sequence reference (170 tokens). So the Gemma2 ragged graph computes identically to the single-sequence path that is token-exact with HF (#491).

## Notes / follow-up

- The uniform-B `emit_decode_batched` (a Stage-1 throughput experiment, not on the serve path) is left as-is.
- Sliding-window attention (a no-op under the 4096 window) is still deferred.
- This shares the MLP; a fuller refactor (one shared per-layer forward including the attention core, so the whole arch is written once) is a natural next step but larger.

Refs #449.
