### PR TITLE
feat: device-index-aware device/stream bindings in mlxcel-core (#487)

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -115,6 +115,10 @@ fn load_generation_model(
     preflight: Option<&MemoryEstimate>,
 ) -> Result<(mlxcel::LoadedModel, mlxcel::tokenizer::MlxcelTokenizer)> {
     println!("Loading model from {:?}...", args.model.model);
+    // Surface the backend's GPU count (epic #486, sub-issue #487). Always 1 on
+    // Metal; reports the real adapter count on a CUDA multi-GPU host, which is
+    // what `--tp-size` shards across.
+    println!("Detected {} GPU(s).", mlxcel_core::gpu_device_count());
     let load_start = Instant::now();
     let shard_config = shard_config_from_cli(
         args.tensor_parallel.tp_size,

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -46,6 +46,37 @@ void synchronize_thread_local_stream(const MlxThreadLocalStream& tls) {
     mlx::core::synchronize(tls.inner);
 }
 
+// --- Multi-GPU device-index surface (epic #486, sub-issue #487) ---
+//
+// Portable across backends via MLX's `device_count` and the
+// `Device(DeviceType, index)` constructor; no CUDA headers required. See
+// the header comment for cross-backend semantics.
+int32_t gpu_device_count() {
+    int count = mlx::core::device_count(mlx::core::Device::gpu);
+    // Clamp to >= 1: a CPU-only build reports 0 GPUs but `Device::gpu`
+    // still resolves to the single default compute device, and callers
+    // (and the acceptance criteria) expect at least one.
+    return count >= 1 ? static_cast<int32_t>(count) : 1;
+}
+
+std::unique_ptr<MlxStream> new_stream_on_gpu_index(int32_t index) {
+    return std::make_unique<MlxStream>(
+        mlx::core::new_stream(Device(Device::gpu, index)));
+}
+
+void set_default_device_index(int32_t index) {
+    mlx::core::set_default_device(Device(Device::gpu, index));
+}
+
+std::unique_ptr<MlxThreadLocalStream> new_thread_local_stream_gpu_index(int32_t index) {
+    return std::make_unique<MlxThreadLocalStream>(
+        mlx::core::new_thread_local_stream(Device(Device::gpu, index)));
+}
+
+std::unique_ptr<MlxArray> copy_array_to_stream(const MlxArray& a, const MlxStream& stream) {
+    return std::make_unique<MlxArray>(mlx::core::copy(a.inner, stream.inner));
+}
+
 // Array factory functions.
 std::unique_ptr<MlxArray> zeros(rust::Slice<const int32_t> shape, int32_t dtype) {
     return std::make_unique<MlxArray>(mlx::core::zeros(to_shape(shape), to_dtype(dtype)));

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -72,6 +72,43 @@ std::unique_ptr<MlxStream> stream_from_thread_local_stream(const MlxThreadLocalS
 // dispatched the work.
 void synchronize_thread_local_stream(const MlxThreadLocalStream& tls);
 
+// --- Multi-GPU device-index surface (epic #486, sub-issue #487) ---
+//
+// The boolean device API (`new_stream_on_device(bool)`,
+// `set_default_device(bool)`) can only target GPU index 0. These
+// index-aware entry points are the foundation for single-node tensor
+// parallelism, where each rank's weights and compute live on their own
+// physical GPU. They use MLX's portable device API
+// (`mlx::core::device_count`, the `Device(DeviceType, index)`
+// constructor) so the same code compiles on Metal (one GPU), a CUDA
+// multi-GPU host, and a CPU-only build; no CUDA headers are required.
+
+// Number of usable GPUs for the active backend, via
+// `mlx::core::device_count(Device::gpu)`. Metal reports 1 (single
+// unified-memory GPU), a CUDA build reports the real adapter count, and a
+// CPU-only build clamps to 1. Always returns >= 1.
+int32_t gpu_device_count();
+
+// New stream pinned to GPU `index` (0-based). `index` must be in
+// `[0, gpu_device_count())`; the Rust wrapper validates this before
+// calling, so an out-of-range index here is undefined per MLX.
+std::unique_ptr<MlxStream> new_stream_on_gpu_index(int32_t index);
+
+// Make GPU `index` the default device for subsequent ops. Mirrors
+// `set_default_device(bool)` but targets a specific GPU.
+void set_default_device_index(int32_t index);
+
+// Thread-local stream pinned to GPU `index`. Index-aware sibling of
+// `new_thread_local_stream_gpu`; each calling thread resolves its own
+// per-thread stream on that GPU.
+std::unique_ptr<MlxThreadLocalStream> new_thread_local_stream_gpu_index(int32_t index);
+
+// Materialize `a` on the device backing `stream` via `mlx::core::copy`.
+// On a multi-GPU CUDA host this is a genuine cross-device copy (used by
+// sub-issue 2 to move shards between GPUs); on a single-GPU backend it is
+// a same-device copy.
+std::unique_ptr<MlxArray> copy_array_to_stream(const MlxArray& a, const MlxStream& stream);
+
 // Array factory functions.
 // Create array filled with zeros
 std::unique_ptr<MlxArray> zeros(rust::Slice<const int32_t> shape, int32_t dtype);

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -59,6 +59,29 @@ mod ffi {
         /// Synchronize the calling thread's stream for this TLS handle.
         fn synchronize_thread_local_stream(tls: &MlxThreadLocalStream);
 
+        // Multi-GPU device-index surface (epic #486, sub-issue #487).
+        //
+        // Index-aware counterparts of the boolean device API. Raw,
+        // unvalidated entry points: prefer the safe wrappers in
+        // [`crate::streams`] (`new_stream_on_gpu`, `set_default_gpu_device`,
+        // `new_thread_local_stream_on_gpu`), which validate the index
+        // against `gpu_device_count`.
+
+        /// Number of usable GPUs for the active backend (always >= 1).
+        fn gpu_device_count() -> i32;
+
+        /// Create a new stream pinned to GPU `index` (0-based, unvalidated).
+        fn new_stream_on_gpu_index(index: i32) -> UniquePtr<MlxStream>;
+
+        /// Make GPU `index` the default device for subsequent ops (unvalidated).
+        fn set_default_device_index(index: i32);
+
+        /// Create a thread-local stream pinned to GPU `index` (unvalidated).
+        fn new_thread_local_stream_gpu_index(index: i32) -> UniquePtr<MlxThreadLocalStream>;
+
+        /// Materialize `a` on the device backing `stream` (cross-device copy).
+        fn copy_array_to_stream(a: &MlxArray, stream: &MlxStream) -> UniquePtr<MlxArray>;
+
         // Array factory functions.
         /// Create array filled with zeros
         fn zeros(shape: &[i32], dtype: i32) -> UniquePtr<MlxArray>;

--- a/src/lib/mlxcel-core/src/streams.rs
+++ b/src/lib/mlxcel-core/src/streams.rs
@@ -183,9 +183,219 @@ pub fn install_default_stream(stream: Option<&UniquePtr<MlxStream>>) {
     }
 }
 
+// --- Index-aware multi-GPU device/stream helpers (epic #486, sub-issue #487) ---
+//
+// The boolean device API targets GPU index 0 only. The helpers below let a
+// caller place a stream or the default device on a specific GPU, validating
+// the index against the backend's reported device count. They are the
+// foundation for per-rank device placement in single-node tensor
+// parallelism; the consuming TP runtime lands in sub-issue #488.
+
+/// Error returned by the index-aware GPU helpers when the requested GPU
+/// index is outside `0..gpu_device_count()`.
+///
+/// On a single-GPU backend (Metal/Apple, CPU-only) only index 0 is valid, so
+/// any `index > 0` produces this error. On a multi-GPU CUDA host the valid
+/// range widens to the real adapter count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidGpuIndex {
+    /// The out-of-range index that was requested.
+    pub requested: i32,
+    /// The number of usable GPUs reported by the active backend.
+    pub device_count: i32,
+}
+
+impl std::fmt::Display for InvalidGpuIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "GPU index {} is out of range: {} GPU(s) available (valid indices 0..{})",
+            self.requested, self.device_count, self.device_count
+        )
+    }
+}
+
+impl std::error::Error for InvalidGpuIndex {}
+
+/// Number of usable GPUs reported by the active MLX backend.
+///
+/// Portable across backends via MLX's `device_count(DeviceType::gpu)`: Metal
+/// reports 1 (single unified-memory GPU), a CUDA build reports the real
+/// adapter count, and a CPU-only build clamps to 1. Always `>= 1`.
+pub fn gpu_device_count() -> i32 {
+    ffi::gpu_device_count()
+}
+
+/// Validate that `index` names a usable GPU for the active backend.
+///
+/// Returns [`InvalidGpuIndex`] for a negative index or one at/above
+/// [`gpu_device_count`].
+fn check_gpu_index(index: i32) -> Result<(), InvalidGpuIndex> {
+    let device_count = ffi::gpu_device_count();
+    if index < 0 || index >= device_count {
+        return Err(InvalidGpuIndex {
+            requested: index,
+            device_count,
+        });
+    }
+    Ok(())
+}
+
+/// Create a new MLX stream pinned to GPU `index` (0-based).
+///
+/// Index-aware sibling of the boolean `new_stream_on_device`. On a
+/// single-GPU backend only index 0 is valid; `index > 0` returns
+/// [`InvalidGpuIndex`]. On a multi-GPU CUDA host any index in
+/// `0..gpu_device_count()` is valid. This is the foundation for placing each
+/// tensor-parallel rank's compute on its own GPU (epic #486).
+pub fn new_stream_on_gpu(index: i32) -> Result<UniquePtr<MlxStream>, InvalidGpuIndex> {
+    check_gpu_index(index)?;
+    Ok(ffi::new_stream_on_gpu_index(index))
+}
+
+/// Make GPU `index` the default device for subsequent MLX ops.
+///
+/// Validates `index` against [`gpu_device_count`]; index 0 is always valid.
+/// Mirrors the boolean `set_default_device` but targets a specific GPU.
+pub fn set_default_gpu_device(index: i32) -> Result<(), InvalidGpuIndex> {
+    check_gpu_index(index)?;
+    ffi::set_default_device_index(index);
+    Ok(())
+}
+
+/// Create a thread-local MLX stream pinned to GPU `index`.
+///
+/// Index-aware sibling of [`new_thread_local_generation_stream`]; validates
+/// `index` against [`gpu_device_count`]. Intended for the multi-GPU TP
+/// runtime (sub-issue #488) so each rank's worker thread dispatches on its
+/// own GPU.
+pub fn new_thread_local_stream_on_gpu(
+    index: i32,
+) -> Result<UniquePtr<MlxThreadLocalStream>, InvalidGpuIndex> {
+    check_gpu_index(index)?;
+    Ok(ffi::new_thread_local_stream_gpu_index(index))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- Index-aware multi-GPU helpers (epic #486, sub-issue #487) ---
+
+    /// The portable device count is always at least one, on every backend.
+    #[test]
+    fn gpu_device_count_is_at_least_one() {
+        assert!(
+            gpu_device_count() >= 1,
+            "gpu_device_count must report at least one usable GPU"
+        );
+    }
+
+    /// A stream can be created on every valid GPU index `0..count`. On Metal
+    /// this exercises only index 0; on a multi-GPU CUDA host it covers all.
+    #[test]
+    fn new_stream_on_gpu_accepts_every_valid_index() {
+        let count = gpu_device_count();
+        for index in 0..count {
+            let stream = new_stream_on_gpu(index)
+                .unwrap_or_else(|e| panic!("index {index} should be valid: {e}"));
+            assert!(
+                !stream.is_null(),
+                "stream for index {index} must be non-null"
+            );
+        }
+    }
+
+    /// Out-of-range indices (at/above the count, and negative) return the
+    /// typed error carrying the offending index and the device count.
+    #[test]
+    fn new_stream_on_gpu_rejects_out_of_range() {
+        let count = gpu_device_count();
+        match new_stream_on_gpu(count) {
+            Ok(_) => panic!("index == count ({count}) must be rejected"),
+            Err(e) => {
+                assert_eq!(e.requested, count);
+                assert_eq!(e.device_count, count);
+            }
+        }
+        match new_stream_on_gpu(-1) {
+            Ok(_) => panic!("negative index must be rejected"),
+            Err(e) => {
+                assert_eq!(e.requested, -1);
+                assert_eq!(e.device_count, count);
+            }
+        }
+    }
+
+    /// `set_default_gpu_device` validates the index: index 0 always succeeds,
+    /// an at-count index errors. The boolean GPU default is restored so the
+    /// process-global default device is not left mutated for sibling tests.
+    #[test]
+    fn set_default_gpu_device_validates_index() {
+        let count = gpu_device_count();
+        assert!(
+            set_default_gpu_device(count).is_err(),
+            "index == count ({count}) must be rejected"
+        );
+        // Index 0 is the GPU that is already the default on a single-GPU
+        // backend, so installing then restoring leaves the process as-is.
+        set_default_gpu_device(0).expect("index 0 is always valid");
+        ffi::set_default_device(true);
+    }
+
+    /// The thread-local stream factory validates indices the same way.
+    #[test]
+    fn new_thread_local_stream_on_gpu_validates_index() {
+        let count = gpu_device_count();
+        let tls = new_thread_local_stream_on_gpu(0).expect("index 0 is always valid");
+        assert!(!tls.is_null(), "TLS handle for index 0 must be non-null");
+        assert!(
+            new_thread_local_stream_on_gpu(count).is_err(),
+            "index == count ({count}) must be rejected"
+        );
+    }
+
+    /// The typed error renders a human-readable, actionable message naming
+    /// both the bad index and the available device count.
+    #[test]
+    fn invalid_gpu_index_display_is_actionable() {
+        let err = InvalidGpuIndex {
+            requested: 3,
+            device_count: 1,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains('3'),
+            "message should name the bad index: {msg}"
+        );
+        assert!(
+            msg.contains('1'),
+            "message should name the device count: {msg}"
+        );
+    }
+
+    /// CUDA-gated: a trivial op runs on a non-default GPU index and produces
+    /// the correct result. Compiled only under the `cuda` feature (no Metal
+    /// build risk) and skipped on a single-GPU CUDA host. Authored for a
+    /// multi-GPU CUDA box; not exercised on this Apple/Metal machine.
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn trivial_op_runs_on_non_default_gpu_index() {
+        let count = gpu_device_count();
+        if count < 2 {
+            // Single-GPU CUDA host: no second device to target.
+            return;
+        }
+        // Pin the default device to GPU 1, compute 1 + 1 there, then restore.
+        set_default_gpu_device(1).expect("index 1 valid on a multi-GPU host");
+        let a = ffi::ones(&[1], crate::dtype::FLOAT32);
+        let b = ffi::ones(&[1], crate::dtype::FLOAT32);
+        let c = ffi::add(&a, &b);
+        ffi::eval(&c);
+        let value = ffi::item_f32(&c);
+        set_default_gpu_device(0).expect("index 0 is always valid");
+        assert_eq!(value, 2.0, "1 + 1 on GPU 1 should equal 2");
+    }
 
     /// Smoke test: the TLS handle factory either succeeds (GPU build)
     /// or returns `None` cleanly (CPU-only build).

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -1103,6 +1103,10 @@ fn validate_pipeline_parallel_startup(startup: &ServerStartupConfig) -> Result<(
 
 fn log_endpoints(startup: &ServerStartupConfig, addr: &str) {
     tracing::info!("Starting mlxcel server on {}", addr);
+    // Surface the backend's GPU count at startup (epic #486, sub-issue #487).
+    // On Metal this is always 1; on a CUDA multi-GPU host it reports the real
+    // adapter count that `--tp-size` can target.
+    tracing::info!("Detected {} GPU(s)", mlxcel_core::gpu_device_count());
     tracing::info!("Endpoints:");
     tracing::info!("  POST /v1/chat/completions  - OpenAI chat completions");
     tracing::info!("  POST /v1/completions       - OpenAI text completions");


### PR DESCRIPTION
## Summary

Adds an index-aware GPU device and stream surface to `mlxcel-core`, the foundation for single-node multi-GPU tensor parallelism (epic #486, sub-issue 1 of 2). The device API was binary CPU/GPU and always targeted GPU index 0, so there was no way to place work on a specific GPU of a multi-GPU node. Sub-issue #488 (the multi-GPU TP runtime) consumes this surface and lands on CUDA hardware.

## What changed

**C++ bridge (`mlx_cxx_bridge.{h,cpp}`)**: new entry points built on MLX's portable device API, so they compile identically on Metal, a CUDA multi-GPU host, and a CPU-only build with no CUDA headers and no preprocessor gating.

- `gpu_device_count() -> i32` via `mlx::core::device_count(Device::gpu)`, clamped to `>= 1` (Metal reports 1, a CUDA build reports the real adapter count).
- `new_stream_on_gpu_index`, `set_default_device_index`, `new_thread_local_stream_gpu_index` via the `Device(DeviceType, index)` constructor.
- `copy_array_to_stream` via `mlx::core::copy(array, stream)` for cross-device materialization (used by sub-issue #488 to move shards between GPUs).

**Rust FFI and safe wrappers (`lib.rs`, `streams.rs`)**: the raw bridge functions are mirrored in the `extern "C++"` block; ergonomic safe wrappers in `streams` (`new_stream_on_gpu`, `set_default_gpu_device`, `new_thread_local_stream_on_gpu`) validate the index against `gpu_device_count()` and return a typed `InvalidGpuIndex` error.

**Integration**: the server startup banner (`log_endpoints`) and the CLI model-load path both log the detected GPU count, exercising the new API in a real code path before sub-issue #488 lands.

## Design note

The issue suggested `cudaGetDeviceCount` for the device count. MLX at the pinned commit already exposes a portable `device_count(DeviceType)` (`mlx/device.h`), so no CUDA runtime header or link is needed: the same code is correct across Metal, CUDA, and CPU-only builds. This removes the only part of the issue that would otherwise have required CUDA-host-only code.

## Testing

Verified on macOS / Apple Silicon (Metal), where `gpu_device_count()` is 1.

- `cargo build` (default/Metal features): green.
- `cargo test -p mlxcel-core --lib streams`: 12/12 pass, including device-count `>= 1`, stream creation on every valid index, out-of-range rejection (at-count and negative), default-device and thread-local validation, and the typed-error message.
- `cargo clippy --all-targets` and `cargo fmt --check`: clean.

The multi-GPU behavior (index `> 0`) is not reachable on a single-GPU Metal machine, so index-`> 0` placement and the cross-GPU `copy` path are validated in sub-issue #488 on CUDA hardware. A `#[cfg(feature = "cuda")]` test (`trivial_op_runs_on_non_default_gpu_index`) is included for that host; the `cuda` feature cannot be built on macOS (no CUDA toolkit), so the cuda build path is verified on a CUDA box as part of #488.

## Acceptance criteria

- [x] New bridge functions compile on the default (Metal/Apple) build. The cuda build is verified on a CUDA host as part of #488.
- [x] `gpu_device_count()` returns `>= 1` on all targets and reports the true count on a multi-GPU CUDA host.
- [x] Rust unit tests: device-count `>= 1`; a stream on each valid index succeeds; an out-of-range index returns the typed error.
- [x] CUDA-gated test runs a trivial op on a non-default GPU index (compiled under the `cuda` feature; runs on a multi-GPU CUDA host).
- [x] `gpu_device_count()` is surfaced and logged at server and CLI startup.
- [x] No clippy or fmt regressions.

Closes #487
