### PR TITLE
feat: build the OpenXLA (xla-iree) backend on macOS with a Metal HAL device (#449)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 fn main() {
     println!("cargo:rerun-if-env-changed=IREE_DIST");
     println!("cargo:rerun-if-env-changed=IREE_CUDA_HOME");
+    println!("cargo:rerun-if-env-changed=IREE_MACOS_HOME");
 
     // The feature env is set for this crate's own enabled features; `xla-iree`
     // becomes `CARGO_FEATURE_XLA_IREE`.
@@ -25,37 +26,137 @@ fn main() {
         return;
     }
 
-    // CUDA mode (GB10): link the source-built cuda-enabled IREE runtime instead
-    // of the prebuilt dist (mutually exclusive; IREE_CUDA_HOME wins). The
-    // source-built `libiree_runtime_unified.a` already bundles the cuda driver
-    // impl + local-task, so whole-archive only it (re-linking the separate cuda
-    // impl libs would multiply-define their objects); the cuda registration
-    // wrapper (driver_module.c.o, pulled by the shim's explicit register call),
-    // IREE's vendored printf (the unified printf.c.o needs vsnprintf_), and flatcc
-    // go in a group. The cuda driver dlopens libcuda at runtime (no -lcuda).
-    if let Ok(home) = env::var("IREE_CUDA_HOME") {
-        let b = PathBuf::from(home).join("build");
-        let unified = b.join("runtime/src/iree/runtime/libiree_runtime_unified.a");
+    // macOS (Apple Silicon dev path): Apple ld, not GNU ld. IREE ships no macOS
+    // iree-dist, so the runtime is the source-built libiree_runtime_unified.a
+    // under IREE_MACOS_HOME. Apple ld uses -force_load (not --whole-archive), is
+    // multi-pass (no --start-group), and has no libgcc. force_load the unified
+    // runtime so use_all_available_drivers + the VM keep all their objects; link
+    // the per-driver and flatcc archives normally so only the members unified
+    // lacks (the driver registration objects) are pulled, without duplicating the
+    // impl objects unified already bundles. The Metal HAL driver needs the system
+    // frameworks.
+    #[cfg(target_os = "macos")]
+    {
+        let home = env::var("IREE_MACOS_HOME").unwrap_or_else(|_| {
+            panic!(
+                "the `xla-iree` feature is enabled on macOS but IREE_MACOS_HOME is \
+                 not set (there is no prebuilt macOS iree-dist); run \
+                 scripts/iree/setup-macos.sh and export the env it prints"
+            )
+        });
+        let build_root = PathBuf::from(home).join("build");
+        let runtime = build_root.join("runtime/src");
+        let unified = runtime.join("iree/runtime/libiree_runtime_unified.a");
         assert!(
             unified.exists(),
-            "IREE_CUDA_HOME build is missing {} (run the runtime build first)",
+            "IREE_MACOS_HOME build is missing {} (run scripts/iree/setup-macos.sh first)",
             unified.display()
         );
-        for d in [
-            "runtime/src/iree/runtime",
-            "runtime/src/iree/hal/drivers/cuda/registration",
-            "build_tools/third_party/flatcc",
-            "build_tools/third_party/printf",
-        ] {
-            println!("cargo:rustc-link-search=native={}", b.join(d).display());
+        // force_load ONLY the unified runtime: all of its objects must be present
+        // for use_all_available_drivers + the VM, and it already bundles the
+        // local-task / metal driver *impl* objects. The per-driver archives and
+        // flatcc are linked normally (no -force_load) so the linker pulls only the
+        // members unified lacks -- chiefly each driver's *registration* object,
+        // which unified's register-all references. force_loading those archives
+        // too would duplicate the impl objects unified already carries.
+        println!("cargo:rustc-link-arg=-Wl,-force_load,{}", unified.display());
+        let mut extra = Vec::new();
+        collect_driver_archives(&runtime.join("iree/hal/drivers"), &mut extra);
+        // flatcc (vmfb FlatBuffer verify/parse) is referenced by the runtime and
+        // the metal driver but lives outside the runtime tree and is not bundled
+        // into the unified archive, so link it explicitly.
+        let flatcc = build_root.join("build_tools/third_party/flatcc/libflatcc_parsing.a");
+        assert!(
+            flatcc.exists(),
+            "IREE_MACOS_HOME build is missing {} (run scripts/iree/setup-macos.sh first)",
+            flatcc.display()
+        );
+        extra.push(flatcc);
+        for a in &extra {
+            println!("cargo:rustc-link-arg={}", a.display());
         }
+        // The Metal HAL driver is Objective-C against the system frameworks.
+        for fw in ["Metal", "Foundation", "QuartzCore"] {
+            println!("cargo:rustc-link-arg=-framework");
+            println!("cargo:rustc-link-arg={fw}");
+        }
+        println!("cargo:rustc-link-lib=c++");
+        return;
+    }
+
+    // The CUDA and Linux-dist recipes below are GNU-ld only and never apply on
+    // macOS (handled by the arm above), so they are gated out there to keep the
+    // macOS build free of dead code.
+    #[cfg(not(target_os = "macos"))]
+    {
+        // CUDA mode (GB10): link the source-built cuda-enabled IREE runtime instead
+        // of the prebuilt dist (mutually exclusive; IREE_CUDA_HOME wins). The
+        // source-built `libiree_runtime_unified.a` already bundles the cuda driver
+        // impl + local-task, so whole-archive only it (re-linking the separate cuda
+        // impl libs would multiply-define their objects); the cuda registration
+        // wrapper (driver_module.c.o, pulled by the shim's explicit register call),
+        // IREE's vendored printf (the unified printf.c.o needs vsnprintf_), and flatcc
+        // go in a group. The cuda driver dlopens libcuda at runtime (no -lcuda).
+        if let Ok(home) = env::var("IREE_CUDA_HOME") {
+            let b = PathBuf::from(home).join("build");
+            let unified = b.join("runtime/src/iree/runtime/libiree_runtime_unified.a");
+            assert!(
+                unified.exists(),
+                "IREE_CUDA_HOME build is missing {} (run the runtime build first)",
+                unified.display()
+            );
+            for d in [
+                "runtime/src/iree/runtime",
+                "runtime/src/iree/hal/drivers/cuda/registration",
+                "build_tools/third_party/flatcc",
+                "build_tools/third_party/printf",
+            ] {
+                println!("cargo:rustc-link-search=native={}", b.join(d).display());
+            }
+            for arg in [
+                "-Wl,--whole-archive",
+                "-l:libiree_runtime_unified.a",
+                "-Wl,--no-whole-archive",
+                "-Wl,--start-group",
+                "-l:libiree_hal_drivers_cuda_registration_registration.a",
+                "-l:libprintf_printf.a",
+                "-l:libflatcc_parsing.a",
+                "-lgcc",
+                "-lm",
+                "-lpthread",
+                "-ldl",
+                "-Wl,--end-group",
+            ] {
+                println!("cargo:rustc-link-arg={arg}");
+            }
+            return;
+        }
+
+        let dist = env::var("IREE_DIST").expect(
+            "the `xla-iree` feature is enabled but IREE_DIST is not set; point it at \
+         the extracted iree-dist-<ver>-linux-<arch> tree (include/, lib/, bin/)",
+        );
+        let lib = PathBuf::from(dist).join("lib");
+        assert!(
+            lib.join("libiree_runtime_unified.a").exists(),
+            "IREE_DIST lib dir {} is missing libiree_runtime_unified.a",
+            lib.display()
+        );
+        println!("cargo:rustc-link-search=native={}", lib.display());
+
+        // GNU ld is single-pass, left to right. The shim object (linked via
+        // mlxcel-xla's rustc-link-lib) references the runtime; `--whole-archive` on
+        // the unified runtime archive forces in all its objects (including the
+        // local-task HAL driver registration that try_create_default_device needs),
+        // so the shim's references resolve regardless of order. flatcc (vmfb
+        // parsing), libgcc (aarch64 outline atomics), and libm (CPU-kernel math)
+        // sit after the runtime in a group so ld re-scans cross-references.
         for arg in [
             "-Wl,--whole-archive",
             "-l:libiree_runtime_unified.a",
             "-Wl,--no-whole-archive",
             "-Wl,--start-group",
-            "-l:libiree_hal_drivers_cuda_registration_registration.a",
-            "-l:libprintf_printf.a",
+            "-l:libflatcc_runtime.a",
             "-l:libflatcc_parsing.a",
             "-lgcc",
             "-lm",
@@ -65,41 +166,27 @@ fn main() {
         ] {
             println!("cargo:rustc-link-arg={arg}");
         }
-        return;
     }
+}
 
-    let dist = env::var("IREE_DIST").expect(
-        "the `xla-iree` feature is enabled but IREE_DIST is not set; point it at \
-         the extracted iree-dist-<ver>-linux-<arch> tree (include/, lib/, bin/)",
-    );
-    let lib = PathBuf::from(dist).join("lib");
-    assert!(
-        lib.join("libiree_runtime_unified.a").exists(),
-        "IREE_DIST lib dir {} is missing libiree_runtime_unified.a",
-        lib.display()
-    );
-    println!("cargo:rustc-link-search=native={}", lib.display());
-
-    // GNU ld is single-pass, left to right. The shim object (linked via
-    // mlxcel-xla's rustc-link-lib) references the runtime; `--whole-archive` on
-    // the unified runtime archive forces in all its objects (including the
-    // local-task HAL driver registration that try_create_default_device needs),
-    // so the shim's references resolve regardless of order. flatcc (vmfb
-    // parsing), libgcc (aarch64 outline atomics), and libm (CPU-kernel math)
-    // sit after the runtime in a group so ld re-scans cross-references.
-    for arg in [
-        "-Wl,--whole-archive",
-        "-l:libiree_runtime_unified.a",
-        "-Wl,--no-whole-archive",
-        "-Wl,--start-group",
-        "-l:libflatcc_runtime.a",
-        "-l:libflatcc_parsing.a",
-        "-lgcc",
-        "-lm",
-        "-lpthread",
-        "-ldl",
-        "-Wl,--end-group",
-    ] {
-        println!("cargo:rustc-link-arg={arg}");
+/// Recursively collect the enabled HAL driver static archives under
+/// `<build>/runtime/src/iree/hal/drivers` for the macOS link recipe (linked
+/// normally, so only the registration members unified lacks are pulled). The
+/// top-level `libiree_hal_drivers_drivers.a` (the register-all init) is already
+/// bundled into `libiree_runtime_unified.a`, so it is skipped.
+#[cfg(target_os = "macos")]
+fn collect_driver_archives(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_driver_archives(&path, out);
+        } else if path.extension().is_some_and(|e| e == "a")
+            && path.file_name().and_then(|n| n.to_str()) != Some("libiree_hal_drivers_drivers.a")
+        {
+            out.push(path);
+        }
     }
 }

--- a/scripts/iree/setup-macos.sh
+++ b/scripts/iree/setup-macos.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Set up the IREE toolchain for the mlxcel OpenXLA backend (`xla-iree`) on macOS
+# (Apple Silicon). IREE publishes no prebuilt macOS `iree-dist`, only linux dists
+# and python wheels, so this script:
+#
+#   1. installs the pinned macOS `iree-compile` (metal-spirv codegen) from the
+#      universal2 wheel into a private venv, and
+#   2. source-builds the IREE *runtime* (runtime only, no LLVM) with the
+#      local-task / local-sync / metal HAL drivers,
+#
+# then prints the env the cargo `xla-iree` build needs. This mirrors the manual
+# CUDA (`IREE_CUDA_HOME`) setup, automated. Idempotent: re-running reuses an
+# existing clone/build/venv.
+#
+# Usage:
+#   scripts/iree/setup-macos.sh                 # build into the default dir
+#   eval "$(scripts/iree/setup-macos.sh --env)" # just print/apply the exports
+#
+# After it finishes, build and run the backend:
+#   eval "$(scripts/iree/setup-macos.sh --env)"
+#   cargo build --release --features metal,accelerate,xla-iree
+#   MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=metal \
+#     ./target/release/mlxcel generate -m <Llama-3.2-1B-Instruct dir> -p "..." -n 48
+set -euo pipefail
+
+# --- pinned IREE version (keep in sync with the runtime/compiler the vmfbs are
+# authored against; see CLAUDE.md "MLX upstream commit upgrade" sibling note) ---
+IREE_TAG="iree-3.12.0rc20260626"
+# macOS universal2, cp312-abi3 (works on CPython >= 3.12). sha256 from the
+# iree-org GitHub release assets for ${IREE_TAG}.
+WHEEL="iree_base_compiler-3.12.0rc20260626-cp312-abi3-macosx_13_0_universal2.whl"
+WHEEL_SHA256="21e76f89f206f396c34845ed8d9da93236038398b60e5597dc9ada2b51b70ae6"
+
+IREE_DIR="${MLXCEL_IREE_MACOS_DIR:-$HOME/.cache/mlxcel/iree-macos}"
+SRC="$IREE_DIR/src"
+BUILD="$IREE_DIR/build"
+VENV="$IREE_DIR/venv"
+IREE_COMPILE="$VENV/bin/iree-compile"
+
+emit_env() {
+  echo "export IREE_MACOS_HOME=$IREE_DIR"
+  echo "export IREE_MACOS_COMPILE=$IREE_COMPILE"
+  echo "export MLXCEL_XLA_IREE_COMPILE=$IREE_COMPILE"
+}
+
+# `--env`: assume already built; just print the exports.
+if [ "${1:-}" = "--env" ]; then
+  emit_env
+  exit 0
+fi
+
+log() { printf '\033[1;34m[setup-macos]\033[0m %s\n' "$*" >&2; }
+
+# --- prerequisites ---
+[ "$(uname -s)" = "Darwin" ] || { echo "this script is macOS-only" >&2; exit 1; }
+for tool in git cmake python3 curl shasum; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
+done
+PYV=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+python3 -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3,12) else 1)' \
+  || { echo "need python >= 3.12 for the cp312-abi3 wheel (have $PYV)" >&2; exit 1; }
+
+mkdir -p "$IREE_DIR"
+
+# --- 1. iree-compile from the pinned macOS wheel, into a private venv ---
+if [ ! -x "$IREE_COMPILE" ]; then
+  log "creating venv and installing $WHEEL"
+  python3 -m venv "$VENV"
+  curl -sSL -o "$IREE_DIR/$WHEEL" \
+    "https://github.com/iree-org/iree/releases/download/${IREE_TAG}/${WHEEL}"
+  GOT=$(shasum -a 256 "$IREE_DIR/$WHEEL" | awk '{print $1}')
+  [ "$GOT" = "$WHEEL_SHA256" ] || { echo "sha256 mismatch for $WHEEL: got $GOT" >&2; exit 1; }
+  "$VENV/bin/python" -m pip install -q --upgrade pip
+  "$VENV/bin/python" -m pip install -q --no-deps "$IREE_DIR/$WHEEL"
+  [ -x "$IREE_COMPILE" ] || { echo "iree-compile not found after install" >&2; exit 1; }
+else
+  log "reusing iree-compile at $IREE_COMPILE"
+fi
+
+# --- 2. source-build the IREE runtime (runtime only; local + metal drivers) ---
+if [ ! -d "$SRC/.git" ]; then
+  log "cloning IREE runtime source @ $IREE_TAG (shallow, no LLVM)"
+  git clone --depth 1 --branch "$IREE_TAG" https://github.com/iree-org/iree.git "$SRC"
+fi
+# The runtime build needs only flatcc (vmfb parsing); skip the compiler-only
+# submodules (llvm-project, stablehlo, torch-mlir, ...) entirely.
+if [ ! -e "$SRC/third_party/flatcc/.git" ]; then
+  log "initializing flatcc submodule only"
+  git -C "$SRC" submodule update --init --depth 1 -- third_party/flatcc
+fi
+
+UNIFIED="$BUILD/runtime/src/iree/runtime/libiree_runtime_unified.a"
+if [ ! -f "$UNIFIED" ]; then
+  log "configuring runtime-only build (local-task/local-sync/metal)"
+  cmake -S "$SRC" -B "$BUILD" -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DIREE_ERROR_ON_MISSING_SUBMODULES=OFF \
+    -DIREE_BUILD_COMPILER=OFF -DIREE_BUILD_TESTS=OFF -DIREE_BUILD_SAMPLES=OFF \
+    -DIREE_BUILD_BENCHMARKS=OFF \
+    -DIREE_HAL_DRIVER_DEFAULTS=OFF \
+    -DIREE_HAL_DRIVER_LOCAL_TASK=ON -DIREE_HAL_DRIVER_LOCAL_SYNC=ON \
+    -DIREE_HAL_DRIVER_METAL=ON
+  log "building iree_runtime_unified"
+  cmake --build "$BUILD" --target iree_runtime_unified -j "$(sysctl -n hw.ncpu)"
+  [ -f "$UNIFIED" ] || { echo "runtime build did not produce $UNIFIED" >&2; exit 1; }
+else
+  log "reusing runtime build at $BUILD"
+fi
+
+log "done. IREE_MACOS_HOME=$IREE_DIR"
+echo >&2
+echo "# Run this (or: eval \"\$(scripts/iree/setup-macos.sh --env)\") to export the build env:" >&2
+emit_env

--- a/src/lib/mlxcel-xla/README.md
+++ b/src/lib/mlxcel-xla/README.md
@@ -73,6 +73,40 @@ Validated on a GB10 (Grace-Blackwell, sm_121): token-exact 48/48, ~5 tok/s
 (~2.6x the CPU path). Vulkan via the prebuilt dist does **not** work on the GB10
 (IREE's Vulkan allocator vs NVIDIA's unified memory), so CUDA is the GPU path.
 
+### macOS (Apple Silicon, Metal) build
+
+On Apple Silicon, **MLX is the default and primary backend**; this OpenXLA path
+is a development / parity path, opt-in exactly like CUDA. IREE publishes no macOS
+`iree-dist` (only linux dists + python wheels), so the runtime is **source-built**
+like the CUDA path. `scripts/iree/setup-macos.sh` automates it: it installs the
+pinned macOS `iree-compile` (metal-spirv codegen) from the universal2 wheel into a
+private venv, source-builds the IREE runtime (`local-task`/`local-sync`/`metal`
+drivers), and prints the env.
+
+```bash
+# 1. One-time setup (clones + builds the IREE runtime; idempotent).
+eval "$(scripts/iree/setup-macos.sh)"        # sets IREE_MACOS_HOME, MLXCEL_XLA_IREE_COMPILE
+# (later shells: eval "$(scripts/iree/setup-macos.sh --env)")
+
+# 2. Build with real execution on (alongside the usual MLX features).
+cargo build --release --features metal,accelerate,xla-iree
+
+# 3. Opt into XLA at runtime; MLX stays default when these are unset.
+#    CPU (local-task), token-exact vs the HF temp-0 reference:
+MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=local-task ./target/release/mlxcel generate \
+  -m <Llama-3.2-1B-Instruct dir> -p "The capital of France is" -n 48
+#    Apple GPU (Metal):
+MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=metal ./target/release/mlxcel generate \
+  -m <Llama-3.2-1B-Instruct dir> -p "The capital of France is" -n 48
+```
+
+Validated on an M1 Ultra: `metal` is token-exact with the `local-task` path
+(which is itself token-exact vs the HF temp-0 reference) and ~1.9x its tok/s. The
+root `build.rs` macOS arm uses Apple `ld` (`-force_load`, no `--whole-archive` /
+`--start-group` / `-lgcc`) and links the Metal/Foundation/QuartzCore frameworks;
+the C shim is unchanged (the `metal` driver registers via
+`use_all_available_drivers`).
+
 ### Scope / limits
 
 - The bundled graphs are authored for **Llama-3.2-1B-Instruct** specifically;

--- a/src/lib/mlxcel-xla/build.rs
+++ b/src/lib/mlxcel-xla/build.rs
@@ -24,6 +24,8 @@ fn main() {
     println!("cargo:rerun-if-env-changed=IREE_DIST");
     println!("cargo:rerun-if-env-changed=IREE_CUDA_HOME");
     println!("cargo:rerun-if-env-changed=IREE_CUDA_COMPILE");
+    println!("cargo:rerun-if-env-changed=IREE_MACOS_HOME");
+    println!("cargo:rerun-if-env-changed=IREE_MACOS_COMPILE");
     // cfg used by src/iree.rs to select the cuda iree-compile / device behavior.
     println!("cargo:rustc-check-cfg=cfg(xla_iree_cuda)");
 
@@ -58,6 +60,37 @@ fn main() {
             .compile("xla_iree");
         println!("cargo:rustc-cfg=xla_iree_cuda");
         if let Ok(ic) = env::var("IREE_CUDA_COMPILE") {
+            println!("cargo:rustc-env=MLXCEL_XLA_IREE_COMPILE={ic}");
+        }
+        return;
+    }
+
+    // macOS (Apple Silicon dev path). IREE publishes no macOS iree-dist (only
+    // linux dists + python wheels), so the runtime is source-built like the CUDA
+    // path and IREE_MACOS_HOME points at that iree source+build tree (src/ and
+    // build/). The shim compiles against the in-tree runtime headers. The vmfbs
+    // are lowered by the pinned macOS universal2 iree-compile (it has metal-spirv
+    // codegen), set via IREE_MACOS_COMPILE (baked here) or MLXCEL_XLA_IREE_COMPILE
+    // at runtime. The runtime link recipe (Apple ld -force_load + Metal
+    // frameworks) lives in the root build.rs. scripts/iree/setup-macos.sh
+    // produces this tree and prints the matching env.
+    #[cfg(target_os = "macos")]
+    if let Ok(home) = env::var("IREE_MACOS_HOME") {
+        let home = PathBuf::from(home);
+        let src_inc = home.join("src/runtime/src");
+        let bld_inc = home.join("build/runtime/src");
+        assert!(
+            src_inc.join("iree/runtime/api.h").exists(),
+            "IREE_MACOS_HOME={} is not an iree source+build tree (missing \
+             src/runtime/src/iree/runtime/api.h); run scripts/iree/setup-macos.sh",
+            home.display()
+        );
+        cc::Build::new()
+            .file("csrc/xla_iree.c")
+            .include(&src_inc)
+            .include(&bld_inc)
+            .compile("xla_iree");
+        if let Ok(ic) = env::var("IREE_MACOS_COMPILE") {
             println!("cargo:rustc-env=MLXCEL_XLA_IREE_COMPILE={ic}");
         }
         return;

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -227,10 +227,14 @@ fn iree_compile_bin() -> Result<PathBuf, String> {
 /// iree-compile target flags for a HAL device. `local-task`/`local-sync` -> the
 /// CPU (llvm-cpu) target; `cuda` -> the CUDA target (only usable in a cuda
 /// build, whose runtime registers the cuda driver and whose iree-compile has
-/// cuda codegen).
+/// cuda codegen); `metal` -> the Metal target (metal-spirv codegen; the Apple
+/// Silicon dev path, where the macOS runtime registers the metal driver and the
+/// pinned macOS universal2 iree-compile has metal-spirv codegen).
 fn target_flags(device: &str) -> Result<&'static [&'static str], String> {
     if device == "cuda" {
         Ok(&["--iree-hal-target-device=cuda"])
+    } else if device == "metal" {
+        Ok(&["--iree-hal-target-device=metal"])
     } else if device.starts_with("local") {
         Ok(&[
             "--iree-hal-target-device=local",
@@ -238,8 +242,8 @@ fn target_flags(device: &str) -> Result<&'static [&'static str], String> {
         ])
     } else {
         Err(format!(
-            "unsupported OpenXLA device {device:?}; use \"local-task\" (CPU) or, in a \
-             cuda build, \"cuda\""
+            "unsupported OpenXLA device {device:?}; use \"local-task\" (CPU), \
+             \"metal\" (Apple Silicon GPU, macOS build), or \"cuda\" (cuda build)"
         ))
     }
 }


### PR DESCRIPTION
Closes #504.

## What

macOS (Apple Silicon) build + run support for the OpenXLA (`xla-iree`) backend, plus a **Metal** HAL device target so the bundled Llama-3.2-1B graphs run on the Apple GPU. MLX stays the default and primary backend on Apple Silicon; XLA is opt-in via `MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=metal`, exactly like the CUDA dev path.

IREE publishes no macOS `iree-dist` (only linux dists + python wheels), so the runtime is **source-built** like the CUDA `IREE_CUDA_HOME` path.

## Changes

- **root `build.rs`**: a `target_os = "macos"` Apple-ld recipe (`-force_load` the unified runtime; link the per-driver and flatcc archives normally so only the registration members unified lacks are pulled, avoiding duplicate symbols; link `Metal`/`Foundation`/`QuartzCore` and `libc++`). The GNU-ld CUDA/dist recipes are gated to non-macOS, so the macOS build carries no dead code.
- **`mlxcel-xla/build.rs`**: a `target_os = "macos"` arm compiling the C shim against the `IREE_MACOS_HOME` source tree, baking `MLXCEL_XLA_IREE_COMPILE` from `IREE_MACOS_COMPILE`.
- **`iree.rs`**: `target_flags()` accepts `metal` (`--iree-hal-target-device=metal`).
- **`scripts/iree/setup-macos.sh`**: turnkey, idempotent IREE toolchain setup (pinned macOS-wheel `iree-compile` + runtime source build), printing the env.
- **`mlxcel-xla/README.md`**: macOS build/run section.

The C shim is unchanged: the `metal` driver registers via `use_all_available_drivers` once the runtime is built with it.

## Validation (M1 Ultra, IREE `iree-3.12.0rc20260626`)

- `scripts/iree/setup-macos.sh` source-builds the runtime (`local-task`/`local-sync`/`metal`) and installs the pinned `iree-compile`.
- `cargo build --release --features metal,accelerate,xla-iree` **links**; no new Rust warnings. `cargo fmt --check` clean.
- `mlxcel generate` on `metal` is **token-exact with the `local-task` CPU path** (itself token-exact vs the HF temp-0 reference) at **~1.9x its tok/s** (1.45 vs 0.75 tok/s, Llama-3.2-1B-Instruct, greedy).
- Default builds untouched: the macOS arms are `#[cfg(target_os = "macos")]` behind the `xla-iree` feature, and `iree.rs` lives in the `xla-backend`-only crate, so default / Linux / CUDA builds are unchanged.

## Notes

- The Metal device path is a dev/parity path; not perf-tuned (correctness first).
- Apple-Silicon shipping builds still never compile `xla-backend`.
