### PR TITLE
feat: default the OpenXLA (xla-iree) HAL device to Metal on Apple Silicon (#449)

### DIFF
--- a/src/lib/mlxcel-xla/README.md
+++ b/src/lib/mlxcel-xla/README.md
@@ -91,21 +91,32 @@ eval "$(scripts/iree/setup-macos.sh)"        # sets IREE_MACOS_HOME, MLXCEL_XLA_
 # 2. Build with real execution on (alongside the usual MLX features).
 cargo build --release --features metal,accelerate,xla-iree
 
-# 3. Opt into XLA at runtime; MLX stays default when these are unset.
-#    CPU (local-task), token-exact vs the HF temp-0 reference:
-MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=local-task ./target/release/mlxcel generate \
+# 3. Opt into XLA at runtime; MLX stays default when MLXCEL_BACKEND is unset.
+#    On Apple Silicon the XLA device defaults to `metal`, so just:
+MLXCEL_BACKEND=xla ./target/release/mlxcel generate \
   -m <Llama-3.2-1B-Instruct dir> -p "The capital of France is" -n 48
-#    Apple GPU (Metal):
-MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=metal ./target/release/mlxcel generate \
+#    Force the CPU path (token-exact vs the HF temp-0 reference) if you need it:
+MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=local-task ./target/release/mlxcel generate \
   -m <Llama-3.2-1B-Instruct dir> -p "The capital of France is" -n 48
 ```
 
-Validated on an M1 Ultra: `metal` is token-exact with the `local-task` path
-(which is itself token-exact vs the HF temp-0 reference) and ~1.9x its tok/s. The
-root `build.rs` macOS arm uses Apple `ld` (`-force_load`, no `--whole-archive` /
-`--start-group` / `-lgcc`) and links the Metal/Foundation/QuartzCore frameworks;
-the C shim is unchanged (the `metal` driver registers via
-`use_all_available_drivers`).
+On Apple Silicon `MLXCEL_XLA_DEVICE` defaults to `metal` (the GPU); set it to
+`local-task` to force the CPU path. Validated on an M1 Ultra: `metal` is
+token-exact with the `local-task` path (which is itself token-exact vs the HF
+temp-0 reference) and ~1.9x its tok/s.
+
+This is a correctness / parity path, **not** a performance path: on the same
+M1 Ultra and model (Llama-3.2-1B-Instruct, greedy, 64 tokens), MLX runs at
+~186 tok/s versus ~1.6 tok/s for XLA-on-Metal (~117x), because the bundled XLA
+graphs are f32 and use generic metal-spirv codegen with a per-step host logits
+readback, while MLX uses bf16 hand-tuned Metal kernels. MLX remains the
+production Apple-Silicon backend; XLA-on-Metal exists to run the same StableHLO
+graphs that target CUDA/Linux on a Mac for development and parity.
+
+The root `build.rs` macOS arm uses Apple `ld` (`-force_load`, no
+`--whole-archive` / `--start-group` / `-lgcc`) and links the
+Metal/Foundation/QuartzCore frameworks; the C shim is unchanged (the `metal`
+driver registers via `use_all_available_drivers`).
 
 ### Scope / limits
 

--- a/src/lib/mlxcel-xla/src/lib.rs
+++ b/src/lib/mlxcel-xla/src/lib.rs
@@ -141,12 +141,33 @@ pub struct XlaInferenceSession {
     cache_len: i32,
 }
 
+/// The default HAL device when `MLXCEL_XLA_DEVICE` is unset.
+///
+/// On Apple Silicon (macOS) the `xla-iree` runtime is built with the Metal
+/// driver and Metal is the GPU, so default to `"metal"` (the dev/parity path,
+/// faster than the CPU fallback). Elsewhere default to the portable multithreaded
+/// CPU (`"local-task"`). CUDA is never auto-selected: it needs a cuda build and
+/// device, so set `MLXCEL_XLA_DEVICE=cuda` explicitly. Override the default on any
+/// platform with `MLXCEL_XLA_DEVICE`.
+#[must_use]
+pub fn default_device() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "metal"
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "local-task"
+    }
+}
+
 impl XlaInferenceSession {
     /// Prepare a session for a model directory.
     ///
     /// Under the `iree` feature this verifies the model architecture, compiles
     /// the bundled `prefill` / `decode_step` graphs, and uploads the weights as
-    /// resident device buffers (on `MLXCEL_XLA_DEVICE`, default `"local-task"`).
+    /// resident device buffers (on `MLXCEL_XLA_DEVICE`, default
+    /// [`default_device`]: `"metal"` on Apple Silicon, `"local-task"` elsewhere).
     /// Without the feature it only records the inputs so the seam wiring stays
     /// exercisable.
     ///
@@ -160,7 +181,7 @@ impl XlaInferenceSession {
         #[cfg(feature = "iree")]
         {
             let device =
-                std::env::var("MLXCEL_XLA_DEVICE").unwrap_or_else(|_| "local-task".to_string());
+                std::env::var("MLXCEL_XLA_DEVICE").unwrap_or_else(|_| default_device().to_string());
             let engine = iree::IreeLlama::load(model_path, &device)?;
             Ok(Self {
                 model_path: model_path.to_path_buf(),
@@ -337,5 +358,14 @@ mod tests {
     fn empty_prompt_is_rejected() {
         let mut s = session();
         assert!(s.generate_greedy(&[], 8, &[2]).is_err());
+    }
+
+    #[test]
+    fn default_device_is_metal_on_apple_silicon_else_cpu() {
+        let d = default_device();
+        #[cfg(target_os = "macos")]
+        assert_eq!(d, "metal");
+        #[cfg(not(target_os = "macos"))]
+        assert_eq!(d, "local-task");
     }
 }

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -876,7 +876,8 @@ pub(crate) fn spawn_legacy_model_worker(
 /// [`XlaServeWorker`](crate::server::batch::XlaServeWorker) through the
 /// [`BatchEngine`](crate::server::batch::BatchEngine) contract. `b_max` is one of
 /// the engine's bundled slot counts; the HAL device is read from
-/// `MLXCEL_XLA_DEVICE` (default `local-task`), matching the single-sequence path.
+/// `MLXCEL_XLA_DEVICE` (default [`mlxcel_xla::default_device`]: `metal` on Apple
+/// Silicon, `local-task` elsewhere), matching the single-sequence path.
 #[cfg(feature = "xla-iree")]
 pub(crate) fn spawn_xla_model_worker(
     model_path: PathBuf,
@@ -891,8 +892,8 @@ pub(crate) fn spawn_xla_model_worker(
         // Same fail-fast posture as the MLX workers (issue #375): abort the
         // process on an uncaught panic rather than unwinding away a serve thread.
         run_core_thread_or_abort("model-worker-xla", move || {
-            let device =
-                std::env::var("MLXCEL_XLA_DEVICE").unwrap_or_else(|_| "local-task".to_string());
+            let device = std::env::var("MLXCEL_XLA_DEVICE")
+                .unwrap_or_else(|_| mlxcel_xla::default_device().to_string());
             tracing::info!(
                 "Model worker thread starting (OpenXLA continuous batching, B_max={b_max}, \
                  device={device}), loading model..."


### PR DESCRIPTION
Closes #507.

## What

When `MLXCEL_XLA_DEVICE` is unset, default the OpenXLA backend's HAL device to `metal` on Apple Silicon (macOS) instead of `local-task`. Follow-up to #504 / PR #506.

This does **not** change the backend default: MLX stays default and primary (unset `MLXCEL_BACKEND` keeps MLX). It only changes the default *device within the OpenXLA backend* once a developer opts in with `MLXCEL_BACKEND=xla`.

## Changes

- `mlxcel_xla::default_device()` returns `"metal"` on `target_os = "macos"`, `"local-task"` elsewhere.
- Both `MLXCEL_XLA_DEVICE` default sites use it: the single-sequence session (`mlxcel-xla/src/lib.rs`) and the server worker (`src/server/model_worker.rs`).
- Unit test (platform decision table) + doc comments + `mlxcel-xla/README.md`.

An explicit `MLXCEL_XLA_DEVICE` still wins on every platform; non-macOS keeps `local-task`; CUDA is never auto-selected.

## Validation (M1 Ultra)

- `cargo test --release -p mlxcel-xla` passes (43 tests incl. the new `default_device` decision-table test). `cargo fmt --check` clean. `cargo build --release --features metal,accelerate,xla-iree` links, no new warnings.
- Smoke: `MLXCEL_BACKEND=xla` with `MLXCEL_XLA_DEVICE` unset runs at ~1.6 tok/s (the Metal GPU path; the CPU `local-task` path is ~0.75), confirming Metal is auto-selected.

## Note on performance

XLA-on-Metal is a dev/parity path, not a performance path. Profiled (`iree-benchmark-module`), the decode step is ~600 ms on the Apple GPU (the time is in the f32 metal-spirv kernels, not host overhead), versus ~5 ms/token for MLX (~117x). MLX remains the production Apple-Silicon backend; this PR only makes Metal the default *device* within XLA, where it is ~2x the CPU fallback and token-exact with it.
