### PR TITLE
feat: f16/bf16 precision mode for the OpenXLA emitter (#449)

### DIFF
--- a/src/lib/mlxcel-xla/README.md
+++ b/src/lib/mlxcel-xla/README.md
@@ -118,6 +118,31 @@ The root `build.rs` macOS arm uses Apple `ld` (`-force_load`, no
 Metal/Foundation/QuartzCore frameworks; the C shim is unchanged (the `metal`
 driver registers via `use_all_available_drivers`).
 
+### Precision (low-precision matmul)
+
+`MLXCEL_XLA_PRECISION` selects the contraction (matmul) input precision, authored
+in the emitted StableHLO graph so it applies on every IREE target (CPU, CUDA,
+Metal, and future NPUs), not just one backend:
+
+- `f32` (default) — unchanged.
+- `f16` / `bf16` — demote the f32 inputs of every `dot_general` to the narrow
+  type while keeping the f32 accumulate and output, so only the matmuls change
+  and the sensitive elementwise ops (norm, softmax, RoPE) stay f32. A blanket
+  program-wide f32 to f16 is deliberately not done (it regressed accuracy and was
+  slower).
+
+```bash
+MLXCEL_XLA_PRECISION=f16 MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=metal \
+  ./target/release/mlxcel generate -m <Llama-3.2-1B-Instruct dir> -p "..." -n 48
+```
+
+On an M1 Ultra (Llama-3.2-1B-Instruct, greedy) `f16` is ~1.9x the `f32` tok/s and
+token-exact with it. The same graph change also speeds up the CPU (`local-task`)
+path. Weights are still uploaded f32 and demoted in the graph; keeping the
+resident weights in the narrow type (a bandwidth win that needs the f16 weight
+FFI) lands with the quantized-weight path. This is a transferable, correctness
+first lever; it does not close the gap to MLX (see the perf note above).
+
 ### Scope / limits
 
 - The bundled graphs are authored for **Llama-3.2-1B-Instruct** specifically;

--- a/src/lib/mlxcel-xla/src/emitter/builder.rs
+++ b/src/lib/mlxcel-xla/src/emitter/builder.rs
@@ -45,9 +45,49 @@ pub struct Val {
     pub ty: Ty,
 }
 
+/// Contraction (matmul) input precision. `F32` is the default (unchanged
+/// behavior). `F16` / `Bf16` demote the f32 inputs of every `dot_general` to the
+/// narrow type while keeping the f32 accumulate and output, so only the matmuls
+/// change and the sensitive elementwise ops (norm, softmax, RoPE) stay f32. This
+/// is authored in the graph (portable to every IREE target), matching
+/// `--iree-global-opt-demote-contraction-inputs-type=f16`. A blanket f32->f16 of
+/// the whole program is deliberately NOT done (it regressed norm/softmax/accum).
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum Precision {
+    #[default]
+    F32,
+    F16,
+    Bf16,
+}
+
+impl Precision {
+    /// The narrow element type to demote contraction inputs to, or `None` for
+    /// f32 (no demotion).
+    fn dot_elt(self) -> Option<&'static str> {
+        match self {
+            Precision::F32 => None,
+            Precision::F16 => Some("f16"),
+            Precision::Bf16 => Some("bf16"),
+        }
+    }
+}
+
+/// The contraction precision selected by `MLXCEL_XLA_PRECISION` (`f16` / `bf16`,
+/// else f32). Read once when a graph is emitted; a different value changes the
+/// emitted MLIR, so the vmfb content-hash cache keys each precision separately.
+#[must_use]
+pub fn precision_from_env() -> Precision {
+    match std::env::var("MLXCEL_XLA_PRECISION").as_deref() {
+        Ok("f16") => Precision::F16,
+        Ok("bf16") => Precision::Bf16,
+        _ => Precision::F32,
+    }
+}
+
 pub struct Builder {
     body: String,
     next: usize,
+    precision: Precision,
 }
 
 fn dims_list(d: &[usize]) -> String {
@@ -76,7 +116,15 @@ impl Builder {
         Builder {
             body: String::new(),
             next: 0,
+            precision: Precision::F32,
         }
+    }
+
+    /// Set the contraction precision (builder-style). Default is `F32`.
+    #[must_use]
+    pub fn with_precision(mut self, precision: Precision) -> Self {
+        self.precision = precision;
+        self
     }
 
     pub fn body(&self) -> &str {
@@ -195,8 +243,9 @@ impl Builder {
         Val { name: r, ty }
     }
 
-    /// Unused by decode today; kept for the int4 dequant path (int -> f32).
-    #[allow(dead_code)]
+    /// Element-type conversion (`stablehlo.convert`), preserving shape. Used by
+    /// the low-precision contraction path (f32 -> f16/bf16) and reserved for the
+    /// int dequant path.
     pub fn convert(&mut self, x: &Val, elt: &'static str) -> Val {
         let ty = Ty::new(x.ty.shape.clone(), elt);
         let r = self.fresh();
@@ -548,6 +597,27 @@ impl Builder {
         rhs_contract: &[usize],
         out_shape: Vec<usize>,
     ) -> Val {
+        // Low-precision mode: demote the f32 contraction inputs to the narrow
+        // type, keeping the f32 accumulate + output (`ty` below stays f32). Only
+        // matmuls change; norm/softmax/RoPE stay f32. No-op under `Precision::F32`.
+        let lhs_demoted;
+        let rhs_demoted;
+        let (lhs, rhs) = match self.precision.dot_elt() {
+            Some(elt) => {
+                lhs_demoted = if lhs.ty.elt == "f32" {
+                    self.convert(lhs, elt)
+                } else {
+                    lhs.clone()
+                };
+                rhs_demoted = if rhs.ty.elt == "f32" {
+                    self.convert(rhs, elt)
+                } else {
+                    rhs.clone()
+                };
+                (&lhs_demoted, &rhs_demoted)
+            }
+            None => (lhs, rhs),
+        };
         let ty = Ty::new(out_shape, "f32");
         let r = self.fresh();
         let batch = if lhs_batch.is_empty() && rhs_batch.is_empty() {
@@ -588,5 +658,49 @@ impl Builder {
         let l = x.ty.shape[0];
         let n = w.ty.shape[0];
         self.dot_general(x, w, &[], &[], &[1], &[1], vec![l, n])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn f32_dot_emits_no_convert() {
+        let mut b = Builder::new(); // default Precision::F32
+        let x = Builder::arg(0, Ty::f32(vec![2048]));
+        let w = Builder::arg(1, Ty::f32(vec![512, 2048]));
+        let _ = b.linear(&x, &w);
+        assert!(!b.body().contains("stablehlo.convert"));
+        assert!(b.body().contains("stablehlo.dot_general"));
+    }
+
+    #[test]
+    fn f16_dot_demotes_inputs_and_keeps_f32_accumulate() {
+        let mut b = Builder::new().with_precision(Precision::F16);
+        let x = Builder::arg(0, Ty::f32(vec![2048]));
+        let w = Builder::arg(1, Ty::f32(vec![512, 2048]));
+        let y = b.linear(&x, &w);
+        let body = b.body();
+        // Both f32 operands are demoted to f16 (two converts).
+        assert_eq!(body.matches("stablehlo.convert").count(), 2);
+        assert!(body.contains("-> tensor<2048xf16>"));
+        assert!(body.contains("-> tensor<512x2048xf16>"));
+        // The dot consumes f16 inputs but accumulates/outputs f32.
+        assert!(body.contains("(tensor<2048xf16>, tensor<512x2048xf16>) -> tensor<512xf32>"));
+        assert_eq!(y.ty.elt, "f32");
+    }
+
+    #[test]
+    fn bf16_dot_demotes_to_bf16() {
+        let mut b = Builder::new().with_precision(Precision::Bf16);
+        let x = Builder::arg(0, Ty::f32(vec![8]));
+        let w = Builder::arg(1, Ty::f32(vec![4, 8]));
+        let _ = b.linear(&x, &w);
+        assert!(b.body().contains("-> tensor<8xbf16>"));
+        assert!(
+            b.body()
+                .contains("(tensor<8xbf16>, tensor<4x8xbf16>) -> tensor<4xf32>")
+        );
     }
 }

--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -14,7 +14,7 @@
 //! `embed` matrix (see [`take_lm_head`]); a tied checkpoint emits no such arg and
 //! is byte-identical to before.
 
-use super::builder::{Builder, Ty, Val};
+use super::builder::{Builder, Ty, Val, precision_from_env};
 use super::config::Config;
 use super::rope;
 
@@ -428,7 +428,7 @@ fn apply_rope(b: &mut Builder, x: &Val, cos: &Val, sin: &Val, heads: usize, d: u
 /// 2b pattern); otherwise it returns the raw `[V]` logits.
 pub fn emit_decode(c: &Config, sample: bool) -> String {
     let (decls, a) = build_arg_schema(c);
-    let mut b = Builder::new();
+    let mut b = Builder::new().with_precision(precision_from_env());
     let k = emit_consts(&mut b, c);
 
     let h = c.hidden;
@@ -728,7 +728,7 @@ fn apply_rope_batched(
 /// returns `[B]` token ids; otherwise it returns `[B, V]` logits.
 pub fn emit_decode_batched(c: &Config, bsz: usize, sample: bool) -> String {
     let (decls, a) = build_batched_arg_schema(c, bsz);
-    let mut b = Builder::new();
+    let mut b = Builder::new().with_precision(precision_from_env());
     let k = emit_consts(&mut b, c);
 
     let h = c.hidden;
@@ -1012,7 +1012,7 @@ fn apply_rope_ragged(
 /// token ids; otherwise returns `[B, V]` logits.
 pub fn emit_decode_ragged(c: &Config, bsz: usize, sample: bool) -> String {
     let (decls, a) = build_ragged_arg_schema(c, bsz);
-    let mut b = Builder::new();
+    let mut b = Builder::new().with_precision(precision_from_env());
     let k = emit_consts(&mut b, c);
     // Constant row indices 0..bsz for the per-row KV-write dim-0 offsets.
     let row_idx: Vec<Val> = (0..bsz).map(|i| b.const_i32(i as i32)).collect();
@@ -1310,7 +1310,7 @@ fn apply_rope_seq(
 pub fn emit_prefill(c: &Config, sample: bool) -> String {
     let lp = PREFILL_LP;
     let (decls, a) = build_prefill_arg_schema(c, lp);
-    let mut b = Builder::new();
+    let mut b = Builder::new().with_precision(precision_from_env());
     let k = emit_consts(&mut b, c);
 
     let h = c.hidden;


### PR DESCRIPTION
Closes #514. Part of #513.

## What

A `Precision` on the OpenXLA StableHLO emitter's `Builder` that demotes the f32 inputs of every `dot_general` (matmul) to f16/bf16 while keeping the f32 accumulate and output. Only the matmuls change; the sensitive elementwise ops (norm, softmax, RoPE) stay f32. Authored **in the graph**, so it is portable to every IREE target (CPU, CUDA, Metal, future NPUs), matching `--iree-global-opt-demote-contraction-inputs-type=f16`.

Selected by `MLXCEL_XLA_PRECISION` (`f16` | `bf16`, default `f32`). The emitted MLIR differs, so `compile_one`'s content-hash vmfb cache keys each precision separately with no extra plumbing.

## Changes

- `emitter/builder.rs`: `Precision` enum + `precision_from_env()`; `Builder` carries it (default `F32`, `with_precision()`); `dot_general` converts f32 operands to the narrow type (f32 output) when set. Unit tests for the f16/bf16 demotion.
- `emitter/model.rs`: the four `emit_*` entry points read `precision_from_env()`.
- `mlxcel-xla/README.md`: a Precision section.

## Design notes

- **Targeted, not blanket.** A program-wide `--iree-input-demote-f32-to-f16` was measured *slower* (f16 norm/softmax/accumulation backfires), so only the contraction inputs are demoted.
- **Weights stay f32-resident** and are demoted in the graph (no FFI change). Keeping the resident weights in the narrow type (a memory-bandwidth win needing the f16 weight FFI) lands with the quantized-weight path (#516), where it matters more; on Metal the decode is compute-bound here, so resident-f16's marginal benefit is a future-NPU concern.

## Validation (M1 Ultra, Llama-3.2-1B-Instruct, greedy)

- `MLXCEL_XLA_PRECISION=f16` on Metal: **2.89 tok/s vs 1.53 (f32) = ~1.9x**, output **token-exact** with f32.
- The same graph change speeds up the CPU (`local-task`) path too.
- The **F32 default is byte-identical** to before: the emitter byte-exact regression test (`from_json_reproduces_bundled_assets_byte_for_byte`) still passes. 46/46 `mlxcel-xla` unit tests green; `cargo fmt --check` clean; emitter clippy clean.
- Default / non-macOS builds unaffected (change is in the `xla-backend`-only crate; the F32 path is a no-op passthrough).

## Note on performance

This is a transferable, correctness-first lever, not a path to MLX parity. XLA-on-Metal remains a dev/parity path (the remaining gap is IREE metal-spirv kernel codegen, out of scope). The value is that this one graph change benefits every IREE target, which is the entry ticket for low-precision-native NPUs.
