### PR TITLE
feat: add Gemma2 sliding-window (local/global) attention

### DIFF
--- a/spike/openxla/gemma2_sliding_window_check.py
+++ b/spike/openxla/gemma2_sliding_window_check.py
@@ -1,0 +1,217 @@
+"""Execution check for issue #495: Gemma2 sliding-window (local/global) attention.
+
+Validates the mlxcel-xla Rust emitter's Gemma2 sliding-window mask against an
+independent HF fp32 Gemma2 oracle, on a small synthetic model so the 4096-token
+production window can be shrunk to bite inside the emitter's 256-slot cache
+(`MAX_SEQ`). transformers 5.x Gemma2 uses the same schedule the emitter does:
+`layer_types = [sliding, full, sliding, full, ...]` (even layers local), a
+per-local-layer `config.sliding_window`, and `(1 + weight)` RMSNorm; so a matched
+config lets us compare last-token logits directly.
+
+Method (weights fed identically to both sides, so the ONLY variable is the mask):
+  1. Build one small HF Gemma2 (random weights; the 1-D norm weights, which HF
+     inits to zero, are randomized so the norms are exercised). Freeze its
+     state_dict.
+  2. For each window W in {inert (>= prompt length), biting (< prompt length)}:
+       - emit the prefill graph for a matched Gemma2 config (window W) via the
+         scoped, pure-Rust `dump_prefill_graph_for_execution_check` test,
+       - compile it with IREE (llvm-cpu) and run it on the frozen weights,
+       - run HF (eager, fp32) with `sliding_window = W` on the same tokens,
+       - compare last-token logits (argmax + max abs diff).
+  3. Confirm the biting window actually changes HF's output vs the inert window
+     (so the "token-exact at the biting window" result is not vacuous).
+
+Run (from the repo, using the spike venv's python):
+    MLXCEL spike venv python  spike/openxla/gemma2_sliding_window_check.py
+
+Exit 0 = PASS. Short prompt / CPU target, streams progress (watchdog-safe).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+import torch
+from iree.compiler.tools import compile_file
+from iree.runtime import load_vm_flatbuffer_file
+from transformers import Gemma2Config, Gemma2ForCausalLM
+
+WORKTREE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PREFILL_LP = 256  # emitter MAX_SEQ / prefill bucket
+PROMPT_LEN = 24  # > biting window, < inert window and < PREFILL_LP
+TOL = 2e-2  # last-token logit tolerance (Gemma2 tanh soft-cap near-ties)
+
+# Small Gemma2 dims shared by the emitter config and the HF config. head_dim is
+# deliberately not hidden/heads (n_q*head_dim = 32 != hidden = 16) to exercise the
+# non-square o_proj, as in real Gemma2.
+DIMS = dict(
+    hidden_size=16,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=8,
+    intermediate_size=32,
+    num_hidden_layers=4,
+    vocab_size=64,
+    rms_norm_eps=1e-6,
+    rope_theta=10000.0,
+    max_position_embeddings=512,
+    query_pre_attn_scalar=8,
+    attn_logit_softcapping=50.0,
+    final_logit_softcapping=30.0,
+    hidden_activation="gelu_pytorch_tanh",
+)
+WINDOWS = {"inert": 64, "biting": 8}  # 64 >= PROMPT_LEN (no-op); 8 < PROMPT_LEN
+
+
+def arg_order_names(n_layers):
+    """The emitter's weight arg order for a tied, bias-free Gemma2 (matches
+    `weight_names` in iree.rs: embed, final_norm, then per layer down, gate,
+    in_ln, post_ln, up, wk, wo, wq, wv, pre_ff, post_ff)."""
+    names = ["model.embed_tokens.weight", "model.norm.weight"]
+    for i in range(n_layers):
+        p = f"model.layers.{i}."
+        for suf in (
+            "mlp.down_proj.weight",
+            "mlp.gate_proj.weight",
+            "input_layernorm.weight",
+            "post_attention_layernorm.weight",
+            "mlp.up_proj.weight",
+            "self_attn.k_proj.weight",
+            "self_attn.o_proj.weight",
+            "self_attn.q_proj.weight",
+            "self_attn.v_proj.weight",
+            "pre_feedforward_layernorm.weight",
+            "post_feedforward_layernorm.weight",
+        ):
+            names.append(p + suf)
+    return names
+
+
+def build_reference_weights():
+    torch.manual_seed(0)
+    cfg = Gemma2Config(**DIMS, sliding_window=WINDOWS["inert"])
+    model = Gemma2ForCausalLM(cfg).eval().float()
+    with torch.no_grad():
+        for _, param in model.named_parameters():
+            if param.dim() == 1:  # RMSNorm weights (HF inits them to zero)
+                param.copy_(torch.randn_like(param) * 0.1)
+    return {k: v.detach().clone() for k, v in model.state_dict().items()}
+
+
+def emitter_logits(window, weights_np, tokens, positions, real_len):
+    cfg_json = dict(
+        model_type="gemma2",
+        hidden_size=DIMS["hidden_size"],
+        num_attention_heads=DIMS["num_attention_heads"],
+        num_key_value_heads=DIMS["num_key_value_heads"],
+        head_dim=DIMS["head_dim"],
+        intermediate_size=DIMS["intermediate_size"],
+        num_hidden_layers=DIMS["num_hidden_layers"],
+        vocab_size=DIMS["vocab_size"],
+        rms_norm_eps=DIMS["rms_norm_eps"],
+        rope_theta=DIMS["rope_theta"],
+        query_pre_attn_scalar=DIMS["query_pre_attn_scalar"],
+        attn_logit_softcapping=DIMS["attn_logit_softcapping"],
+        final_logit_softcapping=DIMS["final_logit_softcapping"],
+        sliding_window=window,
+        tie_word_embeddings=True,
+    )
+    workdir = tempfile.mkdtemp(prefix=f"gemma2_sw_{window}_")
+    cfg_path = os.path.join(workdir, "config.json")
+    mlir_path = os.path.join(workdir, "prefill.mlir")
+    vmfb_path = os.path.join(workdir, "prefill.vmfb")
+    with open(cfg_path, "w") as fh:
+        json.dump(cfg_json, fh)
+
+    print(f"[emit] window={window}: cargo dump prefill graph ...", flush=True)
+    subprocess.run(
+        [
+            "cargo",
+            "test",
+            "-p",
+            "mlxcel-xla",
+            "--lib",
+            "emitter::tests::dump_prefill_graph_for_execution_check",
+            "--",
+            "--ignored",
+            "--nocapture",
+        ],
+        cwd=WORKTREE,
+        env={**os.environ, "MLXCEL_DUMP_CONFIG": cfg_path, "MLXCEL_DUMP_OUT": mlir_path},
+        check=True,
+    )
+
+    print(f"[compile] window={window}: iree-compile (llvm-cpu) ...", flush=True)
+    compile_file(
+        mlir_path,
+        output_file=vmfb_path,
+        input_type="stablehlo",
+        target_backends=["llvm-cpu"],
+    )
+
+    print(f"[run] window={window}: IREE prefill ...", flush=True)
+    mod = load_vm_flatbuffer_file(vmfb_path, driver="local-task")
+    inputs = list(weights_np) + [tokens, positions, real_len]
+    out = mod.main(*inputs)
+    logits = out[0].to_host() if hasattr(out[0], "to_host") else np.asarray(out[0])
+    return np.asarray(logits, dtype=np.float32)
+
+
+def hf_logits(window, state_dict, prompt):
+    cfg = Gemma2Config(**DIMS, sliding_window=window)
+    cfg._attn_implementation = "eager"  # eager applies Gemma2 logit soft-capping
+    model = Gemma2ForCausalLM(cfg).eval().float()
+    model.load_state_dict(state_dict)
+    with torch.no_grad():
+        out = model(input_ids=torch.tensor(prompt[None, :], dtype=torch.long))
+    return out.logits[0, PROMPT_LEN - 1].numpy().astype(np.float32)
+
+
+def main():
+    state_dict = build_reference_weights()
+    names = arg_order_names(DIMS["num_hidden_layers"])
+    weights_np = [np.ascontiguousarray(state_dict[n].numpy(), dtype=np.float32) for n in names]
+
+    rng = np.random.default_rng(0)
+    prompt = rng.integers(0, DIMS["vocab_size"], size=PROMPT_LEN).astype(np.int32)
+    tokens = np.zeros(PREFILL_LP, dtype=np.int32)
+    tokens[:PROMPT_LEN] = prompt
+    positions = np.arange(PREFILL_LP, dtype=np.int32)
+    real_len = np.asarray(PROMPT_LEN, dtype=np.int32)
+
+    ok = True
+    hf_by_window = {}
+    for tag, window in WINDOWS.items():
+        li = emitter_logits(window, weights_np, tokens, positions, real_len)
+        lh = hf_logits(window, state_dict, prompt)
+        hf_by_window[tag] = lh
+        diff = float(np.max(np.abs(li - lh)))
+        ai, ah = int(li.argmax()), int(lh.argmax())
+        match = ai == ah and diff < TOL
+        ok = ok and match
+        print(
+            f"[{tag}] window={window} argmax iree={ai} hf={ah} "
+            f"max|logit diff|={diff:.3e} -> {'OK' if match else 'MISMATCH'}",
+            flush=True,
+        )
+
+    # The biting window must actually change HF's output vs the inert window, else
+    # "token-exact at the biting window" would be a vacuous no-op.
+    bite = float(np.max(np.abs(hf_by_window["inert"] - hf_by_window["biting"])))
+    bit = bite > TOL
+    ok = ok and bit
+    print(
+        f"[bite] HF max|logit diff| inert-vs-biting = {bite:.3e} -> "
+        f"{'window bites' if bit else 'NO EFFECT (window did not bite)'}",
+        flush=True,
+    )
+
+    print("RESULT:", "PASS" if ok else "FAIL", flush=True)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -75,6 +75,15 @@ pub struct Config {
     pub attn_logit_softcap: Option<f32>,
     /// Gemma2 final logit soft-cap on the LM-head logits. `None` for Llama / Qwen2.
     pub final_logit_softcap: Option<f32>,
+    /// Gemma2 sliding-window attention (issue #495): `Some(window)` makes the
+    /// local (even) layers attend only to the last `window` keys, while the
+    /// global (odd) layers keep full-context attention. Read from `config.json`'s
+    /// `sliding_window` (HF Gemma2 default 4096) for a gemma2 checkpoint. `None`
+    /// for Llama / Qwen2, whose every layer is global; the emitter then emits no
+    /// window ops, so those graphs are byte-identical. (Qwen2's own
+    /// `sliding_window` field is deliberately ignored: the emitter serves Qwen2
+    /// with `use_sliding_window = false` semantics.)
+    pub sliding_window: Option<usize>,
 }
 
 impl Config {
@@ -103,6 +112,7 @@ impl Config {
             query_pre_attn_scalar: None,
             attn_logit_softcap: None,
             final_logit_softcap: None,
+            sliding_window: None,
         }
     }
 
@@ -254,6 +264,22 @@ impl Config {
             (None, None, None)
         };
 
+        // Gemma2 sliding-window size (issue #495). Read only for a gemma2
+        // checkpoint; an absent field falls back to the HF Gemma2 default of 4096.
+        // Non-gemma2 architectures get `None` (global attention on every layer),
+        // even if their config carries a `sliding_window` (e.g. Qwen2.5, which the
+        // emitter serves without sliding-window attention).
+        let sliding_window = if gemma2 {
+            Some(
+                v.get("sliding_window")
+                    .and_then(serde_json::Value::as_u64)
+                    .map(|x| x as usize)
+                    .unwrap_or(4096),
+            )
+        } else {
+            None
+        };
+
         Ok(Config {
             hidden,
             inter: u("intermediate_size")?,
@@ -272,6 +298,7 @@ impl Config {
             query_pre_attn_scalar,
             attn_logit_softcap,
             final_logit_softcap,
+            sliding_window,
         })
     }
 
@@ -300,5 +327,15 @@ impl Config {
     /// narrowed, matching HF's `hidden_size**0.5` cast to the activation dtype).
     pub fn embed_normalizer(&self) -> f32 {
         (self.hidden as f64).sqrt() as f32
+    }
+
+    /// Whether attention layer `li` uses sliding-window (local) attention (issue
+    /// #495). Gemma2 alternates local and global attention starting local, so the
+    /// even layers (0, 2, 4, …) are local and the odd layers are global, matching
+    /// HF `Gemma2DecoderLayer` (`is_sliding = not bool(layer_idx % 2)`). Only a
+    /// config with a sliding window (Gemma2) has local layers; Llama / Qwen2
+    /// return `false` for every layer, so their emitted graphs are unchanged.
+    pub fn is_sliding_layer(&self, li: usize) -> bool {
+        self.sliding_window.is_some() && li.is_multiple_of(2)
     }
 }

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -89,6 +89,35 @@ mod tests {
             query_pre_attn_scalar: None,
             attn_logit_softcap: None,
             final_logit_softcap: None,
+            sliding_window: None,
+        }
+    }
+
+    /// A tiny Gemma2-shaped config for the sliding-window structural tests
+    /// (issue #495). `n_layers = 4` gives two local (even) and two global (odd)
+    /// layers so the alternation is observable; `sliding_window` is the only knob
+    /// under test. The soft-caps / four-norm structure are set so the graph is a
+    /// faithful (small) Gemma2, but the window mask is independent of them.
+    fn gemma2_like(sliding_window: Option<usize>) -> Config {
+        Config {
+            hidden: 8,
+            inter: 16,
+            n_layers: 4,
+            n_q: 2,
+            n_kv: 1,
+            head_dim: 4,
+            eps: 1e-6,
+            rope_theta: 10_000.0,
+            vocab: 10,
+            rope: RopeScaling::Plain,
+            qkv_bias: false,
+            tie_word_embeddings: true,
+            quantization: None,
+            gemma2: true,
+            query_pre_attn_scalar: Some(4.0),
+            attn_logit_softcap: Some(50.0),
+            final_logit_softcap: Some(30.0),
+            sliding_window,
         }
     }
 
@@ -192,6 +221,11 @@ mod tests {
         assert_eq!(c.final_logit_softcap, Some(30.0));
         assert_eq!(c.head_dim, 256, "explicit head_dim (!= hidden/n_q)");
         assert!(c.tie_word_embeddings, "Gemma2 ties embeddings by default");
+        assert_eq!(
+            c.sliding_window,
+            Some(4096),
+            "absent sliding_window defaults to the HF Gemma2 4096"
+        );
         // The scale is query_pre_attn_scalar^-0.5 (224), NOT head_dim^-0.5 (256).
         assert_eq!(c.scale(), (224.0f64.powf(-0.5)) as f32);
         assert_ne!(c.scale(), (256.0f32).powf(-0.5), "must not use head_dim");
@@ -380,6 +414,187 @@ mod tests {
                 "{name}: expected final_norm < lm_head < layer0 arg order"
             );
         }
+    }
+
+    /// Issue #495: Gemma2 parses its sliding-window size, defaulting to the HF
+    /// Gemma2 default (4096) when the field is absent; a non-Gemma2 architecture
+    /// gets `None` even when its own config carries a `sliding_window` (Qwen2.5
+    /// ships `sliding_window = 32768` but the emitter serves it globally).
+    #[test]
+    fn from_json_parses_sliding_window() {
+        // Explicit window on a gemma2 checkpoint (gemma2-2b ships 4096).
+        let explicit = r#"{"model_type":"gemma2","hidden_size":8,"num_attention_heads":2,
+            "num_key_value_heads":1,"intermediate_size":16,"num_hidden_layers":4,
+            "rms_norm_eps":1e-6,"rope_theta":1e4,"vocab_size":10,"sliding_window":4096}"#;
+        assert_eq!(
+            Config::from_json_str(explicit)
+                .expect("gemma2 parses")
+                .sliding_window,
+            Some(4096)
+        );
+
+        // Absent field -> HF Gemma2 default of 4096.
+        let absent = r#"{"model_type":"gemma2","hidden_size":8,"num_attention_heads":2,
+            "num_key_value_heads":1,"intermediate_size":16,"num_hidden_layers":4,
+            "rms_norm_eps":1e-6,"rope_theta":1e4,"vocab_size":10}"#;
+        assert_eq!(
+            Config::from_json_str(absent)
+                .expect("gemma2 parses")
+                .sliding_window,
+            Some(4096),
+            "absent sliding_window defaults to 4096"
+        );
+
+        // Qwen2.5 ships a sliding_window (32768) but the emitter serves it with
+        // global attention, so it must parse to None (not the config value).
+        let qwen = Config::from_json_str(QWEN_CONFIG_JSON).expect("qwen parses");
+        assert_eq!(qwen.sliding_window, None, "Qwen2 sliding_window is ignored");
+
+        // Llama has no window.
+        assert_eq!(Config::llama_3_2_1b().sliding_window, None);
+    }
+
+    /// The local/global schedule (issue #495): Gemma2 alternates starting local,
+    /// so even layers are local (sliding) and odd layers global; a config with no
+    /// window (Llama / Qwen2, or a Gemma2 control with the window off) has no local
+    /// layer, so its graphs are unchanged.
+    #[test]
+    fn is_sliding_layer_alternates_even_local() {
+        let g = gemma2_like(Some(4096));
+        assert!(g.is_sliding_layer(0), "layer 0 local");
+        assert!(!g.is_sliding_layer(1), "layer 1 global");
+        assert!(g.is_sliding_layer(2), "layer 2 local");
+        assert!(!g.is_sliding_layer(3), "layer 3 global");
+
+        let none = gemma2_like(None);
+        for li in 0..none.n_layers {
+            assert!(!none.is_sliding_layer(li), "no window -> no local layer");
+        }
+        for li in 0..4 {
+            assert!(!qwen_like(true).is_sliding_layer(li), "Qwen2 is global");
+            assert!(
+                !Config::llama_3_2_1b().is_sliding_layer(li),
+                "Llama is global"
+            );
+        }
+    }
+
+    /// The sliding-window mask is built once per graph and only when a window is
+    /// configured: turning the window on adds exactly one `subtract`, one
+    /// `compare`, and one `select` (the one-time local-mask block) to each graph
+    /// kind, and nothing when the window is `None`. A with/without diff over an
+    /// otherwise-identical Gemma2 config isolates exactly the window surface, so
+    /// the reused-across-local-layers design is confirmed and no stray op shifted.
+    #[test]
+    fn sliding_window_adds_one_local_mask_block_per_graph() {
+        let with = gemma2_like(Some(4096));
+        let without = gemma2_like(None);
+        let graphs = [
+            (
+                emit_decode(&with, false),
+                emit_decode(&without, false),
+                "decode",
+            ),
+            (
+                emit_prefill(&with, false),
+                emit_prefill(&without, false),
+                "prefill",
+            ),
+            (
+                emit_decode_ragged(&with, 4, false),
+                emit_decode_ragged(&without, 4, false),
+                "ragged",
+            ),
+        ];
+        for (g_with, g_without, name) in graphs {
+            assert_eq!(
+                occurs(&g_with, "stablehlo.subtract ") - occurs(&g_without, "stablehlo.subtract "),
+                1,
+                "{name}: one window age subtract"
+            );
+            assert_eq!(
+                occurs(&g_with, "stablehlo.compare ") - occurs(&g_without, "stablehlo.compare "),
+                1,
+                "{name}: one window compare"
+            );
+            assert_eq!(
+                occurs(&g_with, "stablehlo.select ") - occurs(&g_without, "stablehlo.select "),
+                1,
+                "{name}: one window select"
+            );
+        }
+    }
+
+    /// The configured window size is emitted into the graph (as the `i32` constant
+    /// the key age is compared against), so a different window yields a different
+    /// graph. Uses windows that do not collide with the layer-index constants.
+    #[test]
+    fn sliding_window_size_is_emitted_into_the_graph() {
+        let g7 = emit_decode(&gemma2_like(Some(7)), false);
+        let g9 = emit_decode(&gemma2_like(Some(9)), false);
+        assert!(
+            g7.contains("dense<7> : tensor<i32>"),
+            "window 7 constant present"
+        );
+        assert!(!g7.contains("dense<9> : tensor<i32>"));
+        assert!(
+            g9.contains("dense<9> : tensor<i32>"),
+            "window 9 constant present"
+        );
+        assert!(!g9.contains("dense<7> : tensor<i32>"));
+    }
+
+    /// The heart of #495: within one graph the even layers consume the LOCAL
+    /// (sliding-window) mask and the odd layers the GLOBAL (causal) mask, proving
+    /// the per-layer alternation is actually wired, not merely that a local mask
+    /// exists. The score-mask broadcast is `[S] -> [nq, S]` (`dims = [1]`, here
+    /// `tensor<256xf32> -> tensor<2x256xf32>` for the 2-query-head config), and it
+    /// is the only broadcast with that signature; collecting its operand per layer
+    /// in order shows even layers share one mask value, odd layers another, and the
+    /// two differ.
+    #[test]
+    fn local_and_global_layers_use_distinct_masks_alternating() {
+        let g = emit_decode(&gemma2_like(Some(4096)), false);
+        let needle = ", dims = [1] : (tensor<256xf32>) -> tensor<2x256xf32>";
+        let operands: Vec<&str> = g
+            .lines()
+            .filter(|l| l.contains("stablehlo.broadcast_in_dim") && l.contains(needle))
+            .map(|l| {
+                // "  %N = stablehlo.broadcast_in_dim %OP, dims = ..."
+                let after = l
+                    .split("stablehlo.broadcast_in_dim ")
+                    .nth(1)
+                    .expect("broadcast operand");
+                after.split(',').next().expect("operand token").trim()
+            })
+            .collect();
+        assert_eq!(operands.len(), 4, "one mask broadcast per layer");
+        assert_eq!(operands[0], operands[2], "even layers share the local mask");
+        assert_eq!(operands[1], operands[3], "odd layers share the global mask");
+        assert_ne!(
+            operands[0], operands[1],
+            "local (even) and global (odd) masks are distinct values"
+        );
+    }
+
+    /// Opt-in graph dump for the out-of-crate execution check (issue #495). Ignored
+    /// by default; when run with `--ignored` and `MLXCEL_DUMP_CONFIG` /
+    /// `MLXCEL_DUMP_OUT` set, it parses that Gemma2 `config.json` and writes the
+    /// prefill (logits) StableHLO to `MLXCEL_DUMP_OUT`, so the `spike/openxla`
+    /// harness (`gemma2_sliding_window_check.py`) can compile it with IREE and
+    /// compare last-token logits to an HF fp32 Gemma2 oracle at several window
+    /// sizes. Kept as a plain, scoped, pure-Rust entry point so the execution
+    /// check never needs the heavyweight `iree` cargo feature.
+    #[test]
+    #[ignore = "opt-in: writes a graph to disk for the spike/openxla execution check"]
+    fn dump_prefill_graph_for_execution_check() {
+        let cfg_path = std::env::var("MLXCEL_DUMP_CONFIG")
+            .expect("set MLXCEL_DUMP_CONFIG to a Gemma2 config.json path");
+        let out_path =
+            std::env::var("MLXCEL_DUMP_OUT").expect("set MLXCEL_DUMP_OUT to the target .mlir path");
+        let text = std::fs::read_to_string(&cfg_path).expect("read MLXCEL_DUMP_CONFIG");
+        let cfg = Config::from_json_str(&text).expect("parse Gemma2 config.json");
+        std::fs::write(&out_path, emit_prefill(&cfg, false)).expect("write MLXCEL_DUMP_OUT");
     }
 
     /// Plain RoPE base frequencies are the textbook `1 / theta^(2i/head_dim)`

--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -459,6 +459,21 @@ pub fn emit_decode(c: &Config, sample: bool) -> String {
     let zeros_s = b.broadcast(&k.zero, &[], vec![MAX_SEQ]);
     let negs_s = b.broadcast(&k.neg_big, &[], vec![MAX_SEQ]);
     let kmask = b.select(&valid, &zeros_s, &negs_s);
+    // Gemma2 local (sliding-window) mask (issue #495): a local layer additionally
+    // drops keys older than the window, keeping key s iff `cache_len - s < W`. The
+    // global `kmask` already encodes causality, so anding the window in is one more
+    // `select`: within-window -> keep `kmask`, else force -1e30. Built once and
+    // reused by every local layer; emitted only for a config with a window
+    // (Gemma2), so Llama / Qwen2 stay byte-identical. When `W >= MAX_SEQ` the
+    // predicate is always true (`cache_len - s <= MAX_SEQ-1 < W`), so it is a value
+    // no-op, which is why short-context Gemma2 output is unchanged.
+    let kmask_local = c.sliding_window.map(|w| {
+        let wc = b.const_i32(w as i32);
+        let wb = b.broadcast(&wc, &[], vec![MAX_SEQ]);
+        let age = b.subtract(&clen_b, &ii); // cache_len - s
+        let within = b.compare("LT", &age, &wb, "SIGNED");
+        b.select(&within, &kmask, &negs_s)
+    });
 
     let mut kcache = a.kcache.clone();
     let mut vcache = a.vcache.clone();
@@ -513,7 +528,14 @@ pub fn emit_decode(c: &Config, sample: bool) -> String {
             Some(cap) => softcap(&mut b, &scores, cap),
             None => scores,
         };
-        let kmask_b = b.broadcast(&kmask, &[1], vec![nq, MAX_SEQ]);
+        // Local (even) layers use the sliding-window mask; global (odd) layers and
+        // every non-Gemma2 layer use the plain causal `kmask` (same handle, so the
+        // emitted op is unchanged for them).
+        let mask = kmask_local
+            .as_ref()
+            .filter(|_| c.is_sliding_layer(li))
+            .unwrap_or(&kmask);
+        let kmask_b = b.broadcast(mask, &[1], vec![nq, MAX_SEQ]);
         let scores = b.add(&scores, &kmask_b);
 
         // softmax over the key axis
@@ -1046,6 +1068,17 @@ pub fn emit_decode_ragged(c: &Config, bsz: usize, sample: bool) -> String {
     let zeros = b.broadcast(&k.zero, &[], vec![bsz, MAX_SEQ]);
     let negs = b.broadcast(&k.neg_big, &[], vec![bsz, MAX_SEQ]);
     let kmask = b.select(&valid, &zeros, &negs); // [B, S]
+    // Gemma2 local (sliding-window) mask (issue #495), per row: keep key s for row
+    // b iff `cache_len[b] - s < W`. And it into the causal `kmask` with one more
+    // `select`. Emitted only for a windowed config (Gemma2); reused by every local
+    // layer. No-op on the value when `W >= MAX_SEQ` (short-context parity).
+    let kmask_local = c.sliding_window.map(|w| {
+        let wc = b.const_i32(w as i32);
+        let wb = b.broadcast(&wc, &[], vec![bsz, MAX_SEQ]);
+        let age = b.subtract(&clen_b, &ii_b); // cache_len[b] - s
+        let within = b.compare("LT", &age, &wb, "SIGNED");
+        b.select(&within, &kmask, &negs)
+    });
 
     let mut kcache = a.kcache.clone();
     let mut vcache = a.vcache.clone();
@@ -1122,7 +1155,13 @@ pub fn emit_decode_ragged(c: &Config, bsz: usize, sample: bool) -> String {
             Some(cap) => softcap(&mut b, &scores, cap),
             None => scores,
         };
-        let kmask_b = b.broadcast(&kmask, &[0, 2], vec![bsz, nq, MAX_SEQ]); // [B,S] -> [B,nq,S]
+        // Local (even) layers use the per-row sliding-window mask; global (odd) and
+        // non-Gemma2 layers use the plain causal `kmask` (unchanged handle).
+        let mask = kmask_local
+            .as_ref()
+            .filter(|_| c.is_sliding_layer(li))
+            .unwrap_or(&kmask);
+        let kmask_b = b.broadcast(mask, &[0, 2], vec![bsz, nq, MAX_SEQ]); // [B,S] -> [B,nq,S]
         let scores = b.add(&scores, &kmask_b);
 
         let m = b.reduce_max(&scores, 2, &k.neg_inf);
@@ -1342,6 +1381,19 @@ pub fn emit_prefill(c: &Config, sample: bool) -> String {
     let zeros = b.broadcast(&k.zero, &[], vec![lp, lp]);
     let negs = b.broadcast(&k.neg_big, &[], vec![lp, lp]);
     let cmask = b.select(&le, &zeros, &negs); // [Lp, Lp]
+    // Gemma2 local (sliding-window) mask (issue #495): a local layer keeps key j
+    // for query i iff `i - j < W` (prefill positions are 0..Lp, so the buffer
+    // index equals the position). And it into the causal `cmask` with one more
+    // `select`. Emitted only for a windowed config (Gemma2); reused by every local
+    // layer. No-op on the value when `W >= Lp` (`i - j <= Lp-1 < W`), so a
+    // short-prompt Gemma2 prefill is unchanged.
+    let cmask_local = c.sliding_window.map(|w| {
+        let wc = b.const_i32(w as i32);
+        let wb = b.broadcast(&wc, &[], vec![lp, lp]);
+        let age = b.subtract(&row, &col); // i - j
+        let within = b.compare("LT", &age, &wb, "SIGNED");
+        b.select(&within, &cmask, &negs)
+    });
 
     // caches start as zeros; prefill writes the [0:Lp] block and returns them
     let mut kcache = b.broadcast(&k.zero, &[], vec![c.n_layers, MAX_SEQ, nkv, d]);
@@ -1383,7 +1435,13 @@ pub fn emit_prefill(c: &Config, sample: bool) -> String {
             Some(cap) => softcap(&mut b, &scores, cap),
             None => scores,
         };
-        let cmask_b = b.broadcast(&cmask, &[1, 3], vec![nkv, lp, g, lp]);
+        // Local (even) layers use the sliding-window causal mask; global (odd) and
+        // non-Gemma2 layers use the full causal `cmask` (unchanged handle).
+        let mask = cmask_local
+            .as_ref()
+            .filter(|_| c.is_sliding_layer(li))
+            .unwrap_or(&cmask);
+        let cmask_b = b.broadcast(mask, &[1, 3], vec![nkv, lp, g, lp]);
         let scores = b.add(&scores, &cmask_b);
 
         // softmax over the key axis (Lp_j, dim 3)


### PR DESCRIPTION
## Summary

Implements Gemma2's alternating sliding-window (local) / full (global) attention in the OpenXLA emitter (issue #495). The emitter previously emitted global attention on every layer, which is correct only while the context stays under the window; the local (even) layers must stop attending to keys older than the window. The mask is wired from `Config::from_json`, so a Gemma2 checkpoint runs with the correct local/global alternation on both the single-sequence CLI (`MLXCEL_BACKEND=xla`) and the `mlxcel-server` serve path, since both compile the same emitter graphs at load.

## What changed

- `emitter/config.rs`: new `Option<usize> sliding_window` field, read from a gemma2 `config.json` (HF Gemma2 default 4096), left `None` for Llama/Qwen2 (Qwen2's own `sliding_window` is ignored, matching `use_sliding_window = false`). New `is_sliding_layer(li)` schedule: even layers local, odd global (matches HF `Gemma2DecoderLayer`).
- `emitter/model.rs`: in each of the three graph kinds (single decode, prefill, ragged decode), build a local mask once by anding the window into the existing causal mask with one extra `select` (within-window keeps the causal value, else `-1e30`); each local layer broadcasts that mask, each global layer the unchanged causal mask. Emitted only for a windowed config, so Llama/Qwen2 graphs stay byte-identical; a value no-op when the window `>= MAX_SEQ`, so short-context Gemma2 output is unchanged.
- `emitter/mod.rs`: structural tests plus an opt-in (`#[ignore]`) graph-dump test used by the execution check.
- `spike/openxla/gemma2_sliding_window_check.py`: independent HF-oracle execution check (emit -> IREE llvm-cpu -> compare to HF eager fp32).

## Validation

Numbers are from the local run; the full >4096-token GPU sweep is bounded by `MAX_SEQ = 256` (a separate follow-up) and is left for the post-merge gate.

- `cargo test -p mlxcel-xla --lib emitter::tests`: 16 passed (1 ignored). Includes the Llama-3.2-1B byte-for-byte asset test (non-Gemma2 emission unchanged), the even-local schedule, the one-time local-mask block per graph, the emitted window constant, and the per-layer alternation (even layers consume the local mask, odd the global, and they differ).
- `spike/openxla/gemma2_sliding_window_check.py`: a matched synthetic Gemma2 is token-exact and bit-exact vs HF eager fp32 at an inert window (max |logit diff| 4.5e-8) and at a window small enough to bite inside the 256-slot cache (5.9e-8); HF's own output changes by 4.7e-2 between the two, so the biting case is not vacuous.

## Test plan

- [x] `cargo check -p mlxcel-xla --lib --tests`
- [x] `cargo clippy -p mlxcel-xla --lib --tests -- -D warnings`
- [x] `cargo test -p mlxcel-xla --lib emitter::tests`
- [x] `spike/openxla/gemma2_sliding_window_check.py` (HF fp32 oracle, inert + biting window)

Closes #495
