### PR TITLE
feat: per-device default precision and a precision accuracy gate for the OpenXLA backend (#449)

### DIFF
--- a/src/lib/mlxcel-xla/README.md
+++ b/src/lib/mlxcel-xla/README.md
@@ -120,28 +120,37 @@ driver registers via `use_all_available_drivers`).
 
 ### Precision (low-precision matmul)
 
-`MLXCEL_XLA_PRECISION` selects the contraction (matmul) input precision, authored
-in the emitted StableHLO graph so it applies on every IREE target (CPU, CUDA,
-Metal, and future NPUs), not just one backend:
+The contraction (matmul) input precision is authored in the emitted StableHLO
+graph, so it applies on every IREE target (CPU, CUDA, Metal, and future NPUs),
+not just one backend:
 
-- `f32` (default) — unchanged.
 - `f16` / `bf16` — demote the f32 inputs of every `dot_general` to the narrow
   type while keeping the f32 accumulate and output, so only the matmuls change
   and the sensitive elementwise ops (norm, softmax, RoPE) stay f32. A blanket
   program-wide f32 to f16 is deliberately not done (it regressed accuracy and was
   slower).
+- `f32` — no demotion.
+
+**Default is per device:** `f16` on the GPU devices (`metal`, `cuda`), `f32` on
+the CPU (`local-task` / `local-sync`). `MLXCEL_XLA_PRECISION` (`f16` | `bf16` |
+`f32`) overrides the default on any device. So on Apple Silicon the Metal path
+runs f16 by default:
 
 ```bash
-MLXCEL_XLA_PRECISION=f16 MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=metal \
-  ./target/release/mlxcel generate -m <Llama-3.2-1B-Instruct dir> -p "..." -n 48
+# f16 by default on metal (the device default); no env needed:
+MLXCEL_BACKEND=xla ./target/release/mlxcel generate \
+  -m <Llama-3.2-1B-Instruct dir> -p "..." -n 48
+# Force f32 for a token-exact reference:
+MLXCEL_XLA_PRECISION=f32 MLXCEL_BACKEND=xla ./target/release/mlxcel generate \
+  -m <Llama-3.2-1B-Instruct dir> -p "..." -n 48
 ```
 
 On an M1 Ultra (Llama-3.2-1B-Instruct, greedy) `f16` is ~1.9x the `f32` tok/s and
-token-exact with it. The same graph change also speeds up the CPU (`local-task`)
-path. Weights are still uploaded f32 and demoted in the graph; keeping the
-resident weights in the narrow type (a bandwidth win that needs the f16 weight
-FFI) lands with the quantized-weight path. This is a transferable, correctness
-first lever; it does not close the gap to MLX (see the perf note above).
+token-exact with it. The same graph change also speeds up the CPU path. Weights
+are still uploaded f32 and demoted in the graph; keeping the resident weights in
+the narrow type (a bandwidth win that needs the f16 weight FFI) lands with the
+quantized-weight path. This is a transferable, correctness-first lever; it does
+not close the gap to MLX (see the perf note above).
 
 ### Scope / limits
 

--- a/src/lib/mlxcel-xla/src/emitter/builder.rs
+++ b/src/lib/mlxcel-xla/src/emitter/builder.rs
@@ -72,16 +72,50 @@ impl Precision {
     }
 }
 
-/// The contraction precision selected by `MLXCEL_XLA_PRECISION` (`f16` / `bf16`,
-/// else f32). Read once when a graph is emitted; a different value changes the
-/// emitted MLIR, so the vmfb content-hash cache keys each precision separately.
+/// The explicit `MLXCEL_XLA_PRECISION` override (`f16` / `bf16`), or `None` when
+/// unset / unrecognized (so the per-device default applies).
+#[must_use]
+pub fn precision_env_override() -> Option<Precision> {
+    match std::env::var("MLXCEL_XLA_PRECISION").as_deref() {
+        Ok("f16") => Some(Precision::F16),
+        Ok("bf16") => Some(Precision::Bf16),
+        // `f32` is an explicit override too, so it forces f32 even on a GPU device
+        // whose default is f16. Only an unset / unrecognized value falls through
+        // to the per-device default.
+        Ok("f32") => Some(Precision::F32),
+        _ => None,
+    }
+}
+
+/// The contraction precision, honoring `MLXCEL_XLA_PRECISION` else f32. Used where
+/// no HAL device is in scope (e.g. the emitter's byte-exact regression tests).
 #[must_use]
 pub fn precision_from_env() -> Precision {
-    match std::env::var("MLXCEL_XLA_PRECISION").as_deref() {
-        Ok("f16") => Precision::F16,
-        Ok("bf16") => Precision::Bf16,
-        _ => Precision::F32,
+    precision_env_override().unwrap_or(Precision::F32)
+}
+
+/// The default contraction precision for a HAL device when `MLXCEL_XLA_PRECISION`
+/// is unset: `f16` on the GPU devices (`metal`, `cuda`), whose runtimes and the
+/// pinned iree-compile handle f16 well and where it is ~2x, and `f32` on the CPU
+/// (`local-task` / `local-sync`), where f16 gains little and can round-trip
+/// through f32 anyway. CUDA is never *auto*-selected as a device, but if it is
+/// the target this is its default precision.
+#[must_use]
+pub fn default_precision(device: &str) -> Precision {
+    if device == "metal" || device == "cuda" {
+        Precision::F16
+    } else {
+        Precision::F32
     }
+}
+
+/// The precision to emit for `device`: the `MLXCEL_XLA_PRECISION` override wins on
+/// every device; otherwise the per-device default. Read once at graph emission; a
+/// different value changes the MLIR, so the vmfb content-hash cache keys each
+/// precision separately.
+#[must_use]
+pub fn resolve_precision(device: &str) -> Precision {
+    precision_env_override().unwrap_or_else(|| default_precision(device))
 }
 
 pub struct Builder {
@@ -702,5 +736,13 @@ mod tests {
             b.body()
                 .contains("(tensor<8xbf16>, tensor<4x8xbf16>) -> tensor<4xf32>")
         );
+    }
+
+    #[test]
+    fn default_precision_is_f16_on_gpu_and_f32_on_cpu() {
+        assert_eq!(default_precision("metal"), Precision::F16);
+        assert_eq!(default_precision("cuda"), Precision::F16);
+        assert_eq!(default_precision("local-task"), Precision::F32);
+        assert_eq!(default_precision("local-sync"), Precision::F32);
     }
 }

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -40,7 +40,17 @@ mod model;
 mod rope;
 
 pub(crate) use config::Config;
-pub(crate) use model::{emit_decode, emit_decode_ragged, emit_prefill};
+// `resolve_precision` and the precision-taking `*_with` emit variants are consumed
+// by the IREE execution path; the f32-default `emit_*` wrappers by the byte-exact
+// regression tests. Which set is live depends on the build cfg (`iree` vs `test`),
+// so allow the re-export to be unused in the other.
+#[allow(unused_imports)]
+pub(crate) use builder::resolve_precision;
+#[allow(unused_imports)]
+pub(crate) use model::{
+    emit_decode, emit_decode_ragged, emit_decode_ragged_with, emit_decode_with, emit_prefill,
+    emit_prefill_with,
+};
 
 #[cfg(test)]
 mod tests {
@@ -395,5 +405,37 @@ mod tests {
             (inv[1] - 1.0 / theta.powf(2.0 / 4.0)).abs() < 1e-12,
             "i=1 -> theta^(-1/2)"
         );
+    }
+
+    // The precision accuracy gate (structural). Guards the "targeted, not blanket"
+    // invariant that makes f16 token-exact: only matmuls are demoted; RMSNorm
+    // (rsqrt) and softmax (exponential) stay f32. A blanket f32->f16 (which
+    // regressed accuracy and was slower) would demote those and fail this.
+    #[test]
+    fn f16_precision_demotes_only_matmuls_not_norm_or_softmax() {
+        use super::builder::Precision;
+        let c = Config::llama_3_2_1b();
+
+        let f16 = emit_decode_with(&c, true, Precision::F16);
+        assert!(f16.contains("xf16"), "f16 mode emitted no f16");
+        for line in f16.lines().filter(|l| l.contains("stablehlo.dot_general")) {
+            assert!(line.contains("f16>"), "matmul not demoted to f16: {line}");
+            assert!(
+                line.trim_end().ends_with("f32>"),
+                "matmul output not f32 (accumulate lost): {line}"
+            );
+        }
+        for line in f16
+            .lines()
+            .filter(|l| l.contains("stablehlo.rsqrt") || l.contains("stablehlo.exponential"))
+        {
+            assert!(
+                !line.contains("f16"),
+                "norm/softmax wrongly demoted to f16 (blanket regression): {line}"
+            );
+        }
+
+        // The f32 default carries no f16 at all (byte-exact path preserved).
+        assert!(!emit_decode_with(&c, true, Precision::F32).contains("f16"));
     }
 }

--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -14,7 +14,7 @@
 //! `embed` matrix (see [`take_lm_head`]); a tied checkpoint emits no such arg and
 //! is byte-identical to before.
 
-use super::builder::{Builder, Ty, Val, precision_from_env};
+use super::builder::{Builder, Precision, Ty, Val, precision_from_env};
 use super::config::Config;
 use super::rope;
 
@@ -427,8 +427,12 @@ fn apply_rope(b: &mut Builder, x: &Val, cos: &Val, sin: &Val, heads: usize, d: u
 /// an on-device argmax and returns the next token id (`tensor<i32>`, the Phase
 /// 2b pattern); otherwise it returns the raw `[V]` logits.
 pub fn emit_decode(c: &Config, sample: bool) -> String {
+    emit_decode_with(c, sample, precision_from_env())
+}
+
+pub fn emit_decode_with(c: &Config, sample: bool, precision: Precision) -> String {
     let (decls, a) = build_arg_schema(c);
-    let mut b = Builder::new().with_precision(precision_from_env());
+    let mut b = Builder::new().with_precision(precision);
     let k = emit_consts(&mut b, c);
 
     let h = c.hidden;
@@ -727,8 +731,17 @@ fn apply_rope_batched(
 /// `bsz`. With `sample`, the graph ends in a per-row on-device argmax and
 /// returns `[B]` token ids; otherwise it returns `[B, V]` logits.
 pub fn emit_decode_batched(c: &Config, bsz: usize, sample: bool) -> String {
+    emit_decode_batched_with(c, bsz, sample, precision_from_env())
+}
+
+pub fn emit_decode_batched_with(
+    c: &Config,
+    bsz: usize,
+    sample: bool,
+    precision: Precision,
+) -> String {
     let (decls, a) = build_batched_arg_schema(c, bsz);
-    let mut b = Builder::new().with_precision(precision_from_env());
+    let mut b = Builder::new().with_precision(precision);
     let k = emit_consts(&mut b, c);
 
     let h = c.hidden;
@@ -1011,8 +1024,17 @@ fn apply_rope_ragged(
 /// size `bsz`. With `sample`, ends in a per-row on-device argmax returning `[B]`
 /// token ids; otherwise returns `[B, V]` logits.
 pub fn emit_decode_ragged(c: &Config, bsz: usize, sample: bool) -> String {
+    emit_decode_ragged_with(c, bsz, sample, precision_from_env())
+}
+
+pub fn emit_decode_ragged_with(
+    c: &Config,
+    bsz: usize,
+    sample: bool,
+    precision: Precision,
+) -> String {
     let (decls, a) = build_ragged_arg_schema(c, bsz);
-    let mut b = Builder::new().with_precision(precision_from_env());
+    let mut b = Builder::new().with_precision(precision);
     let k = emit_consts(&mut b, c);
     // Constant row indices 0..bsz for the per-row KV-write dim-0 offsets.
     let row_idx: Vec<Val> = (0..bsz).map(|i| b.const_i32(i as i32)).collect();
@@ -1308,9 +1330,13 @@ fn apply_rope_seq(
 /// on-device argmax and returns the first token id (`tensor<i32>`); otherwise it
 /// returns the raw `[V]` logits at `real_len-1`.
 pub fn emit_prefill(c: &Config, sample: bool) -> String {
+    emit_prefill_with(c, sample, precision_from_env())
+}
+
+pub fn emit_prefill_with(c: &Config, sample: bool, precision: Precision) -> String {
     let lp = PREFILL_LP;
     let (decls, a) = build_prefill_arg_schema(c, lp);
-    let mut b = Builder::new().with_precision(precision_from_env());
+    let mut b = Builder::new().with_precision(precision);
     let k = emit_consts(&mut b, c);
 
     let h = c.hidden;

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -50,7 +50,9 @@ use std::process::Command;
 use memmap2::Mmap;
 use safetensors::{Dtype, SafeTensors};
 
-use crate::emitter::{Config, emit_decode, emit_decode_ragged, emit_prefill};
+use crate::emitter::{
+    Config, emit_decode_ragged_with, emit_decode_with, emit_prefill_with, resolve_precision,
+};
 use crate::weights::{bf16_to_f32, dequantize_affine, f16_to_f32, f32_le_to_f32};
 
 /// Prefill bucket baked into the emitted `prefill` graph (`tensor<256xi32>`,
@@ -318,8 +320,9 @@ fn compile_pair(
 /// is emitted from the model config, so `compile_one`'s text-hash cache keys a
 /// distinct vmfb per architecture.
 fn compile_vmfbs(device: &str, cfg: &Config) -> Result<(PathBuf, PathBuf), String> {
-    let prefill = emit_prefill(cfg, true);
-    let decode = emit_decode(cfg, true);
+    let precision = resolve_precision(device);
+    let prefill = emit_prefill_with(cfg, true, precision);
+    let decode = emit_decode_with(cfg, true, precision);
     compile_pair(device, &prefill, "prefill", &decode, "decode")
 }
 
@@ -650,9 +653,11 @@ impl IreeRaggedLlama {
                  {b_max} is not one of them"
             ));
         }
-        // Emit the logits prefill + the ragged decode graph for this model + b_max.
-        let prefill_mlir = emit_prefill(&cfg, false);
-        let decode_mlir = emit_decode_ragged(&cfg, b_max, false);
+        // Emit the logits prefill + the ragged decode graph for this model + b_max
+        // at the device-resolved precision (f16 on GPU by default, f32 on CPU).
+        let precision = resolve_precision(device);
+        let prefill_mlir = emit_prefill_with(&cfg, false, precision);
+        let decode_mlir = emit_decode_ragged_with(&cfg, b_max, false, precision);
         let (prefill_vmfb, decode_vmfb) = compile_pair(
             device,
             &prefill_mlir,


### PR DESCRIPTION
Closes #515. Part of #513.

## What

Per-device default precision for the OpenXLA backend plus a precision accuracy gate, building on the f16 emitter mode (#514).

- **Per-device default:** `f16` on the GPU HAL devices (`metal`, `cuda`), `f32` on the CPU (`local-task` / `local-sync`), resolved per device at graph emission. `MLXCEL_XLA_PRECISION` (`f16` | `bf16` | `f32`) overrides on any device; `f32` forces f32 even on a GPU whose default is f16.
- **Accuracy gate:** a structural emitter test asserting the f16 graph demotes only the matmul inputs and keeps norm (`rsqrt`) and softmax (`exponential`) f32 -- the "targeted, not blanket" invariant that makes f16 token-exact. A blanket demotion (which regressed accuracy and was slower) fails it. Plus a `default_precision` device decision-table test.

## Changes

- `emitter/builder.rs`: `precision_env_override()` (`Option`, now matching `f32` too), `default_precision(device)`, `resolve_precision(device)`; decision-table test.
- `emitter/model.rs`: `emit_*_with(precision)` variants; the plain `emit_*` become f32-default wrappers (test API unchanged).
- `emitter/mod.rs`: re-exports; the structural f16-invariant gate test.
- `iree.rs`: both emit sites use `resolve_precision(device)` + the `_with` variants.
- `mlxcel-xla/README.md`: the per-device default.

## Validation (M1 Ultra, Llama-3.2-1B-Instruct, greedy)

- Metal with **no env** now defaults to f16: **2.95 tok/s vs 1.55 (f32) = ~1.9x**.
- `MLXCEL_XLA_PRECISION=f32` forces f32 (1.55); `=f16` forces f16 (2.91).
- default / f16 / f32 are all **token-exact** with each other.
- 48 `mlxcel-xla` unit tests green (incl. the new gate + decision-table tests); the emitter byte-exact regression still passes; `cargo fmt --check` and emitter clippy clean.
- Default / non-macOS builds unaffected (change is in the `xla-backend`-only crate; the CPU default stays f32).

A bug caught by validation and fixed here: `precision_env_override` previously did not match `f32`, so `MLXCEL_XLA_PRECISION=f32` fell through to the GPU f16 default instead of forcing f32.
