### PR TITLE
feat: int8/int4 packed weight quantization on the OpenXLA path (#516)

### DIFF
--- a/docs/adr/0004-compute-backend-session-seam-and-stablehlo-family.md
+++ b/docs/adr/0004-compute-backend-session-seam-and-stablehlo-family.md
@@ -90,6 +90,14 @@ That split of the performance levers decides where the project invests:
 
 int8 / int4 weight quantization (#516) is the NPU lever, but its payoff is memory bandwidth: a compute-bound Metal decode cannot demonstrate it, and measuring it needs an actual NPU. It is deferred to a hardware-gated follow-up; on Metal only its token-exactness would be verifiable. Metal's absolute throughput is therefore a pessimistic proxy for an NPU, which brings its own optimized kernels.
 
+### int8 weight quantization: the fusion gate (2026-07-01)
+
+The int8 lever (#516) was picked up on a GB10 (Grace-Blackwell, CUDA via a source-built IREE runtime), the first int-native target available. The packed path (`MLXCEL_XLA_QUANT=packed`) keeps the MLX 4/8-bit weights resident packed (`ui32` + f16 scales/biases) and dequantizes each weight in the StableHLO graph (bit-unpack, then `q*scale + bias`), rather than dequantizing to f32 at load. The whole packed ABI landed: an emitter dequant primitive, a per-weight-dtype weight upload, and `ui32` / f16 device buffers.
+
+The result refines the split above rather than contradicting it. On the GB10 the packed decode is **token-exact** with the f32/f16 path (the in-graph reconstruction is bit-identical to the host dequant) but about **4.3x slower** (roughly 1.6 vs 6.7 tok/s, Llama-3.2-1B 4-bit, greedy), with GPU utilization rising (84% to 96%). IREE's CUDA codegen does not fuse the unpack+dequant into the matmul: the decode step is about 678 dispatches and the reconstructed f32 weight is materialized to DRAM every step, so the graph pays more bandwidth and compute, not less. The aggressive-fusion / generalize-matmul / early-truncate-fusion flags leave the dispatch count unchanged (678 to 677).
+
+So the memory-bandwidth payoff is **not** realized by authoring the dequant in the portable graph alone; it requires the target to fuse dequant into the matmul (a quantized-matmul op, or an int8 `dot_general` lowering to the hardware int8 path). This is the same lever split the f16 profiling reached: the graph-level change is in scope and transferable, but the fused low-precision kernel is upstream IREE's responsibility. The packed path therefore stays behind the `MLXCEL_XLA_QUANT=packed` gate, off by default, as the correctness-verified foundation a fused quantized-matmul reuses. The bandwidth win is now gated on that fusion (in IREE, or on an NPU whose HAL driver lowers a quantized dot to its systolic int8 kernels), not on hardware availability alone.
+
 ## Consequences
 
 - The `ComputeBackend` trait from PR #446 is reworked from a load-boundary contract returning `LoadedModel` into a session-engine contract. The selection skeleton (`select_backend`, the `Backend` enum, the `experimental-backend` feature gate) survives the rework; only the contract shape changes.

--- a/scripts/iree/setup-cuda.sh
+++ b/scripts/iree/setup-cuda.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Set up the IREE toolchain for the mlxcel OpenXLA backend (`xla-iree`) on Linux
+# with an NVIDIA GPU (validated on a GB10, Grace-Blackwell sm_121). The prebuilt
+# IREE dist is CPU/Vulkan only (no CUDA driver, and Vulkan cannot allocate against
+# the GB10 unified memory), so this script:
+#
+#   1. installs the CUDA-capable `iree-compile` from the `iree-base-compiler` wheel
+#      into a private venv, and
+#   2. source-builds the IREE *runtime* (runtime only, no LLVM) with the
+#      local-task / local-sync / CUDA HAL drivers, pinned to the exact revision the
+#      wheel was built from (version-matched runtime <-> compiler),
+#
+# then prints the env the cargo `xla-iree` build needs. Mirrors setup-macos.sh.
+# Idempotent: re-running reuses an existing clone/build/venv.
+#
+# Usage:
+#   scripts/iree/setup-cuda.sh                 # build into the default dir
+#   eval "$(scripts/iree/setup-cuda.sh --env)" # just print/apply the exports
+#
+# After it finishes, build and run the backend:
+#   eval "$(scripts/iree/setup-cuda.sh --env)"
+#   cargo build --release --features xla-iree
+#   MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=cuda \
+#     ./target/release/mlxcel generate -m <Llama-3.2-1B dir> -p "..." -n 48
+set -euo pipefail
+
+# --- pinned IREE version. PIP_VER is the wheel; IREE_SHA is the exact iree-org
+# commit that wheel reports (iree-compile --version), so the source-built runtime
+# is byte-version-matched to the compiler that lowers the vmfbs. ---
+PIP_VER="3.11.0"
+IREE_SHA="e4a3b0405d7d23554da26403658d0e8c3c5ecf25"
+
+IREE_DIR="${MLXCEL_IREE_CUDA_DIR:-$HOME/.cache/mlxcel/iree-cuda}"
+SRC="$IREE_DIR/src"
+BUILD="$IREE_DIR/build"
+VENV="$IREE_DIR/venv"
+IREE_COMPILE="$VENV/bin/iree-compile"
+CUDA_ROOT="${CUDAToolkit_ROOT:-/usr/local/cuda}"
+
+emit_env() {
+  echo "export IREE_CUDA_HOME=$IREE_DIR"
+  echo "export IREE_CUDA_COMPILE=$IREE_COMPILE"
+  echo "export MLXCEL_XLA_IREE_COMPILE=$IREE_COMPILE"
+}
+
+# `--env`: assume already built; just print the exports.
+if [ "${1:-}" = "--env" ]; then
+  emit_env
+  exit 0
+fi
+
+log() { printf '\033[1;34m[setup-cuda]\033[0m %s\n' "$*" >&2; }
+
+# --- prerequisites ---
+[ "$(uname -s)" = "Linux" ] || { echo "this script is Linux/CUDA-only (use setup-macos.sh on macOS)" >&2; exit 1; }
+for tool in git cmake make python3; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
+done
+[ -x "$CUDA_ROOT/bin/nvcc" ] || { echo "no CUDA toolkit at $CUDA_ROOT (set CUDAToolkit_ROOT)" >&2; exit 1; }
+
+mkdir -p "$IREE_DIR"
+
+# --- 1. CUDA-capable iree-compile from the pinned wheel, into a private venv ---
+if [ ! -x "$IREE_COMPILE" ]; then
+  log "creating venv and installing iree-base-compiler==$PIP_VER"
+  python3 -m venv "$VENV"
+  "$VENV/bin/python" -m pip install -q --upgrade pip
+  "$VENV/bin/python" -m pip install -q "iree-base-compiler==$PIP_VER"
+  [ -x "$IREE_COMPILE" ] || { echo "iree-compile not found after install" >&2; exit 1; }
+else
+  log "reusing iree-compile at $IREE_COMPILE"
+fi
+
+# --- 2. source-build the IREE runtime (runtime only; local + cuda drivers) ---
+# Fetch the exact pinned commit shallowly (the wheel is an rc, not a release tag).
+if [ ! -e "$SRC/.git" ]; then
+  log "fetching IREE runtime source @ $IREE_SHA (shallow, no LLVM)"
+  git init -q "$SRC"
+  git -C "$SRC" remote add origin https://github.com/iree-org/iree.git 2>/dev/null || true
+  git -C "$SRC" fetch --depth 1 origin "$IREE_SHA"
+  git -C "$SRC" checkout -q FETCH_HEAD
+fi
+# The runtime build needs only flatcc (vmfb parsing); skip the compiler-only
+# submodules (llvm-project, stablehlo, torch-mlir, ...) entirely.
+if [ ! -e "$SRC/third_party/flatcc/.git" ]; then
+  log "initializing flatcc submodule only"
+  git -C "$SRC" submodule update --init --depth 1 -- third_party/flatcc
+fi
+
+UNIFIED="$BUILD/runtime/src/iree/runtime/libiree_runtime_unified.a"
+if [ ! -f "$UNIFIED" ]; then
+  log "configuring runtime-only build (local-task/local-sync/cuda)"
+  cmake -S "$SRC" -B "$BUILD" -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DIREE_ERROR_ON_MISSING_SUBMODULES=OFF \
+    -DIREE_BUILD_COMPILER=OFF -DIREE_BUILD_TESTS=OFF -DIREE_BUILD_SAMPLES=OFF \
+    -DIREE_BUILD_BENCHMARKS=OFF \
+    -DIREE_HAL_DRIVER_DEFAULTS=OFF \
+    -DIREE_HAL_DRIVER_LOCAL_TASK=ON -DIREE_HAL_DRIVER_LOCAL_SYNC=ON \
+    -DIREE_HAL_DRIVER_CUDA=ON -DCUDAToolkit_ROOT="$CUDA_ROOT"
+  log "building iree_runtime_unified"
+  make -C "$BUILD" -j"$(nproc)" iree_runtime_unified
+  [ -f "$UNIFIED" ] || { echo "runtime build did not produce $UNIFIED" >&2; exit 1; }
+else
+  log "reusing runtime build at $BUILD"
+fi
+
+log "done. IREE_CUDA_HOME=$IREE_DIR"
+echo >&2
+echo "# Run this (or: eval \"\$(scripts/iree/setup-cuda.sh --env)\") to export the build env:" >&2
+emit_env

--- a/src/lib/mlxcel-xla/README.md
+++ b/src/lib/mlxcel-xla/README.md
@@ -147,10 +147,13 @@ MLXCEL_XLA_PRECISION=f32 MLXCEL_BACKEND=xla ./target/release/mlxcel generate \
 
 On an M1 Ultra (Llama-3.2-1B-Instruct, greedy) `f16` is ~1.9x the `f32` tok/s and
 token-exact with it. The same graph change also speeds up the CPU path. Weights
-are still uploaded f32 and demoted in the graph; keeping the resident weights in
-the narrow type (a bandwidth win that needs the f16 weight FFI) lands with the
-quantized-weight path. This is a transferable, correctness-first lever; it does
-not close the gap to MLX (see the perf note above).
+are uploaded f32 and demoted in the graph. Keeping the resident weights small is
+the separate weight-quantization axis (`MLXCEL_XLA_QUANT=packed`, issue #516): an
+MLX 4/8-bit checkpoint uploads the packed `ui32` weight + f16 scales/biases and
+dequantizes in the graph. It is token-exact but off by default, because IREE does
+not fuse the in-graph dequant into the matmul on CUDA, so it regresses throughput
+(see "int8 packed dequant on GB10 / CUDA" below). This is a transferable,
+correctness-first lever; it does not close the gap to MLX (see the perf note above).
 
 ### Scope / limits
 
@@ -317,12 +320,48 @@ own optimized kernels; what transfers is the graph, not the Metal tuning.
 ### Decision (2026-07)
 
 - **In scope:** graph-level low precision. f16 / bf16 is landed. int8 / int4
-  weight quantization is the NPU lever, but its payoff is memory bandwidth, which
-  a compute-bound Metal decode cannot demonstrate and which needs an actual NPU to
-  measure; it is **deferred to a hardware-gated follow-up** (on Metal only its
-  token-exactness would be verifiable, not the speedup).
+  weight quantization (the packed in-graph dequant, `MLXCEL_XLA_QUANT=packed`,
+  issue #516) is landed too, **token-exact** but **opt-in and off by default**
+  because on the one available int-capable target it does not yet pay off (see
+  below).
 - **Out of scope:** hand-writing Metal kernels or tuning IREE's `metal-spirv`
   codegen to chase MLX.
+
+### int8 packed dequant on GB10 / CUDA: the fusion gate (2026-07-01)
+
+The int8 lever was picked up on a GB10 (Grace-Blackwell, CUDA via the source-built
+IREE runtime), the one int-native target available. `MLXCEL_XLA_QUANT=packed` keeps
+the MLX 4/8-bit weights resident **packed** (`ui32` + f16 scales/biases) and
+reconstructs each weight in the StableHLO graph (`Builder::dequant_affine`: bit
+unpack -> `q*scale + bias`), instead of dequantizing to f32 at load.
+
+Measured on the GB10 (Llama-3.2-1B, 4-bit `group_size` 64, greedy, warm vmfb):
+
+| decode path | tok/s | GPU util | note |
+|-------------|-------|----------|------|
+| f16, dequant-at-load (default) | ~6.7 | 84% | resident f32 weights, f16 matmul inputs |
+| packed, dequant-in-graph | ~1.6 | 96% | **token-exact** with the f16 path, ~4.3x slower |
+
+The packed path is **correct** (bit-identical reconstruction, so the greedy token
+stream matches the f32/f16 path) but **slower**, because IREE's CUDA codegen does
+**not fuse** the unpack+dequant into the matmul: the decode step is ~678 dispatches
+and the reconstructed f32 weight is materialized to DRAM every step, so the graph
+pays *more* bandwidth + compute, not less (GPU util rises 84% -> 96%). Fusion flags
+(`--iree-dispatch-creation-enable-aggressive-fusion`, `--iree-opt-generalize-matmul`,
+`--iree-dispatch-creation-enable-early-trunc-fusion`) leave the dispatch count
+unchanged (678 -> 677).
+
+So the memory-bandwidth lever is **not** realized by authoring the dequant in the
+portable graph alone; it needs the target to fuse dequant->matmul (a
+quantized-matmul op / int8 `dot_general` lowering to the hardware's int8 path). That
+is the same split the f16 note reaches, now confirmed for int8: the graph-level
+change is necessary but the fused kernel is upstream IREE's job. The packed path
+therefore lands **behind the `MLXCEL_XLA_QUANT=packed` gate, off by default**, as the
+correctness-verified foundation for a fused quantized-matmul follow-up. It also
+carries the whole packed ABI (emitter dequant, per-dtype weight upload, the
+`ui32`/f16 device buffers) that a fused path reuses. The v1 packed path covers the
+standard Llama layout ([`Config::supports_packed_quant`]: non-fused-qkv,
+non-fused-gate-up, non-dense-MLP, non-MoE); embed / lm_head stay f32-resident.
 
 ## File map
 

--- a/src/lib/mlxcel-xla/csrc/xla_iree.c
+++ b/src/lib/mlxcel-xla/csrc/xla_iree.c
@@ -184,8 +184,9 @@ static iree_status_t xla_alloc_bv(xla_ctx* c, iree_host_size_t rank,
 
 static iree_status_t xla_llama_create_impl(
     xla_ctx* c, const char* device_uri, const char* prefill_vmfb,
-    const char* decode_vmfb, int32_t n_weights, const float* const* weight_data,
-    const int32_t* weight_ranks, const int64_t* weight_dims) {
+    const char* decode_vmfb, int32_t n_weights, const void* const* weight_data,
+    const int32_t* weight_dtypes, const int32_t* weight_ranks,
+    const int64_t* weight_dims) {
   c->n_weights = n_weights;
 
 #ifdef XLA_GATE_CUDA
@@ -233,9 +234,31 @@ static iree_status_t xla_llama_create_impl(
       shape[d] = dim;
       nelem *= (iree_host_size_t)dim;
     }
-    IREE_RETURN_IF_ERROR(xla_alloc_bv(c, (iree_host_size_t)rank, shape,
-                                      IREE_HAL_ELEMENT_TYPE_FLOAT_32,
-                                      weight_data[i], nelem * sizeof(float),
+    // issue #516 per-weight dtype: f32 (0, a widened / dequantized weight) or the
+    // raw parts of an MLX affine-quantized projection, f16 (1) scales / biases or a
+    // packed U32 (2) weight the graph dequantizes in place.
+    iree_hal_element_type_t elt;
+    iree_host_size_t esize;
+    switch (weight_dtypes[i]) {
+      case 0:
+        elt = IREE_HAL_ELEMENT_TYPE_FLOAT_32;
+        esize = 4;
+        break;
+      case 1:
+        elt = IREE_HAL_ELEMENT_TYPE_FLOAT_16;
+        esize = 2;
+        break;
+      case 2:
+        elt = IREE_HAL_ELEMENT_TYPE_UINT_32;
+        esize = 4;
+        break;
+      default:
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "unknown weight dtype %d for weight %d",
+                                weight_dtypes[i], i);
+    }
+    IREE_RETURN_IF_ERROR(xla_alloc_bv(c, (iree_host_size_t)rank, shape, elt,
+                                      weight_data[i], nelem * esize,
                                       &c->weights[i]));
   }
   return iree_ok_status();
@@ -243,19 +266,21 @@ static iree_status_t xla_llama_create_impl(
 
 // Create the execution context. `device_uri` is "local-task" (CPU) or another
 // registered HAL driver. `weight_data[i]` points at `prod(weight_dims[i*4..])`
-// f32 values laid out row-major; the shim copies them into resident device
-// buffers, so the caller may free them after this returns. Returns NULL on
-// failure (after printing a diagnostic).
+// elements of dtype `weight_dtypes[i]` (0 f32, 1 f16, 2 packed U32; issue #516)
+// laid out row-major; the shim copies them into resident device buffers, so the
+// caller may free them after this returns. Returns NULL on failure (after printing
+// a diagnostic).
 xla_ctx* xla_llama_create(const char* device_uri, const char* prefill_vmfb,
                           const char* decode_vmfb, int32_t n_weights,
-                          const float* const* weight_data,
+                          const void* const* weight_data,
+                          const int32_t* weight_dtypes,
                           const int32_t* weight_ranks,
                           const int64_t* weight_dims) {
   xla_ctx* c = (xla_ctx*)calloc(1, sizeof(xla_ctx));
   if (!c) return NULL;
   iree_status_t s =
       xla_llama_create_impl(c, device_uri, prefill_vmfb, decode_vmfb, n_weights,
-                            weight_data, weight_ranks, weight_dims);
+                            weight_data, weight_dtypes, weight_ranks, weight_dims);
   if (!iree_status_is_ok(s)) {
     char buf[512];
     iree_host_size_t got = 0;

--- a/src/lib/mlxcel-xla/src/emitter/builder.rs
+++ b/src/lib/mlxcel-xla/src/emitter/builder.rs
@@ -94,6 +94,20 @@ pub fn precision_from_env() -> Precision {
     precision_env_override().unwrap_or(Precision::F32)
 }
 
+/// Whether to keep MLX-quantized weights packed and dequantize them IN THE GRAPH
+/// (issue #516: resident packed `ui32` + f16 scales/biases, unpacked via
+/// [`Builder::dequant_affine`]) instead of dequantizing them to f32 at load. Off by
+/// default, since the load-time dequant is the proven, device-agnostic path;
+/// `MLXCEL_XLA_QUANT=packed` opts in. Read at emit time (like the precision env)
+/// AND by the loader (`iree.rs`), so the uploaded buffers match the emitted args.
+/// A no-op on an unquantized checkpoint (`config.quantization` is `None`), so it
+/// never perturbs the f32 goldens. The bandwidth payoff is int-native-target
+/// specific; on a compute-bound GPU it verifies token-exactness (ADR 0004).
+#[must_use]
+pub fn quant_in_graph() -> bool {
+    matches!(std::env::var("MLXCEL_XLA_QUANT").as_deref(), Ok("packed"))
+}
+
 /// The default contraction precision for a HAL device when `MLXCEL_XLA_PRECISION`
 /// is unset: `f16` on the GPU devices (`metal`, `cuda`), whose runtimes and the
 /// pinned iree-compile handle f16 well and where it is ~2x, and `f32` on the CPU
@@ -278,8 +292,8 @@ impl Builder {
     }
 
     /// Element-type conversion (`stablehlo.convert`), preserving shape. Used by
-    /// the low-precision contraction path (f32 -> f16/bf16) and reserved for the
-    /// int dequant path.
+    /// the low-precision contraction path (f32 -> f16/bf16) and the int dequant
+    /// path (ui32 -> f32, f16 -> f32).
     pub fn convert(&mut self, x: &Val, elt: &'static str) -> Val {
         let ty = Ty::new(x.ty.shape.clone(), elt);
         let r = self.fresh();
@@ -291,6 +305,111 @@ impl Builder {
             ty.render()
         ));
         Val { name: r, ty }
+    }
+
+    // --- quantized-weight dequant (issue #516) -----------------------------
+
+    /// Bitwise AND of two same-shaped integer tensors (`stablehlo.and`). Masks the
+    /// `bits`-wide lanes out of a packed `ui32` weight.
+    pub fn and(&mut self, a: &Val, b: &Val) -> Val {
+        self.binary("and", a, b)
+    }
+
+    /// Logical right shift `a >> b` (elementwise, same shape;
+    /// `stablehlo.shift_right_logical`), unpacking a lane from a packed `ui32`.
+    pub fn shift_right_logical(&mut self, a: &Val, b: &Val) -> Val {
+        self.binary("shift_right_logical", a, b)
+    }
+
+    /// A `ui32` splat constant tensor of `shape` (every lane `v`).
+    pub fn const_splat_u32(&mut self, v: u32, shape: Vec<usize>) -> Val {
+        let ty = Ty::new(shape, "ui32");
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.constant dense<{}> : {}",
+            r,
+            v,
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    /// A 1-D `ui32` constant vector `[v0, v1, ...]`.
+    pub fn const_u32_vec(&mut self, vals: &[u32]) -> Val {
+        let ty = Ty::new(vec![vals.len()], "ui32");
+        let parts: Vec<String> = vals.iter().map(|v| v.to_string()).collect();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = stablehlo.constant dense<[{}]> : {}",
+            r,
+            parts.join(", "),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
+    /// Broadcast a `[out, n_groups]` per-group vector to `[out, in]` (`in =
+    /// n_groups * group_size`), each group's value repeated across its
+    /// `group_size` consecutive input columns. Row-major `[n_groups, group_size]`
+    /// -> `[in]` places column `i` in group `i / group_size`, matching the MLX
+    /// affine layout `scale[o, i / group_size]`.
+    fn broadcast_groups(&mut self, x: &Val, group_size: usize, in_: usize) -> Val {
+        let out = x.ty.shape[0];
+        let ng = x.ty.shape[1];
+        let x3 = self.reshape(x, vec![out, ng, 1]);
+        let xb = self.broadcast(&x3, &[0, 1, 2], vec![out, ng, group_size]);
+        self.reshape(&xb, vec![out, in_])
+    }
+
+    /// Reconstruct a row-major `[out, in]` f32 weight from an MLX affine-quantized
+    /// triple, entirely in the graph (issue #516): `packed` is `[out, in_packed]`
+    /// `ui32` (`in_packed = in * bits / 32`), `scales` / `biases` are
+    /// `[out, in / group_size]` `f16`. Mirrors [`weights::dequantize_affine`]
+    /// (`weights.rs`) exactly, so the in-graph f32 weight is bit-identical to the
+    /// host dequant (hence token-exact with the f32 path):
+    ///
+    /// ```text
+    /// q[o,i] = (packed[o, i / per_u32] >> (bits * (i % per_u32))) & ((1<<bits)-1)
+    /// w[o,i] = q[o,i] * scale[o, i / group_size] + bias[o, i / group_size]
+    /// ```
+    ///
+    /// where `per_u32 = 32 / bits`. The RESIDENT device weight stays packed
+    /// (4/8-bit + f16 scales/biases), the memory-bandwidth lever the OpenXLA path
+    /// carries to an int-native target; whether IREE folds the unpack+dequant into
+    /// the following matmul is target-dependent (the #513 / ADR-0004 open question).
+    pub fn dequant_affine(
+        &mut self,
+        packed: &Val,
+        scales: &Val,
+        biases: &Val,
+        bits: usize,
+        group_size: usize,
+    ) -> Val {
+        let out = packed.ty.shape[0];
+        let in_packed = packed.ty.shape[1];
+        let per_u32 = 32 / bits;
+        let in_ = in_packed * per_u32;
+        let mask = (1u32 << bits) - 1;
+        // Unpack all `per_u32` lanes at once: broadcast packed over a new lane axis
+        // [out, in_packed, per_u32], right-shift lane j by j*bits, mask to `bits`
+        // wide, then reshape to [out, in] (row-major (o,p,j) -> column p*per_u32+j).
+        let packed_b = self.broadcast(packed, &[0, 1], vec![out, in_packed, per_u32]);
+        let shift_vals: Vec<u32> = (0..per_u32).map(|j| (bits * j) as u32).collect();
+        let shifts = self.const_u32_vec(&shift_vals);
+        let shifts_b = self.broadcast(&shifts, &[2], vec![out, in_packed, per_u32]);
+        let shifted = self.shift_right_logical(&packed_b, &shifts_b);
+        let mask_c = self.const_splat_u32(mask, vec![out, in_packed, per_u32]);
+        let q = self.and(&shifted, &mask_c);
+        let q_flat = self.reshape(&q, vec![out, in_]);
+        let q_f32 = self.convert(&q_flat, "f32");
+        // scale/bias: [out, n_groups] f16 -> f32, each group repeated across its
+        // group_size input columns -> [out, in], then w = q*scale + bias.
+        let s_f32 = self.convert(scales, "f32");
+        let b_f32 = self.convert(biases, "f32");
+        let s_b = self.broadcast_groups(&s_f32, group_size, in_);
+        let b_b = self.broadcast_groups(&b_f32, group_size, in_);
+        let scaled = self.multiply(&q_f32, &s_b);
+        self.add(&scaled, &b_b)
     }
 
     /// Static slice. `ranges` is (start, limit) per dim, stride 1.
@@ -744,5 +863,59 @@ mod tests {
         assert_eq!(default_precision("cuda"), Precision::F16);
         assert_eq!(default_precision("local-task"), Precision::F32);
         assert_eq!(default_precision("local-sync"), Precision::F32);
+    }
+
+    /// 4-bit affine dequant-in-graph (issue #516): a `[out, in_packed]` ui32 weight
+    /// unpacks into `per_u32 = 8` lanes (shifts 0,4,..,28; mask 0xF), converts to
+    /// f32, and applies `q*scale + bias`, yielding a `[out, in]` f32 weight.
+    #[test]
+    fn dequant_affine_4bit_unpacks_eight_lanes_to_f32() {
+        let mut b = Builder::new();
+        // [out=2, in_packed=1] ui32 -> in=8; scales/biases [2,1] f16 (group_size 8).
+        let packed = Builder::arg(0, Ty::new(vec![2, 1], "ui32"));
+        let scales = Builder::arg(1, Ty::new(vec![2, 1], "f16"));
+        let biases = Builder::arg(2, Ty::new(vec![2, 1], "f16"));
+        let w = b.dequant_affine(&packed, &scales, &biases, 4, 8);
+        let body = b.body();
+        assert_eq!(w.ty.shape, vec![2, 8], "reconstructed weight is [out, in]");
+        assert_eq!(w.ty.elt, "f32", "reconstructed weight is f32");
+        assert!(
+            body.contains("dense<[0, 4, 8, 12, 16, 20, 24, 28]> : tensor<8xui32>"),
+            "4-bit per-lane shift amounts:\n{body}"
+        );
+        assert!(body.contains("stablehlo.shift_right_logical"));
+        assert!(
+            body.contains("dense<15> : tensor<2x1x8xui32>"),
+            "4-bit mask 0xF splat:\n{body}"
+        );
+        assert!(body.contains("stablehlo.and "));
+        assert!(
+            body.contains("(tensor<2x8xui32>) -> tensor<2x8xf32>"),
+            "unpacked q widened to f32:\n{body}"
+        );
+        assert!(body.contains("stablehlo.multiply"), "q * scale");
+        assert!(body.contains("stablehlo.add "), "+ bias");
+    }
+
+    /// 8-bit affine dequant-in-graph: `per_u32 = 4` lanes (shifts 0,8,16,24; mask
+    /// 0xFF). Exercises the other supported bit width.
+    #[test]
+    fn dequant_affine_8bit_unpacks_four_lanes() {
+        let mut b = Builder::new();
+        // [out=1, in_packed=2] ui32 -> in=8; scales/biases [1,2] f16 (group_size 4).
+        let packed = Builder::arg(0, Ty::new(vec![1, 2], "ui32"));
+        let scales = Builder::arg(1, Ty::new(vec![1, 2], "f16"));
+        let biases = Builder::arg(2, Ty::new(vec![1, 2], "f16"));
+        let w = b.dequant_affine(&packed, &scales, &biases, 8, 4);
+        let body = b.body();
+        assert_eq!(w.ty.shape, vec![1, 8]);
+        assert!(
+            body.contains("dense<[0, 8, 16, 24]> : tensor<4xui32>"),
+            "8-bit per-lane shift amounts:\n{body}"
+        );
+        assert!(
+            body.contains("dense<255> : tensor<1x2x4xui32>"),
+            "8-bit mask 0xFF splat:\n{body}"
+        );
     }
 }

--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -1073,6 +1073,20 @@ impl Config {
         self.n_q / self.n_kv
     }
 
+    /// Whether the issue #516 packed in-graph dequant path can apply: an MLX
+    /// affine-quantized checkpoint in the standard (non-fused-qkv, non-fused-gate-up,
+    /// non-dense-MLP, non-MoE) Llama layout the v1 packed path supports. Combined
+    /// with the `MLXCEL_XLA_QUANT=packed` opt-in (`builder::quant_in_graph`) by BOTH
+    /// the emitter (`take_weight`) and the loader (`weights::weight_specs`), so they
+    /// agree on which projections carry packed args and never diverge.
+    pub(crate) fn supports_packed_quant(&self) -> bool {
+        self.quantization.is_some()
+            && !self.fused_qkv
+            && !self.fused_gate_up
+            && !self.dense_mlp
+            && self.moe.is_none()
+    }
+
     /// Attention score scale. Granite supplies the raw multiplier directly
     /// (`attention_multiplier`, which replaces `head_dim^-0.5`); Gemma2/3 use
     /// `query_pre_attn_scalar^-0.5` (computed in f64 to match HF, since it can

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -62,7 +62,7 @@ pub(crate) use config::{MoeConfig, SharedExpertConfig};
 // so allow the re-export to be unused in the other. `emit_decode_batched` (the
 // superseded uniform-B Stage-1 graph) is re-exported for the validation harness.
 #[allow(unused_imports)]
-pub(crate) use builder::resolve_precision;
+pub(crate) use builder::{quant_in_graph, resolve_precision};
 #[allow(unused_imports)]
 pub(crate) use model::{
     emit_decode, emit_decode_batched, emit_decode_ragged, emit_decode_ragged_with,

--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -19,7 +19,7 @@
 //! `embed` matrix (see [`take_lm_head`]); a tied checkpoint emits no such arg and
 //! is byte-identical to before.
 
-use super::builder::{Builder, Precision, Ty, Val, precision_from_env};
+use super::builder::{Builder, Precision, Ty, Val, precision_from_env, quant_in_graph};
 use super::config::{Config, NormStyle};
 use super::moe::{self, MoeLayerW, MoeSharedW};
 use super::rope;
@@ -136,6 +136,54 @@ fn take_arg(decls: &mut Vec<ArgDecl>, idx: &mut usize, ty: Ty, loc: String) -> V
     val
 }
 
+/// Take one linear-projection weight `[out, in_]`, returning an `[out, in_]` f32
+/// handle the forward consumes uniformly. For an unquantized checkpoint (or with
+/// the packed path off) this is a single f32 arg, byte-identical to before. For an
+/// MLX affine-quantized checkpoint with `MLXCEL_XLA_QUANT=packed` (issue #516) it is
+/// THREE args, the packed `[out, in_/(32/bits)]` `ui32` weight and its
+/// `[out, in_/group_size]` f16 `scales` / `biases`, reconstructed to the `[out, in_]`
+/// f32 weight IN THE GRAPH via [`Builder::dequant_affine`]. That reconstruction is
+/// bit-identical to the host `dequantize_affine`, so the downstream forward (and its
+/// optional f16 contraction demotion) is unchanged and stays token-exact. The three
+/// args are declared packed, scales, biases, the order [`weight_specs`]
+/// (`weights.rs`) mirrors so the loader's uploaded buffers line up with the graph.
+fn take_weight(
+    b: &mut Builder,
+    decls: &mut Vec<ArgDecl>,
+    idx: &mut usize,
+    c: &Config,
+    out: usize,
+    in_: usize,
+    loc: String,
+) -> Val {
+    match c.quantization {
+        Some(qc) if quant_in_graph() && c.supports_packed_quant() => {
+            let in_packed = in_ * qc.bits / 32;
+            let n_groups = in_ / qc.group_size;
+            let packed = take_arg(
+                decls,
+                idx,
+                Ty::new(vec![out, in_packed], "ui32"),
+                loc.clone(),
+            );
+            let scales = take_arg(
+                decls,
+                idx,
+                Ty::new(vec![out, n_groups], "f16"),
+                format!("{loc}.scales"),
+            );
+            let biases = take_arg(
+                decls,
+                idx,
+                Ty::new(vec![out, n_groups], "f16"),
+                format!("{loc}.biases"),
+            );
+            b.dequant_affine(&packed, &scales, &biases, qc.bits, qc.group_size)
+        }
+        _ => take_arg(decls, idx, Ty::f32(vec![out, in_]), loc),
+    }
+}
+
 /// Take the untied LM head weight `params['lm_head']` (`[V, H]`), or `None` for a
 /// tied checkpoint (which reuses `embed` for the final projection). Called right
 /// after `final_norm` and before the layers, so the weight arg order is embed,
@@ -189,7 +237,13 @@ fn take_final_norm_bias(decls: &mut Vec<ArgDecl>, idx: &mut usize, c: &Config) -
 /// `in_ln` is skipped for the OLMo post-norm style (no input norm). The new
 /// conditional weights are inserted after the biases and before the FF norms, so a
 /// config that has none of them (Llama / Qwen2 / Gemma2) is byte-identical.
-fn take_layer_weights(decls: &mut Vec<ArgDecl>, idx: &mut usize, c: &Config, li: usize) -> LayerW {
+fn take_layer_weights(
+    b: &mut Builder,
+    decls: &mut Vec<ArgDecl>,
+    idx: &mut usize,
+    c: &Config,
+    li: usize,
+) -> LayerW {
     let h = c.hidden;
     let inter = c.inter;
     let kv = c.n_kv * c.head_dim;
@@ -202,22 +256,24 @@ fn take_layer_weights(decls: &mut Vec<ArgDecl>, idx: &mut usize, c: &Config, li:
     let gated = !c.dense_mlp;
     let has_post = !c.parallel_block;
     let moe_layer = c.is_moe_layer(li);
-    let down = (!moe_layer).then(|| take_arg(decls, idx, Ty::f32(vec![h, inter]), p("down")));
-    let gate =
-        (gated && !moe_layer).then(|| take_arg(decls, idx, Ty::f32(vec![inter, h]), p("gate")));
+    // The big linear projections take the packed-quantized path when enabled
+    // (issue #516: `take_weight` declares packed+scales+biases and dequants in the
+    // graph); the norms below stay f32. Byte-identical when unquantized / packed off.
+    let down = (!moe_layer).then(|| take_weight(b, decls, idx, c, h, inter, p("down")));
+    let gate = (gated && !moe_layer).then(|| take_weight(b, decls, idx, c, inter, h, p("gate")));
     // input_layernorm: present unless the reordered (OLMo) post-norm drops it.
     let in_ln = c
         .has_input_norm()
         .then(|| take_arg(decls, idx, Ty::f32(vec![h]), p("in_ln")));
     let post_ln = has_post.then(|| take_arg(decls, idx, Ty::f32(vec![h]), p("post_ln")));
-    let up = (!moe_layer).then(|| take_arg(decls, idx, Ty::f32(vec![inter, h]), p("up")));
-    let wk = take_arg(decls, idx, Ty::f32(vec![kv, h]), p("wk"));
+    let up = (!moe_layer).then(|| take_weight(b, decls, idx, c, inter, h, p("up")));
+    let wk = take_weight(b, decls, idx, c, kv, h, p("wk"));
     // o_proj maps `[n_q*head_dim]` -> `[hidden]`, so its weight is `[h, qd]` (HF's
     // `[out, in]`). For Llama / Qwen2 `qd == h`, so this renders the same square
     // type as before (byte-identical); Gemma is genuinely non-square.
-    let wo = take_arg(decls, idx, Ty::f32(vec![h, qd]), p("wo"));
-    let wq = take_arg(decls, idx, Ty::f32(vec![qd, h]), p("wq"));
-    let wv = take_arg(decls, idx, Ty::f32(vec![kv, h]), p("wv"));
+    let wo = take_weight(b, decls, idx, c, h, qd, p("wo"));
+    let wq = take_weight(b, decls, idx, c, qd, h, p("wq"));
+    let wv = take_weight(b, decls, idx, c, kv, h, p("wv"));
     let (bk, bq, bv) = if c.qkv_bias {
         let bk = take_arg(decls, idx, Ty::f32(vec![kv]), p("bk"));
         let bq = take_arg(decls, idx, Ty::f32(vec![qd]), p("bq"));
@@ -371,7 +427,7 @@ fn add_proj_bias_seq(b: &mut Builder, x: Val, bias: &Option<Val>, n: usize, k: u
     }
 }
 
-fn build_arg_schema(c: &Config) -> (Vec<ArgDecl>, Args) {
+fn build_arg_schema(b: &mut Builder, c: &Config) -> (Vec<ArgDecl>, Args) {
     let h = c.hidden;
     let v = c.vocab;
 
@@ -395,7 +451,7 @@ fn build_arg_schema(c: &Config) -> (Vec<ArgDecl>, Args) {
 
     let mut layers = Vec::with_capacity(c.n_layers);
     for li in 0..c.n_layers {
-        layers.push(take_layer_weights(&mut decls, &mut idx, c, li));
+        layers.push(take_layer_weights(b, &mut decls, &mut idx, c, li));
     }
 
     let token = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "token".into());
@@ -1599,8 +1655,8 @@ pub fn emit_decode(c: &Config, sample: bool) -> String {
 }
 
 pub fn emit_decode_with(c: &Config, sample: bool, precision: Precision) -> String {
-    let (decls, a) = build_arg_schema(c);
     let mut b = Builder::new().with_precision(precision);
+    let (decls, a) = build_arg_schema(&mut b, c);
     let k = emit_consts(&mut b, c);
 
     let h = c.hidden;
@@ -1727,7 +1783,11 @@ struct BatchedArgs {
     vcache: Val,
 }
 
-fn build_batched_arg_schema(c: &Config, bsz: usize) -> (Vec<ArgDecl>, BatchedArgs) {
+fn build_batched_arg_schema(
+    b: &mut Builder,
+    c: &Config,
+    bsz: usize,
+) -> (Vec<ArgDecl>, BatchedArgs) {
     let h = c.hidden;
     let v = c.vocab;
 
@@ -1751,7 +1811,7 @@ fn build_batched_arg_schema(c: &Config, bsz: usize) -> (Vec<ArgDecl>, BatchedArg
 
     let mut layers = Vec::with_capacity(c.n_layers);
     for li in 0..c.n_layers {
-        layers.push(take_layer_weights(&mut decls, &mut idx, c, li));
+        layers.push(take_layer_weights(b, &mut decls, &mut idx, c, li));
     }
 
     let token = take_arg(
@@ -1828,8 +1888,8 @@ pub fn emit_decode_batched_with(
     sample: bool,
     precision: Precision,
 ) -> String {
-    let (decls, a) = build_batched_arg_schema(c, bsz);
     let mut b = Builder::new().with_precision(precision);
+    let (decls, a) = build_batched_arg_schema(&mut b, c, bsz);
     let k = emit_consts(&mut b, c);
 
     let h = c.hidden;
@@ -2046,7 +2106,7 @@ struct RaggedArgs {
     vcache: Val,
 }
 
-fn build_ragged_arg_schema(c: &Config, bsz: usize) -> (Vec<ArgDecl>, RaggedArgs) {
+fn build_ragged_arg_schema(b: &mut Builder, c: &Config, bsz: usize) -> (Vec<ArgDecl>, RaggedArgs) {
     let h = c.hidden;
     let v = c.vocab;
 
@@ -2070,7 +2130,7 @@ fn build_ragged_arg_schema(c: &Config, bsz: usize) -> (Vec<ArgDecl>, RaggedArgs)
 
     let mut layers = Vec::with_capacity(c.n_layers);
     for li in 0..c.n_layers {
-        layers.push(take_layer_weights(&mut decls, &mut idx, c, li));
+        layers.push(take_layer_weights(b, &mut decls, &mut idx, c, li));
     }
 
     let token = take_arg(
@@ -2134,8 +2194,8 @@ pub fn emit_decode_ragged_with(
     sample: bool,
     precision: Precision,
 ) -> String {
-    let (decls, a) = build_ragged_arg_schema(c, bsz);
     let mut b = Builder::new().with_precision(precision);
+    let (decls, a) = build_ragged_arg_schema(&mut b, c, bsz);
     let k = emit_consts(&mut b, c);
     // Constant row indices 0..bsz for the per-row KV-write dim-0 offsets.
     let row_idx: Vec<Val> = (0..bsz).map(|i| b.const_i32(i as i32)).collect();
@@ -2259,7 +2319,7 @@ struct PrefillArgs {
     real_len: Val,
 }
 
-fn build_prefill_arg_schema(c: &Config, lp: usize) -> (Vec<ArgDecl>, PrefillArgs) {
+fn build_prefill_arg_schema(b: &mut Builder, c: &Config, lp: usize) -> (Vec<ArgDecl>, PrefillArgs) {
     let h = c.hidden;
     let v = c.vocab;
 
@@ -2283,7 +2343,7 @@ fn build_prefill_arg_schema(c: &Config, lp: usize) -> (Vec<ArgDecl>, PrefillArgs
 
     let mut layers = Vec::with_capacity(c.n_layers);
     for li in 0..c.n_layers {
-        layers.push(take_layer_weights(&mut decls, &mut idx, c, li));
+        layers.push(take_layer_weights(b, &mut decls, &mut idx, c, li));
     }
 
     let tokens = take_arg(
@@ -2399,8 +2459,8 @@ pub fn emit_prefill(c: &Config, sample: bool) -> String {
 
 pub fn emit_prefill_with(c: &Config, sample: bool, precision: Precision) -> String {
     let lp = PREFILL_LP;
-    let (decls, a) = build_prefill_arg_schema(c, lp);
     let mut b = Builder::new().with_precision(precision);
+    let (decls, a) = build_prefill_arg_schema(&mut b, c, lp);
     let k = emit_consts(&mut b, c);
 
     let h = c.hidden;

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -48,7 +48,7 @@
 use std::ffi::CString;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
-use std::os::raw::{c_char, c_int};
+use std::os::raw::{c_char, c_int, c_void};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -66,9 +66,35 @@ use crate::emitter::{
 // and the #500 MoE expert bank (the stacked `switch_mlp` weights, dequantized with
 // `dequantize_affine_stacked`). Both are pure-Rust and unit-tested without `iree`.
 use crate::weights::{
-    WeightSpec, bf16_to_f32, dequantize_affine, dequantize_affine_stacked, f16_to_f32,
+    QuantPart, WeightSpec, bf16_to_f32, dequantize_affine, dequantize_affine_stacked, f16_to_f32,
     f32_le_to_f32, slice_rows, weight_specs,
 };
+
+/// Weight-buffer element dtype passed to the C shim (issue #516 per-weight ABI):
+/// f32 (a widened / dequantized weight), or f16 / packed-U32 for the raw parts of an
+/// MLX affine-quantized projection on the packed path. Kept in sync with the
+/// `switch` in `csrc/xla_iree.c`.
+const WDT_F32: c_int = 0;
+const WDT_F16: c_int = 1;
+const WDT_U32: c_int = 2;
+
+/// A resident-weight host buffer, kept alive until the shim copies it to the device.
+/// Either f32 values (a widened / dequantized weight, the proven path) or raw bytes
+/// (an MLX packed-U32 weight or its f16 scales / biases, issue #516 packed path).
+enum WeightBuf {
+    F32(Vec<f32>),
+    Raw(Vec<u8>),
+}
+
+impl WeightBuf {
+    /// Host pointer to the buffer bytes (the shim copies `nelem * dtype_size` of them).
+    fn as_u8_ptr(&self) -> *const u8 {
+        match self {
+            WeightBuf::F32(v) => v.as_ptr() as *const u8,
+            WeightBuf::Raw(v) => v.as_ptr(),
+        }
+    }
+}
 
 /// Prefill bucket baked into the emitted `prefill` graph (`tensor<256xi32>`,
 /// == MAX_SEQ, so it covers any prompt the 256-slot KV cache holds).
@@ -86,7 +112,8 @@ unsafe extern "C" {
         prefill: *const c_char,
         decode: *const c_char,
         n_weights: c_int,
-        weight_data: *const *const f32,
+        weight_data: *const *const c_void,
+        weight_dtypes: *const c_int,
         weight_ranks: *const c_int,
         weight_dims: *const i64,
     ) -> *mut XlaCtx;
@@ -342,7 +369,7 @@ fn resolve_weight_shards(model_dir: &Path, names: &[String]) -> Result<Vec<PathB
 fn load_weights(
     model_dir: &Path,
     cfg: &Config,
-) -> Result<(Vec<Vec<f32>>, Vec<c_int>, Vec<i64>), String> {
+) -> Result<(Vec<WeightBuf>, Vec<c_int>, Vec<c_int>, Vec<i64>), String> {
     let specs = weight_specs(cfg);
     let names: Vec<String> = specs.iter().map(|s| s.tensor_name().to_string()).collect();
     let shard_paths = resolve_weight_shards(model_dir, &names)?;
@@ -358,7 +385,8 @@ fn load_weights(
     }
 
     let n = specs.len();
-    let mut bufs: Vec<Vec<f32>> = vec![Vec::new(); n];
+    let mut bufs: Vec<WeightBuf> = (0..n).map(|_| WeightBuf::F32(Vec::new())).collect();
+    let mut dtypes: Vec<c_int> = vec![WDT_F32; n];
     let mut ranks: Vec<c_int> = vec![0; n];
     let mut dims: Vec<i64> = vec![0; n * 4];
     for (shard, idxs) in by_shard {
@@ -373,6 +401,35 @@ fn load_weights(
             let t = st
                 .tensor(name)
                 .map_err(|e| format!("weight {name} in {}: {e}", shard.display()))?;
+
+            // issue #516 packed path: upload the raw quantized part (the packed U32
+            // weight, or its f16 scales / biases) as-is, no dequant. Its native dtype
+            // and 2-D shape go straight to the device; the graph dequants in-place.
+            if let WeightSpec::QuantRaw { part, .. } = &specs[i] {
+                let (code, expect) = match part {
+                    QuantPart::Packed => (WDT_U32, Dtype::U32),
+                    QuantPart::Scales | QuantPart::Biases => (WDT_F16, Dtype::F16),
+                };
+                if t.dtype() != expect {
+                    return Err(format!(
+                        "quant part {name} dtype {:?}, expected {expect:?}",
+                        t.dtype()
+                    ));
+                }
+                let shape = t.shape();
+                if shape.len() != 2 {
+                    return Err(format!(
+                        "quant part {name} is rank {} (expected 2)",
+                        shape.len()
+                    ));
+                }
+                dtypes[i] = code;
+                ranks[i] = 2;
+                dims[i * 4] = shape[0] as i64;
+                dims[i * 4 + 1] = shape[1] as i64;
+                bufs[i] = WeightBuf::Raw(t.data().to_vec());
+                continue;
+            }
 
             // Widen the whole tensor to row-major `[out, in]` (or `[out]`) f32 (the
             // graph's dtype): an MLX affine `U32`-packed weight is dequantized (the
@@ -472,7 +529,7 @@ fn load_weights(
                     for (k, &s) in shape.iter().enumerate() {
                         dims[i * 4 + k] = s as i64;
                     }
-                    bufs[i] = data;
+                    bufs[i] = WeightBuf::F32(data);
                 }
                 WeightSpec::Rows { start, end, .. } => {
                     if shape.len() != 2 {
@@ -481,16 +538,21 @@ fn load_weights(
                             shape.len()
                         ));
                     }
-                    bufs[i] = slice_rows(&data, shape[0], *start, *end)
-                        .map_err(|e| format!("row-slice {name}: {e}"))?;
+                    bufs[i] = WeightBuf::F32(
+                        slice_rows(&data, shape[0], *start, *end)
+                            .map_err(|e| format!("row-slice {name}: {e}"))?,
+                    );
                     ranks[i] = 2;
                     dims[i * 4] = (*end - *start) as i64;
                     dims[i * 4 + 1] = shape[1] as i64;
                 }
+                WeightSpec::QuantRaw { .. } => {
+                    unreachable!("QuantRaw is handled by the early-continue above")
+                }
             }
         }
     }
-    Ok((bufs, ranks, dims))
+    Ok((bufs, dtypes, ranks, dims))
 }
 
 fn path_cstring(p: &Path) -> Result<CString, String> {
@@ -508,8 +570,11 @@ fn create_ctx(
     prefill_vmfb: &Path,
     decode_vmfb: &Path,
 ) -> Result<*mut XlaCtx, String> {
-    let (bufs, ranks, dims) = load_weights(model_dir, cfg)?;
-    let ptrs: Vec<*const f32> = bufs.iter().map(|b| b.as_ptr()).collect();
+    let (bufs, dtypes, ranks, dims) = load_weights(model_dir, cfg)?;
+    let ptrs: Vec<*const c_void> = bufs
+        .iter()
+        .map(|b| b.as_u8_ptr() as *const c_void)
+        .collect();
     let c_dev = CString::new(device).map_err(|_| "device has interior nul".to_string())?;
     let c_pre = path_cstring(prefill_vmfb)?;
     let c_dec = path_cstring(decode_vmfb)?;
@@ -522,6 +587,7 @@ fn create_ctx(
             c_dec.as_ptr(),
             bufs.len() as c_int,
             ptrs.as_ptr(),
+            dtypes.as_ptr(),
             ranks.as_ptr(),
             dims.as_ptr(),
         )

--- a/src/lib/mlxcel-xla/src/weights.rs
+++ b/src/lib/mlxcel-xla/src/weights.rs
@@ -23,7 +23,7 @@
 //! feature-gated `iree.rs`) so it is unit-tested without the IREE runtime and stays
 //! in lock-step with the emitter's arg order (`emitter::model::take_layer_weights`).
 
-use crate::emitter::Config;
+use crate::emitter::{Config, quant_in_graph};
 
 /// One checkpoint weight the loader reads, in the emitter's arg order. Most are a
 /// whole safetensors tensor; a Phi3 checkpoint fuses q/k/v into one `qkv_proj` and
@@ -31,7 +31,8 @@ use crate::emitter::Config;
 /// tensor for each of the emitter's separate `wq`/`wk`/`wv`/`gate`/`up` args.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum WeightSpec {
-    /// Load the whole checkpoint tensor `name`.
+    /// Load the whole checkpoint tensor `name` (widened to f32, an MLX-quantized
+    /// U32 tensor dequantized to f32).
     Whole(String),
     /// Load rows `[start, end)` of the checkpoint tensor `name` (a fused Phi3
     /// projection, split into an emitter arg). Row-major `[out, in]`, so this is
@@ -41,14 +42,31 @@ pub(crate) enum WeightSpec {
         start: usize,
         end: usize,
     },
+    /// Upload one part of an MLX affine-quantized projection as RAW bytes without
+    /// dequantizing (issue #516 packed path): the packed `[out, in_packed]` U32
+    /// weight, or its `[out, in/group_size]` f16 `scales` / `biases`. The graph
+    /// dequants it in-place ([`Builder::dequant_affine`]). `name` is the exact
+    /// tensor (`X.weight` / `X.scales` / `X.biases`). Emitted as three consecutive
+    /// specs per projection, matching the emitter's packed / scales / biases args.
+    QuantRaw { name: String, part: QuantPart },
+}
+
+/// Which part of an MLX affine-quantized projection a [`WeightSpec::QuantRaw`]
+/// uploads (issue #516): the packed U32 weight, or its f16 scales / biases.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum QuantPart {
+    Packed,
+    Scales,
+    Biases,
 }
 
 impl WeightSpec {
-    /// The checkpoint tensor this spec reads from (whole or sliced).
+    /// The checkpoint tensor this spec reads from (whole, sliced, or a quant part).
     pub(crate) fn tensor_name(&self) -> &str {
         match self {
             WeightSpec::Whole(n) => n,
             WeightSpec::Rows { name, .. } => name,
+            WeightSpec::QuantRaw { name, .. } => name,
         }
     }
 }
@@ -70,6 +88,40 @@ impl WeightSpec {
 /// family, and it mirrors `take_layer_weights` so the loaded buffers line up with
 /// the emitted graph's args exactly.
 pub(crate) fn weight_specs(cfg: &Config) -> Vec<WeightSpec> {
+    weight_specs_q(cfg, quant_in_graph() && cfg.supports_packed_quant())
+}
+
+/// Push a projection weight `name` (`X.weight`) in the emitter's arg order: three
+/// [`WeightSpec::QuantRaw`] parts (packed / scales / biases, from `X.weight` /
+/// `X.scales` / `X.biases`) when the issue #516 packed path is active (`quant`),
+/// else the single `Whole` f32 tensor (dequantized / widened at load). Mirrors
+/// `take_weight` in the emitter so the loaded buffers line up with the graph's
+/// 1-or-3 args per projection.
+fn push_proj(out: &mut Vec<WeightSpec>, name: String, quant: bool) {
+    if quant {
+        let stem = name.strip_suffix(".weight").unwrap_or(&name).to_string();
+        out.push(WeightSpec::QuantRaw {
+            name,
+            part: QuantPart::Packed,
+        });
+        out.push(WeightSpec::QuantRaw {
+            name: format!("{stem}.scales"),
+            part: QuantPart::Scales,
+        });
+        out.push(WeightSpec::QuantRaw {
+            name: format!("{stem}.biases"),
+            part: QuantPart::Biases,
+        });
+    } else {
+        out.push(WeightSpec::Whole(name));
+    }
+}
+
+/// [`weight_specs`] with the packed-path decision passed explicitly (so it is
+/// testable without the `MLXCEL_XLA_QUANT` env). `quant` already folds in
+/// [`Config::supports_packed_quant`], so it is `true` only for the standard Llama
+/// layout; the fused / dense / MoE branches below are therefore never quantized.
+fn weight_specs_q(cfg: &Config, quant: bool) -> Vec<WeightSpec> {
     let s = crate::weight_names::scheme_names(cfg.weight_scheme);
     let hd = cfg.head_dim;
     let nq = cfg.n_q * hd;
@@ -95,11 +147,12 @@ pub(crate) fn weight_specs(cfg: &Config) -> Vec<WeightSpec> {
         let moe_layer = cfg.is_moe_layer(i);
         // down (dense StarCoder2 uses c_proj; else the scheme's down projection).
         if !moe_layer {
-            out.push(WeightSpec::Whole(if cfg.dense_mlp {
+            let name = if cfg.dense_mlp {
                 format!("{p}mlp.c_proj.weight")
             } else {
                 format!("{p}{}", s.down)
-            }));
+            };
+            push_proj(&mut out, name, quant);
         }
         // gate (gated MLP only; the first half of gate_up_proj for a fused Phi3).
         if gated && !moe_layer {
@@ -110,7 +163,7 @@ pub(crate) fn weight_specs(cfg: &Config) -> Vec<WeightSpec> {
                     end: inter,
                 });
             } else {
-                out.push(WeightSpec::Whole(format!("{p}{}", s.gate)));
+                push_proj(&mut out, format!("{p}{}", s.gate), quant);
             }
         }
         // input_layernorm: present unless the OLMo reordered post-norm drops it.
@@ -136,7 +189,7 @@ pub(crate) fn weight_specs(cfg: &Config) -> Vec<WeightSpec> {
             } else if cfg.dense_mlp {
                 out.push(WeightSpec::Whole(format!("{p}mlp.c_fc.weight")));
             } else {
-                out.push(WeightSpec::Whole(format!("{p}{}", s.up)));
+                push_proj(&mut out, format!("{p}{}", s.up), quant);
             }
         }
         // wk, wo, wq, wv (JAX-alphabetical; a fused Phi3 qkv_proj is [Q|K|V] rows).
@@ -159,10 +212,10 @@ pub(crate) fn weight_specs(cfg: &Config) -> Vec<WeightSpec> {
                 end: nq + 2 * nkv,
             }); // wv
         } else {
-            out.push(WeightSpec::Whole(format!("{p}{}", s.k_proj)));
-            out.push(WeightSpec::Whole(format!("{p}{}", s.o_proj)));
-            out.push(WeightSpec::Whole(format!("{p}{}", s.q_proj)));
-            out.push(WeightSpec::Whole(format!("{p}{}", s.v_proj)));
+            push_proj(&mut out, format!("{p}{}", s.k_proj), quant);
+            push_proj(&mut out, format!("{p}{}", s.o_proj), quant);
+            push_proj(&mut out, format!("{p}{}", s.q_proj), quant);
+            push_proj(&mut out, format!("{p}{}", s.v_proj), quant);
         }
         // q/k/v projection biases (k, q, v order).
         if cfg.qkv_bias {
@@ -742,5 +795,81 @@ mod tests {
         let packed = [0u8; 4]; // one expert's worth, but experts = 2 declared
         let sb = [0u8; 4];
         assert!(dequantize_affine_stacked(&packed, &sb, &sb, 2, 1, 1, 4, 4).is_err());
+    }
+
+    /// The issue #516 packed path expands each of the 7 per-layer projections into
+    /// three consecutive `QuantRaw` specs (packed `.weight`, then `.scales`, then
+    /// `.biases`), while embed / norms stay single `Whole` specs. This is the loader
+    /// contract that must mirror the emitter's `take_weight` 3-args-per-projection so
+    /// the uploaded buffers line up with the graph args. `quant = false` is the
+    /// legacy all-`Whole` order (byte-identical to before), so the packed path is
+    /// purely additive.
+    #[test]
+    fn weight_specs_q_packed_expands_projections_to_triples() {
+        let c = Config::llama_3_2_1b();
+        let specs = weight_specs_q(&c, true);
+        // embed + final_norm remain single f32 tensors (not quantized in the v1 path).
+        assert_eq!(
+            specs[0],
+            WeightSpec::Whole("model.embed_tokens.weight".into())
+        );
+        assert_eq!(specs[1], WeightSpec::Whole("model.norm.weight".into()));
+        let packed = specs
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s,
+                    WeightSpec::QuantRaw {
+                        part: QuantPart::Packed,
+                        ..
+                    }
+                )
+            })
+            .count();
+        let scales = specs
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s,
+                    WeightSpec::QuantRaw {
+                        part: QuantPart::Scales,
+                        ..
+                    }
+                )
+            })
+            .count();
+        let biases = specs
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s,
+                    WeightSpec::QuantRaw {
+                        part: QuantPart::Biases,
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert_eq!(packed, 7 * c.n_layers, "7 packed projections per layer");
+        assert_eq!(scales, packed, "one scales part per packed weight");
+        assert_eq!(biases, packed, "one biases part per packed weight");
+        // The three parts of a projection are consecutive and share the tensor stem.
+        let i = specs
+            .iter()
+            .position(|s| matches!(s, WeightSpec::QuantRaw { name, part: QuantPart::Packed } if name.ends_with("q_proj.weight")))
+            .expect("a packed q_proj part");
+        assert!(
+            matches!(&specs[i + 1], WeightSpec::QuantRaw { name, part: QuantPart::Scales } if name.ends_with("q_proj.scales"))
+        );
+        assert!(
+            matches!(&specs[i + 2], WeightSpec::QuantRaw { name, part: QuantPart::Biases } if name.ends_with("q_proj.biases"))
+        );
+        // quant = false is the legacy all-Whole order (purely additive packed path).
+        assert!(
+            weight_specs_q(&c, false)
+                .iter()
+                .all(|s| matches!(s, WeightSpec::Whole(_))),
+            "unquantized layout is unchanged"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Picks up the int8 lever from #516 / #513 (ADR 0004). The OpenXLA loader stopped
dequantizing MLX 4/8-bit checkpoints to f32: with `MLXCEL_XLA_QUANT=packed` it keeps
the weights resident **packed** (`ui32` weight + f16 scales/biases) and dequantizes
each one **in the StableHLO graph**, so the bandwidth-relevant packed form survives
into the graph where an int-native target could use it. Opt-in, **off by default**.

This landed the whole packed ABI, then measured it on a GB10 (the deferral's
"hardware gate"). The headline finding is below.

## What changed

- **Emitter** (`builder.rs`, `model.rs`): `Builder::dequant_affine` authors the MLX
  affine dequant in StableHLO (bit-unpack the `ui32` lanes with shift/mask, convert,
  then `q*scale + bias` per `group_size`), **bit-identical** to the host
  `weights::dequantize_affine`, so the packed graph is token-exact by construction.
  `take_weight` routes the 7 per-layer projections through it across all four graph
  kinds (decode / ragged / batched / prefill). The dense/unquantized path is
  untouched, so the byte-exact goldens are unchanged.
- **Loader** (`weights.rs`, `iree.rs`): `WeightSpec::QuantRaw` + `weight_specs`
  expansion upload the packed U32 and f16 scales/biases as separate device buffers;
  `load_weights` and the C shim ABI are now **per-weight-dtype** (f32 / f16 / ui32).
- **Gate**: `Config::supports_packed_quant` (standard Llama layout: non-fused-qkv,
  non-fused-gate-up, non-dense-MLP, non-MoE) is shared by the emitter and the loader
  so they never diverge. v1 leaves embed / lm_head f32-resident.
- **Toolchain**: `scripts/iree/setup-cuda.sh` reproduces the source-built cuda IREE
  runtime the GB10 path needs (mirrors `setup-macos.sh`).

## Measured on GB10 (the fusion gate)

Llama-3.2-1B, MLX 4-bit `group_size` 64, greedy, warm vmfb, CUDA via the source-built
IREE runtime:

| decode path | tok/s | GPU util | correctness |
|-------------|-------|----------|-------------|
| f16, dequant-at-load (default) | ~6.7 | 84% | reference |
| packed, dequant-in-graph (`MLXCEL_XLA_QUANT=packed`) | ~1.6 | 96% | **token-exact** with the f16 path |

The packed path is **correct but ~4.3x slower**, because IREE's CUDA codegen **does
not fuse** the unpack+dequant into the matmul: the decode step is ~678 dispatches and
the reconstructed f32 weight is materialized to DRAM every step, so it pays *more*
bandwidth + compute, not less (util rises 84% -> 96%). The fusion flags
(`--iree-dispatch-creation-enable-aggressive-fusion`, `--iree-opt-generalize-matmul`,
`--iree-dispatch-creation-enable-early-trunc-fusion`) leave the dispatch count
unchanged (678 -> 677).

So the memory-bandwidth payoff is **not** realized by authoring the dequant in the
portable graph alone; it needs the target to fuse dequant into the matmul (a
quantized-matmul op, or an int8 `dot_general` lowering to the hardware int8 path).
This is the same split the f16 profiling reached, now confirmed for int8: the
graph-level change is in scope and transferable, but the fused low-precision kernel
is upstream IREE's job. The packed path therefore lands **off by default**, as the
correctness-verified ABI a fused quantized-matmul reuses.

## How to run

```bash
eval "$(scripts/iree/setup-cuda.sh --env)"   # or --env after a first full run
cargo build --release --features xla-iree
# token-exact packed path (opt-in), else default dequant-at-load:
MLXCEL_XLA_QUANT=packed MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=cuda \
  ./target/release/mlxcel generate -m <Llama-3.2-1B 4-bit dir> -p "..." -n 48
```

## Validation

- `cargo test -p mlxcel-xla --lib`: 111/111 (dequant-in-graph unit tests for 4/8-bit,
  the `weight_specs` packed-expansion contract test, and the byte-exact goldens all
  pass; the dense path is unchanged).
- `cargo clippy -p mlxcel-xla --features iree`: clean (no new warnings).
- End-to-end on GB10: packed decode is token-exact with the f16 path and with the
  original baseline output; perf as tabled above.

## Follow-up

A fused quantized-matmul (int8 `dot_general` lowering, or a StableHLO quantized dot
that IREE/an NPU HAL driver fuses into a systolic int8 kernel) is what turns this from
correctness-only into the bandwidth win. This PR is its foundation. I did not
auto-close #516; leaving that to the maintainer to decide (close as
implemented-and-gated, or keep open for the fused lever).

Refs #516. Part of #513. ADR 0004.