### PR TITLE
build: reproducible IREE runtime toolchain via make targets (#571)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ help: ## Show this help message
 	@echo "$(BOLD)Build Targets:$(RESET)"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -E '(build|release|debug)' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(CYAN)%-20s$(RESET) %s\n", $$1, $$2}'
 	@echo ""
+	@echo "$(BOLD)IREE Backend Targets:$(RESET)"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -E '(iree)' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(CYAN)%-20s$(RESET) %s\n", $$1, $$2}'
+	@echo ""
 	@echo "$(BOLD)Test Targets:$(RESET)"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -E '(test|check|lint|clippy)' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(CYAN)%-20s$(RESET) %s\n", $$1, $$2}'
 	@echo ""
@@ -147,6 +150,44 @@ release-cuda: ## Build in release mode with CUDA (Linux/NVIDIA)
 
 .PHONY: debug
 debug: build ## Alias for build (debug mode)
+
+# ============================================================================
+# IREE Toolchain (OpenXLA `xla-iree` backend runtime)
+# ============================================================================
+#
+# Source-build the version-matched IREE runtime + pinned `iree-compile` that the
+# `xla-iree` feature links against, wrapping scripts/iree/setup-{cuda,macos}.sh so
+# the measurement environment is reproducible from a fresh checkout. The scripts
+# are idempotent (they reuse an existing clone / build / venv), so re-running does
+# not rebuild when the pinned artifact is already present. `make iree` auto-detects
+# the host: CUDA on Linux, Metal on macOS.
+
+IREE_CUDA_SCRIPT := scripts/iree/setup-cuda.sh
+IREE_MACOS_SCRIPT := scripts/iree/setup-macos.sh
+
+.PHONY: iree
+iree: ## Set up the IREE backend toolchain for this host (CUDA/Linux, Metal/macOS)
+ifeq ($(UNAME_S),Darwin)
+	@$(MAKE) --no-print-directory iree-metal
+else
+	@$(MAKE) --no-print-directory iree-cuda
+endif
+
+.PHONY: iree-cuda
+iree-cuda: ## Set up the IREE CUDA toolchain (Linux/NVIDIA)
+	@$(IREE_CUDA_SCRIPT)
+
+.PHONY: iree-metal
+iree-metal: ## Set up the IREE Metal toolchain (macOS/Apple Silicon)
+	@$(IREE_MACOS_SCRIPT)
+
+.PHONY: iree-env
+iree-env: ## Print the resolved IREE toolchain paths + pinned version
+ifeq ($(UNAME_S),Darwin)
+	@$(IREE_MACOS_SCRIPT) --info
+else
+	@$(IREE_CUDA_SCRIPT) --info
+endif
 
 # ============================================================================
 # Test Targets

--- a/scripts/iree/setup-cuda.sh
+++ b/scripts/iree/setup-cuda.sh
@@ -43,9 +43,27 @@ emit_env() {
   echo "export MLXCEL_XLA_IREE_COMPILE=$IREE_COMPILE"
 }
 
+# `--info`: human-readable resolved paths + pinned version + HAL drivers, for
+# `make iree-env`. Not eval-safe -- use `--env` to export into a shell.
+emit_info() {
+  echo "IREE backend:  cuda (HAL drivers: local-task, local-sync, cuda)"
+  echo "IREE home:     $IREE_DIR"
+  echo "iree-compile:  $IREE_COMPILE"
+  echo "CUDA root:     $CUDA_ROOT"
+  echo "Pinned:        iree-base-compiler==$PIP_VER  (iree-org @ $IREE_SHA)"
+  echo
+  echo "# export the build env with: eval \"\$(scripts/iree/setup-cuda.sh --env)\""
+  emit_env
+}
+
 # `--env`: assume already built; just print the exports.
 if [ "${1:-}" = "--env" ]; then
   emit_env
+  exit 0
+fi
+# `--info`: print resolved paths + pinned version (human-readable).
+if [ "${1:-}" = "--info" ]; then
+  emit_info
   exit 0
 fi
 
@@ -80,11 +98,19 @@ if [ ! -e "$SRC/.git" ]; then
   git -C "$SRC" fetch --depth 1 origin "$IREE_SHA"
   git -C "$SRC" checkout -q FETCH_HEAD
 fi
-# The runtime build needs only flatcc (vmfb parsing); skip the compiler-only
-# submodules (llvm-project, stablehlo, torch-mlir, ...) entirely.
-if [ ! -e "$SRC/third_party/flatcc/.git" ]; then
-  log "initializing flatcc submodule only"
-  git -C "$SRC" submodule update --init --depth 1 -- third_party/flatcc
+# The runtime build needs the non-compiler submodules: flatcc (vmfb parsing),
+# plus google benchmark and printf, which the top-level CMake pulls in through the
+# threading / runtime gates (IREE_ENABLE_THREADING etc.), not IREE_BUILD_*.
+# Initialize everything EXCEPT the heavy compiler-only submodules (llvm-project,
+# stablehlo, torch-mlir), which a runtime-only build (IREE_BUILD_COMPILER=OFF)
+# never configures. The benchmark sentinel also self-heals an older flatcc-only clone.
+if [ ! -e "$SRC/third_party/benchmark/.git" ]; then
+  log "initializing runtime submodules (all except llvm-project/stablehlo/torch-mlir)"
+  git -C "$SRC" \
+    -c submodule."third_party/llvm-project".update=none \
+    -c submodule."third_party/stablehlo".update=none \
+    -c submodule."third_party/torch-mlir".update=none \
+    submodule update --init --depth 1
 fi
 
 UNIFIED="$BUILD/runtime/src/iree/runtime/libiree_runtime_unified.a"

--- a/scripts/iree/setup-macos.sh
+++ b/scripts/iree/setup-macos.sh
@@ -43,9 +43,26 @@ emit_env() {
   echo "export MLXCEL_XLA_IREE_COMPILE=$IREE_COMPILE"
 }
 
+# `--info`: human-readable resolved paths + pinned version + HAL drivers, for
+# `make iree-env`. Not eval-safe -- use `--env` to export into a shell.
+emit_info() {
+  echo "IREE backend:  metal (HAL drivers: local-task, local-sync, metal)"
+  echo "IREE home:     $IREE_DIR"
+  echo "iree-compile:  $IREE_COMPILE"
+  echo "Pinned:        $IREE_TAG  (wheel $WHEEL)"
+  echo
+  echo "# export the build env with: eval \"\$(scripts/iree/setup-macos.sh --env)\""
+  emit_env
+}
+
 # `--env`: assume already built; just print the exports.
 if [ "${1:-}" = "--env" ]; then
   emit_env
+  exit 0
+fi
+# `--info`: print resolved paths + pinned version (human-readable).
+if [ "${1:-}" = "--info" ]; then
+  emit_info
   exit 0
 fi
 
@@ -82,11 +99,19 @@ if [ ! -d "$SRC/.git" ]; then
   log "cloning IREE runtime source @ $IREE_TAG (shallow, no LLVM)"
   git clone --depth 1 --branch "$IREE_TAG" https://github.com/iree-org/iree.git "$SRC"
 fi
-# The runtime build needs only flatcc (vmfb parsing); skip the compiler-only
-# submodules (llvm-project, stablehlo, torch-mlir, ...) entirely.
-if [ ! -e "$SRC/third_party/flatcc/.git" ]; then
-  log "initializing flatcc submodule only"
-  git -C "$SRC" submodule update --init --depth 1 -- third_party/flatcc
+# The runtime build needs the non-compiler submodules: flatcc (vmfb parsing),
+# plus google benchmark and printf, which the top-level CMake pulls in through the
+# threading / runtime gates (IREE_ENABLE_THREADING etc.), not IREE_BUILD_*.
+# Initialize everything EXCEPT the heavy compiler-only submodules (llvm-project,
+# stablehlo, torch-mlir), which a runtime-only build (IREE_BUILD_COMPILER=OFF)
+# never configures. The benchmark sentinel also self-heals an older flatcc-only clone.
+if [ ! -e "$SRC/third_party/benchmark/.git" ]; then
+  log "initializing runtime submodules (all except llvm-project/stablehlo/torch-mlir)"
+  git -C "$SRC" \
+    -c submodule."third_party/llvm-project".update=none \
+    -c submodule."third_party/stablehlo".update=none \
+    -c submodule."third_party/torch-mlir".update=none \
+    submodule update --init --depth 1
 fi
 
 UNIFIED="$BUILD/runtime/src/iree/runtime/libiree_runtime_unified.a"

--- a/src/lib/mlxcel-xla/README.md
+++ b/src/lib/mlxcel-xla/README.md
@@ -45,23 +45,18 @@ The prebuilt dist is CPU/Vulkan only (no CUDA driver, and its `iree-compile` has
 no CUDA codegen). The CUDA path therefore uses a **source-built cuda-enabled IREE
 runtime** plus a **cuda-capable `iree-compile`**, version-matched to each other.
 It is a separate, mutually-exclusive build mode (set `IREE_CUDA_HOME` instead of
-`IREE_DIST`).
+`IREE_DIST`). `make iree-cuda` (wrapping `scripts/iree/setup-cuda.sh`) automates
+it: it installs the pinned cuda `iree-compile` into a private venv and
+source-builds the version-matched runtime (`local-task`/`local-sync`/`cuda`
+drivers), then prints the env. Idempotent: re-running reuses the clone/build/venv.
 
 ```bash
-# 1. Build the IREE *runtime* from source at the version your iree-compile uses
-#    (runtime only -> no LLVM; skip the third_party/llvm-project submodule):
-git clone --depth 1 --branch <iree-tag> https://github.com/iree-org/iree.git src
-git -C src -c submodule."third_party/llvm-project".update=none \
-    submodule update --init --recursive --depth 1
-cmake -S src -B build -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release \
-  -DIREE_BUILD_COMPILER=OFF -DIREE_HAL_DRIVER_DEFAULTS=OFF \
-  -DIREE_HAL_DRIVER_LOCAL_TASK=ON -DIREE_HAL_DRIVER_LOCAL_SYNC=ON \
-  -DIREE_HAL_DRIVER_CUDA=ON -DCUDAToolkit_ROOT=/usr/local/cuda
-make -C build -j"$(nproc)" iree_runtime_unified
+# 1. Source-build the cuda IREE runtime + pinned iree-compile (idempotent).
+make iree-cuda                                 # or `make iree` (auto-detects the host)
+eval "$(scripts/iree/setup-cuda.sh --env)"     # export IREE_CUDA_HOME / _COMPILE / MLXCEL_XLA_IREE_COMPILE
+# (inspect the resolved paths + pinned version any time: `make iree-env`)
 
-# 2. Point the build at it; provide a cuda-capable iree-compile (matching version).
-export IREE_CUDA_HOME=/abs/path/to/that/iree   # the dir holding src/ and build/
-export IREE_CUDA_COMPILE=/abs/path/to/iree-compile   # cuda codegen, version-matched
+# 2. Build with real execution on.
 cargo build --release --features xla-iree
 
 # 3. Run on the GPU.
@@ -78,15 +73,17 @@ Validated on a GB10 (Grace-Blackwell, sm_121): token-exact 48/48, ~5 tok/s
 On Apple Silicon, **MLX is the default and primary backend**; this OpenXLA path
 is a development / parity path, opt-in exactly like CUDA. IREE publishes no macOS
 `iree-dist` (only linux dists + python wheels), so the runtime is **source-built**
-like the CUDA path. `scripts/iree/setup-macos.sh` automates it: it installs the
-pinned macOS `iree-compile` (metal-spirv codegen) from the universal2 wheel into a
+like the CUDA path. `make iree-metal` (wrapping `scripts/iree/setup-macos.sh`)
+automates it: it installs the pinned macOS `iree-compile` (metal-spirv codegen)
+from the universal2 wheel into a
 private venv, source-builds the IREE runtime (`local-task`/`local-sync`/`metal`
 drivers), and prints the env.
 
 ```bash
-# 1. One-time setup (clones + builds the IREE runtime; idempotent).
-eval "$(scripts/iree/setup-macos.sh)"        # sets IREE_MACOS_HOME, MLXCEL_XLA_IREE_COMPILE
-# (later shells: eval "$(scripts/iree/setup-macos.sh --env)")
+# 1. One-time setup: source-build the IREE runtime (idempotent).
+make iree-metal                              # or `make iree` (auto-detects the host)
+eval "$(scripts/iree/setup-macos.sh --env)"  # export IREE_MACOS_HOME, MLXCEL_XLA_IREE_COMPILE
+# (inspect the resolved paths + pinned version: `make iree-env`)
 
 # 2. Build with real execution on (alongside the usual MLX features).
 cargo build --release --features metal,accelerate,xla-iree


### PR DESCRIPTION
## Summary

Part of the OpenXLA low-precision performance epic (#570). Wraps the source-built IREE runtime setup (`scripts/iree/setup-cuda.sh`, `scripts/iree/setup-macos.sh`) in idempotent `make` targets so the measurement environment for the rest of the epic is reproducible from a fresh checkout rather than a local uncommitted artifact.

## What changed

- **Makefile targets.** `make iree` auto-detects the host (CUDA on Linux, Metal on macOS) and dispatches to `make iree-cuda` / `make iree-metal`, which run the validated setup scripts. `make iree-env` prints the resolved paths, pinned IREE version, and HAL drivers. All are idempotent: the scripts reuse an existing clone / build / venv, so re-running does not rebuild when the pinned artifact is present. A dedicated "IREE Backend Targets" group is added to `make help`.
- **Reproducibility fix (both scripts).** A runtime-only IREE configure at the pinned revision (`e4a3b04`) needs the `benchmark` and `printf` submodules: the top-level CMake pulls `third_party/benchmark` in under `IREE_ENABLE_THREADING` (on for the local-task driver) and `third_party/printf` under the runtime gates, neither gated by `IREE_BUILD_*`. The previous flatcc-only init therefore failed a fresh build at the configure/generate step. Both scripts now initialize every submodule except the heavy compiler-only ones (`llvm-project`, `stablehlo`, `torch-mlir`), which a runtime-only build (`IREE_BUILD_COMPILER=OFF`) never configures. The `benchmark` sentinel also self-heals an older flatcc-only clone.
- **`--info` mode.** Each script gains a read-only `--info` that prints the resolved paths, pinned version, and HAL drivers (surfaced by `make iree-env`); the eval-safe `--env` output is unchanged.
- **README.** The `mlxcel-xla` CUDA and macOS build sections now reference `make iree` instead of the ad-hoc clone / cmake / script invocation.

## Validation (GB10, CUDA)

- `make iree-env` prints backend, home, iree-compile, CUDA root, pinned version, and HAL drivers.
- **Reproducible from a clean source tree:** removing the cloned `src/` + `build/` and running `make iree-cuda` re-clones, initializes `flatcc` + `benchmark` + `printf`, configures, and rebuilds `libiree_runtime_unified.a` (exit 0).
- `cargo build --release --features xla-iree` links the freshly built runtime.
- **Token-exact on the GPU:** greedy generation on Llama-3.2-1B (4-bit) is byte-identical between `cuda` f16 (default) and `cuda` f32 (48/48 tokens); f16 6.8 tok/s vs f32 4.85 tok/s.

## Notes

- The Metal targets (`make iree-metal`) follow the same CMake gates and pass `bash -n`, but are not validatable on this Linux host; Metal validation belongs to a macOS session (tracked under #575).
- Orthogonal observation (not addressed here): on the source-built CUDA runtime, `MLXCEL_XLA_DEVICE=local-task` reports "no driver 'local-task' registered" even though the driver is compiled in (`libiree_hal_drivers_local_task_task_driver.a`). This is a shim/runtime-registration behavior independent of this change and may warrant a follow-up.

Closes #571
Part of #570
