### PR TITLE
docs: fusion spike findings for the packed int8 path (#573)

### DIFF
--- a/scripts/xla/fusion_spike.sh
+++ b/scripts/xla/fusion_spike.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Reproduce the issue #573 spike: does IREE fuse the packed int4/int8 dequant into
+# the matmul on the CUDA target, so the reconstructed weight is not materialized to
+# DRAM every decode step? Measures the static decode dispatch count (the fusion
+# signal: `iree-compile --compile-to=flow` then count `flow.dispatch`) for the real
+# packed decode graph under a flag sweep, plus three isolating microtests.
+#
+# Prereqs: a cuda `iree-compile` (issue #571: `make iree-cuda`, then
+# `eval "$(scripts/iree/setup-cuda.sh --env)"`). tok/s figures come from the mlxcel
+# binary (`MLXCEL_XLA_QUANT=packed ... generate`), not this script.
+#
+# Usage:
+#   scripts/xla/fusion_spike.sh [DECODE_MLIR]
+# With no arg it uses the newest packed decode graph mlxcel left in its vmfb cache
+# ($TMPDIR/mlxcel-xla-vmfb/decode-*.mlir with ui32 weight args); run a packed decode
+# once first: MLXCEL_XLA_QUANT=packed MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=cuda \
+#   ./target/release/mlxcel generate -m <Llama-3.2-1B 4-bit dir> -p "..." -n 8
+set -uo pipefail
+
+IREE_COMPILE="${MLXCEL_XLA_IREE_COMPILE:-}"
+[ -n "$IREE_COMPILE" ] || IREE_COMPILE="$(eval "$(dirname "$0")/../iree/setup-cuda.sh --env" 2>/dev/null; echo "${MLXCEL_XLA_IREE_COMPILE:-}")"
+[ -x "$IREE_COMPILE" ] || { echo "no cuda iree-compile; run: eval \"\$(scripts/iree/setup-cuda.sh --env)\"" >&2; exit 1; }
+
+CACHE="${TMPDIR:-/tmp}/mlxcel-xla-vmfb"
+DECODE="${1:-}"
+if [ -z "$DECODE" ]; then
+  for f in $(ls -t "$CACHE"/decode-*.mlir 2>/dev/null); do
+    [ "$(grep -c ui32 "$f")" -gt 0 ] && DECODE="$f" && break
+  done
+fi
+[ -n "$DECODE" ] && [ -f "$DECODE" ] || { echo "no packed decode graph found; run a packed decode first (see header)" >&2; exit 1; }
+echo "packed decode graph: $DECODE"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+CUDA=(--iree-input-type=stablehlo --iree-hal-target-device=cuda)
+
+dispatches() { # <extra flags...> < in.mlir path is $DECODE
+  local out="$WORK/o.mlir"
+  if "$IREE_COMPILE" "${CUDA[@]}" "$@" --compile-to=flow "$DECODE" -o "$out" 2>"$WORK/e"; then
+    grep -c 'flow.dispatch' "$out"
+  else
+    echo "FAIL($(tail -1 "$WORK/e" | cut -c1-60))"
+  fi
+}
+
+echo ""
+echo "== packed decode: flow.dispatch under an iree-compile flag sweep =="
+printf "  %-16s %s\n" "baseline" "$(dispatches)"
+printf "  %-16s %s\n" "aggressive-fuse" "$(dispatches --iree-dispatch-creation-enable-aggressive-fusion)"
+printf "  %-16s %s\n" "generalize-mm" "$(dispatches --iree-opt-generalize-matmul)"
+printf "  %-16s %s\n" "early-trunc" "$(dispatches --iree-dispatch-creation-enable-early-trunc-fusion)"
+printf "  %-16s %s\n" "horiz-contract" "$(dispatches --iree-dispatch-creation-enable-fuse-horizontal-contractions)"
+printf "  %-16s %s\n" "fuse-multi-use" "$(dispatches --iree-dispatch-creation-fuse-multi-use)"
+printf "  %-16s %s\n" "data-tiling" "$(dispatches --iree-global-opt-data-tiling)"
+printf "  %-16s %s\n" "all-fusion" "$(dispatches --iree-dispatch-creation-enable-aggressive-fusion --iree-opt-generalize-matmul --iree-dispatch-creation-enable-early-trunc-fusion --iree-dispatch-creation-enable-fuse-horizontal-contractions --iree-dispatch-creation-fuse-multi-use)"
+
+micro() { # <name> <mlir file>
+  local out="$WORK/m.mlir"
+  if "$IREE_COMPILE" "${CUDA[@]}" --compile-to=flow "$2" -o "$out" 2>"$WORK/e"; then
+    printf "  %-22s %s dispatch(es)\n" "$1" "$(grep -c 'flow.dispatch' "$out")"
+  else
+    printf "  %-22s FAIL (%s)\n" "$1" "$(tail -1 "$WORK/e" | cut -c1-70)"
+  fi
+}
+
+cat > "$WORK/dq.mlir" <<'MLIR'
+func.func @dq_mm(%act: tensor<8192xf16>, %w: tensor<2048x1024xui32>, %scale: tensor<2048xf16>) -> tensor<2048xf32> {
+  %b = stablehlo.broadcast_in_dim %w, dims = [0, 1] : (tensor<2048x1024xui32>) -> tensor<2048x1024x8xui32>
+  %sh = stablehlo.constant dense<[0, 4, 8, 12, 16, 20, 24, 28]> : tensor<8xui32>
+  %shb = stablehlo.broadcast_in_dim %sh, dims = [2] : (tensor<8xui32>) -> tensor<2048x1024x8xui32>
+  %r = stablehlo.shift_right_logical %b, %shb : tensor<2048x1024x8xui32>
+  %mask = stablehlo.constant dense<15> : tensor<2048x1024x8xui32>
+  %a = stablehlo.and %r, %mask : tensor<2048x1024x8xui32>
+  %rs = stablehlo.reshape %a : (tensor<2048x1024x8xui32>) -> tensor<2048x8192xui32>
+  %f = stablehlo.convert %rs : (tensor<2048x8192xui32>) -> tensor<2048x8192xf16>
+  %sb = stablehlo.broadcast_in_dim %scale, dims = [0] : (tensor<2048xf16>) -> tensor<2048x8192xf16>
+  %w16 = stablehlo.multiply %f, %sb : tensor<2048x8192xf16>
+  %d = stablehlo.dot_general %act, %w16, contracting_dims = [0] x [1] : (tensor<8192xf16>, tensor<2048x8192xf16>) -> tensor<2048xf32>
+  return %d : tensor<2048xf32>
+}
+MLIR
+cat > "$WORK/f16.mlir" <<'MLIR'
+func.func @f16_mm(%act: tensor<8192xf16>, %w: tensor<2048x8192xf16>) -> tensor<2048xf32> {
+  %d = stablehlo.dot_general %act, %w, contracting_dims = [0] x [1] : (tensor<8192xf16>, tensor<2048x8192xf16>) -> tensor<2048xf32>
+  return %d : tensor<2048xf32>
+}
+MLIR
+cat > "$WORK/i8.mlir" <<'MLIR'
+func.func @i8_mm(%act: tensor<8192xi8>, %w: tensor<2048x8192xi8>) -> tensor<2048xi32> {
+  %d = stablehlo.dot_general %act, %w, contracting_dims = [0] x [1] : (tensor<8192xi8>, tensor<2048x8192xi8>) -> tensor<2048xi32>
+  return %d : tensor<2048xi32>
+}
+MLIR
+
+echo ""
+echo "== microtests: one matmul, dispatch count (2 = producer + matmul, not fused) =="
+micro "dequant -> matmul" "$WORK/dq.mlir"
+micro "bare f16 matmul" "$WORK/f16.mlir"
+micro "bare int8 matmul" "$WORK/i8.mlir"
+
+echo ""
+echo "int8 kernel arithmetic (upcast vs int8 tensor cores):"
+"$IREE_COMPILE" "${CUDA[@]}" --iree-hal-dump-executable-intermediates-to="$WORK/i8dump" "$WORK/i8.mlir" -o "$WORK/i8.vmfb" 2>/dev/null
+LL="$(ls "$WORK/i8dump"/*optimized.ll 2>/dev/null | head -1)"
+if [ -n "$LL" ]; then
+  echo "  sext i8->i32 (upcast): $(grep -c 'sext i8\|sext <' "$LL")   dp4a/mma.s8: $(grep -cE 'dp4a|mma.*s8' "$LL")"
+fi

--- a/src/lib/mlxcel-xla/README.md
+++ b/src/lib/mlxcel-xla/README.md
@@ -360,6 +360,47 @@ carries the whole packed ABI (emitter dequant, per-dtype weight upload, the
 standard Llama layout ([`Config::supports_packed_quant`]: non-fused-qkv,
 non-fused-gate-up, non-dense-MLP, non-MoE); embed / lm_head stay f32-resident.
 
+### int8 fusion spike (#573): in-tree vs upstream on GB10
+
+Following the fusion gate above, #573 measured whether any in-tree lever gets IREE's
+CUDA codegen to fuse the packed dequant into the matmul (so the reconstructed weight
+is not materialized to DRAM every decode step). The signal is the static decode
+dispatch count (`iree-compile --compile-to=flow`, count `flow.dispatch`); tok/s is
+end-to-end through the mlxcel binary. Reproduce with `scripts/xla/fusion_spike.sh`.
+
+| decode path | flow.dispatch | tok/s | note |
+|---|---|---|---|
+| packed, in-graph dequant (#568) | 678 | ~1.5 | weight reconstructed + materialized every step |
+| f16-resident (#572) | 454 | ~7.6 | no dequant; f16 weight stored directly |
+
+Findings (GB10, IREE 3.11.0rc @ e4a3b04):
+
+- **No iree-compile flag fuses it.** An 11-config flag sweep (aggressive-fusion,
+  generalize-matmul, early-trunc-fusion, horizontal-contractions, fuse-multi-use,
+  elementwise-multi-reduction, encoding-fusion, data-tiling x2, and all combined)
+  leaves the count at 677-678. Data-tiling is a no-op on CUDA: the encoding layout
+  resolvers exist only for the `hip` / `rocm` targets.
+- **The dequant is a separate dispatch.** A one-matmul microtest (int4 unpack +
+  scale then `dot_general`) is 2 dispatches (elementwise dequant producer + matmul)
+  and stays 2 under every fusion flag: IREE does not fuse an elementwise producer
+  into a matmul operand load on CUDA.
+- **`linalg.quantized_matmul` / ukernels are unavailable for CUDA.** The two IREE
+  facilities that would carry a fused quantized matmul (data-tiling encodings and
+  ukernels) are gated to `hip` / `rocm` / `llvm-cpu`, not the `cuda` target.
+- **int8 `dot_general` lowers, but without int8 tensor cores.** A bare `i8 x i8 ->
+  i32` matmul compiles to a single CUDA kernel (like the f16 one), but the codegen
+  upcasts `i8 -> i32` (17 `sext`, zero `dp4a` / `mma.*.s8`), so an int8 path would
+  not beat f16 here.
+
+**Split.** The graph-level dequant is necessary but the fused kernel is upstream
+IREE's job (a CUDA quantized-matmul codegen path / encoding resolver / ukernel that
+does not exist in 3.11.0). No in-tree representation or flag realizes it on CUDA. The
+realized low-precision bandwidth win today is **f16-resident weights (#572)**; the
+packed int8 path is a correctness-verified foundation but is dominated on CUDA until
+upstream fusion lands. #574 therefore ships the minimal in-tree packed representation
+(folding in the bf16 scales / biases limitation) and tracks the upstream fused
+quantized-matmul, rather than forcing an int8-beats-f16 win in-tree.
+
 ## File map
 
 | Path | Purpose |


### PR DESCRIPTION
## Summary

Part of #570. The #573 spike measures whether IREE's CUDA codegen can fuse the packed int4/int8 dequant into the matmul, so the reconstructed weight is not materialized to DRAM every decode step. Deliverable: a reproducible measurement harness (`scripts/xla/fusion_spike.sh`) and a findings section in the `mlxcel-xla` README.

## Method

The fusion signal is the static decode dispatch count: `iree-compile --compile-to=flow` on the real packed decode graph, counting `flow.dispatch`. tok/s is end-to-end through the mlxcel binary. `scripts/xla/fusion_spike.sh` reproduces the baseline, an 11-config flag sweep, and three one-matmul microtests (dequant then matmul, bare f16, bare int8).

## Findings (GB10, IREE 3.11.0rc @ e4a3b04, Llama-3.2-1B 4-bit)

| decode path | flow.dispatch | tok/s |
|---|---|---|
| packed, in-graph dequant (#568) | 678 | ~1.5 |
| f16-resident (#572) | 454 | ~7.6 |

- **No iree-compile flag fuses it.** The 11-config sweep (aggressive-fusion, generalize-matmul, early-trunc, horizontal-contractions, fuse-multi-use, elementwise-multi-reduction, encoding-fusion, data-tiling x2, all-combined) stays at 677-678. Data-tiling is a no-op on CUDA (encoding layout resolvers are hip/rocm-only).
- **The dequant is a separate dispatch.** The dequant-then-matmul microtest is 2 dispatches (elementwise producer + matmul) under every flag: IREE does not fuse an elementwise producer into a matmul operand load on CUDA.
- **`linalg.quantized_matmul` / ukernels are CUDA-unavailable.** Data-tiling encodings and ukernels, the facilities that carry a fused quantized matmul, are gated to hip/rocm/llvm-cpu, not cuda.
- **int8 `dot_general` lowers, but upcasts.** A bare `i8 x i8 -> i32` matmul compiles to one CUDA kernel (like f16), but the codegen upcasts i8 -> i32 (17 `sext`, zero `dp4a` / `mma.*.s8`): no int8 tensor cores, so int8 would not beat f16 here.

## Split and recommendation for #574

- **In-tree today**: f16-resident weights (#572, landed) is the realized bandwidth lever (token-exact, ~7.6 tok/s). The packed int8 path is a correctness foundation but is dominated on CUDA (678 dispatches, ~1.5 tok/s) until fusion exists.
- **Upstream IREE**: a fused dequant-to-matmul (or a hardware int8 tensor-core matmul) for the CUDA target, an IREE CUDA quantized-matmul codegen path / encoding resolver / ukernel that does not exist in 3.11.0.
- **#574** therefore takes the "ship the minimal in-tree representation + track upstream" branch the issue allows: keep the packed path behind `MLXCEL_XLA_QUANT=packed`, and fold in the bf16 scales/biases limitation (extend the packed emitter + loader to accept bf16 scales, matching #569's dequant-at-load broadening: the emitter declares the `.scales` / `.biases` args, currently f16, as bf16 when the checkpoint stores them bf16, and the loader uploads the raw bf16 bytes with a bf16 dtype code). It does not attempt an int8-beats-f16 fusion win in-tree (not achievable per the measurements above).

Closes #573
Part of #570
