### PR TITLE
feat(deepseek-v3.2 / glm-moe-dsa): implement the DSA lightning indexer

### DIFF
--- a/src/models/deepseek_v32.rs
+++ b/src/models/deepseek_v32.rs
@@ -18,16 +18,30 @@
 //! - MLA (Multi-head Latent Attention) with LoRA-style projections
 //! - Yarn RoPE for extended context (reuses from V2)
 //! - MoE with group expert selection
-//! - Indexer for sparse attention (deferred - using full attention fallback)
+//! - DeepSeek Sparse Attention (DSA) "lightning indexer": per layer, scores
+//!   every cached key against the query and attends only to the top-`index_topk`
+//!   positions (see [`indexer`]).
 //!
-//! Note: The Indexer for sparse attention is deferred. Full attention is used instead.
-//! This is similar to the blocksparse deferral in Phi3Small.
+//! Short-context parity: when the running `kv_len <= index_topk` the indexer
+//! returns no selection and attention reduces to the dense fallback, which is
+//! numerically identical to the pre-#509 behavior. The dense fallback can also
+//! be forced for A/B via the `MLXCEL_DSA_DENSE` environment variable.
 //!
-//! TODO: When implementing the Indexer, add the single-token fast path (L==1)
-//! optimization from upstream commit 7e67225: use take_along_axis to directly
-//! select relevant KV entries instead of creating sparse masks (~40% speedup).
+//! The single-token decode path (`L == 1`) gathers the selected KV entries
+//! directly with `take_along_axis` instead of materializing a per-step sparse
+//! mask; longer prefills build a sparse additive mask (mirrors upstream).
+//!
+//! Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/deepseek_v32.py
+
+#[path = "deepseek_v32_indexer.rs"]
+mod indexer;
+
+#[cfg(test)]
+#[path = "deepseek_v32_tests.rs"]
+mod deepseek_v32_tests;
 
 use crate::distributed::pipeline::{LayerFilter, StageExecutionOutput};
+use indexer::Indexer;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, MultiLinear, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils::{silu, slice_axis, stack_arrays};
@@ -81,6 +95,23 @@ pub struct ModelArgs {
 
     #[serde(default = "default_qk_nope_head_dim")]
     pub qk_nope_head_dim: usize,
+
+    // DeepSeek Sparse Attention (DSA) lightning indexer.
+    #[serde(default = "default_index_topk")]
+    pub index_topk: usize,
+
+    #[serde(default = "default_index_n_heads")]
+    pub index_n_heads: usize,
+
+    #[serde(default = "default_index_head_dim")]
+    pub index_head_dim: usize,
+
+    /// Indexer RoPE `traditional` flag. Per-model default: `false`
+    /// (non-interleaved) for deepseek_v32, `true` (interleaved) for
+    /// glm_moe_dsa. `#[serde(default)]` yields `false` for a raw
+    /// deepseek_v32 config; glm_moe_dsa supplies `true` explicitly.
+    #[serde(default)]
+    pub indexer_rope_interleave: bool,
 
     #[serde(default = "default_topk_method")]
     pub topk_method: String,
@@ -153,6 +184,15 @@ fn default_v_head_dim() -> usize {
     128
 }
 fn default_qk_nope_head_dim() -> usize {
+    128
+}
+pub(crate) fn default_index_topk() -> usize {
+    2048
+}
+pub(crate) fn default_index_n_heads() -> usize {
+    64
+}
+pub(crate) fn default_index_head_dim() -> usize {
     128
 }
 fn default_topk_method() -> String {
@@ -246,6 +286,11 @@ struct MLAAttention {
 
     o_proj: UnifiedLinear,
 
+    // DSA lightning indexer. `None` when the checkpoint carries no indexer
+    // weights or when forced dense via `MLXCEL_DSA_DENSE`; in that case the
+    // forward pass is byte-identical to the pre-#509 full-attention path.
+    indexer: Option<Indexer>,
+
     num_heads: i32,
     kv_lora_rank: i32,
     qk_nope_head_dim: i32,
@@ -267,10 +312,11 @@ impl MLAAttention {
         let b = shape[0];
         let l = shape[1];
 
-        // LoRA-style Q projection
-        let q = self.q_a_proj.forward(x);
-        let q = self.q_a_layernorm.forward(&q);
-        let q = self.q_b_proj.forward(&q);
+        // LoRA-style Q projection. `qr` (post-layernorm, pre-q_b_proj) is the
+        // LoRA-reduced query hidden the indexer also consumes.
+        let q_lora = self.q_a_proj.forward(x);
+        let qr = self.q_a_layernorm.forward(&q_lora);
+        let q = self.q_b_proj.forward(&qr);
         let q = mlxcel_core::reshape(&q, &[b, l, self.num_heads, self.q_head_dim]);
         let q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
 
@@ -308,11 +354,45 @@ impl MLAAttention {
             offset,
         );
 
+        // Indexer q/k/weights for the new tokens. The roped indexer key rides
+        // alongside `kv_latent` in the KV cache (concatenated on the feature
+        // axis) so a decode step can score against every cached position.
+        let indexer_new = self.indexer.as_ref().map(|idx| {
+            (
+                idx.keys(x, offset),
+                idx.queries(&qr, offset),
+                idx.weights(x),
+            )
+        });
+
         // Expand kv_latent for caching: [B, L, kv_lora_rank] → [B, 1, L, kv_lora_rank]
         let kv_latent = mlxcel_core::expand_dims(&kv_latent, 1);
 
-        // Cache stores (kv_latent, k_pe) for memory efficiency
-        let (kv_latent, k_pe) = cache.update_and_fetch(kv_latent, k_pe);
+        // Cache stores (kv_latent [+ indexer key], k_pe) for memory efficiency.
+        let cache_keys = match &indexer_new {
+            Some((idx_key, _, _)) => mlxcel_core::concatenate(&kv_latent, idx_key, -1),
+            None => kv_latent,
+        };
+        let (cache_keys, k_pe) = cache.update_and_fetch(cache_keys, k_pe);
+
+        // Slice the cached indexer key back off the shared buffer.
+        let (kv_latent, indexer_keys) = match &self.indexer {
+            Some(_) => {
+                let kvl = slice_axis(&cache_keys, -1, 0, self.kv_lora_rank);
+                let ik = slice_axis(&cache_keys, -1, self.kv_lora_rank, -1);
+                (kvl, Some(ik))
+            }
+            None => (cache_keys, None),
+        };
+
+        // Top-k key selection. `None` at short context (kv_len <= index_topk),
+        // in which case attention falls through to the dense path unchanged.
+        let topk_indices = match (&self.indexer, &indexer_new, &indexer_keys) {
+            (Some(idx), Some((_, idx_q, idx_w)), Some(idx_k)) => {
+                idx.top_indices(idx_q, idx_k, idx_w, mask)
+            }
+            _ => None,
+        };
 
         // Compute positional encoding scores: pe_scores = (q_pe * scale) @ k_pe.T
         let scale_scalar = mlxcel_core::full_f32(&[1], self.scale, mlxcel_core::array_dtype(&q_pe));
@@ -331,22 +411,62 @@ impl MLAAttention {
         let output = if l == 1 {
             // Decode: project Q into latent space, use kv_latent as K=V
             let q_projected = self.embed_q.forward(&q_nope);
-            let pe_mask_ptr = &*pe_scores as *const MlxArray;
-            let output = unsafe {
-                mlxcel_core::layers::attention_from_ptr(
-                    &q_projected,
+
+            if let Some(indices) = &topk_indices {
+                // Sparse decode fast path: gather the selected KV subset with
+                // take_along_axis (no per-step sparse mask). Decode is always
+                // called with `mask == None` here, and every gathered position
+                // is causally valid, so pe_scores is recomputed maskless over
+                // the gathered k_pe.
+                let (kv_latent_g, k_pe_g) = gather_topk_kv(
                     &kv_latent,
-                    &kv_latent,
-                    self.scale,
-                    pe_mask_ptr,
-                    0.0,
-                    0,
-                )
-            };
-            // Project output from latent space to v_head_dim
-            self.unembed_out.forward(&output)
+                    &k_pe,
+                    indices,
+                    self.kv_lora_rank,
+                    self.qk_rope_head_dim,
+                );
+                let k_pe_g_t = mlxcel_core::transpose_axes(&k_pe_g, &[0, 1, 3, 2]);
+                let pe_scores_g = mlxcel_core::matmul(&q_pe_scaled, &k_pe_g_t);
+                let pe_mask_ptr = &*pe_scores_g as *const MlxArray;
+                let output = unsafe {
+                    mlxcel_core::layers::attention_from_ptr(
+                        &q_projected,
+                        &kv_latent_g,
+                        &kv_latent_g,
+                        self.scale,
+                        pe_mask_ptr,
+                        0.0,
+                        0,
+                    )
+                };
+                self.unembed_out.forward(&output)
+            } else {
+                let pe_mask_ptr = &*pe_scores as *const MlxArray;
+                let output = unsafe {
+                    mlxcel_core::layers::attention_from_ptr(
+                        &q_projected,
+                        &kv_latent,
+                        &kv_latent,
+                        self.scale,
+                        pe_mask_ptr,
+                        0.0,
+                        0,
+                    )
+                };
+                // Project output from latent space to v_head_dim
+                self.unembed_out.forward(&output)
+            }
         } else {
-            // Prefill: project kv_latent to K and V
+            // Prefill: restrict pe_scores to the selected keys via a sparse
+            // additive mask (mirrors upstream's boolean sparse_mask & causal),
+            // then project kv_latent to K and V.
+            let pe_scores = match &topk_indices {
+                Some(indices) => {
+                    let kv_len = mlxcel_core::array_shape(&kv_latent)[2];
+                    apply_sparse_prefill_mask(&pe_scores, indices, kv_len)
+                }
+                None => pe_scores,
+            };
             let k = self.embed_q.forward_no_transpose(&kv_latent);
             let v = self.unembed_out.forward(&kv_latent);
             let pe_mask_ptr = &*pe_scores as *const MlxArray;
@@ -369,6 +489,61 @@ impl MLAAttention {
 
         self.o_proj.forward(&output)
     }
+}
+
+/// Gather the top-`index_topk` cached `kv_latent`/`k_pe` entries for the single
+/// decode query. `indices` is `[b, 1, 1, index_topk]`; the gathered tensors are
+/// `[b, 1, index_topk, feat]`. Used by the `L == 1` sparse-decode fast path.
+fn gather_topk_kv(
+    kv_latent: &MlxArray,
+    k_pe: &MlxArray,
+    indices: &MlxArray,
+    kv_lora_rank: i32,
+    qk_rope_head_dim: i32,
+) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
+    let ishape = mlxcel_core::array_shape(indices);
+    let b = ishape[0];
+    let topk = ishape[3];
+    // [b, 1, 1, topk] -> [b, 1, topk, 1] so the gather indexes the key axis (2).
+    let idx = slice_axis(indices, 2, 0, 1);
+    let idx = mlxcel_core::reshape(&idx, &[b, 1, topk, 1]);
+
+    let kv_idx = mlxcel_core::broadcast_to(&idx, &[b, 1, topk, kv_lora_rank]);
+    let kv_latent_g = mlxcel_core::take_along_axis(kv_latent, &kv_idx, 2);
+
+    let pe_idx = mlxcel_core::broadcast_to(&idx, &[b, 1, topk, qk_rope_head_dim]);
+    let k_pe_g = mlxcel_core::take_along_axis(k_pe, &pe_idx, 2);
+
+    (kv_latent_g, k_pe_g)
+}
+
+/// Build a sparse additive mask for the multi-token prefill path: positions not
+/// in the per-query top-k become `-inf`. `pe_scores` already carries the causal
+/// mask, so keeping it where selected reproduces upstream's `sparse_mask & mask`.
+///
+/// `indices` is `[b, 1, s, index_topk]`; `pe_scores` is `[b, n_heads, s, kv_len]`.
+fn apply_sparse_prefill_mask(
+    pe_scores: &MlxArray,
+    indices: &MlxArray,
+    kv_len: i32,
+) -> UniquePtr<MlxArray> {
+    let ishape = mlxcel_core::array_shape(indices);
+    let b = ishape[0];
+    let s = ishape[2];
+    let topk = ishape[3];
+
+    // Scatter 1.0 into the selected columns, then threshold to a bool keep-mask.
+    // FP32 scatter avoids relying on boolean put_along_axis semantics; the
+    // scatter values match the index shape so the binding needs no broadcast.
+    let base = mlxcel_core::zeros(&[b, 1, s, kv_len], mlxcel_core::dtype::FLOAT32);
+    let ones = mlxcel_core::ones(&[b, 1, s, topk], mlxcel_core::dtype::FLOAT32);
+    let filled = mlxcel_core::put_along_axis(&base, indices, &ones, -1);
+    let half = mlxcel_core::full_f32(&[1], 0.5, mlxcel_core::dtype::FLOAT32);
+    let keep = mlxcel_core::greater(&filled, &half);
+
+    let neg_inf =
+        mlxcel_core::full_f32(&[1], f32::NEG_INFINITY, mlxcel_core::array_dtype(pe_scores));
+    mlxcel_core::where_cond(&keep, pe_scores, &neg_inf)
 }
 
 // MLP (Dense and MoE - reusing from V2).
@@ -907,6 +1082,7 @@ fn load_mla_attention(
             group_size,
             bits,
         )?,
+        indexer: Indexer::load(weights, args, prefix)?,
         num_heads: args.num_attention_heads as i32,
         kv_lora_rank: args.kv_lora_rank as i32,
         qk_nope_head_dim: args.qk_nope_head_dim as i32,

--- a/src/models/deepseek_v32_indexer.rs
+++ b/src/models/deepseek_v32_indexer.rs
@@ -1,0 +1,239 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! DeepSeek Sparse Attention (DSA) "lightning indexer".
+//!
+//! Shared between `deepseek_v32` and `glm_moe_dsa`. Per decoder layer, the
+//! indexer scores every cached key against the current query and selects the
+//! top-`index_topk` positions the main MLA attention should attend to. When
+//! the running `kv_len` is at or below `index_topk`, selection is skipped and
+//! the caller falls back to dense attention (the trained model is numerically
+//! identical to dense at short context).
+//!
+//! Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/deepseek_v32.py (Indexer)
+//! Per-model `indexer_rope_interleave` default (traditional=false for
+//! deepseek_v32, true for glm_moe_dsa) landed in ml-explore/mlx-lm#1431.
+
+use mlxcel_core::layers::{LayerNorm, UnifiedLinear};
+use mlxcel_core::utils::slice_axis;
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+use super::ModelArgs;
+
+/// nn.LayerNorm default epsilon (mlx `nn.LayerNorm(dims, eps=1e-5)`).
+const LAYER_NORM_EPS: f32 = 1e-5;
+
+/// Environment variable that forces the dense full-attention fallback,
+/// disabling the indexer entirely for A/B comparison against the pre-#509
+/// behavior. When set (to any value) the indexer is not loaded.
+pub(super) const DENSE_FALLBACK_ENV: &str = "MLXCEL_DSA_DENSE";
+
+/// The DSA lightning indexer for one attention block.
+pub(super) struct Indexer {
+    wq_b: UnifiedLinear,
+    wk: UnifiedLinear,
+    k_norm: LayerNorm,
+    weights_proj: UnifiedLinear,
+    n_heads: i32,
+    head_dim: i32,
+    rope_head_dim: i32,
+    index_topk: i32,
+    softmax_scale: f32,
+    rope_base: f32,
+    /// `traditional` flag threaded into the indexer RoPE. This is the
+    /// per-model `indexer_rope_interleave` value: `false` (non-interleaved)
+    /// for deepseek_v32, `true` (interleaved) for glm_moe_dsa. Getting it
+    /// wrong silently corrupts key selection with no crash.
+    pub(super) rope_traditional: bool,
+}
+
+impl Indexer {
+    /// Load the indexer for `{attn_prefix}.indexer.*`. Returns `Ok(None)` when
+    /// the checkpoint carries no indexer weights (so the dense fallback is
+    /// preserved) or when [`DENSE_FALLBACK_ENV`] is set.
+    pub(super) fn load(
+        weights: &WeightMap,
+        args: &ModelArgs,
+        attn_prefix: &str,
+    ) -> Result<Option<Self>, String> {
+        let prefix = format!("{}.indexer", attn_prefix);
+        let wk_key = format!("{}.wk.weight", prefix);
+        if !weights.contains_key(&wk_key) {
+            return Ok(None);
+        }
+        if std::env::var_os(DENSE_FALLBACK_ENV).is_some() {
+            return Ok(None);
+        }
+
+        let group_size = args.group_size();
+        let bits = args.bits();
+
+        let wq_b =
+            UnifiedLinear::from_weights(weights, &format!("{}.wq_b", prefix), group_size, bits)?;
+        let wk = UnifiedLinear::from_weights(weights, &format!("{}.wk", prefix), group_size, bits)?;
+        let weights_proj = UnifiedLinear::from_weights(
+            weights,
+            &format!("{}.weights_proj", prefix),
+            group_size,
+            bits,
+        )?;
+
+        let k_norm_weight = super::get_weight_copy(weights, &format!("{}.k_norm.weight", prefix))?;
+        let k_norm_bias = weights
+            .get(&format!("{}.k_norm.bias", prefix))
+            .map(|w| mlxcel_core::copy(w));
+        let k_norm = LayerNorm::new(k_norm_weight, k_norm_bias, LAYER_NORM_EPS);
+
+        let head_dim = args.index_head_dim as i32;
+        Ok(Some(Self {
+            wq_b,
+            wk,
+            k_norm,
+            weights_proj,
+            n_heads: args.index_n_heads as i32,
+            head_dim,
+            rope_head_dim: args.qk_rope_head_dim as i32,
+            index_topk: args.index_topk as i32,
+            softmax_scale: (head_dim as f32).powf(-0.5),
+            rope_base: args.rope_theta,
+            rope_traditional: args.indexer_rope_interleave,
+        }))
+    }
+
+    /// Indexer key for the new tokens: `rope(reshape(k_norm(wk(x))))`.
+    /// Shape `[b, 1, s, index_head_dim]`. RoPE is applied over the first
+    /// `qk_rope_head_dim` dims with the running cache `offset`. This is what
+    /// gets cached (concatenated onto `kv_latent`).
+    pub(super) fn keys(&self, x: &MlxArray, offset: i32) -> UniquePtr<MlxArray> {
+        let shape = mlxcel_core::array_shape(x);
+        let b = shape[0];
+        let s = shape[1];
+        let k = self.wk.forward(x);
+        let k = self.k_norm.forward(&k);
+        let k = mlxcel_core::reshape(&k, &[b, 1, s, self.head_dim]);
+        mlxcel_core::fast_rope(
+            &k,
+            self.rope_head_dim,
+            self.rope_traditional,
+            self.rope_base,
+            1.0,
+            offset,
+        )
+    }
+
+    /// Indexer query: `rope(reshape(wq_b(qr)))`, where `qr` is the LoRA-reduced
+    /// query hidden `q_a_layernorm(q_a_proj(x))`. Shape
+    /// `[b, index_n_heads, s, index_head_dim]`.
+    pub(super) fn queries(&self, qr: &MlxArray, offset: i32) -> UniquePtr<MlxArray> {
+        let shape = mlxcel_core::array_shape(qr);
+        let b = shape[0];
+        let s = shape[1];
+        let q = self.wq_b.forward(qr);
+        let q = mlxcel_core::reshape(&q, &[b, s, self.n_heads, self.head_dim]);
+        let q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
+        mlxcel_core::fast_rope(
+            &q,
+            self.rope_head_dim,
+            self.rope_traditional,
+            self.rope_base,
+            1.0,
+            offset,
+        )
+    }
+
+    /// Raw per-head combination weights `weights_proj(x)`, shape `[b, s, n_heads]`.
+    /// The `n_heads**-0.5 * head_dim**-0.5` scaling is applied inside
+    /// [`indexer_top_indices`].
+    pub(super) fn weights(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        self.weights_proj.forward(x)
+    }
+
+    /// Select the top-`index_topk` key positions for each query. Returns `None`
+    /// when `kv_len <= index_topk` (dense fallback). `q`/`k`/`weights` come from
+    /// [`Self::queries`], the cache-fetched indexer keys, and [`Self::weights`].
+    pub(super) fn top_indices(
+        &self,
+        q: &MlxArray,
+        k: &MlxArray,
+        weights: &MlxArray,
+        mask: Option<&MlxArray>,
+    ) -> Option<UniquePtr<MlxArray>> {
+        indexer_top_indices(
+            q,
+            k,
+            weights,
+            mask,
+            self.n_heads,
+            self.softmax_scale,
+            self.index_topk,
+        )
+    }
+}
+
+/// Pure top-k index selection, factored out for unit testing.
+///
+/// Mirrors upstream `Indexer.__call__` scoring exactly:
+/// `scores = relu(q @ k^T)`, per-head `weights * (n_heads**-0.5 * softmax_scale)`,
+/// combine over heads, apply the (additive) causal `mask`, then
+/// `argpartition(..., kth=kv_len - index_topk)[..., -index_topk:]`.
+///
+/// - `q`: `[b, n_heads, s, head_dim]`
+/// - `k`: `[b, 1, kv_len, head_dim]`
+/// - `weights`: `[b, s, n_heads]` (raw `weights_proj` output, unscaled)
+/// - `mask`: optional additive mask broadcastable to `[b, 1, s, kv_len]`
+///   (0 to keep, `-inf` to drop)
+///
+/// Returns `None` when `kv_len <= index_topk`; otherwise `[b, 1, s, index_topk]`.
+pub(super) fn indexer_top_indices(
+    q: &MlxArray,
+    k: &MlxArray,
+    weights: &MlxArray,
+    mask: Option<&MlxArray>,
+    n_heads: i32,
+    softmax_scale: f32,
+    index_topk: i32,
+) -> Option<UniquePtr<MlxArray>> {
+    let kv_len = mlxcel_core::array_shape(k)[2];
+    if kv_len <= index_topk {
+        return None;
+    }
+
+    // scores = relu(q @ k^T) -> [b, n_heads, s, kv_len] (heads broadcast over k).
+    let k_t = mlxcel_core::transpose_axes(k, &[0, 1, 3, 2]);
+    let scores = mlxcel_core::matmul(q, &k_t);
+    let scores = mlxcel_core::relu(&scores);
+
+    // w = weights * (n_heads**-0.5 * softmax_scale), reshaped to [b, n_heads, s, 1].
+    let w_scale = (n_heads as f32).powf(-0.5) * softmax_scale;
+    let w_scale = mlxcel_core::full_f32(&[1], w_scale, mlxcel_core::array_dtype(weights));
+    let w = mlxcel_core::multiply(weights, &w_scale);
+    let w = mlxcel_core::transpose_axes(&w, &[0, 2, 1]);
+    let w = mlxcel_core::expand_dims(&w, -1);
+
+    // Combine over heads: [b, 1, s, kv_len].
+    let scores = mlxcel_core::multiply(&scores, &w);
+    let scores = mlxcel_core::sum_axis(&scores, 1, true);
+
+    // Apply the additive causal mask (adds -inf to disallowed positions).
+    let scores = match mask {
+        Some(m) => mlxcel_core::add(&scores, m),
+        None => scores,
+    };
+
+    // Top-`index_topk` largest along the key axis.
+    let kth = kv_len - index_topk;
+    let part = mlxcel_core::argpartition(&scores, kth, -1);
+    Some(slice_axis(&part, -1, kth, kv_len))
+}

--- a/src/models/deepseek_v32_tests.rs
+++ b/src/models/deepseek_v32_tests.rs
@@ -1,0 +1,221 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the DeepSeek Sparse Attention (DSA) lightning indexer.
+
+use super::ModelArgs;
+use super::indexer::{Indexer, indexer_top_indices};
+use mlxcel_core::weights::WeightMap;
+use mlxcel_core::{MlxArray, UniquePtr};
+
+/// Minimal deepseek_v32 config that exercises the indexer with tiny dims.
+/// Everything not listed falls back to the serde default, so
+/// `indexer_rope_interleave` is `false` here (the deepseek_v32 default).
+fn tiny_deepseek_config() -> ModelArgs {
+    let json = r#"{
+        "model_type": "deepseek_v32",
+        "vocab_size": 16,
+        "hidden_size": 6,
+        "intermediate_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "q_lora_rank": 8,
+        "qk_rope_head_dim": 2,
+        "index_topk": 2,
+        "index_n_heads": 2,
+        "index_head_dim": 4
+    }"#;
+    serde_json::from_str(json).expect("parse tiny deepseek config")
+}
+
+fn f32_weight(shape: &[i32]) -> UniquePtr<MlxArray> {
+    let n: i32 = shape.iter().product();
+    let data: Vec<f32> = (0..n).map(|i| 0.01 * (i as f32 + 1.0)).collect();
+    mlxcel_core::from_slice_f32(&data, shape)
+}
+
+/// Build synthetic (non-quantized) indexer weights for `{attn_prefix}.indexer.*`.
+fn synthetic_indexer_weights(args: &ModelArgs, attn_prefix: &str) -> WeightMap {
+    let hidden = args.hidden_size as i32;
+    let q_lora = args.q_lora_rank as i32;
+    let n_heads = args.index_n_heads as i32;
+    let head_dim = args.index_head_dim as i32;
+
+    let mut weights: WeightMap = WeightMap::new();
+    let prefix = format!("{}.indexer", attn_prefix);
+    // Linear weights are stored [out, in].
+    weights.insert(
+        format!("{}.wk.weight", prefix),
+        f32_weight(&[head_dim, hidden]),
+    );
+    weights.insert(
+        format!("{}.wq_b.weight", prefix),
+        f32_weight(&[n_heads * head_dim, q_lora]),
+    );
+    weights.insert(
+        format!("{}.weights_proj.weight", prefix),
+        f32_weight(&[n_heads, hidden]),
+    );
+    weights.insert(format!("{}.k_norm.weight", prefix), f32_weight(&[head_dim]));
+    weights.insert(format!("{}.k_norm.bias", prefix), f32_weight(&[head_dim]));
+    weights
+}
+
+fn index_values(indices: &MlxArray, count: i32) -> Vec<i32> {
+    let f = mlxcel_core::astype(indices, mlxcel_core::dtype::FLOAT32);
+    (0..count)
+        .map(|i| {
+            let elem = mlxcel_core::slice(&f, &[0, 0, 0, i], &[1, 1, 1, i + 1]);
+            mlxcel_core::item_f32(&elem).round() as i32
+        })
+        .collect()
+}
+
+#[test]
+fn deepseek_v32_indexer_rope_defaults_to_non_interleaved() {
+    // deepseek_v32: indexer RoPE is non-interleaved (traditional = false).
+    let args = tiny_deepseek_config();
+    assert!(
+        !args.indexer_rope_interleave,
+        "deepseek_v32 default indexer_rope_interleave must be false"
+    );
+}
+
+#[test]
+fn deepseek_v32_indexer_config_defaults() {
+    // Absent explicit index_* fields, the indexer defaults match upstream.
+    let json = r#"{
+        "model_type": "deepseek_v32",
+        "vocab_size": 16,
+        "hidden_size": 6,
+        "intermediate_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2
+    }"#;
+    let args: ModelArgs = serde_json::from_str(json).expect("parse defaults config");
+    assert_eq!(args.index_topk, 2048);
+    assert_eq!(args.index_n_heads, 64);
+    assert_eq!(args.index_head_dim, 128);
+    assert!(!args.indexer_rope_interleave);
+}
+
+#[test]
+fn indexer_load_threads_rope_flag_per_model() {
+    // The RoPE `traditional` flag must be threaded from config into the loaded
+    // Indexer: false for deepseek_v32, true for the glm_moe_dsa mapping. Wrong
+    // value silently corrupts key selection, so pin it directly on the module.
+    let _runtime = crate::initialize_runtime();
+
+    let mut args = tiny_deepseek_config();
+    let weights = synthetic_indexer_weights(&args, "block.self_attn");
+
+    let ds = Indexer::load(&weights, &args, "block.self_attn")
+        .expect("load ok")
+        .expect("indexer present");
+    assert!(
+        !ds.rope_traditional,
+        "deepseek_v32 indexer must be non-interleaved"
+    );
+
+    // Same weights, glm-style interleave flag.
+    args.indexer_rope_interleave = true;
+    let glm = Indexer::load(&weights, &args, "block.self_attn")
+        .expect("load ok")
+        .expect("indexer present");
+    assert!(
+        glm.rope_traditional,
+        "glm_moe_dsa indexer must be interleaved"
+    );
+}
+
+#[test]
+fn indexer_load_absent_weights_is_dense_fallback() {
+    // No indexer weights in the checkpoint -> dense fallback (Ok(None)), which
+    // keeps the pre-#509 full-attention behavior for such models.
+    let _runtime = crate::initialize_runtime();
+    let args = tiny_deepseek_config();
+    let empty: WeightMap = WeightMap::new();
+    let loaded = Indexer::load(&empty, &args, "block.self_attn").expect("load ok");
+    assert!(loaded.is_none(), "absent indexer weights must yield None");
+}
+
+#[test]
+fn indexer_top_indices_none_at_short_context() {
+    // Short-context parity: when kv_len <= index_topk the indexer selects
+    // nothing and the caller reduces to dense attention (bit-for-bit with the
+    // pre-#509 full-attention path).
+    let _runtime = crate::initialize_runtime();
+
+    // b=1, n_heads=1, s=1, head_dim=2, kv_len=3, index_topk=8.
+    let q = mlxcel_core::from_slice_f32(&[1.0, 0.0], &[1, 1, 1, 2]);
+    let k = mlxcel_core::from_slice_f32(&[1.0, 0.0, 5.0, 0.0, 2.0, 0.0], &[1, 1, 3, 2]);
+    let w = mlxcel_core::from_slice_f32(&[1.0], &[1, 1, 1]);
+
+    let out = indexer_top_indices(&q, &k, &w, None, 1, 2.0_f32.powf(-0.5), 8);
+    assert!(out.is_none(), "kv_len <= index_topk must return None");
+}
+
+#[test]
+fn indexer_top_indices_selects_highest_scoring_keys() {
+    // Constructed long-context case: with q=[1,0] the score of key j reduces to
+    // relu(k_j[0]); n_heads=1 and a positive weight preserve that ordering.
+    // Keys' first component: [1, 5, 2, 4, 3] -> the two largest are at
+    // positions 1 (=5) and 3 (=4). Pin that the top-2 index set is {1, 3}.
+    let _runtime = crate::initialize_runtime();
+
+    let q = mlxcel_core::from_slice_f32(&[1.0, 0.0], &[1, 1, 1, 2]);
+    let k = mlxcel_core::from_slice_f32(
+        &[1.0, 0.0, 5.0, 0.0, 2.0, 0.0, 4.0, 0.0, 3.0, 0.0],
+        &[1, 1, 5, 2],
+    );
+    let w = mlxcel_core::from_slice_f32(&[1.0], &[1, 1, 1]);
+
+    let indices = indexer_top_indices(&q, &k, &w, None, 1, 2.0_f32.powf(-0.5), 2)
+        .expect("kv_len > index_topk selects top-k");
+    let shape = mlxcel_core::array_shape(&indices);
+    assert_eq!(shape, vec![1, 1, 1, 2], "top-k indices shape [b,1,s,topk]");
+
+    let mut got = index_values(&indices, 2);
+    got.sort_unstable();
+    assert_eq!(got, vec![1, 3], "top-2 keys must be positions 1 and 3");
+}
+
+#[test]
+fn indexer_top_indices_respects_causal_mask() {
+    // The additive causal mask must push masked positions out of the top-k.
+    // Same key ordering as above, but mask out position 1 (the top score) with
+    // -inf; the top-2 set then becomes {3, 4} (values 4 and 3).
+    let _runtime = crate::initialize_runtime();
+
+    let q = mlxcel_core::from_slice_f32(&[1.0, 0.0], &[1, 1, 1, 2]);
+    let k = mlxcel_core::from_slice_f32(
+        &[1.0, 0.0, 5.0, 0.0, 2.0, 0.0, 4.0, 0.0, 3.0, 0.0],
+        &[1, 1, 5, 2],
+    );
+    let w = mlxcel_core::from_slice_f32(&[1.0], &[1, 1, 1]);
+    let neg_inf = f32::NEG_INFINITY;
+    let mask = mlxcel_core::from_slice_f32(&[0.0, neg_inf, 0.0, 0.0, 0.0], &[1, 1, 1, 5]);
+
+    let indices = indexer_top_indices(&q, &k, &w, Some(&mask), 1, 2.0_f32.powf(-0.5), 2)
+        .expect("kv_len > index_topk selects top-k");
+    let mut got = index_values(&indices, 2);
+    got.sort_unstable();
+    assert_eq!(
+        got,
+        vec![3, 4],
+        "masking position 1 shifts top-2 to {{3,4}}"
+    );
+}

--- a/src/models/glm_moe_dsa.rs
+++ b/src/models/glm_moe_dsa.rs
@@ -95,13 +95,19 @@ pub struct ModelArgs {
     #[serde(default = "default_rope_theta")]
     pub rope_theta: f32,
 
-    // GLM-specific fields (unused by DSV32 but present in config)
+    // DSA lightning indexer config. GLM MoE DSA parses these directly; they
+    // are threaded into the DeepSeek V3.2 attention via `to_dsv32_args`.
     #[serde(default)]
     pub index_head_dim: Option<usize>,
     #[serde(default)]
     pub index_n_heads: Option<usize>,
     #[serde(default)]
     pub index_topk: Option<usize>,
+
+    /// Indexer RoPE `traditional` flag. Defaults to `true` (interleaved) for
+    /// glm_moe_dsa, unlike deepseek_v32 which defaults to `false`.
+    #[serde(default = "default_indexer_rope_interleave")]
+    pub indexer_rope_interleave: bool,
 }
 
 fn default_routed_scaling_factor() -> f32 {
@@ -152,6 +158,9 @@ fn default_rms_norm_eps() -> f32 {
 fn default_rope_theta() -> f32 {
     10000.0
 }
+fn default_indexer_rope_interleave() -> bool {
+    true
+}
 
 impl ModelArgs {
     /// Convert GLM MoE DSA config to DeepSeek V3.2 config.
@@ -201,6 +210,16 @@ impl ModelArgs {
             qk_rope_head_dim: self.qk_rope_head_dim,
             v_head_dim: self.v_head_dim,
             qk_nope_head_dim: self.qk_nope_head_dim,
+            index_topk: self
+                .index_topk
+                .unwrap_or_else(deepseek_v32::default_index_topk),
+            index_n_heads: self
+                .index_n_heads
+                .unwrap_or_else(deepseek_v32::default_index_n_heads),
+            index_head_dim: self
+                .index_head_dim
+                .unwrap_or_else(deepseek_v32::default_index_head_dim),
+            indexer_rope_interleave: self.indexer_rope_interleave,
             topk_method: self.topk_method.clone(),
             scoring_func: self.scoring_func.clone(),
             norm_topk_prob: self.norm_topk_prob,
@@ -314,6 +333,7 @@ mod tests {
             index_head_dim: None,
             index_n_heads: None,
             index_topk: None,
+            indexer_rope_interleave: default_indexer_rope_interleave(),
         }
     }
 
@@ -359,5 +379,45 @@ mod tests {
         assert_eq!(rope_scaling.scaling_type.as_deref(), Some("linear"));
         assert_eq!(rope_scaling.factor, Some(8.0));
         assert_eq!(rope_scaling.mscale_all_dim, None);
+    }
+
+    #[test]
+    fn glm_moe_dsa_indexer_rope_is_interleaved_by_default() {
+        // glm_moe_dsa must default the indexer RoPE to interleaved
+        // (traditional = true), the opposite of deepseek_v32's false. This is
+        // load-bearing: the wrong value silently corrupts key selection.
+        let args = sample_args();
+        assert!(
+            args.indexer_rope_interleave,
+            "glm_moe_dsa default indexer_rope_interleave must be true"
+        );
+        assert!(
+            args.to_dsv32_args().indexer_rope_interleave,
+            "interleave flag must be threaded into the DeepSeek V3.2 args"
+        );
+    }
+
+    #[test]
+    fn glm_moe_dsa_indexer_config_defaults_thread_through() {
+        // Absent explicit index_* fields, the DeepSeek V3.2 indexer defaults
+        // (topk 2048, 64 heads, head_dim 128) must be supplied.
+        let mapped = sample_args().to_dsv32_args();
+        assert_eq!(mapped.index_topk, 2048);
+        assert_eq!(mapped.index_n_heads, 64);
+        assert_eq!(mapped.index_head_dim, 128);
+    }
+
+    #[test]
+    fn glm_moe_dsa_indexer_config_overrides_are_respected() {
+        let mut args = sample_args();
+        args.index_topk = Some(4096);
+        args.index_n_heads = Some(32);
+        args.index_head_dim = Some(96);
+        args.indexer_rope_interleave = false;
+        let mapped = args.to_dsv32_args();
+        assert_eq!(mapped.index_topk, 4096);
+        assert_eq!(mapped.index_n_heads, 32);
+        assert_eq!(mapped.index_head_dim, 96);
+        assert!(!mapped.indexer_rope_interleave);
     }
 }


### PR DESCRIPTION
## Summary

Replaces the full-attention fallback in `deepseek_v32` (DeepSeek V3.2) and `glm_moe_dsa` with the DeepSeek Sparse Attention (DSA) "lightning indexer" these architectures were trained for, so the models attend to the top-k most relevant KV entries per query and restore long-context fidelity.

## Changes

- Shared indexer module (`src/models/deepseek_v32_indexer.rs`): the `wq_b` / `wk` / `k_norm` / `weights_proj` projections, `relu(q @ k^T)` scoring combined with the per-head `weights_proj` scale, causal masking, and top-`index_topk` key selection via gather.
- Per-model `indexer_rope_interleave` flag threaded into the indexer RoPE, with the correct per-model default: non-interleaved (`false`) for `deepseek_v32`, interleaved (`true`) for `glm_moe_dsa`. Getting this wrong silently corrupts key selection, so it is covered by explicit tests.
- Config plumbing: `index_topk` / `index_n_heads` / `index_head_dim` / `indexer_rope_interleave` added to `deepseek_v32` (glm already parsed `index_*`), and the `wq_b` / `wk` / `k_norm` / `weights_proj` indexer weights are loaded. `glm_moe_dsa`'s previously-unused `index_*` fields are now wired.
- When `kv_len <= index_topk` the indexer reduces to the dense path (short context stays numerically equivalent to the previous fallback), and the `L==1` decode path gathers the selected keys instead of materializing a per-step sparse mask.

## Correctness (covered by unit tests)

- `deepseek_v32_indexer_rope_defaults_to_non_interleaved` and `glm_moe_dsa_indexer_rope_is_interleaved_by_default`: the per-model RoPE interleave default is correct.
- `indexer_load_threads_rope_flag_per_model`, `glm_moe_dsa_falls_back_to_direct_rope_fields`, `glm_moe_dsa_prefers_rope_parameters_over_direct_fields`, `..._config_overrides_are_respected`, `..._config_defaults_thread_through`.
- `indexer_load_absent_weights_is_dense_fallback` and `indexer_top_indices_none_at_short_context`: reduces to dense when weights are absent or when `kv_len <= index_topk`.
- `indexer_top_indices_selects_highest_scoring_keys` and `indexer_top_indices_respects_causal_mask`: top-k selection is correct and causal.

## Validation

- `cargo check --lib --tests --features metal,accelerate`: compiles clean.
- `cargo test --release --features metal,accelerate deepseek_v32`: 7 pass. `... glm_moe_dsa`: 5 pass. Total 12 indexer unit tests pass on Apple Silicon Metal.
- Not run here: generation on a real DeepSeek-V3.2 or GLM-MoE-DSA checkpoint at context length greater than `index_topk`. Those real-model parity tests are gated `ignored` (they require local model weights and, for the pipeline variants, TCP-bound remote stages), and no such checkpoint is present in this environment. Long-context behavior is validated at the indexer scoring / top-k selection / dense-reduction level, not real-model generation, and should be confirmed on a real checkpoint before relying on it in production.

Closes #509
