### PR TITLE
fix(qwen3-next): make real checkpoints load and run (MoE naming, gated-delta slice, mask, stateful decode)

### DIFF
--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -38,6 +38,7 @@ use crate::distributed::pipeline::partial_loading::filter_weight_map;
 use crate::models::gated_delta::{
     GatedDeltaCache, RMSNormGated, gated_delta_update, scaled_fast_rms_norm_no_weight,
 };
+use crate::models::model_owned::ModelOwnedSequenceState;
 use mlxcel_core::dtype;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
@@ -1136,9 +1137,17 @@ impl SwitchGLU {
         prefix: &str,
     ) -> Result<Self, String> {
         Ok(Self {
-            gate_proj: SwitchLinear::from_weights(weights, config, &format!("{}.w1", prefix))?,
-            up_proj: SwitchLinear::from_weights(weights, config, &format!("{}.w3", prefix))?,
-            down_proj: SwitchLinear::from_weights(weights, config, &format!("{}.w2", prefix))?,
+            gate_proj: SwitchLinear::from_weights(
+                weights,
+                config,
+                &format!("{}.gate_proj", prefix),
+            )?,
+            up_proj: SwitchLinear::from_weights(weights, config, &format!("{}.up_proj", prefix))?,
+            down_proj: SwitchLinear::from_weights(
+                weights,
+                config,
+                &format!("{}.down_proj", prefix),
+            )?,
         })
     }
 }
@@ -1301,10 +1310,17 @@ impl DecoderLayer {
         let normed = self.input_layernorm.forward(x);
 
         let r = match (&self.attention, cache) {
+            // Linear (gated-delta) layers must NOT receive the full-attention causal
+            // mask: their causality comes from the sequential recurrence and the
+            // causal conv, and the gated-delta path treats `mask` as a [b, s] padding
+            // mask. Passing the [s, s] causal mask makes `where_cond` broadcast the
+            // conv input to [s, s, conv_dim] and crashes the conv-state concatenate.
+            // Single-sequence generation has no padding, so None is correct (this
+            // mirrors the pipeline stage executor, which ignores the incoming mask).
             (AttentionVariant::LinearAttention(attn), Qwen3NextCache::Linear(c)) => {
-                attn.forward(&normed, mask, Some(c))
+                attn.forward(&normed, None, Some(c))
             }
-            (AttentionVariant::LinearAttention(attn), _) => attn.forward(&normed, mask, None),
+            (AttentionVariant::LinearAttention(attn), _) => attn.forward(&normed, None, None),
             (AttentionVariant::FullAttention(attn), Qwen3NextCache::Attention(c)) => {
                 attn.forward(&normed, c, mask)
             }
@@ -1384,6 +1400,11 @@ pub struct Qwen3NextModel {
     pub lm_head: Option<UnifiedLinear>,
     pub tie_word_embeddings: bool,
     pub full_attention_interval: usize,
+    // qwen3-next interleaves attention (KVCache) and linear (GatedDeltaCache)
+    // layers, so it cannot use the trait's homogeneous `&mut [KVCache]`. The
+    // model owns its heterogeneous cache here and persists it across forward
+    // calls; recreating it per call would make decode stateless.
+    sequence_state: ModelOwnedSequenceState<Qwen3NextCache>,
 }
 
 impl Qwen3NextModel {
@@ -1474,7 +1495,7 @@ impl Qwen3NextModel {
             }
 
             let base = format!("model.layers.{}.mlp.switch_mlp", l);
-            for proj in ["w1", "w2", "w3"] {
+            for proj in ["gate_proj", "up_proj", "down_proj"] {
                 let mut expert_weights: Vec<UniquePtr<MlxArray>> = Vec::new();
                 let mut expert_scales: Vec<UniquePtr<MlxArray>> = Vec::new();
                 let mut expert_biases: Vec<UniquePtr<MlxArray>> = Vec::new();
@@ -1546,6 +1567,17 @@ impl Qwen3NextModel {
             )?)
         };
 
+        let internal_caches: Vec<Qwen3NextCache> = layers
+            .iter()
+            .map(|l| {
+                if l.is_linear {
+                    Qwen3NextCache::Linear(GatedDeltaCache::new())
+                } else {
+                    Qwen3NextCache::Attention(KVCache::new())
+                }
+            })
+            .collect();
+
         Ok(Self {
             embed_tokens,
             layers,
@@ -1553,7 +1585,21 @@ impl Qwen3NextModel {
             lm_head,
             tie_word_embeddings: config.tie_word_embeddings,
             full_attention_interval: config.full_attention_interval,
+            sequence_state: ModelOwnedSequenceState::new(internal_caches),
         })
+    }
+
+    fn make_internal_caches(&self) -> Vec<Qwen3NextCache> {
+        self.layers
+            .iter()
+            .map(|l| {
+                if l.is_linear {
+                    Qwen3NextCache::Linear(GatedDeltaCache::new())
+                } else {
+                    Qwen3NextCache::Attention(KVCache::new())
+                }
+            })
+            .collect()
     }
 }
 
@@ -1565,25 +1611,35 @@ impl LanguageModel for Qwen3NextModel {
         _caches: &mut [KVCache],
         _mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
-        // Note: Qwen3Next uses mixed cache types (KVCache + GatedDeltaCache)
-        // For LanguageModel trait compatibility, we use internal caching
-        let mut caches = self.make_caches();
-        let mask = {
-            let shape = mlxcel_core::array_shape(input);
-            let seq_len = shape[1];
-            if seq_len > 1 {
+        // Qwen3Next uses mixed cache types (KVCache + GatedDeltaCache) that do
+        // not fit the trait's `&mut [KVCache]`. The model owns its heterogeneous
+        // cache in `sequence_state` and must persist it across forward calls:
+        // recreating fresh caches every call makes decode stateless (each step
+        // sees only the current token) and produces incoherent output.
+        let seq_len = mlxcel_core::array_shape(input)[1];
+        // A multi-token call is a prefill, i.e. the start of a new sequence:
+        // reset the model-owned fallback cache so it does not inherit stale state.
+        if seq_len > 1 {
+            self.sequence_state
+                .replace_internal(self.make_internal_caches());
+        }
+        self.sequence_state.with_sequence_state(None, |caches| {
+            let mask = if seq_len > 1 {
                 let fa_idx = self.full_attention_interval - 1;
-                let offset = if fa_idx < caches.len() {
-                    caches[fa_idx].offset()
-                } else {
-                    0
-                };
+                let offset = caches.get(fa_idx).map(|c| c.offset()).unwrap_or(0);
                 Some(create_causal_mask(seq_len, offset))
             } else {
                 None
-            }
-        };
-        self.forward(input, &mut caches, mask.as_deref())
+            };
+            self.forward(input, caches, mask.as_deref())
+        })
+    }
+
+    fn reset_runtime_state(&self) {
+        // New CLI / benchmark sequence: reset the model-owned fallback cache so a
+        // fresh generation does not inherit stale attention / gated-delta state.
+        self.sequence_state
+            .replace_internal(self.make_internal_caches());
     }
 
     fn make_caches(&self) -> Vec<KVCache> {

--- a/src/models/qwen3_next_helpers.rs
+++ b/src/models/qwen3_next_helpers.rs
@@ -59,9 +59,13 @@ pub(super) fn build_projection_layout(
         q_range: (0, dn),
         k_range: (dn, 2 * dn),
         v_range: (2 * dn, 2 * dn + v_size),
-        z_range: (2 * dn + v_size, -1),
+        // z has the same width as v. Do NOT use -1 as the stop: mlxcel_core::slice
+        // treats stop = -1 as dim_size - 1 (drops the last element), not "to end",
+        // which would silently truncate z (and a) by one column.
+        z_range: (2 * dn + v_size, 2 * dn + 2 * v_size),
         b_range: (0, b_size),
-        a_range: (b_size, -1),
+        // a has the same width as b; explicit stop for the same slice-semantics reason.
+        a_range: (b_size, 2 * b_size),
         v_shape,
         ba_final_shape,
     }

--- a/src/models/qwen3_next_helpers_tests.rs
+++ b/src/models/qwen3_next_helpers_tests.rs
@@ -23,9 +23,11 @@ fn projection_layout_computes_expected_ranges_and_shapes() {
     assert_eq!(layout.q_range, (0, 4));
     assert_eq!(layout.k_range, (4, 8));
     assert_eq!(layout.v_range, (8, 24));
-    assert_eq!(layout.z_range, (24, -1));
+    // z spans the same width as v; explicit stop (not -1) so mlxcel_core::slice
+    // does not truncate the last column (stop = -1 means dim_size - 1).
+    assert_eq!(layout.z_range, (24, 40));
     assert_eq!(layout.b_range, (0, 2));
-    assert_eq!(layout.a_range, (2, -1));
+    assert_eq!(layout.a_range, (2, 4));
     assert_eq!(layout.v_shape, vec![2, 5, -1, 8]);
     assert_eq!(layout.ba_final_shape, vec![2, 5, 4]);
 }


### PR DESCRIPTION
## Summary

Fixes four independent, pre-existing bugs that prevented `qwen3_next` from loading or running any real checkpoint. The model had never been validated end to end on a real checkpoint, so each bug hid behind the previous crash. Validated on `mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit` (44.9 GB, fits a 128 GB M1 Ultra): both single-process (dense) and `--pp-size 2` now generate coherent, correct output.

Closes #584

## Bugs fixed

1. **MoE expert leaf naming.** `SwitchGLU::from_weights` and the `sanitize_weights` MoE stacking used Mixtral `w1/w2/w3` leaf names; real qwen3_next checkpoints (and mlx-lm) use `gate_proj/up_proj/down_proj`. Symptom: `Error: Missing weight: model.layers.0.mlp.switch_mlp.w1`. The shared `switch_layers.rs` SwitchGLU already defaults to gate/up/down.
2. **gated-delta layout slice `-1`.** `build_projection_layout` set `z_range`/`a_range` stops to `-1`. Those feed raw `mlxcel_core::slice`, where a stop of `-1` means `dim_size - 1` (drops the last column), not "to end". z/a were truncated by one, then reshaping to `v_shape` crashed: `[reshape] Cannot reshape array of size 53040 into shape (1,13,31,128)` at layer 0. Now uses explicit end offsets. (`mlxcel_core::utils::slice_axis` treats `-1` as "to end"; raw `slice` does not.)
3. **gated-delta mask.** `DecoderLayer::forward` passed the `[s,s]` causal attention mask to linear (gated-delta) layers, which use `mask` as a `[b,s]` padding mask -> `where_cond` broadcast the conv input to `[s,s,conv_dim]` -> conv-state concatenate crash. Linear layers now receive `None` (their causality comes from the sequential recurrence and the causal conv, matching the pipeline stage path).
4. **Stateless decode.** `LanguageModel::forward` called `make_caches()` on every invocation, so decode was stateless: each step saw only the current token and produced incoherent output ("The 19. 19. ..."). The model now owns its heterogeneous attention + gated-delta cache via `ModelOwnedSequenceState` and persists it across forward calls, resetting on prefill and via `reset_runtime_state` for fresh sequences (mirrors the `qwen3_5` sibling).

## Validation

- `cargo test --release --features metal,accelerate qwen3_next`: 10 pass. `cargo fmt --all -- --check`: clean.
- Real model `Qwen3-Next-80B-A3B-Instruct-4bit`: dense and `--pp-size 2` both generate "The capital of France is Paris." (token-identical; pp2 additionally renders the `<|im_end|>` EOS). Before this change dense crashed, then produced garbage; pp2 was the only working path.
- Unblocks real-model use of the pipeline-parallel stage support added in #510.

## Files

- src/models/qwen3_next.rs
- src/models/qwen3_next_helpers.rs
- src/models/qwen3_next_helpers_tests.rs

## Note

The root cause of bugs 1 and 2 is a reusable model-porting trap: raw `mlxcel_core::slice` treats stop `-1` as `dim_size-1` (unlike `slice_axis`), and non-Mixtral MoE checkpoints name experts `gate/up/down`. The same slice footgun exists in `longcat_flash_ngram` and is fixed separately in #585.
