### PR TITLE
fix(longcat): n-gram raw slice uses -1 stop on axis 0 (slice-semantics footgun)

### DIFF
--- a/src/models/longcat_flash_ngram.rs
+++ b/src/models/longcat_flash_ngram.rs
@@ -764,7 +764,7 @@ impl NgramEmbedding {
             let keep = (self.n as i32 - 1).max(0);
             if ctx_len > keep {
                 let start = ctx_len - keep;
-                mlxcel_core::slice(&joined, &[0, start], &[-1, ctx_len])
+                slice_axis(&joined, 1, start, ctx_len)
             } else {
                 joined
             }
@@ -778,7 +778,7 @@ impl NgramEmbedding {
         let keep = (self.n as i32 - 1).max(0);
         *context = Some(if ctx_len > keep {
             let start = ctx_len - keep;
-            mlxcel_core::slice(&cur_context, &[0, start], &[-1, ctx_len])
+            slice_axis(&cur_context, 1, start, ctx_len)
         } else {
             mlxcel_core::copy(&cur_context)
         });
@@ -815,7 +815,7 @@ impl NgramEmbedding {
                 let modded_shape = mlxcel_core::array_shape(&modded);
                 let modded_len = modded_shape[modded_shape.len() - 1];
                 let new_ids = if modded_len > seq_len {
-                    mlxcel_core::slice(&modded, &[0, modded_len - seq_len], &[-1, modded_len])
+                    slice_axis(&modded, 1, modded_len - seq_len, modded_len)
                 } else {
                     modded
                 };


### PR DESCRIPTION
## Summary

Fixes three raw `mlxcel_core::slice` calls in the n-gram helper that pass `-1` as the axis-0 stop, intending "all rows / to end". Raw `slice` treats a `-1` stop as `dim_size - 1` (drops the last row; an empty slice when batch = 1), not "to end". This is the same slice-semantics footgun fixed in qwen3_next (#584): raw `slice` and `slice_axis` interpret `-1` oppositely.

Closes #585

## Fix

Use `slice_axis(x, 1, start, stop)` (already imported) for the three single-axis (axis 1) slices in the context-keep helpers and the n-gram id truncation. `slice_axis` keeps axis 0 whole and treats the end index with Python "to end" semantics.

## Validation

- Build clean; `cargo test --release --features metal,accelerate longcat`: 2 pass.
- The n-gram speculative-decoding path is opt-in and no real longcat checkpoint is available on this hardware, so this is a correctness fix validated by build, unit tests, and the slice-semantics analysis (matching the qwen3_next incident).

## Files

- src/models/longcat_flash_ngram.rs
