### PR TITLE
feat(server): let MTP speculative burst reuse an adopted APC prefix

### DIFF
--- a/src/models/gemma4_mtp_target.rs
+++ b/src/models/gemma4_mtp_target.rs
@@ -176,6 +176,17 @@ pub struct Gemma4MtpTargetAdapter<'a> {
     seq_id: Option<SequenceId>,
     /// Buffered rotating-cache slack for MTP verify append + rollback.
     rotating_buffer_size: i32,
+    /// Adopted prompt-cache prefix length (issue #518). When `> 0`,
+    /// `prefill_and_seed` forwards only `prompt_tokens[prefill_start_offset..]`
+    /// and reuses the KV already resident in the per-sequence cache slot for
+    /// `[..prefill_start_offset]`. The slot is populated by the scheduler's APC
+    /// snapshot restore (`restore_sequence_state`) BEFORE the burst runs, and
+    /// the same `ModelOwnedSequenceState[seq_id]` slot is what
+    /// `forward_with_speculative_sinks` resolves — so no double-prefill of the
+    /// cached tokens occurs and RoPE positions continue from the cache's
+    /// restored `offset`. `0` (the default) preserves the cold full-prompt
+    /// prefill byte-for-byte.
+    prefill_start_offset: usize,
 }
 
 impl<'a> Gemma4MtpTargetAdapter<'a> {
@@ -201,7 +212,23 @@ impl<'a> Gemma4MtpTargetAdapter<'a> {
             wrapper,
             seq_id,
             rotating_buffer_size: mtp_rotating_buffer_size(block_size),
+            prefill_start_offset: 0,
         }
+    }
+
+    /// Set the adopted prompt-cache prefix length (issue #518).
+    ///
+    /// When `prefill_start_offset > 0`, the next `prefill_and_seed` forwards
+    /// only the suffix `prompt_tokens[prefill_start_offset..]` and reuses the
+    /// cached KV for `[..prefill_start_offset]` already resident in the
+    /// per-sequence cache slot (restored by the scheduler's APC snapshot
+    /// adoption before the burst runs). The default of `0` keeps the cold
+    /// full-prompt prefill unchanged, so non-adopting callers (CLI, benches,
+    /// existing tests) never need to call this.
+    #[must_use]
+    pub fn with_prefill_start_offset(mut self, prefill_start_offset: usize) -> Self {
+        self.prefill_start_offset = prefill_start_offset;
+        self
     }
 
     /// Slice a `[B, T, H]` hidden tensor down to one position,
@@ -436,8 +463,22 @@ impl<'a> MtpTarget for Gemma4MtpTargetAdapter<'a> {
         MtpVerifyOutput,
         Option<mlxcel_core::sampling::TokenLogprobData>,
     ) {
+        // Suffix-only prefill for an adopted prompt-cache prefix (issue #518).
+        // When `prefill_start_offset > 0` the per-sequence cache slot already
+        // holds the KV for `prompt_tokens[..offset]` (the scheduler's APC
+        // snapshot restore populated the same `ModelOwnedSequenceState[seq_id]`
+        // slot this forward resolves into), so forwarding the whole prompt
+        // would double-prefill and corrupt the cache. We forward only the
+        // suffix; the cache's restored `offset` drives RoPE so the suffix
+        // tokens rotate at their true absolute positions. `offset == 0` (cold)
+        // takes the whole prompt, byte-identical to the pre-#518 path. A
+        // degenerate `offset >= prompt_len` is guarded upstream in
+        // `run_mtp_burst` (declined to classic), so `saturating` here is purely
+        // defensive and never trims the last prompt position in practice.
+        let offset = self.prefill_start_offset.min(prompt_tokens.len());
+        let forward_tokens = &prompt_tokens[offset..];
         let prompt_arr =
-            mlxcel_core::from_slice_i32(prompt_tokens, &[1, prompt_tokens.len() as i32]);
+            mlxcel_core::from_slice_i32(forward_tokens, &[1, forward_tokens.len() as i32]);
 
         // Capture last-layer hidden + last full/SWA shared K/V slabs.
         // Gemma 4 owns its own caches via `ModelOwnedSequenceState`;
@@ -764,6 +805,15 @@ impl<'a> Gemma4VLMtpTargetAdapter<'a> {
             inner: Gemma4MtpTargetAdapter::new_with_block_size(&vlm.text_model, seq_id, block_size),
         }
     }
+
+    /// Set the adopted prompt-cache prefix length (issue #518), delegating to
+    /// the inner text-model adapter. See
+    /// [`Gemma4MtpTargetAdapter::with_prefill_start_offset`].
+    #[must_use]
+    pub fn with_prefill_start_offset(mut self, prefill_start_offset: usize) -> Self {
+        self.inner = self.inner.with_prefill_start_offset(prefill_start_offset);
+        self
+    }
 }
 
 impl<'a> MtpTarget for Gemma4VLMtpTargetAdapter<'a> {
@@ -848,6 +898,15 @@ impl<'a> Gemma4UnifiedMtpTargetAdapter<'a> {
                 block_size,
             ),
         }
+    }
+
+    /// Set the adopted prompt-cache prefix length (issue #518), delegating to
+    /// the inner text-model adapter. See
+    /// [`Gemma4MtpTargetAdapter::with_prefill_start_offset`].
+    #[must_use]
+    pub fn with_prefill_start_offset(mut self, prefill_start_offset: usize) -> Self {
+        self.inner = self.inner.with_prefill_start_offset(prefill_start_offset);
+        self
     }
 }
 

--- a/src/models/gemma4_mtp_target_tests.rs
+++ b/src/models/gemma4_mtp_target_tests.rs
@@ -114,6 +114,72 @@ fn argmax_per_position_returns_one_id_per_position() {
     assert_eq!(argmax, vec![2, 0, 3]);
 }
 
+/// Issue #518: `prefill_and_seed` with an adopted prompt-cache offset forwards
+/// ONLY the suffix and reuses the cached KV for the prefix, producing the
+/// SAME first bonus and `kv_offset` as a cold full-prompt prefill.
+///
+/// This runs on the tiny synthetic Gemma 4 wrapper (1 layer, hidden=4,
+/// vocab=8), not a real checkpoint, so it stays a narrow CPU unit test. It is
+/// the prefix-caching invariant made concrete for the burst path: the
+/// last-position attention reads the same per-position K/V whether the cache
+/// was filled by one full forward `[0..len]` or by a prefix forward `[0..off]`
+/// followed by the adapter's suffix forward `[off..len]`, so the greedy bonus
+/// is bit-identical (no near-tie flakiness — same reduction over the same K/V).
+/// The full on-hardware greedy-parity check against a real Gemma 4 checkpoint
+/// is the orchestrator's deferred `tests/speculative_parity.rs` lane.
+#[test]
+fn prefill_and_seed_with_offset_reuses_prefix_and_matches_cold_full_prompt() {
+    use mlxcel_core::cache::SequenceId;
+    use mlxcel_core::generate::LanguageModel;
+
+    let _runtime = crate::initialize_runtime();
+    let sampler = SamplingConfig::greedy();
+    let logprobs = mlxcel_core::sampling::LogprobsConfig::default();
+
+    // Full-attention layer so the suffix reuse exercises the unbounded KVCache
+    // path (the sliding fixture is equivalent here because the prompt is
+    // shorter than the sliding window, but full-attention is unambiguous).
+    let wrapper = crate::models::gemma4_tests::build_synthetic_wrapper_with_layer("full_attention");
+
+    // Vocab is 8, so keep every id in `[0, 8)`.
+    let prompt: Vec<i32> = vec![2, 5, 1, 7, 3, 6];
+    let offset = 4usize;
+
+    // --- Cold: a fresh slot prefills the whole prompt (offset defaults to 0). ---
+    let seq_cold = SequenceId::from_raw(51_810);
+    let cold_adapter = Gemma4MtpTargetAdapter::new_with_block_size(&wrapper, Some(seq_cold), 4);
+    let (bonus_cold, seed_cold, _) = cold_adapter.prefill_and_seed(&prompt, &sampler, &[], &logprobs);
+
+    // --- Adopted: seed `[..offset]` into a fresh slot (mirrors the scheduler's
+    // APC snapshot restore), then the offset adapter forwards only the suffix. ---
+    let seq_adopt = SequenceId::from_raw(51_811);
+    let prefix_arr = mlxcel_core::from_slice_i32(&prompt[..offset], &[1, offset as i32]);
+    // `forward_with_sequence_id` resolves the same per-sequence slot the adapter
+    // later reads, and appends the prefix KV at absolute positions `[0..offset)`.
+    let _ = wrapper.forward_with_sequence_id(&prefix_arr, Some(seq_adopt), &mut [], None);
+    let adopt_adapter = Gemma4MtpTargetAdapter::new_with_block_size(&wrapper, Some(seq_adopt), 4)
+        .with_prefill_start_offset(offset);
+    let (bonus_adopt, seed_adopt, _) =
+        adopt_adapter.prefill_and_seed(&prompt, &sampler, &[], &logprobs);
+
+    // The reused-prefix run and the cold run must agree on the first bonus...
+    assert_eq!(
+        bonus_cold, bonus_adopt,
+        "suffix-reuse first bonus must equal the cold full-prompt bonus"
+    );
+    // ...and both must report `kv_offset == full prompt length` (the cache holds
+    // `offset` reused + `len - offset` forwarded == `len` tokens after prefill).
+    assert_eq!(
+        seed_cold.kv_offset, seed_adopt.kv_offset,
+        "kv_offset must match between cold and suffix-reuse prefill"
+    );
+    assert_eq!(
+        seed_adopt.kv_offset,
+        prompt.len(),
+        "kv_offset must equal the full prompt length even though only the suffix was forwarded"
+    );
+}
+
 #[test]
 fn verify_bias_suppresses_argmax_at_leaking_position_b1() {
     // issue #350: the B = 1 verify step applies `sampler.token_bias` to the

--- a/src/models/gemma4_mtp_target_tests.rs
+++ b/src/models/gemma4_mtp_target_tests.rs
@@ -148,7 +148,8 @@ fn prefill_and_seed_with_offset_reuses_prefix_and_matches_cold_full_prompt() {
     // --- Cold: a fresh slot prefills the whole prompt (offset defaults to 0). ---
     let seq_cold = SequenceId::from_raw(51_810);
     let cold_adapter = Gemma4MtpTargetAdapter::new_with_block_size(&wrapper, Some(seq_cold), 4);
-    let (bonus_cold, seed_cold, _) = cold_adapter.prefill_and_seed(&prompt, &sampler, &[], &logprobs);
+    let (bonus_cold, seed_cold, _) =
+        cold_adapter.prefill_and_seed(&prompt, &sampler, &[], &logprobs);
 
     // --- Adopted: seed `[..offset]` into a fresh slot (mirrors the scheduler's
     // APC snapshot restore), then the offset adapter forwards only the suffix. ---

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -100,9 +100,24 @@
 //!   eligible.
 //! - The request carries a structured-output constraint: the speculative
 //!   round loops do not yet plumb `llguidance` per-step.
-//! - The request adopted a prompt-cache prefix (`prefill_start_offset > 0`):
-//!   a burst owns the cache for its full lifetime; mixing an adopted prefix
-//!   would double-prefill the leading tokens.
+//!
+//! An adopted prompt-cache prefix (`prefill_start_offset > 0`) is **no longer**
+//! a `should_burst_for_sequence` gate (issue #518). The decision moved into the
+//! per-kind drivers so a cache hit keeps the speculative speedup where it is
+//! safe:
+//!
+//! - **MTP / Gemma 4** ([`run_mtp_burst`]) reuses the adopted KV: it forwards
+//!   only the suffix `prompt_tokens[offset..]` through the same
+//!   `ModelOwnedSequenceState[seq_id]` slot the scheduler's APC snapshot restore
+//!   populated with `[..offset]`, so there is no double-prefill and RoPE
+//!   positions continue from the cache's restored offset. A degenerate offset
+//!   that covers the whole prompt (no suffix to sample the first bonus from)
+//!   still declines to classic.
+//! - **DFlash / Qwen 3.5** ([`run_dflash_burst`]) keeps the safe fallback: it
+//!   builds its own fresh caches that do not hold the adopted KV, so an adopted
+//!   prefix declines to classic (a B = 1 DFlash reuse follow-up).
+//! - **B > 1 batched** declines an adopted prefix via
+//!   [`can_join_batched_burst_window`], routing it to the B = 1 arm.
 //!
 //! History-dependent sampling penalties (repetition / frequency /
 //! presence / DRY) are **not** a gate: the burst threads
@@ -312,10 +327,14 @@ impl WorkerDrafterSlot {
 ///    speculative round loops do not yet plumb the `llguidance` matcher
 ///    through per-step; falling back to classic decode preserves the
 ///    grammar invariants.
-/// 4. `seq` has no prefill-cache adoption (`prefill_start_offset == 0`).
-///    A speculative burst owns the cache for its full lifetime; mixing
-///    an adopted prefix with the burst's own prefill would double-prefill
-///    the leading tokens.
+///
+/// An adopted prompt-cache prefix (`prefill_start_offset > 0`) is **no longer**
+/// a gate here (issue #518). The per-kind driver decides: [`run_mtp_burst`]
+/// reuses the adopted KV by prefilling only the suffix, while
+/// [`run_dflash_burst`] falls back to classic (its fresh caches do not hold the
+/// adopted KV). B > 1 windows exclude adopted prefixes via
+/// [`can_join_batched_burst_window`], so an offset request always lands on the
+/// B = 1 arm.
 ///
 /// History-dependent sampling penalties (repetition / frequency /
 /// presence / DRY) are **no longer** a gate: the burst
@@ -367,14 +386,17 @@ pub(crate) fn should_burst_for_sequence(
         );
         return false;
     }
-    if seq.prefill_start_offset > 0 {
-        tracing::debug!(
-            "speculative burst declined for seq {}: prefill_start_offset={} (adopted cache prefix)",
-            seq.seq_id,
-            seq.prefill_start_offset,
-        );
-        return false;
-    }
+    // An adopted prompt-cache prefix (`prefill_start_offset > 0`) is NO LONGER a
+    // blanket decline-to-classic gate (issue #518). The B = 1 MTP burst reuses
+    // the adopted KV by prefilling only the suffix `[offset..]` (the same
+    // `ModelOwnedSequenceState[seq_id]` slot the snapshot restore populated is
+    // what the speculative forward resolves, so there is no double-prefill). The
+    // per-driver decision lives in `run_mtp_burst` (honors the offset) and
+    // `run_dflash_burst` (declines to classic — its fresh independent caches do
+    // not hold the adopted KV yet; a B = 1 DFlash follow-up). The B > 1 batched
+    // burst still declines an adopted prefix via `can_join_batched_burst_window`
+    // below, so an offset request always lands on the B = 1 arm.
+    //
     // History-dependent sampling penalties (repetition / frequency /
     // presence / DRY) are NO LONGER a decline-to-classic gate. The burst now threads `initial_token_history(&prompt, ..)`
     // into the first-bonus sample via `MtpTarget::prefill_and_seed` /
@@ -411,7 +433,48 @@ pub(crate) fn can_join_batched_burst_window(seq: &SequenceInfo) -> bool {
         );
         return false;
     }
+    // Adopted prompt-cache prefixes (issue #518) are handled only on the B = 1
+    // arm today: the suffix-reuse prefill is wired for the single-request MTP
+    // burst, while the batched round loops assume every row starts from a zero
+    // KV offset. Keeping `prefill_start_offset > 0` requests out of B > 1
+    // windows routes them to the B = 1 burst (where MTP reuses the adopted KV
+    // and DFlash falls back to classic). B > 1 adopted-prefix reuse is a
+    // separate follow-up.
+    if seq.prefill_start_offset > 0 {
+        tracing::debug!(
+            "speculative batched burst declined for seq {}: prefill_start_offset={} \
+             (adopted cache prefix handled on the B=1 arm)",
+            seq.seq_id,
+            seq.prefill_start_offset,
+        );
+        return false;
+    }
     true
+}
+
+/// Resolve the forward-start index for a B = 1 MTP burst that may reuse an
+/// adopted prompt-cache prefix (issue #518).
+///
+/// Given the adopted prefix length `prefill_start_offset` and the full prompt
+/// length `prompt_len`, returns:
+///
+/// - `Some(offset)` — forward only `prompt_tokens[offset..]`, reusing the
+///   already-resident cached KV for `[..offset]`. `offset == 0` is the cold
+///   path (forward the whole prompt, byte-identical to the pre-#518 burst);
+///   any `0 < offset < prompt_len` reuses the adopted prefix.
+/// - `None` — the offset is degenerate (`>= prompt_len`: the whole prompt is
+///   already cached, so there is no suffix position left to forward the
+///   first-bonus logits from). The caller declines to classic decode, which
+///   owns the all-cached edge and keeps the adopted cache untouched.
+pub(crate) fn mtp_prefill_suffix_start(
+    prefill_start_offset: usize,
+    prompt_len: usize,
+) -> Option<usize> {
+    if prefill_start_offset >= prompt_len {
+        None
+    } else {
+        Some(prefill_start_offset)
+    }
 }
 
 /// Whether the Gemma 4 MTP B=1 (single-request) burst path runs for a target
@@ -881,6 +944,30 @@ fn run_mtp_burst(
         }
     };
 
+    // Adopted prompt-cache prefix (issue #518): resolve where the suffix
+    // prefill starts. `None` means the whole prompt is already cached
+    // (`prefill_start_offset >= prompt_len`) with no suffix position to sample
+    // the first bonus from — decline to classic, which owns that all-cached
+    // edge. We check this BEFORE taking the drafter so the decline leaves the
+    // slot and the adopted cache untouched. `Some(0)` (cold) and any
+    // `Some(0 < offset < prompt_len)` (reuse) both proceed.
+    let prefill_start_offset = match mtp_prefill_suffix_start(
+        seq.prefill_start_offset,
+        seq.prompt_tokens.len(),
+    ) {
+        Some(offset) => offset,
+        None => {
+            tracing::debug!(
+                "MTP speculative burst declined for seq {}: prefill_start_offset={} \
+                 covers the whole prompt (len={}); falling back to classic decode",
+                seq.seq_id,
+                seq.prefill_start_offset,
+                seq.prompt_tokens.len(),
+            );
+            return Err(BurstOutcome::DeclineToClassic);
+        }
+    };
+
     // The MTP generator owns the drafter by value; take it from the
     // slot for the burst's lifetime. On success we return it via
     // `return_drafter`; on error we drop it so the next request
@@ -957,7 +1044,8 @@ fn run_mtp_burst(
     let (output, stats) = match ctx.model {
         LoadedModel::Gemma4(wrapper) => {
             let adapter =
-                Gemma4MtpTargetAdapter::new_with_block_size(wrapper, Some(seq.seq_id), block_size);
+                Gemma4MtpTargetAdapter::new_with_block_size(wrapper, Some(seq.seq_id), block_size)
+                    .with_prefill_start_offset(prefill_start_offset);
             drive_mtp_generator(
                 adapter,
                 owned_drafter,
@@ -976,7 +1064,8 @@ fn run_mtp_burst(
                     vlm,
                     Some(seq.seq_id),
                     block_size,
-                );
+                )
+                .with_prefill_start_offset(prefill_start_offset);
             drive_mtp_generator(
                 adapter,
                 owned_drafter,
@@ -995,7 +1084,8 @@ fn run_mtp_burst(
                     unified,
                     Some(seq.seq_id),
                     block_size,
-                );
+                )
+                .with_prefill_start_offset(prefill_start_offset);
             drive_mtp_generator(
                 adapter,
                 owned_drafter,
@@ -1168,6 +1258,29 @@ fn run_dflash_burst(
         return Err(BurstOutcome::DeclineToClassic);
     }
 
+    // Safe fallback for an adopted prompt-cache prefix (issue #518): the DFlash
+    // burst builds its OWN fresh per-layer caches (`make_dflash_caches()`),
+    // independent of the `ModelOwnedSequenceState[seq_id]` slot the scheduler's
+    // APC snapshot restore populates. Those fresh caches do NOT hold the
+    // adopted `[..offset]` KV, so forwarding only the suffix would rotate the
+    // suffix at the wrong positions and attend a missing prefix. Until the B = 1
+    // DFlash path can seed its caches from the adopted prefix (a follow-up),
+    // decline to classic decode — which owns the adopted cache and prefills the
+    // suffix correctly. The check is placed before any drafter load / cache
+    // build so the decline leaves the adopted cache and drafter slot untouched.
+    // (The MTP burst, by contrast, reuses the adopted KV because its target
+    // forward resolves the SAME model-owned slot the snapshot restored into.)
+    if seq.prefill_start_offset > 0 {
+        tracing::debug!(
+            "DFlash speculative burst declined for seq {}: prefill_start_offset={} \
+             (adopted cache prefix not yet reusable by the DFlash burst's \
+             independent caches); falling back to classic decode",
+            seq.seq_id,
+            seq.prefill_start_offset,
+        );
+        return Err(BurstOutcome::DeclineToClassic);
+    }
+
     // HOIST: validate the model variant BEFORE loading the drafter.
     // See the function-level docstring above.
     match ctx.model {
@@ -1319,8 +1432,10 @@ where
     // Build a fresh per-layer cache vector for this request. We do NOT
     // touch the scheduler-owned `sequence_state` map — the speculative
     // burst's caches are independent of the prompt-cache adoption
-    // pipeline (`should_burst_for_sequence` enforces
-    // `prefill_start_offset == 0`).
+    // pipeline. Because these caches start empty, an adopted prefix
+    // cannot be reused here, which is exactly why `run_dflash_burst`
+    // declines `prefill_start_offset > 0` to classic decode (issue #518);
+    // by the time control reaches this helper the offset is guaranteed 0.
     //
     // The target-specific cache factory returns the heterogeneous
     // attention+linear cache vec the round loop needs, while the

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -951,22 +951,20 @@ fn run_mtp_burst(
     // edge. We check this BEFORE taking the drafter so the decline leaves the
     // slot and the adopted cache untouched. `Some(0)` (cold) and any
     // `Some(0 < offset < prompt_len)` (reuse) both proceed.
-    let prefill_start_offset = match mtp_prefill_suffix_start(
-        seq.prefill_start_offset,
-        seq.prompt_tokens.len(),
-    ) {
-        Some(offset) => offset,
-        None => {
-            tracing::debug!(
-                "MTP speculative burst declined for seq {}: prefill_start_offset={} \
+    let prefill_start_offset =
+        match mtp_prefill_suffix_start(seq.prefill_start_offset, seq.prompt_tokens.len()) {
+            Some(offset) => offset,
+            None => {
+                tracing::debug!(
+                    "MTP speculative burst declined for seq {}: prefill_start_offset={} \
                  covers the whole prompt (len={}); falling back to classic decode",
-                seq.seq_id,
-                seq.prefill_start_offset,
-                seq.prompt_tokens.len(),
-            );
-            return Err(BurstOutcome::DeclineToClassic);
-        }
-    };
+                    seq.seq_id,
+                    seq.prefill_start_offset,
+                    seq.prompt_tokens.len(),
+                );
+                return Err(BurstOutcome::DeclineToClassic);
+            }
+        };
 
     // The MTP generator owns the drafter by value; take it from the
     // slot for the burst's lifetime. On success we return it via

--- a/src/server/batch/speculative_burst_tests.rs
+++ b/src/server/batch/speculative_burst_tests.rs
@@ -245,14 +245,56 @@ fn dflash_burst_declined_for_audio_payload_without_embeddings() {
 }
 
 #[test]
-fn burst_declined_for_adopted_prompt_cache_prefix() {
+fn burst_allowed_for_adopted_prompt_cache_prefix() {
+    // Issue #518: an adopted prompt-cache prefix is no longer a blanket gate.
+    // `should_burst_for_sequence` now admits `prefill_start_offset > 0`; the
+    // per-kind driver decides (MTP reuses the suffix, DFlash falls back).
     let dispatch = make_mtp_dispatch();
     let (mut seq, _rx) = make_test_sequence();
     seq.prefill_start_offset = 5;
     assert!(
-        !should_burst_for_sequence(&dispatch, &seq),
-        "requests with an adopted cache prefix must fall back to classic decode"
+        should_burst_for_sequence(&dispatch, &seq),
+        "an adopted cache prefix must reach the B=1 driver, not be gated out at the scheduler"
     );
+}
+
+#[test]
+fn batched_window_declines_adopted_prompt_cache_prefix() {
+    // Issue #518: adopted-prefix requests are handled only on the B=1 arm
+    // today. `can_join_batched_burst_window` keeps them out of B>1 windows so
+    // they route to the single-request burst (MTP suffix-reuse / DFlash
+    // fallback) rather than the batched round loops, which assume a zero KV
+    // offset per row.
+    let (mut seq, _rx) = make_test_sequence();
+    seq.prefill_start_offset = 5;
+    assert!(
+        !can_join_batched_burst_window(&seq),
+        "an adopted cache prefix must be excluded from B>1 windows and land on the B=1 arm"
+    );
+
+    // A cold request (no adopted prefix) still joins a batched window.
+    let (cold_seq, _rx2) = make_test_sequence();
+    assert_eq!(cold_seq.prefill_start_offset, 0);
+    assert!(
+        can_join_batched_burst_window(&cold_seq),
+        "a cold request must remain eligible for a B>1 window"
+    );
+}
+
+#[test]
+fn mtp_prefill_suffix_start_resolves_cold_reuse_and_degenerate_offsets() {
+    use super::speculative_burst::mtp_prefill_suffix_start;
+    // Cold: offset 0 forwards the whole prompt.
+    assert_eq!(mtp_prefill_suffix_start(0, 10), Some(0));
+    // Reuse: a proper prefix forwards only the suffix `[offset..]`.
+    assert_eq!(mtp_prefill_suffix_start(5, 10), Some(5));
+    // Reuse boundary: a single suffix token still has a position to sample the
+    // first bonus from.
+    assert_eq!(mtp_prefill_suffix_start(9, 10), Some(9));
+    // Degenerate: the whole prompt is cached — no suffix position remains, so
+    // the driver must decline to classic.
+    assert_eq!(mtp_prefill_suffix_start(10, 10), None);
+    assert_eq!(mtp_prefill_suffix_start(11, 10), None);
 }
 
 // History-dependent sampling penalties are NO LONGER a decline-to-classic


### PR DESCRIPTION
## Summary

An APC-adopted prompt-cache prefix and the MTP/DFlash speculative burst were mutually exclusive: `should_burst_for_sequence` declined every `prefill_start_offset > 0` request to classic decode, so a cache hit lost speculative decoding entirely. This lets a Gemma 4 MTP cache hit keep the speculative speedup by prefilling only the suffix and reusing the cached KV for the adopted prefix. Qwen 3.5 DFlash keeps a documented safe fallback (its fresh independent caches cannot hold the adopted KV yet), and B>1 batched bursts stay a separate follow-up. B=1 is covered first, per the issue.

## Why MTP reuses and DFlash falls back

The adopted KV for a snapshot-reuse family (Gemma 4 / Qwen 3.5) is restored into the model's `ModelOwnedSequenceState[seq_id]` slot before the burst runs. The MTP burst's `forward_with_speculative_sinks` resolves that same slot, so forwarding only the suffix reuses `[..offset]` with no double-prefill and RoPE continues from the cache's restored `offset`. The DFlash burst instead builds its own fresh `Qwen3NextCache` vector that does not hold the adopted KV, so it declines `prefill_start_offset > 0` to classic until a B=1 DFlash reuse path lands.

## What changed

- `src/models/gemma4_mtp_target.rs`: `Gemma4MtpTargetAdapter` gains a `prefill_start_offset` field plus a `with_prefill_start_offset` builder (defaults to 0, so CLI / bench / existing callers are unchanged). `prefill_and_seed` forwards only `prompt_tokens[offset..]` when the offset is set; `kv_offset` still equals the full prompt length (`offset` reused + suffix forwarded). The VL / Unified adapters delegate the builder to the inner adapter.
- `src/server/batch/speculative_burst.rs`: removed the blanket `prefill_start_offset > 0` decline from `should_burst_for_sequence`; added the `mtp_prefill_suffix_start` helper; `run_mtp_burst` threads the offset into the three Gemma 4 adapters and declines a degenerate all-cached offset; `run_dflash_burst` declines `prefill_start_offset > 0` to classic (safe fallback); `can_join_batched_burst_window` excludes adopted prefixes so they land on the B=1 arm. Module and function docstrings updated to match.
- `initial_token_history` still uses the full prompt, so first-bonus penalties, logprobs, and thinking-budget enforcement stay byte-identical to the classic path.

## Test plan

- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo test --lib server::batch::speculative_burst_tests` (41 passed: gate admits an adopted prefix, batched-window gate excludes it, `mtp_prefill_suffix_start` cold/reuse/degenerate cases)
- [x] `cargo test --lib models::gemma4_mtp_target::tests` (36 passed, including the new synthetic-weight suffix-reuse parity test: the offset adapter forwards only the suffix yet yields the same first bonus and `kv_offset` as a cold full-prompt prefill)

Full real-model greedy parity against a Gemma 4 checkpoint is the deferred `tests/speculative_parity.rs` lane (needs GPU plus weights) and is out of scope for this CPU-only unit.

Closes #518
