### PR TITLE
fix(cli): accept both drafter flag spellings on serve and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ mlxcel inspect -m Qwen3.5-0.8B-4bit --max-tokens 32768
 mlxcel generate -m Qwen3.5-0.8B-4bit -p "Hello, world!" -n 32768 --estimate-memory
 ```
 
+`mlxcel-server` mirrors `mlxcel serve` flag for flag, including the two speculative-decoding flags whose primary spelling differs by convention: the drafter checkpoint path (`--draft-model` on `mlxcel serve`, mlx-lm style; `--model-draft` on `mlxcel-server`, llama-server style) and the per-step draft-token budget (`--draft-max` on `mlxcel serve`; `--draft` on `mlxcel-server`). Both binaries accept both spellings as aliases, so a speculative-decoding command line built for one runs unchanged on the other, for example `--draft-model <path> --draft-kind mtp` also works as `--model-draft <path> --draft-kind mtp` on `mlxcel-server`. `--draft-kind` and `--draft-block-size` already share one spelling everywhere.
+
 Downloaded models land in a location-independent global store at `${MLXCEL_CACHE_DIR:-$HOME/.cache/mlxcel}/models/<owner>/<name>`, shared across every working directory. To relocate the store, write a snapshot to an exact path, change the default org, or tune the memory preflight, see [Environment variables](docs/environment-variables.md), `MLXCEL_MODELS_DIR` / `--models-dir`, `--local-dir`, `MLXCEL_DEFAULT_ORG`, and `MLXCEL_MEMORY_LIMIT` / `MLXCEL_HEADROOM_FACTOR`.
 
 If you build from source instead, use `./target/release/mlxcel` and

--- a/src/bin/mlx_server.rs
+++ b/src/bin/mlx_server.rs
@@ -247,8 +247,13 @@ struct ServerArgs {
     timeout: u64,
 
     /// Path to drafter checkpoint for server speculative decoding
+    ///
+    /// Accepts the llama-server-style `--model-draft` spelling (primary) and
+    /// the mlx-lm-style `--draft-model` spelling (alias, matches `mlxcel
+    /// serve`) so commands copied between the two binaries work unchanged.
     #[arg(
         long = "model-draft",
+        visible_alias = "draft-model",
         env = "LLAMA_ARG_MODEL_DRAFT",
         value_name = "PATH"
     )]
@@ -908,9 +913,13 @@ struct ServerArgs {
     /// Speculative-decoding flag group (`--draft-kind`, `--draft-block-size`).
     /// Defined once in `mlxcel::cli::speculative_args` so all three
     /// binaries (`mlxcel generate`, `mlxcel serve`, `mlxcel-server`) expose
-    /// identical help text and parsing. The `--model-draft` /
-    /// `--draft` flags stay above on this struct because they have
-    /// llama-server-compatible naming on this binary.
+    /// identical help text and parsing. The `--model-draft` / `--draft`
+    /// flags stay above on this struct because their primary spelling is
+    /// llama-server-compatible; each also carries a visible alias
+    /// (`--draft-model`, `--draft-max`) so a `mlxcel serve` command line
+    /// works unchanged on `mlxcel-server`. See the parity note on
+    /// `SpeculativeArgs` and `ServeArgs::draft_model` / `draft_max` in
+    /// `src/main.rs`.
     #[command(flatten)]
     speculative: SpeculativeArgs,
 
@@ -1441,5 +1450,40 @@ mod tests {
         let input = build_startup_input(args).expect("existing path should be accepted");
 
         assert_eq!(input.model_path, local_model);
+    }
+
+    // ── Drafter flag aliases (issue #464) ───────────────────────
+    //
+    // `mlxcel-server` uses the llama-server-style `--model-draft` /
+    // `--draft` spelling as the primary flag names, and `mlxcel serve`
+    // uses the mlx-lm-style `--draft-model` / `--draft-max` spelling.
+    // Both binaries now accept both spellings via `visible_alias`, so a
+    // command line copied from one to the other parses unchanged. These
+    // tests pin that both spellings resolve to the identical `ServerArgs`
+    // field value here; `src/main_tests.rs` carries the matching
+    // assertions for `mlxcel serve`.
+
+    #[test]
+    fn model_draft_and_draft_model_aliases_resolve_identically() {
+        let primary = parse_server_args(&["mlxcel-server", "--model-draft", "models/draft"]);
+        let aliased = parse_server_args(&["mlxcel-server", "--draft-model", "models/draft"]);
+
+        assert_eq!(
+            primary.model_draft, aliased.model_draft,
+            "--model-draft and its --draft-model alias must resolve to the same drafter path"
+        );
+        assert_eq!(primary.model_draft, Some(PathBuf::from("models/draft")));
+    }
+
+    #[test]
+    fn draft_and_draft_max_aliases_resolve_identically() {
+        let primary = parse_server_args(&["mlxcel-server", "--draft", "24"]);
+        let aliased = parse_server_args(&["mlxcel-server", "--draft-max", "24"]);
+
+        assert_eq!(
+            primary.draft, aliased.draft,
+            "--draft and its --draft-max alias must resolve to the same token budget"
+        );
+        assert_eq!(primary.draft, 24);
     }
 }

--- a/src/cli/speculative_args.rs
+++ b/src/cli/speculative_args.rs
@@ -30,13 +30,17 @@
 //!   `env_fallback_draft_*` family) live next to the flag definitions so the
 //!   binary entry points stay slim.
 //!
-//! The existing `--draft-model` (`--model-draft` on `mlxcel-server` for
-//! llama.cpp compatibility) and `--draft-max` / `--num-draft-tokens` flags
-//! intentionally remain on the per-binary `Args` structs because their
-//! names diverge across binaries (the `mlxcel-server` binary needs the
-//! llama.cpp `--model-draft` spelling) and the `--num-draft-tokens` /
-//! `--draft-max` knob has separate semantics on the offline `generate` vs.
-//! the continuous-batched `serve` paths.
+//! The existing `--draft-model` / `--model-draft` and `--draft-max` /
+//! `--draft` flags intentionally remain on the per-binary `Args` structs
+//! rather than joining this shared group, because `mlxcel generate` uses
+//! the unrelated `--num-draft-tokens` spelling with offline-only semantics.
+//! On the two server binaries (`mlxcel serve`, `mlxcel-server`) both
+//! spellings are cross-aliased (`visible_alias`) so a command line written
+//! for one parses unchanged on the other: `--draft-model` /
+//! `--model-draft` both resolve to the drafter checkpoint path, and
+//! `--draft-max` / `--draft` both resolve to the per-step draft-token
+//! budget. See `tests/cli_help_consistency.rs` for the cross-binary
+//! parity test.
 //!
 //! Used by: mlxcel generate, mlxcel serve, mlxcel-server.
 
@@ -63,10 +67,12 @@ pub const DEFAULT_DFLASH_BLOCK_SIZE: u32 = 16;
 /// callers; see the integration test `tests/cli_help_consistency.rs`.
 ///
 /// The group only owns the **dispatch-selecting** flags (`--draft-kind`,
-/// `--draft-block-size`). The `--draft-model` path, the `--draft-max` /
-/// `--num-draft-tokens` knob, and the llama.cpp-compat `--model-draft`
-/// alias all remain on the per-binary `Args` structs because their
-/// spellings and semantics diverge.
+/// `--draft-block-size`). The drafter-path flag (`--draft-model` /
+/// `--model-draft`) and the draft-token-count knob (`--draft-max` /
+/// `--draft` on the servers, `--num-draft-tokens` on offline `generate`)
+/// remain on the per-binary `Args` structs; on `mlxcel serve` and
+/// `mlxcel-server` both spellings of each are cross-aliased for parity,
+/// see the module-level docs above.
 #[derive(Args, Debug, Clone, Default)]
 #[command(next_help_heading = "Speculative Decoding Options")]
 pub struct SpeculativeArgs {

--- a/src/main.rs
+++ b/src/main.rs
@@ -816,11 +816,21 @@ pub(crate) struct ServeArgs {
     n_predict: i32,
 
     /// Path to drafter checkpoint for server speculative decoding
-    #[arg(long, value_name = "PATH")]
+    ///
+    /// Accepts the mlx-lm-style `--draft-model` spelling (primary) and the
+    /// llama-server-style `--model-draft` spelling (alias, matches
+    /// `mlxcel-server`) so commands copied between the two binaries work
+    /// unchanged.
+    #[arg(long, visible_alias = "model-draft", value_name = "PATH")]
     draft_model: Option<PathBuf>,
 
     /// Maximum number of draft tokens per speculation step
-    #[arg(long, env = "LLAMA_ARG_DRAFT_MAX", default_value_t = 16)]
+    #[arg(
+        long,
+        visible_alias = "draft",
+        env = "LLAMA_ARG_DRAFT_MAX",
+        default_value_t = 16
+    )]
     draft_max: usize,
 
     /// Maximum concurrent decode sequences; explicit value shares --ctx-size
@@ -1433,10 +1443,12 @@ pub(crate) struct ServeArgs {
     /// Speculative-decoding flag group (`--draft-kind`, `--draft-block-size`).
     /// Defined once in `mlxcel::cli::speculative_args` so all three
     /// binaries (`mlxcel generate`, `mlxcel serve`, `mlxcel-server`) expose
-    /// identical help text and parsing. The `--draft-model` /
-    /// `--draft-max` flags stay above on this struct because they have
-    /// different naming on `mlxcel-server` (`--model-draft`) for
-    /// llama-server CLI compatibility.
+    /// identical help text and parsing. The `--draft-model` / `--draft-max`
+    /// flags stay above on this struct because their primary spelling is
+    /// mlx-lm-style; each also carries a visible alias (`--model-draft`,
+    /// `--draft`) matching the llama-server-compatible naming
+    /// `mlxcel-server` uses, so a command line built for either binary
+    /// parses on both.
     #[command(flatten)]
     speculative: SpeculativeArgs,
 

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -275,6 +275,76 @@ fn serve_command_surgery_flag_defaults_to_none() {
     );
 }
 
+// ── Drafter flag aliases (issue #464) ───────────────────────────
+//
+// `mlxcel serve` uses the mlx-lm-style `--draft-model` / `--draft-max`
+// spelling as the primary flag names, and `mlxcel-server` uses the
+// llama-server-style `--model-draft` / `--draft` spelling. Both binaries
+// now accept both spellings via `visible_alias`, so a command line copied
+// from one to the other parses unchanged. These tests pin that both
+// spellings resolve to the identical `ServeArgs` field value on `mlxcel
+// serve`; `src/bin/mlx_server.rs`'s test module carries the matching
+// assertions for `mlxcel-server`.
+
+#[test]
+fn serve_draft_model_and_model_draft_aliases_resolve_identically() {
+    let primary = Cli::try_parse_from([
+        "mlxcel",
+        "serve",
+        "-m",
+        "models/foo",
+        "--draft-model",
+        "models/draft",
+    ])
+    .expect("--draft-model must parse on `mlxcel serve`");
+    let Commands::Serve(primary_args) = primary.command else {
+        panic!("expected serve command");
+    };
+
+    let aliased = Cli::try_parse_from([
+        "mlxcel",
+        "serve",
+        "-m",
+        "models/foo",
+        "--model-draft",
+        "models/draft",
+    ])
+    .expect("--model-draft alias must parse on `mlxcel serve`");
+    let Commands::Serve(aliased_args) = aliased.command else {
+        panic!("expected serve command");
+    };
+
+    assert_eq!(
+        primary_args.draft_model, aliased_args.draft_model,
+        "--draft-model and its --model-draft alias must resolve to the same drafter path"
+    );
+    assert_eq!(
+        primary_args.draft_model,
+        Some(std::path::PathBuf::from("models/draft"))
+    );
+}
+
+#[test]
+fn serve_draft_max_and_draft_aliases_resolve_identically() {
+    let primary = Cli::try_parse_from(["mlxcel", "serve", "-m", "models/foo", "--draft-max", "24"])
+        .expect("--draft-max must parse on `mlxcel serve`");
+    let Commands::Serve(primary_args) = primary.command else {
+        panic!("expected serve command");
+    };
+
+    let aliased = Cli::try_parse_from(["mlxcel", "serve", "-m", "models/foo", "--draft", "24"])
+        .expect("--draft alias must parse on `mlxcel serve`");
+    let Commands::Serve(aliased_args) = aliased.command else {
+        panic!("expected serve command");
+    };
+
+    assert_eq!(
+        primary_args.draft_max, aliased_args.draft_max,
+        "--draft-max and its --draft alias must resolve to the same token budget"
+    );
+    assert_eq!(primary_args.draft_max, 24);
+}
+
 #[test]
 fn list_command_parses_to_list() {
     let cli = Cli::try_parse_from(["mlxcel", "list"]).expect("bare `list` must parse");

--- a/tests/cli_help_consistency.rs
+++ b/tests/cli_help_consistency.rs
@@ -456,3 +456,39 @@ fn speculative_flag_signatures_match_across_binaries() {
         );
     }
 }
+
+// ── Drafter flag aliases (issue #464) ───────────────────────────
+//
+// `mlxcel serve` and `mlxcel-server` intentionally keep opposite primary
+// spellings for the drafter-path and draft-token-count flags (mlx-lm vs.
+// llama-server style), but both must accept both spellings so a command
+// line copied between the two binaries parses unchanged. This pins the
+// `--help` output on each binary to document the alias so an operator
+// discovers the alternate spelling without reading the source. Unit tests
+// in `src/main_tests.rs` and `src/bin/mlx_server.rs` cover that the
+// aliases resolve to the identical parsed value.
+#[test]
+fn drafter_flag_aliases_are_documented_on_both_binaries() {
+    let serve_help = help_output("mlxcel", &["serve", "--help"]);
+    let server_help = help_output("mlxcel-server", &["--help"]);
+
+    assert!(
+        serve_help.contains("--draft-model <PATH>")
+            && serve_help.contains("[aliases: --model-draft]"),
+        "mlxcel serve --help must document --draft-model with a --model-draft alias.\nHelp was:\n{serve_help}"
+    );
+    assert!(
+        serve_help.contains("--draft-max <DRAFT_MAX>") && serve_help.contains("[aliases: --draft]"),
+        "mlxcel serve --help must document --draft-max with a --draft alias.\nHelp was:\n{serve_help}"
+    );
+
+    assert!(
+        server_help.contains("--model-draft <PATH>")
+            && server_help.contains("[aliases: --draft-model]"),
+        "mlxcel-server --help must document --model-draft with a --draft-model alias.\nHelp was:\n{server_help}"
+    );
+    assert!(
+        server_help.contains("--draft <DRAFT>") && server_help.contains("[aliases: --draft-max]"),
+        "mlxcel-server --help must document --draft with a --draft-max alias.\nHelp was:\n{server_help}"
+    );
+}


### PR DESCRIPTION
## Summary

`mlxcel-server --draft-model <path>` rejected the flag with `unexpected argument` even though the README documents `mlxcel-server` as equivalent to `mlxcel serve`, because the two binaries used opposite drafter-flag spellings (mlx-lm style `--draft-model`/`--draft-max` on `mlxcel serve`, llama-server style `--model-draft`/`--draft` on `mlxcel-server`). Both binaries now accept both spellings.

## What changed

- `src/main.rs`: `ServeArgs::draft_model` gains `visible_alias = "model-draft"`, `draft_max` gains `visible_alias = "draft"`; doc comments updated to describe the new parity.
- `src/bin/mlx_server.rs`: `ServerArgs::model_draft` gains `visible_alias = "draft-model"`; doc comments updated; new unit tests assert both spellings resolve to the same parsed field.
- `src/cli/speculative_args.rs`: module and struct doc comments updated to describe the cross-aliasing on the two server binaries.
- `src/main_tests.rs`: new unit tests assert `--draft-model`/`--model-draft` and `--draft-max`/`--draft` resolve identically on `mlxcel serve`.
- `tests/cli_help_consistency.rs`: new integration test asserts `--help` documents both aliases on both binaries.
- `README.md`: clarify that `mlxcel-server` mirrors `mlxcel serve` flag for flag, including both drafter-flag spellings.

`--draft-kind` and `--draft-block-size` already shared one spelling via the `SpeculativeArgs` group flattened into both binaries and needed no change.

## Test plan

- [x] `cargo check --bins --tests`
- [x] `cargo clippy --lib --bins --tests -- -D warnings`
- [x] `cargo test --bin mlxcel draft` (2 new unit tests, `mlxcel serve` alias parity)
- [x] `cargo test --bin mlxcel-server draft` (2 new unit tests, `mlxcel-server` alias parity)
- [x] `cargo test --test cli_help_consistency` (11 tests, including the new cross-binary `--help` alias check)
- [x] Manually reproduced the original issue command with a placeholder model path on both binaries: parsing now succeeds and fails later at model resolution instead of `unexpected argument '--draft-model' found`

Closes #464
