### PR TITLE
feat(downloader): detect incomplete snapshot and re-fetch on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **ComputeBackend seam for the forward-execution engine.** A `ComputeBackend` abstraction at the model-load boundary lets a future non-MLX engine host `LanguageModel::forward` without routing through the MLX bridge. The existing MLX path moves behind `MlxBackend` as a behavior-preserving refactor (temp-0 output is byte-identical before and after). Under default features the selection folds to the single MLX backend at compile time with no runtime dispatch on the hot path; a default-off `experimental-backend` feature reserves the plug-in slot. No non-MLX kernels are implemented (#338).
 
+### Fixed
+- **Interrupted model downloads are detected and re-fetched instead of failing at load.** An interrupted `mlxcel run <repo-id>` (also `mlxcel serve` and `mlxcel-server` auto-download) previously reused the partial snapshot and died with a bare `Weight not found`. The load/resolve path now verifies the full weight set against the snapshot's own `model.safetensors.index.json` (every shard present and non-zero), not just `config.json` presence, so a partial snapshot is resumed through the shared downloader (re-fetching only the missing files, with a forced clean re-download as a fallback) before the model loads. Repackaged mlx-community quants whose stale full-precision index no longer matches the on-disk files are still reused without a re-fetch (#465).
+
 ### Docs
 - Finalize the per-backend `MLXCEL_FUSED_QK_NORM` default decision: CUDA (GB10) was measured and is also slower than the graph path, so the fused QK-norm decode path stays opt-in (default off) on every backend; `docs/environment-variables.md` updated to drop the CUDA-pending rationale and record the determinism nuance (#355).
 

--- a/src/downloader/completeness.rs
+++ b/src/downloader/completeness.rs
@@ -1,0 +1,368 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Offline snapshot-completeness gate for the load/resolve path (issue #465).
+//!
+//! The downloader already has a strong completeness gate (`snapshot_complete`)
+//! keyed on the network-fetched wanted-set. The resolver, however, historically
+//! reused a local snapshot after only checking that `config.json` was present.
+//! An interrupted download that fetched `config.json` and only some safetensors
+//! shards therefore passed that weak gate, the re-download was skipped, and the
+//! model loader died at the first missing weight with a bare
+//! `Weight not found: ...`.
+//!
+//! [`classify_snapshot`] closes that gap **without a network round-trip** by
+//! deriving the expected weight set from the snapshot's own
+//! `model.safetensors.index.json`. It deliberately mirrors the loader's
+//! stale-index tolerance ([`mlxcel_core::weights`]): a repackaged mlx-community
+//! quant that ships the original full-precision index (whose shard names no
+//! longer match the on-disk quant files) is reported [`SnapshotState::Complete`]
+//! and never re-fetched, exactly as the loader would glob-load it.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+/// The manifest file every materialized snapshot has. Its absence means the
+/// directory is not a snapshot at all (an empty or unrelated `models/` folder).
+const SNAPSHOT_MARKER: &str = "config.json";
+
+/// Single-file weight name used by non-sharded snapshots (no shard index).
+const SINGLE_WEIGHT_FILE: &str = "model.safetensors";
+
+/// Sharded-weight manifest name.
+const SHARD_INDEX_FILE: &str = "model.safetensors.index.json";
+
+/// Offline completeness verdict for a candidate local snapshot directory,
+/// produced by [`classify_snapshot`].
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum SnapshotState {
+    /// `config.json` is present and every weight file the snapshot needs — each
+    /// shard named by a local `model.safetensors.index.json`, or at least one
+    /// non-zero `*.safetensors` for a single-file / repackaged layout — is
+    /// present and non-zero. Safe to hand to the model loader.
+    Complete,
+    /// `config.json` is present but one or more weight shards named by the local
+    /// index are missing or zero-byte: the hallmark of an interrupted download.
+    /// Carries the missing shard names for the re-fetch message.
+    Incomplete { missing: Vec<String> },
+    /// Not a materialized snapshot at all (not a directory, or no `config.json`).
+    Absent,
+}
+
+/// Classify a candidate snapshot directory against the full weight set — the
+/// load-path completeness gate for issue #465.
+///
+/// This is the offline counterpart of the downloader's own `snapshot_complete`
+/// (which keys on the network-fetched wanted-set): here the expected weights are
+/// derived from the snapshot's own `model.safetensors.index.json` so an
+/// interrupted download (config.json + only some shards) is caught before the
+/// loader is handed a doomed path.
+pub(super) fn classify_snapshot(dir: &Path) -> SnapshotState {
+    if !dir.is_dir() || !dir.join(SNAPSHOT_MARKER).exists() {
+        return SnapshotState::Absent;
+    }
+    match mlxcel_core::weights::parse_shard_index(dir) {
+        // Sharded layout: the index names every weight shard.
+        Ok(Some(shards)) => classify_sharded(dir, &shards),
+        // No index: single-file (or already-globbed) layout. Complete as long as
+        // at least one non-zero `*.safetensors` is present.
+        Ok(None) => {
+            if has_nonzero_safetensors(dir) {
+                SnapshotState::Complete
+            } else {
+                SnapshotState::Incomplete {
+                    missing: vec![SINGLE_WEIGHT_FILE.to_string()],
+                }
+            }
+        }
+        // The index exists but does not parse — often a truncated/zero-byte
+        // index from an interrupted download. Defer to the loader's glob when
+        // any weights are present; otherwise there is nothing loadable.
+        Err(_) => {
+            if has_nonzero_safetensors(dir) {
+                SnapshotState::Complete
+            } else {
+                SnapshotState::Incomplete {
+                    missing: vec![SHARD_INDEX_FILE.to_string()],
+                }
+            }
+        }
+    }
+}
+
+/// Completeness verdict for a sharded snapshot given the shard names its index
+/// references.
+fn classify_sharded(dir: &Path, shards: &[String]) -> SnapshotState {
+    let missing: Vec<String> = shards
+        .iter()
+        .filter(|name| !shard_present(dir, name))
+        .cloned()
+        .collect();
+    if missing.is_empty() {
+        return SnapshotState::Complete;
+    }
+    // Some index shards are absent. Distinguish an interrupted download (the
+    // on-disk shards are a subset of the index) from a repackaged mlx-community
+    // quant whose stale full-precision index names shards that never matched the
+    // on-disk quant files. In the latter case the directory holds a
+    // `*.safetensors` the index does NOT name; the loader globs those and loads
+    // fine, so we must not re-fetch.
+    let indexed: HashSet<&str> = shards.iter().map(String::as_str).collect();
+    let has_unindexed = on_disk_safetensors(dir)
+        .iter()
+        .any(|name| !indexed.contains(name.as_str()));
+    if has_unindexed {
+        SnapshotState::Complete
+    } else {
+        SnapshotState::Incomplete { missing }
+    }
+}
+
+/// True when `name` is a plain shard filename that exists in `dir` and is
+/// non-zero. Non-plain names (separators, traversal) can never be a legitimate
+/// on-disk shard and are treated as missing — mirroring the loader's
+/// `validate_index_shards` guard so a malicious index cannot point the check at
+/// an out-of-directory file.
+fn shard_present(dir: &Path, name: &str) -> bool {
+    if name.is_empty()
+        || name.contains('/')
+        || name.contains('\\')
+        || Path::new(name).components().count() != 1
+    {
+        return false;
+    }
+    super::file_exists_nonempty(&dir.join(name))
+}
+
+/// The non-zero `*.safetensors` filenames directly inside `dir` (non-recursive).
+/// The shard index (`*.safetensors.index.json`) is excluded because its
+/// extension is `json`, not `safetensors`.
+fn on_disk_safetensors(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "safetensors")
+            && super::file_exists_nonempty(&path)
+            && let Some(name) = path.file_name().and_then(|n| n.to_str())
+        {
+            out.push(name.to_string());
+        }
+    }
+    out
+}
+
+/// True when `dir` holds at least one non-zero `*.safetensors` file.
+fn has_nonzero_safetensors(dir: &Path) -> bool {
+    !on_disk_safetensors(dir).is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    fn write(path: &Path, bytes: &[u8]) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, bytes).unwrap();
+    }
+
+    /// Build a `model.safetensors.index.json` whose `weight_map` references the
+    /// given shard filenames.
+    fn write_index(dir: &Path, shards: &[&str]) {
+        let entries: Vec<String> = shards
+            .iter()
+            .enumerate()
+            .map(|(i, s)| format!("\"tensor.{i}\": \"{s}\""))
+            .collect();
+        let json = format!("{{\"weight_map\": {{{}}}}}", entries.join(", "));
+        write(&dir.join(SHARD_INDEX_FILE), json.as_bytes());
+    }
+
+    #[test]
+    fn absent_when_not_a_dir_or_no_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Missing entirely.
+        assert_eq!(
+            classify_snapshot(&tmp.path().join("nope")),
+            SnapshotState::Absent
+        );
+        // Directory without config.json.
+        let dir = tmp.path().join("snap");
+        fs::create_dir_all(&dir).unwrap();
+        write(&dir.join("model.safetensors"), b"w");
+        assert_eq!(classify_snapshot(&dir), SnapshotState::Absent);
+        // A plain file path (config marker check on a file is Absent).
+        let file = tmp.path().join("file");
+        write(&file, b"x");
+        assert_eq!(classify_snapshot(&file), SnapshotState::Absent);
+    }
+
+    #[test]
+    fn complete_single_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("snap");
+        write(&dir.join("config.json"), b"{}");
+        write(&dir.join("model.safetensors"), b"weights");
+        assert_eq!(classify_snapshot(&dir), SnapshotState::Complete);
+    }
+
+    #[test]
+    fn incomplete_single_file_no_weights() {
+        // config.json present but no safetensors and no index: an interrupted
+        // download that stopped right after config.json.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("snap");
+        write(&dir.join("config.json"), b"{}");
+        assert_eq!(
+            classify_snapshot(&dir),
+            SnapshotState::Incomplete {
+                missing: vec![SINGLE_WEIGHT_FILE.to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn complete_sharded_all_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("snap");
+        write(&dir.join("config.json"), b"{}");
+        write_index(
+            &dir,
+            &[
+                "model-00001-of-00002.safetensors",
+                "model-00002-of-00002.safetensors",
+            ],
+        );
+        write(&dir.join("model-00001-of-00002.safetensors"), b"a");
+        write(&dir.join("model-00002-of-00002.safetensors"), b"b");
+        assert_eq!(classify_snapshot(&dir), SnapshotState::Complete);
+    }
+
+    #[test]
+    fn incomplete_sharded_missing_shard() {
+        // The reported bug: index references N shards, only some on disk, and
+        // the on-disk shards are a subset of the index (interrupted download).
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("snap");
+        write(&dir.join("config.json"), b"{}");
+        write_index(
+            &dir,
+            &[
+                "model-00001-of-00002.safetensors",
+                "model-00002-of-00002.safetensors",
+            ],
+        );
+        write(&dir.join("model-00001-of-00002.safetensors"), b"a");
+        // model-00002 missing.
+        assert_eq!(
+            classify_snapshot(&dir),
+            SnapshotState::Incomplete {
+                missing: vec!["model-00002-of-00002.safetensors".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn incomplete_sharded_zero_byte_shard() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("snap");
+        write(&dir.join("config.json"), b"{}");
+        write_index(
+            &dir,
+            &[
+                "model-00001-of-00002.safetensors",
+                "model-00002-of-00002.safetensors",
+            ],
+        );
+        write(&dir.join("model-00001-of-00002.safetensors"), b"a");
+        // Present but zero bytes → still counts as missing.
+        write(&dir.join("model-00002-of-00002.safetensors"), b"");
+        assert_eq!(
+            classify_snapshot(&dir),
+            SnapshotState::Incomplete {
+                missing: vec!["model-00002-of-00002.safetensors".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn complete_stale_index_repackaged_quant() {
+        // A repackaged mlx-community quant: the shipped index still names the
+        // original full-precision shards (absent), but the directory holds a
+        // differently-named quant file. Must NOT be flagged incomplete — the
+        // loader globs it and loads fine.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("snap");
+        write(&dir.join("config.json"), b"{}");
+        write_index(
+            &dir,
+            &[
+                "model-00001-of-00002.safetensors",
+                "model-00002-of-00002.safetensors",
+            ],
+        );
+        // On-disk file is NOT named by the (stale) index.
+        write(&dir.join("model.safetensors"), b"quant");
+        assert_eq!(classify_snapshot(&dir), SnapshotState::Complete);
+    }
+
+    #[test]
+    fn incomplete_malformed_index_no_weights() {
+        // A truncated/zero-byte index with nothing else loadable → re-fetch.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("snap");
+        write(&dir.join("config.json"), b"{}");
+        write(&dir.join(SHARD_INDEX_FILE), b""); // unparseable
+        assert_eq!(
+            classify_snapshot(&dir),
+            SnapshotState::Incomplete {
+                missing: vec![SHARD_INDEX_FILE.to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn complete_malformed_index_with_weights() {
+        // A malformed index but with loadable weights present: defer to the
+        // loader's glob rather than re-fetching a working model.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("snap");
+        write(&dir.join("config.json"), b"{}");
+        write(&dir.join(SHARD_INDEX_FILE), b"{ this is not json");
+        write(&dir.join("model.safetensors"), b"weights");
+        assert_eq!(classify_snapshot(&dir), SnapshotState::Complete);
+    }
+
+    #[test]
+    fn traversal_shard_name_counts_as_missing() {
+        // A malicious index naming a shard outside the directory must never be
+        // counted as present, even if such a file exists elsewhere.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("snap");
+        write(&dir.join("config.json"), b"{}");
+        // The out-of-dir file the malicious index tries to point at.
+        write(&tmp.path().join("outside.safetensors"), b"secret");
+        write_index(&dir, &["../outside.safetensors"]);
+        assert_eq!(
+            classify_snapshot(&dir),
+            SnapshotState::Incomplete {
+                missing: vec!["../outside.safetensors".to_string()],
+            }
+        );
+    }
+}

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -77,6 +77,7 @@
 //!   before the first byte streams.
 
 mod cli;
+mod completeness;
 mod errors;
 mod filters;
 mod progress;

--- a/src/downloader/resolver.rs
+++ b/src/downloader/resolver.rs
@@ -51,17 +51,23 @@
 //! 4. **Neither** — a clear, actionable error (not an existing path, not a
 //!    valid `owner/name` repo-id, and not a bare single segment).
 //!
-//! The "completeness" gate for the legacy and store directories keys on a
-//! present `config.json`, mirroring the downloader's own `snapshot_complete`
-//! check and [`store::hf_cache_snapshot`]'s gate. A directory that exists but
-//! lacks `config.json` (e.g. a half-written or unrelated `models/` folder) is
-//! treated as a miss so the resolver never hands a model loader a path that
-//! will fail to load.
+//! The "completeness" gate for the legacy and store directories verifies the
+//! full weight set, not just `config.json` (issue #465): every shard named by a
+//! local `model.safetensors.index.json` (or, for a single-file / repackaged
+//! layout, at least one non-zero `*.safetensors`) must be present and non-zero.
+//! An interrupted download that fetched `config.json` and only some shards is
+//! therefore treated as a miss, and the resolver re-fetches it — resuming the
+//! partial snapshot through the shared downloader — instead of handing the
+//! loader a path that dies with `Weight not found`. See [`super::completeness`]
+//! for the classifier. The read-only HuggingFace cache reuse
+//! ([`store::hf_cache_snapshot`]) keeps its own `config.json` gate since mlxcel
+//! never writes into that externally-managed layout.
 
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 
+use super::completeness::{SnapshotState, classify_snapshot};
 use super::filters::repo_basename;
 use super::store;
 use super::{DownloadOptions, download_repo};
@@ -70,11 +76,6 @@ use super::{DownloadOptions, download_repo};
 /// (epic #92, issue #93). A repo-id whose basename already lives under
 /// `./models/<basename>` is reused from there for back-compat.
 const LEGACY_MODELS_DIR: &str = "models";
-
-/// File whose presence marks a model snapshot directory as complete enough to
-/// load. Mirrors the downloader's `snapshot_complete` gate and
-/// [`store::hf_cache_snapshot`], both of which key on `config.json`.
-const SNAPSHOT_MARKER: &str = "config.json";
 
 /// Default HuggingFace org prepended to a bare, prefix-less model name
 /// (issue #112) when `MLXCEL_DEFAULT_ORG` is unset or empty.
@@ -163,35 +164,56 @@ fn resolve_repo_id(
 ) -> Result<PathBuf> {
     let cwd_models = PathBuf::from(LEGACY_MODELS_DIR);
 
-    // 2a–2c: reuse an existing snapshot without re-downloading.
+    // 2a–2c: reuse an existing COMPLETE snapshot without re-downloading.
     if let Some(hit) = locate_cached_snapshot(repo_id, revision, &cwd_models, models_dir) {
         return Ok(hit);
     }
 
-    // 2d: cache miss → download into the mlxcel global store (local_dir: None),
-    //     honoring the --models-dir override for the destination root, then
-    //     re-locate where it landed. We reuse the shared hardened downloader
-    //     rather than forking it, so allow-list filtering, token handling,
-    //     progress UX, and HF-cache reuse all stay in lock-step with
-    //     `mlxcel download`.
-    println!("[mlxcel] model '{repo_id}' not found locally; downloading into the mlxcel store...");
-    download_repo(DownloadOptions {
-        repo_id: repo_id.to_string(),
-        local_dir: None,
-        models_dir: models_dir.map(Path::to_path_buf),
-        revision: revision.map(str::to_string),
-        token: None,
-        force: false,
-    })
-    .map_err(|err| anyhow!("failed to download model '{repo_id}': {err}"))?;
+    // 2d: no complete snapshot anywhere. A miss is one of two things: nothing on
+    // disk, or a PARTIAL mlxcel snapshot left by an interrupted download
+    // (config.json + only some shards). We name the latter explicitly — instead
+    // of letting the loader die later with a bare `Weight not found` (issue
+    // #465) — then recover through the shared hardened downloader either way.
+    // Routing the destination back through `download_repo` RESUMES cheaply: it
+    // skips files already present and non-zero and re-fetches only what is
+    // missing. Reusing it (rather than forking) keeps allow-list filtering,
+    // token handling, progress UX, and HF-cache reuse in lock-step with
+    // `mlxcel download`.
+    let store_dest = store::model_dir_with_override(repo_id, models_dir);
+    match store_dest.as_deref().map(classify_snapshot) {
+        Some(SnapshotState::Incomplete { missing }) => {
+            // `store_dest` is Some in this arm, so the unwrap cannot panic.
+            report_incomplete_snapshot(store_dest.as_deref().unwrap_or(&cwd_models), &missing);
+        }
+        _ => announce_fresh_download(repo_id),
+    }
 
-    // After a successful download the snapshot is reachable via either the HF
-    // cache (download_repo reuses an existing HF snapshot read-only) or the
-    // mlxcel store. Re-run the same lookup to return the real landing path.
+    download_repo(download_options(repo_id, revision, models_dir, false))
+        .map_err(|err| anyhow!("failed to download model '{repo_id}': {err}"))?;
+
+    // After a successful download/resume the snapshot is reachable via either the
+    // HF cache (download_repo reuses an existing HF snapshot read-only) or the
+    // mlxcel store. Re-run the same completeness-gated lookup to return the real
+    // landing path.
+    if let Some(hit) = locate_cached_snapshot(repo_id, revision, &cwd_models, models_dir) {
+        return Ok(hit);
+    }
+
+    // The resume did not yield a loadable snapshot (e.g. a present-but-corrupt,
+    // non-zero file the resume skipped). Fall back to the "clean re-download"
+    // recovery from issue #465: force a full re-fetch of every file, then load.
+    eprintln!(
+        "[mlxcel] snapshot for '{repo_id}' still incomplete after resume; \
+         re-fetching every file..."
+    );
+    download_repo(download_options(repo_id, revision, models_dir, true))
+        .map_err(|err| anyhow!("failed to re-download model '{repo_id}': {err}"))?;
+
     locate_cached_snapshot(repo_id, revision, &cwd_models, models_dir).ok_or_else(|| {
         anyhow!(
-            "downloaded model '{repo_id}' but could not locate its snapshot \
-             afterwards (expected under the mlxcel store or HuggingFace cache)"
+            "downloaded model '{repo_id}' but its snapshot is still incomplete \
+             afterwards (expected under the mlxcel store or HuggingFace cache); \
+             remove the partial snapshot and retry"
         )
     })
 }
@@ -212,22 +234,26 @@ fn locate_cached_snapshot(
     models_dir: Option<&Path>,
 ) -> Option<PathBuf> {
     // 2a. Legacy per-CWD `./models/<basename>` (pre-#93 default location).
+    //     Only a fully-materialized snapshot is a hit; an interrupted partial
+    //     (config.json + only some shards) is skipped so 2d re-fetches it.
     let legacy = cwd_models.join(repo_basename(repo_id));
-    if snapshot_is_complete(&legacy) {
+    if matches!(classify_snapshot(&legacy), SnapshotState::Complete) {
         return Some(legacy);
     }
 
     // 2b. Existing HuggingFace Hub cache snapshot (read-only reuse). Its own
-    //     completeness gate already requires a `config.json`.
+    //     completeness gate keys on `config.json`; mlxcel never writes into that
+    //     externally-managed layout, so it is left to HuggingFace tooling.
     if let Some(hf) = store::hf_cache_snapshot(repo_id, revision) {
         return Some(hf);
     }
 
     // 2c. mlxcel global store under the override-aware models root: the
     //     `--models-dir` / `MLXCEL_MODELS_DIR` root directly, or the legacy
-    //     `${MLXCEL_CACHE_DIR}/models/<owner>/<name>`.
+    //     `${MLXCEL_CACHE_DIR}/models/<owner>/<name>`. Same full-weight gate as
+    //     2a so an interrupted store download is re-fetched, not loaded.
     if let Some(store_dir) = store::model_dir_with_override(repo_id, models_dir)
-        && snapshot_is_complete(&store_dir)
+        && matches!(classify_snapshot(&store_dir), SnapshotState::Complete)
     {
         return Some(store_dir);
     }
@@ -235,14 +261,47 @@ fn locate_cached_snapshot(
     None
 }
 
-/// True when `dir` is an existing directory containing a [`SNAPSHOT_MARKER`]
-/// (`config.json`).
-///
-/// Used as the completeness gate for the legacy CWD and mlxcel-store
-/// directories so a half-written or unrelated `models/` folder is treated as a
-/// miss instead of being handed to a model loader that would then fail.
-fn snapshot_is_complete(dir: &Path) -> bool {
-    dir.is_dir() && dir.join(SNAPSHOT_MARKER).exists()
+/// Emit the issue #465 "incomplete download detected" line naming the condition
+/// and the re-fetch action (a bounded preview of the missing files).
+fn report_incomplete_snapshot(dir: &Path, missing: &[String]) {
+    const PREVIEW: usize = 6;
+    let shown: Vec<&str> = missing.iter().take(PREVIEW).map(String::as_str).collect();
+    let extra = missing.len().saturating_sub(shown.len());
+    let more = if extra > 0 {
+        format!(", +{extra} more")
+    } else {
+        String::new()
+    };
+    println!(
+        "[mlxcel] incomplete download detected at {}: re-fetching {} missing file(s): {}{}",
+        dir.display(),
+        missing.len(),
+        shown.join(", "),
+        more,
+    );
+}
+
+/// Print the "not found locally; downloading" line for a genuine cache miss.
+fn announce_fresh_download(repo_id: &str) {
+    println!("[mlxcel] model '{repo_id}' not found locally; downloading into the mlxcel store...");
+}
+
+/// Build [`DownloadOptions`] for the resolver's store-destination download,
+/// threading the `--models-dir` override and the resume/clean `force` flag.
+fn download_options(
+    repo_id: &str,
+    revision: Option<&str>,
+    models_dir: Option<&Path>,
+    force: bool,
+) -> DownloadOptions {
+    DownloadOptions {
+        repo_id: repo_id.to_string(),
+        local_dir: None,
+        models_dir: models_dir.map(Path::to_path_buf),
+        revision: revision.map(str::to_string),
+        token: None,
+        force,
+    }
 }
 
 /// True when `value` has HuggingFace `owner/name` repo-id shape:

--- a/src/downloader/resolver_tests.rs
+++ b/src/downloader/resolver_tests.rs
@@ -37,10 +37,14 @@ fn restore_env(key: &str, prev: Option<String>) {
     }
 }
 
-/// Create a complete (loadable) snapshot directory: `dir` plus a `config.json`.
+/// Create a complete (loadable) snapshot directory: `dir` plus a `config.json`
+/// and a non-zero single-file `model.safetensors`. The weight file is required
+/// for the issue #465 full-weight completeness gate to treat the snapshot as
+/// complete (a bare `config.json` is now an interrupted download, not a hit).
 fn make_complete_snapshot(dir: &Path) {
     fs::create_dir_all(dir).unwrap();
     fs::write(dir.join("config.json"), b"{}").unwrap();
+    fs::write(dir.join("model.safetensors"), b"weights").unwrap();
 }
 
 // ── is_repo_id_shape ────────────────────────────────────────────────────────
@@ -83,30 +87,6 @@ fn repo_id_shape_matches_locked_dot_owner_spec() {
     // repo-id branch (and then fail at the HF API as a malformed owner) — an
     // acceptable user error, not a back-compat regression.
     assert!(is_repo_id_shape("./models"));
-}
-
-// ── snapshot_is_complete ────────────────────────────────────────────────────
-
-#[test]
-fn snapshot_is_complete_requires_config_json() {
-    let tmp = tempfile::tempdir().unwrap();
-    let dir = tmp.path().join("snap");
-    // Missing entirely.
-    assert!(!snapshot_is_complete(&dir));
-    // Exists but no config.json → still incomplete (would fail to load).
-    fs::create_dir_all(&dir).unwrap();
-    assert!(!snapshot_is_complete(&dir));
-    // With config.json → complete.
-    fs::write(dir.join("config.json"), b"{}").unwrap();
-    assert!(snapshot_is_complete(&dir));
-}
-
-#[test]
-fn snapshot_is_complete_false_for_file_path() {
-    let tmp = tempfile::tempdir().unwrap();
-    let file = tmp.path().join("not-a-dir");
-    fs::write(&file, b"x").unwrap();
-    assert!(!snapshot_is_complete(&file));
 }
 
 // ── resolve_model_source: branch 1 (existing path, byte-identical) ───────────
@@ -301,6 +281,50 @@ fn locate_uses_mlxcel_store_when_complete() {
     restore_env("HF_HOME", prev_hf_home);
 
     assert_eq!(hit, Some(store_dir));
+}
+
+/// Regression (issue #465): an interrupted download leaves the mlxcel store
+/// snapshot with `config.json` + an index referencing two shards but only one
+/// shard on disk. The old weak gate (config.json present) returned it and the
+/// loader then died with `Weight not found`; the full-weight gate must instead
+/// treat it as a miss so `resolve_repo_id` re-fetches it.
+#[test]
+fn locate_ignores_incomplete_store_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store_root = tmp.path().join("store");
+    let store_dir = store_root.join("models").join("owner").join("model");
+    fs::create_dir_all(&store_dir).unwrap();
+    fs::write(store_dir.join("config.json"), b"{}").unwrap();
+    fs::write(
+        store_dir.join("model.safetensors.index.json"),
+        br#"{"weight_map": {"a": "model-00001-of-00002.safetensors", "b": "model-00002-of-00002.safetensors"}}"#,
+    )
+    .unwrap();
+    // Only the first shard landed before the download was interrupted.
+    fs::write(store_dir.join("model-00001-of-00002.safetensors"), b"a").unwrap();
+
+    // Empty legacy + empty HF cache so only the (incomplete) store could hit.
+    let cwd_models = tmp.path().join("no-models");
+    let empty_hf = tmp.path().join("hf");
+    fs::create_dir_all(&empty_hf).unwrap();
+
+    let _guard = env_lock();
+    let prev_cache_dir = std::env::var("MLXCEL_CACHE_DIR").ok();
+    let prev_hf_cache = std::env::var("HF_HUB_CACHE").ok();
+    let prev_hf_home = std::env::var("HF_HOME").ok();
+    unsafe {
+        std::env::set_var("MLXCEL_CACHE_DIR", &store_root);
+        std::env::set_var("HF_HUB_CACHE", &empty_hf);
+        std::env::remove_var("HF_HOME");
+    }
+
+    let hit = locate_cached_snapshot("owner/model", None, &cwd_models, None);
+
+    restore_env("MLXCEL_CACHE_DIR", prev_cache_dir);
+    restore_env("HF_HUB_CACHE", prev_hf_cache);
+    restore_env("HF_HOME", prev_hf_home);
+
+    assert_eq!(hit, None, "an interrupted store snapshot must not be a hit");
 }
 
 // ── locate_cached_snapshot: --models-dir override (issue #107) ───────────────


### PR DESCRIPTION
## Summary

An interrupted model download leaves a partial snapshot (config.json plus only some safetensors shards). The resolver reused it after only checking config.json presence, so `mlxcel run <repo-id>` (and `mlxcel serve` / `mlxcel-server` auto-download) loaded the partial snapshot and died with a bare `Weight not found` instead of noticing the snapshot was incomplete and re-fetching it. This strengthens the load/resolve gate to verify the full weight set and to resume the download on incompleteness.

## Root cause

The loader's `collect_shard_paths` has a stale-index tolerance (for repackaged mlx-community quants): when the `model.safetensors.index.json` references shards not on disk but any `*.safetensors` exists, it globs the present shards and loads them. For an interrupted download that has only some shards, this loads the partial set and then fails later at the first missing tensor with `Weight not found`, masking the real cause. The resolver must therefore detect incompleteness itself, and must distinguish an interrupted download from a legitimately repackaged quant.

## What changed

- Add `src/downloader/completeness.rs`: an offline `classify_snapshot` gate (`Complete` / `Incomplete { missing }` / `Absent`) that reuses `mlxcel_core::weights::parse_shard_index` to derive the expected weight set from the snapshot's own index. A sharded snapshot is `Incomplete` only when the on-disk shards are a subset of the index (an interrupted download); a repackaged quant whose stale full-precision index no longer names the on-disk files (there is an unindexed `*.safetensors`) is `Complete` and never re-fetched. A malformed/truncated index defers to the loader glob when weights exist, else re-fetches. A traversal shard name is treated as missing.
- `src/downloader/resolver.rs`: the legacy (2a) and mlxcel-store (2c) reuse gates now require `classify_snapshot(...) == Complete` instead of only `config.json` presence, so an interrupted store snapshot is treated as a miss. `resolve_repo_id` names the condition ("incomplete download detected at <path>: re-fetching N missing file(s): ...") and resumes through the shared `download_repo` (which skips complete files and re-fetches only what is missing), falling back to a forced clean re-download, then loads. The read-only HuggingFace cache reuse keeps its own config.json gate since mlxcel never writes into that externally-managed layout.
- `src/downloader/mod.rs`: register the `completeness` module.
- `src/downloader/resolver_tests.rs`: make the fixture realistic (a complete snapshot now has a weight file), drop the two weak-gate tests (their intent moved to the classifier), and add `locate_ignores_incomplete_store_dir` asserting an interrupted store snapshot is no longer a cache hit.
- `CHANGELOG.md`: record the fix under Unreleased.

## Coverage of `serve` / `mlxcel-server` (relates to #463)

Every subcommand (`run`, `generate`, `chat`, `inspect`, `serve`) and the `mlxcel-server` binary resolve `-m` through `resolve_model_source_with_override`, so the single resolver-level gate covers the server auto-download path as well.

## Test plan

- [x] `cargo test --lib downloader::completeness` (10 new classifier tests: complete/incomplete single-file and sharded, zero-byte shard, stale-index repackaged quant reused, malformed index with/without weights, traversal shard name)
- [x] `cargo test --lib downloader::` (122 passed, 0 failed, including the new `locate_ignores_incomplete_store_dir` regression)
- [x] `cargo clippy --lib --tests -- -D warnings` (clean)
- [x] `cargo fmt` and `cargo check --bins` (clean)

Closes #465
