### PR TITLE
fix: validate external quant scheme and surface unclosed thinking

### DIFF
--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -232,29 +232,29 @@ impl QuantizedEmbedding {
         // biases may not exist for mxfp4/nvfp4/mxfp8 modes
         let biases = weights.get(&biases_name).map(|w| ffi::copy(w));
 
-        // Reconcile caller-supplied bits with the actual tensor shapes, the same
-        // way UnifiedLinear does. Mixed-precision exports quantize the embedding
-        // at a different bit width than the model's top-level `config.quantization`
-        // (e.g. diffusiongemma / gemma4 store embed_tokens, attention, and MLP at
-        // 8-bit while the top-level default is 4-bit). Without this, the embedding
-        // lookup, the tied-embedding lm_head, and dequantized_weight() all
-        // dequantize with the wrong bits and abort. Uniform-quant checkpoints are
-        // unaffected (inference returns the caller bits unchanged).
-        let effective_bits = if mode == "affine" {
-            let w_shape = ffi::array_shape(&weight);
-            let s_shape = ffi::array_shape(&scales);
-            infer_quantization_bits(&w_shape, &s_shape, group_size, bits)
-                .map_err(|e| format!("{} (prefix: {})", e, prefix))?
-        } else {
-            bits
-        };
+        // Reconcile caller-supplied quant params with the actual tensor shapes,
+        // the same way UnifiedLinear does. Mixed-precision exports quantize the
+        // embedding at a different bit width than the model's top-level
+        // `config.quantization` (e.g. diffusiongemma / gemma4 store embed_tokens,
+        // attention, and MLP at 8-bit while the top-level default is 4-bit).
+        // Without this, the embedding lookup, the tied-embedding lm_head, and
+        // dequantized_weight() all dequantize with the wrong params and abort.
+        // Uniform-quant checkpoints are unaffected (reconciliation is a no-op and
+        // emits no warning); a genuine mismatch is surfaced via the shared
+        // warning so a divergent external packing (issue #467) is not silently
+        // mis-loaded.
+        let w_shape = ffi::array_shape(&weight);
+        let s_shape = ffi::array_shape(&scales);
+        let layout = reconcile_quantization_layout_logged(
+            &w_shape, &s_shape, group_size, bits, mode, prefix,
+        )?;
 
         Ok(Self {
             weight,
             scales,
             biases,
-            group_size,
-            bits: effective_bits,
+            group_size: layout.group_size,
+            bits: layout.bits,
             mode: mode.to_string(),
         })
     }
@@ -769,6 +769,144 @@ fn infer_quantization_bits(
     Ok(inferred_bits)
 }
 
+/// Reconciled quantization parameters plus whether reconciliation altered the
+/// caller-declared values.
+///
+/// `reconciled == true` means the on-disk tensor layout did not match the
+/// declared `group_size` / `bits`, so the loader substituted shape-derived
+/// values. Per issue #467, callers surface this (a load-time `tracing::warn!`)
+/// instead of silently overriding the declared metadata: a divergent external
+/// packing (e.g. OptiQ) that is quietly reconciled dequantizes with the wrong
+/// parameters and decodes to degenerate, repeating output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReconciledQuant {
+    pub bits: i32,
+    pub group_size: i32,
+    pub reconciled: bool,
+}
+
+/// Validate and reconcile caller-declared quantization params against the
+/// observed `weight` / `scales` tensor shapes for `mode`.
+///
+/// MLX affine and block-float quantization obey
+/// `packed_in * 32 == bits * num_groups * group_size`, where `packed_in` is the
+/// last dim of `weight` and `num_groups` the last dim of `scales`. This helper:
+///
+/// * returns the declared params unchanged (`reconciled = false`) when they
+///   already satisfy the invariant — the common uniform-quant case,
+/// * reconciles one divergent axis (`reconciled = true`) for legitimate
+///   mixed-precision exports: affine trusts `group_size` and re-derives `bits`
+///   (per-path bit overrides, e.g. Qwen3.5/3.6 MoE gates); block-float trusts
+///   the mode-fixed `bits` and re-derives `group_size` (e.g. minicpm-v mxfp4
+///   stored at group_size 32 under a config default of 64),
+/// * returns `Err` with an actionable message when the affine shapes match no
+///   valid bit width — the signature of a misdeclared / unsupported external
+///   packing that must not be dequantized as standard affine and served as
+///   garbage (issue #467, OptiQ).
+///
+/// Pure over shapes so the reconciliation policy is unit-testable without an
+/// MLX backend. `bits != declared` (affine) or `group_size != declared`
+/// (block-float) sets `reconciled`, which the loader turns into a warning.
+pub fn reconcile_quantization_layout(
+    weight_shape: &[i32],
+    scales_shape: &[i32],
+    group_size: i32,
+    bits: i32,
+    mode: &str,
+) -> Result<ReconciledQuant, String> {
+    // Insufficient shape info: trust the caller, mirroring the historical
+    // early-return in `infer_quantization_bits` for empty / scalar shapes.
+    if weight_shape.is_empty() || scales_shape.is_empty() || group_size <= 0 || bits <= 0 {
+        return Ok(ReconciledQuant {
+            bits,
+            group_size,
+            reconciled: false,
+        });
+    }
+    let packed_in = *weight_shape.last().unwrap();
+    let num_groups = *scales_shape.last().unwrap();
+    if packed_in <= 0 || num_groups <= 0 {
+        return Ok(ReconciledQuant {
+            bits,
+            group_size,
+            reconciled: false,
+        });
+    }
+
+    if mode == "affine" {
+        // Trust group_size, re-derive bits. A non-integer or out-of-range bit
+        // width propagates as the hard-fail path (the unsupported-layout guard).
+        let effective_bits = infer_quantization_bits(weight_shape, scales_shape, group_size, bits)?;
+        Ok(ReconciledQuant {
+            bits: effective_bits,
+            group_size,
+            reconciled: effective_bits != bits,
+        })
+    } else {
+        // Block-float (mxfp4 / nvfp4 / mxfp8): bits are fixed by the mode, so
+        // re-derive group_size from in_features = packed_in * (32 / bits) =
+        // num_groups * group_size. Preserve the historical guard/fallback shape
+        // exactly (keep declared group_size when the shapes are unusable), but
+        // flag an inconsistency so the loader surfaces it instead of proceeding
+        // silently.
+        let can_infer = weight_shape.len() >= 2 && scales_shape.len() >= 2 && 32 % bits == 0;
+        if !can_infer {
+            return Ok(ReconciledQuant {
+                bits,
+                group_size,
+                reconciled: false,
+            });
+        }
+        let in_features = packed_in * (32 / bits);
+        if in_features % num_groups == 0 {
+            let effective_group_size = in_features / num_groups;
+            Ok(ReconciledQuant {
+                bits,
+                group_size: effective_group_size,
+                reconciled: effective_group_size != group_size,
+            })
+        } else {
+            Ok(ReconciledQuant {
+                bits,
+                group_size,
+                reconciled: true,
+            })
+        }
+    }
+}
+
+/// Reconcile quant params and emit a load-time warning when the declared
+/// metadata did not match the tensor shapes. Thin wrapper over the pure
+/// [`reconcile_quantization_layout`] so the linear and embedding loaders
+/// surface the same diagnostic instead of silently overriding the config
+/// (issue #467).
+fn reconcile_quantization_layout_logged(
+    weight_shape: &[i32],
+    scales_shape: &[i32],
+    group_size: i32,
+    bits: i32,
+    mode: &str,
+    prefix: &str,
+) -> Result<ReconciledQuant, String> {
+    let layout = reconcile_quantization_layout(weight_shape, scales_shape, group_size, bits, mode)
+        .map_err(|e| format!("{e} (prefix: {prefix})"))?;
+    if layout.reconciled {
+        tracing::warn!(
+            target: "mlxcel::quant",
+            prefix,
+            mode,
+            declared_bits = bits,
+            declared_group_size = group_size,
+            effective_bits = layout.bits,
+            effective_group_size = layout.group_size,
+            "quantized layout does not match declared metadata; using shape-derived \
+             params. If this is an unsupported external quant format (e.g. OptiQ), \
+             decoding may be degenerate."
+        );
+    }
+    Ok(layout)
+}
+
 /// Unified Linear layer that auto-detects quantization
 ///
 /// Checks for `.scales` key in weight map to determine whether to use
@@ -858,29 +996,18 @@ impl UnifiedLinear {
             // group_size from the shapes instead: in_features = packed_in *
             // (32/bits) = num_groups * group_size (e.g. minicpm-v-4.6 mxfp4
             // stores some weights at group_size 32 while config says 64).
-            let (effective_bits, effective_group_size) = if mode == "affine" {
-                let w_shape = ffi::array_shape(&weight);
-                let s_shape = ffi::array_shape(&scales);
-                let eb = infer_quantization_bits(&w_shape, &s_shape, group_size, bits)
-                    .map_err(|e| format!("{} (prefix: {})", e, prefix))?;
-                (eb, group_size)
-            } else {
-                let w_shape = ffi::array_shape(&weight);
-                let s_shape = ffi::array_shape(&scales);
-                let egs = if w_shape.len() >= 2 && s_shape.len() >= 2 && bits > 0 {
-                    let packed_in = *w_shape.last().unwrap();
-                    let num_groups = *s_shape.last().unwrap();
-                    let in_features = packed_in * (32 / bits);
-                    if num_groups > 0 && in_features % num_groups == 0 {
-                        in_features / num_groups
-                    } else {
-                        group_size
-                    }
-                } else {
-                    group_size
-                };
-                (bits, egs)
-            };
+            //
+            // When reconciliation actually changes a value the wrapper emits a
+            // load-time warning instead of silently overriding the declared
+            // metadata, so a divergent external packing (issue #467, OptiQ)
+            // does not quietly dequantize with the wrong params and decode to
+            // degenerate output.
+            let w_shape = ffi::array_shape(&weight);
+            let s_shape = ffi::array_shape(&scales);
+            let layout = reconcile_quantization_layout_logged(
+                &w_shape, &s_shape, group_size, bits, mode, prefix,
+            )?;
+            let (effective_bits, effective_group_size) = (layout.bits, layout.group_size);
 
             let qweight = QuantizedWeight {
                 weight,
@@ -3110,6 +3237,113 @@ mod tests {
             format!("{prefix}.bias"),
             ffi::zeros(&[out_dim], dtype::FLOAT16),
         );
+    }
+
+    // -- quantization layout reconciliation (issue #467) ----------------
+    //
+    // Pure over tensor shapes: `weight = [out, packed_in]`,
+    // `scales = [out, num_groups]`, obeying
+    // `packed_in * 32 == bits * num_groups * group_size`.
+
+    #[test]
+    fn reconcile_affine_consistent_is_noop() {
+        // 4-bit, group_size 64, in_features 128 -> num_groups 2, packed_in 16.
+        // Declared params match the shapes: no reconciliation, no warning.
+        let layout =
+            reconcile_quantization_layout(&[32, 16], &[32, 2], 64, 4, "affine").expect("valid");
+        assert_eq!(layout.bits, 4);
+        assert_eq!(layout.group_size, 64);
+        assert!(!layout.reconciled);
+    }
+
+    #[test]
+    fn reconcile_affine_per_layer_bit_override_flags_reconciled() {
+        // Declared 4-bit but this tensor is genuinely 8-bit (in_features 128,
+        // num_groups 2, packed_in 32) — a legitimate mixed-precision override
+        // (e.g. a MoE router gate). Bits are re-derived to 8 AND the change is
+        // surfaced (reconciled = true) rather than silently applied.
+        let layout =
+            reconcile_quantization_layout(&[32, 32], &[32, 2], 64, 4, "affine").expect("valid");
+        assert_eq!(layout.bits, 8);
+        assert_eq!(layout.group_size, 64);
+        assert!(layout.reconciled);
+    }
+
+    #[test]
+    fn reconcile_affine_group_size_mismatch_is_flagged_not_silent() {
+        // The OptiQ-class failure: config declares group_size 64 / 4-bit but the
+        // tensor is packed at group_size 32 (in_features 128, num_groups 4,
+        // packed_in 16). The old path silently re-derived bits=2 and served
+        // garbage; now the divergence is flagged so the loader warns.
+        let layout =
+            reconcile_quantization_layout(&[32, 16], &[32, 4], 64, 4, "affine").expect("solvable");
+        assert_eq!(layout.bits, 2);
+        assert!(
+            layout.reconciled,
+            "a shape/metadata mismatch must be surfaced, not silently reconciled"
+        );
+    }
+
+    #[test]
+    fn reconcile_affine_invalid_bit_width_is_hard_error() {
+        // packed_in 14, num_groups 1, group_size 64 -> inferred bits 7, which is
+        // not a valid MLX width {2,3,4,5,6,8}. An unsupported/misdeclared layout
+        // must fail loudly instead of dequantizing as if it were standard affine.
+        let err = reconcile_quantization_layout(&[32, 14], &[32, 1], 64, 4, "affine")
+            .expect_err("bits=7 is not a supported width");
+        assert!(err.contains("not in"), "actionable message, got: {err}");
+    }
+
+    #[test]
+    fn reconcile_affine_non_integer_bits_is_hard_error() {
+        // packed_in 17 makes packed_in*32 not divisible by num_groups*group_size,
+        // so no integer bit width fits — reject rather than reconcile.
+        let err = reconcile_quantization_layout(&[32, 17], &[32, 2], 64, 4, "affine")
+            .expect_err("no integer bit width fits these shapes");
+        assert!(
+            err.contains("inconsistency") || err.contains("cannot derive"),
+            "actionable message, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reconcile_block_float_consistent_is_noop() {
+        // mxfp4 (4-bit), group_size 32, in_features 256 -> num_groups 8,
+        // packed_in 32. Declared params match: no reconciliation.
+        let layout =
+            reconcile_quantization_layout(&[64, 32], &[64, 8], 32, 4, "mxfp4").expect("valid");
+        assert_eq!(layout.bits, 4);
+        assert_eq!(layout.group_size, 32);
+        assert!(!layout.reconciled);
+    }
+
+    #[test]
+    fn reconcile_block_float_group_size_override_flags_reconciled() {
+        // minicpm-v-style: config default group_size 64 but this mxfp4 weight is
+        // stored at group_size 32. group_size is re-derived AND surfaced.
+        let layout =
+            reconcile_quantization_layout(&[64, 32], &[64, 8], 64, 4, "mxfp4").expect("valid");
+        assert_eq!(layout.bits, 4);
+        assert_eq!(layout.group_size, 32);
+        assert!(layout.reconciled);
+    }
+
+    #[test]
+    fn reconcile_block_float_inconsistent_shapes_are_flagged() {
+        // num_groups 7 does not divide in_features 256: the historical fallback
+        // keeps the declared group_size, but the mismatch is now surfaced.
+        let layout =
+            reconcile_quantization_layout(&[64, 32], &[64, 7], 64, 4, "mxfp4").expect("no error");
+        assert_eq!(layout.group_size, 64);
+        assert!(layout.reconciled);
+    }
+
+    #[test]
+    fn reconcile_ignores_degenerate_shapes() {
+        // Empty / scalar shapes carry no layout signal: trust the caller.
+        let layout = reconcile_quantization_layout(&[], &[], 64, 4, "affine").expect("noop");
+        assert_eq!((layout.bits, layout.group_size), (4, 64));
+        assert!(!layout.reconciled);
     }
 
     #[test]

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -3343,6 +3343,61 @@ pub(crate) fn slice_layer_input(
     mlxcel_core::squeeze_axis(&sliced, 2)
 }
 
+/// Quantization schemes mlxcel can actually dequantize: MLX-native affine plus
+/// the block-float families. Anything else uses a packing mlxcel does not
+/// implement.
+const SUPPORTED_QUANT_SCHEMES: &[&str] = &["affine", "mxfp4", "nvfp4", "mxfp8"];
+
+/// Validate that a model's declared quantization scheme is one mlxcel supports,
+/// before any weights are loaded (issue #467).
+///
+/// MLX-native quantization records only `{group_size, bits}` (optionally a
+/// `mode` naming a block-float family); it never carries a `quant_method`.
+/// External / QAT formats such as OptiQ, AWQ, or GPTQ tag themselves with a
+/// `quant_method` (or a non-affine `mode`) whose on-disk packing does not match
+/// the affine layout the loader assumes. Dequantizing one as affine collapses
+/// the logits and produces the degenerate, repeating output reported in issue
+/// #467, so reject it here with an actionable message that names the format
+/// instead of serving garbage.
+///
+/// Inspects the top-level and `text_config`-nested `quantization` /
+/// `quantization_config` objects. Pure over the parsed config JSON so the
+/// policy is unit-testable without a model on disk.
+pub(crate) fn validate_quantization_scheme(config: &serde_json::Value) -> Result<(), String> {
+    fn check_obj(obj: &serde_json::Value, location: &str) -> Result<(), String> {
+        for key in ["quant_method", "mode"] {
+            let Some(raw) = obj.get(key).and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let norm = raw.trim().to_ascii_lowercase();
+            if norm.is_empty() || SUPPORTED_QUANT_SCHEMES.contains(&norm.as_str()) {
+                continue;
+            }
+            return Err(format!(
+                "Unsupported quantization scheme '{raw}' declared at {location}.{key}. \
+                 mlxcel supports MLX-native affine and block-float (mxfp4 / nvfp4 / mxfp8) \
+                 quantization only; external formats such as OptiQ / AWQ / GPTQ use a \
+                 different packing that would dequantize to degenerate output. Re-export the \
+                 model to an MLX affine quantization (mlx_lm.convert / mlx-vlm) before serving."
+            ));
+        }
+        Ok(())
+    }
+
+    let null = serde_json::Value::Null;
+    let text_config = config.get("text_config").unwrap_or(&null);
+    for (root, root_name) in [(config, "config"), (text_config, "text_config")] {
+        for qkey in ["quantization", "quantization_config"] {
+            if let Some(obj) = root.get(qkey)
+                && obj.is_object()
+            {
+                check_obj(obj, &format!("{root_name}.{qkey}"))?;
+            }
+        }
+    }
+    Ok(())
+}
+
 pub struct Gemma4Model {
     pub(crate) text_model: Gemma4TextModel,
     pub(crate) config: TextConfig,
@@ -3362,6 +3417,11 @@ impl Gemma4Model {
             .map_err(|e| format!("Failed to parse config.json: {}", e))?;
         let config_value: serde_json::Value = serde_json::from_str(&config_str)
             .map_err(|e| format!("Failed to parse sanitized config.json: {}", e))?;
+
+        // Refuse unsupported external quantization formats (OptiQ / AWQ / GPTQ)
+        // up front rather than dequantizing them as affine and serving
+        // degenerate output (issue #467).
+        validate_quantization_scheme(&config_value)?;
 
         let is_quantized = config_value.get("quantization").is_some()
             || config_value
@@ -3590,6 +3650,11 @@ impl Gemma4StageModel {
             .map_err(|e| format!("Failed to parse config.json: {}", e))?;
         let config_value: serde_json::Value = serde_json::from_str(&config_str)
             .map_err(|e| format!("Failed to parse sanitized config.json: {}", e))?;
+
+        // Refuse unsupported external quantization formats (OptiQ / AWQ / GPTQ)
+        // up front rather than dequantizing them as affine and serving
+        // degenerate output (issue #467).
+        validate_quantization_scheme(&config_value)?;
 
         let is_quantized = config_value.get("quantization").is_some()
             || config_value
@@ -5044,4 +5109,81 @@ mod gemma4_unified_mask_tests {
     // caller's no-trim invariant is additionally pinned in
     // `gemma3::gemma3_mask_tests`. Gemma 4's real-model over-window behaviour is
     // covered by the byte-identical regression on `gemma-4-12b-it-4bit`.
+}
+
+#[cfg(test)]
+mod quant_scheme_tests {
+    use super::validate_quantization_scheme;
+    use serde_json::json;
+
+    #[test]
+    fn accepts_mlx_native_affine_quantization() {
+        // MLX-native quant records only group_size/bits (no quant_method).
+        let cfg = json!({ "quantization": { "group_size": 64, "bits": 4 } });
+        assert!(validate_quantization_scheme(&cfg).is_ok());
+    }
+
+    #[test]
+    fn accepts_absent_quantization() {
+        // Non-quantized model: nothing to validate.
+        let cfg = json!({ "model_type": "gemma4" });
+        assert!(validate_quantization_scheme(&cfg).is_ok());
+    }
+
+    #[test]
+    fn accepts_supported_block_float_mode() {
+        let cfg = json!({ "quantization": { "group_size": 32, "bits": 4, "mode": "mxfp4" } });
+        assert!(validate_quantization_scheme(&cfg).is_ok());
+    }
+
+    #[test]
+    fn rejects_optiq_quant_method_and_names_it() {
+        // The issue #467 model: an OptiQ-tagged quantization must be rejected
+        // with a message that names the offending scheme.
+        let cfg = json!({
+            "quantization": { "group_size": 64, "bits": 4, "quant_method": "optiq" }
+        });
+        let err = validate_quantization_scheme(&cfg).expect_err("OptiQ must be rejected");
+        assert!(
+            err.to_lowercase().contains("optiq"),
+            "message must name the scheme: {err}"
+        );
+        assert!(
+            err.contains("Unsupported quantization scheme"),
+            "actionable message: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_mode() {
+        let cfg = json!({ "quantization": { "group_size": 64, "bits": 4, "mode": "optiq" } });
+        assert!(validate_quantization_scheme(&cfg).is_err());
+    }
+
+    #[test]
+    fn rejects_awq_gptq_quant_method() {
+        for method in ["awq", "gptq", "AWQ"] {
+            let cfg = json!({ "quantization": { "quant_method": method } });
+            assert!(
+                validate_quantization_scheme(&cfg).is_err(),
+                "external method {method} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn detects_scheme_nested_under_text_config() {
+        // VLM configs nest text quantization under text_config.
+        let cfg = json!({
+            "text_config": { "quantization": { "quant_method": "optiq" } }
+        });
+        assert!(validate_quantization_scheme(&cfg).is_err());
+    }
+
+    #[test]
+    fn detects_hf_quantization_config_object() {
+        // HF-style external formats use a `quantization_config` object.
+        let cfg = json!({ "quantization_config": { "quant_method": "gptq", "bits": 4 } });
+        assert!(validate_quantization_scheme(&cfg).is_err());
+    }
 }

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -449,6 +449,22 @@ async fn non_stream_chat_completion(
     // thinking family at once (Qwen `<think>`, Gemma 4 `<|channel>`).
     let reasoning = extract_reasoning_content(&result.text, primed_open_thinking);
 
+    // Issue #467: when the prompt primed an open thinking channel and the model
+    // never emitted its close marker, the whole generation routes to
+    // `reasoning_content` and the user-facing `content` is emptied below.
+    // Surface that here so a broken or degenerate decode (e.g. an unsupported
+    // quantization collapsing into repeating tokens) does not masquerade as a
+    // clean, intentionally-empty response.
+    if primed_thinking_unclosed(&result.text, primed_open_thinking) {
+        tracing::warn!(
+            target: "mlxcel::thinking",
+            completion_tokens = result.completion_tokens as u64,
+            finish_reason = %result.finish_reason,
+            "primed thinking channel never closed: `content` is empty and all output \
+             routed to `reasoning_content`; the decode may be truncated or degenerate"
+        );
+    }
+
     // Try to parse tool calls from the output
     if tool_calls::should_parse_tool_calls(&request) {
         let tools = request.tools.as_deref();
@@ -953,6 +969,27 @@ pub(crate) fn is_prompt_primed_open_thinking(prompt: &str) -> bool {
 /// closed when any of them appears in the raw output.
 const OPEN_THINKING_CLOSE_MARKERS: &[&str] = &["<channel|>", "</think>"];
 
+/// Whether the prompt primed an open thinking block that the raw output never
+/// closed.
+///
+/// True exactly when `primed` is set (the generation prompt ended with an open
+/// thinking marker) and `raw_output` contains none of the close markers
+/// (`<channel|>` for Gemma 4, `</think>` for Qwen-style). In that state the
+/// whole generation is reasoning and the non-streaming `content` is emptied by
+/// [`strip_unclosed_primed_thinking`].
+///
+/// Callers surface this condition (a `tracing::warn!`) instead of returning a
+/// silently-empty `content`, so a broken or degenerate decode that never emits
+/// a close marker (issue #467: an unsupported quantization collapsing into
+/// repeating tokens) does not masquerade as a clean, intentionally-empty
+/// response.
+fn primed_thinking_unclosed(raw_output: &str, primed: bool) -> bool {
+    primed
+        && !OPEN_THINKING_CLOSE_MARKERS
+            .iter()
+            .any(|m| raw_output.contains(m))
+}
+
 /// Strip reasoning content that would otherwise leak when the prompt primed
 /// an open thinking block and the model never emitted its close marker.
 ///
@@ -960,18 +997,15 @@ const OPEN_THINKING_CLOSE_MARKERS: &[&str] = &["<channel|>", "</think>"];
 /// * Returns `content` unchanged when `raw_output` contains any known close
 ///   marker (`<channel|>` for Gemma 4, `</think>` for Qwen-style) — the
 ///   regular parsers already handle that case.
-/// * Returns an empty string when the whole generation was unclosed thinking.
+/// * Returns an empty string when the whole generation was unclosed thinking
+///   (see [`primed_thinking_unclosed`], the shared predicate the caller also
+///   uses to emit the unclosed-thinking warning).
 fn strip_unclosed_primed_thinking(content: String, raw_output: &str, primed: bool) -> String {
-    if !primed {
-        return content;
+    if primed_thinking_unclosed(raw_output, primed) {
+        String::new()
+    } else {
+        content
     }
-    if OPEN_THINKING_CLOSE_MARKERS
-        .iter()
-        .any(|m| raw_output.contains(m))
-    {
-        return content;
-    }
-    String::new()
 }
 
 /// Extract the reasoning / thinking scratchpad from a completed generation by
@@ -1170,6 +1204,58 @@ mod tests {
         assert_eq!(
             strip_unclosed_primed_thinking(content.clone(), raw, false),
             content
+        );
+    }
+
+    // -- primed_thinking_unclosed (issue #467 unclosed-thinking surface) --
+
+    #[test]
+    fn primed_thinking_unclosed_true_when_primed_and_no_close_marker() {
+        // The reported failure shape: primed Gemma 4 channel, degenerate output
+        // with no `<channel|>` close marker anywhere. This is the condition the
+        // non-streaming path warns on instead of silently emptying content.
+        assert!(primed_thinking_unclosed(
+            "1\n//\n same////\n1 uma\n//\n//",
+            true
+        ));
+    }
+
+    #[test]
+    fn primed_thinking_unclosed_false_when_close_marker_present() {
+        // A real close marker (either family) means the block closed normally.
+        assert!(!primed_thinking_unclosed(
+            "thinking<channel|>the answer",
+            true
+        ));
+        assert!(!primed_thinking_unclosed("reasoning</think>done", true));
+    }
+
+    #[test]
+    fn primed_thinking_unclosed_false_when_not_primed() {
+        // Non-primed requests are never flagged, even without a close marker.
+        assert!(!primed_thinking_unclosed(
+            "plain answer with no markers",
+            false
+        ));
+    }
+
+    #[test]
+    fn primed_thinking_unclosed_is_the_content_emptying_predicate() {
+        // The predicate is the single source of truth: it is true exactly when
+        // strip_unclosed_primed_thinking empties content, so the warning and the
+        // emptying can never disagree.
+        let unclosed = "all reasoning, never closed";
+        assert!(primed_thinking_unclosed(unclosed, true));
+        assert_eq!(
+            strip_unclosed_primed_thinking("x".to_string(), unclosed, true),
+            String::new()
+        );
+
+        let closed = "reasoning<channel|>answer";
+        assert!(!primed_thinking_unclosed(closed, true));
+        assert_eq!(
+            strip_unclosed_primed_thinking("answer".to_string(), closed, true),
+            "answer"
         );
     }
 


### PR DESCRIPTION
## Summary

Externally quantized 4-bit Gemma 4 (`gemma-4-31B-it-qat-OptiQ-4bit`) decoded to degenerate, repeating output at `temperature: 0` with every token trapped in `reasoning_content` and empty `content`. Two independent mlxcel paths combined to produce exactly that shape: the quantized loader silently reconciled quantization parameters against tensor shapes with no validation, and the Gemma 4 thinking-channel filter emptied `content` whenever the primed thinking block never closed. This change makes both paths fail loud instead of silent, and adds regression coverage for each.

## What changed

- `src/lib/mlxcel-core/src/layers.rs`: added a pure, unit-testable `reconcile_quantization_layout` (plus `ReconciledQuant`) that validates the declared `bits` / `group_size` against the actual `weight` / `scales` shapes. Both the linear and embedding quantized loaders now route through a shared logged wrapper that emits a load-time `tracing::warn!` when reconciliation changes a value (previously silent) and hard-errors on affine layouts that fit no valid bit width. Correctly-declared uniform checkpoints and legitimate per-layer mixed-precision exports keep their exact effective parameters (no behavior change beyond the added diagnostic).
- `src/models/gemma4.rs`: added `validate_quantization_scheme`, which rejects unsupported external quantization formats (OptiQ / AWQ / GPTQ, detected via a foreign `quant_method` or a non-affine `mode`, at the top level or nested under `text_config` / `quantization_config`) before any weights load, with an actionable message that names the offending scheme. Wired into both `Gemma4Model::load` and `Gemma4StageModel::load`.
- `src/server/routes/chat.rs`: extracted the content-emptying decision into a shared `primed_thinking_unclosed` predicate and emit a structured `tracing::warn!` in the non-streaming path when a primed thinking channel never closes, so a broken or degenerate decode that never emits `<channel|>` / `</think>` no longer masquerades as a clean, intentionally-empty response.

## Notes

- `<|channel>` / `<channel|>` are Gemma 4's deliberate thinking-channel markers, not leaked gpt-oss tokens, and are left intact.
- The OptiQ model is macOS / MLX specific and cannot run on this Linux / CUDA host, so verification is by unit / regression tests over synthetic tensor shapes and synthetic decode streams, per the acceptance criteria.

## Test plan

- [x] `cargo test -p mlxcel-core --features cuda --lib layers::tests::reconcile` (9 new reconciliation tests)
- [x] `cargo test --features cuda --lib server::routes::chat` (22 tests, incl. 4 new `primed_thinking_unclosed` tests)
- [x] `cargo test --features cuda --lib models::gemma4::quant_scheme_tests` (8 new scheme-validation tests)
- [x] `cargo clippy -p mlxcel-core --features cuda --lib --tests -- -D warnings`
- [x] `cargo clippy --features cuda --lib --tests -- -D warnings`

Closes #467
