### PR TITLE
fix(models/kimi-vl): parse real Kimi-VL text config (nullable field)

### DIFF
--- a/src/loading/vlm_kimi_vl.rs
+++ b/src/loading/vlm_kimi_vl.rs
@@ -242,6 +242,42 @@ mod tests {
         mlxcel_core::ones(&[1], mlxcel_core::dtype::FLOAT32)
     }
 
+    /// The real kimi-vl-a3b-thinking checkpoint stores `text_config.q_lora_rank`
+    /// as JSON `null` (the Moonlight-16B backbone projects the query directly).
+    /// This is the exact shape the loader hands to `parse_required_vlm_subconfig`,
+    /// which previously failed with "invalid type: null, expected usize".
+    #[test]
+    fn parses_real_kimi_vl_text_config_with_null_q_lora_rank() {
+        let full_config = serde_json::json!({
+            "model_type": "kimi_vl",
+            "text_config": {
+                "model_type": "deepseek_v3",
+                "vocab_size": 163840,
+                "hidden_size": 2048,
+                "intermediate_size": 11264,
+                "moe_intermediate_size": 1408,
+                "num_hidden_layers": 27,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 16,
+                "n_routed_experts": 64,
+                "n_shared_experts": 2,
+                "kv_lora_rank": 512,
+                "q_lora_rank": null,
+                "qk_rope_head_dim": 64,
+                "v_head_dim": 128,
+                "qk_nope_head_dim": 128,
+                "first_k_dense_replace": 1,
+                "rope_theta": 800000.0
+            }
+        });
+
+        let text_config: DeepSeekV3Config =
+            parse_required_vlm_subconfig(&full_config, "text_config", "Kimi-VL text config")
+                .expect("real Kimi-VL text config must parse");
+        assert_eq!(text_config.q_lora_rank, None);
+        assert_eq!(text_config.num_hidden_layers, 27);
+    }
+
     #[test]
     fn remaps_language_and_vision_prefixes() {
         let mut raw = WeightMap::new();

--- a/src/models/deepseek_v3.rs
+++ b/src/models/deepseek_v3.rs
@@ -52,7 +52,13 @@ pub struct DeepSeekV3Config {
     pub routed_scaling_factor: f32,
 
     pub kv_lora_rank: usize,
-    pub q_lora_rank: usize,
+
+    // `q_lora_rank` is null for backbones that project the query directly
+    // (e.g. the Moonlight-16B text model used by Kimi-VL); a numeric value
+    // selects the LoRA-style q_a_proj -> q_a_layernorm -> q_b_proj chain
+    // (genuine DeepSeek-V3). Accept both null and an absent key.
+    #[serde(default)]
+    pub q_lora_rank: Option<usize>,
     pub qk_rope_head_dim: usize,
     pub v_head_dim: usize,
     pub qk_nope_head_dim: usize,
@@ -188,10 +194,13 @@ impl DeepSeekV3Config {
 
 // DeepSeek-V3 MLA (Multi-head Latent Attention).
 pub struct DeepSeekV3Attention {
-    // Q projection with LoRA
-    pub q_a_proj: UnifiedLinear,
-    pub q_a_layernorm: RMSNorm,
-    pub q_b_proj: UnifiedLinear,
+    // Q projection: either a direct `q_proj` (when `q_lora_rank` is null) or the
+    // LoRA-style chain q_a_proj -> q_a_layernorm -> q_b_proj. Exactly one form is
+    // populated by `from_weights`.
+    pub q_proj: Option<UnifiedLinear>,
+    pub q_a_proj: Option<UnifiedLinear>,
+    pub q_a_layernorm: Option<RMSNorm>,
+    pub q_b_proj: Option<UnifiedLinear>,
 
     // KV projection with compression
     pub kv_a_proj_with_mqa: UnifiedLinear,
@@ -226,10 +235,16 @@ impl DeepSeekV3Attention {
         let b = shape[0];
         let l = shape[1];
 
-        // Compute Q with LoRA: q_a_proj → norm → q_b_proj
-        let q_a = self.q_a_proj.forward(x);
-        let q_a_norm = self.q_a_layernorm.forward(&q_a);
-        let q = self.q_b_proj.forward(&q_a_norm);
+        // Compute Q: direct projection when `q_lora_rank` is null, otherwise the
+        // LoRA-style chain q_a_proj -> q_a_layernorm -> q_b_proj. `from_weights`
+        // guarantees exactly one form is populated.
+        let q = if let Some(ref q_proj) = self.q_proj {
+            q_proj.forward(x)
+        } else {
+            let q_a = self.q_a_proj.as_ref().unwrap().forward(x);
+            let q_a_norm = self.q_a_layernorm.as_ref().unwrap().forward(&q_a);
+            self.q_b_proj.as_ref().unwrap().forward(&q_a_norm)
+        };
 
         // Reshape Q to [batch, seq, heads, head_dim] then transpose
         let q = mlxcel_core::reshape(&q, &[b, l, self.num_heads, self.q_head_dim]);
@@ -345,18 +360,42 @@ impl DeepSeekV3Attention {
         let bits = args.bits();
         let q_head_dim = args.q_head_dim() as i32;
 
-        let q_a_proj = UnifiedLinear::from_weights(
-            weights,
-            &format!("{}.q_a_proj", prefix),
-            group_size,
-            bits,
-        )?;
-        let q_b_proj = UnifiedLinear::from_weights(
-            weights,
-            &format!("{}.q_b_proj", prefix),
-            group_size,
-            bits,
-        )?;
+        // Q projection: a null `q_lora_rank` selects the direct `q_proj` weight
+        // (Moonlight-16B / Kimi-VL backbone); a numeric value selects the
+        // LoRA-style q_a_proj -> q_a_layernorm -> q_b_proj chain (DeepSeek-V3).
+        let (q_proj, q_a_proj, q_a_layernorm, q_b_proj) = if args.q_lora_rank.is_none() {
+            (
+                Some(UnifiedLinear::from_weights(
+                    weights,
+                    &format!("{}.q_proj", prefix),
+                    group_size,
+                    bits,
+                )?),
+                None,
+                None,
+                None,
+            )
+        } else {
+            (
+                None,
+                Some(UnifiedLinear::from_weights(
+                    weights,
+                    &format!("{}.q_a_proj", prefix),
+                    group_size,
+                    bits,
+                )?),
+                Some(RMSNorm::new(
+                    get_weight_copy(weights, &format!("{}.q_a_layernorm.weight", prefix))?,
+                    1e-6,
+                )),
+                Some(UnifiedLinear::from_weights(
+                    weights,
+                    &format!("{}.q_b_proj", prefix),
+                    group_size,
+                    bits,
+                )?),
+            )
+        };
         let kv_a_proj_with_mqa = UnifiedLinear::from_weights(
             weights,
             &format!("{}.kv_a_proj_with_mqa", prefix),
@@ -376,15 +415,12 @@ impl DeepSeekV3Attention {
             bits,
         )?;
 
-        let q_a_norm_weight =
-            get_weight_copy(weights, &format!("{}.q_a_layernorm.weight", prefix))?;
         let kv_a_norm_weight =
             get_weight_copy(weights, &format!("{}.kv_a_layernorm.weight", prefix))?;
-
-        let q_a_layernorm = RMSNorm::new(q_a_norm_weight, 1e-6);
         let kv_a_layernorm = RMSNorm::new(kv_a_norm_weight, 1e-6);
 
         Ok(Self {
+            q_proj,
             q_a_proj,
             q_a_layernorm,
             q_b_proj,
@@ -1181,7 +1217,7 @@ mod tests {
             n_routed_experts: Some(4),
             routed_scaling_factor: 1.0,
             kv_lora_rank: 32,
-            q_lora_rank: 1,
+            q_lora_rank: Some(1),
             qk_rope_head_dim: 1,
             v_head_dim: 64,
             qk_nope_head_dim: 64,
@@ -1200,6 +1236,73 @@ mod tests {
             attention_bias: false,
             quantization: None,
         }
+    }
+
+    /// Regression guard for the real Kimi-VL / Moonlight text config, whose
+    /// `q_lora_rank` is JSON `null` (the backbone projects the query directly).
+    /// Parsing this shape used to fail with "invalid type: null, expected
+    /// usize"; the Kimi-VL loader reuses this exact `DeepSeekV3Config`.
+    #[test]
+    fn parses_null_q_lora_rank_config() {
+        // Field values mirror the real kimi-vl-a3b-thinking config.json
+        // `text_config` block.
+        let json = r#"{
+            "model_type": "deepseek_v3",
+            "vocab_size": 163840,
+            "hidden_size": 2048,
+            "intermediate_size": 11264,
+            "moe_intermediate_size": 1408,
+            "num_hidden_layers": 27,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 16,
+            "n_routed_experts": 64,
+            "n_shared_experts": 2,
+            "kv_lora_rank": 512,
+            "q_lora_rank": null,
+            "qk_rope_head_dim": 64,
+            "v_head_dim": 128,
+            "qk_nope_head_dim": 128,
+            "first_k_dense_replace": 1,
+            "rope_theta": 800000.0
+        }"#;
+        let cfg: DeepSeekV3Config =
+            serde_json::from_str(json).expect("null q_lora_rank must parse");
+        assert_eq!(cfg.q_lora_rank, None);
+        assert_eq!(cfg.kv_lora_rank, 512);
+        // q_head_dim = qk_nope_head_dim + qk_rope_head_dim = 128 + 64.
+        assert_eq!(cfg.q_head_dim(), 192);
+    }
+
+    /// A numeric `q_lora_rank` (genuine DeepSeek-V3) still parses to `Some`, and
+    /// an absent key defaults to `None` via `#[serde(default)]`.
+    #[test]
+    fn parses_numeric_and_absent_q_lora_rank() {
+        let base = r#"{
+            "vocab_size": 1,
+            "hidden_size": 1,
+            "intermediate_size": 1,
+            "moe_intermediate_size": 1,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "kv_lora_rank": 1,
+            "qk_rope_head_dim": 1,
+            "v_head_dim": 1,
+            "qk_nope_head_dim": 1
+        }"#;
+        // Absent key -> None.
+        let absent: DeepSeekV3Config =
+            serde_json::from_str(base).expect("absent q_lora_rank must parse");
+        assert_eq!(absent.q_lora_rank, None);
+
+        // Numeric value -> Some.
+        let with_rank = base.replace(
+            "\"kv_lora_rank\": 1,",
+            "\"kv_lora_rank\": 1, \"q_lora_rank\": 1536,",
+        );
+        let numeric: DeepSeekV3Config =
+            serde_json::from_str(&with_rank).expect("numeric q_lora_rank must parse");
+        assert_eq!(numeric.q_lora_rank, Some(1536));
     }
 
     /// Insert a dummy (empty) weight entry — sufficient for key-presence checks.

--- a/src/models/youtu_vl_lm_config.rs
+++ b/src/models/youtu_vl_lm_config.rs
@@ -167,7 +167,9 @@ impl YoutuTextConfig {
             n_routed_experts: self.n_routed_experts,
             routed_scaling_factor: self.routed_scaling_factor,
             kv_lora_rank: self.kv_lora_rank,
-            q_lora_rank: self.q_lora_rank,
+            // Youtu-VL always uses LoRA-compressed queries; wrap the required
+            // rank so the shared DeepSeek-V3 attention takes the LoRA branch.
+            q_lora_rank: Some(self.q_lora_rank),
             qk_rope_head_dim: self.qk_rope_head_dim,
             v_head_dim: self.v_head_dim,
             qk_nope_head_dim: self.qk_nope_head_dim,


### PR DESCRIPTION
Follow-up hardening for #525: the merged Kimi-VL port fails to load its real checkpoint.

## Problem

`mlxcel generate -m /path/to/kimi-vl-a3b-thinking-4bit ...` aborts during config parsing:

> Failed to parse Kimi-VL text config: invalid type: null, expected usize

The real `text_config` (a DeepSeek-V3-style block) sets `q_lora_rank` to `null`. The Moonlight-16B backbone that Kimi-VL uses projects the query directly rather than using a LoRA-compressed query, so upstream stores `q_lora_rank: null`. `DeepSeekV3Config` declared the field as a bare `usize`, and serde rejects `null` for `usize`.

## Change

- `DeepSeekV3Config::q_lora_rank` becomes `Option<usize>` with `#[serde(default)]`, so both an explicit `null` and an absent key parse.
- `DeepSeekV3Attention` threads the `None` case through the model build: a null `q_lora_rank` loads a direct `self_attn.q_proj` weight; a numeric value keeps the LoRA-style `q_a_proj -> q_a_layernorm -> q_b_proj` chain. This mirrors the existing DeepSeek-V2 MLA path. The real checkpoint's safetensors index confirms it ships `self_attn.q_proj` and no `q_a_proj` / `q_b_proj`.

## Shared-path consistency

`DeepSeekV3Config` and `DeepSeekV3Attention` are reused by the standalone DeepSeek-V3 loader, the pipeline stage executor, the Kimi-VL loader, and Youtu-VL:

- Kimi-VL and any Moonlight-style backbone (`q_lora_rank: null`) now load via the direct `q_proj` path.
- Youtu-VL wraps its required numeric rank in `Some`, so it keeps taking the LoRA branch (no behavior change).
- Genuine DeepSeek-V3 (numeric `q_lora_rank`) is unchanged.
- DeepSeek-V3.2 and GLM-MoE-DSA keep their own separate config structs and are not affected.

## Tests

- `src/models/deepseek_v3.rs`: `parses_null_q_lora_rank_config` (real config shape with `q_lora_rank: null`) and `parses_numeric_and_absent_q_lora_rank`.
- `src/loading/vlm_kimi_vl.rs`: `parses_real_kimi_vl_text_config_with_null_q_lora_rank` exercises the loader's `parse_required_vlm_subconfig` call with the real config shape.

## Verification

- [x] `cargo test --lib kimi_vl` (16 passed)
- [x] `cargo test --lib deepseek_v3` (15 passed)
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo fmt`

Real-model GPU load is deferred to the orchestrator.
