### PR TITLE
fix(models/moondream2): resolve EOS/prompt so real checkpoint generates

### DIFF
--- a/src/loading/vlm_special.rs
+++ b/src/loading/vlm_special.rs
@@ -669,7 +669,63 @@ pub(crate) fn load_moondream3_vlm(model_path: &Path) -> Result<LoadedModel> {
     }))
 }
 
-pub(super) fn moondream2_text_config_value(full_config: &Value) -> Value {
+/// GPT-2 / CodeGen `<|endoftext|>` id. The moondream2 tokenizer uses this
+/// single token as its begin-of-text, end-of-text and unknown token, so it is
+/// the resolution fallback for both bos and eos.
+const MOONDREAM2_ENDOFTEXT_ID: i32 = 50256;
+
+/// Resolve the moondream2 begin/end-of-text id from the checkpoint.
+///
+/// The shipped `vikhyatk/moondream2` checkpoint (`model_type: "moondream1"`)
+/// leaves both the top-level `eos_token_id` and the nested `config` object
+/// empty, so the authoritative id lives in the GPT-2/CodeGen tokenizer, where
+/// `<|endoftext|>` is id 50256 and doubles as bos/eos/unk. Moondream3 uses id 0
+/// for the same role with a different tokenizer; the moondream2 port must not
+/// inherit that value or generation stops on the very first sampled token.
+///
+/// Resolution order: explicit `eos_token_id` in config.json (top-level, then the
+/// nested `config` object), then the tokenizer's declared `eos_token` id, then
+/// the GPT-2 fallback (50256).
+pub(super) fn resolve_moondream2_eos_token_id(
+    full_config: &Value,
+    tokenizer_config: Option<&Value>,
+) -> i32 {
+    if let Some(id) = full_config.get("eos_token_id").and_then(Value::as_i64) {
+        return id as i32;
+    }
+    if let Some(id) = full_config
+        .get("config")
+        .and_then(|nested| nested.get("eos_token_id"))
+        .and_then(Value::as_i64)
+    {
+        return id as i32;
+    }
+    if let Some(id) = tokenizer_config.and_then(moondream2_tokenizer_eos_token_id) {
+        return id;
+    }
+    MOONDREAM2_ENDOFTEXT_ID
+}
+
+/// Look up the id of the tokenizer's declared `eos_token` string inside
+/// `added_tokens_decoder`, matching the moondream2 `tokenizer_config.json`
+/// shape (`eos_token: "<|endoftext|>"`, `added_tokens_decoder: { "50256": {
+/// "content": "<|endoftext|>", .. } }`). `eos_token` may be a bare string or an
+/// object carrying a `content` field.
+fn moondream2_tokenizer_eos_token_id(tokenizer_config: &Value) -> Option<i32> {
+    let eos_str = match tokenizer_config.get("eos_token")? {
+        Value::String(text) => text.as_str(),
+        Value::Object(entry) => entry.get("content")?.as_str()?,
+        _ => return None,
+    };
+    let decoder = tokenizer_config.get("added_tokens_decoder")?.as_object()?;
+    decoder.iter().find_map(|(id, entry)| {
+        (entry.get("content").and_then(Value::as_str) == Some(eos_str))
+            .then(|| id.parse::<i32>().ok())
+            .flatten()
+    })
+}
+
+pub(super) fn moondream2_text_config_value(full_config: &Value, special_token_id: i32) -> Value {
     let (group_size, bits) = parse_quantization_params(full_config);
     let group_size = if group_size > 0 { group_size } else { 64 };
     let bits = if bits > 0 { bits } else { 4 };
@@ -687,7 +743,8 @@ pub(super) fn moondream2_text_config_value(full_config: &Value) -> Value {
         "layer_norm_eps": 1e-5,
         "group_size": group_size,
         "bits": bits,
-        "eos_token_id": 0
+        "eos_token_id": special_token_id,
+        "bos_token_id": special_token_id
     })
 }
 
@@ -742,8 +799,10 @@ pub(crate) fn load_moondream2_vlm(model_path: &Path) -> Result<LoadedModel> {
     use vision::processors::moondream3::Moondream3Processor;
 
     let (_config_str, full_config) = read_sanitized_vlm_config(model_path)?;
+    let tokenizer_config = read_optional_json_config(model_path, "tokenizer_config.json");
+    let eos_token_id = resolve_moondream2_eos_token_id(&full_config, tokenizer_config.as_ref());
     let text_config: models::moondream2::ModelArgs =
-        serde_json::from_value(moondream2_text_config_value(&full_config))
+        serde_json::from_value(moondream2_text_config_value(&full_config, eos_token_id))
             .map_err(|err| anyhow::anyhow!("Failed to parse Moondream2 text config: {}", err))?;
     let vision_config: Moondream3VisionConfig =
         serde_json::from_value(moondream3_vision_config_value(&full_config))
@@ -767,8 +826,15 @@ pub(crate) fn load_moondream2_vlm(model_path: &Path) -> Result<LoadedModel> {
         text_model,
         vision_tower,
         processor,
-        eos_token_ids: vec![text_config.eos_token_id],
+        eos_token_ids: vec![eos_token_id],
     }))
+}
+
+/// Read and parse an optional JSON sidecar (e.g. `tokenizer_config.json`) from a
+/// model directory. Returns `None` when the file is absent or unparseable.
+fn read_optional_json_config(model_path: &Path, file_name: &str) -> Option<Value> {
+    let content = std::fs::read_to_string(model_path.join(file_name)).ok()?;
+    serde_json::from_str(&content).ok()
 }
 
 pub(super) fn rewrite_phi4_siglip_weight_key(key: &str) -> Option<String> {

--- a/src/loading/vlm_special_tests.rs
+++ b/src/loading/vlm_special_tests.rs
@@ -19,9 +19,10 @@ use super::{
     moondream2_text_config_value, moondream3_text_config_value, moondream3_vision_config_value,
     parse_molmo2_vit_layers, phi3_num_crops, phi4_siglip_text_config_value,
     phi4mm_text_config_value, phi4mm_vision_config_value, remap_minicpmo_text_weights,
-    remap_minicpmv4_6_weights, rewrite_molmo2_weight_key, rewrite_moondream2_weight_key,
-    rewrite_moondream3_weight_key, rewrite_phi3_weight_key, rewrite_phi4_siglip_weight_key,
-    rewrite_phi4mm_vision_key, should_transpose_phi3_patch_embedding,
+    remap_minicpmv4_6_weights, resolve_moondream2_eos_token_id, rewrite_molmo2_weight_key,
+    rewrite_moondream2_weight_key, rewrite_moondream3_weight_key, rewrite_phi3_weight_key,
+    rewrite_phi4_siglip_weight_key, rewrite_phi4mm_vision_key,
+    should_transpose_phi3_patch_embedding,
 };
 use mlxcel_core::dtype;
 use mlxcel_core::weights::WeightMap;
@@ -216,9 +217,12 @@ fn rewrite_moondream2_weight_key_maps_unified_checkpoint_layout() {
 
 #[test]
 fn moondream2_text_config_helper_fills_dense_phi_shapes() {
-    let text = moondream2_text_config_value(&json!({
-        "quantization": {"group_size": 32, "bits": 8}
-    }));
+    let text = moondream2_text_config_value(
+        &json!({
+            "quantization": {"group_size": 32, "bits": 8}
+        }),
+        50256,
+    );
 
     assert_eq!(text["model_type"], "moondream2");
     assert_eq!(text["dim"], 2048);
@@ -227,11 +231,59 @@ fn moondream2_text_config_helper_fills_dense_phi_shapes() {
     assert_eq!(text["rope_theta"], 10000.0);
     assert_eq!(text["group_size"], 32);
     assert_eq!(text["bits"], 8);
+    // The resolved special-token id feeds both bos and eos.
+    assert_eq!(text["eos_token_id"], 50256);
+    assert_eq!(text["bos_token_id"], 50256);
 
     // No quantization block -> fp16 defaults (group_size 64 / bits 4).
-    let text_default = moondream2_text_config_value(&json!({}));
+    let text_default = moondream2_text_config_value(&json!({}), 50256);
     assert_eq!(text_default["group_size"], 64);
     assert_eq!(text_default["bits"], 4);
+}
+
+#[test]
+fn resolve_moondream2_eos_falls_back_to_endoftext_id() {
+    // The real moondream2 checkpoint: `model_type: "moondream1"` with an empty
+    // nested `config` and no top-level `eos_token_id`. Without a tokenizer the
+    // resolver must fall back to the GPT-2 `<|endoftext|>` id (50256), never 0.
+    let real_config = json!({
+        "architectures": ["HfMoondream"],
+        "model_type": "moondream1",
+        "config": {},
+        "torch_dtype": "bfloat16"
+    });
+    assert_eq!(resolve_moondream2_eos_token_id(&real_config, None), 50256);
+}
+
+#[test]
+fn resolve_moondream2_eos_reads_id_from_tokenizer_config() {
+    // The real moondream2 tokenizer_config.json shape: `eos_token` is the
+    // `<|endoftext|>` string and `added_tokens_decoder` maps id 50256 to it.
+    let real_config = json!({ "model_type": "moondream1", "config": {} });
+    let tokenizer_config = json!({
+        "bos_token": "<|endoftext|>",
+        "eos_token": "<|endoftext|>",
+        "unk_token": "<|endoftext|>",
+        "tokenizer_class": "CodeGenTokenizer",
+        "added_tokens_decoder": {
+            "50256": { "content": "<|endoftext|>", "special": true }
+        }
+    });
+    assert_eq!(
+        resolve_moondream2_eos_token_id(&real_config, Some(&tokenizer_config)),
+        50256
+    );
+}
+
+#[test]
+fn resolve_moondream2_eos_prefers_explicit_config_ids() {
+    // An explicit top-level id wins over the tokenizer/fallback.
+    let top_level = json!({ "eos_token_id": 7 });
+    assert_eq!(resolve_moondream2_eos_token_id(&top_level, None), 7);
+
+    // A nested `config.eos_token_id` is honored when the top level is absent.
+    let nested = json!({ "config": { "eos_token_id": 11 } });
+    assert_eq!(resolve_moondream2_eos_token_id(&nested, None), 11);
 }
 
 #[test]

--- a/src/models/moondream2.rs
+++ b/src/models/moondream2.rs
@@ -60,6 +60,8 @@ pub struct ModelArgs {
     pub bits: i32,
     #[serde(default = "default_eos_token_id")]
     pub eos_token_id: i32,
+    #[serde(default = "default_bos_token_id")]
+    pub bos_token_id: i32,
 }
 
 fn default_model_type() -> String {
@@ -114,8 +116,17 @@ fn default_bits() -> i32 {
     4
 }
 
+/// The moondream2 checkpoint ships a GPT-2/CodeGen tokenizer whose
+/// `<|endoftext|>` token (id 50256) doubles as bos, eos and unk. Moondream3
+/// uses id 0 for the same role with a different tokenizer, so the moondream2
+/// port must not inherit that value: a `0` eos collides with a normal sampled
+/// token and halts generation before any output is produced.
 fn default_eos_token_id() -> i32 {
-    0
+    50256
+}
+
+fn default_bos_token_id() -> i32 {
+    50256
 }
 
 impl ModelArgs {
@@ -349,7 +360,7 @@ impl Moondream2Model {
     }
 
     pub fn bos_token_id(&self) -> i32 {
-        0
+        self.config.bos_token_id
     }
 }
 

--- a/src/models/moondream2_tests.rs
+++ b/src/models/moondream2_tests.rs
@@ -24,7 +24,10 @@ fn moondream2_model_args_fill_phi_style_defaults() {
     assert_eq!(args.n_heads, 32);
     assert_eq!(args.n_kv_heads, 32);
     assert_eq!(args.head_dim(), 64);
-    assert_eq!(args.eos_token_id, 0);
+    // The moondream2 tokenizer uses `<|endoftext|>` (id 50256) as bos/eos, not
+    // Moondream3's id 0. A `0` eos halts generation on the first sampled token.
+    assert_eq!(args.eos_token_id, 50256);
+    assert_eq!(args.bos_token_id, 50256);
 }
 
 #[test]

--- a/src/multimodal/moondream2_prompt.rs
+++ b/src/multimodal/moondream2_prompt.rs
@@ -20,7 +20,10 @@
 //! the image path only the framed text tokens are produced here. Text-only
 //! prompts additionally lead with the BOS id so the model still sees a prefix.
 
-pub const MOONDREAM2_BOS_ID: i32 = 0;
+/// The moondream2 tokenizer (GPT-2/CodeGen) uses `<|endoftext|>` (id 50256) as
+/// its begin-of-text token. Moondream3 uses id 0 with a different tokenizer;
+/// the moondream2 port must not reuse that value.
+pub const MOONDREAM2_BOS_ID: i32 = 50256;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Moondream2PromptMode {

--- a/src/multimodal/moondream2_prompt_tests.rs
+++ b/src/multimodal/moondream2_prompt_tests.rs
@@ -20,6 +20,13 @@ fn encode(text: &str, _add_special: bool) -> Vec<i32> {
 }
 
 #[test]
+fn bos_id_is_the_endoftext_token() {
+    // The moondream2 GPT-2/CodeGen tokenizer uses `<|endoftext|>` (id 50256) as
+    // its begin-of-text token, not Moondream3's id 0.
+    assert_eq!(MOONDREAM2_BOS_ID, 50256);
+}
+
+#[test]
 fn text_only_prompt_leads_with_bos_and_frames_question() {
     let prepared = prepare_moondream2_prompt_tokens("What is this?", 0, encode).unwrap();
     assert_eq!(prepared.mode, Moondream2PromptMode::Query);


### PR DESCRIPTION
Follow-up hardening for #522: the merged Moondream2 port loads its real checkpoint (3.48 GB, prepares 16 text + 730 image-prefix tokens) but prints `[Generated 0 tokens]` for a normal caption prompt. This fixes the EOS/BOS wiring so generation produces a non-empty description.

## Root cause

The port inherited Moondream3's `bos_id = eos_id = 0` convention. Moondream3 uses id 0 with its starmie tokenizer, but Moondream2 ships a GPT-2/CodeGen tokenizer (`tokenizer_config.json` / `special_tokens_map.json`) whose special token is `<|endoftext|>` = id 50256 and doubles as bos/eos/unk; id 0 there is the literal `!`.

The loader `moondream2_text_config_value` hardcoded `eos_token_id: 0`, so the generation stop set was exactly `{0}` (the checkpoint's `config.json` has an empty nested `config` object and no top-level eos, and `generation_config.json` carries no eos). The decode loop breaks the instant the first sampled token is read as a member of the stop set, before any token is pushed, which is exactly the observed `[Generated 0 tokens]`. Separately, the BOS prefix embedding used id 0 (`!`) instead of the real `<|endoftext|>`, feeding the decoder a malformed sequence start.

## Fix

Resolve the special-token id from the checkpoint instead of hardcoding it. Order: explicit `eos_token_id` in `config.json` (top-level, then the nested `config` object), then the tokenizer's declared `eos_token` string looked up in `added_tokens_decoder`, then the GPT-2 fallback `50256`. The resolved id feeds the wrapper eos set, the text-config eos, and the BOS prefix, so a caption prompt now generates and terminates on the genuine end-of-text.

## What changed

- `src/loading/vlm_special.rs`: add `resolve_moondream2_eos_token_id` plus a `tokenizer_config.json` reader; `moondream2_text_config_value` now takes the resolved id and emits both `eos_token_id` and `bos_token_id`; `load_moondream2_vlm` wires the resolved id into the wrapper eos set.
- `src/models/moondream2.rs`: default eos/bos to `50256`, add a `bos_token_id` config field, and have `bos_token_id()` read it.
- `src/multimodal/moondream2_prompt.rs`: `MOONDREAM2_BOS_ID` `0` -> `50256`.
- tests: corrected EOS/BOS default assertions, three resolver fixtures built from the real `config.json` / `tokenizer_config.json` shapes, and a BOS-id lock.

## Test plan

- [x] `cargo test --lib moondream2` (17 passed, 0 failed)
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)

The bug manifests at GPU generation time; the two real-model checks in `tests/moondream2_parity.rs` stay `#[ignore]`-gated and are validated separately on device.
