### PR TITLE
perf(vision/mllama): build cross-attention states from real tiles only

### DIFF
--- a/src/models/mllama/text.rs
+++ b/src/models/mllama/text.rs
@@ -581,4 +581,113 @@ mod tests {
             "a new image must produce a different cached key, not a stale one"
         );
     }
+
+    // --- Real-tile cross-states equivalence (issue #527 perf follow-up). ---
+    //
+    // The reference masks every padding-tile position out of the text
+    // cross-attention with an additive -1e9 (`cross_attention_mask` derived
+    // from the per-image `num_tiles`). `exp(logit - 1e9)` underflows to
+    // exactly 0.0, so those positions add exact zeros to the softmax numerator
+    // and denominator: attending over the REAL-tile rows alone is the same
+    // computation. These tests pin that equivalence at the byte level, which
+    // is what licenses `MllamaVLModel` to drop the padding-tile rows from
+    // `cross_attention_states` instead of threading a reference-style mask.
+
+    /// `[1, rows, HIDDEN]` cross-states with identifiable per-row content.
+    fn cross_rows(rows: i32, seed: usize) -> UniquePtr<MlxArray> {
+        mlxcel_core::from_slice_f32(&fill((rows * HIDDEN) as usize, seed), &[1, rows, HIDDEN])
+    }
+
+    /// Additive `[1, 1, Q_LEN, kv]` mask: 0 everywhere, -1e9 on `masked` keys
+    /// (the reference's padding-tile columns).
+    fn additive_kv_mask(kv: i32, masked: &[i32]) -> UniquePtr<MlxArray> {
+        let mut vals = vec![0.0f32; (Q_LEN * kv) as usize];
+        for q in 0..Q_LEN {
+            for &k in masked {
+                vals[(q * kv + k) as usize] = -1e9;
+            }
+        }
+        mlxcel_core::from_slice_f32(&vals, &[1, 1, Q_LEN, kv])
+    }
+
+    fn rows_slice(x: &MlxArray, start: i32, end: i32) -> UniquePtr<MlxArray> {
+        mlxcel_core::slice(x, &[0, start, 0], &[1, end, HIDDEN])
+    }
+
+    /// Single image, 1 real tile of 4 (2 patch rows per tile): attention over
+    /// the real rows only is byte-identical to reference-masked attention over
+    /// all rows, garbage padding-lane features included.
+    #[test]
+    fn real_tile_rows_match_reference_masked_full_rows() {
+        let config = tiny_config();
+        let layer = build_layer(&config);
+        let h = hidden_states();
+
+        // 4 tiles x 2 patches = 8 kv rows; rows 2..8 are padding-lane features
+        // (arbitrary non-zero values, as the tower genuinely produces).
+        let full = cross_rows(8, 42);
+        let mask = additive_kv_mask(8, &[2, 3, 4, 5, 6, 7]);
+        let masked_out = layer.forward(&h, &full, Some(&mask));
+
+        // The fill-once KV cache belongs to the previous cross-states.
+        layer.invalidate_kv_cache();
+        let real_only = rows_slice(&full, 0, 2);
+        let sliced_out = layer.forward(&h, &real_only, None);
+
+        assert_eq!(
+            max_abs_diff(&masked_out, &sliced_out),
+            0.0,
+            "dropping the -1e9-masked padding-tile rows must be byte-identical"
+        );
+    }
+
+    /// Ragged multi-image (media 0: 1 real tile of 2, media 1: 2 of 2):
+    /// media-major concatenation of each image's real rows is byte-identical
+    /// to reference-masked attention over the full row set.
+    #[test]
+    fn ragged_real_tile_rows_match_reference_masked_full_rows() {
+        let config = tiny_config();
+        let layer = build_layer(&config);
+        let h = hidden_states();
+
+        // [media0 t0, media0 t1(pad), media1 t0, media1 t1] x 2 patches.
+        let full = cross_rows(8, 77);
+        let mask = additive_kv_mask(8, &[2, 3]);
+        let masked_out = layer.forward(&h, &full, Some(&mask));
+
+        layer.invalidate_kv_cache();
+        let media0 = rows_slice(&full, 0, 2);
+        let media1 = rows_slice(&full, 4, 8);
+        let sliced = mlxcel_core::concatenate(&media0, &media1, 1);
+        let sliced_out = layer.forward(&h, &sliced, None);
+
+        assert_eq!(
+            max_abs_diff(&masked_out, &sliced_out),
+            0.0,
+            "ragged per-image selection must be byte-identical to the \
+             reference-masked full attention"
+        );
+    }
+
+    /// All tiles real: the all-zero reference mask is the no-mask computation;
+    /// there is nothing to drop and no behavior change.
+    #[test]
+    fn full_tile_mask_is_the_unmasked_computation() {
+        let config = tiny_config();
+        let layer = build_layer(&config);
+        let h = hidden_states();
+
+        let full = cross_rows(8, 99);
+        let mask = additive_kv_mask(8, &[]);
+        let masked_out = layer.forward(&h, &full, Some(&mask));
+
+        layer.invalidate_kv_cache();
+        let unmasked_out = layer.forward(&h, &full, None);
+
+        assert_eq!(
+            max_abs_diff(&masked_out, &unmasked_out),
+            0.0,
+            "an all-zero mask must not perturb the attention output"
+        );
+    }
 }

--- a/src/vision/encoders/mllama.rs
+++ b/src/vision/encoders/mllama.rs
@@ -670,6 +670,7 @@ mod tests {
     use super::{MllamaVisionModel, prepare_aspect_ratio_attention_mask};
     use crate::models::mllama::MllamaVisionConfig;
     use mlxcel_core::weights::WeightMap;
+    use mlxcel_core::{MlxArray, UniquePtr};
 
     fn value_at(mask: &mlxcel_core::MlxArray, i: i32, j: i32) -> f32 {
         // mask: [1, 1, L, L]
@@ -891,6 +892,239 @@ mod tests {
         assert!(
             !model.is_quantized(),
             "a dense tower must not report quantized projections"
+        );
+    }
+
+    // --- Padding-tile semantics (issue #527 perf follow-up). ---
+    //
+    // These tests document WHY the tower must keep processing the zero-padding
+    // tiles even though they look like wasted compute. The aspect-ratio mask is
+    // an outer product of the inverted validity vector, so it adds `-1e9` only
+    // where BOTH the query and the key are padding positions. Real-tile queries
+    // therefore attend to padding-tile keys with a zero bias (strictly positive
+    // softmax weight), and padding-tile lanes ingest real-tile content in one
+    // layer and feed it back to real-tile queries in the next. The padding
+    // tiles act as trained register lanes: dropping them from the tower input
+    // changes the real tiles' output. This matches the reference exactly
+    // (mlx-vlm `_prepare_aspect_ratio_attention_mask` and the HF processor,
+    // which always pads the tile axis to `max_image_tiles` before the tower).
+
+    /// Real->padding and padding->real attention is UNMASKED; only
+    /// padding->padding pairs carry the -1e9 bias. This is the structural
+    /// reason a "run the tower on real tiles only" optimization is unsound.
+    #[test]
+    fn mask_keeps_real_to_padding_attention_open() {
+        // 2 tiles, 2 patches each; tile 1 is a padding tile.
+        // Flattened positions: 0,1 = tile 0 (real), 2,3 = tile 1 (padding).
+        let ar_mask = mlxcel_core::from_slice_i32(&[1, 0], &[1, 2]);
+        let mask = prepare_aspect_ratio_attention_mask(&ar_mask, 2, 2, 2);
+
+        // Real query -> padding key: open (bias 0), NOT excluded.
+        assert_eq!(value_at(&mask, 0, 2), 0.0);
+        assert_eq!(value_at(&mask, 1, 3), 0.0);
+        // Padding query -> real key: also open.
+        assert_eq!(value_at(&mask, 2, 0), 0.0);
+        assert_eq!(value_at(&mask, 3, 1), 0.0);
+        // Only padding query -> padding key is masked.
+        assert!(value_at(&mask, 2, 3) < -1e8);
+        assert!(value_at(&mask, 3, 2) < -1e8);
+    }
+
+    // --- Forward-capable tiny tower harness. ---
+
+    /// Tiny but forward-runnable tower: 4x4 image, patch 2 (4 patches + cls =
+    /// 5, padded to 8), hidden 8, 2 heads, 2 local + 1 gated global layer,
+    /// max_num_tiles 4.
+    fn forward_vision_config() -> MllamaVisionConfig {
+        serde_json::from_str(
+            r#"{
+                "image_size": 4,
+                "patch_size": 2,
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 2,
+                "num_global_layers": 1,
+                "num_attention_heads": 2,
+                "max_num_tiles": 4,
+                "intermediate_layers_indices": [0]
+            }"#,
+        )
+        .expect("forward-capable tiny mllama vision config")
+    }
+
+    /// Deterministic pseudo-random fill in roughly `[-0.5, 0.5]`.
+    fn fill(n: usize, seed: usize) -> Vec<f32> {
+        (0..n)
+            .map(|i| ((i * 131 + seed * 977 + 7) % 251) as f32 / 251.0 - 0.5)
+            .collect()
+    }
+
+    fn put(map: &mut WeightMap, key: &str, shape: &[i32], seed: usize) {
+        let n: i32 = shape.iter().product();
+        map.insert(
+            key.to_string(),
+            mlxcel_core::from_slice_f32(&fill(n as usize, seed), shape),
+        );
+    }
+
+    /// Full dense weight set with non-degenerate values so attention mixing is
+    /// observable (the zero-filled loader-test weights would hide it).
+    fn build_forward_weights(prefix: &str) -> WeightMap {
+        let (h, inter, np, tiles, ar_rows) = (8, 16, 5, 4, 9);
+        let mut w = WeightMap::new();
+
+        put(&mut w, &format!("{prefix}.class_embedding"), &[h], 1);
+        // PyTorch conv layout [out, in, kH, kW]; the loader transposes it.
+        put(
+            &mut w,
+            &format!("{prefix}.patch_embedding.weight"),
+            &[h, 3, 2, 2],
+            2,
+        );
+        for (name, seed) in [("layernorm_pre", 3), ("layernorm_post", 5)] {
+            put(&mut w, &format!("{prefix}.{name}.weight"), &[h], seed);
+            put(&mut w, &format!("{prefix}.{name}.bias"), &[h], seed + 1);
+        }
+
+        put(
+            &mut w,
+            &format!("{prefix}.gated_positional_embedding.embedding"),
+            &[np, h],
+            7,
+        );
+        put(
+            &mut w,
+            &format!("{prefix}.gated_positional_embedding.gate"),
+            &[1],
+            8,
+        );
+        put(
+            &mut w,
+            &format!("{prefix}.gated_positional_embedding.tile_embedding.weight"),
+            &[ar_rows, tiles * np * h],
+            9,
+        );
+        for (name, seed) in [
+            ("pre_tile_positional_embedding", 10),
+            ("post_tile_positional_embedding", 12),
+        ] {
+            put(
+                &mut w,
+                &format!("{prefix}.{name}.embedding.weight"),
+                &[ar_rows, tiles * h],
+                seed,
+            );
+            put(&mut w, &format!("{prefix}.{name}.gate"), &[1], seed + 1);
+        }
+
+        let mut add_layers = |stack: &str, count: usize, gated: bool, base: usize| {
+            for i in 0..count {
+                let p = format!("{prefix}.{stack}.layers.{i}");
+                let s = base + i * 20;
+                put(&mut w, &format!("{p}.input_layernorm.weight"), &[h], s);
+                put(&mut w, &format!("{p}.input_layernorm.bias"), &[h], s + 1);
+                put(
+                    &mut w,
+                    &format!("{p}.post_attention_layernorm.weight"),
+                    &[h],
+                    s + 2,
+                );
+                put(
+                    &mut w,
+                    &format!("{p}.post_attention_layernorm.bias"),
+                    &[h],
+                    s + 3,
+                );
+                for (j, proj) in ["q_proj", "k_proj", "v_proj", "o_proj"].iter().enumerate() {
+                    put(
+                        &mut w,
+                        &format!("{p}.self_attn.{proj}.weight"),
+                        &[h, h],
+                        s + 4 + j,
+                    );
+                }
+                put(&mut w, &format!("{p}.mlp.fc1.weight"), &[inter, h], s + 8);
+                put(&mut w, &format!("{p}.mlp.fc1.bias"), &[inter], s + 9);
+                put(&mut w, &format!("{p}.mlp.fc2.weight"), &[h, inter], s + 10);
+                put(&mut w, &format!("{p}.mlp.fc2.bias"), &[h], s + 11);
+                if gated {
+                    put(&mut w, &format!("{p}.gate_attn"), &[1], s + 12);
+                    put(&mut w, &format!("{p}.gate_ffn"), &[1], s + 13);
+                }
+            }
+        };
+        add_layers("transformer", 2, false, 100);
+        add_layers("global_transformer", 1, true, 200);
+        w
+    }
+
+    fn forward_tower() -> MllamaVisionModel {
+        let config = forward_vision_config();
+        let weights = build_forward_weights("vision_tower");
+        MllamaVisionModel::from_weights(&weights, &config, "vision_tower")
+            .expect("forward-capable tiny tower must load")
+    }
+
+    /// Build `[1, 1, 4, 3, 4, 4]` pixel values: tile 0 is a real tile, tiles
+    /// 1..4 carry the given per-tile fills (zero = processor padding tile).
+    fn pixel_values_with_tiles(tile_fills: [Option<usize>; 4]) -> UniquePtr<MlxArray> {
+        let per_tile = 3 * 4 * 4;
+        let mut pixels = Vec::with_capacity(4 * per_tile);
+        for fill_seed in tile_fills {
+            match fill_seed {
+                Some(seed) => pixels.extend(fill(per_tile, seed)),
+                None => pixels.extend(std::iter::repeat_n(0.0f32, per_tile)),
+            }
+        }
+        mlxcel_core::from_slice_f32(&pixels, &[1, 1, 4, 3, 4, 4])
+    }
+
+    fn max_abs_diff(a: &mlxcel_core::MlxArray, b: &mlxcel_core::MlxArray) -> f32 {
+        let diff = mlxcel_core::subtract(a, b);
+        let m = mlxcel_core::max_all(&mlxcel_core::abs(&diff));
+        mlxcel_core::eval(&m);
+        mlxcel_core::item_f32(&m)
+    }
+
+    /// The content of a padding-tile lane reaches the REAL tile's tower
+    /// output. Two runs share an identical real tile 0 and differ only in
+    /// tile 1 (zero vs non-zero content); the real tile's output changes, so
+    /// padding lanes are live inputs to real-tile results, and slicing them
+    /// away before the tower is NOT an output-preserving optimization.
+    ///
+    /// If this test ever starts failing (diff == 0), the mask semantics were
+    /// changed to truly exclude padding tiles, and a real-tiles-only tower
+    /// fast path would become legal. Revisit issue #527's perf follow-up then.
+    #[test]
+    fn padding_tile_content_reaches_real_tile_output() {
+        let tower = forward_tower();
+        let ar_ids = mlxcel_core::from_slice_i32(&[1], &[1, 1]);
+        let ar_mask = mlxcel_core::from_slice_i32(&[1, 0, 0, 0], &[1, 1, 4]);
+
+        let zero_padding = pixel_values_with_tiles([Some(50), None, None, None]);
+        let perturbed_padding = pixel_values_with_tiles([Some(50), Some(60), None, None]);
+
+        let out_zero = tower.forward(&zero_padding, &ar_ids, &ar_mask);
+        let out_perturbed = tower.forward(&perturbed_padding, &ar_ids, &ar_mask);
+
+        // [1, 1, 4, 5, 16]: hidden (8) + one intermediate layer (8).
+        assert_eq!(
+            mlxcel_core::array_shape(&out_zero),
+            vec![1, 1, 4, 5, 16],
+            "tiny tower output contract"
+        );
+
+        // Compare ONLY the real tile (tile 0).
+        let real_zero = mlxcel_core::slice(&out_zero, &[0, 0, 0, 0, 0], &[1, 1, 1, 5, 16]);
+        let real_perturbed =
+            mlxcel_core::slice(&out_perturbed, &[0, 0, 0, 0, 0], &[1, 1, 1, 5, 16]);
+        let diff = max_abs_diff(&real_zero, &real_perturbed);
+        assert!(
+            diff > 1e-6,
+            "padding-tile content must leak into the real tile's output through \
+             the unmasked real->padding attention (measured diff {diff}); if this \
+             is now 0, the mask semantics changed and a real-tiles-only tower \
+             fast path may have become legal"
         );
     }
 }

--- a/src/vision/mllama_vl.rs
+++ b/src/vision/mllama_vl.rs
@@ -28,6 +28,13 @@
 //! Unlike the LLaVA-style VLMs, mllama does **not** merge image features into
 //! the token stream. Instead the projected features are held as
 //! `cross_attention_states` and consumed by the gated cross-attention layers.
+//! The states keep only each image's REAL tiles: the tower runs on the full
+//! zero-padded tile axis (its lanes are not separable, see the encoder tests),
+//! but the reference's text-side `cross_attention_mask` gives every
+//! padding-tile position an additive `-1e9`, i.e. exactly zero softmax weight,
+//! so dropping those rows here is byte-equivalent to the reference while
+//! shrinking the projector and cross-attention K/V work by
+//! `max_num_tiles / num_real_tiles`.
 //! Because [`crate::LanguageModel::forward`] carries no cross-attention slot,
 //! the state computed by [`MllamaVLModel::prepare_cross_attention_states`] is
 //! stashed in an interior-mutable cell (mirroring the Qwen-VL MRoPE-state
@@ -96,29 +103,81 @@ impl MllamaVLModel {
 
     /// Run the vision tower and projector to obtain the flattened
     /// `cross_attention_states` `[B, num_media * num_tiles * num_patches,
-    /// hidden]`. Mirrors the vision branch of `Model.__call__`.
+    /// hidden]`. Mirrors the vision branch of `Model.__call__` with an unknown
+    /// per-image tile count: every tile lane of the padded tile axis (including
+    /// the processor's zero-padding tiles) lands in the states.
     pub fn compute_cross_attention_states(
         &self,
         pixel_values: &MlxArray,
         aspect_ratio_ids: &MlxArray,
         aspect_ratio_mask: &MlxArray,
     ) -> UniquePtr<MlxArray> {
+        // An empty tile list never passes `select_real_tile_states`, so this
+        // is exactly the legacy all-tiles path.
+        self.compute_cross_attention_states_for_tiles(
+            pixel_values,
+            aspect_ratio_ids,
+            aspect_ratio_mask,
+            &[],
+        )
+    }
+
+    /// Like [`Self::compute_cross_attention_states`], but keeps only the REAL
+    /// tiles of each image in the resulting states, dropping the processor's
+    /// zero-padding tile lanes (`num_tiles` is the per-image real tile count
+    /// the processor reports).
+    ///
+    /// Correctness: the vision tower itself still runs on ALL tile lanes.
+    /// Its aspect-ratio mask only blocks padding->padding attention, so the
+    /// padding lanes are live register-like inputs to the real tiles' outputs
+    /// and cannot be skipped (see the `padding_tile_content_reaches_real_tile
+    /// _output` encoder test). The reference then masks every padding-tile
+    /// position out of the text cross-attention with an additive `-1e9`
+    /// (`cross_attention_mask` built from `num_tiles` in
+    /// `processing_mllama.py`), which zeroes those positions' softmax weights
+    /// exactly. This port passes no text-side cross mask, so dropping the
+    /// padding-tile rows here reproduces the reference's tile-level masking
+    /// exactly while shrinking the projector matmul and every cross-attention
+    /// key/value computation by `max_num_tiles / num_real_tiles`.
+    ///
+    /// When the counts do not warrant (or do not safely permit) selection,
+    /// this falls back to the legacy all-tiles states.
+    pub fn compute_cross_attention_states_for_tiles(
+        &self,
+        pixel_values: &MlxArray,
+        aspect_ratio_ids: &MlxArray,
+        aspect_ratio_mask: &MlxArray,
+        num_tiles: &[usize],
+    ) -> UniquePtr<MlxArray> {
         let batch = mlxcel_core::array_shape(pixel_values)[0];
         let vision_output =
             self.vision_tower
                 .forward(pixel_values, aspect_ratio_ids, aspect_ratio_mask);
-        let projected = self.multi_modal_projector.forward(&vision_output);
         let hidden = self.config.text_config.hidden_size as i32;
-        mlxcel_core::reshape(&projected, &[batch, -1, hidden])
+        match select_real_tile_states(&vision_output, num_tiles) {
+            Some(selected) => {
+                // Project only the surviving rows (the projector is a
+                // per-position linear, so slicing before projecting is exact).
+                let projected = self.multi_modal_projector.forward(&selected);
+                mlxcel_core::reshape(&projected, &[batch, -1, hidden])
+            }
+            None => {
+                let projected = self.multi_modal_projector.forward(&vision_output);
+                mlxcel_core::reshape(&projected, &[batch, -1, hidden])
+            }
+        }
     }
 
     /// Compute and stash the cross-attention states from preprocessed image
     /// inputs so subsequent [`LanguageModel::forward`] calls attend to them.
+    /// Uses the processor's per-image real tile counts to keep only real-tile
+    /// features (see [`Self::compute_cross_attention_states_for_tiles`]).
     pub fn prepare_cross_attention_states(&self, inputs: &MllamaImageInputs) {
-        let states = self.compute_cross_attention_states(
+        let states = self.compute_cross_attention_states_for_tiles(
             &inputs.pixel_values,
             &inputs.aspect_ratio_ids,
             &inputs.aspect_ratio_mask,
+            &inputs.num_tiles,
         );
         self.set_cross_attention_states(states);
     }
@@ -168,6 +227,62 @@ impl MllamaVLModel {
     }
 }
 
+/// Select the real-tile rows of the vision tower output for the
+/// cross-attention states.
+///
+/// `vision_output`: `[B, num_media, max_num_tiles, num_patches, dim]` (all
+/// tile lanes, as produced by [`MllamaVisionModel::forward`]).
+/// `num_tiles[m]`: the number of REAL tiles of image `m`; real tiles are
+/// contiguous at tile indices `0..num_tiles[m]` (the processor appends the
+/// zero-padding tiles).
+///
+/// Returns the media-major concatenation
+/// `[B, sum(num_tiles) * num_patches, dim]`, which is the reference's
+/// flattened `[B, media * tiles * patches, dim]` layout restricted to the
+/// positions its text-side `cross_attention_mask` leaves unmasked. Ragged
+/// per-image tile counts are handled exactly (each image contributes its own
+/// real rows, order preserved).
+///
+/// Returns `None` (caller keeps the legacy all-tiles path) when:
+/// - the batch dimension is not 1 (per-row selection would be ragged across
+///   the shared kv axis; the current runtime only ever builds B == 1),
+/// - `num_tiles` does not match the media count or holds an out-of-range
+///   count (defensive; the processor cannot produce these), or
+/// - every image already uses all `max_num_tiles` tiles (selection would be
+///   a no-op; the legacy path is byte-identical and avoids extra reshapes).
+fn select_real_tile_states(
+    vision_output: &MlxArray,
+    num_tiles: &[usize],
+) -> Option<UniquePtr<MlxArray>> {
+    let shape = mlxcel_core::array_shape(vision_output);
+    if shape.len() != 5 || shape[0] != 1 {
+        return None;
+    }
+    let (media, max_tiles, patches, dim) = (shape[1], shape[2], shape[3], shape[4]);
+    if num_tiles.len() != media as usize
+        || num_tiles.iter().any(|&n| n == 0 || n > max_tiles as usize)
+        || num_tiles.iter().all(|&n| n == max_tiles as usize)
+    {
+        return None;
+    }
+
+    let mut selected: Option<UniquePtr<MlxArray>> = None;
+    for (m, &n) in num_tiles.iter().enumerate() {
+        let m = m as i32;
+        let part = mlxcel_core::slice(
+            vision_output,
+            &[0, m, 0, 0, 0],
+            &[1, m + 1, n as i32, patches, dim],
+        );
+        let part = mlxcel_core::reshape(&part, &[1, n as i32 * patches, dim]);
+        selected = Some(match selected {
+            None => part,
+            Some(acc) => mlxcel_core::concatenate(&acc, &part, 1),
+        });
+    }
+    selected
+}
+
 impl LanguageModel for MllamaVLModel {
     fn forward(
         &self,
@@ -207,8 +322,9 @@ impl LanguageModel for MllamaVLModel {
 
 #[cfg(test)]
 mod tests {
-    use super::MllamaVLModel;
+    use super::{MllamaVLModel, select_real_tile_states};
     use mlxcel_core::weights::WeightMap;
+    use mlxcel_core::{MlxArray, UniquePtr};
 
     /// The real checkpoint stores `multi_modal_projector` quantized with a float
     /// `.bias` alongside the affine `.scales`/`.biases`. The loader must resolve
@@ -240,5 +356,67 @@ mod tests {
             projector.is_quantized(),
             "the 4-bit projector must load quantized, not as a raw packed linear"
         );
+    }
+
+    // --- Real-tile row selection (issue #527 perf follow-up). ---
+
+    /// `[1, media, max_tiles, patches, dim]` filled with 0..N so every row is
+    /// identifiable by value.
+    fn arange_output(media: i32, max_tiles: i32, patches: i32, dim: i32) -> UniquePtr<MlxArray> {
+        let n = (media * max_tiles * patches * dim) as usize;
+        let vals: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        mlxcel_core::from_slice_f32(&vals, &[1, media, max_tiles, patches, dim])
+    }
+
+    fn max_abs_diff(a: &MlxArray, b: &MlxArray) -> f32 {
+        let diff = mlxcel_core::subtract(a, b);
+        let m = mlxcel_core::max_all(&mlxcel_core::abs(&diff));
+        mlxcel_core::eval(&m);
+        mlxcel_core::item_f32(&m)
+    }
+
+    /// Ragged multi-image selection keeps exactly the real-tile rows of every
+    /// image, media-major, in the reference's flatten order.
+    #[test]
+    fn select_keeps_ragged_real_tile_rows_media_major() {
+        // 2 media, 2 tiles, 2 patches, dim 3; media 0 has 1 real tile, media 1
+        // has 2. Row layout (patch rows of dim 3):
+        //   media 0: tile 0 -> values 0..6,   tile 1 -> 6..12 (padding)
+        //   media 1: tile 0 -> values 12..18, tile 1 -> 18..24
+        let output = arange_output(2, 2, 2, 3);
+        let selected =
+            select_real_tile_states(&output, &[1, 2]).expect("sub-max ragged counts must select");
+        assert_eq!(mlxcel_core::array_shape(&selected), vec![1, 6, 3]);
+
+        let expected: Vec<f32> = (0..6)
+            .map(|i| i as f32)
+            .chain((12..24).map(|i| i as f32))
+            .collect();
+        let expected = mlxcel_core::from_slice_f32(&expected, &[1, 6, 3]);
+        assert_eq!(
+            max_abs_diff(&selected, &expected),
+            0.0,
+            "selection must keep media 0 tile 0 and media 1 tiles 0..2, in order"
+        );
+    }
+
+    /// Full tile counts are a no-op: the caller must keep the legacy all-tiles
+    /// path so the states stay byte-identical to the pre-optimization output.
+    #[test]
+    fn select_declines_full_tile_counts() {
+        let output = arange_output(2, 2, 2, 3);
+        assert!(select_real_tile_states(&output, &[2, 2]).is_none());
+    }
+
+    /// Defensive fallbacks: count/media mismatch, zero counts, and
+    /// out-of-range counts all keep the legacy path instead of guessing.
+    #[test]
+    fn select_declines_invalid_tile_counts() {
+        let output = arange_output(2, 2, 2, 3);
+        assert!(select_real_tile_states(&output, &[1]).is_none());
+        assert!(select_real_tile_states(&output, &[1, 2, 1]).is_none());
+        assert!(select_real_tile_states(&output, &[0, 2]).is_none());
+        assert!(select_real_tile_states(&output, &[1, 3]).is_none());
+        assert!(select_real_tile_states(&output, &[]).is_none());
     }
 }

--- a/tests/mllama_parity.rs
+++ b/tests/mllama_parity.rs
@@ -30,10 +30,13 @@ mod common;
 use std::path::PathBuf;
 
 use common::repo_model_dir;
-use mlxcel::models::mllama::MllamaTextConfig;
 use mlxcel::models::mllama::text::MllamaTextModel;
+use mlxcel::models::mllama::{MllamaConfig, MllamaTextConfig};
 use mlxcel::models::{ModelType, get_model_type};
-use mlxcel::vision::processors::mllama::MllamaImageProcessor;
+use mlxcel::vision::MllamaVLModel;
+use mlxcel::vision::encoders::mllama::MllamaVisionModel;
+use mlxcel::vision::processors::mllama::{MllamaImageInputs, MllamaImageProcessor};
+use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 
@@ -337,6 +340,315 @@ fn processor_packs_tower_contract() {
     );
     assert_eq!(inputs.num_tiles.len(), 1);
     assert!(inputs.num_tiles[0] >= 1 && inputs.num_tiles[0] <= 4);
+}
+
+// --- Real-tile cross-attention states (issue #527 perf follow-up). ---
+//
+// The processor pads every image's tile axis to `max_num_tiles` with zero
+// tiles. The tower must keep processing all of those lanes (its aspect-ratio
+// mask deliberately leaves real->padding attention open, see the encoder unit
+// tests), but the reference then masks every padding-tile position out of the
+// TEXT cross-attention with an additive -1e9, which zeroes their softmax
+// weights exactly. `MllamaVLModel` reproduces that tile-level masking by
+// building `cross_attention_states` from the real-tile rows only. These tests
+// pin the states-level contract on a tiny but fully forward-capable VL model.
+
+const V_OUT: i32 = 16; // tower hidden (8) * (1 + |intermediate_layers_indices|)
+const V_PATCHES: i32 = 5; // (4 / 2)^2 patches + class token
+
+fn tiny_vl_config() -> MllamaConfig {
+    serde_json::from_str(
+        r#"{
+            "text_config": {
+                "model_type": "mllama",
+                "vocab_size": 6,
+                "hidden_size": 4,
+                "intermediate_size": 8,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "rms_norm_eps": 1e-5,
+                "rope_theta": 10000.0,
+                "tie_word_embeddings": false,
+                "cross_attention_layers": [1]
+            },
+            "vision_config": {
+                "image_size": 4,
+                "patch_size": 2,
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 2,
+                "num_global_layers": 1,
+                "num_attention_heads": 2,
+                "max_num_tiles": 4,
+                "intermediate_layers_indices": [0]
+            }
+        }"#,
+    )
+    .expect("tiny mllama VL config")
+}
+
+/// Forward-capable tiny tower weights (mirrors the encoder unit-test harness:
+/// 4x4 image, patch 2, hidden 8, 2 local + 1 gated global layer).
+fn build_tiny_vision_weights(prefix: &str) -> WeightMap {
+    let (h, inter, np, tiles, ar_rows) = (8, 16, 5, 4, 9);
+    let mut w = WeightMap::new();
+
+    put(&mut w, &format!("{prefix}.class_embedding"), &[h], 1);
+    put(
+        &mut w,
+        &format!("{prefix}.patch_embedding.weight"),
+        &[h, 3, 2, 2],
+        2,
+    );
+    for (name, seed) in [("layernorm_pre", 3), ("layernorm_post", 5)] {
+        put(&mut w, &format!("{prefix}.{name}.weight"), &[h], seed);
+        put(&mut w, &format!("{prefix}.{name}.bias"), &[h], seed + 1);
+    }
+    put(
+        &mut w,
+        &format!("{prefix}.gated_positional_embedding.embedding"),
+        &[np, h],
+        7,
+    );
+    put(
+        &mut w,
+        &format!("{prefix}.gated_positional_embedding.gate"),
+        &[1],
+        8,
+    );
+    put(
+        &mut w,
+        &format!("{prefix}.gated_positional_embedding.tile_embedding.weight"),
+        &[ar_rows, tiles * np * h],
+        9,
+    );
+    for (name, seed) in [
+        ("pre_tile_positional_embedding", 10),
+        ("post_tile_positional_embedding", 12),
+    ] {
+        put(
+            &mut w,
+            &format!("{prefix}.{name}.embedding.weight"),
+            &[ar_rows, tiles * h],
+            seed,
+        );
+        put(&mut w, &format!("{prefix}.{name}.gate"), &[1], seed + 1);
+    }
+    let mut add_layers = |stack: &str, count: usize, gated: bool, base: usize| {
+        for i in 0..count {
+            let p = format!("{prefix}.{stack}.layers.{i}");
+            let s = base + i * 20;
+            put(&mut w, &format!("{p}.input_layernorm.weight"), &[h], s);
+            put(&mut w, &format!("{p}.input_layernorm.bias"), &[h], s + 1);
+            put(
+                &mut w,
+                &format!("{p}.post_attention_layernorm.weight"),
+                &[h],
+                s + 2,
+            );
+            put(
+                &mut w,
+                &format!("{p}.post_attention_layernorm.bias"),
+                &[h],
+                s + 3,
+            );
+            for (j, proj) in ["q_proj", "k_proj", "v_proj", "o_proj"].iter().enumerate() {
+                put(
+                    &mut w,
+                    &format!("{p}.self_attn.{proj}.weight"),
+                    &[h, h],
+                    s + 4 + j,
+                );
+            }
+            put(&mut w, &format!("{p}.mlp.fc1.weight"), &[inter, h], s + 8);
+            put(&mut w, &format!("{p}.mlp.fc1.bias"), &[inter], s + 9);
+            put(&mut w, &format!("{p}.mlp.fc2.weight"), &[h, inter], s + 10);
+            put(&mut w, &format!("{p}.mlp.fc2.bias"), &[h], s + 11);
+            if gated {
+                put(&mut w, &format!("{p}.gate_attn"), &[1], s + 12);
+                put(&mut w, &format!("{p}.gate_ffn"), &[1], s + 13);
+            }
+        }
+    };
+    add_layers("transformer", 2, false, 100);
+    add_layers("global_transformer", 1, true, 200);
+    w
+}
+
+fn tiny_vl_model() -> MllamaVLModel {
+    let config = tiny_vl_config();
+    let text_model = MllamaTextModel::from_weights(&build_weights(0.5), &config.text_config)
+        .expect("tiny mllama text model");
+    let tower = MllamaVisionModel::from_weights(
+        &build_tiny_vision_weights("vision_tower"),
+        &config.vision_config,
+        "vision_tower",
+    )
+    .expect("tiny mllama vision tower");
+
+    let mut pw = WeightMap::new();
+    put(
+        &mut pw,
+        "multi_modal_projector.weight",
+        &[HIDDEN, V_OUT],
+        300,
+    );
+    put(&mut pw, "multi_modal_projector.bias", &[HIDDEN], 301);
+    let projector = MllamaVLModel::load_projector(&pw, 64, 4).expect("tiny dense projector");
+
+    let processor = MllamaImageProcessor::new(4, 4);
+    MllamaVLModel::from_parts(text_model, tower, projector, processor, config, vec![5])
+}
+
+/// `[1, media, 4, 3, 4, 4]` pixel values; `Some(seed)` tiles carry content,
+/// `None` tiles are the processor's zero padding.
+fn tile_pixels(media_fills: &[[Option<usize>; 4]]) -> UniquePtr<MlxArray> {
+    let per_tile = 3 * 4 * 4;
+    let mut pixels = Vec::with_capacity(media_fills.len() * 4 * per_tile);
+    for tiles in media_fills {
+        for seed in tiles {
+            match seed {
+                Some(seed) => pixels.extend(fill(per_tile, *seed)),
+                None => pixels.extend(std::iter::repeat_n(0.0f32, per_tile)),
+            }
+        }
+    }
+    mlxcel_core::from_slice_f32(&pixels, &[1, media_fills.len() as i32, 4, 3, 4, 4])
+}
+
+fn states_rows(states: &MlxArray, start: i32, end: i32) -> UniquePtr<MlxArray> {
+    mlxcel_core::slice(states, &[0, start, 0], &[1, end, HIDDEN])
+}
+
+/// (a) Sub-max real tiles: the real-tile states are byte-identical to the
+/// corresponding rows of the legacy all-tiles states (slicing before the
+/// per-position projector changes nothing), and only the padding-tile rows
+/// are dropped.
+#[test]
+fn sub_max_real_tiles_keep_the_legacy_real_rows_byte_identical() {
+    let model = tiny_vl_model();
+    let pv = tile_pixels(&[[Some(400), None, None, None]]);
+    let ids = mlxcel_core::from_slice_i32(&[1], &[1, 1]);
+    let mask = mlxcel_core::from_slice_i32(&[1, 0, 0, 0], &[1, 1, 4]);
+
+    let full = model.compute_cross_attention_states(&pv, &ids, &mask);
+    let sub = model.compute_cross_attention_states_for_tiles(&pv, &ids, &mask, &[1]);
+
+    assert_eq!(
+        mlxcel_core::array_shape(&full),
+        vec![1, 4 * V_PATCHES, HIDDEN]
+    );
+    assert_eq!(mlxcel_core::array_shape(&sub), vec![1, V_PATCHES, HIDDEN]);
+
+    let expected = states_rows(&full, 0, V_PATCHES);
+    assert_eq!(
+        max_abs_diff(&sub, &expected),
+        0.0,
+        "real-tile states must be byte-identical to the legacy states' real rows"
+    );
+}
+
+/// (b) Full tile count: selection is a no-op and the states must be
+/// byte-identical to the legacy all-tiles path (zero behavior change).
+#[test]
+fn full_tile_count_states_are_byte_identical_to_legacy() {
+    let model = tiny_vl_model();
+    let pv = tile_pixels(&[[Some(410), Some(411), Some(412), Some(413)]]);
+    let ids = mlxcel_core::from_slice_i32(&[6], &[1, 1]); // (2, 2) tiling
+    let mask = mlxcel_core::from_slice_i32(&[1, 1, 1, 1], &[1, 1, 4]);
+
+    let full = model.compute_cross_attention_states(&pv, &ids, &mask);
+    let via_tiles = model.compute_cross_attention_states_for_tiles(&pv, &ids, &mask, &[4]);
+
+    assert_eq!(
+        max_abs_diff(&full, &via_tiles),
+        0.0,
+        "num_tiles == max_num_tiles must take the identical legacy path"
+    );
+}
+
+/// Ragged multi-image: each image contributes exactly its real-tile rows,
+/// media-major, byte-identical to the legacy states' corresponding rows.
+#[test]
+fn ragged_multi_image_states_concatenate_real_rows() {
+    let model = tiny_vl_model();
+    let pv = tile_pixels(&[
+        [Some(420), None, None, None],
+        [Some(430), Some(431), None, None],
+    ]);
+    let ids = mlxcel_core::from_slice_i32(&[1, 2], &[1, 2]);
+    let mask = mlxcel_core::from_slice_i32(&[1, 0, 0, 0, 1, 1, 0, 0], &[1, 2, 4]);
+
+    let full = model.compute_cross_attention_states(&pv, &ids, &mask);
+    let sub = model.compute_cross_attention_states_for_tiles(&pv, &ids, &mask, &[1, 2]);
+
+    assert_eq!(
+        mlxcel_core::array_shape(&full),
+        vec![1, 2 * 4 * V_PATCHES, HIDDEN]
+    );
+    assert_eq!(
+        mlxcel_core::array_shape(&sub),
+        vec![1, 3 * V_PATCHES, HIDDEN]
+    );
+
+    // Media 0 tile 0 = rows 0..5; media 1 tiles 0..2 = rows 20..30.
+    let media0 = states_rows(&full, 0, V_PATCHES);
+    let media1 = states_rows(&full, 4 * V_PATCHES, 6 * V_PATCHES);
+    let expected = mlxcel_core::concatenate(&media0, &media1, 1);
+    assert_eq!(
+        max_abs_diff(&sub, &expected),
+        0.0,
+        "ragged selection must keep each image's real rows in media-major order"
+    );
+}
+
+/// `prepare_cross_attention_states` threads the processor's real tile counts:
+/// the logits match a manual stash of the real-tile states, and genuinely
+/// differ from stashing the legacy all-tiles states (whose garbage padding
+/// rows the old unmasked cross-attention consulted).
+#[test]
+fn prepare_stashes_real_tile_states() {
+    let model = tiny_vl_model();
+    let pv = tile_pixels(&[[Some(440), None, None, None]]);
+    let ids = mlxcel_core::from_slice_i32(&[1], &[1, 1]);
+    let mask = mlxcel_core::from_slice_i32(&[1, 0, 0, 0], &[1, 1, 4]);
+
+    let vl_forward = |m: &MllamaVLModel| {
+        let ids = input_ids();
+        let mut caches = LanguageModel::make_caches(m);
+        let logits = LanguageModel::forward(m, &ids, &mut caches, None);
+        mlxcel_core::eval(&logits);
+        logits
+    };
+
+    let inputs = MllamaImageInputs {
+        pixel_values: mlxcel_core::copy(&pv),
+        aspect_ratio_ids: mlxcel_core::copy(&ids),
+        aspect_ratio_mask: mlxcel_core::copy(&mask),
+        num_tiles: vec![1],
+    };
+    model.prepare_cross_attention_states(&inputs);
+    assert!(model.has_cross_attention_states());
+    let logits_prepare = vl_forward(&model);
+
+    let sub = model.compute_cross_attention_states_for_tiles(&pv, &ids, &mask, &[1]);
+    model.set_cross_attention_states(sub);
+    let logits_sub = vl_forward(&model);
+    assert_eq!(
+        max_abs_diff(&logits_prepare, &logits_sub),
+        0.0,
+        "prepare must stash exactly the real-tile states"
+    );
+
+    let full = model.compute_cross_attention_states(&pv, &ids, &mask);
+    model.set_cross_attention_states(full);
+    let logits_full = vl_forward(&model);
+    assert!(
+        max_abs_diff(&logits_prepare, &logits_full) > 1e-6,
+        "the legacy all-tiles states let the unmasked cross-attention consult \
+         padding-lane rows; dropping them must actually change the logits"
+    );
 }
 
 // --- Model-gated smoke test (inert without the checkpoint). ---


### PR DESCRIPTION
Follow-up perf for #527: after the decode-path fix (#621), prefill/TTFT still paid for the processor's zero-padding tiles. This PR removes the padding-tile cost everywhere it is provably exact to remove, and documents with tests why the originally proposed tower-level tile skip is not sound.

## What the investigation found

- The proposed fix (run the vision tower on the real tiles only) is NOT output-preserving, so it is not implemented. The aspect-ratio attention mask is an outer product of the inverted validity vector (`-1e9` iff BOTH the query and the key are padding positions), identical in this port, mlx-vlm, and HF. Real-tile queries attend to padding-tile keys with a zero bias, and padding lanes ingest real-tile content every layer: the padding tiles are live register-like lanes the checkpoint was trained with. The HF processor always pads the tile axis to `max_image_tiles`, so the reference oracle runs all lanes too. New encoder tests pin both facts (`mask_keeps_real_to_padding_attention_open`, `padding_tile_content_reaches_real_tile_output`; perturbing a padding tile moves the real tile's output by about 4e-3 on a tiny tower).
- What IS exact: dropping the padding-tile rows AFTER the tower, when building `cross_attention_states`. The reference's text-side `cross_attention_mask` adds `-1e9` to every padding-tile kv position, and `exp(logit - 1e9)` underflows to exactly 0.0, so attention over the real rows alone is byte-identical to the reference-masked computation. This port passes no text-side cross mask (it attended the padding lanes' garbage features unmasked), so the change is simultaneously a perf win and a fidelity fix toward the reference.

## What changed

- `src/vision/mllama_vl.rs`: new `select_real_tile_states` picks each image's real-tile rows (media-major; ragged multi-image handled exactly; batch != 1, anomalous counts, and full-tile counts fall back to the byte-identical legacy path). `compute_cross_attention_states_for_tiles` slices before the projector; `prepare_cross_attention_states` threads the processor's per-image `num_tiles` (already computed, previously unused here).
- `src/vision/encoders/mllama.rs`: no behavior change; adds the mask-semantics test and a forward-capable tiny-tower test proving padding lanes are live inputs to real-tile outputs (the guard documenting why a tower-level skip must not be attempted).
- `src/models/mllama/text.rs`: attention-level byte-identity tests, masked-full vs sliced-real: single image (1 real tile of 4), ragged multi-image, and the all-real no-op, all asserting `max_abs_diff == 0.0`.
- `tests/mllama_parity.rs`: model-level tests on a tiny forward-capable VL model: sliced states equal the legacy states' real rows byte-identically; full counts equal the legacy states byte-identically; ragged concatenation exact; `prepare` stashes exactly the real-tile states and measurably stops consulting padding rows. Real-checkpoint tests remain model-gated and inert without the checkpoint.

## Perf effect (single small image, 1 real tile of 4)

- `multi_modal_projector` matmul: 4x fewer positions (6404 to 1601).
- Each of the 8 text cross-attention layers: fill-once K/V projection 4x smaller at prefill; every decode step attends 1601 instead of 6404 keys; cross-KV cache memory 4x smaller.
- The vision tower itself (the dominant TTFT cost) is intentionally unchanged per the analysis above. To close the remaining gap vs GLM-4V, the next exact-preserving suspects are the tower's attention route with the materialized `[1, 1, 6432, 6432]` f32 additive mask (dtype mismatch against the f16 tower may be forcing a composed, score-materializing SDPA path) and the per-layer intermediate-state copies.

## Test plan

- [x] `cargo test --lib mllama` (24 passed)
- [x] `cargo test --test mllama_parity` (8 passed)
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo fmt --check`
