### PR TITLE
perf(bench): long-prompt prefill ladder + serving telemetry

### DIFF
--- a/benchmarks/cuda_gb10_longprompt_2026-07-03.csv
+++ b/benchmarks/cuda_gb10_longprompt_2026-07-03.csv
@@ -1,0 +1,21 @@
+model,model_path,prompt_tokens,generated_tokens,prefill_ms,prefill_tok_s,decode_ms,decode_tok_s,date,hardware,mlx_version,build_type,max_tokens,prompt,prompt_target_len
+llama-3.1-8b-4bit,./models/llama-3.1-8b-4bit,512,32,155.78,3286.67,589.27,54.30,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",512
+llama-3.1-8b-4bit,./models/llama-3.1-8b-4bit,2048,32,695.17,2946.03,623.06,51.36,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",2048
+llama-3.1-8b-4bit,./models/llama-3.1-8b-4bit,8192,32,4916.19,1666.33,730.88,43.78,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",8192
+llama-3.1-8b-4bit,./models/llama-3.1-8b-4bit,,,,,,,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",32768,FAIL:bench
+qwen2.5-7b-4bit,./models/qwen2.5-7b-4bit,512,32,146.80,3487.65,544.28,58.79,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",512
+qwen2.5-7b-4bit,./models/qwen2.5-7b-4bit,2048,32,655.22,3125.65,559.22,57.22,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",2048
+qwen2.5-7b-4bit,./models/qwen2.5-7b-4bit,8192,32,4538.43,1805.03,604.44,52.94,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",8192
+qwen2.5-7b-4bit,./models/qwen2.5-7b-4bit,32736,32,27836.12,1176.03,775.96,41.24,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",32768
+qwen3-30b-a3b-4bit,./models/qwen3-30b-a3b-4bit,512,32,3149.41,162.57,341.29,93.76,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",512
+qwen3-30b-a3b-4bit,./models/qwen3-30b-a3b-4bit,2048,32,12625.16,162.22,361.66,88.48,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",2048
+qwen3-30b-a3b-4bit,./models/qwen3-30b-a3b-4bit,,,,,,,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",8192,FAIL:bench
+qwen3-30b-a3b-4bit,./models/qwen3-30b-a3b-4bit,,,,,,,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",32768,FAIL:bench
+mixtral-8x7b-4bit,./models/mixtral-8x7b-4bit,512,32,33428.70,15.32,1057.19,30.27,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",512
+mixtral-8x7b-4bit,./models/mixtral-8x7b-4bit,2048,32,148493.10,13.79,1087.42,29.43,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",2048
+mixtral-8x7b-4bit,./models/mixtral-8x7b-4bit,8192,32,323919.23,25.29,1194.07,26.80,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",8192
+mixtral-8x7b-4bit,./models/mixtral-8x7b-4bit,,,,,,,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",32768,FAIL:bench
+gemma-4-31b-it-4bit,./models/gemma-4-31b-it-4bit,512,32,1311.67,390.34,3586.49,8.92,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",512
+gemma-4-31b-it-4bit,./models/gemma-4-31b-it-4bit,2048,32,4186.44,489.20,3758.80,8.51,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",2048
+gemma-4-31b-it-4bit,./models/gemma-4-31b-it-4bit,,,,,,,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",8192,FAIL:bench
+gemma-4-31b-it-4bit,./models/gemma-4-31b-it-4bit,,,,,,,2026-07-03,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",32768,SKIP:oom

--- a/docs/benchmark_results/longprompt-prefill-gb10.md
+++ b/docs/benchmark_results/longprompt-prefill-gb10.md
@@ -1,0 +1,96 @@
+# Long-prompt prefill benchmark ladder (epic #623 #624)
+
+All prior benchmark CSVs (`benchmarks/cuda_gb10_*.csv`, the Metal sets) use
+prompts of 8-66 tokens. At that length the prefill measurement is dominated by
+graph-build and kernel-launch overhead, not matmul/attention throughput, so it
+cannot validate any prefill optimization (MoE prefill fixes, sm_121 GEMM work,
+chunked-prefill tuning). This ladder measures prefill in the compute-bound
+regime by driving deterministic prompts of 512 / 2048 / 8192 / 32768 tokens.
+
+## What was added
+
+- `mlxcel-bench-decode --prompt-tokens N` synthesizes a deterministic prompt by
+  repeating a fixed corpus paragraph, tokenizing with the model's own tokenizer,
+  and truncating to exactly N tokens. The length is capped at the model context
+  (leaving room for `--max-tokens` generation); the actual length used is
+  reported in the existing `prompt_tokens` column.
+- `scripts/bench_decode.sh --prompt-tokens N` threads the flag through and
+  appends one new CSV column, `prompt_target_len` (column 15). The first 14
+  columns are unchanged, so historical CSVs stay comparable. The short-prompt
+  default leaves `prompt_target_len` empty.
+- `scripts/bench_longprompt.sh` runs a representative subset across the ladder
+  into a single CSV, reusing `bench_decode.sh` per cell (so warmup, OOM
+  classification, and the schema are identical).
+
+## Environment
+
+| Item | Value |
+|------|-------|
+| **Hardware** | NVIDIA GB10 (DGX Spark), 122 GB unified LPDDR5x |
+| **OS** | Linux aarch64, kernel 6.17 |
+| **Backend** | CUDA, SM 12.1 |
+| **Build** | `cargo build --release --features cuda` |
+| **mlxcel version** | 0.3.3 |
+| **Harness** | same-process `mlxcel-bench-decode`, warm prefill (warmup=4, max-tokens=32) |
+| **Prompt** | synthesized via `--prompt-tokens`, deterministic repeated corpus |
+
+## How to reproduce
+
+```bash
+# Single model, single length (acceptance check):
+./target/release/mlxcel-bench-decode --model ./models/llama-3.1-8b-4bit --prompt-tokens 8192
+
+# One (model, length) cell through the shell harness (adds prompt_target_len):
+./scripts/bench_decode.sh models/llama-3.1-8b-4bit --prompt-tokens 8192
+
+# Full representative subset across the ladder (auto-named CSV under benchmarks/):
+./scripts/bench_longprompt.sh
+# or with an explicit output path and smaller generation budget:
+./scripts/bench_longprompt.sh --output benchmarks/cuda_gb10_longprompt_2026-07-03.csv --max-tokens 32 --warmup-tokens 4
+```
+
+The ladder is 512 / 2048 / 8192 / 32768 tokens. A cell that exceeds the model
+context is capped (the `prompt_tokens` column shows the actual length). A cell
+that runs out of memory (common at 32768 for the large MoE models) is recorded
+with the usual `SKIP:oom` / `SKIP:oom_estimate` classification and the sweep
+continues.
+
+## Results (prefill throughput, tok/s)
+
+Baseline CSV: `benchmarks/cuda_gb10_longprompt_2026-07-03.csv`. Prefill tok/s at
+each ladder length (higher is better). `fail` = process aborted (exit 134,
+allocation/capacity limit at that length); `oom` = classified out-of-memory.
+
+| Model | kind | 512 | 2048 | 8192 | 32768 |
+|-------|------|----:|-----:|-----:|------:|
+| llama-3.1-8b-4bit | dense | 3286.7 | 2946.0 | 1666.3 | fail |
+| qwen2.5-7b-4bit | dense | 3487.7 | 3125.7 | 1805.0 | 1176.0 (cap 32736) |
+| qwen3-30b-a3b-4bit | MoE | 162.6 | 162.2 | fail | fail |
+| mixtral-8x7b-4bit | MoE | 15.3 | 13.8 | 25.3 | fail |
+| gemma-4-31b-it-4bit | dense | 390.3 | 489.2 | fail | oom |
+
+Reading the numbers:
+
+- Dense 7-8B models prefill at 1600-3500 tok/s and fall as the prompt grows (the O(n^2) attention term), so they are already compute-bound at 512, exactly the regime short 8-66 token prompts cannot reach. qwen2.5-7b (4 KV heads, 28 layers) sustains 32768; llama-3.1-8b (8 KV heads, 32 layers) aborts there on the same host, so the ceiling is model-shape dependent, not a fixed context wall.
+- MoE prefill is the standout weakness this measurement exists to expose. mixtral-8x7b prefills at only 13-25 tok/s (33s at 512, 148s at 2048, 324s at 8192 of wall time), and qwen3-30b-a3b holds ~162 tok/s but aborts at 8192+. Both are far below the dense models at the same length, which is precisely the MoE prefill target of epic #623.
+- Large dense gemma-4-31b prefills well at short lengths (390-489 tok/s, still rising into the compute-bound regime) but cannot reach 8192+ on this host.
+
+This is the measurement foundation the rest of epic #623 builds on: a prefill optimization now has a length axis to move on, and a clear MoE-vs-dense gap to close, instead of a launch-overhead floor.
+
+## Serving telemetry (companion)
+
+The server side of this issue adds two Prometheus histograms, populated once per
+request completion in the batch scheduler's `finalize_completed` (never per
+token):
+
+- `mlxcel_request_ttft_ms` -- per-request time to first token (prefill latency).
+- `mlxcel_request_decode_tok_s` -- per-request decode throughput.
+
+Both are exposed on `/metrics` (requires `--metrics`). Drive concurrent load and
+read them with:
+
+```bash
+./target/release/mlxcel-server -m models/qwen2.5-0.5b-bf16 --port 8080 --metrics &
+python3 scripts/bench_serving_concurrency.py --concurrency 1,2,4,8
+curl -s localhost:8080/metrics | grep -E "ttft|decode_tok"
+```

--- a/scripts/bench_decode.sh
+++ b/scripts/bench_decode.sh
@@ -17,10 +17,18 @@
 # `bench_mlxlm.py` harness and avoiding cold-prefill skew from two separate
 # `mlxcel generate` invocations.
 #
-# CSV columns (14):
+# CSV columns (15):
 #   model, model_path, prompt_tokens, generated_tokens,
 #   prefill_ms, prefill_tok_s, decode_ms, decode_tok_s,
-#   date, hardware, mlx_version, build_type, max_tokens, prompt
+#   date, hardware, mlx_version, build_type, max_tokens, prompt,
+#   prompt_target_len
+#
+# The first 14 columns are unchanged from the historical schema so older CSVs
+# stay comparable. Column 15 (prompt_target_len) records the --prompt-tokens
+# target for long-prompt prefill runs (epic #623 #624) and is empty for the
+# default short-prompt path. The actual prompt length used (after capping at the
+# model context) is still reported in the prompt_tokens column. Any trailing
+# result-classification token (SKIP:*/FAIL:*) follows prompt_target_len.
 #
 # Result classifications (trailing CSV token):
 #   (none)               successful decode with profiling numbers
@@ -59,6 +67,9 @@ TEXT_PROMPT="Hello, how are you today?"
 VLM_PROMPT="What is in this image?"
 MAX_TOKENS=100
 WARMUP_TOKENS=20
+# Optional deterministic long-prompt length (--prompt-tokens N). Empty keeps the
+# short-prompt default so historical CSV rows are byte-compatible.
+PROMPT_TOKENS=""
 TIMEOUT=300
 JIT_PREHEAT_TIMEOUT=600
 VLM_IMAGE="tests/fixtures/test_image.png"
@@ -270,6 +281,11 @@ Options:
                        against raw-prompt mlx-lm stream_generate baselines.
   --max-tokens N      Max tokens to generate (default: 100)
   --warmup-tokens N   Tokens for warmup pass (default: 20)
+  --prompt-tokens N   Synthesize a deterministic prompt of exactly N tokens
+                      (repeated corpus, tokenized, truncated; capped at the
+                      model context) for long-prompt prefill benchmarking.
+                      Recorded in the prompt_target_len CSV column. When unset
+                      the short-prompt --prompt path runs unchanged.
   --timeout N         Timeout per run in seconds (default: 300)
   --jit-preheat-timeout N  Timeout for CUDA JIT warmup in seconds (default: 600)
   --output PATH       Write CSV to specific file (overrides auto-naming)
@@ -381,6 +397,10 @@ bench_one() {
   local model_name
   model_name=$(basename "$model_path")
 
+  # Long-prompt target recorded in the prompt_target_len CSV column; empty for
+  # the short-prompt default so historical rows stay byte-compatible.
+  local ptl="$PROMPT_TOKENS"
+
   # Skip models that won't fit in memory
   if ! model_fits_in_memory "$model_path"; then
     local est_bytes effective_mb limit_mb
@@ -390,7 +410,7 @@ bench_one() {
     effective_mb=$(awk -v b="$est_bytes" -v f="$BENCH_MEM_OVERHEAD_FACTOR" 'BEGIN{printf "%.0f", b * f / 1048576}')
     limit_mb=$(( MEMORY_LIMIT_BYTES / 1048576 ))
     >&2 printf '>>> [skip]   %s (%d MB > %d MB limit)\n' "$model_name" "$effective_mb" "$limit_mb"
-    echo "${model_name},${model_path},,,,,,,$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$TEXT_PROMPT\",SKIP:oom_estimate"
+    echo "${model_name},${model_path},,,,,,,$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$TEXT_PROMPT\",${ptl},SKIP:oom_estimate"
     return
   fi
 
@@ -399,10 +419,15 @@ bench_one() {
   if [[ "$VLM_MODE" -eq 1 ]]; then
     prompt="$VLM_PROMPT"
     if [[ ! -f "$VLM_IMAGE" ]]; then
-      echo "${model_name},${model_path},,,,,,,$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\",SKIP:vlm_image_not_found"
+      echo "${model_name},${model_path},,,,,,,$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\",${ptl},SKIP:vlm_image_not_found"
       return
     fi
     extra_args+=(--image "$VLM_IMAGE")
+  fi
+
+  # Long-prompt prefill mode: synthesize an exactly-N-token prompt in the runner.
+  if [[ -n "$PROMPT_TOKENS" ]]; then
+    extra_args+=(--prompt-tokens "$PROMPT_TOKENS")
   fi
 
   # --- Same-process warmup + measured pass ---
@@ -430,10 +455,10 @@ bench_one() {
   if [[ "$rc" -ne 0 ]]; then
     if is_oom_failure "$rc" "$raw"; then
       >&2 printf '    OOM at load/run (exit %d) — SKIP:oom\n' "$rc"
-      echo "${model_name},${model_path},,,,,,,$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\",SKIP:oom"
+      echo "${model_name},${model_path},,,,,,,$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\",${ptl},SKIP:oom"
     else
       >&2 printf '    benchmark failed (exit %d)\n' "$rc"
-      echo "${model_name},${model_path},,,,,,,$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\",FAIL:bench"
+      echo "${model_name},${model_path},,,,,,,$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\",${ptl},FAIL:bench"
     fi
     return
   fi
@@ -445,10 +470,10 @@ bench_one() {
 
   if [[ -z "$decode_tps" ]]; then
     >&2 echo "    no decode output"
-    echo "${model_name},${model_path},${fields},$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\",FAIL:no_output"
+    echo "${model_name},${model_path},${fields},$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\",${ptl},FAIL:no_output"
   else
     >&2 printf '    decode: %s tok/s\n' "$decode_tps"
-    echo "${model_name},${model_path},${fields},$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\""
+    echo "${model_name},${model_path},${fields},$DATE,$HARDWARE_FULL,$MLX_VERSION,$BUILD_TYPE,$MAX_TOKENS,\"$prompt\",${ptl}"
   fi
 }
 
@@ -488,6 +513,7 @@ while [[ $# -gt 0 ]]; do
     --no-chat-template) NO_CHAT_TEMPLATE=1; shift ;;
     --max-tokens)     MAX_TOKENS="$2"; shift 2 ;;
     --warmup-tokens)  WARMUP_TOKENS="$2"; shift 2 ;;
+    --prompt-tokens)  PROMPT_TOKENS="$2"; shift 2 ;;
     --timeout)        TIMEOUT="$2"; shift 2 ;;
     --jit-preheat-timeout) JIT_PREHEAT_TIMEOUT="$2"; shift 2 ;;
     --output)         OUTPUT="$2"; shift 2 ;;
@@ -538,7 +564,7 @@ fi
 # ---------------------------------------------------------------------------
 # CSV header
 # ---------------------------------------------------------------------------
-CSV_HEADER="model,model_path,prompt_tokens,generated_tokens,prefill_ms,prefill_tok_s,decode_ms,decode_tok_s,date,hardware,mlx_version,build_type,max_tokens,prompt"
+CSV_HEADER="model,model_path,prompt_tokens,generated_tokens,prefill_ms,prefill_tok_s,decode_ms,decode_tok_s,date,hardware,mlx_version,build_type,max_tokens,prompt,prompt_target_len"
 
 mkdir -p "$(dirname "$OUTPUT")"
 echo "$CSV_HEADER" > "$OUTPUT"

--- a/scripts/bench_longprompt.sh
+++ b/scripts/bench_longprompt.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Long-prompt prefill benchmark sweep (epic #623 #624).
+#
+# Runs a representative subset of models across a prompt-length ladder so that
+# prefill throughput is measured in the matmul-bound regime rather than the
+# launch-overhead-bound regime that short (8-66 token) prompts produce. Each
+# cell reuses scripts/bench_decode.sh --prompt-tokens N, so warmup, OOM
+# classification, and the CSV schema are identical to the standard harness; the
+# only added column is prompt_target_len.
+#
+# Usage:
+#   ./scripts/bench_longprompt.sh
+#   ./scripts/bench_longprompt.sh --lengths "512 2048 8192"
+#   ./scripts/bench_longprompt.sh --models "llama-3.1-8b-4bit qwen2.5-7b-4bit"
+#   ./scripts/bench_longprompt.sh --output benchmarks/custom.csv
+#
+# Default output: benchmarks/{backend}_{hardware}_longprompt_{YYYY-MM-DD}.csv
+#   e.g. benchmarks/cuda_gb10_longprompt_2026-07-03.csv
+#
+# A model+length cell that OOMs (common at 32768 for large MoE models) is
+# recorded with the usual SKIP:oom / SKIP:oom_estimate classification and the
+# sweep continues.
+
+set -euo pipefail
+
+trap 'echo "Interrupted (signal received)" >&2; exit 130' INT TERM
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCH_DECODE="${SCRIPT_DIR}/bench_decode.sh"
+MODELS_DIR="./models"
+BENCHMARKS_DIR="./benchmarks"
+DATE=$(date '+%Y-%m-%d')
+
+# Representative subset: mix of dense (llama, qwen2.5), MoE (qwen3-a3b,
+# mixtral), and a large multimodal-capable text model (gemma-4).
+MODELS_DEFAULT="llama-3.1-8b-4bit qwen2.5-7b-4bit qwen3-30b-a3b-4bit mixtral-8x7b-4bit gemma-4-31b-it-4bit"
+LADDER_DEFAULT="512 2048 8192 32768"
+
+MODELS="$MODELS_DEFAULT"
+LADDER="$LADDER_DEFAULT"
+OUTPUT=""
+MAX_TOKENS=32
+WARMUP_TOKENS=4
+COOLDOWN=0
+BIG_COOLDOWN=0
+EXTRA_ARGS=()
+
+usage() {
+  cat <<'EOF'
+Usage: bench_longprompt.sh [options]
+
+Options:
+  --models "A B C"    Space-separated model basenames under ./models
+                      (default: llama-3.1-8b-4bit qwen2.5-7b-4bit
+                      qwen3-30b-a3b-4bit mixtral-8x7b-4bit gemma-4-31b-it-4bit)
+  --lengths "N N N"   Space-separated prompt-token ladder
+                      (default: 512 2048 8192 32768)
+  --max-tokens N      Decode tokens per cell (default: 32; kept small so the
+                      run measures prefill, not decode)
+  --warmup-tokens N   Warmup decode tokens per cell (default: 4)
+  --cooldown N        Seconds to sleep after each cell (default: 0)
+  --big-cooldown N    Extra seconds after a >10GB model (default: 0)
+  --output PATH       Aggregate CSV path (default: auto-named under benchmarks/)
+  --help              Show this help
+
+All cells share one aggregate CSV with the 15-column bench_decode.sh schema
+(prompt_target_len appended). Cell order is model-major, length-minor.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Minimal hardware/backend detection for the default filename (mirrors
+# bench_decode.sh so the two share a naming convention).
+# ---------------------------------------------------------------------------
+detect_backend() {
+  if [[ "$(uname)" == "Linux" ]] && nvidia-smi &>/dev/null; then
+    echo "cuda"
+  else
+    echo "metal"
+  fi
+}
+
+detect_hardware_short() {
+  local chip=""
+  if [[ "$(uname)" == "Darwin" ]]; then
+    chip=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "unknown")
+  else
+    chip=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 || echo "")
+  fi
+  case "$chip" in
+    *M1\ Ultra*) echo "m1ultra" ;;
+    *M5\ Max*)   echo "m5max" ;;
+    *GB10*)      echo "gb10" ;;
+    *)           echo "$chip" | tr '[:upper:] ' '[:lower:]_' | tr ',' '_' | cut -c1-20 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --models)        MODELS="$2"; shift 2 ;;
+    --lengths)       LADDER="$2"; shift 2 ;;
+    --max-tokens)    MAX_TOKENS="$2"; shift 2 ;;
+    --warmup-tokens) WARMUP_TOKENS="$2"; shift 2 ;;
+    --cooldown)      COOLDOWN="$2"; shift 2 ;;
+    --big-cooldown)  BIG_COOLDOWN="$2"; shift 2 ;;
+    --output)        OUTPUT="$2"; shift 2 ;;
+    --help)          usage; exit 0 ;;
+    *)               echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+if [[ ! -x "$BENCH_DECODE" ]]; then
+  echo "Error: $BENCH_DECODE not found or not executable" >&2
+  exit 1
+fi
+
+if [[ -z "$OUTPUT" ]]; then
+  BACKEND=$(detect_backend)
+  HW=$(detect_hardware_short)
+  OUTPUT="${BENCHMARKS_DIR}/${BACKEND}_${HW}_longprompt_${DATE}.csv"
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+: > "$OUTPUT"   # truncate; header is copied from the first cell
+
+TMP_CELL=$(mktemp -t bench_longprompt_cell.XXXXXX.csv)
+cleanup() { rm -f "$TMP_CELL"; }
+trap 'cleanup; echo "Interrupted (signal received)" >&2; exit 130' INT TERM
+trap cleanup EXIT
+
+>&2 echo "Long-prompt sweep"
+>&2 echo "  output:  $OUTPUT"
+>&2 echo "  models:  $MODELS"
+>&2 echo "  lengths: $LADDER"
+>&2 echo "  max-tokens=$MAX_TOKENS warmup-tokens=$WARMUP_TOKENS"
+>&2 echo ""
+
+header_written=0
+for model_name in $MODELS; do
+  model_path="${MODELS_DIR}/${model_name}"
+  if [[ ! -d "$model_path" ]]; then
+    >&2 echo ">>> [miss]   $model_name (not found under $MODELS_DIR, skipping)"
+    continue
+  fi
+  for len in $LADDER; do
+    >&2 echo "=== $model_name @ ${len} tokens ==="
+    # Reuse the standard runner for one (model, length) cell. --output isolates
+    # the cell so the aggregate CSV is never truncated mid-sweep.
+    "$BENCH_DECODE" "$model_path" \
+      --prompt-tokens "$len" \
+      --max-tokens "$MAX_TOKENS" \
+      --warmup-tokens "$WARMUP_TOKENS" \
+      --cooldown "$COOLDOWN" \
+      --big-cooldown "$BIG_COOLDOWN" \
+      --output "$TMP_CELL" \
+      "${EXTRA_ARGS[@]}" >/dev/null || {
+        >&2 echo "    cell runner exited non-zero (continuing)"
+      }
+    if [[ ! -s "$TMP_CELL" ]]; then
+      >&2 echo "    no output produced for this cell (continuing)"
+      continue
+    fi
+    if [[ "$header_written" -eq 0 ]]; then
+      cat "$TMP_CELL" >> "$OUTPUT"
+      header_written=1
+    else
+      tail -n +2 "$TMP_CELL" >> "$OUTPUT"
+    fi
+  done
+done
+
+>&2 echo ""
+>&2 echo "Long-prompt results saved to: $OUTPUT"

--- a/scripts/bench_serving_concurrency.py
+++ b/scripts/bench_serving_concurrency.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Concurrency load generator for the mlxcel OpenAI-compatible server.
+
+Fires N concurrent streaming chat-completion requests against a running
+``mlxcel-server`` and reports, per concurrency level, the mean/p50/p95
+time-to-first-token (TTFT), the mean per-request decode throughput, and the
+aggregate server throughput (all completion tokens divided by the wall-clock
+span of the level). This is the serving-side companion to the offline
+``bench_decode.sh`` / ``bench_longprompt.sh`` prefill benchmarks (epic #623
+#624).
+
+Only the Python standard library is used: each request runs on a worker thread
+via ``asyncio``'s default executor and speaks HTTP/1.1 through ``http.client``,
+so no third-party HTTP client is required.
+
+Examples:
+    # Sweep the default concurrency ladder (1, 2, 4, 8):
+    python3 scripts/bench_serving_concurrency.py
+
+    # Single concurrency level against a non-default port:
+    python3 scripts/bench_serving_concurrency.py --concurrency 4 --port 8081
+
+    # Longer prompts and more decode tokens:
+    python3 scripts/bench_serving_concurrency.py --prompt-tokens 2048 --max-tokens 256
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import http.client
+import json
+import statistics
+import time
+from dataclasses import dataclass, field
+
+# Base sentence repeated to synthesize a prompt of an approximate token length.
+# The server tokenizes it; the client only needs a roughly-sized input, so a
+# words-per-token heuristic is sufficient here.
+_BASE_SENTENCE = (
+    "The quick brown fox jumps over the lazy dog while the benchmark harness "
+    "measures prefill and decode throughput under concurrent streaming load. "
+)
+# Rough tokens-per-word factor for English BPE tokenizers; only used to size the
+# synthetic prompt, never for reporting.
+_TOKENS_PER_WORD = 1.3
+
+
+@dataclass
+class RequestResult:
+    """Outcome of a single streaming request."""
+
+    ok: bool
+    ttft_s: float | None = None
+    decode_tok_s: float | None = None
+    completion_tokens: int = 0
+    total_s: float = 0.0
+    start_s: float = 0.0
+    end_s: float = 0.0
+    error: str | None = None
+
+
+@dataclass
+class LevelSummary:
+    """Aggregated results for one concurrency level."""
+
+    concurrency: int
+    ok_count: int
+    fail_count: int
+    ttft_ms: list[float] = field(default_factory=list)
+    decode_tok_s: list[float] = field(default_factory=list)
+    total_completion_tokens: int = 0
+    wall_s: float = 0.0
+
+    @property
+    def aggregate_tok_s(self) -> float:
+        """Total completion tokens divided by the level's wall-clock span."""
+        return self.total_completion_tokens / self.wall_s if self.wall_s > 0 else 0.0
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Return the ``pct`` percentile (0-100) of ``values`` (nearest-rank)."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = max(0, min(len(ordered) - 1, int(round(pct / 100.0 * (len(ordered) - 1)))))
+    return ordered[rank]
+
+
+def build_prompt(prompt_tokens: int) -> str:
+    """Build a synthetic prompt of roughly ``prompt_tokens`` tokens."""
+    words_per_copy = len(_BASE_SENTENCE.split())
+    target_words = max(words_per_copy, int(prompt_tokens / _TOKENS_PER_WORD))
+    copies = max(1, target_words // words_per_copy + 1)
+    return (_BASE_SENTENCE * copies).strip()
+
+
+def resolve_model(host: str, port: int, override: str | None) -> str:
+    """Resolve the served model id, preferring an explicit override.
+
+    Falls back to querying ``/v1/models`` and finally to ``"default"`` so the
+    script works even when the server does not enforce the model name.
+    """
+    if override:
+        return override
+    try:
+        conn = http.client.HTTPConnection(host, port, timeout=10)
+        conn.request("GET", "/v1/models")
+        resp = conn.getresponse()
+        body = resp.read()
+        conn.close()
+        if resp.status == 200:
+            data = json.loads(body)
+            models = data.get("data") or []
+            if models and isinstance(models[0], dict) and models[0].get("id"):
+                return str(models[0]["id"])
+    except (OSError, ValueError):
+        pass
+    return "default"
+
+
+def stream_request(
+    host: str,
+    port: int,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    timeout: float,
+) -> RequestResult:
+    """Issue one streaming chat completion and time it (blocking).
+
+    Runs on a worker thread. Counts completion tokens from the final ``usage``
+    chunk when the server emits one, otherwise from the number of non-empty
+    content deltas as a proxy.
+    """
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+    )
+    headers = {"Content-Type": "application/json", "Accept": "text/event-stream"}
+    start = time.perf_counter()
+    ttft: float | None = None
+    delta_tokens = 0
+    usage_tokens: int | None = None
+    try:
+        conn = http.client.HTTPConnection(host, port, timeout=timeout)
+        conn.request("POST", "/v1/chat/completions", body=payload, headers=headers)
+        resp = conn.getresponse()
+        if resp.status != 200:
+            body = resp.read().decode("utf-8", "replace")[:200]
+            conn.close()
+            return RequestResult(ok=False, error=f"HTTP {resp.status}: {body}")
+
+        buf = b""
+        while True:
+            chunk = resp.read(1)
+            if not chunk:
+                break
+            buf += chunk
+            if not buf.endswith(b"\n"):
+                continue
+            line = buf.strip()
+            buf = b""
+            if not line.startswith(b"data:"):
+                continue
+            data = line[len(b"data:") :].strip()
+            if data == b"[DONE]":
+                break
+            try:
+                event = json.loads(data)
+            except ValueError:
+                continue
+            usage = event.get("usage")
+            if isinstance(usage, dict) and usage.get("completion_tokens") is not None:
+                usage_tokens = int(usage["completion_tokens"])
+            for choice in event.get("choices", []) or []:
+                content = (choice.get("delta") or {}).get("content")
+                if content:
+                    if ttft is None:
+                        ttft = time.perf_counter() - start
+                    delta_tokens += 1
+        conn.close()
+    except (OSError, http.client.HTTPException) as exc:
+        return RequestResult(ok=False, error=str(exc))
+
+    end = time.perf_counter()
+    completion_tokens = usage_tokens if usage_tokens is not None else delta_tokens
+    total_s = end - start
+    decode_tok_s: float | None = None
+    if ttft is not None and completion_tokens > 1:
+        decode_span = total_s - ttft
+        if decode_span > 0:
+            decode_tok_s = (completion_tokens - 1) / decode_span
+    return RequestResult(
+        ok=True,
+        ttft_s=ttft,
+        decode_tok_s=decode_tok_s,
+        completion_tokens=completion_tokens,
+        total_s=total_s,
+        start_s=start,
+        end_s=end,
+    )
+
+
+async def run_level(
+    concurrency: int,
+    host: str,
+    port: int,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    timeout: float,
+) -> LevelSummary:
+    """Run ``concurrency`` requests in parallel and aggregate the results."""
+    loop = asyncio.get_running_loop()
+    tasks = [
+        loop.run_in_executor(
+            None, stream_request, host, port, model, prompt, max_tokens, timeout
+        )
+        for _ in range(concurrency)
+    ]
+    results: list[RequestResult] = await asyncio.gather(*tasks)
+
+    ok = [r for r in results if r.ok]
+    fail = [r for r in results if not r.ok]
+    summary = LevelSummary(
+        concurrency=concurrency,
+        ok_count=len(ok),
+        fail_count=len(fail),
+    )
+    for r in ok:
+        if r.ttft_s is not None:
+            summary.ttft_ms.append(r.ttft_s * 1000.0)
+        if r.decode_tok_s is not None:
+            summary.decode_tok_s.append(r.decode_tok_s)
+        summary.total_completion_tokens += r.completion_tokens
+    if ok:
+        summary.wall_s = max(r.end_s for r in ok) - min(r.start_s for r in ok)
+    for r in fail:
+        print(f"    request error: {r.error}")
+    return summary
+
+
+def print_table(summaries: list[LevelSummary]) -> None:
+    """Print the per-level summary table to stdout."""
+    header = (
+        f"{'conc':>4}  {'ok':>3}  {'fail':>4}  "
+        f"{'ttft_ms(mean)':>13}  {'ttft_ms(p95)':>12}  "
+        f"{'decode_tok_s(mean)':>18}  {'aggregate_tok_s':>15}"
+    )
+    print("\n" + header)
+    print("-" * len(header))
+    for s in summaries:
+        ttft_mean = statistics.mean(s.ttft_ms) if s.ttft_ms else 0.0
+        ttft_p95 = _percentile(s.ttft_ms, 95)
+        decode_mean = statistics.mean(s.decode_tok_s) if s.decode_tok_s else 0.0
+        print(
+            f"{s.concurrency:>4}  {s.ok_count:>3}  {s.fail_count:>4}  "
+            f"{ttft_mean:>13.1f}  {ttft_p95:>12.1f}  "
+            f"{decode_mean:>18.1f}  {s.aggregate_tok_s:>15.1f}"
+        )
+    print()
+
+
+def parse_concurrency(spec: str) -> list[int]:
+    """Parse a comma-separated concurrency spec into a list of positive ints."""
+    levels: list[int] = []
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        value = int(part)
+        if value <= 0:
+            raise ValueError(f"concurrency must be positive, got {value}")
+        levels.append(value)
+    if not levels:
+        raise ValueError("no concurrency levels parsed")
+    return levels
+
+
+async def _amain(args: argparse.Namespace) -> int:
+    model = resolve_model(args.host, args.port, args.model)
+    prompt = build_prompt(args.prompt_tokens)
+    levels = parse_concurrency(args.concurrency)
+
+    print(f"Server:       http://{args.host}:{args.port}")
+    print(f"Model:        {model}")
+    print(f"Prompt:       ~{args.prompt_tokens} tokens ({len(prompt)} chars)")
+    print(f"Max tokens:   {args.max_tokens}")
+    print(f"Concurrency:  {levels}")
+
+    summaries: list[LevelSummary] = []
+    for level in levels:
+        print(f"\n>>> concurrency={level} ...")
+        summary = await run_level(
+            level,
+            args.host,
+            args.port,
+            model,
+            prompt,
+            args.max_tokens,
+            args.timeout,
+        )
+        summaries.append(summary)
+
+    print_table(summaries)
+    # Non-zero exit if every request at some level failed (server likely down).
+    any_ok = any(s.ok_count > 0 for s in summaries)
+    return 0 if any_ok else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Concurrency load generator for the mlxcel OpenAI-compatible server."
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Server host (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8080, help="Server port (default: 8080)")
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Model id (default: resolved from /v1/models, else 'default')",
+    )
+    parser.add_argument(
+        "--concurrency",
+        default="1,2,4,8",
+        help="Comma-separated concurrency levels (default: 1,2,4,8)",
+    )
+    parser.add_argument(
+        "--prompt-tokens",
+        type=int,
+        default=512,
+        help="Approximate synthetic prompt length in tokens (default: 512)",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=128,
+        help="Max tokens to generate per request (default: 128)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=600.0,
+        help="Per-request socket timeout in seconds (default: 600)",
+    )
+    args = parser.parse_args()
+    return asyncio.run(_amain(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bin/bench_decode.rs
+++ b/src/bin/bench_decode.rs
@@ -58,6 +58,17 @@ struct Args {
     #[arg(long, default_value_t = 20)]
     warmup_tokens: usize,
 
+    /// Synthesize a deterministic prompt of exactly N tokens instead of using
+    /// `--prompt`, for long-prompt prefill benchmarking (epic #623 #624). The
+    /// prompt is built by repeating a fixed corpus paragraph, tokenizing with
+    /// the model's tokenizer, and truncating to N tokens, so it reproduces
+    /// across models. Capped at the model's context window (leaving room for
+    /// `--max-tokens` generation); the actual length used is reported in the
+    /// `Prompt tokens` profile field. When unset, the short-prompt `--prompt`
+    /// path is used unchanged.
+    #[arg(long, value_name = "N")]
+    prompt_tokens: Option<usize>,
+
     /// Image path(s) for VLM benchmark mode.
     #[arg(long, value_name = "PATH", num_args = 1..)]
     image: Vec<PathBuf>,
@@ -144,6 +155,80 @@ fn tokenize_prompt(tokenizer: &MlxcelTokenizer, prompt: &str) -> Result<Vec<i32>
         .encode(prompt, add_special)
         .map_err(|err| anyhow::anyhow!("tokenization failed: {err}"))?;
     Ok(ids.into_iter().map(|id| id as i32).collect())
+}
+
+/// Fixed corpus paragraph repeated to synthesize long prompts. Kept constant
+/// so the `--prompt-tokens N` prompt is byte-identical across benchmark runs
+/// and models (only the tokenizer differs). Neutral prose with punctuation and
+/// varied vocabulary so the token stream resembles real text rather than a
+/// single repeated token.
+const LONG_PROMPT_CORPUS: &str = concat!(
+    "The measurement of large language model inference performance depends on ",
+    "both prefill and decode throughput. During prefill the entire prompt is ",
+    "processed in a single forward pass, so its cost grows with the prompt ",
+    "length and exercises the matrix-multiply kernels at large batch widths. ",
+    "During decode each new token is generated one step at a time, which ",
+    "stresses memory bandwidth and kernel launch overhead instead. A benchmark ",
+    "that only uses short prompts cannot separate these two regimes, because a ",
+    "few dozen prompt tokens are dominated by fixed launch costs. To study ",
+    "prefill behaviour honestly we therefore need prompts that are hundreds or ",
+    "thousands of tokens long, repeated deterministically so that every run ",
+    "observes the same input and the numbers stay comparable over time.\n\n",
+);
+
+/// Build a deterministic prompt of exactly `target_len` tokens by repeating
+/// [`LONG_PROMPT_CORPUS`], tokenizing once with the model's tokenizer, and
+/// truncating. Returns fewer than `target_len` tokens only if `target_len` is
+/// `0`.
+fn synthesize_prompt_tokens(tokenizer: &MlxcelTokenizer, target_len: usize) -> Result<Vec<i32>> {
+    if target_len == 0 {
+        return Ok(Vec::new());
+    }
+    // Estimate tokens per corpus copy (without special tokens) to size the
+    // repeated string, then over-provision so the final tokenization always
+    // yields at least `target_len` tokens before truncation.
+    let per_copy = tokenizer
+        .encode(LONG_PROMPT_CORPUS, false)
+        .map_err(|err| anyhow::anyhow!("tokenization failed: {err}"))?
+        .len()
+        .max(1);
+    let repeats = target_len / per_copy + 4;
+    let corpus = LONG_PROMPT_CORPUS.repeat(repeats);
+    let mut ids: Vec<i32> = tokenizer
+        .encode(&corpus, true)
+        .map_err(|err| anyhow::anyhow!("tokenization failed: {err}"))?
+        .into_iter()
+        .map(|id| id as i32)
+        .collect();
+    ids.truncate(target_len);
+    Ok(ids)
+}
+
+/// Prepare a synthesized long prompt of `target_len` tokens, capped at the
+/// model's context window minus a reservation for the tokens to be generated.
+/// Returns the prepared prompt and the effective (post-cap) token length.
+fn prepare_long_prompt(
+    tokenizer: &MlxcelTokenizer,
+    target_len: usize,
+    max_context: Option<usize>,
+    reserve_for_generation: usize,
+) -> Result<(PreparedPrompt, usize)> {
+    let effective = match max_context {
+        Some(ctx) => {
+            let usable = ctx.saturating_sub(reserve_for_generation).max(1);
+            target_len.min(usable)
+        }
+        None => target_len,
+    };
+    let tokens = synthesize_prompt_tokens(tokenizer, effective)?;
+    let actual = tokens.len();
+    Ok((
+        PreparedPrompt {
+            tokens,
+            embeddings: None,
+        },
+        actual,
+    ))
 }
 
 fn prepare_prompt(
@@ -300,14 +385,35 @@ fn main() -> Result<()> {
     let tokenizer = load_tokenizer(&args.model).unwrap_or(loaded_tokenizer);
     let sampling = sampling_config(&args.model);
 
-    let prepared = prepare_prompt(
-        &model,
-        &args.model,
-        &tokenizer,
-        &args.prompt,
-        args.no_chat_template,
-        &args.image,
-    )?;
+    // `--prompt-tokens N` synthesizes a deterministic long prompt for prefill
+    // benchmarking; otherwise the short-prompt `--prompt` path runs unchanged.
+    // The closure regenerates the prepared prompt on demand so both the warmup
+    // and measured passes see an identical input (long prompts are text-only;
+    // any `--image` args are ignored in this mode).
+    let max_context = mlxcel::read_model_context_window(&args.model);
+    let make_prepared = || -> Result<PreparedPrompt> {
+        if let Some(target) = args.prompt_tokens {
+            let (prepared, actual) =
+                prepare_long_prompt(&tokenizer, target, max_context, args.max_tokens)?;
+            eprintln!(
+                "[long-prompt] target={target} tokens -> using {actual} tokens \
+                 (max_context={max_context:?}, reserved {} for generation)",
+                args.max_tokens
+            );
+            Ok(prepared)
+        } else {
+            prepare_prompt(
+                &model,
+                &args.model,
+                &tokenizer,
+                &args.prompt,
+                args.no_chat_template,
+                &args.image,
+            )
+        }
+    };
+
+    let prepared = make_prepared()?;
     warmup(
         &model,
         &prepared,
@@ -323,14 +429,7 @@ fn main() -> Result<()> {
     // call). The warmup pass consumes that state, so regenerate the prepared
     // prompt before the measured pass. For text-only models this is cheap; for
     // VLM it re-runs the vision encoder against now-warm MLX/Metal state.
-    let prepared = prepare_prompt(
-        &model,
-        &args.model,
-        &tokenizer,
-        &args.prompt,
-        args.no_chat_template,
-        &args.image,
-    )?;
+    let prepared = make_prepared()?;
     let stats = measured(&model, &prepared, args.max_tokens, &sampling, kv_cache_mode)?;
 
     println!("[Profile Results]");

--- a/src/server/batch/observability.rs
+++ b/src/server/batch/observability.rs
@@ -28,6 +28,114 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use mlxcel_core::cache::PagedCacheStats;
 use serde::Serialize;
 
+/// Inclusive upper bounds for the per-request time-to-first-token histogram,
+/// in milliseconds. Chosen to span sub-100ms short-prompt TTFT through the
+/// multi-second range that long-prompt prefill produces (epic #623 #624).
+const TTFT_MS_BUCKETS: [f64; 12] = [
+    5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 30000.0,
+];
+
+/// Inclusive upper bounds for the per-request decode-rate histogram, in
+/// tokens/second. Covers the range from heavily-batched large-model decode up
+/// through small-model single-request rates on accelerated hardware.
+const DECODE_TOK_S_BUCKETS: [f64; 12] = [
+    1.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 150.0, 200.0, 300.0, 500.0, 1000.0,
+];
+
+/// Fixed-bucket cumulative histogram for per-request telemetry.
+///
+/// Prometheus histogram semantics: each observation lands in the first bucket
+/// whose inclusive upper bound is `>= value`, otherwise the implicit `+Inf`
+/// bucket. Bucket counts are stored non-cumulatively and made cumulative at
+/// snapshot time. [`observe`](Self::observe) runs exactly once per request
+/// completion (never per token), so the compare-exchange loop used to
+/// accumulate the floating-point `_sum` is negligible overhead.
+pub struct RequestHistogram {
+    bounds: &'static [f64],
+    counts: Vec<AtomicU64>,
+    sum_bits: AtomicU64,
+    count: AtomicU64,
+}
+
+impl RequestHistogram {
+    fn new(bounds: &'static [f64]) -> Self {
+        let counts = bounds.iter().map(|_| AtomicU64::new(0)).collect();
+        Self {
+            bounds,
+            counts,
+            sum_bits: AtomicU64::new(0.0_f64.to_bits()),
+            count: AtomicU64::new(0),
+        }
+    }
+
+    /// Record a single observation. Non-finite or negative values are clamped
+    /// to `0.0` so a stray timing can never corrupt the running sum.
+    pub fn observe(&self, value: f64) {
+        let value = if value.is_finite() && value > 0.0 {
+            value
+        } else {
+            0.0
+        };
+        self.count.fetch_add(1, Ordering::Relaxed);
+
+        // Accumulate the f64 sum via a compare-exchange loop so the result is
+        // correct regardless of writer count. Only reached once per request.
+        let mut cur = self.sum_bits.load(Ordering::Relaxed);
+        loop {
+            let next = f64::from_bits(cur) + value;
+            match self.sum_bits.compare_exchange_weak(
+                cur,
+                next.to_bits(),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => cur = actual,
+            }
+        }
+
+        for (i, &bound) in self.bounds.iter().enumerate() {
+            if value <= bound {
+                self.counts[i].fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        }
+        // Value exceeds every finite bound; it belongs to the +Inf bucket only,
+        // which the snapshot derives from the total `count`.
+    }
+
+    /// Snapshot with cumulative bucket counts (Prometheus `le` semantics).
+    pub fn snapshot(&self) -> HistogramSnapshot {
+        let mut cumulative = 0u64;
+        let buckets = self
+            .bounds
+            .iter()
+            .enumerate()
+            .map(|(i, &bound)| {
+                cumulative += self.counts[i].load(Ordering::Relaxed);
+                (bound, cumulative)
+            })
+            .collect();
+        HistogramSnapshot {
+            buckets,
+            sum: f64::from_bits(self.sum_bits.load(Ordering::Relaxed)),
+            count: self.count.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Serializable snapshot of a [`RequestHistogram`].
+///
+/// `buckets` holds `(inclusive_upper_bound, cumulative_count)` pairs for the
+/// finite buckets; the `+Inf` bucket equals `count`. `sum` is the running total
+/// of observed values.
+#[derive(Debug, Clone)]
+pub struct HistogramSnapshot {
+    pub buckets: Vec<(f64, u64)>,
+    pub sum: f64,
+    pub count: u64,
+}
+
 /// Detailed observability counters for the batch scheduler.
 ///
 /// These complement the coarser [`BatchMetrics`] already tracked in
@@ -90,6 +198,14 @@ pub struct BatchObservability {
     /// (e.g. `InsertError::OversizedEntry`, `InsertError::Disabled`,
     /// `InsertError::PrefixTooShort`).
     pub prompt_cache_insert_rejects: AtomicU64,
+
+    // -- per-request latency/throughput histograms (epic #623 #624) --
+    /// Per-request time-to-first-token (prefill latency), in milliseconds.
+    /// Recorded once per completed request in `finalize_completed`.
+    pub request_ttft_ms: RequestHistogram,
+    /// Per-request decode throughput, in tokens/second. Recorded once per
+    /// completed request from `completion_tokens / generation_only_ms`.
+    pub request_decode_tok_s: RequestHistogram,
 }
 
 impl Default for BatchObservability {
@@ -124,6 +240,8 @@ impl BatchObservability {
             prompt_cache_hit_tokens: AtomicU64::new(0),
             prompt_cache_inserts: AtomicU64::new(0),
             prompt_cache_insert_rejects: AtomicU64::new(0),
+            request_ttft_ms: RequestHistogram::new(&TTFT_MS_BUCKETS),
+            request_decode_tok_s: RequestHistogram::new(&DECODE_TOK_S_BUCKETS),
         }
     }
 
@@ -181,6 +299,41 @@ impl BatchObservability {
     pub fn record_prompt_cache_insert_reject(&self) {
         self.prompt_cache_insert_rejects
             .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record per-request completion telemetry: time-to-first-token and the
+    /// observed decode rate. Called exactly once per finished sequence from the
+    /// scheduler thread (never per token), so the cost is negligible.
+    ///
+    /// Requests that produced no completion tokens are ignored: TTFT is
+    /// undefined without a first token and a zero-length generation has no
+    /// decode rate. The decode-rate observation is likewise skipped when the
+    /// decode phase rounded to 0ms (single-token completions), where a rate is
+    /// not measurable.
+    pub fn record_request_completion(
+        &self,
+        prompt_eval_ms: u64,
+        generation_only_ms: u64,
+        completion_tokens: usize,
+    ) {
+        if completion_tokens == 0 {
+            return;
+        }
+        self.request_ttft_ms.observe(prompt_eval_ms as f64);
+        if generation_only_ms > 0 {
+            let decode_tok_s = completion_tokens as f64 * 1000.0 / generation_only_ms as f64;
+            self.request_decode_tok_s.observe(decode_tok_s);
+        }
+    }
+
+    /// Snapshot of the per-request TTFT histogram for the `/metrics` endpoint.
+    pub fn ttft_ms_snapshot(&self) -> HistogramSnapshot {
+        self.request_ttft_ms.snapshot()
+    }
+
+    /// Snapshot of the per-request decode-rate histogram for `/metrics`.
+    pub fn decode_tok_s_snapshot(&self) -> HistogramSnapshot {
+        self.request_decode_tok_s.snapshot()
     }
 
     // -- Gauge updates (called by the scheduler thread) --
@@ -385,6 +538,61 @@ mod tests {
         assert_eq!(snap.cache_pool_paged_bytes_reserved, 8192);
         assert_eq!(snap.cache_pool_paged_bytes_in_use, 6144);
         assert_eq!(snap.cache_pool_paged_block_budget, 64);
+    }
+
+    #[test]
+    fn record_request_completion_populates_histograms() {
+        let obs = BatchObservability::new();
+        // 200ms TTFT, 100 decode tokens over 1000ms decode -> 100 tok/s.
+        obs.record_request_completion(200, 1000, 100);
+        // 40ms TTFT, 20 tokens over 500ms -> 40 tok/s.
+        obs.record_request_completion(40, 500, 20);
+
+        let ttft = obs.ttft_ms_snapshot();
+        assert_eq!(ttft.count, 2);
+        assert!((ttft.sum - 240.0).abs() < 1e-6);
+        // le=50 bucket (index 3) should include only the 40ms observation.
+        assert_eq!(ttft.buckets[3].0, 50.0);
+        assert_eq!(ttft.buckets[3].1, 1);
+        // le=250 bucket (index 5) should include both observations.
+        assert_eq!(ttft.buckets[5].0, 250.0);
+        assert_eq!(ttft.buckets[5].1, 2);
+
+        let decode = obs.decode_tok_s_snapshot();
+        assert_eq!(decode.count, 2);
+        assert!((decode.sum - 140.0).abs() < 1e-6);
+        // le=50 bucket (index 4) includes only the 40 tok/s observation.
+        assert_eq!(decode.buckets[4].0, 50.0);
+        assert_eq!(decode.buckets[4].1, 1);
+        // le=100 bucket (index 6) includes both observations.
+        assert_eq!(decode.buckets[6].0, 100.0);
+        assert_eq!(decode.buckets[6].1, 2);
+    }
+
+    #[test]
+    fn record_request_completion_skips_zero_token_requests() {
+        let obs = BatchObservability::new();
+        // Zero completion tokens: neither histogram should record anything.
+        obs.record_request_completion(500, 0, 0);
+        assert_eq!(obs.ttft_ms_snapshot().count, 0);
+        assert_eq!(obs.decode_tok_s_snapshot().count, 0);
+
+        // One token with a 0ms decode phase: TTFT records, decode rate skips.
+        obs.record_request_completion(120, 0, 1);
+        assert_eq!(obs.ttft_ms_snapshot().count, 1);
+        assert_eq!(obs.decode_tok_s_snapshot().count, 0);
+    }
+
+    #[test]
+    fn histogram_counts_plus_inf_observations() {
+        let obs = BatchObservability::new();
+        // 40000ms exceeds the largest finite TTFT bound (30000ms).
+        obs.record_request_completion(40_000, 1000, 10);
+        let ttft = obs.ttft_ms_snapshot();
+        assert_eq!(ttft.count, 1);
+        // No finite bucket captured the observation; the +Inf bucket (== count)
+        // still accounts for it.
+        assert_eq!(ttft.buckets.last().unwrap().1, 0);
     }
 
     #[test]

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -4949,6 +4949,14 @@ impl BatchScheduler {
                     seq.max_tokens,
                     cached,
                 );
+                // Per-request TTFT / decode-rate telemetry (epic #623 #624).
+                // Recorded once here, where the finished sequence's timings are
+                // available, never on the per-token hot path.
+                self.batch_observability.record_request_completion(
+                    result.prompt_eval_ms,
+                    result.generation_only_ms,
+                    result.completion_tokens,
+                );
                 tracing::info!(
                     prompt_tokens = seq.prompt_tokens.len(),
                     cached_tokens = cached,

--- a/src/server/routes/metrics.rs
+++ b/src/server/routes/metrics.rs
@@ -35,6 +35,7 @@ use axum::{
 
 use crate::distributed::pipeline::PipelineObservabilitySnapshot;
 use crate::server::AppState;
+use crate::server::batch::observability::HistogramSnapshot;
 
 /// GET /metrics -- Prometheus text format
 pub async fn metrics(State(state): State<AppState>) -> Response {
@@ -261,6 +262,24 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
     );
 
     let mut body = body;
+
+    // Per-request TTFT / decode-rate histograms (epic #623 #624). Populated
+    // once per completed request by the scheduler's `finalize_completed`.
+    let ttft = state.batch_observability.ttft_ms_snapshot();
+    let decode_rate = state.batch_observability.decode_tok_s_snapshot();
+    append_request_histogram(
+        &mut body,
+        "mlxcel_request_ttft_ms",
+        "Per-request time to first token (prefill latency) in milliseconds",
+        &ttft,
+    );
+    append_request_histogram(
+        &mut body,
+        "mlxcel_request_decode_tok_s",
+        "Per-request decode throughput in tokens per second",
+        &decode_rate,
+    );
+
     append_pipeline_metrics(&mut body, &pp_snapshot);
 
     (
@@ -271,6 +290,22 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
         body,
     )
         .into_response()
+}
+
+/// Append one per-request histogram family in Prometheus text format.
+///
+/// Emits the standard `_bucket{le="…"}` cumulative series (including the
+/// `le="+Inf"` bucket), `_sum`, and `_count` lines. The snapshot reads its
+/// atomics exactly once, so this is safe to call on every scrape.
+fn append_request_histogram(body: &mut String, name: &str, help: &str, snap: &HistogramSnapshot) {
+    let _ = writeln!(body, "# HELP {name} {help}");
+    let _ = writeln!(body, "# TYPE {name} histogram");
+    for (bound, cumulative) in &snap.buckets {
+        let _ = writeln!(body, "{name}_bucket{{le=\"{bound}\"}} {cumulative}");
+    }
+    let _ = writeln!(body, "{name}_bucket{{le=\"+Inf\"}} {}", snap.count);
+    let _ = writeln!(body, "{name}_sum {:.3}", snap.sum);
+    let _ = writeln!(body, "{name}_count {}", snap.count);
 }
 
 /// Append the pipeline-parallel observability families in Prometheus text


### PR DESCRIPTION
## Summary

Measurement foundation for epic #623: long-prompt prefill benchmarking plus serving-level TTFT and decode-rate telemetry. Existing benchmark CSVs use 8-66 token prompts whose prefill is launch-overhead-bound, and the server exposed only aggregate counters, so neither prefill optimizations nor batching/pipelining changes could be measured. The short-prompt path, the historical CSV schema (first 14 columns), and Metal behavior are all unchanged.

## What changed

- `src/bin/bench_decode.rs`: new `--prompt-tokens N` flag that synthesizes a deterministic prompt (repeated fixed corpus, tokenized with the model's own tokenizer, truncated to exactly N) capped at the model context window (`read_model_context_window`), reporting the actual length used in the existing `prompt_tokens` field. The short-prompt `--prompt` path is untouched.
- `scripts/bench_decode.sh`: threads `--prompt-tokens` through and appends one new CSV column `prompt_target_len` (column 15). Columns 1-14 are byte-identical to the historical schema; the column is empty for short-prompt runs and any `SKIP:*`/`FAIL:*` classification token still trails it.
- `scripts/bench_longprompt.sh` (new): runs the representative subset (llama-3.1-8b-4bit, qwen2.5-7b-4bit, qwen3-30b-a3b-4bit, mixtral-8x7b-4bit, gemma-4-31b-it-4bit) across the 512/2048/8192/32768 ladder into one CSV, reusing `bench_decode.sh` per cell so warmup and OOM classification are identical.
- `src/server/batch/observability.rs`: adds a `RequestHistogram` (fixed-bucket, atomic) and two instances, `request_ttft_ms` and `request_decode_tok_s`, plus `record_request_completion` (skips zero-token completions) and snapshot accessors, with unit tests.
- `src/server/batch/scheduler.rs`: records per-request TTFT/decode-rate once in `finalize_completed` where the finished sequence's timings are available (never on the per-token path).
- `src/server/routes/metrics.rs`: exports `mlxcel_request_ttft_ms` and `mlxcel_request_decode_tok_s` on `/metrics` with the standard `_bucket`/`_sum`/`_count` series.
- `scripts/bench_serving_concurrency.py` (new): stdlib asyncio client over the OpenAI-compatible streaming API that fires N concurrent requests and reports per-request TTFT, decode tok/s, and aggregate tok/s for N in {1,2,4,8}.
- `benchmarks/cuda_gb10_longprompt_2026-07-03.csv` and `docs/benchmark_results/longprompt-prefill-gb10.md`: committed GB10 baseline and a note describing the ladder and reproduction.

## Baseline numbers (GB10, prefill tok/s)

| Model | 512 | 2048 | 8192 | 32768 |
|-------|----:|-----:|-----:|------:|
| llama-3.1-8b-4bit | 3286.7 | 2946.0 | 1666.3 | fail |
| qwen2.5-7b-4bit | 3487.7 | 3125.7 | 1805.0 | 1176.0 (cap 32736) |
| qwen3-30b-a3b-4bit (MoE) | 162.6 | 162.2 | fail | fail |
| mixtral-8x7b-4bit (MoE) | 15.3 | 13.8 | 25.3 | fail |
| gemma-4-31b-it-4bit | 390.3 | 489.2 | fail | oom |

MoE prefill (mixtral 13-25 tok/s, qwen3-30b-a3b ~162 tok/s) is far below dense at the same length, which is exactly the epic #623 target. `fail` marks an exit-134 allocation/capacity abort at that length; `oom` is a classified out-of-memory.

## Test plan

- [x] `cargo build --release --features cuda` succeeds.
- [x] `mlxcel-bench-decode --model ./models/llama-3.1-8b-4bit --prompt-tokens 8192` emits a CSV row with `prompt_target_len`; a short-prompt run keeps the old 14 columns and appends an empty `prompt_target_len`.
- [x] `cargo test --release --features cuda -p mlxcel --lib batch::observability` passes (9 tests) and `cargo clippy --release --features cuda -p mlxcel` is clean on touched code.
- [x] `mlxcel-server -m models/qwen2.5-0.5b-bf16 --metrics` plus real requests populate `mlxcel_request_ttft_ms` and `mlxcel_request_decode_tok_s` on `/metrics` (verified count/sum/buckets).
- [x] `python3 scripts/bench_serving_concurrency.py --concurrency 1,2,4,8` prints a summary table against the running server.

Closes #624
