### PR TITLE
fix: parse GPT-OSS Harmony tool calls into structured calls

### DIFF
--- a/src/server/routes/anthropic.rs
+++ b/src/server/routes/anthropic.rs
@@ -553,7 +553,12 @@ fn split_visible_reasoning(
     raw: &str,
     parsed: Option<&tool_calls::ToolCallParseResult>,
 ) -> (String, Option<String>) {
-    let reasoning = extract_reasoning_from_raw(raw);
+    // Harmony (GPT-OSS) carries its `analysis` channel as reasoning inside the
+    // parse result; prefer it, falling back to the raw `<think>` scan for
+    // families whose reasoning is a separable block.
+    let reasoning = parsed
+        .and_then(|p| p.reasoning_content.clone())
+        .or_else(|| extract_reasoning_from_raw(raw));
     let visible_source = match parsed {
         Some(p) => p.content.clone(),
         None => tool_calls::clean_structural_tokens(raw),
@@ -619,5 +624,24 @@ mod tests {
     fn extract_reasoning_empty_yields_none() {
         assert_eq!(extract_reasoning_from_raw("</think>x"), None);
         assert_eq!(extract_reasoning_from_raw("<think></think>x"), None);
+    }
+
+    #[test]
+    fn split_harmony_routes_analysis_to_reasoning() {
+        // Harmony (GPT-OSS) carries reasoning in the parse result rather than an
+        // inline `<think>` block. The split must surface `reasoning_content` as
+        // the reasoning and keep the visible answer empty (the tool call becomes
+        // a separate `tool_use` block), so `<think>`-only extraction is not
+        // enough here.
+        let parsed = tool_calls::ToolCallParseResult {
+            format: Some(tool_calls::ToolCallFormat::Harmony),
+            tool_calls: Vec::new(),
+            content: String::new(),
+            reasoning_content: Some("analysis scratchpad".to_string()),
+        };
+        let (visible, reasoning) =
+            split_visible_reasoning("<|channel|>analysis<|message|>x", Some(&parsed));
+        assert_eq!(visible, "");
+        assert_eq!(reasoning.as_deref(), Some("analysis scratchpad"));
     }
 }

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -470,6 +470,16 @@ async fn non_stream_chat_completion(
         let tools = request.tools.as_deref();
         let parsed = tool_calls::parse_tool_calls(&result.text, tools);
 
+        // Harmony (GPT-OSS) carries its `analysis` channel as reasoning inside
+        // the parse result; prefer it over the StreamFilter-derived `reasoning`,
+        // which does not recognise Harmony's `<|channel|>` markers. Every other
+        // family leaves `parsed.reasoning_content` `None` and keeps the
+        // StreamFilter value.
+        let reasoning = parsed
+            .reasoning_content
+            .clone()
+            .or_else(|| reasoning.clone());
+
         if parsed.has_tool_calls() {
             let tool_call_responses = tool_calls::build_tool_call_responses(&parsed, &request);
             if !tool_call_responses.is_empty() {

--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -75,6 +75,7 @@ pub fn try_hermes(text: &str) -> Option<ToolCallParseResult> {
         format: Some(ToolCallFormat::Hermes),
         tool_calls: calls,
         content,
+        reasoning_content: None,
     })
 }
 
@@ -114,6 +115,7 @@ pub fn try_llama3(text: &str) -> Option<ToolCallParseResult> {
             format: Some(ToolCallFormat::Llama3),
             tool_calls: calls,
             content: String::new(),
+            reasoning_content: None,
         });
     }
 
@@ -124,6 +126,7 @@ pub fn try_llama3(text: &str) -> Option<ToolCallParseResult> {
             format: Some(ToolCallFormat::Llama3),
             tool_calls: vec![call],
             content: String::new(),
+            reasoning_content: None,
         });
     }
 
@@ -175,6 +178,7 @@ pub fn try_mistral_nemo(text: &str) -> Option<ToolCallParseResult> {
         format: Some(ToolCallFormat::MistralNemo),
         tool_calls: calls,
         content: String::new(),
+        reasoning_content: None,
     })
 }
 
@@ -238,6 +242,7 @@ pub fn try_functionary_v31(text: &str) -> Option<ToolCallParseResult> {
         format: Some(ToolCallFormat::FunctionaryV31),
         tool_calls: calls,
         content,
+        reasoning_content: None,
     })
 }
 
@@ -317,6 +322,7 @@ pub fn try_functionary_v32(text: &str) -> Option<ToolCallParseResult> {
         format: Some(ToolCallFormat::FunctionaryV32),
         tool_calls: calls,
         content: content.trim().to_string(),
+        reasoning_content: None,
     })
 }
 
@@ -372,6 +378,7 @@ pub fn try_command_r(text: &str) -> Option<ToolCallParseResult> {
         format: Some(ToolCallFormat::CommandR),
         tool_calls: calls,
         content: content.trim().to_string(),
+        reasoning_content: None,
     })
 }
 
@@ -488,6 +495,7 @@ pub fn try_gemma4(text: &str) -> Option<ToolCallParseResult> {
         format: Some(ToolCallFormat::Gemma4),
         tool_calls: calls,
         content,
+        reasoning_content: None,
     })
 }
 
@@ -760,6 +768,7 @@ pub fn try_minimax_m2(text: &str) -> Option<ToolCallParseResult> {
         format: Some(ToolCallFormat::MinimaxM2),
         tool_calls: calls,
         content: String::new(),
+        reasoning_content: None,
     })
 }
 
@@ -983,6 +992,7 @@ pub fn try_qwen3_coder(text: &str) -> Option<ToolCallParseResult> {
         format: Some(ToolCallFormat::Qwen3Coder),
         tool_calls: calls,
         content,
+        reasoning_content: None,
     })
 }
 
@@ -1070,6 +1080,7 @@ pub fn try_generic_json(text: &str) -> Option<ToolCallParseResult> {
                 format: Some(ToolCallFormat::GenericJson),
                 tool_calls: calls,
                 content: String::new(),
+                reasoning_content: None,
             });
         }
     }
@@ -1083,6 +1094,7 @@ pub fn try_generic_json(text: &str) -> Option<ToolCallParseResult> {
             format: Some(ToolCallFormat::GenericJson),
             tool_calls: vec![call],
             content: String::new(),
+            reasoning_content: None,
         });
     }
 
@@ -1100,6 +1112,175 @@ fn parse_generic_value(v: &serde_json::Value) -> Option<ParsedToolCall> {
             serde_json::to_string(args).ok()?
         },
     })
+}
+
+/// Markers that terminate a Harmony message body. The body after `<|message|>`
+/// runs until the earliest of these (or the end of the text): `<|call|>` ends a
+/// tool call, `<|end|>` ends an analysis/preamble message, `<|return|>` ends the
+/// final answer, and `<|start|>` / `<|channel|>` begin the next message when the
+/// model omitted an explicit terminator (or the output was truncated mid-token,
+/// as happens when `<|call|>` is a stop token that never reaches the text).
+const HARMONY_BODY_TERMINATORS: &[&str] = &[
+    "<|call|>",
+    "<|end|>",
+    "<|return|>",
+    "<|start|>",
+    "<|channel|>",
+];
+
+/// Try parsing the Harmony (GPT-OSS) channel format.
+///
+/// Harmony interleaves reasoning, tool calls, and the visible answer as a
+/// sequence of channel messages:
+///
+/// ```text
+/// <|channel|>analysis<|message|>chain of thought<|end|>
+/// <|start|>assistant<|channel|>commentary to=functions.NAME <|constrain|>json<|message|>{…}<|call|>
+/// <|start|>assistant<|channel|>final<|message|>visible answer<|return|>
+/// ```
+///
+/// Routing:
+/// - a channel header carrying a `to=` recipient is a tool call (the recipient's
+///   `functions.` namespace is stripped to the bare function name),
+/// - the `analysis` channel is chain-of-thought and surfaces as
+///   [`ToolCallParseResult::reasoning_content`],
+/// - the `final` channel (and any recipient-less `commentary` preamble) is the
+///   visible `content`.
+///
+/// The distinctive double-pipe `<|channel|>` / `<|message|>` markers never
+/// collide with Gemma 4's single-pipe `<|channel>` / `<channel|>`, so a plain
+/// `contains` guard is enough to claim only Harmony output. Because this parser
+/// also owns the reasoning/content split, the dispatcher runs it up front and
+/// returns its result whether or not a tool call is present, so channel markup
+/// never leaks into `content`.
+pub fn try_harmony(text: &str) -> Option<ToolCallParseResult> {
+    const CHANNEL: &str = "<|channel|>";
+    const MESSAGE: &str = "<|message|>";
+
+    if !text.contains(CHANNEL) || !text.contains(MESSAGE) {
+        return None;
+    }
+
+    let mut calls = Vec::new();
+    let mut content = String::new();
+    let mut reasoning = String::new();
+
+    let mut rest = text;
+    while let Some(ch_pos) = rest.find(CHANNEL) {
+        // Header = everything between `<|channel|>` and the message marker:
+        // the channel name plus any `to=` recipient and `<|constrain|>` hint.
+        let after_channel = &rest[ch_pos + CHANNEL.len()..];
+        let Some(msg_off) = after_channel.find(MESSAGE) else {
+            break;
+        };
+        let header = &after_channel[..msg_off];
+        let body_region = &after_channel[msg_off + MESSAGE.len()..];
+
+        // Body runs until the earliest terminator (or end of text).
+        let body_end = HARMONY_BODY_TERMINATORS
+            .iter()
+            .filter_map(|marker| body_region.find(marker))
+            .min()
+            .unwrap_or(body_region.len());
+        let body = &body_region[..body_end];
+
+        route_harmony_segment(header, body, &mut calls, &mut content, &mut reasoning);
+
+        // Advance past this body; `body_region` starts inside `rest`, and the
+        // header consumed at least the `<|channel|>` marker, so `rest` strictly
+        // shrinks every iteration (no infinite loop).
+        rest = &body_region[body_end..];
+    }
+
+    let reasoning = reasoning.trim();
+    Some(ToolCallParseResult {
+        format: Some(ToolCallFormat::Harmony),
+        tool_calls: calls,
+        content: content.trim().to_string(),
+        reasoning_content: if reasoning.is_empty() {
+            None
+        } else {
+            Some(reasoning.to_string())
+        },
+    })
+}
+
+/// Route one Harmony `(header, body)` segment to a tool call, reasoning, or
+/// visible content.
+fn route_harmony_segment(
+    header: &str,
+    body: &str,
+    calls: &mut Vec<ParsedToolCall>,
+    content: &mut String,
+    reasoning: &mut String,
+) {
+    // A `to=` recipient marks a tool call regardless of channel name.
+    if let Some(recipient) = harmony_recipient(header) {
+        let name = recipient
+            .strip_prefix("functions.")
+            .unwrap_or(recipient)
+            .to_string();
+        if !name.is_empty() {
+            calls.push(ParsedToolCall {
+                name,
+                arguments: harmony_arguments(body),
+            });
+        }
+        return;
+    }
+
+    let channel = header.split_whitespace().next().unwrap_or("");
+    let body = body.trim();
+    if body.is_empty() {
+        return;
+    }
+    // `analysis` is chain-of-thought; `final` is the answer and a recipient-less
+    // `commentary` is a user-visible preamble. Unknown channels are dropped so
+    // their markup never leaks.
+    let sink = match channel {
+        "analysis" => reasoning,
+        "final" | "commentary" => content,
+        _ => return,
+    };
+    if !sink.is_empty() {
+        sink.push('\n');
+    }
+    sink.push_str(body);
+}
+
+/// Extract the `to=` recipient from a Harmony channel header, if present.
+///
+/// The recipient runs from just after `to=` until the next whitespace or the
+/// next `<|` marker (e.g. `<|constrain|>` or `<|message|>`), whichever comes
+/// first: `commentary to=functions.get_weather <|constrain|>json` yields
+/// `functions.get_weather`.
+fn harmony_recipient(header: &str) -> Option<&str> {
+    let after = &header[header.find("to=")? + "to=".len()..];
+    let end = [after.find(char::is_whitespace), after.find("<|")]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(after.len());
+    let recipient = after[..end].trim();
+    (!recipient.is_empty()).then_some(recipient)
+}
+
+/// Normalize a Harmony tool-call body into a JSON `arguments` string.
+///
+/// The body is JSON when the header carried `<|constrain|>json` (the common
+/// case). Valid JSON is re-serialized to drop the model's pretty-printing (and,
+/// with serde_json's `preserve_order`, keep key order); a body that does not
+/// parse falls back to its trimmed form, and an empty body to `{}`, so a
+/// malformed call never yields invalid `arguments`.
+fn harmony_arguments(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return "{}".to_string();
+    }
+    match serde_json::from_str::<serde_json::Value>(trimmed) {
+        Ok(value) => serde_json::to_string(&value).unwrap_or_else(|_| trimmed.to_string()),
+        Err(_) => trimmed.to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -1701,5 +1882,149 @@ mod tests {
             obj.len()
         );
         assert_eq!(obj.len(), MINIMAX_M2_MAX_PARAMS_PER_CALL);
+    }
+
+    // -- Harmony (GPT-OSS) --
+
+    fn harmony_args(call: &ParsedToolCall) -> serde_json::Value {
+        serde_json::from_str(&call.arguments).expect("arguments must be valid JSON")
+    }
+
+    #[test]
+    fn harmony_single_tool_call_matches_issue_repro() {
+        // The exact leaked output from the issue: an analysis channel followed
+        // by a truncated commentary tool call (no trailing `<|call|>`).
+        let text = "<|channel|>analysis<|message|>The user asks to read /etc/hosts and \
+                    summarize it. We have a tool to read file. We'll use read_file.<|end|>\
+                    <|start|>assistant<|channel|>commentary to=functions.read_file \
+                    <|constrain|>json<|message|>{\n  \"path\": \"/etc/hosts\"\n}";
+        let result = try_harmony(text).unwrap();
+        assert_eq!(result.format, Some(ToolCallFormat::Harmony));
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "read_file");
+        assert_eq!(harmony_args(&result.tool_calls[0])["path"], "/etc/hosts");
+        // Pretty-printed body is compacted.
+        assert_eq!(result.tool_calls[0].arguments, r#"{"path":"/etc/hosts"}"#);
+        // Analysis channel routes to reasoning, not content.
+        assert_eq!(result.content, "");
+        assert!(
+            result
+                .reasoning_content
+                .as_deref()
+                .unwrap()
+                .contains("read_file")
+        );
+    }
+
+    #[test]
+    fn harmony_strips_functions_namespace() {
+        let text = "<|channel|>commentary to=functions.get_weather <|constrain|>json\
+                    <|message|>{\"location\": \"Tokyo\"}<|call|>";
+        let result = try_harmony(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+        assert_eq!(harmony_args(&result.tool_calls[0])["location"], "Tokyo");
+    }
+
+    #[test]
+    fn harmony_constrain_marker_optional() {
+        // Some outputs omit `<|constrain|>json` and go straight to `<|message|>`.
+        let text = "<|channel|>commentary to=functions.get_weather<|message|>\
+                    {\"location\": \"Paris\"}<|call|>";
+        let result = try_harmony(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+        assert_eq!(harmony_args(&result.tool_calls[0])["location"], "Paris");
+    }
+
+    #[test]
+    fn harmony_multiple_sequential_tool_calls() {
+        let text = "<|channel|>analysis<|message|>Plan the calls.<|end|>\
+                    <|start|>assistant<|channel|>commentary to=functions.search \
+                    <|constrain|>json<|message|>{\"query\": \"rust\"}<|call|>\
+                    <|start|>assistant<|channel|>commentary to=functions.calc \
+                    <|constrain|>json<|message|>{\"expr\": \"2+2\"}<|call|>";
+        let result = try_harmony(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(result.tool_calls[0].name, "search");
+        assert_eq!(harmony_args(&result.tool_calls[0])["query"], "rust");
+        assert_eq!(result.tool_calls[1].name, "calc");
+        assert_eq!(harmony_args(&result.tool_calls[1])["expr"], "2+2");
+        assert_eq!(result.reasoning_content.as_deref(), Some("Plan the calls."));
+    }
+
+    #[test]
+    fn harmony_final_channel_is_content_not_tool_call() {
+        // Tools were available but the model answered directly via `final`.
+        let text = "<|channel|>analysis<|message|>Simple question.<|end|>\
+                    <|start|>assistant<|channel|>final<|message|>The answer is 42.<|return|>";
+        let result = try_harmony(text).unwrap();
+        assert!(result.tool_calls.is_empty());
+        assert_eq!(result.content, "The answer is 42.");
+        assert_eq!(
+            result.reasoning_content.as_deref(),
+            Some("Simple question.")
+        );
+    }
+
+    #[test]
+    fn harmony_analysis_routes_to_reasoning() {
+        let text = "<|channel|>analysis<|message|>Deliberating carefully.<|end|>\
+                    <|start|>assistant<|channel|>commentary to=functions.noop \
+                    <|constrain|>json<|message|>{}<|call|>";
+        let result = try_harmony(text).unwrap();
+        assert_eq!(
+            result.reasoning_content.as_deref(),
+            Some("Deliberating carefully.")
+        );
+        assert_eq!(result.tool_calls[0].arguments, "{}");
+    }
+
+    #[test]
+    fn harmony_content_never_leaks_channel_markup() {
+        let text = "<|channel|>analysis<|message|>reasoning<|end|>\
+                    <|start|>assistant<|channel|>commentary to=functions.fn \
+                    <|constrain|>json<|message|>{\"a\": 1}<|call|>";
+        let result = try_harmony(text).unwrap();
+        assert!(!result.content.contains("<|channel|>"));
+        assert!(!result.content.contains("<|message|>"));
+        assert!(!result.content.contains("to=functions"));
+    }
+
+    #[test]
+    fn harmony_no_match_plain_text() {
+        assert!(try_harmony("Hello, how can I help you?").is_none());
+    }
+
+    #[test]
+    fn harmony_no_match_gemma_single_pipe_channel() {
+        // Gemma 4 uses single-pipe `<|channel>` / `<channel|>`; Harmony must not
+        // claim it (that would steal reasoning the Gemma path already handles).
+        let text = "<|channel>thought\nreasoning here<channel|>the answer";
+        assert!(try_harmony(text).is_none());
+    }
+
+    #[test]
+    fn harmony_no_match_hermes_tool_call() {
+        assert!(try_harmony(r#"<tool_call>{"name": "fn", "arguments": {}}</tool_call>"#).is_none());
+    }
+
+    #[test]
+    fn harmony_malformed_missing_message_marker_does_not_panic() {
+        // A channel header with no following `<|message|>`: must not panic and
+        // must not produce a bogus call.
+        let text = "<|channel|>commentary to=functions.fn <|constrain|>json";
+        // `contains("<|message|>")` is false, so this is not claimed at all.
+        assert!(try_harmony(text).is_none());
+    }
+
+    #[test]
+    fn harmony_recipient_stops_at_constrain_without_space() {
+        // Recipient immediately abutting `<|constrain|>` (no separating space).
+        let text = "<|channel|>commentary to=functions.fn<|constrain|>json\
+                    <|message|>{\"k\": \"v\"}<|call|>";
+        let result = try_harmony(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "fn");
     }
 }

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -140,6 +140,20 @@ pub fn parse_tool_calls(raw_output: &str, tools: Option<&[Tool]>) -> ToolCallPar
         return ToolCallParseResult::none(String::new());
     }
 
+    // Harmony (GPT-OSS) is handled up front, ahead of the single-purpose
+    // parsers below. Unlike them it owns the whole channel stream: it routes the
+    // `analysis` channel to `reasoning_content` and strips the channel markup
+    // from `content` even when the model answers directly without a tool call.
+    // Returning its result unconditionally (when the distinctive `<|channel|>`
+    // markers are present) is what prevents that markup from leaking through the
+    // fall-through cleaner in the no-tool-call case.
+    if let Some(mut result) = formats::try_harmony(text) {
+        if let Some(tools) = tools {
+            result.tool_calls = filter_by_tools(result.tool_calls, tools);
+        }
+        return result;
+    }
+
     // Try each format in order of specificity (most distinctive markers first)
     let parsers: &[fn(&str) -> Option<ToolCallParseResult>] = &[
         formats::try_granite, // <response><tool_call> — more specific than bare Hermes
@@ -774,5 +788,77 @@ mod tests {
             !result.has_tool_calls(),
             "unknown namespaced call must be dropped"
         );
+    }
+
+    // -- Harmony (GPT-OSS) end-to-end --------------------------------------------
+
+    #[test]
+    fn parse_harmony_tool_call() {
+        let output = "<|channel|>analysis<|message|>Read the file first.<|end|>\
+                      <|start|>assistant<|channel|>commentary to=functions.read_file \
+                      <|constrain|>json<|message|>{\"path\": \"/etc/hosts\"}<|call|>";
+        let tools = vec![make_tool("read_file")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "read_file");
+        assert_eq!(arg_obj(&result.tool_calls[0])["path"], "/etc/hosts");
+        assert_eq!(
+            result.format,
+            Some(crate::server::tool_calls::ToolCallFormat::Harmony)
+        );
+        // Channel markup must never leak into content.
+        assert_eq!(result.content, "");
+        assert!(!result.content.contains("<|channel|>"));
+        // Analysis channel surfaces as reasoning_content.
+        assert_eq!(
+            result.reasoning_content.as_deref(),
+            Some("Read the file first.")
+        );
+    }
+
+    #[test]
+    fn parse_harmony_filters_unknown_tools() {
+        let output = "<|channel|>commentary to=functions.unknown_fn \
+                      <|constrain|>json<|message|>{}<|call|>";
+        let tools = vec![make_tool("read_file")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(!result.has_tool_calls());
+    }
+
+    #[test]
+    fn parse_harmony_no_tools_accepts_all() {
+        let output = "<|channel|>commentary to=functions.any_fn \
+                      <|constrain|>json<|message|>{\"x\": 1}<|call|>";
+        let result = parse_tool_calls(output, None);
+        assert!(result.has_tool_calls());
+        assert_eq!(result.tool_calls[0].name, "any_fn");
+    }
+
+    #[test]
+    fn parse_harmony_multiple_calls() {
+        let output = "<|channel|>commentary to=functions.a <|constrain|>json\
+                      <|message|>{\"x\": 1}<|call|><|start|>assistant<|channel|>\
+                      commentary to=functions.b <|constrain|>json<|message|>{\"y\": 2}<|call|>";
+        let tools = vec![make_tool("a"), make_tool("b")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(result.tool_calls[0].name, "a");
+        assert_eq!(result.tool_calls[1].name, "b");
+    }
+
+    #[test]
+    fn parse_harmony_final_only_does_not_leak_markup() {
+        // Tools were requested but the model answered directly via `final`.
+        // Without the up-front Harmony handling this markup would leak through
+        // the fall-through content cleaner.
+        let output = "<|channel|>analysis<|message|>Thinking.<|end|><|start|>assistant\
+                      <|channel|>final<|message|>Hello there!<|return|>";
+        let tools = vec![make_tool("read_file")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(!result.has_tool_calls());
+        assert_eq!(result.content, "Hello there!");
+        assert_eq!(result.reasoning_content.as_deref(), Some("Thinking."));
+        assert!(!result.content.contains("<|channel|>"));
     }
 }

--- a/src/server/tool_calls/types.rs
+++ b/src/server/tool_calls/types.rs
@@ -57,6 +57,12 @@ pub enum ToolCallFormat {
     /// markup, not the model, so it also handles newer Qwen models that share
     /// this template (Qwen3.5 / Qwen3.6).
     Qwen3Coder,
+    /// Harmony (GPT-OSS): channel-structured output where a tool call is a
+    /// `commentary` message targeting `to=functions.NAME`, e.g.
+    /// `<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{…}<|call|>`.
+    /// The `analysis` channel carries chain-of-thought (routed to
+    /// `reasoning_content`) and the `final` channel carries the visible answer.
+    Harmony,
 }
 
 /// Result of parsing model output for tool calls.
@@ -68,6 +74,15 @@ pub struct ToolCallParseResult {
     pub tool_calls: Vec<ParsedToolCall>,
     /// Any text content before/outside the tool calls (may be empty)
     pub content: String,
+    /// Chain-of-thought / scratchpad text that the format carries inline and
+    /// that should surface as `reasoning_content` rather than `content`.
+    ///
+    /// Only formats whose reasoning is interleaved with the tool call in a
+    /// single stream populate this (currently Harmony / GPT-OSS, whose
+    /// `analysis` channel is the reasoning). For families where reasoning is a
+    /// separable `<think>` / `<|channel>` block, the routes recover it from the
+    /// raw text via the shared `StreamFilter`, so this stays `None`.
+    pub reasoning_content: Option<String>,
 }
 
 impl ToolCallParseResult {
@@ -82,6 +97,7 @@ impl ToolCallParseResult {
             format: None,
             tool_calls: Vec::new(),
             content,
+            reasoning_content: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

GPT-OSS emits well-formed Harmony channel markup, but `src/server/tool_calls/formats.rs` had no handler for it, so a request carrying `tools` leaked the raw `<|channel|>analysis<|message|>…<|channel|>commentary to=functions.NAME <|constrain|>json<|message|>{…}` into `content` with no structured `tool_calls` / `tool_use` and the wrong finish/stop reason. This adds a Harmony parser and wires it into both non-streaming response mappings.

## What changed

- `tool_calls/formats.rs`: new `try_harmony` parser plus `route_harmony_segment`, `harmony_recipient`, and `harmony_arguments` helpers. Walks the channel stream and routes each message by its header: a `to=functions.NAME` recipient becomes a tool call (the `functions.` namespace is stripped to the bare name), `analysis` becomes reasoning, and `final` (or a recipient-less `commentary` preamble) becomes visible content. Handles the analysis+commentary sequence, the optional `<|constrain|>json` hint, pretty-printed argument bodies (re-serialized compactly), truncated final calls with no trailing `<|call|>`, and multiple sequential calls.
- `tool_calls/types.rs`: `ToolCallFormat::Harmony` variant and a `reasoning_content: Option<String>` field on `ToolCallParseResult` to carry the analysis channel.
- `tool_calls/parser.rs`: dispatch to `try_harmony` ahead of the single-purpose parsers, returning its result whether or not a tool call is present so channel markup never leaks even when the model answers directly. The distinctive double-pipe `<|channel|>` markers never collide with Gemma 4's single-pipe channel markers.
- `routes/chat.rs`: `/v1/chat/completions` prefers the parser's Harmony reasoning, surfacing it as `reasoning_content` with `finish_reason: tool_calls`.
- `routes/anthropic.rs`: `/v1/messages` prefers the parser's Harmony reasoning, surfacing it alongside a `tool_use` block with `stop_reason: tool_use`.

18 new unit tests cover the issue repro, namespace stripping, the constrain variant, multiple sequential calls, direct final-channel answers, and the marker-leak / no-match / malformed guards.

## Test plan

- [x] `cargo test --lib server::tool_calls` (177 passed, incl. 17 Harmony)
- [x] `cargo test --lib server::routes::anthropic` (5 passed, incl. Harmony split)
- [x] `cargo test --lib server::routes::chat` (22 passed)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib --tests -- -D warnings` clean for all changed files (one pre-existing, unrelated `assertions_on_constants` warning remains in `src/models/switch_layers.rs`, untouched by this PR)

## Scope

Non-streaming `/v1/chat/completions` and `/v1/messages`, per the issue repro (both curl examples are non-streaming). The Harmony parser logic is platform-independent, so it is validated by unit tests without needing `gpt-oss-120b` on Apple Silicon.

Closes #654
