### PR TITLE
fix(vision): capture the functional slice_update return in DeepStack and MRoPE-section loops

### DIFF
--- a/src/models/paddleocr_vl.rs
+++ b/src/models/paddleocr_vl.rs
@@ -188,7 +188,15 @@ impl MRoPE {
                 &[src_dim + 1, batch, seq_len, end],
             );
             let section = mlxcel_core::squeeze_axis(&section, 0);
-            mlxcel_core::slice_update(&result, &section, &[0, 0, offset], &[batch, seq_len, end]);
+            // `slice_update` is functional; capture the return or the H/W
+            // sections are silently dropped and every dim keeps the temporal
+            // frequencies (issue #650).
+            result = mlxcel_core::slice_update(
+                &result,
+                &section,
+                &[0, 0, offset],
+                &[batch, seq_len, end],
+            );
             offset = end;
         }
         result
@@ -702,5 +710,36 @@ impl mlxcel_core::generate::LanguageModel for PaddleOcrTextModel {
 
     fn eos_token_ids(&self) -> Vec<i32> {
         self.eos_token_ids.clone()
+    }
+}
+
+#[cfg(test)]
+mod mrope_section_tests {
+    use super::*;
+
+    /// Regression for issue #650: `apply_mrope` must actually write the H and
+    /// W sections (the functional `slice_update` return was dropped, leaving
+    /// every dim on the temporal frequencies).
+    #[test]
+    fn apply_mrope_writes_h_and_w_sections() {
+        let rope = MRoPE::new(12, 10_000.0, vec![2, 2, 2]);
+        // freqs [3, batch=1, seq=1, half=6]: axis T = 1.0, H = 2.0, W = 3.0.
+        let mut data = Vec::new();
+        for axis_val in [1.0f32, 2.0, 3.0] {
+            data.extend(std::iter::repeat_n(axis_val, 6));
+        }
+        let freqs = mlxcel_core::from_slice_f32(&data, &[3, 1, 1, 6]);
+        let mixed = rope.apply_mrope(&freqs);
+        mlxcel_core::eval(&mixed);
+        let expected = [1.0f32, 1.0, 2.0, 2.0, 3.0, 3.0];
+        for (i, &want) in expected.iter().enumerate() {
+            let v = mlxcel_core::slice(&mixed, &[0, 0, i as i32], &[1, 1, i as i32 + 1]);
+            mlxcel_core::eval(&v);
+            let got = mlxcel_core::item_f32(&v);
+            assert!(
+                (got - want).abs() < 1e-6,
+                "dim {i}: expected axis value {want}, got {got} (H/W section write dropped?)"
+            );
+        }
     }
 }

--- a/src/models/qwen2_vl.rs
+++ b/src/models/qwen2_vl.rs
@@ -202,7 +202,15 @@ impl MRoPE {
             let section = mlxcel_core::squeeze_axis(&section, 0);
 
             // Replace in result via slice_update
-            mlxcel_core::slice_update(&result, &section, &[0, 0, offset], &[batch, seq_len, end]);
+            // `slice_update` is functional; capture the return or the H/W
+            // sections are silently dropped and every dim keeps the temporal
+            // frequencies (issue #650).
+            result = mlxcel_core::slice_update(
+                &result,
+                &section,
+                &[0, 0, offset],
+                &[batch, seq_len, end],
+            );
 
             offset = end;
         }
@@ -796,5 +804,36 @@ impl mlxcel_core::generate::LanguageModel for Qwen2VLModel {
 
     fn eos_token_ids(&self) -> Vec<i32> {
         vec![151645, 151643] // Qwen2 EOS tokens
+    }
+}
+
+#[cfg(test)]
+mod mrope_section_tests {
+    use super::*;
+
+    /// Regression for issue #650: `apply_mrope` must actually write the H and
+    /// W sections (the functional `slice_update` return was dropped, leaving
+    /// every dim on the temporal frequencies).
+    #[test]
+    fn apply_mrope_writes_h_and_w_sections() {
+        let rope = MRoPE::new(12, 10_000.0, vec![2, 2, 2]);
+        // freqs [3, batch=1, seq=1, half=6]: axis T = 1.0, H = 2.0, W = 3.0.
+        let mut data = Vec::new();
+        for axis_val in [1.0f32, 2.0, 3.0] {
+            data.extend(std::iter::repeat_n(axis_val, 6));
+        }
+        let freqs = mlxcel_core::from_slice_f32(&data, &[3, 1, 1, 6]);
+        let mixed = rope.apply_mrope(&freqs);
+        mlxcel_core::eval(&mixed);
+        let expected = [1.0f32, 1.0, 2.0, 2.0, 3.0, 3.0];
+        for (i, &want) in expected.iter().enumerate() {
+            let v = mlxcel_core::slice(&mixed, &[0, 0, i as i32], &[1, 1, i as i32 + 1]);
+            mlxcel_core::eval(&v);
+            let got = mlxcel_core::item_f32(&v);
+            assert!(
+                (got - want).abs() < 1e-6,
+                "dim {i}: expected axis value {want}, got {got} (H/W section write dropped?)"
+            );
+        }
     }
 }

--- a/src/models/qwen3_vl.rs
+++ b/src/models/qwen3_vl.rs
@@ -788,14 +788,34 @@ impl Qwen3VLModel {
             // Build result by scatter
             // For simplicity, use the full tensor approach:
             // result = h.copy(), then update positions
-            let result = mlxcel_core::copy(&batch_h);
-            for (local_idx, &pos) in image_positions.iter().enumerate() {
-                let val = mlxcel_core::slice(
+            // `slice_update` is functional (returns a new array); the result
+            // MUST be captured or the write is lost (issue #650, same class as
+            // the Granite 4 Vision blindness fixed by `inject_at_positions`).
+            // Contiguous image runs (the single-image case) collapse to one
+            // slice_update; disjoint runs fall back to per-row.
+            let mut result = mlxcel_core::copy(&batch_h);
+            let contiguous = image_positions
+                .iter()
+                .enumerate()
+                .all(|(i, &p)| p == image_positions[0] + i as i32);
+            if contiguous {
+                let start = image_positions[0];
+                result = mlxcel_core::slice_update(
+                    &result,
                     &updated_vals,
-                    &[local_idx as i32, 0],
-                    &[local_idx as i32 + 1, h_shape[2]],
+                    &[start, 0],
+                    &[start + n_img, h_shape[2]],
                 );
-                mlxcel_core::slice_update(&result, &val, &[pos, 0], &[pos + 1, h_shape[2]]);
+            } else {
+                for (local_idx, &pos) in image_positions.iter().enumerate() {
+                    let val = mlxcel_core::slice(
+                        &updated_vals,
+                        &[local_idx as i32, 0],
+                        &[local_idx as i32 + 1, h_shape[2]],
+                    );
+                    result =
+                        mlxcel_core::slice_update(&result, &val, &[pos, 0], &[pos + 1, h_shape[2]]);
+                }
             }
 
             mlxcel_core::expand_dims(&result, 0)
@@ -1040,5 +1060,39 @@ impl mlxcel_core::generate::LanguageModel for Qwen3VLModel {
 
     fn eos_token_ids(&self) -> Vec<i32> {
         vec![151645, 151643] // Qwen EOS tokens
+    }
+}
+
+#[cfg(test)]
+mod deepstack_injection_tests {
+    use super::*;
+
+    /// Regression for issue #650: `deepstack_process` must add the visual
+    /// embeds at image positions (the functional `slice_update` return was
+    /// dropped, silently skipping the whole injection).
+    #[test]
+    fn deepstack_process_adds_visual_embeds_at_image_positions() {
+        let hidden = 4i32;
+        let seq = 5i32;
+        let h = mlxcel_core::full_f32(&[1, seq, hidden], 1.0, mlxcel_core::dtype::FLOAT32);
+        // Image positions 1..=3 (contiguous run).
+        let mask_vals = [0.0f32, 1.0, 1.0, 1.0, 0.0];
+        let mask = mlxcel_core::from_slice_f32(&mask_vals, &[1, seq]);
+        let mask = mlxcel_core::astype(&mask, mlxcel_core::dtype::BOOL);
+        let visual = mlxcel_core::full_f32(&[3, hidden], 10.0, mlxcel_core::dtype::FLOAT32);
+
+        let out = Qwen3VLModel::deepstack_process(&h, &mask, &visual);
+        mlxcel_core::eval(&out);
+
+        for pos in 0..seq {
+            let v = mlxcel_core::slice(&out, &[0, pos, 0], &[1, pos + 1, 1]);
+            mlxcel_core::eval(&v);
+            let got = mlxcel_core::item_f32(&v);
+            let want = if (1..=3).contains(&pos) { 11.0 } else { 1.0 };
+            assert!(
+                (got - want).abs() < 1e-6,
+                "pos {pos}: expected {want}, got {got} (injection dropped?)"
+            );
+        }
     }
 }

--- a/src/models/qwen3_vl_moe.rs
+++ b/src/models/qwen3_vl_moe.rs
@@ -981,14 +981,34 @@ impl Qwen3VLMoeModel {
             let visual_slice = mlxcel_core::slice(visual_embeds, &[0, 0], &[n_img, h_shape[2]]);
             let updated_vals = mlxcel_core::add(&current_vals, &visual_slice);
 
-            let result = mlxcel_core::copy(&batch_h);
-            for (local_idx, &pos) in image_positions.iter().enumerate() {
-                let val = mlxcel_core::slice(
+            // `slice_update` is functional (returns a new array); the result
+            // MUST be captured or the write is lost (issue #650, same class as
+            // the Granite 4 Vision blindness fixed by `inject_at_positions`).
+            // Contiguous image runs (the single-image case) collapse to one
+            // slice_update; disjoint runs fall back to per-row.
+            let mut result = mlxcel_core::copy(&batch_h);
+            let contiguous = image_positions
+                .iter()
+                .enumerate()
+                .all(|(i, &p)| p == image_positions[0] + i as i32);
+            if contiguous {
+                let start = image_positions[0];
+                result = mlxcel_core::slice_update(
+                    &result,
                     &updated_vals,
-                    &[local_idx as i32, 0],
-                    &[local_idx as i32 + 1, h_shape[2]],
+                    &[start, 0],
+                    &[start + n_img, h_shape[2]],
                 );
-                mlxcel_core::slice_update(&result, &val, &[pos, 0], &[pos + 1, h_shape[2]]);
+            } else {
+                for (local_idx, &pos) in image_positions.iter().enumerate() {
+                    let val = mlxcel_core::slice(
+                        &updated_vals,
+                        &[local_idx as i32, 0],
+                        &[local_idx as i32 + 1, h_shape[2]],
+                    );
+                    result =
+                        mlxcel_core::slice_update(&result, &val, &[pos, 0], &[pos + 1, h_shape[2]]);
+                }
             }
 
             mlxcel_core::expand_dims(&result, 0)
@@ -1232,5 +1252,39 @@ impl mlxcel_core::generate::LanguageModel for Qwen3VLMoeModel {
 
     fn eos_token_ids(&self) -> Vec<i32> {
         vec![151645, 151643] // Qwen EOS tokens
+    }
+}
+
+#[cfg(test)]
+mod deepstack_injection_tests {
+    use super::*;
+
+    /// Regression for issue #650: `deepstack_process` must add the visual
+    /// embeds at image positions (the functional `slice_update` return was
+    /// dropped, silently skipping the whole injection).
+    #[test]
+    fn deepstack_process_adds_visual_embeds_at_image_positions() {
+        let hidden = 4i32;
+        let seq = 5i32;
+        let h = mlxcel_core::full_f32(&[1, seq, hidden], 1.0, mlxcel_core::dtype::FLOAT32);
+        // Image positions 1..=3 (contiguous run).
+        let mask_vals = [0.0f32, 1.0, 1.0, 1.0, 0.0];
+        let mask = mlxcel_core::from_slice_f32(&mask_vals, &[1, seq]);
+        let mask = mlxcel_core::astype(&mask, mlxcel_core::dtype::BOOL);
+        let visual = mlxcel_core::full_f32(&[3, hidden], 10.0, mlxcel_core::dtype::FLOAT32);
+
+        let out = Qwen3VLMoeModel::deepstack_process(&h, &mask, &visual);
+        mlxcel_core::eval(&out);
+
+        for pos in 0..seq {
+            let v = mlxcel_core::slice(&out, &[0, pos, 0], &[1, pos + 1, 1]);
+            mlxcel_core::eval(&v);
+            let got = mlxcel_core::item_f32(&v);
+            let want = if (1..=3).contains(&pos) { 11.0 } else { 1.0 };
+            assert!(
+                (got - want).abs() < 1e-6,
+                "pos {pos}: expected {want}, got {got} (injection dropped?)"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

`mlxcel_core::slice_update` is functional (wraps `mlx::core::slice_update`, which returns a new array and never mutates `src`). Four loops called it as a bare statement and silently lost every write — the same class as the Granite 4 Vision blindness fixed by `inject_at_positions` in PR #649.

| Site | What was dropped | Effect |
|---|---|---|
| `src/models/qwen3_vl.rs` (DeepStack loop) | the whole per-layer visual refinement | quality degradation (main features still enter via `inputs_embeds`) |
| `src/models/qwen3_vl_moe.rs` (DeepStack loop) | same | same |
| `src/models/qwen2_vl.rs` (`apply_mrope`) | the H and W section writes | every head dim kept temporal frequencies; image tokens carried no intra-image spatial position information |
| `src/models/paddleocr_vl.rs` (`apply_mrope`) | same | same |

## Fix

Capture the return. The DeepStack loops mirror the Granite fix: a contiguous single-image run collapses to one `slice_update`, disjoint runs fall back to per-row with the return captured. The `apply_mrope` sites capture the return of each section write.

## Validation

- Four co-located regression tests pin the semantics: `deepstack_process` must add visual embeds at masked positions (qwen3_vl, qwen3_vl_moe); `apply_mrope` must place per-axis frequencies into their sections (qwen2_vl, paddleocr_vl). All four fail on the pre-fix code.
- Real checkpoints, left-red / right-blue split image through the CLI:
  - `qwen2-vl-2b-4bit`: "The color on the left side of the image is red, and the color on the right side is blue."
  - `qwen3-vl-4b-instruct-4bit`: "far left is red ... far right is blue."
  - `qwen3-vl-30b-a3b-4bit` (MoE): "the color on the left side is red, and the color on the right side is blue."
- `paddleocr_vl` shares the identical fixed function with `qwen2_vl` and is covered by its regression test (no local checkpoint on the validation machine).
- Existing qwen3_vl / qwen2_vl / paddleocr unit suites, `cargo fmt`, and `cargo clippy --all-targets -- -D warnings` are clean.

Closes #650
