### PR TITLE
fix(deepseek_v32): add causal-mask fallback so maskless prefill is not bidirectional

### DIFF
--- a/src/models/deepseek_v32.rs
+++ b/src/models/deepseek_v32.rs
@@ -335,8 +335,12 @@ impl MLAAttention {
         // kv_latent = layernorm(compressed)
         let kv_latent = self.kv_a_layernorm.forward(&compressed);
 
-        // Apply RoPE
+        // Apply RoPE. `offset` is the monotonic rope position; `live_before`
+        // is the number of K rows already in the cache BEFORE this call's
+        // update_and_fetch, which the causal fallback below needs (mirrors
+        // deepseek_v3's `live_before`, issue #619).
         let offset = cache.offset;
+        let live_before = cache.live_len();
         let q_pe = mlxcel_core::fast_rope(
             &q_pe,
             self.qk_rope_head_dim,
@@ -385,11 +389,29 @@ impl MLAAttention {
             None => (cache_keys, None),
         };
 
+        // Causal fallback (issue #619, same class as #618): both standard
+        // generation paths pass `mask == None` for prefill, and neither the
+        // SDPA wrapper nor the indexer applies implicit causality, so bake a
+        // causal mask in here for any maskless multi-token forward. It must
+        // reach BOTH consumers: the indexer top-k selection (or future keys
+        // get selected) and the additive `pe_scores` mask (which
+        // `apply_sparse_prefill_mask` documents as already-causal). Decode
+        // (`l == 1`) stays maskless: every cached position is causally valid.
+        let causal_storage;
+        let effective_mask: Option<&MlxArray> = if mask.is_some() {
+            mask
+        } else if l > 1 {
+            causal_storage = mlxcel_core::utils::create_causal_mask(l, live_before);
+            Some(causal_storage.as_ref().unwrap())
+        } else {
+            None
+        };
+
         // Top-k key selection. `None` at short context (kv_len <= index_topk),
         // in which case attention falls through to the dense path unchanged.
         let topk_indices = match (&self.indexer, &indexer_new, &indexer_keys) {
             (Some(idx), Some((_, idx_q, idx_w)), Some(idx_k)) => {
-                idx.top_indices(idx_q, idx_k, idx_w, mask)
+                idx.top_indices(idx_q, idx_k, idx_w, effective_mask)
             }
             _ => None,
         };
@@ -400,8 +422,8 @@ impl MLAAttention {
         let k_pe_t = mlxcel_core::transpose_axes(&k_pe, &[0, 1, 3, 2]);
         let pe_scores = mlxcel_core::matmul(&q_pe_scaled, &k_pe_t);
 
-        // Apply causal mask to pe_scores
-        let pe_scores = if let Some(m) = mask {
+        // Apply the (caller or fallback) causal mask to pe_scores.
+        let pe_scores = if let Some(m) = effective_mask {
             mlxcel_core::add(&pe_scores, m)
         } else {
             pe_scores

--- a/src/models/deepseek_v32_tests.rs
+++ b/src/models/deepseek_v32_tests.rs
@@ -219,3 +219,215 @@ fn indexer_top_indices_respects_causal_mask() {
         "masking position 1 shifts top-2 to {{3,4}}"
     );
 }
+
+/// Tiny config with every MLA dimension shrunk so a synthetic attention block
+/// is buildable in-test (hidden 6, 2 heads, q_head_dim 4 = nope 2 + rope 2,
+/// kv_lora_rank 4, v_head_dim 2).
+fn tiny_mla_config(index_topk: i32) -> ModelArgs {
+    let json = format!(
+        r#"{{
+        "model_type": "deepseek_v32",
+        "vocab_size": 16,
+        "hidden_size": 6,
+        "intermediate_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "q_lora_rank": 8,
+        "kv_lora_rank": 4,
+        "qk_nope_head_dim": 2,
+        "qk_rope_head_dim": 2,
+        "v_head_dim": 2,
+        "index_topk": {index_topk},
+        "index_n_heads": 2,
+        "index_head_dim": 4
+    }}"#
+    );
+    serde_json::from_str(&json).expect("parse tiny MLA config")
+}
+
+/// Synthetic (non-quantized) MLA attention weights for `{prefix}.*`, with
+/// `kv_b_proj` in checkpoint form (sanitize decomposes it into
+/// `embed_q` / `unembed_out`).
+fn synthetic_mla_weights(args: &ModelArgs, prefix: &str, with_indexer: bool) -> WeightMap {
+    let hidden = args.hidden_size as i32;
+    let q_lora = args.q_lora_rank as i32;
+    let kv_lora = args.kv_lora_rank as i32;
+    let heads = args.num_attention_heads as i32;
+    let q_head_dim = args.q_head_dim() as i32;
+    let rope = args.qk_rope_head_dim as i32;
+    let nope = args.qk_nope_head_dim as i32;
+    let v = args.v_head_dim as i32;
+
+    let mut weights = WeightMap::new();
+    let w = |shape: &[i32]| f32_weight(shape);
+    weights.insert(format!("{prefix}.q_a_proj.weight"), w(&[q_lora, hidden]));
+    weights.insert(format!("{prefix}.q_a_layernorm.weight"), w(&[q_lora]));
+    weights.insert(
+        format!("{prefix}.q_b_proj.weight"),
+        w(&[heads * q_head_dim, q_lora]),
+    );
+    weights.insert(
+        format!("{prefix}.kv_a_proj_with_mqa.weight"),
+        w(&[kv_lora + rope, hidden]),
+    );
+    weights.insert(format!("{prefix}.kv_a_layernorm.weight"), w(&[kv_lora]));
+    weights.insert(
+        format!("{prefix}.kv_b_proj.weight"),
+        w(&[heads * (nope + v), kv_lora]),
+    );
+    weights.insert(format!("{prefix}.o_proj.weight"), w(&[hidden, heads * v]));
+    if with_indexer {
+        for (k, v) in synthetic_indexer_weights(args, prefix) {
+            weights.insert(k, v);
+        }
+    }
+    weights
+}
+
+fn tiny_mla_attention(args: &ModelArgs, with_indexer: bool) -> super::MLAAttention {
+    let prefix = "model.layers.0.self_attn";
+    let weights = synthetic_mla_weights(args, prefix, with_indexer);
+    let weights = super::DeepSeekV32Model::sanitize_weights(weights, args);
+    super::load_mla_attention(&weights, args, prefix).expect("tiny MLA attention must load")
+}
+
+fn max_abs_diff(a: &MlxArray, b: &MlxArray) -> f32 {
+    let diff = mlxcel_core::max_all(&mlxcel_core::abs(&mlxcel_core::subtract(a, b)));
+    mlxcel_core::eval(&diff);
+    mlxcel_core::item_f32(&diff)
+}
+
+/// Regression for issue #619 (dense path): a maskless multi-token prefill must
+/// be causal. Position 0 of an N-token prefill must equal a single-token
+/// forward of that token (the deepseek_v3 `prefill_is_causal_without_caller_mask`
+/// assertion, post-#618).
+#[test]
+fn prefill_is_causal_without_caller_mask_dense() {
+    let _runtime = crate::initialize_runtime();
+    // index_topk large -> indexer returns None -> dense path.
+    let args = tiny_mla_config(2048);
+    let attn = tiny_mla_attention(&args, false);
+
+    let hidden = args.hidden_size as i32;
+    // Strongly position-asymmetric inputs (sign flip + growth) so a
+    // bidirectional prefill visibly contaminates position 0.
+    let x_data: Vec<f32> = (0..2 * args.hidden_size)
+        .map(|i| if i < args.hidden_size { 1.0 } else { -3.0 } * (0.4 * (i as f32 % 6.0 + 1.0)))
+        .collect();
+    let x_two = mlxcel_core::from_slice_f32(&x_data, &[1, 2, hidden]);
+    let x_first = mlxcel_core::from_slice_f32(&x_data[..args.hidden_size], &[1, 1, hidden]);
+
+    let mut cache_prefill = mlxcel_core::layers::KVCache::new();
+    let out_two = attn.forward(&x_two, None, &mut cache_prefill);
+    let pos0_of_two = mlxcel_core::slice(&out_two, &[0, 0, 0], &[1, 1, hidden]);
+
+    let mut cache_single = mlxcel_core::layers::KVCache::new();
+    let out_one = attn.forward(&x_first, None, &mut cache_single);
+
+    let diff = max_abs_diff(&pos0_of_two, &out_one);
+    assert!(
+        diff < 1e-4,
+        "dense prefill: position 0 must not attend to position 1 (max diff {diff})"
+    );
+}
+
+/// Regression for issue #619 (sparse-indexer path): with `kv_len > index_topk`
+/// the lightning indexer's top-k selection and the sparse prefill mask must
+/// both be causal when the caller passes no mask.
+#[test]
+fn prefill_is_causal_without_caller_mask_sparse() {
+    let _runtime = crate::initialize_runtime();
+    // index_topk 2 with a 4-token prefill -> kv_len 4 > 2 -> sparse path.
+    let args = tiny_mla_config(2);
+    let attn = tiny_mla_attention(&args, true);
+
+    let hidden = args.hidden_size as i32;
+    let x_data: Vec<f32> = (0..4 * args.hidden_size)
+        .map(|i| {
+            let sign = if (i / args.hidden_size).is_multiple_of(2) {
+                1.0
+            } else {
+                -3.0
+            };
+            sign * (0.4 * (i as f32 % 6.0 + 1.0))
+        })
+        .collect();
+    let x_four = mlxcel_core::from_slice_f32(&x_data, &[1, 4, hidden]);
+    let x_first = mlxcel_core::from_slice_f32(&x_data[..args.hidden_size], &[1, 1, hidden]);
+
+    let mut cache_prefill = mlxcel_core::layers::KVCache::new();
+    let out_four = attn.forward(&x_four, None, &mut cache_prefill);
+    let pos0_of_four = mlxcel_core::slice(&out_four, &[0, 0, 0], &[1, 1, hidden]);
+
+    let mut cache_single = mlxcel_core::layers::KVCache::new();
+    let out_one = attn.forward(&x_first, None, &mut cache_single);
+
+    let diff = max_abs_diff(&pos0_of_four, &out_one);
+    assert!(
+        diff < 1e-4,
+        "sparse prefill: position 0 must not attend to future keys (max diff {diff})"
+    );
+}
+
+/// Decode (`l == 1`) must NOT get the causal fallback: with cached history,
+/// every position is causally valid and a fallback mask of the wrong shape
+/// would corrupt (or crash) the step. Pin that a prefill-then-decode run
+/// produces finite output.
+#[test]
+fn decode_step_stays_maskless_after_prefill() {
+    let _runtime = crate::initialize_runtime();
+    let args = tiny_mla_config(2048);
+    let attn = tiny_mla_attention(&args, false);
+
+    let hidden = args.hidden_size as i32;
+    let x_data: Vec<f32> = (0..3 * args.hidden_size)
+        .map(|i| 0.05 * (i as f32 + 1.0))
+        .collect();
+    let x_two = mlxcel_core::from_slice_f32(&x_data[..2 * args.hidden_size], &[1, 2, hidden]);
+    let x_next = mlxcel_core::from_slice_f32(&x_data[2 * args.hidden_size..], &[1, 1, hidden]);
+
+    let mut cache = mlxcel_core::layers::KVCache::new();
+    let _ = attn.forward(&x_two, None, &mut cache);
+    let out = attn.forward(&x_next, None, &mut cache);
+    let m = mlxcel_core::max_all(&mlxcel_core::abs(&out));
+    mlxcel_core::eval(&m);
+    assert!(
+        mlxcel_core::item_f32(&m).is_finite(),
+        "decode step after prefill must stay finite"
+    );
+}
+
+/// Regression for the #618-class off-by-one: `sanitize_weights` must strip
+/// ONLY the MTP trailer at `layer_idx == num_hidden_layers` and keep every
+/// real decoder layer below it (a stripped real layer would make
+/// `from_weights` fail with a missing weight, dropping the last layer's
+/// computation as in deepseek_v3 pre-#618).
+#[test]
+fn sanitize_strips_only_the_mtp_trailer_layer() {
+    let args = tiny_mla_config(2048); // num_hidden_layers = 1
+    let mut weights = WeightMap::new();
+    weights.insert(
+        "model.layers.0.input_layernorm.weight".to_string(),
+        f32_weight(&[6]),
+    );
+    weights.insert(
+        "model.layers.1.input_layernorm.weight".to_string(), // MTP trailer
+        f32_weight(&[6]),
+    );
+    weights.insert("model.norm.weight".to_string(), f32_weight(&[6]));
+
+    let sanitized = super::DeepSeekV32Model::sanitize_weights(weights, &args);
+    assert!(
+        sanitized.contains_key("model.layers.0.input_layernorm.weight"),
+        "real decoder layer 0 must be kept"
+    );
+    assert!(
+        !sanitized.contains_key("model.layers.1.input_layernorm.weight"),
+        "MTP trailer at index num_hidden_layers must be stripped"
+    );
+    assert!(
+        sanitized.contains_key("model.norm.weight"),
+        "non-layer keys must pass through"
+    );
+}


### PR DESCRIPTION
## Summary

`MLAAttention::forward` in `src/models/deepseek_v32.rs` applied causality to the attention scores only when the caller supplied a mask. Both standard generation paths pass `mask == None` for prefill (the offline CLI text prefill and the VLM embeddings prefill), so a multi-token prefill attended bidirectionally and every layer wrote future-contaminated K/V into the cache. This is the class PR #618 root-caused and fixed on the `deepseek_v3` backbone, which explicitly flagged `deepseek_v32` as carrying the same structure. Two DSA-specific facets were exposed as well: the lightning indexer's `top_indices` received the same `None` (top-k selection could pick future keys), and `apply_sparse_prefill_mask`'s documented invariant ("pe_scores already carries the causal mask") was false.

## Fix

Mirrors `deepseek_v3` post-#618: capture the pre-update live length (`live_before = cache.live_len()`) next to the rope offset, build `create_causal_mask(l, live_before)` once for any maskless multi-token forward, and route that effective mask to BOTH consumers, the indexer top-k selection and the additive `pe_scores` mask. Decode (`l == 1`) stays maskless: every cached or gathered position is causally valid.

## Validation

- **Fail-then-pass**: the dense prefill causality test fails on the pre-fix code (position 0 of a 2-token maskless prefill differs from the single-token forward by 9e-3) and passes after the fix.
- The sparse-indexer variant pins the `kv_len > index_topk` prefill path post-fix; the existing `indexer_top_indices_respects_causal_mask` test pins that the additive mask steers top-k selection.
- A decode-after-prefill test pins the maskless `l == 1` step; a sanitize test locks that only the MTP trailer at `layer_idx == num_hidden_layers` is stripped (the #618-class off-by-one, which deepseek_v32 does not have).
- 49 deepseek-family unit tests, `cargo fmt`, and `cargo clippy --all-targets -- -D warnings` are clean.
- **Real-checkpoint limitation, stated plainly**: every public `deepseek_v32`-backbone checkpoint exceeds the 128 GB validation machine (DeepSeek-V3.2 ~350 GB at 4-bit; GLM-5 via `glm_moe_dsa` ~200 GB at 4-bit), so end-to-end generation could not be re-validated here. The fix is a byte-for-byte mirror of the #618 pattern that WAS validated on real hardware via the deepseek_v3 backbone (Kimi-VL), with the fail-then-pass unit proof standing in for this backbone.

Closes #619
