### PR TITLE
fix(downloader): offload download_repo to a dedicated thread when a Tokio runtime is active

### DIFF
--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -592,6 +592,28 @@ async fn stream_to_tempfile(
 /// invalid repo id, missing authentication on a gated repo, missing revision,
 /// network failure, and on-disk I/O errors.
 pub fn download_repo(opts: DownloadOptions) -> Result<()> {
+    // Issue #463: this function creates its own Tokio runtime and calls
+    // `block_on`, which Tokio forbids on a thread that is already driving a
+    // runtime ("Cannot start a runtime from within a runtime", an abort). The
+    // async `mlxcel serve` / `mlxcel-server` startup paths hit exactly that
+    // when a model must be auto-downloaded. When a runtime is detected on the
+    // current thread, run the blocking download body on a dedicated OS thread
+    // instead; the progress UX is unchanged (the bars write to the same
+    // stderr) and every caller, sync or async, becomes safe.
+    if tokio::runtime::Handle::try_current().is_ok() {
+        let handle = std::thread::Builder::new()
+            .name("mlxcel-download".to_string())
+            .spawn(move || download_repo_blocking(opts))
+            .context("Failed to spawn the download worker thread")?;
+        return match handle.join() {
+            Ok(result) => result,
+            Err(panic) => std::panic::resume_unwind(panic),
+        };
+    }
+    download_repo_blocking(opts)
+}
+
+fn download_repo_blocking(opts: DownloadOptions) -> Result<()> {
     // Issue #171: expand a bare, prefix-less model name (e.g. `Qwen3-4B-4bit`)
     // to `<default-org>/<name>` BEFORE anything is derived from `opts.repo_id` —
     // the HF-cache reuse probe below, the store destination

--- a/src/downloader/tests.rs
+++ b/src/downloader/tests.rs
@@ -856,3 +856,50 @@ fn encode_path_segments_handles_empty_input() {
     assert_eq!(encode_path_segments("a/b/c"), "a/b/c");
     assert_eq!(encode_path_segments("a b/c d"), "a%20b/c%20d");
 }
+
+/// Regression for issue #463: `download_repo` must not abort with "Cannot
+/// start a runtime from within a runtime" when called on a thread that is
+/// already driving a Tokio runtime (the `mlxcel serve` / `mlxcel-server`
+/// auto-download startup path). Pins that the runtime-aware guard offloads
+/// the blocking body and surfaces a normal `Err`. The endpoint points at a
+/// closed local port so the offloaded download fails fast without touching
+/// the network.
+#[tokio::test(flavor = "multi_thread")]
+async fn download_repo_inside_runtime_errors_instead_of_aborting() {
+    let _guard = env_lock();
+    let prev_endpoint = std::env::var("HF_ENDPOINT").ok();
+    let prev_token = std::env::var("HF_TOKEN").ok();
+    unsafe {
+        std::env::set_var("HF_ENDPOINT", "http://127.0.0.1:9");
+        // A token from the host environment would trip the plaintext-endpoint
+        // refusal before the connection attempt; clear it so the failure mode
+        // under test is the (fast, local) connection refusal.
+        std::env::remove_var("HF_TOKEN");
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let opts = DownloadOptions {
+        repo_id: "mlx-community/issue-463-regression-not-a-real-repo".to_string(),
+        local_dir: Some(dir.path().to_path_buf()),
+        models_dir: None,
+        revision: None,
+        token: None,
+        force: true,
+    };
+    let result = download_repo(opts);
+
+    unsafe {
+        match prev_endpoint {
+            Some(v) => std::env::set_var("HF_ENDPOINT", v),
+            None => std::env::remove_var("HF_ENDPOINT"),
+        }
+        if let Some(v) = prev_token {
+            std::env::set_var("HF_TOKEN", v);
+        }
+    }
+
+    assert!(
+        result.is_err(),
+        "a closed endpoint must surface a normal error, not a nested-runtime abort"
+    );
+}


### PR DESCRIPTION
## Summary

`mlxcel serve -m <repo-id>` aborted with Tokio's "Cannot start a runtime from within a runtime" whenever the model had to be auto-downloaded, because `download_repo` builds its own runtime and calls `block_on`, which is forbidden on a thread already driving a runtime (`run_serve` is async). The synchronous `mlxcel run` path never hit it.

## Fix

The `download_repo` entry point now detects an active runtime via `tokio::runtime::Handle::try_current()` and runs the unchanged blocking body (`download_repo_blocking`) on a dedicated OS thread (joined, panics propagated); synchronous callers keep the direct call. This is the issue's "runtime-aware download entry" option: one change makes every current and future caller safe — `mlxcel serve`, `mlxcel-server`'s `#[tokio::main]` download path near startup, and the CLI `download` / `run` verbs — with identical progress output (the bars write to the same stderr).

## Validation

End to end with the release binary and an empty store:

```
mlxcel serve -m mlx-community/SmolLM2-135M-Instruct-8bit --port 18463
  [mlxcel download] 8 files queued (filtered from 10 total siblings)
  [mlxcel download] complete: downloaded=8 cached=0 total_size=141.02 MiB dest=~/.cache/mlxcel/models/...
  ... Warmup complete
```

The server starts and answers a `/v1/chat/completions` request; the same invocation previously aborted at the first internal `block_on` (the issue's exact repro shape). A missing-repo variant surfaces a clean HTTP 404 error through the serve path instead of the abort. A regression test pins that `download_repo` called from inside a multi-thread runtime returns a normal error (closed local endpoint, no network access). 123 downloader unit tests, `cargo fmt`, and `cargo clippy --all-targets -- -D warnings` are clean.

Closes #463
