### PR TITLE
fix(cuda/attention): bound long-prompt prefill memory for flash-ineligible models

### DIFF
--- a/benchmarks/cuda_gb10_gemma_longprompt_672_2026-07-06.csv
+++ b/benchmarks/cuda_gb10_gemma_longprompt_672_2026-07-06.csv
@@ -1,0 +1,6 @@
+model,prompt_tokens,generated_tokens,prefill_chunk,prefill_ms,prefill_tok_s,decode_ms,decode_tok_s,mlx_peak_gb,sys_peak_gb,date,hardware,mlx_version,build_type,notes
+gemma-4-12b-it-4bit,8192,64,0,26084.04,314.06,4575.95,13.99,18.28,,2026-07-06,NVIDIA_GB10_122GB,0.3.3,release,single-pass prefill; pre-#672 this length already ran but with f32-promoted fallback scores
+gemma-4-12b-it-4bit,8192,64,2048,10555.41,776.09,4560.28,14.03,14.56,,2026-07-06,NVIDIA_GB10_122GB,0.3.3,release,MLXCEL_PREFILL_CHUNK=2048; decode unchanged vs single-pass
+gemma-4-12b-it-4bit,32768,16,2048,46389.66,706.36,1158.97,13.81,16.63,23,2026-07-06,NVIDIA_GB10_122GB,0.3.3,release,MLXCEL_PREFILL_CHUNK=2048; pre-#672 this configuration was the OOM class
+gemma-4-31b-it-4bit,16384,16,0,100495.96,163.03,2190.40,7.30,54.26,80,2026-07-06,NVIDIA_GB10_122GB,0.3.3,release,single-pass prefill with #672 attention chunk gate + last-position logits + flag-path masks
+gemma-4-31b-it-4bit,32768,64,2048,120648.11,271.60,11130.15,5.75,29.91,38,2026-07-06,NVIDIA_GB10_122GB,0.3.3,release,MLXCEL_PREFILL_CHUNK=2048; pre-#672 this configuration OOMed at ~101 GB (issue #672 repro)

--- a/benchmarks/cuda_gb10_longprompt_2026-07-04.csv
+++ b/benchmarks/cuda_gb10_longprompt_2026-07-04.csv
@@ -1,0 +1,8 @@
+model,model_path,prompt_tokens,generated_tokens,prefill_ms,prefill_tok_s,decode_ms,decode_tok_s,date,hardware,mlx_version,build_type,max_tokens,prompt,prompt_target_len
+llama-3.1-8b-4bit,./models/llama-3.1-8b-4bit,512,32,165.40,3095.56,590.58,54.18,2026-07-04,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",512
+llama-3.1-8b-4bit,./models/llama-3.1-8b-4bit,2048,32,727.20,2816.30,616.86,51.88,2026-07-04,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",2048
+llama-3.1-8b-4bit,./models/llama-3.1-8b-4bit,8192,32,4829.97,1696.08,730.33,43.82,2026-07-04,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",8192
+llama-3.1-8b-4bit,./models/llama-3.1-8b-4bit,32768,32,21850.09,1499.67,1170.83,27.33,2026-07-04,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",32768
+qwen2.5-7b-4bit,./models/qwen2.5-7b-4bit,512,32,159.16,3216.99,546.10,58.60,2026-07-04,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",512
+qwen2.5-7b-4bit,./models/qwen2.5-7b-4bit,2048,32,687.89,2977.23,562.15,56.92,2026-07-04,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",2048
+qwen2.5-7b-4bit,./models/qwen2.5-7b-4bit,8192,32,4502.82,1819.30,603.65,53.01,2026-07-04,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",8192

--- a/src/bin/bench_decode.rs
+++ b/src/bin/bench_decode.rs
@@ -434,6 +434,13 @@ fn main() -> Result<()> {
 
     println!("[Profile Results]");
     stats.print();
+    // MLX allocator high-water mark for the whole run (model load + prefill +
+    // decode). This is the number an OOM budget must fit, independent of how
+    // much the cudaMallocAsync pool has returned to the OS (issue #672).
+    println!(
+        "  MLX peak memory:  {:.2} GB",
+        mlxcel_core::get_peak_memory() as f64 / 1e9
+    );
     io::stdout().flush()?;
 
     mlxcel_core::clear_memory_cache();

--- a/src/lib/mlxcel-core/src/generate.rs
+++ b/src/lib/mlxcel-core/src/generate.rs
@@ -246,6 +246,65 @@ fn logits_at_position(logits: &MlxArray, pos: usize) -> UniquePtr<MlxArray> {
     ffi::slice(logits, &[0, pos as i32, 0], &[batch, pos as i32 + 1, vocab])
 }
 
+/// Cache-level prefill chunk length for the single-sequence CLI/bench path,
+/// from `MLXCEL_PREFILL_CHUNK` (tokens, default `0` = single-pass prefill,
+/// unchanged behavior).
+///
+/// When enabled, the prompt is fed through `forward_last_logits` in chunks of
+/// this many tokens, evaluating each chunk before the next so the lazy graph
+/// (and its transients) never spans the whole prompt. This bounds prefill
+/// memory the way the server's `prefill_chunk_size` path does: sliding-window
+/// KV caches rotate down to their window between chunks instead of holding
+/// every prompt token for one giant pass, and per-chunk attention scores,
+/// masks, and logits stay chunk-sized (issue #672). Mirrors mlx-lm's
+/// `prefill_step_size` (default 2048 there); opt-in here until per-family
+/// multi-call prefill parity is validated beyond the server-covered models.
+fn prefill_chunk_len() -> usize {
+    static CHUNK: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CHUNK.get_or_init(|| {
+        std::env::var("MLXCEL_PREFILL_CHUNK")
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .unwrap_or(0)
+    })
+}
+
+/// Run a chunked single-sequence prefill: feed `prompt_tokens` through the
+/// model `chunk` tokens at a time, forcing evaluation between chunks, and
+/// return the `[1, 1, vocab]` logits of the final prompt position.
+///
+/// Behavior-equivalent to one `forward_last_logits` over the whole prompt:
+/// each `forward` continues from the KV caches exactly like the multi-token
+/// verify / server chunked-prefill paths, and only the last chunk's final
+/// position is sampled. Intermediate chunks still project a single hidden row
+/// through the LM head (their `[1, 1, vocab]` result is dropped).
+fn chunked_prefill_last_logits<M: LanguageModel + ?Sized>(
+    model: &M,
+    caches: &mut [KVCache],
+    prompt_tokens: &[i32],
+    chunk: usize,
+) -> UniquePtr<MlxArray> {
+    debug_assert!(chunk > 0 && !prompt_tokens.is_empty());
+    let mut logits: Option<UniquePtr<MlxArray>> = None;
+    for piece in prompt_tokens.chunks(chunk) {
+        let input = ffi::from_slice_i32(piece, &[1, piece.len() as i32]);
+        let piece_logits =
+            model.forward_last_logits(&input, caches, None, piece.len().saturating_sub(1));
+        // Evaluate now so this chunk's transients are released before the
+        // next chunk's graph is built; the result is only [1, 1, vocab].
+        ffi::eval(&piece_logits);
+        // Return freed buffers to the OS between chunks. Every chunk sees a
+        // different key length, so its transients (scores, masks, logits)
+        // land in differently-sized allocations; without this the CUDA
+        // async-malloc pool accumulates each shape's high-water mark across
+        // the whole prompt (measured ~84 GB system peak for a 32k gemma-4-31b
+        // chunked prefill whose live set is ~30 GB, issue #672).
+        ffi::clear_memory_cache();
+        logits = Some(piece_logits);
+    }
+    logits.expect("chunked_prefill_last_logits requires a non-empty prompt")
+}
+
 /// Trait for language models that can be used for generation
 pub trait LanguageModel {
     /// Forward pass through the model
@@ -1098,7 +1157,11 @@ impl CxxGenerator {
         // On M5+ hardware pad the sequence to a 32-token tile boundary for
         // optimal Neural Accelerator throughput.
         let actual_len = prompt_tokens.len();
-        let logits = if should_align_prefill() && model.supports_padded_prefill() {
+        let prefill_chunk = prefill_chunk_len();
+        let logits = if prefill_chunk > 0 && actual_len > prefill_chunk {
+            // Opt-in cache-level chunked prefill (MLXCEL_PREFILL_CHUNK).
+            chunked_prefill_last_logits(model, &mut self.caches, prompt_tokens, prefill_chunk)
+        } else if should_align_prefill() && model.supports_padded_prefill() {
             let padded_len = align_to_na_tile(actual_len);
             let (padded_tokens, mask_opt) = pad_tokens_for_prefill(
                 prompt_tokens,
@@ -1762,7 +1825,11 @@ impl CxxGenerator {
         // optimal Neural Accelerator throughput.
         let actual_len = prompt_tokens.len();
         let prefill_start = Instant::now();
-        let logits = if should_align_prefill() && model.supports_padded_prefill() {
+        let prefill_chunk = prefill_chunk_len();
+        let logits = if prefill_chunk > 0 && actual_len > prefill_chunk {
+            // Opt-in cache-level chunked prefill (MLXCEL_PREFILL_CHUNK).
+            chunked_prefill_last_logits(model, &mut self.caches, prompt_tokens, prefill_chunk)
+        } else if should_align_prefill() && model.supports_padded_prefill() {
             let padded_len = align_to_na_tile(actual_len);
             let (padded_tokens, mask_opt) = pad_tokens_for_prefill(
                 prompt_tokens,
@@ -2143,6 +2210,89 @@ mod tests {
 
         fn eos_token_ids(&self) -> Vec<i32> {
             vec![99]
+        }
+    }
+
+    /// Stateful stub: accumulates every token it has seen (its "KV cache")
+    /// and returns logits whose value is the running total, so a chunked
+    /// prefill that dropped or re-fed tokens would produce a different final
+    /// value than a single pass.
+    struct AccumStubModel {
+        seen: std::cell::RefCell<Vec<i32>>,
+    }
+
+    impl LanguageModel for AccumStubModel {
+        fn forward(
+            &self,
+            input_ids: &MlxArray,
+            _caches: &mut [KVCache],
+            _mask: Option<&MlxArray>,
+        ) -> UniquePtr<MlxArray> {
+            let l = ffi::array_shape(input_ids)[1];
+            ffi::eval(input_ids);
+            for i in 0..l {
+                let tok = ffi::slice(input_ids, &[0, i], &[1, i + 1]);
+                self.seen.borrow_mut().push(ffi::item_i32(&tok));
+            }
+            let total: f32 = self.seen.borrow().iter().sum::<i32>() as f32;
+            let mut logits = Vec::with_capacity(l as usize * 4);
+            for _ in 0..l {
+                logits.extend_from_slice(&[total; 4]);
+            }
+            ffi::from_slice_f32(&logits, &[1, l, 4])
+        }
+
+        fn make_caches(&self) -> Vec<KVCache> {
+            vec![KVCache::new()]
+        }
+
+        fn num_layers(&self) -> usize {
+            1
+        }
+
+        fn eos_token_ids(&self) -> Vec<i32> {
+            vec![99]
+        }
+    }
+
+    /// Chunked prefill must feed every prompt token exactly once, in order,
+    /// and return the same final-position logits as a single pass.
+    #[test]
+    fn chunked_prefill_matches_single_pass() {
+        let prompt: Vec<i32> = (1..=10).collect();
+
+        let single = AccumStubModel {
+            seen: std::cell::RefCell::new(Vec::new()),
+        };
+        let mut caches = single.make_caches();
+        let input = ffi::from_slice_i32(&prompt, &[1, prompt.len() as i32]);
+        let single_logits = single.forward_last_logits(&input, &mut caches, None, prompt.len() - 1);
+
+        for chunk in [1usize, 3, 4, 10, 16] {
+            let chunked = AccumStubModel {
+                seen: std::cell::RefCell::new(Vec::new()),
+            };
+            let mut caches = chunked.make_caches();
+            let chunked_logits = chunked_prefill_last_logits(&chunked, &mut caches, &prompt, chunk);
+            assert_eq!(
+                ffi::array_shape(&chunked_logits).as_slice(),
+                &[1, 1, 4],
+                "chunk={chunk}"
+            );
+            assert_eq!(
+                chunked.seen.borrow().as_slice(),
+                prompt.as_slice(),
+                "chunk={chunk} fed tokens out of order or twice"
+            );
+            let first = ffi::slice(&chunked_logits, &[0, 0, 0], &[1, 1, 1]);
+            let single_first = ffi::slice(&single_logits, &[0, 0, 0], &[1, 1, 1]);
+            ffi::eval(&first);
+            ffi::eval(&single_first);
+            assert_eq!(
+                ffi::item_f32(&first),
+                ffi::item_f32(&single_first),
+                "chunk={chunk} final logits diverged from single-pass"
+            );
         }
     }
 

--- a/src/lib/mlxcel-core/src/generate.rs
+++ b/src/lib/mlxcel-core/src/generate.rs
@@ -290,6 +290,33 @@ pub trait LanguageModel {
         Vec::new()
     }
 
+    /// Forward pass for a single-sequence prefill whose caller only needs the
+    /// logits of one position (`last_pos`, 0-based within this call's
+    /// sequence). Returns `[batch, 1, vocab]`.
+    ///
+    /// The default computes the full `[batch, seq_len, vocab]` logits via
+    /// [`Self::forward`] and slices out `last_pos`, which is
+    /// behavior-identical to what the prefill call sites previously did
+    /// inline. Models with a large vocabulary should override this to project
+    /// only the `last_pos` hidden row through the LM head: for a 262k-vocab
+    /// gemma-4 at a 32k-token prefill, the full logits tensor is ~17 GiB in
+    /// f16 plus a same-size `final_logit_softcapping` copy, none of which is
+    /// needed to sample the first generated token (issue #672).
+    ///
+    /// Used by: the single-sequence prefill in `generate_streaming` and
+    /// `generate_with_stats`. Verify/speculative/logprobs paths keep calling
+    /// [`Self::forward`] for full per-position logits.
+    fn forward_last_logits(
+        &self,
+        input_ids: &MlxArray,
+        caches: &mut [KVCache],
+        mask: Option<&MlxArray>,
+        last_pos: usize,
+    ) -> UniquePtr<MlxArray> {
+        let logits = self.forward(input_ids, caches, mask);
+        logits_at_position(&logits, last_pos)
+    }
+
     /// Forward with pre-computed embeddings (for VLM prefill)
     /// Used by: VisionLanguageModel (Gemma3 VLM)
     fn forward_with_embeddings(
@@ -1079,25 +1106,24 @@ impl CxxGenerator {
                 model.supports_maskless_padded_prefill(),
             );
             let input = ffi::from_slice_i32(&padded_tokens, &[1, padded_len as i32]);
-            let raw_logits = model.forward(
+            // Last *real* token position; `forward_last_logits` slices there,
+            // replacing the previous forward + `logits_at_position` pair.
+            let raw_logits = model.forward_last_logits(
                 &input,
                 &mut self.caches,
                 mask_opt.as_ref().map(|m| m.as_ref().unwrap()),
+                actual_len.saturating_sub(1),
             );
             // Trim padding positions from all KV caches so decode uses the
             // correct cache offset (actual_len, not padded_len).
             if padded_len > actual_len {
                 trim_caches_to_actual_len(&mut self.caches, actual_len, padded_len);
                 model.trim_internal_caches((padded_len - actual_len) as i32);
-                // Extract logits at the last real token position.
-                logits_at_position(&raw_logits, actual_len - 1)
-            } else {
-                // No padding was needed (already aligned).
-                raw_logits
             }
+            raw_logits
         } else {
             let input = ffi::from_slice_i32(prompt_tokens, &[1, actual_len as i32]);
-            model.forward(&input, &mut self.caches, None)
+            model.forward_last_logits(&input, &mut self.caches, None, actual_len.saturating_sub(1))
         };
 
         if trace_dtype {
@@ -1744,21 +1770,22 @@ impl CxxGenerator {
                 model.supports_maskless_padded_prefill(),
             );
             let input = ffi::from_slice_i32(&padded_tokens, &[1, padded_len as i32]);
-            let raw_logits = model.forward(
+            // Last *real* token position; `forward_last_logits` slices there,
+            // replacing the previous forward + `logits_at_position` pair.
+            let raw_logits = model.forward_last_logits(
                 &input,
                 &mut self.caches,
                 mask_opt.as_ref().map(|m| m.as_ref().unwrap()),
+                actual_len.saturating_sub(1),
             );
             if padded_len > actual_len {
                 trim_caches_to_actual_len(&mut self.caches, actual_len, padded_len);
                 model.trim_internal_caches((padded_len - actual_len) as i32);
-                logits_at_position(&raw_logits, actual_len - 1)
-            } else {
-                raw_logits
             }
+            raw_logits
         } else {
             let input = ffi::from_slice_i32(prompt_tokens, &[1, actual_len as i32]);
-            model.forward(&input, &mut self.caches, None)
+            model.forward_last_logits(&input, &mut self.caches, None, actual_len.saturating_sub(1))
         };
 
         // Sample first token and force sync to measure prefill accurately
@@ -2083,6 +2110,56 @@ mod tests {
 
         fn eos_token_ids(&self) -> Vec<i32> {
             vec![99]
+        }
+    }
+
+    /// Multi-position stub: logits value encodes the sequence position, so a
+    /// slicing bug in `forward_last_logits` is directly visible.
+    struct SeqStubModel;
+
+    impl LanguageModel for SeqStubModel {
+        fn forward(
+            &self,
+            input_ids: &MlxArray,
+            _caches: &mut [KVCache],
+            _mask: Option<&MlxArray>,
+        ) -> UniquePtr<MlxArray> {
+            // Input [1, L] -> logits [1, L, 4] with row i filled with i as f32.
+            let seq_len = ffi::array_shape(input_ids)[1] as usize;
+            let mut logits = Vec::with_capacity(seq_len * 4);
+            for i in 0..seq_len {
+                logits.extend_from_slice(&[i as f32; 4]);
+            }
+            ffi::from_slice_f32(&logits, &[1, seq_len as i32, 4])
+        }
+
+        fn make_caches(&self) -> Vec<KVCache> {
+            vec![KVCache::new()]
+        }
+
+        fn num_layers(&self) -> usize {
+            1
+        }
+
+        fn eos_token_ids(&self) -> Vec<i32> {
+            vec![99]
+        }
+    }
+
+    /// The default `forward_last_logits` must equal forward + slice at the
+    /// requested position, with shape `[batch, 1, vocab]`.
+    #[test]
+    fn forward_last_logits_default_matches_forward_slice() {
+        let model = SeqStubModel;
+        let input = ffi::from_slice_i32(&[5, 6, 7, 8], &[1, 4]);
+
+        for pos in [0usize, 2, 3] {
+            let mut caches = model.make_caches();
+            let last = model.forward_last_logits(&input, &mut caches, None, pos);
+            assert_eq!(ffi::array_shape(&last).as_slice(), &[1, 1, 4]);
+            let first = ffi::slice(&last, &[0, 0, 0], &[1, 1, 1]);
+            ffi::eval(&first);
+            assert_eq!(ffi::item_f32(&first), pos as f32, "wrong row at pos {pos}");
         }
     }
 

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -2470,10 +2470,30 @@ pub fn attention(
     softcap: f32,
     window_size: i32,
 ) -> UniquePtr<MlxArray> {
-    let mask_ptr = mask.map(|m| m as *const _).unwrap_or(std::ptr::null());
     if should_use_metal4_attention() {
         return metal4_attention(q, k, v, scale, mask, softcap, window_size);
     }
+
+    if let Some(chunk) = materializing_sdpa_query_chunk(q, k, v, softcap) {
+        return chunked_query_attention(q, k, v, scale, mask, softcap, chunk);
+    }
+
+    attention_dispatch(q, k, v, scale, mask, softcap)
+}
+
+/// Single-shot SDPA dispatch: softcap composite or MLX's fused/fallback SDPA.
+///
+/// The score-materialization chunk gate lives in [`attention`]; this inner
+/// dispatch always issues one SDPA over the full query length it is given.
+fn attention_dispatch(
+    q: &MlxArray,
+    k: &MlxArray,
+    v: &MlxArray,
+    scale: f32,
+    mask: Option<&MlxArray>,
+    softcap: f32,
+) -> UniquePtr<MlxArray> {
+    let mask_ptr = mask.map(|m| m as *const _).unwrap_or(std::ptr::null());
 
     if softcap > 0.0 {
         let q_heads = ffi::array_shape(q)[1];
@@ -2491,6 +2511,265 @@ pub fn attention(
 
     // SAFETY: q/k/v/mask_ptr are valid for the duration of this call.
     unsafe { ffi::fast_scaled_dot_product_attention(q, k, v, scale, mask_ptr) }
+}
+
+/// Score-matrix byte budget above which a prefill SDPA is query-chunked, from
+/// `MLXCEL_ATTENTION_CHUNK_BUDGET_MB` (MiB, default 1024; `0` disables
+/// chunking entirely).
+///
+/// The budget bounds the raw `[B, heads, chunk, k_len]` score matmul output;
+/// the fallback composite briefly holds a few score-sized buffers per chunk
+/// (masked scores, softmax), so the live attention transient is a small
+/// multiple of this value. 1024 MiB keeps that multiple to a few GiB while
+/// leaving per-chunk matmuls large enough to stay bandwidth-bound.
+fn attention_chunk_budget_bytes() -> usize {
+    static BUDGET: OnceLock<usize> = OnceLock::new();
+    *BUDGET.get_or_init(|| {
+        std::env::var("MLXCEL_ATTENTION_CHUNK_BUDGET_MB")
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .unwrap_or(1024)
+            .saturating_mul(1024 * 1024)
+    })
+}
+
+/// True when this q/v + softcap combination cannot reach a fused
+/// (memory-linear) SDPA kernel on the CUDA backend, so MLX's fallback would
+/// materialize the full `[B, heads, q_len, k_len]` score matrix.
+///
+/// Mirrors `supports_sdpa_cudnn` in
+/// `mlx/backend/cuda/scaled_dot_product_attention.cpp`: the cuDNN flash SDPA
+/// requires `head_dim % 8 == 0 && head_dim <= 128` for both Q and V and an
+/// f16/bf16 dtype (gemma-3/gemma-4/gemma-3n use head_dim 256 and never
+/// qualify, issue #672). The softcap composite (`compiled_softcap_sdpa*`)
+/// is an explicit op graph and always materializes. `supports_sdpa_vector`
+/// only covers `q_len < 4`, which the chunk gate's own `q_len` threshold
+/// already excludes. Non-CUDA builds return false: Metal has a different
+/// fused-SDPA support matrix and keeps its current behavior.
+fn cuda_sdpa_materializes_scores(q: &MlxArray, v: &MlxArray, softcap: f32) -> bool {
+    if !cfg!(feature = "cuda") {
+        return false;
+    }
+    if softcap > 0.0 {
+        return true;
+    }
+    let q_shape = ffi::array_shape(q);
+    let v_shape = ffi::array_shape(v);
+    let (Some(&dq), Some(&dv)) = (q_shape.last(), v_shape.last()) else {
+        return false;
+    };
+    let dtype = ffi::array_dtype(q);
+    let flash_eligible = dq % 8 == 0
+        && dq <= 128
+        && dv % 8 == 0
+        && dv <= 128
+        && (dtype == crate::dtype::FLOAT16 || dtype == crate::dtype::BFLOAT16);
+    !flash_eligible
+}
+
+/// Pure chunk-length math for [`materializing_sdpa_query_chunk`].
+///
+/// Splits `q_len` into the smallest number of near-equal chunks whose
+/// per-chunk score matrix stays within `budget` bytes. Returns `None` when the
+/// full score matrix already fits.
+fn query_chunk_len(per_row_bytes: usize, q_len: i32, budget: usize) -> Option<i32> {
+    if q_len < 2 || per_row_bytes == 0 || budget == 0 {
+        return None;
+    }
+    let scores = per_row_bytes.saturating_mul(q_len as usize);
+    if scores <= budget {
+        return None;
+    }
+    let n_chunks = scores.div_ceil(budget).max(2);
+    let chunk = (q_len as usize).div_ceil(n_chunks).max(1);
+    Some(chunk as i32)
+}
+
+/// Query-chunk length for a prefill SDPA that would materialize a score
+/// matrix larger than the chunk budget, or `None` to run unchunked.
+///
+/// gemma-4-31b at a 32768-token single-pass prefill materializes
+/// `32 heads * 32768^2 * 2 B ~= 68 GiB` of scores in the CUDA fallback and
+/// OOMs GB10 (#672). Chunking the query axis bounds the transient to the
+/// budget while leaving per-row results mathematically identical: softmax and
+/// the value matmul are row-independent, and every chunk still sees the full
+/// key axis.
+pub(crate) fn materializing_sdpa_query_chunk(
+    q: &MlxArray,
+    k: &MlxArray,
+    v: &MlxArray,
+    softcap: f32,
+) -> Option<i32> {
+    let budget = attention_chunk_budget_bytes();
+    if budget == 0 {
+        return None;
+    }
+    let q_shape = ffi::array_shape(q);
+    if q_shape.len() != 4 {
+        return None;
+    }
+    let q_len = q_shape[2];
+    if q_len < 2 {
+        return None;
+    }
+    if !cuda_sdpa_materializes_scores(q, v, softcap) {
+        return None;
+    }
+    let k_len = ffi::array_shape(k)[2];
+    let bytes = crate::dtype::size_bytes(ffi::array_dtype(q)).unwrap_or(4);
+    let per_row = (q_shape[0].max(1) as usize)
+        .saturating_mul(q_shape[1].max(1) as usize)
+        .saturating_mul(k_len.max(1) as usize)
+        .saturating_mul(bytes);
+    query_chunk_len(per_row, q_len, budget)
+}
+
+/// Slice query rows `[start, stop)` from a `[B, H, L, D]` tensor.
+fn slice_query_rows(a: &MlxArray, start: i32, stop: i32) -> UniquePtr<MlxArray> {
+    let shape = ffi::array_shape(a);
+    ffi::slice(a, &[0, 0, start, 0], &[shape[0], shape[1], stop, shape[3]])
+}
+
+/// Slice the query-row range `[start, stop)` out of an attention mask whose
+/// second-to-last axis spans the full query length. Returns `None` for masks
+/// that broadcast over the query axis (size 1 there, or rank < 2), which are
+/// row-independent and can be reused unsliced.
+fn slice_mask_query_rows(
+    mask: &MlxArray,
+    start: i32,
+    stop: i32,
+    q_len: i32,
+) -> Option<UniquePtr<MlxArray>> {
+    let shape = ffi::array_shape(mask);
+    if shape.len() < 2 {
+        return None;
+    }
+    let q_axis = shape.len() - 2;
+    if shape[q_axis] != q_len {
+        return None;
+    }
+    let mut starts = vec![0; shape.len()];
+    let mut stops = shape.clone();
+    starts[q_axis] = start;
+    stops[q_axis] = stop;
+    Some(ffi::slice(mask, &starts, &stops))
+}
+
+/// Cast an additive f32 mask to the (f16/bf16) score dtype, or `None` when
+/// the mask is already usable as-is.
+///
+/// MLX's SDPA fallback composite adds an additive mask to the scores WITHOUT
+/// casting (`scores = add(scores, mask)` in `mlx/fast.cpp`), so an f32 mask
+/// promotes the masked scores AND the softmax to f32, doubling the largest
+/// transients of exactly the configurations that reach the fallback (#672).
+/// `-inf` sentinels survive the cast. Bool masks take the fallback's `where`
+/// path, which never promotes, and pass through.
+fn mask_in_score_dtype(mask: &MlxArray, q_dtype: i32) -> Option<UniquePtr<MlxArray>> {
+    let m_dtype = ffi::array_dtype(mask);
+    (m_dtype == crate::dtype::FLOAT32
+        && (q_dtype == crate::dtype::FLOAT16 || q_dtype == crate::dtype::BFLOAT16))
+        .then(|| ffi::astype(mask, q_dtype))
+}
+
+/// Query-chunked SDPA: identical math to a single [`attention_dispatch`] call,
+/// with the transient score matrix bounded to `heads * chunk * k_len` (#672).
+fn chunked_query_attention(
+    q: &MlxArray,
+    k: &MlxArray,
+    v: &MlxArray,
+    scale: f32,
+    mask: Option<&MlxArray>,
+    softcap: f32,
+    chunk: i32,
+) -> UniquePtr<MlxArray> {
+    let q_len = ffi::array_shape(q)[2];
+    let q_dtype = ffi::array_dtype(q);
+    let mut parts: Vec<UniquePtr<MlxArray>> =
+        Vec::with_capacity(((q_len + chunk - 1) / chunk).max(1) as usize);
+    let mut start = 0;
+    while start < q_len {
+        let stop = (start + chunk).min(q_len);
+        let q_c = slice_query_rows(q, start, stop);
+        // Row-slice masks that span the query axis (query-broadcast masks are
+        // reused whole), then keep the chunk-sized mask in the score dtype so
+        // the fallback's mask-add cannot promote scores to f32.
+        let sliced = mask.and_then(|m| slice_mask_query_rows(m, start, stop, q_len));
+        let base_ref: Option<&MlxArray> = sliced.as_deref().or(mask);
+        let cast = base_ref.and_then(|m| mask_in_score_dtype(m, q_dtype));
+        let mask_ref: Option<&MlxArray> = cast.as_deref().or(base_ref);
+        parts.push(attention_dispatch(&q_c, k, v, scale, mask_ref, softcap));
+        start = stop;
+    }
+    let ptrs: Vec<*const MlxArray> = parts
+        .iter()
+        .map(|p| p.as_ref().unwrap() as *const MlxArray)
+        .collect();
+    // SAFETY: every pointer references a live array owned by `parts`.
+    unsafe { ffi::concatenate(&ptrs, 2) }
+}
+
+/// Chunked equivalent of the maskless bottom-right-aligned causal SDPA, for
+/// configurations whose CUDA fallback would materialize the full score matrix
+/// (#672).
+///
+/// Query chunk `[start, stop)` (global offset `k_len - q_len`) attends keys
+/// `[0, offset + stop)` only, so K/V are sliced to that causal bound and the
+/// per-chunk `[stop - start, offset + stop]` causal mask reproduces the
+/// unchunked `do_causal` semantics row for row. Requires `k_len >= q_len`
+/// (callers guard; `do_causal` with `q_len > k_len` is undefined here).
+pub(crate) fn chunked_causal_attention(
+    q: &MlxArray,
+    k: &MlxArray,
+    v: &MlxArray,
+    scale: f32,
+    chunk: i32,
+) -> UniquePtr<MlxArray> {
+    let k_shape = ffi::array_shape(k);
+    let v_shape = ffi::array_shape(v);
+    let q_len = ffi::array_shape(q)[2];
+    let k_len = k_shape[2];
+    let offset = k_len - q_len;
+    debug_assert!(
+        offset >= 0,
+        "chunked_causal_attention requires k_len >= q_len"
+    );
+
+    let mut parts: Vec<UniquePtr<MlxArray>> =
+        Vec::with_capacity(((q_len + chunk - 1) / chunk).max(1) as usize);
+    let mut start = 0;
+    while start < q_len {
+        let stop = (start + chunk).min(q_len);
+        let k_end = offset + stop;
+        let q_c = slice_query_rows(q, start, stop);
+        let k_c = ffi::slice(
+            k,
+            &[0, 0, 0, 0],
+            &[k_shape[0], k_shape[1], k_end, k_shape[3]],
+        );
+        let v_c = ffi::slice(
+            v,
+            &[0, 0, 0, 0],
+            &[v_shape[0], v_shape[1], k_end, v_shape[3]],
+        );
+        let mask = crate::utils::create_causal_mask(stop - start, offset + start);
+        // Keep the per-chunk mask in the score dtype (see mask_in_score_dtype).
+        let mask = mask_in_score_dtype(mask.as_ref().unwrap(), ffi::array_dtype(q)).unwrap_or(mask);
+        parts.push(attention_dispatch(
+            &q_c,
+            &k_c,
+            &v_c,
+            scale,
+            Some(mask.as_ref().unwrap()),
+            0.0,
+        ));
+        start = stop;
+    }
+    let ptrs: Vec<*const MlxArray> = parts
+        .iter()
+        .map(|p| p.as_ref().unwrap() as *const MlxArray)
+        .collect();
+    // SAFETY: every pointer references a live array owned by `parts`.
+    unsafe { ffi::concatenate(&ptrs, 2) }
 }
 
 /// Pointer-friendly attention wrapper for existing model call sites.
@@ -3522,6 +3801,138 @@ mod tests {
 
         let out = attention(&q, &k, &v, 0.5, None, 30.0, 0);
         assert_eq!(ffi::array_shape(&out).as_slice(), &[1, 4, 3, 8]);
+    }
+
+    /// Deterministic pseudo-random f32 tensor for chunked-SDPA equivalence tests.
+    fn test_tensor(shape: &[i32]) -> UniquePtr<MlxArray> {
+        let len: i32 = shape.iter().product();
+        let data: Vec<f32> = (0..len)
+            .map(|i| ((i as f32) * 0.7371 + 0.13).sin())
+            .collect();
+        crate::from_slice_f32(&data, shape)
+    }
+
+    #[test]
+    fn query_chunk_len_splits_evenly_within_budget() {
+        // Fits: no chunking.
+        assert_eq!(query_chunk_len(100, 10, 1000), None);
+        assert_eq!(query_chunk_len(100, 10, 1_000_000), None);
+        // 10 rows * 100 B = 1000 B over a 400 B budget -> 3 chunks of 4/4/2.
+        assert_eq!(query_chunk_len(100, 10, 400), Some(4));
+        // Exactly one row over budget still splits in two.
+        assert_eq!(query_chunk_len(100, 10, 999), Some(5));
+        // Degenerate inputs never chunk.
+        assert_eq!(query_chunk_len(0, 10, 400), None);
+        assert_eq!(query_chunk_len(100, 1, 10), None);
+        assert_eq!(query_chunk_len(100, 10, 0), None);
+        // Every chunk's scores stay within budget.
+        let chunk = query_chunk_len(1000, 100, 7000).unwrap();
+        assert!(chunk as usize * 1000 <= 7000);
+    }
+
+    #[test]
+    fn slice_mask_query_rows_slices_and_broadcasts() {
+        let mask = crate::utils::create_causal_mask(4, 2);
+        let sliced = slice_mask_query_rows(mask.as_ref().unwrap(), 1, 3, 4).unwrap();
+        assert_eq!(ffi::array_shape(&sliced).as_slice(), &[2, 6]);
+        // Row 1 of the slice must equal row 2 of the full mask. `-inf - -inf`
+        // is NaN, so compare the attend/block structure instead of raw values.
+        let full_row = ffi::slice(mask.as_ref().unwrap(), &[2, 0], &[3, 6]);
+        let sliced_row = ffi::slice(&sliced, &[1, 0], &[2, 6]);
+        let sentinel = crate::from_slice_f32(&[-1.0; 6], &[1, 6]);
+        let full_open = ffi::astype(&ffi::greater(&full_row, &sentinel), crate::dtype::FLOAT32);
+        let sliced_open = ffi::astype(&ffi::greater(&sliced_row, &sentinel), crate::dtype::FLOAT32);
+        assert!(max_abs_diff(&full_open, &sliced_open) == 0.0);
+
+        // A mask that broadcasts over the query axis passes through unsliced.
+        let broadcast = crate::from_slice_f32(&[0.0; 6], &[1, 6]);
+        assert!(slice_mask_query_rows(&broadcast, 1, 3, 4).is_none());
+    }
+
+    /// Chunked SDPA must reproduce the unchunked dispatch with an explicit
+    /// causal mask, including an uneven final chunk.
+    #[test]
+    fn chunked_query_attention_matches_unchunked_with_mask() {
+        let q = test_tensor(&[1, 2, 6, 4]);
+        let k = test_tensor(&[1, 2, 6, 4]);
+        let v = test_tensor(&[1, 2, 6, 4]);
+        let scale = 0.5_f32;
+        let mask = crate::utils::create_causal_mask(6, 0);
+
+        let full = attention_dispatch(&q, &k, &v, scale, Some(mask.as_ref().unwrap()), 0.0);
+        for chunk in [1, 2, 4, 5] {
+            let chunked = chunked_query_attention(
+                &q,
+                &k,
+                &v,
+                scale,
+                Some(mask.as_ref().unwrap()),
+                0.0,
+                chunk,
+            );
+            assert_eq!(ffi::array_shape(&chunked), ffi::array_shape(&full));
+            assert!(
+                max_abs_diff(&full, &chunked) < 1e-5,
+                "chunk={chunk} diverged from unchunked SDPA"
+            );
+        }
+    }
+
+    /// Chunked SDPA must reproduce the softcap GQA composite path.
+    #[test]
+    fn chunked_query_attention_matches_unchunked_softcap_gqa() {
+        let q = test_tensor(&[1, 4, 6, 4]);
+        let k = test_tensor(&[1, 2, 6, 4]);
+        let v = test_tensor(&[1, 2, 6, 4]);
+        let scale = 0.5_f32;
+        let softcap = 30.0_f32;
+        let mask = crate::utils::create_causal_mask(6, 0);
+
+        let full = attention_dispatch(&q, &k, &v, scale, Some(mask.as_ref().unwrap()), softcap);
+        let chunked =
+            chunked_query_attention(&q, &k, &v, scale, Some(mask.as_ref().unwrap()), softcap, 2);
+        assert!(
+            max_abs_diff(&full, &chunked) < 1e-5,
+            "softcap GQA chunked SDPA diverged from unchunked"
+        );
+    }
+
+    /// A query-broadcast mask (row axis of size 1) is reused across chunks.
+    #[test]
+    fn chunked_query_attention_matches_unchunked_broadcast_mask() {
+        let q = test_tensor(&[1, 2, 6, 4]);
+        let k = test_tensor(&[1, 2, 6, 4]);
+        let v = test_tensor(&[1, 2, 6, 4]);
+        let scale = 0.5_f32;
+        let mask = crate::from_slice_f32(&[0.0, 0.0, 0.0, 0.0, f32::NEG_INFINITY, 0.0], &[1, 6]);
+
+        let full = attention_dispatch(&q, &k, &v, scale, Some(&mask), 0.0);
+        let chunked = chunked_query_attention(&q, &k, &v, scale, Some(&mask), 0.0, 2);
+        assert!(
+            max_abs_diff(&full, &chunked) < 1e-5,
+            "broadcast-mask chunked SDPA diverged from unchunked"
+        );
+    }
+
+    /// The chunked maskless-causal path must reproduce MLX's native
+    /// bottom-right-aligned `do_causal` SDPA, with and without a KV offset.
+    #[test]
+    fn chunked_causal_attention_matches_fast_causal() {
+        let scale = 0.5_f32;
+        for (q_len, k_len) in [(4, 4), (4, 7), (6, 9)] {
+            let q = test_tensor(&[1, 2, q_len, 4]);
+            let k = test_tensor(&[1, 2, k_len, 4]);
+            let v = test_tensor(&[1, 2, k_len, 4]);
+            let native = ffi::ffi_fast_scaled_dot_product_attention_causal(&q, &k, &v, scale);
+            for chunk in [1, 2, 3] {
+                let chunked = chunked_causal_attention(&q, &k, &v, scale, chunk);
+                assert_eq!(ffi::array_shape(&chunked), ffi::array_shape(&native));
+                assert!(
+                    max_abs_diff(&native, &chunked) < 1e-5,
+                    "q_len={q_len} k_len={k_len} chunk={chunk} diverged from do_causal SDPA"
+                );
+            }
+        }
     }
 
     /// Verify the public causal SDPA wrapper preserves the original shape

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -2773,6 +2773,17 @@ pub fn causal_attention(
         return layers::metal4_causal_attention(q, k, v, scale);
     }
 
+    // Maskless causal prefill on a CUDA config with no fused SDPA kernel
+    // (e.g. head_dim > 128) would materialize the full [heads, L, L] score
+    // matrix in MLX's fallback; chunk the query axis instead (issue #672).
+    // `k_len >= q_len` guards the bottom-right causal alignment the chunked
+    // path reproduces.
+    if k_len >= q_len
+        && let Some(chunk) = layers::materializing_sdpa_query_chunk(q, k, v, 0.0)
+    {
+        return layers::chunked_causal_attention(q, k, v, scale, chunk);
+    }
+
     ffi::ffi_fast_scaled_dot_product_attention_causal(q, k, v, scale)
 }
 

--- a/src/lib/mlxcel-core/src/utils.rs
+++ b/src/lib/mlxcel-core/src/utils.rs
@@ -92,21 +92,47 @@ pub fn slice_axis(x: &MlxArray, axis: i32, start: i32, end: i32) -> UniquePtr<Ml
 /// # Returns
 /// Mask of shape [size, size + offset] with -inf in upper triangular region
 pub fn create_causal_mask(size: i32, offset: i32) -> UniquePtr<MlxArray> {
+    additive_causal_window_mask(size, offset, None)
+}
+
+/// Shared builder for full-width additive causal / windowed-causal masks.
+///
+/// Query row `q` (logical position `q + offset`) attends key column `k` iff
+/// `k <= q + offset` and, when `window` is set, `k >= q + offset - window + 1`.
+/// Output is `[size, size + offset]` f32 with `0.0` = attend, `-inf` = block,
+/// identical to the previous `ones -> tril [-> triu -> multiply] -> greater ->
+/// where` chain.
+///
+/// Built from broadcast index comparisons so the only full-size intermediates
+/// are one or two bool `[size, total]` arrays plus the f32 result. The old
+/// chain materialized up to six f32 `[size, total]` buffers, which at a 32k
+/// single-pass prefill is ~4 GiB each and dominated the allocator high-water
+/// mark of the very models the dense masks serve (issue #672).
+///
+/// Intentional FP32 output: additive attention masks carry 0/-inf sentinels
+/// and are added to attention scores, not propagated as model activations.
+fn additive_causal_window_mask(size: i32, offset: i32, window: Option<i32>) -> UniquePtr<MlxArray> {
     let total_len = size + offset;
 
-    // Create lower triangular mask (1 = attend, 0 = mask)
-    let ones = ffi::ones(&[size, total_len], dtype::FLOAT32);
-    let mask = ffi::tril(&ones, offset);
+    // Row coordinates as logical key positions [size, 1]; columns [1, total].
+    let q_idx = ffi::reshape(&ffi::arange_i32(offset, offset + size, 1), &[size, 1]);
+    let k_idx = ffi::reshape(&ffi::arange_i32(0, total_len, 1), &[1, total_len]);
 
-    // Convert to attention mask format: where mask=1 -> 0, where mask=0 -> -inf
-    // Use where_cond to avoid NaN from 0 * -inf
-    // Intentional FP32: additive attention masks carry 0/-inf sentinels and are
-    // added to attention scores, not propagated as model activations.
-    let zeros = ffi::zeros(&[size, total_len], dtype::FLOAT32);
-    let neg_inf = ffi::full_f32(&[size, total_len], f32::NEG_INFINITY, dtype::FLOAT32);
-    let bool_mask = ffi::greater(&mask, &zeros); // mask > 0 gives bool mask
+    // Causal upper bound: k <= q + offset.
+    let mut allowed = ffi::less_equal(&k_idx, &q_idx);
 
-    ffi::where_cond(&bool_mask, &zeros, &neg_inf)
+    // Sliding-window lower bound: k >= q + offset - window + 1.
+    if let Some(w) = window {
+        let q_low = ffi::reshape(
+            &ffi::arange_i32(offset - w + 1, offset - w + 1 + size, 1),
+            &[size, 1],
+        );
+        allowed = ffi::logical_and(&allowed, &ffi::greater_equal(&k_idx, &q_low));
+    }
+
+    let zero = crate::from_slice_f32(&[0.0], &[1, 1]);
+    let neg_inf = crate::from_slice_f32(&[f32::NEG_INFINITY], &[1, 1]);
+    ffi::where_cond(&allowed, &zero, &neg_inf)
 }
 
 /// Create a causal attention mask with per-sequence left-padding support.
@@ -603,27 +629,7 @@ pub fn create_causal_mask_with_window_full(
     offset: i32,
     window: Option<i32>,
 ) -> UniquePtr<MlxArray> {
-    let total_len = size + offset;
-
-    // Causal lower-triangular core: query row q attends to key columns
-    // `k <= q + offset`.
-    let ones = ffi::ones(&[size, total_len], dtype::FLOAT32);
-    let mut mask = ffi::tril(&ones, offset);
-
-    // Sliding-window lower bound: forbid keys older than `window` positions,
-    // i.e. require `k >= q + offset - window + 1`.
-    if let Some(w) = window {
-        let upper_mask = ffi::triu(&ones, offset - w + 1);
-        mask = ffi::multiply(&mask, &upper_mask);
-    }
-
-    // Convert to additive form (0 = attend, -inf = block) via where_cond to
-    // avoid NaN from `0 * -inf`. Intentional FP32 sentinel mask.
-    let zeros = ffi::zeros(&[size, total_len], dtype::FLOAT32);
-    let neg_inf = ffi::full_f32(&[size, total_len], f32::NEG_INFINITY, dtype::FLOAT32);
-    let bool_mask = ffi::greater(&mask, &zeros);
-
-    ffi::where_cond(&bool_mask, &zeros, &neg_inf)
+    additive_causal_window_mask(size, offset, window)
 }
 
 /// Build the sliding-window attention mask for a multi-token prefill

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -2793,6 +2793,26 @@ impl Gemma4TextModel {
                 lp,
             );
             (Some(global_mask), Some(sliding_mask))
+        } else if l > DENSE_PREFILL_MASK_MAX_TOKENS
+            && bidirectional_block_ids.is_none()
+            && per_row_valid_end.is_none()
+        {
+            // Long text-only prefill: leave both masks `None` so `attend`
+            // routes through `causal_attention`'s flag paths instead of
+            // shipping dense `[l, l + offset]` f32 masks through every layer.
+            // At 32k tokens the two retained masks alone are ~8 GiB and their
+            // construction transients more, on top of the O(heads*L^2) score
+            // materialization they used to feed (issue #672). Semantics are
+            // unchanged: full-attention layers (`window_size == 0`) take the
+            // bottom-right-aligned causal path (row `q` attends `k <= q +
+            // offset`, exactly `create_causal_mask(l, live_len)`), and
+            // sliding layers take the over-window prefill path, which builds
+            // the same `create_causal_mask_with_window_full(l, offset,
+            // window)` mask per layer as a transient instead of retaining it
+            // for the whole forward. Short prefills and every verify /
+            // padding / vision-overlay shape keep the dense masks below,
+            // byte-identical to the previous behavior.
+            (None, None)
         } else if l > 1 {
             // Non-ragged prefill / multi-token verify: derive both masks from
             // the cache's live window (`live_len`), not the monotonic
@@ -3348,6 +3368,14 @@ pub(crate) fn slice_layer_input(
 /// implement.
 const SUPPORTED_QUANT_SCHEMES: &[&str] = &["affine", "mxfp4", "nvfp4", "mxfp8"];
 
+/// Longest text-only prefill that still builds the dense `[l, l + offset]`
+/// f32 prefill masks. Above this, the mask pair is left `None` and `attend`
+/// routes through `causal_attention`'s causal / sliding-window flag paths,
+/// avoiding the O(L^2) retained masks entirely (issue #672). 4096 keeps every
+/// dense mask under ~64 MiB and, like the LM-head gate in
+/// `forward_last_logits`, leaves short-context behavior byte-identical.
+const DENSE_PREFILL_MASK_MAX_TOKENS: i32 = 4096;
+
 /// Validate that a model's declared quantization scheme is one mlxcel supports,
 /// before any weights are loaded (issue #467).
 ///
@@ -3481,6 +3509,40 @@ impl Gemma4Model {
             self.text_model
                 .forward(input_ids, input_embeddings, caches, mask, per_layer_inputs);
         let mut logits = self.text_model.embed_tokens.as_linear(&hidden);
+        if let Some(cap) = self.config.final_logit_softcapping {
+            logits = mlxcel_core::compiled_softcap(&logits, cap);
+        }
+        logits
+    }
+
+    /// [`Self::forward_with_caches_and_embeddings`] variant that projects only
+    /// the `last_pos` hidden row through the LM head, for prefill callers that
+    /// sample a single position.
+    ///
+    /// With `vocab_size = 262144`, full-sequence logits at a 32k-token prefill
+    /// are ~17 GiB in f16 and `final_logit_softcapping` materializes a second
+    /// copy; slicing the hidden state first bounds both to `[batch, 1, vocab]`
+    /// (issue #672). The KV caches are updated by the full text forward
+    /// exactly as before; only the LM-head projection width changes.
+    fn forward_last_with_caches_and_embeddings(
+        &self,
+        input_ids: &MlxArray,
+        input_embeddings: Option<&MlxArray>,
+        caches: &mut [Cache],
+        mask: Option<&MlxArray>,
+        per_layer_inputs: Option<&MlxArray>,
+        last_pos: usize,
+    ) -> UniquePtr<MlxArray> {
+        let hidden =
+            self.text_model
+                .forward(input_ids, input_embeddings, caches, mask, per_layer_inputs);
+        let shape = mlxcel_core::array_shape(&hidden);
+        let last = mlxcel_core::slice(
+            &hidden,
+            &[0, last_pos as i32, 0],
+            &[shape[0], last_pos as i32 + 1, shape[2]],
+        );
+        let mut logits = self.text_model.embed_tokens.as_linear(&last);
         if let Some(cap) = self.config.final_logit_softcapping {
             logits = mlxcel_core::compiled_softcap(&logits, cap);
         }
@@ -4790,6 +4852,50 @@ impl LanguageModel for Gemma4Wrapper {
                     sequence_caches,
                     mask,
                     None,
+                )
+            },
+        )
+    }
+
+    /// Long-prefill override: project only the last real position through the
+    /// 262k-vocab LM head instead of materializing `[1, seq_len, vocab]`
+    /// logits plus a `final_logit_softcapping` copy (issue #672).
+    ///
+    /// Short prefills keep the full-logits path: the LM head then runs the
+    /// same batched kernel as before this override existed, so short-context
+    /// greedy output stays byte-identical. The threshold only trades memory
+    /// (full logits are ~0.5 GiB per 1k tokens) against that guarantee; at
+    /// long lengths the single-row projection is mathematically the same
+    /// `hidden[last] @ W` row, merely computed by the single-row kernel.
+    fn forward_last_logits(
+        &self,
+        input_ids: &MlxArray,
+        _caches: &mut [KVCache],
+        mask: Option<&MlxArray>,
+        last_pos: usize,
+    ) -> UniquePtr<MlxArray> {
+        const FULL_LOGITS_MAX_PREFILL: i32 = 4096;
+        let seq_len = mlxcel_core::array_shape(input_ids)[1];
+        if seq_len <= FULL_LOGITS_MAX_PREFILL {
+            let logits = self.forward(input_ids, _caches, mask);
+            let shape = mlxcel_core::array_shape(&logits);
+            return mlxcel_core::slice(
+                &logits,
+                &[0, last_pos as i32, 0],
+                &[shape[0], last_pos as i32 + 1, shape[2]],
+            );
+        }
+        self.sequence_state.with_or_create_sequence_state(
+            None,
+            || self.model.make_caches(),
+            |sequence_caches| {
+                self.model.forward_last_with_caches_and_embeddings(
+                    input_ids,
+                    None,
+                    sequence_caches,
+                    mask,
+                    None,
+                    last_pos,
                 )
             },
         )


### PR DESCRIPTION
## Summary

On CUDA, gemma-4/gemma-3 (head_dim 256) disqualify both fused SDPA kernels (cuDNN caps head_dim at 128; sdpa_vector covers 64/96/128 with q_len < 4), so a long single-pass prefill fell to MLX's materializing fallback: O(heads*L^2) attention scores (~68 GiB at 32k for the 31b), full-sequence 262k-vocab logits plus a same-size final_logit_softcapping copy, and two dense [L, L] f32 masks together pushed GB10 past its ~121 GB budget and OOMed. A cuDNN head_dim cap bump alone was tested and is insufficient; the fix has to stop materializing.

## Changes

- **Query-chunked SDPA gate** (`layers::attention`): when a CUDA config cannot reach a fused SDPA (head_dim > 128, softcap composite, or non-f16/bf16 dtype) and the score matrix would exceed `MLXCEL_ATTENTION_CHUNK_BUDGET_MB` (default 1024, 0 disables), the query axis is split into near-equal chunks. Masks are row-sliced per chunk and cast to the score dtype, because MLX's fallback adds the mask without casting and an f32 mask silently promotes the masked scores and softmax to f32. The maskless causal path in `causal_attention` routes through the same chunking with per-chunk causal masks and K/V sliced to the causal bound.
- **Last-position LM head** (`LanguageModel::forward_last_logits`): the single-sequence prefill in `generate_streaming`/`generate_with_stats` now requests only the sampled position's logits. The default implementation is the previous forward-plus-slice; the gemma4 override projects a single hidden row through the 262k-vocab LM head for prefills longer than 4096 tokens, dropping ~17 GiB of logits plus an equal softcap copy at 32k.
- **Flag-path prefill masks for gemma4**: text-only prefills longer than 4096 tokens leave the mask pair `None`, routing full-attention layers through the causal flag path and sliding layers through the over-window prefill path instead of retaining two dense [l, l+offset] f32 masks (~8 GiB at 32k) across the whole forward. Verify, padding, per-row valid-end, and vision-overlay shapes keep the dense masks byte-identically.
- **Lean mask builders**: `create_causal_mask` / `create_causal_mask_with_window_full` build from broadcast index comparisons instead of the six-buffer ones/tril/triu/multiply/greater/where chain, cutting mask-construction transients from ~24 GiB to ~7 GiB at 32k.
- **Opt-in cache-level chunked prefill** (`MLXCEL_PREFILL_CHUNK`, default 0 = single-pass): feeds the prompt through `forward_last_logits` in chunks, evaluating and releasing pool memory per chunk so rotating sliding-window caches trim between chunks and the cudaMallocAsync pool cannot accumulate per-shape high-water marks (measured 84 GB system peak for a ~30 GB live set without the release). Mirrors the server's `prefill_chunk_size` and upstream mlx-lm/mlx-vlm defaults; flipping the CLI default is #674.
- `mlxcel-bench-decode` prints the MLX allocator peak after each run; benchmarks CSVs for the post-#652 sweep and this validation are included.

## Validation (GB10 CUDA, benchmarks/cuda_gb10_gemma_longprompt_672_2026-07-06.csv)

| configuration | before | after |
|---|---|---|
| gemma-4-12b-it-4bit @32768, single-pass | OOM class (scores alone ~34 GiB) | completes, 56.8 GB MLX peak |
| gemma-4-12b-it-4bit @32768, `MLXCEL_PREFILL_CHUNK=2048` | n/a | 16.6 GB MLX peak / 23 GB system, prefill 706 tok/s |
| gemma-4-31b-it-4bit @16384, single-pass | ~74 GB system peak | 54.3 GB MLX peak / 80 GB system |
| gemma-4-31b-it-4bit @32768, `MLXCEL_PREFILL_CHUNK=2048` | OOM at ~101 GB (issue repro) | 29.9 GB MLX peak / 38 GB system |

Greedy output: forced-chunk A/B on gemma-4-31b is token-identical to the unchunked path on a natural prompt; short-context behavior is byte-identical by construction (the gates never fire below the budget/threshold). Decode is unchanged (13.99 vs 14.03 tok/s at 8192 over 64 tokens). 13 new unit tests cover chunked-vs-unchunked equivalence (mask, softcap GQA, broadcast mask, causal offset), chunk-length math, mask row slicing, `forward_last_logits`, and chunked-prefill exactly-once feeding; `cargo clippy -D warnings` clean on default and cuda features; the mlxcel-core suite passes with only the pre-existing environment-bound failures (verified identical on a clean tree).

## Scope beyond gemma

The chunk gate automatically covers every flash-ineligible CUDA config that routes through `layers::attention`/`causal_attention`: qwen3.5/3.6 (head_dim 256), baichuan-m1 (256), paligemma2 (288 + softcap), and the MLA families (deepseek-v2/v3 qk 192, glm-5 256, deepseek-v4 512). Decode throughput for these families remains fallback-bound and is tracked as #675; defaulting the CLI to chunked prefill is #674.

Closes #672