### PR TITLE
tools: requantization script and perplexity harness

### DIFF
--- a/examples/perplexity.rs
+++ b/examples/perplexity.rs
@@ -1,0 +1,97 @@
+// Teacher-forced perplexity harness for quantization quality gates.
+//
+// Motivated by issue #683: requantizing gemma-4-12b's 8-bit MLP modules to
+// 4-bit measured 1.6x decode throughput, but the shipped checkpoint keeps
+// the MLP at 8-bit presumably for quality headroom, so variants need a
+// quality gate beyond greedy smoke prompts. This harness computes exact
+// next-token negative log-likelihood over a fixed text file, chunk by
+// chunk with fresh KV caches, so different quantization variants of the
+// same model are directly comparable (lower perplexity is better; the
+// ABSOLUTE value depends on the corpus and is not comparable across
+// tokenizers).
+//
+// Usage: cargo run --release --features cuda --example perplexity -- \
+//          MODEL_DIR TEXT_FILE [CHUNK_TOKENS=512] [MAX_CHUNKS=32]
+
+use anyhow::{Context, Result};
+use mlxcel::LanguageModel;
+use mlxcel::tokenizer::load_tokenizer;
+use mlxcel_core::{astype, eval, from_slice_i32, item_f32, log_softmax, sum_all, take_along_axis};
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let model_dir = args
+        .get(1)
+        .context("usage: perplexity MODEL_DIR TEXT_FILE")?;
+    let text_file = args
+        .get(2)
+        .context("usage: perplexity MODEL_DIR TEXT_FILE")?;
+    let chunk_tokens: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(512);
+    let max_chunks: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(32);
+
+    let text = std::fs::read_to_string(text_file).context("failed to read text file")?;
+
+    let model_path = std::path::Path::new(model_dir);
+    let (model, loaded_tokenizer) =
+        mlxcel::load_model(model_path).context("failed to load model")?;
+    let tokenizer = load_tokenizer(model_path).unwrap_or(loaded_tokenizer);
+
+    // Encode once WITH special tokens so the first chunk starts from BOS,
+    // then split into fixed-size windows. Every chunk after the first is
+    // scored as a fresh sequence (fresh caches), which slightly pessimizes
+    // absolute perplexity equally for every variant under comparison.
+    let ids: Vec<i32> = tokenizer
+        .encode(&text, true)
+        .context("tokenize failed")?
+        .into_iter()
+        .map(|t| t as i32)
+        .collect();
+    let n_chunks = ((ids.len() - 1) / chunk_tokens).min(max_chunks);
+    anyhow::ensure!(n_chunks > 0, "text too short: {} tokens", ids.len());
+    println!(
+        "model={model_dir} corpus={} tokens, scoring {n_chunks} chunks x {chunk_tokens}",
+        ids.len()
+    );
+
+    let mut total_nll = 0.0f64;
+    let mut total_tok = 0usize;
+
+    for c in 0..n_chunks {
+        let seg = &ids[c * chunk_tokens..(c + 1) * chunk_tokens + 1];
+        let l = seg.len() as i32; // chunk_tokens + 1
+
+        let input = from_slice_i32(&seg[..(l as usize - 1)], &[1, l - 1]);
+        let mut caches = model.make_caches();
+        let logits = model.forward(&input, &mut caches, None); // [1, L-1, V]
+        let logits = astype(&logits, mlxcel_core::dtype::FLOAT32);
+        let lp = log_softmax(&logits, -1);
+
+        let targets = from_slice_i32(&seg[1..], &[1, l - 1, 1]);
+        let tok_lp = take_along_axis(&lp, &targets, -1); // [1, L-1, 1]
+        let nll = sum_all(&tok_lp);
+        eval(&nll);
+        let chunk_nll = -f64::from(item_f32(&nll));
+        total_nll += chunk_nll;
+        total_tok += l as usize - 1;
+
+        // Free the chunk's transients before the next fresh-cache pass.
+        drop(caches);
+        mlxcel_core::clear_memory_cache();
+
+        println!(
+            "  chunk {:>3}: nll/tok {:.4}  (running ppl {:.3})",
+            c,
+            chunk_nll / (l as f64 - 1.0),
+            (total_nll / total_tok as f64).exp()
+        );
+    }
+
+    println!();
+    println!(
+        "tokens={} mean_nll={:.5} perplexity={:.4}",
+        total_tok,
+        total_nll / total_tok as f64,
+        (total_nll / total_tok as f64).exp()
+    );
+    Ok(())
+}

--- a/scripts/requantize_mlp.py
+++ b/scripts/requantize_mlp.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# Requantize a checkpoint's 8-bit affine module overrides down to 4-bit,
+# producing quantization variants for quality/throughput frontier studies
+# (issue #683). Validated against gemma-4-12b-it-4bit, whose 144 8-bit MLP
+# modules (gate/up/down x 48 layers) account for ~9 GB of the ~10.3 GB
+# streamed per decode token on GB10 and cap decode at ~14 tok/s; the uniform
+# 4-bit variant measured 1.59 to 1.62x decode with 3.6 GB lower peak.
+#
+# Pure numpy on raw safetensors (8-byte LE header length + JSON header +
+# buffer); bf16 handled as uint16 with manual f32 conversion. MLX affine
+# layout: quantized weights are u32-packed LOW-FIRST (8-bit: 4 values/u32 ==
+# LE byte order; 4-bit: 8 nibbles/u32, nibble k at bits [4k, 4k+4)); dequant
+# is q * scale + bias per group along the input axis. The new 4-bit q is
+# computed against the bf16-ROUNDED scale/bias so the stored triple is
+# self-consistent regardless of how MLX's own quantizer would have chosen
+# them.
+#
+# Usage:
+#   python3 scripts/requantize_mlp.py --src MODEL_DIR --dst OUT_DIR \
+#       [--target-group-size 64] [--match REGEX]
+#
+# --match limits requantization to module names matching REGEX (e.g.
+# 'mlp\.(gate|up)_proj$' keeps down_proj at 8-bit). Modules whose resulting
+# (bits, group_size) equal the config's global values lose their override;
+# others get an explicit override entry.
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+
+TARGET_BITS = 4
+
+
+def bf16_to_f32(u16: np.ndarray) -> np.ndarray:
+    return (u16.astype(np.uint32) << 16).view(np.float32)
+
+
+def f32_to_bf16(f: np.ndarray) -> np.ndarray:
+    u = f.astype(np.float32).view(np.uint32)
+    rounded = u + 0x7FFF + ((u >> 16) & 1)  # round-to-nearest-even
+    return (rounded >> 16).astype(np.uint16)
+
+
+def read_safetensors(path: Path):
+    with open(path, "rb") as f:
+        n = int.from_bytes(f.read(8), "little")
+        header = json.loads(f.read(n))
+        buf = np.fromfile(f, dtype=np.uint8)
+    meta = header.pop("__metadata__", None)
+    return header, buf, meta
+
+
+def write_safetensors(path: Path, tensors: dict, meta):
+    header = {}
+    if meta is not None:
+        header["__metadata__"] = meta
+    offset = 0
+    for name, (dt, shape, raw) in tensors.items():
+        header[name] = {
+            "dtype": dt,
+            "shape": shape,
+            "data_offsets": [offset, offset + len(raw)],
+        }
+        offset += len(raw)
+    hj = json.dumps(header, separators=(",", ":")).encode()
+    hj += b" " * ((8 - len(hj) % 8) % 8)  # align data start
+    with open(path, "wb") as f:
+        f.write(len(hj).to_bytes(8, "little"))
+        f.write(hj)
+        for _, (_, _, raw) in tensors.items():
+            f.write(raw)
+    return offset
+
+
+def requant_module(w_u32, w_shape, sc_u16, sc_shape, bi_u16, src_gs, tgt_gs):
+    out, packed = w_shape
+    inp = packed * 4  # source is 8-bit: 4 values per u32
+    g_src = inp // src_gs
+    assert sc_shape == [out, g_src], (sc_shape, [out, g_src])
+
+    q8 = w_u32.view(np.uint8).reshape(out, g_src, src_gs).astype(np.float32)
+    sc = bf16_to_f32(sc_u16).reshape(out, g_src, 1)
+    bi = bf16_to_f32(bi_u16).reshape(out, g_src, 1)
+    w = (q8 * sc + bi).reshape(out, inp)
+
+    g_tgt = inp // tgt_gs
+    w = w.reshape(out, g_tgt, tgt_gs)
+    mn = w.min(axis=2)
+    mx = w.max(axis=2)
+    scale = ((mx - mn) / 15.0).astype(np.float32)
+    scale = np.where(scale <= 0, np.float32(1.0), scale)
+    sc4_u16 = f32_to_bf16(scale)
+    bi4_u16 = f32_to_bf16(mn)
+    sc4 = bf16_to_f32(sc4_u16).reshape(out, g_tgt, 1)
+    sc4 = np.where(sc4 == 0, np.float32(1e-6), sc4)
+    bi4 = bf16_to_f32(bi4_u16).reshape(out, g_tgt, 1)
+    q4 = np.clip(np.rint((w - bi4) / sc4), 0, 15).astype(np.uint32)
+
+    err = float(np.abs((q4 * sc4 + bi4) - w).max())
+
+    q4 = q4.reshape(out, inp // 8, 8)
+    packed4 = np.zeros((out, inp // 8), dtype=np.uint32)
+    for k in range(8):
+        packed4 |= q4[:, :, k] << np.uint32(4 * k)
+
+    return packed4, [out, inp // 8], sc4_u16, bi4_u16, [out, g_tgt], err
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--src", required=True, type=Path)
+    ap.add_argument("--dst", required=True, type=Path)
+    ap.add_argument("--target-group-size", type=int, default=64, choices=(32, 64))
+    ap.add_argument("--match", default=None, help="regex limiting which 8-bit modules are requantized")
+    args = ap.parse_args()
+
+    cfg = json.loads((args.src / "config.json").read_text())
+    q = cfg["quantization"]
+    global_bits = q.get("bits")
+    global_gs = q.get("group_size")
+    pat = re.compile(args.match) if args.match else None
+    targets = {
+        k: v
+        for k, v in q.items()
+        if isinstance(v, dict) and v.get("bits") == 8 and (pat is None or pat.search(k))
+    }
+    if not targets:
+        print("no matching 8-bit module overrides found; nothing to do")
+        return 1
+    src_gs = {v.get("group_size", global_gs) for v in targets.values()}
+    assert src_gs == {64}, f"only group_size-64 8-bit sources are supported, got {src_gs}"
+    tgs = args.target_group_size
+    print(f"{len(targets)} modules -> {TARGET_BITS}-bit group_size {tgs}")
+
+    idx = json.loads((args.src / "model.safetensors.index.json").read_text())
+    shards = sorted(set(idx["weight_map"].values()))
+
+    args.dst.mkdir(exist_ok=True)
+    new_total = 0
+    max_err = 0.0
+    n_done = 0
+
+    for shard in shards:
+        header, buf, meta = read_safetensors(args.src / shard)
+        out_tensors = {}
+        for name in header:
+            info = header[name]
+            s, e = info["data_offsets"]
+            raw = buf[s:e]
+            prefix, _, suffix = name.rpartition(".")
+            if prefix in targets and suffix in ("weight", "scales", "biases"):
+                out_tensors[name] = ("PENDING", prefix, suffix, info, raw)
+            else:
+                out_tensors[name] = (info["dtype"], info["shape"], raw.tobytes())
+
+        prefixes = sorted({v[1] for v in out_tensors.values() if v[0] == "PENDING"})
+        for p in prefixes:
+            wn, sn, bn = f"{p}.weight", f"{p}.scales", f"{p}.biases"
+            if any(n not in out_tensors or out_tensors[n][0] != "PENDING" for n in (wn, sn, bn)):
+                raise RuntimeError(f"module {p} triple not co-located in {shard}")
+            wi, si = out_tensors[wn][3], out_tensors[sn][3]
+            assert wi["dtype"] == "U32" and si["dtype"] == "BF16", (wi, si)
+            w_u32 = np.frombuffer(out_tensors[wn][4].tobytes(), dtype=np.uint32).reshape(wi["shape"])
+            sc_u16 = np.frombuffer(out_tensors[sn][4].tobytes(), dtype=np.uint16)
+            b_u16 = np.frombuffer(out_tensors[bn][4].tobytes(), dtype=np.uint16)
+            pw, pw_shape, s4, b4, sb_shape, err = requant_module(
+                w_u32, wi["shape"], sc_u16, si["shape"], b_u16, 64, tgs
+            )
+            out_tensors[wn] = ("U32", pw_shape, pw.tobytes())
+            out_tensors[sn] = ("BF16", sb_shape, s4.tobytes())
+            out_tensors[bn] = ("BF16", sb_shape, b4.tobytes())
+            max_err = max(max_err, err)
+            n_done += 1
+
+        new_total += write_safetensors(args.dst / shard, out_tensors, meta)
+        print(f"wrote {shard} ({n_done}/{len(targets)} modules done)")
+
+    idx["metadata"]["total_size"] = new_total
+    (args.dst / "model.safetensors.index.json").write_text(json.dumps(idx, indent=2))
+
+    for key in ("quantization", "quantization_config"):
+        if key in cfg and isinstance(cfg[key], dict):
+            for t in targets:
+                if t not in cfg[key]:
+                    continue
+                if TARGET_BITS == cfg[key].get("bits", global_bits) and tgs == cfg[key].get(
+                    "group_size", global_gs
+                ):
+                    del cfg[key][t]
+                else:
+                    cfg[key][t] = {"bits": TARGET_BITS, "group_size": tgs}
+    (args.dst / "config.json").write_text(json.dumps(cfg, indent=2))
+
+    for f in args.src.iterdir():
+        if f.name.startswith("model-") or f.name in (
+            "model.safetensors.index.json",
+            "config.json",
+        ):
+            continue
+        if f.is_file():
+            shutil.copy2(f, args.dst / f.name)
+
+    print(
+        f"done: {n_done} modules, max group reconstruction err {max_err:.5f}, "
+        f"total {new_total / 1e9:.2f} GB"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Lands the two tools behind issue #683 steps 2 and 3 (refs #683, does not close it).

`scripts/requantize_mlp.py`: rewrites a checkpoint's 8-bit affine module overrides down to 4-bit with pure-numpy raw safetensors I/O (bf16 as uint16, u32 low-first packing, q computed against bf16-rounded scales/biases so the stored triples are self-consistent). Supports `--target-group-size 32` and a `--match` regex to requantize only selected modules (e.g. keep down_proj at 8-bit), updating config quantization overrides accordingly. The uniform 4-bit gemma-4-12b variant it produced measured 1.59 to 1.62x decode with 3.6 GB lower peak on GB10 (numbers on the issue).

`examples/perplexity.rs`: exact teacher-forced next-token NLL over a fixed text file, chunked with fresh KV caches, for comparing quantization variants of the same model (the quality gate the greedy smoke prompts cannot provide).

Tool-only change: no library or runtime code is touched.

Refs #683