### PR TITLE
fix(gemma4): render thinking-off closed channel to fix chat pad-collapse (#686)

### DIFF
--- a/benchmarks/cuda_gb10_gemma4_quality_686_2026-07-07.csv
+++ b/benchmarks/cuda_gb10_gemma4_quality_686_2026-07-07.csv
@@ -1,0 +1,22 @@
+model,scored_len,mean_nll,perplexity,variant,date,hardware,notes
+gemma-4-12b-it-4bit,128,3.45017,31.5058,mlxcel-default,2026-07-07,NVIDIA_GB10_122GB,single BOS-anchored fresh forward (chunks=1)
+gemma-4-12b-it-4bit,256,5.71208,302.4982,mlxcel-default,2026-07-07,NVIDIA_GB10_122GB,rises unbounded with position
+gemma-4-12b-it-4bit,512,8.40316,4461.1336,mlxcel-default,2026-07-07,NVIDIA_GB10_122GB,rises unbounded with position
+gemma-4-12b-it-4bit,1024,10.30782,29966.1347,mlxcel-default,2026-07-07,NVIDIA_GB10_122GB,approaching random ln(262144)=12.48
+gemma-4-12b-it-4bit,128,3.4338,30.994,mlx-lm-reference,2026-07-07,NVIDIA_GB10_122GB,independent mlx_lm.models.gemma4_text on GPU
+gemma-4-12b-it-4bit,256,5.6772,292.137,mlx-lm-reference,2026-07-07,NVIDIA_GB10_122GB,matches mlxcel within 0.05 nll
+gemma-4-12b-it-4bit,512,8.3551,4251.764,mlx-lm-reference,2026-07-07,NVIDIA_GB10_122GB,reference reproduces the same rising curve
+gemma-4-12b-it-4bit-uniform,128,3.74223,42.1919,mlxcel-uniform4bit,2026-07-07,NVIDIA_GB10_122GB,uniform 4-bit requant; same curve so quant scheme not the cause
+gemma-4-12b-it-4bit-uniform,512,8.21545,3697.6267,mlxcel-uniform4bit,2026-07-07,NVIDIA_GB10_122GB,uniform 4-bit requant; same curve
+gemma-4-12b-it-4bit,128,3.80883,45.0978,mlxcel-rope-div-rotated,2026-07-07,NVIDIA_GB10_122GB,probe: normalize rope exponent by rotated_dims; WORSE
+gemma-4-12b-it-4bit,256,6.85054,944.3949,mlxcel-rope-div-rotated,2026-07-07,NVIDIA_GB10_122GB,probe worse than default; proportional rope not the bug
+gemma-4-12b-it-4bit,512,9.34612,11454.3477,mlxcel-rope-div-rotated,2026-07-07,NVIDIA_GB10_122GB,probe worse; default div-head_dim confirmed correct
+gemma-4-12b-it-4bit,1024,10.79288,48672.9690,mlxcel-rope-div-rotated,2026-07-07,NVIDIA_GB10_122GB,probe reverted after measurement
+gemma-3-4b-it-4bit,128,1.51702,4.5586,mlxcel-control,2026-07-07,NVIDIA_GB10_122GB,healthy control; standard rope; stays flat
+gemma-3-4b-it-4bit,256,2.83064,16.9564,mlxcel-control,2026-07-07,NVIDIA_GB10_122GB,healthy control
+gemma-3-4b-it-4bit,512,3.52633,33.9991,mlxcel-control,2026-07-07,NVIDIA_GB10_122GB,healthy control; flat vs length
+gemma-3-4b-it-4bit,1024,3.62854,37.6578,mlxcel-control,2026-07-07,NVIDIA_GB10_122GB,healthy control; flat vs length
+qwen3.5-9b-4bit,128,1.10063,3.0061,mlxcel-control,2026-07-07,NVIDIA_GB10_122GB,healthy control; stays flat
+qwen3.5-9b-4bit,256,2.04700,7.7446,mlxcel-control,2026-07-07,NVIDIA_GB10_122GB,healthy control
+qwen3.5-9b-4bit,512,2.69592,14.8192,mlxcel-control,2026-07-07,NVIDIA_GB10_122GB,healthy control; flat vs length
+qwen3.5-9b-4bit,1024,2.55189,12.8314,mlxcel-control,2026-07-07,NVIDIA_GB10_122GB,healthy control; flat vs length

--- a/examples/perplexity.rs
+++ b/examples/perplexity.rs
@@ -10,6 +10,17 @@
 // ABSOLUTE value depends on the corpus and is not comparable across
 // tokenizers).
 //
+// Scoring mode: each chunk is scored as an INDEPENDENT fresh sequence
+// (BOS anchor + fresh caches + reset model-owned state). This is not a
+// continuous-context corpus perplexity; a mid-corpus window carries no real
+// preceding context, so its absolute NLL is pessimistic. That penalty is
+// applied equally to every variant, so cross-variant comparison stays fair,
+// but the single cleanest signal is `MAX_CHUNKS=1`: it scores exactly one
+// BOS-anchored forward over the first `CHUNK_TOKENS` positions, which is the
+// reference-clean measurement used to characterize the gemma-4 long-position
+// forward behavior in issue #686. Sweep `CHUNK_TOKENS` in {128,256,512,1024}
+// at `MAX_CHUNKS=1` to read the NLL-vs-length curve directly.
+//
 // Usage: cargo run --release --features cuda --example perplexity -- \
 //          MODEL_DIR TEXT_FILE [CHUNK_TOKENS=512] [MAX_CHUNKS=32]
 
@@ -38,8 +49,8 @@ fn main() -> Result<()> {
 
     // Encode once WITH special tokens so the first chunk starts from BOS,
     // then split into fixed-size windows. Every chunk after the first is
-    // scored as a fresh sequence (fresh caches), which slightly pessimizes
-    // absolute perplexity equally for every variant under comparison.
+    // scored as a fresh sequence, which slightly pessimizes absolute
+    // perplexity equally for every variant under comparison.
     let ids: Vec<i32> = tokenizer
         .encode(&text, true)
         .context("tokenize failed")?
@@ -53,6 +64,19 @@ fn main() -> Result<()> {
         ids.len()
     );
 
+    // BOS anchor for chunks after the first (issue #686). Gemma-family
+    // quality collapses on BOS-less windows (measured on this harness's
+    // corpus: gemma-3-4b ~+3.6 nats/token, gemma-4-12b ~+6.6 nats/token),
+    // so mid-corpus chunks are scored behind the same single BOS the model
+    // saw in training. Tokenizers that add no BOS produce an empty probe
+    // and keep the historical raw-window behavior. The BOS position's own
+    // logit row is excluded from scoring, so per-chunk token counts are
+    // unchanged.
+    let bos_prefix: Vec<i32> = tokenizer
+        .encode("", true)
+        .map(|ids| ids.into_iter().take(1).map(|t| t as i32).collect())
+        .unwrap_or_default();
+
     let mut total_nll = 0.0f64;
     let mut total_tok = 0usize;
 
@@ -60,9 +84,41 @@ fn main() -> Result<()> {
         let seg = &ids[c * chunk_tokens..(c + 1) * chunk_tokens + 1];
         let l = seg.len() as i32; // chunk_tokens + 1
 
-        let input = from_slice_i32(&seg[..(l as usize - 1)], &[1, l - 1]);
+        let (input_ids, target_offset) = if c == 0 || bos_prefix.is_empty() {
+            (seg[..(l as usize - 1)].to_vec(), 0i32)
+        } else {
+            let mut with_bos = bos_prefix.clone();
+            with_bos.extend_from_slice(&seg[..(l as usize - 1)]);
+            (with_bos, bos_prefix.len() as i32)
+        };
+        let input_len = input_ids.len() as i32;
+        let input = from_slice_i32(&input_ids, &[1, input_len]);
+
+        // Fresh sequence per chunk: models that key their KV state on a
+        // model-owned fallback slot (gemma3/gemma4/llama4/qwen3.5, issue
+        // #686) ignore the external `caches` argument, so `make_caches()`
+        // alone silently CONTINUED the previous chunk's context and made
+        // every chunk after the first score with leaked history. Reset the
+        // internal slot explicitly; external-cache models are a no-op.
+        model.reset_runtime_state();
         let mut caches = model.make_caches();
-        let logits = model.forward(&input, &mut caches, None); // [1, L-1, V]
+        let logits = model.forward(&input, &mut caches, None); // [1, input_len, V]
+        let shape = mlxcel_core::array_shape(&logits);
+        if c == 0 {
+            println!("  logits shape {:?} (expect [1, {}, vocab])", shape, l - 1);
+        }
+        anyhow::ensure!(
+            shape.len() == 3 && shape[1] == input_len,
+            "model.forward returned {:?}, not per-position logits; cannot score",
+            shape
+        );
+        // Row j predicts input[j + 1]; targets seg[1..] live at rows
+        // [target_offset, target_offset + l - 1).
+        let logits = mlxcel_core::slice(
+            &logits,
+            &[0, target_offset, 0],
+            &[1, target_offset + l - 1, shape[2]],
+        );
         let logits = astype(&logits, mlxcel_core::dtype::FLOAT32);
         let lp = log_softmax(&logits, -1);
 
@@ -71,6 +127,15 @@ fn main() -> Result<()> {
         let nll = sum_all(&tok_lp);
         eval(&nll);
         let chunk_nll = -f64::from(item_f32(&nll));
+        // A non-finite chunk NLL (an all-masked softmax row, an overflow in a
+        // degenerate window, or GPU-pool exhaustion after many fresh-cache
+        // iterations) must abort loudly rather than silently poison the mean.
+        anyhow::ensure!(
+            chunk_nll.is_finite(),
+            "chunk {c} produced a non-finite NLL ({chunk_nll}); refusing to \
+             average it into the perplexity. Re-run with MAX_CHUNKS=1 for the \
+             reference-clean single-forward measurement.",
+        );
         total_nll += chunk_nll;
         total_tok += l as usize - 1;
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -683,8 +683,16 @@ fn load_cli_prompt(
         // `<think>\n\n</think>` block; models not trained with that block
         // (e.g. the Qwen3-Omni Instruct thinker) emit an immediate
         // end-of-text after it.
+        //
+        // Exception (issue #686): the Gemma-4 thinking-channel template's
+        // thinking-OFF branch already renders a well-formed CLOSED priming
+        // scaffold that makes the model answer directly, matching
+        // transformers' no-`enable_thinking` default. Forcing thinking on there
+        // instead yields a bare `<|turn>model\n` that greedy-collapses to
+        // `<pad>`, so keep its default at false.
         if let Some(p) = processor.as_mut()
             && tokenizer.infer_thinking_markers().has_thinking()
+            && !p.wants_thinking_default_off()
         {
             p.set_default_enable_thinking(true);
         }

--- a/src/lib/mlxcel-core/src/rope_proportional.rs
+++ b/src/lib/mlxcel-core/src/rope_proportional.rs
@@ -265,6 +265,77 @@ mod tests {
     use super::*;
     use crate::{allclose, array_to_raw_bytes, astype, dtype, eval, item_bool};
 
+    /// The compiled full-head fast path (`compiled_proportional_rope`, taken
+    /// when `last_dim == head_dim`) must be numerically identical to the
+    /// mlx-vlm / mlx-lm reference `ProportionalRoPE.__call__`, which packs the
+    /// first `rotated_dims/2` slots of each head half into a `[.., rotated_dims]`
+    /// tensor, applies `mx.fast.rope` with the finite freqs there, and stitches
+    /// the halves back. Pins that the inf-tail full-head shortcut equals the
+    /// packed reference algorithm for the exact Gemma-4 global-layer config
+    /// (`head_dim = 512`, `partial_rotary_factor = 0.25`, `theta = 1e6`) at
+    /// several positions, including well past the rotated slice's longest
+    /// wavelength. Issue #686: a regression here would corrupt the 8
+    /// full-attention layers' long-range phase and reproduce the position-
+    /// dependent quality collapse that teacher-forced perplexity exposed but
+    /// generation and self-consistency A/Bs never did.
+    #[test]
+    fn proportional_rope_full_head_matches_packed_reference() {
+        let head_dim = 512_i32;
+        let prf = 0.25_f32; // rope_angles = 64, rotated_dims = 128.
+        let base = 1_000_000.0_f32;
+        let rot_half = 64_i32; // rotated_dims / 2
+        let half = head_dim / 2; // 256
+
+        let freqs = compute_proportional_rope_freqs(head_dim, prf, base, 1.0)
+            .expect("freqs must exist for prf=0.25");
+        // The reference packs only the finite (rotated) frequencies.
+        let freqs_rot = slice(&freqs, &[0], &[rot_half]);
+        eval(&freqs);
+        eval(&freqs_rot);
+
+        // Deterministic non-trivial input [1, 2 heads, 3 positions, head_dim].
+        let heads = 2_i32;
+        let positions = 3_i32;
+        let total = (heads * positions * head_dim) as usize;
+        let data: Vec<f32> = (0..total)
+            .map(|i| ((i as f32) * 0.013).sin() + 0.25)
+            .collect();
+        let x = from_slice_f32(&data, &[1, heads, positions, head_dim]);
+
+        // Reference packed algorithm (mlx-vlm ProportionalRoPE, tail empty).
+        let reference = |offset: i32| -> UniquePtr<MlxArray> {
+            let left = slice(&x, &[0, 0, 0, 0], &[1, heads, positions, half]);
+            let right = slice(&x, &[0, 0, 0, half], &[1, heads, positions, head_dim]);
+            let left_first = slice(&left, &[0, 0, 0, 0], &[1, heads, positions, rot_half]);
+            let right_first = slice(&right, &[0, 0, 0, 0], &[1, heads, positions, rot_half]);
+            let packed = concatenate(&left_first, &right_first, 3);
+            let rotated =
+                fast_rope_with_freqs(&packed, 2 * rot_half, false, 1.0, offset, &freqs_rot);
+            let rot_a = slice(&rotated, &[0, 0, 0, 0], &[1, heads, positions, rot_half]);
+            let rot_b = slice(
+                &rotated,
+                &[0, 0, 0, rot_half],
+                &[1, heads, positions, 2 * rot_half],
+            );
+            let left_rest = slice(&left, &[0, 0, 0, rot_half], &[1, heads, positions, half]);
+            let right_rest = slice(&right, &[0, 0, 0, rot_half], &[1, heads, positions, half]);
+            let left_new = concatenate(&rot_a, &left_rest, 3);
+            let right_new = concatenate(&rot_b, &right_rest, 3);
+            concatenate(&left_new, &right_new, 3)
+        };
+
+        for offset in [0_i32, 5, 130, 500] {
+            let got = apply_proportional_rope(&x, head_dim, prf, offset, freqs.as_ref());
+            let expected = reference(offset);
+            let close = allclose(&got, &expected, 1e-5, 1e-5);
+            eval(&close);
+            assert!(
+                item_bool(&close),
+                "full-head proportional rope diverged from the packed reference at offset {offset}"
+            );
+        }
+    }
+
     #[test]
     fn proportional_rope_freqs_match_python_formula() {
         // Gemma 4 full-attention layer: head_dim=256, partial_rotary_factor=0.25,

--- a/src/server/chat_template.rs
+++ b/src/server/chat_template.rs
@@ -181,64 +181,43 @@ impl ChatTemplateProcessor {
         &self.template
     }
 
-    /// Detect a Gemma-4-style chat template whose `enable_thinking=true`
-    /// branch produces a generation prompt ending at `<|turn>model\n`
-    /// (no `<|channel>thought` priming).
+    /// Detect the Gemma-4 "thinking channel" chat template.
     ///
-    /// Without a priming marker, quantized Gemma 4 produces degenerate
-    /// first-token logits when the system turn also carries non-trivial
-    /// tool declarations ("own- own-", "fear- own-" style loops). The
-    /// companion [`Self::patch_gemma4_generation_prompt`] fixes this by
-    /// appending an OPEN `<|channel>thought\n` marker so the model reliably
-    /// enters its reasoning channel and can emit `<|tool_call>` blocks
-    /// afterwards.
+    /// Its `add_generation_prompt` block emits a CLOSED
+    /// `<|channel>thought\n<channel|>` scaffold when
+    /// `not enable_thinking | default(false)` and a bare `<|turn>model\n` when
+    /// thinking is enabled. `transformers`/jinja2 renders the CLOSED scaffold by
+    /// default (no `enable_thinking` kwarg), which primes the model to answer
+    /// directly; the bare ending is the reasoning-on prompt where the model
+    /// opens its own channel.
     ///
     /// The detection is intentionally conservative: it requires BOTH the
     /// `<|channel>thought` marker AND the `not enable_thinking` guard that
     /// define this branch, so Qwen3's `<think>` path and other non-Gemma
-    /// templates are unaffected.
-    fn enable_thinking_drops_priming(&self) -> bool {
+    /// templates never match.
+    fn is_gemma4_thinking_channel_template(&self) -> bool {
         self.template.contains("<|channel>thought") && self.template.contains("not enable_thinking")
     }
 
-    /// Append an open `<|channel>thought\n` priming to a Gemma-4-rendered
-    /// prompt when the template produced the un-primed `<|turn>model\n`
-    /// ending. Returns the input unchanged when the template is not
-    /// Gemma-4 style, `enable_thinking` is not `true`, or the rendered
-    /// prompt already ends with a priming marker.
-    fn patch_gemma4_generation_prompt(
-        &self,
-        rendered: String,
-        kwargs: &ChatTemplateKwargs,
-    ) -> String {
-        if !self.add_generation_prompt || !self.enable_thinking_drops_priming() {
-            return rendered;
-        }
-        let thinking_on = match kwargs
-            .get("enable_thinking")
-            .and_then(serde_json::Value::as_bool)
-        {
-            Some(v) => v,
-            None => self.default_enable_thinking,
-        };
-        if !thinking_on {
-            return rendered;
-        }
-        // Only patch the exact ending the un-primed branch produces. Any
-        // trailing whitespace, extra marker, or pre-existing priming means
-        // the prompt is already in a shape we don't want to touch.
-        const BAD_END: &str = "<|turn>model\n";
-        if !rendered.ends_with(BAD_END) {
-            return rendered;
-        }
-        tracing::debug!(
-            "Gemma 4: appending open <|channel>thought\\n priming for enable_thinking=true \
-             (raw template leaves the prompt at <|turn>model\\n, which destabilizes first \
-             token logits and suppresses tool-call emission)"
-        );
-        let mut out = rendered;
-        out.push_str("<|channel>thought\n");
-        out
+    /// Whether this template's own thinking-OFF branch is the correct
+    /// interactive default, so the tokenizer-derived `has_thinking` heuristic
+    /// (which flips `enable_thinking=true` to avoid Qwen3's empty
+    /// `<think></think>` block, mlx-lm PR #1114) must NOT apply.
+    ///
+    /// True for the Gemma-4 thinking-channel template (issue #686): its
+    /// thinking-OFF branch renders a well-formed CLOSED priming channel
+    /// (`<|turn>model\n<|channel>thought\n<channel|>`) that makes the model
+    /// answer directly, exactly matching `transformers`' no-`enable_thinking`
+    /// default. Forcing `enable_thinking=true` there instead renders a bare
+    /// `<|turn>model\n`, which drives quantized Gemma 4 into an open reasoning
+    /// channel that greedy-decodes to `<pad>` spam. The pre-#686 code both
+    /// forced that default AND appended an OPEN `<|channel>thought\n` marker,
+    /// so the interactive default never reached the closed scaffold.
+    ///
+    /// Used by: `commands::generate` and `server::startup` before flipping the
+    /// `enable_thinking` default for a thinking-marker tokenizer.
+    pub fn wants_thinking_default_off(&self) -> bool {
+        self.is_gemma4_thinking_channel_template()
     }
 
     /// Detect a chat template that gates its `<think>` block on a bare
@@ -455,11 +434,12 @@ impl ChatTemplateProcessor {
             self.wants_bare_thinking_alias(),
         );
 
-        let result = tmpl
-            .render(context)
-            .with_context(|| "Failed to render chat template")?;
-
-        Ok(self.patch_gemma4_generation_prompt(result, kwargs))
+        // Render directly: minijinja reproduces the template's own
+        // enable_thinking branches faithfully (issue #686), so no post-render
+        // Gemma-4 patching is applied. The `enable_thinking` value reaches the
+        // template through `build_template_context` above.
+        tmpl.render(context)
+            .with_context(|| "Failed to render chat template")
     }
 
     /// Apply the chat template to messages.
@@ -518,11 +498,12 @@ impl ChatTemplateProcessor {
             self.wants_bare_thinking_alias(),
         );
 
-        let result = tmpl
-            .render(context)
-            .with_context(|| "Failed to render chat template")?;
-
-        Ok(self.patch_gemma4_generation_prompt(result, kwargs))
+        // Render directly: minijinja reproduces the template's own
+        // enable_thinking branches faithfully (issue #686), so no post-render
+        // Gemma-4 patching is applied. The `enable_thinking` value reaches the
+        // template through `build_template_context` above.
+        tmpl.render(context)
+            .with_context(|| "Failed to render chat template")
     }
 }
 
@@ -2006,19 +1987,20 @@ TOOL
 
     // ----- Gemma 4 enable_thinking priming fix -----
     //
-    // These tests cover the regression where Gemma 4's chat template
-    // dropped the generation-prompt priming when `enable_thinking=true`,
-    // leaving the prompt at `<|turn>model\n` and destabilizing first-token
-    // logits. The fix appends an open `<|channel>thought\n` priming so the
-    // model reliably enters its reasoning channel.
+    // These tests cover issue #686: the Gemma 4 thinking-channel template must
+    // render EXACTLY what transformers/jinja2 renders for each `enable_thinking`
+    // value. The default (and `enable_thinking=false`) render a CLOSED
+    // `<|channel>thought\n<channel|>` scaffold (the model answers directly);
+    // `enable_thinking=true` renders a bare `<|turn>model\n`. The pre-#686 code
+    // forced the thinking default on for this family AND appended an OPEN
+    // `<|channel>thought\n` marker, which drove the model into an open reasoning
+    // channel that greedy-decoded to `<pad>` spam.
 
-    /// Minimal Gemma-4-shaped template that reproduces the pattern of
-    /// interest: opens a `<|turn>model\n` generation prompt and guards the
-    /// `<|channel>thought\n<channel|>` priming behind `not enable_thinking`.
-    /// Small enough to keep tests fast; keeps the exact marker strings the
-    /// detection helpers look for and mirrors the upstream template's use
-    /// of explicit `\n` literals inside whitespace-stripped blocks so the
-    /// rendered prompt really ends with `<|turn>model\n`.
+    /// Minimal Gemma-4-shaped template that reproduces the generation-prompt
+    /// block: opens `<|turn>model\n` and emits the CLOSED
+    /// `<|channel>thought\n<channel|>` scaffold behind `not enable_thinking`.
+    /// Mirrors the upstream template's explicit `\n` literals inside
+    /// whitespace-stripped blocks.
     const GEMMA4_LIKE_TEMPLATE: &str = "{{- bos_token -}}<|turn>user\n\
         {{- messages[0].content -}}<turn|>\n\
         {{- '<|turn>model\\n' -}}\
@@ -2027,101 +2009,110 @@ TOOL
         {%- endif -%}";
 
     #[test]
-    fn enable_thinking_drops_priming_detects_gemma4_shape() {
+    fn is_gemma4_thinking_channel_template_detects_gemma4_shape() {
         let gemma4 = ChatTemplateProcessor::with_template(GEMMA4_LIKE_TEMPLATE.to_string());
-        assert!(gemma4.enable_thinking_drops_priming());
+        assert!(gemma4.is_gemma4_thinking_channel_template());
+        assert!(gemma4.wants_thinking_default_off());
 
-        // Plain default (no channel marker) must NOT trigger — guards against
+        // Plain default (no channel marker) must NOT trigger, guarding against
         // false positives on non-Gemma templates such as Qwen3's <think> path.
         let plain = ChatTemplateProcessor::default();
-        assert!(!plain.enable_thinking_drops_priming());
+        assert!(!plain.is_gemma4_thinking_channel_template());
+        assert!(!plain.wants_thinking_default_off());
 
         // A template with `<|channel>` but no `not enable_thinking` guard
-        // (hypothetical unconditional priming) must also not trigger, since
-        // we only patch the specific un-primed branch.
+        // (hypothetical unconditional priming) must also not trigger.
         let unconditional = r#"<|turn>model
 <|channel>thought
 <channel|>"#;
         let p = ChatTemplateProcessor::with_template(unconditional.to_string());
-        assert!(!p.enable_thinking_drops_priming());
+        assert!(!p.is_gemma4_thinking_channel_template());
     }
 
     #[test]
-    fn patch_gemma4_generation_prompt_appends_open_thinking_when_primed() {
+    fn gemma4_default_renders_closed_thinking_channel() {
+        // Issue #686: the interactive default (no enable_thinking kwarg) must
+        // end with the CLOSED scaffold so the model answers directly. This is
+        // the exact ending transformers renders for `apply_chat_template` with
+        // no `enable_thinking`, and the pad-collapse repro when it is missing.
+        let gemma4 = ChatTemplateProcessor::with_template(GEMMA4_LIKE_TEMPLATE.to_string());
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "hi".to_string(),
+        }];
+        let out = gemma4.apply(&messages, None).unwrap();
+        assert!(
+            out.ends_with("<|turn>model\n<|channel>thought\n<channel|>"),
+            "default must end with the CLOSED thinking-channel scaffold; got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn gemma4_generation_prompt_matches_transformers_for_all_thinking_values() {
         let gemma4 = ChatTemplateProcessor::with_template(GEMMA4_LIKE_TEMPLATE.to_string());
         let messages = vec![ChatMessage {
             role: "user".to_string(),
             content: "hi".to_string(),
         }];
 
-        // enable_thinking=false (default branch): template already primes
-        // with `<|channel>thought\n<channel|>`, so the patch is a no-op.
+        // enable_thinking=false: CLOSED scaffold (direct answer).
         let closed = ChatTemplateKwargs::from_json_str(r#"{"enable_thinking": false}"#).unwrap();
         let rendered_closed = gemma4.apply_with_kwargs(&messages, None, &closed).unwrap();
         assert!(
-            rendered_closed.contains("<|channel>thought\n<channel|>"),
-            "default branch must still prime a closed thinking block"
-        );
-        assert!(
-            !rendered_closed.ends_with("<|turn>model\n"),
-            "closed priming must remain the final content"
+            rendered_closed.ends_with("<|turn>model\n<|channel>thought\n<channel|>"),
+            "enable_thinking=false must end with the CLOSED scaffold; got: {rendered_closed:?}"
         );
 
-        // enable_thinking=true: without the patch the prompt would end at
-        // `<|turn>model\n`. With the patch, an OPEN `<|channel>thought\n`
-        // marker is appended so the model enters the reasoning channel.
+        // enable_thinking=true: BARE `<|turn>model\n` so the model opens its
+        // own channel. No OPEN `<|channel>thought\n` is appended (matches
+        // transformers; the pre-#686 patch is removed).
         let open = ChatTemplateKwargs::from_json_str(r#"{"enable_thinking": true}"#).unwrap();
         let rendered_open = gemma4.apply_with_kwargs(&messages, None, &open).unwrap();
         assert!(
-            rendered_open.ends_with("<|channel>thought\n"),
-            "enable_thinking=true must append an open thinking priming, got: {rendered_open:?}"
+            rendered_open.ends_with("<|turn>model\n"),
+            "enable_thinking=true must end with the bare model turn; got: {rendered_open:?}"
         );
         assert!(
-            !rendered_open.contains("<channel|>"),
-            "the appended priming must be OPEN (no <channel|> close)"
+            !rendered_open.contains("<|channel>thought"),
+            "enable_thinking=true must NOT emit any thinking channel; got: {rendered_open:?}"
         );
     }
 
     #[test]
-    fn patch_gemma4_generation_prompt_uses_default_enable_thinking_when_kwarg_absent() {
-        // Regression guard for HIGH-1 (review): when the server startup
-        // hook sets `default_enable_thinking=true` for a Gemma 4 thinking model,
-        // a request that arrives with empty kwargs must still trigger the
-        // `<|channel>thought\n` priming. Before the fix, `kwargs.get("enable_thinking")`
-        // returned `None` which was treated as `false`, so the patch was skipped and
-        // the model saw an unprimed `<|turn>model\n` — causing degenerate first-token
-        // output / broken tool-call emission.
+    fn gemma4_default_enable_thinking_true_still_renders_bare_no_patch() {
+        // Even if a caller forces default_enable_thinking=true, the render must
+        // faithfully follow the template (bare `<|turn>model\n`) with NO
+        // post-render open-channel append. `wants_thinking_default_off` is the
+        // guard the generate/startup paths use so they never force this on for
+        // the Gemma-4 family in the first place.
         let mut gemma4 = ChatTemplateProcessor::with_template(GEMMA4_LIKE_TEMPLATE.to_string());
         gemma4.set_default_enable_thinking(true);
         let messages = vec![ChatMessage {
             role: "user".to_string(),
             content: "hi".to_string(),
         }];
-
-        // Empty kwargs — no "enable_thinking" key at all. The processor must
-        // fall back to `default_enable_thinking = true` and apply the patch.
         let out = gemma4
             .apply_with_kwargs(&messages, None, &ChatTemplateKwargs::new())
             .unwrap();
         assert!(
-            out.ends_with("<|channel>thought\n"),
-            "default_enable_thinking=true with empty kwargs must append open priming; got: {out:?}"
+            out.ends_with("<|turn>model\n"),
+            "forced default_enable_thinking=true must still render bare; got: {out:?}"
         );
         assert!(
-            !out.contains("<channel|>"),
-            "priming must be open (no <channel|> close); got: {out:?}"
+            !out.contains("<|channel>thought"),
+            "no post-render open-channel priming may be appended; got: {out:?}"
         );
     }
 
     #[test]
-    fn patch_gemma4_generation_prompt_is_noop_on_non_gemma_templates() {
-        // Qwen3-shaped template uses <think> / </think>, not <|channel>, so
-        // `enable_thinking=true` must flow through untouched even though the
-        // kwarg value matches — we don't want to accidentally inject Gemma 4
-        // markers into other model families.
+    fn non_gemma_thinking_templates_are_unaffected() {
+        // Qwen3-shaped template uses <think> / </think>, not <|channel>, so it
+        // must never be detected as the Gemma-4 family and `enable_thinking=true`
+        // flows through untouched.
         let qwen = r#"{% if enable_thinking %}<think>
 {% endif %}{{ messages[0].content }}"#;
         let processor = ChatTemplateProcessor::with_template(qwen.to_string());
+        assert!(!processor.wants_thinking_default_off());
         let messages = vec![ChatMessage {
             role: "user".to_string(),
             content: "hello".to_string(),

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -948,9 +948,13 @@ pub(crate) const MAX_TOOLS: usize = 128;
 /// * `<think>\n` — Qwen3 / Qwen3.5 / Exaone4 / Jamba and similar templates
 ///   that emit `<think>\n` at the end of the generation prompt to prime
 ///   reasoning. The close marker in generated text is `</think>`.
-/// * `<|channel>thought\n` — Gemma 4 when `enable_thinking=true`, courtesy
-///   of [`crate::server::chat_template::ChatTemplateProcessor::patch_gemma4_generation_prompt`].
-///   The close marker in generated text is `<channel|>`.
+/// * `<|channel>thought\n` is the Gemma 4 open reasoning channel. Its close
+///   marker in generated text is `<channel|>`. Since issue #686 the Gemma 4
+///   generation prompt is rendered faithfully to the template (no post-render
+///   priming patch): the interactive default ends with the CLOSED
+///   `<|channel>thought\n<channel|>` scaffold (not primed for open thinking),
+///   so this suffix only matches a prompt that genuinely leaves the channel
+///   open (e.g. a caller-crafted continuation).
 ///
 /// Ordered longest-first so the match is unambiguous.
 const OPEN_THINKING_SUFFIXES: &[&str] = &["<|channel>thought\n", "<think>\n"];
@@ -1154,8 +1158,9 @@ mod tests {
 
     #[test]
     fn prompt_primed_detection_matches_exact_suffix() {
-        // Prompts produced by `patch_gemma4_generation_prompt` end in
-        // exactly `<|channel>thought\n`. Only that exact suffix counts.
+        // A prompt that genuinely ends in exactly `<|channel>thought\n`
+        // (open channel) is primed for open thinking. Only that exact suffix
+        // counts.
         assert!(is_prompt_primed_open_thinking(
             "<|turn>model\n<|channel>thought\n"
         ));

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -1698,7 +1698,12 @@ pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     // (`--chat-template-kwargs`, `LLAMA_ARG_CHAT_TEMPLATE_KWARGS`)
     // continue to win on conflict via `merge_server_and_request`.
     let thinking_markers = tokenizer.infer_thinking_markers();
-    if thinking_markers.has_thinking() {
+    // Issue #686: the Gemma-4 thinking-channel template's thinking-OFF branch
+    // is the correct interactive default (a CLOSED `<|channel>thought\n<channel|>`
+    // priming scaffold matching transformers' no-`enable_thinking` render), so
+    // the `has_thinking` heuristic below must not flip it on; forcing thinking
+    // there produces a bare `<|turn>model\n` that greedy-collapses to `<pad>`.
+    if thinking_markers.has_thinking() && !chat_template.wants_thinking_default_off() {
         tracing::info!(
             think_start = ?thinking_markers.think_start,
             think_end = ?thinking_markers.think_end,

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -784,6 +784,105 @@ fn build_plamo_tokenizer(model_path: &Path) -> Result<tokenizers::Tokenizer> {
     })
 }
 
+/// Repair Gemma-family `tokenizer.json` exports that dropped the
+/// BOS-inserting post-processor (issue #686).
+///
+/// `tokenizer_class: "GemmaTokenizer"` semantics in transformers prepend
+/// `<bos>` on every encode with special tokens (`add_bos_token` defaults to
+/// true), and Gemma model quality collapses without it: measured on the #686
+/// docs corpus, dropping BOS costs gemma-3-4b ~3.6 nats/token and
+/// gemma-4-12b ~6.6 nats/token of teacher-forced NLL. Gemma 3 checkpoints
+/// ship a `TemplateProcessing` post-processor that inserts `<bos>`, but
+/// current Gemma 4 exports ship a passthrough post-processor, so every
+/// raw-text path (CLI `generate`, `/v1/completions`, teacher-forced scoring)
+/// silently ran BOS-less. Chat-template paths were unaffected because the
+/// Gemma 4 template emits `{{ bos_token }}` itself.
+///
+/// The repair installs the exact `TemplateProcessing` Gemma 3 ships
+/// (`<bos> $A` single, `<bos> $A <bos>:1 $B:1` pair) when ALL hold:
+/// - `tokenizer_config.json` declares a Gemma tokenizer class, or an
+///   explicit `"add_bos_token": true`;
+/// - `add_bos_token` is not explicitly `false`;
+/// - the configured `bos_token` resolves to a vocab id; and
+/// - an encode probe shows the loaded post-processor does NOT already
+///   insert that id (so correct exports such as Gemma 3 are untouched).
+fn ensure_bos_post_processor(tokenizer: &mut tokenizers::Tokenizer, model_path: &Path) {
+    let config_path = model_path.join("tokenizer_config.json");
+    let Ok(raw) = std::fs::read_to_string(&config_path) else {
+        return;
+    };
+    let Ok(config) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return;
+    };
+
+    let add_bos = config.get("add_bos_token").and_then(|v| v.as_bool());
+    if add_bos == Some(false) {
+        return;
+    }
+    let tokenizer_class = config
+        .get("tokenizer_class")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let is_gemma_class = matches!(tokenizer_class, "GemmaTokenizer" | "GemmaTokenizerFast");
+    if add_bos != Some(true) && !is_gemma_class {
+        return;
+    }
+
+    // bos_token is either a plain string or an AddedToken-style object.
+    let bos_token = match config.get("bos_token") {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Object(o)) => o
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        _ => String::new(),
+    };
+    if bos_token.is_empty() {
+        return;
+    }
+    let Some(bos_id) = tokenizer.token_to_id(&bos_token) else {
+        return;
+    };
+
+    // Probe: a correct export already inserts BOS on encode-with-specials.
+    if let Ok(probe) = tokenizer.encode("bos probe", true)
+        && probe.get_ids().first() == Some(&bos_id)
+    {
+        return;
+    }
+
+    let template = tokenizers::processors::template::TemplateProcessing::builder()
+        .try_single(format!("{bos_token} $A"))
+        .and_then(|builder| builder.try_pair(format!("{bos_token} $A {bos_token}:1 $B:1")))
+        .and_then(|builder| {
+            builder
+                .special_tokens(vec![(bos_token.clone(), bos_id)])
+                .build()
+                .map_err(|e| e.to_string())
+        });
+    match template {
+        Ok(template) => {
+            tokenizer.with_post_processor(Some(template));
+            tracing::info!(
+                model_path = %model_path.display(),
+                bos_token,
+                bos_id,
+                "tokenizer.json lacks the Gemma BOS post-processor; installed \
+                 the standard `<bos> $A` TemplateProcessing (issue #686)"
+            );
+        }
+        Err(err) => {
+            tracing::warn!(
+                model_path = %model_path.display(),
+                error = %err,
+                "failed to install the Gemma BOS post-processor; raw-text \
+                 encodes will remain BOS-less"
+            );
+        }
+    }
+}
+
 pub fn load_tokenizer(model_path: &Path) -> Result<MlxcelTokenizer> {
     // Model-specific override: some official checkpoints ship a stale
     // tokenizer.json that does not match their weights (starmie-era
@@ -805,8 +904,9 @@ pub fn load_tokenizer(model_path: &Path) -> Result<MlxcelTokenizer> {
     // Try HuggingFace tokenizer.json first
     let tokenizer_json_path = model_path.join("tokenizer.json");
     if tokenizer_json_path.exists() {
-        let tokenizer = tokenizers::Tokenizer::from_file(tokenizer_json_path)
+        let mut tokenizer = tokenizers::Tokenizer::from_file(tokenizer_json_path)
             .map_err(|e| anyhow::anyhow!(e))?;
+        ensure_bos_post_processor(&mut tokenizer, model_path);
         return Ok(MlxcelTokenizer::HuggingFace(tokenizer));
     }
 


### PR DESCRIPTION
## Summary

Corrected diagnosis of #686. The user-visible symptom (temp-0 greedy chat on gemma-4-12b emitting a token or two then `<pad>` spam) is an **mlxcel chat-template rendering bug**, now fixed. The earlier perplexity investigation was accurate that the gemma-4 forward and proportional RoPE are faithful to Apple's mlx_lm reference, but that was a red herring for the user symptom: elevated raw-document perplexity is shared by mlx_lm (an instruct checkpoint scored on out-of-distribution raw text), while the real interactive bug lives in how mlxcel rendered the chat prompt. This PR fixes the chat-template rendering, keeps the tokenizer BOS repair and the proportional-RoPE reference test, and documents a separately-discovered gemma-4 decode-path issue that remains.

## The real bug (fixed): Gemma-4 thinking-channel default

The Gemma 4 `chat_template.jinja` renders the generation prompt as `<|turn>model\n<|channel>thought\n<channel|>` (a CLOSED empty thought channel, so the model answers directly) when `not enable_thinking | default(false)`, and a bare `<|turn>model\n` (the model opens its own reasoning) when thinking is enabled. `transformers.apply_chat_template` with no `enable_thinking` kwarg renders the CLOSED scaffold and the reference then generates the correct answer.

mlxcel diverged two ways: (1) the tokenizer `has_thinking` heuristic (mlx-lm PR #1114) forced `enable_thinking=true` for this template family because it exposes multi-token `<|channel>thought` / `<channel|>` markers, and (2) `patch_gemma4_generation_prompt` then appended an OPEN `<|channel>thought\n` marker for thinking=true. The combination made the interactive default a thinking-on prompt (bare model turn + open channel), which drives quantized Gemma 4 into an open reasoning channel that greedy-collapses to `<pad>`.

Fix: `ChatTemplateProcessor::wants_thinking_default_off()` detects the Gemma-4 thinking-channel template (requires both the `<|channel>thought` marker and the `not enable_thinking` guard, so Qwen3's `<think>` path never matches), and the `commands::generate` and `server::startup` thinking-default hooks skip the PR #1114 flip for it, keeping the transformers-matching thinking-off default. The post-render `patch_gemma4_generation_prompt` (which diverged from transformers by appending the open channel for thinking=true) is removed, so minijinja's faithful render flows through untouched. mlxcel's rendered prompt is now byte-identical to transformers for all three cases (default and `enable_thinking=false` render the CLOSED scaffold; `enable_thinking=true` renders bare), verified by token-id parity on the France and sky prompts (first16 and last8 token ids match the reference exactly, both ending in the closed-channel token id `101`).

## Also fixed / kept

Bug 1 (tokenizer BOS): the Gemma 4 tokenizer.json ships a passthrough post-processor, so raw-text encode paths ran BOS-less; `ensure_bos_post_processor()` installs the standard `<bos> $A` template at load, guarded so correct exports and the chat path are untouched. This is independent of the chat-template fix and independently valuable.

Proportional-RoPE reference test: pins that the compiled full-head fast path equals the mlx-vlm / mlx-lm `ProportionalRoPE` pack/rotate/unpack algorithm, so the (verified-correct) global-layer RoPE cannot silently regress.

## Forward is faithful (finding retained, reframed)

mlxcel's gemma-4 prefill forward matches the independent mlx_lm `gemma4_text` reference within 0.05 nats at every scored length (128/256/512), and controls (gemma-3-4b, qwen3.5-9b) stay flat on the same harness. The proportional RoPE is mathematically equivalent to the reference and pinned by the new test. So the forward is NOT the user-visible bug, and per the review direction it is not modified here.

## Remaining work (separate, newly discovered): gemma-4 KV-cache decode collapse

With the now-byte-identical prompt, the FIRST generated token is correct (France to "Paris", sky to "The"), but mlxcel's gemma-4 KV-cache decode still collapses to `<pad>` after a few tokens, while Apple mlx_lm's KV-cache decode on the same model + prompt is coherent ("...Rayleigh scattering, where Earth's atmosphere scatters shorter blue and violet wavelengths...") and mlxcel's gemma-3 decode is coherent. Isolation: `MLXCEL_DISABLE_SINGLE_QUERY_MASKLESS=1` sharply lengthens the coherent run (2 to 24 tokens on uniform-4bit), and the 8-bit MLP GEMV shortens it further (24 to 6 on the mixed-quant checkpoint), so the single-query maskless decode-attention path is the dominant contributor with a secondary quantized-GEMV factor. This is a decode-kernel issue in the forward path (out of this PR's scope, which explicitly does not touch the forward) and warrants a dedicated follow-up. The chat-template fix here is necessary but not sufficient to fully eliminate the pad-collapse.

## Test plan

- [x] cargo test -p mlxcel --features cuda --lib chat_template (89 passed; new tests pin the closed-channel default, the bare thinking=true render, and no post-render patch)
- [x] cargo test -p mlxcel-core --features cuda --lib rope_proportional (5 passed)
- [x] token-id parity: mlxcel rendered prompt == transformers for France and sky (first16 + last8 ids identical, closed-channel ending id 101)
- [x] mlxcel gemma-4-12b first token now correct (France to "Paris") instead of the pre-fix "The user is asking..." meta-reasoning collapse

Refs #686 (partial: fixes the chat-template and tokenizer aspects; the decode-path collapse is tracked separately and #686 stays open until it lands)