### PR TITLE
fix(gemma4): disable CUDA graphs for decode graph-race collapse (#688)

### DIFF
--- a/benchmarks/cuda_gb10_gemma4_decode_688_2026-07-07.csv
+++ b/benchmarks/cuda_gb10_gemma4_decode_688_2026-07-07.csv
@@ -1,0 +1,8 @@
+model,variant,cuda_graphs,coherent_tokens,deterministic,decode_tok_s,date,hardware,mlx_version,build_type,notes
+gemma-4-12b-it-4bit,shipped-8bit-mlp,on,1-3,no,13.83,2026-07-07,NVIDIA_GB10_122GB,0.3.3,release,"baseline (broken): greedy temp0 collapses to <pad> after 1-3 tokens, nondeterministic run-to-run"
+gemma-4-12b-it-4bit,shipped-8bit-mlp,off,>=200,yes,13.51,2026-07-07,NVIDIA_GB10_122GB,0.3.3,release,"fix #688 (default for gemma-4): deterministic 5/5, coherent, ~2.3% slower steady-state decode vs graphs-on"
+gemma-4-12b-it-4bit-uniform,uniform-4bit,on,2,no,~21,2026-07-07,NVIDIA_GB10_122GB,0.3.3,release,"baseline (broken): collapse after 2 tokens, nondeterministic"
+gemma-4-12b-it-4bit-uniform,uniform-4bit,off,>=110,yes,19.29,2026-07-07,NVIDIA_GB10_122GB,0.3.3,release,"fix #688: deterministic 5/5, matches mlx_lm reference trajectory near-exactly (tiny FP drift ~token 40)"
+gemma-4-31b-it-4bit,shipped-4bit,off,>=40,yes,,2026-07-07,NVIDIA_GB10_122GB,0.3.3,release,"fix #688: coherent decode on the larger 31b variant"
+gemma-3-4b-it-4bit,control,on,>=30,n/a,,2026-07-07,NVIDIA_GB10_122GB,0.3.3,release,"control (non-gemma4): unchanged, graphs stay on; note: gemma-3 hd-256 sdpa_vector decode is separately nondeterministic under graphs (latent, non-collapsing) -> follow-up"
+qwen3.5-4b-4bit,control,on,>=30,yes,,2026-07-07,NVIDIA_GB10_122GB,0.3.3,release,"control (non-gemma4): unchanged, graphs stay on, deterministic"

--- a/src/distributed/pipeline/stage_executor/mod.rs
+++ b/src/distributed/pipeline/stage_executor/mod.rs
@@ -168,6 +168,16 @@ impl LoadedStageExecutor {
             stage.stage_index
         );
 
+        // Issue #688 (M2 hardening): defense-in-depth CUDA-graph disable for a
+        // Gemma 4 pipeline stage, mirroring the non-PP backend-seam load sites.
+        // Both the in-process and the remote-process pipeline loaders reach this
+        // common stage-load chokepoint before any stage weights are realised. The
+        // authoritative env write already happens on the main startup thread in
+        // `start_server`; this idempotent call (guarded by `var_os`) only takes
+        // effect if a future pipeline entry ever bypasses that hoist, so the env is
+        // set before the stage's first GPU eval regardless.
+        crate::loading::maybe_disable_cuda_graphs_for_gemma4_for_path(model_dir);
+
         let filter = LayerFilter::from_stage(stage);
         let family = resolve_stage_family(model_dir)?;
         let backend =

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -4226,6 +4226,87 @@ mod tests {
         );
     }
 
+    /// Fill a `[rows, head_dim]` buffer with a deterministic pseudo-random
+    /// tensor whose every length-`head_dim` row is RMS-normalized (unit RMS,
+    /// so each element is O(1) and the row L2 norm is `sqrt(head_dim)`). This
+    /// mimics the post `q_norm` / `k_norm` distribution of Gemma 4, where the
+    /// attention scale is 1.0 and pre-softmax scores therefore reach O(head_dim).
+    fn rms_normed_rows(rows: usize, head_dim: usize, seed: u64) -> Vec<f32> {
+        let mut state = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut next = || {
+            // SplitMix64 -> uniform in [-1, 1).
+            state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^= z >> 31;
+            ((z >> 11) as f32 / (1u64 << 53) as f32) * 2.0 - 1.0
+        };
+        let mut out = vec![0.0_f32; rows * head_dim];
+        for r in 0..rows {
+            let row = &mut out[r * head_dim..(r + 1) * head_dim];
+            for x in row.iter_mut() {
+                *x = next();
+            }
+            let ms: f32 = row.iter().map(|v| v * v).sum::<f32>() / head_dim as f32;
+            let inv_rms = 1.0 / ms.sqrt().max(1e-6);
+            for x in row.iter_mut() {
+                *x *= inv_rms;
+            }
+        }
+        out
+    }
+
+    /// Numerical parity guard for the head_dim-256 single-query decode path
+    /// investigated under issue #688: the maskless single-query path (which
+    /// routes head_dim-256 attention to the CUDA `sdpa_vector` kernel) must match
+    /// the explicit-mask materializing SDPA for a Gemma-4-shaped decode step,
+    /// INCLUDING the `scale = 1.0` regime where pre-softmax scores reach
+    /// O(head_dim). Gemma 4 uses `scale = 1.0` (its `q_norm`/`k_norm` absorb the
+    /// usual `1/sqrt(d)`), unlike gemma-3 / qwen3.5 (`scale = 1/sqrt(d)`). This
+    /// test confirms the vector kernel is numerically correct EAGERLY at that
+    /// scale; the actual #688 `<pad>` collapse was a CUDA-graph read-before-write
+    /// hazard in Gemma 4's decode (not the kernel math), fixed by disabling CUDA
+    /// graph capture for Gemma 4 in `crate`-external model loading. Keeping this
+    /// guard prevents a future regression of the eager vector-kernel numerics.
+    #[test]
+    fn single_query_maskless_matches_masked_gemma4_large_scale() {
+        let n_heads = 16_i32;
+        let n_kv = 8_i32;
+        let head_dim = 256_i32;
+        let k_len = 25_i32;
+
+        let q_data = rms_normed_rows(n_heads as usize, head_dim as usize, 1);
+        let k_data = rms_normed_rows((n_kv * k_len) as usize, head_dim as usize, 2);
+        let v_data = rms_normed_rows((n_kv * k_len) as usize, head_dim as usize, 3);
+
+        let q = crate::from_slice_f32(&q_data, &[1, n_heads, 1, head_dim]);
+        let k = crate::from_slice_f32(&k_data, &[1, n_kv, k_len, head_dim]);
+        let v = crate::from_slice_f32(&v_data, &[1, n_kv, k_len, head_dim]);
+
+        for &scale in &[1.0_f32, 1.0 / (head_dim as f32).sqrt()] {
+            // Maskless single-query path: `mask = None` routes to the fused
+            // decode kernel (the sdpa_vector kernel for head_dim 256 on CUDA).
+            let out_maskless = attention(&q, &k, &v, scale, None, 0.0, 0);
+            // Explicit all-attend mask: `create_causal_mask(1, k_len - 1)` is
+            // all-zero for a single query, forcing the materializing SDPA path.
+            let mask = crate::utils::create_causal_mask(1, k_len - 1);
+            let out_masked = attention(&q, &k, &v, scale, Some(mask.as_ref().unwrap()), 0.0, 0);
+
+            let diff =
+                crate::subtract(out_maskless.as_ref().unwrap(), out_masked.as_ref().unwrap());
+            let diff_abs = crate::abs(&diff);
+            let max_diff_arr = crate::max_all(&diff_abs);
+            crate::eval(&max_diff_arr);
+            let max_diff = crate::item_f32(&max_diff_arr);
+            assert!(
+                max_diff.is_finite() && max_diff < 2e-3,
+                "maskless single-query decode must match the masked reference at \
+                 scale={scale}; max abs diff = {max_diff}"
+            );
+        }
+    }
+
     /// Verify that the detection condition uses the canonical NA check
     /// (has_neural_accelerator && macos_supports_na) rather than just
     /// metal_version >= 4.

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -374,6 +374,20 @@ pub fn context_window_from_config(config: &serde_json::Value) -> Option<usize> {
 /// process-wide `use_cuda_graphs()` static (read once, on the first graph-eligible
 /// eval) picks it up. An explicit operator value (either direction) is respected.
 /// Non-Gemma-4 loads are untouched.
+///
+/// The sound home for this write is the main startup thread, upstream of any
+/// worker spawn: the server path calls
+/// [`maybe_disable_cuda_graphs_for_gemma4_for_path`] from `start_server` before the
+/// generation or pipeline worker is created (issue #688 M1/M2 hardening), and the
+/// CLI `generate`/`run` path loads on the main thread. The per-load-site calls that
+/// invoke this helper remain as idempotent defense-in-depth.
+///
+/// Invariant: this env-based lever assumes one model per process. The server is
+/// single-model-per-process today (no in-process hot-swap in `start_server`), so a
+/// non-Gemma eval never latches `use_cuda_graphs = true` before a later Gemma 4
+/// load. If in-process model hot-swap is ever added, a non-Gemma model loaded first
+/// would make a subsequent Gemma 4 `set_var` a silent no-op (the static is already
+/// latched) and this approach would need revisiting.
 fn maybe_disable_cuda_graphs_for_gemma4(model_type: ModelType) {
     let is_gemma4 = matches!(
         model_type,
@@ -386,19 +400,44 @@ fn maybe_disable_cuda_graphs_for_gemma4(model_type: ModelType) {
     if std::env::var_os("MLX_USE_CUDA_GRAPHS").is_some() {
         return;
     }
-    // SAFETY: set_var mutates the process-global environment and is unsound only
-    // under a concurrent getenv/setenv on another thread. This runs inside the
-    // model load, on the single loading thread, before any weights are realised
-    // (the first GPU eval) and therefore before MLX's `use_cuda_graphs` static is
-    // first read and before any generation worker thread is spawned. It mirrors
-    // the established one-shot startup env write in
-    // `mlxcel_core::configure_ptx_cache`.
+    // SAFETY: set_var mutates the process-global environment and is unsound under
+    // Rust 2024 only when another thread runs getenv/setenv concurrently. The
+    // authoritative write is hoisted to the main startup thread, upstream of any
+    // worker spawn and of the first GPU eval that latches MLX's `use_cuda_graphs`
+    // static: `maybe_disable_cuda_graphs_for_gemma4_for_path` runs in `start_server`
+    // for every serve path (batched, legacy, tensor-parallel, XLA, in-process and
+    // remote pipeline-parallel), and the CLI `generate`/`run` path loads on the main
+    // thread. On the server path this per-load-site call runs inside the spawned
+    // worker, but by then the main-thread write has already set `MLX_USE_CUDA_GRAPHS`,
+    // so the `var_os` guard above returns early and no set_var executes off the main
+    // thread. This write is therefore reached only on a main-thread load (CLI,
+    // benches) or if a future entry bypasses the hoist. It mirrors the established
+    // one-shot startup env writes `mlxcel_core::ensure_persistent_ptx_cache`,
+    // `hardware::apply_metal_ops_per_buffer_default`, and
+    // `TurboKvCacheArgs::apply_to_environment`, all written upstream of runtime
+    // bring-up.
     unsafe { std::env::set_var("MLX_USE_CUDA_GRAPHS", "0") };
     tracing::info!(
         "Gemma 4 detected: disabling CUDA graph capture (MLX_USE_CUDA_GRAPHS=0) to \
          avoid the decode-path graph hazard from issue #688. Set MLX_USE_CUDA_GRAPHS \
          explicitly to override."
     );
+}
+
+/// Path-based entry to [`maybe_disable_cuda_graphs_for_gemma4`] for the main-thread
+/// hoist (issue #688 M1/M2 hardening).
+///
+/// Peeks the on-disk model type and, for a Gemma 4 checkpoint, performs the
+/// `MLX_USE_CUDA_GRAPHS=0` write on the calling (main startup) thread, before any
+/// generation or pipeline worker is spawned and before the first GPU eval. A
+/// detection error (unreadable or absent `config.json`) is a no-op, which preserves
+/// the baseline for non-model paths and defers to the per-load-site calls. Kept as a
+/// thin wrapper so the Gemma-4 detection, operator-override guard, idempotency, and
+/// logging all stay in the single [`maybe_disable_cuda_graphs_for_gemma4`] helper.
+pub(crate) fn maybe_disable_cuda_graphs_for_gemma4_for_path(model_path: &Path) {
+    if let Ok(model_type) = get_model_type(model_path) {
+        maybe_disable_cuda_graphs_for_gemma4(model_type);
+    }
 }
 
 /// Load a model from a directory (or file — parent directory will be used)

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -355,11 +355,58 @@ pub fn context_window_from_config(config: &serde_json::Value) -> Option<usize> {
     None
 }
 
+/// Force CUDA graph capture off for Gemma 4 checkpoints (issue #688).
+///
+/// mlxcel's Gemma 4 incremental (single-query, KV-cache) decode has a CUDA-graph
+/// read-before-write hazard: greedy (temperature 0) decode is nondeterministic
+/// run to run and collapses to `<pad>` after 1-3 tokens on CUDA, while Apple
+/// mlx_lm decodes the same model and prompt coherently. Prefill and the first
+/// token are correct; the collapse is in the incremental decode graph. The
+/// hazard is not a single op: disabling the head_dim-256 `sdpa_vector` decode
+/// kernel (`MLXCEL_SDPA_VECTOR_LARGE_D=0`), the maskless single-query attention
+/// path (`MLXCEL_DISABLE_SINGLE_QUERY_MASKLESS=1`), or `mx.compile`
+/// (`MLX_DISABLE_COMPILE=1`) each only lengthens the coherent prefix; only
+/// turning off CUDA graph capture removes it entirely, restoring deterministic,
+/// coherent, mlx_lm-matching decode. Gemma 3, Qwen 3.5 and other families do not
+/// exhibit the collapse and keep graph capture on.
+///
+/// This writes `MLX_USE_CUDA_GRAPHS=0` before the first GPU eval so MLX's
+/// process-wide `use_cuda_graphs()` static (read once, on the first graph-eligible
+/// eval) picks it up. An explicit operator value (either direction) is respected.
+/// Non-Gemma-4 loads are untouched.
+fn maybe_disable_cuda_graphs_for_gemma4(model_type: ModelType) {
+    let is_gemma4 = matches!(
+        model_type,
+        ModelType::Gemma4 | ModelType::Gemma4VLM | ModelType::Gemma4Unified
+    );
+    if !is_gemma4 {
+        return;
+    }
+    // Respect an explicit operator override (either direction).
+    if std::env::var_os("MLX_USE_CUDA_GRAPHS").is_some() {
+        return;
+    }
+    // SAFETY: set_var mutates the process-global environment and is unsound only
+    // under a concurrent getenv/setenv on another thread. This runs inside the
+    // model load, on the single loading thread, before any weights are realised
+    // (the first GPU eval) and therefore before MLX's `use_cuda_graphs` static is
+    // first read and before any generation worker thread is spawned. It mirrors
+    // the established one-shot startup env write in
+    // `mlxcel_core::configure_ptx_cache`.
+    unsafe { std::env::set_var("MLX_USE_CUDA_GRAPHS", "0") };
+    tracing::info!(
+        "Gemma 4 detected: disabling CUDA graph capture (MLX_USE_CUDA_GRAPHS=0) to \
+         avoid the decode-path graph hazard from issue #688. Set MLX_USE_CUDA_GRAPHS \
+         explicitly to override."
+    );
+}
+
 /// Load a model from a directory (or file — parent directory will be used)
 pub fn load_model(model_path: &Path) -> Result<(LoadedModel, MlxcelTokenizer)> {
     let model_path = resolve_model_dir(model_path);
     let model_path = model_path.as_path();
     let model_type = get_model_type(model_path)?;
+    maybe_disable_cuda_graphs_for_gemma4(model_type);
 
     // Whisper is an encoder-decoder ASR model, not a text generator. It is
     // wired into the speech-to-text audio endpoints at server startup rather
@@ -466,6 +513,7 @@ pub fn load_model_with_tensor_parallel(
     let model_path = resolve_model_dir(model_path);
     let model_path = model_path.as_path();
     let support = validate_supported_runtime(model_path, shard_config.clone(), adapter_path)?;
+    maybe_disable_cuda_graphs_for_gemma4(support.summary.model_type);
     let model = match support.summary.model_type {
         ModelType::Llama | ModelType::Qwen2 => LoadedModel::TensorParallelLlama(
             TensorParallelLlamaModel::from_model_dir(model_path, shard_config.clone())?,
@@ -508,6 +556,8 @@ pub fn load_model_with_adapter(
 ) -> Result<(LoadedModel, MlxcelTokenizer)> {
     let model_path = resolve_model_dir(model_path);
     let model_path = model_path.as_path();
+    // Disable CUDA graphs for Gemma 4 before any weight realisation (issue #688).
+    maybe_disable_cuda_graphs_for_gemma4(get_model_type(model_path)?);
     // Load base weights
     let base_weights = mlxcel_core::weights::load_weights_from_dir(model_path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -525,6 +575,7 @@ pub fn load_model_with_adapter(
 /// Build a model from pre-loaded weights (used by adapter loading)
 fn load_model_from_weights(model_path: &Path, weights: &mut WeightMap) -> Result<LoadedModel> {
     let model_type = get_model_type(model_path)?;
+    maybe_disable_cuda_graphs_for_gemma4(model_type);
     let config_path = model_path.join("config.json");
     let config_str = std::fs::read_to_string(&config_path)?;
     let config_str = sanitize_config_json(&config_str);

--- a/src/models/gemma4_tests.rs
+++ b/src/models/gemma4_tests.rs
@@ -273,7 +273,7 @@ mod cache_isolation {
                 let weights = make_test_gemma4_weight_map();
                 Gemma4Wrapper::new(Gemma4Model::from_weights(&weights, &args).unwrap())
             };
-            let prompt: Vec<i32> = (0..24).map(|i| (i % 7) as i32).collect();
+            let prompt: Vec<i32> = (0..24).map(|i| i % 7).collect();
 
             let single = build();
             let mut caches = single.make_caches();

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -1542,6 +1542,20 @@ fn install_surgery_pipeline_for_server(startup: &ServerStartupConfig) -> Result<
 /// Shared entry point used by both `mlxcel serve` and `mlxcel-server`.
 pub async fn start_server(mut startup: ServerStartupConfig) -> Result<()> {
     initialize_server_logging(&startup)?;
+
+    // Issue #688 (M1/M2 hardening): disable CUDA graph capture for Gemma 4 here,
+    // on the main startup thread, before any generation or pipeline worker is
+    // spawned and before the first GPU eval latches MLX's process-wide
+    // `use_cuda_graphs` static. Performing the env write on this thread (rather than
+    // only at the per-load-site calls, which run inside the spawned worker) keeps it
+    // sound under Rust 2024's concurrent-getenv rule. This single chokepoint covers
+    // every serve path that flows through `start_server`: the batched, legacy,
+    // tensor-parallel and XLA workers, the in-process pipeline-parallel worker, and
+    // the remote pipeline stage worker (the `serve_remote_pipeline_stage` branch
+    // below) — all load `startup.model_path`. Non-Gemma-4 models and an explicit
+    // `MLX_USE_CUDA_GRAPHS` operator override are left untouched.
+    crate::loading::maybe_disable_cuda_graphs_for_gemma4_for_path(&startup.model_path);
+
     super::media::configure_image_input_limits(super::media::ImageInputLimits {
         max_payload_bytes: startup.max_image_payload_size,
         max_images_per_request: startup.max_images_per_request,


### PR DESCRIPTION
## Symptom

On CUDA (GB10), gemma-4 (both the shipped `gemma-4-12b-it-4bit` with its 8-bit MLP and the uniform-4bit requant) greedy (temperature 0) decode collapsed to `<pad>` (id 0) spam after only 1-3 generated tokens, even on a byte-identical chat prompt that Apple mlx_lm decodes coherently. Prefill and the first token were correct (the merged chat-template fix from #686/#687 already produces a correct first token); the collapse was purely in the incremental single-query KV-cache decode. A decisive tell that the earlier reports missed: the collapse point varied run to run for the SAME model, prompt, and greedy settings (e.g. "The sky", then "The", then "The sky is blue because" across repeated runs), which is the signature of a race, not a deterministic numerical bug.

## Localization trail

Working against an mlx_lm `gemma4_text` oracle (custom loader that strips vision and quantizes, cache-based greedy decode that exercises the same incremental path) that decodes the sky-is-blue prompt coherently and deterministically, I A/B'd the mlxcel decode with the existing env levers and measured coherent-token-count before collapse on the uniform-4bit model: baseline collapses at ~2 tokens; `MLXCEL_DISABLE_SINGLE_QUERY_MASKLESS=1` reaches ~15-24 then still collapses; `MLXCEL_SDPA_VECTOR_LARGE_D=0` (routes the head_dim-256 sliding decode off the #681 `sdpa_vector` overlay kernel to the materializing SDPA) reaches ~8-40 but STILL collapses and STILL varies run to run; `MLXCEL_DISABLE_SINGLE_QUERY_MASKLESS=1` + `MLXCEL_SDPA_VECTOR_LARGE_D=0` together still collapse nondeterministically; `MLX_DISABLE_COMPILE=1` does not fix it either. Only `MLX_USE_CUDA_GRAPHS=0` fully fixes it: 4/4 and then 5/5 identical, coherent 110-token decodes that match the mlx_lm reference trajectory. An eager unit test constructing gemma-4-shaped inputs (16/8 GQA, head_dim 256, RMS-normed q/k, scale 1.0) shows the `sdpa_vector` kernel is numerically correct EAGERLY (maskless == masked within 2e-3), so the kernel math is fine; the fault only appears under CUDA graph capture/replay. Instrumenting the `sdpa_vector` launch site confirmed correct, fresh per-step params (kL grows 24->25->26->27, strides consistent) and forcing a contiguous K/V copy did NOT fix it, ruling out stale params and the strided KV read. Separately, gemma-3 (also head_dim-256, also a rotating sliding-window cache) is ALSO nondeterministic under graphs with the `sdpa_vector` kernel but stays coherent, and qwen3.5 (plain cache) is deterministic; `MLXCEL_SDPA_VECTOR_LARGE_D=0` makes gemma-3 deterministic but does not fix gemma-4, proving the `sdpa_vector` kernel is only one contributor and a second, non-SDPA CUDA-graph hazard remains in gemma-4's decode.

## Root cause

mlxcel's gemma-4 incremental decode has a CUDA-graph read-before-write hazard (a missing ordering edge between the in-place KV-cache write and its downstream reads under graph capture), with at least two contributors: the head_dim-256 `sdpa_vector` decode kernel (the #681 overlay extension) reading the rotating sliding-window cache slice (dominant, and also the cause of gemma-3's latent nondeterminism), plus a residual gemma-4-specific hazard that is not in the SDPA dispatch and not in any `mx.compile`d kernel. Apple mlx_lm's `gemma4_text` decode is graph-safe on the same hardware, so this is an mlxcel-implementation hazard, not a shared-model or checkpoint defect. The 8-bit-MLP "secondary GEMV factor" flagged in the issue was not a separate bug: it only made the model sit closer to the collapse cliff, so the race tipped it over sooner; with the race removed, both the 8-bit-MLP and uniform-4bit variants decode coherently.

## The fix

Disable CUDA graph capture for gemma-4 checkpoints (`ModelType::Gemma4` / `Gemma4VLM` / `Gemma4Unified`) by writing `MLX_USE_CUDA_GRAPHS=0` in the shared model-load path (`src/loading/mod.rs`), before the first GPU eval, so MLX's read-once `use_cuda_graphs()` static picks it up. An explicit operator `MLX_USE_CUDA_GRAPHS` value is respected in either direction; all non-gemma-4 families keep graph capture on and are byte-for-byte unchanged. This is the minimal Rust-side dispatch fix that mirrors how mlx_lm avoids the hazard, and it is applied at all four load entry points (direct, tensor-parallel, adapter, from-weights).

## Reference-parity validation (CUDA, GB10, release, greedy temp 0)

gemma-4-12b-it-4bit-uniform: 5/5 identical, coherent 110-token decodes matching the mlx_lm reference near-exactly ("The sky is blue because Earth's atmosphere scatters shorter blue wavelengths of sunlight more than longer red wavelengths. This phenomenon, known as Rayleigh scattering, occurs as sunlight interacts with ..."), with only a tiny near-tie FP drift after ~40 tokens ("gas molecules and small particles" vs the oracle's "the gases and particles"). gemma-4-12b-it-4bit (shipped 8-bit MLP): 5/5 identical, coherent 110 tokens. gemma-4-31b-it-4bit: coherent. Explicit `MLX_USE_CUDA_GRAPHS=1` reproduces the nondeterministic collapse, confirming the fix is exactly the graph disable and that the override is honored. Coherent-token-count before/after: 1-3 (nondeterministic) -> >=110 (deterministic). A new eager unit test (`single_query_maskless_matches_masked_gemma4_large_scale`) pins the head_dim-256 vector-kernel numerics at scale 1.0. Numbers recorded in `benchmarks/cuda_gb10_gemma4_decode_688_2026-07-07.csv`.

## Blast radius

Touches only the model-load dispatch and is scoped to gemma-4 model types; no shared decode-attention code, KV-cache, or kernel behavior changes, so gemma-3/3n, other head_dim-256 or MQA models, and the sliding-window decode path are unaffected. Controls confirmed unchanged: gemma-3-4b, qwen3.5-4b, qwen3-4b all decode coherently with graph capture still on. Decode throughput cost for gemma-4 is ~2.3% steady-state (200-token run: 13.51 vs 13.83 tok/s), within a few percent of baseline; gemma-4 got no measured benefit from CUDA graph capture beyond that. Two follow-ups discovered during this work, out of scope here: (1) gemma-3's head_dim-256 `sdpa_vector` decode is separately nondeterministic under graphs (latent, non-collapsing) via the same `sdpa_vector`/rotating-cache contributor; (2) the residual non-SDPA CUDA-graph ordering hazard in mlxcel's gemma-4 decode should be root-caused so graph capture can be safely re-enabled for the throughput.

## Review hardening (M1/M2)
The env write is now hoisted to the main thread before the generation worker is spawned (a path-based helper called from server startup), so set_var is not raced against a concurrent getenv on a request-handler thread under --no-warmup; this matches the ensure_persistent_ptx_cache precedent. The in-process pipeline-parallel gemma-4 load path, which bypassed the four backend-seam entry points, now also applies the guard. The per-load-site calls remain as idempotent defense-in-depth. SAFETY comment ordering rationale and a stale symbol reference are corrected.

## Follow-up hardening (M1/M2 from security review)

Two soundness and coverage gaps found in review, fixed on this branch without changing the graph-disable behavior.

M1 (set_var soundness): on the server path the per-load-site `set_var("MLX_USE_CUDA_GRAPHS=0")` runs inside the spawned generation worker thread, which is UB under Rust 2024 if a request-handler thread calls getenv concurrently (reachable with `--no-warmup`, where the listener accepts before load finishes). The gemma-4 detection and env write are now hoisted to the main startup thread in `start_server` (`src/server/startup.rs:1557`), before any worker is spawned and before the first GPU eval latches MLX's read-once `use_cuda_graphs` static, matching the `ensure_persistent_ptx_cache` / `apply_metal_ops_per_buffer_default` / `TurboKvCacheArgs::apply_to_environment` precedents. On the server path the worker-thread load-site call now short-circuits at the `var_os` guard because the main thread already wrote the var, so no `set_var` executes off the main thread. A new one-line path helper `maybe_disable_cuda_graphs_for_gemma4_for_path` (`src/loading/mod.rs`) is the single home reused by the hoist and the defense-in-depth sites; the four load-site calls stay as idempotent belt-and-suspenders. The CLI `generate`/`run` path already loads on the main thread, so it was already sound. The SAFETY comment was rewritten for the new ordering and its stale symbol reference (`configure_ptx_cache`, which does not exist) corrected to `ensure_persistent_ptx_cache`.

M2 (pipeline-parallel coverage): the in-process and remote pipeline-parallel loaders do not go through the four backend-seam entry points, so gemma-4 served via pipeline parallel previously had no graph disable. The `start_server` hoist is upstream of both the in-process pipeline worker spawn and the `serve_remote_pipeline_stage` branch (both load `startup.model_path`), so it now covers them. A defense-in-depth guard was also added at the shared pipeline stage-load chokepoint `LoadedStageExecutor::load_with_adapter` (`src/distributed/pipeline/stage_executor/mod.rs`), so the env is set before a stage's first GPU eval even if a future pipeline entry bypasses the hoist.

L1: documented that the env-based lever assumes single-model-per-process, which holds today (no in-process hot-swap in `start_server`).

Re-verification (CUDA, GB10, after the refactor): CLI gemma-4-12b-it-4bit greedy temp-0 decode is coherent ("Rayleigh scattering ...") and byte-identical across two runs. `mlxcel-server` on gemma-4-12b-it-4bit answered `/v1/chat/completions` coherently (HTTP 200), and the "Gemma 4 detected: disabling CUDA graph capture" log now fires from the main-thread hoist (module `mlxcel::loading`) about 3 seconds before the model worker thread starts. A non-gemma control (`llama-3.2-1b-4bit`, server and CLI) does not log the graph disable and decodes coherently, confirming graph capture stays on for non-gemma families. Touched-module unit tests pass (271 passed, 0 failed).

Closes #688
