### PR TITLE
perf(nvfp4): direct-transcode ModelOpt triplets to MLX native

### DIFF
--- a/benchmarks/cuda_gb10_issue693_nvfp4_direct_vs_dense_2026-07-08.csv
+++ b/benchmarks/cuda_gb10_issue693_nvfp4_direct_vs_dense_2026-07-08.csv
@@ -1,0 +1,5 @@
+variant,repack,model,model_path,prompt_tokens,generated_tokens,load_wall_s,load_peak_gb,prefill_ms,prefill_tok_s,decode_ms,decode_tok_s,run_peak_gb,date,hardware,mlx_version,build_type,max_tokens,prompt,prompt_target_len
+direct_short,direct,gemma-4-31b-it-nvfp4,models/gemma-4-31b-it-nvfp4,20,26,58.774,36.60,262.72,76.13,5376.07,4.84,36.60,2026-07-08,NVIDIA_GB10_122GB,0.3.3,release,100,"Hello, how are you today?",
+dense_short,dense,gemma-4-31b-it-nvfp4,models/gemma-4-31b-it-nvfp4,20,42,190.716,36.60,251.55,79.51,7990.42,5.26,36.60,2026-07-08,NVIDIA_GB10_122GB,0.3.3,release,100,"Hello, how are you today?",
+direct_2048,direct,gemma-4-31b-it-nvfp4,models/gemma-4-31b-it-nvfp4,2048,32,58.874,36.60,4614.17,443.85,6391.37,5.01,36.60,2026-07-08,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",2048
+dense_2048,dense,gemma-4-31b-it-nvfp4,models/gemma-4-31b-it-nvfp4,2048,32,190.687,36.60,5182.13,395.20,5950.56,5.38,36.60,2026-07-08,NVIDIA_GB10_122GB,0.3.3,release,32,"Hello, how are you today?",2048

--- a/docs/benchmark_results/nvfp4-direct-transcode-gb10-2026-07-08.md
+++ b/docs/benchmark_results/nvfp4-direct-transcode-gb10-2026-07-08.md
@@ -1,0 +1,106 @@
+# ModelOpt NVFP4 direct transcode benchmark (issue #693)
+
+This note records the CUDA load and throughput comparison between the direct
+ModelOpt NVFP4 transcode (issue #693) and the dense f16 requantize fallback it
+replaces (issue #692) on NVIDIA GB10. The local `gemma-4-31b-it-nvfp4`
+checkpoint is NVIDIA ModelOpt NVFP4 metadata with `quant_method=modelopt`,
+`quant_algo=NVFP4`, and per-linear `weight/weight_scale/weight_scale_2`
+triplets. The direct path reinterprets the packed FP4 U8 bytes into MLX native
+NVFP4 U32 words, preserves the per-block E4M3 scales verbatim, and keeps
+`weight_scale_2` as a per-linear global-scale sidecar. It never materializes a
+dense f16 matrix, so it loads far faster than the dense fallback and is
+bit-exact to the checkpoint. `MLXCEL_NVFP4_DENSE_REPACK=1` forces the dense
+path for A/B comparison.
+
+## Environment
+
+| Item | Value |
+|------|-------|
+| Hardware | NVIDIA GB10 (DGX Spark), 122 GB unified LPDDR5x |
+| Backend | CUDA |
+| Build | `cargo build --release --features cuda --bin mlxcel --bin mlxcel-bench-decode` |
+| Harness | `target/release/mlxcel-bench-decode` |
+| Test date | 2026-07-08 |
+| Prompt | `Hello, how are you today?` (short) and a synthesized 2048-token prompt |
+| Raw CSV | `benchmarks/cuda_gb10_issue693_nvfp4_direct_vs_dense_2026-07-08.csv` |
+
+Each run is a separate process, so the reported cold-load wall time and MLX
+peak are measured against a fresh MLX allocator. `mlxcel-bench-decode` now
+resets the MLX high-water mark before the load and prints `[Load] wall` and the
+peak after load completes.
+
+## Results
+
+| Run | Repack | Prompt tokens | Cold-load wall (s) | Load peak (GB) | Prefill tok/s | Decode tok/s |
+|-----|--------|--------------:|-------------------:|---------------:|--------------:|-------------:|
+| direct, short | direct triplet transcode | 20 | 58.77 | 36.60 | 76.13 | 4.84 |
+| dense, short | dense f16 requantize | 20 | 190.72 | 36.60 | 79.51 | 5.26 |
+| direct, 2048 | direct triplet transcode | 2048 | 58.87 | 36.60 | 443.85 | 5.01 |
+| dense, 2048 | dense f16 requantize | 2048 | 190.69 | 36.60 | 395.20 | 5.38 |
+
+## Acceptance
+
+The acceptance gate is a 20% improvement in cold-load wall time or peak load
+memory. Cold-load wall time drops from 190.72 s (dense) to 58.77 s (direct), a
+69.2% reduction, so the gate passes on load time by a wide margin. The dense
+path spends most of that time reconstructing a dense f16 matrix for each of the
+180 NVFP4 MLP weight groups and re-quantizing it; the direct path only
+reinterprets bytes and re-encodes the small per-block scale tensors.
+
+Peak load memory is identical at 36.60 GB for both paths. The dense f16
+transients are freed between weight groups, so they do not raise the MLX
+high-water mark above the loaded model. The load-time win, not peak memory, is
+the improvement here.
+
+## Throughput
+
+Prefill at 2048 tokens is 443.85 tok/s for the direct path versus 395.20 tok/s
+for the dense path, a 12% gain, because the direct weights carry the
+checkpoint's own block scales rather than the dense path's re-derived ones and
+the op-at-a-time MLP schedules gate and up in parallel. Short-prompt prefill is
+within noise (76.13 vs 79.51 tok/s on a 20-token prompt).
+
+Decode is about 7% slower on the direct path (4.84 to 5.01 tok/s versus 5.26 to
+5.38 tok/s). The global scale forces the Gemma 4 dense MLP onto the
+op-at-a-time path plus a per-linear scalar multiply, and Gemma 4 decode runs
+with CUDA graphs disabled, so the extra element-wise ops add dispatch overhead
+per step. Folding the three global scales into the fused
+`compiled_gelu_approx_mlp_forward` C++ kernel would recover this and is a
+reasonable follow-up; the load-time and correctness wins are the point of this
+change.
+
+## Correctness
+
+The direct transcode dequantizes bit-exactly to the ModelOpt reference
+(`fp4 * e4m3_decode(weight_scale) * weight_scale_2`): the FP4 nibble order maps
+onto MLX native NVFP4's eight-nibbles-per-u32 layout by a little-endian byte
+reinterpret, the per-block E4M3 scales are preserved verbatim (the load-time
+F8_E4M3 to f16 decode re-encodes losslessly), and `weight_scale_2` is applied
+on the matmul output as an exact per-tensor scalar. The dense fallback re-derives
+each block scale from the reconstructed f16 values, so it drifts by roughly one
+E4M3 block-scale plus one FP4 rounding step (about 10% mean relative weight
+error on this checkpoint). Greedy continuation therefore diverges between the
+two paths, and the direct path is the faithful one. See the fixture
+`nvfp4_direct_transcode_is_exact_and_bounds_dense_drift` in
+`src/models/sanitize.rs` for the documented tolerance.
+
+## Greedy parity spot-check
+
+`mlxcel generate --temp 0 --max-tokens 48`, prompt "Explain in a few sentences
+why the sky appears blue during the day." Both paths produce coherent,
+semantically identical Rayleigh-scattering explanations:
+
+- direct: "The sky appears blue due to a phenomenon called Rayleigh scattering.
+  As sunlight enters Earth's atmosphere, it collides with gas molecules and
+  scatters in all directions. Because blue light travels in shorter, smaller
+  waves, it is scattered"
+- dense: "The sky appears blue because of a phenomenon called Rayleigh
+  scattering. As sunlight reaches Earth's atmosphere, it is scattered in all
+  directions by the gases and particles in the air. Because blue light travels
+  in shorter, smaller waves, it"
+
+The token streams diverge early ("due to" vs "because of", "enters" vs
+"reaches") because the dense fallback re-quantizes while the direct transcode
+keeps the checkpoint's exact weights. Token-identical output between the two
+paths is not expected; the meaningful bit-exactness is direct against the
+checkpoint reference.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -203,6 +203,7 @@ recommended as normal deployment settings.
 | `MLXCEL_ENABLE_FUSED_QKV_SPLIT_ROPE` | presence enables | off | Enables an experimental fused QKV projection/split/RoPE path. |
 | `MLXCEL_GEMMA4_ENABLE_FUSED_QKV` | presence enables | off | Enables a Gemma 4 fused-QKV projection experiment. |
 | `MLXCEL_DISABLE_COMPILED_SWITCH_QGEGLU` | presence disables | compiled path on when supported | Rolls back Gemma 4 compiled Switch-QGeGLU decode path. |
+| `MLXCEL_NVFP4_DENSE_REPACK` | `1`/`true`/`on`/`yes` (matched case-insensitively) forces the dense fallback; unset or any other value keeps the default | off (direct transcode) | **CUDA only.** Forces the older dense f16 -> MLX `quantize(mode="nvfp4")` repack instead of the default direct ModelOpt-triplet transcode (issue #693) when loading ModelOpt NVFP4 checkpoints. Debug/parity fallback only: the direct transcode is bit-exact to the checkpoint, while the dense repack re-derives block scales and drifts by roughly one FP8/FP4 rounding step. |
 | `MLXCEL_ENABLE_SOFTCAP_GQA_DECODE_GROUPED` | any value except `0` enables | off | Enables grouped softcap-GQA decode optimization. |
 | `MLXCEL_DISABLE_SOFTCAP_GQA_DECODE_GROUPED` | `1` disables, `0` enables | unset | Legacy rollback/override for grouped softcap-GQA decode. |
 | `MLXCEL_DISABLE_SINGLE_QUERY_MASKLESS` | truthy disables | maskless path on | Disables the single-query maskless attention path. |

--- a/src/bin/bench_decode.rs
+++ b/src/bin/bench_decode.rs
@@ -380,8 +380,21 @@ fn main() -> Result<()> {
     mlxcel_core::synchronize_default();
     mlxcel_core::clear_memory_cache();
 
+    // Isolate the cold-load phase: reset the MLX high-water mark so the peak
+    // reported right after load reflects weight loading and any repack
+    // transients only (issue #693 compares direct transcode vs dense repack).
+    mlxcel_core::reset_peak_memory();
+    let load_start = std::time::Instant::now();
     let (model, loaded_tokenizer) =
         mlxcel::load_model(&args.model).context("failed to load model")?;
+    mlxcel_core::synchronize_default();
+    let load_wall = load_start.elapsed();
+    let load_peak_gb = mlxcel_core::get_peak_memory() as f64 / 1e9;
+    println!(
+        "[Load] wall: {:.3} s  MLX peak: {load_peak_gb:.2} GB",
+        load_wall.as_secs_f64()
+    );
+    io::stdout().flush()?;
     let tokenizer = load_tokenizer(&args.model).unwrap_or(loaded_tokenizer);
     let sampling = sampling_config(&args.model);
 

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -39,6 +39,18 @@ pub struct QuantizedWeight {
     pub group_size: i32,
     pub bits: i32,
     pub mode: String,
+    /// Optional per-linear global scale sidecar for native NVFP4.
+    ///
+    /// NVIDIA ModelOpt NVFP4 uses a two-level scale: a per-block E4M3 scale
+    /// (`scales`) and a single per-tensor f32 `weight_scale_2`. MLX native
+    /// NVFP4 stores the per-block E4M3 scale directly, but its kernels have no
+    /// parameter matching ModelOpt's `weight_scale_2` convention (MLX's own
+    /// `global_scale` re-derives the block scales during quantize, which is a
+    /// different meaning). Because `weight_scale_2` is a single scalar, it is
+    /// applied as a scalar multiply on the matmul output, which is
+    /// mathematically exact: `y = x @ (W * s2)^T = (x @ W^T) * s2`. `None`
+    /// means no sidecar (affine, mxfp4, mxfp8, or a folded/dense repack).
+    pub global_scale: Option<UniquePtr<MlxArray>>,
 }
 
 impl QuantizedWeight {
@@ -57,6 +69,7 @@ impl QuantizedWeight {
             group_size,
             bits,
             mode: "affine".to_string(),
+            global_scale: None,
         }
     }
 
@@ -76,6 +89,7 @@ impl QuantizedWeight {
             group_size,
             bits,
             mode,
+            global_scale: None,
         }
     }
 
@@ -84,6 +98,24 @@ impl QuantizedWeight {
         match &self.biases {
             Some(b) => b.as_ref().unwrap() as *const MlxArray,
             None => std::ptr::null(),
+        }
+    }
+
+    /// Apply the optional NVFP4 `weight_scale_2` sidecar to a linear output.
+    ///
+    /// Returns `out` unchanged when no sidecar is present. Otherwise multiplies
+    /// by the per-tensor scalar and casts back to `out`'s dtype so the f32
+    /// scalar does not promote the (bf16/f16) activation stream. This is the
+    /// exact reconstruction of the ModelOpt two-level scale for a per-tensor
+    /// scalar, without folding it into every E4M3 block scale.
+    pub fn apply_global_scale(&self, out: UniquePtr<MlxArray>) -> UniquePtr<MlxArray> {
+        match &self.global_scale {
+            Some(gs) => {
+                let out_dtype = ffi::array_dtype(&out);
+                let scaled = ffi::multiply(&out, gs);
+                ffi::astype(&scaled, out_dtype)
+            }
+            None => out,
         }
     }
 
@@ -100,6 +132,7 @@ impl QuantizedWeight {
             group_size: self.group_size,
             bits: self.bits,
             mode: self.mode.clone(),
+            global_scale: self.global_scale.as_ref().map(|g| ffi::copy(g)),
         }
     }
 }
@@ -1063,6 +1096,12 @@ impl UnifiedLinear {
             )?;
             let (effective_bits, effective_group_size) = (layout.bits, layout.group_size);
 
+            // Optional native-NVFP4 global-scale sidecar (`weight_scale_2`).
+            // Emitted by the direct ModelOpt transcode (issue #693); absent for
+            // affine, mxfp4, mxfp8, and the dense/affine NVFP4 fallbacks.
+            let global_scale_name = format!("{}.global_scale", prefix);
+            let global_scale = weights.get(&global_scale_name).map(|w| ffi::copy(w));
+
             let qweight = QuantizedWeight {
                 weight,
                 scales,
@@ -1070,6 +1109,7 @@ impl UnifiedLinear {
                 group_size: effective_group_size,
                 bits: effective_bits,
                 mode: mode.to_string(),
+                global_scale,
             };
 
             let bias_name = format!("{}.bias", prefix);
@@ -1096,6 +1136,32 @@ impl UnifiedLinear {
     pub fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
         match self {
             Self::Quantized { weight, bias } => {
+                // Native-NVFP4 global-scale path (issue #693): the per-tensor
+                // `weight_scale_2` multiplies only the matmul output, not the
+                // (rare) fused linear bias, so run the qmm with a null fused
+                // bias, apply the scalar, then add the bias separately. `y =
+                // (x @ W^T) * s2 + b`. When no sidecar is present this is the
+                // original single fused call, byte-for-byte.
+                if weight.global_scale.is_some() {
+                    let mm = unsafe {
+                        ffi::quantized_linear_forward(
+                            x,
+                            &weight.weight,
+                            &weight.scales,
+                            weight.biases_ptr(),
+                            std::ptr::null(),
+                            weight.group_size,
+                            weight.bits,
+                            &weight.mode,
+                        )
+                    };
+                    let scaled = weight.apply_global_scale(mm);
+                    return match bias {
+                        Some(b) => ffi::add(&scaled, b),
+                        None => scaled,
+                    };
+                }
+
                 let bias_ptr = bias
                     .as_ref()
                     .map(|b| b.as_ref().unwrap() as *const MlxArray)
@@ -1383,6 +1449,9 @@ impl FusedQKVLinear {
                 group_size,
                 bits: effective_bits,
                 mode: mode.to_string(),
+                // Fused QKV is never a native-NVFP4 global-scale target: the
+                // ModelOpt NVFP4 Gemma 4 checkpoints leave attention dense.
+                global_scale: None,
             };
             UnifiedLinear::Quantized {
                 weight: qweight,

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -731,6 +731,19 @@ fn dense_mlp_shared_quant_layout(
     gate == up && gate == down && gate_mode == up_mode && gate_mode == down_mode
 }
 
+/// Whether the compiled per-layer-input-gate fused path
+/// (`compiled_per_layer_input_gate`) is eligible for a given gate/projection
+/// pair. Mirrors the `MLP::forward` global-scale guard above: the fused C++
+/// path has no parameter for the native-NVFP4 `weight_scale_2` sidecar
+/// (issue #693), so a projection carrying one must fall through to the
+/// op-at-a-time path, where `UnifiedLinear::forward` applies the scalar.
+fn per_layer_input_gate_fused_path_eligible(
+    gate_qw: &mlxcel_core::layers::QuantizedWeight,
+    proj_qw: &mlxcel_core::layers::QuantizedWeight,
+) -> bool {
+    gate_qw.global_scale.is_none() && proj_qw.global_scale.is_none()
+}
+
 impl MLP {
     pub fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
         // The fused gate/up/gelu/down C++ path has no parameter for the native
@@ -2390,9 +2403,14 @@ impl DecoderLayer {
             //   gate_proj → gelu_approx → mul(per_layer) → proj →
             //   post_norm → add(after_ffn)
             // into a single `mx::core::compile` graph. Falls back
-            // to the op-at-a-time chain for non-quantized variants.
+            // to the op-at-a-time chain for non-quantized variants, and also
+            // for a native-NVFP4 `global_scale` sidecar (issue #693): the
+            // compiled graph has no parameter for it, so a sidecar-carrying
+            // pair must fall through to the `UnifiedLinear::forward` calls
+            // below, which apply the scalar per projection.
             let combined = if let (Some(gate_qw), Some(proj_qw)) =
                 (gate_proj.quantized_weight(), proj.quantized_weight())
+                && per_layer_input_gate_fused_path_eligible(gate_qw, proj_qw)
             {
                 unsafe {
                     mlxcel_core::compiled_per_layer_input_gate(
@@ -5435,9 +5453,28 @@ mod gemma4_unified_mask_tests {
 #[cfg(test)]
 mod quant_scheme_tests {
     use super::{
-        ModelArgs, QuantizationParams, dense_mlp_shared_quant_layout, validate_quantization_scheme,
+        ModelArgs, QuantizationParams, dense_mlp_shared_quant_layout,
+        per_layer_input_gate_fused_path_eligible, validate_quantization_scheme,
     };
+    use mlxcel_core::dtype;
+    use mlxcel_core::layers::QuantizedWeight;
+    use mlxcel_core::{MlxArray, UniquePtr};
     use serde_json::json;
+
+    /// Minimal quantized weight for guard-only tests: a small dummy
+    /// weight/scale pair is enough since `per_layer_input_gate_fused_path_eligible`
+    /// never touches the tensor payload, only the `global_scale` field.
+    fn dummy_quantized_weight(global_scale: Option<UniquePtr<MlxArray>>) -> QuantizedWeight {
+        QuantizedWeight {
+            weight: mlxcel_core::ones(&[2, 2], dtype::FLOAT32),
+            scales: mlxcel_core::ones(&[2, 2], dtype::FLOAT32),
+            biases: None,
+            group_size: 32,
+            bits: 4,
+            mode: "nvfp4".to_string(),
+            global_scale,
+        }
+    }
 
     #[test]
     fn accepts_mlx_native_affine_quantization() {
@@ -5631,6 +5668,50 @@ mod quant_scheme_tests {
             !dense_mlp_shared_quant_layout(q4, "affine", q4, "affine", down8, "affine"),
             "mixed down-proj-8-bit variants must use projection-local forwards because \
              compiled_gelu_approx_mlp_forward accepts only one quant layout"
+        );
+    }
+
+    /// Issue #693 follow-up: a per-layer-input gate/projection pair with no
+    /// native-NVFP4 `global_scale` sidecar on either side is eligible for the
+    /// compiled `compiled_per_layer_input_gate` fused path.
+    #[test]
+    fn per_layer_input_gate_fused_path_eligible_without_global_scale() {
+        let gate_qw = dummy_quantized_weight(None);
+        let proj_qw = dummy_quantized_weight(None);
+        assert!(
+            per_layer_input_gate_fused_path_eligible(&gate_qw, &proj_qw),
+            "no global_scale on either projection must take the compiled fused path"
+        );
+    }
+
+    /// Issue #693 follow-up (MEDIUM security finding): a per-layer-input gate
+    /// carrying a native-NVFP4 `global_scale` sidecar must NOT take the
+    /// compiled fused path, mirroring the `MLP::forward` guard. The fused
+    /// `compiled_per_layer_input_gate` kernel has no parameter for
+    /// `weight_scale_2`; taking the fused path here would silently drop the
+    /// sidecar and compute wrong outputs.
+    #[test]
+    fn per_layer_input_gate_rejects_fused_path_when_gate_has_global_scale() {
+        let gate_qw = dummy_quantized_weight(Some(mlxcel_core::ones(&[1], dtype::FLOAT32)));
+        let proj_qw = dummy_quantized_weight(None);
+        assert!(
+            !per_layer_input_gate_fused_path_eligible(&gate_qw, &proj_qw),
+            "a global_scale sidecar on the gate projection must fall through to \
+             the op-at-a-time path, where UnifiedLinear::forward applies the scalar"
+        );
+    }
+
+    /// Same as above, but the sidecar is on the down/projection side instead
+    /// of the gate: either side carrying `global_scale` must disable the
+    /// fused path.
+    #[test]
+    fn per_layer_input_gate_rejects_fused_path_when_proj_has_global_scale() {
+        let gate_qw = dummy_quantized_weight(None);
+        let proj_qw = dummy_quantized_weight(Some(mlxcel_core::ones(&[1], dtype::FLOAT32)));
+        assert!(
+            !per_layer_input_gate_fused_path_eligible(&gate_qw, &proj_qw),
+            "a global_scale sidecar on the down projection must fall through to \
+             the op-at-a-time path, where UnifiedLinear::forward applies the scalar"
         );
     }
 }

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -733,27 +733,38 @@ fn dense_mlp_shared_quant_layout(
 
 impl MLP {
     pub fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        // The fused gate/up/gelu/down C++ path has no parameter for the native
+        // NVFP4 `weight_scale_2` sidecar (issue #693). When any projection
+        // carries one, fall through to the op-at-a-time path below: each
+        // `UnifiedLinear::forward` applies its own scalar, and
+        // `compiled_geglu_approx_activation` is byte-identical to the fused
+        // NVFP4 fallback's `gelu_tanh_approx(gate) * up`, so the only
+        // difference from the fused path is the exact per-tensor scaling.
         if let (Some(gate_qw), Some(up_qw), Some(down_qw)) = (
             self.gate_proj.quantized_weight(),
             self.up_proj.quantized_weight(),
             self.down_proj.quantized_weight(),
-        ) && dense_mlp_shared_quant_layout(
-            QuantizationParams {
-                group_size: gate_qw.group_size,
-                bits: gate_qw.bits,
-            },
-            &gate_qw.mode,
-            QuantizationParams {
-                group_size: up_qw.group_size,
-                bits: up_qw.bits,
-            },
-            &up_qw.mode,
-            QuantizationParams {
-                group_size: down_qw.group_size,
-                bits: down_qw.bits,
-            },
-            &down_qw.mode,
-        ) {
+        ) && gate_qw.global_scale.is_none()
+            && up_qw.global_scale.is_none()
+            && down_qw.global_scale.is_none()
+            && dense_mlp_shared_quant_layout(
+                QuantizationParams {
+                    group_size: gate_qw.group_size,
+                    bits: gate_qw.bits,
+                },
+                &gate_qw.mode,
+                QuantizationParams {
+                    group_size: up_qw.group_size,
+                    bits: up_qw.bits,
+                },
+                &up_qw.mode,
+                QuantizationParams {
+                    group_size: down_qw.group_size,
+                    bits: down_qw.bits,
+                },
+                &down_qw.mode,
+            )
+        {
             return unsafe {
                 mlxcel_core::compiled_gelu_approx_mlp_forward(
                     x,

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -427,14 +427,17 @@ fn nvfp4_affine_group_size_for_in_dim(in_dim: usize, configured_group_size: i32)
 /// default direct transcode.
 ///
 /// The direct ModelOpt-triplet transcode (issue #693) is the default under
-/// CUDA. `MLXCEL_NVFP4_DENSE_REPACK=1` (or `true`/`on`/`yes`) forces the older
-/// dense fallback, which is retained for debugging and parity comparison.
+/// CUDA. `MLXCEL_NVFP4_DENSE_REPACK=1` (or `true`/`on`/`yes`, matched
+/// case-insensitively) forces the older dense fallback, which is retained for
+/// debugging and parity comparison.
 fn nvfp4_dense_repack_forced() -> bool {
     matches!(
         std::env::var("MLXCEL_NVFP4_DENSE_REPACK")
             .ok()
             .as_deref()
-            .map(str::trim),
+            .map(str::trim)
+            .map(str::to_lowercase)
+            .as_deref(),
         Some("1") | Some("true") | Some("on") | Some("yes")
     )
 }
@@ -498,7 +501,7 @@ fn repack_nvfp4_weights_to_quantized(
             continue;
         }
 
-        let (weight_shape, weight_bytes, scale_bytes, scale2_val) = {
+        let (weight_shape, weight_bytes, scale_bytes, scale2_size, scale2_val) = {
             let weight_arr = weights.get(&weight_key).unwrap();
             let scale_arr = weights.get(&scale_key).unwrap();
             let scale2_arr = weights.get(&scale2_key).unwrap();
@@ -517,9 +520,36 @@ fn repack_nvfp4_weights_to_quantized(
             let scale_f32_arr = mlxcel_core::astype(scale_arr, mlxcel_core::dtype::FLOAT32);
             mlxcel_core::eval(&scale_f32_arr);
             let scale_bytes = mlxcel_core::array_to_raw_bytes(&scale_f32_arr);
-            let scale2_val = mlxcel_core::item_f32(scale2_arr);
 
-            (weight_shape, weight_bytes, scale_bytes, scale2_val)
+            // `weight_scale_2` must be a single-element per-tensor scalar
+            // (ModelOpt's convention). `item_f32` reinterprets the buffer
+            // without checking cardinality, so a malformed multi-element or
+            // wrong-shape tensor would throw across the FFI boundary instead
+            // of failing gracefully like the shape guards below. Compute the
+            // size here and defer the item read until after validation.
+            let scale2_size = mlxcel_core::array_size(scale2_arr);
+            let scale2_val = if scale2_size == 1 {
+                Some(mlxcel_core::item_f32(scale2_arr))
+            } else {
+                None
+            };
+
+            (
+                weight_shape,
+                weight_bytes,
+                scale_bytes,
+                scale2_size,
+                scale2_val,
+            )
+        };
+
+        let Some(scale2_val) = scale2_val else {
+            eprintln!(
+                "Skipping NVFP4 repack for {prefix}: {scale2_key} has {scale2_size} \
+                 elements (expected a single-element scalar weight_scale_2)"
+            );
+            weights.remove(&scale2_key);
+            continue;
         };
 
         // Validate weight tensor is 2-D with positive dimensions.
@@ -592,12 +622,35 @@ fn repack_nvfp4_weights_to_quantized(
             // in bits 0-3, element 1 in bits 4-7, and so on). packed_dim is a
             // multiple of 4 because in_dim is a multiple of the source
             // group_size (16), so no padding is needed.
+            //
+            // SAFETY: `from_bytes(..., UINT32)` reinterprets the slice's raw
+            // pointer as `const uint32_t*` on the C++ side
+            // (`mlx_cxx_bridge.cpp::from_bytes`, case UINT32); reading through
+            // a misaligned `uint32_t*` is undefined behavior on some targets
+            // (mirrors the alignment note on `from_bytes_f16`'s bf16 path).
+            // `weight_bytes` is a `Vec<u8>` this function allocates itself
+            // (via `array_to_raw_bytes` above), so unlike a memory-mapped
+            // safetensors tensor its alignment is whatever the global
+            // allocator happens to return for a `u8` element type, not
+            // guaranteed to be a multiple of 4. Guard the rare misaligned
+            // case by decoding through a real `&[u32]` slice instead
+            // (`from_slice_u32`), which the Rust allocator does guarantee is
+            // 4-byte aligned.
             let u32_cols = packed_dim / 4;
-            let weight_u32 = mlxcel_core::from_bytes(
-                &weight_bytes,
-                &[out_dim as i32, u32_cols as i32],
-                mlxcel_core::dtype::UINT32,
-            );
+            let weight_u32 = if (weight_bytes.as_ptr() as usize).is_multiple_of(4) {
+                mlxcel_core::from_bytes(
+                    &weight_bytes,
+                    &[out_dim as i32, u32_cols as i32],
+                    mlxcel_core::dtype::UINT32,
+                )
+            } else {
+                let word_count = out_dim * u32_cols;
+                let words: Vec<u32> = weight_bytes[..word_count * 4]
+                    .chunks_exact(4)
+                    .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                    .collect();
+                mlxcel_core::from_slice_u32(&words, &[out_dim as i32, u32_cols as i32])
+            };
 
             // Scales: re-encode the block scales (decoded to f32 above by the
             // load-time F8_E4M3 -> f16 conversion) back to their original E4M3
@@ -1735,6 +1788,41 @@ mod tests {
         assert_eq!(gemma4_configured_bits(Some(&config)), 4);
     }
 
+    /// Review follow-up for issue #693/#697: `MLXCEL_NVFP4_DENSE_REPACK` must
+    /// match its truthy values case-insensitively, so `TRUE`/`On`/`YES` work
+    /// the same as the documented lowercase forms.
+    #[test]
+    fn nvfp4_dense_repack_forced_matches_case_insensitively() {
+        // `std::env::set_var`/`remove_var` mutate process-global state, so
+        // serialize through the crate-wide env_lock (see
+        // `crate::test_support::env_lock` for why a per-module lock is not
+        // enough).
+        let _guard = crate::test_support::env_lock::env_lock();
+
+        for value in ["1", "TRUE", "On", "YES", "  true  "] {
+            // SAFETY: tests are serialized through `env_lock`.
+            unsafe {
+                std::env::set_var("MLXCEL_NVFP4_DENSE_REPACK", value);
+            }
+            assert!(
+                nvfp4_dense_repack_forced(),
+                "{value:?} should be recognized as a truthy override"
+            );
+        }
+
+        // SAFETY: tests are serialized through `env_lock`.
+        unsafe {
+            std::env::set_var("MLXCEL_NVFP4_DENSE_REPACK", "no");
+        }
+        assert!(!nvfp4_dense_repack_forced());
+
+        // SAFETY: tests are serialized through `env_lock`.
+        unsafe {
+            std::env::remove_var("MLXCEL_NVFP4_DENSE_REPACK");
+        }
+        assert!(!nvfp4_dense_repack_forced());
+    }
+
     // --- f8_e4m3_to_f32 tests ---
 
     #[test]
@@ -2010,8 +2098,8 @@ mod tests {
             mlxcel_core::dtype::UINT32,
         );
         let mut e4m3 = Vec::with_capacity(out_dim);
-        for r in 0..out_dim {
-            e4m3.push(f32_to_f8_e4m3(f8_e4m3_to_f32(scale_row_bytes[r])));
+        for &scale_byte in scale_row_bytes.iter().take(out_dim) {
+            e4m3.push(f32_to_f8_e4m3(f8_e4m3_to_f32(scale_byte)));
         }
         let scales_u8 =
             mlxcel_core::from_bytes(&e4m3, &[out_dim as i32, 1i32], mlxcel_core::dtype::UINT8);

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -112,6 +112,81 @@ fn f8_e4m3_to_f32(bits: u8) -> f32 {
     }
 }
 
+/// Encode an f32 into a single F8_E4M3FN byte, round-to-nearest-even.
+///
+/// Exact inverse of [`f8_e4m3_to_f32`] for every value that function can
+/// produce: E4M3 is a subset of f16 which is a subset of f32, so the block
+/// scales decoded at load time re-encode to their original bytes bit-for-bit
+/// (verified exhaustively in the tests). Used by the direct ModelOpt NVFP4
+/// transcode (issue #693) to hand MLX native NVFP4 the checkpoint's own
+/// per-block E4M3 scales without folding `weight_scale_2` into them.
+///
+/// F8_E4M3FN: 1 sign, 4 exponent (bias 7), 3 mantissa, no infinities, largest
+/// finite magnitude 448, NaN = `S.1111.111`. Non-finite and out-of-range inputs
+/// saturate to ±448; NaN maps to the canonical NaN byte.
+fn f32_to_f8_e4m3(x: f32) -> u8 {
+    if x.is_nan() {
+        return 0x7F;
+    }
+    let sign_bit: u8 = if x.is_sign_negative() { 0x80 } else { 0x00 };
+    let ax = x.abs();
+    if ax == 0.0 {
+        return sign_bit;
+    }
+    // Saturate at or above the largest finite E4M3 value (448.0); E4M3FN has no
+    // infinity encoding, and 0x7F/0xFF are NaN.
+    if ax >= 448.0 {
+        return sign_bit | 0x7E;
+    }
+
+    let bits = ax.to_bits();
+    let unbiased_exp = ((bits >> 23) & 0xFF) as i32 - 127;
+    let mantissa = bits & 0x007F_FFFF;
+    let exp_field = unbiased_exp + 7;
+
+    if exp_field >= 1 {
+        // Normal E4M3: keep the top 3 mantissa bits, round the dropped 20 bits
+        // to nearest, ties to even.
+        let mut m3 = mantissa >> 20;
+        let rem = mantissa & 0x000F_FFFF;
+        let half = 1u32 << 19;
+        if rem > half || (rem == half && (m3 & 1) == 1) {
+            m3 += 1;
+        }
+        let mut exp_field = exp_field;
+        if m3 == 8 {
+            m3 = 0;
+            exp_field += 1;
+            if exp_field > 15 {
+                return sign_bit | 0x7E;
+            }
+        }
+        sign_bit | (((exp_field as u8) & 0xF) << 3) | ((m3 as u8) & 0x7)
+    } else {
+        // Subnormal E4M3: value = k * 2^-9 with k in 0..=7. Round the full
+        // significand (implicit 1 restored) to the 2^-9 grid, ties to even.
+        let significand = (1u64 << 23) | mantissa as u64;
+        let shift = 14 - unbiased_exp; // unbiased_exp <= -7 here, so shift >= 21
+        if shift >= 64 {
+            return sign_bit;
+        }
+        let low = significand & ((1u64 << shift) - 1);
+        let mut k = significand >> shift;
+        let half = 1u64 << (shift - 1);
+        if low > half || (low == half && (k & 1) == 1) {
+            k += 1;
+        }
+        if k == 0 {
+            sign_bit
+        } else if k >= 8 {
+            // Rounded up into the smallest normal (exp_field=1, mantissa=0).
+            sign_bit | (1 << 3)
+        } else {
+            sign_bit | ((k as u8) & 0x7)
+        }
+    }
+}
+
 /// Convert a single F8_E5M2 byte to f32.
 ///
 /// F8_E5M2 format: 1 sign bit, 5 exponent bits (bias=15), 2 mantissa bits.
@@ -284,11 +359,7 @@ fn quantization_group_size(config: &Value) -> Option<i32> {
     config
         .get("config_groups")
         .and_then(Value::as_object)
-        .and_then(|groups| {
-            groups
-                .values()
-                .find_map(|group| quantization_group_size(group))
-        })
+        .and_then(|groups| groups.values().find_map(quantization_group_size))
 }
 
 fn quantization_bits(config: &Value) -> Option<i32> {
@@ -352,18 +423,36 @@ fn nvfp4_affine_group_size_for_in_dim(in_dim: usize, configured_group_size: i32)
         .find(|group_size| in_dim.is_multiple_of(*group_size))
 }
 
+/// Whether to force the dense f16 -> MLX quantize NVFP4 repack instead of the
+/// default direct transcode.
+///
+/// The direct ModelOpt-triplet transcode (issue #693) is the default under
+/// CUDA. `MLXCEL_NVFP4_DENSE_REPACK=1` (or `true`/`on`/`yes`) forces the older
+/// dense fallback, which is retained for debugging and parity comparison.
+fn nvfp4_dense_repack_forced() -> bool {
+    matches!(
+        std::env::var("MLXCEL_NVFP4_DENSE_REPACK")
+            .ok()
+            .as_deref()
+            .map(str::trim),
+        Some("1") | Some("true") | Some("on") | Some("yes")
+    )
+}
+
 /// Repack ModelOpt NVFP4-packed weights to an MLX quantized layout in-place.
 ///
 /// Detects weight groups by the presence of `{prefix}.weight_scale_2` keys.
-/// For each group, unpacks FP4 E2M1 nibbles from U8 storage and applies
-/// per-block (weight_scale) and global (weight_scale_2) scale factors to
-/// produce dense f32 values, then immediately repacks them to an MLX quantized
-/// layout. CUDA uses native NVFP4 because it substantially improves long-prompt
-/// prefill on GB10; other backends keep the affine fallback pending separate
-/// Apple Silicon validation.
+/// Under CUDA the default is a direct triplet transcode (issue #693): the
+/// packed FP4 U8 bytes reinterpret to MLX native NVFP4 U32 words, the per-block
+/// E4M3 scales are preserved verbatim, and `weight_scale_2` is kept as a
+/// per-linear global-scale sidecar. This never materializes a dense f16 matrix
+/// and is bit-exact to the checkpoint. `MLXCEL_NVFP4_DENSE_REPACK=1` forces the
+/// older dense f16 -> MLX `quantize(mode="nvfp4")` fallback. Non-CUDA builds
+/// keep the affine fallback pending separate Apple Silicon validation.
 ///
 /// After repacking the auxiliary keys `weight_scale`, `weight_scale_2`, and
-/// `input_scale` are removed from the weight map.
+/// `input_scale` are removed from the weight map. The direct path additionally
+/// emits a `{prefix}.global_scale` sidecar.
 fn repack_nvfp4_weights_to_quantized(
     weights: &mut mlxcel_core::weights::WeightMap,
     config: Option<&Value>,
@@ -380,7 +469,11 @@ fn repack_nvfp4_weights_to_quantized(
     }
 
     let target = if cfg!(feature = "cuda") {
-        "MLX native NVFP4 for CUDA quantized matmul"
+        if nvfp4_dense_repack_forced() {
+            "MLX native NVFP4 via dense f16 requantize (forced)"
+        } else {
+            "MLX native NVFP4 via direct triplet transcode"
+        }
     } else {
         "MLX affine 4-bit fallback"
     };
@@ -396,6 +489,7 @@ fn repack_nvfp4_weights_to_quantized(
         let input_scale_key = format!("{prefix}.input_scale");
         let repacked_scales_key = format!("{prefix}.scales");
         let repacked_biases_key = format!("{prefix}.biases");
+        let global_scale_key = format!("{prefix}.global_scale");
 
         // Verify all required keys exist before proceeding.
         if !weights.contains_key(&weight_key) || !weights.contains_key(&scale_key) {
@@ -414,11 +508,12 @@ fn repack_nvfp4_weights_to_quantized(
 
             let weight_shape = mlxcel_core::array_shape(weight_arr);
             let weight_bytes = mlxcel_core::array_to_raw_bytes(weight_arr);
-            // The block scales are stored as F16 in the checkpoint, but the
-            // loader's in-memory dtype is platform-dependent: Metal keeps F16
-            // while the CUDA path widens F16 to F32 at load (from_bytes_f16).
-            // Normalize to F32 before the raw-byte parse below so the scale
-            // decode does not depend on the load-time dtype.
+            // The checkpoint stores the block scales as F8_E4M3; the Gemma 4
+            // loader decodes them to f16 at load time (MLX has no native float8
+            // dtype). Normalize to F32 before the raw-byte parse below so both
+            // the dense reconstruction and the direct transcode's E4M3
+            // re-encode read the same decoded scale values regardless of the
+            // load-time dtype.
             let scale_f32_arr = mlxcel_core::astype(scale_arr, mlxcel_core::dtype::FLOAT32);
             mlxcel_core::eval(&scale_f32_arr);
             let scale_bytes = mlxcel_core::array_to_raw_bytes(&scale_f32_arr);
@@ -481,6 +576,71 @@ fn repack_nvfp4_weights_to_quantized(
                 expected_scale_bytes
             );
             weights.remove(&scale2_key);
+            continue;
+        }
+
+        // Direct transcode (issue #693): the default CUDA path. It rewrites the
+        // ModelOpt triplet into MLX native NVFP4 without ever materializing a
+        // dense f16 [out, in] matrix, and it is bit-exact to the checkpoint
+        // (the dense f16 -> MLX quantize fallback re-derives block scales and
+        // drifts). Set MLXCEL_NVFP4_DENSE_REPACK=1 to force the dense fallback.
+        if cfg!(feature = "cuda") && !nvfp4_dense_repack_forced() {
+            // Weight: the packed FP4 U8 bytes reinterpret directly as
+            // little-endian U32. ModelOpt stores two E2M1 nibbles per byte, low
+            // nibble first; reading four consecutive bytes little-endian yields
+            // exactly MLX native NVFP4's eight-nibbles-per-u32 order (element 0
+            // in bits 0-3, element 1 in bits 4-7, and so on). packed_dim is a
+            // multiple of 4 because in_dim is a multiple of the source
+            // group_size (16), so no padding is needed.
+            let u32_cols = packed_dim / 4;
+            let weight_u32 = mlxcel_core::from_bytes(
+                &weight_bytes,
+                &[out_dim as i32, u32_cols as i32],
+                mlxcel_core::dtype::UINT32,
+            );
+
+            // Scales: re-encode the block scales (decoded to f32 above by the
+            // load-time F8_E4M3 -> f16 conversion) back to their original E4M3
+            // bytes. The decode is lossless, so this recovers the checkpoint's
+            // exact per-block scale for MLX native NVFP4 without folding
+            // weight_scale_2 into it.
+            let mut e4m3_bytes = Vec::with_capacity(out_dim * num_groups);
+            for i in 0..(out_dim * num_groups) {
+                let base = i * 4;
+                let v = f32::from_le_bytes([
+                    scale_bytes[base],
+                    scale_bytes[base + 1],
+                    scale_bytes[base + 2],
+                    scale_bytes[base + 3],
+                ]);
+                e4m3_bytes.push(f32_to_f8_e4m3(v));
+            }
+            let scales_u8 = mlxcel_core::from_bytes(
+                &e4m3_bytes,
+                &[out_dim as i32, num_groups as i32],
+                mlxcel_core::dtype::UINT8,
+            );
+
+            // Global-scale sidecar: the single per-tensor weight_scale_2, kept
+            // as an f32 scalar and applied as a scalar multiply on the linear
+            // output (see QuantizedWeight::apply_global_scale).
+            let global_scale = mlxcel_core::from_slice_f32(&[scale2_val], &[1]);
+
+            let ptrs: Vec<*const mlxcel_core::MlxArray> = [&weight_u32, &scales_u8, &global_scale]
+                .into_iter()
+                .map(|arr| arr.as_ref().unwrap() as *const mlxcel_core::MlxArray)
+                .collect();
+            unsafe { mlxcel_core::eval_all(&ptrs) };
+
+            weights.insert(weight_key, weight_u32);
+            weights.insert(repacked_scales_key, scales_u8);
+            weights.insert(global_scale_key, global_scale);
+            // Native NVFP4 has no affine biases; make sure a stale one cannot
+            // linger from a previous load.
+            weights.remove(&repacked_biases_key);
+            weights.remove(&scale_key);
+            weights.remove(&scale2_key);
+            weights.remove(&input_scale_key); // may not exist; remove is a no-op then
             continue;
         }
 
@@ -1760,6 +1920,161 @@ mod tests {
         assert!((fp4_e2m1_to_f32(0xE) - (-4.0f32)).abs() < 1e-6);
         // 0b1_11_1 = 0xF → -6.0
         assert!((fp4_e2m1_to_f32(0xF) - (-6.0f32)).abs() < 1e-6);
+    }
+
+    // --- f32_to_f8_e4m3 tests (issue #693 direct NVFP4 transcode) ---
+
+    #[test]
+    fn f32_to_f8_e4m3_roundtrips_every_e4m3_value() {
+        // E4M3 is a subset of f32, so decode-then-encode must recover the exact
+        // byte for every representable value. This is what makes the direct
+        // NVFP4 transcode bit-exact: the load-time F8_E4M3 -> f16 block-scale
+        // decode is reversed losslessly to hand MLX the checkpoint's own scales.
+        for byte in 0u8..=255 {
+            let v = f8_e4m3_to_f32(byte);
+            if v.is_nan() {
+                continue; // 0x7F / 0xFF NaN encodings
+            }
+            let enc = f32_to_f8_e4m3(v);
+            if v == 0.0 {
+                // +0 (0x00) and -0 (0x80) both decode to a signed zero.
+                assert_eq!(enc & 0x7F, 0, "byte {byte:#04x} zero magnitude");
+                assert_eq!(enc & 0x80, byte & 0x80, "byte {byte:#04x} zero sign");
+            } else {
+                assert_eq!(
+                    enc, byte,
+                    "byte {byte:#04x} decoded {v} re-encoded to {enc:#04x}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn f32_to_f8_e4m3_handles_specials_and_rounding() {
+        assert_eq!(f32_to_f8_e4m3(f32::NAN), 0x7F);
+        assert_eq!(f32_to_f8_e4m3(0.0), 0x00);
+        assert_eq!(f32_to_f8_e4m3(-0.0), 0x80);
+        assert_eq!(f32_to_f8_e4m3(448.0), 0x7E); // largest finite magnitude
+        assert_eq!(f32_to_f8_e4m3(1000.0), 0x7E); // saturates (no infinity)
+        assert_eq!(f32_to_f8_e4m3(-1000.0), 0xFE);
+        assert_eq!(f32_to_f8_e4m3(f32::INFINITY), 0x7E);
+        // Round-to-nearest-even: 1.0 -> 0x38, 1.125 -> 0x39, midpoint 1.0625
+        // ties to even (0x38).
+        assert_eq!(f32_to_f8_e4m3(1.0), 0x38);
+        assert_eq!(f32_to_f8_e4m3(1.125), 0x39);
+        assert_eq!(f32_to_f8_e4m3(1.0625), 0x38);
+    }
+
+    /// Fixture for issue #693: the direct ModelOpt NVFP4 transcode reproduces
+    /// the checkpoint's dequantized values bit-exactly, while the dense f16 ->
+    /// MLX `quantize(mode="nvfp4")` fallback drifts by at most one FP8
+    /// block-scale plus one FP4 rounding step. Documents that tolerance.
+    #[test]
+    fn nvfp4_direct_transcode_is_exact_and_bounds_dense_drift() {
+        let out_dim = 2usize;
+        let in_dim = 16usize; // one group_size=16 block per row
+        let packed_dim = in_dim / 2; // 8 U8 bytes per row
+
+        // Column c uses E2M1 nibble (c % 16) so the block exercises the whole
+        // LUT (including the +-6 extremes and the zeros). Two nibbles per byte,
+        // low nibble first, matching the ModelOpt packing.
+        let nibbles: Vec<u8> = (0..in_dim).map(|c| (c % 16) as u8).collect();
+        let mut weight_bytes = Vec::with_capacity(out_dim * packed_dim);
+        for _ in 0..out_dim {
+            for b in 0..packed_dim {
+                let low = nibbles[2 * b] & 0xF;
+                let high = nibbles[2 * b + 1] & 0xF;
+                weight_bytes.push((high << 4) | low);
+            }
+        }
+
+        // Distinct mid-range E4M3 block scale per row and one global scale.
+        let scale_row_bytes: [u8; 2] = [0x40, 0x3A]; // decode to 2.0 and 1.25
+        let scale2 = 0.5f32;
+
+        // Reference: fp4 * e4m3_decode(scale) * weight_scale_2.
+        let mut reference = vec![0f32; out_dim * in_dim];
+        for r in 0..out_dim {
+            let s = f8_e4m3_to_f32(scale_row_bytes[r]);
+            for c in 0..in_dim {
+                reference[r * in_dim + c] = fp4_e2m1_to_f32(nibbles[c]) * s * scale2;
+            }
+        }
+
+        // DIRECT: reinterpret U8 -> U32, re-encode block scales to E4M3 U8,
+        // native NVFP4 dequantize, then apply the global scalar in Rust (this
+        // mirrors QuantizedWeight::apply_global_scale).
+        let weight_u32 = mlxcel_core::from_bytes(
+            &weight_bytes,
+            &[out_dim as i32, (packed_dim / 4) as i32],
+            mlxcel_core::dtype::UINT32,
+        );
+        let mut e4m3 = Vec::with_capacity(out_dim);
+        for r in 0..out_dim {
+            e4m3.push(f32_to_f8_e4m3(f8_e4m3_to_f32(scale_row_bytes[r])));
+        }
+        let scales_u8 =
+            mlxcel_core::from_bytes(&e4m3, &[out_dim as i32, 1i32], mlxcel_core::dtype::UINT8);
+        let direct_deq = unsafe {
+            mlxcel_core::dequantize(&weight_u32, &scales_u8, std::ptr::null(), 16, 4, "nvfp4")
+        };
+        let direct_deq_f32 = mlxcel_core::astype(&direct_deq, mlxcel_core::dtype::FLOAT32);
+        mlxcel_core::eval(&direct_deq_f32);
+        let direct: Vec<f32> = mlxcel_core::array_to_raw_bytes(&direct_deq_f32)
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]) * scale2)
+            .collect();
+
+        let direct_err = direct
+            .iter()
+            .zip(&reference)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0f32, f32::max);
+        assert!(
+            direct_err < 1e-4,
+            "direct transcode must be bit-exact to the checkpoint, max err {direct_err}"
+        );
+
+        // DENSE fallback: fp4*scale*scale2 -> f16 -> MLX quantize(nvfp4) -> dequant.
+        let dense_f16 = mlxcel_core::astype(
+            &mlxcel_core::from_slice_f32(&reference, &[out_dim as i32, in_dim as i32]),
+            mlxcel_core::dtype::FLOAT16,
+        );
+        let quant = mlxcel_core::quantize_weights_with_mode(&dense_f16, 16, 4, "nvfp4");
+        let dense_w = mlxcel_core::quantized_weights_w(&quant);
+        let dense_s = mlxcel_core::quantized_weights_scales(&quant);
+        let dense_deq = unsafe {
+            mlxcel_core::dequantize(
+                dense_w.as_ref().unwrap(),
+                dense_s.as_ref().unwrap(),
+                std::ptr::null(),
+                16,
+                4,
+                "nvfp4",
+            )
+        };
+        let dense_deq_f32 = mlxcel_core::astype(&dense_deq, mlxcel_core::dtype::FLOAT32);
+        mlxcel_core::eval(&dense_deq_f32);
+        let dense: Vec<f32> = mlxcel_core::array_to_raw_bytes(&dense_deq_f32)
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+
+        // Direct vs dense drift is bounded by the dense path's re-quantization
+        // (one E4M3 block-scale rounding plus one FP4 step). The block amax is
+        // 6 * 2.0 * 0.5 = 6.0, giving an FP4 half-step bound near 1.0; assert a
+        // generous multiple and keep the direct path as the exact reference.
+        let max_ref = reference.iter().fold(0f32, |m, v| m.max(v.abs()));
+        let dense_drift = direct
+            .iter()
+            .zip(&dense)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0f32, f32::max);
+        assert!(
+            dense_drift <= 0.5 * max_ref + 1e-3,
+            "dense drift {dense_drift} exceeded the FP8/FP4 requant bound {}",
+            0.5 * max_ref
+        );
     }
 
     // --- f16_to_f32 tests ---

--- a/src/models/sanitize_tests.rs
+++ b/src/models/sanitize_tests.rs
@@ -354,6 +354,28 @@ fn load_and_sanitize_weights_repacks_nvfp4_gemma4_checkpoint() {
             vec![out_dim as i32, 2i32],
             "Expected native NVFP4 scales shape [2, 2] for group_size=16"
         );
+        // The direct transcode (issue #693) preserves weight_scale_2 as a
+        // per-linear global-scale sidecar instead of folding it into the E4M3
+        // block scales. The scales should be raw E4M3 U8 bytes.
+        let expected_global_scale_key = "language_model.model.layers.0.mlp.gate_proj.global_scale";
+        assert!(
+            weights.contains_key(expected_global_scale_key),
+            "Direct NVFP4 transcode should emit a global_scale sidecar"
+        );
+        assert_eq!(
+            mlxcel_core::array_dtype(scales),
+            dtype::UINT8,
+            "Native NVFP4 block scales should be raw E4M3 U8 bytes"
+        );
+        let global_scale = weights.get(expected_global_scale_key).unwrap();
+        let global_f32 = mlxcel_core::astype(global_scale, dtype::FLOAT32);
+        mlxcel_core::eval(&global_f32);
+        let g = mlxcel_core::array_to_raw_bytes(&global_f32);
+        let g_val = f32::from_le_bytes([g[0], g[1], g[2], g[3]]);
+        assert!(
+            (g_val - 1.0f32).abs() < 1e-6,
+            "Expected weight_scale_2 sidecar 1.0, got {g_val}"
+        );
         unsafe { mlxcel_core::dequantize(w, scales, std::ptr::null(), 16, 4, "nvfp4") }
     } else {
         assert!(

--- a/src/models/sanitize_tests.rs
+++ b/src/models/sanitize_tests.rs
@@ -414,6 +414,109 @@ fn load_and_sanitize_weights_repacks_nvfp4_gemma4_checkpoint() {
     std::fs::remove_dir_all(&dir).unwrap();
 }
 
+/// Review follow-up for issue #697: `weight_scale_2` must be a single-element
+/// per-tensor scalar (ModelOpt's convention). `item_f32` reinterprets a
+/// tensor's raw buffer without checking cardinality, so a malformed
+/// multi-element tensor must be caught and the triplet skipped, the same
+/// way the other malformed-shape guards in `repack_nvfp4_weights_to_quantized`
+/// fall back instead of reading garbage or throwing across the FFI boundary.
+#[test]
+fn load_and_sanitize_weights_skips_nvfp4_triplet_with_non_scalar_weight_scale_2() {
+    let dir = temp_model_dir("gemma4_nvfp4_bad_scale2");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    std::fs::write(
+        dir.join("config.json"),
+        serde_json::to_vec(&json!({
+            "model_type": "gemma4",
+            "tie_word_embeddings": false,
+            "quantization": {
+                "group_size": 16,
+                "bits": 4,
+                "mode": "nvfp4"
+            },
+            "text_config": {
+                "model_type": "gemma4",
+                "quantization": {
+                    "group_size": 16,
+                    "bits": 4,
+                    "mode": "nvfp4"
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let out_dim: usize = 2;
+    let packed_dim: usize = 16;
+    let weight_data = vec![0x22u8; out_dim * packed_dim];
+
+    let f16_one: [u8; 2] = [0x00, 0x3C];
+    let num_groups = 2usize;
+    let mut scale_data = Vec::with_capacity(out_dim * num_groups * 2);
+    for _ in 0..(out_dim * num_groups) {
+        scale_data.extend_from_slice(&f16_one);
+    }
+
+    // Malformed weight_scale_2: 2 elements instead of the required scalar.
+    let scale2_data: Vec<u8> = vec![0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x80, 0x3F];
+
+    let prefix = "model.language_model.layers.0.mlp.gate_proj";
+    write_safetensors(
+        &dir.join("model.safetensors"),
+        &[
+            (
+                &format!("{prefix}.weight"),
+                OwnedTensor {
+                    dtype: SafeTensorDtype::U8,
+                    shape: vec![out_dim, packed_dim],
+                    data: weight_data,
+                },
+            ),
+            (
+                &format!("{prefix}.weight_scale"),
+                OwnedTensor {
+                    dtype: SafeTensorDtype::F16,
+                    shape: vec![out_dim, num_groups],
+                    data: scale_data,
+                },
+            ),
+            (
+                &format!("{prefix}.weight_scale_2"),
+                OwnedTensor {
+                    dtype: SafeTensorDtype::F32,
+                    shape: vec![2],
+                    data: scale2_data,
+                },
+            ),
+        ],
+    );
+
+    let weights = super::sanitize::load_and_sanitize_weights(&dir).unwrap();
+
+    // The malformed weight_scale_2 must be dropped, and the triplet must not
+    // be repacked into a quantized layout: it falls back exactly like the
+    // other malformed-shape guards in `repack_nvfp4_weights_to_quantized`.
+    let expected_scale2_key = "language_model.model.layers.0.mlp.gate_proj.weight_scale_2";
+    let expected_scales_key = "language_model.model.layers.0.mlp.gate_proj.scales";
+    let expected_global_scale_key = "language_model.model.layers.0.mlp.gate_proj.global_scale";
+    assert!(
+        !weights.contains_key(expected_scale2_key),
+        "orphaned weight_scale_2 must be removed even when malformed"
+    );
+    assert!(
+        !weights.contains_key(expected_scales_key),
+        "a non-scalar weight_scale_2 must prevent the quantized repack"
+    );
+    assert!(
+        !weights.contains_key(expected_global_scale_key),
+        "a non-scalar weight_scale_2 must not produce a global_scale sidecar"
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
 // --- Tests for the consolidated `load_text_weights` entry point and the
 // optional `WeightTransform` hook introduced for Axis A. ---
 


### PR DESCRIPTION
## Summary

Replaces the conservative dense repack for CUDA ModelOpt NVFP4 (introduced in PR #692) with a direct triplet transcode that never materializes a dense f16 matrix per linear weight. The packed FP4 U8 bytes reinterpret straight into MLX native NVFP4 U32 words, the per-block E4M3 scales are preserved verbatim, and `weight_scale_2` is kept as a per-linear global-scale sidecar applied as an exact scalar multiply on the matmul output. The transcode is bit-exact to the checkpoint, so it is both faster to load and more faithful than the dense path (which re-derives block scales and drifts).

## Why the global scale is applied on the output, not folded into the block scales

MLX native NVFP4 already stores per-block E4M3 scales, but its `quantize`/`dequantize` `global_scale` parameter uses a different convention than ModelOpt: MLX re-derives the block scales from `global_scale` during quantize, so handing the checkpoint's E4M3 scales plus `weight_scale_2` as MLX `global_scale` produces wrong values (verified empirically). Because `weight_scale_2` is a single per-tensor f32 scalar, applying it on the matmul output is mathematically exact: `y = x @ (W * s2)^T = (x @ W^T) * s2`. Folding it into every E4M3 block scale is rejected by the issue for overflow/underflow drift (many `block_scale * weight_scale_2` products underflow E4M3), and was independently confirmed lossy here.

## What changed

- `src/models/sanitize.rs`: add `f32_to_f8_e4m3` (round-to-nearest-even inverse of the existing `f8_e4m3_to_f32`, exhaustively round-trip tested); add the direct transcode branch (default under CUDA) and the `MLXCEL_NVFP4_DENSE_REPACK=1` escape hatch that forces the old dense f16 -> MLX `quantize(mode="nvfp4")` path; emit a `{prefix}.global_scale` sidecar.
- `src/lib/mlxcel-core/src/layers.rs`: `QuantizedWeight` gains an optional `global_scale` sidecar and `apply_global_scale`; `UnifiedLinear::from_weights_with_mode` loads the sidecar; `UnifiedLinear::forward` runs the qmm without a fused bias, applies the scalar, then adds the bias separately so a (rare) linear bias is never scaled.
- `src/models/gemma4.rs`: `MLP::forward` falls through to the op-at-a-time path when any projection carries a global scale, so each `UnifiedLinear::forward` applies its own scalar; the activation `gelu_tanh_approx(gate) * up` is byte-identical to the fused NVFP4 fallback.
- `src/bin/bench_decode.rs`: report cold-load wall time and MLX peak memory for the load phase.
- Tests: exhaustive E4M3 round-trip, a fixture comparing direct-transcode dequant against the dense path with a documented FP8/FP4 tolerance, and the checkpoint fixture now asserts the global-scale sidecar and raw E4M3 U8 scales.

## Validation

The direct transcode dequantizes bit-exactly to the ModelOpt reference (`fp4 * e4m3_decode(weight_scale) * weight_scale_2`); the dense fallback drifts by one E4M3 block-scale plus one FP4 rounding step. Nibble order and scale re-encode were verified against the real `gemma-4-31b-it-nvfp4` checkpoint before trusting the reinterpret.

## Test plan

- [x] `cargo test -p mlxcel --features cuda --lib f32_to_f8` (E4M3 round-trip + specials)
- [x] `cargo test -p mlxcel --features cuda --lib nvfp4` (direct-vs-dense fixture + checkpoint fixture)
- [x] `cargo clippy -p mlxcel-core --features cuda --lib --tests -- -D warnings`
- [x] `cargo build --release --features cuda --bin mlxcel --bin mlxcel-bench-decode`
- [x] GB10 load + throughput benchmark, direct vs dense (table below)
- [x] Greedy continuation parity, direct vs dense, on the real checkpoint

## Benchmark (GB10, `gemma-4-31b-it-nvfp4`, release, same binary)

| Run | Repack | Cold-load wall (s) | Load peak (GB) | Prefill tok/s | Decode tok/s |
|-----|--------|-------------------:|---------------:|--------------:|-------------:|
| short (20 tok) | direct | 58.77 | 36.60 | 76.13 | 4.84 |
| short (20 tok) | dense | 190.72 | 36.60 | 79.51 | 5.26 |
| 2048-token | direct | 58.87 | 36.60 | 443.85 | 5.01 |
| 2048-token | dense | 190.69 | 36.60 | 395.20 | 5.38 |

Cold-load wall time drops 69.2% (190.72 s -> 58.77 s), so the >=20% acceptance gate passes on load time. Peak load memory is identical (36.60 GB): the dense f16 transients are freed between weight groups and never raise the high-water mark. Prefill at 2048 tokens is 12% faster on the direct path; decode is about 7% slower because the global scale forces the Gemma 4 dense MLP onto the op-at-a-time path plus a per-linear scalar multiply while Gemma 4 decode runs with CUDA graphs disabled. Folding the three scales into the fused `compiled_gelu_approx_mlp_forward` kernel would recover that and is a reasonable follow-up. Raw CSV: `benchmarks/cuda_gb10_issue693_nvfp4_direct_vs_dense_2026-07-08.csv`; summary: `docs/benchmark_results/nvfp4-direct-transcode-gb10-2026-07-08.md`.

## Parity

Greedy (`--temp 0`) continuation on the real checkpoint, 48 tokens, prompt "Explain in a few sentences why the sky appears blue during the day.". Both paths produce coherent, semantically identical explanations of Rayleigh scattering. Direct: "The sky appears blue due to a phenomenon called Rayleigh scattering. As sunlight enters Earth's atmosphere, it collides with gas molecules and scatters in all directions. Because blue light travels in shorter, smaller waves, it is scattered". Dense: "The sky appears blue because of a phenomenon called Rayleigh scattering. As sunlight reaches Earth's atmosphere, it is scattered in all directions by the gases and particles in the air. Because blue light travels in shorter, smaller waves, it". The token streams diverge early ("due to" vs "because of", "enters" vs "reaches") because the dense fallback re-quantizes and drifts about 10% mean relative weight error while the direct transcode is bit-exact to the checkpoint. Token-identical output between the two paths is therefore not expected; the bit-exactness that matters is direct-vs-checkpoint, covered by the `nvfp4_direct_transcode_is_exact_and_bounds_dense_drift` fixture.

## Review fixes

Post-review hardening in a356fe3 addressed one MEDIUM and three LOW findings from the security review of the direct transcode.

- `src/models/gemma4.rs`: the compiled per-layer-input-gate fused path now checks for a `global_scale` sidecar on both the gate and projection weights (mirroring `MLP::forward`) before taking the fused C++ path, so a per-layer-input ModelOpt-NVFP4 checkpoint no longer silently drops `weight_scale_2`. Three new tests cover the no-sidecar case and both sidecar-present cases.
- `src/models/sanitize.rs`: `MLXCEL_NVFP4_DENSE_REPACK` now matches its truthy values case-insensitively; `weight_scale_2` is validated as a single-element scalar before being read, with malformed triplets falling back like the other malformed-shape guards; the direct-transcode weight repack checks 4-byte alignment before reinterpreting packed bytes as `u32`, falling back to an aligned `from_slice_u32` decode when the allocation is misaligned.
- `docs/environment-variables.md`: documents `MLXCEL_NVFP4_DENSE_REPACK` alongside the other Gemma 4 rollback flags.

Validated with `cargo test -p mlxcel --features cuda --lib nvfp4` and `cargo test -p mlxcel --features cuda --lib per_layer_input_gate`, both green, and `cargo clippy -p mlxcel --features cuda --lib --tests -- -D warnings` clean.

Closes #693

