### PR TITLE
chore: bump MLX pin to 0.32.1 (#703)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ permissions: {}
 # documented in CLAUDE.md). Hoisted to workflow scope so a future bump
 # touches one literal here instead of one per job.
 env:
-  MLX_EXPECTED_COMMIT: "a6ec7123dac814417147e21d4aeed694924ddd4d"
+  MLX_EXPECTED_COMMIT: "57c66cac7cb3e5b1eb350488a61f1506b40d39f8"
 
 jobs:
   # ============================================================================

--- a/src/lib/mlx-cpp/CMakeLists.txt
+++ b/src/lib/mlx-cpp/CMakeLists.txt
@@ -92,7 +92,7 @@ else()
   FetchContent_Declare(
     mlx
     GIT_REPOSITORY "https://github.com/ml-explore/mlx.git"
-    GIT_TAG e9463bbfc1a7cd9e0e6b96aaa3068a316e234a63)
+    GIT_TAG 57c66cac7cb3e5b1eb350488a61f1506b40d39f8)
 
   # Use FetchContent_Populate + add_subdirectory so we can apply source
   # overlays before the MLX build system processes the files.

--- a/src/lib/mlx-cpp/patches/mlx/backend/metal/compiled.cpp
+++ b/src/lib/mlx-cpp/patches/mlx/backend/metal/compiled.cpp
@@ -336,20 +336,19 @@ void Compiled::eval_gpu(
           /* dynamic_dims = */ false,
           /* use_big_index = */ false,
           /* work_per_thread = */ i > 3 ? 2 : 1);
-      if (i > 1) {
-        build_kernel(
-            kernel,
-            kernel_lib_ + "_strided_" + std::to_string(i) + "_large",
-            inputs_,
-            outputs_,
-            tape_,
-            is_constant_,
-            /* contiguous = */ false,
-            /* ndim = */ i,
-            /* dynamic_dims = */ false,
-            /* use_big_index = */ true,
-            /* work_per_thread = */ i > 3 ? 4 : 1);
-      }
+      // Negative strides force large mode even for small arrays.
+      build_kernel(
+          kernel,
+          kernel_lib_ + "_strided_" + std::to_string(i) + "_large",
+          inputs_,
+          outputs_,
+          tape_,
+          is_constant_,
+          /* contiguous = */ false,
+          /* ndim = */ i,
+          /* dynamic_dims = */ false,
+          /* use_big_index = */ true,
+          /* work_per_thread = */ i > 3 ? 4 : 1);
     }
     build_kernel(
         kernel,

--- a/src/lib/mlx-cpp/patches/mlx/backend/metal/compiled.cpp
+++ b/src/lib/mlx-cpp/patches/mlx/backend/metal/compiled.cpp
@@ -380,11 +380,12 @@ void Compiled::eval_gpu(
 
   // Collapse contiguous dims to route to a faster kernel if possible. Also
   // handle all broadcasting.
-  auto [contiguous, shape, strides] =
+  auto [contiguous, negative_strides, shape, strides] =
       compiled_collapse_contiguous_dims(inputs, outputs[0], is_constant_);
 
-  // Whether to use large index.
-  bool large = compiled_use_large_index(inputs, outputs, contiguous);
+  // Whether to use large index (also true for negative strides).
+  bool large =
+      negative_strides || compiled_use_large_index(inputs, outputs, contiguous);
 
   // Get the kernel from the lib
   int ndim = shape.size();

--- a/src/lib/mlxcel-core/build.rs
+++ b/src/lib/mlxcel-core/build.rs
@@ -176,7 +176,7 @@ fn main() {
 }
 
 /// Expected MLX git commit — must match GIT_TAG in mlx-cpp/CMakeLists.txt.
-const MLX_EXPECTED_COMMIT: &str = "e9463bbfc1a7cd9e0e6b96aaa3068a316e234a63";
+const MLX_EXPECTED_COMMIT: &str = "57c66cac7cb3e5b1eb350488a61f1506b40d39f8";
 
 /// Purge stale cached MLX build artifacts before CMake runs.
 ///


### PR DESCRIPTION
## Summary
- Bump all three synchronized MLX pin locations to upstream `57c66cac7cb3e5b1eb350488a61f1506b40d39f8` (`Patch bump to 0.32.1`, ml-explore/mlx#3816).
- Fix mlxcel's Metal compiled patch overlay for the latest `compiled_collapse_contiguous_dims` return shape by binding `negative_strides`, selecting the large-index path for negative strides, and generating the rank-1 large strided Metal kernel that upstream MLX now needs.
- Note the relevant upstream range includes ml-explore/mlx#3804 (`Fix fp quantized matvec for output dim < 8`), ml-explore/mlx#3728 (`Add math mode option for custom Metal kernels`), and ml-explore/mlx#3720 (`Fix compiled kernel correctness for negative-strided inputs`).

## Test plan
- [x] `cargo build --release --bin mlxcel-bench-decode`
- [x] `cargo test --release -p mlxcel-core sparse_v_kernel_threshold_zero_matches_graph`
- [x] `cargo test --release -p mlxcel-core delegated_fused_kernel_matches_reference_over_200_steps`
- [x] `cargo test --release -p mlxcel-core delegated_steel_envelope_matches_cold_only_fused_over_200_steps`
- [x] `python3 scripts/ci/check_cross_repo_refs.py`

Closes #703

