### PR TITLE
perf(moe): record CUDA fused-MoE Dff cap provenance and decline test

### DIFF
--- a/docs/benchmark_results/fused-moe-decode-kernel-design.md
+++ b/docs/benchmark_results/fused-moe-decode-kernel-design.md
@@ -168,7 +168,7 @@ falls back to the proven `gather_qmm` / `SwitchGLU` path automatically. Set
 | `MLXCEL_FUSED_MOE` | unset (on) | On by default. Set to `0` (also `false`/`off`/`no`, case-insensitive) to force the proven `gather_qmm` / `SwitchGLU` path; any other value, or leaving it unset, keeps the kernel on. |
 | `MLXCEL_FUSED_MOE_SGY` | 8 | Simdgroups per threadgroup (one output row each). Tune per hardware. |
 | `MLXCEL_FUSED_MOE_RELU2` | unset (off) | Enable the squared-ReLU (fc1/relu²/fc2) fused path used by nemotron-class experts. Correct but measured performance-neutral on nemotron-h; kept for a future MoE-dominated squared-ReLU model. |
-| `MLXCEL_FUSED_MOE_MAX_DFF` | 4096 (Metal) / 8192 (CUDA) | Expert-intermediate (Dff) upper bound. Above it, `forward_fused_kernel` declines and the caller falls back to `gather_qmm`. The fused path wins only while `gather_qmm` underutilizes the GPU (small experts); for large experts `gather_qmm` already saturates and the extra dispatch plus global-memory activation staging is a net loss. The break-even is backend-dependent, so the default is chosen from the live backend (`mlx::core::metal::is_available()`). M1 Ultra measurements: Dff 704..2560 gain +3.5% to +15.4%, Dff 6400 (phi-3.5-moe) loses 5.9%, Dff 14336 (mixtral) loses 21%, so Metal keeps 4096. On CUDA the crossover is higher; re-measured on GB10 under MLX pin e9463bb (#626) it collapsed from the old ~13-14k to ~8000 (Dff 6400 +5%, 8192 break-even, 14336 -1.2%; see the 2026-07-03 addendum), so the CUDA default is 8192. An explicit value overrides both backends. |
+| `MLXCEL_FUSED_MOE_MAX_DFF` | 4096 (Metal) / 8192 (CUDA) | Expert-intermediate (Dff) upper bound. Above it, `forward_fused_kernel` declines and the caller falls back to `gather_qmm`. The fused path wins only while `gather_qmm` underutilizes the GPU (small experts); for large experts `gather_qmm` already saturates and the extra dispatch plus global-memory activation staging is a net loss. The break-even is backend-dependent, so the default is chosen from the live backend (`mlx::core::metal::is_available()`). M1 Ultra measurements: Dff 704..2560 gain +3.5% to +15.4%, Dff 6400 (phi-3.5-moe) loses 5.9%, Dff 14336 (mixtral) loses 21%, so Metal keeps 4096. On CUDA the crossover is higher; re-measured on GB10 under MLX pin e9463bb (#626) it collapsed from the old ~13-14k to ~8000 (Dff 6400 +5%, 8192 break-even, 14336 -1.2%; see the 2026-07-03 addendum), so the CUDA default is 8192. That sweep predates the 0.32.1 MLX pin (#703/#704); 8192 is carried forward as the conservative documented-data-based default and a GB10 re-validation on the current pin is pending (see the 2026-07-09 addendum). An explicit value overrides both backends. |
 
 ### Measured decode gains (M1 Ultra, `MLXCEL_FUSED_MOE=1`)
 
@@ -348,3 +348,40 @@ Findings:
 tok/s, break-even). Mixtral (Dff 14336) stays on `gather_qmm`. The env var
 `MLXCEL_FUSED_MOE_MAX_DFF` still overrides both backends. Raw per-run data:
 `fused-moe-decode-dff-sweep-gb10-2026-07-03.csv`.
+
+### 2026-07-09 addendum: CUDA default provenance and pending re-validation on MLX 0.32.1
+
+The backend-aware policy above is unchanged: Metal keeps 4096, CUDA keeps 8192,
+`MLXCEL_FUSED_MOE_MAX_DFF` overrides both. This addendum records the provenance
+of the 8192 CUDA default honestly against the current binaries and states what
+is still owed.
+
+**Provenance.** The 8192 CUDA default comes from the GB10 sweep in the 2026-07-03
+addendum, run on the DGX Spark (sm_121, CUDA 13.0) under MLX pin e9463bb (#626),
+with the backend-aware code landing in #643. Since then the MLX pin has advanced
+to 0.32.1 (#703/#704, commit 57c66cac). 8192 has not been re-measured on the
+0.32.1 binaries; it is carried forward as the documented-data-based default, not
+a value confirmed on the current pin.
+
+**Why keeping 8192 is safe under pin drift.** 8192 is the conservative floor of
+the measured crossover (the break-even point), not the 14336 regression edge. On
+the e9463bb sweep the fused path won clearly through Dff 6400 (phi-3.5-moe +5%)
+and only broke even at 8192, so a pin bump would have to move the crossover below
+8192 to make the default a regression, and even then a break-even model would
+lose only a few percent, recoverable with the env override. Metal is unaffected:
+it stays at 4096 and its dispatch is byte-identical to before, proven by the
+`switch_layers` unit tests (`fused_moe_max_dff_default_is_backend_aware_and_env_overrides`
+and `fused_moe_dff_above_cap_declines_and_at_cap_dispatches`).
+
+**Pending: GB10 re-validation on MLX 0.32.1.** A re-measurement on the current
+pin is owed before the 8192 default is treated as confirmed rather than
+carried-forward. It requires CUDA/GB10 hardware, which was not reachable when
+this note was written. To run it, reproduce the 2026-07-03 harness on the current
+binaries: `mlxcel-bench-decode`, prompt `"Hello, how are you today?"`, 100 decode
+tokens after a 20-token warmup, median of 3. Force each side with the env var
+(`MLXCEL_FUSED_MOE_MAX_DFF=1` selects the `gather_qmm` fallback, `=20000` selects
+the fused kernel) and sweep the same Dff points that bracket the crossover:
+phi-3.5-moe (6400), llama-4-scout-17b (8192), mixtral-8x7b (14336), with lfm2-8b-a1b
+(1792) as a low-expert control. If the ratio=1.0 crossover on 0.32.1 lands away
+from ~8000, update `FUSED_MOE_MAX_DFF_CUDA` and this section together; otherwise
+record the confirmation and drop the "pending" note.

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -79,6 +79,15 @@ const FUSED_MOE_MAX_DFF_METAL: i32 = 4096;
 /// 8192 break-even boundary, which stays well below the 14336 regression while
 /// capturing the phi-3.5-moe / llama-4-scout mid-size experts that the old 4096
 /// default silently declined. The env var overrides this on both backends.
+///
+/// Provenance caveat: that GB10 sweep ran on MLX pin e9463bb (#626). The pin has
+/// since advanced to 0.32.1 (#703/#704, commit 57c66cac), so 8192 is carried
+/// forward as the documented-data-based default, not a value re-measured on the
+/// current binaries. It is deliberately the conservative floor of the measured
+/// crossover (the 8192 break-even, not the 14336 regression edge), so MLX pin
+/// drift cannot flip the default into a regression. A GB10 re-validation on the
+/// 0.32.1 pin is pending; see the pending re-validation note in
+/// `docs/benchmark_results/fused-moe-decode-kernel-design.md`.
 const FUSED_MOE_MAX_DFF_CUDA: i32 = 8192;
 
 /// Resolve the fused-MoE Dff upper bound. An explicit positive
@@ -87,6 +96,16 @@ const FUSED_MOE_MAX_DFF_CUDA: i32 = 8192;
 /// measured crossover). Split out as a pure function so the backend-aware
 /// default is unit-testable without mutating process-global env or querying the
 /// live device; `metal_available` mirrors `mlx::core::metal::is_available()`.
+///
+/// The cap is family-agnostic: it governs every SwitchGLU MoE model uniformly
+/// (Mixtral, Qwen3-MoE, OLMoE, phi-3.5-moe, gemma4, dots.llm1, and the rest of
+/// the module `Used by:` list). The backend is resolved at runtime via
+/// `metal_is_available()` (at the call site in `forward_fused_kernel`) rather
+/// than a `cfg!(feature = "cuda")` compile-time switch, so a single binary built
+/// with both backends picks the cap from the live device. This matches the fused
+/// kernel's own runtime dispatch: `run_fused_moe_two_kernel` selects the
+/// `cuda_kernel` port when `metal::is_available()` is false, so gating the cap
+/// the same way keeps the decision consistent with which kernel actually runs.
 pub(crate) fn fused_moe_max_dff_from(env: Option<&str>, metal_available: bool) -> i32 {
     env.and_then(|s| s.parse::<i32>().ok())
         .filter(|v| *v > 0)
@@ -716,6 +735,36 @@ mod tests {
                 fused_moe_max_dff_from(Some(bad), false),
                 FUSED_MOE_MAX_DFF_CUDA
             );
+        }
+    }
+
+    #[test]
+    fn fused_moe_dff_above_cap_declines_and_at_cap_dispatches() {
+        // `forward_fused_kernel` declines the fused path (falling back to
+        // gather_qmm) exactly when `dff > max_dff`. Pin that boundary against the
+        // resolved cap for both backends and an explicit override, so the decline
+        // predicate cannot silently drift away from the cap it enforces.
+        let declines =
+            |dff: i32, env: Option<&str>, metal: bool| dff > fused_moe_max_dff_from(env, metal);
+
+        // Metal default 4096: at the cap dispatches, one above declines.
+        assert!(!declines(FUSED_MOE_MAX_DFF_METAL, None, true));
+        assert!(declines(FUSED_MOE_MAX_DFF_METAL + 1, None, true));
+
+        // CUDA default 8192: phi-3.5-moe (Dff 6400) and llama-4-scout (Dff 8192)
+        // dispatch, mixtral (Dff 14336) declines.
+        assert!(!declines(6400, None, false));
+        assert!(!declines(FUSED_MOE_MAX_DFF_CUDA, None, false));
+        assert!(declines(FUSED_MOE_MAX_DFF_CUDA + 1, None, false));
+        assert!(declines(14336, None, false));
+
+        // Metal keeps 4096, so the same mid-size experts decline there.
+        assert!(declines(6400, None, true));
+
+        // An explicit override moves the decline boundary on both backends.
+        for metal in [true, false] {
+            assert!(!declines(14336, Some("16384"), metal));
+            assert!(declines(16385, Some("16384"), metal));
         }
     }
 


### PR DESCRIPTION
## Summary

Complete the backend-aware fused-MoE `Dff` cap for #330 by recording the honest provenance of the CUDA default and pinning the decline boundary with a test. The cap-resolution logic itself (Metal 4096 / CUDA 8192, the `MLXCEL_FUSED_MOE_MAX_DFF` override, the pure `fused_moe_max_dff_from`, and the 2026-07-03 GB10 sweep) already landed in #643; that work was measured under MLX pin `e9463bb` (#626) and was never linked to #330. Since #643 the MLX pin advanced to 0.32.1 (#703/#704, commit `57c66cac`), so the CUDA default is now a carried-forward documented-data value, not one confirmed on current binaries. This PR closes that honesty gap, documents the runtime-vs-`cfg!` backend choice, adds a decline-boundary test, and formally closes #330. The cap value 8192 is unchanged.

## What changed

- `src/models/switch_layers.rs`: expanded the `FUSED_MOE_MAX_DFF_CUDA` doc comment with a provenance caveat (the 8192 sweep ran on MLX pin `e9463bb`/#626; the pin has since moved to 0.32.1/#703/#704, commit `57c66cac`; 8192 is the conservative crossover floor kept so pin drift cannot flip it into a regression; a GB10 re-validation on 0.32.1 is pending).
- `src/models/switch_layers.rs`: documented on `fused_moe_max_dff_from` that the cap is family-agnostic (governs every SwitchGLU MoE model per the module `Used by:` list) and that the backend is resolved at runtime via `metal_is_available()` rather than a `cfg!(feature = "cuda")` switch, matching the fused kernel's own runtime dispatch (`run_fused_moe_two_kernel` picks the `cuda_kernel` port when `metal::is_available()` is false).
- `src/models/switch_layers.rs`: added `fused_moe_dff_above_cap_declines_and_at_cap_dispatches`, a pure test pinning that `forward_fused_kernel` declines exactly when `dff > max_dff` at the cap boundary on both backends and under an explicit override.
- `docs/benchmark_results/fused-moe-decode-kernel-design.md`: added the 2026-07-09 addendum (CUDA default provenance, why keeping 8192 is safe under pin drift, and the pending GB10 re-validation on MLX 0.32.1 with the exact `mlxcel-bench-decode` harness to run it), and cross-referenced it from the `MLXCEL_FUSED_MOE_MAX_DFF` table row.

## Design notes

- The value 8192 is unchanged. Under pin drift the most conservative floor of the measured crossover (break-even at 8192, regression only at 14336) is the correct choice, so no re-tuning is done without hardware re-validation.
- Metal behavior is byte-identical by construction (still 4096). The diff is runtime-inert (doc comments, a doc file, and a test only); no compiled non-test code path changed.

## Test plan

Ran here (Apple M1 Ultra, Metal):

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --release --features metal,accelerate -p mlxcel --lib switch_layers` (8/8 pass, including the new `fused_moe_dff_above_cap_declines_and_at_cap_dispatches`; the successful release build subsumes `cargo check --lib --tests`)
- [x] `cargo clippy --features metal,accelerate -p mlxcel --lib --tests -- -D warnings` (clean)
- [x] Metal MoE decode smoke, dispatch unchanged: `mlxcel generate -m models/qwen1.5-moe-a2.7b-4bit -p "Hello" -n 32 --temp 0` produced coherent output at 96.58 tok/s on Apple GPU (Metal), exercising the fused MoE decode path (Dff below the 4096 Metal cap, so it dispatches).

Documented-data (not re-run in this PR): the CUDA default 8192 rests on the GB10 sweep in the 2026-07-03 addendum under MLX pin `e9463bb` (#626), landed in #643.

Pending (hardware-blocked): GB10 re-validation of the crossover on the current MLX 0.32.1 pin. No CUDA/GB10 hardware was reachable for this change; the how-to-run harness is recorded in the 2026-07-09 addendum.

Closes #330
