### PR TITLE
perf(server): incremental detokenization and streaming overhead cuts

### DIFF
--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -4044,7 +4044,13 @@ impl BatchScheduler {
             {
                 tracing::error!("State transition error: {err}");
             }
-            seq.decode_state.flush(&self.tokenizer);
+            // Forward any tail the incremental detokenizer held back (a final
+            // token carrying complete text plus a trailing incomplete UTF-8
+            // byte) as one last token event before Done, so streaming clients
+            // receive it (issue #633).
+            if let Some(tail) = seq.decode_state.flush(&self.tokenizer) {
+                let _ = seq.response_tx.send(GenerateEvent::Token(tail));
+            }
             let cached = seq.already_cached_tokens;
             let result = seq.decode_state.finish_with_cache(
                 seq.created_at,
@@ -4967,7 +4973,12 @@ impl BatchScheduler {
             if let Some(mut seq) = self.active_batch.remove(id) {
                 let tokens_generated = seq.generated_tokens.len();
 
-                seq.decode_state.flush(&self.tokenizer);
+                // Forward the incremental detokenizer's held tail as one final
+                // token event before Done, so streaming clients are not missing
+                // text the non-streaming result.text still carries (issue #633).
+                if let Some(tail) = seq.decode_state.flush(&self.tokenizer) {
+                    let _ = seq.response_tx.send(GenerateEvent::Token(tail));
+                }
                 let cached = seq.already_cached_tokens;
                 let result = seq.decode_state.finish_with_cache(
                     seq.created_at,

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -2236,6 +2236,7 @@ impl BatchScheduler {
         match req {
             ModelRequest::Generate {
                 prompt,
+                prompt_token_ids,
                 options,
                 images,
                 audio,
@@ -2245,6 +2246,7 @@ impl BatchScheduler {
             } => {
                 self.enqueue_request(
                     prompt,
+                    prompt_token_ids,
                     options,
                     images,
                     audio,
@@ -2264,6 +2266,7 @@ impl BatchScheduler {
     fn enqueue_request(
         &mut self,
         prompt: String,
+        prompt_token_ids: Option<Vec<i32>>,
         options: ServerGenerateOptions,
         images: Vec<Vec<u8>>,
         audio: Vec<Vec<u8>>,
@@ -2271,16 +2274,24 @@ impl BatchScheduler {
         response_tx: mpsc::Sender<GenerateEvent>,
         cancelled: Arc<AtomicBool>,
     ) {
-        let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
-        let token_ids = match self.tokenizer.encode(&prompt, add_special) {
-            Ok(ids) => ids,
-            Err(err) => {
-                let _ =
-                    response_tx.send(GenerateEvent::Error(format!("Tokenization error: {err}")));
-                return;
-            }
+        // Prefer the ids tokenized on the request-dispatch thread (issue #633);
+        // fall back to scheduler-side tokenization when the dispatcher had no
+        // pre-tokenizer. `tokenize_prompt_for_generation` is the shared
+        // `add_special` convention so both paths are byte-identical.
+        let mut prompt_tokens: Vec<i32> = match prompt_token_ids {
+            Some(ids) => ids,
+            None => match crate::server::model_provider::tokenize_prompt_for_generation(
+                &self.tokenizer,
+                &prompt,
+            ) {
+                Ok(ids) => ids,
+                Err(err) => {
+                    let _ = response_tx
+                        .send(GenerateEvent::Error(format!("Tokenization error: {err}")));
+                    return;
+                }
+            },
         };
-        let mut prompt_tokens: Vec<i32> = token_ids.iter().map(|&x| x as i32).collect();
 
         // Empty-prompt guard (null/empty-cache safety):
         //

--- a/src/server/batch/speculative_burst.rs
+++ b/src/server/batch/speculative_burst.rs
@@ -1773,7 +1773,11 @@ fn finalize_burst_success(
     }
 
     let tokens_generated = seq.generated_tokens.len();
-    seq.decode_state.flush(ctx.tokenizer);
+    // Forward the incremental detokenizer's held tail as one final token event
+    // before Done so streaming clients receive it (issue #633).
+    if let Some(tail) = seq.decode_state.flush(ctx.tokenizer) {
+        let _ = seq.response_tx.send(GenerateEvent::Token(tail));
+    }
     let cached = seq.already_cached_tokens;
     let result = seq.decode_state.finish_with_cache(
         seq.created_at,

--- a/src/server/batch/xla_worker.rs
+++ b/src/server/batch/xla_worker.rs
@@ -233,6 +233,10 @@ impl XlaServeWorker {
         match req {
             ModelRequest::Generate {
                 prompt,
+                // The XLA worker tokenizes on its own engine thread; the
+                // dispatch-thread pre-tokenized ids (issue #633) are unused here
+                // (the XLA provider path never sets a pre-tokenizer).
+                prompt_token_ids: _,
                 options,
                 images,
                 audio,

--- a/src/server/batch/xla_worker.rs
+++ b/src/server/batch/xla_worker.rs
@@ -354,7 +354,13 @@ impl XlaServeWorker {
                         if !tail.is_empty() {
                             let _ = response_tx.send(GenerateEvent::Token(tail));
                         }
-                        detok.flush(&self.tokenizer);
+                        // Then release any tail the incremental detokenizer held
+                        // back (a final token carrying complete text plus a
+                        // trailing incomplete UTF-8 byte). It is the last output,
+                        // so it follows the stop-matcher tail (issue #633).
+                        if let Some(detok_tail) = detok.flush(&self.tokenizer) {
+                            let _ = response_tx.send(GenerateEvent::Token(detok_tail));
+                        }
                         let mut result = detok.finish(start, prompt_token_count, max_tokens);
                         // The engine knows the authoritative reason; prefer it over
                         // the count-based inference in `finish`.

--- a/src/server/diffusion_worker.rs
+++ b/src/server/diffusion_worker.rs
@@ -368,7 +368,11 @@ fn serve_streaming_request<G>(
 
     match result {
         Ok(finish_reason) => {
-            decode_state.flush(tokenizer);
+            // Forward the incremental detokenizer's held tail as one final token
+            // event before Done so streaming clients receive it (issue #633).
+            if let Some(tail) = decode_state.flush(tokenizer) {
+                let _ = response_tx.send(GenerateEvent::Token(tail));
+            }
             let mut gen_result: GenerationResult = decode_state.finish_with_cache(
                 start,
                 engine_prompt.len(),

--- a/src/server/diffusion_worker.rs
+++ b/src/server/diffusion_worker.rs
@@ -198,6 +198,9 @@ pub(crate) fn run_diffusion_worker_loop(
             }
             ModelRequest::Generate {
                 prompt,
+                // Diffusion workers tokenize internally; the dispatch-thread
+                // pre-tokenized ids (issue #633) are not used here.
+                prompt_token_ids: _,
                 options,
                 images,
                 audio,
@@ -496,6 +499,9 @@ pub(crate) fn run_llada2_worker_loop(
             }
             ModelRequest::Generate {
                 prompt,
+                // Diffusion workers tokenize internally; the dispatch-thread
+                // pre-tokenized ids (issue #633) are not used here.
+                prompt_token_ids: _,
                 options,
                 images,
                 audio,

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -35,6 +35,13 @@ use crate::server::state::BatchMetrics;
 pub(crate) enum ModelRequest {
     Generate {
         prompt: String,
+        /// Pre-tokenized prompt ids, produced on the request-dispatch thread via
+        /// [`tokenize_prompt_for_generation`] (issue #633). When `Some`, the
+        /// scheduler uses these directly instead of tokenizing `prompt` on its
+        /// own thread; `None` falls back to scheduler-side tokenization. The
+        /// `prompt` string is still carried for VLM prompt formatting (e.g.
+        /// Moondream3) and diagnostics.
+        prompt_token_ids: Option<Vec<i32>>,
         options: ServerGenerateOptions,
         /// Raw image bytes for VLM (empty for text-only)
         images: Vec<Vec<u8>>,
@@ -108,6 +115,13 @@ pub struct ModelProvider {
     /// Shared cross-request prompt-prefix KV cache.
     /// `None` when the feature is disabled by config.
     prompt_cache: Option<Arc<crate::server::prompt_cache::PromptCacheStore>>,
+    /// Tokenizer used to encode prompts on the request-dispatch (HTTP-side)
+    /// thread before enqueueing, so a long prompt no longer tokenizes on the
+    /// scheduler thread and stalls concurrent decode ticks (issue #633). `None`
+    /// on paths that do not pre-tokenize (legacy/XLA/tests); the scheduler then
+    /// tokenizes as before. Its encoding is byte-identical to the scheduler's
+    /// because both go through [`tokenize_prompt_for_generation`].
+    prompt_tokenizer: Option<Arc<crate::tokenizer::MlxcelTokenizer>>,
     /// Bounded wait applied during the decode phase of `drain_generation_events*`
     /// to detect a hung model worker.
     ///
@@ -220,6 +234,15 @@ impl ModelProvider {
             return Ok(provider);
         }
 
+        // Pre-tokenizer for the request-dispatch thread (issue #633). Loaded
+        // once here (borrowing `model_path` before it is moved into the worker
+        // constructor) so `send_generate_request_with_cancellation` can encode a
+        // prompt off the scheduler thread. A load failure leaves it `None` and
+        // the scheduler tokenizes as before, so this is never fatal.
+        let prompt_tokenizer = crate::tokenizer::load_tokenizer(&model_path)
+            .ok()
+            .map(std::sync::Arc::new);
+
         if config.no_batch {
             let mut provider = Self::new_with_legacy_worker(
                 model_path,
@@ -233,6 +256,7 @@ impl ModelProvider {
             // legacy path won't exercise it yet — `AppState` should still
             // be able to observe it via the model provider handle.
             provider.prompt_cache = prompt_cache_store;
+            provider.prompt_tokenizer = prompt_tokenizer;
             provider.decode_hang_timeout = decode_hang_timeout;
             // log a warning if the operator asked for
             // speculative decoding but selected `--no-batch`. The legacy
@@ -290,6 +314,7 @@ impl ModelProvider {
                 batch_metrics,
                 batch_observability,
             )?;
+            provider.prompt_tokenizer = prompt_tokenizer;
             provider.decode_hang_timeout = decode_hang_timeout;
             Ok(provider)
         }
@@ -341,6 +366,7 @@ impl ModelProvider {
             batch_metrics,
             batch_observability,
             prompt_cache: None,
+            prompt_tokenizer: None,
             decode_hang_timeout: DECODE_HANG_TIMEOUT,
             _worker_handle: worker_handle,
         })
@@ -390,6 +416,7 @@ impl ModelProvider {
             batch_metrics,
             batch_observability,
             prompt_cache: None,
+            prompt_tokenizer: None,
             decode_hang_timeout: DECODE_HANG_TIMEOUT,
             _worker_handle: worker_handle,
         })
@@ -677,6 +704,7 @@ impl ModelProvider {
             batch_metrics,
             batch_observability,
             prompt_cache: prompt_cache_store,
+            prompt_tokenizer: None,
             decode_hang_timeout: DECODE_HANG_TIMEOUT,
             _worker_handle: worker_handle,
         })
@@ -762,6 +790,7 @@ impl ModelProvider {
             batch_metrics,
             batch_observability,
             prompt_cache: None,
+            prompt_tokenizer: None,
             decode_hang_timeout: DECODE_HANG_TIMEOUT,
             _worker_handle: worker_handle,
         })
@@ -1020,9 +1049,26 @@ impl ModelProvider {
     ) -> Result<mpsc::Receiver<GenerateEvent>> {
         let (response_tx, response_rx) = mpsc::channel();
 
+        // Tokenize on this (request-dispatch / HTTP-side) thread when a
+        // pre-tokenizer is available, so a long prompt no longer stalls the
+        // scheduler thread's decode loop (issue #633). A tokenization failure
+        // falls back to `None` so the scheduler encodes it and surfaces the
+        // error through the normal response channel.
+        let prompt_token_ids = self.prompt_tokenizer.as_ref().and_then(|tok| {
+            tokenize_prompt_for_generation(tok, &prompt)
+                .map_err(|err| {
+                    tracing::debug!(
+                        "HTTP-side prompt tokenization failed ({err}); deferring to scheduler"
+                    );
+                    err
+                })
+                .ok()
+        });
+
         self.request_tx
             .send(ModelRequest::Generate {
                 prompt,
+                prompt_token_ids,
                 options,
                 images,
                 audio,
@@ -1034,6 +1080,22 @@ impl ModelProvider {
 
         Ok(response_rx)
     }
+}
+
+/// Tokenize a rendered prompt into `i32` ids using the same `add_special`
+/// convention the scheduler applies (issue #633).
+///
+/// `add_special` is suppressed when the prompt already begins with a literal BOS
+/// marker (`<bos>` / `<s>`), matching `BatchScheduler::enqueue_request` so that
+/// pre-tokenizing on the dispatch thread is byte-identical to tokenizing on the
+/// scheduler thread. This is the single source of truth for both sites.
+pub(crate) fn tokenize_prompt_for_generation(
+    tokenizer: &crate::tokenizer::MlxcelTokenizer,
+    prompt: &str,
+) -> Result<Vec<i32>> {
+    let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
+    let ids = tokenizer.encode(prompt, add_special)?;
+    Ok(ids.iter().map(|&x| x as i32).collect())
 }
 
 fn send_shutdown_signal(request_tx: &mpsc::Sender<ModelRequest>) -> bool {

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -2173,22 +2173,36 @@ impl StreamingDecodeState {
     }
 
     /// Flush any remaining windowed text (including an unresolved trailing
-    /// incomplete sequence) at the end of generation.
+    /// incomplete sequence) at the end of generation, returning the flushed
+    /// delta so streaming callers can emit it as one final token event.
+    ///
+    /// This return value is load-bearing: `on_token` holds back the WHOLE window
+    /// while its tail is an incomplete UTF-8 sequence (a single token can carry
+    /// complete text plus a trailing incomplete byte), so if generation stops on
+    /// such a token the complete text is still buffered here. A streaming caller
+    /// that ignores the return would append it to `generated_text` (seen by the
+    /// non-streaming `result.text`) but never send it to the client. Every
+    /// streaming finish site must forward this delta before its `Done`/end event.
     ///
     /// Unlike [`Self::on_token`], the trailing-U+FFFD guard is not applied: any
     /// bytes that never completed a UTF-8 sequence are emitted here as U+FFFD
     /// replacement characters so that the streamed output matches a
     /// whole-history decode. The window prefix ended on a complete boundary, so
     /// `prefix_text` is a genuine prefix of `new_text` and the slice is safe.
-    pub fn flush(&mut self, tokenizer: &MlxcelTokenizer) {
+    #[must_use = "the flushed tail must be streamed to the client, not dropped"]
+    pub fn flush(&mut self, tokenizer: &MlxcelTokenizer) -> Option<String> {
         let prefix_text = self.decode_window(tokenizer, self.prefix_offset, self.read_offset);
         let new_text = self.decode_window(tokenizer, self.prefix_offset, self.all_ids.len());
-        if new_text.len() > prefix_text.len() {
+        let flushed = if new_text.len() > prefix_text.len() {
             let delta = self.window_delta(tokenizer, &prefix_text, &new_text);
             self.generated_text.push_str(&delta);
-        }
+            (!delta.is_empty()).then_some(delta)
+        } else {
+            None
+        };
         self.prefix_offset = self.all_ids.len();
         self.read_offset = self.all_ids.len();
+        flushed
     }
 
     #[allow(dead_code)]

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -2014,44 +2014,122 @@ pub(crate) fn build_generation_result_with_cache(
     }
 }
 
-/// Maximum number of bytes accumulated in the byte-fallback buffer before the
-/// buffer is force-flushed as replacement characters to avoid holding tokens
-/// indefinitely on pathological model outputs.
-const BYTE_FALLBACK_BUFFER_MAX: usize = 4;
+/// Maximum number of unemitted trailing tokens the incremental detokenizer will
+/// hold while an incomplete UTF-8 sequence is still forming before it force-emits
+/// them (rendering any still-incomplete bytes as U+FFFD replacement characters).
+///
+/// A legitimate incomplete UTF-8 character is at most four bytes, i.e. at most
+/// four byte-fallback `<0xXX>` tokens (or a handful of split byte-level BPE
+/// pieces), so this bound is only ever reached on degenerate output that emits
+/// an unbounded run of invalid bytes. Capping the held window keeps the
+/// per-token decode cost O(window) instead of letting it grow to O(sequence
+/// length) on such input.
+const MAX_HELD_TOKENS: usize = 32;
 
 /// Incremental, byte-fallback-safe detokenizer for streaming generation.
 ///
-/// Owns the running token-id buffer and emits only the newly-resolved UTF-8
-/// suffix as each token arrives, holding back incomplete multi-byte sequences
-/// (byte-fallback `<0xXX>` tokens and split byte-level BPE pieces) until they
-/// form valid UTF-8. This is the canonical detokenizer for the server's
-/// streaming responses and is also reused by the offline interactive chat
-/// REPL (epic #92 / issue #96) so the two surfaces never diverge.
+/// Emits only the newly-resolved UTF-8 suffix as each token arrives, holding
+/// back incomplete multi-byte sequences (byte-fallback `<0xXX>` tokens and split
+/// byte-level BPE pieces) until they form valid UTF-8. This is the canonical
+/// detokenizer for the server's streaming responses and is also reused by the
+/// offline interactive chat REPL (epic #92 / issue #96) so the two surfaces
+/// never diverge.
+///
+/// ## Incremental windowing (issue #633)
+///
+/// Rather than re-decoding the entire token history on every token (which is
+/// O(N) per token and therefore O(N^2) over a full generation), only a bounded
+/// suffix *window* of the history is re-decoded. Two decodes are taken per
+/// token, both anchored at the same left boundary `prefix_offset`:
+///
+/// * `prefix_text = decode(all_ids[prefix_offset..read_offset])` — the text
+///   already emitted for the current window.
+/// * `new_text = decode(all_ids[prefix_offset..])` — that same text plus the
+///   newest, not-yet-emitted tokens.
+///
+/// Because both decodes share the `prefix_offset` left context, the shared
+/// prefix renders identically in each and cancels out, so the emitted delta
+/// `new_text[prefix_text.len()..]` is byte-identical to slicing a whole-history
+/// decode. This mirrors the mlx-lm `NaiveStreamingDetokenizer`
+/// (<https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/tokenizer_utils.py>)
+/// and the llama.cpp / vLLM incremental detokenizers. `read_offset` only ever
+/// advances to a position whose decoded text ends on a complete UTF-8 boundary,
+/// so `prefix_text` is always a genuine prefix of `new_text` and the byte slice
+/// never splits a multi-byte character.
+///
+/// This assumes the tokenizer's `decode` does not apply context-sensitive
+/// `clean_up_tokenization_spaces` rewriting across the window boundary, which
+/// holds for every tokenizer in the supported set (Llama, Qwen, Gemma,
+/// DeepSeek, Mixtral, ... all ship `clean_up_tokenization_spaces=false`); it is
+/// the same assumption the mlx-lm naive detokenizer makes.
 pub struct StreamingDecodeState {
+    /// Full running token-id history (prompt followed by generated tokens).
+    /// Retained for the window slices and for `finish_truncated`, but never
+    /// decoded in full on the hot path.
     all_ids: Vec<u32>,
-    prev_decoded_len: usize,
+    /// Left anchor of the re-decode window (token index into `all_ids`). See the
+    /// struct-level docs for how the shared-prefix cancellation keeps the
+    /// emitted delta byte-identical to a whole-history decode.
+    prefix_offset: usize,
+    /// Boundary between already-emitted tokens and the newest unemitted tokens
+    /// (token index into `all_ids`). Always advanced to a UTF-8-complete
+    /// position so it never splits a multi-byte character.
+    read_offset: usize,
     generated_text: String,
     completion_tokens: usize,
     first_token_time: Option<Instant>,
-    /// Buffer for raw bytes accumulated from consecutive byte-fallback tokens
-    /// (`<0xXX>`). Held until enough bytes arrive to form a valid UTF-8
-    /// sequence. Cleared on each successful decode or when a non-byte-fallback
-    /// token follows.
-    byte_fallback_buffer: Vec<u8>,
 }
 
 impl StreamingDecodeState {
-    pub fn new(tokenizer: &MlxcelTokenizer, prompt_tokens: &[i32]) -> Self {
+    pub fn new(_tokenizer: &MlxcelTokenizer, prompt_tokens: &[i32]) -> Self {
         let all_ids: Vec<u32> = prompt_tokens.iter().map(|&x| x as u32).collect();
-        let prev_decoded_len = tokenizer.decode(&all_ids, false).unwrap_or_default().len();
+        let read_offset = all_ids.len();
 
         Self {
             all_ids,
-            prev_decoded_len,
+            // Anchor the window at the very start so the first generated token's
+            // delta carries the full prompt as left context. This makes the
+            // first emitted byte identical to slicing a whole-history decode at
+            // the prompt boundary (the previous implementation's behaviour),
+            // including any leading-space handling at the prompt/generation seam.
+            prefix_offset: 0,
+            read_offset,
             generated_text: String::new(),
             completion_tokens: 0,
             first_token_time: None,
-            byte_fallback_buffer: Vec::new(),
+        }
+    }
+
+    /// Decode the token-id window `all_ids[start..end]` to text, tolerating
+    /// decode errors by yielding an empty string (matching the previous
+    /// `unwrap_or_default` behaviour on the full-history decode).
+    fn decode_window(&self, tokenizer: &MlxcelTokenizer, start: usize, end: usize) -> String {
+        tokenizer
+            .decode(&self.all_ids[start..end], false)
+            .unwrap_or_default()
+    }
+
+    /// The text newly emittable from the current window: the suffix of
+    /// `new_text` past the already-emitted `prefix_text`.
+    ///
+    /// Normally `prefix_text` is a genuine prefix of `new_text` (the window's
+    /// `read_offset` only advances to a UTF-8-complete boundary), so this is a
+    /// plain suffix. The fallback covers a decoder that retroactively rewrites
+    /// already-emitted text: the `tokenizers` `ByteFallback` decoder renders an
+    /// entire consecutive byte-token run as U+FFFD once it holds an incomplete
+    /// byte, which can change how an earlier byte in the same run rendered. In
+    /// that rare case `strip_prefix` fails; decoding only the un-emitted tail
+    /// tokens keeps streaming causal and never panics on a non-char-boundary
+    /// slice.
+    fn window_delta(
+        &self,
+        tokenizer: &MlxcelTokenizer,
+        prefix_text: &str,
+        new_text: &str,
+    ) -> String {
+        match new_text.strip_prefix(prefix_text) {
+            Some(rest) => rest.to_string(),
+            None => self.decode_window(tokenizer, self.read_offset, self.all_ids.len()),
         }
     }
 
@@ -2062,159 +2140,55 @@ impl StreamingDecodeState {
         self.completion_tokens += 1;
         self.all_ids.push(token_id as u32);
 
-        // --- Byte-fallback buffering ---
-        // Tokenizers that use byte-fallback (e.g. Gemma variants with
-        // `byte_fallback = true`) map each byte of a multi-byte UTF-8
-        // character to an individual token in the form `<0xXX>`. When decoded
-        // one token at a time, incomplete byte sequences produce U+FFFD
-        // replacement characters in the output.
+        // Re-decode only the bounded suffix window (see struct docs). Both
+        // decodes share the `prefix_offset` left context so the shared prefix
+        // cancels out and the delta is byte-identical to a whole-history decode.
+        let prefix_text = self.decode_window(tokenizer, self.prefix_offset, self.read_offset);
+        let new_text = self.decode_window(tokenizer, self.prefix_offset, self.all_ids.len());
+
+        // Hold back an incomplete trailing UTF-8 sequence: a byte-fallback or
+        // byte-level piece that only decodes to U+FFFD until the completing
+        // token arrives. Emitting it now would corrupt the stream because the
+        // byte offset shifts when the replacement character resolves into a
+        // shorter real character. The window is re-decoded on the next token, so
+        // nothing is lost by waiting.
         //
-        // We detect byte-fallback tokens by looking up the raw token piece. If
-        // the piece matches `<0xXX>`, we accumulate the raw byte into a
-        // dedicated buffer and defer emission until the buffer forms valid
-        // UTF-8. Once a non-byte-fallback token arrives, any remaining bytes in
-        // the buffer are force-flushed as replacement characters.
-        //
-        // The buffer is also bounded to BYTE_FALLBACK_BUFFER_MAX bytes to
-        // prevent indefinite buffering on pathological inputs; excess bytes are
-        // force-flushed as replacement characters.
-        if let Some(piece) = tokenizer.token_piece(token_id as u32)
-            && let Some(byte_val) = parse_byte_fallback_token(&piece)
-        {
-            self.byte_fallback_buffer.push(byte_val);
-
-            // Force-flush if buffer exceeds the maximum size (guards
-            // against unbounded growth on unusual model outputs).
-            if self.byte_fallback_buffer.len() >= BYTE_FALLBACK_BUFFER_MAX {
-                return self.flush_byte_fallback_buffer();
-            }
-
-            // Try to decode the buffered bytes as UTF-8.
-            match std::str::from_utf8(&self.byte_fallback_buffer) {
-                Ok(decoded) if !decoded.is_empty() => {
-                    let decoded = decoded.to_string();
-                    self.byte_fallback_buffer.clear();
-                    self.generated_text.push_str(&decoded);
-                    // Advance prev_decoded_len by syncing with the full
-                    // re-decode so that subsequent tokens start from the
-                    // right position.
-                    let full_text = tokenizer.decode(&self.all_ids, false).unwrap_or_default();
-                    self.prev_decoded_len = safe_emit_boundary(&full_text);
-                    return Some(decoded);
-                }
-                _ => {
-                    // Incomplete sequence -- hold in buffer, emit nothing.
-                    return None;
-                }
-            }
-        }
-
-        // Non-byte-fallback token: flush any leftover byte-fallback bytes as
-        // replacement characters before continuing with the normal decode path.
-        if !self.byte_fallback_buffer.is_empty() {
-            let flushed = self.flush_byte_fallback_buffer();
-            // Re-run the normal path for the current (non-byte-fallback) token.
-            // The flush already updated prev_decoded_len, so the subsequent
-            // re-decode will pick up where it left off.
-            let extra = self.emit_regular_token(tokenizer);
-            return match (flushed, extra) {
-                (Some(a), Some(b)) => Some(a + &b),
-                (Some(a), None) => Some(a),
-                (None, Some(b)) => Some(b),
-                (None, None) => None,
-            };
-        }
-
-        self.emit_regular_token(tokenizer)
-    }
-
-    /// Emit text from the current `all_ids` using the standard re-decode path.
-    ///
-    /// Advances `prev_decoded_len` to the safe boundary. Returns the newly
-    /// emitted text, or `None` if nothing can be emitted yet.
-    fn emit_regular_token(&mut self, tokenizer: &MlxcelTokenizer) -> Option<String> {
-        let full_text = tokenizer.decode(&self.all_ids, false).unwrap_or_default();
-
-        // Find the safe emit boundary: skip trailing U+FFFD replacement characters.
-        // Byte-level BPE tokenizers split multi-byte UTF-8 sequences across tokens.
-        // Incomplete byte sequences decode as U+FFFD, but become valid characters
-        // once the completing token arrives. Emitting FFFD prematurely corrupts
-        // the output because the byte offset shifts when the replacement chars
-        // resolve into shorter real characters.
-        let safe_len = safe_emit_boundary(&full_text);
-
-        if safe_len <= self.prev_decoded_len {
+        // `MAX_HELD_TOKENS` force-emits on degenerate output that never
+        // completes a sequence, bounding the held window (and thus the per-token
+        // decode cost). A legitimate incomplete character never spans that many
+        // tokens.
+        let force = self.all_ids.len().saturating_sub(self.read_offset) >= MAX_HELD_TOKENS;
+        if new_text.len() <= prefix_text.len() || (!force && new_text.ends_with('\u{FFFD}')) {
             return None;
         }
 
-        let new_text = &full_text[self.prev_decoded_len..safe_len];
-        if new_text.is_empty() {
+        let delta = self.window_delta(tokenizer, &prefix_text, &new_text);
+        self.prefix_offset = self.read_offset;
+        self.read_offset = self.all_ids.len();
+        if delta.is_empty() {
             return None;
         }
-
-        self.generated_text.push_str(new_text);
-        self.prev_decoded_len = safe_len;
-        Some(new_text.to_string())
+        self.generated_text.push_str(&delta);
+        Some(delta)
     }
 
-    /// Flush the byte-fallback buffer to the output.
+    /// Flush any remaining windowed text (including an unresolved trailing
+    /// incomplete sequence) at the end of generation.
     ///
-    /// If the buffered bytes form valid UTF-8, emit the decoded string.
-    /// Otherwise emit one replacement character (U+FFFD) per buffered byte, in
-    /// line with the `ByteFallback` decoder's own fallback behaviour. In both
-    /// cases the buffer is cleared and `prev_decoded_len` is re-synced.
-    fn flush_byte_fallback_buffer(&mut self) -> Option<String> {
-        if self.byte_fallback_buffer.is_empty() {
-            return None;
-        }
-        let buf = std::mem::take(&mut self.byte_fallback_buffer);
-        let flushed = match std::str::from_utf8(&buf) {
-            Ok(s) => s.to_string(),
-            Err(_) => "\u{FFFD}".repeat(buf.len()),
-        };
-        // Advance prev_decoded_len by the exact byte length of what was just
-        // emitted. Using safe_emit_boundary on the full re-decode would advance
-        // past any trailing text from the next regular token (which has already
-        // been pushed into all_ids), causing that text to be silently dropped.
-        self.prev_decoded_len += flushed.len();
-
-        if flushed.is_empty() {
-            None
-        } else {
-            self.generated_text.push_str(&flushed);
-            Some(flushed)
-        }
-    }
-
-    /// Flush any remaining buffered text (including unresolved replacement chars)
-    /// at the end of generation.
-    ///
-    /// Also drains the byte-fallback buffer: any accumulated bytes that did not
-    /// form a complete UTF-8 sequence are emitted as U+FFFD replacement
-    /// characters so that the streamed output matches the non-streaming result.
+    /// Unlike [`Self::on_token`], the trailing-U+FFFD guard is not applied: any
+    /// bytes that never completed a UTF-8 sequence are emitted here as U+FFFD
+    /// replacement characters so that the streamed output matches a
+    /// whole-history decode. The window prefix ended on a complete boundary, so
+    /// `prefix_text` is a genuine prefix of `new_text` and the slice is safe.
     pub fn flush(&mut self, tokenizer: &MlxcelTokenizer) {
-        // Drain the byte-fallback buffer first. Any incomplete byte sequences
-        // are flushed as replacement characters here; we then skip past the
-        // corresponding replacement chars in the full-decode result below so
-        // they are not emitted a second time.
-        if !self.byte_fallback_buffer.is_empty() {
-            self.flush_byte_fallback_buffer();
-            // After a byte-fallback flush, prev_decoded_len sits at
-            // safe_emit_boundary (i.e. just before trailing U+FFFD chars
-            // from the incomplete sequence). Advance it past those trailing
-            // replacement chars so the normal emit path below does not
-            // re-emit them.
-            let full_text = tokenizer.decode(&self.all_ids, false).unwrap_or_default();
-            self.prev_decoded_len = full_text.len();
-            return;
+        let prefix_text = self.decode_window(tokenizer, self.prefix_offset, self.read_offset);
+        let new_text = self.decode_window(tokenizer, self.prefix_offset, self.all_ids.len());
+        if new_text.len() > prefix_text.len() {
+            let delta = self.window_delta(tokenizer, &prefix_text, &new_text);
+            self.generated_text.push_str(&delta);
         }
-
-        let full_text = tokenizer.decode(&self.all_ids, false).unwrap_or_default();
-        if full_text.len() > self.prev_decoded_len {
-            let remaining = &full_text[self.prev_decoded_len..];
-            self.generated_text.push_str(remaining);
-            self.prev_decoded_len = full_text.len();
-        }
+        self.prefix_offset = self.all_ids.len();
+        self.read_offset = self.all_ids.len();
     }
 
     #[allow(dead_code)]
@@ -2278,45 +2252,6 @@ impl StreamingDecodeState {
             self.generated_text.truncate(cut);
         }
         self.finish_with_cache(start, prompt_token_count, max_tokens, 0)
-    }
-}
-
-/// Find the byte position after the last non-U+FFFD character.
-/// Trailing replacement characters are buffered because they likely come from
-/// incomplete multi-byte UTF-8 sequences that will be completed by the next token.
-fn safe_emit_boundary(text: &str) -> usize {
-    text.char_indices()
-        .rev()
-        .find(|(_, c)| *c != '\u{FFFD}')
-        .map(|(i, c)| i + c.len_utf8())
-        .unwrap_or(0)
-}
-
-/// Detect a byte-fallback token piece and return the raw byte value.
-///
-/// Byte-fallback tokens have the form `<0xXX>` where `XX` is a two-digit
-/// hex value, e.g. `<0xE2>`, `<0x80>`, `<0x9C>`. These are produced by
-/// tokenizers whose model config has `byte_fallback = true` (common in Gemma
-/// and some Llama variants built with SentencePiece byte-fallback vocabulary).
-///
-/// Returns `None` for regular token pieces that do not match this pattern.
-///
-/// Used by: StreamingDecodeState (model_worker.rs)
-fn parse_byte_fallback_token(piece: &str) -> Option<u8> {
-    // Must be exactly 6 bytes: '<', '0', 'x', HI, LO, '>'
-    // Use byte-level checks so that `from_str_radix` never sees a leading '+'
-    // or '-' sign (defense-in-depth: e.g. `<0x+f>` would otherwise parse as
-    // byte 0x0F).
-    let bytes = piece.as_bytes();
-    if bytes.len() == 6
-        && &bytes[..3] == b"<0x"
-        && bytes[5] == b'>'
-        && bytes[3].is_ascii_hexdigit()
-        && bytes[4].is_ascii_hexdigit()
-    {
-        u8::from_str_radix(std::str::from_utf8(&bytes[3..5]).ok()?, 16).ok()
-    } else {
-        None
     }
 }
 

--- a/src/server/model_worker_tests.rs
+++ b/src/server/model_worker_tests.rs
@@ -136,7 +136,12 @@ fn simulate_byte_fallback_stream(
             chunks.push(chunk);
         }
     }
-    state.flush(tokenizer);
+    // Model a correct streaming client: the end-of-stream flush can carry real
+    // text the last token held back (complete text plus a trailing incomplete
+    // byte), so its return is part of the streamed output, not dropped.
+    if let Some(tail) = state.flush(tokenizer) {
+        chunks.push(tail);
+    }
     let start = Instant::now();
     let result = state.finish_with_cache(start, prompt_ids.len(), usize::MAX, 0);
     (chunks, result.text)
@@ -304,10 +309,12 @@ fn incremental_detok_truncated_mid_multibyte_holds_partial() {
         );
     }
 
-    // After flush the held partial surfaces as replacement char(s). The already
-    // streamed "Hello" is preserved and the whole result is byte-identical to a
-    // one-shot decode of exactly the truncated ids.
-    state.flush(&tokenizer);
+    // After flush the held partial surfaces as replacement char(s). The flush
+    // return is part of the stream, so a correct client accumulates it; the full
+    // streamed text and the non-streaming result.text are both byte-identical to
+    // a one-shot decode of exactly the truncated ids.
+    let flushed = state.flush(&tokenizer);
+    let full_streamed = format!("{streamed}{}", flushed.clone().unwrap_or_default());
     let result = state.finish_with_cache(std::time::Instant::now(), 0, usize::MAX, 0);
     let expected = tokenizer
         .decode(
@@ -317,6 +324,157 @@ fn incremental_detok_truncated_mid_multibyte_holds_partial() {
         .unwrap_or_default();
     assert!(result.text.starts_with("Hello"));
     assert_eq!(result.text, expected);
+    assert_eq!(
+        full_streamed, result.text,
+        "streamed deltas plus the flush return must equal the non-streaming text"
+    );
+}
+
+/// GPT-2/ByteLevel byte -> visible-char map (the map the ByteLevel decoder
+/// inverts). Lets a test build a vocab token whose decoded bytes end in the
+/// middle of a multibyte UTF-8 character. Unlike byte-fallback tokenizers, a
+/// ByteLevel tokenizer (Qwen, GPT-2, ...) can carry complete text plus an
+/// incomplete trailing byte inside a single token.
+fn bytelevel_byte_to_char() -> [char; 256] {
+    let mut is_direct = [false; 256];
+    let mut map = ['\0'; 256];
+    for (lo, hi) in [(0x21u32, 0x7E), (0xA1, 0xAC), (0xAE, 0xFF)] {
+        for b in lo..=hi {
+            is_direct[b as usize] = true;
+            map[b as usize] = char::from_u32(b).unwrap();
+        }
+    }
+    let mut n = 0u32;
+    for b in 0..256usize {
+        if !is_direct[b] {
+            map[b] = char::from_u32(256 + n).unwrap();
+            n += 1;
+        }
+    }
+    map
+}
+
+fn bytelevel_token(bytes: &[u8], map: &[char; 256]) -> String {
+    bytes.iter().map(|&b| map[b as usize]).collect()
+}
+
+/// A HuggingFace ByteLevel tokenizer whose token 0 decodes to "abc" plus the
+/// first byte of the 3-byte character "가" (i.e. a single token carrying
+/// complete text and an incomplete UTF-8 tail), and tokens 1/2 are the two
+/// remaining bytes of "가". This is the token shape that produces the
+/// "complete text held on a trailing incomplete byte" case the flush-return
+/// path must recover.
+fn stub_bytelevel_split_char() -> MlxcelTokenizer {
+    let map = bytelevel_byte_to_char();
+    let ga = "가".as_bytes(); // [0xEA, 0xB0, 0x80]
+    let t0 = bytelevel_token(&[b'a', b'b', b'c', ga[0]], &map);
+    let t1 = bytelevel_token(&[ga[1]], &map);
+    let t2 = bytelevel_token(&[ga[2]], &map);
+    let json = format!(
+        r#"{{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [],
+            "normalizer": null,
+            "pre_tokenizer": {{"type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true, "use_regex": true}},
+            "post_processor": null,
+            "decoder": {{"type": "ByteLevel", "add_prefix_space": true, "trim_offsets": true, "use_regex": true}},
+            "model": {{
+                "type": "BPE",
+                "dropout": null,
+                "unk_token": null,
+                "continuing_subword_prefix": null,
+                "end_of_word_suffix": null,
+                "fuse_unk": false,
+                "byte_fallback": false,
+                "vocab": {{"{t0}": 0, "{t1}": 1, "{t2}": 2}},
+                "merges": []
+            }}
+        }}"#
+    );
+    let tokenizer = tokenizers::Tokenizer::from_bytes(json.as_bytes())
+        .expect("failed to build ByteLevel split-char stub tokenizer");
+    MlxcelTokenizer::HuggingFace(tokenizer)
+}
+
+/// Regression for the flush-drop bug (PR #713 review): a single final token
+/// decodes to complete text ("abc") plus a trailing incomplete UTF-8 byte, then
+/// generation stops. `on_token` correctly holds the whole window (it ends in
+/// U+FFFD), so the complete "abc" is only recoverable from the `flush` return.
+/// A streaming client that ignores the return would lose "abc" while the
+/// non-streaming `result.text` keeps it. The streamed deltas plus the flush
+/// return must equal both `result.text` and a one-shot decode.
+#[test]
+fn incremental_detok_flush_returns_held_complete_text() {
+    let tokenizer = stub_bytelevel_split_char();
+    // Precondition: the stub really produces "complete + incomplete tail".
+    assert_eq!(
+        tokenizer.decode(&[0], false).unwrap_or_default(),
+        "abc\u{FFFD}",
+        "ByteLevel stub token 0 must decode to 'abc' + one replacement char"
+    );
+
+    let mut state = StreamingDecodeState::new(&tokenizer, &[]);
+    let held = state.on_token(0, &tokenizer);
+    assert!(
+        held.is_none(),
+        "a window ending in an incomplete byte must be held, not streamed: {held:?}"
+    );
+
+    // Generation stops here; flush must return the held text so it is streamed.
+    let flushed = state.flush(&tokenizer);
+    assert_eq!(
+        flushed.as_deref(),
+        Some("abc\u{FFFD}"),
+        "flush must return the held complete text plus the U+FFFD tail"
+    );
+
+    let streamed: String = flushed.unwrap_or_default();
+    let result = state.finish_with_cache(std::time::Instant::now(), 0, usize::MAX, 0);
+    assert_eq!(
+        streamed, result.text,
+        "streamed text must equal result.text"
+    );
+    assert_eq!(
+        result.text,
+        tokenizer.decode(&[0], false).unwrap_or_default(),
+        "result.text must equal a one-shot decode"
+    );
+}
+
+/// The mixed complete-plus-incomplete token followed by the completing bytes:
+/// mid-stream (generation continues) the completed text is emitted by `on_token`
+/// and `flush` has nothing to add. Byte-exact against a one-shot decode.
+#[test]
+fn incremental_detok_bytelevel_split_char_completes_mid_stream() {
+    let tokenizer = stub_bytelevel_split_char();
+    assert_eq!(
+        tokenizer.decode(&[0, 1, 2], false).unwrap_or_default(),
+        "abc가",
+        "ByteLevel stub tokens [0,1,2] must decode to 'abc가'"
+    );
+
+    let mut state = StreamingDecodeState::new(&tokenizer, &[]);
+    let mut chunks = Vec::new();
+    for tok in [0, 1, 2] {
+        if let Some(c) = state.on_token(tok, &tokenizer) {
+            chunks.push(c);
+        }
+    }
+    if let Some(tail) = state.flush(&tokenizer) {
+        chunks.push(tail);
+    }
+    let concatenated: String = chunks.concat();
+    let result = state.finish_with_cache(std::time::Instant::now(), 0, usize::MAX, 0);
+    assert_eq!(concatenated, "abc가");
+    assert_eq!(result.text, "abc가");
+    for chunk in &chunks {
+        assert!(
+            !chunk.contains('\u{FFFD}'),
+            "no chunk may contain a replacement char once the char completes: {chunk:?}"
+        );
+    }
 }
 
 /// Fuzz: many random valid UTF-8 strings streamed byte-by-byte must each be
@@ -454,10 +612,10 @@ fn byte_fallback_single_byte_ascii_emits_immediately() {
 /// `flush()` as replacement characters, matching the ByteFallback decoder's
 /// own behaviour for invalid byte sequences.
 ///
-/// Note: replacement chars from end-of-stream flushing are appended to
-/// `generated_text` but not emitted as streaming delta chunks. This is
-/// consistent with how the non-streaming decoder handles incomplete sequences
-/// (the final result includes U+FFFD; no intermediate chunk is sent).
+/// The U+FFFD tail is streamed exactly once, as the `flush` return (the final
+/// end-of-stream delta), never as a mid-stream `on_token` chunk. A streaming
+/// client that accumulates deltas therefore ends up byte-identical to the
+/// non-streaming `result.text` (issue #633 flush-return fix).
 #[test]
 fn byte_fallback_incomplete_sequence_flushed_at_end_of_stream() {
     // Token 5 = <0xE5>: alone, this is an incomplete UTF-8 sequence.
@@ -465,20 +623,34 @@ fn byte_fallback_incomplete_sequence_flushed_at_end_of_stream() {
     let prompt_ids: &[i32] = &[0]; // <BOS>
     let gen_ids: &[i32] = &[5]; // <0xE5> alone (incomplete)
 
-    let (chunks, generated) = simulate_byte_fallback_stream(&tokenizer, prompt_ids, gen_ids);
-
-    // An incomplete sequence must flush as one replacement char in the final text.
-    assert_eq!(
-        generated, "\u{FFFD}",
-        "incomplete byte-fallback must flush as U+FFFD"
+    // Stream without the flush merged, to inspect the mid-stream on_token chunks
+    // separately from the final flush delta.
+    let mut state = StreamingDecodeState::new(&tokenizer, prompt_ids);
+    let mut on_token_chunks = Vec::new();
+    for &tok in gen_ids {
+        if let Some(c) = state.on_token(tok, &tokenizer) {
+            on_token_chunks.push(c);
+        }
+    }
+    // Mid-stream, an incomplete sequence yields no chunk (nothing is emitted
+    // prematurely with a replacement char).
+    assert!(
+        on_token_chunks.is_empty(),
+        "incomplete byte-fallback must not emit a mid-stream chunk: {on_token_chunks:?}"
     );
 
-    // Incomplete sequences are not emitted as streaming chunks (they only appear
-    // in the final text after end-of-stream flush). So the chunks should be empty
-    // and the concatenation of streaming chunks does not include the replacement char.
-    assert!(
-        chunks.is_empty() || chunks.iter().all(|c| !c.contains('\u{FFFD}')),
-        "incomplete byte-fallback must not produce replacement chars in streaming chunks: {chunks:?}"
+    // The flush return carries the U+FFFD tail exactly once, so a streaming
+    // client receives it (previously it was appended to result.text but never
+    // streamed, dropping it from the client's accumulated text).
+    let flushed = state.flush(&tokenizer);
+    assert_eq!(flushed.as_deref(), Some("\u{FFFD}"));
+    let result =
+        state.finish_with_cache(std::time::Instant::now(), prompt_ids.len(), usize::MAX, 0);
+    assert_eq!(result.text, "\u{FFFD}");
+    assert_eq!(
+        flushed.unwrap_or_default(),
+        result.text,
+        "the streamed flush delta must equal the non-streaming result text"
     );
 }
 

--- a/src/server/model_worker_tests.rs
+++ b/src/server/model_worker_tests.rs
@@ -18,8 +18,7 @@ use image::{DynamicImage, ImageBuffer, ImageFormat, Rgb};
 
 use super::{
     StreamingDecodeState, build_generation_result, decode_request_images,
-    decode_request_images_with_limits, merge_config_stop_tokens, parse_byte_fallback_token,
-    resolve_end_of_turn_token_id, safe_emit_boundary,
+    decode_request_images_with_limits, merge_config_stop_tokens, resolve_end_of_turn_token_id,
 };
 use crate::SamplingConfig;
 use crate::server::media::ImageInputLimits;
@@ -116,68 +115,6 @@ fn build_generation_result_computes_finish_reason_and_generation_split() {
     assert_eq!(length.generation_only_ms, 0);
 }
 
-#[test]
-fn safe_emit_boundary_stops_before_trailing_replacement_chars() {
-    // ASCII string: boundary is at the end.
-    assert_eq!(safe_emit_boundary("hello"), 5);
-
-    // Replacement char at end: boundary stops before it.
-    let with_replacement = "ok\u{FFFD}";
-    let expected = "ok".len();
-    assert_eq!(safe_emit_boundary(with_replacement), expected);
-
-    // All replacement chars: boundary is 0.
-    assert_eq!(safe_emit_boundary("\u{FFFD}\u{FFFD}"), 0);
-
-    // Empty string: boundary is 0.
-    assert_eq!(safe_emit_boundary(""), 0);
-
-    // Multi-byte character followed by replacement char.
-    let mixed = "\u{AC00}\u{FFFD}"; // Korean syllable + replacement
-    assert_eq!(safe_emit_boundary(mixed), "\u{AC00}".len()); // 3 bytes
-}
-
-// ── parse_byte_fallback_token tests ─────────────────────────────────────────
-
-/// Tokens in the form `<0xXX>` with a two-digit hex suffix should return the
-/// corresponding byte value.
-#[test]
-fn parse_byte_fallback_token_recognises_hex_tokens() {
-    assert_eq!(parse_byte_fallback_token("<0x00>"), Some(0x00));
-    assert_eq!(parse_byte_fallback_token("<0x61>"), Some(0x61)); // 'a'
-    assert_eq!(parse_byte_fallback_token("<0xE5>"), Some(0xE5));
-    assert_eq!(parse_byte_fallback_token("<0xAB>"), Some(0xAB));
-    assert_eq!(parse_byte_fallback_token("<0xFF>"), Some(0xFF));
-}
-
-/// Tokens that do not match the exact `<0xXX>` pattern must return `None`.
-#[test]
-fn parse_byte_fallback_token_rejects_non_hex_tokens() {
-    assert_eq!(parse_byte_fallback_token("Hello"), None);
-    assert_eq!(parse_byte_fallback_token("<BOS>"), None);
-    assert_eq!(parse_byte_fallback_token("<0x>"), None); // too short
-    assert_eq!(parse_byte_fallback_token("<0xABC>"), None); // too long
-    assert_eq!(parse_byte_fallback_token("0xE5"), None); // missing angle brackets
-    assert_eq!(parse_byte_fallback_token("<0xGG>"), None); // invalid hex
-    assert_eq!(parse_byte_fallback_token(""), None);
-}
-
-/// Defense-in-depth: `u8::from_str_radix` accepts a leading `+` sign, so
-/// `<0x+f>` would previously parse as `Some(0x0f)`. Byte-level checks now
-/// ensure both digit positions must be ASCII hex digits, rejecting `+` and `-`.
-#[test]
-fn parse_byte_fallback_token_rejects_leading_sign() {
-    // These six-character strings match the length and prefix/suffix of a valid
-    // byte-fallback token but contain a leading sign in the hex digit area.
-    assert_eq!(parse_byte_fallback_token("<0x+f>"), None);
-    assert_eq!(parse_byte_fallback_token("<0x-f>"), None);
-    assert_eq!(parse_byte_fallback_token("<0x+F>"), None);
-    // Valid tokens continue to work after the byte-level guard is applied.
-    assert_eq!(parse_byte_fallback_token("<0xE5>"), Some(0xE5));
-    assert_eq!(parse_byte_fallback_token("<0x00>"), Some(0x00));
-    assert_eq!(parse_byte_fallback_token("<0xff>"), Some(0xff));
-}
-
 // ── Byte-fallback streaming regression tests ───────────────────
 
 /// Helper: simulate streaming a sequence of tokens and collect the emitted
@@ -203,6 +140,213 @@ fn simulate_byte_fallback_stream(
     let start = Instant::now();
     let result = state.finish_with_cache(start, prompt_ids.len(), usize::MAX, 0);
     (chunks, result.text)
+}
+
+/// Build a HuggingFace tokenizer whose vocab contains every byte-fallback token
+/// `<0x00>`..`<0xFF>` (token id == byte value) plus a couple of regular ASCII
+/// word tokens, with a `ByteFallback` decoder. This lets a test drive the
+/// incremental detokenizer with the exact byte sequence of any UTF-8 string, so
+/// byte-exactness can be checked against a one-shot decode of the same ids.
+fn stub_all_byte_fallback() -> MlxcelTokenizer {
+    let mut vocab_entries: Vec<String> = (0u16..=255)
+        .map(|b| format!("\"<0x{b:02X}>\": {b}"))
+        .collect();
+    // Regular word tokens after the 256 byte ids, exercising the mixed
+    // regular-piece + byte-fallback path.
+    vocab_entries.push("\"Hello\": 256".to_string());
+    vocab_entries.push("\"world\": 257".to_string());
+    let vocab = vocab_entries.join(", ");
+    let json = format!(
+        r#"{{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [],
+            "normalizer": null,
+            "pre_tokenizer": null,
+            "post_processor": null,
+            "decoder": {{"type": "ByteFallback"}},
+            "model": {{
+                "type": "BPE",
+                "dropout": null,
+                "unk_token": null,
+                "continuing_subword_prefix": null,
+                "end_of_word_suffix": null,
+                "fuse_unk": false,
+                "byte_fallback": true,
+                "vocab": {{{vocab}}},
+                "merges": []
+            }}
+        }}"#
+    );
+    let tokenizer = tokenizers::Tokenizer::from_bytes(json.as_bytes())
+        .expect("failed to build all-byte-fallback stub tokenizer");
+    MlxcelTokenizer::HuggingFace(tokenizer)
+}
+
+/// The `<0xXX>` token ids for the UTF-8 bytes of `s` in [`stub_all_byte_fallback`]
+/// (token id == byte value).
+fn byte_fallback_ids(s: &str) -> Vec<i32> {
+    s.bytes().map(|b| b as i32).collect()
+}
+
+/// Core byte-exactness invariant for the incremental detokenizer: streaming a
+/// token sequence one token at a time and concatenating the emitted chunks (plus
+/// the end-of-stream flush) must reproduce a one-shot `tokenizer.decode` of the
+/// whole sequence exactly. `prompt_ids` are treated as already-emitted context
+/// and excluded from the streamed output, matching production use.
+fn assert_stream_matches_oneshot(tokenizer: &MlxcelTokenizer, prompt_ids: &[i32], gen_ids: &[i32]) {
+    let mut all_ids: Vec<u32> = prompt_ids.iter().map(|&x| x as u32).collect();
+    all_ids.extend(gen_ids.iter().map(|&x| x as u32));
+    let full = tokenizer.decode(&all_ids, false).unwrap_or_default();
+    let prompt_decoded = tokenizer
+        .decode(
+            &prompt_ids.iter().map(|&x| x as u32).collect::<Vec<_>>(),
+            false,
+        )
+        .unwrap_or_default();
+    let expected = &full[prompt_decoded.len()..];
+
+    let (chunks, generated) = simulate_byte_fallback_stream(tokenizer, prompt_ids, gen_ids);
+    let concatenated: String = chunks.concat();
+
+    assert_eq!(
+        concatenated, generated,
+        "streamed chunks must equal the finished text"
+    );
+    assert_eq!(
+        generated,
+        expected,
+        "incremental detokenization must be byte-identical to a one-shot decode \
+         (prompt_ids={prompt_ids:?}, gen_ids len={})",
+        gen_ids.len()
+    );
+}
+
+/// Korean (Hangul, 3 bytes/char) streamed byte-by-byte must reconstruct exactly
+/// and match a one-shot decode; no chunk may contain a partial (U+FFFD) char.
+#[test]
+fn incremental_detok_korean_matches_oneshot() {
+    let tokenizer = stub_all_byte_fallback();
+    let text = "안녕하세요 세계";
+    let gen_ids = byte_fallback_ids(text);
+    assert_stream_matches_oneshot(&tokenizer, &[], &gen_ids);
+
+    let (chunks, generated) = simulate_byte_fallback_stream(&tokenizer, &[], &gen_ids);
+    assert_eq!(generated, text);
+    for chunk in &chunks {
+        assert!(
+            !chunk.contains('\u{FFFD}'),
+            "no streamed chunk may contain a replacement char: {chunk:?}"
+        );
+    }
+}
+
+/// Mixed ASCII, CJK, emoji, and Korean streamed byte-by-byte must be
+/// byte-identical to a one-shot decode.
+#[test]
+fn incremental_detok_mixed_scripts_match_oneshot() {
+    let tokenizer = stub_all_byte_fallback();
+    let text = "ab叫cd😀ef 안녕 gh€ij";
+    assert_stream_matches_oneshot(&tokenizer, &[], &byte_fallback_ids(text));
+}
+
+/// A regular word piece adjacent to multibyte byte-fallback runs (the common
+/// real-model shape) streams byte-exactly.
+#[test]
+fn incremental_detok_regular_piece_then_multibyte_matches_oneshot() {
+    let tokenizer = stub_all_byte_fallback();
+    // "Hello" (id 256), "world" (id 257), then a CJK char and an emoji as bytes.
+    let mut gen_ids = vec![256, 257];
+    gen_ids.extend(byte_fallback_ids("叫😀"));
+    assert_stream_matches_oneshot(&tokenizer, &[], &gen_ids);
+}
+
+/// A non-empty prompt is treated as already-emitted context: the streamed
+/// output starts after the prompt boundary and stays byte-exact across the
+/// prompt/generation seam even when the generation begins with a multibyte char.
+#[test]
+fn incremental_detok_with_prompt_context_matches_oneshot() {
+    let tokenizer = stub_all_byte_fallback();
+    let prompt_ids = byte_fallback_ids("prompt: ");
+    let gen_ids = byte_fallback_ids("안녕 world 叫");
+    assert_stream_matches_oneshot(&tokenizer, &prompt_ids, &gen_ids);
+}
+
+/// Stopping the stream mid-multibyte (as a stop-string truncation would) must
+/// never leave a partial character in the streamed chunks; the incomplete tail
+/// only surfaces (as U+FFFD) after the end-of-stream flush, matching a one-shot
+/// decode of the truncated ids.
+#[test]
+fn incremental_detok_truncated_mid_multibyte_holds_partial() {
+    let tokenizer = stub_all_byte_fallback();
+    // A regular word piece "Hello" (id 256, the shape real text takes) followed
+    // by the first two of the three bytes of "가" (EA B0 80) — i.e. a stop-string
+    // truncation that lands in the middle of a multibyte character.
+    let mut truncated = vec![256];
+    truncated.extend_from_slice(&byte_fallback_ids("가")[..2]);
+
+    let mut state = StreamingDecodeState::new(&tokenizer, &[]);
+    let mut chunks = Vec::new();
+    for &tok in &truncated {
+        if let Some(chunk) = state.on_token(tok, &tokenizer) {
+            chunks.push(chunk);
+        }
+    }
+    // Before flush, only the complete "Hello" may have been emitted; the
+    // incomplete "가" bytes must be held back — never streamed as a partial char.
+    let streamed: String = chunks.concat();
+    assert_eq!(streamed, "Hello", "partial multibyte must not be streamed");
+    for chunk in &chunks {
+        assert!(
+            !chunk.contains('\u{FFFD}'),
+            "no streamed chunk may contain a replacement char: {chunk:?}"
+        );
+    }
+
+    // After flush the held partial surfaces as replacement char(s). The already
+    // streamed "Hello" is preserved and the whole result is byte-identical to a
+    // one-shot decode of exactly the truncated ids.
+    state.flush(&tokenizer);
+    let result = state.finish_with_cache(std::time::Instant::now(), 0, usize::MAX, 0);
+    let expected = tokenizer
+        .decode(
+            &truncated.iter().map(|&x| x as u32).collect::<Vec<_>>(),
+            false,
+        )
+        .unwrap_or_default();
+    assert!(result.text.starts_with("Hello"));
+    assert_eq!(result.text, expected);
+}
+
+/// Fuzz: many random valid UTF-8 strings streamed byte-by-byte must each be
+/// byte-identical to a one-shot decode. Uses a deterministic xorshift PRNG so
+/// failures reproduce.
+#[test]
+fn incremental_detok_fuzz_matches_oneshot() {
+    let tokenizer = stub_all_byte_fallback();
+    // A pool of characters spanning 1/2/3/4-byte UTF-8 lengths plus ASCII
+    // whitespace so pieces land on and off char boundaries.
+    let pool: Vec<char> = "aZ9 \n.叫가한€😀🎉ßé中".chars().collect();
+
+    let mut seed: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut next = || {
+        // xorshift64
+        seed ^= seed << 13;
+        seed ^= seed >> 7;
+        seed ^= seed << 17;
+        seed
+    };
+
+    for _ in 0..300 {
+        let len = (next() % 40) as usize;
+        let mut s = String::new();
+        for _ in 0..len {
+            let c = pool[(next() as usize) % pool.len()];
+            s.push(c);
+        }
+        assert_stream_matches_oneshot(&tokenizer, &[], &byte_fallback_ids(&s));
+    }
 }
 
 /// A stream of three byte-fallback tokens [<0xE5>, <0x8F>, <0xAB>] that

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -803,7 +803,7 @@ async fn stream_chat_completion(
                         }
 
                         // Preserve token-position alignment for parallel tool
-                        // calls (upstream mlx-lm PR #1170, commit aa4f880). When
+                        // calls (upstream ml-explore/mlx-lm#1170, commit aa4f880). When
                         // the stream filter consumed a control-token delimiter
                         // (e.g. `<tool_call>`) it drained those bytes without
                         // producing output; with logprobs enabled, downstream

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -548,6 +548,26 @@ async fn non_stream_chat_completion(
     ))
 }
 
+/// Per-request streaming callback state (issue #633).
+///
+/// Collapses the three previously-separate `Arc<Mutex<…>>` values (tool-call
+/// accumulator, logprobs buffer, stream filter) into a single lock. The
+/// streaming callback runs on one blocking thread and the post-generation flush
+/// runs on that same thread afterwards, so the lock exists only to satisfy the
+/// `Send` bound on the `spawn_blocking` closure (an `Arc<RefCell<…>>` would not
+/// be `Send`); it is never contended. Combining them turns three lock/unlock
+/// pairs per token into one.
+struct StreamCallbackState {
+    /// Raw generated text accumulated for end-of-stream tool-call parsing. Only
+    /// appended to when tool-call parsing is enabled.
+    accumulated: String,
+    /// Stream filter that splits reasoning/content and strips structural tokens.
+    stream_filter: StreamFilter,
+    /// Per-`feed()` logprob buffer, drained in lockstep with the filter's
+    /// consumed/suppressed positions. Only used when logprobs are enabled.
+    lp_buffer: std::collections::VecDeque<Option<TokenLogprobData>>,
+}
+
 async fn stream_chat_completion(
     state: AppState,
     request: ChatCompletionRequest,
@@ -658,9 +678,10 @@ async fn stream_chat_completion(
         let request_id_inner = request_id_clone.clone();
         let model_id_inner = model_id_clone.clone();
 
-        let accumulated = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
-        let acc_clone = accumulated.clone();
-
+        // Single per-token lock (issue #633): the tool-call accumulator, the
+        // stream filter, and the parallel logprob buffer live behind one Mutex
+        // instead of three, so the hot callback locks once per token.
+        //
         // Stream filter: strips model-specific structural tokens from content
         // deltas so clients never see <|channel>, <|tool_call>, <think>, etc.
         // Always on — even non-tool chat requests need to suppress thinking-
@@ -675,34 +696,25 @@ async fn stream_chat_completion(
         // `reasoning_content` until the model emits the matching close marker
         // (`<channel|>` or `</think>`); otherwise the scratchpad leaks to the
         // client when max_tokens is reached mid-reasoning.
-        let stream_filter = std::sync::Arc::new(std::sync::Mutex::new(if primed_open_thinking {
-            StreamFilter::new_primed_open_thinking()
-        } else {
-            StreamFilter::new()
+        //
+        // The logprob buffer holds one entry per `feed()` call. The stream
+        // filter buffers incoming text fragments to handle delimiter matching at
+        // token boundaries; when it later drains buffered bytes, the original
+        // per-token `lp_data` is drained in lockstep with the filter's
+        // `consumed_positions` output (drop `consumed - suppressed` emitted
+        // entries; pop `suppressed` entries for placeholder chunks). This
+        // preserves the upstream mlx-lm `replace(t, text="")` semantics so OpenAI
+        // clients aligning by `choices[].logprobs.content` keep position info.
+        let cb_state = std::sync::Arc::new(std::sync::Mutex::new(StreamCallbackState {
+            accumulated: String::new(),
+            stream_filter: if primed_open_thinking {
+                StreamFilter::new_primed_open_thinking()
+            } else {
+                StreamFilter::new()
+            },
+            lp_buffer: std::collections::VecDeque::new(),
         }));
-        let filter_for_callback = stream_filter.clone();
-
-        // Parallel logprob buffer — one entry per `feed()` call (one per token).
-        //
-        // The stream filter buffers incoming text fragments to handle delimiter
-        // matching at token boundaries. When it later drains buffered bytes, the
-        // original per-token `lp_data` that arrived with those bytes is no longer
-        // directly available (the closure has moved on to newer tokens). This
-        // `VecDeque` mirrors the filter's internal fragment queue: we push
-        // `lp_data` here on every `feed()` call, then drain in lockstep with the
-        // filter's `consumed_positions` output:
-        //
-        //   - drop `consumed_positions - suppressed_positions` entries (emitted text)
-        //   - pop `suppressed_positions` entries → lp_data for placeholder chunks
-        //
-        // This preserves the upstream mlx-lm `replace(t, text="")` semantics:
-        // each suppressed delimiter position carries its original logprob metadata
-        // so OpenAI clients aligning by `choices[].logprobs.content` do not lose
-        // position information.
-        let lp_buffer: std::sync::Arc<
-            std::sync::Mutex<std::collections::VecDeque<Option<TokenLogprobData>>>,
-        > = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new()));
-        let lp_buffer_for_callback = lp_buffer.clone();
+        let cb_state_for_callback = cb_state.clone();
 
         let result = state
             .model_provider
@@ -714,116 +726,116 @@ async fn stream_chat_completion(
                 prepared.videos,
                 cancelled,
                 |token, lp_data| {
-                    // Always accumulate raw text for tool call parsing
-                    if parse_tools && let Ok(mut acc) = acc_clone.lock() {
-                        acc.push_str(&token);
-                    }
+                    // Single lock per token (issue #633): accumulate raw text,
+                    // push this token's lp_data, run the stream filter, and drain
+                    // the lp buffer under one lock. `lp_data` is pushed before
+                    // `feed()` because the filter may buffer the token internally
+                    // until a partial-match ambiguity resolves; the original
+                    // lp_data must stay available for placeholder chunks it later
+                    // drains. The emitted chunks are collected and sent after the
+                    // lock is released so the (uncontended) lock never spans a
+                    // channel send.
+                    let mut pending: Vec<ChatCompletionChunk> = Vec::new();
+                    {
+                        let Ok(mut cb) = cb_state_for_callback.lock() else {
+                            return;
+                        };
+                        let cb = &mut *cb;
 
-                    // Push this token's lp_data into the parallel buffer before
-                    // feeding the text to the stream filter. The filter may buffer
-                    // this token internally until a partial-match ambiguity
-                    // resolves; when it later drains those bytes we need the
-                    // original lp_data available for placeholder chunks.
-                    if logprobs_enabled && let Ok(mut buf) = lp_buffer_for_callback.lock() {
-                        buf.push_back(lp_data.clone());
-                    }
+                        if parse_tools {
+                            cb.accumulated.push_str(&token);
+                        }
+                        if logprobs_enabled {
+                            cb.lp_buffer.push_back(lp_data.clone());
+                        }
 
-                    // Apply stream filter to split thinking scratchpad from
-                    // user-facing content. Thinking goes out as
-                    // `delta.reasoning_content` so routers/UIs can surface a
-                    // "thinking" state; regular text goes as `delta.content`.
-                    let emit = filter_for_callback
-                        .lock()
-                        .ok()
-                        .map(|mut f| f.feed(&token))
-                        .unwrap_or_default();
+                        // Split thinking scratchpad from user-facing content.
+                        // Thinking goes out as `delta.reasoning_content`; regular
+                        // text goes as `delta.content`.
+                        let emit = cb.stream_filter.feed(&token);
 
-                    // Drain the parallel lp_data buffer in lockstep with the
-                    // filter's consumed_positions output:
-                    //   - Emitted positions (consumed but not suppressed): drop.
-                    //   - Suppressed positions: collect for placeholder chunks.
-                    let suppressed_lp: Vec<Option<TokenLogprobData>> =
-                        if logprobs_enabled && emit.consumed_positions > 0 {
+                        // Drain the parallel lp_data buffer in lockstep with the
+                        // filter's consumed_positions output:
+                        //   - Emitted positions (consumed, not suppressed): drop.
+                        //   - Suppressed positions: collect for placeholder chunks.
+                        let suppressed_lp: Vec<Option<TokenLogprobData>> = if logprobs_enabled
+                            && emit.consumed_positions > 0
+                        {
                             let emitted = emit.consumed_positions - emit.suppressed_positions;
                             let mut suppressed_out = Vec::with_capacity(emit.suppressed_positions);
-                            if let Ok(mut buf) = lp_buffer_for_callback.lock() {
-                                // Drop emitted-position entries (their text went to content/reasoning).
-                                for _ in 0..emitted {
-                                    buf.pop_front();
-                                }
-                                // Collect suppressed-position entries for placeholder chunks.
-                                for _ in 0..emit.suppressed_positions {
-                                    suppressed_out.push(buf.pop_front().flatten());
-                                }
+                            for _ in 0..emitted {
+                                cb.lp_buffer.pop_front();
+                            }
+                            for _ in 0..emit.suppressed_positions {
+                                suppressed_out.push(cb.lp_buffer.pop_front().flatten());
                             }
                             suppressed_out
                         } else {
                             Vec::new()
                         };
 
-                    if let Some(reasoning_text) = emit.reasoning
-                        && !reasoning_text.is_empty()
-                    {
-                        let chunk = ChatCompletionChunk::reasoning_content(
-                            request_id_inner.clone(),
-                            model_id_inner.clone(),
-                            reasoning_text,
-                        );
-                        let _ = token_events.json(&chunk);
-                    }
-
-                    if let Some(text) = emit.content
-                        && !text.is_empty()
-                    {
-                        let logprobs = if logprobs_enabled {
-                            lp_data
-                                .as_ref()
-                                .map(|lp| build_single_token_chat_logprobs(&tokenizer, lp, top_k))
-                        } else {
-                            None
-                        };
-                        let chunk = ChatCompletionChunk::content_with_logprobs(
-                            request_id_inner.clone(),
-                            model_id_inner.clone(),
-                            text,
-                            logprobs,
-                        );
-                        let _ = token_events.json(&chunk);
-                    }
-
-                    // Preserve token-position alignment for parallel tool calls
-                    // (upstream mlx-lm PR #1170, commit aa4f880).
-                    //
-                    // When the stream filter consumed a control-token delimiter
-                    // (e.g. `<tool_call>`, `</tool_call>`) it drained those
-                    // bytes without producing any text output. If logprobs are
-                    // enabled, downstream consumers expect one event per token
-                    // position. Emit an empty-content placeholder chunk for each
-                    // suppressed position, carrying the original per-token
-                    // lp_data so that OpenAI clients aligning by
-                    // `choices[].logprobs.content` do not lose the position.
-                    if logprobs_enabled && emit.suppressed_positions > 0 {
-                        for slot_lp in suppressed_lp {
-                            let logprobs = slot_lp
-                                .as_ref()
-                                .map(|lp| build_single_token_chat_logprobs(&tokenizer, lp, top_k));
-                            let chunk = ChatCompletionChunk::content_with_logprobs(
+                        if let Some(reasoning_text) = emit.reasoning
+                            && !reasoning_text.is_empty()
+                        {
+                            pending.push(ChatCompletionChunk::reasoning_content(
                                 request_id_inner.clone(),
                                 model_id_inner.clone(),
-                                String::new(),
-                                logprobs,
-                            );
-                            let _ = token_events.json(&chunk);
+                                reasoning_text,
+                            ));
                         }
+
+                        if let Some(text) = emit.content
+                            && !text.is_empty()
+                        {
+                            let logprobs = if logprobs_enabled {
+                                lp_data.as_ref().map(|lp| {
+                                    build_single_token_chat_logprobs(&tokenizer, lp, top_k)
+                                })
+                            } else {
+                                None
+                            };
+                            pending.push(ChatCompletionChunk::content_with_logprobs(
+                                request_id_inner.clone(),
+                                model_id_inner.clone(),
+                                text,
+                                logprobs,
+                            ));
+                        }
+
+                        // Preserve token-position alignment for parallel tool
+                        // calls (upstream mlx-lm PR #1170, commit aa4f880). When
+                        // the stream filter consumed a control-token delimiter
+                        // (e.g. `<tool_call>`) it drained those bytes without
+                        // producing output; with logprobs enabled, downstream
+                        // consumers expect one event per token position, so emit
+                        // an empty-content placeholder carrying the original
+                        // per-token lp_data.
+                        if logprobs_enabled && emit.suppressed_positions > 0 {
+                            for slot_lp in suppressed_lp {
+                                let logprobs = slot_lp.as_ref().map(|lp| {
+                                    build_single_token_chat_logprobs(&tokenizer, lp, top_k)
+                                });
+                                pending.push(ChatCompletionChunk::content_with_logprobs(
+                                    request_id_inner.clone(),
+                                    model_id_inner.clone(),
+                                    String::new(),
+                                    logprobs,
+                                ));
+                            }
+                        }
+                    }
+
+                    for chunk in &pending {
+                        let _ = token_events.json(chunk);
                     }
                 },
             );
 
         // Flush any remaining buffered content from the stream filter
-        let remaining = stream_filter
+        let remaining = cb_state
             .lock()
             .ok()
-            .map(|mut f| f.flush())
+            .map(|mut cb| cb.stream_filter.flush())
             .unwrap_or_default();
         if let Some(text) = remaining.reasoning
             && !text.is_empty()
@@ -853,9 +865,9 @@ async fn stream_chat_completion(
             Err(_) => "error".to_string(),
         };
 
-        if parse_tools && let Ok(full_output) = accumulated.lock() {
+        if parse_tools && let Ok(cb) = cb_state.lock() {
             let tools_ref = tools_for_parser.as_deref();
-            let parsed = tool_calls::parse_tool_calls(&full_output, tools_ref);
+            let parsed = tool_calls::parse_tool_calls(&cb.accumulated, tools_ref);
 
             if parsed.has_tool_calls() {
                 // Emit tool call deltas

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -158,16 +158,18 @@ impl MlxcelTokenizer {
     /// Look up the raw token string for a given token ID, without applying any
     /// decoder transformations. Returns `None` if the ID is out of vocabulary.
     ///
-    /// Used by [`StreamingDecodeState`] to detect byte-fallback tokens
-    /// (`<0xXX>`) so they can be buffered until a complete UTF-8 sequence forms.
+    /// General vocab-lookup helper. Since issue #633 the streaming detokenizer
+    /// no longer inspects individual pieces to detect byte-fallback tokens
+    /// (`<0xXX>`): `StreamingDecodeState` holds incomplete UTF-8 by re-decoding a
+    /// bounded token window, so this is off the detok hot path.
     ///
-    /// Used by: StreamingDecodeState (model_worker.rs)
+    /// Used by: model_worker_tests (byte-fallback token identification)
     pub fn token_piece(&self, id: u32) -> Option<String> {
         match self {
             Self::HuggingFace(t) => t.id_to_token(id),
             // SentencePiece byte-fallback tokens appear directly as <0xXX> in
             // the decoded output; the incremental decoder handles them via the
-            // full re-decode path rather than per-piece inspection.
+            // windowed re-decode path rather than per-piece inspection.
             Self::SentencePiece(_) | Self::Tiktoken(_) => None,
         }
     }


### PR DESCRIPTION
## Summary

Reduces three host-side per-token costs on the serving path (issue #633): O(N)-per-token detokenization, three per-token mutex acquisitions in the chat streaming callback, and prompt tokenization on the scheduler thread. The dominant win is the incremental detokenizer, which turns the quadratic-with-output-length detok cost into O(window) per token while staying byte-exact.

## What changed

### 1. Incremental detokenizer (`src/server/model_worker.rs`)

`StreamingDecodeState` previously called `tokenizer.decode(&all_ids, false)` over the full token history on every generated token (regular emit path and byte-fallback re-sync), which is O(N) per token and O(N^2) over a full generation, on the single generation thread. It now re-decodes only a bounded suffix window: two decodes anchored at the same `prefix_offset` (the already-emitted window prefix, and that prefix plus the newest tokens), emitting the delta past the shared prefix. Since both decodes share the left context, the shared prefix cancels out and the delta is byte-identical to a whole-history decode. `read_offset` only advances to a UTF-8-complete boundary, so an incomplete multibyte sequence (byte-fallback `<0xXX>` runs or split byte-level pieces) is held until it completes and is never streamed as U+FFFD. Mirrors the mlx-lm `NaiveStreamingDetokenizer` and the llama.cpp/vLLM incremental detokenizers.

A `MAX_HELD_TOKENS` cap bounds the window on degenerate never-completing output, and a `strip_prefix` guard keeps the delta slice panic-safe when a decoder retroactively rewrites already-emitted text (the `tokenizers` `ByteFallback` decoder renders an entire byte run as U+FFFD once it holds an incomplete byte). The public `StreamingDecodeState` surface is unchanged, so the batched, single, speculative, diffusion, XLA, and CLI decode call sites are untouched. The now-redundant `token_piece` byte-fallback buffer, `parse_byte_fallback_token`, and `safe_emit_boundary` helpers are removed; their behavior (never emit incomplete UTF-8) is preserved by the window guard and covered end-to-end by the streaming tests.

### 2. Streaming-path diet (`src/server/routes/chat.rs`)

The chat streaming callback locked three separate mutexes per token (tool-call accumulator, logprobs buffer, stream filter). They are collapsed into one `StreamCallbackState` behind a single `Mutex`, so the hot callback locks once per token; emitted chunks are collected and sent after the lock is released. The lock is required only for the `Send` bound on the `spawn_blocking` closure (an `Arc<RefCell>` would not be `Send`) and is never contended. The SSE wire format is byte-identical.

### 3. Tokenize off the generation thread (`src/server/model_provider.rs`, `src/server/batch/scheduler.rs`)

Prompt tokenization moved out of `BatchScheduler::enqueue_request` (scheduler thread, which stalled concurrent decode ticks for a long prompt) to the request-dispatch path. `ModelProvider` holds an optional pre-tokenizer and encodes the prompt in `send_generate_request_with_cancellation` (HTTP-side thread), passing the ids through `ModelRequest::Generate`. The scheduler uses them when present and falls back to tokenizing itself otherwise. `tokenize_prompt_for_generation` is the single source of truth for the `add_special` convention (suppressed on a literal `<bos>`/`<s>` prefix), so both paths are byte-identical. Legacy, XLA, diffusion, and test paths keep the `None` fallback.

## Test plan

Hardware: Apple M1 Ultra (macOS), features `metal,accelerate`. Model: `models/qwen2.5-0.5b-bf16` (bf16, ByteLevel tokenizer, `clean_up_tokenization_spaces=false`).

Measured here:

- **Detok is O(window), not O(N).** Single greedy 4096-token stream, tok/s bucketed by output position (custom SSE arrival timer):

  | | first 512 tok/s | last 512 tok/s | end/start ratio | overall decode tok/s |
  |---|---|---|---|---|
  | BEFORE (`main` b73be08d6) | 196.9 | 160.4 | 0.815 | 163.0 |
  | AFTER (this branch) | 191.8 | 179.6 | 0.936 | 181.2 |

  The length-dependent degradation drops from 18.5% to 6.4% (the residual is GPU warmup/thermal, not detok). Tail throughput +12% (160.4 -> 179.6), overall decode +11% (163.0 -> 181.2). `scripts/bench_serving_concurrency.py --concurrency 1 --max-tokens 4096` corroborates the overall figure (162.8 -> 180.9 aggregate tok/s).

- **Byte-exact streaming.** New unit tests beside the code assert the accumulated streamed text equals a one-shot `tokenizer.decode` of the final ids across Korean, mixed CJK/emoji/ASCII, regular-piece + multibyte, a non-empty prompt seam, mid-multibyte truncation, and a 300-case fuzz. All existing byte-fallback streaming regressions and the `server::routes::chat` / `server::streaming` tests pass.
- `cargo test --release --features metal,accelerate --lib -- server::model_provider::model_worker::tests` -> 24 passed, 0 failed.
- Combined `server::model_provider::model_worker::tests server::routes::chat::tests server::streaming::tests` -> all pass.
- `cargo check --lib --tests --features metal,accelerate`, `cargo clippy --lib --tests --features metal,accelerate -- -D warnings`, `cargo fmt --all -- --check` -> clean.

Pending (not cheaply reproducible on this hardware; recorded per acceptance criteria):

- **#624 long-prompt admission (8k-prompt request does not stall a concurrent short request's TTFT).** Item 3 moves tokenization off the scheduler thread by construction, but the mixed-workload scenario needs a client that fires one 8k-prompt request alongside short requests; `scripts/bench_serving_concurrency.py` fires N identical requests and does not model the mixed case. Suggested command for a follow-up run: `python3 scripts/bench_serving_concurrency.py --concurrency 8 --prompt-tokens 8192 --max-tokens 64` while separately timing a short request's TTFT.

## Review follow-up: stream the held detokenizer tail

The incremental detokenizer holds back the whole window while its tail is an incomplete UTF-8 sequence, and a single byte-level token (Qwen-style) can carry complete text plus a trailing incomplete byte. If generation stopped on such a token, `StreamingDecodeState::flush` appended that complete text to `generated_text` (seen by the non-streaming `result.text`) but returned nothing, so streaming clients dropped it. `flush` now returns the flushed delta (`Option<String>`, `#[must_use]`) and every streaming finish site forwards it as one final `GenerateEvent::Token` before `Done`: both `BatchScheduler` finish paths, the speculative-burst finalize, the diffusion worker, and the XLA worker's `Finished` branch (after the stop-matcher tail). The XLA stop-string finalize still drops its post-stop tail and the CLI print paths already recover the tail via a separate `decode(generated_ids)` + `strip_prefix`, so both are unchanged.

New/updated tests: a ByteLevel stub whose single token decodes to `abc` + the first byte of a 3-byte char proves `flush` returns the held `abc` tail on stop and stays byte-exact when the char completes mid-stream; the byte-fallback stream helper now folds the `flush` return into the streamed chunks and the incomplete-at-end regression asserts the U+FFFD tail is streamed exactly once and equals `result.text`. `cargo test --release --features metal,accelerate --lib -- server::model_provider::model_worker::tests server::routes::chat::tests server::streaming::tests` -> 66 passed, 0 failed. `cargo check --lib --tests --bins`, `cargo clippy --lib --tests -- -D warnings`, `cargo fmt --all -- --check` clean.

Closes #633
