### PR TITLE
fix(distributed): reject model-owned paged families from the prefill handoff

### DIFF
--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -125,6 +125,16 @@ The code shares the same cluster config, registry, transport, and metrics
 infrastructure as PP. Treat it as a topology-specific feature: run a live test
 with your traffic shape before publishing performance claims.
 
+Model support is narrower than PP: the paged prefill/decode handoff works only
+for pool-backed Fp16 families (dense-natural backends such as qwen3 and
+llama3). Model-owned paged families (gemma3, gemma4, llama4, qwen3_5,
+qwen3_next) carry their KV state outside the shared block pool, so it cannot
+be serialized across the handoff. A request against one of those families is
+rejected at the prefill node with a clean per-request error before any
+prefill work runs, and the node keeps serving subsequent requests (issue
+#708). See [continuous batching and disaggregated serving](CONTINUOUS_BATCHING.md#scope-and-limitations)
+for the full scope and limitations list.
+
 A `--node-role router` front balances independent prefill and decode pools. It
 picks both the prefill node and the decode node per request (round-robin over
 the nodes the registry marks online), ships the chosen decode node to the

--- a/src/distributed/disaggregated/coordinator.rs
+++ b/src/distributed/disaggregated/coordinator.rs
@@ -423,8 +423,19 @@ impl ServingCoordinator {
                 );
                 continue;
             }
-            let request = PrefillRequestFrame::decode(&payload)
-                .context("prefill role: decode prefill request frame")?;
+            // A malformed-but-well-framed request payload is a per-request
+            // condition, not a transport failure: there is no decoded
+            // `reply_to` to answer, but the loop must keep serving everyone
+            // else (#708). Only the recv() arm above may exit the loop.
+            let request = match PrefillRequestFrame::decode(&payload) {
+                Ok(request) => request,
+                Err(e) => {
+                    tracing::warn!(
+                        "prefill role: dropping undecodable prefill request frame: {e:#}"
+                    );
+                    continue;
+                }
+            };
 
             // Node-level rejection for a model-owned paged family (#708): return a
             // clean per-request error frame and keep serving, rather than driving a
@@ -440,16 +451,23 @@ impl ServingCoordinator {
                     error: Some(
                         "the disaggregated handoff does not support this model's model-owned \
                          paged sequence-state backend; only pool-backed dense Fp16 families \
-                         (qwen3 / llama3) can be handed off (issue #708)"
+                         (qwen3 / llama3) can be handed off"
                             .to_string(),
                     ),
                     generated_tokens: None,
                 };
-                if let Err(e) = self
-                    .transport
-                    .send(&request.reply_to, err_result.encode()?)
-                    .await
-                {
+                let encoded = match err_result.encode() {
+                    Ok(encoded) => encoded,
+                    Err(e) => {
+                        tracing::warn!(
+                            request_id = request.request_id,
+                            "prefill role: failed to encode the model-owned rejection: {e}; \
+                             dropping request"
+                        );
+                        continue;
+                    }
+                };
+                if let Err(e) = self.transport.send(&request.reply_to, encoded).await {
                     tracing::warn!(
                         request_id = request.request_id,
                         reply_to = %request.reply_to,
@@ -490,11 +508,18 @@ impl ServingCoordinator {
                         error: Some(format!("prefill failed: {e}")),
                         generated_tokens: None,
                     };
-                    if let Err(send_err) = self
-                        .transport
-                        .send(&request.reply_to, err_result.encode()?)
-                        .await
-                    {
+                    let encoded = match err_result.encode() {
+                        Ok(encoded) => encoded,
+                        Err(encode_err) => {
+                            tracing::warn!(
+                                request_id = request.request_id,
+                                "prefill role: failed to encode the prefill error: \
+                                 {encode_err}; dropping request"
+                            );
+                            continue;
+                        }
+                    };
+                    if let Err(send_err) = self.transport.send(&request.reply_to, encoded).await {
                         tracing::warn!(
                             request_id = request.request_id,
                             reply_to = %request.reply_to,
@@ -531,11 +556,17 @@ impl ServingCoordinator {
                 error: drained.error,
                 generated_tokens: Some(prefill_generated),
             };
-            if let Err(e) = self
-                .transport
-                .send(&request.reply_to, first_result.encode()?)
-                .await
-            {
+            let first_encoded = match first_result.encode() {
+                Ok(encoded) => encoded,
+                Err(e) => {
+                    tracing::warn!(
+                        request_id = request.request_id,
+                        "prefill role: failed to encode the first token: {e}; dropping request"
+                    );
+                    continue;
+                }
+            };
+            if let Err(e) = self.transport.send(&request.reply_to, first_encoded).await {
                 tracing::warn!(
                     request_id = request.request_id,
                     reply_to = %request.reply_to,
@@ -609,10 +640,9 @@ impl ServingCoordinator {
                                 )),
                                 generated_tokens: None,
                             };
-                            let _ = self
-                                .transport
-                                .send(&request.reply_to, err_result.encode()?)
-                                .await;
+                            if let Ok(encoded) = err_result.encode() {
+                                let _ = self.transport.send(&request.reply_to, encoded).await;
+                            }
                             continue;
                         }
                     },
@@ -639,10 +669,9 @@ impl ServingCoordinator {
                         error: Some(format!("decode handoff to {decode_peer} failed: {e}")),
                         generated_tokens: None,
                     };
-                    let _ = self
-                        .transport
-                        .send(&request.reply_to, err_result.encode()?)
-                        .await;
+                    if let Ok(encoded) = err_result.encode() {
+                        let _ = self.transport.send(&request.reply_to, encoded).await;
+                    }
                 }
             }
         }

--- a/src/distributed/disaggregated/coordinator.rs
+++ b/src/distributed/disaggregated/coordinator.rs
@@ -381,6 +381,23 @@ impl ServingCoordinator {
         &self,
         scheduler: &mut BatchScheduler,
     ) -> Result<()> {
+        // The whole node serves one model, so its handoff eligibility is fixed:
+        // model-owned paged families (gemma3 / gemma4 / llama4 / qwen3_5 /
+        // qwen3_next) cannot be handed off over the pool-block transport (#125),
+        // and attempting it used to read unwritten pool tensors and crash this
+        // loop, taking the node down for every subsequent request (#708). Check it
+        // once here and reject each such request cheaply below with a clean
+        // per-request error, rather than doing (and discarding) prefill work.
+        let handoff_supported = scheduler.handoff_supported();
+        if !handoff_supported {
+            tracing::warn!(
+                "prefill role: this model uses a model-owned paged sequence-state backend, \
+                 which the disaggregated pool-block KV handoff does not support (#708). Every \
+                 prefill request to this node is rejected with a clean per-request error and \
+                 the node keeps serving; deploy a pool-backed dense Fp16 family (qwen3 / \
+                 llama3) for disaggregated prefill."
+            );
+        }
         loop {
             let message = match self.transport.recv().await {
                 Ok((from, message)) => {
@@ -409,16 +426,85 @@ impl ServingCoordinator {
             let request = PrefillRequestFrame::decode(&payload)
                 .context("prefill role: decode prefill request frame")?;
 
+            // Node-level rejection for a model-owned paged family (#708): return a
+            // clean per-request error frame and keep serving, rather than driving a
+            // prefill whose extracted KV cannot be pool-transferred. The router
+            // renders this error as a chat/completions failure to the client.
+            if !handoff_supported {
+                let err_result = ResultFrame {
+                    request_id: request.request_id,
+                    phase: ResultPhase::FirstToken,
+                    tokens: Vec::new(),
+                    start_sequence: 0,
+                    done: true,
+                    error: Some(
+                        "the disaggregated handoff does not support this model's model-owned \
+                         paged sequence-state backend; only pool-backed dense Fp16 families \
+                         (qwen3 / llama3) can be handed off (issue #708)"
+                            .to_string(),
+                    ),
+                    generated_tokens: None,
+                };
+                if let Err(e) = self
+                    .transport
+                    .send(&request.reply_to, err_result.encode()?)
+                    .await
+                {
+                    tracing::warn!(
+                        request_id = request.request_id,
+                        reply_to = %request.reply_to,
+                        "prefill role: failed to return the model-owned rejection: {e}; \
+                         dropping request"
+                    );
+                }
+                continue;
+            }
+
             // Drive the standard full-prefill + extract entry, capturing the
             // first token on a local channel so it can be returned over the wire.
             let (token_tx, token_rx) = mpsc::channel();
-            let frame = scheduler.prefill_text_request_for_handoff(
+            let frame = match scheduler.prefill_text_request_for_handoff(
                 request.prompt_tokens,
                 sampling_from_serializable(&request.sampling),
                 request.max_tokens as usize,
                 token_tx,
                 Arc::new(AtomicBool::new(false)),
-            )?;
+            ) {
+                Ok(frame) => frame,
+                // A per-request prefill/extract failure must not tear down the
+                // serving loop that serves everyone (#708). Return a clean error
+                // frame for this request and keep serving; loop exit is reserved
+                // for the transport-level/fatal condition on the recv() arm above.
+                Err(e) => {
+                    tracing::warn!(
+                        request_id = request.request_id,
+                        reply_to = %request.reply_to,
+                        "prefill role: prefill/extract failed: {e:#}; failing the request"
+                    );
+                    let err_result = ResultFrame {
+                        request_id: request.request_id,
+                        phase: ResultPhase::FirstToken,
+                        tokens: Vec::new(),
+                        start_sequence: 0,
+                        done: true,
+                        error: Some(format!("prefill failed: {e}")),
+                        generated_tokens: None,
+                    };
+                    if let Err(send_err) = self
+                        .transport
+                        .send(&request.reply_to, err_result.encode()?)
+                        .await
+                    {
+                        tracing::warn!(
+                            request_id = request.request_id,
+                            reply_to = %request.reply_to,
+                            "prefill role: failed to return the prefill error: {send_err}; \
+                             dropping request"
+                        );
+                    }
+                    continue;
+                }
+            };
             let drained = drain_generation_events(&token_rx);
 
             // The prefill node's authoritative count of model tokens it

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -6278,8 +6278,13 @@ impl CachePool {
     /// decode node remaps these to fresh ids in
     /// [`Self::restore_paged_state_with_contents`].
     ///
-    /// Returns an empty vector for dense / model-owned sequences, for a paged
-    /// sequence with no block table, or when no paged pool exists.
+    /// Returns an empty vector for dense sequences, for a model-owned paged
+    /// sequence with dense placeholder caches, for a paged sequence with no
+    /// block table, or when no paged pool exists. Returns a clean error for a
+    /// model-owned paged sequence with a POPULATED shadow block table (empty
+    /// pool-backed caches): its KV lives model-internal, so there is nothing
+    /// pool-paged to extract and reading the shadow block ids would hit unwritten
+    /// pool tensors (issue #708).
     pub fn extract_paged_blocks(&self, id: SequenceId) -> Result<Vec<PagedBlockContents>, String> {
         let sequence = self
             .active
@@ -6289,11 +6294,38 @@ impl CachePool {
             return Ok(Vec::new());
         }
         // Only POOL-BACKED (Fp16 paged) sequences keep their K/V in the shared
-        // pool. A model-owned paged sequence (gemma3 / llama4 / qwen3_5) holds
-        // dense placeholder caches and keeps its KV model-internal, with the pool
-        // tracking a shadow block table only, so there is nothing pool-paged to
-        // transfer. `caches.is_empty()` (a paged-natural stub) is vacuously
-        // pool-backed and falls through to the empty block-table fast path below.
+        // pool. Their per-layer caches are the `KVCache::new_paged` handles that
+        // route `update_and_fetch` into the pool, so a pool-backed sequence has
+        // one non-empty cache per layer and every one reports `is_paged_backed()`.
+        //
+        // A model-owned paged family (gemma3 / gemma4 / llama4 / qwen3_5 /
+        // qwen3_next) keeps its KV model-internal and is routed through the paged
+        // backend for SHADOW block-table accounting only: `make_caches()` returns
+        // an EMPTY vec while `sync_paged_state_with_lengths` populates each layer's
+        // `block_ids`. Empty `caches` therefore means no cache ever wrote to the
+        // pool, so those shadow `block_ids` reference rows the pool never filled and
+        // `read_block_contents` would fail with "layer N has no pool tensors to read
+        // from". Detect this explicitly rather than letting the vacuous `.all()`
+        // (true for an empty iterator) fall through into a doomed pool read that
+        // used to crash the prefill serving loop (issue #708).
+        if sequence.caches.is_empty() {
+            // A populated shadow block table with no pool-backed caches is the
+            // model-owned handoff case: return a clean error the prefill node can
+            // surface as a per-request failure. An empty shadow table is a fresh
+            // paged sequence with nothing to transfer, so take the empty fast path.
+            // Either way, never issue a pool read for unwritten tensors.
+            let has_shadow_blocks = sequence
+                .paged_state()
+                .is_some_and(|state| state.layers.iter().any(|layer| !layer.block_ids.is_empty()));
+            if has_shadow_blocks {
+                return Err(format!(
+                    "CachePool::extract_paged_blocks: sequence {id} uses a model-owned paged \
+                     backend (shadow block table, no pool-backed caches); its KV lives \
+                     model-internal and cannot be extracted for a pool-block handoff"
+                ));
+            }
+            return Ok(Vec::new());
+        }
         if !sequence.caches.iter().all(|cache| cache.is_paged_backed()) {
             return Ok(Vec::new());
         }
@@ -7351,6 +7383,44 @@ mod tests {
         }
     }
 
+    /// Model-owned family whose `make_caches()` returns an EMPTY vec, mirroring
+    /// the REAL gemma3 / gemma4 / llama4 / qwen3_5 / qwen3_next shape (unlike
+    /// [`ShadowDenseModel`], which keeps NON-empty dense placeholder caches).
+    /// Allocated with a paged layout override and synced via
+    /// `sync_paged_state_with_lengths`, it reproduces the #708 shape:
+    /// `backend == PagedKvCache`, empty pool-backed caches, and a populated
+    /// SHADOW block table whose pool tensors were never written.
+    struct ModelOwnedEmptyModel {
+        num_layers: usize,
+    }
+
+    impl crate::generate::LanguageModel for ModelOwnedEmptyModel {
+        fn forward(
+            &self,
+            _input_ids: &MlxArray,
+            _caches: &mut [KVCache],
+            _mask: Option<&MlxArray>,
+        ) -> UniquePtr<MlxArray> {
+            ffi::zeros(&[1], 0)
+        }
+
+        fn make_caches(&self) -> Vec<KVCache> {
+            Vec::new()
+        }
+
+        fn num_layers(&self) -> usize {
+            self.num_layers
+        }
+
+        fn eos_token_ids(&self) -> Vec<i32> {
+            vec![0]
+        }
+
+        fn sequence_state_layout(&self) -> SequenceStateLayout {
+            SequenceStateLayout::model_owned(self.num_layers)
+        }
+    }
+
     #[test]
     fn cache_pool_allocate_and_release() {
         let model = StubModel { num_layers: 4 };
@@ -7787,6 +7857,71 @@ mod tests {
                 a.layer_idx
             );
         }
+    }
+
+    #[test]
+    fn extract_paged_blocks_rejects_model_owned_shadow_sequence() {
+        // #708 regression. A model-owned paged family (gemma3 and friends) is
+        // routed through the paged backend for SHADOW block-table accounting, so
+        // `extract_paged_blocks` sees a PagedKvCache sequence with a POPULATED
+        // block table but EMPTY pool-backed caches (its `make_caches()` returns
+        // `Vec::new()`). The pool tensors behind those shadow block ids were never
+        // written, so a pool read fails with "layer 0 has no pool tensors to read
+        // from" and used to propagate out of the prefill serving loop and kill the
+        // node. The guard must reject cleanly, never issue that pool read.
+        let num_layers = 2usize;
+        let block_size = 4usize;
+        let layout = PagedKvLayout::uniform(num_layers, block_size, block_size * 8).unwrap();
+        let model = ModelOwnedEmptyModel { num_layers };
+
+        let mut pool = CachePool::new(4);
+        let id = pool
+            .allocate_with_layout(&model, Some(SequenceStateLayout::paged_kv_cache(layout)))
+            .unwrap();
+
+        // The sequence is paged-backed for accounting, but its `make_caches()` is
+        // empty (the model-owned shape), so no pool-backed cache exists.
+        assert!(
+            pool.get_caches_mut(id).unwrap().is_empty(),
+            "model-owned family must allocate with empty pool-backed caches"
+        );
+
+        // Populate the shadow block table exactly as the scheduler does for a
+        // model-owned family (`sync_paged_state_with_lengths`), leaving the pool
+        // tensors unwritten.
+        pool.sync_paged_state_with_lengths(id, &[6, 6]).unwrap();
+        // Sanity-check the premise: the shadow block table is genuinely populated,
+        // otherwise the test would pass vacuously on the buggy code too.
+        let has_blocks = pool
+            .get_paged_state(id)
+            .unwrap()
+            .layers
+            .iter()
+            .any(|layer| !layer.block_ids.is_empty());
+        assert!(
+            has_blocks,
+            "shadow block table must be populated to reproduce #708"
+        );
+
+        // `PagedBlockContents` is not `Debug`, so match rather than `expect_err`.
+        let err = match pool.extract_paged_blocks(id) {
+            Ok(blocks) => panic!(
+                "extract_paged_blocks must reject a model-owned shadow sequence, not read the \
+                 pool (returned {} blocks)",
+                blocks.len()
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains("model-owned paged backend"),
+            "expected a clean model-owned rejection, got: {err}"
+        );
+        // The failure must be the clean model-owned rejection, NOT the raw
+        // pool-read error that signalled the #708 crash.
+        assert!(
+            !err.contains("no pool tensors to read from"),
+            "extract_paged_blocks fell through to the doomed pool read: {err}"
+        );
     }
 
     #[test]

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -477,6 +477,20 @@ impl BatchScheduler {
         )
     }
 
+    /// Whether this node's model can participate in the disaggregated pool-block
+    /// KV handoff (#125). The handoff extracts pool-backed Fp16 KV, which only the
+    /// dense external KV-cache families (natural backend `DenseKvCache`: qwen3 /
+    /// llama3) produce. Model-owned paged families (gemma3 / gemma4 / llama4 /
+    /// qwen3_5 / qwen3_next, natural backend `ModelOwned`) keep their KV
+    /// model-internal and are routed through the paged backend for shadow
+    /// accounting only, so there is nothing pool-paged to extract: a handoff
+    /// attempt reads unwritten pool tensors and used to crash the prefill serving
+    /// loop (#708). The whole node serves one model, so this is a node-level fact
+    /// the serving-role loop checks once and applies to every request.
+    pub(crate) fn handoff_supported(&self) -> bool {
+        self.model.sequence_state_layout().backend == SequenceStateBackend::DenseKvCache
+    }
+
     /// Prefill role (#126 B2b): run a full prefill for `seq`, then extract its
     /// pool-backed KV as a handoff frame for a decode node and release the local
     /// caches.
@@ -576,6 +590,20 @@ impl BatchScheduler {
         response_tx: mpsc::Sender<GenerateEvent>,
         cancelled: Arc<AtomicBool>,
     ) -> anyhow::Result<Option<Vec<u8>>> {
+        // Reject model-owned paged families up front, before any allocation or
+        // prefill work: the pool-block handoff only supports pool-backed dense
+        // Fp16 families (#125). A model-owned family keeps its KV model-internal,
+        // so extraction would read unwritten pool tensors (#708). The serving-role
+        // loop turns this error into a per-request failure frame and keeps serving.
+        if !self.handoff_supported() {
+            anyhow::bail!(
+                "prefill-role handoff: the disaggregated handoff does not support this model's \
+                 {:?} sequence-state backend; only pool-backed dense Fp16 families (qwen3 / \
+                 llama3) can be handed off. Model-owned paged families (gemma3 / gemma4 / llama4 \
+                 / qwen3_5 / qwen3_next) keep their KV model-internal (issue #708).",
+                self.model.sequence_state_layout().backend
+            );
+        }
         if prompt_tokens.is_empty() {
             anyhow::bail!("prefill-role handoff: empty prompt has no tokens to prefill");
         }

--- a/tests/disaggregated_router_e2e.rs
+++ b/tests/disaggregated_router_e2e.rs
@@ -49,7 +49,7 @@ const QWEN3_DIR: &str = "qwen3-0.6b-4bit";
 /// request for it must be rejected per-request with a clean error while the
 /// prefill node keeps serving (issue #708). Used by
 /// [`disaggregated_router_rejects_model_owned_family_and_keeps_serving`] as the
-/// model-owned fixture (it is NOT a byte-fallback parity fixture — see
+/// model-owned fixture (it is NOT a byte-fallback parity fixture; see
 /// [`MINICPM_DIR`], which is both byte-fallback AND pool-backed). Fetch with:
 /// `./target/release/mlxcel download mlx-community/gemma-3-1b-it-4bit`.
 const GEMMA_DIR: &str = "gemma-3-1b-it-4bit";
@@ -1431,7 +1431,7 @@ async fn disaggregated_router_chat_usage_matches_single_node_byte_fallback() {
 
 /// Issue #708: a `POST /v1/completions` for a MODEL-OWNED paged family (gemma3)
 /// through the 3-node disaggregated stack must fail with a CLEAN per-request
-/// error, and the prefill node must KEEP SERVING afterward — it must not crash
+/// error, and the prefill node must KEEP SERVING afterward: it must not crash
 /// the serving-role loop and take the node down (which would surface as a 503
 /// peer-down on every subsequent request).
 ///

--- a/tests/disaggregated_router_e2e.rs
+++ b/tests/disaggregated_router_e2e.rs
@@ -44,18 +44,19 @@ use common::{repo_binary_path, repo_model_dir};
 /// qwen3 checkpoint directory name (pool-backed Fp16, the handoff scope).
 const QWEN3_DIR: &str = "qwen3-0.6b-4bit";
 
-/// Gemma checkpoint directory name (issue #387). Gemma's SentencePiece
-/// tokenizer has `byte_fallback = true`, so a multi-byte character (e.g. the
-/// `é` in "café") is emitted as a `<0xXX>` byte sequence: several model tokens
-/// surfacing as one detokenized text piece. Counting emitted pieces would
-/// under-count those tokens, which is exactly what the authoritative wire count
-/// fixes. Fetch with:
+/// Gemma checkpoint directory name. gemma3 is a MODEL-OWNED paged family: the
+/// disaggregated pool-block handoff (#125) does not support it, so a prefill
+/// request for it must be rejected per-request with a clean error while the
+/// prefill node keeps serving (issue #708). Used by
+/// [`disaggregated_router_rejects_model_owned_family_and_keeps_serving`] as the
+/// model-owned fixture (it is NOT a byte-fallback parity fixture — see
+/// [`MINICPM_DIR`], which is both byte-fallback AND pool-backed). Fetch with:
 /// `./target/release/mlxcel download mlx-community/gemma-3-1b-it-4bit`.
 const GEMMA_DIR: &str = "gemma-3-1b-it-4bit";
 
-/// Model alias for the Gemma byte-fallback parity test (single-node baseline
-/// started with `--alias <this>` so its `display_model_id()` matches the router-
-/// echoed `model`).
+/// Model alias for the model-owned rejection test (single-node baseline started
+/// with `--alias <this>` so its `display_model_id()` matches the router-echoed
+/// `model`).
 const GEMMA_MODEL_ALIAS: &str = "gemma-completions";
 
 /// MiniCPM-2B (llama-format export) checkpoint directory name (issue #398).
@@ -82,6 +83,11 @@ const MINICPM_DIR: &str = "minicpm-2b-4bit";
 /// completions-path and chat-path fixtures independent even though each test
 /// spawns its own isolated set of processes.
 const MINICPM_CHAT_MODEL_ALIAS: &str = "minicpm-chat";
+
+/// Model alias for the MiniCPM byte-fallback COMPLETIONS parity test (issues
+/// #387 / #708). Distinct from [`MINICPM_CHAT_MODEL_ALIAS`] so the
+/// completions-path and chat-path fixtures stay independent.
+const MINICPM_COMPLETIONS_MODEL_ALIAS: &str = "minicpm-completions";
 
 /// Expected concatenated SSE content from the router for the test prompt.
 ///
@@ -829,10 +835,12 @@ async fn disaggregated_router_completions_match_single_node() {
 
 /// Issue #387: `POST /v1/completions` through the disaggregated router must
 /// report `usage.completion_tokens` and `finish_reason` identical to single-node
-/// for a BYTE-FALLBACK tokenizer (Gemma), not just byte-level-BPE (Qwen).
+/// for a BYTE-FALLBACK tokenizer (MiniCPM-2B, llama-format export), not just
+/// byte-level-BPE (Qwen).
 ///
-/// Gemma's SentencePiece tokenizer emits multi-byte characters as `<0xXX>` byte
-/// sequences: several model tokens that surface as a single detokenized text
+/// The MiniCPM llama-format SentencePiece tokenizer has `byte_fallback = true`,
+/// so a multi-byte character (e.g. the `é` in "café") is emitted as `<0xXX>`
+/// byte pieces: several model tokens that surface as a single detokenized text
 /// piece. The previous router counted emitted pieces, which under-counted those
 /// tokens and could flip `finish_reason` between "length" and "stop". With the
 /// worker's authoritative token count carried over the wire
@@ -843,17 +851,25 @@ async fn disaggregated_router_completions_match_single_node() {
 /// (normalizing only the volatile `id` / `created`), and `usage.completion_tokens`
 /// plus `finish_reason` are asserted explicitly for a clear failure message.
 ///
+/// Retargeted from Gemma to MiniCPM-2B (issue #708): the original fixture used
+/// [`GEMMA_DIR`], but gemma3 is a model-owned paged family the disaggregated
+/// handoff cannot serve (the request crashed the prefill node), so the test was
+/// unrunnable. MiniCPM-2B is both byte-fallback AND pool-backed dense Llama, so
+/// it exercises the same authoritative-count path inside the handoff scope. See
+/// [`MINICPM_DIR`].
+///
 /// Gated like the other real-model tests: `#[ignore]` plus a checkpoint-presence
-/// guard that skips cleanly when the Gemma checkpoint is absent. Requires a
-/// byte-fallback checkpoint that also supports the pool-backed paged handoff.
+/// guard that skips cleanly when the MiniCPM checkpoint is absent.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "spawns four real mlxcel-server processes loading gemma-3-1b-it-4bit; run with --ignored"]
+#[ignore = "spawns four real mlxcel-server processes loading minicpm-2b-4bit; run with --ignored"]
 async fn disaggregated_router_completions_match_single_node_byte_fallback() {
-    let model_dir = repo_model_dir(GEMMA_DIR);
+    let model_dir = repo_model_dir(MINICPM_DIR);
     if !model_dir.exists() {
         eprintln!(
-            "Skipping {GEMMA_DIR}: model directory not found at {}.\n\
-             Fetch with: ./target/release/mlxcel download mlx-community/gemma-3-1b-it-4bit",
+            "Skipping {MINICPM_DIR}: model directory not found at {}.\n\
+             Fetch with: ./target/release/mlxcel download \
+             mlx-community/MiniCPM-2B-sft-4bit-llama-format-mlx (place it at \
+             models/{MINICPM_DIR})",
             model_dir.display()
         );
         return;
@@ -868,13 +884,13 @@ async fn disaggregated_router_completions_match_single_node_byte_fallback() {
     // sequence) into the greedy continuation so the count fix is exercised.
     let prompt = "Spell the French word for coffee. It is café. Repeat it:";
     let nonstream_body = serde_json::json!({
-        "model": GEMMA_MODEL_ALIAS,
+        "model": MINICPM_COMPLETIONS_MODEL_ALIAS,
         "prompt": prompt,
         "max_tokens": 16,
         "temperature": 0.0
     });
     let stream_body = serde_json::json!({
-        "model": GEMMA_MODEL_ALIAS,
+        "model": MINICPM_COMPLETIONS_MODEL_ALIAS,
         "prompt": prompt,
         "max_tokens": 16,
         "temperature": 0.0,
@@ -895,14 +911,14 @@ async fn disaggregated_router_completions_match_single_node_byte_fallback() {
             "--port",
             &http,
             "--alias",
-            GEMMA_MODEL_ALIAS,
+            MINICPM_COMPLETIONS_MODEL_ALIAS,
             "--no-warmup",
         ]);
         let deadline = Instant::now() + Duration::from_secs(240);
         let health_url = format!("http://127.0.0.1:{http}/health");
         assert!(
             wait_for_http_health(&health_url, deadline).await,
-            "single-node Gemma reference never became healthy at {health_url}"
+            "single-node MiniCPM reference never became healthy at {health_url}"
         );
         let completions_url = format!("http://127.0.0.1:{http}/v1/completions");
 
@@ -941,17 +957,17 @@ async fn disaggregated_router_completions_match_single_node_byte_fallback() {
         )
         // _single drops here, killing the reference server.
     };
-    eprintln!("single-node Gemma non-stream reference: {ref_nonstream}");
+    eprintln!("single-node MiniCPM non-stream reference: {ref_nonstream}");
     let ref_text = ref_nonstream["choices"][0]["text"].as_str().unwrap_or("");
     assert!(
         !ref_text.is_empty(),
-        "single-node Gemma reference produced empty completion text; parity check would be vacuous"
+        "single-node MiniCPM reference produced empty completion text; parity check would be vacuous"
     );
     // Guard the test's premise: the byte-fallback path is only exercised if the
     // greedy output actually contains a multi-byte character.
     assert!(
         !ref_text.is_ascii(),
-        "single-node Gemma output {ref_text:?} is pure ASCII; the byte-fallback \
+        "single-node MiniCPM output {ref_text:?} is pure ASCII; the byte-fallback \
          count path is not exercised. Adjust the prompt so the output contains a \
          multi-byte character."
     );
@@ -1057,7 +1073,7 @@ async fn disaggregated_router_completions_match_single_node_byte_fallback() {
             .await
             .expect("parse router non-stream completion JSON"),
     );
-    eprintln!("router Gemma non-stream: {router_ns}");
+    eprintln!("router MiniCPM non-stream: {router_ns}");
     assert_eq!(
         router_ns["usage"]["completion_tokens"], ref_nonstream["usage"]["completion_tokens"],
         "router usage.completion_tokens diverges from single-node for a byte-fallback tokenizer"
@@ -1068,7 +1084,7 @@ async fn disaggregated_router_completions_match_single_node_byte_fallback() {
     );
     assert_eq!(
         router_ns, ref_nonstream,
-        "router non-stream /v1/completions body is not byte-identical to single-node (Gemma)"
+        "router non-stream /v1/completions body is not byte-identical to single-node (MiniCPM)"
     );
 
     // Streaming parity: the usage chunk and finish chunk must match too.
@@ -1087,7 +1103,7 @@ async fn disaggregated_router_completions_match_single_node_byte_fallback() {
     let router_st_chunks = parse_completion_chunks(&router_st_body);
     assert_eq!(
         router_st_chunks, ref_stream_chunks,
-        "router stream /v1/completions chunks are not byte-identical to single-node (Gemma)"
+        "router stream /v1/completions chunks are not byte-identical to single-node (MiniCPM)"
     );
     eprintln!(
         "OK: router /v1/completions matches single-node for a byte-fallback tokenizer \
@@ -1410,6 +1426,168 @@ async fn disaggregated_router_chat_usage_matches_single_node_byte_fallback() {
     eprintln!(
         "OK: router /v1/chat/completions matches single-node usage for a byte-fallback \
          tokenizer (non-stream + stream)."
+    );
+}
+
+/// Issue #708: a `POST /v1/completions` for a MODEL-OWNED paged family (gemma3)
+/// through the 3-node disaggregated stack must fail with a CLEAN per-request
+/// error, and the prefill node must KEEP SERVING afterward — it must not crash
+/// the serving-role loop and take the node down (which would surface as a 503
+/// peer-down on every subsequent request).
+///
+/// Before the fix, `extract_paged_blocks` read the model-owned shadow block
+/// table's unwritten pool tensors (`PagedBlockPool::read_block_contents: layer 0
+/// has no pool tensors to read from`), the error propagated out of the prefill
+/// serving-role loop, the loop exited, the router health monitor marked the peer
+/// down, and every later request returned 503. After the fix the prefill node
+/// rejects the request up front (a node-level `handoff_supported` check) with a
+/// per-request error frame and stays alive.
+///
+/// The availability assertion: one model is served per node, so a follow-up
+/// request on a SUPPORTED model is impossible on the same stack. "Keeps serving"
+/// is therefore asserted by a SECOND identical request returning the SAME clean
+/// per-request error (an error status that is NOT 503 peer-down, with the
+/// model-owned rejection message in the body) rather than a wedged node.
+///
+/// Gated like the other real-model tests: `#[ignore]` plus a checkpoint-presence
+/// guard that skips cleanly when the Gemma checkpoint is absent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "spawns three real mlxcel-server processes loading gemma-3-1b-it-4bit; run with --ignored"]
+async fn disaggregated_router_rejects_model_owned_family_and_keeps_serving() {
+    let model_dir = repo_model_dir(GEMMA_DIR);
+    if !model_dir.exists() {
+        eprintln!(
+            "Skipping {GEMMA_DIR}: model directory not found at {}.\n\
+             Fetch with: ./target/release/mlxcel download mlx-community/gemma-3-1b-it-4bit",
+            model_dir.display()
+        );
+        return;
+    }
+    let binary = repo_binary_path("mlxcel-server");
+    if !binary.exists() {
+        eprintln!("Skipping: mlxcel-server binary not found");
+        return;
+    }
+    let model_arg = model_dir.to_string_lossy().to_string();
+    let client = reqwest::Client::new();
+
+    // ---- Three-process disaggregated router run ----
+    let ports = reserve_ports(6);
+    let prefill_http = ports[0].to_string();
+    let decode_http = ports[1].to_string();
+    let router_http = ports[2].to_string();
+    let prefill_serving_addr = format!("127.0.0.1:{}", ports[3]);
+    let decode_serving_addr = format!("127.0.0.1:{}", ports[4]);
+    let router_serving_addr = format!("127.0.0.1:{}", ports[5]);
+
+    let _decode = spawn_decode(&model_arg, &decode_http, &decode_serving_addr);
+    let _prefill = spawn_prefill(
+        &model_arg,
+        &prefill_http,
+        &prefill_serving_addr,
+        &decode_serving_addr,
+    );
+    let _router = spawn_role_server(&[
+        "-m",
+        &model_arg,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &router_http,
+        "--node-role",
+        "router",
+        "--serving-bind",
+        &router_serving_addr,
+        "--prefill-peers",
+        &prefill_serving_addr,
+        "--decode-peers",
+        &decode_serving_addr,
+        "--no-warmup",
+    ]);
+
+    let deadline = Instant::now() + Duration::from_secs(240);
+    assert!(
+        wait_for_tcp(&decode_serving_addr, deadline).await,
+        "decode node serving transport never came up"
+    );
+    assert!(
+        wait_for_tcp(&prefill_serving_addr, deadline).await,
+        "prefill node serving transport never came up"
+    );
+    let health_url = format!("http://127.0.0.1:{router_http}/health");
+    assert!(
+        wait_for_http_health(&health_url, deadline).await,
+        "router HTTP /health never returned 200"
+    );
+    let completions_url = format!("http://127.0.0.1:{router_http}/v1/completions");
+    let body = serde_json::json!({
+        "model": GEMMA_MODEL_ALIAS,
+        "prompt": "The capital of France is",
+        "max_tokens": 8,
+        "temperature": 0.0
+    });
+
+    // ---- Request #1: a clean per-request error (not a hang, not success) ----
+    let resp1 = client
+        .post(&completions_url)
+        .json(&body)
+        .send()
+        .await
+        .expect("POST router /v1/completions (#1)");
+    let status1 = resp1.status();
+    let body1 = resp1.text().await.unwrap_or_default();
+    eprintln!("model-owned request #1 -> HTTP {status1}: {body1}");
+    assert!(
+        status1.is_client_error() || status1.is_server_error(),
+        "model-owned request should return a clean 4xx/5xx error, got HTTP {status1}"
+    );
+    assert_ne!(
+        status1,
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "first model-owned request returned 503 (peer-down); the prefill node should reject \
+         per-request, not be marked down"
+    );
+    assert!(
+        body1.contains("model-owned") || body1.contains("handoff"),
+        "error body should explain the model-owned handoff rejection, got: {body1}"
+    );
+
+    // Give a hypothetically-crashed node time to be marked down by the router's
+    // health monitor, so request #2 is a genuine "is the node still serving?"
+    // probe (mirrors the failover test's post-kill settle delay).
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // ---- Request #2: proves the prefill node kept serving ----
+    // A crashed node would be marked down by now, wedging this into a 503
+    // peer-down (or a transport error) with no model-owned rejection body. A
+    // live node returns the SAME clean per-request rejection.
+    let resp2 = client
+        .post(&completions_url)
+        .json(&body)
+        .send()
+        .await
+        .expect("POST router /v1/completions (#2)");
+    let status2 = resp2.status();
+    let body2 = resp2.text().await.unwrap_or_default();
+    eprintln!("model-owned request #2 -> HTTP {status2}: {body2}");
+    assert_ne!(
+        status2,
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "second model-owned request returned 503 (peer-down): the prefill node did not keep \
+         serving after the first rejected request (issue #708 regression)"
+    );
+    assert!(
+        body2.contains("model-owned") || body2.contains("handoff"),
+        "second request must carry the same clean model-owned rejection, proving the node is \
+         still serving; got HTTP {status2}: {body2}"
+    );
+    assert_eq!(
+        status1, status2,
+        "the prefill node must reject both requests identically; got {status1} then {status2}"
+    );
+    eprintln!(
+        "OK: model-owned family rejected per-request with a clean error and the prefill node \
+         kept serving (no 503 peer-down)."
     );
 }
 


### PR DESCRIPTION
## Summary

A disaggregated request for a model-owned paged family (gemma3 / gemma4 / llama4 / qwen3_5 / qwen3_next) crashed the prefill node's serving-role loop and took the whole node down: one request left every subsequent request returning 503 peer-down. This rejects those families with a clean per-request error and keeps the node serving.

## Root cause

`CachePool::extract_paged_blocks` guarded against model-owned sequences with `!caches.iter().all(is_paged_backed())`, but a model-owned family's `make_caches()` returns an EMPTY vec, so `.all()` on the empty iterator is vacuously true and the guard fell through. These families are routed through the paged backend for shadow block-table accounting only, so `sync_paged_state_with_lengths` populates the block ids while the pool tensors are never written. The fall-through then read those unwritten tensors and `PagedBlockPool::read_block_contents` failed with "layer 0 has no pool tensors to read from". The error propagated out of `prefill_text_request_for_handoff` and the serving-role loop treated it as fatal and exited, so the router health monitor marked the peer down.

## What changed

- `src/lib/mlxcel-core/src/cache.rs`: `extract_paged_blocks` now detects the empty-caches case explicitly. A populated shadow block table with no pool-backed caches returns a clean error instead of issuing the doomed pool read; an empty shadow table takes the empty fast path. Added the `extract_paged_blocks_rejects_model_owned_shadow_sequence` unit test (with a model-owned empty-caches stub) pinning this.
- `src/server/batch/scheduler.rs`: new `BatchScheduler::handoff_supported()` (natural sequence-state backend is `DenseKvCache`). `prefill_text_request_for_handoff` rejects unsupported models up front, before any allocation or prefill work.
- `src/distributed/disaggregated/coordinator.rs`: `run_prefill_role_networked` checks `handoff_supported` once at startup (single warning, which keeps the `#708` reference for operators) and rejects each request with a clean per-request error frame. It also no longer exits on a per-request prefill/extract failure: it reports an error frame for that request and keeps serving, reserving loop exit for transport-level conditions.
- `tests/disaggregated_router_e2e.rs`: retargeted `disaggregated_router_completions_match_single_node_byte_fallback` from Gemma (model-owned, unrunnable by construction) to MiniCPM-2B (byte-fallback AND pool-backed), mirroring the chat-usage test; updated the `GEMMA_DIR` doc comment to note its new use. Added `disaggregated_router_rejects_model_owned_family_and_keeps_serving`.

A follow-up hardening pass addressed three review findings in the same serving loop: a malformed-but-well-framed request payload (a decode failure with no `reply_to` to answer) now drops just that request via `continue` instead of exiting the loop, since it is the same availability symptom as the original bug through a different trigger; every error/first-token `ResultFrame` encode failure at each in-loop send site now degrades to a per-request drop (logged and skipped) instead of propagating out and exiting the loop; and the issue number was moved out of the client-facing rejection message into the startup warning only, so operators still get the `#708` pointer in logs without leaking an internal issue reference to API clients.

## What the client sees

A completions/chat request for a model-owned family is rejected at the prefill node before any prefill work. The prefill node returns an error frame; the router renders it as an HTTP 500 JSON error (`{"error":{"message":"prefill node error: the disaggregated handoff does not support this model's model-owned paged sequence-state backend; only pool-backed dense Fp16 families (qwen3 / llama3) can be handed off"}}`). The node stays alive, so a second identical request receives the same clean 500, not a 503 peer-down.

## Test plan

All run on Apple M1 Ultra with `--features metal,accelerate`.

- [x] `cargo check --lib --tests` (workspace) and `cargo clippy --lib --tests --features metal,accelerate -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [x] `cargo test --release --features metal,accelerate -p mlxcel-core cache::tests -- --test-threads=1`: 60 passed, including `extract_paged_blocks_rejects_model_owned_shadow_sequence`.
- [x] `cargo test --release --features metal,accelerate --lib -- distributed::disaggregated`: 177 passed (coordinator / serving-protocol / stream-bridge).
- [x] E2E `disaggregated_router_rejects_model_owned_family_and_keeps_serving` on gemma-3-1b-it-4bit, re-run on the final hardened code (after the malformed-frame and encode-failure fixes): PASS, two consecutive requests, two consecutive clean HTTP 500s with the model-owned rejection message, no 503 peer-down.
- [x] E2E `disaggregated_router_completions_match_single_node_byte_fallback` on minicpm-2b-4bit: PASS, router body byte-identical to single-node (`" café, café, café.\n..."`, completion_tokens 16, finish_reason length).
- [x] E2E `disaggregated_router_chat_usage_matches_single_node_byte_fallback` on minicpm-2b-4bit (regression check on serving-loop changes): PASS.

Closes #708
