### PR TITLE
perf(cuda/quant): sm_120/121 qmm CTA tile (M=128) for Blackwell prefill

### DIFF
--- a/docs/benchmark_results/qmm-sm121-tile-tuning-gb10-2026-07-10.md
+++ b/docs/benchmark_results/qmm-sm121-tile-tuning-gb10-2026-07-10.md
@@ -1,11 +1,11 @@
 # sm_120/121 quantized GEMM tile tuning for Blackwell (issue #637, GB10)
 
-Date: 2026-07-10. Host: NVIDIA GB10 (Grace-Blackwell, sm_121 / cc 12.1), CUDA 13.0, MLX 0.32.0.
+Date: 2026-07-10. Host: NVIDIA GB10 (Grace-Blackwell, sm_121 / cc 12.1), CUDA 13.0, MLX 0.32.1 (pin `57c66cac`).
 Binary: `make release-cuda`. Bench: `mlxcel-bench-decode` (`--prompt-tokens` for prefill), `mlxcel generate` (greedy parity).
 
 ## TL;DR
 
-The CUDA quantized prefill GEMM (`qmm_sm80`) ran at ~0.55x the bf16 ceiling on GB10 because it used the Ampere CTA tile (M=64), which underutilizes Blackwell's SMs. Raising the CTA tile's M cap to 128 on sm_120/121 (a one-line, arch-gated heuristic change in the overlay `qmm_sm80.cu`) recovers **+32-35% prefill** throughput, greedy-parity identical, no decode regression. Wider-N / deeper-K tiles were also swept but break the fixed-MMA shared-memory layout (JIT failure), so `tile_m` is the one safely-tunable axis in-tree.
+The CUDA quantized prefill GEMM (`qmm_sm80`) ran at ~0.55x the bf16 ceiling on GB10 because it used the Ampere CTA tile (M=64), which underutilizes Blackwell's SMs. Raising the CTA tile's M cap to 128 on sm_120/121 (a one-line, arch-gated heuristic change in the overlay `qmm_sm80.cu`) recovers **+31-38% prefill** throughput, greedy-parity identical, no decode regression. Wider-N / deeper-K tiles were also swept but break the fixed-MMA shared-memory layout (JIT failure), so `tile_m` is the one safely-tunable axis in-tree.
 
 ## Kernel dispatch map on sm_121
 
@@ -57,10 +57,12 @@ Only `tile_m` is safely tunable; wider `tile_n` / deeper `tile_k` break the fixe
 
 Arch-gated `make_cta_tiler` (overlay `qmm_sm80.cu`): `tile_m` cap = 128 when `device.compute_capability_major() >= 12` (sm_120/121), else 64. Small-M (decode) is unaffected because `min(128, next_power_of_2(m))` stays small.
 
+Numbers below are the same-session paired comparison (arch-gated default tile_m=128 vs `MLXCEL_QMM_TILE_M=64`), the most apples-to-apples measurement. The tile_m=64 baseline itself varies ~5% run-to-run (2213-2330 tok/s observed for llama @8192); every measurement clears the +25% bar.
+
 | check | result |
 |-------|--------|
-| llama-3.1-8b-4bit prefill @8192 | 2330 -> ~3075 (+32%) |
-| qwen2.5-7b-4bit prefill @8192 | 2435 -> 3206 (+32%) |
+| llama-3.1-8b-4bit prefill @8192 | 2213 -> 3054 (+38%) |
+| qwen2.5-7b-4bit prefill @8192 | 2410 -> 3168 (+31%) |
 | greedy parity (llama, 40 tok, temp 0) | generated tokens identical |
 | decode (llama, m=1) | unaffected (qmv path, never reaches qmm_sm80) |
 

--- a/docs/benchmark_results/qmm-sm121-tile-tuning-gb10-2026-07-10.md
+++ b/docs/benchmark_results/qmm-sm121-tile-tuning-gb10-2026-07-10.md
@@ -1,0 +1,77 @@
+# sm_120/121 quantized GEMM tile tuning for Blackwell (issue #637, GB10)
+
+Date: 2026-07-10. Host: NVIDIA GB10 (Grace-Blackwell, sm_121 / cc 12.1), CUDA 13.0, MLX 0.32.0.
+Binary: `make release-cuda`. Bench: `mlxcel-bench-decode` (`--prompt-tokens` for prefill), `mlxcel generate` (greedy parity).
+
+## TL;DR
+
+The CUDA quantized prefill GEMM (`qmm_sm80`) ran at ~0.55x the bf16 ceiling on GB10 because it used the Ampere CTA tile (M=64), which underutilizes Blackwell's SMs. Raising the CTA tile's M cap to 128 on sm_120/121 (a one-line, arch-gated heuristic change in the overlay `qmm_sm80.cu`) recovers **+32-35% prefill** throughput, greedy-parity identical, no decode regression. Wider-N / deeper-K tiles were also swept but break the fixed-MMA shared-memory layout (JIT failure), so `tile_m` is the one safely-tunable axis in-tree.
+
+## Kernel dispatch map on sm_121
+
+From `patches/mlx/backend/cuda/quantized/quantized.cpp`:
+
+- **sm_90 (Hopper) kernel**: not available (the GB10 build passes arch `121`, not `90a`, so `supports_qmm_sm90` is false).
+- **sm_80 (Ampere) kernel**: available (Ampere `mma` JIT-compiles for 121). Used for large-M prefill.
+- **naive**: fallback.
+- **qmv (matrix-vector)**: taken when `M==1 && B==1` (single-sequence decode) or `M*B < 8` (small batched decode).
+
+Net: single-sequence decode uses `qmv` (GEMV-bound, correct). Prefill (large M) uses `qmm_sm80`. Batched decode with `M*B` in [2,8) uses per-row `qmv`; `>=8` uses `qmm_sm80`.
+
+## Prefill 4bit-vs-bf16 ceiling (before the fix)
+
+| model | prompt tokens | 4bit tok/s | bf16 tok/s | 4bit/bf16 |
+|-------|--------------:|-----------:|-----------:|----------:|
+| llama-3.1-8b-4bit | 2048 | 2797 | 4742 | 0.59x |
+| llama-3.1-8b-4bit | 8192 | 2330 | 4261 | 0.55x |
+
+4bit prefill should be at least as fast as bf16 (fewer weight bytes to move); 0.55x means the quantized GEMM leaves the GPU idle.
+
+## ncu roofline (qmm_sm80, tile 64x128x64, 8192 prefill)
+
+| metric | value |
+|--------|-------|
+| SM (compute) throughput | 35-47% |
+| Memory throughput | 52-68% |
+
+Neither roofline is saturated. The Ampere-tuned tile underutilizes Blackwell SMs. Headroom confirmed (ncu run via `--set roofline`; requires admin profiling access on this host).
+
+## Tile sweep (llama-3.1-8b-4bit prefill @8192)
+
+Swept via an env override of the CTA tiler (`MLXCEL_QMM_TILE_M/N/K`); the kernel JIT-compiles per resolved tile.
+
+| tile (M,N,K) | prefill tok/s | note |
+|--------------|--------------:|------|
+| 64,128,64 (Ampere default) | 2271 | baseline |
+| **128,128,64** | **3075** | **+35%, winner** |
+| 64,128,128 | ERR | JIT failure (smem/MMA layout) |
+| 64,128,256 | ERR | JIT failure |
+| 64,256,64 | ERR | JIT failure |
+| 64,256,128 | ERR | JIT failure |
+| 128,128,128 | ERR | JIT failure |
+| 64,64,64 | ERR | JIT failure |
+
+Only `tile_m` is safely tunable; wider `tile_n` / deeper `tile_k` break the fixed-`make_tiled_mma` shared-memory layout.
+
+## Fix + validation
+
+Arch-gated `make_cta_tiler` (overlay `qmm_sm80.cu`): `tile_m` cap = 128 when `device.compute_capability_major() >= 12` (sm_120/121), else 64. Small-M (decode) is unaffected because `min(128, next_power_of_2(m))` stays small.
+
+| check | result |
+|-------|--------|
+| llama-3.1-8b-4bit prefill @8192 | 2330 -> ~3075 (+32%) |
+| qwen2.5-7b-4bit prefill @8192 | 2435 -> 3206 (+32%) |
+| greedy parity (llama, 40 tok, temp 0) | generated tokens identical |
+| decode (llama, m=1) | unaffected (qmv path, never reaches qmm_sm80) |
+
+Meets #637's acceptance (>= 25% prefill @8192).
+
+## Scope: addressed vs not
+
+- **Addressed**: large-M prefill and batched prefill on sm_120/121 (+32%).
+- **NOT addressed**: small-M batched decode (`M*B` in [2,8)) still uses per-row `qmv` (no weight amortization across the batch), and the `tile_m` cap does not raise small-M tiles. This is the batched-decode non-amortization behind #714's `--parallel 4` CUDA regression, and needs a dedicated small-M kernel (or a weight-reusing batched `qmv`) - upstream MLX territory. Until then, #714's `--parallel` default should be made backend-aware (fall back to 1 on CUDA/Blackwell).
+- **Further prefill gains** toward the bf16 ceiling (0.72x -> 1.0x) need a Blackwell-tuned kernel (5th-gen tensor-core MMA, wider tiles with a compatible smem layout) - upstream MLX.
+
+## Upstream
+
+MLX's CUDA quantized GEMM has no sm_120/121 tile specialization: the Ampere tile underutilizes Blackwell (ncu evidence above), and there is no amortizing small-M (batched decode) quantized path on Blackwell. A tracking issue on lablup/mlxcel should carry this for upstream follow-up.

--- a/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/qmm/qmm_sm80.cu
+++ b/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/qmm/qmm_sm80.cu
@@ -1,0 +1,147 @@
+// Copyright © 2026 Apple Inc.
+
+#include "mlx/backend/cuda/device/qmm_sm80.cuh"
+
+#include "mlx/backend/cuda/cutlass_utils.cuh"
+#include "mlx/backend/cuda/jit_module.h"
+#include "mlx/backend/cuda/kernel_utils.cuh"
+#include "mlx/backend/cuda/quantized/qmm/qmm.h"
+#include "mlx/backend/cuda/quantized/qmm/qmm_utils.h"
+
+#include "cuda_jit_sources.h"
+
+#include <cstdlib>
+
+namespace mlx::core {
+
+namespace {
+
+inline auto make_cta_tiler(int m, int group_size, cu::Device& device) {
+  // #637 (mlxcel overlay): on consumer Blackwell (sm_120/121, cc major >= 12)
+  // a 128-row CTA tile fills the SMs far better for large-M (prefill / batched)
+  // shapes; the upstream Ampere cap of 64 leaves them underutilized there (ncu:
+  // ~35-47% SM throughput). Measured on GB10: +35% prefill @8192 on
+  // llama-3.1-8b-4bit and +32% on qwen2.5-7b-4bit, greedy-parity identical, no
+  // decode regression (decode m=1 takes the qmv path and never reaches here).
+  // sm_90/sm_80 keep the stock cap of 64 (untuned here). Wider tile_n / deeper
+  // tile_k were also swept but break the fixed-MMA smem layout (JIT failure),
+  // so tile_m is the one safely-tunable axis.
+  int tile_m_cap = device.compute_capability_major() >= 12 ? 128 : 64;
+  int tile_m = std::max(16, std::min(tile_m_cap, next_power_of_2(m)));
+  int tile_n = 128;
+  int tile_k = std::max(64, group_size);
+  // Optional env overrides retained as a tuning / escape hatch (#637 spike).
+  if (const char* e = std::getenv("MLXCEL_QMM_TILE_M")) {
+    int v = std::atoi(e);
+    if (v > 0) {
+      tile_m = v;
+    }
+  }
+  if (const char* e = std::getenv("MLXCEL_QMM_TILE_N")) {
+    int v = std::atoi(e);
+    if (v > 0) {
+      tile_n = v;
+    }
+  }
+  if (const char* e = std::getenv("MLXCEL_QMM_TILE_K")) {
+    int v = std::atoi(e);
+    if (v > 0) {
+      tile_k = v;
+    }
+  }
+  return cute::make_shape(tile_m, tile_n, tile_k);
+}
+
+} // namespace
+
+void qmm_sm80(
+    const array& x,
+    const array& w,
+    const array& scales,
+    const std::optional<array>& biases,
+    const std::optional<array>& lhs_indices,
+    const std::optional<array>& rhs_indices,
+    array& out,
+    int bits,
+    int group_size,
+    QuantizationMode mode,
+    cu::CommandEncoder& encoder) {
+  auto [m, n, k, l, broadcast_b] = make_problem_shape(x, w, out);
+  auto cta_tiler = make_cta_tiler(m, group_size, encoder.device());
+
+  std::string module_name = fmt::format(
+      "qmm_sm80_tn_{}_m{}_b{}_g{}_{}",
+      dtype_to_string(x.dtype()),
+      cute::size<0>(cta_tiler),
+      bits,
+      group_size,
+      quantization_mode_to_string(mode));
+
+  auto [ctype_x, ctype_q, ctype_s] = get_qmm_cutlass_types(x, bits, mode);
+  std::string kernel_name = fmt::format(
+      "mlx::core::cu::qmm_sm80_kernel<{}, {}, {}, {}, {}>",
+      group_size,
+      ctype_x,
+      ctype_q,
+      ctype_s,
+      cta_tiler_to_string(cta_tiler));
+
+  cu::JitModule& mod = cu::get_jit_module(encoder.device(), module_name, [&]() {
+    return std::make_tuple(
+        false, jit_source_qmm_sm80, std::vector{kernel_name});
+  });
+
+  encoder.set_input_array(x);
+  encoder.set_input_array(w);
+  encoder.set_input_array(scales);
+  if (biases) {
+    encoder.set_input_array(*biases);
+  }
+  if (lhs_indices) {
+    encoder.set_input_array(*lhs_indices);
+  }
+  if (rhs_indices) {
+    encoder.set_input_array(*rhs_indices);
+  }
+  encoder.set_output_array(out);
+
+  dim3 num_blocks{
+      uint32_t(cute::ceil_div(m, cute::size<0>(cta_tiler))),
+      uint32_t(cute::ceil_div(n, cute::size<1>(cta_tiler))),
+      uint32_t(l)};
+  dim3 block_dims{uint32_t(cute::size(cu::make_tiled_mma()))};
+
+  auto [sA_layout, sB_layout, sC_layout] = cu::make_smem_layouts(cta_tiler);
+  size_t smem_bytes = std::max(
+      cute::cosize(sA_layout) * x.itemsize() +
+          cute::cosize(sB_layout) * bits / 8,
+      cute::cosize(sC_layout) * x.itemsize());
+
+  auto kernel = mod.get_kernel(kernel_name, [&](CUfunction kernel) {
+    if (smem_bytes > 48000) {
+      cuFuncSetAttribute(
+          kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, smem_bytes);
+    }
+  });
+
+  encoder.add_kernel_node_ex(
+      kernel,
+      num_blocks,
+      block_dims,
+      {},
+      smem_bytes,
+      gpu_ptr<void>(x),
+      gpu_ptr<void>(w),
+      gpu_ptr<void>(scales),
+      biases ? gpu_ptr<void>(*biases) : nullptr,
+      lhs_indices ? gpu_ptr<void>(*lhs_indices) : nullptr,
+      rhs_indices ? gpu_ptr<void>(*rhs_indices) : nullptr,
+      gpu_ptr<void>(out),
+      m,
+      n,
+      k,
+      l,
+      broadcast_b);
+}
+
+} // namespace mlx::core

--- a/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/qmm/qmm_sm80.cu
+++ b/src/lib/mlx-cpp/patches/mlx/backend/cuda/quantized/qmm/qmm_sm80.cu
@@ -20,8 +20,8 @@ inline auto make_cta_tiler(int m, int group_size, cu::Device& device) {
   // #637 (mlxcel overlay): on consumer Blackwell (sm_120/121, cc major >= 12)
   // a 128-row CTA tile fills the SMs far better for large-M (prefill / batched)
   // shapes; the upstream Ampere cap of 64 leaves them underutilized there (ncu:
-  // ~35-47% SM throughput). Measured on GB10: +35% prefill @8192 on
-  // llama-3.1-8b-4bit and +32% on qwen2.5-7b-4bit, greedy-parity identical, no
+  // ~35-47% SM throughput). Measured on GB10: +38% prefill @8192 on
+  // llama-3.1-8b-4bit and +31% on qwen2.5-7b-4bit, greedy-parity identical, no
   // decode regression (decode m=1 takes the qmv path and never reaches here).
   // sm_90/sm_80 keep the stock cap of 64 (untuned here). Wider tile_n / deeper
   // tile_k were also swept but break the fixed-MMA smem layout (JIT failure),


### PR DESCRIPTION
## Summary
Raises the CUDA quantized-matmul (`qmm_sm80`) CTA tile M cap from 64 to 128 on Blackwell consumer GPUs (sm_120/121, `cc_major >= 12`), recovering +31-38% prefill throughput on GB10. Part of epic #623.

Closes #637

## Root cause
`qmm_sm80`'s `make_cta_tiler` caps `tile_m` at 64 (Ampere-tuned). On GB10 (sm_121) the Ampere tile leaves the SMs idle: ncu shows **35-47% SM / 52-68% memory throughput**, and 4bit prefill runs at **0.55x** the bf16 ceiling. (The sm_90 Hopper kernel isn't compiled for arch `121`, so Blackwell falls to the Ampere `qmm_sm80`.)

## Fix
Arch-gated `make_cta_tiler` (overlay `qmm_sm80.cu`): `tile_m` cap = 128 when `device.compute_capability_major() >= 12`, else 64 (stock). A tile sweep confirmed `tile_m` is the **only** safely-tunable axis (wider `tile_n` / deeper `tile_k` break the fixed-MMA shared-memory layout -> JIT failure). Adds `MLXCEL_QMM_TILE_M/N/K` env overrides as a tuning hatch.

## Benchmark (GB10, full detail committed under `docs/benchmark_results/`)
| model | forced tile_m=64 | arch-gated default (128) | delta |
|---|---|---|---|
| llama-3.1-8b-4bit prefill @8192 | 2213 | 3054 | **+38%** |
| qwen2.5-7b-4bit prefill @8192 | 2410 | 3168 | **+31%** |

- Greedy parity: default(128) vs forced(64) generated tokens **byte-identical**.
- Decode (m=1): **unaffected** (single-seq decode takes the qmv path, never reaches `qmm_sm80`).
- 0.55x -> 0.72x of the bf16 ceiling.

## Scope / not addressed
- **Addressed**: large-M prefill + batched prefill on sm_120/121 (+31-38%).
- **NOT addressed**: small-M batched decode (`M*B` in [2,8)) still uses per-row qmv (no weight amortization); the `tile_m` cap doesn't raise small-M tiles. This is the gap behind #714's `--parallel 4` CUDA regression and needs a dedicated small-M kernel (upstream MLX). #714's `--parallel` default should be made backend-aware until then.

## Validation
- C++ overlay change only (no Rust touched). Validated by greedy parity + prefill benchmark (the right gates for a GEMM tile change).
- `make release-cuda` builds clean. The arch gate uses runtime `compute_capability_major()`, so it works for both `121` and `121a` builds (both cc 12.1 at runtime).

## Acceptance criteria (#637)
- [x] Findings doc in `docs/benchmark_results/` (achieved-vs-ceiling, sm_121 dispatch map, ncu roofline, go/no-go).
- [x] >= 25% prefill @8192 on llama-3.1-8b-4bit on GB10 (measured **+38%**), no decode regression, parity green.
- [x] Both `121`/`121a` build (arch-gate is runtime cc, not compile-time arch string).
