### PR TITLE
perf(server): pipeline scheduler decode with lookahead async_eval

### DIFF
--- a/docs/benchmark_results/scheduler-decode-lookahead-gb10-2026-07-10.md
+++ b/docs/benchmark_results/scheduler-decode-lookahead-gb10-2026-07-10.md
@@ -1,0 +1,35 @@
+# Scheduler decode lookahead pipelining acceptance (issue #632, GB10)
+
+Date: 2026-07-10. Host: NVIDIA GB10 (Grace-Blackwell), CUDA build.
+Bench: `bench_serving_concurrency.py` (512 prompt tokens, 512 max tokens) against `mlxcel-bench-decode --prompt-tokens 512` as the matched-context CLI reference; sync baseline via `MLXCEL_FORCE_SYNC=1`. Full run and methodology: PR #729.
+
+## TL;DR
+
+Porting the CLI generation loop's lookahead `async_eval` pipelining into the server `BatchScheduler` decode tick closes most of the structural decode-throughput gap between server and CLI on CUDA. The lookahead pipeline engages 509/511 decode steps per 512-token request, and greedy output stays byte-identical to the `MLXCEL_FORCE_SYNC=1` synchronous path.
+
+## B=1 decode
+
+| case | sync | pipelined | CLI reference | verdict |
+|------|-----:|----------:|--------------:|---------|
+| qwen2.5-0.5b-bf16 B=1 decode | 147.9 | 182.4-191.3 across runs | 199.0-200.3 | pipeline +23-29% over sync; CLI gap 3.9-8.5% (5% AC met at the best run; residual is SSE/HTTP per-token cost, not pipelining) |
+| llama-3.1-8b-4bit B=1 decode (dense backend) | 44.3 (default backend) | 52.0 | 51.8 | server exceeds CLI; AC met |
+| llama-3.1-8b-4bit B=1 decode (default paged backend) | 44.3 | 47.2 | 51.8 | +6.5% over sync; remaining 8.9% gap is the paged-attention decode kernel cost, tracked by #634, reproduced independently of this PR |
+
+## B=4 aggregate
+
+| case | sync | pipelined | verdict |
+|------|-----:|----------:|---------|
+| qwen2.5-0.5b-bf16 B=4 aggregate | 289.7 | 340.5 | +17.5%; AC met |
+| llama-3.1-8b-4bit B=4 aggregate | 44.7 | 46.4 | +3.8% (bounded by the CUDA batched-decode non-amortization caveat from #724) |
+
+## Correctness and coverage
+
+Lookahead engagement: 509/511 decode steps per 512-token request (`mlxcel_batch_decode_lookahead_steps_total`), for cold and prompt-cache-hit requests alike. Greedy outputs are byte-identical pipelined vs `MLXCEL_FORCE_SYNC=1` (orchestrator-independent check on llama plus the implementation's dense/paged checks on qwen). Full `cargo test --release --features cuda --no-fail-fast -- --test-threads=1`: 4362 passed, 1 failed (the pre-existing #728 flake, passes on rerun).
+
+## Side finding
+
+During validation a separate pre-existing anomaly surfaced: decode is ~11% slower after a prompt-cache hit than after a cold prefill, with the pipeline engaged in both modes. Filed as #730, out of scope for this PR.
+
+## Conclusion
+
+The lookahead decode pipeline meets acceptance for the qwen2.5-0.5b-bf16 and llama-3.1-8b-4bit dense-backend cases; the paged-backend llama case is a partial win bounded by the separately tracked #634 paged-attention decode cost, and B=4 llama is bounded by the separately tracked #724 CUDA batched-decode caveat. `MLXCEL_FORCE_SYNC=1` remains the rollback path.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -246,7 +246,7 @@ throughput measurements. Use them for diagnosis, not capacity planning.
 | Variable | Values | Default | Purpose |
 |----------|--------|---------|---------|
 | `MLXCEL_TRACE_DTYPE` | presence enables | off | Prints selected tensor dtypes/shapes during generation. |
-| `MLXCEL_FORCE_SYNC` | presence enables | off | Forces synchronous decode evaluation. |
+| `MLXCEL_FORCE_SYNC` | presence enables | off | Forces synchronous decode evaluation. Also disables the server `BatchScheduler`'s lookahead decode pipeline (issue #632), falling back to the pre-pipeline synchronous tick. |
 | `MLXCEL_PROFILE_PIPELINE` | presence enables | off | Emits high-level generation pipeline timing. |
 | `MLXCEL_PROFILE_PIPELINE_DETAIL` | presence enables | off | Adds per-step pipeline timing detail. |
 | `MLXCEL_PROFILE_BLOCKS` | presence enables | off | Emits per-block/model-family timing where implemented. |

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -345,6 +345,25 @@ rust::Vec<uint8_t> array_to_raw_bytes(const MlxArray& arr) {
     return result;
 }
 
+rust::Vec<uint8_t> array_evaluated_bytes(const MlxArray& arr) {
+    // Surgical read: `array::eval()` waits on THIS array's own completion event
+    // and enqueues no new op, so a later forward already scheduled on the same
+    // stream keeps running on the GPU (the #632 overlap). No `contiguous()` — the
+    // caller guarantees `arr` is already row-contiguous.
+    auto& a = const_cast<mlx::core::array&>(arr.inner);
+    a.eval();
+
+    size_t nbytes = a.nbytes();
+    const auto* data = reinterpret_cast<const uint8_t*>(a.data<void>());
+
+    rust::Vec<uint8_t> result;
+    result.reserve(nbytes);
+    for (size_t i = 0; i < nbytes; ++i) {
+        result.push_back(data[i]);
+    }
+    return result;
+}
+
 // Same body as `array_to_raw_bytes`, but declared `-> Result<Vec<u8>>` on the
 // Rust side so cxx wraps the call in a try/catch and converts any thrown MLX
 // exception (an allocation failure making the contiguous copy, or any deferred

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -349,9 +349,19 @@ rust::Vec<uint8_t> array_evaluated_bytes(const MlxArray& arr) {
     // Surgical read: `array::eval()` waits on THIS array's own completion event
     // and enqueues no new op, so a later forward already scheduled on the same
     // stream keeps running on the GPU (the #632 overlap). No `contiguous()` — the
-    // caller guarantees `arr` is already row-contiguous.
+    // caller is expected to pass an already-row-contiguous array.
     auto& a = const_cast<mlx::core::array&>(arr.inner);
     a.eval();
+
+    // Enforce the contiguity contract rather than trusting the caller: a
+    // non-row-contiguous array's `nbytes()` can exceed the backing allocation
+    // (strided / broadcast views), so reading it here would run past the buffer.
+    // Fall back to the safe `contiguous()` + eval copy in that case. Correct but
+    // slower (it enqueues the extra op the fast path avoids); it should never
+    // trigger for a `fused_sample` output.
+    if (!a.flags().row_contiguous) {
+        return array_to_raw_bytes(arr);
+    }
 
     size_t nbytes = a.nbytes();
     const auto* data = reinterpret_cast<const uint8_t*>(a.data<void>());

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp
@@ -348,7 +348,7 @@ rust::Vec<uint8_t> array_to_raw_bytes(const MlxArray& arr) {
 rust::Vec<uint8_t> array_evaluated_bytes(const MlxArray& arr) {
     // Surgical read: `array::eval()` waits on THIS array's own completion event
     // and enqueues no new op, so a later forward already scheduled on the same
-    // stream keeps running on the GPU (the #632 overlap). No `contiguous()` — the
+    // stream keeps running on the GPU (the #632 overlap). No `contiguous()`: the
     // caller is expected to pass an already-row-contiguous array.
     auto& a = const_cast<mlx::core::array&>(arr.inner);
     a.eval();

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -190,7 +190,9 @@ rust::Vec<uint8_t> try_array_to_raw_bytes(const MlxArray& arr);
 // just scheduled a later forward on the same stream (the #632 lookahead
 // pipeline), evaluating that fresh op would block on the later forward and
 // destroy the overlap. This reader adds no op, so it waits only for `arr`.
-// Caller MUST guarantee `arr` is row-contiguous (e.g. a `fused_sample` output).
+// Intended for an already-row-contiguous `arr` (e.g. a `fused_sample` output);
+// if the array is not row-contiguous it falls back to the safe
+// `array_to_raw_bytes` contiguous copy rather than reading past the allocation.
 rust::Vec<uint8_t> array_evaluated_bytes(const MlxArray& arr);
 
 // Evaluation.

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -183,6 +183,16 @@ rust::Vec<uint8_t> array_to_raw_bytes(const MlxArray& arr);
 // as a Rust `Err` instead of aborting.
 rust::Vec<uint8_t> try_array_to_raw_bytes(const MlxArray& arr);
 
+// Copy an ALREADY-CONTIGUOUS array's data to host, evaluating it with the
+// surgical per-array `array::eval()` (waits on the array's own completion
+// event) rather than `array_to_raw_bytes`' `contiguous()` + `eval()`. The
+// `contiguous()` call enqueues a fresh op onto the stream; when the caller has
+// just scheduled a later forward on the same stream (the #632 lookahead
+// pipeline), evaluating that fresh op would block on the later forward and
+// destroy the overlap. This reader adds no op, so it waits only for `arr`.
+// Caller MUST guarantee `arr` is row-contiguous (e.g. a `fused_sample` output).
+rust::Vec<uint8_t> array_evaluated_bytes(const MlxArray& arr);
+
 // Evaluation.
 void eval(const MlxArray& arr);
 // Fallible counterpart of `eval`; declared `-> Result<()>` in the bridge so cxx

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -176,6 +176,14 @@ mod ffi {
         /// Used by: KV cache serialization for disaggregated inference
         fn array_to_raw_bytes(arr: &MlxArray) -> Vec<u8>;
 
+        /// Copy an ALREADY-CONTIGUOUS array's bytes to host using the surgical
+        /// per-array `array::eval()` (waits on the array's own event, enqueues
+        /// no op). Unlike [`array_to_raw_bytes`] it does not call `contiguous()`,
+        /// so a forward already scheduled on the same stream keeps running on the
+        /// GPU. Caller MUST guarantee `arr` is row-contiguous (e.g. a
+        /// `fused_sample` output). Used by: the #632 lookahead decode pipeline.
+        fn array_evaluated_bytes(arr: &MlxArray) -> Vec<u8>;
+
         /// Fallible counterpart of [`array_to_raw_bytes`].
         ///
         /// Makes the array contiguous, evaluates it, and copies the bytes out,

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -180,8 +180,10 @@ mod ffi {
         /// per-array `array::eval()` (waits on the array's own event, enqueues
         /// no op). Unlike [`array_to_raw_bytes`] it does not call `contiguous()`,
         /// so a forward already scheduled on the same stream keeps running on the
-        /// GPU. Caller MUST guarantee `arr` is row-contiguous (e.g. a
-        /// `fused_sample` output). Used by: the #632 lookahead decode pipeline.
+        /// GPU. Intended for an already-row-contiguous `arr` (e.g. a
+        /// `fused_sample` output); a non-contiguous array falls back to the safe
+        /// `array_to_raw_bytes` copy rather than reading past the allocation.
+        /// Used by: the #632 lookahead decode pipeline.
         fn array_evaluated_bytes(arr: &MlxArray) -> Vec<u8>;
 
         /// Fallible counterpart of [`array_to_raw_bytes`].

--- a/src/server/batch/observability.rs
+++ b/src/server/batch/observability.rs
@@ -156,6 +156,14 @@ pub struct BatchObservability {
     pub prefill_chunks_processed: AtomicU64,
     /// Number of decode steps executed (one per tick per batch).
     pub decode_steps_processed: AtomicU64,
+    /// Number of decode steps served by the lookahead async_eval pipeline
+    /// (issue #632). One increment per steady pipelined tick where the batch
+    /// committed a token from a prebuilt (async-scheduled) forward instead of
+    /// running synchronously. Ticks that fall back to the synchronous path
+    /// (admission, stop, preemption, ineligible sampling, `MLXCEL_FORCE_SYNC`)
+    /// do not increment this, so the ratio against `decode_steps_processed`
+    /// reports how often lookahead actually engaged.
+    pub decode_lookahead_steps: AtomicU64,
 
     // -- Gauges (point-in-time values set by the scheduler) --
     /// Number of sequences currently in the active decode batch.
@@ -224,6 +232,7 @@ impl BatchObservability {
             total_decode_tokens: AtomicU64::new(0),
             prefill_chunks_processed: AtomicU64::new(0),
             decode_steps_processed: AtomicU64::new(0),
+            decode_lookahead_steps: AtomicU64::new(0),
             current_batch_size: AtomicUsize::new(0),
             current_queue_depth: AtomicUsize::new(0),
             cache_pool_active: AtomicUsize::new(0),
@@ -265,6 +274,12 @@ impl BatchObservability {
         self.decode_steps_processed.fetch_add(1, Ordering::Relaxed);
         self.total_decode_tokens
             .fetch_add(batch_size as u64, Ordering::Relaxed);
+    }
+
+    /// Record that one decode step was served by the lookahead async_eval
+    /// pipeline (issue #632). Called once per steady pipelined tick.
+    pub fn record_lookahead_step(&self) {
+        self.decode_lookahead_steps.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Record that a sequence has completed generation.
@@ -384,6 +399,7 @@ impl BatchObservability {
             total_decode_tokens: self.total_decode_tokens.load(Ordering::Relaxed),
             prefill_chunks_processed: self.prefill_chunks_processed.load(Ordering::Relaxed),
             decode_steps_processed: self.decode_steps_processed.load(Ordering::Relaxed),
+            decode_lookahead_steps: self.decode_lookahead_steps.load(Ordering::Relaxed),
             current_batch_size: self.current_batch_size.load(Ordering::Relaxed),
             current_queue_depth: self.current_queue_depth.load(Ordering::Relaxed),
             cache_pool_active: self.cache_pool_active.load(Ordering::Relaxed),
@@ -424,6 +440,8 @@ pub struct ObservabilitySnapshot {
     pub total_decode_tokens: u64,
     pub prefill_chunks_processed: u64,
     pub decode_steps_processed: u64,
+    /// Decode steps served by the lookahead async_eval pipeline (issue #632).
+    pub decode_lookahead_steps: u64,
     pub current_batch_size: usize,
     pub current_queue_depth: usize,
     pub cache_pool_active: usize,
@@ -462,6 +480,7 @@ mod tests {
         assert_eq!(snap.total_decode_tokens, 0);
         assert_eq!(snap.prefill_chunks_processed, 0);
         assert_eq!(snap.decode_steps_processed, 0);
+        assert_eq!(snap.decode_lookahead_steps, 0);
         assert_eq!(snap.current_batch_size, 0);
         assert_eq!(snap.current_queue_depth, 0);
         assert_eq!(snap.cache_pool_active, 0);

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -428,13 +428,18 @@ struct DecodeLookahead {
     tokens: UniquePtr<mlxcel_core::MlxArray>,
 }
 
-/// Copy a `[B]` device token-id array to host as `Vec<i32>` with a single
-/// evaluation. `fused_sample` returns `uint32` ids; the raw bytes are
-/// reinterpreted as `i32`, exact for any token id in `0..vocab_size`. Mirrors
-/// `mlxcel_core::sampling::token_ids_to_host` (which is crate-private) so the
-/// scheduler can read the pipeline's device tokens without an extra dependency.
+/// Copy a `[B]` device token-id array to host as `Vec<i32>`. `fused_sample`
+/// returns a row-contiguous `uint32` array; the raw bytes are reinterpreted as
+/// `i32`, exact for any token id in `0..vocab_size`.
+///
+/// Uses [`mlxcel_core::array_evaluated_bytes`] (surgical per-array `eval`, no
+/// `contiguous()` op) rather than `array_to_raw_bytes`: the steady pipeline has
+/// already scheduled the next forward on the same stream before this read, and
+/// `array_to_raw_bytes`' `contiguous()` would enqueue a fresh op behind that
+/// forward, making the read block on it and collapsing the overlap. This reader
+/// waits only on the token array's own completion event.
 fn lookahead_tokens_to_host(tokens: &mlxcel_core::MlxArray) -> Vec<i32> {
-    let bytes = mlxcel_core::array_to_raw_bytes(tokens);
+    let bytes = mlxcel_core::array_evaluated_bytes(tokens);
     bytes
         .chunks_exact(4)
         .map(|c| i32::from_ne_bytes([c[0], c[1], c[2], c[3]]))
@@ -4465,7 +4470,7 @@ impl BatchScheduler {
             Some(la) => {
                 // Stale id set or no longer eligible/safe: undo the one
                 // speculative KV position and fall back to a clean sync step.
-                self.apply_lookahead_trim(&la.ids);
+                self.apply_lookahead_trim(&la.ids, 1);
                 drop(la);
                 self.dispatch_sync_decode(seq_ids);
                 self.maybe_prime_lookahead(seq_ids);
@@ -4569,7 +4574,16 @@ impl BatchScheduler {
     /// token per layer, releasing any tail block); dense (and dense-natural
     /// paged mirror) sequences trim the dense KV tail and re-mirror the shorter
     /// length into the paged bookkeeping state.
-    fn apply_lookahead_trim(&mut self, ids: &[SequenceId]) {
+    ///
+    /// `positions` is the number of speculative appends to unwind: `1` for a
+    /// teardown before the step-n+1 prime forward has run (admission,
+    /// preemption, stale id set, cancellation seen in `finalize_completed`),
+    /// `2` for the steady-tick teardown that already issued the step-n+1 prime
+    /// (both the step-n and step-n+1 appends).
+    fn apply_lookahead_trim(&mut self, ids: &[SequenceId], positions: usize) {
+        if positions == 0 {
+            return;
+        }
         let num_layers = self.model.num_layers();
         for &seq_id in ids {
             let paged_backed = self
@@ -4579,11 +4593,11 @@ impl BatchScheduler {
                 .unwrap_or(false);
             if paged_backed {
                 for layer in 0..num_layers {
-                    let _ = self.cache_pool.rewind_paged_tokens(seq_id, layer, 1);
+                    let _ = self.cache_pool.rewind_paged_tokens(seq_id, layer, positions);
                 }
             } else if let Some(caches) = self.cache_pool.get_caches_mut(seq_id) {
                 for cache in caches {
-                    cache.trim(1);
+                    cache.trim(positions as i32);
                 }
                 // Re-mirror the shorter dense length into any paged bookkeeping
                 // (no-op for a pure dense pool).
@@ -4598,7 +4612,9 @@ impl BatchScheduler {
     /// before completion / cancellation donation (`finalize_completed`).
     fn discard_lookahead(&mut self) {
         if let Some(la) = self.decode_lookahead.take() {
-            self.apply_lookahead_trim(&la.ids);
+            // A stored lookahead carries exactly one speculative append per
+            // sequence (the prime forward that produced its tokens).
+            self.apply_lookahead_trim(&la.ids, 1);
         }
     }
 
@@ -4625,22 +4641,22 @@ impl BatchScheduler {
             }
         }
         let input = mlxcel_core::from_slice_i32(&last_tokens, &[seq_ids.len() as i32, 1]);
-        self.prime_lookahead_with_input(seq_ids, &input, &params);
+        self.decode_lookahead = self.prime_lookahead_with_input(seq_ids, &input, &params);
     }
 
     /// Run one forward for `seq_ids` on `input` (`[B, 1]`), fused-sample the
-    /// next tokens on-device, schedule them with `async_eval`, and store the
-    /// prebuilt step. The forward appends one KV position per sequence (the
-    /// speculative advance undone by [`Self::apply_lookahead_trim`]).
+    /// next tokens on-device, schedule them with `async_eval`, and return the
+    /// prebuilt step. The forward appends one speculative KV position per
+    /// sequence (undone by [`Self::apply_lookahead_trim`]). Returns `None` if a
+    /// sequence's caches vanished. The caller decides whether to keep the step
+    /// (store it in `decode_lookahead`) or unwind it.
     fn prime_lookahead_with_input(
         &mut self,
         seq_ids: &[SequenceId],
         input: &mlxcel_core::MlxArray,
         params: &FusedSampleParams,
-    ) {
-        let Some(logits) = self.lookahead_forward(seq_ids, input) else {
-            return;
-        };
+    ) -> Option<DecodeLookahead> {
+        let logits = self.lookahead_forward(seq_ids, input)?;
         let last_logits = mlxcel_core::slice_last_logits(&logits);
         let tokens = mlxcel_core::fused_sample(
             &last_logits,
@@ -4651,12 +4667,12 @@ impl BatchScheduler {
         );
         // Schedule the sampled tokens (and thus the whole forward graph) without
         // reading them to host, so the GPU runs ahead while the caller returns
-        // to the scheduler loop.
+        // to the scheduler loop and reads the PREVIOUS step's tokens.
         mlxcel_core::async_eval(&tokens);
-        self.decode_lookahead = Some(DecodeLookahead {
+        Some(DecodeLookahead {
             ids: seq_ids.to_vec(),
             tokens,
-        });
+        })
     }
 
     /// Forward pass for the lookahead pipeline, mirroring the synchronous decode
@@ -4694,73 +4710,84 @@ impl BatchScheduler {
         Some(logits)
     }
 
-    /// Steady pipelined decode: consume the prebuilt step, and if no sequence
-    /// finishes, commit its tokens and prime the next step from the same device
-    /// token array (no host round-trip for the forward input). Any finish or
-    /// unsafe condition tears the pipeline down and re-runs the tick
-    /// synchronously so completion / donation flows through the untouched sync
-    /// path from a clean cache state.
+    /// Steady pipelined decode, ordered exactly like the CLI generation loop
+    /// (`generate.rs`) so the GPU never idles on the host read:
+    ///
+    /// 1. FIRST build and `async_eval` step n+1 from `la.tokens` fed back
+    ///    device-side (no host knowledge needed). The GPU starts the next
+    ///    forward immediately.
+    /// 2. THEN read step n's tokens to host (this blocks on the PREVIOUS tick's
+    ///    prime forward, which by now has finished, while step n+1 runs on the
+    ///    GPU) and run the finish pre-check.
+    /// 3. If a row finishes (EOS / length / cancel) or the shape is off, unwind
+    ///    BOTH speculative appends (step n and the just-issued step n+1) and
+    ///    re-run the tick synchronously, so completion / donation flows through
+    ///    the untouched sync path from a clean cache state.
+    /// 4. Otherwise commit step n and keep the step n+1 prebuilt step.
     fn pipelined_steady_decode(
         &mut self,
         la: DecodeLookahead,
         seq_ids: &[SequenceId],
         params: &FusedSampleParams,
     ) {
-        // Sync point: read the prebuilt tokens to host (blocks on the in-flight
-        // prime forward). The overlap has already been paid — the GPU ran the
-        // forward while the previous tick did its host bookkeeping.
-        let toks = lookahead_tokens_to_host(&la.tokens);
-        if toks.len() != seq_ids.len() {
-            // Defensive: shape mismatch should be impossible, but never commit a
-            // misaligned batch. Fall back cleanly.
-            self.apply_lookahead_trim(&la.ids);
-            drop(la);
-            self.dispatch_sync_decode(seq_ids);
-            self.maybe_prime_lookahead(seq_ids);
-            return;
-        }
+        // Step 1: speculatively build + schedule step n+1 FIRST. Feed la.tokens
+        // ([B]) back as the next [B, 1] input device-side (reshape + int32 cast
+        // to match the synchronous from_slice_i32 dtype), keeping the GPU busy
+        // through the host read below. This appends a second speculative KV
+        // position per sequence (the overshoot the issue accepts).
+        let col = mlxcel_core::reshape_token_for_forward(&la.tokens);
+        let next_input = mlxcel_core::astype(&col, mlxcel_core::dtype::INT32);
+        let next = self.prime_lookahead_with_input(seq_ids, &next_input, params);
 
-        // Pre-check every host-knowable finish (EOS, length) plus cancellation.
-        // Loop detection is excluded by eligibility. Any finish means the batch
-        // changes next tick, so hand the whole tick to the synchronous path.
-        let mut finishing = false;
-        for (i, &seq_id) in seq_ids.iter().enumerate() {
-            let Some(seq) = self.active_batch.get(seq_id) else {
-                finishing = true;
-                break;
-            };
-            if lookahead_token_finishes(
-                toks[i],
-                seq.generated_tokens.len(),
-                seq.max_tokens,
-                &seq.merged_eos,
-                seq.cancelled.load(Ordering::Relaxed),
-            ) {
-                finishing = true;
-                break;
+        // Step 2: read step n's tokens to host (the sync point) and finish-check.
+        let toks = lookahead_tokens_to_host(&la.tokens);
+        let mut finishing = toks.len() != seq_ids.len();
+        if !finishing {
+            for (i, &seq_id) in seq_ids.iter().enumerate() {
+                let Some(seq) = self.active_batch.get(seq_id) else {
+                    finishing = true;
+                    break;
+                };
+                if lookahead_token_finishes(
+                    toks[i],
+                    seq.generated_tokens.len(),
+                    seq.max_tokens,
+                    &seq.merged_eos,
+                    seq.cancelled.load(Ordering::Relaxed),
+                ) {
+                    finishing = true;
+                    break;
+                }
             }
         }
 
         if finishing {
-            self.apply_lookahead_trim(&la.ids);
+            // Step 3: tear down. Sync the in-flight step n+1 forward so its
+            // kernels are not still writing KV when we rewind, then unwind both
+            // speculative appends (step n from the previous prime plus step n+1
+            // when it was actually issued) back to the synchronous-decode
+            // invariant and re-run the tick synchronously.
+            let positions = match &next {
+                Some(nla) => {
+                    mlxcel_core::eval(&nla.tokens);
+                    2
+                }
+                None => 1,
+            };
+            self.apply_lookahead_trim(&la.ids, positions);
+            drop(next);
             drop(la);
             self.dispatch_sync_decode(seq_ids);
             self.maybe_prime_lookahead(seq_ids);
             return;
         }
 
-        // Every row continues: commit the prebuilt tokens (reusing the batched
-        // fast-path bookkeeping — no finish can fire after the pre-check), then
-        // feed the SAME device token array back as the next [B, 1] input and
-        // prime the next forward.
-        self.apply_fused_decode_tokens(seq_ids, &toks);
-
-        // Device-side feedback: reshape [B] -> [B, 1] and cast to int32 to match
-        // the synchronous `from_slice_i32` input dtype exactly.
-        let col = mlxcel_core::reshape_token_for_forward(&la.tokens);
-        let next_input = mlxcel_core::astype(&col, mlxcel_core::dtype::INT32);
+        // Step 4: every row continues. Commit step n (reusing the batched
+        // fast-path bookkeeping; no finish can fire after the pre-check) and
+        // keep the already-primed step n+1.
         drop(la);
-        self.prime_lookahead_with_input(seq_ids, &next_input, params);
+        self.apply_fused_decode_tokens(seq_ids, &toks);
+        self.decode_lookahead = next;
         self.batch_observability.record_lookahead_step();
     }
 

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -4558,8 +4558,7 @@ impl BatchScheduler {
                 Some(set)
                     if matches!(
                         set.backend,
-                        SequenceStateBackend::DenseKvCache
-                            | SequenceStateBackend::PagedKvCache
+                        SequenceStateBackend::DenseKvCache | SequenceStateBackend::PagedKvCache
                     ) => {}
                 _ => return None,
             }
@@ -4611,7 +4610,9 @@ impl BatchScheduler {
                     // A failed rewind silently leaks the speculative KV
                     // position(s), which would corrupt a later donation of this
                     // sequence's cache; surface it so the leak is diagnosable.
-                    if let Err(err) = self.cache_pool.rewind_paged_tokens(seq_id, layer, positions)
+                    if let Err(err) = self
+                        .cache_pool
+                        .rewind_paged_tokens(seq_id, layer, positions)
                     {
                         tracing::warn!(
                             seq_id = %seq_id,
@@ -5452,9 +5453,10 @@ impl BatchScheduler {
         // reuse and the surviving sequences rebuild their pipeline next tick
         // (#632 constraints 2, 3, 6). No-op on the steady no-finish path.
         if self.decode_lookahead.is_some()
-            && self.active_batch.iter_sequences().any(|s| {
-                s.state.is_finished() || s.cancelled.load(Ordering::Relaxed)
-            })
+            && self
+                .active_batch
+                .iter_sequences()
+                .any(|s| s.state.is_finished() || s.cancelled.load(Ordering::Relaxed))
         {
             self.discard_lookahead();
         }

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -473,6 +473,19 @@ fn lookahead_token_finishes(
     cancelled || merged_eos.contains(&next_token) || generated_len + 1 >= max_tokens
 }
 
+/// Number of speculative KV positions a lookahead teardown must unwind.
+///
+/// The steady tick issues step n+1's prime forward BEFORE it learns step n's
+/// finish outcome, so a teardown after a successful prime (`next_prime_issued`)
+/// must unwind two speculative appends (step n plus step n+1). A prime that
+/// bailed (its forward returned `None`) or any teardown that runs before a prime
+/// (admission, preemption, stale id set, cancellation in `finalize_completed`)
+/// unwinds one (step n only). Mirrors the count selection in
+/// [`BatchScheduler::pipelined_steady_decode`] and the `1`-position teardowns.
+fn lookahead_teardown_positions(next_prime_issued: bool) -> usize {
+    if next_prime_issued { 2 } else { 1 }
+}
+
 impl BatchScheduler {
     fn release_sequence_caches(&mut self, seq_id: SequenceId) {
         self.model.release_sequence_state_by_id(seq_id);
@@ -4468,9 +4481,10 @@ impl BatchScheduler {
                 self.pipelined_steady_decode(la, seq_ids, &params.unwrap());
             }
             Some(la) => {
-                // Stale id set or no longer eligible/safe: undo the one
-                // speculative KV position and fall back to a clean sync step.
-                self.apply_lookahead_trim(&la.ids, 1);
+                // Stale id set or no longer eligible/safe: no step n+1 prime was
+                // issued, so undo the one speculative KV position and fall back
+                // to a clean sync step.
+                self.apply_lookahead_trim(&la.ids, lookahead_teardown_positions(false));
                 drop(la);
                 self.dispatch_sync_decode(seq_ids);
                 self.maybe_prime_lookahead(seq_ids);
@@ -4509,8 +4523,9 @@ impl BatchScheduler {
     /// deliberately narrow: it reuses the batched-fused predicate (which
     /// already rejects penalties/token-history, token bias, structured-output
     /// masks, thinking-budget overrides, and per-token logprobs) and further
-    /// requires dense caches, no `--max-kv-size`, no paged decode, no
-    /// speculative dispatch, and `MLXCEL_FORCE_SYNC` unset.
+    /// requires a trimmable KV tail (dense or pool-backed paged; model-owned
+    /// SSM / hybrid / mixed-cache backends stay synchronous), no
+    /// `--max-kv-size`, no speculative dispatch, and `MLXCEL_FORCE_SYNC` unset.
     fn lookahead_params(&self, seq_ids: &[SequenceId]) -> Option<FusedSampleParams> {
         if self.lookahead_force_sync {
             return None;
@@ -4593,11 +4608,38 @@ impl BatchScheduler {
                 .unwrap_or(false);
             if paged_backed {
                 for layer in 0..num_layers {
-                    let _ = self.cache_pool.rewind_paged_tokens(seq_id, layer, positions);
+                    // A failed rewind silently leaks the speculative KV
+                    // position(s), which would corrupt a later donation of this
+                    // sequence's cache; surface it so the leak is diagnosable.
+                    if let Err(err) = self.cache_pool.rewind_paged_tokens(seq_id, layer, positions)
+                    {
+                        tracing::warn!(
+                            seq_id = %seq_id,
+                            layer,
+                            positions,
+                            "lookahead teardown: paged rewind failed, speculative KV \
+                             position may leak: {err}"
+                        );
+                    }
                 }
             } else if let Some(caches) = self.cache_pool.get_caches_mut(seq_id) {
-                for cache in caches {
-                    cache.trim(positions as i32);
+                let want = positions as i32;
+                for (layer, cache) in caches.iter_mut().enumerate() {
+                    // KVCache::trim clamps to the live window and returns the
+                    // count actually removed; a short trim means a speculative
+                    // position was not unwound (e.g. an unexpectedly short cache),
+                    // which would desync the KV against generated_tokens.
+                    let trimmed = cache.trim(want);
+                    if trimmed != want {
+                        tracing::warn!(
+                            seq_id = %seq_id,
+                            layer,
+                            requested = want,
+                            trimmed,
+                            "lookahead teardown: dense trim removed fewer positions \
+                             than requested, KV may be out of sync"
+                        );
+                    }
                 }
                 // Re-mirror the shorter dense length into any paged bookkeeping
                 // (no-op for a pure dense pool).
@@ -4613,8 +4655,9 @@ impl BatchScheduler {
     fn discard_lookahead(&mut self) {
         if let Some(la) = self.decode_lookahead.take() {
             // A stored lookahead carries exactly one speculative append per
-            // sequence (the prime forward that produced its tokens).
-            self.apply_lookahead_trim(&la.ids, 1);
+            // sequence (the prime forward that produced its tokens); no step
+            // n+1 prime has been issued on this teardown path.
+            self.apply_lookahead_trim(&la.ids, lookahead_teardown_positions(false));
         }
     }
 
@@ -4767,13 +4810,10 @@ impl BatchScheduler {
             // speculative appends (step n from the previous prime plus step n+1
             // when it was actually issued) back to the synchronous-decode
             // invariant and re-run the tick synchronously.
-            let positions = match &next {
-                Some(nla) => {
-                    mlxcel_core::eval(&nla.tokens);
-                    2
-                }
-                None => 1,
-            };
+            if let Some(nla) = &next {
+                mlxcel_core::eval(&nla.tokens);
+            }
+            let positions = lookahead_teardown_positions(next.is_some());
             self.apply_lookahead_trim(&la.ids, positions);
             drop(next);
             drop(la);

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -4657,6 +4657,13 @@ impl BatchScheduler {
             // A stored lookahead carries exactly one speculative append per
             // sequence (the prime forward that produced its tokens); no step
             // n+1 prime has been issued on this teardown path.
+            //
+            // Unlike the steady finishing path, no pre-trim eval is needed
+            // here even if that prime is still in flight: KVCache::trim only
+            // adjusts a host-tracked offset, and all decode work runs on the
+            // single generation stream, so the lazy slice the trim enqueues is
+            // dependency-ordered after the append. The finishing path's eval
+            // is defensive, not required for safety.
             self.apply_lookahead_trim(&la.ids, lookahead_teardown_positions(false));
         }
     }
@@ -4817,6 +4824,14 @@ impl BatchScheduler {
             self.apply_lookahead_trim(&la.ids, positions);
             drop(next);
             drop(la);
+            // The sync re-dispatch below re-samples step n's token. fused_sample
+            // draws from MLX's global RNG (random::categorical without an
+            // explicit key), so at temperature > 0 the re-drawn token can
+            // differ from the discarded lookahead sample that triggered this
+            // finish pre-check; greedy (temp 0) is unaffected, matching the
+            // byte-equivalence gate. Bounded to one token per completing
+            // request, and stochastic runs carry no cross-mode determinism
+            // guarantee.
             self.dispatch_sync_decode(seq_ids);
             self.maybe_prime_lookahead(seq_ids);
             return;

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -394,6 +394,78 @@ pub struct BatchScheduler {
     /// the in-crate seam it builds on.
     #[allow(dead_code)]
     paged_handoff_geometry: Option<crate::distributed::kv_cache_serde::ExpectedBlockGeometry>,
+
+    // -- Lookahead async_eval decode pipeline (issue #632) --
+    /// Prebuilt next-step tokens for the active decode batch, scheduled with
+    /// `async_eval` one tick ahead so the GPU forward overlaps the host-side
+    /// commit / stop-check / next-tick bookkeeping. `None` outside a steady
+    /// pipelined run (the bit-exact synchronous fallback). See
+    /// [`DecodeLookahead`] and [`Self::execute_decode_step`] for the state
+    /// machine and every invalidation trigger.
+    decode_lookahead: Option<DecodeLookahead>,
+
+    /// `MLXCEL_FORCE_SYNC` kill switch, read once at construction (mirrors the
+    /// CLI generation loop's hoisted env probe). When `true` the scheduler
+    /// never engages the lookahead pipeline and every decode tick runs
+    /// synchronously, so the sync path stays available for A/B equivalence.
+    lookahead_force_sync: bool,
+}
+
+/// One prebuilt decode step held across ticks by the lookahead pipeline.
+///
+/// The `tokens` array was sampled from a forward that has already been issued
+/// (`async_eval`), and that forward appended exactly one KV position per
+/// sequence (the last committed token). `tokens` themselves are NOT yet
+/// committed and NOT yet in the KV cache. Tearing the pipeline down
+/// (`discard_lookahead`) trims that one speculative KV position per sequence
+/// and drops `tokens`, restoring the exact synchronous-decode cache invariant.
+struct DecodeLookahead {
+    /// Active sequence id set this step was built for, in batch order. The
+    /// pipeline is only consumed when the next tick decodes this identical set.
+    ids: Vec<SequenceId>,
+    /// `[B]` device token-id array (uint32), one per `ids` entry, already
+    /// scheduled with `async_eval`.
+    tokens: UniquePtr<mlxcel_core::MlxArray>,
+}
+
+/// Copy a `[B]` device token-id array to host as `Vec<i32>` with a single
+/// evaluation. `fused_sample` returns `uint32` ids; the raw bytes are
+/// reinterpreted as `i32`, exact for any token id in `0..vocab_size`. Mirrors
+/// `mlxcel_core::sampling::token_ids_to_host` (which is crate-private) so the
+/// scheduler can read the pipeline's device tokens without an extra dependency.
+fn lookahead_tokens_to_host(tokens: &mlxcel_core::MlxArray) -> Vec<i32> {
+    let bytes = mlxcel_core::array_to_raw_bytes(tokens);
+    bytes
+        .chunks_exact(4)
+        .map(|c| i32::from_ne_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+/// Pure decision: may the lookahead pipeline stay engaged for the next tick?
+///
+/// False when the next tick would change batch membership: a queued request is
+/// waiting to be admitted, a chunked prefill is interleaving, or a preemption is
+/// pending. Extracted from [`BatchScheduler::lookahead_safe`] so unit tests can
+/// exercise every invalidation trigger without constructing a live model.
+fn lookahead_pipeline_safe(queue_empty: bool, chunked_in_progress: bool, preempting: bool) -> bool {
+    queue_empty && !chunked_in_progress && !preempting
+}
+
+/// Pure decision: does committing `next_token` finish this sequence?
+///
+/// A finishing token (cancellation, an EOS / stop id, or the length limit) forces
+/// the steady pipeline to discard its prebuilt step and re-run the tick
+/// synchronously, so completion and prompt-cache donation always flow through the
+/// untouched synchronous path from a clean cache state. Mirrors the per-row
+/// pre-check in [`BatchScheduler::pipelined_steady_decode`].
+fn lookahead_token_finishes(
+    next_token: i32,
+    generated_len: usize,
+    max_tokens: usize,
+    merged_eos: &[i32],
+    cancelled: bool,
+) -> bool {
+    cancelled || merged_eos.contains(&next_token) || generated_len + 1 >= max_tokens
 }
 
 impl BatchScheduler {
@@ -917,6 +989,11 @@ impl BatchScheduler {
             // MTP dispatch. The non-speculative hot path never touches it.
             mtp_policy: None,
             paged_handoff_geometry: None,
+            decode_lookahead: None,
+            // Honor MLXCEL_FORCE_SYNC=1 as the pipeline kill switch, probed once
+            // here (the server worker is long-lived, so a per-tick getenv would
+            // be pure overhead).
+            lookahead_force_sync: std::env::var("MLXCEL_FORCE_SYNC").is_ok(),
         }
     }
 
@@ -1967,6 +2044,12 @@ impl BatchScheduler {
             // 3. Execute
             match action {
                 BatchSchedulerAction::Prefill(seq_id) => {
+                    // Admission / chunked-prefill interleave / preemption all
+                    // change batch membership; tear down any prebuilt lookahead
+                    // (trimming its speculative KV) before the prefill runs so
+                    // the next decode rebuilds against the new batch (#632
+                    // invalidation).
+                    self.discard_lookahead();
                     // Use batched prefill when max_batch_prefill > 1 and at
                     // least 2 requests are waiting, otherwise take the regular
                     // single-request path so there is zero overhead for the
@@ -4339,14 +4422,346 @@ impl BatchScheduler {
         let _span = tracing::info_span!("decode_step", batch_size = seq_ids.len(),).entered();
         self.batch_observability.record_decode_step(seq_ids.len());
 
+        // Lookahead async_eval pipeline (issue #632). Eligible batches overlap
+        // the next forward with the current tick's host bookkeeping; anything
+        // outside the narrow eligibility window (see `lookahead_params`) runs
+        // the untouched synchronous path. `run_decode_tick` owns the state
+        // machine and always leaves the caches in the synchronous-decode
+        // invariant on any teardown, so the fallback is bit-exact.
+        self.run_decode_tick(seq_ids);
+    }
+
+    /// Raw synchronous decode dispatch for `seq_ids` (no observability
+    /// recording; the caller already counted the step). B=1 and non-batching
+    /// models take the per-sequence path; larger batches take the batched
+    /// forward. This is the exact pre-#632 behavior and the pipeline's
+    /// guaranteed fallback.
+    fn dispatch_sync_decode(&mut self, seq_ids: &[SequenceId]) {
         if seq_ids.len() <= 1 || !self.model.supports_batching() {
             for &seq_id in seq_ids {
                 self.decode_single_step(seq_id);
             }
             return;
         }
-
         self.execute_batched_decode(seq_ids);
+    }
+
+    /// Drive one decode tick through the lookahead pipeline state machine.
+    ///
+    /// States:
+    /// - A prebuilt lookahead for the identical id set and still-safe
+    ///   conditions -> steady pipelined commit + re-prime.
+    /// - A prebuilt lookahead that is stale (id set changed) or now unsafe ->
+    ///   discard (trim + drop), run synchronously, then re-prime if eligible.
+    /// - No prebuilt lookahead -> run synchronously, then prime if eligible
+    ///   (bootstrap).
+    fn run_decode_tick(&mut self, seq_ids: &[SequenceId]) {
+        let params = self.lookahead_params(seq_ids);
+
+        match self.decode_lookahead.take() {
+            Some(la) if la.ids == seq_ids && params.is_some() && self.lookahead_safe() => {
+                self.pipelined_steady_decode(la, seq_ids, &params.unwrap());
+            }
+            Some(la) => {
+                // Stale id set or no longer eligible/safe: undo the one
+                // speculative KV position and fall back to a clean sync step.
+                self.apply_lookahead_trim(&la.ids);
+                drop(la);
+                self.dispatch_sync_decode(seq_ids);
+                self.maybe_prime_lookahead(seq_ids);
+            }
+            None => {
+                self.dispatch_sync_decode(seq_ids);
+                self.maybe_prime_lookahead(seq_ids);
+            }
+        }
+    }
+
+    /// Batched decode-storage context for the active backend. Shared by the
+    /// synchronous batched decode and the lookahead prime so both drive the
+    /// identical dense / native-paged execution path.
+    fn decode_batch_context(&self) -> DecodeBatchContext {
+        match self.decode_storage_backend {
+            DecodeStorageBackend::Auto | DecodeStorageBackend::Dense => {
+                debug_assert_ne!(
+                    self.decode_storage_backend,
+                    DecodeStorageBackend::Auto,
+                    "scheduler should normalize decode storage backend before decode dispatch"
+                );
+                DecodeBatchContext::dense()
+            }
+            DecodeStorageBackend::Paged => DecodeBatchContext {
+                storage_backend: CoreDecodeStorageBackend::Paged,
+                paged_block_size: DEFAULT_PAGED_BLOCK_SIZE as i32,
+                use_native_paged_kernel: true,
+            },
+        }
+    }
+
+    /// Whether the active decode batch is eligible for the lookahead pipeline
+    /// this tick, returning the shared fused sampling params on success. A
+    /// `None` return routes the tick to the synchronous path. The gate is
+    /// deliberately narrow: it reuses the batched-fused predicate (which
+    /// already rejects penalties/token-history, token bias, structured-output
+    /// masks, thinking-budget overrides, and per-token logprobs) and further
+    /// requires dense caches, no `--max-kv-size`, no paged decode, no
+    /// speculative dispatch, and `MLXCEL_FORCE_SYNC` unset.
+    fn lookahead_params(&self, seq_ids: &[SequenceId]) -> Option<FusedSampleParams> {
+        if self.lookahead_force_sync {
+            return None;
+        }
+        // Speculative decoding drives its own decode loop.
+        if self.should_dispatch_speculative() {
+            return None;
+        }
+        // --max-kv-size trims the live window mid-decode (trim_front); keep
+        // those runs synchronous so the speculative +1 accounting stays simple.
+        if self.max_kv_size.is_some() {
+            return None;
+        }
+        // The batched fused gate rejects every per-row feature the device
+        // feedback path cannot honor; reusing it keeps pipeline sampling
+        // bit-identical to the fast path it accelerates.
+        let params = self.batched_decode_fused_params(seq_ids)?;
+        for &seq_id in seq_ids {
+            let seq = self.active_batch.get(seq_id)?;
+            // Loop detection needs a post-commit host scan the steady path
+            // skips (off by default, so no common-case cost).
+            if seq.sampling.loop_detection.is_enabled() {
+                return None;
+            }
+            // Dense and pool-backed paged sequences both have a trimmable KV
+            // tail (dense via KVCache::trim, paged via the pool rewind API in
+            // apply_lookahead_trim). Model-owned families (SSM / hybrid /
+            // mixed-cache) carry no such tail, so they stay synchronous.
+            match self.cache_pool.get(seq_id) {
+                Some(set)
+                    if matches!(
+                        set.backend,
+                        SequenceStateBackend::DenseKvCache
+                            | SequenceStateBackend::PagedKvCache
+                    ) => {}
+                _ => return None,
+            }
+        }
+        Some(params)
+    }
+
+    /// Conditions under which priming the next forward is safe: the next tick
+    /// will decode this identical id set. False on a pending admission
+    /// (queue non-empty), a chunked-prefill interleave, or a pending
+    /// preemption, each of which mutates batch membership next tick.
+    fn lookahead_safe(&self) -> bool {
+        lookahead_pipeline_safe(
+            self.prefill_queue.is_empty(),
+            self.chunked_prefill_seq.is_some(),
+            self.should_preempt(),
+        )
+    }
+
+    /// Trim the one speculative KV position the prime forward appended from
+    /// each sequence, restoring the synchronous-decode invariant (the last
+    /// committed token is not yet in the KV cache). Called on every pipeline
+    /// teardown before the synchronous path, a completion, or a prompt-cache
+    /// donation runs, so slot reuse and detach always see clean caches.
+    ///
+    /// Pool-backed paged sequences rewind through the pool block table (one
+    /// token per layer, releasing any tail block); dense (and dense-natural
+    /// paged mirror) sequences trim the dense KV tail and re-mirror the shorter
+    /// length into the paged bookkeeping state.
+    fn apply_lookahead_trim(&mut self, ids: &[SequenceId]) {
+        let num_layers = self.model.num_layers();
+        for &seq_id in ids {
+            let paged_backed = self
+                .cache_pool
+                .get(seq_id)
+                .map(|s| s.caches.iter().any(|c| c.is_paged_backed()))
+                .unwrap_or(false);
+            if paged_backed {
+                for layer in 0..num_layers {
+                    let _ = self.cache_pool.rewind_paged_tokens(seq_id, layer, 1);
+                }
+            } else if let Some(caches) = self.cache_pool.get_caches_mut(seq_id) {
+                for cache in caches {
+                    cache.trim(1);
+                }
+                // Re-mirror the shorter dense length into any paged bookkeeping
+                // (no-op for a pure dense pool).
+                self.sync_sequence_storage(seq_id);
+            }
+        }
+    }
+
+    /// Tear down any live lookahead: trim the speculative KV position from each
+    /// of its sequences and drop the prebuilt tokens. Idempotent no-op when the
+    /// pipeline is idle. Invoked before admission / preemption (`run`) and
+    /// before completion / cancellation donation (`finalize_completed`).
+    fn discard_lookahead(&mut self) {
+        if let Some(la) = self.decode_lookahead.take() {
+            self.apply_lookahead_trim(&la.ids);
+        }
+    }
+
+    /// Prime the next forward for `seq_ids` after a synchronous step (pipeline
+    /// bootstrap). Reads each sequence's last committed token from host state,
+    /// builds the `[B, 1]` input, and schedules the forward + fused sample.
+    /// No-op unless eligible, safe, and every sequence is still live.
+    fn maybe_prime_lookahead(&mut self, seq_ids: &[SequenceId]) {
+        let Some(params) = self.lookahead_params(seq_ids) else {
+            return;
+        };
+        if !self.lookahead_safe() {
+            return;
+        }
+        // A sequence that just finished (EOS / length) leaves the batch next
+        // tick; do not prime across a membership change.
+        let mut last_tokens: Vec<i32> = Vec::with_capacity(seq_ids.len());
+        for &seq_id in seq_ids {
+            match self.active_batch.get(seq_id) {
+                Some(seq) if !seq.state.is_finished() => {
+                    last_tokens.push(*seq.generated_tokens.last().unwrap_or(&0));
+                }
+                _ => return,
+            }
+        }
+        let input = mlxcel_core::from_slice_i32(&last_tokens, &[seq_ids.len() as i32, 1]);
+        self.prime_lookahead_with_input(seq_ids, &input, &params);
+    }
+
+    /// Run one forward for `seq_ids` on `input` (`[B, 1]`), fused-sample the
+    /// next tokens on-device, schedule them with `async_eval`, and store the
+    /// prebuilt step. The forward appends one KV position per sequence (the
+    /// speculative advance undone by [`Self::apply_lookahead_trim`]).
+    fn prime_lookahead_with_input(
+        &mut self,
+        seq_ids: &[SequenceId],
+        input: &mlxcel_core::MlxArray,
+        params: &FusedSampleParams,
+    ) {
+        let Some(logits) = self.lookahead_forward(seq_ids, input) else {
+            return;
+        };
+        let last_logits = mlxcel_core::slice_last_logits(&logits);
+        let tokens = mlxcel_core::fused_sample(
+            &last_logits,
+            params.temperature,
+            params.top_k,
+            params.top_p,
+            params.min_p,
+        );
+        // Schedule the sampled tokens (and thus the whole forward graph) without
+        // reading them to host, so the GPU runs ahead while the caller returns
+        // to the scheduler loop.
+        mlxcel_core::async_eval(&tokens);
+        self.decode_lookahead = Some(DecodeLookahead {
+            ids: seq_ids.to_vec(),
+            tokens,
+        });
+    }
+
+    /// Forward pass for the lookahead pipeline, mirroring the synchronous decode
+    /// forward exactly: the B=1 per-sequence path
+    /// ([`Self::decode_single_step`]) or the batched path
+    /// ([`Self::execute_batched_decode`]) with the same decode-storage context.
+    /// Returns `None` if a sequence's caches vanished (the caller then skips
+    /// priming).
+    fn lookahead_forward(
+        &mut self,
+        seq_ids: &[SequenceId],
+        input: &mlxcel_core::MlxArray,
+    ) -> Option<UniquePtr<mlxcel_core::MlxArray>> {
+        let logits = if seq_ids.len() == 1 {
+            let seq_id = seq_ids[0];
+            let caches = self.cache_pool.get_caches_mut(seq_id)?;
+            self.model
+                .forward_with_sequence_id(input, Some(seq_id), caches, None)
+        } else {
+            let decode_context = self.decode_batch_context();
+            let mut batch_caches = self.cache_pool.get_batch_caches_mut(seq_ids).ok()?;
+            let logits = self.model.forward_batched_with_context_and_ids(
+                input,
+                Some(seq_ids),
+                &mut batch_caches,
+                None,
+                Some(&decode_context),
+            );
+            drop(batch_caches);
+            logits
+        };
+        for &seq_id in seq_ids {
+            self.sync_sequence_storage(seq_id);
+        }
+        Some(logits)
+    }
+
+    /// Steady pipelined decode: consume the prebuilt step, and if no sequence
+    /// finishes, commit its tokens and prime the next step from the same device
+    /// token array (no host round-trip for the forward input). Any finish or
+    /// unsafe condition tears the pipeline down and re-runs the tick
+    /// synchronously so completion / donation flows through the untouched sync
+    /// path from a clean cache state.
+    fn pipelined_steady_decode(
+        &mut self,
+        la: DecodeLookahead,
+        seq_ids: &[SequenceId],
+        params: &FusedSampleParams,
+    ) {
+        // Sync point: read the prebuilt tokens to host (blocks on the in-flight
+        // prime forward). The overlap has already been paid — the GPU ran the
+        // forward while the previous tick did its host bookkeeping.
+        let toks = lookahead_tokens_to_host(&la.tokens);
+        if toks.len() != seq_ids.len() {
+            // Defensive: shape mismatch should be impossible, but never commit a
+            // misaligned batch. Fall back cleanly.
+            self.apply_lookahead_trim(&la.ids);
+            drop(la);
+            self.dispatch_sync_decode(seq_ids);
+            self.maybe_prime_lookahead(seq_ids);
+            return;
+        }
+
+        // Pre-check every host-knowable finish (EOS, length) plus cancellation.
+        // Loop detection is excluded by eligibility. Any finish means the batch
+        // changes next tick, so hand the whole tick to the synchronous path.
+        let mut finishing = false;
+        for (i, &seq_id) in seq_ids.iter().enumerate() {
+            let Some(seq) = self.active_batch.get(seq_id) else {
+                finishing = true;
+                break;
+            };
+            if lookahead_token_finishes(
+                toks[i],
+                seq.generated_tokens.len(),
+                seq.max_tokens,
+                &seq.merged_eos,
+                seq.cancelled.load(Ordering::Relaxed),
+            ) {
+                finishing = true;
+                break;
+            }
+        }
+
+        if finishing {
+            self.apply_lookahead_trim(&la.ids);
+            drop(la);
+            self.dispatch_sync_decode(seq_ids);
+            self.maybe_prime_lookahead(seq_ids);
+            return;
+        }
+
+        // Every row continues: commit the prebuilt tokens (reusing the batched
+        // fast-path bookkeeping — no finish can fire after the pre-check), then
+        // feed the SAME device token array back as the next [B, 1] input and
+        // prime the next forward.
+        self.apply_fused_decode_tokens(seq_ids, &toks);
+
+        // Device-side feedback: reshape [B] -> [B, 1] and cast to int32 to match
+        // the synchronous `from_slice_i32` input dtype exactly.
+        let col = mlxcel_core::reshape_token_for_forward(&la.tokens);
+        let next_input = mlxcel_core::astype(&col, mlxcel_core::dtype::INT32);
+        drop(la);
+        self.prime_lookahead_with_input(seq_ids, &next_input, params);
+        self.batch_observability.record_lookahead_step();
     }
 
     /// Batched decode: one forward_batched() call for all active sequences.
@@ -4405,6 +4820,7 @@ impl BatchScheduler {
             "execute_batched_decode: duplicate SequenceId in seq_ids"
         );
 
+        let decode_context = self.decode_batch_context();
         let mut batch_caches = match self.cache_pool.get_batch_caches_mut(seq_ids) {
             Ok(caches) => caches,
             Err(err) => {
@@ -4413,21 +4829,6 @@ impl BatchScheduler {
             }
         };
 
-        let decode_context = match self.decode_storage_backend {
-            DecodeStorageBackend::Auto | DecodeStorageBackend::Dense => {
-                debug_assert_ne!(
-                    self.decode_storage_backend,
-                    DecodeStorageBackend::Auto,
-                    "scheduler should normalize decode storage backend before decode dispatch"
-                );
-                DecodeBatchContext::dense()
-            }
-            DecodeStorageBackend::Paged => DecodeBatchContext {
-                storage_backend: CoreDecodeStorageBackend::Paged,
-                paged_block_size: DEFAULT_PAGED_BLOCK_SIZE as i32,
-                use_native_paged_kernel: true,
-            },
-        };
         let logits = self.model.forward_batched_with_context_and_ids(
             &input,
             Some(seq_ids),
@@ -4963,6 +5364,19 @@ impl BatchScheduler {
     // ------------------------------------------------------------------
 
     fn finalize_completed(&mut self) {
+        // Any completion or cancellation changes batch membership and may donate
+        // a sequence's KV to the prompt cache. Tear down a live lookahead first
+        // so its speculative KV position is trimmed off before donation / slot
+        // reuse and the surviving sequences rebuild their pipeline next tick
+        // (#632 constraints 2, 3, 6). No-op on the steady no-finish path.
+        if self.decode_lookahead.is_some()
+            && self.active_batch.iter_sequences().any(|s| {
+                s.state.is_finished() || s.cancelled.load(Ordering::Relaxed)
+            })
+        {
+            self.discard_lookahead();
+        }
+
         // First, transition any cancelled sequences to Finished(Cancelled).
         // This must happen before the finished-ID scan so that newly cancelled
         // sequences are collected in the same pass.

--- a/src/server/batch/scheduler_tests.rs
+++ b/src/server/batch/scheduler_tests.rs
@@ -1411,3 +1411,101 @@ fn batch_kv_quant_per_layer_table_disabled_skip_keeps_uniform_modes() {
         );
     }
 }
+
+// -------------------------------------------------------------------
+// Lookahead async_eval pipeline invalidation logic (issue #632)
+// -------------------------------------------------------------------
+//
+// These exercise the pure decision helpers that govern when the steady
+// pipeline stays engaged versus falls back to a synchronous decode step. They
+// mirror the file's existing philosophy of testing scheduler policy in
+// isolation (see `decide_action_from_state`) so no live model or GPU is
+// required. The forward/sample plumbing is covered by the build + the
+// greedy-equivalence smoke run recorded on the PR.
+
+use super::{lookahead_pipeline_safe, lookahead_token_finishes};
+
+#[test]
+fn lookahead_engages_when_batch_stable_and_queue_empty() {
+    // Steady state: no queued admission, no chunked prefill, no preemption.
+    assert!(lookahead_pipeline_safe(
+        /* queue_empty */ true,
+        /* chunked_in_progress */ false,
+        /* preempting */ false,
+    ));
+}
+
+#[test]
+fn lookahead_invalidated_by_admission_mid_lookahead() {
+    // A queued request waiting to be admitted grows the batch next tick, so the
+    // prebuilt step for the old id set must be discarded and the tick run
+    // synchronously.
+    assert!(!lookahead_pipeline_safe(
+        /* queue_empty */ false,
+        false,
+        false,
+    ));
+}
+
+#[test]
+fn lookahead_invalidated_by_chunked_prefill_interleave() {
+    assert!(!lookahead_pipeline_safe(
+        /* queue_empty */ true,
+        /* chunked_in_progress */ true,
+        false,
+    ));
+}
+
+#[test]
+fn lookahead_invalidated_by_preemption() {
+    // A pending higher-priority preemption evicts a running sequence next tick.
+    assert!(!lookahead_pipeline_safe(
+        /* queue_empty */ true,
+        false,
+        /* preempting */ true,
+    ));
+}
+
+#[test]
+fn lookahead_falls_back_on_eos_stop_mid_lookahead() {
+    // The prebuilt token is an EOS/stop id: committing it stops the sequence, so
+    // the pipeline must hand the tick to the synchronous finish/donation path.
+    let merged_eos = [2, 100];
+    assert!(lookahead_token_finishes(
+        /* next_token */ 2,
+        /* generated_len */ 5,
+        /* max_tokens */ 128,
+        &merged_eos,
+        /* cancelled */ false,
+    ));
+    // A non-stop token well short of the limit keeps the pipeline engaged.
+    assert!(!lookahead_token_finishes(7, 5, 128, &merged_eos, false));
+}
+
+#[test]
+fn lookahead_falls_back_on_length_limit_mid_lookahead() {
+    // Committing this token would reach max_tokens (5 generated + 1 == 6), so
+    // the sequence finishes on length and the step runs synchronously.
+    assert!(lookahead_token_finishes(
+        /* next_token */ 7,
+        /* generated_len */ 5,
+        /* max_tokens */ 6,
+        &[2],
+        false,
+    ));
+    // One token earlier the pipeline is still safe to engage.
+    assert!(!lookahead_token_finishes(7, 4, 6, &[2], false));
+}
+
+#[test]
+fn lookahead_falls_back_on_cancellation_mid_lookahead() {
+    // A cancelled sequence aborts through the synchronous finalize path even
+    // when the token itself is neither an EOS nor at the length limit.
+    assert!(lookahead_token_finishes(
+        /* next_token */ 7,
+        /* generated_len */ 5,
+        /* max_tokens */ 128,
+        &[2],
+        /* cancelled */ true,
+    ));
+}

--- a/src/server/batch/scheduler_tests.rs
+++ b/src/server/batch/scheduler_tests.rs
@@ -1423,7 +1423,7 @@ fn batch_kv_quant_per_layer_table_disabled_skip_keeps_uniform_modes() {
 // required. The forward/sample plumbing is covered by the build + the
 // greedy-equivalence smoke run recorded on the PR.
 
-use super::{lookahead_pipeline_safe, lookahead_token_finishes};
+use super::{lookahead_pipeline_safe, lookahead_teardown_positions, lookahead_token_finishes};
 
 #[test]
 fn lookahead_engages_when_batch_stable_and_queue_empty() {
@@ -1508,4 +1508,18 @@ fn lookahead_falls_back_on_cancellation_mid_lookahead() {
         &[2],
         /* cancelled */ true,
     ));
+}
+
+#[test]
+fn lookahead_teardown_unwinds_two_positions_after_prime() {
+    // A steady-tick teardown that already issued step n+1's prime forward must
+    // unwind both speculative appends (step n plus step n+1).
+    assert_eq!(lookahead_teardown_positions(/* next_prime_issued */ true), 2);
+}
+
+#[test]
+fn lookahead_teardown_unwinds_one_position_without_prime() {
+    // A prime that bailed (None) or any teardown before a prime (admission,
+    // preemption, stale id set, cancellation) unwinds only step n.
+    assert_eq!(lookahead_teardown_positions(/* next_prime_issued */ false), 1);
 }

--- a/src/server/batch/scheduler_tests.rs
+++ b/src/server/batch/scheduler_tests.rs
@@ -1429,8 +1429,7 @@ use super::{lookahead_pipeline_safe, lookahead_teardown_positions, lookahead_tok
 fn lookahead_engages_when_batch_stable_and_queue_empty() {
     // Steady state: no queued admission, no chunked prefill, no preemption.
     assert!(lookahead_pipeline_safe(
-        /* queue_empty */ true,
-        /* chunked_in_progress */ false,
+        /* queue_empty */ true, /* chunked_in_progress */ false,
         /* preempting */ false,
     ));
 }
@@ -1441,18 +1440,14 @@ fn lookahead_invalidated_by_admission_mid_lookahead() {
     // prebuilt step for the old id set must be discarded and the tick run
     // synchronously.
     assert!(!lookahead_pipeline_safe(
-        /* queue_empty */ false,
-        false,
-        false,
+        /* queue_empty */ false, false, false,
     ));
 }
 
 #[test]
 fn lookahead_invalidated_by_chunked_prefill_interleave() {
     assert!(!lookahead_pipeline_safe(
-        /* queue_empty */ true,
-        /* chunked_in_progress */ true,
-        false,
+        /* queue_empty */ true, /* chunked_in_progress */ true, false,
     ));
 }
 
@@ -1460,9 +1455,7 @@ fn lookahead_invalidated_by_chunked_prefill_interleave() {
 fn lookahead_invalidated_by_preemption() {
     // A pending higher-priority preemption evicts a running sequence next tick.
     assert!(!lookahead_pipeline_safe(
-        /* queue_empty */ true,
-        false,
-        /* preempting */ true,
+        /* queue_empty */ true, false, /* preempting */ true,
     ));
 }
 
@@ -1514,12 +1507,18 @@ fn lookahead_falls_back_on_cancellation_mid_lookahead() {
 fn lookahead_teardown_unwinds_two_positions_after_prime() {
     // A steady-tick teardown that already issued step n+1's prime forward must
     // unwind both speculative appends (step n plus step n+1).
-    assert_eq!(lookahead_teardown_positions(/* next_prime_issued */ true), 2);
+    assert_eq!(
+        lookahead_teardown_positions(/* next_prime_issued */ true),
+        2
+    );
 }
 
 #[test]
 fn lookahead_teardown_unwinds_one_position_without_prime() {
     // A prime that bailed (None) or any teardown before a prime (admission,
     // preemption, stale id set, cancellation) unwinds only step n.
-    assert_eq!(lookahead_teardown_positions(/* next_prime_issued */ false), 1);
+    assert_eq!(
+        lookahead_teardown_positions(/* next_prime_issued */ false),
+        1
+    );
 }

--- a/src/server/routes/metrics.rs
+++ b/src/server/routes/metrics.rs
@@ -154,6 +154,9 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
          # HELP mlxcel_batch_decode_steps_total Total decode steps executed\n\
          # TYPE mlxcel_batch_decode_steps_total counter\n\
          mlxcel_batch_decode_steps_total {decode_steps}\n\
+         # HELP mlxcel_batch_decode_lookahead_steps_total Decode steps served by the lookahead async_eval pipeline\n\
+         # TYPE mlxcel_batch_decode_lookahead_steps_total counter\n\
+         mlxcel_batch_decode_lookahead_steps_total {decode_lookahead_steps}\n\
          # HELP mlxcel_batch_prefill_chunks_total Total prefill chunks processed\n\
          # TYPE mlxcel_batch_prefill_chunks_total counter\n\
          mlxcel_batch_prefill_chunks_total {prefill_chunks}\n\
@@ -235,6 +238,7 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
         prefill_tokens = obs.total_prefill_tokens,
         decode_tokens = obs.total_decode_tokens,
         decode_steps = obs.decode_steps_processed,
+        decode_lookahead_steps = obs.decode_lookahead_steps,
         prefill_chunks = obs.prefill_chunks_processed,
         batch_size = obs.current_batch_size,
         cache_active = obs.cache_pool_active,


### PR DESCRIPTION
## Summary

Ports the CLI generation loop's lookahead `async_eval` pipelining into the server `BatchScheduler` decode paths so server decode overlaps the next forward with the current tick's host read and bookkeeping, closing the structural gap with CLI decode on CUDA where kernel-launch and graph-build latency dominate overhead-bound (<= 2B) models.

## What changed

`src/server/batch/scheduler.rs`: adds a cross-tick `DecodeLookahead` state machine (`run_decode_tick`). `pipelined_steady_decode` is ordered exactly like the CLI loop: it FIRST builds and `async_eval`s step n+1 from `la.tokens` fed back device-side as the next `[B,1]` input (no host knowledge needed, so the GPU starts the next forward immediately), and only THEN reads step n's ids to host and runs the finish pre-check. The GPU runs step n+1 while the host does the read plus commit, and the step n+1 graph build overlaps the tail of the step n forward. If a row finishes (EOS/length/cancel) or conditions turn unsafe, the pipeline unwinds its speculative KV appends and re-runs the tick synchronously, so completion / donation / stop handling always flow through the untouched synchronous path from a clean cache state.

Because the next forward is issued before the finish is known, a finishing row leaves two speculative KV positions to unwind (step n plus the just-scheduled step n+1); `apply_lookahead_trim` takes a position count, and the teardown `eval`s the in-flight step n+1 tokens before trimming so kernels are not still writing KV. All other teardowns (admission, preemption, stale id set, cancellation) unwind one position.

`src/lib/mlxcel-core/cpp/mlx_cxx_bridge.{h,cpp}` + `src/lib/mlxcel-core/src/lib.rs`: adds `array_evaluated_bytes`, a surgical host reader that calls the per-array `array::eval()` (waits on the token array's own completion event, enqueues no op, exactly like the CLI's `item()`) and skips `contiguous()` since `fused_sample` output is already row-contiguous. This is load-bearing for the overlap: `array_to_raw_bytes`' defensive `contiguous()` enqueues a fresh op AFTER the step n+1 forward on the same stream, so evaluating it blocked on that forward and collapsed the pipeline. The lookahead read now waits only for step n while step n+1 keeps running on the GPU.

Eligibility reuses the batched fused gate (no penalties/token-history, token bias, structured-output masks, thinking-budget overrides, or per-token logprobs) and further requires no loop detection, no `--max-kv-size`, no speculative dispatch, and a trimmable dense or pool-backed paged KV tail; model-owned (SSM / hybrid) sequences stay synchronous. The overshoot trim is backend-aware: dense trims the KV tail (`KVCache::trim`) and re-mirrors the shorter length into paged bookkeeping; pool-backed paged rewinds through the pool block table (`CachePool::rewind_paged_tokens`) before slot reuse or donation. `MLXCEL_FORCE_SYNC=1` is honored as the kill switch.

`src/server/batch/observability.rs` + `src/server/routes/metrics.rs`: adds a `decode_lookahead_steps` counter exposed at `/metrics` as `mlxcel_batch_decode_lookahead_steps_total`.

`src/server/batch/scheduler_tests.rs`: adds invalidation-decision unit tests (admission, EOS/stop, length, cancellation, chunked-prefill, preemption) plus the steady-engage case.

## Test plan

- [x] `cargo check --features cuda --lib --tests`; `cargo clippy --features cuda --lib` (clean).
- [x] `cargo test --release --features cuda --lib server::batch::scheduler::tests::lookahead` (7 pass) and `server::batch::observability::tests` (9 pass).
- [x] Decode throughput (GB10, qwen2.5-0.5b-bf16, default paged, 5x 512-token deterministic completions, decode-only telemetry): 162.8 tok/s synchronous -> 200.1 tok/s pipelined (+22.9%).
- [x] Greedy byte-identical output with pipeline engaged (61/63 decode steps) vs `MLXCEL_FORCE_SYNC=1`, on both the dense and default paged backends.
- [x] Two-turn chat on the paged pipeline records prompt-cache hits, confirming donation after the two-position overshoot trim leaves a reusable, uncorrupted prefix.
- [x] Four concurrent staggered-length greedy requests (B up to 4) complete coherently, exercising the batch-shrink teardown.
- [ ] Acceptance tok/s benchmarks (B=1 within 5% of CLI; B=4 aggregate improvement) run by the orchestrator.

## Acceptance measurements (GB10, orchestrator-verified)

All numbers from `bench_serving_concurrency.py` (512 prompt tokens, 512 max tokens) against `mlxcel-bench-decode --prompt-tokens 512` as the matched-context CLI reference; sync baseline via `MLXCEL_FORCE_SYNC=1`.

| case | sync | pipelined | CLI reference | verdict |
|------|-----:|----------:|--------------:|---------|
| qwen2.5-0.5b-bf16 B=1 decode | 147.9 | 182.4-191.3 across runs | 199.0-200.3 | pipeline +23-29% over sync; CLI gap 3.9-8.5% (5% AC met at the best run; residual is SSE/HTTP per-token cost, not pipelining) |
| llama-3.1-8b-4bit B=1 decode (dense backend) | 44.3 (default backend) | 52.0 | 51.8 | server exceeds CLI; AC met |
| llama-3.1-8b-4bit B=1 decode (default paged backend) | 44.3 | 47.2 | 51.8 | +6.5% over sync; the remaining 8.9% gap is the paged-attention decode kernel cost, tracked by #634, reproduced independently of this PR |
| qwen2.5-0.5b-bf16 B=4 aggregate | 289.7 | 340.5 | n/a | +17.5%; AC met |
| llama-3.1-8b-4bit B=4 aggregate | 44.7 | 46.4 | n/a | +3.8% (bounded by the CUDA batched-decode caveat from #724) |

Lookahead engagement: 509/511 decode steps per 512-token request (`mlxcel_batch_decode_lookahead_steps_total`), for cold and prompt-cache-hit requests alike. Greedy outputs byte-identical pipelined vs `MLXCEL_FORCE_SYNC=1` (orchestrator-independent check on llama plus the implementation's dense/paged checks on qwen). Full `cargo test --release --features cuda --no-fail-fast -- --test-threads=1`: 4362 passed, 1 failed (the pre-existing #728 flake, passes on rerun).

During validation a separate pre-existing anomaly surfaced (decode ~11% slower after a prompt-cache hit than after a cold prefill, pipeline engaged in both modes); filed as #730, out of scope here.

Closes #632
