### PR TITLE
docs: document all cargo build features and XLA backend env vars

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -44,7 +44,7 @@ and cached on first use. Set them before starting `mlxcel` or `mlxcel-server`.
 | `MLXCEL_MAX_BATCH_PREFILL_TOKENS` | unsigned integer tokens, `0` disables | derived (`2 * max_batch_prefill * prefill_chunk_size`) | Padded-token budget bounding one server batched prefill's transient memory (issue #715). The batched path pads a cohort to its longest prompt `L` and materializes a `[B, L, L]` FP32 mask, an `O(B*L^2)` transient; this caps the drained window by total padded tokens (`rows * L`) so the mask stays within `~2*N^2` bytes, with rows past the budget spilling to the chunked single-sequence path. `--max-batch-prefill-tokens` takes precedence. Unset derives `2 * max_batch_prefill * prefill_chunk_size` (the shipped `2 * 4 * 512 = 4096`; the 2x headroom keeps a full batch of slightly-over-chunk-sized prompts in one window); `0` disables the cap (pre-#715 unbounded behavior). Only affects families with `supports_batched_prefill()` under `--max-batch-prefill > 1`. |
 | `MLXCEL_ATTENTION_CHUNK_BUDGET_MB` | unsigned integer MiB, `0` disables | `1024` | **Advanced.** Score-matrix byte budget for the CUDA attention fallback. When a configuration cannot reach a fused SDPA kernel (head_dim > 128 families such as gemma-3/gemma-4, or softcap composites) and one attention call would materialize more scores than this budget, the query axis is processed in budget-sized chunks (issue #672). Larger values trade memory for fewer kernel launches; `0` restores the unchunked fallback. |
 | `MLXCEL_ALLOWED_ORIGINS` | comma-separated origin list (e.g. `https://app.example.com,https://admin.example.com`) | unset (permissive) | Restricts CORS to the listed origins. `--allowed-origins` takes precedence. Unset keeps the permissive default that reflects any origin. Each value must be a bare `scheme://host[:port]` origin (`http`/`https`, no path or query); a malformed value fails server startup with a clear message instead of being silently dropped. Only affects the browser-reachable TCP HTTP listener: the Unix-socket transport sends no `Origin` header and is unaffected. |
-| `MLXCEL_SURGERY` | YAML file path | unset | Feature-gated weight-load surgery configuration. `--surgery` takes precedence when the `surgery` feature is built. |
+| `MLXCEL_SURGERY` | YAML file path | unset | Weight-load surgery configuration path. `--surgery` takes precedence. Active when the `surgery` feature is built, which it is by default; a `--no-default-features` build ignores it. See [Cargo feature flags](installation.md#cargo-feature-flags). |
 
 ## Server context sizing
 
@@ -80,6 +80,27 @@ These are read by the `mlxcel-core` build script.
 
 CUDA builds also use non-`MLXCEL_*` variables such as `CUDA_HOME` and
 `MLX_CUDA_ARCHITECTURES`; see [Installation](installation.md#linux-with-cuda).
+
+## OpenXLA / StableHLO backend variables
+
+**Advanced.** These apply only to builds that enable the `xla-backend` /
+`xla-iree` Cargo features (issue #449, [ADR 0004](adr/0004-compute-backend-session-seam-and-stablehlo-family.md));
+shipping Apple-Silicon and CUDA binaries do not, so on those builds the variables
+below are inert and the engine is always MLX. See
+[Installation](installation.md#openxla--stablehlo-backend-xla-backend-xla-iree)
+for how to build the backend.
+
+| Variable | Values | Default | Notes |
+|----------|--------|---------|-------|
+| `MLXCEL_BACKEND` | `mlx`, `xla` | `mlx` | Runtime compute-backend selector read by `select_backend()`. `xla` routes `load_model` / `forward` through the OpenXLA/IREE engine; it takes effect only when the binary was built with `xla-backend` (else it is ignored and MLX runs). Any other value selects MLX. |
+| `MLXCEL_XLA_DEVICE` | `metal`, `cuda`, `local-task` | `metal` on macOS, `local-task` elsewhere | IREE HAL device for the XLA engine. CUDA is never auto-selected (it needs a CUDA-enabled runtime build), so set `cuda` explicitly on a GB10-class host. `local-task` is the CPU device. |
+| `MLXCEL_XLA_PRECISION` | `f32`, `f16`, `bf16` | `f32` | Contraction precision the StableHLO emitter uses for matmuls (norms and softmax stay in f32). Read at graph-emit time. An explicit value forces that precision even on a GPU device whose default would differ; an unset or unrecognized value falls back to the per-device default. The committed byte-exact goldens are the `f32` graphs, so a byte-exactness check rejects a non-default precision. |
+| `MLXCEL_XLA_QUANT` | `packed` | unset | `packed` keeps quantized weights packed inside the graph (device-side dequant) instead of dequantizing at load. Read both at emit time and by the loader so uploaded buffers match the emitted args. A no-op on unquantized checkpoints. Not supported on the Metal target (packed int8 dequant prefill faults on the Metal HAL driver); use the CUDA or `local-task` target, or leave it unset to dequant at load. |
+| `MLXCEL_XLA_IREE_COMPILE` | path to `iree-compile` | baked at build time | Runtime override for the `iree-compile` binary used to lower the bundled graphs to vmfbs. The CUDA source-runtime build ships no compiler, so this must point at a cuda-capable `iree-compile` matching the runtime version; the CPU/Vulkan dist build falls back to the dist's own `bin/iree-compile`. |
+| `IREE_DIST` | path to an `iree-dist` tree | baked at build time | Non-`MLXCEL_*` runtime override for the IREE distribution (CPU/Vulkan build). Takes precedence over the path baked in at build time. Also the build-time variable that selects the dist to link against; see [Installation](installation.md#openxla--stablehlo-backend-xla-backend-xla-iree). |
+
+Compiled vmfbs are cached on disk (keyed by graph text, flags, and the compiler
+path), so only the first load of each graph variant pays the `iree-compile` cost.
 
 ## Downloader variables
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,61 @@ static binaries: platform GPU/runtime libraries are still required.
 | Linux CPU-only | not a release target | none | May compile in limited configurations, but it is not a useful or validated inference target for this project. |
 | Windows | not documented here | — | The current public installation path is macOS/Linux. |
 
+## Cargo feature flags
+
+Both binaries (`mlxcel` and `mlxcel-server`) build from the same root package, so
+one feature set applies to both. Pass them with `cargo build --features <a,b>`.
+Shipping builds enable only the platform backend flags; the rest are opt-in seams
+or test scaffolding.
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `surgery` | **on** | Axis A weight-load surgery. Exposes `--surgery <config.yaml>` and `MLXCEL_SURGERY` for `scale` / `add` / `prune` / `replace` / `interpolate` weight-space edits at load time, and pulls in the `mlxcel-surgery` crate. When no surgery config is supplied the load path is byte-for-byte identical to a build without the feature. |
+| `metal` | off | Apple Silicon Metal GPU backend (delegates to `mlxcel-core/metal`). Standard on macOS. |
+| `accelerate` | off | Apple Accelerate CPU BLAS backend (delegates to `mlxcel-core/accelerate`). Standard on macOS. |
+| `cuda` | off | NVIDIA CUDA GPU backend (delegates to `mlxcel-core/cuda`). Required on NVIDIA hosts; a plain build is CPU-only (see the footgun note below). |
+| `experimental-backend` | off | Reserves the non-MLX compute-backend seam slot (issue #338). Ships no kernels and adds no runtime dispatch; it only compiles the plug-in boundary where a future non-MLX engine (e.g. FuriosaAI RNGD) would implement `ComputeBackend`. `select_backend()` still folds to MLX. |
+| `xla-backend` | off | OpenXLA / StableHLO backend seam (issue #449, [ADR 0004](adr/0004-compute-backend-session-seam-and-stablehlo-family.md)). Pulls in `mlxcel-xla` and compiles the `Backend::Xla` / `Session::Xla` arms and the `MLXCEL_BACKEND=xla` selector, but no native execution engine: the crate is pure-Rust stubs plus the StableHLO graph emitter, so CI builds it unchanged. |
+| `xla-iree` | off | `xla-backend` plus real IREE execution (`mlxcel-xla/iree`). Compiles a C shim against a prebuilt IREE runtime and drives the bundled prefill / decode_step graphs. Needs `IREE_DIST` (or the source-build vars below) at build time, so it is a local / opt-in build, not a CI or release default. |
+| `test-utils` | off | Test-only helpers. Required to build the `distributed_integration`, `pipeline_e2e`, and `paged_handoff_parity` integration tests (`cargo test --features test-utils`). Not needed for the binaries. |
+
+`default = ["surgery"]`, so a plain `cargo build` enables surgery only. A real
+build always adds a platform backend on top, e.g. `--features metal,accelerate` on
+Apple Silicon or `--features cuda` on NVIDIA. Build with `--no-default-features`
+to drop the `mlxcel-surgery` crate entirely (CI parity tests against pre-surgery
+behavior, or constrained embedded targets):
+
+```bash
+# Metal + Accelerate, no surgery crate.
+cargo build --release --no-default-features --features metal,accelerate
+```
+
+### OpenXLA / StableHLO backend (`xla-backend`, `xla-iree`)
+
+The XLA path is a two-tier opt-in and never enters Apple-Silicon or CUDA shipping
+builds, so those binaries compile none of it and the seam folds to MLX:
+
+- `xla-backend` compiles only the seam: the `Backend::Xla` / `Session::Xla` arms,
+  the `MLXCEL_BACKEND=xla` selection, and the StableHLO graph emitter. It needs no
+  native toolchain, so CI builds it unchanged.
+- `xla-iree` adds the executing runtime. Its build script compiles a C shim
+  against a prebuilt IREE distribution, so one of these must be set at build time:
+  - `IREE_DIST`: the extracted `iree-dist-<ver>-linux-<arch>` tree (CPU / Vulkan
+    dist). The dist's own `bin/iree-compile` lowers the bundled graphs.
+  - `IREE_CUDA_HOME` (+ `IREE_CUDA_COMPILE`): a source-built CUDA-enabled IREE
+    runtime and a matching cuda-capable `iree-compile`, for the GB10-class GPU
+    path. `scripts/iree/setup-cuda.sh` produces this tree.
+  - `IREE_MACOS_HOME` (+ `IREE_MACOS_COMPILE`): a source-built macOS runtime and
+    a Metal-capable `iree-compile`, for the Apple Silicon dev path.
+    `scripts/iree/setup-macos.sh` produces this tree and prints the matching
+    environment.
+
+At runtime, select the backend with `MLXCEL_BACKEND=xla` and tune it with the
+`MLXCEL_XLA_*` variables (device, precision, packed quant). See
+[Environment variables](environment-variables.md#openxla--stablehlo-backend-variables)
+for the full list and [ADR 0004](adr/0004-compute-backend-session-seam-and-stablehlo-family.md)
+for the design.
+
 ## macOS on Apple Silicon
 
 Prerequisites:


### PR DESCRIPTION
## Summary

The install docs only covered the platform backend flags (`metal`, `accelerate`, `cuda`). The remaining Cargo features were discoverable only from `Cargo.toml` or the ADRs, and the XLA runtime environment variables were missing from the env reference. This fills both gaps in the flat `docs/*.md` tree.

## Changes

**`docs/installation.md`** — new "Cargo feature flags" section:
- Full feature table: `surgery` (default-on), `metal` / `accelerate` / `cuda`, `experimental-backend` (#338), `xla-backend` / `xla-iree` (#449), `test-utils`, with default status, delegated crate, and purpose.
- `--no-default-features` opt-out (drops the `mlxcel-surgery` crate) with an example.
- "OpenXLA / StableHLO backend" subsection: the two-tier `xla-backend` (seam only) vs `xla-iree` (real IREE execution) build, and its `IREE_DIST` / `IREE_CUDA_HOME` / `IREE_MACOS_HOME` requirements plus `scripts/iree/setup-*.sh`.

**`docs/environment-variables.md`** — new "OpenXLA / StableHLO backend variables" section:
- Documents `MLXCEL_BACKEND`, `MLXCEL_XLA_DEVICE`, `MLXCEL_XLA_PRECISION`, `MLXCEL_XLA_QUANT`, `MLXCEL_XLA_IREE_COMPILE`, and `IREE_DIST` with valid values, defaults, and runtime-vs-build-time semantics.
- Clarifies `MLXCEL_SURGERY` is default-on and ignored under `--no-default-features`.

Values, defaults, and runtime/build-time distinctions were verified against the source (`src/backend/mod.rs`, `src/lib/mlxcel-xla/src/{lib,iree,emitter}.rs`, and the `build.rs` scripts).

## Notes

Docs-only change; no code paths touched. The repo has no MkDocs source tree (`docs/en/` does not exist), so the flat `docs/*.md` files are the maintained docs; cross-link anchors follow GitHub's slugify.