### PR TITLE
fix: bind gemma-4 NVFP4 vision tower so image input works

### DIFF
--- a/benchmarks/cuda_gb10_vlm_2026-07-12_single_gemma-4-31b-it-nvfp4.csv
+++ b/benchmarks/cuda_gb10_vlm_2026-07-12_single_gemma-4-31b-it-nvfp4.csv
@@ -1,0 +1,2 @@
+model,model_path,prompt_tokens,generated_tokens,prefill_ms,prefill_tok_s,decode_ms,decode_tok_s,date,hardware,mlx_version,build_type,max_tokens,prompt,prompt_target_len
+gemma-4-31b-it-nvfp4,models/gemma-4-31b-it-nvfp4,278,27,787.09,353.20,5544.07,4.87,2026-07-12,NVIDIA_GB10_122GB,0.4.0-rc.1,release,100,"What is in this image?",

--- a/docs/benchmark_results/model_tests.md
+++ b/docs/benchmark_results/model_tests.md
@@ -40,7 +40,7 @@ Current source-of-truth data lives in `benchmarks/`:
 | `pylm_m1ultra_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlx-lm 0.31.3 baseline, https://github.com/ml-explore/mlx-lm @ `df1d3f3`; >65GB skipped) | Text |
 | `pylm_m1ultra_vlm_2026-05-19.csv` | M1 Ultra | 2026-05-19 (mlx-vlm baseline, https://github.com/Blaizzy/mlx-vlm @ `d85ca4d`; >65GB skipped) | VLM |
 | `cuda_gb10_2026-07-12.csv` | GB10 | 2026-07-12 (mlxcel 0.4.0-rc.1, MLX pin `57c66cac` / 0.32.1, CUDA 13.0 / SM 12.1; full 159-dir sweep, 142 measured / 0 code failures / 7 memory-gate `SKIP:oom_estimate` at `BENCH_MEM_OVERHEAD_FACTOR=2.0` / 10 N.A. FAILs [drafters, speech/TTS, incomplete checkpoints]) | Text |
-| `cuda_gb10_vlm_2026-07-12.csv` | GB10 | 2026-07-12 (mlxcel 0.4.0-rc.1; full VLM sweep over all dirs, 63 measured image rows; text-only models FAIL by design; gemma-4-31b-it-nvfp4 image-input FAIL is a real finding, tracked in #749) | VLM |
+| `cuda_gb10_vlm_2026-07-12.csv` | GB10 | 2026-07-12 (mlxcel 0.4.0-rc.1; full VLM sweep over all dirs, 63 measured image rows; text-only models FAIL by design; gemma-4-31b-it-nvfp4 image-input FAIL captured here, since fixed by #749) | VLM |
 | `cuda_gb10_2026-07-09.csv` | GB10 | 2026-07-09 (mlxcel 0.4.0-rc.1, MLX pin `57c66cac` / 0.32.1, CUDA 13.0 / SM 12.1; 19-model representative subset re-benchmark, 19 pass / 0 fail, includes gemma-4-31b-it-nvfp4 now functional via the ModelOpt NVFP4 direct-transcode path #692/#693/#697) | Text |
 | `cuda_gb10_2026-06-17.csv` | GB10 | 2026-06-17 (mlxcel 0.3.1 [CSV relabeled; Cargo.toml 0.3.0 until release], MLX pin a6ec7123, CUDA 13.0 / SM 12.1, post-#319 CUDA fused decode-MoE; full text re-benchmark, 147 models, 136 pass / 0 fail / 9 not-tested-N.A. / 2 too-large) | Text |
 | `cuda_gb10_vlm_2026-06-17.csv` | GB10 | 2026-06-17 (mlxcel 0.3.1; full VLM re-benchmark, 54 measured image rows) | VLM |
@@ -93,7 +93,7 @@ For Qwen2.5-0.5B the 4-bit row is the directly comparable cross-hardware figure;
 | Text models tested (M1 Ultra, 2026-06-15) | 136 pass, 2 partial, 4 fail, 9 skip/non-standalone (151 dirs; adds apertus, seed-oss, dots.llm1, granite family, lfm2, plamo-2, falcon-h1, BitNet; diffusiongemma loads via #291) |
 | Text models tested (M5 Max, 2026-06-15) | 131 pass, 5 partial, 14 fail/skip (0.2.1 full sweep; post-sweep: qwen2.5-vl-3b-4bit fixed by re-download, oversized bf16 hunyuan dropped; neither a code regression) |
 | Text models tested (GB10, 2026-07-12) | 141 pass measured + 5 pass carried (memory-gate skips), 0 code failures, 13 not-tested/N.A. (glm-5 pair incomplete/absent; paligemma2 image-only; docling/granite-speech/whisper/kokoro non-text-gen; 4 MTP/DFlash drafters; glm-4.5v + mistral-small-4-119b memory-gated, never measured) (159 dirs; 0.4.0-rc.1 full sweep) |
-| VLM models tested (GB10, 2026-07-12) | 63 measured image rows + 1 carried (llama-4-scout, memory-gate skip); gemma-4-31b-it-nvfp4 image-input FAIL, tracked in #749 (0.4.0-rc.1) |
+| VLM models tested (GB10, 2026-07-12) | 63 measured image rows + 1 carried (llama-4-scout, memory-gate skip); gemma-4-31b-it-nvfp4 image-input FAIL since fixed by #749 (0.4.0-rc.1) |
 | VLM models tested (M5 Max, 2026-06-15) | 54 valid VLM rows (0.2.1 full VLM re-sweep; adds qwen3-vl-4b/8b, minicpm-v-4.6-bf16, nemotron-omni, youtu-vl; qwen2.5-vl-3b-4bit restored after re-download) |
 | VLM models tested (M1 Ultra, 2026-06-15) | 55 measured VLM rows (53 pass + 2 partial) |
 | Beating mlx-lm on M1 Ultra (text, >=100%) | 24/74 (32%, 6-15 vs pinned 5-19 baseline) |

--- a/docs/benchmark_results/model_tests_gb10.md
+++ b/docs/benchmark_results/model_tests_gb10.md
@@ -98,7 +98,7 @@ Prefill/Decode are the measured-pass figures from `mlxcel-bench-decode`. Notes r
 | gemma-4-31b-4bit | ✅ | 23.08 | 8.84 |  |
 | gemma-4-31b-it-4bit | ✅ | 52.37 | 8.33 | 26 tok |
 | gemma-4-31b-it-assistant-bf16 | ⚪ | - | - | MTP/DFlash drafter (needs a target; not standalone) |
-| gemma-4-31b-it-nvfp4 | ✅ | 76.38 | 4.88 | 26 tok; ModelOpt NVFP4 direct transcode (#692, #693, #697); image input fails (see VLM note) |
+| gemma-4-31b-it-nvfp4 | ✅ | 76.38 | 4.88 | 26 tok; ModelOpt NVFP4 direct transcode (#692, #693, #697); image input works (see VLM note; fixed by #749) |
 | gemma-4-31b-it-qat-4bit | ✅ | 59.15 | 5.39 | 26 tok |
 | gemma-4-e2b-it-4bit | ✅ | 650.91 | 100.61 | 72 tok |
 | gemma-4-e2b-it-8bit | ✅ | 654.70 | 58.55 | 70 tok |
@@ -351,9 +351,9 @@ Models that accept image input and generated tokens under the `"What is in this 
 | smolvlm-instruct-bf16 | ✅ | 100 | 2815.60 | 67.24 |
 | youtu-vl-4b-instruct | ✅ | 30 | 337.10 | 20.89 |
 | llama-4-scout-17b-4bit | ✅ | 100 | 29.15 | 20.54 |
-| gemma-4-31b-it-nvfp4 | ❌ | - | - | - |
+| gemma-4-31b-it-nvfp4 | ✅ | 27 | 353.20 | 4.87 |
 
-`llama-4-scout-17b-4bit` figures are from 2026-06-17 (memory-gate skip on 2026-07-12). `gemma-4-31b-it-nvfp4` passes the text-only run but rejects image input: the NVFP4 key remapper translates only the 1372 text-decoder keys and leaves all 356 `model.vision_tower.*` / `model.embed_vision.*` keys unmapped, so the vision tower never binds and the model registers as text-only. Tracked in #749.
+`llama-4-scout-17b-4bit` figures are from 2026-06-17 (memory-gate skip on 2026-07-12). `gemma-4-31b-it-nvfp4` now serves image input (fixed by #749): the NVFP4 key remapper strips the `model.` prefix from all 356 `model.vision_tower.*` / `model.embed_vision.*` keys, not just the 1372 text-decoder keys, so the checkpoint routes to Gemma4VLM and the vision tower binds. The vision front-end stays dense (ModelOpt keeps `model.vision_tower*` / `model.embed_vision*` in `quantization_config.ignore`), so it needs key renaming only, no NVFP4 transcode.
 
 ---
 
@@ -378,7 +378,7 @@ Models that accept image input and generated tokens under the `"What is in this 
 - **Text-only prefill for several VLM-capable models is an order of magnitude higher than 0.3.1** (aya-vision-8b 124.91 → 1354.53, pixtral-12b 35.97 → 120.39, youtu-vl 134.27 → 451.42, mistral-small-3.1-24b 63.68 → 891.89), consistent with the text-prompt path no longer paying vision-tower costs rather than with a kernel speedup.
 - **Decode improvements >10% on dense/MoE models**: apertus-8b +21%, gemma3-4b / gemma-3-4b-it +19%, gemma3-1b +15%, gemma3n-e2b +10%, qwen3-0.6b-4bit +13%, aya-expanse-8b +12%, plus the VLM-side gains below.
 - **VLM (image-input) gains**: molmo-7b 23.81 → 35.89 (+51%), nemotron-omni-30b 32.86 → 70.09 (+113%), gemma3-4b family +13-18%.
-- **gemma-4-31b-it-nvfp4 rejects image input** while its text pass is stable (76.38 prefill / 4.88 decode); the NVFP4 key remapper leaves the 356 vision-tower keys unmapped so the model registers as text-only. Tracked in #749.
+- **gemma-4-31b-it-nvfp4 now serves image input** (fixed by #749: 27 tok, 353.20 prefill / 4.87 decode) with its text pass stable (76.38 prefill / 4.88 decode); the NVFP4 key remapper now strips the `model.` prefix from the 356 vision-tower keys, so the checkpoint routes to Gemma4VLM and the vision tower binds.
 
 ### New model directories since 2026-06-17 (14)
 

--- a/src/loading/vlm_gemma.rs
+++ b/src/loading/vlm_gemma.rs
@@ -312,6 +312,14 @@ pub(crate) fn load_gemma4_vlm(model_path: &Path) -> Result<LoadedModel> {
     let args: models::gemma4::ModelArgs = parse_vlm_config(&config_str, "Gemma4 config")?;
     let (mut weights, weight_backing) = models::load_gemma4_vlm_weights_with_backing(model_path)
         .map_err(|e| anyhow::anyhow!("Failed to load Gemma4 VLM weights: {}", e))?;
+    // ModelOpt NVFP4 exports nest weights under `model.` and pack the text
+    // decoder as ModelOpt FP4 triplets. Remap the keys (text decoder AND the
+    // `model.vision_tower.` / `model.embed_vision.` front-end) and repack the
+    // quantized language-model groups so the vision tower and text model both
+    // bind on the VLM path (issue #749). This is a no-op for MLX-community
+    // Gemma 4 VLM checkpoints: they carry no `model.language_model.` keys and no
+    // `weight_scale_2` sidecars, so both stages inside skip immediately.
+    models::sanitize_gemma4_nvfp4_weights(&mut weights, Some(&full_config));
     // Drop k_proj/v_proj/k_norm weight entries for KV-shared layers before
     // building the model.  The weight loader already materialized them via
     // eval_all, but releasing the entries here prevents the model constructor

--- a/src/models/detection.rs
+++ b/src/models/detection.rs
@@ -35,9 +35,18 @@ fn gemma4_has_vision_weights(model_path: &Path) -> bool {
         && let Ok(index) = serde_json::from_str::<Value>(&index_str)
         && let Some(weight_map) = index.get("weight_map").and_then(Value::as_object)
     {
-        return weight_map
-            .keys()
-            .any(|key| key.starts_with("vision_tower.") || key.starts_with("embed_vision."));
+        // MLX-community checkpoints expose the vision front-end unprefixed
+        // (`vision_tower.` / `embed_vision.`); ModelOpt NVFP4 exports nest it
+        // under a leading `model.` (`model.vision_tower.` /
+        // `model.embed_vision.`). Recognize both so an NVFP4 multimodal
+        // checkpoint routes to Gemma4VLM instead of the text-only path, where
+        // `normalize_nvfp4_keys` then strips the `model.` prefix (issue #749).
+        return weight_map.keys().any(|key| {
+            key.starts_with("vision_tower.")
+                || key.starts_with("embed_vision.")
+                || key.starts_with("model.vision_tower.")
+                || key.starts_with("model.embed_vision.")
+        });
     }
 
     model_path.join("processor_config.json").exists()

--- a/src/models/detection_tests.rs
+++ b/src/models/detection_tests.rs
@@ -334,6 +334,54 @@ fn gemma4_detection_uses_vlm_route_when_vision_weights_exist() {
 }
 
 #[test]
+fn gemma4_detection_uses_vlm_route_for_nvfp4_prefixed_vision_weights() {
+    // ModelOpt NVFP4 exports nest the vision front-end under a leading
+    // `model.` (`model.vision_tower.` / `model.embed_vision.`) instead of the
+    // MLX-community unprefixed `vision_tower.` / `embed_vision.` keys. Both
+    // prefixed forms must also route to Gemma4VLM so `normalize_nvfp4_keys`
+    // gets a chance to strip the prefix later (issue #749).
+    for weight_key in [
+        "model.vision_tower.encoder.layers.0.input_layernorm.weight",
+        "model.embed_vision.embedding_projection.weight",
+    ] {
+        let model_dir = temp_path(&format!(
+            "gemma4_vlm_route_nvfp4_{}",
+            weight_key.replace(['.', '/'], "_")
+        ));
+        fs::create_dir_all(&model_dir).unwrap();
+        fs::write(
+            model_dir.join("config.json"),
+            r#"{
+                "model_type": "gemma4",
+                "vision_config": {},
+                "text_config": { "model_type": "gemma4_text" }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            model_dir.join("model.safetensors.index.json"),
+            format!(
+                r#"{{
+                    "weight_map": {{
+                        "{weight_key}": "model-00001-of-00001.safetensors"
+                    }}
+                }}"#
+            ),
+        )
+        .unwrap();
+
+        let detected = super::detection::get_model_type(&model_dir).unwrap();
+        assert_eq!(
+            detected,
+            ModelType::Gemma4VLM,
+            "for weight key {weight_key}"
+        );
+
+        fs::remove_dir_all(model_dir).unwrap();
+    }
+}
+
+#[test]
 fn idefics3_smolvlm_instruct_model_type_is_detected() {
     // SmolVLM-Instruct ships as an Idefics3 checkpoint: top-level
     // `model_type: "idefics3"` (`Idefics3ForConditionalGeneration`) with a Llama

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -216,7 +216,7 @@ pub use rwkv7::Rwkv7;
 pub(crate) use sanitize::{
     Gemma4WeightBacking, load_gemma4_text_weights_with_backing,
     load_gemma4_unified_weights_with_backing, load_gemma4_vlm_weights_with_backing,
-    strip_gemma4_kv_shared_weights,
+    sanitize_gemma4_nvfp4_weights, strip_gemma4_kv_shared_weights,
 };
 pub use sanitize::{
     convert_bf16_weights, convert_bf16_weights_with_keep, gemma3n_language_mlp_bf16_key,

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -282,37 +282,51 @@ fn f16_to_f32(bits: u16) -> f32 {
 
 /// Remap NVFP4-style weight keys to the MLX-community naming convention.
 ///
-/// nvfp4 Gemma 4 checkpoints use `model.language_model.X` prefixes while the
-/// model code expects `language_model.model.X`. This function performs the
-/// following remapping:
+/// ModelOpt NVFP4 Gemma 4 checkpoints nest every tensor under a leading
+/// `model.` prefix: the text decoder as `model.language_model.X`, the vision
+/// front-end as `model.vision_tower.X` / `model.embed_vision.X`, and (when
+/// present) `model.lm_head.X`. The model code expects the MLX-community
+/// convention, so this function rewrites:
 ///
 /// - `model.language_model.X` → `language_model.model.X`
+/// - `model.vision_tower.X`   → `vision_tower.X`
 /// - `model.embed_vision.X`   → `embed_vision.X`
 /// - `model.lm_head.X`        → `lm_head.X`
 ///
-/// If no keys matching the nvfp4 pattern are found, this is a no-op.
+/// The `model.vision_tower.` / `model.embed_vision.` strips are what let the
+/// gemma4 vision tower and multimodal embedder bind on the NVFP4 path (issue
+/// #749); without them the vision front-end stays under the `model.` prefix, so
+/// `gemma4_has_vision_weights` misdetects the checkpoint as text-only and
+/// `Gemma4VisionModel::from_weights` finds no `vision_tower.*` weights. The
+/// vision front-end is unquantized (ModelOpt keeps `model.vision_tower*` /
+/// `model.embed_vision*` in `quantization_config.ignore`), so it needs key
+/// renaming only, not an NVFP4 transcode; `repack_nvfp4_weights_to_quantized`
+/// leaves it alone because those tensors carry no `weight_scale_2` sidecar.
+///
+/// If no keys matching the nvfp4 pattern (a `model.language_model.` prefix) are
+/// found, this is a no-op.
 fn normalize_nvfp4_keys(weights: &mut mlxcel_core::weights::WeightMap) {
-    let nvfp4_keys: Vec<String> = weights
+    // The distinctive marker of a ModelOpt/NVFP4 export is the
+    // language-model-under-model nesting; MLX-community checkpoints use the
+    // inverse `language_model.model.` order. Detect on that before touching
+    // any keys so this stays a no-op on already-converted checkpoints.
+    let is_nvfp4_layout = weights
         .keys()
-        .filter(|k| k.starts_with("model.language_model."))
-        .cloned()
-        .collect();
-
-    if nvfp4_keys.is_empty() {
+        .any(|k| k.starts_with("model.language_model."));
+    if !is_nvfp4_layout {
         return;
     }
 
-    eprintln!(
-        "Remapping {} NVFP4-style weight keys to MLX-community convention...",
-        nvfp4_keys.len()
-    );
-
-    // Collect all key-value pairs that need remapping, then reinsert.
+    // Collect all key-value pairs that need remapping (text decoder AND vision
+    // front-end), then reinsert. Counting the full set here keeps the reported
+    // count honest: the vision keys are remapped too, not just the text ones.
     let remappings: Vec<(String, String)> = weights
         .keys()
         .filter_map(|k| {
             let new_key = if let Some(rest) = k.strip_prefix("model.language_model.") {
                 format!("language_model.model.{rest}")
+            } else if let Some(rest) = k.strip_prefix("model.vision_tower.") {
+                format!("vision_tower.{rest}")
             } else if let Some(rest) = k.strip_prefix("model.embed_vision.") {
                 format!("embed_vision.{rest}")
             } else if let Some(rest) = k.strip_prefix("model.lm_head.") {
@@ -323,6 +337,11 @@ fn normalize_nvfp4_keys(weights: &mut mlxcel_core::weights::WeightMap) {
             Some((k.clone(), new_key))
         })
         .collect();
+
+    eprintln!(
+        "Remapping {} NVFP4-style weight keys to MLX-community convention...",
+        remappings.len()
+    );
 
     for (old_key, new_key) in remappings {
         if let Some(arr) = weights.remove(&old_key) {
@@ -2528,6 +2547,58 @@ mod tests {
         assert!(weights.contains_key("lm_head.weight"));
         assert!(!weights.contains_key("model.embed_vision.proj.weight"));
         assert!(!weights.contains_key("model.lm_head.weight"));
+    }
+
+    #[test]
+    fn normalize_nvfp4_keys_remaps_vision_tower_and_embed_vision() {
+        // Representative ModelOpt NVFP4 multimodal key set (issue #749): the
+        // vision front-end nests under `model.vision_tower.` / `model.embed_vision.`
+        // with the extra `.linear.weight` projection nesting and the bare
+        // `std_bias` / `position_embedding_table` tensors. All of them must be
+        // stripped to the unprefixed MLX-community convention so the gemma4
+        // vision tower and multimodal embedder bind.
+        let mut weights = mlxcel_core::weights::WeightMap::new();
+        // A `model.language_model.` key is present in every real NVFP4 export
+        // and is what arms the remapper.
+        weights.insert(
+            "model.language_model.layers.0.mlp.gate_proj.weight".to_string(),
+            mlxcel_core::from_slice_f32(&[1.0f32], &[1]),
+        );
+        weights.insert(
+            "model.vision_tower.encoder.layers.0.mlp.down_proj.linear.weight".to_string(),
+            mlxcel_core::from_slice_f32(&[1.0f32], &[1]),
+        );
+        weights.insert(
+            "model.embed_vision.embedding_projection.weight".to_string(),
+            mlxcel_core::from_slice_f32(&[1.0f32], &[1]),
+        );
+        weights.insert(
+            "model.vision_tower.std_bias".to_string(),
+            mlxcel_core::from_slice_f32(&[1.0f32], &[1]),
+        );
+        weights.insert(
+            "model.vision_tower.patch_embedder.position_embedding_table".to_string(),
+            mlxcel_core::from_slice_f32(&[1.0f32], &[1]),
+        );
+
+        normalize_nvfp4_keys(&mut weights);
+
+        // Vision keys stripped to the unprefixed convention.
+        assert!(weights.contains_key("vision_tower.encoder.layers.0.mlp.down_proj.linear.weight"));
+        assert!(weights.contains_key("embed_vision.embedding_projection.weight"));
+        assert!(weights.contains_key("vision_tower.std_bias"));
+        assert!(weights.contains_key("vision_tower.patch_embedder.position_embedding_table"));
+        // Text decoder key still remapped (language-model-under-model inversion).
+        assert!(weights.contains_key("language_model.model.layers.0.mlp.gate_proj.weight"));
+        // No `model.`-prefixed vision key survives.
+        assert!(
+            !weights
+                .keys()
+                .any(|k| k.starts_with("model.vision_tower.")
+                    || k.starts_with("model.embed_vision.")),
+            "prefixed vision keys must be removed; keys: {:?}",
+            weights.keys().collect::<Vec<_>>()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The ModelOpt NVFP4 export `gemma-4-31b-it-nvfp4` loaded and generated on the text path but rejected every image request with `Error: Images provided but model is not a vision-language model`. Its vision front-end is nested under a leading `model.` prefix (`model.vision_tower.*`, `model.embed_vision.*`) that two loader stages never handled, so the checkpoint was misdetected as text-only and, even on the VLM path, the vision tower found no weights to bind. This binds the vision tower so the model serves image input like its 4-bit sibling.

## Root cause

The safetensors index for this checkpoint holds 1728 tensors: 1372 `model.language_model.*` (quantized text decoder), 355 `model.vision_tower.*`, and 1 `model.embed_vision.embedding_projection.weight`. Two stages assumed the MLX-community unprefixed names: `gemma4_has_vision_weights` scanned the index only for `vision_tower.` / `embed_vision.`, so the checkpoint matched neither and routed to `ModelType::Gemma4` (text) instead of `Gemma4VLM`; and `normalize_nvfp4_keys` remapped the text decoder and `model.embed_vision.` but had no `model.vision_tower.` branch, so the 355 vision-tower tensors stayed under `model.` and never bound. The vision front-end is unquantized (ModelOpt keeps `model.vision_tower*` / `model.embed_vision*` in `quantization_config.ignore`, and the tensors carry no `weight_scale_2` sidecar), so it needs key renaming only, not an NVFP4 transcode.

## What changed

- `src/models/sanitize.rs`: `normalize_nvfp4_keys` now strips `model.vision_tower.` -> `vision_tower.` alongside the existing text-decoder / `model.embed_vision.` / `model.lm_head.` remaps, and reports the full remapped count (1728 for this checkpoint, previously 1372) instead of just the language-model subset. `repack_nvfp4_weights_to_quantized` leaves the vision tensors alone because they carry no `weight_scale_2`.
- `src/models/detection.rs`: `gemma4_has_vision_weights` also recognizes the `model.`-prefixed vision keys, so an NVFP4 multimodal export routes to `Gemma4VLM`.
- `src/loading/vlm_gemma.rs`: `load_gemma4_vlm` runs `sanitize_gemma4_nvfp4_weights` after loading so the text decoder remaps and repacks and the vision keys remap on the VLM path. This is a no-op for MLX-community Gemma 4 VLM checkpoints (no `model.language_model.` keys and no `weight_scale_2` sidecars, so both inner stages skip immediately).
- `src/models/mod.rs`: re-export `sanitize_gemma4_nvfp4_weights` for the VLM loader.
- Unit test `normalize_nvfp4_keys_remaps_vision_tower_and_embed_vision` covers the vision-key remap (the `.linear.weight` projection nesting, the embed_vision projection, and the bare `std_bias` / `position_embedding_table` tensors).
- Docs: GB10 VLM benchmark table row is now a pass, and the `#749` notes in `model_tests_gb10.md` and `model_tests.md` describe the fix. The single-model VLM benchmark CSV is committed as evidence.

## Validation (GB10, CUDA, SM 12.1)

Before (from the issue repro):

```
Error: Images provided but model is not a vision-language model
```

After, image path (`generate -m models/gemma-4-31b-it-nvfp4 -p "What is in this image?" --image tests/fixtures/test_image.png -n 32`):

```
Remapping 1728 NVFP4-style weight keys to MLX-community convention...
Repacking 180 ModelOpt NVFP4 weight groups to MLX native NVFP4 via direct triplet transcode...
Model loaded in 58.559s (resident: 30.39 GB, peak: 34.34 GB).
Loaded 1 image(s).
Gemma4: expanded 1 image slot(s) into dynamic soft tokens (278 total tokens)
This image consists of a solid, flat background divided into two colors: a dark grey area on the top and a burnt orange/terracotta area on the
```

After, text-only path (`generate -m models/gemma-4-31b-it-nvfp4 -p "Hello" -n 8`) still works: `Hello! How can I help you today` (4.93 tok/s).

Benchmark row (`scripts/bench_decode.sh models/gemma-4-31b-it-nvfp4 --vlm --cooldown 0`), added to the GB10 VLM table: `gemma-4-31b-it-nvfp4` pass, 278 prompt tokens, 27 generated tokens, 353.20 prefill tok/s, 4.87 decode tok/s.

## Out of scope

Audio weights are absent from this export (0 tensors match audio despite `config.json` carrying an `audio_config`), so the audio tower is not loaded and is out of scope for this fix.

## Test plan

- [x] `cargo test --lib models::sanitize --features cuda` (70 passed, including the new vision-remap test)
- [x] `cargo clippy --lib --tests --features cuda -- -D warnings` (clean)
- [x] Real-model image + text validation on GB10 (outputs above)

Closes #749
