### PR TITLE
ci: generate and publish a CycloneDX SBOM on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -855,3 +855,58 @@ jobs:
           gh release edit "${{ github.event.release.tag_name }}" \
             --repo "${{ github.repository }}" \
             --prerelease=false
+
+  # ============================================================================
+  # Software Bill of Materials (CycloneDX SBOM) generation
+  # ============================================================================
+  generate-sbom:
+    name: Generate CycloneDX SBOM
+    needs: [build-macos, build-linux-cuda, build-linux-x86_64-cuda]
+    # Real release uploads only, scoped to the canonical repo. Skips build-only
+    # verification runs (workflow_dispatch without a release_tag), mirroring the
+    # upload guards on the build jobs above.
+    if: |
+      github.repository == 'lablup/mlxcel' && (
+        github.event_name == 'release' ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          # Don't leave GITHUB_TOKEN in .git/config; this job only reads source.
+          persist-credentials: false
+          # Catalog the source of the released tag, not the triggering branch, so
+          # the SBOM reflects exactly what shipped.
+          ref: ${{ github.event.release.tag_name || github.event.inputs.release_tag || github.sha }}
+
+      - name: Install Syft
+        run: |
+          set -euo pipefail
+          # Pin both the installer script and the syft binary to a tag for
+          # reproducibility (tracking main would drift the catalog over time).
+          SYFT_VERSION="v1.46.0"
+          curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${SYFT_VERSION}/install.sh" \
+            | sh -s -- -b /usr/local/bin "${SYFT_VERSION}"
+          syft version
+
+      - name: Generate and upload CycloneDX SBOM
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          # syft dir:. catalogs the Rust workspace via the committed Cargo.lock.
+          # Note: it does NOT capture the MLX C++ dependency fetched at build time
+          # via FetchContent (pinned by MLX_EXPECTED_COMMIT at the top of this
+          # file); recording that native pin in the SBOM is out of scope here.
+          syft dir:. -o cyclonedx-json > sbom.cyclonedx.json
+          gzip -9 sbom.cyclonedx.json
+          SBOM_FILE="sbom-${VERSION}.cyclonedx.json.gz"
+          mv sbom.cyclonedx.json.gz "$SBOM_FILE"
+          gh release upload "$TAG" "$SBOM_FILE" --clobber --repo "${{ github.repository }}"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -177,8 +177,10 @@ and GB10 (`121`) in a single build (`90a;100;121`), and x86_64 covering Ampere
 through Blackwell (`80;86;89;90a;100;120`). For each target the `mlxcel` CLI and the
 `mlxcel-server` are published as separate archives (`mlxcel-...` and
 `mlxcel-server-...`, each roughly 347 MB) so a consumer downloads only the one
-it needs. Treat other GPU/OS combinations as source builds that need local
-validation.
+it needs. Every published release also ships a CycloneDX SBOM named
+`sbom-<version>.cyclonedx.json.gz` for supply-chain transparency and
+vulnerability scanning. Treat other GPU/OS combinations as source builds that
+need local validation.
 
 ### Prebuilt CUDA artifact: runtime requirements
 


### PR DESCRIPTION
## Summary

Add a `generate-sbom` job to `.github/workflows/release.yml` so every real release publishes a CycloneDX JSON SBOM (`sbom-<version>.cyclonedx.json.gz`) as a release asset, matching the approach already in production in `lablup/backend.ai-go`.

## What changed

- New job `generate-sbom` in `.github/workflows/release.yml`, placed after `promote-release`, `needs: [build-macos, build-linux-cuda, build-linux-x86_64-cuda]` so it only runs once every platform build has succeeded.
- Checks out the exact released ref (`github.event.release.tag_name || github.event.inputs.release_tag || github.sha`) with `persist-credentials: false`, since this job only reads source.
- Installs Syft pinned to `v1.46.0` (both the installer script and the resolved binary version, for reproducibility instead of tracking `main`).
- Runs `syft dir:. -o cyclonedx-json`, gzips with `-9`, renames to `sbom-<version>.cyclonedx.json.gz`, and uploads with `gh release upload "$TAG" ... --clobber --repo "${{ github.repository }}"` (the explicit `--repo` is needed because `persist-credentials: false` leaves no git remote credential context for `gh` to infer the repo from).

## Key design decisions

- `runs-on: ubuntu-latest` (GitHub-hosted), matching `notify-teams` and `promote-release`. Syft catalogs source, not binaries, so no self-hosted GPU runner is needed, and `gh` is preinstalled on `ubuntu-latest`.
- Plain `needs` (no `if: always()`), matching `notify-teams`: the SBOM only publishes after a successful build, so a broken release never ships an SBOM.
- The job-level `if` gate mirrors the existing per-platform "Upload release artifacts" guard exactly (`github.event_name == 'release'` or `workflow_dispatch` with a non-empty `release_tag`), scoped to `github.repository == 'lablup/mlxcel'`, so build-only verification runs are skipped and forks cannot trigger an upload.
- `permissions: contents: write` under the file's default-deny top-level `permissions: {}`; the only permission `gh release upload` needs.
- Syft version `v1.46.0` was the latest stable tag at implementation time; pinning avoids catalog drift from tracking `main`.
- Known limitation: partial `workflow_dispatch` runs that build only a subset of platforms (e.g. `targets: macos`) will skip `generate-sbom`, because a skipped `needs` dependency blocks a downstream job by default. This is acceptable: real `release` events always build every platform, so the SBOM job always has all three dependencies satisfied on an actual release. Recording the MLX C++ FetchContent pin (`MLX_EXPECTED_COMMIT`) in the SBOM is also out of scope for this first cut, as called out in the issue.

## Validation

This is a workflow-only change; nothing here compiles, so no `cargo` commands were run.

- YAML sanity: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release.yml')); print('yaml ok')"` → `yaml ok`. `actionlint` was not available in this environment, so it was not run.
- Proved Syft will catalog the Rust dependency graph without picking up untracked files or the gitignored `./models` symlink: exported the tracked tree only via `git archive --format=tar HEAD | tar -x -C "$WORK"`, installed Syft `v1.46.0` into a scratch `bin/` directory, and ran `syft dir:"$WORK" -o cyclonedx-json > "$WORK/sbom.json"` against that export.
- Confirmed the export excluded the 20 untracked `benchmarks/*.csv` files present in the working tree and had no `models` entry.
- `jq -e '.bomFormat=="CycloneDX"'` → `true` (specVersion `1.7`).
- `jq '[.components[]? | select((.purl // "")|startswith("pkg:cargo/"))] | length'` → `439` cargo components found (out of 1163 total components), confirming the Cargo.lock crate graph is captured.

Closes #719
