### PR TITLE
test(surgery): stop the empty-pipeline comparison at the first EOS

### DIFF
--- a/tests/surgery_cli.rs
+++ b/tests/surgery_cli.rs
@@ -148,6 +148,17 @@ fn run_generate(model: &PathBuf, extra: &[&str]) -> (String, std::process::ExitS
 /// that the active-pipeline slot integration does not perturb load
 /// behaviour, and that the empty `transform.apply` short-circuits to
 /// zero work.
+///
+/// The comparison window is truncated at the first EOS marker in each
+/// run's own output (see [`truncate_at_first_eos`]) rather than
+/// spanning the full fixed `-n 20` token budget. `mlxcel generate`
+/// keeps sampling for the full `-n` count instead of stopping at EOS,
+/// so tokens after `<|im_end|>` / `<|endoftext|>` are a free-running
+/// tail with no signal for the no-op property under test; on the CUDA
+/// backend, near-tied logits in that tail let GPU reduction-order
+/// variance flip the argmax and make a full-window comparison flaky
+/// (issue #728). Truncating independently per run still catches any
+/// genuine pre-EOS divergence between the baseline and surgery paths.
 #[test]
 fn empty_surgery_pipeline_matches_baseline_output() {
     if skip_heavy_test_via_env() {
@@ -186,11 +197,11 @@ fn empty_surgery_pipeline_matches_baseline_output() {
     // that vary across runs, then compare just the generated suffix.
     // The reproducible substring is the final "Hello" + generated text
     // emitted by `print_generation_result`.
-    let baseline_generated = extract_generated_suffix(&baseline_stdout);
-    let surgery_generated = extract_generated_suffix(&surgery_stdout);
+    let baseline_generated = truncate_at_first_eos(extract_generated_suffix(&baseline_stdout));
+    let surgery_generated = truncate_at_first_eos(extract_generated_suffix(&surgery_stdout));
     assert_eq!(
         baseline_generated, surgery_generated,
-        "empty surgery pipeline must not change generated tokens\n\
+        "empty surgery pipeline must not change generated tokens (pre-EOS window)\n\
          baseline:\n{baseline_stdout}\n\
          surgery:\n{surgery_stdout}"
     );
@@ -208,6 +219,40 @@ fn extract_generated_suffix(stdout: &str) -> &str {
     let from_hello = &stdout[start..];
     let end = from_hello.find("\n[Generated").unwrap_or(from_hello.len());
     &from_hello[..end]
+}
+
+/// EOS marker strings that may appear literally in decoded CLI output.
+/// `decode_generated_text` (`src/commands/generate.rs`) decodes with
+/// `skip_special_tokens = false`, so the reference model's chat-template
+/// turn terminator and underlying EOS token render as literal text rather
+/// than being suppressed. `qwen2.5-0.5b-4bit`'s tokenizer emits both:
+/// `<|im_end|>` (the `config.json` `eos_token_id`) and `<|endoftext|>`
+/// (`tokenizer_config.json` `pad_token`, also observed as a de facto stop
+/// marker in generation).
+const EOS_MARKERS: &[&str] = &["<|im_end|>", "<|endoftext|>"];
+
+/// Truncate `text` at the end of whichever [`EOS_MARKERS`] entry starts
+/// earliest, keeping the marker itself in the returned prefix. Falls back
+/// to the full string when no marker is present, so a run that never
+/// reaches EOS within the fixed `-n` token budget still gets a full-window
+/// comparison (issue #728 acceptance criterion: the test must still
+/// meaningfully assert something in that case).
+///
+/// Applying this independently to each run's output bounds the equality
+/// assertion to the deterministic pre-EOS region while still failing loudly
+/// on any genuine divergence there: if the baseline and surgery outputs
+/// disagree before either one's first EOS marker, the truncated prefixes
+/// themselves differ and `assert_eq!` catches it.
+fn truncate_at_first_eos(text: &str) -> &str {
+    let first_match_end = EOS_MARKERS
+        .iter()
+        .filter_map(|marker| text.find(marker).map(|start| (start, start + marker.len())))
+        .min_by_key(|&(start, _)| start)
+        .map(|(_, end)| end);
+    match first_match_end {
+        Some(end) => &text[..end],
+        None => text,
+    }
 }
 
 /// Acceptance criterion (a) for the YAML parser side: a malformed


### PR DESCRIPTION
## Summary

`empty_surgery_pipeline_matches_baseline_output` compared the baseline and empty-surgery-pipeline CLI outputs byte-for-byte over the full fixed `-n 20` token budget. `mlxcel generate` keeps sampling for the whole `-n` count instead of stopping at EOS, so on `qwen2.5-0.5b-4bit` both runs already emit `<|im_end|>` and `<|endoftext|>` partway through and then continue into a free-running tail that carries no signal for the no-op property under test. On the CUDA/GB10 backend, near-tied logits in that tail let GPU reduction-order variance flip the argmax, making the full-window comparison flaky. This PR truncates the comparison at the first EOS marker instead.

## Root cause

Confirmed locally on this machine's Metal backend that the same post-EOS tail exists outside CUDA (`mlxcel generate -m models/qwen2.5-0.5b-4bit -p "Hello" -n 20 --temp 0.0` prints `...<|im_end|>\n<|endoftext|>Human: How can I improve my public` for the last few tokens), matching the left/right sample in the issue. The property under test (an empty surgery pipeline must not alter output) is sound; only the comparison window was fragile, exactly as the issue diagnosed. Changing the CLI's own EOS-stop behavior is out of scope for this test-only fix.

## What changed

- `tests/surgery_cli.rs`: added `EOS_MARKERS` (`<|im_end|>`, `<|endoftext|>` — the literal strings `decode_generated_text` renders since it decodes with `skip_special_tokens = false`) and `truncate_at_first_eos`, which truncates a decoded run's text at the end of whichever marker starts earliest, or returns the full text unchanged when no marker is present.
- The baseline and surgery outputs are now truncated independently with `truncate_at_first_eos` before the `assert_eq!`, so the assertion is bounded to the deterministic pre-EOS region.
- Any genuine pre-EOS divergence between the two runs is still caught: if the text before either run's own first marker differs, the truncated prefixes differ and the assertion fails.
- If neither run's output reaches EOS within the 20-token budget, the helper falls back to comparing the full window, so the test still asserts something meaningful in that case.

## Test plan

- [x] `cargo check --tests` (metal, accelerate features)
- [x] `cargo build --release --features metal,accelerate`
- [x] `cargo test --release --test surgery_cli empty_surgery_pipeline_matches_baseline_output -- --nocapture` — 5 consecutive runs, all passed (`test result: ok. 1 passed`)
- [x] `cargo test --release --test surgery_cli -- --nocapture` — full 3-test suite (including `malformed_surgery_yaml_fails_fast` and `missing_surgery_yaml_fails_fast`) passed together
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/ci/check_cross_repo_refs.py`

All validation above ran on this machine's Metal backend against the real `models/qwen2.5-0.5b-4bit` checkpoint. The issue's GB10/CUDA 5-consecutive-run acceptance criterion still needs confirmation on CUDA hardware, which was not reachable from this session. That said, the fix removes the flake mechanism (post-EOS near-tie argmax under GPU reduction-order variance) platform-independently by construction: the comparison no longer inspects the post-EOS region on any backend, so there is nothing left for reduction-order nondeterminism to disturb.

Closes #728
