### PR TITLE
feat(server): add Kimi K2 sectioned tool-call parser

### DIFF
--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -20,6 +20,8 @@
 //!
 //! Used by: tool_calls::parser
 
+use fancy_regex::Regex;
+
 use super::types::{ParsedToolCall, ToolCallFormat, ToolCallParseResult};
 
 /// Try parsing Hermes/Qwen format:
@@ -1283,6 +1285,199 @@ fn harmony_arguments(body: &str) -> String {
     }
 }
 
+/// Try parsing the Kimi K2 sectioned tool-call format:
+///
+/// ```text
+/// <|tool_calls_section_begin|>
+/// <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location": "Paris"}<|tool_call_end|>
+/// <|tool_calls_section_end|>
+/// ```
+///
+/// The per-call `<|tool_call_begin|>` / `<|tool_call_end|>` wrappers are
+/// optional: when the section body carries none, the whole section body is
+/// parsed as a single call. Each call id has the shape `functions.NAME:INDEX`
+/// (the `functions.` namespace prefix is optional); only the middle `NAME`
+/// segment is kept. The model-provided id and index are discarded, matching
+/// every other parser in this module — `ParsedToolCall` has no `id` field, so
+/// the caller regenerates a fresh id via `generate_tool_call_id`.
+pub fn try_kimi_k2(text: &str) -> Option<ToolCallParseResult> {
+    const SECTION_BEGIN: &str = "<|tool_calls_section_begin|>";
+    const SECTION_END: &str = "<|tool_calls_section_end|>";
+    const CALL_BEGIN: &str = "<|tool_call_begin|>";
+    const CALL_END: &str = "<|tool_call_end|>";
+
+    let section_start = text.find(SECTION_BEGIN)?;
+    let content = text[..section_start].trim().to_string();
+    let body_start = section_start + SECTION_BEGIN.len();
+
+    let body = match text[body_start..].find(SECTION_END) {
+        Some(end_offset) => &text[body_start..body_start + end_offset],
+        None => &text[body_start..],
+    };
+
+    // Name/argument marker: `functions.NAME:INDEX<|tool_call_argument_begin|>`.
+    // Group 1 (unused downstream) is the full id `functions.NAME:INDEX`;
+    // group 2 is the bare function NAME. Compiled once and reused across
+    // every call segment in this section.
+    let Ok(name_re) =
+        Regex::new(r"^\s*((?:functions\.)?(.+?):\d+)\s*<\|tool_call_argument_begin\|>")
+    else {
+        return None;
+    };
+
+    let mut calls = Vec::new();
+
+    if body.contains(CALL_BEGIN) {
+        let mut remaining = body;
+        while let Some(start) = remaining.find(CALL_BEGIN) {
+            let call_start = start + CALL_BEGIN.len();
+            let call_body = match remaining[call_start..].find(CALL_END) {
+                Some(end_offset) => {
+                    let b = &remaining[call_start..call_start + end_offset];
+                    remaining = &remaining[call_start + end_offset + CALL_END.len()..];
+                    b
+                }
+                None => {
+                    // No closing wrapper: take the rest as the last call body.
+                    let b = &remaining[call_start..];
+                    remaining = "";
+                    b
+                }
+            };
+            if let Some(call) = parse_kimi_k2_call(call_body, &name_re) {
+                calls.push(call);
+            }
+        }
+    } else if let Some(call) = parse_kimi_k2_call(body, &name_re) {
+        calls.push(call);
+    }
+
+    if calls.is_empty() {
+        return None;
+    }
+
+    Some(ToolCallParseResult {
+        format: Some(ToolCallFormat::KimiK2),
+        tool_calls: calls,
+        content,
+        reasoning_content: None,
+    })
+}
+
+/// Parse one Kimi K2 call body: `functions.NAME:INDEX<|tool_call_argument_begin|>{...}`.
+///
+/// Returns `None` when the name marker does not match (e.g. a call segment
+/// that carries no `functions.NAME:INDEX<|tool_call_argument_begin|>` header
+/// at all), so a single malformed call in a multi-call section is skipped
+/// rather than discarding the whole result.
+fn parse_kimi_k2_call(call_body: &str, name_re: &Regex) -> Option<ParsedToolCall> {
+    let caps = name_re.captures(call_body).ok()??;
+    let name = caps.get(2)?.as_str().to_string();
+    if name.is_empty() {
+        return None;
+    }
+    let marker_end = caps.get(0)?.end();
+    let args_raw = call_body[marker_end..].trim();
+    Some(ParsedToolCall {
+        name,
+        arguments: kimi_k2_arguments(args_raw),
+    })
+}
+
+/// Convert raw Kimi K2 argument text (everything after
+/// `<|tool_call_argument_begin|>`, already trimmed) into a JSON `arguments`
+/// string.
+///
+/// Parse order: strict JSON first (the common case — Kimi K2 emits a JSON
+/// object literal); if that fails, a loose literal reparse that tolerates
+/// Python-dict-repr spellings (single-quoted strings, `True`/`False`/`None`);
+/// if both fail, the raw text is kept verbatim so a malformed call still
+/// produces a call instead of being dropped.
+fn kimi_k2_arguments(raw: &str) -> String {
+    if raw.is_empty() {
+        return "{}".to_string();
+    }
+
+    if let Some(json) = kimi_k2_try_json(raw) {
+        return json;
+    }
+
+    let loosened = kimi_k2_loosen_literal(raw);
+    if let Some(json) = kimi_k2_try_json(&loosened) {
+        return json;
+    }
+
+    raw.to_string()
+}
+
+/// Parse `raw` as a JSON value, re-serializing to a compact JSON string.
+/// A value that is itself a JSON string is unwrapped rather than
+/// double-encoded, mirroring `parse_hermes_json` / `try_mistral_nemo`.
+fn kimi_k2_try_json(raw: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(raw).ok()?;
+    Some(if value.is_string() {
+        value.as_str().unwrap_or_default().to_string()
+    } else {
+        serde_json::to_string(&value).ok()?
+    })
+}
+
+/// Best-effort normalization of Python-dict-repr-style arguments (single
+/// quotes, `True`/`False`/`None`) into JSON syntax, used as the second parse
+/// attempt in [`kimi_k2_arguments`]. Not a full Python literal evaluator:
+/// quotes are swapped verbatim, so a string value containing an apostrophe
+/// will not round-trip — the caller's raw-string fallback covers that case.
+fn kimi_k2_loosen_literal(raw: &str) -> String {
+    let quoted: String = raw
+        .chars()
+        .map(|c| if c == '\'' { '"' } else { c })
+        .collect();
+    replace_python_literals(&quoted)
+}
+
+/// Replace whole-word Python literal tokens (`True`, `False`, `None`) with
+/// their JSON equivalents (`true`, `false`, `null`). A token only matches
+/// when it is not adjacent to another identifier character on either side,
+/// so `NoneType` or `TrueValue` are left untouched.
+fn replace_python_literals(text: &str) -> String {
+    const REPLACEMENTS: &[(&str, &str)] = &[("True", "true"), ("False", "false"), ("None", "null")];
+
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < text.len() {
+        let mut matched = false;
+        for (lit, json) in REPLACEMENTS {
+            if text[i..].starts_with(lit) {
+                let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+                let after = i + lit.len();
+                let after_ok = after >= text.len() || !is_ident_byte(bytes[after]);
+                if before_ok && after_ok {
+                    out.push_str(json);
+                    i = after;
+                    matched = true;
+                    break;
+                }
+            }
+        }
+        if !matched {
+            let ch = text[i..]
+                .chars()
+                .next()
+                .expect("i < text.len() guarantees a char");
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+    out
+}
+
+/// Whether a byte can be part of an identifier (used for word-boundary
+/// detection in [`replace_python_literals`]).
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2026,5 +2221,112 @@ mod tests {
         let result = try_harmony(text).unwrap();
         assert_eq!(result.tool_calls.len(), 1);
         assert_eq!(result.tool_calls[0].name, "fn");
+    }
+
+    // -- Kimi K2 --
+
+    #[test]
+    fn kimi_k2_single_call_with_wrapper() {
+        let text = "<|tool_calls_section_begin|>\
+                     <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\": \"Paris\"}<|tool_call_end|>\
+                     <|tool_calls_section_end|>";
+        let result = try_kimi_k2(text).unwrap();
+        assert_eq!(result.format, Some(ToolCallFormat::KimiK2));
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["location"], "Paris");
+    }
+
+    #[test]
+    fn kimi_k2_multiple_calls_in_one_section() {
+        let text = "<|tool_calls_section_begin|>\
+                     <|tool_call_begin|>functions.search:0<|tool_call_argument_begin|>{\"query\": \"rust\"}<|tool_call_end|>\
+                     <|tool_call_begin|>functions.calc:1<|tool_call_argument_begin|>{\"expr\": \"2+2\"}<|tool_call_end|>\
+                     <|tool_calls_section_end|>";
+        let result = try_kimi_k2(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(result.tool_calls[0].name, "search");
+        assert_eq!(result.tool_calls[1].name, "calc");
+        let args0: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args0["query"], "rust");
+        let args1: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[1].arguments).unwrap();
+        assert_eq!(args1["expr"], "2+2");
+    }
+
+    #[test]
+    fn kimi_k2_missing_per_call_wrappers_parses_whole_section_as_one_call() {
+        // No `<|tool_call_begin|>` / `<|tool_call_end|>` wrappers inside the
+        // section: the whole section body is a single call.
+        let text = "<|tool_calls_section_begin|>functions.get_time:0<|tool_call_argument_begin|>{}<|tool_calls_section_end|>";
+        let result = try_kimi_k2(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "get_time");
+        assert_eq!(result.tool_calls[0].arguments, "{}");
+    }
+
+    #[test]
+    fn kimi_k2_malformed_json_args_falls_back_to_raw_string() {
+        let text = "<|tool_calls_section_begin|>\
+                     <|tool_call_begin|>functions.broken:0<|tool_call_argument_begin|>{not valid json at all<|tool_call_end|>\
+                     <|tool_calls_section_end|>";
+        let result = try_kimi_k2(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "broken");
+        // Falls back to the raw (trimmed) argument text rather than panicking
+        // or dropping the call.
+        assert_eq!(result.tool_calls[0].arguments, "{not valid json at all");
+    }
+
+    #[test]
+    fn kimi_k2_name_extracted_from_functions_prefixed_id() {
+        // The tricky part of the name regex: `functions.NAME:INDEX` must
+        // yield the bare middle segment `NAME`, discarding both the
+        // `functions.` namespace and the `:INDEX` suffix.
+        let text = "<|tool_calls_section_begin|>\
+                     <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{}<|tool_call_end|>\
+                     <|tool_calls_section_end|>";
+        let result = try_kimi_k2(text).unwrap();
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+    }
+
+    #[test]
+    fn kimi_k2_name_extracted_without_functions_prefix() {
+        // The `functions.` namespace prefix is optional per the spec regex.
+        let text = "<|tool_calls_section_begin|>\
+                     <|tool_call_begin|>get_weather:3<|tool_call_argument_begin|>{}<|tool_call_end|>\
+                     <|tool_calls_section_end|>";
+        let result = try_kimi_k2(text).unwrap();
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+    }
+
+    #[test]
+    fn kimi_k2_no_match_without_section_marker() {
+        assert!(try_kimi_k2("Hello, world!").is_none());
+        assert!(try_kimi_k2(r#"<tool_call>{"name": "fn", "arguments": {}}</tool_call>"#).is_none());
+    }
+
+    #[test]
+    fn kimi_k2_content_before_section_preserved() {
+        let text = "Let me check the weather.\
+                     <|tool_calls_section_begin|>\
+                     <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Tokyo\"}<|tool_call_end|>\
+                     <|tool_calls_section_end|>";
+        let result = try_kimi_k2(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert!(result.content.contains("check the weather"));
+    }
+
+    #[test]
+    fn kimi_k2_missing_section_end_marker_still_parses() {
+        // No closing `<|tool_calls_section_end|>`: take the rest of the text.
+        let text = "<|tool_calls_section_begin|>\
+                     <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"city\": \"Seoul\"}<|tool_call_end|>";
+        let result = try_kimi_k2(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "get_weather");
     }
 }

--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -2329,4 +2329,40 @@ mod tests {
         assert_eq!(result.tool_calls.len(), 1);
         assert_eq!(result.tool_calls[0].name, "get_weather");
     }
+
+    #[test]
+    fn kimi_k2_loose_literal_python_repr_arguments_coerced() {
+        // Arguments spelled as a Python dict repr (single-quoted keys/values,
+        // `True`/`False`/`None`) fail strict JSON parsing, so this exercises
+        // the second parse attempt in `kimi_k2_arguments`: the loose-literal
+        // reparse via `kimi_k2_loosen_literal` / `replace_python_literals`.
+        let text = "<|tool_calls_section_begin|>\
+                     <|tool_call_begin|>functions.set_profile:0<|tool_call_argument_begin|>{'active': True, 'name': 'Paris', 'note': None}<|tool_call_end|>\
+                     <|tool_calls_section_end|>";
+        let result = try_kimi_k2(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "set_profile");
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["active"], true);
+        assert_eq!(args["name"], "Paris");
+        assert!(args["note"].is_null());
+    }
+
+    #[test]
+    fn kimi_k2_loose_literal_word_boundary_guard_preserves_identifier_substrings() {
+        // `NoneType` contains the literal token `None` as a substring, but
+        // `replace_python_literals` only replaces whole-word matches, so it
+        // must survive the loose-literal reparse untouched while the
+        // standalone `True` is still coerced to JSON `true`.
+        let text = "<|tool_calls_section_begin|>\
+                     <|tool_call_begin|>functions.describe:0<|tool_call_argument_begin|>{'active': True, 'kind': 'NoneType'}<|tool_call_end|>\
+                     <|tool_calls_section_end|>";
+        let result = try_kimi_k2(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["active"], true);
+        assert_eq!(args["kind"], "NoneType");
+    }
 }

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -160,6 +160,7 @@ pub fn parse_tool_calls(raw_output: &str, tools: Option<&[Tool]>) -> ToolCallPar
         formats::try_gemma4,  // <|tool_call>call:... — pipe-delimited, before Hermes
         formats::try_hermes,  // <tool_call> — Hermes/Qwen/DeepSeek
         formats::try_minimax_m2, // <invoke name=...><parameter name=...>...</parameter></invoke>
+        formats::try_kimi_k2, // <|tool_calls_section_begin|>...<|tool_calls_section_end|>
         formats::try_mistral_nemo, // [TOOL_CALLS]
         formats::try_functionary_v31, // <function=name>{json}
         formats::try_qwen3_coder, // <function=name><parameter=key>val</parameter> (after v31, which declines non-JSON bodies)
@@ -614,6 +615,50 @@ mod tests {
     #[test]
     fn parse_minimax_m2_filters_unknown_tools() {
         let output = "<invoke name=\"unknown_fn\">\n<parameter name=\"k\">v</parameter>\n</invoke>";
+        let tools = vec![make_tool("get_weather")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(!result.has_tool_calls());
+    }
+
+    // -- Kimi K2 --
+
+    #[test]
+    fn parse_kimi_k2_single_call() {
+        let output = "<|tool_calls_section_begin|>\
+                       <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\": \"Paris\"}<|tool_call_end|>\
+                       <|tool_calls_section_end|>";
+        let tools = vec![make_tool("get_weather")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["location"], "Paris");
+        assert_eq!(
+            result.format,
+            Some(crate::server::tool_calls::ToolCallFormat::KimiK2)
+        );
+    }
+
+    #[test]
+    fn parse_kimi_k2_multiple_calls() {
+        let output = "<|tool_calls_section_begin|>\
+                       <|tool_call_begin|>functions.search:0<|tool_call_argument_begin|>{\"query\": \"weather\"}<|tool_call_end|>\
+                       <|tool_call_begin|>functions.read_file:1<|tool_call_argument_begin|>{\"path\": \"/tmp/test.txt\"}<|tool_call_end|>\
+                       <|tool_calls_section_end|>";
+        let tools = vec![make_tool("search"), make_tool("read_file")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(result.tool_calls[0].name, "search");
+        assert_eq!(result.tool_calls[1].name, "read_file");
+    }
+
+    #[test]
+    fn parse_kimi_k2_filters_unknown_tools() {
+        let output = "<|tool_calls_section_begin|>\
+                       <|tool_call_begin|>functions.unknown_fn:0<|tool_call_argument_begin|>{}<|tool_call_end|>\
+                       <|tool_calls_section_end|>";
         let tools = vec![make_tool("get_weather")];
         let result = parse_tool_calls(output, Some(&tools));
         assert!(!result.has_tool_calls());

--- a/src/server/tool_calls/stream_filter.rs
+++ b/src/server/tool_calls/stream_filter.rs
@@ -196,6 +196,11 @@ enum DelimiterAction {
 ///   exists; all subsequent content (the JSON array) is tool-call payload.
 ///   It is placed after the `<tag>` families so angle-bracket markers still
 ///   benefit from the tighter (shorter) partial-match window that `<` gives.
+/// - Kimi K2 `<|tool_calls_section_end|>` / `<|tool_calls_section_begin|>` —
+///   exit before enter, matching the Hermes convention above. Neither prefix-
+///   collides with any other entry: `<|tool_call>` (Gemma 4) requires a `>`
+///   immediately after `tool_call`, whereas Kimi's markers continue with
+///   `s_section_...`, so the two families never partial-match each other.
 ///
 /// TODO: Consider extracting this into a startup-time configurable
 /// owned by the model worker so new reasoning families don't require a rebuild.
@@ -220,6 +225,13 @@ const CHAT_DELIMITERS: &[(&str, DelimiterAction)] = &[
     ("<tool_call>", DelimiterAction::EnterToolCall),
     // Mistral Nemo: `[TOOL_CALLS] [...]` — no exit; the rest of output is JSON.
     ("[TOOL_CALLS]", DelimiterAction::EnterToolCall),
+    // Kimi K2: `<|tool_calls_section_begin|>...<|tool_calls_section_end|>`.
+    // Exit before enter, mirroring the Hermes convention above.
+    ("<|tool_calls_section_end|>", DelimiterAction::ExitToolCall),
+    (
+        "<|tool_calls_section_begin|>",
+        DelimiterAction::EnterToolCall,
+    ),
 ];
 
 /// The state of the streaming filter state machine.
@@ -1521,6 +1533,106 @@ mod tests {
             "feed(`</`) + feed(`tool`) + feed(`_call>`) must give suppressed_positions == 3; \
              got {}",
             r3.suppressed_positions
+        );
+    }
+
+    // -- Kimi K2 sectioned tool-call markers --
+
+    #[test]
+    fn kimi_k2_tool_call_section_suppressed_in_one_fragment() {
+        // A full Kimi K2 section fed as a single fragment: the section body
+        // (including the per-call wrappers and JSON payload) must not leak
+        // into delta.content.
+        let mut f = StreamFilter::new();
+        let out = f.feed(
+            "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0\
+             <|tool_call_argument_begin|>{\"location\": \"Paris\"}<|tool_call_end|>\
+             <|tool_calls_section_end|>",
+        );
+        assert_eq!(
+            out.content, None,
+            "Kimi K2 tool-call section markup must not appear in delta.content"
+        );
+        assert_eq!(out.reasoning, None);
+    }
+
+    #[test]
+    fn kimi_k2_content_before_section_emitted() {
+        let mut f = StreamFilter::new();
+        let out = f.feed(
+            "Let me check the weather.<|tool_calls_section_begin|><|tool_call_begin|>\
+             functions.get_weather:0<|tool_call_argument_begin|>{\"location\": \"Tokyo\"}\
+             <|tool_call_end|><|tool_calls_section_end|>",
+        );
+        assert_eq!(
+            out.content.as_deref(),
+            Some("Let me check the weather."),
+            "only the preamble text must appear in delta.content"
+        );
+        assert!(
+            !out.content
+                .as_deref()
+                .unwrap_or("")
+                .contains("<|tool_calls_section_begin|>")
+        );
+    }
+
+    #[test]
+    fn kimi_k2_section_markers_split_across_fragment_boundaries() {
+        // The long `<|tool_calls_section_begin|>` / `<|tool_calls_section_end|>`
+        // markers arrive split across multiple decode fragments (as a real
+        // tokenizer would emit them token-by-token). The filter must buffer
+        // partial matches and suppress the whole tool-call body regardless of
+        // how the marker bytes are chunked.
+        let mut f = StreamFilter::new();
+        let fragments = [
+            "Sure, let me check.",
+            "<|tool_calls",
+            "_section_begin|>",
+            "<|tool_call_begin|>functions.get_",
+            "weather:0<|tool_call_argument_begin|>",
+            "{\"location\": \"Se",
+            "oul\"}",
+            "<|tool_call_end|>",
+            "<|tool_calls_section",
+            "_end|>",
+            "Done.",
+        ];
+
+        let mut total_content = String::new();
+        for frag in &fragments {
+            if let Some(c) = f.feed(frag).content {
+                total_content.push_str(&c);
+            }
+        }
+        let flushed = f.flush();
+        if let Some(c) = flushed.content {
+            total_content.push_str(&c);
+        }
+
+        assert_eq!(
+            total_content, "Sure, let me check.Done.",
+            "only the pre- and post-section text must survive; the tool-call \
+             body must be fully suppressed even when the section markers \
+             straddle fragment boundaries; got: {total_content:?}"
+        );
+        assert!(!total_content.contains("tool_calls_section"));
+        assert!(!total_content.contains("Seoul"));
+    }
+
+    #[test]
+    fn kimi_k2_tool_call_not_confused_with_hermes_or_gemma4() {
+        // Kimi K2's `<|tool_calls_section_begin|>` must not be mistaken for
+        // Gemma 4's `<|tool_call>` open tag (both share the `<|tool_cal` prefix)
+        // and must not leave the filter in a state where a subsequent Hermes
+        // `<tool_call>` fails to enter ToolCall state.
+        let mut f = StreamFilter::new();
+        let out = f.feed("<|tool_calls_section_begin|>body<|tool_calls_section_end|>");
+        assert_eq!(out.content, None);
+        assert_eq!(
+            f.feed("after").content.as_deref(),
+            Some("after"),
+            "content after the Kimi K2 section must resume normally"
         );
     }
 }

--- a/src/server/tool_calls/types.rs
+++ b/src/server/tool_calls/types.rs
@@ -63,6 +63,13 @@ pub enum ToolCallFormat {
     /// The `analysis` channel carries chain-of-thought (routed to
     /// `reasoning_content`) and the `final` channel carries the visible answer.
     Harmony,
+    /// Kimi K2: sectioned marker format `<|tool_calls_section_begin|>...<|tool_calls_section_end|>`
+    /// wrapping one or more `<|tool_call_begin|>...<|tool_call_end|>` calls
+    /// (the per-call wrapper is optional; an unwrapped section body is parsed
+    /// as a single call). Each call is shaped
+    /// `functions.NAME:INDEX<|tool_call_argument_begin|>{json arguments}`,
+    /// e.g. `functions.get_weather:0<|tool_call_argument_begin|>{"location": "Paris"}`.
+    KimiK2,
 }
 
 /// Result of parsing model output for tool calls.


### PR DESCRIPTION
## Summary

Kimi models emit tool calls wrapped in `<|tool_calls_section_begin|>...<|tool_calls_section_end|>` section markers, a format none of the existing `tool_calls::formats` parsers recognized, so those calls fell through to plain content instead of structured `tool_calls`.

## What changed

- `src/server/tool_calls/formats.rs`: added `try_kimi_k2`, which locates the section, splits on the optional per-call `<|tool_call_begin|>`/`<|tool_call_end|>` wrappers (falling back to treating the whole section body as one call when the wrappers are absent), and extracts each call's function name from the `functions.NAME:INDEX<|tool_call_argument_begin|>` header via a regex compiled once per section. Uses `fancy-regex`, already a project dependency, so no new crate was added. Arguments are parsed as strict JSON first, then a loose literal reparse tolerating Python-dict-repr spellings (single quotes, `True`/`False`/`None`), then fall back to the raw trimmed text so a malformed call still produces a call instead of being dropped.
- `src/server/tool_calls/types.rs`: added the `KimiK2` variant to `ToolCallFormat` with a doc comment describing the marker format.
- `src/server/tool_calls/parser.rs`: registered `formats::try_kimi_k2` in the ordered parser dispatch list, ahead of the generic fallback parsers. `ParsedToolCall` still carries only `name` and `arguments` (unchanged struct); the model-provided id/index is discarded and a fresh id is generated downstream via `generate_tool_call_id`, matching every other parser.
- `src/server/tool_calls/stream_filter.rs`: added the section begin/end markers to `CHAT_DELIMITERS` (exit before enter, mirroring the existing Hermes convention) so streaming responses suppress the tool-call section from `delta.content` instead of leaking the raw markers.

## Test plan

- [x] `cargo test --lib server::tool_calls::formats` — 76 passed (includes single call with wrappers, multiple calls in one section, missing per-call wrappers, malformed JSON argument fallback, name extraction with/without the `functions.` prefix, missing section-end marker, content-before-section preservation)
- [x] `cargo test --lib server::tool_calls::parser` — 58 passed (end-to-end `parse_tool_calls` coverage: single call, multiple calls, unknown-tool filtering)
- [x] `cargo test --lib server::tool_calls::stream_filter` — 59 passed (single-fragment suppression, content-before-section, markers split across fragment boundaries, no confusion with Hermes/Gemma 4 tool-call delimiters)
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo fmt -- --check` on the four changed files

Closes #766
