### PR TITLE
fix(qwen3_5): layout-gate the norm shift so bundled MTP weights cannot double-shift converted checkpoints

### DIFF
--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -2295,6 +2295,18 @@ impl Qwen35StageModel {
 }
 
 // Weight Sanitization.
+
+/// Whether a `conv1d.weight` tensor is still in the raw torch layout.
+///
+/// The gated-delta conv is depthwise (`groups == channels`), so a raw torch
+/// weight is `[out, 1, kW]` and the converted MLX weight is `[out, kW, 1]`. A
+/// tensor of rank < 3 carries no layout information, so it reads as converted:
+/// the norm-shift gate in [`sanitize_weights`] keys on this predicate, and a
+/// degenerate tensor must not be able to trigger a shift that transposes nothing.
+fn is_raw_conv1d_layout(shape: &[i32]) -> bool {
+    shape.len() >= 3 && shape[shape.len() - 1] != 1
+}
+
 pub fn sanitize_weights(mut weights: WeightMap, config: &Qwen35Config) -> WeightMap {
     // 1. Detect sanitization needs.
     //
@@ -2311,11 +2323,13 @@ pub fn sanitize_weights(mut weights: WeightMap, config: &Qwen35Config) -> Weight
     // has_unsanitized_conv1d`
     // (https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/qwen3_5.py).
     // Do not reintroduce the `mtp.` term when syncing against that file.
+    //
+    // The gate and the transpose below share `is_raw_conv1d_layout`, so the
+    // invariant is "the norms shift only if at least one conv1d is actually
+    // transposed". A degenerate conv1d tensor of rank < 3 is undecidable, so it
+    // reads as converted and fails safe: no transpose, no shift.
     let has_unsanitized_conv1d = weights.iter().any(|(k, v)| {
-        k.contains("conv1d.weight") && {
-            let shape = mlxcel_core::array_shape(v);
-            shape.last() != Some(&1)
-        }
+        k.contains("conv1d.weight") && is_raw_conv1d_layout(&mlxcel_core::array_shape(v))
     });
     let should_shift_norms = has_unsanitized_conv1d;
 
@@ -2338,11 +2352,10 @@ pub fn sanitize_weights(mut weights: WeightMap, config: &Qwen35Config) -> Weight
 
     let keys: Vec<String> = weights.keys().cloned().collect();
     for k in &keys {
-        // Conv1d weight: moveaxis(2, 1) when shape[-1] != 1
+        // Conv1d weight: moveaxis(2, 1) when the layout is still raw
         if k.contains("conv1d.weight") {
             let v = weights.get(k.as_str()).unwrap();
-            let shape = mlxcel_core::array_shape(v);
-            if shape.len() >= 3 && shape[shape.len() - 1] != 1 {
+            if is_raw_conv1d_layout(&mlxcel_core::array_shape(v)) {
                 let transposed = mlxcel_core::swap_axes(v, -1, -2);
                 weights.insert(k.clone(), transposed);
             }

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -2298,22 +2298,19 @@ impl Qwen35StageModel {
 pub fn sanitize_weights(mut weights: WeightMap, config: &Qwen35Config) -> WeightMap {
     // 1. Detect sanitization needs.
     //
-    // The conv1d weight layout is the reliable raw-vs-converted discriminator: a
-    // raw torch/HF conv1d weight is `[out, in, kW]` (last dim is the kernel size,
-    // never 1 for these kernel sizes), while an already-converted one is
-    // `[out, kW, 1]`. Every local qwen3.5-*/minicpm-v-4.6-* checkpoint inspected
-    // for issue #776 (0.8b/2b/4b/9b/27b/35b-a3b 4bit and 9b/27b bf16, plus both
-    // minicpm-v-4.6 variants) ships the converted `[out, kW, 1]` shape and none
-    // carries `mtp.*` keys, matching the issue's own observation that converted
-    // checkpoints ship the MTP head as a separate repo today. In every raw
-    // layout, a bundled `mtp.*` weight and the unconverted conv1d weight come
-    // from the same unsanitized dump, so `has_mtp` alone never adds a case that
-    // `has_unsanitized_conv1d` does not already cover. Keeping `has_mtp` as an
-    // independent OR term is actively unsafe: if a future converted repo ever
-    // bundles the MTP head into an already-sanitized checkpoint (norms already
-    // shifted by +1.0, conv1d already transposed), the norms would be shifted a
-    // second time and every RMSNorm would be corrupted. Gate on the conv1d
-    // layout alone so bundled MTP weights can never trigger a double shift.
+    // The conv1d weight layout is the only reliable raw-vs-converted signal: a raw
+    // torch conv1d weight is `[out, in, kW]`, a converted one is `[out, kW, 1]`.
+    // The norm shift is gated on that layout alone. An `mtp.` key is not a
+    // raw-layout signal: a converted checkpoint that bundles the MTP head (norms
+    // already shifted by +1.0, conv1d already transposed) would have its norms
+    // shifted a second time, corrupting every RMSNorm. No coverage is lost, because
+    // a raw checkpoint carrying `mtp.` weights carries unconverted conv1d weights
+    // from the same dump, and every qwen3_5 checkpoint has gated-delta layers.
+    //
+    // This diverges from mlx-lm, which still gates on `has_mtp or
+    // has_unsanitized_conv1d`
+    // (https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/qwen3_5.py).
+    // Do not reintroduce the `mtp.` term when syncing against that file.
     let has_unsanitized_conv1d = weights.iter().any(|(k, v)| {
         k.contains("conv1d.weight") && {
             let shape = mlxcel_core::array_shape(v);

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -2296,15 +2296,31 @@ impl Qwen35StageModel {
 
 // Weight Sanitization.
 pub fn sanitize_weights(mut weights: WeightMap, config: &Qwen35Config) -> WeightMap {
-    // 1. Detect sanitization needs
-    let has_mtp = weights.keys().any(|k| k.contains("mtp."));
+    // 1. Detect sanitization needs.
+    //
+    // The conv1d weight layout is the reliable raw-vs-converted discriminator: a
+    // raw torch/HF conv1d weight is `[out, in, kW]` (last dim is the kernel size,
+    // never 1 for these kernel sizes), while an already-converted one is
+    // `[out, kW, 1]`. Every local qwen3.5-*/minicpm-v-4.6-* checkpoint inspected
+    // for issue #776 (0.8b/2b/4b/9b/27b/35b-a3b 4bit and 9b/27b bf16, plus both
+    // minicpm-v-4.6 variants) ships the converted `[out, kW, 1]` shape and none
+    // carries `mtp.*` keys, matching the issue's own observation that converted
+    // checkpoints ship the MTP head as a separate repo today. In every raw
+    // layout, a bundled `mtp.*` weight and the unconverted conv1d weight come
+    // from the same unsanitized dump, so `has_mtp` alone never adds a case that
+    // `has_unsanitized_conv1d` does not already cover. Keeping `has_mtp` as an
+    // independent OR term is actively unsafe: if a future converted repo ever
+    // bundles the MTP head into an already-sanitized checkpoint (norms already
+    // shifted by +1.0, conv1d already transposed), the norms would be shifted a
+    // second time and every RMSNorm would be corrupted. Gate on the conv1d
+    // layout alone so bundled MTP weights can never trigger a double shift.
     let has_unsanitized_conv1d = weights.iter().any(|(k, v)| {
         k.contains("conv1d.weight") && {
             let shape = mlxcel_core::array_shape(v);
             shape.last() != Some(&1)
         }
     });
-    let should_shift_norms = has_mtp || has_unsanitized_conv1d;
+    let should_shift_norms = has_unsanitized_conv1d;
 
     // 2. Filter MTP weights
     weights.retain(|k, _| !k.contains("mtp."));

--- a/src/models/qwen3_5_tests.rs
+++ b/src/models/qwen3_5_tests.rs
@@ -311,7 +311,7 @@ fn sanitize_weights_drops_lm_head_when_tied_embeddings() {
 }
 
 // ---------------------------------------------------------------------------
-// `sanitize_weights` idempotency (issue #776) — the norm `+1.0` shift must be
+// `sanitize_weights` idempotency (issue #776): the norm `+1.0` shift must be
 // layout-gated on the conv1d weight shape alone. A bundled `mtp.*` tensor
 // must never force a second shift on an already-converted checkpoint, and a
 // genuinely raw checkpoint must still shift exactly once.
@@ -396,9 +396,18 @@ fn sanitize_weights_shifts_norms_exactly_once_on_raw_layout() {
         "model.embed_tokens.weight".to_string(),
         mlxcel_core::from_slice_f32(&[0.0_f32; 8], &[2, 4]),
     );
+    // A raw checkpoint that bundles the MTP head. This is the direction in which
+    // dropping the `has_mtp` term could have lost coverage, so pin it: the raw
+    // conv1d layout alone must still drive the shift.
+    weights.insert(
+        "mtp.layers.0.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0_f32; 16], &[4, 4]),
+    );
 
     let config = make_tiny_config();
     let sanitized = sanitize_weights(weights, &config);
+
+    assert!(sanitized.keys().all(|k| !k.contains("mtp.")));
 
     // The norm gammas must be shifted exactly once: 0.5 + 1.0 = 1.5.
     assert_allclose(
@@ -419,4 +428,42 @@ fn sanitize_weights_shifts_norms_exactly_once_on_raw_layout() {
             .unwrap(),
     );
     assert_eq!(conv1d_shape, vec![4, 4, 1]);
+}
+
+#[test]
+#[ignore = "requires serial MLX execution"]
+fn sanitize_weights_does_not_shift_norms_on_a_degenerate_conv1d_shape() {
+    // A conv1d tensor of rank < 3 carries no layout information. The gate and the
+    // transpose share `is_raw_conv1d_layout`, so such a tensor must read as
+    // converted: nothing is transposed, and therefore nothing may be shifted.
+    // Gating on `shape.last() != Some(&1)` instead would shift every norm here
+    // while transposing no conv1d at all, which is the corruption issue #776 is
+    // about.
+    let mut weights = WeightMap::new();
+    weights.insert(
+        "model.layers.0.linear_attn.conv1d.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0_f32; 16], &[4, 4]),
+    );
+    weights.insert(
+        "model.norm.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[1.5_f32; 4], &[4]),
+    );
+    weights.insert(
+        "model.embed_tokens.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0_f32; 8], &[2, 4]),
+    );
+
+    let config = make_tiny_config();
+    let sanitized = sanitize_weights(weights, &config);
+
+    assert_allclose(
+        sanitized.get("model.norm.weight").unwrap(),
+        &mlxcel_core::from_slice_f32(&[1.5_f32; 4], &[4]),
+    );
+    let conv1d_shape = mlxcel_core::array_shape(
+        sanitized
+            .get("model.layers.0.linear_attn.conv1d.weight")
+            .unwrap(),
+    );
+    assert_eq!(conv1d_shape, vec![4, 4]);
 }

--- a/src/models/qwen3_5_tests.rs
+++ b/src/models/qwen3_5_tests.rs
@@ -309,3 +309,114 @@ fn sanitize_weights_drops_lm_head_when_tied_embeddings() {
     );
     assert!(sanitized.contains_key("model.embed_tokens.weight"));
 }
+
+// ---------------------------------------------------------------------------
+// `sanitize_weights` idempotency (issue #776) — the norm `+1.0` shift must be
+// layout-gated on the conv1d weight shape alone. A bundled `mtp.*` tensor
+// must never force a second shift on an already-converted checkpoint, and a
+// genuinely raw checkpoint must still shift exactly once.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires serial MLX execution"]
+fn sanitize_weights_is_idempotent_on_already_converted_checkpoint_with_stray_mtp_key() {
+    let mut weights = WeightMap::new();
+    // Already-converted conv1d layout: `[out, kW, 1]` (last dim == 1).
+    weights.insert(
+        "model.layers.0.linear_attn.conv1d.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0_f32; 16], &[4, 4, 1]),
+    );
+    // Already-shifted norm gammas (a raw gamma of 0.5 becomes 1.5 after a
+    // single +1.0 shift; a second shift would produce 2.5).
+    weights.insert(
+        "model.norm.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[1.5_f32; 4], &[4]),
+    );
+    weights.insert(
+        "model.layers.0.input_layernorm.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[1.5_f32; 8], &[8]),
+    );
+    weights.insert(
+        "model.embed_tokens.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0_f32; 8], &[2, 4]),
+    );
+    // A bundled MTP tensor, mirroring a future converted repo that ships the
+    // MTP head alongside an already-sanitized main checkpoint.
+    weights.insert(
+        "mtp.layers.0.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0_f32; 16], &[4, 4]),
+    );
+
+    let config = make_tiny_config();
+    let sanitized = sanitize_weights(weights, &config);
+
+    // mtp.* must still be stripped.
+    assert!(sanitized.keys().all(|k| !k.starts_with("mtp.")));
+
+    // The norm gammas must be UNCHANGED (no second shift), not 2.5.
+    assert_allclose(
+        sanitized.get("model.norm.weight").unwrap(),
+        &mlxcel_core::from_slice_f32(&[1.5_f32; 4], &[4]),
+    );
+    assert_allclose(
+        sanitized
+            .get("model.layers.0.input_layernorm.weight")
+            .unwrap(),
+        &mlxcel_core::from_slice_f32(&[1.5_f32; 8], &[8]),
+    );
+
+    // The already-converted conv1d weight must not be re-transposed: shape
+    // stays `[out, kW, 1]`.
+    let conv1d_shape = mlxcel_core::array_shape(
+        sanitized
+            .get("model.layers.0.linear_attn.conv1d.weight")
+            .unwrap(),
+    );
+    assert_eq!(conv1d_shape, vec![4, 4, 1]);
+}
+
+#[test]
+#[ignore = "requires serial MLX execution"]
+fn sanitize_weights_shifts_norms_exactly_once_on_raw_layout() {
+    let mut weights = WeightMap::new();
+    // Raw torch/HF conv1d layout: `[out, in, kW]` (last dim = kernel size != 1).
+    weights.insert(
+        "model.layers.0.linear_attn.conv1d.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0_f32; 16], &[4, 1, 4]),
+    );
+    weights.insert(
+        "model.norm.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.5_f32; 4], &[4]),
+    );
+    weights.insert(
+        "model.layers.0.input_layernorm.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.5_f32; 8], &[8]),
+    );
+    weights.insert(
+        "model.embed_tokens.weight".to_string(),
+        mlxcel_core::from_slice_f32(&[0.0_f32; 8], &[2, 4]),
+    );
+
+    let config = make_tiny_config();
+    let sanitized = sanitize_weights(weights, &config);
+
+    // The norm gammas must be shifted exactly once: 0.5 + 1.0 = 1.5.
+    assert_allclose(
+        sanitized.get("model.norm.weight").unwrap(),
+        &mlxcel_core::from_slice_f32(&[1.5_f32; 4], &[4]),
+    );
+    assert_allclose(
+        sanitized
+            .get("model.layers.0.input_layernorm.weight")
+            .unwrap(),
+        &mlxcel_core::from_slice_f32(&[1.5_f32; 8], &[8]),
+    );
+
+    // The raw conv1d weight must be transposed to `[out, kW, 1]`.
+    let conv1d_shape = mlxcel_core::array_shape(
+        sanitized
+            .get("model.layers.0.linear_attn.conv1d.weight")
+            .unwrap(),
+    );
+    assert_eq!(conv1d_shape, vec![4, 4, 1]);
+}


### PR DESCRIPTION
## Summary

`sanitize_weights` for qwen3_5 decided whether to add +1.0 to 1-D RMSNorm gammas via `should_shift_norms = has_mtp || has_unsanitized_conv1d`. The conv1d-layout check (raw torch `[out, in, kW]` vs. converted `[out, kW, 1]`) is the reliable raw-vs-converted discriminator, but the standalone `has_mtp` clause could override a correct "already converted" verdict: a converted checkpoint that bundles `mtp.`-prefixed weights (norms already shifted, conv1d already transposed) would get its norms shifted a second time, corrupting every RMSNorm. This PR makes the conv1d layout signal authoritative.

## Investigation

I inspected the safetensors headers of every local qwen3.5 checkpoint (0.8b/2b/4b/9b/27b/35b-a3b 4bit, 9b/27b bf16, 4b/27b dflash) and both minicpm-v-4.6 variants (bf16, mxfp4). Every one ships the already-converted `conv1d.weight` shape `[out, kW, 1]` (last dim == 1) and none carries any `mtp.*` key, which matches the issue's own premise that converted repos ship the MTP head as a separate repo today. Cross-checking against the raw HF/torch layout (https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/qwen3_5.py, the upstream mirror this port follows) confirms the raw conv1d shape is `[out, in, kW]`: a bundled `mtp.*` tensor in a raw checkpoint always co-occurs with the unconverted conv1d shape, because both come from the same unsanitized dump. There is no observed or plausible raw layout where `mtp.*` weights exist without conv1d evidence, so `has_mtp` never adds coverage that `has_unsanitized_conv1d` does not already provide, and keeping it as an independent OR term is unsafe for any future converted repo that bundles the MTP head.

## What changed

- `src/models/qwen3_5.rs`: `should_shift_norms` is now `has_unsanitized_conv1d` alone (the `has_mtp` variable and its OR term are removed). The comment above the guard documents the checkpoint layouts observed and the reasoning for dropping `has_mtp`.
- `src/models/qwen3_5_tests.rs`: added two idempotency regression tests: `sanitize_weights_is_idempotent_on_already_converted_checkpoint_with_stray_mtp_key` (already-shifted norms + already-transposed conv1d `[out, kW, 1]` + a stray `mtp.`-prefixed tensor must leave norms unchanged) and `sanitize_weights_shifts_norms_exactly_once_on_raw_layout` (raw conv1d layout `[out, in, kW]` must still shift norms exactly once and transpose the conv1d weight).
- The MiniCPM-V 4.6 call site (`src/loading/vlm_special.rs:551`) delegates to this same `qwen3_5::sanitize_weights` on already de-prefixed text weights. Both local minicpm-v-4.6 checkpoints carry zero `mtp.*` keys, so this gate change does not alter its behavior; no code change was needed there.

## Test plan

- [x] `cargo check --lib --tests`
- [x] `cargo test --lib models::qwen3_5_tests -- --ignored --test-threads=1` (10 passed, including both new idempotency tests)
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`

Closes #776

