### PR TITLE
fix(server): parse the bracketed Mistral tool-call format

### DIFF
--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -1644,6 +1644,49 @@ mod tests {
         assert!(try_mistral_bracket(text).is_none());
     }
 
+    #[test]
+    fn mistral_bracket_no_args_marker_no_quadratic_blowup() {
+        // Adversarial body: `[TOOL_CALLS]` followed by a long run of word
+        // characters with no `[ARGS]` marker anywhere. The `(\w+)` capture in
+        // `^\s*(\w+)\[ARGS\]\s*(\{.*\})` backtracks one character at a time
+        // looking for the literal `[ARGS]` that never appears, so this must
+        // stay linear rather than hang.
+        let mut text = String::from("[TOOL_CALLS]");
+        text.push_str(&"a".repeat(50_000));
+
+        let start = std::time::Instant::now();
+        let result = try_mistral_bracket(&text);
+        let elapsed = start.elapsed();
+
+        // Should complete in well under one second on any reasonable hardware.
+        assert!(
+            elapsed.as_secs() < 2,
+            "parsing took {elapsed:?}; suggests catastrophic backtracking"
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn mistral_bracket_unclosed_args_no_quadratic_blowup() {
+        // Adversarial body: `[TOOL_CALLS]fn[ARGS]{` followed by a long run of
+        // word characters with no closing brace. The dotall `(\{.*\})` group
+        // cannot match without a closing `}`, so the regex must fail fast
+        // rather than degrade while `.*` backtracks across the whole buffer.
+        let mut text = String::from("[TOOL_CALLS]fn[ARGS]{");
+        text.push_str(&"a".repeat(50_000));
+
+        let start = std::time::Instant::now();
+        let result = try_mistral_bracket(&text);
+        let elapsed = start.elapsed();
+
+        // Should complete in well under one second on any reasonable hardware.
+        assert!(
+            elapsed.as_secs() < 2,
+            "parsing took {elapsed:?}; suggests catastrophic backtracking"
+        );
+        assert!(result.is_none());
+    }
+
     // -- Functionary v3.1 --
 
     #[test]

--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -184,6 +184,45 @@ pub fn try_mistral_nemo(text: &str) -> Option<ToolCallParseResult> {
     })
 }
 
+/// Try parsing the bracketed Mistral tool-call format:
+/// `[TOOL_CALLS]NAME[ARGS]{json}`
+///
+/// Used by Ministral 2410 and later, Mistral Small 3, Magistral, and
+/// Devstral. Distinguished from the older Mistral Nemo JSON-array format
+/// (`[TOOL_CALLS] [{"name": ..., "arguments": ...}]`, handled by
+/// [`try_mistral_nemo`]) by the literal `[ARGS]` marker: when the text after
+/// the `[TOOL_CALLS]` prefix does not match `NAME[ARGS]{json}`, this returns
+/// `None` so the older format falls through to `try_mistral_nemo`. Single
+/// call per message.
+pub fn try_mistral_bracket(text: &str) -> Option<ToolCallParseResult> {
+    let trimmed = text.trim();
+    let rest = trimmed.strip_prefix("[TOOL_CALLS]")?;
+
+    // Only compile the regex once we know `[TOOL_CALLS]` is present.
+    let re = Regex::new(r"(?s)^\s*(\w+)\[ARGS\]\s*(\{.*\})").ok()?;
+    let caps = re.captures(rest).ok()??;
+
+    let name = caps.get(1)?.as_str().to_string();
+    let args_raw = caps.get(2)?.as_str();
+
+    // Coerce the matched arguments to a JSON string the same way the other
+    // parsers in this module do: unwrap a JSON-string value, re-serialize an
+    // object/array, and fall back to the raw matched text (rather than
+    // dropping the call) when it fails to parse as JSON.
+    let arguments = match serde_json::from_str::<serde_json::Value>(args_raw) {
+        Ok(value) if value.is_string() => value.as_str().unwrap_or_default().to_string(),
+        Ok(value) => serde_json::to_string(&value).unwrap_or_else(|_| args_raw.to_string()),
+        Err(_) => args_raw.to_string(),
+    };
+
+    Some(ToolCallParseResult {
+        format: Some(ToolCallFormat::Mistral),
+        tool_calls: vec![ParsedToolCall { name, arguments }],
+        content: String::new(),
+        reasoning_content: None,
+    })
+}
+
 /// Try parsing Functionary v3.1 format:
 /// `<function=fn_name>{"key": "val"}</function>`
 pub fn try_functionary_v31(text: &str) -> Option<ToolCallParseResult> {
@@ -1556,6 +1595,53 @@ mod tests {
     #[test]
     fn mistral_nemo_no_prefix() {
         assert!(try_mistral_nemo(r#"[{"name": "x", "arguments": {}}]"#).is_none());
+    }
+
+    // -- Mistral (bracketed) --
+
+    #[test]
+    fn mistral_bracket_single_call() {
+        let text = r#"[TOOL_CALLS]get_weather[ARGS]{"city": "Paris"}"#;
+        let result = try_mistral_bracket(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["city"], "Paris");
+        assert_eq!(result.format, Some(ToolCallFormat::Mistral));
+    }
+
+    #[test]
+    fn mistral_bracket_nested_braces_and_newlines() {
+        // The greedy dotall `.*` in the arguments capture must reach the
+        // final closing brace even when the JSON itself contains nested
+        // objects and embedded newlines.
+        let text = "[TOOL_CALLS]search[ARGS]{\"filter\": {\"nested\": true},\n \"n\": 2}";
+        let result = try_mistral_bracket(text).unwrap();
+        assert_eq!(result.tool_calls[0].name, "search");
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["filter"]["nested"], true);
+        assert_eq!(args["n"], 2);
+    }
+
+    #[test]
+    fn mistral_bracket_old_format_regression_returns_none() {
+        // The older Mistral Nemo JSON-array format carries no `[ARGS]`
+        // marker, so `try_mistral_bracket` must decline it and let the
+        // dispatcher fall through to `try_mistral_nemo`.
+        let text = r#"[TOOL_CALLS] [{"name": "x", "arguments": {}}]"#;
+        assert!(try_mistral_bracket(text).is_none());
+    }
+
+    #[test]
+    fn mistral_bracket_leading_content_returns_none() {
+        // The spec strips `[TOOL_CALLS]` after trimming, mirroring
+        // `try_mistral_nemo`'s `strip_prefix` behaviour: leading prose before
+        // the marker means the prefix strip fails, so this format declines
+        // rather than scanning mid-string for the marker.
+        let text = "Sure![TOOL_CALLS]fn[ARGS]{}";
+        assert!(try_mistral_bracket(text).is_none());
     }
 
     // -- Functionary v3.1 --

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -161,7 +161,10 @@ pub fn parse_tool_calls(raw_output: &str, tools: Option<&[Tool]>) -> ToolCallPar
         formats::try_hermes,  // <tool_call> — Hermes/Qwen/DeepSeek
         formats::try_minimax_m2, // <invoke name=...><parameter name=...>...</parameter></invoke>
         formats::try_kimi_k2, // <|tool_calls_section_begin|>...<|tool_calls_section_end|>
-        formats::try_mistral_nemo, // [TOOL_CALLS]
+        // [TOOL_CALLS]NAME[ARGS]{json}; declines (returns None) without [ARGS], so the
+        // older JSON-array format below still falls through to try_mistral_nemo.
+        formats::try_mistral_bracket,
+        formats::try_mistral_nemo,    // [TOOL_CALLS]
         formats::try_functionary_v31, // <function=name>{json}
         formats::try_qwen3_coder, // <function=name><parameter=key>val</parameter> (after v31, which declines non-JSON bodies)
         formats::try_functionary_v32, // >>>name\n
@@ -300,6 +303,37 @@ mod tests {
         let result = parse_tool_calls(output, Some(&tools));
         assert!(result.has_tool_calls());
         assert_eq!(result.tool_calls[0].name, "search");
+        // Regression: the old JSON-array format must still resolve to
+        // MistralNemo, proving try_mistral_bracket correctly falls through.
+        assert_eq!(
+            result.format,
+            Some(crate::server::tool_calls::ToolCallFormat::MistralNemo)
+        );
+    }
+
+    #[test]
+    fn parse_mistral_bracket_format() {
+        let output = r#"[TOOL_CALLS]get_weather[ARGS]{"city": "Paris"}"#;
+        let tools = vec![make_tool("get_weather")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["city"], "Paris");
+        assert_eq!(
+            result.format,
+            Some(crate::server::tool_calls::ToolCallFormat::Mistral)
+        );
+    }
+
+    #[test]
+    fn parse_mistral_bracket_filters_unknown_tools() {
+        let output = r#"[TOOL_CALLS]unknown_fn[ARGS]{}"#;
+        let tools = vec![make_tool("get_weather")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(!result.has_tool_calls());
     }
 
     #[test]

--- a/src/server/tool_calls/stream_filter.rs
+++ b/src/server/tool_calls/stream_filter.rs
@@ -1258,6 +1258,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn mistral_bracket_tool_calls_marker_suppressed() {
+        // Newer Mistral-family models (Ministral 2410+, Mistral Small 3,
+        // Magistral, Devstral) emit `[TOOL_CALLS]NAME[ARGS]{json}`. Because
+        // `[TOOL_CALLS]` is already a one-shot `EnterToolCall` marker, this
+        // shape is suppressed by the same delimiter as Mistral Nemo: no
+        // dedicated `[ARGS]` delimiter row is needed.
+        let mut f = StreamFilter::new();
+        let out = f.feed(r#"[TOOL_CALLS]get_weather[ARGS]{"city": "Paris"}"#);
+        assert_eq!(
+            out.content, None,
+            "bracketed Mistral tool-call payload must not appear in delta.content"
+        );
+    }
+
     // -- Token-position preservation for parallel tool calls --
     //
     // Upstream mlx-lm PR #1170 (commit aa4f880) fixed `_process_control_tokens`

--- a/src/server/tool_calls/types.rs
+++ b/src/server/tool_calls/types.rs
@@ -35,6 +35,9 @@ pub enum ToolCallFormat {
     Llama3,
     /// Mistral Nemo: `[TOOL_CALLS] [{"name": ..., "arguments": ...}]`
     MistralNemo,
+    /// Mistral (bracketed): `[TOOL_CALLS]NAME[ARGS]{json}`, used by Ministral
+    /// 2410 and later, Mistral Small 3, Magistral, and Devstral.
+    Mistral,
     /// Functionary v3.1: `<function=name>{"key": "val"}</function>`
     FunctionaryV31,
     /// Functionary v3.2: `>>>name\n{"key": "val"}`


### PR DESCRIPTION
## Summary

Adds support for the bracketed Mistral tool-call format (`[TOOL_CALLS]NAME[ARGS]{json}`) used by Ministral 2410+, Mistral Small 3, Magistral, and Devstral, which previously fell back to plain text with no `tool_calls` because `try_mistral_nemo` only understood the older `[TOOL_CALLS] [{"name": ..., "arguments": ...}]` JSON-array shape.

## What changed

- `src/server/tool_calls/types.rs`: added `ToolCallFormat::Mistral` (`#[non_exhaustive]` enum) documenting the bracketed format and its model coverage.
- `src/server/tool_calls/formats.rs`: added `pub fn try_mistral_bracket`, which strips the `[TOOL_CALLS]` prefix, matches `^\s*(\w+)\[ARGS\]\s*(\{.*\})` with a dotall `fancy_regex`, and coerces the captured arguments to a JSON string (unwrap a JSON-string value, re-serialize an object, or keep the raw text on parse failure), matching the convention used by the other format parsers in this module. Returns `None` when `[ARGS]` is absent so the older JSON-array format is left untouched.
- `src/server/tool_calls/parser.rs`: registered `try_mistral_bracket` in the dispatch list immediately before `try_mistral_nemo`, with a comment explaining the `[ARGS]` disambiguation and fall-through.
- `src/server/tool_calls/stream_filter.rs`: added a streaming test confirming the bracketed shape is already suppressed by the existing one-shot `[TOOL_CALLS]` `EnterToolCall` delimiter (no new delimiter rows were needed).

`try_mistral_nemo` and its existing tests are untouched.

## Test plan

- [x] `cargo test --lib server::tool_calls::formats` (new: single-call bracket parse, nested-brace/newline arguments, old-format regression returning `None`, leading-content handling)
- [x] `cargo test --lib server::tool_calls::parser` (new: end-to-end dispatch for the bracketed format with `ToolCallFormat::Mistral`, unknown-tool filtering, and a regression confirming the old array format still resolves to `ToolCallFormat::MistralNemo`)
- [x] `cargo test --lib server::tool_calls::stream_filter` (new: bracketed payload suppressed from `delta.content`)
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`

Closes #767
