### PR TITLE
feat(server): add pythonic tool-call parser ([func(arg=value)] format)

### DIFF
--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -1517,6 +1517,145 @@ fn is_ident_byte(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_'
 }
 
+/// Try parsing the pythonic bracketed-call tool-call format:
+/// `<|tool_call_start|>[func(arg=value, ...)]<|tool_call_end|>`
+///
+/// Used by Llama-family "pythonic" tool use chat templates and some
+/// Nemotron templates. The call regex `\[(\w+)\((.*?)\)\]` (dotall, so it
+/// spans embedded newlines) only requires `[word(...)]` somewhere in the
+/// text, so it naturally ignores the surrounding `<|tool_call_start|>` /
+/// `<|tool_call_end|>` markers: marker-wrapped and bare bodies share this
+/// one code path. Only the FIRST match is used — the format carries a
+/// single call per message in practice.
+///
+/// Known limitation, preserved on purpose: nested parentheses, or commas
+/// inside a plain (non-bracketed) unquoted value, are not supported —
+/// matching the format's real usage rather than building a full expression
+/// parser. A single level of `[...]` list literal in a value IS supported.
+pub fn try_pythonic(text: &str) -> Option<ToolCallParseResult> {
+    let call_re = Regex::new(r"(?s)\[(\w+)\((.*?)\)\]").ok()?;
+    let caps = call_re.captures(text).ok()??;
+
+    let name = caps.get(1)?.as_str().to_string();
+    let args_raw = caps.get(2).map(|m| m.as_str()).unwrap_or_default();
+
+    Some(ToolCallParseResult {
+        format: Some(ToolCallFormat::Pythonic),
+        tool_calls: vec![ParsedToolCall {
+            name,
+            arguments: pythonic_arguments(args_raw),
+        }],
+        content: String::new(),
+        reasoning_content: None,
+    })
+}
+
+/// Placeholder used to temporarily hide commas that sit inside a `[...]`
+/// list literal from the per-argument regex in [`pythonic_arguments`]
+/// (whose unquoted alternative `[^,]+` would otherwise stop at the first
+/// comma, breaking multi-element lists such as `tags=[1, 2, 3]`). Restored
+/// by [`unmask_bracketed_commas`] once the surrounding key=value span has
+/// been captured. A Unicode Private Use Area codepoint is used so it cannot
+/// collide with a comma that legitimately appears in real argument text.
+const MASKED_COMMA: char = '\u{E000}';
+
+/// Hide commas that occur inside an unquoted `[...]` list literal (bracket
+/// depth > 0, outside a quoted string) behind [`MASKED_COMMA`] so the
+/// per-argument regex's unquoted alternative can span the whole list.
+fn mask_bracketed_commas(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut depth: i32 = 0;
+    let mut in_quotes = false;
+    for c in raw.chars() {
+        match c {
+            '"' => {
+                in_quotes = !in_quotes;
+                out.push(c);
+            }
+            '[' if !in_quotes => {
+                depth += 1;
+                out.push(c);
+            }
+            ']' if !in_quotes => {
+                depth = depth.saturating_sub(1);
+                out.push(c);
+            }
+            ',' if !in_quotes && depth > 0 => out.push(MASKED_COMMA),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Restore commas hidden by [`mask_bracketed_commas`].
+fn unmask_bracketed_commas(masked: &str) -> String {
+    masked.replace(MASKED_COMMA, ",")
+}
+
+/// Build the JSON `arguments` object from a pythonic call's raw argument
+/// text (the `(.*?)` capture between the call's parentheses), using the
+/// per-argument regex `(\w+)=(?:"([^"]*)"|([^,]+))(?:,\s*|$)`: group 1 is
+/// the key; a matched quoted alternative (group 2) becomes a JSON string
+/// verbatim; a matched unquoted alternative (group 3) is coerced via
+/// [`coerce_pythonic_value`]. Returns `"{}"` for empty args (e.g. `ping()`).
+fn pythonic_arguments(args_raw: &str) -> String {
+    let masked = mask_bracketed_commas(args_raw);
+    let Ok(args_re) = Regex::new(r#"(\w+)=(?:"([^"]*)"|([^,]+))(?:,\s*|$)"#) else {
+        return "{}".to_string();
+    };
+
+    let mut map = serde_json::Map::new();
+    for caps in args_re.captures_iter(&masked) {
+        let Ok(caps) = caps else { continue };
+        let Some(key) = caps.get(1) else { continue };
+
+        let value = if let Some(quoted) = caps.get(2) {
+            serde_json::Value::String(quoted.as_str().to_string())
+        } else if let Some(unquoted) = caps.get(3) {
+            let restored = unmask_bracketed_commas(unquoted.as_str());
+            coerce_pythonic_value(restored.trim())
+        } else {
+            continue;
+        };
+
+        map.insert(key.as_str().to_string(), value);
+    }
+
+    serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_else(|_| "{}".to_string())
+}
+
+/// Coerce a trimmed unquoted pythonic argument value (or list item) in the
+/// order the format spec prescribes: integer, float, bool (`true`/`false`),
+/// a bracketed list `[...]` (each inner comma-separated item coerced the
+/// same way, recursively), else the raw string. A quoted list item (e.g.
+/// `"a"` inside `tags=["a", "b"]`) has its surrounding quotes stripped
+/// rather than falling through to the raw-string branch verbatim.
+fn coerce_pythonic_value(raw: &str) -> serde_json::Value {
+    if let Ok(i) = raw.parse::<i64>() {
+        return serde_json::Value::Number(i.into());
+    }
+    if let Ok(f) = raw.parse::<f64>()
+        && let Some(n) = serde_json::Number::from_f64(f)
+    {
+        return serde_json::Value::Number(n);
+    }
+    if raw == "true" || raw == "false" {
+        return serde_json::Value::Bool(raw == "true");
+    }
+    if let Some(inner) = raw.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+        let items = inner
+            .split(',')
+            .filter(|s| !s.trim().is_empty())
+            .map(|item| coerce_pythonic_value(item.trim()))
+            .collect();
+        return serde_json::Value::Array(items);
+    }
+    if raw.len() >= 2 && raw.starts_with('"') && raw.ends_with('"') {
+        return serde_json::Value::String(raw[1..raw.len() - 1].to_string());
+    }
+    serde_json::Value::String(raw.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2493,5 +2632,109 @@ mod tests {
             serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
         assert_eq!(args["active"], true);
         assert_eq!(args["kind"], "NoneType");
+    }
+
+    // -- Pythonic --
+
+    #[test]
+    fn pythonic_quoted_string_arg() {
+        let text = r#"<|tool_call_start|>[get_weather(city="Paris")]<|tool_call_end|>"#;
+        let result = try_pythonic(text).unwrap();
+        assert_eq!(result.format, Some(ToolCallFormat::Pythonic));
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["city"], "Paris");
+    }
+
+    #[test]
+    fn pythonic_unquoted_int_arg() {
+        let text = "[set_count(count=42)]";
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["count"], 42);
+    }
+
+    #[test]
+    fn pythonic_unquoted_float_arg() {
+        let text = "[set_temp(value=98.6)]";
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["value"], 98.6);
+    }
+
+    #[test]
+    fn pythonic_unquoted_bool_args() {
+        let text = "[toggle(enabled=true, verbose=false)]";
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["enabled"], true);
+        assert_eq!(args["verbose"], false);
+    }
+
+    #[test]
+    fn pythonic_bracketed_list_arg() {
+        // The unquoted alternative `[^,]+` in the per-argument regex cannot
+        // itself cross a comma, so this exercises the comma-masking done in
+        // `mask_bracketed_commas` / `unmask_bracketed_commas` around the
+        // per-argument regex, which lets a multi-element list survive intact.
+        let text = "[tag(tags=[1, 2, 3])]";
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["tags"], serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn pythonic_mixed_quoted_and_unquoted_args() {
+        let text = r#"[get_weather(city="Paris", days=2)]"#;
+        let result = try_pythonic(text).unwrap();
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["city"], "Paris");
+        assert_eq!(args["days"], 2);
+    }
+
+    #[test]
+    fn pythonic_empty_args() {
+        let text = "[ping()]";
+        let result = try_pythonic(text).unwrap();
+        assert_eq!(result.tool_calls[0].name, "ping");
+        assert_eq!(result.tool_calls[0].arguments, "{}");
+    }
+
+    #[test]
+    fn pythonic_non_matching_text_returns_none() {
+        assert!(try_pythonic("Hello, world!").is_none());
+        assert!(try_pythonic(r#"{"name": "fn", "arguments": {}}"#).is_none());
+    }
+
+    #[test]
+    fn pythonic_marker_wrapped_and_bare_body_match() {
+        let wrapped = r#"<|tool_call_start|>[f(x="y")]<|tool_call_end|>"#;
+        let bare = r#"[f(x="y")]"#;
+        let wrapped_result = try_pythonic(wrapped).unwrap();
+        let bare_result = try_pythonic(bare).unwrap();
+        assert_eq!(wrapped_result.tool_calls, bare_result.tool_calls);
+        assert_eq!(wrapped_result.tool_calls[0].name, "f");
+        let args: serde_json::Value =
+            serde_json::from_str(&wrapped_result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["x"], "y");
+    }
+
+    #[test]
+    fn pythonic_first_match_only() {
+        let text = r#"[a(x=1)] [b(y=2)]"#;
+        let result = try_pythonic(text).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "a");
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["x"], 1);
     }
 }

--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -1637,6 +1637,15 @@ fn pythonic_arguments(args_raw: &str) -> String {
     serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_else(|_| "{}".to_string())
 }
 
+/// Maximum nesting depth honoured when coercing a pythonic `[...]` list
+/// literal. Each `[...]` level recurses one frame in
+/// [`coerce_pythonic_value_inner`]; untrusted model output can nest brackets
+/// arbitrarily (`[f(x=[[[[...]]]]))]`), so without a cap a few thousand
+/// brackets overflow a worker thread's stack and abort the whole process. Real
+/// pythonic tool calls nest a couple of levels at most; at the cap the
+/// still-bracketed value is kept verbatim as a raw string.
+const PYTHONIC_MAX_LIST_DEPTH: usize = 32;
+
 /// Coerce a trimmed unquoted pythonic argument value (or list item) in the
 /// order the format spec prescribes: integer, float, bool (`true`/`false`),
 /// a bracketed list `[...]` (each inner comma-separated item coerced the
@@ -1644,6 +1653,13 @@ fn pythonic_arguments(args_raw: &str) -> String {
 /// `"a"` inside `tags=["a", "b"]`) has its surrounding quotes stripped
 /// rather than falling through to the raw-string branch verbatim.
 fn coerce_pythonic_value(raw: &str) -> serde_json::Value {
+    coerce_pythonic_value_inner(raw, 0)
+}
+
+/// Depth-tracked worker for [`coerce_pythonic_value`]. `depth` counts how many
+/// `[...]` levels have already been entered so the recursion is bounded by
+/// [`PYTHONIC_MAX_LIST_DEPTH`].
+fn coerce_pythonic_value_inner(raw: &str, depth: usize) -> serde_json::Value {
     if let Ok(i) = raw.parse::<i64>() {
         return serde_json::Value::Number(i.into());
     }
@@ -1655,11 +1671,16 @@ fn coerce_pythonic_value(raw: &str) -> serde_json::Value {
     if raw == "true" || raw == "false" {
         return serde_json::Value::Bool(raw == "true");
     }
-    if let Some(inner) = raw.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+    // Only descend into a `[...]` list while under the depth cap. Past the cap
+    // the value is left as a raw string, so adversarial deeply-nested brackets
+    // cannot drive unbounded recursion into a stack overflow.
+    if depth < PYTHONIC_MAX_LIST_DEPTH
+        && let Some(inner) = raw.strip_prefix('[').and_then(|s| s.strip_suffix(']'))
+    {
         let items = inner
             .split(',')
             .filter(|s| !s.trim().is_empty())
-            .map(|item| coerce_pythonic_value(item.trim()))
+            .map(|item| coerce_pythonic_value_inner(item.trim(), depth + 1))
             .collect();
         return serde_json::Value::Array(items);
     }
@@ -2765,5 +2786,26 @@ mod tests {
             try_pythonic(r#"[{"name": "search", "arguments": {"q": "[calc(x=1)]"}}]"#)
                 .is_none()
         );
+    }
+
+    #[test]
+    fn pythonic_deeply_nested_list_does_not_overflow_stack() {
+        // Adversarial deeply-nested bracket value. Before the depth cap this
+        // recursed once per level and overflowed a worker-thread stack,
+        // aborting the process. The cap must keep parsing bounded: the call is
+        // still recognised, and the over-deep value degrades to a string rather
+        // than crashing.
+        let depth = 50_000;
+        let mut text = String::from("[f(x=");
+        text.push_str(&"[".repeat(depth));
+        text.push_str(&"]".repeat(depth));
+        text.push_str(")]");
+
+        let result = try_pythonic(&text).unwrap();
+        assert_eq!(result.tool_calls[0].name, "f");
+        // Arguments must still be valid, serializable JSON (never a panic).
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert!(args.get("x").is_some());
     }
 }

--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -1532,7 +1532,20 @@ fn is_ident_byte(b: u8) -> bool {
 /// inside a plain (non-bracketed) unquoted value, are not supported —
 /// matching the format's real usage rather than building a full expression
 /// parser. A single level of `[...]` list literal in a value IS supported.
+///
+/// Declines any input whose whole (trimmed) body is valid JSON. A genuine
+/// pythonic call (`[func(arg=value)]`, bare or marker-wrapped) is never itself
+/// valid JSON, whereas a JSON-format tool call IS, and its string arguments
+/// may merely CONTAIN a `[word(...)]` substring (e.g. a `search` call whose
+/// query is `"[calc(x=1)]"`). Because this parser runs before `try_llama3` /
+/// `try_generic_json` and its regex scans anywhere, without this guard such a
+/// JSON call would be mis-routed to the bracketed inner name. Declining lets
+/// the JSON parsers that run next own it.
 pub fn try_pythonic(text: &str) -> Option<ToolCallParseResult> {
+    if serde_json::from_str::<serde_json::Value>(text.trim()).is_ok() {
+        return None;
+    }
+
     let call_re = Regex::new(r"(?s)\[(\w+)\((.*?)\)\]").ok()?;
     let caps = call_re.captures(text).ok()??;
 
@@ -2736,5 +2749,21 @@ mod tests {
         let args: serde_json::Value =
             serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
         assert_eq!(args["x"], 1);
+    }
+
+    #[test]
+    fn pythonic_declines_json_with_embedded_bracket_call() {
+        // A JSON tool call whose string argument merely contains a
+        // `[word(...)]` substring must be declined here so the downstream JSON
+        // parsers claim it, instead of the pythonic parser stealing the inner
+        // bracketed name. Both object and array JSON shapes are covered.
+        assert!(
+            try_pythonic(r#"{"name": "search", "arguments": {"query": "[calc(x=1)]"}}"#)
+                .is_none()
+        );
+        assert!(
+            try_pythonic(r#"[{"name": "search", "arguments": {"q": "[calc(x=1)]"}}]"#)
+                .is_none()
+        );
     }
 }

--- a/src/server/tool_calls/formats.rs
+++ b/src/server/tool_calls/formats.rs
@@ -2724,6 +2724,18 @@ mod tests {
     }
 
     #[test]
+    fn pythonic_bracketed_list_with_quoted_string_items() {
+        // Each list item is coerced independently by `coerce_pythonic_value_inner`,
+        // so a quoted item (unlike the bare integers above) must have its
+        // surrounding quotes stripped rather than kept as a literal `"a"` string.
+        let text = r#"[tag(tags=["a", "b"])]"#;
+        let result = try_pythonic(text).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["tags"], serde_json::json!(["a", "b"]));
+    }
+
+    #[test]
     fn pythonic_mixed_quoted_and_unquoted_args() {
         let text = r#"[get_weather(city="Paris", days=2)]"#;
         let result = try_pythonic(text).unwrap();
@@ -2779,12 +2791,10 @@ mod tests {
         // parsers claim it, instead of the pythonic parser stealing the inner
         // bracketed name. Both object and array JSON shapes are covered.
         assert!(
-            try_pythonic(r#"{"name": "search", "arguments": {"query": "[calc(x=1)]"}}"#)
-                .is_none()
+            try_pythonic(r#"{"name": "search", "arguments": {"query": "[calc(x=1)]"}}"#).is_none()
         );
         assert!(
-            try_pythonic(r#"[{"name": "search", "arguments": {"q": "[calc(x=1)]"}}]"#)
-                .is_none()
+            try_pythonic(r#"[{"name": "search", "arguments": {"q": "[calc(x=1)]"}}]"#).is_none()
         );
     }
 
@@ -2807,5 +2817,45 @@ mod tests {
         let args: serde_json::Value =
             serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
         assert!(args.get("x").is_some());
+    }
+
+    /// Wrap `leaf` in `layers` levels of single-element JSON arrays, i.e.
+    /// `wrap_layers(leaf, 2)` is `[[leaf]]`. Used to build the expected value
+    /// for [`pythonic_list_depth_cap_boundary`] without hand-counting nesting.
+    fn wrap_layers(leaf: serde_json::Value, layers: usize) -> serde_json::Value {
+        (0..layers).fold(leaf, |v, _| serde_json::Value::Array(vec![v]))
+    }
+
+    #[test]
+    fn pythonic_list_depth_cap_boundary() {
+        // Exactly `PYTHONIC_MAX_LIST_DEPTH` (32) nested empty `[...]` pairs. Each
+        // `[...]` strip is gated by `depth < 32`, and depths 0..=31 (32 checks)
+        // are all under the cap, so the value fully resolves: 31 single-element
+        // array layers wrap an innermost empty array, matching `[f(x=32 pairs)]`
+        // decoded with no cap in effect at all: the cap never actually engages.
+        let at_cap = format!("[f(x={})]", "[".repeat(32) + &"]".repeat(32));
+        let result = try_pythonic(&at_cap).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        let expected_at_cap = wrap_layers(serde_json::json!([]), 31);
+        assert_eq!(
+            args["x"], expected_at_cap,
+            "32 nested pairs must fully resolve to arrays, never degrading to a string"
+        );
+
+        // One bracket pair beyond the cap: the 33rd `[...]` is reached at
+        // depth == 32, where `depth < 32` is false, so it is left unstripped.
+        // The 32 layers up to the cap still resolve to arrays, but the
+        // innermost element degrades to the literal string "[]" instead of
+        // continuing as an (empty) array.
+        let over_cap = format!("[f(x={})]", "[".repeat(33) + &"]".repeat(33));
+        let result = try_pythonic(&over_cap).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        let expected_over_cap = wrap_layers(serde_json::Value::String("[]".to_string()), 32);
+        assert_eq!(
+            args["x"], expected_over_cap,
+            "the pair past the cap must degrade to a raw string, not crash or vanish"
+        );
     }
 }

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -168,9 +168,11 @@ pub fn parse_tool_calls(raw_output: &str, tools: Option<&[Tool]>) -> ToolCallPar
         formats::try_functionary_v31, // <function=name>{json}
         formats::try_qwen3_coder, // <function=name><parameter=key>val</parameter> (after v31, which declines non-JSON bodies)
         formats::try_functionary_v32, // >>>name\n
-        formats::try_llama3,      // {"name": ..., "parameters": ...}
+        // <|tool_call_start|>[func(arg=value)]<|tool_call_end|> — pythonic, before generic JSON
+        formats::try_pythonic,
+        formats::try_llama3,       // {"name": ..., "parameters": ...}
         formats::try_generic_json, // {"name": ..., "arguments": ...}
-        formats::try_command_r,   // Action: / Action Input: — least specific
+        formats::try_command_r,    // Action: / Action Input: — least specific
     ];
 
     for parser in parsers {
@@ -693,6 +695,34 @@ mod tests {
         let output = "<|tool_calls_section_begin|>\
                        <|tool_call_begin|>functions.unknown_fn:0<|tool_call_argument_begin|>{}<|tool_call_end|>\
                        <|tool_calls_section_end|>";
+        let tools = vec![make_tool("get_weather")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(!result.has_tool_calls());
+    }
+
+    // -- Pythonic --
+
+    #[test]
+    fn parse_pythonic_format() {
+        let output = r#"<|tool_call_start|>[get_weather(city="Paris", days=2)]<|tool_call_end|>"#;
+        let tools = vec![make_tool("get_weather")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "get_weather");
+        let args: serde_json::Value =
+            serde_json::from_str(&result.tool_calls[0].arguments).unwrap();
+        assert_eq!(args["city"], "Paris");
+        assert_eq!(args["days"], 2);
+        assert_eq!(
+            result.format,
+            Some(crate::server::tool_calls::ToolCallFormat::Pythonic)
+        );
+    }
+
+    #[test]
+    fn parse_pythonic_filters_unknown_tools() {
+        let output = "<|tool_call_start|>[unknown_fn(x=1)]<|tool_call_end|>";
         let tools = vec![make_tool("get_weather")];
         let result = parse_tool_calls(output, Some(&tools));
         assert!(!result.has_tool_calls());

--- a/src/server/tool_calls/parser.rs
+++ b/src/server/tool_calls/parser.rs
@@ -729,6 +729,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_pythonic_does_not_steal_json_tool_call() {
+        // Regression guard: `try_pythonic` runs before the JSON parsers and its
+        // call regex `\[(\w+)\(...\)\]` scans anywhere, so a valid JSON tool
+        // call whose string argument merely CONTAINS a `[word(...)]` substring
+        // must not be re-routed to the bracketed inner name. Here the real call
+        // is `search`, and `calc` (which appears inside the query string) is
+        // also a registered tool, so the parser must still return `search`.
+        let output = r#"{"name": "search", "arguments": {"query": "[calc(x=1)]"}}"#;
+        let tools = vec![make_tool("search"), make_tool("calc")];
+        let result = parse_tool_calls(output, Some(&tools));
+        assert!(result.has_tool_calls());
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(
+            result.tool_calls[0].name, "search",
+            "a JSON `search` call must not be mis-parsed as the bracketed `calc`"
+        );
+        assert_ne!(
+            result.format,
+            Some(crate::server::tool_calls::ToolCallFormat::Pythonic),
+            "a JSON tool call must be claimed by a JSON parser, not the pythonic one"
+        );
+    }
+
+    #[test]
     fn parse_tool_calls_empty_after_strip_returns_empty_content() {
         // Previously we fell back to `raw_output` when stripping emptied the
         // text, which leaked the scratchpad back into the visible response.

--- a/src/server/tool_calls/stream_filter.rs
+++ b/src/server/tool_calls/stream_filter.rs
@@ -201,6 +201,10 @@ enum DelimiterAction {
 ///   collides with any other entry: `<|tool_call>` (Gemma 4) requires a `>`
 ///   immediately after `tool_call`, whereas Kimi's markers continue with
 ///   `s_section_...`, so the two families never partial-match each other.
+/// - Pythonic `<|tool_call_start|>` is **enter-only on purpose** — see the
+///   comment on its entry below for why an `<|tool_call_end|>` exit row must
+///   NOT be added. It does not prefix-collide with Gemma 4's `<|tool_call>`
+///   either: they diverge at `_start` vs `>` immediately after `tool_call`.
 ///
 /// TODO: Consider extracting this into a startup-time configurable
 /// owned by the model worker so new reasoning families don't require a rebuild.
@@ -232,6 +236,20 @@ const CHAT_DELIMITERS: &[(&str, DelimiterAction)] = &[
         "<|tool_calls_section_begin|>",
         DelimiterAction::EnterToolCall,
     ),
+    // Pythonic: `<|tool_call_start|>[func(arg=value)]<|tool_call_end|>`.
+    // Enter-only, deliberately with NO matching `<|tool_call_end|>` exit row:
+    // that marker is already registered as Kimi K2's PER-CALL terminator
+    // inside a `<|tool_calls_section_begin|>...<|tool_calls_section_end|>`
+    // section, whose streaming suppression relies on the section begin/end
+    // pair and treats `<|tool_call_end|>` as ordinary suppressed content. If
+    // `<|tool_call_end|>` were also registered as a global `ExitToolCall`
+    // here, it would fire on every Kimi K2 per-call terminator and
+    // prematurely exit tool-call suppression mid-section, leaking the
+    // second and later Kimi calls into visible `delta.content` (a
+    // regression of #766). Pythonic calls are terminal in practice, so
+    // enter-only (mirroring Mistral Nemo's one-shot `[TOOL_CALLS]` above)
+    // fully suppresses the payload without needing an exit marker.
+    ("<|tool_call_start|>", DelimiterAction::EnterToolCall),
 ];
 
 /// The state of the streaming filter state machine.
@@ -1649,5 +1667,78 @@ mod tests {
             Some("after"),
             "content after the Kimi K2 section must resume normally"
         );
+    }
+
+    #[test]
+    fn kimi_k2_multi_call_section_all_calls_suppressed() {
+        // Regression guard for #766. `<|tool_call_end|>` is Kimi K2's
+        // PER-CALL terminator, appearing once per call inside the section —
+        // it is intentionally NOT registered as a global `ExitToolCall`
+        // delimiter (see the pythonic entry's comment on `CHAT_DELIMITERS`
+        // for why). Feed a two-call section split right after the first
+        // `<|tool_call_end|>` so the second call's body arrives in its own
+        // fragment: if `<|tool_call_end|>` incorrectly triggered an
+        // `ExitToolCall` transition, this second fragment would leak into
+        // `delta.content`.
+        let mut f = StreamFilter::new();
+        let first = "<|tool_calls_section_begin|>\
+                      <|tool_call_begin|>functions.search:0<|tool_call_argument_begin|>\
+                      {\"query\": \"rust\"}<|tool_call_end|>";
+        let second = "<|tool_call_begin|>functions.calc:1<|tool_call_argument_begin|>\
+                       {\"expr\": \"2+2\"}<|tool_call_end|><|tool_calls_section_end|>";
+
+        let out1 = f.feed(first);
+        assert_eq!(
+            out1.content, None,
+            "first Kimi K2 call body must not leak into delta.content"
+        );
+
+        let out2 = f.feed(second);
+        assert_eq!(
+            out2.content, None,
+            "second Kimi K2 call body must not leak into delta.content after \
+             the first call's <|tool_call_end|> terminator"
+        );
+
+        let flushed = f.flush();
+        assert_eq!(flushed.content, None);
+    }
+
+    // -- Pythonic tool-call markers --
+
+    #[test]
+    fn pythonic_tool_call_suppressed() {
+        let mut f = StreamFilter::new();
+        let out = f.feed(r#"<|tool_call_start|>[get_weather(city="Paris")]<|tool_call_end|>"#);
+        assert_eq!(
+            out.content, None,
+            "pythonic tool-call payload must not leak into delta.content"
+        );
+        let flushed = f.flush();
+        assert_eq!(flushed.content, None);
+    }
+
+    #[test]
+    fn pythonic_content_before_call_emitted() {
+        let mut f = StreamFilter::new();
+        let out = f.feed(
+            r#"Let me check.<|tool_call_start|>[get_weather(city="Paris")]<|tool_call_end|>"#,
+        );
+        assert_eq!(
+            out.content.as_deref(),
+            Some("Let me check."),
+            "only the preamble text must appear in delta.content"
+        );
+    }
+
+    #[test]
+    fn pythonic_start_marker_not_confused_with_gemma4_or_kimi_k2() {
+        // `<|tool_call_start|>` shares the `<|tool_call` prefix with both
+        // Gemma 4's `<|tool_call>` and Kimi K2's `<|tool_calls_section_begin|>`,
+        // but diverges immediately after (`_start` vs `>` vs `s_section...`),
+        // so none of the three should partial-match another.
+        let mut f = StreamFilter::new();
+        let out = f.feed("<|tool_call_start|>[fn(x=1)]<|tool_call_end|>");
+        assert_eq!(out.content, None);
     }
 }

--- a/src/server/tool_calls/types.rs
+++ b/src/server/tool_calls/types.rs
@@ -73,6 +73,12 @@ pub enum ToolCallFormat {
     /// `functions.NAME:INDEX<|tool_call_argument_begin|>{json arguments}`,
     /// e.g. `functions.get_weather:0<|tool_call_argument_begin|>{"location": "Paris"}`.
     KimiK2,
+    /// Pythonic (Llama-family pythonic tool use, some Nemotron templates):
+    /// a bracketed Python-like call, e.g. `[get_weather(city="Paris", days=2)]`,
+    /// wrapped in `<|tool_call_start|>` / `<|tool_call_end|>` markers (the
+    /// corresponding tool-list template marker is `<|tool_list_start|>`).
+    /// Single call per message.
+    Pythonic,
 }
 
 /// Result of parsing model output for tool calls.


### PR DESCRIPTION
## Summary

Adds a parser for the pythonic bracketed tool-call format (`[func(arg=value, ...)]` wrapped in `<|tool_call_start|>`/`<|tool_call_end|>` markers) used by Llama-family pythonic tool use and some Nemotron chat templates, and wires it into the non-streaming parser registry and the streaming delimiter table.

## What changed

- `src/server/tool_calls/types.rs`: added the `ToolCallFormat::Pythonic` variant.
- `src/server/tool_calls/formats.rs`: added `try_pythonic`, which matches `(?s)\[(\w+)\((.*?)\)\]` (first match only) and builds the JSON `arguments` object from `(\w+)=(?:"([^"]*)"|([^,]+))(?:,\s*|$)`, coercing unquoted values to integer, float, bool, a bracketed list, or a raw-string fallback. A comma-masking helper (`mask_bracketed_commas` / `unmask_bracketed_commas`) hides commas inside `[...]` list literals from the per-argument regex before it runs so multi-element lists such as `tags=[1, 2, 3]` survive intact, then restores them for list-item coercion. Nested parentheses or commas inside a non-bracketed unquoted value remain unsupported by design, matching the format's real usage rather than a full expression parser.
- `src/server/tool_calls/parser.rs`: registered `formats::try_pythonic` in the dispatch list right after `try_functionary_v32` and before `try_llama3`, ahead of the generic JSON parsers, since the pythonic regex requires `[word(` and cannot false-positive on JSON or any other registered format.
- `src/server/tool_calls/stream_filter.rs`: added `<|tool_call_start|>` to `CHAT_DELIMITERS` as an enter-only `EnterToolCall` delimiter. No matching `<|tool_call_end|>` exit row was added on purpose: that marker is Kimi K2's per-call terminator inside a `<|tool_calls_section_begin|>...<|tool_calls_section_end|>` section (added in #783), and registering it as a global exit would fire on every Kimi K2 per-call terminator and prematurely exit tool-call suppression mid-section, leaking the second and later Kimi calls into `delta.content` (a regression of #766). Pythonic calls are terminal in practice, so enter-only fully suppresses the payload, mirroring Mistral Nemo's one-shot `[TOOL_CALLS]` entry.

## Test plan

- [x] `cargo test --lib server::tool_calls::formats` (94 passed, including 9 new `pythonic_*` cases: quoted string, unquoted int/float/bool, bracketed list, mixed quoted+unquoted, empty args, non-matching text, marker-wrapped vs bare body, first-match-only)
- [x] `cargo test --lib server::tool_calls::parser` (62 passed, including `parse_pythonic_format` and `parse_pythonic_filters_unknown_tools`)
- [x] `cargo test --lib server::tool_calls::stream_filter` (64 passed, including `pythonic_tool_call_suppressed`, `pythonic_content_before_call_emitted`, `pythonic_start_marker_not_confused_with_gemma4_or_kimi_k2`, and a new `kimi_k2_multi_call_section_all_calls_suppressed` regression test proving `<|tool_call_end|>` still does not exit tool-call suppression mid-section)
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`

Closes #768
