### PR TITLE
feat(gemma4): per-request soft-token budget override for image inputs

### DIFF
--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -112,6 +112,95 @@ Audio/video capability is model-specific. The server request types include
 must advertise support for the corresponding modality. Video frame extraction
 uses the system `ffmpeg`/`ffprobe` binaries at runtime.
 
+### Gemma 4 image soft-token budget
+
+Gemma 4's vision front-end is resolution-driven: it works over whatever patch
+grid the preprocessor hands it, with no fixed feature length. The number of soft
+tokens an image contributes to the prompt therefore follows directly from the
+resize target, and the resize target follows from a soft-token budget. That
+budget is read from the checkpoint's config at load time (280 for every shipped
+Gemma 4 checkpoint) and can be overridden per request.
+
+This applies to both Gemma 4 architectures: `gemma4` (the ViT tower, e.g.
+`gemma-4-e2b-it`, `gemma-4-31b-it`) and `gemma4_unified` (the encoder-free patch
+projector, e.g. `gemma-4-12b-it`).
+
+A larger budget keeps more detail (denser patch grid, better small-text and
+fine-structure reading) at the cost of a longer prompt and more prefill work. A
+smaller budget is cheaper and faster. Supported values, shared with the video
+per-frame budget:
+
+| Budget | Meaning |
+|--------|---------|
+| 70 | Smallest. What `detail: "low"` maps to. |
+| 140 | |
+| 280 | Checkpoint default for the shipped Gemma 4 models. |
+| 560 | |
+| 1120 | Largest. What `detail: "high"` maps to. |
+
+Any other value is rejected with a 400. The budget is untrusted request input
+and it scales the resized image and its patch grid, so it is validated against
+this ladder rather than clamped: a silent clamp would leave the caller believing
+they got a budget they did not get. 1120 is also the hard ceiling for
+`gemma4_unified`, whose learned 2-D position table is exactly 1120 wide; a budget
+past it would index off the end of that table.
+
+#### Server
+
+Two optional fields on the `image_url` content part:
+
+```json
+{
+  "model": "gemma-4-12b-it-4bit",
+  "messages": [{
+    "role": "user",
+    "content": [
+      {"type": "text", "text": "Transcribe the small print."},
+      {"type": "image_url", "image_url": {
+        "url": "data:image/png;base64,...",
+        "detail": "high"
+      }}
+    ]
+  }]
+}
+```
+
+* `detail` is the OpenAI-standard field. `"low"` maps to 70, `"high"` maps to
+  1120, and `"auto"` (or an absent field) leaves the checkpoint's configured
+  budget in place. An unknown value is a 400, not a silent fallback to `"auto"`.
+* `max_soft_tokens` is an **mlxcel extension**, not part of the OpenAI spec. It
+  names an exact budget from the ladder above and takes precedence over `detail`
+  when both are present:
+
+  ```json
+  {"type": "image_url", "image_url": {"url": "...", "max_soft_tokens": 560}}
+  ```
+
+Both fields are optional and default to absent, so a request that sends only
+`url` behaves exactly as it did before these fields existed. The budget applies
+to the request as a whole; when a request carries several `image_url` parts they
+must agree on an explicit budget (parts that set neither field are free to
+coexist with parts that do). Every non-Gemma-4 model ignores both fields.
+
+Note that the budget is part of the vision-feature cache identity, so the same
+image requested at two budgets is encoded twice rather than served the wrong
+cached features.
+
+#### CLI
+
+`mlxcel generate --image-soft-tokens <N>` takes the same ladder and the same
+validation:
+
+```bash
+./target/release/mlxcel generate -m models/gemma-4-12b-it-4bit \
+  --image receipt.png --image-soft-tokens 1120 \
+  -p "What is the total?"
+```
+
+Omitting the flag uses the checkpoint's configured budget. The flag applies to
+`--image` inputs only; `--video` frames keep their own (smaller) per-frame
+budget.
+
 ### Thinking default for `gemma4_unified`
 
 Gemma 4 Unified (`gemma4_unified`) ships `<|channel>` / `<channel|>` thinking

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1836,6 +1836,15 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
                 &user_prompt,
             );
         }
+        // Reject an off-ladder `--image-soft-tokens` before loading any image:
+        // the budget drives the resize target, so an unsupported value is a
+        // user error, not something to clamp silently.
+        let image_soft_tokens = args
+            .generation
+            .image_soft_tokens
+            .map(mlxcel::vision::processors::gemma4::validate_image_soft_tokens)
+            .transpose()
+            .map_err(|err| anyhow::anyhow!("--image-soft-tokens: {err}"))?;
         let vlm_embeddings = generate_vlm::compute_vlm_embeddings(
             &model,
             &mut prompt_tokens,
@@ -1845,6 +1854,7 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
             &args.generation.video,
             args.generation.fps,
             &tokenizer,
+            image_soft_tokens,
         )?;
         print_generation_preamble(&user_prompt)?;
         let generation = run_generation_mode(

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -292,6 +292,7 @@ fn sample_generate_args(model_path: PathBuf) -> crate::GenerateArgs {
         generation: crate::GenerationOptions {
             prompt: Some("Hello".to_string()),
             image: Vec::new(),
+            image_soft_tokens: None,
             audio: None,
             video: Vec::new(),
             fps: 2.0,

--- a/src/commands/generate_vlm.rs
+++ b/src/commands/generate_vlm.rs
@@ -19,7 +19,7 @@ use mlxcel::LoadedModel;
 use mlxcel::video;
 use mlxcel::vision::merge::InputEmbeddings;
 use mlxcel::vlm_prompt::ImageTokenBlockAction;
-use mlxcel::vlm_runtime::{VlmPreparationSummary, prepare_and_compute_vlm_embeddings};
+use mlxcel::vlm_runtime::{VlmPreparationSummary, prepare_and_compute_vlm_embeddings_with_budget};
 
 use crate::MlxcelTokenizer;
 
@@ -302,6 +302,10 @@ fn print_preparation_summary(summary: VlmPreparationSummary) {
     }
 }
 
+/// `image_soft_tokens` is the `--image-soft-tokens` override (Gemma 4 only).
+/// `None` uses the checkpoint's configured budget. Validated by the caller
+/// against `SUPPORTED_IMAGE_SOFT_TOKENS`.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn compute_vlm_embeddings(
     model: &LoadedModel,
     prompt_tokens: &mut Vec<i32>,
@@ -311,6 +315,7 @@ pub(crate) fn compute_vlm_embeddings(
     video_paths: &[PathBuf],
     target_fps: f64,
     tokenizer: &MlxcelTokenizer,
+    image_soft_tokens: Option<usize>,
 ) -> Result<Option<InputEmbeddings>> {
     // Handle video-only or video + image mode for Gemma4.
     // Video and audio cannot coexist in this CLI surface yet, surface a
@@ -328,6 +333,7 @@ pub(crate) fn compute_vlm_embeddings(
                 image_paths,
                 video_paths,
                 target_fps,
+                image_soft_tokens,
             );
         }
         if let LoadedModel::Gemma4Unified(unified) = model {
@@ -337,6 +343,7 @@ pub(crate) fn compute_vlm_embeddings(
                 image_paths,
                 video_paths,
                 target_fps,
+                image_soft_tokens,
             );
         }
         if let LoadedModel::KimiVL(kimi) = model {
@@ -366,7 +373,13 @@ pub(crate) fn compute_vlm_embeddings(
         && let Some(audio) = audio_path
         && let LoadedModel::Gemma4VLM(gemma4_vl) = model
     {
-        return compute_gemma4_multimodal_embeddings(gemma4_vl, prompt_tokens, image_paths, audio);
+        return compute_gemma4_multimodal_embeddings(
+            gemma4_vl,
+            prompt_tokens,
+            image_paths,
+            audio,
+            image_soft_tokens,
+        );
     }
 
     // Handle audio-only and image+audio for Gemma 4 Unified (encoder-free).
@@ -378,6 +391,7 @@ pub(crate) fn compute_vlm_embeddings(
             prompt_tokens,
             image_paths,
             audio,
+            image_soft_tokens,
         );
     }
 
@@ -460,11 +474,12 @@ pub(crate) fn compute_vlm_embeddings(
         .collect::<Result<Vec<_>>>()?;
     println!("Loaded {} image(s).", images.len());
 
-    let prepared = prepare_and_compute_vlm_embeddings(
+    let prepared = prepare_and_compute_vlm_embeddings_with_budget(
         model,
         prompt_tokens,
         prompt,
         &images,
+        image_soft_tokens,
         |text, add_special| {
             tokenizer
                 .encode(text, add_special)
@@ -582,6 +597,7 @@ fn compute_gemma4_multimodal_embeddings(
     prompt_tokens: &mut Vec<i32>,
     image_paths: &[PathBuf],
     audio_path: &Path,
+    image_soft_tokens: Option<usize>,
 ) -> Result<Option<InputEmbeddings>> {
     use mlxcel::audio;
 
@@ -600,10 +616,13 @@ fn compute_gemma4_multimodal_embeddings(
         .collect::<Result<Vec<_>>>()?;
     println!("Loaded {} image(s).", images.len());
 
-    let processed_images = gemma4_vl.processor.preprocess(&images);
+    let processed_images = gemma4_vl
+        .processor
+        .preprocess_with_budget(&images, image_soft_tokens);
     let num_soft_tokens: Vec<usize> = processed_images.iter().map(|i| i.num_soft_tokens).collect();
 
-    // Expand image tokens
+    // Expand image tokens. The count comes from the features this exact call
+    // produced, so the placeholder run matches the emitted rows at any budget.
     mlxcel::vlm_runtime::expand_gemma4_image_tokens_pub(
         prompt_tokens,
         gemma4_vl.image_token_id,
@@ -675,6 +694,7 @@ fn compute_gemma4_unified_multimodal_embeddings(
     prompt_tokens: &mut Vec<i32>,
     image_paths: &[PathBuf],
     audio_path: &Path,
+    image_soft_tokens: Option<usize>,
 ) -> Result<Option<InputEmbeddings>> {
     use mlxcel::audio;
 
@@ -696,7 +716,9 @@ fn compute_gemma4_unified_multimodal_embeddings(
             })
             .collect::<Result<Vec<_>>>()?;
         println!("Loaded {} image(s).", images.len());
-        let processed = unified.processor.preprocess(&images);
+        let processed = unified
+            .processor
+            .preprocess_with_budget(&images, image_soft_tokens);
         let num_soft_tokens: Vec<usize> = processed.iter().map(|i| i.num_soft_tokens).collect();
         mlxcel::vlm_runtime::expand_gemma4_image_tokens_pub(
             prompt_tokens,
@@ -761,6 +783,7 @@ fn compute_gemma4_video_embeddings(
     image_paths: &[PathBuf],
     video_paths: &[PathBuf],
     target_fps: f64,
+    image_soft_tokens: Option<usize>,
 ) -> Result<Option<InputEmbeddings>> {
     if !video::ffmpeg_available() {
         return Err(anyhow::anyhow!(
@@ -790,8 +813,12 @@ fn compute_gemma4_video_embeddings(
         println!("Loaded {} image(s).", images.len());
     }
 
-    let processed_images = gemma4_vl.processor.preprocess(&images);
-    let image_soft_tokens: Vec<usize> = processed_images
+    // Companion still images honor `--image-soft-tokens`; the video frames keep
+    // their own smaller per-frame budget.
+    let processed_images = gemma4_vl
+        .processor
+        .preprocess_with_budget(&images, image_soft_tokens);
+    let image_soft_token_counts: Vec<usize> = processed_images
         .iter()
         .map(|img| img.num_soft_tokens)
         .collect();
@@ -837,7 +864,7 @@ fn compute_gemma4_video_embeddings(
             gemma4_vl.image_token_id,
             gemma4_vl.boi_token_id,
             gemma4_vl.eoi_token_id,
-            &image_soft_tokens,
+            &image_soft_token_counts,
         )?;
         mlxcel::vlm_runtime::expand_gemma4_video_tokens(
             prompt_tokens,
@@ -947,6 +974,7 @@ fn compute_gemma4_unified_video_embeddings(
     image_paths: &[PathBuf],
     video_paths: &[PathBuf],
     target_fps: f64,
+    image_soft_tokens: Option<usize>,
 ) -> Result<Option<InputEmbeddings>> {
     if !video::ffmpeg_available() {
         return Err(anyhow::anyhow!(
@@ -977,7 +1005,9 @@ fn compute_gemma4_unified_video_embeddings(
             })
             .collect::<Result<Vec<_>>>()?;
         println!("Loaded {} image(s).", images.len());
-        let processed = unified.processor.preprocess(&images);
+        let processed = unified
+            .processor
+            .preprocess_with_budget(&images, image_soft_tokens);
         let num_soft_tokens: Vec<usize> = processed.iter().map(|i| i.num_soft_tokens).collect();
         mlxcel::vlm_runtime::expand_gemma4_image_tokens_pub(
             prompt_tokens,

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,7 +338,7 @@ pub(crate) struct GenerationOptions {
     /// omitted, the budget configured in the checkpoint's
     /// `processor_config.json` is used (280 for the shipped Gemma 4
     /// checkpoints). Ignored by every other model family.
-    #[arg(long, value_name = "N")]
+    #[arg(long, value_name = "N", value_parser = parse_image_soft_tokens)]
     pub(crate) image_soft_tokens: Option<usize>,
 
     /// Audio file path for audio-language models (e.g. Gemma4 with audio)
@@ -580,6 +580,13 @@ fn parse_unit_interval(s: &str) -> Result<f32, String> {
     } else {
         Err(format!("must be between 0 and 1, got {v}"))
     }
+}
+
+/// Validate `--image-soft-tokens` at parse time so an off-ladder value is
+/// rejected before any model or image is loaded.
+fn parse_image_soft_tokens(s: &str) -> Result<usize, String> {
+    let v: usize = s.parse().map_err(|e| format!("not a number: {e}"))?;
+    mlxcel::vision::processors::gemma4::validate_image_soft_tokens(v)
 }
 
 /// Block-diffusion generation options.

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,6 +330,17 @@ pub(crate) struct GenerationOptions {
     #[arg(long, value_name = "PATH", num_args = 1..)]
     pub(crate) image: Vec<PathBuf>,
 
+    /// Soft-token budget per `--image` (Gemma 4 only).
+    ///
+    /// Controls how much detail the vision tower keeps: the image is resized to
+    /// fit this many soft tokens, so a larger budget means a denser patch grid
+    /// and a longer prompt. Must be one of 70, 140, 280, 560, or 1120. When
+    /// omitted, the budget configured in the checkpoint's
+    /// `processor_config.json` is used (280 for the shipped Gemma 4
+    /// checkpoints). Ignored by every other model family.
+    #[arg(long, value_name = "N")]
+    pub(crate) image_soft_tokens: Option<usize>,
+
     /// Audio file path for audio-language models (e.g. Gemma4 with audio)
     #[arg(long, value_name = "PATH")]
     pub(crate) audio: Option<PathBuf>,

--- a/src/multimodal/vlm_runtime.rs
+++ b/src/multimodal/vlm_runtime.rs
@@ -289,6 +289,37 @@ where
         images,
         None,
         None,
+        None,
+        encode,
+    )
+}
+
+/// [`prepare_and_compute_vlm_embeddings`] with a per-request Gemma 4 image
+/// soft-token budget.
+///
+/// `image_soft_tokens = None` is identical to
+/// [`prepare_and_compute_vlm_embeddings`]. The budget must already have passed
+/// [`crate::vision::processors::gemma4::validate_image_soft_tokens`]; every
+/// non-Gemma-4 family ignores it.
+pub fn prepare_and_compute_vlm_embeddings_with_budget<E>(
+    model: &LoadedModel,
+    prompt_tokens: &mut Vec<i32>,
+    prompt: &str,
+    images: &[DynamicImage],
+    image_soft_tokens: Option<usize>,
+    encode: E,
+) -> Result<Option<PreparedVlmEmbeddings>>
+where
+    E: FnMut(&str, bool) -> Vec<i32>,
+{
+    prepare_and_compute_vlm_embeddings_with_cache(
+        model,
+        prompt_tokens,
+        prompt,
+        images,
+        None,
+        None,
+        image_soft_tokens,
         encode,
     )
 }
@@ -303,6 +334,13 @@ where
 ///
 /// Passing `caches == None` or `caches.enabled() == false` falls through to
 /// the un-cached path with zero additional cost.
+///
+/// `image_soft_tokens` is the per-request Gemma 4 soft-token budget (`None` =
+/// the checkpoint's configured budget). When set, callers that also pass
+/// `image_cache_keys` must have folded the budget into those keys (see
+/// [`crate::vision::feature_cache::image_hash_from_bytes_with_soft_tokens`]),
+/// because the cached vision features differ per budget.
+#[allow(clippy::too_many_arguments)]
 pub fn prepare_and_compute_vlm_embeddings_with_cache<E>(
     model: &LoadedModel,
     prompt_tokens: &mut Vec<i32>,
@@ -310,6 +348,7 @@ pub fn prepare_and_compute_vlm_embeddings_with_cache<E>(
     images: &[DynamicImage],
     image_cache_keys: Option<&[Option<CacheKey>]>,
     caches: Option<&ModelVisionCaches>,
+    image_soft_tokens: Option<usize>,
     mut encode: E,
 ) -> Result<Option<PreparedVlmEmbeddings>>
 where
@@ -559,7 +598,16 @@ where
             }))
         }
         VlmRuntimeRef::Gemma4(gemma4_vl) => {
-            let processed_images = gemma4_vl.processor.preprocess(images);
+            // The placeholder expansion below is derived from the
+            // `num_soft_tokens` the preprocessor actually produced for THIS
+            // call's budget, not from the budget itself. That is what keeps the
+            // prompt's image-token run exactly as long as the feature rows the
+            // vision tower will emit; recomputing the count from the budget
+            // independently would desync the two whenever the resize rounds
+            // down to a smaller patch grid than the budget allows.
+            let processed_images = gemma4_vl
+                .processor
+                .preprocess_with_budget(images, image_soft_tokens);
             let num_soft_tokens: Vec<usize> = processed_images
                 .iter()
                 .map(|image| image.num_soft_tokens)
@@ -613,7 +661,12 @@ where
         VlmRuntimeRef::Gemma4Unified(unified) => {
             // Encoder-free patch projector: preprocess to flat patch matrices +
             // 2-D positions, expand BOI/IMAGE/EOI placeholders, then merge.
-            let processed_images = unified.processor.preprocess(images);
+            // Same lockstep rule as the Gemma4 arm: the placeholder expansion
+            // below counts the `num_soft_tokens` this call actually produced,
+            // which is the real (unpadded) patch count, not the budget.
+            let processed_images = unified
+                .processor
+                .preprocess_with_budget(images, image_soft_tokens);
             let num_soft_tokens: Vec<usize> = processed_images
                 .iter()
                 .map(|image| image.num_soft_tokens)

--- a/src/server/anthropic_translator.rs
+++ b/src/server/anthropic_translator.rs
@@ -206,7 +206,7 @@ fn append_message(out: &mut Vec<Message>, message: &AnthropicMessage) {
                             && let Some(url) = source.to_image_ref()
                         {
                             image_parts.push(ContentPart::ImageUrl {
-                                image_url: ImageUrl { url },
+                                image_url: ImageUrl::new(url),
                             });
                         }
                     }
@@ -506,7 +506,7 @@ fn tool_result_message(
         }
         for url in images {
             parts.push(ContentPart::ImageUrl {
-                image_url: ImageUrl { url },
+                image_url: ImageUrl::new(url),
             });
         }
         MessageContent::Parts(parts)

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -2653,6 +2653,7 @@ impl BatchScheduler {
                 &audio,
                 &videos,
                 Some(self.vision_caches.as_ref()),
+                options.image_soft_tokens,
             ) {
                 Ok(emb) => Some(emb),
                 Err(err) => {
@@ -2735,6 +2736,7 @@ impl BatchScheduler {
                 &audio,
                 &videos,
                 Some(self.vision_caches.as_ref()),
+                options.image_soft_tokens,
             ) {
                 Ok(emb) => emb,
                 Err(err) => {

--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -77,6 +77,16 @@ use super::types::request::Tool;
 pub(crate) struct PreparedChatRequest {
     pub(crate) prompt: String,
     pub(crate) image_data: Vec<Vec<u8>>,
+    /// Request-scoped Gemma 4 image soft-token budget, resolved from the
+    /// `detail` / `max_soft_tokens` fields on the `image_url` content parts
+    /// (see [`crate::server::types::request::ImageUrl`]).
+    ///
+    /// `None` means "no override" and leaves the checkpoint's configured
+    /// budget in place, which is the behavior for every request that does not
+    /// set either field. Validation happens here, at the request boundary, so
+    /// an unsupported value fails the whole request with a 400 before any
+    /// image is decoded.
+    pub(crate) image_soft_tokens: Option<usize>,
     pub(crate) audio_data: Vec<Vec<u8>>,
     /// Resolved video items (hardened).
     ///
@@ -208,6 +218,13 @@ pub(crate) async fn prepare_chat_request_with_cache(
             })
     };
 
+    // Validate the per-request soft-token budget before any image is fetched or
+    // decoded: an unsupported `detail` / `max_soft_tokens` is a client error, so
+    // there is no reason to spend a download or a decode on it first.
+    let image_soft_tokens = request
+        .image_soft_tokens()
+        .map_err(|err| anyhow::anyhow!("{err}"))?;
+
     let (image_data, audio_data, videos) = tokio::join!(
         try_extract_chat_image_data(request),
         extract_chat_audio_data(request),
@@ -217,6 +234,7 @@ pub(crate) async fn prepare_chat_request_with_cache(
     Ok(PreparedChatRequest {
         prompt,
         image_data: image_data?,
+        image_soft_tokens,
         audio_data,
         videos,
     })

--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -52,9 +52,7 @@ fn build_chat_messages_flattens_text_parts() {
                 text: "Hello".to_string(),
             },
             ContentPart::ImageUrl {
-                image_url: ImageUrl {
-                    url: "data:image/png;base64,aGVsbG8=".to_string(),
-                },
+                image_url: ImageUrl::new("data:image/png;base64,aGVsbG8=".to_string()),
             },
             ContentPart::Text {
                 text: " world".to_string(),
@@ -81,9 +79,7 @@ async fn prepare_chat_request_uses_template_output_and_extracts_images() {
                 text: "Look".to_string(),
             },
             ContentPart::ImageUrl {
-                image_url: ImageUrl {
-                    url: "data:image/png;base64,aGVsbG8=".to_string(),
-                },
+                image_url: ImageUrl::new("data:image/png;base64,aGVsbG8=".to_string()),
             },
         ]),
         name: None,

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -153,6 +153,19 @@ pub struct ServerGenerateOptions {
     pub structured: Option<
         std::sync::Arc<std::sync::Mutex<crate::server::structured::StructuredOutputConstraint>>,
     >,
+
+    /// per-request Gemma 4 image soft-token budget.
+    ///
+    /// `None` means "no override": the Gemma 4 preprocessor uses the budget
+    /// read from the checkpoint's `processor_config.json` at load time, which
+    /// is the behavior for every request that does not set `detail` or
+    /// `max_soft_tokens` on an `image_url` content part.
+    ///
+    /// Resolved and validated in the route layer (see
+    /// [`crate::server::types::request::resolve_request_image_soft_tokens`]),
+    /// so by the time the scheduler sees this field it is already known to be
+    /// on the supported ladder. Ignored by every non-Gemma-4 model.
+    pub image_soft_tokens: Option<usize>,
 }
 
 /// Per-request reasoning-budget override.

--- a/src/server/media_tests.rs
+++ b/src/server/media_tests.rs
@@ -167,9 +167,7 @@ async fn extract_chat_image_data_reads_file_urls() {
     fs::write(&path, b"image-bytes").unwrap();
 
     let request = build_chat_request(vec![ContentPart::ImageUrl {
-        image_url: ImageUrl {
-            url: format!("file://{}", path.display()),
-        },
+        image_url: ImageUrl::new(format!("file://{}", path.display())),
     }]);
 
     let images = extract_chat_image_data(&request).await;
@@ -198,14 +196,10 @@ async fn extract_chat_image_data_collects_images_across_messages() {
                         text: "look".to_string(),
                     },
                     ContentPart::ImageUrl {
-                        image_url: ImageUrl {
-                            url: "data:image/png;base64,aGVsbG8=".to_string(),
-                        },
+                        image_url: ImageUrl::new("data:image/png;base64,aGVsbG8=".to_string()),
                     },
                     ContentPart::ImageUrl {
-                        image_url: ImageUrl {
-                            url: "data:image/png;base64,d29ybGQ=".to_string(),
-                        },
+                        image_url: ImageUrl::new("data:image/png;base64,d29ybGQ=".to_string()),
                     },
                 ]),
                 name: None,

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -40,7 +40,7 @@ use crate::tokenizer::MlxcelTokenizer;
 use crate::vision::feature_cache::ModelVisionCaches;
 use crate::vision::merge::InputEmbeddings;
 use crate::vlm_runtime::{
-    prepare_and_compute_vlm_embeddings, prepare_and_compute_vlm_embeddings_with_cache,
+    prepare_and_compute_vlm_embeddings_with_budget, prepare_and_compute_vlm_embeddings_with_cache,
 };
 use crate::worker_failfast::run_core_thread_or_abort;
 
@@ -1065,6 +1065,10 @@ fn is_image_limit_error(err: &ImageError) -> bool {
     matches!(err, ImageError::Limits(_))
 }
 
+/// `image_soft_tokens` is the request-scoped Gemma 4 image soft-token budget
+/// (`None` = use the checkpoint's configured budget). It is already validated
+/// against the supported ladder at the request boundary. Every non-Gemma-4
+/// family ignores it.
 pub(crate) fn prepare_request_vlm_embeddings(
     model: &LoadedModel,
     tokenizer: &MlxcelTokenizer,
@@ -1074,6 +1078,7 @@ pub(crate) fn prepare_request_vlm_embeddings(
     audio: &[Vec<u8>],
     videos: &[crate::server::media::ResolvedVideo],
     vision_caches: Option<&ModelVisionCaches>,
+    image_soft_tokens: Option<usize>,
 ) -> Result<Option<InputEmbeddings>> {
     let has_media = !images.is_empty() || !audio.is_empty() || !videos.is_empty();
 
@@ -1126,7 +1131,13 @@ pub(crate) fn prepare_request_vlm_embeddings(
         if !audio.is_empty() {
             return Err(anyhow!("Combined video and audio inputs are not supported"));
         }
-        return prepare_request_video_embeddings(model, prompt_tokens, images, videos);
+        return prepare_request_video_embeddings(
+            model,
+            prompt_tokens,
+            images,
+            videos,
+            image_soft_tokens,
+        );
     }
 
     // Audio-only or audio+images for Gemma4 / Gemma4 Unified
@@ -1143,6 +1154,7 @@ pub(crate) fn prepare_request_vlm_embeddings(
             images,
             audio,
             end_of_turn_token_id,
+            image_soft_tokens,
         )? {
             return Ok(Some(embeddings));
         }
@@ -1152,6 +1164,7 @@ pub(crate) fn prepare_request_vlm_embeddings(
             images,
             audio,
             end_of_turn_token_id,
+            image_soft_tokens,
         )? {
             return Ok(Some(embeddings));
         }
@@ -1189,11 +1202,18 @@ pub(crate) fn prepare_request_vlm_embeddings(
     if !images.is_empty() {
         let decoded_images = decode_request_images(images)?;
         let prepared = if let Some(caches) = vision_caches.filter(|c| c.enabled()) {
+            // The cached value is the vision tower's output, which for Gemma 4
+            // depends on the soft-token budget as well as the image bytes.
+            // Fold the budget into the key so the same image requested at two
+            // budgets cannot serve one's features for the other.
             let image_cache_keys: Vec<Option<crate::vision::feature_cache::CacheKey>> = images
                 .iter()
                 .map(|bytes| {
                     Some(crate::vision::feature_cache::CacheKey::from_hash(
-                        crate::vision::feature_cache::image_hash_from_bytes(bytes),
+                        crate::vision::feature_cache::image_hash_from_bytes_with_soft_tokens(
+                            bytes,
+                            image_soft_tokens,
+                        ),
                     ))
                 })
                 .collect();
@@ -1204,6 +1224,7 @@ pub(crate) fn prepare_request_vlm_embeddings(
                 &decoded_images,
                 Some(&image_cache_keys),
                 Some(caches),
+                image_soft_tokens,
                 |text, add_special| {
                     tokenizer
                         .encode(text, add_special)
@@ -1214,11 +1235,12 @@ pub(crate) fn prepare_request_vlm_embeddings(
                 },
             )?
         } else {
-            prepare_and_compute_vlm_embeddings(
+            prepare_and_compute_vlm_embeddings_with_budget(
                 model,
                 prompt_tokens,
                 prompt,
                 &decoded_images,
+                image_soft_tokens,
                 |text, add_special| {
                     tokenizer
                         .encode(text, add_special)
@@ -1321,6 +1343,7 @@ fn prepare_gemma4_audio_embeddings(
     images: &[Vec<u8>],
     audio_data: &[Vec<u8>],
     end_of_turn_token_id: Option<i32>,
+    image_soft_tokens: Option<usize>,
 ) -> Result<Option<InputEmbeddings>> {
     use crate::audio;
 
@@ -1392,10 +1415,15 @@ fn prepare_gemma4_audio_embeddings(
     let audio_mask = mlxcel_core::from_slice_i32(&mask_i32, &[1, num_frames as i32]);
     let audio_mask = mlxcel_core::astype(&audio_mask, mlxcel_core::dtype::BOOL);
 
-    // Process images if present alongside audio
+    // Process images if present alongside audio. The placeholder expansion is
+    // driven by the `num_soft_tokens` this exact preprocess call produced, so
+    // the image-token run in the prompt matches the feature rows one-for-one at
+    // whatever budget the request asked for.
     let processed_images = if !images.is_empty() {
         let decoded_images = decode_request_images(images)?;
-        let processed = gemma4_vl.processor.preprocess(&decoded_images);
+        let processed = gemma4_vl
+            .processor
+            .preprocess_with_budget(&decoded_images, image_soft_tokens);
         let num_soft_tokens: Vec<usize> = processed.iter().map(|img| img.num_soft_tokens).collect();
         crate::vlm_runtime::expand_gemma4_image_tokens_pub(
             prompt_tokens,
@@ -1434,6 +1462,7 @@ fn prepare_gemma4_unified_audio_embeddings(
     images: &[Vec<u8>],
     audio_data: &[Vec<u8>],
     end_of_turn_token_id: Option<i32>,
+    image_soft_tokens: Option<usize>,
 ) -> Result<Option<InputEmbeddings>> {
     use crate::audio;
 
@@ -1478,7 +1507,9 @@ fn prepare_gemma4_unified_audio_embeddings(
     // Process images alongside audio (encoder-free patch projector).
     let processed_images = if !images.is_empty() {
         let decoded_images = decode_request_images(images)?;
-        let processed = unified.processor.preprocess(&decoded_images);
+        let processed = unified
+            .processor
+            .preprocess_with_budget(&decoded_images, image_soft_tokens);
         let num_soft_tokens: Vec<usize> = processed.iter().map(|img| img.num_soft_tokens).collect();
         crate::vlm_runtime::expand_gemma4_image_tokens_pub(
             prompt_tokens,
@@ -1786,6 +1817,7 @@ fn prepare_request_video_embeddings(
     prompt_tokens: &mut Vec<i32>,
     images: &[Vec<u8>],
     videos: &[crate::server::media::ResolvedVideo],
+    image_soft_tokens: Option<usize>,
 ) -> Result<Option<InputEmbeddings>> {
     use crate::multimodal::video;
 
@@ -1793,7 +1825,13 @@ fn prepare_request_video_embeddings(
     // per-frame patches scatter into video_token_id placeholders rather than
     // through the ViT image tower.
     if let LoadedModel::Gemma4Unified(unified) = model {
-        return prepare_gemma4_unified_video_embeddings(unified, prompt_tokens, images, videos);
+        return prepare_gemma4_unified_video_embeddings(
+            unified,
+            prompt_tokens,
+            images,
+            videos,
+            image_soft_tokens,
+        );
     }
 
     // Kimi-VL / Kimi-VL 2.5 (kimi_k25) MoonViT 3D video path (issue #551).
@@ -1856,8 +1894,13 @@ fn prepare_request_video_embeddings(
         decode_request_images(images)?
     };
 
-    let processed_images = gemma4_vl.processor.preprocess(&decoded_images);
-    let image_soft_tokens: Vec<usize> = processed_images
+    // Companion still images honor the per-request budget; the video frames keep
+    // their own (smaller) per-frame budget, which `--image-soft-tokens` and the
+    // `image_url` fields deliberately do not touch.
+    let processed_images = gemma4_vl
+        .processor
+        .preprocess_with_budget(&decoded_images, image_soft_tokens);
+    let image_soft_token_counts: Vec<usize> = processed_images
         .iter()
         .map(|img| img.num_soft_tokens)
         .collect();
@@ -1897,7 +1940,7 @@ fn prepare_request_video_embeddings(
             gemma4_vl.image_token_id,
             gemma4_vl.boi_token_id,
             gemma4_vl.eoi_token_id,
-            &image_soft_tokens,
+            &image_soft_token_counts,
         )?;
         crate::vlm_runtime::expand_gemma4_video_tokens(
             prompt_tokens,
@@ -2006,6 +2049,7 @@ fn prepare_gemma4_unified_video_embeddings(
     prompt_tokens: &mut Vec<i32>,
     images: &[Vec<u8>],
     videos: &[crate::server::media::ResolvedVideo],
+    image_soft_tokens: Option<usize>,
 ) -> Result<Option<InputEmbeddings>> {
     use crate::multimodal::video;
 
@@ -2044,7 +2088,9 @@ fn prepare_gemma4_unified_video_embeddings(
         Vec::new()
     } else {
         let decoded_images = decode_request_images(images)?;
-        let processed = unified.processor.preprocess(&decoded_images);
+        let processed = unified
+            .processor
+            .preprocess_with_budget(&decoded_images, image_soft_tokens);
         let num_soft_tokens: Vec<usize> = processed.iter().map(|img| img.num_soft_tokens).collect();
         crate::vlm_runtime::expand_gemma4_image_tokens_pub(
             prompt_tokens,

--- a/src/server/request_options.rs
+++ b/src/server/request_options.rs
@@ -174,6 +174,11 @@ pub(crate) fn build_server_generate_options(
         // that handle `response_format` populate this after the helper
         // returns — see `chat.rs` and `completions.rs`.
         structured: None,
+        // Default unset (use the checkpoint's configured Gemma 4 budget). The
+        // chat routes populate this from the resolved `image_url` content
+        // parts after the helper returns; the raw text-completion endpoints
+        // carry no image parts and always leave it `None`.
+        image_soft_tokens: None,
     }
 }
 

--- a/src/server/routes/anthropic.rs
+++ b/src/server/routes/anthropic.rs
@@ -164,6 +164,9 @@ async fn non_stream_messages(
 
     let mut options = build_generate_options(&translated.chat_request.params, &state.config);
     options.priority = priority;
+    // per-request Gemma 4 image soft-token budget, resolved and validated from
+    // the translated `image_url` content parts. `None` when unset.
+    options.image_soft_tokens = prepared.image_soft_tokens;
     options.reasoning_budget = budget_override;
     // Wire the cross-request prompt-prefix KV cache (epic #116) into the
     // Anthropic Messages path, mirroring the chat-completions handler. Built
@@ -280,6 +283,9 @@ async fn stream_messages(
 
     let mut options = build_generate_options(&translated.chat_request.params, &state.config);
     options.priority = priority;
+    // per-request Gemma 4 image soft-token budget, resolved and validated from
+    // the translated `image_url` content parts. `None` when unset.
+    options.image_soft_tokens = prepared.image_soft_tokens;
     options.reasoning_budget = budget_override;
     // Wire the prompt-prefix KV cache (epic #116) into the streaming Anthropic
     // path too, before `options`/`prepared` move into the spawned task.

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -383,6 +383,10 @@ async fn non_stream_chat_completion(
     options.priority = priority;
     options.reasoning_budget = budget_override;
     options.prompt_cache_ctx = prompt_cache_ctx;
+    // per-request Gemma 4 image soft-token budget, already validated against the
+    // supported ladder by `prepare_chat_request_with_cache`. `None` for every
+    // request that did not set `detail` / `max_soft_tokens`.
+    options.image_soft_tokens = prepared.image_soft_tokens;
     // `ThinkingState` counts reasoning tokens from the first decoded token
     // only when the prompt already left the model inside an open thinking
     // block. The chat template decides this at render time (Qwen primes
@@ -615,6 +619,10 @@ async fn stream_chat_completion(
     options.priority = priority;
     options.reasoning_budget = budget_override;
     options.prompt_cache_ctx = prompt_cache_ctx;
+    // per-request Gemma 4 image soft-token budget, already validated against the
+    // supported ladder by `prepare_chat_request_with_cache`. `None` for every
+    // request that did not set `detail` / `max_soft_tokens`.
+    options.image_soft_tokens = prepared.image_soft_tokens;
     // `ThinkingState` counts reasoning tokens from the first decoded token
     // only when the prompt already left the model inside an open thinking
     // block. The chat template decides this at render time (Qwen primes
@@ -1470,9 +1478,7 @@ mod tests {
                 text: "describe".to_string(),
             },
             ContentPart::ImageUrl {
-                image_url: ImageUrl {
-                    url: "data:image/png;base64,abc".to_string(),
-                },
+                image_url: ImageUrl::new("data:image/png;base64,abc".to_string()),
             },
         ]);
         assert!(!request_has_video_blocks(&req));

--- a/src/server/routes/responses.rs
+++ b/src/server/routes/responses.rs
@@ -193,6 +193,9 @@ async fn non_stream_create_response(
     };
     let mut options = build_generate_options(&translated.chat_request.params, &state.config);
     options.priority = priority;
+    // per-request Gemma 4 image soft-token budget, resolved and validated from
+    // the translated `image_url` content parts. `None` when unset.
+    options.image_soft_tokens = prepared.image_soft_tokens;
     options.reasoning_budget = budget_override;
     options.structured = structured;
     // Wire the cross-request prompt-prefix KV cache (epic #116) into the
@@ -301,6 +304,9 @@ async fn stream_create_response(
     };
     let mut options = build_generate_options(&translated.chat_request.params, &state.config);
     options.priority = priority;
+    // per-request Gemma 4 image soft-token budget, resolved and validated from
+    // the translated `image_url` content parts. `None` when unset.
+    options.image_soft_tokens = prepared.image_soft_tokens;
     options.reasoning_budget = budget_override;
     options.structured = structured;
     // Wire the prompt-prefix KV cache (epic #116) into the streaming Responses

--- a/src/server/startup.rs
+++ b/src/server/startup.rs
@@ -1044,6 +1044,8 @@ fn warmup_model(model_provider: &ModelProvider) -> Result<()> {
             prompt_cache_ctx: None,
             // Warmup never asks for structured output.
             structured: None,
+            // Warmup is text-only; no image budget to override.
+            image_soft_tokens: None,
         },
     )?;
     Ok(())

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -17,6 +17,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::vision::processors::gemma4::{SUPPORTED_IMAGE_SOFT_TOKENS, validate_image_soft_tokens};
+
 /// Chat message role
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -163,12 +165,127 @@ pub enum ContentPart {
     InputAudio { input_audio: InputAudio },
 }
 
-/// Image URL reference
+/// Image URL reference.
+///
+/// Both budget fields are optional and default to `None`, so a request that
+/// sends only `url` behaves exactly as it did before they existed.
+///
+/// # Soft-token budget (Gemma 4 only)
+///
+/// Gemma 4's vision tower is resolution-driven: the number of soft tokens an
+/// image contributes to the prompt is a function of the resize target, which
+/// is a function of the soft-token budget. These two fields expose that dial
+/// per request. Every other VLM family ignores them.
+///
+/// * [`Self::detail`] is the OpenAI-standard field. `"low"` maps to the
+///   smallest supported budget, `"high"` to the largest, and `"auto"` (or an
+///   absent field) leaves the checkpoint's configured default in place.
+/// * [`Self::max_soft_tokens`] is an **mlxcel extension**, not part of the
+///   OpenAI spec. It names an exact budget from the supported ladder and wins
+///   over `detail` when both are present.
+///
+/// Both are validated at the request boundary; an unsupported value is a 400
+/// rather than a silent clamp. See
+/// [`Self::resolve_soft_token_budget`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImageUrl {
     /// URL: `data:image/...;base64,...`, `file://...`, bare local path, or
     /// `http(s)://...`
     pub url: String,
+    /// OpenAI-standard detail hint: `"low"`, `"high"`, or `"auto"`.
+    ///
+    /// Maps onto the Gemma 4 soft-token ladder (see [`Self`]). Unknown values
+    /// are rejected with a 400 rather than silently treated as `"auto"`, so a
+    /// typo cannot quietly downgrade image fidelity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// mlxcel extension: exact Gemma 4 soft-token budget for this image.
+    ///
+    /// Must be one of
+    /// [`mlxcel::vision::processors::gemma4::SUPPORTED_IMAGE_SOFT_TOKENS`].
+    /// Takes precedence over [`Self::detail`]. Not part of the OpenAI API.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_soft_tokens: Option<usize>,
+}
+
+impl ImageUrl {
+    /// Construct a plain image reference with no budget override, i.e. the
+    /// checkpoint's configured default. Used by translators (e.g. the Anthropic
+    /// Messages API) whose wire format has no soft-token dial.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            detail: None,
+            max_soft_tokens: None,
+        }
+    }
+
+    /// Resolve this content part's soft-token budget.
+    ///
+    /// Returns `Ok(None)` when the caller expressed no preference (neither
+    /// field set, or `detail: "auto"`), which means "use the checkpoint's
+    /// configured default" and preserves today's behavior exactly.
+    ///
+    /// The numeric field wins over `detail` when both are present.
+    ///
+    /// # Errors
+    /// Returns `Err` with a caller-facing message (surfaced as a 400) when
+    /// `max_soft_tokens` is off the supported ladder or `detail` is not one of
+    /// `low` / `high` / `auto`. Both values are untrusted request input and the
+    /// budget drives the resize target, so neither is clamped.
+    pub fn resolve_soft_token_budget(&self) -> Result<Option<usize>, String> {
+        if let Some(requested) = self.max_soft_tokens {
+            return validate_image_soft_tokens(requested).map(Some);
+        }
+
+        let Some(detail) = self.detail.as_deref() else {
+            return Ok(None);
+        };
+
+        match detail.trim().to_ascii_lowercase().as_str() {
+            // The ladder is non-empty, so first/last always resolve; fall back
+            // to "no override" rather than panicking if that ever changes.
+            "low" => Ok(SUPPORTED_IMAGE_SOFT_TOKENS.first().copied()),
+            "high" => Ok(SUPPORTED_IMAGE_SOFT_TOKENS.last().copied()),
+            "auto" => Ok(None),
+            other => Err(format!(
+                "image_url.detail must be one of [\"low\", \"high\", \"auto\"], got \"{other}\""
+            )),
+        }
+    }
+}
+
+/// Resolve a single request-scoped Gemma 4 image soft-token budget from every
+/// `image_url` content part in the request.
+///
+/// The budget is applied per request rather than per image because the Gemma 4
+/// preprocessor takes one budget for the whole batch. Parts that express no
+/// preference are ignored. When two parts request *different* explicit budgets
+/// the request is rejected: silently picking one (or the max) would give the
+/// caller a budget they did not ask for on at least one image, and the prompt's
+/// placeholder expansion would then be derived from a value the caller cannot
+/// predict.
+///
+/// # Errors
+/// Returns `Err` when any part fails [`ImageUrl::resolve_soft_token_budget`],
+/// or when two parts disagree on an explicit budget.
+pub fn resolve_request_image_soft_tokens(parts: &[ImageUrl]) -> Result<Option<usize>, String> {
+    let mut resolved: Option<usize> = None;
+    for part in parts {
+        let Some(budget) = part.resolve_soft_token_budget()? else {
+            continue;
+        };
+        match resolved {
+            Some(existing) if existing != budget => {
+                return Err(format!(
+                    "conflicting image soft-token budgets in one request: {existing} and {budget}; \
+                     all image_url parts must agree"
+                ));
+            }
+            _ => resolved = Some(budget),
+        }
+    }
+    Ok(resolved)
 }
 
 /// Video URL reference. Same wire shape as [`ImageUrl`] for
@@ -234,6 +351,21 @@ impl MessageContent {
                 .iter()
                 .filter_map(|p| match p {
                     ContentPart::ImageUrl { image_url } => Some(image_url.url.clone()),
+                    _ => None,
+                })
+                .collect(),
+        }
+    }
+
+    /// Extract whole `image_url` content parts, preserving the per-part
+    /// `detail` / `max_soft_tokens` fields that [`Self::image_urls`] drops.
+    pub fn image_parts(&self) -> Vec<ImageUrl> {
+        match self {
+            MessageContent::Text(_) => Vec::new(),
+            MessageContent::Parts(parts) => parts
+                .iter()
+                .filter_map(|p| match p {
+                    ContentPart::ImageUrl { image_url } => Some(image_url.clone()),
                     _ => None,
                 })
                 .collect(),
@@ -673,6 +805,24 @@ impl ChatCompletionRequest {
             .collect()
     }
 
+    /// Extract all `image_url` content parts from messages, preserving the
+    /// per-part budget fields. Same order as [`Self::image_urls`].
+    pub fn image_parts(&self) -> Vec<ImageUrl> {
+        self.messages
+            .iter()
+            .flat_map(|m| m.content.image_parts())
+            .collect()
+    }
+
+    /// Resolve the request-scoped Gemma 4 image soft-token budget.
+    ///
+    /// # Errors
+    /// Returns `Err` when a part carries an unsupported `detail` /
+    /// `max_soft_tokens`, or when parts disagree. Routes surface this as a 400.
+    pub fn image_soft_tokens(&self) -> Result<Option<usize>, String> {
+        resolve_request_image_soft_tokens(&self.image_parts())
+    }
+
     /// Extract all audio inputs from messages
     pub fn audio_inputs(&self) -> Vec<InputAudio> {
         self.messages
@@ -940,5 +1090,176 @@ mod tests {
             minimal.temperature.is_none(),
             "temperature defaults to None"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-request Gemma 4 image soft-token budget (issue #777)
+    // -----------------------------------------------------------------------
+
+    fn chat_request_with_image_part(image_url_json: &str) -> ChatCompletionRequest {
+        let json = format!(
+            r#"{{
+                "model": "gemma-4",
+                "messages": [
+                    {{"role": "user", "content": [
+                        {{"type": "text", "text": "what is this?"}},
+                        {{"type": "image_url", "image_url": {image_url_json}}}
+                    ]}}
+                ]
+            }}"#
+        );
+        serde_json::from_str(&json).expect("request must deserialize")
+    }
+
+    #[test]
+    fn image_url_without_budget_fields_deserializes_and_means_no_override() {
+        // The pre-existing wire shape: bare `url`. Must stay valid and must
+        // resolve to "no override" so existing requests are unchanged.
+        let req = chat_request_with_image_part(r#"{"url": "data:image/png;base64,aGk="}"#);
+        let parts = req.image_parts();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].detail, None);
+        assert_eq!(parts[0].max_soft_tokens, None);
+        assert_eq!(req.image_soft_tokens(), Ok(None));
+        // And the plain URL accessor still sees it.
+        assert_eq!(
+            req.image_urls(),
+            vec!["data:image/png;base64,aGk=".to_string()]
+        );
+    }
+
+    #[test]
+    fn detail_low_and_high_map_to_ladder_ends() {
+        let low = chat_request_with_image_part(r#"{"url": "x.png", "detail": "low"}"#);
+        assert_eq!(low.image_soft_tokens(), Ok(Some(70)));
+
+        let high = chat_request_with_image_part(r#"{"url": "x.png", "detail": "high"}"#);
+        assert_eq!(high.image_soft_tokens(), Ok(Some(1120)));
+    }
+
+    #[test]
+    fn detail_auto_means_no_override() {
+        let auto = chat_request_with_image_part(r#"{"url": "x.png", "detail": "auto"}"#);
+        assert_eq!(
+            auto.image_soft_tokens(),
+            Ok(None),
+            "auto must leave the checkpoint default in place"
+        );
+    }
+
+    #[test]
+    fn detail_is_case_insensitive() {
+        let req = chat_request_with_image_part(r#"{"url": "x.png", "detail": "HIGH"}"#);
+        assert_eq!(req.image_soft_tokens(), Ok(Some(1120)));
+    }
+
+    #[test]
+    fn unknown_detail_value_is_rejected() {
+        let req = chat_request_with_image_part(r#"{"url": "x.png", "detail": "ultra"}"#);
+        let err = req
+            .image_soft_tokens()
+            .expect_err("an unknown detail must be a client error, not silently ignored");
+        assert!(err.contains("detail"), "error should name the field: {err}");
+        assert!(
+            err.contains("ultra"),
+            "error should echo the bad value: {err}"
+        );
+    }
+
+    #[test]
+    fn max_soft_tokens_extension_names_an_exact_budget() {
+        for budget in [70usize, 140, 280, 560, 1120] {
+            let req = chat_request_with_image_part(&format!(
+                r#"{{"url": "x.png", "max_soft_tokens": {budget}}}"#
+            ));
+            assert_eq!(req.image_soft_tokens(), Ok(Some(budget)));
+        }
+    }
+
+    #[test]
+    fn off_ladder_max_soft_tokens_is_rejected() {
+        // An unbounded budget scales the resized image and its patch grid, so
+        // it is a memory/DoS vector. Reject rather than clamp.
+        for bad in ["0", "281", "100000", "18446744073709551615"] {
+            let req = chat_request_with_image_part(&format!(
+                r#"{{"url": "x.png", "max_soft_tokens": {bad}}}"#
+            ));
+            let err = req
+                .image_soft_tokens()
+                .expect_err("off-ladder max_soft_tokens must be rejected");
+            assert!(
+                err.contains("must be one of"),
+                "error should name the supported values: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn numeric_budget_wins_over_detail() {
+        let req = chat_request_with_image_part(
+            r#"{"url": "x.png", "detail": "low", "max_soft_tokens": 560}"#,
+        );
+        assert_eq!(
+            req.image_soft_tokens(),
+            Ok(Some(560)),
+            "the mlxcel extension field takes precedence over detail"
+        );
+    }
+
+    #[test]
+    fn an_invalid_numeric_budget_is_rejected_even_when_detail_is_valid() {
+        // The numeric field wins, so its validation must not be skipped just
+        // because a valid `detail` is also present.
+        let req = chat_request_with_image_part(
+            r#"{"url": "x.png", "detail": "high", "max_soft_tokens": 999}"#,
+        );
+        assert!(req.image_soft_tokens().is_err());
+    }
+
+    #[test]
+    fn agreeing_parts_resolve_to_one_budget() {
+        let parts = vec![
+            ImageUrl {
+                url: "a.png".into(),
+                detail: Some("high".into()),
+                max_soft_tokens: None,
+            },
+            ImageUrl {
+                url: "b.png".into(),
+                detail: None,
+                max_soft_tokens: Some(1120),
+            },
+            // A part with no preference does not veto the others.
+            ImageUrl::new("c.png"),
+        ];
+        assert_eq!(resolve_request_image_soft_tokens(&parts), Ok(Some(1120)));
+    }
+
+    #[test]
+    fn conflicting_parts_are_rejected() {
+        let parts = vec![
+            ImageUrl {
+                url: "a.png".into(),
+                detail: Some("low".into()),
+                max_soft_tokens: None,
+            },
+            ImageUrl {
+                url: "b.png".into(),
+                detail: Some("high".into()),
+                max_soft_tokens: None,
+            },
+        ];
+        let err = resolve_request_image_soft_tokens(&parts).expect_err(
+            "two different explicit budgets in one request must not be silently merged",
+        );
+        assert!(err.contains("conflicting"), "got: {err}");
+    }
+
+    #[test]
+    fn image_url_serialization_omits_unset_budget_fields() {
+        // Round-tripping a plain image part must not introduce `detail: null`
+        // or `max_soft_tokens: null` into the wire payload.
+        let json = serde_json::to_string(&ImageUrl::new("x.png")).expect("serializes");
+        assert_eq!(json, r#"{"url":"x.png"}"#);
     }
 }

--- a/src/vision/feature_cache.rs
+++ b/src/vision/feature_cache.rs
@@ -101,20 +101,28 @@ pub fn image_hash_from_bytes(bytes: &[u8]) -> [u8; 32] {
 /// let the first request's features be served to the second, desyncing the
 /// features from the prompt's placeholder expansion.
 ///
-/// `max_soft_tokens = None` (the overwhelmingly common case: no per-request
-/// override) returns exactly [`image_hash_from_bytes`], so cache identity for
-/// unmodified requests is bit-identical to before this parameter existed.
+/// The image payload is length-prefixed and the budget field is tagged, so an
+/// attacker cannot craft an image whose trailing bytes reproduce the budget
+/// field of a different request and collide the two keys. The `None` budget
+/// (no per-request override, the common case) is a distinct sentinel from any
+/// concrete budget. `ModelVisionCaches` is a per-process in-memory cache with
+/// no on-disk form, so this framing costs nothing: the cache is empty at
+/// startup regardless of the key layout.
 pub fn image_hash_from_bytes_with_soft_tokens(
     bytes: &[u8],
     max_soft_tokens: Option<usize>,
 ) -> [u8; 32] {
-    let Some(budget) = max_soft_tokens else {
-        return image_hash_from_bytes(bytes);
-    };
     let mut hasher = Sha256::new();
+    hasher.update(b"mlxcel:image-soft-tokens:v2");
+    hasher.update((bytes.len() as u64).to_le_bytes());
     hasher.update(bytes);
-    hasher.update(b"mlxcel:image-soft-tokens:v1");
-    hasher.update((budget as u64).to_le_bytes());
+    match max_soft_tokens {
+        Some(budget) => {
+            hasher.update([1u8]);
+            hasher.update((budget as u64).to_le_bytes());
+        }
+        None => hasher.update([0u8]),
+    }
     let out = hasher.finalize();
     let mut digest = [0u8; 32];
     digest.copy_from_slice(&out);
@@ -497,6 +505,40 @@ mod tests {
         let hash_key = CacheKey::from_hash([0u8; 32]);
         let path_key = CacheKey::from_path("");
         assert_ne!(hash_key, path_key);
+    }
+
+    #[test]
+    fn soft_token_budget_partitions_the_cache_key() {
+        let bytes = b"\x89PNG\r\n\x1a\n fake image payload";
+        // No override, a concrete budget, and a different budget are all
+        // distinct keys, so the same image at two budgets can never be served
+        // the other budget's vision features.
+        let none = image_hash_from_bytes_with_soft_tokens(bytes, None);
+        let b70 = image_hash_from_bytes_with_soft_tokens(bytes, Some(70));
+        let b1120 = image_hash_from_bytes_with_soft_tokens(bytes, Some(1120));
+        assert_ne!(none, b70);
+        assert_ne!(none, b1120);
+        assert_ne!(b70, b1120);
+        // The key is deterministic for a given (bytes, budget).
+        assert_eq!(b70, image_hash_from_bytes_with_soft_tokens(bytes, Some(70)));
+    }
+
+    #[test]
+    fn soft_token_budget_key_resists_byte_boundary_collision() {
+        // The security concern: without length-prefixing, an attacker could
+        // craft an image whose trailing bytes reproduce the budget field of a
+        // different request. Construct exactly that: image A carries a payload
+        // that ends in what could look like image B's budget suffix, sent with
+        // no override; image B is the shorter prefix sent at that budget. The
+        // two must not collide.
+        let prefix = b"shared image prefix bytes";
+        let mut crafted = prefix.to_vec();
+        crafted.extend_from_slice(&[1u8]);
+        crafted.extend_from_slice(&(70u64).to_le_bytes());
+
+        let crafted_no_budget = image_hash_from_bytes_with_soft_tokens(&crafted, None);
+        let prefix_at_70 = image_hash_from_bytes_with_soft_tokens(prefix, Some(70));
+        assert_ne!(crafted_no_budget, prefix_at_70);
     }
 
     #[test]

--- a/src/vision/feature_cache.rs
+++ b/src/vision/feature_cache.rs
@@ -91,6 +91,36 @@ pub fn image_hash_from_bytes(bytes: &[u8]) -> [u8; 32] {
     digest
 }
 
+/// SHA-256 digest of an encoded image payload, domain-separated by a
+/// preprocessing soft-token budget.
+///
+/// The cached value is the *vision tower output*, which for Gemma 4 depends on
+/// both the image bytes and the soft-token budget the preprocessor resized
+/// under: the same PNG at budget 70 and budget 1120 yields different patch
+/// grids and a different number of feature rows. Keying on bytes alone would
+/// let the first request's features be served to the second, desyncing the
+/// features from the prompt's placeholder expansion.
+///
+/// `max_soft_tokens = None` (the overwhelmingly common case: no per-request
+/// override) returns exactly [`image_hash_from_bytes`], so cache identity for
+/// unmodified requests is bit-identical to before this parameter existed.
+pub fn image_hash_from_bytes_with_soft_tokens(
+    bytes: &[u8],
+    max_soft_tokens: Option<usize>,
+) -> [u8; 32] {
+    let Some(budget) = max_soft_tokens else {
+        return image_hash_from_bytes(bytes);
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.update(b"mlxcel:image-soft-tokens:v1");
+    hasher.update((budget as u64).to_le_bytes());
+    let out = hasher.finalize();
+    let mut digest = [0u8; 32];
+    digest.copy_from_slice(&out);
+    digest
+}
+
 /// SHA-256 digest of an MLX pixel tensor's raw bytes.
 ///
 /// Used when the image already lives on the MLX side (e.g. the request handler
@@ -98,6 +128,10 @@ pub fn image_hash_from_bytes(bytes: &[u8]) -> [u8; 32] {
 /// pixel buffer size — roughly ~8 ms for a 896×896×3 f32 tensor — which is
 /// still ~25x cheaper than the 230 ms vision tower forward pass on Gemma 4, so
 /// a cache hit is always a net win.
+///
+/// This variant needs no budget domain-separation: the pixel tensor it hashes
+/// is the *already resized* one, so a different budget produces different
+/// bytes and therefore a different digest on its own.
 pub fn image_hash_from_pixels(array: &MlxArray) -> [u8; 32] {
     // Fully materialize before extracting bytes; without eval() the contents
     // may reference lazy graph nodes that have not been realized yet.

--- a/src/vision/processors/gemma4.rs
+++ b/src/vision/processors/gemma4.rs
@@ -42,9 +42,51 @@ pub const DEFAULT_VIDEO_NUM_FRAMES: usize = 32;
 /// `default_fps = 2.0`.
 pub const DEFAULT_VIDEO_FPS: f64 = 2.0;
 
+/// Allowed soft-token budgets accepted by Gemma 4 preprocessing. Mirrors
+/// upstream `_SUPPORTED_SOFT_TOKENS`.
+///
+/// Images and video frames intentionally share one ladder: the resize math is
+/// the same function of the budget in both paths
+/// ([`Gemma4Processor::aspect_ratio_preserving_resize_dims`] and
+/// [`Gemma4Processor::video_resize_dims`] differ only in which budget they
+/// read), and the vision tower is fully resolution-driven, so any budget that
+/// is valid for a frame is valid for a still image. Keeping one ladder means a
+/// per-request image override cannot land on a value the video path would
+/// reject.
+pub const SUPPORTED_SOFT_TOKENS: &[usize] = &[70, 140, 280, 560, 1120];
+
 /// Allowed per-frame soft-token budgets accepted by Gemma 4 video
-/// processing. Mirrors upstream `_SUPPORTED_SOFT_TOKENS`.
-pub const SUPPORTED_VIDEO_SOFT_TOKENS: &[usize] = &[70, 140, 280, 560, 1120];
+/// processing. Alias of [`SUPPORTED_SOFT_TOKENS`], kept under its original
+/// name because `set_video_config` and its callers already reference it.
+pub const SUPPORTED_VIDEO_SOFT_TOKENS: &[usize] = SUPPORTED_SOFT_TOKENS;
+
+/// Allowed per-image soft-token budgets accepted by a per-request override.
+/// Alias of [`SUPPORTED_SOFT_TOKENS`]; see that constant for why images and
+/// video share the ladder.
+pub const SUPPORTED_IMAGE_SOFT_TOKENS: &[usize] = SUPPORTED_SOFT_TOKENS;
+
+/// Validate an untrusted per-request image soft-token budget against
+/// [`SUPPORTED_IMAGE_SOFT_TOKENS`].
+///
+/// The budget arrives from the HTTP request body (or a CLI flag) and drives
+/// the resize target: the preprocessed image, its patch grid, and the number
+/// of soft tokens injected into the prompt all scale with it. An unbounded
+/// value is therefore a memory-amplification vector, so anything outside the
+/// ladder is rejected rather than clamped: a silent clamp would leave the
+/// caller believing they got a budget they did not get.
+///
+/// # Errors
+/// Returns `Err` with a message naming the supported values when
+/// `max_soft_tokens` is not on the ladder.
+pub fn validate_image_soft_tokens(max_soft_tokens: usize) -> Result<usize, String> {
+    if SUPPORTED_IMAGE_SOFT_TOKENS.contains(&max_soft_tokens) {
+        Ok(max_soft_tokens)
+    } else {
+        Err(format!(
+            "image max_soft_tokens must be one of {SUPPORTED_IMAGE_SOFT_TOKENS:?}, got {max_soft_tokens}"
+        ))
+    }
+}
 
 /// Preprocessed output for a single image (or a single video frame) ready
 /// for the Gemma 4 vision tower.
@@ -152,17 +194,53 @@ impl Gemma4Processor {
         Ok(())
     }
 
-    /// Preprocess a batch of static images.
+    /// Preprocess a batch of static images at the checkpoint's configured
+    /// soft-token budget.
     ///
     /// Each image is resized to the aspect-ratio-preserving target dimensions
     /// derived from [`Self::max_soft_tokens`], rescaled to `[0, 1]`, and
     /// packed into a `[1, 3, H, W]` channel-first tensor. Returns one
     /// [`Gemma4ImageInput`] per input image, in the same order.
+    ///
+    /// Equivalent to [`Self::preprocess_with_budget`] with `None`.
     pub fn preprocess(&self, images: &[DynamicImage]) -> Vec<Gemma4ImageInput> {
+        self.preprocess_with_budget(images, None)
+    }
+
+    /// Preprocess a batch of static images under an optional per-call
+    /// soft-token budget.
+    ///
+    /// `max_soft_tokens` shadows [`Self::max_soft_tokens`] for this call only;
+    /// `None` uses the checkpoint's configured budget and is byte-identical to
+    /// [`Self::preprocess`]. A larger budget resizes the image to a larger
+    /// target, which yields a denser patch grid and therefore more soft tokens.
+    ///
+    /// Callers **must** derive the prompt's placeholder expansion from the
+    /// `num_soft_tokens` on the returned [`Gemma4ImageInput`]s rather than from
+    /// any independently computed budget. The vision tower emits exactly
+    /// `num_soft_tokens` rows per image, so a placeholder count derived from a
+    /// different budget would desync the prompt from the features and the model
+    /// would attend to garbage.
+    ///
+    /// The budget is expected to already have passed
+    /// [`validate_image_soft_tokens`] at the request boundary. A zero budget is
+    /// floored to 1 so the resize math cannot divide the target area to nothing.
+    pub fn preprocess_with_budget(
+        &self,
+        images: &[DynamicImage],
+        max_soft_tokens: Option<usize>,
+    ) -> Vec<Gemma4ImageInput> {
         images
             .iter()
-            .map(|image| self.preprocess_single(image))
+            .map(|image| self.preprocess_single(image, max_soft_tokens))
             .collect()
+    }
+
+    /// Resolve the effective image soft-token budget for one call: the
+    /// per-call override when present, otherwise the checkpoint's configured
+    /// [`Self::max_soft_tokens`].
+    fn effective_image_soft_tokens(&self, max_soft_tokens: Option<usize>) -> usize {
+        max_soft_tokens.unwrap_or(self.max_soft_tokens).max(1)
     }
 
     /// Process one or more videos into Gemma 4 video features.
@@ -319,10 +397,17 @@ impl Gemma4Processor {
         (target_h, target_w)
     }
 
-    fn preprocess_single(&self, image: &DynamicImage) -> Gemma4ImageInput {
+    fn preprocess_single(
+        &self,
+        image: &DynamicImage,
+        max_soft_tokens: Option<usize>,
+    ) -> Gemma4ImageInput {
         let rgb = image.to_rgb8();
-        let (target_h, target_w) =
-            self.aspect_ratio_preserving_resize_dims(rgb.height() as usize, rgb.width() as usize);
+        let (target_h, target_w) = self.aspect_ratio_preserving_resize_dims(
+            rgb.height() as usize,
+            rgb.width() as usize,
+            max_soft_tokens,
+        );
 
         let resized = if rgb.height() as usize == target_h && rgb.width() as usize == target_w {
             rgb
@@ -358,12 +443,18 @@ impl Gemma4Processor {
         }
     }
 
+    /// Target `(height, width)` for one image under an optional per-call
+    /// soft-token budget. `max_soft_tokens = None` uses the checkpoint's
+    /// configured [`Self::max_soft_tokens`], which reproduces the pre-override
+    /// behavior exactly.
     fn aspect_ratio_preserving_resize_dims(
         &self,
         image_height: usize,
         image_width: usize,
+        max_soft_tokens: Option<usize>,
     ) -> (usize, usize) {
-        let max_patches = self.max_soft_tokens * self.pooling_kernel_size.pow(2);
+        let budget = self.effective_image_soft_tokens(max_soft_tokens);
+        let max_patches = budget * self.pooling_kernel_size.pow(2);
         let target_px = max_patches as f64 * (self.patch_size * self.patch_size) as f64;
         let factor = (target_px / ((image_height * image_width).max(1) as f64)).sqrt();
         let side_mult = self.pooling_kernel_size * self.patch_size;

--- a/src/vision/processors/gemma4_tests.rs
+++ b/src/vision/processors/gemma4_tests.rs
@@ -394,6 +394,31 @@ fn image_soft_token_budget_ladder_is_shared_with_video() {
 }
 
 #[test]
+fn patch_grid_at_top_budget_stays_inside_the_vit_position_table() {
+    // The gemma4 ViT indexes its learned per-axis position table with the raw
+    // patch x/y ids (`build_patch_position_ids` in encoders/gemma4.rs), gathered
+    // with `mlxcel_core::take`, which WRAPS on an out-of-range index rather than
+    // faulting. So an oversized patch grid would silently produce wrong position
+    // embeddings. The table default is `position_embedding_size = 10_240`. Pin
+    // that even a pathological aspect ratio at the top ladder budget keeps every
+    // single-axis patch index below it, mirroring the gemma4_unified bound test.
+    const VIT_POSITION_TABLE_SIZE: usize = 10_240;
+    let processor = Gemma4Processor::new(16, 280, 3);
+    // Extreme aspect ratios drive one axis toward `max_side_length`.
+    for (w, h) in [(8192u32, 64u32), (64u32, 8192u32), (16384u32, 32u32)] {
+        let image = synthetic_rgb(w, h, 100);
+        let out = processor.preprocess_with_budget(std::slice::from_ref(&image), Some(1120));
+        let (patch_h, patch_w) = out[0].patch_grid;
+        assert!(
+            patch_h < VIT_POSITION_TABLE_SIZE && patch_w < VIT_POSITION_TABLE_SIZE,
+            "patch grid {:?} for a {w}x{h} image at budget 1120 must stay inside the \
+             {VIT_POSITION_TABLE_SIZE}-wide position table",
+            (patch_h, patch_w)
+        );
+    }
+}
+
+#[test]
 fn preprocess_with_budget_yields_strictly_increasing_soft_tokens() {
     // Matches every shipped gemma4 checkpoint: patch 16, pooling 3, default 280.
     let processor = Gemma4Processor::new(16, 280, 3);

--- a/src/vision/processors/gemma4_tests.rs
+++ b/src/vision/processors/gemma4_tests.rs
@@ -357,3 +357,173 @@ fn process_videos_pixel_values_match_input_color() {
         "channel 2 (B) mean after de-norm: {mean_b_8bit:.1} != expected {TARGET_B} (±{TOLERANCE})"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Per-request image soft-token budget override (issue #777)
+// ---------------------------------------------------------------------------
+
+/// Emulate the placeholder expansion the runtime performs, so the tests can
+/// assert the prompt's image-token run and the emitted feature rows agree.
+///
+/// Mirrors `vlm_runtime::expand_gemma4_image_tokens`: each image becomes
+/// `<boi>` + `image_token * num_soft_tokens` + `<eoi>`.
+fn expanded_placeholder_count(inputs: &[Gemma4ImageInput], image_token_id: i32) -> usize {
+    const BOI: i32 = -1;
+    const EOI: i32 = -2;
+    let mut expanded: Vec<i32> = Vec::new();
+    for input in inputs {
+        expanded.push(BOI);
+        expanded.extend(std::iter::repeat_n(image_token_id, input.num_soft_tokens));
+        expanded.push(EOI);
+    }
+    expanded.iter().filter(|&&t| t == image_token_id).count()
+}
+
+/// The soft-token count the vision tower will actually emit for an image is
+/// `patch_h * patch_w / pooling_kernel_size^2`. Recompute it straight from the
+/// patch grid so the test does not just re-read the field it is validating.
+fn soft_tokens_from_patch_grid(input: &Gemma4ImageInput, pooling_kernel_size: usize) -> usize {
+    let (patch_h, patch_w) = input.patch_grid;
+    (patch_h * patch_w) / pooling_kernel_size.pow(2)
+}
+
+#[test]
+fn image_soft_token_budget_ladder_is_shared_with_video() {
+    assert_eq!(SUPPORTED_IMAGE_SOFT_TOKENS, SUPPORTED_VIDEO_SOFT_TOKENS);
+    assert_eq!(SUPPORTED_IMAGE_SOFT_TOKENS, &[70, 140, 280, 560, 1120]);
+}
+
+#[test]
+fn preprocess_with_budget_yields_strictly_increasing_soft_tokens() {
+    // Matches every shipped gemma4 checkpoint: patch 16, pooling 3, default 280.
+    let processor = Gemma4Processor::new(16, 280, 3);
+    let image = synthetic_rgb(640, 480, 120);
+
+    let counts: Vec<usize> = [70usize, 280, 1120]
+        .iter()
+        .map(|&budget| {
+            let out = processor.preprocess_with_budget(std::slice::from_ref(&image), Some(budget));
+            assert_eq!(out.len(), 1);
+            out[0].num_soft_tokens
+        })
+        .collect();
+
+    assert!(
+        counts[0] < counts[1] && counts[1] < counts[2],
+        "soft-token counts must strictly increase with the budget, got {counts:?}"
+    );
+    // Each budget is an upper bound, never exceeded.
+    for (&budget, &count) in [70usize, 280, 1120].iter().zip(counts.iter()) {
+        assert!(
+            count <= budget,
+            "budget {budget} produced {count} soft tokens, which exceeds the budget"
+        );
+    }
+}
+
+#[test]
+fn placeholder_expansion_matches_feature_count_at_every_budget() {
+    const IMAGE_TOKEN_ID: i32 = 258_880;
+    let processor = Gemma4Processor::new(16, 280, 3);
+    let image = synthetic_rgb(800, 600, 90);
+
+    for budget in [70usize, 280, 1120] {
+        let processed =
+            processor.preprocess_with_budget(std::slice::from_ref(&image), Some(budget));
+
+        // What the vision tower will emit, derived from the patch grid.
+        let emitted: usize = processed
+            .iter()
+            .map(|input| soft_tokens_from_patch_grid(input, processor.pooling_kernel_size))
+            .sum();
+        // What the prompt will reserve.
+        let placeholders = expanded_placeholder_count(&processed, IMAGE_TOKEN_ID);
+
+        assert_eq!(
+            placeholders, emitted,
+            "budget {budget}: prompt reserves {placeholders} image tokens but the tower emits \
+             {emitted} feature rows; the prompt would desync from the features"
+        );
+    }
+}
+
+#[test]
+fn placeholder_expansion_matches_feature_count_for_multiple_images() {
+    const IMAGE_TOKEN_ID: i32 = 258_880;
+    let processor = Gemma4Processor::new(16, 280, 3);
+    // Different aspect ratios so the per-image counts differ under one budget.
+    let images = vec![
+        synthetic_rgb(640, 480, 30),
+        synthetic_rgb(480, 640, 60),
+        synthetic_rgb(1024, 256, 90),
+    ];
+
+    for budget in [70usize, 560] {
+        let processed = processor.preprocess_with_budget(&images, Some(budget));
+        assert_eq!(processed.len(), 3);
+
+        let emitted: usize = processed
+            .iter()
+            .map(|input| soft_tokens_from_patch_grid(input, processor.pooling_kernel_size))
+            .sum();
+        let placeholders = expanded_placeholder_count(&processed, IMAGE_TOKEN_ID);
+        assert_eq!(placeholders, emitted, "budget {budget}: multi-image desync");
+    }
+}
+
+#[test]
+fn default_path_is_byte_identical_to_configured_budget() {
+    let processor = Gemma4Processor::new(16, 280, 3);
+    let images = vec![synthetic_rgb(640, 480, 120), synthetic_rgb(333, 777, 40)];
+
+    let default_out = processor.preprocess(&images);
+    let none_out = processor.preprocess_with_budget(&images, None);
+    // Explicitly asking for the checkpoint's configured budget must land on the
+    // same result as not asking at all.
+    let explicit_out = processor.preprocess_with_budget(&images, Some(280));
+
+    for i in 0..images.len() {
+        assert_eq!(default_out[i].patch_grid, none_out[i].patch_grid);
+        assert_eq!(
+            default_out[i].num_soft_tokens, none_out[i].num_soft_tokens,
+            "preprocess() and preprocess_with_budget(None) must agree"
+        );
+        assert_eq!(default_out[i].patch_grid, explicit_out[i].patch_grid);
+        assert_eq!(
+            default_out[i].num_soft_tokens,
+            explicit_out[i].num_soft_tokens
+        );
+
+        // Same pixel tensor shape, and byte-identical contents.
+        let lhs = default_out[i].pixel_values.as_ref().unwrap();
+        let rhs = none_out[i].pixel_values.as_ref().unwrap();
+        assert_eq!(mlxcel_core::array_shape(lhs), mlxcel_core::array_shape(rhs));
+        mlxcel_core::eval(lhs);
+        mlxcel_core::eval(rhs);
+        assert_eq!(
+            mlxcel_core::array_to_raw_bytes(lhs),
+            mlxcel_core::array_to_raw_bytes(rhs),
+            "default path must be byte-identical to the pre-override behavior"
+        );
+    }
+}
+
+#[test]
+fn validate_image_soft_tokens_accepts_every_ladder_rung() {
+    for &budget in SUPPORTED_IMAGE_SOFT_TOKENS {
+        assert_eq!(validate_image_soft_tokens(budget), Ok(budget));
+    }
+}
+
+#[test]
+fn validate_image_soft_tokens_rejects_off_ladder_values() {
+    // Zero, an unbounded value, and a plausible-looking near-miss.
+    for bad in [0usize, 1, 281, 2240, usize::MAX] {
+        let err = validate_image_soft_tokens(bad)
+            .expect_err("off-ladder budget must be rejected, not clamped");
+        assert!(
+            err.contains("must be one of"),
+            "error should name the supported values, got: {err}"
+        );
+    }
+}

--- a/src/vision/processors/gemma4_unified.rs
+++ b/src/vision/processors/gemma4_unified.rs
@@ -98,11 +98,39 @@ impl Gemma4UnifiedProcessor {
         self.model_patch_size * self.model_patch_size * 3
     }
 
-    /// Preprocess a batch of images.
+    /// Preprocess a batch of images at the checkpoint's configured budget.
+    ///
+    /// Equivalent to [`Self::preprocess_with_budget`] with `None`.
     pub fn preprocess(&self, images: &[DynamicImage]) -> Vec<Gemma4UnifiedImageInput> {
+        self.preprocess_with_budget(images, None)
+    }
+
+    /// Preprocess a batch of images under an optional per-call soft-token
+    /// budget, shadowing [`Self::num_soft_tokens`] when present.
+    ///
+    /// The ladder this budget is validated against
+    /// ([`crate::vision::processors::gemma4::SUPPORTED_IMAGE_SOFT_TOKENS`])
+    /// tops out at 1120, and the checkpoint's learned 2-D position table is
+    /// `mm_posemb_size = 1120` wide, so the largest grid index a ladder budget
+    /// can produce (`resize_dims` hard-caps `grid_h * grid_w <= budget`, hence a
+    /// single-axis index of at most `budget - 1`) still lands inside the table.
+    /// A budget above the ladder would index past it, which is one more reason
+    /// off-ladder values are rejected rather than clamped.
+    ///
+    /// Callers must derive the prompt's placeholder expansion from the
+    /// `num_soft_tokens` on the returned inputs, not from the budget: the patch
+    /// rows are padded up to the budget while `num_soft_tokens` carries the
+    /// real patch count, and only the latter matches the rows the embedder
+    /// keeps.
+    pub fn preprocess_with_budget(
+        &self,
+        images: &[DynamicImage],
+        num_soft_tokens: Option<usize>,
+    ) -> Vec<Gemma4UnifiedImageInput> {
+        let cap = num_soft_tokens.unwrap_or(self.num_soft_tokens).max(1);
         images
             .iter()
-            .map(|image| self.preprocess_single(image))
+            .map(|image| self.patchify(image, cap))
             .collect()
     }
 
@@ -123,13 +151,9 @@ impl Gemma4UnifiedProcessor {
             .collect()
     }
 
-    fn preprocess_single(&self, image: &DynamicImage) -> Gemma4UnifiedImageInput {
-        self.patchify(image, self.num_soft_tokens)
-    }
-
     /// Patchify one image (or video frame) into flat patch vectors plus grid
     /// positions, capped and padded to `soft_token_cap` rows. Shared by the
-    /// image ([`Self::preprocess_single`]) and video
+    /// image ([`Self::preprocess_with_budget`]) and video
     /// ([`Self::preprocess_video_frames`]) paths so the patch loop lives in one
     /// place; only the soft-token budget differs.
     fn patchify(&self, image: &DynamicImage, soft_token_cap: usize) -> Gemma4UnifiedImageInput {

--- a/src/vision/processors/gemma4_unified_tests.rs
+++ b/src/vision/processors/gemma4_unified_tests.rs
@@ -214,3 +214,136 @@ fn audio_exact_multiple_all_valid() {
         assert!(m, "frame {f} should be valid");
     }
 }
+
+// ---------------------------------------------------------------------------
+// Per-request image soft-token budget override (issue #777)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn preprocess_with_budget_yields_strictly_increasing_soft_tokens() {
+    // Mirrors gemma-4-12b-it-4bit: model_patch_size 48, num_soft_tokens 280.
+    let processor = Gemma4UnifiedProcessor::new(48, 280, 480);
+    let image = solid_image(1400, 900, [200, 40, 40]);
+
+    let counts: Vec<usize> = [70usize, 280, 1120]
+        .iter()
+        .map(|&budget| {
+            let out = processor.preprocess_with_budget(std::slice::from_ref(&image), Some(budget));
+            out[0].num_soft_tokens
+        })
+        .collect();
+
+    assert!(
+        counts[0] < counts[1] && counts[1] < counts[2],
+        "soft-token counts must strictly increase with the budget, got {counts:?}"
+    );
+    for (&budget, &count) in [70usize, 280, 1120].iter().zip(counts.iter()) {
+        assert!(
+            count <= budget,
+            "budget {budget} produced {count} soft tokens"
+        );
+    }
+}
+
+#[test]
+fn budget_padded_rows_match_the_budget_while_real_count_is_the_patch_count() {
+    // The unified path pads `patches`/`positions` up to the budget while
+    // `num_soft_tokens` carries the REAL patch count. The prompt's placeholder
+    // expansion is driven by the latter, so the two must not be conflated.
+    let processor = Gemma4UnifiedProcessor::new(48, 280, 480);
+    let image = solid_image(1400, 900, [10, 200, 10]);
+
+    for budget in [70usize, 280, 1120] {
+        let out = processor.preprocess_with_budget(std::slice::from_ref(&image), Some(budget));
+        let shape = mlxcel_core::array_shape(out[0].patches.as_ref().unwrap());
+        assert_eq!(
+            shape[0] as usize, budget,
+            "patch rows are padded up to the budget"
+        );
+        assert!(
+            out[0].num_soft_tokens <= budget,
+            "the real patch count never exceeds the budget"
+        );
+    }
+}
+
+#[test]
+fn grid_positions_stay_inside_the_learned_position_table_at_max_budget() {
+    // The learned 2-D position table is `mm_posemb_size` (1120) wide and is
+    // indexed by the raw (x, y) grid coordinate. An index at or past the table
+    // would wrap under MLX `take` semantics and silently produce garbage, so
+    // the top of the ladder must stay strictly inside it. This is the invariant
+    // that makes 1120 the highest safe budget.
+    const MM_POSEMB_SIZE: i32 = 1120;
+    let processor = Gemma4UnifiedProcessor::new(48, 280, 480);
+
+    // Extreme aspect ratios push one axis as far as the resize will allow.
+    for image in [
+        solid_image(4000, 60, [1, 2, 3]),
+        solid_image(60, 4000, [3, 2, 1]),
+        solid_image(1400, 900, [9, 9, 9]),
+    ] {
+        let out = processor.preprocess_with_budget(std::slice::from_ref(&image), Some(1120));
+        let positions = out[0].positions.as_ref().unwrap();
+        let rows = mlxcel_core::array_shape(positions)[0];
+        let mut max_pos = -1i32;
+        for r in 0..rows {
+            for axis in 0..2 {
+                max_pos = max_pos.max(read_i32_at(positions, &[r, axis]));
+            }
+        }
+        assert!(
+            max_pos < MM_POSEMB_SIZE,
+            "grid position {max_pos} would index past the {MM_POSEMB_SIZE}-wide position table"
+        );
+    }
+}
+
+#[test]
+fn default_path_is_unchanged_by_the_override_plumbing() {
+    let processor = Gemma4UnifiedProcessor::new(48, 280, 480);
+    let images = vec![
+        solid_image(640, 480, [120, 120, 120]),
+        solid_image(333, 777, [40, 90, 10]),
+    ];
+
+    let default_out = processor.preprocess(&images);
+    let none_out = processor.preprocess_with_budget(&images, None);
+    let explicit_out = processor.preprocess_with_budget(&images, Some(280));
+
+    for i in 0..images.len() {
+        assert_eq!(default_out[i].num_soft_tokens, none_out[i].num_soft_tokens);
+        assert_eq!(
+            default_out[i].num_soft_tokens,
+            explicit_out[i].num_soft_tokens
+        );
+
+        let lhs = default_out[i].patches.as_ref().unwrap();
+        let rhs = none_out[i].patches.as_ref().unwrap();
+        mlxcel_core::eval(lhs);
+        mlxcel_core::eval(rhs);
+        assert_eq!(
+            mlxcel_core::array_to_raw_bytes(lhs),
+            mlxcel_core::array_to_raw_bytes(rhs),
+            "preprocess() must stay byte-identical to preprocess_with_budget(None)"
+        );
+    }
+}
+
+#[test]
+fn video_frame_budget_is_untouched_by_the_image_override() {
+    // `--image-soft-tokens` / `detail` must not leak into the per-frame video
+    // budget, which is a separate (smaller) dial.
+    let processor = Gemma4UnifiedProcessor::new(48, 280, 480);
+    let frames = vec![solid_image(640, 480, [5, 5, 5])];
+
+    let baseline = processor.preprocess_video_frames(&frames);
+    let after_image_override = {
+        let _ = processor.preprocess_with_budget(&frames, Some(1120));
+        processor.preprocess_video_frames(&frames)
+    };
+    assert_eq!(
+        baseline[0].num_soft_tokens,
+        after_image_override[0].num_soft_tokens
+    );
+}

--- a/tests/pipeline_ci_multi_stage_real_models.rs
+++ b/tests/pipeline_ci_multi_stage_real_models.rs
@@ -258,6 +258,7 @@ fn assert_multi_stage_coordinator_matches_dense_baseline(
         thinking_enter_block_on_start: false,
         prompt_cache_ctx: None,
         structured: None,
+        image_soft_tokens: None,
     };
 
     let dense = dense_provider

--- a/tests/pipeline_server_remote_real_models.rs
+++ b/tests/pipeline_server_remote_real_models.rs
@@ -137,6 +137,7 @@ fn assert_remote_coordinator_matches_dense_baseline(
         thinking_enter_block_on_start: false,
         prompt_cache_ctx: None,
         structured: None,
+        image_soft_tokens: None,
     };
 
     let dense = dense_provider

--- a/tests/structured_outputs.rs
+++ b/tests/structured_outputs.rs
@@ -264,6 +264,7 @@ fn end_to_end_constrained_chat_completion_emits_schema_conforming_json() {
         thinking_enter_block_on_start: false,
         prompt_cache_ctx: None,
         structured: Some(constraint),
+        image_soft_tokens: None,
     };
 
     let result = provider

--- a/tests/zero_config_cluster_init.rs
+++ b/tests/zero_config_cluster_init.rs
@@ -249,6 +249,7 @@ fn zero_config_two_stage_cluster_matches_dense_baseline() {
         thinking_enter_block_on_start: false,
         prompt_cache_ctx: None,
         structured: None,
+        image_soft_tokens: None,
     };
 
     let dense = dense_provider


### PR DESCRIPTION
## Summary

Gemma 4's image soft-token budget was fixed at load time from the checkpoint config, so callers had no way to trade prompt length for image detail. Both Gemma 4 front-ends are resolution-driven, so the budget can be varied per request with no tower change. This adds the dial to the server wire format and the CLI.

## Wire schema

Two optional fields on the `image_url` content part. Both are `Option` + `#[serde(default)]` and are omitted on serialize, so a request that sends only `url` is byte-identical in behavior to before.

```jsonc
{"type": "image_url", "image_url": {
  "url": "data:image/png;base64,...",
  "detail": "high",          // OpenAI-standard: "low" -> 70, "high" -> 1120, "auto"/absent -> checkpoint default
  "max_soft_tokens": 560     // mlxcel EXTENSION (not OpenAI): exact budget; wins over `detail` when both are present
}}
```

CLI equivalent: `mlxcel generate --image-soft-tokens <N>`, same ladder and same validation.

Supported ladder (shared by images and video): `[70, 140, 280, 560, 1120]`. 280 is the default for every shipped Gemma 4 checkpoint.

## Scope correction worth flagging in review

The issue premise pinned `src/loading/vlm_gemma.rs` + `src/vision/processors/gemma4.rs`, which is the `gemma4` (ViT tower) path. While validating I found that the flagship local checkpoint `gemma-4-12b-it-4bit` is actually `Gemma4UnifiedForConditionalGeneration` (`model_type: gemma4_unified`) and routes through a **different** processor (`Gemma4UnifiedProcessor`), so the dial was a silent no-op on it. Since silently ignoring `detail` is exactly the failure mode this feature is meant to avoid, `gemma4_unified` is wired too. Its `patchify` already took a budget parameter, so the change is small. I confirmed its learned 2-D position table is `mm_posemb_size = 1120`, exactly the top of the ladder, and `resize_dims` hard-caps `grid_h * grid_w <= budget`, so every ladder budget stays inside the table (there is a regression test pinning this).

## Security

`max_soft_tokens` and `detail` are untrusted request input, and the budget scales the resized image, its patch grid, and the injected prompt tokens. Both are validated against the ladder and rejected with a 400 rather than clamped: a silent clamp would hand back a budget the caller did not ask for, and an unbounded budget is a memory-amplification vector. An unknown `detail` is a 400 too, not a silent fallback to `"auto"`. For `gemma4_unified` an off-ladder budget would additionally index past the 1120-wide position table (MLX `take` wraps rather than faulting), so the ladder check is load-bearing, not cosmetic.

## Keeping placeholder expansion in lockstep with the features

The prompt's image-token run is always derived from the `num_soft_tokens` that the same `preprocess_with_budget` call actually produced, never recomputed from the budget. The resize rounds the patch grid down to a multiple of the pooling stride, so a count derived from the budget would overshoot and desync the prompt from the emitted feature rows.

## Vision-cache correctness fix

The per-image vision-feature cache key was `sha256(image_bytes)`. The cached value is the vision front-end's output, which now differs per budget for identical bytes, so the same image at budget 70 and 1120 would have collided and served one budget's features to the other request. Keys now fold the budget in via `image_hash_from_bytes_with_soft_tokens`; with no override the key is bit-identical to before.

## What changed

- `src/vision/processors/gemma4.rs`: shared `SUPPORTED_SOFT_TOKENS` ladder with `SUPPORTED_IMAGE_SOFT_TOKENS` / `SUPPORTED_VIDEO_SOFT_TOKENS` aliases, `validate_image_soft_tokens()`, and `preprocess_with_budget()`; `aspect_ratio_preserving_resize_dims` takes an `Option<usize>` that shadows `self.max_soft_tokens`.
- `src/vision/processors/gemma4_unified.rs`: `preprocess_with_budget()` (delegates to the existing budget-taking `patchify`); `preprocess()` now delegates with `None`.
- `src/server/types/request.rs`: `ImageUrl { detail, max_soft_tokens }`, `ImageUrl::new()`, `resolve_soft_token_budget()`, `resolve_request_image_soft_tokens()`, and `image_parts()` / `image_soft_tokens()` accessors.
- `src/server/chat_request.rs`: resolves and validates the budget at the request boundary (before any image is fetched or decoded) onto `PreparedChatRequest`.
- `src/server/config.rs` + routes (`chat`, `responses`, `anthropic`): `ServerGenerateOptions::image_soft_tokens`, threaded from the resolved request.
- `src/server/batch/scheduler.rs`, `src/server/model_worker.rs`, `src/multimodal/vlm_runtime.rs`: threading, including the Gemma 4 audio and video companion-image paths; `prepare_and_compute_vlm_embeddings_with_budget()` added, the existing 5-arg entry point kept unchanged.
- `src/vision/feature_cache.rs`: `image_hash_from_bytes_with_soft_tokens()`.
- `src/main.rs` + `src/commands/generate{,_vlm}.rs`: `--image-soft-tokens`, validated before the model loads.
- `docs/supported-models.md`: new "Gemma 4 image soft-token budget" section covering both fields, the ladder, both architectures, and the CLI flag.

## Test plan

- [x] `cargo test --lib vision::processors::gemma4` (32 passed): strictly increasing soft tokens across 70/280/1120; placeholder expansion equals the feature count at every budget, single and multi-image; default path byte-identical to `preprocess()`; off-ladder budgets rejected; unified grid positions stay inside the 1120-wide position table; video per-frame budget unaffected by the image override.
- [x] `cargo test --lib server::types` (64 passed): `detail` low/high/auto, case-insensitivity, unknown `detail` rejected, exact `max_soft_tokens` on every rung, off-ladder numeric rejected, numeric wins over `detail`, conflicting parts rejected, and a bare `url` still round-trips without emitting null budget fields.
- [x] `cargo test --lib server::chat_request` (53), `server::media` (26), `server::anthropic_translator` (31), `server::request_options` (12), `vision::feature_cache` (10).
- [x] `cargo clippy --lib --bins --tests -- -D warnings` clean; `cargo fmt --all --check` clean.
- [x] Real checkpoint, `gemma-4-12b-it-4bit` (`gemma4_unified`) on a synthetic receipt with fine print. Budget 70 (89 prompt tokens) reads the total as "2,024.55" and hallucinates the fine-print line as "Line Item 07: $100.00". Budget 1120 (1095 prompt tokens) returns the exact ground truth: "2,024.50" and "serial 8F-3042 rev C tolerance 0.02mm lot QA-106 inspected OK".
- [x] Real checkpoint, `gemma-4-e2b-it-4bit` (`gemma4`): 84 / 284 / 1090 prompt tokens at 70 / 280 / 1120.
- [x] Default path unchanged: with no flag, both architectures still expand to 280 tokens.
- [x] `--image-soft-tokens 999` is rejected before the model loads: `image max_soft_tokens must be one of [70, 140, 280, 560, 1120], got 999`.

Closes #777
