### PR TITLE
ci: drop broken log-level input from cargo-deny-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check
-          log-level: warn
 
   fmt:
     name: cargo-fmt


### PR DESCRIPTION
## Summary

CI's `cargo-deny` job fails on every PR and on `main` with `error: unrecognized subcommand 'warn'`. `EmbarkStudios/cargo-deny-action@v2` now installs cargo-deny 0.20.2, whose CLI change makes the `log-level: warn` input mis-invoke the tool as `cargo-deny warn ...` instead of a valid log-level flag.

## Fix

Drop the `log-level: warn` input from the `cargo-deny-action` step in `.github/workflows/ci.yml`. It only controlled log verbosity; the action then runs the standard `cargo-deny check`. This PR's own `cargo-deny` check validates the fix.