### PR TITLE
fix(mlxcel-core): drop needless borrow on march flag in build script

### DIFF
--- a/src/lib/mlxcel-core/build.rs
+++ b/src/lib/mlxcel-core/build.rs
@@ -87,7 +87,7 @@ fn main() {
             }
             Ok("none") => {}
             Ok(march) => {
-                bridge.flag_if_supported(&format!("-march={march}"));
+                bridge.flag_if_supported(format!("-march={march}"));
             }
         }
         // On macOS, Clang produces LLVM bitcode with -flto, which is compatible


### PR DESCRIPTION
## Summary

`bridge.flag_if_supported(&format!("-march={march}"))` in `src/lib/mlxcel-core/build.rs` passes a needless borrow: `flag_if_supported` takes `AsRef<str>`, so `&format!(...)` trips `clippy::needless_borrows_for_generic_args` under `-D warnings`.

## Why CI never caught it

The lint only fires when the `-march` branch actually compiles, i.e. when `MLXCEL_CXX_MARCH` is set to a concrete arch, which is exercised by a local `--features cuda` build on this arch. The ubuntu PR CI does not build with cuda, so the branch is cfg-inactive there and the lint stays dormant.

## Fix

Pass the owned `String` directly. Verified with a full-workspace `cargo clippy --release --lib --tests --features cuda -- -D warnings` (clean) and `cargo fmt --all -- --check` (clean).