### PR TITLE
fix(gemma4): restore E-series Conformer audio parity with the reference pipeline

### DIFF
--- a/src/audio/encoder.rs
+++ b/src/audio/encoder.rs
@@ -32,6 +32,20 @@ fn copy_weight(weights: &WeightMap, key: &str) -> Result<UniquePtr<MlxArray>, St
         .ok_or_else(|| format!("Audio weight not found: {key}"))
 }
 
+/// Debug probe: dump an intermediate activation as raw f32 + shape when
+/// `MLXCEL_AUDIO_PROBE_DIR` is set. Used for parity diffing against the
+/// reference implementation; no-op in normal operation.
+pub(crate) fn audio_probe_dump(name: &str, arr: &MlxArray) {
+    if let Ok(dir) = std::env::var("MLXCEL_AUDIO_PROBE_DIR") {
+        let arr_f32 = mlxcel_core::astype(arr, mlxcel_core::dtype::FLOAT32);
+        mlxcel_core::eval(&arr_f32);
+        let bytes = mlxcel_core::array_to_raw_bytes(&arr_f32);
+        let shape = mlxcel_core::array_shape(&arr_f32);
+        let _ = std::fs::write(format!("{dir}/{name}.f32"), &bytes);
+        let _ = std::fs::write(format!("{dir}/{name}.shape"), format!("{shape:?}"));
+    }
+}
+
 // ---------------------------------------------------------------------------
 // AudioRMSNorm: weight applied directly (no +1 offset like Gemma text RMSNorm)
 // ---------------------------------------------------------------------------
@@ -55,12 +69,20 @@ impl AudioRMSNorm {
 }
 
 // ---------------------------------------------------------------------------
-// ClippableLinear: loads `linear.weight` as regular UnifiedLinear, skips
-// input_max/min/output_max/min (training artifacts, not used at inference).
+// ClippableLinear: `linear.weight` plus the checkpoint's input/output clamp
+// bounds. The Gemma 4 audio checkpoints ship FINITE per-layer bounds (for
+// example lconv1d.linear_end input is clamped to roughly +-5.8 while block
+// activations reach far larger tails), and the reference implementation
+// clamps input and output at inference, so the clamps are part of the
+// trained function. Skipping them decorrelates the Conformer stack: the
+// per-block error compounds from ~8% relative RMS after block 0 to ~95%
+// after block 11 (issue #782).
 // ---------------------------------------------------------------------------
 
 pub(crate) struct AudioLinear {
     linear: UnifiedLinear,
+    input_bounds: Option<(UniquePtr<MlxArray>, UniquePtr<MlxArray>)>,
+    output_bounds: Option<(UniquePtr<MlxArray>, UniquePtr<MlxArray>)>,
 }
 
 impl AudioLinear {
@@ -70,6 +92,11 @@ impl AudioLinear {
         group_size: i32,
         bits: i32,
     ) -> Result<Self, String> {
+        let bounds =
+            |min_key: &str, max_key: &str| match (weights.get(min_key), weights.get(max_key)) {
+                (Some(min), Some(max)) => Some((mlxcel_core::copy(min), mlxcel_core::copy(max))),
+                _ => None,
+            };
         Ok(Self {
             linear: UnifiedLinear::from_weights(
                 weights,
@@ -77,11 +104,31 @@ impl AudioLinear {
                 group_size,
                 bits,
             )?,
+            input_bounds: bounds(
+                &format!("{prefix}.input_min"),
+                &format!("{prefix}.input_max"),
+            ),
+            output_bounds: bounds(
+                &format!("{prefix}.output_min"),
+                &format!("{prefix}.output_max"),
+            ),
         })
     }
 
     pub(crate) fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
-        self.linear.forward(x)
+        let clipped_input;
+        let x = if let Some((min, max)) = &self.input_bounds {
+            clipped_input = mlxcel_core::clip(x, min, max);
+            clipped_input.as_ref().unwrap()
+        } else {
+            x
+        };
+        let y = self.linear.forward(x);
+        if let Some((min, max)) = &self.output_bounds {
+            mlxcel_core::clip(&y, min, max)
+        } else {
+            y
+        }
     }
 }
 
@@ -591,14 +638,21 @@ impl AudioEncoder {
         audio_mel: &MlxArray,
         audio_mel_mask: &MlxArray,
     ) -> Result<(UniquePtr<MlxArray>, UniquePtr<MlxArray>), String> {
+        audio_probe_dump("in_mel", audio_mel);
+        audio_probe_dump(
+            "in_mask",
+            &mlxcel_core::astype(audio_mel_mask, mlxcel_core::dtype::FLOAT32),
+        );
         let (mut encodings, mut current_mask) = self
             .subsample_conv_projection
             .forward(audio_mel, audio_mel_mask)?;
+        audio_probe_dump("sscp_out", &encodings);
 
         let causal_valid_mask = self.build_causal_valid_mask();
 
-        for block in &self.layers {
+        for (idx, block) in self.layers.iter().enumerate() {
             encodings = block.forward(&encodings, &current_mask, &causal_valid_mask)?;
+            audio_probe_dump(&format!("block_{idx:02}"), &encodings);
         }
 
         // Output projection (with bias)
@@ -621,7 +675,12 @@ impl AudioEncoder {
         let mask_expanded = mlxcel_core::reshape(&current_mask, &[batch, enc_t, 1]);
         let zeros = mlxcel_core::zeros_like(&encodings);
         encodings = mlxcel_core::where_cond(&mask_expanded, &zeros, &encodings);
+        audio_probe_dump("tower_out", &encodings);
 
         Ok((encodings, current_mask))
     }
 }
+
+#[cfg(test)]
+#[path = "encoder_tests.rs"]
+mod tests;

--- a/src/audio/encoder_tests.rs
+++ b/src/audio/encoder_tests.rs
@@ -1,0 +1,100 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::AudioLinear;
+use mlxcel_core::weights::WeightMap;
+
+fn identity_weight(dim: usize) -> mlxcel_core::UniquePtr<mlxcel_core::MlxArray> {
+    let mut data = vec![0.0f32; dim * dim];
+    for i in 0..dim {
+        data[i * dim + i] = 1.0;
+    }
+    mlxcel_core::from_slice_f32(&data, &[dim as i32, dim as i32])
+}
+
+fn to_vec_f32(arr: &mlxcel_core::MlxArray) -> Vec<f32> {
+    let arr = mlxcel_core::astype(arr, mlxcel_core::dtype::FLOAT32);
+    mlxcel_core::eval(&arr);
+    mlxcel_core::array_to_raw_bytes(&arr)
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
+        .collect()
+}
+
+/// The Gemma 4 audio checkpoints ship finite input/output clamp bounds for
+/// every ClippableLinear, and the reference implementation applies them at
+/// inference. Skipping them decorrelates the Conformer stack (issue #782):
+/// the per-block error compounds from ~8% relative RMS after block 0 to ~95%
+/// after block 11 on a real clip. This test locks the clamp semantics in.
+#[test]
+fn audio_linear_applies_checkpoint_clip_bounds() {
+    let mut weights = WeightMap::new();
+    weights.insert(
+        "clip.linear.weight".to_string(),
+        mlxcel_core::copy(&identity_weight(4)),
+    );
+    weights.insert(
+        "clip.input_min".to_string(),
+        mlxcel_core::from_slice_f32(&[-1.0], &[1]),
+    );
+    weights.insert(
+        "clip.input_max".to_string(),
+        mlxcel_core::from_slice_f32(&[1.0], &[1]),
+    );
+    weights.insert(
+        "clip.output_min".to_string(),
+        mlxcel_core::from_slice_f32(&[-0.5], &[1]),
+    );
+    weights.insert(
+        "clip.output_max".to_string(),
+        mlxcel_core::from_slice_f32(&[0.5], &[1]),
+    );
+
+    let layer = AudioLinear::from_weights(&weights, "clip", 64, 4).expect("clippable linear");
+    let x = mlxcel_core::from_slice_f32(&[2.0, -3.0, 0.3, 0.9], &[1, 4]);
+    let y = to_vec_f32(&layer.forward(&x));
+
+    // Input clamps to [-1, 1] -> identity matmul -> output clamps to [-0.5, 0.5]:
+    // 2.0 -> 1.0 -> 0.5; -3.0 -> -1.0 -> -0.5; 0.3 passes through; 0.9 -> 0.5.
+    let expected = [0.5, -0.5, 0.3, 0.5];
+    for (actual, expected) in y.iter().zip(expected) {
+        assert!(
+            (actual - expected).abs() < 1e-6,
+            "clipped output {y:?} != expected {expected:?}"
+        );
+    }
+}
+
+/// Without bound tensors in the checkpoint the layer must behave as a plain
+/// linear (clamping disabled), so non-clippable checkpoints keep working.
+#[test]
+fn audio_linear_without_bounds_is_plain_linear() {
+    let mut weights = WeightMap::new();
+    weights.insert(
+        "plain.linear.weight".to_string(),
+        mlxcel_core::copy(&identity_weight(4)),
+    );
+
+    let layer = AudioLinear::from_weights(&weights, "plain", 64, 4).expect("plain linear");
+    let x = mlxcel_core::from_slice_f32(&[2.0, -3.0, 0.3, 0.9], &[1, 4]);
+    let y = to_vec_f32(&layer.forward(&x));
+
+    let expected = [2.0, -3.0, 0.3, 0.9];
+    for (actual, expected) in y.iter().zip(expected) {
+        assert!(
+            (actual - expected).abs() < 1e-6,
+            "passthrough output {y:?} != expected {expected:?}"
+        );
+    }
+}

--- a/src/audio/feature_extractor.rs
+++ b/src/audio/feature_extractor.rs
@@ -66,6 +66,14 @@ fn mel_filter_bank(
 }
 
 /// Audio feature extractor configuration.
+///
+/// Field names and defaults mirror the reference `Gemma4AudioFeatureExtractor`
+/// (https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4/audio_feature_extractor.py),
+/// so a `feature_extractor` block from a checkpoint's `processor_config.json`
+/// deserializes directly. Any field absent from the block keeps the reference
+/// default.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(default)]
 pub struct AudioFeatureExtractorConfig {
     pub feature_size: usize,
     pub sampling_rate: u32,
@@ -79,6 +87,8 @@ pub struct AudioFeatureExtractorConfig {
     pub fft_overdrive: bool,
     pub input_scale_factor: f64,
     pub mel_floor: f64,
+    pub per_bin_mean: Option<Vec<f64>>,
+    pub per_bin_stddev: Option<Vec<f64>>,
 }
 
 impl Default for AudioFeatureExtractorConfig {
@@ -93,10 +103,33 @@ impl Default for AudioFeatureExtractorConfig {
             max_frequency: 8000.0,
             preemphasis: 0.0,
             preemphasis_htk_flavor: true,
-            fft_overdrive: true,
+            // The published Gemma 4 E-series checkpoints ship no
+            // `feature_extractor` block, so this default IS the effective
+            // config. The reference extractor defaults to `false`
+            // (fft_length 512 for the 20 ms / 320-sample frame); `true`
+            // (fft_length 1024) shifts every log-mel value by ~ln 2 and
+            // changes the fine spectral structure, which garbles the
+            // Conformer's perception (issue #782).
+            fft_overdrive: false,
             input_scale_factor: 1.0,
             mel_floor: 1e-3,
+            per_bin_mean: None,
+            per_bin_stddev: None,
         }
+    }
+}
+
+impl AudioFeatureExtractorConfig {
+    /// Build the config from a checkpoint's `processor_config.json` value.
+    ///
+    /// Reads the optional `feature_extractor` block; missing file, missing
+    /// block, or a malformed block all fall back to the reference defaults so
+    /// existing checkpoints keep working.
+    pub fn from_processor_config(processor_config: Option<&serde_json::Value>) -> Self {
+        processor_config
+            .and_then(|config| config.get("feature_extractor"))
+            .and_then(|block| serde_json::from_value(block.clone()).ok())
+            .unwrap_or_default()
     }
 }
 
@@ -116,6 +149,8 @@ pub struct AudioFeatureExtractor {
     fft_length: usize,
     window: Vec<f32>,
     mel_filters: Vec<f32>, // [fft_length/2 + 1, feature_size]
+    per_bin_mean: Option<Vec<f64>>,
+    per_bin_stddev: Option<Vec<f64>>,
 }
 
 impl AudioFeatureExtractor {
@@ -151,6 +186,15 @@ impl AudioFeatureExtractor {
             config.sampling_rate,
         );
 
+        // Per-bin normalization vectors must cover every mel bin; a
+        // wrong-length vector from a malformed config block is ignored.
+        let per_bin_mean = config
+            .per_bin_mean
+            .filter(|mean| mean.len() == config.feature_size);
+        let per_bin_stddev = config
+            .per_bin_stddev
+            .filter(|stddev| stddev.len() == config.feature_size);
+
         Self {
             feature_size: config.feature_size,
             sampling_rate: config.sampling_rate,
@@ -164,6 +208,8 @@ impl AudioFeatureExtractor {
             fft_length,
             window,
             mel_filters,
+            per_bin_mean,
+            per_bin_stddev,
         }
     }
 
@@ -209,14 +255,13 @@ impl AudioFeatureExtractor {
             }
         }
 
-        // Frame extraction with preemphasis.
-        // Non-HTK preemphasis reads frame_data[i+1], so needs frame_length+1
-        // samples per window. HTK flavor and no-preemphasis only need frame_length.
-        let frame_size_for_unfold = if self.preemphasis > 0.0 && !self.preemphasis_htk_flavor {
-            self.frame_length + 1
-        } else {
-            self.frame_length
-        };
+        // Frame extraction. The reference unfolds frame_length + 1 samples per
+        // window regardless of preemphasis (the trailing sample feeds the
+        // preemphasis difference; without preemphasis it is dropped), so the
+        // frame count is (total_len - frame_length - 1) / hop + 1. Unfolding
+        // only frame_length samples would emit one extra frame whenever
+        // total_len is a multiple of the hop.
+        let frame_size_for_unfold = self.frame_length + 1;
         let num_frames = if total_len >= frame_size_for_unfold {
             (total_len - frame_size_for_unfold) / self.hop_length + 1
         } else {
@@ -277,16 +322,38 @@ impl AudioFeatureExtractor {
                     mel_val +=
                         mag * self.mel_filters[freq_idx * self.feature_size + mel_idx] as f64;
                 }
-                // Log with floor
-                let log_mel = mel_val.max(self.mel_floor).ln() as f32;
-                features[frame_idx * self.feature_size + mel_idx] = log_mel;
+                // Additive log floor, log(mel + floor), matching the
+                // reference. A hard clamp, log(max(mel, floor)), differs by
+                // up to ln 2 on low-energy bins.
+                let mut log_mel = (mel_val + self.mel_floor).ln();
+                if let Some(mean) = &self.per_bin_mean {
+                    log_mel -= mean[mel_idx];
+                }
+                if let Some(stddev) = &self.per_bin_stddev {
+                    log_mel /= stddev[mel_idx];
+                }
+                features[frame_idx * self.feature_size + mel_idx] = log_mel as f32;
             }
         }
 
-        // Downsample attention mask by hop_length
+        // A frame is valid only when every sample in its analysis window
+        // [i*hop, i*hop + frame_size_for_unfold - 1] is real audio; the
+        // reference checks the window's LAST sample. Checking the first
+        // sample instead would wrongly invalidate frame 0 (whose window
+        // starts inside the structural left-pad) and wrongly validate tail
+        // frames that straddle the right padding.
         let frame_mask: Vec<bool> = (0..num_frames)
-            .map(|i| attn_mask[i * self.hop_length] == 0)
+            .map(|i| attn_mask[i * self.hop_length + frame_size_for_unfold - 1] == 0)
             .collect();
+
+        // Zero out padded (invalid) frames, matching the reference's
+        // `spec * mask` so the encoder receives identical input.
+        for (frame_idx, &invalid) in frame_mask.iter().enumerate() {
+            if invalid {
+                features[frame_idx * self.feature_size..(frame_idx + 1) * self.feature_size]
+                    .fill(0.0);
+            }
+        }
 
         (features, frame_mask)
     }
@@ -490,10 +557,15 @@ mod tests {
 
     /// Test that the semicausal left-pad produces the correct frame count.
     ///
-    /// A 1-second 440 Hz tone at 16 kHz should produce exactly 100 frames with
-    /// a 10 ms hop and 20 ms frame (frame_length=320, hop_length=160, left_pad=160):
+    /// A 1-second 440 Hz tone at 16 kHz should produce exactly 99 frames with
+    /// a 10 ms hop and 20 ms frame (frame_length=320, hop_length=160,
+    /// left_pad=160). The reference unfolds frame_length + 1 = 321 samples
+    /// per window:
     ///   total_len = 160 + 16000 = 16160
-    ///   num_frames = (16160 - 320) / 160 + 1 = 100
+    ///   num_frames = (16160 - 321) / 160 + 1 = 99
+    ///
+    /// Unfolding only 320 samples would yield a 100th frame here, one more
+    /// than the reference emits (issue #782).
     #[test]
     fn test_semicausal_left_pad_frame_count() {
         let tone = generate_tone(440.0, 1.0, 16_000);
@@ -501,10 +573,158 @@ mod tests {
         let (features, mask) = extractor.extract(&tone, None);
         let num_frames = features.len() / extractor.feature_size();
         assert_eq!(
-            num_frames, 100,
-            "expected 100 frames for 1s audio with left-pad, got {num_frames}"
+            num_frames, 99,
+            "expected 99 frames for 1s audio with left-pad, got {num_frames}"
         );
-        assert_eq!(mask.len(), 100, "mask length must equal num_frames");
+        assert_eq!(mask.len(), 99, "mask length must equal num_frames");
+        assert!(
+            mask.iter().all(|&invalid| !invalid),
+            "no frame of an unpadded 1s clip may be marked invalid"
+        );
+    }
+
+    /// The default config must match the reference `Gemma4AudioFeatureExtractor`
+    /// defaults. The published Gemma 4 E-series checkpoints ship no
+    /// `feature_extractor` block, so these defaults are the effective config;
+    /// `fft_overdrive = true` (fft_length 1024) garbles the Conformer's
+    /// perception (issue #782).
+    #[test]
+    fn test_default_config_matches_reference() {
+        let config = AudioFeatureExtractorConfig::default();
+        assert!(
+            !config.fft_overdrive,
+            "reference default is fft_overdrive=false"
+        );
+        let extractor = AudioFeatureExtractor::new(config);
+        assert_eq!(
+            extractor.fft_length, 512,
+            "20ms/320-sample frame -> fft 512"
+        );
+        assert_eq!(extractor.frame_length, 320);
+        assert_eq!(extractor.hop_length, 160);
+        assert_eq!(extractor.feature_size, 128);
+    }
+
+    /// Golden log-mel check against the reference extractor.
+    ///
+    /// The probe values were produced by running the HF/mlx-vlm reference
+    /// `Gemma4AudioFeatureExtractor` (default config) over this exact
+    /// waveform: a 1 s f64 sine mixture cast to f32,
+    ///   0.4*sin(2*pi*440*i/16000) + 0.2*sin(2*pi*1000*i/16000)
+    ///   + 0.1*sin(2*pi*3200*i/16000).
+    ///
+    /// The 1e-3 tolerance is far below the smallest semantic divergence this
+    /// guards against (the additive-vs-clamp mel floor differs by up to
+    /// ~0.69 = ln 2 per bin; fft_overdrive shifts every bin by ~ln 2) while
+    /// leaving room for f32 rounding and libm differences.
+    #[test]
+    fn test_golden_log_mel_matches_reference() {
+        let n = 16_000;
+        let waveform: Vec<f32> = (0..n)
+            .map(|i| {
+                let t = i as f64 / 16_000.0;
+                (0.4 * (2.0 * PI * 440.0 * t).sin()
+                    + 0.2 * (2.0 * PI * 1000.0 * t).sin()
+                    + 0.1 * (2.0 * PI * 3200.0 * t).sin()) as f32
+            })
+            .collect();
+
+        let extractor = AudioFeatureExtractor::new(AudioFeatureExtractorConfig::default());
+        let (features, mask) = extractor.extract(&waveform, None);
+        let feature_size = extractor.feature_size();
+        assert_eq!(mask.len(), 99);
+        assert_eq!(features.len(), 99 * feature_size);
+
+        // (frame, mel_bin) -> reference value. The -6.907755 = ln(1e-3)
+        // entries probe the additive mel floor on near-zero-energy bins.
+        let golden: &[(usize, usize, f32)] = &[
+            (0, 0, -6.907755),
+            (0, 25, 2.3889),
+            (0, 64, -0.843163),
+            (0, 127, -0.936063),
+            (10, 3, -4.119002),
+            (25, 25, 2.974617),
+            (50, 40, -1.472469),
+            (50, 90, -3.042887),
+            (80, 10, -4.155638),
+            (90, 70, -6.709886),
+            (98, 0, -6.907755),
+            (98, 127, -6.883512),
+        ];
+        for &(frame, bin, expected) in golden {
+            let actual = features[frame * feature_size + bin];
+            assert!(
+                (actual - expected).abs() < 1e-3,
+                "features[{frame}][{bin}] = {actual}, reference = {expected}"
+            );
+        }
+
+        let mean: f64 = features.iter().map(|&v| v as f64).sum::<f64>() / features.len() as f64;
+        assert!(
+            (mean - (-3.93961)).abs() < 1e-3,
+            "global feature mean {mean} deviates from reference -3.93961"
+        );
+    }
+
+    /// A clip needing right-padding (15000 samples pads to 15104, a multiple
+    /// of 128) must mark exactly the tail frame whose analysis window
+    /// straddles the padding as invalid, zero that feature row, and keep
+    /// frame 0 (whose window starts inside the structural left-pad) valid.
+    /// Matches the reference, which checks the LAST sample of each window
+    /// and multiplies the spectrogram by the mask.
+    #[test]
+    fn test_tail_padding_mask_and_zeroing() {
+        let waveform = generate_tone(440.0, 0.9375, 16_000); // 15000 samples
+        assert_eq!(waveform.len(), 15_000);
+        let extractor = AudioFeatureExtractor::new(AudioFeatureExtractorConfig::default());
+        let (features, mask) = extractor.extract(&waveform, None);
+        let feature_size = extractor.feature_size();
+        assert_eq!(mask.len(), 94, "(160 + 15104 - 321) / 160 + 1 = 94 frames");
+        assert!(!mask[0], "frame 0 must be valid despite the left-pad");
+        let invalid: Vec<usize> = (0..mask.len()).filter(|&i| mask[i]).collect();
+        assert_eq!(invalid, vec![93], "only the tail frame is invalid");
+        assert!(
+            features[93 * feature_size..94 * feature_size]
+                .iter()
+                .all(|&v| v == 0.0),
+            "invalid frame's features must be zeroed"
+        );
+    }
+
+    /// `from_processor_config` honors a checkpoint-shipped block and falls
+    /// back to reference defaults otherwise; wrong-length per-bin vectors
+    /// are rejected at construction.
+    #[test]
+    fn test_from_processor_config() {
+        // No processor config / no block -> reference defaults.
+        let config = AudioFeatureExtractorConfig::from_processor_config(None);
+        assert!(!config.fft_overdrive);
+        let empty = serde_json::json!({ "image_processor": {} });
+        let config = AudioFeatureExtractorConfig::from_processor_config(Some(&empty));
+        assert!(!config.fft_overdrive);
+        assert_eq!(config.feature_size, 128);
+
+        // Checkpoint-shipped block overrides only the fields it names.
+        let with_block = serde_json::json!({
+            "feature_extractor": {
+                "feature_extractor_type": "Gemma4AudioFeatureExtractor",
+                "fft_overdrive": true,
+                "frame_length_ms": 32.0,
+                "mel_floor": 1e-5,
+                "per_bin_mean": [0.5],
+            }
+        });
+        let config = AudioFeatureExtractorConfig::from_processor_config(Some(&with_block));
+        assert!(config.fft_overdrive);
+        assert_eq!(config.frame_length_ms, 32.0);
+        assert_eq!(config.mel_floor, 1e-5);
+        assert_eq!(config.hop_length_ms, 10.0, "unnamed fields keep defaults");
+        let extractor = AudioFeatureExtractor::new(config);
+        assert_eq!(extractor.fft_length, 1024, "512-sample frame + overdrive");
+        assert!(
+            extractor.per_bin_mean.is_none(),
+            "length-1 per_bin_mean must be rejected for feature_size 128"
+        );
     }
 
     /// Test that the periodic Hann window places the 440 Hz energy peak in the

--- a/src/audio/feature_extractor.rs
+++ b/src/audio/feature_extractor.rs
@@ -155,10 +155,48 @@ pub struct AudioFeatureExtractor {
 
 impl AudioFeatureExtractor {
     pub fn new(config: AudioFeatureExtractorConfig) -> Self {
+        // A checkpoint's `processor_config.json` `feature_extractor` block is
+        // semi-trusted input read at load. Guard the scalar fields so a
+        // malformed or hostile block cannot drive a divide-by-zero in
+        // `extract` (hop_length == 0), an unbounded mel/feature allocation
+        // (feature_size), or a runaway `fft_length` doubling loop (frame_length).
+        // Out-of-range values fall back to the reference defaults, mirroring the
+        // per-bin-vector validation below.
+        let defaults = AudioFeatureExtractorConfig::default();
+        let mut config = config;
+        if config.sampling_rate == 0 {
+            config.sampling_rate = defaults.sampling_rate;
+        }
+        if !config.frame_length_ms.is_finite() || config.frame_length_ms <= 0.0 {
+            config.frame_length_ms = defaults.frame_length_ms;
+        }
+        if !config.hop_length_ms.is_finite() || config.hop_length_ms <= 0.0 {
+            config.hop_length_ms = defaults.hop_length_ms;
+        }
+        // 4096 mel bins is far above any real value (128) yet keeps the
+        // `[fft_length/2+1, feature_size]` filterbank and the per-frame feature
+        // buffer bounded.
+        if config.feature_size == 0 || config.feature_size > 4096 {
+            config.feature_size = defaults.feature_size;
+        }
+
         let frame_length =
             (config.sampling_rate as f64 * config.frame_length_ms / 1000.0).round() as usize;
         let hop_length =
             (config.sampling_rate as f64 * config.hop_length_ms / 1000.0).round() as usize;
+
+        // A tiny `*_ms` can still round to 0, and a huge one to an allocation
+        // bomb; re-derive from the defaults if either lands out of range.
+        let (frame_length, hop_length) = if (1..=65_536).contains(&frame_length) && hop_length >= 1
+        {
+            (frame_length, hop_length)
+        } else {
+            let fl = (defaults.sampling_rate as f64 * defaults.frame_length_ms / 1000.0).round()
+                as usize;
+            let hl =
+                (defaults.sampling_rate as f64 * defaults.hop_length_ms / 1000.0).round() as usize;
+            (fl, hl)
+        };
 
         let mut fft_length = 1;
         while fft_length < frame_length {
@@ -763,5 +801,61 @@ mod tests {
             (15..=40).contains(&peak_bin),
             "440 Hz mel energy peak at bin {peak_bin}, expected in range 15-40"
         );
+    }
+
+    /// A malformed `feature_extractor` config block (which reaches this path now
+    /// that the extractor honors `processor_config.json`) must not build an
+    /// extractor that divides by zero, allocates unboundedly, or spins the
+    /// `fft_length` loop. Each nonsensical scalar falls back to the reference
+    /// default, and `extract` then runs to completion on a real waveform.
+    #[test]
+    fn malformed_config_scalars_fall_back_to_defaults() {
+        let defaults = AudioFeatureExtractorConfig::default();
+        let tone = generate_tone(440.0, 0.5, 16_000);
+
+        // hop_length_ms == 0 would divide by zero in `extract`.
+        for bad in [
+            AudioFeatureExtractorConfig {
+                hop_length_ms: 0.0,
+                ..AudioFeatureExtractorConfig::default()
+            },
+            AudioFeatureExtractorConfig {
+                frame_length_ms: 0.0,
+                ..AudioFeatureExtractorConfig::default()
+            },
+            AudioFeatureExtractorConfig {
+                frame_length_ms: f64::NAN,
+                ..AudioFeatureExtractorConfig::default()
+            },
+            AudioFeatureExtractorConfig {
+                sampling_rate: 0,
+                ..AudioFeatureExtractorConfig::default()
+            },
+            AudioFeatureExtractorConfig {
+                feature_size: 0,
+                ..AudioFeatureExtractorConfig::default()
+            },
+            AudioFeatureExtractorConfig {
+                feature_size: usize::MAX,
+                ..AudioFeatureExtractorConfig::default()
+            },
+            AudioFeatureExtractorConfig {
+                frame_length_ms: 1.0e12,
+                ..AudioFeatureExtractorConfig::default()
+            },
+        ] {
+            let extractor = AudioFeatureExtractor::new(bad);
+            // feature_size never exceeds the sane cap; the default is restored
+            // for the zero/oversized cases.
+            assert!(extractor.feature_size() >= 1 && extractor.feature_size() <= 4096);
+            let (features, mask) = extractor.extract(&tone, None);
+            assert!(!features.is_empty());
+            assert_eq!(features.len() % extractor.feature_size(), 0);
+            assert!(!mask.is_empty());
+        }
+
+        // A well-formed default config is untouched by the guards.
+        let ok = AudioFeatureExtractor::new(defaults);
+        assert_eq!(ok.feature_size(), 128);
     }
 }

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -37,6 +37,7 @@ pub mod whisper_mel;
 
 pub use config::AudioConfig;
 pub use encoder::AudioEncoder;
+pub(crate) use encoder::audio_probe_dump as encoder_probe_dump;
 pub use feature_extractor::{
     AudioFeatureExtractor, AudioFeatureExtractorConfig, compute_audio_num_tokens, load_wav_file,
     load_wav_from_bytes,

--- a/src/commands/generate_vlm.rs
+++ b/src/commands/generate_vlm.rs
@@ -564,9 +564,9 @@ fn compute_gemma4_audio_embeddings(
         samples
     };
 
-    // Extract mel spectrogram
-    let extractor =
-        audio::AudioFeatureExtractor::new(audio::AudioFeatureExtractorConfig::default());
+    // Extract mel spectrogram with the checkpoint's feature-extractor config
+    // (reference defaults when the checkpoint ships no block).
+    let extractor = audio::AudioFeatureExtractor::new(gemma4_vl.audio_extractor_config.clone());
     let (features, mask) = extractor.extract(&samples, None);
     let num_frames = mask.len();
 
@@ -668,9 +668,9 @@ fn compute_gemma4_multimodal_embeddings(
         samples
     };
 
-    // Extract mel spectrogram
-    let extractor =
-        audio::AudioFeatureExtractor::new(audio::AudioFeatureExtractorConfig::default());
+    // Extract mel spectrogram with the checkpoint's feature-extractor config
+    // (reference defaults when the checkpoint ships no block).
+    let extractor = audio::AudioFeatureExtractor::new(gemma4_vl.audio_extractor_config.clone());
     let (features, mask) = extractor.extract(&samples, None);
     let num_frames = mask.len();
     let audio_features = mlxcel_core::from_slice_f32(

--- a/src/loading/vlm_gemma.rs
+++ b/src/loading/vlm_gemma.rs
@@ -369,7 +369,9 @@ pub(crate) fn load_gemma4_vlm(model_path: &Path) -> Result<LoadedModel> {
     )
     .map_err(|e| anyhow::anyhow!("Failed to load Gemma4 multimodal embedder: {}", e))?;
 
-    let image_processor_config = read_optional_model_json(model_path, "processor_config.json")
+    let processor_config = read_optional_model_json(model_path, "processor_config.json");
+    let image_processor_config = processor_config
+        .as_ref()
         .and_then(|config| config.get("image_processor").cloned());
     let max_soft_tokens = image_processor_config
         .as_ref()
@@ -467,6 +469,15 @@ pub(crate) fn load_gemma4_vlm(model_path: &Path) -> Result<LoadedModel> {
                 boa_token_id,
                 eoa_token_id,
             );
+
+            // Mel front-end config: honor a `feature_extractor` block from
+            // processor_config.json when the checkpoint ships one; the
+            // published Gemma 4 E-series checkpoints do not, so this
+            // resolves to the reference defaults (fft_length 512).
+            vlm.audio_extractor_config =
+                crate::audio::AudioFeatureExtractorConfig::from_processor_config(
+                    processor_config.as_ref(),
+                );
 
             eprintln!(
                 "Loaded Gemma4 audio encoder ({} Conformer layers)",

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -1401,9 +1401,9 @@ fn prepare_gemma4_audio_embeddings(
         samples
     };
 
-    // Extract mel spectrogram features
-    let extractor =
-        audio::AudioFeatureExtractor::new(audio::AudioFeatureExtractorConfig::default());
+    // Extract mel spectrogram features with the checkpoint's
+    // feature-extractor config (reference defaults when absent).
+    let extractor = audio::AudioFeatureExtractor::new(gemma4_vl.audio_extractor_config.clone());
     let (features, mask) = extractor.extract(&samples, None);
     let num_frames = mask.len();
 

--- a/src/vision/gemma4_vl.rs
+++ b/src/vision/gemma4_vl.rs
@@ -41,6 +41,10 @@ pub struct Gemma4VLModel {
     pub audio_token_id: i32,
     pub boa_token_id: i32,
     pub eoa_token_id: i32,
+    /// Mel front-end config for the Conformer audio tower. Populated from the
+    /// checkpoint's `processor_config.json` `feature_extractor` block when
+    /// present; reference defaults otherwise.
+    pub audio_extractor_config: audio::AudioFeatureExtractorConfig,
     /// Per-`SequenceId` storage for projected `per_layer_inputs`
     /// Mirrors `MRopeState`.
     per_layer_inputs_state: Gemma4PerLayerInputsState,
@@ -70,6 +74,7 @@ impl Gemma4VLModel {
             audio_token_id: 258_881,
             boa_token_id: 256_000,
             eoa_token_id: 258_883,
+            audio_extractor_config: audio::AudioFeatureExtractorConfig::default(),
             per_layer_inputs_state: Gemma4PerLayerInputsState::new(),
             _weight_backing: crate::models::Gemma4WeightBacking::default(),
         }
@@ -335,6 +340,7 @@ impl Gemma4VLModel {
             // abort) and is propagated to the caller as a per-request error.
             let (audio_encodings, _) = audio_tower.forward(audio_feat, &audio_mel_mask)?;
             let audio_encodings = embed_audio.forward(&audio_encodings);
+            crate::audio::encoder_probe_dump("embed_audio_out", &audio_encodings);
 
             let current_embeds = &result_embeds.inputs_embeds;
             let audio_encodings =


### PR DESCRIPTION
## Summary

Fixes the garbled audio perception on the Gemma 4 E-series (E2B/E4B) Conformer path: a 16 kHz PCM16 clip that the 12B Unified path transcribed correctly came out as nonsense phonemes on E2B/E4B. A numerical reference-diff harness against the canonical `Gemma4AudioFeatureExtractor` (transformers 5.8.0, identical to upstream mlx-vlm main) and the upstream mlx-vlm gemma4 audio tower localized two independent root causes, both fixed here. This is the completion of the incomplete #436 fix.

## Numerical premise check

Method: extract log-mel features for one fixed 16 kHz mono PCM16 speech clip (98832 samples, 6.18 s) with the reference extractor in Python and with mlxcel's extractor on the same bytes, then compare per-frame per-mel-bin; afterwards feed the bit-identical mel input through mlxcel's Conformer tower (env-gated stage dumper) and upstream mlx-vlm's tower and compare per stage.

Root cause 1, mel front-end (src/audio/feature_extractor.rs). mlxcel was ported from the previous generation of the extractor and diverged on four ops: `fft_overdrive` defaulted to `true` (fft_length 1024) where the reference defaults to `false` (512); log floor was the hard clamp `ln(max(mel, 1e-3))` instead of the additive `ln(mel + 1e-3)`; the unfold window was `frame_length` instead of `frame_length + 1`, emitting one extra frame whenever total_len is a multiple of the hop (1248 vs 1247 frames on the issue's 12.5 s clip); and the frame mask was computed at the window START (frame 0 wrongly invalid, tail frames straddling right-padding wrongly valid) instead of the window END, without zeroing invalid rows. Before the fix the features diverged from the reference by RMS 0.818, max abs 6.89, mean offset +0.65 (about ln 2, from the fft_overdrive doubling), on features whose own RMS is 3.14. After the fix: max abs 4.8e-7, RMS 7e-8 (f32 rounding), identical shapes and masks on both test clips including the 199680-sample edge case. Confirmation that the reference generation is what the checkpoints expect: the installed mlx-vlm 0.4.4, whose extractor still has the OLD semantics (fft_overdrive true, no left-pad, clamp floor), reproduces the exact same "cannot hear the audio" failure end to end on `gemma-4-e4b-it-4bit`, while upstream mlx-vlm main (new semantics) transcribes the same clip word-exact.

Root cause 2, missing ClippableLinear clamps (src/audio/encoder.rs). The checkpoints ship finite per-layer `input_min/max` and `output_min/max` bounds for every audio ClippableLinear (for example `lconv1d.linear_end` input clamps to about +-5.8 while block activations reach far larger tails) and the reference clamps input and output at inference; the bounds are part of the trained function. mlxcel's `AudioLinear` skipped them as "training artifacts". With bit-exact mel input, the stage diff against the upstream tower read: `in_mel` and `sscp_out` (no ClippableLinear) rel RMS 0.000, then block 0 = 0.079, growing monotonically to block 11 = 0.952 and `tower_out` = 0.965 (fully decorrelated). After loading and applying the bounds, every stage matches within 8.2e-4 relative RMS (dtype noise) and `embed_audio_out` within 8.6e-4. The vision tower already applied these bounds; the audio port had dropped them.

## What changed

- `src/audio/feature_extractor.rs`: `fft_overdrive` default false; additive mel floor; `frame_length + 1` unfold; end-indexed frame mask; zero invalid feature rows; optional `per_bin_mean`/`per_bin_stddev` normalization; serde-deserializable config plus `from_processor_config` honoring a checkpoint-shipped `feature_extractor` block (the published checkpoints ship none, so reference defaults apply).
- `src/audio/encoder.rs`: `AudioLinear` loads and applies the checkpoint's input/output clamp bounds when present; env-gated `MLXCEL_AUDIO_PROBE_DIR` stage dumper for future parity diffing.
- `src/vision/gemma4_vl.rs`, `src/loading/vlm_gemma.rs`, `src/commands/generate_vlm.rs`, `src/server/model_worker.rs`: the model carries the extractor config from `processor_config.json` to the CLI and server call sites.
- `src/audio/encoder_tests.rs` (new) and extended `feature_extractor` tests: golden log-mel vector baked from the reference extractor for a fixed synthetic waveform (no network, no Python dependency), reference-default invariants (fft_length 512), frame count, end-indexed tail mask with row zeroing, `processor_config.json` parsing, and `AudioLinear` clamp semantics.

## Validation (real checkpoints, -t 0)

- `gemma-4-e4b-it-4bit`, 16 kHz English clip: word-exact transcription ("The quick brown fox jumps over the lazy dog. The bridge construction was completed in August of 2011."), previously "okran faqchambavadalaijidag ..." nonsense.
- `gemma-4-e4b-it-4bit`, Korean clip of the issue's FLEURS ground-truth sentence (say/Yuna TTS at 16 kHz; the FLEURS datasets-server API was persistently 503): near-exact, comparable to upstream mlx-vlm and well inside the issue's ~5.5% CER expectation.
- `gemma-4-e2b-it-4bit` and `-8bit`: transcribe both clips correctly. One prompt/clip combination on the 4-bit E2B ends at EOS before emitting text at -t 0; it perceives the same audio correctly with a slightly different prompt, so it is a knife-edge sampling artifact, not the feature-path defect.
- 24 kHz source clip on E4B: resample path (#436) still word-exact.
- `gemma-4-12b-it-4bit` Unified path: unchanged (English clip perceived correctly; the Korean TTS clip produces the same channel-marker loop on the released 0.3.3 binary, pre-existing and unrelated).
- `cargo test --release --lib audio::` 71 passed, `loading::` 215 passed, `gemma` 307 passed; `cargo clippy --lib --tests --features metal,accelerate -- -D warnings` clean; `cargo fmt --all -- --check` clean.

## Follow-ups (out of scope, from the issue's secondary observations)

- The raw `<|channel|>thought` marker and thinking stream still leak into CLI output on the E-series generate path (related in spirit to #350/#352).
- `--audio` still rejects IEEE Float WAV (the format datasets-server serves) with an unclear "WAV scan error: failed to fill whole buffer"; wider float-subformat support or a clearer error needs a WAV chunk-parser rework.
- The 12B Unified path emits a channel-marker loop on one synthetic Korean TTS clip (pre-existing on 0.3.3, reproducible).

Closes #782
