### PR TITLE
feat(sampling): implement XTC sampling end to end

### DIFF
--- a/docs/python-client.md
+++ b/docs/python-client.md
@@ -109,7 +109,7 @@ print(llm.chat(messages, max_tokens=128, temperature=0.3))
 
 ## Sampling parameters
 
-Generation methods accept OpenAI sampling fields directly: `max_tokens`, `temperature`, `top_p`, `stop`, `seed`, `presence_penalty`, `frequency_penalty`, `logit_bias`, and `response_format`. Server-specific knobs that are not part of the OpenAI schema (`top_k`, `min_p`, `repetition_penalty`, DRY settings, and the vLLM-compatible loop-detection fields `max_pattern_size` / `min_pattern_size` / `min_count`) are forwarded in the request body. You can also pass an explicit `extra_body={...}` for arbitrary server fields; values you set there win on conflict.
+Generation methods accept OpenAI sampling fields directly: `max_tokens`, `temperature`, `top_p`, `stop`, `seed`, `presence_penalty`, `frequency_penalty`, `logit_bias`, and `response_format`. Server-specific knobs that are not part of the OpenAI schema (`top_k`, `min_p`, `repetition_penalty`, DRY settings, `xtc_probability` / `xtc_threshold`, and the vLLM-compatible loop-detection fields `max_pattern_size` / `min_pattern_size` / `min_count`) are forwarded in the request body. `xtc_probability` (`0.0`-`1.0`, default `0.0`, disabled) is the per-step chance that XTC (Exclude Top Choices) removes all but the single least-probable token among those whose probability exceeds `xtc_threshold` (`0.0`-`0.5`, default `0.1`); both are validated on `/v1/chat/completions`, `/v1/completions`, and `/v1/responses`, and an out-of-range value returns a 400 before generation starts. You can also pass an explicit `extra_body={...}` for arbitrary server fields; values you set there win on conflict.
 
 ```python
 llm.generate("Once upon a time", max_tokens=200, top_p=0.9, top_k=40, min_p=0.05)

--- a/src/bin/bench_decode.rs
+++ b/src/bin/bench_decode.rs
@@ -292,6 +292,8 @@ fn sampling_config(model_path: &Path) -> SamplingConfig {
         dry_sequence_breakers: Vec::new(),
         frequency_penalty: 0.0,
         presence_penalty: 0.0,
+        xtc_probability: 0.0,
+        xtc_threshold: 0.1,
         stop_token_ids: mlxcel::read_eos_token_ids(model_path),
     })
 }

--- a/src/commands/chat_tests.rs
+++ b/src/commands/chat_tests.rs
@@ -203,6 +203,8 @@ fn chat_options_new_sets_conventional_defaults() {
         dry_sequence_breakers: Vec::new(),
         frequency_penalty: 0.0,
         presence_penalty: 0.0,
+        xtc_probability: 0.0,
+        xtc_threshold: 0.1,
         stop_token_ids: Vec::new(),
     };
     let opts = ChatOptions::new(PathBuf::from("models/foo"), 128, sampling);

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -814,6 +814,10 @@ fn build_cli_sampling_config(args: &GenerateArgs, stop_token_ids: Vec<i32>) -> S
         dry_sequence_breakers: Vec::new(),
         frequency_penalty: 0.0,
         presence_penalty: 0.0,
+        // XTC is not yet exposed as a CLI flag; the CLI generation path
+        // keeps it disabled.
+        xtc_probability: 0.0,
+        xtc_threshold: 0.1,
         stop_token_ids,
     })
 }
@@ -1507,6 +1511,9 @@ fn chat_options_from_args(args: &GenerateArgs) -> Result<crate::commands::ChatOp
         dry_sequence_breakers: Vec::new(),
         frequency_penalty: 0.0,
         presence_penalty: 0.0,
+        // XTC is not yet exposed as a CLI flag; the REPL keeps it disabled.
+        xtc_probability: 0.0,
+        xtc_threshold: 0.1,
         stop_token_ids: Vec::new(),
     };
 

--- a/src/distributed/disaggregated/serving_protocol.rs
+++ b/src/distributed/disaggregated/serving_protocol.rs
@@ -274,6 +274,12 @@ pub fn sampling_from_serializable(state: &SerializableSamplingState) -> Sampling
         // prefill/decode handoff; the decode node keeps the disabled baseline.
         // Wiring it into `SerializableSamplingState` is a follow-up.
         loop_detection: Default::default(),
+        // XTC is likewise not yet part of the wire frame; the decode node
+        // keeps the disabled baseline (`xtc_probability == 0.0`) until this
+        // is wired into `SerializableSamplingState` as a follow-up.
+        xtc_probability: Default::default(),
+        xtc_threshold: Default::default(),
+        xtc_special_token_ids: Default::default(),
     }
 }
 

--- a/src/execution/sampling.rs
+++ b/src/execution/sampling.rs
@@ -41,6 +41,11 @@ pub struct ResolvedSamplingParams {
     pub dry_sequence_breakers: Vec<i32>,
     pub frequency_penalty: f32,
     pub presence_penalty: f32,
+    /// XTC (Exclude Top Choices) per-step probability (0.0 = disabled).
+    pub xtc_probability: f32,
+    /// XTC probability threshold (valid range `0.0..=0.5`, enforced at the
+    /// request layer). Unused while `xtc_probability == 0.0`.
+    pub xtc_threshold: f32,
     pub stop_token_ids: Vec<i32>,
 }
 
@@ -56,6 +61,11 @@ pub fn build_sampling_config(params: ResolvedSamplingParams) -> SamplingConfig {
             dry_base: params.dry_base,
             dry_allowed_length: params.dry_allowed_length,
             dry_penalty_last_n: params.dry_penalty_last_n,
+            // XTC is a logits pre-processing step applied regardless of
+            // temperature (like the repetition/DRY/frequency/presence
+            // penalties above), so the greedy branch threads it through too.
+            xtc_probability: params.xtc_probability,
+            xtc_threshold: params.xtc_threshold,
             stop_token_ids: params.stop_token_ids,
             ..SamplingConfig::greedy()
         }
@@ -74,6 +84,8 @@ pub fn build_sampling_config(params: ResolvedSamplingParams) -> SamplingConfig {
             dry_sequence_breakers: params.dry_sequence_breakers,
             frequency_penalty: params.frequency_penalty,
             presence_penalty: params.presence_penalty,
+            xtc_probability: params.xtc_probability,
+            xtc_threshold: params.xtc_threshold,
             stop_token_ids: params.stop_token_ids,
             token_bias: TokenBiasMap::default(),
             // Loop detection defaults to disabled here. The server control
@@ -81,6 +93,12 @@ pub fn build_sampling_config(params: ResolvedSamplingParams) -> SamplingConfig {
             // where the loaded model family is visible (see
             // `request_options::build_server_generate_options`).
             loop_detection: LoopDetectionConfig::default(),
+            // The special-token allowlist is resolved per-request from the
+            // tokenizer and the merged EOS set, which are not visible here;
+            // the server control plane sets `sampling.xtc_special_token_ids`
+            // after this helper returns (see
+            // `BatchScheduler::enqueue_request`).
+            xtc_special_token_ids: Vec::new(),
         }
     }
 }

--- a/src/execution/sampling_tests.rs
+++ b/src/execution/sampling_tests.rs
@@ -29,6 +29,8 @@ fn sample_params() -> ResolvedSamplingParams {
         dry_sequence_breakers: vec![10, 20],
         frequency_penalty: 0.2,
         presence_penalty: 0.3,
+        xtc_probability: 0.4,
+        xtc_threshold: 0.15,
         stop_token_ids: vec![1, 2],
     }
 }
@@ -51,6 +53,8 @@ fn build_sampling_config_keeps_sampling_fields_when_temperature_is_positive() {
     assert_eq!(config.dry_sequence_breakers, params.dry_sequence_breakers);
     assert_eq!(config.frequency_penalty, params.frequency_penalty);
     assert_eq!(config.presence_penalty, params.presence_penalty);
+    assert_eq!(config.xtc_probability, params.xtc_probability);
+    assert_eq!(config.xtc_threshold, params.xtc_threshold);
     assert_eq!(config.stop_token_ids, params.stop_token_ids);
 }
 
@@ -69,5 +73,9 @@ fn build_sampling_config_uses_greedy_defaults_when_temperature_is_zero() {
     assert_eq!(config.repetition_penalty, params.repetition_penalty);
     assert_eq!(config.frequency_penalty, params.frequency_penalty);
     assert_eq!(config.presence_penalty, params.presence_penalty);
+    // XTC is applied regardless of temperature, so the greedy branch still
+    // threads the resolved probability/threshold through.
+    assert_eq!(config.xtc_probability, params.xtc_probability);
+    assert_eq!(config.xtc_threshold, params.xtc_threshold);
     assert_eq!(config.stop_token_ids, params.stop_token_ids);
 }

--- a/src/lib/mlxcel-core/src/generate.rs
+++ b/src/lib/mlxcel-core/src/generate.rs
@@ -814,6 +814,23 @@ pub struct SamplingConfig {
     /// When enabled, the decode loops end generation early once the raw
     /// generated stream collapses into a short repeated pattern.
     pub loop_detection: LoopDetectionConfig,
+    /// XTC (Exclude Top Choices) per-step probability (0.0 = disabled, the
+    /// default). With this probability, each sampling step applies the XTC
+    /// filter (see [`crate::sampling::apply_xtc_filter`]); otherwise the step
+    /// samples normally. `0.0` is a zero-overhead no-op that preserves the
+    /// bit-exact baseline: the gate is skipped entirely rather than drawing
+    /// (and thereby consuming) a random sample.
+    pub xtc_probability: f32,
+    /// XTC probability threshold: among the tokens whose probability exceeds
+    /// this value, the filter removes all but the single least-probable one.
+    /// Valid range `0.0..=0.5` (enforced at the request layer). Unused while
+    /// `xtc_probability == 0.0`.
+    pub xtc_threshold: f32,
+    /// Token ids the XTC filter must never remove, even when selected by its
+    /// removal rule: the tokenizer's newline token id(s) plus every id in the
+    /// merged end-of-sequence set. Resolved once per request at enqueue time
+    /// (empty by default, and unused while `xtc_probability == 0.0`).
+    pub xtc_special_token_ids: Vec<i32>,
 }
 
 impl Default for SamplingConfig {
@@ -835,6 +852,9 @@ impl Default for SamplingConfig {
             stop_token_ids: Vec::new(),
             token_bias: TokenBiasMap::default(),
             loop_detection: LoopDetectionConfig::default(),
+            xtc_probability: 0.0,
+            xtc_threshold: 0.1,
+            xtc_special_token_ids: Vec::new(),
         }
     }
 }
@@ -859,6 +879,9 @@ impl SamplingConfig {
             stop_token_ids: Vec::new(),
             token_bias: TokenBiasMap::default(),
             loop_detection: LoopDetectionConfig::default(),
+            xtc_probability: 0.0,
+            xtc_threshold: 0.1,
+            xtc_special_token_ids: Vec::new(),
         }
     }
 

--- a/src/lib/mlxcel-core/src/sampling.rs
+++ b/src/lib/mlxcel-core/src/sampling.rs
@@ -482,13 +482,15 @@ impl FusedSampleParams {
 /// The fast path applies one set of scalar parameters across the whole
 /// `[B, vocab]` batch in a single [`ffi::fused_sample`] call. It cannot
 /// represent per-row history-based penalties (repetition / DRY / frequency /
-/// presence) or a non-empty token bias, both of which require per-row logit
-/// edits before sampling. When this returns `false`, the caller must fall
-/// back to the per-row sampler.
+/// presence), a non-empty token bias, or XTC (`xtc_probability > 0.0`), all of
+/// which require per-row logit edits before sampling. XTC, like a non-empty
+/// token bias, is a per-row logit edit that must run through the per-row
+/// sampler, so it disqualifies the fused fast path. When this returns `false`,
+/// the caller must fall back to the per-row sampler.
 ///
 /// Used by: `BatchScheduler::execute_batched_decode` fast-path gate
 pub fn config_supports_fused_batch(config: &SamplingConfig) -> bool {
-    !config.needs_token_history() && config.token_bias.is_empty()
+    !config.needs_token_history() && config.token_bias.is_empty() && config.xtc_probability <= 0.0
 }
 
 /// Per-row eligibility for the batched fused fast path.
@@ -1460,6 +1462,15 @@ mod tests {
             ..Default::default()
         };
         assert!(!config_supports_fused_batch(&dry));
+    }
+
+    #[test]
+    fn config_supports_fused_batch_false_for_xtc() {
+        let xtc = SamplingConfig {
+            xtc_probability: 1.0,
+            ..Default::default()
+        };
+        assert!(!config_supports_fused_batch(&xtc));
     }
 
     #[test]

--- a/src/lib/mlxcel-core/src/sampling.rs
+++ b/src/lib/mlxcel-core/src/sampling.rs
@@ -379,6 +379,18 @@ fn sample_token_optimized_core(
         last_logits
     };
 
+    // XTC (Exclude Top Choices): a logits pre-processing step, applied here
+    // (before the fused temperature/top-k/top-p/min-p/categorical sampler)
+    // the same way the penalties above are. `xtc_probability <= 0.0` is the
+    // default disabled state and skips this entirely — no array ops, and no
+    // draw from the per-request RNG stream, which keeps every existing
+    // request's token stream byte-identical to before this feature existed.
+    let last_logits = if config.xtc_probability > 0.0 {
+        apply_xtc_step(&last_logits, config)
+    } else {
+        last_logits
+    };
+
     let token = ffi::fused_sample(
         &last_logits,
         config.temperature,
@@ -1151,6 +1163,128 @@ pub(crate) fn top_p_filter(logits: &MlxArray, p: f32) -> UniquePtr<MlxArray> {
 
     // Step 8: scatter filtered logits back to original vocab order per row.
     ffi::take_along_axis(&filtered_sorted, &unsort_indices, -1)
+}
+
+/// Apply XTC (Exclude Top Choices) filtering to logits.
+///
+/// Among the tokens whose probability exceeds `threshold`, if two or more
+/// exist, this removes (sets to `-inf`) all of them except the single
+/// least-probable one — suppressing the dominant choices promotes lexical
+/// diversity. If fewer than two tokens exceed the threshold, this is a
+/// no-op. Token ids in `allowlist` are never removed even when selected by
+/// that rule; callers pass the tokenizer's newline token id(s) plus the full
+/// merged end-of-sequence set (see `BatchScheduler::enqueue_request`) so XTC
+/// can never suppress a token needed to end a line or the sequence.
+///
+/// This is a logits pre-processing step, applied the same way
+/// [`apply_dry_penalty`] and the repetition/frequency/presence penalties
+/// are: before the fused C++ temperature/top-k/top-p/min-p/categorical
+/// sampler ([`ffi::fused_sample`]), not inside it.
+///
+/// Algorithm (all lazy MLX array ops, no host round-trip):
+/// 1. `probs = softmax(logits)`; `above = probs > threshold`.
+/// 2. No-op guard: `count(above) < 2` disables removal for that row.
+/// 3. Mask every non-`above` position to `+inf` in a scratch copy of
+///    `probs`, then `argmin` finds the single least-probable `above` token
+///    (the one to keep).
+/// 4. Removal candidates = `above` AND NOT the kept index AND NOT
+///    `allowlist`, gated by the no-op guard from step 2.
+/// 5. `where(remove, -inf, logits)`.
+///
+/// Used by: [`apply_xtc_step`]
+pub(crate) fn apply_xtc_filter(
+    logits: &MlxArray,
+    threshold: f32,
+    allowlist: &[i32],
+) -> UniquePtr<MlxArray> {
+    let shape = ffi::array_shape(logits);
+    let vocab_size = *shape.last().unwrap() as usize;
+
+    let probs = ffi::softmax(logits, -1);
+
+    // Tokens whose probability exceeds the threshold.
+    let threshold_arr = ffi::full_f32(&[1], threshold, dtype::FLOAT32);
+    let above = ffi::greater(&probs, &threshold_arr);
+
+    // No-op guard: fewer than two above-threshold tokens in this row.
+    let above_f32 = ffi::astype(&above, dtype::FLOAT32);
+    let count = ffi::sum_axis(&above_f32, -1, true);
+    let two = ffi::full_f32(&[1], 2.0, dtype::FLOAT32);
+    let has_two_or_more = ffi::greater_equal(&count, &two);
+
+    // Identify the single least-probable above-threshold token: mask every
+    // other position to +inf so it can never win the row-wise argmin.
+    let pos_inf = ffi::full_f32(&[1], f32::INFINITY, dtype::FLOAT32);
+    let masked_probs = ffi::where_cond(&above, &probs, &pos_inf);
+    let least_idx = ffi::argmin(&masked_probs, -1, true);
+
+    // One-hot mark of the least-probable token via scatter, so it can be
+    // excluded from the removal set below.
+    let zeros_full = ffi::zeros(&shape, dtype::FLOAT32);
+    let least_idx_shape = ffi::array_shape(&least_idx);
+    let ones_col = ffi::ones(&least_idx_shape, dtype::FLOAT32);
+    let is_least_f32 = ffi::put_along_axis(&zeros_full, &least_idx, &ones_col, -1);
+    let zero_scalar = ffi::full_f32(&[1], 0.0, dtype::FLOAT32);
+    let is_least = ffi::greater(&is_least_f32, &zero_scalar);
+
+    // Removal candidates: above-threshold, excluding the least-probable one.
+    let not_least = ffi::logical_not(&is_least);
+    let remove_candidate = ffi::logical_and(&above, &not_least);
+
+    // Never remove allowlisted special tokens (newline + merged EOS ids).
+    let remove_candidate = if allowlist.is_empty() {
+        remove_candidate
+    } else {
+        let mut allow_vec = vec![0.0f32; vocab_size];
+        for &id in allowlist {
+            if id >= 0 && (id as usize) < vocab_size {
+                allow_vec[id as usize] = 1.0;
+            }
+        }
+        let allow_arr = ffi::from_slice_f32(&allow_vec, &[1, vocab_size as i32]);
+        let allow_broadcast = ffi::broadcast_to(&allow_arr, &shape);
+        let is_allowed = ffi::greater(&allow_broadcast, &zero_scalar);
+        let not_allowed = ffi::logical_not(&is_allowed);
+        ffi::logical_and(&remove_candidate, &not_allowed)
+    };
+
+    // Gate the whole filter on having >= 2 above-threshold candidates.
+    let remove_mask = ffi::logical_and(&remove_candidate, &has_two_or_more);
+
+    let neg_inf = ffi::full_f32(&[1], f32::NEG_INFINITY, dtype::FLOAT32);
+    ffi::where_cond(&remove_mask, &neg_inf, logits)
+}
+
+/// Per-step probability gate for [`apply_xtc_filter`].
+///
+/// Draws exactly one uniform sample from the same per-request seeded global
+/// MLX random stream the fused categorical sampler consumes at the end of
+/// [`sample_token_optimized_core`] (`ffi::random_seed`, called once per
+/// generation via `generation_policy::seed_rng_if_needed`, seeds this
+/// stream). MLX's default random key is a thread-local sequence that is
+/// split synchronously at graph-*construction* time, not at `eval` time —
+/// so the order these calls are made in Rust (not the order their results
+/// are later evaluated) determines which slice of the stream each one
+/// consumes. Drawing here, before the categorical draw inside
+/// [`ffi::fused_sample`], keeps the whole decode step reproducible for a
+/// fixed seed: the same seed always produces the same gate outcome followed
+/// by the same categorical sample.
+///
+/// Only called when `config.xtc_probability > 0.0` (see
+/// [`sample_token_optimized_core`]); a request that leaves XTC disabled
+/// never advances the RNG stream here, preserving the pre-XTC token stream
+/// byte-for-byte.
+fn apply_xtc_step(logits: &MlxArray, config: &SamplingConfig) -> UniquePtr<MlxArray> {
+    // SAFETY: `key` is documented to accept a null pointer, meaning "draw
+    // from the current thread-local default RNG state" (mirrors the
+    // existing `std::ptr::null()` "no explicit key" usage in `layers.rs`).
+    let gate_draw =
+        unsafe { ffi::random_uniform(0.0, 1.0, &[1], dtype::FLOAT32, std::ptr::null()) };
+    let probability = ffi::full_f32(&[1], config.xtc_probability, dtype::FLOAT32);
+    let gate = ffi::less(&gate_draw, &probability);
+
+    let filtered = apply_xtc_filter(logits, config.xtc_threshold, &config.xtc_special_token_ids);
+    ffi::where_cond(&gate, &filtered, logits)
 }
 
 #[cfg(test)]
@@ -2177,5 +2311,129 @@ mod tests {
             fast.logprob,
             full
         );
+    }
+
+    // -- XTC (Exclude Top Choices) filter --
+
+    /// Logits whose softmax probabilities are roughly: token 0 ~0.665,
+    /// token 1 ~0.245, token 2 ~0.090, token 3 ~1.4e-9. Tokens 0-2 clearly
+    /// exceed a 0.01 threshold; token 3 clearly does not. Only token 0
+    /// exceeds a 0.5 threshold.
+    fn xtc_test_logits() -> UniquePtr<MlxArray> {
+        ffi::from_slice_f32(&[10.0, 9.0, 8.0, -10.0], &[1, 4])
+    }
+
+    #[test]
+    fn apply_xtc_filter_keeps_least_probable_above_threshold_token() {
+        let logits = xtc_test_logits();
+        let result = apply_xtc_filter(&logits, 0.01, &[]);
+
+        // Tokens 0 and 1 are above threshold and not the least-probable of
+        // the three, so both are removed. Token 2 is the least-probable
+        // above-threshold token and is kept. Token 3 never exceeded the
+        // threshold and is untouched either way.
+        assert_eq!(logit_at(&result, 0), f32::NEG_INFINITY);
+        assert_eq!(logit_at(&result, 1), f32::NEG_INFINITY);
+        assert_eq!(logit_at(&result, 2), 8.0);
+        assert_eq!(logit_at(&result, 3), -10.0);
+    }
+
+    #[test]
+    fn apply_xtc_filter_allowlist_tokens_survive_removal() {
+        let logits = xtc_test_logits();
+        // Token 0 would otherwise be removed (above threshold, not the
+        // least-probable); the allowlist must keep it intact.
+        let result = apply_xtc_filter(&logits, 0.01, &[0]);
+
+        assert_eq!(logit_at(&result, 0), 10.0);
+        assert_eq!(logit_at(&result, 1), f32::NEG_INFINITY);
+        assert_eq!(logit_at(&result, 2), 8.0);
+        assert_eq!(logit_at(&result, 3), -10.0);
+    }
+
+    #[test]
+    fn apply_xtc_filter_is_noop_with_fewer_than_two_candidates() {
+        let logits = xtc_test_logits();
+        // threshold 0.5: only token 0 (~0.665) exceeds it, so the filter
+        // must not remove anything.
+        let result = apply_xtc_filter(&logits, 0.5, &[]);
+
+        assert_eq!(logit_at(&result, 0), 10.0);
+        assert_eq!(logit_at(&result, 1), 9.0);
+        assert_eq!(logit_at(&result, 2), 8.0);
+        assert_eq!(logit_at(&result, 3), -10.0);
+    }
+
+    #[test]
+    fn apply_xtc_filter_is_noop_with_zero_candidates() {
+        let logits = xtc_test_logits();
+        // threshold 0.9: no token exceeds it.
+        let result = apply_xtc_filter(&logits, 0.9, &[]);
+
+        assert_eq!(logit_at(&result, 0), 10.0);
+        assert_eq!(logit_at(&result, 1), 9.0);
+        assert_eq!(logit_at(&result, 2), 8.0);
+        assert_eq!(logit_at(&result, 3), -10.0);
+    }
+
+    #[test]
+    fn apply_xtc_step_gate_at_zero_never_fires() {
+        let config = SamplingConfig {
+            xtc_probability: 0.0,
+            xtc_threshold: 0.01,
+            ..Default::default()
+        };
+        // Try several seeds: a probability-0.0 gate must never fire
+        // regardless of the drawn uniform sample.
+        for seed in [1u64, 2, 3] {
+            ffi::random_seed(seed);
+            let logits = xtc_test_logits();
+            let result = apply_xtc_step(&logits, &config);
+            assert_eq!(logit_at(&result, 0), 10.0);
+            assert_eq!(logit_at(&result, 1), 9.0);
+        }
+    }
+
+    #[test]
+    fn apply_xtc_step_gate_at_one_always_fires() {
+        let config = SamplingConfig {
+            xtc_probability: 1.0,
+            xtc_threshold: 0.01,
+            ..Default::default()
+        };
+        // Uniform samples are drawn from [0, 1), so a probability-1.0 gate
+        // must always fire regardless of the drawn value.
+        for seed in [11u64, 12, 13] {
+            ffi::random_seed(seed);
+            let logits = xtc_test_logits();
+            let result = apply_xtc_step(&logits, &config);
+            assert_eq!(logit_at(&result, 0), f32::NEG_INFINITY);
+            assert_eq!(logit_at(&result, 1), f32::NEG_INFINITY);
+            assert_eq!(logit_at(&result, 2), 8.0);
+        }
+    }
+
+    #[test]
+    fn apply_xtc_step_mid_probability_is_reproducible_for_the_same_seed() {
+        let config = SamplingConfig {
+            xtc_probability: 0.5,
+            xtc_threshold: 0.01,
+            ..Default::default()
+        };
+
+        ffi::random_seed(42);
+        let result_a = apply_xtc_step(&xtc_test_logits(), &config);
+        let a0 = logit_at(&result_a, 0);
+        let a1 = logit_at(&result_a, 1);
+
+        // Re-seeding with the same value must reproduce the same gate
+        // outcome (and therefore the same resulting logits) deterministically.
+        ffi::random_seed(42);
+        let result_b = apply_xtc_step(&xtc_test_logits(), &config);
+        let b0 = logit_at(&result_b, 0);
+        let b1 = logit_at(&result_b, 1);
+
+        assert_eq!(a0, b0);
+        assert_eq!(a1, b1);
     }
 }

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -369,6 +369,17 @@ pub struct BatchScheduler {
     /// keeps the enqueue path zero-cost.
     model_output_suppressed: Vec<i32>,
 
+    /// Tokenizer newline token id(s), resolved once at worker startup.
+    ///
+    /// Part of the XTC (Exclude Top Choices) special-token allowlist: at
+    /// [`Self::enqueue_request`] time this is combined with the per-request
+    /// merged end-of-sequence set and installed on
+    /// `sampling.xtc_special_token_ids` so the filter can never remove a
+    /// token needed to end a line or the sequence. Empty for tokenizers
+    /// whose newline does not resolve (unlikely, but not fatal); the enqueue
+    /// path only spends the merge cost when `sampling.xtc_probability > 0.0`.
+    xtc_newline_token_ids: Vec<i32>,
+
     // -- — thinking-token budget --
     /// Server-wide default thinking-token budget. `None` means unrestricted.
     /// Per-request `thinking_budget_tokens` overrides this at enqueue time.
@@ -1066,6 +1077,7 @@ impl BatchScheduler {
             )),
             token_bias: TokenBiasMap::default(),
             model_output_suppressed,
+            xtc_newline_token_ids: Vec::new(),
             reasoning_budget: None,
             thinking_token_ids: None,
             prompt_cache: None,
@@ -1411,6 +1423,18 @@ impl BatchScheduler {
     /// Returns a reference to the cached token-bias map (for tests).
     pub fn token_bias(&self) -> &TokenBiasMap {
         &self.token_bias
+    }
+
+    /// Attach the tokenizer's newline token id(s), resolved once at worker
+    /// startup, for the XTC special-token allowlist.
+    ///
+    /// Cached for the scheduler's lifetime and combined with each request's
+    /// merged end-of-sequence set at enqueue time (see
+    /// [`Self::enqueue_request`]). An empty list is a no-op — it simply
+    /// contributes nothing to the allowlist.
+    pub fn with_xtc_newline_token_ids(mut self, ids: Vec<i32>) -> Self {
+        self.xtc_newline_token_ids = ids;
+        self
     }
 
     /// Attach the server-wide thinking-token budget and resolved
@@ -2620,6 +2644,23 @@ impl BatchScheduler {
             sampling
                 .token_bias
                 .suppress_tokens(&self.model_output_suppressed);
+        }
+
+        // XTC (Exclude Top Choices) special-token allowlist: the tokenizer's
+        // newline id(s) plus every id in this request's merged end-of-sequence
+        // set (built the same way EOS detection does during decode, see the
+        // `merged_eos_token_ids` calls in `execute_batched_decode` and the
+        // classic decode paths). Only computed when XTC is actually enabled
+        // for this request — the overwhelming majority of requests leave
+        // `xtc_probability == 0.0` and skip this entirely.
+        if sampling.xtc_probability > 0.0 {
+            let mut allowlist = self.xtc_newline_token_ids.clone();
+            for id in merged_eos_token_ids(self.model.eos_token_ids(), &sampling.stop_token_ids) {
+                if !allowlist.contains(&id) {
+                    allowlist.push(id);
+                }
+            }
+            sampling.xtc_special_token_ids = allowlist;
         }
 
         let is_multimodal = !images.is_empty() || !audio.is_empty() || !videos.is_empty();

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -503,6 +503,12 @@ pub(crate) fn spawn_model_worker_with_batch_config(
                 );
             }
 
+            // resolve the tokenizer's newline token id(s) once, for the
+            // XTC (Exclude Top Choices) special-token allowlist. Combined
+            // with each request's merged end-of-sequence set at enqueue time
+            // (see `BatchScheduler::enqueue_request`).
+            let xtc_newline_token_ids = resolve_xtc_newline_token_ids(&tokenizer);
+
             // #122 b3: resolve the `--kv-cache-budget` directive into a paged
             // block count now (the model's geometry is known) and install it on
             // the scheduler's pool below. A no-op (unbounded) when the flag is
@@ -533,6 +539,7 @@ pub(crate) fn spawn_model_worker_with_batch_config(
             // cap the batched-prefill transient to --max-batch-prefill-tokens (#715).
             .with_max_batch_prefill_tokens(sched_config.max_batch_prefill_tokens)
             .with_token_bias(token_bias)
+            .with_xtc_newline_token_ids(xtc_newline_token_ids)
             .with_reasoning_budget(sched_config.reasoning_budget, thinking_ids)
             .with_prompt_cache(sched_config.prompt_cache)
             .with_kv_cache_mode(sched_config.kv_cache_mode)
@@ -914,6 +921,11 @@ pub(crate) fn spawn_legacy_model_worker(
                 );
             }
 
+            // resolve the tokenizer's newline token id(s) once, mirroring
+            // the batched-worker path above, for the XTC special-token
+            // allowlist.
+            let xtc_newline_token_ids = resolve_xtc_newline_token_ids(&tokenizer);
+
             // Reuse BatchScheduler with max_batch_size=1 and chunking disabled.
             // Per the scheduler docs, size-1 behavior is identical to the old
             // sequential recv() loop, with no extra overhead.
@@ -937,6 +949,7 @@ pub(crate) fn spawn_legacy_model_worker(
                 1, // max_batch_prefill = 1 → sequential prefill
                 crate::server::DecodeStorageBackend::Dense,
             )
+            .with_xtc_newline_token_ids(xtc_newline_token_ids)
             .with_reasoning_budget(reasoning_budget, thinking_ids);
             scheduler.serve();
         })
@@ -1332,6 +1345,24 @@ fn resolve_end_of_turn_token_id(tokenizer: &MlxcelTokenizer) -> Option<i32> {
         }
     }
     None
+}
+
+/// Resolve the tokenizer's newline token id(s), once per model load.
+///
+/// XTC (Exclude Top Choices) sampling must never remove a token needed to end
+/// a line, so these ids are folded into the per-request special-token
+/// allowlist alongside the merged end-of-sequence set (see
+/// `BatchScheduler::enqueue_request`). Encoding the bare `"\n"` character
+/// (no special tokens) covers both a single-token byte-level newline piece
+/// (e.g. the GPT-2/Llama-style `Ċ`) and any tokenizer that splits it into
+/// more than one id. An encode failure (not expected for a model's own
+/// tokenizer) yields an empty allowlist contribution rather than aborting
+/// startup.
+fn resolve_xtc_newline_token_ids(tokenizer: &MlxcelTokenizer) -> Vec<i32> {
+    tokenizer
+        .encode("\n", false)
+        .map(|ids| ids.into_iter().map(|id| id as i32).collect())
+        .unwrap_or_default()
 }
 
 /// Process audio (and optionally images) for Gemma4 VLM models.

--- a/src/server/model_worker_tests.rs
+++ b/src/server/model_worker_tests.rs
@@ -19,6 +19,7 @@ use image::{DynamicImage, ImageBuffer, ImageFormat, Rgb};
 use super::{
     StreamingDecodeState, build_generation_result, decode_request_images,
     decode_request_images_with_limits, merge_config_stop_tokens, resolve_end_of_turn_token_id,
+    resolve_xtc_newline_token_ids,
 };
 use crate::SamplingConfig;
 use crate::server::media::ImageInputLimits;
@@ -938,4 +939,55 @@ fn resolve_end_of_turn_id_prefers_gemma_over_chatml() {
         Some(107),
         "<end_of_turn> must win over <|im_end|> when both are present (candidate order)"
     );
+}
+
+// -- resolve_xtc_newline_token_ids (XTC special-token allowlist) --
+
+/// Minimal HF tokenizer stub whose vocab is the same ASCII `"a"`/`"b"` pair as
+/// [`stub_tokenizer_no_eot`] plus a literal single-character newline entry.
+/// Used to exercise the single-token case of `resolve_xtc_newline_token_ids`.
+fn stub_tokenizer_with_newline() -> MlxcelTokenizer {
+    let json = r#"{
+        "version": "1.0",
+        "truncation": null,
+        "padding": null,
+        "added_tokens": [],
+        "normalizer": null,
+        "pre_tokenizer": null,
+        "post_processor": null,
+        "decoder": null,
+        "model": {
+            "type": "BPE",
+            "dropout": null,
+            "unk_token": null,
+            "continuing_subword_prefix": null,
+            "end_of_word_suffix": null,
+            "fuse_unk": false,
+            "byte_fallback": false,
+            "vocab": {"a": 0, "b": 1, "\n": 2},
+            "merges": []
+        }
+    }"#;
+    let tokenizer = tokenizers::Tokenizer::from_bytes(json.as_bytes())
+        .expect("failed to build stub newline tokenizer");
+    MlxcelTokenizer::HuggingFace(tokenizer)
+}
+
+/// A byte-level BPE tokenizer whose vocabulary contains the bare `"\n"`
+/// character resolves it to that single id, mirroring how most
+/// production tokenizers (GPT-2/Llama-style) represent a newline as one
+/// token.
+#[test]
+fn resolve_xtc_newline_token_ids_finds_single_token_newline() {
+    let tokenizer = stub_tokenizer_with_newline();
+    assert_eq!(resolve_xtc_newline_token_ids(&tokenizer), vec![2]);
+}
+
+/// A tokenizer whose vocabulary has no entry for `"\n"` (and no `unk_token`
+/// fallback) must contribute nothing to the XTC allowlist rather than
+/// panicking or aborting model load.
+#[test]
+fn resolve_xtc_newline_token_ids_empty_when_newline_not_in_vocab() {
+    let tokenizer = stub_tokenizer_no_eot();
+    assert_eq!(resolve_xtc_newline_token_ids(&tokenizer), Vec::<i32>::new());
 }

--- a/src/server/request_options.rs
+++ b/src/server/request_options.rs
@@ -49,6 +49,12 @@ pub(crate) struct RequestOptionOverrides {
     pub dry_allowed_length: Option<usize>,
     pub dry_penalty_last_n: Option<usize>,
     pub dry_sequence_breakers: Option<Vec<i32>>,
+    /// XTC (Exclude Top Choices) per-step probability override. Validated at
+    /// the request layer (`0.0..=1.0`) before it reaches here.
+    pub xtc_probability: Option<f32>,
+    /// XTC probability threshold override. Validated at the request layer
+    /// (`0.0..=0.5`) before it reaches here.
+    pub xtc_threshold: Option<f32>,
     pub stop_sequences: Option<Vec<String>>,
     pub priority: RequestPriority,
     /// per-request thinking-token budget override.
@@ -145,6 +151,14 @@ pub(crate) fn build_server_generate_options(
         presence_penalty: overrides
             .presence_penalty
             .unwrap_or(config.default_presence_penalty),
+        // XTC has no server-level CLI default (unlike the other knobs above):
+        // it is an experimental, purely opt-in per-request feature, so an
+        // absent request field always resolves to the disabled baseline
+        // (`0.0`) regardless of server configuration. `0.1` is the inert
+        // upstream-conventional threshold value used only while
+        // `xtc_probability > 0.0`.
+        xtc_probability: overrides.xtc_probability.unwrap_or(0.0),
+        xtc_threshold: overrides.xtc_threshold.unwrap_or(0.1),
         stop_token_ids: Vec::new(),
     });
 

--- a/src/server/request_options_tests.rs
+++ b/src/server/request_options_tests.rs
@@ -38,6 +38,10 @@ fn build_server_generate_options_uses_server_defaults() {
         options.sampling.dry_multiplier,
         config.default_dry_multiplier
     );
+    // XTC has no server-level CLI default; an absent request field always
+    // resolves to the disabled baseline regardless of server configuration.
+    assert_eq!(options.sampling.xtc_probability, 0.0);
+    assert_eq!(options.sampling.xtc_threshold, 0.1);
     assert_eq!(options.stop_sequences, None);
 }
 
@@ -61,6 +65,8 @@ fn build_server_generate_options_applies_request_overrides() {
             dry_allowed_length: Some(5),
             dry_penalty_last_n: Some(17),
             dry_sequence_breakers: Some(vec![1, 2]),
+            xtc_probability: Some(0.7),
+            xtc_threshold: Some(0.2),
             stop_sequences: Some(vec!["stop".to_string()]),
             priority: crate::server::batch::RequestPriority::High,
             reasoning_budget: crate::server::config::ReasoningBudgetOverride::default(),
@@ -83,6 +89,8 @@ fn build_server_generate_options_applies_request_overrides() {
     assert_eq!(options.sampling.dry_allowed_length, 5);
     assert_eq!(options.sampling.dry_penalty_last_n, 17);
     assert_eq!(options.sampling.dry_sequence_breakers, Vec::<i32>::new());
+    assert_eq!(options.sampling.xtc_probability, 0.7);
+    assert_eq!(options.sampling.xtc_threshold, 0.2);
     assert_eq!(options.stop_sequences, Some(vec!["stop".to_string()]));
 }
 

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -970,7 +970,7 @@ fn request_has_video_blocks(request: &ChatCompletionRequest) -> bool {
 /// server default then applies. Returns `Err` with a client-facing message
 /// so the caller can surface a 400 `invalid_request_error` before any
 /// generation work begins.
-fn validate_xtc_params(
+pub(crate) fn validate_xtc_params(
     xtc_threshold: Option<f32>,
     xtc_probability: Option<f32>,
 ) -> Result<(), &'static str> {

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -218,6 +218,14 @@ pub async fn chat_completions(
         .into_response();
     }
 
+    // Validate XTC (Exclude Top Choices) sampling parameter ranges before any
+    // generation work begins.
+    if let Err(message) =
+        validate_xtc_params(request.params.xtc_threshold, request.params.xtc_probability)
+    {
+        return ErrorResponse::new(message, "invalid_request_error").into_response();
+    }
+
     // reject `video_url` content blocks early for models that do
     // not support video. Detected once at startup from `config.json` and
     // cached on `AppState.media_support`. Returning a 400 keeps the client
@@ -955,6 +963,30 @@ fn request_has_video_blocks(request: &ChatCompletionRequest) -> bool {
     !request.video_urls().is_empty()
 }
 
+/// Validate the XTC (Exclude Top Choices) sampling parameter ranges.
+///
+/// `xtc_threshold` must be `0.0..=0.5` and `xtc_probability` must be
+/// `0.0..=1.0` when set; an absent field (`None`) is always valid since the
+/// server default then applies. Returns `Err` with a client-facing message
+/// so the caller can surface a 400 `invalid_request_error` before any
+/// generation work begins.
+fn validate_xtc_params(
+    xtc_threshold: Option<f32>,
+    xtc_probability: Option<f32>,
+) -> Result<(), &'static str> {
+    if let Some(threshold) = xtc_threshold
+        && !(0.0..=0.5).contains(&threshold)
+    {
+        return Err("xtc_threshold must be between 0.0 and 0.5");
+    }
+    if let Some(probability) = xtc_probability
+        && !(0.0..=1.0).contains(&probability)
+    {
+        return Err("xtc_probability must be between 0.0 and 1.0");
+    }
+    Ok(())
+}
+
 /// Maximum number of tools allowed in a single request.
 ///
 /// Enforced in `chat_completions()` to prevent DoS via large tool definitions
@@ -1113,6 +1145,8 @@ pub(crate) fn build_generate_options(
             dry_allowed_length: params.dry_allowed_length,
             dry_penalty_last_n: params.dry_penalty_last_n,
             dry_sequence_breakers: params.dry_sequence_breakers.clone(),
+            xtc_probability: params.xtc_probability,
+            xtc_threshold: params.xtc_threshold,
             stop_sequences: params.stop.clone(),
             priority: RequestPriority::default(),
             // the caller (non_stream_chat_completion /
@@ -1154,6 +1188,57 @@ mod tests {
     #[test]
     fn max_tools_constant_is_128() {
         assert_eq!(MAX_TOOLS, 128);
+    }
+
+    // -- XTC (Exclude Top Choices) request validation --
+
+    #[test]
+    fn validate_xtc_params_accepts_unset_fields() {
+        assert!(validate_xtc_params(None, None).is_ok());
+    }
+
+    #[test]
+    fn validate_xtc_params_accepts_in_range_boundaries() {
+        assert!(validate_xtc_params(Some(0.0), Some(0.0)).is_ok());
+        assert!(validate_xtc_params(Some(0.5), Some(1.0)).is_ok());
+        assert!(validate_xtc_params(Some(0.1), Some(0.4)).is_ok());
+    }
+
+    #[test]
+    fn validate_xtc_params_rejects_out_of_range_threshold() {
+        // Above the 0.5 upper bound.
+        assert_eq!(
+            validate_xtc_params(Some(0.6), None),
+            Err("xtc_threshold must be between 0.0 and 0.5")
+        );
+        // Below the 0.0 lower bound.
+        assert_eq!(
+            validate_xtc_params(Some(-0.1), None),
+            Err("xtc_threshold must be between 0.0 and 0.5")
+        );
+    }
+
+    #[test]
+    fn validate_xtc_params_rejects_out_of_range_probability() {
+        // Above the 1.0 upper bound.
+        assert_eq!(
+            validate_xtc_params(None, Some(1.1)),
+            Err("xtc_probability must be between 0.0 and 1.0")
+        );
+        // Below the 0.0 lower bound.
+        assert_eq!(
+            validate_xtc_params(None, Some(-0.5)),
+            Err("xtc_probability must be between 0.0 and 1.0")
+        );
+    }
+
+    #[test]
+    fn validate_xtc_params_checks_threshold_before_probability() {
+        // Both fields invalid: the threshold check runs first.
+        assert_eq!(
+            validate_xtc_params(Some(0.9), Some(2.0)),
+            Err("xtc_threshold must be between 0.0 and 0.5")
+        );
     }
 
     #[test]

--- a/src/server/routes/completions.rs
+++ b/src/server/routes/completions.rs
@@ -40,6 +40,7 @@ use crate::tokenizer::MlxcelTokenizer;
 
 use super::chat::{
     build_generate_options, decode_token, parse_priority_header, structured_error_to_response,
+    validate_xtc_params,
 };
 
 /// Build a `CompletionLogprobs` from a list of `TokenLogprobData` (legacy format).
@@ -121,6 +122,14 @@ pub async fn completions(
     {
         return ErrorResponse::new("logprobs must be between 0 and 5", "invalid_request_error")
             .into_response();
+    }
+
+    // Validate XTC (Exclude Top Choices) sampling parameter ranges before any
+    // generation work begins.
+    if let Err(message) =
+        validate_xtc_params(request.params.xtc_threshold, request.params.xtc_probability)
+    {
+        return ErrorResponse::new(message, "invalid_request_error").into_response();
     }
 
     // validate thinking_budget_tokens early.
@@ -385,4 +394,48 @@ async fn stream_completion(
     Sse::new(stream)
         .keep_alive(keepalive.into_inner())
         .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- XTC (Exclude Top Choices) request validation on /v1/completions --
+    //
+    // `CompletionRequest` flattens `SamplingParams`, so `xtc_probability` /
+    // `xtc_threshold` are reachable off `request.params`. These tests exercise
+    // the same field access the `completions` handler performs and confirm the
+    // shared `validate_xtc_params` gate rejects out-of-range values.
+
+    #[test]
+    fn completions_rejects_out_of_range_xtc_probability() {
+        let request: CompletionRequest =
+            serde_json::from_str(r#"{"model":"m","prompt":"hi","xtc_probability":2.0}"#).unwrap();
+        assert_eq!(
+            validate_xtc_params(request.params.xtc_threshold, request.params.xtc_probability),
+            Err("xtc_probability must be between 0.0 and 1.0")
+        );
+    }
+
+    #[test]
+    fn completions_rejects_out_of_range_xtc_threshold() {
+        let request: CompletionRequest =
+            serde_json::from_str(r#"{"model":"m","prompt":"hi","xtc_threshold":-0.1}"#).unwrap();
+        assert_eq!(
+            validate_xtc_params(request.params.xtc_threshold, request.params.xtc_probability),
+            Err("xtc_threshold must be between 0.0 and 0.5")
+        );
+    }
+
+    #[test]
+    fn completions_accepts_in_range_xtc() {
+        let request: CompletionRequest = serde_json::from_str(
+            r#"{"model":"m","prompt":"hi","xtc_probability":0.5,"xtc_threshold":0.1}"#,
+        )
+        .unwrap();
+        assert!(
+            validate_xtc_params(request.params.xtc_threshold, request.params.xtc_probability)
+                .is_ok()
+        );
+    }
 }

--- a/src/server/routes/native_completion.rs
+++ b/src/server/routes/native_completion.rs
@@ -259,6 +259,11 @@ fn build_native_generate_options(
             dry_allowed_length: request.dry_allowed_length,
             dry_penalty_last_n: request.dry_penalty_last_n,
             dry_sequence_breakers: request.dry_sequence_breakers.clone(),
+            // The native `/completion` endpoint has no per-request XTC
+            // fields (llama-server's `/completion` schema does not define
+            // them), so XTC always resolves to the disabled baseline here.
+            xtc_probability: None,
+            xtc_threshold: None,
             stop_sequences: request.stop.clone(),
             priority: RequestPriority::default(),
             // the caller fills this from the validated request

--- a/src/server/routes/responses.rs
+++ b/src/server/routes/responses.rs
@@ -60,6 +60,7 @@ use crate::server::types::responses_stream::ResponseStreamEvent;
 
 use super::chat::{
     build_generate_options, build_prompt_cache_request_context, parse_priority_header,
+    validate_xtc_params,
 };
 
 /// POST /v1/responses
@@ -77,6 +78,15 @@ pub async fn create_response(
         Ok(t) => t,
         Err(err) => return translate_error_to_response(err).into_response(),
     };
+
+    // Validate XTC (Exclude Top Choices) sampling parameter ranges before any
+    // generation work begins.
+    if let Err(message) = validate_xtc_params(
+        translated.chat_request.params.xtc_threshold,
+        translated.chat_request.params.xtc_probability,
+    ) {
+        return ErrorResponse::new(message, "invalid_request_error").into_response();
+    }
 
     // Build the structured-output constraint (json_schema) up front.
     let structured = {
@@ -993,5 +1003,56 @@ mod tests {
         let (visible, reasoning) = split_reasoning("just text", None);
         assert_eq!(visible, "just text");
         assert!(reasoning.is_none());
+    }
+
+    // -- XTC (Exclude Top Choices) request validation on /v1/responses --
+    //
+    // `CreateResponseRequest` flattens `SamplingParams`, and the translator
+    // forwards it into `translated.chat_request.params`. These tests walk the
+    // same translate-then-validate path as `create_response` and confirm the
+    // shared `validate_xtc_params` gate rejects out-of-range values.
+
+    #[test]
+    fn responses_rejects_out_of_range_xtc_probability() {
+        let request: CreateResponseRequest =
+            serde_json::from_str(r#"{"model":"m","input":"hi","xtc_probability":2.0}"#).unwrap();
+        let translated = responses_request_to_chat(&request, None, None).unwrap();
+        assert_eq!(
+            validate_xtc_params(
+                translated.chat_request.params.xtc_threshold,
+                translated.chat_request.params.xtc_probability,
+            ),
+            Err("xtc_probability must be between 0.0 and 1.0")
+        );
+    }
+
+    #[test]
+    fn responses_rejects_out_of_range_xtc_threshold() {
+        let request: CreateResponseRequest =
+            serde_json::from_str(r#"{"model":"m","input":"hi","xtc_threshold":-0.1}"#).unwrap();
+        let translated = responses_request_to_chat(&request, None, None).unwrap();
+        assert_eq!(
+            validate_xtc_params(
+                translated.chat_request.params.xtc_threshold,
+                translated.chat_request.params.xtc_probability,
+            ),
+            Err("xtc_threshold must be between 0.0 and 0.5")
+        );
+    }
+
+    #[test]
+    fn responses_accepts_in_range_xtc() {
+        let request: CreateResponseRequest = serde_json::from_str(
+            r#"{"model":"m","input":"hi","xtc_probability":0.5,"xtc_threshold":0.1}"#,
+        )
+        .unwrap();
+        let translated = responses_request_to_chat(&request, None, None).unwrap();
+        assert!(
+            validate_xtc_params(
+                translated.chat_request.params.xtc_threshold,
+                translated.chat_request.params.xtc_probability,
+            )
+            .is_ok()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implement XTC (Exclude Top Choices) sampling end to end: the server request schema already accepted `xtc_probability` and `xtc_threshold` but nothing read them, so clients setting these fields silently got default sampling.

## What changed

- `src/lib/mlxcel-core/src/sampling.rs`: new `apply_xtc_filter` (removes all but the least-probable token among those exceeding `xtc_threshold`, no-op below two candidates, never removes allowlisted ids) and `apply_xtc_step` (gates the filter with a draw from the same per-request seeded global MLX RNG the fused categorical sampler consumes, keeping the whole decode step reproducible for a fixed seed). Both are wired into `sample_token_optimized_core`, gated on `xtc_probability > 0.0` so a disabled request never advances the RNG stream or pays any array-op cost.
- `src/lib/mlxcel-core/src/generate.rs`: `SamplingConfig` gains `xtc_probability`, `xtc_threshold`, and `xtc_special_token_ids`.
- `src/execution/sampling.rs`: `ResolvedSamplingParams` / `build_sampling_config` thread the new fields through for both the greedy and sampled branches.
- `src/server/request_options.rs`: `RequestOptionOverrides` / `build_server_generate_options` resolve per-request values against a disabled default (XTC has no server-level CLI default).
- `src/server/routes/chat.rs`: `build_generate_options` maps `SamplingParams` into the overrides, and the shared `validate_xtc_params` helper (`0.0..=0.5` for `xtc_threshold`, `0.0..=1.0` for `xtc_probability`) sits next to the existing `top_logprobs` range check. It now runs in `chat_completions`, `completions`, and `create_response`, each returning a 400 `invalid_request_error` before any generation work begins.
- `src/server/model_worker.rs` / `src/server/batch/scheduler.rs`: the special-token allowlist (tokenizer newline id(s) plus the full merged end-of-sequence set) is resolved once per model load (`resolve_xtc_newline_token_ids`, wired into both scheduler-construction call sites) and combined with the per-request merged EOS set in `BatchScheduler::enqueue_request`, only when `xtc_probability > 0.0`.
- `src/server/routes/native_completion.rs`, `src/distributed/disaggregated/serving_protocol.rs`, `src/bin/bench_decode.rs`, `src/commands/generate.rs`, `src/commands/chat_tests.rs`: updated every other `SamplingConfig` / `ResolvedSamplingParams` / `RequestOptionOverrides` construction site to keep the previous disabled defaults, so nothing outside the OpenAI-compatible chat/completions/responses routes changes behavior.

## Review-cycle fixes

- **CRITICAL, fused-batch bypass**: `config_supports_fused_batch` only excluded rows that need token history or carry a token bias, so an XTC-only request (no penalties, no bias) was admitted to the batched fused sampler, which calls `fused_sample` directly and never runs `apply_xtc_step`. Both the batched decode dispatch and the async lookahead priming go through this gate via `row_supports_fused_batch`, so XTC applied only to the first token (`finish_prefill` uses the per-row sampler) and was silently dropped for every token after it, failing issue #772's acceptance criterion that `xtc_probability=1.0` observably changes the distribution. XTC is now treated as a per-row logit edit like a non-empty token bias: `xtc_probability > 0.0` disqualifies the fused fast path, so every decode token runs through the per-row sampler.
- **MEDIUM, route validation coverage**: `validate_xtc_params` was wired only into `/v1/chat/completions`. `/v1/completions` and `/v1/responses` both reach XTC through the shared `build_generate_options` and both flatten `SamplingParams`, so an out-of-range `xtc_probability` / `xtc_threshold` bypassed the documented 400 and still mutated sampling on those two routes. The helper is now `pub(crate)` and called from the `completions` and `create_response` handlers too.

## Test plan

- [x] `cargo build --release --features cuda --workspace` (zero errors)
- [x] `cargo test --release --features cuda -p mlxcel-core sampling::`: 8 XTC tests: filter keeps the least-probable token, allowlist survives removal, no-op below two/zero candidates, gate at 0.0 never fires, gate at 1.0 always fires, mid-probability gate reproducible for a fixed seed, and the fused-batch gate disqualifies `xtc_probability > 0.0`
- [x] `cargo test --release --features cuda --lib execution::sampling::`: 2 passed
- [x] `cargo test --release --features cuda --lib request_options::`: 12 passed
- [x] `cargo test --release --features cuda --lib server::routes::chat::`: 27 passed (5 `validate_xtc_params` tests)
- [x] `cargo test --release --features cuda --lib server::routes::completions::`: 3 new tests: out-of-range `xtc_probability`, out-of-range `xtc_threshold`, in-range accepted
- [x] `cargo test --release --features cuda --lib server::routes::responses::`: 3 new tests: out-of-range `xtc_probability`, out-of-range `xtc_threshold`, in-range accepted
- [x] `cargo test --release --features cuda --lib server::batch::scheduler::tests::`: 69 passed
- [x] `cargo test --release --features cuda --lib model_worker`: 28 passed (2 `resolve_xtc_newline_token_ids` tests)
- [x] `cargo test --release --features cuda --lib serving_protocol`: 10 passed
- [x] `cargo test --release --features cuda --bin mlxcel chat_options_new_sets_conventional_defaults`: 1 passed
- [x] `cargo test --release --features cuda --all-targets` (server crate, full run): exit 0
- [x] `cargo fmt --all -- --check`: clean

Closes #772
