### PR TITLE
feat(bench): monotonic OOM backstop and persistent OOM record for decode benchmark sweeps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ __pycache__/
 webpage/site/.next/
 webpage/site/out/
 webpage/site/node_modules/
+
+# Persistent cross-run OOM record for scripts/bench_longprompt.sh (issue #807).
+# Host-specific and reactive to local memory conditions, so it never belongs
+# in version control alongside the tracked benchmarks/*.csv result files.
+/benchmarks/.oom-record

--- a/scripts/bench_decode.sh
+++ b/scripts/bench_decode.sh
@@ -248,6 +248,8 @@ model_fits_in_memory() {
 #                 failed to allocate, cannot allocate memory, unable to allocate,
 #                 bad_alloc, "memory allocation of N bytes failed" (Rust abort)
 #   MLX Metal:    "greater than the maximum allowed buffer size", metal::malloc
+#   MLX CUDA:     CUDA_ERROR_OUT_OF_MEMORY, cudaErrorMemoryAllocation,
+#                 "cuMemAlloc failed" (issue #807, GB10 CUDA unified memory)
 #
 # Bare "oom" is intentionally excluded to avoid false positives (e.g. "zoom").
 is_oom_failure() {
@@ -264,7 +266,7 @@ is_oom_failure() {
   # Otherwise (exit 1 cxx exception, 134 bad_alloc abort, ...) it is OOM only
   # if the captured output names an allocator failure.
   printf '%s\n' "$err_text" | grep -qiE \
-    'out of memory|out-of-memory|insufficient memory|failed to allocate|cannot allocate memory|unable to allocate|bad_alloc|memory allocation of [0-9]|greater than the maximum allowed buffer size|metal::malloc'
+    'out of memory|out-of-memory|insufficient memory|failed to allocate|cannot allocate memory|unable to allocate|bad_alloc|memory allocation of [0-9]|greater than the maximum allowed buffer size|metal::malloc|CUDA_ERROR_OUT_OF_MEMORY|cudaErrorMemoryAllocation|cuMemAlloc failed'
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/bench_longprompt.sh
+++ b/scripts/bench_longprompt.sh
@@ -20,6 +20,57 @@
 # A model+length cell that OOMs (common at 32768 for large MoE models) is
 # recorded with the usual SKIP:oom / SKIP:oom_estimate classification and the
 # sweep continues.
+#
+# --- OOM avoidance (issue #807) ---------------------------------------------
+#
+# Near-OOM CUDA runs have repeatedly left the GB10 driver in a degraded state
+# (NVRM NV_ERR_NO_MEMORY accumulating for hours, eventually wedging the
+# kernel), so cells that are certain to OOM should never be launched at all.
+# Both layers below are purely empirical: they react to an observed SKIP:oom
+# cell, they never predict from a memory model. Only the SKIP:oom
+# classification (a true OOM at load/run time, see is_oom_failure() in
+# bench_decode.sh) feeds either layer; FAIL:bench, timeout (exit 124),
+# SKIP:oom_estimate, and cells for a missing ./models symlink or missing model
+# directory never do.
+#
+# 1. Monotonic backstop (within one sweep run). Once a (model, len) cell
+#    classifies as SKIP:oom, every remaining cell for that same model with
+#    length >= the OOM'd length is skipped before launch and logged as an
+#    explicit SKIP:oom_backstop CSV row (same 16-field layout as other rows)
+#    plus a stderr message.
+#
+# 2. Persistent OOM record (across runs). Each true SKIP:oom cell is appended
+#    to a gitignored record file at benchmarks/.oom-record, one line per
+#    event:
+#      model,prompt_target_len,date,commit,peak_bytes,source_csv
+#    `peak_bytes` is always blank today (the harness does not capture peak
+#    memory); `commit` is `git rev-parse --short HEAD` (or "unknown" outside a
+#    git checkout). On later runs, any cell whose model has a recorded OOM at
+#    a length <= the cell's length is pre-skipped and logged as a
+#    SKIP:oom_record row (the stderr message includes the matching record
+#    line). Set MLXCEL_BENCH_IGNORE_OOM_RECORD=1 to disable the pre-skip for
+#    one run; new SKIP:oom cells are still appended even when the pre-skip is
+#    disabled. A missing or empty record file is treated as "no records"; a
+#    malformed line (wrong field count, non-numeric length) is skipped with a
+#    stderr warning rather than aborting the sweep.
+#
+#    Staleness / pruning: records go stale whenever memory behavior improves.
+#    For example, the gemma-4-31b 32768-token OOM that originally motivated
+#    this design was fixed by the chunked-prefill change in PR #676, so a
+#    record line dated before that merge is no longer valid evidence. The
+#    per-line date and commit exist precisely so stale entries can be found
+#    and removed by hand, e.g.:
+#      grep -v '^gemma-4-31b-it-4bit,' benchmarks/.oom-record > /tmp/pruned \
+#        && mv /tmp/pruned benchmarks/.oom-record
+#    or by deleting lines whose date/commit predate a known fix. There is no
+#    automatic expiry; MLXCEL_BENCH_IGNORE_OOM_RECORD=1 is the low-effort way
+#    to re-test a single run without editing the file.
+#
+# 3. MLXCEL_BENCH_FAKE_OOM="model:len[,model:len...]" (testing hook). When the
+#    current cell's (model, len) pair is listed, the sweep skips invoking
+#    bench_decode.sh entirely and synthesizes a cell result containing a
+#    SKIP:oom row, so the backstop and persistent-record logic can be
+#    exercised deterministically without a real OOM.
 
 set -euo pipefail
 
@@ -30,6 +81,12 @@ BENCH_DECODE="${SCRIPT_DIR}/bench_decode.sh"
 MODELS_DIR="./models"
 BENCHMARKS_DIR="./benchmarks"
 DATE=$(date '+%Y-%m-%d')
+
+# Same 15-column header bench_decode.sh writes (its CSV_HEADER constant), so
+# aggregate rows -- whether they come from a real cell, a synthesized fake-OOM
+# cell, or a backstop/record skip row emitted directly by this script -- share
+# one schema. Trailing SKIP:*/FAIL:* tokens are an unnamed 16th field.
+CSV_HEADER="model,model_path,prompt_tokens,generated_tokens,prefill_ms,prefill_tok_s,decode_ms,decode_tok_s,date,hardware,mlx_version,build_type,max_tokens,prompt,prompt_target_len"
 
 # Representative subset: mix of dense (llama, qwen2.5), MoE (qwen3-a3b,
 # mixtral), and a large multimodal-capable text model (gemma-4).
@@ -44,6 +101,17 @@ WARMUP_TOKENS=4
 COOLDOWN=0
 BIG_COOLDOWN=0
 EXTRA_ARGS=()
+
+# OOM avoidance state (issue #807). See the header comment above for the
+# design; IGNORE_OOM_RECORD and FAKE_OOM_SET are read from the environment
+# only (no CLI flag) so a stray flag typo can never silently disable them.
+OOM_RECORD_FILE="${BENCHMARKS_DIR}/.oom-record"
+IGNORE_OOM_RECORD="${MLXCEL_BENCH_IGNORE_OOM_RECORD:-0}"
+declare -A OOM_MIN_LEN=()       # model_name -> smallest length observed SKIP:oom at
+declare -A FAKE_OOM_SET=()      # "model:len" -> 1, from MLXCEL_BENCH_FAKE_OOM
+OOM_RECORD_MODEL=()             # parallel arrays loaded from OOM_RECORD_FILE
+OOM_RECORD_LEN=()
+OOM_RECORD_LINE=()
 
 usage() {
   cat <<'EOF'
@@ -65,6 +133,37 @@ Options:
 
 All cells share one aggregate CSV with the 15-column bench_decode.sh schema
 (prompt_target_len appended). Cell order is model-major, length-minor.
+
+OOM avoidance (issue #807):
+  A cell that classifies as SKIP:oom (a true OOM at load/run time; see
+  is_oom_failure() in bench_decode.sh) triggers two purely empirical,
+  reactive-only skip layers -- neither one predicts from a memory model:
+
+  1. Monotonic backstop: every remaining cell for that model at length >= the
+     OOM'd length is skipped for the rest of this run, logged as
+     SKIP:oom_backstop.
+  2. Persistent record: the OOM is appended to the gitignored
+     benchmarks/.oom-record file (model,prompt_target_len,date,commit,
+     peak_bytes,source_csv). On later runs, any cell whose model has a
+     recorded OOM at a length <= the cell's length is pre-skipped and logged
+     as SKIP:oom_record.
+
+  Only SKIP:oom feeds either layer. FAIL:bench, a timeout (exit 124),
+  SKIP:oom_estimate, a missing ./models symlink, and a missing model
+  directory never do.
+
+Environment variables:
+  MLXCEL_BENCH_IGNORE_OOM_RECORD=1
+      Disable the persistent-record pre-skip for this run (new SKIP:oom cells
+      are still appended to benchmarks/.oom-record). Use this to re-test
+      cells after a memory fix lands; see the staleness/pruning guidance in
+      this script's header comment for removing the corresponding record
+      lines once the fix is confirmed.
+  MLXCEL_BENCH_FAKE_OOM="model:len[,model:len...]"
+      Testing hook: for each listed (model, len) pair, skip invoking
+      bench_decode.sh and synthesize a cell result containing a SKIP:oom row,
+      so the backstop and persistent-record logic can be validated without a
+      real OOM.
 EOF
 }
 
@@ -96,6 +195,109 @@ detect_hardware_short() {
 }
 
 # ---------------------------------------------------------------------------
+# OOM avoidance helpers (issue #807)
+# ---------------------------------------------------------------------------
+
+# Extract the trailing SKIP:*/FAIL:* classification token from the data row
+# in $TMP_CELL, or the empty string for a successful row (no trailing token)
+# or an empty/missing cell file. The row's quoted prompt field can itself
+# contain a comma (e.g. the default "Hello, how are you today?"), so this
+# parses from the end of the line (last comma-separated field) rather than by
+# a fixed field index.
+cell_classification() {
+  local row token
+  row=$(tail -n +2 "$TMP_CELL" 2>/dev/null | head -n 1)
+  if [[ -z "$row" ]]; then
+    echo ""
+    return 0
+  fi
+  token=$(awk -F, '{print $NF}' <<< "$row")
+  if [[ "$token" =~ ^(SKIP|FAIL): ]]; then
+    echo "$token"
+  else
+    echo ""
+  fi
+}
+
+# Append a schema-compatible 16-field skip row for a cell that was never
+# launched (monotonic backstop or persistent-record pre-skip). Writes the
+# shared CSV header first if this is the first row of the aggregate output.
+# This script does not compute `hardware`/`mlx_version`/`build_type` (only
+# bench_decode.sh does), so those three fields are left blank; downstream
+# consumers filter on the SKIP: prefix and treat these rows as capacity
+# exclusions regardless.
+emit_skip_row() {
+  local model_name="$1" model_path="$2" len="$3" classification="$4"
+  if [[ "$header_written" -eq 0 ]]; then
+    echo "$CSV_HEADER" >> "$OUTPUT"
+    header_written=1
+  fi
+  echo "${model_name},${model_path},,,,,,,${DATE},,,,${MAX_TOKENS},\"\",${len},${classification}" >> "$OUTPUT"
+}
+
+# Append a true-OOM cell to the persistent record file. peak_bytes is always
+# blank today; the harness does not capture peak memory.
+append_oom_record() {
+  local model_name="$1" len="$2"
+  local commit
+  commit=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
+  mkdir -p "$(dirname "$OOM_RECORD_FILE")"
+  echo "${model_name},${len},${DATE},${commit},,${OUTPUT}" >> "$OOM_RECORD_FILE"
+}
+
+# Load benchmarks/.oom-record into parallel arrays once, up front, so the
+# per-cell lookup is a cheap in-memory scan and malformed lines are only
+# warned about once (not once per cell). Tolerates a missing/empty file.
+load_oom_record() {
+  [[ -f "$OOM_RECORD_FILE" ]] || return 0
+  local line_num=0 line
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_num=$((line_num + 1))
+    [[ -z "$line" ]] && continue
+    local rec_model rec_len
+    rec_model=$(cut -d, -f1 <<< "$line")
+    rec_len=$(cut -d, -f2 <<< "$line")
+    if [[ -z "$rec_model" || ! "$rec_len" =~ ^[0-9]+$ ]]; then
+      >&2 echo "Warning: malformed line $line_num in $OOM_RECORD_FILE, skipping: $line"
+      continue
+    fi
+    OOM_RECORD_MODEL+=("$rec_model")
+    OOM_RECORD_LEN+=("$rec_len")
+    OOM_RECORD_LINE+=("$line")
+  done < "$OOM_RECORD_FILE"
+}
+
+# Print the first record line whose model matches $1 and whose recorded
+# length is <= $2 (the current cell's length), and return success. Returns
+# failure with no output when there is no match.
+check_oom_record() {
+  local model_name="$1" len="$2" i
+  for i in "${!OOM_RECORD_MODEL[@]}"; do
+    if [[ "${OOM_RECORD_MODEL[$i]}" == "$model_name" && "$len" -ge "${OOM_RECORD_LEN[$i]}" ]]; then
+      echo "${OOM_RECORD_LINE[$i]}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# True when MLXCEL_BENCH_FAKE_OOM lists this exact (model, len) pair.
+is_fake_oom_cell() {
+  local model_name="$1" len="$2"
+  [[ -n "${FAKE_OOM_SET[${model_name}:${len}]:-}" ]]
+}
+
+# Write a synthetic SKIP:oom cell result to $TMP_CELL in place of invoking
+# bench_decode.sh, for MLXCEL_BENCH_FAKE_OOM.
+synthesize_fake_oom_cell() {
+  local model_name="$1" model_path="$2" len="$3"
+  {
+    echo "$CSV_HEADER"
+    echo "${model_name},${model_path},,,,,,,${DATE},,,,${MAX_TOKENS},\"(faked via MLXCEL_BENCH_FAKE_OOM)\",${len},SKIP:oom"
+  } > "$TMP_CELL"
+}
+
+# ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
@@ -124,7 +326,19 @@ if [[ -z "$OUTPUT" ]]; then
 fi
 
 mkdir -p "$(dirname "$OUTPUT")"
-: > "$OUTPUT"   # truncate; header is copied from the first cell
+: > "$OUTPUT"   # truncate; header is copied from the first cell (or written by emit_skip_row)
+
+if [[ -n "${MLXCEL_BENCH_FAKE_OOM:-}" ]]; then
+  IFS=',' read -ra _fake_entries <<< "$MLXCEL_BENCH_FAKE_OOM"
+  for _entry in "${_fake_entries[@]}"; do
+    [[ -z "$_entry" ]] && continue
+    FAKE_OOM_SET["$_entry"]=1
+  done
+fi
+
+if [[ "$IGNORE_OOM_RECORD" != "1" ]]; then
+  load_oom_record
+fi
 
 TMP_CELL=$(mktemp -t bench_longprompt_cell.XXXXXX.csv)
 cleanup() { rm -f "$TMP_CELL"; }
@@ -136,6 +350,11 @@ trap cleanup EXIT
 >&2 echo "  models:  $MODELS"
 >&2 echo "  lengths: $LADDER"
 >&2 echo "  max-tokens=$MAX_TOKENS warmup-tokens=$WARMUP_TOKENS"
+if [[ "$IGNORE_OOM_RECORD" == "1" ]]; then
+  >&2 echo "  oom-record: ${#OOM_RECORD_MODEL[@]} entries loaded but pre-skip DISABLED (MLXCEL_BENCH_IGNORE_OOM_RECORD=1)"
+else
+  >&2 echo "  oom-record: ${#OOM_RECORD_MODEL[@]} entries loaded from $OOM_RECORD_FILE"
+fi
 >&2 echo ""
 
 header_written=0
@@ -147,18 +366,43 @@ for model_name in $MODELS; do
   fi
   for len in $LADDER; do
     >&2 echo "=== $model_name @ ${len} tokens ==="
-    # Reuse the standard runner for one (model, length) cell. --output isolates
-    # the cell so the aggregate CSV is never truncated mid-sweep.
-    "$BENCH_DECODE" "$model_path" \
-      --prompt-tokens "$len" \
-      --max-tokens "$MAX_TOKENS" \
-      --warmup-tokens "$WARMUP_TOKENS" \
-      --cooldown "$COOLDOWN" \
-      --big-cooldown "$BIG_COOLDOWN" \
-      --output "$TMP_CELL" \
-      "${EXTRA_ARGS[@]}" >/dev/null || {
-        >&2 echo "    cell runner exited non-zero (continuing)"
-      }
+
+    # 1. Monotonic backstop: this model already OOM'd at <= len earlier in
+    #    this same sweep.
+    if [[ -n "${OOM_MIN_LEN[$model_name]:-}" ]] && [[ "$len" -ge "${OOM_MIN_LEN[$model_name]}" ]]; then
+      >&2 echo "    backstop: $model_name already SKIP:oom at ${OOM_MIN_LEN[$model_name]} tokens <= ${len}, skipping before launch (SKIP:oom_backstop)"
+      emit_skip_row "$model_name" "$model_path" "$len" "SKIP:oom_backstop"
+      continue
+    fi
+
+    # 2. Persistent record: a prior run recorded this model OOM'ing at <= len.
+    if [[ "$IGNORE_OOM_RECORD" != "1" ]]; then
+      if record_match=$(check_oom_record "$model_name" "$len"); then
+        >&2 echo "    oom-record: matched \"$record_match\", skipping before launch (SKIP:oom_record)"
+        emit_skip_row "$model_name" "$model_path" "$len" "SKIP:oom_record"
+        continue
+      fi
+    fi
+
+    # 3. Testing hook: synthesize a SKIP:oom cell instead of launching.
+    if is_fake_oom_cell "$model_name" "$len"; then
+      >&2 echo "    fake-oom: synthesizing SKIP:oom for $model_name @ ${len} (MLXCEL_BENCH_FAKE_OOM)"
+      synthesize_fake_oom_cell "$model_name" "$model_path" "$len"
+    else
+      # Reuse the standard runner for one (model, length) cell. --output
+      # isolates the cell so the aggregate CSV is never truncated mid-sweep.
+      "$BENCH_DECODE" "$model_path" \
+        --prompt-tokens "$len" \
+        --max-tokens "$MAX_TOKENS" \
+        --warmup-tokens "$WARMUP_TOKENS" \
+        --cooldown "$COOLDOWN" \
+        --big-cooldown "$BIG_COOLDOWN" \
+        --output "$TMP_CELL" \
+        "${EXTRA_ARGS[@]}" >/dev/null || {
+          >&2 echo "    cell runner exited non-zero (continuing)"
+        }
+    fi
+
     if [[ ! -s "$TMP_CELL" ]]; then
       >&2 echo "    no output produced for this cell (continuing)"
       continue
@@ -168,6 +412,16 @@ for model_name in $MODELS; do
       header_written=1
     else
       tail -n +2 "$TMP_CELL" >> "$OUTPUT"
+    fi
+
+    # Only a true SKIP:oom feeds the backstop and the persistent record.
+    # FAIL:bench, timeouts, SKIP:oom_estimate, etc. never do.
+    classification=$(cell_classification)
+    if [[ "$classification" == "SKIP:oom" ]]; then
+      if [[ -z "${OOM_MIN_LEN[$model_name]:-}" ]] || [[ "$len" -lt "${OOM_MIN_LEN[$model_name]}" ]]; then
+        OOM_MIN_LEN[$model_name]="$len"
+      fi
+      append_oom_record "$model_name" "$len"
     fi
   done
 done

--- a/scripts/bench_longprompt.sh
+++ b/scripts/bench_longprompt.sh
@@ -348,6 +348,21 @@ if [[ ! -x "$BENCH_DECODE" ]]; then
   exit 1
 fi
 
+# Every ladder length must be a plain non-negative integer. The OOM backstop
+# and the persistent-record pre-skip both compare the cell length with `[[
+# "$len" -ge N ]]`, and a non-numeric entry (a typo such as "2o48", or "32k")
+# makes that arithmetic error out and silently evaluate false -- which would
+# launch a cell the backstop was supposed to skip. Since launching a
+# near-OOM cell is exactly what wedges the GB10 driver (issue #807), a
+# malformed length is a fatal config error, caught before the sweep starts
+# rather than after hours of running.
+for _len in $LADDER; do
+  if [[ ! "$_len" =~ ^[0-9]+$ ]]; then
+    echo "Error: --lengths must be space-separated non-negative integers; got \"$_len\"." >&2
+    exit 1
+  fi
+done
+
 if [[ -z "$OUTPUT" ]]; then
   BACKEND=$(detect_backend)
   HW=$(detect_hardware_short)

--- a/scripts/bench_longprompt.sh
+++ b/scripts/bench_longprompt.sh
@@ -74,6 +74,29 @@
 
 set -euo pipefail
 
+# This script uses associative arrays (declare -A), a bash 4+ feature. Stock
+# macOS ships bash 3.2 as /bin/bash, and this harness explicitly supports
+# Darwin/Metal (see detect_hardware_short below), so re-exec under a newer
+# bash when one is on PATH (Homebrew installs it at /opt/homebrew/bin or
+# /usr/local/bin). If none is found, fail with an actionable message instead
+# of the cryptic "declare: -A: invalid option" abort bash 3.2 would emit. The
+# guard itself is bash-3-compatible and only re-execs into a bash whose major
+# version is >= 4, so it cannot loop.
+if [[ -z "${BASH_VERSINFO:-}" || "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+  for _alt_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+    if [[ -n "$_alt_bash" && -x "$_alt_bash" ]]; then
+      # shellcheck disable=SC2016  # intentional: the candidate bash must expand this, not us
+      _alt_major=$("$_alt_bash" -c 'echo "${BASH_VERSINFO[0]}"' 2>/dev/null || echo 0)
+      if [[ "$_alt_major" -ge 4 ]]; then
+        exec "$_alt_bash" "$0" "$@"
+      fi
+    fi
+  done
+  echo "Error: bench_longprompt.sh requires bash >= 4 (associative arrays); running under ${BASH_VERSION:-unknown}." >&2
+  echo "       On macOS install a newer bash, e.g. 'brew install bash', or invoke it explicitly: /opt/homebrew/bin/bash scripts/bench_longprompt.sh" >&2
+  exit 1
+fi
+
 trap 'echo "Interrupted (signal received)" >&2; exit 130' INT TERM
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -254,10 +277,16 @@ load_oom_record() {
   while IFS= read -r line || [[ -n "$line" ]]; do
     line_num=$((line_num + 1))
     [[ -z "$line" ]] && continue
-    local rec_model rec_len
+    local rec_model rec_len field_count
     rec_model=$(cut -d, -f1 <<< "$line")
     rec_len=$(cut -d, -f2 <<< "$line")
-    if [[ -z "$rec_model" || ! "$rec_len" =~ ^[0-9]+$ ]]; then
+    # The documented record format is six fields
+    # (model,prompt_target_len,date,commit,peak_bytes,source_csv); reject any
+    # line with fewer, so a truncated/hand-edited entry like "model,32768" is
+    # skipped rather than treated as an active OOM record. A source path that
+    # itself contains a comma only inflates the count, so >= 6 stays lenient.
+    field_count=$(awk -F, '{print NF}' <<< "$line")
+    if [[ "$field_count" -lt 6 || -z "$rec_model" || ! "$rec_len" =~ ^[0-9]+$ ]]; then
       >&2 echo "Warning: malformed line $line_num in $OOM_RECORD_FILE, skipping: $line"
       continue
     fi


### PR DESCRIPTION
## Summary

On the GB10 (DGX Spark, CUDA unified memory) machine, benchmark cells that OOM are worse than wasted time: near-OOM CUDA runs have repeatedly left the driver in a degraded state (NVRM NV_ERR_NO_MEMORY accumulating for hours, eventually wedging the kernel and requiring a reboot), so cells that are certain to OOM should never be launched at all. This PR adds two purely empirical, reactive-only OOM-avoidance layers to `scripts/bench_longprompt.sh`, plus a small hardening item in `scripts/bench_decode.sh`, plus three review-driven hardening fixes to the OOM-avoidance layers themselves.

## What changed

- `scripts/bench_longprompt.sh`: monotonic within-sweep backstop, keyed per model, that skips every remaining cell at length `>=` an observed `SKIP:oom` length for the rest of the run, emitting an explicit `SKIP:oom_backstop` CSV row plus a stderr message.
- `scripts/bench_longprompt.sh`: persistent cross-run OOM record at gitignored `benchmarks/.oom-record` (`model,prompt_target_len,date,commit,peak_bytes,source_csv`, `peak_bytes` always blank today). On later runs, any cell whose model has a recorded OOM at a length `<=` the cell's length is pre-skipped and logged as `SKIP:oom_record`, with the matching record line echoed to stderr. `MLXCEL_BENCH_IGNORE_OOM_RECORD=1` disables the pre-skip for one run (new `SKIP:oom` cells are still appended). Missing/empty record files and malformed lines are tolerated with a stderr warning, not a hard failure.
- `scripts/bench_longprompt.sh`: `MLXCEL_BENCH_FAKE_OOM="model:len[,model:len...]"` testing hook that skips invoking the runner for a listed cell and synthesizes a `SKIP:oom` row, so the backstop and record logic can be exercised deterministically without a real OOM.
- `scripts/bench_longprompt.sh`: only the exact `SKIP:oom` classification feeds either layer; `FAIL:bench`, timeout (exit 124), `SKIP:oom_estimate`, a missing `./models` symlink, and a missing model directory never do, since the gate is a strict string-equality check on the trailing classification token.
- `scripts/bench_longprompt.sh`: the record-file format, pre-skip semantics, the override env var, and staleness/pruning guidance (the PR #676 chunked-prefill fix is used as the concrete precedent: a record taken before that merge is stale and should be pruned with `grep -v`) are documented in both the script's header comment block and its `usage()` text.
- `scripts/bench_decode.sh`: extended the `is_oom_failure` pattern list with three CUDA-specific allocator markers (`CUDA_ERROR_OUT_OF_MEMORY`, `cudaErrorMemoryAllocation`, `cuMemAlloc failed`), kept alongside the existing generic and Metal patterns under the same "specific and grounded" rule.
- `.gitignore`: added `/benchmarks/.oom-record` since it is a locally accumulated, host-specific record and not sweep output meant to be committed.

### Review-driven hardening (3 follow-up fixes)

- `scripts/bench_longprompt.sh`: bash-version guard. The `OOM_MIN_LEN` / `FAKE_OOM_SET` associative arrays (`declare -A`) are a bash 4+ feature, but the script explicitly supports Darwin/Metal and stock macOS ships bash 3.2 as `/bin/bash`, where `declare -A` aborts the whole script at startup (including `--help`). The script now re-execs into a bash `>= 4` found on `PATH` (Homebrew `/opt/homebrew/bin` or `/usr/local/bin`) if one exists, and otherwise exits with an actionable "install a newer bash" message instead of the cryptic `declare: -A: invalid option` failure; the guard cannot loop since it only re-execs into a version that passes the check.
- `scripts/bench_longprompt.sh`: `load_oom_record` field-count validation. It previously validated only the first two fields (non-empty model, numeric length), so a truncated or hand-edited entry like `model,32768` was accepted and pre-skipped indefinitely, contradicting the header comment's promise that wrong-field-count lines are skipped with a warning. It now validates the full field count (`>= 6`, the documented `model,prompt_target_len,date,commit,peak_bytes,source_csv` format) so truncated records are rejected while a `source_csv` path that itself contains a comma stays accepted.
- `scripts/bench_longprompt.sh`: `--lengths` ladder validation. Both the monotonic backstop and the persistent-record pre-skip gate on `[[ "$len" -ge N ]]`, an arithmetic comparison; a non-numeric `--lengths` entry (a typo such as `2o48` or `32k`) made that comparison error out and silently evaluate false, so the cell the backstop was supposed to skip launched anyway and the OOM was never recorded, i.e. the safety net could fail open on a config typo. Every ladder length is now rejected up front, before the output CSV is truncated, if it is not a plain non-negative integer, naming the offending token.

Successful-row CSV output is unchanged; the trailing classification token remains an unnamed field after `prompt_target_len`, consistent with the existing `SKIP:oom_estimate` / `SKIP:oom` / `FAIL:bench` convention in `bench_decode.sh`.

## Test plan

- [x] `bash -n scripts/bench_longprompt.sh` and `bash -n scripts/bench_decode.sh` (syntax check)
- [x] `shellcheck scripts/bench_longprompt.sh scripts/bench_decode.sh` (no new warnings; one pre-existing unrelated SC2002 note in `bench_decode.sh`)
- [x] Fake-OOM sweep: `MLXCEL_BENCH_FAKE_OOM="qwen2.5-0.5b-4bit:512"` with `--lengths "512 2048 8192"` produced `SKIP:oom` at 512 and `SKIP:oom_backstop` at 2048/8192, with no real launch for the backstopped cells; `benchmarks/.oom-record` gained exactly one correctly-formatted line
- [x] Cross-model isolation: a real launch of a second model (`llama-3.2-1b-4bit`) in a separate sweep produced a normal successful row and left the first model's `.oom-record` entry untouched, confirming the backstop and record are keyed per model
- [x] Hand-written record: a manually written `(qwen2.5-0.5b-4bit, 512)` record line pre-skipped all three ladder lengths as `SKIP:oom_record` with no launch and left the record file unchanged; re-running with `MLXCEL_BENCH_IGNORE_OOM_RECORD=1` executed the cell for real instead of pre-skipping it
- [x] Non-OOM isolation: pointing `--models` at a nonexistent model directory produced the existing `[miss]` skip path with zero CSV rows and no `benchmarks/.oom-record` file created
- [x] Malformed-record rejection: a truncated two-field line (`model,32768`) appended to `.oom-record` is skipped with an explicit stderr warning and does not count toward loaded entries, while the valid six-field line alongside it still loads and pre-skips
- [x] Ladder validation: `--lengths "512 2o48"` exits 1 with an explicit "must be space-separated non-negative integers" message before any cell launches or the output CSV is truncated, while a valid ladder still runs and the backstop still fires
- [x] Working tree verified clean of test artifacts afterward; the ~20 pre-existing untracked `benchmarks/*.csv` files were left untouched throughout, and the test-only `benchmarks/.oom-record` file was removed

Closes #807
