### PR TITLE
build: add a fast test profile to cut edit-test iteration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,8 @@ Thank you for your interest in contributing to mlxcel! This document covers the 
    cargo deny check             # advisories + licenses + sources
    ```
    CI enforces `clippy` (with `-D warnings`) and `cargo test` on the `self-hosted-macos-26-arm64` runner on every PR that touches Rust files. CUDA verification is not gated at PR time — that stays exclusive to `release.yml`.
+
+   While iterating, prefer `[profile.test-fast]` over `--release`: `make test-fast` / `make test-fast-cuda` (or `cargo test --profile test-fast --features <...>`) rebuild in seconds instead of minutes. It is for local/agent edit-test loops only — run the `--release` commands above (or `make verify`) before opening or updating a PR. See [`docs/installation.md`](docs/installation.md#fast-iteration-builds) for the measured comparison.
 5. For inference changes, validate against a real checkpoint — synthetic or build-only validation is not enough (see [`AGENTS.md`](AGENTS.md) for why).
 6. Commit with a conventional prefix (see below) and a clear message.
 7. Push to your fork and open a Pull Request. The PR template will prompt for a summary, test plan, and linked issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Thank you for your interest in contributing to mlxcel! This document covers the 
    ```
    CI enforces `clippy` (with `-D warnings`) and `cargo test` on the `self-hosted-macos-26-arm64` runner on every PR that touches Rust files. CUDA verification is not gated at PR time — that stays exclusive to `release.yml`.
 
-   While iterating, prefer `[profile.test-fast]` over `--release`: `make test-fast` / `make test-fast-cuda` (or `cargo test --profile test-fast --features <...>`) rebuild in seconds instead of minutes. It is for local/agent edit-test loops only — run the `--release` commands above (or `make verify`) before opening or updating a PR. See [`docs/installation.md`](docs/installation.md#fast-iteration-builds) for the measured comparison.
+   While iterating, prefer `[profile.test-fast]` over `--release`: `make test-fast` / `make test-fast-cuda` (or `cargo test --profile test-fast --features <...>`) rebuild in seconds instead of minutes. It is for local/agent edit-test loops only; run the `--release` commands above (or `make verify`) before opening or updating a PR. See [`docs/installation.md`](docs/installation.md#fast-iteration-builds) for the measured comparison.
 5. For inference changes, validate against a real checkpoint — synthetic or build-only validation is not enough (see [`AGENTS.md`](AGENTS.md) for why).
 6. Commit with a conventional prefix (see below) and a clear message.
 7. Push to your fork and open a Pull Request. The PR template will prompt for a summary, test plan, and linked issues.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,6 +220,42 @@ opt-level = 3             # Maximum speed optimization (inference is compute-bou
 # crashes cleanly for a supervised restart rather than silently unwinding.
 panic = "unwind"
 
+# Fast profile for local/agent edit-test iteration (issue #809).
+#
+# [profile.release] above is tuned for shipping binaries: fat LTO across all
+# ~439 locked crates plus a single codegen unit (`codegen-units = 1`) for the
+# ~390k-line main crate maximizes runtime performance and minimizes binary
+# size, at the cost of a multi-minute link on every rebuild — measured at
+# 4 to 6 minutes per incremental rebuild, and a typical issue cycle pays 5 to
+# 8 such rebuilds. See docs/installation.md ("Fast iteration builds") for the
+# full measurement writeup.
+#
+# `test-fast` keeps `opt-level = 3` (MLX-heavy tests need optimized numerics
+# for tolerable runtimes) but relaxes everything that exists purely to shrink
+# or speed up the *shipped* binary:
+#   - `codegen-units = 16` restores parallel codegen instead of serializing
+#     the whole crate onto one core.
+#   - `lto = "thin"` keeps cross-crate inlining across the mlxcel /
+#     mlxcel-core workspace boundary (the hot MLX FFI call sites), unlike
+#     `lto = false`, while dropping the whole-program fat-LTO link that
+#     dominates release build time.
+#   - `incremental = true` lets rustc reuse per-function codegen work between
+#     edits instead of recompiling the whole crate query graph from scratch.
+#   - `strip = false` skips a symbol-stripping pass nobody needs for a local
+#     test binary.
+#
+# DO NOT use this profile for anything that ships or gets measured:
+# performance benchmarks, release binaries, or numbers quoted in a PR as
+# representative throughput/latency. Use `[profile.release]` (via
+# `make release*` / `make verify-test`) for those.
+[profile.test-fast]
+inherits = "release"
+lto = "thin"           # cross-crate inlining kept; drops the whole-program fat-LTO link
+codegen-units = 16     # parallel codegen instead of one serialized unit
+strip = false          # skip the strip pass; irrelevant for a local test binary
+incremental = true     # reuse per-function codegen work between edits
+opt-level = 3          # keep: MLX-heavy tests need optimized numerics for tolerable runtimes
+
 [lints.clippy]
 upper_case_acronyms = "allow"
 too_many_arguments = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,7 +225,7 @@ panic = "unwind"
 # [profile.release] above is tuned for shipping binaries: fat LTO across all
 # ~439 locked crates plus a single codegen unit (`codegen-units = 1`) for the
 # ~390k-line main crate maximizes runtime performance and minimizes binary
-# size, at the cost of a multi-minute link on every rebuild — measured at
+# size, at the cost of a multi-minute link on every rebuild, measured at
 # 4 to 6 minutes per incremental rebuild, and a typical issue cycle pays 5 to
 # 8 such rebuilds. See docs/installation.md ("Fast iteration builds") for the
 # full measurement writeup.

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ test-doc: ## Run documentation tests
 # `test` / `verify-test` above build under [profile.release] (fat LTO,
 # codegen-units = 1), which is the right choice for CI-faithful and shipping
 # validation but measured at 4 to 6 minutes per incremental rebuild on the
-# ~390k-line main crate — expensive for the edit-test-edit loop of local and
+# ~390k-line main crate, which is expensive for the edit-test-edit loop of local and
 # agent development. These targets build under [profile.test-fast] instead
 # (thin LTO, parallel codegen, incremental compilation); see the profile's
 # Cargo.toml comment and docs/installation.md ("Fast iteration builds") for

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ MODEL ?= ./models/default
 # Default prompt for examples
 PROMPT ?= "Hello, world!"
 
+# Optional test-name filter forwarded to `cargo test` by the test-fast targets
+# below, e.g. `make test-fast-cuda FILTER=server::chat_request` (issue #809).
+FILTER ?=
+
 # Server settings
 HOST ?= 127.0.0.1
 PORT ?= 8080
@@ -95,6 +99,7 @@ help: ## Show this help message
 	@echo "  make run-generate MODEL=./models/llama PROMPT=\"Tell me a joke\""
 	@echo "  make serve MODEL=./models/qwen PORT=8000"
 	@echo "  make test                            # Run all tests"
+	@echo "  make test-fast-cuda FILTER=server::chat_request  # Fast filtered test-fast-profile run"
 	@echo ""
 
 # ============================================================================
@@ -211,6 +216,37 @@ test-lib: ## Run library tests only
 .PHONY: test-doc
 test-doc: ## Run documentation tests
 	$(CARGO) test --doc
+
+# ----------------------------------------------------------------------------
+# Fast dev-iteration test targets (issue #809)
+#
+# `test` / `verify-test` above build under [profile.release] (fat LTO,
+# codegen-units = 1), which is the right choice for CI-faithful and shipping
+# validation but measured at 4 to 6 minutes per incremental rebuild on the
+# ~390k-line main crate — expensive for the edit-test-edit loop of local and
+# agent development. These targets build under [profile.test-fast] instead
+# (thin LTO, parallel codegen, incremental compilation); see the profile's
+# Cargo.toml comment and docs/installation.md ("Fast iteration builds") for
+# the measured speedup. Set FILTER to narrow the run, e.g.
+# `make test-fast-cuda FILTER=server::chat_request`.
+# ----------------------------------------------------------------------------
+
+.PHONY: test-fast
+test-fast: ## Run tests under the fast dev-iteration profile (macOS adds metal,accelerate; set FILTER=<path>; issue #809)
+	@echo "$(CYAN)Running tests (test-fast profile)...$(RESET)"
+	$(CARGO) test --profile test-fast $(RELEASE_FEATURE_FLAG) $(FILTER) -- --test-threads=1
+	@echo "$(GREEN)All tests passed!$(RESET)"
+
+.PHONY: test-fast-cuda
+test-fast-cuda: ## Run tests under the fast dev-iteration profile with CUDA (Linux/NVIDIA; set FILTER=<path>; issue #809)
+	@echo "$(CYAN)Running tests (test-fast profile, CUDA)...$(RESET)"
+	$(CARGO) test --profile test-fast --features cuda $(FILTER) -- --test-threads=1
+	@echo "$(GREEN)All tests passed!$(RESET)"
+
+.PHONY: check-fast
+check-fast: ## Check all targets under the fast dev-iteration profile (issue #809)
+	@echo "$(CYAN)Checking code (test-fast profile)...$(RESET)"
+	$(CARGO) check --all-targets --profile test-fast $(RELEASE_FEATURE_FLAG)
 
 .PHONY: check
 check: ## Check code without building

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -286,7 +286,7 @@ cargo test --release --features cuda -- --test-threads=1
 fat LTO across all ~439 locked crates plus `codegen-units = 1` for the
 ~390k-line main crate. That is the right tradeoff for CI-faithful validation
 and for anything you ship, but it is expensive for the day-to-day edit-test
-loop — measured at 4 to 6 minutes per incremental rebuild, so a typical issue
+loop: measured at 4 to 6 minutes per incremental rebuild, so a typical issue
 cycle of several edit-test iterations pays 20+ minutes of pure compile time.
 
 For local and agent development, use `[profile.test-fast]` instead (thin LTO,
@@ -310,9 +310,16 @@ or invoke cargo directly:
 cargo test --profile test-fast --features cuda -- --test-threads=1
 ```
 
+Measured on the Linux/CUDA development machine (2026-07): a cold `test-fast`
+build (all dependencies plus the MLX C++ tree) takes about 4m53s, and an
+incremental rebuild after touching one main-crate source file takes about 19s,
+versus 4 to 6 minutes under `[profile.release]`, roughly a 13x to 19x
+iteration speedup. A representative narrow test set (139 tests across model,
+server, sampling, and cache modules) passes identically under both profiles.
+
 `test-fast` is for iteration only. Use `[profile.release]` (`make release*`,
 `make verify-test`, or plain `cargo test --release`) for anything you ship,
-benchmark, or quote as representative performance — `test-fast` trades link
+benchmark, or quote as representative performance: `test-fast` trades link
 time and binary size for rebuild speed and is not tuned for either.
 
 ## Troubleshooting

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -280,6 +280,41 @@ binaries are unaffected; this is a test-parallelism artifact.
 cargo test --release --features cuda -- --test-threads=1
 ```
 
+## Fast iteration builds
+
+`cargo test --release` (and `cargo build --release`) use `[profile.release]`:
+fat LTO across all ~439 locked crates plus `codegen-units = 1` for the
+~390k-line main crate. That is the right tradeoff for CI-faithful validation
+and for anything you ship, but it is expensive for the day-to-day edit-test
+loop — measured at 4 to 6 minutes per incremental rebuild, so a typical issue
+cycle of several edit-test iterations pays 20+ minutes of pure compile time.
+
+For local and agent development, use `[profile.test-fast]` instead (thin LTO,
+`codegen-units = 16`, incremental compilation, `strip = false`; still
+`opt-level = 3` so MLX-heavy numerics stay representative):
+
+```bash
+# CPU / Metal / Accelerate (macOS adds metal,accelerate automatically)
+make test-fast
+
+# Linux / CUDA
+make test-fast-cuda
+
+# Narrow to a subset while iterating
+make test-fast-cuda FILTER=server::chat_request
+```
+
+or invoke cargo directly:
+
+```bash
+cargo test --profile test-fast --features cuda -- --test-threads=1
+```
+
+`test-fast` is for iteration only. Use `[profile.release]` (`make release*`,
+`make verify-test`, or plain `cargo test --release`) for anything you ship,
+benchmark, or quote as representative performance — `test-fast` trades link
+time and binary size for rebuild speed and is not tuned for either.
+
 ## Troubleshooting
 
 **Missing Metal toolchain on macOS** — run


### PR DESCRIPTION
## Summary

Add `[profile.test-fast]` to Cargo.toml plus Makefile and doc support so local and agent edit-test iteration no longer pays the `[profile.release]` fat-LTO + `codegen-units = 1` cost, which is measured at 4 to 6 minutes per incremental rebuild of the ~390k-line main crate today.

## What changed

- `Cargo.toml`: new `[profile.test-fast]` (`inherits = "release"`, `lto = "thin"`, `codegen-units = 16`, `strip = false`, `incremental = true`, `opt-level = 3` kept), with a comment explaining why it exists and when not to use it, mirroring the `[profile.release]` comment style.
- `Makefile`: new `test-fast` (platform-aware, mirrors `release`/`RELEASE_FEATURE_FLAG`), `test-fast-cuda` (mirrors `release-cuda`, explicit `--features cuda`), and `check-fast` targets, all wrapping `cargo test`/`cargo check --profile test-fast`; a `FILTER` variable for narrowing runs; a `make help` example line.
- `docs/installation.md`: new "Fast iteration builds" subsection explaining the tradeoff and giving `make test-fast` / `make test-fast-cuda` / `FILTER=` usage.
- `CONTRIBUTING.md`: points contributors at `test-fast` for iteration in the existing build/test step, while keeping the `--release` commands as the pre-PR gate.

## Why `lto = "thin"` and not `false`

The workspace is split across crates (`mlxcel`, `mlxcel-core`, `mlxcel-surgery`), and the hot MLX FFI call sites cross that `mlxcel` / `mlxcel-core` boundary. `lto = "thin"` keeps cross-crate inlining there while dropping the whole-program fat-LTO link that dominates release build time; `lto = false` would wall off that boundary from inlining entirely. The measured incremental number below already lands well inside the "seconds, not minutes" target with thin LTO, so there was no measured case for dropping further to `false` and risking a numerics regression in MLX-heavy tests.

## Measured timings (this session, Linux/CUDA, `CARGO_TARGET_DIR` pointed at the shared target dir)

- Cold build (`cargo test --profile test-fast --features cuda --lib -- models::minimax_m3 server::chat_request`, all ~439 deps plus the MLX CUDA C++ tree compiled under the new profile for the first time): 293s (4m53s) wall clock, 343 crates compiled.
- Incremental rebuild (`touch src/server/chat_request.rs`, same narrow test target): 19s wall clock (17.46s of that is the `cargo` compile step itself).
- Baseline for comparison: today's `[profile.release]` incremental rebuild of the same crate is measured at 4 to 6 minutes (240 to 360s).
- Incremental speedup: roughly 13x to 19x, well above the 3 to 5x expected in the issue.

## Parity check

Ran the representative narrow test set from the issue under `test-fast` and compared against today's release-profile pass counts (recorded from today's implementation chain runs on the same code at `main` `80a05f9`, not rerun here to avoid clobbering a busy shared build directory):

- `cargo test --profile test-fast --features cuda --lib -- models::minimax_m3 server::chat_request`: 78 passed, 0 failed (10 `minimax_m3` + 68 `chat_request`), matching the release-profile counts.
- `cargo test --profile test-fast --features cuda -p mlxcel-core -- sampling cache::ring`: 61 passed, 0 failed (57 sampling + 4 `cache::ring`), matching the release-profile counts.

## Test plan

- [x] `cargo test --profile test-fast --features cuda --lib -- models::minimax_m3 server::chat_request` (78 passed, 0 failed)
- [x] `cargo test --profile test-fast --features cuda -p mlxcel-core -- sampling cache::ring` (61 passed, 0 failed)
- [x] Cold and incremental timings recorded above
- [x] No `.rs` files touched, so `cargo fmt --all -- --check` is not applicable to this change

Closes #809
