### PR TITLE
fix(server): reject /v1/messages requests with no effective input

### DIFF
--- a/src/server/routes/anthropic.rs
+++ b/src/server/routes/anthropic.rs
@@ -42,7 +42,7 @@ use crate::server::anthropic_translator::{
     AnthropicTranslated, anthropic_request_to_chat, anthropic_stop_reason, apply_stop_sequences,
     build_content_blocks, parsed_call_to_tool_use, short_uuid, thinking_enabled,
 };
-use crate::server::chat_request::prepare_chat_request_with_cache;
+use crate::server::chat_request::{prepare_chat_request_with_cache, request_has_effective_input};
 use crate::server::config::ReasoningBudgetOverride;
 use crate::server::streaming_anthropic::{AnthropicBlockEmitter, anthropic_sse_channel};
 use crate::server::thinking_budget::{pick_budget_alias, resolve_request_budget};
@@ -68,6 +68,19 @@ pub async fn anthropic_messages(
     Json(request): Json<AnthropicRequest>,
 ) -> Response {
     let translated = anthropic_request_to_chat(&request);
+
+    // Reject requests with no effective input before any model dispatch
+    // (issue #805, extending the #773 guard to the Anthropic Messages
+    // route). Runs on the translated `ChatCompletionRequest` so a non-empty
+    // top-level `system` prompt (folded into a leading system message by
+    // `anthropic_request_to_chat`) counts toward "effective input" the same
+    // way `instructions`-alone does on the responses route.
+    if !request_has_effective_input(&translated.chat_request) {
+        return AnthropicErrorResponse::bad_request(
+            "Request must include at least one non-empty message content or media input.",
+        )
+        .into_response();
+    }
 
     // Enforce the tools array size limit to prevent DoS via template
     // rendering, matching the chat-completions route. The check runs on the
@@ -649,5 +662,110 @@ mod tests {
             split_visible_reasoning("<|channel|>analysis<|message|>x", Some(&parsed));
         assert_eq!(visible, "");
         assert_eq!(reasoning.as_deref(), Some("analysis scratchpad"));
+    }
+
+    // -- no-effective-input rejection (issue #805), exercised on the
+    // translated request `anthropic_messages` actually checks, mirroring the
+    // matrix in `super::responses::tests` (issue #773 / #803).
+
+    fn parse_req(body: &str) -> AnthropicRequest {
+        serde_json::from_str(body).unwrap()
+    }
+
+    fn translate(body: &str) -> crate::server::types::request::ChatCompletionRequest {
+        anthropic_request_to_chat(&parse_req(body)).chat_request
+    }
+
+    #[test]
+    fn anthropic_route_rejects_empty_messages_array() {
+        let chat_request = translate(r#"{"model":"m","max_tokens":8,"messages":[]}"#);
+        assert!(!request_has_effective_input(&chat_request));
+    }
+
+    #[test]
+    fn anthropic_route_rejects_single_empty_string_content() {
+        let chat_request =
+            translate(r#"{"model":"m","max_tokens":8,"messages":[{"role":"user","content":""}]}"#);
+        assert!(!request_has_effective_input(&chat_request));
+    }
+
+    #[test]
+    fn anthropic_route_rejects_whitespace_only_content() {
+        let chat_request = translate(
+            r#"{"model":"m","max_tokens":8,"messages":[{"role":"user","content":"   \n\t"}]}"#,
+        );
+        assert!(!request_has_effective_input(&chat_request));
+    }
+
+    #[test]
+    fn anthropic_route_rejects_content_list_with_only_empty_text_block() {
+        let chat_request = translate(
+            r#"{"model":"m","max_tokens":8,"messages":[
+                {"role":"user","content":[{"type":"text","text":""}]}
+            ]}"#,
+        );
+        assert!(!request_has_effective_input(&chat_request));
+    }
+
+    #[test]
+    fn anthropic_route_accepts_image_only_message() {
+        let chat_request = translate(
+            r#"{"model":"m","max_tokens":8,"messages":[
+                {"role":"user","content":[
+                    {"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGVsbG8="}}
+                ]}
+            ]}"#,
+        );
+        assert!(request_has_effective_input(&chat_request));
+    }
+
+    #[test]
+    fn anthropic_route_accepts_tool_result_only_message() {
+        let chat_request = translate(
+            r#"{"model":"m","max_tokens":8,"messages":[{"role":"user","content":[
+                {"type":"tool_result","tool_use_id":"toolu_1","content":"sunny"}
+            ]}]}"#,
+        );
+        assert!(request_has_effective_input(&chat_request));
+    }
+
+    #[test]
+    fn anthropic_route_history_with_real_content_passes_despite_empty_last_message() {
+        let chat_request = translate(
+            r#"{"model":"m","max_tokens":8,"messages":[
+                {"role":"user","content":"What is the capital of France?"},
+                {"role":"assistant","content":"Paris."},
+                {"role":"user","content":""}
+            ]}"#,
+        );
+        assert!(request_has_effective_input(&chat_request));
+    }
+
+    #[test]
+    fn anthropic_route_system_prompt_alone_counts_as_effective_input() {
+        // `system` is folded into a leading system message by
+        // `anthropic_request_to_chat` (see `anthropic_translator.rs`), so a
+        // request with an empty `messages` array but a real `system` prompt
+        // is not degenerate, consistent with how `instructions`-alone is
+        // treated on the responses route (issue #803).
+        let chat_request = translate(
+            r#"{"model":"m","max_tokens":8,"system":"You are a helpful assistant.","messages":[]}"#,
+        );
+        assert!(request_has_effective_input(&chat_request));
+    }
+
+    #[test]
+    fn anthropic_route_rejects_empty_system_and_empty_messages() {
+        let chat_request =
+            translate(r#"{"model":"m","max_tokens":8,"system":"   ","messages":[]}"#);
+        assert!(!request_has_effective_input(&chat_request));
+    }
+
+    #[test]
+    fn anthropic_route_accepts_normal_request() {
+        let chat_request = translate(
+            r#"{"model":"m","max_tokens":8,"messages":[{"role":"user","content":"Hello there"}]}"#,
+        );
+        assert!(request_has_effective_input(&chat_request));
     }
 }


### PR DESCRIPTION
## Summary

`POST /v1/messages` (the Anthropic-compatible route) dispatched requests to model generation without checking for effective input, unlike `/v1/chat/completions` and `/v1/responses` which already reject empty or whitespace-only requests before dispatch (#773, #803). This extends the same guard to the Anthropic route, closing the gap flagged during the #803 review.

## What changed

- `src/server/routes/anthropic.rs`: `anthropic_messages` now calls `request_has_effective_input` (from `src/server/chat_request.rs`) on the translated `ChatCompletionRequest`, immediately after `anthropic_request_to_chat` and before the `MAX_TOOLS` guard. Rejected requests get HTTP 400 with the Anthropic error envelope via the existing `AnthropicErrorResponse::bad_request` helper, using the same message string as the other two routes: "Request must include at least one non-empty message content or media input."
- No new effective-input logic: `anthropic_request_to_chat` already flattens text, image, tool_use, tool_result, thinking, and system-prompt content into the internal `Message` shape the helper already understands, so the check is reused as-is.
- Added a 10-case test matrix to the existing `anthropic::tests` module: empty messages array, single empty-string content, whitespace-only content, content list with only an empty text block, image-only message (passes), tool_result-only message (passes), history with real content despite an empty last message (passes), system-prompt-alone request (passes, consistent with how `instructions`-alone is treated on the responses route), empty system prompt with empty messages (rejected), and a normal request (passes).

## Test plan

- [x] `cargo test --profile test-fast --features cuda --lib -- server::routes::anthropic server::chat_request` (83 passed, 0 failed)
- [x] `cargo clippy --profile test-fast --features cuda --lib -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Closes #805
