### PR TITLE
fix(server): reject whitespace-only prompts on /v1/completions

### DIFF
--- a/docs/responses-api.md
+++ b/docs/responses-api.md
@@ -116,7 +116,11 @@ the translated conversation (including history pulled in through
 `invalid_request_error`. A blank `input` combined with non-empty
 `instructions` still passes, since `instructions` becomes a real system
 message in the rendered conversation. The same check applies to
-`/v1/chat/completions`.
+`/v1/chat/completions`. `/v1/completions` (the raw-prompt legacy endpoint) is
+a deliberate exception: it rejects a whitespace-only prompt with the same 400
+`invalid_request_error`, but allows a fully empty prompt through, since
+unconditional generation from BOS is a legitimate base-model use case on a
+route that has no chat-template scaffolding to be empty around (issue #806).
 
 ## Response shape
 

--- a/src/server/routes/completions.rs
+++ b/src/server/routes/completions.rs
@@ -110,12 +110,40 @@ fn build_single_token_completion_logprobs(
     }
 }
 
+/// Returns `true` when `prompt` is whitespace-only but non-empty (issue
+/// #806): a string that survives deserialization as a `String` but has no
+/// non-whitespace character.
+///
+/// A fully empty prompt (`""`) is deliberately *not* flagged by this
+/// predicate: unlike the chat-shaped routes (`/v1/chat/completions`,
+/// `/v1/responses`, `/v1/messages`), which always have template scaffolding
+/// around user content, `/v1/completions` takes a raw prompt with no
+/// scaffolding, so an empty prompt is a legitimate request for unconditional
+/// generation from BOS on a base/text-completion model. `"   \n\t"`-shaped
+/// prompts have no such legitimate reading, so they are treated the same as
+/// no effective input.
+fn prompt_is_whitespace_only(prompt: &str) -> bool {
+    !prompt.is_empty() && prompt.trim().is_empty()
+}
+
 /// POST /v1/completions
 pub async fn completions(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(request): Json<CompletionRequest>,
 ) -> Response {
+    // Reject whitespace-only-but-nonempty prompts before any model dispatch,
+    // alongside the route's other pre-dispatch validations (issue #806).
+    // See `prompt_is_whitespace_only` for why an empty prompt is allowed
+    // through instead of rejected here.
+    if prompt_is_whitespace_only(&request.prompt) {
+        return ErrorResponse::new(
+            "Request must include at least one non-empty message content or media input.",
+            "invalid_request_error",
+        )
+        .into_response();
+    }
+
     // Validate logprobs range per OpenAI spec (0-5 for legacy completions)
     if let Some(top) = request.logprobs
         && top > 5
@@ -437,5 +465,75 @@ mod tests {
             validate_xtc_params(request.params.xtc_threshold, request.params.xtc_probability)
                 .is_ok()
         );
+    }
+
+    // -- no-effective-input decision for /v1/completions (issue #806) --
+    //
+    // Unlike the chat-shaped routes, `/v1/completions` deliberately allows a
+    // fully empty prompt through (unconditional generation from BOS is a
+    // legitimate base-model use case) while still rejecting
+    // whitespace-only-but-nonempty prompts, which have no such legitimate
+    // reading. These tests exercise `prompt_is_whitespace_only`, the same
+    // predicate the `completions` handler calls before dispatch.
+
+    #[test]
+    fn completions_rejects_whitespace_only_spaces() {
+        assert!(prompt_is_whitespace_only("   "));
+    }
+
+    #[test]
+    fn completions_rejects_whitespace_only_newline() {
+        assert!(prompt_is_whitespace_only("\n"));
+    }
+
+    #[test]
+    fn completions_rejects_whitespace_only_tabs_and_mixed() {
+        assert!(prompt_is_whitespace_only("\t \n\t"));
+    }
+
+    /// Pinned regression test: an empty prompt (`""`) is an intentional
+    /// unconditional-generation request on `/v1/completions` (issue #806)
+    /// and must NOT be rejected by the guard. This test exists specifically
+    /// so a future change cannot silently regress that decision back to
+    /// rejecting empty prompts.
+    #[test]
+    fn completions_allows_fully_empty_prompt() {
+        assert!(!prompt_is_whitespace_only(""));
+    }
+
+    #[test]
+    fn completions_allows_normal_prompt() {
+        assert!(!prompt_is_whitespace_only("Hello, world"));
+    }
+
+    #[test]
+    fn completions_no_effective_input_error_matches_issue_773_spec() {
+        // The handler's whitespace-only-prompt rejection must surface the
+        // same HTTP 400 `invalid_request_error` shape and message string as
+        // the #773 guard used on the chat-shaped routes.
+        let response = ErrorResponse::new(
+            "Request must include at least one non-empty message content or media input.",
+            "invalid_request_error",
+        );
+        assert_eq!(response.status, axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(response.error.error_type, "invalid_request_error");
+        assert_eq!(
+            response.error.message,
+            "Request must include at least one non-empty message content or media input."
+        );
+    }
+
+    #[test]
+    fn completions_deserializes_empty_and_whitespace_prompts() {
+        // Confirms `{"prompt":""}` and a whitespace-only prompt both pass
+        // deserialization (required `String`, not `Option`), so the guard
+        // is the only line of defense before dispatch.
+        let empty: CompletionRequest =
+            serde_json::from_str(r#"{"model":"m","prompt":""}"#).unwrap();
+        assert!(!prompt_is_whitespace_only(&empty.prompt));
+
+        let whitespace: CompletionRequest =
+            serde_json::from_str(r#"{"model":"m","prompt":"  \n\t"}"#).unwrap();
+        assert!(prompt_is_whitespace_only(&whitespace.prompt));
     }
 }


### PR DESCRIPTION
## Summary

`POST /v1/completions` had no guard against degenerate empty-input requests: `prompt` is a required `String`, so both `{"prompt":""}` and whitespace-only prompts (`"   "`, `"\n\t"`) passed deserialization and dispatched straight to generation. This decides and enforces the semantics: whitespace-only-but-nonempty prompts are rejected before dispatch, while a fully empty prompt is deliberately allowed through, since unconditional generation from BOS is a legitimate base-model use case on a route with no chat-template scaffolding (unlike `/v1/chat/completions` and `/v1/responses`, already covered by the #773 guard).

## What changed

- `src/server/routes/completions.rs`: added `prompt_is_whitespace_only`, called from the `completions` handler before any other pre-dispatch validation (XTC params, thinking-budget parsing, structured-output constraint build). Returns the same HTTP 400 `invalid_request_error` shape and message string as the #773 guard on the chat-shaped routes.
- Added unit tests: whitespace-only rejection across several shapes (spaces, newline, mixed tabs/newline), a pinned regression test asserting the empty-string-allowed decision so it cannot silently regress, a normal-prompt acceptance test, an error-envelope shape test, and a deserialization test confirming both `""` and whitespace-only prompts pass `CompletionRequest` deserialization (since `prompt` is a required, non-`Option` `String`).
- `docs/responses-api.md`: added a sentence next to the existing #773 effective-input description noting `/v1/completions` as a deliberate exception with different empty-vs-whitespace semantics.

## Test plan

- [x] `cargo test --profile test-fast --features cuda --lib -- server::routes::completions` (10 passed: 7 new tests plus 3 pre-existing XTC validation tests)
- [x] `cargo fmt --all -- --check`

Closes #806
