### PR TITLE
perf(server): allocation-free effective-input text check

### DIFF
--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -325,14 +325,15 @@ pub(crate) fn request_has_effective_input(request: &ChatCompletionRequest) -> bo
 
 /// Single-message half of [`request_has_effective_input`].
 fn message_has_effective_input(message: &Message) -> bool {
-    if !message.content.text().trim().is_empty() {
+    if message.content.has_effective_text() {
         return true;
     }
 
     if let MessageContent::Parts(parts) = &message.content {
         for part in parts {
             match part {
-                // Text parts are already covered by `content.text()` above.
+                // Text parts are already covered by
+                // `content.has_effective_text()` above.
                 ContentPart::Text { .. } => {}
                 ContentPart::ImageUrl { image_url } => {
                     if !image_url.url.trim().is_empty() {

--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -1834,7 +1834,7 @@ fn effective_input_rejects_content_list_with_only_an_empty_text_item() {
 
 #[test]
 fn effective_input_rejects_content_list_with_several_whitespace_only_text_items() {
-    // Several whitespace-only text parts, joined, are still whitespace-only —
+    // Several whitespace-only text parts, joined, are still whitespace-only;
     // this exercises the `Parts` branch of `has_effective_text` with more
     // than one part, none of which is individually non-whitespace.
     let request = request_with_messages(vec![Message {

--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -1833,6 +1833,72 @@ fn effective_input_rejects_content_list_with_only_an_empty_text_item() {
 }
 
 #[test]
+fn effective_input_rejects_content_list_with_several_whitespace_only_text_items() {
+    // Several whitespace-only text parts, joined, are still whitespace-only —
+    // this exercises the `Parts` branch of `has_effective_text` with more
+    // than one part, none of which is individually non-whitespace.
+    let request = request_with_messages(vec![Message {
+        role: Role::User,
+        content: MessageContent::Parts(vec![
+            ContentPart::Text {
+                text: "   ".to_string(),
+            },
+            ContentPart::Text {
+                text: "\n\t".to_string(),
+            },
+            ContentPart::Text {
+                text: String::new(),
+            },
+        ]),
+        name: None,
+        tool_call_id: None,
+        reasoning: None,
+        tool_calls: None,
+    }]);
+    assert!(!request_has_effective_input(&request));
+}
+
+#[test]
+fn effective_input_accepts_content_list_with_one_non_whitespace_text_among_whitespace_ones() {
+    // Only one of several text parts is non-whitespace; `has_effective_text`
+    // must find it via `any` even though the first part(s) are blank.
+    let request = request_with_messages(vec![Message {
+        role: Role::User,
+        content: MessageContent::Parts(vec![
+            ContentPart::Text {
+                text: "   ".to_string(),
+            },
+            ContentPart::Text {
+                text: "hello".to_string(),
+            },
+            ContentPart::Text {
+                text: "".to_string(),
+            },
+        ]),
+        name: None,
+        tool_call_id: None,
+        reasoning: None,
+        tool_calls: None,
+    }]);
+    assert!(request_has_effective_input(&request));
+}
+
+#[test]
+fn effective_input_rejects_empty_content_parts_list() {
+    // An empty `Parts` vec (no text, no media parts at all) must not count
+    // as effective input.
+    let request = request_with_messages(vec![Message {
+        role: Role::User,
+        content: MessageContent::Parts(vec![]),
+        name: None,
+        tool_call_id: None,
+        reasoning: None,
+        tool_calls: None,
+    }]);
+    assert!(!request_has_effective_input(&request));
+}
+
+#[test]
 fn effective_input_accepts_image_only_request() {
     let request = request_with_messages(vec![Message {
         role: Role::User,

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -343,6 +343,22 @@ impl MessageContent {
         }
     }
 
+    /// Returns `true` when the content has at least one non-whitespace text
+    /// character, without allocating a `String` the way [`Self::text`] does.
+    ///
+    /// Equivalent to `!self.text().trim().is_empty()`: joining `Parts` text
+    /// parts with `""` is non-whitespace iff at least one part is
+    /// non-whitespace on its own, so a per-part `any` check gives the same
+    /// answer as trimming the joined string.
+    pub fn has_effective_text(&self) -> bool {
+        match self {
+            MessageContent::Text(s) => !s.trim().is_empty(),
+            MessageContent::Parts(parts) => parts
+                .iter()
+                .any(|p| matches!(p, ContentPart::Text { text } if !text.trim().is_empty())),
+        }
+    }
+
     /// Extract image data URIs/paths from multimodal content
     pub fn image_urls(&self) -> Vec<String> {
         match self {
@@ -974,6 +990,51 @@ mod tests {
         let c = MessageContent::default();
         assert_eq!(c.text(), "");
         assert!(matches!(c, MessageContent::Text(_)));
+    }
+
+    /// `has_effective_text` must agree with `!text().trim().is_empty()` for
+    /// every shape (issue #804): `Text` variants directly, and `Parts`
+    /// variants where the borrow-only per-part `any` check has to reach the
+    /// same verdict as trimming the fully joined string.
+    #[test]
+    fn has_effective_text_matches_text_trim_is_empty_for_all_shapes() {
+        let cases = [
+            MessageContent::Text(String::new()),
+            MessageContent::Text("   \n\t  ".to_string()),
+            MessageContent::Text("hello".to_string()),
+            MessageContent::Parts(vec![]),
+            MessageContent::Parts(vec![ContentPart::Text {
+                text: String::new(),
+            }]),
+            MessageContent::Parts(vec![
+                ContentPart::Text {
+                    text: "   ".to_string(),
+                },
+                ContentPart::Text {
+                    text: "\n\t".to_string(),
+                },
+            ]),
+            MessageContent::Parts(vec![
+                ContentPart::Text {
+                    text: "   ".to_string(),
+                },
+                ContentPart::Text {
+                    text: "hi".to_string(),
+                },
+            ]),
+            MessageContent::Parts(vec![ContentPart::ImageUrl {
+                image_url: ImageUrl::new("data:image/png;base64,aGVsbG8="),
+            }]),
+        ];
+        for content in cases {
+            let expected = !content.text().trim().is_empty();
+            assert_eq!(
+                content.has_effective_text(),
+                expected,
+                "mismatch for {content:?}: text()={:?}",
+                content.text()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`message_has_effective_input` (added by #803 for issue #773) validated a message's text via `message.content.text().trim().is_empty()`, and `MessageContent::text()` is not allocation-free: it clones the full string for the `Text` variant and collects-then-joins content parts into a fresh `String` for the `Parts` variant, so a request-validation check that runs before any model dispatch was paying an unnecessary allocation. This replaces it with a borrow-only check.

## What changed

- `src/server/types/request.rs`: added `MessageContent::has_effective_text(&self) -> bool` next to the existing `text()` method. `Text(s)` trims and checks the borrowed `&str` directly; `Parts(parts)` uses `parts.iter().any(...)` over each `ContentPart::Text` part's borrowed text, with no `String` allocation in either branch. `MessageContent::text()` itself is untouched, so there is no public API change to the existing method.
- `src/server/chat_request.rs`: `message_has_effective_input` now calls `message.content.has_effective_text()` instead of `message.content.text().trim().is_empty()`. The stale comment on the `Parts` loop (previously "Text parts are already covered by `content.text()` above") is updated to reference `has_effective_text()`.
- Equivalence argument: joining `Parts` text parts with `""` produces a non-whitespace string if and only if at least one individual part is non-whitespace (whitespace-only parts joined together stay whitespace-only, since `""` insertion adds nothing), so the per-part `any(!text.trim().is_empty())` check gives byte-for-byte identical accept/reject outcomes to the old `text().trim().is_empty()` check for every input shape.
- Survey (per the issue's optional checklist): grepped `src/server/` for other `.text()` call sites that might purely check emptiness/length. `chat_request.rs`'s rolling-checkpoint stripping (lines ~408/420/560/570) and `anthropic_translator.rs`'s system-message merging and translation (lines ~347/351/1069) all consume the owned, joined text itself, not just its emptiness, so none of them are convertible to the new helper. `types/request.rs`'s `to_prompt()` also needs the full text. The scope of this change therefore stays limited to the validation helper, matching the issue's own assessment that this is a checklist item rather than a requirement.
- `src/server/chat_request_tests.rs`: added three gap-filling test cases not previously covered by the #773/#803 matrix: `effective_input_rejects_content_list_with_several_whitespace_only_text_items` (several whitespace-only `Parts` text items, still non-effective), `effective_input_accepts_content_list_with_one_non_whitespace_text_among_whitespace_ones` (one non-whitespace text part among whitespace ones, effective), and `effective_input_rejects_empty_content_parts_list` (an empty `Parts` vec with no media parts, non-effective). All existing effective-input tests are unchanged.
- `src/server/types/request.rs` tests: added `has_effective_text_matches_text_trim_is_empty_for_all_shapes`, a table-driven check asserting `has_effective_text()` agrees with `!text().trim().is_empty()` across `Text` (empty, whitespace-only, non-whitespace) and `Parts` (empty, single empty text part, multiple whitespace-only text parts, one non-whitespace among whitespace, a non-text `ImageUrl` part) shapes.

## Test plan

- [x] `cargo check --lib --tests`
- [x] `make test-fast-cuda FILTER=server::chat_request` (71 passed, 0 failed, the full `server::chat_request` module including the new gap-filling cases)
- [x] `cargo test --profile test-fast --features cuda has_effective_text -- --test-threads=1` (1 passed, 0 failed, the new `MessageContent::has_effective_text` equivalence test in `types/request.rs`, outside the narrower filter above)

Closes #804
