### PR TITLE
refactor(vlm): add owned host prefill preprocessing (#859)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,10 @@ pub use mlxcel_core::generate::{
     SamplingConfig,
 };
 pub use mlxcel_core::speculative::SpeculativeGenerator;
+pub use multimodal::host_preprocessor::{
+    FakeHostMultimodalPreprocessor, HostMultimodalPreprocessor, HostPreprocessorError,
+    LlavaHostPreprocessor,
+};
 pub use multimodal::{
     internvl_prompt, kimi_vl_prompt, minicpmo_prompt, moondream2_prompt, moondream3_prompt,
     phi3v_prompt, phi4_siglip_prompt, phi4mm_prompt, pixtral_prompt, qwen_vl, smolvlm_prompt,
@@ -88,7 +92,11 @@ pub use multimodal::{
 // the server batched path keeps using `load_model`. Under default features both
 // fold to the single MLX variant with no runtime dispatch.
 pub use backend::{Backend, ComputeBackend, MlxBackend, Session, select_backend};
-pub use mlxcel_core::session::{InferenceSession, MlxInferenceSession, SessionCapabilities};
+pub use mlxcel_core::session::{
+    InferenceSession, MlxInferenceSession, OwnedTensor, PreparedAttentionBias, PreparedModality,
+    PreparedPositions, PreparedPrefill, PreparedPrefillError, PreparedTensorDType,
+    SessionCapabilities,
+};
 
 // Re-export split modules
 pub use loaded_model::LoadedModel;

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -2595,6 +2595,10 @@ pub use ops::{concatenate, divide_scalar, multiply_scalar, stack, stack_owned, w
 pub use sampling::TokenBiasMap;
 // Re-export the inference-session contract (issue #448, ADR 0004) so the root
 // crate's compute-backend seam can construct and dispatch MLX sessions.
+pub use multimodal::{
+    OwnedTensor, PreparedAttentionBias, PreparedModality, PreparedPositions, PreparedPrefill,
+    PreparedPrefillError, PreparedTensorDType,
+};
 pub use session::{InferenceSession, MlxInferenceSession, SessionCapabilities};
 // Re-export N-gram loop-detection so the server control plane and CLI decode
 // loops can configure and run early-stop on degenerate token-repetition.
@@ -2938,6 +2942,11 @@ pub mod generate;
 // `InferenceSession` trait plus the MLX `MlxInferenceSession` that wraps
 // `CxxGenerator`. The CLI single-sequence paths drive generation through this.
 pub mod session;
+
+// Backend-neutral owned tensors produced by host-side multimodal preprocessing.
+// Kept beside the session contract so compiler backends can consume prepared
+// prefills without depending on MLX array handles or server request types.
+pub mod multimodal;
 
 // Decode-loop setup helpers shared by standard and speculative generation.
 // Public so that the server batch scheduler can reuse seed/EOS/history helpers.

--- a/src/lib/mlxcel-core/src/multimodal.rs
+++ b/src/lib/mlxcel-core/src/multimodal.rs
@@ -1,0 +1,280 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Backend-neutral multimodal prefill values.
+//!
+//! These types form the ownership boundary between a host-side media
+//! preprocessor and an inference engine. They deliberately contain only owned
+//! Rust values: no MLX arrays, safetensor views, model handles, or server
+//! request state. A prepared value can therefore be moved to a compiler-backend
+//! worker without tying that worker to the producer's tensor runtime.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Element types accepted at the prepared-prefill boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PreparedTensorDType {
+    Float16,
+    BFloat16,
+    Float32,
+    Int32,
+}
+
+impl PreparedTensorDType {
+    /// Number of bytes occupied by one element.
+    #[must_use]
+    pub const fn size_bytes(self) -> usize {
+        match self {
+            Self::Float16 | Self::BFloat16 => 2,
+            Self::Float32 | Self::Int32 => 4,
+        }
+    }
+
+    /// Whether this dtype is valid for embeddings and additive attention bias.
+    #[must_use]
+    pub const fn is_float(self) -> bool {
+        matches!(self, Self::Float16 | Self::BFloat16 | Self::Float32)
+    }
+}
+
+/// A contiguous, row-major tensor whose storage is owned by this value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnedTensor {
+    pub bytes: Vec<u8>,
+    pub dtype: PreparedTensorDType,
+    pub shape: Vec<usize>,
+}
+
+impl OwnedTensor {
+    /// Construct an owned tensor after checking shape arithmetic and byte size.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PreparedPrefillError::ShapeOverflow`] when the shape cannot be
+    /// represented and [`PreparedPrefillError::ByteCountMismatch`] when the
+    /// storage length does not match `shape * dtype.size_bytes()`.
+    pub fn new(
+        bytes: Vec<u8>,
+        dtype: PreparedTensorDType,
+        shape: Vec<usize>,
+    ) -> Result<Self, PreparedPrefillError> {
+        let expected = checked_byte_count(&shape, dtype)?;
+        if bytes.len() != expected {
+            return Err(PreparedPrefillError::ByteCountMismatch {
+                expected,
+                actual: bytes.len(),
+            });
+        }
+        Ok(Self {
+            bytes,
+            dtype,
+            shape,
+        })
+    }
+
+    /// Number of logical elements in the tensor.
+    #[must_use]
+    pub fn element_count(&self) -> usize {
+        self.shape.iter().copied().product()
+    }
+}
+
+/// Position encoding associated with a prepared prefill.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PreparedPositions {
+    /// Dense positions `start..start + length`, the LLaVA reference layout.
+    Sequential { start: i32, length: usize },
+    /// Explicit position rows for model families that do not use a scalar
+    /// sequence position (for example multimodal RoPE families).
+    Explicit(OwnedTensor),
+}
+
+impl PreparedPositions {
+    #[must_use]
+    fn sequence_len(&self) -> Option<usize> {
+        match self {
+            Self::Sequential { length, .. } => Some(*length),
+            Self::Explicit(tensor) => tensor.shape.last().copied(),
+        }
+    }
+}
+
+/// Additive attention bias and its causal interpretation.
+///
+/// The tensor may use broadcast dimensions. The LLaVA producer emits a compact
+/// `[1, 1, 1, sequence]` all-zero padding bias and sets `causal = true`, which
+/// is equivalent to the existing MLX path's implicit causal mask without an
+/// unnecessary quadratic host allocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreparedAttentionBias {
+    pub tensor: OwnedTensor,
+    pub causal: bool,
+}
+
+/// Metrics and validation facts for one prepared modality.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreparedModality {
+    /// Stable model-family identifier, such as `"llava"`.
+    pub family: String,
+    /// Number of decoded media items consumed.
+    pub item_count: usize,
+    /// Number of logical sequence positions occupied by the modality.
+    pub token_count: usize,
+}
+
+/// Owned prefill payload crossing from host preprocessing to an engine worker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreparedPrefill {
+    /// Logical ids after family-specific placeholder expansion.
+    pub token_ids: Vec<i32>,
+    /// `[batch, sequence, hidden]` merged embeddings.
+    pub embeddings: OwnedTensor,
+    pub positions: PreparedPositions,
+    pub attention_bias: PreparedAttentionBias,
+    pub sequence_len: usize,
+    pub modalities: Vec<PreparedModality>,
+}
+
+impl PreparedPrefill {
+    /// Construct and validate a backend-neutral prepared prefill.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed error when token, embedding, position, or attention
+    /// shapes disagree. Producers should call this only after their
+    /// family-specific hidden-size and media-cardinality checks.
+    pub fn new(
+        token_ids: Vec<i32>,
+        embeddings: OwnedTensor,
+        positions: PreparedPositions,
+        attention_bias: PreparedAttentionBias,
+        modalities: Vec<PreparedModality>,
+    ) -> Result<Self, PreparedPrefillError> {
+        let sequence_len = token_ids.len();
+        if embeddings.shape.len() != 3
+            || embeddings.shape[0] != 1
+            || embeddings.shape[1] != sequence_len
+        {
+            return Err(PreparedPrefillError::EmbeddingShape {
+                shape: embeddings.shape.clone(),
+                sequence_len,
+            });
+        }
+        if !embeddings.dtype.is_float() {
+            return Err(PreparedPrefillError::EmbeddingDType(embeddings.dtype));
+        }
+        let position_len = positions.sequence_len();
+        if position_len != Some(sequence_len) {
+            return Err(PreparedPrefillError::PositionLength {
+                expected: sequence_len,
+                actual: position_len,
+            });
+        }
+        if let PreparedPositions::Explicit(tensor) = &positions
+            && tensor.dtype != PreparedTensorDType::Int32
+        {
+            return Err(PreparedPrefillError::PositionDType(tensor.dtype));
+        }
+        if !attention_bias.tensor.dtype.is_float() {
+            return Err(PreparedPrefillError::AttentionBiasDType(
+                attention_bias.tensor.dtype,
+            ));
+        }
+        let bias_sequence = attention_bias.tensor.shape.last().copied();
+        if bias_sequence != Some(sequence_len) {
+            return Err(PreparedPrefillError::AttentionBiasShape {
+                shape: attention_bias.tensor.shape.clone(),
+                sequence_len,
+            });
+        }
+        let modality_tokens = modalities.iter().try_fold(0usize, |total, modality| {
+            total
+                .checked_add(modality.token_count)
+                .ok_or(PreparedPrefillError::ShapeOverflow)
+        })?;
+        if modality_tokens > sequence_len {
+            return Err(PreparedPrefillError::ModalityTokenCount {
+                token_count: modality_tokens,
+                sequence_len,
+            });
+        }
+
+        Ok(Self {
+            token_ids,
+            embeddings,
+            positions,
+            attention_bias,
+            sequence_len,
+            modalities,
+        })
+    }
+}
+
+/// Structural errors at the owned prefill boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum PreparedPrefillError {
+    #[error("prepared tensor shape or byte-size calculation overflowed")]
+    ShapeOverflow,
+    #[error("prepared tensor byte count mismatch: expected {expected}, got {actual}")]
+    ByteCountMismatch { expected: usize, actual: usize },
+    #[error("prepared embedding shape {shape:?} must be [1, {sequence_len}, hidden]")]
+    EmbeddingShape {
+        shape: Vec<usize>,
+        sequence_len: usize,
+    },
+    #[error("prepared embedding dtype {0:?} is not floating point")]
+    EmbeddingDType(PreparedTensorDType),
+    #[error("prepared position length mismatch: expected {expected}, got {actual:?}")]
+    PositionLength {
+        expected: usize,
+        actual: Option<usize>,
+    },
+    #[error("prepared explicit-position dtype {0:?} must be Int32")]
+    PositionDType(PreparedTensorDType),
+    #[error("prepared attention-bias dtype {0:?} is not floating point")]
+    AttentionBiasDType(PreparedTensorDType),
+    #[error(
+        "prepared attention-bias shape {shape:?} does not end in sequence length {sequence_len}"
+    )]
+    AttentionBiasShape {
+        shape: Vec<usize>,
+        sequence_len: usize,
+    },
+    #[error(
+        "prepared modality metadata accounts for {token_count} tokens, exceeding sequence length {sequence_len}"
+    )]
+    ModalityTokenCount {
+        token_count: usize,
+        sequence_len: usize,
+    },
+}
+
+fn checked_byte_count(
+    shape: &[usize],
+    dtype: PreparedTensorDType,
+) -> Result<usize, PreparedPrefillError> {
+    shape
+        .iter()
+        .try_fold(1usize, |count, &dim| count.checked_mul(dim))
+        .and_then(|count| count.checked_mul(dtype.size_bytes()))
+        .ok_or(PreparedPrefillError::ShapeOverflow)
+}
+
+#[cfg(test)]
+#[path = "multimodal_tests.rs"]
+mod tests;

--- a/src/lib/mlxcel-core/src/multimodal_tests.rs
+++ b/src/lib/mlxcel-core/src/multimodal_tests.rs
@@ -1,0 +1,116 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{
+    OwnedTensor, PreparedAttentionBias, PreparedModality, PreparedPositions, PreparedPrefill,
+    PreparedPrefillError, PreparedTensorDType,
+};
+
+fn zeros(dtype: PreparedTensorDType, shape: &[usize]) -> OwnedTensor {
+    let count = shape.iter().product::<usize>() * dtype.size_bytes();
+    OwnedTensor::new(vec![0; count], dtype, shape.to_vec()).unwrap()
+}
+
+#[test]
+fn owned_tensor_checks_each_supported_model_dtype() {
+    for dtype in [
+        PreparedTensorDType::Float16,
+        PreparedTensorDType::BFloat16,
+        PreparedTensorDType::Float32,
+    ] {
+        let tensor = zeros(dtype, &[1, 3, 5]);
+        assert_eq!(tensor.bytes.len(), 15 * dtype.size_bytes());
+        assert_eq!(tensor.element_count(), 15);
+    }
+}
+
+#[test]
+fn owned_tensor_rejects_wrong_byte_count() {
+    let error = OwnedTensor::new(vec![0; 7], PreparedTensorDType::Float32, vec![1, 2]).unwrap_err();
+    assert_eq!(
+        error,
+        PreparedPrefillError::ByteCountMismatch {
+            expected: 8,
+            actual: 7,
+        }
+    );
+}
+
+#[test]
+fn prepared_prefill_is_owned_send_data() {
+    fn assert_send<T: Send>() {}
+    assert_send::<PreparedPrefill>();
+
+    let prepared = PreparedPrefill::new(
+        vec![1, 2, 3],
+        zeros(PreparedTensorDType::Float16, &[1, 3, 4]),
+        PreparedPositions::Sequential {
+            start: 0,
+            length: 3,
+        },
+        PreparedAttentionBias {
+            tensor: zeros(PreparedTensorDType::Float32, &[1, 1, 1, 3]),
+            causal: true,
+        },
+        vec![PreparedModality {
+            family: "llava".to_string(),
+            item_count: 1,
+            token_count: 2,
+        }],
+    )
+    .unwrap();
+
+    let moved = std::thread::spawn(move || prepared.sequence_len)
+        .join()
+        .unwrap();
+    assert_eq!(moved, 3);
+}
+
+#[test]
+fn prepared_prefill_rejects_shape_drift() {
+    let error = PreparedPrefill::new(
+        vec![1, 2, 3],
+        zeros(PreparedTensorDType::Float16, &[1, 2, 4]),
+        PreparedPositions::Sequential {
+            start: 0,
+            length: 3,
+        },
+        PreparedAttentionBias {
+            tensor: zeros(PreparedTensorDType::Float32, &[1, 1, 1, 3]),
+            causal: true,
+        },
+        Vec::new(),
+    )
+    .unwrap_err();
+    assert!(matches!(error, PreparedPrefillError::EmbeddingShape { .. }));
+}
+
+#[test]
+fn prepared_prefill_rejects_floating_point_explicit_positions() {
+    let error = PreparedPrefill::new(
+        vec![1, 2, 3],
+        zeros(PreparedTensorDType::Float16, &[1, 3, 4]),
+        PreparedPositions::Explicit(zeros(PreparedTensorDType::Float32, &[1, 3])),
+        PreparedAttentionBias {
+            tensor: zeros(PreparedTensorDType::Float32, &[1, 1, 1, 3]),
+            causal: true,
+        },
+        Vec::new(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        error,
+        PreparedPrefillError::PositionDType(PreparedTensorDType::Float32)
+    );
+}

--- a/src/lib/mlxcel-core/src/session.rs
+++ b/src/lib/mlxcel-core/src/session.rs
@@ -67,6 +67,13 @@ use crate::ffi::MlxArray;
 use crate::generate::{CxxGenerator, GenerationStats, LanguageModel, SamplingConfig};
 use crate::sampling::TokenBiasMap;
 
+// Keep the prepared-prefill DTO discoverable from the session boundary while
+// its implementation remains in a focused module below the 500-line file cap.
+pub use crate::multimodal::{
+    OwnedTensor, PreparedAttentionBias, PreparedModality, PreparedPositions, PreparedPrefill,
+    PreparedPrefillError, PreparedTensorDType,
+};
+
 /// Capabilities a backend inference session advertises so the control plane can
 /// gate features a given backend does not support yet.
 ///

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -56,6 +56,7 @@ use self::special::try_load_special_model_from_weights;
 use self::vlm::*;
 
 // Re-exported at the crate root for the CLI's lazy `--output-audio` load.
+pub(crate) use self::vlm::load_llava_host_preprocessor;
 pub use self::vlm::load_qwen3_omni_speech;
 
 /// Resolve model path: if a file is given, use its parent directory.

--- a/src/loading/vlm.rs
+++ b/src/loading/vlm.rs
@@ -106,7 +106,7 @@ pub(crate) use idefics2::load_idefics2_vlm;
 pub(crate) use internvl::load_internvl_vlm;
 pub(crate) use kimi_vl_loader::load_kimi_vl_vlm;
 pub(crate) use lfm2_vl::load_lfm2_vl;
-pub(crate) use llava::{load_llava_bunny_vlm, load_llava_vlm};
+pub(crate) use llava::{load_llava_bunny_vlm, load_llava_host_preprocessor, load_llava_vlm};
 pub(crate) use minimax_m3_vl::load_minimax_m3_vl;
 pub(crate) use mllama::load_mllama_vlm;
 pub(crate) use nemotron_h_nano_omni::load_nemotron_h_nano_omni_vlm;
@@ -207,7 +207,7 @@ pub(crate) fn load_vlm_weights_common(
 ) -> Result<WeightMap> {
     let mut weights = mlxcel_core::weights::load_weights_from_dir(model_path)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
-    finish_vlm_weights_common(model_path, &mut weights, transform)?;
+    finish_vlm_weights_common(model_path, &mut weights, transform, true)?;
 
     Ok(weights)
 }
@@ -227,7 +227,28 @@ where
 {
     let mut weights = mlxcel_core::weights::load_weights_from_dir_filtered(model_path, keep)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
-    finish_vlm_weights_common(model_path, &mut weights, transform)?;
+    finish_vlm_weights_common(model_path, &mut weights, transform, true)?;
+
+    Ok(weights)
+}
+
+/// Filtered canonical-checkpoint loader for host data paired with a backend
+/// that reads the checkpoint directly.
+///
+/// Unlike [`load_vlm_weights_common_filtered`], this path deliberately ignores
+/// the process-global surgery fallback. The paired backend therefore cannot
+/// observe raw checkpoint tensors while host preprocessing observes transformed
+/// tensors. Explicit transformations are not accepted on this boundary.
+pub(crate) fn load_vlm_weights_common_filtered_canonical<F>(
+    model_path: &Path,
+    keep: F,
+) -> Result<WeightMap>
+where
+    F: FnMut(&str) -> bool,
+{
+    let mut weights = mlxcel_core::weights::load_weights_from_dir_filtered(model_path, keep)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    finish_vlm_weights_common(model_path, &mut weights, None, false)?;
 
     Ok(weights)
 }
@@ -236,6 +257,7 @@ fn finish_vlm_weights_common(
     model_path: &Path,
     weights: &mut WeightMap,
     transform: Option<&dyn mlxcel_core::weights::WeightTransform>,
+    allow_active_pipeline: bool,
 ) -> Result<()> {
     // On Apple Silicon, convert bf16 → f16 for performance (no Apple GPU has
     // native bf16 ALU).  Quantized models keep bf16 scales/biases as-is.
@@ -268,10 +290,11 @@ fn finish_vlm_weights_common(
     //   2. CLI-installed active pipeline (--surgery flag).
     //   3. Baseline — no transform applied.
     #[cfg(feature = "surgery")]
-    let active_pipeline = transform
-        .is_none()
+    let active_pipeline = (allow_active_pipeline && transform.is_none())
         .then(crate::surgery::snapshot_active_pipeline)
         .flatten();
+    #[cfg(not(feature = "surgery"))]
+    let _ = allow_active_pipeline;
     let resolved_transform: Option<&dyn mlxcel_core::weights::WeightTransform> = match transform {
         Some(t) => Some(t),
         None => {

--- a/src/loading/vlm_llava.rs
+++ b/src/loading/vlm_llava.rs
@@ -22,17 +22,20 @@
 //! selection and projector wiring, so their config normalization lives here.
 
 use anyhow::Result;
+use mlxcel_core::layers::UnifiedEmbedding;
 use mlxcel_core::weights::WeightMap;
 use serde_json::Value;
 use std::path::Path;
 
 use crate::LoadedModel;
 use crate::models;
+use crate::multimodal::host_preprocessor::{HostPreprocessorError, LlavaHostPreprocessor};
 use crate::vision;
+use crate::vision::config::VLMConfig;
 
 use super::{
-    load_vlm_weights_common, parse_vlm_config, read_sanitized_vlm_config,
-    strip_language_model_prefix,
+    load_vlm_weights_common, load_vlm_weights_common_filtered_canonical, parse_vlm_config,
+    read_sanitized_vlm_config, strip_language_model_prefix,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -200,6 +203,175 @@ fn llava_processor(
     } else {
         vision::processors::siglip::SigLipProcessor::new(image_size)
     }
+}
+
+/// Whether a raw checkpoint tensor belongs to the host-first LLaVA prefix.
+///
+/// The optional `language_model.` wrapper is normalized by
+/// [`strip_language_model_prefix`] after loading. Decoder layers, final norm,
+/// and LM head deliberately fail this predicate, so they are never retained by
+/// the host preprocessor.
+pub(super) fn is_llava_host_preprocessor_weight(name: &str) -> bool {
+    let canonical = name.strip_prefix("language_model.").unwrap_or(name);
+    canonical.starts_with("vision_tower.")
+        || canonical.starts_with("multi_modal_projector.")
+        || canonical.starts_with("model.embed_tokens.")
+}
+
+fn require_llava_host_family(config: &VLMConfig) -> Result<(), HostPreprocessorError> {
+    if !matches!(config.model_type.as_str(), "llava" | "llava_next") {
+        return Err(HostPreprocessorError::FamilyMismatch {
+            actual: config.model_type.clone(),
+        });
+    }
+    if !(config.vision_config.model_type.contains("clip")
+        || config.vision_config.model_type.contains("siglip"))
+    {
+        return Err(HostPreprocessorError::FamilyMismatch {
+            actual: format!(
+                "{} with vision tower {}",
+                config.model_type, config.vision_config.model_type
+            ),
+        });
+    }
+    if config.vision_config.num_channels != 3 {
+        return Err(HostPreprocessorError::InvalidConfig(format!(
+            "LLaVA host preprocessing supports RGB vision towers only, got {} channels",
+            config.vision_config.num_channels
+        )));
+    }
+    if config.vision_config.patch_size == 0
+        || !config
+            .vision_config
+            .image_size
+            .is_multiple_of(config.vision_config.patch_size)
+    {
+        return Err(HostPreprocessorError::InvalidConfig(format!(
+            "LLaVA image_size {} must be divisible by non-zero patch_size {}",
+            config.vision_config.image_size, config.vision_config.patch_size
+        )));
+    }
+    Ok(())
+}
+
+/// Load only the host-side components needed to prepare LLaVA embeddings for
+/// XLA. The full text decoder is neither constructed nor retained.
+pub(crate) fn load_llava_host_preprocessor(
+    model_path: &Path,
+) -> Result<LlavaHostPreprocessor, HostPreprocessorError> {
+    use vision::connectors::mlp::MLPProjector;
+    use vision::encoders::siglip::SigLipVisionModel;
+
+    let (config_str, full_config) = read_sanitized_vlm_config(model_path)
+        .map_err(|error| HostPreprocessorError::InvalidConfig(error.to_string()))?;
+    let vlm_config: VLMConfig = parse_vlm_config(&config_str, "VLM config")
+        .map_err(|error| HostPreprocessorError::InvalidConfig(error.to_string()))?;
+    require_llava_host_family(&vlm_config)?;
+
+    let text_model_type = vlm_config
+        .text_config
+        .get("model_type")
+        .and_then(Value::as_str)
+        .unwrap_or("llama");
+    llava_text_backend(text_model_type, "LLaVA host preprocessor").map_err(|error| {
+        HostPreprocessorError::FamilyMismatch {
+            actual: error.to_string(),
+        }
+    })?;
+
+    let weights = load_vlm_weights_common_filtered_canonical(model_path, |name| {
+        is_llava_host_preprocessor_weight(name)
+    })
+    .map(strip_language_model_prefix)
+    .map_err(|error| HostPreprocessorError::WeightLoad(error.to_string()))?;
+
+    let quant_group_size = full_config
+        .get("quantization")
+        .and_then(|q| q.get("group_size"))
+        .and_then(Value::as_i64)
+        .unwrap_or(64) as i32;
+    let quant_bits = full_config
+        .get("quantization")
+        .and_then(|q| q.get("bits"))
+        .and_then(Value::as_i64)
+        .unwrap_or(4) as i32;
+
+    let text_embeddings = UnifiedEmbedding::from_weights(
+        &weights,
+        "model.embed_tokens",
+        quant_group_size,
+        quant_bits,
+    )
+    .map_err(|error| {
+        HostPreprocessorError::WeightLoad(format!(
+            "missing or invalid LLaVA text embedding table: {error}"
+        ))
+    })?;
+    let connector = MLPProjector::from_weights(
+        &weights,
+        "multi_modal_projector",
+        quant_group_size,
+        quant_bits,
+    )
+    .map_err(|error| {
+        HostPreprocessorError::WeightLoad(format!(
+            "missing or invalid LLaVA multi_modal_projector weights: {error}"
+        ))
+    })?;
+    let encoder = SigLipVisionModel::from_weights(
+        &weights,
+        &vlm_config.vision_config,
+        "vision_tower.vision_model",
+    )
+    .map_err(|error| {
+        HostPreprocessorError::WeightLoad(format!(
+            "missing or invalid LLaVA vision_tower weights: {error}"
+        ))
+    })?
+    .with_feature_selection(
+        vlm_config.vision_feature_layer,
+        vlm_config.vision_feature_select_strategy.clone(),
+    );
+
+    let text_hidden_size = vlm_config
+        .text_config
+        .get("hidden_size")
+        .and_then(Value::as_u64)
+        .or_else(|| full_config.get("hidden_size").and_then(Value::as_u64))
+        .ok_or_else(|| {
+            HostPreprocessorError::InvalidConfig(
+                "LLaVA text_config.hidden_size is required for host preprocessing".to_string(),
+            )
+        })? as usize;
+    let max_sequence_len = vlm_config
+        .text_config
+        .get("max_position_embeddings")
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            full_config
+                .get("max_position_embeddings")
+                .and_then(Value::as_u64)
+        })
+        .unwrap_or(4096) as usize;
+    let num_patches =
+        (vlm_config.vision_config.image_size / vlm_config.vision_config.patch_size).pow(2);
+    let tokens_per_image = vlm_config.mm_tokens_per_image.unwrap_or(num_patches);
+    let processor = llava_processor(
+        &vlm_config.vision_config.model_type,
+        vlm_config.vision_config.image_size,
+    );
+
+    LlavaHostPreprocessor::from_parts(
+        Box::new(processor),
+        Box::new(encoder),
+        Box::new(connector),
+        text_embeddings,
+        vlm_config.image_token_index,
+        tokens_per_image,
+        text_hidden_size,
+        vlm_config.vision_config.image_size,
+        max_sequence_len,
+    )
 }
 
 fn bunny_processor(

--- a/src/loading/vlm_llava_tests.rs
+++ b/src/loading/vlm_llava_tests.rs
@@ -14,9 +14,11 @@
 
 use super::{
     LlavaTextBackend, detect_bunny_text_backend, infer_llama_config_from_weights,
-    inherit_text_quantization_if_missing, llava_text_backend, parse_bunny_vision_config,
-    rewrite_bunny_weight_key,
+    inherit_text_quantization_if_missing, is_llava_host_preprocessor_weight, llava_text_backend,
+    parse_bunny_vision_config, require_llava_host_family, rewrite_bunny_weight_key,
 };
+use crate::multimodal::host_preprocessor::HostPreprocessorError;
+use crate::vision::config::VLMConfig;
 use mlxcel_core::dtype;
 use mlxcel_core::weights::WeightMap;
 use serde_json::json;
@@ -168,4 +170,50 @@ fn parse_bunny_vision_config_preserves_full_configs() {
     assert_eq!(config.intermediate_size, 1536);
     assert_eq!(config.patch_size, 16);
     assert_eq!(config.image_size, 224);
+}
+
+#[test]
+fn host_weight_filter_keeps_no_decoder_layer_or_lm_head() {
+    for key in [
+        "vision_tower.vision_model.encoder.layers.0.self_attn.q_proj.weight",
+        "multi_modal_projector.linear_1.weight",
+        "model.embed_tokens.weight",
+        "model.embed_tokens.scales",
+        "language_model.model.embed_tokens.biases",
+    ] {
+        assert!(is_llava_host_preprocessor_weight(key), "{key}");
+    }
+    for key in [
+        "model.layers.0.self_attn.q_proj.weight",
+        "language_model.model.layers.31.mlp.down_proj.weight",
+        "model.norm.weight",
+        "lm_head.weight",
+    ] {
+        assert!(!is_llava_host_preprocessor_weight(key), "{key}");
+    }
+}
+
+#[test]
+fn host_family_validation_rejects_incompatible_processor_family() {
+    let config: VLMConfig = serde_json::from_value(json!({
+        "model_type": "qwen2_vl",
+        "text_config": {"model_type": "qwen2", "hidden_size": 8},
+        "vision_config": {
+            "model_type": "qwen2_vl",
+            "num_hidden_layers": 1,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "num_attention_heads": 1,
+            "patch_size": 2,
+            "image_size": 4,
+            "num_channels": 3
+        }
+    }))
+    .unwrap();
+
+    let error = require_llava_host_family(&config).unwrap_err();
+    assert!(matches!(
+        error,
+        HostPreprocessorError::FamilyMismatch { .. }
+    ));
 }

--- a/src/multimodal/host_preprocessor.rs
+++ b/src/multimodal/host_preprocessor.rs
@@ -1,0 +1,365 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Host-side multimodal preprocessing for compiler backends.
+//!
+//! The producer in this module may use MLX to run the existing vision tower,
+//! projector, and embedding lookup. Its output is the fully-owned
+//! [`PreparedPrefill`] contract from `mlxcel-core`, so no MLX value crosses the
+//! session/worker boundary.
+
+use std::path::Path;
+
+use image::DynamicImage;
+use mlxcel_core::layers::UnifiedEmbedding;
+use mlxcel_core::session::{
+    OwnedTensor, PreparedPrefill, PreparedPrefillError, PreparedTensorDType,
+};
+use thiserror::Error;
+
+use crate::vision::connectors::MultiModalConnector;
+use crate::vision::encoders::VisionEncoder;
+use crate::vision::merge::{InputEmbeddings, merge_llava};
+use crate::vision::processors::ImageProcessor;
+
+use super::vlm_prompt::{ImageTokenBlockError, ImageTokenBlockInfo, apply_image_token_blocks};
+
+#[path = "host_preprocessor_export.rs"]
+mod export;
+#[cfg(test)]
+use export::export_mlx_tensor;
+use export::{
+    build_prepared_prefill, export_llava_prefill, usize_to_i32, validate_embedding_shape,
+    validate_processor_shape, validate_projected_shape, validate_sequence_capacity,
+};
+
+/// A host preprocessor consumes tokenized text plus already-decoded images.
+///
+/// URL fetching, data-URI limits, image decoding, and other request security
+/// policy remain at the server boundary. Audio and video are intentionally not
+/// admitted by this first image-only contract.
+pub trait HostMultimodalPreprocessor {
+    /// Prepare an owned prefill payload for an engine worker.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation, tensor-export, or family error before any
+    /// compiler runtime is invoked.
+    fn prepare(
+        &self,
+        token_ids: &[i32],
+        images: &[DynamicImage],
+    ) -> Result<PreparedPrefill, HostPreprocessorError>;
+}
+
+/// LLaVA host preprocessor retaining only the components needed before XLA.
+pub struct LlavaHostPreprocessor {
+    processor: Box<dyn ImageProcessor>,
+    encoder: Box<dyn VisionEncoder>,
+    connector: Box<dyn MultiModalConnector>,
+    /// Canonical checkpoint embedding lookup. This owns only
+    /// `model.embed_tokens.{weight,scales,biases}` handles loaded through the
+    /// filtered loader; no decoder layer or LM head is constructed or retained.
+    text_embeddings: UnifiedEmbedding,
+    image_token_id: i32,
+    tokens_per_image: usize,
+    hidden_size: usize,
+    image_size: usize,
+    max_sequence_len: usize,
+}
+
+impl LlavaHostPreprocessor {
+    /// Load the LLaVA processor, vision tower, projector, and embedding lookup
+    /// from a checkpoint without constructing a text decoder.
+    ///
+    /// The canonical filtered host loader and IREE both read the same immutable
+    /// model directory. It explicitly bypasses process-global weight surgery,
+    /// which IREE does not apply, so the host representation cannot select a
+    /// different embedding revision or transformed value from the uploaded
+    /// buffers. Changing either requires changing the shared model path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an actionable typed error for incompatible families, malformed
+    /// config, missing required weights, or an invalid embedding layout.
+    pub fn load(model_path: &Path) -> Result<Self, HostPreprocessorError> {
+        crate::loading::load_llava_host_preprocessor(model_path)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_parts(
+        processor: Box<dyn ImageProcessor>,
+        encoder: Box<dyn VisionEncoder>,
+        connector: Box<dyn MultiModalConnector>,
+        text_embeddings: UnifiedEmbedding,
+        image_token_id: i32,
+        tokens_per_image: usize,
+        hidden_size: usize,
+        image_size: usize,
+        max_sequence_len: usize,
+    ) -> Result<Self, HostPreprocessorError> {
+        if tokens_per_image == 0 {
+            return Err(HostPreprocessorError::InvalidConfig(
+                "LLaVA mm_tokens_per_image must be greater than zero".to_string(),
+            ));
+        }
+        if hidden_size == 0 {
+            return Err(HostPreprocessorError::InvalidConfig(
+                "LLaVA text hidden_size must be greater than zero".to_string(),
+            ));
+        }
+        if image_size == 0 {
+            return Err(HostPreprocessorError::InvalidConfig(
+                "LLaVA processor image_size must be greater than zero".to_string(),
+            ));
+        }
+        if max_sequence_len == 0 {
+            return Err(HostPreprocessorError::InvalidConfig(
+                "LLaVA max sequence length must be greater than zero".to_string(),
+            ));
+        }
+        Ok(Self {
+            processor,
+            encoder,
+            connector,
+            text_embeddings,
+            image_token_id,
+            tokens_per_image,
+            hidden_size,
+            image_size,
+            max_sequence_len,
+        })
+    }
+
+    fn token_block_info(&self) -> ImageTokenBlockInfo {
+        ImageTokenBlockInfo {
+            use_boi_eoi: false,
+            image_token_id: self.image_token_id,
+            mm_tokens_per_image: self.tokens_per_image,
+            boi_token_id: 0,
+            eoi_token_id: 0,
+            has_bos: true,
+            separator_token_id: None,
+            suffix_tokens: Vec::new(),
+            block_prefix_tokens: Vec::new(),
+            block_suffix_tokens: Vec::new(),
+        }
+    }
+}
+
+impl HostMultimodalPreprocessor for LlavaHostPreprocessor {
+    fn prepare(
+        &self,
+        token_ids: &[i32],
+        images: &[DynamicImage],
+    ) -> Result<PreparedPrefill, HostPreprocessorError> {
+        let mut logical_tokens = token_ids.to_vec();
+        apply_image_token_blocks(&mut logical_tokens, self.token_block_info(), images.len())?;
+        validate_sequence_capacity(logical_tokens.len(), self.max_sequence_len)?;
+
+        let input_ids = mlxcel_core::from_slice_i32(
+            &logical_tokens,
+            &[1, usize_to_i32(logical_tokens.len(), "sequence length")?],
+        );
+        let text_embeddings = self.text_embeddings.forward(&input_ids);
+        validate_embedding_shape(
+            &mlxcel_core::array_shape(&text_embeddings),
+            logical_tokens.len(),
+            self.hidden_size,
+            "text embedding table",
+        )?;
+
+        let merged = if images.is_empty() {
+            InputEmbeddings {
+                inputs_embeds: text_embeddings,
+                attention_mask_4d: None,
+            }
+        } else {
+            let pixels = self.processor.preprocess(images);
+            validate_processor_shape(
+                &mlxcel_core::array_shape(&pixels),
+                images.len(),
+                self.image_size,
+            )?;
+
+            // The standard processor emits channels-first f32. Normalize layout
+            // for the shared CLIP/SigLIP encoder and normalize dtype once to the
+            // text embedding dtype before vision execution.
+            let pixels = mlxcel_core::transpose_axes(&pixels, &[0, 2, 3, 1]);
+            let embed_dtype = mlxcel_core::array_dtype(&text_embeddings);
+            let pixels = mlxcel_core::astype(&pixels, embed_dtype);
+            let encoded = self.encoder.forward(&pixels);
+            let projected = self.connector.forward(&encoded.hidden_states);
+            validate_projected_shape(
+                &mlxcel_core::array_shape(&projected),
+                images.len(),
+                self.tokens_per_image,
+                self.hidden_size,
+            )?;
+
+            merge_llava(
+                self.image_token_id,
+                &projected,
+                &text_embeddings,
+                &input_ids,
+            )
+        };
+
+        export_llava_prefill(
+            logical_tokens,
+            merged,
+            self.image_token_id,
+            images.len(),
+            self.tokens_per_image,
+            self.hidden_size,
+        )
+    }
+}
+
+/// Deterministic checkpoint-free producer for engine and server contract tests.
+#[derive(Debug, Clone)]
+pub struct FakeHostMultimodalPreprocessor {
+    pub image_token_id: i32,
+    pub tokens_per_image: usize,
+    pub hidden_size: usize,
+    pub max_sequence_len: usize,
+}
+
+impl Default for FakeHostMultimodalPreprocessor {
+    fn default() -> Self {
+        Self {
+            image_token_id: -200,
+            tokens_per_image: 4,
+            hidden_size: 8,
+            max_sequence_len: 4096,
+        }
+    }
+}
+
+impl HostMultimodalPreprocessor for FakeHostMultimodalPreprocessor {
+    fn prepare(
+        &self,
+        token_ids: &[i32],
+        images: &[DynamicImage],
+    ) -> Result<PreparedPrefill, HostPreprocessorError> {
+        let mut logical_tokens = token_ids.to_vec();
+        let info = ImageTokenBlockInfo {
+            use_boi_eoi: false,
+            image_token_id: self.image_token_id,
+            mm_tokens_per_image: self.tokens_per_image,
+            boi_token_id: 0,
+            eoi_token_id: 0,
+            has_bos: true,
+            separator_token_id: None,
+            suffix_tokens: Vec::new(),
+            block_prefix_tokens: Vec::new(),
+            block_suffix_tokens: Vec::new(),
+        };
+        apply_image_token_blocks(&mut logical_tokens, info, images.len())?;
+        validate_sequence_capacity(logical_tokens.len(), self.max_sequence_len)?;
+
+        let element_count = logical_tokens
+            .len()
+            .checked_mul(self.hidden_size)
+            .ok_or(HostPreprocessorError::ShapeOverflow)?;
+        let byte_count = element_count
+            .checked_mul(PreparedTensorDType::Float32.size_bytes())
+            .ok_or(HostPreprocessorError::ShapeOverflow)?;
+        let mut bytes = Vec::with_capacity(byte_count);
+        for (position, &token) in logical_tokens.iter().enumerate() {
+            for lane in 0..self.hidden_size {
+                // Stable across platforms and independent of image contents.
+                let value = token as f32 * 0.001 + position as f32 * 0.01 + lane as f32;
+                bytes.extend_from_slice(&value.to_le_bytes());
+            }
+        }
+        let embeddings = OwnedTensor::new(
+            bytes,
+            PreparedTensorDType::Float32,
+            vec![1, logical_tokens.len(), self.hidden_size],
+        )?;
+        let image_token_count = images
+            .len()
+            .checked_mul(self.tokens_per_image)
+            .ok_or(HostPreprocessorError::ShapeOverflow)?;
+        build_prepared_prefill(
+            logical_tokens,
+            embeddings,
+            images.len(),
+            image_token_count,
+            "fake-llava",
+        )
+    }
+}
+
+/// Typed failures surfaced before an XLA runtime invocation.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum HostPreprocessorError {
+    #[error(transparent)]
+    Placeholder(#[from] ImageTokenBlockError),
+    #[error("incompatible multimodal family: expected LLaVA, got {actual}")]
+    FamilyMismatch { actual: String },
+    #[error("invalid LLaVA host-preprocessor config: {0}")]
+    InvalidConfig(String),
+    #[error("failed to load LLaVA host-preprocessor weights: {0}")]
+    WeightLoad(String),
+    #[error(
+        "processor output shape {actual:?} does not match decoded RGB batch [{image_count}, 3, {image_size}, {image_size}]"
+    )]
+    ProcessorShape {
+        actual: Vec<i32>,
+        image_count: usize,
+        image_size: usize,
+    },
+    #[error("{source_name} shape {actual:?} does not match [1, {sequence_len}, {hidden_size}]")]
+    EmbeddingShape {
+        source_name: &'static str,
+        actual: Vec<i32>,
+        sequence_len: usize,
+        hidden_size: usize,
+    },
+    #[error(
+        "projected image shape {actual:?} does not match [{image_count}, {tokens_per_image}, {hidden_size}]"
+    )]
+    ProjectedShape {
+        actual: Vec<i32>,
+        image_count: usize,
+        tokens_per_image: usize,
+        hidden_size: usize,
+    },
+    #[error("expanded sequence length {actual} exceeds model capacity {maximum}")]
+    SequenceCapacity { actual: usize, maximum: usize },
+    #[error(
+        "expanded prompt contains {actual} image token(s), expected {expected} from decoded media"
+    )]
+    ExpandedLength { actual: usize, expected: usize },
+    #[error("unsupported prepared tensor dtype code {0}")]
+    UnsupportedDType(i32),
+    #[error("failed to export evaluated contiguous {tensor} tensor: {message}")]
+    TensorExport {
+        tensor: &'static str,
+        message: String,
+    },
+    #[error("{label} cannot be represented by the MLX i32 shape ABI: {value}")]
+    DimensionOverflow { label: &'static str, value: usize },
+    #[error("prepared tensor shape calculation overflowed")]
+    ShapeOverflow,
+    #[error(transparent)]
+    Prepared(#[from] PreparedPrefillError),
+}
+
+#[cfg(test)]
+#[path = "host_preprocessor_tests.rs"]
+mod tests;

--- a/src/multimodal/host_preprocessor_export.rs
+++ b/src/multimodal/host_preprocessor_export.rs
@@ -1,0 +1,238 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Validation and owned-export helpers for the host multimodal producer.
+
+use mlxcel_core::MlxArray;
+use mlxcel_core::session::{
+    OwnedTensor, PreparedAttentionBias, PreparedModality, PreparedPositions, PreparedPrefill,
+    PreparedTensorDType,
+};
+
+use crate::vision::merge::InputEmbeddings;
+
+use super::HostPreprocessorError;
+
+pub(super) fn validate_sequence_capacity(
+    sequence_len: usize,
+    maximum: usize,
+) -> Result<(), HostPreprocessorError> {
+    if sequence_len == 0 {
+        return Err(HostPreprocessorError::InvalidConfig(
+            "tokenized prompt must not be empty".to_string(),
+        ));
+    }
+    if sequence_len > maximum {
+        return Err(HostPreprocessorError::SequenceCapacity {
+            actual: sequence_len,
+            maximum,
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn validate_processor_shape(
+    shape: &[i32],
+    image_count: usize,
+    image_size: usize,
+) -> Result<(), HostPreprocessorError> {
+    let expected = [
+        usize_to_i32(image_count, "image count")?,
+        3,
+        usize_to_i32(image_size, "image size")?,
+        usize_to_i32(image_size, "image size")?,
+    ];
+    if shape != expected {
+        return Err(HostPreprocessorError::ProcessorShape {
+            actual: shape.to_vec(),
+            image_count,
+            image_size,
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn validate_embedding_shape(
+    shape: &[i32],
+    sequence_len: usize,
+    hidden_size: usize,
+    source_name: &'static str,
+) -> Result<(), HostPreprocessorError> {
+    let expected = [
+        1,
+        usize_to_i32(sequence_len, "sequence length")?,
+        usize_to_i32(hidden_size, "hidden size")?,
+    ];
+    if shape != expected {
+        return Err(HostPreprocessorError::EmbeddingShape {
+            source_name,
+            actual: shape.to_vec(),
+            sequence_len,
+            hidden_size,
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn validate_projected_shape(
+    shape: &[i32],
+    image_count: usize,
+    tokens_per_image: usize,
+    hidden_size: usize,
+) -> Result<(), HostPreprocessorError> {
+    let expected = [
+        usize_to_i32(image_count, "image count")?,
+        usize_to_i32(tokens_per_image, "tokens per image")?,
+        usize_to_i32(hidden_size, "hidden size")?,
+    ];
+    if shape != expected {
+        return Err(HostPreprocessorError::ProjectedShape {
+            actual: shape.to_vec(),
+            image_count,
+            tokens_per_image,
+            hidden_size,
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn export_llava_prefill(
+    logical_tokens: Vec<i32>,
+    merged: InputEmbeddings,
+    image_token_id: i32,
+    image_count: usize,
+    tokens_per_image: usize,
+    hidden_size: usize,
+) -> Result<PreparedPrefill, HostPreprocessorError> {
+    let actual_image_tokens = logical_tokens
+        .iter()
+        .filter(|&&token| token == image_token_id)
+        .count();
+    let expected_image_tokens = image_count
+        .checked_mul(tokens_per_image)
+        .ok_or(HostPreprocessorError::ShapeOverflow)?;
+    if actual_image_tokens != expected_image_tokens {
+        return Err(HostPreprocessorError::ExpandedLength {
+            actual: actual_image_tokens,
+            expected: expected_image_tokens,
+        });
+    }
+    validate_embedding_shape(
+        &mlxcel_core::array_shape(&merged.inputs_embeds),
+        logical_tokens.len(),
+        hidden_size,
+        "merged embedding",
+    )?;
+    if merged.attention_mask_4d.is_some() {
+        return Err(HostPreprocessorError::InvalidConfig(
+            "LLaVA host preprocessing requires standard causal masking, not a family-specific 4D mask"
+                .to_string(),
+        ));
+    }
+
+    let embeddings = export_mlx_tensor(&merged.inputs_embeds, "merged embedding")?;
+    build_prepared_prefill(
+        logical_tokens,
+        embeddings,
+        image_count,
+        expected_image_tokens,
+        "llava",
+    )
+}
+
+pub(super) fn export_mlx_tensor(
+    array: &MlxArray,
+    label: &'static str,
+) -> Result<OwnedTensor, HostPreprocessorError> {
+    let shape = mlxcel_core::array_shape(array)
+        .into_iter()
+        .map(|dim| {
+            usize::try_from(dim).map_err(|_| HostPreprocessorError::TensorExport {
+                tensor: label,
+                message: format!("negative dimension {dim}"),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let dtype = prepared_dtype(mlxcel_core::array_dtype(array))?;
+
+    // This one fallible FFI operation makes the lazy result contiguous,
+    // evaluates it, and copies its bytes. No earlier raw view is retained.
+    let bytes = mlxcel_core::try_array_to_raw_bytes(array).map_err(|error| {
+        HostPreprocessorError::TensorExport {
+            tensor: label,
+            message: error.to_string(),
+        }
+    })?;
+    OwnedTensor::new(bytes, dtype, shape).map_err(HostPreprocessorError::from)
+}
+
+fn prepared_dtype(dtype: i32) -> Result<PreparedTensorDType, HostPreprocessorError> {
+    match dtype {
+        mlxcel_core::dtype::FLOAT16 => Ok(PreparedTensorDType::Float16),
+        mlxcel_core::dtype::BFLOAT16 => Ok(PreparedTensorDType::BFloat16),
+        mlxcel_core::dtype::FLOAT32 => Ok(PreparedTensorDType::Float32),
+        other => Err(HostPreprocessorError::UnsupportedDType(other)),
+    }
+}
+
+pub(super) fn build_prepared_prefill(
+    logical_tokens: Vec<i32>,
+    embeddings: OwnedTensor,
+    image_count: usize,
+    image_token_count: usize,
+    family: &str,
+) -> Result<PreparedPrefill, HostPreprocessorError> {
+    let sequence_len = logical_tokens.len();
+    let bias_bytes = vec![
+        0u8;
+        sequence_len
+            .checked_mul(PreparedTensorDType::Float32.size_bytes())
+            .ok_or(HostPreprocessorError::ShapeOverflow)?
+    ];
+    let attention_bias = PreparedAttentionBias {
+        tensor: OwnedTensor::new(
+            bias_bytes,
+            PreparedTensorDType::Float32,
+            vec![1, 1, 1, sequence_len],
+        )?,
+        causal: true,
+    };
+    let modalities = if image_count == 0 {
+        Vec::new()
+    } else {
+        vec![PreparedModality {
+            family: family.to_string(),
+            item_count: image_count,
+            token_count: image_token_count,
+        }]
+    };
+    PreparedPrefill::new(
+        logical_tokens,
+        embeddings,
+        PreparedPositions::Sequential {
+            start: 0,
+            length: sequence_len,
+        },
+        attention_bias,
+        modalities,
+    )
+    .map_err(HostPreprocessorError::from)
+}
+
+pub(super) fn usize_to_i32(
+    value: usize,
+    label: &'static str,
+) -> Result<i32, HostPreprocessorError> {
+    i32::try_from(value).map_err(|_| HostPreprocessorError::DimensionOverflow { label, value })
+}

--- a/src/multimodal/host_preprocessor_tests.rs
+++ b/src/multimodal/host_preprocessor_tests.rs
@@ -1,0 +1,162 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Once;
+
+use image::DynamicImage;
+use mlxcel_core::dtype;
+
+use super::{
+    FakeHostMultimodalPreprocessor, HostMultimodalPreprocessor, HostPreprocessorError,
+    export_llava_prefill, export_mlx_tensor, validate_processor_shape,
+};
+use crate::multimodal::vlm_prompt::ImageTokenBlockError;
+use crate::vision::merge::merge_llava;
+
+fn ensure_cpu_device() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| mlxcel_core::set_default_device(false));
+}
+
+fn images(count: usize) -> Vec<DynamicImage> {
+    (0..count).map(|_| DynamicImage::new_rgb8(2, 2)).collect()
+}
+
+fn fake() -> FakeHostMultimodalPreprocessor {
+    FakeHostMultimodalPreprocessor {
+        image_token_id: -200,
+        tokens_per_image: 2,
+        hidden_size: 3,
+        max_sequence_len: 32,
+    }
+}
+
+#[test]
+fn fake_preprocessor_handles_zero_one_and_multiple_placeholders() {
+    let zero = fake().prepare(&[1, 2], &[]).unwrap();
+    assert_eq!(zero.token_ids, vec![1, 2]);
+    assert!(zero.modalities.is_empty());
+
+    let one = fake().prepare(&[1, -200, 2], &images(1)).unwrap();
+    assert_eq!(one.token_ids, vec![1, -200, -200, 2]);
+    assert_eq!(one.modalities[0].item_count, 1);
+    assert_eq!(one.modalities[0].token_count, 2);
+
+    let multiple = fake().prepare(&[1, -200, 2, -200, 3], &images(2)).unwrap();
+    assert_eq!(multiple.token_ids, vec![1, -200, -200, 2, -200, -200, 3]);
+    assert_eq!(multiple.modalities[0].item_count, 2);
+    assert_eq!(multiple.modalities[0].token_count, 4);
+}
+
+#[test]
+fn fake_preprocessor_rejects_media_count_mismatch() {
+    let error = fake().prepare(&[1, -200, 2], &images(2)).unwrap_err();
+    assert!(matches!(
+        error,
+        HostPreprocessorError::Placeholder(ImageTokenBlockError::MediaCardinality {
+            placeholder_count: 1,
+            image_count: 2,
+        })
+    ));
+}
+
+#[test]
+fn fake_preprocessor_rejects_expanded_sequence_over_capacity() {
+    let preprocessor = FakeHostMultimodalPreprocessor {
+        max_sequence_len: 3,
+        ..fake()
+    };
+    let error = preprocessor.prepare(&[1, -200, 2], &images(1)).unwrap_err();
+    assert!(matches!(
+        error,
+        HostPreprocessorError::SequenceCapacity {
+            actual: 4,
+            maximum: 3,
+        }
+    ));
+}
+
+#[test]
+fn processor_shape_validation_rejects_layout_and_size_drift() {
+    let error = validate_processor_shape(&[1, 224, 224, 3], 1, 224).unwrap_err();
+    assert!(matches!(
+        error,
+        HostPreprocessorError::ProcessorShape { .. }
+    ));
+
+    let error = validate_processor_shape(&[1, 3, 336, 336], 1, 224).unwrap_err();
+    assert!(matches!(
+        error,
+        HostPreprocessorError::ProcessorShape { .. }
+    ));
+}
+
+#[test]
+fn owned_llava_export_matches_existing_mlx_merge_fixture() {
+    ensure_cpu_device();
+    let text = mlxcel_core::from_slice_f32(&[1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5], &[1, 4, 2]);
+    let ids = mlxcel_core::from_slice_i32(&[7, 42, 42, 8], &[1, 4]);
+    let vision = mlxcel_core::from_slice_f32(&[10.0, 11.0, 12.0, 13.0], &[1, 2, 2]);
+    let merged = merge_llava(42, &vision, &text, &ids);
+    let expected_bytes = mlxcel_core::try_array_to_raw_bytes(&merged.inputs_embeds).unwrap();
+
+    let prepared = export_llava_prefill(vec![7, 42, 42, 8], merged, 42, 1, 2, 2).unwrap();
+
+    assert_eq!(prepared.embeddings.bytes, expected_bytes);
+    assert_eq!(prepared.embeddings.shape, vec![1, 4, 2]);
+    assert_eq!(
+        prepared.positions,
+        mlxcel_core::session::PreparedPositions::Sequential {
+            start: 0,
+            length: 4,
+        }
+    );
+    assert!(prepared.attention_bias.causal);
+    assert_eq!(prepared.attention_bias.tensor.shape, vec![1, 1, 1, 4]);
+    assert!(
+        prepared
+            .attention_bias
+            .tensor
+            .bytes
+            .iter()
+            .all(|&byte| byte == 0)
+    );
+}
+
+#[test]
+fn mlx_export_supports_f16_bf16_and_f32_with_exact_byte_counts() {
+    ensure_cpu_device();
+    let values = mlxcel_core::from_slice_f32(&[1.0, 2.0, 3.0, 4.0], &[1, 2, 2]);
+    for mlx_dtype in [dtype::FLOAT16, dtype::BFLOAT16, dtype::FLOAT32] {
+        let array = mlxcel_core::astype(&values, mlx_dtype);
+        let exported = export_mlx_tensor(&array, "test tensor").unwrap();
+        assert_eq!(exported.bytes.len(), 4 * exported.dtype.size_bytes());
+        assert_eq!(exported.shape, vec![1, 2, 2]);
+    }
+}
+
+#[test]
+fn llava_export_rejects_hidden_size_mismatch() {
+    ensure_cpu_device();
+    let text = mlxcel_core::from_slice_f32(&[1.0, 2.0, 3.0, 4.0], &[1, 2, 2]);
+    let merged = crate::vision::merge::InputEmbeddings {
+        inputs_embeds: text,
+        attention_mask_4d: None,
+    };
+    let error = export_llava_prefill(vec![1, 2], merged, 42, 0, 2, 3).unwrap_err();
+    assert!(matches!(
+        error,
+        HostPreprocessorError::EmbeddingShape { .. }
+    ));
+}

--- a/src/multimodal/mod.rs
+++ b/src/multimodal/mod.rs
@@ -23,6 +23,7 @@
 //!   vision wrapper that needs `forward_batched_with_context_and_ids` to route
 //!   each row through `forward_with_sequence_id`.
 //! - `gemma4_vl`: Gemma 4 mixed-length batching helpers
+//! - `host_preprocessor`: owned host-first prefill production for compiler backends
 //! - `phi4mm_prompt`: Phi4MM `<|image_N|>` normalization and audio guard
 //! - `phi4_siglip_prompt`: Phi4-SigLIP `<image>` placeholder handling
 //! - `minicpmo_prompt`: MiniCPM-o image placeholder expansion and bounds
@@ -40,6 +41,7 @@ pub mod deepseekocr_prompt;
 pub mod fastvlm_prompt;
 pub mod gemma4_vl;
 pub mod granite_vision_prompt;
+pub mod host_preprocessor;
 pub mod internvl_prompt;
 pub mod kimi_vl_prompt;
 pub mod lfm2_vl_prompt;

--- a/src/multimodal/vlm_prompt.rs
+++ b/src/multimodal/vlm_prompt.rs
@@ -18,6 +18,8 @@
 //! predictable insertion or expansion of image-token blocks. This module keeps
 //! that policy separate from model loading and request parsing.
 
+use thiserror::Error;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImageTokenBlockInfo {
     pub use_boi_eoi: bool,
@@ -57,13 +59,32 @@ pub struct ImageTokenBlockStats {
     pub tokens_per_image: usize,
 }
 
+/// Invalid family-neutral image-placeholder layouts.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum ImageTokenBlockError {
+    #[error("cannot place {image_count} image(s) into an empty tokenized prompt")]
+    EmptyPrompt { image_count: usize },
+    #[error("image-token block size must be greater than zero")]
+    EmptyImageBlock,
+    #[error(
+        "prompt contains {placeholder_count} image placeholder(s), but {image_count} decoded image(s) were provided"
+    )]
+    MediaCardinality {
+        placeholder_count: usize,
+        image_count: usize,
+    },
+    #[error("image-token expansion capacity overflowed")]
+    CapacityOverflow,
+}
+
 pub fn apply_image_token_blocks(
     prompt_tokens: &mut Vec<i32>,
     info: ImageTokenBlockInfo,
     num_images: usize,
-) -> Option<ImageTokenBlockStats> {
-    if prompt_tokens.is_empty() || num_images == 0 {
-        return None;
+) -> Result<Option<ImageTokenBlockStats>, ImageTokenBlockError> {
+    if info.mm_tokens_per_image == 0 {
+        return Err(ImageTokenBlockError::EmptyImageBlock);
     }
 
     // Count existing image tokens or BOI tokens (from chat template) that
@@ -84,11 +105,36 @@ pub fn apply_image_token_blocks(
     };
     let total_existing = existing_image_count + existing_boi_count;
 
+    if total_existing != 0 && total_existing != num_images {
+        return Err(ImageTokenBlockError::MediaCardinality {
+            placeholder_count: total_existing,
+            image_count: num_images,
+        });
+    }
+    if num_images == 0 {
+        return Ok(None);
+    }
+    if prompt_tokens.is_empty() {
+        return Err(ImageTokenBlockError::EmptyPrompt {
+            image_count: num_images,
+        });
+    }
+
     if total_existing > 0 {
-        let extra_per_block = info.block_prefix_tokens.len() + info.block_suffix_tokens.len();
-        let mut expanded = Vec::with_capacity(
-            prompt_tokens.len() + (info.mm_tokens_per_image - 1 + extra_per_block) * total_existing,
-        );
+        let wrapper_tokens = if info.use_boi_eoi { 2 } else { 0 };
+        let extra_tokens = info
+            .mm_tokens_per_image
+            .checked_sub(1)
+            .and_then(|tokens| tokens.checked_add(wrapper_tokens))
+            .and_then(|tokens| tokens.checked_add(info.block_prefix_tokens.len()))
+            .and_then(|tokens| tokens.checked_add(info.block_suffix_tokens.len()))
+            .and_then(|tokens| tokens.checked_mul(total_existing))
+            .ok_or(ImageTokenBlockError::CapacityOverflow)?;
+        let capacity = prompt_tokens
+            .len()
+            .checked_add(extra_tokens)
+            .ok_or(ImageTokenBlockError::CapacityOverflow)?;
+        let mut expanded = Vec::with_capacity(capacity);
         for &token in prompt_tokens.iter() {
             if token == info.image_token_id || (info.use_boi_eoi && token == info.boi_token_id) {
                 // Insert block prefix tokens (e.g., \n\n for Gemma3 VLM)
@@ -110,15 +156,31 @@ pub fn apply_image_token_blocks(
         }
         *prompt_tokens = expanded;
 
-        return Some(ImageTokenBlockStats {
+        return Ok(Some(ImageTokenBlockStats {
             action: ImageTokenBlockAction::Expanded {
                 existing_image_count: total_existing,
             },
             tokens_per_image: info.mm_tokens_per_image,
-        });
+        }));
     }
 
-    let mut image_tokens = Vec::new();
+    let wrapper_tokens = if info.use_boi_eoi { 2 } else { 0 };
+    let block_len = info
+        .mm_tokens_per_image
+        .checked_add(wrapper_tokens)
+        .ok_or(ImageTokenBlockError::CapacityOverflow)?;
+    let image_token_capacity = block_len
+        .checked_mul(num_images)
+        .ok_or(ImageTokenBlockError::CapacityOverflow)?;
+    let separator_len = usize::from(!info.has_bos && info.separator_token_id.is_some());
+    prompt_tokens
+        .len()
+        .checked_add(image_token_capacity)
+        .and_then(|len| len.checked_add(separator_len))
+        .and_then(|len| len.checked_add(info.suffix_tokens.len()))
+        .ok_or(ImageTokenBlockError::CapacityOverflow)?;
+
+    let mut image_tokens = Vec::with_capacity(image_token_capacity);
     for _ in 0..num_images {
         if info.use_boi_eoi {
             image_tokens.push(info.boi_token_id);
@@ -150,12 +212,12 @@ pub fn apply_image_token_blocks(
 
     prompt_tokens.extend_from_slice(&info.suffix_tokens);
 
-    Some(ImageTokenBlockStats {
+    Ok(Some(ImageTokenBlockStats {
         action: ImageTokenBlockAction::Inserted {
             image_blocks: num_images,
         },
         tokens_per_image: info.mm_tokens_per_image,
-    })
+    }))
 }
 
 #[cfg(test)]

--- a/src/multimodal/vlm_prompt_tests.rs
+++ b/src/multimodal/vlm_prompt_tests.rs
@@ -32,7 +32,7 @@ fn apply_image_token_blocks_expands_existing_tokens_with_boi_eoi() {
     };
     let mut prompt_tokens = vec![1, 99, 2];
 
-    let stats = apply_image_token_blocks(&mut prompt_tokens, info, 1);
+    let stats = apply_image_token_blocks(&mut prompt_tokens, info, 1).unwrap();
 
     assert_eq!(
         stats,
@@ -62,7 +62,7 @@ fn apply_image_token_blocks_inserts_blocks_after_bos() {
     };
     let mut prompt_tokens = vec![1, 2, 3];
 
-    let stats = apply_image_token_blocks(&mut prompt_tokens, info, 2);
+    let stats = apply_image_token_blocks(&mut prompt_tokens, info, 2).unwrap();
 
     assert_eq!(
         stats,
@@ -91,7 +91,7 @@ fn apply_image_token_blocks_paligemma_format() {
     };
     let mut prompt_tokens = vec![100, 200, 300]; // text tokens only, no BOS
 
-    let stats = apply_image_token_blocks(&mut prompt_tokens, info, 1);
+    let stats = apply_image_token_blocks(&mut prompt_tokens, info, 1).unwrap();
 
     assert_eq!(
         stats,
@@ -125,11 +125,14 @@ fn apply_image_token_blocks_is_noop_without_prompt_or_images() {
     let mut empty_prompt = Vec::new();
     assert_eq!(
         apply_image_token_blocks(&mut empty_prompt, info.clone(), 1),
-        None
+        Err(super::ImageTokenBlockError::EmptyPrompt { image_count: 1 })
     );
 
     let mut prompt_tokens = vec![1, 2, 3];
-    assert_eq!(apply_image_token_blocks(&mut prompt_tokens, info, 0), None);
+    assert_eq!(
+        apply_image_token_blocks(&mut prompt_tokens, info, 0),
+        Ok(None)
+    );
     assert_eq!(prompt_tokens, vec![1, 2, 3]);
 }
 
@@ -153,7 +156,7 @@ fn apply_image_token_blocks_expands_with_block_prefix_and_suffix() {
     // Prompt has a BOI token (10) that should be expanded
     let mut prompt_tokens = vec![1, 10, 2];
 
-    let stats = apply_image_token_blocks(&mut prompt_tokens, info, 1);
+    let stats = apply_image_token_blocks(&mut prompt_tokens, info, 1).unwrap();
 
     assert_eq!(
         stats,
@@ -166,4 +169,54 @@ fn apply_image_token_blocks_expands_with_block_prefix_and_suffix() {
     );
     // prefix(108) + BOI(10) + img*3(99,99,99) + EOI(11) + suffix(108)
     assert_eq!(prompt_tokens, vec![1, 108, 10, 99, 99, 99, 11, 108, 2]);
+}
+
+#[test]
+fn apply_image_token_blocks_rejects_media_cardinality_mismatch() {
+    let info = ImageTokenBlockInfo {
+        use_boi_eoi: false,
+        image_token_id: 99,
+        mm_tokens_per_image: 2,
+        boi_token_id: 0,
+        eoi_token_id: 0,
+        has_bos: true,
+        separator_token_id: None,
+        suffix_tokens: Vec::new(),
+        block_prefix_tokens: Vec::new(),
+        block_suffix_tokens: Vec::new(),
+    };
+    let mut prompt_tokens = vec![1, 99, 2];
+
+    let error = apply_image_token_blocks(&mut prompt_tokens, info, 2).unwrap_err();
+
+    assert_eq!(
+        error,
+        super::ImageTokenBlockError::MediaCardinality {
+            placeholder_count: 1,
+            image_count: 2,
+        }
+    );
+    assert_eq!(prompt_tokens, vec![1, 99, 2]);
+}
+
+#[test]
+fn apply_image_token_blocks_rejects_insert_capacity_overflow() {
+    let info = ImageTokenBlockInfo {
+        use_boi_eoi: true,
+        image_token_id: 99,
+        mm_tokens_per_image: 2,
+        boi_token_id: 10,
+        eoi_token_id: 11,
+        has_bos: true,
+        separator_token_id: None,
+        suffix_tokens: Vec::new(),
+        block_prefix_tokens: Vec::new(),
+        block_suffix_tokens: Vec::new(),
+    };
+    let mut prompt_tokens = vec![1, 2];
+
+    let error = apply_image_token_blocks(&mut prompt_tokens, info, usize::MAX).unwrap_err();
+
+    assert_eq!(error, super::ImageTokenBlockError::CapacityOverflow);
+    assert_eq!(prompt_tokens, vec![1, 2]);
 }

--- a/src/multimodal/vlm_runtime.rs
+++ b/src/multimodal/vlm_runtime.rs
@@ -628,10 +628,11 @@ where
             }))
         }
         VlmRuntimeRef::Gemma3n(gemma3n_vl) => {
-            let preparation = model
-                .image_token_block_info()
-                .and_then(|info| apply_image_token_blocks(prompt_tokens, info, images.len()))
-                .map(VlmPreparationSummary::ImageBlocks);
+            let preparation = match model.image_token_block_info() {
+                Some(info) => apply_image_token_blocks(prompt_tokens, info, images.len())?
+                    .map(VlmPreparationSummary::ImageBlocks),
+                None => None,
+            };
 
             let pixel_values = gemma3n_vl.processor.preprocess(images);
             let input_ids_arr = prompt_ids_array(prompt_tokens);
@@ -1380,7 +1381,7 @@ where
             };
             let tokens_per_image = vision_module.mm_tokens_per_image;
             let preparation =
-                apply_image_token_blocks(prompt_tokens, info, images.len()).map(|_| {
+                apply_image_token_blocks(prompt_tokens, info, images.len())?.map(|_| {
                     VlmPreparationSummary::FastVLM {
                         image_blocks: images.len(),
                         total_image_tokens: (images.len() * tokens_per_image) as i32,
@@ -1616,10 +1617,11 @@ where
             }))
         }
         VlmRuntimeRef::Standard(vision_module) => {
-            let preparation = model
-                .image_token_block_info()
-                .and_then(|info| apply_image_token_blocks(prompt_tokens, info, images.len()))
-                .map(VlmPreparationSummary::ImageBlocks);
+            let preparation = match model.image_token_block_info() {
+                Some(info) => apply_image_token_blocks(prompt_tokens, info, images.len())?
+                    .map(VlmPreparationSummary::ImageBlocks),
+                None => None,
+            };
 
             let pixel_values = vision_module.processor.preprocess(images);
             let mask =

--- a/src/vision/merge.rs
+++ b/src/vision/merge.rs
@@ -207,9 +207,6 @@ pub fn merge_llava(
     // Use masked_scatter to place features at image token positions
     let final_embedding = masked_scatter(inputs_embeds, &image_mask_expanded, &flat_features);
 
-    // Cast to input dtype
-    let final_embedding = mlxcel_core::astype(&final_embedding, embed_dtype);
-
     InputEmbeddings {
         inputs_embeds: final_embedding,
         attention_mask_4d: None, // LLaVA uses standard causal masking


### PR DESCRIPTION
## Summary

- Add a backend-neutral owned prepared-prefill DTO with validated embeddings, positions, additive attention bias, logical token history, and modality metadata.
- Add a LLaVA host preprocessor and canonical filtered loader that retain only the vision tower, projector, and text embedding weights while bypassing transformations not applied by IREE.
- Share exact image-placeholder cardinality and overflow-safe expansion semantics with the existing MLX path, and export evaluated contiguous tensors through the fallible FFI boundary.
- Provide a deterministic checkpoint-free fake plus focused parity, dtype, shape, capacity, and loader-filter tests.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p mlxcel-core --lib --tests`
- `cargo check -p mlxcel --lib --tests`
- `cargo test -q -p mlxcel-core multimodal::tests`
- `cargo test -q -p mlxcel multimodal::host_preprocessor::tests --lib`
- `cargo test -q -p mlxcel multimodal::vlm_prompt::tests --lib`
- `cargo test -q -p mlxcel loading::vlm::llava::tests --lib`
- `cargo test -q -p mlxcel vision::merge::tests --lib`
- `cargo clippy -p mlxcel-core --lib --tests -- -D warnings`
- `cargo clippy -p mlxcel --lib --tests -- -D warnings`

Closes #859
