### PR TITLE
feat(xla): seed IREE sessions from prepared embeddings (#860)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,6 +278,10 @@ required-features = ["test-utils"]
 name = "paged_handoff_parity"
 required-features = ["test-utils"]
 
+[[test]]
+name = "xla_prepared_prefill"
+required-features = ["xla-iree"]
+
 # Reference-equivalence + throughput harness for the OpenXLA/IREE continuous
 # batching engine (#449 M3 Stage 2b). Needs real IREE execution, so it builds
 # only under `xla-iree` (which carries the runtime link recipe); default/CI

--- a/build.rs
+++ b/build.rs
@@ -114,20 +114,27 @@ fn main() {
             ] {
                 println!("cargo:rustc-link-search=native={}", b.join(d).display());
             }
-            for arg in [
+            let mut link_args = vec![
                 "-Wl,--whole-archive",
                 "-l:libiree_runtime_unified.a",
                 "-Wl,--no-whole-archive",
                 "-Wl,--start-group",
                 "-l:libiree_hal_drivers_cuda_registration_registration.a",
-                "-l:libprintf_printf.a",
                 "-l:libflatcc_parsing.a",
                 "-lgcc",
                 "-lm",
                 "-lpthread",
                 "-ldl",
                 "-Wl,--end-group",
-            ] {
+            ];
+            // Older source builds leave the vendored printf implementation in
+            // its own archive; newer unified runtimes carry it directly and do
+            // not produce that archive. Link it only when the build generated it.
+            let printf = b.join("build_tools/third_party/printf/libprintf_printf.a");
+            if printf.exists() {
+                link_args.insert(5, "-l:libprintf_printf.a");
+            }
+            for arg in link_args {
                 println!("cargo:rustc-link-arg={arg}");
             }
             return;

--- a/src/backend/session.rs
+++ b/src/backend/session.rs
@@ -40,6 +40,8 @@ use mlxcel_core::MlxArray;
 use mlxcel_core::generate::{GenerationStats, LanguageModel, SamplingConfig};
 #[cfg(feature = "xla-backend")]
 use mlxcel_core::session::InferenceSession;
+#[cfg(feature = "xla-backend")]
+use mlxcel_core::session::PreparedPrefill;
 use mlxcel_core::session::{MlxInferenceSession, SessionCapabilities};
 #[cfg(feature = "xla-backend")]
 use mlxcel_xla::XlaInferenceSession;
@@ -180,11 +182,14 @@ impl Session {
                 sampling,
                 on_token,
             ),
-            // The XLA session is single-sequence text; it has no multimodal
-            // capability, so it ignores the input embeddings and drives the token
-            // stream from the prompt ids.
             #[cfg(feature = "xla-backend")]
             Session::Xla(s) => {
+                if input_embeddings.is_some() || mask.is_some() {
+                    eprintln!(
+                        "OpenXLA generation rejected native MLX embeddings; provide an owned PreparedPrefill through generate_streaming_with_prepared"
+                    );
+                    return Vec::new();
+                }
                 let eos = s.eos_token_ids().to_vec();
                 s.generate_streaming_greedy(prompt_tokens, max_tokens, &eos, on_token)
                     .unwrap_or_else(|e| {
@@ -220,6 +225,49 @@ impl Session {
         }
     }
 
+    /// Streaming OpenXLA generation from the backend-neutral owned embeddings
+    /// contract. MLX callers must continue using their native array entry.
+    #[cfg(feature = "xla-backend")]
+    #[inline]
+    pub fn generate_streaming_with_prepared<F: FnMut(i32) -> bool>(
+        &mut self,
+        prepared: &PreparedPrefill,
+        max_tokens: usize,
+        on_token: F,
+    ) -> Result<Vec<i32>, String> {
+        match self {
+            Session::Mlx(_) => Err(
+                "the MLX session does not consume PreparedPrefill; use generate_streaming_with_embeddings with native MLX arrays"
+                    .to_string(),
+            ),
+            Session::Xla(s) => {
+                let eos = s.eos_token_ids().to_vec();
+                s.generate_prepared_streaming_greedy(prepared, max_tokens, &eos, on_token)
+            }
+        }
+    }
+
+    /// Non-streaming OpenXLA generation from owned prepared embeddings.
+    #[cfg(feature = "xla-backend")]
+    #[inline]
+    pub fn generate_with_stats_and_prepared(
+        &mut self,
+        prepared: &PreparedPrefill,
+        max_tokens: usize,
+    ) -> Result<(Vec<i32>, GenerationStats), String> {
+        match self {
+            Session::Mlx(_) => Err(
+                "the MLX session does not consume PreparedPrefill; use generate_with_stats_and_embeddings with native MLX arrays"
+                    .to_string(),
+            ),
+            Session::Xla(s) => {
+                let eos = s.eos_token_ids().to_vec();
+                let tokens = s.generate_prepared_greedy(prepared, max_tokens, &eos)?;
+                Ok((tokens, GenerationStats::default()))
+            }
+        }
+    }
+
     /// Embedding-prefill generation with profiling stats.
     #[inline]
     pub fn generate_with_stats_and_embeddings<M: LanguageModel>(
@@ -242,6 +290,12 @@ impl Session {
             ),
             #[cfg(feature = "xla-backend")]
             Session::Xla(s) => {
+                if input_embeddings.is_some() || mask.is_some() {
+                    eprintln!(
+                        "OpenXLA generation rejected native MLX embeddings; provide an owned PreparedPrefill through generate_with_stats_and_prepared"
+                    );
+                    return (Vec::new(), GenerationStats::default());
+                }
                 let eos = s.eos_token_ids().to_vec();
                 let toks = s
                     .generate_greedy(prompt_tokens, max_tokens, &eos)

--- a/src/lib/mlxcel-core/src/session.rs
+++ b/src/lib/mlxcel-core/src/session.rs
@@ -113,6 +113,13 @@ impl SessionCapabilities {
             multimodal: false,
         }
     }
+
+    /// Advertise owned/native multimodal prefill on a single-sequence session.
+    #[must_use]
+    pub const fn with_multimodal(mut self) -> Self {
+        self.multimodal = true;
+        self
+    }
 }
 
 /// The engine-neutral, single-sequence inference contract (ADR 0004).
@@ -144,6 +151,20 @@ pub trait InferenceSession {
     /// Backends that do not expose token-level stepping (the MLX reference
     /// session) return an error pointing at the fused generation entry points.
     fn prefill(&mut self, token_ids: &[i32]) -> Result<(), String>;
+
+    /// Seed KV from an owned, validated embeddings payload and return the first
+    /// sampled token produced at its effective final position.
+    ///
+    /// Returning the first token keeps the expanded embedding length distinct
+    /// from logical token history: the backend seeds every prepared position
+    /// exactly once, then decode begins at `sequence_len`.
+    ///
+    /// # Errors
+    ///
+    /// Backends without an owned prepared-prefill entry return an explicit
+    /// unsupported error. Implementations must never fall back to token prefill
+    /// while silently discarding this payload.
+    fn prefill_prepared(&mut self, prepared: &PreparedPrefill) -> Result<i32, String>;
 
     /// Advance generation by one token given the previously emitted token, and
     /// return the next sampled token id (conceptual contract).
@@ -325,6 +346,13 @@ impl InferenceSession for MlxInferenceSession {
 
     fn prefill(&mut self, _token_ids: &[i32]) -> Result<(), String> {
         Err(RESERVED_STEP_CONTRACT.to_string())
+    }
+
+    fn prefill_prepared(&mut self, _prepared: &PreparedPrefill) -> Result<i32, String> {
+        Err(
+            "MlxInferenceSession does not consume the owned PreparedPrefill contract; use its native MLX embedding-prefill entry points"
+                .to_string(),
+        )
     }
 
     fn decode_step(&mut self, _token: i32) -> Result<i32, String> {

--- a/src/lib/mlxcel-xla/csrc/xla_iree.c
+++ b/src/lib/mlxcel-xla/csrc/xla_iree.c
@@ -20,6 +20,7 @@
 // token-exact from Rust before being vendored here. Rust calls the flat C ABI
 // (`xla_llama_*`) and never binds the IREE runtime structs directly.
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -31,14 +32,6 @@
 #include <iree/runtime/api.h>
 #include <iree/hal/buffer_view_util.h>
 #include <iree/hal/buffer_transfer.h>
-#ifdef XLA_GATE_CUDA
-// CUDA mode (GB10): built against a source-built cuda-enabled IREE runtime
-// (build.rs cuda mode defines XLA_GATE_CUDA). The unified runtime bundles the
-// cuda driver impl + local-task, but the registration wrapper is separate, so
-// the driver is registered explicitly below.
-#include <iree/hal/drivers/cuda/registration/driver_module.h>
-#endif
-
 // libc-backed implementation of the system allocator control function.
 iree_status_t iree_xla_libc_ctl(void* self, iree_allocator_command_t command,
                                 const void* params, void** inout_ptr) {
@@ -85,13 +78,28 @@ iree_status_t iree_xla_libc_ctl(void* self, iree_allocator_command_t command,
     }                                                                    \
   } while (0)
 
+#define XLA_CHECK_GOTO(expr, label, rc_var)                              \
+  do {                                                                   \
+    iree_status_t _s = (expr);                                           \
+    if (!iree_status_is_ok(_s)) {                                        \
+      int _c = (int)iree_status_code(_s);                                \
+      fprintf(stderr, "xla_iree: %s failed (status %d):\n", #expr, _c); \
+      iree_status_fprint(stderr, _s);                                    \
+      iree_status_ignore(_s);                                            \
+      rc_var = _c ? _c : 1;                                             \
+      goto label;                                                        \
+    }                                                                    \
+  } while (0)
+
 typedef struct xla_ctx {
   iree_runtime_instance_t* instance;
   iree_hal_device_t* device;
-  iree_runtime_session_t* session;   // holds both @prefill and @decode_step
-  iree_hal_allocator_t* allocator;   // device allocator (shared by both calls)
+  iree_runtime_session_t* session;   // holds @prefill, @prefill_embeddings, @decode_step
+  iree_hal_allocator_t* allocator;   // device allocator (shared by all calls)
+  uint64_t compatibility_fingerprint;
   int32_t n_weights;
   int32_t context_capacity;
+  int32_t hidden_size;
   iree_hal_buffer_view_t** weights;  // resident weights, uploaded once
   iree_hal_buffer_view_t* kcache;    // threaded KV (set by prefill, advanced by decode)
   iree_hal_buffer_view_t* vcache;
@@ -106,6 +114,17 @@ typedef struct xla_ctx {
   iree_host_size_t rg_per;
   iree_hal_dim_t rg_dims[4];
 } xla_ctx;
+
+// Explicit descriptor for host tensors entering the embeddings ABI. `dtype` is
+// 0=f32 or 1=i32. Rust supplies every byte/rank/shape field and this shim repeats
+// all safety-critical checks before constructing an IREE buffer view.
+typedef struct xla_tensor_desc {
+  const void* data;
+  size_t byte_length;
+  int32_t dtype;
+  int32_t rank;
+  int64_t dims[4];
+} xla_tensor_desc;
 
 // Forward declaration: xla_llama_create's error path frees a partial context.
 void xla_llama_free(xla_ctx* c);
@@ -187,6 +206,59 @@ static iree_status_t xla_alloc_bv(xla_ctx* c, iree_host_size_t rank,
       iree_make_const_byte_span(data, nbytes), out);
 }
 
+static int xla_validate_tensor_desc(const char* name,
+                                    const xla_tensor_desc* desc,
+                                    int32_t expected_dtype,
+                                    int32_t expected_rank,
+                                    const int64_t* expected_dims) {
+  if (!desc || !desc->data || desc->dtype != expected_dtype ||
+      desc->rank != expected_rank || expected_rank < 0 || expected_rank > 4) {
+    fprintf(stderr,
+            "xla_iree: invalid %s descriptor pointer/dtype/rank (want dtype=%d rank=%d)\n",
+            name, expected_dtype, expected_rank);
+    return 1;
+  }
+  size_t element_size = expected_dtype == 0 ? sizeof(float) : sizeof(int32_t);
+  size_t elements = 1;
+  for (int32_t axis = 0; axis < expected_rank; ++axis) {
+    int64_t dim = desc->dims[axis];
+    if (dim <= 0 || dim != expected_dims[axis] ||
+        (size_t)dim > SIZE_MAX / elements) {
+      fprintf(stderr,
+              "xla_iree: invalid %s descriptor axis %d=%lld (want %lld)\n",
+              name, axis, (long long)dim, (long long)expected_dims[axis]);
+      return 1;
+    }
+    elements *= (size_t)dim;
+  }
+  if (elements > SIZE_MAX / element_size) {
+    fprintf(stderr, "xla_iree: %s descriptor byte count overflowed\n", name);
+    return 1;
+  }
+  size_t expected_bytes = elements * element_size;
+  if (desc->byte_length != expected_bytes) {
+    fprintf(stderr,
+            "xla_iree: invalid %s descriptor byte_length=%zu (want %zu)\n",
+            name, desc->byte_length, expected_bytes);
+    return 1;
+  }
+  return 0;
+}
+
+static iree_status_t xla_alloc_desc_bv(xla_ctx* c,
+                                       const xla_tensor_desc* desc,
+                                       iree_hal_buffer_view_t** out) {
+  iree_hal_dim_t shape[4];
+  for (int32_t axis = 0; axis < desc->rank; ++axis) {
+    shape[axis] = (iree_hal_dim_t)desc->dims[axis];
+  }
+  iree_hal_element_type_t element_type =
+      desc->dtype == 0 ? IREE_HAL_ELEMENT_TYPE_FLOAT_32
+                       : IREE_HAL_ELEMENT_TYPE_INT_32;
+  return xla_alloc_bv(c, (iree_host_size_t)desc->rank, shape, element_type,
+                      desc->data, (iree_host_size_t)desc->byte_length, out);
+}
+
 // Validate the static KV contract shared by the paired prefill/decode modules.
 // `context_axis` is 1 for rank-4 [L,S,nkv,d] and 2 for rank-5 [B,L,S,nkv,d].
 static int xla_validate_kv_pair(xla_ctx* c, iree_hal_buffer_view_t* kc,
@@ -194,8 +266,12 @@ static int xla_validate_kv_pair(xla_ctx* c, iree_hal_buffer_view_t* kc,
                                 iree_host_size_t rank,
                                 iree_host_size_t context_axis) {
   if (!kc || !vc || iree_hal_buffer_view_shape_rank(kc) != rank ||
-      iree_hal_buffer_view_shape_rank(vc) != rank) {
-    fprintf(stderr, "xla_iree: expected matching rank-%zu K/V buffers\n",
+      iree_hal_buffer_view_shape_rank(vc) != rank ||
+      iree_hal_buffer_view_element_type(kc) !=
+          IREE_HAL_ELEMENT_TYPE_FLOAT_32 ||
+      iree_hal_buffer_view_element_type(vc) !=
+          IREE_HAL_ELEMENT_TYPE_FLOAT_32) {
+    fprintf(stderr, "xla_iree: expected matching rank-%zu f32 K/V buffers\n",
             (size_t)rank);
     return 1;
   }
@@ -221,27 +297,28 @@ static int xla_validate_kv_pair(xla_ctx* c, iree_hal_buffer_view_t* kc,
 
 static iree_status_t xla_llama_create_impl(
     xla_ctx* c, const char* device_uri, const char* prefill_vmfb,
-    const char* decode_vmfb, int32_t n_weights, const void* const* weight_data,
+    const char* prefill_embeddings_vmfb, const char* decode_vmfb,
+    uint64_t compatibility_fingerprint, int32_t n_weights,
+    const void* const* weight_data,
     const int32_t* weight_dtypes, const int32_t* weight_ranks,
-    const int64_t* weight_dims, int32_t context_capacity) {
-  if (context_capacity <= 0) {
+    const int64_t* weight_dims, int32_t context_capacity,
+    int32_t hidden_size) {
+  if (context_capacity <= 0 || hidden_size <= 0 ||
+      compatibility_fingerprint == 0) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "context_capacity must be positive");
+                            "bundle fingerprint, context_capacity, and hidden_size must be positive");
   }
   c->n_weights = n_weights;
   c->context_capacity = context_capacity;
-
-#ifdef XLA_GATE_CUDA
-  // Register the CUDA driver so use_all_available_drivers exposes it for a
-  // device_uri of "cuda" (GB10). Non-fatal; CUDA is initialized only when a
-  // cuda device is actually created.
-  iree_status_t cu_reg =
-      iree_hal_cuda_driver_module_register(iree_hal_driver_registry_default());
-  if (!iree_status_is_ok(cu_reg)) iree_status_ignore(cu_reg);
-#endif
+  c->hidden_size = hidden_size;
+  c->compatibility_fingerprint = compatibility_fingerprint;
 
   iree_runtime_instance_options_t inst_opts;
   iree_runtime_instance_options_initialize(&inst_opts);
+  // The unified runtime's register-all module owns both CUDA and local-task.
+  // Pre-registering CUDA here makes register-all stop at the duplicate entry
+  // before local-task is reached, which silently breaks CPU parity runs in a
+  // CUDA-enabled build.
   iree_runtime_instance_options_use_all_available_drivers(&inst_opts);
   IREE_RETURN_IF_ERROR(iree_runtime_instance_create(
       &inst_opts, iree_allocator_system(), &c->instance));
@@ -255,12 +332,24 @@ static iree_status_t xla_llama_create_impl(
       c->instance, &sess_opts, c->device,
       iree_runtime_instance_host_allocator(c->instance), &c->session));
 
-  // Both modules in one session; their distinct names (@prefill, @decode_step)
-  // make the calls "prefill.main" and "decode_step.main".
+  // All bundle members enter one session atomically. Their distinct names make
+  // the calls "prefill.main", "prefill_embeddings.main", and
+  // "decode_step.main".
   IREE_RETURN_IF_ERROR(iree_runtime_session_append_bytecode_module_from_file(
       c->session, prefill_vmfb));
   IREE_RETURN_IF_ERROR(iree_runtime_session_append_bytecode_module_from_file(
+      c->session, prefill_embeddings_vmfb));
+  IREE_RETURN_IF_ERROR(iree_runtime_session_append_bytecode_module_from_file(
       c->session, decode_vmfb));
+
+  const char* required_entries[] = {"prefill.main", "prefill_embeddings.main",
+                                    "decode_step.main"};
+  for (size_t i = 0; i < 3; ++i) {
+    iree_runtime_call_t probe;
+    IREE_RETURN_IF_ERROR(iree_runtime_call_initialize_by_name(
+        c->session, iree_make_cstring_view(required_entries[i]), &probe));
+    iree_runtime_call_deinitialize(&probe);
+  }
 
   c->allocator = iree_runtime_session_device_allocator(c->session);
 
@@ -313,18 +402,23 @@ static iree_status_t xla_llama_create_impl(
 // caller may free them after this returns. Returns NULL on failure (after printing
 // a diagnostic).
 xla_ctx* xla_llama_create(const char* device_uri, const char* prefill_vmfb,
-                          const char* decode_vmfb, int32_t n_weights,
+                          const char* prefill_embeddings_vmfb,
+                          const char* decode_vmfb,
+                          uint64_t compatibility_fingerprint,
+                          int32_t n_weights,
                           const void* const* weight_data,
                           const int32_t* weight_dtypes,
                           const int32_t* weight_ranks,
                           const int64_t* weight_dims,
-                          int32_t context_capacity) {
+                          int32_t context_capacity, int32_t hidden_size) {
   xla_ctx* c = (xla_ctx*)calloc(1, sizeof(xla_ctx));
   if (!c) return NULL;
   iree_status_t s =
-      xla_llama_create_impl(c, device_uri, prefill_vmfb, decode_vmfb, n_weights,
-                            weight_data, weight_dtypes, weight_ranks, weight_dims,
-                            context_capacity);
+      xla_llama_create_impl(c, device_uri, prefill_vmfb,
+                            prefill_embeddings_vmfb, decode_vmfb,
+                            compatibility_fingerprint, n_weights, weight_data,
+                            weight_dtypes, weight_ranks, weight_dims,
+                            context_capacity, hidden_size);
   if (!iree_status_is_ok(s)) {
     char buf[512];
     iree_host_size_t got = 0;
@@ -491,7 +585,16 @@ int xla_llama_decode(xla_ctx* c, int32_t token, int32_t pos, int32_t cache_len,
 // makes a zeroed (cache_len 0) slot a harmless no-op whose output is discarded.
 static iree_status_t xla_ensure_batch_kv(xla_ctx* c) {
   if (c->kcache_b && c->vcache_b) return iree_ok_status();
+  if (c->rg_bsz <= 0 || c->rg_per == 0 ||
+      (iree_host_size_t)c->rg_bsz > SIZE_MAX / c->rg_per) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "batch KV element count overflowed");
+  }
   iree_host_size_t count = (iree_host_size_t)c->rg_bsz * c->rg_per;
+  if (count > SIZE_MAX / sizeof(float)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "batch KV byte count overflowed");
+  }
   iree_host_size_t bytes = count * sizeof(float);
   float* zeros = (float*)calloc((size_t)count, sizeof(float));
   if (!zeros) return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED);
@@ -504,7 +607,67 @@ static iree_status_t xla_ensure_batch_kv(xla_ctx* c) {
                      &c->vcache_b);
   }
   free(zeros);
+  if (!iree_status_is_ok(s)) {
+    if (c->kcache_b) {
+      iree_hal_buffer_view_release(c->kcache_b);
+      c->kcache_b = NULL;
+    }
+    if (c->vcache_b) {
+      iree_hal_buffer_view_release(c->vcache_b);
+      c->vcache_b = NULL;
+    }
+  }
   return s;
+}
+
+// Copy one rank-4 prefill KV pair directly into the selected region of the
+// resident rank-5 batch cache. Token and embeddings prefill both use this exact
+// device-side path; no KV bytes cross host memory.
+static int xla_store_prefill_kv_slot(xla_ctx* c, int32_t slot,
+                                     iree_hal_buffer_view_t* kc,
+                                     iree_hal_buffer_view_t* vc) {
+  if (slot < 0 || slot >= c->rg_bsz ||
+      xla_validate_kv_pair(c, kc, vc, 4, 1) != 0) {
+    return 1;
+  }
+  iree_host_size_t per = iree_hal_buffer_view_element_count(kc);
+  if (c->rg_per == 0) {
+    c->rg_per = per;
+    for (int32_t i = 0; i < 4; ++i) {
+      c->rg_dims[i] = iree_hal_buffer_view_shape_dim(kc, i);
+    }
+  } else {
+    if (per != c->rg_per) {
+      fprintf(stderr, "xla_iree: prefill KV element count changed\n");
+      return 1;
+    }
+    for (int32_t i = 0; i < 4; ++i) {
+      if (c->rg_dims[i] != iree_hal_buffer_view_shape_dim(kc, i)) {
+        fprintf(stderr, "xla_iree: prefill KV shape changed at axis %d\n", i);
+        return 1;
+      }
+    }
+  }
+  XLA_CHECK(xla_ensure_batch_kv(c));
+  if (per > IREE_DEVICE_SIZE_MAX / sizeof(float)) {
+    fprintf(stderr, "xla_iree: prefill KV byte count overflowed\n");
+    return 1;
+  }
+  iree_device_size_t len = (iree_device_size_t)per * sizeof(float);
+  if ((iree_device_size_t)slot > IREE_DEVICE_SIZE_MAX / len) {
+    fprintf(stderr, "xla_iree: prefill KV slot offset overflowed\n");
+    return 1;
+  }
+  iree_device_size_t off = (iree_device_size_t)slot * len;
+  XLA_CHECK(iree_hal_device_transfer_d2d(
+      c->device, iree_hal_buffer_view_buffer(kc), 0,
+      iree_hal_buffer_view_buffer(c->kcache_b), off, len,
+      IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout()));
+  XLA_CHECK(iree_hal_device_transfer_d2d(
+      c->device, iree_hal_buffer_view_buffer(vc), 0,
+      iree_hal_buffer_view_buffer(c->vcache_b), off, len,
+      IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout()));
+  return 0;
 }
 
 // Reset the batched state for `bsz` slots: drop any rank-5 KV and forget the
@@ -589,11 +752,6 @@ int xla_llama_prefill_slot_logits(xla_ctx* c, int32_t slot, const int32_t* token
     iree_runtime_call_deinitialize(&call);
     return 1;
   }
-  if (c->kcache) iree_hal_buffer_view_release(c->kcache);
-  if (c->vcache) iree_hal_buffer_view_release(c->vcache);
-  c->kcache = kc;
-  c->vcache = vc;
-
   iree_status_t rs =
       xla_read_logits(c, logits, out_logits, (iree_host_size_t)vocab);
   iree_hal_buffer_view_release(logits);
@@ -604,45 +762,140 @@ int xla_llama_prefill_slot_logits(xla_ctx* c, int32_t slot, const int32_t* token
   if (!iree_status_is_ok(rs)) {
     int code = (int)iree_status_code(rs);
     iree_status_ignore(rs);
+    iree_hal_buffer_view_release(kc);
+    iree_hal_buffer_view_release(vc);
     return code ? code : 1;
   }
+  int copy_rc = xla_store_prefill_kv_slot(c, slot, kc, vc);
+  iree_hal_buffer_view_release(kc);
+  iree_hal_buffer_view_release(vc);
+  return copy_rc;
+}
 
-  iree_host_size_t per = iree_hal_buffer_view_element_count(c->kcache);
-  if (c->rg_per == 0) {
-    c->rg_per = per;
-    for (int32_t i = 0; i < 4; i++) {
-      c->rg_dims[i] = iree_hal_buffer_view_shape_dim(c->kcache, i);
-    }
-  } else {
-    if (per != c->rg_per) {
-      fprintf(stderr, "xla_llama_prefill_slot_logits: KV element count changed\n");
-      return 1;
-    }
-    for (int32_t i = 0; i < 4; i++) {
-      if (c->rg_dims[i] != iree_hal_buffer_view_shape_dim(c->kcache, i)) {
-        fprintf(stderr,
-                "xla_llama_prefill_slot_logits: KV shape changed at axis %d\n",
-                i);
-        return 1;
-      }
-    }
+static int xla_llama_prefill_embeddings_impl(
+    xla_ctx* c, int32_t slot, const xla_tensor_desc* embeddings,
+    const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
+    int32_t real_len, int32_t vocab, int32_t* out_token, float* out_logits) {
+  if (!c || real_len <= 0 || real_len > c->context_capacity) {
+    fprintf(stderr,
+            "xla_llama_prefill_embeddings: real_len=%d context_capacity=%d\n",
+            real_len, c ? c->context_capacity : 0);
+    return 1;
   }
-  XLA_CHECK(xla_ensure_batch_kv(c));
-  iree_device_size_t off = (iree_device_size_t)slot * per * sizeof(float);
-  iree_device_size_t len = (iree_device_size_t)per * sizeof(float);
-  XLA_CHECK(iree_hal_device_transfer_d2d(
-      c->device, iree_hal_buffer_view_buffer(c->kcache), 0,
-      iree_hal_buffer_view_buffer(c->kcache_b), off, len,
-      IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout()));
-  XLA_CHECK(iree_hal_device_transfer_d2d(
-      c->device, iree_hal_buffer_view_buffer(c->vcache), 0,
-      iree_hal_buffer_view_buffer(c->vcache_b), off, len,
-      IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout()));
-  iree_hal_buffer_view_release(c->kcache);
-  c->kcache = NULL;
-  iree_hal_buffer_view_release(c->vcache);
-  c->vcache = NULL;
-  return 0;
+  int64_t embeddings_dims[2] = {c->context_capacity, c->hidden_size};
+  int64_t positions_dims[1] = {c->context_capacity};
+  int64_t bias_dims[2] = {c->context_capacity, c->context_capacity};
+  if (xla_validate_tensor_desc("embeddings", embeddings, 0, 2,
+                               embeddings_dims) != 0 ||
+      xla_validate_tensor_desc("positions", positions, 1, 1,
+                               positions_dims) != 0 ||
+      xla_validate_tensor_desc("attention_bias", attention_bias, 0, 2,
+                               bias_dims) != 0) {
+    return 1;
+  }
+  bool batched = slot >= 0;
+  if ((!batched && !out_token) ||
+      (batched && (slot >= c->rg_bsz || vocab <= 0 || !out_logits))) {
+    fprintf(stderr,
+            "xla_llama_prefill_embeddings: invalid slot/output/vocab contract\n");
+    return 1;
+  }
+
+  int rc = 0;
+  bool call_initialized = false;
+  iree_runtime_call_t call;
+  iree_hal_buffer_view_t* embeddings_bv = NULL;
+  iree_hal_buffer_view_t* positions_bv = NULL;
+  iree_hal_buffer_view_t* len_bv = NULL;
+  iree_hal_buffer_view_t* bias_bv = NULL;
+  iree_hal_buffer_view_t* output = NULL;
+  iree_hal_buffer_view_t* kc = NULL;
+  iree_hal_buffer_view_t* vc = NULL;
+
+  XLA_CHECK_GOTO(iree_runtime_call_initialize_by_name(
+                     c->session,
+                     iree_make_cstring_view("prefill_embeddings.main"), &call),
+                 cleanup, rc);
+  call_initialized = true;
+  for (int32_t i = 0; i < c->n_weights; ++i) {
+    XLA_CHECK_GOTO(
+        iree_runtime_call_inputs_push_back_buffer_view(&call, c->weights[i]),
+        cleanup, rc);
+  }
+  XLA_CHECK_GOTO(xla_alloc_desc_bv(c, embeddings, &embeddings_bv), cleanup, rc);
+  XLA_CHECK_GOTO(xla_alloc_desc_bv(c, positions, &positions_bv), cleanup, rc);
+  XLA_CHECK_GOTO(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32,
+                             &real_len, sizeof(int32_t), &len_bv),
+                 cleanup, rc);
+  XLA_CHECK_GOTO(xla_alloc_desc_bv(c, attention_bias, &bias_bv), cleanup, rc);
+  XLA_CHECK_GOTO(
+      iree_runtime_call_inputs_push_back_buffer_view(&call, embeddings_bv),
+      cleanup, rc);
+  XLA_CHECK_GOTO(
+      iree_runtime_call_inputs_push_back_buffer_view(&call, positions_bv),
+      cleanup, rc);
+  XLA_CHECK_GOTO(iree_runtime_call_inputs_push_back_buffer_view(&call, len_bv),
+                 cleanup, rc);
+  XLA_CHECK_GOTO(iree_runtime_call_inputs_push_back_buffer_view(&call, bias_bv),
+                 cleanup, rc);
+  XLA_CHECK_GOTO(iree_runtime_call_invoke(&call, 0), cleanup, rc);
+  XLA_CHECK_GOTO(
+      iree_runtime_call_outputs_pop_front_buffer_view(&call, &output), cleanup,
+      rc);
+  XLA_CHECK_GOTO(iree_runtime_call_outputs_pop_front_buffer_view(&call, &kc),
+                 cleanup, rc);
+  XLA_CHECK_GOTO(iree_runtime_call_outputs_pop_front_buffer_view(&call, &vc),
+                 cleanup, rc);
+  if (xla_validate_kv_pair(c, kc, vc, 4, 1) != 0) {
+    rc = 1;
+    goto cleanup;
+  }
+
+  if (batched) {
+    XLA_CHECK_GOTO(
+        xla_read_logits(c, output, out_logits, (iree_host_size_t)vocab),
+        cleanup, rc);
+    rc = xla_store_prefill_kv_slot(c, slot, kc, vc);
+  } else {
+    XLA_CHECK_GOTO(xla_read_token(c, output, out_token), cleanup, rc);
+    iree_hal_buffer_view_t* old_k = c->kcache;
+    iree_hal_buffer_view_t* old_v = c->vcache;
+    c->kcache = kc;
+    c->vcache = vc;
+    kc = NULL;
+    vc = NULL;
+    if (old_k) iree_hal_buffer_view_release(old_k);
+    if (old_v) iree_hal_buffer_view_release(old_v);
+  }
+
+cleanup:
+  if (output) iree_hal_buffer_view_release(output);
+  if (kc) iree_hal_buffer_view_release(kc);
+  if (vc) iree_hal_buffer_view_release(vc);
+  if (embeddings_bv) iree_hal_buffer_view_release(embeddings_bv);
+  if (positions_bv) iree_hal_buffer_view_release(positions_bv);
+  if (len_bv) iree_hal_buffer_view_release(len_bv);
+  if (bias_bv) iree_hal_buffer_view_release(bias_bv);
+  if (call_initialized) iree_runtime_call_deinitialize(&call);
+  return rc;
+}
+
+int xla_llama_prefill_embeddings(
+    xla_ctx* c, const xla_tensor_desc* embeddings,
+    const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
+    int32_t real_len, int32_t* out_token) {
+  return xla_llama_prefill_embeddings_impl(
+      c, -1, embeddings, positions, attention_bias, real_len, 0, out_token,
+      NULL);
+}
+
+int xla_llama_prefill_embeddings_slot_logits(
+    xla_ctx* c, int32_t slot, const xla_tensor_desc* embeddings,
+    const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
+    int32_t real_len, int32_t vocab, float* out_logits) {
+  return xla_llama_prefill_embeddings_impl(
+      c, slot, embeddings, positions, attention_bias, real_len, vocab, NULL,
+      out_logits);
 }
 
 // Ragged decode_step: token[B], pos[B], cache_len[B] (per row), rank-5 KV ->

--- a/src/lib/mlxcel-xla/src/batch.rs
+++ b/src/lib/mlxcel-xla/src/batch.rs
@@ -39,10 +39,14 @@ use std::collections::VecDeque;
 use std::fmt;
 
 #[cfg(feature = "iree")]
+use mlxcel_core::session::PreparedPrefill;
+
+#[cfg(feature = "iree")]
 use std::path::Path;
 
 #[cfg(feature = "iree")]
 use crate::iree::{IreeLlama, IreeRaggedLlama};
+use crate::prepared::{PreparedInputError, PreparedIreePrefill};
 use crate::sampler::SampleParams;
 #[cfg(feature = "iree")]
 use crate::sampler::sample;
@@ -54,6 +58,7 @@ pub enum XlaAdmissionError {
     EmptyPrompt,
     ZeroMaxNewTokens,
     ContextCapacity(ContextCapacityError),
+    Prepared(PreparedInputError),
 }
 
 impl fmt::Display for XlaAdmissionError {
@@ -62,6 +67,7 @@ impl fmt::Display for XlaAdmissionError {
             Self::EmptyPrompt => f.write_str("XLA batched submit requires a non-empty prompt"),
             Self::ZeroMaxNewTokens => f.write_str("max_new_tokens must be >= 1"),
             Self::ContextCapacity(err) => err.fmt(f),
+            Self::Prepared(err) => err.fmt(f),
         }
     }
 }
@@ -71,6 +77,12 @@ impl std::error::Error for XlaAdmissionError {}
 impl From<ContextCapacityError> for XlaAdmissionError {
     fn from(value: ContextCapacityError) -> Self {
         Self::ContextCapacity(value)
+    }
+}
+
+impl From<PreparedInputError> for XlaAdmissionError {
+    fn from(value: PreparedInputError) -> Self {
+        Self::Prepared(value)
     }
 }
 
@@ -116,10 +128,34 @@ struct Slot {
     history: Vec<i32>,
 }
 
+/// Owned input retained while a request is queued. Logical token ids stay
+/// separate from the prepared static embeddings buffers so history-based
+/// sampling and request accounting never infer token history from KV length.
+enum PendingInput {
+    Tokens(Vec<i32>),
+    Prepared(PreparedIreePrefill),
+}
+
+impl PendingInput {
+    fn logical_tokens(&self) -> &[i32] {
+        match self {
+            Self::Tokens(tokens) => tokens,
+            Self::Prepared(prepared) => &prepared.token_ids,
+        }
+    }
+
+    fn effective_len(&self) -> usize {
+        match self {
+            Self::Tokens(tokens) => tokens.len(),
+            Self::Prepared(prepared) => prepared.effective_len,
+        }
+    }
+}
+
 /// A queued, not-yet-admitted request.
 struct Pending {
     req_id: u64,
-    prompt: Vec<i32>,
+    input: PendingInput,
     cap: usize,
     params: SampleParams,
     cancelled: bool,
@@ -169,17 +205,21 @@ impl Scheduler {
     }
 
     /// Queue a request and return its id (monotonically increasing).
-    fn submit(&mut self, prompt: Vec<i32>, cap: usize, params: SampleParams) -> u64 {
+    fn submit_input(&mut self, input: PendingInput, cap: usize, params: SampleParams) -> u64 {
         let req_id = self.next_id;
         self.next_id += 1;
         self.queue.push_back(Pending {
             req_id,
-            prompt,
+            input,
             cap,
             params,
             cancelled: false,
         });
         req_id
+    }
+
+    fn submit(&mut self, prompt: Vec<i32>, cap: usize, params: SampleParams) -> u64 {
+        self.submit_input(PendingInput::Tokens(prompt), cap, params)
     }
 
     /// Cancel a request by id: free its slot if active, or drop it from the queue
@@ -247,6 +287,20 @@ fn queue_request(
     }
     validate_request_capacity(prompt.len(), max_new_tokens, context_capacity)?;
     Ok(sched.submit(prompt.to_vec(), max_new_tokens, params))
+}
+
+fn queue_prepared_request(
+    sched: &mut Scheduler,
+    prepared: PreparedIreePrefill,
+    max_new_tokens: usize,
+    params: SampleParams,
+    context_capacity: usize,
+) -> Result<u64, XlaAdmissionError> {
+    if max_new_tokens == 0 {
+        return Err(XlaAdmissionError::ZeroMaxNewTokens);
+    }
+    validate_request_capacity(prepared.effective_len, max_new_tokens, context_capacity)?;
+    Ok(sched.submit_input(PendingInput::Prepared(prepared), max_new_tokens, params))
 }
 
 /// The continuous-batching engine: `B_max` slots over one ragged decode graph,
@@ -350,6 +404,27 @@ impl XlaBatchEngine {
         )
     }
 
+    /// Queue an owned prepared-embeddings request. Validation and static-bucket
+    /// materialization complete before scheduler state changes, and the queue
+    /// then owns the only runtime copy until admission or cancellation.
+    pub fn submit_prepared(
+        &mut self,
+        prepared: PreparedPrefill,
+        max_new_tokens: usize,
+        params: SampleParams,
+    ) -> Result<u64, XlaAdmissionError> {
+        let context_capacity = self.context_capacity();
+        let prepared =
+            PreparedIreePrefill::prepare(&prepared, self.engine.hidden_size(), context_capacity)?;
+        queue_prepared_request(
+            &mut self.sched,
+            prepared,
+            max_new_tokens,
+            params,
+            context_capacity,
+        )
+    }
+
     /// Cancel a request by id (frees its slot or drops it from the queue).
     /// Returns whether it was found. A cancelled request emits no further events.
     pub fn cancel(&mut self, req_id: u64) -> bool {
@@ -381,14 +456,19 @@ impl XlaBatchEngine {
             let Some(p) = self.sched.pop_next_pending() else {
                 break;
             };
-            let logits = self.engine.prefill_slot_logits(s, &p.prompt)?;
+            let logits = match &p.input {
+                PendingInput::Tokens(prompt) => self.engine.prefill_slot_logits(s, prompt)?,
+                PendingInput::Prepared(prepared) => {
+                    self.engine.prefill_prepared_slot_logits(s, prepared)?
+                }
+            };
             let mut rng = resolve_seed(&p.params, p.req_id);
             // History-based penalties see the prompt plus generated tokens (the
             // same window mlxcel-core seeds via `initial_token_history`). Build it
             // only when a penalty is active; greedy requests keep it empty.
             let needs_history = p.params.needs_penalties();
             let mut history = if needs_history {
-                p.prompt.clone()
+                p.input.logical_tokens().to_vec()
             } else {
                 Vec::new()
             };
@@ -403,7 +483,7 @@ impl XlaBatchEngine {
             let slot = Slot {
                 req_id: p.req_id,
                 cur: first,
-                cache_len: p.prompt.len() as i32,
+                cache_len: p.input.effective_len() as i32,
                 produced: 1,
                 cap: p.cap,
                 params: p.params,
@@ -543,6 +623,10 @@ impl XlaReferenceEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mlxcel_core::session::{
+        OwnedTensor, PreparedAttentionBias, PreparedModality, PreparedPositions,
+        PreparedTensorDType,
+    };
 
     const EOS: [i32; 1] = [42];
 
@@ -557,6 +641,41 @@ mod tests {
 
     fn g() -> SampleParams {
         SampleParams::greedy()
+    }
+
+    fn prepared_input(tokens: Vec<i32>, hidden: usize, capacity: usize) -> PreparedIreePrefill {
+        let sequence = tokens.len();
+        let embedding_bytes = vec![0; sequence * hidden * std::mem::size_of::<f32>()];
+        let bias_bytes = vec![0; sequence * std::mem::size_of::<f32>()];
+        let value = mlxcel_core::session::PreparedPrefill::new(
+            tokens,
+            OwnedTensor::new(
+                embedding_bytes,
+                PreparedTensorDType::Float32,
+                vec![1, sequence, hidden],
+            )
+            .unwrap(),
+            PreparedPositions::Sequential {
+                start: 0,
+                length: sequence,
+            },
+            PreparedAttentionBias {
+                tensor: OwnedTensor::new(
+                    bias_bytes,
+                    PreparedTensorDType::Float32,
+                    vec![1, 1, 1, sequence],
+                )
+                .unwrap(),
+                causal: true,
+            },
+            vec![PreparedModality {
+                family: "test".into(),
+                item_count: 1,
+                token_count: 1,
+            }],
+        )
+        .unwrap();
+        PreparedIreePrefill::prepare(&value, hidden, capacity).unwrap()
     }
 
     #[test]
@@ -622,6 +741,70 @@ mod tests {
         let got = s.pop_next_pending().expect("a live request remains");
         assert_eq!(got.req_id, b);
         assert!(s.pop_next_pending().is_none());
+    }
+
+    #[test]
+    fn mixed_pending_inputs_keep_logical_history_and_effective_length_distinct() {
+        let mut s = Scheduler::new(2, EOS.to_vec());
+        let text = s.submit(vec![1, 2], 8, g());
+        let prepared = prepared_input(vec![7, 8, 9], 2, 8);
+        let multimodal =
+            s.submit_input(PendingInput::Prepared(prepared), 8, SampleParams::greedy());
+
+        let first = s.pop_next_pending().unwrap();
+        assert_eq!(first.req_id, text);
+        assert!(matches!(first.input, PendingInput::Tokens(_)));
+        assert_eq!(first.input.logical_tokens(), &[1, 2]);
+        assert_eq!(first.input.effective_len(), 2);
+
+        let second = s.pop_next_pending().unwrap();
+        assert_eq!(second.req_id, multimodal);
+        assert!(matches!(second.input, PendingInput::Prepared(_)));
+        assert_eq!(second.input.logical_tokens(), &[7, 8, 9]);
+        assert_eq!(second.input.effective_len(), 3);
+    }
+
+    #[test]
+    fn cancel_each_input_form_before_and_after_admit_reuses_slots() {
+        let mut s = Scheduler::new(1, EOS.to_vec());
+        let queued_text = s.submit(vec![1, 2], 8, g());
+        assert!(s.cancel(queued_text));
+
+        let prepared = prepared_input(vec![4, 5, 6], 2, 8);
+        let queued_prepared =
+            s.submit_input(PendingInput::Prepared(prepared), 8, SampleParams::greedy());
+        let pending = s.pop_next_pending().expect("prepared request remains");
+        assert_eq!(pending.req_id, queued_prepared);
+        let effective_len = pending.input.effective_len();
+        drop(pending);
+
+        s.slots[0] = Some(Slot {
+            req_id: queued_prepared,
+            cur: 7,
+            cache_len: effective_len as i32,
+            produced: 1,
+            cap: 8,
+            params: g(),
+            rng: 0,
+            history: vec![4, 5, 6, 7],
+        });
+        assert!(s.cancel(queued_prepared));
+        assert_eq!(s.free_slots(), vec![0]);
+
+        let reused = s.submit(vec![9], 2, g());
+        assert_eq!(s.pop_next_pending().unwrap().req_id, reused);
+        assert_eq!(s.free_slots(), vec![0]);
+    }
+
+    #[test]
+    fn prepared_capacity_rejection_is_atomic() {
+        let mut s = Scheduler::new(1, EOS.to_vec());
+        let prepared = prepared_input(vec![1, 2, 3], 2, 4);
+        let err = queue_prepared_request(&mut s, prepared, 2, g(), 4).unwrap_err();
+        assert!(matches!(err, XlaAdmissionError::ContextCapacity(_)));
+        assert_eq!(s.next_id, 0);
+        assert!(s.queue.is_empty());
+        assert_eq!(s.free_slots(), vec![0]);
     }
 
     #[test]

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -54,12 +54,15 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use memmap2::Mmap;
+use mlxcel_core::session::PreparedPrefill;
 use safetensors::{Dtype, SafeTensors};
 
 use crate::emitter::{
     Config, Precision, check_packed_supported, emit_decode_ragged_with, emit_decode_with,
-    emit_prefill_with, quant_in_graph, resolve_precision, resolve_precision_checked,
+    emit_prefill_embeddings_with, emit_prefill_with, quant_in_graph, resolve_precision,
+    resolve_precision_checked,
 };
+use crate::prepared::{PreparedIreePrefill, validate_slot};
 // The loader reads the per-architecture checkpoint-weight order from
 // `weights::weight_specs`, which sources its names from `weight_names::scheme_names`
 // (issue #499 naming schemes) and covers the #498 dense pack (LayerNorm / o_proj /
@@ -78,6 +81,84 @@ use crate::weights::{
 const WDT_F32: c_int = 0;
 const WDT_F16: c_int = 1;
 const WDT_U32: c_int = 2;
+
+/// C-side tensor element types. Keep in sync with `xla_tensor_desc` validation
+/// in `csrc/xla_iree.c`.
+const TENSOR_F32: c_int = 0;
+const TENSOR_I32: c_int = 1;
+
+/// Explicit tensor descriptor crossing the C ABI. Every input includes its byte
+/// length, dtype, rank, and complete static shape; the shim revalidates these
+/// fields before constructing an IREE buffer view.
+#[repr(C)]
+struct XlaTensorDesc {
+    data: *const c_void,
+    byte_length: usize,
+    dtype: c_int,
+    rank: c_int,
+    dims: [i64; 4],
+}
+
+impl XlaTensorDesc {
+    fn f32(data: &[f32], shape: &[usize]) -> Result<Self, String> {
+        Self::new(
+            data.as_ptr().cast(),
+            data.len(),
+            std::mem::size_of::<f32>(),
+            TENSOR_F32,
+            shape,
+        )
+    }
+
+    fn i32(data: &[i32], shape: &[usize]) -> Result<Self, String> {
+        Self::new(
+            data.as_ptr().cast(),
+            data.len(),
+            std::mem::size_of::<i32>(),
+            TENSOR_I32,
+            shape,
+        )
+    }
+
+    fn new(
+        data: *const c_void,
+        elements: usize,
+        element_size: usize,
+        dtype: c_int,
+        shape: &[usize],
+    ) -> Result<Self, String> {
+        if shape.len() > 4 {
+            return Err(format!(
+                "IREE tensor descriptor rank {} exceeds 4",
+                shape.len()
+            ));
+        }
+        let expected = shape
+            .iter()
+            .try_fold(1usize, |count, &dim| count.checked_mul(dim))
+            .ok_or_else(|| "IREE tensor descriptor element count overflowed".to_string())?;
+        if elements != expected {
+            return Err(format!(
+                "IREE tensor descriptor element count {elements} disagrees with shape {shape:?} ({expected})"
+            ));
+        }
+        let byte_length = elements
+            .checked_mul(element_size)
+            .ok_or_else(|| "IREE tensor descriptor byte count overflowed".to_string())?;
+        let mut dims = [0i64; 4];
+        for (index, &dim) in shape.iter().enumerate() {
+            dims[index] = i64::try_from(dim)
+                .map_err(|_| format!("IREE tensor dimension {dim} does not fit i64"))?;
+        }
+        Ok(Self {
+            data,
+            byte_length,
+            dtype,
+            rank: shape.len() as c_int,
+            dims,
+        })
+    }
+}
 
 /// A resident-weight host buffer, kept alive until the shim copies it to the device.
 /// f32 values (a widened / dequantized weight, the proven path), f16 values (an
@@ -110,13 +191,16 @@ unsafe extern "C" {
     fn xla_llama_create(
         device: *const c_char,
         prefill: *const c_char,
+        prefill_embeddings: *const c_char,
         decode: *const c_char,
+        compatibility_fingerprint: u64,
         n_weights: c_int,
         weight_data: *const *const c_void,
         weight_dtypes: *const c_int,
         weight_ranks: *const c_int,
         weight_dims: *const i64,
         context_capacity: c_int,
+        hidden_size: c_int,
     ) -> *mut XlaCtx;
     fn xla_llama_prefill(
         c: *mut XlaCtx,
@@ -144,6 +228,24 @@ unsafe extern "C" {
         tokens: *const c_int,
         lp: c_int,
         positions: *const c_int,
+        real_len: c_int,
+        vocab: c_int,
+        out_logits: *mut f32,
+    ) -> c_int;
+    fn xla_llama_prefill_embeddings(
+        c: *mut XlaCtx,
+        embeddings: *const XlaTensorDesc,
+        positions: *const XlaTensorDesc,
+        attention_bias: *const XlaTensorDesc,
+        real_len: c_int,
+        out_token: *mut c_int,
+    ) -> c_int;
+    fn xla_llama_prefill_embeddings_slot_logits(
+        c: *mut XlaCtx,
+        slot: c_int,
+        embeddings: *const XlaTensorDesc,
+        positions: *const XlaTensorDesc,
+        attention_bias: *const XlaTensorDesc,
         real_len: c_int,
         vocab: c_int,
         out_logits: *mut f32,
@@ -288,16 +390,29 @@ fn compile_one(
     Ok(vmfb_path)
 }
 
-/// Compile a (prefill, decode) graph pair for `device`. The single-sequence engine
-/// uses the argmax pair; the ragged engine uses the logits pair (Stage 2d).
-fn compile_pair(
+/// Three compatible entry modules loaded atomically into one runtime session.
+struct CompiledBundle {
+    prefill_vmfb: PathBuf,
+    prefill_embeddings_vmfb: PathBuf,
+    decode_vmfb: PathBuf,
+    compatibility_fingerprint: u64,
+}
+
+/// Compile the token prefill, embeddings prefill, and decode entries as one
+/// compatibility bundle. The fingerprint binds their architecture/config text,
+/// weight argument schema, precision, context/hidden/KV dimensions, and ABI
+/// schema version; a member compiled from a different contract therefore cannot
+/// be substituted without changing the fingerprint.
+fn compile_bundle(
     device: &str,
+    cfg: &Config,
     prefill_mlir: &str,
     prefill_tag: &str,
+    prefill_embeddings_mlir: &str,
+    prefill_embeddings_tag: &str,
     decode_mlir: &str,
     decode_tag: &str,
-    context_capacity: usize,
-) -> Result<(PathBuf, PathBuf), String> {
+) -> Result<CompiledBundle, String> {
     let iree_compile = iree_compile_bin()?;
     if !iree_compile.exists() {
         return Err(format!(
@@ -314,7 +429,15 @@ fn compile_pair(
         flags,
         &cache,
         prefill_tag,
-        context_capacity,
+        cfg.context_capacity,
+    )?;
+    let pre_embeddings = compile_one(
+        &iree_compile,
+        prefill_embeddings_mlir,
+        flags,
+        &cache,
+        prefill_embeddings_tag,
+        cfg.context_capacity,
     )?;
     let dec = compile_one(
         &iree_compile,
@@ -322,27 +445,41 @@ fn compile_pair(
         flags,
         &cache,
         decode_tag,
-        context_capacity,
+        cfg.context_capacity,
     )?;
-    Ok((pre, dec))
+    let mut fingerprint = std::collections::hash_map::DefaultHasher::new();
+    "mlxcel-xla-runtime-bundle-v1".hash(&mut fingerprint);
+    format!("{cfg:?}").hash(&mut fingerprint);
+    format!("{:?}", weight_specs(cfg)).hash(&mut fingerprint);
+    format!("{:?}", resolve_precision(device)).hash(&mut fingerprint);
+    prefill_mlir.hash(&mut fingerprint);
+    prefill_embeddings_mlir.hash(&mut fingerprint);
+    decode_mlir.hash(&mut fingerprint);
+    let compatibility_fingerprint = fingerprint.finish();
+    Ok(CompiledBundle {
+        prefill_vmfb: pre,
+        prefill_embeddings_vmfb: pre_embeddings,
+        decode_vmfb: dec,
+        compatibility_fingerprint: compatibility_fingerprint.max(1),
+    })
 }
 
-/// Emit and compile the argmax prefill + single-token decode graphs for `cfg` on
-/// `device` (the single-sequence engine's on-device-argmax pair). The graph text
-/// is emitted from the model config, so `compile_one`'s text-hash cache keys a
-/// distinct vmfb per architecture.
-fn compile_vmfbs(device: &str, cfg: &Config) -> Result<(PathBuf, PathBuf), String> {
+/// Emit and compile the argmax prefill bundle for a single-sequence engine.
+fn compile_vmfbs(device: &str, cfg: &Config) -> Result<CompiledBundle, String> {
     let precision = resolve_precision_checked(device)?;
     check_packed_supported(device, quant_in_graph() && cfg.supports_packed_quant())?;
     let prefill = emit_prefill_with(cfg, true, precision);
+    let prefill_embeddings = emit_prefill_embeddings_with(cfg, true, precision);
     let decode = emit_decode_with(cfg, true, precision);
-    compile_pair(
+    compile_bundle(
         device,
+        cfg,
         &prefill,
         "prefill",
+        &prefill_embeddings,
+        "prefill_embeddings",
         &decode,
         "decode",
-        cfg.context_capacity,
     )
 }
 
@@ -610,6 +747,21 @@ fn path_cstring(p: &Path) -> Result<CString, String> {
         .map_err(|_| format!("path has an interior nul byte: {}", p.display()))
 }
 
+fn prepared_descriptors(
+    prepared: &PreparedIreePrefill,
+) -> Result<(XlaTensorDesc, XlaTensorDesc, XlaTensorDesc), String> {
+    let embeddings = XlaTensorDesc::f32(
+        &prepared.embeddings,
+        &[prepared.context_capacity, prepared.hidden_size],
+    )?;
+    let positions = XlaTensorDesc::i32(&prepared.positions, &[prepared.context_capacity])?;
+    let attention_bias = XlaTensorDesc::f32(
+        &prepared.attention_bias,
+        &[prepared.context_capacity, prepared.context_capacity],
+    )?;
+    Ok((embeddings, positions, attention_bias))
+}
+
 /// Load the weights and create the C execution context for a (prefill, decode)
 /// vmfb pair on `device`. Shared by the single-sequence ([`IreeLlama`]) and ragged
 /// ([`IreeRaggedLlama`]) engines, which differ only in which decode vmfb they pass.
@@ -617,8 +769,7 @@ fn create_ctx(
     model_dir: &Path,
     cfg: &Config,
     device: &str,
-    prefill_vmfb: &Path,
-    decode_vmfb: &Path,
+    bundle: &CompiledBundle,
 ) -> Result<*mut XlaCtx, String> {
     // issue #572: the f16 GPU path uploads the projection weights f16-resident to
     // match the emitter's f16 args. Uses the same resolve_precision(device) the graph
@@ -630,21 +781,25 @@ fn create_ctx(
         .map(|b| b.as_u8_ptr() as *const c_void)
         .collect();
     let c_dev = CString::new(device).map_err(|_| "device has interior nul".to_string())?;
-    let c_pre = path_cstring(prefill_vmfb)?;
-    let c_dec = path_cstring(decode_vmfb)?;
+    let c_pre = path_cstring(&bundle.prefill_vmfb)?;
+    let c_pre_embeddings = path_cstring(&bundle.prefill_embeddings_vmfb)?;
+    let c_dec = path_cstring(&bundle.decode_vmfb)?;
     // Safety: pointers are valid for the duration of the call; the shim copies
     // the weight data into device buffers before returning.
     let ctx = unsafe {
         xla_llama_create(
             c_dev.as_ptr(),
             c_pre.as_ptr(),
+            c_pre_embeddings.as_ptr(),
             c_dec.as_ptr(),
+            bundle.compatibility_fingerprint,
             bufs.len() as c_int,
             ptrs.as_ptr(),
             dtypes.as_ptr(),
             ranks.as_ptr(),
             dims.as_ptr(),
             cfg.context_capacity as c_int,
+            cfg.hidden as c_int,
         )
     };
     // Weights are resident on the device now; free the host copy.
@@ -664,6 +819,7 @@ fn create_ctx(
 pub struct IreeLlama {
     ctx: *mut XlaCtx,
     context_capacity: usize,
+    hidden_size: usize,
 }
 
 impl IreeLlama {
@@ -672,11 +828,12 @@ impl IreeLlama {
     /// weights resident, and readies the prefill / decode calls.
     pub fn load(model_dir: &Path, device: &str, context_capacity: usize) -> Result<Self, String> {
         let cfg = Config::from_json(model_dir)?.with_context_capacity(context_capacity)?;
-        let (prefill_vmfb, decode_vmfb) = compile_vmfbs(device, &cfg)?;
-        let ctx = create_ctx(model_dir, &cfg, device, &prefill_vmfb, &decode_vmfb)?;
+        let bundle = compile_vmfbs(device, &cfg)?;
+        let ctx = create_ctx(model_dir, &cfg, device, &bundle)?;
         Ok(Self {
             ctx,
             context_capacity: cfg.context_capacity,
+            hidden_size: cfg.hidden,
         })
     }
 
@@ -706,6 +863,34 @@ impl IreeLlama {
             return Err("prefill_first requires a non-empty prompt".to_string());
         }
         self.prefill_padded(prompt)
+    }
+
+    /// Validate an owned embeddings payload, seed the resident KV through the
+    /// dedicated embeddings module, and return the first sampled token.
+    pub fn prefill_prepared_first(&mut self, prepared: &PreparedPrefill) -> Result<i32, String> {
+        let prepared =
+            PreparedIreePrefill::prepare(prepared, self.hidden_size, self.context_capacity)
+                .map_err(|error| error.to_string())?;
+        let (embeddings, positions, attention_bias) = prepared_descriptors(&prepared)?;
+        let real_len = i32::try_from(prepared.effective_len)
+            .map_err(|_| "prepared effective length does not fit i32".to_string())?;
+        let mut out = 0i32;
+        // Safety: every descriptor references a validated owned vector that
+        // outlives the call; the C shim repeats dtype/rank/shape/byte checks.
+        let rc = unsafe {
+            xla_llama_prefill_embeddings(
+                self.ctx,
+                &embeddings,
+                &positions,
+                &attention_bias,
+                real_len,
+                &mut out,
+            )
+        };
+        if rc != 0 {
+            return Err(format!("xla_llama_prefill_embeddings failed (status {rc})"));
+        }
+        Ok(out)
     }
 
     /// Pad `prompt` into the configured static bucket, run the prefill, and return its
@@ -786,6 +971,7 @@ pub struct IreeRaggedLlama {
     /// buffers and the per-row logits slice are sized by it.
     vocab: usize,
     context_capacity: usize,
+    hidden_size: usize,
 }
 
 impl IreeRaggedLlama {
@@ -812,16 +998,19 @@ impl IreeRaggedLlama {
         let precision = resolve_precision_checked(device)?;
         check_packed_supported(device, quant_in_graph() && cfg.supports_packed_quant())?;
         let prefill_mlir = emit_prefill_with(&cfg, false, precision);
+        let prefill_embeddings_mlir = emit_prefill_embeddings_with(&cfg, false, precision);
         let decode_mlir = emit_decode_ragged_with(&cfg, b_max, false, precision);
-        let (prefill_vmfb, decode_vmfb) = compile_pair(
+        let bundle = compile_bundle(
             device,
+            &cfg,
             &prefill_mlir,
             "prefill_logits",
+            &prefill_embeddings_mlir,
+            "prefill_embeddings_logits",
             &decode_mlir,
             &format!("decode_ragged_logits_b{b_max}"),
-            cfg.context_capacity,
         )?;
-        let ctx = create_ctx(model_dir, &cfg, device, &prefill_vmfb, &decode_vmfb)?;
+        let ctx = create_ctx(model_dir, &cfg, device, &bundle)?;
         // Safety: ctx is a fresh valid context from create_ctx; free it on error.
         let rc = unsafe { xla_llama_ragged_reset(ctx, b_max as c_int) };
         if rc != 0 {
@@ -833,6 +1022,7 @@ impl IreeRaggedLlama {
             b_max,
             vocab: cfg.vocab,
             context_capacity: cfg.context_capacity,
+            hidden_size: cfg.hidden,
         })
     }
 
@@ -855,15 +1045,19 @@ impl IreeRaggedLlama {
         self.context_capacity
     }
 
+    /// Model hidden width compiled into the embeddings entry.
+    #[must_use]
+    pub fn hidden_size(&self) -> usize {
+        self.hidden_size
+    }
+
     /// Seed slot `slot` with `prompt` (up to the configured capacity) and return its
     /// first-token `[vocab]` LOGITS (#449 M3 Stage 2d). The prompt's KV is written
     /// device-side into the slot's region of the rank-5 cache; the other slots are
     /// untouched, so a mid-stream admit does not disturb live sequences. The caller
     /// samples the first token from the returned logits.
     pub fn prefill_slot_logits(&mut self, slot: usize, prompt: &[i32]) -> Result<Vec<f32>, String> {
-        if slot >= self.b_max {
-            return Err(format!("slot {slot} out of range [0,{})", self.b_max));
-        }
+        validate_slot(slot, self.b_max).map_err(|error| error.to_string())?;
         if prompt.is_empty() {
             return Err("prefill_slot_logits requires a non-empty prompt".to_string());
         }
@@ -895,6 +1089,50 @@ impl IreeRaggedLlama {
         if rc != 0 {
             return Err(format!(
                 "xla_llama_prefill_slot_logits failed (status {rc})"
+            ));
+        }
+        Ok(logits)
+    }
+
+    /// Seed one batch slot from a validated owned embeddings payload. The C
+    /// shim copies the returned rank-4 KV directly into this slot's rank-5
+    /// device cache, sharing the token-prefill slot population path.
+    pub fn prefill_prepared_slot_logits(
+        &mut self,
+        slot: usize,
+        prepared: &PreparedIreePrefill,
+    ) -> Result<Vec<f32>, String> {
+        validate_slot(slot, self.b_max).map_err(|error| error.to_string())?;
+        if prepared.hidden_size != self.hidden_size
+            || prepared.context_capacity != self.context_capacity
+            || prepared.effective_len == 0
+            || prepared.effective_len > self.context_capacity
+        {
+            return Err(
+                "prepared IREE payload is incompatible with this runtime bundle".to_string(),
+            );
+        }
+        let (embeddings, positions, attention_bias) = prepared_descriptors(prepared)?;
+        let real_len = i32::try_from(prepared.effective_len)
+            .map_err(|_| "prepared effective length does not fit i32".to_string())?;
+        let mut logits = vec![0.0; self.vocab];
+        // Safety: descriptors and output buffers outlive the call and carry
+        // exact lengths; the shim validates slot/vocab and every descriptor.
+        let rc = unsafe {
+            xla_llama_prefill_embeddings_slot_logits(
+                self.ctx,
+                slot as c_int,
+                &embeddings,
+                &positions,
+                &attention_bias,
+                real_len,
+                self.vocab as c_int,
+                logits.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            return Err(format!(
+                "xla_llama_prefill_embeddings_slot_logits failed (status {rc})"
             ));
         }
         Ok(logits)

--- a/src/lib/mlxcel-xla/src/lib.rs
+++ b/src/lib/mlxcel-xla/src/lib.rs
@@ -47,9 +47,12 @@
 
 use std::path::{Path, PathBuf};
 
-use mlxcel_core::session::{InferenceSession, SessionCapabilities};
+use mlxcel_core::session::{InferenceSession, PreparedPrefill, SessionCapabilities};
 
 mod context;
+#[cfg(any(feature = "iree", test))]
+#[cfg_attr(not(feature = "iree"), allow(dead_code))]
+mod prepared;
 
 #[cfg(feature = "iree")]
 mod iree;
@@ -106,6 +109,8 @@ pub use context::{
     CONTEXT_CAPACITY_ENV, ContextCapacityError, DEFAULT_CONTEXT_CAPACITY,
     context_capacity_from_env, validate_request_capacity,
 };
+#[cfg(feature = "iree")]
+pub use prepared::PreparedInputError;
 #[cfg(feature = "iree")]
 pub use sampler::SampleParams;
 
@@ -321,11 +326,62 @@ impl XlaInferenceSession {
         }
         Ok(out)
     }
+
+    /// Greedy generation seeded by an owned prepared-embeddings payload.
+    pub fn generate_prepared_greedy(
+        &mut self,
+        prepared: &PreparedPrefill,
+        max_new_tokens: usize,
+        eos_token_ids: &[i32],
+    ) -> Result<Vec<i32>, String> {
+        self.generate_prepared_streaming_greedy(prepared, max_new_tokens, eos_token_ids, |_| true)
+    }
+
+    /// Streaming greedy generation from prepared embeddings. The embeddings
+    /// entry seeds all `sequence_len` positions and returns the first generated
+    /// token, so decode starts at the expanded length without replaying a
+    /// placeholder or logical token.
+    pub fn generate_prepared_streaming_greedy<F: FnMut(i32) -> bool>(
+        &mut self,
+        prepared: &PreparedPrefill,
+        max_new_tokens: usize,
+        eos_token_ids: &[i32],
+        mut on_token: F,
+    ) -> Result<Vec<i32>, String> {
+        if max_new_tokens == 0 {
+            return Ok(Vec::new());
+        }
+        validate_request_capacity(prepared.sequence_len, max_new_tokens, self.context_capacity)
+            .map_err(|error| error.to_string())?;
+        let first = self.prefill_prepared(prepared)?;
+        let mut out = Vec::with_capacity(max_new_tokens);
+        out.push(first);
+        if !on_token(first) || eos_token_ids.contains(&first) {
+            return Ok(out);
+        }
+        let mut current = first;
+        while out.len() < max_new_tokens {
+            let next = self.decode_step(current)?;
+            out.push(next);
+            if !on_token(next) || eos_token_ids.contains(&next) {
+                break;
+            }
+            current = next;
+        }
+        Ok(out)
+    }
 }
 
 impl InferenceSession for XlaInferenceSession {
     fn capabilities(&self) -> SessionCapabilities {
-        SessionCapabilities::single_sequence()
+        #[cfg(feature = "iree")]
+        {
+            SessionCapabilities::single_sequence().with_multimodal()
+        }
+        #[cfg(not(feature = "iree"))]
+        {
+            SessionCapabilities::single_sequence()
+        }
     }
 
     #[cfg(feature = "iree")]
@@ -344,6 +400,19 @@ impl InferenceSession for XlaInferenceSession {
 
     #[cfg(not(feature = "iree"))]
     fn prefill(&mut self, _token_ids: &[i32]) -> Result<(), String> {
+        Err(NOT_WIRED.to_string())
+    }
+
+    #[cfg(feature = "iree")]
+    fn prefill_prepared(&mut self, prepared: &PreparedPrefill) -> Result<i32, String> {
+        let first = self.engine.prefill_prepared_first(prepared)?;
+        self.cache_len = i32::try_from(prepared.sequence_len)
+            .map_err(|_| "prepared sequence length does not fit i32".to_string())?;
+        Ok(first)
+    }
+
+    #[cfg(not(feature = "iree"))]
+    fn prefill_prepared(&mut self, _prepared: &PreparedPrefill) -> Result<i32, String> {
         Err(NOT_WIRED.to_string())
     }
 
@@ -373,9 +442,34 @@ impl InferenceSession for XlaInferenceSession {
 #[cfg(all(test, not(feature = "iree")))]
 mod tests {
     use super::*;
+    use mlxcel_core::session::{
+        OwnedTensor, PreparedAttentionBias, PreparedPositions, PreparedTensorDType,
+    };
 
     fn session() -> XlaInferenceSession {
         XlaInferenceSession::load(Path::new("/tmp/xla-model"), 16).unwrap()
+    }
+
+    fn prepared() -> PreparedPrefill {
+        PreparedPrefill::new(
+            vec![1],
+            OwnedTensor::new(vec![0; 4], PreparedTensorDType::Float32, vec![1, 1, 1]).unwrap(),
+            PreparedPositions::Sequential {
+                start: 0,
+                length: 1,
+            },
+            PreparedAttentionBias {
+                tensor: OwnedTensor::new(
+                    vec![0; 4],
+                    PreparedTensorDType::Float32,
+                    vec![1, 1, 1, 1],
+                )
+                .unwrap(),
+                causal: true,
+            },
+            Vec::new(),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -411,6 +505,7 @@ mod tests {
     fn token_primitives_report_not_wired() {
         let mut s = session();
         assert_eq!(s.prefill(&[1, 2, 3]).unwrap_err(), NOT_WIRED);
+        assert_eq!(s.prefill_prepared(&prepared()).unwrap_err(), NOT_WIRED);
         assert_eq!(s.decode_step(1).unwrap_err(), NOT_WIRED);
     }
 
@@ -419,6 +514,11 @@ mod tests {
         let mut s = session();
         assert_eq!(
             s.generate_greedy(&[1, 2, 3], 8, &[2]).unwrap_err(),
+            NOT_WIRED
+        );
+        assert_eq!(
+            s.generate_prepared_greedy(&prepared(), 8, &[2])
+                .unwrap_err(),
             NOT_WIRED
         );
     }

--- a/src/lib/mlxcel-xla/src/prepared.rs
+++ b/src/lib/mlxcel-xla/src/prepared.rs
@@ -1,0 +1,468 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Validation and static-bucket materialization for owned multimodal prefill.
+
+use std::fmt;
+
+use mlxcel_core::session::{OwnedTensor, PreparedPositions, PreparedPrefill, PreparedTensorDType};
+
+const MASKED_VALUE: f32 = -1.0e30;
+
+/// A validated prepared prefill in the exact static shapes consumed by IREE.
+#[derive(Debug)]
+pub(crate) struct PreparedIreePrefill {
+    pub(crate) token_ids: Vec<i32>,
+    pub(crate) embeddings: Vec<f32>,
+    pub(crate) positions: Vec<i32>,
+    pub(crate) attention_bias: Vec<f32>,
+    pub(crate) effective_len: usize,
+    pub(crate) hidden_size: usize,
+    pub(crate) context_capacity: usize,
+}
+
+/// Why an owned prepared payload cannot enter the IREE runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreparedInputError {
+    Empty,
+    SequenceLength {
+        declared: usize,
+        token_ids: usize,
+    },
+    Capacity {
+        effective_len: usize,
+        context_capacity: usize,
+    },
+    Slot {
+        slot: usize,
+        slot_count: usize,
+    },
+    EmbeddingDType(PreparedTensorDType),
+    EmbeddingShape {
+        shape: Vec<usize>,
+        expected: Vec<usize>,
+    },
+    HiddenSize {
+        actual: usize,
+        expected: usize,
+    },
+    PositionDType(PreparedTensorDType),
+    PositionShape(Vec<usize>),
+    UnsupportedPositions,
+    AttentionBiasDType(PreparedTensorDType),
+    AttentionBiasShape(Vec<usize>),
+    ByteCount {
+        tensor: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    InvalidFloat {
+        tensor: &'static str,
+    },
+    ShapeOverflow,
+}
+
+impl fmt::Display for PreparedInputError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("prepared IREE prefill requires a non-empty sequence"),
+            Self::SequenceLength {
+                declared,
+                token_ids,
+            } => write!(
+                f,
+                "prepared sequence_len={declared} disagrees with {} logical token ids",
+                token_ids
+            ),
+            Self::Capacity {
+                effective_len,
+                context_capacity,
+            } => write!(
+                f,
+                "prepared effective length {effective_len} exceeds context_capacity={context_capacity}"
+            ),
+            Self::Slot { slot, slot_count } => {
+                write!(f, "prepared slot {slot} is outside [0,{slot_count})")
+            }
+            Self::EmbeddingDType(dtype) => {
+                write!(f, "IREE prepared embeddings must be Float32, got {dtype:?}")
+            }
+            Self::EmbeddingShape { shape, expected } => {
+                write!(f, "prepared embedding shape {shape:?} must be {expected:?}")
+            }
+            Self::HiddenSize { actual, expected } => {
+                write!(f, "prepared hidden size {actual} must match model hidden size {expected}")
+            }
+            Self::PositionDType(dtype) => {
+                write!(f, "IREE prepared positions must be Int32, got {dtype:?}")
+            }
+            Self::PositionShape(shape) => write!(
+                f,
+                "prepared explicit positions shape {shape:?} must be [sequence] or [1, sequence]"
+            ),
+            Self::UnsupportedPositions => f.write_str(
+                "IREE prepared positions must be the dense zero-based sequence; M-RoPE/offset positions are not supported",
+            ),
+            Self::AttentionBiasDType(dtype) => {
+                write!(f, "IREE prepared attention bias must be Float32, got {dtype:?}")
+            }
+            Self::AttentionBiasShape(shape) => write!(
+                f,
+                "prepared attention bias shape {shape:?} must be [sequence], [1,1,1,sequence], [sequence,sequence], or [1,1,sequence,sequence]"
+            ),
+            Self::ByteCount {
+                tensor,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "prepared {tensor} byte count mismatch: expected {expected}, got {actual}"
+            ),
+            Self::InvalidFloat { tensor } => {
+                write!(f, "prepared {tensor} contains NaN or an invalid positive mask value")
+            }
+            Self::ShapeOverflow => f.write_str("prepared IREE static shape overflowed"),
+        }
+    }
+}
+
+impl std::error::Error for PreparedInputError {}
+
+pub(crate) fn validate_slot(slot: usize, slot_count: usize) -> Result<(), PreparedInputError> {
+    if slot >= slot_count {
+        return Err(PreparedInputError::Slot { slot, slot_count });
+    }
+    Ok(())
+}
+
+fn checked_count(shape: &[usize], element_size: usize) -> Result<usize, PreparedInputError> {
+    shape
+        .iter()
+        .try_fold(1usize, |count, &dim| count.checked_mul(dim))
+        .and_then(|count| count.checked_mul(element_size))
+        .ok_or(PreparedInputError::ShapeOverflow)
+}
+
+fn validate_bytes(tensor: &'static str, value: &OwnedTensor) -> Result<(), PreparedInputError> {
+    let expected = checked_count(&value.shape, value.dtype.size_bytes())?;
+    if value.bytes.len() != expected {
+        return Err(PreparedInputError::ByteCount {
+            tensor,
+            expected,
+            actual: value.bytes.len(),
+        });
+    }
+    Ok(())
+}
+
+fn read_f32(tensor: &'static str, value: &OwnedTensor) -> Result<Vec<f32>, PreparedInputError> {
+    validate_bytes(tensor, value)?;
+    Ok(value
+        .bytes
+        .chunks_exact(4)
+        .map(|bytes| f32::from_le_bytes(bytes.try_into().expect("four-byte chunk")))
+        .collect())
+}
+
+fn read_i32(tensor: &'static str, value: &OwnedTensor) -> Result<Vec<i32>, PreparedInputError> {
+    validate_bytes(tensor, value)?;
+    Ok(value
+        .bytes
+        .chunks_exact(4)
+        .map(|bytes| i32::from_le_bytes(bytes.try_into().expect("four-byte chunk")))
+        .collect())
+}
+
+impl PreparedIreePrefill {
+    pub(crate) fn prepare(
+        value: &PreparedPrefill,
+        hidden_size: usize,
+        context_capacity: usize,
+    ) -> Result<Self, PreparedInputError> {
+        let effective_len = value.sequence_len;
+        if effective_len == 0 {
+            return Err(PreparedInputError::Empty);
+        }
+        if effective_len != value.token_ids.len() {
+            return Err(PreparedInputError::SequenceLength {
+                declared: effective_len,
+                token_ids: value.token_ids.len(),
+            });
+        }
+        if effective_len > context_capacity {
+            return Err(PreparedInputError::Capacity {
+                effective_len,
+                context_capacity,
+            });
+        }
+        if value.embeddings.dtype != PreparedTensorDType::Float32 {
+            return Err(PreparedInputError::EmbeddingDType(value.embeddings.dtype));
+        }
+        let expected_embedding_shape = vec![1, effective_len, hidden_size];
+        if value.embeddings.shape != expected_embedding_shape {
+            let actual_hidden = value.embeddings.shape.get(2).copied();
+            if value.embeddings.shape.len() == 3
+                && value.embeddings.shape[0] == 1
+                && value.embeddings.shape[1] == effective_len
+                && actual_hidden != Some(hidden_size)
+            {
+                return Err(PreparedInputError::HiddenSize {
+                    actual: actual_hidden.unwrap_or(0),
+                    expected: hidden_size,
+                });
+            }
+            return Err(PreparedInputError::EmbeddingShape {
+                shape: value.embeddings.shape.clone(),
+                expected: expected_embedding_shape,
+            });
+        }
+        let input_embeddings = read_f32("embeddings", &value.embeddings)?;
+        if input_embeddings.iter().any(|v| !v.is_finite()) {
+            return Err(PreparedInputError::InvalidFloat {
+                tensor: "embeddings",
+            });
+        }
+        let embedding_count = context_capacity
+            .checked_mul(hidden_size)
+            .ok_or(PreparedInputError::ShapeOverflow)?;
+        let mut embeddings = vec![0.0; embedding_count];
+        embeddings[..input_embeddings.len()].copy_from_slice(&input_embeddings);
+
+        let mut positions: Vec<i32> = (0..context_capacity)
+            .map(|position| i32::try_from(position).map_err(|_| PreparedInputError::ShapeOverflow))
+            .collect::<Result<_, _>>()?;
+        match &value.positions {
+            PreparedPositions::Sequential { start, length } => {
+                if *start != 0 || *length != effective_len {
+                    return Err(PreparedInputError::UnsupportedPositions);
+                }
+            }
+            PreparedPositions::Explicit(tensor) => {
+                if tensor.dtype != PreparedTensorDType::Int32 {
+                    return Err(PreparedInputError::PositionDType(tensor.dtype));
+                }
+                if tensor.shape != [effective_len] && tensor.shape != [1, effective_len] {
+                    return Err(PreparedInputError::PositionShape(tensor.shape.clone()));
+                }
+                let explicit = read_i32("positions", tensor)?;
+                if explicit
+                    .iter()
+                    .enumerate()
+                    .any(|(index, &position)| position != index as i32)
+                {
+                    return Err(PreparedInputError::UnsupportedPositions);
+                }
+                positions[..effective_len].copy_from_slice(&explicit);
+            }
+            _ => return Err(PreparedInputError::UnsupportedPositions),
+        }
+
+        let bias_tensor = &value.attention_bias.tensor;
+        if bias_tensor.dtype != PreparedTensorDType::Float32 {
+            return Err(PreparedInputError::AttentionBiasDType(bias_tensor.dtype));
+        }
+        let compact_bias = read_f32("attention bias", bias_tensor)?;
+        if compact_bias
+            .iter()
+            .any(|value| value.is_nan() || *value > 0.0)
+        {
+            return Err(PreparedInputError::InvalidFloat {
+                tensor: "attention bias",
+            });
+        }
+        let key_bias =
+            bias_tensor.shape == [effective_len] || bias_tensor.shape == [1, 1, 1, effective_len];
+        let matrix_bias = bias_tensor.shape == [effective_len, effective_len]
+            || bias_tensor.shape == [1, 1, effective_len, effective_len];
+        if !key_bias && !matrix_bias {
+            return Err(PreparedInputError::AttentionBiasShape(
+                bias_tensor.shape.clone(),
+            ));
+        }
+        let bias_count = context_capacity
+            .checked_mul(context_capacity)
+            .ok_or(PreparedInputError::ShapeOverflow)?;
+        let mut attention_bias = vec![MASKED_VALUE; bias_count];
+        for query in 0..effective_len {
+            for key in 0..effective_len {
+                let base = if key_bias {
+                    compact_bias[key]
+                } else {
+                    compact_bias[query * effective_len + key]
+                };
+                attention_bias[query * context_capacity + key] =
+                    if value.attention_bias.causal && key > query {
+                        MASKED_VALUE
+                    } else {
+                        base
+                    };
+            }
+        }
+
+        Ok(Self {
+            token_ids: value.token_ids.clone(),
+            embeddings,
+            positions,
+            attention_bias,
+            effective_len,
+            hidden_size,
+            context_capacity,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mlxcel_core::session::{PreparedAttentionBias, PreparedModality};
+
+    fn tensor_f32(shape: &[usize], values: impl IntoIterator<Item = f32>) -> OwnedTensor {
+        let bytes = values
+            .into_iter()
+            .flat_map(f32::to_le_bytes)
+            .collect::<Vec<_>>();
+        OwnedTensor::new(bytes, PreparedTensorDType::Float32, shape.to_vec()).unwrap()
+    }
+
+    fn fixture() -> PreparedPrefill {
+        PreparedPrefill::new(
+            vec![11, 22, 33],
+            tensor_f32(&[1, 3, 2], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            PreparedPositions::Sequential {
+                start: 0,
+                length: 3,
+            },
+            PreparedAttentionBias {
+                tensor: tensor_f32(&[1, 1, 1, 3], [0.0, 0.0, 0.0]),
+                causal: true,
+            },
+            vec![PreparedModality {
+                family: "test".into(),
+                item_count: 1,
+                token_count: 1,
+            }],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn materializes_static_shapes_and_causal_bias() {
+        let prepared = PreparedIreePrefill::prepare(&fixture(), 2, 5).unwrap();
+        assert_eq!(prepared.effective_len, 3);
+        assert_eq!(prepared.token_ids, [11, 22, 33]);
+        assert_eq!(prepared.embeddings.len(), 10);
+        assert_eq!(&prepared.embeddings[..6], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        assert_eq!(&prepared.positions, &[0, 1, 2, 3, 4]);
+        assert_eq!(prepared.attention_bias[0], 0.0);
+        assert_eq!(prepared.attention_bias[1], MASKED_VALUE);
+        assert_eq!(prepared.attention_bias[2 * 5 + 2], 0.0);
+        assert_eq!(prepared.attention_bias[3 * 5], MASKED_VALUE);
+    }
+
+    #[test]
+    fn rejects_wrong_dtype_rank_hidden_bytes_mask_and_capacity() {
+        let mut value = fixture();
+        value.embeddings.dtype = PreparedTensorDType::Float16;
+        assert!(matches!(
+            PreparedIreePrefill::prepare(&value, 2, 5),
+            Err(PreparedInputError::EmbeddingDType(_))
+        ));
+
+        let mut value = fixture();
+        value.embeddings.shape = vec![3, 2];
+        assert!(matches!(
+            PreparedIreePrefill::prepare(&value, 2, 5),
+            Err(PreparedInputError::EmbeddingShape { .. })
+        ));
+
+        let value = fixture();
+        assert!(matches!(
+            PreparedIreePrefill::prepare(&value, 4, 5),
+            Err(PreparedInputError::HiddenSize { .. })
+        ));
+
+        let mut value = fixture();
+        value.embeddings.bytes.pop();
+        assert!(matches!(
+            PreparedIreePrefill::prepare(&value, 2, 5),
+            Err(PreparedInputError::ByteCount { .. })
+        ));
+
+        let mut value = fixture();
+        value.attention_bias.tensor.shape = vec![1, 3, 1];
+        assert!(matches!(
+            PreparedIreePrefill::prepare(&value, 2, 5),
+            Err(PreparedInputError::AttentionBiasShape(_))
+        ));
+
+        let value = fixture();
+        assert!(matches!(
+            PreparedIreePrefill::prepare(&value, 2, 2),
+            Err(PreparedInputError::Capacity { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_overlong_host_buffer_without_touching_canary() {
+        let mut value = fixture();
+        let canary = [0xA5, 0x5A, 0xC3, 0x3C];
+        value.embeddings.bytes.extend_from_slice(&canary);
+
+        let error = PreparedIreePrefill::prepare(&value, 2, 5).unwrap_err();
+        assert_eq!(
+            error,
+            PreparedInputError::ByteCount {
+                tensor: "embeddings",
+                expected: 24,
+                actual: 28,
+            }
+        );
+        assert_eq!(&value.embeddings.bytes[24..], &canary);
+    }
+
+    #[test]
+    fn rejects_invalid_real_len_slot_inputs_and_positions() {
+        assert_eq!(
+            validate_slot(4, 4).unwrap_err(),
+            PreparedInputError::Slot {
+                slot: 4,
+                slot_count: 4
+            }
+        );
+
+        let mut value = fixture();
+        value.sequence_len = 2;
+        assert!(matches!(
+            PreparedIreePrefill::prepare(&value, 2, 5),
+            Err(PreparedInputError::SequenceLength { .. })
+        ));
+
+        let mut value = fixture();
+        value.positions = PreparedPositions::Sequential {
+            start: 1,
+            length: 3,
+        };
+        assert_eq!(
+            PreparedIreePrefill::prepare(&value, 2, 5).unwrap_err(),
+            PreparedInputError::UnsupportedPositions
+        );
+
+        let mut value = fixture();
+        value.attention_bias.tensor = tensor_f32(&[1, 1, 1, 3], [0.0, f32::NAN, 0.0]);
+        assert!(matches!(
+            PreparedIreePrefill::prepare(&value, 2, 5),
+            Err(PreparedInputError::InvalidFloat { .. })
+        ));
+    }
+}

--- a/tests/xla_prepared_prefill.rs
+++ b/tests/xla_prepared_prefill.rs
@@ -1,0 +1,231 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real-IREE parity gate for token and prepared-embedding admission.
+//!
+//! This integration test belongs to the root crate because its `xla-iree`
+//! build script owns the whole-archive IREE runtime link recipe. Run it with the
+//! pinned distribution and compiler; it is ignored in ordinary CI.
+
+use std::collections::HashMap;
+
+use mlxcel::{
+    OwnedTensor, PreparedAttentionBias, PreparedPositions, PreparedPrefill, PreparedTensorDType,
+};
+use mlxcel_xla::{EngineEvent, SampleParams, XlaBatchEngine, XlaInferenceSession};
+use safetensors::{Dtype, tensor::TensorView};
+use tempfile::TempDir;
+
+const CAPACITY: usize = 8;
+const HIDDEN: usize = 8;
+const VOCAB: usize = 32;
+
+struct TinyModel {
+    dir: TempDir,
+    embeddings: Vec<f32>,
+}
+
+impl TinyModel {
+    fn path(&self) -> &std::path::Path {
+        self.dir.path()
+    }
+
+    fn prepared(&self, tokens: &[i32]) -> PreparedPrefill {
+        let values = tokens
+            .iter()
+            .flat_map(|&token| {
+                let row = token as usize * HIDDEN;
+                self.embeddings[row..row + HIDDEN].iter().copied()
+            })
+            .collect::<Vec<_>>();
+        PreparedPrefill::new(
+            tokens.to_vec(),
+            tensor_f32(&[1, tokens.len(), HIDDEN], &values),
+            PreparedPositions::Sequential {
+                start: 0,
+                length: tokens.len(),
+            },
+            PreparedAttentionBias {
+                tensor: tensor_f32(&[1, 1, 1, tokens.len()], &vec![0.0; tokens.len()]),
+                causal: true,
+            },
+            Vec::new(),
+        )
+        .expect("valid prepared input")
+    }
+}
+
+fn tensor_f32(shape: &[usize], values: &[f32]) -> OwnedTensor {
+    OwnedTensor::new(
+        values
+            .iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect(),
+        PreparedTensorDType::Float32,
+        shape.to_vec(),
+    )
+    .expect("valid f32 tensor")
+}
+
+fn deterministic_values(elements: usize, seed: usize) -> Vec<f32> {
+    (0..elements)
+        .map(|index| (((index + seed * 17) % 29) as f32 - 14.0) * 0.003)
+        .collect()
+}
+
+fn add_tensor(
+    tensors: &mut Vec<(String, Vec<usize>, Vec<u8>)>,
+    name: impl Into<String>,
+    shape: &[usize],
+    values: Vec<f32>,
+) {
+    tensors.push((
+        name.into(),
+        shape.to_vec(),
+        values
+            .iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect(),
+    ));
+}
+
+fn create_tiny_model() -> TinyModel {
+    let dir = tempfile::tempdir().expect("temporary model directory");
+    std::fs::write(
+        dir.path().join("config.json"),
+        r#"{"model_type":"llama","hidden_size":8,"intermediate_size":16,"num_hidden_layers":2,"num_attention_heads":2,"num_key_value_heads":1,"head_dim":4,"vocab_size":32,"rms_norm_eps":1e-6,"rope_theta":10000.0,"tie_word_embeddings":true}"#,
+    )
+    .expect("model config");
+
+    let embeddings = deterministic_values(VOCAB * HIDDEN, 1);
+    let mut tensors = Vec::new();
+    add_tensor(
+        &mut tensors,
+        "model.embed_tokens.weight",
+        &[VOCAB, HIDDEN],
+        embeddings.clone(),
+    );
+    add_tensor(
+        &mut tensors,
+        "model.norm.weight",
+        &[HIDDEN],
+        vec![1.0; HIDDEN],
+    );
+    for layer in 0..2 {
+        let prefix = format!("model.layers.{layer}");
+        add_tensor(
+            &mut tensors,
+            format!("{prefix}.input_layernorm.weight"),
+            &[HIDDEN],
+            vec![1.0; HIDDEN],
+        );
+        add_tensor(
+            &mut tensors,
+            format!("{prefix}.post_attention_layernorm.weight"),
+            &[HIDDEN],
+            vec![1.0; HIDDEN],
+        );
+        for (offset, suffix, shape) in [
+            (2, "self_attn.q_proj.weight", vec![8, 8]),
+            (3, "self_attn.k_proj.weight", vec![4, 8]),
+            (4, "self_attn.v_proj.weight", vec![4, 8]),
+            (5, "self_attn.o_proj.weight", vec![8, 8]),
+            (6, "mlp.gate_proj.weight", vec![16, 8]),
+            (7, "mlp.up_proj.weight", vec![16, 8]),
+            (8, "mlp.down_proj.weight", vec![8, 16]),
+        ] {
+            add_tensor(
+                &mut tensors,
+                format!("{prefix}.{suffix}"),
+                &shape,
+                deterministic_values(shape.iter().product(), layer * 10 + offset),
+            );
+        }
+    }
+    let views = tensors
+        .iter()
+        .map(|(name, shape, bytes)| {
+            (
+                name.as_str(),
+                TensorView::new(Dtype::F32, shape.clone(), bytes).expect("valid tensor view"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    safetensors::serialize_to_file(&views, None, &dir.path().join("model.safetensors"))
+        .expect("model weights");
+    TinyModel { dir, embeddings }
+}
+
+#[test]
+#[ignore = "requires the pinned IREE runtime and compiler"]
+fn local_task_token_and_prepared_paths_are_exact_with_mixed_slot_reuse() {
+    let fixture = create_tiny_model();
+    let tokens = [1, 2, 3];
+    let prepared = fixture.prepared(&tokens);
+
+    let mut token_session =
+        XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
+            .expect("token session");
+    let mut prepared_session =
+        XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
+            .expect("prepared session");
+    let text_output = token_session
+        .generate_greedy(&tokens, 2, &[])
+        .expect("token generation");
+    let prepared_output = prepared_session
+        .generate_prepared_greedy(&prepared, 2, &[])
+        .expect("prepared generation");
+    assert_eq!(prepared_output, text_output);
+
+    let mut batch =
+        XlaBatchEngine::load_with_context_capacity(fixture.path(), 4, "local-task", CAPACITY)
+            .expect("mixed batch");
+    let cancelled = batch
+        .submit_prepared(prepared.clone(), 4, SampleParams::greedy())
+        .expect("queue cancellation candidate");
+    assert!(batch.cancel(cancelled));
+    assert!(batch.pump().expect("drain cancelled request").is_empty());
+
+    let text = batch
+        .submit(&tokens, 4, SampleParams::greedy())
+        .expect("queue token request");
+    let embedded = batch
+        .submit_prepared(prepared, 4, SampleParams::greedy())
+        .expect("queue prepared request");
+    let mut text_tokens = Vec::new();
+    let mut prepared_tokens = Vec::new();
+    while !batch.is_idle() {
+        for event in batch.pump().expect("mixed batch pump") {
+            if let EngineEvent::Token { req_id, token } = event {
+                if req_id == text {
+                    text_tokens.push(token);
+                } else if req_id == embedded {
+                    prepared_tokens.push(token);
+                }
+            }
+        }
+    }
+    assert_eq!(prepared_tokens, text_tokens);
+    assert_eq!(text_tokens.len(), 4);
+
+    let reused = batch
+        .submit_prepared(fixture.prepared(&tokens), 2, SampleParams::greedy())
+        .expect("reuse released slot");
+    let events = batch.pump().expect("pump reused slot");
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, EngineEvent::Token { req_id, .. } if *req_id == reused))
+    );
+}


### PR DESCRIPTION
## Summary

- load token prefill, prepared-embedding prefill, and decode as one fingerprinted IREE runtime bundle
- seed single and continuous-batch sessions from owned prepared embeddings without losing logical token history
- reject unsupported embedding inputs instead of silently falling back to token-only execution

## Changes

- add strict Rust materialization and a typed C descriptor ABI with repeated dtype, rank, shape, byte-count, capacity, slot, KV dtype, and overflow checks
- share the device-to-device KV slot population path between token and embeddings prefill
- retain prepared buffers through queueing and cancellation while tracking expanded cache length separately from logical IDs
- support optional vendored printf archives and preserve local-task registration in CUDA-enabled pinned IREE builds
- add canary, cancellation, slot-reuse, parity, and real-IREE integration coverage

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p mlxcel-xla --lib --tests -- -D warnings`
- `cargo check -p mlxcel-xla --lib --tests`
- `cargo check --lib --tests --features xla-backend`
- `cargo check -p mlxcel-xla --features iree --lib --tests`
- `cargo test -p mlxcel-xla prepared::tests` (4 passed)
- `cargo test -p mlxcel-xla batch::tests` (10 passed)
- pinned IREE 3.12.0rc `local-task`: `cargo test --features xla-iree --test xla_prepared_prefill -- --ignored --nocapture` (1 passed)

Closes #860