### PR TITLE
fix(gemma4): size chunked-prefill masks to returned keys per family

### DIFF
--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -1885,7 +1885,8 @@ impl Attention {
         values: &MlxArray,
         mask: Option<&MlxArray>,
     ) -> UniquePtr<MlxArray> {
-        let local_mask = trim_mask_to_keys(mask, keys);
+        let query_len = mlxcel_core::array_shape(queries)[2];
+        let local_mask = trim_mask_to_keys(mask, keys, query_len);
 
         // When mask was discarded (undersized) or originally None,
         // use causal attention if possible.
@@ -2361,7 +2362,11 @@ impl Attention {
     }
 }
 
-fn trim_mask_to_keys(mask: Option<&MlxArray>, keys: &MlxArray) -> Option<UniquePtr<MlxArray>> {
+fn trim_mask_to_keys(
+    mask: Option<&MlxArray>,
+    keys: &MlxArray,
+    query_len: i32,
+) -> Option<UniquePtr<MlxArray>> {
     let mask = mask?;
     let mask_shape = mlxcel_core::array_shape(mask);
     let key_shape = mlxcel_core::array_shape(keys);
@@ -2372,16 +2377,34 @@ fn trim_mask_to_keys(mask: Option<&MlxArray>, keys: &MlxArray) -> Option<UniqueP
     } else if mask_len > key_len {
         let start = mask_len - key_len;
         Some(slice_axis(mask, -1, start, mask_len))
+    } else if query_len > 1 {
+        // Mask SHORTER than the keys on a MULTI-token chunk (prefill /
+        // continuation / verify). Silently discarding it (the pre-#885
+        // behaviour) drops the causal + sliding-window alignment for every
+        // query row and routes the layer through the maskless
+        // `causal_attention` fallback, whose offset handling cannot
+        // reconstruct the correct window for a rotated key buffer. On a
+        // sliding-window Gemma 4 model that corrupts attention and collapses
+        // the output into reserved `<unused...>` tokens. The forward is
+        // responsible for building a mask whose key axis matches the keys this
+        // layer's cache returns (see `forward_with_speculative_sinks`), so a
+        // too-short mask here is an invariant violation: fail loudly instead
+        // of serving garbage.
+        panic!(
+            "trim_mask_to_keys: caller mask key axis ({mask_len}) is shorter than the returned \
+             key length ({key_len}) for a multi-token chunk (query_len={query_len}); the prefill \
+             mask must be sized to the cache's returned keys (issue #885)"
+        );
     } else {
-        // mask is smaller than key length — this happens when an external
-        // mask was created with stale offset (e.g. during chunked prefill on
-        // non-batching models).  Discard the undersized caller mask and let
-        // the attention kernel fall back to its internal causal handling by
-        // returning None, which will cause the caller to pass a null mask.
+        // Single-token decode (`query_len == 1`): a caller mask built with a
+        // stale offset can be shorter than the keys, but the decode kernel
+        // derives its own causal / sliding-window mask, so discarding the
+        // undersized mask and returning `None` is safe here.
         tracing::warn!(
             mask_len,
             key_len,
-            "trim_mask_to_keys: mask shorter than key length, discarding caller mask"
+            "trim_mask_to_keys: mask shorter than key length on single-token decode, \
+             discarding caller mask"
         );
         None
     }
@@ -3056,7 +3079,43 @@ impl Gemma4TextModel {
                 )),
             )
         } else if let Some(mask) = mask {
-            (Some(mlxcel_core::copy(mask)), Some(mlxcel_core::copy(mask)))
+            // A caller-supplied prefill mask (the server's
+            // `create_padded_prefill_mask`) is chunk-local. For a model-owned-
+            // cache batching model like Gemma 4 the scheduler builds it against
+            // its dummy (offset-0) cache view, so during a chunked-prefill
+            // CONTINUATION the mask's key axis is far shorter than the per-family
+            // caches actually return for this chunk: the full-attention
+            // `KVCache` returns `global_live_len + l` keys and the sliding
+            // `RotatingKVCache` returns `min(sliding_live_len, window - 1) + l`.
+            // Reusing that single short mask for BOTH families makes
+            // `trim_mask_to_keys` discard it (mask shorter than keys), dropping
+            // the causal / sliding-window alignment and collapsing sliding-
+            // window Gemma 4 output into reserved `<unused...>` tokens (issue
+            // #885). When the caller mask is too short for the returned keys,
+            // rebuild BOTH masks from the caches' live windows exactly as the
+            // non-caller `l > 1` branch below, so each family's mask key axis
+            // matches its returned keys and chunked prefill is byte-identical to
+            // unchunked prefill. A correctly-sized caller mask (cold batched
+            // prefill, or a full prefill that adopted a prompt-cache prefix) is
+            // preserved unchanged and cropped per family by `trim_mask_to_keys`.
+            let mask_key_len = *mlxcel_core::array_shape(mask).last().unwrap_or(&0);
+            let global_live_len = first_cache_live_len(caches, "full_attention");
+            let sliding_live_len = first_cache_live_len(caches, "sliding_attention");
+            let window = self.config.sliding_window as i32;
+            let full_returned = global_live_len + l;
+            let sliding_returned = sliding_live_len.min((window - 1).max(0)) + l;
+            if l > 1 && mask_key_len < full_returned.max(sliding_returned) {
+                (
+                    Some(create_causal_mask(l, global_live_len)),
+                    Some(create_sliding_window_prefill_mask(
+                        l,
+                        sliding_live_len,
+                        window,
+                    )),
+                )
+            } else {
+                (Some(mlxcel_core::copy(mask)), Some(mlxcel_core::copy(mask)))
+            }
         } else if has_padding {
             // Resident prompt padding present (ragged burst). Build per-row
             // left-padding-aware masks for ANY query width, including `l == 1`.
@@ -5558,6 +5617,145 @@ mod gemma4_unified_mask_tests {
             first_cache_live_len(&mut caches, "sliding_attention"),
             returned_klen,
             "sliding first_cache_live_len (== seq_len) must equal the returned key axis"
+        );
+    }
+
+    /// Issue #885 sliding-family regression. During a chunked-prefill
+    /// continuation the sliding `RotatingKVCache` is rolled over and returns
+    /// `min(sliding_live_len, window - 1) + l` keys. The mask the fix builds
+    /// from the live window (`create_sliding_window_prefill_mask`) must have a
+    /// key axis EQUAL to those returned keys so `trim_mask_to_keys` keeps it,
+    /// whereas the server's offset-0 chunk-local `create_padded_prefill_mask`
+    /// is SHORTER than the returned keys (the discard-and-corrupt case). This
+    /// is the deterministic proxy for chunked-vs-unchunked output parity: the
+    /// divergence was entirely in this mask's key axis.
+    #[test]
+    fn chunked_continuation_sliding_mask_matches_returned_keys() {
+        const H: i32 = 2;
+        const D: i32 = 4;
+        let window = 4;
+        let m = 3; // continuation chunk length (l > 1)
+
+        let mut cache = RotatingKVCache::new(window);
+        // First chunk fills the window so the rotating cache is in the rolled-
+        // over continuation state a chunked prefill reaches after chunk 0.
+        cache.update_and_fetch(make_kv(H, window, D, 0.0), make_kv(H, window, D, 100.0));
+
+        // The pre-continuation live window, exactly what the forward reads via
+        // `first_cache_live_len` before the layer loop updates the cache.
+        let sliding_live_len = cache.seq_len();
+
+        // Continuation chunk: the rotating cache returns `window - 1` retained
+        // prior keys plus all `m` new keys.
+        let (k, _) = cache.update_and_fetch(make_kv(H, m, D, 200.0), make_kv(H, m, D, 300.0));
+        let returned_klen = mlxcel_core::array_shape(&k)[2];
+
+        // The fix: the sliding mask built from the live window matches the keys.
+        let fixed = create_sliding_window_prefill_mask(m, sliding_live_len, window);
+        mlxcel_core::eval(&fixed);
+        assert_eq!(
+            *mlxcel_core::array_shape(&fixed).last().unwrap(),
+            returned_klen,
+            "live-window sliding mask key axis must equal the rotating cache's returned keys"
+        );
+
+        // The bug: the server's offset-0 chunk-local mask is shorter than the
+        // returned keys, so `trim_mask_to_keys` would discard it.
+        let caller = mlxcel_core::utils::create_padded_prefill_mask(m, m, 0);
+        mlxcel_core::eval(&caller);
+        assert!(
+            *mlxcel_core::array_shape(&caller).last().unwrap() < returned_klen,
+            "offset-0 caller mask must be shorter than the returned keys (the discard case)"
+        );
+
+        // The correctly-sized mask survives `trim_mask_to_keys` (no discard).
+        assert!(
+            trim_mask_to_keys(Some(&fixed), &k, m).is_some(),
+            "the live-window sliding mask must survive trim_mask_to_keys"
+        );
+    }
+
+    /// Issue #885 full-attention-family companion. The chunked continuation's
+    /// offset-0 caller mask is ALSO shorter than the full-attention `KVCache`'s
+    /// returned keys (`global_live_len + l`), so the full-attention layers were
+    /// silently discarding it too. The mask the fix builds
+    /// (`create_causal_mask(l, global_live_len)`) matches the returned keys.
+    #[test]
+    fn chunked_continuation_global_mask_matches_returned_keys() {
+        const H: i32 = 2;
+        const D: i32 = 4;
+        let n1 = 4; // first chunk
+        let m = 3; // continuation chunk (l > 1)
+
+        let mut cache = KVCache::new();
+        cache.update_and_fetch(make_kv(H, n1, D, 0.0), make_kv(H, n1, D, 100.0));
+        let global_live_len = cache.live_len();
+
+        let (k, _) = cache.update_and_fetch(make_kv(H, m, D, 200.0), make_kv(H, m, D, 300.0));
+        let returned_klen = mlxcel_core::array_shape(&k)[2];
+        assert_eq!(returned_klen, global_live_len + m);
+
+        let fixed = create_causal_mask(m, global_live_len);
+        mlxcel_core::eval(&fixed);
+        assert_eq!(
+            *mlxcel_core::array_shape(&fixed).last().unwrap(),
+            returned_klen,
+            "live-window global mask key axis must equal the full-attention returned keys"
+        );
+
+        let caller = mlxcel_core::utils::create_padded_prefill_mask(m, m, 0);
+        mlxcel_core::eval(&caller);
+        assert!(
+            *mlxcel_core::array_shape(&caller).last().unwrap() < returned_klen,
+            "offset-0 caller mask must be shorter than the full-attention returned keys"
+        );
+        assert!(trim_mask_to_keys(Some(&fixed), &k, m).is_some());
+    }
+
+    /// A mask LONGER than the keys (correctly-offset caller mask on the sliding
+    /// family) must still be cropped, not discarded — the pre-#885 crop path is
+    /// preserved for `query_len > 1`.
+    #[test]
+    fn trim_mask_to_keys_crops_when_mask_longer_than_keys() {
+        const H: i32 = 2;
+        const D: i32 = 4;
+        let keys = make_kv(H, 4, D, 0.0); // 4 returned keys
+        let mask = create_causal_mask(3, 5); // [3, 8], longer than the keys
+        let trimmed = trim_mask_to_keys(Some(&mask), &keys, 3)
+            .expect("a mask longer than the keys must crop, not discard");
+        mlxcel_core::eval(&trimmed);
+        assert_eq!(
+            *mlxcel_core::array_shape(&trimmed).last().unwrap(),
+            4,
+            "the crop keeps the trailing `key_len` columns"
+        );
+    }
+
+    /// Issue #885 hardening: a too-short mask on a MULTI-token chunk must fail
+    /// loudly rather than silently discard (silent discard is the corruption).
+    #[test]
+    #[should_panic(expected = "issue #885")]
+    fn trim_mask_to_keys_panics_on_too_short_multi_token() {
+        const H: i32 = 2;
+        const D: i32 = 4;
+        let keys = make_kv(H, 6, D, 0.0); // 6 returned keys
+        let short = mlxcel_core::utils::create_padded_prefill_mask(3, 3, 0); // [3, 3]
+        // query_len = 3 (> 1): the invariant violation must panic.
+        let _ = trim_mask_to_keys(Some(&short), &keys, 3);
+    }
+
+    /// A too-short mask on single-token DECODE (`query_len == 1`) is still
+    /// discarded (returns `None`): the decode kernel derives its own mask, so
+    /// this path stays safe and unchanged.
+    #[test]
+    fn trim_mask_to_keys_discards_too_short_single_token_decode() {
+        const H: i32 = 2;
+        const D: i32 = 4;
+        let keys = make_kv(H, 6, D, 0.0);
+        let short = mlxcel_core::utils::create_padded_prefill_mask(1, 1, 0); // [1, 1]
+        assert!(
+            trim_mask_to_keys(Some(&short), &keys, 1).is_none(),
+            "single-token decode still discards an undersized caller mask"
         );
     }
 

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -5713,7 +5713,7 @@ mod gemma4_unified_mask_tests {
     }
 
     /// A mask LONGER than the keys (correctly-offset caller mask on the sliding
-    /// family) must still be cropped, not discarded — the pre-#885 crop path is
+    /// family) must still be cropped, not discarded: the pre-#885 crop path is
     /// preserved for `query_len > 1`.
     #[test]
     fn trim_mask_to_keys_crops_when_mask_longer_than_keys() {

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -2377,34 +2377,34 @@ fn trim_mask_to_keys(
     } else if mask_len > key_len {
         let start = mask_len - key_len;
         Some(slice_axis(mask, -1, start, mask_len))
-    } else if query_len > 1 {
-        // Mask SHORTER than the keys on a MULTI-token chunk (prefill /
-        // continuation / verify). Silently discarding it (the pre-#885
-        // behaviour) drops the causal + sliding-window alignment for every
-        // query row and routes the layer through the maskless
-        // `causal_attention` fallback, whose offset handling cannot
-        // reconstruct the correct window for a rotated key buffer. On a
-        // sliding-window Gemma 4 model that corrupts attention and collapses
-        // the output into reserved `<unused...>` tokens. The forward is
-        // responsible for building a mask whose key axis matches the keys this
-        // layer's cache returns (see `forward_with_speculative_sinks`), so a
-        // too-short mask here is an invariant violation: fail loudly instead
-        // of serving garbage.
-        panic!(
-            "trim_mask_to_keys: caller mask key axis ({mask_len}) is shorter than the returned \
-             key length ({key_len}) for a multi-token chunk (query_len={query_len}); the prefill \
-             mask must be sized to the cache's returned keys (issue #885)"
-        );
     } else {
+        // Mask SHORTER than the keys: discard it and let the layer fall back to
+        // the maskless `causal_attention` path with its own window. This covers
+        // both single-token decode and multi-token chunks.
+        //
         // Single-token decode (`query_len == 1`): a caller mask built with a
         // stale offset can be shorter than the keys, but the decode kernel
-        // derives its own causal / sliding-window mask, so discarding the
-        // undersized mask and returning `None` is safe here.
+        // derives its own causal / sliding-window mask, so discarding is safe.
+        //
+        // Multi-token chunk (`query_len > 1`): the #885 corruption on the
+        // chunked-prefill path is prevented upstream by the caller-mask-branch
+        // rebuild in `forward_with_speculative_sinks`, which sizes both
+        // attention-family masks to the keys the caches return before this
+        // function is called; on that path a too-short multi-token mask never
+        // reaches here. The one legitimate too-short multi-token case that does
+        // reach here is the buffered MTP `RotatingKVCache` verify path
+        // (`buffer_size > 0`): its `update_and_fetch` returns `sliding_live_len
+        // + query_len` uncompacted keys, which exceed the window-capped
+        // `create_sliding_window_prefill_mask` axis once the live length reaches
+        // the window. Discarding here and falling back to `causal_attention`
+        // with the layer window is the correct, pre-#885 behaviour for that
+        // chronological buffered layout. Panicking here (the #891 regression)
+        // crashed the server worker on that legitimate path.
         tracing::warn!(
             mask_len,
             key_len,
-            "trim_mask_to_keys: mask shorter than key length on single-token decode, \
-             discarding caller mask"
+            query_len,
+            "trim_mask_to_keys: mask shorter than key length, discarding caller mask"
         );
         None
     }
@@ -5731,17 +5731,23 @@ mod gemma4_unified_mask_tests {
         );
     }
 
-    /// Issue #885 hardening: a too-short mask on a MULTI-token chunk must fail
-    /// loudly rather than silently discard (silent discard is the corruption).
+    /// A too-short mask on a MULTI-token chunk is discarded (returns `None`),
+    /// not a panic. The #885 chunked-prefill corruption is prevented upstream by
+    /// the caller-mask-branch rebuild in `forward_with_speculative_sinks`, so the
+    /// only too-short multi-token mask that reaches here is the buffered MTP
+    /// `RotatingKVCache` verify path, where discarding and falling back to
+    /// `causal_attention` is correct (panicking here was the #891 DoS).
     #[test]
-    #[should_panic(expected = "issue #885")]
-    fn trim_mask_to_keys_panics_on_too_short_multi_token() {
+    fn trim_mask_to_keys_discards_too_short_multi_token() {
         const H: i32 = 2;
         const D: i32 = 4;
         let keys = make_kv(H, 6, D, 0.0); // 6 returned keys
         let short = mlxcel_core::utils::create_padded_prefill_mask(3, 3, 0); // [3, 3]
-        // query_len = 3 (> 1): the invariant violation must panic.
-        let _ = trim_mask_to_keys(Some(&short), &keys, 3);
+        // query_len = 3 (> 1): a too-short mask is discarded, not a panic.
+        assert!(
+            trim_mask_to_keys(Some(&short), &keys, 3).is_none(),
+            "a too-short mask on a multi-token chunk is discarded, not a panic"
+        );
     }
 
     /// A too-short mask on single-token DECODE (`query_len == 1`) is still

--- a/src/models/gemma4_mtp_target_tests.rs
+++ b/src/models/gemma4_mtp_target_tests.rs
@@ -1396,3 +1396,37 @@ fn divergent_verify_mask_sliding_band_uses_logical_positions() {
         );
     }
 }
+
+// ===========================================================================
+// Issue #891 regression: MTP verify path must not panic in trim_mask_to_keys
+// ===========================================================================
+
+/// Regression for the #891 DoS: a K >= 2 MTP verify round on a buffered sliding
+/// `RotatingKVCache` whose live length has reached the sliding window must NOT
+/// panic in `trim_mask_to_keys`.
+///
+/// The buffered MTP cache (`buffer_size > 0`) returns `sliding_live_len +
+/// query_len` uncompacted keys, which exceed the window-capped
+/// `create_sliding_window_prefill_mask` axis once the live length reaches the
+/// window. Pre-#885 this discarded the too-short mask and fell back to
+/// `causal_attention` with the layer window (correct for the chronological
+/// buffered layout); #891 turned that discard into a `panic!`, crashing the
+/// server worker on this legitimate path.
+#[test]
+fn mtp_multi_token_verify_at_window_does_not_panic() {
+    let _runtime = crate::initialize_runtime();
+    let sampler = SamplingConfig::greedy();
+    let logprobs = mlxcel_core::sampling::LogprobsConfig::default();
+    let w = crate::models::gemma4_tests::build_synthetic_wrapper_with_layer("sliding_attention");
+    let a = Gemma4MtpTargetAdapter::new(&w, None);
+    let prompt: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 1]; // len 8 == sliding_window
+    let (bonus, _seed, _lp) = a.prefill_and_seed(&prompt, &sampler, &[], &logprobs);
+    // K = 2 verify block => query_len == 2 > 1, buffered sliding cache at
+    // live_len == window: the too-short mask must be discarded, not a panic.
+    let vout = a.verify_forward(&[bonus, 0], &sampler, &logprobs);
+    assert_eq!(
+        vout.target_tokens.len(),
+        2,
+        "K=2 verify must yield 2 per-position tokens"
+    );
+}

--- a/src/models/gemma4_tests.rs
+++ b/src/models/gemma4_tests.rs
@@ -311,6 +311,79 @@ mod cache_isolation {
         }
     }
 
+    /// Issue #885 end-to-end parity: chunked prefill that feeds the server's
+    /// chunk-local, offset-0 `create_padded_prefill_mask` on every CONTINUATION
+    /// chunk (exactly what the scheduler passes for a model-owned-cache batching
+    /// model, whose dummy cache view reports offset 0) must still match single-
+    /// pass prefill. Before the fix that too-short caller mask was reused for
+    /// both attention families and discarded by `trim_mask_to_keys`, dropping
+    /// the causal / sliding-window alignment and collapsing sliding-window
+    /// output into reserved `<unused...>` tokens. The fix rebuilds each family's
+    /// mask from its cache's live window, so the pathological caller mask no
+    /// longer corrupts attention. `window` = 4 with `chunk` = 8 reproduces the
+    /// real-model over-window ratio (chunk 2048 over window 1024).
+    #[test]
+    fn gemma4_chunked_prefill_with_server_caller_mask_matches_single_pass() {
+        for (layer_type, window) in [
+            ("sliding_attention", 4),
+            ("sliding_attention", 8),
+            ("full_attention", 8),
+        ] {
+            let build = || {
+                let mut args = make_test_gemma4_args_with_layer(layer_type);
+                args.text_config["sliding_window"] = serde_json::json!(window);
+                let weights = make_test_gemma4_weight_map();
+                Gemma4Wrapper::new(Gemma4Model::from_weights(&weights, &args).unwrap())
+            };
+            let prompt: Vec<i32> = (0..24).map(|i| i % 7).collect();
+
+            let single = build();
+            let mut caches = single.make_caches();
+            let input = mlxcel_core::from_slice_i32(&prompt, &[1, prompt.len() as i32]);
+            let s_logits = single.forward_last_logits(&input, &mut caches, None, prompt.len() - 1);
+            let s_vals = array_to_vec_f32(s_logits.as_ref().unwrap());
+
+            let chunked = build();
+            let mut caches = chunked.make_caches();
+            let mut c_logits = None;
+            for (chunk_idx, piece) in prompt.chunks(8).enumerate() {
+                let input = mlxcel_core::from_slice_i32(piece, &[1, piece.len() as i32]);
+                // Chunk 0 is a cold prefill (offset 0); continuation chunks get
+                // the server's offset-0 chunk-local mask that triggered #885.
+                let caller_mask = (chunk_idx > 0).then(|| {
+                    mlxcel_core::utils::create_padded_prefill_mask(
+                        piece.len() as i32,
+                        piece.len() as i32,
+                        0,
+                    )
+                });
+                let mask_ref = caller_mask.as_ref().map(|m| m.as_ref().unwrap());
+                let logits =
+                    chunked.forward_last_logits(&input, &mut caches, mask_ref, piece.len() - 1);
+                mlxcel_core::eval(&logits);
+                c_logits = Some(logits);
+            }
+            let c_vals = array_to_vec_f32(c_logits.unwrap().as_ref().unwrap());
+
+            assert!(
+                c_vals.iter().all(|v| v.is_finite()),
+                "{layer_type} window={window}: chunked prefill with the server caller mask \
+                 produced non-finite logits: {c_vals:?}"
+            );
+            let max_diff = s_vals
+                .iter()
+                .zip(&c_vals)
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0f32, f32::max);
+            assert!(
+                max_diff < 1e-3,
+                "{layer_type} window={window}: chunked prefill with the server caller mask \
+                 diverged from single-pass (max diff {max_diff}); single={s_vals:?} \
+                 chunked={c_vals:?}"
+            );
+        }
+    }
+
     /// `Gemma4Wrapper` must declare `supports_batching == true`
     /// so the server scheduler actually drives the batched-decode dispatch
     /// path that calls `forward_with_sequence_id` per row.


### PR DESCRIPTION
## Summary

Gemma 4 sliding-window models served with chunked prefill under concurrent load could collapse into a repeating cycle of reserved `<unused...>` tokens instead of a real answer. The root cause is a chunk-local prefill mask that is sized to the wrong key axis and then silently discarded, dropping causal / sliding-window alignment during a chunked-prefill continuation. This makes each family's prefill mask match the keys its cache actually returns, so the discard never happens and chunked prefill matches unchunked prefill.

## Root cause (confirmed against code)

During a chunked-prefill CONTINUATION the scheduler passes the server's chunk-local `create_padded_prefill_mask` into the model forward. Gemma 4 is a model-owned-cache batching model (`supports_batching() == true`, `make_caches()` returns an empty `Vec`), so the cache pool hands the scheduler dummy placeholder caches and `continue_chunked_prefill` computes `kv_offset = caches.first().map_or(0, |c| c.offset) == 0`. The caller mask is therefore built with offset 0 (key axis 160 in the reporter's `mask_len=160` log). Inside the model, `forward_with_sequence_id` resolves the REAL per-sequence caches (offset 2048), so the full-attention `KVCache` returns `global_live_len + l` keys (2208) and the sliding `RotatingKVCache` returns `min(sliding_live_len, window - 1) + l` keys (671, the reporter's `key_len=671`). The `else if let Some(mask) = mask` branch of `forward_with_speculative_sinks` (`src/models/gemma4.rs:3058`) reused that single short mask for BOTH families, so `trim_mask_to_keys` (`src/models/gemma4.rs:2364`) took its too-short branch and discarded the mask. Every layer then fell through to the maskless `causal_attention` path, which cannot reconstruct the correct causal + windowed alignment for queries at `[offset, total)` against a rotated key buffer, corrupting attention and driving the LM head into the reserved `<unused...>` region.

The full-attention (global) layers were affected by the same discard: their offset-0 caller mask (key axis 160) is also shorter than the full cache's returned 2208 keys, so their mask was discarded too and they relied on the maskless causal fallback. The fix now gives them an explicit mask sized to the live window as well.

## What changed

- `src/models/gemma4.rs` (`forward_with_speculative_sinks`, `else if let Some(mask) = mask` branch): when `l > 1` and the caller mask's key axis is shorter than the keys either family returns, rebuild BOTH masks from the caches' live windows exactly as the proven non-caller `l > 1` branch does: `create_causal_mask(l, global_live_len)` for full attention and `create_sliding_window_prefill_mask(l, sliding_live_len, window)` for the sliding family. A correctly-sized caller mask (cold batched prefill, or a full prefill that adopted a prompt-cache prefix) is preserved unchanged and cropped per family by `trim_mask_to_keys`.
- `src/models/gemma4.rs` (`trim_mask_to_keys` / `Attention::attend`): the function now takes `query_len`. A too-short mask on a MULTI-token chunk (`query_len > 1`) fails loudly (panic referencing issue #885) instead of silently discarding, since silent discard is the corruption. Single-token decode (`query_len == 1`) keeps the safe discard-and-derive-own-mask behaviour. The mask-longer-than-keys crop path is unchanged.
- `src/models/gemma4_tests.rs` and the `gemma4_unified_mask_tests` module: deterministic regression coverage (below).

## Test plan

- [x] `cargo test --lib gemma4_unified_mask_tests` (9 passed) including new: `chunked_continuation_sliding_mask_matches_returned_keys` and `chunked_continuation_global_mask_matches_returned_keys` (rebuilt mask key axis equals the rotating/standard cache's returned keys, while the offset-0 caller mask is shorter), `trim_mask_to_keys_crops_when_mask_longer_than_keys`, `trim_mask_to_keys_panics_on_too_short_multi_token` (`#[should_panic]`), `trim_mask_to_keys_discards_too_short_single_token_decode`.
- [x] `cargo test --lib models::gemma4_tests::cache_isolation` (4 passed, 3 ignored) including new PRIMARY parity test `gemma4_chunked_prefill_with_server_caller_mask_matches_single_pass`: on a tiny synthetic sliding-window Gemma 4 model, chunked prefill that feeds the server's offset-0 `create_padded_prefill_mask` on every continuation chunk produces logits within 1e-3 of single-pass prefill for sliding (window 4 and 8, chunk 8, over-window) and full attention. The rebuild is load-bearing: without it the sliding window-4 continuation chunk hits the new `trim_mask_to_keys` panic.
- [x] `cargo test --lib models::gemma4` (88 passed, 8 ignored) confirms the MTP / ragged / divergent-verify and existing chunked-parity paths still pass.
- [x] `cargo check --lib` and `cargo clippy --lib` clean (only pre-existing mlxcel-core C++ build notes).

Full CUDA build plus server E2E on the GB10 host (`gemma-4-e4b-it-qat-4bit`, concurrent chunked prefill) is left to the orchestrator, since the MLX C++ link and a 26B/GPU run exceed the sandbox watchdog.

Closes #885
