### PR TITLE
feat(xla): add Gemma3n text runtime and dense PLE prefill

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,11 @@ xla-backend = ["dep:mlxcel-xla"]
 # StableHLO prefill / decode_step graphs. Needs IREE_DIST at build time (the
 # extracted iree dist), so it is a local / opt-in build, not a CI default.
 xla-iree = ["xla-backend", "mlxcel-xla/iree"]
+# Explicit test-only forwarding for Gemma3n intermediate oracle validation.
+# Its pinned reference is the production CUDA runtime, so enabling diagnostics
+# also enables the root MLX CUDA backend. This is not part of `xla-iree`; normal
+# production bundles remain unchanged.
+xla-diagnostics = ["cuda", "xla-iree", "mlxcel-xla/diagnostics"]
 # Axis A "weight-load surgery" framework.
 #
 # On by default so production `mlxcel` and `mlxcel-server` binaries expose

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -1221,6 +1221,24 @@ impl UnifiedLinear {
         }
     }
 
+    /// Return the logical dense `[out, in]` weight for diagnostics and external
+    /// compiler backends that need to isolate a projection from MLX's QMM.
+    pub fn dequantized_weight(&self) -> UniquePtr<MlxArray> {
+        match self {
+            Self::Quantized { weight, .. } => unsafe {
+                ffi::dequantize(
+                    &weight.weight,
+                    &weight.scales,
+                    weight.biases_ptr(),
+                    weight.group_size,
+                    weight.bits,
+                    &weight.mode,
+                )
+            },
+            Self::Regular(linear) => ffi::copy(&linear.weight),
+        }
+    }
+
     /// Forward pass
     pub fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
         match self {

--- a/src/lib/mlxcel-xla/Cargo.toml
+++ b/src/lib/mlxcel-xla/Cargo.toml
@@ -26,6 +26,10 @@ build = "build.rs"
 # in CI (no IREE dist). When on, build.rs compiles csrc/xla_iree.c and links the
 # prebuilt IREE runtime (IREE_DIST must point at the extracted dist).
 iree = ["dep:safetensors", "dep:memmap2"]
+# Test-only Gemma3n intermediate-oracle surface. Default-off and intentionally
+# separate from `iree`, so production bundles never compile or load diagnostic
+# MLIR unless the explicit root `xla-diagnostics` feature forwards this flag.
+diagnostics = ["iree"]
 
 [dependencies]
 # The engine-neutral inference-session contract lives in mlxcel-core. This

--- a/src/lib/mlxcel-xla/build.rs
+++ b/src/lib/mlxcel-xla/build.rs
@@ -18,9 +18,59 @@
 // the vmfbs at runtime so the bytecode and the linked runtime match.
 use std::env;
 use std::path::PathBuf;
+use std::process::Command;
+
+fn cuda_nvcc() -> PathBuf {
+    if let Some(path) = env::var_os("NVCC") {
+        return PathBuf::from(path);
+    }
+    let conventional = PathBuf::from("/usr/local/cuda/bin/nvcc");
+    if conventional.is_file() {
+        return conventional;
+    }
+    let available_on_path = Command::new("nvcc")
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success());
+    if available_on_path {
+        return PathBuf::from("nvcc");
+    }
+    panic!(
+        "the CUDA IREE Gemma3n QMV build requires nvcc; set NVCC, install \
+         /usr/local/cuda/bin/nvcc, or put nvcc on PATH"
+    );
+}
+
+fn compile_gemma3n_qmv_ptx() {
+    let source = PathBuf::from("csrc/gemma3n_qmv.cu");
+    let output = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR"))
+        .join("gemma3n_qmv_sm80.ptx");
+    let nvcc = cuda_nvcc();
+    let mut command = Command::new(&nvcc);
+    command
+        .arg("-ptx")
+        .arg("--std=c++17")
+        .arg("-O3")
+        .arg("-arch=compute_80");
+    let result = command
+        .arg("-o")
+        .arg(&output)
+        .arg(&source)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {}: {error}", nvcc.display()));
+    if !result.status.success() {
+        panic!(
+            "failed to compile Gemma3n QMV PTX with {}:\n{}",
+            nvcc.display(),
+            String::from_utf8_lossy(&result.stderr)
+        );
+    }
+}
 
 fn main() {
     println!("cargo:rerun-if-changed=csrc/xla_iree.c");
+    println!("cargo:rerun-if-changed=csrc/gemma3n_qmv.cu");
+    println!("cargo:rerun-if-env-changed=NVCC");
     println!("cargo:rerun-if-env-changed=IREE_DIST");
     println!("cargo:rerun-if-env-changed=IREE_CUDA_HOME");
     println!("cargo:rerun-if-env-changed=IREE_CUDA_COMPILE");
@@ -58,6 +108,7 @@ fn main() {
             .include(&bld_inc)
             .define("XLA_GATE_CUDA", None)
             .compile("xla_iree");
+        compile_gemma3n_qmv_ptx();
         println!("cargo:rustc-cfg=xla_iree_cuda");
         if let Ok(ic) = env::var("IREE_CUDA_COMPILE") {
             println!("cargo:rustc-env=MLXCEL_XLA_IREE_COMPILE={ic}");

--- a/src/lib/mlxcel-xla/csrc/gemma3n_qmv.cu
+++ b/src/lib/mlxcel-xla/csrc/gemma3n_qmv.cu
@@ -1,0 +1,399 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+#include <cuda_bf16.h>
+#include <cuda/std/cmath>
+#include <stdint.h>
+
+// cuBLASLt FAST_TF32 uses round-to-nearest-even operand conversion. Keep this
+// bit conversion explicit: sm_80 PTX only exposes cvt.rna.tf32.f32, while the
+// cuBLAS contract rounds halfway values according to the retained mantissa LSB.
+__device__ __forceinline__ float gemma3n_to_tf32_rne(float value) {
+  const uint32_t bits = __float_as_uint(value);
+  if ((bits & 0x7F800000u) == 0x7F800000u) {
+    return value;
+  }
+  const uint32_t retained_lsb = (bits >> 13) & 1u;
+  return __uint_as_float((bits + 0x0FFFu + retained_lsb) & 0xFFFFE000u);
+}
+
+// Correctness-first Gemma3n Q4 prefill projection.
+//
+// IREE custom-dispatch ABI:
+//   bindings: input f32[M,K], weight f32[N,K], output f32[M,N]
+//   constants: M, N, K
+//   workgroup: [32, 8, 1], grid: [ceildiv(N, 8), M, 1]
+//
+// The resident f32 buffers are BF16 carriers produced by the existing loader.
+// Convert at the kernel boundary and preserve MLX CUDA's 16 independent BF16
+// FMA chains, ordered f32 slot fold, and f32 warp-reduction schedule. Each warp
+// owns one weight/output row in one M-row workgroup.
+extern "C" __global__ void gemma3n_qmv(
+    const float* __restrict__ input, const float* __restrict__ weight,
+    float* __restrict__ output, int32_t m_rows, int32_t n_rows,
+    int32_t k_width) {
+  const int32_t lane = static_cast<int32_t>(threadIdx.x);
+  const int32_t output_row =
+      static_cast<int32_t>(blockIdx.x) * static_cast<int32_t>(blockDim.y) +
+      static_cast<int32_t>(threadIdx.y);
+  const int32_t m = static_cast<int32_t>(blockIdx.y);
+  if (output_row >= n_rows || m >= m_rows) {
+    return;
+  }
+
+  const float* weight_row =
+      weight + static_cast<int64_t>(output_row) * k_width;
+  const float* input_row = input + static_cast<int64_t>(m) * k_width;
+  __nv_bfloat16 sums[16] = {};
+
+  // One lane owns 16 contiguous slots in each 512-element round. The loop
+  // order is part of the numerical ABI: each i slot is an independent BF16
+  // FMA chain across rounds.
+  // K is host-validated as i32, but keep the 512-step loop arithmetic in i64
+  // so the terminating multiplication cannot overflow at the i32 boundary.
+  for (int64_t base = 0; base < k_width; base += 512) {
+#pragma unroll
+    for (int32_t i = 0; i < 16; ++i) {
+      const int64_t k = lane * 16 + i + base;
+      if (k < k_width) {
+        const __nv_bfloat16 lhs = __float2bfloat16(input_row[k]);
+        const __nv_bfloat16 rhs = __float2bfloat16(weight_row[k]);
+        sums[i] = __hfma(lhs, rhs, sums[i]);
+      }
+    }
+  }
+
+  // Fold the 16 BF16 chains in ascending slot order using f32 additions.
+  float sum = 0.0f;
+#pragma unroll
+  for (int32_t i = 0; i < 16; ++i) {
+    sum += __bfloat162float(sums[i]);
+  }
+
+  // Fixed f32 butterfly order matching the pinned MLX CUDA warp reduction.
+  constexpr uint32_t kFullWarp = 0xFFFFFFFFu;
+#pragma unroll
+  for (int32_t mask = 16; mask >= 1; mask >>= 1) {
+    sum += __shfl_xor_sync(kFullWarp, sum, mask);
+  }
+
+  if (lane == 0) {
+    output[static_cast<int64_t>(m) * n_rows + output_row] =
+        __bfloat162float(__float2bfloat16(sum));
+  }
+}
+
+// Match MLX CUDA's f32 AltUp router nonlinearity exactly. MLX dispatches
+// `cuda::std::tanh(float)` from its unary kernel; StableHLO/IREE's generic tanh
+// lowering differs by an f32 ULP on the pinned checkpoint, which is enough to
+// perturb the subsequent f32 4x16 coefficient projection and BF16 plane update.
+extern "C" __global__ void gemma3n_tanh(
+    const float* __restrict__ input, float* __restrict__ output,
+    int32_t length) {
+  const int32_t index = static_cast<int32_t>(blockIdx.x) *
+                            static_cast<int32_t>(blockDim.x) +
+                        static_cast<int32_t>(threadIdx.x);
+  if (index < length) {
+    output[index] = cuda::std::tanh(input[index]);
+  }
+}
+
+// Match MLX CUDA's default cuBLASLt coefficient projection contract:
+// CUBLAS_COMPUTE_32F_FAST_TF32 converts both f32 operands to TF32 before the
+// f32 accumulation. AltUp's coefficient dimensions are tiny (K is normally 4),
+// so one thread owns one output and pins the accumulation order.
+extern "C" __global__ void gemma3n_altup_coeff(
+    const float* __restrict__ input, const float* __restrict__ weight,
+    float* __restrict__ output, int32_t rows, int32_t output_width,
+    int32_t inner_width) {
+  const int32_t index = static_cast<int32_t>(blockIdx.x) *
+                            static_cast<int32_t>(blockDim.x) +
+                        static_cast<int32_t>(threadIdx.x);
+  // The host emitter proves rows * output_width <= INT32_MAX.
+  const int32_t length = rows * output_width;
+  if (index >= length) {
+    return;
+  }
+  const int32_t row = index / output_width;
+  const int32_t column = index - row * output_width;
+  float sum = 0.0f;
+  for (int32_t k = 0; k < inner_width; ++k) {
+    const float lhs =
+        gemma3n_to_tf32_rne(
+            input[static_cast<int64_t>(row) * inner_width + k]);
+    const float rhs =
+        gemma3n_to_tf32_rne(
+            weight[static_cast<int64_t>(column) * inner_width + k]);
+    sum = fmaf(lhs, rhs, sum);
+  }
+  output[index] = sum;
+}
+
+// Match MLX CUDA's cuBLASLt FAST_TF32 batched AltUp prediction and the
+// immediately observable BF16 activation boundary. `coefficients` has the
+// logical [rows, source, target] layout produced by the reference transpose.
+//
+// One warp computes a [16, 8] tile from A[16, 4] and B[4, 8]. The logical
+// AltUp target width is four; B columns 4..7 are zero padding and only D
+// columns 0..3 are stored. This emits the same single m16n8k4 Tensor Core
+// accumulation as the pinned cuBLASLt algorithm, then adds the residual in f32
+// and rounds to BF16.
+extern "C" __global__ void gemma3n_altup_predict(
+    const float* __restrict__ planes,
+    const float* __restrict__ coefficients, float* __restrict__ output,
+    int32_t plane_count, int32_t rows, int32_t hidden) {
+  const int32_t lane = static_cast<int32_t>(threadIdx.x);
+  const int32_t group = lane >> 2;
+  const int32_t thread_in_group = lane & 3;
+  const int32_t row = static_cast<int32_t>(blockIdx.y);
+  const int32_t feature_base = static_cast<int32_t>(blockIdx.x) * 16;
+  const int32_t feature0 = feature_base + group;
+  const int32_t feature1 = feature0 + 8;
+  const int32_t plane_size = rows * hidden;
+
+  const auto load_plane = [&](int32_t feature) {
+    if (thread_in_group >= plane_count || feature >= hidden) {
+      return 0.0f;
+    }
+    return planes[static_cast<int64_t>(thread_in_group) * plane_size +
+                  static_cast<int64_t>(row) * hidden + feature];
+  };
+  const float a0_tf32 = gemma3n_to_tf32_rne(load_plane(feature0));
+  const float a1_tf32 = gemma3n_to_tf32_rne(load_plane(feature1));
+
+  float b_tf32 = 0.0f;
+  if (thread_in_group < plane_count && group < plane_count) {
+    b_tf32 = gemma3n_to_tf32_rne(
+        coefficients[(static_cast<int64_t>(row) * plane_count +
+                      thread_in_group) *
+                         plane_count +
+                     group]);
+  }
+
+  const uint32_t a0 = __float_as_uint(a0_tf32);
+  const uint32_t a1 = __float_as_uint(a1_tf32);
+  const uint32_t b0 = __float_as_uint(b_tf32);
+  float d0;
+  float d1;
+  float d2;
+  float d3;
+  asm volatile(
+      "mma.sync.aligned.m16n8k4.row.col.f32.tf32.tf32.f32 "
+      "{%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};"
+      : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+      : "r"(a0), "r"(a1), "r"(b0), "f"(0.0f), "f"(0.0f), "f"(0.0f),
+        "f"(0.0f));
+
+  if (thread_in_group >= 2) {
+    return;
+  }
+  const int32_t target0 = thread_in_group * 2;
+  const int32_t target1 = target0 + 1;
+  const auto store = [&](int32_t target, int32_t feature, float delta) {
+    if (target >= plane_count || feature >= hidden) {
+      return;
+    }
+    const int64_t index = static_cast<int64_t>(target) * plane_size +
+                          static_cast<int64_t>(row) * hidden + feature;
+    const float predicted = planes[index] + delta;
+    output[index] = __bfloat162float(__float2bfloat16(predicted));
+  };
+  store(target0, feature0, d0);
+  store(target1, feature0, d1);
+  store(target0, feature1, d2);
+  store(target1, feature1, d3);
+}
+
+// Reproduce MLX CUDA Compiled's generated GeGLU tape exactly. Its fused JIT
+// declares every node in gelu_tanh_approx as __nv_bfloat16, including the
+// dtype-authored scalar constants and every intermediate primitive result.
+extern "C" __global__ void gemma3n_geglu_bf16(
+    const float* __restrict__ gate, const float* __restrict__ up,
+    float* __restrict__ output, int32_t length) {
+  const int32_t index = static_cast<int32_t>(blockIdx.x) *
+                            static_cast<int32_t>(blockDim.x) +
+                        static_cast<int32_t>(threadIdx.x);
+  if (index >= length) {
+    return;
+  }
+
+  const __nv_bfloat16 x = __float2bfloat16(gate[index]);
+  const __nv_bfloat16 up_value = __float2bfloat16(up[index]);
+  const __nv_bfloat16 half = __float2bfloat16(0.5f);
+  const __nv_bfloat16 one = __float2bfloat16(1.0f);
+  const __nv_bfloat16 root = __float2bfloat16(0.7978845608028654f);
+  const __nv_bfloat16 cubic = __float2bfloat16(0.044715f);
+  const __nv_bfloat16 x2 = x * x;
+  const __nv_bfloat16 x3 = x2 * x;
+  // MLX's generated CUDA is authored as separate BF16 multiply/add nodes, but
+  // nvcc contracts them to HFMA2.BF16_V2. Use the scalar BF16 intrinsic so the
+  // single-rounding behavior is explicit and stable across this AOT kernel.
+  const __nv_bfloat16 inner_add = __hfma(x3, cubic, x);
+  const __nv_bfloat16 inner = root * inner_add;
+  const __nv_bfloat16 tanh_value = cuda::std::tanh(inner);
+  const __nv_bfloat16 one_tanh = one + tanh_value;
+  const __nv_bfloat16 cdf = half * one_tanh;
+  const __nv_bfloat16 gelu = x * cdf;
+  const __nv_bfloat16 product = gelu * up_value;
+  output[index] = __bfloat162float(product);
+}
+
+// Token-exact decode attention schedule for the production CUDA bundle.
+//
+// This reproduces MLX CUDA's kernel_sdpav_1pass<bf16, false, 256> launch:
+// one 1024-thread block per query head, one live key stream per warp, eight
+// f32 FFMA lanes per thread, butterfly reductions, online base-2 softmax, and
+// the shared-memory transpose used to combine all 32 warp accumulators.
+//
+// IREE custom-dispatch ABI:
+//   bindings:
+//     query  f32[query_heads, 256]       (BF16 carriers)
+//     keys   f32[capacity, kv_heads, 256] (BF16 carriers)
+//     values f32[capacity, kv_heads, 256] (BF16 carriers)
+//     output f32[query_heads, 256]       (BF16 carriers)
+//   constants: query_heads, kv_heads, capacity, position, window, scale_bits
+//   workgroup: [1024, 1, 1], grid: [query_heads, 1, 1]
+//
+// `window == 0` or `window >= live` means full attention. Truncated windows
+// require a mask/fallback and are rejected: MLX's vector kernel itself has no
+// window input. The fixed-capacity time-major KV addressing intentionally
+// differs from MLX's compact head-major view while preserving the same logical
+// key order and arithmetic schedule.
+__device__ __forceinline__ float gemma3n_sdpa_exp2(float value) {
+  // MLX CUDA's instantiated exp2f path preserves subnormal-range results by
+  // evaluating half the exponent and squaring. Pin that behavior explicitly
+  // instead of relying on the target-specific libdevice lowering.
+  const bool underflow_range = value < -126.0f;
+  const float exponent = underflow_range ? value * 0.5f : value;
+  const float result = exp2f(exponent);
+  return underflow_range ? result * result : result;
+}
+
+extern "C" __global__ __launch_bounds__(1024)
+void gemma3n_sdpa_vector(
+    const float* __restrict__ query, const float* __restrict__ keys,
+    const float* __restrict__ values, float* __restrict__ output,
+    int32_t query_heads, int32_t kv_heads, int32_t capacity,
+    int32_t position, int32_t window, int32_t scale_bits) {
+  constexpr int32_t kWarpSize = 32;
+  constexpr int32_t kHeadDim = 256;
+  constexpr int32_t kValuesPerThread = kHeadDim / kWarpSize;
+  constexpr uint32_t kFullWarp = 0xFFFFFFFFu;
+
+  const int32_t head = static_cast<int32_t>(blockIdx.x);
+  const int32_t lane = static_cast<int32_t>(threadIdx.x) & 31;
+  const int32_t warp = static_cast<int32_t>(threadIdx.x) >> 5;
+  const int32_t live = position + 1;
+  const float scale = __int_as_float(scale_bits);
+
+  // Every predicate is block-uniform, so an invalid dispatch can
+  // return before the barriers without creating partial-block deadlock.
+  if (static_cast<int32_t>(blockDim.x) != 1024 || head >= query_heads ||
+      query_heads <= 0 || kv_heads <= 0 || query_heads % kv_heads != 0 ||
+      capacity <= 0 || live <= 0 || live > capacity || live > 1024 ||
+      window < 0 || (window != 0 && window < live) || !(scale > 0.0f)) {
+    return;
+  }
+
+  const int32_t group = query_heads / kv_heads;
+  const int32_t kv_head = head / group;
+  const float scale_log2 =
+      static_cast<float>(static_cast<double>(scale) *
+                         1.44269504088896340735992468100189214);
+
+  float q[kValuesPerThread];
+  float accumulated[kValuesPerThread];
+#pragma unroll
+  for (int32_t i = 0; i < kValuesPerThread; ++i) {
+    q[i] =
+        scale_log2 * query[static_cast<int64_t>(head) * kHeadDim +
+                           kValuesPerThread * lane + i];
+    accumulated[i] = 0.0f;
+  }
+
+  float max_score = -3.402823466e+38F;
+  float sum_exp_score = 0.0f;
+
+  // Warp `warp` owns keys first + warp, first + warp + 32, ... exactly as the
+  // MLX BN=32 one-pass kernel owns kv_seq_idx + n*BN.
+  for (int32_t key = warp; key < live; key += kWarpSize) {
+    const int64_t kv_base =
+        (static_cast<int64_t>(key) * kv_heads + kv_head) * kHeadDim;
+    float score = 0.0f;
+#pragma unroll
+    for (int32_t i = 0; i < kValuesPerThread; ++i) {
+      const float key_value =
+          keys[kv_base + kValuesPerThread * lane + i];
+      score = fmaf(q[i], key_value, score);
+    }
+#pragma unroll
+    for (int32_t mask = 16; mask >= 1; mask >>= 1) {
+      score += __shfl_xor_sync(kFullWarp, score, mask);
+    }
+
+    const float new_max = fmaxf(max_score, score);
+    const float factor = gemma3n_sdpa_exp2(max_score - new_max);
+    const float exp_score = gemma3n_sdpa_exp2(score - new_max);
+    max_score = new_max;
+    sum_exp_score = fmaf(sum_exp_score, factor, exp_score);
+#pragma unroll
+    for (int32_t i = 0; i < kValuesPerThread; ++i) {
+      const float value =
+          values[kv_base + kValuesPerThread * lane + i];
+      accumulated[i] =
+          fmaf(accumulated[i], factor, exp_score * value);
+    }
+  }
+
+  __shared__ float outputs[kWarpSize][kWarpSize + 1];
+  __shared__ float max_scores[kWarpSize];
+  __shared__ float sum_exp_scores[kWarpSize];
+  if (lane == 0) {
+    max_scores[warp] = max_score;
+    sum_exp_scores[warp] = sum_exp_score;
+  }
+  __syncthreads();
+
+  // Each lane now represents one source warp. Preserve MLX's butterfly order
+  // for both the global maximum and the rescaled denominator.
+  max_score = max_scores[lane];
+  float new_max = max_score;
+#pragma unroll
+  for (int32_t mask = 16; mask >= 1; mask >>= 1) {
+    new_max = fmaxf(new_max, __shfl_xor_sync(kFullWarp, new_max, mask));
+  }
+  const float factor = gemma3n_sdpa_exp2(max_score - new_max);
+  sum_exp_score = sum_exp_scores[lane] * factor;
+#pragma unroll
+  for (int32_t mask = 16; mask >= 1; mask >>= 1) {
+    sum_exp_score +=
+        __shfl_xor_sync(kFullWarp, sum_exp_score, mask);
+  }
+  sum_exp_score =
+      sum_exp_score == 0.0f ? 0.0f : __frcp_rn(sum_exp_score);
+
+  // Transpose [dimension-lane, source-warp]. Warp `warp` reduces the eight
+  // output dimensions originally held by lane `warp` in every source warp.
+#pragma unroll
+  for (int32_t i = 0; i < kValuesPerThread; ++i) {
+    outputs[lane][warp] = accumulated[i];
+    __syncthreads();
+    float combined = outputs[warp][lane] * factor;
+#pragma unroll
+    for (int32_t mask = 16; mask >= 1; mask >>= 1) {
+      combined += __shfl_xor_sync(kFullWarp, combined, mask);
+    }
+    combined *= sum_exp_score;
+    __syncthreads();
+    if (lane == 0) {
+      output[static_cast<int64_t>(head) * kHeadDim +
+             kValuesPerThread * warp + i] =
+          __bfloat162float(__float2bfloat16(combined));
+    }
+  }
+}

--- a/src/lib/mlxcel-xla/csrc/xla_iree.c
+++ b/src/lib/mlxcel-xla/csrc/xla_iree.c
@@ -100,6 +100,12 @@ typedef struct xla_ctx {
   int32_t n_weights;
   int32_t context_capacity;
   int32_t hidden_size;
+  // 0 = ordinary `prefill_embeddings.main`, 1 = Gemma3n's distinct
+  // `prefill_embeddings_ple.main` with a rank-3 dense PLE argument.
+  int32_t prefill_embeddings_kind;
+  int32_t dense_ple_layers;
+  int32_t dense_ple_hidden;
+  int32_t has_prefill_diagnostics;
   iree_hal_buffer_view_t** weights;  // resident weights, uploaded once
   iree_hal_buffer_view_t* kcache;    // threaded KV (set by prefill, advanced by decode)
   iree_hal_buffer_view_t* vcache;
@@ -298,20 +304,36 @@ static int xla_validate_kv_pair(xla_ctx* c, iree_hal_buffer_view_t* kc,
 static iree_status_t xla_llama_create_impl(
     xla_ctx* c, const char* device_uri, const char* prefill_vmfb,
     const char* prefill_embeddings_vmfb, const char* decode_vmfb,
+    const char* prefill_diagnostics_vmfb,
     uint64_t compatibility_fingerprint, int32_t n_weights,
     const void* const* weight_data,
     const int32_t* weight_dtypes, const int32_t* weight_ranks,
     const int64_t* weight_dims, int32_t context_capacity,
-    int32_t hidden_size) {
+    int32_t hidden_size, int32_t prefill_embeddings_kind,
+    int32_t dense_ple_layers, int32_t dense_ple_hidden) {
   if (context_capacity <= 0 || hidden_size <= 0 ||
       compatibility_fingerprint == 0) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "bundle fingerprint, context_capacity, and hidden_size must be positive");
   }
+  if ((prefill_embeddings_kind != 0 && prefill_embeddings_kind != 1) ||
+      (prefill_embeddings_kind == 0 &&
+       (dense_ple_layers != 0 || dense_ple_hidden != 0)) ||
+      (prefill_embeddings_kind == 1 &&
+       (dense_ple_layers <= 0 || dense_ple_hidden <= 0))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "invalid embeddings entry kind or dense PLE dimensions");
+  }
   c->n_weights = n_weights;
   c->context_capacity = context_capacity;
   c->hidden_size = hidden_size;
   c->compatibility_fingerprint = compatibility_fingerprint;
+  c->prefill_embeddings_kind = prefill_embeddings_kind;
+  c->dense_ple_layers = dense_ple_layers;
+  c->dense_ple_hidden = dense_ple_hidden;
+  c->has_prefill_diagnostics =
+      prefill_diagnostics_vmfb && prefill_diagnostics_vmfb[0] != '\0';
 
   iree_runtime_instance_options_t inst_opts;
   iree_runtime_instance_options_initialize(&inst_opts);
@@ -341,13 +363,26 @@ static iree_status_t xla_llama_create_impl(
       c->session, prefill_embeddings_vmfb));
   IREE_RETURN_IF_ERROR(iree_runtime_session_append_bytecode_module_from_file(
       c->session, decode_vmfb));
+  if (c->has_prefill_diagnostics) {
+    IREE_RETURN_IF_ERROR(iree_runtime_session_append_bytecode_module_from_file(
+        c->session, prefill_diagnostics_vmfb));
+  }
 
-  const char* required_entries[] = {"prefill.main", "prefill_embeddings.main",
+  const char* embeddings_entry = prefill_embeddings_kind == 1
+                                      ? "prefill_embeddings_ple.main"
+                                      : "prefill_embeddings.main";
+  const char* required_entries[] = {"prefill.main", embeddings_entry,
                                     "decode_step.main"};
   for (size_t i = 0; i < 3; ++i) {
     iree_runtime_call_t probe;
     IREE_RETURN_IF_ERROR(iree_runtime_call_initialize_by_name(
         c->session, iree_make_cstring_view(required_entries[i]), &probe));
+    iree_runtime_call_deinitialize(&probe);
+  }
+  if (c->has_prefill_diagnostics) {
+    iree_runtime_call_t probe;
+    IREE_RETURN_IF_ERROR(iree_runtime_call_initialize_by_name(
+        c->session, iree_make_cstring_view("prefill_diagnostics.main"), &probe));
     iree_runtime_call_deinitialize(&probe);
   }
 
@@ -404,21 +439,28 @@ static iree_status_t xla_llama_create_impl(
 xla_ctx* xla_llama_create(const char* device_uri, const char* prefill_vmfb,
                           const char* prefill_embeddings_vmfb,
                           const char* decode_vmfb,
+                          const char* prefill_diagnostics_vmfb,
                           uint64_t compatibility_fingerprint,
                           int32_t n_weights,
                           const void* const* weight_data,
                           const int32_t* weight_dtypes,
                           const int32_t* weight_ranks,
                           const int64_t* weight_dims,
-                          int32_t context_capacity, int32_t hidden_size) {
+                          int32_t context_capacity, int32_t hidden_size,
+                          int32_t prefill_embeddings_kind,
+                          int32_t dense_ple_layers,
+                          int32_t dense_ple_hidden) {
   xla_ctx* c = (xla_ctx*)calloc(1, sizeof(xla_ctx));
   if (!c) return NULL;
   iree_status_t s =
       xla_llama_create_impl(c, device_uri, prefill_vmfb,
                             prefill_embeddings_vmfb, decode_vmfb,
+                            prefill_diagnostics_vmfb,
                             compatibility_fingerprint, n_weights, weight_data,
                             weight_dtypes, weight_ranks, weight_dims,
-                            context_capacity, hidden_size);
+                            context_capacity, hidden_size,
+                            prefill_embeddings_kind, dense_ple_layers,
+                            dense_ple_hidden);
   if (!iree_status_is_ok(s)) {
     char buf[512];
     iree_host_size_t got = 0;
@@ -772,8 +814,92 @@ int xla_llama_prefill_slot_logits(xla_ctx* c, int32_t slot, const int32_t* token
   return copy_rc;
 }
 
+// Test-only Gemma3n intermediate-oracle entry. The optional diagnostic module
+// is never loaded by normal bundles. Its first output is one statically laid
+// out f32 vector; K/V are handled exactly like ordinary slot prefill so the
+// same loaded context can continue through decode and greedy validation.
+int xla_llama_prefill_diagnostics_slot(
+    xla_ctx* c, int32_t slot, const int32_t* tokens, int32_t lp,
+    const int32_t* positions, int32_t real_len, int32_t diagnostic_len,
+    float* out_diagnostics) {
+  if (!c || !c->has_prefill_diagnostics || slot < 0 || slot >= c->rg_bsz ||
+      lp != c->context_capacity || real_len <= 0 || real_len > lp ||
+      diagnostic_len <= 0 || !out_diagnostics) {
+    fprintf(stderr,
+            "xla_llama_prefill_diagnostics_slot: invalid diagnostic bundle/input contract\n");
+    return 1;
+  }
+  int rc = 0;
+  bool call_initialized = false;
+  iree_runtime_call_t call;
+  iree_hal_buffer_view_t* tok_bv = NULL;
+  iree_hal_buffer_view_t* pos_bv = NULL;
+  iree_hal_buffer_view_t* len_bv = NULL;
+  iree_hal_buffer_view_t* output = NULL;
+  iree_hal_buffer_view_t* kc = NULL;
+  iree_hal_buffer_view_t* vc = NULL;
+  XLA_CHECK_GOTO(iree_runtime_call_initialize_by_name(
+                     c->session,
+                     iree_make_cstring_view("prefill_diagnostics.main"), &call),
+                 cleanup, rc);
+  call_initialized = true;
+  for (int32_t i = 0; i < c->n_weights; ++i) {
+    XLA_CHECK_GOTO(
+        iree_runtime_call_inputs_push_back_buffer_view(&call, c->weights[i]),
+        cleanup, rc);
+  }
+  iree_hal_dim_t seq_shape[1] = {(iree_hal_dim_t)lp};
+  iree_host_size_t seq_bytes = (iree_host_size_t)lp * sizeof(int32_t);
+  XLA_CHECK_GOTO(xla_alloc_bv(c, 1, seq_shape, IREE_HAL_ELEMENT_TYPE_INT_32,
+                             tokens, seq_bytes, &tok_bv),
+                 cleanup, rc);
+  XLA_CHECK_GOTO(xla_alloc_bv(c, 1, seq_shape, IREE_HAL_ELEMENT_TYPE_INT_32,
+                             positions, seq_bytes, &pos_bv),
+                 cleanup, rc);
+  XLA_CHECK_GOTO(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32,
+                             &real_len, sizeof(int32_t), &len_bv),
+                 cleanup, rc);
+  XLA_CHECK_GOTO(
+      iree_runtime_call_inputs_push_back_buffer_view(&call, tok_bv), cleanup,
+      rc);
+  XLA_CHECK_GOTO(
+      iree_runtime_call_inputs_push_back_buffer_view(&call, pos_bv), cleanup,
+      rc);
+  XLA_CHECK_GOTO(
+      iree_runtime_call_inputs_push_back_buffer_view(&call, len_bv), cleanup,
+      rc);
+  XLA_CHECK_GOTO(iree_runtime_call_invoke(&call, 0), cleanup, rc);
+  XLA_CHECK_GOTO(
+      iree_runtime_call_outputs_pop_front_buffer_view(&call, &output), cleanup,
+      rc);
+  XLA_CHECK_GOTO(iree_runtime_call_outputs_pop_front_buffer_view(&call, &kc),
+                 cleanup, rc);
+  XLA_CHECK_GOTO(iree_runtime_call_outputs_pop_front_buffer_view(&call, &vc),
+                 cleanup, rc);
+  if (xla_validate_kv_pair(c, kc, vc, 4, 1) != 0) {
+    rc = 1;
+    goto cleanup;
+  }
+  XLA_CHECK_GOTO(
+      xla_read_logits(c, output, out_diagnostics,
+                      (iree_host_size_t)diagnostic_len),
+      cleanup, rc);
+  rc = xla_store_prefill_kv_slot(c, slot, kc, vc);
+
+cleanup:
+  if (output) iree_hal_buffer_view_release(output);
+  if (kc) iree_hal_buffer_view_release(kc);
+  if (vc) iree_hal_buffer_view_release(vc);
+  if (tok_bv) iree_hal_buffer_view_release(tok_bv);
+  if (pos_bv) iree_hal_buffer_view_release(pos_bv);
+  if (len_bv) iree_hal_buffer_view_release(len_bv);
+  if (call_initialized) iree_runtime_call_deinitialize(&call);
+  return rc;
+}
+
 static int xla_llama_prefill_embeddings_impl(
     xla_ctx* c, int32_t slot, const xla_tensor_desc* embeddings,
+    const xla_tensor_desc* dense_ple,
     const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
     int32_t real_len, int32_t vocab, int32_t* out_token, float* out_logits) {
   if (!c || real_len <= 0 || real_len > c->context_capacity) {
@@ -785,12 +911,22 @@ static int xla_llama_prefill_embeddings_impl(
   int64_t embeddings_dims[2] = {c->context_capacity, c->hidden_size};
   int64_t positions_dims[1] = {c->context_capacity};
   int64_t bias_dims[2] = {c->context_capacity, c->context_capacity};
+  int64_t dense_ple_dims[3] = {
+      c->context_capacity, c->dense_ple_layers, c->dense_ple_hidden};
   if (xla_validate_tensor_desc("embeddings", embeddings, 0, 2,
                                embeddings_dims) != 0 ||
       xla_validate_tensor_desc("positions", positions, 1, 1,
                                positions_dims) != 0 ||
       xla_validate_tensor_desc("attention_bias", attention_bias, 0, 2,
                                bias_dims) != 0) {
+    return 1;
+  }
+  if ((c->prefill_embeddings_kind == 0 && dense_ple != NULL) ||
+      (c->prefill_embeddings_kind == 1 &&
+       xla_validate_tensor_desc("dense_ple", dense_ple, 0, 3,
+                                dense_ple_dims) != 0)) {
+    fprintf(stderr,
+            "xla_llama_prefill_embeddings: dense PLE does not match bundle kind\n");
     return 1;
   }
   bool batched = slot >= 0;
@@ -805,6 +941,7 @@ static int xla_llama_prefill_embeddings_impl(
   bool call_initialized = false;
   iree_runtime_call_t call;
   iree_hal_buffer_view_t* embeddings_bv = NULL;
+  iree_hal_buffer_view_t* dense_ple_bv = NULL;
   iree_hal_buffer_view_t* positions_bv = NULL;
   iree_hal_buffer_view_t* len_bv = NULL;
   iree_hal_buffer_view_t* bias_bv = NULL;
@@ -814,7 +951,11 @@ static int xla_llama_prefill_embeddings_impl(
 
   XLA_CHECK_GOTO(iree_runtime_call_initialize_by_name(
                      c->session,
-                     iree_make_cstring_view("prefill_embeddings.main"), &call),
+                     iree_make_cstring_view(
+                         c->prefill_embeddings_kind == 1
+                             ? "prefill_embeddings_ple.main"
+                             : "prefill_embeddings.main"),
+                     &call),
                  cleanup, rc);
   call_initialized = true;
   for (int32_t i = 0; i < c->n_weights; ++i) {
@@ -823,6 +964,9 @@ static int xla_llama_prefill_embeddings_impl(
         cleanup, rc);
   }
   XLA_CHECK_GOTO(xla_alloc_desc_bv(c, embeddings, &embeddings_bv), cleanup, rc);
+  if (dense_ple) {
+    XLA_CHECK_GOTO(xla_alloc_desc_bv(c, dense_ple, &dense_ple_bv), cleanup, rc);
+  }
   XLA_CHECK_GOTO(xla_alloc_desc_bv(c, positions, &positions_bv), cleanup, rc);
   XLA_CHECK_GOTO(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32,
                              &real_len, sizeof(int32_t), &len_bv),
@@ -831,6 +975,11 @@ static int xla_llama_prefill_embeddings_impl(
   XLA_CHECK_GOTO(
       iree_runtime_call_inputs_push_back_buffer_view(&call, embeddings_bv),
       cleanup, rc);
+  if (dense_ple_bv) {
+    XLA_CHECK_GOTO(
+        iree_runtime_call_inputs_push_back_buffer_view(&call, dense_ple_bv),
+        cleanup, rc);
+  }
   XLA_CHECK_GOTO(
       iree_runtime_call_inputs_push_back_buffer_view(&call, positions_bv),
       cleanup, rc);
@@ -873,6 +1022,7 @@ cleanup:
   if (kc) iree_hal_buffer_view_release(kc);
   if (vc) iree_hal_buffer_view_release(vc);
   if (embeddings_bv) iree_hal_buffer_view_release(embeddings_bv);
+  if (dense_ple_bv) iree_hal_buffer_view_release(dense_ple_bv);
   if (positions_bv) iree_hal_buffer_view_release(positions_bv);
   if (len_bv) iree_hal_buffer_view_release(len_bv);
   if (bias_bv) iree_hal_buffer_view_release(bias_bv);
@@ -885,7 +1035,7 @@ int xla_llama_prefill_embeddings(
     const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
     int32_t real_len, int32_t* out_token) {
   return xla_llama_prefill_embeddings_impl(
-      c, -1, embeddings, positions, attention_bias, real_len, 0, out_token,
+      c, -1, embeddings, NULL, positions, attention_bias, real_len, 0, out_token,
       NULL);
 }
 
@@ -894,8 +1044,28 @@ int xla_llama_prefill_embeddings_slot_logits(
     const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
     int32_t real_len, int32_t vocab, float* out_logits) {
   return xla_llama_prefill_embeddings_impl(
-      c, slot, embeddings, positions, attention_bias, real_len, vocab, NULL,
+      c, slot, embeddings, NULL, positions, attention_bias, real_len, vocab, NULL,
       out_logits);
+}
+
+int xla_llama_prefill_embeddings_ple(
+    xla_ctx* c, const xla_tensor_desc* embeddings,
+    const xla_tensor_desc* dense_ple, const xla_tensor_desc* positions,
+    const xla_tensor_desc* attention_bias, int32_t real_len,
+    int32_t* out_token) {
+  return xla_llama_prefill_embeddings_impl(
+      c, -1, embeddings, dense_ple, positions, attention_bias, real_len, 0,
+      out_token, NULL);
+}
+
+int xla_llama_prefill_embeddings_ple_slot_logits(
+    xla_ctx* c, int32_t slot, const xla_tensor_desc* embeddings,
+    const xla_tensor_desc* dense_ple, const xla_tensor_desc* positions,
+    const xla_tensor_desc* attention_bias, int32_t real_len, int32_t vocab,
+    float* out_logits) {
+  return xla_llama_prefill_embeddings_impl(
+      c, slot, embeddings, dense_ple, positions, attention_bias, real_len,
+      vocab, NULL, out_logits);
 }
 
 // Ragged decode_step: token[B], pos[B], cache_len[B] (per row), rank-5 KV ->

--- a/src/lib/mlxcel-xla/src/batch.rs
+++ b/src/lib/mlxcel-xla/src/batch.rs
@@ -40,10 +40,17 @@ use std::fmt;
 
 #[cfg(feature = "iree")]
 use mlxcel_core::session::PreparedPrefill;
+#[cfg(feature = "diagnostics")]
+use mlxcel_core::session::{
+    OwnedTensor, PreparedAttentionBias, PreparedPositions, PreparedTensorDType,
+};
 
 #[cfg(feature = "iree")]
 use std::path::Path;
 
+use crate::Gemma3nDensePle;
+#[cfg(feature = "iree")]
+use crate::Gemma3nPreparedPrefill;
 #[cfg(feature = "iree")]
 use crate::iree::{IreeLlama, IreeRaggedLlama};
 use crate::prepared::{PreparedInputError, PreparedIreePrefill};
@@ -59,6 +66,7 @@ pub enum XlaAdmissionError {
     ZeroMaxNewTokens,
     ContextCapacity(ContextCapacityError),
     Prepared(PreparedInputError),
+    Gemma3nPrepared(String),
 }
 
 impl fmt::Display for XlaAdmissionError {
@@ -68,6 +76,7 @@ impl fmt::Display for XlaAdmissionError {
             Self::ZeroMaxNewTokens => f.write_str("max_new_tokens must be >= 1"),
             Self::ContextCapacity(err) => err.fmt(f),
             Self::Prepared(err) => err.fmt(f),
+            Self::Gemma3nPrepared(err) => f.write_str(err),
         }
     }
 }
@@ -134,6 +143,10 @@ struct Slot {
 enum PendingInput {
     Tokens(Vec<i32>),
     Prepared(PreparedIreePrefill),
+    Gemma3nPrepared {
+        prepared: PreparedIreePrefill,
+        dense_ple: Gemma3nDensePle,
+    },
 }
 
 impl PendingInput {
@@ -141,6 +154,7 @@ impl PendingInput {
         match self {
             Self::Tokens(tokens) => tokens,
             Self::Prepared(prepared) => &prepared.token_ids,
+            Self::Gemma3nPrepared { prepared, .. } => &prepared.token_ids,
         }
     }
 
@@ -148,6 +162,7 @@ impl PendingInput {
         match self {
             Self::Tokens(tokens) => tokens.len(),
             Self::Prepared(prepared) => prepared.effective_len,
+            Self::Gemma3nPrepared { prepared, .. } => prepared.effective_len,
         }
     }
 }
@@ -232,11 +247,13 @@ impl Scheduler {
                 return true;
             }
         }
-        for p in &mut self.queue {
-            if p.req_id == req_id && !p.cancelled {
-                p.cancelled = true;
-                return true;
-            }
+        if let Some(index) = self
+            .queue
+            .iter()
+            .position(|pending| pending.req_id == req_id && !pending.cancelled)
+        {
+            self.queue.remove(index);
+            return true;
         }
         false
     }
@@ -301,6 +318,28 @@ fn queue_prepared_request(
     }
     validate_request_capacity(prepared.effective_len, max_new_tokens, context_capacity)?;
     Ok(sched.submit_input(PendingInput::Prepared(prepared), max_new_tokens, params))
+}
+
+fn queue_gemma3n_prepared_request(
+    sched: &mut Scheduler,
+    prepared: PreparedIreePrefill,
+    dense_ple: Gemma3nDensePle,
+    max_new_tokens: usize,
+    params: SampleParams,
+    context_capacity: usize,
+) -> Result<u64, XlaAdmissionError> {
+    if max_new_tokens == 0 {
+        return Err(XlaAdmissionError::ZeroMaxNewTokens);
+    }
+    validate_request_capacity(prepared.effective_len, max_new_tokens, context_capacity)?;
+    Ok(sched.submit_input(
+        PendingInput::Gemma3nPrepared {
+            prepared,
+            dense_ple,
+        },
+        max_new_tokens,
+        params,
+    ))
 }
 
 /// The continuous-batching engine: `B_max` slots over one ragged decode graph,
@@ -425,6 +464,32 @@ impl XlaBatchEngine {
         )
     }
 
+    /// Queue a Gemma3n embeddings-plus-dense-PLE request. Both allocations move
+    /// into the pending entry and are dropped immediately on cancellation or
+    /// after the slot is seeded.
+    pub fn submit_gemma3n_prepared(
+        &mut self,
+        request: Gemma3nPreparedPrefill,
+        max_new_tokens: usize,
+        params: SampleParams,
+    ) -> Result<u64, XlaAdmissionError> {
+        let context_capacity = self.context_capacity();
+        let (prepared, dense_ple) = request.into_parts();
+        self.engine
+            .validate_gemma3n_dense_ple(&dense_ple)
+            .map_err(XlaAdmissionError::Gemma3nPrepared)?;
+        let prepared =
+            PreparedIreePrefill::prepare(&prepared, self.engine.hidden_size(), context_capacity)?;
+        queue_gemma3n_prepared_request(
+            &mut self.sched,
+            prepared,
+            dense_ple,
+            max_new_tokens,
+            params,
+            context_capacity,
+        )
+    }
+
     /// Cancel a request by id (frees its slot or drops it from the queue).
     /// Returns whether it was found. A cancelled request emits no further events.
     pub fn cancel(&mut self, req_id: u64) -> bool {
@@ -461,6 +526,12 @@ impl XlaBatchEngine {
                 PendingInput::Prepared(prepared) => {
                     self.engine.prefill_prepared_slot_logits(s, prepared)?
                 }
+                PendingInput::Gemma3nPrepared {
+                    prepared,
+                    dense_ple,
+                } => self
+                    .engine
+                    .prefill_gemma3n_prepared_slot_logits(s, prepared, dense_ple)?,
             };
             let mut rng = resolve_seed(&p.params, p.req_id);
             // History-based penalties see the prompt plus generated tokens (the
@@ -543,6 +614,336 @@ impl XlaBatchEngine {
         }
         Ok(events)
     }
+}
+
+#[cfg(feature = "diagnostics")]
+#[derive(Debug)]
+pub struct Gemma3nCanonicalDiagnosticRun {
+    pub layout: crate::Gemma3nDiagnosticLayout,
+    pub intermediates: Vec<f32>,
+    pub token_prefill_logits: Vec<f32>,
+    pub prepared_prefill_logits: Vec<f32>,
+    pub prefix_decode_logits: Vec<f32>,
+    pub greedy_tokens: Vec<i32>,
+}
+
+#[cfg(feature = "diagnostics")]
+#[derive(Debug)]
+pub struct Gemma3nAllLayerDiagnosticRun {
+    pub layout: crate::Gemma3nDiagnosticLayout,
+    pub intermediates: Vec<f32>,
+}
+
+#[cfg(feature = "diagnostics")]
+#[derive(Debug)]
+pub struct Gemma3nPrefixDecodeDiagnosticRun {
+    pub active_slot: usize,
+    pub carrier_tokens: Vec<i32>,
+    pub carrier_positions: Vec<i32>,
+    pub carrier_cache_lengths: Vec<i32>,
+    pub logits: Vec<f32>,
+    pub top1: i32,
+}
+
+#[cfg(feature = "diagnostics")]
+fn diagnostic_argmax(values: &[f32]) -> i32 {
+    values
+        .iter()
+        .enumerate()
+        .max_by(|left, right| left.1.total_cmp(right.1))
+        .map_or(0, |(index, _)| index as i32)
+}
+
+#[cfg(feature = "diagnostics")]
+pub fn run_gemma3n_all_layer_diagnostics(
+    model_dir: &Path,
+    device: &str,
+    context_capacity: usize,
+    prompt: &[i32],
+) -> Result<Gemma3nAllLayerDiagnosticRun, String> {
+    const DIAGNOSTIC_SLOTS: usize = 4;
+    if prompt.is_empty() || prompt.len() > context_capacity {
+        return Err(format!(
+            "all-layer diagnostic prompt length {} must be in 1..={context_capacity}",
+            prompt.len()
+        ));
+    }
+    let mut engine = IreeRaggedLlama::load_with_all_layer_diagnostics(
+        model_dir,
+        device,
+        DIAGNOSTIC_SLOTS,
+        context_capacity,
+    )?;
+    let intermediates = engine.prefill_diagnostics_slot(0, prompt)?;
+    let layout = engine.diagnostic_layout()?.clone();
+    layout.validate()?;
+    if intermediates.len() != layout.total_len {
+        return Err(format!(
+            "all-layer diagnostic output has {} values, expected {}",
+            intermediates.len(),
+            layout.total_len
+        ));
+    }
+    Ok(Gemma3nAllLayerDiagnosticRun {
+        layout,
+        intermediates,
+    })
+}
+
+/// Seed exactly one fixed batch slot with a prefix, then execute one production
+/// ragged decode step with zero-valued carrier rows around it.
+///
+/// This bounded probe deliberately excludes the canonical diagnostic module,
+/// prepared-prefill parity, and greedy continuation. It exists to validate the
+/// actual production decode bundle after emitter/plumbing changes without
+/// consuming a canonical-oracle approval.
+#[cfg(feature = "diagnostics")]
+pub fn run_gemma3n_prefix_decode_diagnostic(
+    model_dir: &Path,
+    device: &str,
+    context_capacity: usize,
+    prompt: &[i32],
+) -> Result<Gemma3nPrefixDecodeDiagnosticRun, String> {
+    const DIAGNOSTIC_SLOTS: usize = 4;
+    const ACTIVE_SLOT: usize = DIAGNOSTIC_SLOTS - 1;
+    if prompt.len() < 2 || prompt.len() > context_capacity {
+        return Err(format!(
+            "prefix-decode diagnostic prompt length {} must be in 2..={context_capacity}",
+            prompt.len()
+        ));
+    }
+    let mut engine = IreeRaggedLlama::load(model_dir, device, DIAGNOSTIC_SLOTS, context_capacity)?;
+    let prefix = &prompt[..prompt.len() - 1];
+    let prefix_logits = engine.prefill_slot_logits(ACTIVE_SLOT, prefix)?;
+    if prefix_logits.len() != engine.vocab() {
+        return Err("prefix prefill returned an invalid vocabulary width".to_string());
+    }
+
+    let mut carrier_tokens = vec![0; DIAGNOSTIC_SLOTS];
+    let mut carrier_positions = vec![0; DIAGNOSTIC_SLOTS];
+    let mut carrier_cache_lengths = vec![0; DIAGNOSTIC_SLOTS];
+    carrier_tokens[ACTIVE_SLOT] = prompt[prompt.len() - 1];
+    let prefix_len =
+        i32::try_from(prefix.len()).map_err(|_| "prefix length does not fit i32".to_string())?;
+    carrier_positions[ACTIVE_SLOT] = prefix_len;
+    carrier_cache_lengths[ACTIVE_SLOT] = prefix_len;
+
+    let all_logits =
+        engine.decode_ragged_logits(&carrier_tokens, &carrier_positions, &carrier_cache_lengths)?;
+    let vocab = engine.vocab();
+    let start = ACTIVE_SLOT
+        .checked_mul(vocab)
+        .ok_or_else(|| "active decode row offset overflows".to_string())?;
+    let end = start
+        .checked_add(vocab)
+        .ok_or_else(|| "active decode row end overflows".to_string())?;
+    let logits = all_logits
+        .get(start..end)
+        .ok_or_else(|| "ragged decode returned a truncated active row".to_string())?
+        .to_vec();
+    let top1 = diagnostic_argmax(&logits);
+    Ok(Gemma3nPrefixDecodeDiagnosticRun {
+        active_slot: ACTIVE_SLOT,
+        carrier_tokens,
+        carrier_positions,
+        carrier_cache_lengths,
+        logits,
+        top1,
+    })
+}
+
+/// Execute the entire pinned Gemma3n oracle surface with one model load.
+///
+/// This symbol only exists behind the explicit `diagnostics` feature. Normal
+/// `iree` builds expose no raw-logit or intermediate-state diagnostic API and
+/// do not compile/load the optional diagnostic module.
+#[cfg(feature = "diagnostics")]
+pub fn run_gemma3n_canonical_diagnostics(
+    model_dir: &Path,
+    device: &str,
+    context_capacity: usize,
+    prompt: &[i32],
+    greedy_steps: usize,
+) -> Result<Gemma3nCanonicalDiagnosticRun, String> {
+    const DIAGNOSTIC_SLOTS: usize = 4;
+    if prompt.len() < 2 || prompt.len() >= context_capacity {
+        return Err(format!(
+            "canonical diagnostic prompt length {} must be in 2..{context_capacity}",
+            prompt.len()
+        ));
+    }
+    if greedy_steps == 0 || prompt.len().saturating_add(greedy_steps) > context_capacity {
+        return Err("canonical diagnostic greedy trajectory exceeds context capacity".to_string());
+    }
+    let mut engine = IreeRaggedLlama::load_with_diagnostics(
+        model_dir,
+        device,
+        DIAGNOSTIC_SLOTS,
+        context_capacity,
+    )?;
+    let intermediates = engine.prefill_diagnostics_slot(0, prompt)?;
+    let layout = engine.diagnostic_layout()?.clone();
+    layout.validate()?;
+    if intermediates.len() != layout.total_len {
+        return Err(format!(
+            "diagnostic output has {} values, expected {}",
+            intermediates.len(),
+            layout.total_len
+        ));
+    }
+    let embeddings_segment = layout
+        .segment("scaled_embeddings")
+        .ok_or_else(|| "diagnostic layout is missing scaled_embeddings".to_string())?;
+    let expected_embeddings_shape = [context_capacity, engine.hidden_size()];
+    if embeddings_segment.shape != expected_embeddings_shape {
+        return Err(format!(
+            "diagnostic scaled_embeddings shape {:?} does not match {:?}",
+            embeddings_segment.shape, expected_embeddings_shape
+        ));
+    }
+    let embeddings_len = prompt
+        .len()
+        .checked_mul(engine.hidden_size())
+        .ok_or_else(|| "diagnostic embedding prefix length overflows".to_string())?;
+    let embeddings_end = embeddings_segment
+        .offset
+        .checked_add(embeddings_len)
+        .ok_or_else(|| "diagnostic embedding range overflows".to_string())?;
+    let embeddings = intermediates
+        .get(embeddings_segment.offset..embeddings_end)
+        .ok_or_else(|| "diagnostic embedding prefix is truncated".to_string())?;
+    let prepared = PreparedPrefill::new(
+        prompt.to_vec(),
+        OwnedTensor::new(
+            embeddings
+                .iter()
+                .flat_map(|value| value.to_le_bytes())
+                .collect(),
+            PreparedTensorDType::Float32,
+            vec![1, prompt.len(), engine.hidden_size()],
+        )
+        .map_err(|error| error.to_string())?,
+        PreparedPositions::Sequential {
+            start: 0,
+            length: prompt.len(),
+        },
+        PreparedAttentionBias {
+            tensor: OwnedTensor::new(
+                vec![0; prompt.len() * std::mem::size_of::<f32>()],
+                PreparedTensorDType::Float32,
+                vec![1, 1, 1, prompt.len()],
+            )
+            .map_err(|error| error.to_string())?,
+            causal: true,
+        },
+        Vec::new(),
+    )
+    .map_err(|error| error.to_string())?;
+
+    let ple_segment = layout
+        .segment("projected_ple")
+        .ok_or_else(|| "diagnostic layout is missing projected_ple".to_string())?;
+    if ple_segment.shape.len() != 3 || ple_segment.shape[0] != context_capacity {
+        return Err(format!(
+            "diagnostic projected_ple shape {:?} is not [capacity, layers, hidden]",
+            ple_segment.shape
+        ));
+    }
+    let ple_row = ple_segment.shape[1]
+        .checked_mul(ple_segment.shape[2])
+        .ok_or_else(|| "diagnostic PLE row width overflows".to_string())?;
+    let ple_prefix_len = prompt
+        .len()
+        .checked_mul(ple_row)
+        .ok_or_else(|| "diagnostic PLE prefix length overflows".to_string())?;
+    let ple_end = ple_segment
+        .offset
+        .checked_add(ple_prefix_len)
+        .ok_or_else(|| "diagnostic PLE range overflows".to_string())?;
+    let ple_prefix = intermediates
+        .get(ple_segment.offset..ple_end)
+        .ok_or_else(|| "diagnostic PLE prefix is truncated".to_string())?;
+    let mut ple = vec![0.0; ple_segment.len];
+    ple[..ple_prefix.len()].copy_from_slice(ple_prefix);
+    let request = Gemma3nPreparedPrefill::new(
+        prepared,
+        Gemma3nDensePle::new(
+            ple,
+            context_capacity,
+            ple_segment.shape[1],
+            ple_segment.shape[2],
+        )
+        .map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())?;
+
+    let token_prefill_logits = engine.prefill_slot_logits(1, prompt)?;
+    let (prepared, dense_ple) = request.into_parts();
+    engine.validate_gemma3n_dense_ple(&dense_ple)?;
+    let prepared = PreparedIreePrefill::prepare(&prepared, engine.hidden_size(), context_capacity)
+        .map_err(|error| error.to_string())?;
+    let prepared_prefill_logits =
+        engine.prefill_gemma3n_prepared_slot_logits(2, &prepared, &dense_ple)?;
+    let prefix = &prompt[..prompt.len() - 1];
+    let prefix_logits = engine.prefill_slot_logits(3, prefix)?;
+    let diagnostic_logits_segment = layout
+        .segment("logits")
+        .ok_or_else(|| "diagnostic layout is missing logits".to_string())?;
+    let diagnostic_logits = &intermediates[diagnostic_logits_segment.offset
+        ..diagnostic_logits_segment.offset + diagnostic_logits_segment.len];
+
+    let mut tokens = vec![
+        diagnostic_argmax(diagnostic_logits),
+        diagnostic_argmax(&token_prefill_logits),
+        diagnostic_argmax(&prepared_prefill_logits),
+        prompt[prompt.len() - 1],
+    ];
+    let prompt_position =
+        i32::try_from(prompt.len()).map_err(|_| "prompt length does not fit i32".to_string())?;
+    let prefix_position =
+        i32::try_from(prefix.len()).map_err(|_| "prefix length does not fit i32".to_string())?;
+    let mut positions = vec![
+        prompt_position,
+        prompt_position,
+        prompt_position,
+        prefix_position,
+    ];
+    let first_decode = engine.decode_ragged_logits(&tokens, &positions, &positions)?;
+    let vocab = engine.vocab();
+    let prefix_decode_logits = first_decode[3 * vocab..4 * vocab].to_vec();
+    let mut greedy_tokens = vec![tokens[1]];
+    if greedy_steps > 1 {
+        tokens = first_decode
+            .chunks_exact(vocab)
+            .map(diagnostic_argmax)
+            .collect();
+        greedy_tokens.push(tokens[1]);
+    }
+    for _ in 2..greedy_steps {
+        for position in &mut positions {
+            *position += 1;
+        }
+        if positions
+            .iter()
+            .any(|position| *position < 0 || *position as usize >= context_capacity)
+        {
+            return Err("canonical diagnostic decode exceeded context capacity".to_string());
+        }
+        let logits = engine.decode_ragged_logits(&tokens, &positions, &positions)?;
+        tokens = logits.chunks_exact(vocab).map(diagnostic_argmax).collect();
+        greedy_tokens.push(tokens[1]);
+    }
+    if prefix_logits.len() != vocab {
+        return Err("prefix prefill returned an invalid vocabulary width".to_string());
+    }
+    Ok(Gemma3nCanonicalDiagnosticRun {
+        layout,
+        intermediates,
+        token_prefill_logits,
+        prepared_prefill_logits,
+        prefix_decode_logits,
+        greedy_tokens,
+    })
 }
 
 /// A single-sequence reference engine used to validate [`XlaBatchEngine`]: it
@@ -678,6 +1079,13 @@ mod tests {
         PreparedIreePrefill::prepare(&value, hidden, capacity).unwrap()
     }
 
+    fn gemma3n_input(tokens: Vec<i32>) -> PendingInput {
+        PendingInput::Gemma3nPrepared {
+            prepared: prepared_input(tokens, 2, 8),
+            dense_ple: Gemma3nDensePle::new(vec![0.0; 8 * 2 * 2], 8, 2, 2).unwrap(),
+        }
+    }
+
     #[test]
     fn submit_assigns_increasing_ids_and_queues() {
         let mut s = Scheduler::new(2, EOS.to_vec());
@@ -750,6 +1158,7 @@ mod tests {
         let prepared = prepared_input(vec![7, 8, 9], 2, 8);
         let multimodal =
             s.submit_input(PendingInput::Prepared(prepared), 8, SampleParams::greedy());
+        let gemma3n = s.submit_input(gemma3n_input(vec![10, 11]), 8, SampleParams::greedy());
 
         let first = s.pop_next_pending().unwrap();
         assert_eq!(first.req_id, text);
@@ -762,6 +1171,12 @@ mod tests {
         assert!(matches!(second.input, PendingInput::Prepared(_)));
         assert_eq!(second.input.logical_tokens(), &[7, 8, 9]);
         assert_eq!(second.input.effective_len(), 3);
+
+        let third = s.pop_next_pending().unwrap();
+        assert_eq!(third.req_id, gemma3n);
+        assert!(matches!(third.input, PendingInput::Gemma3nPrepared { .. }));
+        assert_eq!(third.input.logical_tokens(), &[10, 11]);
+        assert_eq!(third.input.effective_len(), 2);
     }
 
     #[test]
@@ -793,6 +1208,22 @@ mod tests {
 
         let reused = s.submit(vec![9], 2, g());
         assert_eq!(s.pop_next_pending().unwrap().req_id, reused);
+        assert_eq!(s.free_slots(), vec![0]);
+    }
+
+    #[test]
+    fn gemma3n_ple_is_removed_immediately_on_cancel_and_slot_can_be_reused() {
+        let mut s = Scheduler::new(1, EOS.to_vec());
+        let gemma = s.submit_input(gemma3n_input(vec![1, 2, 3]), 8, g());
+        assert_eq!(s.queue.len(), 1);
+        assert!(s.cancel(gemma));
+        assert!(
+            s.queue.is_empty(),
+            "cancellation must drop the request-owned PLE now, not at a later pump"
+        );
+
+        let replacement = s.submit(vec![9], 2, g());
+        assert_eq!(s.pop_next_pending().unwrap().req_id, replacement);
         assert_eq!(s.free_slots(), vec![0]);
     }
 

--- a/src/lib/mlxcel-xla/src/emitter/builder.rs
+++ b/src/lib/mlxcel-xla/src/emitter/builder.rs
@@ -630,6 +630,22 @@ impl Builder {
         self.unary("tanh", a)
     }
 
+    /// Error function from the CHLO extension accepted by StableHLO import.
+    /// Gemma3n's sparse GELU uses the exact erf form (the ordinary GeGLU path
+    /// deliberately keeps the tanh approximation).
+    pub fn erf(&mut self, a: &Val) -> Val {
+        let ty = a.ty.clone();
+        let r = self.fresh();
+        self.line(format!(
+            "{} = \"chlo.erf\"({}) : ({}) -> {}",
+            r,
+            a.name,
+            ty.render(),
+            ty.render()
+        ));
+        Val { name: r, ty }
+    }
+
     /// `compare DIR, a, b, SIGNED|FLOAT` -> i1 tensor of the same shape.
     pub fn compare(&mut self, dir: &str, a: &Val, b: &Val, kind: &str) -> Val {
         let ty = Ty::new(a.ty.shape.clone(), "i1");

--- a/src/lib/mlxcel-xla/src/emitter/builder.rs
+++ b/src/lib/mlxcel-xla/src/emitter/builder.rs
@@ -11,6 +11,8 @@
 
 use std::fmt::Write as _;
 
+use super::gemma3n::{checked_native_i32_dim, checked_native_i32_product};
+
 /// Tensor type: shape plus element type ("f32" | "i32" | "i1").
 #[derive(Clone, Debug)]
 pub struct Ty {
@@ -43,6 +45,15 @@ impl Ty {
 pub struct Val {
     pub name: String,
     pub ty: Ty,
+}
+
+fn native_dispatch_i32(name: &str, value: usize) -> i32 {
+    checked_native_i32_dim(name, value).unwrap_or_else(|error| panic!("{error}"))
+}
+
+fn native_dispatch_length(name: &str, dims: &[usize]) -> (usize, i32) {
+    let value = checked_native_i32_product(name, dims).unwrap_or_else(|error| panic!("{error}"));
+    (value as usize, value)
 }
 
 /// Contraction (matmul) input precision. `F32` is the default (unchanged
@@ -197,6 +208,7 @@ pub struct Builder {
     body: String,
     next: usize,
     precision: Precision,
+    gemma3n_qmv: bool,
 }
 
 fn dims_list(d: &[usize]) -> String {
@@ -226,6 +238,7 @@ impl Builder {
             body: String::new(),
             next: 0,
             precision: Precision::F32,
+            gemma3n_qmv: false,
         }
     }
 
@@ -234,6 +247,17 @@ impl Builder {
     pub fn with_precision(mut self, precision: Precision) -> Self {
         self.precision = precision;
         self
+    }
+
+    /// Enable the CUDA custom QMV dispatch used only by Gemma3n Q4 prefill.
+    #[must_use]
+    pub(crate) fn with_gemma3n_qmv(mut self, enabled: bool) -> Self {
+        self.gemma3n_qmv = enabled;
+        self
+    }
+
+    pub(crate) fn gemma3n_qmv_enabled(&self) -> bool {
+        self.gemma3n_qmv
     }
 
     /// The contraction precision this builder emits at (`F32` by default, else the
@@ -257,6 +281,403 @@ impl Builder {
         self.body.push_str("    ");
         self.body.push_str(&s);
         self.body.push('\n');
+    }
+
+    /// Dispatch the fixed-schedule CUDA Gemma3n QMV kernel.
+    ///
+    /// Inputs are f32 BF16 carriers. Rank-1 inputs are modeled as one row and
+    /// reshaped back after dispatch; rank-2 inputs preserve all M rows.
+    pub(crate) fn gemma3n_qmv(&mut self, input: &Val, weight: &Val) -> Val {
+        assert!(self.gemma3n_qmv, "Gemma3n QMV is not enabled");
+        assert_eq!(input.ty.elt, "f32");
+        assert_eq!(weight.ty.elt, "f32");
+        assert_eq!(weight.ty.shape.len(), 2);
+        let (input, rank_one) = match input.ty.shape.as_slice() {
+            [k] => (self.reshape(input, vec![1, *k]), true),
+            [_, _] => (input.clone(), false),
+            shape => panic!("Gemma3n QMV input must have rank 1 or 2, got {shape:?}"),
+        };
+        let m = input.ty.shape[0];
+        let k = input.ty.shape[1];
+        let n = weight.ty.shape[0];
+        assert_eq!(
+            weight.ty.shape[1], k,
+            "Gemma3n QMV contraction width mismatch"
+        );
+        let m_value = native_dispatch_i32("Gemma3n native QMV M", m);
+        let n_value = native_dispatch_i32("Gemma3n native QMV N", n);
+        let k_value = native_dispatch_i32("Gemma3n native QMV K", k);
+        let m_index = self.fresh();
+        self.line(format!("{m_index} = arith.constant {m} : index"));
+        let n_index = self.fresh();
+        self.line(format!("{n_index} = arith.constant {n} : index"));
+        let m_i32 = self.fresh();
+        self.line(format!("{m_i32} = arith.constant {m_value} : i32"));
+        let n_i32 = self.fresh();
+        self.line(format!("{n_i32} = arith.constant {n_value} : i32"));
+        let k_i32 = self.fresh();
+        self.line(format!("{k_i32} = arith.constant {k_value} : i32"));
+        let result = self.fresh();
+        let result_ty = Ty::f32(vec![m, n]);
+        self.line(format!(
+            "{result} = flow.dispatch @custom_qmv::@gemma3n_qmv[{n_index}, {m_index}]\
+             ({m_i32}, {n_i32}, {k_i32}, {input}, {weight}) : \
+             (i32, i32, i32, {input_ty}, {weight_ty}) -> {result_ty}",
+            input = input.name,
+            weight = weight.name,
+            input_ty = input.ty.render(),
+            weight_ty = weight.ty.render(),
+            result_ty = result_ty.render(),
+        ));
+        let output = Val {
+            name: result,
+            ty: result_ty,
+        };
+        if rank_one {
+            self.reshape(&output, vec![n])
+        } else {
+            output
+        }
+    }
+
+    /// Dispatch CUDA's `tanhf` for Gemma3n when the embedded native executable
+    /// is enabled, otherwise retain portable StableHLO tanh.
+    ///
+    /// MLX CUDA uses `cuda::std::tanh(float)`. IREE's generic StableHLO tanh
+    /// differs by an f32 ULP near zero, which is amplified by AltUp's f32
+    /// coefficient projection before the next BF16 boundary.
+    pub(crate) fn gemma3n_tanh(&mut self, input: &Val) -> Val {
+        if !self.gemma3n_qmv {
+            return self.tanh(input);
+        }
+        assert_eq!(input.ty.elt, "f32");
+        let shape = input.ty.shape.clone();
+        let (length, length_value) = native_dispatch_length("Gemma3n native tanh length", &shape);
+        let flat = if shape.len() == 1 {
+            input.clone()
+        } else {
+            self.reshape(input, vec![length])
+        };
+        let length_index = self.fresh();
+        self.line(format!("{length_index} = arith.constant {length} : index"));
+        let length_i32 = self.fresh();
+        self.line(format!(
+            "{length_i32} = arith.constant {length_value} : i32"
+        ));
+        let result = self.fresh();
+        let result_ty = Ty::f32(vec![length]);
+        self.line(format!(
+            "{result} = flow.dispatch @custom_qmv::@gemma3n_tanh[{length_index}]\
+             ({length_i32}, {input}) : (i32, {input_ty}) -> {result_ty}",
+            input = flat.name,
+            input_ty = flat.ty.render(),
+            result_ty = result_ty.render(),
+        ));
+        let output = Val {
+            name: result,
+            ty: result_ty,
+        };
+        if shape.len() == 1 {
+            output
+        } else {
+            self.reshape(&output, shape)
+        }
+    }
+
+    /// Dispatch the fixed-schedule TF32 coefficient projection used by
+    /// Gemma3n AltUp when the native CUDA executable is enabled.
+    pub(crate) fn gemma3n_altup_coeff(&mut self, input: &Val, weight: &Val) -> Val {
+        if !self.gemma3n_qmv {
+            return self.linear_seq(input, weight);
+        }
+        assert_eq!(input.ty.elt, "f32");
+        assert_eq!(weight.ty.elt, "f32");
+        assert_eq!(input.ty.shape.len(), 2);
+        assert_eq!(weight.ty.shape.len(), 2);
+        let rows = input.ty.shape[0];
+        let inner = input.ty.shape[1];
+        let output_width = weight.ty.shape[0];
+        assert_eq!(weight.ty.shape[1], inner);
+        let rows_value = native_dispatch_i32("Gemma3n native AltUp coefficient rows", rows);
+        let output_value = native_dispatch_i32(
+            "Gemma3n native AltUp coefficient output width",
+            output_width,
+        );
+        let inner_value =
+            native_dispatch_i32("Gemma3n native AltUp coefficient inner width", inner);
+        native_dispatch_length(
+            "Gemma3n native AltUp coefficient output length",
+            &[rows, output_width],
+        );
+        let rows_index = self.fresh();
+        self.line(format!("{rows_index} = arith.constant {rows} : index"));
+        let output_index = self.fresh();
+        self.line(format!(
+            "{output_index} = arith.constant {output_width} : index"
+        ));
+        let rows_i32 = self.fresh();
+        self.line(format!("{rows_i32} = arith.constant {rows_value} : i32"));
+        let output_i32 = self.fresh();
+        self.line(format!(
+            "{output_i32} = arith.constant {output_value} : i32"
+        ));
+        let inner_i32 = self.fresh();
+        self.line(format!("{inner_i32} = arith.constant {inner_value} : i32"));
+        let result = self.fresh();
+        let result_ty = Ty::f32(vec![rows, output_width]);
+        self.line(format!(
+            "{result} = flow.dispatch @custom_qmv::@gemma3n_altup_coeff\
+             [{rows_index}, {output_index}]({rows_i32}, {output_i32}, {inner_i32}, \
+             {input}, {weight}) : (i32, i32, i32, {input_ty}, {weight_ty}) -> {result_ty}",
+            input = input.name,
+            weight = weight.name,
+            input_ty = input.ty.render(),
+            weight_ty = weight.ty.render(),
+            result_ty = result_ty.render(),
+        ));
+        Val {
+            name: result,
+            ty: result_ty,
+        }
+    }
+
+    /// Reproduce MLX CUDA's FAST_TF32 batched AltUp prediction, residual add,
+    /// and BF16 output boundary when the native executable is enabled.
+    ///
+    /// `planes` is `[plane, row, hidden]`; `coefficients` is the transposed
+    /// reference layout `[row, source, target]`.
+    pub(crate) fn gemma3n_altup_predict(&mut self, planes: &Val, coefficients: &Val) -> Val {
+        assert_eq!(planes.ty.elt, "f32");
+        assert_eq!(coefficients.ty.elt, "f32");
+        assert_eq!(planes.ty.shape.len(), 3);
+        assert_eq!(coefficients.ty.shape.len(), 3);
+        let plane_count = planes.ty.shape[0];
+        let rows = planes.ty.shape[1];
+        let hidden = planes.ty.shape[2];
+        assert_eq!(coefficients.ty.shape, vec![rows, plane_count, plane_count]);
+
+        if !self.gemma3n_qmv {
+            let by_feature = self.transpose(planes, &[1, 2, 0]);
+            let delta = self.dot_general(
+                &by_feature,
+                coefficients,
+                &[0],
+                &[0],
+                &[2],
+                &[1],
+                vec![rows, hidden, plane_count],
+            );
+            let delta = self.transpose(&delta, &[2, 0, 1]);
+            let predicted = self.add(planes, &delta);
+            let predicted = self.convert(&predicted, "bf16");
+            return self.convert(&predicted, "f32");
+        }
+        assert_eq!(
+            plane_count, 4,
+            "native Gemma3n AltUp prediction requires four planes"
+        );
+
+        let plane_count_value =
+            native_dispatch_i32("Gemma3n native AltUp prediction plane count", plane_count);
+        let rows_value = native_dispatch_i32("Gemma3n native AltUp prediction rows", rows);
+        let hidden_value =
+            native_dispatch_i32("Gemma3n native AltUp prediction hidden width", hidden);
+        native_dispatch_length(
+            "Gemma3n native AltUp prediction plane size",
+            &[rows, hidden],
+        );
+        native_dispatch_length(
+            "Gemma3n native AltUp prediction length",
+            &[plane_count, rows, hidden],
+        );
+        let plane_count_index = self.fresh();
+        self.line(format!(
+            "{plane_count_index} = arith.constant {plane_count} : index"
+        ));
+        let rows_index = self.fresh();
+        self.line(format!("{rows_index} = arith.constant {rows} : index"));
+        let hidden_index = self.fresh();
+        self.line(format!("{hidden_index} = arith.constant {hidden} : index"));
+        let plane_count_i32 = self.fresh();
+        self.line(format!(
+            "{plane_count_i32} = arith.constant {plane_count_value} : i32"
+        ));
+        let rows_i32 = self.fresh();
+        self.line(format!("{rows_i32} = arith.constant {rows_value} : i32"));
+        let hidden_i32 = self.fresh();
+        self.line(format!(
+            "{hidden_i32} = arith.constant {hidden_value} : i32"
+        ));
+        let result = self.fresh();
+        let result_ty = Ty::f32(vec![plane_count, rows, hidden]);
+        self.line(format!(
+            "{result} = flow.dispatch @custom_qmv::@gemma3n_altup_predict\
+             [{plane_count_index}, {rows_index}, {hidden_index}]\
+             ({plane_count_i32}, {rows_i32}, {hidden_i32}, {planes}, {coefficients}) : \
+             (i32, i32, i32, {planes_ty}, {coefficients_ty}) -> {result_ty}",
+            planes = planes.name,
+            coefficients = coefficients.name,
+            planes_ty = planes.ty.render(),
+            coefficients_ty = coefficients.ty.render(),
+            result_ty = result_ty.render(),
+        ));
+        Val {
+            name: result,
+            ty: result_ty,
+        }
+    }
+
+    /// Dispatch MLX CUDA Compiled's BF16-typed GeGLU tape exactly.
+    pub(crate) fn gemma3n_geglu_bf16(&mut self, gate: &Val, up: &Val) -> Val {
+        assert_eq!(gate.ty.elt, up.ty.elt);
+        assert_eq!(gate.ty.shape, up.ty.shape);
+        assert_eq!(gate.ty.elt, "f32");
+        let shape = gate.ty.shape.clone();
+        let (length, length_value) = native_dispatch_length("Gemma3n native GeGLU length", &shape);
+        assert!(
+            self.gemma3n_qmv,
+            "native Gemma3n GeGLU requires the custom CUDA executable"
+        );
+
+        let flat_gate = if shape.len() == 1 {
+            gate.clone()
+        } else {
+            self.reshape(gate, vec![length])
+        };
+        let flat_up = if shape.len() == 1 {
+            up.clone()
+        } else {
+            self.reshape(up, vec![length])
+        };
+        let length_index = self.fresh();
+        self.line(format!("{length_index} = arith.constant {length} : index"));
+        let length_i32 = self.fresh();
+        self.line(format!(
+            "{length_i32} = arith.constant {length_value} : i32"
+        ));
+        let result = self.fresh();
+        let result_ty = Ty::f32(vec![length]);
+        self.line(format!(
+            "{result} = flow.dispatch @custom_qmv::@gemma3n_geglu_bf16[{length_index}]\
+             ({length_i32}, {gate}, {up}) : (i32, {gate_ty}, {up_ty}) -> {result_ty}",
+            gate = flat_gate.name,
+            up = flat_up.name,
+            gate_ty = flat_gate.ty.render(),
+            up_ty = flat_up.ty.render(),
+            result_ty = result_ty.render(),
+        ));
+        let output = Val {
+            name: result,
+            ty: result_ty,
+        };
+        if shape.len() == 1 {
+            output
+        } else {
+            self.reshape(&output, shape)
+        }
+    }
+
+    /// Dispatch the D=256 MLX vector-SDPA schedule for one decode query.
+    pub(crate) fn gemma3n_sdpa_vector(
+        &mut self,
+        query: &Val,
+        keys: &Val,
+        values: &Val,
+        position: &Val,
+        window: Option<usize>,
+        scale: f32,
+    ) -> Val {
+        assert!(
+            self.gemma3n_qmv,
+            "Gemma3n SDPA requires the custom CUDA executable"
+        );
+        assert_eq!(query.ty.elt, "f32");
+        assert_eq!(keys.ty.elt, "f32");
+        assert_eq!(values.ty.elt, "f32");
+        assert_eq!(query.ty.shape.len(), 2);
+        assert_eq!(keys.ty.shape.len(), 3);
+        assert_eq!(values.ty.shape, keys.ty.shape);
+        let query_heads = query.ty.shape[0];
+        let head_dim = query.ty.shape[1];
+        let capacity = keys.ty.shape[0];
+        let kv_heads = keys.ty.shape[1];
+        assert_eq!(position.ty.elt, "i32");
+        assert!(position.ty.shape.is_empty());
+        assert_eq!(head_dim, 256, "native SDPA requires D=256");
+        assert_eq!(keys.ty.shape[2], head_dim);
+        assert!(query_heads > 0 && kv_heads > 0);
+        assert!(query_heads.is_multiple_of(kv_heads));
+        assert!(capacity > 0);
+        assert!(
+            capacity <= 1024,
+            "native SDPA supports cache capacity <=1024"
+        );
+        let window = window.unwrap_or(0);
+        assert!(window <= i32::MAX as usize);
+        assert!(
+            window == 0 || window >= capacity,
+            "native SDPA does not support truncated sliding-window masks"
+        );
+        assert!(
+            scale.is_finite() && scale > 0.0,
+            "native SDPA requires a finite positive scale"
+        );
+
+        let query_heads_value =
+            native_dispatch_i32("Gemma3n SDPA diagnostic query heads", query_heads);
+        let kv_heads_value = native_dispatch_i32("Gemma3n SDPA diagnostic KV heads", kv_heads);
+        let capacity_value = native_dispatch_i32("Gemma3n SDPA diagnostic capacity", capacity);
+        let window_value = window as i32;
+        let query_heads_index = self.fresh();
+        self.line(format!(
+            "{query_heads_index} = arith.constant {query_heads} : index"
+        ));
+        let query_heads_i32 = self.fresh();
+        self.line(format!(
+            "{query_heads_i32} = arith.constant {query_heads_value} : i32"
+        ));
+        let kv_heads_i32 = self.fresh();
+        self.line(format!(
+            "{kv_heads_i32} = arith.constant {kv_heads_value} : i32"
+        ));
+        let capacity_i32 = self.fresh();
+        self.line(format!(
+            "{capacity_i32} = arith.constant {capacity_value} : i32"
+        ));
+        let position_i32 = self.fresh();
+        self.line(format!(
+            "{position_i32} = tensor.extract {position}[] : tensor<i32>",
+            position = position.name,
+        ));
+        let window_i32 = self.fresh();
+        self.line(format!(
+            "{window_i32} = arith.constant {window_value} : i32"
+        ));
+        let scale_i32 = self.fresh();
+        let scale_bits = scale.to_bits() as i32;
+        self.line(format!("{scale_i32} = arith.constant {scale_bits} : i32"));
+
+        let result = self.fresh();
+        let result_ty = Ty::f32(vec![query_heads, head_dim]);
+        self.line(format!(
+            "{result} = flow.dispatch \
+             @custom_qmv::@gemma3n_sdpa_vector[{query_heads_index}]\
+             ({query_heads_i32}, {kv_heads_i32}, {capacity_i32}, {position_i32}, \
+             {window_i32}, {scale_i32}, {query}, {keys}, {values}) : \
+             (i32, i32, i32, i32, i32, i32, {query_ty}, {keys_ty}, {values_ty}) -> \
+             {result_ty}",
+            query = query.name,
+            keys = keys.name,
+            values = values.name,
+            query_ty = query.ty.render(),
+            keys_ty = keys.ty.render(),
+            values_ty = values.ty.render(),
+            result_ty = result_ty.render(),
+        ));
+        Val {
+            name: result,
+            ty: result_ty,
+        }
     }
 
     /// Construct a handle to an existing func argument (not emitted).
@@ -626,6 +1047,9 @@ impl Builder {
     pub fn rsqrt(&mut self, a: &Val) -> Val {
         self.unary("rsqrt", a)
     }
+    pub fn sqrt(&mut self, a: &Val) -> Val {
+        self.unary("sqrt", a)
+    }
     pub fn tanh(&mut self, a: &Val) -> Val {
         self.unary("tanh", a)
     }
@@ -973,6 +1397,29 @@ mod tests {
         assert!(packed_runs_on("cuda", true));
         assert!(packed_runs_on("local-task", true));
         assert!(packed_runs_on("local-sync", true));
+    }
+
+    #[test]
+    fn native_dispatch_i32_preflight_rejects_dimensions_and_products() {
+        assert_eq!(
+            checked_native_i32_dim("dimension", i32::MAX as usize).unwrap(),
+            i32::MAX
+        );
+        assert!(
+            checked_native_i32_dim("dimension", i32::MAX as usize + 1)
+                .unwrap_err()
+                .contains("exceeds the signed i32 dispatch maximum")
+        );
+        assert!(
+            checked_native_i32_product("length", &[i32::MAX as usize, 2])
+                .unwrap_err()
+                .contains("exceeds the signed i32 dispatch maximum")
+        );
+        assert!(
+            checked_native_i32_product("length", &[usize::MAX, 2])
+                .unwrap_err()
+                .contains("overflow usize")
+        );
     }
 
     /// 4-bit affine dequant-in-graph (issue #516): a `[out, in_packed]` ui32 weight

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n.rs
@@ -14,9 +14,20 @@ pub(crate) enum Gemma3nLayerType {
     Sliding,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Gemma3nKvCacheContract {
+    /// Stable public cache axis order: the concrete layer indices in checkpoint
+    /// order, independent of the number of logical shared layers.
+    pub physical_layers: Vec<usize>,
+    /// Logical layer index to the physical cache axis read by both prefill and
+    /// decode.
+    pub logical_to_physical: Vec<usize>,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct Gemma3nConfig {
     pub context_capacity: usize,
+    pub max_position_embeddings: usize,
     pub hidden: usize,
     pub intermediate: Vec<usize>,
     pub n_layers: usize,
@@ -32,11 +43,11 @@ pub(crate) struct Gemma3nConfig {
     pub sliding_window: usize,
     pub rope_theta: f64,
     pub rope_local_base: f64,
-    pub final_logit_softcap: f32,
+    pub final_logit_softcap: Option<f32>,
     pub num_kv_shared_layers: usize,
     pub altup_num_inputs: usize,
     pub altup_active_idx: usize,
-    pub altup_coef_clip: f32,
+    pub altup_coef_clip: Option<f32>,
     pub altup_correct_scale: bool,
     pub laurel_rank: usize,
     pub tie_word_embeddings: bool,
@@ -66,13 +77,26 @@ impl Gemma3nConfig {
         let u = |key: &str| -> Result<usize, String> {
             text.get(key)
                 .and_then(serde_json::Value::as_u64)
-                .map(|v| v as usize)
+                .map(|v| {
+                    usize::try_from(v)
+                        .map_err(|_| format!("Gemma3n text_config integer `{key}` overflows usize"))
+                })
+                .transpose()?
                 .ok_or_else(|| format!("Gemma3n text_config missing integer `{key}`"))
         };
         let f = |key: &str| -> Result<f64, String> {
             text.get(key)
                 .and_then(serde_json::Value::as_f64)
                 .ok_or_else(|| format!("Gemma3n text_config missing number `{key}`"))
+        };
+        let optional_f = |key: &str| -> Result<Option<f64>, String> {
+            match text.get(key) {
+                None | Some(serde_json::Value::Null) => Ok(None),
+                Some(value) => value
+                    .as_f64()
+                    .map(Some)
+                    .ok_or_else(|| format!("Gemma3n text_config `{key}` must be numeric or null")),
+            }
         };
         let b = |key: &str| -> Result<bool, String> {
             text.get(key)
@@ -87,7 +111,11 @@ impl Gemma3nConfig {
                 .iter()
                 .map(|v| {
                     v.as_u64()
-                        .map(|n| n as usize)
+                        .map(|n| {
+                            usize::try_from(n)
+                                .map_err(|_| format!("Gemma3n `{key}` integer overflows usize"))
+                        })
+                        .transpose()?
                         .ok_or_else(|| format!("Gemma3n `{key}` must contain integers"))
                 })
                 .collect()
@@ -95,24 +123,28 @@ impl Gemma3nConfig {
         let intermediate = match text.get("intermediate_size") {
             Some(serde_json::Value::Array(_)) => vec_usize("intermediate_size")?,
             Some(v) => vec![
-                v.as_u64()
-                    .ok_or("Gemma3n intermediate_size must be an integer or array")?
-                    as usize;
+                usize::try_from(
+                    v.as_u64()
+                        .ok_or("Gemma3n intermediate_size must be an integer or array")?,
+                )
+                .map_err(|_| "Gemma3n intermediate_size overflows usize")?;
                 n_layers
             ],
             None => return Err("Gemma3n text_config missing `intermediate_size`".to_string()),
         };
-        let activation_sparsity: Vec<f32> = text
-            .get("activation_sparsity_pattern")
-            .and_then(serde_json::Value::as_array)
-            .ok_or("Gemma3n text_config missing array `activation_sparsity_pattern`")?
-            .iter()
-            .map(|v| {
-                v.as_f64()
-                    .map(|n| n as f32)
-                    .ok_or_else(|| "Gemma3n activation sparsity must be numeric".to_string())
-            })
-            .collect::<Result<_, _>>()?;
+        let activation_sparsity: Vec<f32> = match text.get("activation_sparsity_pattern") {
+            None | Some(serde_json::Value::Null) => vec![0.0; n_layers],
+            Some(value) => value
+                .as_array()
+                .ok_or("Gemma3n activation_sparsity_pattern must be an array or null")?
+                .iter()
+                .map(|v| {
+                    v.as_f64()
+                        .map(|n| n as f32)
+                        .ok_or_else(|| "Gemma3n activation sparsity must be numeric".to_string())
+                })
+                .collect::<Result<_, _>>()?,
+        };
         let layer_types: Vec<Gemma3nLayerType> = text
             .get("layer_types")
             .and_then(serde_json::Value::as_array)
@@ -128,6 +160,7 @@ impl Gemma3nConfig {
         let quantization = parse_quantization(&root, text)?;
         let cfg = Self {
             context_capacity: crate::DEFAULT_CONTEXT_CAPACITY,
+            max_position_embeddings: u("max_position_embeddings")?,
             hidden: u("hidden_size")?,
             intermediate,
             n_layers,
@@ -143,11 +176,11 @@ impl Gemma3nConfig {
             sliding_window: u("sliding_window")?,
             rope_theta: f("rope_theta")?,
             rope_local_base: f("rope_local_base_freq")?,
-            final_logit_softcap: f("final_logit_softcapping")? as f32,
+            final_logit_softcap: optional_f("final_logit_softcapping")?.map(|value| value as f32),
             num_kv_shared_layers: u("num_kv_shared_layers")?,
             altup_num_inputs: u("altup_num_inputs")?,
             altup_active_idx: u("altup_active_idx")?,
-            altup_coef_clip: f("altup_coef_clip")? as f32,
+            altup_coef_clip: optional_f("altup_coef_clip")?.map(|value| value as f32),
             altup_correct_scale: b("altup_correct_scale")?,
             laurel_rank: u("laurel_rank")?,
             tie_word_embeddings: text
@@ -169,10 +202,54 @@ impl Gemma3nConfig {
 
     pub(crate) fn with_context_capacity(mut self, capacity: usize) -> Result<Self, String> {
         self.context_capacity = crate::context::validate_context_capacity_value(capacity)?;
+        self.validate()?;
         Ok(self)
     }
 
     fn validate(&self) -> Result<(), String> {
+        if self.n_layers == 0
+            || self.hidden == 0
+            || self.head_dim == 0
+            || !self.head_dim.is_multiple_of(2)
+            || self.vocab == 0
+            || self.per_layer_vocab == 0
+            || self.hidden_per_layer_input == 0
+            || self.sliding_window == 0
+            || self.laurel_rank == 0
+            || self.intermediate.contains(&0)
+        {
+            return Err(
+                "Gemma3n dimensions, vocabularies, sliding window, and intermediate widths \
+                 must be nonzero, and head_dim must be even"
+                    .into(),
+            );
+        }
+        if self.max_position_embeddings == 0 || self.context_capacity > self.max_position_embeddings
+        {
+            return Err(format!(
+                "Gemma3n context_capacity={} exceeds max_position_embeddings={}",
+                self.context_capacity, self.max_position_embeddings
+            ));
+        }
+        if !self.eps.is_finite()
+            || self.eps <= 0.0
+            || !self.rope_theta.is_finite()
+            || self.rope_theta <= 0.0
+            || !self.rope_local_base.is_finite()
+            || self.rope_local_base <= 0.0
+            || self
+                .final_logit_softcap
+                .is_some_and(|value| !value.is_finite() || value <= 0.0)
+            || self
+                .altup_coef_clip
+                .is_some_and(|value| !value.is_finite() || value < 0.0)
+        {
+            return Err(
+                "Gemma3n RMS epsilon, RoPE bases, and optional logit softcap must be finite \
+                 and positive; optional AltUp clip must be finite and nonnegative"
+                    .into(),
+            );
+        }
         if self.intermediate.len() != self.n_layers
             || self.layer_types.len() != self.n_layers
             || self.activation_sparsity.len() != self.n_layers
@@ -207,9 +284,6 @@ impl Gemma3nConfig {
         if self.per_layer_vocab > self.vocab {
             return Err("Gemma3n per-layer vocab cannot exceed token vocab".into());
         }
-        if self.hidden == 0 || self.hidden_per_layer_input == 0 || self.laurel_rank == 0 {
-            return Err("Gemma3n hidden, per-layer hidden, and LAUREL rank must be nonzero".into());
-        }
         if self
             .activation_sparsity
             .iter()
@@ -227,14 +301,44 @@ impl Gemma3nConfig {
                 ));
             }
         }
-        if self.quantization.is_some_and(|q| {
-            !matches!(q.bits, 4 | 8)
-                || q.group_size == 0
-                || !self.hidden.is_multiple_of(q.group_size)
-        }) {
-            return Err(
-                "Gemma3n quantization requires 4/8 bits and a hidden-aligned group_size".into(),
-            );
+        let ple_width = self
+            .n_layers
+            .checked_mul(self.hidden_per_layer_input)
+            .ok_or("Gemma3n dense PLE width overflows usize")?;
+        let attention_width = self
+            .n_q
+            .checked_mul(self.head_dim)
+            .ok_or("Gemma3n attention width overflows usize")?;
+        self.context_capacity
+            .checked_mul(2)
+            .ok_or("Gemma3n shared-query RoPE capacity overflows usize")?;
+        if let Some(q) = self.quantization {
+            if !matches!(q.bits, 4 | 8) || q.group_size == 0 {
+                return Err(
+                    "Gemma3n quantization requires 4/8 bits and a nonzero group_size".into(),
+                );
+            }
+            let incompatible = [
+                ("hidden_size", self.hidden),
+                ("attention output", attention_width),
+                ("LAUREL rank", self.laurel_rank),
+                ("per-layer input", self.hidden_per_layer_input),
+                ("dense PLE row", ple_width),
+            ]
+            .into_iter()
+            .chain(
+                self.intermediate
+                    .iter()
+                    .copied()
+                    .map(|width| ("MLP intermediate", width)),
+            )
+            .find(|(_, width)| !width.is_multiple_of(q.group_size));
+            if let Some((name, width)) = incompatible {
+                return Err(format!(
+                    "Gemma3n quantization group_size={} does not divide {name} width {width}",
+                    q.group_size
+                ));
+            }
         }
         if !self.tie_word_embeddings {
             return Err(
@@ -244,11 +348,100 @@ impl Gemma3nConfig {
         Ok(())
     }
 
+    /// Prove every dimension and flattened length passed to the native CUDA
+    /// Gemma3n executable fits its signed 32-bit scalar ABI.
+    ///
+    /// This is called before native-QMV graph emission. The builder repeats the
+    /// checks at each dispatch site so diagnostics and direct emitter tests
+    /// cannot bypass the runtime preflight.
+    pub(crate) fn validate_native_cuda_dispatches(&self) -> Result<(), String> {
+        let rows = self.context_capacity;
+        let planes = self.altup_num_inputs;
+        let ple_width = self
+            .n_layers
+            .checked_mul(self.hidden_per_layer_input)
+            .ok_or("Gemma3n native CUDA dense PLE width overflows usize")?;
+        let attention_width = self
+            .n_q
+            .checked_mul(self.head_dim)
+            .ok_or("Gemma3n native CUDA attention width overflows usize")?;
+        let kv_width = self
+            .n_kv
+            .checked_mul(self.head_dim)
+            .ok_or("Gemma3n native CUDA KV width overflows usize")?;
+        let prediction_width = planes
+            .checked_mul(planes)
+            .ok_or("Gemma3n native CUDA AltUp coefficient width overflows usize")?;
+
+        // Kernels that flatten their launch space into a signed int index.
+        checked_native_i32_product("Gemma3n native CUDA router tanh length", &[rows, planes])?;
+        if self.final_logit_softcap.is_some() {
+            checked_native_i32_dim("Gemma3n native CUDA logit tanh length", self.vocab)?;
+        }
+        for (layer, &width) in self.intermediate.iter().enumerate() {
+            checked_native_i32_product(
+                &format!("Gemma3n native CUDA layer {layer} MLP GeLU length"),
+                &[rows, width],
+            )?;
+        }
+        checked_native_i32_product(
+            "Gemma3n native CUDA AltUp prediction coefficient length",
+            &[rows, prediction_width],
+        )?;
+        checked_native_i32_product(
+            "Gemma3n native CUDA AltUp correction coefficient length",
+            &[rows, planes],
+        )?;
+        checked_native_i32_product(
+            "Gemma3n native CUDA AltUp prediction plane size",
+            &[rows, self.hidden],
+        )?;
+        checked_native_i32_product(
+            "Gemma3n native CUDA AltUp prediction length",
+            &[planes, rows, self.hidden],
+        )?;
+        checked_native_i32_product(
+            "Gemma3n native CUDA GeGLU length",
+            &[rows, self.hidden_per_layer_input],
+        )?;
+
+        // Every M/N/K scalar that can reach the native QMV ABI. Products are
+        // indexed with int64_t inside QMV; each dimension and launch grid axis
+        // still has to fit the signed i32 constants accepted by the kernel.
+        for (name, value) in [
+            ("row count", rows),
+            ("hidden width", self.hidden),
+            ("vocabulary width", self.vocab),
+            ("dense PLE width", ple_width),
+            ("attention width", attention_width),
+            ("KV width", kv_width),
+            ("AltUp plane width", planes),
+            ("AltUp coefficient width", prediction_width),
+            ("LAUREL rank", self.laurel_rank),
+            ("per-layer input width", self.hidden_per_layer_input),
+        ]
+        .into_iter()
+        .chain(
+            self.intermediate
+                .iter()
+                .copied()
+                .map(|width| ("MLP intermediate width", width)),
+        ) {
+            checked_native_i32_dim(&format!("Gemma3n native CUDA QMV {name}"), value)?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn kv_cache_layers(&self) -> usize {
         self.n_layers - self.num_kv_shared_layers
     }
 
     pub(crate) fn layer_to_cache(&self) -> Result<Vec<usize>, String> {
+        self.kv_cache_contract()
+            .map(|contract| contract.logical_to_physical)
+    }
+
+    pub(crate) fn kv_cache_contract(&self) -> Result<Gemma3nKvCacheContract, String> {
         let concrete = self.kv_cache_layers();
         let mut last_full = None;
         let mut last_sliding = None;
@@ -272,7 +465,10 @@ impl Gemma3nConfig {
                 );
             }
         }
-        Ok(out)
+        Ok(Gemma3nKvCacheContract {
+            physical_layers: (0..concrete).collect(),
+            logical_to_physical: out,
+        })
     }
 
     pub(crate) fn dense_ple_shape(&self) -> [usize; 3] {
@@ -285,11 +481,12 @@ impl Gemma3nConfig {
 
     pub(crate) fn compatibility_fingerprint(&self) -> String {
         format!(
-            "gemma3n:h{}:i{:?}:l{}:q{}:kv{}:d{}:eps{:x}:v{}:pv{}:ph{}:lt{:?}:sp{:?}:\
-             sw{}:rt{:x}:rl{:x}:sc{:x}:shared{}:alt{}:{}:{:x}:{}:laurel{}:tie{}:q{:?}:c{}",
+            "gemma3n:bf16-stream-f32-altup-v1:h{}:i{:?}:l{}:mp{}:q{}:kv{}:d{}:eps{:x}:v{}:pv{}:ph{}:lt{:?}:sp{:?}:\
+             sw{}:rt{:x}:rl{:x}:sc{:?}:shared{}:alt{}:{}:{:?}:{}:laurel{}:tie{}:q{:?}:c{}",
             self.hidden,
             self.intermediate,
             self.n_layers,
+            self.max_position_embeddings,
             self.n_q,
             self.n_kv,
             self.head_dim,
@@ -305,11 +502,11 @@ impl Gemma3nConfig {
             self.sliding_window,
             self.rope_theta.to_bits(),
             self.rope_local_base.to_bits(),
-            self.final_logit_softcap.to_bits(),
+            self.final_logit_softcap.map(f32::to_bits),
             self.num_kv_shared_layers,
             self.altup_num_inputs,
             self.altup_active_idx,
-            self.altup_coef_clip.to_bits(),
+            self.altup_coef_clip.map(f32::to_bits),
             self.altup_correct_scale,
             self.laurel_rank,
             self.tie_word_embeddings,
@@ -319,21 +516,40 @@ impl Gemma3nConfig {
     }
 }
 
+pub(crate) fn checked_native_i32_dim(name: &str, value: usize) -> Result<i32, String> {
+    i32::try_from(value)
+        .map_err(|_| format!("{name} {value} exceeds the signed i32 dispatch maximum"))
+}
+
+pub(crate) fn checked_native_i32_product(name: &str, dims: &[usize]) -> Result<i32, String> {
+    let value = dims.iter().try_fold(1usize, |value, &dim| {
+        value
+            .checked_mul(dim)
+            .ok_or_else(|| format!("{name} dimensions {dims:?} overflow usize"))
+    })?;
+    checked_native_i32_dim(name, value)
+}
+
 fn parse_quantization(
     root: &serde_json::Value,
     text: &serde_json::Value,
 ) -> Result<Option<QuantConfig>, String> {
-    let value = root
+    // Match the MLX loader: the text-backbone contract is authoritative when
+    // both the multimodal root and nested text config carry quantization.
+    let value = text
         .get("quantization")
-        .or_else(|| text.get("quantization"));
-    let Some(q) = value.filter(|v| !v.is_null()) else {
+        .filter(|v| !v.is_null())
+        .or_else(|| root.get("quantization").filter(|v| !v.is_null()));
+    let Some(q) = value else {
         return Ok(None);
     };
     let number = |key: &str| {
-        q.get(key)
+        let value = q
+            .get(key)
             .and_then(serde_json::Value::as_u64)
-            .map(|v| v as usize)
-            .ok_or_else(|| format!("Gemma3n quantization missing integer `{key}`"))
+            .ok_or_else(|| format!("Gemma3n quantization missing integer `{key}`"))?;
+        usize::try_from(value)
+            .map_err(|_| format!("Gemma3n quantization integer `{key}` overflows usize"))
     };
     Ok(Some(QuantConfig {
         bits: number("bits")?,
@@ -396,10 +612,11 @@ mod tests {
     fn tiny_config() -> String {
         serde_json::json!({
             "model_type": "gemma3n",
-            "quantization": {"bits": 4, "group_size": 4},
+            "quantization": {"bits": 4, "group_size": 2},
             "text_config": {
                 "model_type": "gemma3n_text",
                 "hidden_size": 8,
+                "max_position_embeddings": 4096,
                 "intermediate_size": [16, 16, 16, 16],
                 "num_hidden_layers": 4,
                 "num_attention_heads": 2,
@@ -433,18 +650,52 @@ mod tests {
     #[test]
     fn parses_nested_contract_and_maps_shared_kv_by_attention_kind() {
         let cfg = Gemma3nConfig::from_json_str(&tiny_config()).unwrap();
-        assert_eq!(cfg.kv_cache_layers(), 2);
-        assert_eq!(cfg.layer_to_cache().unwrap(), vec![0, 1, 0, 1]);
+        let cache = cfg.kv_cache_contract().unwrap();
+        assert_eq!(cache.physical_layers, vec![0, 1]);
+        assert_eq!(cache.logical_to_physical, vec![0, 1, 0, 1]);
+        assert_eq!(cfg.layer_to_cache().unwrap(), cache.logical_to_physical);
         assert_eq!(
             cfg.quantization,
             Some(QuantConfig {
                 bits: 4,
-                group_size: 4
+                group_size: 2
             })
         );
         assert_eq!(
             cfg.dense_ple_shape(),
             [crate::DEFAULT_CONTEXT_CAPACITY, 4, 2]
+        );
+    }
+
+    #[test]
+    fn nested_text_quantization_overrides_multimodal_root() {
+        let mut value: serde_json::Value = serde_json::from_str(&tiny_config()).unwrap();
+        value["quantization"] = serde_json::json!({"bits": 8, "group_size": 2});
+        value["text_config"]["quantization"] = serde_json::json!({"bits": 4, "group_size": 2});
+
+        let cfg = Gemma3nConfig::from_json_str(&value.to_string()).unwrap();
+        assert_eq!(
+            cfg.quantization,
+            Some(QuantConfig {
+                bits: 4,
+                group_size: 2
+            })
+        );
+    }
+
+    #[test]
+    fn null_nested_quantization_falls_back_to_multimodal_root() {
+        let mut value: serde_json::Value = serde_json::from_str(&tiny_config()).unwrap();
+        value["quantization"] = serde_json::json!({"bits": 4, "group_size": 2});
+        value["text_config"]["quantization"] = serde_json::Value::Null;
+
+        let cfg = Gemma3nConfig::from_json_str(&value.to_string()).unwrap();
+        assert_eq!(
+            cfg.quantization,
+            Some(QuantConfig {
+                bits: 4,
+                group_size: 2
+            })
         );
     }
 
@@ -462,6 +713,81 @@ mod tests {
         assert_ne!(
             base.compatibility_fingerprint(),
             changed.compatibility_fingerprint()
+        );
+        changed = base.clone();
+        changed.max_position_embeddings += 1;
+        assert_ne!(
+            base.compatibility_fingerprint(),
+            changed.compatibility_fingerprint()
+        );
+        changed = base.clone();
+        changed.final_logit_softcap = None;
+        assert_ne!(
+            base.compatibility_fingerprint(),
+            changed.compatibility_fingerprint()
+        );
+        changed = base.clone();
+        changed.altup_coef_clip = None;
+        assert_ne!(
+            base.compatibility_fingerprint(),
+            changed.compatibility_fingerprint()
+        );
+    }
+
+    #[test]
+    fn native_cuda_dispatch_preflight_rejects_each_signed_product_boundary() {
+        let base = Gemma3nConfig::from_json_str(&tiny_config())
+            .unwrap()
+            .with_context_capacity(2)
+            .unwrap();
+        base.validate_native_cuda_dispatches().unwrap();
+
+        let mut qmv = base.clone();
+        qmv.final_logit_softcap = None;
+        qmv.vocab = i32::MAX as usize + 1;
+        assert!(
+            qmv.validate_native_cuda_dispatches()
+                .unwrap_err()
+                .contains("QMV vocabulary width")
+        );
+
+        let mut tanh = base.clone();
+        tanh.intermediate[0] = i32::MAX as usize;
+        assert!(
+            tanh.validate_native_cuda_dispatches()
+                .unwrap_err()
+                .contains("layer 0 MLP GeLU length")
+        );
+
+        let mut coefficients = base.clone();
+        coefficients.context_capacity = 1;
+        coefficients.altup_num_inputs = 46_341;
+        assert!(
+            coefficients
+                .validate_native_cuda_dispatches()
+                .unwrap_err()
+                .contains("prediction coefficient length")
+        );
+
+        let mut prediction = base.clone();
+        prediction.context_capacity = i32::MAX as usize / (2 * prediction.hidden) + 1;
+        prediction.altup_num_inputs = 2;
+        prediction.intermediate.fill(1);
+        prediction.final_logit_softcap = None;
+        assert!(
+            prediction
+                .validate_native_cuda_dispatches()
+                .unwrap_err()
+                .contains("AltUp prediction length")
+        );
+
+        let mut geglu = base;
+        geglu.hidden_per_layer_input = i32::MAX as usize / 2 + 1;
+        assert!(
+            geglu
+                .validate_native_cuda_dispatches()
+                .unwrap_err()
+                .contains("GeGLU length")
         );
     }
 
@@ -504,5 +830,65 @@ mod tests {
                 .unwrap_err()
                 .contains("per-layer arrays")
         );
+    }
+
+    #[test]
+    fn invalid_context_numeric_and_quantization_contracts_fail_early() {
+        let base = tiny_config();
+        let too_short = base.replacen(
+            "\"max_position_embeddings\":4096",
+            "\"max_position_embeddings\":128",
+            1,
+        );
+        assert!(
+            Gemma3nConfig::from_json_str(&too_short)
+                .unwrap_err()
+                .contains("exceeds max_position_embeddings")
+        );
+
+        let zero_eps = base.replacen("\"rms_norm_eps\":1e-6", "\"rms_norm_eps\":0.0", 1);
+        assert!(
+            Gemma3nConfig::from_json_str(&zero_eps)
+                .unwrap_err()
+                .contains("finite and positive")
+        );
+
+        let bad_group = base.replacen("\"group_size\":2", "\"group_size\":3", 1);
+        assert!(
+            Gemma3nConfig::from_json_str(&bad_group)
+                .unwrap_err()
+                .contains("does not divide")
+        );
+    }
+
+    #[test]
+    fn omitted_and_null_optional_math_contracts_match_mlx_defaults() {
+        for null_out in [false, true] {
+            let mut value: serde_json::Value = serde_json::from_str(&tiny_config()).unwrap();
+            let text = value["text_config"].as_object_mut().unwrap();
+            for key in [
+                "activation_sparsity_pattern",
+                "final_logit_softcapping",
+                "altup_coef_clip",
+            ] {
+                if null_out {
+                    text.insert(key.to_string(), serde_json::Value::Null);
+                } else {
+                    text.remove(key);
+                }
+            }
+            let cfg = Gemma3nConfig::from_json_str(&value.to_string()).unwrap();
+            assert_eq!(cfg.activation_sparsity, vec![0.0; cfg.n_layers]);
+            assert_eq!(cfg.final_logit_softcap, None);
+            assert_eq!(cfg.altup_coef_clip, None);
+        }
+    }
+
+    #[test]
+    fn zero_altup_clip_is_a_valid_explicit_clamp() {
+        let mut value: serde_json::Value = serde_json::from_str(&tiny_config()).unwrap();
+        value["text_config"]["altup_coef_clip"] = serde_json::json!(0.0);
+        let cfg = Gemma3nConfig::from_json_str(&value.to_string()).unwrap();
+        assert_eq!(cfg.altup_coef_clip, Some(0.0));
     }
 }

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n.rs
@@ -1,0 +1,508 @@
+//! Validated Gemma3n text-backbone configuration and dense-PLE ABI metadata.
+//!
+//! Gemma3n is not a flag combination of the ordinary Llama emitter: AltUp keeps
+//! multiple hidden planes, LAUREL adds a low-rank residual, later logical layers
+//! reuse earlier physical KV slots, and multimodal callers supply one dense PLE
+//! vector per logical layer.  Keep that contract explicit so an unsupported or
+//! malformed checkpoint fails before graph compilation or buffer upload.
+
+use super::config::QuantConfig;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Gemma3nLayerType {
+    Full,
+    Sliding,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Gemma3nConfig {
+    pub context_capacity: usize,
+    pub hidden: usize,
+    pub intermediate: Vec<usize>,
+    pub n_layers: usize,
+    pub n_q: usize,
+    pub n_kv: usize,
+    pub head_dim: usize,
+    pub eps: f32,
+    pub vocab: usize,
+    pub per_layer_vocab: usize,
+    pub hidden_per_layer_input: usize,
+    pub layer_types: Vec<Gemma3nLayerType>,
+    pub activation_sparsity: Vec<f32>,
+    pub sliding_window: usize,
+    pub rope_theta: f64,
+    pub rope_local_base: f64,
+    pub final_logit_softcap: f32,
+    pub num_kv_shared_layers: usize,
+    pub altup_num_inputs: usize,
+    pub altup_active_idx: usize,
+    pub altup_coef_clip: f32,
+    pub altup_correct_scale: bool,
+    pub laurel_rank: usize,
+    pub tie_word_embeddings: bool,
+    pub quantization: Option<QuantConfig>,
+}
+
+impl Gemma3nConfig {
+    pub(crate) fn from_json_str(s: &str) -> Result<Self, String> {
+        let root: serde_json::Value =
+            serde_json::from_str(s).map_err(|e| format!("parse config.json: {e}"))?;
+        let root_type = root.get("model_type").and_then(serde_json::Value::as_str);
+        let text = if root_type == Some("gemma3n") {
+            root.get("text_config")
+                .ok_or("Gemma3n config missing object `text_config`")?
+        } else if root_type == Some("gemma3n_text") {
+            &root
+        } else {
+            return Err(format!(
+                "unsupported Gemma3n model_type {:?}; expected gemma3n or gemma3n_text",
+                root_type
+            ));
+        };
+        if text.get("model_type").and_then(serde_json::Value::as_str) != Some("gemma3n_text") {
+            return Err("Gemma3n text_config.model_type must be `gemma3n_text`".to_string());
+        }
+
+        let u = |key: &str| -> Result<usize, String> {
+            text.get(key)
+                .and_then(serde_json::Value::as_u64)
+                .map(|v| v as usize)
+                .ok_or_else(|| format!("Gemma3n text_config missing integer `{key}`"))
+        };
+        let f = |key: &str| -> Result<f64, String> {
+            text.get(key)
+                .and_then(serde_json::Value::as_f64)
+                .ok_or_else(|| format!("Gemma3n text_config missing number `{key}`"))
+        };
+        let b = |key: &str| -> Result<bool, String> {
+            text.get(key)
+                .and_then(serde_json::Value::as_bool)
+                .ok_or_else(|| format!("Gemma3n text_config missing boolean `{key}`"))
+        };
+        let n_layers = u("num_hidden_layers")?;
+        let vec_usize = |key: &str| -> Result<Vec<usize>, String> {
+            text.get(key)
+                .and_then(serde_json::Value::as_array)
+                .ok_or_else(|| format!("Gemma3n text_config missing array `{key}`"))?
+                .iter()
+                .map(|v| {
+                    v.as_u64()
+                        .map(|n| n as usize)
+                        .ok_or_else(|| format!("Gemma3n `{key}` must contain integers"))
+                })
+                .collect()
+        };
+        let intermediate = match text.get("intermediate_size") {
+            Some(serde_json::Value::Array(_)) => vec_usize("intermediate_size")?,
+            Some(v) => vec![
+                v.as_u64()
+                    .ok_or("Gemma3n intermediate_size must be an integer or array")?
+                    as usize;
+                n_layers
+            ],
+            None => return Err("Gemma3n text_config missing `intermediate_size`".to_string()),
+        };
+        let activation_sparsity: Vec<f32> = text
+            .get("activation_sparsity_pattern")
+            .and_then(serde_json::Value::as_array)
+            .ok_or("Gemma3n text_config missing array `activation_sparsity_pattern`")?
+            .iter()
+            .map(|v| {
+                v.as_f64()
+                    .map(|n| n as f32)
+                    .ok_or_else(|| "Gemma3n activation sparsity must be numeric".to_string())
+            })
+            .collect::<Result<_, _>>()?;
+        let layer_types: Vec<Gemma3nLayerType> = text
+            .get("layer_types")
+            .and_then(serde_json::Value::as_array)
+            .ok_or("Gemma3n text_config missing array `layer_types`")?
+            .iter()
+            .map(|v| match v.as_str() {
+                Some("full_attention") => Ok(Gemma3nLayerType::Full),
+                Some("sliding_attention") => Ok(Gemma3nLayerType::Sliding),
+                other => Err(format!("unsupported Gemma3n layer type {other:?}")),
+            })
+            .collect::<Result<_, _>>()?;
+
+        let quantization = parse_quantization(&root, text)?;
+        let cfg = Self {
+            context_capacity: crate::DEFAULT_CONTEXT_CAPACITY,
+            hidden: u("hidden_size")?,
+            intermediate,
+            n_layers,
+            n_q: u("num_attention_heads")?,
+            n_kv: u("num_key_value_heads")?,
+            head_dim: u("head_dim")?,
+            eps: f("rms_norm_eps")? as f32,
+            vocab: u("vocab_size")?,
+            per_layer_vocab: u("vocab_size_per_layer_input")?,
+            hidden_per_layer_input: u("hidden_size_per_layer_input")?,
+            layer_types,
+            activation_sparsity,
+            sliding_window: u("sliding_window")?,
+            rope_theta: f("rope_theta")?,
+            rope_local_base: f("rope_local_base_freq")?,
+            final_logit_softcap: f("final_logit_softcapping")? as f32,
+            num_kv_shared_layers: u("num_kv_shared_layers")?,
+            altup_num_inputs: u("altup_num_inputs")?,
+            altup_active_idx: u("altup_active_idx")?,
+            altup_coef_clip: f("altup_coef_clip")? as f32,
+            altup_correct_scale: b("altup_correct_scale")?,
+            laurel_rank: u("laurel_rank")?,
+            tie_word_embeddings: text
+                .get("tie_word_embeddings")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true),
+            quantization,
+        };
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    pub(crate) fn from_json(model_dir: &std::path::Path) -> Result<Self, String> {
+        let path = model_dir.join("config.json");
+        let text =
+            std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        Self::from_json_str(&text).map_err(|e| format!("{}: {e}", path.display()))
+    }
+
+    pub(crate) fn with_context_capacity(mut self, capacity: usize) -> Result<Self, String> {
+        self.context_capacity = crate::context::validate_context_capacity_value(capacity)?;
+        Ok(self)
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.intermediate.len() != self.n_layers
+            || self.layer_types.len() != self.n_layers
+            || self.activation_sparsity.len() != self.n_layers
+        {
+            return Err(format!(
+                "Gemma3n per-layer arrays must all have num_hidden_layers={} entries \
+                 (intermediate={}, layer_types={}, activation_sparsity={})",
+                self.n_layers,
+                self.intermediate.len(),
+                self.layer_types.len(),
+                self.activation_sparsity.len()
+            ));
+        }
+        if self.n_q == 0 || self.n_kv == 0 || !self.n_q.is_multiple_of(self.n_kv) {
+            return Err("Gemma3n attention heads require nonzero n_q divisible by n_kv".into());
+        }
+        if self.num_kv_shared_layers >= self.n_layers {
+            return Err("Gemma3n num_kv_shared_layers must be smaller than layer count".into());
+        }
+        if self.altup_num_inputs < 2 || self.altup_active_idx >= self.altup_num_inputs {
+            return Err(
+                "Gemma3n AltUp requires at least two planes and a valid active index".into(),
+            );
+        }
+        if self.altup_active_idx != 0 {
+            return Err(
+                "Gemma3n OpenXLA currently requires altup_active_idx=0 so the base, \
+                 injection, and unembed plane contract is unambiguous"
+                    .into(),
+            );
+        }
+        if self.per_layer_vocab > self.vocab {
+            return Err("Gemma3n per-layer vocab cannot exceed token vocab".into());
+        }
+        if self.hidden == 0 || self.hidden_per_layer_input == 0 || self.laurel_rank == 0 {
+            return Err("Gemma3n hidden, per-layer hidden, and LAUREL rank must be nonzero".into());
+        }
+        if self
+            .activation_sparsity
+            .iter()
+            .any(|&v| !(0.0..1.0).contains(&v))
+        {
+            return Err("Gemma3n activation sparsity entries must be in [0, 1)".into());
+        }
+        let concrete = self.kv_cache_layers();
+        for kind in [Gemma3nLayerType::Full, Gemma3nLayerType::Sliding] {
+            if self.layer_types[..concrete].iter().all(|&v| v != kind)
+                && self.layer_types[concrete..].contains(&kind)
+            {
+                return Err(format!(
+                    "Gemma3n shared {kind:?} layers have no concrete KV source"
+                ));
+            }
+        }
+        if self.quantization.is_some_and(|q| {
+            !matches!(q.bits, 4 | 8)
+                || q.group_size == 0
+                || !self.hidden.is_multiple_of(q.group_size)
+        }) {
+            return Err(
+                "Gemma3n quantization requires 4/8 bits and a hidden-aligned group_size".into(),
+            );
+        }
+        if !self.tie_word_embeddings {
+            return Err(
+                "Gemma3n untied LM heads are not supported by the checkpoint contract".into(),
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn kv_cache_layers(&self) -> usize {
+        self.n_layers - self.num_kv_shared_layers
+    }
+
+    pub(crate) fn layer_to_cache(&self) -> Result<Vec<usize>, String> {
+        let concrete = self.kv_cache_layers();
+        let mut last_full = None;
+        let mut last_sliding = None;
+        let mut out = Vec::with_capacity(self.n_layers);
+        for (index, &kind) in self.layer_types.iter().enumerate() {
+            if index < concrete {
+                match kind {
+                    Gemma3nLayerType::Full => last_full = Some(index),
+                    Gemma3nLayerType::Sliding => last_sliding = Some(index),
+                }
+                out.push(index);
+            } else {
+                out.push(
+                    match kind {
+                        Gemma3nLayerType::Full => last_full,
+                        Gemma3nLayerType::Sliding => last_sliding,
+                    }
+                    .ok_or_else(|| {
+                        format!("Gemma3n shared layer {index} has no matching KV source")
+                    })?,
+                );
+            }
+        }
+        Ok(out)
+    }
+
+    pub(crate) fn dense_ple_shape(&self) -> [usize; 3] {
+        [
+            self.context_capacity,
+            self.n_layers,
+            self.hidden_per_layer_input,
+        ]
+    }
+
+    pub(crate) fn compatibility_fingerprint(&self) -> String {
+        format!(
+            "gemma3n:h{}:i{:?}:l{}:q{}:kv{}:d{}:eps{:x}:v{}:pv{}:ph{}:lt{:?}:sp{:?}:\
+             sw{}:rt{:x}:rl{:x}:sc{:x}:shared{}:alt{}:{}:{:x}:{}:laurel{}:tie{}:q{:?}:c{}",
+            self.hidden,
+            self.intermediate,
+            self.n_layers,
+            self.n_q,
+            self.n_kv,
+            self.head_dim,
+            self.eps.to_bits(),
+            self.vocab,
+            self.per_layer_vocab,
+            self.hidden_per_layer_input,
+            self.layer_types,
+            self.activation_sparsity
+                .iter()
+                .map(|v| v.to_bits())
+                .collect::<Vec<_>>(),
+            self.sliding_window,
+            self.rope_theta.to_bits(),
+            self.rope_local_base.to_bits(),
+            self.final_logit_softcap.to_bits(),
+            self.num_kv_shared_layers,
+            self.altup_num_inputs,
+            self.altup_active_idx,
+            self.altup_coef_clip.to_bits(),
+            self.altup_correct_scale,
+            self.laurel_rank,
+            self.tie_word_embeddings,
+            self.quantization,
+            self.context_capacity,
+        )
+    }
+}
+
+fn parse_quantization(
+    root: &serde_json::Value,
+    text: &serde_json::Value,
+) -> Result<Option<QuantConfig>, String> {
+    let value = root
+        .get("quantization")
+        .or_else(|| text.get("quantization"));
+    let Some(q) = value.filter(|v| !v.is_null()) else {
+        return Ok(None);
+    };
+    let number = |key: &str| {
+        q.get(key)
+            .and_then(serde_json::Value::as_u64)
+            .map(|v| v as usize)
+            .ok_or_else(|| format!("Gemma3n quantization missing integer `{key}`"))
+    };
+    Ok(Some(QuantConfig {
+        bits: number("bits")?,
+        group_size: number("group_size")?,
+    }))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Gemma3nPleDType {
+    F32,
+    F16,
+    Bf16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Gemma3nPleMetadata {
+    pub shape: [usize; 3],
+    pub dtype: Gemma3nPleDType,
+    pub byte_length: usize,
+}
+
+pub(crate) fn validate_gemma3n_ple(
+    cfg: &Gemma3nConfig,
+    metadata: Gemma3nPleMetadata,
+) -> Result<(), String> {
+    if metadata.shape != cfg.dense_ple_shape() {
+        return Err(format!(
+            "Gemma3n dense PLE shape {:?} does not match required {:?}",
+            metadata.shape,
+            cfg.dense_ple_shape()
+        ));
+    }
+    if metadata.dtype != Gemma3nPleDType::F32 {
+        return Err(format!(
+            "Gemma3n dense PLE dtype {:?} is unsupported; expected F32",
+            metadata.dtype
+        ));
+    }
+    let elements = metadata
+        .shape
+        .into_iter()
+        .try_fold(1usize, usize::checked_mul)
+        .ok_or("Gemma3n dense PLE element count overflows")?;
+    let expected = elements
+        .checked_mul(std::mem::size_of::<f32>())
+        .ok_or("Gemma3n dense PLE byte length overflows")?;
+    if metadata.byte_length != expected {
+        return Err(format!(
+            "Gemma3n dense PLE byte length {} does not match required {expected}",
+            metadata.byte_length
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny_config() -> String {
+        serde_json::json!({
+            "model_type": "gemma3n",
+            "quantization": {"bits": 4, "group_size": 4},
+            "text_config": {
+                "model_type": "gemma3n_text",
+                "hidden_size": 8,
+                "intermediate_size": [16, 16, 16, 16],
+                "num_hidden_layers": 4,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 4,
+                "rms_norm_eps": 0.000001,
+                "vocab_size": 12,
+                "vocab_size_per_layer_input": 10,
+                "hidden_size_per_layer_input": 2,
+                "layer_types": [
+                    "sliding_attention", "full_attention",
+                    "sliding_attention", "full_attention"
+                ],
+                "activation_sparsity_pattern": [0.5, 0.0, 0.0, 0.0],
+                "sliding_window": 4,
+                "rope_theta": 1000000.0,
+                "rope_local_base_freq": 10000.0,
+                "final_logit_softcapping": 30.0,
+                "num_kv_shared_layers": 2,
+                "altup_num_inputs": 4,
+                "altup_active_idx": 0,
+                "altup_coef_clip": 120.0,
+                "altup_correct_scale": true,
+                "laurel_rank": 2,
+                "tie_word_embeddings": true
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn parses_nested_contract_and_maps_shared_kv_by_attention_kind() {
+        let cfg = Gemma3nConfig::from_json_str(&tiny_config()).unwrap();
+        assert_eq!(cfg.kv_cache_layers(), 2);
+        assert_eq!(cfg.layer_to_cache().unwrap(), vec![0, 1, 0, 1]);
+        assert_eq!(
+            cfg.quantization,
+            Some(QuantConfig {
+                bits: 4,
+                group_size: 4
+            })
+        );
+        assert_eq!(
+            cfg.dense_ple_shape(),
+            [crate::DEFAULT_CONTEXT_CAPACITY, 4, 2]
+        );
+    }
+
+    #[test]
+    fn structural_options_change_artifact_identity() {
+        let base = Gemma3nConfig::from_json_str(&tiny_config()).unwrap();
+        let mut changed = base.clone();
+        changed.activation_sparsity[0] = 0.25;
+        assert_ne!(
+            base.compatibility_fingerprint(),
+            changed.compatibility_fingerprint()
+        );
+        changed = base.clone();
+        changed.layer_types.swap(0, 1);
+        assert_ne!(
+            base.compatibility_fingerprint(),
+            changed.compatibility_fingerprint()
+        );
+    }
+
+    #[test]
+    fn dense_ple_metadata_checks_shape_dtype_and_bytes() {
+        let cfg = Gemma3nConfig::from_json_str(&tiny_config())
+            .unwrap()
+            .with_context_capacity(2)
+            .unwrap();
+        validate_gemma3n_ple(
+            &cfg,
+            Gemma3nPleMetadata {
+                shape: [2, 4, 2],
+                dtype: Gemma3nPleDType::F32,
+                byte_length: 64,
+            },
+        )
+        .unwrap();
+        let err = validate_gemma3n_ple(
+            &cfg,
+            Gemma3nPleMetadata {
+                shape: [2, 4, 2],
+                dtype: Gemma3nPleDType::F16,
+                byte_length: 32,
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("expected F32"));
+    }
+
+    #[test]
+    fn malformed_per_layer_arrays_and_shared_sources_fail_early() {
+        let bad = tiny_config().replacen(
+            "\"activation_sparsity_pattern\":[0.5,0.0,0.0,0.0]",
+            "\"activation_sparsity_pattern\":[0.5]",
+            1,
+        );
+        assert!(
+            Gemma3nConfig::from_json_str(&bad)
+                .unwrap_err()
+                .contains("per-layer arrays")
+        );
+    }
+}

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_decode.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_decode.rs
@@ -1,0 +1,156 @@
+//! Single-token Gemma3n decode StableHLO graph.
+
+use super::builder::{Builder, Ty, Val, precision_from_env};
+use super::gemma3n::Gemma3nConfig;
+use super::gemma3n_emit::input_head;
+use super::gemma3n_emit_ops::{
+    altup_correct, altup_predict, attention_decode, constants, geglu, gelu, normalize_to, rms_last,
+    sparse_gelu,
+};
+use super::gemma3n_schema::{Input, build_schema, take};
+
+pub(crate) fn emit_gemma3n_decode(c: &Gemma3nConfig, sample: bool) -> String {
+    let mut b = Builder::new().with_precision(precision_from_env());
+    let (mut decls, args) = build_schema(c, false, 1, true);
+    debug_assert!(matches!(args.input, Input::Tokens(_)));
+    // `real_len` occupies the generic cache-length position in this schema.
+    let mut index = decls.len();
+    let cache_ty = Ty::f32(vec![
+        c.kv_cache_layers(),
+        c.context_capacity,
+        c.n_kv,
+        c.head_dim,
+    ]);
+    let mut kcache = take(&mut decls, &mut index, cache_ty.clone(), "kcache");
+    let mut vcache = take(&mut decls, &mut index, cache_ty.clone(), "vcache");
+    let k = constants(&mut b, c);
+    let (base, dense_ple) = input_head(&mut b, c, &k, &args, 1);
+    let target = magnitude(&mut b, &base, c.hidden, &k.zero, &k.one);
+    let mut planes = vec![base.clone()];
+    for projection in &args.weights.initial_projections {
+        let projected = b.linear_seq(&base, projection);
+        planes.push(normalize_to(&mut b, &projected, &target, &k));
+    }
+    let cache_map = c.layer_to_cache().expect("validated Gemma3n KV map");
+    for (layer, &cache_index) in cache_map.iter().enumerate() {
+        let lw = &args.weights.layers[layer];
+        let predicted = altup_predict(&mut b, &planes, lw, c, &k, 1);
+        let active = &predicted[c.altup_active_idx];
+        let normalized = rms_last(&mut b, active, Some(&lw.input_norm), &k.eps, &k.zero);
+        let laurel = b.linear_seq(&normalized, &lw.laurel_left);
+        let laurel = b.linear_seq(&laurel, &lw.laurel_right);
+        let laurel = rms_last(&mut b, &laurel, Some(&lw.laurel_norm), &k.eps, &k.zero);
+        let laurel = b.add(&normalized, &laurel);
+        let attended = attention_decode(
+            &mut b,
+            &normalized,
+            &args.positions,
+            lw,
+            layer,
+            cache_index,
+            c,
+            &k,
+            &mut kcache,
+            &mut vcache,
+        );
+        let attended = rms_last(&mut b, &attended, Some(&lw.post_attn_norm), &k.eps, &k.zero);
+        let sum = b.add(active, &attended);
+        let sum = b.add(&sum, &laurel);
+        let inv = b.broadcast(&k.inv_sqrt2, &[], vec![1, c.hidden]);
+        let residual = b.multiply(&sum, &inv);
+        let ff_input = rms_last(&mut b, &residual, Some(&lw.pre_ff_norm), &k.eps, &k.zero);
+        let gate = b.linear_seq(&ff_input, &lw.gate);
+        let up = b.linear_seq(&ff_input, &lw.up);
+        let activated_gate = if c.activation_sparsity[layer] > 0.0 {
+            sparse_gelu(&mut b, &gate, c.activation_sparsity[layer], &k)
+        } else {
+            gelu(&mut b, &gate)
+        };
+        let mlp = b.multiply(&activated_gate, &up);
+        let mlp = b.linear_seq(&mlp, &lw.down);
+        let mlp = rms_last(&mut b, &mlp, Some(&lw.post_ff_norm), &k.eps, &k.zero);
+        let activated = b.add(&residual, &mlp);
+        planes = altup_correct(&mut b, &predicted, &activated, lw, c, &k, 1);
+        let mut corrected_active = planes[c.altup_active_idx].clone();
+        if c.altup_correct_scale {
+            let scale = b.broadcast(&lw.correct_scale, &[1], vec![1, c.hidden]);
+            corrected_active = b.multiply(&corrected_active, &scale);
+        }
+        let ple = b.slice(
+            &dense_ple,
+            &[(0, 1), (layer, layer + 1), (0, c.hidden_per_layer_input)],
+        );
+        let ple = b.reshape(&ple, vec![1, c.hidden_per_layer_input]);
+        let gate = b.linear_seq(&corrected_active, &lw.ple_gate);
+        let injected = geglu(&mut b, &gate, &ple);
+        let injected = b.linear_seq(&injected, &lw.ple_projection);
+        let injected = rms_last(&mut b, &injected, Some(&lw.ple_norm), &k.eps, &k.zero);
+        for (plane, value) in planes.iter_mut().enumerate() {
+            if plane != c.altup_active_idx {
+                *value = b.add(value, &injected);
+            }
+        }
+    }
+    let target = magnitude(
+        &mut b,
+        &planes[c.altup_active_idx],
+        c.hidden,
+        &k.zero,
+        &k.one,
+    );
+    let mut collapsed = planes[c.altup_active_idx].clone();
+    for (index, projection) in args.weights.unembed_projections.iter().enumerate() {
+        let projected = b.linear_seq(&planes[index + 1], projection);
+        let projected = normalize_to(&mut b, &projected, &target, &k);
+        collapsed = b.add(&collapsed, &projected);
+    }
+    let count = b.const_f32(c.altup_num_inputs as f32);
+    let count = b.broadcast(&count, &[], vec![1, c.hidden]);
+    let collapsed = b.divide(&collapsed, &count);
+    let normalized = rms_last(
+        &mut b,
+        &collapsed,
+        Some(&args.weights.final_norm),
+        &k.eps,
+        &k.zero,
+    );
+    let normalized = b.reshape(&normalized, vec![c.hidden]);
+    let logits = b.linear(&normalized, &args.weights.embed);
+    let cap = b.const_f32(c.final_logit_softcap);
+    let cap = b.broadcast(&cap, &[], vec![c.vocab]);
+    let logits = b.divide(&logits, &cap);
+    let logits = b.tanh(&logits);
+    let logits = b.multiply(&logits, &cap);
+    let (result, result_ty) = if sample {
+        let token = b.argmax(&logits);
+        (token.name, token.ty.render())
+    } else {
+        (logits.name, logits.ty.render())
+    };
+    let signature = decls
+        .iter()
+        .enumerate()
+        .map(|(i, d)| format!("%arg{i}: {} loc(\"{}\")", d.ty.render(), d.loc))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "module @decode_step {{\n  func.func public @main({signature}) -> \
+         ({result_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {result}, {kc}, {vc} : \
+         {result_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
+        cache_ty = cache_ty.render(),
+        body = b.body(),
+        kc = kcache.name,
+        vc = vcache.name,
+    )
+}
+
+fn magnitude(b: &mut Builder, value: &Val, hidden: usize, zero: &Val, one: &Val) -> Val {
+    let squared = b.multiply(value, value);
+    let sum = b.reduce_add(&squared, 1, zero);
+    let width = b.const_f32(hidden as f32);
+    let width = b.broadcast(&width, &[], vec![1]);
+    let mean = b.divide(&sum, &width);
+    let inverse = b.rsqrt(&mean);
+    let one = b.broadcast(one, &[], vec![1]);
+    b.divide(&one, &inverse)
+}

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_decode.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_decode.rs
@@ -1,21 +1,104 @@
-//! Single-token Gemma3n decode StableHLO graph.
+//! Single-token and fixed-slot ragged Gemma3n decode StableHLO graphs.
 
-use super::builder::{Builder, Ty, Val, precision_from_env};
+use super::builder::{Builder, Precision, Ty, Val, precision_from_env};
 use super::gemma3n::Gemma3nConfig;
-use super::gemma3n_emit::input_head;
+use super::gemma3n_emit::token_input_head;
 use super::gemma3n_emit_ops::{
-    altup_correct, altup_predict, attention_decode, constants, geglu, gelu, normalize_to, rms_last,
+    Constants, altup_correct, altup_predict, attention_decode, bf16_scalar, constants, geglu,
+    linear_bf16, linear_seq_bf16, mean_planes_bf16, normalize_to, rms_last_bf16, round_bf16,
     sparse_gelu,
 };
-use super::gemma3n_schema::{Input, build_schema, take};
+use super::gemma3n_qmv;
+use super::gemma3n_schema::{Decl, Input, Weights, build_schema, take};
 
 pub(crate) fn emit_gemma3n_decode(c: &Gemma3nConfig, sample: bool) -> String {
-    let mut b = Builder::new().with_precision(precision_from_env());
-    let (mut decls, args) = build_schema(c, false, 1, true);
-    debug_assert!(matches!(args.input, Input::Tokens(_)));
-    // `real_len` occupies the generic cache-length position in this schema.
+    emit_gemma3n_decode_with(c, sample, precision_from_env())
+}
+
+pub(crate) fn emit_gemma3n_decode_with(
+    c: &Gemma3nConfig,
+    sample: bool,
+    precision: Precision,
+) -> String {
+    emit_gemma3n_decode_with_qmv(c, sample, precision, false)
+}
+
+pub(crate) fn emit_gemma3n_decode_with_qmv(
+    c: &Gemma3nConfig,
+    sample: bool,
+    precision: Precision,
+    native_qmv: bool,
+) -> String {
+    // Gemma3n's explicit BF16 boundaries coexist with F32 AltUp coefficient
+    // islands, so generic whole-builder contraction demotion is incorrect.
+    let _ = precision;
+    let mut b = Builder::new().with_gemma3n_qmv(native_qmv);
+    let (mut decls, args) = build_schema(c, false, 1, true, false);
+    let token = match &args.input {
+        Input::Tokens(token) => token.clone(),
+        Input::Prepared { .. } => unreachable!("decode accepts token input"),
+    };
     let mut index = decls.len();
+    let cache_ty = scalar_cache_ty(c);
+    let mut kcache = take(&mut decls, &mut index, cache_ty.clone(), "kcache");
+    let mut vcache = take(&mut decls, &mut index, cache_ty.clone(), "vcache");
+    let k = constants(&mut b, c);
+    let logits = decode_row(
+        &mut b,
+        c,
+        &k,
+        &args.weights,
+        &token,
+        &args.positions,
+        &mut kcache,
+        &mut vcache,
+    );
+    let result = if sample { b.argmax(&logits) } else { logits };
+    render_decode(&decls, &b, &result, &kcache, &vcache, &cache_ty)
+}
+
+/// Emit the fixed-slot ragged decode used by continuous batching.
+///
+/// Each row executes the same scalar Gemma3n body against its own rank-4
+/// physical shared-KV slab. The graph is statically unrolled for `b_max`, then
+/// returns `[B,V]` logits and rank-5 caches. This preserves the existing
+/// device-side slot population path without turning logical shared layers into
+/// duplicate cache storage.
+pub(crate) fn emit_gemma3n_decode_ragged(c: &Gemma3nConfig, b_max: usize, sample: bool) -> String {
+    emit_gemma3n_decode_ragged_with(c, b_max, sample, precision_from_env())
+}
+
+pub(crate) fn emit_gemma3n_decode_ragged_with(
+    c: &Gemma3nConfig,
+    b_max: usize,
+    sample: bool,
+    precision: Precision,
+) -> String {
+    emit_gemma3n_decode_ragged_with_qmv(c, b_max, sample, precision, false)
+}
+
+pub(crate) fn emit_gemma3n_decode_ragged_with_qmv(
+    c: &Gemma3nConfig,
+    b_max: usize,
+    sample: bool,
+    precision: Precision,
+    native_qmv: bool,
+) -> String {
+    assert!(
+        b_max > 0,
+        "Gemma3n ragged decode requires at least one slot"
+    );
+    let _ = precision;
+    let mut b = Builder::new().with_gemma3n_qmv(native_qmv);
+    let (mut decls, args) = build_schema(c, false, b_max, false, true);
+    let tokens = match &args.input {
+        Input::Tokens(tokens) => tokens.clone(),
+        Input::Prepared { .. } => unreachable!("decode accepts token input"),
+    };
+    let mut index = decls.len();
+    let scalar_cache = scalar_cache_ty(c);
     let cache_ty = Ty::f32(vec![
+        b_max,
         c.kv_cache_layers(),
         c.context_capacity,
         c.n_kv,
@@ -24,121 +107,241 @@ pub(crate) fn emit_gemma3n_decode(c: &Gemma3nConfig, sample: bool) -> String {
     let mut kcache = take(&mut decls, &mut index, cache_ty.clone(), "kcache");
     let mut vcache = take(&mut decls, &mut index, cache_ty.clone(), "vcache");
     let k = constants(&mut b, c);
-    let (base, dense_ple) = input_head(&mut b, c, &k, &args, 1);
-    let target = magnitude(&mut b, &base, c.hidden, &k.zero, &k.one);
-    let mut planes = vec![base.clone()];
-    for projection in &args.weights.initial_projections {
-        let projected = b.linear_seq(&base, projection);
-        planes.push(normalize_to(&mut b, &projected, &target, &k));
-    }
-    let cache_map = c.layer_to_cache().expect("validated Gemma3n KV map");
-    for (layer, &cache_index) in cache_map.iter().enumerate() {
-        let lw = &args.weights.layers[layer];
-        let predicted = altup_predict(&mut b, &planes, lw, c, &k, 1);
-        let active = &predicted[c.altup_active_idx];
-        let normalized = rms_last(&mut b, active, Some(&lw.input_norm), &k.eps, &k.zero);
-        let laurel = b.linear_seq(&normalized, &lw.laurel_left);
-        let laurel = b.linear_seq(&laurel, &lw.laurel_right);
-        let laurel = rms_last(&mut b, &laurel, Some(&lw.laurel_norm), &k.eps, &k.zero);
-        let laurel = b.add(&normalized, &laurel);
-        let attended = attention_decode(
+    let mut rows = Vec::with_capacity(b_max);
+    for row in 0..b_max {
+        let token = b.slice(&tokens, &[(row, row + 1)]);
+        let token = b.reshape(&token, Vec::new());
+        let position = b.slice(&args.positions, &[(row, row + 1)]);
+        let position = b.reshape(&position, Vec::new());
+        let mut row_k = b.slice(
+            &kcache,
+            &[
+                (row, row + 1),
+                (0, c.kv_cache_layers()),
+                (0, c.context_capacity),
+                (0, c.n_kv),
+                (0, c.head_dim),
+            ],
+        );
+        row_k = b.reshape(&row_k, scalar_cache.shape.clone());
+        let mut row_v = b.slice(
+            &vcache,
+            &[
+                (row, row + 1),
+                (0, c.kv_cache_layers()),
+                (0, c.context_capacity),
+                (0, c.n_kv),
+                (0, c.head_dim),
+            ],
+        );
+        row_v = b.reshape(&row_v, scalar_cache.shape.clone());
+        let logits = decode_row(
             &mut b,
+            c,
+            &k,
+            &args.weights,
+            &token,
+            &position,
+            &mut row_k,
+            &mut row_v,
+        );
+        rows.push(b.reshape(&logits, vec![1, c.vocab]));
+
+        let zero = b.const_i32(0);
+        let row_index = b.const_i32(row as i32);
+        let row_k = b.reshape(
+            &row_k,
+            vec![
+                1,
+                c.kv_cache_layers(),
+                c.context_capacity,
+                c.n_kv,
+                c.head_dim,
+            ],
+        );
+        kcache = b.dynamic_update_slice(&kcache, &row_k, &[&row_index, &zero, &zero, &zero, &zero]);
+        let row_v = b.reshape(
+            &row_v,
+            vec![
+                1,
+                c.kv_cache_layers(),
+                c.context_capacity,
+                c.n_kv,
+                c.head_dim,
+            ],
+        );
+        vcache = b.dynamic_update_slice(&vcache, &row_v, &[&row_index, &zero, &zero, &zero, &zero]);
+    }
+    let mut rows = rows.into_iter();
+    let mut logits = rows.next().expect("b_max is nonzero");
+    for row in rows {
+        logits = b.concatenate(&logits, &row, 0);
+    }
+    let result = if sample {
+        b.argmax_batched(&logits)
+    } else {
+        logits
+    };
+    render_decode(&decls, &b, &result, &kcache, &vcache, &cache_ty)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn decode_row(
+    b: &mut Builder,
+    c: &Gemma3nConfig,
+    k: &Constants,
+    weights: &Weights,
+    token: &Val,
+    position: &Val,
+    kcache: &mut Val,
+    vcache: &mut Val,
+) -> Val {
+    let (base, dense_ple) = token_input_head(b, c, k, weights, token, 1);
+    let target = magnitude(b, &base, c.hidden, &k.zero, &k.one);
+    let mut planes = vec![base.clone()];
+    for projection in &weights.initial_projections {
+        let projected = linear_seq_bf16(b, &base, projection);
+        planes.push(normalize_to(b, &projected, &target, k));
+    }
+    let cache_map = c
+        .kv_cache_contract()
+        .expect("validated Gemma3n KV map")
+        .logical_to_physical;
+    for (layer, &cache_index) in cache_map.iter().enumerate() {
+        let lw = &weights.layers[layer];
+        let predicted = altup_predict(b, &planes, lw, c, k, 1);
+        let active = &predicted[c.altup_active_idx];
+        let normalized = rms_last_bf16(b, active, Some(&lw.input_norm), &k.eps, &k.zero);
+        let laurel = linear_seq_bf16(b, &normalized, &lw.laurel_left);
+        let laurel = linear_seq_bf16(b, &laurel, &lw.laurel_right);
+        let laurel = rms_last_bf16(b, &laurel, Some(&lw.laurel_norm), &k.eps, &k.zero);
+        let laurel = b.add(&normalized, &laurel);
+        let laurel = round_bf16(b, &laurel);
+        let attended = attention_decode(
+            b,
             &normalized,
-            &args.positions,
+            position,
             lw,
             layer,
             cache_index,
             c,
-            &k,
-            &mut kcache,
-            &mut vcache,
+            k,
+            kcache,
+            vcache,
         );
-        let attended = rms_last(&mut b, &attended, Some(&lw.post_attn_norm), &k.eps, &k.zero);
+        let attended = rms_last_bf16(b, &attended, Some(&lw.post_attn_norm), &k.eps, &k.zero);
         let sum = b.add(active, &attended);
+        let sum = round_bf16(b, &sum);
         let sum = b.add(&sum, &laurel);
+        let sum = round_bf16(b, &sum);
         let inv = b.broadcast(&k.inv_sqrt2, &[], vec![1, c.hidden]);
         let residual = b.multiply(&sum, &inv);
-        let ff_input = rms_last(&mut b, &residual, Some(&lw.pre_ff_norm), &k.eps, &k.zero);
-        let gate = b.linear_seq(&ff_input, &lw.gate);
-        let up = b.linear_seq(&ff_input, &lw.up);
-        let activated_gate = if c.activation_sparsity[layer] > 0.0 {
-            sparse_gelu(&mut b, &gate, c.activation_sparsity[layer], &k)
+        let residual = round_bf16(b, &residual);
+        let ff_input = rms_last_bf16(b, &residual, Some(&lw.pre_ff_norm), &k.eps, &k.zero);
+        let gate = linear_seq_bf16(b, &ff_input, &lw.gate);
+        let up = linear_seq_bf16(b, &ff_input, &lw.up);
+        let mlp = if c.activation_sparsity[layer] > 0.0 {
+            let activated_gate = sparse_gelu(b, &gate, c.activation_sparsity[layer], k);
+            let product = b.multiply(&activated_gate, &up);
+            round_bf16(b, &product)
         } else {
-            gelu(&mut b, &gate)
+            geglu(b, &gate, &up)
         };
-        let mlp = b.multiply(&activated_gate, &up);
-        let mlp = b.linear_seq(&mlp, &lw.down);
-        let mlp = rms_last(&mut b, &mlp, Some(&lw.post_ff_norm), &k.eps, &k.zero);
+        let mlp = linear_seq_bf16(b, &mlp, &lw.down);
+        let mlp = rms_last_bf16(b, &mlp, Some(&lw.post_ff_norm), &k.eps, &k.zero);
         let activated = b.add(&residual, &mlp);
-        planes = altup_correct(&mut b, &predicted, &activated, lw, c, &k, 1);
+        let activated = round_bf16(b, &activated);
+        planes = altup_correct(b, &predicted, &activated, lw, c, k, 1);
         let mut corrected_active = planes[c.altup_active_idx].clone();
         if c.altup_correct_scale {
             let scale = b.broadcast(&lw.correct_scale, &[1], vec![1, c.hidden]);
             corrected_active = b.multiply(&corrected_active, &scale);
+            corrected_active = round_bf16(b, &corrected_active);
         }
         let ple = b.slice(
             &dense_ple,
             &[(0, 1), (layer, layer + 1), (0, c.hidden_per_layer_input)],
         );
         let ple = b.reshape(&ple, vec![1, c.hidden_per_layer_input]);
-        let gate = b.linear_seq(&corrected_active, &lw.ple_gate);
-        let injected = geglu(&mut b, &gate, &ple);
-        let injected = b.linear_seq(&injected, &lw.ple_projection);
-        let injected = rms_last(&mut b, &injected, Some(&lw.ple_norm), &k.eps, &k.zero);
+        let gate = linear_seq_bf16(b, &corrected_active, &lw.ple_gate);
+        let injected = geglu(b, &gate, &ple);
+        let injected = linear_seq_bf16(b, &injected, &lw.ple_projection);
+        let injected = rms_last_bf16(b, &injected, Some(&lw.ple_norm), &k.eps, &k.zero);
         for (plane, value) in planes.iter_mut().enumerate() {
             if plane != c.altup_active_idx {
                 *value = b.add(value, &injected);
+                *value = round_bf16(b, value);
             }
         }
     }
-    let target = magnitude(
-        &mut b,
-        &planes[c.altup_active_idx],
-        c.hidden,
-        &k.zero,
-        &k.one,
-    );
-    let mut collapsed = planes[c.altup_active_idx].clone();
-    for (index, projection) in args.weights.unembed_projections.iter().enumerate() {
-        let projected = b.linear_seq(&planes[index + 1], projection);
-        let projected = normalize_to(&mut b, &projected, &target, &k);
-        collapsed = b.add(&collapsed, &projected);
+    let target = magnitude(b, &planes[c.altup_active_idx], c.hidden, &k.zero, &k.one);
+    let mut collapsed_planes = vec![planes[c.altup_active_idx].clone()];
+    for (index, projection) in weights.unembed_projections.iter().enumerate() {
+        let projected = linear_seq_bf16(b, &planes[index + 1], projection);
+        let projected = normalize_to(b, &projected, &target, k);
+        collapsed_planes.push(projected);
     }
-    let count = b.const_f32(c.altup_num_inputs as f32);
-    let count = b.broadcast(&count, &[], vec![1, c.hidden]);
-    let collapsed = b.divide(&collapsed, &count);
-    let normalized = rms_last(
-        &mut b,
-        &collapsed,
-        Some(&args.weights.final_norm),
-        &k.eps,
-        &k.zero,
-    );
+    assert_eq!(collapsed_planes.len(), c.altup_num_inputs);
+    let collapsed = mean_planes_bf16(b, &collapsed_planes, &k.zero);
+    let normalized = rms_last_bf16(b, &collapsed, Some(&weights.final_norm), &k.eps, &k.zero);
     let normalized = b.reshape(&normalized, vec![c.hidden]);
-    let logits = b.linear(&normalized, &args.weights.embed);
-    let cap = b.const_f32(c.final_logit_softcap);
-    let cap = b.broadcast(&cap, &[], vec![c.vocab]);
-    let logits = b.divide(&logits, &cap);
-    let logits = b.tanh(&logits);
-    let logits = b.multiply(&logits, &cap);
-    let (result, result_ty) = if sample {
-        let token = b.argmax(&logits);
-        (token.name, token.ty.render())
+    let logits = linear_bf16(b, &normalized, &weights.embed);
+    if let Some(cap) = c.final_logit_softcap {
+        let cap = bf16_scalar(b, cap);
+        let cap = b.broadcast(&cap, &[], vec![c.vocab]);
+        let logits = b.divide(&logits, &cap);
+        let logits = round_bf16(b, &logits);
+        let logits = b.gemma3n_tanh(&logits);
+        let logits = round_bf16(b, &logits);
+        let logits = b.multiply(&logits, &cap);
+        round_bf16(b, &logits)
     } else {
-        (logits.name, logits.ty.render())
-    };
+        logits
+    }
+}
+
+fn scalar_cache_ty(c: &Gemma3nConfig) -> Ty {
+    Ty::f32(vec![
+        c.kv_cache_layers(),
+        c.context_capacity,
+        c.n_kv,
+        c.head_dim,
+    ])
+}
+
+fn render_decode(
+    decls: &[Decl],
+    b: &Builder,
+    result: &Val,
+    kcache: &Val,
+    vcache: &Val,
+    cache_ty: &Ty,
+) -> String {
     let signature = decls
         .iter()
         .enumerate()
         .map(|(i, d)| format!("%arg{i}: {} loc(\"{}\")", d.ty.render(), d.loc))
         .collect::<Vec<_>>()
         .join(", ");
+    let target_alias = if b.gemma3n_qmv_enabled() {
+        gemma3n_qmv::target_alias()
+    } else {
+        ""
+    };
+    let executable_source = if b.gemma3n_qmv_enabled() {
+        gemma3n_qmv::executable_source()
+    } else {
+        String::new()
+    };
     format!(
-        "module @decode_step {{\n  func.func public @main({signature}) -> \
+        "{target_alias}module @decode_step {{\n{executable_source}  \
+         func.func public @main({signature}) -> \
          ({result_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {result}, {kc}, {vc} : \
          {result_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
+        result_ty = result.ty.render(),
         cache_ty = cache_ty.render(),
         body = b.body(),
+        result = result.name,
         kc = kcache.name,
         vc = vcache.name,
     )
@@ -146,11 +349,14 @@ pub(crate) fn emit_gemma3n_decode(c: &Gemma3nConfig, sample: bool) -> String {
 
 fn magnitude(b: &mut Builder, value: &Val, hidden: usize, zero: &Val, one: &Val) -> Val {
     let squared = b.multiply(value, value);
+    let squared = round_bf16(b, &squared);
     let sum = b.reduce_add(&squared, 1, zero);
+    let sum = round_bf16(b, &sum);
     let width = b.const_f32(hidden as f32);
     let width = b.broadcast(&width, &[], vec![1]);
     let mean = b.divide(&sum, &width);
-    let inverse = b.rsqrt(&mean);
-    let one = b.broadcast(one, &[], vec![1]);
-    b.divide(&one, &inverse)
+    let mean = round_bf16(b, &mean);
+    let magnitude = b.sqrt(&mean);
+    let _ = one;
+    round_bf16(b, &magnitude)
 }

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_emit.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_emit.rs
@@ -1,0 +1,348 @@
+//! Gemma3n StableHLO prefill graphs.
+//!
+//! Both entries share the complete AltUp/LAUREL/shared-KV backbone. Token
+//! prefill gathers ordinary and per-layer embeddings; multimodal prefill accepts
+//! already post-scale merged embeddings plus dense projected PLE.
+
+use super::builder::{Builder, Precision, Val, precision_from_env};
+use super::gemma3n::{Gemma3nConfig, Gemma3nLayerType};
+use super::gemma3n_emit_ops::{
+    Constants, altup_correct, altup_predict, apply_sliding_window, attention, causal_mask,
+    constants, geglu, normalize_to, rms_last, sparse_gelu,
+};
+use super::gemma3n_schema::{Args, Decl, Input, build_schema};
+
+pub(crate) fn emit_gemma3n_prefill(c: &Gemma3nConfig, sample: bool) -> String {
+    emit(c, sample, false, precision_from_env())
+}
+
+pub(crate) fn emit_gemma3n_prefill_embeddings_ple(c: &Gemma3nConfig, sample: bool) -> String {
+    emit(c, sample, true, precision_from_env())
+}
+
+fn emit(c: &Gemma3nConfig, sample: bool, prepared: bool, precision: Precision) -> String {
+    let lp = c.context_capacity;
+    let mut b = Builder::new().with_precision(precision);
+    let (decls, args) = build_schema(c, prepared, lp, false);
+    let k = constants(&mut b, c);
+    let (base, dense_ple) = input_head(&mut b, c, &k, &args, lp);
+    let target = magnitude(&mut b, &base, c, &k);
+    let mut planes = vec![base.clone()];
+    for projection in &args.weights.initial_projections {
+        let projected = b.linear_seq(&base, projection);
+        planes.push(normalize_to(&mut b, &projected, &target, &k));
+    }
+    let full_mask = args
+        .attention_bias
+        .clone()
+        .unwrap_or_else(|| causal_mask(&mut b, lp, None, &k));
+    let sliding_mask = apply_sliding_window(&mut b, &full_mask, lp, c.sliding_window, &k);
+    let cache_map = c.layer_to_cache().expect("validated Gemma3n KV map");
+    let cache_shape = vec![c.kv_cache_layers(), lp, c.n_kv, c.head_dim];
+    let mut kcache = b.broadcast(&k.zero, &[], cache_shape.clone());
+    let mut vcache = b.broadcast(&k.zero, &[], cache_shape.clone());
+    for (layer, &cache_index) in cache_map.iter().enumerate() {
+        let lw = &args.weights.layers[layer];
+        let predicted = altup_predict(&mut b, &planes, lw, c, &k, lp);
+        let active = &predicted[c.altup_active_idx];
+        let normalized = rms_last(&mut b, active, Some(&lw.input_norm), &k.eps, &k.zero);
+        let laurel = b.linear_seq(&normalized, &lw.laurel_left);
+        let laurel = b.linear_seq(&laurel, &lw.laurel_right);
+        let laurel = rms_last(&mut b, &laurel, Some(&lw.laurel_norm), &k.eps, &k.zero);
+        let laurel = b.add(&normalized, &laurel);
+        let mask = match c.layer_types[layer] {
+            Gemma3nLayerType::Full => &full_mask,
+            Gemma3nLayerType::Sliding => &sliding_mask,
+        };
+        let attended = attention(
+            &mut b,
+            &normalized,
+            &args.positions,
+            mask,
+            lw,
+            layer,
+            cache_index,
+            c,
+            &k,
+            &mut kcache,
+            &mut vcache,
+        );
+        let attended = rms_last(&mut b, &attended, Some(&lw.post_attn_norm), &k.eps, &k.zero);
+        let inv = b.broadcast(&k.inv_sqrt2, &[], vec![lp, c.hidden]);
+        let residual = b.add(active, &attended);
+        let residual = b.add(&residual, &laurel);
+        let residual = b.multiply(&residual, &inv);
+        let ff_input = rms_last(&mut b, &residual, Some(&lw.pre_ff_norm), &k.eps, &k.zero);
+        let gate = b.linear_seq(&ff_input, &lw.gate);
+        let up = b.linear_seq(&ff_input, &lw.up);
+        let activated_gate = if c.activation_sparsity[layer] > 0.0 {
+            sparse_gelu(&mut b, &gate, c.activation_sparsity[layer], &k)
+        } else {
+            super::gemma3n_emit_ops::gelu(&mut b, &gate)
+        };
+        let mlp = b.multiply(&activated_gate, &up);
+        let mlp = b.linear_seq(&mlp, &lw.down);
+        let mlp = rms_last(&mut b, &mlp, Some(&lw.post_ff_norm), &k.eps, &k.zero);
+        let activated = b.add(&residual, &mlp);
+        planes = altup_correct(&mut b, &predicted, &activated, lw, c, &k, lp);
+        let mut corrected_active = planes[c.altup_active_idx].clone();
+        if c.altup_correct_scale {
+            let scale = b.broadcast(&lw.correct_scale, &[1], vec![lp, c.hidden]);
+            corrected_active = b.multiply(&corrected_active, &scale);
+        }
+        let ple = b.slice(
+            &dense_ple,
+            &[(0, lp), (layer, layer + 1), (0, c.hidden_per_layer_input)],
+        );
+        let ple = b.reshape(&ple, vec![lp, c.hidden_per_layer_input]);
+        let ple_gate = b.linear_seq(&corrected_active, &lw.ple_gate);
+        let injected = geglu(&mut b, &ple_gate, &ple);
+        let injected = b.linear_seq(&injected, &lw.ple_projection);
+        let injected = rms_last(&mut b, &injected, Some(&lw.ple_norm), &k.eps, &k.zero);
+        for (plane, value) in planes.iter_mut().enumerate() {
+            if plane != c.altup_active_idx {
+                *value = b.add(value, &injected);
+            }
+        }
+    }
+    let target = magnitude(&mut b, &planes[c.altup_active_idx], c, &k);
+    let mut collapsed = planes[c.altup_active_idx].clone();
+    for (index, projection) in args.weights.unembed_projections.iter().enumerate() {
+        let projected = b.linear_seq(&planes[index + 1], projection);
+        let projected = normalize_to(&mut b, &projected, &target, &k);
+        collapsed = b.add(&collapsed, &projected);
+    }
+    let count = b.const_f32(c.altup_num_inputs as f32);
+    let count = b.broadcast(&count, &[], vec![lp, c.hidden]);
+    collapsed = b.divide(&collapsed, &count);
+    let normalized = rms_last(
+        &mut b,
+        &collapsed,
+        Some(&args.weights.final_norm),
+        &k.eps,
+        &k.zero,
+    );
+    let one = b.const_i32(1);
+    let last_index = b.subtract(&args.real_len, &one);
+    let zero = b.const_i32(0);
+    let row = b.dynamic_slice(&normalized, &[&last_index, &zero], vec![1, c.hidden]);
+    let row = b.reshape(&row, vec![c.hidden]);
+    let logits = b.linear(&row, &args.weights.embed);
+    let cap = b.const_f32(c.final_logit_softcap);
+    let cap_b = b.broadcast(&cap, &[], vec![c.vocab]);
+    let logits = b.divide(&logits, &cap_b);
+    let logits = b.tanh(&logits);
+    let logits = b.multiply(&logits, &cap_b);
+    let (result, result_ty) = if sample {
+        let token = b.argmax(&logits);
+        (token.name, token.ty.render())
+    } else {
+        (logits.name, logits.ty.render())
+    };
+    render_module(
+        if prepared {
+            "prefill_embeddings_ple"
+        } else {
+            "prefill"
+        },
+        &decls,
+        &b,
+        &result,
+        &result_ty,
+        &kcache,
+        &vcache,
+    )
+}
+
+pub(super) fn input_head(
+    b: &mut Builder,
+    c: &Gemma3nConfig,
+    k: &Constants,
+    a: &Args,
+    lp: usize,
+) -> (Val, Val) {
+    let ple_width = c.n_layers * c.hidden_per_layer_input;
+    match &a.input {
+        Input::Prepared {
+            embeddings,
+            dense_ple,
+        } => (embeddings.clone(), dense_ple.clone()),
+        Input::Tokens(tokens) => {
+            let tokens = if tokens.ty.shape.is_empty() {
+                b.reshape(tokens, vec![1])
+            } else {
+                tokens.clone()
+            };
+            let indices = b.reshape(&tokens, vec![lp, 1]);
+            let base = b.gather(&a.weights.embed, &indices);
+            let scale = b.const_f32((c.hidden as f32).sqrt());
+            let scale = b.broadcast(&scale, &[], vec![lp, c.hidden]);
+            let base = b.multiply(&base, &scale);
+            let limit = b.const_i32(c.per_layer_vocab as i32);
+            let limit = b.broadcast(&limit, &[], vec![lp]);
+            let zero_i = b.const_i32(0);
+            let zero_ids = b.broadcast(&zero_i, &[], vec![lp]);
+            let nonnegative = b.compare("GE", &tokens, &zero_ids, "SIGNED");
+            let below = b.compare("LT", &tokens, &limit, "SIGNED");
+            let valid = b.select(&nonnegative, &below, &nonnegative);
+            let safe = b.select(&valid, &tokens, &zero_ids);
+            let safe = b.reshape(&safe, vec![lp, 1]);
+            let token_ple = b.gather(&a.weights.token_ple, &safe);
+            let zeros = b.broadcast(&k.zero, &[], vec![lp, ple_width]);
+            let valid = b.broadcast(&valid, &[0], vec![lp, ple_width]);
+            let token_ple = b.select(&valid, &token_ple, &zeros);
+            let token_scale = b.const_f32((c.hidden_per_layer_input as f32).sqrt());
+            let token_scale = b.broadcast(&token_scale, &[], vec![lp, ple_width]);
+            let token_ple = b.multiply(&token_ple, &token_scale);
+            let projected = b.linear_seq(&base, &a.weights.ple_projection);
+            let model_scale = b.const_f32((c.hidden as f32).sqrt().recip());
+            let model_scale = b.broadcast(&model_scale, &[], vec![lp, ple_width]);
+            let projected = b.multiply(&projected, &model_scale);
+            let projected = b.reshape(&projected, vec![lp, c.n_layers, c.hidden_per_layer_input]);
+            let projected = rms_last(
+                b,
+                &projected,
+                Some(&a.weights.ple_projection_norm),
+                &k.eps,
+                &k.zero,
+            );
+            let token_ple = b.reshape(&token_ple, vec![lp, c.n_layers, c.hidden_per_layer_input]);
+            let inv = b.broadcast(
+                &k.inv_sqrt2,
+                &[],
+                vec![lp, c.n_layers, c.hidden_per_layer_input],
+            );
+            let combined = b.add(&projected, &token_ple);
+            let combined = b.multiply(&combined, &inv);
+            (base, combined)
+        }
+    }
+}
+
+fn magnitude(b: &mut Builder, value: &Val, c: &Gemma3nConfig, k: &Constants) -> Val {
+    let sq = b.multiply(value, value);
+    let sum = b.reduce_add(&sq, 1, &k.zero);
+    let width = b.broadcast(&k.hidden, &[], vec![c.context_capacity]);
+    let mean = b.divide(&sum, &width);
+    let inverse = b.rsqrt(&mean);
+    let one = b.broadcast(&k.one, &[], vec![c.context_capacity]);
+    b.divide(&one, &inverse)
+}
+
+fn render_module(
+    name: &str,
+    decls: &[Decl],
+    b: &Builder,
+    result: &str,
+    result_ty: &str,
+    kcache: &Val,
+    vcache: &Val,
+) -> String {
+    let signature = decls
+        .iter()
+        .enumerate()
+        .map(|(index, decl)| format!("%arg{index}: {} loc(\"{}\")", decl.ty.render(), decl.loc))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let cache_ty = kcache.ty.render();
+    format!(
+        "module @{name} {{\n  func.func public @main({signature}) -> ({result_ty}, \
+         {cache_ty}, {cache_ty}) {{\n{body}    return {result}, {kc}, {vc} : \
+         {result_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
+        body = b.body(),
+        kc = kcache.name,
+        vc = vcache.name,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny() -> Gemma3nConfig {
+        Gemma3nConfig::from_json_str(
+            &serde_json::json!({
+                "model_type": "gemma3n_text",
+                "hidden_size": 8, "intermediate_size": [12, 12, 12, 12],
+                "num_hidden_layers": 4, "num_attention_heads": 2,
+                "num_key_value_heads": 1, "head_dim": 4, "rms_norm_eps": 1e-6,
+                "vocab_size": 12, "vocab_size_per_layer_input": 10,
+                "hidden_size_per_layer_input": 2,
+                "layer_types": ["sliding_attention", "full_attention",
+                                "sliding_attention", "full_attention"],
+                "activation_sparsity_pattern": [0.5, 0.0, 0.0, 0.0],
+                "sliding_window": 2, "rope_theta": 1000000.0,
+                "rope_local_base_freq": 10000.0, "final_logit_softcapping": 30.0,
+                "num_kv_shared_layers": 2, "altup_num_inputs": 2,
+                "altup_active_idx": 0, "altup_coef_clip": 120.0,
+                "altup_correct_scale": true, "laurel_rank": 2,
+                "tie_word_embeddings": true
+            })
+            .to_string(),
+        )
+        .unwrap()
+        .with_context_capacity(4)
+        .unwrap()
+    }
+
+    #[test]
+    fn emits_distinct_token_and_dense_ple_entries_with_physical_kv_count() {
+        let c = tiny();
+        let token = emit_gemma3n_prefill(&c, false);
+        let prepared = emit_gemma3n_prefill_embeddings_ple(&c, false);
+        assert!(token.contains("module @prefill"));
+        assert!(!token.contains("loc(\"dense_ple\")"));
+        assert!(prepared.contains("module @prefill_embeddings_ple"));
+        assert!(prepared.contains("tensor<4x4x2xf32> loc(\"dense_ple\")"));
+        assert!(prepared.contains("tensor<2x4x1x4xf32>"));
+        assert!(prepared.contains("altup.prediction_coefs.weight"));
+        assert!(prepared.contains("laurel.linear_left.weight"));
+        assert!(!prepared.contains("layers.2.self_attn.k_proj.weight"));
+        let decode = super::super::gemma3n_decode::emit_gemma3n_decode(&c, true);
+        assert!(decode.contains("module @decode_step"));
+        assert!(decode.contains("tensor<2x4x1x4xf32> loc(\"kcache\")"));
+        assert!(!decode.contains("layers.2.self_attn.k_proj.weight"));
+    }
+
+    #[test]
+    #[ignore = "requires the pinned IREE compiler; run explicitly for the production target"]
+    fn iree_compiles_tiny_token_and_dense_ple_graphs() {
+        let compiler = std::env::var_os("MLXCEL_XLA_IREE_COMPILE")
+            .expect("set MLXCEL_XLA_IREE_COMPILE to the pinned iree-compile");
+        let target =
+            std::env::var("MLXCEL_XLA_IREE_TEST_TARGET").unwrap_or_else(|_| "local".to_string());
+        for (tag, graph) in [
+            ("token", emit_gemma3n_prefill(&tiny(), true)),
+            (
+                "embeddings-ple",
+                emit_gemma3n_prefill_embeddings_ple(&tiny(), true),
+            ),
+            (
+                "decode",
+                super::super::gemma3n_decode::emit_gemma3n_decode(&tiny(), true),
+            ),
+        ] {
+            let stem = format!("mlxcel-gemma3n-{tag}-{}", std::process::id());
+            let input = std::env::temp_dir().join(format!("{stem}.mlir"));
+            let output = std::env::temp_dir().join(format!("{stem}.vmfb"));
+            std::fs::write(&input, graph).unwrap();
+            let mut command = std::process::Command::new(&compiler);
+            command.arg("--iree-input-type=stablehlo");
+            if target == "cuda" {
+                command.arg("--iree-hal-target-device=cuda");
+            } else {
+                command
+                    .arg("--iree-hal-target-device=local")
+                    .arg("--iree-hal-local-target-device-backends=llvm-cpu");
+            }
+            let result = command.arg(&input).arg("-o").arg(&output).output().unwrap();
+            let _ = std::fs::remove_file(&input);
+            let _ = std::fs::remove_file(&output);
+            assert!(
+                result.status.success(),
+                "{tag} failed IREE compile: {}",
+                String::from_utf8_lossy(&result.stderr)
+            );
+        }
+    }
+}

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_emit.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_emit.rs
@@ -7,29 +7,293 @@
 use super::builder::{Builder, Precision, Val, precision_from_env};
 use super::gemma3n::{Gemma3nConfig, Gemma3nLayerType};
 use super::gemma3n_emit_ops::{
-    Constants, altup_correct, altup_predict, apply_sliding_window, attention, causal_mask,
-    constants, geglu, normalize_to, rms_last, sparse_gelu,
+    Constants, altup_correct, altup_predict, apply_sliding_window, attention, bf16_scalar,
+    causal_mask, constants, geglu, linear_bf16, linear_seq_bf16, mean_planes_bf16, normalize_to,
+    rms_last_bf16, round_bf16, sparse_gelu,
 };
-use super::gemma3n_schema::{Args, Decl, Input, build_schema};
+use super::gemma3n_qmv;
+use super::gemma3n_schema::{Args, Decl, Input, Weights, build_schema};
 
 pub(crate) fn emit_gemma3n_prefill(c: &Gemma3nConfig, sample: bool) -> String {
     emit(c, sample, false, precision_from_env())
+}
+
+pub(crate) fn emit_gemma3n_prefill_with(
+    c: &Gemma3nConfig,
+    sample: bool,
+    precision: Precision,
+) -> String {
+    emit(c, sample, false, precision)
+}
+
+pub(crate) fn emit_gemma3n_prefill_with_qmv(
+    c: &Gemma3nConfig,
+    sample: bool,
+    precision: Precision,
+    native_qmv: bool,
+) -> String {
+    emit_inner(c, sample, false, precision, false, false, native_qmv)
 }
 
 pub(crate) fn emit_gemma3n_prefill_embeddings_ple(c: &Gemma3nConfig, sample: bool) -> String {
     emit(c, sample, true, precision_from_env())
 }
 
+pub(crate) fn emit_gemma3n_prefill_embeddings_ple_with(
+    c: &Gemma3nConfig,
+    sample: bool,
+    precision: Precision,
+) -> String {
+    emit(c, sample, true, precision)
+}
+
+pub(crate) fn emit_gemma3n_prefill_embeddings_ple_with_qmv(
+    c: &Gemma3nConfig,
+    sample: bool,
+    precision: Precision,
+    native_qmv: bool,
+) -> String {
+    emit_inner(c, sample, true, precision, false, false, native_qmv)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Gemma3nDiagnosticSegment {
+    pub name: &'static str,
+    pub shape: Vec<usize>,
+    pub offset: usize,
+    pub len: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Gemma3nDiagnosticLayout {
+    pub segments: Vec<Gemma3nDiagnosticSegment>,
+    pub total_len: usize,
+}
+
+impl Gemma3nDiagnosticLayout {
+    pub fn validate(&self) -> Result<(), String> {
+        let mut offset = 0usize;
+        for segment in &self.segments {
+            let len = segment
+                .shape
+                .iter()
+                .try_fold(1usize, |product, dim| product.checked_mul(*dim))
+                .ok_or_else(|| format!("diagnostic segment {} overflows", segment.name))?;
+            if segment.offset != offset || segment.len != len {
+                return Err(format!(
+                    "diagnostic segment {} has offset/len {}/{}, expected {offset}/{len}",
+                    segment.name, segment.offset, segment.len
+                ));
+            }
+            offset = offset
+                .checked_add(len)
+                .ok_or_else(|| "diagnostic layout length overflows".to_string())?;
+        }
+        if offset != self.total_len {
+            return Err(format!(
+                "diagnostic layout total_len={} but segments end at {offset}",
+                self.total_len
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn segment(&self, name: &str) -> Option<&Gemma3nDiagnosticSegment> {
+        self.segments.iter().find(|segment| segment.name == name)
+    }
+}
+
+pub fn gemma3n_diagnostic_layout(c: &Gemma3nConfig) -> Gemma3nDiagnosticLayout {
+    let capacity = c.context_capacity;
+    let shapes = [
+        ("scaled_embeddings", vec![capacity, c.hidden]),
+        (
+            "projected_ple",
+            vec![capacity, c.n_layers, c.hidden_per_layer_input],
+        ),
+        ("layer0_laurel", vec![capacity, c.hidden]),
+        ("layer0_ple_injected", vec![capacity, c.hidden]),
+        (
+            "layer0_all_planes",
+            vec![c.altup_num_inputs, capacity, c.hidden],
+        ),
+        ("layer0_active_plane", vec![capacity, c.hidden]),
+        (
+            "layer_mid_all_planes",
+            vec![c.altup_num_inputs, capacity, c.hidden],
+        ),
+        ("layer_mid_active_plane", vec![capacity, c.hidden]),
+        (
+            "layer_last_all_planes",
+            vec![c.altup_num_inputs, capacity, c.hidden],
+        ),
+        ("layer_last_active_plane", vec![capacity, c.hidden]),
+        ("layer0_k", vec![capacity, c.n_kv, c.head_dim]),
+        ("layer0_v", vec![capacity, c.n_kv, c.head_dim]),
+        ("final_hidden", vec![capacity, c.hidden]),
+        ("logits", vec![c.vocab]),
+    ];
+    let mut offset = 0usize;
+    let segments = shapes
+        .into_iter()
+        .map(|(name, shape)| {
+            let len = shape.iter().product();
+            let segment = Gemma3nDiagnosticSegment {
+                name,
+                shape,
+                offset,
+                len,
+            };
+            offset += len;
+            segment
+        })
+        .collect();
+    Gemma3nDiagnosticLayout {
+        segments,
+        total_len: offset,
+    }
+}
+
+fn gemma3n_all_layer_diagnostic_window(c: &Gemma3nConfig) -> (usize, usize) {
+    const START_ENV: &str = "MLXCEL_XLA_GEMMA3N_TRACE_LAYER_START";
+    let start = std::env::var(START_ENV)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|error| panic!("{START_ENV} must be an unsigned integer: {error}"))
+        })
+        .unwrap_or(0);
+    assert!(
+        start < c.n_layers,
+        "{START_ENV}={start} must be less than the Gemma3n layer count {}",
+        c.n_layers
+    );
+    (start, (c.n_layers - start).min(10))
+}
+
+pub fn gemma3n_all_layer_diagnostic_layout(c: &Gemma3nConfig) -> Gemma3nDiagnosticLayout {
+    // Keep this targeted trace deliberately bounded. It exists to locate the
+    // first cross-runtime divergence in one ten-layer window, not to expose
+    // every capacity row or retain every logical layer in one IREE result.
+    let (_, layer_count) = gemma3n_all_layer_diagnostic_window(c);
+    let rows = c.context_capacity.min(3);
+    let shapes = [
+        (
+            "all_layer_all_planes",
+            vec![layer_count, c.altup_num_inputs, rows, c.hidden],
+        ),
+        ("all_layer_active_planes", vec![layer_count, rows, c.hidden]),
+    ];
+    let mut offset = 0usize;
+    let segments = shapes
+        .into_iter()
+        .map(|(name, shape)| {
+            let len = shape.iter().product();
+            let segment = Gemma3nDiagnosticSegment {
+                name,
+                shape,
+                offset,
+                len,
+            };
+            offset += len;
+            segment
+        })
+        .collect();
+    Gemma3nDiagnosticLayout {
+        segments,
+        total_len: offset,
+    }
+}
+
+#[cfg(feature = "diagnostics")]
+pub(crate) fn emit_gemma3n_prefill_diagnostics_with(
+    c: &Gemma3nConfig,
+    precision: Precision,
+) -> (String, Gemma3nDiagnosticLayout) {
+    let layout = gemma3n_diagnostic_layout(c);
+    layout
+        .validate()
+        .expect("validated Gemma3n diagnostic layout");
+    (
+        emit_inner(c, false, false, precision, true, false, false),
+        layout,
+    )
+}
+
+#[cfg(feature = "diagnostics")]
+pub(crate) fn emit_gemma3n_prefill_diagnostics_with_qmv(
+    c: &Gemma3nConfig,
+    precision: Precision,
+    native_qmv: bool,
+) -> (String, Gemma3nDiagnosticLayout) {
+    let layout = gemma3n_diagnostic_layout(c);
+    layout
+        .validate()
+        .expect("validated Gemma3n diagnostic layout");
+    (
+        emit_inner(c, false, false, precision, true, false, native_qmv),
+        layout,
+    )
+}
+
+#[cfg(feature = "diagnostics")]
+pub(crate) fn emit_gemma3n_all_layer_diagnostics_with_qmv(
+    c: &Gemma3nConfig,
+    precision: Precision,
+    native_qmv: bool,
+) -> (String, Gemma3nDiagnosticLayout) {
+    let layout = gemma3n_all_layer_diagnostic_layout(c);
+    layout
+        .validate()
+        .expect("validated Gemma3n all-layer diagnostic layout");
+    (
+        emit_inner(c, false, false, precision, false, true, native_qmv),
+        layout,
+    )
+}
+
 fn emit(c: &Gemma3nConfig, sample: bool, prepared: bool, precision: Precision) -> String {
+    emit_inner(c, sample, prepared, precision, false, false, false)
+}
+
+fn emit_inner(
+    c: &Gemma3nConfig,
+    sample: bool,
+    prepared: bool,
+    precision: Precision,
+    diagnostics: bool,
+    all_layer_diagnostics: bool,
+    native_qmv: bool,
+) -> String {
+    assert!(
+        !(diagnostics && all_layer_diagnostics),
+        "Gemma3n diagnostic modes are mutually exclusive"
+    );
     let lp = c.context_capacity;
-    let mut b = Builder::new().with_precision(precision);
-    let (decls, args) = build_schema(c, prepared, lp, false);
+    // Gemma3n has an explicit BF16 activation stream with small F32 AltUp
+    // coefficient islands. A global contraction precision would incorrectly
+    // demote those coefficient matrices (and CUDA's generic default is F16), so
+    // keep the builder F32 and place BF16 boundaries locally.
+    let _ = precision;
+    let mut b = Builder::new().with_gemma3n_qmv(native_qmv);
+    let (decls, args) = build_schema(c, prepared, lp, false, false);
     let k = constants(&mut b, c);
     let (base, dense_ple) = input_head(&mut b, c, &k, &args, lp);
+    let diagnostic_base = diagnostics.then(|| base.clone());
+    let diagnostic_ple = diagnostics.then(|| dense_ple.clone());
+    let mut diagnostic_layer0_laurel = None;
+    let mut diagnostic_layer0_ple_injected = None;
+    let mut diagnostic_layer0_planes = None;
+    let mut diagnostic_layer_mid_planes = None;
+    let mut diagnostic_layer_last_planes = None;
+    let mut diagnostic_layer0_k = None;
+    let mut diagnostic_layer0_v = None;
+    let mut diagnostic_all_layer_planes = Vec::new();
     let target = magnitude(&mut b, &base, c, &k);
     let mut planes = vec![base.clone()];
     for projection in &args.weights.initial_projections {
-        let projected = b.linear_seq(&base, projection);
+        let projected = linear_seq_bf16(&mut b, &base, projection);
         planes.push(normalize_to(&mut b, &projected, &target, &k));
     }
     let full_mask = args
@@ -37,7 +301,10 @@ fn emit(c: &Gemma3nConfig, sample: bool, prepared: bool, precision: Precision) -
         .clone()
         .unwrap_or_else(|| causal_mask(&mut b, lp, None, &k));
     let sliding_mask = apply_sliding_window(&mut b, &full_mask, lp, c.sliding_window, &k);
-    let cache_map = c.layer_to_cache().expect("validated Gemma3n KV map");
+    let cache_map = c
+        .kv_cache_contract()
+        .expect("validated Gemma3n KV map")
+        .logical_to_physical;
     let cache_shape = vec![c.kv_cache_layers(), lp, c.n_kv, c.head_dim];
     let mut kcache = b.broadcast(&k.zero, &[], cache_shape.clone());
     let mut vcache = b.broadcast(&k.zero, &[], cache_shape.clone());
@@ -45,11 +312,12 @@ fn emit(c: &Gemma3nConfig, sample: bool, prepared: bool, precision: Precision) -
         let lw = &args.weights.layers[layer];
         let predicted = altup_predict(&mut b, &planes, lw, c, &k, lp);
         let active = &predicted[c.altup_active_idx];
-        let normalized = rms_last(&mut b, active, Some(&lw.input_norm), &k.eps, &k.zero);
-        let laurel = b.linear_seq(&normalized, &lw.laurel_left);
-        let laurel = b.linear_seq(&laurel, &lw.laurel_right);
-        let laurel = rms_last(&mut b, &laurel, Some(&lw.laurel_norm), &k.eps, &k.zero);
+        let normalized = rms_last_bf16(&mut b, active, Some(&lw.input_norm), &k.eps, &k.zero);
+        let laurel = linear_seq_bf16(&mut b, &normalized, &lw.laurel_left);
+        let laurel = linear_seq_bf16(&mut b, &laurel, &lw.laurel_right);
+        let laurel = rms_last_bf16(&mut b, &laurel, Some(&lw.laurel_norm), &k.eps, &k.zero);
         let laurel = b.add(&normalized, &laurel);
+        let laurel = round_bf16(&mut b, &laurel);
         let mask = match c.layer_types[layer] {
             Gemma3nLayerType::Full => &full_mask,
             Gemma3nLayerType::Sliding => &sliding_mask,
@@ -58,6 +326,7 @@ fn emit(c: &Gemma3nConfig, sample: bool, prepared: bool, precision: Precision) -
             &mut b,
             &normalized,
             &args.positions,
+            &args.real_len,
             mask,
             lw,
             layer,
@@ -67,55 +336,108 @@ fn emit(c: &Gemma3nConfig, sample: bool, prepared: bool, precision: Precision) -
             &mut kcache,
             &mut vcache,
         );
-        let attended = rms_last(&mut b, &attended, Some(&lw.post_attn_norm), &k.eps, &k.zero);
+        let attended = rms_last_bf16(&mut b, &attended, Some(&lw.post_attn_norm), &k.eps, &k.zero);
         let inv = b.broadcast(&k.inv_sqrt2, &[], vec![lp, c.hidden]);
         let residual = b.add(active, &attended);
+        let residual = round_bf16(&mut b, &residual);
         let residual = b.add(&residual, &laurel);
+        let residual = round_bf16(&mut b, &residual);
         let residual = b.multiply(&residual, &inv);
-        let ff_input = rms_last(&mut b, &residual, Some(&lw.pre_ff_norm), &k.eps, &k.zero);
-        let gate = b.linear_seq(&ff_input, &lw.gate);
-        let up = b.linear_seq(&ff_input, &lw.up);
-        let activated_gate = if c.activation_sparsity[layer] > 0.0 {
-            sparse_gelu(&mut b, &gate, c.activation_sparsity[layer], &k)
+        let residual = round_bf16(&mut b, &residual);
+        let ff_input = rms_last_bf16(&mut b, &residual, Some(&lw.pre_ff_norm), &k.eps, &k.zero);
+        let gate = linear_seq_bf16(&mut b, &ff_input, &lw.gate);
+        let up = linear_seq_bf16(&mut b, &ff_input, &lw.up);
+        let mlp = if c.activation_sparsity[layer] > 0.0 {
+            let activated_gate = sparse_gelu(&mut b, &gate, c.activation_sparsity[layer], &k);
+            let product = b.multiply(&activated_gate, &up);
+            round_bf16(&mut b, &product)
         } else {
-            super::gemma3n_emit_ops::gelu(&mut b, &gate)
+            geglu(&mut b, &gate, &up)
         };
-        let mlp = b.multiply(&activated_gate, &up);
-        let mlp = b.linear_seq(&mlp, &lw.down);
-        let mlp = rms_last(&mut b, &mlp, Some(&lw.post_ff_norm), &k.eps, &k.zero);
+        let mlp = linear_seq_bf16(&mut b, &mlp, &lw.down);
+        let mlp = rms_last_bf16(&mut b, &mlp, Some(&lw.post_ff_norm), &k.eps, &k.zero);
         let activated = b.add(&residual, &mlp);
+        let activated = round_bf16(&mut b, &activated);
         planes = altup_correct(&mut b, &predicted, &activated, lw, c, &k, lp);
         let mut corrected_active = planes[c.altup_active_idx].clone();
         if c.altup_correct_scale {
             let scale = b.broadcast(&lw.correct_scale, &[1], vec![lp, c.hidden]);
             corrected_active = b.multiply(&corrected_active, &scale);
+            corrected_active = round_bf16(&mut b, &corrected_active);
         }
         let ple = b.slice(
             &dense_ple,
             &[(0, lp), (layer, layer + 1), (0, c.hidden_per_layer_input)],
         );
         let ple = b.reshape(&ple, vec![lp, c.hidden_per_layer_input]);
-        let ple_gate = b.linear_seq(&corrected_active, &lw.ple_gate);
+        let ple_gate = linear_seq_bf16(&mut b, &corrected_active, &lw.ple_gate);
         let injected = geglu(&mut b, &ple_gate, &ple);
-        let injected = b.linear_seq(&injected, &lw.ple_projection);
-        let injected = rms_last(&mut b, &injected, Some(&lw.ple_norm), &k.eps, &k.zero);
+        let injected = linear_seq_bf16(&mut b, &injected, &lw.ple_projection);
+        let injected = rms_last_bf16(&mut b, &injected, Some(&lw.ple_norm), &k.eps, &k.zero);
         for (plane, value) in planes.iter_mut().enumerate() {
             if plane != c.altup_active_idx {
                 *value = b.add(value, &injected);
+                *value = round_bf16(&mut b, value);
+            }
+        }
+        if all_layer_diagnostics {
+            let (trace_layer_start, trace_layer_count) = gemma3n_all_layer_diagnostic_window(c);
+            if layer >= trace_layer_start && layer < trace_layer_start + trace_layer_count {
+                diagnostic_all_layer_planes.push(planes.clone());
+            }
+        }
+        if diagnostics {
+            if layer == 0 {
+                let layer0_cache = c
+                    .kv_cache_contract()
+                    .expect("validated Gemma3n KV map")
+                    .logical_to_physical[0];
+                assert_eq!(
+                    cache_index, layer0_cache,
+                    "layer0 diagnostic must capture its concrete physical cache"
+                );
+                diagnostic_layer0_laurel = Some(laurel.clone());
+                diagnostic_layer0_ple_injected = Some(injected.clone());
+                diagnostic_layer0_planes = Some(planes.clone());
+                let keys = b.slice(
+                    &kcache,
+                    &[
+                        (cache_index, cache_index + 1),
+                        (0, lp),
+                        (0, c.n_kv),
+                        (0, c.head_dim),
+                    ],
+                );
+                diagnostic_layer0_k = Some(b.reshape(&keys, vec![lp, c.n_kv, c.head_dim]));
+                let values = b.slice(
+                    &vcache,
+                    &[
+                        (cache_index, cache_index + 1),
+                        (0, lp),
+                        (0, c.n_kv),
+                        (0, c.head_dim),
+                    ],
+                );
+                diagnostic_layer0_v = Some(b.reshape(&values, vec![lp, c.n_kv, c.head_dim]));
+            }
+            if layer == c.n_layers / 2 {
+                diagnostic_layer_mid_planes = Some(planes.clone());
+            }
+            if layer + 1 == c.n_layers {
+                diagnostic_layer_last_planes = Some(planes.clone());
             }
         }
     }
     let target = magnitude(&mut b, &planes[c.altup_active_idx], c, &k);
-    let mut collapsed = planes[c.altup_active_idx].clone();
+    let mut collapsed_planes = vec![planes[c.altup_active_idx].clone()];
     for (index, projection) in args.weights.unembed_projections.iter().enumerate() {
-        let projected = b.linear_seq(&planes[index + 1], projection);
+        let projected = linear_seq_bf16(&mut b, &planes[index + 1], projection);
         let projected = normalize_to(&mut b, &projected, &target, &k);
-        collapsed = b.add(&collapsed, &projected);
+        collapsed_planes.push(projected);
     }
-    let count = b.const_f32(c.altup_num_inputs as f32);
-    let count = b.broadcast(&count, &[], vec![lp, c.hidden]);
-    collapsed = b.divide(&collapsed, &count);
-    let normalized = rms_last(
+    assert_eq!(collapsed_planes.len(), c.altup_num_inputs);
+    let collapsed = mean_planes_bf16(&mut b, &collapsed_planes, &k.zero);
+    let normalized = rms_last_bf16(
         &mut b,
         &collapsed,
         Some(&args.weights.final_norm),
@@ -127,13 +449,92 @@ fn emit(c: &Gemma3nConfig, sample: bool, prepared: bool, precision: Precision) -
     let zero = b.const_i32(0);
     let row = b.dynamic_slice(&normalized, &[&last_index, &zero], vec![1, c.hidden]);
     let row = b.reshape(&row, vec![c.hidden]);
-    let logits = b.linear(&row, &args.weights.embed);
-    let cap = b.const_f32(c.final_logit_softcap);
-    let cap_b = b.broadcast(&cap, &[], vec![c.vocab]);
-    let logits = b.divide(&logits, &cap_b);
-    let logits = b.tanh(&logits);
-    let logits = b.multiply(&logits, &cap_b);
-    let (result, result_ty) = if sample {
+    let logits = linear_bf16(&mut b, &row, &args.weights.embed);
+    let logits = if let Some(cap) = c.final_logit_softcap {
+        let cap = bf16_scalar(&mut b, cap);
+        let cap_b = b.broadcast(&cap, &[], vec![c.vocab]);
+        let logits = b.divide(&logits, &cap_b);
+        let logits = round_bf16(&mut b, &logits);
+        let logits = b.gemma3n_tanh(&logits);
+        let logits = round_bf16(&mut b, &logits);
+        let logits = b.multiply(&logits, &cap_b);
+        round_bf16(&mut b, &logits)
+    } else {
+        logits
+    };
+    let (result, result_ty) = if all_layer_diagnostics {
+        let (trace_layer_start, trace_layer_count) = gemma3n_all_layer_diagnostic_window(c);
+        let trace_rows = c.context_capacity.min(3);
+        assert_eq!(
+            diagnostic_all_layer_planes.len(),
+            trace_layer_count,
+            "Gemma3n layer-window diagnostics must capture the bounded logical-layer window \
+             starting at {trace_layer_start}"
+        );
+        let layout = gemma3n_all_layer_diagnostic_layout(c);
+        let all_planes = flatten_all_layer_diagnostic_planes(
+            &mut b,
+            &diagnostic_all_layer_planes,
+            trace_rows,
+            c.hidden,
+        );
+        let active = b.slice(
+            &diagnostic_all_layer_planes[0][c.altup_active_idx],
+            &[(0, trace_rows), (0, c.hidden)],
+        );
+        let mut active_planes = b.reshape(&active, vec![trace_rows * c.hidden]);
+        for layer_planes in &diagnostic_all_layer_planes[1..] {
+            let active = b.slice(
+                &layer_planes[c.altup_active_idx],
+                &[(0, trace_rows), (0, c.hidden)],
+            );
+            let active = b.reshape(&active, vec![trace_rows * c.hidden]);
+            active_planes = b.concatenate(&active_planes, &active, 0);
+        }
+        let all_planes = b.reshape(&all_planes, vec![layout.segments[0].len]);
+        let active_planes = b.reshape(&active_planes, vec![layout.segments[1].len]);
+        let flat = b.concatenate(&all_planes, &active_planes, 0);
+        assert_eq!(flat.ty.shape, vec![layout.total_len]);
+        (flat.name, flat.ty.render())
+    } else if diagnostics {
+        let layout = gemma3n_diagnostic_layout(c);
+        let layer0_planes =
+            diagnostic_layer0_planes.expect("Gemma3n diagnostics capture layer0 planes");
+        let layer_mid_planes =
+            diagnostic_layer_mid_planes.expect("Gemma3n diagnostics capture middle-layer planes");
+        let layer_last_planes =
+            diagnostic_layer_last_planes.expect("Gemma3n diagnostics capture last-layer planes");
+        let layer0_active = layer0_planes[c.altup_active_idx].clone();
+        let layer_mid_active = layer_mid_planes[c.altup_active_idx].clone();
+        let layer_last_active = layer_last_planes[c.altup_active_idx].clone();
+        let layer0_all = flatten_diagnostic_planes(&mut b, &layer0_planes, lp, c.hidden);
+        let layer_mid_all = flatten_diagnostic_planes(&mut b, &layer_mid_planes, lp, c.hidden);
+        let layer_last_all = flatten_diagnostic_planes(&mut b, &layer_last_planes, lp, c.hidden);
+        let values = [
+            diagnostic_base.expect("Gemma3n diagnostics capture input"),
+            diagnostic_ple.expect("Gemma3n diagnostics capture PLE"),
+            diagnostic_layer0_laurel.expect("Gemma3n diagnostics capture layer0 LAUREL"),
+            diagnostic_layer0_ple_injected
+                .expect("Gemma3n diagnostics capture layer0 PLE injection"),
+            layer0_all,
+            layer0_active,
+            layer_mid_all,
+            layer_mid_active,
+            layer_last_all,
+            layer_last_active,
+            diagnostic_layer0_k.expect("Gemma3n diagnostics capture layer0 K"),
+            diagnostic_layer0_v.expect("Gemma3n diagnostics capture layer0 V"),
+            normalized.clone(),
+            logits.clone(),
+        ];
+        let mut flat = b.reshape(&values[0], vec![layout.segments[0].len]);
+        for (value, segment) in values.iter().skip(1).zip(layout.segments.iter().skip(1)) {
+            let value = b.reshape(value, vec![segment.len]);
+            flat = b.concatenate(&flat, &value, 0);
+        }
+        assert_eq!(flat.ty.shape, vec![layout.total_len]);
+        (flat.name, flat.ty.render())
+    } else if sample {
         let token = b.argmax(&logits);
         (token.name, token.ty.render())
     } else {
@@ -142,6 +543,8 @@ fn emit(c: &Gemma3nConfig, sample: bool, prepared: bool, precision: Precision) -
     render_module(
         if prepared {
             "prefill_embeddings_ple"
+        } else if diagnostics || all_layer_diagnostics {
+            "prefill_diagnostics"
         } else {
             "prefill"
         },
@@ -154,6 +557,45 @@ fn emit(c: &Gemma3nConfig, sample: bool, prepared: bool, precision: Precision) -
     )
 }
 
+fn flatten_diagnostic_planes(b: &mut Builder, planes: &[Val], rows: usize, hidden: usize) -> Val {
+    let mut flattened = b.reshape(&planes[0], vec![rows * hidden]);
+    for plane in &planes[1..] {
+        let plane = b.reshape(plane, vec![rows * hidden]);
+        flattened = b.concatenate(&flattened, &plane, 0);
+    }
+    flattened
+}
+
+fn flatten_all_layer_diagnostic_planes(
+    b: &mut Builder,
+    layers: &[Vec<Val>],
+    rows: usize,
+    hidden: usize,
+) -> Val {
+    let mut flattened = flatten_diagnostic_plane_prefix(b, &layers[0], rows, hidden);
+    for planes in &layers[1..] {
+        let layer = flatten_diagnostic_plane_prefix(b, planes, rows, hidden);
+        flattened = b.concatenate(&flattened, &layer, 0);
+    }
+    flattened
+}
+
+fn flatten_diagnostic_plane_prefix(
+    b: &mut Builder,
+    planes: &[Val],
+    rows: usize,
+    hidden: usize,
+) -> Val {
+    let first = b.slice(&planes[0], &[(0, rows), (0, hidden)]);
+    let mut flattened = b.reshape(&first, vec![rows * hidden]);
+    for plane in &planes[1..] {
+        let plane = b.slice(plane, &[(0, rows), (0, hidden)]);
+        let plane = b.reshape(&plane, vec![rows * hidden]);
+        flattened = b.concatenate(&flattened, &plane, 0);
+    }
+    flattened
+}
+
 pub(super) fn input_head(
     b: &mut Builder,
     c: &Gemma3nConfig,
@@ -161,72 +603,88 @@ pub(super) fn input_head(
     a: &Args,
     lp: usize,
 ) -> (Val, Val) {
-    let ple_width = c.n_layers * c.hidden_per_layer_input;
     match &a.input {
         Input::Prepared {
             embeddings,
             dense_ple,
-        } => (embeddings.clone(), dense_ple.clone()),
-        Input::Tokens(tokens) => {
-            let tokens = if tokens.ty.shape.is_empty() {
-                b.reshape(tokens, vec![1])
-            } else {
-                tokens.clone()
-            };
-            let indices = b.reshape(&tokens, vec![lp, 1]);
-            let base = b.gather(&a.weights.embed, &indices);
-            let scale = b.const_f32((c.hidden as f32).sqrt());
-            let scale = b.broadcast(&scale, &[], vec![lp, c.hidden]);
-            let base = b.multiply(&base, &scale);
-            let limit = b.const_i32(c.per_layer_vocab as i32);
-            let limit = b.broadcast(&limit, &[], vec![lp]);
-            let zero_i = b.const_i32(0);
-            let zero_ids = b.broadcast(&zero_i, &[], vec![lp]);
-            let nonnegative = b.compare("GE", &tokens, &zero_ids, "SIGNED");
-            let below = b.compare("LT", &tokens, &limit, "SIGNED");
-            let valid = b.select(&nonnegative, &below, &nonnegative);
-            let safe = b.select(&valid, &tokens, &zero_ids);
-            let safe = b.reshape(&safe, vec![lp, 1]);
-            let token_ple = b.gather(&a.weights.token_ple, &safe);
-            let zeros = b.broadcast(&k.zero, &[], vec![lp, ple_width]);
-            let valid = b.broadcast(&valid, &[0], vec![lp, ple_width]);
-            let token_ple = b.select(&valid, &token_ple, &zeros);
-            let token_scale = b.const_f32((c.hidden_per_layer_input as f32).sqrt());
-            let token_scale = b.broadcast(&token_scale, &[], vec![lp, ple_width]);
-            let token_ple = b.multiply(&token_ple, &token_scale);
-            let projected = b.linear_seq(&base, &a.weights.ple_projection);
-            let model_scale = b.const_f32((c.hidden as f32).sqrt().recip());
-            let model_scale = b.broadcast(&model_scale, &[], vec![lp, ple_width]);
-            let projected = b.multiply(&projected, &model_scale);
-            let projected = b.reshape(&projected, vec![lp, c.n_layers, c.hidden_per_layer_input]);
-            let projected = rms_last(
-                b,
-                &projected,
-                Some(&a.weights.ple_projection_norm),
-                &k.eps,
-                &k.zero,
-            );
-            let token_ple = b.reshape(&token_ple, vec![lp, c.n_layers, c.hidden_per_layer_input]);
-            let inv = b.broadcast(
-                &k.inv_sqrt2,
-                &[],
-                vec![lp, c.n_layers, c.hidden_per_layer_input],
-            );
-            let combined = b.add(&projected, &token_ple);
-            let combined = b.multiply(&combined, &inv);
-            (base, combined)
-        }
+        } => (round_bf16(b, embeddings), round_bf16(b, dense_ple)),
+        Input::Tokens(tokens) => token_input_head(b, c, k, &a.weights, tokens, lp),
     }
+}
+
+pub(super) fn token_input_head(
+    b: &mut Builder,
+    c: &Gemma3nConfig,
+    k: &Constants,
+    weights: &Weights,
+    tokens: &Val,
+    lp: usize,
+) -> (Val, Val) {
+    let ple_width = c.n_layers * c.hidden_per_layer_input;
+    let tokens = if tokens.ty.shape.is_empty() {
+        b.reshape(tokens, vec![1])
+    } else {
+        tokens.clone()
+    };
+    let indices = b.reshape(&tokens, vec![lp, 1]);
+    let base = b.gather(&weights.embed, &indices);
+    let scale = bf16_scalar(b, (c.hidden as f32).sqrt());
+    let scale = b.broadcast(&scale, &[], vec![lp, c.hidden]);
+    let base = b.multiply(&base, &scale);
+    let base = round_bf16(b, &base);
+    let limit = b.const_i32(c.per_layer_vocab as i32);
+    let limit = b.broadcast(&limit, &[], vec![lp]);
+    let zero_i = b.const_i32(0);
+    let zero_ids = b.broadcast(&zero_i, &[], vec![lp]);
+    let nonnegative = b.compare("GE", &tokens, &zero_ids, "SIGNED");
+    let below = b.compare("LT", &tokens, &limit, "SIGNED");
+    let valid = b.select(&nonnegative, &below, &nonnegative);
+    let safe = b.select(&valid, &tokens, &zero_ids);
+    let safe = b.reshape(&safe, vec![lp, 1]);
+    let token_ple = b.gather(&weights.token_ple, &safe);
+    let zeros = b.broadcast(&k.zero, &[], vec![lp, ple_width]);
+    let valid = b.broadcast(&valid, &[0], vec![lp, ple_width]);
+    let token_ple = b.select(&valid, &token_ple, &zeros);
+    let token_scale = bf16_scalar(b, (c.hidden_per_layer_input as f32).sqrt());
+    let token_scale = b.broadcast(&token_scale, &[], vec![lp, ple_width]);
+    let token_ple = b.multiply(&token_ple, &token_scale);
+    let token_ple = round_bf16(b, &token_ple);
+    let projected = linear_seq_bf16(b, &base, &weights.ple_projection);
+    let model_scale = bf16_scalar(b, (c.hidden as f32).sqrt().recip());
+    let model_scale = b.broadcast(&model_scale, &[], vec![lp, ple_width]);
+    let projected = b.multiply(&projected, &model_scale);
+    let projected = round_bf16(b, &projected);
+    let projected = b.reshape(&projected, vec![lp, c.n_layers, c.hidden_per_layer_input]);
+    let projected = rms_last_bf16(
+        b,
+        &projected,
+        Some(&weights.ple_projection_norm),
+        &k.eps,
+        &k.zero,
+    );
+    let token_ple = b.reshape(&token_ple, vec![lp, c.n_layers, c.hidden_per_layer_input]);
+    let inv = b.broadcast(
+        &k.inv_sqrt2,
+        &[],
+        vec![lp, c.n_layers, c.hidden_per_layer_input],
+    );
+    let combined = b.add(&projected, &token_ple);
+    let combined = round_bf16(b, &combined);
+    let combined = b.multiply(&combined, &inv);
+    let combined = round_bf16(b, &combined);
+    (base, combined)
 }
 
 fn magnitude(b: &mut Builder, value: &Val, c: &Gemma3nConfig, k: &Constants) -> Val {
     let sq = b.multiply(value, value);
+    let sq = round_bf16(b, &sq);
     let sum = b.reduce_add(&sq, 1, &k.zero);
+    let sum = round_bf16(b, &sum);
     let width = b.broadcast(&k.hidden, &[], vec![c.context_capacity]);
     let mean = b.divide(&sum, &width);
-    let inverse = b.rsqrt(&mean);
-    let one = b.broadcast(&k.one, &[], vec![c.context_capacity]);
-    b.divide(&one, &inverse)
+    let mean = round_bf16(b, &mean);
+    let magnitude = b.sqrt(&mean);
+    round_bf16(b, &magnitude)
 }
 
 fn render_module(
@@ -245,8 +703,18 @@ fn render_module(
         .collect::<Vec<_>>()
         .join(", ");
     let cache_ty = kcache.ty.render();
+    let target_alias = if b.gemma3n_qmv_enabled() {
+        gemma3n_qmv::target_alias()
+    } else {
+        ""
+    };
+    let executable_source = if b.gemma3n_qmv_enabled() {
+        gemma3n_qmv::executable_source()
+    } else {
+        String::new()
+    };
     format!(
-        "module @{name} {{\n  func.func public @main({signature}) -> ({result_ty}, \
+        "{target_alias}module @{name} {{\n{executable_source}  func.func public @main({signature}) -> ({result_ty}, \
          {cache_ty}, {cache_ty}) {{\n{body}    return {result}, {kc}, {vc} : \
          {result_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
         body = b.body(),
@@ -264,6 +732,7 @@ mod tests {
             &serde_json::json!({
                 "model_type": "gemma3n_text",
                 "hidden_size": 8, "intermediate_size": [12, 12, 12, 12],
+                "max_position_embeddings": 4096,
                 "num_hidden_layers": 4, "num_attention_heads": 2,
                 "num_key_value_heads": 1, "head_dim": 4, "rms_norm_eps": 1e-6,
                 "vocab_size": 12, "vocab_size_per_layer_input": 10,
@@ -302,6 +771,185 @@ mod tests {
         assert!(decode.contains("module @decode_step"));
         assert!(decode.contains("tensor<2x4x1x4xf32> loc(\"kcache\")"));
         assert!(!decode.contains("layers.2.self_attn.k_proj.weight"));
+        let ragged = super::super::gemma3n_decode::emit_gemma3n_decode_ragged(&c, 4, false);
+        assert!(ragged.contains("tensor<4x2x4x1x4xf32> loc(\"kcache\")"));
+        assert!(ragged.contains("tensor<4x12xf32>"));
+        assert!(!ragged.contains("layers.2.self_attn.k_proj.weight"));
+        #[cfg(xla_iree_cuda)]
+        {
+            let mut native = c.clone();
+            native.altup_num_inputs = 4;
+            for (name, graph) in [
+                (
+                    "normal",
+                    super::super::gemma3n_decode::emit_gemma3n_decode_with_qmv(
+                        &native,
+                        true,
+                        Precision::F32,
+                        true,
+                    ),
+                ),
+                (
+                    "ragged",
+                    super::super::gemma3n_decode::emit_gemma3n_decode_ragged_with_qmv(
+                        &native,
+                        4,
+                        false,
+                        Precision::F32,
+                        true,
+                    ),
+                ),
+            ] {
+                assert!(graph.contains("gemma3n-qmv:kernel-v8:abi-v6:min-sm80"));
+                assert!(graph.contains("hal.executable.source private @custom_qmv"));
+                for export in [
+                    "gemma3n_qmv",
+                    "gemma3n_tanh",
+                    "gemma3n_altup_coeff",
+                    "gemma3n_altup_predict",
+                    "gemma3n_geglu_bf16",
+                ] {
+                    assert!(
+                        graph.contains(&format!("flow.dispatch @custom_qmv::@{export}")),
+                        "{name} decode is missing native {export} dispatch"
+                    );
+                }
+                assert!(
+                    !graph.contains("flow.dispatch @custom_qmv::@gemma3n_sdpa_vector"),
+                    "{name} D=4 decode must retain materialized attention"
+                );
+            }
+
+            let mut native_sdpa = native.clone();
+            native_sdpa.hidden = 512;
+            native_sdpa.n_q = 2;
+            native_sdpa.n_kv = 1;
+            native_sdpa.head_dim = 256;
+            native_sdpa.sliding_window = native_sdpa.context_capacity;
+            for (name, graph, expected_dispatches) in [
+                (
+                    "normal",
+                    super::super::gemma3n_decode::emit_gemma3n_decode_with_qmv(
+                        &native_sdpa,
+                        true,
+                        Precision::F32,
+                        true,
+                    ),
+                    native_sdpa.n_layers,
+                ),
+                (
+                    "ragged",
+                    super::super::gemma3n_decode::emit_gemma3n_decode_ragged_with_qmv(
+                        &native_sdpa,
+                        4,
+                        false,
+                        Precision::F32,
+                        true,
+                    ),
+                    native_sdpa.n_layers * 4,
+                ),
+            ] {
+                assert_eq!(
+                    graph
+                        .matches("flow.dispatch @custom_qmv::@gemma3n_sdpa_vector")
+                        .count(),
+                    expected_dispatches,
+                    "{name} safe D=256 decode must use native SDPA for every layer"
+                );
+                assert!(
+                    !graph.contains("stablehlo.exponential"),
+                    "{name} all-native decode must omit materialized softmax"
+                );
+            }
+
+            native_sdpa.sliding_window = native_sdpa.context_capacity - 1;
+            let mixed = super::super::gemma3n_decode::emit_gemma3n_decode_with_qmv(
+                &native_sdpa,
+                true,
+                Precision::F32,
+                true,
+            );
+            assert_eq!(
+                mixed
+                    .matches("flow.dispatch @custom_qmv::@gemma3n_sdpa_vector")
+                    .count(),
+                2,
+                "only full-attention layers are native when the sliding window truncates"
+            );
+            assert!(
+                mixed.contains("stablehlo.exponential"),
+                "truncated sliding-window layers must retain materialized softmax"
+            );
+        }
+    }
+
+    #[test]
+    fn gemma3n_precision_is_local_and_keeps_altup_coefficients_f32() {
+        let c = tiny();
+        let f32_graph = emit_gemma3n_prefill_with(&c, false, Precision::F32);
+        assert_eq!(
+            f32_graph,
+            emit_gemma3n_prefill_with(&c, false, Precision::F16)
+        );
+        assert_eq!(
+            f32_graph,
+            emit_gemma3n_prefill_with(&c, false, Precision::Bf16)
+        );
+        assert!(f32_graph.contains("-> tensor<4x8xbf16>"));
+        assert!(f32_graph.contains("(tensor<4x2xf32>, tensor<4x2xf32>) -> tensor<4x4xf32>"));
+        assert!(f32_graph.contains("altup.prediction_coefs.weight"));
+        assert!(f32_graph.contains("altup.correction_coefs.weight"));
+    }
+
+    #[test]
+    fn absent_softcap_skips_only_the_final_logit_tanh() {
+        let with_softcap = emit_gemma3n_prefill_with(&tiny(), false, Precision::Bf16);
+        let mut without = tiny();
+        without.final_logit_softcap = None;
+        let without_softcap = emit_gemma3n_prefill_with(&without, false, Precision::Bf16);
+        assert_eq!(
+            with_softcap.matches("stablehlo.tanh").count(),
+            without_softcap.matches("stablehlo.tanh").count() + 1
+        );
+    }
+
+    #[cfg(feature = "diagnostics")]
+    #[test]
+    fn diagnostic_layout_is_flat_stable_and_absent_from_normal_prefill() {
+        let c = tiny();
+        let expected = [
+            ("scaled_embeddings", vec![4, 8], 0, 32),
+            ("projected_ple", vec![4, 4, 2], 32, 32),
+            ("layer0_laurel", vec![4, 8], 64, 32),
+            ("layer0_ple_injected", vec![4, 8], 96, 32),
+            ("layer0_all_planes", vec![2, 4, 8], 128, 64),
+            ("layer0_active_plane", vec![4, 8], 192, 32),
+            ("layer_mid_all_planes", vec![2, 4, 8], 224, 64),
+            ("layer_mid_active_plane", vec![4, 8], 288, 32),
+            ("layer_last_all_planes", vec![2, 4, 8], 320, 64),
+            ("layer_last_active_plane", vec![4, 8], 384, 32),
+            ("layer0_k", vec![4, 1, 4], 416, 16),
+            ("layer0_v", vec![4, 1, 4], 432, 16),
+            ("final_hidden", vec![4, 8], 448, 32),
+            ("logits", vec![12], 480, 12),
+        ];
+        let (diagnostic, layout) = emit_gemma3n_prefill_diagnostics_with(&c, Precision::Bf16);
+        layout.validate().unwrap();
+        assert_eq!(layout.total_len, 492);
+        assert_eq!(layout.segments.len(), expected.len());
+        for (segment, (name, shape, offset, len)) in layout.segments.iter().zip(expected) {
+            assert_eq!(segment.name, name);
+            assert_eq!(segment.shape, shape);
+            assert_eq!(segment.offset, offset);
+            assert_eq!(segment.len, len);
+        }
+        assert!(diagnostic.contains("module @prefill_diagnostics"));
+        assert!(diagnostic.contains("tensor<492xf32>"));
+
+        let normal = emit_gemma3n_prefill_with(&c, false, Precision::Bf16);
+        assert!(normal.contains("module @prefill"));
+        assert!(!normal.contains("@prefill_diagnostics"));
+        assert!(!normal.contains("tensor<492xf32>"));
     }
 
     #[test]
@@ -311,7 +959,7 @@ mod tests {
             .expect("set MLXCEL_XLA_IREE_COMPILE to the pinned iree-compile");
         let target =
             std::env::var("MLXCEL_XLA_IREE_TEST_TARGET").unwrap_or_else(|_| "local".to_string());
-        for (tag, graph) in [
+        let graphs = vec![
             ("token", emit_gemma3n_prefill(&tiny(), true)),
             (
                 "embeddings-ple",
@@ -321,7 +969,21 @@ mod tests {
                 "decode",
                 super::super::gemma3n_decode::emit_gemma3n_decode(&tiny(), true),
             ),
-        ] {
+            (
+                "decode-ragged-b4",
+                super::super::gemma3n_decode::emit_gemma3n_decode_ragged(&tiny(), 4, false),
+            ),
+        ];
+        #[cfg(feature = "diagnostics")]
+        let graphs = {
+            let mut graphs = graphs;
+            graphs.push((
+                "diagnostics",
+                emit_gemma3n_prefill_diagnostics_with(&tiny(), Precision::Bf16).0,
+            ));
+            graphs
+        };
+        for (tag, graph) in graphs {
             let stem = format!("mlxcel-gemma3n-{tag}-{}", std::process::id());
             let input = std::env::temp_dir().join(format!("{stem}.mlir"));
             let output = std::env::temp_dir().join(format!("{stem}.vmfb"));

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_emit_ops.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_emit_ops.rs
@@ -1,0 +1,587 @@
+//! StableHLO building blocks shared by Gemma3n token and embeddings+PLE prefill.
+
+use super::builder::{Builder, Val};
+use super::gemma3n::Gemma3nConfig;
+use super::rope::{plain_inv_freq_with_base, rope_tables_from_inv};
+
+pub(super) struct Constants {
+    pub zero: Val,
+    pub one: Val,
+    pub eps: Val,
+    pub neg_inf: Val,
+    pub neg_big: Val,
+    pub hidden: Val,
+    pub inv_sqrt2: Val,
+    pub cos_global: Val,
+    pub sin_global: Val,
+    pub cos_local: Val,
+    pub sin_local: Val,
+}
+
+pub(super) struct LayerWeights {
+    pub correct_scale: Val,
+    pub correction: Val,
+    pub router: Val,
+    pub router_norm: Val,
+    pub prediction: Val,
+    pub laurel_left: Val,
+    pub laurel_right: Val,
+    pub laurel_norm: Val,
+    pub input_norm: Val,
+    pub post_attn_norm: Val,
+    pub pre_ff_norm: Val,
+    pub post_ff_norm: Val,
+    pub wq: Val,
+    pub wk: Option<Val>,
+    pub wv: Option<Val>,
+    pub wo: Val,
+    pub q_norm: Val,
+    pub k_norm: Option<Val>,
+    pub gate: Val,
+    pub up: Val,
+    pub down: Val,
+    pub ple_gate: Val,
+    pub ple_projection: Val,
+    pub ple_norm: Val,
+}
+
+pub(super) fn constants(b: &mut Builder, c: &Gemma3nConfig) -> Constants {
+    let (cg, sg) = rope_tables_from_inv(
+        &plain_inv_freq_with_base(c.head_dim, c.rope_theta),
+        c.head_dim,
+        c.context_capacity,
+        false,
+    );
+    let (cl, sl) = rope_tables_from_inv(
+        &plain_inv_freq_with_base(c.head_dim, c.rope_local_base),
+        c.head_dim,
+        c.context_capacity,
+        false,
+    );
+    Constants {
+        zero: b.const_f32(0.0),
+        one: b.const_f32(1.0),
+        eps: b.const_f32(c.eps),
+        neg_inf: b.const_f32(f32::NEG_INFINITY),
+        neg_big: b.const_f32(-1e30),
+        hidden: b.const_f32(c.hidden as f32),
+        inv_sqrt2: b.const_f32(std::f32::consts::FRAC_1_SQRT_2),
+        cos_global: b.const_tensor_f32(&cg, vec![c.context_capacity, c.head_dim]),
+        sin_global: b.const_tensor_f32(&sg, vec![c.context_capacity, c.head_dim]),
+        cos_local: b.const_tensor_f32(&cl, vec![c.context_capacity, c.head_dim]),
+        sin_local: b.const_tensor_f32(&sl, vec![c.context_capacity, c.head_dim]),
+    }
+}
+
+pub(super) fn rms_last(
+    b: &mut Builder,
+    x: &Val,
+    weight: Option<&Val>,
+    eps: &Val,
+    zero: &Val,
+) -> Val {
+    let axis = x.ty.shape.len() - 1;
+    let width = x.ty.shape[axis];
+    let reduced_shape: Vec<usize> =
+        x.ty.shape
+            .iter()
+            .enumerate()
+            .filter_map(|(i, d)| (i != axis).then_some(*d))
+            .collect();
+    let width_c = b.const_f32(width as f32);
+    let width_b = b.broadcast(&width_c, &[], reduced_shape.clone());
+    let sq = b.multiply(x, x);
+    let sum = b.reduce_add(&sq, axis, zero);
+    let mean = b.divide(&sum, &width_b);
+    let eps_b = b.broadcast(eps, &[], reduced_shape);
+    let mean = b.add(&mean, &eps_b);
+    let inv = b.rsqrt(&mean);
+    let keep: Vec<usize> = (0..axis).collect();
+    let inv_b = b.broadcast(&inv, &keep, x.ty.shape.clone());
+    let normalized = b.multiply(x, &inv_b);
+    match weight {
+        Some(weight) => {
+            let wb = b.broadcast(weight, &[axis], x.ty.shape.clone());
+            b.multiply(&normalized, &wb)
+        }
+        None => normalized,
+    }
+}
+
+pub(super) fn normalize_to(b: &mut Builder, plane: &Val, target: &Val, k: &Constants) -> Val {
+    let axis = plane.ty.shape.len() - 1;
+    let width = plane.ty.shape[axis];
+    let width_c = b.const_f32(width as f32);
+    let reduced: Vec<usize> = plane.ty.shape[..axis].to_vec();
+    let width_b = b.broadcast(&width_c, &[], reduced.clone());
+    let sq = b.multiply(plane, plane);
+    let sum = b.reduce_add(&sq, axis, &k.zero);
+    let mean = b.divide(&sum, &width_b);
+    let inverse = b.rsqrt(&mean);
+    let one = b.broadcast(&k.one, &[], reduced.clone());
+    let magnitude = b.divide(&one, &inverse);
+    let eps_b = b.broadcast(&k.eps, &[], reduced.clone());
+    let pred = b.compare("GT", &magnitude, &eps_b, "FLOAT");
+    let safe = b.select(&pred, &magnitude, &eps_b);
+    let scale = b.divide(target, &safe);
+    let keep: Vec<usize> = (0..axis).collect();
+    let scale_b = b.broadcast(&scale, &keep, plane.ty.shape.clone());
+    b.multiply(plane, &scale_b)
+}
+
+pub(super) fn gelu(b: &mut Builder, x: &Val) -> Val {
+    let shape = x.ty.shape.clone();
+    let splat = |b: &mut Builder, value: f32, shape: &[usize]| {
+        let scalar = b.const_f32(value);
+        b.broadcast(&scalar, &[], shape.to_vec())
+    };
+    let root = splat(b, (2.0f32 / std::f32::consts::PI).sqrt(), &shape);
+    let cubic = splat(b, 0.044_715, &shape);
+    let half = splat(b, 0.5, &shape);
+    let one = splat(b, 1.0, &shape);
+    let x2 = b.multiply(x, x);
+    let x3 = b.multiply(&x2, x);
+    let cubic_x = b.multiply(&cubic, &x3);
+    let inner = b.add(x, &cubic_x);
+    let inner = b.multiply(&root, &inner);
+    let tanh = b.tanh(&inner);
+    let half_x = b.multiply(&half, x);
+    let one_tanh = b.add(&one, &tanh);
+    b.multiply(&half_x, &one_tanh)
+}
+
+pub(super) fn geglu(b: &mut Builder, gate: &Val, up: &Val) -> Val {
+    let gate = gelu(b, gate);
+    b.multiply(&gate, up)
+}
+
+pub(super) fn sparse_gelu(b: &mut Builder, x: &Val, sparsity: f32, k: &Constants) -> Val {
+    let rows = x.ty.shape[0];
+    let width = x.ty.shape[1];
+    let width_scalar = b.const_f32(width as f32);
+    let width_b = b.broadcast(&width_scalar, &[], vec![rows]);
+    let sum = b.reduce_add(x, 1, &k.zero);
+    let mean = b.divide(&sum, &width_b);
+    let mean_b = b.broadcast(&mean, &[0], vec![rows, width]);
+    let centered = b.subtract(x, &mean_b);
+    let squared = b.multiply(&centered, &centered);
+    let variance = b.reduce_add(&squared, 1, &k.zero);
+    let variance = b.divide(&variance, &width_b);
+    let inverse = b.rsqrt(&variance);
+    let one = b.broadcast(&k.one, &[], vec![rows]);
+    let stddev = b.divide(&one, &inverse);
+    let multiplier = std::f32::consts::SQRT_2 * erfinv(2.0 * sparsity - 1.0);
+    let multiplier = b.const_f32(multiplier);
+    let multiplier = b.broadcast(&multiplier, &[], vec![rows]);
+    let spread = b.multiply(&stddev, &multiplier);
+    let cutoff = b.add(&mean, &spread);
+    let cutoff = b.broadcast(&cutoff, &[0], vec![rows, width]);
+    let shifted = b.subtract(x, &cutoff);
+    let zeros = b.broadcast(&k.zero, &[], vec![rows, width]);
+    let positive = b.compare("GT", &shifted, &zeros, "FLOAT");
+    let shifted = b.select(&positive, &shifted, &zeros);
+    let sqrt2 = b.const_f32(std::f32::consts::SQRT_2);
+    let sqrt2 = b.broadcast(&sqrt2, &[], vec![rows, width]);
+    let scaled = b.divide(&shifted, &sqrt2);
+    let erf = b.erf(&scaled);
+    let half = b.const_f32(0.5);
+    let half = b.broadcast(&half, &[], vec![rows, width]);
+    let one = b.broadcast(&k.one, &[], vec![rows, width]);
+    let one_erf = b.add(&one, &erf);
+    let scale = b.multiply(&half, &one_erf);
+    b.multiply(&shifted, &scale)
+}
+
+fn erfinv(x: f32) -> f32 {
+    if x == 0.0 {
+        return 0.0;
+    }
+    let a = 0.147;
+    let ln = (1.0 - x * x).ln();
+    let first = 2.0 / (std::f32::consts::PI * a) + ln / 2.0;
+    let second = ln / a;
+    x.signum() * ((first * first - second).sqrt() - first).sqrt()
+}
+
+pub(super) fn softmax(b: &mut Builder, scores: &Val, axis: usize, k: &Constants) -> Val {
+    let shape = scores.ty.shape.clone();
+    let keep: Vec<usize> = (0..shape.len()).filter(|&i| i != axis).collect();
+    let max = b.reduce_max(scores, axis, &k.neg_inf);
+    let max_b = b.broadcast(&max, &keep, shape.clone());
+    let shifted = b.subtract(scores, &max_b);
+    let exp = b.exponential(&shifted);
+    let sum = b.reduce_add(&exp, axis, &k.zero);
+    let sum_b = b.broadcast(&sum, &keep, shape);
+    b.divide(&exp, &sum_b)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn rope(
+    b: &mut Builder,
+    x: &Val,
+    positions: &Val,
+    cosine: &Val,
+    sine: &Val,
+    rows: usize,
+    heads: usize,
+    dim: usize,
+) -> Val {
+    let indices = b.reshape(positions, vec![rows, 1]);
+    let cos = b.gather(cosine, &indices);
+    let sin = b.gather(sine, &indices);
+    let cos = b.broadcast(&cos, &[0, 2], vec![rows, heads, dim]);
+    let sin = b.broadcast(&sin, &[0, 2], vec![rows, heads, dim]);
+    let half = dim / 2;
+    let left = b.slice(x, &[(0, rows), (0, heads), (0, half)]);
+    let right = b.slice(x, &[(0, rows), (0, heads), (half, dim)]);
+    let right = b.negate(&right);
+    let rotated = b.concatenate(&right, &left, 2);
+    let cosine = b.multiply(x, &cos);
+    let sine = b.multiply(&rotated, &sin);
+    b.add(&cosine, &sine)
+}
+
+pub(super) fn causal_mask(
+    b: &mut Builder,
+    capacity: usize,
+    window: Option<usize>,
+    k: &Constants,
+) -> Val {
+    let row_iota = b.iota(capacity);
+    let rows = b.broadcast(&row_iota, &[0], vec![capacity, capacity]);
+    let col_iota = b.iota(capacity);
+    let cols = b.broadcast(&col_iota, &[1], vec![capacity, capacity]);
+    let causal = b.compare("LE", &cols, &rows, "SIGNED");
+    let zeros = b.broadcast(&k.zero, &[], vec![capacity, capacity]);
+    let masked = b.broadcast(&k.neg_big, &[], vec![capacity, capacity]);
+    let base = b.select(&causal, &zeros, &masked);
+    match window {
+        None => base,
+        Some(width) => {
+            let age = b.subtract(&rows, &cols);
+            let w = b.const_i32(width as i32);
+            let wb = b.broadcast(&w, &[], vec![capacity, capacity]);
+            let within = b.compare("LT", &age, &wb, "SIGNED");
+            b.select(&within, &base, &masked)
+        }
+    }
+}
+
+pub(super) fn apply_sliding_window(
+    b: &mut Builder,
+    base: &Val,
+    capacity: usize,
+    width: usize,
+    k: &Constants,
+) -> Val {
+    let row_iota = b.iota(capacity);
+    let rows = b.broadcast(&row_iota, &[0], vec![capacity, capacity]);
+    let col_iota = b.iota(capacity);
+    let cols = b.broadcast(&col_iota, &[1], vec![capacity, capacity]);
+    let age = b.subtract(&rows, &cols);
+    let width = b.const_i32(width as i32);
+    let width = b.broadcast(&width, &[], vec![capacity, capacity]);
+    let within = b.compare("LT", &age, &width, "SIGNED");
+    let masked = b.broadcast(&k.neg_big, &[], vec![capacity, capacity]);
+    b.select(&within, base, &masked)
+}
+
+pub(super) fn altup_predict(
+    b: &mut Builder,
+    planes: &[Val],
+    lw: &LayerWeights,
+    c: &Gemma3nConfig,
+    k: &Constants,
+    rows: usize,
+) -> Vec<Val> {
+    let n = c.altup_num_inputs;
+    let active = &planes[c.altup_active_idx];
+    let routed = rms_last(b, active, Some(&lw.router_norm), &k.eps, &k.zero);
+    let routed = b.linear_seq(&routed, &lw.router);
+    let hidden_b = b.broadcast(&k.hidden, &[], vec![rows, n]);
+    let modalities = b.divide(&routed, &hidden_b);
+    let modalities = b.tanh(&modalities);
+    let prediction = clipped(b, &lw.prediction, c.altup_coef_clip);
+    let coefficients = b.linear_seq(&modalities, &prediction);
+    let coefficients = b.reshape(&coefficients, vec![rows, n, n]);
+    let coefficients = b.transpose(&coefficients, &[0, 2, 1]);
+    let stacked = stack_planes(b, planes, rows, c.hidden);
+    let by_feature = b.transpose(&stacked, &[1, 2, 0]);
+    let delta = b.dot_general(
+        &by_feature,
+        &coefficients,
+        &[0],
+        &[0],
+        &[2],
+        &[1],
+        vec![rows, c.hidden, n],
+    );
+    let delta = b.transpose(&delta, &[2, 0, 1]);
+    let predicted = b.add(&stacked, &delta);
+    split_planes(b, &predicted, n, rows, c.hidden)
+}
+
+pub(super) fn altup_correct(
+    b: &mut Builder,
+    predicted: &[Val],
+    activated: &Val,
+    lw: &LayerWeights,
+    c: &Gemma3nConfig,
+    k: &Constants,
+    rows: usize,
+) -> Vec<Val> {
+    let n = c.altup_num_inputs;
+    let active_prediction = &predicted[c.altup_active_idx];
+    let routed = rms_last(b, activated, Some(&lw.router_norm), &k.eps, &k.zero);
+    let routed = b.linear_seq(&routed, &lw.router);
+    let hidden_b = b.broadcast(&k.hidden, &[], vec![rows, n]);
+    let modalities = b.divide(&routed, &hidden_b);
+    let modalities = b.tanh(&modalities);
+    let correction = clipped(b, &lw.correction, c.altup_coef_clip);
+    let coefficients = b.linear_seq(&modalities, &correction);
+    let one_b = b.broadcast(&k.one, &[], vec![rows, n]);
+    let coefficients = b.add(&coefficients, &one_b);
+    let innovation = b.subtract(activated, active_prediction);
+    let mut corrected = Vec::with_capacity(n);
+    for (plane, predicted_plane) in predicted.iter().enumerate() {
+        let coefficient = b.slice(&coefficients, &[(0, rows), (plane, plane + 1)]);
+        let coefficient = b.broadcast(&coefficient, &[0, 1], vec![rows, c.hidden]);
+        let delta = b.multiply(&innovation, &coefficient);
+        corrected.push(b.add(predicted_plane, &delta));
+    }
+    corrected
+}
+
+fn clipped(b: &mut Builder, value: &Val, limit: f32) -> Val {
+    let positive = b.const_f32(limit);
+    let positive = b.broadcast(&positive, &[], value.ty.shape.clone());
+    let negative = b.const_f32(-limit);
+    let negative = b.broadcast(&negative, &[], value.ty.shape.clone());
+    let above = b.compare("GT", value, &positive, "FLOAT");
+    let value = b.select(&above, &positive, value);
+    let below = b.compare("LT", &value, &negative, "FLOAT");
+    b.select(&below, &negative, &value)
+}
+
+fn stack_planes(b: &mut Builder, planes: &[Val], rows: usize, hidden: usize) -> Val {
+    let mut stacked = b.reshape(&planes[0], vec![1, rows, hidden]);
+    for plane in &planes[1..] {
+        let plane = b.reshape(plane, vec![1, rows, hidden]);
+        stacked = b.concatenate(&stacked, &plane, 0);
+    }
+    stacked
+}
+
+fn split_planes(
+    b: &mut Builder,
+    stacked: &Val,
+    count: usize,
+    rows: usize,
+    hidden: usize,
+) -> Vec<Val> {
+    (0..count)
+        .map(|plane| {
+            let value = b.slice(stacked, &[(plane, plane + 1), (0, rows), (0, hidden)]);
+            b.reshape(&value, vec![rows, hidden])
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn attention(
+    b: &mut Builder,
+    normalized: &Val,
+    positions: &Val,
+    mask: &Val,
+    lw: &LayerWeights,
+    layer: usize,
+    cache_index: usize,
+    c: &Gemma3nConfig,
+    k: &Constants,
+    kcache: &mut Val,
+    vcache: &mut Val,
+) -> Val {
+    let rows = c.context_capacity;
+    let d = c.head_dim;
+    let group = c.n_q / c.n_kv;
+    let q = b.linear_seq(normalized, &lw.wq);
+    let q = b.reshape(&q, vec![rows, c.n_q, d]);
+    let q = rms_last(b, &q, Some(&lw.q_norm), &k.eps, &k.zero);
+    let (cos, sin) = match c.layer_types[layer] {
+        super::gemma3n::Gemma3nLayerType::Full => (&k.cos_global, &k.sin_global),
+        super::gemma3n::Gemma3nLayerType::Sliding => (&k.cos_local, &k.sin_local),
+    };
+    let q = rope(b, &q, positions, cos, sin, rows, c.n_q, d);
+    let (keys, values) = match (&lw.wk, &lw.wv, &lw.k_norm) {
+        (Some(wk), Some(wv), Some(k_norm)) => {
+            let keys = b.linear_seq(normalized, wk);
+            let keys = b.reshape(&keys, vec![rows, c.n_kv, d]);
+            let keys = rms_last(b, &keys, Some(k_norm), &k.eps, &k.zero);
+            let keys = rope(b, &keys, positions, cos, sin, rows, c.n_kv, d);
+            let values = b.linear_seq(normalized, wv);
+            let values = b.reshape(&values, vec![rows, c.n_kv, d]);
+            let values = rms_last(b, &values, None, &k.eps, &k.zero);
+            let ci = b.const_i32(cache_index as i32);
+            let c0 = b.const_i32(0);
+            let key_update = b.reshape(&keys, vec![1, rows, c.n_kv, d]);
+            *kcache = b.dynamic_update_slice(kcache, &key_update, &[&ci, &c0, &c0, &c0]);
+            let value_update = b.reshape(&values, vec![1, rows, c.n_kv, d]);
+            *vcache = b.dynamic_update_slice(vcache, &value_update, &[&ci, &c0, &c0, &c0]);
+            (keys, values)
+        }
+        (None, None, None) => {
+            let keys = b.slice(
+                kcache,
+                &[
+                    (cache_index, cache_index + 1),
+                    (0, rows),
+                    (0, c.n_kv),
+                    (0, d),
+                ],
+            );
+            let values = b.slice(
+                vcache,
+                &[
+                    (cache_index, cache_index + 1),
+                    (0, rows),
+                    (0, c.n_kv),
+                    (0, d),
+                ],
+            );
+            (
+                b.reshape(&keys, vec![rows, c.n_kv, d]),
+                b.reshape(&values, vec![rows, c.n_kv, d]),
+            )
+        }
+        _ => unreachable!("Gemma3n K/V projection and norm arguments are atomic"),
+    };
+    let q = b.reshape(&q, vec![rows, c.n_kv, group, d]);
+    let scores = b.dot_general(
+        &q,
+        &keys,
+        &[1],
+        &[1],
+        &[3],
+        &[2],
+        vec![c.n_kv, rows, group, rows],
+    );
+    // Gemma3n deliberately uses attention scale 1.0.
+    let mask = b.broadcast(mask, &[1, 3], vec![c.n_kv, rows, group, rows]);
+    let scores = b.add(&scores, &mask);
+    let probabilities = softmax(b, &scores, 3, k);
+    let context = b.dot_general(
+        &probabilities,
+        &values,
+        &[0],
+        &[1],
+        &[3],
+        &[0],
+        vec![c.n_kv, rows, group, d],
+    );
+    let context = b.transpose(&context, &[1, 0, 2, 3]);
+    let context = b.reshape(&context, vec![rows, c.n_q * d]);
+    b.linear_seq(&context, &lw.wo)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn attention_decode(
+    b: &mut Builder,
+    normalized: &Val,
+    position: &Val,
+    lw: &LayerWeights,
+    layer: usize,
+    cache_index: usize,
+    c: &Gemma3nConfig,
+    k: &Constants,
+    kcache: &mut Val,
+    vcache: &mut Val,
+) -> Val {
+    let d = c.head_dim;
+    let group = c.n_q / c.n_kv;
+    let position_row = b.reshape(position, vec![1]);
+    let q = b.linear_seq(normalized, &lw.wq);
+    let q = b.reshape(&q, vec![1, c.n_q, d]);
+    let q = rms_last(b, &q, Some(&lw.q_norm), &k.eps, &k.zero);
+    let (cos, sin, window) = match c.layer_types[layer] {
+        super::gemma3n::Gemma3nLayerType::Full => (&k.cos_global, &k.sin_global, None),
+        super::gemma3n::Gemma3nLayerType::Sliding => {
+            (&k.cos_local, &k.sin_local, Some(c.sliding_window))
+        }
+    };
+    let q = rope(b, &q, &position_row, cos, sin, 1, c.n_q, d);
+    if let (Some(wk), Some(wv), Some(k_norm)) = (&lw.wk, &lw.wv, &lw.k_norm) {
+        let keys = b.linear_seq(normalized, wk);
+        let keys = b.reshape(&keys, vec![1, c.n_kv, d]);
+        let keys = rms_last(b, &keys, Some(k_norm), &k.eps, &k.zero);
+        let keys = rope(b, &keys, &position_row, cos, sin, 1, c.n_kv, d);
+        let values = b.linear_seq(normalized, wv);
+        let values = b.reshape(&values, vec![1, c.n_kv, d]);
+        let values = rms_last(b, &values, None, &k.eps, &k.zero);
+        let cache = b.const_i32(cache_index as i32);
+        let zero = b.const_i32(0);
+        let keys = b.reshape(&keys, vec![1, 1, c.n_kv, d]);
+        *kcache = b.dynamic_update_slice(kcache, &keys, &[&cache, position, &zero, &zero]);
+        let values = b.reshape(&values, vec![1, 1, c.n_kv, d]);
+        *vcache = b.dynamic_update_slice(vcache, &values, &[&cache, position, &zero, &zero]);
+    }
+    let keys = b.slice(
+        kcache,
+        &[
+            (cache_index, cache_index + 1),
+            (0, c.context_capacity),
+            (0, c.n_kv),
+            (0, d),
+        ],
+    );
+    let keys = b.reshape(&keys, vec![c.context_capacity, c.n_kv, d]);
+    let values = b.slice(
+        vcache,
+        &[
+            (cache_index, cache_index + 1),
+            (0, c.context_capacity),
+            (0, c.n_kv),
+            (0, d),
+        ],
+    );
+    let values = b.reshape(&values, vec![c.context_capacity, c.n_kv, d]);
+    let q = b.reshape(&q, vec![1, c.n_kv, group, d]);
+    let scores = b.dot_general(
+        &q,
+        &keys,
+        &[1],
+        &[1],
+        &[3],
+        &[2],
+        vec![c.n_kv, 1, group, c.context_capacity],
+    );
+    let indices = b.iota(c.context_capacity);
+    let position_b = b.broadcast(position, &[], vec![c.context_capacity]);
+    let visible = b.compare("LE", &indices, &position_b, "SIGNED");
+    let visible = if let Some(width) = window {
+        let first = b.const_i32(width.saturating_sub(1) as i32);
+        let first = b.subtract(position, &first);
+        let first = b.broadcast(&first, &[], vec![c.context_capacity]);
+        let local = b.compare("GE", &indices, &first, "SIGNED");
+        b.select(&visible, &local, &visible)
+    } else {
+        visible
+    };
+    let zeros = b.broadcast(&k.zero, &[], vec![c.context_capacity]);
+    let masked = b.broadcast(&k.neg_big, &[], vec![c.context_capacity]);
+    let mask = b.select(&visible, &zeros, &masked);
+    let mask = b.broadcast(&mask, &[3], vec![c.n_kv, 1, group, c.context_capacity]);
+    let scores = b.add(&scores, &mask);
+    let probabilities = softmax(b, &scores, 3, k);
+    let context = b.dot_general(
+        &probabilities,
+        &values,
+        &[0],
+        &[1],
+        &[3],
+        &[0],
+        vec![c.n_kv, 1, group, d],
+    );
+    let context = b.transpose(&context, &[1, 0, 2, 3]);
+    let context = b.reshape(&context, vec![1, c.n_q * d]);
+    b.linear_seq(&context, &lw.wo)
+}

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_emit_ops.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_emit_ops.rs
@@ -3,6 +3,7 @@
 use super::builder::{Builder, Val};
 use super::gemma3n::Gemma3nConfig;
 use super::rope::{plain_inv_freq_with_base, rope_tables_from_inv};
+use crate::weights::round_bf16_f32;
 
 pub(super) struct Constants {
     pub zero: Val,
@@ -45,19 +46,92 @@ pub(super) struct LayerWeights {
     pub ple_norm: Val,
 }
 
+/// Keep Gemma3n's native BF16 activation stream explicit while carrying values
+/// through the public ABI as f32. This is intentionally local to Gemma3n:
+/// dense-family precision policy must not change when reproducing MLX's
+/// operation-by-operation BF16 rounding.
+pub(super) fn round_bf16(b: &mut Builder, value: &Val) -> Val {
+    let narrowed = b.convert(value, "bf16");
+    b.convert(&narrowed, "f32")
+}
+
+/// Materialize a scalar that MLX constructs directly in a BF16 input's dtype.
+///
+/// Author the already-rounded host value as f32 instead of relying on a
+/// constant f32→bf16→f32 convert pair: compiler constant folding may erase the
+/// observable BF16 rounding even though the same pair remains correct for
+/// dynamic values.
+pub(super) fn bf16_scalar(b: &mut Builder, value: f32) -> Val {
+    b.const_f32(round_bf16_f32(value))
+}
+
+/// Gemma3n quantized projections consume BF16 operands and return a BF16
+/// activation. StableHLO's dot accumulates into f32; the explicit round pins the
+/// observable MLX output dtype before the next operation.
+pub(super) fn linear_seq_bf16(b: &mut Builder, input: &Val, weight: &Val) -> Val {
+    if b.gemma3n_qmv_enabled() {
+        return b.gemma3n_qmv(input, weight);
+    }
+    let input = b.convert(input, "bf16");
+    let weight = b.convert(weight, "bf16");
+    let output = b.linear_seq(&input, &weight);
+    round_bf16(b, &output)
+}
+
+pub(super) fn linear_bf16(b: &mut Builder, input: &Val, weight: &Val) -> Val {
+    if b.gemma3n_qmv_enabled() {
+        return b.gemma3n_qmv(input, weight);
+    }
+    let input = b.convert(input, "bf16");
+    let weight = b.convert(weight, "bf16");
+    let output = b.linear(&input, &weight);
+    round_bf16(b, &output)
+}
+
+/// Match MLX's `mean(stack(planes), axis=0)` schedule: reduce all BF16-carried
+/// planes in f32, round the completed sum once, then multiply by a BF16
+/// reciprocal and round the result. Rounding each pairwise add changes the
+/// Gemma3n four-plane collapse.
+pub(super) fn mean_planes_bf16(b: &mut Builder, planes: &[Val], zero: &Val) -> Val {
+    assert!(!planes.is_empty(), "Gemma3n AltUp collapse needs planes");
+    let plane_shape = planes[0].ty.shape.clone();
+    let mut stacked_shape = vec![1];
+    stacked_shape.extend_from_slice(&plane_shape);
+    let mut stacked = b.reshape(&planes[0], stacked_shape.clone());
+    for plane in &planes[1..] {
+        assert_eq!(
+            plane.ty.shape, plane_shape,
+            "Gemma3n AltUp collapse plane shape mismatch"
+        );
+        let plane = b.reshape(plane, stacked_shape.clone());
+        stacked = b.concatenate(&stacked, &plane, 0);
+    }
+    let sum = b.reduce_add(&stacked, 0, zero);
+    let sum = round_bf16(b, &sum);
+    let reciprocal = bf16_scalar(b, (planes.len() as f32).recip());
+    let reciprocal = b.broadcast(&reciprocal, &[], plane_shape);
+    let mean = b.multiply(&sum, &reciprocal);
+    round_bf16(b, &mean)
+}
+
 pub(super) fn constants(b: &mut Builder, c: &Gemma3nConfig) -> Constants {
+    // A shared-KV layer observes the mapped concrete cache after it has
+    // advanced by the current prefill length, so its query positions span up
+    // to `2 * context_capacity - 1`.
+    let rope_capacity = c.context_capacity * 2;
     let (cg, sg) = rope_tables_from_inv(
         &plain_inv_freq_with_base(c.head_dim, c.rope_theta),
         c.head_dim,
-        c.context_capacity,
+        rope_capacity,
         false,
     );
     let (cl, sl) = rope_tables_from_inv(
         &plain_inv_freq_with_base(c.head_dim, c.rope_local_base),
         c.head_dim,
-        c.context_capacity,
+        rope_capacity,
         false,
     );
+    let inv_sqrt2 = bf16_scalar(b, std::f32::consts::FRAC_1_SQRT_2);
     Constants {
         zero: b.const_f32(0.0),
         one: b.const_f32(1.0),
@@ -65,11 +139,11 @@ pub(super) fn constants(b: &mut Builder, c: &Gemma3nConfig) -> Constants {
         neg_inf: b.const_f32(f32::NEG_INFINITY),
         neg_big: b.const_f32(-1e30),
         hidden: b.const_f32(c.hidden as f32),
-        inv_sqrt2: b.const_f32(std::f32::consts::FRAC_1_SQRT_2),
-        cos_global: b.const_tensor_f32(&cg, vec![c.context_capacity, c.head_dim]),
-        sin_global: b.const_tensor_f32(&sg, vec![c.context_capacity, c.head_dim]),
-        cos_local: b.const_tensor_f32(&cl, vec![c.context_capacity, c.head_dim]),
-        sin_local: b.const_tensor_f32(&sl, vec![c.context_capacity, c.head_dim]),
+        inv_sqrt2,
+        cos_global: b.const_tensor_f32(&cg, vec![rope_capacity, c.head_dim]),
+        sin_global: b.const_tensor_f32(&sg, vec![rope_capacity, c.head_dim]),
+        cos_local: b.const_tensor_f32(&cl, vec![rope_capacity, c.head_dim]),
+        sin_local: b.const_tensor_f32(&sl, vec![rope_capacity, c.head_dim]),
     }
 }
 
@@ -108,6 +182,30 @@ pub(super) fn rms_last(
     }
 }
 
+pub(super) fn rms_last_bf16(
+    b: &mut Builder,
+    x: &Val,
+    weight: Option<&Val>,
+    eps: &Val,
+    zero: &Val,
+) -> Val {
+    // MLX's CUDA RMSNorm kernel stores `x * inv_rms` through a `T` temporary
+    // before applying the optional weight. For Gemma3n, `T` is BF16: preserve
+    // that intermediate rounding boundary instead of fusing both multiplies in
+    // f32 and rounding only the final result.
+    let normalized = rms_last(b, x, None, eps, zero);
+    let normalized = round_bf16(b, &normalized);
+    match weight {
+        Some(weight) => {
+            let axis = x.ty.shape.len() - 1;
+            let weight = b.broadcast(weight, &[axis], x.ty.shape.clone());
+            let weighted = b.multiply(&normalized, &weight);
+            round_bf16(b, &weighted)
+        }
+        None => normalized,
+    }
+}
+
 pub(super) fn normalize_to(b: &mut Builder, plane: &Val, target: &Val, k: &Constants) -> Val {
     let axis = plane.ty.shape.len() - 1;
     let width = plane.ty.shape[axis];
@@ -115,18 +213,23 @@ pub(super) fn normalize_to(b: &mut Builder, plane: &Val, target: &Val, k: &Const
     let reduced: Vec<usize> = plane.ty.shape[..axis].to_vec();
     let width_b = b.broadcast(&width_c, &[], reduced.clone());
     let sq = b.multiply(plane, plane);
+    let sq = round_bf16(b, &sq);
     let sum = b.reduce_add(&sq, axis, &k.zero);
+    let sum = round_bf16(b, &sum);
     let mean = b.divide(&sum, &width_b);
-    let inverse = b.rsqrt(&mean);
-    let one = b.broadcast(&k.one, &[], reduced.clone());
-    let magnitude = b.divide(&one, &inverse);
+    let mean = round_bf16(b, &mean);
+    let magnitude = b.sqrt(&mean);
+    let magnitude = round_bf16(b, &magnitude);
     let eps_b = b.broadcast(&k.eps, &[], reduced.clone());
     let pred = b.compare("GT", &magnitude, &eps_b, "FLOAT");
     let safe = b.select(&pred, &magnitude, &eps_b);
+    let safe = round_bf16(b, &safe);
     let scale = b.divide(target, &safe);
+    let scale = round_bf16(b, &scale);
     let keep: Vec<usize> = (0..axis).collect();
     let scale_b = b.broadcast(&scale, &keep, plane.ty.shape.clone());
-    b.multiply(plane, &scale_b)
+    let normalized = b.multiply(plane, &scale_b);
+    round_bf16(b, &normalized)
 }
 
 pub(super) fn gelu(b: &mut Builder, x: &Val) -> Val {
@@ -144,52 +247,103 @@ pub(super) fn gelu(b: &mut Builder, x: &Val) -> Val {
     let cubic_x = b.multiply(&cubic, &x3);
     let inner = b.add(x, &cubic_x);
     let inner = b.multiply(&root, &inner);
-    let tanh = b.tanh(&inner);
+    let tanh = b.gemma3n_tanh(&inner);
     let half_x = b.multiply(&half, x);
     let one_tanh = b.add(&one, &tanh);
     b.multiply(&half_x, &one_tanh)
 }
 
 pub(super) fn geglu(b: &mut Builder, gate: &Val, up: &Val) -> Val {
+    if b.gemma3n_qmv_enabled() {
+        return b.gemma3n_geglu_bf16(gate, up);
+    }
     let gate = gelu(b, gate);
-    b.multiply(&gate, up)
+    let product = b.multiply(&gate, up);
+    round_bf16(b, &product)
 }
 
-pub(super) fn sparse_gelu(b: &mut Builder, x: &Val, sparsity: f32, k: &Constants) -> Val {
+pub(super) struct SparseGeluStages {
+    pub mean: Val,
+    pub variance: Val,
+    pub stddev: Val,
+    pub cutoff: Val,
+    pub shifted_raw: Val,
+    pub shifted: Val,
+    pub erf: Val,
+    pub activated: Val,
+}
+
+/// Match the materialized BF16 carrier tape used by MLX's sparse GELU.
+///
+/// Reductions accumulate in f32, but every observable elementwise result is
+/// stored through BF16 before it feeds the next operation.
+pub(super) fn sparse_gelu_stages(
+    b: &mut Builder,
+    x: &Val,
+    sparsity: f32,
+    zero: &Val,
+    one: &Val,
+) -> SparseGeluStages {
     let rows = x.ty.shape[0];
     let width = x.ty.shape[1];
     let width_scalar = b.const_f32(width as f32);
     let width_b = b.broadcast(&width_scalar, &[], vec![rows]);
-    let sum = b.reduce_add(x, 1, &k.zero);
+    let sum = b.reduce_add(x, 1, zero);
     let mean = b.divide(&sum, &width_b);
+    let mean = round_bf16(b, &mean);
     let mean_b = b.broadcast(&mean, &[0], vec![rows, width]);
     let centered = b.subtract(x, &mean_b);
+    let centered = round_bf16(b, &centered);
     let squared = b.multiply(&centered, &centered);
-    let variance = b.reduce_add(&squared, 1, &k.zero);
+    let squared = round_bf16(b, &squared);
+    let variance = b.reduce_add(&squared, 1, zero);
     let variance = b.divide(&variance, &width_b);
-    let inverse = b.rsqrt(&variance);
-    let one = b.broadcast(&k.one, &[], vec![rows]);
-    let stddev = b.divide(&one, &inverse);
+    let variance = round_bf16(b, &variance);
+    let stddev = b.sqrt(&variance);
+    let stddev = round_bf16(b, &stddev);
     let multiplier = std::f32::consts::SQRT_2 * erfinv(2.0 * sparsity - 1.0);
     let multiplier = b.const_f32(multiplier);
     let multiplier = b.broadcast(&multiplier, &[], vec![rows]);
     let spread = b.multiply(&stddev, &multiplier);
+    let spread = round_bf16(b, &spread);
     let cutoff = b.add(&mean, &spread);
-    let cutoff = b.broadcast(&cutoff, &[0], vec![rows, width]);
-    let shifted = b.subtract(x, &cutoff);
-    let zeros = b.broadcast(&k.zero, &[], vec![rows, width]);
-    let positive = b.compare("GT", &shifted, &zeros, "FLOAT");
-    let shifted = b.select(&positive, &shifted, &zeros);
+    let cutoff = round_bf16(b, &cutoff);
+    let cutoff_b = b.broadcast(&cutoff, &[0], vec![rows, width]);
+    let shifted_raw = b.subtract(x, &cutoff_b);
+    let shifted_raw = round_bf16(b, &shifted_raw);
+    let zeros = b.broadcast(zero, &[], vec![rows, width]);
+    let positive = b.compare("GT", &shifted_raw, &zeros, "FLOAT");
+    let shifted = b.select(&positive, &shifted_raw, &zeros);
+    let shifted = round_bf16(b, &shifted);
     let sqrt2 = b.const_f32(std::f32::consts::SQRT_2);
     let sqrt2 = b.broadcast(&sqrt2, &[], vec![rows, width]);
     let scaled = b.divide(&shifted, &sqrt2);
+    let scaled = round_bf16(b, &scaled);
     let erf = b.erf(&scaled);
+    let erf = round_bf16(b, &erf);
     let half = b.const_f32(0.5);
     let half = b.broadcast(&half, &[], vec![rows, width]);
-    let one = b.broadcast(&k.one, &[], vec![rows, width]);
+    let one = b.broadcast(one, &[], vec![rows, width]);
     let one_erf = b.add(&one, &erf);
+    let one_erf = round_bf16(b, &one_erf);
     let scale = b.multiply(&half, &one_erf);
-    b.multiply(&shifted, &scale)
+    let scale = round_bf16(b, &scale);
+    let activated = b.multiply(&shifted, &scale);
+    let activated = round_bf16(b, &activated);
+    SparseGeluStages {
+        mean,
+        variance,
+        stddev,
+        cutoff,
+        shifted_raw,
+        shifted,
+        erf,
+        activated,
+    }
+}
+
+pub(super) fn sparse_gelu(b: &mut Builder, x: &Val, sparsity: f32, k: &Constants) -> Val {
+    sparse_gelu_stages(b, x, sparsity, &k.zero, &k.one).activated
 }
 
 fn erfinv(x: f32) -> f32 {
@@ -204,13 +358,17 @@ fn erfinv(x: f32) -> f32 {
 }
 
 pub(super) fn softmax(b: &mut Builder, scores: &Val, axis: usize, k: &Constants) -> Val {
+    stable_softmax(b, scores, axis, &k.zero, &k.neg_inf)
+}
+
+fn stable_softmax(b: &mut Builder, scores: &Val, axis: usize, zero: &Val, neg_inf: &Val) -> Val {
     let shape = scores.ty.shape.clone();
     let keep: Vec<usize> = (0..shape.len()).filter(|&i| i != axis).collect();
-    let max = b.reduce_max(scores, axis, &k.neg_inf);
+    let max = b.reduce_max(scores, axis, neg_inf);
     let max_b = b.broadcast(&max, &keep, shape.clone());
     let shifted = b.subtract(scores, &max_b);
     let exp = b.exponential(&shifted);
-    let sum = b.reduce_add(&exp, axis, &k.zero);
+    let sum = b.reduce_add(&exp, axis, zero);
     let sum_b = b.broadcast(&sum, &keep, shape);
     b.divide(&exp, &sum_b)
 }
@@ -238,7 +396,8 @@ pub(super) fn rope(
     let rotated = b.concatenate(&right, &left, 2);
     let cosine = b.multiply(x, &cos);
     let sine = b.multiply(&rotated, &sin);
-    b.add(&cosine, &sine)
+    let rotated = b.add(&cosine, &sine);
+    round_bf16(b, &rotated)
 }
 
 pub(super) fn causal_mask(
@@ -296,28 +455,19 @@ pub(super) fn altup_predict(
 ) -> Vec<Val> {
     let n = c.altup_num_inputs;
     let active = &planes[c.altup_active_idx];
-    let routed = rms_last(b, active, Some(&lw.router_norm), &k.eps, &k.zero);
-    let routed = b.linear_seq(&routed, &lw.router);
-    let hidden_b = b.broadcast(&k.hidden, &[], vec![rows, n]);
-    let modalities = b.divide(&routed, &hidden_b);
-    let modalities = b.tanh(&modalities);
+    let routed = rms_last_bf16(b, active, Some(&lw.router_norm), &k.eps, &k.zero);
+    let hidden_b = b.broadcast(&k.hidden, &[], vec![rows, c.hidden]);
+    let routed = b.divide(&routed, &hidden_b);
+    let routed = round_bf16(b, &routed);
+    let modalities = linear_seq_bf16(b, &routed, &lw.router);
+    // MLX explicitly casts the quantized router output to f32 before tanh.
+    let modalities = b.gemma3n_tanh(&modalities);
     let prediction = clipped(b, &lw.prediction, c.altup_coef_clip);
-    let coefficients = b.linear_seq(&modalities, &prediction);
+    let coefficients = b.gemma3n_altup_coeff(&modalities, &prediction);
     let coefficients = b.reshape(&coefficients, vec![rows, n, n]);
     let coefficients = b.transpose(&coefficients, &[0, 2, 1]);
     let stacked = stack_planes(b, planes, rows, c.hidden);
-    let by_feature = b.transpose(&stacked, &[1, 2, 0]);
-    let delta = b.dot_general(
-        &by_feature,
-        &coefficients,
-        &[0],
-        &[0],
-        &[2],
-        &[1],
-        vec![rows, c.hidden, n],
-    );
-    let delta = b.transpose(&delta, &[2, 0, 1]);
-    let predicted = b.add(&stacked, &delta);
+    let predicted = b.gemma3n_altup_predict(&stacked, &coefficients);
     split_planes(b, &predicted, n, rows, c.hidden)
 }
 
@@ -332,27 +482,48 @@ pub(super) fn altup_correct(
 ) -> Vec<Val> {
     let n = c.altup_num_inputs;
     let active_prediction = &predicted[c.altup_active_idx];
-    let routed = rms_last(b, activated, Some(&lw.router_norm), &k.eps, &k.zero);
-    let routed = b.linear_seq(&routed, &lw.router);
-    let hidden_b = b.broadcast(&k.hidden, &[], vec![rows, n]);
-    let modalities = b.divide(&routed, &hidden_b);
-    let modalities = b.tanh(&modalities);
+    let routed = rms_last_bf16(b, activated, Some(&lw.router_norm), &k.eps, &k.zero);
+    let hidden_b = b.broadcast(&k.hidden, &[], vec![rows, c.hidden]);
+    let routed = b.divide(&routed, &hidden_b);
+    let routed = round_bf16(b, &routed);
+    let modalities = linear_seq_bf16(b, &routed, &lw.router);
+    // From here through coefficient projection, stay in the intentional f32
+    // island. The correction/prediction matrices are stored as f32.
+    let modalities = b.gemma3n_tanh(&modalities);
     let correction = clipped(b, &lw.correction, c.altup_coef_clip);
-    let coefficients = b.linear_seq(&modalities, &correction);
+    let coefficients = b.gemma3n_altup_coeff(&modalities, &correction);
     let one_b = b.broadcast(&k.one, &[], vec![rows, n]);
     let coefficients = b.add(&coefficients, &one_b);
     let innovation = b.subtract(activated, active_prediction);
+    let innovation = round_bf16(b, &innovation);
     let mut corrected = Vec::with_capacity(n);
     for (plane, predicted_plane) in predicted.iter().enumerate() {
         let coefficient = b.slice(&coefficients, &[(0, rows), (plane, plane + 1)]);
         let coefficient = b.broadcast(&coefficient, &[0, 1], vec![rows, c.hidden]);
-        let delta = b.multiply(&innovation, &coefficient);
-        corrected.push(b.add(predicted_plane, &delta));
+        let (_, corrected_plane) =
+            altup_correct_plane(b, predicted_plane, &innovation, &coefficient);
+        corrected.push(corrected_plane);
     }
     corrected
 }
 
-fn clipped(b: &mut Builder, value: &Val, limit: f32) -> Val {
+pub(super) fn altup_correct_plane(
+    b: &mut Builder,
+    predicted: &Val,
+    innovation: &Val,
+    coefficient: &Val,
+) -> (Val, Val) {
+    let correction = b.multiply(innovation, coefficient);
+    let correction = round_bf16(b, &correction);
+    let corrected = b.add(predicted, &correction);
+    let corrected = round_bf16(b, &corrected);
+    (correction, corrected)
+}
+
+fn clipped(b: &mut Builder, value: &Val, limit: Option<f32>) -> Val {
+    let Some(limit) = limit else {
+        return value.clone();
+    };
     let positive = b.const_f32(limit);
     let positive = b.broadcast(&positive, &[], value.ty.shape.clone());
     let negative = b.const_f32(-limit);
@@ -387,11 +558,47 @@ fn split_planes(
         .collect()
 }
 
+/// Match MLX CUDA's materialized explicit-mask attention carrier schedule.
+///
+/// Q/K/V arrive as logical BF16 values in f32 ABI tensors. The QK result,
+/// additive mask, masked scores, and precise-softmax result are each stored as
+/// BF16 before the next operation.
+#[allow(clippy::too_many_arguments)]
+fn materialized_attention_probabilities(
+    b: &mut Builder,
+    q: &Val,
+    keys: &Val,
+    mask: &Val,
+    zero: &Val,
+    neg_inf: &Val,
+    rows: usize,
+    kv_heads: usize,
+    group: usize,
+) -> Val {
+    let scores = b.dot_general(
+        q,
+        keys,
+        &[1],
+        &[1],
+        &[3],
+        &[2],
+        vec![kv_heads, rows, group, rows],
+    );
+    let scores = round_bf16(b, &scores);
+    let mask = round_bf16(b, mask);
+    let mask = b.broadcast(&mask, &[1, 3], vec![kv_heads, rows, group, rows]);
+    let scores = b.add(&scores, &mask);
+    let scores = round_bf16(b, &scores);
+    let probabilities = stable_softmax(b, &scores, 3, zero, neg_inf);
+    round_bf16(b, &probabilities)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn attention(
     b: &mut Builder,
     normalized: &Val,
     positions: &Val,
+    real_len: &Val,
     mask: &Val,
     lw: &LayerWeights,
     layer: usize,
@@ -404,23 +611,33 @@ pub(super) fn attention(
     let rows = c.context_capacity;
     let d = c.head_dim;
     let group = c.n_q / c.n_kv;
-    let q = b.linear_seq(normalized, &lw.wq);
+    let q = linear_seq_bf16(b, normalized, &lw.wq);
     let q = b.reshape(&q, vec![rows, c.n_q, d]);
-    let q = rms_last(b, &q, Some(&lw.q_norm), &k.eps, &k.zero);
+    let q = rms_last_bf16(b, &q, Some(&lw.q_norm), &k.eps, &k.zero);
     let (cos, sin) = match c.layer_types[layer] {
         super::gemma3n::Gemma3nLayerType::Full => (&k.cos_global, &k.sin_global),
         super::gemma3n::Gemma3nLayerType::Sliding => (&k.cos_local, &k.sin_local),
     };
-    let q = rope(b, &q, positions, cos, sin, rows, c.n_q, d);
+    // The maintained MLX Gemma3n implementation reuses the concrete layer's
+    // cache object for a shared-KV layer. That cache has already advanced by
+    // the prefill length, so the shared layer's query RoPE starts at that
+    // offset even though its K/V come from the earlier logical layer.
+    let query_positions = if lw.wk.is_none() {
+        let offset = b.broadcast(real_len, &[], vec![rows]);
+        b.add(positions, &offset)
+    } else {
+        positions.clone()
+    };
+    let q = rope(b, &q, &query_positions, cos, sin, rows, c.n_q, d);
     let (keys, values) = match (&lw.wk, &lw.wv, &lw.k_norm) {
         (Some(wk), Some(wv), Some(k_norm)) => {
-            let keys = b.linear_seq(normalized, wk);
+            let keys = linear_seq_bf16(b, normalized, wk);
             let keys = b.reshape(&keys, vec![rows, c.n_kv, d]);
-            let keys = rms_last(b, &keys, Some(k_norm), &k.eps, &k.zero);
+            let keys = rms_last_bf16(b, &keys, Some(k_norm), &k.eps, &k.zero);
             let keys = rope(b, &keys, positions, cos, sin, rows, c.n_kv, d);
-            let values = b.linear_seq(normalized, wv);
+            let values = linear_seq_bf16(b, normalized, wv);
             let values = b.reshape(&values, vec![rows, c.n_kv, d]);
-            let values = rms_last(b, &values, None, &k.eps, &k.zero);
+            let values = rms_last_bf16(b, &values, None, &k.eps, &k.zero);
             let ci = b.const_i32(cache_index as i32);
             let c0 = b.const_i32(0);
             let key_update = b.reshape(&keys, vec![1, rows, c.n_kv, d]);
@@ -456,19 +673,10 @@ pub(super) fn attention(
         _ => unreachable!("Gemma3n K/V projection and norm arguments are atomic"),
     };
     let q = b.reshape(&q, vec![rows, c.n_kv, group, d]);
-    let scores = b.dot_general(
-        &q,
-        &keys,
-        &[1],
-        &[1],
-        &[3],
-        &[2],
-        vec![c.n_kv, rows, group, rows],
-    );
     // Gemma3n deliberately uses attention scale 1.0.
-    let mask = b.broadcast(mask, &[1, 3], vec![c.n_kv, rows, group, rows]);
-    let scores = b.add(&scores, &mask);
-    let probabilities = softmax(b, &scores, 3, k);
+    let probabilities = materialized_attention_probabilities(
+        b, &q, &keys, mask, &k.zero, &k.neg_inf, rows, c.n_kv, group,
+    );
     let context = b.dot_general(
         &probabilities,
         &values,
@@ -480,7 +688,8 @@ pub(super) fn attention(
     );
     let context = b.transpose(&context, &[1, 0, 2, 3]);
     let context = b.reshape(&context, vec![rows, c.n_q * d]);
-    b.linear_seq(&context, &lw.wo)
+    let context = round_bf16(b, &context);
+    linear_seq_bf16(b, &context, &lw.wo)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -496,34 +705,87 @@ pub(super) fn attention_decode(
     kcache: &mut Val,
     vcache: &mut Val,
 ) -> Val {
+    attention_decode_traced(
+        b,
+        normalized,
+        position,
+        lw,
+        layer,
+        cache_index,
+        c,
+        k,
+        kcache,
+        vcache,
+    )
+    .0
+}
+
+pub(super) struct DecodeAttentionTrace {
+    pub q_projection: Val,
+    pub q_norm: Val,
+    pub q_rope: Val,
+    pub k_projection: Option<Val>,
+    pub k_norm: Option<Val>,
+    pub k_rope: Option<Val>,
+    pub v_projection: Option<Val>,
+    pub v_norm: Option<Val>,
+    pub keys: Val,
+    pub values: Val,
+    pub context: Val,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn attention_decode_traced(
+    b: &mut Builder,
+    normalized: &Val,
+    position: &Val,
+    lw: &LayerWeights,
+    layer: usize,
+    cache_index: usize,
+    c: &Gemma3nConfig,
+    k: &Constants,
+    kcache: &mut Val,
+    vcache: &mut Val,
+) -> (Val, DecodeAttentionTrace) {
     let d = c.head_dim;
     let group = c.n_q / c.n_kv;
     let position_row = b.reshape(position, vec![1]);
-    let q = b.linear_seq(normalized, &lw.wq);
-    let q = b.reshape(&q, vec![1, c.n_q, d]);
-    let q = rms_last(b, &q, Some(&lw.q_norm), &k.eps, &k.zero);
+    let q_projection = linear_seq_bf16(b, normalized, &lw.wq);
+    let q = b.reshape(&q_projection, vec![1, c.n_q, d]);
+    let q_norm = rms_last_bf16(b, &q, Some(&lw.q_norm), &k.eps, &k.zero);
     let (cos, sin, window) = match c.layer_types[layer] {
         super::gemma3n::Gemma3nLayerType::Full => (&k.cos_global, &k.sin_global, None),
         super::gemma3n::Gemma3nLayerType::Sliding => {
             (&k.cos_local, &k.sin_local, Some(c.sliding_window))
         }
     };
-    let q = rope(b, &q, &position_row, cos, sin, 1, c.n_q, d);
-    if let (Some(wk), Some(wv), Some(k_norm)) = (&lw.wk, &lw.wv, &lw.k_norm) {
-        let keys = b.linear_seq(normalized, wk);
-        let keys = b.reshape(&keys, vec![1, c.n_kv, d]);
-        let keys = rms_last(b, &keys, Some(k_norm), &k.eps, &k.zero);
-        let keys = rope(b, &keys, &position_row, cos, sin, 1, c.n_kv, d);
-        let values = b.linear_seq(normalized, wv);
-        let values = b.reshape(&values, vec![1, c.n_kv, d]);
-        let values = rms_last(b, &values, None, &k.eps, &k.zero);
-        let cache = b.const_i32(cache_index as i32);
-        let zero = b.const_i32(0);
-        let keys = b.reshape(&keys, vec![1, 1, c.n_kv, d]);
-        *kcache = b.dynamic_update_slice(kcache, &keys, &[&cache, position, &zero, &zero]);
-        let values = b.reshape(&values, vec![1, 1, c.n_kv, d]);
-        *vcache = b.dynamic_update_slice(vcache, &values, &[&cache, position, &zero, &zero]);
-    }
+    let query_position = if lw.wk.is_none() {
+        let one = b.const_i32(1);
+        b.add(position, &one)
+    } else {
+        position.clone()
+    };
+    let query_position = b.reshape(&query_position, vec![1]);
+    let q_rope = rope(b, &q_norm, &query_position, cos, sin, 1, c.n_q, d);
+    let projected_kv =
+        if let (Some(wk), Some(wv), Some(k_norm_weight)) = (&lw.wk, &lw.wv, &lw.k_norm) {
+            let k_projection = linear_seq_bf16(b, normalized, wk);
+            let keys = b.reshape(&k_projection, vec![1, c.n_kv, d]);
+            let k_norm = rms_last_bf16(b, &keys, Some(k_norm_weight), &k.eps, &k.zero);
+            let k_rope = rope(b, &k_norm, &position_row, cos, sin, 1, c.n_kv, d);
+            let v_projection = linear_seq_bf16(b, normalized, wv);
+            let values = b.reshape(&v_projection, vec![1, c.n_kv, d]);
+            let v_norm = rms_last_bf16(b, &values, None, &k.eps, &k.zero);
+            let cache = b.const_i32(cache_index as i32);
+            let zero = b.const_i32(0);
+            let keys = b.reshape(&k_rope, vec![1, 1, c.n_kv, d]);
+            *kcache = b.dynamic_update_slice(kcache, &keys, &[&cache, position, &zero, &zero]);
+            let values = b.reshape(&v_norm, vec![1, 1, c.n_kv, d]);
+            *vcache = b.dynamic_update_slice(vcache, &values, &[&cache, position, &zero, &zero]);
+            Some((k_projection, k_norm, k_rope, v_projection, v_norm))
+        } else {
+            None
+        };
     let keys = b.slice(
         kcache,
         &[
@@ -544,44 +806,250 @@ pub(super) fn attention_decode(
         ],
     );
     let values = b.reshape(&values, vec![c.context_capacity, c.n_kv, d]);
-    let q = b.reshape(&q, vec![1, c.n_kv, group, d]);
-    let scores = b.dot_general(
-        &q,
-        &keys,
-        &[1],
-        &[1],
-        &[3],
-        &[2],
-        vec![c.n_kv, 1, group, c.context_capacity],
-    );
-    let indices = b.iota(c.context_capacity);
-    let position_b = b.broadcast(position, &[], vec![c.context_capacity]);
-    let visible = b.compare("LE", &indices, &position_b, "SIGNED");
-    let visible = if let Some(width) = window {
-        let first = b.const_i32(width.saturating_sub(1) as i32);
-        let first = b.subtract(position, &first);
-        let first = b.broadcast(&first, &[], vec![c.context_capacity]);
-        let local = b.compare("GE", &indices, &first, "SIGNED");
-        b.select(&visible, &local, &visible)
+    let context = if native_decode_sdpa_supported(b, c, window) {
+        let q = b.reshape(&q_rope, vec![c.n_q, d]);
+        let context = b.gemma3n_sdpa_vector(&q, &keys, &values, position, window, 1.0);
+        b.reshape(&context, vec![1, c.n_q * d])
     } else {
-        visible
+        let q = b.reshape(&q_rope, vec![1, c.n_kv, group, d]);
+        let scores = b.dot_general(
+            &q,
+            &keys,
+            &[1],
+            &[1],
+            &[3],
+            &[2],
+            vec![c.n_kv, 1, group, c.context_capacity],
+        );
+        let indices = b.iota(c.context_capacity);
+        let position_b = b.broadcast(position, &[], vec![c.context_capacity]);
+        let visible = b.compare("LE", &indices, &position_b, "SIGNED");
+        let visible = if let Some(width) = window {
+            let first = b.const_i32(width.saturating_sub(1) as i32);
+            let first = b.subtract(position, &first);
+            let first = b.broadcast(&first, &[], vec![c.context_capacity]);
+            let local = b.compare("GE", &indices, &first, "SIGNED");
+            b.select(&visible, &local, &visible)
+        } else {
+            visible
+        };
+        let zeros = b.broadcast(&k.zero, &[], vec![c.context_capacity]);
+        let masked = b.broadcast(&k.neg_big, &[], vec![c.context_capacity]);
+        let mask = b.select(&visible, &zeros, &masked);
+        let mask = b.broadcast(&mask, &[3], vec![c.n_kv, 1, group, c.context_capacity]);
+        let scores = b.add(&scores, &mask);
+        let probabilities = softmax(b, &scores, 3, k);
+        let context = b.dot_general(
+            &probabilities,
+            &values,
+            &[0],
+            &[1],
+            &[3],
+            &[0],
+            vec![c.n_kv, 1, group, d],
+        );
+        let context = b.transpose(&context, &[1, 0, 2, 3]);
+        b.reshape(&context, vec![1, c.n_q * d])
     };
-    let zeros = b.broadcast(&k.zero, &[], vec![c.context_capacity]);
-    let masked = b.broadcast(&k.neg_big, &[], vec![c.context_capacity]);
-    let mask = b.select(&visible, &zeros, &masked);
-    let mask = b.broadcast(&mask, &[3], vec![c.n_kv, 1, group, c.context_capacity]);
-    let scores = b.add(&scores, &mask);
-    let probabilities = softmax(b, &scores, 3, k);
-    let context = b.dot_general(
-        &probabilities,
-        &values,
-        &[0],
-        &[1],
-        &[3],
-        &[0],
-        vec![c.n_kv, 1, group, d],
-    );
-    let context = b.transpose(&context, &[1, 0, 2, 3]);
-    let context = b.reshape(&context, vec![1, c.n_q * d]);
-    b.linear_seq(&context, &lw.wo)
+    let context = round_bf16(b, &context);
+    let projected = linear_seq_bf16(b, &context, &lw.wo);
+    let (k_projection, k_norm, k_rope, v_projection, v_norm) = projected_kv
+        .map_or((None, None, None, None, None), |(kp, kn, kr, vp, vn)| {
+            (Some(kp), Some(kn), Some(kr), Some(vp), Some(vn))
+        });
+    (
+        projected,
+        DecodeAttentionTrace {
+            q_projection,
+            q_norm,
+            q_rope,
+            k_projection,
+            k_norm,
+            k_rope,
+            v_projection,
+            v_norm,
+            keys,
+            values,
+            context,
+        },
+    )
+}
+
+#[cfg(xla_iree_cuda)]
+fn native_decode_sdpa_supported(b: &Builder, c: &Gemma3nConfig, window: Option<usize>) -> bool {
+    b.gemma3n_qmv_enabled()
+        && c.head_dim == 256
+        && (1..=1024).contains(&c.context_capacity)
+        && c.n_q > 0
+        && c.n_kv > 0
+        && c.n_q.is_multiple_of(c.n_kv)
+        && window.is_none_or(|width| width >= c.context_capacity)
+}
+
+#[cfg(not(xla_iree_cuda))]
+fn native_decode_sdpa_supported(_b: &Builder, _c: &Gemma3nConfig, _window: Option<usize>) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::emitter::builder::Ty;
+
+    #[test]
+    fn bf16_scalar_is_host_rounded_without_a_convert_pair() {
+        let value = (2048.0f32).sqrt();
+        assert_eq!(round_bf16_f32(value), 45.25);
+
+        let mut b = Builder::new();
+        let scalar = bf16_scalar(&mut b, value);
+        let mut expected = Builder::new();
+        expected.const_f32(45.25);
+        assert_eq!(scalar.ty.elt, "f32");
+        assert_eq!(b.body(), expected.body());
+        assert!(!b.body().contains("stablehlo.convert"));
+    }
+
+    #[test]
+    fn bf16_round_is_explicit_in_stablehlo() {
+        let mut b = Builder::new();
+        let value = Builder::arg(0, Ty::f32(vec![2, 8]));
+        let rounded = round_bf16(&mut b, &value);
+        assert_eq!(rounded.ty.elt, "f32");
+        assert_eq!(b.body().matches("stablehlo.convert").count(), 2);
+        assert!(
+            b.body()
+                .contains("stablehlo.convert %arg0 : (tensor<2x8xf32>) -> tensor<2x8xbf16>")
+        );
+        assert!(b.body().contains("-> tensor<2x8xf32>"));
+    }
+
+    #[test]
+    fn bf16_projection_has_f32_island_boundary() {
+        let mut b = Builder::new();
+        let input = Builder::arg(0, Ty::f32(vec![2, 8]));
+        let weight = Builder::arg(1, Ty::f32(vec![4, 8]));
+        let output = linear_seq_bf16(&mut b, &input, &weight);
+        assert_eq!(output.ty.elt, "f32");
+        assert_eq!(b.body().matches("stablehlo.convert").count(), 4);
+        assert!(
+            b.body()
+                .contains("(tensor<2x8xbf16>, tensor<4x8xbf16>) -> tensor<2x4xf32>")
+        );
+        assert!(b.body().contains("-> tensor<2x4xbf16>"));
+        assert!(b.body().contains("-> tensor<2x4xf32>"));
+    }
+
+    #[test]
+    fn sparse_gelu_materializes_every_mlx_bf16_carrier() {
+        let mut b = Builder::new();
+        let input = Builder::arg(0, Ty::f32(vec![2, 8]));
+        let zero = b.const_f32(0.0);
+        let one = b.const_f32(1.0);
+        let stages = sparse_gelu_stages(&mut b, &input, 0.5, &zero, &one);
+
+        assert_eq!(stages.activated.ty.elt, "f32");
+        assert_eq!(stages.activated.ty.shape, vec![2, 8]);
+        let body = b.body();
+        assert_eq!(
+            body.matches("stablehlo.convert").count(),
+            28,
+            "14 dynamic MLX intermediates must each round through bf16"
+        );
+        assert_eq!(body.matches("stablehlo.sqrt").count(), 1);
+        assert!(!body.contains("stablehlo.rsqrt"));
+    }
+
+    #[test]
+    fn altup_correction_rounds_product_before_residual_add() {
+        let mut b = Builder::new();
+        let predicted = Builder::arg(0, Ty::f32(vec![2, 8]));
+        let innovation = Builder::arg(1, Ty::f32(vec![2, 8]));
+        let coefficient = Builder::arg(2, Ty::f32(vec![2, 8]));
+        let (correction, corrected) =
+            altup_correct_plane(&mut b, &predicted, &innovation, &coefficient);
+
+        assert_eq!(correction.ty.elt, "f32");
+        assert_eq!(correction.ty.shape, vec![2, 8]);
+        assert_eq!(corrected.ty.elt, "f32");
+        assert_eq!(corrected.ty.shape, vec![2, 8]);
+        let body = b.body();
+        assert_eq!(body.matches("stablehlo.multiply").count(), 1);
+        assert_eq!(body.matches("stablehlo.add").count(), 1);
+        assert_eq!(
+            body.matches("stablehlo.convert").count(),
+            4,
+            "product and corrected value must independently round through bf16"
+        );
+        let multiply = body.find("stablehlo.multiply").unwrap();
+        let first_round = body.find("stablehlo.convert").unwrap();
+        let add = body.find("stablehlo.add").unwrap();
+        assert!(multiply < first_round && first_round < add);
+    }
+
+    #[test]
+    fn materialized_attention_pins_bf16_score_mask_and_probability_carriers() {
+        let mut b = Builder::new();
+        let q = Builder::arg(0, Ty::f32(vec![3, 1, 2, 4]));
+        let keys = Builder::arg(1, Ty::f32(vec![3, 1, 4]));
+        let mask = Builder::arg(2, Ty::f32(vec![3, 3]));
+        let zero = b.const_f32(0.0);
+        let neg_inf = b.const_f32(f32::NEG_INFINITY);
+        let probabilities = materialized_attention_probabilities(
+            &mut b, &q, &keys, &mask, &zero, &neg_inf, 3, 1, 2,
+        );
+
+        assert_eq!(probabilities.ty.elt, "f32");
+        assert_eq!(probabilities.ty.shape, vec![1, 3, 2, 3]);
+        let body = b.body();
+        assert_eq!(body.matches("stablehlo.dot_general").count(), 1);
+        assert_eq!(
+            body.matches("stablehlo.convert").count(),
+            8,
+            "QK, mask, masked score, and softmax output each need bf16->f32 carriers"
+        );
+        let exponential = body.find("stablehlo.exponential").unwrap();
+        assert_eq!(
+            body[..exponential].matches("stablehlo.convert").count(),
+            6,
+            "score and mask carriers must be rounded before precise softmax"
+        );
+        assert_eq!(
+            body[exponential..].matches("stablehlo.convert").count(),
+            2,
+            "precise softmax must store its result through BF16"
+        );
+    }
+
+    #[test]
+    fn bf16_rms_norm_rounds_before_and_after_weight() {
+        let mut weighted = Builder::new();
+        let x = Builder::arg(0, Ty::f32(vec![2, 8]));
+        let weight = Builder::arg(1, Ty::f32(vec![8]));
+        let eps = Builder::arg(2, Ty::scalar("f32"));
+        let zero = Builder::arg(3, Ty::scalar("f32"));
+        let result = rms_last_bf16(&mut weighted, &x, Some(&weight), &eps, &zero);
+        assert_eq!(result.ty.elt, "f32");
+        assert_eq!(weighted.body().matches("stablehlo.convert").count(), 4);
+        assert_eq!(weighted.body().matches("stablehlo.multiply").count(), 3);
+
+        let mut unweighted = Builder::new();
+        let result = rms_last_bf16(&mut unweighted, &x, None, &eps, &zero);
+        assert_eq!(result.ty.elt, "f32");
+        assert_eq!(unweighted.body().matches("stablehlo.convert").count(), 2);
+        assert_eq!(unweighted.body().matches("stablehlo.multiply").count(), 2);
+    }
+
+    #[test]
+    fn absent_altup_clip_leaves_coefficients_unchanged() {
+        let mut b = Builder::new();
+        let value = Builder::arg(0, Ty::f32(vec![4, 4]));
+        let unchanged = clipped(&mut b, &value, None);
+        assert_eq!(unchanged.name, value.name);
+        assert!(b.body().is_empty());
+
+        let clipped = clipped(&mut b, &value, Some(0.0));
+        assert_ne!(clipped.name, value.name);
+        assert_eq!(b.body().matches("stablehlo.compare").count(), 2);
+    }
 }

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_math.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_math.rs
@@ -35,10 +35,13 @@ pub(crate) fn per_layer_embedding_lookup(
     Ok(out)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn project_dense_ple(
     merged_embeddings: &[f32],
     token_ple: &[f32],
     projection: &[f32],
+    projection_norm: &[f32],
+    eps: f32,
     positions: usize,
     hidden: usize,
     layers: usize,
@@ -50,23 +53,32 @@ pub(crate) fn project_dense_ple(
     if merged_embeddings.len() != positions.saturating_mul(hidden)
         || token_ple.len() != positions.saturating_mul(ple_width)
         || projection.len() != ple_width.saturating_mul(hidden)
+        || projection_norm.len() != hidden_per_layer
     {
         return Err("Gemma3n dense PLE projection shape mismatch".into());
     }
-    let mut out = vec![0.0; token_ple.len()];
+    let mut projected = vec![0.0; token_ple.len()];
     let model_scale = (hidden as f32).sqrt().recip();
-    let combine_scale = std::f32::consts::FRAC_1_SQRT_2;
     for p in 0..positions {
         for o in 0..ple_width {
-            let mut projected = 0.0;
+            let mut value = 0.0;
             for i in 0..hidden {
-                projected += merged_embeddings[p * hidden + i] * projection[o * hidden + i];
+                value += merged_embeddings[p * hidden + i] * projection[o * hidden + i];
             }
-            out[p * ple_width + o] =
-                (projected * model_scale + token_ple[p * ple_width + o]) * combine_scale;
+            projected[p * ple_width + o] = value * model_scale;
+        }
+        for layer in 0..layers {
+            let start = p * ple_width + layer * hidden_per_layer;
+            let end = start + hidden_per_layer;
+            let normalized = rms_weighted(&projected[start..end], projection_norm, eps)?;
+            projected[start..end].copy_from_slice(&normalized);
         }
     }
-    Ok(out)
+    Ok(projected
+        .into_iter()
+        .zip(token_ple)
+        .map(|(projected, token)| (projected + token) * std::f32::consts::FRAC_1_SQRT_2)
+        .collect())
 }
 
 pub(crate) fn normalize_magnitude(plane: &mut [f32], target_rms: f32) {
@@ -78,6 +90,53 @@ pub(crate) fn normalize_magnitude(plane: &mut [f32], target_rms: f32) {
     for value in plane {
         *value *= scale;
     }
+}
+
+fn matvec(input: &[f32], weight: &[f32], output: usize) -> Result<Vec<f32>, String> {
+    if output == 0 || weight.len() != output.saturating_mul(input.len()) {
+        return Err("Gemma3n projection shape mismatch".into());
+    }
+    Ok(weight
+        .chunks_exact(input.len())
+        .map(|row| {
+            row.iter()
+                .zip(input)
+                .map(|(weight, value)| weight * value)
+                .sum()
+        })
+        .collect())
+}
+
+fn rms_weighted(input: &[f32], weight: &[f32], eps: f32) -> Result<Vec<f32>, String> {
+    if input.is_empty() || input.len() != weight.len() {
+        return Err("Gemma3n RMS norm shape mismatch".into());
+    }
+    let inverse = (input.iter().map(|value| value * value).sum::<f32>() / input.len() as f32 + eps)
+        .sqrt()
+        .recip();
+    Ok(input
+        .iter()
+        .zip(weight)
+        .map(|(value, weight)| value * inverse * weight)
+        .collect())
+}
+
+pub(crate) fn laurel_residual(
+    normalized: &[f32],
+    linear_left: &[f32],
+    linear_right: &[f32],
+    post_norm: &[f32],
+    rank: usize,
+    eps: f32,
+) -> Result<Vec<f32>, String> {
+    let low_rank = matvec(normalized, linear_left, rank)?;
+    let restored = matvec(&low_rank, linear_right, normalized.len())?;
+    let restored = rms_weighted(&restored, post_norm, eps)?;
+    Ok(normalized
+        .iter()
+        .zip(restored)
+        .map(|(residual, update)| residual + update)
+        .collect())
 }
 
 pub(crate) fn altup_predict(
@@ -140,6 +199,22 @@ pub(crate) fn gelu_approx(value: f32) -> f32 {
     0.5 * value * (1.0 + inner.tanh())
 }
 
+fn erf_approx(value: f32) -> f32 {
+    // Abramowitz-Stegun 7.1.26 is sufficient for this independent f32 oracle.
+    let sign = value.signum();
+    let x = value.abs();
+    let t = 1.0 / (1.0 + 0.327_591_1 * x);
+    let polynomial = (((((1.061_405_4 * t - 1.453_152_1) * t) + 1.421_413_8) * t - 0.284_496_72)
+        * t
+        + 0.254_829_6)
+        * t;
+    sign * (1.0 - polynomial * (-x * x).exp())
+}
+
+fn gelu_erf(value: f32) -> f32 {
+    0.5 * value * (1.0 + erf_approx(value / std::f32::consts::SQRT_2))
+}
+
 pub(crate) fn sparse_gelu(values: &[f32], std_multiplier: f32) -> Vec<f32> {
     if values.is_empty() {
         return Vec::new();
@@ -150,11 +225,8 @@ pub(crate) fn sparse_gelu(values: &[f32], std_multiplier: f32) -> Vec<f32> {
     values
         .iter()
         .map(|&value| {
-            if value >= cutoff {
-                gelu_approx(value)
-            } else {
-                0.0
-            }
+            let shifted = (value - cutoff).max(0.0);
+            gelu_erf(shifted)
         })
         .collect()
 }
@@ -167,6 +239,103 @@ pub(crate) fn geglu_approx(gate: &[f32], up: &[f32]) -> Result<Vec<f32>, String>
         .iter()
         .zip(up)
         .map(|(&gate, &up)| gelu_approx(gate) * up)
+        .collect())
+}
+
+pub(crate) fn ple_injection(
+    corrected_active: &[f32],
+    dense_ple: &[f32],
+    gate_projection: &[f32],
+    output_projection: &[f32],
+    post_norm: &[f32],
+    eps: f32,
+) -> Result<Vec<f32>, String> {
+    let gate = matvec(corrected_active, gate_projection, dense_ple.len())?;
+    let activated = geglu_approx(&gate, dense_ple)?;
+    let projected = matvec(&activated, output_projection, corrected_active.len())?;
+    rms_weighted(&projected, post_norm, eps)
+}
+
+pub(crate) fn finish_layer_planes(
+    corrected: &[Vec<f32>],
+    active_index: usize,
+    ple_injection: &[f32],
+) -> Result<Vec<Vec<f32>>, String> {
+    let hidden = corrected.first().map_or(0, Vec::len);
+    if active_index >= corrected.len()
+        || hidden == 0
+        || ple_injection.len() != hidden
+        || corrected.iter().any(|plane| plane.len() != hidden)
+    {
+        return Err("Gemma3n layer-boundary plane shape mismatch".into());
+    }
+    Ok(corrected
+        .iter()
+        .enumerate()
+        .map(|(index, plane)| {
+            if index == active_index {
+                plane.clone()
+            } else {
+                plane
+                    .iter()
+                    .zip(ple_injection)
+                    .map(|(value, injection)| value + injection)
+                    .collect()
+            }
+        })
+        .collect())
+}
+
+pub(crate) fn collapse_altup_planes(
+    active: &[f32],
+    other_planes: &[Vec<f32>],
+    unembed_projections: &[Vec<f32>],
+) -> Result<Vec<f32>, String> {
+    if active.is_empty()
+        || other_planes.len() != unembed_projections.len()
+        || other_planes.iter().any(|plane| plane.len() != active.len())
+    {
+        return Err("Gemma3n AltUp collapse shape mismatch".into());
+    }
+    let target_rms =
+        (active.iter().map(|value| value * value).sum::<f32>() / active.len() as f32).sqrt();
+    let mut normalized_planes = vec![active.to_vec()];
+    for (plane, projection) in other_planes.iter().zip(unembed_projections) {
+        let mut projected = matvec(plane, projection, active.len())?;
+        normalize_magnitude(&mut projected, target_rms);
+        normalized_planes.push(projected);
+    }
+    mean_altup_planes_bf16(&normalized_planes)
+}
+
+pub(crate) fn mean_altup_planes_bf16(planes: &[Vec<f32>]) -> Result<Vec<f32>, String> {
+    let hidden = planes.first().map_or(0, Vec::len);
+    if hidden == 0 || planes.iter().any(|plane| plane.len() != hidden) {
+        return Err("Gemma3n AltUp mean plane shape mismatch".into());
+    }
+    let mut sum = vec![0.0f32; hidden];
+    for plane in planes {
+        for (sum, value) in sum.iter_mut().zip(plane) {
+            *sum += value;
+        }
+    }
+    let reciprocal = crate::weights::round_bf16_f32((planes.len() as f32).recip());
+    Ok(sum
+        .into_iter()
+        .map(|value| {
+            let value = crate::weights::round_bf16_f32(value);
+            crate::weights::round_bf16_f32(value * reciprocal)
+        })
+        .collect())
+}
+
+pub(crate) fn softcap_logits(logits: &[f32], cap: f32) -> Result<Vec<f32>, String> {
+    if !cap.is_finite() || cap <= 0.0 {
+        return Err("Gemma3n logit softcap must be finite and positive".into());
+    }
+    Ok(logits
+        .iter()
+        .map(|value| cap * (value / cap).tanh())
         .collect())
 }
 
@@ -220,11 +389,31 @@ mod tests {
     }
 
     #[test]
+    fn laurel_low_rank_residual_matches_hand_computation() {
+        let got =
+            laurel_residual(&[3.0, 4.0], &[2.0, 0.0], &[1.0, 2.0], &[1.0, 1.0], 1, 0.0).unwrap();
+        let rms = ((6.0f32.powi(2) + 12.0f32.powi(2)) / 2.0).sqrt();
+        assert!((got[0] - (3.0 + 6.0 / rms)).abs() < 1e-6);
+        assert!((got[1] - (4.0 + 12.0 / rms)).abs() < 1e-6);
+    }
+
+    #[test]
     fn dense_ple_projection_and_geglu_match_hand_computation() {
-        let projected =
-            project_dense_ple(&[2.0, 4.0], &[1.0, 3.0], &[1.0, 0.0, 0.0, 1.0], 1, 2, 1, 2).unwrap();
-        assert!((projected[0] - (2.0 / 2.0f32.sqrt() + 1.0) / 2.0f32.sqrt()).abs() < 1e-6);
-        assert!((projected[1] - (4.0 / 2.0f32.sqrt() + 3.0) / 2.0f32.sqrt()).abs() < 1e-6);
+        let projected = project_dense_ple(
+            &[2.0, 4.0],
+            &[1.0, 3.0],
+            &[1.0, 0.0, 0.0, 1.0],
+            &[1.0, 1.0],
+            0.0,
+            1,
+            2,
+            1,
+            2,
+        )
+        .unwrap();
+        let projected_rms = ((1.0f32 + 4.0) / 2.0).sqrt();
+        assert!((projected[0] - (1.0 / projected_rms + 1.0) / 2.0f32.sqrt()).abs() < 1e-6);
+        assert!((projected[1] - (2.0 / projected_rms + 3.0) / 2.0f32.sqrt()).abs() < 1e-6);
         assert_eq!(geglu_approx(&[0.0], &[7.0]).unwrap(), vec![0.0]);
     }
 
@@ -242,6 +431,59 @@ mod tests {
         let mut zero = vec![0.0; 4];
         normalize_magnitude(&mut zero, 2.0);
         assert_eq!(zero, vec![0.0; 4]);
-        assert_eq!(sparse_gelu(&[0.0, 1.0, 2.0], 0.0)[0], 0.0);
+        let sparse = sparse_gelu(&[0.0, 1.0, 2.0], 0.0);
+        assert_eq!(sparse[0], 0.0);
+        assert_eq!(sparse[1], 0.0);
+        assert!((sparse[2] - gelu_erf(1.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn ple_injection_collapse_and_softcap_pin_late_layer_math() {
+        let injection = ple_injection(
+            &[1.0, 2.0],
+            &[3.0],
+            &[1.0, 0.0],
+            &[1.0, 2.0],
+            &[1.0, 1.0],
+            0.0,
+        )
+        .unwrap();
+        assert!((injection[0] - 2.5f32.sqrt().recip()).abs() < 1e-6);
+        assert!((injection[1] - 2.0 * 2.5f32.sqrt().recip()).abs() < 1e-6);
+
+        let next = finish_layer_planes(&[vec![2.0, 3.0], vec![5.0, 7.0]], 0, &injection).unwrap();
+        assert_eq!(next[0], vec![2.0, 3.0]);
+        assert!((next[1][0] - (5.0 + injection[0])).abs() < 1e-6);
+        assert!((next[1][1] - (7.0 + injection[1])).abs() < 1e-6);
+
+        let collapsed =
+            collapse_altup_planes(&[3.0, 4.0], &[vec![0.0, 5.0]], &[vec![1.0, 0.0, 0.0, 1.0]])
+                .unwrap();
+        assert!((collapsed[0] - 1.5).abs() < 1e-6);
+        assert!((collapsed[1] - 4.5).abs() < 1e-6);
+
+        let capped = softcap_logits(&[-60.0, 0.0, 60.0], 30.0).unwrap();
+        assert_eq!(capped[1].to_bits(), 0);
+        assert!(capped[0] < -28.0 && capped[0] > -30.0);
+        assert!(capped[2] > 28.0 && capped[2] < 30.0);
+    }
+
+    #[test]
+    fn final_altup_mean_reduces_in_f32_before_bf16_rounding() {
+        let planes = vec![
+            vec![1.0],
+            vec![0.00390625],
+            vec![0.00390625],
+            vec![0.00390625],
+        ];
+        let collapsed = mean_altup_planes_bf16(&planes).unwrap();
+        assert_eq!(collapsed, vec![0.25390625]);
+
+        let pairwise_rounded = planes.iter().skip(1).fold(planes[0][0], |sum, plane| {
+            crate::weights::round_bf16_f32(sum + plane[0])
+        });
+        let pairwise_mean = crate::weights::round_bf16_f32(pairwise_rounded * 0.25);
+        assert_eq!(pairwise_mean, 0.25);
+        assert_ne!(collapsed[0], pairwise_mean);
     }
 }

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_math.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_math.rs
@@ -1,0 +1,247 @@
+//! Small f32 Gemma3n oracle kernels used to isolate graph math in unit tests.
+//!
+//! These are deliberately dependency-free and operate on flattened row-major
+//! buffers.  They are not the production executor; they pin formulas and edge
+//! semantics so StableHLO changes can be compared one sublayer at a time.
+
+pub(crate) fn per_layer_embedding_lookup(
+    token_ids: &[i32],
+    table: &[f32],
+    per_layer_vocab: usize,
+    layers: usize,
+    hidden_per_layer: usize,
+) -> Result<Vec<f32>, String> {
+    let row = layers
+        .checked_mul(hidden_per_layer)
+        .ok_or("Gemma3n PLE row width overflows")?;
+    if table.len() != per_layer_vocab.saturating_mul(row) {
+        return Err(format!(
+            "Gemma3n PLE table has {} elements; expected {}",
+            table.len(),
+            per_layer_vocab.saturating_mul(row)
+        ));
+    }
+    let mut out = vec![0.0; token_ids.len().saturating_mul(row)];
+    for (position, &token) in token_ids.iter().enumerate() {
+        // The PLE vocabulary is intentionally smaller than the ordinary token
+        // vocabulary.  Negative and high ids map to an exact all-zero row.
+        if let Ok(index) = usize::try_from(token)
+            && index < per_layer_vocab
+        {
+            out[position * row..(position + 1) * row]
+                .copy_from_slice(&table[index * row..(index + 1) * row]);
+        }
+    }
+    Ok(out)
+}
+
+pub(crate) fn project_dense_ple(
+    merged_embeddings: &[f32],
+    token_ple: &[f32],
+    projection: &[f32],
+    positions: usize,
+    hidden: usize,
+    layers: usize,
+    hidden_per_layer: usize,
+) -> Result<Vec<f32>, String> {
+    let ple_width = layers
+        .checked_mul(hidden_per_layer)
+        .ok_or("Gemma3n projected PLE width overflows")?;
+    if merged_embeddings.len() != positions.saturating_mul(hidden)
+        || token_ple.len() != positions.saturating_mul(ple_width)
+        || projection.len() != ple_width.saturating_mul(hidden)
+    {
+        return Err("Gemma3n dense PLE projection shape mismatch".into());
+    }
+    let mut out = vec![0.0; token_ple.len()];
+    let model_scale = (hidden as f32).sqrt().recip();
+    let combine_scale = std::f32::consts::FRAC_1_SQRT_2;
+    for p in 0..positions {
+        for o in 0..ple_width {
+            let mut projected = 0.0;
+            for i in 0..hidden {
+                projected += merged_embeddings[p * hidden + i] * projection[o * hidden + i];
+            }
+            out[p * ple_width + o] =
+                (projected * model_scale + token_ple[p * ple_width + o]) * combine_scale;
+        }
+    }
+    Ok(out)
+}
+
+pub(crate) fn normalize_magnitude(plane: &mut [f32], target_rms: f32) {
+    if plane.is_empty() {
+        return;
+    }
+    let rms = (plane.iter().map(|v| v * v).sum::<f32>() / plane.len() as f32).sqrt();
+    let scale = target_rms / rms.max(1e-6);
+    for value in plane {
+        *value *= scale;
+    }
+}
+
+pub(crate) fn altup_predict(
+    planes: &[Vec<f32>],
+    coefficients: &[f32],
+) -> Result<Vec<Vec<f32>>, String> {
+    let n = planes.len();
+    let hidden = planes.first().map_or(0, Vec::len);
+    if n < 2 || planes.iter().any(|plane| plane.len() != hidden) || coefficients.len() != n * n {
+        return Err("Gemma3n AltUp predict shape mismatch".into());
+    }
+    let mut predicted = planes.to_vec();
+    for target in 0..n {
+        for source in 0..n {
+            let coefficient = coefficients[source * n + target];
+            for feature in 0..hidden {
+                predicted[target][feature] += coefficient * planes[source][feature];
+            }
+        }
+    }
+    Ok(predicted)
+}
+
+pub(crate) fn altup_correct(
+    predicted: &[Vec<f32>],
+    activated: &[f32],
+    active_prediction: &[f32],
+    correction: &[f32],
+) -> Result<Vec<Vec<f32>>, String> {
+    let n = predicted.len();
+    let hidden = activated.len();
+    if predicted.iter().any(|plane| plane.len() != hidden)
+        || active_prediction.len() != hidden
+        || correction.len() != n
+    {
+        return Err("Gemma3n AltUp correct shape mismatch".into());
+    }
+    let innovation: Vec<f32> = activated
+        .iter()
+        .zip(active_prediction)
+        .map(|(actual, predicted)| actual - predicted)
+        .collect();
+    Ok(predicted
+        .iter()
+        .zip(correction)
+        .map(|(plane, &coefficient)| {
+            plane
+                .iter()
+                .zip(&innovation)
+                // Reference adds one to the learned correction coefficient.
+                .map(|(value, delta)| value + (coefficient + 1.0) * delta)
+                .collect()
+        })
+        .collect())
+}
+
+pub(crate) fn gelu_approx(value: f32) -> f32 {
+    let inner =
+        (2.0f32 / std::f32::consts::PI).sqrt() * (value + 0.044_715 * value * value * value);
+    0.5 * value * (1.0 + inner.tanh())
+}
+
+pub(crate) fn sparse_gelu(values: &[f32], std_multiplier: f32) -> Vec<f32> {
+    if values.is_empty() {
+        return Vec::new();
+    }
+    let mean = values.iter().sum::<f32>() / values.len() as f32;
+    let variance = values.iter().map(|v| (v - mean).powi(2)).sum::<f32>() / values.len() as f32;
+    let cutoff = mean + std_multiplier * variance.sqrt();
+    values
+        .iter()
+        .map(|&value| {
+            if value >= cutoff {
+                gelu_approx(value)
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn geglu_approx(gate: &[f32], up: &[f32]) -> Result<Vec<f32>, String> {
+    if gate.len() != up.len() {
+        return Err("Gemma3n GeGLU inputs must have the same length".into());
+    }
+    Ok(gate
+        .iter()
+        .zip(up)
+        .map(|(&gate, &up)| gelu_approx(gate) * up)
+        .collect())
+}
+
+pub(crate) fn attention_bias(
+    capacity: usize,
+    real_len: usize,
+    window: Option<usize>,
+) -> Result<Vec<f32>, String> {
+    if !(1..=capacity).contains(&real_len) {
+        return Err(format!("real_len {real_len} is outside 1..={capacity}"));
+    }
+    let mut bias = vec![-1e30; capacity.saturating_mul(capacity)];
+    for query in 0..capacity {
+        let first = window.map_or(0, |width| (query + 1).saturating_sub(width));
+        for key in first..=query {
+            // Padded rows keep a deterministic causal mask. Real rows cannot
+            // see padded keys because key <= query < real_len.
+            if query >= real_len || key < real_len {
+                bias[query * capacity + key] = 0.0;
+            }
+        }
+    }
+    Ok(bias)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn per_layer_vocab_overflow_is_exact_zero_not_row_zero() {
+        let table = vec![
+            3.0, 4.0, // token 0
+            5.0, 6.0, // token 1
+        ];
+        let got = per_layer_embedding_lookup(&[0, 2, -1, 1], &table, 2, 1, 2).unwrap();
+        assert_eq!(got, vec![3.0, 4.0, 0.0, 0.0, 0.0, 0.0, 5.0, 6.0]);
+        assert_eq!(got[2].to_bits(), 0);
+        assert_eq!(got[3].to_bits(), 0);
+    }
+
+    #[test]
+    fn altup_prediction_and_correction_are_plane_isolated() {
+        let planes = vec![vec![1.0, 2.0], vec![10.0, 20.0]];
+        let predicted = altup_predict(&planes, &[0.0, 0.5, 0.25, 0.0]).unwrap();
+        assert_eq!(predicted, vec![vec![3.5, 7.0], vec![10.5, 21.0]]);
+        let corrected =
+            altup_correct(&predicted, &[12.5, 23.0], &predicted[1], &[0.0, 1.0]).unwrap();
+        assert_eq!(corrected[0], vec![5.5, 9.0]);
+        assert_eq!(corrected[1], vec![14.5, 25.0]);
+    }
+
+    #[test]
+    fn dense_ple_projection_and_geglu_match_hand_computation() {
+        let projected =
+            project_dense_ple(&[2.0, 4.0], &[1.0, 3.0], &[1.0, 0.0, 0.0, 1.0], 1, 2, 1, 2).unwrap();
+        assert!((projected[0] - (2.0 / 2.0f32.sqrt() + 1.0) / 2.0f32.sqrt()).abs() < 1e-6);
+        assert!((projected[1] - (4.0 / 2.0f32.sqrt() + 3.0) / 2.0f32.sqrt()).abs() < 1e-6);
+        assert_eq!(geglu_approx(&[0.0], &[7.0]).unwrap(), vec![0.0]);
+    }
+
+    #[test]
+    fn full_and_sliding_masks_keep_padding_explicit() {
+        let full = attention_bias(4, 2, None).unwrap();
+        let sliding = attention_bias(4, 2, Some(2)).unwrap();
+        assert_eq!(&full[4..8], &[0.0, 0.0, -1e30, -1e30]);
+        assert_eq!(&sliding[12..16], &[-1e30, -1e30, 0.0, 0.0]);
+        assert_eq!(full[2], -1e30);
+    }
+
+    #[test]
+    fn magnitude_and_sparse_activation_are_stable_at_zero() {
+        let mut zero = vec![0.0; 4];
+        normalize_magnitude(&mut zero, 2.0);
+        assert_eq!(zero, vec![0.0; 4]);
+        assert_eq!(sparse_gelu(&[0.0, 1.0, 2.0], 0.0)[0], 0.0);
+    }
+}

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_qmv.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_qmv.rs
@@ -1,0 +1,2303 @@
+//! CUDA custom-dispatch definition for Gemma3n Q4 prefill projections.
+//!
+//! The PTX is generated only by the CUDA-IREE build and embedded into every
+//! native-QMV MLIR module. Other IREE targets never reference this module.
+
+use std::fmt::Write as _;
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+use std::path::PathBuf;
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+use std::process::Command;
+
+pub(crate) const GEMMA3N_QMV_ABI_VERSION: u32 = 6;
+pub(crate) const GEMMA3N_QMV_KERNEL_VERSION: u32 = 8;
+pub(crate) const GEMMA3N_QMV_MIN_SM: u32 = 80;
+
+#[cfg(xla_iree_cuda)]
+const GEMMA3N_QMV_PTX: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/gemma3n_qmv_sm80.ptx"));
+
+pub(crate) fn is_available() -> bool {
+    cfg!(xla_iree_cuda)
+}
+
+#[cfg(xla_iree_cuda)]
+fn ptx() -> &'static [u8] {
+    GEMMA3N_QMV_PTX
+}
+
+#[cfg(not(xla_iree_cuda))]
+fn ptx() -> &'static [u8] {
+    &[]
+}
+
+/// Stable metadata hash. PTX bytes themselves are embedded in the MLIR and
+/// therefore already participate in the graph/cache hash; this hash exists for
+/// compact logs and artifact-identity diagnostics.
+pub(crate) fn ptx_fnv1a64() -> u64 {
+    ptx().iter().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+    })
+}
+
+pub(crate) fn artifact_identity() -> String {
+    format!(
+        "gemma3n-qmv:kernel-v{}:abi-v{}:min-sm{}:ptx-fnv1a64={:016x}",
+        GEMMA3N_QMV_KERNEL_VERSION,
+        GEMMA3N_QMV_ABI_VERSION,
+        GEMMA3N_QMV_MIN_SM,
+        ptx_fnv1a64(),
+    )
+}
+
+pub(crate) fn target_alias() -> &'static str {
+    "#gemma3n_qmv_target = #hal.executable.target<\"cuda\", \"cuda-nvptx-fb\">\n"
+}
+
+fn sdpa_vector_export() -> &'static str {
+    "    hal.executable.export public @gemma3n_sdpa_vector ordinal(5)\n\
+     \x20       layout(#hal.pipeline.layout<constants = 6, bindings = [\n\
+     \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+     \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+     \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+     \x20         #hal.pipeline.binding<storage_buffer>\n\
+     \x20       ]>) count(%device: !hal.device, %query_heads: index) -> \
+     (index, index, index) {\n\
+     \x20     %c1 = arith.constant 1 : index\n\
+     \x20     hal.return %query_heads, %c1, %c1 : index, index, index\n\
+     \x20   } attributes {\n\
+     \x20     workgroup_size = [1024 : index, 1 : index, 1 : index]\n\
+     \x20   }\n"
+}
+
+pub(crate) fn executable_source() -> String {
+    assert!(
+        is_available(),
+        "Gemma3n native QMV requires a CUDA-IREE build"
+    );
+    let bytes = ptx();
+    assert!(!bytes.is_empty(), "Gemma3n native QMV PTX is empty");
+    let mut dense = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(dense, "{byte:02X}");
+    }
+    format!(
+        "  // {identity}\n  hal.executable.source private @custom_qmv attributes {{\n\
+         \x20   objects = #hal.executable.objects<{{\n\
+         \x20     #gemma3n_qmv_target = [#hal.executable.object<{{\n\
+         \x20       path = \"gemma3n_qmv_compute80.ptx\",\n\
+         \x20       data = dense<\"0x{dense}\"> : vector<{byte_len}xi8>\n\
+         \x20     }}>]\n\
+         \x20   }}>\n\
+         \x20 }} {{\n\
+         \x20   hal.executable.export public @gemma3n_qmv ordinal(0)\n\
+         \x20       layout(#hal.pipeline.layout<constants = 3, bindings = [\n\
+         \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+         \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+         \x20         #hal.pipeline.binding<storage_buffer>\n\
+         \x20       ]>) count(%device: !hal.device, %n: index, %m: index) -> \
+         (index, index, index) {{\n\
+         \x20     %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 8)>()[%n]\n\
+         \x20     %c1 = arith.constant 1 : index\n\
+         \x20     hal.return %x, %m, %c1 : index, index, index\n\
+         \x20   }} attributes {{\n\
+         \x20     workgroup_size = [32 : index, 8 : index, 1 : index]\n\
+         \x20   }}\n\
+         \x20   hal.executable.export public @gemma3n_tanh ordinal(1)\n\
+         \x20       layout(#hal.pipeline.layout<constants = 1, bindings = [\n\
+         \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+         \x20         #hal.pipeline.binding<storage_buffer>\n\
+         \x20       ]>) count(%device: !hal.device, %length: index) -> \
+         (index, index, index) {{\n\
+         \x20     %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 256)>()[%length]\n\
+         \x20     %c1 = arith.constant 1 : index\n\
+         \x20     hal.return %x, %c1, %c1 : index, index, index\n\
+         \x20   }} attributes {{\n\
+         \x20     workgroup_size = [256 : index, 1 : index, 1 : index]\n\
+         \x20   }}\n\
+         \x20   hal.executable.export public @gemma3n_altup_coeff ordinal(2)\n\
+         \x20       layout(#hal.pipeline.layout<constants = 3, bindings = [\n\
+         \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+         \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+         \x20         #hal.pipeline.binding<storage_buffer>\n\
+         \x20       ]>) count(%device: !hal.device, %rows: index, %output_width: index) -> \
+         (index, index, index) {{\n\
+         \x20     %length = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%rows, %output_width]\n\
+         \x20     %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 256)>()[%length]\n\
+         \x20     %c1 = arith.constant 1 : index\n\
+         \x20     hal.return %x, %c1, %c1 : index, index, index\n\
+         \x20   }} attributes {{\n\
+         \x20     workgroup_size = [256 : index, 1 : index, 1 : index]\n\
+         \x20   }}\n\
+         \x20   hal.executable.export public @gemma3n_altup_predict ordinal(3)\n\
+         \x20       layout(#hal.pipeline.layout<constants = 3, bindings = [\n\
+         \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+         \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+         \x20         #hal.pipeline.binding<storage_buffer>\n\
+         \x20       ]>) count(%device: !hal.device, %plane_count: index, %rows: index, \
+         %hidden: index) -> (index, index, index) {{\n\
+         \x20     %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 16)>()[%hidden]\n\
+         \x20     %c1 = arith.constant 1 : index\n\
+         \x20     hal.return %x, %rows, %c1 : index, index, index\n\
+         \x20   }} attributes {{\n\
+         \x20     workgroup_size = [32 : index, 1 : index, 1 : index]\n\
+         \x20   }}\n\
+         \x20   hal.executable.export public @gemma3n_geglu_bf16 ordinal(4)\n\
+         \x20       layout(#hal.pipeline.layout<constants = 1, bindings = [\n\
+         \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+         \x20         #hal.pipeline.binding<storage_buffer, ReadOnly>,\n\
+         \x20         #hal.pipeline.binding<storage_buffer>\n\
+         \x20       ]>) count(%device: !hal.device, %length: index) -> \
+         (index, index, index) {{\n\
+         \x20     %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 256)>()[%length]\n\
+         \x20     %c1 = arith.constant 1 : index\n\
+         \x20     hal.return %x, %c1, %c1 : index, index, index\n\
+         \x20   }} attributes {{\n\
+         \x20     workgroup_size = [256 : index, 1 : index, 1 : index]\n\
+         \x20   }}\n\
+         {sdpa_vector_export}\
+         \x20 }}\n",
+        identity = artifact_identity(),
+        byte_len = bytes.len(),
+        sdpa_vector_export = sdpa_vector_export(),
+    )
+}
+
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+fn run_cuda_stablehlo_probe(
+    tag: &str,
+    mlir: String,
+    inputs: &[(&[f32], &[usize])],
+    output_len: usize,
+) -> Result<Vec<f32>, String> {
+    let compiler = std::env::var_os("MLXCEL_XLA_IREE_COMPILE")
+        .map(PathBuf::from)
+        .or_else(|| option_env!("MLXCEL_XLA_IREE_COMPILE").map(PathBuf::from))
+        .ok_or("set MLXCEL_XLA_IREE_COMPILE for the Gemma3n diagnostic")?;
+    let runner = std::env::var_os("MLXCEL_XLA_IREE_RUN_MODULE")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("IREE_CUDA_HOME").map(|home| {
+                PathBuf::from(home)
+                    .join("build")
+                    .join("tools")
+                    .join("iree-run-module")
+            })
+        })
+        .ok_or("set MLXCEL_XLA_IREE_RUN_MODULE or IREE_CUDA_HOME")?;
+    let stem = format!("mlxcel-gemma3n-{tag}-{}", std::process::id());
+    let mlir_path = std::env::temp_dir().join(format!("{stem}.mlir"));
+    let vmfb_path = std::env::temp_dir().join(format!("{stem}.vmfb"));
+    let input_paths = (0..inputs.len())
+        .map(|index| std::env::temp_dir().join(format!("{stem}-input{index}.bin")))
+        .collect::<Vec<_>>();
+    let output_path = std::env::temp_dir().join(format!("{stem}-output.bin"));
+    let result = (|| {
+        std::fs::write(&mlir_path, mlir)
+            .map_err(|error| format!("write {}: {error}", mlir_path.display()))?;
+        for ((values, shape), path) in inputs.iter().zip(&input_paths) {
+            let expected = shape.iter().product::<usize>();
+            if values.len() != expected {
+                return Err(format!(
+                    "Gemma3n {tag} input has {} values, expected {expected} for {shape:?}",
+                    values.len()
+                ));
+            }
+            std::fs::write(
+                path,
+                values
+                    .iter()
+                    .flat_map(|value| value.to_le_bytes())
+                    .collect::<Vec<_>>(),
+            )
+            .map_err(|error| format!("write {}: {error}", path.display()))?;
+        }
+        let compiled = Command::new(&compiler)
+            .arg("--iree-input-type=stablehlo")
+            .arg("--iree-hal-target-device=cuda")
+            .arg("--iree-cuda-target=sm_80")
+            .arg(&mlir_path)
+            .arg("-o")
+            .arg(&vmfb_path)
+            .output()
+            .map_err(|error| format!("run {}: {error}", compiler.display()))?;
+        if !compiled.status.success() {
+            return Err(format!(
+                "iree-compile failed:\n{}",
+                String::from_utf8_lossy(&compiled.stderr)
+            ));
+        }
+        let mut command = Command::new(&runner);
+        command
+            .arg("--device=cuda")
+            .arg(format!("--module={}", vmfb_path.display()))
+            .arg("--function=main");
+        for ((_, shape), path) in inputs.iter().zip(&input_paths) {
+            let dimensions = shape
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join("x");
+            command.arg(format!("--input={dimensions}xf32=@{}", path.display()));
+        }
+        let ran = command
+            .arg(format!("--output=@{}", output_path.display()))
+            .output()
+            .map_err(|error| format!("run {}: {error}", runner.display()))?;
+        if !ran.status.success() {
+            return Err(format!(
+                "iree-run-module failed:\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&ran.stdout),
+                String::from_utf8_lossy(&ran.stderr)
+            ));
+        }
+        let bytes = std::fs::read(&output_path)
+            .map_err(|error| format!("read {}: {error}", output_path.display()))?;
+        if bytes.len() != output_len * 4 {
+            return Err(format!(
+                "Gemma3n {tag} output has {} bytes, expected {}",
+                bytes.len(),
+                output_len * 4
+            ));
+        }
+        Ok(bytes
+            .chunks_exact(4)
+            .map(|bytes| f32::from_le_bytes(bytes.try_into().unwrap()))
+            .collect())
+    })();
+    for path in input_paths {
+        let _ = std::fs::remove_file(path);
+    }
+    for path in [mlir_path, vmfb_path, output_path] {
+        let _ = std::fs::remove_file(path);
+    }
+    result
+}
+
+/// Run the embedded native QMV against explicit logical BF16-carrier buffers.
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub fn run_diagnostic_probe(
+    input: &[f32],
+    weight: &[f32],
+    m: usize,
+    n: usize,
+    k: usize,
+) -> Result<Vec<f32>, String> {
+    if input.len() != m * k || weight.len() != n * k {
+        return Err(format!(
+            "QMV diagnostic buffer lengths {}/{} do not match {}/{}",
+            input.len(),
+            weight.len(),
+            m * k,
+            n * k
+        ));
+    }
+    let mut builder = super::builder::Builder::new().with_gemma3n_qmv(true);
+    let input_arg = super::builder::Builder::arg(0, super::builder::Ty::f32(vec![m, k]));
+    let weight_arg = super::builder::Builder::arg(1, super::builder::Ty::f32(vec![n, k]));
+    let output = builder.gemma3n_qmv(&input_arg, &weight_arg);
+    let mlir = format!(
+        "{target}module @gemma3n_qmv_probe {{\n{source}  \
+         func.func public @main(%arg0: {input_ty}, %arg1: {weight_ty}) -> {result_ty} \
+         {{\n{body}    return {result} : {result_ty}\n  }}\n}}\n",
+        target = target_alias(),
+        source = executable_source(),
+        input_ty = input_arg.ty.render(),
+        weight_ty = weight_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    run_cuda_stablehlo_probe(
+        "real-qmv",
+        mlir,
+        &[(input, &[m, k]), (weight, &[n, k])],
+        m * n,
+    )
+}
+
+/// Run the Gemma3n BF16 RMSNorm graph against explicit logical carriers.
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub fn run_rms_diagnostic_probe(
+    input: &[f32],
+    weight: &[f32],
+    rows: usize,
+    width: usize,
+    eps: f32,
+) -> Result<Vec<f32>, String> {
+    if input.len() != rows * width || weight.len() != width {
+        return Err(format!(
+            "RMSNorm diagnostic buffer lengths {}/{} do not match {}/{}",
+            input.len(),
+            weight.len(),
+            rows * width,
+            width
+        ));
+    }
+    let mut builder = super::builder::Builder::new();
+    let input_arg = super::builder::Builder::arg(0, super::builder::Ty::f32(vec![rows, width]));
+    let weight_arg = super::builder::Builder::arg(1, super::builder::Ty::f32(vec![width]));
+    let eps = builder.const_f32(eps);
+    let zero = builder.const_f32(0.0);
+    let output = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &input_arg,
+        Some(&weight_arg),
+        &eps,
+        &zero,
+    );
+    let mlir = format!(
+        "module @gemma3n_rms_probe {{\n  \
+         func.func public @main(%arg0: {input_ty}, %arg1: {weight_ty}) -> {result_ty} \
+         {{\n{body}    return {result} : {result_ty}\n  }}\n}}\n",
+        input_ty = input_arg.ty.render(),
+        weight_ty = weight_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    run_cuda_stablehlo_probe(
+        "real-rms",
+        mlir,
+        &[(input, &[rows, width]), (weight, &[width])],
+        rows * width,
+    )
+}
+
+/// Return the layer attention stages while consuming the exact MLX
+/// q-projection, K/V cache, mask, active prediction, and LAUREL carriers.
+///
+/// Keeping every stage input except q-norm/RoPE identical lets the canonical
+/// diagnostic distinguish the first q rotation mismatch from attention math,
+/// output projection, post-attention norm, and residual rounding.
+#[allow(clippy::too_many_arguments)]
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub fn run_attention_diagnostic_probe(
+    q_projection: &[f32],
+    q_norm_weight: &[f32],
+    keys: &[f32],
+    values: &[f32],
+    mask: &[f32],
+    o_weight: &[f32],
+    post_norm_weight: &[f32],
+    active_prediction: &[f32],
+    laurel: &[f32],
+    rows: usize,
+    query_heads: usize,
+    kv_heads: usize,
+    head_dim: usize,
+    rope_base: f64,
+    eps: f32,
+) -> Result<Vec<f32>, String> {
+    let hidden = query_heads * head_dim;
+    if query_heads == 0
+        || kv_heads == 0
+        || !query_heads.is_multiple_of(kv_heads)
+        || q_projection.len() != rows * hidden
+        || q_norm_weight.len() != head_dim
+        || keys.len() != rows * kv_heads * head_dim
+        || values.len() != rows * kv_heads * head_dim
+        || mask.len() != rows * rows
+        || o_weight.len() != hidden * hidden
+        || post_norm_weight.len() != hidden
+        || active_prediction.len() != rows * hidden
+        || laurel.len() != rows * hidden
+    {
+        return Err("attention diagnostic input lengths do not match the shape".to_string());
+    }
+
+    let mut builder = super::builder::Builder::new().with_gemma3n_qmv(true);
+    let q_projection_arg =
+        super::builder::Builder::arg(0, super::builder::Ty::f32(vec![rows, hidden]));
+    let q_norm_arg = super::builder::Builder::arg(1, super::builder::Ty::f32(vec![head_dim]));
+    let keys_arg =
+        super::builder::Builder::arg(2, super::builder::Ty::f32(vec![rows, kv_heads, head_dim]));
+    let values_arg =
+        super::builder::Builder::arg(3, super::builder::Ty::f32(vec![rows, kv_heads, head_dim]));
+    let mask_arg = super::builder::Builder::arg(4, super::builder::Ty::f32(vec![rows, rows]));
+    let o_weight_arg =
+        super::builder::Builder::arg(5, super::builder::Ty::f32(vec![hidden, hidden]));
+    let post_norm_arg = super::builder::Builder::arg(6, super::builder::Ty::f32(vec![hidden]));
+    let active_arg = super::builder::Builder::arg(7, super::builder::Ty::f32(vec![rows, hidden]));
+    let laurel_arg = super::builder::Builder::arg(8, super::builder::Ty::f32(vec![rows, hidden]));
+
+    let zero = builder.const_f32(0.0);
+    let eps_value = builder.const_f32(eps);
+    let q = builder.reshape(&q_projection_arg, vec![rows, query_heads, head_dim]);
+    let q = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &q,
+        Some(&q_norm_arg),
+        &eps_value,
+        &zero,
+    );
+    let positions = builder.iota(rows);
+    let (cosine, sine) = super::rope::rope_tables_from_inv(
+        &super::rope::plain_inv_freq_with_base(head_dim, rope_base),
+        head_dim,
+        rows,
+        false,
+    );
+    let cosine = builder.const_tensor_f32(&cosine, vec![rows, head_dim]);
+    let sine = builder.const_tensor_f32(&sine, vec![rows, head_dim]);
+    let q = super::gemma3n_emit_ops::rope(
+        &mut builder,
+        &q,
+        &positions,
+        &cosine,
+        &sine,
+        rows,
+        query_heads,
+        head_dim,
+    );
+
+    let group = query_heads / kv_heads;
+    let grouped_q = builder.reshape(&q, vec![rows, kv_heads, group, head_dim]);
+    let raw_scores = builder.dot_general(
+        &grouped_q,
+        &keys_arg,
+        &[1],
+        &[1],
+        &[3],
+        &[2],
+        vec![kv_heads, rows, group, rows],
+    );
+    let raw_scores = super::gemma3n_emit_ops::round_bf16(&mut builder, &raw_scores);
+    let bf16_mask = super::gemma3n_emit_ops::round_bf16(&mut builder, &mask_arg);
+    let bf16_mask = builder.broadcast(&bf16_mask, &[1, 3], vec![kv_heads, rows, group, rows]);
+    let masked_scores = builder.add(&raw_scores, &bf16_mask);
+    let masked_scores = super::gemma3n_emit_ops::round_bf16(&mut builder, &masked_scores);
+    let neg_inf = builder.const_f32(f32::NEG_INFINITY);
+    let probabilities = {
+        let scores = &masked_scores;
+        let shape = scores.ty.shape.clone();
+        let max = builder.reduce_max(scores, 3, &neg_inf);
+        let max = builder.broadcast(&max, &[0, 1, 2], shape.clone());
+        let shifted = builder.subtract(scores, &max);
+        let exp = builder.exponential(&shifted);
+        let sum = builder.reduce_add(&exp, 3, &zero);
+        let sum = builder.broadcast(&sum, &[0, 1, 2], shape);
+        builder.divide(&exp, &sum)
+    };
+    let probabilities = super::gemma3n_emit_ops::round_bf16(&mut builder, &probabilities);
+    let context = builder.dot_general(
+        &probabilities,
+        &values_arg,
+        &[0],
+        &[1],
+        &[3],
+        &[0],
+        vec![kv_heads, rows, group, head_dim],
+    );
+    let context = builder.transpose(&context, &[1, 0, 2, 3]);
+    let context = builder.reshape(&context, vec![rows, hidden]);
+    let context = super::gemma3n_emit_ops::round_bf16(&mut builder, &context);
+    let projected = builder.gemma3n_qmv(&context, &o_weight_arg);
+    let post_norm = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &projected,
+        Some(&post_norm_arg),
+        &eps_value,
+        &zero,
+    );
+    let residual = builder.add(&active_arg, &post_norm);
+    let residual = super::gemma3n_emit_ops::round_bf16(&mut builder, &residual);
+    let with_laurel = builder.add(&residual, &laurel_arg);
+    let with_laurel = super::gemma3n_emit_ops::round_bf16(&mut builder, &with_laurel);
+    let inv_sqrt2 =
+        super::gemma3n_emit_ops::bf16_scalar(&mut builder, std::f32::consts::FRAC_1_SQRT_2);
+    let inv_sqrt2 = builder.broadcast(&inv_sqrt2, &[], vec![rows, hidden]);
+    let attn_laurel = builder.multiply(&with_laurel, &inv_sqrt2);
+    let attn_laurel = super::gemma3n_emit_ops::round_bf16(&mut builder, &attn_laurel);
+    let output = flatten_and_concatenate(
+        &mut builder,
+        &[
+            q,
+            raw_scores,
+            masked_scores,
+            probabilities,
+            context,
+            projected,
+            post_norm,
+            residual,
+            attn_laurel,
+        ],
+    );
+
+    let mlir = format!(
+        "{target}module @gemma3n_attention_probe {{\n{source}  \
+         func.func public @main(%arg0: {q_projection_ty}, %arg1: {q_norm_ty}, \
+         %arg2: {keys_ty}, %arg3: {values_ty}, %arg4: {mask_ty}, \
+         %arg5: {o_weight_ty}, %arg6: {post_norm_ty}, %arg7: {active_ty}, \
+         %arg8: {laurel_ty}) -> {result_ty} {{\n{body}    return {result} : \
+         {result_ty}\n  }}\n}}\n",
+        target = target_alias(),
+        source = executable_source(),
+        q_projection_ty = q_projection_arg.ty.render(),
+        q_norm_ty = q_norm_arg.ty.render(),
+        keys_ty = keys_arg.ty.render(),
+        values_ty = values_arg.ty.render(),
+        mask_ty = mask_arg.ty.render(),
+        o_weight_ty = o_weight_arg.ty.render(),
+        post_norm_ty = post_norm_arg.ty.render(),
+        active_ty = active_arg.ty.render(),
+        laurel_ty = laurel_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    run_cuda_stablehlo_probe(
+        "attention-stages",
+        mlir,
+        &[
+            (q_projection, &[rows, hidden]),
+            (q_norm_weight, &[head_dim]),
+            (keys, &[rows, kv_heads, head_dim]),
+            (values, &[rows, kv_heads, head_dim]),
+            (mask, &[rows, rows]),
+            (o_weight, &[hidden, hidden]),
+            (post_norm_weight, &[hidden]),
+            (active_prediction, &[rows, hidden]),
+            (laurel, &[rows, hidden]),
+        ],
+        rows * hidden * 6 + kv_heads * rows * group * rows * 3,
+    )
+}
+
+/// Run only the production D=256 MLX vector-SDPA context dispatch.
+///
+/// This smaller diagnostics-only entry point supports synthetic address,
+/// boundary-length, GQA, and rounding fixtures without compiling the Gemma3n
+/// output projection tail.
+#[allow(clippy::too_many_arguments)]
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub fn run_sdpa_vector_context_diagnostic_probe(
+    query: &[f32],
+    keys: &[f32],
+    values: &[f32],
+    position: usize,
+    capacity: usize,
+    query_heads: usize,
+    kv_heads: usize,
+    scale: f32,
+    sliding_window: Option<usize>,
+) -> Result<Vec<f32>, String> {
+    const HEAD_DIM: usize = 256;
+    let hidden = query_heads
+        .checked_mul(HEAD_DIM)
+        .ok_or("SDPA diagnostic hidden width overflow")?;
+    let kv_length = capacity
+        .checked_mul(kv_heads)
+        .and_then(|length| length.checked_mul(HEAD_DIM))
+        .ok_or("SDPA diagnostic KV length overflow")?;
+    if query_heads == 0
+        || kv_heads == 0
+        || !query_heads.is_multiple_of(kv_heads)
+        || position >= capacity
+        || position >= 1024
+        || query.len() != hidden
+        || keys.len() != kv_length
+        || values.len() != kv_length
+    {
+        return Err("SDPA vector context diagnostic inputs do not match the shape".to_string());
+    }
+
+    let mut builder = super::builder::Builder::new().with_gemma3n_qmv(true);
+    let query_arg =
+        super::builder::Builder::arg(0, super::builder::Ty::f32(vec![query_heads, HEAD_DIM]));
+    let keys_arg = super::builder::Builder::arg(
+        1,
+        super::builder::Ty::f32(vec![capacity, kv_heads, HEAD_DIM]),
+    );
+    let values_arg = super::builder::Builder::arg(
+        2,
+        super::builder::Ty::f32(vec![capacity, kv_heads, HEAD_DIM]),
+    );
+    let position_value = builder.const_i32(position as i32);
+    let context = builder.gemma3n_sdpa_vector(
+        &query_arg,
+        &keys_arg,
+        &values_arg,
+        &position_value,
+        sliding_window,
+        scale,
+    );
+    let output = builder.reshape(&context, vec![hidden]);
+    let mlir = format!(
+        "{target}module @gemma3n_sdpa_vector_context_probe {{\n{source}  \
+         func.func public @main(%arg0: {query_ty}, %arg1: {keys_ty}, \
+         %arg2: {values_ty}) -> {result_ty} {{\n\
+         {body}    return {result} : {result_ty}\n  }}\n}}\n",
+        target = target_alias(),
+        source = executable_source(),
+        query_ty = query_arg.ty.render(),
+        keys_ty = keys_arg.ty.render(),
+        values_ty = values_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    run_cuda_stablehlo_probe(
+        "sdpa-vector-context",
+        mlir,
+        &[
+            (query, &[query_heads, HEAD_DIM]),
+            (keys, &[capacity, kv_heads, HEAD_DIM]),
+            (values, &[capacity, kv_heads, HEAD_DIM]),
+        ],
+        hidden,
+    )
+}
+
+/// Trace the concrete layer-0 production decode attention stages while
+/// consuming exact MLX normalized-input and prefix-KV carriers.
+///
+/// This wrapper calls the same traced core as normal and ragged decode; it does
+/// not carry a separately-authored materialized attention implementation.
+#[allow(clippy::too_many_arguments)]
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub fn run_decode_attention_diagnostic_probe(
+    normalized: &[f32],
+    q_weight: &[f32],
+    k_weight: &[f32],
+    v_weight: &[f32],
+    q_norm_weight: &[f32],
+    k_norm_weight: &[f32],
+    prefix_keys: &[f32],
+    prefix_values: &[f32],
+    o_weight: &[f32],
+    post_norm_weight: &[f32],
+    active_prediction: &[f32],
+    laurel: &[f32],
+    position: usize,
+    capacity: usize,
+    query_heads: usize,
+    kv_heads: usize,
+    head_dim: usize,
+    rope_base: f64,
+    eps: f32,
+    sliding_window: Option<usize>,
+) -> Result<Vec<f32>, String> {
+    run_production_decode_attention_trace(
+        normalized,
+        q_weight,
+        k_weight,
+        v_weight,
+        q_norm_weight,
+        k_norm_weight,
+        prefix_keys,
+        prefix_values,
+        o_weight,
+        post_norm_weight,
+        active_prediction,
+        laurel,
+        position,
+        capacity,
+        query_heads,
+        kv_heads,
+        head_dim,
+        rope_base,
+        eps,
+        sliding_window,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+fn run_production_decode_attention_trace(
+    normalized: &[f32],
+    q_weight: &[f32],
+    k_weight: &[f32],
+    v_weight: &[f32],
+    q_norm_weight: &[f32],
+    k_norm_weight: &[f32],
+    prefix_keys: &[f32],
+    prefix_values: &[f32],
+    o_weight: &[f32],
+    post_norm_weight: &[f32],
+    active_prediction: &[f32],
+    laurel: &[f32],
+    position: usize,
+    capacity: usize,
+    query_heads: usize,
+    kv_heads: usize,
+    head_dim: usize,
+    rope_base: f64,
+    eps: f32,
+    sliding_window: Option<usize>,
+) -> Result<Vec<f32>, String> {
+    use super::gemma3n::{Gemma3nConfig, Gemma3nLayerType};
+    use super::gemma3n_emit_ops::{
+        LayerWeights, attention_decode_traced, bf16_scalar, constants, rms_last_bf16, round_bf16,
+    };
+
+    let hidden = query_heads
+        .checked_mul(head_dim)
+        .ok_or("decode attention hidden width overflow")?;
+    let kv_width = kv_heads
+        .checked_mul(head_dim)
+        .ok_or("decode attention KV width overflow")?;
+    let valid_len = position
+        .checked_add(1)
+        .ok_or("decode attention live length overflow")?;
+    if query_heads == 0
+        || kv_heads == 0
+        || !query_heads.is_multiple_of(kv_heads)
+        || valid_len > capacity
+        || normalized.len() != hidden
+        || q_weight.len() != hidden * hidden
+        || k_weight.len() != kv_width * hidden
+        || v_weight.len() != kv_width * hidden
+        || q_norm_weight.len() != head_dim
+        || k_norm_weight.len() != head_dim
+        || prefix_keys.len() != position * kv_width
+        || prefix_values.len() != position * kv_width
+        || o_weight.len() != hidden * hidden
+        || post_norm_weight.len() != hidden
+        || active_prediction.len() != hidden
+        || laurel.len() != hidden
+    {
+        return Err("production decode attention trace inputs do not match the shape".to_string());
+    }
+
+    let mut builder = super::builder::Builder::new().with_gemma3n_qmv(true);
+    let normalized_arg = super::builder::Builder::arg(0, super::builder::Ty::f32(vec![1, hidden]));
+    let q_weight_arg =
+        super::builder::Builder::arg(1, super::builder::Ty::f32(vec![hidden, hidden]));
+    let k_weight_arg =
+        super::builder::Builder::arg(2, super::builder::Ty::f32(vec![kv_width, hidden]));
+    let v_weight_arg =
+        super::builder::Builder::arg(3, super::builder::Ty::f32(vec![kv_width, hidden]));
+    let q_norm_arg = super::builder::Builder::arg(4, super::builder::Ty::f32(vec![head_dim]));
+    let k_norm_arg = super::builder::Builder::arg(5, super::builder::Ty::f32(vec![head_dim]));
+    let prefix_keys_arg = super::builder::Builder::arg(
+        6,
+        super::builder::Ty::f32(vec![position, kv_heads, head_dim]),
+    );
+    let prefix_values_arg = super::builder::Builder::arg(
+        7,
+        super::builder::Ty::f32(vec![position, kv_heads, head_dim]),
+    );
+    let o_weight_arg =
+        super::builder::Builder::arg(8, super::builder::Ty::f32(vec![hidden, hidden]));
+    let post_norm_arg = super::builder::Builder::arg(9, super::builder::Ty::f32(vec![hidden]));
+    let active_arg = super::builder::Builder::arg(10, super::builder::Ty::f32(vec![1, hidden]));
+    let laurel_arg = super::builder::Builder::arg(11, super::builder::Ty::f32(vec![1, hidden]));
+
+    let layer_type = if sliding_window.is_some() {
+        Gemma3nLayerType::Sliding
+    } else {
+        Gemma3nLayerType::Full
+    };
+    let config = Gemma3nConfig {
+        context_capacity: capacity,
+        max_position_embeddings: capacity.max(1),
+        hidden,
+        intermediate: vec![hidden],
+        n_layers: 1,
+        n_q: query_heads,
+        n_kv: kv_heads,
+        head_dim,
+        eps,
+        vocab: 1,
+        per_layer_vocab: 1,
+        hidden_per_layer_input: 1,
+        layer_types: vec![layer_type],
+        activation_sparsity: vec![0.0],
+        sliding_window: sliding_window.unwrap_or(capacity.max(1)),
+        rope_theta: rope_base,
+        rope_local_base: rope_base,
+        final_logit_softcap: None,
+        num_kv_shared_layers: 0,
+        altup_num_inputs: 2,
+        altup_active_idx: 0,
+        altup_coef_clip: None,
+        altup_correct_scale: false,
+        laurel_rank: 1,
+        tie_word_embeddings: true,
+        quantization: None,
+    };
+    let constants = constants(&mut builder, &config);
+    let unused = normalized_arg.clone();
+    let layer = LayerWeights {
+        correct_scale: unused.clone(),
+        correction: unused.clone(),
+        router: unused.clone(),
+        router_norm: unused.clone(),
+        prediction: unused.clone(),
+        laurel_left: unused.clone(),
+        laurel_right: unused.clone(),
+        laurel_norm: unused.clone(),
+        input_norm: unused.clone(),
+        post_attn_norm: post_norm_arg.clone(),
+        pre_ff_norm: unused.clone(),
+        post_ff_norm: unused.clone(),
+        wq: q_weight_arg.clone(),
+        wk: Some(k_weight_arg.clone()),
+        wv: Some(v_weight_arg.clone()),
+        wo: o_weight_arg.clone(),
+        q_norm: q_norm_arg.clone(),
+        k_norm: Some(k_norm_arg.clone()),
+        gate: unused.clone(),
+        up: unused.clone(),
+        down: unused.clone(),
+        ple_gate: unused.clone(),
+        ple_projection: unused.clone(),
+        ple_norm: unused,
+    };
+
+    let zero = builder.const_f32(0.0);
+    let padding = capacity - position;
+    let key_padding = builder.broadcast(&zero, &[], vec![padding, kv_heads, head_dim]);
+    let value_padding = builder.broadcast(&zero, &[], vec![padding, kv_heads, head_dim]);
+    let initial_keys = builder.concatenate(&prefix_keys_arg, &key_padding, 0);
+    let initial_values = builder.concatenate(&prefix_values_arg, &value_padding, 0);
+    let mut kcache = builder.reshape(&initial_keys, vec![1, capacity, kv_heads, head_dim]);
+    let mut vcache = builder.reshape(&initial_values, vec![1, capacity, kv_heads, head_dim]);
+    let position_value = builder.const_i32(position as i32);
+    let (projected, trace) = attention_decode_traced(
+        &mut builder,
+        &normalized_arg,
+        &position_value,
+        &layer,
+        0,
+        0,
+        &config,
+        &constants,
+        &mut kcache,
+        &mut vcache,
+    );
+    let valid_keys = builder.slice(&trace.keys, &[(0, valid_len), (0, kv_heads), (0, head_dim)]);
+    let valid_values = builder.slice(
+        &trace.values,
+        &[(0, valid_len), (0, kv_heads), (0, head_dim)],
+    );
+    let post_norm = rms_last_bf16(
+        &mut builder,
+        &projected,
+        Some(&post_norm_arg),
+        &constants.eps,
+        &constants.zero,
+    );
+    let residual = builder.add(&active_arg, &post_norm);
+    let residual = round_bf16(&mut builder, &residual);
+    let with_laurel = builder.add(&residual, &laurel_arg);
+    let with_laurel = round_bf16(&mut builder, &with_laurel);
+    let inv_sqrt2 = bf16_scalar(&mut builder, std::f32::consts::FRAC_1_SQRT_2);
+    let inv_sqrt2 = builder.broadcast(&inv_sqrt2, &[], vec![1, hidden]);
+    let attn_laurel = builder.multiply(&with_laurel, &inv_sqrt2);
+    let attn_laurel = round_bf16(&mut builder, &attn_laurel);
+    let output = flatten_and_concatenate(
+        &mut builder,
+        &[
+            trace.q_projection,
+            trace.q_norm,
+            trace.q_rope,
+            trace
+                .k_projection
+                .expect("concrete diagnostic K projection"),
+            trace.k_norm.expect("concrete diagnostic K norm"),
+            trace.k_rope.expect("concrete diagnostic K RoPE"),
+            trace
+                .v_projection
+                .expect("concrete diagnostic V projection"),
+            trace.v_norm.expect("concrete diagnostic V norm"),
+            valid_keys,
+            valid_values,
+            trace.context,
+            projected,
+            post_norm,
+            residual,
+            attn_laurel,
+        ],
+    );
+
+    let mlir = format!(
+        "{target}module @gemma3n_production_decode_attention_trace {{\n{source}  \
+         func.func public @main(%arg0: {normalized_ty}, %arg1: {q_weight_ty}, \
+         %arg2: {k_weight_ty}, %arg3: {v_weight_ty}, %arg4: {q_norm_ty}, \
+         %arg5: {k_norm_ty}, %arg6: {prefix_keys_ty}, %arg7: {prefix_values_ty}, \
+         %arg8: {o_weight_ty}, %arg9: {post_norm_ty}, %arg10: {active_ty}, \
+         %arg11: {laurel_ty}) -> {result_ty} {{\n{body}    return {result} : \
+         {result_ty}\n  }}\n}}\n",
+        target = target_alias(),
+        source = executable_source(),
+        normalized_ty = normalized_arg.ty.render(),
+        q_weight_ty = q_weight_arg.ty.render(),
+        k_weight_ty = k_weight_arg.ty.render(),
+        v_weight_ty = v_weight_arg.ty.render(),
+        q_norm_ty = q_norm_arg.ty.render(),
+        k_norm_ty = k_norm_arg.ty.render(),
+        prefix_keys_ty = prefix_keys_arg.ty.render(),
+        prefix_values_ty = prefix_values_arg.ty.render(),
+        o_weight_ty = o_weight_arg.ty.render(),
+        post_norm_ty = post_norm_arg.ty.render(),
+        active_ty = active_arg.ty.render(),
+        laurel_ty = laurel_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    run_cuda_stablehlo_probe(
+        "production-decode-attention-trace",
+        mlir,
+        &[
+            (normalized, &[1, hidden]),
+            (q_weight, &[hidden, hidden]),
+            (k_weight, &[kv_width, hidden]),
+            (v_weight, &[kv_width, hidden]),
+            (q_norm_weight, &[head_dim]),
+            (k_norm_weight, &[head_dim]),
+            (prefix_keys, &[position, kv_heads, head_dim]),
+            (prefix_values, &[position, kv_heads, head_dim]),
+            (o_weight, &[hidden, hidden]),
+            (post_norm_weight, &[hidden]),
+            (active_prediction, &[1, hidden]),
+            (laurel, &[1, hidden]),
+        ],
+        hidden * 8 + kv_width * 5 + valid_len * kv_width * 2,
+    )
+}
+
+/// Return the exact production post-attention MLP stages while consuming the
+/// already-proven MLX attention+LAUREL carrier.
+///
+/// This probe intentionally duplicates the production StableHLO schedule
+/// instead of changing the diagnostic layout of the canonical graph. That
+/// keeps the bisect isolated from production graph fusion and lets the caller
+/// identify the first divergent BF16 boundary.
+#[allow(clippy::too_many_arguments)]
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub fn run_post_attention_diagnostic_probe(
+    attention_laurel: &[f32],
+    pre_ff_norm_weight: &[f32],
+    gate_weight: &[f32],
+    up_weight: &[f32],
+    down_weight: &[f32],
+    post_ff_norm_weight: &[f32],
+    rows: usize,
+    hidden: usize,
+    intermediate: usize,
+    eps: f32,
+    sparsity: f32,
+) -> Result<Vec<f32>, String> {
+    if attention_laurel.len() != rows * hidden
+        || pre_ff_norm_weight.len() != hidden
+        || gate_weight.len() != intermediate * hidden
+        || up_weight.len() != intermediate * hidden
+        || down_weight.len() != hidden * intermediate
+        || post_ff_norm_weight.len() != hidden
+    {
+        return Err(
+            "post-attention diagnostic input lengths do not match the requested shape".to_string(),
+        );
+    }
+
+    let mut builder = super::builder::Builder::new().with_gemma3n_qmv(true);
+    let attention_arg =
+        super::builder::Builder::arg(0, super::builder::Ty::f32(vec![rows, hidden]));
+    let pre_ff_norm_arg = super::builder::Builder::arg(1, super::builder::Ty::f32(vec![hidden]));
+    let gate_weight_arg =
+        super::builder::Builder::arg(2, super::builder::Ty::f32(vec![intermediate, hidden]));
+    let up_weight_arg =
+        super::builder::Builder::arg(3, super::builder::Ty::f32(vec![intermediate, hidden]));
+    let down_weight_arg =
+        super::builder::Builder::arg(4, super::builder::Ty::f32(vec![hidden, intermediate]));
+    let post_ff_norm_arg = super::builder::Builder::arg(5, super::builder::Ty::f32(vec![hidden]));
+
+    let zero = builder.const_f32(0.0);
+    let one = builder.const_f32(1.0);
+    let eps_value = builder.const_f32(eps);
+    let pre_ff_norm = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &attention_arg,
+        Some(&pre_ff_norm_arg),
+        &eps_value,
+        &zero,
+    );
+    let gate = builder.gemma3n_qmv(&pre_ff_norm, &gate_weight_arg);
+    let up = builder.gemma3n_qmv(&pre_ff_norm, &up_weight_arg);
+
+    let sparse =
+        super::gemma3n_emit_ops::sparse_gelu_stages(&mut builder, &gate, sparsity, &zero, &one);
+    let product = builder.multiply(&sparse.activated, &up);
+    let product = super::gemma3n_emit_ops::round_bf16(&mut builder, &product);
+    let down = builder.gemma3n_qmv(&product, &down_weight_arg);
+    let post_ff_norm = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &down,
+        Some(&post_ff_norm_arg),
+        &eps_value,
+        &zero,
+    );
+    let ff_residual = builder.add(&attention_arg, &post_ff_norm);
+    let ff_residual = super::gemma3n_emit_ops::round_bf16(&mut builder, &ff_residual);
+
+    let output = flatten_and_concatenate(
+        &mut builder,
+        &[
+            pre_ff_norm,
+            gate,
+            up,
+            sparse.mean,
+            sparse.variance,
+            sparse.stddev,
+            sparse.cutoff,
+            sparse.shifted_raw,
+            sparse.shifted,
+            sparse.erf,
+            sparse.activated,
+            product,
+            down,
+            post_ff_norm,
+            ff_residual,
+        ],
+    );
+
+    let mlir = format!(
+        "{target}module @gemma3n_post_attention_probe {{\n{source}  \
+         func.func public @main(%arg0: {attention_ty}, %arg1: {pre_ff_norm_ty}, \
+         %arg2: {gate_weight_ty}, %arg3: {up_weight_ty}, \
+         %arg4: {down_weight_ty}, %arg5: {post_ff_norm_ty}) -> {result_ty} \
+         {{\n{body}    return {result} : \
+         {result_ty}\n  }}\n}}\n",
+        target = target_alias(),
+        source = executable_source(),
+        attention_ty = attention_arg.ty.render(),
+        pre_ff_norm_ty = pre_ff_norm_arg.ty.render(),
+        gate_weight_ty = gate_weight_arg.ty.render(),
+        up_weight_ty = up_weight_arg.ty.render(),
+        down_weight_ty = down_weight_arg.ty.render(),
+        post_ff_norm_ty = post_ff_norm_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    let output_len = rows * hidden * 4 + rows * intermediate * 7 + rows * 4;
+    run_cuda_stablehlo_probe(
+        "post-attention-stages",
+        mlir,
+        &[
+            (attention_laurel, &[rows, hidden]),
+            (pre_ff_norm_weight, &[hidden]),
+            (gate_weight, &[intermediate, hidden]),
+            (up_weight, &[intermediate, hidden]),
+            (down_weight, &[hidden, intermediate]),
+            (post_ff_norm_weight, &[hidden]),
+        ],
+        output_len,
+    )
+}
+
+/// Pin the production native dense-GeGLU schedule from an exact MLX input
+/// carrier without expanding the full-graph diagnostic result.
+#[allow(clippy::too_many_arguments)]
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub fn run_dense_mlp_diagnostic_probe(
+    attention_laurel: &[f32],
+    pre_ff_norm_weight: &[f32],
+    gate_weight: &[f32],
+    up_weight: &[f32],
+    down_weight: &[f32],
+    post_ff_norm_weight: &[f32],
+    rows: usize,
+    hidden: usize,
+    intermediate: usize,
+    eps: f32,
+) -> Result<Vec<f32>, String> {
+    if attention_laurel.len() != rows * hidden
+        || pre_ff_norm_weight.len() != hidden
+        || gate_weight.len() != intermediate * hidden
+        || up_weight.len() != intermediate * hidden
+        || down_weight.len() != hidden * intermediate
+        || post_ff_norm_weight.len() != hidden
+    {
+        return Err("dense MLP diagnostic inputs do not match the shape".to_string());
+    }
+
+    let mut builder = super::builder::Builder::new().with_gemma3n_qmv(true);
+    let attention_arg =
+        super::builder::Builder::arg(0, super::builder::Ty::f32(vec![rows, hidden]));
+    let pre_ff_norm_arg = super::builder::Builder::arg(1, super::builder::Ty::f32(vec![hidden]));
+    let gate_weight_arg =
+        super::builder::Builder::arg(2, super::builder::Ty::f32(vec![intermediate, hidden]));
+    let up_weight_arg =
+        super::builder::Builder::arg(3, super::builder::Ty::f32(vec![intermediate, hidden]));
+    let down_weight_arg =
+        super::builder::Builder::arg(4, super::builder::Ty::f32(vec![hidden, intermediate]));
+    let post_ff_norm_arg = super::builder::Builder::arg(5, super::builder::Ty::f32(vec![hidden]));
+
+    let zero = builder.const_f32(0.0);
+    let eps_value = builder.const_f32(eps);
+    let pre_ff_norm = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &attention_arg,
+        Some(&pre_ff_norm_arg),
+        &eps_value,
+        &zero,
+    );
+    let gate = builder.gemma3n_qmv(&pre_ff_norm, &gate_weight_arg);
+    let up = builder.gemma3n_qmv(&pre_ff_norm, &up_weight_arg);
+
+    let product = super::gemma3n_emit_ops::geglu(&mut builder, &gate, &up);
+    let down = builder.gemma3n_qmv(&product, &down_weight_arg);
+    let post = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &down,
+        Some(&post_ff_norm_arg),
+        &eps_value,
+        &zero,
+    );
+    let residual = builder.add(&attention_arg, &post);
+    let residual = super::gemma3n_emit_ops::round_bf16(&mut builder, &residual);
+
+    let output = flatten_and_concatenate(
+        &mut builder,
+        &[pre_ff_norm, gate, up, product, down, post, residual],
+    );
+    let mlir = format!(
+        "{target}module @gemma3n_dense_mlp_probe {{\n{source}  \
+         func.func public @main(%arg0: {attention_ty}, %arg1: {pre_ff_norm_ty}, \
+         %arg2: {gate_weight_ty}, %arg3: {up_weight_ty}, \
+         %arg4: {down_weight_ty}, %arg5: {post_ff_norm_ty}) -> {result_ty} \
+         {{\n{body}    return {result} : {result_ty}\n  }}\n}}\n",
+        target = target_alias(),
+        source = executable_source(),
+        attention_ty = attention_arg.ty.render(),
+        pre_ff_norm_ty = pre_ff_norm_arg.ty.render(),
+        gate_weight_ty = gate_weight_arg.ty.render(),
+        up_weight_ty = up_weight_arg.ty.render(),
+        down_weight_ty = down_weight_arg.ty.render(),
+        post_ff_norm_ty = post_ff_norm_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    run_cuda_stablehlo_probe(
+        "dense-mlp-stages",
+        mlir,
+        &[
+            (attention_laurel, &[rows, hidden]),
+            (pre_ff_norm_weight, &[hidden]),
+            (gate_weight, &[intermediate, hidden]),
+            (up_weight, &[intermediate, hidden]),
+            (down_weight, &[hidden, intermediate]),
+            (post_ff_norm_weight, &[hidden]),
+        ],
+        rows * hidden * 4 + rows * intermediate * 3,
+    )
+}
+
+/// Isolate AltUp correction by consuming the exact MLX activated carrier.
+#[allow(clippy::too_many_arguments)]
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub fn run_altup_correct_diagnostic_probe(
+    predicted_stacked: &[f32],
+    active_prediction: &[f32],
+    activated: &[f32],
+    router_norm_weight: &[f32],
+    router_weight: &[f32],
+    correction_weight: &[f32],
+    correct_scale: &[f32],
+    rows: usize,
+    hidden: usize,
+    plane_count: usize,
+    active_index: usize,
+    eps: f32,
+    clip: Option<f32>,
+) -> Result<Vec<f32>, String> {
+    if predicted_stacked.len() != plane_count * rows * hidden
+        || active_prediction.len() != rows * hidden
+        || activated.len() != rows * hidden
+        || router_norm_weight.len() != hidden
+        || router_weight.len() != plane_count * hidden
+        || correction_weight.len() != plane_count * plane_count
+        || correct_scale.len() != hidden
+        || active_index >= plane_count
+    {
+        return Err("AltUp correction inputs do not match the requested shape".to_string());
+    }
+    let mut builder = super::builder::Builder::new().with_gemma3n_qmv(true);
+    let predicted_arg =
+        super::builder::Builder::arg(0, super::builder::Ty::f32(vec![plane_count, rows, hidden]));
+    let active_arg = super::builder::Builder::arg(1, super::builder::Ty::f32(vec![rows, hidden]));
+    let activated_arg =
+        super::builder::Builder::arg(2, super::builder::Ty::f32(vec![rows, hidden]));
+    let router_norm_arg = super::builder::Builder::arg(3, super::builder::Ty::f32(vec![hidden]));
+    let router_weight_arg =
+        super::builder::Builder::arg(4, super::builder::Ty::f32(vec![plane_count, hidden]));
+    let correction_arg =
+        super::builder::Builder::arg(5, super::builder::Ty::f32(vec![plane_count, plane_count]));
+    let scale_arg = super::builder::Builder::arg(6, super::builder::Ty::f32(vec![hidden]));
+    let zero = builder.const_f32(0.0);
+    let one = builder.const_f32(1.0);
+    let eps_value = builder.const_f32(eps);
+    let router_norm = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &activated_arg,
+        Some(&router_norm_arg),
+        &eps_value,
+        &zero,
+    );
+    let hidden_value = builder.const_f32(hidden as f32);
+    let hidden_value = builder.broadcast(&hidden_value, &[], vec![rows, hidden]);
+    let router_scaled = builder.divide(&router_norm, &hidden_value);
+    let router_scaled = super::gemma3n_emit_ops::round_bf16(&mut builder, &router_scaled);
+    let modalities = builder.gemma3n_qmv(&router_scaled, &router_weight_arg);
+    let modalities = builder.gemma3n_tanh(&modalities);
+    let correction = match clip {
+        Some(limit) => {
+            let upper = builder.const_f32(limit);
+            let upper = builder.broadcast(&upper, &[], vec![plane_count, plane_count]);
+            let lower = builder.const_f32(-limit);
+            let lower = builder.broadcast(&lower, &[], vec![plane_count, plane_count]);
+            let above = builder.compare("GT", &correction_arg, &upper, "FLOAT");
+            let clipped = builder.select(&above, &upper, &correction_arg);
+            let below = builder.compare("LT", &clipped, &lower, "FLOAT");
+            builder.select(&below, &lower, &clipped)
+        }
+        None => correction_arg.clone(),
+    };
+    let coefficients = builder.gemma3n_altup_coeff(&modalities, &correction);
+    let one_b = builder.broadcast(&one, &[], vec![rows, plane_count]);
+    let coefficients = builder.add(&coefficients, &one_b);
+    let innovation = builder.subtract(&activated_arg, &active_arg);
+    let innovation = super::gemma3n_emit_ops::round_bf16(&mut builder, &innovation);
+    let mut corrections = Vec::with_capacity(plane_count);
+    let mut corrected = Vec::with_capacity(plane_count);
+    for plane in 0..plane_count {
+        let coefficient = builder.slice(&coefficients, &[(0, rows), (plane, plane + 1)]);
+        let coefficient = builder.broadcast(&coefficient, &[0, 1], vec![rows, hidden]);
+        let predicted = builder.slice(
+            &predicted_arg,
+            &[(plane, plane + 1), (0, rows), (0, hidden)],
+        );
+        let predicted = builder.reshape(&predicted, vec![rows, hidden]);
+        let (correction, corrected_plane) = super::gemma3n_emit_ops::altup_correct_plane(
+            &mut builder,
+            &predicted,
+            &innovation,
+            &coefficient,
+        );
+        corrections.push(correction.clone());
+        corrected.push(corrected_plane);
+    }
+    let stack = |builder: &mut super::builder::Builder,
+                 planes: &[super::builder::Val]|
+     -> super::builder::Val {
+        let mut stacked = builder.reshape(&planes[0], vec![1, rows, hidden]);
+        for plane in &planes[1..] {
+            let plane = builder.reshape(plane, vec![1, rows, hidden]);
+            stacked = builder.concatenate(&stacked, &plane, 0);
+        }
+        stacked
+    };
+    let corrections = stack(&mut builder, &corrections);
+    let corrected_stacked = stack(&mut builder, &corrected);
+    let corrected_active = corrected[active_index].clone();
+    let scale = builder.broadcast(&scale_arg, &[1], vec![rows, hidden]);
+    let scaled_active = builder.multiply(&corrected_active, &scale);
+    let scaled_active = super::gemma3n_emit_ops::round_bf16(&mut builder, &scaled_active);
+    let output = flatten_and_concatenate(
+        &mut builder,
+        &[
+            router_norm,
+            router_scaled,
+            modalities,
+            coefficients,
+            innovation,
+            corrections,
+            corrected_stacked,
+            corrected_active,
+            scaled_active,
+        ],
+    );
+    let mlir = format!(
+        "{target}module @gemma3n_altup_correct_probe {{\n{source}  \
+         func.func public @main(%arg0: {predicted_ty}, %arg1: {active_ty}, \
+         %arg2: {activated_ty}, %arg3: {router_norm_ty}, \
+         %arg4: {router_weight_ty}, %arg5: {correction_ty}, %arg6: {scale_ty}) -> \
+         {result_ty} {{\n{body}    return {result} : {result_ty}\n  }}\n}}\n",
+        target = target_alias(),
+        source = executable_source(),
+        predicted_ty = predicted_arg.ty.render(),
+        active_ty = active_arg.ty.render(),
+        activated_ty = activated_arg.ty.render(),
+        router_norm_ty = router_norm_arg.ty.render(),
+        router_weight_ty = router_weight_arg.ty.render(),
+        correction_ty = correction_arg.ty.render(),
+        scale_ty = scale_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    run_cuda_stablehlo_probe(
+        "altup-correct",
+        mlir,
+        &[
+            (predicted_stacked, &[plane_count, rows, hidden]),
+            (active_prediction, &[rows, hidden]),
+            (activated, &[rows, hidden]),
+            (router_norm_weight, &[hidden]),
+            (router_weight, &[plane_count, hidden]),
+            (correction_weight, &[plane_count, plane_count]),
+            (correct_scale, &[hidden]),
+        ],
+        rows * hidden * 5 + rows * plane_count * 2 + plane_count * rows * hidden * 2,
+    )
+}
+
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+fn flatten_and_concatenate(
+    builder: &mut super::builder::Builder,
+    values: &[super::builder::Val],
+) -> super::builder::Val {
+    let mut flattened = builder.reshape(
+        &values[0],
+        vec![values[0].ty.shape.iter().product::<usize>()],
+    );
+    for value in &values[1..] {
+        let value = builder.reshape(value, vec![value.ty.shape.iter().product::<usize>()]);
+        flattened = builder.concatenate(&flattened, &value, 0);
+    }
+    flattened
+}
+
+/// Return raw/scaled/RMS/add/inv-sqrt2 PLE stages as one flat diagnostic vector.
+#[allow(clippy::too_many_arguments)]
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub fn run_ple_diagnostic_probe(
+    raw_projection: &[f32],
+    token_ple: &[f32],
+    norm_weight: &[f32],
+    rows: usize,
+    layers: usize,
+    ple_width: usize,
+    hidden: usize,
+    eps: f32,
+) -> Result<Vec<f32>, String> {
+    let total = layers * ple_width;
+    if raw_projection.len() != rows * total
+        || token_ple.len() != rows * total
+        || norm_weight.len() != ple_width
+    {
+        return Err("PLE diagnostic input lengths do not match the requested shape".to_string());
+    }
+    let mut builder = super::builder::Builder::new();
+    let raw = super::builder::Builder::arg(0, super::builder::Ty::f32(vec![rows, total]));
+    let token =
+        super::builder::Builder::arg(1, super::builder::Ty::f32(vec![rows, layers, ple_width]));
+    let weight = super::builder::Builder::arg(2, super::builder::Ty::f32(vec![ple_width]));
+    let scale = super::gemma3n_emit_ops::bf16_scalar(&mut builder, (hidden as f32).sqrt().recip());
+    let scale = builder.broadcast(&scale, &[], vec![rows, total]);
+    let scaled = builder.multiply(&raw, &scale);
+    let scaled = super::gemma3n_emit_ops::round_bf16(&mut builder, &scaled);
+    let reshaped = builder.reshape(&scaled, vec![rows, layers, ple_width]);
+    let eps = builder.const_f32(eps);
+    let zero = builder.const_f32(0.0);
+    let normed =
+        super::gemma3n_emit_ops::rms_last_bf16(&mut builder, &reshaped, Some(&weight), &eps, &zero);
+    let added = builder.add(&normed, &token);
+    let added = super::gemma3n_emit_ops::round_bf16(&mut builder, &added);
+    let inv = super::gemma3n_emit_ops::bf16_scalar(&mut builder, std::f32::consts::FRAC_1_SQRT_2);
+    let inv = builder.broadcast(&inv, &[], vec![rows, layers, ple_width]);
+    let combined = builder.multiply(&added, &inv);
+    let combined = super::gemma3n_emit_ops::round_bf16(&mut builder, &combined);
+    let output = flatten_and_concatenate(
+        &mut builder,
+        &[raw.clone(), scaled, normed, added, combined],
+    );
+    let mlir = format!(
+        "module @gemma3n_ple_probe {{\n  \
+         func.func public @main(%arg0: {raw_ty}, %arg1: {token_ty}, %arg2: {weight_ty}) -> \
+         {result_ty} {{\n{body}    return {result} : {result_ty}\n  }}\n}}\n",
+        raw_ty = raw.ty.render(),
+        token_ty = token.ty.render(),
+        weight_ty = weight.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    run_cuda_stablehlo_probe(
+        "ple-stages",
+        mlir,
+        &[
+            (raw_projection, &[rows, total]),
+            (token_ple, &[rows, layers, ple_width]),
+            (norm_weight, &[ple_width]),
+        ],
+        rows * total * 5,
+    )
+}
+
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+fn bf16_magnitude(
+    builder: &mut super::builder::Builder,
+    value: &super::builder::Val,
+    rows: usize,
+    width: usize,
+    zero: &super::builder::Val,
+) -> super::builder::Val {
+    let squared = builder.multiply(value, value);
+    let squared = super::gemma3n_emit_ops::round_bf16(builder, &squared);
+    let sum = builder.reduce_add(&squared, 1, zero);
+    let sum = super::gemma3n_emit_ops::round_bf16(builder, &sum);
+    let width = builder.const_f32(width as f32);
+    let width = builder.broadcast(&width, &[], vec![rows]);
+    let mean = builder.divide(&sum, &width);
+    let mean = super::gemma3n_emit_ops::round_bf16(builder, &mean);
+    let magnitude = builder.sqrt(&mean);
+    super::gemma3n_emit_ops::round_bf16(builder, &magnitude)
+}
+
+/// Return target magnitude and all normalized non-base AltUp planes.
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub fn run_initial_altup_diagnostic_probe(
+    base: &[f32],
+    projections: &[f32],
+    projection_count: usize,
+    rows: usize,
+    hidden: usize,
+    eps: f32,
+) -> Result<Vec<f32>, String> {
+    if base.len() != rows * hidden || projections.len() != projection_count * rows * hidden {
+        return Err(
+            "initial AltUp diagnostic input lengths do not match the requested shape".to_string(),
+        );
+    }
+    let mut builder = super::builder::Builder::new();
+    let base_arg = super::builder::Builder::arg(0, super::builder::Ty::f32(vec![rows, hidden]));
+    let projections_arg = super::builder::Builder::arg(
+        1,
+        super::builder::Ty::f32(vec![projection_count, rows, hidden]),
+    );
+    let zero = builder.const_f32(0.0);
+    let target = bf16_magnitude(&mut builder, &base_arg, rows, hidden, &zero);
+    let mut outputs = vec![target.clone()];
+    for index in 0..projection_count {
+        let plane = builder.slice(
+            &projections_arg,
+            &[(index, index + 1), (0, rows), (0, hidden)],
+        );
+        let plane = builder.reshape(&plane, vec![rows, hidden]);
+        let magnitude = bf16_magnitude(&mut builder, &plane, rows, hidden, &zero);
+        let eps_value = builder.const_f32(eps);
+        let eps_value = builder.broadcast(&eps_value, &[], vec![rows]);
+        let safe_pred = builder.compare("GT", &magnitude, &eps_value, "FLOAT");
+        let safe = builder.select(&safe_pred, &magnitude, &eps_value);
+        let safe = super::gemma3n_emit_ops::round_bf16(&mut builder, &safe);
+        let scale = builder.divide(&target, &safe);
+        let scale = super::gemma3n_emit_ops::round_bf16(&mut builder, &scale);
+        let scale = builder.broadcast(&scale, &[0], vec![rows, hidden]);
+        let normalized = builder.multiply(&plane, &scale);
+        outputs.push(super::gemma3n_emit_ops::round_bf16(
+            &mut builder,
+            &normalized,
+        ));
+    }
+    let output = flatten_and_concatenate(&mut builder, &outputs);
+    let mlir = format!(
+        "module @gemma3n_initial_altup_probe {{\n  \
+         func.func public @main(%arg0: {base_ty}, %arg1: {projections_ty}) -> {result_ty} \
+         {{\n{body}    return {result} : {result_ty}\n  }}\n}}\n",
+        base_ty = base_arg.ty.render(),
+        projections_ty = projections_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    run_cuda_stablehlo_probe(
+        "initial-altup-stages",
+        mlir,
+        &[
+            (base, &[rows, hidden]),
+            (projections, &[projection_count, rows, hidden]),
+        ],
+        rows + projection_count * rows * hidden,
+    )
+}
+
+/// Return router-norm/scaled/modalities/predicted/active/input-norm stages.
+#[allow(clippy::too_many_arguments)]
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub fn run_altup_predict_diagnostic_probe(
+    planes: &[f32],
+    router_norm_weight: &[f32],
+    router_weight: &[f32],
+    prediction_weight: &[f32],
+    input_norm_weight: &[f32],
+    plane_count: usize,
+    active_index: usize,
+    rows: usize,
+    hidden: usize,
+    eps: f32,
+    clip: Option<f32>,
+) -> Result<Vec<f32>, String> {
+    if planes.len() != plane_count * rows * hidden
+        || router_norm_weight.len() != hidden
+        || router_weight.len() != plane_count * hidden
+        || prediction_weight.len() != plane_count * plane_count * plane_count
+        || input_norm_weight.len() != hidden
+        || active_index >= plane_count
+    {
+        return Err("AltUp predict diagnostic input lengths do not match the shape".to_string());
+    }
+    let mut builder = super::builder::Builder::new().with_gemma3n_qmv(true);
+    let planes_arg =
+        super::builder::Builder::arg(0, super::builder::Ty::f32(vec![plane_count, rows, hidden]));
+    let router_norm_arg = super::builder::Builder::arg(1, super::builder::Ty::f32(vec![hidden]));
+    let router_weight_arg =
+        super::builder::Builder::arg(2, super::builder::Ty::f32(vec![plane_count, hidden]));
+    let prediction_arg = super::builder::Builder::arg(
+        3,
+        super::builder::Ty::f32(vec![plane_count * plane_count, plane_count]),
+    );
+    let input_norm_arg = super::builder::Builder::arg(4, super::builder::Ty::f32(vec![hidden]));
+    let active = builder.slice(
+        &planes_arg,
+        &[(active_index, active_index + 1), (0, rows), (0, hidden)],
+    );
+    let active = builder.reshape(&active, vec![rows, hidden]);
+    let eps_value = builder.const_f32(eps);
+    let zero = builder.const_f32(0.0);
+    let routed_norm = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &active,
+        Some(&router_norm_arg),
+        &eps_value,
+        &zero,
+    );
+    let hidden_value = builder.const_f32(hidden as f32);
+    let hidden_value = builder.broadcast(&hidden_value, &[], vec![rows, hidden]);
+    let routed_scaled = builder.divide(&routed_norm, &hidden_value);
+    let routed_scaled = super::gemma3n_emit_ops::round_bf16(&mut builder, &routed_scaled);
+    let modalities = builder.gemma3n_qmv(&routed_scaled, &router_weight_arg);
+    let modalities = builder.gemma3n_tanh(&modalities);
+    let prediction = match clip {
+        Some(limit) => {
+            let positive = builder.const_f32(limit);
+            let positive =
+                builder.broadcast(&positive, &[], vec![plane_count * plane_count, plane_count]);
+            let negative = builder.const_f32(-limit);
+            let negative =
+                builder.broadcast(&negative, &[], vec![plane_count * plane_count, plane_count]);
+            let above = builder.compare("GT", &prediction_arg, &positive, "FLOAT");
+            let clipped = builder.select(&above, &positive, &prediction_arg);
+            let below = builder.compare("LT", &clipped, &negative, "FLOAT");
+            builder.select(&below, &negative, &clipped)
+        }
+        None => prediction_arg.clone(),
+    };
+    let coefficients = builder.gemma3n_altup_coeff(&modalities, &prediction);
+    let coefficients = builder.reshape(&coefficients, vec![rows, plane_count, plane_count]);
+    let coefficients = builder.transpose(&coefficients, &[0, 2, 1]);
+    let predicted = builder.gemma3n_altup_predict(&planes_arg, &coefficients);
+    let active_predicted = builder.slice(
+        &predicted,
+        &[(active_index, active_index + 1), (0, rows), (0, hidden)],
+    );
+    let active_predicted = builder.reshape(&active_predicted, vec![rows, hidden]);
+    let input_norm = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &active_predicted,
+        Some(&input_norm_arg),
+        &eps_value,
+        &zero,
+    );
+    let output = flatten_and_concatenate(
+        &mut builder,
+        &[
+            routed_norm,
+            routed_scaled,
+            modalities,
+            coefficients,
+            predicted,
+            active_predicted,
+            input_norm,
+        ],
+    );
+    let mlir = format!(
+        "{target}module @gemma3n_altup_predict_probe {{\n{source}  \
+         func.func public @main(%arg0: {planes_ty}, %arg1: {router_norm_ty}, \
+         %arg2: {router_weight_ty}, %arg3: {prediction_ty}, %arg4: {input_norm_ty}) -> \
+         {result_ty} {{\n{body}    return {result} : {result_ty}\n  }}\n}}\n",
+        target = target_alias(),
+        source = executable_source(),
+        planes_ty = planes_arg.ty.render(),
+        router_norm_ty = router_norm_arg.ty.render(),
+        router_weight_ty = router_weight_arg.ty.render(),
+        prediction_ty = prediction_arg.ty.render(),
+        input_norm_ty = input_norm_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    let output_len = rows * hidden * 2
+        + rows * hidden * 2
+        + rows * plane_count
+        + rows * plane_count * plane_count
+        + plane_count * rows * hidden;
+    run_cuda_stablehlo_probe(
+        "altup-predict-stages",
+        mlir,
+        &[
+            (planes, &[plane_count, rows, hidden]),
+            (router_norm_weight, &[hidden]),
+            (router_weight, &[plane_count, hidden]),
+            (prediction_weight, &[plane_count * plane_count, plane_count]),
+            (input_norm_weight, &[hidden]),
+        ],
+        output_len,
+    )
+}
+
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+#[allow(clippy::too_many_arguments)]
+pub fn run_ple_injection_diagnostic_probe(
+    corrected_active: &[f32],
+    correct_scale: &[f32],
+    per_layer_input: &[f32],
+    gate_weight: &[f32],
+    projection_weight: &[f32],
+    norm_weight: &[f32],
+    residual_plane: &[f32],
+    rows: usize,
+    hidden: usize,
+    ple_width: usize,
+    eps: f32,
+) -> Result<Vec<f32>, String> {
+    if corrected_active.len() != rows * hidden
+        || correct_scale.len() != hidden
+        || per_layer_input.len() != rows * ple_width
+        || gate_weight.len() != ple_width * hidden
+        || projection_weight.len() != hidden * ple_width
+        || norm_weight.len() != hidden
+        || residual_plane.len() != rows * hidden
+    {
+        return Err("PLE injection diagnostic input lengths do not match the shape".to_string());
+    }
+
+    let mut builder = super::builder::Builder::new().with_gemma3n_qmv(true);
+    let active_arg = super::builder::Builder::arg(0, super::builder::Ty::f32(vec![rows, hidden]));
+    let scale_arg = super::builder::Builder::arg(1, super::builder::Ty::f32(vec![hidden]));
+    let ple_arg = super::builder::Builder::arg(2, super::builder::Ty::f32(vec![rows, ple_width]));
+    let gate_arg =
+        super::builder::Builder::arg(3, super::builder::Ty::f32(vec![ple_width, hidden]));
+    let projection_arg =
+        super::builder::Builder::arg(4, super::builder::Ty::f32(vec![hidden, ple_width]));
+    let norm_arg = super::builder::Builder::arg(5, super::builder::Ty::f32(vec![hidden]));
+    let residual_arg = super::builder::Builder::arg(6, super::builder::Ty::f32(vec![rows, hidden]));
+
+    let scale = builder.broadcast(&scale_arg, &[1], vec![rows, hidden]);
+    let scaled_active = builder.multiply(&active_arg, &scale);
+    let scaled_active = super::gemma3n_emit_ops::round_bf16(&mut builder, &scaled_active);
+    let gate = builder.gemma3n_qmv(&scaled_active, &gate_arg);
+    let activated = super::gemma3n_emit_ops::geglu(&mut builder, &gate, &ple_arg);
+    let projected = builder.gemma3n_qmv(&activated, &projection_arg);
+    let eps_value = builder.const_f32(eps);
+    let zero = builder.const_f32(0.0);
+    let injected = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &projected,
+        Some(&norm_arg),
+        &eps_value,
+        &zero,
+    );
+    let updated = builder.add(&residual_arg, &injected);
+    let updated = super::gemma3n_emit_ops::round_bf16(&mut builder, &updated);
+    let outputs = vec![scaled_active, gate, activated, projected, injected, updated];
+    let output = flatten_and_concatenate(&mut builder, &outputs);
+    let mlir = format!(
+        "{target}module @gemma3n_ple_injection_probe {{\n{source}  \
+         func.func public @main(%arg0: {active_ty}, %arg1: {scale_ty}, \
+         %arg2: {ple_ty}, %arg3: {gate_ty}, %arg4: {projection_ty}, \
+         %arg5: {norm_ty}, %arg6: {residual_ty}) -> {result_ty} {{\n\
+         {body}    return {result} : {result_ty}\n  }}\n}}\n",
+        target = target_alias(),
+        source = executable_source(),
+        active_ty = active_arg.ty.render(),
+        scale_ty = scale_arg.ty.render(),
+        ple_ty = ple_arg.ty.render(),
+        gate_ty = gate_arg.ty.render(),
+        projection_ty = projection_arg.ty.render(),
+        norm_ty = norm_arg.ty.render(),
+        residual_ty = residual_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    let output_len = rows * (hidden * 4 + ple_width * 2);
+    run_cuda_stablehlo_probe(
+        "ple-injection-stages",
+        mlir,
+        &[
+            (corrected_active, &[rows, hidden]),
+            (correct_scale, &[hidden]),
+            (per_layer_input, &[rows, ple_width]),
+            (gate_weight, &[ple_width, hidden]),
+            (projection_weight, &[hidden, ple_width]),
+            (norm_weight, &[hidden]),
+            (residual_plane, &[rows, hidden]),
+        ],
+        output_len,
+    )
+}
+
+/// Isolate the PLE injection and every non-active AltUp residual update using
+/// exact MLX carriers from one logical layer.
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+#[allow(clippy::too_many_arguments)]
+pub fn run_ple_injection_all_planes_diagnostic_probe(
+    corrected_active: &[f32],
+    correct_scale: &[f32],
+    per_layer_input: &[f32],
+    gate_weight: &[f32],
+    projection_weight: &[f32],
+    norm_weight: &[f32],
+    residual_planes: &[f32],
+    rows: usize,
+    hidden: usize,
+    ple_width: usize,
+    non_active_planes: usize,
+    eps: f32,
+) -> Result<Vec<f32>, String> {
+    if non_active_planes == 0
+        || corrected_active.len() != rows * hidden
+        || correct_scale.len() != hidden
+        || per_layer_input.len() != rows * ple_width
+        || gate_weight.len() != ple_width * hidden
+        || projection_weight.len() != hidden * ple_width
+        || norm_weight.len() != hidden
+        || residual_planes.len() != non_active_planes * rows * hidden
+    {
+        return Err("all-plane PLE diagnostic inputs do not match the shape".to_string());
+    }
+
+    let mut builder = super::builder::Builder::new().with_gemma3n_qmv(true);
+    let active_arg = super::builder::Builder::arg(0, super::builder::Ty::f32(vec![rows, hidden]));
+    let scale_arg = super::builder::Builder::arg(1, super::builder::Ty::f32(vec![hidden]));
+    let ple_arg = super::builder::Builder::arg(2, super::builder::Ty::f32(vec![rows, ple_width]));
+    let gate_arg =
+        super::builder::Builder::arg(3, super::builder::Ty::f32(vec![ple_width, hidden]));
+    let projection_arg =
+        super::builder::Builder::arg(4, super::builder::Ty::f32(vec![hidden, ple_width]));
+    let norm_arg = super::builder::Builder::arg(5, super::builder::Ty::f32(vec![hidden]));
+    let residual_arg = super::builder::Builder::arg(
+        6,
+        super::builder::Ty::f32(vec![non_active_planes, rows, hidden]),
+    );
+
+    let scale = builder.broadcast(&scale_arg, &[1], vec![rows, hidden]);
+    let scaled_active = builder.multiply(&active_arg, &scale);
+    let scaled_active = super::gemma3n_emit_ops::round_bf16(&mut builder, &scaled_active);
+    let gate = builder.gemma3n_qmv(&scaled_active, &gate_arg);
+    let activated = super::gemma3n_emit_ops::geglu(&mut builder, &gate, &ple_arg);
+    let projected = builder.gemma3n_qmv(&activated, &projection_arg);
+    let eps_value = builder.const_f32(eps);
+    let zero = builder.const_f32(0.0);
+    let injected = super::gemma3n_emit_ops::rms_last_bf16(
+        &mut builder,
+        &projected,
+        Some(&norm_arg),
+        &eps_value,
+        &zero,
+    );
+    let injected_planes =
+        builder.broadcast(&injected, &[1, 2], vec![non_active_planes, rows, hidden]);
+    let residual_sums = builder.add(&residual_arg, &injected_planes);
+    let residuals_updated = super::gemma3n_emit_ops::round_bf16(&mut builder, &residual_sums);
+    let outputs = vec![
+        scaled_active,
+        gate,
+        activated,
+        projected,
+        injected,
+        residual_arg.clone(),
+        residual_sums,
+        residuals_updated,
+    ];
+    let output = flatten_and_concatenate(&mut builder, &outputs);
+    let mlir = format!(
+        "{target}module @gemma3n_ple_injection_all_planes_probe {{\n{source}  \
+         func.func public @main(%arg0: {active_ty}, %arg1: {scale_ty}, \
+         %arg2: {ple_ty}, %arg3: {gate_ty}, %arg4: {projection_ty}, \
+         %arg5: {norm_ty}, %arg6: {residual_ty}) -> {result_ty} {{\n\
+         {body}    return {result} : {result_ty}\n  }}\n}}\n",
+        target = target_alias(),
+        source = executable_source(),
+        active_ty = active_arg.ty.render(),
+        scale_ty = scale_arg.ty.render(),
+        ple_ty = ple_arg.ty.render(),
+        gate_ty = gate_arg.ty.render(),
+        projection_ty = projection_arg.ty.render(),
+        norm_ty = norm_arg.ty.render(),
+        residual_ty = residual_arg.ty.render(),
+        result_ty = output.ty.render(),
+        body = builder.body(),
+        result = output.name,
+    );
+    let output_len = rows * (hidden * 3 + ple_width * 2) + non_active_planes * rows * hidden * 3;
+    run_cuda_stablehlo_probe(
+        "ple-injection-all-planes-stages",
+        mlir,
+        &[
+            (corrected_active, &[rows, hidden]),
+            (correct_scale, &[hidden]),
+            (per_layer_input, &[rows, ple_width]),
+            (gate_weight, &[ple_width, hidden]),
+            (projection_weight, &[hidden, ple_width]),
+            (norm_weight, &[hidden]),
+            (residual_planes, &[non_active_planes, rows, hidden]),
+        ],
+        output_len,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(xla_iree_cuda)]
+    use crate::emitter::builder::Builder;
+    use crate::weights::round_bf16_f32;
+    #[cfg(xla_iree_cuda)]
+    use std::path::PathBuf;
+    #[cfg(xla_iree_cuda)]
+    use std::process::Command;
+
+    fn reference_qmv(input: &[f32], weight: &[f32], m: usize, n: usize, k: usize) -> Vec<f32> {
+        assert_eq!(input.len(), m * k);
+        assert_eq!(weight.len(), n * k);
+        let mut output = vec![0.0; m * n];
+        for row in 0..m {
+            for output_row in 0..n {
+                let mut lane_sums = [0.0f32; 32];
+                for (lane, lane_sum) in lane_sums.iter_mut().enumerate() {
+                    let mut slots = [0.0f32; 16];
+                    for round in 0..k.div_ceil(512) {
+                        for (i, slot) in slots.iter_mut().enumerate() {
+                            let column = lane * 16 + i + round * 512;
+                            if column < k {
+                                let lhs = round_bf16_f32(input[row * k + column]);
+                                let rhs = round_bf16_f32(weight[output_row * k + column]);
+                                *slot = round_bf16_f32(lhs.mul_add(rhs, *slot));
+                            }
+                        }
+                    }
+                    let mut sum = 0.0f32;
+                    for slot in slots {
+                        sum += slot;
+                    }
+                    *lane_sum = sum;
+                }
+                for mask in [16, 8, 4, 2, 1] {
+                    let previous = lane_sums;
+                    for lane in 0..32 {
+                        lane_sums[lane] += previous[lane ^ mask];
+                    }
+                }
+                output[row * n + output_row] = round_bf16_f32(lane_sums[0]);
+            }
+        }
+        output
+    }
+
+    fn synthetic_q4_carriers(m: usize, n: usize, k: usize) -> (Vec<f32>, Vec<f32>) {
+        let input = (0..m * k)
+            .map(|index| {
+                let signed = ((index * 17 + index / 7) % 101) as i32 - 50;
+                round_bf16_f32(signed as f32 * 0.03125)
+            })
+            .collect();
+        let weight = (0..n * k)
+            .map(|index| {
+                let signed = ((index * 29 + index / 11) % 127) as i32 - 63;
+                round_bf16_f32(signed as f32 * 0.015625)
+            })
+            .collect();
+        (input, weight)
+    }
+
+    fn round_tf32_rne_bits(bits: u32) -> u32 {
+        if bits & 0x7f80_0000 == 0x7f80_0000 {
+            return bits;
+        }
+        let retained_lsb = (bits >> 13) & 1;
+        bits.wrapping_add(0x0fff + retained_lsb) & 0xffff_e000
+    }
+
+    #[cfg(xla_iree_cuda)]
+    fn probe_mlir(m: usize, n: usize, k: usize) -> String {
+        let mut builder = Builder::new().with_gemma3n_qmv(true);
+        let input = Builder::arg(0, crate::emitter::builder::Ty::f32(vec![m, k]));
+        let weight = Builder::arg(1, crate::emitter::builder::Ty::f32(vec![n, k]));
+        let output = builder.gemma3n_qmv(&input, &weight);
+        format!(
+            "{target}module @gemma3n_qmv_probe {{\n{source}  \
+             func.func public @main(%arg0: {input_ty}, %arg1: {weight_ty}) -> {result_ty} \
+             {{\n{body}    \
+             return {result} : {result_ty}\n  }}\n}}\n",
+            target = target_alias(),
+            source = executable_source(),
+            input_ty = input.ty.render(),
+            weight_ty = weight.ty.render(),
+            result_ty = output.ty.render(),
+            body = builder.body(),
+            result = output.name,
+        )
+    }
+
+    #[cfg(xla_iree_cuda)]
+    fn sdpa_dynamic_position_probe_mlir() -> String {
+        const CAPACITY: usize = 8;
+        const QUERY_HEADS: usize = 8;
+        const KV_HEADS: usize = 2;
+        const HEAD_DIM: usize = 256;
+        let mut builder = Builder::new().with_gemma3n_qmv(true);
+        let query = Builder::arg(
+            0,
+            crate::emitter::builder::Ty::f32(vec![QUERY_HEADS, HEAD_DIM]),
+        );
+        let keys = Builder::arg(
+            1,
+            crate::emitter::builder::Ty::f32(vec![CAPACITY, KV_HEADS, HEAD_DIM]),
+        );
+        let values = Builder::arg(
+            2,
+            crate::emitter::builder::Ty::f32(vec![CAPACITY, KV_HEADS, HEAD_DIM]),
+        );
+        let position = Builder::arg(3, crate::emitter::builder::Ty::scalar("i32"));
+        let output = builder.gemma3n_sdpa_vector(&query, &keys, &values, &position, None, 1.0);
+        format!(
+            "{target}module @gemma3n_sdpa_dynamic_position_probe {{\n{source}  \
+             func.func public @main(%arg0: {query_ty}, %arg1: {keys_ty}, \
+             %arg2: {values_ty}, %arg3: tensor<i32>) -> {result_ty} {{\n{body}    \
+             return {result} : {result_ty}\n  }}\n}}\n",
+            target = target_alias(),
+            source = executable_source(),
+            query_ty = query.ty.render(),
+            keys_ty = keys.ty.render(),
+            values_ty = values.ty.render(),
+            result_ty = output.ty.render(),
+            body = builder.body(),
+            result = output.name,
+        )
+    }
+
+    #[cfg(xla_iree_cuda)]
+    fn required_path(env_name: &str, fallback: impl FnOnce() -> Option<PathBuf>) -> PathBuf {
+        std::env::var_os(env_name)
+            .map(PathBuf::from)
+            .or_else(fallback)
+            .unwrap_or_else(|| panic!("set {env_name} for the CUDA QMV parity test"))
+    }
+
+    #[test]
+    fn metadata_identity_pins_numerical_abi() {
+        let identity = artifact_identity();
+        assert!(identity.contains("kernel-v8"));
+        assert!(identity.contains("abi-v6"));
+        assert!(identity.contains("min-sm80"));
+        assert!(identity.contains("ptx-fnv1a64="));
+    }
+
+    #[cfg(feature = "diagnostics")]
+    #[test]
+    fn sdpa_production_abi_passes_dynamic_position_and_exact_scale_bits() {
+        let mut builder = Builder::new().with_gemma3n_qmv(true);
+        let query = Builder::arg(0, crate::emitter::builder::Ty::f32(vec![8, 256]));
+        let keys = Builder::arg(1, crate::emitter::builder::Ty::f32(vec![8, 2, 256]));
+        let values = Builder::arg(2, crate::emitter::builder::Ty::f32(vec![8, 2, 256]));
+        let position = Builder::arg(3, crate::emitter::builder::Ty::scalar("i32"));
+        let _ = builder.gemma3n_sdpa_vector(&query, &keys, &values, &position, Some(512), 1.0);
+        let body = builder.body();
+        assert!(body.contains("arith.constant 1065353216 : i32"));
+        assert!(body.contains("(i32, i32, i32, i32, i32, i32,"));
+        assert!(body.contains("tensor.extract %arg3[] : tensor<i32>"));
+        assert!(!body.contains("arith.constant 1.000000000 : f32"));
+        let source = executable_source();
+        assert!(source.contains("@gemma3n_sdpa_vector ordinal(5)"));
+        assert!(source.contains("#hal.pipeline.layout<constants = 6"));
+
+        let invalid_gqa = std::panic::catch_unwind(|| {
+            let mut builder = Builder::new().with_gemma3n_qmv(true);
+            let query = Builder::arg(0, crate::emitter::builder::Ty::f32(vec![3, 256]));
+            let keys = Builder::arg(1, crate::emitter::builder::Ty::f32(vec![8, 2, 256]));
+            let values = Builder::arg(2, crate::emitter::builder::Ty::f32(vec![8, 2, 256]));
+            let position = Builder::arg(3, crate::emitter::builder::Ty::scalar("i32"));
+            builder.gemma3n_sdpa_vector(&query, &keys, &values, &position, None, 1.0)
+        });
+        assert!(invalid_gqa.is_err());
+
+        let invalid_dimension = std::panic::catch_unwind(|| {
+            let mut builder = Builder::new().with_gemma3n_qmv(true);
+            let query = Builder::arg(0, crate::emitter::builder::Ty::f32(vec![8, 128]));
+            let keys = Builder::arg(1, crate::emitter::builder::Ty::f32(vec![8, 2, 128]));
+            let values = Builder::arg(2, crate::emitter::builder::Ty::f32(vec![8, 2, 128]));
+            let position = Builder::arg(3, crate::emitter::builder::Ty::scalar("i32"));
+            builder.gemma3n_sdpa_vector(&query, &keys, &values, &position, None, 1.0)
+        });
+        assert!(invalid_dimension.is_err());
+
+        let invalid_capacity = std::panic::catch_unwind(|| {
+            let mut builder = Builder::new().with_gemma3n_qmv(true);
+            let query = Builder::arg(0, crate::emitter::builder::Ty::f32(vec![8, 256]));
+            let keys = Builder::arg(1, crate::emitter::builder::Ty::f32(vec![1025, 2, 256]));
+            let values = Builder::arg(2, crate::emitter::builder::Ty::f32(vec![1025, 2, 256]));
+            let position = Builder::arg(3, crate::emitter::builder::Ty::scalar("i32"));
+            builder.gemma3n_sdpa_vector(&query, &keys, &values, &position, None, 1.0)
+        });
+        assert!(invalid_capacity.is_err());
+
+        let invalid_window = std::panic::catch_unwind(|| {
+            let mut builder = Builder::new().with_gemma3n_qmv(true);
+            let query = Builder::arg(0, crate::emitter::builder::Ty::f32(vec![8, 256]));
+            let keys = Builder::arg(1, crate::emitter::builder::Ty::f32(vec![64, 2, 256]));
+            let values = Builder::arg(2, crate::emitter::builder::Ty::f32(vec![64, 2, 256]));
+            let position = Builder::arg(3, crate::emitter::builder::Ty::scalar("i32"));
+            builder.gemma3n_sdpa_vector(&query, &keys, &values, &position, Some(8), 1.0)
+        });
+        assert!(invalid_window.is_err());
+
+        let cuda = include_str!("../../csrc/gemma3n_qmv.cu");
+        assert!(cuda.contains("live > 1024"));
+        assert!(cuda.contains("query_heads % kv_heads != 0"));
+        assert!(cuda.contains("window != 0 && window < live"));
+    }
+
+    #[cfg(xla_iree_cuda)]
+    #[test]
+    #[ignore = "requires the pinned CUDA-capable IREE compiler"]
+    fn sdpa_dynamic_tensor_position_compiles_to_scalar_push_constant() {
+        let compiler = required_path("MLXCEL_XLA_IREE_COMPILE", || {
+            option_env!("MLXCEL_XLA_IREE_COMPILE").map(PathBuf::from)
+        });
+        let stem = format!("mlxcel-gemma3n-sdpa-position-{}", std::process::id());
+        let mlir_path = std::env::temp_dir().join(format!("{stem}.mlir"));
+        let vmfb_path = std::env::temp_dir().join(format!("{stem}.vmfb"));
+        std::fs::write(&mlir_path, sdpa_dynamic_position_probe_mlir()).unwrap();
+        let compiled = Command::new(&compiler)
+            .arg("--iree-input-type=stablehlo")
+            .arg("--iree-hal-target-device=cuda")
+            .arg("--iree-cuda-target=sm_80")
+            .arg(&mlir_path)
+            .arg("-o")
+            .arg(&vmfb_path)
+            .output()
+            .unwrap();
+        let _ = std::fs::remove_file(&mlir_path);
+        let _ = std::fs::remove_file(&vmfb_path);
+        assert!(
+            compiled.status.success(),
+            "dynamic-position SDPA failed typed IREE compile:\n{}",
+            String::from_utf8_lossy(&compiled.stderr)
+        );
+    }
+
+    #[test]
+    fn tf32_halfway_rounds_to_nearest_even() {
+        const HALFWAY_EVEN: u32 = 0xbe5d_5000;
+        assert_eq!(round_tf32_rne_bits(HALFWAY_EVEN), 0xbe5d_4000);
+        assert_ne!(
+            round_tf32_rne_bits(HALFWAY_EVEN),
+            HALFWAY_EVEN.wrapping_add(0x1000) & 0xffff_e000,
+        );
+    }
+
+    #[test]
+    fn native_altup_source_pins_rne_and_tensor_core_schedule() {
+        let source = include_str!("../../csrc/gemma3n_qmv.cu");
+        assert!(source.contains("float gemma3n_to_tf32_rne(float value)"));
+        assert!(source.contains("0x0FFFu + retained_lsb"));
+        assert!(!source.contains("cvt.rna.tf32.f32 converted"));
+        assert_eq!(
+            source
+                .matches("mma.sync.aligned.m16n8k4.row.col.f32.tf32.tf32.f32")
+                .count(),
+            1,
+        );
+        assert!(!source.contains("void gemma3n_altup_predict_mma("));
+    }
+
+    #[cfg(xla_iree_cuda)]
+    #[test]
+    fn native_altup_ptx_has_one_mma_and_no_scalar_reduction() {
+        let ptx = std::str::from_utf8(ptx()).expect("nvcc PTX is UTF-8 text");
+        let entry = ptx
+            .find(".visible .entry gemma3n_altup_predict(")
+            .expect("production AltUp prediction entry");
+        let tail = &ptx[entry..];
+        let end = tail[1..]
+            .find(".visible .entry ")
+            .map_or(tail.len(), |offset| offset + 1);
+        let body = &tail[..end];
+        assert_eq!(
+            body.matches("mma.sync.aligned.m16n8k4.row.col.f32.tf32.tf32.f32")
+                .count(),
+            1,
+        );
+        assert!(!body.contains("fma.rn.f32"));
+        assert!(!body.contains("fma.rn.ftz.f32"));
+
+        let source = executable_source();
+        assert!(source.contains("(s0 ceildiv 16)>()[%hidden]"));
+        assert!(source.contains("hal.return %x, %rows, %c1"));
+        assert!(source.contains("workgroup_size = [32 : index, 1 : index, 1 : index]"));
+    }
+
+    #[test]
+    fn native_geglu_pins_mlx_bf16_fma_boundary() {
+        let source = include_str!("../../csrc/gemma3n_qmv.cu");
+        assert!(source.contains("void gemma3n_geglu_bf16("));
+        assert!(source.contains("__hfma(x3, cubic, x)"));
+    }
+
+    #[test]
+    fn synthetic_q4_group64_schedule_has_pinned_output_bits() {
+        const M: usize = 2;
+        const N: usize = 9;
+        const K: usize = 576;
+        let (input, weight) = synthetic_q4_carriers(M, N, K);
+        let bits = reference_qmv(&input, &weight, M, N, K)
+            .into_iter()
+            .map(f32::to_bits)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            bits,
+            vec![
+                3238133760, 3231449088, 3234856960, 1080819712, 1086062592, 1082785792, 1083703296,
+                1079902208, 1082916864, 3238920192, 3212836864, 3239378944, 3207856128, 3231121408,
+                1077936128, 3225681920, 1090650112, 1066139648,
+            ]
+        );
+    }
+
+    #[cfg(xla_iree_cuda)]
+    #[test]
+    #[ignore = "requires pinned IREE compiler/runtime plus a CUDA device"]
+    fn actual_cuda_dispatch_matches_q4_group64_reference_bit_exactly() {
+        const M: usize = 2;
+        const N: usize = 9;
+        const K: usize = 576;
+        let (input, weight) = synthetic_q4_carriers(M, N, K);
+        let expected = reference_qmv(&input, &weight, M, N, K);
+        let mlir = probe_mlir(M, N, K);
+
+        let compiler = required_path("MLXCEL_XLA_IREE_COMPILE", || {
+            option_env!("MLXCEL_XLA_IREE_COMPILE").map(PathBuf::from)
+        });
+        let runner = required_path("MLXCEL_XLA_IREE_RUN_MODULE", || {
+            std::env::var_os("IREE_CUDA_HOME").map(|home| {
+                PathBuf::from(home)
+                    .join("build")
+                    .join("tools")
+                    .join("iree-run-module")
+            })
+        });
+        assert!(compiler.is_file(), "missing {}", compiler.display());
+        assert!(runner.is_file(), "missing {}", runner.display());
+
+        let stem = format!("mlxcel-gemma3n-qmv-probe-{}", std::process::id());
+        let mlir_path = std::env::temp_dir().join(format!("{stem}.mlir"));
+        let vmfb_path = std::env::temp_dir().join(format!("{stem}.vmfb"));
+        let input_path = std::env::temp_dir().join(format!("{stem}-input.bin"));
+        let weight_path = std::env::temp_dir().join(format!("{stem}-weight.bin"));
+        let output_path = std::env::temp_dir().join(format!("{stem}.bin"));
+        std::fs::write(&mlir_path, mlir).unwrap();
+        std::fs::write(
+            &input_path,
+            input
+                .iter()
+                .flat_map(|value| value.to_le_bytes())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        std::fs::write(
+            &weight_path,
+            weight
+                .iter()
+                .flat_map(|value| value.to_le_bytes())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        let compile = Command::new(&compiler)
+            .arg("--iree-input-type=stablehlo")
+            .arg("--iree-hal-target-device=cuda")
+            .arg("--iree-cuda-target=sm_80")
+            .arg(&mlir_path)
+            .arg("-o")
+            .arg(&vmfb_path)
+            .output()
+            .unwrap();
+        assert!(
+            compile.status.success(),
+            "iree-compile failed:\n{}",
+            String::from_utf8_lossy(&compile.stderr)
+        );
+        let run = Command::new(&runner)
+            .arg("--device=cuda")
+            .arg(format!("--module={}", vmfb_path.display()))
+            .arg("--function=main")
+            .arg(format!("--input={M}x{K}xf32=@{}", input_path.display()))
+            .arg(format!("--input={N}x{K}xf32=@{}", weight_path.display()))
+            .arg(format!("--output=@{}", output_path.display()))
+            .output()
+            .unwrap();
+        assert!(
+            run.status.success(),
+            "iree-run-module failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&run.stdout),
+            String::from_utf8_lossy(&run.stderr),
+        );
+        let bytes = std::fs::read(&output_path).unwrap();
+        assert_eq!(bytes.len(), expected.len() * std::mem::size_of::<f32>());
+        let actual = bytes
+            .chunks_exact(4)
+            .map(|bytes| f32::from_le_bytes(bytes.try_into().unwrap()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            expected
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>()
+        );
+
+        for path in [mlir_path, vmfb_path, input_path, weight_path, output_path] {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+    #[test]
+    #[ignore = "requires pinned IREE compiler/runtime plus a CUDA device"]
+    fn actual_cuda_altup_coeff_rounds_tf32_halfway_to_even() {
+        let input = [f32::from_bits(0xbe5d_5000)];
+        let weight = [1.0f32];
+        let mut builder = Builder::new().with_gemma3n_qmv(true);
+        let input_arg = Builder::arg(0, crate::emitter::builder::Ty::f32(vec![1, 1]));
+        let weight_arg = Builder::arg(1, crate::emitter::builder::Ty::f32(vec![1, 1]));
+        let output = builder.gemma3n_altup_coeff(&input_arg, &weight_arg);
+        let mlir = format!(
+            "{target}module @gemma3n_altup_coeff_rne_probe {{\n{source}  \
+             func.func public @main(%arg0: {input_ty}, %arg1: {weight_ty}) -> {result_ty} \
+             {{\n{body}    return {result} : {result_ty}\n  }}\n}}\n",
+            target = target_alias(),
+            source = executable_source(),
+            input_ty = input_arg.ty.render(),
+            weight_ty = weight_arg.ty.render(),
+            result_ty = output.ty.render(),
+            body = builder.body(),
+            result = output.name,
+        );
+        let actual = run_cuda_stablehlo_probe(
+            "altup-coeff-rne-halfway",
+            mlir,
+            &[(&input, &[1, 1]), (&weight, &[1, 1])],
+            1,
+        )
+        .unwrap();
+        assert_eq!(actual[0].to_bits(), 0xbe5d_4000);
+    }
+}

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_schema.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_schema.rs
@@ -53,6 +53,7 @@ pub(super) fn build_schema(
     prepared: bool,
     rows: usize,
     scalar_inputs: bool,
+    vector_real_len: bool,
 ) -> (Vec<Decl>, Args) {
     let mut decls = Vec::new();
     let mut index = 0;
@@ -322,7 +323,16 @@ pub(super) fn build_schema(
         },
         "positions",
     );
-    let real_len = take(&mut decls, &mut index, Ty::scalar("i32"), "real_len");
+    let real_len = take(
+        &mut decls,
+        &mut index,
+        if vector_real_len {
+            Ty::new(vec![rows], "i32")
+        } else {
+            Ty::scalar("i32")
+        },
+        "real_len",
+    );
     let attention_bias = prepared.then(|| {
         take(
             &mut decls,

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_schema.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_schema.rs
@@ -1,0 +1,357 @@
+//! Stable Gemma3n graph argument schema shared by prefill and decode.
+
+use super::builder::{Builder, Ty, Val};
+use super::gemma3n::Gemma3nConfig;
+use super::gemma3n_emit_ops::LayerWeights;
+
+pub(super) struct Decl {
+    pub ty: Ty,
+    pub loc: String,
+}
+
+pub(super) struct Weights {
+    pub embed: Val,
+    pub token_ple: Val,
+    pub ple_projection: Val,
+    pub ple_projection_norm: Val,
+    pub final_norm: Val,
+    pub initial_projections: Vec<Val>,
+    pub unembed_projections: Vec<Val>,
+    pub layers: Vec<LayerWeights>,
+}
+
+pub(super) enum Input {
+    Tokens(Val),
+    Prepared { embeddings: Val, dense_ple: Val },
+}
+
+pub(super) struct Args {
+    pub weights: Weights,
+    pub input: Input,
+    pub positions: Val,
+    pub real_len: Val,
+    pub attention_bias: Option<Val>,
+}
+
+pub(super) fn take(
+    decls: &mut Vec<Decl>,
+    index: &mut usize,
+    ty: Ty,
+    loc: impl Into<String>,
+) -> Val {
+    let value = Builder::arg(*index, ty.clone());
+    decls.push(Decl {
+        ty,
+        loc: loc.into(),
+    });
+    *index += 1;
+    value
+}
+
+pub(super) fn build_schema(
+    c: &Gemma3nConfig,
+    prepared: bool,
+    rows: usize,
+    scalar_inputs: bool,
+) -> (Vec<Decl>, Args) {
+    let mut decls = Vec::new();
+    let mut index = 0;
+    let root = "model.language_model";
+    let h = c.hidden;
+    let ple_width = c.n_layers * c.hidden_per_layer_input;
+    let projection =
+        |decls: &mut Vec<Decl>, index: &mut usize, out: usize, in_: usize, name: String| {
+            take(decls, index, Ty::f32(vec![out, in_]), name)
+        };
+    let embed = projection(
+        &mut decls,
+        &mut index,
+        c.vocab,
+        h,
+        format!("{root}.embed_tokens.weight"),
+    );
+    let token_ple = projection(
+        &mut decls,
+        &mut index,
+        c.per_layer_vocab,
+        ple_width,
+        format!("{root}.embed_tokens_per_layer.weight"),
+    );
+    let ple_projection = projection(
+        &mut decls,
+        &mut index,
+        ple_width,
+        h,
+        format!("{root}.per_layer_model_projection.weight"),
+    );
+    let ple_projection_norm = take(
+        &mut decls,
+        &mut index,
+        Ty::f32(vec![c.hidden_per_layer_input]),
+        format!("{root}.per_layer_projection_norm.weight"),
+    );
+    let final_norm = take(
+        &mut decls,
+        &mut index,
+        Ty::f32(vec![h]),
+        format!("{root}.norm.weight"),
+    );
+    let initial_projections = (0..c.altup_num_inputs - 1)
+        .map(|plane| {
+            projection(
+                &mut decls,
+                &mut index,
+                h,
+                h,
+                format!("{root}.altup_projections.{plane}.weight"),
+            )
+        })
+        .collect();
+    let unembed_projections = (0..c.altup_num_inputs - 1)
+        .map(|plane| {
+            projection(
+                &mut decls,
+                &mut index,
+                h,
+                h,
+                format!("{root}.altup_unembed_projections.{plane}.weight"),
+            )
+        })
+        .collect();
+    let mut layers = Vec::with_capacity(c.n_layers);
+    for layer in 0..c.n_layers {
+        let p = format!("{root}.layers.{layer}");
+        let concrete = layer < c.kv_cache_layers();
+        layers.push(LayerWeights {
+            correct_scale: take(
+                &mut decls,
+                &mut index,
+                Ty::f32(vec![h]),
+                format!("{p}.altup.correct_output_scale"),
+            ),
+            correction: take(
+                &mut decls,
+                &mut index,
+                Ty::f32(vec![c.altup_num_inputs, c.altup_num_inputs]),
+                format!("{p}.altup.correction_coefs.weight"),
+            ),
+            router: projection(
+                &mut decls,
+                &mut index,
+                c.altup_num_inputs,
+                h,
+                format!("{p}.altup.modality_router.weight"),
+            ),
+            router_norm: take(
+                &mut decls,
+                &mut index,
+                Ty::f32(vec![h]),
+                format!("{p}.altup.router_norm.weight"),
+            ),
+            prediction: take(
+                &mut decls,
+                &mut index,
+                Ty::f32(vec![
+                    c.altup_num_inputs * c.altup_num_inputs,
+                    c.altup_num_inputs,
+                ]),
+                format!("{p}.altup.prediction_coefs.weight"),
+            ),
+            laurel_left: projection(
+                &mut decls,
+                &mut index,
+                c.laurel_rank,
+                h,
+                format!("{p}.laurel.linear_left.weight"),
+            ),
+            laurel_right: projection(
+                &mut decls,
+                &mut index,
+                h,
+                c.laurel_rank,
+                format!("{p}.laurel.linear_right.weight"),
+            ),
+            laurel_norm: take(
+                &mut decls,
+                &mut index,
+                Ty::f32(vec![h]),
+                format!("{p}.laurel.post_laurel_norm.weight"),
+            ),
+            input_norm: norm(
+                &mut decls,
+                &mut index,
+                h,
+                format!("{p}.input_layernorm.weight"),
+            ),
+            post_attn_norm: norm(
+                &mut decls,
+                &mut index,
+                h,
+                format!("{p}.post_attention_layernorm.weight"),
+            ),
+            pre_ff_norm: norm(
+                &mut decls,
+                &mut index,
+                h,
+                format!("{p}.pre_feedforward_layernorm.weight"),
+            ),
+            post_ff_norm: norm(
+                &mut decls,
+                &mut index,
+                h,
+                format!("{p}.post_feedforward_layernorm.weight"),
+            ),
+            wq: projection(
+                &mut decls,
+                &mut index,
+                c.n_q * c.head_dim,
+                h,
+                format!("{p}.self_attn.q_proj.weight"),
+            ),
+            wk: concrete.then(|| {
+                projection(
+                    &mut decls,
+                    &mut index,
+                    c.n_kv * c.head_dim,
+                    h,
+                    format!("{p}.self_attn.k_proj.weight"),
+                )
+            }),
+            wv: concrete.then(|| {
+                projection(
+                    &mut decls,
+                    &mut index,
+                    c.n_kv * c.head_dim,
+                    h,
+                    format!("{p}.self_attn.v_proj.weight"),
+                )
+            }),
+            wo: projection(
+                &mut decls,
+                &mut index,
+                h,
+                c.n_q * c.head_dim,
+                format!("{p}.self_attn.o_proj.weight"),
+            ),
+            q_norm: norm(
+                &mut decls,
+                &mut index,
+                c.head_dim,
+                format!("{p}.self_attn.q_norm.weight"),
+            ),
+            k_norm: concrete.then(|| {
+                norm(
+                    &mut decls,
+                    &mut index,
+                    c.head_dim,
+                    format!("{p}.self_attn.k_norm.weight"),
+                )
+            }),
+            gate: projection(
+                &mut decls,
+                &mut index,
+                c.intermediate[layer],
+                h,
+                format!("{p}.mlp.gate_proj.weight"),
+            ),
+            up: projection(
+                &mut decls,
+                &mut index,
+                c.intermediate[layer],
+                h,
+                format!("{p}.mlp.up_proj.weight"),
+            ),
+            down: projection(
+                &mut decls,
+                &mut index,
+                h,
+                c.intermediate[layer],
+                format!("{p}.mlp.down_proj.weight"),
+            ),
+            ple_gate: projection(
+                &mut decls,
+                &mut index,
+                c.hidden_per_layer_input,
+                h,
+                format!("{p}.per_layer_input_gate.weight"),
+            ),
+            ple_projection: projection(
+                &mut decls,
+                &mut index,
+                h,
+                c.hidden_per_layer_input,
+                format!("{p}.per_layer_projection.weight"),
+            ),
+            ple_norm: norm(
+                &mut decls,
+                &mut index,
+                h,
+                format!("{p}.post_per_layer_input_norm.weight"),
+            ),
+        });
+    }
+    let input = if prepared {
+        Input::Prepared {
+            embeddings: take(&mut decls, &mut index, Ty::f32(vec![rows, h]), "embeddings"),
+            dense_ple: take(
+                &mut decls,
+                &mut index,
+                Ty::f32(vec![rows, c.n_layers, c.hidden_per_layer_input]),
+                "dense_ple",
+            ),
+        }
+    } else {
+        Input::Tokens(take(
+            &mut decls,
+            &mut index,
+            if scalar_inputs {
+                Ty::scalar("i32")
+            } else {
+                Ty::new(vec![rows], "i32")
+            },
+            "tokens",
+        ))
+    };
+    let positions = take(
+        &mut decls,
+        &mut index,
+        if scalar_inputs {
+            Ty::scalar("i32")
+        } else {
+            Ty::new(vec![rows], "i32")
+        },
+        "positions",
+    );
+    let real_len = take(&mut decls, &mut index, Ty::scalar("i32"), "real_len");
+    let attention_bias = prepared.then(|| {
+        take(
+            &mut decls,
+            &mut index,
+            Ty::f32(vec![rows, rows]),
+            "attention_bias",
+        )
+    });
+    (
+        decls,
+        Args {
+            weights: Weights {
+                embed,
+                token_ple,
+                ple_projection,
+                ple_projection_norm,
+                final_norm,
+                initial_projections,
+                unembed_projections,
+                layers,
+            },
+            input,
+            positions,
+            real_len,
+            attention_bias,
+        },
+    )
+}
+
+fn norm(decls: &mut Vec<Decl>, index: &mut usize, width: usize, name: String) -> Val {
+    take(decls, index, Ty::f32(vec![width]), name)
+}

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_weights.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_weights.rs
@@ -94,6 +94,7 @@ mod tests {
     fn cfg() -> Gemma3nConfig {
         Gemma3nConfig {
             context_capacity: 8,
+            max_position_embeddings: 4096,
             hidden: 8,
             intermediate: vec![16; 4],
             n_layers: 4,
@@ -114,11 +115,11 @@ mod tests {
             sliding_window: 4,
             rope_theta: 1e6,
             rope_local_base: 1e4,
-            final_logit_softcap: 30.0,
+            final_logit_softcap: Some(30.0),
             num_kv_shared_layers: 2,
             altup_num_inputs: 4,
             altup_active_idx: 0,
-            altup_coef_clip: 120.0,
+            altup_coef_clip: Some(120.0),
             altup_correct_scale: true,
             laurel_rank: 2,
             tie_word_embeddings: true,

--- a/src/lib/mlxcel-xla/src/emitter/gemma3n_weights.rs
+++ b/src/lib/mlxcel-xla/src/emitter/gemma3n_weights.rs
@@ -1,0 +1,190 @@
+//! Gemma3n checkpoint tensors in a deterministic graph-argument order.
+
+use super::gemma3n::Gemma3nConfig;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Gemma3nWeightSpec {
+    Tensor(String),
+    Projection(String),
+}
+
+impl Gemma3nWeightSpec {
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            Self::Tensor(name) | Self::Projection(name) => name,
+        }
+    }
+}
+
+fn tensor(out: &mut Vec<Gemma3nWeightSpec>, name: impl Into<String>) {
+    out.push(Gemma3nWeightSpec::Tensor(name.into()));
+}
+
+fn projection(out: &mut Vec<Gemma3nWeightSpec>, name: impl Into<String>) {
+    out.push(Gemma3nWeightSpec::Projection(name.into()));
+}
+
+/// Return the exact converted-MLX tensor names consumed by the Gemma3n graph.
+///
+/// Quantized checkpoints retain the same logical order.  The existing loader
+/// resolves a `Projection` as either a dense tensor or the affine
+/// `weight/scales/biases` triple; norms and AltUp coefficient matrices stay
+/// ordinary tensors.
+pub(crate) fn gemma3n_weight_specs(cfg: &Gemma3nConfig) -> Vec<Gemma3nWeightSpec> {
+    // Hugging Face Gemma3n stores the text backbone below
+    // `model.language_model`; unlike the sanitized MLX in-memory map, there is no
+    // extra `.model` component in the safetensors files read by XLA.
+    let root = "model.language_model";
+    let mut out = Vec::new();
+    projection(&mut out, format!("{root}.embed_tokens.weight"));
+    projection(&mut out, format!("{root}.embed_tokens_per_layer.weight"));
+    projection(
+        &mut out,
+        format!("{root}.per_layer_model_projection.weight"),
+    );
+    tensor(&mut out, format!("{root}.per_layer_projection_norm.weight"));
+    tensor(&mut out, format!("{root}.norm.weight"));
+    for plane in 0..cfg.altup_num_inputs - 1 {
+        projection(&mut out, format!("{root}.altup_projections.{plane}.weight"));
+    }
+    for plane in 0..cfg.altup_num_inputs - 1 {
+        projection(
+            &mut out,
+            format!("{root}.altup_unembed_projections.{plane}.weight"),
+        );
+    }
+    for layer in 0..cfg.n_layers {
+        let p = format!("{root}.layers.{layer}");
+        tensor(&mut out, format!("{p}.altup.correct_output_scale"));
+        tensor(&mut out, format!("{p}.altup.correction_coefs.weight"));
+        projection(&mut out, format!("{p}.altup.modality_router.weight"));
+        tensor(&mut out, format!("{p}.altup.router_norm.weight"));
+        tensor(&mut out, format!("{p}.altup.prediction_coefs.weight"));
+        projection(&mut out, format!("{p}.laurel.linear_left.weight"));
+        projection(&mut out, format!("{p}.laurel.linear_right.weight"));
+        tensor(&mut out, format!("{p}.laurel.post_laurel_norm.weight"));
+        tensor(&mut out, format!("{p}.input_layernorm.weight"));
+        tensor(&mut out, format!("{p}.post_attention_layernorm.weight"));
+        tensor(&mut out, format!("{p}.pre_feedforward_layernorm.weight"));
+        tensor(&mut out, format!("{p}.post_feedforward_layernorm.weight"));
+        projection(&mut out, format!("{p}.self_attn.q_proj.weight"));
+        if layer < cfg.kv_cache_layers() {
+            projection(&mut out, format!("{p}.self_attn.k_proj.weight"));
+            projection(&mut out, format!("{p}.self_attn.v_proj.weight"));
+        }
+        projection(&mut out, format!("{p}.self_attn.o_proj.weight"));
+        tensor(&mut out, format!("{p}.self_attn.q_norm.weight"));
+        if layer < cfg.kv_cache_layers() {
+            tensor(&mut out, format!("{p}.self_attn.k_norm.weight"));
+        }
+        projection(&mut out, format!("{p}.mlp.gate_proj.weight"));
+        projection(&mut out, format!("{p}.mlp.up_proj.weight"));
+        projection(&mut out, format!("{p}.mlp.down_proj.weight"));
+        projection(&mut out, format!("{p}.per_layer_input_gate.weight"));
+        projection(&mut out, format!("{p}.per_layer_projection.weight"));
+        tensor(&mut out, format!("{p}.post_per_layer_input_norm.weight"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> Gemma3nConfig {
+        Gemma3nConfig {
+            context_capacity: 8,
+            hidden: 8,
+            intermediate: vec![16; 4],
+            n_layers: 4,
+            n_q: 2,
+            n_kv: 1,
+            head_dim: 4,
+            eps: 1e-6,
+            vocab: 12,
+            per_layer_vocab: 10,
+            hidden_per_layer_input: 2,
+            layer_types: vec![
+                super::super::gemma3n::Gemma3nLayerType::Sliding,
+                super::super::gemma3n::Gemma3nLayerType::Full,
+                super::super::gemma3n::Gemma3nLayerType::Sliding,
+                super::super::gemma3n::Gemma3nLayerType::Full,
+            ],
+            activation_sparsity: vec![0.5, 0.0, 0.0, 0.0],
+            sliding_window: 4,
+            rope_theta: 1e6,
+            rope_local_base: 1e4,
+            final_logit_softcap: 30.0,
+            num_kv_shared_layers: 2,
+            altup_num_inputs: 4,
+            altup_active_idx: 0,
+            altup_coef_clip: 120.0,
+            altup_correct_scale: true,
+            laurel_rank: 2,
+            tie_word_embeddings: true,
+            quantization: None,
+        }
+    }
+
+    #[test]
+    fn shared_layers_do_not_add_physical_kv_projection_arguments() {
+        let specs = gemma3n_weight_specs(&cfg());
+        assert!(
+            specs
+                .iter()
+                .any(|s| s.name().ends_with("layers.1.self_attn.k_proj.weight"))
+        );
+        assert!(
+            !specs
+                .iter()
+                .any(|s| s.name().ends_with("layers.2.self_attn.k_proj.weight"))
+        );
+        assert!(
+            !specs
+                .iter()
+                .any(|s| s.name().ends_with("layers.3.self_attn.v_proj.weight"))
+        );
+        assert!(
+            specs
+                .iter()
+                .any(|s| s.name().ends_with("layers.3.self_attn.q_proj.weight"))
+        );
+    }
+
+    #[test]
+    fn uses_real_hugging_face_gemma3n_tensor_paths() {
+        let specs = gemma3n_weight_specs(&cfg());
+        assert_eq!(specs[0].name(), "model.language_model.embed_tokens.weight");
+        assert!(
+            specs
+                .iter()
+                .any(|s| { s.name() == "model.language_model.layers.0.laurel.linear_left.weight" })
+        );
+        assert!(specs.iter().any(|s| {
+            s.name() == "model.language_model.layers.0.altup.correction_coefs.weight"
+        }));
+    }
+
+    #[test]
+    #[ignore = "requires GEMMA3N_MODEL_DIR pointing at a real local checkpoint"]
+    fn real_checkpoint_config_and_weight_index_cover_the_graph_schema() {
+        let model_dir =
+            std::path::PathBuf::from(std::env::var_os("GEMMA3N_MODEL_DIR").expect("model dir"));
+        let cfg = Gemma3nConfig::from_json(&model_dir).unwrap();
+        let index_path = model_dir.join("model.safetensors.index.json");
+        let index: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&index_path).unwrap()).unwrap();
+        let weights = index["weight_map"].as_object().expect("weight_map object");
+        let missing: Vec<String> = gemma3n_weight_specs(&cfg)
+            .into_iter()
+            .map(|spec| spec.name().to_string())
+            .filter(|name| !weights.contains_key(name))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "graph weights missing from index: {missing:?}"
+        );
+        assert_eq!(cfg.layer_to_cache().unwrap().len(), cfg.n_layers);
+        assert_eq!(cfg.kv_cache_layers(), 20);
+    }
+}

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -52,6 +52,7 @@ mod gemma3n_decode;
 mod gemma3n_emit;
 mod gemma3n_emit_ops;
 mod gemma3n_math;
+mod gemma3n_qmv;
 mod gemma3n_schema;
 mod gemma3n_weights;
 mod model;
@@ -61,15 +62,49 @@ mod rope;
 #[cfg(test)]
 mod context_tests;
 
-pub(crate) use config::{Config, NormStyle, QkNorm, WeightScheme};
+#[allow(unused_imports)]
+pub(crate) use config::{Config, NormStyle, QkNorm, QuantConfig, WeightScheme};
 #[allow(unused_imports)]
 pub(crate) use gemma3n::{
     Gemma3nConfig, Gemma3nLayerType, Gemma3nPleDType, Gemma3nPleMetadata, validate_gemma3n_ple,
 };
 #[allow(unused_imports)]
-pub(crate) use gemma3n_decode::emit_gemma3n_decode;
+pub(crate) use gemma3n_decode::{
+    emit_gemma3n_decode, emit_gemma3n_decode_ragged, emit_gemma3n_decode_ragged_with,
+    emit_gemma3n_decode_ragged_with_qmv, emit_gemma3n_decode_with, emit_gemma3n_decode_with_qmv,
+};
+#[cfg(feature = "diagnostics")]
+pub use gemma3n_emit::{Gemma3nDiagnosticLayout, Gemma3nDiagnosticSegment};
+#[cfg(feature = "diagnostics")]
+pub(crate) use gemma3n_emit::{
+    emit_gemma3n_all_layer_diagnostics_with_qmv, emit_gemma3n_prefill_diagnostics_with_qmv,
+};
 #[allow(unused_imports)]
-pub(crate) use gemma3n_emit::{emit_gemma3n_prefill, emit_gemma3n_prefill_embeddings_ple};
+pub(crate) use gemma3n_emit::{
+    emit_gemma3n_prefill, emit_gemma3n_prefill_embeddings_ple,
+    emit_gemma3n_prefill_embeddings_ple_with, emit_gemma3n_prefill_embeddings_ple_with_qmv,
+    emit_gemma3n_prefill_with, emit_gemma3n_prefill_with_qmv,
+};
+#[allow(unused_imports)]
+pub(crate) use gemma3n_qmv::{
+    artifact_identity as gemma3n_qmv_artifact_identity, is_available as gemma3n_qmv_is_available,
+};
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub use gemma3n_qmv::{
+    run_altup_correct_diagnostic_probe as run_gemma3n_altup_correct_diagnostic_probe,
+    run_altup_predict_diagnostic_probe as run_gemma3n_altup_predict_diagnostic_probe,
+    run_attention_diagnostic_probe as run_gemma3n_attention_diagnostic_probe,
+    run_decode_attention_diagnostic_probe as run_gemma3n_decode_attention_diagnostic_probe,
+    run_dense_mlp_diagnostic_probe as run_gemma3n_dense_mlp_diagnostic_probe,
+    run_diagnostic_probe as run_gemma3n_qmv_diagnostic_probe,
+    run_initial_altup_diagnostic_probe as run_gemma3n_initial_altup_diagnostic_probe,
+    run_ple_diagnostic_probe as run_gemma3n_ple_diagnostic_probe,
+    run_ple_injection_all_planes_diagnostic_probe as run_gemma3n_ple_injection_all_planes_diagnostic_probe,
+    run_ple_injection_diagnostic_probe as run_gemma3n_ple_injection_diagnostic_probe,
+    run_post_attention_diagnostic_probe as run_gemma3n_post_attention_diagnostic_probe,
+    run_rms_diagnostic_probe as run_gemma3n_rms_diagnostic_probe,
+    run_sdpa_vector_context_diagnostic_probe as run_gemma3n_sdpa_vector_context_diagnostic_probe,
+};
 #[allow(unused_imports)]
 pub(crate) use gemma3n_weights::{Gemma3nWeightSpec, gemma3n_weight_specs};
 // MoE FFN config types (issue #500), read by the weight loader (`iree.rs`) and the

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -47,6 +47,13 @@
 
 mod builder;
 mod config;
+mod gemma3n;
+mod gemma3n_decode;
+mod gemma3n_emit;
+mod gemma3n_emit_ops;
+mod gemma3n_math;
+mod gemma3n_schema;
+mod gemma3n_weights;
 mod model;
 mod moe;
 mod rope;
@@ -55,6 +62,16 @@ mod rope;
 mod context_tests;
 
 pub(crate) use config::{Config, NormStyle, QkNorm, WeightScheme};
+#[allow(unused_imports)]
+pub(crate) use gemma3n::{
+    Gemma3nConfig, Gemma3nLayerType, Gemma3nPleDType, Gemma3nPleMetadata, validate_gemma3n_ple,
+};
+#[allow(unused_imports)]
+pub(crate) use gemma3n_decode::emit_gemma3n_decode;
+#[allow(unused_imports)]
+pub(crate) use gemma3n_emit::{emit_gemma3n_prefill, emit_gemma3n_prefill_embeddings_ple};
+#[allow(unused_imports)]
+pub(crate) use gemma3n_weights::{Gemma3nWeightSpec, gemma3n_weight_specs};
 // MoE FFN config types (issue #500), read by the weight loader (`iree.rs`) and the
 // validation harness. `SharedExpertConfig` is only named in some build cfgs.
 #[allow(unused_imports)]

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -58,11 +58,20 @@ use mlxcel_core::session::PreparedPrefill;
 use safetensors::{Dtype, SafeTensors};
 
 use crate::emitter::{
-    Config, Precision, check_packed_supported, emit_decode_ragged_with, emit_decode_with,
-    emit_prefill_embeddings_with, emit_prefill_with, quant_in_graph, resolve_precision,
-    resolve_precision_checked,
+    Config, Gemma3nConfig, Gemma3nWeightSpec, Precision, QuantConfig, check_packed_supported,
+    emit_decode_ragged_with, emit_decode_with, emit_gemma3n_decode_ragged_with_qmv,
+    emit_gemma3n_decode_with_qmv, emit_gemma3n_prefill_embeddings_ple_with_qmv,
+    emit_gemma3n_prefill_with_qmv, emit_prefill_embeddings_with, emit_prefill_with,
+    gemma3n_qmv_artifact_identity, gemma3n_qmv_is_available, gemma3n_weight_specs, quant_in_graph,
+    resolve_precision, resolve_precision_checked,
+};
+#[cfg(feature = "diagnostics")]
+use crate::emitter::{
+    Gemma3nDiagnosticLayout, emit_gemma3n_all_layer_diagnostics_with_qmv,
+    emit_gemma3n_prefill_diagnostics_with_qmv,
 };
 use crate::prepared::{PreparedIreePrefill, validate_slot};
+use crate::{Gemma3nDensePle, Gemma3nPreparedPrefill};
 // The loader reads the per-architecture checkpoint-weight order from
 // `weights::weight_specs`, which sources its names from `weight_names::scheme_names`
 // (issue #499 naming schemes) and covers the #498 dense pack (LayerNorm / o_proj /
@@ -70,8 +79,8 @@ use crate::prepared::{PreparedIreePrefill, validate_slot};
 // and the #500 MoE expert bank (the stacked `switch_mlp` weights, dequantized with
 // `dequantize_affine_stacked`). Both are pure-Rust and unit-tested without `iree`.
 use crate::weights::{
-    QuantPart, WeightSpec, bf16_to_f32, dequantize_affine, dequantize_affine_stacked, f16_to_f32,
-    f32_le_to_f32, pack_f16, slice_rows, weight_specs,
+    QuantPart, WeightSpec, bf16_to_f32, dequantize_affine, dequantize_affine_bf16_fused,
+    dequantize_affine_stacked, f16_to_f32, f32_le_to_f32, pack_f16, slice_rows, weight_specs,
 };
 
 /// Weight-buffer element dtype passed to the C shim (issue #516 per-weight ABI):
@@ -154,7 +163,8 @@ impl XlaTensorDesc {
             data,
             byte_length,
             dtype,
-            rank: shape.len() as c_int,
+            rank: c_int::try_from(shape.len())
+                .map_err(|_| format!("IREE tensor rank {} does not fit c_int", shape.len()))?,
             dims,
         })
     }
@@ -193,6 +203,7 @@ unsafe extern "C" {
         prefill: *const c_char,
         prefill_embeddings: *const c_char,
         decode: *const c_char,
+        prefill_diagnostics: *const c_char,
         compatibility_fingerprint: u64,
         n_weights: c_int,
         weight_data: *const *const c_void,
@@ -201,6 +212,9 @@ unsafe extern "C" {
         weight_dims: *const i64,
         context_capacity: c_int,
         hidden_size: c_int,
+        prefill_embeddings_kind: c_int,
+        dense_ple_layers: c_int,
+        dense_ple_hidden: c_int,
     ) -> *mut XlaCtx;
     fn xla_llama_prefill(
         c: *mut XlaCtx,
@@ -232,6 +246,17 @@ unsafe extern "C" {
         vocab: c_int,
         out_logits: *mut f32,
     ) -> c_int;
+    #[cfg(feature = "diagnostics")]
+    fn xla_llama_prefill_diagnostics_slot(
+        c: *mut XlaCtx,
+        slot: c_int,
+        tokens: *const c_int,
+        lp: c_int,
+        positions: *const c_int,
+        real_len: c_int,
+        diagnostic_len: c_int,
+        out_diagnostics: *mut f32,
+    ) -> c_int;
     fn xla_llama_prefill_embeddings(
         c: *mut XlaCtx,
         embeddings: *const XlaTensorDesc,
@@ -244,6 +269,26 @@ unsafe extern "C" {
         c: *mut XlaCtx,
         slot: c_int,
         embeddings: *const XlaTensorDesc,
+        positions: *const XlaTensorDesc,
+        attention_bias: *const XlaTensorDesc,
+        real_len: c_int,
+        vocab: c_int,
+        out_logits: *mut f32,
+    ) -> c_int;
+    fn xla_llama_prefill_embeddings_ple(
+        c: *mut XlaCtx,
+        embeddings: *const XlaTensorDesc,
+        dense_ple: *const XlaTensorDesc,
+        positions: *const XlaTensorDesc,
+        attention_bias: *const XlaTensorDesc,
+        real_len: c_int,
+        out_token: *mut c_int,
+    ) -> c_int;
+    fn xla_llama_prefill_embeddings_ple_slot_logits(
+        c: *mut XlaCtx,
+        slot: c_int,
+        embeddings: *const XlaTensorDesc,
+        dense_ple: *const XlaTensorDesc,
         positions: *const XlaTensorDesc,
         attention_bias: *const XlaTensorDesc,
         real_len: c_int,
@@ -266,6 +311,237 @@ unsafe extern "C" {
 /// ragged decode graph for the chosen `b_max` is emitted from the model config at
 /// load (any `b_max` is emittable; the worker selects from this set).
 pub(crate) const RAGGED_B_VALUES: &[usize] = &[4, 8];
+
+#[derive(Clone, Debug)]
+enum RuntimeConfig {
+    Dense(Config),
+    Gemma3n(Gemma3nConfig),
+}
+
+fn checked_ffi_int(value: usize, name: &str) -> Result<c_int, String> {
+    c_int::try_from(value).map_err(|_| format!("{name}={value} does not fit the IREE C ABI c_int"))
+}
+
+fn checked_ffi_i64(value: usize, name: &str) -> Result<i64, String> {
+    i64::try_from(value).map_err(|_| format!("{name}={value} does not fit the IREE C ABI i64"))
+}
+
+#[derive(Debug)]
+struct RuntimeFfiDimensions {
+    n_weights: c_int,
+    context_capacity: c_int,
+    hidden: c_int,
+    dense_ple_layers: c_int,
+    dense_ple_hidden: c_int,
+}
+
+fn runtime_ffi_dimensions(
+    cfg: &RuntimeConfig,
+    n_weights: usize,
+) -> Result<RuntimeFfiDimensions, String> {
+    let dense_ple = cfg.dense_ple_shape();
+    checked_ffi_int(cfg.vocab(), "vocab_size")?;
+    Ok(RuntimeFfiDimensions {
+        n_weights: checked_ffi_int(n_weights, "n_weights")?,
+        context_capacity: checked_ffi_int(cfg.context_capacity(), "context_capacity")?,
+        hidden: checked_ffi_int(cfg.hidden(), "hidden_size")?,
+        dense_ple_layers: checked_ffi_int(
+            dense_ple.map_or(0, |shape| shape[1]),
+            "dense_ple_layers",
+        )?,
+        dense_ple_hidden: checked_ffi_int(
+            dense_ple.map_or(0, |shape| shape[2]),
+            "dense_ple_hidden",
+        )?,
+    })
+}
+
+impl RuntimeConfig {
+    fn from_json(model_dir: &Path, context_capacity: usize) -> Result<Self, String> {
+        let path = model_dir.join("config.json");
+        let text = std::fs::read_to_string(&path)
+            .map_err(|error| format!("read {}: {error}", path.display()))?;
+        let root: serde_json::Value = serde_json::from_str(&text)
+            .map_err(|error| format!("parse {}: {error}", path.display()))?;
+        let model_type = root.get("model_type").and_then(serde_json::Value::as_str);
+        if matches!(model_type, Some("gemma3n" | "gemma3n_text")) {
+            return Gemma3nConfig::from_json_str(&text)
+                .and_then(|config| config.with_context_capacity(context_capacity))
+                .map(Self::Gemma3n)
+                .map_err(|error| format!("{}: {error}", path.display()));
+        }
+        Config::from_json(model_dir)?
+            .with_context_capacity(context_capacity)
+            .map(Self::Dense)
+    }
+
+    fn context_capacity(&self) -> usize {
+        match self {
+            Self::Dense(config) => config.context_capacity,
+            Self::Gemma3n(config) => config.context_capacity,
+        }
+    }
+
+    fn hidden(&self) -> usize {
+        match self {
+            Self::Dense(config) => config.hidden,
+            Self::Gemma3n(config) => config.hidden,
+        }
+    }
+
+    fn vocab(&self) -> usize {
+        match self {
+            Self::Dense(config) => config.vocab,
+            Self::Gemma3n(config) => config.vocab,
+        }
+    }
+
+    fn quantization(&self) -> Option<QuantConfig> {
+        match self {
+            Self::Dense(config) => config.quantization,
+            Self::Gemma3n(config) => config.quantization,
+        }
+    }
+
+    fn weight_specs(&self) -> Vec<WeightSpec> {
+        match self {
+            Self::Dense(config) => weight_specs(config),
+            Self::Gemma3n(config) => gemma3n_weight_specs(config)
+                .into_iter()
+                .map(|spec| match spec {
+                    Gemma3nWeightSpec::Tensor(name) => WeightSpec::Whole(name),
+                    Gemma3nWeightSpec::Projection(name) => WeightSpec::Proj(name),
+                })
+                .collect(),
+        }
+    }
+
+    fn artifact_identity(&self) -> String {
+        match self {
+            Self::Dense(config) => format!("dense:{config:?}"),
+            Self::Gemma3n(config) => config.compatibility_fingerprint(),
+        }
+    }
+
+    fn supports_f16_resident(&self) -> bool {
+        matches!(self, Self::Dense(config) if config.supports_f16_resident())
+    }
+
+    fn dense_ple_shape(&self) -> Option<[usize; 3]> {
+        match self {
+            Self::Dense(_) => None,
+            Self::Gemma3n(config) => Some(config.dense_ple_shape()),
+        }
+    }
+}
+
+fn effective_precision(device: &str, cfg: &RuntimeConfig) -> Result<Precision, String> {
+    match cfg {
+        RuntimeConfig::Dense(_) => resolve_precision_checked(device),
+        RuntimeConfig::Gemma3n(_) if device == "metal" => Err(
+            "Gemma3n uses an exact BF16 activation stream with F32 AltUp coefficient islands, \
+             but the Metal target cannot lower BF16. Use CUDA or a CPU local-task/local-sync \
+             target."
+                .to_string(),
+        ),
+        RuntimeConfig::Gemma3n(_) => Ok(Precision::Bf16),
+    }
+}
+
+fn gemma3n_native_qmv_eligibility(
+    device: &str,
+    quantization: Option<QuantConfig>,
+    qmv_available: bool,
+) -> Result<bool, String> {
+    if device != "cuda" {
+        return Ok(false);
+    }
+    let Some(quantization) = quantization else {
+        return Ok(false);
+    };
+    if quantization.bits == 8 {
+        return Ok(false);
+    }
+    if quantization.bits != 4 {
+        return Err(format!(
+            "Gemma3n CUDA native QMV supports 4-bit checkpoints; got {} bits",
+            quantization.bits
+        ));
+    }
+    if quantization.group_size != 64 {
+        return Err(format!(
+            "Gemma3n CUDA native QMV currently pins the Q4 group_size=64 contract; got {}",
+            quantization.group_size
+        ));
+    }
+    if !qmv_available {
+        return Err(
+            "Gemma3n CUDA Q4 requires the token-exact native QMV, but this binary was \
+             built without the CUDA-IREE PTX (`cfg(xla_iree_cuda)`). Rebuild with \
+             IREE_CUDA_HOME and nvcc; refusing the numerically different dot fallback."
+                .to_string(),
+        );
+    }
+    Ok(true)
+}
+
+fn gemma3n_native_qmv(device: &str, config: &Gemma3nConfig) -> Result<bool, String> {
+    let enabled =
+        gemma3n_native_qmv_eligibility(device, config.quantization, gemma3n_qmv_is_available())?;
+    if enabled {
+        config.validate_native_cuda_dispatches()?;
+    }
+    Ok(enabled)
+}
+
+#[cfg(test)]
+mod gemma3n_qmv_eligibility_tests {
+    use super::*;
+
+    const Q4_GROUP64: Option<QuantConfig> = Some(QuantConfig {
+        bits: 4,
+        group_size: 64,
+    });
+
+    #[test]
+    fn cuda_q4_requires_native_qmv_and_exact_group_contract() {
+        assert!(gemma3n_native_qmv_eligibility("cuda", Q4_GROUP64, true).unwrap());
+        assert!(
+            gemma3n_native_qmv_eligibility("cuda", Q4_GROUP64, false)
+                .unwrap_err()
+                .contains("refusing the numerically different dot fallback")
+        );
+        assert!(
+            gemma3n_native_qmv_eligibility(
+                "cuda",
+                Some(QuantConfig {
+                    bits: 4,
+                    group_size: 32,
+                }),
+                true,
+            )
+            .unwrap_err()
+            .contains("group_size=64")
+        );
+    }
+
+    #[test]
+    fn only_cuda_q4_selects_native_qmv() {
+        assert!(!gemma3n_native_qmv_eligibility("local-task", Q4_GROUP64, true).unwrap());
+        assert!(
+            !gemma3n_native_qmv_eligibility(
+                "cuda",
+                Some(QuantConfig {
+                    bits: 8,
+                    group_size: 64,
+                }),
+                true,
+            )
+            .unwrap()
+        );
+        assert!(!gemma3n_native_qmv_eligibility("cuda", None, true).unwrap());
+    }
+}
 
 // The per-architecture checkpoint-weight order the loader reads lives in
 // `weights::weight_specs` (pure logic, unit-tested without the IREE runtime, and
@@ -403,9 +679,11 @@ struct CompiledBundle {
 /// weight argument schema, precision, context/hidden/KV dimensions, and ABI
 /// schema version; a member compiled from a different contract therefore cannot
 /// be substituted without changing the fingerprint.
+#[allow(clippy::too_many_arguments)]
 fn compile_bundle(
     device: &str,
-    cfg: &Config,
+    cfg: &RuntimeConfig,
+    gemma3n_qmv: bool,
     prefill_mlir: &str,
     prefill_tag: &str,
     prefill_embeddings_mlir: &str,
@@ -420,38 +698,44 @@ fn compile_bundle(
             iree_compile.display()
         ));
     }
-    let flags = target_flags(device)?;
+    let mut flags = target_flags(device)?.to_vec();
+    if gemma3n_qmv {
+        flags.push("--iree-cuda-target=sm_80");
+    }
     let cache = std::env::temp_dir().join("mlxcel-xla-vmfb");
     std::fs::create_dir_all(&cache).map_err(|e| format!("mkdir {}: {e}", cache.display()))?;
     let pre = compile_one(
         &iree_compile,
         prefill_mlir,
-        flags,
+        &flags,
         &cache,
         prefill_tag,
-        cfg.context_capacity,
+        cfg.context_capacity(),
     )?;
     let pre_embeddings = compile_one(
         &iree_compile,
         prefill_embeddings_mlir,
-        flags,
+        &flags,
         &cache,
         prefill_embeddings_tag,
-        cfg.context_capacity,
+        cfg.context_capacity(),
     )?;
     let dec = compile_one(
         &iree_compile,
         decode_mlir,
-        flags,
+        &flags,
         &cache,
         decode_tag,
-        cfg.context_capacity,
+        cfg.context_capacity(),
     )?;
     let mut fingerprint = std::collections::hash_map::DefaultHasher::new();
     "mlxcel-xla-runtime-bundle-v1".hash(&mut fingerprint);
-    format!("{cfg:?}").hash(&mut fingerprint);
-    format!("{:?}", weight_specs(cfg)).hash(&mut fingerprint);
-    format!("{:?}", resolve_precision(device)).hash(&mut fingerprint);
+    cfg.artifact_identity().hash(&mut fingerprint);
+    format!("{:?}", cfg.weight_specs()).hash(&mut fingerprint);
+    format!("{:?}", effective_precision(device, cfg)?).hash(&mut fingerprint);
+    if gemma3n_qmv {
+        gemma3n_qmv_artifact_identity().hash(&mut fingerprint);
+    }
     prefill_mlir.hash(&mut fingerprint);
     prefill_embeddings_mlir.hash(&mut fingerprint);
     decode_mlir.hash(&mut fingerprint);
@@ -465,15 +749,31 @@ fn compile_bundle(
 }
 
 /// Emit and compile the argmax prefill bundle for a single-sequence engine.
-fn compile_vmfbs(device: &str, cfg: &Config) -> Result<CompiledBundle, String> {
-    let precision = resolve_precision_checked(device)?;
-    check_packed_supported(device, quant_in_graph() && cfg.supports_packed_quant())?;
-    let prefill = emit_prefill_with(cfg, true, precision);
-    let prefill_embeddings = emit_prefill_embeddings_with(cfg, true, precision);
-    let decode = emit_decode_with(cfg, true, precision);
+fn compile_vmfbs(device: &str, cfg: &RuntimeConfig) -> Result<CompiledBundle, String> {
+    let precision = effective_precision(device, cfg)?;
+    let native_qmv = match cfg {
+        RuntimeConfig::Dense(_) => false,
+        RuntimeConfig::Gemma3n(config) => gemma3n_native_qmv(device, config)?,
+    };
+    let (prefill, prefill_embeddings, decode) = match cfg {
+        RuntimeConfig::Dense(config) => {
+            check_packed_supported(device, quant_in_graph() && config.supports_packed_quant())?;
+            (
+                emit_prefill_with(config, true, precision),
+                emit_prefill_embeddings_with(config, true, precision),
+                emit_decode_with(config, true, precision),
+            )
+        }
+        RuntimeConfig::Gemma3n(config) => (
+            emit_gemma3n_prefill_with_qmv(config, true, precision, native_qmv),
+            emit_gemma3n_prefill_embeddings_ple_with_qmv(config, true, precision, native_qmv),
+            emit_gemma3n_decode_with_qmv(config, true, precision, native_qmv),
+        ),
+    };
     compile_bundle(
         device,
         cfg,
+        native_qmv,
         &prefill,
         "prefill",
         &prefill_embeddings,
@@ -481,6 +781,49 @@ fn compile_vmfbs(device: &str, cfg: &Config) -> Result<CompiledBundle, String> {
         &decode,
         "decode",
     )
+}
+
+#[cfg(feature = "diagnostics")]
+fn compile_gemma3n_diagnostics(
+    device: &str,
+    cfg: &RuntimeConfig,
+    all_layers: bool,
+) -> Result<(PathBuf, Gemma3nDiagnosticLayout), String> {
+    let RuntimeConfig::Gemma3n(config) = cfg else {
+        return Err("Gemma3n diagnostics require a Gemma3n runtime config".to_string());
+    };
+    let precision = effective_precision(device, cfg)?;
+    let native_qmv = gemma3n_native_qmv(device, config)?;
+    let (mlir, layout) = if all_layers {
+        emit_gemma3n_all_layer_diagnostics_with_qmv(config, precision, native_qmv)
+    } else {
+        emit_gemma3n_prefill_diagnostics_with_qmv(config, precision, native_qmv)
+    };
+    layout.validate()?;
+    let compiler = iree_compile_bin()?;
+    if !compiler.exists() {
+        return Err(format!("iree-compile not found at {}", compiler.display()));
+    }
+    let cache = std::env::temp_dir().join("mlxcel-xla-vmfb");
+    std::fs::create_dir_all(&cache)
+        .map_err(|error| format!("mkdir {}: {error}", cache.display()))?;
+    let mut flags = target_flags(device)?.to_vec();
+    if native_qmv {
+        flags.push("--iree-cuda-target=sm_80");
+    }
+    let vmfb = compile_one(
+        &compiler,
+        &mlir,
+        &flags,
+        &cache,
+        if all_layers {
+            "prefill_all_layer_diagnostics"
+        } else {
+            "prefill_diagnostics"
+        },
+        cfg.context_capacity(),
+    )?;
+    Ok((vmfb, layout))
 }
 
 /// Map each needed weight name to the safetensors file that holds it, in the same
@@ -519,6 +862,254 @@ fn resolve_weight_shards(model_dir: &Path, names: &[String]) -> Result<Vec<PathB
         .collect()
 }
 
+/// mlx-community Gemma3n quantized repacks retain the upstream index but rewrite
+/// the language backbone's safetensors prefix. Keep the graph's canonical HF
+/// argument order and only try this one architecture-specific alternate after
+/// the canonical name is absent.
+fn gemma3n_repackaged_tensor_name(name: &str) -> Option<String> {
+    name.strip_prefix("model.language_model.")
+        .map(|suffix| format!("language_model.model.{suffix}"))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Gemma3nCheckpointNames {
+    Canonical,
+    Repackaged,
+}
+
+fn merge_gemma3n_name_scheme(
+    current: Option<Gemma3nCheckpointNames>,
+    observed: Gemma3nCheckpointNames,
+) -> Result<Option<Gemma3nCheckpointNames>, String> {
+    match current {
+        Some(current) if current != observed => Err(
+            "Gemma3n checkpoint mixes canonical `model.language_model.*` and repackaged \
+             `language_model.model.*` tensor names"
+                .to_string(),
+        ),
+        Some(current) => Ok(Some(current)),
+        None => Ok(Some(observed)),
+    }
+}
+
+fn gemma3n_candidate_shards(model_dir: &Path, names: &[String]) -> Result<Vec<PathBuf>, String> {
+    let indexed = resolve_weight_shards(model_dir, names);
+    if let Ok(paths) = &indexed
+        && paths.iter().all(|path| path.is_file())
+    {
+        let mut unique = paths.clone();
+        unique.sort();
+        unique.dedup();
+        return Ok(unique);
+    }
+    let mut actual: Vec<PathBuf> = std::fs::read_dir(model_dir)
+        .map_err(|error| format!("read {}: {error}", model_dir.display()))?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with(".safetensors"))
+        })
+        .collect();
+    actual.sort();
+    if actual.is_empty() {
+        return Err(match indexed {
+            Err(error) => error,
+            Ok(_) => format!("no safetensors files found in {}", model_dir.display()),
+        });
+    }
+    Ok(actual)
+}
+
+fn resolve_gemma3n_weight_sources(
+    model_dir: &Path,
+    names: &[String],
+) -> Result<(Vec<PathBuf>, Gemma3nCheckpointNames), String> {
+    let candidate_shards = gemma3n_candidate_shards(model_dir, names)?;
+    let mut resolved: Vec<Option<PathBuf>> = vec![None; names.len()];
+    let mut scheme = None;
+    for shard in candidate_shards {
+        let file = File::open(&shard).map_err(|e| format!("open {}: {e}", shard.display()))?;
+        // Safety: the file is read-only for the lifetime of this header scan.
+        let mmap =
+            unsafe { Mmap::map(&file) }.map_err(|e| format!("mmap {}: {e}", shard.display()))?;
+        let st = SafeTensors::deserialize(&mmap)
+            .map_err(|e| format!("parse {}: {e}", shard.display()))?;
+        for (index, canonical) in names.iter().enumerate() {
+            let alias = gemma3n_repackaged_tensor_name(canonical).ok_or_else(|| {
+                format!("Gemma3n graph weight has an unsupported canonical name: {canonical}")
+            })?;
+            let has_canonical = st.tensor(canonical).is_ok();
+            let has_alias = st.tensor(&alias).is_ok();
+            let observed = match (has_canonical, has_alias) {
+                (false, false) => continue,
+                (true, false) => Gemma3nCheckpointNames::Canonical,
+                (false, true) => Gemma3nCheckpointNames::Repackaged,
+                (true, true) => {
+                    return Err(format!(
+                        "Gemma3n checkpoint {} contains both `{canonical}` and `{alias}`",
+                        shard.display()
+                    ));
+                }
+            };
+            if let Some(previous) = &resolved[index] {
+                return Err(format!(
+                    "Gemma3n tensor `{canonical}` is duplicated in {} and {}",
+                    previous.display(),
+                    shard.display()
+                ));
+            }
+            resolved[index] = Some(shard.clone());
+            scheme = merge_gemma3n_name_scheme(scheme, observed)?;
+        }
+    }
+    let missing: Vec<&str> = resolved
+        .iter()
+        .zip(names)
+        .filter_map(|(path, name)| path.is_none().then_some(name.as_str()))
+        .collect();
+    if !missing.is_empty() {
+        let preview = missing
+            .iter()
+            .take(8)
+            .copied()
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(format!(
+            "Gemma3n checkpoint is missing {} graph weight(s): {preview}",
+            missing.len()
+        ));
+    }
+    let scheme = scheme.ok_or_else(|| "Gemma3n checkpoint has no graph weights".to_string())?;
+    Ok((
+        resolved
+            .into_iter()
+            .map(|path| path.expect("missing paths rejected above"))
+            .collect(),
+        scheme,
+    ))
+}
+
+fn checkpoint_tensor_name(
+    scheme: Option<Gemma3nCheckpointNames>,
+    canonical: &str,
+) -> Result<String, String> {
+    match scheme {
+        Some(Gemma3nCheckpointNames::Repackaged) => gemma3n_repackaged_tensor_name(canonical)
+            .ok_or_else(|| format!("unsupported Gemma3n tensor name: {canonical}")),
+        Some(Gemma3nCheckpointNames::Canonical) | None => Ok(canonical.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod checkpoint_name_tests {
+    use super::*;
+
+    fn tiny_gemma3n_runtime() -> RuntimeConfig {
+        RuntimeConfig::Gemma3n(
+            Gemma3nConfig::from_json_str(
+                &serde_json::json!({
+                    "model_type": "gemma3n_text",
+                    "hidden_size": 8, "intermediate_size": [12, 12],
+                    "max_position_embeddings": 4096,
+                    "num_hidden_layers": 2, "num_attention_heads": 2,
+                    "num_key_value_heads": 1, "head_dim": 4, "rms_norm_eps": 1e-6,
+                    "vocab_size": 12, "vocab_size_per_layer_input": 10,
+                    "hidden_size_per_layer_input": 2,
+                    "layer_types": ["sliding_attention", "full_attention"],
+                    "activation_sparsity_pattern": [0.0, 0.0],
+                    "sliding_window": 2, "rope_theta": 1000000.0,
+                    "rope_local_base_freq": 10000.0, "final_logit_softcapping": 30.0,
+                    "num_kv_shared_layers": 0, "altup_num_inputs": 2,
+                    "altup_active_idx": 0, "altup_coef_clip": 120.0,
+                    "altup_correct_scale": true, "laurel_rank": 2,
+                    "tie_word_embeddings": true
+                })
+                .to_string(),
+            )
+            .unwrap()
+            .with_context_capacity(4)
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn gemma3n_runtime_precision_is_fixed_bf16_and_rejects_metal() {
+        let cfg = tiny_gemma3n_runtime();
+        assert_eq!(effective_precision("cuda", &cfg).unwrap(), Precision::Bf16);
+        assert_eq!(
+            effective_precision("local-task", &cfg).unwrap(),
+            Precision::Bf16
+        );
+        assert!(
+            effective_precision("metal", &cfg)
+                .unwrap_err()
+                .contains("BF16")
+        );
+    }
+
+    #[test]
+    fn runtime_ffi_preflight_rejects_oversized_config_and_weight_count() {
+        let mut cfg = tiny_gemma3n_runtime();
+        let RuntimeConfig::Gemma3n(config) = &mut cfg else {
+            unreachable!()
+        };
+        config.hidden = i32::MAX as usize + 1;
+        let error = runtime_ffi_dimensions(&cfg, 1).unwrap_err();
+        assert!(error.contains("hidden_size"));
+        assert!(error.contains("does not fit"));
+
+        let cfg = tiny_gemma3n_runtime();
+        let error = runtime_ffi_dimensions(&cfg, i32::MAX as usize + 1).unwrap_err();
+        assert!(error.contains("n_weights"));
+        assert!(error.contains("does not fit"));
+    }
+
+    #[test]
+    fn gemma3n_repack_alias_covers_weight_and_quant_companions() {
+        assert_eq!(
+            gemma3n_repackaged_tensor_name("model.language_model.layers.0.self_attn.q_proj.weight")
+                .as_deref(),
+            Some("language_model.model.layers.0.self_attn.q_proj.weight")
+        );
+        assert_eq!(
+            gemma3n_repackaged_tensor_name("model.language_model.embed_tokens.scales").as_deref(),
+            Some("language_model.model.embed_tokens.scales")
+        );
+        assert_eq!(
+            gemma3n_repackaged_tensor_name("model.language_model.embed_tokens.biases").as_deref(),
+            Some("language_model.model.embed_tokens.biases")
+        );
+    }
+
+    #[test]
+    fn gemma3n_name_scheme_rejects_mixed_checkpoints() {
+        let scheme = merge_gemma3n_name_scheme(None, Gemma3nCheckpointNames::Canonical).unwrap();
+        let error =
+            merge_gemma3n_name_scheme(scheme, Gemma3nCheckpointNames::Repackaged).unwrap_err();
+        assert!(error.contains("mixes canonical"));
+    }
+
+    #[test]
+    #[ignore = "requires GEMMA3N_MODEL_DIR pointing at a real local checkpoint"]
+    fn real_gemma3n_headers_resolve_every_graph_weight_once() {
+        let model_dir =
+            PathBuf::from(std::env::var_os("GEMMA3N_MODEL_DIR").expect("GEMMA3N_MODEL_DIR"));
+        let cfg = RuntimeConfig::from_json(&model_dir, 8).unwrap();
+        let names: Vec<String> = cfg
+            .weight_specs()
+            .iter()
+            .map(|spec| spec.tensor_name().to_string())
+            .collect();
+        let (paths, _) = resolve_gemma3n_weight_sources(&model_dir, &names).unwrap();
+        assert_eq!(paths.len(), names.len());
+        assert!(paths.iter().all(|path| path.is_file()));
+    }
+}
+
 /// Load the weights bf16 -> f32 in the emitter's arg order, returning the owned
 /// f32 buffers (kept alive until the shim copies them) plus the flat (ptr, rank,
 /// dims) arrays the C ABI takes. `cfg` fixes the layer count and weight order.
@@ -531,12 +1122,18 @@ fn resolve_weight_shards(model_dir: &Path, names: &[String]) -> Result<Vec<PathB
 #[allow(clippy::type_complexity)]
 fn load_weights(
     model_dir: &Path,
-    cfg: &Config,
+    cfg: &RuntimeConfig,
     resident_f16: bool,
 ) -> Result<(Vec<WeightBuf>, Vec<c_int>, Vec<c_int>, Vec<i64>), String> {
-    let specs = weight_specs(cfg);
+    let specs = cfg.weight_specs();
     let names: Vec<String> = specs.iter().map(|s| s.tensor_name().to_string()).collect();
-    let shard_paths = resolve_weight_shards(model_dir, &names)?;
+    let (shard_paths, gemma3n_name_scheme) = match cfg {
+        RuntimeConfig::Gemma3n(_) => {
+            let (paths, scheme) = resolve_gemma3n_weight_sources(model_dir, &names)?;
+            (paths, Some(scheme))
+        }
+        RuntimeConfig::Dense(_) => (resolve_weight_shards(model_dir, &names)?, None),
+    };
 
     // Group weight indices by shard so each shard file is opened/mmap'd once; the
     // results are placed by index, preserving the emitter's arg order. A Phi3
@@ -562,9 +1159,13 @@ fn load_weights(
             .map_err(|e| format!("parse {}: {e}", shard.display()))?;
         for &i in &idxs {
             let name = &names[i];
-            let t = st
-                .tensor(name)
-                .map_err(|e| format!("weight {name} in {}: {e}", shard.display()))?;
+            let checkpoint_name = checkpoint_tensor_name(gemma3n_name_scheme, name)?;
+            let t = st.tensor(&checkpoint_name).map_err(|e| {
+                format!(
+                    "resolved weight {checkpoint_name} (canonical {name}) in {}: {e}",
+                    shard.display()
+                )
+            })?;
 
             // issue #516 packed path: upload the raw quantized part (the packed U32
             // weight, or its f16 scales / biases) as-is, no dequant. Its native dtype
@@ -589,8 +1190,8 @@ fn load_weights(
                 }
                 dtypes[i] = code;
                 ranks[i] = 2;
-                dims[i * 4] = shape[0] as i64;
-                dims[i * 4 + 1] = shape[1] as i64;
+                dims[i * 4] = checked_ffi_i64(shape[0], &format!("weight {name} dim 0"))?;
+                dims[i * 4 + 1] = checked_ffi_i64(shape[1], &format!("weight {name} dim 1"))?;
                 bufs[i] = WeightBuf::Raw(t.data().to_vec());
                 continue;
             }
@@ -599,14 +1200,14 @@ fn load_weights(
             // graph's dtype): an MLX affine `U32`-packed weight is dequantized (the
             // layernorms / biases are not quantized and take the widen path).
             let (data, shape): (Vec<f32>, Vec<usize>) = if t.dtype() == Dtype::U32 {
-                let qc = cfg.quantization.ok_or_else(|| {
+                let qc = cfg.quantization().ok_or_else(|| {
                     format!(
                         "weight {name} is U32 (quantized) but config.json has no `quantization`"
                     )
                 })?;
-                let prefix = name
-                    .strip_suffix(".weight")
-                    .ok_or_else(|| format!("quantized weight {name} does not end in `.weight`"))?;
+                let prefix = checkpoint_name.strip_suffix(".weight").ok_or_else(|| {
+                    format!("quantized weight {checkpoint_name} does not end in `.weight`")
+                })?;
                 let scales_name = format!("{prefix}.scales");
                 let biases_name = format!("{prefix}.biases");
                 let scales = st.tensor(&scales_name).map_err(|e| {
@@ -634,16 +1235,33 @@ fn load_weights(
                     2 => {
                         let (out, in_packed) = (shape[0], shape[1]);
                         let in_ = in_packed * (32 / qc.bits);
-                        let d = dequantize_affine(
-                            t.data(),
-                            scales.data(),
-                            biases.data(),
-                            out,
-                            in_packed,
-                            qc.bits,
-                            qc.group_size,
-                            sb_bf16,
-                        )
+                        let d = if matches!(cfg, RuntimeConfig::Gemma3n(_)) {
+                            if !sb_bf16 {
+                                return Err(format!(
+                                    "{prefix} uses F16 affine scales/biases, but Gemma3n requires BF16 affine metadata"
+                                ));
+                            }
+                            dequantize_affine_bf16_fused(
+                                t.data(),
+                                scales.data(),
+                                biases.data(),
+                                out,
+                                in_packed,
+                                qc.bits,
+                                qc.group_size,
+                            )
+                        } else {
+                            dequantize_affine(
+                                t.data(),
+                                scales.data(),
+                                biases.data(),
+                                out,
+                                in_packed,
+                                qc.bits,
+                                qc.group_size,
+                                sb_bf16,
+                            )
+                        }
                         .map_err(|e| format!("dequantize {name}: {e}"))?;
                         (d, vec![out, in_])
                     }
@@ -696,9 +1314,9 @@ fn load_weights(
             // Place the whole tensor, or (Phi3 fused) a row-slice, into arg slot i.
             match &specs[i] {
                 WeightSpec::Whole(_) => {
-                    ranks[i] = shape.len() as c_int;
+                    ranks[i] = checked_ffi_int(shape.len(), &format!("weight {name} rank"))?;
                     for (k, &s) in shape.iter().enumerate() {
-                        dims[i * 4 + k] = s as i64;
+                        dims[i * 4 + k] = checked_ffi_i64(s, &format!("weight {name} dim {k}"))?;
                     }
                     bufs[i] = WeightBuf::F32(data);
                 }
@@ -707,9 +1325,9 @@ fn load_weights(
                 // and halving its per-step DRAM read; otherwise upload f32, identical
                 // to the old `Whole`. `data` / `shape` are the widened row-major weight.
                 WeightSpec::Proj(_) => {
-                    ranks[i] = shape.len() as c_int;
+                    ranks[i] = checked_ffi_int(shape.len(), &format!("weight {name} rank"))?;
                     for (k, &s) in shape.iter().enumerate() {
-                        dims[i * 4 + k] = s as i64;
+                        dims[i * 4 + k] = checked_ffi_i64(s, &format!("weight {name} dim {k}"))?;
                     }
                     if resident_f16 {
                         dtypes[i] = WDT_F16;
@@ -730,8 +1348,9 @@ fn load_weights(
                             .map_err(|e| format!("row-slice {name}: {e}"))?,
                     );
                     ranks[i] = 2;
-                    dims[i * 4] = (*end - *start) as i64;
-                    dims[i * 4 + 1] = shape[1] as i64;
+                    dims[i * 4] =
+                        checked_ffi_i64(*end - *start, &format!("weight {name} sliced rows"))?;
+                    dims[i * 4 + 1] = checked_ffi_i64(shape[1], &format!("weight {name} dim 1"))?;
                 }
                 WeightSpec::QuantRaw { .. } => {
                     unreachable!("QuantRaw is handled by the early-continue above")
@@ -762,20 +1381,35 @@ fn prepared_descriptors(
     Ok((embeddings, positions, attention_bias))
 }
 
+fn dense_ple_descriptor(dense_ple: &Gemma3nDensePle) -> Result<XlaTensorDesc, String> {
+    XlaTensorDesc::f32(dense_ple.as_slice(), &dense_ple.shape())
+}
+
 /// Load the weights and create the C execution context for a (prefill, decode)
 /// vmfb pair on `device`. Shared by the single-sequence ([`IreeLlama`]) and ragged
 /// ([`IreeRaggedLlama`]) engines, which differ only in which decode vmfb they pass.
 fn create_ctx(
     model_dir: &Path,
-    cfg: &Config,
+    cfg: &RuntimeConfig,
     device: &str,
     bundle: &CompiledBundle,
+) -> Result<*mut XlaCtx, String> {
+    create_ctx_with_diagnostics(model_dir, cfg, device, bundle, None)
+}
+
+fn create_ctx_with_diagnostics(
+    model_dir: &Path,
+    cfg: &RuntimeConfig,
+    device: &str,
+    bundle: &CompiledBundle,
+    prefill_diagnostics_vmfb: Option<&Path>,
 ) -> Result<*mut XlaCtx, String> {
     // issue #572: the f16 GPU path uploads the projection weights f16-resident to
     // match the emitter's f16 args. Uses the same resolve_precision(device) the graph
     // emit uses, so the uploaded buffer dtype always lines up with the emitted arg.
     let resident_f16 = resolve_precision(device) == Precision::F16 && cfg.supports_f16_resident();
     let (bufs, dtypes, ranks, dims) = load_weights(model_dir, cfg, resident_f16)?;
+    let ffi = runtime_ffi_dimensions(cfg, bufs.len())?;
     let ptrs: Vec<*const c_void> = bufs
         .iter()
         .map(|b| b.as_u8_ptr() as *const c_void)
@@ -784,6 +1418,7 @@ fn create_ctx(
     let c_pre = path_cstring(&bundle.prefill_vmfb)?;
     let c_pre_embeddings = path_cstring(&bundle.prefill_embeddings_vmfb)?;
     let c_dec = path_cstring(&bundle.decode_vmfb)?;
+    let c_diagnostics = prefill_diagnostics_vmfb.map(path_cstring).transpose()?;
     // Safety: pointers are valid for the duration of the call; the shim copies
     // the weight data into device buffers before returning.
     let ctx = unsafe {
@@ -792,14 +1427,20 @@ fn create_ctx(
             c_pre.as_ptr(),
             c_pre_embeddings.as_ptr(),
             c_dec.as_ptr(),
+            c_diagnostics
+                .as_ref()
+                .map_or(std::ptr::null(), |path| path.as_ptr()),
             bundle.compatibility_fingerprint,
-            bufs.len() as c_int,
+            ffi.n_weights,
             ptrs.as_ptr(),
             dtypes.as_ptr(),
             ranks.as_ptr(),
             dims.as_ptr(),
-            cfg.context_capacity as c_int,
-            cfg.hidden as c_int,
+            ffi.context_capacity,
+            ffi.hidden,
+            i32::from(cfg.dense_ple_shape().is_some()),
+            ffi.dense_ple_layers,
+            ffi.dense_ple_hidden,
         )
     };
     // Weights are resident on the device now; free the host copy.
@@ -820,6 +1461,7 @@ pub struct IreeLlama {
     ctx: *mut XlaCtx,
     context_capacity: usize,
     hidden_size: usize,
+    dense_ple_shape: Option<[usize; 3]>,
 }
 
 impl IreeLlama {
@@ -827,13 +1469,15 @@ impl IreeLlama {
     /// (`"local-task"` for CPU). Compiles the bundled graphs, uploads the
     /// weights resident, and readies the prefill / decode calls.
     pub fn load(model_dir: &Path, device: &str, context_capacity: usize) -> Result<Self, String> {
-        let cfg = Config::from_json(model_dir)?.with_context_capacity(context_capacity)?;
+        let cfg = RuntimeConfig::from_json(model_dir, context_capacity)?;
+        runtime_ffi_dimensions(&cfg, cfg.weight_specs().len())?;
         let bundle = compile_vmfbs(device, &cfg)?;
         let ctx = create_ctx(model_dir, &cfg, device, &bundle)?;
         Ok(Self {
             ctx,
-            context_capacity: cfg.context_capacity,
-            hidden_size: cfg.hidden,
+            context_capacity: cfg.context_capacity(),
+            hidden_size: cfg.hidden(),
+            dense_ple_shape: cfg.dense_ple_shape(),
         })
     }
 
@@ -868,6 +1512,11 @@ impl IreeLlama {
     /// Validate an owned embeddings payload, seed the resident KV through the
     /// dedicated embeddings module, and return the first sampled token.
     pub fn prefill_prepared_first(&mut self, prepared: &PreparedPrefill) -> Result<i32, String> {
+        if self.dense_ple_shape.is_some() {
+            return Err(
+                "Gemma3n requires the distinct embeddings-plus-dense-PLE prefill entry".to_string(),
+            );
+        }
         let prepared =
             PreparedIreePrefill::prepare(prepared, self.hidden_size, self.context_capacity)
                 .map_err(|error| error.to_string())?;
@@ -893,6 +1542,53 @@ impl IreeLlama {
         Ok(out)
     }
 
+    /// Seed Gemma3n KV from post-scale merged embeddings plus a canonical dense
+    /// projected PLE tensor.
+    pub fn prefill_gemma3n_prepared_first(
+        &mut self,
+        request: &Gemma3nPreparedPrefill,
+    ) -> Result<i32, String> {
+        let expected = self.dense_ple_shape.ok_or_else(|| {
+            "dense Gemma3n PLE prefill was requested from a non-Gemma3n bundle".to_string()
+        })?;
+        let prepared = PreparedIreePrefill::prepare(
+            request.prepared(),
+            self.hidden_size,
+            self.context_capacity,
+        )
+        .map_err(|error| error.to_string())?;
+        if request.dense_ple().shape() != expected {
+            return Err(format!(
+                "Gemma3n dense PLE shape {:?} does not match runtime bundle {expected:?}",
+                request.dense_ple().shape()
+            ));
+        }
+        let (embeddings, positions, attention_bias) = prepared_descriptors(&prepared)?;
+        let dense_ple = dense_ple_descriptor(request.dense_ple())?;
+        let real_len = i32::try_from(prepared.effective_len)
+            .map_err(|_| "prepared effective length does not fit i32".to_string())?;
+        let mut out = 0i32;
+        // Safety: all typed descriptors reference validated owned vectors that
+        // outlive the call; the C shim repeats exact dtype/rank/shape/byte checks.
+        let rc = unsafe {
+            xla_llama_prefill_embeddings_ple(
+                self.ctx,
+                &embeddings,
+                &dense_ple,
+                &positions,
+                &attention_bias,
+                real_len,
+                &mut out,
+            )
+        };
+        if rc != 0 {
+            return Err(format!(
+                "xla_llama_prefill_embeddings_ple failed (status {rc})"
+            ));
+        }
+        Ok(out)
+    }
+
     /// Pad `prompt` into the configured static bucket, run the prefill, and return its
     /// first token. Accepts an empty prompt (the seed-then-decode loop prefills a
     /// zero-length prefix when the prompt is a single token).
@@ -906,16 +1602,18 @@ impl IreeLlama {
         }
         let mut tokens = vec![0i32; self.context_capacity];
         tokens[..prompt.len()].copy_from_slice(prompt);
-        let positions: Vec<c_int> = (0..self.context_capacity as c_int).collect();
+        let capacity = checked_ffi_int(self.context_capacity, "context_capacity")?;
+        let real_len = checked_ffi_int(prompt.len(), "prompt length")?;
+        let positions: Vec<c_int> = (0..capacity).collect();
         let mut out = 0i32;
         // Safety: buffers outlive the call; the shim stores the returned KV.
         let rc = unsafe {
             xla_llama_prefill(
                 self.ctx,
                 tokens.as_ptr(),
-                self.context_capacity as c_int,
+                capacity,
                 positions.as_ptr(),
-                prompt.len() as c_int,
+                real_len,
                 &mut out,
             )
         };
@@ -972,6 +1670,9 @@ pub struct IreeRaggedLlama {
     vocab: usize,
     context_capacity: usize,
     hidden_size: usize,
+    dense_ple_shape: Option<[usize; 3]>,
+    #[cfg(feature = "diagnostics")]
+    diagnostic_layout: Option<Gemma3nDiagnosticLayout>,
 }
 
 impl IreeRaggedLlama {
@@ -986,7 +1687,41 @@ impl IreeRaggedLlama {
         b_max: usize,
         context_capacity: usize,
     ) -> Result<Self, String> {
-        let cfg = Config::from_json(model_dir)?.with_context_capacity(context_capacity)?;
+        Self::load_inner(model_dir, device, b_max, context_capacity, false, false)
+    }
+
+    #[cfg(feature = "diagnostics")]
+    pub fn load_with_diagnostics(
+        model_dir: &Path,
+        device: &str,
+        b_max: usize,
+        context_capacity: usize,
+    ) -> Result<Self, String> {
+        Self::load_inner(model_dir, device, b_max, context_capacity, true, false)
+    }
+
+    #[cfg(feature = "diagnostics")]
+    pub fn load_with_all_layer_diagnostics(
+        model_dir: &Path,
+        device: &str,
+        b_max: usize,
+        context_capacity: usize,
+    ) -> Result<Self, String> {
+        Self::load_inner(model_dir, device, b_max, context_capacity, false, true)
+    }
+
+    fn load_inner(
+        model_dir: &Path,
+        device: &str,
+        b_max: usize,
+        context_capacity: usize,
+        diagnostics: bool,
+        all_layer_diagnostics: bool,
+    ) -> Result<Self, String> {
+        debug_assert!(!(diagnostics && all_layer_diagnostics));
+        let cfg = RuntimeConfig::from_json(model_dir, context_capacity)?;
+        runtime_ffi_dimensions(&cfg, cfg.weight_specs().len())?;
+        checked_ffi_int(b_max, "b_max")?;
         if !RAGGED_B_VALUES.contains(&b_max) {
             return Err(format!(
                 "the OpenXLA serve worker selects B_max from {RAGGED_B_VALUES:?}; \
@@ -995,14 +1730,30 @@ impl IreeRaggedLlama {
         }
         // Emit the logits prefill + the ragged decode graph for this model + b_max
         // at the device-resolved precision (f16 on GPU by default, f32 on CPU).
-        let precision = resolve_precision_checked(device)?;
-        check_packed_supported(device, quant_in_graph() && cfg.supports_packed_quant())?;
-        let prefill_mlir = emit_prefill_with(&cfg, false, precision);
-        let prefill_embeddings_mlir = emit_prefill_embeddings_with(&cfg, false, precision);
-        let decode_mlir = emit_decode_ragged_with(&cfg, b_max, false, precision);
+        let precision = effective_precision(device, &cfg)?;
+        let native_qmv = match &cfg {
+            RuntimeConfig::Dense(_) => false,
+            RuntimeConfig::Gemma3n(config) => gemma3n_native_qmv(device, config)?,
+        };
+        let (prefill_mlir, prefill_embeddings_mlir, decode_mlir) = match &cfg {
+            RuntimeConfig::Dense(config) => {
+                check_packed_supported(device, quant_in_graph() && config.supports_packed_quant())?;
+                (
+                    emit_prefill_with(config, false, precision),
+                    emit_prefill_embeddings_with(config, false, precision),
+                    emit_decode_ragged_with(config, b_max, false, precision),
+                )
+            }
+            RuntimeConfig::Gemma3n(config) => (
+                emit_gemma3n_prefill_with_qmv(config, false, precision, native_qmv),
+                emit_gemma3n_prefill_embeddings_ple_with_qmv(config, false, precision, native_qmv),
+                emit_gemma3n_decode_ragged_with_qmv(config, b_max, false, precision, native_qmv),
+            ),
+        };
         let bundle = compile_bundle(
             device,
             &cfg,
+            native_qmv,
             &prefill_mlir,
             "prefill_logits",
             &prefill_embeddings_mlir,
@@ -1010,9 +1761,28 @@ impl IreeRaggedLlama {
             &decode_mlir,
             &format!("decode_ragged_logits_b{b_max}"),
         )?;
+        #[cfg(feature = "diagnostics")]
+        let (diagnostic_vmfb, diagnostic_layout) = if diagnostics || all_layer_diagnostics {
+            let (vmfb, layout) = compile_gemma3n_diagnostics(device, &cfg, all_layer_diagnostics)?;
+            (Some(vmfb), Some(layout))
+        } else {
+            (None, None)
+        };
+        #[cfg(not(feature = "diagnostics"))]
+        debug_assert!(!diagnostics && !all_layer_diagnostics);
+        #[cfg(feature = "diagnostics")]
+        let ctx = create_ctx_with_diagnostics(
+            model_dir,
+            &cfg,
+            device,
+            &bundle,
+            diagnostic_vmfb.as_deref(),
+        )?;
+        #[cfg(not(feature = "diagnostics"))]
         let ctx = create_ctx(model_dir, &cfg, device, &bundle)?;
         // Safety: ctx is a fresh valid context from create_ctx; free it on error.
-        let rc = unsafe { xla_llama_ragged_reset(ctx, b_max as c_int) };
+        let b_max_ffi = checked_ffi_int(b_max, "b_max")?;
+        let rc = unsafe { xla_llama_ragged_reset(ctx, b_max_ffi) };
         if rc != 0 {
             unsafe { xla_llama_free(ctx) };
             return Err(format!("xla_llama_ragged_reset failed (status {rc})"));
@@ -1020,9 +1790,12 @@ impl IreeRaggedLlama {
         Ok(Self {
             ctx,
             b_max,
-            vocab: cfg.vocab,
-            context_capacity: cfg.context_capacity,
-            hidden_size: cfg.hidden,
+            vocab: cfg.vocab(),
+            context_capacity: cfg.context_capacity(),
+            hidden_size: cfg.hidden(),
+            dense_ple_shape: cfg.dense_ple_shape(),
+            #[cfg(feature = "diagnostics")]
+            diagnostic_layout,
         })
     }
 
@@ -1051,6 +1824,73 @@ impl IreeRaggedLlama {
         self.hidden_size
     }
 
+    pub fn validate_gemma3n_dense_ple(&self, dense_ple: &Gemma3nDensePle) -> Result<(), String> {
+        let expected = self.dense_ple_shape.ok_or_else(|| {
+            "dense Gemma3n PLE was submitted to a non-Gemma3n runtime bundle".to_string()
+        })?;
+        if dense_ple.shape() != expected {
+            return Err(format!(
+                "Gemma3n dense PLE shape {:?} does not match runtime bundle {expected:?}",
+                dense_ple.shape()
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "diagnostics")]
+    pub fn diagnostic_layout(&self) -> Result<&Gemma3nDiagnosticLayout, String> {
+        self.diagnostic_layout
+            .as_ref()
+            .ok_or_else(|| "this runtime bundle has no diagnostic module".to_string())
+    }
+
+    #[cfg(feature = "diagnostics")]
+    pub fn prefill_diagnostics_slot(
+        &mut self,
+        slot: usize,
+        prompt: &[i32],
+    ) -> Result<Vec<f32>, String> {
+        validate_slot(slot, self.b_max).map_err(|error| error.to_string())?;
+        if prompt.is_empty() || prompt.len() > self.context_capacity {
+            return Err(format!(
+                "diagnostic prompt length {} is outside 1..={}",
+                prompt.len(),
+                self.context_capacity
+            ));
+        }
+        let layout = self.diagnostic_layout()?.clone();
+        layout.validate()?;
+        let mut tokens = vec![0i32; self.context_capacity];
+        tokens[..prompt.len()].copy_from_slice(prompt);
+        let slot = checked_ffi_int(slot, "slot")?;
+        let capacity = checked_ffi_int(self.context_capacity, "context_capacity")?;
+        let real_len = checked_ffi_int(prompt.len(), "prompt length")?;
+        let positions: Vec<c_int> = (0..capacity).collect();
+        let diagnostic_len = c_int::try_from(layout.total_len)
+            .map_err(|_| "diagnostic output length does not fit c_int".to_string())?;
+        let mut output = vec![0.0f32; layout.total_len];
+        // Safety: every input/output slice has the statically validated length;
+        // the C shim validates the optional module and exact output element count.
+        let rc = unsafe {
+            xla_llama_prefill_diagnostics_slot(
+                self.ctx,
+                slot,
+                tokens.as_ptr(),
+                capacity,
+                positions.as_ptr(),
+                real_len,
+                diagnostic_len,
+                output.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            return Err(format!(
+                "xla_llama_prefill_diagnostics_slot failed (status {rc})"
+            ));
+        }
+        Ok(output)
+    }
+
     /// Seed slot `slot` with `prompt` (up to the configured capacity) and return its
     /// first-token `[vocab]` LOGITS (#449 M3 Stage 2d). The prompt's KV is written
     /// device-side into the slot's region of the rank-5 cache; the other slots are
@@ -1070,19 +1910,23 @@ impl IreeRaggedLlama {
         }
         let mut tokens = vec![0i32; self.context_capacity];
         tokens[..prompt.len()].copy_from_slice(prompt);
-        let positions: Vec<c_int> = (0..self.context_capacity as c_int).collect();
+        let slot = checked_ffi_int(slot, "slot")?;
+        let capacity = checked_ffi_int(self.context_capacity, "context_capacity")?;
+        let real_len = checked_ffi_int(prompt.len(), "prompt length")?;
+        let vocab = checked_ffi_int(self.vocab, "vocab_size")?;
+        let positions: Vec<c_int> = (0..capacity).collect();
         let mut logits = vec![0f32; self.vocab];
         // Safety: input buffers outlive the call; `logits` has self.vocab elements,
         // which the shim fills; the shim also writes the slot's KV device-side.
         let rc = unsafe {
             xla_llama_prefill_slot_logits(
                 self.ctx,
-                slot as c_int,
+                slot,
                 tokens.as_ptr(),
-                self.context_capacity as c_int,
+                capacity,
                 positions.as_ptr(),
-                prompt.len() as c_int,
-                self.vocab as c_int,
+                real_len,
+                vocab,
                 logits.as_mut_ptr(),
             )
         };
@@ -1102,6 +1946,11 @@ impl IreeRaggedLlama {
         slot: usize,
         prepared: &PreparedIreePrefill,
     ) -> Result<Vec<f32>, String> {
+        if self.dense_ple_shape.is_some() {
+            return Err(
+                "Gemma3n requires the distinct embeddings-plus-dense-PLE prefill entry".to_string(),
+            );
+        }
         validate_slot(slot, self.b_max).map_err(|error| error.to_string())?;
         if prepared.hidden_size != self.hidden_size
             || prepared.context_capacity != self.context_capacity
@@ -1115,24 +1964,77 @@ impl IreeRaggedLlama {
         let (embeddings, positions, attention_bias) = prepared_descriptors(prepared)?;
         let real_len = i32::try_from(prepared.effective_len)
             .map_err(|_| "prepared effective length does not fit i32".to_string())?;
+        let slot = checked_ffi_int(slot, "slot")?;
+        let vocab = checked_ffi_int(self.vocab, "vocab_size")?;
         let mut logits = vec![0.0; self.vocab];
         // Safety: descriptors and output buffers outlive the call and carry
         // exact lengths; the shim validates slot/vocab and every descriptor.
         let rc = unsafe {
             xla_llama_prefill_embeddings_slot_logits(
                 self.ctx,
-                slot as c_int,
+                slot,
                 &embeddings,
                 &positions,
                 &attention_bias,
                 real_len,
-                self.vocab as c_int,
+                vocab,
                 logits.as_mut_ptr(),
             )
         };
         if rc != 0 {
             return Err(format!(
                 "xla_llama_prefill_embeddings_slot_logits failed (status {rc})"
+            ));
+        }
+        Ok(logits)
+    }
+
+    /// Seed one Gemma3n batch slot from owned prepared embeddings and dense PLE.
+    pub fn prefill_gemma3n_prepared_slot_logits(
+        &mut self,
+        slot: usize,
+        prepared: &PreparedIreePrefill,
+        dense_ple: &Gemma3nDensePle,
+    ) -> Result<Vec<f32>, String> {
+        validate_slot(slot, self.b_max).map_err(|error| error.to_string())?;
+        let expected = self.dense_ple_shape.ok_or_else(|| {
+            "dense Gemma3n PLE prefill was requested from a non-Gemma3n bundle".to_string()
+        })?;
+        if dense_ple.shape() != expected
+            || prepared.hidden_size != self.hidden_size
+            || prepared.context_capacity != self.context_capacity
+            || prepared.effective_len == 0
+            || prepared.effective_len > self.context_capacity
+        {
+            return Err(
+                "Gemma3n prepared payload is incompatible with this runtime bundle".to_string(),
+            );
+        }
+        let (embeddings, positions, attention_bias) = prepared_descriptors(prepared)?;
+        let dense_ple = dense_ple_descriptor(dense_ple)?;
+        let real_len = i32::try_from(prepared.effective_len)
+            .map_err(|_| "prepared effective length does not fit i32".to_string())?;
+        let slot = checked_ffi_int(slot, "slot")?;
+        let vocab = checked_ffi_int(self.vocab, "vocab_size")?;
+        let mut logits = vec![0.0; self.vocab];
+        // Safety: the typed descriptors and output remain live for the call; the
+        // shim validates the Gemma3n-specific descriptor before device upload.
+        let rc = unsafe {
+            xla_llama_prefill_embeddings_ple_slot_logits(
+                self.ctx,
+                slot,
+                &embeddings,
+                &dense_ple,
+                &positions,
+                &attention_bias,
+                real_len,
+                vocab,
+                logits.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            return Err(format!(
+                "xla_llama_prefill_embeddings_ple_slot_logits failed (status {rc})"
             ));
         }
         Ok(logits)
@@ -1166,16 +2068,18 @@ impl IreeRaggedLlama {
             }
         }
         let mut logits = vec![0f32; self.b_max * self.vocab];
+        let b_max = checked_ffi_int(self.b_max, "b_max")?;
+        let vocab = checked_ffi_int(self.vocab, "vocab_size")?;
         // Safety: the three input slices are length b_max == bsz; `logits` has
         // b_max*self.vocab elements, which the shim fills; it threads its rank-5 KV.
         let rc = unsafe {
             xla_llama_decode_ragged_logits(
                 self.ctx,
-                self.b_max as c_int,
+                b_max,
                 tokens.as_ptr(),
                 pos.as_ptr(),
                 cache_len.as_ptr(),
-                self.vocab as c_int,
+                vocab,
                 logits.as_mut_ptr(),
             )
         };

--- a/src/lib/mlxcel-xla/src/lib.rs
+++ b/src/lib/mlxcel-xla/src/lib.rs
@@ -106,13 +106,43 @@ mod validation;
 
 #[cfg(feature = "iree")]
 pub use batch::{EngineEvent, FinishReason, XlaAdmissionError, XlaBatchEngine, XlaReferenceEngine};
+#[cfg(feature = "diagnostics")]
+pub use batch::{
+    Gemma3nAllLayerDiagnosticRun, Gemma3nCanonicalDiagnosticRun, Gemma3nPrefixDecodeDiagnosticRun,
+    run_gemma3n_all_layer_diagnostics, run_gemma3n_canonical_diagnostics,
+    run_gemma3n_prefix_decode_diagnostic,
+};
 pub use context::{
     CONTEXT_CAPACITY_ENV, ContextCapacityError, DEFAULT_CONTEXT_CAPACITY,
     context_capacity_from_env, validate_request_capacity,
 };
-pub use prepared_gemma3n::{Gemma3nDensePle, Gemma3nDensePleError};
+#[cfg(all(feature = "diagnostics", xla_iree_cuda))]
+pub use emitter::{
+    run_gemma3n_altup_correct_diagnostic_probe, run_gemma3n_altup_predict_diagnostic_probe,
+    run_gemma3n_attention_diagnostic_probe, run_gemma3n_decode_attention_diagnostic_probe,
+    run_gemma3n_dense_mlp_diagnostic_probe, run_gemma3n_initial_altup_diagnostic_probe,
+    run_gemma3n_ple_diagnostic_probe, run_gemma3n_ple_injection_all_planes_diagnostic_probe,
+    run_gemma3n_ple_injection_diagnostic_probe, run_gemma3n_post_attention_diagnostic_probe,
+    run_gemma3n_qmv_diagnostic_probe, run_gemma3n_rms_diagnostic_probe,
+    run_gemma3n_sdpa_vector_context_diagnostic_probe,
+};
+#[cfg(feature = "diagnostics")]
+pub fn dequantize_gemma3n_affine_diagnostic(
+    packed: &[u8],
+    scales: &[u8],
+    biases: &[u8],
+    out: usize,
+    in_packed: usize,
+    bits: usize,
+    group_size: usize,
+) -> Result<Vec<f32>, String> {
+    weights::dequantize_affine_bf16_fused(packed, scales, biases, out, in_packed, bits, group_size)
+}
+#[cfg(feature = "diagnostics")]
+pub use emitter::{Gemma3nDiagnosticLayout, Gemma3nDiagnosticSegment};
 #[cfg(feature = "iree")]
 pub use prepared::PreparedInputError;
+pub use prepared_gemma3n::{Gemma3nDensePle, Gemma3nDensePleError, Gemma3nPreparedPrefill};
 #[cfg(feature = "iree")]
 pub use sampler::SampleParams;
 
@@ -329,6 +359,34 @@ impl XlaInferenceSession {
         Ok(out)
     }
 
+    /// Seed KV from a complete token prompt and return the prefill argmax.
+    ///
+    /// This mirrors the batched slot-seed convention and is distinct from the
+    /// prefix-prefill-plus-decode generation loop.
+    pub fn prefill_first_token(&mut self, prompt_tokens: &[i32]) -> Result<i32, String> {
+        if prompt_tokens.is_empty() {
+            return Err("prefill_first_token requires a non-empty prompt".to_string());
+        }
+        if prompt_tokens.len() > self.context_capacity {
+            return Err(format!(
+                "prefill length {} exceeds context_capacity={}",
+                prompt_tokens.len(),
+                self.context_capacity
+            ));
+        }
+        #[cfg(feature = "iree")]
+        {
+            let first = self.engine.prefill_first(prompt_tokens)?;
+            self.cache_len = i32::try_from(prompt_tokens.len())
+                .map_err(|_| "prefill length does not fit i32".to_string())?;
+            Ok(first)
+        }
+        #[cfg(not(feature = "iree"))]
+        {
+            Err(NOT_WIRED.to_string())
+        }
+    }
+
     /// Greedy generation seeded by an owned prepared-embeddings payload.
     pub fn generate_prepared_greedy(
         &mut self,
@@ -337,6 +395,53 @@ impl XlaInferenceSession {
         eos_token_ids: &[i32],
     ) -> Result<Vec<i32>, String> {
         self.generate_prepared_streaming_greedy(prepared, max_new_tokens, eos_token_ids, |_| true)
+    }
+
+    /// Seed a Gemma3n session through its distinct embeddings-plus-dense-PLE
+    /// entry and return the first generated token.
+    pub fn prefill_gemma3n_prepared(
+        &mut self,
+        request: &Gemma3nPreparedPrefill,
+    ) -> Result<i32, String> {
+        #[cfg(feature = "iree")]
+        {
+            let first = self.engine.prefill_gemma3n_prepared_first(request)?;
+            self.cache_len = i32::try_from(request.prepared().sequence_len)
+                .map_err(|_| "prepared sequence length does not fit i32".to_string())?;
+            Ok(first)
+        }
+        #[cfg(not(feature = "iree"))]
+        {
+            let _ = request;
+            Err(NOT_WIRED.to_string())
+        }
+    }
+
+    /// Greedy generation seeded by Gemma3n post-scale embeddings and dense PLE.
+    pub fn generate_gemma3n_prepared_greedy(
+        &mut self,
+        request: &Gemma3nPreparedPrefill,
+        max_new_tokens: usize,
+        eos_token_ids: &[i32],
+    ) -> Result<Vec<i32>, String> {
+        if max_new_tokens == 0 {
+            return Ok(Vec::new());
+        }
+        validate_request_capacity(
+            request.prepared().sequence_len,
+            max_new_tokens,
+            self.context_capacity,
+        )
+        .map_err(|error| error.to_string())?;
+        let first = self.prefill_gemma3n_prepared(request)?;
+        let mut out = Vec::with_capacity(max_new_tokens);
+        out.push(first);
+        let mut current = first;
+        while out.len() < max_new_tokens && !eos_token_ids.contains(&current) {
+            current = self.decode_step(current)?;
+            out.push(current);
+        }
+        Ok(out)
     }
 
     /// Streaming greedy generation from prepared embeddings. The embeddings

--- a/src/lib/mlxcel-xla/src/lib.rs
+++ b/src/lib/mlxcel-xla/src/lib.rs
@@ -53,6 +53,7 @@ mod context;
 #[cfg(any(feature = "iree", test))]
 #[cfg_attr(not(feature = "iree"), allow(dead_code))]
 mod prepared;
+mod prepared_gemma3n;
 
 #[cfg(feature = "iree")]
 mod iree;
@@ -109,6 +110,7 @@ pub use context::{
     CONTEXT_CAPACITY_ENV, ContextCapacityError, DEFAULT_CONTEXT_CAPACITY,
     context_capacity_from_env, validate_request_capacity,
 };
+pub use prepared_gemma3n::{Gemma3nDensePle, Gemma3nDensePleError};
 #[cfg(feature = "iree")]
 pub use prepared::PreparedInputError;
 #[cfg(feature = "iree")]

--- a/src/lib/mlxcel-xla/src/prepared_gemma3n.rs
+++ b/src/lib/mlxcel-xla/src/prepared_gemma3n.rs
@@ -6,11 +6,22 @@
 
 use std::fmt;
 
+use mlxcel_core::session::PreparedPrefill;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Gemma3nDensePleError {
     ZeroDimension(&'static str),
     ElementCountOverflow,
-    LengthMismatch { actual: usize, expected: usize },
+    LengthMismatch {
+        actual: usize,
+        expected: usize,
+    },
+    SequenceCapacity {
+        sequence_len: usize,
+        capacity: usize,
+    },
+    NonFinite,
+    NonZeroPadding,
 }
 
 impl fmt::Display for Gemma3nDensePleError {
@@ -22,6 +33,17 @@ impl fmt::Display for Gemma3nDensePleError {
                 f,
                 "Gemma3n dense PLE has {actual} f32 elements; expected exactly {expected}"
             ),
+            Self::SequenceCapacity {
+                sequence_len,
+                capacity,
+            } => write!(
+                f,
+                "Gemma3n prepared sequence length {sequence_len} exceeds dense PLE capacity {capacity}"
+            ),
+            Self::NonFinite => f.write_str("Gemma3n dense PLE contains a non-finite value"),
+            Self::NonZeroPadding => {
+                f.write_str("Gemma3n dense PLE rows after sequence_len must be explicit zeros")
+            }
         }
     }
 }
@@ -67,6 +89,9 @@ impl Gemma3nDensePle {
                 expected,
             });
         }
+        if values.iter().any(|value| !value.is_finite()) {
+            return Err(Gemma3nDensePleError::NonFinite);
+        }
         Ok(Self {
             values,
             capacity,
@@ -93,6 +118,66 @@ impl Gemma3nDensePle {
     pub fn into_values(self) -> Vec<f32> {
         self.values
     }
+
+    fn validate_sequence(&self, sequence_len: usize) -> Result<(), Gemma3nDensePleError> {
+        if sequence_len > self.capacity {
+            return Err(Gemma3nDensePleError::SequenceCapacity {
+                sequence_len,
+                capacity: self.capacity,
+            });
+        }
+        let row_width = self
+            .layers
+            .checked_mul(self.hidden_per_layer)
+            .ok_or(Gemma3nDensePleError::ElementCountOverflow)?;
+        if self.values[sequence_len * row_width..]
+            .iter()
+            .any(|value| *value != 0.0)
+        {
+            return Err(Gemma3nDensePleError::NonZeroPadding);
+        }
+        Ok(())
+    }
+}
+
+/// An owned Gemma3n multimodal prefill request.
+///
+/// The ordinary prepared-embeddings schema remains unchanged. Gemma3n callers
+/// opt into this separate request type, which couples post-scale merged
+/// embeddings with the dense projected PLE rows consumed by
+/// `prefill_embeddings_ple.main`.
+#[derive(Clone, Debug)]
+pub struct Gemma3nPreparedPrefill {
+    prepared: PreparedPrefill,
+    dense_ple: Gemma3nDensePle,
+}
+
+impl Gemma3nPreparedPrefill {
+    pub fn new(
+        prepared: PreparedPrefill,
+        dense_ple: Gemma3nDensePle,
+    ) -> Result<Self, Gemma3nDensePleError> {
+        dense_ple.validate_sequence(prepared.sequence_len)?;
+        Ok(Self {
+            prepared,
+            dense_ple,
+        })
+    }
+
+    #[must_use]
+    pub fn prepared(&self) -> &PreparedPrefill {
+        &self.prepared
+    }
+
+    #[must_use]
+    pub fn dense_ple(&self) -> &Gemma3nDensePle {
+        &self.dense_ple
+    }
+
+    #[cfg(feature = "iree")]
+    pub(crate) fn into_parts(self) -> (PreparedPrefill, Gemma3nDensePle) {
+        (self.prepared, self.dense_ple)
+    }
 }
 
 #[cfg(test)]
@@ -113,6 +198,41 @@ mod tests {
         let ple = Gemma3nDensePle::new(vec![0.0; 24], 2, 3, 4).unwrap();
         assert_eq!(ple.shape(), [2, 3, 4]);
         assert_eq!(ple.byte_len(), 96);
+    }
+
+    #[test]
+    fn prepared_request_rejects_nonzero_padding() {
+        use mlxcel_core::session::{
+            OwnedTensor, PreparedAttentionBias, PreparedPositions, PreparedTensorDType,
+        };
+
+        let tensor = |shape: Vec<usize>, values: Vec<f32>| {
+            OwnedTensor::new(
+                values.into_iter().flat_map(f32::to_le_bytes).collect(),
+                PreparedTensorDType::Float32,
+                shape,
+            )
+            .unwrap()
+        };
+        let prepared = PreparedPrefill::new(
+            vec![1],
+            tensor(vec![1, 1, 2], vec![0.0; 2]),
+            PreparedPositions::Sequential {
+                start: 0,
+                length: 1,
+            },
+            PreparedAttentionBias {
+                tensor: tensor(vec![1], vec![0.0]),
+                causal: true,
+            },
+            Vec::new(),
+        )
+        .unwrap();
+        let ple = Gemma3nDensePle::new(vec![0.0, 0.0, 1.0, 0.0], 2, 1, 2).unwrap();
+        assert_eq!(
+            Gemma3nPreparedPrefill::new(prepared, ple).unwrap_err(),
+            Gemma3nDensePleError::NonZeroPadding
+        );
     }
 
     #[test]

--- a/src/lib/mlxcel-xla/src/prepared_gemma3n.rs
+++ b/src/lib/mlxcel-xla/src/prepared_gemma3n.rs
@@ -1,0 +1,136 @@
+//! Owned dense per-layer embeddings for Gemma3n prepared prefill.
+//!
+//! The scheduler keeps this value in the pending request.  Its `Vec<f32>`
+//! ownership makes normal completion, admission rejection, and cancellation all
+//! release the potentially large PLE allocation through the same drop path.
+
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Gemma3nDensePleError {
+    ZeroDimension(&'static str),
+    ElementCountOverflow,
+    LengthMismatch { actual: usize, expected: usize },
+}
+
+impl fmt::Display for Gemma3nDensePleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ZeroDimension(name) => write!(f, "Gemma3n dense PLE {name} must be nonzero"),
+            Self::ElementCountOverflow => write!(f, "Gemma3n dense PLE element count overflows"),
+            Self::LengthMismatch { actual, expected } => write!(
+                f,
+                "Gemma3n dense PLE has {actual} f32 elements; expected exactly {expected}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Gemma3nDensePleError {}
+
+/// Dense projected per-layer embeddings with canonical `[capacity, layers,
+/// hidden_per_layer]` row-major layout.
+///
+/// Construction is exact: callers must explicitly pad to `capacity`; this type
+/// never truncates a longer payload or silently adds zero rows.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Gemma3nDensePle {
+    values: Vec<f32>,
+    capacity: usize,
+    layers: usize,
+    hidden_per_layer: usize,
+}
+
+impl Gemma3nDensePle {
+    pub fn new(
+        values: Vec<f32>,
+        capacity: usize,
+        layers: usize,
+        hidden_per_layer: usize,
+    ) -> Result<Self, Gemma3nDensePleError> {
+        for (name, value) in [
+            ("capacity", capacity),
+            ("layer count", layers),
+            ("hidden width", hidden_per_layer),
+        ] {
+            if value == 0 {
+                return Err(Gemma3nDensePleError::ZeroDimension(name));
+            }
+        }
+        let expected = capacity
+            .checked_mul(layers)
+            .and_then(|v| v.checked_mul(hidden_per_layer))
+            .ok_or(Gemma3nDensePleError::ElementCountOverflow)?;
+        if values.len() != expected {
+            return Err(Gemma3nDensePleError::LengthMismatch {
+                actual: values.len(),
+                expected,
+            });
+        }
+        Ok(Self {
+            values,
+            capacity,
+            layers,
+            hidden_per_layer,
+        })
+    }
+
+    #[must_use]
+    pub fn shape(&self) -> [usize; 3] {
+        [self.capacity, self.layers, self.hidden_per_layer]
+    }
+
+    #[must_use]
+    pub fn byte_len(&self) -> usize {
+        self.values.len() * std::mem::size_of::<f32>()
+    }
+
+    #[must_use]
+    pub fn as_slice(&self) -> &[f32] {
+        &self.values
+    }
+
+    pub fn into_values(self) -> Vec<f32> {
+        self.values
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Weak};
+
+    #[test]
+    fn dense_ple_rejects_truncation_and_implicit_padding() {
+        let err = Gemma3nDensePle::new(vec![0.0; 23], 2, 3, 4).unwrap_err();
+        assert_eq!(
+            err,
+            Gemma3nDensePleError::LengthMismatch {
+                actual: 23,
+                expected: 24
+            }
+        );
+        let ple = Gemma3nDensePle::new(vec![0.0; 24], 2, 3, 4).unwrap();
+        assert_eq!(ple.shape(), [2, 3, 4]);
+        assert_eq!(ple.byte_len(), 96);
+    }
+
+    #[test]
+    fn pending_owner_drop_releases_dense_ple_on_cancel() {
+        struct Pending {
+            _ple: Gemma3nDensePle,
+            _lifetime: Arc<()>,
+        }
+        let lifetime = Arc::new(());
+        let weak: Weak<()> = Arc::downgrade(&lifetime);
+        let pending = Pending {
+            _ple: Gemma3nDensePle::new(vec![0.0; 8], 1, 2, 4).unwrap(),
+            _lifetime: lifetime,
+        };
+        drop(pending);
+        assert!(
+            weak.upgrade().is_none(),
+            "cancel must drop pending PLE owner"
+        );
+    }
+}

--- a/src/lib/mlxcel-xla/src/weight_names.rs
+++ b/src/lib/mlxcel-xla/src/weight_names.rs
@@ -158,6 +158,7 @@ pub(crate) fn scheme_names(scheme: WeightScheme) -> SchemeNames {
 /// conditional `input_layernorm`, the q/k/v biases, the q/k norms, the feed-forward
 /// norms, the #498 biases) come from that one place. A fused (Phi3) checkpoint
 /// lists its fused tensor once per arg that row-slices it.
+#[allow(dead_code)]
 pub(crate) fn weight_names(cfg: &Config) -> Vec<String> {
     crate::weights::weight_specs(cfg)
         .iter()

--- a/src/lib/mlxcel-xla/src/weights.rs
+++ b/src/lib/mlxcel-xla/src/weights.rs
@@ -340,6 +340,18 @@ pub(crate) fn bf16_to_f32(bytes: &[u8]) -> Vec<f32> {
         .collect()
 }
 
+/// Round one f32 value to BF16 using round-to-nearest, ties-to-even, then widen
+/// it back to an f32 carrier.
+#[inline]
+pub(crate) fn round_bf16_f32(value: f32) -> f32 {
+    let bits = value.to_bits();
+    if bits & 0x7f80_0000 == 0x7f80_0000 {
+        return value;
+    }
+    let rounded = bits.wrapping_add(0x7fff + ((bits >> 16) & 1));
+    f32::from_bits(rounded & 0xffff_0000)
+}
+
 /// One IEEE 754 half (f16) -> f32. The arithmetic forms are exact: a normal's
 /// `1 + mant/1024` is a dyadic with denominator 2^10 and the `2^(exp-15)` / `2^-24`
 /// scales are exact powers of two, so the widening is bit-for-bit.
@@ -508,6 +520,102 @@ pub(crate) fn dequantize_affine(
         }
     }
     Ok(w)
+}
+
+/// Gemma3n's MLX CUDA affine-dequant kernel evaluates `scale * q + bias` as a
+/// fused expression and rounds the result once to the BF16 scales dtype.
+/// Preserve those BF16 values in f32 carriers for the public IREE graph ABI.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn dequantize_affine_bf16_fused(
+    packed: &[u8],
+    scales: &[u8],
+    biases: &[u8],
+    out: usize,
+    in_packed: usize,
+    bits: usize,
+    group_size: usize,
+) -> Result<Vec<f32>, String> {
+    if !(bits == 4 || bits == 8) {
+        return Err(format!(
+            "unsupported quantization bits {bits} (expected 4 or 8)"
+        ));
+    }
+    let per_u32 = 32 / bits;
+    let in_ = in_packed * per_u32;
+    if group_size == 0 || !in_.is_multiple_of(group_size) {
+        return Err(format!(
+            "quantization group_size {group_size} does not divide in dimension {in_}"
+        ));
+    }
+    let n_groups = in_ / group_size;
+    if packed.len() != out * in_packed * 4 {
+        return Err(format!(
+            "packed weight is {} bytes, expected {} ([{out}, {in_packed}] u32)",
+            packed.len(),
+            out * in_packed * 4
+        ));
+    }
+    let scales = bf16_to_f32(scales);
+    let biases = bf16_to_f32(biases);
+    if scales.len() != out * n_groups || biases.len() != out * n_groups {
+        return Err(format!(
+            "scales/biases have {}/{} elements, expected {} ([{out}, {n_groups}])",
+            scales.len(),
+            biases.len(),
+            out * n_groups
+        ));
+    }
+    let mask = (1u32 << bits) - 1;
+    let mut weights = vec![0.0; out * in_];
+    if bits == 4 {
+        // Reuse one LUT bank across all output rows. The embedding table has
+        // hundreds of thousands of rows, so allocating it inside this loop
+        // would erase most of the fused-arithmetic speedup.
+        let mut luts = vec![[0.0f32; 16]; n_groups];
+        for output in 0..out {
+            let row = &packed[output * in_packed * 4..(output + 1) * in_packed * 4];
+            let group_row = output * n_groups;
+            let weight_row = output * in_;
+            // A Gemma3n E2B group has 64 lanes but only 16 possible nibble
+            // values. Compute the fused BF16 affine result once per value and
+            // group, then decode the packed row through the tiny hot LUT.
+            for (group_index, lut) in luts.iter_mut().enumerate() {
+                let group = group_row + group_index;
+                for (quantized, value) in lut.iter_mut().enumerate() {
+                    *value = round_bf16_f32(quantized as f32 * scales[group] + biases[group]);
+                }
+            }
+            for packed_index in 0..in_packed {
+                let offset = packed_index * 4;
+                let word = u32::from_le_bytes(row[offset..offset + 4].try_into().unwrap());
+                for lane in 0..per_u32 {
+                    let input = packed_index * per_u32 + lane;
+                    let quantized = ((word >> (bits * lane)) & mask) as usize;
+                    weights[weight_row + input] = luts[input / group_size][quantized];
+                }
+            }
+        }
+    } else {
+        // A 256-entry table can cost more than the usual 8-bit group saves, so
+        // retain the direct fused-round calculation for uncommon 8-bit checkpoints.
+        for output in 0..out {
+            let row = &packed[output * in_packed * 4..(output + 1) * in_packed * 4];
+            let group_row = output * n_groups;
+            let weight_row = output * in_;
+            for packed_index in 0..in_packed {
+                let offset = packed_index * 4;
+                let word = u32::from_le_bytes(row[offset..offset + 4].try_into().unwrap());
+                for lane in 0..per_u32 {
+                    let input = packed_index * per_u32 + lane;
+                    let quantized = ((word >> (bits * lane)) & mask) as f32;
+                    let group = group_row + input / group_size;
+                    weights[weight_row + input] =
+                        round_bf16_f32(quantized * scales[group] + biases[group]);
+                }
+            }
+        }
+    }
+    Ok(weights)
 }
 
 /// Dequantize a STACKED mlx-lm affine-quantized expert weight (issue #500) to
@@ -877,6 +985,42 @@ mod tests {
         let biases = [0x20u8, 0x41, 0x80, 0xBF]; // bf16 [10.0, -1.0]
         let w = dequantize_affine(&packed, &scales, &biases, 1, 1, 4, 4, true).unwrap();
         assert_eq!(w, vec![12.0, 14.0, 16.0, 18.0, 1.5, 2.0, 2.5, 3.0]);
+    }
+
+    #[test]
+    fn gemma3n_bf16_affine_fuses_multiply_and_bias_before_rounding() {
+        // Low nibble q=9 with the actual E2B token-2 embedding group values.
+        let packed = 9u32.to_le_bytes();
+        let scale = 0xbbfb_u16.to_le_bytes();
+        let bias = 0x3d7b_u16.to_le_bytes();
+        let fused = dequantize_affine_bf16_fused(&packed, &scale, &bias, 1, 1, 4, 8).unwrap();
+        assert_eq!(fused[0], -0.007_659_912);
+        let ordinary = dequantize_affine(&packed, &scale, &bias, 1, 1, 4, 8, true).unwrap();
+        assert_eq!(fused, ordinary);
+    }
+
+    #[test]
+    fn gemma3n_bf16_affine_lut_matches_scalar_reference_across_groups() {
+        let packed = [0x21u8, 0x43, 0x65, 0x87];
+        let scale_values = [f32::from_bits(0xbbfb_0000), f32::from_bits(0x3b7c_0000)];
+        let bias_values = [f32::from_bits(0x3d7b_0000), f32::from_bits(0xbd00_0000)];
+        let bf16_bytes = |values: &[f32]| {
+            values
+                .iter()
+                .flat_map(|value| (((*value).to_bits() >> 16) as u16).to_le_bytes())
+                .collect::<Vec<_>>()
+        };
+        let scales = bf16_bytes(&scale_values);
+        let biases = bf16_bytes(&bias_values);
+        let got = dequantize_affine_bf16_fused(&packed, &scales, &biases, 1, 1, 4, 4).unwrap();
+        let expected = (1..=8)
+            .enumerate()
+            .map(|(input, quantized)| {
+                let group = input / 4;
+                round_bf16_f32(quantized as f32 * scale_values[group] + bias_values[group])
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(got, expected);
     }
 
     /// 8-bit affine dequant: one u32 packs four bytes 10/20/30/40 (low-order

--- a/src/models/gemma3n.rs
+++ b/src/models/gemma3n.rs
@@ -897,6 +897,40 @@ pub struct DecoderLayer {
     pub altup_correct_scale: bool,
 }
 
+struct DecoderLayerForward {
+    planes: Vec<UniquePtr<MlxArray>>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    laurel_output: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    corrected_active: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    ple_scaled_active: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    ple_gate: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    ple_activated: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    ple_projected: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    ple_injected: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    ple_residual: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    ple_residual_updated: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    ple_residuals: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    ple_residuals_updated: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    altup_predicted: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    altup_predicted_active: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    altup_activated: UniquePtr<MlxArray>,
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    altup_corrected: UniquePtr<MlxArray>,
+}
+
 impl DecoderLayer {
     pub fn forward(
         &self,
@@ -908,6 +942,22 @@ impl DecoderLayer {
         // The stacked AltUp path (added in #60) speeds up decode on non-NA
         // Apple Silicon but regresses M5-class hardware. Dispatch to the split
         // path on NA hardware; keep the stacked path elsewhere.
+        let traced = if use_fused_decode_path() {
+            self.forward_stacked(x, mask, cache, per_layer_input)
+        } else {
+            self.forward_split(x, mask, cache, per_layer_input)
+        };
+        traced.planes
+    }
+
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    fn forward_diagnostics(
+        &self,
+        x: &[UniquePtr<MlxArray>],
+        mask: Option<&MlxArray>,
+        cache: &mut KVCache,
+        per_layer_input: &MlxArray,
+    ) -> DecoderLayerForward {
         if use_fused_decode_path() {
             self.forward_stacked(x, mask, cache, per_layer_input)
         } else {
@@ -924,12 +974,16 @@ impl DecoderLayer {
         mask: Option<&MlxArray>,
         cache: &mut KVCache,
         per_layer_input: &MlxArray,
-    ) -> Vec<UniquePtr<MlxArray>> {
+    ) -> DecoderLayerForward {
         // AltUp predict. Keep the prediction tensor stacked until correction
         // so decode avoids slicing four planes and stacking them again within
         // the same layer.
         let predictions = self.altup.predict_stacked(x);
         let active_prediction = slice_altup_plane(&predictions, self.altup_active_idx);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let altup_predicted = mlxcel_core::copy(&predictions);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let altup_predicted_active = mlxcel_core::copy(&active_prediction);
 
         // Input layernorm
         let active_normed = self.input_layernorm.forward(&active_prediction);
@@ -953,31 +1007,92 @@ impl DecoderLayer {
         let ffw_norm = self.post_feedforward_layernorm.forward(&ffw);
         let ffw_gated = mlxcel_core::add(&attn_laurel, &ffw_norm);
         let ffw_gated = mlxcel_core::astype(&ffw_gated, mlxcel_core::dtype::BFLOAT16);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let altup_activated = mlxcel_core::copy(&ffw_gated);
 
         // AltUp correct
         let corrected = self
             .altup
             .correct_stacked(&predictions, &active_prediction, &ffw_gated);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let altup_corrected = mlxcel_core::copy(&corrected);
 
         // Per-layer input processing
         let first = slice_altup_plane(&corrected, self.altup_active_idx);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let corrected_active = mlxcel_core::copy(&first);
         let first = if self.altup_correct_scale {
             mlxcel_core::multiply(&first, &self.altup.correct_output_scale)
         } else {
             first
         };
 
-        let first = self.per_layer_input_gate.forward(&first);
-        let first = mlxcel_core::compiled_geglu_approx_activation(&first, per_layer_input);
-        let first = self.per_layer_projection.forward(&first);
-        let first_prediction = self.post_per_layer_input_norm.forward(&first);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_scaled_active = mlxcel_core::copy(&first);
+        let ple_gate_value = self.per_layer_input_gate.forward(&first);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_gate = mlxcel_core::copy(&ple_gate_value);
+        let ple_activated_value =
+            mlxcel_core::compiled_geglu_approx_activation(&ple_gate_value, per_layer_input);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_activated = mlxcel_core::copy(&ple_activated_value);
+        let ple_projected_value = self.per_layer_projection.forward(&ple_activated_value);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_projected = mlxcel_core::copy(&ple_projected_value);
+        let first_prediction = self.post_per_layer_input_norm.forward(&ple_projected_value);
 
         // Add first_prediction to corrected[1:] and split for the next layer.
-        split_altup_after_per_layer_update(
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_residual = slice_altup_plane(&corrected, 1);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_residuals = {
+            let residuals = (1..self.altup.altup_num_inputs)
+                .map(|plane| slice_altup_plane(&corrected, plane))
+                .collect::<Vec<_>>();
+            stack_arrays(&residuals, 0)
+        };
+        let planes = split_altup_after_per_layer_update(
             &corrected,
             &first_prediction,
             self.altup.altup_num_inputs,
-        )
+        );
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_residual_updated = mlxcel_core::copy(&planes[1]);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_residuals_updated = stack_arrays(&planes[1..], 0);
+        DecoderLayerForward {
+            planes,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            laurel_output,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            corrected_active,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_scaled_active,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_gate,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_activated,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_projected,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_injected: first_prediction,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_residual,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_residual_updated,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_residuals,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_residuals_updated,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            altup_predicted,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            altup_predicted_active,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            altup_activated,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            altup_corrected,
+        }
     }
 
     /// Split-path layer forward (the path before #60's fused path):
@@ -989,10 +1104,14 @@ impl DecoderLayer {
         mask: Option<&MlxArray>,
         cache: &mut KVCache,
         per_layer_input: &MlxArray,
-    ) -> Vec<UniquePtr<MlxArray>> {
+    ) -> DecoderLayerForward {
         // AltUp predict
         let predictions = self.altup.predict(x);
         let active_prediction = &predictions[self.altup_active_idx];
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let altup_predicted = stack_arrays(&predictions, 0);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let altup_predicted_active = mlxcel_core::copy(active_prediction);
 
         // Input layernorm
         let active_normed = self.input_layernorm.forward(active_prediction);
@@ -1016,24 +1135,43 @@ impl DecoderLayer {
         let ffw_norm = self.post_feedforward_layernorm.forward(&ffw);
         let ffw_gated = mlxcel_core::add(&attn_laurel, &ffw_norm);
         let ffw_gated = mlxcel_core::astype(&ffw_gated, mlxcel_core::dtype::BFLOAT16);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let altup_activated = mlxcel_core::copy(&ffw_gated);
 
         // AltUp correct
         let corrected = self.altup.correct(&predictions, &ffw_gated);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let altup_corrected = stack_arrays(&corrected, 0);
 
         // Per-layer input processing
         let first = &corrected[self.altup_active_idx];
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let corrected_active = mlxcel_core::copy(first);
         let first = if self.altup_correct_scale {
             mlxcel_core::multiply(first, &self.altup.correct_output_scale)
         } else {
             mlxcel_core::copy(first)
         };
 
-        let first = self.per_layer_input_gate.forward(&first);
-        let first = mlxcel_core::compiled_geglu_approx_activation(&first, per_layer_input);
-        let first = self.per_layer_projection.forward(&first);
-        let first_prediction = self.post_per_layer_input_norm.forward(&first);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_scaled_active = mlxcel_core::copy(&first);
+        let ple_gate_value = self.per_layer_input_gate.forward(&first);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_gate = mlxcel_core::copy(&ple_gate_value);
+        let ple_activated_value =
+            mlxcel_core::compiled_geglu_approx_activation(&ple_gate_value, per_layer_input);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_activated = mlxcel_core::copy(&ple_activated_value);
+        let ple_projected_value = self.per_layer_projection.forward(&ple_activated_value);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_projected = mlxcel_core::copy(&ple_projected_value);
+        let first_prediction = self.post_per_layer_input_norm.forward(&ple_projected_value);
 
         // Add first_prediction to corrected[1:].
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_residual = mlxcel_core::copy(&corrected[1]);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_residuals = stack_arrays(&corrected[1..], 0);
         let mut result = Vec::with_capacity(corrected.len());
         let mut corrected = corrected.into_iter();
         if let Some(first) = corrected.next() {
@@ -1042,8 +1180,44 @@ impl DecoderLayer {
         for item in corrected {
             result.push(mlxcel_core::add(&item, &first_prediction));
         }
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_residual_updated = mlxcel_core::copy(&result[1]);
+        #[cfg(all(test, feature = "xla-diagnostics"))]
+        let ple_residuals_updated = stack_arrays(&result[1..], 0);
 
-        result
+        DecoderLayerForward {
+            planes: result,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            laurel_output,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            corrected_active,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_scaled_active,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_gate,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_activated,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_projected,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_injected: first_prediction,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_residual,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_residual_updated,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_residuals,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            ple_residuals_updated,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            altup_predicted,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            altup_predicted_active,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            altup_activated,
+            #[cfg(all(test, feature = "xla-diagnostics"))]
+            altup_corrected,
+        }
     }
 
     pub fn from_weights(
@@ -1158,6 +1332,26 @@ pub struct Gemma3nLanguageModel {
     pub first_full_idx: usize,
 }
 
+#[cfg(all(test, feature = "xla-diagnostics"))]
+struct Gemma3nMlxDiagnostics {
+    scaled_embeddings: UniquePtr<MlxArray>,
+    projected_ple: UniquePtr<MlxArray>,
+    layer0_laurel: UniquePtr<MlxArray>,
+    layer0_ple_injected: UniquePtr<MlxArray>,
+    layer0_all_planes: UniquePtr<MlxArray>,
+    layer0_active_plane: UniquePtr<MlxArray>,
+    layer_mid_all_planes: UniquePtr<MlxArray>,
+    layer_mid_active_plane: UniquePtr<MlxArray>,
+    layer_last_all_planes: UniquePtr<MlxArray>,
+    layer_last_active_plane: UniquePtr<MlxArray>,
+    all_layer_all_planes: Vec<UniquePtr<MlxArray>>,
+    all_layer_active_planes: Vec<UniquePtr<MlxArray>>,
+    layer0_k: UniquePtr<MlxArray>,
+    layer0_v: UniquePtr<MlxArray>,
+    final_hidden: UniquePtr<MlxArray>,
+    logits: UniquePtr<MlxArray>,
+}
+
 impl Gemma3nLanguageModel {
     fn pretranspose_large_m5_embedding(
         embedding: &UnifiedEmbedding,
@@ -1179,6 +1373,145 @@ impl Gemma3nLanguageModel {
         match &self.embed_tokens_weight_t {
             Some(weight_t) => mlxcel_core::matmul(out, weight_t),
             None => self.embed_tokens.as_linear(out),
+        }
+    }
+
+    #[cfg(all(test, feature = "xla-diagnostics"))]
+    fn forward_diagnostics(
+        &self,
+        inputs: &MlxArray,
+        caches: &mut [KVCache],
+    ) -> Gemma3nMlxDiagnostics {
+        let scaled_embeddings = self.get_embed_tokens(inputs);
+        let token_ple = self.get_per_layer_inputs(inputs);
+        let projected_ple = self.project_per_layer_inputs(&scaled_embeddings, &token_ple);
+        let shape = mlxcel_core::array_shape(&scaled_embeddings);
+        let b = shape[0];
+        let l = shape[1];
+        let global_live_len = caches[self.first_full_idx].live_len();
+        let sliding_live_len = caches[self.first_sliding_idx].live_len();
+        let global_mask = (l > 1).then(|| create_causal_mask(l, global_live_len));
+        let sliding_mask = (l > 1).then(|| {
+            create_sliding_window_prefill_mask_dense(
+                l,
+                sliding_live_len,
+                self.config.sliding_window as i32,
+            )
+        });
+
+        let target_magnitude = compute_magnitude(&scaled_embeddings);
+        let mut planes = vec![mlxcel_core::copy(&scaled_embeddings)];
+        for projection in &self.altup_projections {
+            planes.push(projection.forward(&scaled_embeddings));
+        }
+        normalize_magnitudes(&mut planes, &target_magnitude);
+
+        let mut layer0_all_planes = None;
+        let mut layer0_active_plane = None;
+        let mut layer0_laurel = None;
+        let mut layer0_ple_injected = None;
+        let mut layer_mid_all_planes = None;
+        let mut layer_mid_active_plane = None;
+        let mut layer_last_all_planes = None;
+        let mut layer_last_active_plane = None;
+        let mut all_layer_all_planes = Vec::with_capacity(self.layers.len());
+        let mut all_layer_active_planes = Vec::with_capacity(self.layers.len());
+        let mut layer0_k = None;
+        let mut layer0_v = None;
+        for (layer_index, layer) in self.layers.iter().enumerate() {
+            let cache_index = self.layer_idx_to_cache_idx[layer_index];
+            let mask = if self.config.layer_types[layer_index] == "full_attention" {
+                global_mask.as_ref()
+            } else {
+                sliding_mask.as_ref()
+            };
+            let per_layer_input = slice_layer_input(
+                &projected_ple,
+                layer_index as i32,
+                b,
+                l,
+                self.config.hidden_size_per_layer_input as i32,
+            );
+            let traced = layer.forward_diagnostics(
+                &planes,
+                mask.map(|value| value.as_ref().unwrap()),
+                &mut caches[cache_index],
+                &per_layer_input,
+            );
+            planes = traced.planes;
+            all_layer_all_planes.push(stack_arrays(&planes, 0));
+            all_layer_active_planes.push(mlxcel_core::copy(&planes[self.config.altup_active_idx]));
+            if layer_index == 0 {
+                assert_eq!(
+                    cache_index, 0,
+                    "pinned Gemma3n layer0 must map to concrete physical cache0"
+                );
+                layer0_all_planes = Some(stack_arrays(&planes, 0));
+                layer0_active_plane =
+                    Some(mlxcel_core::copy(&planes[self.config.altup_active_idx]));
+                layer0_laurel = Some(traced.laurel_output);
+                layer0_ple_injected = Some(traced.ple_injected);
+                layer0_k = Some(mlxcel_core::copy(
+                    caches[cache_index]
+                        .keys
+                        .as_ref()
+                        .expect("layer0 concrete K cache"),
+                ));
+                layer0_v = Some(mlxcel_core::copy(
+                    caches[cache_index]
+                        .values
+                        .as_ref()
+                        .expect("layer0 concrete V cache"),
+                ));
+            }
+            if layer_index == self.layers.len() / 2 {
+                layer_mid_all_planes = Some(stack_arrays(&planes, 0));
+                layer_mid_active_plane =
+                    Some(mlxcel_core::copy(&planes[self.config.altup_active_idx]));
+            }
+            if layer_index + 1 == self.layers.len() {
+                layer_last_all_planes = Some(stack_arrays(&planes, 0));
+                layer_last_active_plane =
+                    Some(mlxcel_core::copy(&planes[self.config.altup_active_idx]));
+            }
+        }
+
+        let target_magnitude = compute_magnitude(&planes[0]);
+        for (index, projection) in self.altup_unembed_projections.iter().enumerate() {
+            planes[index + 1] = projection.forward(&planes[index + 1]);
+        }
+        normalize_magnitudes_from_idx(&mut planes, 1, &target_magnitude);
+        let collapsed = mean_arrays(&planes);
+        let final_hidden = self.norm.forward(&collapsed);
+        let final_hidden = if self.embed_tokens.is_quantized() {
+            final_hidden
+        } else {
+            mlxcel_core::astype(
+                &final_hidden,
+                mlxcel_core::array_dtype(self.embed_tokens.weight()),
+            )
+        };
+        let mut logits = self.lm_head(&final_hidden);
+        if let Some(cap) = self.config.final_logit_softcapping {
+            logits = apply_softcap(&logits, cap);
+        }
+        Gemma3nMlxDiagnostics {
+            scaled_embeddings,
+            projected_ple,
+            layer0_laurel: layer0_laurel.expect("layer0 LAUREL"),
+            layer0_ple_injected: layer0_ple_injected.expect("layer0 PLE injection"),
+            layer0_all_planes: layer0_all_planes.expect("layer0 planes"),
+            layer0_active_plane: layer0_active_plane.expect("layer0 active plane"),
+            layer_mid_all_planes: layer_mid_all_planes.expect("middle-layer planes"),
+            layer_mid_active_plane: layer_mid_active_plane.expect("middle-layer active plane"),
+            layer_last_all_planes: layer_last_all_planes.expect("last-layer planes"),
+            layer_last_active_plane: layer_last_active_plane.expect("last-layer active plane"),
+            all_layer_all_planes,
+            all_layer_active_planes,
+            layer0_k: layer0_k.expect("layer0 K"),
+            layer0_v: layer0_v.expect("layer0 V"),
+            final_hidden,
+            logits,
         }
     }
 
@@ -1695,6 +2028,3346 @@ impl LanguageModel for Gemma3nModel {
     /// dedicated investigation clears it.
     fn supports_chunked_prefill(&self) -> bool {
         false
+    }
+}
+
+#[cfg(all(test, feature = "xla-diagnostics"))]
+mod xla_canonical_diagnostics {
+    use super::*;
+    use crate::loaded_model::LoadedModel;
+    use mlxcel_xla::{
+        dequantize_gemma3n_affine_diagnostic, run_gemma3n_all_layer_diagnostics,
+        run_gemma3n_altup_correct_diagnostic_probe, run_gemma3n_altup_predict_diagnostic_probe,
+        run_gemma3n_attention_diagnostic_probe, run_gemma3n_canonical_diagnostics,
+        run_gemma3n_decode_attention_diagnostic_probe, run_gemma3n_dense_mlp_diagnostic_probe,
+        run_gemma3n_initial_altup_diagnostic_probe, run_gemma3n_ple_diagnostic_probe,
+        run_gemma3n_ple_injection_all_planes_diagnostic_probe,
+        run_gemma3n_ple_injection_diagnostic_probe, run_gemma3n_post_attention_diagnostic_probe,
+        run_gemma3n_prefix_decode_diagnostic, run_gemma3n_qmv_diagnostic_probe,
+        run_gemma3n_rms_diagnostic_probe, run_gemma3n_sdpa_vector_context_diagnostic_probe,
+    };
+    use sha2::{Digest, Sha256};
+
+    const MODEL_ID: &str = "mlx-community/gemma-3n-E2B-it-4bit";
+    const CONFIG_SHA256: &str = "f865367012e0738cef66e19353f46cb96c67aead717c4e86e72f130450d8e52a";
+    const INDEX_SHA256: &str = "3ed4d02b8c245c61ba2f542e48cc40ed98398f7098457d63d3d7d0fda8d09c0c";
+    const MODEL_SHA256: &str = "8d5af4ae73617d12496301ebad11226f9056c4b0d51dbb9ef9409234fb87d6fa";
+    const CAPACITY: usize = 8;
+    const PROMPT: [i32; 3] = [2, 100, 200];
+
+    fn sha256(path: &Path) -> String {
+        use std::io::Read;
+
+        let file = std::fs::File::open(path).unwrap();
+        let mut reader = std::io::BufReader::with_capacity(1024 * 1024, file);
+        let mut buffer = vec![0u8; 1024 * 1024];
+        let mut digest = Sha256::new();
+        loop {
+            let read = reader.read(&mut buffer).unwrap();
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
+        }
+        format!("{:x}", digest.finalize())
+    }
+
+    fn array_to_f32(array: &MlxArray) -> Vec<f32> {
+        let array = mlxcel_core::astype(array, mlxcel_core::dtype::FLOAT32);
+        mlxcel_core::eval(&array);
+        mlxcel_core::array_to_raw_bytes(&array)
+            .chunks_exact(4)
+            .map(|bytes| f32::from_le_bytes(bytes.try_into().unwrap()))
+            .collect()
+    }
+
+    fn argmax(values: &[f32]) -> i32 {
+        values
+            .iter()
+            .enumerate()
+            .max_by(|left, right| left.1.total_cmp(right.1))
+            .map_or(0, |(index, _)| index as i32)
+    }
+
+    fn top_k(values: &[f32], count: usize) -> Vec<(usize, f32)> {
+        let mut indexed: Vec<_> = values.iter().copied().enumerate().collect();
+        indexed.sort_unstable_by(|left, right| right.1.total_cmp(&left.1));
+        indexed.truncate(count);
+        indexed
+    }
+
+    fn xla_segment_prefix(
+        flat: &[f32],
+        layout: &mlxcel_xla::Gemma3nDiagnosticLayout,
+        name: &str,
+        real_len: usize,
+    ) -> Vec<f32> {
+        let segment = layout.segment(name).unwrap();
+        let values = &flat[segment.offset..segment.offset + segment.len];
+        match name {
+            "scaled_embeddings" | "final_hidden" => values[..real_len * segment.shape[1]].to_vec(),
+            "projected_ple" | "layer0_k" | "layer0_v" => {
+                let row: usize = segment.shape[1..].iter().product();
+                values[..real_len * row].to_vec()
+            }
+            "layer0_all_planes" | "layer_mid_all_planes" | "layer_last_all_planes" => {
+                let row = segment.shape[2];
+                let capacity = segment.shape[1];
+                (0..segment.shape[0])
+                    .flat_map(|plane| {
+                        let start = plane * capacity * row;
+                        values[start..start + real_len * row].iter().copied()
+                    })
+                    .collect()
+            }
+            "layer0_laurel"
+            | "layer0_ple_injected"
+            | "layer0_active_plane"
+            | "layer_mid_active_plane"
+            | "layer_last_active_plane" => values[..real_len * segment.shape[1]].to_vec(),
+            "logits" => values.to_vec(),
+            _ => panic!("unknown diagnostic segment {name}"),
+        }
+    }
+
+    fn mlx_layer0_cache_prefix(array: &MlxArray, real_len: usize) -> Vec<f32> {
+        let shape = mlxcel_core::array_shape(array);
+        assert_eq!(shape.len(), 4);
+        let values = array_to_f32(array);
+        mlx_layer0_cache_prefix_values(
+            &values,
+            [
+                shape[0] as usize,
+                shape[1] as usize,
+                shape[2] as usize,
+                shape[3] as usize,
+            ],
+            real_len,
+        )
+    }
+
+    fn mlx_layer0_cache_prefix_values(
+        values: &[f32],
+        shape: [usize; 4],
+        real_len: usize,
+    ) -> Vec<f32> {
+        assert_eq!(shape[0], 1);
+        let heads = shape[1];
+        let cache_capacity = shape[2];
+        let dim = shape[3];
+        assert!(cache_capacity >= real_len);
+        assert_eq!(values.len(), shape.iter().product::<usize>());
+        let mut transposed = Vec::with_capacity(real_len * heads * dim);
+        for token in 0..real_len {
+            for head in 0..heads {
+                let start = (head * cache_capacity + token) * dim;
+                transposed.extend_from_slice(&values[start..start + dim]);
+            }
+        }
+        transposed
+    }
+
+    #[test]
+    fn mlx_cache_prefix_uses_physical_capacity_stride() {
+        let values = (0..30).map(|value| value as f32).collect::<Vec<_>>();
+        assert_eq!(
+            mlx_layer0_cache_prefix_values(&values, [1, 2, 5, 3], 2),
+            vec![
+                0.0, 1.0, 2.0, 15.0, 16.0, 17.0, 3.0, 4.0, 5.0, 18.0, 19.0, 20.0,
+            ]
+        );
+    }
+
+    #[derive(Clone, Copy)]
+    struct RegressionEnvelope {
+        max_abs: f32,
+        min_cosine: f64,
+        max_normalized_rmse: f64,
+    }
+
+    impl RegressionEnvelope {
+        const fn pinned_cuda(max_abs: f32) -> Self {
+            Self {
+                max_abs,
+                min_cosine: 0.90,
+                max_normalized_rmse: 0.50,
+            }
+        }
+    }
+
+    fn compare(
+        name: &str,
+        mlx: &[f32],
+        xla: &[f32],
+        envelope: RegressionEnvelope,
+        failures: &mut Vec<String>,
+    ) {
+        if mlx.len() != xla.len() {
+            eprintln!("{name}: length mlx={} xla={}", mlx.len(), xla.len());
+            failures.push(format!("{name}: length mismatch"));
+            return;
+        }
+        let nonfinite = mlx
+            .iter()
+            .zip(xla)
+            .enumerate()
+            .find(|(_, (left, right))| !left.is_finite() || !right.is_finite())
+            .map(|(index, (&left, &right))| (index, left, right));
+        if let Some(nonfinite) = nonfinite {
+            eprintln!("{name}: non-finite value at {nonfinite:?}");
+            failures.push(format!("{name}: non-finite value at {nonfinite:?}"));
+            return;
+        }
+        let mut max_abs = 0.0f32;
+        let mut first = None;
+        let mut square_error = 0.0f64;
+        let mut mlx_square = 0.0f64;
+        let mut xla_square = 0.0f64;
+        let mut dot = 0.0f64;
+        for (index, (&left, &right)) in mlx.iter().zip(xla).enumerate() {
+            let delta = (left - right).abs();
+            max_abs = max_abs.max(delta);
+            if delta != 0.0 && first.is_none() {
+                first = Some((index, left, right, delta));
+            }
+            let left = f64::from(left);
+            let right = f64::from(right);
+            let error = left - right;
+            square_error += error * error;
+            mlx_square += left * left;
+            xla_square += right * right;
+            dot += left * right;
+        }
+        let count = mlx.len().max(1) as f64;
+        let rmse = (square_error / count).sqrt();
+        let mlx_rms = (mlx_square / count).sqrt();
+        let normalized_rmse = if mlx_rms == 0.0 {
+            if rmse == 0.0 { 0.0 } else { f64::INFINITY }
+        } else {
+            rmse / mlx_rms
+        };
+        let cosine = if mlx_square == 0.0 || xla_square == 0.0 {
+            if mlx_square == 0.0 && xla_square == 0.0 {
+                1.0
+            } else {
+                0.0
+            }
+        } else {
+            dot / (mlx_square.sqrt() * xla_square.sqrt())
+        };
+        eprintln!(
+            "{name}: len={} max_abs={max_abs} cosine={cosine:.8} \
+             normalized_rmse={normalized_rmse:.8} first={first:?} \
+             envelope(max_abs<={}, cosine>={}, normalized_rmse<={})",
+            mlx.len(),
+            envelope.max_abs,
+            envelope.min_cosine,
+            envelope.max_normalized_rmse,
+        );
+        if max_abs > envelope.max_abs
+            || cosine < envelope.min_cosine
+            || normalized_rmse > envelope.max_normalized_rmse
+        {
+            failures.push(format!(
+                "{name}: max_abs={max_abs} cosine={cosine:.8} \
+                 normalized_rmse={normalized_rmse:.8} first={first:?}"
+            ));
+        }
+    }
+
+    fn compare_top1(name: &str, mlx: &[f32], xla: &[f32], failures: &mut Vec<String>) {
+        let mlx_top1 = argmax(mlx);
+        let xla_top1 = argmax(xla);
+        eprintln!("{name} top1: mlx={mlx_top1} xla={xla_top1}");
+        if mlx_top1 != xla_top1 {
+            failures.push(format!(
+                "{name}: top1 mismatch mlx={mlx_top1} xla={xla_top1}"
+            ));
+        }
+    }
+
+    fn compare_exact(name: &str, left: &[f32], right: &[f32], failures: &mut Vec<String>) {
+        if left.len() != right.len() {
+            eprintln!("{name}: length left={} right={}", left.len(), right.len());
+            failures.push(format!("{name}: length mismatch"));
+            return;
+        }
+        if let Some((index, (&left, &right))) = left
+            .iter()
+            .zip(right)
+            .enumerate()
+            .find(|(_, (left, right))| left.to_bits() != right.to_bits())
+        {
+            let delta = (left - right).abs();
+            eprintln!(
+                "{name}: first mismatch index={index} left={left} right={right} delta={delta}"
+            );
+            failures.push(format!(
+                "{name}: first mismatch index={index} left={left} right={right} delta={delta}"
+            ));
+        } else {
+            eprintln!("{name}: exact match across {} values", left.len());
+        }
+    }
+
+    fn probe_real_projection(name: &str, linear: &UnifiedLinear, input: &MlxArray) {
+        let input_shape = mlxcel_core::array_shape(input);
+        let k = *input_shape.last().unwrap() as usize;
+        let m = input_shape[..input_shape.len() - 1]
+            .iter()
+            .map(|&dim| dim as usize)
+            .product::<usize>();
+        let input_2d = mlxcel_core::reshape(input, &[m as i32, k as i32]);
+        let full = array_to_f32(&linear.forward(&input_2d));
+
+        let mut per_row = Vec::with_capacity(full.len());
+        for row in 0..m {
+            let one = mlxcel_core::slice(&input_2d, &[row as i32, 0], &[row as i32 + 1, k as i32]);
+            per_row.extend(array_to_f32(&linear.forward(&one)));
+        }
+        let stock_mismatch = full
+            .iter()
+            .zip(&per_row)
+            .enumerate()
+            .find(|(_, (left, right))| left.to_bits() != right.to_bits());
+
+        let weight = linear.dequantized_weight();
+        let weight_shape = mlxcel_core::array_shape(&weight);
+        assert_eq!(weight_shape.len(), 2);
+        assert_eq!(weight_shape[1] as usize, k);
+        let n = weight_shape[0] as usize;
+        let input_values = array_to_f32(&input_2d);
+        let weight_values = array_to_f32(&weight);
+        let quantized = linear
+            .as_quantized_weight()
+            .expect("real projection probe requires an affine quantized weight");
+        assert_eq!(quantized.mode, "affine");
+        let packed_shape = mlxcel_core::array_shape(&quantized.weight);
+        assert_eq!(
+            packed_shape,
+            [n as i32, (k * quantized.bits as usize / 32) as i32]
+        );
+        let biases = quantized
+            .biases
+            .as_ref()
+            .expect("affine quantized weight requires biases");
+        let carrier_values = dequantize_gemma3n_affine_diagnostic(
+            &mlxcel_core::array_to_raw_bytes(&quantized.weight),
+            &mlxcel_core::array_to_raw_bytes(&quantized.scales),
+            &mlxcel_core::array_to_raw_bytes(biases),
+            n,
+            packed_shape[1] as usize,
+            quantized.bits as usize,
+            quantized.group_size as usize,
+        )
+        .unwrap();
+        let mut carrier_max_abs = 0.0f32;
+        let mut carrier_first = None;
+        let mut carrier_bit_mismatches = 0usize;
+        for (index, (&mlx, &rust)) in weight_values.iter().zip(&carrier_values).enumerate() {
+            carrier_max_abs = carrier_max_abs.max((mlx - rust).abs());
+            if mlx.to_bits() != rust.to_bits() {
+                carrier_bit_mismatches += 1;
+                carrier_first.get_or_insert((index, mlx, rust, (mlx - rust).abs()));
+            }
+        }
+        let native =
+            run_gemma3n_qmv_diagnostic_probe(&input_values, &weight_values, m, n, k).unwrap();
+        let mut max_abs = 0.0f32;
+        let mut first = None;
+        let mut bit_mismatches = 0usize;
+        for (index, (&mlx, &xla)) in full.iter().zip(&native).enumerate() {
+            max_abs = max_abs.max((mlx - xla).abs());
+            if mlx.to_bits() != xla.to_bits() {
+                bit_mismatches += 1;
+                first.get_or_insert((index, mlx, xla, (mlx - xla).abs()));
+            }
+        }
+        eprintln!(
+            "real_qmv {name}: shape M={m} N={n} K={k} \
+             multirow_vs_perrow_first={stock_mismatch:?} \
+             carrier_bit_mismatches={carrier_bit_mismatches}/{} \
+             carrier_max_abs={carrier_max_abs} carrier_first={carrier_first:?} \
+             native_bit_mismatches={bit_mismatches}/{} max_abs={max_abs} first={first:?}",
+            weight_values.len(),
+            full.len()
+        );
+        assert_eq!(
+            carrier_bit_mismatches, 0,
+            "{name}: Rust carrier differs from MLX dequantized weight"
+        );
+    }
+
+    fn assert_real_projection_weight_carrier(name: &str, linear: &UnifiedLinear) -> Vec<f32> {
+        let weight = linear.dequantized_weight();
+        let shape = mlxcel_core::array_shape(&weight);
+        assert_eq!(shape.len(), 2);
+        let n = shape[0] as usize;
+        let k = shape[1] as usize;
+        let mlx = array_to_f32(&weight);
+        let quantized = linear
+            .as_quantized_weight()
+            .expect("real projection carrier probe requires an affine quantized weight");
+        assert_eq!(quantized.mode, "affine");
+        let packed_shape = mlxcel_core::array_shape(&quantized.weight);
+        assert_eq!(
+            packed_shape,
+            [n as i32, (k * quantized.bits as usize / 32) as i32]
+        );
+        let biases = quantized
+            .biases
+            .as_ref()
+            .expect("affine quantized weight requires biases");
+        let rust = dequantize_gemma3n_affine_diagnostic(
+            &mlxcel_core::array_to_raw_bytes(&quantized.weight),
+            &mlxcel_core::array_to_raw_bytes(&quantized.scales),
+            &mlxcel_core::array_to_raw_bytes(biases),
+            n,
+            packed_shape[1] as usize,
+            quantized.bits as usize,
+            quantized.group_size as usize,
+        )
+        .unwrap();
+        let mut mismatches = 0usize;
+        let mut max_abs = 0.0f32;
+        let mut first = None;
+        for (index, (&mlx, &rust)) in mlx.iter().zip(&rust).enumerate() {
+            let delta = (mlx - rust).abs();
+            max_abs = max_abs.max(delta);
+            if mlx.to_bits() != rust.to_bits() {
+                mismatches += 1;
+                first.get_or_insert((index, mlx, rust, delta));
+            }
+        }
+        eprintln!(
+            "real_weight_carrier {name}: shape N={n} K={k} \
+             bit_mismatches={mismatches}/{} max_abs={max_abs} first={first:?}",
+            mlx.len()
+        );
+        assert_eq!(
+            mismatches, 0,
+            "{name}: Rust carrier differs from MLX dequantized weight"
+        );
+        mlx
+    }
+
+    fn assert_checkpoint_bf16_weight_carrier(
+        model_dir: &Path,
+        canonical_name: &str,
+        mlx_weight: &MlxArray,
+        clip: Option<f32>,
+    ) -> Vec<f32> {
+        let file = std::fs::File::open(model_dir.join("model.safetensors")).unwrap();
+        // Safety: the checkpoint is mapped read-only and remains open while the
+        // safetensors view is consumed in this helper.
+        let mmap = unsafe { memmap2::Mmap::map(&file) }.unwrap();
+        let tensors = safetensors::SafeTensors::deserialize(&mmap).unwrap();
+        let suffix = canonical_name
+            .strip_prefix("model.language_model.")
+            .expect("canonical Gemma3n language-model tensor name");
+        let checkpoint_name = format!("language_model.model.{suffix}");
+        let tensor = tensors.tensor(&checkpoint_name).unwrap();
+        assert_eq!(tensor.dtype(), safetensors::Dtype::BF16);
+        let mut checkpoint = tensor
+            .data()
+            .chunks_exact(2)
+            .map(|bytes| f32::from_bits((u16::from_le_bytes([bytes[0], bytes[1]]) as u32) << 16))
+            .collect::<Vec<_>>();
+        if let Some(limit) = clip {
+            for value in &mut checkpoint {
+                *value = value.clamp(-limit, limit);
+            }
+        }
+        let mlx = array_to_f32(mlx_weight);
+        assert_eq!(mlx.len(), checkpoint.len());
+        let mut mismatches = 0usize;
+        let mut max_abs = 0.0f32;
+        let mut first = None;
+        for (index, (&mlx, &checkpoint)) in mlx.iter().zip(&checkpoint).enumerate() {
+            let delta = (mlx - checkpoint).abs();
+            max_abs = max_abs.max(delta);
+            if mlx.to_bits() != checkpoint.to_bits() {
+                mismatches += 1;
+                first.get_or_insert((index, mlx, checkpoint, delta));
+            }
+        }
+        eprintln!(
+            "checkpoint_bf16_weight_carrier {canonical_name}: shape={:?} \
+             bit_mismatches={mismatches}/{} max_abs={max_abs} first={first:?}",
+            tensor.shape(),
+            mlx.len()
+        );
+        assert_eq!(
+            mismatches, 0,
+            "{canonical_name}: checkpoint carrier differs from MLX f32 weight"
+        );
+        mlx
+    }
+
+    fn probe_real_rms_norm(name: &str, norm: &RMSNorm, input: &MlxArray) {
+        let shape = mlxcel_core::array_shape(input);
+        let width = *shape.last().unwrap() as usize;
+        let rows = shape[..shape.len() - 1]
+            .iter()
+            .map(|&dim| dim as usize)
+            .product::<usize>();
+        let mlx = array_to_f32(&norm.forward(input));
+        let input = array_to_f32(input);
+        let weight = array_to_f32(&norm.weight);
+        let xla = run_gemma3n_rms_diagnostic_probe(&input, &weight, rows, width, norm.eps).unwrap();
+        let mut max_abs = 0.0f32;
+        let mut first = None;
+        let mut bit_mismatches = 0usize;
+        for (index, (&mlx, &xla)) in mlx.iter().zip(&xla).enumerate() {
+            max_abs = max_abs.max((mlx - xla).abs());
+            if mlx.to_bits() != xla.to_bits() {
+                bit_mismatches += 1;
+                first.get_or_insert((index, mlx, xla, (mlx - xla).abs()));
+            }
+        }
+        eprintln!(
+            "real_rms {name}: shape rows={rows} width={width} \
+             bit_mismatches={bit_mismatches}/{} max_abs={max_abs} first={first:?}",
+            mlx.len()
+        );
+        assert_eq!(
+            bit_mismatches, 0,
+            "{name}: narrow XLA RMSNorm differs from MLX"
+        );
+    }
+
+    fn compare_narrow_stage(name: &str, mlx: &[f32], xla: &[f32], failures: &mut Vec<String>) {
+        assert_eq!(mlx.len(), xla.len(), "{name}: stage length mismatch");
+        let mut max_abs = 0.0f32;
+        let mut first = None;
+        let mut bit_mismatches = 0usize;
+        let mlx_bf16_carriers = mlx
+            .iter()
+            .filter(|value| value.to_bits() & 0xffff == 0)
+            .count();
+        let xla_bf16_carriers = xla
+            .iter()
+            .filter(|value| value.to_bits() & 0xffff == 0)
+            .count();
+        for (index, (&mlx, &xla)) in mlx.iter().zip(xla).enumerate() {
+            max_abs = max_abs.max((mlx - xla).abs());
+            if mlx.to_bits() != xla.to_bits() {
+                bit_mismatches += 1;
+                first.get_or_insert((index, mlx, xla, (mlx - xla).abs()));
+            }
+        }
+        eprintln!(
+            "narrow_stage {name}: bit_mismatches={bit_mismatches}/{} \
+             max_abs={max_abs} first={first:?} \
+             bf16_carriers_mlx={mlx_bf16_carriers}/{} \
+             bf16_carriers_xla={xla_bf16_carriers}/{}",
+            mlx.len(),
+            xla.len(),
+            mlx.len()
+        );
+        if bit_mismatches != 0 {
+            failures.push(format!(
+                "{name}: {bit_mismatches}/{} mismatches, max_abs={max_abs}",
+                mlx.len()
+            ));
+        }
+    }
+
+    fn take_diagnostic_stage<'a>(values: &'a [f32], cursor: &mut usize, len: usize) -> &'a [f32] {
+        let start = *cursor;
+        *cursor += len;
+        values
+            .get(start..*cursor)
+            .expect("diagnostic stage output is truncated")
+    }
+
+    fn round_tf32_rne(value: f32) -> f32 {
+        let bits = value.to_bits();
+        if bits & 0x7f80_0000 == 0x7f80_0000 {
+            return value;
+        }
+        let retained_lsb = (bits >> 13) & 1;
+        f32::from_bits(bits.wrapping_add(0x0fff + retained_lsb) & 0xffff_e000)
+    }
+
+    fn round_bf16_rne(value: f32) -> f32 {
+        let bits = value.to_bits();
+        if bits & 0x7f80_0000 == 0x7f80_0000 {
+            return value;
+        }
+        f32::from_bits(bits.wrapping_add(0x7fff + ((bits >> 16) & 1)) & 0xffff_0000)
+    }
+
+    fn permutations4() -> Vec<[usize; 4]> {
+        let mut permutations = Vec::with_capacity(24);
+        for a in 0..4 {
+            for b in 0..4 {
+                for c in 0..4 {
+                    for d in 0..4 {
+                        if a != b && a != c && a != d && b != c && b != d && c != d {
+                            permutations.push([a, b, c, d]);
+                        }
+                    }
+                }
+            }
+        }
+        permutations
+    }
+
+    fn add_tree4(products: &[f32; 4], order: [usize; 4], tree: usize) -> f32 {
+        let [a, b, c, d] = order.map(|index| products[index]);
+        match tree {
+            0 => ((a + b) + c) + d,
+            1 => (a + (b + c)) + d,
+            2 => a + ((b + c) + d),
+            3 => a + (b + (c + d)),
+            4 => (a + b) + (c + d),
+            _ => unreachable!("five binary trees for four leaves"),
+        }
+    }
+
+    fn analyze_altup_predict_schedule(
+        name: &str,
+        layer: &DecoderLayer,
+        stacked_planes: &MlxArray,
+        rows: usize,
+        hidden: usize,
+        plane_count: usize,
+    ) -> Vec<f32> {
+        assert_eq!(
+            plane_count, 4,
+            "schedule enumeration is pinned to AltUp K=4"
+        );
+        let active = slice_altup_plane(stacked_planes, layer.altup_active_idx);
+        let router_norm = layer.altup.router_norm.forward(&active);
+        let router_scaled = mlxcel_core::multiply_scalar(&router_norm, (hidden as f32).powf(-1.0));
+        let modalities = layer.altup.modality_router.forward(&router_scaled);
+        let modalities = mlxcel_core::astype(&modalities, mlxcel_core::dtype::FLOAT32);
+        let modalities = mlxcel_core::tanh(&modalities);
+        let coefficients = layer.altup.prediction_coefs.forward(&modalities);
+        let coefficients = mlxcel_core::reshape(
+            &coefficients,
+            &[1, rows as i32, plane_count as i32, plane_count as i32],
+        );
+        let coefficients = mlxcel_core::transpose_axes(&coefficients, &[0, 1, 3, 2]);
+        let planes_f32 = mlxcel_core::astype(stacked_planes, mlxcel_core::dtype::FLOAT32);
+        let by_feature = mlxcel_core::transpose_axes(&planes_f32, &[1, 2, 3, 0]);
+        let delta = mlxcel_core::matmul(&by_feature, &coefficients);
+        let delta = mlxcel_core::transpose_axes(&delta, &[3, 0, 1, 2]);
+        let pre_round = mlxcel_core::add(&planes_f32, &delta);
+        let predicted = mlxcel_core::astype(&pre_round, mlxcel_core::dtype::BFLOAT16);
+        let planes = array_to_f32(&planes_f32);
+        let coefficients = array_to_f32(&coefficients);
+        let delta = array_to_f32(&delta);
+        let predicted = array_to_f32(&predicted);
+        let plane_len = rows * hidden;
+        let output_len = plane_count * plane_len;
+        assert_eq!(planes.len(), output_len);
+        assert_eq!(delta.len(), output_len);
+        assert_eq!(predicted.len(), output_len);
+
+        let measure = |candidate: &[f32], expected: &[f32]| {
+            let mut mismatches = 0usize;
+            let mut max_abs = 0.0f32;
+            let mut first = None;
+            for (index, (&candidate, &expected)) in candidate.iter().zip(expected).enumerate() {
+                let difference = (candidate - expected).abs();
+                max_abs = max_abs.max(difference);
+                if candidate.to_bits() != expected.to_bits() {
+                    mismatches += 1;
+                    first.get_or_insert((index, expected, candidate, difference));
+                }
+            }
+            (mismatches, max_abs, first)
+        };
+        let mut separate_from_mlx_delta = Vec::with_capacity(output_len);
+        for index in 0..output_len {
+            separate_from_mlx_delta.push(round_bf16_rne(planes[index] + delta[index]));
+        }
+        let separate_summary = measure(&separate_from_mlx_delta, &predicted);
+
+        let permutations = permutations4();
+        let mut best_fma_delta = None;
+        let mut best_fma_final = None;
+        let mut best_seeded_final = None;
+        let mut best_tree_delta = None;
+        let mut best_tree_final = None;
+        for order in permutations {
+            let mut fma_delta = Vec::with_capacity(output_len);
+            let mut fma_final = Vec::with_capacity(output_len);
+            let mut seeded_final = Vec::with_capacity(output_len);
+            let mut tree_deltas = (0..5)
+                .map(|_| Vec::with_capacity(output_len))
+                .collect::<Vec<_>>();
+            let mut tree_finals = (0..5)
+                .map(|_| Vec::with_capacity(output_len))
+                .collect::<Vec<_>>();
+            for target in 0..plane_count {
+                for row in 0..rows {
+                    for feature in 0..hidden {
+                        let within = row * hidden + feature;
+                        let output_index = target * plane_len + within;
+                        let mut lhs = [0.0f32; 4];
+                        let mut rhs = [0.0f32; 4];
+                        let mut products = [0.0f32; 4];
+                        for source in 0..plane_count {
+                            lhs[source] = round_tf32_rne(planes[source * plane_len + within]);
+                            rhs[source] = round_tf32_rne(
+                                coefficients[(row * plane_count + source) * plane_count + target],
+                            );
+                            products[source] = lhs[source] * rhs[source];
+                        }
+                        let mut sum = 0.0f32;
+                        let mut seeded = planes[output_index];
+                        for source in order {
+                            sum = lhs[source].mul_add(rhs[source], sum);
+                            seeded = lhs[source].mul_add(rhs[source], seeded);
+                        }
+                        fma_delta.push(sum);
+                        fma_final.push(round_bf16_rne(planes[output_index] + sum));
+                        seeded_final.push(round_bf16_rne(seeded));
+                        for tree in 0..5 {
+                            let tree_sum = add_tree4(&products, order, tree);
+                            tree_deltas[tree].push(tree_sum);
+                            tree_finals[tree].push(round_bf16_rne(planes[output_index] + tree_sum));
+                        }
+                    }
+                }
+            }
+            let fma_delta_summary = measure(&fma_delta, &delta);
+            let fma_final_summary = measure(&fma_final, &predicted);
+            let seeded_final_summary = measure(&seeded_final, &predicted);
+            if best_fma_delta.as_ref().is_none_or(
+                |(_, (mismatches, _, _)): &([usize; 4], (usize, f32, _))| {
+                    fma_delta_summary.0 < *mismatches
+                },
+            ) {
+                best_fma_delta = Some((order, fma_delta_summary));
+            }
+            if best_fma_final.as_ref().is_none_or(
+                |(_, (mismatches, _, _)): &([usize; 4], (usize, f32, _))| {
+                    fma_final_summary.0 < *mismatches
+                },
+            ) {
+                best_fma_final = Some((order, fma_final_summary));
+            }
+            if best_seeded_final.as_ref().is_none_or(
+                |(_, (mismatches, _, _)): &([usize; 4], (usize, f32, _))| {
+                    seeded_final_summary.0 < *mismatches
+                },
+            ) {
+                best_seeded_final = Some((order, seeded_final_summary));
+            }
+            for tree in 0..5 {
+                let tree_delta_summary = measure(&tree_deltas[tree], &delta);
+                let tree_final_summary = measure(&tree_finals[tree], &predicted);
+                if best_tree_delta.as_ref().is_none_or(
+                    |(_, _, (mismatches, _, _)): &([usize; 4], usize, (usize, f32, _))| {
+                        tree_delta_summary.0 < *mismatches
+                    },
+                ) {
+                    best_tree_delta = Some((order, tree, tree_delta_summary));
+                }
+                if best_tree_final.as_ref().is_none_or(
+                    |(_, _, (mismatches, _, _)): &([usize; 4], usize, (usize, f32, _))| {
+                        tree_final_summary.0 < *mismatches
+                    },
+                ) {
+                    best_tree_final = Some((order, tree, tree_final_summary));
+                }
+            }
+        }
+        eprintln!(
+            "altup_predict_schedule {name}: separate_mlx_delta={separate_summary:?} \
+             best_fma_delta={best_fma_delta:?} best_fma_final={best_fma_final:?} \
+             best_seeded_final={best_seeded_final:?} \
+             best_tree_delta={best_tree_delta:?} best_tree_final={best_tree_final:?}"
+        );
+        if rows > 1 && hidden > 472 {
+            let row = 1;
+            let feature = 472;
+            let target = 1;
+            let within = row * hidden + feature;
+            let output_index = target * plane_len + within;
+            let inputs = (0..plane_count)
+                .map(|source| planes[source * plane_len + within])
+                .collect::<Vec<_>>();
+            let coefficients = (0..plane_count)
+                .map(|source| coefficients[(row * plane_count + source) * plane_count + target])
+                .collect::<Vec<_>>();
+            eprintln!(
+                "altup_predict_schedule_carrier {name}: plane=1 row=1 hidden=472 \
+                 inputs={inputs:?} coefficients={coefficients:?} delta_mlx={} \
+                 residual={} pre_round_mlx={} final_bf16_mlx={}",
+                delta[output_index],
+                planes[output_index],
+                planes[output_index] + delta[output_index],
+                predicted[output_index],
+            );
+        }
+        assert_eq!(
+            separate_summary.0, 0,
+            "{name}: MLX residual add and BF16 cast are not separate"
+        );
+        predicted
+    }
+
+    fn mlp_input_projection_weight(projection: &MlpInputProjection) -> UniquePtr<MlxArray> {
+        match projection {
+            MlpInputProjection::Standard(linear) => linear.dequantized_weight(),
+            MlpInputProjection::Pretransposed { weight_t, .. } => mlxcel_core::transpose(weight_t),
+        }
+    }
+
+    #[test]
+    #[ignore = "requires pinned Gemma3n E2B checkpoint plus MLX and IREE CUDA"]
+    fn pinned_e2b_real_projection_qmv_probe() {
+        let model_dir_env = std::env::var_os("GEMMA3N_MODEL_DIR").expect("set GEMMA3N_MODEL_DIR");
+        let model_dir = Path::new(&model_dir_env);
+        assert_eq!(sha256(&model_dir.join("model.safetensors")), MODEL_SHA256);
+        let (loaded, _) = crate::load_model(model_dir).expect("load pinned MLX checkpoint");
+        let language_model = match &loaded {
+            LoadedModel::Gemma3n(model) => &model.language_model,
+            LoadedModel::Gemma3nVLM(model) => &model.text_model.language_model,
+            _ => panic!("pinned checkpoint did not load as Gemma3n"),
+        };
+        let input = mlxcel_core::from_slice_i32(&PROMPT, &[1, PROMPT.len() as i32]);
+        let scaled = language_model.get_embed_tokens(&input);
+        let rows = PROMPT.len();
+        let hidden = language_model.config.hidden_size;
+        let layer_count = language_model.config.num_hidden_layers;
+        let ple_width = language_model.config.hidden_size_per_layer_input;
+        let plane_count = language_model.config.altup_num_inputs;
+        let mut failures = Vec::new();
+
+        probe_real_projection(
+            "per_layer_model_projection",
+            &language_model.per_layer_model_projection,
+            &scaled,
+        );
+
+        let token_ple = language_model.get_per_layer_inputs(&input);
+        let raw_ple = language_model.per_layer_model_projection.forward(&scaled);
+        let scaled_ple = mlxcel_core::multiply_scalar(&raw_ple, (hidden as f32).powf(-0.5));
+        let reshaped_ple = mlxcel_core::reshape(
+            &scaled_ple,
+            &[1, rows as i32, layer_count as i32, ple_width as i32],
+        );
+        let normed_ple = language_model
+            .per_layer_projection_norm
+            .forward(&reshaped_ple);
+        let added_ple = mlxcel_core::add(&normed_ple, &token_ple);
+        let combined_ple =
+            mlxcel_core::multiply_scalar(&added_ple, std::f32::consts::FRAC_1_SQRT_2);
+        let raw_ple_values = array_to_f32(&raw_ple);
+        let token_ple_values = array_to_f32(&token_ple);
+        let ple_stage_len = rows * layer_count * ple_width;
+        let xla_ple = run_gemma3n_ple_diagnostic_probe(
+            &raw_ple_values,
+            &token_ple_values,
+            &array_to_f32(&language_model.per_layer_projection_norm.weight),
+            rows,
+            layer_count,
+            ple_width,
+            hidden,
+            language_model.per_layer_projection_norm.eps,
+        );
+        let xla_ple = xla_ple.unwrap();
+        for (index, (name, expected)) in [
+            ("ple_raw_projection", raw_ple_values),
+            ("ple_hidden^-0.5_scale", array_to_f32(&scaled_ple)),
+            ("ple_rms_norm", array_to_f32(&normed_ple)),
+            ("ple_token_add", array_to_f32(&added_ple)),
+            ("ple_inv_sqrt2", array_to_f32(&combined_ple)),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            compare_narrow_stage(
+                name,
+                &expected,
+                &xla_ple[index * ple_stage_len..(index + 1) * ple_stage_len],
+                &mut failures,
+            );
+        }
+
+        let target_magnitude = compute_magnitude(&scaled);
+        let mut planes = vec![mlxcel_core::copy(&scaled)];
+        for (index, projection) in language_model.altup_projections.iter().enumerate() {
+            probe_real_projection(&format!("initial_projection{index}"), projection, &scaled);
+            planes.push(projection.forward(&scaled));
+        }
+        let raw_projection_values = planes[1..]
+            .iter()
+            .flat_map(|plane| array_to_f32(plane))
+            .collect::<Vec<_>>();
+        let xla_initial = run_gemma3n_initial_altup_diagnostic_probe(
+            &array_to_f32(&scaled),
+            &raw_projection_values,
+            plane_count - 1,
+            rows,
+            hidden,
+            1e-6,
+        )
+        .unwrap();
+        compare_narrow_stage(
+            "initial_target_magnitude",
+            &array_to_f32(&target_magnitude),
+            &xla_initial[..rows],
+            &mut failures,
+        );
+        normalize_magnitudes(&mut planes, &target_magnitude);
+        let plane_len = rows * hidden;
+        for (index, plane) in planes[1..].iter().enumerate() {
+            let offset = rows + index * plane_len;
+            compare_narrow_stage(
+                &format!("initial_normalized_plane{}", index + 1),
+                &array_to_f32(plane),
+                &xla_initial[offset..offset + plane_len],
+                &mut failures,
+            );
+        }
+
+        let layer0 = &language_model.layers[0];
+        let active = &planes[layer0.altup_active_idx];
+        let router_norm = layer0.altup.router_norm.forward(active);
+        let router_scaled = mlxcel_core::multiply_scalar(&router_norm, (hidden as f32).powf(-1.0));
+        let modalities = layer0.altup.modality_router.forward(&router_scaled);
+        let modalities = mlxcel_core::astype(&modalities, mlxcel_core::dtype::FLOAT32);
+        let modalities = mlxcel_core::tanh(&modalities);
+        assert!(
+            layer0.altup.prediction_coefs.bias.is_none(),
+            "pinned AltUp prediction probe does not model a bias"
+        );
+        let coefficients = layer0.altup.prediction_coefs.forward(&modalities);
+        let coefficients = mlxcel_core::reshape(
+            &coefficients,
+            &[1, rows as i32, plane_count as i32, plane_count as i32],
+        );
+        let coefficients = mlxcel_core::transpose_axes(&coefficients, &[0, 1, 3, 2]);
+        let predicted_stacked = layer0.altup.predict_stacked(&planes);
+        let predicted_active = slice_altup_plane(&predicted_stacked, layer0.altup_active_idx);
+        let input_norm = layer0.input_layernorm.forward(&predicted_active);
+        let stacked_planes = stack_arrays(&planes, 0);
+        let xla_predict = run_gemma3n_altup_predict_diagnostic_probe(
+            &array_to_f32(&stacked_planes),
+            &array_to_f32(&layer0.altup.router_norm.weight),
+            &array_to_f32(&layer0.altup.modality_router.dequantized_weight()),
+            &array_to_f32(&layer0.altup.prediction_coefs.weight),
+            &array_to_f32(&layer0.input_layernorm.weight),
+            plane_count,
+            layer0.altup_active_idx,
+            rows,
+            hidden,
+            layer0.input_layernorm.eps,
+            language_model.config.altup_coef_clip,
+        )
+        .unwrap();
+        let mut cursor = 0usize;
+        for (name, expected) in [
+            ("layer0_router_norm", array_to_f32(&router_norm)),
+            ("layer0_router_scale", array_to_f32(&router_scaled)),
+            ("layer0_modalities", array_to_f32(&modalities)),
+            (
+                "layer0_prediction_coefficients",
+                array_to_f32(&coefficients),
+            ),
+            ("layer0_predicted_all", array_to_f32(&predicted_stacked)),
+            ("layer0_predicted_active", array_to_f32(&predicted_active)),
+            ("layer0_input_norm", array_to_f32(&input_norm)),
+        ] {
+            let len = expected.len();
+            compare_narrow_stage(
+                name,
+                &expected,
+                &xla_predict[cursor..cursor + len],
+                &mut failures,
+            );
+            cursor += len;
+        }
+        assert_eq!(cursor, xla_predict.len());
+
+        let predicted = split_altup_planes(&predicted_stacked, plane_count);
+        probe_real_rms_norm(
+            "layer0_input_norm",
+            &layer0.input_layernorm,
+            &predicted[layer0.altup_active_idx],
+        );
+        let normalized = layer0
+            .input_layernorm
+            .forward(&predicted[layer0.altup_active_idx]);
+        probe_real_projection("layer0_q_proj", &layer0.self_attn.q_proj, &normalized);
+        probe_real_projection(
+            "layer0_laurel_left",
+            &layer0.laurel.linear_left,
+            &normalized,
+        );
+
+        assert_eq!(
+            layer0.altup_active_idx, 0,
+            "pinned PLE residual probe expects active AltUp plane zero"
+        );
+        let per_layer_input = slice_layer_input(&combined_ple, 0, 1, rows as i32, ple_width as i32);
+        let mut layer0_caches = language_model.make_caches();
+        let cache_index = language_model.layer_idx_to_cache_idx[0];
+        let mask = if language_model.config.layer_types[0] == "full_attention" {
+            create_causal_mask(rows as i32, layer0_caches[cache_index].live_len())
+        } else {
+            create_sliding_window_prefill_mask_dense(
+                rows as i32,
+                layer0_caches[cache_index].live_len(),
+                language_model.config.sliding_window as i32,
+            )
+        };
+        let traced = layer0.forward_diagnostics(
+            &planes,
+            Some(mask.as_ref().unwrap()),
+            &mut layer0_caches[cache_index],
+            &per_layer_input,
+        );
+
+        // Bisect the earliest canonical layer0 mismatch using exact MLX stage
+        // carriers as the XLA probe inputs. This deliberately reconstructs the
+        // MLX attention stages outside `forward` so diagnostics do not alter
+        // the production graph or its fusion choices.
+        let q_projection = layer0.self_attn.q_proj.forward(&normalized);
+        let q = mlxcel_core::reshape(
+            &q_projection,
+            &[
+                1,
+                rows as i32,
+                layer0.self_attn.num_heads,
+                layer0.self_attn.head_dim,
+            ],
+        );
+        let q = layer0.self_attn.q_norm.forward(&q);
+        let q = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
+        let q = mlxcel_core::fast_rope(
+            &q,
+            layer0.self_attn.head_dim,
+            false,
+            layer0.self_attn.rope_theta,
+            1.0,
+            0,
+        );
+        let q_rows = mlxcel_core::transpose_axes(&q, &[0, 2, 1, 3]);
+        let mut attention_caches = language_model.make_caches();
+        let (keys, values) = layer0.self_attn.compute_kv(
+            &normalized,
+            1,
+            rows as i32,
+            0,
+            &mut attention_caches[cache_index],
+        );
+        assert_eq!(
+            mlxcel_core::array_shape(&keys),
+            vec![
+                1,
+                layer0.self_attn.num_kv_heads,
+                rows as i32,
+                layer0.self_attn.head_dim,
+            ],
+            "attention diagnostic must use the live K slice"
+        );
+        assert_eq!(
+            mlxcel_core::array_shape(&values),
+            vec![
+                1,
+                layer0.self_attn.num_kv_heads,
+                rows as i32,
+                layer0.self_attn.head_dim,
+            ],
+            "attention diagnostic must use the live V slice"
+        );
+        let context = unsafe {
+            mlxcel_core::layers::attention_from_ptr(
+                &q,
+                &keys,
+                &values,
+                layer0.self_attn.scale,
+                mask.as_ref().unwrap() as *const MlxArray,
+                0.0,
+                layer0.self_attn.window_size,
+            )
+        };
+        let context = mlxcel_core::transpose_axes(&context, &[0, 2, 1, 3]);
+        let context = mlxcel_core::reshape(
+            &context,
+            &[
+                1,
+                rows as i32,
+                layer0.self_attn.num_heads * layer0.self_attn.head_dim,
+            ],
+        );
+        let query_group = layer0.self_attn.num_heads / layer0.self_attn.num_kv_heads;
+        let q_scaled = mlxcel_core::multiply_scalar(&q, layer0.self_attn.scale);
+        let q_grouped = mlxcel_core::reshape(
+            &q_scaled,
+            &[
+                1,
+                layer0.self_attn.num_kv_heads,
+                query_group,
+                rows as i32,
+                layer0.self_attn.head_dim,
+            ],
+        );
+        let keys_grouped = mlxcel_core::reshape(
+            &keys,
+            &[
+                1,
+                layer0.self_attn.num_kv_heads,
+                1,
+                rows as i32,
+                layer0.self_attn.head_dim,
+            ],
+        );
+        let keys_transposed = mlxcel_core::transpose_axes(&keys_grouped, &[0, 1, 2, 4, 3]);
+        let raw_scores = mlxcel_core::matmul(&q_grouped, &keys_transposed);
+        let mask_bf16 = mlxcel_core::astype(mask.as_ref().unwrap(), mlxcel_core::dtype::BFLOAT16);
+        let mask_heads = mlxcel_core::broadcast_to(
+            &mask_bf16,
+            &[1, layer0.self_attn.num_heads, rows as i32, rows as i32],
+        );
+        let mask_grouped = mlxcel_core::reshape(
+            &mask_heads,
+            &[
+                1,
+                layer0.self_attn.num_kv_heads,
+                query_group,
+                rows as i32,
+                rows as i32,
+            ],
+        );
+        let masked_scores = mlxcel_core::add(&raw_scores, &mask_grouped);
+        let probabilities = mlxcel_core::softmax_precise(&masked_scores, -1);
+        let values_grouped = mlxcel_core::reshape(
+            &values,
+            &[
+                1,
+                layer0.self_attn.num_kv_heads,
+                1,
+                rows as i32,
+                layer0.self_attn.head_dim,
+            ],
+        );
+        let explicit_context = mlxcel_core::matmul(&probabilities, &values_grouped);
+        let explicit_context = mlxcel_core::transpose_axes(&explicit_context, &[0, 3, 1, 2, 4]);
+        let explicit_context = mlxcel_core::reshape(
+            &explicit_context,
+            &[
+                1,
+                rows as i32,
+                layer0.self_attn.num_heads * layer0.self_attn.head_dim,
+            ],
+        );
+        for (name, value) in [
+            ("q", q.as_ref().unwrap()),
+            ("raw_scores", raw_scores.as_ref().unwrap()),
+            ("masked_scores", masked_scores.as_ref().unwrap()),
+            ("probabilities", probabilities.as_ref().unwrap()),
+            ("context", explicit_context.as_ref().unwrap()),
+        ] {
+            assert_eq!(
+                mlxcel_core::array_dtype(value),
+                mlxcel_core::dtype::BFLOAT16,
+                "MLX materialized SDPA {name} must remain BF16"
+            );
+        }
+        compare_narrow_stage(
+            "layer0_attention_explicit_context_vs_dispatch",
+            &array_to_f32(&context),
+            &array_to_f32(&explicit_context),
+            &mut failures,
+        );
+        let raw_scores = mlxcel_core::transpose_axes(&raw_scores, &[0, 1, 3, 2, 4]);
+        let masked_scores = mlxcel_core::transpose_axes(&masked_scores, &[0, 1, 3, 2, 4]);
+        let probabilities = mlxcel_core::transpose_axes(&probabilities, &[0, 1, 3, 2, 4]);
+        let attention_projected = layer0.self_attn.o_proj.forward(&context);
+        let attention_post_norm = layer0
+            .post_attention_layernorm
+            .forward(&attention_projected);
+        let attention_residual =
+            mlxcel_core::add(&predicted[layer0.altup_active_idx], &attention_post_norm);
+        let attention_with_laurel = mlxcel_core::add(&attention_residual, &traced.laurel_output);
+        let attention_laurel =
+            mlxcel_core::multiply_scalar(&attention_with_laurel, std::f32::consts::FRAC_1_SQRT_2);
+        let keys_rows = mlxcel_core::transpose_axes(&keys, &[0, 2, 1, 3]);
+        let values_rows = mlxcel_core::transpose_axes(&values, &[0, 2, 1, 3]);
+        let xla_attention = run_gemma3n_attention_diagnostic_probe(
+            &array_to_f32(&q_projection),
+            &array_to_f32(&layer0.self_attn.q_norm.weight),
+            &array_to_f32(&keys_rows),
+            &array_to_f32(&values_rows),
+            &array_to_f32(mask.as_ref().unwrap()),
+            &array_to_f32(&layer0.self_attn.o_proj.dequantized_weight()),
+            &array_to_f32(&layer0.post_attention_layernorm.weight),
+            &array_to_f32(&predicted[layer0.altup_active_idx]),
+            &array_to_f32(&traced.laurel_output),
+            rows,
+            layer0.self_attn.num_heads as usize,
+            layer0.self_attn.num_kv_heads as usize,
+            layer0.self_attn.head_dim as usize,
+            layer0.self_attn.rope_theta as f64,
+            layer0.post_attention_layernorm.eps,
+        )
+        .unwrap();
+        let mut attention_cursor = 0usize;
+        for (name, expected) in [
+            ("layer0_q_after_rope", array_to_f32(&q_rows)),
+            ("layer0_attention_raw_scores", array_to_f32(&raw_scores)),
+            (
+                "layer0_attention_masked_scores",
+                array_to_f32(&masked_scores),
+            ),
+            (
+                "layer0_attention_probabilities",
+                array_to_f32(&probabilities),
+            ),
+            ("layer0_attention_context", array_to_f32(&context)),
+            (
+                "layer0_attention_o_projection",
+                array_to_f32(&attention_projected),
+            ),
+            (
+                "layer0_attention_post_norm",
+                array_to_f32(&attention_post_norm),
+            ),
+            (
+                "layer0_attention_residual",
+                array_to_f32(&attention_residual),
+            ),
+            ("layer0_attention_laurel", array_to_f32(&attention_laurel)),
+        ] {
+            let len = expected.len();
+            compare_narrow_stage(
+                name,
+                &expected,
+                &xla_attention[attention_cursor..attention_cursor + len],
+                &mut failures,
+            );
+            attention_cursor += len;
+        }
+        assert_eq!(attention_cursor, xla_attention.len());
+
+        // Continue the actual-input bisect from the now-exact scaled-LAUREL
+        // carrier through the sparse MLP and AltUp correction. The standalone
+        // MLX graph below spells out every gelu_topk intermediate; pin its final
+        // BF16 output against the compiled production helper before using the
+        // intermediates as a reference.
+        let pre_ff_norm = layer0.pre_feedforward_layernorm.forward(&attention_laurel);
+        let gate = layer0.mlp.gate_proj.forward(&pre_ff_norm);
+        let up = layer0.mlp.up_proj.forward(&pre_ff_norm);
+        assert!(
+            layer0.mlp.activation_sparsity > 0.0,
+            "pinned layer0 post-attention probe expects sparse gelu_topk"
+        );
+        let sparse_mean = mlxcel_core::mean_axis(&gate, -1, true);
+        let sparse_centered = mlxcel_core::subtract(&gate, &sparse_mean);
+        let sparse_variance =
+            mlxcel_core::mean_axis(&mlxcel_core::square(&sparse_centered), -1, true);
+        let sparse_stddev = mlxcel_core::sqrt(&sparse_variance);
+        let sparse_multiplier =
+            mlxcel_core::full_f32(&[1], layer0.mlp.std_multiplier, mlxcel_core::dtype::FLOAT32);
+        let sparse_cutoff = mlxcel_core::add(
+            &sparse_mean,
+            &mlxcel_core::multiply(&sparse_stddev, &sparse_multiplier),
+        );
+        let sparse_shifted_raw = mlxcel_core::subtract(&gate, &sparse_cutoff);
+        let sparse_zero = mlxcel_core::full_f32(&[1], 0.0, mlxcel_core::dtype::FLOAT32);
+        let sparse_shifted = mlxcel_core::maximum(&sparse_shifted_raw, &sparse_zero);
+        let sparse_sqrt2 =
+            mlxcel_core::full_f32(&[1], std::f32::consts::SQRT_2, mlxcel_core::dtype::FLOAT32);
+        let sparse_erf = mlxcel_core::erf(&mlxcel_core::divide(&sparse_shifted, &sparse_sqrt2));
+        let sparse_half = mlxcel_core::full_f32(&[1], 0.5, mlxcel_core::dtype::FLOAT32);
+        let sparse_one = mlxcel_core::full_f32(&[1], 1.0, mlxcel_core::dtype::FLOAT32);
+        let sparse_scale =
+            mlxcel_core::multiply(&sparse_half, &mlxcel_core::add(&sparse_one, &sparse_erf));
+        let sparse_activation_manual = mlxcel_core::astype(
+            &mlxcel_core::multiply(&sparse_shifted, &sparse_scale),
+            mlxcel_core::array_dtype(&gate),
+        );
+        let sparse_activation = layer0.mlp.gelu_topk(&gate);
+        compare_narrow_stage(
+            "layer0_sparse_activation_manual_vs_compiled",
+            &array_to_f32(&sparse_activation),
+            &array_to_f32(&sparse_activation_manual),
+            &mut failures,
+        );
+        let sparse_product = mlxcel_core::multiply(&sparse_activation, &up);
+        let mlp_down = layer0.mlp.down_proj.forward(&sparse_product);
+        let post_ff_norm = layer0.post_feedforward_layernorm.forward(&mlp_down);
+        let ff_residual = mlxcel_core::astype(
+            &mlxcel_core::add(&attention_laurel, &post_ff_norm),
+            mlxcel_core::dtype::BFLOAT16,
+        );
+
+        let correction_router_norm = layer0.altup.router_norm.forward(&ff_residual);
+        let correction_router_scaled =
+            mlxcel_core::multiply_scalar(&correction_router_norm, (hidden as f32).powf(-1.0));
+        let correction_modalities = layer0
+            .altup
+            .modality_router
+            .forward(&correction_router_scaled);
+        let correction_modalities =
+            mlxcel_core::astype(&correction_modalities, mlxcel_core::dtype::FLOAT32);
+        let correction_modalities = mlxcel_core::tanh(&correction_modalities);
+        assert!(
+            layer0.altup.correction_coefs.bias.is_none(),
+            "pinned AltUp correction probe does not model a bias"
+        );
+        let correction_coefficients = layer0
+            .altup
+            .correction_coefs
+            .forward(&correction_modalities);
+        let correction_one = mlxcel_core::full_f32(
+            &[1],
+            1.0,
+            mlxcel_core::array_dtype(&correction_coefficients),
+        );
+        let correction_coefficients = mlxcel_core::add(&correction_coefficients, &correction_one);
+        let correction_innovation = mlxcel_core::subtract(&ff_residual, &predicted_active);
+        let correction_coefficients_planes =
+            mlxcel_core::transpose_axes(&correction_coefficients, &[2, 0, 1]);
+        let correction_coefficients_broadcast = mlxcel_core::broadcast_to(
+            &mlxcel_core::reshape(
+                &correction_coefficients_planes,
+                &[plane_count as i32, 1, rows as i32, 1],
+            ),
+            &[plane_count as i32, 1, rows as i32, hidden as i32],
+        );
+        let correction_innovation_expanded =
+            mlxcel_core::reshape(&correction_innovation, &[1, 1, rows as i32, hidden as i32]);
+        let correction_products = mlxcel_core::multiply(
+            &correction_innovation_expanded,
+            &correction_coefficients_broadcast,
+        );
+        let corrected_manual = mlxcel_core::astype(
+            &mlxcel_core::add(&predicted_stacked, &correction_products),
+            mlxcel_core::dtype::BFLOAT16,
+        );
+        let corrected_stacked =
+            layer0
+                .altup
+                .correct_stacked(&predicted_stacked, &predicted_active, &ff_residual);
+        compare_narrow_stage(
+            "layer0_corrected_manual_vs_compiled",
+            &array_to_f32(&corrected_stacked),
+            &array_to_f32(&corrected_manual),
+            &mut failures,
+        );
+        let corrected_active = slice_altup_plane(&corrected_stacked, layer0.altup_active_idx);
+        let scaled_corrected_active =
+            mlxcel_core::multiply(&corrected_active, &layer0.altup.correct_output_scale);
+
+        for (name, value, expected_dtype) in [
+            (
+                "pre_ff_norm",
+                pre_ff_norm.as_ref().unwrap(),
+                mlxcel_core::dtype::BFLOAT16,
+            ),
+            ("gate", gate.as_ref().unwrap(), mlxcel_core::dtype::BFLOAT16),
+            ("up", up.as_ref().unwrap(), mlxcel_core::dtype::BFLOAT16),
+            (
+                "sparse_activation",
+                sparse_activation.as_ref().unwrap(),
+                mlxcel_core::dtype::BFLOAT16,
+            ),
+            (
+                "sparse_product",
+                sparse_product.as_ref().unwrap(),
+                mlxcel_core::dtype::BFLOAT16,
+            ),
+            (
+                "mlp_down",
+                mlp_down.as_ref().unwrap(),
+                mlxcel_core::dtype::BFLOAT16,
+            ),
+            (
+                "post_ff_norm",
+                post_ff_norm.as_ref().unwrap(),
+                mlxcel_core::dtype::BFLOAT16,
+            ),
+            (
+                "ff_residual",
+                ff_residual.as_ref().unwrap(),
+                mlxcel_core::dtype::BFLOAT16,
+            ),
+        ] {
+            assert_eq!(
+                mlxcel_core::array_dtype(value),
+                expected_dtype,
+                "MLX post-attention {name} dtype drifted"
+            );
+        }
+
+        let intermediate = mlxcel_core::array_shape(&gate).last().copied().unwrap() as usize;
+        let gate_weight = mlp_input_projection_weight(&layer0.mlp.gate_proj);
+        let up_weight = mlp_input_projection_weight(&layer0.mlp.up_proj);
+        let xla_post_attention = run_gemma3n_post_attention_diagnostic_probe(
+            &array_to_f32(&attention_laurel),
+            &array_to_f32(&layer0.pre_feedforward_layernorm.weight),
+            &array_to_f32(&gate_weight),
+            &array_to_f32(&up_weight),
+            &array_to_f32(&layer0.mlp.down_proj.dequantized_weight()),
+            &array_to_f32(&layer0.post_feedforward_layernorm.weight),
+            rows,
+            hidden,
+            intermediate,
+            layer0.pre_feedforward_layernorm.eps,
+            layer0.mlp.activation_sparsity,
+        )
+        .unwrap();
+        let mut post_attention_cursor = 0usize;
+        for (name, expected) in [
+            ("layer0_pre_ff_norm", array_to_f32(&pre_ff_norm)),
+            ("layer0_mlp_gate", array_to_f32(&gate)),
+            ("layer0_mlp_up", array_to_f32(&up)),
+            ("layer0_sparse_mean", array_to_f32(&sparse_mean)),
+            ("layer0_sparse_variance", array_to_f32(&sparse_variance)),
+            ("layer0_sparse_stddev", array_to_f32(&sparse_stddev)),
+            ("layer0_sparse_cutoff", array_to_f32(&sparse_cutoff)),
+            (
+                "layer0_sparse_shifted_raw",
+                array_to_f32(&sparse_shifted_raw),
+            ),
+            ("layer0_sparse_shifted", array_to_f32(&sparse_shifted)),
+            ("layer0_sparse_erf", array_to_f32(&sparse_erf)),
+            ("layer0_sparse_activation", array_to_f32(&sparse_activation)),
+            ("layer0_sparse_product", array_to_f32(&sparse_product)),
+            ("layer0_mlp_down", array_to_f32(&mlp_down)),
+            ("layer0_post_ff_norm", array_to_f32(&post_ff_norm)),
+            ("layer0_ff_residual", array_to_f32(&ff_residual)),
+        ] {
+            let len = expected.len();
+            compare_narrow_stage(
+                name,
+                &expected,
+                &xla_post_attention[post_attention_cursor..post_attention_cursor + len],
+                &mut failures,
+            );
+            post_attention_cursor += len;
+        }
+        assert_eq!(post_attention_cursor, xla_post_attention.len());
+
+        let xla_altup_correct = run_gemma3n_altup_correct_diagnostic_probe(
+            &array_to_f32(&predicted_stacked),
+            &array_to_f32(&predicted_active),
+            &array_to_f32(&ff_residual),
+            &array_to_f32(&layer0.altup.router_norm.weight),
+            &array_to_f32(&layer0.altup.modality_router.dequantized_weight()),
+            &array_to_f32(&layer0.altup.correction_coefs.weight),
+            &array_to_f32(&layer0.altup.correct_output_scale),
+            rows,
+            hidden,
+            plane_count,
+            layer0.altup_active_idx,
+            layer0.altup.router_norm.eps,
+            language_model.config.altup_coef_clip,
+        )
+        .unwrap();
+        let mut altup_correct_cursor = 0usize;
+        for (name, expected) in [
+            (
+                "layer0_correction_router_norm",
+                array_to_f32(&correction_router_norm),
+            ),
+            (
+                "layer0_correction_router_scaled",
+                array_to_f32(&correction_router_scaled),
+            ),
+            (
+                "layer0_correction_modalities",
+                array_to_f32(&correction_modalities),
+            ),
+            (
+                "layer0_correction_coefficients",
+                array_to_f32(&correction_coefficients),
+            ),
+            (
+                "layer0_correction_innovation",
+                array_to_f32(&correction_innovation),
+            ),
+            (
+                "layer0_correction_product",
+                array_to_f32(&correction_products),
+            ),
+            ("layer0_corrected_all", array_to_f32(&corrected_stacked)),
+            ("layer0_corrected_active", array_to_f32(&corrected_active)),
+            (
+                "layer0_corrected_scaled_active",
+                array_to_f32(&scaled_corrected_active),
+            ),
+        ] {
+            let len = expected.len();
+            compare_narrow_stage(
+                name,
+                &expected,
+                &xla_altup_correct[altup_correct_cursor..altup_correct_cursor + len],
+                &mut failures,
+            );
+            altup_correct_cursor += len;
+        }
+        assert_eq!(altup_correct_cursor, xla_altup_correct.len());
+
+        let xla_ple_injection = run_gemma3n_ple_injection_diagnostic_probe(
+            &array_to_f32(&traced.corrected_active),
+            &array_to_f32(&layer0.altup.correct_output_scale),
+            &array_to_f32(&per_layer_input),
+            &array_to_f32(&layer0.per_layer_input_gate.dequantized_weight()),
+            &array_to_f32(&layer0.per_layer_projection.dequantized_weight()),
+            &array_to_f32(&layer0.post_per_layer_input_norm.weight),
+            &array_to_f32(&traced.ple_residual),
+            rows,
+            hidden,
+            ple_width,
+            layer0.post_per_layer_input_norm.eps,
+        )
+        .unwrap();
+        let mut ple_cursor = 0usize;
+        for (name, expected) in [
+            (
+                "layer0_ple_scaled_active",
+                array_to_f32(&traced.ple_scaled_active),
+            ),
+            ("layer0_ple_gate", array_to_f32(&traced.ple_gate)),
+            ("layer0_ple_geglu", array_to_f32(&traced.ple_activated)),
+            ("layer0_ple_projection", array_to_f32(&traced.ple_projected)),
+            ("layer0_ple_injected", array_to_f32(&traced.ple_injected)),
+            (
+                "layer0_ple_residual",
+                array_to_f32(&traced.ple_residual_updated),
+            ),
+        ] {
+            let len = expected.len();
+            compare_narrow_stage(
+                name,
+                &expected,
+                &xla_ple_injection[ple_cursor..ple_cursor + len],
+                &mut failures,
+            );
+            ple_cursor += len;
+        }
+        assert_eq!(ple_cursor, xla_ple_injection.len());
+        assert!(
+            failures.is_empty(),
+            "narrow Gemma3n stages diverged:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    #[test]
+    #[ignore = "requires pinned Gemma3n E2B checkpoint plus MLX and IREE CUDA"]
+    fn pinned_e2b_all_layer_altup_plane_trace() {
+        let model_dir_env = std::env::var_os("GEMMA3N_MODEL_DIR").expect("set GEMMA3N_MODEL_DIR");
+        let model_dir = Path::new(&model_dir_env);
+        assert_eq!(sha256(&model_dir.join("config.json")), CONFIG_SHA256);
+        assert_eq!(
+            sha256(&model_dir.join("model.safetensors.index.json")),
+            INDEX_SHA256
+        );
+        assert_eq!(sha256(&model_dir.join("model.safetensors")), MODEL_SHA256);
+
+        let (
+            mlx_all_layers,
+            mlx_active_layers,
+            layer_types,
+            cache_map,
+            sparsities,
+            altup_correct_scale,
+            altup_coef_clip,
+            sliding_window,
+            num_kv_shared_layers,
+            plane_count,
+            active_index,
+            hidden,
+        ) = {
+            let (loaded, _) = crate::load_model(model_dir).expect("load pinned MLX checkpoint");
+            let language_model = match &loaded {
+                LoadedModel::Gemma3n(model) => &model.language_model,
+                LoadedModel::Gemma3nVLM(model) => &model.text_model.language_model,
+                _ => panic!("pinned checkpoint did not load as Gemma3n"),
+            };
+            let input = mlxcel_core::from_slice_i32(&PROMPT, &[1, PROMPT.len() as i32]);
+            let mut caches = language_model.make_caches();
+            let traced = language_model.forward_diagnostics(&input, &mut caches);
+            let all_layers = traced
+                .all_layer_all_planes
+                .iter()
+                .map(|value| {
+                    assert_eq!(
+                        mlxcel_core::array_dtype(value),
+                        mlxcel_core::dtype::BFLOAT16
+                    );
+                    array_to_f32(value)
+                })
+                .collect::<Vec<_>>();
+            let active_layers = traced
+                .all_layer_active_planes
+                .iter()
+                .map(|value| {
+                    assert_eq!(
+                        mlxcel_core::array_dtype(value),
+                        mlxcel_core::dtype::BFLOAT16
+                    );
+                    array_to_f32(value)
+                })
+                .collect::<Vec<_>>();
+            (
+                all_layers,
+                active_layers,
+                language_model.config.layer_types.clone(),
+                language_model.layer_idx_to_cache_idx.clone(),
+                (0..language_model.layers.len())
+                    .map(|layer| language_model.config.get_activation_sparsity(layer))
+                    .collect::<Vec<_>>(),
+                language_model.config.altup_correct_scale,
+                language_model.config.altup_coef_clip,
+                language_model.config.sliding_window,
+                language_model.config.num_kv_shared_layers,
+                language_model.config.altup_num_inputs,
+                language_model.config.altup_active_idx,
+                language_model.config.hidden_size,
+            )
+        };
+        mlxcel_core::memory::clear_cache();
+
+        let device = std::env::var("MLXCEL_XLA_DEVICE").unwrap_or_else(|_| "cuda".to_string());
+        let xla = run_gemma3n_all_layer_diagnostics(model_dir, &device, CAPACITY, &PROMPT).unwrap();
+        let all_segment = xla.layout.segment("all_layer_all_planes").unwrap();
+        let active_segment = xla.layout.segment("all_layer_active_planes").unwrap();
+        let rows = PROMPT.len();
+        let trace_layer_start = std::env::var("MLXCEL_XLA_GEMMA3N_TRACE_LAYER_START")
+            .ok()
+            .map(|value| value.parse::<usize>().expect("valid trace layer start"))
+            .unwrap_or(0);
+        let layer_count = all_segment.shape[0];
+        let total_layers = layer_types.len();
+        assert_eq!(
+            layer_count,
+            (total_layers - trace_layer_start).min(10),
+            "bounded trace window length"
+        );
+        assert_eq!(
+            all_segment.shape,
+            vec![layer_count, plane_count, rows, hidden]
+        );
+        assert_eq!(active_segment.shape, vec![layer_count, rows, hidden]);
+        assert!(mlx_all_layers.len() >= trace_layer_start + layer_count);
+        assert!(mlx_active_layers.len() >= trace_layer_start + layer_count);
+        assert!(layer_types.len() >= trace_layer_start + layer_count);
+        assert!(cache_map.len() >= trace_layer_start + layer_count);
+
+        let summarize = |mlx: &[f32], xla: &[f32]| {
+            assert_eq!(mlx.len(), xla.len());
+            let mut mismatches = 0usize;
+            let mut max_abs = 0.0f32;
+            let mut first = None;
+            for (index, (&mlx, &xla)) in mlx.iter().zip(xla).enumerate() {
+                let delta = (mlx - xla).abs();
+                max_abs = max_abs.max(delta);
+                if mlx.to_bits() != xla.to_bits() {
+                    mismatches += 1;
+                    first.get_or_insert((index, mlx, xla, delta));
+                }
+            }
+            (mismatches, max_abs, first)
+        };
+
+        let plane_len = rows * hidden;
+        let layer_all_len = plane_count * plane_len;
+        let mut earliest = None;
+        for window_layer in 0..layer_count {
+            let layer = trace_layer_start + window_layer;
+            let layer_all_start = all_segment.offset + window_layer * layer_all_len;
+            let xla_all = &xla.intermediates[layer_all_start..layer_all_start + layer_all_len];
+            let active_start = active_segment.offset + window_layer * plane_len;
+            let xla_active = &xla.intermediates[active_start..active_start + plane_len];
+            let mlx_all = &mlx_all_layers[layer];
+            let mlx_active = &mlx_active_layers[layer];
+            assert_eq!(mlx_all.len(), plane_count * rows * hidden);
+            assert_eq!(mlx_active.len(), rows * hidden);
+
+            let active_plane_start = active_index * plane_len;
+            let mlx_all_active = &mlx_all[active_plane_start..active_plane_start + plane_len];
+            let xla_all_active = &xla_all[active_plane_start..active_plane_start + plane_len];
+            assert_eq!(
+                mlx_active
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                mlx_all_active
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>()
+            );
+            assert_eq!(
+                xla_active
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>(),
+                xla_all_active
+                    .iter()
+                    .map(|value| value.to_bits())
+                    .collect::<Vec<_>>()
+            );
+
+            let (all_mismatches, all_max_abs, all_first) = summarize(mlx_all, xla_all);
+            let (active_mismatches, active_max_abs, active_first) =
+                summarize(mlx_active, xla_active);
+            let shared_kv = layer >= total_layers - num_kv_shared_layers;
+            eprintln!(
+                "all_layer_trace layer={layer} type={} cache_map={layer}->{} shared_kv={shared_kv} \
+                 sparsity={} all_bit_mismatches={all_mismatches}/{} all_max_abs={all_max_abs} \
+                 all_first={all_first:?} active_bit_mismatches={active_mismatches}/{} \
+                 active_max_abs={active_max_abs} active_first={active_first:?} \
+                 altup_correct_scale={altup_correct_scale} altup_coef_clip={altup_coef_clip:?} \
+                 sliding_window={sliding_window}",
+                layer_types[layer],
+                cache_map[layer],
+                sparsities[layer],
+                mlx_all.len(),
+                mlx_active.len(),
+            );
+            if earliest.is_none() && (all_mismatches != 0 || active_mismatches != 0) {
+                earliest = Some(layer);
+            }
+        }
+        eprintln!(
+            "all_layer_trace_summary earliest_divergent_layer={earliest:?} \
+             window={trace_layer_start}..{} layers={layer_count} \
+             planes={plane_count} rows={rows} hidden={hidden} \
+             num_kv_shared_layers={num_kv_shared_layers}",
+            trace_layer_start + layer_count,
+        );
+    }
+
+    #[test]
+    #[ignore = "requires pinned Gemma3n E2B checkpoint plus MLX and IREE CUDA"]
+    fn pinned_e2b_layer10_dense_mlp_actual_input_bisect() {
+        const TARGET_LAYER: usize = 10;
+
+        let model_dir_env = std::env::var_os("GEMMA3N_MODEL_DIR").expect("set GEMMA3N_MODEL_DIR");
+        let model_dir = Path::new(&model_dir_env);
+        assert_eq!(sha256(&model_dir.join("config.json")), CONFIG_SHA256);
+        assert_eq!(
+            sha256(&model_dir.join("model.safetensors.index.json")),
+            INDEX_SHA256
+        );
+        assert_eq!(sha256(&model_dir.join("model.safetensors")), MODEL_SHA256);
+
+        let (loaded, _) = crate::load_model(model_dir).expect("load pinned MLX checkpoint");
+        let language_model = match &loaded {
+            LoadedModel::Gemma3n(model) => &model.language_model,
+            LoadedModel::Gemma3nVLM(model) => &model.text_model.language_model,
+            _ => panic!("pinned checkpoint did not load as Gemma3n"),
+        };
+        let rows = PROMPT.len();
+        let hidden = language_model.config.hidden_size;
+        let ple_width = language_model.config.hidden_size_per_layer_input;
+        let layer = &language_model.layers[TARGET_LAYER];
+        assert_eq!(layer.mlp.activation_sparsity, 0.0);
+        assert_eq!(
+            layer.pre_feedforward_layernorm.eps,
+            layer.post_feedforward_layernorm.eps
+        );
+
+        let input = mlxcel_core::from_slice_i32(&PROMPT, &[1, rows as i32]);
+        let scaled_embeddings = language_model.get_embed_tokens(&input);
+        let token_ple = language_model.get_per_layer_inputs(&input);
+        let projected_ple = language_model.project_per_layer_inputs(&scaled_embeddings, &token_ple);
+        let target_magnitude = compute_magnitude(&scaled_embeddings);
+        let mut planes = vec![mlxcel_core::copy(&scaled_embeddings)];
+        for projection in &language_model.altup_projections {
+            planes.push(projection.forward(&scaled_embeddings));
+        }
+        normalize_magnitudes(&mut planes, &target_magnitude);
+
+        let mut caches = language_model.make_caches();
+        let global_live_len = caches[language_model.first_full_idx].live_len();
+        let sliding_live_len = caches[language_model.first_sliding_idx].live_len();
+        let global_mask = create_causal_mask(rows as i32, global_live_len);
+        let sliding_mask = create_sliding_window_prefill_mask_dense(
+            rows as i32,
+            sliding_live_len,
+            language_model.config.sliding_window as i32,
+        );
+        let mut traced_target = None;
+        for layer_index in 0..=TARGET_LAYER {
+            let cache_index = language_model.layer_idx_to_cache_idx[layer_index];
+            let mask = if language_model.config.layer_types[layer_index] == "full_attention" {
+                global_mask.as_ref().unwrap()
+            } else {
+                sliding_mask.as_ref().unwrap()
+            };
+            let per_layer_input = slice_layer_input(
+                &projected_ple,
+                layer_index as i32,
+                1,
+                rows as i32,
+                ple_width as i32,
+            );
+            let traced = language_model.layers[layer_index].forward_diagnostics(
+                &planes,
+                Some(mask),
+                &mut caches[cache_index],
+                &per_layer_input,
+            );
+            if layer_index == TARGET_LAYER {
+                traced_target = Some(traced);
+                break;
+            }
+            planes = traced.planes;
+        }
+        let traced = traced_target.expect("capture layer10 MLX trace");
+        let attention_laurel = traced.laurel_output;
+        let pre_ff_norm = layer.pre_feedforward_layernorm.forward(&attention_laurel);
+        let gate = layer.mlp.gate_proj.forward(&pre_ff_norm);
+        let up = layer.mlp.up_proj.forward(&pre_ff_norm);
+        let product = mlxcel_core::compiled_geglu_approx_activation(&gate, &up);
+        let down = layer.mlp.down_proj.forward(&product);
+        let down = mlxcel_core::astype(&down, mlxcel_core::dtype::BFLOAT16);
+        let post_ff_norm = layer.post_feedforward_layernorm.forward(&down);
+        let ff_residual = mlxcel_core::astype(
+            &mlxcel_core::add(&attention_laurel, &post_ff_norm),
+            mlxcel_core::dtype::BFLOAT16,
+        );
+
+        let intermediate = mlxcel_core::array_shape(&gate).last().copied().unwrap() as usize;
+        let gate_weight = mlp_input_projection_weight(&layer.mlp.gate_proj);
+        let up_weight = mlp_input_projection_weight(&layer.mlp.up_proj);
+        let xla = run_gemma3n_dense_mlp_diagnostic_probe(
+            &array_to_f32(&attention_laurel),
+            &array_to_f32(&layer.pre_feedforward_layernorm.weight),
+            &array_to_f32(&gate_weight),
+            &array_to_f32(&up_weight),
+            &array_to_f32(&layer.mlp.down_proj.dequantized_weight()),
+            &array_to_f32(&layer.post_feedforward_layernorm.weight),
+            rows,
+            hidden,
+            intermediate,
+            layer.pre_feedforward_layernorm.eps,
+        )
+        .unwrap();
+
+        let rh = rows * hidden;
+        let ri = rows * intermediate;
+        let mut cursor = 0usize;
+        macro_rules! stage {
+            ($len:expr) => {{
+                let start = cursor;
+                cursor += $len;
+                &xla[start..cursor]
+            }};
+        }
+        let xla_pre_ff_norm = stage!(rh);
+        let xla_gate = stage!(ri);
+        let xla_up = stage!(ri);
+        let xla_product = stage!(ri);
+        let xla_down = stage!(rh);
+        let xla_post = stage!(rh);
+        let xla_residual = stage!(rh);
+        assert_eq!(cursor, xla.len());
+
+        let mut failures = Vec::new();
+        compare_narrow_stage(
+            "layer10_dense_pre_ff_norm",
+            &array_to_f32(&pre_ff_norm),
+            xla_pre_ff_norm,
+            &mut failures,
+        );
+        compare_narrow_stage(
+            "layer10_dense_gate",
+            &array_to_f32(&gate),
+            xla_gate,
+            &mut failures,
+        );
+        compare_narrow_stage(
+            "layer10_dense_up",
+            &array_to_f32(&up),
+            xla_up,
+            &mut failures,
+        );
+        compare_narrow_stage(
+            "layer10_dense_product",
+            &array_to_f32(&product),
+            xla_product,
+            &mut failures,
+        );
+        compare_narrow_stage(
+            "layer10_dense_down",
+            &array_to_f32(&down),
+            xla_down,
+            &mut failures,
+        );
+        compare_narrow_stage(
+            "layer10_dense_post_norm",
+            &array_to_f32(&post_ff_norm),
+            xla_post,
+            &mut failures,
+        );
+        compare_narrow_stage(
+            "layer10_dense_residual",
+            &array_to_f32(&ff_residual),
+            xla_residual,
+            &mut failures,
+        );
+        assert!(
+            failures.is_empty(),
+            "production layer10 dense MLP path diverged:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    #[test]
+    #[ignore = "requires pinned Gemma3n E2B checkpoint plus MLX and IREE CUDA"]
+    fn pinned_e2b_layer3_ple_actual_input_bisect() {
+        const TARGET_LAYER: usize = 3;
+
+        let model_dir_env = std::env::var_os("GEMMA3N_MODEL_DIR").expect("set GEMMA3N_MODEL_DIR");
+        let model_dir = Path::new(&model_dir_env);
+        assert_eq!(sha256(&model_dir.join("config.json")), CONFIG_SHA256);
+        assert_eq!(
+            sha256(&model_dir.join("model.safetensors.index.json")),
+            INDEX_SHA256
+        );
+        assert_eq!(sha256(&model_dir.join("model.safetensors")), MODEL_SHA256);
+
+        let (loaded, _) = crate::load_model(model_dir).expect("load pinned MLX checkpoint");
+        let language_model = match &loaded {
+            LoadedModel::Gemma3n(model) => &model.language_model,
+            LoadedModel::Gemma3nVLM(model) => &model.text_model.language_model,
+            _ => panic!("pinned checkpoint did not load as Gemma3n"),
+        };
+        let rows = PROMPT.len();
+        let hidden = language_model.config.hidden_size;
+        let plane_count = language_model.config.altup_num_inputs;
+        let non_active_planes = plane_count - 1;
+        let ple_width = language_model.config.hidden_size_per_layer_input;
+        assert_eq!(
+            language_model.config.altup_active_idx, 0,
+            "layer3 residual mapping assumes active AltUp plane zero"
+        );
+        assert_eq!(
+            language_model.config.layer_types[TARGET_LAYER],
+            "sliding_attention"
+        );
+        assert_eq!(
+            language_model.layer_idx_to_cache_idx[TARGET_LAYER],
+            TARGET_LAYER
+        );
+
+        let input = mlxcel_core::from_slice_i32(&PROMPT, &[1, rows as i32]);
+        let scaled_embeddings = language_model.get_embed_tokens(&input);
+        let token_ple = language_model.get_per_layer_inputs(&input);
+        let projected_ple = language_model.project_per_layer_inputs(&scaled_embeddings, &token_ple);
+        let target_magnitude = compute_magnitude(&scaled_embeddings);
+        let mut planes = vec![mlxcel_core::copy(&scaled_embeddings)];
+        for projection in &language_model.altup_projections {
+            planes.push(projection.forward(&scaled_embeddings));
+        }
+        normalize_magnitudes(&mut planes, &target_magnitude);
+        let layer0_input_planes = stack_arrays(&planes, 0);
+
+        let mut caches = language_model.make_caches();
+        let global_live_len = caches[language_model.first_full_idx].live_len();
+        let sliding_live_len = caches[language_model.first_sliding_idx].live_len();
+        let global_mask = create_causal_mask(rows as i32, global_live_len);
+        let sliding_mask = create_sliding_window_prefill_mask_dense(
+            rows as i32,
+            sliding_live_len,
+            language_model.config.sliding_window as i32,
+        );
+        let mut target_ple = None;
+        let mut target_input_planes = None;
+        let mut traced_target = None;
+        for layer_index in 0..=TARGET_LAYER {
+            let layer = &language_model.layers[layer_index];
+            let cache_index = language_model.layer_idx_to_cache_idx[layer_index];
+            let mask = if language_model.config.layer_types[layer_index] == "full_attention" {
+                global_mask.as_ref().unwrap()
+            } else {
+                sliding_mask.as_ref().unwrap()
+            };
+            let per_layer_input = slice_layer_input(
+                &projected_ple,
+                layer_index as i32,
+                1,
+                rows as i32,
+                ple_width as i32,
+            );
+            if layer_index == TARGET_LAYER {
+                target_input_planes = Some(stack_arrays(&planes, 0));
+            }
+            let traced = layer.forward_diagnostics(
+                &planes,
+                Some(mask),
+                &mut caches[cache_index],
+                &per_layer_input,
+            );
+            if layer_index == TARGET_LAYER {
+                target_ple = Some(per_layer_input);
+                traced_target = Some(traced);
+                break;
+            }
+            planes = traced.planes;
+        }
+        let traced = traced_target.expect("capture layer3 MLX trace");
+        let per_layer_input = target_ple.expect("capture layer3 dense PLE slice");
+        let input_planes = target_input_planes.expect("capture exact layer2 output planes");
+        let layer = &language_model.layers[TARGET_LAYER];
+
+        let router_weight = assert_real_projection_weight_carrier(
+            "layer3_altup_modality_router",
+            &layer.altup.modality_router,
+        );
+        assert_eq!(
+            mlxcel_core::array_dtype(&layer.altup.prediction_coefs.weight),
+            mlxcel_core::dtype::FLOAT32
+        );
+        assert_eq!(
+            mlxcel_core::array_dtype(&layer.altup.correction_coefs.weight),
+            mlxcel_core::dtype::FLOAT32
+        );
+        assert!(layer.altup.prediction_coefs.bias.is_none());
+        assert!(layer.altup.correction_coefs.bias.is_none());
+        let prediction_weight = assert_checkpoint_bf16_weight_carrier(
+            model_dir,
+            "model.language_model.layers.3.altup.prediction_coefs.weight",
+            &layer.altup.prediction_coefs.weight,
+            language_model.config.altup_coef_clip,
+        );
+        let correction_weight = assert_checkpoint_bf16_weight_carrier(
+            model_dir,
+            "model.language_model.layers.3.altup.correction_coefs.weight",
+            &layer.altup.correction_coefs.weight,
+            language_model.config.altup_coef_clip,
+        );
+        eprintln!(
+            "layer3_altup_f32_weight_carriers prediction_values={} correction_values={} \
+             prediction_bf16_aligned={} correction_bf16_aligned={}",
+            prediction_weight.len(),
+            correction_weight.len(),
+            prediction_weight
+                .iter()
+                .filter(|value| value.to_bits() & 0xffff == 0)
+                .count(),
+            correction_weight
+                .iter()
+                .filter(|value| value.to_bits() & 0xffff == 0)
+                .count(),
+        );
+
+        let active_input = slice_altup_plane(&input_planes, layer.altup_active_idx);
+        let predict_router_norm = layer.altup.router_norm.forward(&active_input);
+        let predict_router_scaled =
+            mlxcel_core::multiply_scalar(&predict_router_norm, (hidden as f32).powf(-1.0));
+        let predict_modalities = layer.altup.modality_router.forward(&predict_router_scaled);
+        let predict_modalities =
+            mlxcel_core::astype(&predict_modalities, mlxcel_core::dtype::FLOAT32);
+        let predict_modalities = mlxcel_core::tanh(&predict_modalities);
+        let predict_coefficients = layer.altup.prediction_coefs.forward(&predict_modalities);
+        let predict_coefficients = mlxcel_core::reshape(
+            &predict_coefficients,
+            &[1, rows as i32, plane_count as i32, plane_count as i32],
+        );
+        let predict_coefficients =
+            mlxcel_core::transpose_axes(&predict_coefficients, &[0, 1, 3, 2]);
+        let predicted_all = array_to_f32(&traced.altup_predicted);
+        let predicted_active = array_to_f32(&traced.altup_predicted_active);
+        let layer0_schedule = analyze_altup_predict_schedule(
+            "layer0",
+            &language_model.layers[0],
+            &layer0_input_planes,
+            rows,
+            hidden,
+            plane_count,
+        );
+        let layer0_split = split_altup_planes(&layer0_input_planes, plane_count);
+        let layer0_predicted = language_model.layers[0]
+            .altup
+            .predict_stacked(&layer0_split);
+        assert_eq!(
+            layer0_schedule
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            array_to_f32(&layer0_predicted)
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            "layer0 standalone MLX schedule reconstruction drifted"
+        );
+        let layer3_schedule = analyze_altup_predict_schedule(
+            "layer3",
+            layer,
+            &input_planes,
+            rows,
+            hidden,
+            plane_count,
+        );
+        assert_eq!(
+            layer3_schedule
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            predicted_all
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            "layer3 standalone MLX schedule reconstruction drifted"
+        );
+        let predict_input_norm = layer
+            .input_layernorm
+            .forward(&traced.altup_predicted_active);
+        let xla_predict = run_gemma3n_altup_predict_diagnostic_probe(
+            &array_to_f32(&input_planes),
+            &array_to_f32(&layer.altup.router_norm.weight),
+            &router_weight,
+            &prediction_weight,
+            &array_to_f32(&layer.input_layernorm.weight),
+            plane_count,
+            layer.altup_active_idx,
+            rows,
+            hidden,
+            layer.input_layernorm.eps,
+            language_model.config.altup_coef_clip,
+        )
+        .unwrap();
+        let mut failures = Vec::new();
+        let mut predict_cursor = 0usize;
+        for (name, expected) in [
+            (
+                "layer3_predict_router_norm",
+                array_to_f32(&predict_router_norm),
+            ),
+            (
+                "layer3_predict_router_scaled",
+                array_to_f32(&predict_router_scaled),
+            ),
+            (
+                "layer3_predict_modalities_native_qmv_tanh",
+                array_to_f32(&predict_modalities),
+            ),
+            (
+                "layer3_predict_coefficients_tf32",
+                array_to_f32(&predict_coefficients),
+            ),
+            ("layer3_predicted_all_tf32", predicted_all.clone()),
+            ("layer3_predicted_active", predicted_active.clone()),
+            (
+                "layer3_predict_input_norm",
+                array_to_f32(&predict_input_norm),
+            ),
+        ] {
+            let len = expected.len();
+            compare_narrow_stage(
+                name,
+                &expected,
+                &xla_predict[predict_cursor..predict_cursor + len],
+                &mut failures,
+            );
+            predict_cursor += len;
+        }
+        assert_eq!(predict_cursor, xla_predict.len());
+
+        let activated = array_to_f32(&traced.altup_activated);
+        let correction_router_norm = layer.altup.router_norm.forward(&traced.altup_activated);
+        let correction_router_scaled =
+            mlxcel_core::multiply_scalar(&correction_router_norm, (hidden as f32).powf(-1.0));
+        let correction_modalities = layer
+            .altup
+            .modality_router
+            .forward(&correction_router_scaled);
+        let correction_modalities =
+            mlxcel_core::astype(&correction_modalities, mlxcel_core::dtype::FLOAT32);
+        let correction_modalities = mlxcel_core::tanh(&correction_modalities);
+        let correction_coefficients = layer.altup.correction_coefs.forward(&correction_modalities);
+        let correction_one = mlxcel_core::full_f32(
+            &[1],
+            1.0,
+            mlxcel_core::array_dtype(&correction_coefficients),
+        );
+        let correction_coefficients = mlxcel_core::add(&correction_coefficients, &correction_one);
+        let correction_innovation =
+            mlxcel_core::subtract(&traced.altup_activated, &traced.altup_predicted_active);
+        let correction_coefficients_planes =
+            mlxcel_core::transpose_axes(&correction_coefficients, &[2, 0, 1]);
+        let correction_coefficients_broadcast = mlxcel_core::broadcast_to(
+            &mlxcel_core::reshape(
+                &correction_coefficients_planes,
+                &[plane_count as i32, 1, rows as i32, 1],
+            ),
+            &[plane_count as i32, 1, rows as i32, hidden as i32],
+        );
+        let correction_innovation_expanded =
+            mlxcel_core::reshape(&correction_innovation, &[1, 1, rows as i32, hidden as i32]);
+        let correction_products = mlxcel_core::multiply(
+            &correction_innovation_expanded,
+            &correction_coefficients_broadcast,
+        );
+        let corrected_all = array_to_f32(&traced.altup_corrected);
+        let corrected_active = array_to_f32(&traced.corrected_active);
+        let xla_correct = run_gemma3n_altup_correct_diagnostic_probe(
+            &predicted_all,
+            &predicted_active,
+            &activated,
+            &array_to_f32(&layer.altup.router_norm.weight),
+            &router_weight,
+            &correction_weight,
+            &array_to_f32(&layer.altup.correct_output_scale),
+            rows,
+            hidden,
+            plane_count,
+            layer.altup_active_idx,
+            layer.altup.router_norm.eps,
+            language_model.config.altup_coef_clip,
+        )
+        .unwrap();
+        let mut correct_cursor = 0usize;
+        for (name, expected) in [
+            (
+                "layer3_correction_router_norm",
+                array_to_f32(&correction_router_norm),
+            ),
+            (
+                "layer3_correction_router_scaled",
+                array_to_f32(&correction_router_scaled),
+            ),
+            (
+                "layer3_correction_modalities_native_qmv_tanh",
+                array_to_f32(&correction_modalities),
+            ),
+            (
+                "layer3_correction_coefficients_tf32",
+                array_to_f32(&correction_coefficients),
+            ),
+            (
+                "layer3_correction_innovation",
+                array_to_f32(&correction_innovation),
+            ),
+            (
+                "layer3_correction_products",
+                array_to_f32(&correction_products),
+            ),
+            ("layer3_corrected_all", corrected_all.clone()),
+            ("layer3_corrected_active", corrected_active.clone()),
+            (
+                "layer3_corrected_scaled_active",
+                array_to_f32(&traced.ple_scaled_active),
+            ),
+        ] {
+            let len = expected.len();
+            compare_narrow_stage(
+                name,
+                &expected,
+                &xla_correct[correct_cursor..correct_cursor + len],
+                &mut failures,
+            );
+            correct_cursor += len;
+        }
+        assert_eq!(correct_cursor, xla_correct.len());
+
+        let gate_weight =
+            assert_real_projection_weight_carrier("layer3_ple_gate", &layer.per_layer_input_gate);
+        let projection_weight = assert_real_projection_weight_carrier(
+            "layer3_ple_projection",
+            &layer.per_layer_projection,
+        );
+        let correct_scale = array_to_f32(&layer.altup.correct_output_scale);
+        let per_layer_input_values = array_to_f32(&per_layer_input);
+        let norm_weight = array_to_f32(&layer.post_per_layer_input_norm.weight);
+        let residuals = array_to_f32(&traced.ple_residuals);
+        let residuals_updated = array_to_f32(&traced.ple_residuals_updated);
+        assert_eq!(residuals.len(), non_active_planes * rows * hidden);
+        assert_eq!(residuals_updated.len(), non_active_planes * rows * hidden);
+        let injected = array_to_f32(&traced.ple_injected);
+        let mut raw_residual_sums = Vec::with_capacity(residuals.len());
+        for plane in 0..non_active_planes {
+            let plane_start = plane * rows * hidden;
+            for index in 0..rows * hidden {
+                raw_residual_sums.push(residuals[plane_start + index] + injected[index]);
+            }
+        }
+
+        let xla = run_gemma3n_ple_injection_all_planes_diagnostic_probe(
+            &corrected_active,
+            &correct_scale,
+            &per_layer_input_values,
+            &gate_weight,
+            &projection_weight,
+            &norm_weight,
+            &residuals,
+            rows,
+            hidden,
+            ple_width,
+            non_active_planes,
+            layer.post_per_layer_input_norm.eps,
+        )
+        .unwrap();
+        let mut cursor = 0usize;
+        let scaled_active = array_to_f32(&traced.ple_scaled_active);
+        let gate = array_to_f32(&traced.ple_gate);
+        let activated = array_to_f32(&traced.ple_activated);
+        let projected = array_to_f32(&traced.ple_projected);
+        for (name, expected) in [
+            ("layer3_ple_scaled_active", scaled_active.as_slice()),
+            ("layer3_ple_gate_native_qmv", gate.as_slice()),
+            ("layer3_ple_geglu", activated.as_slice()),
+            ("layer3_ple_projection_native_qmv", projected.as_slice()),
+            ("layer3_ple_injected", injected.as_slice()),
+            ("layer3_ple_residuals_pre", residuals.as_slice()),
+            ("layer3_ple_residuals_raw_add", raw_residual_sums.as_slice()),
+            (
+                "layer3_ple_residuals_post_bf16",
+                residuals_updated.as_slice(),
+            ),
+        ] {
+            let len = expected.len();
+            compare_narrow_stage(name, expected, &xla[cursor..cursor + len], &mut failures);
+            cursor += len;
+        }
+        assert_eq!(cursor, xla.len());
+
+        // The all-layer trace's flat index 8664 maps to logical plane 1,
+        // prompt row 1, hidden column 472. In the non-active residual stack,
+        // plane 1 is residual plane 0.
+        const MISMATCH_ROW: usize = 1;
+        const MISMATCH_HIDDEN: usize = 472;
+        let mismatch_index = MISMATCH_ROW * hidden + MISMATCH_HIDDEN;
+        let plane_len = rows * hidden;
+        let plane1_index = plane_len + mismatch_index;
+        let predict_all_offset =
+            plane_len * 2 + rows * plane_count + rows * plane_count * plane_count;
+        let correction_products_offset = plane_len * 3 + rows * plane_count * 2;
+        let corrected_all_offset = correction_products_offset + plane_count * plane_len;
+        eprintln!(
+            "layer3_altup_mismatch_carrier plane=1 row={MISMATCH_ROW} hidden={MISMATCH_HIDDEN} \
+             input_mlx={} predicted_mlx={} predicted_xla={} correction_product_mlx={} \
+             correction_product_xla={} corrected_mlx={} corrected_xla={}",
+            array_to_f32(&input_planes)[plane1_index],
+            predicted_all[plane1_index],
+            xla_predict[predict_all_offset + plane1_index],
+            array_to_f32(&correction_products)[plane1_index],
+            xla_correct[correction_products_offset + plane1_index],
+            corrected_all[plane1_index],
+            xla_correct[corrected_all_offset + plane1_index],
+        );
+        let stage_prefix = rows * (hidden * 3 + ple_width * 2);
+        let residual_stage_len = non_active_planes * rows * hidden;
+        eprintln!(
+            "layer3_ple_mismatch_carrier plane=1 row={MISMATCH_ROW} hidden={MISMATCH_HIDDEN} \
+             residual_mlx={} injected_mlx={} raw_sum_mlx={} post_bf16_mlx={} \
+             residual_xla={} raw_sum_xla={} post_bf16_xla={}",
+            residuals[mismatch_index],
+            injected[mismatch_index],
+            raw_residual_sums[mismatch_index],
+            residuals_updated[mismatch_index],
+            xla[stage_prefix + mismatch_index],
+            xla[stage_prefix + residual_stage_len + mismatch_index],
+            xla[stage_prefix + residual_stage_len * 2 + mismatch_index],
+        );
+        assert!(
+            failures.is_empty(),
+            "layer3 actual-input PLE stages diverged:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    #[test]
+    #[ignore = "requires pinned Gemma3n E2B checkpoint plus MLX and IREE CUDA"]
+    fn pinned_e2b_layer0_prefix_decode_attention_bisect() {
+        let model_dir_env = std::env::var_os("GEMMA3N_MODEL_DIR").expect("set GEMMA3N_MODEL_DIR");
+        let model_dir = Path::new(&model_dir_env);
+        assert_eq!(sha256(&model_dir.join("config.json")), CONFIG_SHA256);
+        assert_eq!(
+            sha256(&model_dir.join("model.safetensors.index.json")),
+            INDEX_SHA256
+        );
+        assert_eq!(sha256(&model_dir.join("model.safetensors")), MODEL_SHA256);
+
+        let (loaded, _) = crate::load_model(model_dir).expect("load pinned MLX checkpoint");
+        let language_model = match &loaded {
+            LoadedModel::Gemma3n(model) => &model.language_model,
+            LoadedModel::Gemma3nVLM(model) => &model.text_model.language_model,
+            _ => panic!("pinned checkpoint did not load as Gemma3n"),
+        };
+        let layer0 = &language_model.layers[0];
+        let cache_index = language_model.layer_idx_to_cache_idx[0];
+        assert_eq!(cache_index, 0);
+        let hidden = language_model.config.hidden_size;
+        let query_heads = layer0.self_attn.num_heads as usize;
+        let kv_heads = layer0.self_attn.num_kv_heads as usize;
+        let head_dim = layer0.self_attn.head_dim as usize;
+        let kv_width = kv_heads * head_dim;
+        assert_eq!(hidden, query_heads * head_dim);
+
+        let mut caches = language_model.make_caches();
+        let prefix =
+            mlxcel_core::from_slice_i32(&PROMPT[..PROMPT.len() - 1], &[1, PROMPT.len() as i32 - 1]);
+        let seeded = language_model.forward(&prefix, &mut caches);
+        mlxcel_core::eval(&seeded);
+        let position = caches[cache_index].offset as usize;
+        assert_eq!(position, PROMPT.len() - 1);
+        let prefix_keys =
+            mlx_layer0_cache_prefix(caches[cache_index].keys.as_ref().unwrap(), position);
+        let prefix_values =
+            mlx_layer0_cache_prefix(caches[cache_index].values.as_ref().unwrap(), position);
+
+        let last = mlxcel_core::from_slice_i32(&PROMPT[PROMPT.len() - 1..], &[1, 1]);
+        let scaled_embeddings = language_model.get_embed_tokens(&last);
+        let token_ple = language_model.get_per_layer_inputs(&last);
+        let projected_ple = language_model.project_per_layer_inputs(&scaled_embeddings, &token_ple);
+        let target_magnitude = compute_magnitude(&scaled_embeddings);
+        let mut planes = vec![mlxcel_core::copy(&scaled_embeddings)];
+        for projection in &language_model.altup_projections {
+            planes.push(projection.forward(&scaled_embeddings));
+        }
+        normalize_magnitudes(&mut planes, &target_magnitude);
+        let predicted_stacked = layer0.altup.predict_stacked(&planes);
+        let predicted_active = slice_altup_plane(&predicted_stacked, layer0.altup_active_idx);
+        let normalized = layer0.input_layernorm.forward(&predicted_active);
+        let laurel = layer0.laurel.forward(&normalized);
+        let per_layer_input = slice_layer_input(
+            &projected_ple,
+            0,
+            1,
+            1,
+            language_model.config.hidden_size_per_layer_input as i32,
+        );
+        assert_eq!(
+            mlxcel_core::array_shape(&per_layer_input)[1],
+            1,
+            "decode layer0 PLE must carry one row"
+        );
+
+        let q_projection = layer0.self_attn.q_proj.forward(&normalized);
+        let q = mlxcel_core::reshape(
+            &q_projection,
+            &[1, 1, layer0.self_attn.num_heads, layer0.self_attn.head_dim],
+        );
+        let q_norm = layer0.self_attn.q_norm.forward(&q);
+        let q = mlxcel_core::transpose_axes(&q_norm, &[0, 2, 1, 3]);
+        let q_rope = mlxcel_core::fast_rope(
+            &q,
+            layer0.self_attn.head_dim,
+            false,
+            layer0.self_attn.rope_theta,
+            1.0,
+            position as i32,
+        );
+
+        let k_projection = layer0.self_attn.k_proj.forward(&normalized);
+        let k = mlxcel_core::reshape(
+            &k_projection,
+            &[
+                1,
+                1,
+                layer0.self_attn.num_kv_heads,
+                layer0.self_attn.head_dim,
+            ],
+        );
+        let k_norm = layer0.self_attn.k_norm.forward(&k);
+        let k = mlxcel_core::transpose_axes(&k_norm, &[0, 2, 1, 3]);
+        let k_rope = mlxcel_core::fast_rope(
+            &k,
+            layer0.self_attn.head_dim,
+            false,
+            layer0.self_attn.rope_theta,
+            1.0,
+            position as i32,
+        );
+        let v_projection = layer0.self_attn.v_proj.forward(&normalized);
+        let v = mlxcel_core::reshape(
+            &v_projection,
+            &[
+                1,
+                1,
+                layer0.self_attn.num_kv_heads,
+                layer0.self_attn.head_dim,
+            ],
+        );
+        let v_norm = layer0.self_attn.v_norm.forward(&v);
+        let v_norm = mlxcel_core::transpose_axes(&v_norm, &[0, 2, 1, 3]);
+        let (keys, values) = caches[cache_index].update_and_fetch(k_rope, v_norm);
+        let valid_len = position + 1;
+        assert_eq!(
+            mlxcel_core::array_shape(&keys),
+            vec![1, kv_heads as i32, valid_len as i32, head_dim as i32]
+        );
+        let keys_rows = mlxcel_core::transpose_axes(&keys, &[0, 2, 1, 3]);
+        let values_rows = mlxcel_core::transpose_axes(&values, &[0, 2, 1, 3]);
+
+        let native_context = unsafe {
+            mlxcel_core::layers::attention_from_ptr(
+                &q_rope,
+                &keys,
+                &values,
+                layer0.self_attn.scale,
+                std::ptr::null(),
+                0.0,
+                layer0.self_attn.window_size,
+            )
+        };
+        let native_context = mlxcel_core::transpose_axes(&native_context, &[0, 2, 1, 3]);
+        let native_context = mlxcel_core::reshape(&native_context, &[1, 1, hidden as i32]);
+
+        let production = run_gemma3n_decode_attention_diagnostic_probe(
+            &array_to_f32(&normalized),
+            &array_to_f32(&layer0.self_attn.q_proj.dequantized_weight()),
+            &array_to_f32(&layer0.self_attn.k_proj.dequantized_weight()),
+            &array_to_f32(&layer0.self_attn.v_proj.dequantized_weight()),
+            &array_to_f32(&layer0.self_attn.q_norm.weight),
+            &array_to_f32(&layer0.self_attn.k_norm.weight),
+            &prefix_keys,
+            &prefix_values,
+            &array_to_f32(&layer0.self_attn.o_proj.dequantized_weight()),
+            &array_to_f32(&layer0.post_attention_layernorm.weight),
+            &array_to_f32(&predicted_active),
+            &array_to_f32(&laurel),
+            position,
+            CAPACITY,
+            query_heads,
+            kv_heads,
+            head_dim,
+            layer0.self_attn.rope_theta as f64,
+            layer0.post_attention_layernorm.eps,
+            Some(language_model.config.sliding_window),
+        )
+        .unwrap();
+
+        let lengths = [
+            hidden,
+            hidden,
+            hidden,
+            kv_width,
+            kv_width,
+            kv_width,
+            kv_width,
+            kv_width,
+            valid_len * kv_width,
+            valid_len * kv_width,
+            hidden,
+            hidden,
+            hidden,
+            hidden,
+            hidden,
+        ];
+        let parse = |values: &[f32]| {
+            let mut cursor = 0;
+            let stages = lengths
+                .iter()
+                .map(|&len| take_diagnostic_stage(values, &mut cursor, len).to_vec())
+                .collect::<Vec<_>>();
+            assert_eq!(cursor, values.len());
+            stages
+        };
+        let production = parse(&production);
+
+        let mut carrier_failures = Vec::new();
+        for (name, expected, index) in [
+            ("decode_q_projection", array_to_f32(&q_projection), 0),
+            ("decode_q_norm", array_to_f32(&q_norm), 1),
+            ("decode_q_rope", array_to_f32(&q_rope), 2),
+            ("decode_k_projection", array_to_f32(&k_projection), 3),
+            ("decode_k_norm", array_to_f32(&k_norm), 4),
+            (
+                "decode_k_rope",
+                array_to_f32(&mlxcel_core::slice(
+                    &keys,
+                    &[0, 0, position as i32, 0],
+                    &[1, kv_heads as i32, valid_len as i32, head_dim as i32],
+                )),
+                5,
+            ),
+            ("decode_v_projection", array_to_f32(&v_projection), 6),
+            (
+                "decode_v_norm",
+                array_to_f32(&mlxcel_core::slice(
+                    &values,
+                    &[0, 0, position as i32, 0],
+                    &[1, kv_heads as i32, valid_len as i32, head_dim as i32],
+                )),
+                7,
+            ),
+            ("decode_cache_k_valid", array_to_f32(&keys_rows), 8),
+            ("decode_cache_v_valid", array_to_f32(&values_rows), 9),
+        ] {
+            compare_narrow_stage(name, &expected, &production[index], &mut carrier_failures);
+        }
+
+        let native_projected = layer0.self_attn.o_proj.forward(&native_context);
+        let native_post_norm = layer0.post_attention_layernorm.forward(&native_projected);
+        let native_residual = mlxcel_core::astype(
+            &mlxcel_core::add(&predicted_active, &native_post_norm),
+            mlxcel_core::dtype::BFLOAT16,
+        );
+        let native_with_laurel = mlxcel_core::astype(
+            &mlxcel_core::add(&native_residual, &laurel),
+            mlxcel_core::dtype::BFLOAT16,
+        );
+        let native_attention_laurel = mlxcel_core::astype(
+            &mlxcel_core::multiply_scalar(&native_with_laurel, std::f32::consts::FRAC_1_SQRT_2),
+            mlxcel_core::dtype::BFLOAT16,
+        );
+        let mut production_attention_failures = Vec::new();
+        for (name, expected, index) in [
+            (
+                "decode_production_context",
+                array_to_f32(&native_context),
+                10,
+            ),
+            (
+                "decode_production_o_projection",
+                array_to_f32(&native_projected),
+                11,
+            ),
+            (
+                "decode_production_post_norm",
+                array_to_f32(&native_post_norm),
+                12,
+            ),
+            (
+                "decode_production_residual",
+                array_to_f32(&native_residual),
+                13,
+            ),
+            (
+                "decode_production_attention_laurel",
+                array_to_f32(&native_attention_laurel),
+                14,
+            ),
+        ] {
+            compare_narrow_stage(
+                name,
+                &expected,
+                &production[index],
+                &mut production_attention_failures,
+            );
+        }
+
+        let pre_ff_norm = layer0
+            .pre_feedforward_layernorm
+            .forward(&native_attention_laurel);
+        let gate = layer0.mlp.gate_proj.forward(&pre_ff_norm);
+        let up = layer0.mlp.up_proj.forward(&pre_ff_norm);
+        assert!(layer0.mlp.activation_sparsity > 0.0);
+        let sparse_mean = mlxcel_core::mean_axis(&gate, -1, true);
+        let sparse_centered = mlxcel_core::subtract(&gate, &sparse_mean);
+        let sparse_variance =
+            mlxcel_core::mean_axis(&mlxcel_core::square(&sparse_centered), -1, true);
+        let sparse_stddev = mlxcel_core::sqrt(&sparse_variance);
+        let sparse_multiplier =
+            mlxcel_core::full_f32(&[1], layer0.mlp.std_multiplier, mlxcel_core::dtype::FLOAT32);
+        let sparse_cutoff = mlxcel_core::add(
+            &sparse_mean,
+            &mlxcel_core::multiply(&sparse_stddev, &sparse_multiplier),
+        );
+        let sparse_shifted_raw = mlxcel_core::subtract(&gate, &sparse_cutoff);
+        let sparse_zero = mlxcel_core::full_f32(&[1], 0.0, mlxcel_core::dtype::FLOAT32);
+        let sparse_shifted = mlxcel_core::maximum(&sparse_shifted_raw, &sparse_zero);
+        let sparse_sqrt2 =
+            mlxcel_core::full_f32(&[1], std::f32::consts::SQRT_2, mlxcel_core::dtype::FLOAT32);
+        let sparse_erf = mlxcel_core::erf(&mlxcel_core::divide(&sparse_shifted, &sparse_sqrt2));
+        let sparse_activation = layer0.mlp.gelu_topk(&gate);
+        let sparse_product = mlxcel_core::multiply(&sparse_activation, &up);
+        let mlp_down = layer0.mlp.down_proj.forward(&sparse_product);
+        let post_ff_norm = layer0.post_feedforward_layernorm.forward(&mlp_down);
+        let ff_residual = mlxcel_core::astype(
+            &mlxcel_core::add(&native_attention_laurel, &post_ff_norm),
+            mlxcel_core::dtype::BFLOAT16,
+        );
+        let intermediate = mlxcel_core::array_shape(&gate).last().copied().unwrap() as usize;
+        let gate_weight = mlp_input_projection_weight(&layer0.mlp.gate_proj);
+        let up_weight = mlp_input_projection_weight(&layer0.mlp.up_proj);
+        let xla_post_attention = run_gemma3n_post_attention_diagnostic_probe(
+            &array_to_f32(&native_attention_laurel),
+            &array_to_f32(&layer0.pre_feedforward_layernorm.weight),
+            &array_to_f32(&gate_weight),
+            &array_to_f32(&up_weight),
+            &array_to_f32(&layer0.mlp.down_proj.dequantized_weight()),
+            &array_to_f32(&layer0.post_feedforward_layernorm.weight),
+            1,
+            hidden,
+            intermediate,
+            layer0.pre_feedforward_layernorm.eps,
+            layer0.mlp.activation_sparsity,
+        )
+        .unwrap();
+        let mut post_attention_cursor = 0;
+        let mut post_attention_failures = Vec::new();
+        for (name, expected) in [
+            ("decode_pre_ff_norm", array_to_f32(&pre_ff_norm)),
+            ("decode_mlp_gate", array_to_f32(&gate)),
+            ("decode_mlp_up", array_to_f32(&up)),
+            ("decode_sparse_mean", array_to_f32(&sparse_mean)),
+            ("decode_sparse_variance", array_to_f32(&sparse_variance)),
+            ("decode_sparse_stddev", array_to_f32(&sparse_stddev)),
+            ("decode_sparse_cutoff", array_to_f32(&sparse_cutoff)),
+            (
+                "decode_sparse_shifted_raw",
+                array_to_f32(&sparse_shifted_raw),
+            ),
+            ("decode_sparse_shifted", array_to_f32(&sparse_shifted)),
+            ("decode_sparse_erf", array_to_f32(&sparse_erf)),
+            ("decode_sparse_activation", array_to_f32(&sparse_activation)),
+            ("decode_sparse_product", array_to_f32(&sparse_product)),
+            ("decode_mlp_down", array_to_f32(&mlp_down)),
+            ("decode_post_ff_norm", array_to_f32(&post_ff_norm)),
+            ("decode_ff_residual", array_to_f32(&ff_residual)),
+        ] {
+            let actual = take_diagnostic_stage(
+                &xla_post_attention,
+                &mut post_attention_cursor,
+                expected.len(),
+            );
+            compare_narrow_stage(name, &expected, actual, &mut post_attention_failures);
+        }
+        assert_eq!(post_attention_cursor, xla_post_attention.len());
+
+        let correction_router_norm = layer0.altup.router_norm.forward(&ff_residual);
+        let correction_router_scaled =
+            mlxcel_core::multiply_scalar(&correction_router_norm, (hidden as f32).powf(-1.0));
+        let correction_modalities = layer0
+            .altup
+            .modality_router
+            .forward(&correction_router_scaled);
+        let correction_modalities =
+            mlxcel_core::astype(&correction_modalities, mlxcel_core::dtype::FLOAT32);
+        let correction_modalities = mlxcel_core::tanh(&correction_modalities);
+        let correction_coefficients = layer0
+            .altup
+            .correction_coefs
+            .forward(&correction_modalities);
+        let correction_one = mlxcel_core::full_f32(
+            &[1],
+            1.0,
+            mlxcel_core::array_dtype(&correction_coefficients),
+        );
+        let correction_coefficients = mlxcel_core::add(&correction_coefficients, &correction_one);
+        let correction_innovation = mlxcel_core::subtract(&ff_residual, &predicted_active);
+        let plane_count = planes.len();
+        let correction_coefficients_planes =
+            mlxcel_core::transpose_axes(&correction_coefficients, &[2, 0, 1]);
+        let correction_coefficients_broadcast = mlxcel_core::broadcast_to(
+            &mlxcel_core::reshape(
+                &correction_coefficients_planes,
+                &[plane_count as i32, 1, 1, 1],
+            ),
+            &[plane_count as i32, 1, 1, hidden as i32],
+        );
+        let correction_innovation_expanded =
+            mlxcel_core::reshape(&correction_innovation, &[1, 1, 1, hidden as i32]);
+        let correction_products = mlxcel_core::multiply(
+            &correction_innovation_expanded,
+            &correction_coefficients_broadcast,
+        );
+        let corrected_stacked =
+            layer0
+                .altup
+                .correct_stacked(&predicted_stacked, &predicted_active, &ff_residual);
+        let corrected_active = slice_altup_plane(&corrected_stacked, layer0.altup_active_idx);
+        let scaled_corrected_active =
+            mlxcel_core::multiply(&corrected_active, &layer0.altup.correct_output_scale);
+        let xla_altup_correct = run_gemma3n_altup_correct_diagnostic_probe(
+            &array_to_f32(&predicted_stacked),
+            &array_to_f32(&predicted_active),
+            &array_to_f32(&ff_residual),
+            &array_to_f32(&layer0.altup.router_norm.weight),
+            &array_to_f32(&layer0.altup.modality_router.dequantized_weight()),
+            &array_to_f32(&layer0.altup.correction_coefs.weight),
+            &array_to_f32(&layer0.altup.correct_output_scale),
+            1,
+            hidden,
+            plane_count,
+            layer0.altup_active_idx,
+            layer0.altup.router_norm.eps,
+            language_model.config.altup_coef_clip,
+        )
+        .unwrap();
+        let mut altup_cursor = 0;
+        let mut altup_failures = Vec::new();
+        let mut coefficient_reports = Vec::new();
+        for (name, expected) in [
+            (
+                "decode_correction_router_norm",
+                array_to_f32(&correction_router_norm),
+            ),
+            (
+                "decode_correction_router_scaled",
+                array_to_f32(&correction_router_scaled),
+            ),
+            (
+                "decode_correction_modalities",
+                array_to_f32(&correction_modalities),
+            ),
+            (
+                "decode_correction_coefficients",
+                array_to_f32(&correction_coefficients),
+            ),
+            (
+                "decode_correction_innovation",
+                array_to_f32(&correction_innovation),
+            ),
+            (
+                "decode_correction_products",
+                array_to_f32(&correction_products),
+            ),
+            ("decode_corrected_all", array_to_f32(&corrected_stacked)),
+            ("decode_corrected_active", array_to_f32(&corrected_active)),
+            (
+                "decode_scaled_corrected_active",
+                array_to_f32(&scaled_corrected_active),
+            ),
+        ] {
+            let actual =
+                take_diagnostic_stage(&xla_altup_correct, &mut altup_cursor, expected.len());
+            if name == "decode_correction_coefficients" {
+                compare(
+                    name,
+                    &expected,
+                    actual,
+                    RegressionEnvelope {
+                        max_abs: 2.0e-6,
+                        min_cosine: 0.999_999,
+                        max_normalized_rmse: 1.0e-5,
+                    },
+                    &mut coefficient_reports,
+                );
+            } else {
+                compare_narrow_stage(name, &expected, actual, &mut altup_failures);
+            }
+        }
+        assert_eq!(altup_cursor, xla_altup_correct.len());
+        assert!(
+            coefficient_reports.is_empty(),
+            "decode AltUp F32 coefficient drift exceeded its narrow envelope:\n{}",
+            coefficient_reports.join("\n")
+        );
+
+        assert!(
+            carrier_failures.is_empty(),
+            "decode layer0 carrier stages diverged before attention:\n{}",
+            carrier_failures.join("\n")
+        );
+        assert!(
+            production_attention_failures.is_empty(),
+            "decode layer0 production attention stages diverged:\n{}",
+            production_attention_failures.join("\n")
+        );
+        assert!(
+            post_attention_failures.is_empty(),
+            "decode layer0 sparse MLP stages diverged:\n{}",
+            post_attention_failures.join("\n")
+        );
+        assert!(
+            altup_failures.is_empty(),
+            "decode layer0 AltUp correction stages diverged:\n{}",
+            altup_failures.join("\n")
+        );
+    }
+
+    #[test]
+    #[ignore = "requires MLX CUDA plus pinned IREE compiler/runtime"]
+    fn synthetic_d256_production_sdpa_matches_mlx_vector_boundaries() {
+        const HEAD_DIM: usize = 256;
+        const QUERY_HEADS: usize = 8;
+        const KV_HEADS: usize = 2;
+        const CAPACITY: usize = 1024;
+        let hidden = QUERY_HEADS * HEAD_DIM;
+
+        let mlx_context = |query: &[f32],
+                           keys: &[f32],
+                           values: &[f32],
+                           live: usize,
+                           window: usize| {
+            let query = mlxcel_core::astype(
+                &mlxcel_core::from_slice_f32(query, &[1, QUERY_HEADS as i32, 1, HEAD_DIM as i32]),
+                mlxcel_core::dtype::BFLOAT16,
+            );
+            let mut head_major_keys = vec![0.0f32; live * KV_HEADS * HEAD_DIM];
+            let mut head_major_values = vec![0.0f32; live * KV_HEADS * HEAD_DIM];
+            for token in 0..live {
+                for head in 0..KV_HEADS {
+                    let time_offset = (token * KV_HEADS + head) * HEAD_DIM;
+                    let head_offset = (head * live + token) * HEAD_DIM;
+                    head_major_keys[head_offset..head_offset + HEAD_DIM]
+                        .copy_from_slice(&keys[time_offset..time_offset + HEAD_DIM]);
+                    head_major_values[head_offset..head_offset + HEAD_DIM]
+                        .copy_from_slice(&values[time_offset..time_offset + HEAD_DIM]);
+                }
+            }
+            let keys = mlxcel_core::astype(
+                &mlxcel_core::from_slice_f32(
+                    &head_major_keys,
+                    &[1, KV_HEADS as i32, live as i32, HEAD_DIM as i32],
+                ),
+                mlxcel_core::dtype::BFLOAT16,
+            );
+            let values = mlxcel_core::astype(
+                &mlxcel_core::from_slice_f32(
+                    &head_major_values,
+                    &[1, KV_HEADS as i32, live as i32, HEAD_DIM as i32],
+                ),
+                mlxcel_core::dtype::BFLOAT16,
+            );
+            let output = unsafe {
+                mlxcel_core::layers::attention_from_ptr(
+                    &query,
+                    &keys,
+                    &values,
+                    1.0,
+                    std::ptr::null(),
+                    0.0,
+                    window as i32,
+                )
+            };
+            array_to_f32(&output)
+        };
+
+        let compare_case = |name: &str,
+                            query: &[f32],
+                            keys: &[f32],
+                            values: &[f32],
+                            live: usize,
+                            window: Option<usize>| {
+            let expected = mlx_context(query, keys, values, live, window.unwrap_or(0));
+            let actual = run_gemma3n_sdpa_vector_context_diagnostic_probe(
+                query,
+                keys,
+                values,
+                live - 1,
+                CAPACITY,
+                QUERY_HEADS,
+                KV_HEADS,
+                1.0,
+                window,
+            )
+            .unwrap();
+            assert_eq!(expected.len(), hidden);
+            assert_eq!(actual.len(), hidden);
+            let mut failures = Vec::new();
+            compare_narrow_stage(name, &expected, &actual, &mut failures);
+            assert!(
+                failures.is_empty(),
+                "{name} diverged from MLX vector oracle:\n{}",
+                failures.join("\n")
+            );
+            actual
+        };
+
+        let zero_query = vec![0.0f32; hidden];
+        for live in [1usize, 2, 31, 32, 33, 1024] {
+            let keys = vec![0.0f32; CAPACITY * KV_HEADS * HEAD_DIM];
+            let mut values = vec![31.0f32; CAPACITY * KV_HEADS * HEAD_DIM];
+            for token in 0..live {
+                for head in 0..KV_HEADS {
+                    for feature in 0..HEAD_DIM {
+                        values[(token * KV_HEADS + head) * HEAD_DIM + feature] =
+                            head as f32 * 4.0 + (token % 7) as f32 * 0.25 - 0.75
+                                + (feature % 16) as f32 * 0.03125
+                                - 0.25;
+                    }
+                }
+            }
+            compare_case(
+                &format!("synthetic_sdpa_equal_l{live}"),
+                &zero_query,
+                &keys,
+                &values,
+                live,
+                None,
+            );
+        }
+
+        // A configured window spanning the fixed cache capacity is accepted
+        // and must retain the same fixed-capacity address mapping. A truncated
+        // window is routed to materialized attention and rejected by the
+        // direct-native builder guard in the structural emitter regressions.
+        let live = 33;
+        let keys = vec![0.0f32; CAPACITY * KV_HEADS * HEAD_DIM];
+        let mut values = vec![29.0f32; CAPACITY * KV_HEADS * HEAD_DIM];
+        for token in live - 8..live {
+            for head in 0..KV_HEADS {
+                for feature in 0..HEAD_DIM {
+                    values[(token * KV_HEADS + head) * HEAD_DIM + feature] =
+                        head as f32 * 2.0 + (feature % 8) as f32 * 0.125 - 0.5;
+                }
+            }
+        }
+        compare_case(
+            "synthetic_sdpa_full_window_boundary",
+            &zero_query,
+            &keys,
+            &values,
+            live,
+            Some(CAPACITY),
+        );
+
+        // MLX's underflow-safe exp2 path evaluates half the exponent and
+        // squares. A natural-score gap of -100 falls below -126 in log2 space.
+        let mut underflow_query = vec![0.0f32; hidden];
+        for head in 0..QUERY_HEADS {
+            underflow_query[head * HEAD_DIM] = 1.0;
+        }
+        let mut underflow_keys = vec![0.0f32; CAPACITY * KV_HEADS * HEAD_DIM];
+        let mut underflow_values = vec![0.0f32; CAPACITY * KV_HEADS * HEAD_DIM];
+        for head in 0..KV_HEADS {
+            underflow_keys[(KV_HEADS + head) * HEAD_DIM] = -100.0;
+            for feature in 0..HEAD_DIM {
+                let carrier = head as f32 + (feature % 8) as f32 * 0.125 + 0.5;
+                underflow_values[head * HEAD_DIM + feature] = carrier;
+                underflow_values[(KV_HEADS + head) * HEAD_DIM + feature] = -carrier;
+            }
+        }
+        compare_case(
+            "synthetic_sdpa_exp2_underflow",
+            &underflow_query,
+            &underflow_keys,
+            &underflow_values,
+            2,
+            None,
+        );
+
+        // Equal scores and adjacent BF16 values produce the exact halfway
+        // 1.00390625; round-to-nearest-even must select 1.0.
+        let halfway_keys = vec![0.0f32; CAPACITY * KV_HEADS * HEAD_DIM];
+        let mut halfway_values = vec![0.0f32; CAPACITY * KV_HEADS * HEAD_DIM];
+        for head in 0..KV_HEADS {
+            for feature in 0..HEAD_DIM {
+                halfway_values[head * HEAD_DIM + feature] = 1.0;
+                halfway_values[(KV_HEADS + head) * HEAD_DIM + feature] = 1.0078125;
+            }
+        }
+        let halfway = compare_case(
+            "synthetic_sdpa_bf16_halfway",
+            &zero_query,
+            &halfway_keys,
+            &halfway_values,
+            2,
+            None,
+        );
+        assert!(
+            halfway
+                .iter()
+                .all(|value| value.to_bits() == 1.0f32.to_bits()),
+            "BF16 halfway fixture did not round to the even 1.0 carrier"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires pinned Gemma3n E2B checkpoint plus MLX and IREE CUDA"]
+    fn pinned_e2b_one_row_prefix_decode_matches_mlx() {
+        let model_dir_env = std::env::var_os("GEMMA3N_MODEL_DIR").expect("set GEMMA3N_MODEL_DIR");
+        let model_dir = Path::new(&model_dir_env);
+        let readme = std::fs::read_to_string(model_dir.join("README.md")).unwrap();
+        assert!(
+            readme.contains(&format!("# {MODEL_ID}")),
+            "checkpoint README does not identify {MODEL_ID}"
+        );
+        assert_eq!(sha256(&model_dir.join("config.json")), CONFIG_SHA256);
+        assert_eq!(
+            sha256(&model_dir.join("model.safetensors.index.json")),
+            INDEX_SHA256
+        );
+        assert_eq!(sha256(&model_dir.join("model.safetensors")), MODEL_SHA256);
+
+        let mlx_prefix_decode = {
+            let (loaded, _) = crate::load_model(model_dir).expect("load pinned MLX checkpoint");
+            let language_model = match &loaded {
+                LoadedModel::Gemma3n(model) => &model.language_model,
+                LoadedModel::Gemma3nVLM(model) => &model.text_model.language_model,
+                _ => panic!("pinned checkpoint did not load as Gemma3n"),
+            };
+            let mut caches = language_model.make_caches();
+            let prefix = mlxcel_core::from_slice_i32(
+                &PROMPT[..PROMPT.len() - 1],
+                &[1, PROMPT.len() as i32 - 1],
+            );
+            let seeded = language_model.forward(&prefix, &mut caches);
+            mlxcel_core::eval(&seeded);
+            let last = mlxcel_core::from_slice_i32(&PROMPT[PROMPT.len() - 1..], &[1, 1]);
+            array_to_f32(&language_model.forward(&last, &mut caches))
+        };
+        assert_eq!(
+            argmax(&mlx_prefix_decode),
+            236798,
+            "pinned production-CUDA prefix-decode MLX top1 drifted"
+        );
+        mlxcel_core::memory::clear_cache();
+
+        let device = std::env::var("MLXCEL_XLA_DEVICE").unwrap_or_else(|_| "cuda".to_string());
+        let xla = run_gemma3n_prefix_decode_diagnostic(model_dir, &device, CAPACITY, &PROMPT)
+            .expect("one-row XLA prefix-decode diagnostic");
+        assert_eq!(xla.active_slot, 3);
+        assert_eq!(xla.carrier_tokens, [0, 0, 0, PROMPT[2]]);
+        assert_eq!(xla.carrier_positions, [0, 0, 0, 2]);
+        assert_eq!(xla.carrier_cache_lengths, [0, 0, 0, 2]);
+        assert_eq!(xla.top1, argmax(&xla.logits));
+
+        let mut failures = Vec::new();
+        compare(
+            "one_row_prefix_decode_logits",
+            &mlx_prefix_decode,
+            &xla.logits,
+            RegressionEnvelope::pinned_cuda(1.5),
+            &mut failures,
+        );
+        compare_top1(
+            "one_row_prefix_decode_logits",
+            &mlx_prefix_decode,
+            &xla.logits,
+            &mut failures,
+        );
+        eprintln!(
+            "one-row prefix decode carrier token={:?} position={:?} cache_len={:?} \
+             top1 mlx={} xla={}",
+            xla.carrier_tokens,
+            xla.carrier_positions,
+            xla.carrier_cache_lengths,
+            argmax(&mlx_prefix_decode),
+            xla.top1,
+        );
+        assert!(
+            failures.is_empty(),
+            "one-row prefix decode mismatches:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    #[test]
+    #[ignore = "requires pinned Gemma3n E2B checkpoint plus MLX and IREE CUDA"]
+    fn pinned_e2b_intermediates_prefill_decode_and_greedy_match() {
+        let model_dir_env = std::env::var_os("GEMMA3N_MODEL_DIR").expect("set GEMMA3N_MODEL_DIR");
+        let model_dir = Path::new(&model_dir_env);
+        let readme = std::fs::read_to_string(model_dir.join("README.md")).unwrap();
+        assert!(
+            readme.contains(&format!("# {MODEL_ID}")),
+            "checkpoint README does not identify {MODEL_ID}"
+        );
+        assert_eq!(sha256(&model_dir.join("config.json")), CONFIG_SHA256);
+        assert_eq!(
+            sha256(&model_dir.join("model.safetensors.index.json")),
+            INDEX_SHA256
+        );
+        assert_eq!(sha256(&model_dir.join("model.safetensors")), MODEL_SHA256);
+
+        let (mlx_prefix_decode, mlx_greedy, mlx_logits, mlx_segments) = {
+            let (loaded, _) = crate::load_model(model_dir).expect("load pinned MLX checkpoint");
+            let language_model = match &loaded {
+                LoadedModel::Gemma3n(model) => &model.language_model,
+                LoadedModel::Gemma3nVLM(model) => &model.text_model.language_model,
+                _ => panic!("pinned checkpoint did not load as Gemma3n"),
+            };
+            assert_eq!(language_model.layer_idx_to_cache_idx[0], 0);
+            let input = mlxcel_core::from_slice_i32(&PROMPT, &[1, PROMPT.len() as i32]);
+            let mut caches = language_model.make_caches();
+            let mlx = language_model.forward_diagnostics(&input, &mut caches);
+
+            let mut prefix_caches = language_model.make_caches();
+            let prefix = mlxcel_core::from_slice_i32(
+                &PROMPT[..PROMPT.len() - 1],
+                &[1, PROMPT.len() as i32 - 1],
+            );
+            let seeded = language_model.forward(&prefix, &mut prefix_caches);
+            mlxcel_core::eval(&seeded);
+            let last = mlxcel_core::from_slice_i32(&PROMPT[PROMPT.len() - 1..], &[1, 1]);
+            let mlx_prefix_decode =
+                array_to_f32(&language_model.forward(&last, &mut prefix_caches));
+
+            let mut greedy_caches = language_model.make_caches();
+            let full = language_model.forward(&input, &mut greedy_caches);
+            let full_values = array_to_f32(&full);
+            let vocab = language_model.config.vocab_size;
+            let first = argmax(&full_values[full_values.len() - vocab..]);
+            let next = mlxcel_core::from_slice_i32(&[first], &[1, 1]);
+            let second_logits = array_to_f32(&language_model.forward(&next, &mut greedy_caches));
+            let mlx_greedy = vec![first, argmax(&second_logits)];
+            let mlx_logits_all = array_to_f32(&mlx.logits);
+            let mlx_logits = mlx_logits_all[mlx_logits_all.len() - vocab..].to_vec();
+            let mlx_segments = [
+                ("scaled_embeddings", array_to_f32(&mlx.scaled_embeddings)),
+                ("projected_ple", array_to_f32(&mlx.projected_ple)),
+                ("layer0_laurel", array_to_f32(&mlx.layer0_laurel)),
+                (
+                    "layer0_ple_injected",
+                    array_to_f32(&mlx.layer0_ple_injected),
+                ),
+                ("layer0_all_planes", array_to_f32(&mlx.layer0_all_planes)),
+                (
+                    "layer0_active_plane",
+                    array_to_f32(&mlx.layer0_active_plane),
+                ),
+                (
+                    "layer_mid_all_planes",
+                    array_to_f32(&mlx.layer_mid_all_planes),
+                ),
+                (
+                    "layer_mid_active_plane",
+                    array_to_f32(&mlx.layer_mid_active_plane),
+                ),
+                (
+                    "layer_last_all_planes",
+                    array_to_f32(&mlx.layer_last_all_planes),
+                ),
+                (
+                    "layer_last_active_plane",
+                    array_to_f32(&mlx.layer_last_active_plane),
+                ),
+                (
+                    "layer0_k",
+                    mlx_layer0_cache_prefix(&mlx.layer0_k, PROMPT.len()),
+                ),
+                (
+                    "layer0_v",
+                    mlx_layer0_cache_prefix(&mlx.layer0_v, PROMPT.len()),
+                ),
+                ("final_hidden", array_to_f32(&mlx.final_hidden)),
+                ("logits", mlx_logits.clone()),
+            ];
+            (mlx_prefix_decode, mlx_greedy, mlx_logits, mlx_segments)
+        };
+        assert_eq!(
+            argmax(&mlx_logits),
+            236798,
+            "pinned production-CUDA full-prefill MLX top1 drifted"
+        );
+        assert_eq!(
+            argmax(&mlx_prefix_decode),
+            236798,
+            "pinned production-CUDA prefix-decode MLX top1 drifted"
+        );
+        assert_eq!(
+            mlx_greedy,
+            vec![236798, 236789],
+            "pinned production-CUDA MLX greedy reference drifted"
+        );
+        // XLA allocates a second copy of the multi-GiB checkpoint. Release every
+        // MLX model/cache/array handle and its allocator cache before loading it.
+        mlxcel_core::memory::clear_cache();
+
+        let device = std::env::var("MLXCEL_XLA_DEVICE").unwrap_or_else(|_| "cuda".to_string());
+        let xla = run_gemma3n_canonical_diagnostics(
+            model_dir,
+            &device,
+            CAPACITY,
+            &PROMPT,
+            mlx_greedy.len(),
+        )
+        .expect("single-load XLA canonical diagnostics");
+        xla.layout.validate().unwrap();
+
+        let mut failures = Vec::new();
+        // These max-absolute thresholds are no wider than 2x the immediately
+        // preceding pinned production-CUDA measurement (most are exactly 2x).
+        // Cosine and reference-RMS-normalized RMSE additionally prevent a broad
+        // directional or scale regression from hiding inside a local max bound.
+        for (name, mlx_values) in mlx_segments {
+            let xla_values =
+                xla_segment_prefix(&xla.intermediates, &xla.layout, name, PROMPT.len());
+            let max_abs = match name {
+                "scaled_embeddings" => 0.0,
+                "projected_ple" => 0.125,
+                "layer0_laurel" => 1.0,
+                "layer0_ple_injected" => 0.25,
+                "layer0_all_planes" => 3.0,
+                "layer0_active_plane" => 1.0,
+                "layer_mid_all_planes" => 3.0,
+                "layer_mid_active_plane" => 1.0,
+                "layer_last_all_planes" => 3.0,
+                "layer_last_active_plane" => 1.0,
+                "layer0_k" => 0.016,
+                "layer0_v" => 0.0625,
+                "final_hidden" => 6.0,
+                "logits" => 1.5,
+                _ => panic!("missing pinned CUDA regression envelope for {name}"),
+            };
+            compare(
+                name,
+                &mlx_values,
+                &xla_values,
+                RegressionEnvelope::pinned_cuda(max_abs),
+                &mut failures,
+            );
+        }
+        compare(
+            "token_prefill_logits",
+            &mlx_logits,
+            &xla.token_prefill_logits,
+            RegressionEnvelope::pinned_cuda(1.5),
+            &mut failures,
+        );
+        compare(
+            "prepared_prefill_logits",
+            &mlx_logits,
+            &xla.prepared_prefill_logits,
+            RegressionEnvelope::pinned_cuda(1.5),
+            &mut failures,
+        );
+        compare_exact(
+            "token_vs_prepared_logits",
+            &xla.token_prefill_logits,
+            &xla.prepared_prefill_logits,
+            &mut failures,
+        );
+        compare(
+            "prefix_decode_logits",
+            &mlx_prefix_decode,
+            &xla.prefix_decode_logits,
+            RegressionEnvelope::pinned_cuda(1.5),
+            &mut failures,
+        );
+        let diagnostic_logits =
+            xla_segment_prefix(&xla.intermediates, &xla.layout, "logits", PROMPT.len());
+        compare_top1(
+            "diagnostic_logits",
+            &mlx_logits,
+            &diagnostic_logits,
+            &mut failures,
+        );
+        compare_top1(
+            "token_prefill_logits",
+            &mlx_logits,
+            &xla.token_prefill_logits,
+            &mut failures,
+        );
+        compare_top1(
+            "prepared_prefill_logits",
+            &mlx_logits,
+            &xla.prepared_prefill_logits,
+            &mut failures,
+        );
+        compare_top1(
+            "token_vs_prepared_logits",
+            &xla.token_prefill_logits,
+            &xla.prepared_prefill_logits,
+            &mut failures,
+        );
+        compare_top1(
+            "prefix_decode_logits",
+            &mlx_prefix_decode,
+            &xla.prefix_decode_logits,
+            &mut failures,
+        );
+        eprintln!(
+            "logits top10 mlx={:?} token={:?} prepared={:?} decode_mlx={:?} decode_xla={:?}",
+            top_k(&mlx_logits, 10),
+            top_k(&xla.token_prefill_logits, 10),
+            top_k(&xla.prepared_prefill_logits, 10),
+            top_k(&mlx_prefix_decode, 10),
+            top_k(&xla.prefix_decode_logits, 10),
+        );
+        eprintln!("greedy mlx={mlx_greedy:?} xla={:?}", xla.greedy_tokens);
+        if mlx_greedy != xla.greedy_tokens {
+            failures.push(format!(
+                "greedy mismatch mlx={mlx_greedy:?} xla={:?}",
+                xla.greedy_tokens
+            ));
+        }
+        assert!(
+            failures.is_empty(),
+            "pinned Gemma3n canonical mismatches:\n{}",
+            failures.join("\n")
+        );
     }
 }
 

--- a/tests/xla_gemma3n_prefill.rs
+++ b/tests/xla_gemma3n_prefill.rs
@@ -1,0 +1,416 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Real-IREE Gemma3n token/dense-PLE equivalence and mixed-slot lifecycle gate.
+
+#![cfg(feature = "xla-iree")]
+
+use std::collections::HashMap;
+
+use mlxcel::{
+    OwnedTensor, PreparedAttentionBias, PreparedPositions, PreparedPrefill, PreparedTensorDType,
+};
+use mlxcel_xla::{
+    EngineEvent, Gemma3nDensePle, Gemma3nPreparedPrefill, SampleParams, XlaBatchEngine,
+    XlaInferenceSession,
+};
+use safetensors::{Dtype, tensor::TensorView};
+use tempfile::TempDir;
+
+const CAPACITY: usize = 8;
+const HIDDEN: usize = 8;
+const LAYERS: usize = 4;
+const PLE_HIDDEN: usize = 2;
+const PLE_WIDTH: usize = LAYERS * PLE_HIDDEN;
+const VOCAB: usize = 32;
+const PER_LAYER_VOCAB: usize = 24;
+
+struct TinyGemma3n {
+    dir: TempDir,
+    embeddings: Vec<f32>,
+    token_ple: Vec<f32>,
+    model_projection: Vec<f32>,
+}
+
+impl TinyGemma3n {
+    fn path(&self) -> &std::path::Path {
+        self.dir.path()
+    }
+
+    fn prepared(&self, tokens: &[i32]) -> Gemma3nPreparedPrefill {
+        let scale = (HIDDEN as f32).sqrt();
+        let embeddings = tokens
+            .iter()
+            .flat_map(|&token| {
+                let row = token as usize * HIDDEN;
+                self.embeddings[row..row + HIDDEN]
+                    .iter()
+                    .map(move |value| value * scale)
+            })
+            .collect::<Vec<_>>();
+        let prepared = PreparedPrefill::new(
+            tokens.to_vec(),
+            tensor_f32(&[1, tokens.len(), HIDDEN], &embeddings),
+            PreparedPositions::Sequential {
+                start: 0,
+                length: tokens.len(),
+            },
+            PreparedAttentionBias {
+                tensor: tensor_f32(&[1, 1, 1, tokens.len()], &vec![0.0; tokens.len()]),
+                causal: true,
+            },
+            Vec::new(),
+        )
+        .expect("valid prepared embeddings");
+
+        let mut dense = vec![0.0; CAPACITY * PLE_WIDTH];
+        for (position, &token) in tokens.iter().enumerate() {
+            let base = &embeddings[position * HIDDEN..(position + 1) * HIDDEN];
+            let mut projected = [0.0; PLE_WIDTH];
+            for (output, value) in projected.iter_mut().enumerate() {
+                *value = (0..HIDDEN)
+                    .map(|input| self.model_projection[output * HIDDEN + input] * base[input])
+                    .sum::<f32>()
+                    / (HIDDEN as f32).sqrt();
+            }
+            for layer in 0..LAYERS {
+                let start = layer * PLE_HIDDEN;
+                rms_norm(&mut projected[start..start + PLE_HIDDEN], 1e-6);
+            }
+            let mut token_row = [0.0; PLE_WIDTH];
+            if token >= 0 && (token as usize) < PER_LAYER_VOCAB {
+                let start = token as usize * PLE_WIDTH;
+                for (output, value) in token_row.iter_mut().enumerate() {
+                    *value = self.token_ple[start + output] * (PLE_HIDDEN as f32).sqrt();
+                }
+            }
+            for output in 0..PLE_WIDTH {
+                dense[position * PLE_WIDTH + output] =
+                    (projected[output] + token_row[output]) * std::f32::consts::FRAC_1_SQRT_2;
+            }
+        }
+        let dense_ple =
+            Gemma3nDensePle::new(dense, CAPACITY, LAYERS, PLE_HIDDEN).expect("valid dense PLE");
+        Gemma3nPreparedPrefill::new(prepared, dense_ple).expect("aligned Gemma3n request")
+    }
+}
+
+fn rms_norm(row: &mut [f32], eps: f32) {
+    let mean = row.iter().map(|value| value * value).sum::<f32>() / row.len() as f32;
+    let scale = (mean + eps).sqrt().recip();
+    for value in row {
+        *value *= scale;
+    }
+}
+
+fn tensor_f32(shape: &[usize], values: &[f32]) -> OwnedTensor {
+    OwnedTensor::new(
+        values
+            .iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect(),
+        PreparedTensorDType::Float32,
+        shape.to_vec(),
+    )
+    .expect("valid f32 tensor")
+}
+
+fn deterministic_values(elements: usize, seed: usize) -> Vec<f32> {
+    (0..elements)
+        .map(|index| (((index + seed * 19) % 31) as f32 - 15.0) * 0.002)
+        .collect()
+}
+
+fn add_tensor(
+    tensors: &mut Vec<(String, Vec<usize>, Vec<u8>)>,
+    name: impl Into<String>,
+    shape: &[usize],
+    values: Vec<f32>,
+) {
+    tensors.push((
+        name.into(),
+        shape.to_vec(),
+        values.into_iter().flat_map(f32::to_le_bytes).collect(),
+    ));
+}
+
+fn create_tiny_gemma3n() -> TinyGemma3n {
+    let dir = tempfile::tempdir().expect("temporary Gemma3n model");
+    let config = serde_json::json!({
+        "model_type": "gemma3n",
+        "text_config": {
+            "model_type": "gemma3n_text",
+            "hidden_size": HIDDEN,
+            "max_position_embeddings": 4096,
+            "intermediate_size": [12, 12, 12, 12],
+            "num_hidden_layers": LAYERS,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "rms_norm_eps": 1e-6,
+            "vocab_size": VOCAB,
+            "vocab_size_per_layer_input": PER_LAYER_VOCAB,
+            "hidden_size_per_layer_input": PLE_HIDDEN,
+            "layer_types": [
+                "sliding_attention", "full_attention",
+                "sliding_attention", "full_attention"
+            ],
+            "activation_sparsity_pattern": [0.5, 0.0, 0.0, 0.0],
+            "sliding_window": 4,
+            "rope_theta": 1_000_000.0,
+            "rope_local_base_freq": 10_000.0,
+            "final_logit_softcapping": 30.0,
+            "num_kv_shared_layers": 2,
+            "altup_num_inputs": 2,
+            "altup_active_idx": 0,
+            "altup_coef_clip": 120.0,
+            "altup_correct_scale": true,
+            "laurel_rank": 2,
+            "tie_word_embeddings": true
+        }
+    });
+    std::fs::write(
+        dir.path().join("config.json"),
+        serde_json::to_vec(&config).unwrap(),
+    )
+    .unwrap();
+
+    let root = "model.language_model";
+    let embeddings = deterministic_values(VOCAB * HIDDEN, 1);
+    let token_ple = deterministic_values(PER_LAYER_VOCAB * PLE_WIDTH, 2);
+    let model_projection = deterministic_values(PLE_WIDTH * HIDDEN, 3);
+    let mut tensors = Vec::new();
+    add_tensor(
+        &mut tensors,
+        format!("{root}.embed_tokens.weight"),
+        &[VOCAB, HIDDEN],
+        embeddings.clone(),
+    );
+    add_tensor(
+        &mut tensors,
+        format!("{root}.embed_tokens_per_layer.weight"),
+        &[PER_LAYER_VOCAB, PLE_WIDTH],
+        token_ple.clone(),
+    );
+    add_tensor(
+        &mut tensors,
+        format!("{root}.per_layer_model_projection.weight"),
+        &[PLE_WIDTH, HIDDEN],
+        model_projection.clone(),
+    );
+    add_tensor(
+        &mut tensors,
+        format!("{root}.per_layer_projection_norm.weight"),
+        &[PLE_HIDDEN],
+        vec![1.0; PLE_HIDDEN],
+    );
+    add_tensor(
+        &mut tensors,
+        format!("{root}.norm.weight"),
+        &[HIDDEN],
+        vec![1.0; HIDDEN],
+    );
+    add_tensor(
+        &mut tensors,
+        format!("{root}.altup_projections.0.weight"),
+        &[HIDDEN, HIDDEN],
+        deterministic_values(HIDDEN * HIDDEN, 4),
+    );
+    add_tensor(
+        &mut tensors,
+        format!("{root}.altup_unembed_projections.0.weight"),
+        &[HIDDEN, HIDDEN],
+        deterministic_values(HIDDEN * HIDDEN, 5),
+    );
+    for layer in 0..LAYERS {
+        add_layer_tensors(&mut tensors, root, layer);
+    }
+    let views = tensors
+        .iter()
+        .map(|(name, shape, bytes)| {
+            (
+                name.as_str(),
+                TensorView::new(Dtype::F32, shape.clone(), bytes).expect("valid tensor"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    safetensors::serialize_to_file(&views, None, &dir.path().join("model.safetensors"))
+        .expect("Gemma3n weights");
+    TinyGemma3n {
+        dir,
+        embeddings,
+        token_ple,
+        model_projection,
+    }
+}
+
+fn add_layer_tensors(tensors: &mut Vec<(String, Vec<usize>, Vec<u8>)>, root: &str, layer: usize) {
+    let prefix = format!("{root}.layers.{layer}");
+    let add = |tensors: &mut Vec<(String, Vec<usize>, Vec<u8>)>,
+               suffix: &str,
+               shape: &[usize],
+               seed: usize| {
+        add_tensor(
+            tensors,
+            format!("{prefix}.{suffix}"),
+            shape,
+            deterministic_values(shape.iter().product(), layer * 31 + seed),
+        );
+    };
+    add_tensor(
+        tensors,
+        format!("{prefix}.altup.correct_output_scale"),
+        &[HIDDEN],
+        vec![1.0; HIDDEN],
+    );
+    add(tensors, "altup.correction_coefs.weight", &[2, 2], 2);
+    add(tensors, "altup.modality_router.weight", &[2, HIDDEN], 3);
+    add_tensor(
+        tensors,
+        format!("{prefix}.altup.router_norm.weight"),
+        &[HIDDEN],
+        vec![1.0; HIDDEN],
+    );
+    add(tensors, "altup.prediction_coefs.weight", &[4, 2], 5);
+    add(tensors, "laurel.linear_left.weight", &[2, HIDDEN], 6);
+    add(tensors, "laurel.linear_right.weight", &[HIDDEN, 2], 7);
+    for suffix in [
+        "laurel.post_laurel_norm.weight",
+        "input_layernorm.weight",
+        "post_attention_layernorm.weight",
+        "pre_feedforward_layernorm.weight",
+        "post_feedforward_layernorm.weight",
+    ] {
+        add_tensor(
+            tensors,
+            format!("{prefix}.{suffix}"),
+            &[HIDDEN],
+            vec![1.0; HIDDEN],
+        );
+    }
+    add(tensors, "self_attn.q_proj.weight", &[8, HIDDEN], 13);
+    if layer < 2 {
+        add(tensors, "self_attn.k_proj.weight", &[4, HIDDEN], 14);
+        add(tensors, "self_attn.v_proj.weight", &[4, HIDDEN], 15);
+    }
+    add(tensors, "self_attn.o_proj.weight", &[HIDDEN, 8], 16);
+    add_tensor(
+        tensors,
+        format!("{prefix}.self_attn.q_norm.weight"),
+        &[4],
+        vec![1.0; 4],
+    );
+    if layer < 2 {
+        add_tensor(
+            tensors,
+            format!("{prefix}.self_attn.k_norm.weight"),
+            &[4],
+            vec![1.0; 4],
+        );
+    }
+    add(tensors, "mlp.gate_proj.weight", &[12, HIDDEN], 18);
+    add(tensors, "mlp.up_proj.weight", &[12, HIDDEN], 19);
+    add(tensors, "mlp.down_proj.weight", &[HIDDEN, 12], 20);
+    add(
+        tensors,
+        "per_layer_input_gate.weight",
+        &[PLE_HIDDEN, HIDDEN],
+        21,
+    );
+    add(
+        tensors,
+        "per_layer_projection.weight",
+        &[HIDDEN, PLE_HIDDEN],
+        22,
+    );
+    add_tensor(
+        tensors,
+        format!("{prefix}.post_per_layer_input_norm.weight"),
+        &[HIDDEN],
+        vec![1.0; HIDDEN],
+    );
+}
+
+#[test]
+#[ignore = "requires the pinned IREE runtime/compiler and a production target"]
+fn token_and_dense_ple_match_with_mixed_cancel_and_slot_reuse() {
+    let fixture = create_tiny_gemma3n();
+    let tokens = [1, PER_LAYER_VOCAB as i32 + 1, 3];
+    let prepared = fixture.prepared(&tokens);
+
+    let mut token_session =
+        XlaInferenceSession::load_with_context_capacity(fixture.path(), LAYERS, CAPACITY)
+            .expect("token session");
+    let mut prepared_session =
+        XlaInferenceSession::load_with_context_capacity(fixture.path(), LAYERS, CAPACITY)
+            .expect("PLE session");
+    let token_output = token_session
+        .generate_greedy(&tokens, 3, &[])
+        .expect("token generation");
+    let prepared_output = prepared_session
+        .generate_gemma3n_prepared_greedy(&prepared, 3, &[])
+        .expect("dense PLE generation");
+    assert_eq!(prepared_output, token_output);
+
+    // Full-capacity prefill drives shared-layer query RoPE through position
+    // `2 * capacity - 1`, proving the extended table and no-truncation path.
+    let near_capacity: Vec<i32> = (0..CAPACITY as i32)
+        .map(|index| index % PER_LAYER_VOCAB as i32)
+        .collect();
+    let token_first = token_session
+        .prefill_first_token(&near_capacity)
+        .expect("near-capacity token prefill");
+    let ple_first = prepared_session
+        .prefill_gemma3n_prepared(&fixture.prepared(&near_capacity))
+        .expect("near-capacity dense PLE prefill");
+    assert_eq!(ple_first, token_first);
+
+    let device = std::env::var("MLXCEL_XLA_DEVICE").unwrap_or_else(|_| "local-task".to_string());
+    let mut batch =
+        XlaBatchEngine::load_with_context_capacity(fixture.path(), 4, &device, CAPACITY)
+            .expect("Gemma3n batch");
+    let cancelled = batch
+        .submit_gemma3n_prepared(prepared.clone(), 3, SampleParams::greedy())
+        .expect("cancellation candidate");
+    assert!(batch.cancel(cancelled));
+    assert!(batch.pump().expect("cancel pump").is_empty());
+
+    let text = batch
+        .submit(&tokens, 3, SampleParams::greedy())
+        .expect("token request");
+    let ple = batch
+        .submit_gemma3n_prepared(prepared, 3, SampleParams::greedy())
+        .expect("PLE request");
+    let mut streams: HashMap<u64, Vec<i32>> = HashMap::new();
+    while !batch.is_idle() {
+        for event in batch.pump().expect("mixed Gemma3n pump") {
+            if let EngineEvent::Token { req_id, token } = event {
+                streams.entry(req_id).or_default().push(token);
+            }
+        }
+    }
+    assert_eq!(streams.get(&text), streams.get(&ple));
+    assert_eq!(streams.get(&text).map(Vec::len), Some(3));
+
+    let reused = batch
+        .submit_gemma3n_prepared(fixture.prepared(&tokens), 2, SampleParams::greedy())
+        .expect("reused PLE slot");
+    assert!(
+        batch
+            .pump()
+            .expect("reuse pump")
+            .iter()
+            .any(|event| matches!(event, EngineEvent::Token { req_id, .. } if *req_id == reused))
+    );
+}


### PR DESCRIPTION
## Summary

- Add a dedicated Gemma3n XLA architecture, configuration and weight schema, token prefill, dense projected per-layer-input prefill, normal decode, and ragged batch decode.
- Port the Gemma3n text math across AltUp prediction and correction, magnitude normalization, LAUREL, alternating full and sliding attention, activation-sparse MLP, per-layer GeGLU interaction, plane collapse, final normalization, tied unembedding, and logit softcap.
- Make shared-KV cache ownership and public cache ordering explicit, align logical tokens, effective sequence length, dense PLE length, and cache length, and release request-owned PLE state across prefill, cancellation, completion, and slot reuse.
- Extend the IREE C ABI and Rust runtime for the Gemma3n module family, prepared dense-PLE descriptors, single-session execution, mixed batch execution, diagnostics, artifact compatibility, and quantized or supported unquantized weight loading.
- Embed the versioned `kernel-v8` / `abi-v6` CUDA Q4 projection and D=256 decode SDPA bundle, including dynamic decode-position push constants, exact scale-bit transport, bounded GQA/cache support, and materialized StableHLO fallbacks for unsupported dimensions, capacities, layouts, prefill, and truncated sliding windows.

## Correctness boundaries

- Token IDs outside the per-layer vocabulary produce zero per-layer inputs, while token-derived dense PLE and externally prepared dense PLE use the same canonical shape and math.
- Normal and ragged decode share the same production attention core; shared full/sliding KV mappings are bounds-checked and validated across the layer transition.
- Native decode SDPA is restricted to one-query D=256 CUDA execution with valid GQA, cache capacity up to 1024, and an absent or capacity-spanning window; unsupported cases retain the existing materialized attention path.
- The native artifact identity includes kernel and ABI versions, minimum SM, PTX identity, and all Gemma3n graph compatibility inputs.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --release -p mlxcel-xla --lib --features diagnostics -- -D warnings`
- `cargo clippy --release -p mlxcel --lib --features xla-iree,xla-diagnostics -- -D warnings`
- `cargo test --release -p mlxcel-xla --lib --features diagnostics`: 185 passed, 0 failed, 10 ignored.
- Typed CUDA-capable IREE compilation verified dynamic tensor decode positions lower to scalar push constants.
- Actual CUDA Q4 group-64 projection matched its reference bit-exactly.
- Production CUDA SDPA matched the MLX vector oracle bit-exactly for live lengths 1, 2, 31, 32, 33, and 1024, a capacity-spanning window, exp2 underflow, and BF16 halfway rounding.
- Synthetic emitter coverage verifies `kernel-v8` / `abi-v6`, normal and ragged native dispatch, materialized fallbacks, shared-KV mapping, AltUp, LAUREL, activation sparsity, GeGLU, plane collapse, and softcap.
- Real-IREE CUDA mixed lifecycle coverage verifies token versus dense-PLE generation, near-capacity prefill, cancellation, simultaneous token and PLE requests, and completed-slot reuse.
- Pinned E2B actual-input layer 0 and dense layer 10 probes matched MLX at every BF16 carrier; bounded layer traces for layers 10-19 and shared-KV layers 20-29 found no active or all-plane divergence.
- The pinned E2B canonical gate passed in one session: every prefill intermediate, final hidden state, diagnostic logits, token-prefill logits, and prepared-prefill logits matched exactly; prefix-decode logits remained within the pinned envelope with max absolute error 1.4765625, cosine 0.97841440, and normalized RMSE 0.26351152; all top-1 results matched at token 236798 and greedy output matched `[236798, 236789]`.

Closes #876
