### PR TITLE
feat(xla): add sparse DeepStack prefill

### DIFF
--- a/spike/openxla/deepstack_prefill_check.py
+++ b/spike/openxla/deepstack_prefill_check.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """Compile and execute the real sparse DeepStack prefill entry with IREE.
 
-The Qwen3 fixture makes every transformer projection zero, keeps all RMSNorm
-weights at one, and uses an identity untied LM head. Sparse features injected
-after the first, middle, and last language layers therefore accumulate at the
-final visual row to [1, 1, 1, 0]. The expected logits are its exact
-RMS-normalized value. This exercises the production StableHLO entry and the
-same post-language-layer injection point as MLX Qwen3-VL, not a test-only probe.
+This ports the fixed `Qwen3VLModel::deepstack_process` regression fixture:
+hidden states start at one, visual positions are 1..=3, and each visual feature
+component is ten. With zero transformer projections and unit RMSNorm weights,
+the first/middle/last post-hook residuals are exactly 11/21/31 at visual rows
+and one elsewhere. The production entry's final logits and every K/V element
+are also checked. The diagnostic entry reuses the production layer loop and
+only exposes those post-hook states for this oracle.
 """
 
 from __future__ import annotations
@@ -36,7 +37,7 @@ IREE_RUN = Path(
 LP = 256
 HIDDEN = 4
 LAYERS = 3
-VISUAL_MAX = 2
+VISUAL_MAX = 3
 EPS = 1e-6
 
 
@@ -111,15 +112,13 @@ def weight_inputs(work: Path) -> list[str]:
 
 
 def runtime_inputs(work: Path) -> list[str]:
-    features = [0.0] * (LAYERS * VISUAL_MAX * HIDDEN)
-    for layer in range(LAYERS):
-        features[(layer * VISUAL_MAX * HIDDEN) + layer] = 1.0
+    features = [10.0] * (LAYERS * VISUAL_MAX * HIDDEN)
     return [
-        input_file(work, "embeddings", (LP, HIDDEN), "f32", [0.0] * (LP * HIDDEN)),
+        input_file(work, "embeddings", (LP, HIDDEN), "f32", [1.0] * (LP * HIDDEN)),
         input_file(work, "positions", (LP,), "i32", list(range(LP))),
-        "--input=i32=2",
+        "--input=i32=4",
         input_file(work, "bias", (LP, LP), "f32", [0.0] * (LP * LP)),
-        input_file(work, "visual_positions", (VISUAL_MAX,), "i32", [1, -1]),
+        input_file(work, "visual_positions", (VISUAL_MAX,), "i32", [1, 2, 3]),
         input_file(
             work,
             "layer_features",
@@ -129,8 +128,60 @@ def runtime_inputs(work: Path) -> list[str]:
         ),
         input_file(work, "layer_indices", (LAYERS,), "i32", [0, 1, 2]),
         f"--input=i32={LAYERS}",
-        "--input=i32=1",
+        f"--input=i32={VISUAL_MAX}",
     ]
+
+
+def compile_module(source: Path, output: Path) -> None:
+    subprocess.run(
+        [
+            str(IREE_COMPILE),
+            str(source),
+            "--iree-input-type=stablehlo",
+            "--iree-hal-target-device=local",
+            "--iree-hal-local-target-device-backends=llvm-cpu",
+            "--iree-llvmcpu-target-cpu=host",
+            "-o",
+            str(output),
+        ],
+        check=True,
+    )
+
+
+def expected_post_hook_states(work: Path) -> str:
+    # Exact MLX-derived table, extended with unchanged rows to the static bucket.
+    visual_values = [11.0, 21.0, 31.0]
+    states: list[float] = []
+    for value in visual_values:
+        for position in range(LP):
+            row_value = value if position in (1, 2, 3) else 1.0
+            states.extend([row_value] * HIDDEN)
+    path = work / "expected_post_hook_states.bin"
+    write_values(path, "f", states)
+    return f"--expected_output={LAYERS}x{LP}x{HIDDEN}xf32=@{path}"
+
+
+def run_module(work: Path, vmfb: Path, include_states: bool) -> None:
+    normalized = 31.0 / math.sqrt(31.0 * 31.0 + EPS)
+    expected = [
+        f"--expected_output=4xf32={normalized} {normalized} {normalized} {normalized}",
+        f"--expected_output={LAYERS}x{LP}x1x{HIDDEN}xf32=0",
+        f"--expected_output={LAYERS}x{LP}x1x{HIDDEN}xf32=0",
+    ]
+    if include_states:
+        expected.append(expected_post_hook_states(work))
+    subprocess.run(
+        [
+            str(IREE_RUN),
+            "--device=local-task",
+            f"--module={vmfb}",
+            "--function=main",
+            *weight_inputs(work),
+            *runtime_inputs(work),
+            *expected,
+        ],
+        check=True,
+    )
 
 
 def main() -> int:
@@ -159,35 +210,18 @@ def main() -> int:
             },
             check=True,
         )
-        mlir = work / "prefill_embeddings_deepstack_logits.mlir"
-        vmfb = work / "prefill_embeddings_deepstack_logits.vmfb"
-        subprocess.run(
-            [
-                str(IREE_COMPILE),
-                str(mlir),
-                "--iree-input-type=stablehlo",
-                "--iree-hal-target-device=local",
-                "--iree-hal-local-target-device-backends=llvm-cpu",
-                "--iree-llvmcpu-target-cpu=host",
-                "-o",
-                str(vmfb),
-            ],
-            check=True,
-        )
-        normalized = 1.0 / math.sqrt(0.75 + EPS)
-        command = [
-            str(IREE_RUN),
-            "--device=local-task",
-            f"--module={vmfb}",
-            "--function=main",
-            *weight_inputs(work),
-            *runtime_inputs(work),
-            f"--expected_output=4xf32={normalized} {normalized} {normalized} 0",
-            "--expected_output=(ignored)",
-            "--expected_output=(ignored)",
-        ]
-        subprocess.run(command, check=True)
-    print("RESULT: PASS (sparse DeepStack prefill, IREE local-task)")
+        production_mlir = work / "prefill_embeddings_deepstack_logits.mlir"
+        production_vmfb = work / "prefill_embeddings_deepstack_logits.vmfb"
+        diagnostics_mlir = work / "prefill_embeddings_deepstack_diagnostics.mlir"
+        diagnostics_vmfb = work / "prefill_embeddings_deepstack_diagnostics.vmfb"
+        compile_module(production_mlir, production_vmfb)
+        compile_module(diagnostics_mlir, diagnostics_vmfb)
+        run_module(work, production_vmfb, include_states=False)
+        run_module(work, diagnostics_vmfb, include_states=True)
+    print(
+        "RESULT: PASS (Qwen3-VL fixed post-hook states, logits, and every K/V; "
+        "IREE local-task)"
+    )
     return 0
 
 

--- a/spike/openxla/deepstack_prefill_check.py
+++ b/spike/openxla/deepstack_prefill_check.py
@@ -7,7 +7,9 @@ component is ten. With zero transformer projections and unit RMSNorm weights,
 the first/middle/last post-hook residuals are exactly 11/21/31 at visual rows
 and one elsewhere. The production entry's final logits and every K/V element
 are also checked. The diagnostic entry reuses the production layer loop and
-only exposes those post-hook states for this oracle.
+only exposes those post-hook states for this oracle. Both ordinary 1D and
+explicit Qwen M-RoPE `[3, S]` positions execute the same fixed oracle; the root
+`xla_prepared_prefill` integration test covers the stateful first decode step.
 """
 
 from __future__ import annotations
@@ -35,14 +37,14 @@ IREE_RUN = Path(
 )
 
 LP = 256
-HIDDEN = 4
+HIDDEN = 6
 LAYERS = 3
 VISUAL_MAX = 3
 EPS = 1e-6
 
 
-def config() -> dict[str, object]:
-    return {
+def config(mrope: bool) -> dict[str, object]:
+    value: dict[str, object] = {
         "model_type": "qwen3",
         "hidden_size": HIDDEN,
         "intermediate_size": HIDDEN,
@@ -57,6 +59,12 @@ def config() -> dict[str, object]:
         "deepstack_language_layer_indices": [0, 1, 2],
         "deepstack_max_visual_positions": VISUAL_MAX,
     }
+    if mrope:
+        value["rope_scaling"] = {
+            "rope_type": "mrope",
+            "mrope_section": [1, 1, 1],
+        }
+    return value
 
 
 def write_values(path: Path, code: str, values: list[float | int]) -> None:
@@ -111,11 +119,25 @@ def weight_inputs(work: Path) -> list[str]:
     ]
 
 
-def runtime_inputs(work: Path) -> list[str]:
+def runtime_inputs(work: Path, mrope: bool) -> list[str]:
     features = [10.0] * (LAYERS * VISUAL_MAX * HIDDEN)
+    if mrope:
+        position_shape = (3, LP)
+        positions = [
+            coordinate
+            for axis in range(3)
+            for coordinate in (
+                list(range(LP))
+                if axis == 0
+                else [max(0, value - axis) for value in range(LP)]
+            )
+        ]
+    else:
+        position_shape = (LP,)
+        positions = list(range(LP))
     return [
         input_file(work, "embeddings", (LP, HIDDEN), "f32", [1.0] * (LP * HIDDEN)),
-        input_file(work, "positions", (LP,), "i32", list(range(LP))),
+        input_file(work, "positions", position_shape, "i32", positions),
         "--input=i32=4",
         input_file(work, "bias", (LP, LP), "f32", [0.0] * (LP * LP)),
         input_file(work, "visual_positions", (VISUAL_MAX,), "i32", [1, 2, 3]),
@@ -161,10 +183,11 @@ def expected_post_hook_states(work: Path) -> str:
     return f"--expected_output={LAYERS}x{LP}x{HIDDEN}xf32=@{path}"
 
 
-def run_module(work: Path, vmfb: Path, include_states: bool) -> None:
+def run_module(work: Path, vmfb: Path, include_states: bool, mrope: bool) -> None:
     normalized = 31.0 / math.sqrt(31.0 * 31.0 + EPS)
     expected = [
-        f"--expected_output=4xf32={normalized} {normalized} {normalized} {normalized}",
+        f"--expected_output={HIDDEN}xf32="
+        + " ".join([str(normalized)] * HIDDEN),
         f"--expected_output={LAYERS}x{LP}x1x{HIDDEN}xf32=0",
         f"--expected_output={LAYERS}x{LP}x1x{HIDDEN}xf32=0",
     ]
@@ -177,7 +200,7 @@ def run_module(work: Path, vmfb: Path, include_states: bool) -> None:
             f"--module={vmfb}",
             "--function=main",
             *weight_inputs(work),
-            *runtime_inputs(work),
+            *runtime_inputs(work, mrope),
             *expected,
         ],
         check=True,
@@ -188,39 +211,43 @@ def main() -> int:
     if not IREE_COMPILE.is_file() or not IREE_RUN.is_file():
         raise SystemExit("set IREE_COMPILE and IREE_RUN_MODULE to pinned IREE tools")
     with tempfile.TemporaryDirectory(prefix="mlxcel_deepstack_") as temp:
-        work = Path(temp)
-        config_path = work / "config.json"
-        config_path.write_text(json.dumps(config()), encoding="utf-8")
-        subprocess.run(
-            [
-                os.environ.get("CARGO", "cargo"),
-                "test",
-                "-p",
-                "mlxcel-xla",
-                "--lib",
-                "emitter::tests::dump_prefill_embeddings_parity_graphs",
-                "--",
-                "--ignored",
-            ],
-            cwd=REPO_ROOT,
-            env={
-                **os.environ,
-                "MLXCEL_DUMP_CONFIG": str(config_path),
-                "MLXCEL_DUMP_DIR": str(work),
-            },
-            check=True,
-        )
-        production_mlir = work / "prefill_embeddings_deepstack_logits.mlir"
-        production_vmfb = work / "prefill_embeddings_deepstack_logits.vmfb"
-        diagnostics_mlir = work / "prefill_embeddings_deepstack_diagnostics.mlir"
-        diagnostics_vmfb = work / "prefill_embeddings_deepstack_diagnostics.vmfb"
-        compile_module(production_mlir, production_vmfb)
-        compile_module(diagnostics_mlir, diagnostics_vmfb)
-        run_module(work, production_vmfb, include_states=False)
-        run_module(work, diagnostics_vmfb, include_states=True)
+        root = Path(temp)
+        for mode_name, mrope in [("one_d", False), ("mrope", True)]:
+            work = root / mode_name
+            work.mkdir()
+            config_path = work / "config.json"
+            config_path.write_text(json.dumps(config(mrope)), encoding="utf-8")
+            subprocess.run(
+                [
+                    os.environ.get("CARGO", "cargo"),
+                    "test",
+                    "-p",
+                    "mlxcel-xla",
+                    "--lib",
+                    "emitter::tests::dump_prefill_embeddings_parity_graphs",
+                    "--",
+                    "--ignored",
+                ],
+                cwd=REPO_ROOT,
+                env={
+                    **os.environ,
+                    "MLXCEL_DUMP_CONFIG": str(config_path),
+                    "MLXCEL_DUMP_DIR": str(work),
+                },
+                check=True,
+            )
+            production_mlir = work / "prefill_embeddings_deepstack_logits.mlir"
+            production_vmfb = work / "prefill_embeddings_deepstack_logits.vmfb"
+            diagnostics_mlir = work / "prefill_embeddings_deepstack_diagnostics.mlir"
+            diagnostics_vmfb = work / "prefill_embeddings_deepstack_diagnostics.vmfb"
+            compile_module(production_mlir, production_vmfb)
+            compile_module(diagnostics_mlir, diagnostics_vmfb)
+            run_module(work, production_vmfb, include_states=False, mrope=mrope)
+            run_module(work, diagnostics_vmfb, include_states=True, mrope=mrope)
+            print(f"MODE {mode_name}: PASS")
     print(
-        "RESULT: PASS (Qwen3-VL fixed post-hook states, logits, and every K/V; "
-        "IREE local-task)"
+        "RESULT: PASS (1D + M-RoPE Qwen3-VL fixed post-hook states, logits, "
+        "and every K/V; IREE local-task)"
     )
     return 0
 

--- a/spike/openxla/deepstack_prefill_check.py
+++ b/spike/openxla/deepstack_prefill_check.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Compile and execute the real sparse DeepStack prefill entry with IREE.
+
+The Qwen3 fixture makes every transformer projection zero, keeps all RMSNorm
+weights at one, and uses an identity untied LM head. Sparse features injected
+after the first, middle, and last language layers therefore accumulate at the
+final visual row to [1, 1, 1, 0]. The expected logits are its exact
+RMS-normalized value. This exercises the production StableHLO entry and the
+same post-language-layer injection point as MLX Qwen3-VL, not a test-only probe.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import struct
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IREE_HOME = Path(
+    os.environ.get(
+        "IREE_CUDA_HOME",
+        "/home/inureyes/.cache/mlxcel/iree-cuda-3.12.0rc20260721",
+    )
+)
+IREE_COMPILE = Path(
+    os.environ.get("IREE_COMPILE", IREE_HOME / "venv/bin/iree-compile")
+)
+IREE_RUN = Path(
+    os.environ.get("IREE_RUN_MODULE", IREE_HOME / "build/tools/iree-run-module")
+)
+
+LP = 256
+HIDDEN = 4
+LAYERS = 3
+VISUAL_MAX = 2
+EPS = 1e-6
+
+
+def config() -> dict[str, object]:
+    return {
+        "model_type": "qwen3",
+        "hidden_size": HIDDEN,
+        "intermediate_size": HIDDEN,
+        "num_hidden_layers": LAYERS,
+        "num_attention_heads": 1,
+        "num_key_value_heads": 1,
+        "head_dim": HIDDEN,
+        "vocab_size": HIDDEN,
+        "rms_norm_eps": EPS,
+        "rope_theta": 10_000.0,
+        "tie_word_embeddings": False,
+        "deepstack_language_layer_indices": [0, 1, 2],
+        "deepstack_max_visual_positions": VISUAL_MAX,
+    }
+
+
+def write_values(path: Path, code: str, values: list[float | int]) -> None:
+    path.write_bytes(struct.pack(f"<{len(values)}{code}", *values))
+
+
+def input_file(
+    work: Path,
+    name: str,
+    shape: tuple[int, ...],
+    dtype: str,
+    values: list[float | int],
+) -> str:
+    path = work / f"{name}.bin"
+    write_values(path, "f" if dtype == "f32" else "i", values)
+    dimensions = "x".join(str(dim) for dim in shape)
+    return f"--input={dimensions}x{dtype}=@{path}"
+
+
+def weight_inputs(work: Path) -> list[str]:
+    zero_matrix = [0.0] * (HIDDEN * HIDDEN)
+    one_norm = [1.0] * HIDDEN
+    identity = [
+        float(row == column)
+        for row in range(HIDDEN)
+        for column in range(HIDDEN)
+    ]
+    specs: list[tuple[str, tuple[int, ...], list[float]]] = [
+        ("embed", (HIDDEN, HIDDEN), zero_matrix),
+        ("final_norm", (HIDDEN,), one_norm),
+        ("lm_head", (HIDDEN, HIDDEN), identity),
+    ]
+    for layer in range(LAYERS):
+        specs.extend(
+            [
+                (f"l{layer}_down", (HIDDEN, HIDDEN), zero_matrix),
+                (f"l{layer}_gate", (HIDDEN, HIDDEN), zero_matrix),
+                (f"l{layer}_input_norm", (HIDDEN,), one_norm),
+                (f"l{layer}_post_norm", (HIDDEN,), one_norm),
+                (f"l{layer}_up", (HIDDEN, HIDDEN), zero_matrix),
+                (f"l{layer}_wk", (HIDDEN, HIDDEN), zero_matrix),
+                (f"l{layer}_wo", (HIDDEN, HIDDEN), zero_matrix),
+                (f"l{layer}_wq", (HIDDEN, HIDDEN), zero_matrix),
+                (f"l{layer}_wv", (HIDDEN, HIDDEN), zero_matrix),
+                (f"l{layer}_q_norm", (HIDDEN,), one_norm),
+                (f"l{layer}_k_norm", (HIDDEN,), one_norm),
+            ]
+        )
+    return [
+        input_file(work, name, shape, "f32", values)
+        for name, shape, values in specs
+    ]
+
+
+def runtime_inputs(work: Path) -> list[str]:
+    features = [0.0] * (LAYERS * VISUAL_MAX * HIDDEN)
+    for layer in range(LAYERS):
+        features[(layer * VISUAL_MAX * HIDDEN) + layer] = 1.0
+    return [
+        input_file(work, "embeddings", (LP, HIDDEN), "f32", [0.0] * (LP * HIDDEN)),
+        input_file(work, "positions", (LP,), "i32", list(range(LP))),
+        "--input=i32=2",
+        input_file(work, "bias", (LP, LP), "f32", [0.0] * (LP * LP)),
+        input_file(work, "visual_positions", (VISUAL_MAX,), "i32", [1, -1]),
+        input_file(
+            work,
+            "layer_features",
+            (LAYERS, VISUAL_MAX, HIDDEN),
+            "f32",
+            features,
+        ),
+        input_file(work, "layer_indices", (LAYERS,), "i32", [0, 1, 2]),
+        f"--input=i32={LAYERS}",
+        "--input=i32=1",
+    ]
+
+
+def main() -> int:
+    if not IREE_COMPILE.is_file() or not IREE_RUN.is_file():
+        raise SystemExit("set IREE_COMPILE and IREE_RUN_MODULE to pinned IREE tools")
+    with tempfile.TemporaryDirectory(prefix="mlxcel_deepstack_") as temp:
+        work = Path(temp)
+        config_path = work / "config.json"
+        config_path.write_text(json.dumps(config()), encoding="utf-8")
+        subprocess.run(
+            [
+                os.environ.get("CARGO", "cargo"),
+                "test",
+                "-p",
+                "mlxcel-xla",
+                "--lib",
+                "emitter::tests::dump_prefill_embeddings_parity_graphs",
+                "--",
+                "--ignored",
+            ],
+            cwd=REPO_ROOT,
+            env={
+                **os.environ,
+                "MLXCEL_DUMP_CONFIG": str(config_path),
+                "MLXCEL_DUMP_DIR": str(work),
+            },
+            check=True,
+        )
+        mlir = work / "prefill_embeddings_deepstack_logits.mlir"
+        vmfb = work / "prefill_embeddings_deepstack_logits.vmfb"
+        subprocess.run(
+            [
+                str(IREE_COMPILE),
+                str(mlir),
+                "--iree-input-type=stablehlo",
+                "--iree-hal-target-device=local",
+                "--iree-hal-local-target-device-backends=llvm-cpu",
+                "--iree-llvmcpu-target-cpu=host",
+                "-o",
+                str(vmfb),
+            ],
+            check=True,
+        )
+        normalized = 1.0 / math.sqrt(0.75 + EPS)
+        command = [
+            str(IREE_RUN),
+            "--device=local-task",
+            f"--module={vmfb}",
+            "--function=main",
+            *weight_inputs(work),
+            *runtime_inputs(work),
+            f"--expected_output=4xf32={normalized} {normalized} {normalized} 0",
+            "--expected_output=(ignored)",
+            "--expected_output=(ignored)",
+        ]
+        subprocess.run(command, check=True)
+    print("RESULT: PASS (sparse DeepStack prefill, IREE local-task)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lib/mlxcel-xla/csrc/xla_iree.c
+++ b/src/lib/mlxcel-xla/csrc/xla_iree.c
@@ -21,6 +21,7 @@
 // (`xla_llama_*`) and never binds the IREE runtime structs directly.
 #include <stdint.h>
 #include <stdbool.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -94,7 +95,7 @@ iree_status_t iree_xla_libc_ctl(void* self, iree_allocator_command_t command,
 typedef struct xla_ctx {
   iree_runtime_instance_t* instance;
   iree_hal_device_t* device;
-  iree_runtime_session_t* session;   // holds @prefill, @prefill_embeddings, @decode_step
+  iree_runtime_session_t* session;   // holds the compatible prefill/decode bundle
   iree_hal_allocator_t* allocator;   // device allocator (shared by all calls)
   uint64_t compatibility_fingerprint;
   int32_t n_weights;
@@ -108,6 +109,11 @@ typedef struct xla_ctx {
   int32_t prefill_embeddings_kind;
   int32_t dense_ple_layers;
   int32_t dense_ple_hidden;
+  int32_t model_layers;
+  int32_t deepstack_layers;
+  int32_t deepstack_visual_positions;
+  int32_t* deepstack_target_layers;
+  int32_t has_deepstack;
   int32_t has_prefill_diagnostics;
   iree_hal_buffer_view_t** weights;  // resident weights, uploaded once
   iree_hal_buffer_view_t* kcache;    // threaded KV (set by prefill, advanced by decode)
@@ -306,7 +312,8 @@ static int xla_validate_kv_pair(xla_ctx* c, iree_hal_buffer_view_t* kc,
 
 static iree_status_t xla_llama_create_impl(
     xla_ctx* c, const char* device_uri, const char* prefill_vmfb,
-    const char* prefill_embeddings_vmfb, const char* decode_vmfb,
+    const char* prefill_embeddings_vmfb,
+    const char* prefill_embeddings_deepstack_vmfb, const char* decode_vmfb,
     const char* prefill_diagnostics_vmfb,
     uint64_t compatibility_fingerprint, int32_t n_weights,
     const void* const* weight_data,
@@ -314,7 +321,9 @@ static iree_status_t xla_llama_create_impl(
     const int64_t* weight_dims, int32_t context_capacity,
     int32_t hidden_size, int32_t position_mode,
     int32_t prefill_embeddings_kind,
-    int32_t dense_ple_layers, int32_t dense_ple_hidden) {
+    int32_t dense_ple_layers, int32_t dense_ple_hidden, int32_t model_layers,
+    int32_t deepstack_layers, int32_t deepstack_visual_positions,
+    const int32_t* deepstack_target_layers) {
   if (context_capacity <= 0 || hidden_size <= 0 ||
       compatibility_fingerprint == 0) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
@@ -333,6 +342,27 @@ static iree_status_t xla_llama_create_impl(
         IREE_STATUS_INVALID_ARGUMENT,
         "invalid embeddings entry kind or dense PLE dimensions");
   }
+  bool has_deepstack = prefill_embeddings_deepstack_vmfb &&
+                       prefill_embeddings_deepstack_vmfb[0] != '\0';
+  if (model_layers <= 0 ||
+      (has_deepstack &&
+       (prefill_embeddings_kind != 0 || deepstack_layers <= 0 ||
+        deepstack_visual_positions <= 0 || !deepstack_target_layers)) ||
+      (!has_deepstack &&
+       (deepstack_layers != 0 || deepstack_visual_positions != 0 ||
+        deepstack_target_layers != NULL))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid optional DeepStack bundle contract");
+  }
+  for (int32_t i = 0; i < deepstack_layers; ++i) {
+    int32_t layer = deepstack_target_layers[i];
+    if (layer < 0 || layer >= model_layers ||
+        (i > 0 && layer <= deepstack_target_layers[i - 1])) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "DeepStack target layers must be sorted, unique, and in model bounds");
+    }
+  }
   c->n_weights = n_weights;
   c->context_capacity = context_capacity;
   c->hidden_size = hidden_size;
@@ -341,6 +371,19 @@ static iree_status_t xla_llama_create_impl(
   c->prefill_embeddings_kind = prefill_embeddings_kind;
   c->dense_ple_layers = dense_ple_layers;
   c->dense_ple_hidden = dense_ple_hidden;
+  c->model_layers = model_layers;
+  c->deepstack_layers = deepstack_layers;
+  c->deepstack_visual_positions = deepstack_visual_positions;
+  c->has_deepstack = has_deepstack;
+  if (has_deepstack) {
+    c->deepstack_target_layers =
+        (int32_t*)malloc((size_t)deepstack_layers * sizeof(int32_t));
+    if (!c->deepstack_target_layers) {
+      return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED);
+    }
+    memcpy(c->deepstack_target_layers, deepstack_target_layers,
+           (size_t)deepstack_layers * sizeof(int32_t));
+  }
   c->has_prefill_diagnostics =
       prefill_diagnostics_vmfb && prefill_diagnostics_vmfb[0] != '\0';
 
@@ -370,6 +413,10 @@ static iree_status_t xla_llama_create_impl(
       c->session, prefill_vmfb));
   IREE_RETURN_IF_ERROR(iree_runtime_session_append_bytecode_module_from_file(
       c->session, prefill_embeddings_vmfb));
+  if (c->has_deepstack) {
+    IREE_RETURN_IF_ERROR(iree_runtime_session_append_bytecode_module_from_file(
+        c->session, prefill_embeddings_deepstack_vmfb));
+  }
   IREE_RETURN_IF_ERROR(iree_runtime_session_append_bytecode_module_from_file(
       c->session, decode_vmfb));
   if (c->has_prefill_diagnostics) {
@@ -386,6 +433,13 @@ static iree_status_t xla_llama_create_impl(
     iree_runtime_call_t probe;
     IREE_RETURN_IF_ERROR(iree_runtime_call_initialize_by_name(
         c->session, iree_make_cstring_view(required_entries[i]), &probe));
+    iree_runtime_call_deinitialize(&probe);
+  }
+  if (c->has_deepstack) {
+    iree_runtime_call_t probe;
+    IREE_RETURN_IF_ERROR(iree_runtime_call_initialize_by_name(
+        c->session,
+        iree_make_cstring_view("prefill_embeddings_deepstack.main"), &probe));
     iree_runtime_call_deinitialize(&probe);
   }
   if (c->has_prefill_diagnostics) {
@@ -447,6 +501,7 @@ static iree_status_t xla_llama_create_impl(
 // a diagnostic).
 xla_ctx* xla_llama_create(const char* device_uri, const char* prefill_vmfb,
                           const char* prefill_embeddings_vmfb,
+                          const char* prefill_embeddings_deepstack_vmfb,
                           const char* decode_vmfb,
                           const char* prefill_diagnostics_vmfb,
                           uint64_t compatibility_fingerprint,
@@ -459,19 +514,25 @@ xla_ctx* xla_llama_create(const char* device_uri, const char* prefill_vmfb,
                           int32_t position_mode,
                           int32_t prefill_embeddings_kind,
                           int32_t dense_ple_layers,
-                          int32_t dense_ple_hidden) {
+                          int32_t dense_ple_hidden, int32_t model_layers,
+                          int32_t deepstack_layers,
+                          int32_t deepstack_visual_positions,
+                          const int32_t* deepstack_target_layers) {
   xla_ctx* c = (xla_ctx*)calloc(1, sizeof(xla_ctx));
   if (!c) return NULL;
   iree_status_t s =
       xla_llama_create_impl(c, device_uri, prefill_vmfb,
-                            prefill_embeddings_vmfb, decode_vmfb,
+                            prefill_embeddings_vmfb,
+                            prefill_embeddings_deepstack_vmfb, decode_vmfb,
                             prefill_diagnostics_vmfb,
                             compatibility_fingerprint, n_weights, weight_data,
                             weight_dtypes, weight_ranks, weight_dims,
                             context_capacity, hidden_size,
                             position_mode,
                             prefill_embeddings_kind, dense_ple_layers,
-                            dense_ple_hidden);
+                            dense_ple_hidden, model_layers, deepstack_layers,
+                            deepstack_visual_positions,
+                            deepstack_target_layers);
   if (!iree_status_is_ok(s)) {
     char buf[512];
     iree_host_size_t got = 0;
@@ -1128,6 +1189,235 @@ int xla_llama_prefill_embeddings_ple_slot_logits(
       real_len, vocab, NULL, out_logits);
 }
 
+static int xla_llama_prefill_embeddings_deepstack_impl(
+    xla_ctx* c, int32_t slot, const xla_tensor_desc* embeddings,
+    const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
+    const xla_tensor_desc* visual_positions,
+    const xla_tensor_desc* layer_features,
+    const xla_tensor_desc* layer_indices, int32_t actual_layer_count,
+    int32_t actual_visual_count, int32_t real_len, int32_t vocab,
+    int32_t* out_token, float* out_logits) {
+  if (!c || !c->has_deepstack || real_len <= 0 ||
+      real_len > c->context_capacity ||
+      actual_layer_count != c->deepstack_layers ||
+      actual_visual_count < 0 ||
+      actual_visual_count > c->deepstack_visual_positions) {
+    fprintf(stderr,
+            "xla_llama_prefill_embeddings_deepstack: invalid bundle/count/length contract\n");
+    return 1;
+  }
+  int64_t embeddings_dims[2] = {c->context_capacity, c->hidden_size};
+  int64_t positions_dims[1] = {c->context_capacity};
+  int64_t bias_dims[2] = {c->context_capacity, c->context_capacity};
+  int64_t visual_position_dims[1] = {c->deepstack_visual_positions};
+  int64_t layer_feature_dims[3] = {
+      c->deepstack_layers, c->deepstack_visual_positions, c->hidden_size};
+  int64_t layer_index_dims[1] = {c->deepstack_layers};
+  if (xla_validate_tensor_desc("embeddings", embeddings, 0, 2,
+                               embeddings_dims) != 0 ||
+      xla_validate_tensor_desc("positions", positions, 1, 1,
+                               positions_dims) != 0 ||
+      xla_validate_tensor_desc("attention_bias", attention_bias, 0, 2,
+                               bias_dims) != 0 ||
+      xla_validate_tensor_desc("deepstack.visual_positions", visual_positions,
+                               1, 1, visual_position_dims) != 0 ||
+      xla_validate_tensor_desc("deepstack.layer_features", layer_features, 0,
+                               3, layer_feature_dims) != 0 ||
+      xla_validate_tensor_desc("deepstack.layer_indices", layer_indices, 1, 1,
+                               layer_index_dims) != 0) {
+    return 1;
+  }
+
+  const int32_t* visual = (const int32_t*)visual_positions->data;
+  const int32_t* layers = (const int32_t*)layer_indices->data;
+  const float* features = (const float*)layer_features->data;
+  for (int32_t i = 0; i < actual_visual_count; ++i) {
+    if (visual[i] < 0 || visual[i] >= real_len ||
+        (i > 0 && visual[i] <= visual[i - 1])) {
+      fprintf(stderr,
+              "xla_llama_prefill_embeddings_deepstack: visual positions must be sorted, unique, and in range\n");
+      return 1;
+    }
+  }
+  for (int32_t i = actual_visual_count;
+       i < c->deepstack_visual_positions; ++i) {
+    if (visual[i] != -1) {
+      fprintf(stderr,
+              "xla_llama_prefill_embeddings_deepstack: padded visual positions must be -1\n");
+      return 1;
+    }
+  }
+  for (int32_t i = 0; i < actual_layer_count; ++i) {
+    if (layers[i] != c->deepstack_target_layers[i] || layers[i] < 0 ||
+        layers[i] >= c->model_layers) {
+      fprintf(stderr,
+              "xla_llama_prefill_embeddings_deepstack: layer indices disagree with compiled targets\n");
+      return 1;
+    }
+  }
+  size_t feature_count =
+      (size_t)c->deepstack_layers *
+      (size_t)c->deepstack_visual_positions * (size_t)c->hidden_size;
+  for (size_t i = 0; i < feature_count; ++i) {
+    if (!isfinite(features[i])) {
+      fprintf(stderr,
+              "xla_llama_prefill_embeddings_deepstack: non-finite layer feature\n");
+      return 1;
+    }
+  }
+  for (int32_t layer = 0; layer < c->deepstack_layers; ++layer) {
+    for (int32_t visual_index = actual_visual_count;
+         visual_index < c->deepstack_visual_positions; ++visual_index) {
+      size_t offset =
+          ((size_t)layer * (size_t)c->deepstack_visual_positions +
+           (size_t)visual_index) *
+          (size_t)c->hidden_size;
+      for (int32_t hidden = 0; hidden < c->hidden_size; ++hidden) {
+        if (features[offset + (size_t)hidden] != 0.0f) {
+          fprintf(stderr,
+                  "xla_llama_prefill_embeddings_deepstack: padded feature rows must be zero\n");
+          return 1;
+        }
+      }
+    }
+  }
+
+  bool batched = slot >= 0;
+  if ((!batched && !out_token) ||
+      (batched && (slot >= c->rg_bsz || vocab <= 0 || !out_logits))) {
+    fprintf(stderr,
+            "xla_llama_prefill_embeddings_deepstack: invalid slot/output/vocab contract\n");
+    return 1;
+  }
+
+  int rc = 0;
+  bool call_initialized = false;
+  iree_runtime_call_t call;
+  iree_hal_buffer_view_t* embeddings_bv = NULL;
+  iree_hal_buffer_view_t* positions_bv = NULL;
+  iree_hal_buffer_view_t* len_bv = NULL;
+  iree_hal_buffer_view_t* bias_bv = NULL;
+  iree_hal_buffer_view_t* visual_bv = NULL;
+  iree_hal_buffer_view_t* features_bv = NULL;
+  iree_hal_buffer_view_t* layers_bv = NULL;
+  iree_hal_buffer_view_t* actual_layers_bv = NULL;
+  iree_hal_buffer_view_t* actual_visual_bv = NULL;
+  iree_hal_buffer_view_t* output = NULL;
+  iree_hal_buffer_view_t* kc = NULL;
+  iree_hal_buffer_view_t* vc = NULL;
+
+  XLA_CHECK_GOTO(iree_runtime_call_initialize_by_name(
+                     c->session,
+                     iree_make_cstring_view(
+                         "prefill_embeddings_deepstack.main"),
+                     &call),
+                 cleanup, rc);
+  call_initialized = true;
+  for (int32_t i = 0; i < c->n_weights; ++i) {
+    XLA_CHECK_GOTO(
+        iree_runtime_call_inputs_push_back_buffer_view(&call, c->weights[i]),
+        cleanup, rc);
+  }
+  XLA_CHECK_GOTO(xla_alloc_desc_bv(c, embeddings, &embeddings_bv), cleanup, rc);
+  XLA_CHECK_GOTO(xla_alloc_desc_bv(c, positions, &positions_bv), cleanup, rc);
+  XLA_CHECK_GOTO(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32,
+                             &real_len, sizeof(int32_t), &len_bv),
+                 cleanup, rc);
+  XLA_CHECK_GOTO(xla_alloc_desc_bv(c, attention_bias, &bias_bv), cleanup, rc);
+  XLA_CHECK_GOTO(xla_alloc_desc_bv(c, visual_positions, &visual_bv), cleanup,
+                 rc);
+  XLA_CHECK_GOTO(xla_alloc_desc_bv(c, layer_features, &features_bv), cleanup,
+                 rc);
+  XLA_CHECK_GOTO(xla_alloc_desc_bv(c, layer_indices, &layers_bv), cleanup, rc);
+  XLA_CHECK_GOTO(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32,
+                             &actual_layer_count, sizeof(int32_t),
+                             &actual_layers_bv),
+                 cleanup, rc);
+  XLA_CHECK_GOTO(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32,
+                             &actual_visual_count, sizeof(int32_t),
+                             &actual_visual_bv),
+                 cleanup, rc);
+  iree_hal_buffer_view_t* inputs[] = {
+      embeddings_bv, positions_bv, len_bv,          bias_bv, visual_bv,
+      features_bv,   layers_bv,    actual_layers_bv, actual_visual_bv};
+  for (size_t i = 0; i < sizeof(inputs) / sizeof(inputs[0]); ++i) {
+    XLA_CHECK_GOTO(
+        iree_runtime_call_inputs_push_back_buffer_view(&call, inputs[i]),
+        cleanup, rc);
+  }
+  XLA_CHECK_GOTO(iree_runtime_call_invoke(&call, 0), cleanup, rc);
+  XLA_CHECK_GOTO(
+      iree_runtime_call_outputs_pop_front_buffer_view(&call, &output), cleanup,
+      rc);
+  XLA_CHECK_GOTO(iree_runtime_call_outputs_pop_front_buffer_view(&call, &kc),
+                 cleanup, rc);
+  XLA_CHECK_GOTO(iree_runtime_call_outputs_pop_front_buffer_view(&call, &vc),
+                 cleanup, rc);
+  if (xla_validate_kv_pair(c, kc, vc, 4, 1) != 0) {
+    rc = 1;
+    goto cleanup;
+  }
+  if (batched) {
+    XLA_CHECK_GOTO(
+        xla_read_logits(c, output, out_logits, (iree_host_size_t)vocab),
+        cleanup, rc);
+    rc = xla_store_prefill_kv_slot(c, slot, kc, vc);
+  } else {
+    XLA_CHECK_GOTO(xla_read_token(c, output, out_token), cleanup, rc);
+    iree_hal_buffer_view_t* old_k = c->kcache;
+    iree_hal_buffer_view_t* old_v = c->vcache;
+    c->kcache = kc;
+    c->vcache = vc;
+    kc = NULL;
+    vc = NULL;
+    if (old_k) iree_hal_buffer_view_release(old_k);
+    if (old_v) iree_hal_buffer_view_release(old_v);
+  }
+
+cleanup:
+  if (output) iree_hal_buffer_view_release(output);
+  if (kc) iree_hal_buffer_view_release(kc);
+  if (vc) iree_hal_buffer_view_release(vc);
+  if (embeddings_bv) iree_hal_buffer_view_release(embeddings_bv);
+  if (positions_bv) iree_hal_buffer_view_release(positions_bv);
+  if (len_bv) iree_hal_buffer_view_release(len_bv);
+  if (bias_bv) iree_hal_buffer_view_release(bias_bv);
+  if (visual_bv) iree_hal_buffer_view_release(visual_bv);
+  if (features_bv) iree_hal_buffer_view_release(features_bv);
+  if (layers_bv) iree_hal_buffer_view_release(layers_bv);
+  if (actual_layers_bv) iree_hal_buffer_view_release(actual_layers_bv);
+  if (actual_visual_bv) iree_hal_buffer_view_release(actual_visual_bv);
+  if (call_initialized) iree_runtime_call_deinitialize(&call);
+  return rc;
+}
+
+int xla_llama_prefill_embeddings_deepstack(
+    xla_ctx* c, const xla_tensor_desc* embeddings,
+    const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
+    const xla_tensor_desc* visual_positions,
+    const xla_tensor_desc* layer_features,
+    const xla_tensor_desc* layer_indices, int32_t actual_layer_count,
+    int32_t actual_visual_count, int32_t real_len, int32_t* out_token) {
+  return xla_llama_prefill_embeddings_deepstack_impl(
+      c, -1, embeddings, positions, attention_bias, visual_positions,
+      layer_features, layer_indices, actual_layer_count, actual_visual_count,
+      real_len, 0, out_token, NULL);
+}
+
+int xla_llama_prefill_embeddings_deepstack_slot_logits(
+    xla_ctx* c, int32_t slot, const xla_tensor_desc* embeddings,
+    const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
+    const xla_tensor_desc* visual_positions,
+    const xla_tensor_desc* layer_features,
+    const xla_tensor_desc* layer_indices, int32_t actual_layer_count,
+    int32_t actual_visual_count, int32_t real_len, int32_t vocab,
+    float* out_logits) {
+  return xla_llama_prefill_embeddings_deepstack_impl(
+      c, slot, embeddings, positions, attention_bias, visual_positions,
+      layer_features, layer_indices, actual_layer_count, actual_visual_count,
+      real_len, vocab, NULL, out_logits);
+}
+
 // Ragged decode_step: token[B], pos[B], cache_len[B] (per row), rank-5 KV ->
 // `[B, vocab]` LOGITS (copied to host `out_logits`); advances the resident rank-5
 // KV in place. The caller (engine) samples a token per row. Inactive rows
@@ -1259,6 +1549,7 @@ void xla_llama_free(xla_ctx* c) {
   if (c->vcache) iree_hal_buffer_view_release(c->vcache);
   if (c->kcache_b) iree_hal_buffer_view_release(c->kcache_b);
   if (c->vcache_b) iree_hal_buffer_view_release(c->vcache_b);
+  free(c->deepstack_target_layers);
   if (c->session) iree_runtime_session_release(c->session);
   if (c->device) iree_hal_device_release(c->device);
   if (c->instance) iree_runtime_instance_release(c->instance);

--- a/src/lib/mlxcel-xla/csrc/xla_iree.c
+++ b/src/lib/mlxcel-xla/csrc/xla_iree.c
@@ -1190,24 +1190,27 @@ int xla_llama_prefill_embeddings_ple_slot_logits(
 }
 
 static int xla_llama_prefill_embeddings_deepstack_impl(
-    xla_ctx* c, int32_t slot, const xla_tensor_desc* embeddings,
+    xla_ctx* c, int32_t slot, int32_t position_mode,
+    const xla_tensor_desc* embeddings,
     const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
     const xla_tensor_desc* visual_positions,
     const xla_tensor_desc* layer_features,
     const xla_tensor_desc* layer_indices, int32_t actual_layer_count,
     int32_t actual_visual_count, int32_t real_len, int32_t vocab,
     int32_t* out_token, float* out_logits) {
-  if (!c || !c->has_deepstack || real_len <= 0 ||
+  if (!c || !c->has_deepstack || position_mode != c->position_mode ||
+      real_len <= 0 ||
       real_len > c->context_capacity ||
       actual_layer_count != c->deepstack_layers ||
       actual_visual_count < 0 ||
       actual_visual_count > c->deepstack_visual_positions) {
     fprintf(stderr,
-            "xla_llama_prefill_embeddings_deepstack: invalid bundle/count/length contract\n");
+            "xla_llama_prefill_embeddings_deepstack: invalid bundle/mode/count/length contract\n");
     return 1;
   }
   int64_t embeddings_dims[2] = {c->context_capacity, c->hidden_size};
-  int64_t positions_dims[1] = {c->context_capacity};
+  int64_t positions_1d_dims[1] = {c->context_capacity};
+  int64_t positions_mrope_dims[2] = {3, c->context_capacity};
   int64_t bias_dims[2] = {c->context_capacity, c->context_capacity};
   int64_t visual_position_dims[1] = {c->deepstack_visual_positions};
   int64_t layer_feature_dims[3] = {
@@ -1215,8 +1218,9 @@ static int xla_llama_prefill_embeddings_deepstack_impl(
   int64_t layer_index_dims[1] = {c->deepstack_layers};
   if (xla_validate_tensor_desc("embeddings", embeddings, 0, 2,
                                embeddings_dims) != 0 ||
-      xla_validate_tensor_desc("positions", positions, 1, 1,
-                               positions_dims) != 0 ||
+      xla_validate_tensor_desc(
+          "positions", positions, 1, position_mode == 1 ? 2 : 1,
+          position_mode == 1 ? positions_mrope_dims : positions_1d_dims) != 0 ||
       xla_validate_tensor_desc("attention_bias", attention_bias, 0, 2,
                                bias_dims) != 0 ||
       xla_validate_tensor_desc("deepstack.visual_positions", visual_positions,
@@ -1392,20 +1396,21 @@ cleanup:
 }
 
 int xla_llama_prefill_embeddings_deepstack(
-    xla_ctx* c, const xla_tensor_desc* embeddings,
+    xla_ctx* c, int32_t position_mode, const xla_tensor_desc* embeddings,
     const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
     const xla_tensor_desc* visual_positions,
     const xla_tensor_desc* layer_features,
     const xla_tensor_desc* layer_indices, int32_t actual_layer_count,
     int32_t actual_visual_count, int32_t real_len, int32_t* out_token) {
   return xla_llama_prefill_embeddings_deepstack_impl(
-      c, -1, embeddings, positions, attention_bias, visual_positions,
+      c, -1, position_mode, embeddings, positions, attention_bias, visual_positions,
       layer_features, layer_indices, actual_layer_count, actual_visual_count,
       real_len, 0, out_token, NULL);
 }
 
 int xla_llama_prefill_embeddings_deepstack_slot_logits(
-    xla_ctx* c, int32_t slot, const xla_tensor_desc* embeddings,
+    xla_ctx* c, int32_t slot, int32_t position_mode,
+    const xla_tensor_desc* embeddings,
     const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
     const xla_tensor_desc* visual_positions,
     const xla_tensor_desc* layer_features,
@@ -1413,7 +1418,7 @@ int xla_llama_prefill_embeddings_deepstack_slot_logits(
     int32_t actual_visual_count, int32_t real_len, int32_t vocab,
     float* out_logits) {
   return xla_llama_prefill_embeddings_deepstack_impl(
-      c, slot, embeddings, positions, attention_bias, visual_positions,
+      c, slot, position_mode, embeddings, positions, attention_bias, visual_positions,
       layer_features, layer_indices, actual_layer_count, actual_visual_count,
       real_len, vocab, NULL, out_logits);
 }

--- a/src/lib/mlxcel-xla/src/batch.rs
+++ b/src/lib/mlxcel-xla/src/batch.rs
@@ -48,6 +48,8 @@ use mlxcel_core::session::{
 #[cfg(feature = "iree")]
 use std::path::Path;
 
+#[cfg(feature = "iree")]
+use crate::DeepStackPreparedPrefill;
 use crate::Gemma3nDensePle;
 #[cfg(feature = "iree")]
 use crate::Gemma3nPreparedPrefill;
@@ -58,6 +60,7 @@ use crate::prepared::PreparedPositionMode;
 use crate::prepared::{
     MropeCoordinateError, PreparedInputError, PreparedIreePrefill, mrope_decode_coordinate,
 };
+use crate::prepared_deepstack::PreparedDeepStack;
 use crate::sampler::SampleParams;
 #[cfg(feature = "iree")]
 use crate::sampler::sample;
@@ -71,6 +74,7 @@ pub enum XlaAdmissionError {
     ContextCapacity(ContextCapacityError),
     Prepared(PreparedInputError),
     Gemma3nPrepared(String),
+    DeepStackPrepared(String),
 }
 
 impl fmt::Display for XlaAdmissionError {
@@ -81,6 +85,7 @@ impl fmt::Display for XlaAdmissionError {
             Self::ContextCapacity(err) => err.fmt(f),
             Self::Prepared(err) => err.fmt(f),
             Self::Gemma3nPrepared(err) => f.write_str(err),
+            Self::DeepStackPrepared(err) => f.write_str(err),
         }
     }
 }
@@ -153,6 +158,10 @@ enum PendingInput {
         prepared: PreparedIreePrefill,
         dense_ple: Gemma3nDensePle,
     },
+    DeepStackPrepared {
+        prepared: PreparedIreePrefill,
+        deepstack: PreparedDeepStack,
+    },
 }
 
 impl PendingInput {
@@ -161,6 +170,7 @@ impl PendingInput {
             Self::Tokens(tokens) => tokens,
             Self::Prepared(prepared) => &prepared.token_ids,
             Self::Gemma3nPrepared { prepared, .. } => &prepared.token_ids,
+            Self::DeepStackPrepared { prepared, .. } => &prepared.token_ids,
         }
     }
 
@@ -169,6 +179,7 @@ impl PendingInput {
             Self::Tokens(tokens) => tokens.len(),
             Self::Prepared(prepared) => prepared.effective_len,
             Self::Gemma3nPrepared { prepared, .. } => prepared.effective_len,
+            Self::DeepStackPrepared { prepared, .. } => prepared.effective_len,
         }
     }
 
@@ -368,6 +379,28 @@ fn mrope_slot_coordinates(slots: &[Option<Slot>]) -> Result<Vec<[i32; 3]>, Mrope
         .collect()
 }
 
+fn queue_deepstack_prepared_request(
+    sched: &mut Scheduler,
+    prepared: PreparedIreePrefill,
+    deepstack: PreparedDeepStack,
+    max_new_tokens: usize,
+    params: SampleParams,
+    context_capacity: usize,
+) -> Result<u64, XlaAdmissionError> {
+    if max_new_tokens == 0 {
+        return Err(XlaAdmissionError::ZeroMaxNewTokens);
+    }
+    validate_request_capacity(prepared.effective_len, max_new_tokens, context_capacity)?;
+    Ok(sched.submit_input(
+        PendingInput::DeepStackPrepared {
+            prepared,
+            deepstack,
+        },
+        max_new_tokens,
+        params,
+    ))
+}
+
 /// The continuous-batching engine: `B_max` slots over one ragged decode graph,
 /// fed by a FIFO queue. See the module docs.
 #[cfg(feature = "iree")]
@@ -520,6 +553,34 @@ impl XlaBatchEngine {
         )
     }
 
+    /// Queue a prepared embeddings request with compact per-layer DeepStack
+    /// features. The pending entry owns both static payloads and drops them on
+    /// admission, cancellation, or any error path; decode slot state retains
+    /// only KV and logical token history.
+    pub fn submit_deepstack_prepared(
+        &mut self,
+        request: DeepStackPreparedPrefill,
+        max_new_tokens: usize,
+        params: SampleParams,
+    ) -> Result<u64, XlaAdmissionError> {
+        let context_capacity = self.context_capacity();
+        let (prepared, features) = request.into_parts();
+        let deepstack = self
+            .engine
+            .prepare_deepstack(&features)
+            .map_err(XlaAdmissionError::DeepStackPrepared)?;
+        let prepared =
+            PreparedIreePrefill::prepare(&prepared, self.engine.hidden_size(), context_capacity)?;
+        queue_deepstack_prepared_request(
+            &mut self.sched,
+            prepared,
+            deepstack,
+            max_new_tokens,
+            params,
+            context_capacity,
+        )
+    }
+
     /// Cancel a request by id (frees its slot or drops it from the queue).
     /// Returns whether it was found. A cancelled request emits no further events.
     pub fn cancel(&mut self, req_id: u64) -> bool {
@@ -562,6 +623,12 @@ impl XlaBatchEngine {
                 } => self
                     .engine
                     .prefill_gemma3n_prepared_slot_logits(s, prepared, dense_ple)?,
+                PendingInput::DeepStackPrepared {
+                    prepared,
+                    deepstack,
+                } => self
+                    .engine
+                    .prefill_deepstack_prepared_slot_logits(s, prepared, deepstack)?,
             };
             let mut rng = resolve_seed(&p.params, p.req_id);
             // History-based penalties see the prompt plus generated tokens (the
@@ -1126,6 +1193,22 @@ mod tests {
         }
     }
 
+    fn deepstack_input(tokens: Vec<i32>) -> PendingInput {
+        PendingInput::DeepStackPrepared {
+            prepared: prepared_input(tokens, 2, 8),
+            deepstack: PreparedDeepStack {
+                visual_positions: vec![1, -1],
+                layer_features: vec![1.0, 2.0, 0.0, 0.0],
+                layer_indices: vec![0],
+                actual_layer_count: 1,
+                actual_visual_count: 1,
+                max_layer_count: 1,
+                max_visual_count: 2,
+                hidden_size: 2,
+            },
+        }
+    }
+
     #[test]
     fn submit_assigns_increasing_ids_and_queues() {
         let mut s = Scheduler::new(2, EOS.to_vec());
@@ -1200,6 +1283,8 @@ mod tests {
         let multimodal =
             s.submit_input(PendingInput::Prepared(prepared), 8, SampleParams::greedy());
         let gemma3n = s.submit_input(gemma3n_input(vec![10, 11]), 8, SampleParams::greedy());
+        let deepstack =
+            s.submit_input(deepstack_input(vec![12, 13, 14]), 8, SampleParams::greedy());
 
         let first = s.pop_next_pending().unwrap();
         assert_eq!(first.req_id, text);
@@ -1218,6 +1303,15 @@ mod tests {
         assert!(matches!(third.input, PendingInput::Gemma3nPrepared { .. }));
         assert_eq!(third.input.logical_tokens(), &[10, 11]);
         assert_eq!(third.input.effective_len(), 2);
+
+        let fourth = s.pop_next_pending().unwrap();
+        assert_eq!(fourth.req_id, deepstack);
+        assert!(matches!(
+            fourth.input,
+            PendingInput::DeepStackPrepared { .. }
+        ));
+        assert_eq!(fourth.input.logical_tokens(), &[12, 13, 14]);
+        assert_eq!(fourth.input.effective_len(), 3);
     }
 
     #[test]
@@ -1333,6 +1427,22 @@ mod tests {
         assert!(
             s.queue.is_empty(),
             "cancellation must drop the request-owned PLE now, not at a later pump"
+        );
+
+        let replacement = s.submit(vec![9], 2, g());
+        assert_eq!(s.pop_next_pending().unwrap().req_id, replacement);
+        assert_eq!(s.free_slots(), vec![0]);
+    }
+
+    #[test]
+    fn deepstack_side_tensors_are_dropped_on_cancel_and_slot_can_be_reused() {
+        let mut s = Scheduler::new(1, EOS.to_vec());
+        let deepstack = s.submit_input(deepstack_input(vec![1, 2, 3]), 8, g());
+        assert_eq!(s.queue.len(), 1);
+        assert!(s.cancel(deepstack));
+        assert!(
+            s.queue.is_empty(),
+            "cancellation must drop request-owned DeepStack tensors immediately"
         );
 
         let replacement = s.submit(vec![9], 2, g());

--- a/src/lib/mlxcel-xla/src/batch.rs
+++ b/src/lib/mlxcel-xla/src/batch.rs
@@ -48,14 +48,12 @@ use mlxcel_core::session::{
 #[cfg(feature = "iree")]
 use std::path::Path;
 
-#[cfg(feature = "iree")]
-use crate::DeepStackPreparedPrefill;
 use crate::Gemma3nDensePle;
 #[cfg(feature = "iree")]
 use crate::Gemma3nPreparedPrefill;
 #[cfg(feature = "iree")]
 use crate::iree::{IreeLlama, IreeRaggedLlama};
-#[cfg(feature = "iree")]
+#[cfg(any(feature = "iree", test))]
 use crate::prepared::PreparedPositionMode;
 use crate::prepared::{
     MropeCoordinateError, PreparedInputError, PreparedIreePrefill, mrope_decode_coordinate,
@@ -65,6 +63,8 @@ use crate::sampler::SampleParams;
 #[cfg(feature = "iree")]
 use crate::sampler::sample;
 use crate::{ContextCapacityError, validate_request_capacity};
+#[cfg(any(feature = "iree", test))]
+use crate::{DeepStackFeatures, DeepStackPreparedPrefill};
 
 /// Typed validation failure returned before a request enters the scheduler.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -403,6 +403,28 @@ fn queue_deepstack_prepared_request(
     ))
 }
 
+#[cfg(any(feature = "iree", test))]
+fn prepare_deepstack_input<F>(
+    request: DeepStackPreparedPrefill,
+    hidden_size: usize,
+    context_capacity: usize,
+    position_mode: PreparedPositionMode,
+    prepare_features: F,
+) -> Result<(PreparedIreePrefill, PreparedDeepStack), XlaAdmissionError>
+where
+    F: FnOnce(&DeepStackFeatures) -> Result<PreparedDeepStack, String>,
+{
+    let (prepared, features) = request.into_parts();
+    let deepstack = prepare_features(&features).map_err(XlaAdmissionError::DeepStackPrepared)?;
+    let prepared = PreparedIreePrefill::prepare_for_mode(
+        &prepared,
+        hidden_size,
+        context_capacity,
+        position_mode,
+    )?;
+    Ok((prepared, deepstack))
+}
+
 /// The continuous-batching engine: `B_max` slots over one ragged decode graph,
 /// fed by a FIFO queue. See the module docs.
 #[cfg(feature = "iree")]
@@ -566,16 +588,14 @@ impl XlaBatchEngine {
         params: SampleParams,
     ) -> Result<u64, XlaAdmissionError> {
         let context_capacity = self.context_capacity();
-        let (prepared, features) = request.into_parts();
-        let deepstack = self
-            .engine
-            .prepare_deepstack(&features)
-            .map_err(XlaAdmissionError::DeepStackPrepared)?;
-        let prepared = PreparedIreePrefill::prepare_for_mode(
-            &prepared,
-            self.engine.hidden_size(),
+        let hidden_size = self.engine.hidden_size();
+        let position_mode = self.engine.position_mode();
+        let (prepared, deepstack) = prepare_deepstack_input(
+            request,
+            hidden_size,
             context_capacity,
-            self.engine.position_mode(),
+            position_mode,
+            |features| self.engine.prepare_deepstack(features),
         )?;
         queue_deepstack_prepared_request(
             &mut self.sched,
@@ -1191,6 +1211,92 @@ mod tests {
         PreparedIreePrefill::prepare(&value, hidden, capacity).unwrap()
     }
 
+    fn tensor_i32(shape: &[usize], values: &[i32]) -> OwnedTensor {
+        OwnedTensor::new(
+            values
+                .iter()
+                .flat_map(|value| value.to_le_bytes())
+                .collect(),
+            PreparedTensorDType::Int32,
+            shape.to_vec(),
+        )
+        .unwrap()
+    }
+
+    fn tensor_f32(shape: &[usize], values: &[f32]) -> OwnedTensor {
+        OwnedTensor::new(
+            values
+                .iter()
+                .flat_map(|value| value.to_le_bytes())
+                .collect(),
+            PreparedTensorDType::Float32,
+            shape.to_vec(),
+        )
+        .unwrap()
+    }
+
+    fn public_deepstack_input(rope_delta: i32) -> (PreparedIreePrefill, PreparedDeepStack) {
+        let sequence = 4;
+        let hidden = 2;
+        let prepared = mlxcel_core::session::PreparedPrefill::new(
+            vec![1, 2, 3, 4],
+            tensor_f32(&[1, sequence, hidden], &[0.0; 8]),
+            PreparedPositions::Mrope3D {
+                tensor: tensor_i32(&[3, sequence], &[0, 1, 2, 3, 0, 1, 3, 3, 0, 2, 2, 3]),
+                rope_delta,
+            },
+            PreparedAttentionBias {
+                tensor: tensor_f32(&[1, 1, 1, sequence], &[0.0; 4]),
+                causal: true,
+            },
+            vec![PreparedModality {
+                family: "deepstack-test".into(),
+                item_count: 1,
+                token_count: 1,
+            }],
+        )
+        .unwrap();
+        let features = DeepStackFeatures::new(
+            tensor_i32(&[1], &[1]),
+            tensor_f32(&[1, 1, hidden], &[0.25, -0.5]),
+            tensor_i32(&[1], &[0]),
+        )
+        .unwrap();
+        let request = DeepStackPreparedPrefill::new(prepared, features).unwrap();
+        let schema = crate::emitter::DeepStackConfig {
+            target_layer_indices: vec![0],
+            max_visual_positions: 2,
+        };
+        prepare_deepstack_input(
+            request,
+            hidden,
+            8,
+            PreparedPositionMode::Mrope3D,
+            |features| {
+                PreparedDeepStack::prepare(features, &schema, hidden)
+                    .map_err(|error| error.to_string())
+            },
+        )
+        .unwrap()
+    }
+
+    fn admit_next(scheduler: &mut Scheduler, slot_index: usize) -> u64 {
+        let pending = scheduler.pop_next_pending().expect("pending request");
+        let req_id = pending.req_id;
+        scheduler.slots[slot_index] = Some(Slot {
+            req_id,
+            cur: 7,
+            cache_len: pending.input.effective_len() as i32,
+            rope_delta: pending.input.rope_delta(),
+            produced: 1,
+            cap: pending.cap,
+            params: pending.params,
+            rng: 0,
+            history: Vec::new(),
+        });
+        req_id
+    }
+
     fn gemma3n_input(tokens: Vec<i32>) -> PendingInput {
         PendingInput::Gemma3nPrepared {
             prepared: prepared_input(tokens, 2, 8),
@@ -1317,6 +1423,70 @@ mod tests {
         ));
         assert_eq!(fourth.input.logical_tokens(), &[12, 13, 14]);
         assert_eq!(fourth.input.effective_len(), 3);
+    }
+
+    #[test]
+    fn public_deepstack_deltas_survive_pending_slots_and_zero_on_reuse() {
+        let mut scheduler = Scheduler::new(3, EOS.to_vec());
+        let (negative_prepared, negative_features) = public_deepstack_input(-1);
+        let negative = queue_deepstack_prepared_request(
+            &mut scheduler,
+            negative_prepared,
+            negative_features,
+            4,
+            g(),
+            8,
+        )
+        .unwrap();
+        let (positive_prepared, positive_features) = public_deepstack_input(2);
+        let positive = queue_deepstack_prepared_request(
+            &mut scheduler,
+            positive_prepared,
+            positive_features,
+            4,
+            g(),
+            8,
+        )
+        .unwrap();
+        let (zero_prepared, zero_features) = public_deepstack_input(0);
+        let zero = queue_deepstack_prepared_request(
+            &mut scheduler,
+            zero_prepared,
+            zero_features,
+            4,
+            g(),
+            8,
+        )
+        .unwrap();
+
+        assert_eq!(
+            scheduler
+                .queue
+                .iter()
+                .map(|pending| (pending.req_id, pending.input.rope_delta()))
+                .collect::<Vec<_>>(),
+            vec![(negative, -1), (positive, 2), (zero, 0)],
+            "the scheduler must own each public request's signed delta while pending"
+        );
+
+        assert_eq!(admit_next(&mut scheduler, 0), negative);
+        assert_eq!(admit_next(&mut scheduler, 1), positive);
+        assert_eq!(admit_next(&mut scheduler, 2), zero);
+        assert_eq!(
+            mrope_slot_coordinates(&scheduler.slots).unwrap(),
+            [[3, 3, 3], [6, 6, 6], [4, 4, 4]],
+            "the first decode coordinate for each row is sequence_len + its own delta"
+        );
+
+        assert!(scheduler.cancel(positive));
+        assert_eq!(scheduler.free_slots(), [1]);
+        let replacement = scheduler.submit(vec![9, 10, 11, 12], 4, g());
+        assert_eq!(admit_next(&mut scheduler, 1), replacement);
+        assert_eq!(
+            mrope_slot_coordinates(&scheduler.slots).unwrap(),
+            [[3, 3, 3], [4, 4, 4], [4, 4, 4]],
+            "reusing the cancelled positive-delta slot must restore text delta zero"
+        );
     }
 
     #[test]

--- a/src/lib/mlxcel-xla/src/batch.rs
+++ b/src/lib/mlxcel-xla/src/batch.rs
@@ -571,8 +571,12 @@ impl XlaBatchEngine {
             .engine
             .prepare_deepstack(&features)
             .map_err(XlaAdmissionError::DeepStackPrepared)?;
-        let prepared =
-            PreparedIreePrefill::prepare(&prepared, self.engine.hidden_size(), context_capacity)?;
+        let prepared = PreparedIreePrefill::prepare_for_mode(
+            &prepared,
+            self.engine.hidden_size(),
+            context_capacity,
+            self.engine.position_mode(),
+        )?;
         queue_deepstack_prepared_request(
             &mut self.sched,
             prepared,
@@ -1132,7 +1136,6 @@ impl XlaReferenceEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prepared::PreparedIreePositions;
     use mlxcel_core::session::{
         OwnedTensor, PreparedAttentionBias, PreparedModality, PreparedPositions,
         PreparedTensorDType,
@@ -1314,80 +1317,6 @@ mod tests {
         ));
         assert_eq!(fourth.input.logical_tokens(), &[12, 13, 14]);
         assert_eq!(fourth.input.effective_len(), 3);
-    }
-
-    #[test]
-    fn mixed_text_and_mrope_slots_keep_deltas_independent_through_reuse() {
-        let text = prepared_input(vec![1, 2, 3], 2, 8);
-        assert_eq!(text.positions.rope_delta(), 0);
-        let mut vision = deepstack_input(vec![4, 5, 6, 7]);
-        let PendingInput::DeepStackPrepared { prepared, .. } = &mut vision else {
-            panic!("DeepStack test helper must produce a prepared payload");
-        };
-        prepared.positions = PreparedIreePositions::Mrope3D {
-            values: vec![0; 3 * 8],
-            rope_delta: -2,
-        };
-        let mut positive = prepared_input(vec![8, 9], 2, 8);
-        positive.positions = PreparedIreePositions::Mrope3D {
-            values: vec![0; 3 * 8],
-            rope_delta: 5,
-        };
-
-        let mut sched = Scheduler::new(3, EOS.to_vec());
-        let text_id = sched.submit_input(PendingInput::Prepared(text), 8, g());
-        let vision_id = sched.submit_input(vision, 8, g());
-        let positive_id = sched.submit_input(PendingInput::Prepared(positive), 8, g());
-        for slot in 0..3 {
-            let pending = sched.pop_next_pending().unwrap();
-            let rope_delta = pending.input.rope_delta();
-            sched.slots[slot] = Some(Slot {
-                req_id: pending.req_id,
-                cur: 1,
-                cache_len: pending.input.effective_len() as i32,
-                rope_delta,
-                produced: 1,
-                cap: pending.cap,
-                params: pending.params,
-                rng: 0,
-                history: Vec::new(),
-            });
-        }
-
-        assert_eq!(
-            mrope_slot_coordinates(&sched.slots).unwrap(),
-            [[3, 3, 3], [2, 2, 2], [7, 7, 7]]
-        );
-        assert!(sched.cancel(vision_id));
-        assert_eq!(
-            mrope_slot_coordinates(&sched.slots).unwrap(),
-            [[3, 3, 3], [0, 0, 0], [7, 7, 7]],
-            "cancelling one row clears only its own delta"
-        );
-
-        let replacement = sched.submit(vec![10, 11], 8, g());
-        let pending = sched.pop_next_pending().unwrap();
-        assert_eq!(pending.req_id, replacement);
-        let free = sched.free_slots();
-        assert_eq!(free, [1]);
-        sched.slots[free[0]] = Some(Slot {
-            req_id: pending.req_id,
-            cur: 1,
-            cache_len: pending.input.effective_len() as i32,
-            rope_delta: pending.input.rope_delta(),
-            produced: 1,
-            cap: pending.cap,
-            params: pending.params,
-            rng: 0,
-            history: Vec::new(),
-        });
-        assert_eq!(
-            mrope_slot_coordinates(&sched.slots).unwrap(),
-            [[3, 3, 3], [2, 2, 2], [7, 7, 7]],
-            "reused text slot starts with delta zero"
-        );
-        assert_eq!(sched.slots[0].as_ref().unwrap().req_id, text_id);
-        assert_eq!(sched.slots[2].as_ref().unwrap().req_id, positive_id);
     }
 
     #[test]

--- a/src/lib/mlxcel-xla/src/batch.rs
+++ b/src/lib/mlxcel-xla/src/batch.rs
@@ -186,7 +186,9 @@ impl PendingInput {
     fn rope_delta(&self) -> i32 {
         match self {
             Self::Tokens(_) | Self::Gemma3nPrepared { .. } => 0,
-            Self::Prepared(prepared) => prepared.positions.rope_delta(),
+            Self::Prepared(prepared) | Self::DeepStackPrepared { prepared, .. } => {
+                prepared.positions.rope_delta()
+            }
         }
     }
 }
@@ -1318,8 +1320,11 @@ mod tests {
     fn mixed_text_and_mrope_slots_keep_deltas_independent_through_reuse() {
         let text = prepared_input(vec![1, 2, 3], 2, 8);
         assert_eq!(text.positions.rope_delta(), 0);
-        let mut vision = prepared_input(vec![4, 5, 6, 7], 2, 8);
-        vision.positions = PreparedIreePositions::Mrope3D {
+        let mut vision = deepstack_input(vec![4, 5, 6, 7]);
+        let PendingInput::DeepStackPrepared { prepared, .. } = &mut vision else {
+            panic!("DeepStack test helper must produce a prepared payload");
+        };
+        prepared.positions = PreparedIreePositions::Mrope3D {
             values: vec![0; 3 * 8],
             rope_delta: -2,
         };
@@ -1331,7 +1336,7 @@ mod tests {
 
         let mut sched = Scheduler::new(3, EOS.to_vec());
         let text_id = sched.submit_input(PendingInput::Prepared(text), 8, g());
-        let vision_id = sched.submit_input(PendingInput::Prepared(vision), 8, g());
+        let vision_id = sched.submit_input(vision, 8, g());
         let positive_id = sched.submit_input(PendingInput::Prepared(positive), 8, g());
         for slot in 0..3 {
             let pending = sched.pop_next_pending().unwrap();

--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -176,6 +176,49 @@ pub struct MoeConfig {
     pub weight_prefix: &'static str,
 }
 
+/// Static DeepStack schema declared by an architecture.
+///
+/// The target language-layer indices are part of the compiled artifact identity.
+/// `max_visual_positions` is the compact side-input bucket; it is deliberately
+/// independent from `context_capacity`, so the host never allocates a dense
+/// `[layers, sequence, hidden]` tensor.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct DeepStackConfig {
+    pub target_layer_indices: Vec<usize>,
+    pub max_visual_positions: usize,
+}
+
+impl DeepStackConfig {
+    pub(crate) fn validate(&self, n_layers: usize, context_capacity: usize) -> Result<(), String> {
+        if self.target_layer_indices.is_empty() {
+            return Err("DeepStack requires at least one target language layer".to_string());
+        }
+        if self.max_visual_positions == 0 || self.max_visual_positions > context_capacity {
+            return Err(format!(
+                "DeepStack max_visual_positions={} must be in 1..={context_capacity}",
+                self.max_visual_positions
+            ));
+        }
+        if self
+            .target_layer_indices
+            .windows(2)
+            .any(|pair| pair[0] >= pair[1])
+        {
+            return Err("DeepStack target language layers must be sorted and unique".to_string());
+        }
+        if let Some(&layer) = self
+            .target_layer_indices
+            .iter()
+            .find(|&&layer| layer >= n_layers)
+        {
+            return Err(format!(
+                "DeepStack target language layer {layer} is outside [0,{n_layers})"
+            ));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Config {
     /// Static sequence dimension shared by prefill, decode, and every KV cache.
@@ -248,6 +291,10 @@ pub struct Config {
     /// Three-axis multimodal RoPE. `None` preserves the exact one-dimensional
     /// prefill/decode schemas and emitted modules.
     pub mrope: Option<MropeConfig>,
+    /// Optional sparse, prefill-only residual additions injected immediately
+    /// after selected transformer layers. Ordinary embeddings prefill and decode
+    /// ignore this declaration and keep their existing schemas.
+    pub deepstack: Option<DeepStackConfig>,
     /// Mixture-of-Experts FFN parameters (issues #500 / #501). `Some` for a MoE
     /// architecture (Mixtral, Qwen2-MoE, Qwen3-MoE, OLMoE); the FFN then routes the
     /// top-k of N experts instead of a dense MLP. `None` for a dense model, whose
@@ -363,6 +410,7 @@ impl Config {
             sliding_pattern: 2,
             use_rope_layers: None,
             mrope: None,
+            deepstack: None,
             moe: None,
             weight_scheme: WeightScheme::Llama,
             layernorm: false,
@@ -501,6 +549,46 @@ impl Config {
         let head_dim = ou("head_dim").unwrap_or(hidden / n_q.max(1));
         // ExaOne 3.x uses `num_layers` in place of `num_hidden_layers`.
         let n_layers = u_any(&["num_hidden_layers", "num_layers"])?;
+        let deepstack = match (
+            v.get("deepstack_language_layer_indices"),
+            v.get("deepstack_max_visual_positions"),
+        ) {
+            (None | Some(serde_json::Value::Null), None | Some(serde_json::Value::Null)) => None,
+            (Some(value), Some(max_visual_positions))
+                if !value.is_null() && !max_visual_positions.is_null() =>
+            {
+                let layers = value
+                    .as_array()
+                    .ok_or_else(|| {
+                        "config.json deepstack_language_layer_indices must be an integer array"
+                            .to_string()
+                    })?
+                    .iter()
+                    .map(|value| {
+                        value.as_u64().map(|layer| layer as usize).ok_or_else(|| {
+                            "config.json deepstack_language_layer_indices must contain non-negative integers"
+                                .to_string()
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let max_visual_positions = max_visual_positions.as_u64().ok_or_else(|| {
+                    "config.json deepstack_max_visual_positions must be a positive integer"
+                        .to_string()
+                })? as usize;
+                let config = DeepStackConfig {
+                    target_layer_indices: layers,
+                    max_visual_positions,
+                };
+                config.validate(n_layers, crate::DEFAULT_CONTEXT_CAPACITY)?;
+                Some(config)
+            }
+            _ => {
+                return Err(
+                    "config.json must declare DeepStack layer indices and max visual positions together"
+                        .to_string(),
+                );
+            }
+        };
 
         // Norm epsilon: `rms_norm_eps` (RMSNorm archs), else `layer_norm_eps`
         // (Cohere / StableLM LayerNorm), else `layer_norm_epsilon` (ExaOne), else
@@ -1168,6 +1256,7 @@ impl Config {
             sliding_pattern,
             use_rope_layers,
             mrope,
+            deepstack,
             moe,
             weight_scheme,
             layernorm,
@@ -1199,6 +1288,9 @@ impl Config {
     /// Select the static sequence shape used by all emitted graphs and caches.
     pub fn with_context_capacity(mut self, context_capacity: usize) -> Result<Self, String> {
         self.context_capacity = crate::context::validate_context_capacity_value(context_capacity)?;
+        if let Some(deepstack) = &self.deepstack {
+            deepstack.validate(self.n_layers, self.context_capacity)?;
+        }
         Ok(self)
     }
 

--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -189,15 +189,12 @@ pub struct DeepStackConfig {
 }
 
 impl DeepStackConfig {
-    pub(crate) fn validate(&self, n_layers: usize, context_capacity: usize) -> Result<(), String> {
+    fn validate_structure(&self, n_layers: usize) -> Result<(), String> {
         if self.target_layer_indices.is_empty() {
             return Err("DeepStack requires at least one target language layer".to_string());
         }
-        if self.max_visual_positions == 0 || self.max_visual_positions > context_capacity {
-            return Err(format!(
-                "DeepStack max_visual_positions={} must be in 1..={context_capacity}",
-                self.max_visual_positions
-            ));
+        if self.max_visual_positions == 0 {
+            return Err("DeepStack max_visual_positions must be positive".to_string());
         }
         if self
             .target_layer_indices
@@ -216,6 +213,21 @@ impl DeepStackConfig {
             ));
         }
         Ok(())
+    }
+
+    fn validate_capacity(&self, context_capacity: usize) -> Result<(), String> {
+        if self.max_visual_positions > context_capacity {
+            return Err(format!(
+                "DeepStack max_visual_positions={} exceeds selected context capacity {context_capacity}",
+                self.max_visual_positions
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate(&self, n_layers: usize, context_capacity: usize) -> Result<(), String> {
+        self.validate_structure(n_layers)?;
+        self.validate_capacity(context_capacity)
     }
 }
 
@@ -579,7 +591,11 @@ impl Config {
                     target_layer_indices: layers,
                     max_visual_positions,
                 };
-                config.validate(n_layers, crate::DEFAULT_CONTEXT_CAPACITY)?;
+                // Capacity is selected by RuntimeConfig after parsing. Validate
+                // only intrinsic schema facts here so a 512-token graph may
+                // legitimately declare a compact visual maximum above the
+                // historical 256-token default.
+                config.validate_structure(n_layers)?;
                 Some(config)
             }
             _ => {

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -1024,6 +1024,30 @@ mod tests {
             "target language layers participate in the compiled artifact identity"
         );
 
+        let larger_bucket = valid.replace(
+            "\"deepstack_max_visual_positions\":5",
+            "\"deepstack_max_visual_positions\":300",
+        );
+        let parsed =
+            Config::from_json_str(&larger_bucket).expect("capacity-independent schema parses");
+        let selected = parsed
+            .clone()
+            .with_context_capacity(512)
+            .expect("selected 512 capacity admits compact maximum 300");
+        assert_eq!(selected.context_capacity, 512);
+        assert_eq!(
+            selected
+                .deepstack
+                .as_ref()
+                .expect("DeepStack schema")
+                .max_visual_positions,
+            300
+        );
+        let error = parsed
+            .with_context_capacity(256)
+            .expect_err("selected capacity below compact maximum must fail");
+        assert!(error.contains("exceeds selected context capacity 256"));
+
         for invalid in [
             valid.replace("[0,2,3]", "[0,2,2]"),
             valid.replace("[0,2,3]", "[0,2,4]"),

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -1004,6 +1004,43 @@ mod tests {
     }
 
     #[test]
+    fn deepstack_c_abi_pins_explicit_position_mode_rank_and_bytes() {
+        let source = include_str!("../../csrc/xla_iree.c");
+        let (_, implementation) = source
+            .split_once("static int xla_llama_prefill_embeddings_deepstack_impl(")
+            .expect("DeepStack C implementation");
+        let (implementation, _) = implementation
+            .split_once("int xla_llama_prefill_embeddings_deepstack(")
+            .expect("DeepStack C public wrappers");
+        assert!(
+            implementation.contains("position_mode != c->position_mode"),
+            "the native boundary must reject a caller mode that disagrees with the bundle"
+        );
+        assert!(
+            implementation.contains("\"positions\", positions, 1, position_mode == 1 ? 2 : 1,")
+        );
+        assert!(
+            implementation
+                .contains("position_mode == 1 ? positions_mrope_dims : positions_1d_dims")
+        );
+        assert!(
+            source
+                .contains("xla_ctx* c, int32_t position_mode, const xla_tensor_desc* embeddings,"),
+            "single DeepStack ABI must carry the explicit position mode"
+        );
+        assert!(
+            source.contains(
+                "xla_ctx* c, int32_t slot, int32_t position_mode,\n    const xla_tensor_desc* embeddings,"
+            ),
+            "ragged DeepStack ABI must carry the explicit position mode"
+        );
+        assert!(
+            source.contains("desc->byte_length != expected_bytes"),
+            "the shared descriptor validator must reject rank-correct truncated buffers"
+        );
+    }
+
+    #[test]
     fn qwen_deepstack_config_parses_and_rejects_unstable_schema() {
         let valid = r#"{"model_type":"qwen3","hidden_size":8,"num_attention_heads":2,
             "num_key_value_heads":1,"head_dim":4,"intermediate_size":16,
@@ -1512,16 +1549,22 @@ mod tests {
 
     #[test]
     fn mrope_graphs_have_explicit_position_shapes_and_dynamic_trig() {
-        let cfg = mrope_qwen(MropeLayout::Chunked);
+        let mut cfg = mrope_qwen(MropeLayout::Chunked);
+        cfg.deepstack = Some(DeepStackConfig {
+            target_layer_indices: vec![0],
+            max_visual_positions: 2,
+        });
         let prefill = emit_prefill(&cfg, false);
         let embeddings = emit_prefill_embeddings(&cfg, false);
+        let deepstack =
+            emit_prefill_embeddings_deepstack_with(&cfg, false, super::builder::Precision::F32);
         let decode = emit_decode(&cfg, false);
         let ragged = emit_decode_ragged(&cfg, 4, false);
 
-        for graph in [&prefill, &embeddings] {
+        for graph in [&prefill, &embeddings, &deepstack] {
             assert!(
                 graph.contains("tensor<3x8xi32>"),
-                "prefill positions must be explicit [3,L]"
+                "every prefill entry must carry explicit M-RoPE [3,L] positions"
             );
             assert!(graph.contains("stablehlo.cosine"));
             assert!(graph.contains("stablehlo.sine"));

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -127,8 +127,9 @@ pub(crate) use model::{
     PREFILL_EMBEDDINGS_MASKED_VALUE, PositionInputMode, PrefillEmbeddingsDType,
     PrefillEmbeddingsInputMetadata, emit_decode, emit_decode_batched, emit_decode_ragged,
     emit_decode_ragged_with, emit_decode_with, emit_moe_probe, emit_moe_probe_with, emit_prefill,
-    emit_prefill_embeddings, emit_prefill_embeddings_deepstack_with, emit_prefill_embeddings_with,
-    emit_prefill_with, mrope_axis_selector, validate_prefill_embeddings_attention_bias,
+    emit_prefill_embeddings, emit_prefill_embeddings_deepstack_diagnostics_with,
+    emit_prefill_embeddings_deepstack_with, emit_prefill_embeddings_with, emit_prefill_with,
+    mrope_axis_selector, validate_prefill_embeddings_attention_bias,
     validate_prefill_embeddings_metadata,
 };
 
@@ -835,6 +836,14 @@ mod tests {
                 emit_prefill_embeddings_deepstack_with(&cfg, false, super::builder::Precision::F32),
             )
             .expect("write DeepStack embeddings prefill graph");
+            std::fs::write(
+                dir.join("prefill_embeddings_deepstack_diagnostics.mlir"),
+                emit_prefill_embeddings_deepstack_diagnostics_with(
+                    &cfg,
+                    super::builder::Precision::F32,
+                ),
+            )
+            .expect("write DeepStack post-hook diagnostics graph");
         }
     }
 
@@ -981,6 +990,16 @@ mod tests {
             occurs(&deepstack, "stablehlo.reduce(") - occurs(&ordinary, "stablehlo.reduce("),
             3,
             "each target reduces only across the compact visual-position axis"
+        );
+
+        let diagnostics = emit_prefill_embeddings_deepstack_diagnostics_with(
+            &cfg,
+            super::builder::Precision::F32,
+        );
+        assert!(diagnostics.starts_with("module @prefill_embeddings_deepstack_diagnostics {"));
+        assert!(
+            diagnostics.contains("tensor<3x256x8xf32>"),
+            "diagnostics return every first/middle/last post-hook hidden state"
         );
     }
 

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -64,7 +64,7 @@ mod context_tests;
 
 #[allow(unused_imports)]
 pub(crate) use config::{
-    Config, MropeConfig, MropeLayout, NormStyle, QkNorm, QuantConfig, WeightScheme,
+    Config, DeepStackConfig, MropeConfig, MropeLayout, NormStyle, QkNorm, QuantConfig, WeightScheme,
 };
 #[allow(unused_imports)]
 pub(crate) use gemma3n::{
@@ -127,8 +127,9 @@ pub(crate) use model::{
     PREFILL_EMBEDDINGS_MASKED_VALUE, PositionInputMode, PrefillEmbeddingsDType,
     PrefillEmbeddingsInputMetadata, emit_decode, emit_decode_batched, emit_decode_ragged,
     emit_decode_ragged_with, emit_decode_with, emit_moe_probe, emit_moe_probe_with, emit_prefill,
-    emit_prefill_embeddings, emit_prefill_embeddings_with, emit_prefill_with, mrope_axis_selector,
-    validate_prefill_embeddings_attention_bias, validate_prefill_embeddings_metadata,
+    emit_prefill_embeddings, emit_prefill_embeddings_deepstack_with, emit_prefill_embeddings_with,
+    emit_prefill_with, mrope_axis_selector, validate_prefill_embeddings_attention_bias,
+    validate_prefill_embeddings_metadata,
 };
 
 #[cfg(test)]
@@ -828,6 +829,13 @@ mod tests {
             emit_prefill_embeddings(&cfg, false),
         )
         .expect("write embeddings prefill graph");
+        if cfg.deepstack.is_some() {
+            std::fs::write(
+                dir.join("prefill_embeddings_deepstack_logits.mlir"),
+                emit_prefill_embeddings_deepstack_with(&cfg, false, super::builder::Precision::F32),
+            )
+            .expect("write DeepStack embeddings prefill graph");
+        }
     }
 
     #[test]
@@ -908,6 +916,113 @@ mod tests {
             .rfind(|line| line.contains("stablehlo.dot_general"))
             .expect("untied logits dot");
         assert!(untied_tail.contains("%arg2"), "untied logits use lm_head");
+    }
+
+    #[test]
+    fn deepstack_prefill_is_distinct_sparse_and_leaves_ordinary_graph_byte_exact() {
+        let mut cfg = qwen_like(false);
+        cfg.n_layers = 4;
+        let ordinary = emit_prefill_embeddings(&cfg, false);
+        let token = emit_prefill(&cfg, false);
+        let decode = emit_decode(&cfg, false);
+        cfg.deepstack = Some(DeepStackConfig {
+            target_layer_indices: vec![0, 2, 3],
+            max_visual_positions: 5,
+        });
+
+        assert_eq!(
+            emit_prefill_embeddings(&cfg, false),
+            ordinary,
+            "declaring DeepStack must not change the ordinary embeddings entry"
+        );
+        assert_eq!(
+            emit_prefill(&cfg, false),
+            token,
+            "declaring DeepStack must not change token prefill"
+        );
+        assert_eq!(
+            emit_decode(&cfg, false),
+            decode,
+            "declaring DeepStack must not change decode"
+        );
+        let deepstack =
+            emit_prefill_embeddings_deepstack_with(&cfg, false, super::builder::Precision::F32);
+        assert!(deepstack.starts_with("module @prefill_embeddings_deepstack {"));
+        assert!(
+            !deepstack.contains("tensor<4x2048x8xf32>"),
+            "the ABI must not expose a dense [num_layers, Lp, hidden] payload"
+        );
+
+        let ordered = [
+            "loc(\"embeddings\")",
+            "loc(\"positions\")",
+            "loc(\"real_len\")",
+            "loc(\"attention_bias\")",
+            "loc(\"deepstack.visual_positions\")",
+            "loc(\"deepstack.layer_features\")",
+            "loc(\"deepstack.layer_indices\")",
+            "loc(\"deepstack.actual_layer_count\")",
+            "loc(\"deepstack.actual_visual_count\")",
+        ];
+        let offsets = ordered
+            .iter()
+            .map(|needle| deepstack.find(needle).expect("DeepStack schema arg"))
+            .collect::<Vec<_>>();
+        assert!(offsets.windows(2).all(|pair| pair[0] < pair[1]));
+        assert!(deepstack.contains("tensor<5xi32> loc(\"deepstack.visual_positions\")"));
+        assert!(deepstack.contains("tensor<3x5x8xf32> loc(\"deepstack.layer_features\")"));
+        assert!(deepstack.contains("tensor<3xi32> loc(\"deepstack.layer_indices\")"));
+        assert_eq!(
+            occurs(&deepstack, "stablehlo.select ") - occurs(&ordinary, "stablehlo.select "),
+            3,
+            "first, middle, and last target layers each get one sparse residual injection"
+        );
+        assert_eq!(
+            occurs(&deepstack, "stablehlo.reduce(") - occurs(&ordinary, "stablehlo.reduce("),
+            3,
+            "each target reduces only across the compact visual-position axis"
+        );
+    }
+
+    #[test]
+    fn qwen_deepstack_config_parses_and_rejects_unstable_schema() {
+        let valid = r#"{"model_type":"qwen3","hidden_size":8,"num_attention_heads":2,
+            "num_key_value_heads":1,"head_dim":4,"intermediate_size":16,
+            "num_hidden_layers":4,"rms_norm_eps":1e-6,"rope_theta":1e6,
+            "vocab_size":10,"tie_word_embeddings":true,
+            "deepstack_language_layer_indices":[0,2,3],
+            "deepstack_max_visual_positions":5}"#;
+        let cfg = Config::from_json_str(valid).expect("canonical Qwen DeepStack config");
+        assert_eq!(
+            cfg.deepstack,
+            Some(DeepStackConfig {
+                target_layer_indices: vec![0, 2, 3],
+                max_visual_positions: 5,
+            })
+        );
+        assert!(
+            format!("{cfg:?}").contains("target_layer_indices: [0, 2, 3]"),
+            "target language layers participate in the compiled artifact identity"
+        );
+
+        for invalid in [
+            valid.replace("[0,2,3]", "[0,2,2]"),
+            valid.replace("[0,2,3]", "[0,2,4]"),
+            valid.replace(",\n            \"deepstack_max_visual_positions\":5", ""),
+            valid.replace(
+                "\"deepstack_language_layer_indices\":[0,2,3],\n            ",
+                "",
+            ),
+            valid.replace(
+                "\"deepstack_max_visual_positions\":5",
+                "\"deepstack_max_visual_positions\":0",
+            ),
+        ] {
+            assert!(
+                Config::from_json_str(&invalid).is_err(),
+                "invalid DeepStack schema must fail closed: {invalid}"
+            );
+        }
     }
 
     #[test]

--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -20,7 +20,7 @@
 //! is byte-identical to before.
 
 use super::builder::{Builder, Precision, Ty, Val, precision_from_env, quant_in_graph};
-use super::config::{Config, MropeLayout, NormStyle};
+use super::config::{Config, DeepStackConfig, MropeLayout, NormStyle};
 use super::moe::{self, MoeLayerW, MoeSharedW};
 use super::rope;
 
@@ -2566,11 +2566,23 @@ pub fn emit_decode_ragged_with(
 enum PrefillInputKind {
     Tokens,
     Embeddings,
+    DeepStack,
 }
 
 enum PrefillInput {
     Tokens(Val),
     Embeddings { hidden: Val, attention_bias: Val },
+    DeepStack(Box<DeepStackPrefillInput>),
+}
+
+struct DeepStackPrefillInput {
+    hidden: Val,
+    attention_bias: Val,
+    visual_positions: Val,
+    layer_features: Val,
+    layer_indices: Val,
+    actual_layer_count: Val,
+    actual_visual_count: Val,
 }
 
 /// Prefill arg handles. Weights are identical to decode (same order/locs), which
@@ -2632,7 +2644,7 @@ fn build_prefill_arg_schema(
             )),
             None,
         ),
-        PrefillInputKind::Embeddings => (
+        PrefillInputKind::Embeddings | PrefillInputKind::DeepStack => (
             None,
             Some(take_arg(
                 &mut decls,
@@ -2656,8 +2668,8 @@ fn build_prefill_arg_schema(
         "positions".into(),
     );
     let real_len = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "real_len".into());
-    let input = match (tokens, embeddings) {
-        (None, Some(hidden)) => PrefillInput::Embeddings {
+    let input = match (tokens, embeddings, input_kind) {
+        (None, Some(hidden), PrefillInputKind::Embeddings) => PrefillInput::Embeddings {
             hidden,
             attention_bias: take_arg(
                 &mut decls,
@@ -2666,7 +2678,54 @@ fn build_prefill_arg_schema(
                 "attention_bias".into(),
             ),
         },
-        (Some(tokens), None) => PrefillInput::Tokens(tokens),
+        (None, Some(hidden), PrefillInputKind::DeepStack) => {
+            let schema = c
+                .deepstack
+                .as_ref()
+                .expect("DeepStack prefill requires a declared schema");
+            let layer_count = schema.target_layer_indices.len();
+            let max_visual = schema.max_visual_positions;
+            PrefillInput::DeepStack(Box::new(DeepStackPrefillInput {
+                hidden,
+                attention_bias: take_arg(
+                    &mut decls,
+                    &mut idx,
+                    Ty::f32(vec![lp, lp]),
+                    "attention_bias".into(),
+                ),
+                visual_positions: take_arg(
+                    &mut decls,
+                    &mut idx,
+                    Ty::new(vec![max_visual], "i32"),
+                    "deepstack.visual_positions".into(),
+                ),
+                layer_features: take_arg(
+                    &mut decls,
+                    &mut idx,
+                    Ty::f32(vec![layer_count, max_visual, c.hidden]),
+                    "deepstack.layer_features".into(),
+                ),
+                layer_indices: take_arg(
+                    &mut decls,
+                    &mut idx,
+                    Ty::new(vec![layer_count], "i32"),
+                    "deepstack.layer_indices".into(),
+                ),
+                actual_layer_count: take_arg(
+                    &mut decls,
+                    &mut idx,
+                    Ty::scalar("i32"),
+                    "deepstack.actual_layer_count".into(),
+                ),
+                actual_visual_count: take_arg(
+                    &mut decls,
+                    &mut idx,
+                    Ty::scalar("i32"),
+                    "deepstack.actual_visual_count".into(),
+                ),
+            }))
+        }
+        (Some(tokens), None, PrefillInputKind::Tokens) => PrefillInput::Tokens(tokens),
         _ => unreachable!("each prefill schema has exactly one input representation"),
     };
 
@@ -2868,6 +2927,90 @@ pub(crate) fn emit_prefill_embeddings_with(
     emit_prefill_module(c, sample, precision, PrefillInputKind::Embeddings)
 }
 
+/// Emit the optional sparse DeepStack embeddings-prefill entry.
+///
+/// DeepStack additions occur immediately after each selected language layer,
+/// matching the MLX Qwen3-VL reference path. The ordinary embeddings entry
+/// remains a distinct module with its original schema.
+pub(crate) fn emit_prefill_embeddings_deepstack_with(
+    c: &Config,
+    sample: bool,
+    precision: Precision,
+) -> String {
+    c.deepstack
+        .as_ref()
+        .expect("DeepStack prefill requires a declared schema")
+        .validate(c.n_layers, c.context_capacity)
+        .expect("invalid DeepStack schema");
+    emit_prefill_module(c, sample, precision, PrefillInputKind::DeepStack)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_deepstack_after_layer(
+    b: &mut Builder,
+    schema: &DeepStackConfig,
+    layer_index: usize,
+    hidden: &Val,
+    visual_positions: &Val,
+    layer_features: &Val,
+    layer_indices: &Val,
+    actual_layer_count: &Val,
+    actual_visual_count: &Val,
+) -> Val {
+    let Some(payload_index) = schema
+        .target_layer_indices
+        .iter()
+        .position(|&configured_layer| configured_layer == layer_index)
+    else {
+        return hidden.clone();
+    };
+    let lp = hidden.ty.shape[0];
+    let hidden_size = hidden.ty.shape[1];
+    let max_visual = schema.max_visual_positions;
+
+    let row_indices = b.iota(lp);
+    let row_matrix = b.broadcast(&row_indices, &[0], vec![lp, max_visual]);
+    let positions_matrix = b.broadcast(visual_positions, &[1], vec![lp, max_visual]);
+    let position_matches = b.compare("EQ", &row_matrix, &positions_matrix, "SIGNED");
+
+    let visual_indices = b.iota(max_visual);
+    let visual_limit = b.broadcast(actual_visual_count, &[], vec![max_visual]);
+    let visual_active = b.compare("LT", &visual_indices, &visual_limit, "SIGNED");
+    let visual_active = b.broadcast(&visual_active, &[1], vec![lp, max_visual]);
+    let position_matches = b.and(&position_matches, &visual_active);
+
+    let zero = b.const_f32(0.0);
+    let zero_rows = b.broadcast(&zero, &[], vec![lp, max_visual, hidden_size]);
+    let payload_layer = b.slice(layer_indices, &[(payload_index, payload_index + 1)]);
+    let payload_layer = b.reshape(&payload_layer, vec![]);
+    let expected_layer = b.const_i32(layer_index as i32);
+    let layer_matches = b.compare("EQ", &payload_layer, &expected_layer, "SIGNED");
+    let payload_slot = b.const_i32(payload_index as i32);
+    let slot_active = b.compare("LT", &payload_slot, actual_layer_count, "SIGNED");
+    let layer_active = b.and(&layer_matches, &slot_active);
+    let layer_active = b.broadcast(&layer_active, &[], vec![lp, max_visual]);
+    let active_positions = b.and(&position_matches, &layer_active);
+    let active_positions = b.broadcast(
+        &active_positions,
+        &[0, 1],
+        vec![lp, max_visual, hidden_size],
+    );
+
+    let features = b.slice(
+        layer_features,
+        &[
+            (payload_index, payload_index + 1),
+            (0, max_visual),
+            (0, hidden_size),
+        ],
+    );
+    let features = b.reshape(&features, vec![max_visual, hidden_size]);
+    let features = b.broadcast(&features, &[1, 2], vec![lp, max_visual, hidden_size]);
+    let selected = b.select(&active_positions, &features, &zero_rows);
+    let delta = b.reduce_add(&selected, 1, &zero);
+    b.add(hidden, &delta)
+}
+
 fn emit_prefill_module(
     c: &Config,
     sample: bool,
@@ -2893,6 +3036,7 @@ fn emit_prefill_module(
             scale_embedding(&mut b, c, emb, vec![lp, h])
         }
         PrefillInput::Embeddings { hidden, .. } => hidden.clone(),
+        PrefillInput::DeepStack(deepstack) => deepstack.hidden.clone(),
     };
 
     // --- shared position preparation ---
@@ -2959,6 +3103,22 @@ fn emit_prefill_module(
             });
             (cmask, cmask_local)
         }
+        PrefillInput::DeepStack(deepstack) => {
+            let cmask = deepstack.attention_bias.clone();
+            let cmask_local = c.sliding_window.map(|w| {
+                let irow = b.iota(lp);
+                let row = b.broadcast(&irow, &[0], vec![lp, lp]);
+                let jcol = b.iota(lp);
+                let col = b.broadcast(&jcol, &[1], vec![lp, lp]);
+                let wc = b.const_i32(w as i32);
+                let wb = b.broadcast(&wc, &[], vec![lp, lp]);
+                let age = b.subtract(&row, &col);
+                let within = b.compare("LT", &age, &wb, "SIGNED");
+                let negs = b.broadcast(&k.neg_big, &[], vec![lp, lp]);
+                b.select(&within, &cmask, &negs)
+            });
+            (cmask, cmask_local)
+        }
     };
 
     let layout = AttnLayout::Prefill {
@@ -2979,6 +3139,19 @@ fn emit_prefill_module(
         let lw = &a.layers[li];
         // Full transformer layer, shared with the single / ragged graphs.
         x = emit_transformer_layer(&mut b, c, &k, lw, li, &x, &layout, &mut kcache, &mut vcache);
+        if let (Some(schema), PrefillInput::DeepStack(deepstack)) = (&c.deepstack, &a.input) {
+            x = apply_deepstack_after_layer(
+                &mut b,
+                schema,
+                li,
+                &x,
+                &deepstack.visual_positions,
+                &deepstack.layer_features,
+                &deepstack.layer_indices,
+                &deepstack.actual_layer_count,
+                &deepstack.actual_visual_count,
+            );
+        }
     }
 
     // --- tail: final norm (+ LayerNorm bias), take the row at real_len-1, LM head
@@ -3012,6 +3185,7 @@ fn emit_prefill_module(
     let module_name = match input_kind {
         PrefillInputKind::Tokens => "prefill",
         PrefillInputKind::Embeddings => "prefill_embeddings",
+        PrefillInputKind::DeepStack => "prefill_embeddings_deepstack",
     };
     format!(
         "module @{module_name} {{\n  func.func public @main({sig}) -> ({out_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {l}, {kc}, {vc} : {out_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",

--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -2908,7 +2908,7 @@ pub fn emit_prefill(c: &Config, sample: bool) -> String {
 }
 
 pub fn emit_prefill_with(c: &Config, sample: bool, precision: Precision) -> String {
-    emit_prefill_module(c, sample, precision, PrefillInputKind::Tokens)
+    emit_prefill_module(c, sample, precision, PrefillInputKind::Tokens, false)
 }
 
 /// Emit the distinct prefill-from-embeddings StableHLO module at the ambient
@@ -2924,7 +2924,7 @@ pub(crate) fn emit_prefill_embeddings_with(
     sample: bool,
     precision: Precision,
 ) -> String {
-    emit_prefill_module(c, sample, precision, PrefillInputKind::Embeddings)
+    emit_prefill_module(c, sample, precision, PrefillInputKind::Embeddings, false)
 }
 
 /// Emit the optional sparse DeepStack embeddings-prefill entry.
@@ -2942,7 +2942,23 @@ pub(crate) fn emit_prefill_embeddings_deepstack_with(
         .expect("DeepStack prefill requires a declared schema")
         .validate(c.n_layers, c.context_capacity)
         .expect("invalid DeepStack schema");
-    emit_prefill_module(c, sample, precision, PrefillInputKind::DeepStack)
+    emit_prefill_module(c, sample, precision, PrefillInputKind::DeepStack, false)
+}
+
+/// Emit the full DeepStack prefill plus post-hook hidden states for oracle tests.
+///
+/// This uses the production layer loop and residual hook but remains a diagnostic
+/// module that is never loaded into a serving session.
+pub(crate) fn emit_prefill_embeddings_deepstack_diagnostics_with(
+    c: &Config,
+    precision: Precision,
+) -> String {
+    c.deepstack
+        .as_ref()
+        .expect("DeepStack diagnostics require a declared schema")
+        .validate(c.n_layers, c.context_capacity)
+        .expect("invalid DeepStack schema");
+    emit_prefill_module(c, false, precision, PrefillInputKind::DeepStack, true)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3016,7 +3032,12 @@ fn emit_prefill_module(
     sample: bool,
     precision: Precision,
     input_kind: PrefillInputKind,
+    capture_deepstack_states: bool,
 ) -> String {
+    assert!(
+        !capture_deepstack_states || matches!(input_kind, PrefillInputKind::DeepStack),
+        "post-hook state capture is only valid for DeepStack prefill"
+    );
     let lp = c.context_capacity;
     let mut b = Builder::new().with_precision(precision);
     let (decls, a) = build_prefill_arg_schema(&mut b, c, lp, input_kind);
@@ -3134,6 +3155,7 @@ fn emit_prefill_module(
     // caches start as zeros; prefill writes the [0:Lp] block and returns them
     let mut kcache = b.broadcast(&k.zero, &[], vec![c.n_layers, lp, nkv, d]);
     let mut vcache = b.broadcast(&k.zero, &[], vec![c.n_layers, lp, nkv, d]);
+    let mut deepstack_states: Option<Val> = None;
 
     for li in 0..c.n_layers {
         let lw = &a.layers[li];
@@ -3151,6 +3173,13 @@ fn emit_prefill_module(
                 &deepstack.actual_layer_count,
                 &deepstack.actual_visual_count,
             );
+            if capture_deepstack_states && schema.target_layer_indices.contains(&li) {
+                let state = b.reshape(&x, vec![1, lp, h]);
+                deepstack_states = Some(match deepstack_states {
+                    Some(previous) => b.concatenate(&previous, &state, 0),
+                    None => state,
+                });
+            }
         }
     }
 
@@ -3182,22 +3211,32 @@ fn emit_prefill_module(
 
     let sig = render_signature(&decls);
     let cache_ty = Ty::f32(vec![c.n_layers, lp, c.n_kv, c.head_dim]).render();
-    let module_name = match input_kind {
-        PrefillInputKind::Tokens => "prefill",
-        PrefillInputKind::Embeddings => "prefill_embeddings",
-        PrefillInputKind::DeepStack => "prefill_embeddings_deepstack",
+    let module_name = match (input_kind, capture_deepstack_states) {
+        (PrefillInputKind::DeepStack, true) => "prefill_embeddings_deepstack_diagnostics",
+        (PrefillInputKind::Tokens, false) => "prefill",
+        (PrefillInputKind::Embeddings, false) => "prefill_embeddings",
+        (PrefillInputKind::DeepStack, false) => "prefill_embeddings_deepstack",
+        _ => unreachable!("diagnostic capture requires DeepStack"),
     };
-    format!(
-        "module @{module_name} {{\n  func.func public @main({sig}) -> ({out_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {l}, {kc}, {vc} : {out_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
-        module_name = module_name,
-        sig = sig,
-        out_ty = out_ty,
-        cache_ty = cache_ty,
-        body = b.body(),
-        l = out_val,
-        kc = kcache.name,
-        vc = vcache.name,
-    )
+    if let Some(states) = deepstack_states {
+        let state_ty = states.ty.render();
+        format!(
+            "module @{module_name} {{\n  func.func public @main({sig}) -> ({out_ty}, {cache_ty}, {cache_ty}, {state_ty}) {{\n{body}    return {l}, {kc}, {vc}, {states} : {out_ty}, {cache_ty}, {cache_ty}, {state_ty}\n  }}\n}}\n",
+            body = b.body(),
+            l = out_val,
+            kc = kcache.name,
+            vc = vcache.name,
+            states = states.name,
+        )
+    } else {
+        format!(
+            "module @{module_name} {{\n  func.func public @main({sig}) -> ({out_ty}, {cache_ty}, {cache_ty}) {{\n{body}    return {l}, {kc}, {vc} : {out_ty}, {cache_ty}, {cache_ty}\n  }}\n}}\n",
+            body = b.body(),
+            l = out_val,
+            kc = kcache.name,
+            vc = vcache.name,
+        )
+    }
 }
 
 // ===========================================================================

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -373,8 +373,8 @@ pub(crate) const RAGGED_B_VALUES: &[usize] = &[4, 8];
 
 #[derive(Clone, Debug)]
 enum RuntimeConfig {
-    Dense(Config),
-    Gemma3n(Gemma3nConfig),
+    Dense(Box<Config>),
+    Gemma3n(Box<Gemma3nConfig>),
 }
 
 fn checked_ffi_int(value: usize, name: &str) -> Result<c_int, String> {
@@ -440,11 +440,13 @@ impl RuntimeConfig {
         if matches!(model_type, Some("gemma3n" | "gemma3n_text")) {
             return Gemma3nConfig::from_json_str(&text)
                 .and_then(|config| config.with_context_capacity(context_capacity))
+                .map(Box::new)
                 .map(Self::Gemma3n)
                 .map_err(|error| format!("{}: {error}", path.display()));
         }
         Config::from_json(model_dir)?
             .with_context_capacity(context_capacity)
+            .map(Box::new)
             .map(Self::Dense)
     }
 
@@ -1170,7 +1172,7 @@ mod checkpoint_name_tests {
     use super::*;
 
     fn tiny_gemma3n_runtime() -> RuntimeConfig {
-        RuntimeConfig::Gemma3n(
+        RuntimeConfig::Gemma3n(Box::new(
             Gemma3nConfig::from_json_str(
                 &serde_json::json!({
                     "model_type": "gemma3n_text",
@@ -1194,7 +1196,7 @@ mod checkpoint_name_tests {
             .unwrap()
             .with_context_capacity(4)
             .unwrap(),
-        )
+        ))
     }
 
     #[test]

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -319,6 +319,7 @@ unsafe extern "C" {
     ) -> c_int;
     fn xla_llama_prefill_embeddings_deepstack(
         c: *mut XlaCtx,
+        position_mode: c_int,
         embeddings: *const XlaTensorDesc,
         positions: *const XlaTensorDesc,
         attention_bias: *const XlaTensorDesc,
@@ -333,6 +334,7 @@ unsafe extern "C" {
     fn xla_llama_prefill_embeddings_deepstack_slot_logits(
         c: *mut XlaCtx,
         slot: c_int,
+        position_mode: c_int,
         embeddings: *const XlaTensorDesc,
         positions: *const XlaTensorDesc,
         attention_bias: *const XlaTensorDesc,
@@ -1820,12 +1822,14 @@ impl IreeLlama {
             "DeepStack prefill was requested from a runtime bundle without that capability"
                 .to_string()
         })?;
-        let prepared = PreparedIreePrefill::prepare(
+        let prepared = PreparedIreePrefill::prepare_for_mode(
             request.prepared(),
             self.hidden_size,
             self.context_capacity,
+            self.position_mode,
         )
         .map_err(|error| error.to_string())?;
+        let rope_delta = prepared.positions.rope_delta();
         let deepstack = PreparedDeepStack::prepare(request.deepstack(), schema, self.hidden_size)
             .map_err(|error| error.to_string())?;
         let (embeddings, positions, attention_bias) = prepared_descriptors(&prepared)?;
@@ -1843,6 +1847,7 @@ impl IreeLlama {
         let rc = unsafe {
             xla_llama_prefill_embeddings_deepstack(
                 self.ctx,
+                prepared.positions.mode().ffi_code(),
                 &embeddings,
                 &positions,
                 &attention_bias,
@@ -1860,6 +1865,7 @@ impl IreeLlama {
                 "xla_llama_prefill_embeddings_deepstack failed (status {rc})"
             ));
         }
+        self.rope_delta = rope_delta;
         Ok(out)
     }
 
@@ -2380,6 +2386,9 @@ impl IreeRaggedLlama {
         validate_slot(slot, self.b_max).map_err(|error| error.to_string())?;
         if prepared.hidden_size != self.hidden_size
             || prepared.context_capacity != self.context_capacity
+            || prepared.effective_len == 0
+            || prepared.effective_len > self.context_capacity
+            || prepared.positions.mode() != self.position_mode
             || deepstack.hidden_size != self.hidden_size
             || deepstack.max_layer_count != schema.target_layer_indices.len()
             || deepstack.max_visual_count != schema.max_visual_positions
@@ -2406,6 +2415,7 @@ impl IreeRaggedLlama {
             xla_llama_prefill_embeddings_deepstack_slot_logits(
                 self.ctx,
                 slot,
+                prepared.positions.mode().ffi_code(),
                 &embeddings,
                 &positions,
                 &attention_bias,

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -72,7 +72,7 @@ use crate::emitter::{
     emit_gemma3n_prefill_diagnostics_with_qmv,
 };
 use crate::prepared::{
-    PreparedIreePrefill, PreparedPositionMode, canonical_text_positions, mrope_decode_coordinate,
+    DecodePositionState, PreparedIreePrefill, PreparedPositionMode, canonical_text_positions,
     validate_slot,
 };
 use crate::prepared_deepstack::PreparedDeepStack;
@@ -1721,7 +1721,7 @@ pub struct IreeLlama {
     hidden_size: usize,
     dense_ple_shape: Option<[usize; 3]>,
     position_mode: PreparedPositionMode,
-    rope_delta: i32,
+    decode_position: DecodePositionState,
     deepstack_schema: Option<DeepStackConfig>,
 }
 
@@ -1740,7 +1740,7 @@ impl IreeLlama {
             hidden_size: cfg.hidden(),
             dense_ple_shape: cfg.dense_ple_shape(),
             position_mode: cfg.position_mode(),
-            rope_delta: 0,
+            decode_position: DecodePositionState::default(),
             deepstack_schema: cfg.deepstack().cloned(),
         })
     }
@@ -1806,11 +1806,12 @@ impl IreeLlama {
                 &mut out,
             )
         };
-        if rc != 0 {
-            return Err(format!("xla_llama_prefill_embeddings failed (status {rc})"));
-        }
-        self.rope_delta = rope_delta;
-        Ok(out)
+        let result = if rc == 0 {
+            Ok(out)
+        } else {
+            Err(format!("xla_llama_prefill_embeddings failed (status {rc})"))
+        };
+        self.decode_position.complete_prefill(rope_delta, result)
     }
 
     /// Seed KV through the distinct sparse DeepStack embeddings entry.
@@ -1860,13 +1861,14 @@ impl IreeLlama {
                 &mut out,
             )
         };
-        if rc != 0 {
-            return Err(format!(
+        let result = if rc == 0 {
+            Ok(out)
+        } else {
+            Err(format!(
                 "xla_llama_prefill_embeddings_deepstack failed (status {rc})"
-            ));
-        }
-        self.rope_delta = rope_delta;
-        Ok(out)
+            ))
+        };
+        self.decode_position.complete_prefill(rope_delta, result)
     }
 
     /// Seed Gemma3n KV from post-scale merged embeddings plus a canonical dense
@@ -1909,13 +1911,14 @@ impl IreeLlama {
                 &mut out,
             )
         };
-        if rc != 0 {
-            return Err(format!(
+        let result = if rc == 0 {
+            Ok(out)
+        } else {
+            Err(format!(
                 "xla_llama_prefill_embeddings_ple failed (status {rc})"
-            ));
-        }
-        self.rope_delta = 0;
-        Ok(out)
+            ))
+        };
+        self.decode_position.complete_prefill(0, result)
     }
 
     /// Pad `prompt` into the configured static bucket, run the prefill, and return its
@@ -1947,11 +1950,12 @@ impl IreeLlama {
                 &mut out,
             )
         };
-        if rc != 0 {
-            return Err(format!("xla_llama_prefill failed (status {rc})"));
-        }
-        self.rope_delta = 0;
-        Ok(out)
+        let result = if rc == 0 {
+            Ok(out)
+        } else {
+            Err(format!("xla_llama_prefill failed (status {rc})"))
+        };
+        self.decode_position.complete_prefill(0, result)
     }
 
     /// Advance one token at `cache_len` (== position), returning the next token
@@ -1970,7 +1974,9 @@ impl IreeLlama {
                 unsafe { xla_llama_decode(self.ctx, token, cache_len, cache_len, &mut out) }
             }
             PreparedPositionMode::Mrope3D => {
-                let coordinate = mrope_decode_coordinate(cache_len, self.rope_delta)
+                let coordinate = self
+                    .decode_position
+                    .mrope_coordinate(cache_len)
                     .map_err(|error| error.to_string())?;
                 let positions = [coordinate; 3];
                 // Safety: positions is exactly the explicit rank-1 `[3]` ABI payload.

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -58,10 +58,11 @@ use mlxcel_core::session::PreparedPrefill;
 use safetensors::{Dtype, SafeTensors};
 
 use crate::emitter::{
-    Config, Gemma3nConfig, Gemma3nWeightSpec, Precision, QuantConfig, check_packed_supported,
-    emit_decode_ragged_with, emit_decode_with, emit_gemma3n_decode_ragged_with_qmv,
-    emit_gemma3n_decode_with_qmv, emit_gemma3n_prefill_embeddings_ple_with_qmv,
-    emit_gemma3n_prefill_with_qmv, emit_prefill_embeddings_with, emit_prefill_with,
+    Config, DeepStackConfig, Gemma3nConfig, Gemma3nWeightSpec, Precision, QuantConfig,
+    check_packed_supported, emit_decode_ragged_with, emit_decode_with,
+    emit_gemma3n_decode_ragged_with_qmv, emit_gemma3n_decode_with_qmv,
+    emit_gemma3n_prefill_embeddings_ple_with_qmv, emit_gemma3n_prefill_with_qmv,
+    emit_prefill_embeddings_deepstack_with, emit_prefill_embeddings_with, emit_prefill_with,
     gemma3n_qmv_artifact_identity, gemma3n_qmv_is_available, gemma3n_weight_specs, quant_in_graph,
     resolve_precision, resolve_precision_checked,
 };
@@ -74,7 +75,8 @@ use crate::prepared::{
     PreparedIreePrefill, PreparedPositionMode, canonical_text_positions, mrope_decode_coordinate,
     validate_slot,
 };
-use crate::{Gemma3nDensePle, Gemma3nPreparedPrefill};
+use crate::prepared_deepstack::PreparedDeepStack;
+use crate::{DeepStackFeatures, DeepStackPreparedPrefill, Gemma3nDensePle, Gemma3nPreparedPrefill};
 // The loader reads the per-architecture checkpoint-weight order from
 // `weights::weight_specs`, which sources its names from `weight_names::scheme_names`
 // (issue #499 naming schemes) and covers the #498 dense pack (LayerNorm / o_proj /
@@ -205,6 +207,7 @@ unsafe extern "C" {
         device: *const c_char,
         prefill: *const c_char,
         prefill_embeddings: *const c_char,
+        prefill_embeddings_deepstack: *const c_char,
         decode: *const c_char,
         prefill_diagnostics: *const c_char,
         compatibility_fingerprint: u64,
@@ -219,6 +222,10 @@ unsafe extern "C" {
         prefill_embeddings_kind: c_int,
         dense_ple_layers: c_int,
         dense_ple_hidden: c_int,
+        model_layers: c_int,
+        deepstack_layers: c_int,
+        deepstack_visual_positions: c_int,
+        deepstack_target_layers: *const c_int,
     ) -> *mut XlaCtx;
     fn xla_llama_prefill(
         c: *mut XlaCtx,
@@ -310,6 +317,34 @@ unsafe extern "C" {
         vocab: c_int,
         out_logits: *mut f32,
     ) -> c_int;
+    fn xla_llama_prefill_embeddings_deepstack(
+        c: *mut XlaCtx,
+        embeddings: *const XlaTensorDesc,
+        positions: *const XlaTensorDesc,
+        attention_bias: *const XlaTensorDesc,
+        visual_positions: *const XlaTensorDesc,
+        layer_features: *const XlaTensorDesc,
+        layer_indices: *const XlaTensorDesc,
+        actual_layer_count: c_int,
+        actual_visual_count: c_int,
+        real_len: c_int,
+        out_token: *mut c_int,
+    ) -> c_int;
+    fn xla_llama_prefill_embeddings_deepstack_slot_logits(
+        c: *mut XlaCtx,
+        slot: c_int,
+        embeddings: *const XlaTensorDesc,
+        positions: *const XlaTensorDesc,
+        attention_bias: *const XlaTensorDesc,
+        visual_positions: *const XlaTensorDesc,
+        layer_features: *const XlaTensorDesc,
+        layer_indices: *const XlaTensorDesc,
+        actual_layer_count: c_int,
+        actual_visual_count: c_int,
+        real_len: c_int,
+        vocab: c_int,
+        out_logits: *mut f32,
+    ) -> c_int;
     fn xla_llama_decode_ragged_logits(
         c: *mut XlaCtx,
         bsz: c_int,
@@ -357,6 +392,9 @@ struct RuntimeFfiDimensions {
     hidden: c_int,
     dense_ple_layers: c_int,
     dense_ple_hidden: c_int,
+    model_layers: c_int,
+    deepstack_layers: c_int,
+    deepstack_visual: c_int,
 }
 
 fn runtime_ffi_dimensions(
@@ -376,6 +414,17 @@ fn runtime_ffi_dimensions(
         dense_ple_hidden: checked_ffi_int(
             dense_ple.map_or(0, |shape| shape[2]),
             "dense_ple_hidden",
+        )?,
+        model_layers: checked_ffi_int(cfg.n_layers(), "model_layers")?,
+        deepstack_layers: checked_ffi_int(
+            cfg.deepstack()
+                .map_or(0, |schema| schema.target_layer_indices.len()),
+            "deepstack_layers",
+        )?,
+        deepstack_visual: checked_ffi_int(
+            cfg.deepstack()
+                .map_or(0, |schema| schema.max_visual_positions),
+            "deepstack_visual_positions",
         )?,
     })
 }
@@ -417,6 +466,13 @@ impl RuntimeConfig {
         match self {
             Self::Dense(config) => config.vocab,
             Self::Gemma3n(config) => config.vocab,
+        }
+    }
+
+    fn n_layers(&self) -> usize {
+        match self {
+            Self::Dense(config) => config.n_layers,
+            Self::Gemma3n(config) => config.n_layers,
         }
     }
 
@@ -462,6 +518,13 @@ impl RuntimeConfig {
         match self {
             Self::Dense(config) if config.uses_mrope() => PreparedPositionMode::Mrope3D,
             Self::Dense(_) | Self::Gemma3n(_) => PreparedPositionMode::OneD,
+        }
+    }
+
+    fn deepstack(&self) -> Option<&DeepStackConfig> {
+        match self {
+            Self::Dense(config) => config.deepstack.as_ref(),
+            Self::Gemma3n(_) => None,
         }
     }
 }
@@ -697,10 +760,11 @@ fn compile_one(
     Ok(vmfb_path)
 }
 
-/// Three compatible entry modules loaded atomically into one runtime session.
+/// Compatible entry modules loaded atomically into one runtime session.
 struct CompiledBundle {
     prefill_vmfb: PathBuf,
     prefill_embeddings_vmfb: PathBuf,
+    prefill_embeddings_deepstack_vmfb: Option<PathBuf>,
     decode_vmfb: PathBuf,
     compatibility_fingerprint: u64,
 }
@@ -719,6 +783,7 @@ fn compile_bundle(
     prefill_tag: &str,
     prefill_embeddings_mlir: &str,
     prefill_embeddings_tag: &str,
+    prefill_embeddings_deepstack: Option<(&str, &str)>,
     decode_mlir: &str,
     decode_tag: &str,
 ) -> Result<CompiledBundle, String> {
@@ -751,6 +816,18 @@ fn compile_bundle(
         prefill_embeddings_tag,
         cfg.context_capacity(),
     )?;
+    let pre_embeddings_deepstack = prefill_embeddings_deepstack
+        .map(|(mlir, tag)| {
+            compile_one(
+                &iree_compile,
+                mlir,
+                &flags,
+                &cache,
+                tag,
+                cfg.context_capacity(),
+            )
+        })
+        .transpose()?;
     let dec = compile_one(
         &iree_compile,
         decode_mlir,
@@ -769,11 +846,15 @@ fn compile_bundle(
     }
     prefill_mlir.hash(&mut fingerprint);
     prefill_embeddings_mlir.hash(&mut fingerprint);
+    prefill_embeddings_deepstack
+        .map(|(mlir, _)| mlir)
+        .hash(&mut fingerprint);
     decode_mlir.hash(&mut fingerprint);
     let compatibility_fingerprint = fingerprint.finish();
     Ok(CompiledBundle {
         prefill_vmfb: pre,
         prefill_embeddings_vmfb: pre_embeddings,
+        prefill_embeddings_deepstack_vmfb: pre_embeddings_deepstack,
         decode_vmfb: dec,
         compatibility_fingerprint: compatibility_fingerprint.max(1),
     })
@@ -786,18 +867,23 @@ fn compile_vmfbs(device: &str, cfg: &RuntimeConfig) -> Result<CompiledBundle, St
         RuntimeConfig::Dense(_) => false,
         RuntimeConfig::Gemma3n(config) => gemma3n_native_qmv(device, config)?,
     };
-    let (prefill, prefill_embeddings, decode) = match cfg {
+    let (prefill, prefill_embeddings, prefill_embeddings_deepstack, decode) = match cfg {
         RuntimeConfig::Dense(config) => {
             check_packed_supported(device, quant_in_graph() && config.supports_packed_quant())?;
             (
                 emit_prefill_with(config, true, precision),
                 emit_prefill_embeddings_with(config, true, precision),
+                config
+                    .deepstack
+                    .as_ref()
+                    .map(|_| emit_prefill_embeddings_deepstack_with(config, true, precision)),
                 emit_decode_with(config, true, precision),
             )
         }
         RuntimeConfig::Gemma3n(config) => (
             emit_gemma3n_prefill_with_qmv(config, true, precision, native_qmv),
             emit_gemma3n_prefill_embeddings_ple_with_qmv(config, true, precision, native_qmv),
+            None,
             emit_gemma3n_decode_with_qmv(config, true, precision, native_qmv),
         ),
     };
@@ -809,6 +895,9 @@ fn compile_vmfbs(device: &str, cfg: &RuntimeConfig) -> Result<CompiledBundle, St
         "prefill",
         &prefill_embeddings,
         "prefill_embeddings",
+        prefill_embeddings_deepstack
+            .as_deref()
+            .map(|mlir| (mlir, "prefill_embeddings_deepstack")),
         &decode,
         "decode",
     )
@@ -1505,6 +1594,23 @@ fn dense_ple_descriptor(dense_ple: &Gemma3nDensePle) -> Result<XlaTensorDesc, St
     XlaTensorDesc::f32(dense_ple.as_slice(), &dense_ple.shape())
 }
 
+fn deepstack_descriptors(
+    deepstack: &PreparedDeepStack,
+) -> Result<(XlaTensorDesc, XlaTensorDesc, XlaTensorDesc), String> {
+    Ok((
+        XlaTensorDesc::i32(&deepstack.visual_positions, &[deepstack.max_visual_count])?,
+        XlaTensorDesc::f32(
+            &deepstack.layer_features,
+            &[
+                deepstack.max_layer_count,
+                deepstack.max_visual_count,
+                deepstack.hidden_size,
+            ],
+        )?,
+        XlaTensorDesc::i32(&deepstack.layer_indices, &[deepstack.max_layer_count])?,
+    ))
+}
+
 /// Load the weights and create the C execution context for a (prefill, decode)
 /// vmfb pair on `device`. Shared by the single-sequence ([`IreeLlama`]) and ragged
 /// ([`IreeRaggedLlama`]) engines, which differ only in which decode vmfb they pass.
@@ -1537,8 +1643,24 @@ fn create_ctx_with_diagnostics(
     let c_dev = CString::new(device).map_err(|_| "device has interior nul".to_string())?;
     let c_pre = path_cstring(&bundle.prefill_vmfb)?;
     let c_pre_embeddings = path_cstring(&bundle.prefill_embeddings_vmfb)?;
+    let c_pre_embeddings_deepstack = bundle
+        .prefill_embeddings_deepstack_vmfb
+        .as_deref()
+        .map(path_cstring)
+        .transpose()?;
     let c_dec = path_cstring(&bundle.decode_vmfb)?;
     let c_diagnostics = prefill_diagnostics_vmfb.map(path_cstring).transpose()?;
+    let deepstack_target_layers = cfg
+        .deepstack()
+        .map(|schema| {
+            schema
+                .target_layer_indices
+                .iter()
+                .map(|&layer| checked_ffi_int(layer, "deepstack target layer"))
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
     // Safety: pointers are valid for the duration of the call; the shim copies
     // the weight data into device buffers before returning.
     let ctx = unsafe {
@@ -1546,6 +1668,9 @@ fn create_ctx_with_diagnostics(
             c_dev.as_ptr(),
             c_pre.as_ptr(),
             c_pre_embeddings.as_ptr(),
+            c_pre_embeddings_deepstack
+                .as_ref()
+                .map_or(std::ptr::null(), |path| path.as_ptr()),
             c_dec.as_ptr(),
             c_diagnostics
                 .as_ref()
@@ -1562,6 +1687,14 @@ fn create_ctx_with_diagnostics(
             i32::from(cfg.dense_ple_shape().is_some()),
             ffi.dense_ple_layers,
             ffi.dense_ple_hidden,
+            ffi.model_layers,
+            ffi.deepstack_layers,
+            ffi.deepstack_visual,
+            if deepstack_target_layers.is_empty() {
+                std::ptr::null()
+            } else {
+                deepstack_target_layers.as_ptr()
+            },
         )
     };
     // Weights are resident on the device now; free the host copy.
@@ -1585,6 +1718,7 @@ pub struct IreeLlama {
     dense_ple_shape: Option<[usize; 3]>,
     position_mode: PreparedPositionMode,
     rope_delta: i32,
+    deepstack_schema: Option<DeepStackConfig>,
 }
 
 impl IreeLlama {
@@ -1603,6 +1737,7 @@ impl IreeLlama {
             dense_ple_shape: cfg.dense_ple_shape(),
             position_mode: cfg.position_mode(),
             rope_delta: 0,
+            deepstack_schema: cfg.deepstack().cloned(),
         })
     }
 
@@ -1671,6 +1806,58 @@ impl IreeLlama {
             return Err(format!("xla_llama_prefill_embeddings failed (status {rc})"));
         }
         self.rope_delta = rope_delta;
+        Ok(out)
+    }
+
+    /// Seed KV through the distinct sparse DeepStack embeddings entry.
+    pub fn prefill_deepstack_prepared_first(
+        &mut self,
+        request: &DeepStackPreparedPrefill,
+    ) -> Result<i32, String> {
+        let schema = self.deepstack_schema.as_ref().ok_or_else(|| {
+            "DeepStack prefill was requested from a runtime bundle without that capability"
+                .to_string()
+        })?;
+        let prepared = PreparedIreePrefill::prepare(
+            request.prepared(),
+            self.hidden_size,
+            self.context_capacity,
+        )
+        .map_err(|error| error.to_string())?;
+        let deepstack = PreparedDeepStack::prepare(request.deepstack(), schema, self.hidden_size)
+            .map_err(|error| error.to_string())?;
+        let (embeddings, positions, attention_bias) = prepared_descriptors(&prepared)?;
+        let (visual_positions, layer_features, layer_indices) = deepstack_descriptors(&deepstack)?;
+        let actual_layer_count =
+            checked_ffi_int(deepstack.actual_layer_count, "DeepStack actual layer count")?;
+        let actual_visual_count = checked_ffi_int(
+            deepstack.actual_visual_count,
+            "DeepStack actual visual count",
+        )?;
+        let real_len = checked_ffi_int(prepared.effective_len, "prepared effective length")?;
+        let mut out = 0i32;
+        // Safety: all descriptors reference validated owned buffers that outlive
+        // the call. The C shim repeats descriptor, value, and bound checks.
+        let rc = unsafe {
+            xla_llama_prefill_embeddings_deepstack(
+                self.ctx,
+                &embeddings,
+                &positions,
+                &attention_bias,
+                &visual_positions,
+                &layer_features,
+                &layer_indices,
+                actual_layer_count,
+                actual_visual_count,
+                real_len,
+                &mut out,
+            )
+        };
+        if rc != 0 {
+            return Err(format!(
+                "xla_llama_prefill_embeddings_deepstack failed (status {rc})"
+            ));
+        }
         Ok(out)
     }
 
@@ -1821,6 +2008,7 @@ pub struct IreeRaggedLlama {
     hidden_size: usize,
     dense_ple_shape: Option<[usize; 3]>,
     position_mode: PreparedPositionMode,
+    deepstack_schema: Option<DeepStackConfig>,
     #[cfg(feature = "diagnostics")]
     diagnostic_layout: Option<Gemma3nDiagnosticLayout>,
 }
@@ -1885,21 +2073,33 @@ impl IreeRaggedLlama {
             RuntimeConfig::Dense(_) => false,
             RuntimeConfig::Gemma3n(config) => gemma3n_native_qmv(device, config)?,
         };
-        let (prefill_mlir, prefill_embeddings_mlir, decode_mlir) = match &cfg {
-            RuntimeConfig::Dense(config) => {
-                check_packed_supported(device, quant_in_graph() && config.supports_packed_quant())?;
-                (
-                    emit_prefill_with(config, false, precision),
-                    emit_prefill_embeddings_with(config, false, precision),
-                    emit_decode_ragged_with(config, b_max, false, precision),
-                )
-            }
-            RuntimeConfig::Gemma3n(config) => (
-                emit_gemma3n_prefill_with_qmv(config, false, precision, native_qmv),
-                emit_gemma3n_prefill_embeddings_ple_with_qmv(config, false, precision, native_qmv),
-                emit_gemma3n_decode_ragged_with_qmv(config, b_max, false, precision, native_qmv),
-            ),
-        };
+        let (prefill_mlir, prefill_embeddings_mlir, prefill_embeddings_deepstack_mlir, decode_mlir) =
+            match &cfg {
+                RuntimeConfig::Dense(config) => {
+                    check_packed_supported(
+                        device,
+                        quant_in_graph() && config.supports_packed_quant(),
+                    )?;
+                    (
+                        emit_prefill_with(config, false, precision),
+                        emit_prefill_embeddings_with(config, false, precision),
+                        config.deepstack.as_ref().map(|_| {
+                            emit_prefill_embeddings_deepstack_with(config, false, precision)
+                        }),
+                        emit_decode_ragged_with(config, b_max, false, precision),
+                    )
+                }
+                RuntimeConfig::Gemma3n(config) => (
+                    emit_gemma3n_prefill_with_qmv(config, false, precision, native_qmv),
+                    emit_gemma3n_prefill_embeddings_ple_with_qmv(
+                        config, false, precision, native_qmv,
+                    ),
+                    None,
+                    emit_gemma3n_decode_ragged_with_qmv(
+                        config, b_max, false, precision, native_qmv,
+                    ),
+                ),
+            };
         let bundle = compile_bundle(
             device,
             &cfg,
@@ -1908,6 +2108,9 @@ impl IreeRaggedLlama {
             "prefill_logits",
             &prefill_embeddings_mlir,
             "prefill_embeddings_logits",
+            prefill_embeddings_deepstack_mlir
+                .as_deref()
+                .map(|mlir| (mlir, "prefill_embeddings_deepstack_logits")),
             &decode_mlir,
             &format!("decode_ragged_logits_b{b_max}"),
         )?;
@@ -1945,6 +2148,7 @@ impl IreeRaggedLlama {
             hidden_size: cfg.hidden(),
             dense_ple_shape: cfg.dense_ple_shape(),
             position_mode: cfg.position_mode(),
+            deepstack_schema: cfg.deepstack().cloned(),
             #[cfg(feature = "diagnostics")]
             diagnostic_layout,
         })
@@ -1977,6 +2181,18 @@ impl IreeRaggedLlama {
 
     pub(crate) const fn position_mode(&self) -> PreparedPositionMode {
         self.position_mode
+    }
+
+    pub(crate) fn prepare_deepstack(
+        &self,
+        features: &DeepStackFeatures,
+    ) -> Result<PreparedDeepStack, String> {
+        let schema = self.deepstack_schema.as_ref().ok_or_else(|| {
+            "DeepStack prefill was requested from a runtime bundle without that capability"
+                .to_string()
+        })?;
+        PreparedDeepStack::prepare(features, schema, self.hidden_size)
+            .map_err(|error| error.to_string())
     }
 
     pub fn validate_gemma3n_dense_ple(&self, dense_ple: &Gemma3nDensePle) -> Result<(), String> {
@@ -2143,6 +2359,67 @@ impl IreeRaggedLlama {
         if rc != 0 {
             return Err(format!(
                 "xla_llama_prefill_embeddings_slot_logits failed (status {rc})"
+            ));
+        }
+        Ok(logits)
+    }
+
+    /// Seed one batch slot through the sparse DeepStack prefill entry.
+    pub fn prefill_deepstack_prepared_slot_logits(
+        &mut self,
+        slot: usize,
+        prepared: &PreparedIreePrefill,
+        deepstack: &PreparedDeepStack,
+    ) -> Result<Vec<f32>, String> {
+        let schema = self.deepstack_schema.as_ref().ok_or_else(|| {
+            "DeepStack prefill was requested from a runtime bundle without that capability"
+                .to_string()
+        })?;
+        validate_slot(slot, self.b_max).map_err(|error| error.to_string())?;
+        if prepared.hidden_size != self.hidden_size
+            || prepared.context_capacity != self.context_capacity
+            || deepstack.hidden_size != self.hidden_size
+            || deepstack.max_layer_count != schema.target_layer_indices.len()
+            || deepstack.max_visual_count != schema.max_visual_positions
+        {
+            return Err(
+                "DeepStack prepared payload is incompatible with this runtime bundle".to_string(),
+            );
+        }
+        let (embeddings, positions, attention_bias) = prepared_descriptors(prepared)?;
+        let (visual_positions, layer_features, layer_indices) = deepstack_descriptors(deepstack)?;
+        let slot = checked_ffi_int(slot, "slot")?;
+        let actual_layer_count =
+            checked_ffi_int(deepstack.actual_layer_count, "DeepStack actual layer count")?;
+        let actual_visual_count = checked_ffi_int(
+            deepstack.actual_visual_count,
+            "DeepStack actual visual count",
+        )?;
+        let real_len = checked_ffi_int(prepared.effective_len, "prepared effective length")?;
+        let vocab = checked_ffi_int(self.vocab, "vocab_size")?;
+        let mut logits = vec![0.0; self.vocab];
+        // Safety: descriptors and output remain live for the call; the C shim
+        // repeats all descriptor and compact-index checks before device upload.
+        let rc = unsafe {
+            xla_llama_prefill_embeddings_deepstack_slot_logits(
+                self.ctx,
+                slot,
+                &embeddings,
+                &positions,
+                &attention_bias,
+                &visual_positions,
+                &layer_features,
+                &layer_indices,
+                actual_layer_count,
+                actual_visual_count,
+                real_len,
+                vocab,
+                logits.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            return Err(format!(
+                "xla_llama_prefill_embeddings_deepstack_slot_logits failed (status {rc})"
             ));
         }
         Ok(logits)

--- a/src/lib/mlxcel-xla/src/lib.rs
+++ b/src/lib/mlxcel-xla/src/lib.rs
@@ -53,6 +53,7 @@ mod context;
 #[cfg(any(feature = "iree", test))]
 #[cfg_attr(not(feature = "iree"), allow(dead_code))]
 mod prepared;
+mod prepared_deepstack;
 mod prepared_gemma3n;
 
 #[cfg(feature = "iree")]
@@ -142,6 +143,7 @@ pub fn dequantize_gemma3n_affine_diagnostic(
 pub use emitter::{Gemma3nDiagnosticLayout, Gemma3nDiagnosticSegment};
 #[cfg(feature = "iree")]
 pub use prepared::PreparedInputError;
+pub use prepared_deepstack::{DeepStackFeatures, DeepStackInputError, DeepStackPreparedPrefill};
 pub use prepared_gemma3n::{Gemma3nDensePle, Gemma3nDensePleError, Gemma3nPreparedPrefill};
 #[cfg(feature = "iree")]
 pub use sampler::SampleParams;
@@ -415,6 +417,52 @@ impl XlaInferenceSession {
             let _ = request;
             Err(NOT_WIRED.to_string())
         }
+    }
+
+    /// Seed a session through the distinct sparse DeepStack embeddings entry.
+    pub fn prefill_deepstack_prepared(
+        &mut self,
+        request: &DeepStackPreparedPrefill,
+    ) -> Result<i32, String> {
+        #[cfg(feature = "iree")]
+        {
+            let first = self.engine.prefill_deepstack_prepared_first(request)?;
+            self.cache_len = i32::try_from(request.prepared().sequence_len)
+                .map_err(|_| "prepared sequence length does not fit i32".to_string())?;
+            Ok(first)
+        }
+        #[cfg(not(feature = "iree"))]
+        {
+            let _ = request;
+            Err(NOT_WIRED.to_string())
+        }
+    }
+
+    /// Greedy generation seeded by compact prefill-only DeepStack additions.
+    pub fn generate_deepstack_prepared_greedy(
+        &mut self,
+        request: &DeepStackPreparedPrefill,
+        max_new_tokens: usize,
+        eos_token_ids: &[i32],
+    ) -> Result<Vec<i32>, String> {
+        if max_new_tokens == 0 {
+            return Ok(Vec::new());
+        }
+        validate_request_capacity(
+            request.prepared().sequence_len,
+            max_new_tokens,
+            self.context_capacity,
+        )
+        .map_err(|error| error.to_string())?;
+        let first = self.prefill_deepstack_prepared(request)?;
+        let mut out = Vec::with_capacity(max_new_tokens);
+        out.push(first);
+        let mut current = first;
+        while out.len() < max_new_tokens && !eos_token_ids.contains(&current) {
+            current = self.decode_step(current)?;
+            out.push(current);
+        }
+        Ok(out)
     }
 
     /// Greedy generation seeded by Gemma3n post-scale embeddings and dense PLE.

--- a/src/lib/mlxcel-xla/src/prepared.rs
+++ b/src/lib/mlxcel-xla/src/prepared.rs
@@ -300,6 +300,27 @@ pub(crate) fn mrope_decode_coordinate(
     Ok(coordinate)
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct DecodePositionState {
+    rope_delta: i32,
+}
+
+impl DecodePositionState {
+    pub(crate) fn complete_prefill<T>(
+        &mut self,
+        next_rope_delta: i32,
+        result: Result<T, String>,
+    ) -> Result<T, String> {
+        let output = result?;
+        self.rope_delta = next_rope_delta;
+        Ok(output)
+    }
+
+    pub(crate) fn mrope_coordinate(&self, cache_len: i32) -> Result<i32, MropeCoordinateError> {
+        mrope_decode_coordinate(cache_len, self.rope_delta)
+    }
+}
+
 pub(crate) fn validate_slot(slot: usize, slot_count: usize) -> Result<(), PreparedInputError> {
     if slot >= slot_count {
         return Err(PreparedInputError::Slot { slot, slot_count });

--- a/src/lib/mlxcel-xla/src/prepared_deepstack.rs
+++ b/src/lib/mlxcel-xla/src/prepared_deepstack.rs
@@ -329,7 +329,7 @@ impl DeepStackPreparedPrefill {
         &self.deepstack
     }
 
-    #[cfg(feature = "iree")]
+    #[cfg(any(feature = "iree", test))]
     pub(crate) fn into_parts(self) -> (PreparedPrefill, DeepStackFeatures) {
         (self.prepared, self.deepstack)
     }

--- a/src/lib/mlxcel-xla/src/prepared_deepstack.rs
+++ b/src/lib/mlxcel-xla/src/prepared_deepstack.rs
@@ -1,0 +1,423 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compact owned DeepStack side inputs for embeddings prefill.
+
+use std::fmt;
+
+use mlxcel_core::session::{OwnedTensor, PreparedPrefill, PreparedTensorDType};
+
+#[cfg(any(feature = "iree", test))]
+use crate::emitter::DeepStackConfig;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DeepStackInputError {
+    DType {
+        tensor: &'static str,
+        actual: PreparedTensorDType,
+        expected: PreparedTensorDType,
+    },
+    Shape {
+        tensor: &'static str,
+        actual: Vec<usize>,
+        expected: String,
+    },
+    ByteCount {
+        tensor: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    ShapeOverflow,
+    EmptyLayerSet,
+    InvalidPosition {
+        index: usize,
+        position: i32,
+        sequence_len: usize,
+    },
+    PositionsNotSortedUnique,
+    ModalityPositionCount {
+        positions: usize,
+        modality_tokens: usize,
+    },
+    InvalidLayerIndex(i32),
+    LayerContract {
+        actual: Vec<i32>,
+        expected: Vec<usize>,
+    },
+    StaticMaxOverflow {
+        actual: usize,
+        maximum: usize,
+    },
+    HiddenSize {
+        actual: usize,
+        expected: usize,
+    },
+    NonFiniteFeature,
+}
+
+impl fmt::Display for DeepStackInputError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DType {
+                tensor,
+                actual,
+                expected,
+            } => write!(
+                f,
+                "DeepStack {tensor} dtype {actual:?} must be {expected:?}"
+            ),
+            Self::Shape {
+                tensor,
+                actual,
+                expected,
+            } => write!(f, "DeepStack {tensor} shape {actual:?} must be {expected}"),
+            Self::ByteCount {
+                tensor,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "DeepStack {tensor} byte count mismatch: expected {expected}, got {actual}"
+            ),
+            Self::ShapeOverflow => f.write_str("DeepStack tensor shape arithmetic overflowed"),
+            Self::EmptyLayerSet => f.write_str("DeepStack requires at least one feature layer"),
+            Self::InvalidPosition {
+                index,
+                position,
+                sequence_len,
+            } => write!(
+                f,
+                "DeepStack visual position {index}={position} is outside [0,{sequence_len})"
+            ),
+            Self::PositionsNotSortedUnique => {
+                f.write_str("DeepStack visual positions must be strictly sorted and unique")
+            }
+            Self::ModalityPositionCount {
+                positions,
+                modality_tokens,
+            } => write!(
+                f,
+                "DeepStack has {positions} visual positions but placeholder expansion metadata accounts for {modality_tokens} modality tokens"
+            ),
+            Self::InvalidLayerIndex(layer) => {
+                write!(f, "DeepStack layer index {layer} must be non-negative")
+            }
+            Self::LayerContract { actual, expected } => write!(
+                f,
+                "DeepStack layer indices {actual:?} do not match compiled target layers {expected:?}"
+            ),
+            Self::StaticMaxOverflow { actual, maximum } => write!(
+                f,
+                "DeepStack visual position count {actual} exceeds static maximum {maximum}"
+            ),
+            Self::HiddenSize { actual, expected } => write!(
+                f,
+                "DeepStack feature hidden size {actual} must match model hidden size {expected}"
+            ),
+            Self::NonFiniteFeature => {
+                f.write_str("DeepStack layer features contain a non-finite value")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DeepStackInputError {}
+
+fn checked_byte_count(
+    tensor: &'static str,
+    value: &OwnedTensor,
+) -> Result<(), DeepStackInputError> {
+    let expected = value
+        .shape
+        .iter()
+        .try_fold(1usize, |count, &dim| count.checked_mul(dim))
+        .and_then(|count| count.checked_mul(value.dtype.size_bytes()))
+        .ok_or(DeepStackInputError::ShapeOverflow)?;
+    if value.bytes.len() != expected {
+        return Err(DeepStackInputError::ByteCount {
+            tensor,
+            expected,
+            actual: value.bytes.len(),
+        });
+    }
+    Ok(())
+}
+
+fn read_i32(tensor: &'static str, value: &OwnedTensor) -> Result<Vec<i32>, DeepStackInputError> {
+    checked_byte_count(tensor, value)?;
+    Ok(value
+        .bytes
+        .chunks_exact(4)
+        .map(|bytes| i32::from_le_bytes(bytes.try_into().expect("four-byte chunk")))
+        .collect())
+}
+
+fn read_f32(tensor: &'static str, value: &OwnedTensor) -> Result<Vec<f32>, DeepStackInputError> {
+    checked_byte_count(tensor, value)?;
+    Ok(value
+        .bytes
+        .chunks_exact(4)
+        .map(|bytes| f32::from_le_bytes(bytes.try_into().expect("four-byte chunk")))
+        .collect())
+}
+
+/// Compact side tensors with shapes `[Nv]`, `[K, Nv, hidden]`, and `[K]`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeepStackFeatures {
+    visual_positions: OwnedTensor,
+    layer_features: OwnedTensor,
+    layer_indices: OwnedTensor,
+}
+
+impl DeepStackFeatures {
+    pub fn new(
+        visual_positions: OwnedTensor,
+        layer_features: OwnedTensor,
+        layer_indices: OwnedTensor,
+    ) -> Result<Self, DeepStackInputError> {
+        if visual_positions.dtype != PreparedTensorDType::Int32 {
+            return Err(DeepStackInputError::DType {
+                tensor: "visual_positions",
+                actual: visual_positions.dtype,
+                expected: PreparedTensorDType::Int32,
+            });
+        }
+        if layer_indices.dtype != PreparedTensorDType::Int32 {
+            return Err(DeepStackInputError::DType {
+                tensor: "layer_indices",
+                actual: layer_indices.dtype,
+                expected: PreparedTensorDType::Int32,
+            });
+        }
+        if layer_features.dtype != PreparedTensorDType::Float32 {
+            return Err(DeepStackInputError::DType {
+                tensor: "layer_features",
+                actual: layer_features.dtype,
+                expected: PreparedTensorDType::Float32,
+            });
+        }
+        if visual_positions.shape.len() != 1 {
+            return Err(DeepStackInputError::Shape {
+                tensor: "visual_positions",
+                actual: visual_positions.shape.clone(),
+                expected: "[Nv]".to_string(),
+            });
+        }
+        if layer_indices.shape.len() != 1 {
+            return Err(DeepStackInputError::Shape {
+                tensor: "layer_indices",
+                actual: layer_indices.shape.clone(),
+                expected: "[K]".to_string(),
+            });
+        }
+        if layer_indices.shape[0] == 0 {
+            return Err(DeepStackInputError::EmptyLayerSet);
+        }
+        let layer_count = layer_indices.shape[0];
+        let visual_count = visual_positions.shape[0];
+        if layer_features.shape.len() != 3
+            || layer_features.shape[0] != layer_count
+            || layer_features.shape[1] != visual_count
+            || layer_features.shape[2] == 0
+        {
+            return Err(DeepStackInputError::Shape {
+                tensor: "layer_features",
+                actual: layer_features.shape.clone(),
+                expected: format!("[{layer_count}, {visual_count}, hidden>0]"),
+            });
+        }
+        checked_byte_count("visual_positions", &visual_positions)?;
+        checked_byte_count("layer_features", &layer_features)?;
+        checked_byte_count("layer_indices", &layer_indices)?;
+        Ok(Self {
+            visual_positions,
+            layer_features,
+            layer_indices,
+        })
+    }
+
+    #[must_use]
+    pub fn visual_count(&self) -> usize {
+        self.visual_positions.shape[0]
+    }
+
+    #[must_use]
+    pub fn layer_count(&self) -> usize {
+        self.layer_indices.shape[0]
+    }
+
+    #[must_use]
+    pub fn hidden_size(&self) -> usize {
+        self.layer_features.shape[2]
+    }
+}
+
+/// Prepared embeddings coupled to compact, prefill-only DeepStack additions.
+#[derive(Clone, Debug)]
+pub struct DeepStackPreparedPrefill {
+    prepared: PreparedPrefill,
+    deepstack: DeepStackFeatures,
+}
+
+impl DeepStackPreparedPrefill {
+    pub fn new(
+        prepared: PreparedPrefill,
+        deepstack: DeepStackFeatures,
+    ) -> Result<Self, DeepStackInputError> {
+        let positions = read_i32("visual_positions", &deepstack.visual_positions)?;
+        if positions.windows(2).any(|pair| pair[0] >= pair[1]) {
+            return Err(DeepStackInputError::PositionsNotSortedUnique);
+        }
+        if let Some((index, &position)) = positions
+            .iter()
+            .enumerate()
+            .find(|(_, position)| **position < 0 || **position as usize >= prepared.sequence_len)
+        {
+            return Err(DeepStackInputError::InvalidPosition {
+                index,
+                position,
+                sequence_len: prepared.sequence_len,
+            });
+        }
+        let modality_tokens = prepared
+            .modalities
+            .iter()
+            .try_fold(0usize, |count, modality| {
+                count.checked_add(modality.token_count)
+            })
+            .ok_or(DeepStackInputError::ShapeOverflow)?;
+        if modality_tokens != positions.len() {
+            return Err(DeepStackInputError::ModalityPositionCount {
+                positions: positions.len(),
+                modality_tokens,
+            });
+        }
+        let layers = read_i32("layer_indices", &deepstack.layer_indices)?;
+        if let Some(&layer) = layers.iter().find(|&&layer| layer < 0) {
+            return Err(DeepStackInputError::InvalidLayerIndex(layer));
+        }
+        if read_f32("layer_features", &deepstack.layer_features)?
+            .iter()
+            .any(|value| !value.is_finite())
+        {
+            return Err(DeepStackInputError::NonFiniteFeature);
+        }
+        Ok(Self {
+            prepared,
+            deepstack,
+        })
+    }
+
+    #[must_use]
+    pub fn prepared(&self) -> &PreparedPrefill {
+        &self.prepared
+    }
+
+    #[must_use]
+    pub fn deepstack(&self) -> &DeepStackFeatures {
+        &self.deepstack
+    }
+
+    #[cfg(feature = "iree")]
+    pub(crate) fn into_parts(self) -> (PreparedPrefill, DeepStackFeatures) {
+        (self.prepared, self.deepstack)
+    }
+}
+
+#[cfg(any(feature = "iree", test))]
+#[derive(Debug)]
+pub(crate) struct PreparedDeepStack {
+    pub(crate) visual_positions: Vec<i32>,
+    pub(crate) layer_features: Vec<f32>,
+    pub(crate) layer_indices: Vec<i32>,
+    pub(crate) actual_layer_count: usize,
+    pub(crate) actual_visual_count: usize,
+    pub(crate) max_layer_count: usize,
+    pub(crate) max_visual_count: usize,
+    pub(crate) hidden_size: usize,
+}
+
+#[cfg(any(feature = "iree", test))]
+impl PreparedDeepStack {
+    pub(crate) fn prepare(
+        value: &DeepStackFeatures,
+        schema: &DeepStackConfig,
+        hidden_size: usize,
+    ) -> Result<Self, DeepStackInputError> {
+        let actual_visual_count = value.visual_count();
+        if actual_visual_count > schema.max_visual_positions {
+            return Err(DeepStackInputError::StaticMaxOverflow {
+                actual: actual_visual_count,
+                maximum: schema.max_visual_positions,
+            });
+        }
+        if value.hidden_size() != hidden_size {
+            return Err(DeepStackInputError::HiddenSize {
+                actual: value.hidden_size(),
+                expected: hidden_size,
+            });
+        }
+        let actual_layers = read_i32("layer_indices", &value.layer_indices)?;
+        if actual_layers
+            != schema
+                .target_layer_indices
+                .iter()
+                .map(|&layer| layer as i32)
+                .collect::<Vec<_>>()
+        {
+            return Err(DeepStackInputError::LayerContract {
+                actual: actual_layers,
+                expected: schema.target_layer_indices.clone(),
+            });
+        }
+        let compact_positions = read_i32("visual_positions", &value.visual_positions)?;
+        let compact_features = read_f32("layer_features", &value.layer_features)?;
+        let max_layer_count = schema.target_layer_indices.len();
+        let max_visual_count = schema.max_visual_positions;
+        let static_count = max_layer_count
+            .checked_mul(max_visual_count)
+            .and_then(|count| count.checked_mul(hidden_size))
+            .ok_or(DeepStackInputError::ShapeOverflow)?;
+        let mut layer_features = vec![0.0; static_count];
+        for layer in 0..max_layer_count {
+            for visual in 0..actual_visual_count {
+                let source = (layer * actual_visual_count + visual) * hidden_size;
+                let destination = (layer * max_visual_count + visual) * hidden_size;
+                layer_features[destination..destination + hidden_size]
+                    .copy_from_slice(&compact_features[source..source + hidden_size]);
+            }
+        }
+        let mut visual_positions = vec![-1; max_visual_count];
+        visual_positions[..actual_visual_count].copy_from_slice(&compact_positions);
+        let layer_indices = schema
+            .target_layer_indices
+            .iter()
+            .map(|&layer| layer as i32)
+            .collect();
+        Ok(Self {
+            visual_positions,
+            layer_features,
+            layer_indices,
+            actual_layer_count: max_layer_count,
+            actual_visual_count,
+            max_layer_count,
+            max_visual_count,
+            hidden_size,
+        })
+    }
+}
+
+#[cfg(test)]
+#[path = "prepared_deepstack_tests.rs"]
+mod tests;

--- a/src/lib/mlxcel-xla/src/prepared_deepstack_tests.rs
+++ b/src/lib/mlxcel-xla/src/prepared_deepstack_tests.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::*;
+use crate::prepared::{PreparedInputError, PreparedIreePrefill, PreparedPositionMode};
 use mlxcel_core::session::{
     PreparedAttentionBias, PreparedModality, PreparedPositions, PreparedTensorDType,
 };
@@ -71,6 +72,44 @@ fn schema() -> DeepStackConfig {
     DeepStackConfig {
         target_layer_indices: vec![0, 2, 3],
         max_visual_positions: 4,
+    }
+}
+
+#[test]
+fn public_deepstack_request_preserves_mrope_delta_and_rejects_wrong_mode() {
+    for rope_delta in [-2, 5] {
+        let mut value = prepared(2);
+        value.positions = PreparedPositions::Mrope3D {
+            tensor: tensor_i32(&[3, 4], [0, 1, 2, 3, 0, 1, 3, 3, 0, 2, 2, 3]),
+            rope_delta,
+        };
+        let request =
+            DeepStackPreparedPrefill::new(value, features(&[1, 3], &[0, 2, 3], 2)).unwrap();
+        let prepared = PreparedIreePrefill::prepare_for_mode(
+            request.prepared(),
+            2,
+            8,
+            PreparedPositionMode::Mrope3D,
+        )
+        .unwrap();
+        assert_eq!(prepared.positions.mode(), PreparedPositionMode::Mrope3D);
+        assert_eq!(prepared.positions.rope_delta(), rope_delta);
+        assert_eq!(prepared.positions.values().len(), 3 * 8);
+
+        let error = PreparedIreePrefill::prepare_for_mode(
+            request.prepared(),
+            2,
+            8,
+            PreparedPositionMode::OneD,
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            PreparedInputError::PositionModeMismatch {
+                expected: PreparedPositionMode::OneD,
+                actual: PreparedPositionMode::Mrope3D,
+            }
+        );
     }
 }
 

--- a/src/lib/mlxcel-xla/src/prepared_deepstack_tests.rs
+++ b/src/lib/mlxcel-xla/src/prepared_deepstack_tests.rs
@@ -107,6 +107,46 @@ fn accepts_zero_visual_positions_without_special_dense_buffers() {
 }
 
 #[test]
+fn fixed_qwen3_vl_fixture_matches_every_post_hook_residual() {
+    // Port of Qwen3VLModel::deepstack_process's issue #650 fixture: hidden
+    // states start at one, image positions are 1..=3, and every visual feature
+    // component is ten. Repeating the same MLX add-after-layer operation at the
+    // first, middle, and last target gives the fixed 11/21/31 residual table.
+    const SEQUENCE: usize = 5;
+    const HIDDEN: usize = 4;
+    const POSITIONS: [usize; 3] = [1, 2, 3];
+    const EXPECTED_VISUAL_ROWS: [f32; 3] = [11.0, 21.0, 31.0];
+
+    let mut hidden = vec![1.0f32; SEQUENCE * HIDDEN];
+    let mut snapshots = Vec::new();
+    for _target_layer in 0..3 {
+        for &position in &POSITIONS {
+            for column in 0..HIDDEN {
+                hidden[position * HIDDEN + column] += 10.0;
+            }
+        }
+        snapshots.push(hidden.clone());
+    }
+
+    for (layer, snapshot) in snapshots.iter().enumerate() {
+        for position in 0..SEQUENCE {
+            for column in 0..HIDDEN {
+                let expected = if POSITIONS.contains(&position) {
+                    EXPECTED_VISUAL_ROWS[layer]
+                } else {
+                    1.0
+                };
+                assert_eq!(
+                    snapshot[position * HIDDEN + column],
+                    expected,
+                    "post-hook layer={layer} position={position} hidden={column}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn request_validation_rejects_position_metadata_and_non_finite_features() {
     for (positions, expected) in [
         (vec![1, 1], DeepStackInputError::PositionsNotSortedUnique),

--- a/src/lib/mlxcel-xla/src/prepared_deepstack_tests.rs
+++ b/src/lib/mlxcel-xla/src/prepared_deepstack_tests.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use super::*;
-use crate::prepared::{PreparedInputError, PreparedIreePrefill, PreparedPositionMode};
+use crate::prepared::{
+    DecodePositionState, PreparedInputError, PreparedIreePrefill, PreparedPositionMode,
+};
 use mlxcel_core::session::{
     PreparedAttentionBias, PreparedModality, PreparedPositions, PreparedTensorDType,
 };
@@ -75,16 +77,19 @@ fn schema() -> DeepStackConfig {
     }
 }
 
+fn public_mrope_request(rope_delta: i32) -> DeepStackPreparedPrefill {
+    let mut value = prepared(2);
+    value.positions = PreparedPositions::Mrope3D {
+        tensor: tensor_i32(&[3, 4], [0, 1, 2, 3, 0, 1, 3, 3, 0, 2, 2, 3]),
+        rope_delta,
+    };
+    DeepStackPreparedPrefill::new(value, features(&[1, 3], &[0, 2, 3], 2)).unwrap()
+}
+
 #[test]
 fn public_deepstack_request_preserves_mrope_delta_and_rejects_wrong_mode() {
     for rope_delta in [-2, 5] {
-        let mut value = prepared(2);
-        value.positions = PreparedPositions::Mrope3D {
-            tensor: tensor_i32(&[3, 4], [0, 1, 2, 3, 0, 1, 3, 3, 0, 2, 2, 3]),
-            rope_delta,
-        };
-        let request =
-            DeepStackPreparedPrefill::new(value, features(&[1, 3], &[0, 2, 3], 2)).unwrap();
+        let request = public_mrope_request(rope_delta);
         let prepared = PreparedIreePrefill::prepare_for_mode(
             request.prepared(),
             2,
@@ -111,6 +116,51 @@ fn public_deepstack_request_preserves_mrope_delta_and_rejects_wrong_mode() {
             }
         );
     }
+}
+
+#[test]
+fn public_deepstack_delta_commits_single_decode_coordinate_only_on_success() {
+    let successful = public_mrope_request(-2);
+    let successful = PreparedIreePrefill::prepare_for_mode(
+        successful.prepared(),
+        2,
+        8,
+        PreparedPositionMode::Mrope3D,
+    )
+    .unwrap();
+    let mut state = DecodePositionState::default();
+    assert_eq!(
+        state
+            .complete_prefill(successful.positions.rope_delta(), Ok(17))
+            .unwrap(),
+        17
+    );
+    assert_eq!(
+        state.mrope_coordinate(successful.effective_len as i32),
+        Ok(2),
+        "the first decode coordinate is sequence_len + signed delta"
+    );
+
+    let failed = public_mrope_request(5);
+    let failed = PreparedIreePrefill::prepare_for_mode(
+        failed.prepared(),
+        2,
+        8,
+        PreparedPositionMode::Mrope3D,
+    )
+    .unwrap();
+    assert_eq!(
+        state.complete_prefill::<i32>(
+            failed.positions.rope_delta(),
+            Err("native prefill failed".to_string()),
+        ),
+        Err("native prefill failed".to_string())
+    );
+    assert_eq!(
+        state.mrope_coordinate(successful.effective_len as i32),
+        Ok(2),
+        "a failed prefill must retain the previously committed coordinate"
+    );
 }
 
 #[test]

--- a/src/lib/mlxcel-xla/src/prepared_deepstack_tests.rs
+++ b/src/lib/mlxcel-xla/src/prepared_deepstack_tests.rs
@@ -1,0 +1,224 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use mlxcel_core::session::{
+    PreparedAttentionBias, PreparedModality, PreparedPositions, PreparedTensorDType,
+};
+
+fn tensor_i32(shape: &[usize], values: impl IntoIterator<Item = i32>) -> OwnedTensor {
+    let bytes = values
+        .into_iter()
+        .flat_map(i32::to_le_bytes)
+        .collect::<Vec<_>>();
+    OwnedTensor::new(bytes, PreparedTensorDType::Int32, shape.to_vec()).unwrap()
+}
+
+fn tensor_f32(shape: &[usize], values: impl IntoIterator<Item = f32>) -> OwnedTensor {
+    let bytes = values
+        .into_iter()
+        .flat_map(f32::to_le_bytes)
+        .collect::<Vec<_>>();
+    OwnedTensor::new(bytes, PreparedTensorDType::Float32, shape.to_vec()).unwrap()
+}
+
+fn prepared(modality_tokens: usize) -> PreparedPrefill {
+    PreparedPrefill::new(
+        vec![10, 11, 12, 13],
+        tensor_f32(&[1, 4, 2], [0.0; 8]),
+        PreparedPositions::Sequential {
+            start: 0,
+            length: 4,
+        },
+        PreparedAttentionBias {
+            tensor: tensor_f32(&[1, 1, 1, 4], [0.0; 4]),
+            causal: true,
+        },
+        vec![PreparedModality {
+            family: "qwen3_vl".into(),
+            item_count: usize::from(modality_tokens != 0),
+            token_count: modality_tokens,
+        }],
+    )
+    .unwrap()
+}
+
+fn features(positions: &[i32], layers: &[i32], hidden: usize) -> DeepStackFeatures {
+    let value_count = layers.len() * positions.len() * hidden;
+    DeepStackFeatures::new(
+        tensor_i32(&[positions.len()], positions.iter().copied()),
+        tensor_f32(
+            &[layers.len(), positions.len(), hidden],
+            (0..value_count).map(|index| index as f32 + 1.0),
+        ),
+        tensor_i32(&[layers.len()], layers.iter().copied()),
+    )
+    .unwrap()
+}
+
+fn schema() -> DeepStackConfig {
+    DeepStackConfig {
+        target_layer_indices: vec![0, 2, 3],
+        max_visual_positions: 4,
+    }
+}
+
+#[test]
+fn owns_compact_payload_and_materializes_only_static_runtime_padding() {
+    let compact = features(&[1, 3], &[0, 2, 3], 2);
+    let request = DeepStackPreparedPrefill::new(prepared(2), compact.clone()).unwrap();
+    assert_eq!(request.deepstack().visual_count(), 2);
+    assert_eq!(request.deepstack().layer_count(), 3);
+    assert_eq!(request.deepstack().hidden_size(), 2);
+
+    let runtime = PreparedDeepStack::prepare(&compact, &schema(), 2).unwrap();
+    assert_eq!(runtime.visual_positions, [1, 3, -1, -1]);
+    assert_eq!(runtime.layer_indices, [0, 2, 3]);
+    assert_eq!(runtime.actual_layer_count, 3);
+    assert_eq!(runtime.actual_visual_count, 2);
+    assert_eq!(runtime.max_layer_count, 3);
+    assert_eq!(runtime.max_visual_count, 4);
+    assert_eq!(runtime.hidden_size, 2);
+    assert_eq!(runtime.layer_features.len(), 3 * 4 * 2);
+    assert_eq!(&runtime.layer_features[0..4], &[1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(&runtime.layer_features[4..8], &[0.0; 4]);
+    assert_eq!(&runtime.layer_features[8..12], &[5.0, 6.0, 7.0, 8.0]);
+}
+
+#[test]
+fn accepts_zero_visual_positions_without_special_dense_buffers() {
+    let compact = features(&[], &[0, 2, 3], 2);
+    DeepStackPreparedPrefill::new(prepared(0), compact.clone()).unwrap();
+    let runtime = PreparedDeepStack::prepare(&compact, &schema(), 2).unwrap();
+    assert_eq!(runtime.actual_visual_count, 0);
+    assert_eq!(runtime.visual_positions, [-1; 4]);
+    assert!(runtime.layer_features.iter().all(|&value| value == 0.0));
+}
+
+#[test]
+fn request_validation_rejects_position_metadata_and_non_finite_features() {
+    for (positions, expected) in [
+        (vec![1, 1], DeepStackInputError::PositionsNotSortedUnique),
+        (vec![3, 1], DeepStackInputError::PositionsNotSortedUnique),
+    ] {
+        let error = DeepStackPreparedPrefill::new(prepared(2), features(&positions, &[0, 2, 3], 2))
+            .unwrap_err();
+        assert_eq!(error, expected);
+    }
+
+    let error =
+        DeepStackPreparedPrefill::new(prepared(2), features(&[1, 4], &[0, 2, 3], 2)).unwrap_err();
+    assert!(matches!(
+        error,
+        DeepStackInputError::InvalidPosition {
+            index: 1,
+            position: 4,
+            sequence_len: 4
+        }
+    ));
+
+    let error =
+        DeepStackPreparedPrefill::new(prepared(1), features(&[1, 3], &[0, 2, 3], 2)).unwrap_err();
+    assert!(matches!(
+        error,
+        DeepStackInputError::ModalityPositionCount {
+            positions: 2,
+            modality_tokens: 1
+        }
+    ));
+
+    let error =
+        DeepStackPreparedPrefill::new(prepared(2), features(&[1, 3], &[-1, 2, 3], 2)).unwrap_err();
+    assert_eq!(error, DeepStackInputError::InvalidLayerIndex(-1));
+
+    let mut invalid = features(&[1, 3], &[0, 2, 3], 2);
+    invalid.layer_features.bytes[0..4].copy_from_slice(&f32::NAN.to_le_bytes());
+    assert_eq!(
+        DeepStackPreparedPrefill::new(prepared(2), invalid).unwrap_err(),
+        DeepStackInputError::NonFiniteFeature
+    );
+}
+
+#[test]
+fn runtime_validation_rejects_schema_hidden_and_static_bound_mismatches() {
+    let compact = features(&[1, 3], &[0, 2, 3], 2);
+    let wrong_layers = DeepStackConfig {
+        target_layer_indices: vec![0, 1, 3],
+        max_visual_positions: 4,
+    };
+    assert!(matches!(
+        PreparedDeepStack::prepare(&compact, &wrong_layers, 2),
+        Err(DeepStackInputError::LayerContract { .. })
+    ));
+    assert!(matches!(
+        PreparedDeepStack::prepare(&compact, &schema(), 3),
+        Err(DeepStackInputError::HiddenSize {
+            actual: 2,
+            expected: 3
+        })
+    ));
+    let too_small = DeepStackConfig {
+        target_layer_indices: vec![0, 2, 3],
+        max_visual_positions: 1,
+    };
+    assert!(matches!(
+        PreparedDeepStack::prepare(&compact, &too_small, 2),
+        Err(DeepStackInputError::StaticMaxOverflow {
+            actual: 2,
+            maximum: 1
+        })
+    ));
+}
+
+#[test]
+fn compact_tensor_constructor_rejects_dtype_shape_and_storage_drift() {
+    let error = DeepStackFeatures::new(
+        tensor_f32(&[2], [1.0, 3.0]),
+        tensor_f32(&[1, 2, 2], [0.0; 4]),
+        tensor_i32(&[1], [0]),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        DeepStackInputError::DType {
+            tensor: "visual_positions",
+            ..
+        }
+    ));
+
+    let error = DeepStackFeatures::new(
+        tensor_i32(&[2], [1, 3]),
+        tensor_f32(&[1, 3, 2], [0.0; 6]),
+        tensor_i32(&[1], [0]),
+    )
+    .unwrap_err();
+    assert!(matches!(error, DeepStackInputError::Shape { .. }));
+
+    let mut positions = tensor_i32(&[2], [1, 3]);
+    positions.bytes.pop();
+    let error = DeepStackFeatures::new(
+        positions,
+        tensor_f32(&[1, 2, 2], [0.0; 4]),
+        tensor_i32(&[1], [0]),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        DeepStackInputError::ByteCount {
+            tensor: "visual_positions",
+            expected: 8,
+            actual: 7
+        }
+    ));
+}

--- a/tests/xla_prepared_prefill.rs
+++ b/tests/xla_prepared_prefill.rs
@@ -21,9 +21,13 @@
 use std::collections::HashMap;
 
 use mlxcel::{
-    OwnedTensor, PreparedAttentionBias, PreparedPositions, PreparedPrefill, PreparedTensorDType,
+    OwnedTensor, PreparedAttentionBias, PreparedModality, PreparedPositions, PreparedPrefill,
+    PreparedTensorDType,
 };
-use mlxcel_xla::{EngineEvent, SampleParams, XlaBatchEngine, XlaInferenceSession};
+use mlxcel_xla::{
+    DeepStackFeatures, DeepStackPreparedPrefill, EngineEvent, SampleParams, XlaBatchEngine,
+    XlaInferenceSession,
+};
 use safetensors::{Dtype, tensor::TensorView};
 use tempfile::TempDir;
 
@@ -117,7 +121,7 @@ fn create_tiny_model() -> TinyModel {
     let dir = tempfile::tempdir().expect("temporary model directory");
     std::fs::write(
         dir.path().join("config.json"),
-        r#"{"model_type":"llama","hidden_size":8,"intermediate_size":16,"num_hidden_layers":2,"num_attention_heads":2,"num_key_value_heads":1,"head_dim":4,"vocab_size":32,"rms_norm_eps":1e-6,"rope_theta":10000.0,"tie_word_embeddings":true}"#,
+        r#"{"model_type":"llama","hidden_size":8,"intermediate_size":16,"num_hidden_layers":2,"num_attention_heads":2,"num_key_value_heads":1,"head_dim":4,"vocab_size":32,"rms_norm_eps":1e-6,"rope_theta":10000.0,"tie_word_embeddings":true,"deepstack_language_layer_indices":[0,1],"deepstack_max_visual_positions":2}"#,
     )
     .expect("model config");
 
@@ -184,7 +188,7 @@ fn create_tiny_mrope_model() -> TinyModel {
     let dir = tempfile::tempdir().expect("temporary M-RoPE model directory");
     std::fs::write(
         dir.path().join("config.json"),
-        r#"{"model_type":"qwen2","hidden_size":12,"intermediate_size":24,"num_hidden_layers":2,"num_attention_heads":2,"num_key_value_heads":1,"head_dim":6,"vocab_size":32,"rms_norm_eps":1e-6,"rope_theta":10000.0,"tie_word_embeddings":true,"attention_bias":true,"hidden_act":"silu","rope_scaling":{"rope_type":"mrope","mrope_section":[1,1,1]}}"#,
+        r#"{"model_type":"qwen2","hidden_size":12,"intermediate_size":24,"num_hidden_layers":2,"num_attention_heads":2,"num_key_value_heads":1,"head_dim":6,"vocab_size":32,"rms_norm_eps":1e-6,"rope_theta":10000.0,"tie_word_embeddings":true,"attention_bias":true,"hidden_act":"silu","rope_scaling":{"rope_type":"mrope","mrope_section":[1,1,1]},"deepstack_language_layer_indices":[0,1],"deepstack_max_visual_positions":2}"#,
     )
     .expect("M-RoPE model config");
 
@@ -316,6 +320,46 @@ fn mrope_text_prepared(fixture: &TinyModel, tokens: &[i32]) -> PreparedPrefill {
     .expect("valid text-only prepared input for an M-RoPE bundle")
 }
 
+fn deepstack_request(
+    mut prepared: PreparedPrefill,
+    visual_positions: &[i32],
+    layer_indices: &[i32],
+    hidden_size: usize,
+    feature_value: f32,
+) -> DeepStackPreparedPrefill {
+    prepared.modalities = vec![PreparedModality {
+        family: "deepstack-test".to_string(),
+        item_count: usize::from(!visual_positions.is_empty()),
+        token_count: visual_positions.len(),
+    }];
+    let features = DeepStackFeatures::new(
+        tensor_i32(&[visual_positions.len()], visual_positions),
+        tensor_f32(
+            &[layer_indices.len(), visual_positions.len(), hidden_size],
+            &vec![feature_value; layer_indices.len() * visual_positions.len() * hidden_size],
+        ),
+        tensor_i32(&[layer_indices.len()], layer_indices),
+    )
+    .expect("valid compact DeepStack features");
+    DeepStackPreparedPrefill::new(prepared, features).expect("valid DeepStack request")
+}
+
+fn mrope_positions_for_one_d_fixture(
+    mut prepared: PreparedPrefill,
+    rope_delta: i32,
+) -> PreparedPrefill {
+    let sequence = prepared.sequence_len;
+    let values = (0..3)
+        .flat_map(|_| 0..sequence)
+        .map(|position| position as i32)
+        .collect::<Vec<_>>();
+    prepared.positions = PreparedPositions::Mrope3D {
+        tensor: tensor_i32(&[3, sequence], &values),
+        rope_delta,
+    };
+    prepared
+}
+
 #[test]
 #[ignore = "requires the pinned IREE runtime and compiler"]
 fn local_task_token_and_prepared_paths_are_exact_with_mixed_slot_reuse() {
@@ -336,6 +380,15 @@ fn local_task_token_and_prepared_paths_are_exact_with_mixed_slot_reuse() {
         .generate_prepared_greedy(&prepared, 2, &[])
         .expect("prepared generation");
     assert_eq!(prepared_output, text_output);
+
+    let deepstack = deepstack_request(prepared.clone(), &[1, 2], &[0, 1], HIDDEN, 0.01);
+    let mut deepstack_session =
+        XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
+            .expect("1D DeepStack session");
+    let deepstack_output = deepstack_session
+        .generate_deepstack_prepared_greedy(&deepstack, 3, &[])
+        .expect("1D DeepStack prefill and first decode");
+    assert_eq!(deepstack_output.len(), 3);
 
     let mut batch =
         XlaBatchEngine::load_with_context_capacity(fixture.path(), 4, "local-task", CAPACITY)
@@ -371,12 +424,44 @@ fn local_task_token_and_prepared_paths_are_exact_with_mixed_slot_reuse() {
     let reused = batch
         .submit_prepared(fixture.prepared(&tokens), 2, SampleParams::greedy())
         .expect("reuse released slot");
-    let events = batch.pump().expect("pump reused slot");
-    assert!(
-        events
-            .iter()
-            .any(|event| matches!(event, EngineEvent::Token { req_id, .. } if *req_id == reused))
+    let deepstack_id = batch
+        .submit_deepstack_prepared(deepstack, 3, SampleParams::greedy())
+        .expect("queue public 1D DeepStack request");
+    let mut reused_seen = false;
+    let mut deepstack_tokens = Vec::new();
+    while !batch.is_idle() {
+        for event in batch.pump().expect("pump reused and DeepStack slots") {
+            if let EngineEvent::Token { req_id, token } = event {
+                reused_seen |= req_id == reused;
+                if req_id == deepstack_id {
+                    deepstack_tokens.push(token);
+                }
+            }
+        }
+    }
+    assert!(reused_seen);
+    assert_eq!(deepstack_tokens, deepstack_output);
+
+    let wrong_mode = deepstack_request(
+        mrope_positions_for_one_d_fixture(fixture.prepared(&tokens), -1),
+        &[1, 2],
+        &[0, 1],
+        HIDDEN,
+        0.01,
     );
+    let mut wrong_single =
+        XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
+            .expect("wrong-mode single session");
+    let error = wrong_single
+        .prefill_deepstack_prepared(&wrong_mode)
+        .expect_err("M-RoPE positions must fail against a 1D DeepStack bundle");
+    assert!(error.contains("position mode"));
+    let pending_before = batch.pending_len();
+    let error = batch
+        .submit_deepstack_prepared(wrong_mode, 2, SampleParams::greedy())
+        .expect_err("wrong-mode batch admission must fail closed");
+    assert!(error.to_string().contains("position mode"));
+    assert_eq!(batch.pending_len(), pending_before);
 }
 
 #[test]
@@ -396,6 +481,10 @@ fn local_task_mrope_prefill_decode_and_per_slot_deltas_execute() {
         [&[0, 1, 1, 3], &[0, 1, 2, 3], &[0, 2, 1, 3]],
         2,
     );
+    let negative_deepstack =
+        deepstack_request(negative.clone(), &[1, 3], &[0, 1], MROPE_HIDDEN, 0.01);
+    let positive_deepstack =
+        deepstack_request(positive.clone(), &[1, 3], &[0, 1], MROPE_HIDDEN, 0.02);
 
     let mut single_text =
         XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
@@ -421,6 +510,36 @@ fn local_task_mrope_prefill_decode_and_per_slot_deltas_execute() {
         .expect("real-IREE M-RoPE single prefill/decode");
     assert_eq!(single_tokens.len(), 3);
 
+    let mut single_deepstack =
+        XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
+            .expect("M-RoPE single DeepStack session");
+    let single_deepstack_tokens = single_deepstack
+        .generate_deepstack_prepared_greedy(&negative_deepstack, 3, &[])
+        .expect("real-IREE M-RoPE DeepStack prefill and first decode");
+    assert_eq!(single_deepstack_tokens.len(), 3);
+
+    let mut atomic = XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
+        .expect("M-RoPE DeepStack atomic-failure session");
+    let first = atomic
+        .prefill_deepstack_prepared(&negative_deepstack)
+        .expect("seed negative-delta DeepStack state");
+    let wrong_layers = deepstack_request(negative.clone(), &[1, 3], &[0], MROPE_HIDDEN, 0.01);
+    let error = atomic
+        .prefill_deepstack_prepared(&wrong_layers)
+        .expect_err("runtime DeepStack schema mismatch must fail");
+    assert!(error.contains("do not match compiled target layers"));
+    let after_failure = mlxcel::InferenceSession::decode_step(&mut atomic, first)
+        .expect("failed prefill must retain the prior signed-delta decode state");
+    let mut control = XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
+        .expect("M-RoPE DeepStack atomic-failure control");
+    let control_first = control
+        .prefill_deepstack_prepared(&negative_deepstack)
+        .expect("seed control negative-delta state");
+    let control_next =
+        mlxcel::InferenceSession::decode_step(&mut control, control_first).expect("decode control");
+    assert_eq!(first, control_first);
+    assert_eq!(after_failure, control_next);
+
     let mut batch =
         XlaBatchEngine::load_with_context_capacity(fixture.path(), 4, "local-task", CAPACITY)
             .expect("M-RoPE ragged batch");
@@ -428,11 +547,11 @@ fn local_task_mrope_prefill_decode_and_per_slot_deltas_execute() {
         .submit(&tokens, 3, SampleParams::greedy())
         .expect("text-only Qwen request canonicalizes to 3D with delta zero");
     let vision = batch
-        .submit_prepared(negative, 3, SampleParams::greedy())
-        .expect("negative-delta vision request");
+        .submit_deepstack_prepared(negative_deepstack, 3, SampleParams::greedy())
+        .expect("negative-delta DeepStack vision request");
     let cancelled = batch
-        .submit_prepared(positive.clone(), 3, SampleParams::greedy())
-        .expect("positive-delta cancellation candidate");
+        .submit_deepstack_prepared(positive_deepstack.clone(), 3, SampleParams::greedy())
+        .expect("positive-delta DeepStack cancellation candidate");
     assert!(batch.cancel(cancelled));
 
     let mut text_tokens = Vec::new();
@@ -453,13 +572,13 @@ fn local_task_mrope_prefill_decode_and_per_slot_deltas_execute() {
         "ragged text token prefill must upload the exact [3, capacity] position buffer"
     );
     assert_eq!(
-        vision_tokens, single_tokens,
-        "single and ragged logits must select the same M-RoPE tokens"
+        vision_tokens, single_deepstack_tokens,
+        "single and ragged DeepStack logits must select the same M-RoPE tokens"
     );
 
     let reused = batch
-        .submit_prepared(positive, 2, SampleParams::greedy())
-        .expect("positive delta enters a released slot");
+        .submit_deepstack_prepared(positive_deepstack, 2, SampleParams::greedy())
+        .expect("positive-delta DeepStack request enters a released slot");
     let reused_text = batch
         .submit(&tokens, 3, SampleParams::greedy())
         .expect("text token request reuses a released M-RoPE slot");


### PR DESCRIPTION
## Summary

- Add the distinct optional `prefill_embeddings_deepstack.main` entry with compact `[Nv]`, `[K, Nv, hidden]`, and `[K]` side tensors and post-language-layer sparse residual injection.
- Validate config pairing, descriptors, byte counts, expanded-sequence positions, target layers, finite features, and static bounds in Rust and again in the C ABI.
- Wire optional VMFB compilation/loading, artifact identity, single-session and ragged batch execution, and request-owned cancellation/error cleanup without changing decode state.
- Preserve token prefill, ordinary embeddings prefill, and decode IR byte-for-byte when DeepStack is declared.
- Add a diagnostic-only graph that reuses the production shared layer loop and exposes every post-hook hidden state for the fixed MLX Qwen3-VL oracle; it is never loaded into serving sessions.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p mlxcel-xla --lib` (193 passed, 6 opt-in ignored, 0 failed)
- `cargo test -p mlxcel-xla --lib deepstack` (9 passed)
- `cargo clippy -p mlxcel-xla --lib --tests -- -D warnings`
- `IREE_CUDA_HOME=... IREE_CUDA_COMPILE=... cargo clippy -p mlxcel-xla --lib --features iree -- -D warnings`
- `CARGO_TARGET_DIR=... python3 spike/openxla/deepstack_prefill_check.py` compiled and ran both production and diagnostic Qwen3-shaped VMFBs on IREE local-task. The fixture ports `Qwen3VLModel::deepstack_process` semantics and exactly checks the full first/middle/last `[3, 256, 4]` post-hook residual tensor against visual-row values 11/21/31, final logits, and every K/V element for both graphs.

Closes #867