### PR TITLE
feat(xla): add multimodal RoPE position state

### DIFF
--- a/src/lib/mlxcel-core/src/multimodal.rs
+++ b/src/lib/mlxcel-core/src/multimodal.rs
@@ -98,9 +98,19 @@ impl OwnedTensor {
 pub enum PreparedPositions {
     /// Dense positions `start..start + length`, the LLaVA reference layout.
     Sequential { start: i32, length: usize },
-    /// Explicit position rows for model families that do not use a scalar
-    /// sequence position (for example multimodal RoPE families).
+    /// Explicit scalar positions for a one-dimensional RoPE model.
     Explicit(OwnedTensor),
+    /// Canonical temporal/height/width coordinates for an M-RoPE model.
+    ///
+    /// `tensor` is row-major `[3, sequence]` in `[temporal, height, width]`
+    /// order. `rope_delta` is the signed per-sequence decode adjustment:
+    /// decode coordinate = physical KV length + `rope_delta`. Keeping this as a
+    /// distinct enum variant prevents a native backend from guessing position
+    /// semantics from tensor rank after the ownership boundary.
+    Mrope3D {
+        tensor: OwnedTensor,
+        rope_delta: i32,
+    },
 }
 
 impl PreparedPositions {
@@ -109,6 +119,7 @@ impl PreparedPositions {
         match self {
             Self::Sequential { length, .. } => Some(*length),
             Self::Explicit(tensor) => tensor.shape.last().copied(),
+            Self::Mrope3D { tensor, .. } => tensor.shape.last().copied(),
         }
     }
 }
@@ -184,10 +195,27 @@ impl PreparedPrefill {
                 actual: position_len,
             });
         }
-        if let PreparedPositions::Explicit(tensor) = &positions
-            && tensor.dtype != PreparedTensorDType::Int32
-        {
-            return Err(PreparedPrefillError::PositionDType(tensor.dtype));
+        match &positions {
+            PreparedPositions::Explicit(tensor)
+                if tensor.shape != [sequence_len] && tensor.shape != [1, sequence_len] =>
+            {
+                return Err(PreparedPrefillError::ExplicitPositionShape {
+                    shape: tensor.shape.clone(),
+                    sequence_len,
+                });
+            }
+            PreparedPositions::Mrope3D { tensor, .. } if tensor.shape != [3, sequence_len] => {
+                return Err(PreparedPrefillError::MropePositionShape {
+                    shape: tensor.shape.clone(),
+                    sequence_len,
+                });
+            }
+            PreparedPositions::Explicit(tensor) | PreparedPositions::Mrope3D { tensor, .. }
+                if tensor.dtype != PreparedTensorDType::Int32 =>
+            {
+                return Err(PreparedPrefillError::PositionDType(tensor.dtype));
+            }
+            _ => {}
         }
         if !attention_bias.tensor.dtype.is_float() {
             return Err(PreparedPrefillError::AttentionBiasDType(
@@ -243,6 +271,16 @@ pub enum PreparedPrefillError {
     PositionLength {
         expected: usize,
         actual: Option<usize>,
+    },
+    #[error("prepared 1D position shape {shape:?} must be [{sequence_len}] or [1, {sequence_len}]")]
+    ExplicitPositionShape {
+        shape: Vec<usize>,
+        sequence_len: usize,
+    },
+    #[error("prepared M-RoPE position shape {shape:?} must be [3, {sequence_len}]")]
+    MropePositionShape {
+        shape: Vec<usize>,
+        sequence_len: usize,
     },
     #[error("prepared explicit-position dtype {0:?} must be Int32")]
     PositionDType(PreparedTensorDType),

--- a/src/lib/mlxcel-core/src/multimodal_tests.rs
+++ b/src/lib/mlxcel-core/src/multimodal_tests.rs
@@ -114,3 +114,53 @@ fn prepared_prefill_rejects_floating_point_explicit_positions() {
         PreparedPrefillError::PositionDType(PreparedTensorDType::Float32)
     );
 }
+
+#[test]
+fn prepared_prefill_keeps_mrope_mode_and_signed_delta_explicit() {
+    let prepared = PreparedPrefill::new(
+        vec![1, 2, 3],
+        zeros(PreparedTensorDType::Float16, &[1, 3, 4]),
+        PreparedPositions::Mrope3D {
+            tensor: zeros(PreparedTensorDType::Int32, &[3, 3]),
+            rope_delta: -2,
+        },
+        PreparedAttentionBias {
+            tensor: zeros(PreparedTensorDType::Float32, &[1, 1, 1, 3]),
+            causal: true,
+        },
+        Vec::new(),
+    )
+    .unwrap();
+
+    assert!(matches!(
+        prepared.positions,
+        PreparedPositions::Mrope3D { rope_delta: -2, .. }
+    ));
+}
+
+#[test]
+fn prepared_prefill_rejects_missing_or_extra_mrope_axes() {
+    for axes in [2, 4] {
+        let error = PreparedPrefill::new(
+            vec![1, 2, 3],
+            zeros(PreparedTensorDType::Float16, &[1, 3, 4]),
+            PreparedPositions::Mrope3D {
+                tensor: zeros(PreparedTensorDType::Int32, &[axes, 3]),
+                rope_delta: 0,
+            },
+            PreparedAttentionBias {
+                tensor: zeros(PreparedTensorDType::Float32, &[1, 1, 1, 3]),
+                causal: true,
+            },
+            Vec::new(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            PreparedPrefillError::MropePositionShape {
+                shape: vec![axes, 3],
+                sequence_len: 3,
+            }
+        );
+    }
+}

--- a/src/lib/mlxcel-xla/csrc/xla_iree.c
+++ b/src/lib/mlxcel-xla/csrc/xla_iree.c
@@ -100,6 +100,9 @@ typedef struct xla_ctx {
   int32_t n_weights;
   int32_t context_capacity;
   int32_t hidden_size;
+  // Explicit position ABI selected when the bundle is created:
+  // 0 = scalar/1D RoPE, 1 = M-RoPE temporal/height/width coordinates.
+  int32_t position_mode;
   // 0 = ordinary `prefill_embeddings.main`, 1 = Gemma3n's distinct
   // `prefill_embeddings_ple.main` with a rank-3 dense PLE argument.
   int32_t prefill_embeddings_kind;
@@ -309,12 +312,17 @@ static iree_status_t xla_llama_create_impl(
     const void* const* weight_data,
     const int32_t* weight_dtypes, const int32_t* weight_ranks,
     const int64_t* weight_dims, int32_t context_capacity,
-    int32_t hidden_size, int32_t prefill_embeddings_kind,
+    int32_t hidden_size, int32_t position_mode,
+    int32_t prefill_embeddings_kind,
     int32_t dense_ple_layers, int32_t dense_ple_hidden) {
   if (context_capacity <= 0 || hidden_size <= 0 ||
       compatibility_fingerprint == 0) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "bundle fingerprint, context_capacity, and hidden_size must be positive");
+  }
+  if (position_mode != 0 && position_mode != 1) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "position_mode must be 0 (1D) or 1 (M-RoPE 3D)");
   }
   if ((prefill_embeddings_kind != 0 && prefill_embeddings_kind != 1) ||
       (prefill_embeddings_kind == 0 &&
@@ -328,6 +336,7 @@ static iree_status_t xla_llama_create_impl(
   c->n_weights = n_weights;
   c->context_capacity = context_capacity;
   c->hidden_size = hidden_size;
+  c->position_mode = position_mode;
   c->compatibility_fingerprint = compatibility_fingerprint;
   c->prefill_embeddings_kind = prefill_embeddings_kind;
   c->dense_ple_layers = dense_ple_layers;
@@ -447,6 +456,7 @@ xla_ctx* xla_llama_create(const char* device_uri, const char* prefill_vmfb,
                           const int32_t* weight_ranks,
                           const int64_t* weight_dims,
                           int32_t context_capacity, int32_t hidden_size,
+                          int32_t position_mode,
                           int32_t prefill_embeddings_kind,
                           int32_t dense_ple_layers,
                           int32_t dense_ple_hidden) {
@@ -459,6 +469,7 @@ xla_ctx* xla_llama_create(const char* device_uri, const char* prefill_vmfb,
                             compatibility_fingerprint, n_weights, weight_data,
                             weight_dtypes, weight_ranks, weight_dims,
                             context_capacity, hidden_size,
+                            position_mode,
                             prefill_embeddings_kind, dense_ple_layers,
                             dense_ple_hidden);
   if (!iree_status_is_ok(s)) {
@@ -474,7 +485,8 @@ xla_ctx* xla_llama_create(const char* device_uri, const char* prefill_vmfb,
   return c;
 }
 
-// prefill: tokens[lp], positions[lp], real_len -> first token id; the returned
+// prefill: tokens[lp], positions[lp] or positions[3, lp], real_len -> first token
+// id; the returned
 // KV cache becomes the resident cache decode threads forward.
 int xla_llama_prefill(xla_ctx* c, const int32_t* tokens, int32_t lp,
                       const int32_t* positions, int32_t real_len,
@@ -493,14 +505,19 @@ int xla_llama_prefill(xla_ctx* c, const int32_t* tokens, int32_t lp,
         iree_runtime_call_inputs_push_back_buffer_view(&call, c->weights[i]));
   }
   iree_hal_dim_t seq_shape[1] = {(iree_hal_dim_t)lp};
+  iree_hal_dim_t position_shape[2] = {3, (iree_hal_dim_t)lp};
   iree_host_size_t seq_bytes = (iree_host_size_t)lp * sizeof(int32_t);
+  iree_host_size_t position_bytes =
+      seq_bytes * (c->position_mode == 1 ? 3 : 1);
   iree_hal_buffer_view_t* tok_bv = NULL;
   iree_hal_buffer_view_t* pos_bv = NULL;
   iree_hal_buffer_view_t* len_bv = NULL;
   XLA_CHECK(xla_alloc_bv(c, 1, seq_shape, IREE_HAL_ELEMENT_TYPE_INT_32, tokens,
                          seq_bytes, &tok_bv));
-  XLA_CHECK(xla_alloc_bv(c, 1, seq_shape, IREE_HAL_ELEMENT_TYPE_INT_32,
-                         positions, seq_bytes, &pos_bv));
+  XLA_CHECK(xla_alloc_bv(c, c->position_mode == 1 ? 2 : 1,
+                         c->position_mode == 1 ? position_shape : seq_shape,
+                         IREE_HAL_ELEMENT_TYPE_INT_32, positions,
+                         position_bytes, &pos_bv));
   XLA_CHECK(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32, &real_len,
                          sizeof(int32_t), &len_bv));
   XLA_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call, tok_bv));
@@ -540,16 +557,26 @@ int xla_llama_prefill(xla_ctx* c, const int32_t* tokens, int32_t lp,
   return 0;
 }
 
-// decode_step: token, pos, cache_len + resident KV -> next token id; advances
-// the resident KV cache in place.
-int xla_llama_decode(xla_ctx* c, int32_t token, int32_t pos, int32_t cache_len,
-                     int32_t* out_token) {
-  if (!c->kcache || !c->vcache || pos != cache_len || pos < 0 ||
-      pos >= c->context_capacity) {
+// Shared decode implementation. `position_mode` is an explicit ABI contract,
+// never inferred from the position buffer rank.
+static int xla_llama_decode_impl(xla_ctx* c, int32_t token,
+                                 const int32_t* positions,
+                                 int32_t position_mode, int32_t cache_len,
+                                 int32_t* out_token) {
+  if (!c->kcache || !c->vcache || c->position_mode != position_mode ||
+      cache_len < 0 || cache_len >= c->context_capacity) {
     fprintf(stderr,
-            "xla_llama_decode: pos=%d cache_len=%d context_capacity=%d or KV is uninitialized\n",
-            pos, cache_len, c->context_capacity);
+            "xla_llama_decode: mode=%d bundle_mode=%d cache_len=%d context_capacity=%d or KV is uninitialized\n",
+            position_mode, c->position_mode, cache_len, c->context_capacity);
     return 1;
+  }
+  int32_t position_count = position_mode == 1 ? 3 : 1;
+  for (int32_t axis = 0; axis < position_count; ++axis) {
+    if (positions[axis] < 0) {
+      fprintf(stderr, "xla_llama_decode: position axis %d is negative (%d)\n",
+              axis, positions[axis]);
+      return 1;
+    }
   }
   iree_runtime_call_t call;
   XLA_CHECK(iree_runtime_call_initialize_by_name(
@@ -563,8 +590,12 @@ int xla_llama_decode(xla_ctx* c, int32_t token, int32_t pos, int32_t cache_len,
   iree_hal_buffer_view_t* len_bv = NULL;
   XLA_CHECK(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32, &token,
                          sizeof(int32_t), &tok_bv));
-  XLA_CHECK(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32, &pos,
-                         sizeof(int32_t), &pos_bv));
+  iree_hal_dim_t position_shape[1] = {3};
+  XLA_CHECK(xla_alloc_bv(c, position_mode == 1 ? 1 : 0,
+                         position_mode == 1 ? position_shape : NULL,
+                         IREE_HAL_ELEMENT_TYPE_INT_32, positions,
+                         (iree_host_size_t)position_count * sizeof(int32_t),
+                         &pos_bv));
   XLA_CHECK(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32, &cache_len,
                          sizeof(int32_t), &len_bv));
   XLA_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call, tok_bv));
@@ -608,6 +639,17 @@ int xla_llama_decode(xla_ctx* c, int32_t token, int32_t pos, int32_t cache_len,
   iree_hal_buffer_view_release(old_k);
   iree_hal_buffer_view_release(old_v);
   return 0;
+}
+
+int xla_llama_decode(xla_ctx* c, int32_t token, int32_t pos,
+                     int32_t cache_len, int32_t* out_token) {
+  return xla_llama_decode_impl(c, token, &pos, 0, cache_len, out_token);
+}
+
+int xla_llama_decode_mrope(xla_ctx* c, int32_t token,
+                           const int32_t positions[3], int32_t cache_len,
+                           int32_t* out_token) {
+  return xla_llama_decode_impl(c, token, positions, 1, cache_len, out_token);
 }
 
 // ===========================================================================
@@ -762,14 +804,19 @@ int xla_llama_prefill_slot_logits(xla_ctx* c, int32_t slot, const int32_t* token
         iree_runtime_call_inputs_push_back_buffer_view(&call, c->weights[i]));
   }
   iree_hal_dim_t seq_shape[1] = {(iree_hal_dim_t)lp};
+  iree_hal_dim_t position_shape[2] = {3, (iree_hal_dim_t)lp};
   iree_host_size_t seq_bytes = (iree_host_size_t)lp * sizeof(int32_t);
+  iree_host_size_t position_bytes =
+      seq_bytes * (c->position_mode == 1 ? 3 : 1);
   iree_hal_buffer_view_t* tok_bv = NULL;
   iree_hal_buffer_view_t* pos_bv = NULL;
   iree_hal_buffer_view_t* len_bv = NULL;
   XLA_CHECK(xla_alloc_bv(c, 1, seq_shape, IREE_HAL_ELEMENT_TYPE_INT_32, tokens,
                          seq_bytes, &tok_bv));
-  XLA_CHECK(xla_alloc_bv(c, 1, seq_shape, IREE_HAL_ELEMENT_TYPE_INT_32, positions,
-                         seq_bytes, &pos_bv));
+  XLA_CHECK(xla_alloc_bv(c, c->position_mode == 1 ? 2 : 1,
+                         c->position_mode == 1 ? position_shape : seq_shape,
+                         IREE_HAL_ELEMENT_TYPE_INT_32, positions,
+                         position_bytes, &pos_bv));
   XLA_CHECK(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32, &real_len,
                          sizeof(int32_t), &len_bv));
   XLA_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call, tok_bv));
@@ -898,25 +945,31 @@ cleanup:
 }
 
 static int xla_llama_prefill_embeddings_impl(
-    xla_ctx* c, int32_t slot, const xla_tensor_desc* embeddings,
+    xla_ctx* c, int32_t slot, int32_t position_mode,
+    const xla_tensor_desc* embeddings,
     const xla_tensor_desc* dense_ple,
     const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
     int32_t real_len, int32_t vocab, int32_t* out_token, float* out_logits) {
-  if (!c || real_len <= 0 || real_len > c->context_capacity) {
+  if (!c || real_len <= 0 || real_len > c->context_capacity ||
+      position_mode != c->position_mode) {
     fprintf(stderr,
-            "xla_llama_prefill_embeddings: real_len=%d context_capacity=%d\n",
-            real_len, c ? c->context_capacity : 0);
+            "xla_llama_prefill_embeddings: real_len=%d context_capacity=%d mode=%d bundle_mode=%d\n",
+            real_len, c ? c->context_capacity : 0, position_mode,
+            c ? c->position_mode : -1);
     return 1;
   }
   int64_t embeddings_dims[2] = {c->context_capacity, c->hidden_size};
-  int64_t positions_dims[1] = {c->context_capacity};
+  int64_t positions_1d_dims[1] = {c->context_capacity};
+  int64_t positions_mrope_dims[2] = {3, c->context_capacity};
   int64_t bias_dims[2] = {c->context_capacity, c->context_capacity};
   int64_t dense_ple_dims[3] = {
       c->context_capacity, c->dense_ple_layers, c->dense_ple_hidden};
   if (xla_validate_tensor_desc("embeddings", embeddings, 0, 2,
                                embeddings_dims) != 0 ||
-      xla_validate_tensor_desc("positions", positions, 1, 1,
-                               positions_dims) != 0 ||
+      xla_validate_tensor_desc(
+          "positions", positions, 1, position_mode == 1 ? 2 : 1,
+          position_mode == 1 ? positions_mrope_dims : positions_1d_dims) !=
+          0 ||
       xla_validate_tensor_desc("attention_bias", attention_bias, 0, 2,
                                bias_dims) != 0) {
     return 1;
@@ -1031,63 +1084,77 @@ cleanup:
 }
 
 int xla_llama_prefill_embeddings(
-    xla_ctx* c, const xla_tensor_desc* embeddings,
+    xla_ctx* c, int32_t position_mode, const xla_tensor_desc* embeddings,
     const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
     int32_t real_len, int32_t* out_token) {
   return xla_llama_prefill_embeddings_impl(
-      c, -1, embeddings, NULL, positions, attention_bias, real_len, 0, out_token,
-      NULL);
+      c, -1, position_mode, embeddings, NULL, positions, attention_bias,
+      real_len, 0, out_token, NULL);
 }
 
 int xla_llama_prefill_embeddings_slot_logits(
-    xla_ctx* c, int32_t slot, const xla_tensor_desc* embeddings,
+    xla_ctx* c, int32_t slot, int32_t position_mode,
+    const xla_tensor_desc* embeddings,
     const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
     int32_t real_len, int32_t vocab, float* out_logits) {
   return xla_llama_prefill_embeddings_impl(
-      c, slot, embeddings, NULL, positions, attention_bias, real_len, vocab, NULL,
-      out_logits);
+      c, slot, position_mode, embeddings, NULL, positions, attention_bias,
+      real_len, vocab, NULL, out_logits);
 }
 
 int xla_llama_prefill_embeddings_ple(
-    xla_ctx* c, const xla_tensor_desc* embeddings,
+    xla_ctx* c, int32_t position_mode, const xla_tensor_desc* embeddings,
     const xla_tensor_desc* dense_ple, const xla_tensor_desc* positions,
     const xla_tensor_desc* attention_bias, int32_t real_len,
     int32_t* out_token) {
   return xla_llama_prefill_embeddings_impl(
-      c, -1, embeddings, dense_ple, positions, attention_bias, real_len, 0,
-      out_token, NULL);
+      c, -1, position_mode, embeddings, dense_ple, positions, attention_bias,
+      real_len, 0, out_token, NULL);
 }
 
 int xla_llama_prefill_embeddings_ple_slot_logits(
-    xla_ctx* c, int32_t slot, const xla_tensor_desc* embeddings,
+    xla_ctx* c, int32_t slot, int32_t position_mode,
+    const xla_tensor_desc* embeddings,
     const xla_tensor_desc* dense_ple, const xla_tensor_desc* positions,
     const xla_tensor_desc* attention_bias, int32_t real_len, int32_t vocab,
     float* out_logits) {
   return xla_llama_prefill_embeddings_impl(
-      c, slot, embeddings, dense_ple, positions, attention_bias, real_len,
-      vocab, NULL, out_logits);
+      c, slot, position_mode, embeddings, dense_ple, positions, attention_bias,
+      real_len, vocab, NULL, out_logits);
 }
 
 // Ragged decode_step: token[B], pos[B], cache_len[B] (per row), rank-5 KV ->
 // `[B, vocab]` LOGITS (copied to host `out_logits`); advances the resident rank-5
 // KV in place. The caller (engine) samples a token per row. Inactive rows
 // (token/pos/cache_len 0) are masked no-ops whose logits the caller discards.
-int xla_llama_decode_ragged_logits(xla_ctx* c, int32_t bsz, const int32_t* tokens,
-                                   const int32_t* pos, const int32_t* cache_len,
-                                   int32_t vocab, float* out_logits) {
-  if (bsz != c->rg_bsz || !c->kcache_b || !c->vcache_b) {
+static int xla_llama_decode_ragged_impl(
+    xla_ctx* c, int32_t bsz, const int32_t* tokens,
+    const int32_t* positions, int32_t position_mode,
+    const int32_t* cache_len, int32_t vocab, float* out_logits) {
+  if (bsz != c->rg_bsz || !c->kcache_b || !c->vcache_b ||
+      c->position_mode != position_mode) {
     fprintf(stderr,
-            "xla_llama_decode_ragged_logits: bsz=%d configured=%d or KV is uninitialized\n",
-            bsz, c->rg_bsz);
+            "xla_llama_decode_ragged_logits: bsz=%d configured=%d mode=%d bundle_mode=%d or KV is uninitialized\n",
+            bsz, c->rg_bsz, position_mode, c->position_mode);
     return 1;
   }
   for (int32_t i = 0; i < bsz; ++i) {
-    if (pos[i] != cache_len[i] || pos[i] < 0 ||
-        pos[i] >= c->context_capacity) {
+    if (cache_len[i] < 0 || cache_len[i] >= c->context_capacity) {
       fprintf(stderr,
-              "xla_llama_decode_ragged_logits: row=%d pos=%d cache_len=%d context_capacity=%d\n",
-              i, pos[i], cache_len[i], c->context_capacity);
+              "xla_llama_decode_ragged_logits: row=%d cache_len=%d context_capacity=%d\n",
+              i, cache_len[i], c->context_capacity);
       return 1;
+    }
+    int32_t position_count = position_mode == 1 ? 3 : 1;
+    for (int32_t axis = 0; axis < position_count; ++axis) {
+      int32_t coordinate = positions[i * position_count + axis];
+      if (coordinate < 0 ||
+          (position_mode == 0 && coordinate != cache_len[i])) {
+        fprintf(stderr,
+                "xla_llama_decode_ragged_logits: row=%d axis=%d coordinate=%d cache_len=%d\n",
+                i, axis, coordinate, cache_len[i]);
+        return 1;
+      }
     }
   }
   iree_runtime_call_t call;
@@ -1098,14 +1165,19 @@ int xla_llama_decode_ragged_logits(xla_ctx* c, int32_t bsz, const int32_t* token
         iree_runtime_call_inputs_push_back_buffer_view(&call, c->weights[i]));
   }
   iree_hal_dim_t vshape[1] = {(iree_hal_dim_t)bsz};
+  iree_hal_dim_t position_shape[2] = {(iree_hal_dim_t)bsz, 3};
   iree_host_size_t vbytes = (iree_host_size_t)bsz * sizeof(int32_t);
+  iree_host_size_t position_bytes =
+      vbytes * (position_mode == 1 ? 3 : 1);
   iree_hal_buffer_view_t* tok_bv = NULL;
   iree_hal_buffer_view_t* pos_bv = NULL;
   iree_hal_buffer_view_t* len_bv = NULL;
   XLA_CHECK(xla_alloc_bv(c, 1, vshape, IREE_HAL_ELEMENT_TYPE_INT_32, tokens,
                          vbytes, &tok_bv));
-  XLA_CHECK(xla_alloc_bv(c, 1, vshape, IREE_HAL_ELEMENT_TYPE_INT_32, pos, vbytes,
-                         &pos_bv));
+  XLA_CHECK(xla_alloc_bv(c, position_mode == 1 ? 2 : 1,
+                         position_mode == 1 ? position_shape : vshape,
+                         IREE_HAL_ELEMENT_TYPE_INT_32, positions,
+                         position_bytes, &pos_bv));
   XLA_CHECK(xla_alloc_bv(c, 1, vshape, IREE_HAL_ELEMENT_TYPE_INT_32, cache_len,
                          vbytes, &len_bv));
   XLA_CHECK(iree_runtime_call_inputs_push_back_buffer_view(&call, tok_bv));
@@ -1151,6 +1223,23 @@ int xla_llama_decode_ragged_logits(xla_ctx* c, int32_t bsz, const int32_t* token
   iree_hal_buffer_view_release(old_k);
   iree_hal_buffer_view_release(old_v);
   return 0;
+}
+
+int xla_llama_decode_ragged_logits(xla_ctx* c, int32_t bsz,
+                                   const int32_t* tokens,
+                                   const int32_t* positions,
+                                   const int32_t* cache_len, int32_t vocab,
+                                   float* out_logits) {
+  return xla_llama_decode_ragged_impl(c, bsz, tokens, positions, 0, cache_len,
+                                      vocab, out_logits);
+}
+
+int xla_llama_decode_ragged_mrope_logits(
+    xla_ctx* c, int32_t bsz, const int32_t* tokens,
+    const int32_t* positions, const int32_t* cache_len, int32_t vocab,
+    float* out_logits) {
+  return xla_llama_decode_ragged_impl(c, bsz, tokens, positions, 1, cache_len,
+                                      vocab, out_logits);
 }
 
 void xla_llama_free(xla_ctx* c) {

--- a/src/lib/mlxcel-xla/csrc/xla_iree.c
+++ b/src/lib/mlxcel-xla/csrc/xla_iree.c
@@ -896,12 +896,17 @@ int xla_llama_prefill_diagnostics_slot(
         cleanup, rc);
   }
   iree_hal_dim_t seq_shape[1] = {(iree_hal_dim_t)lp};
+  iree_hal_dim_t position_shape[2] = {3, (iree_hal_dim_t)lp};
   iree_host_size_t seq_bytes = (iree_host_size_t)lp * sizeof(int32_t);
+  iree_host_size_t position_bytes =
+      seq_bytes * (c->position_mode == 1 ? 3 : 1);
   XLA_CHECK_GOTO(xla_alloc_bv(c, 1, seq_shape, IREE_HAL_ELEMENT_TYPE_INT_32,
                              tokens, seq_bytes, &tok_bv),
                  cleanup, rc);
-  XLA_CHECK_GOTO(xla_alloc_bv(c, 1, seq_shape, IREE_HAL_ELEMENT_TYPE_INT_32,
-                             positions, seq_bytes, &pos_bv),
+  XLA_CHECK_GOTO(xla_alloc_bv(c, c->position_mode == 1 ? 2 : 1,
+                             c->position_mode == 1 ? position_shape : seq_shape,
+                             IREE_HAL_ELEMENT_TYPE_INT_32, positions,
+                             position_bytes, &pos_bv),
                  cleanup, rc);
   XLA_CHECK_GOTO(xla_alloc_bv(c, 0, NULL, IREE_HAL_ELEMENT_TYPE_INT_32,
                              &real_len, sizeof(int32_t), &len_bv),

--- a/src/lib/mlxcel-xla/src/batch.rs
+++ b/src/lib/mlxcel-xla/src/batch.rs
@@ -53,7 +53,11 @@ use crate::Gemma3nDensePle;
 use crate::Gemma3nPreparedPrefill;
 #[cfg(feature = "iree")]
 use crate::iree::{IreeLlama, IreeRaggedLlama};
-use crate::prepared::{PreparedInputError, PreparedIreePrefill};
+#[cfg(feature = "iree")]
+use crate::prepared::PreparedPositionMode;
+use crate::prepared::{
+    MropeCoordinateError, PreparedInputError, PreparedIreePrefill, mrope_decode_coordinate,
+};
 use crate::sampler::SampleParams;
 #[cfg(feature = "iree")]
 use crate::sampler::sample;
@@ -122,6 +126,8 @@ struct Slot {
     cur: i32,
     /// Tokens currently in this slot's KV (== the next write position).
     cache_len: i32,
+    /// Signed logical RoPE offset retained independently for this slot.
+    rope_delta: i32,
     /// Tokens emitted so far (counts toward `cap`).
     produced: usize,
     /// Token budget (`max_new_tokens`).
@@ -163,6 +169,13 @@ impl PendingInput {
             Self::Tokens(tokens) => tokens.len(),
             Self::Prepared(prepared) => prepared.effective_len,
             Self::Gemma3nPrepared { prepared, .. } => prepared.effective_len,
+        }
+    }
+
+    fn rope_delta(&self) -> i32 {
+        match self {
+            Self::Tokens(_) | Self::Gemma3nPrepared { .. } => 0,
+            Self::Prepared(prepared) => prepared.positions.rope_delta(),
         }
     }
 }
@@ -342,6 +355,19 @@ fn queue_gemma3n_prepared_request(
     ))
 }
 
+fn mrope_slot_coordinates(slots: &[Option<Slot>]) -> Result<Vec<[i32; 3]>, MropeCoordinateError> {
+    slots
+        .iter()
+        .map(|slot| {
+            let Some(slot) = slot else {
+                return Ok([0; 3]);
+            };
+            let coordinate = mrope_decode_coordinate(slot.cache_len, slot.rope_delta)?;
+            Ok([coordinate; 3])
+        })
+        .collect()
+}
+
 /// The continuous-batching engine: `B_max` slots over one ragged decode graph,
 /// fed by a FIFO queue. See the module docs.
 #[cfg(feature = "iree")]
@@ -453,8 +479,12 @@ impl XlaBatchEngine {
         params: SampleParams,
     ) -> Result<u64, XlaAdmissionError> {
         let context_capacity = self.context_capacity();
-        let prepared =
-            PreparedIreePrefill::prepare(&prepared, self.engine.hidden_size(), context_capacity)?;
+        let prepared = PreparedIreePrefill::prepare_for_mode(
+            &prepared,
+            self.engine.hidden_size(),
+            context_capacity,
+            self.engine.position_mode(),
+        )?;
         queue_prepared_request(
             &mut self.sched,
             prepared,
@@ -555,6 +585,7 @@ impl XlaBatchEngine {
                 req_id: p.req_id,
                 cur: first,
                 cache_len: p.input.effective_len() as i32,
+                rope_delta: p.input.rope_delta(),
                 produced: 1,
                 cap: p.cap,
                 params: p.params,
@@ -580,16 +611,24 @@ impl XlaBatchEngine {
         // zeros (masked no-ops) and their logits are discarded.
         let b = self.sched.b_max;
         let mut tok = vec![0i32; b];
-        let mut pos = vec![0i32; b];
         let mut clen = vec![0i32; b];
+        let mut pos = vec![0i32; b];
         for (s, slot) in self.sched.slots.iter().enumerate() {
             if let Some(st) = slot {
                 tok[s] = st.cur;
-                pos[s] = st.cache_len;
                 clen[s] = st.cache_len;
+                pos[s] = st.cache_len;
             }
         }
-        let logits = self.engine.decode_ragged_logits(&tok, &pos, &clen)?;
+        let logits = match self.engine.position_mode() {
+            PreparedPositionMode::OneD => self.engine.decode_ragged_logits(&tok, &pos, &clen)?,
+            PreparedPositionMode::Mrope3D => {
+                let mrope_positions =
+                    mrope_slot_coordinates(&self.sched.slots).map_err(|error| error.to_string())?;
+                self.engine
+                    .decode_ragged_mrope_logits(&tok, &mrope_positions, &clen)?
+            }
+        };
         let vocab = self.engine.vocab();
 
         // ADVANCE + EVICT: sample each active row from its `[vocab]` logit slice.
@@ -1024,6 +1063,7 @@ impl XlaReferenceEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prepared::PreparedIreePositions;
     use mlxcel_core::session::{
         OwnedTensor, PreparedAttentionBias, PreparedModality, PreparedPositions,
         PreparedTensorDType,
@@ -1120,6 +1160,7 @@ mod tests {
             req_id: 41,
             cur: 7,
             cache_len: 300,
+            rope_delta: 0,
             produced: 4,
             cap: 100,
             params: g(),
@@ -1180,6 +1221,77 @@ mod tests {
     }
 
     #[test]
+    fn mixed_text_and_mrope_slots_keep_deltas_independent_through_reuse() {
+        let text = prepared_input(vec![1, 2, 3], 2, 8);
+        assert_eq!(text.positions.rope_delta(), 0);
+        let mut vision = prepared_input(vec![4, 5, 6, 7], 2, 8);
+        vision.positions = PreparedIreePositions::Mrope3D {
+            values: vec![0; 3 * 8],
+            rope_delta: -2,
+        };
+        let mut positive = prepared_input(vec![8, 9], 2, 8);
+        positive.positions = PreparedIreePositions::Mrope3D {
+            values: vec![0; 3 * 8],
+            rope_delta: 5,
+        };
+
+        let mut sched = Scheduler::new(3, EOS.to_vec());
+        let text_id = sched.submit_input(PendingInput::Prepared(text), 8, g());
+        let vision_id = sched.submit_input(PendingInput::Prepared(vision), 8, g());
+        let positive_id = sched.submit_input(PendingInput::Prepared(positive), 8, g());
+        for slot in 0..3 {
+            let pending = sched.pop_next_pending().unwrap();
+            let rope_delta = pending.input.rope_delta();
+            sched.slots[slot] = Some(Slot {
+                req_id: pending.req_id,
+                cur: 1,
+                cache_len: pending.input.effective_len() as i32,
+                rope_delta,
+                produced: 1,
+                cap: pending.cap,
+                params: pending.params,
+                rng: 0,
+                history: Vec::new(),
+            });
+        }
+
+        assert_eq!(
+            mrope_slot_coordinates(&sched.slots).unwrap(),
+            [[3, 3, 3], [2, 2, 2], [7, 7, 7]]
+        );
+        assert!(sched.cancel(vision_id));
+        assert_eq!(
+            mrope_slot_coordinates(&sched.slots).unwrap(),
+            [[3, 3, 3], [0, 0, 0], [7, 7, 7]],
+            "cancelling one row clears only its own delta"
+        );
+
+        let replacement = sched.submit(vec![10, 11], 8, g());
+        let pending = sched.pop_next_pending().unwrap();
+        assert_eq!(pending.req_id, replacement);
+        let free = sched.free_slots();
+        assert_eq!(free, [1]);
+        sched.slots[free[0]] = Some(Slot {
+            req_id: pending.req_id,
+            cur: 1,
+            cache_len: pending.input.effective_len() as i32,
+            rope_delta: pending.input.rope_delta(),
+            produced: 1,
+            cap: pending.cap,
+            params: pending.params,
+            rng: 0,
+            history: Vec::new(),
+        });
+        assert_eq!(
+            mrope_slot_coordinates(&sched.slots).unwrap(),
+            [[3, 3, 3], [2, 2, 2], [7, 7, 7]],
+            "reused text slot starts with delta zero"
+        );
+        assert_eq!(sched.slots[0].as_ref().unwrap().req_id, text_id);
+        assert_eq!(sched.slots[2].as_ref().unwrap().req_id, positive_id);
+    }
+
+    #[test]
     fn cancel_each_input_form_before_and_after_admit_reuses_slots() {
         let mut s = Scheduler::new(1, EOS.to_vec());
         let queued_text = s.submit(vec![1, 2], 8, g());
@@ -1197,6 +1309,7 @@ mod tests {
             req_id: queued_prepared,
             cur: 7,
             cache_len: effective_len as i32,
+            rope_delta: 0,
             produced: 1,
             cap: 8,
             params: g(),
@@ -1248,6 +1361,7 @@ mod tests {
             req_id: p.req_id,
             cur: 5,
             cache_len: 1,
+            rope_delta: 0,
             produced: 1,
             cap: p.cap,
             params: p.params,

--- a/src/lib/mlxcel-xla/src/emitter/builder.rs
+++ b/src/lib/mlxcel-xla/src/emitter/builder.rs
@@ -1053,6 +1053,12 @@ impl Builder {
     pub fn tanh(&mut self, a: &Val) -> Val {
         self.unary("tanh", a)
     }
+    pub fn cosine(&mut self, a: &Val) -> Val {
+        self.unary("cosine", a)
+    }
+    pub fn sine(&mut self, a: &Val) -> Val {
+        self.unary("sine", a)
+    }
 
     /// Error function from the CHLO extension accepted by StableHLO import.
     /// Gemma3n's sparse GELU uses the exact erf form (the ordinary GeGLU path

--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -79,6 +79,24 @@ pub struct QkNorm {
     pub one_plus: bool,
 }
 
+/// How the three temporal/height/width frequency sources are assigned to the
+/// rotary-frequency columns.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MropeLayout {
+    /// Qwen2/Qwen2.5-VL: contiguous temporal, height, and width sections.
+    Chunked,
+    /// Qwen3-VL: the existing MLX step-3 axis-selection layout.
+    Interleaved,
+}
+
+/// Validated multimodal three-axis RoPE configuration.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct MropeConfig {
+    /// Section widths over the half-rotary frequency dimension, ordered T/H/W.
+    pub sections: [usize; 3],
+    pub layout: MropeLayout,
+}
+
 /// The checkpoint tensor-naming scheme (issue #499). Almost every Llama-family
 /// checkpoint uses the standard HF layout
 /// (`model.layers.{i}.self_attn.q_proj.weight`, `model.embed_tokens.weight`,
@@ -227,6 +245,9 @@ pub struct Config {
     /// Per-layer NoPE mask (SmolLM3): `use_rope_layers[li] == false` skips RoPE on
     /// that layer (`no_rope_layers`). `None` applies RoPE on every layer.
     pub use_rope_layers: Option<Vec<bool>>,
+    /// Three-axis multimodal RoPE. `None` preserves the exact one-dimensional
+    /// prefill/decode schemas and emitted modules.
+    pub mrope: Option<MropeConfig>,
     /// Mixture-of-Experts FFN parameters (issues #500 / #501). `Some` for a MoE
     /// architecture (Mixtral, Qwen2-MoE, Qwen3-MoE, OLMoE); the FFN then routes the
     /// top-k of N experts instead of a dense MLP. `None` for a dense model, whose
@@ -341,6 +362,7 @@ impl Config {
             sliding_window: None,
             sliding_pattern: 2,
             use_rope_layers: None,
+            mrope: None,
             moe: None,
             weight_scheme: WeightScheme::Llama,
             layernorm: false,
@@ -877,7 +899,8 @@ impl Config {
         // When present, the supported schemes are llama3 (scaled) and, served as
         // plain RoPE, the `default` (identity) and in-context `dynamic` types;
         // anything else (e.g. yarn, which OLMo3 uses at full size) is a follow-up.
-        let rope = match v.get("rope_scaling") {
+        let rope_scaling = v.get("rope_scaling");
+        let rope = match rope_scaling {
             None | Some(serde_json::Value::Null) => RopeScaling::Plain,
             Some(scaling) => {
                 let rope_type = scaling
@@ -890,7 +913,7 @@ impl Config {
                     // rescales beyond it, so short / in-context generation is served
                     // as plain RoPE here (both use `rope_theta`); the long-context
                     // NTK rescale is a follow-up.
-                    Some("default") | Some("dynamic") => RopeScaling::Plain,
+                    Some("default") | Some("dynamic") | Some("mrope") => RopeScaling::Plain,
                     Some("llama3") => {
                         let sf = |k: &str| -> Result<f64, String> {
                             scaling
@@ -924,6 +947,71 @@ impl Config {
                         ));
                     }
                 }
+            }
+        };
+
+        let mrope = match rope_scaling.and_then(|scaling| scaling.get("mrope_section")) {
+            None => None,
+            Some(section) => {
+                let values = section.as_array().ok_or_else(|| {
+                    "config.json rope_scaling.mrope_section must be an integer array".to_string()
+                })?;
+                if values.len() != 3 {
+                    return Err(format!(
+                        "config.json rope_scaling.mrope_section must contain exactly 3 T/H/W axes, got {}",
+                        values.len()
+                    ));
+                }
+                let mut sections = [0usize; 3];
+                for (axis, value) in values.iter().enumerate() {
+                    let width = value.as_u64().ok_or_else(|| {
+                        format!(
+                            "config.json rope_scaling.mrope_section[{axis}] must be a positive integer"
+                        )
+                    })?;
+                    sections[axis] = usize::try_from(width).map_err(|_| {
+                        format!("config.json rope_scaling.mrope_section[{axis}] does not fit usize")
+                    })?;
+                    if sections[axis] == 0 {
+                        return Err(format!(
+                            "config.json rope_scaling.mrope_section[{axis}] must be positive"
+                        ));
+                    }
+                }
+                let rotary_width = rotary_dim.unwrap_or(head_dim);
+                if rotary_width == 0 || !rotary_width.is_multiple_of(2) {
+                    return Err(format!(
+                        "M-RoPE rotary width {rotary_width} must be a positive even value"
+                    ));
+                }
+                let section_sum = sections.iter().try_fold(0usize, |sum, &width| {
+                    sum.checked_add(width)
+                        .ok_or_else(|| "M-RoPE section sum overflowed".to_string())
+                })?;
+                if section_sum != rotary_width / 2 {
+                    return Err(format!(
+                        "M-RoPE T/H/W sections {sections:?} sum to {section_sum}, expected rotary_width/2 = {}",
+                        rotary_width / 2
+                    ));
+                }
+                let supported_family = matches!(model_type, Some("qwen2") | Some("qwen3"));
+                if !supported_family {
+                    return Err(format!(
+                        "M-RoPE sections are only supported by the Qwen2/Qwen3 language backbone, got model_type={model_type:?}"
+                    ));
+                }
+                let interleaved = rope_scaling
+                    .and_then(|scaling| scaling.get("mrope_interleaved"))
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(model_type == Some("qwen3"));
+                Some(MropeConfig {
+                    sections,
+                    layout: if interleaved {
+                        MropeLayout::Interleaved
+                    } else {
+                        MropeLayout::Chunked
+                    },
+                })
             }
         };
 
@@ -1046,6 +1134,7 @@ impl Config {
             sliding_window,
             sliding_pattern,
             use_rope_layers,
+            mrope,
             moe,
             weight_scheme,
             layernorm,
@@ -1132,6 +1221,12 @@ impl Config {
     /// else the full `head_dim` (Llama family). Always even.
     pub fn rotary_width(&self) -> usize {
         self.rotary_dim.unwrap_or(self.head_dim)
+    }
+
+    /// Whether this runtime uses an explicit T/H/W position schema.
+    #[must_use]
+    pub fn uses_mrope(&self) -> bool {
+        self.mrope.is_some()
     }
 
     /// Gemma input-embedding normalizer `sqrt(hidden)` (computed in f64 then
@@ -1343,5 +1438,51 @@ mod tests {
                 .contains("model_type"),
             "unsupported model_type rejected"
         );
+    }
+
+    #[test]
+    fn parses_and_validates_explicit_mrope_sections() {
+        let base = |model_type: &str, section: &str, extra: &str| {
+            format!(
+                r#"{{"model_type":"{model_type}","hidden_size":12,"intermediate_size":24,
+                "num_hidden_layers":2,"num_attention_heads":2,"num_key_value_heads":1,
+                "head_dim":6,"rms_norm_eps":1e-6,"rope_theta":1e6,"vocab_size":16,
+                "tie_word_embeddings":true,"hidden_act":"silu","rope_scaling":{{
+                "rope_type":"mrope","mrope_section":{section}{extra}}}}}"#
+            )
+        };
+
+        let qwen2 =
+            Config::from_json_str(&base("qwen2", "[1,1,1]", "")).expect("Qwen2 M-RoPE parses");
+        assert_eq!(
+            qwen2.mrope,
+            Some(MropeConfig {
+                sections: [1, 1, 1],
+                layout: MropeLayout::Chunked,
+            })
+        );
+        let qwen3 = Config::from_json_str(&base("qwen3", "[1,1,1]", "")).expect("Qwen3 parses");
+        assert_eq!(
+            qwen3.mrope.unwrap().layout,
+            MropeLayout::Interleaved,
+            "Qwen3 defaults to its interleaved layout"
+        );
+        let forced =
+            Config::from_json_str(&base("qwen3", "[1,1,1]", ",\"mrope_interleaved\":false"))
+                .expect("explicit layout override parses");
+        assert_eq!(forced.mrope.unwrap().layout, MropeLayout::Chunked);
+
+        for (json, needle) in [
+            (base("qwen2", "[1,2]", ""), "exactly 3"),
+            (base("qwen2", "[1,1,0]", ""), "positive"),
+            (base("qwen2", "[1,1,2]", ""), "sum to"),
+            (base("llama", "[1,1,1]", ""), "Qwen2/Qwen3"),
+        ] {
+            let error = Config::from_json_str(&json).expect_err("invalid M-RoPE must fail");
+            assert!(
+                error.contains(needle),
+                "expected {needle:?} in validation error: {error}"
+            );
+        }
     }
 }

--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -907,13 +907,22 @@ impl Config {
                     .get("rope_type")
                     .or_else(|| scaling.get("type"))
                     .and_then(serde_json::Value::as_str);
+                let has_mrope_section = scaling.get("mrope_section").is_some();
+                if rope_type == Some("mrope") && !has_mrope_section {
+                    return Err("config.json rope_scaling.rope_type = \"mrope\" requires \
+                         rope_scaling.mrope_section"
+                        .to_string());
+                }
                 match rope_type {
                     // `default` is HF's identity rope (Seed-OSS). `dynamic` NTK
                     // (InternLM2/3) is identity within the original context and only
                     // rescales beyond it, so short / in-context generation is served
                     // as plain RoPE here (both use `rope_theta`); the long-context
-                    // NTK rescale is a follow-up.
+                    // NTK rescale is a follow-up. Some Qwen/GLM configs omit the
+                    // type while carrying the M-RoPE section table; the table is
+                    // the explicit schema signal in that representation.
                     Some("default") | Some("dynamic") | Some("mrope") => RopeScaling::Plain,
+                    None if has_mrope_section => RopeScaling::Plain,
                     Some("llama3") => {
                         let sf = |k: &str| -> Result<f64, String> {
                             scaling
@@ -1442,13 +1451,19 @@ mod tests {
 
     #[test]
     fn parses_and_validates_explicit_mrope_sections() {
-        let base = |model_type: &str, section: &str, extra: &str| {
+        let config = |model_type: &str, scaling: &str| {
             format!(
                 r#"{{"model_type":"{model_type}","hidden_size":12,"intermediate_size":24,
                 "num_hidden_layers":2,"num_attention_heads":2,"num_key_value_heads":1,
                 "head_dim":6,"rms_norm_eps":1e-6,"rope_theta":1e6,"vocab_size":16,
-                "tie_word_embeddings":true,"hidden_act":"silu","rope_scaling":{{
-                "rope_type":"mrope","mrope_section":{section}{extra}}}}}"#
+                "tie_word_embeddings":true,"hidden_act":"silu",
+                "rope_scaling":{{{scaling}}}}}"#
+            )
+        };
+        let base = |model_type: &str, section: &str, extra: &str| {
+            config(
+                model_type,
+                &format!(r#""rope_type":"mrope","mrope_section":{section}{extra}"#),
             )
         };
 
@@ -1471,6 +1486,31 @@ mod tests {
             Config::from_json_str(&base("qwen3", "[1,1,1]", ",\"mrope_interleaved\":false"))
                 .expect("explicit layout override parses");
         assert_eq!(forced.mrope.unwrap().layout, MropeLayout::Chunked);
+
+        let explicit_without_sections = config("qwen2", r#""rope_type":"mrope""#);
+        let error = Config::from_json_str(&explicit_without_sections)
+            .expect_err("explicit M-RoPE type without sections must fail");
+        assert!(
+            error.contains("requires rope_scaling.mrope_section"),
+            "missing-section error identifies the required schema: {error}"
+        );
+
+        for (model_type, scaling, expected_layout) in [
+            (
+                "qwen2",
+                r#""rope_type":"default","mrope_section":[1,1,1]"#,
+                MropeLayout::Chunked,
+            ),
+            (
+                "qwen3",
+                r#""mrope_section":[1,1,1]"#,
+                MropeLayout::Interleaved,
+            ),
+        ] {
+            let parsed = Config::from_json_str(&config(model_type, scaling))
+                .expect("M-RoPE sections are authoritative when rope type is default or omitted");
+            assert_eq!(parsed.mrope.expect("M-RoPE config").layout, expected_layout);
+        }
 
         for (json, needle) in [
             (base("qwen2", "[1,2]", ""), "exactly 3"),

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -63,7 +63,9 @@ mod rope;
 mod context_tests;
 
 #[allow(unused_imports)]
-pub(crate) use config::{Config, NormStyle, QkNorm, QuantConfig, WeightScheme};
+pub(crate) use config::{
+    Config, MropeConfig, MropeLayout, NormStyle, QkNorm, QuantConfig, WeightScheme,
+};
 #[allow(unused_imports)]
 pub(crate) use gemma3n::{
     Gemma3nConfig, Gemma3nLayerType, Gemma3nPleDType, Gemma3nPleMetadata, validate_gemma3n_ple,
@@ -122,11 +124,11 @@ pub(crate) use builder::{
 };
 #[allow(unused_imports)]
 pub(crate) use model::{
-    PREFILL_EMBEDDINGS_MASKED_VALUE, PrefillEmbeddingsDType, PrefillEmbeddingsInputMetadata,
-    emit_decode, emit_decode_batched, emit_decode_ragged, emit_decode_ragged_with,
-    emit_decode_with, emit_moe_probe, emit_moe_probe_with, emit_prefill, emit_prefill_embeddings,
-    emit_prefill_embeddings_with, emit_prefill_with, validate_prefill_embeddings_attention_bias,
-    validate_prefill_embeddings_metadata,
+    PREFILL_EMBEDDINGS_MASKED_VALUE, PositionInputMode, PrefillEmbeddingsDType,
+    PrefillEmbeddingsInputMetadata, emit_decode, emit_decode_batched, emit_decode_ragged,
+    emit_decode_ragged_with, emit_decode_with, emit_moe_probe, emit_moe_probe_with, emit_prefill,
+    emit_prefill_embeddings, emit_prefill_embeddings_with, emit_prefill_with, mrope_axis_selector,
+    validate_prefill_embeddings_attention_bias, validate_prefill_embeddings_metadata,
 };
 
 #[cfg(test)]
@@ -189,6 +191,20 @@ mod tests {
             // pull them (sliding_pattern, use_rope_layers, weight_scheme, and the
             // dense-arch-pack flags) from the reference Llama config.
             ..Config::llama_3_2_1b()
+        }
+    }
+
+    fn mrope_qwen(layout: MropeLayout) -> Config {
+        Config {
+            context_capacity: 8,
+            hidden: 24,
+            n_q: 2,
+            head_dim: 12,
+            mrope: Some(MropeConfig {
+                sections: [2, 2, 2],
+                layout,
+            }),
+            ..qwen_like(true)
         }
     }
 
@@ -915,7 +931,7 @@ mod tests {
                 ..valid
             },
             PrefillEmbeddingsInputMetadata {
-                positions_shape: [lp - 1],
+                positions_shape: [lp - 1, 0],
                 ..valid
             },
             PrefillEmbeddingsInputMetadata {
@@ -1257,6 +1273,131 @@ mod tests {
             // dense-arch-pack flags all take their Llama defaults.
             ..Config::llama_3_2_1b()
         }
+    }
+
+    #[test]
+    fn mrope_axis_selection_matches_qwen2_and_qwen3_layouts() {
+        let chunked = mrope_axis_selector(&mrope_qwen(MropeLayout::Chunked)).unwrap();
+        assert_eq!(chunked, [0, 0, 1, 1, 2, 2]);
+
+        let interleaved = mrope_axis_selector(&mrope_qwen(MropeLayout::Interleaved)).unwrap();
+        assert_eq!(interleaved, [0, 1, 2, 0, 1, 2]);
+    }
+
+    fn eager_mrope_half_split(
+        input: &[f32],
+        rows: usize,
+        rotary_width: usize,
+        positions: &[[i32; 3]],
+        axes: &[usize],
+        theta: f64,
+    ) -> Vec<f32> {
+        let half = rotary_width / 2;
+        let mut output = vec![0.0; input.len()];
+        for row in 0..rows {
+            for column in 0..half {
+                let inv = 1.0 / theta.powf((2 * column) as f64 / rotary_width as f64);
+                let angle = positions[row][axes[column]] as f64 * inv;
+                let (sin, cos) = angle.sin_cos();
+                let left = input[row * rotary_width + column] as f64;
+                let right = input[row * rotary_width + half + column] as f64;
+                output[row * rotary_width + column] = (left * cos - right * sin) as f32;
+                output[row * rotary_width + half + column] = (right * cos + left * sin) as f32;
+            }
+        }
+        output
+    }
+
+    #[test]
+    fn mrope_qk_rotation_matches_independent_eager_oracle() {
+        let positions = [[3, 5, 7], [11, 13, 17]];
+        let q = (0..24)
+            .map(|index| index as f32 * 0.03125 - 0.4)
+            .collect::<Vec<_>>();
+        let k = (0..24)
+            .map(|index| 0.7 - index as f32 * 0.021)
+            .collect::<Vec<_>>();
+
+        for (layout, oracle_axes) in [
+            (MropeLayout::Chunked, [0, 0, 1, 1, 2, 2]),
+            (MropeLayout::Interleaved, [0, 1, 2, 0, 1, 2]),
+        ] {
+            let cfg = mrope_qwen(layout);
+            let emitted_axes = mrope_axis_selector(&cfg).unwrap();
+            for tensor in [&q, &k] {
+                let actual = eager_mrope_half_split(
+                    tensor,
+                    2,
+                    cfg.rotary_width(),
+                    &positions,
+                    &emitted_axes,
+                    cfg.rope_theta,
+                );
+                let expected = eager_mrope_half_split(
+                    tensor,
+                    2,
+                    cfg.rotary_width(),
+                    &positions,
+                    &oracle_axes,
+                    cfg.rope_theta,
+                );
+                assert!(
+                    actual
+                        .iter()
+                        .zip(expected.iter())
+                        .all(|(left, right)| (left - right).abs() < 1.0e-6),
+                    "{layout:?} transformed Q/K must match the independent eager oracle"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn mrope_graphs_have_explicit_position_shapes_and_dynamic_trig() {
+        let cfg = mrope_qwen(MropeLayout::Chunked);
+        let prefill = emit_prefill(&cfg, false);
+        let embeddings = emit_prefill_embeddings(&cfg, false);
+        let decode = emit_decode(&cfg, false);
+        let ragged = emit_decode_ragged(&cfg, 4, false);
+
+        for graph in [&prefill, &embeddings] {
+            assert!(
+                graph.contains("tensor<3x8xi32>"),
+                "prefill positions must be explicit [3,L]"
+            );
+            assert!(graph.contains("stablehlo.cosine"));
+            assert!(graph.contains("stablehlo.sine"));
+        }
+        assert!(
+            decode.contains("tensor<3xi32>"),
+            "single decode carries one explicit T/H/W coordinate"
+        );
+        assert!(
+            ragged.contains("tensor<4x3xi32>"),
+            "ragged decode carries one T/H/W coordinate per slot"
+        );
+        for graph in [&decode, &ragged] {
+            assert!(graph.contains("stablehlo.cosine"));
+            assert!(graph.contains("stablehlo.sine"));
+        }
+
+        let metadata = PrefillEmbeddingsInputMetadata::canonical(&cfg);
+        assert_eq!(metadata.position_mode, PositionInputMode::Mrope3D);
+        assert_eq!(metadata.positions_shape, [3, 8]);
+        assert_eq!(metadata.positions_rank, 2);
+        validate_prefill_embeddings_metadata(&cfg, &metadata).unwrap();
+        assert!(
+            validate_prefill_embeddings_metadata(
+                &cfg,
+                &PrefillEmbeddingsInputMetadata {
+                    position_mode: PositionInputMode::OneD,
+                    positions_shape: [8, 0],
+                    positions_rank: 1,
+                    ..metadata
+                }
+            )
+            .is_err()
+        );
     }
 
     fn qwen3_like() -> Config {

--- a/src/lib/mlxcel-xla/src/emitter/model.rs
+++ b/src/lib/mlxcel-xla/src/emitter/model.rs
@@ -20,7 +20,7 @@
 //! is byte-identical to before.
 
 use super::builder::{Builder, Precision, Ty, Val, precision_from_env, quant_in_graph};
-use super::config::{Config, NormStyle};
+use super::config::{Config, MropeLayout, NormStyle};
 use super::moe::{self, MoeLayerW, MoeSharedW};
 use super::rope;
 
@@ -43,18 +43,27 @@ pub(crate) enum PrefillEmbeddingsDType {
     Bf16,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PositionInputMode {
+    OneD,
+    Mrope3D,
+}
+
 /// Shape/dtype metadata validated before compiling or invoking
 /// `prefill_embeddings.main`.
 ///
 /// Argument order after the model weights is stable and deliberately documented
-/// here: `embeddings`, `positions`, `real_len`, `attention_bias`. Positions remain
-/// one-dimensional in this entry; a later M-RoPE entry can add a distinct position
-/// representation without overloading this contract.
+/// here: `embeddings`, `positions`, `real_len`, `attention_bias`. The explicit
+/// `position_mode` fixes positions as either `[L]` or M-RoPE `[3,L]`; rank is
+/// never inferred from the payload after the runtime boundary.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct PrefillEmbeddingsInputMetadata {
     pub embeddings_shape: [usize; 2],
     pub embeddings_dtype: PrefillEmbeddingsDType,
-    pub positions_shape: [usize; 1],
+    pub position_mode: PositionInputMode,
+    /// The first `positions_rank` dimensions are significant.
+    pub positions_shape: [usize; 2],
+    pub positions_rank: usize,
     pub attention_bias_shape: [usize; 2],
     pub attention_bias_dtype: PrefillEmbeddingsDType,
     pub real_len: usize,
@@ -67,7 +76,13 @@ impl PrefillEmbeddingsInputMetadata {
         Self {
             embeddings_shape: [lp, c.hidden],
             embeddings_dtype: PrefillEmbeddingsDType::F32,
-            positions_shape: [lp],
+            position_mode: if c.uses_mrope() {
+                PositionInputMode::Mrope3D
+            } else {
+                PositionInputMode::OneD
+            },
+            positions_shape: if c.uses_mrope() { [3, lp] } else { [lp, 0] },
+            positions_rank: if c.uses_mrope() { 2 } else { 1 },
             attention_bias_shape: [lp, lp],
             attention_bias_dtype: PrefillEmbeddingsDType::F32,
             real_len: lp,
@@ -100,10 +115,25 @@ pub(crate) fn validate_prefill_embeddings_metadata(
             metadata.embeddings_dtype
         ));
     }
-    if metadata.positions_shape != [lp] {
+    let expected_position_mode = if c.uses_mrope() {
+        PositionInputMode::Mrope3D
+    } else {
+        PositionInputMode::OneD
+    };
+    let expected_positions_shape = if c.uses_mrope() { [3, lp] } else { [lp, 0] };
+    let expected_positions_rank = if c.uses_mrope() { 2 } else { 1 };
+    if metadata.position_mode != expected_position_mode
+        || metadata.positions_shape != expected_positions_shape
+        || metadata.positions_rank != expected_positions_rank
+    {
         return Err(format!(
-            "prefill positions shape {:?} does not match required [{}]",
-            metadata.positions_shape, lp
+            "prefill position mode/shape {:?} {:?} rank {} does not match required {:?} {:?} rank {}",
+            metadata.position_mode,
+            metadata.positions_shape,
+            metadata.positions_rank,
+            expected_position_mode,
+            expected_positions_shape,
+            expected_positions_rank,
         ));
     }
     if metadata.attention_bias_shape != [lp, lp] {
@@ -597,7 +627,12 @@ fn build_arg_schema(b: &mut Builder, c: &Config) -> (Vec<ArgDecl>, Args) {
     }
 
     let token = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "token".into());
-    let pos = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "pos".into());
+    let pos = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::new(if c.uses_mrope() { vec![3] } else { vec![] }, "i32"),
+        "pos".into(),
+    );
     let cache_len = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "cache_len".into());
     let kcache = take_arg(
         &mut decls,
@@ -1816,20 +1851,32 @@ pub fn emit_decode_with(c: &Config, sample: bool, precision: Precision) -> Strin
     let emb = b.reshape(&emb_row, vec![h]);
     let mut x = scale_embedding(&mut b, c, emb, vec![h]);
 
-    let cos_row = b.dynamic_slice(&k.cos_table, &[&a.pos, &k.c0], vec![1, rot]);
-    let cos_vec = b.reshape(&cos_row, vec![rot]);
-    let sin_row = b.dynamic_slice(&k.sin_table, &[&a.pos, &k.c0], vec![1, rot]);
-    let sin_vec = b.reshape(&sin_row, vec![rot]);
-    // Dual-RoPE (Gemma3 / OLMo3): the local-base [rot] vectors for the sliding layers.
-    let (cos_local, sin_local) = match (&k.cos_local, &k.sin_local) {
-        (Some(ct), Some(st)) => {
-            let cr = b.dynamic_slice(ct, &[&a.pos, &k.c0], vec![1, rot]);
-            let cl = b.reshape(&cr, vec![rot]);
-            let sr = b.dynamic_slice(st, &[&a.pos, &k.c0], vec![1, rot]);
-            let sl = b.reshape(&sr, vec![rot]);
-            (Some(cl), Some(sl))
-        }
-        _ => (None, None),
+    let (cos_vec, sin_vec, cos_local, sin_local) = if c.uses_mrope() {
+        let positions = b.reshape(&a.pos, vec![3, 1]);
+        let (cos, sin) = mrope_cos_sin(&mut b, c, &positions, 1);
+        (
+            b.reshape(&cos, vec![rot]),
+            b.reshape(&sin, vec![rot]),
+            None,
+            None,
+        )
+    } else {
+        let cos_row = b.dynamic_slice(&k.cos_table, &[&a.pos, &k.c0], vec![1, rot]);
+        let cos_vec = b.reshape(&cos_row, vec![rot]);
+        let sin_row = b.dynamic_slice(&k.sin_table, &[&a.pos, &k.c0], vec![1, rot]);
+        let sin_vec = b.reshape(&sin_row, vec![rot]);
+        // Dual-RoPE (Gemma3 / OLMo3): the local-base [rot] vectors for the sliding layers.
+        let (cos_local, sin_local) = match (&k.cos_local, &k.sin_local) {
+            (Some(ct), Some(st)) => {
+                let cr = b.dynamic_slice(ct, &[&a.pos, &k.c0], vec![1, rot]);
+                let cl = b.reshape(&cr, vec![rot]);
+                let sr = b.dynamic_slice(st, &[&a.pos, &k.c0], vec![1, rot]);
+                let sl = b.reshape(&sr, vec![rot]);
+                (Some(cl), Some(sl))
+            }
+            _ => (None, None),
+        };
+        (cos_vec, sin_vec, cos_local, sin_local)
     };
 
     // mask: keys s valid iff s <= cache_len -> additive 0 / -1e30, shape [S]
@@ -1967,7 +2014,12 @@ fn build_batched_arg_schema(
         Ty::new(vec![bsz], "i32"),
         "token".into(),
     );
-    let pos = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "pos".into());
+    let pos = take_arg(
+        &mut decls,
+        &mut idx,
+        Ty::new(if c.uses_mrope() { vec![3] } else { vec![] }, "i32"),
+        "pos".into(),
+    );
     let cache_len = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "cache_len".into());
     let kcache = take_arg(
         &mut decls,
@@ -2063,10 +2115,17 @@ pub fn emit_decode_batched_with(
     let mut x = b.gather(&a.embed, &tok_idx); // [B, H]
 
     // pos is shared (lockstep), so cos/sin are one [d] vector for every row.
-    let cos_row = b.dynamic_slice(&k.cos_table, &[&a.pos, &k.c0], vec![1, d]);
-    let cos_vec = b.reshape(&cos_row, vec![d]);
-    let sin_row = b.dynamic_slice(&k.sin_table, &[&a.pos, &k.c0], vec![1, d]);
-    let sin_vec = b.reshape(&sin_row, vec![d]);
+    let (cos_vec, sin_vec) = if c.uses_mrope() {
+        let positions = b.reshape(&a.pos, vec![3, 1]);
+        let (cos, sin) = mrope_cos_sin(&mut b, c, &positions, 1);
+        (b.reshape(&cos, vec![d]), b.reshape(&sin, vec![d]))
+    } else {
+        let cos_row = b.dynamic_slice(&k.cos_table, &[&a.pos, &k.c0], vec![1, d]);
+        let cos_vec = b.reshape(&cos_row, vec![d]);
+        let sin_row = b.dynamic_slice(&k.sin_table, &[&a.pos, &k.c0], vec![1, d]);
+        let sin_vec = b.reshape(&sin_row, vec![d]);
+        (cos_vec, sin_vec)
+    };
 
     // shared key mask [S]: key s valid iff s <= cache_len -> additive 0 / -1e30
     let ii = b.iota(seq);
@@ -2302,7 +2361,14 @@ fn build_ragged_arg_schema(b: &mut Builder, c: &Config, bsz: usize) -> (Vec<ArgD
     let pos = take_arg(
         &mut decls,
         &mut idx,
-        Ty::new(vec![bsz], "i32"),
+        Ty::new(
+            if c.uses_mrope() {
+                vec![bsz, 3]
+            } else {
+                vec![bsz]
+            },
+            "i32",
+        ),
         "pos".into(),
     );
     let cache_len = take_arg(
@@ -2381,13 +2447,20 @@ pub fn emit_decode_ragged_with(
     let mut x = scale_embedding(&mut b, c, emb, vec![bsz, h]);
 
     // each row's rope vectors come from its own position: gather [B,d] by pos[B]
-    let pos_idx = b.reshape(&a.pos, vec![bsz, 1]);
-    let cos = b.gather(&k.cos_table, &pos_idx); // [B, d]
-    let sin = b.gather(&k.sin_table, &pos_idx); // [B, d]
-    // Dual-RoPE (Gemma3 / OLMo3): per-row local-base gathers for the sliding layers.
-    let (cos_local, sin_local) = match (&k.cos_local, &k.sin_local) {
-        (Some(ct), Some(st)) => (Some(b.gather(ct, &pos_idx)), Some(b.gather(st, &pos_idx))),
-        _ => (None, None),
+    let (cos, sin, cos_local, sin_local) = if c.uses_mrope() {
+        let positions = b.transpose(&a.pos, &[1, 0]);
+        let (cos, sin) = mrope_cos_sin(&mut b, c, &positions, bsz);
+        (cos, sin, None, None)
+    } else {
+        let pos_idx = b.reshape(&a.pos, vec![bsz, 1]);
+        let cos = b.gather(&k.cos_table, &pos_idx); // [B, d]
+        let sin = b.gather(&k.sin_table, &pos_idx); // [B, d]
+        // Dual-RoPE (Gemma3 / OLMo3): per-row local-base gathers for the sliding layers.
+        let (cos_local, sin_local) = match (&k.cos_local, &k.sin_local) {
+            (Some(ct), Some(st)) => (Some(b.gather(ct, &pos_idx)), Some(b.gather(st, &pos_idx))),
+            _ => (None, None),
+        };
+        (cos, sin, cos_local, sin_local)
     };
 
     // per-row key mask [B,S]: key s valid for row b iff s <= cache_len[b]
@@ -2418,7 +2491,14 @@ pub fn emit_decode_ragged_with(
         sin_local,
         mask: kmask,
         mask_local: kmask_local,
-        pos: a.pos.clone(),
+        // M-RoPE KV writes are indexed by physical cache length while the
+        // distinct position input may include a signed per-slot delta. Preserve
+        // the byte-exact legacy 1D graph, whose ABI validates pos == cache_len.
+        pos: if c.uses_mrope() {
+            a.cache_len.clone()
+        } else {
+            a.pos.clone()
+        },
         row_idx,
     };
 
@@ -2565,7 +2645,14 @@ fn build_prefill_arg_schema(
     let positions = take_arg(
         &mut decls,
         &mut idx,
-        Ty::new(vec![lp], "i32"),
+        Ty::new(
+            if c.uses_mrope() {
+                vec![3, lp]
+            } else {
+                vec![lp]
+            },
+            "i32",
+        ),
         "positions".into(),
     );
     let real_len = take_arg(&mut decls, &mut idx, Ty::scalar("i32"), "real_len".into());
@@ -2636,6 +2723,87 @@ fn apply_rope_seq(
     let x_pass = b.slice(x, &[(0, n), (0, heads), (rd, d)]);
     let rotated = rotate_seq(b, c, &x_rot, cos, sin, n, heads, rd);
     b.concatenate(&rotated, &x_pass, 2)
+}
+
+/// The MLX Qwen axis source for each half-rotary frequency column.
+pub(crate) fn mrope_axis_selector(c: &Config) -> Result<Vec<usize>, String> {
+    let mrope = c
+        .mrope
+        .as_ref()
+        .ok_or_else(|| "M-RoPE axis selection requires an M-RoPE config".to_string())?;
+    let half = c.rotary_width() / 2;
+    let selector = match mrope.layout {
+        MropeLayout::Chunked => {
+            let mut selector = Vec::with_capacity(half);
+            for (axis, &width) in mrope.sections.iter().enumerate() {
+                selector.extend(std::iter::repeat_n(axis, width));
+            }
+            selector
+        }
+        MropeLayout::Interleaved => {
+            // Match `InterleavedMRoPE::apply_interleaved_mrope` in the MLX Qwen3
+            // implementation: temporal is the default, and H/W overwrite the
+            // step-3 columns within their configured windows.
+            let mut selector = vec![0usize; half];
+            for (offset, &section_len) in mrope.sections[1..].iter().enumerate() {
+                let axis = offset + 1;
+                let mut index = axis;
+                while index < section_len * 3 {
+                    if index < selector.len() {
+                        selector[index] = axis;
+                    }
+                    index += 3;
+                }
+            }
+            selector
+        }
+    };
+    if selector.len() != half {
+        return Err(format!(
+            "M-RoPE axis selector has {} columns, expected {half}",
+            selector.len()
+        ));
+    }
+    Ok(selector)
+}
+
+/// Build dynamic M-RoPE cos/sin values for explicit signed coordinates.
+///
+/// `positions` is `[3, N]` ordered temporal/height/width. Unlike the ordinary
+/// one-dimensional path, this intentionally computes trig in the graph instead
+/// of indexing a context-sized table: decode coordinates are physical KV length
+/// plus a signed per-sequence delta and therefore are not bounded by the KV
+/// table's index range.
+fn mrope_cos_sin(b: &mut Builder, c: &Config, positions: &Val, n: usize) -> (Val, Val) {
+    assert_eq!(positions.ty.elt, "i32");
+    assert_eq!(positions.ty.shape, vec![3, n]);
+    let selector =
+        mrope_axis_selector(c).unwrap_or_else(|error| panic!("invalid M-RoPE config: {error}"));
+    let axes: Vec<Val> = (0..3)
+        .map(|axis| {
+            let row = b.slice(positions, &[(axis, axis + 1), (0, n)]);
+            b.reshape(&row, vec![n])
+        })
+        .collect();
+    let columns: Vec<Val> = selector
+        .into_iter()
+        .map(|axis| b.broadcast(&axes[axis], &[0], vec![n, 1]))
+        .collect();
+    let mut columns = columns.into_iter();
+    let mut selected = columns.next().expect("positive M-RoPE rotary width");
+    for column in columns {
+        selected = b.concatenate(&selected, &column, 1);
+    }
+    let selected = b.convert(&selected, "f32");
+    let inv = rope::inv_freq(c)
+        .into_iter()
+        .map(|value| value as f32)
+        .collect::<Vec<_>>();
+    let inv = b.const_tensor_f32(&inv, vec![c.rotary_width() / 2]);
+    let inv = b.broadcast(&inv, &[1], vec![n, c.rotary_width() / 2]);
+    let freqs = b.multiply(&selected, &inv);
+    let angles = b.concatenate(&freqs, &freqs, 1);
+    (b.cosine(&angles), b.sine(&angles))
 }
 
 /// The core RoPE rotation on x:[N, heads, rd] with per-row cos/sin [N, rd].
@@ -2728,13 +2896,19 @@ fn emit_prefill_module(
     };
 
     // --- shared position preparation ---
-    let pos_idx = b.reshape(&a.positions, vec![lp, 1]);
-    let cos = b.gather(&k.cos_table, &pos_idx); // [Lp, d]
-    let sin = b.gather(&k.sin_table, &pos_idx); // [Lp, d]
-    // Dual-RoPE (Gemma3 / OLMo3): per-position local-base gathers for sliding layers.
-    let (cos_local, sin_local) = match (&k.cos_local, &k.sin_local) {
-        (Some(ct), Some(st)) => (Some(b.gather(ct, &pos_idx)), Some(b.gather(st, &pos_idx))),
-        _ => (None, None),
+    let (cos, sin, cos_local, sin_local) = if c.uses_mrope() {
+        let (cos, sin) = mrope_cos_sin(&mut b, c, &a.positions, lp);
+        (cos, sin, None, None)
+    } else {
+        let pos_idx = b.reshape(&a.positions, vec![lp, 1]);
+        let cos = b.gather(&k.cos_table, &pos_idx); // [Lp, d]
+        let sin = b.gather(&k.sin_table, &pos_idx); // [Lp, d]
+        // Dual-RoPE (Gemma3 / OLMo3): per-position local-base gathers for sliding layers.
+        let (cos_local, sin_local) = match (&k.cos_local, &k.sin_local) {
+            (Some(ct), Some(st)) => (Some(b.gather(ct, &pos_idx)), Some(b.gather(st, &pos_idx))),
+            _ => (None, None),
+        };
+        (cos, sin, cos_local, sin_local)
     };
 
     // --- attention-bias preparation ---

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -71,7 +71,8 @@ use crate::emitter::{
     emit_gemma3n_prefill_diagnostics_with_qmv,
 };
 use crate::prepared::{
-    PreparedIreePrefill, PreparedPositionMode, mrope_decode_coordinate, validate_slot,
+    PreparedIreePrefill, PreparedPositionMode, canonical_text_positions, mrope_decode_coordinate,
+    validate_slot,
 };
 use crate::{Gemma3nDensePle, Gemma3nPreparedPrefill};
 // The loader reads the per-architecture checkpoint-weight order from
@@ -1655,17 +1656,8 @@ impl IreeLlama {
         tokens[..prompt.len()].copy_from_slice(prompt);
         let capacity = checked_ffi_int(self.context_capacity, "context_capacity")?;
         let real_len = checked_ffi_int(prompt.len(), "prompt length")?;
-        let one_axis: Vec<c_int> = (0..capacity).collect();
-        let positions = match self.position_mode {
-            PreparedPositionMode::OneD => one_axis,
-            PreparedPositionMode::Mrope3D => {
-                let mut values = Vec::with_capacity(self.context_capacity * 3);
-                values.extend_from_slice(&one_axis);
-                values.extend_from_slice(&one_axis);
-                values.extend_from_slice(&one_axis);
-                values
-            }
-        };
+        let positions = canonical_text_positions(self.position_mode, self.context_capacity)
+            .map_err(|error| format!("cannot build text-only prefill positions: {error}"))?;
         let mut out = 0i32;
         // Safety: buffers outlive the call; the shim stores the returned KV.
         let rc = unsafe {
@@ -1946,17 +1938,8 @@ impl IreeRaggedLlama {
         let slot = checked_ffi_int(slot, "slot")?;
         let capacity = checked_ffi_int(self.context_capacity, "context_capacity")?;
         let real_len = checked_ffi_int(prompt.len(), "prompt length")?;
-        let one_axis: Vec<c_int> = (0..capacity).collect();
-        let positions = match self.position_mode {
-            PreparedPositionMode::OneD => one_axis,
-            PreparedPositionMode::Mrope3D => {
-                let mut values = Vec::with_capacity(self.context_capacity * 3);
-                values.extend_from_slice(&one_axis);
-                values.extend_from_slice(&one_axis);
-                values.extend_from_slice(&one_axis);
-                values
-            }
-        };
+        let positions = canonical_text_positions(self.position_mode, self.context_capacity)
+            .map_err(|error| format!("cannot build text-only diagnostic positions: {error}"))?;
         let diagnostic_len = c_int::try_from(layout.total_len)
             .map_err(|_| "diagnostic output length does not fit c_int".to_string())?;
         let mut output = vec![0.0f32; layout.total_len];
@@ -2005,7 +1988,8 @@ impl IreeRaggedLlama {
         let capacity = checked_ffi_int(self.context_capacity, "context_capacity")?;
         let real_len = checked_ffi_int(prompt.len(), "prompt length")?;
         let vocab = checked_ffi_int(self.vocab, "vocab_size")?;
-        let positions: Vec<c_int> = (0..capacity).collect();
+        let positions = canonical_text_positions(self.position_mode, self.context_capacity)
+            .map_err(|error| format!("cannot build text-only slot positions: {error}"))?;
         let mut logits = vec![0f32; self.vocab];
         // Safety: input buffers outlive the call; `logits` has self.vocab elements,
         // which the shim fills; the shim also writes the slot's KV device-side.

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -70,7 +70,9 @@ use crate::emitter::{
     Gemma3nDiagnosticLayout, emit_gemma3n_all_layer_diagnostics_with_qmv,
     emit_gemma3n_prefill_diagnostics_with_qmv,
 };
-use crate::prepared::{PreparedIreePrefill, validate_slot};
+use crate::prepared::{
+    PreparedIreePrefill, PreparedPositionMode, mrope_decode_coordinate, validate_slot,
+};
 use crate::{Gemma3nDensePle, Gemma3nPreparedPrefill};
 // The loader reads the per-architecture checkpoint-weight order from
 // `weights::weight_specs`, which sources its names from `weight_names::scheme_names`
@@ -212,6 +214,7 @@ unsafe extern "C" {
         weight_dims: *const i64,
         context_capacity: c_int,
         hidden_size: c_int,
+        position_mode: c_int,
         prefill_embeddings_kind: c_int,
         dense_ple_layers: c_int,
         dense_ple_hidden: c_int,
@@ -228,6 +231,13 @@ unsafe extern "C" {
         c: *mut XlaCtx,
         token: c_int,
         pos: c_int,
+        cache_len: c_int,
+        out_token: *mut c_int,
+    ) -> c_int;
+    fn xla_llama_decode_mrope(
+        c: *mut XlaCtx,
+        token: c_int,
+        positions: *const c_int,
         cache_len: c_int,
         out_token: *mut c_int,
     ) -> c_int;
@@ -259,6 +269,7 @@ unsafe extern "C" {
     ) -> c_int;
     fn xla_llama_prefill_embeddings(
         c: *mut XlaCtx,
+        position_mode: c_int,
         embeddings: *const XlaTensorDesc,
         positions: *const XlaTensorDesc,
         attention_bias: *const XlaTensorDesc,
@@ -268,6 +279,7 @@ unsafe extern "C" {
     fn xla_llama_prefill_embeddings_slot_logits(
         c: *mut XlaCtx,
         slot: c_int,
+        position_mode: c_int,
         embeddings: *const XlaTensorDesc,
         positions: *const XlaTensorDesc,
         attention_bias: *const XlaTensorDesc,
@@ -277,6 +289,7 @@ unsafe extern "C" {
     ) -> c_int;
     fn xla_llama_prefill_embeddings_ple(
         c: *mut XlaCtx,
+        position_mode: c_int,
         embeddings: *const XlaTensorDesc,
         dense_ple: *const XlaTensorDesc,
         positions: *const XlaTensorDesc,
@@ -287,6 +300,7 @@ unsafe extern "C" {
     fn xla_llama_prefill_embeddings_ple_slot_logits(
         c: *mut XlaCtx,
         slot: c_int,
+        position_mode: c_int,
         embeddings: *const XlaTensorDesc,
         dense_ple: *const XlaTensorDesc,
         positions: *const XlaTensorDesc,
@@ -300,6 +314,15 @@ unsafe extern "C" {
         bsz: c_int,
         tokens: *const c_int,
         pos: *const c_int,
+        cache_len: *const c_int,
+        vocab: c_int,
+        out_logits: *mut f32,
+    ) -> c_int;
+    fn xla_llama_decode_ragged_mrope_logits(
+        c: *mut XlaCtx,
+        bsz: c_int,
+        tokens: *const c_int,
+        positions: *const c_int,
         cache_len: *const c_int,
         vocab: c_int,
         out_logits: *mut f32,
@@ -431,6 +454,13 @@ impl RuntimeConfig {
         match self {
             Self::Dense(_) => None,
             Self::Gemma3n(config) => Some(config.dense_ple_shape()),
+        }
+    }
+
+    fn position_mode(&self) -> PreparedPositionMode {
+        match self {
+            Self::Dense(config) if config.uses_mrope() => PreparedPositionMode::Mrope3D,
+            Self::Dense(_) | Self::Gemma3n(_) => PreparedPositionMode::OneD,
         }
     }
 }
@@ -729,7 +759,7 @@ fn compile_bundle(
         cfg.context_capacity(),
     )?;
     let mut fingerprint = std::collections::hash_map::DefaultHasher::new();
-    "mlxcel-xla-runtime-bundle-v1".hash(&mut fingerprint);
+    "mlxcel-xla-runtime-bundle-v2-explicit-position-mode".hash(&mut fingerprint);
     cfg.artifact_identity().hash(&mut fingerprint);
     format!("{:?}", cfg.weight_specs()).hash(&mut fingerprint);
     format!("{:?}", effective_precision(device, cfg)?).hash(&mut fingerprint);
@@ -1373,7 +1403,14 @@ fn prepared_descriptors(
         &prepared.embeddings,
         &[prepared.context_capacity, prepared.hidden_size],
     )?;
-    let positions = XlaTensorDesc::i32(&prepared.positions, &[prepared.context_capacity])?;
+    let positions = match prepared.positions.mode() {
+        PreparedPositionMode::OneD => {
+            XlaTensorDesc::i32(prepared.positions.values(), &[prepared.context_capacity])?
+        }
+        PreparedPositionMode::Mrope3D => {
+            XlaTensorDesc::i32(prepared.positions.values(), &[3, prepared.context_capacity])?
+        }
+    };
     let attention_bias = XlaTensorDesc::f32(
         &prepared.attention_bias,
         &[prepared.context_capacity, prepared.context_capacity],
@@ -1438,6 +1475,7 @@ fn create_ctx_with_diagnostics(
             dims.as_ptr(),
             ffi.context_capacity,
             ffi.hidden,
+            cfg.position_mode().ffi_code(),
             i32::from(cfg.dense_ple_shape().is_some()),
             ffi.dense_ple_layers,
             ffi.dense_ple_hidden,
@@ -1462,6 +1500,8 @@ pub struct IreeLlama {
     context_capacity: usize,
     hidden_size: usize,
     dense_ple_shape: Option<[usize; 3]>,
+    position_mode: PreparedPositionMode,
+    rope_delta: i32,
 }
 
 impl IreeLlama {
@@ -1478,6 +1518,8 @@ impl IreeLlama {
             context_capacity: cfg.context_capacity(),
             hidden_size: cfg.hidden(),
             dense_ple_shape: cfg.dense_ple_shape(),
+            position_mode: cfg.position_mode(),
+            rope_delta: 0,
         })
     }
 
@@ -1517,9 +1559,14 @@ impl IreeLlama {
                 "Gemma3n requires the distinct embeddings-plus-dense-PLE prefill entry".to_string(),
             );
         }
-        let prepared =
-            PreparedIreePrefill::prepare(prepared, self.hidden_size, self.context_capacity)
-                .map_err(|error| error.to_string())?;
+        let prepared = PreparedIreePrefill::prepare_for_mode(
+            prepared,
+            self.hidden_size,
+            self.context_capacity,
+            self.position_mode,
+        )
+        .map_err(|error| error.to_string())?;
+        let rope_delta = prepared.positions.rope_delta();
         let (embeddings, positions, attention_bias) = prepared_descriptors(&prepared)?;
         let real_len = i32::try_from(prepared.effective_len)
             .map_err(|_| "prepared effective length does not fit i32".to_string())?;
@@ -1529,6 +1576,7 @@ impl IreeLlama {
         let rc = unsafe {
             xla_llama_prefill_embeddings(
                 self.ctx,
+                prepared.positions.mode().ffi_code(),
                 &embeddings,
                 &positions,
                 &attention_bias,
@@ -1539,6 +1587,7 @@ impl IreeLlama {
         if rc != 0 {
             return Err(format!("xla_llama_prefill_embeddings failed (status {rc})"));
         }
+        self.rope_delta = rope_delta;
         Ok(out)
     }
 
@@ -1573,6 +1622,7 @@ impl IreeLlama {
         let rc = unsafe {
             xla_llama_prefill_embeddings_ple(
                 self.ctx,
+                prepared.positions.mode().ffi_code(),
                 &embeddings,
                 &dense_ple,
                 &positions,
@@ -1586,6 +1636,7 @@ impl IreeLlama {
                 "xla_llama_prefill_embeddings_ple failed (status {rc})"
             ));
         }
+        self.rope_delta = 0;
         Ok(out)
     }
 
@@ -1604,7 +1655,17 @@ impl IreeLlama {
         tokens[..prompt.len()].copy_from_slice(prompt);
         let capacity = checked_ffi_int(self.context_capacity, "context_capacity")?;
         let real_len = checked_ffi_int(prompt.len(), "prompt length")?;
-        let positions: Vec<c_int> = (0..capacity).collect();
+        let one_axis: Vec<c_int> = (0..capacity).collect();
+        let positions = match self.position_mode {
+            PreparedPositionMode::OneD => one_axis,
+            PreparedPositionMode::Mrope3D => {
+                let mut values = Vec::with_capacity(self.context_capacity * 3);
+                values.extend_from_slice(&one_axis);
+                values.extend_from_slice(&one_axis);
+                values.extend_from_slice(&one_axis);
+                values
+            }
+        };
         let mut out = 0i32;
         // Safety: buffers outlive the call; the shim stores the returned KV.
         let rc = unsafe {
@@ -1620,6 +1681,7 @@ impl IreeLlama {
         if rc != 0 {
             return Err(format!("xla_llama_prefill failed (status {rc})"));
         }
+        self.rope_delta = 0;
         Ok(out)
     }
 
@@ -1633,8 +1695,21 @@ impl IreeLlama {
             ));
         }
         let mut out = 0i32;
-        // Safety: the shim threads its own resident KV; only scalars cross here.
-        let rc = unsafe { xla_llama_decode(self.ctx, token, cache_len, cache_len, &mut out) };
+        let rc = match self.position_mode {
+            PreparedPositionMode::OneD => {
+                // Safety: the shim threads its own resident KV; only scalars cross here.
+                unsafe { xla_llama_decode(self.ctx, token, cache_len, cache_len, &mut out) }
+            }
+            PreparedPositionMode::Mrope3D => {
+                let coordinate = mrope_decode_coordinate(cache_len, self.rope_delta)
+                    .map_err(|error| error.to_string())?;
+                let positions = [coordinate; 3];
+                // Safety: positions is exactly the explicit rank-1 `[3]` ABI payload.
+                unsafe {
+                    xla_llama_decode_mrope(self.ctx, token, positions.as_ptr(), cache_len, &mut out)
+                }
+            }
+        };
         if rc != 0 {
             return Err(format!("xla_llama_decode failed (status {rc})"));
         }
@@ -1671,6 +1746,7 @@ pub struct IreeRaggedLlama {
     context_capacity: usize,
     hidden_size: usize,
     dense_ple_shape: Option<[usize; 3]>,
+    position_mode: PreparedPositionMode,
     #[cfg(feature = "diagnostics")]
     diagnostic_layout: Option<Gemma3nDiagnosticLayout>,
 }
@@ -1794,6 +1870,7 @@ impl IreeRaggedLlama {
             context_capacity: cfg.context_capacity(),
             hidden_size: cfg.hidden(),
             dense_ple_shape: cfg.dense_ple_shape(),
+            position_mode: cfg.position_mode(),
             #[cfg(feature = "diagnostics")]
             diagnostic_layout,
         })
@@ -1822,6 +1899,10 @@ impl IreeRaggedLlama {
     #[must_use]
     pub fn hidden_size(&self) -> usize {
         self.hidden_size
+    }
+
+    pub(crate) const fn position_mode(&self) -> PreparedPositionMode {
+        self.position_mode
     }
 
     pub fn validate_gemma3n_dense_ple(&self, dense_ple: &Gemma3nDensePle) -> Result<(), String> {
@@ -1865,7 +1946,17 @@ impl IreeRaggedLlama {
         let slot = checked_ffi_int(slot, "slot")?;
         let capacity = checked_ffi_int(self.context_capacity, "context_capacity")?;
         let real_len = checked_ffi_int(prompt.len(), "prompt length")?;
-        let positions: Vec<c_int> = (0..capacity).collect();
+        let one_axis: Vec<c_int> = (0..capacity).collect();
+        let positions = match self.position_mode {
+            PreparedPositionMode::OneD => one_axis,
+            PreparedPositionMode::Mrope3D => {
+                let mut values = Vec::with_capacity(self.context_capacity * 3);
+                values.extend_from_slice(&one_axis);
+                values.extend_from_slice(&one_axis);
+                values.extend_from_slice(&one_axis);
+                values
+            }
+        };
         let diagnostic_len = c_int::try_from(layout.total_len)
             .map_err(|_| "diagnostic output length does not fit c_int".to_string())?;
         let mut output = vec![0.0f32; layout.total_len];
@@ -1956,6 +2047,7 @@ impl IreeRaggedLlama {
             || prepared.context_capacity != self.context_capacity
             || prepared.effective_len == 0
             || prepared.effective_len > self.context_capacity
+            || prepared.positions.mode() != self.position_mode
         {
             return Err(
                 "prepared IREE payload is incompatible with this runtime bundle".to_string(),
@@ -1973,6 +2065,7 @@ impl IreeRaggedLlama {
             xla_llama_prefill_embeddings_slot_logits(
                 self.ctx,
                 slot,
+                prepared.positions.mode().ffi_code(),
                 &embeddings,
                 &positions,
                 &attention_bias,
@@ -2023,6 +2116,7 @@ impl IreeRaggedLlama {
             xla_llama_prefill_embeddings_ple_slot_logits(
                 self.ctx,
                 slot,
+                prepared.positions.mode().ffi_code(),
                 &embeddings,
                 &dense_ple,
                 &positions,
@@ -2050,6 +2144,9 @@ impl IreeRaggedLlama {
         pos: &[i32],
         cache_len: &[i32],
     ) -> Result<Vec<f32>, String> {
+        if self.position_mode != PreparedPositionMode::OneD {
+            return Err("1D decode was requested from an M-RoPE runtime bundle".to_string());
+        }
         if tokens.len() != self.b_max || pos.len() != self.b_max || cache_len.len() != self.b_max {
             return Err(format!(
                 "decode_ragged_logits expects per-row arrays of length b_max = {}",
@@ -2086,6 +2183,67 @@ impl IreeRaggedLlama {
         if rc != 0 {
             return Err(format!(
                 "xla_llama_decode_ragged_logits failed (status {rc})"
+            ));
+        }
+        Ok(logits)
+    }
+
+    /// Advance an M-RoPE batch with explicit temporal/height/width coordinates
+    /// per row while retaining physical KV writes at `cache_len`.
+    pub fn decode_ragged_mrope_logits(
+        &mut self,
+        tokens: &[i32],
+        positions: &[[i32; 3]],
+        cache_len: &[i32],
+    ) -> Result<Vec<f32>, String> {
+        if self.position_mode != PreparedPositionMode::Mrope3D {
+            return Err("M-RoPE decode was requested from a 1D runtime bundle".to_string());
+        }
+        if tokens.len() != self.b_max
+            || positions.len() != self.b_max
+            || cache_len.len() != self.b_max
+        {
+            return Err(format!(
+                "decode_ragged_mrope_logits expects per-row arrays of length b_max = {}",
+                self.b_max
+            ));
+        }
+        for (row, (&physical, coordinates)) in cache_len.iter().zip(positions.iter()).enumerate() {
+            if physical < 0 || physical as usize >= self.context_capacity {
+                return Err(format!(
+                    "decode row {row} has cache_len={physical} outside context_capacity={}",
+                    self.context_capacity
+                ));
+            }
+            if coordinates.iter().any(|&coordinate| coordinate < 0) {
+                return Err(format!(
+                    "decode row {row} has negative M-RoPE coordinates {coordinates:?}"
+                ));
+            }
+        }
+        let flat_positions: Vec<i32> = positions
+            .iter()
+            .flat_map(|coordinates| coordinates.iter().copied())
+            .collect();
+        let mut logits = vec![0f32; self.b_max * self.vocab];
+        let b_max = checked_ffi_int(self.b_max, "b_max")?;
+        let vocab = checked_ffi_int(self.vocab, "vocab_size")?;
+        // Safety: all per-row inputs have b_max rows, each position row has
+        // exactly three coordinates, and logits has b_max*vocab elements.
+        let rc = unsafe {
+            xla_llama_decode_ragged_mrope_logits(
+                self.ctx,
+                b_max,
+                tokens.as_ptr(),
+                flat_positions.as_ptr(),
+                cache_len.as_ptr(),
+                vocab,
+                logits.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            return Err(format!(
+                "xla_llama_decode_ragged_mrope_logits failed (status {rc})"
             ));
         }
         Ok(logits)

--- a/src/lib/mlxcel-xla/src/prepared.rs
+++ b/src/lib/mlxcel-xla/src/prepared.rs
@@ -20,12 +20,68 @@ use mlxcel_core::session::{OwnedTensor, PreparedPositions, PreparedPrefill, Prep
 
 const MASKED_VALUE: f32 = -1.0e30;
 
+/// Position schema compiled into an IREE language-model bundle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreparedPositionMode {
+    OneD,
+    Mrope3D,
+}
+
+impl PreparedPositionMode {
+    pub(crate) const fn name(self) -> &'static str {
+        match self {
+            Self::OneD => "1D",
+            Self::Mrope3D => "M-RoPE 3D",
+        }
+    }
+
+    pub(crate) const fn ffi_code(self) -> i32 {
+        match self {
+            Self::OneD => 0,
+            Self::Mrope3D => 1,
+        }
+    }
+}
+
+/// Static-bucket positions retained with their explicit semantic mode.
+#[derive(Debug)]
+pub(crate) enum PreparedIreePositions {
+    OneD(Vec<i32>),
+    Mrope3D {
+        /// Row-major `[3, context_capacity]`, ordered temporal/height/width.
+        values: Vec<i32>,
+        rope_delta: i32,
+    },
+}
+
+impl PreparedIreePositions {
+    pub(crate) const fn mode(&self) -> PreparedPositionMode {
+        match self {
+            Self::OneD(_) => PreparedPositionMode::OneD,
+            Self::Mrope3D { .. } => PreparedPositionMode::Mrope3D,
+        }
+    }
+
+    pub(crate) fn values(&self) -> &[i32] {
+        match self {
+            Self::OneD(values) | Self::Mrope3D { values, .. } => values,
+        }
+    }
+
+    pub(crate) const fn rope_delta(&self) -> i32 {
+        match self {
+            Self::OneD(_) => 0,
+            Self::Mrope3D { rope_delta, .. } => *rope_delta,
+        }
+    }
+}
+
 /// A validated prepared prefill in the exact static shapes consumed by IREE.
 #[derive(Debug)]
 pub(crate) struct PreparedIreePrefill {
     pub(crate) token_ids: Vec<i32>,
     pub(crate) embeddings: Vec<f32>,
-    pub(crate) positions: Vec<i32>,
+    pub(crate) positions: PreparedIreePositions,
     pub(crate) attention_bias: Vec<f32>,
     pub(crate) effective_len: usize,
     pub(crate) hidden_size: usize,
@@ -58,7 +114,19 @@ pub enum PreparedInputError {
         expected: usize,
     },
     PositionDType(PreparedTensorDType),
-    PositionShape(Vec<usize>),
+    PositionShape {
+        shape: Vec<usize>,
+        expected: Vec<usize>,
+    },
+    PositionModeMismatch {
+        expected: PreparedPositionMode,
+        actual: PreparedPositionMode,
+    },
+    NegativePosition {
+        axis: usize,
+        index: usize,
+        value: i32,
+    },
     UnsupportedPositions,
     AttentionBiasDType(PreparedTensorDType),
     AttentionBiasShape(Vec<usize>),
@@ -107,9 +175,23 @@ impl fmt::Display for PreparedInputError {
             Self::PositionDType(dtype) => {
                 write!(f, "IREE prepared positions must be Int32, got {dtype:?}")
             }
-            Self::PositionShape(shape) => write!(
+            Self::PositionShape { shape, expected } => write!(
                 f,
-                "prepared explicit positions shape {shape:?} must be [sequence] or [1, sequence]"
+                "prepared explicit positions shape {shape:?} must be {expected:?}"
+            ),
+            Self::PositionModeMismatch { expected, actual } => write!(
+                f,
+                "prepared position mode {} disagrees with loaded model mode {}",
+                actual.name(),
+                expected.name()
+            ),
+            Self::NegativePosition {
+                axis,
+                index,
+                value,
+            } => write!(
+                f,
+                "prepared M-RoPE position axis {axis} index {index} is negative ({value})"
             ),
             Self::UnsupportedPositions => f.write_str(
                 "IREE prepared positions must be the dense zero-based sequence; M-RoPE/offset positions are not supported",
@@ -138,6 +220,54 @@ impl fmt::Display for PreparedInputError {
 }
 
 impl std::error::Error for PreparedInputError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MropeCoordinateError {
+    Overflow { cache_len: i32, rope_delta: i32 },
+    Negative { cache_len: i32, rope_delta: i32 },
+}
+
+impl fmt::Display for MropeCoordinateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Overflow {
+                cache_len,
+                rope_delta,
+            } => write!(
+                f,
+                "M-RoPE decode coordinate overflow: cache_len={cache_len}, rope_delta={rope_delta}"
+            ),
+            Self::Negative {
+                cache_len,
+                rope_delta,
+            } => write!(
+                f,
+                "M-RoPE decode coordinate is negative: cache_len={cache_len}, rope_delta={rope_delta}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MropeCoordinateError {}
+
+pub(crate) fn mrope_decode_coordinate(
+    cache_len: i32,
+    rope_delta: i32,
+) -> Result<i32, MropeCoordinateError> {
+    let coordinate = cache_len
+        .checked_add(rope_delta)
+        .ok_or(MropeCoordinateError::Overflow {
+            cache_len,
+            rope_delta,
+        })?;
+    if coordinate < 0 {
+        return Err(MropeCoordinateError::Negative {
+            cache_len,
+            rope_delta,
+        });
+    }
+    Ok(coordinate)
+}
 
 pub(crate) fn validate_slot(slot: usize, slot_count: usize) -> Result<(), PreparedInputError> {
     if slot >= slot_count {
@@ -190,6 +320,20 @@ impl PreparedIreePrefill {
         hidden_size: usize,
         context_capacity: usize,
     ) -> Result<Self, PreparedInputError> {
+        Self::prepare_for_mode(
+            value,
+            hidden_size,
+            context_capacity,
+            PreparedPositionMode::OneD,
+        )
+    }
+
+    pub(crate) fn prepare_for_mode(
+        value: &PreparedPrefill,
+        hidden_size: usize,
+        context_capacity: usize,
+        expected_mode: PreparedPositionMode,
+    ) -> Result<Self, PreparedInputError> {
         let effective_len = value.sequence_len;
         if effective_len == 0 {
             return Err(PreparedInputError::Empty);
@@ -239,34 +383,111 @@ impl PreparedIreePrefill {
         let mut embeddings = vec![0.0; embedding_count];
         embeddings[..input_embeddings.len()].copy_from_slice(&input_embeddings);
 
-        let mut positions: Vec<i32> = (0..context_capacity)
+        let sequential: Vec<i32> = (0..context_capacity)
             .map(|position| i32::try_from(position).map_err(|_| PreparedInputError::ShapeOverflow))
             .collect::<Result<_, _>>()?;
-        match &value.positions {
-            PreparedPositions::Sequential { start, length } => {
+        let validate_1d = |tensor: &OwnedTensor| -> Result<Vec<i32>, PreparedInputError> {
+            if tensor.dtype != PreparedTensorDType::Int32 {
+                return Err(PreparedInputError::PositionDType(tensor.dtype));
+            }
+            if tensor.shape != [effective_len] && tensor.shape != [1, effective_len] {
+                return Err(PreparedInputError::PositionShape {
+                    shape: tensor.shape.clone(),
+                    expected: vec![effective_len],
+                });
+            }
+            let explicit = read_i32("positions", tensor)?;
+            if explicit
+                .iter()
+                .enumerate()
+                .any(|(index, &position)| position != index as i32)
+            {
+                return Err(PreparedInputError::UnsupportedPositions);
+            }
+            Ok(explicit)
+        };
+        let positions = match (expected_mode, &value.positions) {
+            (PreparedPositionMode::OneD, PreparedPositions::Sequential { start, length }) => {
                 if *start != 0 || *length != effective_len {
                     return Err(PreparedInputError::UnsupportedPositions);
                 }
+                PreparedIreePositions::OneD(sequential)
             }
-            PreparedPositions::Explicit(tensor) => {
+            (PreparedPositionMode::OneD, PreparedPositions::Explicit(tensor)) => {
+                let explicit = validate_1d(tensor)?;
+                let mut positions = sequential;
+                positions[..effective_len].copy_from_slice(&explicit);
+                PreparedIreePositions::OneD(positions)
+            }
+            (PreparedPositionMode::OneD, PreparedPositions::Mrope3D { .. }) => {
+                return Err(PreparedInputError::PositionModeMismatch {
+                    expected: PreparedPositionMode::OneD,
+                    actual: PreparedPositionMode::Mrope3D,
+                });
+            }
+            (PreparedPositionMode::Mrope3D, PreparedPositions::Sequential { start, length }) => {
+                if *start != 0 || *length != effective_len {
+                    return Err(PreparedInputError::UnsupportedPositions);
+                }
+                let mut values = Vec::with_capacity(3 * context_capacity);
+                for _ in 0..3 {
+                    values.extend_from_slice(&sequential);
+                }
+                PreparedIreePositions::Mrope3D {
+                    values,
+                    rope_delta: 0,
+                }
+            }
+            (PreparedPositionMode::Mrope3D, PreparedPositions::Explicit(tensor)) => {
+                let explicit = validate_1d(tensor)?;
+                let mut values = Vec::with_capacity(3 * context_capacity);
+                for _ in 0..3 {
+                    let mut axis = sequential.clone();
+                    axis[..effective_len].copy_from_slice(&explicit);
+                    values.extend(axis);
+                }
+                PreparedIreePositions::Mrope3D {
+                    values,
+                    rope_delta: 0,
+                }
+            }
+            (PreparedPositionMode::Mrope3D, PreparedPositions::Mrope3D { tensor, rope_delta }) => {
                 if tensor.dtype != PreparedTensorDType::Int32 {
                     return Err(PreparedInputError::PositionDType(tensor.dtype));
                 }
-                if tensor.shape != [effective_len] && tensor.shape != [1, effective_len] {
-                    return Err(PreparedInputError::PositionShape(tensor.shape.clone()));
+                if tensor.shape != [3, effective_len] {
+                    return Err(PreparedInputError::PositionShape {
+                        shape: tensor.shape.clone(),
+                        expected: vec![3, effective_len],
+                    });
                 }
                 let explicit = read_i32("positions", tensor)?;
-                if explicit
+                if let Some((flat_index, &position)) = explicit
                     .iter()
                     .enumerate()
-                    .any(|(index, &position)| position != index as i32)
+                    .find(|(_, position)| **position < 0)
                 {
-                    return Err(PreparedInputError::UnsupportedPositions);
+                    return Err(PreparedInputError::NegativePosition {
+                        axis: flat_index / effective_len,
+                        index: flat_index % effective_len,
+                        value: position,
+                    });
                 }
-                positions[..effective_len].copy_from_slice(&explicit);
+                let mut values = Vec::with_capacity(3 * context_capacity);
+                for axis in 0..3 {
+                    let mut padded = sequential.clone();
+                    let start = axis * effective_len;
+                    padded[..effective_len]
+                        .copy_from_slice(&explicit[start..start + effective_len]);
+                    values.extend(padded);
+                }
+                PreparedIreePositions::Mrope3D {
+                    values,
+                    rope_delta: *rope_delta,
+                }
             }
             _ => return Err(PreparedInputError::UnsupportedPositions),
-        }
+        };
 
         let bias_tensor = &value.attention_bias.tensor;
         if bias_tensor.dtype != PreparedTensorDType::Float32 {
@@ -356,6 +577,35 @@ mod tests {
         .unwrap()
     }
 
+    fn mrope_fixture(axes: [&[i32]; 3], rope_delta: i32) -> PreparedPrefill {
+        let sequence_len = axes[0].len();
+        assert!(axes.iter().all(|axis| axis.len() == sequence_len));
+        let coordinates = axes
+            .into_iter()
+            .flat_map(|axis| axis.iter().copied())
+            .flat_map(i32::to_le_bytes)
+            .collect();
+        PreparedPrefill::new(
+            vec![1; sequence_len],
+            tensor_f32(&[1, sequence_len, 2], vec![0.25; sequence_len * 2]),
+            PreparedPositions::Mrope3D {
+                tensor: OwnedTensor::new(
+                    coordinates,
+                    PreparedTensorDType::Int32,
+                    vec![3, sequence_len],
+                )
+                .unwrap(),
+                rope_delta,
+            },
+            PreparedAttentionBias {
+                tensor: tensor_f32(&[1, 1, 1, sequence_len], vec![0.0; sequence_len]),
+                causal: true,
+            },
+            Vec::new(),
+        )
+        .unwrap()
+    }
+
     #[test]
     fn materializes_static_shapes_and_causal_bias() {
         let prepared = PreparedIreePrefill::prepare(&fixture(), 2, 5).unwrap();
@@ -363,7 +613,10 @@ mod tests {
         assert_eq!(prepared.token_ids, [11, 22, 33]);
         assert_eq!(prepared.embeddings.len(), 10);
         assert_eq!(&prepared.embeddings[..6], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-        assert_eq!(&prepared.positions, &[0, 1, 2, 3, 4]);
+        assert!(matches!(
+            prepared.positions,
+            PreparedIreePositions::OneD(ref values) if values == &[0, 1, 2, 3, 4]
+        ));
         assert_eq!(prepared.attention_bias[0], 0.0);
         assert_eq!(prepared.attention_bias[1], MASKED_VALUE);
         assert_eq!(prepared.attention_bias[2 * 5 + 2], 0.0);
@@ -464,5 +717,147 @@ mod tests {
             PreparedIreePrefill::prepare(&value, 2, 5),
             Err(PreparedInputError::InvalidFloat { .. })
         ));
+    }
+
+    #[test]
+    fn canonicalizes_mrope_axes_and_preserves_signed_delta() {
+        let mut value = fixture();
+        value.positions = PreparedPositions::Mrope3D {
+            tensor: OwnedTensor::new(
+                [0i32, 1, 2, 0, 4, 5, 0, 6, 7]
+                    .into_iter()
+                    .flat_map(i32::to_le_bytes)
+                    .collect(),
+                PreparedTensorDType::Int32,
+                vec![3, 3],
+            )
+            .unwrap(),
+            rope_delta: -4,
+        };
+
+        let prepared =
+            PreparedIreePrefill::prepare_for_mode(&value, 2, 5, PreparedPositionMode::Mrope3D)
+                .unwrap();
+        assert_eq!(prepared.positions.rope_delta(), -4);
+        assert_eq!(
+            prepared.positions.values(),
+            &[0, 1, 2, 3, 4, 0, 4, 5, 3, 4, 0, 6, 7, 3, 4]
+        );
+    }
+
+    #[test]
+    fn rejects_mrope_payload_for_one_dimensional_bundle() {
+        let mut value = fixture();
+        value.positions = PreparedPositions::Mrope3D {
+            tensor: OwnedTensor::new(vec![0; 3 * 3 * 4], PreparedTensorDType::Int32, vec![3, 3])
+                .unwrap(),
+            rope_delta: 0,
+        };
+        assert!(matches!(
+            PreparedIreePrefill::prepare(&value, 2, 5),
+            Err(PreparedInputError::PositionModeMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn ports_qwen_text_image_multi_image_video_and_padding_coordinates() {
+        // These row-major fixtures are the direct outputs of the existing MLX
+        // Qwen `compute_rope_index` walk for merge=1. Padding fixtures pin the
+        // explicit prepared-input convention supported by this backend seam.
+        let fixtures: Vec<(&str, [&[i32]; 3], i32)> = vec![
+            (
+                "text-only",
+                [&[0, 1, 2, 3, 4], &[0, 1, 2, 3, 4], &[0, 1, 2, 3, 4]],
+                0,
+            ),
+            (
+                "one-image-1x2x2",
+                [
+                    &[0, 1, 2, 2, 2, 2, 4],
+                    &[0, 1, 2, 2, 3, 3, 4],
+                    &[0, 1, 2, 3, 2, 3, 4],
+                ],
+                -2,
+            ),
+            (
+                "multiple-images",
+                [
+                    &[0, 1, 1, 3, 4, 4, 6],
+                    &[0, 1, 1, 3, 4, 5, 6],
+                    &[0, 1, 2, 3, 4, 4, 6],
+                ],
+                0,
+            ),
+            (
+                "video-2x1x2",
+                [
+                    &[0, 1, 1, 2, 2, 3],
+                    &[0, 1, 1, 1, 1, 3],
+                    &[0, 1, 2, 1, 2, 3],
+                ],
+                -2,
+            ),
+            (
+                "left-padding",
+                [&[0, 0, 0, 1, 2], &[0, 0, 0, 1, 2], &[0, 0, 0, 1, 2]],
+                -2,
+            ),
+            (
+                "right-padding",
+                [&[0, 1, 2, 0, 0], &[0, 1, 2, 0, 0], &[0, 1, 2, 0, 0]],
+                -2,
+            ),
+        ];
+
+        for (name, axes, delta) in fixtures {
+            let sequence_len = axes[0].len();
+            let prepared = PreparedIreePrefill::prepare_for_mode(
+                &mrope_fixture(axes, delta),
+                2,
+                sequence_len + 2,
+                PreparedPositionMode::Mrope3D,
+            )
+            .unwrap_or_else(|error| panic!("{name}: {error}"));
+            assert_eq!(prepared.positions.rope_delta(), delta, "{name}");
+            for (axis, expected) in axes.iter().enumerate() {
+                let start = axis * (sequence_len + 2);
+                assert_eq!(
+                    &prepared.positions.values()[start..start + sequence_len],
+                    *expected,
+                    "{name} axis {axis}"
+                );
+            }
+        }
+
+        let long = (0..2048).collect::<Vec<i32>>();
+        let prepared = PreparedIreePrefill::prepare_for_mode(
+            &mrope_fixture([&long, &long, &long], 17),
+            2,
+            2050,
+            PreparedPositionMode::Mrope3D,
+        )
+        .expect("long M-RoPE fixture");
+        assert_eq!(&prepared.positions.values()[..2048], long);
+        assert_eq!(prepared.positions.rope_delta(), 17);
+    }
+
+    #[test]
+    fn decode_coordinate_supports_signed_deltas_and_typed_failures() {
+        assert_eq!(mrope_decode_coordinate(12, -5), Ok(7));
+        assert_eq!(mrope_decode_coordinate(12, 5), Ok(17));
+        assert_eq!(
+            mrope_decode_coordinate(2, -3),
+            Err(MropeCoordinateError::Negative {
+                cache_len: 2,
+                rope_delta: -3,
+            })
+        );
+        assert_eq!(
+            mrope_decode_coordinate(i32::MAX, 1),
+            Err(MropeCoordinateError::Overflow {
+                cache_len: i32::MAX,
+                rope_delta: 1,
+            })
+        );
     }
 }

--- a/src/lib/mlxcel-xla/src/prepared.rs
+++ b/src/lib/mlxcel-xla/src/prepared.rs
@@ -250,6 +250,37 @@ impl fmt::Display for MropeCoordinateError {
 
 impl std::error::Error for MropeCoordinateError {}
 
+/// Build the static position buffer for text-only input.
+///
+/// Accepting backend-neutral sequential or explicit 1D positions in an
+/// M-RoPE bundle is intentional: text tokens use the same logical coordinate
+/// on the temporal, height, and width axes. The resulting row-major buffer is
+/// therefore `[axis0, axis1, axis2]`, with each axis containing the same
+/// zero-based sequence. Multimodal callers must instead provide
+/// [`PreparedPositions::Mrope3D`] so their axes and signed decode delta remain
+/// explicit.
+pub(crate) fn canonical_text_positions(
+    mode: PreparedPositionMode,
+    context_capacity: usize,
+) -> Result<Vec<i32>, PreparedInputError> {
+    let one_axis: Vec<i32> = (0..context_capacity)
+        .map(|position| i32::try_from(position).map_err(|_| PreparedInputError::ShapeOverflow))
+        .collect::<Result<_, _>>()?;
+    match mode {
+        PreparedPositionMode::OneD => Ok(one_axis),
+        PreparedPositionMode::Mrope3D => {
+            let capacity = context_capacity
+                .checked_mul(3)
+                .ok_or(PreparedInputError::ShapeOverflow)?;
+            let mut values = Vec::with_capacity(capacity);
+            for _ in 0..3 {
+                values.extend_from_slice(&one_axis);
+            }
+            Ok(values)
+        }
+    }
+}
+
 pub(crate) fn mrope_decode_coordinate(
     cache_len: i32,
     rope_delta: i32,
@@ -383,9 +414,7 @@ impl PreparedIreePrefill {
         let mut embeddings = vec![0.0; embedding_count];
         embeddings[..input_embeddings.len()].copy_from_slice(&input_embeddings);
 
-        let sequential: Vec<i32> = (0..context_capacity)
-            .map(|position| i32::try_from(position).map_err(|_| PreparedInputError::ShapeOverflow))
-            .collect::<Result<_, _>>()?;
+        let sequential = canonical_text_positions(PreparedPositionMode::OneD, context_capacity)?;
         let validate_1d = |tensor: &OwnedTensor| -> Result<Vec<i32>, PreparedInputError> {
             if tensor.dtype != PreparedTensorDType::Int32 {
                 return Err(PreparedInputError::PositionDType(tensor.dtype));
@@ -429,22 +458,20 @@ impl PreparedIreePrefill {
                 if *start != 0 || *length != effective_len {
                     return Err(PreparedInputError::UnsupportedPositions);
                 }
-                let mut values = Vec::with_capacity(3 * context_capacity);
-                for _ in 0..3 {
-                    values.extend_from_slice(&sequential);
-                }
                 PreparedIreePositions::Mrope3D {
-                    values,
+                    values: canonical_text_positions(
+                        PreparedPositionMode::Mrope3D,
+                        context_capacity,
+                    )?,
                     rope_delta: 0,
                 }
             }
             (PreparedPositionMode::Mrope3D, PreparedPositions::Explicit(tensor)) => {
                 let explicit = validate_1d(tensor)?;
-                let mut values = Vec::with_capacity(3 * context_capacity);
-                for _ in 0..3 {
-                    let mut axis = sequential.clone();
+                let mut values =
+                    canonical_text_positions(PreparedPositionMode::Mrope3D, context_capacity)?;
+                for axis in values.chunks_exact_mut(context_capacity) {
                     axis[..effective_len].copy_from_slice(&explicit);
-                    values.extend(axis);
                 }
                 PreparedIreePositions::Mrope3D {
                     values,
@@ -743,6 +770,44 @@ mod tests {
             prepared.positions.values(),
             &[0, 1, 2, 3, 4, 0, 4, 5, 3, 4, 0, 6, 7, 3, 4]
         );
+    }
+
+    #[test]
+    fn intentionally_canonicalizes_text_only_positions_for_mrope_bundles() {
+        let expected = [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4];
+        assert_eq!(
+            canonical_text_positions(PreparedPositionMode::Mrope3D, 5).unwrap(),
+            expected
+        );
+
+        let sequential =
+            PreparedIreePrefill::prepare_for_mode(&fixture(), 2, 5, PreparedPositionMode::Mrope3D)
+                .expect("text-only sequential positions in an M-RoPE bundle");
+        assert_eq!(sequential.positions.mode(), PreparedPositionMode::Mrope3D);
+        assert_eq!(sequential.positions.values(), expected);
+        assert_eq!(sequential.positions.rope_delta(), 0);
+
+        let mut explicit_value = fixture();
+        explicit_value.positions = PreparedPositions::Explicit(
+            OwnedTensor::new(
+                [0i32, 1, 2]
+                    .into_iter()
+                    .flat_map(i32::to_le_bytes)
+                    .collect(),
+                PreparedTensorDType::Int32,
+                vec![1, 3],
+            )
+            .unwrap(),
+        );
+        let explicit = PreparedIreePrefill::prepare_for_mode(
+            &explicit_value,
+            2,
+            5,
+            PreparedPositionMode::Mrope3D,
+        )
+        .expect("text-only explicit positions in an M-RoPE bundle");
+        assert_eq!(explicit.positions.values(), expected);
+        assert_eq!(explicit.positions.rope_delta(), 0);
     }
 
     #[test]

--- a/tests/xla_prepared_prefill.rs
+++ b/tests/xla_prepared_prefill.rs
@@ -292,6 +292,30 @@ fn mrope_prepared(
     .expect("valid M-RoPE prepared input")
 }
 
+fn mrope_text_prepared(fixture: &TinyModel, tokens: &[i32]) -> PreparedPrefill {
+    let values = tokens
+        .iter()
+        .flat_map(|&token| {
+            let row = token as usize * MROPE_HIDDEN;
+            fixture.embeddings[row..row + MROPE_HIDDEN].iter().copied()
+        })
+        .collect::<Vec<_>>();
+    PreparedPrefill::new(
+        tokens.to_vec(),
+        tensor_f32(&[1, tokens.len(), MROPE_HIDDEN], &values),
+        PreparedPositions::Sequential {
+            start: 0,
+            length: tokens.len(),
+        },
+        PreparedAttentionBias {
+            tensor: tensor_f32(&[1, 1, 1, tokens.len()], &vec![0.0; tokens.len()]),
+            causal: true,
+        },
+        Vec::new(),
+    )
+    .expect("valid text-only prepared input for an M-RoPE bundle")
+}
+
 #[test]
 #[ignore = "requires the pinned IREE runtime and compiler"]
 fn local_task_token_and_prepared_paths_are_exact_with_mixed_slot_reuse() {
@@ -373,6 +397,23 @@ fn local_task_mrope_prefill_decode_and_per_slot_deltas_execute() {
         2,
     );
 
+    let mut single_text =
+        XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
+            .expect("M-RoPE single text session");
+    let single_text_tokens = single_text
+        .generate_greedy(&tokens, 3, &[])
+        .expect("real-IREE M-RoPE text token prefill/decode");
+    let mut single_prepared_text =
+        XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
+            .expect("M-RoPE single prepared-text session");
+    let prepared_text_tokens = single_prepared_text
+        .generate_prepared_greedy(&mrope_text_prepared(&fixture, &tokens), 3, &[])
+        .expect("real-IREE M-RoPE sequential prepared prefill/decode");
+    assert_eq!(
+        prepared_text_tokens, single_text_tokens,
+        "text-only sequential positions must canonicalize to three identical M-RoPE axes"
+    );
+
     let mut single = XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
         .expect("M-RoPE single session");
     let single_tokens = single
@@ -407,7 +448,10 @@ fn local_task_mrope_prefill_decode_and_per_slot_deltas_execute() {
             }
         }
     }
-    assert_eq!(text_tokens.len(), 3);
+    assert_eq!(
+        text_tokens, single_text_tokens,
+        "ragged text token prefill must upload the exact [3, capacity] position buffer"
+    );
     assert_eq!(
         vision_tokens, single_tokens,
         "single and ragged logits must select the same M-RoPE tokens"
@@ -416,14 +460,25 @@ fn local_task_mrope_prefill_decode_and_per_slot_deltas_execute() {
     let reused = batch
         .submit_prepared(positive, 2, SampleParams::greedy())
         .expect("positive delta enters a released slot");
+    let reused_text = batch
+        .submit(&tokens, 3, SampleParams::greedy())
+        .expect("text token request reuses a released M-RoPE slot");
     let mut reused_tokens = 0;
+    let mut reused_text_tokens = Vec::new();
     while !batch.is_idle() {
-        reused_tokens += batch
-            .pump()
-            .expect("reused positive-delta slot")
-            .iter()
-            .filter(|event| matches!(event, EngineEvent::Token { req_id, .. } if *req_id == reused))
-            .count();
+        for event in batch.pump().expect("mixed reused M-RoPE slots") {
+            if let EngineEvent::Token { req_id, token } = event {
+                if req_id == reused {
+                    reused_tokens += 1;
+                } else if req_id == reused_text {
+                    reused_text_tokens.push(token);
+                }
+            }
+        }
     }
     assert_eq!(reused_tokens, 2);
+    assert_eq!(
+        reused_text_tokens, single_text_tokens,
+        "reused text slot must retain zero delta and canonical three-axis positions"
+    );
 }

--- a/tests/xla_prepared_prefill.rs
+++ b/tests/xla_prepared_prefill.rs
@@ -30,6 +30,7 @@ use tempfile::TempDir;
 const CAPACITY: usize = 8;
 const HIDDEN: usize = 8;
 const VOCAB: usize = 32;
+const MROPE_HIDDEN: usize = 12;
 
 struct TinyModel {
     dir: TempDir,
@@ -76,6 +77,18 @@ fn tensor_f32(shape: &[usize], values: &[f32]) -> OwnedTensor {
         shape.to_vec(),
     )
     .expect("valid f32 tensor")
+}
+
+fn tensor_i32(shape: &[usize], values: &[i32]) -> OwnedTensor {
+    OwnedTensor::new(
+        values
+            .iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect(),
+        PreparedTensorDType::Int32,
+        shape.to_vec(),
+    )
+    .expect("valid i32 tensor")
 }
 
 fn deterministic_values(elements: usize, seed: usize) -> Vec<f32> {
@@ -167,6 +180,118 @@ fn create_tiny_model() -> TinyModel {
     TinyModel { dir, embeddings }
 }
 
+fn create_tiny_mrope_model() -> TinyModel {
+    let dir = tempfile::tempdir().expect("temporary M-RoPE model directory");
+    std::fs::write(
+        dir.path().join("config.json"),
+        r#"{"model_type":"qwen2","hidden_size":12,"intermediate_size":24,"num_hidden_layers":2,"num_attention_heads":2,"num_key_value_heads":1,"head_dim":6,"vocab_size":32,"rms_norm_eps":1e-6,"rope_theta":10000.0,"tie_word_embeddings":true,"attention_bias":true,"hidden_act":"silu","rope_scaling":{"rope_type":"mrope","mrope_section":[1,1,1]}}"#,
+    )
+    .expect("M-RoPE model config");
+
+    let embeddings = deterministic_values(VOCAB * MROPE_HIDDEN, 31);
+    let mut tensors = Vec::new();
+    add_tensor(
+        &mut tensors,
+        "model.embed_tokens.weight",
+        &[VOCAB, MROPE_HIDDEN],
+        embeddings.clone(),
+    );
+    add_tensor(
+        &mut tensors,
+        "model.norm.weight",
+        &[MROPE_HIDDEN],
+        vec![1.0; MROPE_HIDDEN],
+    );
+    for layer in 0..2 {
+        let prefix = format!("model.layers.{layer}");
+        add_tensor(
+            &mut tensors,
+            format!("{prefix}.input_layernorm.weight"),
+            &[MROPE_HIDDEN],
+            vec![1.0; MROPE_HIDDEN],
+        );
+        add_tensor(
+            &mut tensors,
+            format!("{prefix}.post_attention_layernorm.weight"),
+            &[MROPE_HIDDEN],
+            vec![1.0; MROPE_HIDDEN],
+        );
+        for (offset, suffix, shape) in [
+            (2, "self_attn.q_proj.weight", vec![12, 12]),
+            (3, "self_attn.k_proj.weight", vec![6, 12]),
+            (4, "self_attn.v_proj.weight", vec![6, 12]),
+            (5, "self_attn.o_proj.weight", vec![12, 12]),
+            (6, "mlp.gate_proj.weight", vec![24, 12]),
+            (7, "mlp.up_proj.weight", vec![24, 12]),
+            (8, "mlp.down_proj.weight", vec![12, 24]),
+        ] {
+            add_tensor(
+                &mut tensors,
+                format!("{prefix}.{suffix}"),
+                &shape,
+                deterministic_values(shape.iter().product(), layer * 20 + offset),
+            );
+        }
+        for (offset, suffix, width) in [
+            (11, "self_attn.q_proj.bias", 12),
+            (12, "self_attn.k_proj.bias", 6),
+            (13, "self_attn.v_proj.bias", 6),
+        ] {
+            add_tensor(
+                &mut tensors,
+                format!("{prefix}.{suffix}"),
+                &[width],
+                deterministic_values(width, layer * 20 + offset),
+            );
+        }
+    }
+    let views = tensors
+        .iter()
+        .map(|(name, shape, bytes)| {
+            (
+                name.as_str(),
+                TensorView::new(Dtype::F32, shape.clone(), bytes).expect("valid tensor view"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    safetensors::serialize_to_file(&views, None, &dir.path().join("model.safetensors"))
+        .expect("M-RoPE model weights");
+    TinyModel { dir, embeddings }
+}
+
+fn mrope_prepared(
+    fixture: &TinyModel,
+    tokens: &[i32],
+    axes: [&[i32]; 3],
+    rope_delta: i32,
+) -> PreparedPrefill {
+    let values = tokens
+        .iter()
+        .flat_map(|&token| {
+            let row = token as usize * MROPE_HIDDEN;
+            fixture.embeddings[row..row + MROPE_HIDDEN].iter().copied()
+        })
+        .collect::<Vec<_>>();
+    let positions = axes
+        .into_iter()
+        .flat_map(|axis| axis.iter().copied())
+        .collect::<Vec<_>>();
+    PreparedPrefill::new(
+        tokens.to_vec(),
+        tensor_f32(&[1, tokens.len(), MROPE_HIDDEN], &values),
+        PreparedPositions::Mrope3D {
+            tensor: tensor_i32(&[3, tokens.len()], &positions),
+            rope_delta,
+        },
+        PreparedAttentionBias {
+            tensor: tensor_f32(&[1, 1, 1, tokens.len()], &vec![0.0; tokens.len()]),
+            causal: true,
+        },
+        Vec::new(),
+    )
+    .expect("valid M-RoPE prepared input")
+}
+
 #[test]
 #[ignore = "requires the pinned IREE runtime and compiler"]
 fn local_task_token_and_prepared_paths_are_exact_with_mixed_slot_reuse() {
@@ -228,4 +353,77 @@ fn local_task_token_and_prepared_paths_are_exact_with_mixed_slot_reuse() {
             .iter()
             .any(|event| matches!(event, EngineEvent::Token { req_id, .. } if *req_id == reused))
     );
+}
+
+#[test]
+#[ignore = "requires the pinned IREE runtime and compiler"]
+fn local_task_mrope_prefill_decode_and_per_slot_deltas_execute() {
+    let fixture = create_tiny_mrope_model();
+    let tokens = [1, 2, 3, 4];
+    let negative = mrope_prepared(
+        &fixture,
+        &tokens,
+        [&[0, 1, 2, 3], &[0, 1, 3, 3], &[0, 2, 2, 3]],
+        -1,
+    );
+    let positive = mrope_prepared(
+        &fixture,
+        &tokens,
+        [&[0, 1, 1, 3], &[0, 1, 2, 3], &[0, 2, 1, 3]],
+        2,
+    );
+
+    let mut single = XlaInferenceSession::load_with_context_capacity(fixture.path(), 2, CAPACITY)
+        .expect("M-RoPE single session");
+    let single_tokens = single
+        .generate_prepared_greedy(&negative, 3, &[])
+        .expect("real-IREE M-RoPE single prefill/decode");
+    assert_eq!(single_tokens.len(), 3);
+
+    let mut batch =
+        XlaBatchEngine::load_with_context_capacity(fixture.path(), 4, "local-task", CAPACITY)
+            .expect("M-RoPE ragged batch");
+    let text = batch
+        .submit(&tokens, 3, SampleParams::greedy())
+        .expect("text-only Qwen request canonicalizes to 3D with delta zero");
+    let vision = batch
+        .submit_prepared(negative, 3, SampleParams::greedy())
+        .expect("negative-delta vision request");
+    let cancelled = batch
+        .submit_prepared(positive.clone(), 3, SampleParams::greedy())
+        .expect("positive-delta cancellation candidate");
+    assert!(batch.cancel(cancelled));
+
+    let mut text_tokens = Vec::new();
+    let mut vision_tokens = Vec::new();
+    while !batch.is_idle() {
+        for event in batch.pump().expect("mixed M-RoPE batch step") {
+            if let EngineEvent::Token { req_id, token } = event {
+                if req_id == text {
+                    text_tokens.push(token);
+                } else if req_id == vision {
+                    vision_tokens.push(token);
+                }
+            }
+        }
+    }
+    assert_eq!(text_tokens.len(), 3);
+    assert_eq!(
+        vision_tokens, single_tokens,
+        "single and ragged logits must select the same M-RoPE tokens"
+    );
+
+    let reused = batch
+        .submit_prepared(positive, 2, SampleParams::greedy())
+        .expect("positive delta enters a released slot");
+    let mut reused_tokens = 0;
+    while !batch.is_idle() {
+        reused_tokens += batch
+            .pump()
+            .expect("reused positive-delta slot")
+            .iter()
+            .filter(|event| matches!(event, EngineEvent::Token { req_id, .. } if *req_id == reused))
+            .count();
+    }
+    assert_eq!(reused_tokens, 2);
 }


### PR DESCRIPTION
## Summary
- Add an explicit 1D versus three-axis M-RoPE prepared-position contract and validate Qwen section layouts.
- Thread signed per-request decode deltas through StableHLO, the C ABI, single sessions, and continuous-batch slot lifecycle.
- Preserve byte-exact 1D graphs and add MLX coordinate, eager Q/K, mixed-slot, and real-IREE regression gates.

## Validation
- `cargo test -p mlxcel-core --lib multimodal --quiet`
- `cargo test -p mlxcel-xla --lib --quiet`
- `cargo clippy -p mlxcel-core -p mlxcel-xla --lib --tests -- -D warnings`
- `cargo clippy -p mlxcel-xla --lib --tests --features iree -- -D warnings`
- `cargo check -p mlxcel-xla --lib --features iree` with the pinned IREE CUDA toolchain
- `local_task_mrope_prefill_decode_and_per_slot_deltas_execute` against real IREE
- Existing `local_task_prefill_and_decode_execute` token/prepared mixed-slot gate against real IREE

Closes #864