### PR TITLE
feat(xla): admit image requests in CLI and continuous-batch serving

### DIFF
--- a/src/backend/session.rs
+++ b/src/backend/session.rs
@@ -46,6 +46,77 @@ use mlxcel_core::session::{MlxInferenceSession, SessionCapabilities};
 #[cfg(feature = "xla-backend")]
 use mlxcel_xla::XlaInferenceSession;
 
+/// Root-crate OpenXLA session with the matching host image preprocessor.
+///
+/// The compiler runtime lives in `mlxcel-xla`, while the host preprocessor
+/// deliberately reuses this crate's qualified MLX vision tower and projector.
+/// Keeping both in one session makes capability reporting and image execution
+/// depend on the same loaded value.
+#[cfg(feature = "xla-backend")]
+pub struct XlaBackendSession {
+    engine: XlaInferenceSession,
+    image_preprocessor: Option<Box<dyn crate::HostMultimodalPreprocessor>>,
+}
+
+#[cfg(feature = "xla-backend")]
+impl XlaBackendSession {
+    #[must_use]
+    pub(crate) fn new(
+        engine: XlaInferenceSession,
+        image_preprocessor: Option<Box<dyn crate::HostMultimodalPreprocessor>>,
+    ) -> Self {
+        Self {
+            engine,
+            image_preprocessor,
+        }
+    }
+
+    /// Report only capabilities whose complete host/runtime path was loaded.
+    #[must_use]
+    pub fn capabilities(&self) -> SessionCapabilities {
+        let mut capabilities = self.engine.capabilities();
+        capabilities.multimodal = capabilities.multimodal && self.image_preprocessor.is_some();
+        capabilities
+    }
+
+    /// Whether this session can prepare and execute image-prefill requests.
+    #[must_use]
+    pub fn supports_images(&self) -> bool {
+        self.image_preprocessor.is_some() && self.engine.capabilities().multimodal
+    }
+
+    /// Prepare decoded images through the exact preprocessor used by the
+    /// capability predicate.
+    pub fn prepare_images(
+        &self,
+        token_ids: &[i32],
+        images: &[image::DynamicImage],
+    ) -> Result<PreparedPrefill, String> {
+        let preprocessor = self.image_preprocessor.as_ref().ok_or_else(|| {
+            "the loaded OpenXLA model/runtime bundle does not support image input".to_string()
+        })?;
+        preprocessor
+            .prepare(token_ids, images)
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[cfg(feature = "xla-backend")]
+impl std::ops::Deref for XlaBackendSession {
+    type Target = XlaInferenceSession;
+
+    fn deref(&self) -> &Self::Target {
+        &self.engine
+    }
+}
+
+#[cfg(feature = "xla-backend")]
+impl std::ops::DerefMut for XlaBackendSession {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.engine
+    }
+}
+
 /// The inference session selected for a load.
 ///
 /// Under default features this enum has a single variant, [`Session::Mlx`].
@@ -61,7 +132,7 @@ pub enum Session {
     /// on-device, so it self-drives the engine-neutral prefill / decode_step
     /// contract and ignores the threaded MLX model and sampling config (greedy).
     #[cfg(feature = "xla-backend")]
-    Xla(XlaInferenceSession),
+    Xla(XlaBackendSession),
 }
 
 impl Session {
@@ -76,8 +147,11 @@ impl Session {
     #[cfg(feature = "xla-backend")]
     #[inline]
     #[must_use]
-    pub fn xla(session: XlaInferenceSession) -> Self {
-        Session::Xla(session)
+    pub(crate) fn xla(
+        session: XlaInferenceSession,
+        image_preprocessor: Option<Box<dyn crate::HostMultimodalPreprocessor>>,
+    ) -> Self {
+        Session::Xla(XlaBackendSession::new(session, image_preprocessor))
     }
 
     /// What this session can do, so the control plane can gate features.

--- a/src/backend/session.rs
+++ b/src/backend/session.rs
@@ -46,6 +46,23 @@ use mlxcel_core::session::{MlxInferenceSession, SessionCapabilities};
 #[cfg(feature = "xla-backend")]
 use mlxcel_xla::XlaInferenceSession;
 
+#[cfg(feature = "xla-backend")]
+pub(super) fn qualified_xla_capabilities(
+    mut engine_capabilities: SessionCapabilities,
+    has_image_preprocessor: bool,
+) -> SessionCapabilities {
+    engine_capabilities.multimodal = engine_capabilities.multimodal && has_image_preprocessor;
+    engine_capabilities
+}
+
+#[cfg(feature = "xla-backend")]
+pub(super) fn qualified_xla_supports_images(
+    engine_capabilities: SessionCapabilities,
+    has_image_preprocessor: bool,
+) -> bool {
+    qualified_xla_capabilities(engine_capabilities, has_image_preprocessor).multimodal
+}
+
 /// Root-crate OpenXLA session with the matching host image preprocessor.
 ///
 /// The compiler runtime lives in `mlxcel-xla`, while the host preprocessor
@@ -74,15 +91,19 @@ impl XlaBackendSession {
     /// Report only capabilities whose complete host/runtime path was loaded.
     #[must_use]
     pub fn capabilities(&self) -> SessionCapabilities {
-        let mut capabilities = self.engine.capabilities();
-        capabilities.multimodal = capabilities.multimodal && self.image_preprocessor.is_some();
-        capabilities
+        qualified_xla_capabilities(
+            self.engine.capabilities(),
+            self.image_preprocessor.is_some(),
+        )
     }
 
     /// Whether this session can prepare and execute image-prefill requests.
     #[must_use]
     pub fn supports_images(&self) -> bool {
-        self.image_preprocessor.is_some() && self.engine.capabilities().multimodal
+        qualified_xla_supports_images(
+            self.engine.capabilities(),
+            self.image_preprocessor.is_some(),
+        )
     }
 
     /// Prepare decoded images through the exact preprocessor used by the

--- a/src/backend/tests.rs
+++ b/src/backend/tests.rs
@@ -161,13 +161,14 @@ fn xla_backend_creates_a_single_sequence_session_scaffold() {
         "the XLA backend drives generation through the session, not load_model"
     );
 
+    let model_dir = tempfile::tempdir().expect("temporary text-model fixture");
+    std::fs::write(
+        model_dir.path().join("config.json"),
+        r#"{"model_type":"llama"}"#,
+    )
+    .expect("write text-model config");
     let session = backend
-        .create_session(
-            std::path::Path::new("/tmp/model"),
-            16,
-            KVCacheMode::Fp16,
-            TokenBiasMap::new(),
-        )
+        .create_session(model_dir.path(), 16, KVCacheMode::Fp16, TokenBiasMap::new())
         .expect("xla session creation must succeed");
     let caps = session.capabilities();
     assert!(

--- a/src/backend/tests.rs
+++ b/src/backend/tests.rs
@@ -124,6 +124,29 @@ fn mlx_session_threads_the_token_bias_through() {
     }
 }
 
+#[cfg(feature = "xla-backend")]
+#[test]
+fn xla_image_capability_requires_runtime_and_host_preprocessor() {
+    use super::session::{qualified_xla_capabilities, qualified_xla_supports_images};
+    use mlxcel_core::session::SessionCapabilities;
+
+    let text_runtime = SessionCapabilities::single_sequence();
+    let multimodal_runtime = text_runtime.with_multimodal();
+
+    assert!(!qualified_xla_supports_images(text_runtime, false));
+    assert!(!qualified_xla_supports_images(text_runtime, true));
+    assert!(!qualified_xla_supports_images(multimodal_runtime, false));
+    assert!(qualified_xla_supports_images(multimodal_runtime, true));
+    assert!(
+        !qualified_xla_capabilities(multimodal_runtime, false).multimodal,
+        "missing required host artifact must keep capability false"
+    );
+    assert!(
+        qualified_xla_capabilities(multimodal_runtime, true).multimodal,
+        "only a qualified runtime plus loaded preprocessor advertises images"
+    );
+}
+
 /// The experimental scaffold has no engine wired in, so it cannot produce a
 /// session. Compiled only under the optional feature; default builds carry none
 /// of it.

--- a/src/backend/xla.rs
+++ b/src/backend/xla.rs
@@ -107,9 +107,11 @@ impl ComputeBackend for XlaBackend {
         // without it, the session loads but `prefill` / `decode_step` report that
         // the `iree` feature is off. KV mode and token bias do not apply: the
         // session owns its own KV and samples greedily on-device.
+        let image_preprocessor = crate::load_xla_image_preprocessor(model_path)
+            .map_err(|error| anyhow::anyhow!("OpenXLA image preprocessor load failed: {error}"))?;
         let session =
             XlaInferenceSession::load(model_path, num_layers).map_err(|e| anyhow::anyhow!(e))?;
-        Ok(Session::xla(session))
+        Ok(Session::xla(session, image_preprocessor))
     }
 
     fn supports_batched_serving(&self) -> bool {

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -18,7 +18,7 @@
 //! prompt preparation, generation-mode selection, and terminal output helpers.
 
 use anyhow::{Result, anyhow, ensure};
-use std::io::{self, IsTerminal, Write as IoWrite};
+use std::io::{self, IsTerminal, Read, Write as IoWrite};
 use std::path::Path;
 use std::time::{Duration, Instant};
 
@@ -1031,31 +1031,87 @@ fn xla_num_layers(model_dir: &Path) -> usize {
         .map_or(0, |n| n as usize)
 }
 
-/// Self-contained text generation for the OpenXLA backend (issue #449 Phase 3).
+#[cfg(feature = "xla-backend")]
+fn decode_xla_cli_images(paths: &[std::path::PathBuf]) -> Result<Vec<image::DynamicImage>> {
+    let limits = mlxcel::current_image_input_limits();
+    ensure!(
+        paths.len() <= limits.max_images_per_request,
+        "OpenXLA image request contains {} image(s), exceeding the configured maximum of {}",
+        paths.len(),
+        limits.max_images_per_request
+    );
+    let read_limit = limits
+        .max_payload_bytes
+        .checked_add(1)
+        .ok_or_else(|| anyhow!("configured image payload limit overflowed"))?;
+    let mut payloads = Vec::with_capacity(paths.len());
+    for path in paths {
+        let mut bytes = Vec::new();
+        std::fs::File::open(path)
+            .map_err(|error| anyhow!("Failed to open image {path:?}: {error}"))?
+            .take(read_limit as u64)
+            .read_to_end(&mut bytes)
+            .map_err(|error| anyhow!("Failed to read image {path:?}: {error}"))?;
+        ensure!(
+            bytes.len() <= limits.max_payload_bytes,
+            "Image payload {path:?} is {} bytes, exceeding the configured maximum of {}",
+            bytes.len(),
+            limits.max_payload_bytes
+        );
+        payloads.push(bytes);
+    }
+    mlxcel::decode_image_payloads_with_limits(&payloads, limits)
+}
+
+/// Self-contained generation for the OpenXLA backend (issue #449 Phase 3).
 ///
 /// The OpenXLA engine drives generation from its own session and has no MLX
 /// `LoadedModel`, so this path skips `load_model` (which the XLA backend rejects)
 /// and the generic model-threaded loop: it creates the session straight from the
-/// model directory and runs the session's own greedy loop, which seeds KV and
-/// samples on-device. Text-only and greedy by design (no VLM / draft / sampling
-/// knobs), so the caller routes here only when `MLXCEL_BACKEND=xla` is selected.
+/// model directory and runs the session's own greedy loop. Image requests use
+/// the same decoded-image security limits and owned `PreparedPrefill` contract
+/// as serving; audio and video remain explicit unsupported modalities.
 #[cfg(feature = "xla-backend")]
-fn generate_xla_text(
+fn generate_xla(
     model_path: &Path,
     num_layers: usize,
     prompt_tokens: &[i32],
+    image_paths: &[std::path::PathBuf],
+    has_audio: bool,
+    has_video: bool,
     max_tokens: usize,
     kv_cache_mode: KVCacheMode,
     token_bias: TokenBiasMap,
 ) -> Result<(Vec<i32>, GenerationStats)> {
+    ensure!(
+        !has_audio,
+        "the OpenXLA backend does not support audio input yet"
+    );
+    ensure!(
+        !has_video,
+        "the OpenXLA backend does not support video input yet"
+    );
     let mut session =
         select_backend().create_session(model_path, num_layers, kv_cache_mode, token_bias)?;
     let start_time = Instant::now();
     let tokens = match &mut session {
         mlxcel::Session::Xla(s) => {
             let eos = s.eos_token_ids().to_vec();
-            s.generate_greedy(prompt_tokens, max_tokens, &eos)
-                .map_err(|e| anyhow!("OpenXLA generation failed: {e}"))?
+            if image_paths.is_empty() {
+                s.generate_greedy(prompt_tokens, max_tokens, &eos)
+                    .map_err(|e| anyhow!("OpenXLA generation failed: {e}"))?
+            } else {
+                ensure!(
+                    s.supports_images(),
+                    "the loaded OpenXLA model/runtime bundle does not support image input"
+                );
+                let images = decode_xla_cli_images(image_paths)?;
+                let prepared = s
+                    .prepare_images(prompt_tokens, &images)
+                    .map_err(|error| anyhow!("OpenXLA image preprocessing failed: {error}"))?;
+                s.generate_prepared_greedy(&prepared, max_tokens, &eos)
+                    .map_err(|error| anyhow!("OpenXLA image generation failed: {error}"))?
+            }
         }
         // `select_backend()` returned the XLA backend, so its `create_session`
         // yields an XLA session; any other variant would be a wiring bug.
@@ -1819,10 +1875,13 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
     if select_backend().name() == "xla" {
         let num_layers = xla_num_layers(&args.model.model);
         print_generation_preamble(&user_prompt)?;
-        let (generated_tokens, stats) = generate_xla_text(
+        let (generated_tokens, stats) = generate_xla(
             &args.model.model,
             num_layers,
             &prompt_tokens,
+            &args.generation.image,
+            args.generation.audio.is_some(),
+            !args.generation.video.is_empty(),
             args.generation.max_tokens,
             kv_cache_mode,
             token_bias,

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1042,6 +1042,16 @@ fn validate_xla_output_audio(output_audio: Option<&Path>) -> Result<()> {
     Ok(())
 }
 
+#[cfg(any(feature = "xla-backend", test))]
+fn validate_xla_cli_image_cardinality(declared: usize, decoded: usize) -> Result<()> {
+    ensure!(
+        declared == decoded,
+        "OpenXLA image decode cardinality mismatch: {declared} image path(s) provided, \
+         {decoded} decoded; refusing partial image execution"
+    );
+    Ok(())
+}
+
 #[cfg(feature = "xla-backend")]
 fn decode_xla_cli_images(paths: &[std::path::PathBuf]) -> Result<Vec<image::DynamicImage>> {
     let limits = mlxcel::current_image_input_limits();
@@ -1071,7 +1081,9 @@ fn decode_xla_cli_images(paths: &[std::path::PathBuf]) -> Result<Vec<image::Dyna
         );
         payloads.push(bytes);
     }
-    mlxcel::decode_image_payloads_with_limits(&payloads, limits)
+    let images = mlxcel::decode_image_payloads_with_limits(&payloads, limits)?;
+    validate_xla_cli_image_cardinality(paths.len(), images.len())?;
+    Ok(images)
 }
 
 /// Self-contained generation for the OpenXLA backend (issue #449 Phase 3).

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -18,7 +18,9 @@
 //! prompt preparation, generation-mode selection, and terminal output helpers.
 
 use anyhow::{Result, anyhow, ensure};
-use std::io::{self, IsTerminal, Read, Write as IoWrite};
+#[cfg(feature = "xla-backend")]
+use std::io::Read;
+use std::io::{self, IsTerminal, Write as IoWrite};
 use std::path::Path;
 use std::time::{Duration, Instant};
 
@@ -1031,6 +1033,15 @@ fn xla_num_layers(model_dir: &Path) -> usize {
         .map_or(0, |n| n as usize)
 }
 
+#[cfg(any(feature = "xla-backend", test))]
+fn validate_xla_output_audio(output_audio: Option<&Path>) -> Result<()> {
+    ensure!(
+        output_audio.is_none(),
+        "--output-audio is not supported by the OpenXLA backend"
+    );
+    Ok(())
+}
+
 #[cfg(feature = "xla-backend")]
 fn decode_xla_cli_images(paths: &[std::path::PathBuf]) -> Result<Vec<image::DynamicImage>> {
     let limits = mlxcel::current_image_input_limits();
@@ -1873,6 +1884,7 @@ fn run_generate_once(mut args: GenerateArgs) -> Result<()> {
     // `token_bias` is sound because this branch diverges with `return`.)
     #[cfg(feature = "xla-backend")]
     if select_backend().name() == "xla" {
+        validate_xla_output_audio(args.generation.output_audio.as_deref())?;
         let num_layers = xla_num_layers(&args.model.model);
         print_generation_preamble(&user_prompt)?;
         let (generated_tokens, stats) = generate_xla(

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -17,7 +17,7 @@ use super::{
     estimate_delta_label_and_bytes, generated_suffix, generation_stats_from_duration,
     memory_preflight_ctx_len, resolve_cli_pipeline_assignments, resolve_cli_prompt,
     should_route_offline_mtp, strip_trailing_eos, validate_pipeline_parallel_args,
-    validate_tensor_parallel_args, validate_xla_output_audio,
+    validate_tensor_parallel_args, validate_xla_cli_image_cardinality, validate_xla_output_audio,
 };
 use mlxcel::server::chat_template::ChatTemplateProcessor;
 use mlxcel_core::drafter::DrafterKind;
@@ -34,6 +34,26 @@ fn xla_rejects_output_audio_before_generation() {
             .to_string()
             .contains("not supported by the OpenXLA backend")
     );
+}
+
+#[test]
+fn xla_cli_rejects_partial_multi_image_decode() {
+    let payloads = vec![
+        include_bytes!("../../tests/fixtures/test_image.png").to_vec(),
+        b"not-an-image".to_vec(),
+    ];
+    let images =
+        mlxcel::decode_image_payloads_with_limits(&payloads, mlxcel::ImageInputLimits::default())
+            .unwrap();
+    assert_eq!(images.len(), 1, "the shared decoder remains tolerant");
+
+    let error = validate_xla_cli_image_cardinality(payloads.len(), images.len())
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("2 image path(s) provided"));
+    assert!(error.contains("1 decoded"));
+    assert!(error.contains("refusing partial image execution"));
+    assert!(validate_xla_cli_image_cardinality(1, images.len()).is_ok());
 }
 
 // issue #166: the offline MTP loop is constructed only when the operator

--- a/src/commands/generate_tests.rs
+++ b/src/commands/generate_tests.rs
@@ -17,13 +17,24 @@ use super::{
     estimate_delta_label_and_bytes, generated_suffix, generation_stats_from_duration,
     memory_preflight_ctx_len, resolve_cli_pipeline_assignments, resolve_cli_prompt,
     should_route_offline_mtp, strip_trailing_eos, validate_pipeline_parallel_args,
-    validate_tensor_parallel_args,
+    validate_tensor_parallel_args, validate_xla_output_audio,
 };
 use mlxcel::server::chat_template::ChatTemplateProcessor;
 use mlxcel_core::drafter::DrafterKind;
 use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
+
+#[test]
+fn xla_rejects_output_audio_before_generation() {
+    assert!(validate_xla_output_audio(None).is_ok());
+    let error = validate_xla_output_audio(Some(std::path::Path::new("out.wav"))).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("not supported by the OpenXLA backend")
+    );
+}
 
 // issue #166: the offline MTP loop is constructed only when the operator
 // explicitly passes `--draft-kind mtp`. An auto-detected MTP shape (no explicit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub use mlxcel_core::generate::{
 pub use mlxcel_core::speculative::SpeculativeGenerator;
 pub use multimodal::host_preprocessor::{
     FakeHostMultimodalPreprocessor, HostMultimodalPreprocessor, HostPreprocessorError,
-    LlavaHostPreprocessor,
+    LlavaHostPreprocessor, load_xla_image_preprocessor,
 };
 pub use multimodal::{
     internvl_prompt, kimi_vl_prompt, minicpmo_prompt, moondream2_prompt, moondream3_prompt,
@@ -98,6 +98,21 @@ pub use mlxcel_core::session::{
     PreparedPositions, PreparedPrefill, PreparedPrefillError, PreparedTensorDType,
     SessionCapabilities,
 };
+pub use server::ImageInputLimits;
+
+/// Return the image admission limits shared by CLI and server requests.
+#[must_use]
+pub fn current_image_input_limits() -> ImageInputLimits {
+    server::current_image_input_limits()
+}
+
+/// Decode already-bounded image payloads with the same limits as the server.
+pub fn decode_image_payloads_with_limits(
+    images: &[Vec<u8>],
+    limits: ImageInputLimits,
+) -> anyhow::Result<Vec<image::DynamicImage>> {
+    server::model_provider::model_worker::decode_request_images_with_limits(images, limits)
+}
 
 // Re-export split modules
 pub use loaded_model::LoadedModel;

--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -398,8 +398,32 @@ impl Config {
     /// a `rope_scaling` whose `rope_type` is not `llama3` (e.g. yarn), or MiniCPM3's
     /// MLA attention.
     pub fn from_json_str(s: &str) -> Result<Self, String> {
-        let v: serde_json::Value =
+        let root: serde_json::Value =
             serde_json::from_str(s).map_err(|e| format!("parse config.json: {e}"))?;
+        let v = if matches!(
+            root.get("model_type").and_then(serde_json::Value::as_str),
+            Some("llava" | "llava_next")
+        ) {
+            let mut text = root
+                .get("text_config")
+                .and_then(serde_json::Value::as_object)
+                .cloned()
+                .ok_or_else(|| {
+                    "LLaVA config.json missing object `text_config` for the XLA text graph"
+                        .to_string()
+                })?;
+            // mlx-community quantized VLMs commonly keep the affine scheme at
+            // the wrapper level even though the tensors belong to the nested
+            // language model.
+            if !text.contains_key("quantization")
+                && let Some(quantization) = root.get("quantization")
+            {
+                text.insert("quantization".to_string(), quantization.clone());
+            }
+            serde_json::Value::Object(text)
+        } else {
+            root
+        };
 
         let model_type = v.get("model_type").and_then(serde_json::Value::as_str);
 
@@ -1524,5 +1548,31 @@ mod tests {
                 "expected {needle:?} in validation error: {error}"
             );
         }
+    }
+
+    #[test]
+    fn llava_wrapper_uses_nested_qwen2_text_config() {
+        let j = r#"{
+            "model_type":"llava",
+            "quantization":{"bits":4,"group_size":64},
+            "vision_config":{"model_type":"siglip_vision_model"},
+            "text_config":{
+                "model_type":"qwen2","hidden_size":1024,"intermediate_size":2816,
+                "num_hidden_layers":24,"num_attention_heads":16,"num_key_value_heads":16,
+                "rms_norm_eps":1e-6,"rope_theta":1000000,"vocab_size":152000,
+                "tie_word_embeddings":true
+            }
+        }"#;
+        let config = Config::from_json_str(j).expect("nested LLaVA text config parses");
+        assert_eq!(config.hidden, 1024);
+        assert_eq!(config.n_layers, 24);
+        assert!(config.qkv_bias);
+        assert_eq!(
+            config.quantization,
+            Some(QuantConfig {
+                bits: 4,
+                group_size: 64
+            })
+        );
     }
 }

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -893,6 +893,47 @@ fn resolve_weight_shards(model_dir: &Path, names: &[String]) -> Result<Vec<PathB
         .collect()
 }
 
+fn language_model_tensor_name(name: &str) -> String {
+    format!("language_model.{name}")
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DenseCheckpointNames {
+    Canonical,
+    LanguageModelPrefixed,
+}
+
+/// Resolve dense-language weights from either a standalone checkpoint or the
+/// `language_model.*` namespace used by LLaVA wrappers.
+///
+/// A single-file checkpoint defers namespace detection until its safetensors
+/// header is open. A sharded checkpoint must choose one complete namespace
+/// from the index so a partially mixed wrapper is rejected.
+fn resolve_dense_weight_sources(
+    model_dir: &Path,
+    names: &[String],
+) -> Result<(Vec<PathBuf>, Option<DenseCheckpointNames>), String> {
+    let single = model_dir.join("model.safetensors");
+    if single.exists() {
+        return Ok((vec![single; names.len()], None));
+    }
+    if let Ok(paths) = resolve_weight_shards(model_dir, names) {
+        return Ok((paths, Some(DenseCheckpointNames::Canonical)));
+    }
+    let wrapped: Vec<String> = names
+        .iter()
+        .map(|name| language_model_tensor_name(name))
+        .collect();
+    resolve_weight_shards(model_dir, &wrapped)
+        .map(|paths| (paths, Some(DenseCheckpointNames::LanguageModelPrefixed)))
+        .map_err(|error| {
+            format!(
+                "dense checkpoint has neither a complete canonical nor `language_model.*` \
+                 weight namespace: {error}"
+            )
+        })
+}
+
 /// mlx-community Gemma3n quantized repacks retain the upstream index but rewrite
 /// the language backbone's safetensors prefix. Keep the graph's canonical HF
 /// argument order and only try this one architecture-specific alternate after
@@ -1158,12 +1199,15 @@ fn load_weights(
 ) -> Result<(Vec<WeightBuf>, Vec<c_int>, Vec<c_int>, Vec<i64>), String> {
     let specs = cfg.weight_specs();
     let names: Vec<String> = specs.iter().map(|s| s.tensor_name().to_string()).collect();
-    let (shard_paths, gemma3n_name_scheme) = match cfg {
+    let (shard_paths, mut dense_name_scheme, gemma3n_name_scheme) = match cfg {
         RuntimeConfig::Gemma3n(_) => {
             let (paths, scheme) = resolve_gemma3n_weight_sources(model_dir, &names)?;
-            (paths, Some(scheme))
+            (paths, None, Some(scheme))
         }
-        RuntimeConfig::Dense(_) => (resolve_weight_shards(model_dir, &names)?, None),
+        RuntimeConfig::Dense(_) => {
+            let (paths, scheme) = resolve_dense_weight_sources(model_dir, &names)?;
+            (paths, scheme, None)
+        }
     };
 
     // Group weight indices by shard so each shard file is opened/mmap'd once; the
@@ -1190,13 +1234,51 @@ fn load_weights(
             .map_err(|e| format!("parse {}: {e}", shard.display()))?;
         for &i in &idxs {
             let name = &names[i];
-            let checkpoint_name = checkpoint_tensor_name(gemma3n_name_scheme, name)?;
-            let t = st.tensor(&checkpoint_name).map_err(|e| {
-                format!(
-                    "resolved weight {checkpoint_name} (canonical {name}) in {}: {e}",
-                    shard.display()
-                )
-            })?;
+            let (checkpoint_name, t) = match cfg {
+                RuntimeConfig::Gemma3n(_) => {
+                    let checkpoint_name = checkpoint_tensor_name(gemma3n_name_scheme, name)?;
+                    let tensor = st.tensor(&checkpoint_name).map_err(|error| {
+                        format!(
+                            "resolved weight {checkpoint_name} (canonical {name}) in {}: {error}",
+                            shard.display()
+                        )
+                    })?;
+                    (checkpoint_name, tensor)
+                }
+                RuntimeConfig::Dense(_) => {
+                    let checkpoint_name = match dense_name_scheme {
+                        Some(DenseCheckpointNames::Canonical) => name.clone(),
+                        Some(DenseCheckpointNames::LanguageModelPrefixed) => {
+                            language_model_tensor_name(name)
+                        }
+                        None => {
+                            if st.tensor(name).is_ok() {
+                                dense_name_scheme = Some(DenseCheckpointNames::Canonical);
+                                name.clone()
+                            } else {
+                                let wrapped = language_model_tensor_name(name);
+                                st.tensor(&wrapped).map_err(|error| {
+                                    format!(
+                                        "resolved neither canonical weight {name} nor wrapped \
+                                         weight {wrapped} in {}: {error}",
+                                        shard.display()
+                                    )
+                                })?;
+                                dense_name_scheme =
+                                    Some(DenseCheckpointNames::LanguageModelPrefixed);
+                                wrapped
+                            }
+                        }
+                    };
+                    let tensor = st.tensor(&checkpoint_name).map_err(|error| {
+                        format!(
+                            "resolved weight {checkpoint_name} (canonical {name}) in {}: {error}",
+                            shard.display()
+                        )
+                    })?;
+                    (checkpoint_name, tensor)
+                }
+            };
 
             // issue #516 packed path: upload the raw quantized part (the packed U32
             // weight, or its f16 scales / biases) as-is, no dequant. Its native dtype

--- a/src/loading/vlm_llava.rs
+++ b/src/loading/vlm_llava.rs
@@ -240,15 +240,10 @@ fn require_llava_host_family(config: &VLMConfig) -> Result<(), HostPreprocessorE
             config.vision_config.num_channels
         )));
     }
-    if config.vision_config.patch_size == 0
-        || !config
-            .vision_config
-            .image_size
-            .is_multiple_of(config.vision_config.patch_size)
-    {
+    if config.vision_config.patch_size == 0 {
         return Err(HostPreprocessorError::InvalidConfig(format!(
-            "LLaVA image_size {} must be divisible by non-zero patch_size {}",
-            config.vision_config.image_size, config.vision_config.patch_size
+            "LLaVA patch_size must be non-zero for image_size {}",
+            config.vision_config.image_size
         )));
     }
     Ok(())

--- a/src/loading/vlm_llava_tests.rs
+++ b/src/loading/vlm_llava_tests.rs
@@ -217,3 +217,24 @@ fn host_family_validation_rejects_incompatible_processor_family() {
         HostPreprocessorError::FamilyMismatch { .. }
     ));
 }
+
+#[test]
+fn host_family_validation_accepts_floor_patch_grid_used_by_llava_interleave() {
+    let config: VLMConfig = serde_json::from_value(json!({
+        "model_type": "llava",
+        "text_config": {"model_type": "qwen2", "hidden_size": 8},
+        "vision_config": {
+            "model_type": "siglip_vision_model",
+            "num_hidden_layers": 1,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "num_attention_heads": 1,
+            "patch_size": 14,
+            "image_size": 384,
+            "num_channels": 3
+        }
+    }))
+    .unwrap();
+
+    require_llava_host_family(&config).unwrap();
+}

--- a/src/multimodal/host_preprocessor.rs
+++ b/src/multimodal/host_preprocessor.rs
@@ -63,6 +63,40 @@ pub trait HostMultimodalPreprocessor {
     ) -> Result<PreparedPrefill, HostPreprocessorError>;
 }
 
+/// Load the image preprocessor supported by the OpenXLA host-first path.
+///
+/// `Ok(None)` is the conservative result for text-only checkpoints and VLM
+/// families whose processor/position contract has not been qualified for XLA
+/// yet. Once a checkpoint is identified as the supported LLaVA family, missing
+/// or malformed processor/projector weights are startup errors rather than a
+/// capability downgrade.
+///
+/// # Errors
+///
+/// Returns a typed configuration or weight-loading error for a supported LLaVA
+/// checkpoint that cannot construct its complete host preprocessor.
+pub fn load_xla_image_preprocessor(
+    model_path: &Path,
+) -> Result<Option<Box<dyn HostMultimodalPreprocessor>>, HostPreprocessorError> {
+    let model_type = crate::models::get_model_type(model_path).map_err(|error| {
+        HostPreprocessorError::InvalidConfig(format!(
+            "failed to identify model family from {}: {error}",
+            model_path.display()
+        ))
+    })?;
+    if model_type != crate::models::ModelType::LlavaVLM {
+        return Ok(None);
+    }
+
+    match LlavaHostPreprocessor::load(model_path) {
+        Ok(preprocessor) => Ok(Some(Box::new(preprocessor))),
+        // A LLaVA-shaped checkpoint can still carry an unqualified text or
+        // vision backend. Keep capability false for that combination.
+        Err(HostPreprocessorError::FamilyMismatch { .. }) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
 /// LLaVA host preprocessor retaining only the components needed before XLA.
 pub struct LlavaHostPreprocessor {
     processor: Box<dyn ImageProcessor>,
@@ -214,6 +248,16 @@ impl HostMultimodalPreprocessor for LlavaHostPreprocessor {
                 &text_embeddings,
                 &input_ids,
             )
+        };
+
+        // The qualified IREE embeddings entry is intentionally F32-only. MLX
+        // checkpoints may store the language embedding table and vision tower
+        // in BF16/F16, so widen the fully merged result exactly once at the
+        // ownership boundary instead of making the runtime accept a dtype it
+        // cannot execute.
+        let merged = InputEmbeddings {
+            inputs_embeds: mlxcel_core::astype(&merged.inputs_embeds, mlxcel_core::dtype::FLOAT32),
+            attention_mask_4d: merged.attention_mask_4d,
         };
 
         export_llava_prefill(

--- a/src/multimodal/host_preprocessor_tests.rs
+++ b/src/multimodal/host_preprocessor_tests.rs
@@ -19,7 +19,7 @@ use mlxcel_core::dtype;
 
 use super::{
     FakeHostMultimodalPreprocessor, HostMultimodalPreprocessor, HostPreprocessorError,
-    export_llava_prefill, export_mlx_tensor, validate_processor_shape,
+    export_llava_prefill, export_mlx_tensor, load_xla_image_preprocessor, validate_processor_shape,
 };
 use crate::multimodal::vlm_prompt::ImageTokenBlockError;
 use crate::vision::merge::merge_llava;
@@ -40,6 +40,59 @@ fn fake() -> FakeHostMultimodalPreprocessor {
         hidden_size: 3,
         max_sequence_len: 32,
     }
+}
+
+#[test]
+fn xla_loader_keeps_text_and_unqualified_vlm_image_capability_false() {
+    for model_type in ["llama", "qwen2_vl"] {
+        let model_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            model_dir.path().join("config.json"),
+            format!(r#"{{"model_type":"{model_type}"}}"#),
+        )
+        .unwrap();
+        let preprocessor = load_xla_image_preprocessor(model_dir.path()).unwrap();
+        assert!(
+            preprocessor.is_none(),
+            "{model_type} is not a qualified LLaVA host/runtime pair"
+        );
+    }
+}
+
+#[test]
+fn xla_loader_fails_startup_for_llava_missing_required_artifacts() {
+    let model_dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        model_dir.path().join("config.json"),
+        r#"{
+            "model_type": "llava",
+            "text_config": {
+                "model_type": "llama",
+                "hidden_size": 8,
+                "max_position_embeddings": 32
+            },
+            "vision_config": {
+                "model_type": "siglip_vision_model",
+                "num_hidden_layers": 1,
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_attention_heads": 1,
+                "patch_size": 2,
+                "image_size": 4,
+                "num_channels": 3
+            },
+            "image_token_index": -200
+        }"#,
+    )
+    .unwrap();
+
+    let error = load_xla_image_preprocessor(model_dir.path())
+        .err()
+        .expect("qualified LLaVA without projector/vision/embedding artifacts must fail");
+    assert!(
+        !matches!(error, HostPreprocessorError::FamilyMismatch { .. }),
+        "a qualified family must fail startup, not silently downgrade capability: {error}"
+    );
 }
 
 #[test]

--- a/src/server/batch/mod.rs
+++ b/src/server/batch/mod.rs
@@ -63,6 +63,8 @@ mod stop_matcher;
 /// `mlxcel-xla` continuous-batching engine to the [`BatchEngine`] contract.
 /// Behind `xla-iree` (real IREE execution); the MLX serving path is unaffected.
 #[cfg(feature = "xla-iree")]
+mod xla_preprocess;
+#[cfg(feature = "xla-iree")]
 pub(crate) mod xla_worker;
 
 pub use active::ActiveBatch;

--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -2846,6 +2846,7 @@ impl BatchScheduler {
                 images,
                 audio,
                 videos,
+                media: _,
                 response_tx,
                 cancelled,
             } => {

--- a/src/server/batch/xla_preprocess.rs
+++ b/src/server/batch/xla_preprocess.rs
@@ -1,0 +1,327 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded host-image preprocessing for the OpenXLA serve worker.
+//!
+//! The MLX-backed vision tower remains on this dedicated thread. The IREE
+//! scheduler only enqueues bounded jobs and polls owned `PreparedPrefill`
+//! results, so image decoding/vision execution cannot stall active decode rows.
+
+use std::any::Any;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, mpsc};
+use std::thread;
+
+use mlxcel_core::session::PreparedPrefill;
+
+use crate::{
+    HostMultimodalPreprocessor, load_xla_image_preprocessor,
+    server::model_provider::model_worker::decode_request_images,
+};
+
+pub(super) struct ImagePreprocessJob {
+    pub job_id: u64,
+    pub token_ids: Vec<i32>,
+    pub images: Vec<Vec<u8>>,
+    pub cancelled: Arc<AtomicBool>,
+}
+
+pub(super) enum ImagePreprocessOutcome {
+    Prepared(PreparedPrefill),
+    Cancelled,
+    Failed(String),
+}
+
+pub(super) struct ImagePreprocessResult {
+    pub job_id: u64,
+    pub outcome: ImagePreprocessOutcome,
+}
+
+/// A single-worker, bounded preprocessing queue.
+///
+/// The host preprocessor is constructed inside its owning thread, so its MLX
+/// handles never cross threads and the trait does not need an artificial
+/// `Send` bound.
+pub(super) struct ImagePreprocessStage {
+    job_tx: mpsc::SyncSender<ImagePreprocessJob>,
+    result_rx: mpsc::Receiver<ImagePreprocessResult>,
+}
+
+impl ImagePreprocessStage {
+    pub(super) fn spawn_for_model(
+        model_path: PathBuf,
+        queue_depth: usize,
+    ) -> Result<Option<Self>, String> {
+        Self::spawn_with_loader(queue_depth, move || {
+            load_xla_image_preprocessor(&model_path).map_err(|error| error.to_string())
+        })
+    }
+
+    pub(super) fn spawn_with_loader<F>(
+        queue_depth: usize,
+        loader: F,
+    ) -> Result<Option<Self>, String>
+    where
+        F: FnOnce() -> Result<Option<Box<dyn HostMultimodalPreprocessor>>, String> + Send + 'static,
+    {
+        let (job_tx, job_rx) = mpsc::sync_channel(queue_depth.max(1));
+        let (result_tx, result_rx) = mpsc::channel();
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+        thread::Builder::new()
+            .name("model-worker-xla-images".to_string())
+            .spawn(move || {
+                let loaded = std::panic::catch_unwind(std::panic::AssertUnwindSafe(loader));
+                let Some(preprocessor) = (match loaded {
+                    Ok(Ok(preprocessor)) => {
+                        let _ = ready_tx.send(Ok(preprocessor.is_some()));
+                        preprocessor
+                    }
+                    Ok(Err(error)) => {
+                        let _ = ready_tx.send(Err(error));
+                        return;
+                    }
+                    Err(payload) => {
+                        let _ = ready_tx.send(Err(format!(
+                            "OpenXLA image preprocessor panicked during startup: {}",
+                            panic_message(payload.as_ref())
+                        )));
+                        return;
+                    }
+                }) else {
+                    return;
+                };
+
+                while let Ok(job) = job_rx.recv() {
+                    let result = process_job(preprocessor.as_ref(), job);
+                    if result_tx.send(result).is_err() {
+                        break;
+                    }
+                }
+            })
+            .map_err(|error| format!("failed to spawn OpenXLA image preprocessor: {error}"))?;
+
+        match ready_rx.recv() {
+            Ok(Ok(true)) => Ok(Some(Self { job_tx, result_rx })),
+            Ok(Ok(false)) => Ok(None),
+            Ok(Err(error)) => Err(error),
+            Err(_) => {
+                Err("OpenXLA image preprocessor exited before reporting startup status".to_string())
+            }
+        }
+    }
+
+    pub(super) fn try_submit(
+        &self,
+        job: ImagePreprocessJob,
+    ) -> Result<(), mpsc::TrySendError<ImagePreprocessJob>> {
+        self.job_tx.try_send(job)
+    }
+
+    pub(super) fn try_recv(&self) -> Result<ImagePreprocessResult, mpsc::TryRecvError> {
+        self.result_rx.try_recv()
+    }
+}
+
+fn process_job(
+    preprocessor: &dyn HostMultimodalPreprocessor,
+    job: ImagePreprocessJob,
+) -> ImagePreprocessResult {
+    let ImagePreprocessJob {
+        job_id,
+        token_ids,
+        images,
+        cancelled,
+    } = job;
+    if cancelled.load(Ordering::Acquire) {
+        return ImagePreprocessResult {
+            job_id,
+            outcome: ImagePreprocessOutcome::Cancelled,
+        };
+    }
+
+    let prepared = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let decoded = decode_request_images(&images).map_err(|error| error.to_string())?;
+        if cancelled.load(Ordering::Acquire) {
+            return Err("request cancelled during image decoding".to_string());
+        }
+        preprocessor
+            .prepare(&token_ids, &decoded)
+            .map_err(|error| error.to_string())
+    }));
+
+    let outcome = if cancelled.load(Ordering::Acquire) {
+        ImagePreprocessOutcome::Cancelled
+    } else {
+        match prepared {
+            Ok(Ok(prepared)) => ImagePreprocessOutcome::Prepared(prepared),
+            Ok(Err(error)) => ImagePreprocessOutcome::Failed(error),
+            Err(payload) => ImagePreprocessOutcome::Failed(format!(
+                "image preprocessing panicked: {}",
+                panic_message(payload.as_ref())
+            )),
+        }
+    };
+    ImagePreprocessResult { job_id, outcome }
+}
+
+fn panic_message(payload: &(dyn Any + Send)) -> &str {
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::sync::atomic::AtomicBool;
+
+    use image::{DynamicImage, ImageFormat};
+
+    use super::*;
+    use crate::{FakeHostMultimodalPreprocessor, HostPreprocessorError};
+
+    fn png_bytes() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        DynamicImage::new_rgb8(2, 2)
+            .write_to(&mut Cursor::new(&mut bytes), ImageFormat::Png)
+            .unwrap();
+        bytes
+    }
+
+    fn stage(max_sequence_len: usize) -> ImagePreprocessStage {
+        ImagePreprocessStage::spawn_with_loader(1, move || {
+            Ok(Some(Box::new(FakeHostMultimodalPreprocessor {
+                image_token_id: -200,
+                tokens_per_image: 2,
+                hidden_size: 3,
+                max_sequence_len,
+            })))
+        })
+        .unwrap()
+        .unwrap()
+    }
+
+    fn receive(stage: &ImagePreprocessStage) -> ImagePreprocessResult {
+        for _ in 0..200 {
+            match stage.try_recv() {
+                Ok(result) => return result,
+                Err(mpsc::TryRecvError::Empty) => {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+                Err(error) => panic!("preprocessor disconnected: {error}"),
+            }
+        }
+        panic!("timed out waiting for image preprocessing")
+    }
+
+    #[test]
+    fn bounded_stage_prepares_owned_payload() {
+        let stage = stage(16);
+        stage
+            .try_submit(ImagePreprocessJob {
+                job_id: 7,
+                token_ids: vec![1, -200, 2],
+                images: vec![png_bytes()],
+                cancelled: Arc::new(AtomicBool::new(false)),
+            })
+            .unwrap();
+        let result = receive(&stage);
+        assert_eq!(result.job_id, 7);
+        let ImagePreprocessOutcome::Prepared(prepared) = result.outcome else {
+            panic!("expected prepared payload");
+        };
+        assert_eq!(prepared.token_ids, vec![1, -200, -200, 2]);
+        assert_eq!(prepared.sequence_len, 4);
+    }
+
+    #[test]
+    fn malformed_media_and_placeholder_mismatch_are_per_job_failures() {
+        let stage = stage(16);
+        stage
+            .try_submit(ImagePreprocessJob {
+                job_id: 1,
+                token_ids: vec![1, -200, 2],
+                images: vec![b"not-an-image".to_vec()],
+                cancelled: Arc::new(AtomicBool::new(false)),
+            })
+            .unwrap();
+        assert!(matches!(
+            receive(&stage).outcome,
+            ImagePreprocessOutcome::Failed(_)
+        ));
+
+        stage
+            .try_submit(ImagePreprocessJob {
+                job_id: 2,
+                token_ids: vec![1, -200, -200, 2],
+                images: vec![png_bytes()],
+                cancelled: Arc::new(AtomicBool::new(false)),
+            })
+            .unwrap();
+        assert!(matches!(
+            receive(&stage).outcome,
+            ImagePreprocessOutcome::Failed(_)
+        ));
+    }
+
+    #[test]
+    fn expanded_capacity_and_cancellation_are_isolated() {
+        let stage = stage(3);
+        stage
+            .try_submit(ImagePreprocessJob {
+                job_id: 3,
+                token_ids: vec![1, -200, 2],
+                images: vec![png_bytes()],
+                cancelled: Arc::new(AtomicBool::new(false)),
+            })
+            .unwrap();
+        let ImagePreprocessOutcome::Failed(error) = receive(&stage).outcome else {
+            panic!("expected capacity failure");
+        };
+        assert!(error.contains("exceeds model capacity"));
+
+        let cancelled = Arc::new(AtomicBool::new(true));
+        stage
+            .try_submit(ImagePreprocessJob {
+                job_id: 4,
+                token_ids: vec![1, -200, 2],
+                images: vec![png_bytes()],
+                cancelled,
+            })
+            .unwrap();
+        assert!(matches!(
+            receive(&stage).outcome,
+            ImagePreprocessOutcome::Cancelled
+        ));
+    }
+
+    #[test]
+    fn unsupported_loader_returns_no_stage() {
+        let stage = ImagePreprocessStage::spawn_with_loader(1, || Ok(None)).unwrap();
+        assert!(stage.is_none());
+    }
+
+    #[test]
+    fn supported_loader_error_fails_startup() {
+        let error = ImagePreprocessStage::spawn_with_loader(1, || {
+            Err(HostPreprocessorError::WeightLoad("missing projector".to_string()).to_string())
+        })
+        .err()
+        .expect("startup should fail");
+        assert!(error.contains("missing projector"));
+    }
+}

--- a/src/server/batch/xla_preprocess.rs
+++ b/src/server/batch/xla_preprocess.rs
@@ -34,6 +34,11 @@ use crate::{
 pub(super) struct ImagePreprocessJob {
     pub job_id: u64,
     pub token_ids: Vec<i32>,
+    /// Declaration count captured at the HTTP boundary.
+    ///
+    /// The worker rejects any decode result that does not preserve this count,
+    /// preventing malformed or oversized images from silently disappearing.
+    pub expected_image_count: usize,
     pub images: Vec<Vec<u8>>,
     pub cancelled: Arc<AtomicBool>,
 }
@@ -141,6 +146,7 @@ fn process_job(
     let ImagePreprocessJob {
         job_id,
         token_ids,
+        expected_image_count,
         images,
         cancelled,
     } = job;
@@ -153,6 +159,13 @@ fn process_job(
 
     let prepared = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let decoded = decode_request_images(&images).map_err(|error| error.to_string())?;
+        if decoded.len() != expected_image_count {
+            return Err(format!(
+                "decoded image cardinality mismatch: expected {expected_image_count}, decoded {}; \
+                 refusing partial multimodal execution",
+                decoded.len()
+            ));
+        }
         if cancelled.load(Ordering::Acquire) {
             return Err("request cancelled during image decoding".to_string());
         }
@@ -190,9 +203,34 @@ mod tests {
     use std::sync::atomic::AtomicBool;
 
     use image::{DynamicImage, ImageFormat};
+    use mlxcel_core::session::PreparedPrefill;
 
     use super::*;
     use crate::{FakeHostMultimodalPreprocessor, HostPreprocessorError};
+
+    struct BlockingPreprocessor {
+        started_tx: mpsc::Sender<i32>,
+        release_rx: mpsc::Receiver<()>,
+        finished_tx: Option<mpsc::Sender<i32>>,
+        inner: FakeHostMultimodalPreprocessor,
+    }
+
+    impl HostMultimodalPreprocessor for BlockingPreprocessor {
+        fn prepare(
+            &self,
+            token_ids: &[i32],
+            images: &[DynamicImage],
+        ) -> Result<PreparedPrefill, HostPreprocessorError> {
+            let marker = token_ids[0];
+            self.started_tx.send(marker).unwrap();
+            self.release_rx.recv().unwrap();
+            let prepared = self.inner.prepare(token_ids, images);
+            if let Some(finished_tx) = &self.finished_tx {
+                let _ = finished_tx.send(marker);
+            }
+            prepared
+        }
+    }
 
     fn png_bytes() -> Vec<u8> {
         let mut bytes = Vec::new();
@@ -228,6 +266,16 @@ mod tests {
         panic!("timed out waiting for image preprocessing")
     }
 
+    fn job(job_id: u64, marker: i32, cancelled: Arc<AtomicBool>) -> ImagePreprocessJob {
+        ImagePreprocessJob {
+            job_id,
+            token_ids: vec![marker, -200, marker + 1],
+            expected_image_count: 1,
+            images: vec![png_bytes()],
+            cancelled,
+        }
+    }
+
     #[test]
     fn bounded_stage_prepares_owned_payload() {
         let stage = stage(16);
@@ -235,6 +283,7 @@ mod tests {
             .try_submit(ImagePreprocessJob {
                 job_id: 7,
                 token_ids: vec![1, -200, 2],
+                expected_image_count: 1,
                 images: vec![png_bytes()],
                 cancelled: Arc::new(AtomicBool::new(false)),
             })
@@ -255,6 +304,7 @@ mod tests {
             .try_submit(ImagePreprocessJob {
                 job_id: 1,
                 token_ids: vec![1, -200, 2],
+                expected_image_count: 1,
                 images: vec![b"not-an-image".to_vec()],
                 cancelled: Arc::new(AtomicBool::new(false)),
             })
@@ -266,8 +316,23 @@ mod tests {
 
         stage
             .try_submit(ImagePreprocessJob {
+                job_id: 5,
+                token_ids: vec![1, -200, 2, -200, 3],
+                expected_image_count: 2,
+                images: vec![png_bytes(), b"not-an-image".to_vec()],
+                cancelled: Arc::new(AtomicBool::new(false)),
+            })
+            .unwrap();
+        let ImagePreprocessOutcome::Failed(error) = receive(&stage).outcome else {
+            panic!("partial decode must fail the whole request");
+        };
+        assert!(error.contains("decoded image cardinality mismatch"));
+
+        stage
+            .try_submit(ImagePreprocessJob {
                 job_id: 2,
                 token_ids: vec![1, -200, -200, 2],
+                expected_image_count: 1,
                 images: vec![png_bytes()],
                 cancelled: Arc::new(AtomicBool::new(false)),
             })
@@ -285,6 +350,7 @@ mod tests {
             .try_submit(ImagePreprocessJob {
                 job_id: 3,
                 token_ids: vec![1, -200, 2],
+                expected_image_count: 1,
                 images: vec![png_bytes()],
                 cancelled: Arc::new(AtomicBool::new(false)),
             })
@@ -299,6 +365,7 @@ mod tests {
             .try_submit(ImagePreprocessJob {
                 job_id: 4,
                 token_ids: vec![1, -200, 2],
+                expected_image_count: 1,
                 images: vec![png_bytes()],
                 cancelled,
             })
@@ -307,6 +374,98 @@ mod tests {
             receive(&stage).outcome,
             ImagePreprocessOutcome::Cancelled
         ));
+    }
+
+    #[test]
+    fn bounded_stage_preserves_fifo_and_progress_after_inflight_cancel() {
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let stage = ImagePreprocessStage::spawn_with_loader(1, move || {
+            Ok(Some(Box::new(BlockingPreprocessor {
+                started_tx,
+                release_rx,
+                finished_tx: None,
+                inner: FakeHostMultimodalPreprocessor {
+                    image_token_id: -200,
+                    tokens_per_image: 2,
+                    hidden_size: 3,
+                    max_sequence_len: 16,
+                },
+            })))
+        })
+        .unwrap()
+        .unwrap();
+
+        let cancelled_a = Arc::new(AtomicBool::new(false));
+        stage.try_submit(job(10, 10, cancelled_a.clone())).unwrap();
+        assert_eq!(
+            started_rx.recv_timeout(std::time::Duration::from_secs(1)),
+            Ok(10)
+        );
+
+        stage
+            .try_submit(job(20, 20, Arc::new(AtomicBool::new(false))))
+            .unwrap();
+        let full = stage
+            .try_submit(job(30, 30, Arc::new(AtomicBool::new(false))))
+            .unwrap_err();
+        assert!(matches!(full, mpsc::TrySendError::Full(_)));
+
+        cancelled_a.store(true, Ordering::Release);
+        release_tx.send(()).unwrap();
+        assert!(matches!(
+            receive(&stage).outcome,
+            ImagePreprocessOutcome::Cancelled
+        ));
+        assert_eq!(
+            started_rx.recv_timeout(std::time::Duration::from_secs(1)),
+            Ok(20),
+            "the queued request must start next in FIFO order"
+        );
+
+        release_tx.send(()).unwrap();
+        let result = receive(&stage);
+        assert_eq!(result.job_id, 20);
+        assert!(matches!(
+            result.outcome,
+            ImagePreprocessOutcome::Prepared(_)
+        ));
+    }
+
+    #[test]
+    fn result_receiver_disconnect_does_not_strand_inflight_preprocessor() {
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (finished_tx, finished_rx) = mpsc::channel();
+        let stage = ImagePreprocessStage::spawn_with_loader(1, move || {
+            Ok(Some(Box::new(BlockingPreprocessor {
+                started_tx,
+                release_rx,
+                finished_tx: Some(finished_tx),
+                inner: FakeHostMultimodalPreprocessor {
+                    image_token_id: -200,
+                    tokens_per_image: 2,
+                    hidden_size: 3,
+                    max_sequence_len: 16,
+                },
+            })))
+        })
+        .unwrap()
+        .unwrap();
+
+        stage
+            .try_submit(job(40, 40, Arc::new(AtomicBool::new(false))))
+            .unwrap();
+        assert_eq!(
+            started_rx.recv_timeout(std::time::Duration::from_secs(1)),
+            Ok(40)
+        );
+        drop(stage);
+        release_tx.send(()).unwrap();
+        assert_eq!(
+            finished_rx.recv_timeout(std::time::Duration::from_secs(1)),
+            Ok(40)
+        );
     }
 
     #[test]

--- a/src/server/batch/xla_worker.rs
+++ b/src/server/batch/xla_worker.rs
@@ -57,6 +57,7 @@ use super::observability::BatchObservability;
 use super::stop_matcher::StopMatcher;
 use super::xla_preprocess::ImagePreprocessStage;
 use crate::server::ServerGenerateOptions;
+use crate::server::media::MediaRequestMetadata;
 use crate::server::model_provider::model_worker::StreamingDecodeState;
 use crate::server::model_provider::{GenerateEvent, ModelRequest};
 use crate::server::state::BatchMetrics;

--- a/src/server/batch/xla_worker.rs
+++ b/src/server/batch/xla_worker.rs
@@ -23,7 +23,10 @@
 //! [`EngineEvent`] back to a [`GenerateEvent`] on that request's channel, reusing
 //! the server's [`StreamingDecodeState`] for byte-fallback-safe detokenization.
 //!
-//! Scope: text-only. This path honors `max_tokens`, the model's EOS ids,
+//! Text and qualified LLaVA image requests share this path. Image decoding and
+//! host vision execution run through a bounded preprocessing stage, then enter
+//! the same engine as an owned prepared prefill. This path honors `max_tokens`,
+//! the model's EOS ids,
 //! sampling (temperature / top-k / top-p / min-p / seed, #449 M3 Stage 2d), the
 //! history-based penalties (repetition / frequency / presence / DRY, #449 M3
 //! Stage 2d, applied host-side in the engine's sampler with the same math and
@@ -35,7 +38,7 @@
 //! applied incrementally so it is safe across token boundaries). Requests that
 //! need features the engine cannot provide are rejected with a clear error rather
 //! than served wrong: logprobs (no logit readback), structured / JSON-schema
-//! output (no constraint masking), and multimodal inputs (text-only).
+//! output (no constraint masking), and unsupported audio/video inputs.
 //!
 //! Compiled only under `xla-iree` (real IREE execution). The MLX serving path is
 //! untouched.
@@ -46,16 +49,91 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::time::Instant;
 
+use mlxcel_core::session::PreparedPrefill;
 use mlxcel_xla::{EngineEvent, FinishReason as XlaFinishReason, SampleParams, XlaBatchEngine};
 
 use super::BatchEngine;
 use super::observability::BatchObservability;
 use super::stop_matcher::StopMatcher;
+use super::xla_preprocess::ImagePreprocessStage;
 use crate::server::ServerGenerateOptions;
 use crate::server::model_provider::model_worker::StreamingDecodeState;
 use crate::server::model_provider::{GenerateEvent, ModelRequest};
 use crate::server::state::BatchMetrics;
 use crate::tokenizer::MlxcelTokenizer;
+
+#[path = "xla_worker_admission.rs"]
+mod admission;
+#[cfg(test)]
+#[path = "xla_worker_tests.rs"]
+mod tests;
+
+pub(crate) trait XlaServingEngine {
+    fn b_max(&self) -> usize;
+    fn is_idle(&self) -> bool;
+    fn pending_len(&self) -> usize;
+    fn active_len(&self) -> usize;
+    fn submit(
+        &mut self,
+        prompt: &[i32],
+        max_new_tokens: usize,
+        params: SampleParams,
+    ) -> Result<u64, String>;
+    fn submit_prepared(
+        &mut self,
+        prepared: PreparedPrefill,
+        max_new_tokens: usize,
+        params: SampleParams,
+    ) -> Result<u64, String>;
+    fn cancel(&mut self, req_id: u64) -> bool;
+    fn pump(&mut self) -> Result<Vec<EngineEvent>, String>;
+}
+
+impl XlaServingEngine for XlaBatchEngine {
+    fn b_max(&self) -> usize {
+        XlaBatchEngine::b_max(self)
+    }
+
+    fn is_idle(&self) -> bool {
+        XlaBatchEngine::is_idle(self)
+    }
+
+    fn pending_len(&self) -> usize {
+        XlaBatchEngine::pending_len(self)
+    }
+
+    fn active_len(&self) -> usize {
+        XlaBatchEngine::active_len(self)
+    }
+
+    fn submit(
+        &mut self,
+        prompt: &[i32],
+        max_new_tokens: usize,
+        params: SampleParams,
+    ) -> Result<u64, String> {
+        XlaBatchEngine::submit(self, prompt, max_new_tokens, params)
+            .map_err(|error| error.to_string())
+    }
+
+    fn submit_prepared(
+        &mut self,
+        prepared: PreparedPrefill,
+        max_new_tokens: usize,
+        params: SampleParams,
+    ) -> Result<u64, String> {
+        XlaBatchEngine::submit_prepared(self, prepared, max_new_tokens, params)
+            .map_err(|error| error.to_string())
+    }
+
+    fn cancel(&mut self, req_id: u64) -> bool {
+        XlaBatchEngine::cancel(self, req_id)
+    }
+
+    fn pump(&mut self) -> Result<Vec<EngineEvent>, String> {
+        XlaBatchEngine::pump(self)
+    }
+}
 
 /// Per-active-request state, keyed by the engine's request id.
 struct ServeState {
@@ -66,7 +144,11 @@ struct ServeState {
     /// request set no stop strings, so those requests stream exactly as before.
     stop: StopMatcher,
     start: Instant,
+    /// Public/API usage keeps the original logical prompt count.
     prompt_token_count: usize,
+    /// Internal prefill throughput and KV positions use the expanded prepared
+    /// length. Kept separately so future metrics cannot conflate the two.
+    effective_prefill_len: usize,
     max_tokens: usize,
     /// Tokens the engine has generated for this request (one per `Token` event,
     /// counted even when detok withholds the piece), reported to `BatchMetrics`
@@ -74,11 +156,21 @@ struct ServeState {
     generated_tokens: usize,
 }
 
+struct PendingImageState {
+    response_tx: mpsc::Sender<GenerateEvent>,
+    cancelled: Arc<AtomicBool>,
+    prompt_tokens: Vec<i32>,
+    params: SampleParams,
+    stop_sequences: Vec<String>,
+    max_tokens: usize,
+    start: Instant,
+}
+
 /// Server-side worker that serves requests through the OpenXLA continuous-batching
 /// engine. Built and run on a single worker thread (see
 /// `model_worker::spawn_xla_model_worker`).
-pub(crate) struct XlaServeWorker {
-    engine: XlaBatchEngine,
+pub(crate) struct XlaServeWorker<E = XlaBatchEngine> {
+    engine: E,
     tokenizer: MlxcelTokenizer,
     request_rx: mpsc::Receiver<ModelRequest>,
     /// Active requests, keyed by the engine req id `submit` returned.
@@ -91,28 +183,38 @@ pub(crate) struct XlaServeWorker {
     /// prefill/decode token throughput. The cache-pool / paged gauges are
     /// MLX-specific and stay zero for this path (it has neither).
     batch_observability: Arc<BatchObservability>,
+    image_preprocessor: Option<ImagePreprocessStage>,
+    pending_images: HashMap<u64, PendingImageState>,
+    next_image_job_id: u64,
     shutdown: bool,
 }
 
-impl XlaServeWorker {
+impl XlaServeWorker<XlaBatchEngine> {
     pub(crate) fn new(
         engine: XlaBatchEngine,
         tokenizer: MlxcelTokenizer,
+        model_path: std::path::PathBuf,
         request_rx: mpsc::Receiver<ModelRequest>,
         batch_metrics: Arc<BatchMetrics>,
         batch_observability: Arc<BatchObservability>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, String> {
+        let image_preprocessor = ImagePreprocessStage::spawn_for_model(model_path, engine.b_max())?;
+        Ok(Self {
             engine,
             tokenizer,
             request_rx,
             states: HashMap::new(),
             batch_metrics,
             batch_observability,
+            image_preprocessor,
+            pending_images: HashMap::new(),
+            next_image_job_id: 0,
             shutdown: false,
-        }
+        })
     }
+}
 
+impl<E: XlaServingEngine> XlaServeWorker<E> {
     /// Refresh the active-count and queue-depth gauges from the engine. Cheap
     /// (two atomic stores), called each serve iteration so `/metrics` tracks the
     /// live batch.
@@ -121,165 +223,6 @@ impl XlaServeWorker {
             .set_active_count(self.engine.active_len());
         self.batch_metrics
             .set_queue_depth(self.engine.pending_len());
-    }
-
-    /// Validate, tokenize, and submit one `Generate` request, or send a terminal
-    /// `Error` / empty `Done` when it cannot be served as submitted.
-    fn admit(
-        &mut self,
-        prompt: String,
-        options: ServerGenerateOptions,
-        images: Vec<Vec<u8>>,
-        audio: Vec<Vec<u8>>,
-        videos: Vec<crate::server::media::ResolvedVideo>,
-        response_tx: mpsc::Sender<GenerateEvent>,
-        cancelled: Arc<AtomicBool>,
-    ) {
-        // Reject what the engine genuinely cannot serve, rather than serve it wrong.
-        if !images.is_empty() || !audio.is_empty() || !videos.is_empty() {
-            let _ = response_tx.send(GenerateEvent::Error(
-                "the OpenXLA backend is text-only; multimodal inputs are not supported".to_string(),
-            ));
-            return;
-        }
-        if options.logprobs.enabled {
-            let _ = response_tx.send(GenerateEvent::Error(
-                "the OpenXLA backend does not support logprobs (greedy argmax, no logit readback)"
-                    .to_string(),
-            ));
-            return;
-        }
-        if options.structured.is_some() {
-            let _ = response_tx.send(GenerateEvent::Error(
-                "the OpenXLA backend does not support structured / JSON-schema output".to_string(),
-            ));
-            return;
-        }
-
-        // Sampling: temperature / top-k / top-p / min-p / seed and the
-        // history-based penalties (repetition / frequency / presence / DRY) are
-        // honored; stop strings are enforced below by a per-request `StopMatcher`.
-        // The penalty math runs host-side in the engine's sampler and mirrors the
-        // MLX path, so the two backends penalize identically for the same history.
-        let sampling = &options.sampling;
-        let params = SampleParams {
-            temperature: sampling.temperature,
-            top_k: sampling.top_k.max(0) as usize,
-            top_p: sampling.top_p,
-            min_p: sampling.min_p,
-            seed: sampling.seed,
-            repetition_penalty: sampling.repetition_penalty,
-            frequency_penalty: sampling.frequency_penalty,
-            presence_penalty: sampling.presence_penalty,
-            dry_multiplier: sampling.dry_multiplier,
-            dry_base: sampling.dry_base,
-            dry_allowed_length: sampling.dry_allowed_length,
-            dry_penalty_last_n: sampling.dry_penalty_last_n,
-            dry_sequence_breakers: sampling.dry_sequence_breakers.clone(),
-        };
-
-        let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
-        let token_ids = match self.tokenizer.encode(&prompt, add_special) {
-            Ok(ids) => ids,
-            Err(err) => {
-                let _ =
-                    response_tx.send(GenerateEvent::Error(format!("Tokenization error: {err}")));
-                return;
-            }
-        };
-        let prompt_tokens: Vec<i32> = token_ids.iter().map(|&x| x as i32).collect();
-
-        // A zero token budget asks for no generation: return an empty result so the
-        // route still sees usage counts, without touching the engine.
-        if options.max_tokens == 0 {
-            let detok = StreamingDecodeState::new(&self.tokenizer, &prompt_tokens);
-            let result = detok.finish(Instant::now(), prompt_tokens.len(), 0);
-            let _ = response_tx.send(GenerateEvent::Done(result));
-            return;
-        }
-
-        let detok = StreamingDecodeState::new(&self.tokenizer, &prompt_tokens);
-        match self
-            .engine
-            .submit(&prompt_tokens, options.max_tokens, params)
-        {
-            Ok(req_id) => {
-                // The sequence has entered the batch; count it and its prompt.
-                self.batch_observability
-                    .record_prefill_start(prompt_tokens.len());
-                self.states.insert(
-                    req_id,
-                    ServeState {
-                        response_tx,
-                        cancelled,
-                        detok,
-                        stop: StopMatcher::new(options.stop_sequences.unwrap_or_default()),
-                        start: Instant::now(),
-                        prompt_token_count: prompt_tokens.len(),
-                        max_tokens: options.max_tokens,
-                        generated_tokens: 0,
-                    },
-                );
-            }
-            Err(err) => {
-                let _ = response_tx.send(GenerateEvent::Error(format!(
-                    "OpenXLA submit failed: {err}"
-                )));
-            }
-        }
-    }
-
-    fn handle(&mut self, req: ModelRequest) {
-        match req {
-            ModelRequest::Generate {
-                prompt,
-                // The XLA worker tokenizes on its own engine thread; the
-                // dispatch-thread pre-tokenized ids (issue #633) are unused here
-                // (the XLA provider path never sets a pre-tokenizer).
-                prompt_token_ids: _,
-                options,
-                images,
-                audio,
-                videos,
-                response_tx,
-                cancelled,
-            } => self.admit(
-                prompt,
-                options,
-                images,
-                audio,
-                videos,
-                response_tx,
-                cancelled,
-            ),
-            ModelRequest::Shutdown => self.shutdown = true,
-        }
-    }
-
-    /// Pull requests off the channel. When `block` is set (the engine is idle so
-    /// there is nothing else to do), block for the first one; then drain any more
-    /// that are already queued without blocking.
-    fn drain_incoming(&mut self, block: bool) {
-        if block {
-            match self.request_rx.recv() {
-                Ok(req) => self.handle(req),
-                // Sender dropped: treat as shutdown.
-                Err(_) => {
-                    self.shutdown = true;
-                    return;
-                }
-            }
-        }
-        loop {
-            match self.request_rx.try_recv() {
-                Ok(req) => self.handle(req),
-                Err(mpsc::TryRecvError::Empty) => break,
-                Err(mpsc::TryRecvError::Disconnected) => {
-                    self.shutdown = true;
-                    break;
-                }
-            }
-        }
     }
 
     /// Drop any requests whose client cancelled, freeing their engine slots. A
@@ -294,6 +237,15 @@ impl XlaServeWorker {
         for id in ids {
             self.engine.cancel(id);
             self.states.remove(&id);
+        }
+        let jobs: Vec<u64> = self
+            .pending_images
+            .iter()
+            .filter(|(_, state)| state.cancelled.load(Ordering::Relaxed))
+            .map(|(&job_id, _)| job_id)
+            .collect();
+        for job_id in jobs {
+            self.pending_images.remove(&job_id);
         }
     }
 
@@ -340,10 +292,16 @@ impl XlaServeWorker {
                             mut stop,
                             start,
                             prompt_token_count,
+                            effective_prefill_len,
                             max_tokens,
                             generated_tokens,
                             ..
                         } = state;
+                        tracing::debug!(
+                            prompt_token_count,
+                            effective_prefill_len,
+                            "OpenXLA request completed with distinct public and KV prefill lengths"
+                        );
                         self.batch_metrics
                             .record_sequence_completed(generated_tokens);
                         self.batch_observability.record_sequence_completed();
@@ -411,22 +369,29 @@ impl XlaServeWorker {
                 .response_tx
                 .send(GenerateEvent::Error(msg.to_string()));
         }
+        for (_, state) in self.pending_images.drain() {
+            let _ = state
+                .response_tx
+                .send(GenerateEvent::Error(msg.to_string()));
+        }
     }
 }
 
-impl BatchEngine for XlaServeWorker {
+impl<E: XlaServingEngine> BatchEngine for XlaServeWorker<E> {
     fn serve(&mut self) {
         tracing::info!(
             "OpenXLA serve worker starting (continuous batching, B_max={}, sampling, stop strings)",
             self.engine.b_max()
         );
         loop {
+            self.drain_preprocessed();
             self.evict_cancelled();
 
             // If the engine has no work, block for the next request so the thread
             // does not spin; otherwise pick up any newly queued requests and pump.
             let block = self.engine.is_idle() && !self.shutdown;
             self.drain_incoming(block);
+            self.drain_preprocessed();
             self.evict_cancelled();
             // Reflect admits/cancels (and a drained-to-idle batch) in the gauges.
             self.update_gauges();

--- a/src/server/batch/xla_worker_admission.rs
+++ b/src/server/batch/xla_worker_admission.rs
@@ -1,0 +1,360 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Request admission and asynchronous image-preprocessing completion.
+
+use std::time::Duration;
+
+use super::super::xla_preprocess::{
+    ImagePreprocessJob, ImagePreprocessOutcome, ImagePreprocessResult,
+};
+use super::*;
+
+impl<E: XlaServingEngine> XlaServeWorker<E> {
+    /// Validate, tokenize, and submit one request. Images enter the bounded
+    /// preprocessing stage; text reaches the engine directly.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn admit(
+        &mut self,
+        prompt: String,
+        prompt_token_ids: Option<Vec<i32>>,
+        options: ServerGenerateOptions,
+        images: Vec<Vec<u8>>,
+        audio: Vec<Vec<u8>>,
+        videos: Vec<crate::server::media::ResolvedVideo>,
+        response_tx: mpsc::Sender<GenerateEvent>,
+        cancelled: Arc<AtomicBool>,
+    ) {
+        if options.logprobs.enabled {
+            let _ = response_tx.send(GenerateEvent::Error(
+                "the OpenXLA backend does not support logprobs (no logit readback)".to_string(),
+            ));
+            return;
+        }
+        if options.structured.is_some() {
+            let _ = response_tx.send(GenerateEvent::Error(
+                "the OpenXLA backend does not support structured / JSON-schema output".to_string(),
+            ));
+            return;
+        }
+        if !audio.is_empty() {
+            let _ = response_tx.send(GenerateEvent::Error(
+                "the OpenXLA backend does not support audio input yet".to_string(),
+            ));
+            return;
+        }
+        if !videos.is_empty() {
+            let _ = response_tx.send(GenerateEvent::Error(
+                "the OpenXLA backend does not support video input yet".to_string(),
+            ));
+            return;
+        }
+
+        let prompt_tokens = match prompt_token_ids {
+            Some(tokens) => tokens,
+            None => {
+                let add_special = !prompt.starts_with("<bos>") && !prompt.starts_with("<s>");
+                match self.tokenizer.encode(&prompt, add_special) {
+                    Ok(ids) => ids.into_iter().map(|token| token as i32).collect(),
+                    Err(error) => {
+                        let _ = response_tx
+                            .send(GenerateEvent::Error(format!("Tokenization error: {error}")));
+                        return;
+                    }
+                }
+            }
+        };
+        let params = sample_params(&options);
+        let stop_sequences = options.stop_sequences.unwrap_or_default();
+        let start = Instant::now();
+
+        if images.is_empty() {
+            self.submit_text(
+                prompt_tokens,
+                options.max_tokens,
+                params,
+                stop_sequences,
+                start,
+                response_tx,
+                cancelled,
+            );
+            return;
+        }
+
+        let Some(stage) = self.image_preprocessor.as_ref() else {
+            let _ = response_tx.send(GenerateEvent::Error(
+                "the loaded OpenXLA model/runtime bundle does not support image input".to_string(),
+            ));
+            return;
+        };
+        let Some(next_job_id) = self.next_image_job_id.checked_add(1) else {
+            let _ = response_tx.send(GenerateEvent::Error(
+                "OpenXLA image preprocessing request id overflowed".to_string(),
+            ));
+            return;
+        };
+        let job_id = self.next_image_job_id;
+        self.next_image_job_id = next_job_id;
+        let job = ImagePreprocessJob {
+            job_id,
+            token_ids: prompt_tokens.clone(),
+            images,
+            cancelled: cancelled.clone(),
+        };
+        match stage.try_submit(job) {
+            Ok(()) => {
+                self.pending_images.insert(
+                    job_id,
+                    PendingImageState {
+                        response_tx,
+                        cancelled,
+                        prompt_tokens,
+                        params,
+                        stop_sequences,
+                        max_tokens: options.max_tokens,
+                        start,
+                    },
+                );
+            }
+            Err(mpsc::TrySendError::Full(_)) => {
+                let _ = response_tx.send(GenerateEvent::Error(
+                    "OpenXLA image preprocessing queue is full; retry later".to_string(),
+                ));
+            }
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                let _ = response_tx.send(GenerateEvent::Error(
+                    "OpenXLA image preprocessor is unavailable".to_string(),
+                ));
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn submit_text(
+        &mut self,
+        prompt_tokens: Vec<i32>,
+        max_tokens: usize,
+        params: SampleParams,
+        stop_sequences: Vec<String>,
+        start: Instant,
+        response_tx: mpsc::Sender<GenerateEvent>,
+        cancelled: Arc<AtomicBool>,
+    ) {
+        if max_tokens == 0 {
+            self.finish_zero_budget(prompt_tokens, start, response_tx);
+            return;
+        }
+        let prompt_len = prompt_tokens.len();
+        match self.engine.submit(&prompt_tokens, max_tokens, params) {
+            Ok(req_id) => {
+                self.batch_observability.record_prefill_start(prompt_len);
+                self.states.insert(
+                    req_id,
+                    ServeState {
+                        response_tx,
+                        cancelled,
+                        detok: StreamingDecodeState::new(&self.tokenizer, &prompt_tokens),
+                        stop: StopMatcher::new(stop_sequences),
+                        start,
+                        prompt_token_count: prompt_len,
+                        effective_prefill_len: prompt_len,
+                        max_tokens,
+                        generated_tokens: 0,
+                    },
+                );
+            }
+            Err(error) => {
+                let _ = response_tx.send(GenerateEvent::Error(format!(
+                    "OpenXLA submit failed: {error}"
+                )));
+            }
+        }
+    }
+
+    fn finish_zero_budget(
+        &self,
+        prompt_tokens: Vec<i32>,
+        start: Instant,
+        response_tx: mpsc::Sender<GenerateEvent>,
+    ) {
+        let prompt_len = prompt_tokens.len();
+        let detok = StreamingDecodeState::new(&self.tokenizer, &prompt_tokens);
+        let _ = response_tx.send(GenerateEvent::Done(detok.finish(start, prompt_len, 0)));
+    }
+
+    fn handle_preprocessed(&mut self, result: ImagePreprocessResult) {
+        let Some(state) = self.pending_images.remove(&result.job_id) else {
+            return;
+        };
+        if state.cancelled.load(Ordering::Acquire) {
+            return;
+        }
+        let prepared = match result.outcome {
+            ImagePreprocessOutcome::Prepared(prepared) => prepared,
+            ImagePreprocessOutcome::Cancelled => return,
+            ImagePreprocessOutcome::Failed(error) => {
+                let _ = state.response_tx.send(GenerateEvent::Error(format!(
+                    "OpenXLA image preprocessing failed: {error}"
+                )));
+                return;
+            }
+        };
+        if state.max_tokens == 0 {
+            self.finish_zero_budget(state.prompt_tokens, state.start, state.response_tx);
+            return;
+        }
+
+        let effective_prefill_len = prepared.sequence_len;
+        let prompt_token_count = state.prompt_tokens.len();
+        match self
+            .engine
+            .submit_prepared(prepared, state.max_tokens, state.params)
+        {
+            Ok(req_id) => {
+                // Internal throughput/KV accounting uses the expanded prepared
+                // length; the API result below retains the logical prompt count.
+                self.batch_observability
+                    .record_prefill_start(effective_prefill_len);
+                self.states.insert(
+                    req_id,
+                    ServeState {
+                        response_tx: state.response_tx,
+                        cancelled: state.cancelled,
+                        detok: StreamingDecodeState::new(&self.tokenizer, &state.prompt_tokens),
+                        stop: StopMatcher::new(state.stop_sequences),
+                        start: state.start,
+                        prompt_token_count,
+                        effective_prefill_len,
+                        max_tokens: state.max_tokens,
+                        generated_tokens: 0,
+                    },
+                );
+            }
+            Err(error) => {
+                let _ = state.response_tx.send(GenerateEvent::Error(format!(
+                    "OpenXLA prepared-prefill admission failed: {error}"
+                )));
+            }
+        }
+    }
+
+    pub(super) fn drain_preprocessed(&mut self) {
+        loop {
+            let received = match self.image_preprocessor.as_ref() {
+                Some(stage) => stage.try_recv(),
+                None => return,
+            };
+            match received {
+                Ok(result) => self.handle_preprocessed(result),
+                Err(mpsc::TryRecvError::Empty) => return,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.image_preprocessor = None;
+                    for (_, state) in self.pending_images.drain() {
+                        let _ = state.response_tx.send(GenerateEvent::Error(
+                            "OpenXLA image preprocessor stopped unexpectedly".to_string(),
+                        ));
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
+    fn handle(&mut self, request: ModelRequest) {
+        match request {
+            ModelRequest::Generate {
+                prompt,
+                prompt_token_ids,
+                options,
+                images,
+                audio,
+                videos,
+                response_tx,
+                cancelled,
+            } => self.admit(
+                prompt,
+                prompt_token_ids,
+                options,
+                images,
+                audio,
+                videos,
+                response_tx,
+                cancelled,
+            ),
+            ModelRequest::Shutdown => {
+                self.shutdown = true;
+                for state in self.pending_images.values() {
+                    state.cancelled.store(true, Ordering::Release);
+                }
+                self.pending_images.clear();
+            }
+        }
+    }
+
+    /// Block on the request channel only when no image result is outstanding.
+    /// With preprocessing in flight, a short timeout keeps the scheduler asleep
+    /// without delaying completion or active decode rows.
+    pub(super) fn drain_incoming(&mut self, block: bool) {
+        if block {
+            let request = if self.pending_images.is_empty() {
+                match self.request_rx.recv() {
+                    Ok(request) => request,
+                    Err(_) => {
+                        self.shutdown = true;
+                        return;
+                    }
+                }
+            } else {
+                match self.request_rx.recv_timeout(Duration::from_millis(2)) {
+                    Ok(request) => request,
+                    Err(mpsc::RecvTimeoutError::Timeout) => return,
+                    Err(mpsc::RecvTimeoutError::Disconnected) => {
+                        self.shutdown = true;
+                        return;
+                    }
+                }
+            };
+            self.handle(request);
+        }
+        loop {
+            match self.request_rx.try_recv() {
+                Ok(request) => self.handle(request),
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.shutdown = true;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn sample_params(options: &ServerGenerateOptions) -> SampleParams {
+    let sampling = &options.sampling;
+    SampleParams {
+        temperature: sampling.temperature,
+        top_k: sampling.top_k.max(0) as usize,
+        top_p: sampling.top_p,
+        min_p: sampling.min_p,
+        seed: sampling.seed,
+        repetition_penalty: sampling.repetition_penalty,
+        frequency_penalty: sampling.frequency_penalty,
+        presence_penalty: sampling.presence_penalty,
+        dry_multiplier: sampling.dry_multiplier,
+        dry_base: sampling.dry_base,
+        dry_allowed_length: sampling.dry_allowed_length,
+        dry_penalty_last_n: sampling.dry_penalty_last_n,
+        dry_sequence_breakers: sampling.dry_sequence_breakers.clone(),
+    }
+}

--- a/src/server/batch/xla_worker_admission.rs
+++ b/src/server/batch/xla_worker_admission.rs
@@ -21,6 +21,20 @@ use super::super::xla_preprocess::{
 };
 use super::*;
 
+pub(super) fn validate_xla_output_features(logprobs: bool, structured: bool) -> Result<(), String> {
+    if logprobs {
+        return Err(
+            "the OpenXLA backend does not support logprobs (no logit readback)".to_string(),
+        );
+    }
+    if structured {
+        return Err(
+            "the OpenXLA backend does not support structured / JSON-schema output".to_string(),
+        );
+    }
+    Ok(())
+}
+
 impl<E: XlaServingEngine> XlaServeWorker<E> {
     /// Validate, tokenize, and submit one request. Images enter the bounded
     /// preprocessing stage; text reaches the engine directly.
@@ -33,34 +47,20 @@ impl<E: XlaServingEngine> XlaServeWorker<E> {
         images: Vec<Vec<u8>>,
         audio: Vec<Vec<u8>>,
         videos: Vec<crate::server::media::ResolvedVideo>,
+        media: MediaRequestMetadata,
         response_tx: mpsc::Sender<GenerateEvent>,
         cancelled: Arc<AtomicBool>,
     ) {
-        if options.logprobs.enabled {
-            let _ = response_tx.send(GenerateEvent::Error(
-                "the OpenXLA backend does not support logprobs (no logit readback)".to_string(),
-            ));
+        if let Err(error) = media.validate_xla_raw_counts(images.len(), audio.len(), videos.len()) {
+            let _ = response_tx.send(GenerateEvent::Error(error));
             return;
         }
-        if options.structured.is_some() {
-            let _ = response_tx.send(GenerateEvent::Error(
-                "the OpenXLA backend does not support structured / JSON-schema output".to_string(),
-            ));
+        if let Err(error) =
+            validate_xla_output_features(options.logprobs.enabled, options.structured.is_some())
+        {
+            let _ = response_tx.send(GenerateEvent::Error(error));
             return;
         }
-        if !audio.is_empty() {
-            let _ = response_tx.send(GenerateEvent::Error(
-                "the OpenXLA backend does not support audio input yet".to_string(),
-            ));
-            return;
-        }
-        if !videos.is_empty() {
-            let _ = response_tx.send(GenerateEvent::Error(
-                "the OpenXLA backend does not support video input yet".to_string(),
-            ));
-            return;
-        }
-
         let prompt_tokens = match prompt_token_ids {
             Some(tokens) => tokens,
             None => {
@@ -109,6 +109,7 @@ impl<E: XlaServingEngine> XlaServeWorker<E> {
         let job = ImagePreprocessJob {
             job_id,
             token_ids: prompt_tokens.clone(),
+            expected_image_count: media.declared_images,
             images,
             cancelled: cancelled.clone(),
         };
@@ -280,6 +281,7 @@ impl<E: XlaServingEngine> XlaServeWorker<E> {
                 images,
                 audio,
                 videos,
+                media,
                 response_tx,
                 cancelled,
             } => self.admit(
@@ -289,6 +291,7 @@ impl<E: XlaServingEngine> XlaServeWorker<E> {
                 images,
                 audio,
                 videos,
+                media,
                 response_tx,
                 cancelled,
             ),

--- a/src/server/batch/xla_worker_tests.rs
+++ b/src/server/batch/xla_worker_tests.rs
@@ -1,0 +1,342 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+use std::io::Cursor;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, mpsc};
+use std::time::Duration;
+
+use image::{DynamicImage, ImageFormat};
+
+use super::*;
+use crate::FakeHostMultimodalPreprocessor;
+use crate::server::request_options::{RequestOptionOverrides, build_server_generate_options};
+use crate::server::{GenerationResult, ServerConfig};
+
+#[derive(Default)]
+struct FakeServingEngine {
+    next_id: u64,
+    active: BTreeSet<u64>,
+    text_submissions: Vec<Vec<i32>>,
+    prepared_submissions: Vec<(Vec<i32>, usize)>,
+}
+
+impl XlaServingEngine for FakeServingEngine {
+    fn b_max(&self) -> usize {
+        4
+    }
+
+    fn is_idle(&self) -> bool {
+        self.active.is_empty()
+    }
+
+    fn pending_len(&self) -> usize {
+        0
+    }
+
+    fn active_len(&self) -> usize {
+        self.active.len()
+    }
+
+    fn submit(
+        &mut self,
+        prompt: &[i32],
+        _max_new_tokens: usize,
+        _params: SampleParams,
+    ) -> Result<u64, String> {
+        self.text_submissions.push(prompt.to_vec());
+        Ok(self.activate())
+    }
+
+    fn submit_prepared(
+        &mut self,
+        prepared: PreparedPrefill,
+        _max_new_tokens: usize,
+        _params: SampleParams,
+    ) -> Result<u64, String> {
+        self.prepared_submissions
+            .push((prepared.token_ids, prepared.sequence_len));
+        Ok(self.activate())
+    }
+
+    fn cancel(&mut self, req_id: u64) -> bool {
+        self.active.remove(&req_id)
+    }
+
+    fn pump(&mut self) -> Result<Vec<EngineEvent>, String> {
+        let ids: Vec<_> = self.active.iter().copied().collect();
+        self.active.clear();
+        let mut events = Vec::with_capacity(ids.len() * 2);
+        for req_id in ids {
+            events.push(EngineEvent::Token { req_id, token: 0 });
+            events.push(EngineEvent::Finished {
+                req_id,
+                reason: XlaFinishReason::Length,
+            });
+        }
+        Ok(events)
+    }
+}
+
+impl FakeServingEngine {
+    fn activate(&mut self) -> u64 {
+        let req_id = self.next_id;
+        self.next_id += 1;
+        self.active.insert(req_id);
+        req_id
+    }
+}
+
+fn png_bytes() -> Vec<u8> {
+    let mut bytes = Vec::new();
+    DynamicImage::new_rgb8(2, 2)
+        .write_to(&mut Cursor::new(&mut bytes), ImageFormat::Png)
+        .unwrap();
+    bytes
+}
+
+fn options(max_tokens: usize) -> ServerGenerateOptions {
+    build_server_generate_options(
+        &ServerConfig::default(),
+        RequestOptionOverrides {
+            max_tokens: Some(max_tokens),
+            ..RequestOptionOverrides::default()
+        },
+    )
+}
+
+fn image_stage() -> ImagePreprocessStage {
+    ImagePreprocessStage::spawn_with_loader(2, || {
+        Ok(Some(Box::new(FakeHostMultimodalPreprocessor {
+            image_token_id: -200,
+            tokens_per_image: 3,
+            hidden_size: 4,
+            max_sequence_len: 32,
+        })))
+    })
+    .unwrap()
+    .unwrap()
+}
+
+fn worker(image_preprocessor: Option<ImagePreprocessStage>) -> XlaServeWorker<FakeServingEngine> {
+    let (_request_tx, request_rx) = mpsc::channel();
+    XlaServeWorker {
+        engine: FakeServingEngine::default(),
+        tokenizer: MlxcelTokenizer::stub(),
+        request_rx,
+        states: HashMap::new(),
+        batch_metrics: Arc::new(BatchMetrics::new()),
+        batch_observability: Arc::new(BatchObservability::new()),
+        image_preprocessor,
+        pending_images: HashMap::new(),
+        next_image_job_id: 0,
+        shutdown: false,
+    }
+}
+
+fn wait_for_preprocessing(worker: &mut XlaServeWorker<FakeServingEngine>) {
+    for _ in 0..500 {
+        worker.drain_preprocessed();
+        if worker.pending_images.is_empty() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    panic!("timed out waiting for image preprocessing");
+}
+
+fn receive_done(rx: &mpsc::Receiver<GenerateEvent>) -> GenerationResult {
+    loop {
+        match rx.recv_timeout(Duration::from_secs(1)).unwrap() {
+            GenerateEvent::Done(result) => return result,
+            GenerateEvent::Token(_) | GenerateEvent::TokenWithLogprobs(_, _) => {}
+            GenerateEvent::Error(error) => panic!("unexpected generation failure: {error}"),
+        }
+    }
+}
+
+#[test]
+fn mixed_text_and_image_admission_keeps_public_and_effective_lengths_distinct() {
+    let mut worker = worker(Some(image_stage()));
+    let (text_tx, text_rx) = mpsc::channel();
+    let (image_tx, image_rx) = mpsc::channel();
+
+    worker.admit(
+        String::new(),
+        Some(vec![10, 11]),
+        options(1),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        text_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+    worker.admit(
+        String::new(),
+        Some(vec![20, -200, 21]),
+        options(1),
+        vec![png_bytes()],
+        Vec::new(),
+        Vec::new(),
+        image_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+
+    assert_eq!(worker.engine.text_submissions, vec![vec![10, 11]]);
+    assert_eq!(worker.states.len(), 1);
+    wait_for_preprocessing(&mut worker);
+    assert_eq!(
+        worker.engine.prepared_submissions,
+        vec![(vec![20, -200, -200, -200, 21], 5)]
+    );
+    assert_eq!(worker.states.len(), 2);
+    assert_eq!(
+        worker
+            .batch_observability
+            .total_prefill_tokens
+            .load(Ordering::Relaxed),
+        7
+    );
+
+    let events = worker.engine.pump().unwrap();
+    worker.dispatch(events);
+    let text_result = receive_done(&text_rx);
+    let image_result = receive_done(&image_rx);
+    assert_eq!(text_result.prompt_tokens, 2);
+    assert_eq!(image_result.prompt_tokens, 3);
+    assert_eq!(text_result.completion_tokens, 1);
+    assert_eq!(image_result.completion_tokens, 1);
+    assert_eq!(
+        worker
+            .batch_metrics
+            .total_sequences_processed
+            .load(Ordering::Relaxed),
+        2
+    );
+}
+
+#[test]
+fn malformed_image_failure_does_not_disturb_active_text_request() {
+    let mut worker = worker(Some(image_stage()));
+    let (text_tx, text_rx) = mpsc::channel();
+    let (image_tx, image_rx) = mpsc::channel();
+
+    worker.admit(
+        String::new(),
+        Some(vec![1, 2]),
+        options(1),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        text_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+    worker.admit(
+        String::new(),
+        Some(vec![3, -200, 4]),
+        options(1),
+        vec![b"not-an-image".to_vec()],
+        Vec::new(),
+        Vec::new(),
+        image_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+
+    wait_for_preprocessing(&mut worker);
+    let GenerateEvent::Error(error) = image_rx.recv_timeout(Duration::from_secs(1)).unwrap() else {
+        panic!("malformed image must fail only its request");
+    };
+    assert!(error.contains("image preprocessing failed"));
+    assert_eq!(worker.states.len(), 1);
+    assert_eq!(worker.engine.active_len(), 1);
+
+    let events = worker.engine.pump().unwrap();
+    worker.dispatch(events);
+    assert_eq!(receive_done(&text_rx).prompt_tokens, 2);
+}
+
+#[test]
+fn unsupported_logprobs_and_audio_are_rejected_before_engine_admission() {
+    let mut worker = worker(Some(image_stage()));
+    let (logprobs_tx, logprobs_rx) = mpsc::channel();
+    let mut logprobs_options = options(1);
+    logprobs_options.logprobs.enabled = true;
+    worker.admit(
+        String::new(),
+        Some(vec![1]),
+        logprobs_options,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        logprobs_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+    let GenerateEvent::Error(error) = logprobs_rx.recv().unwrap() else {
+        panic!("logprobs must stay explicitly unsupported");
+    };
+    assert!(error.contains("does not support logprobs"));
+
+    let (audio_tx, audio_rx) = mpsc::channel();
+    worker.admit(
+        String::new(),
+        Some(vec![1]),
+        options(1),
+        Vec::new(),
+        vec![vec![1, 2, 3]],
+        Vec::new(),
+        audio_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+    let GenerateEvent::Error(error) = audio_rx.recv().unwrap() else {
+        panic!("audio must be explicitly unsupported");
+    };
+    assert!(error.contains("does not support audio"));
+    assert!(worker.engine.text_submissions.is_empty());
+    assert!(worker.engine.prepared_submissions.is_empty());
+}
+
+#[test]
+fn pending_preprocess_poll_timeout_does_not_shutdown_worker() {
+    let (request_tx, request_rx) = mpsc::channel();
+    let mut worker = XlaServeWorker {
+        engine: FakeServingEngine::default(),
+        tokenizer: MlxcelTokenizer::stub(),
+        request_rx,
+        states: HashMap::new(),
+        batch_metrics: Arc::new(BatchMetrics::new()),
+        batch_observability: Arc::new(BatchObservability::new()),
+        image_preprocessor: Some(image_stage()),
+        pending_images: HashMap::new(),
+        next_image_job_id: 0,
+        shutdown: false,
+    };
+    let (response_tx, _response_rx) = mpsc::channel();
+    worker.admit(
+        String::new(),
+        Some(vec![1, -200, 2]),
+        options(1),
+        vec![png_bytes()],
+        Vec::new(),
+        Vec::new(),
+        response_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+    assert_eq!(worker.pending_images.len(), 1);
+
+    worker.drain_incoming(true);
+
+    assert!(!worker.shutdown);
+    drop(request_tx);
+}

--- a/src/server/batch/xla_worker_tests.rs
+++ b/src/server/batch/xla_worker_tests.rs
@@ -117,6 +117,10 @@ fn options(max_tokens: usize) -> ServerGenerateOptions {
     )
 }
 
+fn media(images: usize, audio: usize, videos: usize) -> MediaRequestMetadata {
+    MediaRequestMetadata::from_resolved(images, audio, videos)
+}
+
 fn image_stage() -> ImagePreprocessStage {
     ImagePreprocessStage::spawn_with_loader(2, || {
         Ok(Some(Box::new(FakeHostMultimodalPreprocessor {
@@ -180,6 +184,7 @@ fn mixed_text_and_image_admission_keeps_public_and_effective_lengths_distinct() 
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        media(0, 0, 0),
         text_tx,
         Arc::new(AtomicBool::new(false)),
     );
@@ -190,6 +195,7 @@ fn mixed_text_and_image_admission_keeps_public_and_effective_lengths_distinct() 
         vec![png_bytes()],
         Vec::new(),
         Vec::new(),
+        media(1, 0, 0),
         image_tx,
         Arc::new(AtomicBool::new(false)),
     );
@@ -240,6 +246,7 @@ fn malformed_image_failure_does_not_disturb_active_text_request() {
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        media(0, 0, 0),
         text_tx,
         Arc::new(AtomicBool::new(false)),
     );
@@ -250,6 +257,7 @@ fn malformed_image_failure_does_not_disturb_active_text_request() {
         vec![b"not-an-image".to_vec()],
         Vec::new(),
         Vec::new(),
+        media(1, 0, 0),
         image_tx,
         Arc::new(AtomicBool::new(false)),
     );
@@ -265,10 +273,87 @@ fn malformed_image_failure_does_not_disturb_active_text_request() {
     let events = worker.engine.pump().unwrap();
     worker.dispatch(events);
     assert_eq!(receive_done(&text_rx).prompt_tokens, 2);
+
+    let (reuse_tx, reuse_rx) = mpsc::channel();
+    worker.admit(
+        String::new(),
+        Some(vec![5, -200, 6]),
+        options(1),
+        vec![png_bytes()],
+        Vec::new(),
+        Vec::new(),
+        media(1, 0, 0),
+        reuse_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+    wait_for_preprocessing(&mut worker);
+    let events = worker.engine.pump().unwrap();
+    worker.dispatch(events);
+    assert_eq!(receive_done(&reuse_rx).prompt_tokens, 3);
 }
 
 #[test]
-fn unsupported_logprobs_and_audio_are_rejected_before_engine_admission() {
+fn cancelled_image_does_not_disturb_active_text_or_prevent_slot_reuse() {
+    let mut worker = worker(Some(image_stage()));
+    let (text_tx, text_rx) = mpsc::channel();
+    let (cancelled_tx, cancelled_rx) = mpsc::channel();
+
+    worker.admit(
+        String::new(),
+        Some(vec![1, 2]),
+        options(1),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        media(0, 0, 0),
+        text_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+    worker.admit(
+        String::new(),
+        Some(vec![3, -200, 4]),
+        options(1),
+        vec![png_bytes()],
+        Vec::new(),
+        Vec::new(),
+        media(1, 0, 0),
+        cancelled_tx,
+        Arc::new(AtomicBool::new(true)),
+    );
+    wait_for_preprocessing(&mut worker);
+    assert!(cancelled_rx.try_recv().is_err());
+    assert_eq!(worker.states.len(), 1);
+
+    let events = worker.engine.pump().unwrap();
+    worker.dispatch(events);
+    assert_eq!(receive_done(&text_rx).prompt_tokens, 2);
+
+    let (reuse_tx, reuse_rx) = mpsc::channel();
+    worker.admit(
+        String::new(),
+        Some(vec![5, -200, 6]),
+        options(1),
+        vec![png_bytes()],
+        Vec::new(),
+        Vec::new(),
+        media(1, 0, 0),
+        reuse_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+    wait_for_preprocessing(&mut worker);
+    let events = worker.engine.pump().unwrap();
+    worker.dispatch(events);
+    assert_eq!(receive_done(&reuse_rx).prompt_tokens, 3);
+}
+
+#[test]
+fn unsupported_output_features_are_rejected_before_engine_admission() {
+    assert!(
+        admission::validate_xla_output_features(false, true)
+            .unwrap_err()
+            .contains("structured")
+    );
+
     let mut worker = worker(Some(image_stage()));
     let (logprobs_tx, logprobs_rx) = mpsc::channel();
     let mut logprobs_options = options(1);
@@ -280,6 +365,7 @@ fn unsupported_logprobs_and_audio_are_rejected_before_engine_admission() {
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        media(0, 0, 0),
         logprobs_tx,
         Arc::new(AtomicBool::new(false)),
     );
@@ -296,6 +382,7 @@ fn unsupported_logprobs_and_audio_are_rejected_before_engine_admission() {
         Vec::new(),
         vec![vec![1, 2, 3]],
         Vec::new(),
+        media(0, 1, 0),
         audio_tx,
         Arc::new(AtomicBool::new(false)),
     );
@@ -303,6 +390,69 @@ fn unsupported_logprobs_and_audio_are_rejected_before_engine_admission() {
         panic!("audio must be explicitly unsupported");
     };
     assert!(error.contains("does not support audio"));
+    assert!(worker.engine.text_submissions.is_empty());
+    assert!(worker.engine.prepared_submissions.is_empty());
+}
+
+#[test]
+fn declared_audio_video_and_unqualified_images_never_fall_back_to_text() {
+    let mut worker = worker(None);
+
+    for (media, expected) in [
+        (MediaRequestMetadata::new(0, 1, 0, 0, 0, 0), "audio"),
+        (MediaRequestMetadata::new(0, 0, 1, 0, 0, 0), "video"),
+    ] {
+        let (tx, rx) = mpsc::channel();
+        worker.admit(
+            String::new(),
+            Some(vec![1]),
+            options(1),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            media,
+            tx,
+            Arc::new(AtomicBool::new(false)),
+        );
+        let GenerateEvent::Error(error) = rx.recv().unwrap() else {
+            panic!("{expected} declaration must be rejected");
+        };
+        assert!(error.contains(expected));
+    }
+
+    let (partial_tx, partial_rx) = mpsc::channel();
+    worker.admit(
+        String::new(),
+        Some(vec![1]),
+        options(1),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        MediaRequestMetadata::new(1, 0, 0, 0, 0, 0),
+        partial_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+    let GenerateEvent::Error(error) = partial_rx.recv().unwrap() else {
+        panic!("dropped image declaration must be rejected");
+    };
+    assert!(error.contains("refusing text fallback"));
+
+    let (unsupported_tx, unsupported_rx) = mpsc::channel();
+    worker.admit(
+        String::new(),
+        Some(vec![1, -200, 2]),
+        options(1),
+        vec![png_bytes()],
+        Vec::new(),
+        Vec::new(),
+        media(1, 0, 0),
+        unsupported_tx,
+        Arc::new(AtomicBool::new(false)),
+    );
+    let GenerateEvent::Error(error) = unsupported_rx.recv().unwrap() else {
+        panic!("image input without qualified preprocessor must be rejected");
+    };
+    assert!(error.contains("does not support image input"));
     assert!(worker.engine.text_submissions.is_empty());
     assert!(worker.engine.prepared_submissions.is_empty());
 }
@@ -330,6 +480,7 @@ fn pending_preprocess_poll_timeout_does_not_shutdown_worker() {
         vec![png_bytes()],
         Vec::new(),
         Vec::new(),
+        media(1, 0, 0),
         response_tx,
         Arc::new(AtomicBool::new(false)),
     );

--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -68,7 +68,8 @@ use super::chat_template_kwargs::{
     strip_think_block,
 };
 use super::media::{
-    ResolvedVideo, extract_chat_audio_data, extract_chat_video_paths, try_extract_chat_image_data,
+    MediaRequestMetadata, ResolvedVideo, extract_chat_audio_data, extract_chat_video_paths,
+    try_extract_chat_image_data,
 };
 use super::prompt_cache::key::resolve_session_key;
 use super::types::ChatCompletionRequest;
@@ -77,6 +78,12 @@ use super::types::request::{ContentPart, Message, MessageContent, Tool};
 pub(crate) struct PreparedChatRequest {
     pub(crate) prompt: String,
     pub(crate) image_data: Vec<Vec<u8>>,
+    /// Cardinalities before and after the tolerant media resolver.
+    ///
+    /// MLX consumers retain their historical behavior. XLA carries this
+    /// metadata to its worker so invalid or partially resolved media cannot be
+    /// mistaken for a text-only request.
+    pub(crate) media: MediaRequestMetadata,
     /// Request-scoped Gemma 4 image soft-token budget, resolved from the
     /// `detail` / `max_soft_tokens` fields on the `image_url` content parts
     /// (see [`crate::server::types::request::ImageUrl`]).
@@ -225,15 +232,28 @@ pub(crate) async fn prepare_chat_request_with_cache(
         .image_soft_tokens()
         .map_err(|err| anyhow::anyhow!("{err}"))?;
 
+    let declared_images = request.image_urls().len();
+    let declared_audio = request.audio_inputs().len();
+    let declared_videos = request.video_urls().len();
     let (image_data, audio_data, videos) = tokio::join!(
         try_extract_chat_image_data(request),
         extract_chat_audio_data(request),
         extract_chat_video_paths(request),
     );
+    let image_data = image_data?;
+    let media = MediaRequestMetadata::new(
+        declared_images,
+        declared_audio,
+        declared_videos,
+        image_data.len(),
+        audio_data.len(),
+        videos.len(),
+    );
 
     Ok(PreparedChatRequest {
         prompt,
-        image_data: image_data?,
+        image_data,
+        media,
         image_soft_tokens,
         audio_data,
         videos,

--- a/src/server/diffusion_worker.rs
+++ b/src/server/diffusion_worker.rs
@@ -205,6 +205,7 @@ pub(crate) fn run_diffusion_worker_loop(
                 images,
                 audio,
                 videos,
+                media: _,
                 response_tx,
                 cancelled,
             } => {
@@ -510,6 +511,7 @@ pub(crate) fn run_llada2_worker_loop(
                 images,
                 audio,
                 videos,
+                media: _,
                 response_tx,
                 cancelled,
             } => {

--- a/src/server/media.rs
+++ b/src/server/media.rs
@@ -95,6 +95,99 @@ impl ResolvedVideo {
     }
 }
 
+/// Declared and successfully resolved media cardinality for one request.
+///
+/// Generic MLX paths intentionally remain tolerant of resolver failures. XLA
+/// uses both halves at its admission boundary so an invalid media declaration
+/// cannot collapse to an empty vector and silently become a text request.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct MediaRequestMetadata {
+    pub(crate) declared_images: usize,
+    pub(crate) declared_audio: usize,
+    pub(crate) declared_videos: usize,
+    pub(crate) resolved_images: usize,
+    pub(crate) resolved_audio: usize,
+    pub(crate) resolved_videos: usize,
+}
+
+impl MediaRequestMetadata {
+    #[must_use]
+    pub(crate) const fn new(
+        declared_images: usize,
+        declared_audio: usize,
+        declared_videos: usize,
+        resolved_images: usize,
+        resolved_audio: usize,
+        resolved_videos: usize,
+    ) -> Self {
+        Self {
+            declared_images,
+            declared_audio,
+            declared_videos,
+            resolved_images,
+            resolved_audio,
+            resolved_videos,
+        }
+    }
+
+    /// Metadata for non-chat/internal callers that already supply raw media.
+    ///
+    /// These callers have no separate resolution phase, so declaration and
+    /// resolution cardinalities are identical and their historical behavior is
+    /// unchanged.
+    #[must_use]
+    pub(crate) const fn from_resolved(images: usize, audio: usize, videos: usize) -> Self {
+        Self::new(images, audio, videos, images, audio, videos)
+    }
+
+    /// Validate the XLA request seam without changing tolerant MLX resolution.
+    ///
+    /// Audio/video declarations are rejected from the declared counts so a
+    /// failed resolver cannot erase an unsupported modality. Images require a
+    /// one-to-one declaration → raw payload handoff; decoded cardinality is
+    /// checked later by the bounded preprocessing worker.
+    #[cfg_attr(not(feature = "xla-iree"), allow(dead_code))]
+    pub(crate) fn validate_xla_raw_counts(
+        self,
+        images: usize,
+        audio: usize,
+        videos: usize,
+    ) -> Result<(), String> {
+        if self.declared_audio > 0 {
+            return Err(format!(
+                "the OpenXLA backend does not support audio input yet ({} declared)",
+                self.declared_audio
+            ));
+        }
+        if self.declared_videos > 0 {
+            return Err(format!(
+                "the OpenXLA backend does not support video input yet ({} declared)",
+                self.declared_videos
+            ));
+        }
+        if (
+            self.resolved_images,
+            self.resolved_audio,
+            self.resolved_videos,
+        ) != (images, audio, videos)
+        {
+            return Err(format!(
+                "OpenXLA media handoff cardinality changed after resolution: metadata \
+                 image/audio/video={}/{}/{}, payloads={images}/{audio}/{videos}",
+                self.resolved_images, self.resolved_audio, self.resolved_videos
+            ));
+        }
+        if self.declared_images != self.resolved_images {
+            return Err(format!(
+                "OpenXLA image resolution cardinality mismatch: {} image input(s) declared, \
+                 {} raw payload(s) resolved; refusing text fallback",
+                self.declared_images, self.resolved_images
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Maximum encoded image payload size after base64/HTTP/file resolution: 64 MiB.
 ///
 /// This keeps common VLM uploads well inside the default while bounding the

--- a/src/server/media_tests.rs
+++ b/src/server/media_tests.rs
@@ -16,7 +16,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use super::{
-    ImageInputLimits, collect_image_data, extract_chat_image_data,
+    ImageInputLimits, MediaRequestMetadata, collect_image_data, extract_chat_image_data,
     extract_chat_video_paths_with_allowlist, read_image_url, scan_insecure_allowlist_dirs,
     try_collect_image_data_with_limits, try_read_image_url_with_limits,
 };
@@ -127,6 +127,68 @@ async fn collect_image_data_skips_invalid_entries() {
     ])
     .await;
     assert_eq!(images, vec![b"hello".to_vec()]);
+}
+
+#[tokio::test]
+async fn xla_rejects_all_invalid_images_instead_of_text_fallback() {
+    let images = try_collect_image_data_with_limits(
+        [
+            "ftp://example.com/image.png",
+            "data:image/png;base64,%%%bad%%%",
+        ],
+        ImageInputLimits::default(),
+    )
+    .await
+    .unwrap();
+    assert!(images.is_empty(), "generic resolution remains tolerant");
+
+    let media = MediaRequestMetadata::new(2, 0, 0, images.len(), 0, 0);
+    let error = media
+        .validate_xla_raw_counts(images.len(), 0, 0)
+        .unwrap_err();
+    assert!(error.contains("2 image input(s) declared"));
+    assert!(error.contains("refusing text fallback"));
+}
+
+#[tokio::test]
+async fn xla_rejects_partial_image_resolution_instead_of_partial_execution() {
+    let images = try_collect_image_data_with_limits(
+        [
+            "data:image/png;base64,aGVsbG8=",
+            "data:image/png;base64,%%%bad%%%",
+        ],
+        ImageInputLimits::default(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(images, vec![b"hello".to_vec()]);
+
+    let media = MediaRequestMetadata::new(2, 0, 0, images.len(), 0, 0);
+    let error = media
+        .validate_xla_raw_counts(images.len(), 0, 0)
+        .unwrap_err();
+    assert!(error.contains("2 image input(s) declared"));
+    assert!(error.contains("1 raw payload(s) resolved"));
+}
+
+#[tokio::test]
+async fn xla_rejects_oversized_image_dropped_by_tolerant_resolver() {
+    let limits = ImageInputLimits {
+        max_payload_bytes: 2,
+        ..ImageInputLimits::default()
+    };
+    let images = try_collect_image_data_with_limits(["data:image/png;base64,aGVsbG8="], limits)
+        .await
+        .unwrap();
+    assert!(images.is_empty(), "generic resolution remains tolerant");
+
+    let media = MediaRequestMetadata::new(1, 0, 0, images.len(), 0, 0);
+    assert!(
+        media
+            .validate_xla_raw_counts(images.len(), 0, 0)
+            .unwrap_err()
+            .contains("refusing text fallback")
+    );
 }
 
 #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -73,6 +73,7 @@ pub use config::{
     DecodeStorageBackend, PipelineParallelRuntimeConfig, PreemptionPolicy,
     RemotePipelineStageConfig, ServerConfig, ServerGenerateOptions,
 };
+pub(crate) use media::current_image_input_limits;
 pub use media::{
     DEFAULT_MAX_IMAGE_DECODE_ALLOC_BYTES, DEFAULT_MAX_IMAGE_HEIGHT, DEFAULT_MAX_IMAGE_PAYLOAD_SIZE,
     DEFAULT_MAX_IMAGE_WIDTH, DEFAULT_MAX_IMAGES_PER_REQUEST, ImageInputLimits,

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -28,7 +28,7 @@ use mlxcel_core::sampling::TokenLogprobData;
 
 use crate::server::ServerGenerateOptions;
 use crate::server::batch::BatchObservability;
-use crate::server::media::ResolvedVideo;
+use crate::server::media::{MediaRequestMetadata, ResolvedVideo};
 use crate::server::state::BatchMetrics;
 
 /// Request to the model thread
@@ -58,6 +58,13 @@ pub(crate) enum ModelRequest {
         /// path — closing the canonicalise → ffmpeg-open TOCTOU window.
         /// Empty for non-video requests.
         videos: Vec<ResolvedVideo>,
+        /// Declared and resolved media counts retained from the HTTP boundary.
+        ///
+        /// MLX/diffusion workers ignore this metadata and keep their tolerant
+        /// resolver behavior. XLA validates it before deciding whether a
+        /// request is text-only.
+        #[cfg_attr(not(feature = "xla-iree"), allow(dead_code))]
+        media: MediaRequestMetadata,
         response_tx: mpsc::Sender<GenerateEvent>,
         /// Cancellation flag set by the SSE sender when the client disconnects.
         /// The `BatchScheduler` polls this to abort orphaned sequences.
@@ -890,7 +897,23 @@ impl ModelProvider {
         audio: Vec<Vec<u8>>,
         videos: Vec<ResolvedVideo>,
     ) -> Result<GenerationResult> {
-        let response_rx = self.send_generate_request(prompt, options, images, audio, videos)?;
+        let media = MediaRequestMetadata::from_resolved(images.len(), audio.len(), videos.len());
+        self.generate_with_media_and_videos_declared(prompt, options, images, audio, videos, media)
+    }
+
+    /// Generation entry used by prepared HTTP requests that retain declared
+    /// media cardinality across tolerant resolution.
+    pub(crate) fn generate_with_media_and_videos_declared(
+        &self,
+        prompt: String,
+        options: ServerGenerateOptions,
+        images: Vec<Vec<u8>>,
+        audio: Vec<Vec<u8>>,
+        videos: Vec<ResolvedVideo>,
+        media: MediaRequestMetadata,
+    ) -> Result<GenerationResult> {
+        let response_rx = self
+            .send_generate_request_with_metadata(prompt, options, images, audio, videos, media)?;
         drain_generation_events(response_rx, self.decode_hang_timeout, |_| {})
     }
 
@@ -1020,8 +1043,31 @@ impl ModelProvider {
     where
         F: FnMut(String, Option<TokenLogprobData>),
     {
-        let response_rx = self.send_generate_request_with_cancellation(
-            prompt, options, images, audio, videos, cancelled,
+        let media = MediaRequestMetadata::from_resolved(images.len(), audio.len(), videos.len());
+        self.generate_streaming_with_logprobs_cancellable_videos_declared(
+            prompt, options, images, audio, videos, media, cancelled, callback,
+        )
+    }
+
+    /// Streaming entry used by prepared HTTP requests that retain declared
+    /// media cardinality across tolerant resolution.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn generate_streaming_with_logprobs_cancellable_videos_declared<F>(
+        &self,
+        prompt: String,
+        options: ServerGenerateOptions,
+        images: Vec<Vec<u8>>,
+        audio: Vec<Vec<u8>>,
+        videos: Vec<ResolvedVideo>,
+        media: MediaRequestMetadata,
+        cancelled: Arc<AtomicBool>,
+        callback: F,
+    ) -> Result<GenerationResult>
+    where
+        F: FnMut(String, Option<TokenLogprobData>),
+    {
+        let response_rx = self.send_generate_request_with_cancellation_and_metadata(
+            prompt, options, images, audio, videos, media, cancelled,
         )?;
         drain_generation_events_with_logprobs(response_rx, self.decode_hang_timeout, callback)
     }
@@ -1034,12 +1080,26 @@ impl ModelProvider {
         audio: Vec<Vec<u8>>,
         videos: Vec<ResolvedVideo>,
     ) -> Result<mpsc::Receiver<GenerateEvent>> {
-        self.send_generate_request_with_cancellation(
+        let media = MediaRequestMetadata::from_resolved(images.len(), audio.len(), videos.len());
+        self.send_generate_request_with_metadata(prompt, options, images, audio, videos, media)
+    }
+
+    fn send_generate_request_with_metadata(
+        &self,
+        prompt: String,
+        options: ServerGenerateOptions,
+        images: Vec<Vec<u8>>,
+        audio: Vec<Vec<u8>>,
+        videos: Vec<ResolvedVideo>,
+        media: MediaRequestMetadata,
+    ) -> Result<mpsc::Receiver<GenerateEvent>> {
+        self.send_generate_request_with_cancellation_and_metadata(
             prompt,
             options,
             images,
             audio,
             videos,
+            media,
             Arc::new(AtomicBool::new(false)),
         )
     }
@@ -1056,6 +1116,23 @@ impl ModelProvider {
         images: Vec<Vec<u8>>,
         audio: Vec<Vec<u8>>,
         videos: Vec<ResolvedVideo>,
+        cancelled: Arc<AtomicBool>,
+    ) -> Result<mpsc::Receiver<GenerateEvent>> {
+        let media = MediaRequestMetadata::from_resolved(images.len(), audio.len(), videos.len());
+        self.send_generate_request_with_cancellation_and_metadata(
+            prompt, options, images, audio, videos, media, cancelled,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn send_generate_request_with_cancellation_and_metadata(
+        &self,
+        prompt: String,
+        options: ServerGenerateOptions,
+        images: Vec<Vec<u8>>,
+        audio: Vec<Vec<u8>>,
+        videos: Vec<ResolvedVideo>,
+        media: MediaRequestMetadata,
         cancelled: Arc<AtomicBool>,
     ) -> Result<mpsc::Receiver<GenerateEvent>> {
         let (response_tx, response_rx) = mpsc::channel();
@@ -1084,6 +1161,7 @@ impl ModelProvider {
                 images,
                 audio,
                 videos,
+                media,
                 response_tx,
                 cancelled,
             })

--- a/src/server/model_worker.rs
+++ b/src/server/model_worker.rs
@@ -1016,6 +1016,22 @@ pub(crate) fn spawn_xla_model_worker(
                     return;
                 }
             };
+            let mut worker = match crate::server::batch::XlaServeWorker::new(
+                engine,
+                tokenizer,
+                model_path,
+                request_rx,
+                batch_metrics,
+                batch_observability,
+            ) {
+                Ok(worker) => worker,
+                Err(err) => {
+                    tracing::error!(
+                        "Failed to load the OpenXLA image preprocessor/runtime bundle: {err}"
+                    );
+                    return;
+                }
+            };
             let load_elapsed = load_start.elapsed();
             tracing::info!(
                 worker_model_id = %worker_model_id,
@@ -1024,14 +1040,6 @@ pub(crate) fn spawn_xla_model_worker(
                 load_elapsed.as_secs_f64(),
             );
             loaded.store(true, Ordering::Release);
-
-            let mut worker = crate::server::batch::XlaServeWorker::new(
-                engine,
-                tokenizer,
-                request_rx,
-                batch_metrics,
-                batch_observability,
-            );
             worker.serve();
         })
     })

--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -622,6 +622,10 @@ fn service_unavailable(message: &str) -> Response {
         .into_response()
 }
 
+fn has_declared_media(media: super::media::MediaRequestMetadata) -> bool {
+    media.declared_images > 0 || media.declared_audio > 0 || media.declared_videos > 0
+}
+
 /// Core chat routing logic: tokenizes, sends to prefill, merges result.
 async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> Result<Response> {
     // Admission control first: reject with 503 when the cluster cannot take the
@@ -641,10 +645,7 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
     .await
     .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    if !prepared.image_data.is_empty()
-        || !prepared.audio_data.is_empty()
-        || !prepared.videos.is_empty()
-    {
+    if has_declared_media(prepared.media) {
         anyhow::bail!("the disaggregated router supports text-only requests");
     }
 

--- a/src/server/router_front_tests.rs
+++ b/src/server/router_front_tests.rs
@@ -25,6 +25,19 @@
 
 use super::*;
 
+#[test]
+fn text_only_router_rejects_declared_media_even_when_resolution_drops_it() {
+    let invalid_image = super::super::media::MediaRequestMetadata::new(1, 0, 0, 0, 0, 0);
+    let invalid_audio = super::super::media::MediaRequestMetadata::new(0, 1, 0, 0, 0, 0);
+    let invalid_video = super::super::media::MediaRequestMetadata::new(0, 0, 1, 0, 0, 0);
+    assert!(has_declared_media(invalid_image));
+    assert!(has_declared_media(invalid_audio));
+    assert!(has_declared_media(invalid_video));
+    assert!(!has_declared_media(
+        super::super::media::MediaRequestMetadata::default()
+    ));
+}
+
 /// When the worker reports an authoritative count, it is used verbatim even if
 /// it differs from the emitted-piece count. This is the byte-fallback case: a
 /// Gemma `<0xXX>` sequence produces fewer text pieces than model tokens, so the

--- a/src/server/routes/anthropic.rs
+++ b/src/server/routes/anthropic.rs
@@ -193,13 +193,16 @@ async fn non_stream_messages(
         &prepared.audio_data,
     );
 
-    let result = match state.model_provider.generate_with_media_and_videos(
-        prepared.prompt,
-        options,
-        prepared.image_data,
-        prepared.audio_data,
-        prepared.videos,
-    ) {
+    let result = match state
+        .model_provider
+        .generate_with_media_and_videos_declared(
+            prepared.prompt,
+            options,
+            prepared.image_data,
+            prepared.audio_data,
+            prepared.videos,
+            prepared.media,
+        ) {
         Ok(r) => r,
         Err(e) => {
             return AnthropicErrorResponse::api_error(format!("Generation failed: {e}"))
@@ -365,12 +368,13 @@ async fn stream_messages(
 
         let result = state
             .model_provider
-            .generate_streaming_with_logprobs_cancellable_videos(
+            .generate_streaming_with_logprobs_cancellable_videos_declared(
                 prepared.prompt,
                 options,
                 prepared.image_data,
                 prepared.audio_data,
                 prepared.videos,
+                prepared.media,
                 cancelled,
                 |token, _lp| {
                     if let Ok(mut acc) = acc_clone.lock() {

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -438,12 +438,13 @@ async fn non_stream_chat_completion(
     // model supports video.
     let result = state
         .model_provider
-        .generate_with_media_and_videos(
+        .generate_with_media_and_videos_declared(
             prepared.prompt,
             options,
             prepared.image_data,
             prepared.audio_data,
             prepared.videos,
+            prepared.media,
         )
         .map_err(|e| ErrorResponse::new(format!("Generation error: {e}"), "server_error"))?;
 
@@ -746,12 +747,13 @@ async fn stream_chat_completion(
 
         let result = state
             .model_provider
-            .generate_streaming_with_logprobs_cancellable_videos(
+            .generate_streaming_with_logprobs_cancellable_videos_declared(
                 prepared.prompt,
                 options,
                 prepared.image_data,
                 prepared.audio_data,
                 prepared.videos,
+                prepared.media,
                 cancelled,
                 |token, lp_data| {
                     // Single lock per token (issue #633): accumulate raw text,

--- a/src/server/routes/responses.rs
+++ b/src/server/routes/responses.rs
@@ -234,13 +234,16 @@ async fn non_stream_create_response(
         &prepared.audio_data,
     );
 
-    let result = state.model_provider.generate_with_media_and_videos(
-        prepared.prompt,
-        options,
-        prepared.image_data,
-        prepared.audio_data,
-        prepared.videos,
-    );
+    let result = state
+        .model_provider
+        .generate_with_media_and_videos_declared(
+            prepared.prompt,
+            options,
+            prepared.image_data,
+            prepared.audio_data,
+            prepared.videos,
+            prepared.media,
+        );
 
     let result = match result {
         Ok(r) => r,
@@ -423,12 +426,13 @@ async fn stream_create_response(
 
         let result = state_for_task
             .model_provider
-            .generate_streaming_with_logprobs_cancellable_videos(
+            .generate_streaming_with_logprobs_cancellable_videos_declared(
                 prepared.prompt,
                 options,
                 prepared.image_data,
                 prepared.audio_data,
                 prepared.videos,
+                prepared.media,
                 cancelled,
                 |token, _lp| {
                     if let Ok(mut acc) = acc_clone.lock() {


### PR DESCRIPTION
## Summary

- load the qualified LLaVA host preprocessor alongside XLA sessions and report multimodal capability only when the complete path is available
- route CLI images through the shared bounded decode and prepared-prefill contract
- add a bounded asynchronous image-preprocessing stage to continuous-batch serving, preserving logical usage counts separately from effective prefill lengths
- recognize nested LLaVA text configs and `language_model.*` checkpoint weights required by the real LLaVA Interleave target
- keep audio, video, logprobs, and structured output explicitly unsupported, with per-request image failure and cancellation isolation

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p mlxcel --lib --tests --features xla-iree -- -D warnings`
- `cargo check -p mlxcel --lib --tests --features xla-backend`
- `cargo check -p mlxcel --lib --tests --features xla-iree`
- focused XLA preprocessing/worker tests: 9 passed
- nested LLaVA config regression: 1 passed
- LLaVA Interleave 384/14 loader regression: 1 passed
- XLA scaffold/capability regression: 1 passed
- real IREE CLI image generation with `llava-interleave-qwen-0.5b-bf16`: generated one token successfully
- real OpenAI-compatible streaming image request: returned `The`, `finish_reason=length`, usage `24/1/25`, `[DONE]`; subsequent `/health` returned `status=ok`

The full 4,583-test `xla-backend` library run progressed through the affected tests, including the updated XLA scaffold regression, but the process aborted at the existing CUDA-only `models::bitnet::tests::bitlinear_matmul_known_ternary_case` because this host has no CUDA backend.

Closes #861
