### PR TITLE
test(xla): validate a LLaVA reference architecture end to end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,3 +311,10 @@ required-features = ["xla-iree"]
 [[example]]
 name = "xla_traj_dump"
 required-features = ["xla-iree"]
+
+# Independent LLaVA stage capture against the pinned HF oracle (#862).
+# Host vision/projector diagnostics require the qualified CUDA-backed MLX path,
+# while text prefill/decode run on the selected IREE CPU or CUDA device.
+[[example]]
+name = "xla_llava_reference_check"
+required-features = ["xla-diagnostics"]

--- a/examples/xla_llava_reference_check.rs
+++ b/examples/xla_llava_reference_check.rs
@@ -1,0 +1,528 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Diagnostics-only LLaVA reference capture for issue #862.
+//!
+//! The host stages come from the same qualified preprocessor as CLI/server
+//! image requests. The decoder stages come from one production IREE ragged
+//! bundle, with compact selected-KV readback enabled only by
+//! `xla-diagnostics`. Generated binary captures stay outside Git and are
+//! compared by `spike/openxla/llava_reference_oracle.py`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use image::DynamicImage;
+use mlxcel::{
+    HostMultimodalPreprocessor, LlavaHostPreprocessor, OwnedTensor, PreparedPositions,
+    PreparedTensorDType, initialize_runtime, server::ChatTemplateProcessor,
+    tokenizer::load_tokenizer,
+};
+use mlxcel_xla::LlavaReferenceDiagnosticEngine;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+#[derive(Debug, Deserialize)]
+struct ReferenceManifest {
+    kv_selection: KvSelection,
+    generation: Generation,
+    cases: Vec<ReferenceCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KvSelection {
+    width: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct Generation {
+    max_new_tokens: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReferenceCase {
+    name: String,
+    user_prompt: String,
+    text: String,
+    image_count: usize,
+    unexpanded_input_ids: Vec<i32>,
+}
+
+const VISION_BLOCK0_STAGES: [&str; 12] = [
+    "vision_block0_layer_norm1",
+    "vision_block0_q_proj",
+    "vision_block0_k_proj",
+    "vision_block0_v_proj",
+    "vision_block0_attention_context",
+    "vision_block0_attention_output",
+    "vision_block0_attention_residual",
+    "vision_block0_layer_norm2",
+    "vision_block0_mlp_fc1",
+    "vision_block0_mlp_activation",
+    "vision_block0_mlp_fc2",
+    "vision_block0_output",
+];
+
+fn argument(flag: &str) -> Option<String> {
+    let args: Vec<String> = std::env::args().collect();
+    args.iter()
+        .position(|value| value == flag)
+        .and_then(|index| args.get(index + 1))
+        .cloned()
+}
+
+fn required_path(flag: &str) -> PathBuf {
+    argument(flag)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| panic!("missing required {flag}"))
+}
+
+fn required_usize(flag: &str, default: usize) -> usize {
+    argument(flag)
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("{flag} must be an unsigned integer"))
+        })
+        .unwrap_or(default)
+}
+
+fn dtype_name(dtype: PreparedTensorDType) -> &'static str {
+    match dtype {
+        PreparedTensorDType::Float16 => "float16",
+        PreparedTensorDType::BFloat16 => "bfloat16",
+        PreparedTensorDType::Float32 => "float32",
+        PreparedTensorDType::Int32 => "int32",
+        _ => panic!("unsupported future prepared tensor dtype"),
+    }
+}
+
+fn write_raw(
+    out: &Path,
+    case: &str,
+    stage: &str,
+    bytes: &[u8],
+    dtype: &str,
+    shape: &[usize],
+) -> Value {
+    let filename = format!("{case}.{stage}.bin");
+    fs::write(out.join(&filename), bytes).unwrap_or_else(|error| {
+        panic!(
+            "write {} capture {}: {error}",
+            stage,
+            out.join(&filename).display()
+        )
+    });
+    json!({"file": filename, "dtype": dtype, "shape": shape})
+}
+
+fn write_tensor(out: &Path, case: &str, stage: &str, tensor: &OwnedTensor) -> Value {
+    write_raw(
+        out,
+        case,
+        stage,
+        &tensor.bytes,
+        dtype_name(tensor.dtype),
+        &tensor.shape,
+    )
+}
+
+fn i32_bytes(values: &[i32]) -> Vec<u8> {
+    values
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect()
+}
+
+fn f32_bytes(values: &[f32]) -> Vec<u8> {
+    values
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect()
+}
+
+fn peak_rss_kib() -> Option<u64> {
+    fs::read_to_string("/proc/self/status")
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("VmHWM:"))
+        .and_then(|value| value.split_whitespace().next())
+        .and_then(|value| value.parse().ok())
+}
+
+fn mem_available_kib() -> Option<u64> {
+    fs::read_to_string("/proc/meminfo")
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("MemAvailable:"))
+        .and_then(|value| value.split_whitespace().next())
+        .and_then(|value| value.parse().ok())
+}
+
+fn positions(value: &PreparedPositions, sequence_len: usize) -> Vec<i32> {
+    match value {
+        PreparedPositions::Sequential { start, length } => {
+            assert_eq!(*start, 0);
+            assert_eq!(*length, sequence_len);
+            (0..sequence_len)
+                .map(|position| i32::try_from(position).expect("position fits i32"))
+                .collect()
+        }
+        other => panic!("LLaVA reference expected sequential positions, got {other:?}"),
+    }
+}
+
+fn render_converted_prompt(
+    processor: &ChatTemplateProcessor,
+    user_prompt: &str,
+    image_count: usize,
+) -> String {
+    let mut content: Vec<Value> = (0..image_count).map(|_| json!({"type": "image"})).collect();
+    content.push(json!({"type": "text", "text": user_prompt}));
+    processor
+        .apply_raw(
+            &json!([{
+                "role": "user",
+                "content": content,
+            }]),
+            None,
+        )
+        .expect("render converted checkpoint chat template")
+}
+
+fn main() {
+    let model = required_path("--model");
+    let reference_dir = required_path("--reference");
+    let image_path = required_path("--image");
+    let out = required_path("--out");
+    let device = argument("--device").unwrap_or_else(|| "local-task".to_string());
+    let context_capacity = required_usize("--context-capacity", 2048);
+    let runtime = initialize_runtime();
+    mlxcel_core::reset_peak_memory();
+    let mem_available_before_kib = mem_available_kib();
+    fs::create_dir_all(&out)
+        .unwrap_or_else(|error| panic!("create capture directory {}: {error}", out.display()));
+    let reference: ReferenceManifest = serde_json::from_str(
+        &fs::read_to_string(reference_dir.join("manifest.json"))
+            .unwrap_or_else(|error| panic!("read reference manifest: {error}")),
+    )
+    .unwrap_or_else(|error| panic!("parse reference manifest: {error}"));
+    let image = image::open(&image_path)
+        .unwrap_or_else(|error| panic!("open fixture image {}: {error}", image_path.display()))
+        .into_rgb8();
+    let image = DynamicImage::ImageRgb8(image);
+
+    let host_load_started = Instant::now();
+    let preprocessor = LlavaHostPreprocessor::load(&model)
+        .unwrap_or_else(|error| panic!("load LLaVA host preprocessor: {error}"));
+    let chat_template = ChatTemplateProcessor::from_model_path(&model)
+        .unwrap_or_else(|error| panic!("load converted checkpoint chat template: {error}"))
+        .expect("converted checkpoint must include a chat template");
+    let tokenizer = load_tokenizer(&model)
+        .unwrap_or_else(|error| panic!("load converted checkpoint tokenizer: {error}"));
+    let host_load_seconds = host_load_started.elapsed().as_secs_f64();
+    let compile_started = Instant::now();
+    let mut engine = LlavaReferenceDiagnosticEngine::load(&model, &device, context_capacity)
+        .unwrap_or_else(|error| panic!("load LLaVA IREE diagnostic engine: {error}"));
+    let compile_load_seconds = compile_started.elapsed().as_secs_f64();
+
+    let mut captured_cases = Vec::new();
+    for reference_case in &reference.cases {
+        let converted_prompt = render_converted_prompt(
+            &chat_template,
+            &reference_case.user_prompt,
+            reference_case.image_count,
+        );
+        assert_eq!(
+            converted_prompt, reference_case.text,
+            "source and converted chat templates diverged for {}",
+            reference_case.name
+        );
+        let converted_ids: Vec<i32> = tokenizer
+            .encode(&converted_prompt, false)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "encode converted prompt for {}: {error}",
+                    reference_case.name
+                )
+            })
+            .into_iter()
+            .map(|token| i32::try_from(token).expect("token id fits i32"))
+            .collect();
+        assert_eq!(
+            converted_ids, reference_case.unexpanded_input_ids,
+            "source and converted tokenizer ids diverged for {}",
+            reference_case.name
+        );
+        let converted_u32: Vec<u32> = converted_ids
+            .iter()
+            .map(|&token| u32::try_from(token).expect("token id is non-negative"))
+            .collect();
+        let decoded = tokenizer
+            .decode(&converted_u32, false)
+            .unwrap_or_else(|error| panic!("decode converted prompt: {error}"));
+        assert_eq!(
+            decoded, converted_prompt,
+            "converted tokenizer round-trip diverged for {}",
+            reference_case.name
+        );
+        let images: Vec<DynamicImage> = (0..reference_case.image_count)
+            .map(|_| image.clone())
+            .collect();
+        let preprocessing_started = Instant::now();
+        let capture = preprocessor
+            .prepare_with_reference_diagnostics(&converted_ids, &images)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "prepare LLaVA reference case {}: {error}",
+                    reference_case.name
+                )
+            });
+        let preprocessing_seconds = preprocessing_started.elapsed().as_secs_f64();
+        let run = engine
+            .capture(
+                &capture.prepared,
+                reference.kv_selection.width,
+                reference.generation.max_new_tokens,
+            )
+            .unwrap_or_else(|error| {
+                panic!(
+                    "run LLaVA reference case {} on {device}: {error}",
+                    reference_case.name
+                )
+            });
+
+        let mut arrays = serde_json::Map::new();
+        if let Some(pixel_values) = &capture.pixel_values {
+            arrays.insert(
+                "processor_pixel_values".to_string(),
+                write_tensor(
+                    &out,
+                    &reference_case.name,
+                    "processor_pixel_values",
+                    pixel_values,
+                ),
+            );
+        }
+        arrays.insert(
+            "expanded_token_ids".to_string(),
+            write_raw(
+                &out,
+                &reference_case.name,
+                "expanded_token_ids",
+                &i32_bytes(&capture.prepared.token_ids),
+                "int32",
+                &[1, capture.prepared.sequence_len],
+            ),
+        );
+        let prepared_positions =
+            positions(&capture.prepared.positions, capture.prepared.sequence_len);
+        arrays.insert(
+            "positions".to_string(),
+            write_raw(
+                &out,
+                &reference_case.name,
+                "positions",
+                &i32_bytes(&prepared_positions),
+                "int32",
+                &[1, capture.prepared.sequence_len],
+            ),
+        );
+        let attention_mask = vec![1i32; capture.prepared.sequence_len];
+        arrays.insert(
+            "attention_mask".to_string(),
+            write_raw(
+                &out,
+                &reference_case.name,
+                "attention_mask",
+                &i32_bytes(&attention_mask),
+                "int32",
+                &[1, capture.prepared.sequence_len],
+            ),
+        );
+        if let Some(projected) = &capture.projected_image_features {
+            let selected = capture
+                .selected_vision_features
+                .as_ref()
+                .expect("projected features require selected vision features");
+            for (index, hidden_state) in capture.vision_hidden_states.iter().enumerate() {
+                let stage = format!("vision_hidden_state_{index:02}");
+                arrays.insert(
+                    stage.clone(),
+                    write_tensor(&out, &reference_case.name, &stage, hidden_state),
+                );
+            }
+            assert_eq!(
+                capture.vision_block0_states.len(),
+                VISION_BLOCK0_STAGES.len(),
+                "SigLIP diagnostics must capture every first-block sub-stage"
+            );
+            for (stage, state) in VISION_BLOCK0_STAGES
+                .iter()
+                .zip(&capture.vision_block0_states)
+            {
+                arrays.insert(
+                    (*stage).to_string(),
+                    write_tensor(&out, &reference_case.name, stage, state),
+                );
+            }
+            arrays.insert(
+                "selected_vision_features".to_string(),
+                write_tensor(
+                    &out,
+                    &reference_case.name,
+                    "selected_vision_features",
+                    selected,
+                ),
+            );
+            arrays.insert(
+                "projected_image_features".to_string(),
+                write_tensor(
+                    &out,
+                    &reference_case.name,
+                    "projected_image_features",
+                    projected,
+                ),
+            );
+        }
+        arrays.insert(
+            "merged_embeddings".to_string(),
+            write_tensor(
+                &out,
+                &reference_case.name,
+                "merged_embeddings",
+                &capture.prepared.embeddings,
+            ),
+        );
+        arrays.insert(
+            "first_prefill_logits".to_string(),
+            write_raw(
+                &out,
+                &reference_case.name,
+                "first_prefill_logits",
+                &f32_bytes(&run.prefill.logits),
+                "float32",
+                &[run.prefill.logits.len()],
+            ),
+        );
+        arrays.insert(
+            "selected_kv".to_string(),
+            write_raw(
+                &out,
+                &reference_case.name,
+                "selected_kv",
+                &f32_bytes(&run.prefill.kv),
+                "float32",
+                &[run.prefill.layers, 2, run.prefill.kv_width],
+            ),
+        );
+        arrays.insert(
+            "greedy_tokens".to_string(),
+            write_raw(
+                &out,
+                &reference_case.name,
+                "greedy_tokens",
+                &i32_bytes(&run.tokens),
+                "int32",
+                &[run.tokens.len()],
+            ),
+        );
+        captured_cases.push(json!({
+            "name": reference_case.name,
+            "image_count": reference_case.image_count,
+            "arrays": arrays,
+            "timings": {
+                "host_preprocessing_seconds": preprocessing_seconds,
+                "prefill_seconds": run.prefill_seconds,
+                "decode_seconds": run.decode_seconds,
+                "decode_tokens_per_second": if run.tokens.len() > 1 {
+                    (run.tokens.len() - 1) as f64 / run.decode_seconds
+                } else {
+                    0.0
+                },
+            },
+        }));
+    }
+
+    // Required negative cases exercise the same public boundaries, but retain
+    // only their stable error category/message in the manifest.
+    let malformed = preprocessor
+        .prepare(&[151646, 151646], std::slice::from_ref(&image))
+        .expect_err("two placeholders for one image must be rejected");
+    let overflow_tokens = vec![1i32; context_capacity + 1];
+    let overflow_prepared = preprocessor
+        .prepare(&overflow_tokens, &[])
+        .expect("host model capacity exceeds the IREE test bucket");
+    let overflow = engine
+        .capture(
+            &overflow_prepared,
+            reference.kv_selection.width,
+            reference.generation.max_new_tokens,
+        )
+        .expect_err("prepared prompt beyond IREE bucket must be rejected");
+
+    let manifest = json!({
+        "schema": 1,
+        "producer": "mlxcel-xla-diagnostics",
+        "device": device,
+        "host_preprocessor_device": runtime.device.to_string(),
+        "host_compute": {
+            "vision_projector": "float32",
+            "prompt_embedding_lookup": "bfloat16",
+            "mlx_enable_tf32": std::env::var("MLX_ENABLE_TF32")
+                .unwrap_or_else(|_| "1 (MLX default)".to_string()),
+        },
+        "model_ownership": {
+            "host": "processor, vision tower, projector, and text embedding table only",
+            "iree": "single resident text decoder bundle used for prefill, KV capture, and decode",
+            "duplicate_text_decoder": false,
+        },
+        "context_capacity": context_capacity,
+        "kv_selection": {
+            "position": "last_effective_prompt",
+            "kv_head": 0,
+            "width": reference.kv_selection.width,
+        },
+        "timings": {
+            "host_component_load_seconds": host_load_seconds,
+            "iree_compile_and_load_seconds": compile_load_seconds,
+        },
+        "host_peak_rss_kib": peak_rss_kib(),
+        "runtime_memory": {
+            "mlx_peak_device_bytes": mlxcel_core::get_peak_memory(),
+            "linux_mem_available_before_kib": mem_available_before_kib,
+            "linux_mem_available_after_kib": mem_available_kib(),
+            "iree_device_bytes": Value::Null,
+            "iree_device_note": mlxcel_xla::llava_diagnostic_device_memory_note(&device),
+        },
+        "negative_cases": {
+            "malformed_placeholder": {
+                "passed": true,
+                "error": malformed.to_string(),
+            },
+            "context_overflow": {
+                "passed": true,
+                "error": overflow,
+            },
+        },
+        "cases": captured_cases,
+    });
+    fs::write(
+        out.join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).expect("serialize XLA manifest"),
+    )
+    .unwrap_or_else(|error| panic!("write XLA manifest: {error}"));
+    println!("{}", out.join("manifest.json").display());
+}

--- a/examples/xla_llava_reference_check.rs
+++ b/examples/xla_llava_reference_check.rs
@@ -28,9 +28,9 @@ use std::time::Instant;
 
 use image::DynamicImage;
 use mlxcel::{
-    HostMultimodalPreprocessor, LlavaHostPreprocessor, OwnedTensor, PreparedPositions,
-    PreparedTensorDType, initialize_runtime, server::ChatTemplateProcessor,
-    tokenizer::load_tokenizer,
+    HostMultimodalPreprocessor, HostPreprocessorError, LlavaHostPreprocessor, OwnedTensor,
+    PreparedPositions, PreparedTensorDType, initialize_runtime, server::ChatTemplateProcessor,
+    tokenizer::load_tokenizer, vlm_prompt::ImageTokenBlockError,
 };
 use mlxcel_xla::LlavaReferenceDiagnosticEngine;
 use serde::{Deserialize, Serialize};
@@ -64,13 +64,17 @@ struct ImageFixture {
     two_image_transform: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct KvSelection {
+    position: String,
+    kv_head: usize,
     width: usize,
+    layers: usize,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct Generation {
+    mode: String,
     max_new_tokens: usize,
 }
 
@@ -86,6 +90,9 @@ struct ReferenceCase {
 
 const FIXTURE_PATH: &str = "tests/fixtures/test_image.png";
 const FIXTURE_SHA256: &str = "5e7d54e8a7d21802378c87d2d70cf551e29739fe27599ddf129ebccdad1e6261";
+const PINNED_KV_WIDTH: usize = 8;
+const PINNED_TEXT_LAYERS: usize = 24;
+const PINNED_MAX_NEW_TOKENS: usize = 4;
 
 const VISION_BLOCK0_STAGES: [&str; 12] = [
     "vision_block0_layer_norm1",
@@ -198,6 +205,30 @@ fn sha256_file(path: &Path) -> String {
 }
 
 fn verify_artifact_manifest(root: &Path, manifest: &ArtifactManifest) {
+    let forbidden_names = [
+        "chat_template.jinja",
+        "tokenizer.model",
+        "tokenizer.jsonl",
+        "tiktoken.model",
+    ];
+    let mut runtime_alternates = fs::read_dir(root)
+        .unwrap_or_else(|error| panic!("inspect pinned {}: {error}", root.display()))
+        .filter_map(|entry| {
+            let entry = entry.unwrap_or_else(|error| panic!("inspect pinned artifact: {error}"));
+            let filename = entry.file_name().to_string_lossy().into_owned();
+            let is_runtime_alternate = forbidden_names.contains(&filename.as_str())
+                || filename.ends_with(".tiktoken")
+                || filename.ends_with(".safetensors")
+                || filename.ends_with(".safetensors.index.json")
+                || filename.ends_with(".index.json");
+            (is_runtime_alternate && !manifest.files.contains_key(&filename)).then_some(filename)
+        })
+        .collect::<Vec<_>>();
+    runtime_alternates.sort();
+    assert!(
+        runtime_alternates.is_empty(),
+        "converted snapshot has unpinned runtime alternate(s): {runtime_alternates:?}"
+    );
     let mut canonical = String::new();
     for (filename, expected) in &manifest.files {
         assert!(
@@ -227,10 +258,57 @@ fn verify_artifact_manifest(root: &Path, manifest: &ArtifactManifest) {
 fn transformed_image(image: &DynamicImage, transform: &str) -> DynamicImage {
     match transform {
         "identity" => image.clone(),
-        "horizontal_mirror" => {
-            DynamicImage::ImageRgb8(image::imageops::flip_horizontal(&image.to_rgb8()))
+        "swap_red_blue" => {
+            let mut transformed = image.to_rgb8();
+            for pixel in transformed.pixels_mut() {
+                pixel.0.swap(0, 2);
+            }
+            assert_ne!(
+                transformed.as_raw(),
+                image.as_bytes(),
+                "swap_red_blue must change the pinned RGB bytes"
+            );
+            DynamicImage::ImageRgb8(transformed)
         }
         other => panic!("unsupported pinned image transform {other:?}"),
+    }
+}
+
+fn expected_image_transforms(case: &str) -> &'static [&'static str] {
+    match case {
+        "image_text" => &["identity"],
+        "two_images" => &["identity", "swap_red_blue"],
+        "no_image" => &[],
+        other => panic!("unexpected pinned case {other:?}"),
+    }
+}
+
+fn classify_malformed_placeholder(error: &HostPreprocessorError) -> Result<&'static str, String> {
+    match error {
+        HostPreprocessorError::Placeholder(ImageTokenBlockError::MediaCardinality {
+            placeholder_count: 2,
+            image_count: 1,
+        }) => Ok("placeholder_count_mismatch"),
+        other => Err(format!(
+            "expected MediaCardinality {{ placeholder_count: 2, image_count: 1 }}, got {other:?}"
+        )),
+    }
+}
+
+fn classify_context_overflow(
+    error: &str,
+    effective_len: usize,
+    context_capacity: usize,
+) -> Result<&'static str, String> {
+    let expected = format!(
+        "prepared effective length {effective_len} exceeds context_capacity={context_capacity}"
+    );
+    if error == expected {
+        Ok("context_capacity_exceeded")
+    } else {
+        Err(format!(
+            "expected context-capacity error {expected:?}, got {error:?}"
+        ))
     }
 }
 
@@ -242,6 +320,56 @@ mod tests {
     fn streaming_hash_matches_the_pinned_fixture() {
         let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join(FIXTURE_PATH);
         assert_eq!(sha256_file(&fixture), FIXTURE_SHA256);
+    }
+
+    #[test]
+    fn swap_red_blue_changes_rgb_bytes() {
+        let image = DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+            2,
+            1,
+            image::Rgb([255, 100, 50]),
+        ));
+        let transformed = transformed_image(&image, "swap_red_blue");
+        assert_ne!(image.as_bytes(), transformed.as_bytes());
+        assert_eq!(transformed.to_rgb8().get_pixel(0, 0).0, [50, 100, 255]);
+    }
+
+    #[test]
+    fn negative_error_classifiers_reject_wrong_variants() {
+        let correct = HostPreprocessorError::Placeholder(ImageTokenBlockError::MediaCardinality {
+            placeholder_count: 2,
+            image_count: 1,
+        });
+        assert_eq!(
+            classify_malformed_placeholder(&correct).unwrap(),
+            "placeholder_count_mismatch"
+        );
+        let wrong = HostPreprocessorError::Placeholder(ImageTokenBlockError::EmptyImageBlock);
+        assert!(classify_malformed_placeholder(&wrong).is_err());
+        assert_eq!(
+            classify_context_overflow(
+                "prepared effective length 1537 exceeds context_capacity=1536",
+                1537,
+                1536,
+            )
+            .unwrap(),
+            "context_capacity_exceeded"
+        );
+        assert!(classify_context_overflow("wrong error", 1537, 1536).is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "unpinned runtime alternate")]
+    fn converted_snapshot_rejects_extra_jinja() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(directory.path().join("chat_template.jinja"), "conflict").unwrap();
+        verify_artifact_manifest(
+            directory.path(),
+            &ArtifactManifest {
+                canonical_sha256: String::new(),
+                files: BTreeMap::new(),
+            },
+        );
     }
 }
 
@@ -313,10 +441,13 @@ fn main() {
     .unwrap_or_else(|error| panic!("parse reference manifest: {error}"));
     assert_eq!(reference.image_fixture.path, FIXTURE_PATH);
     assert_eq!(reference.image_fixture.sha256, FIXTURE_SHA256);
-    assert_eq!(
-        reference.image_fixture.two_image_transform,
-        "horizontal_mirror"
-    );
+    assert_eq!(reference.image_fixture.two_image_transform, "swap_red_blue");
+    assert_eq!(reference.kv_selection.position, "last_effective_prompt");
+    assert_eq!(reference.kv_selection.kv_head, 0);
+    assert_eq!(reference.kv_selection.width, PINNED_KV_WIDTH);
+    assert_eq!(reference.kv_selection.layers, PINNED_TEXT_LAYERS);
+    assert_eq!(reference.generation.mode, "greedy");
+    assert_eq!(reference.generation.max_new_tokens, PINNED_MAX_NEW_TOKENS);
     assert_eq!(
         sha256_file(&image_path),
         FIXTURE_SHA256,
@@ -344,6 +475,16 @@ fn main() {
 
     let mut captured_cases = Vec::new();
     for reference_case in &reference.cases {
+        assert_eq!(
+            reference_case
+                .image_transforms
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            expected_image_transforms(&reference_case.name),
+            "pinned image transform contract differs for {}",
+            reference_case.name
+        );
         assert_eq!(
             reference_case.image_count,
             reference_case.image_transforms.len(),
@@ -402,6 +543,32 @@ fn main() {
                     reference_case.name
                 )
             });
+        if reference_case.name == "two_images" {
+            assert_ne!(
+                images[0].as_bytes(),
+                images[1].as_bytes(),
+                "two-image RGB inputs must be byte-distinct"
+            );
+            let pixels = capture
+                .pixel_values
+                .as_ref()
+                .expect("two-image capture must include processor pixels");
+            assert_eq!(pixels.shape, [2, 3, 384, 384]);
+            let bytes_per_image = pixels.bytes.len() / 2;
+            let first = &pixels.bytes[..bytes_per_image];
+            let second = &pixels.bytes[bytes_per_image..];
+            assert_ne!(
+                first, second,
+                "two-image processor tensors must differ after channel swap"
+            );
+            let mut reversed = Vec::with_capacity(pixels.bytes.len());
+            reversed.extend_from_slice(second);
+            reversed.extend_from_slice(first);
+            assert_ne!(
+                pixels.bytes, reversed,
+                "reversing two-image order must change the processor tensor"
+            );
+        }
         let preprocessing_seconds = preprocessing_started.elapsed().as_secs_f64();
         let run = engine
             .capture(
@@ -571,20 +738,26 @@ fn main() {
 
     // Required negative cases exercise the same public boundaries, but retain
     // only their stable rejected outcome/category in the manifest.
-    let _malformed = preprocessor
+    let malformed = preprocessor
         .prepare(&[151646, 151646], std::slice::from_ref(&image))
         .expect_err("two placeholders for one image must be rejected");
+    let malformed_category = classify_malformed_placeholder(&malformed)
+        .unwrap_or_else(|error| panic!("classify malformed-placeholder error: {error}"));
     let overflow_tokens = vec![1i32; context_capacity + 1];
     let overflow_prepared = preprocessor
         .prepare(&overflow_tokens, &[])
         .expect("host model capacity exceeds the IREE test bucket");
-    let _overflow = engine
+    let overflow_effective_len = overflow_prepared.sequence_len;
+    let overflow = engine
         .capture(
             &overflow_prepared,
             reference.kv_selection.width,
             reference.generation.max_new_tokens,
         )
         .expect_err("prepared prompt beyond IREE bucket must be rejected");
+    let overflow_category =
+        classify_context_overflow(&overflow, overflow_effective_len, context_capacity)
+            .unwrap_or_else(|error| panic!("classify context-overflow error: {error}"));
 
     let manifest = json!({
         "schema": 1,
@@ -607,11 +780,8 @@ fn main() {
             "artifact_manifest": reference.converted_checkpoint.artifact_manifest,
         },
         "image_fixture": reference.image_fixture,
-        "kv_selection": {
-            "position": "last_effective_prompt",
-            "kv_head": 0,
-            "width": reference.kv_selection.width,
-        },
+        "kv_selection": reference.kv_selection,
+        "generation": reference.generation,
         "timings": {
             "host_component_load_seconds": host_load_seconds,
             "iree_compile_and_load_seconds": compile_load_seconds,
@@ -628,12 +798,12 @@ fn main() {
             "malformed_placeholder": {
                 "passed": true,
                 "outcome": "rejected",
-                "category": "placeholder_count_mismatch",
+                "category": malformed_category,
             },
             "context_overflow": {
                 "passed": true,
                 "outcome": "rejected",
-                "category": "context_capacity_exceeded",
+                "category": overflow_category,
             },
         },
         "cases": captured_cases,

--- a/examples/xla_llava_reference_check.rs
+++ b/examples/xla_llava_reference_check.rs
@@ -20,7 +20,9 @@
 //! `xla-diagnostics`. Generated binary captures stay outside Git and are
 //! compared by `spike/openxla/llava_reference_oracle.py`.
 
-use std::fs;
+use std::collections::BTreeMap;
+use std::fs::{self, File};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -31,14 +33,35 @@ use mlxcel::{
     tokenizer::load_tokenizer,
 };
 use mlxcel_xla::LlavaReferenceDiagnosticEngine;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Deserialize)]
 struct ReferenceManifest {
     kv_selection: KvSelection,
     generation: Generation,
+    image_fixture: ImageFixture,
+    converted_checkpoint: ConvertedCheckpoint,
     cases: Vec<ReferenceCase>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ArtifactManifest {
+    canonical_sha256: String,
+    files: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConvertedCheckpoint {
+    artifact_manifest: ArtifactManifest,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ImageFixture {
+    path: String,
+    sha256: String,
+    two_image_transform: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -57,8 +80,12 @@ struct ReferenceCase {
     user_prompt: String,
     text: String,
     image_count: usize,
+    image_transforms: Vec<String>,
     unexpanded_input_ids: Vec<i32>,
 }
+
+const FIXTURE_PATH: &str = "tests/fixtures/test_image.png";
+const FIXTURE_SHA256: &str = "5e7d54e8a7d21802378c87d2d70cf551e29739fe27599ddf129ebccdad1e6261";
 
 const VISION_BLOCK0_STAGES: [&str; 12] = [
     "vision_block0_layer_norm1",
@@ -153,6 +180,71 @@ fn f32_bytes(values: &[f32]) -> Vec<u8> {
         .collect()
 }
 
+fn sha256_file(path: &Path) -> String {
+    let mut file =
+        File::open(path).unwrap_or_else(|error| panic!("open pinned {}: {error}", path.display()));
+    let mut digest = Sha256::new();
+    let mut buffer = vec![0u8; 1024 * 1024];
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .unwrap_or_else(|error| panic!("hash pinned {}: {error}", path.display()));
+        if count == 0 {
+            break;
+        }
+        digest.update(&buffer[..count]);
+    }
+    format!("{:x}", digest.finalize())
+}
+
+fn verify_artifact_manifest(root: &Path, manifest: &ArtifactManifest) {
+    let mut canonical = String::new();
+    for (filename, expected) in &manifest.files {
+        assert!(
+            !filename.contains('/') && !filename.contains('\\'),
+            "artifact manifest path must be a filename: {filename}"
+        );
+        let path = root.join(filename);
+        let actual = sha256_file(&path);
+        assert_eq!(
+            actual,
+            *expected,
+            "converted snapshot hash differs for {}",
+            path.display()
+        );
+        canonical.push_str(filename);
+        canonical.push('=');
+        canonical.push_str(expected);
+        canonical.push('\n');
+    }
+    let actual_canonical = format!("{:x}", Sha256::digest(canonical.as_bytes()));
+    assert_eq!(
+        actual_canonical, manifest.canonical_sha256,
+        "converted snapshot canonical manifest hash differs"
+    );
+}
+
+fn transformed_image(image: &DynamicImage, transform: &str) -> DynamicImage {
+    match transform {
+        "identity" => image.clone(),
+        "horizontal_mirror" => {
+            DynamicImage::ImageRgb8(image::imageops::flip_horizontal(&image.to_rgb8()))
+        }
+        other => panic!("unsupported pinned image transform {other:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn streaming_hash_matches_the_pinned_fixture() {
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join(FIXTURE_PATH);
+        assert_eq!(sha256_file(&fixture), FIXTURE_SHA256);
+    }
+}
+
 fn peak_rss_kib() -> Option<u64> {
     fs::read_to_string("/proc/self/status")
         .ok()?
@@ -219,6 +311,18 @@ fn main() {
             .unwrap_or_else(|error| panic!("read reference manifest: {error}")),
     )
     .unwrap_or_else(|error| panic!("parse reference manifest: {error}"));
+    assert_eq!(reference.image_fixture.path, FIXTURE_PATH);
+    assert_eq!(reference.image_fixture.sha256, FIXTURE_SHA256);
+    assert_eq!(
+        reference.image_fixture.two_image_transform,
+        "horizontal_mirror"
+    );
+    assert_eq!(
+        sha256_file(&image_path),
+        FIXTURE_SHA256,
+        "fixture image SHA-256 differs"
+    );
+    verify_artifact_manifest(&model, &reference.converted_checkpoint.artifact_manifest);
     let image = image::open(&image_path)
         .unwrap_or_else(|error| panic!("open fixture image {}: {error}", image_path.display()))
         .into_rgb8();
@@ -240,6 +344,12 @@ fn main() {
 
     let mut captured_cases = Vec::new();
     for reference_case in &reference.cases {
+        assert_eq!(
+            reference_case.image_count,
+            reference_case.image_transforms.len(),
+            "image count and transform count diverged for {}",
+            reference_case.name
+        );
         let converted_prompt = render_converted_prompt(
             &chat_template,
             &reference_case.user_prompt,
@@ -278,8 +388,10 @@ fn main() {
             "converted tokenizer round-trip diverged for {}",
             reference_case.name
         );
-        let images: Vec<DynamicImage> = (0..reference_case.image_count)
-            .map(|_| image.clone())
+        let images: Vec<DynamicImage> = reference_case
+            .image_transforms
+            .iter()
+            .map(|transform| transformed_image(&image, transform))
             .collect();
         let preprocessing_started = Instant::now();
         let capture = preprocessor
@@ -442,6 +554,7 @@ fn main() {
         captured_cases.push(json!({
             "name": reference_case.name,
             "image_count": reference_case.image_count,
+            "image_transforms": reference_case.image_transforms,
             "arrays": arrays,
             "timings": {
                 "host_preprocessing_seconds": preprocessing_seconds,
@@ -457,15 +570,15 @@ fn main() {
     }
 
     // Required negative cases exercise the same public boundaries, but retain
-    // only their stable error category/message in the manifest.
-    let malformed = preprocessor
+    // only their stable rejected outcome/category in the manifest.
+    let _malformed = preprocessor
         .prepare(&[151646, 151646], std::slice::from_ref(&image))
         .expect_err("two placeholders for one image must be rejected");
     let overflow_tokens = vec![1i32; context_capacity + 1];
     let overflow_prepared = preprocessor
         .prepare(&overflow_tokens, &[])
         .expect("host model capacity exceeds the IREE test bucket");
-    let overflow = engine
+    let _overflow = engine
         .capture(
             &overflow_prepared,
             reference.kv_selection.width,
@@ -490,6 +603,10 @@ fn main() {
             "duplicate_text_decoder": false,
         },
         "context_capacity": context_capacity,
+        "converted_checkpoint": {
+            "artifact_manifest": reference.converted_checkpoint.artifact_manifest,
+        },
+        "image_fixture": reference.image_fixture,
         "kv_selection": {
             "position": "last_effective_prompt",
             "kv_head": 0,
@@ -510,11 +627,13 @@ fn main() {
         "negative_cases": {
             "malformed_placeholder": {
                 "passed": true,
-                "error": malformed.to_string(),
+                "outcome": "rejected",
+                "category": "placeholder_count_mismatch",
             },
             "context_overflow": {
                 "passed": true,
-                "error": overflow,
+                "outcome": "rejected",
+                "category": "context_capacity_exceeded",
             },
         },
         "cases": captured_cases,

--- a/scripts/xla/validate_arch.sh
+++ b/scripts/xla/validate_arch.sh
@@ -13,6 +13,10 @@
 # checkpoint in fp32 (dequantizing an MLX 4-bit/8-bit checkpoint offline first) and
 # records the greedy continuation the token-exact gate diffs against.
 #
+# LLaVA's host vision/projector plus prepared-embeddings path has a separate
+# independent HF stage oracle and CLI/server gate:
+#   scripts/xla/validate_llava_reference.sh --help
+#
 # The two execution gates need a real IREE build (the `xla-iree` feature), so set
 # the IREE environment first (see src/lib/mlxcel-xla/README.md):
 #   - CPU (prebuilt dist):  export IREE_DIST=/path/to/iree-dist

--- a/scripts/xla/validate_llava_reference.sh
+++ b/scripts/xla/validate_llava_reference.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# End-to-end LLaVA reference validation for the OpenXLA / IREE backend (#862).
+#
+# This gate uses the pinned, independently maintained Hugging Face model as the
+# oracle and the converted MLX checkpoint as the production input. Both local
+# directories are verified by SHA-256 before inference; no weights or generated
+# captures belong in Git.
+#
+# Source:
+#   llava-hf/llava-interleave-qwen-0.5b-hf
+#   revision 1090956dd1c79bc93ae98dcf395590369435ec91
+# Converted:
+#   mlx-community/llava-interleave-qwen-0.5b-bf16
+#   revision ba7385935f69c5417bfbe29c3809858a98afc22f
+# License:
+#   Tongyi Qianwen Research License (research/evaluation use; review its terms)
+#
+# Usage:
+#   scripts/xla/validate_llava_reference.sh \
+#     --image tests/fixtures/test_image.png \
+#     --out /tmp/mlxcel-llava-reference \
+#     [--source-model /path/to/pinned-hf-snapshot] \
+#     [--model /path/to/pinned-mlx-snapshot] \
+#     [--device local-task|local-sync|cuda|metal]
+#     [--text-model /path/to/text-checkpoint]
+#
+# The selected IREE runtime must already be configured. See
+# src/lib/mlxcel-xla/README.md for IREE_DIST, IREE_CUDA_HOME, and Metal setup.
+# If a constrained Linux host rejects local-task worker creation, local-sync is
+# the documented single-threaded CPU execution fallback.
+# `--text-model` runs validate_arch.sh after the multimodal gates to provide the
+# ordinary text/batch regression companion requested by the architecture gate.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PYTHON="${MLXCEL_ORACLE_PYTHON:-$REPO_ROOT/spike/openxla/.venv/bin/python}"
+ORACLE="$REPO_ROOT/spike/openxla/llava_reference_oracle.py"
+SURFACE_CHECK="$REPO_ROOT/spike/openxla/llava_cli_server_check.py"
+CACHE_ROOT="${MLXCEL_REFERENCE_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/mlxcel/reference-models}"
+SOURCE_REVISION="1090956dd1c79bc93ae98dcf395590369435ec91"
+CONVERTED_REVISION="ba7385935f69c5417bfbe29c3809858a98afc22f"
+
+usage() { sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//; $d'; }
+
+SOURCE_MODEL="$CACHE_ROOT/llava-interleave-qwen-0.5b-hf-$SOURCE_REVISION"
+MODEL="$CACHE_ROOT/llava-interleave-qwen-0.5b-bf16-$CONVERTED_REVISION"
+IMAGE=""
+OUT=""
+DEVICE="${MLXCEL_XLA_DEVICE:-local-task}"
+TEXT_MODEL=""
+CONTEXT_CAPACITY=1536
+PORT=18062
+SKIP_STRUCTURAL=0
+SKIP_SURFACES=0
+STRUCTURAL_ONLY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source-model) SOURCE_MODEL="${2:?}"; shift 2 ;;
+    --model) MODEL="${2:?}"; shift 2 ;;
+    --image) IMAGE="${2:?}"; shift 2 ;;
+    --out) OUT="${2:?}"; shift 2 ;;
+    --device) DEVICE="${2:?}"; shift 2 ;;
+    --text-model) TEXT_MODEL="${2:?}"; shift 2 ;;
+    --context-capacity) CONTEXT_CAPACITY="${2:?}"; shift 2 ;;
+    --port) PORT="${2:?}"; shift 2 ;;
+    --skip-structural) SKIP_STRUCTURAL=1; shift ;;
+    --skip-surfaces) SKIP_SURFACES=1; shift ;;
+    --structural-only) STRUCTURAL_ONLY=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+cd "$REPO_ROOT"
+# The reference policy is true F32. MLX CUDA enables FAST_TF32 by default,
+# which is a useful production throughput mode but a different compute dtype.
+export MLX_ENABLE_TF32=0
+
+if [ "$SKIP_STRUCTURAL" -eq 0 ]; then
+  echo "== [structural] LLaVA diagnostic seam and chat-template selection =="
+  cargo test -p mlxcel-xla --lib llava_diagnostics_share_the_production_embeddings_prefill
+  cargo test --lib server::chat_template
+  echo "[structural] PASS"
+fi
+if [ "$STRUCTURAL_ONLY" -eq 1 ]; then
+  echo "RESULT: PASS (structural only)"
+  exit 0
+fi
+
+for value in IMAGE OUT; do
+  [ -n "${!value}" ] || { echo "error: --$(echo "$value" | tr '[:upper:]_' '[:lower:]-') is required" >&2; usage; exit 2; }
+done
+[ -f "$IMAGE" ] || { echo "error: image not found: $IMAGE" >&2; exit 2; }
+[ -x "$PYTHON" ] || { echo "error: oracle Python not found: $PYTHON" >&2; exit 3; }
+
+ensure_snapshot() {
+  local repo="$1"
+  local revision="$2"
+  local directory="$3"
+  if [ -f "$directory/model.safetensors" ] && [ -f "$directory/tokenizer.json" ]; then
+    return
+  fi
+  command -v hf >/dev/null 2>&1 || {
+    echo "error: pinned snapshot unavailable at $directory and the 'hf' CLI is not installed" >&2
+    exit 3
+  }
+  mkdir -p "$directory"
+  echo "== [download] $repo@$revision -> $directory =="
+  hf download "$repo" --revision "$revision" --local-dir "$directory"
+}
+
+ensure_snapshot \
+  "llava-hf/llava-interleave-qwen-0.5b-hf" \
+  "$SOURCE_REVISION" \
+  "$SOURCE_MODEL"
+ensure_snapshot \
+  "mlx-community/llava-interleave-qwen-0.5b-bf16" \
+  "$CONVERTED_REVISION" \
+  "$MODEL"
+
+mkdir -p "$OUT"
+REFERENCE="$OUT/hf-reference"
+ACTUAL="$OUT/xla-$DEVICE"
+REPORT="$OUT/comparison-$DEVICE.json"
+
+echo "== [oracle] pinned Hugging Face capture =="
+"$PYTHON" "$ORACLE" capture \
+  --source-model "$SOURCE_MODEL" \
+  --converted-model "$MODEL" \
+  --image "$IMAGE" \
+  --out "$REFERENCE" \
+  --device cpu
+
+echo "== [runtime] production host preprocessor + IREE $DEVICE =="
+cargo run --release --features xla-diagnostics --example xla_llava_reference_check -- \
+  --model "$MODEL" \
+  --reference "$REFERENCE" \
+  --image "$IMAGE" \
+  --out "$ACTUAL" \
+  --device "$DEVICE" \
+  --context-capacity "$CONTEXT_CAPACITY"
+
+echo "== [comparison] ordered first-divergence gate =="
+"$PYTHON" "$ORACLE" compare \
+  --reference "$REFERENCE" \
+  --actual "$ACTUAL" \
+  --report "$REPORT"
+
+if [ "$SKIP_SURFACES" -eq 0 ]; then
+  echo "== [surfaces] non-streaming CLI + streaming OpenAI API + metrics =="
+  cargo build --release --features xla-diagnostics --bin mlxcel
+  "$PYTHON" "$SURFACE_CHECK" \
+    --mlxcel-bin "$REPO_ROOT/target/release/mlxcel" \
+    --model "$MODEL" \
+    --reference "$REFERENCE" \
+    --image "$IMAGE" \
+    --device "$DEVICE" \
+    --port "$PORT" \
+    --context-capacity "$CONTEXT_CAPACITY"
+fi
+
+if [ -n "$TEXT_MODEL" ]; then
+  echo "== [regression] existing text and batch architecture gates =="
+  "$REPO_ROOT/scripts/xla/validate_arch.sh" \
+    --model "$TEXT_MODEL" \
+    --device "$DEVICE" \
+    --skip-structural
+fi
+
+echo "RESULT: PASS"
+echo "reference: $REFERENCE/manifest.json"
+echo "actual:    $ACTUAL/manifest.json"
+echo "report:    $REPORT"

--- a/scripts/xla/validate_llava_reference.sh
+++ b/scripts/xla/validate_llava_reference.sh
@@ -35,6 +35,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PYTHON="${MLXCEL_ORACLE_PYTHON:-$REPO_ROOT/spike/openxla/.venv/bin/python}"
 ORACLE="$REPO_ROOT/spike/openxla/llava_reference_oracle.py"
+ORACLE_TEST="$REPO_ROOT/spike/openxla/test_llava_reference_oracle.py"
 SURFACE_CHECK="$REPO_ROOT/spike/openxla/llava_cli_server_check.py"
 CACHE_ROOT="${MLXCEL_REFERENCE_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/mlxcel/reference-models}"
 SOURCE_REVISION="1090956dd1c79bc93ae98dcf395590369435ec91"
@@ -89,8 +90,11 @@ cd "$REPO_ROOT"
 # which is a useful production throughput mode but a different compute dtype.
 export MLX_ENABLE_TF32=0
 
+[ -x "$PYTHON" ] || { echo "error: oracle Python not found: $PYTHON" >&2; exit 3; }
+
 if [ "$SKIP_STRUCTURAL" -eq 0 ]; then
   echo "== [structural] LLaVA diagnostic seam and chat-template selection =="
+  "$PYTHON" -m unittest -v "$ORACLE_TEST"
   cargo test -p mlxcel-xla --lib llava_diagnostics_share_the_production_embeddings_prefill
   cargo test --lib server::chat_template
   echo "[structural] PASS"
@@ -104,7 +108,6 @@ for value in IMAGE OUT; do
   [ -n "${!value}" ] || { echo "error: --$(echo "$value" | tr '[:upper:]_' '[:lower:]-') is required" >&2; usage; exit 2; }
 done
 [ -f "$IMAGE" ] || { echo "error: image not found: $IMAGE" >&2; exit 2; }
-[ -x "$PYTHON" ] || { echo "error: oracle Python not found: $PYTHON" >&2; exit 3; }
 ACTUAL_FIXTURE_SHA256="$(sha256sum "$IMAGE" | cut -d' ' -f1)"
 [ "$ACTUAL_FIXTURE_SHA256" = "$FIXTURE_SHA256" ] || {
   echo "error: image fixture SHA-256 mismatch: expected $FIXTURE_SHA256, got $ACTUAL_FIXTURE_SHA256" >&2

--- a/scripts/xla/validate_llava_reference.sh
+++ b/scripts/xla/validate_llava_reference.sh
@@ -39,6 +39,18 @@ SURFACE_CHECK="$REPO_ROOT/spike/openxla/llava_cli_server_check.py"
 CACHE_ROOT="${MLXCEL_REFERENCE_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/mlxcel/reference-models}"
 SOURCE_REVISION="1090956dd1c79bc93ae98dcf395590369435ec91"
 CONVERTED_REVISION="ba7385935f69c5417bfbe29c3809858a98afc22f"
+FIXTURE_SHA256="5e7d54e8a7d21802378c87d2d70cf551e29739fe27599ddf129ebccdad1e6261"
+SOURCE_ARTIFACTS=(
+  added_tokens.json chat_template.json config.json generation_config.json
+  merges.txt model.safetensors preprocessor_config.json processor_config.json
+  special_tokens_map.json tokenizer.json tokenizer_config.json vocab.json
+)
+CONVERTED_ARTIFACTS=(
+  added_tokens.json chat_template.json config.json generation_config.json
+  merges.txt model.safetensors model.safetensors.index.json
+  preprocessor_config.json processor_config.json special_tokens_map.json
+  tokenizer.json tokenizer_config.json vocab.json
+)
 
 usage() { sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//; $d'; }
 
@@ -93,12 +105,26 @@ for value in IMAGE OUT; do
 done
 [ -f "$IMAGE" ] || { echo "error: image not found: $IMAGE" >&2; exit 2; }
 [ -x "$PYTHON" ] || { echo "error: oracle Python not found: $PYTHON" >&2; exit 3; }
+ACTUAL_FIXTURE_SHA256="$(sha256sum "$IMAGE" | cut -d' ' -f1)"
+[ "$ACTUAL_FIXTURE_SHA256" = "$FIXTURE_SHA256" ] || {
+  echo "error: image fixture SHA-256 mismatch: expected $FIXTURE_SHA256, got $ACTUAL_FIXTURE_SHA256" >&2
+  exit 3
+}
 
 ensure_snapshot() {
   local repo="$1"
   local revision="$2"
   local directory="$3"
-  if [ -f "$directory/model.safetensors" ] && [ -f "$directory/tokenizer.json" ]; then
+  shift 3
+  local complete=1
+  local artifact
+  for artifact in "$@"; do
+    if [ ! -f "$directory/$artifact" ]; then
+      complete=0
+      break
+    fi
+  done
+  if [ "$complete" -eq 1 ]; then
     return
   fi
   command -v hf >/dev/null 2>&1 || {
@@ -108,16 +134,24 @@ ensure_snapshot() {
   mkdir -p "$directory"
   echo "== [download] $repo@$revision -> $directory =="
   hf download "$repo" --revision "$revision" --local-dir "$directory"
+  for artifact in "$@"; do
+    [ -f "$directory/$artifact" ] || {
+      echo "error: pinned snapshot is missing required artifact: $directory/$artifact" >&2
+      exit 3
+    }
+  done
 }
 
 ensure_snapshot \
   "llava-hf/llava-interleave-qwen-0.5b-hf" \
   "$SOURCE_REVISION" \
-  "$SOURCE_MODEL"
+  "$SOURCE_MODEL" \
+  "${SOURCE_ARTIFACTS[@]}"
 ensure_snapshot \
   "mlx-community/llava-interleave-qwen-0.5b-bf16" \
   "$CONVERTED_REVISION" \
-  "$MODEL"
+  "$MODEL" \
+  "${CONVERTED_ARTIFACTS[@]}"
 
 mkdir -p "$OUT"
 REFERENCE="$OUT/hf-reference"

--- a/spike/openxla/llava_cli_server_check.py
+++ b/spike/openxla/llava_cli_server_check.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import hashlib
 import json
 import os
 import re
@@ -16,6 +17,8 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any
+
+FIXTURE_SHA256 = "5e7d54e8a7d21802378c87d2d70cf551e29739fe27599ddf129ebccdad1e6261"
 
 
 def fail(message: str) -> None:
@@ -209,6 +212,12 @@ def main() -> int:
     ):
         if not path.exists():
             fail(f"{label} not found: {path}")
+    actual_fixture_sha = hashlib.sha256(args.image.read_bytes()).hexdigest()
+    if actual_fixture_sha != FIXTURE_SHA256:
+        fail(
+            "image fixture SHA-256 mismatch: "
+            f"expected {FIXTURE_SHA256}, got {actual_fixture_sha}"
+        )
     manifest = json.loads((args.reference / "manifest.json").read_text())
     case = next(case for case in manifest["cases"] if case["name"] == "image_text")
     if "greedy_text" not in case:

--- a/spike/openxla/llava_cli_server_check.py
+++ b/spike/openxla/llava_cli_server_check.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Validate the public CLI and streaming OpenAI LLaVA XLA surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def image_data_uri(path: Path) -> str:
+    suffix = path.suffix.lower()
+    mime = "image/png" if suffix == ".png" else "image/jpeg"
+    return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode()}"
+
+
+def get(url: str, timeout: float = 10.0) -> bytes:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return response.read()
+
+
+def wait_ready(base_url: str, process: subprocess.Popen[Any], timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            fail(f"server exited before readiness with status {process.returncode}")
+        try:
+            get(f"{base_url}/health", timeout=2.0)
+            return
+        except (OSError, urllib.error.URLError):
+            time.sleep(0.25)
+    fail(f"server did not become healthy within {timeout:.0f}s")
+
+
+def metric_value(metrics: str, name: str) -> float:
+    match = re.search(rf"(?m)^{re.escape(name)} ([0-9.eE+-]+)$", metrics)
+    if match is None:
+        fail(f"missing metric {name}")
+    return float(match.group(1))
+
+
+def run_cli(args: argparse.Namespace, case: dict[str, Any], env: dict[str, str]) -> None:
+    command = [
+        str(args.mlxcel_bin),
+        "generate",
+        "--model",
+        str(args.model),
+        "--prompt",
+        case["user_prompt"],
+        "--image",
+        str(args.image),
+        "--max-tokens",
+        str(args.max_new),
+        "--temp",
+        "0",
+    ]
+    completed = subprocess.run(
+        command,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=args.timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        fail(
+            f"CLI exited {completed.returncode}\nstdout:\n{completed.stdout}\n"
+            f"stderr:\n{completed.stderr}"
+        )
+    prefix = f"Generating...\n{case['user_prompt']}"
+    if prefix not in completed.stdout or "\n\n[Generated " not in completed.stdout:
+        fail(f"unrecognized CLI output:\n{completed.stdout}")
+    generated = completed.stdout.split(prefix, 1)[1].rsplit("\n\n[Generated ", 1)[0]
+    if generated != case["greedy_text"]:
+        fail(
+            f"CLI text mismatch: expected {case['greedy_text']!r}, got {generated!r}"
+        )
+    print(f"[cli] PASS content={generated!r}")
+
+
+def stream_server(
+    args: argparse.Namespace,
+    case: dict[str, Any],
+    base_url: str,
+) -> None:
+    request_body = {
+        "model": args.alias,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": image_data_uri(args.image)},
+                    },
+                    {"type": "text", "text": case["user_prompt"]},
+                ],
+            }
+        ],
+        "max_tokens": args.max_new,
+        "temperature": 0.0,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    request = urllib.request.Request(
+        f"{base_url}/v1/chat/completions",
+        data=json.dumps(request_body).encode(),
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    events: list[dict[str, Any]] = []
+    done = False
+    with urllib.request.urlopen(request, timeout=args.timeout) as response:
+        for raw_line in response:
+            line = raw_line.decode().strip()
+            if not line.startswith("data: "):
+                continue
+            data = line.removeprefix("data: ")
+            if data == "[DONE]":
+                done = True
+                break
+            events.append(json.loads(data))
+    if not done:
+        fail("stream ended without [DONE]")
+    if not events or events[0]["choices"][0]["delta"].get("role") != "assistant":
+        fail("first streaming event did not declare the assistant role")
+
+    content: list[str] = []
+    finish_index = None
+    usage_index = None
+    finish_reason = None
+    usage = None
+    for index, event in enumerate(events):
+        choices = event.get("choices", [])
+        if choices:
+            choice = choices[0]
+            piece = choice.get("delta", {}).get("content")
+            if piece:
+                if finish_index is not None:
+                    fail("content event appeared after finish event")
+                content.append(piece)
+            if choice.get("finish_reason") is not None:
+                if finish_index is not None:
+                    fail("multiple finish events")
+                finish_index = index
+                finish_reason = choice["finish_reason"]
+        if event.get("usage") is not None:
+            if event.get("choices") != []:
+                fail("usage event must have an empty choices array")
+            usage_index = index
+            usage = event["usage"]
+
+    if finish_index is None or usage_index is None or usage_index <= finish_index:
+        fail("stream must order content, finish, usage, then [DONE]")
+    generated = "".join(content)
+    if generated != case["greedy_text"]:
+        fail(
+            f"server text mismatch: expected {case['greedy_text']!r}, got {generated!r}"
+        )
+    if finish_reason != "length":
+        fail(f"expected finish_reason='length', got {finish_reason!r}")
+    logical_prompt_tokens = len(case["unexpanded_input_ids"])
+    expected_usage = {
+        "prompt_tokens": logical_prompt_tokens,
+        "completion_tokens": args.max_new,
+        "total_tokens": logical_prompt_tokens + args.max_new,
+    }
+    for key, expected in expected_usage.items():
+        if usage.get(key) != expected:
+            fail(f"usage.{key}: expected {expected}, got {usage.get(key)}")
+    print(
+        f"[server] PASS content={generated!r} finish_reason={finish_reason} "
+        f"usage={expected_usage}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mlxcel-bin", type=Path, required=True)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--reference", type=Path, required=True)
+    parser.add_argument("--image", type=Path, required=True)
+    parser.add_argument("--device", default="local-task")
+    parser.add_argument("--port", type=int, default=18062)
+    parser.add_argument("--alias", default="llava-reference")
+    parser.add_argument("--max-new", type=int, default=4)
+    parser.add_argument("--context-capacity", type=int, default=1536)
+    parser.add_argument("--timeout", type=float, default=300.0)
+    args = parser.parse_args()
+    for path, label in (
+        (args.mlxcel_bin, "mlxcel binary"),
+        (args.model, "model"),
+        (args.reference / "manifest.json", "reference manifest"),
+        (args.image, "image"),
+    ):
+        if not path.exists():
+            fail(f"{label} not found: {path}")
+    manifest = json.loads((args.reference / "manifest.json").read_text())
+    case = next(case for case in manifest["cases"] if case["name"] == "image_text")
+    if "greedy_text" not in case:
+        fail("reference manifest predates greedy_text; recapture it with the oracle")
+
+    env = os.environ.copy()
+    env.update(
+        MLXCEL_BACKEND="xla",
+        MLXCEL_XLA_DEVICE=args.device,
+        MLXCEL_XLA_CONTEXT_CAPACITY=str(args.context_capacity),
+        MLXCEL_XLA_REFERENCE_EXPECT_UNEXPANDED_IDS=json.dumps(
+            case["unexpanded_input_ids"], separators=(",", ":")
+        ),
+    )
+    run_cli(args, case, env)
+
+    base_url = f"http://127.0.0.1:{args.port}"
+    command = [
+        str(args.mlxcel_bin),
+        "serve",
+        "--model",
+        str(args.model),
+        "--alias",
+        args.alias,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(args.port),
+        "--n-predict",
+        str(args.max_new),
+        "--max-batch-size",
+        "4",
+        "--max-batch-prefill",
+        "1",
+        "--metrics",
+        "--no-warmup",
+    ]
+    with tempfile.NamedTemporaryFile(
+        prefix="mlxcel-llava-server.", suffix=".log", delete=False
+    ) as log:
+        log_path = Path(log.name)
+        process = subprocess.Popen(command, env=env, stdout=log, stderr=log)
+    try:
+        wait_ready(base_url, process, args.timeout)
+        stream_server(args, case, base_url)
+        print(
+            "[server-render] PASS unexpanded_input_ids="
+            f"{case['unexpanded_input_ids']}"
+        )
+        metrics = get(f"{base_url}/metrics", timeout=10.0).decode()
+        effective_prompt_tokens = case["arrays"]["expanded_token_ids"]["shape"][1]
+        checks = {
+            "mlxcel_batch_sequences_started": 1,
+            "mlxcel_batch_sequences_completed": 1,
+            "mlxcel_batch_prefill_tokens_total": effective_prompt_tokens,
+            "mlxcel_batch_decode_tokens_total": args.max_new,
+        }
+        for name, minimum in checks.items():
+            actual = metric_value(metrics, name)
+            if actual < minimum:
+                fail(f"{name}: expected >= {minimum}, got {actual}")
+        print(f"[metrics] PASS {checks}")
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+        if process.returncode not in (0, -15):
+            print(f"server log retained at {log_path}", file=sys.stderr)
+        else:
+            log_path.unlink(missing_ok=True)
+    print("RESULT: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/spike/openxla/llava_reference_oracle.py
+++ b/spike/openxla/llava_reference_oracle.py
@@ -1,0 +1,776 @@
+#!/usr/bin/env python3
+"""Pinned LLaVA reference capture and first-divergence comparator.
+
+Weights and generated captures stay outside Git. The maintained code records
+the independent Hugging Face stages needed to diagnose a compiler-backend
+divergence without accepting mlxcel output as its own oracle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import resource
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+SOURCE_REPO = "llava-hf/llava-interleave-qwen-0.5b-hf"
+SOURCE_REVISION = "1090956dd1c79bc93ae98dcf395590369435ec91"
+SOURCE_MODEL_SHA256 = "ec7b02696781afdb1f27871fdffe0f71ef030932d10fbd759bc59392669605f7"
+SOURCE_TOKENIZER_SHA256 = "d26f54ac5bcc30ba15d418234e89d2ca44caf0bd57ce14749612a74f436738ef"
+CONVERTED_REPO = "mlx-community/llava-interleave-qwen-0.5b-bf16"
+CONVERTED_REVISION = "ba7385935f69c5417bfbe29c3809858a98afc22f"
+CONVERTED_MODEL_SHA256 = "43919c1ea46e00c6063204515169bb9635d0c2c6b3a07f975e20e9ea23c33d4c"
+CONVERTED_TOKENIZER_SHA256 = "32e8f623d8dce60b5a93496ec810434ef744287ac041cf2c6032743a3578baa5"
+IMAGE_SIZE = 384
+COMPUTE_DTYPES = {
+    "processor": "float32",
+    "prompt_embedding_lookup": "bfloat16",
+    "vision_projector": "float32",
+    "multimodal_merge": "bfloat16 then widened to float32",
+    "text_decoder": "float32",
+}
+
+VISION_HIDDEN_STATE_STAGES = tuple(
+    f"vision_hidden_state_{index:02}" for index in range(27)
+)
+VISION_BLOCK0_STAGES = (
+    "vision_block0_layer_norm1",
+    "vision_block0_q_proj",
+    "vision_block0_k_proj",
+    "vision_block0_v_proj",
+    "vision_block0_attention_context",
+    "vision_block0_attention_output",
+    "vision_block0_attention_residual",
+    "vision_block0_layer_norm2",
+    "vision_block0_mlp_fc1",
+    "vision_block0_mlp_activation",
+    "vision_block0_mlp_fc2",
+    "vision_block0_output",
+)
+STAGE_ORDER = (
+    "processor_pixel_values",
+    "expanded_token_ids",
+    "positions",
+    "attention_mask",
+) + VISION_HIDDEN_STATE_STAGES[:1] + VISION_BLOCK0_STAGES + VISION_HIDDEN_STATE_STAGES[1:] + (
+    "selected_vision_features",
+    "projected_image_features",
+    "merged_embeddings",
+    "first_prefill_logits",
+    "selected_kv",
+    "greedy_tokens",
+)
+
+# The processor is mathematically exact. Both implementations preserve the
+# checkpoint's BF16 prompt lookup and merge destination, then widen the merged
+# result at the IREE boundary. Vision, projector, and decoder arithmetic are F32.
+TOLERANCES = {
+    "float32": {
+        "processor_pixel_values": {"atol": 1.0e-6, "rtol": 1.0e-6},
+        "selected_vision_features": {"atol": 4.0e-3, "rtol": 1.0e-3},
+        "projected_image_features": {"atol": 1.0e-3, "rtol": 1.0e-3},
+        "merged_embeddings": {"atol": 4.0e-3, "rtol": 1.0e-3},
+        "first_prefill_logits": {"atol": 3.0e-2, "rtol": 3.0e-3},
+        "selected_kv": {"atol": 3.0e-3, "rtol": 3.0e-3},
+    },
+    "bfloat16": {
+        "processor_pixel_values": {"atol": 1.0e-6, "rtol": 1.0e-6},
+        "selected_vision_features": {"atol": 8.0e-2, "rtol": 4.0e-2},
+        "projected_image_features": {"atol": 8.0e-2, "rtol": 4.0e-2},
+        "merged_embeddings": {"atol": 8.0e-2, "rtol": 4.0e-2},
+        "first_prefill_logits": {"atol": 1.5e-1, "rtol": 5.0e-2},
+        "selected_kv": {"atol": 1.5e-1, "rtol": 5.0e-2},
+    },
+}
+for stage in VISION_BLOCK0_STAGES:
+    TOLERANCES["float32"][stage] = {"atol": 2.0e-4, "rtol": 2.0e-4}
+    TOLERANCES["bfloat16"][stage] = TOLERANCES["bfloat16"][
+        "selected_vision_features"
+    ]
+for index, stage in enumerate(VISION_HIDDEN_STATE_STAGES):
+    # Residual depth accumulates otherwise-independent F32 reduction order.
+    # The 12% per-layer budget starts at the strict block boundary and reaches
+    # 0.0038 at layer 26; logits and KV retain their tighter output budgets.
+    budget = 2.0e-4 * (1.12**index)
+    TOLERANCES["float32"][stage] = {"atol": budget, "rtol": budget}
+    TOLERANCES["bfloat16"][stage] = TOLERANCES["bfloat16"][
+        "selected_vision_features"
+    ]
+
+STAGE_POLICY_DTYPES = {"merged_embeddings": "bfloat16"}
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_sha(path: Path, expected: str, label: str) -> None:
+    if not path.is_file():
+        raise SystemExit(f"error: missing {label}: {path}")
+    actual = sha256(path)
+    if actual != expected:
+        raise SystemExit(
+            f"error: {label} SHA-256 mismatch: expected {expected}, got {actual}"
+        )
+
+
+def verify_vision_block0_conversion(
+    source_model: Path, converted_model: Path
+) -> dict[str, Any]:
+    """Prove that conversion did not change embedding/block-0 BF16 bits."""
+    import torch
+    from safetensors import safe_open
+
+    prefixes = (
+        "vision_tower.vision_model.embeddings.",
+        "vision_tower.vision_model.encoder.layers.0.",
+    )
+    digest = hashlib.sha256()
+    with (
+        safe_open(source_model, framework="pt", device="cpu") as source,
+        safe_open(converted_model, framework="pt", device="cpu") as converted,
+    ):
+        keys = sorted(key for key in source.keys() if key.startswith(prefixes))
+        if not keys:
+            raise SystemExit("error: source checkpoint has no vision block-0 tensors")
+        for key in keys:
+            if key not in converted.keys():
+                raise SystemExit(f"error: converted checkpoint is missing {key}")
+            expected = source.get_tensor(key)
+            actual = converted.get_tensor(key)
+            if key.endswith("embeddings.patch_embedding.weight"):
+                expected = expected.permute(0, 2, 3, 1).contiguous()
+            if expected.dtype != actual.dtype or expected.shape != actual.shape:
+                raise SystemExit(
+                    f"error: converted tensor metadata differs for {key}: "
+                    f"source={expected.dtype}/{tuple(expected.shape)}, "
+                    f"converted={actual.dtype}/{tuple(actual.shape)}"
+                )
+            if not torch.equal(expected, actual):
+                mismatches = int(
+                    (expected.view(torch.int16) != actual.view(torch.int16))
+                    .sum()
+                    .item()
+                )
+                raise SystemExit(
+                    f"error: converted tensor is not bit-exact for {key}: "
+                    f"{mismatches} BF16 values differ"
+                )
+            digest.update(key.encode())
+            digest.update(expected.view(torch.uint8).numpy().tobytes())
+    return {
+        "scope": "vision embeddings and encoder block 0",
+        "tensor_count": len(keys),
+        "bit_exact": True,
+        "canonical_sha256": digest.hexdigest(),
+        "layout_transform": "patch_embedding OIHW to OHWI",
+    }
+
+
+def rss_peak_kib() -> int:
+    # Linux reports KiB; macOS reports bytes. This harness is currently
+    # qualified on Linux GB10/CPU and records the platform in the manifest.
+    return int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+
+
+def store_array(
+    root: Path, case: str, stage: str, value: np.ndarray, arrays: dict[str, Any]
+) -> None:
+    value = np.ascontiguousarray(value)
+    filename = f"{case}.{stage}.bin"
+    value.tofile(root / filename)
+    arrays[stage] = {
+        "file": filename,
+        "dtype": str(value.dtype),
+        "shape": list(value.shape),
+    }
+
+
+def cases(processor: Any, image_path: Path) -> list[dict[str, Any]]:
+    definitions = (
+        ("image_text", "Describe the image briefly.", 1),
+        ("two_images", "Compare the two images briefly.", 2),
+        ("no_image", "Reply with one short greeting.", 0),
+    )
+    result = []
+    for name, user_prompt, image_count in definitions:
+        content = [{"type": "image"} for _ in range(image_count)]
+        content.append({"type": "text", "text": user_prompt})
+        text = processor.apply_chat_template(
+            [{"role": "user", "content": content}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        tokenized = processor.tokenizer(
+            text, add_special_tokens=False, return_tensors="pt"
+        )
+        result.append(
+            {
+                "name": name,
+                "user_prompt": user_prompt,
+                "text": text,
+                "image_count": image_count,
+                "image_path": str(image_path),
+                "unexpanded_input_ids": tokenized.input_ids[0]
+                .to(dtype=np_int32_torch())
+                .tolist(),
+            }
+        )
+    return result
+
+
+def np_int32_torch() -> Any:
+    import torch
+
+    return torch.int32
+
+
+def capture(args: argparse.Namespace) -> int:
+    try:
+        import torch
+        from PIL import Image
+        from transformers import AutoProcessor, LlavaForConditionalGeneration
+    except ImportError as error:
+        raise SystemExit(
+            "error: capture requires torch, transformers, numpy, and Pillow in "
+            f"the oracle environment: {error}"
+        ) from error
+
+    source = args.source_model.resolve()
+    converted = args.converted_model.resolve()
+    require_sha(source / "model.safetensors", SOURCE_MODEL_SHA256, "source weights")
+    require_sha(source / "tokenizer.json", SOURCE_TOKENIZER_SHA256, "source tokenizer")
+    require_sha(
+        converted / "model.safetensors", CONVERTED_MODEL_SHA256, "converted weights"
+    )
+    require_sha(
+        converted / "tokenizer.json",
+        CONVERTED_TOKENIZER_SHA256,
+        "converted tokenizer",
+    )
+    conversion_equivalence = verify_vision_block0_conversion(
+        source / "model.safetensors", converted / "model.safetensors"
+    )
+    args.out.mkdir(parents=True, exist_ok=True)
+    processor = AutoProcessor.from_pretrained(source, local_files_only=True)
+    image = Image.open(args.image).convert("RGB")
+    load_started = time.perf_counter()
+    model = LlavaForConditionalGeneration.from_pretrained(
+        source,
+        local_files_only=True,
+        dtype=torch.bfloat16,
+        attn_implementation="eager",
+    ).eval()
+    # Match the production ownership boundary exactly. Prompt text embedding is
+    # looked up from the immutable BF16 table on the host, while vision,
+    # projector, and the IREE decoder widen checkpoint values to F32.
+    prompt_embedding_weight = (
+        model.model.language_model.embed_tokens.weight.detach().clone()
+    )
+    model.model.vision_tower.float()
+    model.model.multi_modal_projector.float()
+    model.model.language_model.float()
+    model.lm_head.float()
+    device = torch.device(args.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise SystemExit("error: --device cuda requested but torch.cuda is unavailable")
+    model.to(device)
+    model_load_seconds = time.perf_counter() - load_started
+
+    manifest: dict[str, Any] = {
+        "schema": 1,
+        "producer": "huggingface-transformers",
+        "source": {
+            "repo": SOURCE_REPO,
+            "revision": SOURCE_REVISION,
+            "model_sha256": SOURCE_MODEL_SHA256,
+            "tokenizer_sha256": SOURCE_TOKENIZER_SHA256,
+            "license": "Tongyi Qianwen Research License",
+        },
+        "converted_checkpoint": {
+            "repo": CONVERTED_REPO,
+            "revision": CONVERTED_REVISION,
+            "model_sha256": CONVERTED_MODEL_SHA256,
+            "tokenizer_sha256": CONVERTED_TOKENIZER_SHA256,
+        },
+        "conversion_equivalence": conversion_equivalence,
+        "processor": {
+            "image_size": IMAGE_SIZE,
+            "resample": "bicubic",
+            "rescale_factor": 1.0 / 255.0,
+            "image_mean": [0.5, 0.5, 0.5],
+            "image_std": [0.5, 0.5, 0.5],
+        },
+        "compute_dtypes": COMPUTE_DTYPES,
+        "runtime": {
+            "device": str(device),
+            "torch_version": torch.__version__,
+            "cuda_version": torch.version.cuda,
+        },
+        "kv_selection": {
+            "position": "last_effective_prompt",
+            "kv_head": 0,
+            "width": args.kv_width,
+            "layers": int(model.config.text_config.num_hidden_layers),
+        },
+        "generation": {"mode": "greedy", "max_new_tokens": args.max_new},
+        "tolerances": TOLERANCES,
+        "stage_policy_dtypes": STAGE_POLICY_DTYPES,
+        "timings": {"model_load_seconds": model_load_seconds},
+        "host_peak_rss_kib": rss_peak_kib(),
+        "cases": [],
+    }
+
+    for definition in cases(processor, args.image.resolve()):
+        started = time.perf_counter()
+        images = [image.copy() for _ in range(definition["image_count"])]
+        inputs = processor(
+            text=definition["text"],
+            images=images or None,
+            return_tensors="pt",
+        )
+        inputs = inputs.to(device)
+        processor_seconds = time.perf_counter() - started
+        expanded_ids = inputs.input_ids
+        attention_mask = inputs.attention_mask
+        position_ids = torch.arange(
+            expanded_ids.shape[1], dtype=torch.int64, device=device
+        ).unsqueeze(0)
+
+        arrays: dict[str, Any] = {}
+        if definition["image_count"]:
+            store_array(
+                args.out,
+                definition["name"],
+                "processor_pixel_values",
+                inputs.pixel_values.cpu().numpy().astype(np.float32),
+                arrays,
+            )
+
+        with torch.inference_mode():
+            text_embeddings = torch.nn.functional.embedding(
+                expanded_ids, prompt_embedding_weight
+            )
+            image_features = None
+            selected_vision_features = None
+            vision_hidden_states = None
+            vision_block0: dict[str, torch.Tensor] = {}
+            vision_seconds = 0.0
+            if definition["image_count"]:
+                layer0 = model.model.vision_tower.encoder.layers[0]
+                hooks = []
+
+                def capture_output(name: str):
+                    def hook(_module: Any, _inputs: Any, output: Any) -> None:
+                        vision_block0[name] = output
+
+                    return hook
+
+                def capture_input(name: str):
+                    def hook(_module: Any, inputs: Any) -> None:
+                        vision_block0[name] = inputs[0]
+
+                    return hook
+
+                hooks.extend(
+                    (
+                        layer0.layer_norm1.register_forward_hook(
+                            capture_output("vision_block0_layer_norm1")
+                        ),
+                        layer0.self_attn.q_proj.register_forward_hook(
+                            capture_output("vision_block0_q_proj")
+                        ),
+                        layer0.self_attn.k_proj.register_forward_hook(
+                            capture_output("vision_block0_k_proj")
+                        ),
+                        layer0.self_attn.v_proj.register_forward_hook(
+                            capture_output("vision_block0_v_proj")
+                        ),
+                        layer0.self_attn.out_proj.register_forward_pre_hook(
+                            capture_input("vision_block0_attention_context")
+                        ),
+                        layer0.self_attn.out_proj.register_forward_hook(
+                            capture_output("vision_block0_attention_output")
+                        ),
+                        layer0.layer_norm2.register_forward_hook(
+                            capture_output("vision_block0_layer_norm2")
+                        ),
+                        layer0.mlp.fc1.register_forward_hook(
+                            capture_output("vision_block0_mlp_fc1")
+                        ),
+                        layer0.mlp.activation_fn.register_forward_hook(
+                            capture_output("vision_block0_mlp_activation")
+                        ),
+                        layer0.mlp.fc2.register_forward_hook(
+                            capture_output("vision_block0_mlp_fc2")
+                        ),
+                    )
+                )
+                vision_started = time.perf_counter()
+                image_outputs = model.get_image_features(
+                    pixel_values=inputs.pixel_values.to(torch.float32),
+                    vision_feature_layer=model.config.vision_feature_layer,
+                    vision_feature_select_strategy=model.config.vision_feature_select_strategy,
+                    return_dict=True,
+                )
+                for hook in hooks:
+                    hook.remove()
+                selected_vision_features = image_outputs.hidden_states[
+                    model.config.vision_feature_layer
+                ]
+                vision_hidden_states = image_outputs.hidden_states
+                vision_block0["vision_block0_attention_residual"] = (
+                    vision_hidden_states[0]
+                    + vision_block0["vision_block0_attention_output"]
+                )
+                vision_block0["vision_block0_output"] = vision_hidden_states[1]
+                image_features = torch.cat(image_outputs.pooler_output, dim=0).to(
+                    text_embeddings.device
+                )
+                vision_seconds = time.perf_counter() - vision_started
+                merge_image_features = image_features.to(text_embeddings.dtype)
+                mask = model.model.get_placeholder_mask(
+                    expanded_ids,
+                    inputs_embeds=text_embeddings,
+                    image_features=merge_image_features,
+                )
+                merged_embeddings = text_embeddings.masked_scatter(
+                    mask, merge_image_features
+                ).float()
+            else:
+                merged_embeddings = text_embeddings.float()
+
+            prefill_started = time.perf_counter()
+            language_output = model.model.language_model(
+                inputs_embeds=merged_embeddings,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                use_cache=True,
+                return_dict=True,
+            )
+            first_logits = model.lm_head(language_output.last_hidden_state[:, -1:])
+            prefill_seconds = time.perf_counter() - prefill_started
+            cache = language_output.past_key_values
+            selected = []
+            for layer in cache.layers:
+                selected.append(
+                    torch.stack(
+                        (
+                            layer.keys[0, 0, -1, : args.kv_width],
+                            layer.values[0, 0, -1, : args.kv_width],
+                        )
+                    )
+                )
+            selected_kv = torch.stack(selected)
+
+            greedy = [int(first_logits[0, -1].argmax().item())]
+            current = torch.tensor([[greedy[0]]], dtype=torch.int64, device=device)
+            decode_started = time.perf_counter()
+            while len(greedy) < args.max_new:
+                attention_mask = torch.cat(
+                    (
+                        attention_mask,
+                        torch.ones(
+                            (1, 1),
+                            dtype=attention_mask.dtype,
+                            device=attention_mask.device,
+                        ),
+                    ),
+                    dim=1,
+                )
+                decode_output = model.model.language_model(
+                    input_ids=current,
+                    attention_mask=attention_mask,
+                    past_key_values=cache,
+                    use_cache=True,
+                    return_dict=True,
+                )
+                decode_logits = model.lm_head(decode_output.last_hidden_state[:, -1:])
+                token = int(decode_logits[0, -1].argmax().item())
+                greedy.append(token)
+                current = torch.tensor([[token]], dtype=torch.int64, device=device)
+                cache = decode_output.past_key_values
+            decode_seconds = time.perf_counter() - decode_started
+
+        store_array(
+            args.out,
+            definition["name"],
+            "expanded_token_ids",
+            expanded_ids.cpu().numpy().astype(np.int32),
+            arrays,
+        )
+        store_array(
+            args.out,
+            definition["name"],
+            "positions",
+            position_ids.cpu().numpy().astype(np.int32),
+            arrays,
+        )
+        store_array(
+            args.out,
+            definition["name"],
+            "attention_mask",
+            inputs.attention_mask.cpu().numpy().astype(np.int32),
+            arrays,
+        )
+        if image_features is not None:
+            assert selected_vision_features is not None
+            assert vision_hidden_states is not None
+            for stage in VISION_BLOCK0_STAGES:
+                store_array(
+                    args.out,
+                    definition["name"],
+                    stage,
+                    vision_block0[stage].float().cpu().numpy().astype(np.float32),
+                    arrays,
+                )
+            for index, hidden_state in enumerate(vision_hidden_states):
+                store_array(
+                    args.out,
+                    definition["name"],
+                    f"vision_hidden_state_{index:02}",
+                    hidden_state.float().cpu().numpy().astype(np.float32),
+                    arrays,
+                )
+            store_array(
+                args.out,
+                definition["name"],
+                "selected_vision_features",
+                selected_vision_features.float().cpu().numpy().astype(np.float32),
+                arrays,
+            )
+            per_image_features = image_features.reshape(
+                definition["image_count"], -1, image_features.shape[-1]
+            )
+            store_array(
+                args.out,
+                definition["name"],
+                "projected_image_features",
+                per_image_features.float().cpu().numpy().astype(np.float32),
+                arrays,
+            )
+        store_array(
+            args.out,
+            definition["name"],
+            "merged_embeddings",
+            merged_embeddings.cpu().numpy().astype(np.float32),
+            arrays,
+        )
+        store_array(
+            args.out,
+            definition["name"],
+            "first_prefill_logits",
+            first_logits[0, -1].cpu().numpy().astype(np.float32),
+            arrays,
+        )
+        store_array(
+            args.out,
+            definition["name"],
+            "selected_kv",
+            selected_kv.cpu().numpy().astype(np.float32),
+            arrays,
+        )
+        store_array(
+            args.out,
+            definition["name"],
+            "greedy_tokens",
+            np.asarray(greedy, dtype=np.int32),
+            arrays,
+        )
+        manifest["cases"].append(
+            {
+                **definition,
+                "greedy_text": processor.tokenizer.decode(
+                    greedy,
+                    skip_special_tokens=True,
+                    clean_up_tokenization_spaces=False,
+                ),
+                "arrays": arrays,
+                "timings": {
+                    "processor_seconds": processor_seconds,
+                    "vision_projector_seconds": vision_seconds,
+                    "prefill_seconds": prefill_seconds,
+                    "decode_seconds": decode_seconds,
+                },
+            }
+        )
+        manifest["host_peak_rss_kib"] = max(
+            manifest["host_peak_rss_kib"], rss_peak_kib()
+        )
+        del (
+            inputs,
+            expanded_ids,
+            text_embeddings,
+            merged_embeddings,
+            language_output,
+            first_logits,
+            selected_kv,
+            cache,
+        )
+        gc.collect()
+
+    (args.out / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+    print(args.out / "manifest.json")
+    return 0
+
+
+def load_array(root: Path, spec: dict[str, Any]) -> np.ndarray:
+    dtype = spec["dtype"]
+    path = root / spec["file"]
+    if dtype == "bfloat16":
+        raw = np.fromfile(path, dtype=np.uint16)
+        values = (raw.astype(np.uint32) << 16).view(np.float32)
+    else:
+        values = np.fromfile(path, dtype=np.dtype(dtype))
+    return values.reshape(spec["shape"])
+
+
+def compare(args: argparse.Namespace) -> int:
+    reference_manifest = json.loads(
+        (args.reference / "manifest.json").read_text(encoding="utf-8")
+    )
+    actual_manifest = json.loads(
+        (args.actual / "manifest.json").read_text(encoding="utf-8")
+    )
+    reference_cases = {case["name"]: case for case in reference_manifest["cases"]}
+    actual_cases = {case["name"]: case for case in actual_manifest["cases"]}
+    report: dict[str, Any] = {
+        "schema": 1,
+        "reference": str(args.reference),
+        "actual": str(args.actual),
+        "passed": True,
+        "first_divergence": None,
+        "cases": [],
+    }
+    for case_name in ("image_text", "two_images", "no_image"):
+        case_report: dict[str, Any] = {
+            "name": case_name,
+            "passed": True,
+            "stages": [],
+        }
+        if case_name not in reference_cases or case_name not in actual_cases:
+            case_report["passed"] = False
+            case_report["error"] = "case missing from one manifest"
+            report["passed"] = False
+            report["first_divergence"] = report["first_divergence"] or {
+                "case": case_name,
+                "stage": "case",
+            }
+            report["cases"].append(case_report)
+            continue
+        reference = reference_cases[case_name]
+        actual = actual_cases[case_name]
+        for stage in STAGE_ORDER:
+            ref_spec = reference["arrays"].get(stage)
+            actual_spec = actual["arrays"].get(stage)
+            if ref_spec is None and actual_spec is None:
+                continue
+            stage_report: dict[str, Any] = {"stage": stage, "passed": True}
+            if ref_spec is None or actual_spec is None:
+                stage_report.update(
+                    passed=False, error="stage missing from one capture"
+                )
+            else:
+                ref = load_array(args.reference, ref_spec)
+                got = load_array(args.actual, actual_spec)
+                stage_report["reference_shape"] = list(ref.shape)
+                stage_report["actual_shape"] = list(got.shape)
+                if ref.shape != got.shape:
+                    stage_report.update(passed=False, error="shape mismatch")
+                elif np.issubdtype(ref.dtype, np.integer):
+                    mismatch = np.flatnonzero(ref.reshape(-1) != got.reshape(-1))
+                    stage_report["mismatch_count"] = int(mismatch.size)
+                    if mismatch.size:
+                        index = int(mismatch[0])
+                        stage_report.update(
+                            passed=False,
+                            first_mismatch_index=index,
+                            reference=int(ref.reshape(-1)[index]),
+                            actual=int(got.reshape(-1)[index]),
+                        )
+                else:
+                    policy_dtype = STAGE_POLICY_DTYPES.get(
+                        stage, actual_spec["dtype"]
+                    )
+                    if policy_dtype not in TOLERANCES:
+                        policy_dtype = "float32"
+                    tolerance = TOLERANCES[policy_dtype][stage]
+                    delta = np.abs(got.astype(np.float64) - ref.astype(np.float64))
+                    limit = tolerance["atol"] + tolerance["rtol"] * np.abs(
+                        ref.astype(np.float64)
+                    )
+                    mismatch = np.flatnonzero(delta.reshape(-1) > limit.reshape(-1))
+                    relative = delta / np.maximum(np.abs(ref), 1.0e-12)
+                    stage_report.update(
+                        tolerance_dtype=policy_dtype,
+                        atol=tolerance["atol"],
+                        rtol=tolerance["rtol"],
+                        max_abs=float(delta.max(initial=0.0)),
+                        max_rel=float(relative.max(initial=0.0)),
+                        mismatch_count=int(mismatch.size),
+                    )
+                    if mismatch.size:
+                        index = int(mismatch[0])
+                        stage_report.update(
+                            passed=False,
+                            first_mismatch_index=index,
+                            reference=float(ref.reshape(-1)[index]),
+                            actual=float(got.reshape(-1)[index]),
+                        )
+            if not stage_report["passed"]:
+                case_report["passed"] = False
+                report["passed"] = False
+                report["first_divergence"] = report["first_divergence"] or {
+                    "case": case_name,
+                    "stage": stage,
+                }
+            case_report["stages"].append(stage_report)
+        report["cases"].append(case_report)
+
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report["first_divergence"], sort_keys=True))
+    print(f"RESULT: {'PASS' if report['passed'] else 'FAIL'}")
+    return 0 if report["passed"] else 1
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    subcommands = root.add_subparsers(dest="command", required=True)
+    capture_parser = subcommands.add_parser("capture")
+    capture_parser.add_argument("--source-model", type=Path, required=True)
+    capture_parser.add_argument("--converted-model", type=Path, required=True)
+    capture_parser.add_argument("--image", type=Path, required=True)
+    capture_parser.add_argument("--out", type=Path, required=True)
+    capture_parser.add_argument("--max-new", type=int, default=4)
+    capture_parser.add_argument("--kv-width", type=int, default=8)
+    capture_parser.add_argument(
+        "--device", choices=("cpu", "cuda"), default="cpu"
+    )
+    capture_parser.set_defaults(run=capture)
+    compare_parser = subcommands.add_parser("compare")
+    compare_parser.add_argument("--reference", type=Path, required=True)
+    compare_parser.add_argument("--actual", type=Path, required=True)
+    compare_parser.add_argument("--report", type=Path, required=True)
+    compare_parser.set_defaults(run=compare)
+    return root
+
+
+if __name__ == "__main__":
+    parsed = parser().parse_args()
+    if getattr(parsed, "max_new", 1) <= 0 or getattr(parsed, "kv_width", 1) <= 0:
+        raise SystemExit("error: --max-new and --kv-width must be positive")
+    sys.exit(parsed.run(parsed))

--- a/spike/openxla/llava_reference_oracle.py
+++ b/spike/openxla/llava_reference_oracle.py
@@ -63,10 +63,34 @@ FIXTURE_PATH = "tests/fixtures/test_image.png"
 FIXTURE_SHA256 = "5e7d54e8a7d21802378c87d2d70cf551e29739fe27599ddf129ebccdad1e6261"
 CASE_IMAGE_TRANSFORMS = {
     "image_text": ("identity",),
-    "two_images": ("identity", "horizontal_mirror"),
+    "two_images": ("identity", "swap_red_blue"),
     "no_image": (),
 }
 IMAGE_SIZE = 384
+IMAGE_TOKENS = 729
+VISION_HIDDEN_SIZE = 1152
+VISION_INTERMEDIATE_SIZE = 4304
+TEXT_HIDDEN_SIZE = 1024
+VOCAB_SIZE = 152000
+TEXT_LAYERS = 24
+CASE_SEQUENCE_LENGTHS = {
+    "image_text": 743,
+    "two_images": 1473,
+    "no_image": 14,
+}
+PINNED_KV_SELECTION = {
+    "position": "last_effective_prompt",
+    "kv_head": 0,
+    "width": 8,
+    "layers": TEXT_LAYERS,
+}
+PINNED_GENERATION = {"mode": "greedy", "max_new_tokens": 4}
+FORBIDDEN_RUNTIME_ALTERNATE_NAMES = {
+    "chat_template.jinja",
+    "tokenizer.model",
+    "tokenizer.jsonl",
+    "tiktoken.model",
+}
 COMPUTE_DTYPES = {
     "processor": "float32",
     "prompt_embedding_lookup": "bfloat16",
@@ -207,12 +231,44 @@ def canonical_artifact_sha(artifacts: dict[str, str]) -> str:
     return hashlib.sha256(payload.encode()).hexdigest()
 
 
+def is_runtime_alternate(filename: str, allowed: set[str]) -> bool:
+    if filename in allowed:
+        return False
+    return (
+        filename in FORBIDDEN_RUNTIME_ALTERNATE_NAMES
+        or filename.endswith(".tiktoken")
+        or filename.endswith(".safetensors")
+        or filename.endswith(".safetensors.index.json")
+        or filename.endswith(".index.json")
+    )
+
+
+def reject_runtime_alternates(
+    root: Path, expected_artifacts: dict[str, str], label: str
+) -> None:
+    allowed = set(expected_artifacts)
+    try:
+        extras = sorted(
+            entry.name
+            for entry in root.iterdir()
+            if (entry.is_file() or entry.is_symlink())
+            and is_runtime_alternate(entry.name, allowed)
+        )
+    except OSError as error:
+        raise SystemExit(f"error: cannot inspect {label} snapshot {root}: {error}") from error
+    if extras:
+        raise SystemExit(
+            f"error: {label} snapshot has unpinned runtime alternate(s): {extras}"
+        )
+
+
 def require_artifact_manifest(
     root: Path,
     expected_artifacts: dict[str, str],
     expected_manifest_sha: str,
     label: str,
 ) -> dict[str, Any]:
+    reject_runtime_alternates(root, expected_artifacts, label)
     for filename, expected_sha in expected_artifacts.items():
         require_sha(root / filename, expected_sha, f"{label} {filename}")
     actual_manifest_sha = canonical_artifact_sha(expected_artifacts)
@@ -225,6 +281,70 @@ def require_artifact_manifest(
         "canonical_sha256": actual_manifest_sha,
         "files": expected_artifacts,
     }
+
+
+def transformed_image(image: Any, transform: str) -> Any:
+    from PIL import Image
+
+    if transform == "identity":
+        return image.copy()
+    if transform == "swap_red_blue":
+        red, green, blue = image.split()
+        transformed = Image.merge("RGB", (blue, green, red))
+        if transformed.size != image.size or transformed.tobytes() == image.tobytes():
+            raise AssertionError("swap_red_blue must preserve size and change RGB bytes")
+        return transformed
+    raise AssertionError(f"unsupported pinned image transform {transform!r}")
+
+
+def expected_stage_shapes(case_name: str) -> dict[str, list[int]]:
+    image_count = len(CASE_IMAGE_TRANSFORMS[case_name])
+    sequence_len = CASE_SEQUENCE_LENGTHS[case_name]
+    result = {
+        "expanded_token_ids": [1, sequence_len],
+        "positions": [1, sequence_len],
+        "attention_mask": [1, sequence_len],
+        "merged_embeddings": [1, sequence_len, TEXT_HIDDEN_SIZE],
+        "first_prefill_logits": [VOCAB_SIZE],
+        "selected_kv": [
+            TEXT_LAYERS,
+            2,
+            PINNED_KV_SELECTION["width"],
+        ],
+        "greedy_tokens": [PINNED_GENERATION["max_new_tokens"]],
+    }
+    if image_count:
+        result["processor_pixel_values"] = [
+            image_count,
+            3,
+            IMAGE_SIZE,
+            IMAGE_SIZE,
+        ]
+        for stage in VISION_HIDDEN_STATE_STAGES:
+            result[stage] = [
+                image_count,
+                IMAGE_TOKENS,
+                VISION_HIDDEN_SIZE,
+            ]
+        for stage in VISION_BLOCK0_STAGES:
+            width = (
+                VISION_INTERMEDIATE_SIZE
+                if stage
+                in {"vision_block0_mlp_fc1", "vision_block0_mlp_activation"}
+                else VISION_HIDDEN_SIZE
+            )
+            result[stage] = [image_count, IMAGE_TOKENS, width]
+        result["selected_vision_features"] = [
+            image_count,
+            IMAGE_TOKENS,
+            VISION_HIDDEN_SIZE,
+        ]
+        result["projected_image_features"] = [
+            image_count,
+            IMAGE_TOKENS,
+            TEXT_HIDDEN_SIZE,
+        ]
+    return result
 
 
 def verify_vision_block0_conversion(
@@ -343,6 +463,16 @@ def np_int32_torch() -> Any:
 
 
 def capture(args: argparse.Namespace) -> int:
+    if args.max_new != PINNED_GENERATION["max_new_tokens"]:
+        raise SystemExit(
+            "error: pinned capture requires "
+            f"--max-new {PINNED_GENERATION['max_new_tokens']}"
+        )
+    if args.kv_width != PINNED_KV_SELECTION["width"]:
+        raise SystemExit(
+            "error: pinned capture requires "
+            f"--kv-width {PINNED_KV_SELECTION['width']}"
+        )
     try:
         import torch
         from PIL import Image
@@ -415,7 +545,7 @@ def capture(args: argparse.Namespace) -> int:
         "image_fixture": {
             "path": FIXTURE_PATH,
             "sha256": FIXTURE_SHA256,
-            "two_image_transform": "horizontal_mirror",
+            "two_image_transform": "swap_red_blue",
         },
         "conversion_equivalence": conversion_equivalence,
         "processor": {
@@ -448,17 +578,28 @@ def capture(args: argparse.Namespace) -> int:
     for definition in cases(processor, image_path):
         started = time.perf_counter()
         images = [
-            image.copy()
-            if transform == "identity"
-            else image.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+            transformed_image(image, transform)
             for transform in definition["image_transforms"]
         ]
+        if definition["name"] == "two_images":
+            if images[0].tobytes() == images[1].tobytes():
+                raise AssertionError("two-image RGB inputs must be byte-distinct")
         inputs = processor(
             text=definition["text"],
             images=images or None,
             return_tensors="pt",
         )
         inputs = inputs.to(device)
+        if definition["name"] == "two_images":
+            pixels = inputs.pixel_values
+            if torch.equal(pixels[0], pixels[1]):
+                raise AssertionError(
+                    "two-image processor tensors must differ after channel swap"
+                )
+            if torch.equal(pixels, pixels.flip(0)):
+                raise AssertionError(
+                    "reversing two-image order must change the processor tensor"
+                )
         processor_seconds = time.perf_counter() - started
         expanded_ids = inputs.input_ids
         attention_mask = inputs.attention_mask
@@ -813,10 +954,14 @@ def validate_capture_manifest(
     expected_fixture = {
         "path": FIXTURE_PATH,
         "sha256": FIXTURE_SHA256,
-        "two_image_transform": "horizontal_mirror",
+        "two_image_transform": "swap_red_blue",
     }
     if fixture != expected_fixture:
         raise ContractError(f"{role} image fixture contract differs")
+    if manifest.get("kv_selection") != PINNED_KV_SELECTION:
+        raise ContractError(f"{role} kv_selection contract differs")
+    if manifest.get("generation") != PINNED_GENERATION:
+        raise ContractError(f"{role} generation contract differs")
 
     converted = manifest.get("converted_checkpoint")
     if not isinstance(converted, dict):
@@ -852,6 +997,7 @@ def validate_capture_manifest(
 
     root = root.resolve()
     for case_name, case in cases.items():
+        expected_shapes = expected_stage_shapes(case_name)
         expected_transforms = list(CASE_IMAGE_TRANSFORMS[case_name])
         if case.get("image_count") != len(expected_transforms):
             raise ContractError(f"{role} {case_name} image_count differs")
@@ -896,6 +1042,11 @@ def validate_capture_manifest(
             ):
                 raise ContractError(
                     f"{role} {case_name}/{stage} has an invalid shape"
+                )
+            if shape != expected_shapes[stage]:
+                raise ContractError(
+                    f"{role} {case_name}/{stage} shape must be "
+                    f"{expected_shapes[stage]}, got {shape}"
                 )
             element_count = 1
             for dimension in shape:

--- a/spike/openxla/llava_reference_oracle.py
+++ b/spike/openxla/llava_reference_oracle.py
@@ -22,12 +22,50 @@ import numpy as np
 
 SOURCE_REPO = "llava-hf/llava-interleave-qwen-0.5b-hf"
 SOURCE_REVISION = "1090956dd1c79bc93ae98dcf395590369435ec91"
-SOURCE_MODEL_SHA256 = "ec7b02696781afdb1f27871fdffe0f71ef030932d10fbd759bc59392669605f7"
-SOURCE_TOKENIZER_SHA256 = "d26f54ac5bcc30ba15d418234e89d2ca44caf0bd57ce14749612a74f436738ef"
 CONVERTED_REPO = "mlx-community/llava-interleave-qwen-0.5b-bf16"
 CONVERTED_REVISION = "ba7385935f69c5417bfbe29c3809858a98afc22f"
-CONVERTED_MODEL_SHA256 = "43919c1ea46e00c6063204515169bb9635d0c2c6b3a07f975e20e9ea23c33d4c"
-CONVERTED_TOKENIZER_SHA256 = "32e8f623d8dce60b5a93496ec810434ef744287ac041cf2c6032743a3578baa5"
+SOURCE_ARTIFACTS = {
+    "added_tokens.json": "f86f2a952b4888d195b8d77e3d56ad96864ecc696cca2155d0d4ac933fcfd55f",
+    "chat_template.json": "9d98326321da3c0514e31c907a2119f5efc323fc685d9794536c6098ca897852",
+    "config.json": "9b9b24a2b7a08b950c0c338f234d5cdfc5ebf526f360759f98a937b0f9374219",
+    "generation_config.json": "0b640df36b033e96856a803d834155919eafae4a427631ea046b67e12643157e",
+    "merges.txt": "8831e4f1a044471340f7c0a83d7bd71306a5b867e95fd870f74d0c5308a904d5",
+    "model.safetensors": "ec7b02696781afdb1f27871fdffe0f71ef030932d10fbd759bc59392669605f7",
+    "preprocessor_config.json": "6239b91cf50d40f36b4390ccc604a985c2388b95c5c77fa48c0658183bc5102c",
+    "processor_config.json": "e8ff88c7591da9738760aec6ca01c8aadc9cf514f30a2a88ca3994d8c1c4a52e",
+    "special_tokens_map.json": "f4f79e08d97f4d1c87f8d89264f525c8789da3b73b3bb55d1e12f692f41a7b1b",
+    "tokenizer.json": "d26f54ac5bcc30ba15d418234e89d2ca44caf0bd57ce14749612a74f436738ef",
+    "tokenizer_config.json": "5504fd209f6064bcba7a82b875f0af1927cd12fa7da2a6fbda0609070ce8d253",
+    "vocab.json": "ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910",
+}
+SOURCE_ARTIFACT_MANIFEST_SHA256 = (
+    "9c16795365b84aa42b7792ddcab2b954cc4e09e1a6307dddbcbafc2fac692a62"
+)
+CONVERTED_ARTIFACTS = {
+    "added_tokens.json": "f86f2a952b4888d195b8d77e3d56ad96864ecc696cca2155d0d4ac933fcfd55f",
+    "chat_template.json": "b7e65242c4107a669b40a2a6f62e5f4306ef328fa0d00c6bc0117df44f411603",
+    "config.json": "77cafd419e5c4218e1b1a45b3bd4b603873a9e7a316c62e8d2d5391f40d93d1b",
+    "generation_config.json": "0b640df36b033e96856a803d834155919eafae4a427631ea046b67e12643157e",
+    "merges.txt": "8831e4f1a044471340f7c0a83d7bd71306a5b867e95fd870f74d0c5308a904d5",
+    "model.safetensors": "43919c1ea46e00c6063204515169bb9635d0c2c6b3a07f975e20e9ea23c33d4c",
+    "model.safetensors.index.json": "0bf1ff182c7dbdede0e53341fa3f0c65019f86ac909ec9d388aca065a713191e",
+    "preprocessor_config.json": "6239b91cf50d40f36b4390ccc604a985c2388b95c5c77fa48c0658183bc5102c",
+    "processor_config.json": "2634ec0e0c3a222fa9439131f6e4a43a02ab8b50d25cf77d1f7766eb3efdcf2a",
+    "special_tokens_map.json": "1710dcae506cfff57fc8e63e1bff58f1d8c6aa2e2a8af56b65b33ed808a4c644",
+    "tokenizer.json": "32e8f623d8dce60b5a93496ec810434ef744287ac041cf2c6032743a3578baa5",
+    "tokenizer_config.json": "9d874e0d02b5a74d6e4863b38979e749d3738c2b03c1324675a4f1578730a802",
+    "vocab.json": "ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910",
+}
+CONVERTED_ARTIFACT_MANIFEST_SHA256 = (
+    "912650461f7abfce6fd3962711387c7aad485df239afb3c83c75126476f2050c"
+)
+FIXTURE_PATH = "tests/fixtures/test_image.png"
+FIXTURE_SHA256 = "5e7d54e8a7d21802378c87d2d70cf551e29739fe27599ddf129ebccdad1e6261"
+CASE_IMAGE_TRANSFORMS = {
+    "image_text": ("identity",),
+    "two_images": ("identity", "horizontal_mirror"),
+    "no_image": (),
+}
 IMAGE_SIZE = 384
 COMPUTE_DTYPES = {
     "processor": "float32",
@@ -105,6 +143,43 @@ for index, stage in enumerate(VISION_HIDDEN_STATE_STAGES):
     ]
 
 STAGE_POLICY_DTYPES = {"merged_embeddings": "bfloat16"}
+INTEGER_STAGES = {
+    "expanded_token_ids",
+    "positions",
+    "attention_mask",
+    "greedy_tokens",
+}
+CASE_REQUIRED_STAGES = {
+    "image_text": frozenset(STAGE_ORDER),
+    "two_images": frozenset(STAGE_ORDER),
+    "no_image": frozenset(
+        {
+            "expanded_token_ids",
+            "positions",
+            "attention_mask",
+            "merged_embeddings",
+            "first_prefill_logits",
+            "selected_kv",
+            "greedy_tokens",
+        }
+    ),
+}
+EXPECTED_NEGATIVE_CASES = {
+    "malformed_placeholder": {
+        "passed": True,
+        "outcome": "rejected",
+        "category": "placeholder_count_mismatch",
+    },
+    "context_overflow": {
+        "passed": True,
+        "outcome": "rejected",
+        "category": "context_capacity_exceeded",
+    },
+}
+
+
+class ContractError(ValueError):
+    """A capture failed the closed reference-manifest contract."""
 
 
 def sha256(path: Path) -> str:
@@ -123,6 +198,33 @@ def require_sha(path: Path, expected: str, label: str) -> None:
         raise SystemExit(
             f"error: {label} SHA-256 mismatch: expected {expected}, got {actual}"
         )
+
+
+def canonical_artifact_sha(artifacts: dict[str, str]) -> str:
+    payload = "".join(
+        f"{filename}={artifacts[filename]}\n" for filename in sorted(artifacts)
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def require_artifact_manifest(
+    root: Path,
+    expected_artifacts: dict[str, str],
+    expected_manifest_sha: str,
+    label: str,
+) -> dict[str, Any]:
+    for filename, expected_sha in expected_artifacts.items():
+        require_sha(root / filename, expected_sha, f"{label} {filename}")
+    actual_manifest_sha = canonical_artifact_sha(expected_artifacts)
+    if actual_manifest_sha != expected_manifest_sha:
+        raise SystemExit(
+            f"error: internal {label} canonical manifest mismatch: "
+            f"expected {expected_manifest_sha}, got {actual_manifest_sha}"
+        )
+    return {
+        "canonical_sha256": actual_manifest_sha,
+        "files": expected_artifacts,
+    }
 
 
 def verify_vision_block0_conversion(
@@ -205,6 +307,9 @@ def cases(processor: Any, image_path: Path) -> list[dict[str, Any]]:
     )
     result = []
     for name, user_prompt, image_count in definitions:
+        image_transforms = CASE_IMAGE_TRANSFORMS[name]
+        if len(image_transforms) != image_count:
+            raise AssertionError(f"invalid image transform contract for {name}")
         content = [{"type": "image"} for _ in range(image_count)]
         content.append({"type": "text", "text": user_prompt})
         text = processor.apply_chat_template(
@@ -221,6 +326,7 @@ def cases(processor: Any, image_path: Path) -> list[dict[str, Any]]:
                 "user_prompt": user_prompt,
                 "text": text,
                 "image_count": image_count,
+                "image_transforms": list(image_transforms),
                 "image_path": str(image_path),
                 "unexpanded_input_ids": tokenized.input_ids[0]
                 .to(dtype=np_int32_torch())
@@ -249,22 +355,26 @@ def capture(args: argparse.Namespace) -> int:
 
     source = args.source_model.resolve()
     converted = args.converted_model.resolve()
-    require_sha(source / "model.safetensors", SOURCE_MODEL_SHA256, "source weights")
-    require_sha(source / "tokenizer.json", SOURCE_TOKENIZER_SHA256, "source tokenizer")
-    require_sha(
-        converted / "model.safetensors", CONVERTED_MODEL_SHA256, "converted weights"
+    source_artifact_manifest = require_artifact_manifest(
+        source,
+        SOURCE_ARTIFACTS,
+        SOURCE_ARTIFACT_MANIFEST_SHA256,
+        "source snapshot",
     )
-    require_sha(
-        converted / "tokenizer.json",
-        CONVERTED_TOKENIZER_SHA256,
-        "converted tokenizer",
+    converted_artifact_manifest = require_artifact_manifest(
+        converted,
+        CONVERTED_ARTIFACTS,
+        CONVERTED_ARTIFACT_MANIFEST_SHA256,
+        "converted snapshot",
     )
+    image_path = args.image.resolve()
+    require_sha(image_path, FIXTURE_SHA256, "pinned image fixture")
     conversion_equivalence = verify_vision_block0_conversion(
         source / "model.safetensors", converted / "model.safetensors"
     )
     args.out.mkdir(parents=True, exist_ok=True)
     processor = AutoProcessor.from_pretrained(source, local_files_only=True)
-    image = Image.open(args.image).convert("RGB")
+    image = Image.open(image_path).convert("RGB")
     load_started = time.perf_counter()
     model = LlavaForConditionalGeneration.from_pretrained(
         source,
@@ -294,15 +404,18 @@ def capture(args: argparse.Namespace) -> int:
         "source": {
             "repo": SOURCE_REPO,
             "revision": SOURCE_REVISION,
-            "model_sha256": SOURCE_MODEL_SHA256,
-            "tokenizer_sha256": SOURCE_TOKENIZER_SHA256,
+            "artifact_manifest": source_artifact_manifest,
             "license": "Tongyi Qianwen Research License",
         },
         "converted_checkpoint": {
             "repo": CONVERTED_REPO,
             "revision": CONVERTED_REVISION,
-            "model_sha256": CONVERTED_MODEL_SHA256,
-            "tokenizer_sha256": CONVERTED_TOKENIZER_SHA256,
+            "artifact_manifest": converted_artifact_manifest,
+        },
+        "image_fixture": {
+            "path": FIXTURE_PATH,
+            "sha256": FIXTURE_SHA256,
+            "two_image_transform": "horizontal_mirror",
         },
         "conversion_equivalence": conversion_equivalence,
         "processor": {
@@ -332,9 +445,14 @@ def capture(args: argparse.Namespace) -> int:
         "cases": [],
     }
 
-    for definition in cases(processor, args.image.resolve()):
+    for definition in cases(processor, image_path):
         started = time.perf_counter()
-        images = [image.copy() for _ in range(definition["image_count"])]
+        images = [
+            image.copy()
+            if transform == "identity"
+            else image.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+            for transform in definition["image_transforms"]
+        ]
         inputs = processor(
             text=definition["text"],
             images=images or None,
@@ -627,69 +745,242 @@ def capture(args: argparse.Namespace) -> int:
     return 0
 
 
+def strict_json_load(path: Path) -> dict[str, Any]:
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ContractError(f"duplicate JSON key {key!r} in {path}")
+            result[key] = value
+        return result
+
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=lambda constant: (_ for _ in ()).throw(
+                ContractError(f"non-finite JSON value {constant!r} in {path}")
+            ),
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ContractError(f"cannot read {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ContractError(f"{path} must contain a JSON object")
+    return value
+
+
+def validate_artifact_contract(
+    value: Any,
+    expected_artifacts: dict[str, str],
+    expected_manifest_sha: str,
+    label: str,
+) -> None:
+    if not isinstance(value, dict) or set(value) != {"canonical_sha256", "files"}:
+        raise ContractError(f"{label} artifact_manifest has an invalid schema")
+    if value["files"] != expected_artifacts:
+        raise ContractError(f"{label} artifact_manifest file hashes differ")
+    if value["canonical_sha256"] != expected_manifest_sha:
+        raise ContractError(f"{label} artifact_manifest canonical hash differs")
+    if canonical_artifact_sha(value["files"]) != expected_manifest_sha:
+        raise ContractError(f"{label} artifact_manifest is not canonical")
+
+
+def validate_capture_manifest(
+    root: Path, manifest: dict[str, Any], role: str
+) -> dict[str, dict[str, Any]]:
+    if manifest.get("schema") != 1:
+        raise ContractError(f"{role} manifest schema must be 1")
+    cases_value = manifest.get("cases")
+    if not isinstance(cases_value, list):
+        raise ContractError(f"{role} manifest cases must be a list")
+    cases: dict[str, dict[str, Any]] = {}
+    for case in cases_value:
+        if not isinstance(case, dict) or not isinstance(case.get("name"), str):
+            raise ContractError(f"{role} manifest has an invalid case")
+        name = case["name"]
+        if name in cases:
+            raise ContractError(f"{role} manifest has duplicate case {name!r}")
+        cases[name] = case
+    expected_cases = set(CASE_REQUIRED_STAGES)
+    if set(cases) != expected_cases:
+        missing = sorted(expected_cases - set(cases))
+        extra = sorted(set(cases) - expected_cases)
+        raise ContractError(
+            f"{role} case set differs: missing={missing}, extra={extra}"
+        )
+
+    fixture = manifest.get("image_fixture")
+    expected_fixture = {
+        "path": FIXTURE_PATH,
+        "sha256": FIXTURE_SHA256,
+        "two_image_transform": "horizontal_mirror",
+    }
+    if fixture != expected_fixture:
+        raise ContractError(f"{role} image fixture contract differs")
+
+    converted = manifest.get("converted_checkpoint")
+    if not isinstance(converted, dict):
+        raise ContractError(f"{role} converted checkpoint metadata is missing")
+    validate_artifact_contract(
+        converted.get("artifact_manifest"),
+        CONVERTED_ARTIFACTS,
+        CONVERTED_ARTIFACT_MANIFEST_SHA256,
+        f"{role} converted",
+    )
+    if role == "reference":
+        if converted.get("repo") != CONVERTED_REPO:
+            raise ContractError("reference converted repo differs")
+        if converted.get("revision") != CONVERTED_REVISION:
+            raise ContractError("reference converted revision differs")
+        source = manifest.get("source")
+        if not isinstance(source, dict):
+            raise ContractError("reference source metadata is missing")
+        if source.get("repo") != SOURCE_REPO:
+            raise ContractError("reference source repo differs")
+        if source.get("revision") != SOURCE_REVISION:
+            raise ContractError("reference source revision differs")
+        validate_artifact_contract(
+            source.get("artifact_manifest"),
+            SOURCE_ARTIFACTS,
+            SOURCE_ARTIFACT_MANIFEST_SHA256,
+            "reference source",
+        )
+    elif manifest.get("negative_cases") != EXPECTED_NEGATIVE_CASES:
+        raise ContractError(
+            "actual negative_cases must exactly match the required rejected outcomes"
+        )
+
+    root = root.resolve()
+    for case_name, case in cases.items():
+        expected_transforms = list(CASE_IMAGE_TRANSFORMS[case_name])
+        if case.get("image_count") != len(expected_transforms):
+            raise ContractError(f"{role} {case_name} image_count differs")
+        if case.get("image_transforms") != expected_transforms:
+            raise ContractError(f"{role} {case_name} image transforms differ")
+        arrays = case.get("arrays")
+        if not isinstance(arrays, dict):
+            raise ContractError(f"{role} {case_name} arrays must be an object")
+        required_stages = CASE_REQUIRED_STAGES[case_name]
+        if set(arrays) != required_stages:
+            missing = sorted(required_stages - set(arrays))
+            extra = sorted(set(arrays) - required_stages)
+            raise ContractError(
+                f"{role} {case_name} stage set differs: "
+                f"missing={missing}, extra={extra}"
+            )
+        for stage, spec in arrays.items():
+            if not isinstance(spec, dict) or set(spec) != {"file", "dtype", "shape"}:
+                raise ContractError(
+                    f"{role} {case_name}/{stage} has an invalid array schema"
+                )
+            expected_file = f"{case_name}.{stage}.bin"
+            if spec["file"] != expected_file:
+                raise ContractError(
+                    f"{role} {case_name}/{stage} has an invalid array path"
+                )
+            expected_dtype = "int32" if stage in INTEGER_STAGES else "float32"
+            if spec["dtype"] != expected_dtype:
+                raise ContractError(
+                    f"{role} {case_name}/{stage} dtype must be {expected_dtype}"
+                )
+            shape = spec["shape"]
+            if (
+                not isinstance(shape, list)
+                or not shape
+                or any(
+                    isinstance(dimension, bool)
+                    or not isinstance(dimension, int)
+                    or dimension <= 0
+                    for dimension in shape
+                )
+            ):
+                raise ContractError(
+                    f"{role} {case_name}/{stage} has an invalid shape"
+                )
+            element_count = 1
+            for dimension in shape:
+                element_count *= dimension
+                if element_count > 2**63 - 1:
+                    raise ContractError(
+                        f"{role} {case_name}/{stage} shape is too large"
+                    )
+            path = root / expected_file
+            if path.is_symlink() or not path.is_file():
+                raise ContractError(
+                    f"{role} {case_name}/{stage} binary is missing or not regular"
+                )
+            expected_size = element_count * np.dtype(expected_dtype).itemsize
+            actual_size = path.stat().st_size
+            if actual_size != expected_size:
+                raise ContractError(
+                    f"{role} {case_name}/{stage} binary size differs: "
+                    f"expected={expected_size}, actual={actual_size}"
+                )
+    return cases
+
+
 def load_array(root: Path, spec: dict[str, Any]) -> np.ndarray:
-    dtype = spec["dtype"]
-    path = root / spec["file"]
-    if dtype == "bfloat16":
-        raw = np.fromfile(path, dtype=np.uint16)
-        values = (raw.astype(np.uint32) << 16).view(np.float32)
-    else:
-        values = np.fromfile(path, dtype=np.dtype(dtype))
+    values = np.fromfile(root / spec["file"], dtype=np.dtype(spec["dtype"]))
     return values.reshape(spec["shape"])
 
 
-def compare(args: argparse.Namespace) -> int:
-    reference_manifest = json.loads(
-        (args.reference / "manifest.json").read_text(encoding="utf-8")
-    )
-    actual_manifest = json.loads(
-        (args.actual / "manifest.json").read_text(encoding="utf-8")
-    )
-    reference_cases = {case["name"]: case for case in reference_manifest["cases"]}
-    actual_cases = {case["name"]: case for case in actual_manifest["cases"]}
+def compare_capture_roots(reference_root: Path, actual_root: Path) -> dict[str, Any]:
     report: dict[str, Any] = {
         "schema": 1,
-        "reference": str(args.reference),
-        "actual": str(args.actual),
+        "reference": str(reference_root),
+        "actual": str(actual_root),
         "passed": True,
         "first_divergence": None,
         "cases": [],
     }
-    for case_name in ("image_text", "two_images", "no_image"):
+    try:
+        reference_manifest = strict_json_load(reference_root / "manifest.json")
+        actual_manifest = strict_json_load(actual_root / "manifest.json")
+        reference_cases = validate_capture_manifest(
+            reference_root, reference_manifest, "reference"
+        )
+        actual_cases = validate_capture_manifest(actual_root, actual_manifest, "actual")
+    except ContractError as error:
+        report.update(
+            passed=False,
+            first_divergence={"case": "manifest", "stage": "contract"},
+            error=str(error),
+        )
+        return report
+
+    for case_name in CASE_REQUIRED_STAGES:
         case_report: dict[str, Any] = {
             "name": case_name,
             "passed": True,
             "stages": [],
         }
-        if case_name not in reference_cases or case_name not in actual_cases:
-            case_report["passed"] = False
-            case_report["error"] = "case missing from one manifest"
-            report["passed"] = False
-            report["first_divergence"] = report["first_divergence"] or {
-                "case": case_name,
-                "stage": "case",
-            }
-            report["cases"].append(case_report)
-            continue
         reference = reference_cases[case_name]
         actual = actual_cases[case_name]
         for stage in STAGE_ORDER:
+            if stage not in CASE_REQUIRED_STAGES[case_name]:
+                continue
             ref_spec = reference["arrays"].get(stage)
             actual_spec = actual["arrays"].get(stage)
-            if ref_spec is None and actual_spec is None:
-                continue
             stage_report: dict[str, Any] = {"stage": stage, "passed": True}
-            if ref_spec is None or actual_spec is None:
-                stage_report.update(
-                    passed=False, error="stage missing from one capture"
-                )
+            if ref_spec["dtype"] != actual_spec["dtype"]:
+                stage_report.update(passed=False, error="dtype mismatch")
             else:
-                ref = load_array(args.reference, ref_spec)
-                got = load_array(args.actual, actual_spec)
+                ref = load_array(reference_root, ref_spec)
+                got = load_array(actual_root, actual_spec)
                 stage_report["reference_shape"] = list(ref.shape)
                 stage_report["actual_shape"] = list(got.shape)
                 if ref.shape != got.shape:
                     stage_report.update(passed=False, error="shape mismatch")
+                elif (
+                    np.issubdtype(ref.dtype, np.floating)
+                    and (
+                        not bool(np.isfinite(ref).all())
+                        or not bool(np.isfinite(got).all())
+                    )
+                ):
+                    stage_report.update(
+                        passed=False, error="non-finite array value"
+                    )
                 elif np.issubdtype(ref.dtype, np.integer):
                     mismatch = np.flatnonzero(ref.reshape(-1) != got.reshape(-1))
                     stage_report["mismatch_count"] = int(mismatch.size)
@@ -739,7 +1030,11 @@ def compare(args: argparse.Namespace) -> int:
                 }
             case_report["stages"].append(stage_report)
         report["cases"].append(case_report)
+    return report
 
+
+def compare(args: argparse.Namespace) -> int:
+    report = compare_capture_roots(args.reference, args.actual)
     args.report.parent.mkdir(parents=True, exist_ok=True)
     args.report.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
     print(json.dumps(report["first_divergence"], sort_keys=True))

--- a/spike/openxla/requirements.lock
+++ b/spike/openxla/requirements.lock
@@ -23,6 +23,7 @@ networkx==3.6.1
 numpy==2.5.0
 opt-einsum==3.4.0
 packaging==26.2
+pillow==10.4.0
 pygments==2.20.0
 pyyaml==6.0.3
 regex==2026.5.9

--- a/spike/openxla/test_llava_reference_oracle.py
+++ b/spike/openxla/test_llava_reference_oracle.py
@@ -29,6 +29,8 @@ class ComparatorContractTests(unittest.TestCase):
         self.actual_manifest = self.manifest("actual")
         self.write_arrays(self.reference, self.reference_manifest)
         self.write_arrays(self.actual, self.actual_manifest)
+        self.write_distinct_two_image_pixels(self.reference)
+        self.write_distinct_two_image_pixels(self.actual)
         self.write_manifests()
 
     def tearDown(self) -> None:
@@ -42,8 +44,10 @@ class ComparatorContractTests(unittest.TestCase):
             "image_fixture": {
                 "path": oracle.FIXTURE_PATH,
                 "sha256": oracle.FIXTURE_SHA256,
-                "two_image_transform": "horizontal_mirror",
+                "two_image_transform": "swap_red_blue",
             },
+            "kv_selection": copy.deepcopy(oracle.PINNED_KV_SELECTION),
+            "generation": copy.deepcopy(oracle.PINNED_GENERATION),
             "converted_checkpoint": {
                 "repo": oracle.CONVERTED_REPO,
                 "revision": oracle.CONVERTED_REVISION,
@@ -69,12 +73,13 @@ class ComparatorContractTests(unittest.TestCase):
             )
         for case_name, stages in oracle.CASE_REQUIRED_STAGES.items():
             arrays = {}
+            expected_shapes = oracle.expected_stage_shapes(case_name)
             for stage in stages:
                 dtype = "int32" if stage in oracle.INTEGER_STAGES else "float32"
                 arrays[stage] = {
                     "file": f"{case_name}.{stage}.bin",
                     "dtype": dtype,
-                    "shape": [1],
+                    "shape": expected_shapes[stage],
                 }
             manifest["cases"].append(
                 {
@@ -92,9 +97,22 @@ class ComparatorContractTests(unittest.TestCase):
     def write_arrays(root: Path, manifest: dict[str, Any]) -> None:
         for case in manifest["cases"]:
             for spec in case["arrays"].values():
-                np.zeros(spec["shape"], dtype=spec["dtype"]).tofile(
-                    root / spec["file"]
-                )
+                element_count = int(np.prod(spec["shape"], dtype=np.int64))
+                with (root / spec["file"]).open("wb") as stream:
+                    stream.truncate(
+                        element_count * np.dtype(spec["dtype"]).itemsize
+                    )
+
+    @staticmethod
+    def write_distinct_two_image_pixels(root: Path) -> None:
+        per_image = 3 * oracle.IMAGE_SIZE * oracle.IMAGE_SIZE
+        pixels = np.concatenate(
+            (
+                np.zeros(per_image, dtype=np.float32),
+                np.ones(per_image, dtype=np.float32),
+            )
+        )
+        pixels.tofile(root / "two_images.processor_pixel_values.bin")
 
     def write_manifests(self) -> None:
         (self.reference / "manifest.json").write_text(
@@ -158,7 +176,7 @@ class ComparatorContractTests(unittest.TestCase):
             injection = (
                 '"arrays": {"selected_kv": '
                 '{"file": "image_text.selected_kv.bin", '
-                '"dtype": "float32", "shape": [1]},'
+                '"dtype": "float32", "shape": [24, 2, 8]},'
             )
             path.write_text(text.replace('"arrays": {', injection, 1), encoding="utf-8")
             self.assert_rejected("duplicate json key")
@@ -167,7 +185,8 @@ class ComparatorContractTests(unittest.TestCase):
         path = self.actual / "image_text.first_prefill_logits.bin"
         for value in (np.nan, np.inf):
             with self.subTest(value=value):
-                np.asarray([value], dtype=np.float32).tofile(path)
+                with path.open("r+b") as stream:
+                    stream.write(np.asarray([value], dtype=np.float32).tobytes())
                 report = oracle.compare_capture_roots(self.reference, self.actual)
                 self.assertFalse(report["passed"], report)
                 stage = next(
@@ -200,12 +219,29 @@ class ComparatorContractTests(unittest.TestCase):
             self.write_manifests()
             self.assert_rejected("invalid array path")
 
+    def test_positive_but_semantically_wrong_shapes_are_rejected(self) -> None:
+        mutations = (
+            ("first_prefill_logits", [1]),
+            (
+                "attention_mask",
+                [1, oracle.CASE_SEQUENCE_LENGTHS["image_text"] - 1],
+            ),
+            ("selected_kv", [oracle.TEXT_LAYERS, 1, 16]),
+        )
+        baseline = copy.deepcopy(self.actual_manifest)
+        for stage, shape in mutations:
+            with self.subTest(stage=stage):
+                self.actual_manifest = copy.deepcopy(baseline)
+                self.actual_manifest["cases"][0]["arrays"][stage]["shape"] = shape
+                self.write_manifests()
+                self.assert_rejected("shape must be")
+
     def test_truncated_and_oversized_binaries_are_rejected(self) -> None:
         path = self.actual / "image_text.selected_kv.bin"
         with self.subTest("truncated"):
             path.write_bytes(b"\x00\x00")
             self.assert_rejected("binary size differs")
-        np.zeros([1], dtype=np.float32).tofile(path)
+        path.write_bytes(bytes(oracle.TEXT_LAYERS * 2 * 8 * 4))
         with self.subTest("oversized"):
             path.write_bytes(path.read_bytes() + b"\x00")
             self.assert_rejected("binary size differs")
@@ -230,6 +266,77 @@ class ComparatorContractTests(unittest.TestCase):
                 mutate(self.actual_manifest["negative_cases"])
                 self.write_manifests()
                 self.assert_rejected("negative_cases")
+
+    def test_reversed_two_image_transform_labels_are_rejected(self) -> None:
+        two_images = next(
+            case
+            for case in self.actual_manifest["cases"]
+            if case["name"] == "two_images"
+        )
+        two_images["image_transforms"] = ["swap_red_blue", "identity"]
+        self.write_manifests()
+        self.assert_rejected("image transforms differ")
+
+    def test_reversed_two_image_tensor_payload_is_first_divergence(self) -> None:
+        path = self.actual / "two_images.processor_pixel_values.bin"
+        payload = path.read_bytes()
+        per_image = len(payload) // 2
+        path.write_bytes(payload[per_image:] + payload[:per_image])
+        report = oracle.compare_capture_roots(self.reference, self.actual)
+        self.assertFalse(report["passed"], report)
+        self.assertEqual(
+            report["first_divergence"],
+            {"case": "two_images", "stage": "processor_pixel_values"},
+        )
+
+    def test_kv_and_generation_metadata_are_exact(self) -> None:
+        with self.subTest("kv-width"):
+            self.actual_manifest["kv_selection"]["width"] = 1
+            self.write_manifests()
+            self.assert_rejected("kv_selection")
+        self.actual_manifest["kv_selection"] = copy.deepcopy(
+            oracle.PINNED_KV_SELECTION
+        )
+        with self.subTest("generation"):
+            self.actual_manifest["generation"]["max_new_tokens"] = 1
+            self.write_manifests()
+            self.assert_rejected("generation")
+
+
+class SnapshotPinningTests(unittest.TestCase):
+    def test_swap_red_blue_is_byte_distinct_and_reversible(self) -> None:
+        from PIL import Image
+
+        identity = Image.new("RGB", (2, 1), (255, 100, 50))
+        swapped = oracle.transformed_image(identity, "swap_red_blue")
+        self.assertNotEqual(identity.tobytes(), swapped.tobytes())
+        self.assertEqual(swapped.getpixel((0, 0)), (50, 100, 255))
+        restored = oracle.transformed_image(swapped, "swap_red_blue")
+        self.assertEqual(restored.tobytes(), identity.tobytes())
+
+    def test_extra_chat_template_jinja_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "chat_template.jinja").write_text("conflicting template")
+            with self.assertRaisesRegex(SystemExit, "unpinned runtime alternate"):
+                oracle.reject_runtime_alternates(
+                    root, oracle.CONVERTED_ARTIFACTS, "converted"
+                )
+
+    def test_runtime_metadata_is_ignored_but_alternate_weights_are_rejected(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "README.md").write_text("metadata")
+            oracle.reject_runtime_alternates(
+                root, oracle.CONVERTED_ARTIFACTS, "converted"
+            )
+            (root / "model-00001-of-00002.safetensors").write_bytes(b"")
+            with self.assertRaisesRegex(SystemExit, "unpinned runtime alternate"):
+                oracle.reject_runtime_alternates(
+                    root, oracle.CONVERTED_ARTIFACTS, "converted"
+                )
 
 
 if __name__ == "__main__":

--- a/spike/openxla/test_llava_reference_oracle.py
+++ b/spike/openxla/test_llava_reference_oracle.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Adversarial, model-free tests for the LLaVA capture comparator."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import llava_reference_oracle as oracle
+
+
+class ComparatorContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.reference = self.root / "reference"
+        self.actual = self.root / "actual"
+        self.reference.mkdir()
+        self.actual.mkdir()
+        self.reference_manifest = self.manifest("reference")
+        self.actual_manifest = self.manifest("actual")
+        self.write_arrays(self.reference, self.reference_manifest)
+        self.write_arrays(self.actual, self.actual_manifest)
+        self.write_manifests()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    @staticmethod
+    def manifest(role: str) -> dict[str, Any]:
+        manifest: dict[str, Any] = {
+            "schema": 1,
+            "producer": role,
+            "image_fixture": {
+                "path": oracle.FIXTURE_PATH,
+                "sha256": oracle.FIXTURE_SHA256,
+                "two_image_transform": "horizontal_mirror",
+            },
+            "converted_checkpoint": {
+                "repo": oracle.CONVERTED_REPO,
+                "revision": oracle.CONVERTED_REVISION,
+                "artifact_manifest": {
+                    "canonical_sha256": oracle.CONVERTED_ARTIFACT_MANIFEST_SHA256,
+                    "files": oracle.CONVERTED_ARTIFACTS,
+                },
+            },
+            "cases": [],
+        }
+        if role == "reference":
+            manifest["source"] = {
+                "repo": oracle.SOURCE_REPO,
+                "revision": oracle.SOURCE_REVISION,
+                "artifact_manifest": {
+                    "canonical_sha256": oracle.SOURCE_ARTIFACT_MANIFEST_SHA256,
+                    "files": oracle.SOURCE_ARTIFACTS,
+                },
+            }
+        else:
+            manifest["negative_cases"] = copy.deepcopy(
+                oracle.EXPECTED_NEGATIVE_CASES
+            )
+        for case_name, stages in oracle.CASE_REQUIRED_STAGES.items():
+            arrays = {}
+            for stage in stages:
+                dtype = "int32" if stage in oracle.INTEGER_STAGES else "float32"
+                arrays[stage] = {
+                    "file": f"{case_name}.{stage}.bin",
+                    "dtype": dtype,
+                    "shape": [1],
+                }
+            manifest["cases"].append(
+                {
+                    "name": case_name,
+                    "image_count": len(oracle.CASE_IMAGE_TRANSFORMS[case_name]),
+                    "image_transforms": list(
+                        oracle.CASE_IMAGE_TRANSFORMS[case_name]
+                    ),
+                    "arrays": arrays,
+                }
+            )
+        return manifest
+
+    @staticmethod
+    def write_arrays(root: Path, manifest: dict[str, Any]) -> None:
+        for case in manifest["cases"]:
+            for spec in case["arrays"].values():
+                np.zeros(spec["shape"], dtype=spec["dtype"]).tofile(
+                    root / spec["file"]
+                )
+
+    def write_manifests(self) -> None:
+        (self.reference / "manifest.json").write_text(
+            json.dumps(self.reference_manifest), encoding="utf-8"
+        )
+        (self.actual / "manifest.json").write_text(
+            json.dumps(self.actual_manifest), encoding="utf-8"
+        )
+
+    def assert_rejected(self, contains: str) -> None:
+        report = oracle.compare_capture_roots(self.reference, self.actual)
+        self.assertFalse(report["passed"], report)
+        self.assertIn(contains, report.get("error", "").lower())
+
+    def test_valid_capture_passes(self) -> None:
+        self.assertTrue(
+            oracle.compare_capture_roots(self.reference, self.actual)["passed"]
+        )
+
+    def test_missing_required_stage_from_both_is_rejected(self) -> None:
+        for manifest in (self.reference_manifest, self.actual_manifest):
+            del manifest["cases"][0]["arrays"]["selected_kv"]
+        self.write_manifests()
+        self.assert_rejected("stage set differs")
+
+    def test_extra_and_duplicate_cases_are_rejected(self) -> None:
+        baseline = copy.deepcopy(self.actual_manifest)
+        with self.subTest("extra"):
+            self.actual_manifest["cases"].append(
+                copy.deepcopy(self.actual_manifest["cases"][0])
+                | {"name": "unexpected"}
+            )
+            self.write_manifests()
+            self.assert_rejected("case set differs")
+        self.actual_manifest = copy.deepcopy(baseline)
+        with self.subTest("duplicate"):
+            self.actual_manifest["cases"].append(
+                copy.deepcopy(self.actual_manifest["cases"][0])
+            )
+            self.write_manifests()
+            self.assert_rejected("duplicate case")
+
+    def test_extra_and_duplicate_stages_are_rejected(self) -> None:
+        baseline = copy.deepcopy(self.actual_manifest)
+        with self.subTest("extra"):
+            self.actual_manifest["cases"][0]["arrays"]["unexpected"] = {
+                "file": "image_text.unexpected.bin",
+                "dtype": "float32",
+                "shape": [1],
+            }
+            np.zeros([1], dtype=np.float32).tofile(
+                self.actual / "image_text.unexpected.bin"
+            )
+            self.write_manifests()
+            self.assert_rejected("stage set differs")
+        self.actual_manifest = copy.deepcopy(baseline)
+        self.write_manifests()
+        with self.subTest("duplicate-json-key"):
+            path = self.actual / "manifest.json"
+            text = path.read_text(encoding="utf-8")
+            injection = (
+                '"arrays": {"selected_kv": '
+                '{"file": "image_text.selected_kv.bin", '
+                '"dtype": "float32", "shape": [1]},'
+            )
+            path.write_text(text.replace('"arrays": {', injection, 1), encoding="utf-8")
+            self.assert_rejected("duplicate json key")
+
+    def test_non_finite_arrays_are_rejected(self) -> None:
+        path = self.actual / "image_text.first_prefill_logits.bin"
+        for value in (np.nan, np.inf):
+            with self.subTest(value=value):
+                np.asarray([value], dtype=np.float32).tofile(path)
+                report = oracle.compare_capture_roots(self.reference, self.actual)
+                self.assertFalse(report["passed"], report)
+                stage = next(
+                    stage
+                    for case in report["cases"]
+                    if case["name"] == "image_text"
+                    for stage in case["stages"]
+                    if stage["stage"] == "first_prefill_logits"
+                )
+                self.assertEqual(stage.get("error"), "non-finite array value")
+
+    def test_dtype_mismatch_is_rejected(self) -> None:
+        self.actual_manifest["cases"][0]["arrays"]["first_prefill_logits"][
+            "dtype"
+        ] = "int32"
+        self.write_manifests()
+        self.assert_rejected("dtype must be float32")
+
+    def test_invalid_shape_and_path_are_rejected(self) -> None:
+        baseline = copy.deepcopy(self.actual_manifest)
+        with self.subTest("shape"):
+            self.actual_manifest["cases"][0]["arrays"]["selected_kv"]["shape"] = [0]
+            self.write_manifests()
+            self.assert_rejected("invalid shape")
+        self.actual_manifest = copy.deepcopy(baseline)
+        with self.subTest("path"):
+            self.actual_manifest["cases"][0]["arrays"]["selected_kv"][
+                "file"
+            ] = "../selected_kv.bin"
+            self.write_manifests()
+            self.assert_rejected("invalid array path")
+
+    def test_truncated_and_oversized_binaries_are_rejected(self) -> None:
+        path = self.actual / "image_text.selected_kv.bin"
+        with self.subTest("truncated"):
+            path.write_bytes(b"\x00\x00")
+            self.assert_rejected("binary size differs")
+        np.zeros([1], dtype=np.float32).tofile(path)
+        with self.subTest("oversized"):
+            path.write_bytes(path.read_bytes() + b"\x00")
+            self.assert_rejected("binary size differs")
+
+    def test_negative_case_names_and_outcomes_are_exact(self) -> None:
+        mutations = (
+            lambda value: value.pop("context_overflow"),
+            lambda value: value["malformed_placeholder"].update(passed=False),
+            lambda value: value.update(
+                unexpected={
+                    "passed": True,
+                    "outcome": "rejected",
+                    "category": "unexpected",
+                }
+            ),
+        )
+        for index, mutate in enumerate(mutations):
+            with self.subTest(index=index):
+                self.actual_manifest["negative_cases"] = copy.deepcopy(
+                    oracle.EXPECTED_NEGATIVE_CASES
+                )
+                mutate(self.actual_manifest["negative_cases"])
+                self.write_manifests()
+                self.assert_rejected("negative_cases")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,8 @@ pub use mlxcel_core::generate::{
     SamplingConfig,
 };
 pub use mlxcel_core::speculative::SpeculativeGenerator;
+#[cfg(feature = "xla-diagnostics")]
+pub use multimodal::host_preprocessor::LlavaHostReferenceCapture;
 pub use multimodal::host_preprocessor::{
     FakeHostMultimodalPreprocessor, HostMultimodalPreprocessor, HostPreprocessorError,
     LlavaHostPreprocessor, load_xla_image_preprocessor,

--- a/src/lib/mlxcel-xla/README.md
+++ b/src/lib/mlxcel-xla/README.md
@@ -185,12 +185,105 @@ plus every K/V element across one-token, nonzero-padding, and near-capacity case
 spike/openxla/.venv/bin/python spike/openxla/prefill_embeddings_check.py
 ```
 
+### LLaVA independent reference gate
+
+`scripts/xla/validate_llava_reference.sh` is the reproducible multimodal
+correctness gate. It compares the production host preprocessor and IREE
+prefill/decode bundle with Hugging Face Transformers, rather than treating an
+MLX or IREE result as its own oracle. The reference is pinned to:
+
+- source `llava-hf/llava-interleave-qwen-0.5b-hf` at
+  `1090956dd1c79bc93ae98dcf395590369435ec91`;
+- converted checkpoint `mlx-community/llava-interleave-qwen-0.5b-bf16` at
+  `ba7385935f69c5417bfbe29c3809858a98afc22f`;
+- the model and tokenizer SHA-256 values recorded in
+  `spike/openxla/llava_reference_oracle.py`.
+
+The source uses the Tongyi Qianwen Research License. Obtain and use it only
+under those research/evaluation terms. Model files and generated binary
+captures must remain outside Git. One way to obtain immutable local snapshots
+is:
+
+```bash
+hf download llava-hf/llava-interleave-qwen-0.5b-hf \
+  --revision 1090956dd1c79bc93ae98dcf395590369435ec91 \
+  --local-dir /tmp/llava-interleave-qwen-0.5b-hf
+hf download mlx-community/llava-interleave-qwen-0.5b-bf16 \
+  --revision ba7385935f69c5417bfbe29c3809858a98afc22f \
+  --local-dir /path/outside/repo/llava-interleave-qwen-0.5b-bf16
+```
+
+After configuring a real IREE CPU, CUDA, or Metal runtime, run:
+
+```bash
+scripts/xla/validate_llava_reference.sh \
+  --source-model /tmp/llava-interleave-qwen-0.5b-hf \
+  --model /path/outside/repo/llava-interleave-qwen-0.5b-bf16 \
+  --image tests/fixtures/test_image.png \
+  --out /tmp/mlxcel-llava-reference \
+  --device cuda
+```
+
+The companion command sets `MLX_ENABLE_TF32=0`: the declared reference policy
+is true F32, while MLX CUDA's default FAST_TF32 mode is an intentional,
+lower-precision throughput policy and is not labeled as F32 evidence.
+
+The gate verifies exact processor tokens, positions, and masks; every vision
+hidden state plus first-block internal stages; selected/projected image
+features; merged embeddings; first prefill logits; compact all-layer K/V
+samples; and the greedy token trajectory. Cases cover one image plus text,
+mandatory two-image ordering, and text-only input. Negative checks cover
+malformed placeholder counts and effective context overflow before device
+execution. Floating-point comparisons use the per-stage dtype policy recorded
+in the reference manifest and report the first divergent stage.
+
+The same command also checks non-streaming CLI output and the streaming OpenAI
+chat-completions contract, including role/content/finish/usage/`[DONE]` order
+and batch metrics. Manifests record compile/load, host preprocessing, prefill,
+decode, host peak RSS, and runtime device-memory evidence. Add
+`--text-model /path/to/text/checkpoint` to run `validate_arch.sh` as the
+ordinary text and batch regression companion. Use `--skip-surfaces` only when
+isolating a stage-level diagnostic failure.
+
+On the qualified GB10 host, IREE `local-task` could not create its worker pool
+under either 20-core or 4-core affinity (`thread creation failed with 22 (code
+13)`). `local-sync` is the CPU execution fallback on such constrained hosts; it
+ran the identical three-case reference comparison successfully. This is a mixed
+runtime check: MLX CUDA owns host vision preprocessing and IREE `local-sync`
+owns the text decoder. Use `--device local-sync` with the CUDA-enabled IREE
+runtime, or `local-task` where worker creation is permitted.
+
+The initial non-regression baseline was recorded on 2026-07-24 on an NVIDIA GB10
+(driver 580.159.03, CUDA 13.0), IREE 3.12.0rc20260721 CUDA, context 1536,
+four-token greedy decode, and `MLX_ENABLE_TF32=0`:
+
+| Case | Host preprocess | IREE prefill | Decode |
+|------|----------------:|-------------:|-------:|
+| one image + text (743 effective tokens) | 1.351 s | 0.985 s | 8.37 tok/s |
+| two images + text (1473 effective tokens) | 1.278 s | 0.670 s | 8.36 tok/s |
+| text only (14 effective tokens) | 0.0004 s | 0.675 s | 8.27 tok/s |
+
+Host component load was 0.220 s and IREE compile/load was 1.316 s. Peak process
+RSS was 2,551,368 KiB and MLX reported 2,401,427,528 peak device bytes. Dedicated
+IREE device bytes are unavailable on the GB10 unified-memory runtime, so the
+manifest also records Linux available-memory before/after. The host loader's
+allowlist retains processor, vision tower, projector, and the one text embedding
+table; decoder layers and LM head are rejected by its structural test. Prefill,
+selected-KV capture, and decode share one resident IREE text decoder bundle.
+
+The `local-sync` CPU fallback on the same host passed all stages and exact
+greedy tokens. It recorded 1.375 s compile/load, 1.035 s one-image host
+preprocessing, 19.158 s prefill, 1.30 decode tok/s, and 6,374,948 KiB peak RSS.
+The higher RSS and latency are expected from the static 1536-token CPU graph and
+serve as the CPU non-regression baseline.
+
 ### Scope / limits
 
 - The bundled graphs are authored for **Llama-3.2-1B-Instruct** specifically;
   `load` verifies `config.json` matches and errors otherwise.
 - The context capacity is a static graph shape selected with `MLXCEL_XLA_CONTEXT_CAPACITY` (compatibility default `256`).
-- Greedy sampling only; text-only (no VLM / draft).
+- Greedy sampling only; LLaVA prepared-prefill validation is limited to the
+  pinned family above, and draft-model decoding remains out of scope.
 - `XlaInferenceSession` is single-sequence; `XlaBatchEngine` (below) adds
   multi-sequence throughput.
 - **Metal precision (issue #575):** `f16` is the transferable lever on Metal (the
@@ -250,12 +343,16 @@ MLXCEL_BACKEND=xla MLXCEL_XLA_DEVICE=cuda ./target/release/mlxcel-server \
 # then POST /v1/completions (temperature / top_p / top_k / seed are honored).
 ```
 
-The serve path is text-only: it honors `max_tokens`, the model's EOS ids, and
-sampling (temperature / top-k / top-p / min-p / seed). The history-based penalties
-(repetition / frequency / presence / DRY) are not applied (logged once). Requests
-it cannot serve faithfully are rejected with a clear error rather than served
-wrong: logprobs, structured / JSON-schema output, and multimodal inputs. Stop
-strings are not enforced yet. `--max-batch-size` maps to the engine's bundled
+The serve path accepts text and qualified LLaVA image requests. LLaVA image
+decoding and the production MLX vision/projector path run in a bounded host
+preprocessing stage, then the resulting prepared embeddings enter the same IREE
+batch engine as text requests. The `xla-diagnostics` feature supplies the CUDA
+host runtime used by the reproducible mixed-runtime gate above. Sampling
+(temperature / top-k / top-p / min-p / seed), history-based penalties
+(repetition / frequency / presence / DRY), stop strings, `max_tokens`, and the
+model's EOS ids are honored. Requests the engine cannot serve faithfully are
+rejected with a clear error: logprobs, structured / JSON-schema output, and
+unsupported audio/video inputs. `--max-batch-size` maps to the engine's bundled
 `B_max` (`>= 8` -> 8, else 4).
 
 Prove the engine without the server with the reference-equivalence + throughput

--- a/src/lib/mlxcel-xla/csrc/xla_iree.c
+++ b/src/lib/mlxcel-xla/csrc/xla_iree.c
@@ -209,6 +209,92 @@ static iree_status_t xla_read_logits(xla_ctx* c, iree_hal_buffer_view_t* out,
       IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
 }
 
+// Diagnostics-only readback of one compact K/V slice per decoder layer.
+//
+// The normal prefill graph already returns the complete rank-4 caches
+// [layers, sequence, kv_heads, head_dim]. Reading the final effective prompt
+// position, head zero, and a caller-bounded prefix of head_dim lets the LLaVA
+// reference harness compare every layer without compiling a second decoder or
+// copying the full caches to host. Production callers pass kv_width=0 and never
+// enter this branch.
+static int xla_read_selected_kv(xla_ctx* c, iree_hal_buffer_view_t* kc,
+                                iree_hal_buffer_view_t* vc, int32_t real_len,
+                                int32_t kv_width, float* out_kv) {
+  if (kv_width == 0 && out_kv == NULL) return 0;
+  if (kv_width <= 0 || !out_kv || real_len <= 0 ||
+      real_len > c->context_capacity) {
+    fprintf(stderr, "xla_iree: invalid selected KV diagnostic contract\n");
+    return 1;
+  }
+  iree_hal_dim_t layers = iree_hal_buffer_view_shape_dim(kc, 0);
+  iree_hal_dim_t sequence = iree_hal_buffer_view_shape_dim(kc, 1);
+  iree_hal_dim_t kv_heads = iree_hal_buffer_view_shape_dim(kc, 2);
+  iree_hal_dim_t head_dim = iree_hal_buffer_view_shape_dim(kc, 3);
+  if (layers != (iree_hal_dim_t)c->model_layers ||
+      sequence != (iree_hal_dim_t)c->context_capacity || kv_heads <= 0 ||
+      (iree_hal_dim_t)kv_width > head_dim) {
+    fprintf(stderr,
+            "xla_iree: selected KV dimensions disagree with runtime "
+            "(layers=%lld sequence=%lld heads=%lld head_dim=%lld width=%d)\n",
+            (long long)layers, (long long)sequence, (long long)kv_heads,
+            (long long)head_dim, kv_width);
+    return 1;
+  }
+
+  iree_hal_buffer_t* buffers[2] = {
+      iree_hal_buffer_view_buffer(kc),
+      iree_hal_buffer_view_buffer(vc),
+  };
+  for (iree_hal_dim_t layer = 0; layer < layers; ++layer) {
+    uint64_t element_offset = (uint64_t)layer;
+    if (element_offset > UINT64_MAX / (uint64_t)sequence) {
+      fprintf(stderr, "xla_iree: selected KV layer offset overflowed\n");
+      return 1;
+    }
+    element_offset *= (uint64_t)sequence;
+    if (element_offset > UINT64_MAX - (uint64_t)(real_len - 1)) {
+      fprintf(stderr, "xla_iree: selected KV position offset overflowed\n");
+      return 1;
+    }
+    element_offset += (uint64_t)(real_len - 1);
+    if (element_offset > UINT64_MAX / (uint64_t)kv_heads) {
+      fprintf(stderr, "xla_iree: selected KV head offset overflowed\n");
+      return 1;
+    }
+    element_offset *= (uint64_t)kv_heads;
+    if (element_offset > UINT64_MAX / (uint64_t)head_dim) {
+      fprintf(stderr, "xla_iree: selected KV dimension offset overflowed\n");
+      return 1;
+    }
+    element_offset *= (uint64_t)head_dim;
+    if (element_offset > UINT64_MAX / sizeof(float)) {
+      fprintf(stderr, "xla_iree: selected KV byte offset overflowed\n");
+      return 1;
+    }
+    iree_device_size_t byte_offset =
+        (iree_device_size_t)(element_offset * sizeof(float));
+    for (int32_t kind = 0; kind < 2; ++kind) {
+      float* destination =
+          out_kv + (((size_t)layer * 2u + (size_t)kind) * (size_t)kv_width);
+      iree_status_t status = iree_hal_device_transfer_d2h(
+          c->device, buffers[kind], byte_offset, destination,
+          (iree_device_size_t)kv_width * sizeof(float),
+          IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
+      if (!iree_status_is_ok(status)) {
+        int code = (int)iree_status_code(status);
+        fprintf(stderr,
+                "xla_iree: selected KV d2h failed at layer=%lld kind=%d "
+                "(status %d):\n",
+                (long long)layer, kind, code);
+        iree_status_fprint(stderr, status);
+        iree_status_ignore(status);
+        return code ? code : 1;
+      }
+    }
+  }
+  return 0;
+}
+
 // Allocate a resident device buffer view of the given shape/elt and copy bytes.
 static iree_status_t xla_alloc_bv(xla_ctx* c, iree_host_size_t rank,
                                   const iree_hal_dim_t* shape,
@@ -285,8 +371,13 @@ static int xla_validate_kv_pair(xla_ctx* c, iree_hal_buffer_view_t* kc,
       iree_hal_buffer_view_element_type(kc) !=
           IREE_HAL_ELEMENT_TYPE_FLOAT_32 ||
       iree_hal_buffer_view_element_type(vc) !=
-          IREE_HAL_ELEMENT_TYPE_FLOAT_32) {
-    fprintf(stderr, "xla_iree: expected matching rank-%zu f32 K/V buffers\n",
+          IREE_HAL_ELEMENT_TYPE_FLOAT_32 ||
+      iree_hal_buffer_view_encoding_type(kc) !=
+          IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR ||
+      iree_hal_buffer_view_encoding_type(vc) !=
+          IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR) {
+    fprintf(stderr,
+            "xla_iree: expected matching dense-row-major rank-%zu f32 K/V buffers\n",
             (size_t)rank);
     return 1;
   }
@@ -1015,7 +1106,8 @@ static int xla_llama_prefill_embeddings_impl(
     const xla_tensor_desc* embeddings,
     const xla_tensor_desc* dense_ple,
     const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
-    int32_t real_len, int32_t vocab, int32_t* out_token, float* out_logits) {
+    int32_t real_len, int32_t vocab, int32_t* out_token, float* out_logits,
+    int32_t kv_width, float* out_kv) {
   if (!c || real_len <= 0 || real_len > c->context_capacity ||
       position_mode != c->position_mode) {
     fprintf(stderr,
@@ -1123,6 +1215,8 @@ static int xla_llama_prefill_embeddings_impl(
     XLA_CHECK_GOTO(
         xla_read_logits(c, output, out_logits, (iree_host_size_t)vocab),
         cleanup, rc);
+    rc = xla_read_selected_kv(c, kc, vc, real_len, kv_width, out_kv);
+    if (rc != 0) goto cleanup;
     rc = xla_store_prefill_kv_slot(c, slot, kc, vc);
   } else {
     XLA_CHECK_GOTO(xla_read_token(c, output, out_token), cleanup, rc);
@@ -1155,7 +1249,7 @@ int xla_llama_prefill_embeddings(
     int32_t real_len, int32_t* out_token) {
   return xla_llama_prefill_embeddings_impl(
       c, -1, position_mode, embeddings, NULL, positions, attention_bias,
-      real_len, 0, out_token, NULL);
+      real_len, 0, out_token, NULL, 0, NULL);
 }
 
 int xla_llama_prefill_embeddings_slot_logits(
@@ -1165,7 +1259,18 @@ int xla_llama_prefill_embeddings_slot_logits(
     int32_t real_len, int32_t vocab, float* out_logits) {
   return xla_llama_prefill_embeddings_impl(
       c, slot, position_mode, embeddings, NULL, positions, attention_bias,
-      real_len, vocab, NULL, out_logits);
+      real_len, vocab, NULL, out_logits, 0, NULL);
+}
+
+int xla_llama_prefill_embeddings_slot_diagnostics(
+    xla_ctx* c, int32_t slot, int32_t position_mode,
+    const xla_tensor_desc* embeddings,
+    const xla_tensor_desc* positions, const xla_tensor_desc* attention_bias,
+    int32_t real_len, int32_t vocab, int32_t kv_width, float* out_logits,
+    float* out_kv) {
+  return xla_llama_prefill_embeddings_impl(
+      c, slot, position_mode, embeddings, NULL, positions, attention_bias,
+      real_len, vocab, NULL, out_logits, kv_width, out_kv);
 }
 
 int xla_llama_prefill_embeddings_ple(
@@ -1175,7 +1280,7 @@ int xla_llama_prefill_embeddings_ple(
     int32_t* out_token) {
   return xla_llama_prefill_embeddings_impl(
       c, -1, position_mode, embeddings, dense_ple, positions, attention_bias,
-      real_len, 0, out_token, NULL);
+      real_len, 0, out_token, NULL, 0, NULL);
 }
 
 int xla_llama_prefill_embeddings_ple_slot_logits(
@@ -1186,7 +1291,7 @@ int xla_llama_prefill_embeddings_ple_slot_logits(
     float* out_logits) {
   return xla_llama_prefill_embeddings_impl(
       c, slot, position_mode, embeddings, dense_ple, positions, attention_bias,
-      real_len, vocab, NULL, out_logits);
+      real_len, vocab, NULL, out_logits, 0, NULL);
 }
 
 static int xla_llama_prefill_embeddings_deepstack_impl(

--- a/src/lib/mlxcel-xla/src/batch.rs
+++ b/src/lib/mlxcel-xla/src/batch.rs
@@ -37,6 +37,8 @@
 
 use std::collections::VecDeque;
 use std::fmt;
+#[cfg(feature = "diagnostics")]
+use std::time::Instant;
 
 #[cfg(feature = "iree")]
 use mlxcel_core::session::PreparedPrefill;
@@ -51,6 +53,8 @@ use std::path::Path;
 use crate::Gemma3nDensePle;
 #[cfg(feature = "iree")]
 use crate::Gemma3nPreparedPrefill;
+#[cfg(feature = "diagnostics")]
+use crate::iree::PreparedPrefillDiagnostics;
 #[cfg(feature = "iree")]
 use crate::iree::{IreeLlama, IreeRaggedLlama};
 #[cfg(any(feature = "iree", test))]
@@ -784,6 +788,97 @@ fn diagnostic_argmax(values: &[f32]) -> i32 {
         .enumerate()
         .max_by(|left, right| left.1.total_cmp(right.1))
         .map_or(0, |(index, _)| index as i32)
+}
+
+/// Diagnostics-only LLaVA runner that shares one production ragged prefill /
+/// decode bundle for capture and greedy generation.
+#[cfg(feature = "diagnostics")]
+pub struct LlavaReferenceDiagnosticEngine {
+    engine: IreeRaggedLlama,
+}
+
+#[cfg(feature = "diagnostics")]
+impl LlavaReferenceDiagnosticEngine {
+    /// Compile and load the smallest production serve bundle at an explicit
+    /// static context capacity.
+    pub fn load(model_path: &Path, device: &str, context_capacity: usize) -> Result<Self, String> {
+        Ok(Self {
+            engine: IreeRaggedLlama::load(model_path, device, 4, context_capacity)?,
+        })
+    }
+
+    #[must_use]
+    pub fn context_capacity(&self) -> usize {
+        self.engine.context_capacity()
+    }
+
+    /// Capture production prefill logits plus selected all-layer K/V and then
+    /// continue greedily on the same resident cache.
+    pub fn capture(
+        &mut self,
+        prepared: &PreparedPrefill,
+        kv_width: usize,
+        max_new_tokens: usize,
+    ) -> Result<LlavaReferenceDiagnosticRun, String> {
+        if max_new_tokens == 0 {
+            return Err("LLaVA diagnostic generation requires max_new_tokens >= 1".to_string());
+        }
+        let prepared_iree = PreparedIreePrefill::prepare(
+            prepared,
+            self.engine.hidden_size(),
+            self.engine.context_capacity(),
+        )
+        .map_err(|error| error.to_string())?;
+        let prefill_started = Instant::now();
+        let prefill = self
+            .engine
+            .prefill_prepared_slot_diagnostics(0, &prepared_iree, kv_width)?;
+        let prefill_seconds = prefill_started.elapsed().as_secs_f64();
+        let mut tokens = Vec::with_capacity(max_new_tokens);
+        let mut current = diagnostic_argmax(&prefill.logits);
+        tokens.push(current);
+        let mut cache_len = i32::try_from(prepared.sequence_len)
+            .map_err(|_| "prepared sequence length does not fit i32".to_string())?;
+        let decode_started = Instant::now();
+        while tokens.len() < max_new_tokens {
+            if cache_len as usize >= self.engine.context_capacity() {
+                return Err(format!(
+                    "diagnostic decode would exceed context_capacity={}",
+                    self.engine.context_capacity()
+                ));
+            }
+            let mut carrier_tokens = vec![0; self.engine.b_max()];
+            let mut carrier_positions = vec![0; self.engine.b_max()];
+            let mut carrier_cache_lengths = vec![0; self.engine.b_max()];
+            carrier_tokens[0] = current;
+            carrier_positions[0] = cache_len;
+            carrier_cache_lengths[0] = cache_len;
+            let logits = self.engine.decode_ragged_logits(
+                &carrier_tokens,
+                &carrier_positions,
+                &carrier_cache_lengths,
+            )?;
+            current = diagnostic_argmax(&logits[..self.engine.vocab()]);
+            tokens.push(current);
+            cache_len += 1;
+        }
+        let decode_seconds = decode_started.elapsed().as_secs_f64();
+        Ok(LlavaReferenceDiagnosticRun {
+            prefill,
+            tokens,
+            prefill_seconds,
+            decode_seconds,
+        })
+    }
+}
+
+#[cfg(feature = "diagnostics")]
+#[derive(Debug, Clone, PartialEq)]
+pub struct LlavaReferenceDiagnosticRun {
+    pub prefill: PreparedPrefillDiagnostics,
+    pub tokens: Vec<i32>,
+    pub prefill_seconds: f64,
+    pub decode_seconds: f64,
 }
 
 #[cfg(feature = "diagnostics")]

--- a/src/lib/mlxcel-xla/src/iree.rs
+++ b/src/lib/mlxcel-xla/src/iree.rs
@@ -295,6 +295,20 @@ unsafe extern "C" {
         vocab: c_int,
         out_logits: *mut f32,
     ) -> c_int;
+    #[cfg(feature = "diagnostics")]
+    fn xla_llama_prefill_embeddings_slot_diagnostics(
+        c: *mut XlaCtx,
+        slot: c_int,
+        position_mode: c_int,
+        embeddings: *const XlaTensorDesc,
+        positions: *const XlaTensorDesc,
+        attention_bias: *const XlaTensorDesc,
+        real_len: c_int,
+        vocab: c_int,
+        kv_width: c_int,
+        out_logits: *mut f32,
+        out_kv: *mut f32,
+    ) -> c_int;
     fn xla_llama_prefill_embeddings_ple(
         c: *mut XlaCtx,
         position_mode: c_int,
@@ -2012,6 +2026,17 @@ impl Drop for IreeLlama {
 ///
 /// [`prefill_slot_logits`]: Self::prefill_slot_logits
 /// [`decode_ragged_logits`]: Self::decode_ragged_logits
+#[cfg(feature = "diagnostics")]
+#[derive(Debug, Clone, PartialEq)]
+pub struct PreparedPrefillDiagnostics {
+    /// First-token logits returned by the ordinary production prefill graph.
+    pub logits: Vec<f32>,
+    /// Flattened `[layers, 2 (K,V), kv_width]` final-position slices.
+    pub kv: Vec<f32>,
+    pub layers: usize,
+    pub kv_width: usize,
+}
+
 pub struct IreeRaggedLlama {
     ctx: *mut XlaCtx,
     b_max: usize,
@@ -2020,6 +2045,8 @@ pub struct IreeRaggedLlama {
     vocab: usize,
     context_capacity: usize,
     hidden_size: usize,
+    #[cfg(feature = "diagnostics")]
+    model_layers: usize,
     dense_ple_shape: Option<[usize; 3]>,
     position_mode: PreparedPositionMode,
     deepstack_schema: Option<DeepStackConfig>,
@@ -2160,6 +2187,8 @@ impl IreeRaggedLlama {
             vocab: cfg.vocab(),
             context_capacity: cfg.context_capacity(),
             hidden_size: cfg.hidden(),
+            #[cfg(feature = "diagnostics")]
+            model_layers: cfg.n_layers(),
             dense_ple_shape: cfg.dense_ple_shape(),
             position_mode: cfg.position_mode(),
             deepstack_schema: cfg.deepstack().cloned(),
@@ -2191,6 +2220,12 @@ impl IreeRaggedLlama {
     #[must_use]
     pub fn hidden_size(&self) -> usize {
         self.hidden_size
+    }
+
+    #[cfg(feature = "diagnostics")]
+    #[must_use]
+    pub fn model_layers(&self) -> usize {
+        self.model_layers
     }
 
     pub(crate) const fn position_mode(&self) -> PreparedPositionMode {
@@ -2376,6 +2411,80 @@ impl IreeRaggedLlama {
             ));
         }
         Ok(logits)
+    }
+
+    /// Run the ordinary embeddings prefill and read a compact final-position
+    /// K/V slice from every decoder layer.
+    ///
+    /// This diagnostics-only entry shares the production prefill invocation and
+    /// slot population path. It does not compile or retain a second decoder.
+    #[cfg(feature = "diagnostics")]
+    pub fn prefill_prepared_slot_diagnostics(
+        &mut self,
+        slot: usize,
+        prepared: &PreparedIreePrefill,
+        kv_width: usize,
+    ) -> Result<PreparedPrefillDiagnostics, String> {
+        if self.dense_ple_shape.is_some() {
+            return Err(
+                "LLaVA diagnostics require the ordinary embeddings prefill entry".to_string(),
+            );
+        }
+        validate_slot(slot, self.b_max).map_err(|error| error.to_string())?;
+        if prepared.hidden_size != self.hidden_size
+            || prepared.context_capacity != self.context_capacity
+            || prepared.effective_len == 0
+            || prepared.effective_len > self.context_capacity
+            || prepared.positions.mode() != self.position_mode
+        {
+            return Err(
+                "prepared IREE payload is incompatible with this runtime bundle".to_string(),
+            );
+        }
+        if kv_width == 0 {
+            return Err("diagnostic KV width must be greater than zero".to_string());
+        }
+        let (embeddings, positions, attention_bias) = prepared_descriptors(prepared)?;
+        let real_len = checked_ffi_int(prepared.effective_len, "prepared effective length")?;
+        let slot = checked_ffi_int(slot, "slot")?;
+        let vocab = checked_ffi_int(self.vocab, "vocab_size")?;
+        let kv_width_ffi = checked_ffi_int(kv_width, "diagnostic KV width")?;
+        let layers = self.model_layers();
+        let kv_len = layers
+            .checked_mul(2)
+            .and_then(|value| value.checked_mul(kv_width))
+            .ok_or_else(|| "diagnostic KV output length overflows".to_string())?;
+        let mut logits = vec![0.0; self.vocab];
+        let mut kv = vec![0.0; kv_len];
+        // Safety: descriptors and output buffers outlive the call. The C shim
+        // validates their exact runtime dimensions before any readback and uses
+        // the same production prefill call before extracting selected KV rows.
+        let rc = unsafe {
+            xla_llama_prefill_embeddings_slot_diagnostics(
+                self.ctx,
+                slot,
+                prepared.positions.mode().ffi_code(),
+                &embeddings,
+                &positions,
+                &attention_bias,
+                real_len,
+                vocab,
+                kv_width_ffi,
+                logits.as_mut_ptr(),
+                kv.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            return Err(format!(
+                "xla_llama_prefill_embeddings_slot_diagnostics failed (status {rc})"
+            ));
+        }
+        Ok(PreparedPrefillDiagnostics {
+            logits,
+            kv,
+            layers,
+            kv_width,
+        })
     }
 
     /// Seed one batch slot through the sparse DeepStack prefill entry.

--- a/src/lib/mlxcel-xla/src/lib.rs
+++ b/src/lib/mlxcel-xla/src/lib.rs
@@ -110,8 +110,8 @@ pub use batch::{EngineEvent, FinishReason, XlaAdmissionError, XlaBatchEngine, Xl
 #[cfg(feature = "diagnostics")]
 pub use batch::{
     Gemma3nAllLayerDiagnosticRun, Gemma3nCanonicalDiagnosticRun, Gemma3nPrefixDecodeDiagnosticRun,
-    run_gemma3n_all_layer_diagnostics, run_gemma3n_canonical_diagnostics,
-    run_gemma3n_prefix_decode_diagnostic,
+    LlavaReferenceDiagnosticEngine, LlavaReferenceDiagnosticRun, run_gemma3n_all_layer_diagnostics,
+    run_gemma3n_canonical_diagnostics, run_gemma3n_prefix_decode_diagnostic,
 };
 pub use context::{
     CONTEXT_CAPACITY_ENV, ContextCapacityError, DEFAULT_CONTEXT_CAPACITY,
@@ -127,6 +127,17 @@ pub use emitter::{
     run_gemma3n_qmv_diagnostic_probe, run_gemma3n_rms_diagnostic_probe,
     run_gemma3n_sdpa_vector_context_diagnostic_probe,
 };
+#[cfg(feature = "diagnostics")]
+pub use iree::PreparedPrefillDiagnostics;
+#[cfg(any(test, feature = "diagnostics"))]
+#[must_use]
+pub fn llava_diagnostic_device_memory_note(device: &str) -> &'static str {
+    if device == "cuda" {
+        "IREE CUDA reports N/A for dedicated memory on GB10 unified memory"
+    } else {
+        "the IREE C runtime integration exposes no portable device-allocation counter"
+    }
+}
 #[cfg(feature = "diagnostics")]
 pub fn dequantize_gemma3n_affine_diagnostic(
     packed: &[u8],
@@ -702,5 +713,39 @@ mod tests {
         assert_eq!(d, "metal");
         #[cfg(not(target_os = "macos"))]
         assert_eq!(d, "local-task");
+    }
+
+    #[test]
+    fn llava_diagnostics_share_the_production_embeddings_prefill() {
+        let c = include_str!("../csrc/xla_iree.c");
+        let diagnostic = c
+            .split("int xla_llama_prefill_embeddings_slot_diagnostics(")
+            .nth(1)
+            .expect("diagnostic C ABI")
+            .split("int xla_llama_prefill_embeddings_ple(")
+            .next()
+            .expect("bounded diagnostic C ABI");
+        assert!(diagnostic.contains("xla_llama_prefill_embeddings_impl("));
+        assert!(!diagnostic.contains("iree_runtime_call_invoke"));
+
+        let rust = include_str!("iree.rs");
+        let ffi = rust
+            .split("fn xla_llama_prefill_embeddings_slot_diagnostics(")
+            .next()
+            .expect("diagnostic Rust FFI");
+        assert!(
+            ffi.lines()
+                .rev()
+                .take(2)
+                .any(|line| line.contains("cfg(feature = \"diagnostics\")")),
+            "the diagnostic ABI must remain feature-gated"
+        );
+    }
+
+    #[test]
+    fn llava_device_memory_note_does_not_label_cpu_as_cuda() {
+        assert!(super::llava_diagnostic_device_memory_note("cuda").contains("GB10"));
+        assert!(!super::llava_diagnostic_device_memory_note("local-sync").contains("CUDA"));
+        assert!(!super::llava_diagnostic_device_memory_note("local-task").contains("GB10"));
     }
 }

--- a/src/loading/vlm_llava.rs
+++ b/src/loading/vlm_llava.rs
@@ -218,6 +218,25 @@ pub(super) fn is_llava_host_preprocessor_weight(name: &str) -> bool {
         || canonical.starts_with("model.embed_tokens.")
 }
 
+/// Widen only the host vision tower and projector weights used by the
+/// qualified XLA LLaVA path.
+///
+/// The checkpoint remains immutable BF16 on disk and the text embedding table
+/// stays at its checkpoint dtype. MLX otherwise selects BF16 matmul output when
+/// either a vision weight or activation is BF16, so widening only the input
+/// pixels is insufficient to prevent layer-by-layer reduction drift.
+fn widen_llava_host_vision_weights(weights: &mut WeightMap) {
+    for (name, tensor) in weights.iter_mut() {
+        if !(name.starts_with("vision_tower.") || name.starts_with("multi_modal_projector.")) {
+            continue;
+        }
+        let dtype = mlxcel_core::array_dtype(tensor);
+        if dtype == mlxcel_core::dtype::BFLOAT16 || dtype == mlxcel_core::dtype::FLOAT16 {
+            *tensor = mlxcel_core::astype(tensor, mlxcel_core::dtype::FLOAT32);
+        }
+    }
+}
+
 fn require_llava_host_family(config: &VLMConfig) -> Result<(), HostPreprocessorError> {
     if !matches!(config.model_type.as_str(), "llava" | "llava_next") {
         return Err(HostPreprocessorError::FamilyMismatch {
@@ -274,11 +293,12 @@ pub(crate) fn load_llava_host_preprocessor(
         }
     })?;
 
-    let weights = load_vlm_weights_common_filtered_canonical(model_path, |name| {
+    let mut weights = load_vlm_weights_common_filtered_canonical(model_path, |name| {
         is_llava_host_preprocessor_weight(name)
     })
     .map(strip_language_model_prefix)
     .map_err(|error| HostPreprocessorError::WeightLoad(error.to_string()))?;
+    widen_llava_host_vision_weights(&mut weights);
 
     let quant_group_size = full_config
         .get("quantization")
@@ -425,6 +445,7 @@ fn parse_bunny_vision_config(
             image_size: 384,
             num_channels: 3,
             layer_norm_eps: 1e-6,
+            hidden_act: vision::config::VisionHiddenActivation::ExactGelu,
         }
     })
 }

--- a/src/loading/vlm_special.rs
+++ b/src/loading/vlm_special.rs
@@ -53,6 +53,7 @@ fn phi3_vision_config() -> vision::config::VisionConfig {
         num_channels: 3,
         patch_size: 14,
         layer_norm_eps: 1e-5,
+        hidden_act: vision::config::VisionHiddenActivation::ExactGelu,
     }
 }
 

--- a/src/multimodal/host_preprocessor.rs
+++ b/src/multimodal/host_preprocessor.rs
@@ -37,7 +37,6 @@ use super::vlm_prompt::{ImageTokenBlockError, ImageTokenBlockInfo, apply_image_t
 
 #[path = "host_preprocessor_export.rs"]
 mod export;
-#[cfg(test)]
 use export::export_mlx_tensor;
 use export::{
     build_prepared_prefill, export_llava_prefill, usize_to_i32, validate_embedding_shape,
@@ -111,6 +110,25 @@ pub struct LlavaHostPreprocessor {
     hidden_size: usize,
     image_size: usize,
     max_sequence_len: usize,
+}
+
+/// Diagnostics-only capture from the exact host preprocessing path used by
+/// OpenXLA image requests.
+#[cfg(feature = "xla-diagnostics")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LlavaHostReferenceCapture {
+    pub prepared: PreparedPrefill,
+    /// Canonical processor output in `[images, 3, height, width]` layout.
+    pub pixel_values: Option<OwnedTensor>,
+    /// Selected vision-tower output before the multimodal projector in
+    /// `[images, image_tokens, vision_hidden]` layout.
+    pub selected_vision_features: Option<OwnedTensor>,
+    /// Encoder embedding output followed by each selected vision layer output.
+    pub vision_hidden_states: Vec<OwnedTensor>,
+    /// First encoder block's normalization, attention, and MLP sub-stages.
+    pub vision_block0_states: Vec<OwnedTensor>,
+    /// Projected vision features in `[images, image_tokens, hidden]` layout.
+    pub projected_image_features: Option<OwnedTensor>,
 }
 
 impl LlavaHostPreprocessor {
@@ -190,14 +208,23 @@ impl LlavaHostPreprocessor {
             block_suffix_tokens: Vec::new(),
         }
     }
-}
 
-impl HostMultimodalPreprocessor for LlavaHostPreprocessor {
-    fn prepare(
+    fn prepare_internal(
         &self,
         token_ids: &[i32],
         images: &[DynamicImage],
-    ) -> Result<PreparedPrefill, HostPreprocessorError> {
+        capture_diagnostics: bool,
+    ) -> Result<
+        (
+            PreparedPrefill,
+            Option<OwnedTensor>,
+            Option<OwnedTensor>,
+            Option<OwnedTensor>,
+            Vec<OwnedTensor>,
+            Vec<OwnedTensor>,
+        ),
+        HostPreprocessorError,
+    > {
         let mut logical_tokens = token_ids.to_vec();
         apply_image_token_blocks(&mut logical_tokens, self.token_block_info(), images.len())?;
         validate_sequence_capacity(logical_tokens.len(), self.max_sequence_len)?;
@@ -214,6 +241,17 @@ impl HostMultimodalPreprocessor for LlavaHostPreprocessor {
             "text embedding table",
         )?;
 
+        let mut pixel_values = None;
+        let mut selected_vision_features = None;
+        let mut projected_image_features = None;
+        #[cfg(feature = "xla-diagnostics")]
+        let mut vision_hidden_states = Vec::new();
+        #[cfg(not(feature = "xla-diagnostics"))]
+        let vision_hidden_states = Vec::new();
+        #[cfg(feature = "xla-diagnostics")]
+        let mut vision_block0_states = Vec::new();
+        #[cfg(not(feature = "xla-diagnostics"))]
+        let vision_block0_states = Vec::new();
         let merged = if images.is_empty() {
             InputEmbeddings {
                 inputs_embeds: text_embeddings,
@@ -226,14 +264,41 @@ impl HostMultimodalPreprocessor for LlavaHostPreprocessor {
                 images.len(),
                 self.image_size,
             )?;
+            if capture_diagnostics {
+                pixel_values = Some(export_mlx_tensor(&pixels, "processor pixel_values")?);
+            }
 
             // The standard processor emits channels-first f32. Normalize layout
-            // for the shared CLIP/SigLIP encoder and normalize dtype once to the
-            // text embedding dtype before vision execution.
+            // for the shared CLIP/SigLIP encoder. Keep the qualified LLaVA
+            // vision path in f32: layer-by-layer BF16 reduction differences
+            // compound sharply in this 26-layer SigLIP tower even when the
+            // checkpoint itself stores BF16 weights.
             let pixels = mlxcel_core::transpose_axes(&pixels, &[0, 2, 3, 1]);
-            let embed_dtype = mlxcel_core::array_dtype(&text_embeddings);
-            let pixels = mlxcel_core::astype(&pixels, embed_dtype);
+            let pixels = mlxcel_core::astype(&pixels, mlxcel_core::dtype::FLOAT32);
+            #[cfg(feature = "xla-diagnostics")]
+            let encoded = if capture_diagnostics {
+                let (encoded, hidden_states, block0_states) =
+                    self.encoder.forward_with_hidden_state_diagnostics(&pixels);
+                vision_hidden_states = hidden_states
+                    .iter()
+                    .map(|state| export_mlx_tensor(state, "vision hidden state"))
+                    .collect::<Result<Vec<_>, _>>()?;
+                vision_block0_states = block0_states
+                    .iter()
+                    .map(|state| export_mlx_tensor(state, "vision block 0 state"))
+                    .collect::<Result<Vec<_>, _>>()?;
+                encoded
+            } else {
+                self.encoder.forward(&pixels)
+            };
+            #[cfg(not(feature = "xla-diagnostics"))]
             let encoded = self.encoder.forward(&pixels);
+            if capture_diagnostics {
+                selected_vision_features = Some(export_mlx_tensor(
+                    &encoded.hidden_states,
+                    "selected vision features",
+                )?);
+            }
             let projected = self.connector.forward(&encoded.hidden_states);
             validate_projected_shape(
                 &mlxcel_core::array_shape(&projected),
@@ -241,6 +306,10 @@ impl HostMultimodalPreprocessor for LlavaHostPreprocessor {
                 self.tokens_per_image,
                 self.hidden_size,
             )?;
+            if capture_diagnostics {
+                projected_image_features =
+                    Some(export_mlx_tensor(&projected, "projected image features")?);
+            }
 
             merge_llava(
                 self.image_token_id,
@@ -260,14 +329,59 @@ impl HostMultimodalPreprocessor for LlavaHostPreprocessor {
             attention_mask_4d: merged.attention_mask_4d,
         };
 
-        export_llava_prefill(
+        let prepared = export_llava_prefill(
             logical_tokens,
             merged,
             self.image_token_id,
             images.len(),
             self.tokens_per_image,
             self.hidden_size,
-        )
+        )?;
+        Ok((
+            prepared,
+            pixel_values,
+            selected_vision_features,
+            projected_image_features,
+            vision_hidden_states,
+            vision_block0_states,
+        ))
+    }
+
+    /// Capture processor/projector/prepared values without changing the
+    /// production preprocessing sequence.
+    #[cfg(feature = "xla-diagnostics")]
+    pub fn prepare_with_reference_diagnostics(
+        &self,
+        token_ids: &[i32],
+        images: &[DynamicImage],
+    ) -> Result<LlavaHostReferenceCapture, HostPreprocessorError> {
+        let (
+            prepared,
+            pixel_values,
+            selected_vision_features,
+            projected_image_features,
+            vision_hidden_states,
+            vision_block0_states,
+        ) = self.prepare_internal(token_ids, images, true)?;
+        Ok(LlavaHostReferenceCapture {
+            prepared,
+            pixel_values,
+            selected_vision_features,
+            vision_hidden_states,
+            vision_block0_states,
+            projected_image_features,
+        })
+    }
+}
+
+impl HostMultimodalPreprocessor for LlavaHostPreprocessor {
+    fn prepare(
+        &self,
+        token_ids: &[i32],
+        images: &[DynamicImage],
+    ) -> Result<PreparedPrefill, HostPreprocessorError> {
+        self.prepare_internal(token_ids, images, false)
+            .map(|(prepared, _, _, _, _, _)| prepared)
     }
 }
 

--- a/src/server/batch/xla_worker_admission.rs
+++ b/src/server/batch/xla_worker_admission.rs
@@ -75,6 +75,13 @@ impl<E: XlaServingEngine> XlaServeWorker<E> {
                 }
             }
         };
+        #[cfg(feature = "xla-diagnostics")]
+        if !images.is_empty()
+            && let Err(error) = validate_reference_prompt_tokens_from_env(&prompt_tokens)
+        {
+            let _ = response_tx.send(GenerateEvent::Error(error));
+            return;
+        }
         let params = sample_params(&options);
         let stop_sequences = options.stop_sequences.unwrap_or_default();
         let start = Instant::now();
@@ -341,6 +348,27 @@ impl<E: XlaServingEngine> XlaServeWorker<E> {
             }
         }
     }
+}
+
+#[cfg(feature = "xla-diagnostics")]
+fn validate_reference_prompt_tokens_from_env(prompt_tokens: &[i32]) -> Result<(), String> {
+    const ENV_NAME: &str = "MLXCEL_XLA_REFERENCE_EXPECT_UNEXPANDED_IDS";
+    let Ok(raw) = std::env::var(ENV_NAME) else {
+        return Ok(());
+    };
+    let expected: Vec<i32> = serde_json::from_str(&raw)
+        .map_err(|error| format!("{ENV_NAME} must be a JSON integer array: {error}"))?;
+    if prompt_tokens != expected {
+        return Err(format!(
+            "OpenXLA reference prompt mismatch before admission: expected {expected:?}, \
+             server rendered {prompt_tokens:?}"
+        ));
+    }
+    tracing::info!(
+        unexpanded_prompt_ids = ?prompt_tokens,
+        "OpenXLA reference prompt matched before admission"
+    );
+    Ok(())
 }
 
 fn sample_params(options: &ServerGenerateOptions) -> SampleParams {

--- a/src/server/chat_request.rs
+++ b/src/server/chat_request.rs
@@ -192,12 +192,16 @@ pub(crate) async fn prepare_chat_request_with_cache(
 
     let preserve_thinking = merged_kwargs.preserve_thinking();
 
-    let prompt = if has_tool_fields(request) || has_reasoning_fields(request) {
-        // When messages contain tool_calls / tool_call_id, or a parallel
-        // `reasoning` field (issue #362), use raw JSON rendering so the Jinja2
-        // template can access all fields. The typed `ChatMessage` path only
-        // carries role + content, so reasoning would otherwise be dropped
-        // before reaching templates that render `message.get('reasoning')`.
+    let prompt = if has_tool_fields(request)
+        || has_reasoning_fields(request)
+        || has_template_media_parts(request)
+    {
+        // When messages contain tool_calls / tool_call_id, a parallel
+        // `reasoning` field (issue #362), or typed media content, use raw JSON
+        // rendering so the Jinja2 template can access the complete message
+        // shape. The typed `ChatMessage` path only carries role + flattened
+        // text, which would otherwise drop image/audio/video positions before
+        // processor-aware templates can render their placeholder tokens.
         let raw_messages = build_raw_json_messages_with_thinking(request, preserve_thinking);
         // Build the stripped ChatMessages in parallel so the fallback path can
         // use them without re-running strip_rolling_checkpoint.
@@ -440,9 +444,9 @@ fn build_raw_json_messages_with_thinking(
             let stripped = strip_indices.contains(&idx);
             let raw_content = m.content.text();
             let content = if stripped {
-                strip_think_block(&raw_content).into_owned()
+                serde_json::Value::String(strip_think_block(&raw_content).into_owned())
             } else {
-                raw_content
+                template_content(&m.content)
             };
 
             let mut msg = serde_json::json!({
@@ -480,7 +484,7 @@ fn build_raw_json_messages_with_thinking(
             if !stripped
                 && let Some(reasoning) = m.reasoning.as_ref()
                 && !reasoning.is_empty()
-                && !content.contains("<think>")
+                && !raw_content.contains("<think>")
             {
                 msg["reasoning"] = serde_json::Value::String(reasoning.clone());
             }
@@ -490,6 +494,58 @@ fn build_raw_json_messages_with_thinking(
         .collect();
 
     serde_json::Value::Array(messages)
+}
+
+/// Return whether any message carries a media part whose position must reach
+/// the processor-aware chat template.
+///
+/// OpenAI's wire types (`image_url`, `video_url`, `input_audio`) are transport
+/// objects, while Hugging Face processor templates branch on semantic types
+/// (`image`, `video`, `audio`). Routing only these requests through the raw
+/// renderer keeps the established string-content path unchanged for ordinary
+/// text requests and text-only content arrays.
+fn has_template_media_parts(request: &ChatCompletionRequest) -> bool {
+    request.messages.iter().any(|message| {
+        matches!(
+            &message.content,
+            MessageContent::Parts(parts)
+                if parts.iter().any(|part| !matches!(part, ContentPart::Text { .. }))
+        )
+    })
+}
+
+/// Normalize OpenAI transport content into the typed content shape consumed by
+/// Hugging Face processor templates.
+///
+/// Media bytes/URLs are resolved by the server's media pipeline, not by Jinja.
+/// Exposing them to a template would both leak unnecessarily large payloads
+/// into rendering and fail templates such as LLaVA's, which select
+/// `content.type == "image"`. Keep only an ordered semantic marker at this
+/// boundary.
+fn template_content(content: &MessageContent) -> serde_json::Value {
+    match content {
+        MessageContent::Text(text) => serde_json::Value::String(text.clone()),
+        MessageContent::Parts(parts) => serde_json::Value::Array(
+            parts
+                .iter()
+                .map(|part| match part {
+                    ContentPart::Text { text } => serde_json::json!({
+                        "type": "text",
+                        "text": text,
+                    }),
+                    ContentPart::ImageUrl { .. } => serde_json::json!({
+                        "type": "image",
+                    }),
+                    ContentPart::VideoUrl { .. } => serde_json::json!({
+                        "type": "video",
+                    }),
+                    ContentPart::InputAudio { .. } => serde_json::json!({
+                        "type": "audio",
+                    }),
+                })
+                .collect(),
+        ),
+    }
 }
 
 /// Normalize each tool call's `function.arguments` from a JSON-encoded string

--- a/src/server/chat_request_tests.rs
+++ b/src/server/chat_request_tests.rs
@@ -87,14 +87,109 @@ async fn prepare_chat_request_uses_template_output_and_extracts_images() {
         reasoning: None,
         tool_calls: None,
     }]);
-    let processor =
-        ChatTemplateProcessor::with_template("Prompt: {{ messages[0].content }}".to_string());
+    let processor = ChatTemplateProcessor::with_template(
+        "{% for item in messages[0].content %}\
+         {% if item.type == 'image' %}<image>{% elif item.type == 'text' %}{{ item.text }}{% endif %}\
+         {% endfor %}"
+            .to_string(),
+    );
 
     let prepared = prepare_chat_request(&processor, &request, None)
         .await
         .unwrap();
-    assert_eq!(prepared.prompt, "Prompt: Look");
+    assert_eq!(prepared.prompt, "Look<image>");
     assert_eq!(prepared.image_data, vec![b"hello".to_vec()]);
+}
+
+#[tokio::test]
+async fn llava_server_render_preserves_image_marker_and_exact_prompt() {
+    let request = request_with_messages(vec![Message {
+        role: Role::User,
+        content: MessageContent::Parts(vec![
+            ContentPart::ImageUrl {
+                image_url: ImageUrl::new(
+                    "data:image/png;base64,aGVsbG8tdGVtcGxhdGUtYm91bmRhcnk=".to_string(),
+                ),
+            },
+            ContentPart::Text {
+                text: "Describe the image briefly.".to_string(),
+            },
+        ]),
+        name: None,
+        tool_call_id: None,
+        reasoning: None,
+        tool_calls: None,
+    }]);
+    let processor = ChatTemplateProcessor::with_template(
+        r#"{% for message in messages %}{{'<|im_start|>' + message['role'] + '
+'}}{% for content in message['content'] | selectattr('type', 'equalto', 'image') %}{{ '<image>' }}{% endfor %}{% if message['role'] != 'assistant' %}{% for content in message['content'] | selectattr('type', 'equalto', 'text') %}{{ '
+' + content['text'] }}{% endfor %}{% endif %}{{'<|im_end|>' + '
+'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant
+' }}{% endif %}"#
+            .to_string(),
+    );
+
+    let prepared = prepare_chat_request(&processor, &request, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        prepared.prompt,
+        "<|im_start|>user\n<image>\nDescribe the image briefly.<|im_end|>\n\
+         <|im_start|>assistant\n"
+    );
+    assert!(
+        !prepared.prompt.contains("base64"),
+        "transport payload must not enter the template prompt"
+    );
+}
+
+#[test]
+fn raw_template_content_normalizes_openai_media_types_without_payloads() {
+    let request = request_with_messages(vec![Message {
+        role: Role::User,
+        content: MessageContent::Parts(vec![
+            ContentPart::Text {
+                text: "before".to_string(),
+            },
+            ContentPart::ImageUrl {
+                image_url: ImageUrl::new("https://secret.example/image.png"),
+            },
+            ContentPart::VideoUrl {
+                video_url: VideoUrl {
+                    url: "https://secret.example/video.mp4".to_string(),
+                    fps: Some(2.0),
+                },
+            },
+            ContentPart::InputAudio {
+                input_audio: InputAudio {
+                    data: "private-audio-data".to_string(),
+                    format: "wav".to_string(),
+                },
+            },
+            ContentPart::Text {
+                text: "after".to_string(),
+            },
+        ]),
+        name: None,
+        tool_call_id: None,
+        reasoning: None,
+        tool_calls: None,
+    }]);
+
+    let raw = build_raw_json_messages(&request);
+    assert_eq!(
+        raw[0]["content"],
+        serde_json::json!([
+            {"type": "text", "text": "before"},
+            {"type": "image"},
+            {"type": "video"},
+            {"type": "audio"},
+            {"type": "text", "text": "after"},
+        ])
+    );
+    let serialized = raw.to_string();
+    assert!(!serialized.contains("secret.example"));
+    assert!(!serialized.contains("private-audio-data"));
 }
 
 #[tokio::test]

--- a/src/server/chat_template.rs
+++ b/src/server/chat_template.rs
@@ -74,34 +74,44 @@ impl ChatTemplateProcessor {
             None
         };
 
-        // Try tokenizer_config.json "chat_template" field first, then a separate
-        // chat_template.jinja file, then a chat_template.json file.
+        // Read tokenizer_config.json plus the two standalone template formats.
         // Some models (e.g. Gemma 4 MLX Community quantizations) have an empty
         // string for chat_template in tokenizer_config.json but ship a separate
         // .jinja file. Others (e.g. Idefics2) ship only a chat_template.json
         // (`{"chat_template": "..."}`), the newer transformers convention.
-        let template = config
+        //
+        // LLaVA interleave checkpoints can ship both: a legacy string-only
+        // tokenizer template and a processor-aware standalone JSON template.
+        // Transformers selects the latter for image messages. Prefer a
+        // standalone typed-content template over the legacy config value so
+        // CLI/server image requests render the same logical prompt.
+        let config_template = config
             .as_ref()
             .and_then(|c| c.get("chat_template"))
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
-            .map(String::from)
+            .map(String::from);
+        let jinja_template = std::fs::read_to_string(model_path.join("chat_template.jinja"))
+            .ok()
+            .filter(|s| !s.trim().is_empty());
+        let json_template = std::fs::read_to_string(model_path.join("chat_template.json"))
+            .ok()
+            .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+            .and_then(|value| value.get("chat_template")?.as_str().map(String::from))
+            .filter(|s| !s.is_empty());
+        let typed_standalone = jinja_template
+            .as_ref()
+            .filter(|template| template_renders_typed_image_content(template))
             .or_else(|| {
-                let jinja_path = model_path.join("chat_template.jinja");
-                std::fs::read_to_string(jinja_path)
-                    .ok()
-                    .filter(|s| !s.trim().is_empty())
+                json_template
+                    .as_ref()
+                    .filter(|template| template_renders_typed_image_content(template))
             })
-            .or_else(|| {
-                let json_path = model_path.join("chat_template.json");
-                let content = std::fs::read_to_string(json_path).ok()?;
-                serde_json::from_str::<serde_json::Value>(&content)
-                    .ok()?
-                    .get("chat_template")?
-                    .as_str()
-                    .filter(|s| !s.is_empty())
-                    .map(String::from)
-            });
+            .cloned();
+        let template = typed_standalone
+            .or(config_template)
+            .or(jinja_template)
+            .or(json_template);
 
         let Some(template) = template else {
             return Ok(None);
@@ -694,6 +704,37 @@ fn truncate_key_for_log(key: &str) -> String {
 /// effect on the rendered prompt, so we simply drop both delimiters so the
 /// template parses cleanly under minijinja. Affected models: SmolLM3, and
 /// any other HF template that adopts this marker.
+fn template_renders_typed_image_content(template: &str) -> bool {
+    let processor = ChatTemplateProcessor::with_template(template.to_string());
+    if !processor.supports_image_content() {
+        return false;
+    }
+    let with_image = serde_json::json!([{
+        "role": "user",
+        "content": [
+            {"type": "image"},
+            {"type": "text", "text": "__mlxcel_text_probe__"},
+        ],
+    }]);
+    let text_only = serde_json::json!([{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "__mlxcel_text_probe__"},
+        ],
+    }]);
+    match (
+        processor.apply_raw(&with_image, None),
+        processor.apply_raw(&text_only, None),
+    ) {
+        (Ok(with_image), Ok(text_only)) => {
+            with_image.contains("__mlxcel_text_probe__")
+                && text_only.contains("__mlxcel_text_probe__")
+                && with_image != text_only
+        }
+        _ => false,
+    }
+}
+
 fn preprocess_template(template: String) -> String {
     // Handle all whitespace-control variants of the two delimiters. Using
     // explicit replaces keeps this allocation-light and regex-free.
@@ -1101,6 +1142,113 @@ impl std::fmt::Debug for ChatTemplateProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn standalone_typed_template_overrides_legacy_string_template() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join("tokenizer_config.json"),
+            r#"{"chat_template":"legacy={{ messages[0]['content'] }}"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            directory.path().join("chat_template.json"),
+            serde_json::json!({
+                "chat_template": "{% for item in messages[0]['content'] %}{% if item['type'] == 'image' %}<image>{% else %}{{ item['text'] }}{% endif %}{% endfor %}"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let processor = ChatTemplateProcessor::from_model_path(directory.path())
+            .unwrap()
+            .unwrap();
+        assert!(processor.supports_image_content());
+        let rendered = processor
+            .apply_raw(
+                &serde_json::json!([{
+                    "role": "user",
+                    "content": [
+                        {"type": "image"},
+                        {"type": "text", "text": "describe"},
+                    ],
+                }]),
+                None,
+            )
+            .unwrap();
+        assert_eq!(rendered, "<image>describe");
+        let text_only = processor
+            .apply_raw(
+                &serde_json::json!([{
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hello"}],
+                }]),
+                None,
+            )
+            .unwrap();
+        assert_eq!(text_only, "hello");
+    }
+
+    #[test]
+    fn tokenizer_config_only_legacy_template_keeps_existing_precedence() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join("tokenizer_config.json"),
+            r#"{"chat_template":"legacy={{ messages[0]['content'] }}"}"#,
+        )
+        .unwrap();
+
+        let processor = ChatTemplateProcessor::from_model_path(directory.path())
+            .unwrap()
+            .unwrap();
+        assert!(!processor.supports_image_content());
+        assert_eq!(
+            processor
+                .apply(
+                    &[ChatMessage {
+                        role: "user".to_string(),
+                        content: "hello".to_string(),
+                    }],
+                    None,
+                )
+                .unwrap(),
+            "legacy=hello"
+        );
+    }
+
+    #[test]
+    fn malformed_or_untyped_standalone_template_falls_back_to_legacy_config() {
+        for standalone in [
+            r#"{"chat_template":"{% if broken %}"}"#,
+            r#"{"chat_template":"standalone={{ messages[0]['content'] }}"}"#,
+            r#"{"not_chat_template":"ignored"}"#,
+        ] {
+            let directory = tempfile::tempdir().unwrap();
+            std::fs::write(
+                directory.path().join("tokenizer_config.json"),
+                r#"{"chat_template":"legacy={{ messages[0]['content'] }}"}"#,
+            )
+            .unwrap();
+            std::fs::write(directory.path().join("chat_template.json"), standalone).unwrap();
+
+            let processor = ChatTemplateProcessor::from_model_path(directory.path())
+                .unwrap()
+                .unwrap();
+            assert!(!processor.supports_image_content());
+            assert_eq!(
+                processor
+                    .apply(
+                        &[ChatMessage {
+                            role: "user".to_string(),
+                            content: "hello".to_string(),
+                        }],
+                        None,
+                    )
+                    .unwrap(),
+                "legacy=hello"
+            );
+        }
+    }
 
     #[test]
     fn supports_audio_content_detects_audio_branch() {

--- a/src/vision/config.rs
+++ b/src/vision/config.rs
@@ -27,6 +27,19 @@ where
     Option::deserialize(deserializer).map(|opt| opt.unwrap_or_default())
 }
 
+/// Activation selected by a SigLIP/CLIP checkpoint.
+///
+/// Existing and unknown values retain mlxcel's exact-erf GELU behavior. The
+/// explicit `gelu_pytorch_tanh` variant follows the Hugging Face polynomial.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+pub enum VisionHiddenActivation {
+    #[serde(rename = "gelu_pytorch_tanh")]
+    GeluPytorchTanh,
+    #[default]
+    #[serde(other)]
+    ExactGelu,
+}
+
 /// Vision encoder configuration (SigLIP)
 #[derive(Debug, Clone, Deserialize)]
 pub struct VisionConfig {
@@ -42,6 +55,8 @@ pub struct VisionConfig {
     pub num_channels: usize,
     #[serde(default = "default_layer_norm_eps")]
     pub layer_norm_eps: f32,
+    #[serde(default, deserialize_with = "null_default")]
+    pub hidden_act: VisionHiddenActivation,
 }
 
 fn default_image_size() -> usize {
@@ -112,5 +127,40 @@ impl VLMConfig {
                     .map(|v| v as usize)
             })
             .unwrap_or(256)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{VisionConfig, VisionHiddenActivation};
+
+    fn config(hidden_act: Option<&str>) -> serde_json::Value {
+        let mut value = serde_json::json!({
+            "model_type": "siglip_vision_model",
+            "num_hidden_layers": 1,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "num_attention_heads": 2,
+            "patch_size": 2
+        });
+        if let Some(hidden_act) = hidden_act {
+            value["hidden_act"] = serde_json::Value::String(hidden_act.to_string());
+        }
+        value
+    }
+
+    #[test]
+    fn vision_hidden_act_selects_only_the_explicit_pytorch_tanh_variant() {
+        let tanh: VisionConfig = serde_json::from_value(config(Some("gelu_pytorch_tanh"))).unwrap();
+        assert_eq!(tanh.hidden_act, VisionHiddenActivation::GeluPytorchTanh);
+
+        for value in [
+            config(None),
+            config(Some("gelu")),
+            config(Some("quick_gelu")),
+        ] {
+            let parsed: VisionConfig = serde_json::from_value(value).unwrap();
+            assert_eq!(parsed.hidden_act, VisionHiddenActivation::ExactGelu);
+        }
     }
 }

--- a/src/vision/encoders/mod.rs
+++ b/src/vision/encoders/mod.rs
@@ -62,4 +62,18 @@ pub struct VisionEncoderOutput {
 /// Trait for vision encoders
 pub trait VisionEncoder {
     fn forward(&self, pixel_values: &MlxArray) -> VisionEncoderOutput;
+
+    /// Run the exact encoder path while retaining ordered hidden states for a
+    /// reference-oracle first-divergence report.
+    #[cfg(feature = "xla-diagnostics")]
+    fn forward_with_hidden_state_diagnostics(
+        &self,
+        pixel_values: &MlxArray,
+    ) -> (
+        VisionEncoderOutput,
+        Vec<UniquePtr<MlxArray>>,
+        Vec<UniquePtr<MlxArray>>,
+    ) {
+        (self.forward(pixel_values), Vec::new(), Vec::new())
+    }
 }

--- a/src/vision/encoders/siglip.rs
+++ b/src/vision/encoders/siglip.rs
@@ -21,7 +21,7 @@
 //! - VisionEmbeddings: Conv2d patch embedding + learned position embedding [+ CLS token for CLIP]
 //! - EncoderLayer: LayerNorm → Attention → residual → LayerNorm → MLP → residual
 //! - Attention: standard multi-head with bias, uses scaled_dot_product_attention
-//! - MLP: Linear → GELU(precise) → Linear
+//! - MLP: Linear → checkpoint-selected GELU → Linear
 //!
 //! Used by: Gemma3 VLM (SigLIP), LLaVA (CLIP or SigLIP), Idefics2 (via
 //! `forward_with_position_ids`, bucketized variable-resolution tiles)
@@ -31,27 +31,88 @@ use mlxcel_core::layers::{LayerNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 
-use crate::vision::config::VisionConfig;
+use crate::vision::config::{VisionConfig, VisionHiddenActivation};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VisionMlpActivation {
+    Exact,
+    PytorchTanh,
+    FastSigmoid,
+}
+
+fn select_mlp_activation(
+    hidden_act: VisionHiddenActivation,
+    use_fast_gelu: bool,
+) -> VisionMlpActivation {
+    if use_fast_gelu {
+        VisionMlpActivation::FastSigmoid
+    } else {
+        match hidden_act {
+            VisionHiddenActivation::GeluPytorchTanh => VisionMlpActivation::PytorchTanh,
+            VisionHiddenActivation::ExactGelu => VisionMlpActivation::Exact,
+        }
+    }
+}
 
 // Vision MLP.
 struct VisionMLP {
     fc1: UnifiedLinear,
     fc2: UnifiedLinear,
-    /// When true, use the sigmoid `GELU(approx="fast")` (`x * sigmoid(1.702x)`)
-    /// that the Idefics2 vision tower uses; otherwise the tanh `approx="precise"`
-    /// GELU that SigLIP/CLIP, Idefics3/SmolVLM, Gemma3, and LLaVA use.
-    use_fast_gelu: bool,
+    activation: VisionMlpActivation,
+}
+
+/// Hugging Face's `gelu_pytorch_tanh`, evaluated in F32 to avoid the BF16
+/// `x.pow(3)` overflow that motivated the legacy exact-erf fallback.
+///
+/// Keep this SigLIP/CLIP-specific: changing the global `gelu_approx` helper
+/// would silently alter model families whose checkpoints expect exact GELU.
+fn gelu_pytorch_tanh(x: &MlxArray) -> UniquePtr<MlxArray> {
+    let output_dtype = mlxcel_core::array_dtype(x);
+    let x = mlxcel_core::astype(x, mlxcel_core::dtype::FLOAT32);
+    let half = mlxcel_core::full_f32(&[1], 0.5, mlxcel_core::dtype::FLOAT32);
+    let one = mlxcel_core::full_f32(&[1], 1.0, mlxcel_core::dtype::FLOAT32);
+    let sqrt_two_over_pi = mlxcel_core::full_f32(&[1], 0.797_884_6, mlxcel_core::dtype::FLOAT32);
+    let cubic_coefficient = mlxcel_core::full_f32(&[1], 0.044_715, mlxcel_core::dtype::FLOAT32);
+
+    // Multiplication, rather than a generic power operation, is defined for
+    // negative inputs and matches PyTorch's polynomial evaluation order.
+    let squared = mlxcel_core::multiply(&x, &x);
+    let cubed = mlxcel_core::multiply(&squared, &x);
+    let cubic = mlxcel_core::multiply(&cubic_coefficient, &cubed);
+    let inner = mlxcel_core::multiply(&sqrt_two_over_pi, &mlxcel_core::add(&x, &cubic));
+    let cdf = mlxcel_core::multiply(&half, &mlxcel_core::add(&one, &mlxcel_core::tanh(&inner)));
+    let activated = mlxcel_core::multiply(&x, &cdf);
+    if output_dtype == mlxcel_core::dtype::FLOAT32 {
+        activated
+    } else {
+        mlxcel_core::astype(&activated, output_dtype)
+    }
 }
 
 impl VisionMLP {
-    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+    fn forward_impl(
+        &self,
+        x: &MlxArray,
+        capture: bool,
+    ) -> (UniquePtr<MlxArray>, Vec<UniquePtr<MlxArray>>) {
         let x = self.fc1.forward(x);
-        let x = if self.use_fast_gelu {
-            mlxcel_core::utils::gelu_sigmoid(&x)
-        } else {
-            mlxcel_core::gelu_approx(&x)
+        let mut diagnostics = Vec::new();
+        if capture {
+            diagnostics.push(mlxcel_core::copy(&x));
+        }
+        let x = match self.activation {
+            VisionMlpActivation::Exact => mlxcel_core::gelu_approx(&x),
+            VisionMlpActivation::PytorchTanh => gelu_pytorch_tanh(&x),
+            VisionMlpActivation::FastSigmoid => mlxcel_core::utils::gelu_sigmoid(&x),
         };
-        self.fc2.forward(&x)
+        if capture {
+            diagnostics.push(mlxcel_core::copy(&x));
+        }
+        let x = self.fc2.forward(&x);
+        if capture {
+            diagnostics.push(mlxcel_core::copy(&x));
+        }
+        (x, diagnostics)
     }
 
     fn from_weights(
@@ -59,7 +120,7 @@ impl VisionMLP {
         prefix: &str,
         group_size: i32,
         bits: i32,
-        use_fast_gelu: bool,
+        activation: VisionMlpActivation,
     ) -> Result<Self, String> {
         let fc1 =
             UnifiedLinear::from_weights(weights, &format!("{}.fc1", prefix), group_size, bits)?;
@@ -68,7 +129,7 @@ impl VisionMLP {
         Ok(Self {
             fc1,
             fc2,
-            use_fast_gelu,
+            activation,
         })
     }
 }
@@ -84,7 +145,11 @@ struct VisionAttention {
 }
 
 impl VisionAttention {
-    fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+    fn forward_impl(
+        &self,
+        x: &MlxArray,
+        capture: bool,
+    ) -> (UniquePtr<MlxArray>, Vec<UniquePtr<MlxArray>>) {
         let shape = mlxcel_core::array_shape(x);
         let b = shape[0];
         let l = shape[1];
@@ -92,6 +157,12 @@ impl VisionAttention {
         let queries = self.q_proj.forward(x);
         let keys = self.k_proj.forward(x);
         let values = self.v_proj.forward(x);
+        let mut diagnostics = Vec::new();
+        if capture {
+            diagnostics.push(mlxcel_core::copy(&queries));
+            diagnostics.push(mlxcel_core::copy(&keys));
+            diagnostics.push(mlxcel_core::copy(&values));
+        }
 
         let head_dim = mlxcel_core::array_shape(&queries)[2] / self.num_heads;
 
@@ -119,8 +190,15 @@ impl VisionAttention {
         // Transpose back and reshape: [B, num_heads, L, head_dim] -> [B, L, D]
         let output = mlxcel_core::transpose_axes(&output, &[0, 2, 1, 3]);
         let output = mlxcel_core::reshape(&output, &[b, l, self.num_heads * head_dim]);
+        if capture {
+            diagnostics.push(mlxcel_core::copy(&output));
+        }
 
-        self.out_proj.forward(&output)
+        let output = self.out_proj.forward(&output);
+        if capture {
+            diagnostics.push(mlxcel_core::copy(&output));
+        }
+        (output, diagnostics)
     }
 
     fn from_weights(
@@ -168,14 +246,38 @@ struct EncoderLayer {
 
 impl EncoderLayer {
     fn forward(&self, x: &MlxArray) -> UniquePtr<MlxArray> {
+        self.forward_impl(x, false).0
+    }
+
+    fn forward_impl(
+        &self,
+        x: &MlxArray,
+        capture: bool,
+    ) -> (UniquePtr<MlxArray>, Vec<UniquePtr<MlxArray>>) {
+        let mut diagnostics = Vec::new();
         // LayerNorm -> Attention -> residual
         let ln1 = self.layer_norm1.forward(x);
-        let r = self.self_attn.forward(&ln1);
+        if capture {
+            diagnostics.push(mlxcel_core::copy(&ln1));
+        }
+        let (r, attention_diagnostics) = self.self_attn.forward_impl(&ln1, capture);
+        diagnostics.extend(attention_diagnostics);
         let h = mlxcel_core::add(x, &r);
+        if capture {
+            diagnostics.push(mlxcel_core::copy(&h));
+        }
         // LayerNorm -> MLP -> residual
         let ln2 = self.layer_norm2.forward(&h);
-        let r = self.mlp.forward(&ln2);
-        mlxcel_core::add(&h, &r)
+        if capture {
+            diagnostics.push(mlxcel_core::copy(&ln2));
+        }
+        let (r, mlp_diagnostics) = self.mlp.forward_impl(&ln2, capture);
+        diagnostics.extend(mlp_diagnostics);
+        let output = mlxcel_core::add(&h, &r);
+        if capture {
+            diagnostics.push(mlxcel_core::copy(&output));
+        }
+        (output, diagnostics)
     }
 
     fn from_weights(
@@ -184,7 +286,7 @@ impl EncoderLayer {
         config: &VisionConfig,
         group_size: i32,
         bits: i32,
-        use_fast_gelu: bool,
+        activation: VisionMlpActivation,
     ) -> Result<Self, String> {
         let self_attn = VisionAttention::from_weights(
             weights,
@@ -211,7 +313,7 @@ impl EncoderLayer {
             &format!("{}.mlp", prefix),
             group_size,
             bits,
-            use_fast_gelu,
+            activation,
         )?;
 
         Ok(Self {
@@ -413,8 +515,9 @@ impl SigLipVisionModel {
 
     /// Like [`Self::from_weights_with_quant`] but selects the encoder MLP GELU
     /// variant. `use_fast_gelu = true` uses the sigmoid `GELU(approx="fast")`
-    /// that the Idefics2 vision tower uses; `false` keeps the tanh
-    /// `approx="precise"` GELU every other SigLIP/CLIP consumer uses.
+    /// that the Idefics2 vision tower uses. Otherwise `hidden_act` selects the
+    /// explicit PyTorch tanh approximation, with exact-erf GELU as the
+    /// compatibility default for missing and unknown values.
     pub fn from_weights_with_quant_and_gelu(
         weights: &WeightMap,
         config: &VisionConfig,
@@ -426,6 +529,7 @@ impl SigLipVisionModel {
         let emb_prefix = format!("{}.embeddings", prefix);
         let embeddings =
             VisionEmbeddings::from_weights(weights, &emb_prefix, config, group_size, bits)?;
+        let activation = select_mlp_activation(config.hidden_act, use_fast_gelu);
 
         let mut layers = Vec::with_capacity(config.num_hidden_layers);
         for i in 0..config.num_hidden_layers {
@@ -436,7 +540,7 @@ impl SigLipVisionModel {
                 config,
                 group_size,
                 bits,
-                use_fast_gelu,
+                activation,
             )?;
             layers.push(layer);
         }
@@ -537,12 +641,43 @@ impl SigLipVisionModel {
 
 impl VisionEncoder for SigLipVisionModel {
     fn forward(&self, pixel_values: &MlxArray) -> VisionEncoderOutput {
+        self.forward_impl(pixel_values, false).0
+    }
+
+    #[cfg(feature = "xla-diagnostics")]
+    fn forward_with_hidden_state_diagnostics(
+        &self,
+        pixel_values: &MlxArray,
+    ) -> (
+        VisionEncoderOutput,
+        Vec<UniquePtr<MlxArray>>,
+        Vec<UniquePtr<MlxArray>>,
+    ) {
+        self.forward_impl(pixel_values, true)
+    }
+}
+
+impl SigLipVisionModel {
+    fn forward_impl(
+        &self,
+        pixel_values: &MlxArray,
+        capture_hidden_states: bool,
+    ) -> (
+        VisionEncoderOutput,
+        Vec<UniquePtr<MlxArray>>,
+        Vec<UniquePtr<MlxArray>>,
+    ) {
         // Embed patches (+ CLS for CLIP)
         let mut h = self.embeddings.forward(pixel_values);
 
         // Apply pre-layernorm if present (CLIP only)
         if let Some(ref pre_ln) = self.pre_layrnorm {
             h = pre_ln.forward(&h);
+        }
+        let mut hidden_states = Vec::new();
+        let mut block0_diagnostics = Vec::new();
+        if capture_hidden_states {
+            hidden_states.push(mlxcel_core::copy(&h));
         }
 
         // Check if we need to collect hidden states for layer selection
@@ -557,30 +692,58 @@ impl VisionEncoder for SigLipVisionModel {
             };
 
             for (i, layer) in self.layers.iter().enumerate() {
-                h = layer.forward(&h);
+                if capture_hidden_states && i == 0 {
+                    (h, block0_diagnostics) = layer.forward_impl(&h, true);
+                } else {
+                    h = layer.forward(&h);
+                }
+                if capture_hidden_states {
+                    hidden_states.push(mlxcel_core::copy(&h));
+                }
                 if i == target_layer {
                     // Select features from this layer (before post_layernorm)
                     let selected = self.apply_feature_select_strategy(&h);
-                    return VisionEncoderOutput {
-                        hidden_states: selected,
-                    };
+                    return (
+                        VisionEncoderOutput {
+                            hidden_states: selected,
+                        },
+                        hidden_states,
+                        block0_diagnostics,
+                    );
                 }
             }
             // Fallback: if target_layer >= num_layers, use last layer output
             let selected = self.apply_feature_select_strategy(&h);
-            return VisionEncoderOutput {
-                hidden_states: selected,
-            };
+            return (
+                VisionEncoderOutput {
+                    hidden_states: selected,
+                },
+                hidden_states,
+                block0_diagnostics,
+            );
         }
 
         // Default path (Gemma3 SigLIP): pass through all layers + post_layernorm
-        for layer in &self.layers {
-            h = layer.forward(&h);
+        for (i, layer) in self.layers.iter().enumerate() {
+            if capture_hidden_states && i == 0 {
+                (h, block0_diagnostics) = layer.forward_impl(&h, true);
+            } else {
+                h = layer.forward(&h);
+            }
+            if capture_hidden_states {
+                hidden_states.push(mlxcel_core::copy(&h));
+            }
         }
 
-        let hidden_states = self.post_layernorm.forward(&h);
+        let selected = self.post_layernorm.forward(&h);
 
-        VisionEncoderOutput { hidden_states }
+        (
+            VisionEncoderOutput {
+                hidden_states: selected,
+            },
+            hidden_states,
+            block0_diagnostics,
+        )
     }
 }
 
@@ -626,4 +789,41 @@ fn load_layer_norm(weights: &WeightMap, prefix: &str, eps: f32) -> Result<LayerN
     let bias = weights.get(&bias_key).map(|w| mlxcel_core::copy(w));
 
     Ok(LayerNorm::new(weight, bias, eps))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{VisionMlpActivation, gelu_pytorch_tanh, select_mlp_activation};
+    use crate::vision::config::VisionHiddenActivation;
+
+    #[test]
+    fn activation_selection_preserves_exact_and_fast_compatibility() {
+        assert_eq!(
+            select_mlp_activation(VisionHiddenActivation::ExactGelu, false),
+            VisionMlpActivation::Exact
+        );
+        assert_eq!(
+            select_mlp_activation(VisionHiddenActivation::GeluPytorchTanh, false),
+            VisionMlpActivation::PytorchTanh
+        );
+        assert_eq!(
+            select_mlp_activation(VisionHiddenActivation::GeluPytorchTanh, true),
+            VisionMlpActivation::FastSigmoid
+        );
+    }
+
+    #[test]
+    fn pytorch_tanh_gelu_matches_hugging_face_f32_golden() {
+        let input = mlxcel_core::from_slice_f32(&[-3.0, -1.0, 0.0, 1.0, 3.0], &[5]);
+        let output = gelu_pytorch_tanh(&input);
+        mlxcel_core::eval(&output);
+        let expected = [-0.003_637_433, -0.158_808, 0.0, 0.841_192, 2.996_362_7];
+        for (index, expected) in expected.into_iter().enumerate() {
+            let value = mlxcel_core::slice(&output, &[index as i32], &[index as i32 + 1]);
+            assert!(
+                (mlxcel_core::item_f32(&value) - expected).abs() <= 2.0e-6,
+                "GELU mismatch at {index}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Pin the public HF and converted LLaVA checkpoints by revision, license, canonical manifests for every consumed model/tokenizer/processor sidecar, and 19-tensor conversion identity.
- Pin `tests/fixtures/test_image.png` at the oracle, diagnostic runner, validation script, and public-surface boundaries.
- Capture independent processor, vision, projector, merged embedding, logits, all-layer KV, and greedy-token reference seams, then compare the production MLX-host plus IREE path with ordered first-divergence reporting.
- Make the comparator fail closed on exact cases/stages, duplicate JSON keys, dtype/semantic shape/path/size errors, non-finite arrays, exact KV/generation metadata, and exact negative-case outcomes; cover the contract with model-free adversarial tests wired into the structural validation gate.
- Add one-image, text-only, malformed-placeholder, and context-overflow cases. The two-image case uses the pinned original followed by a deterministic red/blue channel swap, and Python/Rust now prove that raw bytes, processor slices, and concatenated order are observably distinct.
- Derive malformed-placeholder and context-overflow categories from the production typed/exact errors, and reject tokenizer/chat-template/weight alternates that could take runtime precedence over the pinned manifests.
- Preserve typed media content at the server template boundary so OpenAI `image_url` parts render the same LLaVA prompt and unexpanded token IDs as the CLI.
- Document CUDA and CPU local-sync runtime, memory, preprocessing, prefill, and decode baselines without committing weights or generated captures.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --features xla-diagnostics --lib --bins --example xla_llava_reference_check -- -D warnings`
- `cargo test --features xla-diagnostics --example xla_llava_reference_check`: 4 passed
- `python -m unittest -v spike/openxla/test_llava_reference_oracle.py`: 16 adversarial comparator/oracle tests passed
- `MLXCEL_ORACLE_PYTHON=... scripts/xla/validate_llava_reference.sh --structural-only`: oracle 16 passed, diagnostic seam 1 passed, chat-template 92 passed/1 ignored
- `cargo test -p mlxcel-xla --lib llava_diagnostics_share_the_production_embeddings_prefill`: 1 passed
- `cargo test --lib server::chat_template`: 92 passed, 1 ignored
- `cargo test --lib -- --test-threads=1 --skip models::bitnet::tests::bitlinear_matmul_known_ternary_case`: 4,482 passed, 113 ignored; the skipped test aborts only in the backend-less Linux build
- `cargo test --release --lib --features cuda -- --test-threads=1`: 4,482 passed, 113 ignored
- `scripts/xla/validate_arch.sh --structural-only`: 9 passed
- Fresh HF versus XLA CUDA and CPU local-sync stage comparisons after the channel-swap change: every one-image/two-image/text-only case passed with `first_divergence = null`
- CUDA surface gate after hardening: CLI and streaming server both generated `The image displays a`; exact 15 unexpanded prompt IDs, finish reason, usage 15/4/19, chunk order, effective prefill 743, and metrics passed
- Qwen2 CUDA companion: HF token-exact single sequence passed; four-request batch reference equivalence passed at 20.53 tok/s
- `bash -n`, Python bytecode compilation, `git diff --check`, and explicit staged/untracked CSV checks passed; no CSV or generated capture is committed

## Environment notes

- IREE `local-task` could not create worker threads under the constrained host; the documented `local-sync` CPU fallback passed with the CUDA host preprocessor.
- Debug CUDA libtest linking exceeded the AArch64 call relocation range; the CI-style release CUDA suite linked and passed.
- All-target Clippy reaches a pre-existing `print_literal` warning in `examples/qmm_gemv_microbench.rs`; all library, binary, and new LLaVA example targets pass with `-D warnings`.

Closes #862