### PR TITLE
feat: add Qwen2-VL OpenXLA vision path (#865)

### DIFF
--- a/src/lib/mlxcel-xla/src/emitter/config.rs
+++ b/src/lib/mlxcel-xla/src/emitter/config.rs
@@ -717,7 +717,10 @@ impl Config {
                     }
                 }
             }
-            Some("qwen2") => {
+            Some("qwen2") | Some("qwen2_vl") => {
+                // Qwen2-VL keeps the Qwen2 language configuration at the wrapper
+                // root (unlike LLaVA's nested `text_config`). Its language graph
+                // is therefore the ordinary Qwen2 graph with M-RoPE positions.
                 qkv_bias = true;
             }
             Some("qwen3") => {
@@ -1194,7 +1197,8 @@ impl Config {
                         rotary_width / 2
                     ));
                 }
-                let supported_family = matches!(model_type, Some("qwen2") | Some("qwen3"));
+                let supported_family =
+                    matches!(model_type, Some("qwen2") | Some("qwen2_vl") | Some("qwen3"));
                 if !supported_family {
                     return Err(format!(
                         "M-RoPE sections are only supported by the Qwen2/Qwen3 language backbone, got model_type={model_type:?}"
@@ -1704,6 +1708,10 @@ mod tests {
                 layout: MropeLayout::Chunked,
             })
         );
+        let qwen2_vl = Config::from_json_str(&base("qwen2_vl", "[1,1,1]", ""))
+            .expect("Qwen2-VL root language config parses");
+        assert_eq!(qwen2_vl.mrope, qwen2.mrope);
+        assert!(qwen2_vl.qkv_bias);
         let qwen3 = Config::from_json_str(&base("qwen3", "[1,1,1]", "")).expect("Qwen3 parses");
         assert_eq!(
             qwen3.mrope.unwrap().layout,

--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -58,6 +58,7 @@ mod gemma3n_weights;
 mod model;
 mod moe;
 mod phi4_audio;
+mod qwen2_vl;
 mod rope;
 mod vision;
 mod vision_config;
@@ -118,6 +119,13 @@ pub(crate) use phi4_audio::{
     Phi4AudioConfig, Phi4AudioDiagnosticSpec, Phi4AudioWeightSpec, emit_phi4_audio,
     emit_phi4_audio_diagnostic_with, emit_phi4_audio_with, phi4_audio_diagnostic_specs,
     phi4_audio_weight_specs, validate_phi4_audio_weight_shapes,
+};
+#[allow(unused_imports)]
+pub(crate) use qwen2_vl::emit_qwen2_vl;
+#[allow(unused_imports)]
+pub(crate) use qwen2_vl::{
+    QWEN2_VL_PATCH_BUCKETS, Qwen2VlConfig, Qwen2VlGridPlan, Qwen2VlHostInputs, Qwen2VlWeightSpec,
+    prepare_qwen2_vl_host_inputs,
 };
 // MoE FFN config types (issue #500), read by the weight loader (`iree.rs`) and the
 // validation harness. `SharedExpertConfig` is only named in some build cfgs.

--- a/src/lib/mlxcel-xla/src/emitter/qwen2_vl.rs
+++ b/src/lib/mlxcel-xla/src/emitter/qwen2_vl.rs
@@ -1,0 +1,904 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Static-shape contract for the Qwen2-VL vision tower.
+//!
+//! The processor keeps the checkpoint's dynamic smart-resize policy, while the
+//! compiled graph admits only this finite set of patch capacities. Inputs are
+//! padded to the selected capacity and carry their actual patch count plus
+//! packed-sequence boundaries. No graph is compiled for an arbitrary image
+//! resolution.
+
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::builder::{Builder, Ty, Val};
+
+/// Qualified flattened-patch capacities for the pinned Qwen2-VL image path.
+///
+/// Every capacity is divisible by `spatial_merge_size²` for the checkpoint's
+/// 2x2 merger. Larger grids fail explicitly instead of triggering an unbounded
+/// compile or falling back to the MLX vision encoder.
+pub(crate) const QWEN2_VL_PATCH_BUCKETS: [usize; 3] = [16, 64, 256];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Qwen2VlWeightSpec {
+    pub(crate) name: String,
+    /// Logical dequantized F32 shape consumed by StableHLO.
+    pub(crate) shape: Vec<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Qwen2VlConfig {
+    pub(crate) depth: usize,
+    pub(crate) hidden: usize,
+    pub(crate) intermediate: usize,
+    pub(crate) heads: usize,
+    pub(crate) patch_size: usize,
+    pub(crate) temporal_patch_size: usize,
+    pub(crate) spatial_merge_size: usize,
+    pub(crate) channels: usize,
+    pub(crate) text_hidden: usize,
+    pub(crate) layer_norm_eps: f32,
+    pub(crate) quantization: Option<(usize, usize)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Qwen2VlGridPlan {
+    pub(crate) patch_bucket: usize,
+    pub(crate) actual_patches: usize,
+    pub(crate) packed_cu_seqlens: Vec<usize>,
+    pub(crate) merged_tokens_per_image: Vec<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Qwen2VlHostInputs {
+    pub(crate) plan: Qwen2VlGridPlan,
+    pub(crate) patches: Vec<f32>,
+    pub(crate) vision_rope_freqs: Vec<f32>,
+    pub(crate) packed_attention_bias: Vec<f32>,
+}
+
+struct Args {
+    values: Vec<Val>,
+    declarations: Vec<String>,
+    cursor: usize,
+}
+
+impl Args {
+    fn new(specs: &[Qwen2VlWeightSpec]) -> Self {
+        let mut values = Vec::with_capacity(specs.len() + 3);
+        let mut declarations = Vec::with_capacity(specs.len() + 3);
+        for (index, spec) in specs.iter().enumerate() {
+            let ty = Ty::f32(spec.shape.clone());
+            declarations.push(format!(
+                "%arg{index}: {} loc(\"{}\")",
+                ty.render(),
+                spec.name
+            ));
+            values.push(Builder::arg(index, ty));
+        }
+        Self {
+            values,
+            declarations,
+            cursor: 0,
+        }
+    }
+
+    fn take(&mut self) -> Val {
+        let value = self.values[self.cursor].clone();
+        self.cursor += 1;
+        value
+    }
+
+    fn push_input(&mut self, ty: Ty, name: &str) -> Val {
+        let index = self.values.len();
+        self.declarations
+            .push(format!("%arg{index}: {} loc(\"{name}\")", ty.render()));
+        let value = Builder::arg(index, ty);
+        self.values.push(value.clone());
+        value
+    }
+}
+
+fn positive_usize(object: &serde_json::Map<String, Value>, field: &str) -> Result<usize, String> {
+    let value = object
+        .get(field)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| format!("config.json vision_config.{field} must be a positive integer"))?;
+    let value = usize::try_from(value)
+        .map_err(|_| format!("config.json vision_config.{field} does not fit usize"))?;
+    if value == 0 {
+        return Err(format!(
+            "config.json vision_config.{field} must be greater than zero"
+        ));
+    }
+    Ok(value)
+}
+
+impl Qwen2VlConfig {
+    pub(crate) fn from_model_dir(model_dir: &Path) -> Result<Self, String> {
+        let path = model_dir.join("config.json");
+        let text = std::fs::read_to_string(&path)
+            .map_err(|error| format!("{}: {error}", path.display()))?;
+        Self::from_json_str(&text)
+    }
+
+    pub(crate) fn from_json_str(text: &str) -> Result<Self, String> {
+        let root: Value =
+            serde_json::from_str(text).map_err(|error| format!("parse config.json: {error}"))?;
+        if root.get("model_type").and_then(Value::as_str) != Some("qwen2_vl") {
+            return Err("Qwen2-VL IREE vision requires model_type=qwen2_vl".to_string());
+        }
+        let vision = root
+            .get("vision_config")
+            .and_then(Value::as_object)
+            .ok_or_else(|| "config.json vision_config must be an object".to_string())?;
+        let depth = positive_usize(vision, "depth")?;
+        let hidden = positive_usize(vision, "embed_dim")?;
+        let heads = positive_usize(vision, "num_heads")?;
+        if hidden % heads != 0 {
+            return Err(format!(
+                "Qwen2-VL vision embed_dim={hidden} is not divisible by num_heads={heads}"
+            ));
+        }
+        let mlp_ratio = vision
+            .get("mlp_ratio")
+            .and_then(Value::as_f64)
+            .ok_or_else(|| {
+                "config.json vision_config.mlp_ratio must be a positive number".to_string()
+            })?;
+        if !mlp_ratio.is_finite() || mlp_ratio <= 0.0 {
+            return Err(
+                "config.json vision_config.mlp_ratio must be finite and positive".to_string(),
+            );
+        }
+        let intermediate_f64 = hidden as f64 * mlp_ratio;
+        if intermediate_f64.fract() != 0.0 || intermediate_f64 > usize::MAX as f64 {
+            return Err(format!(
+                "Qwen2-VL vision intermediate size {hidden} * {mlp_ratio} is not an integer"
+            ));
+        }
+        let intermediate = intermediate_f64 as usize;
+        let patch_size = positive_usize(vision, "patch_size")?;
+        let temporal_patch_size = positive_usize(vision, "temporal_patch_size")?;
+        let spatial_merge_size = positive_usize(vision, "spatial_merge_size")?;
+        let channels = vision
+            .get("in_chans")
+            .or_else(|| vision.get("in_channels"))
+            .and_then(Value::as_u64)
+            .map_or(Ok(3usize), |value| {
+                usize::try_from(value).map_err(|_| {
+                    "config.json vision_config.in_chans does not fit usize".to_string()
+                })
+            })?;
+        if channels == 0 {
+            return Err("config.json vision_config.in_chans must be positive".to_string());
+        }
+        let text_hidden = root
+            .get("hidden_size")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| "config.json hidden_size must be a positive integer".to_string())
+            .and_then(|value| {
+                usize::try_from(value)
+                    .map_err(|_| "config.json hidden_size does not fit usize".to_string())
+            })?;
+        if text_hidden == 0 {
+            return Err("config.json hidden_size must be positive".to_string());
+        }
+        if spatial_merge_size != 2 {
+            return Err(format!(
+                "Qwen2-VL IREE vision currently qualifies spatial_merge_size=2, got {spatial_merge_size}"
+            ));
+        }
+        if temporal_patch_size != 2 {
+            return Err(format!(
+                "Qwen2-VL IREE image vision currently qualifies temporal_patch_size=2, got {temporal_patch_size}"
+            ));
+        }
+        let quantization = match root.get("quantization") {
+            None => None,
+            Some(value) => {
+                let object = value
+                    .as_object()
+                    .ok_or_else(|| "config.json quantization must be an object".to_string())?;
+                let bits = positive_usize(object, "bits")
+                    .map_err(|error| error.replace("vision_config.", "quantization."))?;
+                let group_size = positive_usize(object, "group_size")
+                    .map_err(|error| error.replace("vision_config.", "quantization."))?;
+                if !matches!(bits, 4 | 8) {
+                    return Err(format!(
+                        "Qwen2-VL IREE vision supports 4-bit or 8-bit affine weights, got {bits}"
+                    ));
+                }
+                if hidden % group_size != 0 || intermediate % group_size != 0 {
+                    return Err(format!(
+                        "Qwen2-VL vision dimensions hidden={hidden}, intermediate={intermediate} must be divisible by quantization group_size={group_size}"
+                    ));
+                }
+                Some((bits, group_size))
+            }
+        };
+        Ok(Self {
+            depth,
+            hidden,
+            intermediate,
+            heads,
+            patch_size,
+            temporal_patch_size,
+            spatial_merge_size,
+            channels,
+            text_hidden,
+            layer_norm_eps: 1e-6,
+            quantization,
+        })
+    }
+
+    pub(crate) fn bucket_for_patches(&self, actual_patches: usize) -> Result<usize, String> {
+        if actual_patches == 0 {
+            return Err("Qwen2-VL image grid must contain at least one patch".to_string());
+        }
+        let merge_area = self
+            .spatial_merge_size
+            .checked_mul(self.spatial_merge_size)
+            .ok_or_else(|| "Qwen2-VL merge area overflowed".to_string())?;
+        if !actual_patches.is_multiple_of(merge_area) {
+            return Err(format!(
+                "Qwen2-VL image grid has {actual_patches} patches, which is not divisible by spatial_merge_size²={merge_area}"
+            ));
+        }
+        QWEN2_VL_PATCH_BUCKETS
+            .iter()
+            .copied()
+            .find(|&bucket| actual_patches <= bucket)
+            .ok_or_else(|| {
+                format!(
+                    "Qwen2-VL image grid has {actual_patches} patches, exceeding qualified capacity {}",
+                    QWEN2_VL_PATCH_BUCKETS[QWEN2_VL_PATCH_BUCKETS.len() - 1]
+                )
+            })
+    }
+
+    /// Validate each image grid before selecting one packed static bucket.
+    ///
+    /// Per-axis merge divisibility is stronger than checking only the total:
+    /// `1x16` has a merge-area-divisible product but cannot form 2x2 groups.
+    /// Temporal grids are rejected by the image-only issue scope.
+    pub(crate) fn plan_image_grids(
+        &self,
+        grids: &[(i32, i32, i32)],
+    ) -> Result<Qwen2VlGridPlan, String> {
+        if grids.is_empty() {
+            return Err("Qwen2-VL image execution requires at least one grid".to_string());
+        }
+        let mut actual_patches = 0usize;
+        let mut packed_cu_seqlens = vec![0usize];
+        let mut merged_tokens_per_image = Vec::with_capacity(grids.len());
+        for (index, &(temporal, height, width)) in grids.iter().enumerate() {
+            if temporal != 1 {
+                return Err(format!(
+                    "Qwen2-VL grid {index} has temporal size {temporal}; video/temporal grids are unsupported by the image-only XLA path"
+                ));
+            }
+            let height = usize::try_from(height)
+                .map_err(|_| format!("Qwen2-VL grid {index} has non-positive height {height}"))?;
+            let width = usize::try_from(width)
+                .map_err(|_| format!("Qwen2-VL grid {index} has non-positive width {width}"))?;
+            if height == 0 || width == 0 {
+                return Err(format!(
+                    "Qwen2-VL grid {index} dimensions must be positive, got {height}x{width}"
+                ));
+            }
+            if !height.is_multiple_of(self.spatial_merge_size)
+                || !width.is_multiple_of(self.spatial_merge_size)
+            {
+                return Err(format!(
+                    "Qwen2-VL grid {index} {height}x{width} must be divisible on each spatial axis by spatial_merge_size={}",
+                    self.spatial_merge_size
+                ));
+            }
+            let patches = height
+                .checked_mul(width)
+                .ok_or_else(|| format!("Qwen2-VL grid {index} patch count overflowed"))?;
+            actual_patches = actual_patches
+                .checked_add(patches)
+                .ok_or_else(|| "Qwen2-VL packed patch count overflowed".to_string())?;
+            packed_cu_seqlens.push(actual_patches);
+            merged_tokens_per_image.push(self.merged_tokens(patches));
+        }
+        Ok(Qwen2VlGridPlan {
+            patch_bucket: self.bucket_for_patches(actual_patches)?,
+            actual_patches,
+            packed_cu_seqlens,
+            merged_tokens_per_image,
+        })
+    }
+
+    #[must_use]
+    pub(crate) fn merged_tokens(&self, actual_patches: usize) -> usize {
+        actual_patches / (self.spatial_merge_size * self.spatial_merge_size)
+    }
+
+    #[must_use]
+    pub(crate) fn fingerprint(&self, patch_bucket: usize) -> String {
+        format!(
+            "qwen2-vl-vision-v1:bucket={patch_bucket}:patch={}:temporal={}:merge={}:channels={}:hidden={}:intermediate={}:heads={}:depth={}:text={}:dtype=f32:source_quant={:?}",
+            self.patch_size,
+            self.temporal_patch_size,
+            self.spatial_merge_size,
+            self.channels,
+            self.hidden,
+            self.intermediate,
+            self.heads,
+            self.depth,
+            self.text_hidden,
+            self.quantization,
+        )
+    }
+
+    pub(crate) fn weight_specs(&self) -> Vec<Qwen2VlWeightSpec> {
+        let patch_width =
+            self.channels * self.temporal_patch_size * self.patch_size * self.patch_size;
+        let mut specs = vec![self.spec(
+            "vision_tower.patch_embed.proj.weight",
+            [self.hidden, patch_width],
+        )];
+        for layer in 0..self.depth {
+            let prefix = format!("vision_tower.blocks.{layer}");
+            for (suffix, shape) in [
+                ("norm1.weight", vec![self.hidden]),
+                ("norm1.bias", vec![self.hidden]),
+                ("attn.qkv.weight", vec![self.hidden * 3, self.hidden]),
+                ("attn.qkv.bias", vec![self.hidden * 3]),
+                ("attn.proj.weight", vec![self.hidden, self.hidden]),
+                ("attn.proj.bias", vec![self.hidden]),
+                ("norm2.weight", vec![self.hidden]),
+                ("norm2.bias", vec![self.hidden]),
+                ("mlp.fc1.weight", vec![self.intermediate, self.hidden]),
+                ("mlp.fc1.bias", vec![self.intermediate]),
+                ("mlp.fc2.weight", vec![self.hidden, self.intermediate]),
+                ("mlp.fc2.bias", vec![self.hidden]),
+            ] {
+                specs.push(Qwen2VlWeightSpec {
+                    name: format!("{prefix}.{suffix}"),
+                    shape,
+                });
+            }
+        }
+        let merge_width = self.hidden * self.spatial_merge_size * self.spatial_merge_size;
+        specs.extend([
+            self.spec("vision_tower.merger.ln_q.weight", [self.hidden]),
+            self.spec("vision_tower.merger.ln_q.bias", [self.hidden]),
+            self.spec(
+                "vision_tower.merger.mlp.0.weight",
+                [merge_width, merge_width],
+            ),
+            self.spec("vision_tower.merger.mlp.0.bias", [merge_width]),
+            self.spec(
+                "vision_tower.merger.mlp.2.weight",
+                [self.text_hidden, merge_width],
+            ),
+            self.spec("vision_tower.merger.mlp.2.bias", [self.text_hidden]),
+        ]);
+        specs
+    }
+
+    fn spec<const N: usize>(&self, name: &str, shape: [usize; N]) -> Qwen2VlWeightSpec {
+        Qwen2VlWeightSpec {
+            name: name.to_string(),
+            shape: shape.into(),
+        }
+    }
+}
+
+pub(crate) fn prepare_qwen2_vl_host_inputs(
+    config: &Qwen2VlConfig,
+    grids: &[(i32, i32, i32)],
+    temporal_patch_rows: &[f32],
+) -> Result<Qwen2VlHostInputs, String> {
+    let plan = config.plan_image_grids(grids)?;
+    let row_width = config
+        .channels
+        .checked_mul(config.patch_size)
+        .and_then(|value| value.checked_mul(config.patch_size))
+        .ok_or_else(|| "Qwen2-VL processor row width overflowed".to_string())?;
+    let actual_values = plan
+        .actual_patches
+        .checked_mul(config.temporal_patch_size)
+        .and_then(|value| value.checked_mul(row_width))
+        .ok_or_else(|| "Qwen2-VL processor tensor size overflowed".to_string())?;
+    if temporal_patch_rows.len() != actual_values {
+        return Err(format!(
+            "Qwen2-VL processor produced {} values, expected {actual_values} for {} patches x temporal {} x row width {row_width}",
+            temporal_patch_rows.len(),
+            plan.actual_patches,
+            config.temporal_patch_size
+        ));
+    }
+    if let Some((index, value)) = temporal_patch_rows
+        .iter()
+        .enumerate()
+        .find(|(_, value)| !value.is_finite())
+    {
+        return Err(format!(
+            "Qwen2-VL processor values contain non-finite value {value} at flat index {index}"
+        ));
+    }
+    let patch_width = row_width
+        .checked_mul(config.temporal_patch_size)
+        .ok_or_else(|| "Qwen2-VL temporal patch width overflowed".to_string())?;
+    let padded_values = plan
+        .patch_bucket
+        .checked_mul(patch_width)
+        .ok_or_else(|| "Qwen2-VL padded patch tensor size overflowed".to_string())?;
+    let mut patches = Vec::with_capacity(padded_values);
+    // The shared processor emits the temporal rows contiguously for each
+    // spatial patch. Flattening those adjacent rows is exactly the
+    // `[patch, temporal*channels*height*width]` patch-projection contract.
+    patches.extend_from_slice(temporal_patch_rows);
+    patches.resize(padded_values, 0.0);
+
+    let head_dim = config.hidden / config.heads;
+    let rotary_dim = head_dim / 2;
+    let frequency_width = rotary_dim;
+    let axis_width = rotary_dim / 2;
+    if head_dim % 4 != 0 {
+        return Err(format!(
+            "Qwen2-VL vision head_dim={head_dim} must be divisible by 4 for 2D RoPE"
+        ));
+    }
+    let inv_freq = (0..axis_width)
+        .map(|index| 1.0 / 10_000.0f32.powf((2 * index) as f32 / rotary_dim as f32))
+        .collect::<Vec<_>>();
+    let mut vision_rope_freqs = Vec::with_capacity(plan.patch_bucket * frequency_width);
+    let merge = config.spatial_merge_size;
+    for &(temporal, height, width) in grids {
+        debug_assert_eq!(temporal, 1);
+        let height = height as usize;
+        let width = width as usize;
+        for block_h in 0..height / merge {
+            for block_w in 0..width / merge {
+                for inner_h in 0..merge {
+                    for inner_w in 0..merge {
+                        let h = (block_h * merge + inner_h) as f32;
+                        let w = (block_w * merge + inner_w) as f32;
+                        vision_rope_freqs.extend(inv_freq.iter().map(|frequency| h * frequency));
+                        vision_rope_freqs.extend(inv_freq.iter().map(|frequency| w * frequency));
+                    }
+                }
+            }
+        }
+    }
+    vision_rope_freqs.resize(plan.patch_bucket * frequency_width, 0.0);
+
+    let bias_values = plan
+        .patch_bucket
+        .checked_mul(plan.patch_bucket)
+        .ok_or_else(|| "Qwen2-VL packed attention bias size overflowed".to_string())?;
+    let mut packed_attention_bias = vec![f32::NEG_INFINITY; bias_values];
+    for segment in plan.packed_cu_seqlens.windows(2) {
+        for row in segment[0]..segment[1] {
+            for column in segment[0]..segment[1] {
+                packed_attention_bias[row * plan.patch_bucket + column] = 0.0;
+            }
+        }
+    }
+    // Give every padded query one finite self key so its softmax cannot create
+    // NaNs. Padded rows remain unreachable from every real media segment.
+    for index in plan.actual_patches..plan.patch_bucket {
+        packed_attention_bias[index * plan.patch_bucket + index] = 0.0;
+    }
+    Ok(Qwen2VlHostInputs {
+        plan,
+        patches,
+        vision_rope_freqs,
+        packed_attention_bias,
+    })
+}
+
+fn bias_2d(builder: &mut Builder, value: &Val, bias: &Val) -> Val {
+    let rows = value.ty.shape[0];
+    let width = value.ty.shape[1];
+    let bias = builder.broadcast(bias, &[1], vec![rows, width]);
+    builder.add(value, &bias)
+}
+
+fn linear_2d(builder: &mut Builder, value: &Val, weight: &Val, bias: &Val) -> Val {
+    let value = builder.linear_seq(value, weight);
+    bias_2d(builder, &value, bias)
+}
+
+fn layer_norm(builder: &mut Builder, value: &Val, weight: &Val, bias: &Val, epsilon: f32) -> Val {
+    let rows = value.ty.shape[0];
+    let width = value.ty.shape[1];
+    let zero = builder.const_f32(0.0);
+    let width_scalar = builder.const_f32(width as f32);
+    let width_rows = builder.broadcast(&width_scalar, &[], vec![rows]);
+    let sum = builder.reduce_add(value, 1, &zero);
+    let mean = builder.divide(&sum, &width_rows);
+    let mean = builder.broadcast(&mean, &[0], vec![rows, width]);
+    let centered = builder.subtract(value, &mean);
+    let squared = builder.multiply(&centered, &centered);
+    let squared_sum = builder.reduce_add(&squared, 1, &zero);
+    let variance = builder.divide(&squared_sum, &width_rows);
+    let epsilon = builder.const_f32(epsilon);
+    let epsilon = builder.broadcast(&epsilon, &[], vec![rows]);
+    let variance = builder.add(&variance, &epsilon);
+    let inv_std = builder.rsqrt(&variance);
+    let inv_std = builder.broadcast(&inv_std, &[0], vec![rows, width]);
+    let normalized = builder.multiply(&centered, &inv_std);
+    let weight = builder.broadcast(weight, &[1], vec![rows, width]);
+    let bias = builder.broadcast(bias, &[1], vec![rows, width]);
+    let normalized = builder.multiply(&normalized, &weight);
+    builder.add(&normalized, &bias)
+}
+
+fn exact_gelu(builder: &mut Builder, value: &Val) -> Val {
+    let shape = value.ty.shape.clone();
+    let half = builder.const_f32(0.5);
+    let half = builder.broadcast(&half, &[], shape.clone());
+    let one = builder.const_f32(1.0);
+    let one = builder.broadcast(&one, &[], shape.clone());
+    let inv_sqrt_two = builder.const_f32(std::f32::consts::FRAC_1_SQRT_2);
+    let inv_sqrt_two = builder.broadcast(&inv_sqrt_two, &[], shape);
+    let scaled = builder.multiply(value, &inv_sqrt_two);
+    let erf = builder.erf(&scaled);
+    let cdf = builder.add(&one, &erf);
+    let half_value = builder.multiply(value, &half);
+    builder.multiply(&half_value, &cdf)
+}
+
+fn tanh_gelu(builder: &mut Builder, value: &Val) -> Val {
+    let shape = value.ty.shape.clone();
+    let half = builder.const_f32(0.5);
+    let half = builder.broadcast(&half, &[], shape.clone());
+    let one = builder.const_f32(1.0);
+    let one = builder.broadcast(&one, &[], shape.clone());
+    let coefficient = builder.const_f32(0.044_715);
+    let coefficient = builder.broadcast(&coefficient, &[], shape.clone());
+    let scale = builder.const_f32(0.797_884_6);
+    let scale = builder.broadcast(&scale, &[], shape);
+    let squared = builder.multiply(value, value);
+    let cubed = builder.multiply(&squared, value);
+    let nonlinear = builder.multiply(&coefficient, &cubed);
+    let inner = builder.add(value, &nonlinear);
+    let scaled = builder.multiply(&scale, &inner);
+    let tanh = builder.tanh(&scaled);
+    let cdf = builder.add(&one, &tanh);
+    let half_value = builder.multiply(value, &half);
+    builder.multiply(&half_value, &cdf)
+}
+
+fn rotate_half(builder: &mut Builder, value: &Val) -> Val {
+    let tokens = value.ty.shape[0];
+    let heads = value.ty.shape[1];
+    let width = value.ty.shape[2];
+    let half = width / 2;
+    let first = builder.slice(value, &[(0, tokens), (0, heads), (0, half)]);
+    let second = builder.slice(value, &[(0, tokens), (0, heads), (half, width)]);
+    let second = builder.negate(&second);
+    builder.concatenate(&second, &first, 2)
+}
+
+fn apply_vision_rope(builder: &mut Builder, value: &Val, freqs: &Val) -> Val {
+    let tokens = value.ty.shape[0];
+    let heads = value.ty.shape[1];
+    let half = freqs.ty.shape[1];
+    let cos = builder.cosine(freqs);
+    let sin = builder.sine(freqs);
+    let cos = builder.concatenate(&cos, &cos, 1);
+    let sin = builder.concatenate(&sin, &sin, 1);
+    let cos = builder.broadcast(&cos, &[0, 2], vec![tokens, heads, half * 2]);
+    let sin = builder.broadcast(&sin, &[0, 2], vec![tokens, heads, half * 2]);
+    let rotated = rotate_half(builder, value);
+    let direct = builder.multiply(value, &cos);
+    let rotated = builder.multiply(&rotated, &sin);
+    builder.add(&direct, &rotated)
+}
+
+fn attention(
+    builder: &mut Builder,
+    hidden: &Val,
+    args: &mut Args,
+    config: &Qwen2VlConfig,
+    freqs: &Val,
+    attention_bias: &Val,
+) -> Val {
+    let tokens = hidden.ty.shape[0];
+    let head_dim = config.hidden / config.heads;
+    let qkv = linear_2d(builder, hidden, &args.take(), &args.take());
+    let qkv = builder.reshape(&qkv, vec![tokens, 3, config.heads, head_dim]);
+    let q = builder.slice(
+        &qkv,
+        &[(0, tokens), (0, 1), (0, config.heads), (0, head_dim)],
+    );
+    let k = builder.slice(
+        &qkv,
+        &[(0, tokens), (1, 2), (0, config.heads), (0, head_dim)],
+    );
+    let v = builder.slice(
+        &qkv,
+        &[(0, tokens), (2, 3), (0, config.heads), (0, head_dim)],
+    );
+    let q = builder.reshape(&q, vec![tokens, config.heads, head_dim]);
+    let k = builder.reshape(&k, vec![tokens, config.heads, head_dim]);
+    let v = builder.reshape(&v, vec![tokens, config.heads, head_dim]);
+    let q = apply_vision_rope(builder, &q, freqs);
+    let k = apply_vision_rope(builder, &k, freqs);
+    let q = builder.transpose(&q, &[1, 0, 2]);
+    let k = builder.transpose(&k, &[1, 0, 2]);
+    let v = builder.transpose(&v, &[1, 0, 2]);
+    let scores = builder.dot_general(
+        &q,
+        &k,
+        &[0],
+        &[0],
+        &[2],
+        &[2],
+        vec![config.heads, tokens, tokens],
+    );
+    let scale = builder.const_f32((head_dim as f32).powf(-0.5));
+    let scale = builder.broadcast(&scale, &[], vec![config.heads, tokens, tokens]);
+    let scores = builder.multiply(&scores, &scale);
+    let attention_bias =
+        builder.broadcast(attention_bias, &[1, 2], vec![config.heads, tokens, tokens]);
+    let scores = builder.add(&scores, &attention_bias);
+    let negative_infinity = builder.const_f32(f32::NEG_INFINITY);
+    let maximum = builder.reduce_max(&scores, 2, &negative_infinity);
+    let maximum = builder.broadcast(&maximum, &[0, 1], vec![config.heads, tokens, tokens]);
+    let shifted = builder.subtract(&scores, &maximum);
+    let exponentials = builder.exponential(&shifted);
+    let zero = builder.const_f32(0.0);
+    let denominator = builder.reduce_add(&exponentials, 2, &zero);
+    let denominator = builder.broadcast(&denominator, &[0, 1], vec![config.heads, tokens, tokens]);
+    let probabilities = builder.divide(&exponentials, &denominator);
+    let context = builder.dot_general(
+        &probabilities,
+        &v,
+        &[0],
+        &[0],
+        &[2],
+        &[1],
+        vec![config.heads, tokens, head_dim],
+    );
+    let context = builder.transpose(&context, &[1, 0, 2]);
+    let context = builder.reshape(&context, vec![tokens, config.hidden]);
+    linear_2d(builder, &context, &args.take(), &args.take())
+}
+
+fn encoder_layer(
+    builder: &mut Builder,
+    hidden: &Val,
+    args: &mut Args,
+    config: &Qwen2VlConfig,
+    freqs: &Val,
+    attention_bias: &Val,
+) -> Val {
+    let norm1 = layer_norm(
+        builder,
+        hidden,
+        &args.take(),
+        &args.take(),
+        config.layer_norm_eps,
+    );
+    let attention = attention(builder, &norm1, args, config, freqs, attention_bias);
+    let residual = builder.add(hidden, &attention);
+    let norm2 = layer_norm(
+        builder,
+        &residual,
+        &args.take(),
+        &args.take(),
+        config.layer_norm_eps,
+    );
+    let fc1 = linear_2d(builder, &norm2, &args.take(), &args.take());
+    let activated = tanh_gelu(builder, &fc1);
+    let fc2 = linear_2d(builder, &activated, &args.take(), &args.take());
+    builder.add(&residual, &fc2)
+}
+
+/// Emit one Qwen2-VL bucket. `patches` are already in the processor's
+/// post-smart-resize, spatial-merge-grouped order. `vision_rope` and
+/// `attention_bias` are host-built from `grid_thw`/packed boundaries, keeping
+/// cross-image isolation explicit while preserving one finite static graph.
+pub(crate) fn emit_qwen2_vl(config: &Qwen2VlConfig, patch_bucket: usize) -> String {
+    assert!(
+        QWEN2_VL_PATCH_BUCKETS.contains(&patch_bucket),
+        "unqualified Qwen2-VL patch bucket"
+    );
+    let specs = config.weight_specs();
+    let mut args = Args::new(&specs);
+    let mut builder = Builder::new();
+    let patch_weight = args.take();
+    let patch_width =
+        config.channels * config.temporal_patch_size * config.patch_size * config.patch_size;
+    let head_dim = config.hidden / config.heads;
+    let patches = args.push_input(Ty::f32(vec![patch_bucket, patch_width]), "patches.grouped");
+    let freqs = args.push_input(
+        Ty::f32(vec![patch_bucket, head_dim / 2]),
+        "vision_rope.freqs",
+    );
+    let attention_bias = args.push_input(
+        Ty::f32(vec![patch_bucket, patch_bucket]),
+        "packed_attention.bias",
+    );
+    let mut hidden = builder.linear_seq(&patches, &patch_weight);
+    for _ in 0..config.depth {
+        hidden = encoder_layer(
+            &mut builder,
+            &hidden,
+            &mut args,
+            config,
+            &freqs,
+            &attention_bias,
+        );
+    }
+    hidden = layer_norm(
+        &mut builder,
+        &hidden,
+        &args.take(),
+        &args.take(),
+        config.layer_norm_eps,
+    );
+    let merge_width = config.hidden * config.spatial_merge_size * config.spatial_merge_size;
+    let merged = builder.reshape(
+        &hidden,
+        vec![
+            patch_bucket / (config.spatial_merge_size * config.spatial_merge_size),
+            merge_width,
+        ],
+    );
+    let merged = linear_2d(&mut builder, &merged, &args.take(), &args.take());
+    let merged = exact_gelu(&mut builder, &merged);
+    let projected = linear_2d(&mut builder, &merged, &args.take(), &args.take());
+    assert_eq!(args.cursor, specs.len(), "Qwen2-VL weight schema drifted");
+    format!(
+        "module @qwen2_vl_vision {{\n  func.func public @main({signature}) -> {result_type} {{\n{body}    return {result} : {result_type}\n  }}\n}}\n",
+        signature = args.declarations.join(", "),
+        result_type = projected.ty.render(),
+        body = builder.body(),
+        result = projected.name,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> Qwen2VlConfig {
+        Qwen2VlConfig::from_json_str(
+            r#"{
+                "model_type": "qwen2_vl",
+                "hidden_size": 1536,
+                "vision_config": {
+                    "depth": 2,
+                    "embed_dim": 1280,
+                    "mlp_ratio": 4,
+                    "num_heads": 16,
+                    "in_chans": 3,
+                    "patch_size": 14,
+                    "spatial_merge_size": 2,
+                    "temporal_patch_size": 2
+                }
+            }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn static_buckets_bound_qwen2_vl_grids_without_per_shape_compilation() {
+        let config = config();
+        assert_eq!(config.bucket_for_patches(16), Ok(16));
+        assert_eq!(config.bucket_for_patches(20), Ok(64));
+        assert_eq!(config.bucket_for_patches(256), Ok(256));
+        assert!(
+            config
+                .bucket_for_patches(18)
+                .unwrap_err()
+                .contains("divisible")
+        );
+        assert!(
+            config
+                .bucket_for_patches(260)
+                .unwrap_err()
+                .contains("exceeding qualified capacity")
+        );
+        assert_eq!(config.merged_tokens(64), 16);
+        assert!(config.fingerprint(64).contains("bucket=64"));
+        assert!(
+            config
+                .plan_image_grids(&[(1, 1, 16)])
+                .unwrap_err()
+                .contains("each spatial axis")
+        );
+        assert!(
+            config
+                .plan_image_grids(&[(2, 4, 4)])
+                .unwrap_err()
+                .contains("video/temporal grids")
+        );
+        let packed = config.plan_image_grids(&[(1, 4, 4), (1, 4, 8)]).unwrap();
+        assert_eq!(packed.patch_bucket, 64);
+        assert_eq!(packed.actual_patches, 48);
+        assert_eq!(packed.packed_cu_seqlens, vec![0, 16, 48]);
+        assert_eq!(packed.merged_tokens_per_image, vec![4, 8]);
+    }
+
+    #[test]
+    fn weight_schema_covers_patch_blocks_and_merger_in_checkpoint_order() {
+        let config = config();
+        let specs = config.weight_specs();
+        assert_eq!(
+            specs.first().unwrap(),
+            &Qwen2VlWeightSpec {
+                name: "vision_tower.patch_embed.proj.weight".to_string(),
+                shape: vec![1280, 1176],
+            }
+        );
+        assert_eq!(specs.len(), 1 + 2 * 12 + 6);
+        assert_eq!(
+            specs.last().unwrap(),
+            &Qwen2VlWeightSpec {
+                name: "vision_tower.merger.mlp.2.bias".to_string(),
+                shape: vec![1536],
+            }
+        );
+    }
+
+    #[test]
+    fn emitted_bucket_has_packed_bias_rope_and_merged_output_contract() {
+        let config = config();
+        let mlir = emit_qwen2_vl(&config, 16);
+        assert!(mlir.contains("loc(\"patches.grouped\")"));
+        assert!(mlir.contains("tensor<16x1176xf32>"));
+        assert!(mlir.contains("loc(\"vision_rope.freqs\")"));
+        assert!(mlir.contains("tensor<16x40xf32>"));
+        assert!(mlir.contains("loc(\"packed_attention.bias\")"));
+        assert!(mlir.contains("tensor<16x16xf32>"));
+        assert!(mlir.contains("-> tensor<4x1536xf32>"));
+        assert_eq!(mlir.matches("stablehlo.dot_general").count(), 15);
+        assert_eq!(mlir.matches("chlo.erf").count(), 1);
+    }
+
+    #[test]
+    fn host_inputs_preserve_packed_media_isolation_and_finite_padding_rows() {
+        let config = config();
+        let grids = [(1, 4, 4), (1, 4, 8)];
+        let row_width = 3 * 14 * 14;
+        let values = vec![0.25; (16 + 32) * 2 * row_width];
+        let inputs = prepare_qwen2_vl_host_inputs(&config, &grids, &values).unwrap();
+        assert_eq!(inputs.plan.patch_bucket, 64);
+        assert_eq!(inputs.patches.len(), 64 * 1176);
+        assert_eq!(inputs.vision_rope_freqs.len(), 64 * 40);
+        assert_eq!(inputs.packed_attention_bias.len(), 64 * 64);
+        assert_eq!(inputs.packed_attention_bias[15 * 64 + 15], 0.0);
+        assert_eq!(
+            inputs.packed_attention_bias[15 * 64 + 16],
+            f32::NEG_INFINITY
+        );
+        assert_eq!(
+            inputs.packed_attention_bias[16 * 64 + 15],
+            f32::NEG_INFINITY
+        );
+        assert_eq!(inputs.packed_attention_bias[48 * 64 + 48], 0.0);
+        assert_eq!(inputs.packed_attention_bias[48 * 64 + 0], f32::NEG_INFINITY);
+        let mut non_finite = values;
+        non_finite[7] = f32::NAN;
+        assert!(
+            prepare_qwen2_vl_host_inputs(&config, &grids, &non_finite)
+                .unwrap_err()
+                .contains("flat index 7")
+        );
+    }
+}

--- a/src/lib/mlxcel-xla/src/lib.rs
+++ b/src/lib/mlxcel-xla/src/lib.rs
@@ -67,6 +67,8 @@ mod iree;
 #[cfg(feature = "iree")]
 mod phi4_audio;
 #[cfg(feature = "iree")]
+mod qwen2_vl_runtime;
+#[cfg(feature = "iree")]
 mod vision_runtime;
 
 // The continuous-batching engine (#449 M3 Stage 2b). Present under `iree` (real
@@ -149,6 +151,10 @@ pub use phi4_audio::{
 #[cfg(feature = "iree")]
 #[doc(hidden)]
 pub use phi4_audio::{Phi4AudioCheckpoint, Phi4AudioDiagnosticRuntime, Phi4AudioDiagnostics};
+#[cfg(feature = "iree")]
+pub use qwen2_vl_runtime::{
+    IreeQwen2VlProjector, Qwen2VlVisionExecutionMetrics, Qwen2VlVisionProjection,
+};
 #[cfg(feature = "diagnostics")]
 pub use vision_runtime::{IreeVisionDiagnosticProjector, VisionDiagnosticProjection};
 #[cfg(feature = "iree")]

--- a/src/lib/mlxcel-xla/src/qwen2_vl_runtime.rs
+++ b/src/lib/mlxcel-xla/src/qwen2_vl_runtime.rs
@@ -1,0 +1,765 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Resident IREE execution for the Qwen2-VL vision tower and patch merger.
+//!
+//! Only normalized patch extraction and grid metadata remain on the host. The
+//! full 32-layer vision tower and merger execute in the selected IREE target;
+//! this module never constructs or calls the MLX vision encoder.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use memmap2::Mmap;
+use safetensors::{Dtype, SafeTensors};
+use sha2::{Digest, Sha256};
+
+use crate::aux::{
+    AuxiliaryInput, AuxiliaryOutput, AuxiliaryTensorDType, AuxiliaryWeight, AuxiliaryWeightDType,
+    IreeAuxiliaryModule,
+};
+use crate::aux_manifest::{AuxiliaryArtifactContract, ensure_qualified_auxiliary_artifact};
+use crate::emitter::{
+    Qwen2VlConfig, Qwen2VlHostInputs, emit_qwen2_vl, prepare_qwen2_vl_host_inputs,
+};
+use crate::iree::{cached_vmfb_path, compile_one_to, iree_compile_bin, target_flags};
+use crate::weights::{bf16_to_f32, dequantize_affine, f16_to_f32, f32_le_to_f32};
+
+const ENTRY_NAME: &str = "qwen2_vl_vision.main";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Qwen2VlVisionExecutionMetrics {
+    pub patch_upload_bytes: usize,
+    pub metadata_upload_bytes: usize,
+    pub projected_transfer_bytes: usize,
+    pub elapsed_seconds: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Qwen2VlVisionProjection {
+    pub values: Vec<f32>,
+    pub shape: [usize; 2],
+    pub merged_tokens_per_image: Vec<usize>,
+    pub packed_cu_seqlens: Vec<usize>,
+    pub metrics: Qwen2VlVisionExecutionMetrics,
+}
+
+struct ActiveModule {
+    patch_bucket: usize,
+    module: IreeAuxiliaryModule,
+}
+
+pub struct IreeQwen2VlProjector {
+    model_dir: PathBuf,
+    device: String,
+    config: Qwen2VlConfig,
+    processor_identity: String,
+    active: Option<ActiveModule>,
+}
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write;
+        write!(output, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    output
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex_bytes(&Sha256::digest(bytes))
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let mut file = File::open(path).map_err(|error| format!("open {}: {error}", path.display()))?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| format!("read {}: {error}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(hex_bytes(&digest.finalize()))
+}
+
+fn compiler_generation_identity(
+    compiler: &Path,
+    flags: &[&str],
+    mlir: &str,
+) -> Result<String, String> {
+    let version = Command::new(compiler)
+        .arg("--version")
+        .output()
+        .map_err(|error| format!("run {} --version: {error}", compiler.display()))?;
+    if !version.status.success() {
+        return Err(format!(
+            "{} --version failed: {}",
+            compiler.display(),
+            String::from_utf8_lossy(&version.stderr)
+        ));
+    }
+    Ok(format!(
+        "compiler={};compiler_sha256={};version={};flags={flags:?};mlir_sha256={}",
+        compiler.display(),
+        sha256_file(compiler)?,
+        String::from_utf8_lossy(&version.stdout).trim(),
+        sha256_hex(mlir.as_bytes())
+    ))
+}
+
+fn processor_identity(model_dir: &Path, config: &Qwen2VlConfig) -> Result<String, String> {
+    let path = model_dir.join("preprocessor_config.json");
+    let bytes = std::fs::read(&path).map_err(|error| format!("{}: {error}", path.display()))?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("parse {}: {error}", path.display()))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| format!("{} must contain an object", path.display()))?;
+    for field in ["do_resize", "do_rescale", "do_normalize", "do_convert_rgb"] {
+        if object.get(field).and_then(serde_json::Value::as_bool) != Some(true) {
+            return Err(format!(
+                "preprocessor_config.json {field}=true is required by Qwen2-VL IREE vision"
+            ));
+        }
+    }
+    let positive = |field: &str| -> Result<usize, String> {
+        object
+            .get(field)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| usize::try_from(value).ok())
+            .filter(|&value| value > 0)
+            .ok_or_else(|| format!("preprocessor_config.json {field} must be a positive integer"))
+    };
+    for (field, expected) in [
+        ("patch_size", config.patch_size),
+        ("temporal_patch_size", config.temporal_patch_size),
+        ("merge_size", config.spatial_merge_size),
+    ] {
+        let actual = positive(field)?;
+        if actual != expected {
+            return Err(format!(
+                "preprocessor_config.json {field}={actual} disagrees with config value {expected}"
+            ));
+        }
+    }
+    if object
+        .get("image_processor_type")
+        .and_then(serde_json::Value::as_str)
+        != Some("Qwen2VLImageProcessor")
+    {
+        return Err(
+            "Qwen2-VL IREE vision requires image_processor_type=Qwen2VLImageProcessor".to_string(),
+        );
+    }
+    Ok(format!(
+        "qwen2-vl-processor-v1:sha256={}:patch={}:temporal={}:merge={}",
+        sha256_hex(&bytes),
+        config.patch_size,
+        config.temporal_patch_size,
+        config.spatial_merge_size
+    ))
+}
+
+fn model_shards(model_dir: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut shards = std::fs::read_dir(model_dir)
+        .map_err(|error| format!("read {}: {error}", model_dir.display()))?
+        .map(|entry| {
+            entry
+                .map(|entry| entry.path())
+                .map_err(|error| format!("read {} entry: {error}", model_dir.display()))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    shards.retain(|path| {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".safetensors"))
+    });
+    shards.sort();
+    if shards.is_empty() {
+        return Err(format!(
+            "no safetensors checkpoint shards found in {}",
+            model_dir.display()
+        ));
+    }
+    Ok(shards)
+}
+
+fn tensor_locations(model_dir: &Path) -> Result<BTreeMap<String, PathBuf>, String> {
+    let mut locations = BTreeMap::new();
+    for shard in model_shards(model_dir)? {
+        let file =
+            File::open(&shard).map_err(|error| format!("open {}: {error}", shard.display()))?;
+        // Safety: the map is read-only and lives through the header scan.
+        let mmap = unsafe { Mmap::map(&file) }
+            .map_err(|error| format!("mmap {}: {error}", shard.display()))?;
+        let tensors = SafeTensors::deserialize(&mmap)
+            .map_err(|error| format!("parse {}: {error}", shard.display()))?;
+        for name in tensors
+            .names()
+            .into_iter()
+            .filter(|name| name.starts_with("vision_tower."))
+        {
+            if let Some(previous) = locations.insert(name.to_string(), shard.clone()) {
+                return Err(format!(
+                    "Qwen2-VL vision tensor {name:?} is duplicated in {} and {}",
+                    previous.display(),
+                    shard.display()
+                ));
+            }
+        }
+    }
+    Ok(locations)
+}
+
+fn native_f32_bytes(values: Vec<f32>) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(values.len() * std::mem::size_of::<f32>());
+    for value in values {
+        bytes.extend_from_slice(&value.to_ne_bytes());
+    }
+    bytes
+}
+
+fn validate_finite(label: &str, values: &[f32]) -> Result<(), String> {
+    if let Some((index, value)) = values
+        .iter()
+        .enumerate()
+        .find(|(_, value)| !value.is_finite())
+    {
+        return Err(format!(
+            "{label} contains non-finite value {value} at flat index {index}"
+        ));
+    }
+    Ok(())
+}
+
+fn transpose_patch_t_h_w_c_to_t_c_h_w(values: Vec<f32>, config: &Qwen2VlConfig) -> Vec<f32> {
+    let out = config.hidden;
+    let temporal = config.temporal_patch_size;
+    let height = config.patch_size;
+    let width = config.patch_size;
+    let channels = config.channels;
+    let mut transposed = vec![0.0; values.len()];
+    for output in 0..out {
+        for t in 0..temporal {
+            for channel in 0..channels {
+                for y in 0..height {
+                    for x in 0..width {
+                        let source = ((((output * temporal + t) * height + y) * width + x)
+                            * channels)
+                            + channel;
+                        let target =
+                            ((((output * temporal + t) * channels + channel) * height + y) * width)
+                                + x;
+                        transposed[target] = values[source];
+                    }
+                }
+            }
+        }
+    }
+    transposed
+}
+
+fn decode_direct_f32(
+    label: &str,
+    dtype: Dtype,
+    data: &[u8],
+    expected_shape: &[usize],
+    source_shape: &[usize],
+) -> Result<Vec<f32>, String> {
+    if source_shape != expected_shape {
+        return Err(format!(
+            "{label} has shape {source_shape:?}, expected {expected_shape:?}"
+        ));
+    }
+    let values = match dtype {
+        Dtype::BF16 => bf16_to_f32(data),
+        Dtype::F16 => f16_to_f32(data),
+        Dtype::F32 => f32_le_to_f32(data),
+        other => {
+            return Err(format!(
+                "{label} has unsupported dtype {other:?}; expected BF16, F16, F32, or an affine U32 projection"
+            ));
+        }
+    };
+    validate_finite(label, &values)?;
+    Ok(values)
+}
+
+fn quant_sibling(name: &str, suffix: &str) -> Result<String, String> {
+    let stem = name
+        .strip_suffix(".weight")
+        .ok_or_else(|| format!("quantized Qwen2-VL tensor {name} must end in .weight"))?;
+    Ok(format!("{stem}.{suffix}"))
+}
+
+fn load_weights(
+    model_dir: &Path,
+    config: &Qwen2VlConfig,
+) -> Result<(Vec<AuxiliaryWeight>, String), String> {
+    let specs = config.weight_specs();
+    let locations = tensor_locations(model_dir)?;
+    let required = specs
+        .iter()
+        .map(|spec| spec.name.as_str())
+        .collect::<BTreeSet<_>>();
+    let missing = required
+        .iter()
+        .filter(|name| !locations.contains_key(**name))
+        .copied()
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        return Err(format!(
+            "checkpoint is missing {} Qwen2-VL vision tensor(s): {}",
+            missing.len(),
+            missing
+                .iter()
+                .take(8)
+                .copied()
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    let mut by_shard = BTreeMap::<&Path, Vec<usize>>::new();
+    for (index, spec) in specs.iter().enumerate() {
+        by_shard
+            .entry(
+                locations
+                    .get(&spec.name)
+                    .expect("missing specs rejected")
+                    .as_path(),
+            )
+            .or_default()
+            .push(index);
+    }
+    let mut loaded = (0..specs.len())
+        .map(|_| None)
+        .collect::<Vec<Option<AuxiliaryWeight>>>();
+    let mut source_schema = vec![String::new(); specs.len()];
+    for (shard, indices) in by_shard {
+        let file =
+            File::open(shard).map_err(|error| format!("open {}: {error}", shard.display()))?;
+        // Safety: the map is read-only and lives while selected tensors copy.
+        let mmap = unsafe { Mmap::map(&file) }
+            .map_err(|error| format!("mmap {}: {error}", shard.display()))?;
+        let tensors = SafeTensors::deserialize(&mmap)
+            .map_err(|error| format!("parse {}: {error}", shard.display()))?;
+        for index in indices {
+            let spec = &specs[index];
+            let tensor = tensors.tensor(&spec.name).map_err(|error| {
+                format!(
+                    "resolved Qwen2-VL tensor {} in {}: {error}",
+                    spec.name,
+                    shard.display()
+                )
+            })?;
+            let source_dtype = tensor.dtype();
+            let source_shape = tensor.shape().to_vec();
+            let (values, transform) = if spec.name == "vision_tower.patch_embed.proj.weight" {
+                let expected_source = [
+                    config.hidden,
+                    config.temporal_patch_size,
+                    config.patch_size,
+                    config.patch_size,
+                    config.channels,
+                ];
+                if source_shape != expected_source {
+                    return Err(format!(
+                        "{} has source shape {source_shape:?}, expected Conv3d [out,t,h,w,c] {expected_source:?}",
+                        spec.name
+                    ));
+                }
+                let values = decode_direct_f32(
+                    &spec.name,
+                    source_dtype,
+                    tensor.data(),
+                    &expected_source,
+                    &source_shape,
+                )?;
+                (
+                    transpose_patch_t_h_w_c_to_t_c_h_w(values, config),
+                    format!(
+                        "conv3d-source={source_shape:?}:layout=O,T,H,W,C->O,T,C,H,W->O,{}",
+                        spec.shape[1]
+                    ),
+                )
+            } else if source_dtype == Dtype::U32 {
+                let Some((bits, group_size)) = config.quantization else {
+                    return Err(format!(
+                        "{} is U32 affine-quantized but config.json has no quantization contract",
+                        spec.name
+                    ));
+                };
+                if spec.shape.len() != 2 {
+                    return Err(format!(
+                        "{} is quantized but logical shape {:?} is not rank 2",
+                        spec.name, spec.shape
+                    ));
+                }
+                let out = spec.shape[0];
+                let in_packed = spec.shape[1]
+                    .checked_mul(bits)
+                    .ok_or_else(|| format!("{} packed width overflowed", spec.name))?
+                    / 32;
+                if source_shape != [out, in_packed] {
+                    return Err(format!(
+                        "{} has packed shape {source_shape:?}, expected [{out}, {in_packed}]",
+                        spec.name
+                    ));
+                }
+                let scales_name = quant_sibling(&spec.name, "scales")?;
+                let biases_name = quant_sibling(&spec.name, "biases")?;
+                for sibling in [&scales_name, &biases_name] {
+                    if locations.get(sibling).map(PathBuf::as_path) != Some(shard) {
+                        return Err(format!(
+                            "quantized Qwen2-VL tensor {} and sibling {sibling} must share one immutable shard",
+                            spec.name
+                        ));
+                    }
+                }
+                let scales = tensors
+                    .tensor(&scales_name)
+                    .map_err(|error| format!("load {scales_name}: {error}"))?;
+                let biases = tensors
+                    .tensor(&biases_name)
+                    .map_err(|error| format!("load {biases_name}: {error}"))?;
+                let scales_bf16 = match (scales.dtype(), biases.dtype()) {
+                    (Dtype::F16, Dtype::F16) => false,
+                    (Dtype::BF16, Dtype::BF16) => true,
+                    (left, right) => {
+                        return Err(format!(
+                            "{} affine metadata dtypes {left:?}/{right:?} must be matching F16 or BF16",
+                            spec.name
+                        ));
+                    }
+                };
+                let values = dequantize_affine(
+                    tensor.data(),
+                    scales.data(),
+                    biases.data(),
+                    out,
+                    in_packed,
+                    bits,
+                    group_size,
+                    scales_bf16,
+                )?;
+                validate_finite(&format!("Qwen2-VL tensor {}", spec.name), &values)?;
+                (
+                    values,
+                    format!(
+                        "affine-source={source_dtype:?}:{source_shape:?};scales={:?}:{:?};biases={:?}:{:?};bits={bits};group={group_size}->f32",
+                        scales.dtype(),
+                        scales.shape(),
+                        biases.dtype(),
+                        biases.shape()
+                    ),
+                )
+            } else {
+                (
+                    decode_direct_f32(
+                        &spec.name,
+                        source_dtype,
+                        tensor.data(),
+                        &spec.shape,
+                        &source_shape,
+                    )?,
+                    "identity->f32".to_string(),
+                )
+            };
+            let expected = spec.shape.iter().try_fold(1usize, |count, dimension| {
+                count
+                    .checked_mul(*dimension)
+                    .ok_or_else(|| format!("{} logical element count overflowed", spec.name))
+            })?;
+            if values.len() != expected {
+                return Err(format!(
+                    "{} decoded {} values, expected {expected} for logical shape {:?}",
+                    spec.name,
+                    values.len(),
+                    spec.shape
+                ));
+            }
+            loaded[index] = Some(AuxiliaryWeight {
+                name: spec.name.clone(),
+                bytes: native_f32_bytes(values),
+                dtype: AuxiliaryWeightDType::Float32,
+                shape: spec.shape.clone(),
+            });
+            source_schema[index] = format!(
+                "{}:{source_dtype:?}:{source_shape:?}:{transform}",
+                spec.name
+            );
+        }
+    }
+    Ok((
+        loaded
+            .into_iter()
+            .map(|weight| weight.expect("all Qwen2-VL specs loaded"))
+            .collect(),
+        source_schema.join("\n"),
+    ))
+}
+
+fn f32_as_bytes(values: &[f32]) -> &[u8] {
+    // Safety: f32 has no invalid bit patterns and the view cannot outlive input.
+    unsafe {
+        std::slice::from_raw_parts(values.as_ptr().cast::<u8>(), std::mem::size_of_val(values))
+    }
+}
+
+fn checked_f32_output(label: &str, bytes: Vec<u8>) -> Result<Vec<f32>, String> {
+    if !bytes.len().is_multiple_of(std::mem::size_of::<f32>()) {
+        return Err(format!(
+            "{label} returned {} bytes, not a whole number of f32 values",
+            bytes.len()
+        ));
+    }
+    let values = bytes
+        .chunks_exact(std::mem::size_of::<f32>())
+        .map(|chunk| f32::from_ne_bytes(chunk.try_into().expect("four-byte f32 chunk")))
+        .collect::<Vec<_>>();
+    validate_finite(label, &values)?;
+    Ok(values)
+}
+
+fn compile_and_load(
+    model_dir: &Path,
+    device: &str,
+    config: &Qwen2VlConfig,
+    processor_identity: &str,
+    patch_bucket: usize,
+) -> Result<IreeAuxiliaryModule, String> {
+    let mlir = emit_qwen2_vl(config, patch_bucket);
+    let compiler = iree_compile_bin()?;
+    if !compiler.is_file() {
+        return Err(format!("iree-compile not found at {}", compiler.display()));
+    }
+    let flags = target_flags(device)?;
+    let cache = std::env::temp_dir().join("mlxcel-xla-qwen2-vl-vmfb");
+    std::fs::create_dir_all(&cache)
+        .map_err(|error| format!("mkdir {}: {error}", cache.display()))?;
+    let (weights, checkpoint_schema) = load_weights(model_dir, config)?;
+    let contract = AuxiliaryArtifactContract::new(
+        ENTRY_NAME,
+        format!(
+            "{};{};checkpoint_schema_sha256={}",
+            config.fingerprint(patch_bucket),
+            processor_identity,
+            sha256_hex(checkpoint_schema.as_bytes())
+        ),
+        compiler_generation_identity(&compiler, flags, &mlir)?,
+    )?;
+    let tag = format!("qwen2-vl-vision-{patch_bucket}");
+    let vmfb = cached_vmfb_path(&compiler, &mlir, flags, &cache, &tag, 0);
+    ensure_qualified_auxiliary_artifact(&vmfb, &contract, &weights, |temporary| {
+        compile_one_to(&compiler, &mlir, flags, &cache, &tag, 0, temporary)
+    })?;
+    IreeAuxiliaryModule::load(device, &vmfb, &contract, weights)
+}
+
+impl IreeQwen2VlProjector {
+    pub fn load(model_dir: &Path, device: &str) -> Result<Self, String> {
+        let config = Qwen2VlConfig::from_model_dir(model_dir)?;
+        let processor_identity = processor_identity(model_dir, &config)?;
+        Ok(Self {
+            model_dir: model_dir.to_path_buf(),
+            device: device.to_string(),
+            config,
+            processor_identity,
+            active: None,
+        })
+    }
+
+    #[must_use]
+    pub fn active_bucket(&self) -> Option<usize> {
+        self.active.as_ref().map(|active| active.patch_bucket)
+    }
+
+    #[must_use]
+    pub fn text_hidden(&self) -> usize {
+        self.config.text_hidden
+    }
+
+    fn ensure_bucket(&mut self, patch_bucket: usize) -> Result<&mut IreeAuxiliaryModule, String> {
+        if self.active.as_ref().map(|active| active.patch_bucket) != Some(patch_bucket) {
+            let module = compile_and_load(
+                &self.model_dir,
+                &self.device,
+                &self.config,
+                &self.processor_identity,
+                patch_bucket,
+            )?;
+            self.active = Some(ActiveModule {
+                patch_bucket,
+                module,
+            });
+        }
+        Ok(&mut self
+            .active
+            .as_mut()
+            .expect("active module installed")
+            .module)
+    }
+
+    pub fn project(
+        &mut self,
+        temporal_patch_rows: &[f32],
+        grids: &[(i32, i32, i32)],
+    ) -> Result<Qwen2VlVisionProjection, String> {
+        let Qwen2VlHostInputs {
+            plan,
+            patches,
+            vision_rope_freqs,
+            packed_attention_bias,
+        } = prepare_qwen2_vl_host_inputs(&self.config, grids, temporal_patch_rows)?;
+        let patch_width = self.config.channels
+            * self.config.temporal_patch_size
+            * self.config.patch_size
+            * self.config.patch_size;
+        let frequency_width = self.config.hidden / self.config.heads / 2;
+        let patch_shape = [plan.patch_bucket, patch_width];
+        let frequency_shape = [plan.patch_bucket, frequency_width];
+        let bias_shape = [plan.patch_bucket, plan.patch_bucket];
+        let full_output_shape = [
+            plan.patch_bucket / (self.config.spatial_merge_size * self.config.spatial_merge_size),
+            self.config.text_hidden,
+        ];
+        let mut output =
+            vec![0u8; full_output_shape.iter().product::<usize>() * std::mem::size_of::<f32>()];
+        let started = Instant::now();
+        self.ensure_bucket(plan.patch_bucket)?.invoke(
+            &[
+                AuxiliaryInput {
+                    bytes: f32_as_bytes(&patches),
+                    dtype: AuxiliaryTensorDType::Float32,
+                    shape: &patch_shape,
+                },
+                AuxiliaryInput {
+                    bytes: f32_as_bytes(&vision_rope_freqs),
+                    dtype: AuxiliaryTensorDType::Float32,
+                    shape: &frequency_shape,
+                },
+                AuxiliaryInput {
+                    bytes: f32_as_bytes(&packed_attention_bias),
+                    dtype: AuxiliaryTensorDType::Float32,
+                    shape: &bias_shape,
+                },
+            ],
+            &mut [AuxiliaryOutput {
+                bytes: &mut output,
+                dtype: AuxiliaryTensorDType::Float32,
+                shape: &full_output_shape,
+            }],
+        )?;
+        let elapsed_seconds = started.elapsed().as_secs_f64();
+        let all_values = checked_f32_output("Qwen2-VL IREE projected output", output)?;
+        let actual_tokens = plan.merged_tokens_per_image.iter().sum::<usize>();
+        let actual_values = actual_tokens
+            .checked_mul(self.config.text_hidden)
+            .ok_or_else(|| "Qwen2-VL projected output size overflowed".to_string())?;
+        let values = all_values
+            .get(..actual_values)
+            .ok_or_else(|| "Qwen2-VL IREE output is shorter than the actual grid".to_string())?
+            .to_vec();
+        Ok(Qwen2VlVisionProjection {
+            values,
+            shape: [actual_tokens, self.config.text_hidden],
+            merged_tokens_per_image: plan.merged_tokens_per_image,
+            packed_cu_seqlens: plan.packed_cu_seqlens,
+            metrics: Qwen2VlVisionExecutionMetrics {
+                patch_upload_bytes: std::mem::size_of_val(patches.as_slice()),
+                metadata_upload_bytes: std::mem::size_of_val(vision_rope_freqs.as_slice())
+                    + std::mem::size_of_val(packed_attention_bias.as_slice()),
+                projected_transfer_bytes: std::mem::size_of_val(all_values.as_slice()),
+                elapsed_seconds,
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny_config() -> Qwen2VlConfig {
+        Qwen2VlConfig::from_json_str(
+            r#"{
+                "model_type":"qwen2_vl",
+                "hidden_size":12,
+                "vision_config":{
+                    "depth":1,
+                    "embed_dim":8,
+                    "mlp_ratio":2,
+                    "num_heads":2,
+                    "in_chans":3,
+                    "patch_size":2,
+                    "spatial_merge_size":2,
+                    "temporal_patch_size":2
+                }
+            }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn conv3d_layout_transform_matches_o_t_c_h_w_flattening() {
+        let config = tiny_config();
+        let source = (0..config.hidden
+            * config.temporal_patch_size
+            * config.patch_size
+            * config.patch_size
+            * config.channels)
+            .map(|value| value as f32)
+            .collect::<Vec<_>>();
+        let transformed = transpose_patch_t_h_w_c_to_t_c_h_w(source.clone(), &config);
+        let source_index = |o: usize, t: usize, y: usize, x: usize, c: usize| {
+            ((((o * 2 + t) * 2 + y) * 2 + x) * 3) + c
+        };
+        let target_index = |o: usize, t: usize, c: usize, y: usize, x: usize| {
+            ((((o * 2 + t) * 3 + c) * 2 + y) * 2) + x
+        };
+        for o in 0..8 {
+            for t in 0..2 {
+                for c in 0..3 {
+                    for y in 0..2 {
+                        for x in 0..2 {
+                            assert_eq!(
+                                transformed[target_index(o, t, c, y, x)],
+                                source[source_index(o, t, y, x, c)]
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn output_decoder_rejects_non_finite_values() {
+        let mut bytes = 1.0f32.to_ne_bytes().to_vec();
+        bytes.extend_from_slice(&f32::NAN.to_ne_bytes());
+        assert!(
+            checked_f32_output("qwen vision", bytes)
+                .unwrap_err()
+                .contains("flat index 1")
+        );
+    }
+}

--- a/src/loading/mod.rs
+++ b/src/loading/mod.rs
@@ -59,6 +59,8 @@ use self::vlm::*;
 pub(crate) use self::vlm::load_llava_host_preprocessor;
 #[cfg(feature = "xla-iree")]
 pub(crate) use self::vlm::load_llava_iree_host_preprocessor;
+#[cfg(feature = "xla-iree")]
+pub(crate) use self::vlm::load_qwen2_vl_iree_host_preprocessor;
 pub use self::vlm::load_qwen3_omni_speech;
 #[cfg(feature = "xla-iree")]
 pub(crate) use self::vlm::{

--- a/src/loading/vlm.rs
+++ b/src/loading/vlm.rs
@@ -114,6 +114,8 @@ pub(crate) use mllama::load_mllama_vlm;
 pub(crate) use nemotron_h_nano_omni::load_nemotron_h_nano_omni_vlm;
 pub(crate) use paddleocr::load_paddleocr_vl;
 pub(crate) use pixtral::{load_mistral3_vlm, load_pixtral_vlm};
+#[cfg(feature = "xla-iree")]
+pub(crate) use qwen::load_qwen2_vl_iree_host_preprocessor;
 pub(crate) use qwen::{
     load_glm_ocr, load_glm4v, load_glm4v_moe, load_qwen2_5_vl, load_qwen2_vl, load_qwen3_5_moe_vlm,
     load_qwen3_5_vlm, load_qwen3_omni_moe, load_qwen3_vl, load_qwen3_vl_moe,

--- a/src/loading/vlm_qwen.rs
+++ b/src/loading/vlm_qwen.rs
@@ -29,8 +29,12 @@ use std::path::Path;
 
 use crate::LoadedModel;
 use crate::models;
+#[cfg(feature = "xla-iree")]
+use crate::multimodal::host_preprocessor::{HostPreprocessorError, Qwen2VlIreeHostPreprocessor};
 use crate::vision;
 
+#[cfg(feature = "xla-iree")]
+use super::load_vlm_weights_common_filtered_canonical;
 use super::{
     Qwen35VlmVariant, QwenVisionTokenIds, inherit_qwen_text_quantization,
     inherit_qwen_vision_quantization, load_vlm_weights_common, load_vlm_weights_common_filtered,
@@ -93,6 +97,107 @@ pub(crate) fn load_qwen2_vl(model_path: &Path) -> Result<LoadedModel> {
     };
 
     Ok(LoadedModel::Qwen2VL(vlm))
+}
+
+/// Load only Qwen2-VL host patch preprocessing and the text embedding table;
+/// the complete vision tower and merger are resident in IREE.
+#[cfg(feature = "xla-iree")]
+pub(crate) fn load_qwen2_vl_iree_host_preprocessor(
+    model_path: &Path,
+    device: &str,
+) -> Result<Qwen2VlIreeHostPreprocessor, HostPreprocessorError> {
+    use mlxcel_core::layers::UnifiedEmbedding;
+    use vision::encoders::qwen2_vl::Qwen2VLVisionConfig;
+
+    let (_config_str, full_config) = read_sanitized_vlm_config(model_path)
+        .map_err(|error| HostPreprocessorError::InvalidConfig(error.to_string()))?;
+    if full_config
+        .get("model_type")
+        .and_then(serde_json::Value::as_str)
+        != Some("qwen2_vl")
+    {
+        return Err(HostPreprocessorError::FamilyMismatch {
+            actual: full_config
+                .get("model_type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("<missing>")
+                .to_string(),
+        });
+    }
+    let mut vision_config: Qwen2VLVisionConfig =
+        parse_required_vlm_subconfig(&full_config, "vision_config", "Qwen2VL vision config")
+            .map_err(|error| HostPreprocessorError::InvalidConfig(error.to_string()))?;
+    inherit_qwen_vision_quantization(&mut vision_config, &full_config);
+    let weights = load_vlm_weights_common_filtered_canonical(model_path, |name| {
+        let canonical = name.strip_prefix("language_model.").unwrap_or(name);
+        canonical.starts_with("model.embed_tokens.")
+    })
+    .map(strip_language_model_prefix)
+    .map_err(|error| HostPreprocessorError::WeightLoad(error.to_string()))?;
+    let quant_group_size = full_config
+        .get("quantization")
+        .and_then(|value| value.get("group_size"))
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0) as i32;
+    let quant_bits = full_config
+        .get("quantization")
+        .and_then(|value| value.get("bits"))
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0) as i32;
+    let text_embeddings = UnifiedEmbedding::from_weights(
+        &weights,
+        "model.embed_tokens",
+        quant_group_size,
+        quant_bits,
+    )
+    .map_err(|error| {
+        HostPreprocessorError::WeightLoad(format!(
+            "missing or invalid Qwen2-VL text embedding table: {error}"
+        ))
+    })?;
+    let hidden_size = full_config
+        .get("hidden_size")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .filter(|&value| value > 0)
+        .ok_or_else(|| {
+            HostPreprocessorError::InvalidConfig(
+                "Qwen2-VL hidden_size must be a positive integer".to_string(),
+            )
+        })?;
+    let max_sequence_len = full_config
+        .get("max_position_embeddings")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .filter(|&value| value > 0)
+        .ok_or_else(|| {
+            HostPreprocessorError::InvalidConfig(
+                "Qwen2-VL max_position_embeddings must be a positive integer".to_string(),
+            )
+        })?;
+    let token_ids = qwen_vl_token_ids(
+        &full_config,
+        QwenVisionTokenIds {
+            image_token_id: 151655,
+            video_token_id: 151656,
+            vision_start_token_id: 151652,
+        },
+    );
+    let processor = qwen_vl_processor(&vision_config);
+    let projector = mlxcel_xla::IreeQwen2VlProjector::load(model_path, device)
+        .map_err(HostPreprocessorError::Iree)?;
+    Qwen2VlIreeHostPreprocessor::from_parts(
+        processor,
+        text_embeddings,
+        projector,
+        token_ids.image_token_id,
+        token_ids.video_token_id,
+        token_ids.vision_start_token_id,
+        vision_config.spatial_merge_size,
+        hidden_size,
+        max_sequence_len,
+        device.to_string(),
+    )
 }
 
 /// Load a Qwen2.5-VL model (windowed ViT + Qwen2 language model with MRoPE)

--- a/src/multimodal/host_preprocessor.rs
+++ b/src/multimodal/host_preprocessor.rs
@@ -40,10 +40,13 @@ use super::vlm_prompt::{ImageTokenBlockError, ImageTokenBlockInfo, apply_image_t
 
 #[path = "host_preprocessor_export.rs"]
 mod export;
+#[cfg(feature = "xla-iree")]
+use super::qwen_vl::insert_qwen_vl_image_tokens;
 use export::export_mlx_tensor;
 use export::{
-    build_prepared_prefill, export_llava_prefill, usize_to_i32, validate_embedding_shape,
-    validate_processor_shape, validate_projected_shape, validate_sequence_capacity,
+    build_prepared_prefill, export_llava_prefill, export_qwen2_vl_prefill, usize_to_i32,
+    validate_embedding_shape, validate_processor_shape, validate_projected_shape,
+    validate_sequence_capacity,
 };
 
 /// Vision implementation selected for OpenXLA multimodal preprocessing.
@@ -144,6 +147,34 @@ pub fn load_xla_image_preprocessor(
             model_path.display()
         ))
     })?;
+    if model_type == crate::models::ModelType::Qwen2VL {
+        let policy = XlaVisionBackendPolicy::from_env()?;
+        if policy == XlaVisionBackendPolicy::Host {
+            return Err(HostPreprocessorError::InvalidConfig(
+                "Qwen2-VL XLA vision has no MLX fallback; MLXCEL_XLA_VISION_BACKEND=host is unsupported"
+                    .to_string(),
+            ));
+        }
+        #[cfg(feature = "xla-iree")]
+        {
+            let device = std::env::var("MLXCEL_XLA_DEVICE")
+                .unwrap_or_else(|_| mlxcel_xla::default_device().to_string());
+            let preprocessor = Qwen2VlIreeHostPreprocessor::load(model_path, &device)?;
+            tracing::info!(
+                vision_backend = "iree",
+                vision_device = %device,
+                family = "qwen2_vl",
+                "OpenXLA multimodal vision backend selected"
+            );
+            return Ok(Some(Box::new(preprocessor)));
+        }
+        #[cfg(not(feature = "xla-iree"))]
+        {
+            return Err(HostPreprocessorError::InvalidConfig(
+                "Qwen2-VL XLA image execution requires the xla-iree feature".to_string(),
+            ));
+        }
+    }
     if model_type != crate::models::ModelType::LlavaVLM {
         return Ok(None);
     }
@@ -243,6 +274,188 @@ pub struct LlavaIreeHostPreprocessor {
     image_size: usize,
     max_sequence_len: usize,
     device: String,
+}
+
+/// Qwen2-VL producer with shared host smart-resize/patch extraction, a
+/// filtered text embedding table, and the complete vision tower in IREE.
+#[cfg(feature = "xla-iree")]
+pub struct Qwen2VlIreeHostPreprocessor {
+    processor: crate::vision::processors::qwen2_vl::Qwen2VLProcessor,
+    text_embeddings: UnifiedEmbedding,
+    projector: RefCell<mlxcel_xla::IreeQwen2VlProjector>,
+    image_token_id: i32,
+    video_token_id: i32,
+    vision_start_token_id: i32,
+    spatial_merge_size: usize,
+    hidden_size: usize,
+    max_sequence_len: usize,
+    device: String,
+}
+
+#[cfg(feature = "xla-iree")]
+impl Qwen2VlIreeHostPreprocessor {
+    pub fn load(model_path: &Path, device: &str) -> Result<Self, HostPreprocessorError> {
+        crate::loading::load_qwen2_vl_iree_host_preprocessor(model_path, device)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_parts(
+        processor: crate::vision::processors::qwen2_vl::Qwen2VLProcessor,
+        text_embeddings: UnifiedEmbedding,
+        projector: mlxcel_xla::IreeQwen2VlProjector,
+        image_token_id: i32,
+        video_token_id: i32,
+        vision_start_token_id: i32,
+        spatial_merge_size: usize,
+        hidden_size: usize,
+        max_sequence_len: usize,
+        device: String,
+    ) -> Result<Self, HostPreprocessorError> {
+        if hidden_size == 0 || max_sequence_len == 0 || spatial_merge_size == 0 {
+            return Err(HostPreprocessorError::InvalidConfig(
+                "Qwen2-VL hidden size, sequence capacity, and spatial merge size must be positive"
+                    .to_string(),
+            ));
+        }
+        if projector.text_hidden() != hidden_size {
+            return Err(HostPreprocessorError::InvalidConfig(format!(
+                "Qwen2-VL IREE projector hidden size {} disagrees with text hidden size {hidden_size}",
+                projector.text_hidden()
+            )));
+        }
+        Ok(Self {
+            processor,
+            text_embeddings,
+            projector: RefCell::new(projector),
+            image_token_id,
+            video_token_id,
+            vision_start_token_id,
+            spatial_merge_size,
+            hidden_size,
+            max_sequence_len,
+            device,
+        })
+    }
+
+    fn prepare_iree(
+        &self,
+        token_ids: &[i32],
+        images: &[DynamicImage],
+    ) -> Result<PreparedPrefill, HostPreprocessorError> {
+        if images.is_empty() {
+            return Err(HostPreprocessorError::InvalidConfig(
+                "Qwen2-VL image preprocessing requires at least one decoded image; text-only requests use ordinary XLA token prefill"
+                    .to_string(),
+            ));
+        }
+        let (patch_values, grids) = self.processor.preprocess_values_with_grid(images);
+        let mut logical_tokens = token_ids.to_vec();
+        let inserted = insert_qwen_vl_image_tokens(
+            &mut logical_tokens,
+            &grids,
+            self.spatial_merge_size,
+            self.vision_start_token_id,
+            self.image_token_id,
+        )
+        .ok_or_else(|| {
+            HostPreprocessorError::InvalidConfig(format!(
+                "Qwen2-VL image placeholder count does not match {} decoded image(s), or the prompt is already expanded",
+                images.len()
+            ))
+        })?;
+        if inserted.image_blocks != images.len() {
+            return Err(HostPreprocessorError::InvalidConfig(format!(
+                "Qwen2-VL expanded {} image blocks for {} decoded images",
+                inserted.image_blocks,
+                images.len()
+            )));
+        }
+        validate_sequence_capacity(logical_tokens.len(), self.max_sequence_len)?;
+        let input_ids = mlxcel_core::from_slice_i32(
+            &logical_tokens,
+            &[1, usize_to_i32(logical_tokens.len(), "sequence length")?],
+        );
+        let text_embeddings = mlxcel_core::astype(
+            &self.text_embeddings.forward(&input_ids),
+            mlxcel_core::dtype::FLOAT32,
+        );
+        validate_embedding_shape(
+            &mlxcel_core::array_shape(&text_embeddings),
+            logical_tokens.len(),
+            self.hidden_size,
+            "Qwen2-VL text embedding table",
+        )?;
+        let mut projector = self.projector.try_borrow_mut().map_err(|_| {
+            HostPreprocessorError::Iree(
+                "concurrent/re-entrant Qwen2-VL IREE vision invocation is unsupported".to_string(),
+            )
+        })?;
+        let projection = projector
+            .project(&patch_values, &grids)
+            .map_err(HostPreprocessorError::Iree)?;
+        let expected_projected_tokens = usize::try_from(inserted.total_image_tokens)
+            .map_err(|_| HostPreprocessorError::ShapeOverflow)?;
+        if projection.shape != [expected_projected_tokens, self.hidden_size] {
+            return Err(HostPreprocessorError::InvalidConfig(format!(
+                "Qwen2-VL IREE projection shape {:?} disagrees with expanded image-token shape [{}, {}]",
+                projection.shape, inserted.total_image_tokens, self.hidden_size
+            )));
+        }
+        tracing::info!(
+            vision_backend = "iree",
+            vision_device = %self.device,
+            image_count = images.len(),
+            patch_upload_bytes = projection.metrics.patch_upload_bytes,
+            metadata_upload_bytes = projection.metrics.metadata_upload_bytes,
+            projected_transfer_bytes = projection.metrics.projected_transfer_bytes,
+            iree_vision_seconds = projection.metrics.elapsed_seconds,
+            packed_cu_seqlens = ?projection.packed_cu_seqlens,
+            "Qwen2-VL OpenXLA vision projection completed"
+        );
+        let projected = mlxcel_core::from_slice_f32(
+            &projection.values,
+            &[
+                usize_to_i32(projection.shape[0], "Qwen2-VL projected token count")?,
+                usize_to_i32(self.hidden_size, "hidden size")?,
+            ],
+        );
+        let merged = merge_llava(
+            self.image_token_id,
+            &projected,
+            &text_embeddings,
+            &input_ids,
+        );
+        export_qwen2_vl_prefill(
+            logical_tokens,
+            InputEmbeddings {
+                inputs_embeds: mlxcel_core::astype(
+                    &merged.inputs_embeds,
+                    mlxcel_core::dtype::FLOAT32,
+                ),
+                attention_mask_4d: merged.attention_mask_4d,
+            },
+            &grids,
+            self.image_token_id,
+            self.video_token_id,
+            self.spatial_merge_size,
+            self.hidden_size,
+        )
+    }
+}
+
+#[cfg(feature = "xla-iree")]
+impl HostMultimodalPreprocessor for Qwen2VlIreeHostPreprocessor {
+    fn backend(&self) -> XlaVisionBackend {
+        XlaVisionBackend::Iree
+    }
+
+    fn prepare(
+        &self,
+        token_ids: &[i32],
+        images: &[DynamicImage],
+    ) -> Result<PreparedPrefill, HostPreprocessorError> {
+        self.prepare_iree(token_ids, images)
+    }
 }
 
 #[cfg(feature = "xla-iree")]

--- a/src/multimodal/host_preprocessor_export.rs
+++ b/src/multimodal/host_preprocessor_export.rs
@@ -151,6 +151,221 @@ pub(super) fn export_llava_prefill(
     )
 }
 
+pub(super) fn export_qwen2_vl_prefill(
+    logical_tokens: Vec<i32>,
+    merged: InputEmbeddings,
+    grids: &[(i32, i32, i32)],
+    image_token_id: i32,
+    video_token_id: i32,
+    spatial_merge_size: usize,
+    hidden_size: usize,
+) -> Result<PreparedPrefill, HostPreprocessorError> {
+    if spatial_merge_size == 0 {
+        return Err(HostPreprocessorError::InvalidConfig(
+            "Qwen2-VL spatial_merge_size must be positive".to_string(),
+        ));
+    }
+    if logical_tokens.contains(&video_token_id) {
+        return Err(HostPreprocessorError::InvalidConfig(
+            "Qwen2-VL XLA image preprocessing does not support video placeholders".to_string(),
+        ));
+    }
+    validate_embedding_shape(
+        &mlxcel_core::array_shape(&merged.inputs_embeds),
+        logical_tokens.len(),
+        hidden_size,
+        "Qwen2-VL merged embedding",
+    )?;
+    if merged.attention_mask_4d.is_some() {
+        return Err(HostPreprocessorError::InvalidConfig(
+            "Qwen2-VL prepared prefill requires the standard causal mask".to_string(),
+        ));
+    }
+    let merge = i32::try_from(spatial_merge_size).map_err(|_| {
+        HostPreprocessorError::InvalidConfig(
+            "Qwen2-VL spatial_merge_size does not fit i32".to_string(),
+        )
+    })?;
+    let expected_per_image = grids
+        .iter()
+        .enumerate()
+        .map(|(index, &(temporal, height, width))| {
+            if temporal != 1
+                || height <= 0
+                || width <= 0
+                || height % merge != 0
+                || width % merge != 0
+            {
+                return Err(HostPreprocessorError::InvalidConfig(format!(
+                    "invalid Qwen2-VL image grid {index}: ({temporal},{height},{width})"
+                )));
+            }
+            let count = temporal
+                .checked_mul(height / merge)
+                .and_then(|value| value.checked_mul(width / merge))
+                .ok_or(HostPreprocessorError::ShapeOverflow)?;
+            usize::try_from(count).map_err(|_| HostPreprocessorError::ShapeOverflow)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let expected_image_tokens = expected_per_image.iter().sum::<usize>();
+    let actual_image_tokens = logical_tokens
+        .iter()
+        .filter(|&&token| token == image_token_id)
+        .count();
+    if actual_image_tokens != expected_image_tokens {
+        return Err(HostPreprocessorError::ExpandedLength {
+            actual: actual_image_tokens,
+            expected: expected_image_tokens,
+        });
+    }
+
+    let mut axes = [Vec::new(), Vec::new(), Vec::new()];
+    let mut current_position = 0i32;
+    let mut segment_start = 0usize;
+    let mut image_index = 0usize;
+    let mut cursor = 0usize;
+    while cursor < logical_tokens.len() {
+        if logical_tokens[cursor] != image_token_id {
+            cursor += 1;
+            continue;
+        }
+        let vision_start = cursor;
+        while cursor < logical_tokens.len() && logical_tokens[cursor] == image_token_id {
+            cursor += 1;
+        }
+        if image_index >= grids.len() {
+            return Err(HostPreprocessorError::InvalidConfig(
+                "Qwen2-VL prompt has more image-token runs than decoded images".to_string(),
+            ));
+        }
+        let text_length = i32::try_from(vision_start - segment_start)
+            .map_err(|_| HostPreprocessorError::ShapeOverflow)?;
+        for position in current_position
+            ..current_position
+                .checked_add(text_length)
+                .ok_or(HostPreprocessorError::ShapeOverflow)?
+        {
+            for axis in &mut axes {
+                axis.push(position);
+            }
+        }
+        current_position = current_position
+            .checked_add(text_length)
+            .ok_or(HostPreprocessorError::ShapeOverflow)?;
+        let run_length = cursor - vision_start;
+        if run_length != expected_per_image[image_index] {
+            return Err(HostPreprocessorError::InvalidConfig(format!(
+                "Qwen2-VL image-token run {image_index} has {run_length} tokens, expected {}",
+                expected_per_image[image_index]
+            )));
+        }
+        let (temporal, height, width) = grids[image_index];
+        let llm_height = height / merge;
+        let llm_width = width / merge;
+        for t in 0..temporal {
+            for h in 0..llm_height {
+                for w in 0..llm_width {
+                    axes[0].push(
+                        current_position
+                            .checked_add(t)
+                            .ok_or(HostPreprocessorError::ShapeOverflow)?,
+                    );
+                    axes[1].push(
+                        current_position
+                            .checked_add(h)
+                            .ok_or(HostPreprocessorError::ShapeOverflow)?,
+                    );
+                    axes[2].push(
+                        current_position
+                            .checked_add(w)
+                            .ok_or(HostPreprocessorError::ShapeOverflow)?,
+                    );
+                }
+            }
+        }
+        current_position = current_position
+            .checked_add(temporal.max(llm_height).max(llm_width))
+            .ok_or(HostPreprocessorError::ShapeOverflow)?;
+        image_index += 1;
+        segment_start = cursor;
+    }
+    if image_index != grids.len() {
+        return Err(HostPreprocessorError::InvalidConfig(format!(
+            "Qwen2-VL prompt has {image_index} image-token runs, expected {}",
+            grids.len()
+        )));
+    }
+    let trailing = logical_tokens.len() - segment_start;
+    for offset in 0..trailing {
+        let position = current_position
+            .checked_add(i32::try_from(offset).map_err(|_| HostPreprocessorError::ShapeOverflow)?)
+            .ok_or(HostPreprocessorError::ShapeOverflow)?;
+        for axis in &mut axes {
+            axis.push(position);
+        }
+    }
+    if axes.iter().any(|axis| axis.len() != logical_tokens.len()) {
+        return Err(HostPreprocessorError::InvalidConfig(
+            "Qwen2-VL M-RoPE position construction did not cover the logical prompt".to_string(),
+        ));
+    }
+    let maximum = axes
+        .iter()
+        .flat_map(|axis| axis.iter())
+        .copied()
+        .max()
+        .ok_or_else(|| {
+            HostPreprocessorError::InvalidConfig(
+                "Qwen2-VL logical prompt must not be empty".to_string(),
+            )
+        })?;
+    let sequence_len_i32 =
+        i32::try_from(logical_tokens.len()).map_err(|_| HostPreprocessorError::ShapeOverflow)?;
+    let rope_delta = maximum
+        .checked_add(1)
+        .and_then(|value| value.checked_sub(sequence_len_i32))
+        .ok_or(HostPreprocessorError::ShapeOverflow)?;
+    let positions = axes.into_iter().flatten().collect::<Vec<_>>();
+    let position_bytes = positions
+        .into_iter()
+        .flat_map(i32::to_ne_bytes)
+        .collect::<Vec<_>>();
+    let sequence_len = logical_tokens.len();
+    let embeddings = export_mlx_tensor(&merged.inputs_embeds, "Qwen2-VL merged embedding")?;
+    let attention_bytes = vec![
+        0u8;
+        sequence_len
+            .checked_mul(PreparedTensorDType::Float32.size_bytes())
+            .ok_or(HostPreprocessorError::ShapeOverflow)?
+    ];
+    PreparedPrefill::new(
+        logical_tokens,
+        embeddings,
+        PreparedPositions::Mrope3D {
+            tensor: OwnedTensor::new(
+                position_bytes,
+                PreparedTensorDType::Int32,
+                vec![3, sequence_len],
+            )?,
+            rope_delta,
+        },
+        PreparedAttentionBias {
+            tensor: OwnedTensor::new(
+                attention_bytes,
+                PreparedTensorDType::Float32,
+                vec![1, 1, 1, sequence_len],
+            )?,
+            causal: true,
+        },
+        vec![PreparedModality {
+            family: "qwen2_vl".to_string(),
+            item_count: grids.len(),
+            token_count: expected_image_tokens,
+        }],
+    )
+    .map_err(HostPreprocessorError::from)
+}
+
 pub(super) fn export_mlx_tensor(
     array: &MlxArray,
     label: &'static str,

--- a/src/multimodal/host_preprocessor_tests.rs
+++ b/src/multimodal/host_preprocessor_tests.rs
@@ -20,7 +20,7 @@ use mlxcel_core::dtype;
 use super::{
     FakeHostMultimodalPreprocessor, HostMultimodalPreprocessor, HostPreprocessorError,
     XlaVisionBackend, XlaVisionBackendPolicy, export_llava_prefill, export_mlx_tensor,
-    load_xla_image_preprocessor, validate_processor_shape,
+    export_qwen2_vl_prefill, load_xla_image_preprocessor, validate_processor_shape,
 };
 use crate::multimodal::vlm_prompt::ImageTokenBlockError;
 use crate::vision::merge::merge_llava;
@@ -234,5 +234,83 @@ fn llava_export_rejects_hidden_size_mismatch() {
     assert!(matches!(
         error,
         HostPreprocessorError::EmbeddingShape { .. }
+    ));
+}
+
+#[test]
+fn qwen2_vl_export_builds_exact_mrope_positions_and_delta() {
+    ensure_cpu_device();
+    let merged = crate::vision::merge::InputEmbeddings {
+        inputs_embeds: mlxcel_core::from_slice_f32(&[0.0; 12], &[1, 6, 2]),
+        attention_mask_4d: None,
+    };
+    let prepared = export_qwen2_vl_prefill(
+        vec![10, 42, 42, 42, 42, 11],
+        merged,
+        &[(1, 4, 4)],
+        42,
+        43,
+        2,
+        2,
+    )
+    .unwrap();
+
+    let mlxcel_core::session::PreparedPositions::Mrope3D { tensor, rope_delta } =
+        prepared.positions
+    else {
+        panic!("Qwen2-VL must export M-RoPE positions");
+    };
+    assert_eq!(rope_delta, -2);
+    assert_eq!(tensor.shape, vec![3, 6]);
+    let positions = tensor
+        .bytes
+        .chunks_exact(4)
+        .map(|bytes| i32::from_ne_bytes(bytes.try_into().unwrap()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        positions,
+        vec![
+            0, 1, 1, 1, 1, 3, // temporal axis
+            0, 1, 1, 2, 2, 3, // height axis
+            0, 1, 2, 1, 2, 3, // width axis
+        ]
+    );
+    assert_eq!(prepared.modalities[0].family, "qwen2_vl");
+    assert_eq!(prepared.modalities[0].item_count, 1);
+    assert_eq!(prepared.modalities[0].token_count, 4);
+}
+
+#[test]
+fn qwen2_vl_export_rejects_video_and_cross_image_run_drift() {
+    ensure_cpu_device();
+    let input = || crate::vision::merge::InputEmbeddings {
+        inputs_embeds: mlxcel_core::from_slice_f32(&[0.0; 12], &[1, 6, 2]),
+        attention_mask_4d: None,
+    };
+    let video = export_qwen2_vl_prefill(
+        vec![10, 43, 42, 42, 42, 11],
+        input(),
+        &[(1, 4, 4)],
+        42,
+        43,
+        2,
+        2,
+    )
+    .unwrap_err();
+    assert!(matches!(video, HostPreprocessorError::InvalidConfig(_)));
+
+    let split_runs = export_qwen2_vl_prefill(
+        vec![42, 42, 10, 42, 42, 11],
+        input(),
+        &[(1, 4, 4)],
+        42,
+        43,
+        2,
+        2,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        split_runs,
+        HostPreprocessorError::InvalidConfig(_)
     ));
 }

--- a/src/vision/processors/qwen2_vl.rs
+++ b/src/vision/processors/qwen2_vl.rs
@@ -71,7 +71,7 @@ impl Qwen2VLProcessor {
 
     /// Compute target size that satisfies constraints
     /// Returns (height, width) padded to multiples of factor
-    fn smart_resize(&self, orig_h: u32, orig_w: u32) -> (u32, u32) {
+    pub(crate) fn smart_resize(&self, orig_h: u32, orig_w: u32) -> (u32, u32) {
         let factor = (self.patch_size * self.spatial_merge_size) as u32; // 28
 
         // Start with original size, round to factor
@@ -120,6 +120,30 @@ impl Qwen2VLProcessor {
         &self,
         images: &[image::DynamicImage],
     ) -> (UniquePtr<MlxArray>, Vec<(i32, i32, i32)>) {
+        let (all_patches, grid_thw) = self.preprocess_values_with_grid(images);
+        let in_channels = 3usize;
+        let patch_area = self.patch_size * self.patch_size;
+        let features_per_pixel = in_channels * patch_area;
+        let total_rows: usize = grid_thw
+            .iter()
+            .map(|&(t, h, w)| (t as usize) * (h as usize) * (w as usize) * self.temporal_patch_size)
+            .sum();
+        let pixel_values = mlxcel_core::from_slice_f32(
+            &all_patches,
+            &[total_rows as i32, features_per_pixel as i32],
+        );
+        (pixel_values, grid_thw)
+    }
+
+    /// Pure host form of [`Self::preprocess_with_grid`].
+    ///
+    /// The OpenXLA path consumes these owned F32 values directly, while the MLX
+    /// path wraps the exact same values in an `MlxArray`. Keeping one processor
+    /// implementation prevents resize/normalize/patch-order drift.
+    pub fn preprocess_values_with_grid(
+        &self,
+        images: &[image::DynamicImage],
+    ) -> (Vec<f32>, Vec<(i32, i32, i32)>) {
         let grid_thw = self.compute_grid_thw(images);
         let mut all_patches: Vec<f32> = Vec::new();
         let in_channels = 3usize;
@@ -150,49 +174,54 @@ impl Qwen2VLProcessor {
                 }
             }
 
-            // Convert to patch format:
-            // For each spatial patch, extract [C, patch_size, patch_size] -> flatten to [C*P*P]
-            // Then duplicate for temporal_patch_size (2 frames for single image)
-            let total_patches = (h_patches * w_patches) as usize;
+            // Convert to the reference merger-grouped patch order:
+            // [grid_h/merge, grid_w/merge, merge_h, merge_w, temporal, C, P, P].
+            // The vision tower preserves this order and PatchMerger reshapes
+            // each consecutive merge² group into one language token.
             let temporal = t as usize;
-
             for _t in 0..temporal {
-                for patch_idx in 0..total_patches {
-                    let py = patch_idx / w_patches as usize;
-                    let px = patch_idx % w_patches as usize;
-                    let y_start = py * self.patch_size;
-                    let x_start = px * self.patch_size;
-
-                    // For temporal_patch_size=2, we output 2 rows per spatial patch
-                    for _tp in 0..self.temporal_patch_size {
-                        let mut patch_data = Vec::with_capacity(features_per_pixel);
-                        for c in 0..in_channels {
-                            for dy in 0..self.patch_size {
-                                for dx in 0..self.patch_size {
-                                    let y = y_start + dy;
-                                    let x = x_start + dx;
-                                    patch_data.push(normalized[c * h * w + y * w + x]);
+                for block_y in 0..h_patches as usize / self.spatial_merge_size {
+                    for block_x in 0..w_patches as usize / self.spatial_merge_size {
+                        for inner_y in 0..self.spatial_merge_size {
+                            for inner_x in 0..self.spatial_merge_size {
+                                let py = block_y * self.spatial_merge_size + inner_y;
+                                let px = block_x * self.spatial_merge_size + inner_x;
+                                let y_start = py * self.patch_size;
+                                let x_start = px * self.patch_size;
+                                // For temporal_patch_size=2, emit two contiguous
+                                // rows per spatial patch. The Conv3d-degenerated
+                                // projection concatenates the pair.
+                                for _tp in 0..self.temporal_patch_size {
+                                    for c in 0..in_channels {
+                                        for dy in 0..self.patch_size {
+                                            for dx in 0..self.patch_size {
+                                                let y = y_start + dy;
+                                                let x = x_start + dx;
+                                                all_patches.push(normalized[c * h * w + y * w + x]);
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
-                        all_patches.extend_from_slice(&patch_data);
                     }
                 }
             }
         }
-
-        // Total rows: sum over all images of (t * h_patches * w_patches * temporal_patch_size)
-        let total_rows: usize = grid_thw
-            .iter()
-            .map(|&(t, h, w)| (t as usize) * (h as usize) * (w as usize) * self.temporal_patch_size)
-            .sum();
-
-        let pixel_values = mlxcel_core::from_slice_f32(
-            &all_patches,
-            &[total_rows as i32, features_per_pixel as i32],
+        debug_assert_eq!(
+            all_patches.len(),
+            grid_thw
+                .iter()
+                .map(|&(t, h, w)| {
+                    t as usize
+                        * h as usize
+                        * w as usize
+                        * self.temporal_patch_size
+                        * features_per_pixel
+                })
+                .sum::<usize>()
         );
-
-        (pixel_values, grid_thw)
+        (all_patches, grid_thw)
     }
 }
 
@@ -200,5 +229,43 @@ impl ImageProcessor for Qwen2VLProcessor {
     fn preprocess(&self, images: &[image::DynamicImage]) -> UniquePtr<MlxArray> {
         let (pixel_values, _) = self.preprocess_with_grid(images);
         pixel_values
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use image::{DynamicImage, Rgb, RgbImage};
+
+    use super::*;
+
+    #[test]
+    fn owned_and_mlx_paths_share_spatial_merge_grouped_patch_order() {
+        let processor = Qwen2VLProcessor::new(14, 2, 2);
+        let mut image = RgbImage::new(56, 56);
+        for patch_y in 0..4u32 {
+            for patch_x in 0..4u32 {
+                let value = (patch_y * 4 + patch_x) as u8 * 10;
+                for y in patch_y * 14..(patch_y + 1) * 14 {
+                    for x in patch_x * 14..(patch_x + 1) * 14 {
+                        image.put_pixel(x, y, Rgb([value, 0, 0]));
+                    }
+                }
+            }
+        }
+        let image = DynamicImage::ImageRgb8(image);
+        let (values, grids) = processor.preprocess_values_with_grid(&[image]);
+        assert_eq!(grids, vec![(1, 4, 4)]);
+        let row_width = 3 * 14 * 14;
+        let observed = (0..16)
+            .map(|patch| values[patch * 2 * row_width])
+            .collect::<Vec<_>>();
+        let grouped_patch_ids = [0u8, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15];
+        for (actual, patch_id) in observed.into_iter().zip(grouped_patch_ids) {
+            let expected = (patch_id as f32 * 10.0 / 255.0 - processor.mean[0]) / processor.std[0];
+            assert!((actual - expected).abs() < 1e-6);
+        }
+        let (mlx, mlx_grids) = processor.preprocess_with_grid(&[DynamicImage::new_rgb8(56, 56)]);
+        assert_eq!(mlx_grids, grids);
+        assert_eq!(mlxcel_core::array_shape(&mlx), vec![32, row_width as i32]);
     }
 }


### PR DESCRIPTION
## Summary

- Add a pinned Qwen2-VL StableHLO/IREE vision path with bounded 16/64/256 patch buckets, patch projection, 2D vision RoPE, packed per-image attention, all transformer blocks, and the merger.
- Decode direct and MLX q4 checkpoint tensors into an identity-bound auxiliary artifact while preserving the Conv3d source layout transform and processor/config/compiler fingerprints.
- Reuse the existing Qwen2 language emitter and exact M-RoPE prepared-prefill positions/delta for CLI and server execution; no second decoder or silent MLX vision fallback is introduced.
- Share smart resize and spatial-merge patch ordering between MLX and IREE producers, reject video/invalid grids/cross-image token-run drift, and keep only the filtered text embedding table on the host.

## Validation

- [x] `cargo test -p mlxcel-xla qwen2_vl -- --nocapture` (4 passed)
- [x] `cargo test -p mlxcel-xla parses_and_validates_explicit_mrope_sections -- --nocapture` (1 passed)
- [x] `cargo test -p mlxcel --lib qwen2_vl -- --nocapture` (4 passed)
- [x] `cargo check --features xla-iree --lib --bins`
- [x] `cargo clippy --features xla-iree --lib --bins --no-deps` (passes with pre-existing dead-code/style warnings outside this change)
- [x] Real CUDA IREE CLI smoke using `/home/inureyes/models/qwen2-vl-2b`, `tests/fixtures/test_image.png`, context 128, and one greedy token: generated bucket-256 vision VMFB plus M-RoPE prefill/decode artifacts and returned `The` in 50.59 seconds.
- [ ] Independent MLX eager token-exact comparison: the CPU-only build loaded the same checkpoint and inserted the expected 64 image tokens, but produced no token before the bounded five-minute timeout. The IREE token is therefore not claimed as independently token-exact yet.

## Runtime notes

- The real IREE smoke exercised the production CLI path and wrote only cache artifacts under `/tmp/mlxcel-xla-qwen2-vl-vmfb` and `/tmp/mlxcel-xla-vmfb`; no generated CSV or runtime artifact is committed.
- Video remains explicitly unsupported on this pinned image-only path.

Closes #865
