### PR TITLE
feat(xla): version auxiliary dtype contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,7 @@ dependencies = [
  "memmap2",
  "mlxcel-core",
  "safetensors 0.4.5",
+ "serde",
  "serde_json",
  "sha2 0.10.9",
 ]

--- a/src/lib/mlxcel-xla/Cargo.toml
+++ b/src/lib/mlxcel-xla/Cargo.toml
@@ -45,6 +45,7 @@ memmap2 = { version = "0.9", optional = true }
 sha2 = { version = "0.10", optional = true }
 # config.json parsing: the emitter reads model dimensions from it to generate the
 # graphs at load (always compiled with the crate), and the iree path also uses it.
+serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1" }
 
 [build-dependencies]

--- a/src/lib/mlxcel-xla/src/aux_manifest.rs
+++ b/src/lib/mlxcel-xla/src/aux_manifest.rs
@@ -18,6 +18,9 @@
 //! the wrong config, argument order, or compiler target. Loading therefore
 //! compares the actual VMFB, canonical config, ordered resident-weight schema,
 //! entry point, and VMFB generation identity against a persisted manifest.
+//! Families may additionally opt into a versioned dtype/materialization
+//! identity. That identity is necessary for, but does not by itself establish,
+//! bounded operator-oracle qualification.
 
 use std::fs::{File, OpenOptions};
 use std::io::Write as _;
@@ -27,8 +30,10 @@ use std::time::{Duration, Instant, SystemTime};
 use sha2::{Digest, Sha256};
 
 use crate::aux::AuxiliaryWeight;
+use crate::numeric_dtype_contract::NumericDTypeContract;
 
-const SCHEMA: &str = "mlxcel-xla-aux-artifact-v1";
+const SCHEMA_V1: &str = "mlxcel-xla-aux-artifact-v1";
+const SCHEMA_NUMERIC_DTYPE_V2: &str = "mlxcel-xla-aux-artifact-v2-numeric-dtype";
 const CACHE_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
 const CACHE_LOCK_STALE_AFTER: Duration = Duration::from_secs(30 * 60);
 const CACHE_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -39,18 +44,49 @@ pub(crate) struct AuxiliaryArtifactContract {
     pub(crate) config_identity: String,
     /// Canonical compiler identity, target flags, and source-MLIR digest.
     pub(crate) generation_identity: String,
+    /// A necessary identity subset, not proof that an operator oracle passed.
+    numeric_dtype_contract: Option<NumericDTypeContract>,
 }
 
 impl AuxiliaryArtifactContract {
-    pub(crate) fn new(
+    /// Preserve the pre-numeric v1 identity for existing qualified artifacts.
+    ///
+    /// New family activation must use a versioned numeric contract instead.
+    pub(crate) fn new_legacy_unqualified(
         entry_name: impl Into<String>,
         config_identity: impl Into<String>,
         generation_identity: impl Into<String>,
+    ) -> Result<Self, String> {
+        Self::build(entry_name, config_identity, generation_identity, None)
+    }
+
+    /// Opt into the dtype-aware v2 manifest.
+    #[allow(dead_code)] // Adopted explicitly by each family with its complete oracle contract.
+    pub(crate) fn new_with_numeric_dtype_contract(
+        entry_name: impl Into<String>,
+        config_identity: impl Into<String>,
+        generation_identity: impl Into<String>,
+        numeric_dtype_contract: NumericDTypeContract,
+    ) -> Result<Self, String> {
+        Self::build(
+            entry_name,
+            config_identity,
+            generation_identity,
+            Some(numeric_dtype_contract),
+        )
+    }
+
+    fn build(
+        entry_name: impl Into<String>,
+        config_identity: impl Into<String>,
+        generation_identity: impl Into<String>,
+        numeric_dtype_contract: Option<NumericDTypeContract>,
     ) -> Result<Self, String> {
         let contract = Self {
             entry_name: entry_name.into(),
             config_identity: config_identity.into(),
             generation_identity: generation_identity.into(),
+            numeric_dtype_contract,
         };
         if contract.entry_name.is_empty()
             || contract.config_identity.is_empty()
@@ -62,6 +98,14 @@ impl AuxiliaryArtifactContract {
             );
         }
         Ok(contract)
+    }
+
+    fn manifest_schema(&self) -> &'static str {
+        if self.numeric_dtype_contract.is_some() {
+            SCHEMA_NUMERIC_DTYPE_V2
+        } else {
+            SCHEMA_V1
+        }
     }
 }
 
@@ -103,26 +147,80 @@ pub(crate) fn auxiliary_manifest_path(vmfb: &Path) -> PathBuf {
     vmfb.with_file_name(name)
 }
 
+struct IdentityFields {
+    entry: String,
+    config: String,
+    numeric_dtype_contract: Option<String>,
+    weight_schema: String,
+    generation: String,
+    vmfb: String,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedManifest {
+    schema: String,
+    entry_sha256: String,
+    config_sha256: String,
+    numeric_dtype_contract_sha256: Option<String>,
+    weight_schema_sha256: String,
+    generation_sha256: String,
+    vmfb_sha256: String,
+    artifact_sha256: String,
+}
+
+fn read_persisted_manifest(path: &Path) -> Result<PersistedManifest, String> {
+    let bytes = std::fs::read(path).map_err(|error| format!("read {}: {error}", path.display()))?;
+    let persisted: PersistedManifest = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("parse {}: {error}", path.display()))?;
+    // `Option<String>` accepts both a missing field and an explicit JSON null.
+    // Preserve the exact schema shape by requiring a present field to be text.
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("parse {}: {error}", path.display()))?;
+    let numeric_field_present = value
+        .as_object()
+        .is_some_and(|object| object.contains_key("numeric_dtype_contract_sha256"));
+    if numeric_field_present != persisted.numeric_dtype_contract_sha256.is_some() {
+        return Err(format!(
+            "parse {}: numeric_dtype_contract_sha256 must be a string when present",
+            path.display()
+        ));
+    }
+    Ok(persisted)
+}
+
 fn identity_fields(
     vmfb: &Path,
     contract: &AuxiliaryArtifactContract,
     weights: &[AuxiliaryWeight],
-) -> Result<[String; 5], String> {
+) -> Result<IdentityFields, String> {
     let vmfb_bytes =
         std::fs::read(vmfb).map_err(|error| format!("read {}: {error}", vmfb.display()))?;
     let schema = weight_schema(weights)?;
-    Ok([
-        sha256_hex(contract.entry_name.as_bytes()),
-        sha256_hex(contract.config_identity.as_bytes()),
-        sha256_hex(schema.as_bytes()),
-        sha256_hex(contract.generation_identity.as_bytes()),
-        sha256_hex(&vmfb_bytes),
-    ])
+    Ok(IdentityFields {
+        entry: sha256_hex(contract.entry_name.as_bytes()),
+        config: sha256_hex(contract.config_identity.as_bytes()),
+        numeric_dtype_contract: contract
+            .numeric_dtype_contract
+            .map(NumericDTypeContract::canonical_identity)
+            .map(|identity| sha256_hex(identity.as_bytes())),
+        weight_schema: sha256_hex(schema.as_bytes()),
+        generation: sha256_hex(contract.generation_identity.as_bytes()),
+        vmfb: sha256_hex(&vmfb_bytes),
+    })
 }
 
-fn artifact_digest(fields: &[String; 5]) -> String {
-    let mut bytes = SCHEMA.as_bytes().to_vec();
-    for field in fields {
+fn artifact_digest(schema: &str, fields: &IdentityFields) -> String {
+    let mut bytes = schema.as_bytes().to_vec();
+    let ordered = [
+        Some(&fields.entry),
+        Some(&fields.config),
+        fields.numeric_dtype_contract.as_ref(),
+        Some(&fields.weight_schema),
+        Some(&fields.generation),
+        Some(&fields.vmfb),
+    ];
+    for field in ordered.into_iter().flatten() {
         bytes.push(0);
         bytes.extend_from_slice(field.as_bytes());
     }
@@ -135,15 +233,31 @@ pub(crate) fn write_auxiliary_manifest(
     weights: &[AuxiliaryWeight],
 ) -> Result<PathBuf, String> {
     let fields = identity_fields(vmfb, contract, weights)?;
-    let value = serde_json::json!({
-        "schema": SCHEMA,
-        "entry_sha256": fields[0],
-        "config_sha256": fields[1],
-        "weight_schema_sha256": fields[2],
-        "generation_sha256": fields[3],
-        "vmfb_sha256": fields[4],
-        "artifact_sha256": artifact_digest(&fields),
-    });
+    let schema = contract.manifest_schema();
+    let mut object = serde_json::Map::new();
+    object.insert("schema".to_string(), schema.into());
+    object.insert("entry_sha256".to_string(), fields.entry.clone().into());
+    object.insert("config_sha256".to_string(), fields.config.clone().into());
+    if let Some(numeric_dtype_contract) = &fields.numeric_dtype_contract {
+        object.insert(
+            "numeric_dtype_contract_sha256".to_string(),
+            numeric_dtype_contract.clone().into(),
+        );
+    }
+    object.insert(
+        "weight_schema_sha256".to_string(),
+        fields.weight_schema.clone().into(),
+    );
+    object.insert(
+        "generation_sha256".to_string(),
+        fields.generation.clone().into(),
+    );
+    object.insert("vmfb_sha256".to_string(), fields.vmfb.clone().into());
+    object.insert(
+        "artifact_sha256".to_string(),
+        artifact_digest(schema, &fields).into(),
+    );
+    let value = serde_json::Value::Object(object);
     let path = auxiliary_manifest_path(vmfb);
     let bytes = serde_json::to_vec_pretty(&value)
         .map_err(|error| format!("serialize {}: {error}", path.display()))?;
@@ -175,42 +289,108 @@ pub(crate) fn verify_auxiliary_manifest(
     weights: &[AuxiliaryWeight],
 ) -> Result<u64, String> {
     let path = auxiliary_manifest_path(vmfb);
-    let bytes =
-        std::fs::read(&path).map_err(|error| format!("read {}: {error}", path.display()))?;
-    let value: serde_json::Value = serde_json::from_slice(&bytes)
-        .map_err(|error| format!("parse {}: {error}", path.display()))?;
-    let object = value
-        .as_object()
-        .ok_or_else(|| format!("{} must contain a JSON object", path.display()))?;
+    let persisted = read_persisted_manifest(&path)?;
     let fields = identity_fields(vmfb, contract, weights)?;
+    let schema = contract.manifest_schema();
+    let artifact = artifact_digest(schema, &fields);
+    if persisted.schema != schema {
+        return Err(format!(
+            "auxiliary artifact identity mismatch for schema in {}",
+            path.display()
+        ));
+    }
+    if persisted.numeric_dtype_contract_sha256.as_deref()
+        != fields.numeric_dtype_contract.as_deref()
+    {
+        return Err(format!(
+            "auxiliary artifact identity mismatch for numeric_dtype_contract_sha256 in {}",
+            path.display()
+        ));
+    }
     let expected = [
-        ("schema", SCHEMA.to_string()),
-        ("entry_sha256", fields[0].clone()),
-        ("config_sha256", fields[1].clone()),
-        ("weight_schema_sha256", fields[2].clone()),
-        ("generation_sha256", fields[3].clone()),
-        ("vmfb_sha256", fields[4].clone()),
-        ("artifact_sha256", artifact_digest(&fields)),
+        (
+            "entry_sha256",
+            persisted.entry_sha256.as_str(),
+            fields.entry.as_str(),
+        ),
+        (
+            "config_sha256",
+            persisted.config_sha256.as_str(),
+            fields.config.as_str(),
+        ),
+        (
+            "weight_schema_sha256",
+            persisted.weight_schema_sha256.as_str(),
+            fields.weight_schema.as_str(),
+        ),
+        (
+            "generation_sha256",
+            persisted.generation_sha256.as_str(),
+            fields.generation.as_str(),
+        ),
+        (
+            "vmfb_sha256",
+            persisted.vmfb_sha256.as_str(),
+            fields.vmfb.as_str(),
+        ),
+        (
+            "artifact_sha256",
+            persisted.artifact_sha256.as_str(),
+            artifact.as_str(),
+        ),
     ];
-    for (name, expected_value) in &expected {
-        let actual = object.get(*name).and_then(serde_json::Value::as_str);
-        if actual != Some(expected_value.as_str()) {
+    for (name, actual, expected_value) in expected {
+        if actual != expected_value {
             return Err(format!(
                 "auxiliary artifact identity mismatch for {name} in {}",
                 path.display()
             ));
         }
     }
-    if object.len() != expected.len() {
-        return Err(format!(
-            "{} contains unknown identity fields",
-            path.display()
-        ));
-    }
-    let digest = artifact_digest(&fields);
-    let fingerprint = u64::from_str_radix(&digest[..16], 16)
+    let fingerprint = u64::from_str_radix(&artifact[..16], 16)
         .map_err(|error| format!("invalid artifact digest: {error}"))?;
     Ok(fingerprint.max(1))
+}
+
+fn manifest_schema_version(schema: &str) -> Option<u32> {
+    let version = schema.strip_prefix("mlxcel-xla-aux-artifact-v")?;
+    let digits = version
+        .as_bytes()
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digits == 0 {
+        None
+    } else {
+        version[..digits].parse().ok()
+    }
+}
+
+fn reject_manifest_downgrade(
+    manifest: &Path,
+    contract: &AuxiliaryArtifactContract,
+) -> Result<(), String> {
+    let persisted = read_persisted_manifest(manifest).map_err(|error| {
+        format!("refusing to replace an unclassified auxiliary artifact manifest: {error}")
+    })?;
+    let actual_schema = persisted.schema.as_str();
+    let expected_schema = contract.manifest_schema();
+    if actual_schema == expected_schema {
+        return Ok(());
+    }
+    let actual_version = manifest_schema_version(actual_schema);
+    let expected_version = manifest_schema_version(expected_schema);
+    if actual_version
+        .zip(expected_version)
+        .is_some_and(|(actual_version, expected_version)| actual_version < expected_version)
+    {
+        return Ok(());
+    }
+    Err(format!(
+        "refusing to replace auxiliary artifact manifest {} from schema {actual_schema} \
+         with {expected_schema}",
+        manifest.display()
+    ))
 }
 
 /// Reuse a qualified auxiliary VMFB or rebuild and publish one exactly once.
@@ -230,11 +410,11 @@ where
 {
     let _lock = acquire_auxiliary_cache_lock(vmfb)?;
     let manifest = auxiliary_manifest_path(vmfb);
-    if vmfb.is_file()
-        && manifest.is_file()
-        && verify_auxiliary_manifest(vmfb, contract, weights).is_ok()
-    {
-        return Ok(());
+    if vmfb.is_file() && manifest.is_file() {
+        if verify_auxiliary_manifest(vmfb, contract, weights).is_ok() {
+            return Ok(());
+        }
+        reject_manifest_downgrade(&manifest, contract)?;
     }
 
     remove_file_if_present(vmfb)?;
@@ -422,6 +602,7 @@ mod tests {
 
     use super::*;
     use crate::aux::{AuxiliaryWeight, AuxiliaryWeightDType};
+    use crate::numeric_dtype_contract::{NumericDType, NumericDTypeContract, WeightExecution};
 
     fn temp_vmfb(tag: &str) -> PathBuf {
         let nonce = std::time::SystemTime::now()
@@ -443,11 +624,22 @@ mod tests {
         }]
     }
 
+    fn numeric_dtype_contract() -> NumericDTypeContract {
+        NumericDTypeContract::new(
+            WeightExecution::HostAffineDequantized,
+            NumericDType::F32,
+            NumericDType::F32,
+            NumericDType::F32,
+            NumericDType::F32,
+            NumericDType::F32,
+        )
+    }
+
     #[test]
     fn identity_mismatches_fail_closed() {
         let vmfb = temp_vmfb("mismatch");
         std::fs::write(&vmfb, b"vmfb-a").unwrap();
-        let contract = AuxiliaryArtifactContract::new(
+        let contract = AuxiliaryArtifactContract::new_legacy_unqualified(
             "aux.main",
             "config=image:384",
             "compiler=v1;flags=cpu;mlir=abc",
@@ -457,7 +649,7 @@ mod tests {
         let manifest = write_auxiliary_manifest(&vmfb, &contract, &resident_weights).unwrap();
         assert!(verify_auxiliary_manifest(&vmfb, &contract, &resident_weights).is_ok());
 
-        let wrong_config = AuxiliaryArtifactContract::new(
+        let wrong_config = AuxiliaryArtifactContract::new_legacy_unqualified(
             "aux.main",
             "config=image:224",
             &contract.generation_identity,
@@ -468,9 +660,12 @@ mod tests {
                 .unwrap_err()
                 .contains("config_sha256")
         );
-        let wrong_generation =
-            AuxiliaryArtifactContract::new("aux.main", &contract.config_identity, "compiler=v2")
-                .unwrap();
+        let wrong_generation = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "aux.main",
+            &contract.config_identity,
+            "compiler=v2",
+        )
+        .unwrap();
         assert!(
             verify_auxiliary_manifest(&vmfb, &wrong_generation, &resident_weights)
                 .unwrap_err()
@@ -494,11 +689,176 @@ mod tests {
     }
 
     #[test]
+    fn numeric_dtype_contract_mismatch_fails_closed() {
+        let vmfb = temp_vmfb("numeric-mismatch");
+        std::fs::write(&vmfb, b"vmfb-numeric").unwrap();
+        let contract = AuxiliaryArtifactContract::new_with_numeric_dtype_contract(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+            numeric_dtype_contract(),
+        )
+        .unwrap();
+        let resident_weights = weights();
+        let manifest = write_auxiliary_manifest(&vmfb, &contract, &resident_weights).unwrap();
+        assert!(verify_auxiliary_manifest(&vmfb, &contract, &resident_weights).is_ok());
+
+        let changed_numeric = AuxiliaryArtifactContract::new_with_numeric_dtype_contract(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+            NumericDTypeContract {
+                contraction_input: NumericDType::Bf16,
+                ..numeric_dtype_contract()
+            },
+        )
+        .unwrap();
+        assert!(
+            verify_auxiliary_manifest(&vmfb, &changed_numeric, &resident_weights)
+                .unwrap_err()
+                .contains("numeric_dtype_contract_sha256")
+        );
+
+        let v1_contract = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+        )
+        .unwrap();
+        assert!(
+            verify_auxiliary_manifest(&vmfb, &v1_contract, &resident_weights)
+                .unwrap_err()
+                .contains("schema")
+        );
+
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&manifest).unwrap()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("numeric_dtype_contract_sha256");
+        std::fs::write(&manifest, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
+        assert!(
+            verify_auxiliary_manifest(&vmfb, &contract, &resident_weights)
+                .unwrap_err()
+                .contains("numeric_dtype_contract_sha256")
+        );
+
+        write_auxiliary_manifest(&vmfb, &contract, &resident_weights).unwrap();
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&manifest).unwrap()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("unexpected".to_string(), "field".into());
+        std::fs::write(&manifest, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
+        assert!(
+            verify_auxiliary_manifest(&vmfb, &contract, &resident_weights)
+                .unwrap_err()
+                .contains("unknown field")
+        );
+
+        std::fs::remove_file(vmfb).ok();
+        std::fs::remove_file(manifest).ok();
+    }
+
+    #[test]
+    fn v1_artifact_digest_remains_legacy_compatible() {
+        let vmfb = temp_vmfb("v1-digest");
+        std::fs::write(&vmfb, b"legacy-vmfb").unwrap();
+        let contract = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+        )
+        .unwrap();
+        let resident_weights = weights();
+        let fields = identity_fields(&vmfb, &contract, &resident_weights).unwrap();
+        assert!(fields.numeric_dtype_contract.is_none());
+
+        let mut legacy_bytes = SCHEMA_V1.as_bytes().to_vec();
+        for field in [
+            &fields.entry,
+            &fields.config,
+            &fields.weight_schema,
+            &fields.generation,
+            &fields.vmfb,
+        ] {
+            legacy_bytes.push(0);
+            legacy_bytes.extend_from_slice(field.as_bytes());
+        }
+        assert_eq!(
+            artifact_digest(SCHEMA_V1, &fields),
+            sha256_hex(&legacy_bytes)
+        );
+
+        let manifest = write_auxiliary_manifest(&vmfb, &contract, &resident_weights).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&manifest).unwrap()).unwrap();
+        assert_eq!(value["schema"], SCHEMA_V1);
+        assert!(value.get("numeric_dtype_contract_sha256").is_none());
+        assert_eq!(value.as_object().unwrap().len(), 7);
+
+        let mut null_numeric = value;
+        null_numeric.as_object_mut().unwrap().insert(
+            "numeric_dtype_contract_sha256".to_string(),
+            serde_json::Value::Null,
+        );
+        std::fs::write(&manifest, serde_json::to_vec_pretty(&null_numeric).unwrap()).unwrap();
+        assert!(
+            verify_auxiliary_manifest(&vmfb, &contract, &resident_weights)
+                .unwrap_err()
+                .contains("must be a string")
+        );
+
+        std::fs::remove_file(vmfb).ok();
+        std::fs::remove_file(manifest).ok();
+    }
+
+    #[test]
+    fn numeric_dtype_contract_changes_fingerprint_for_same_artifact() {
+        let vmfb = temp_vmfb("numeric-fingerprint");
+        std::fs::write(&vmfb, b"same-vmfb").unwrap();
+        let resident_weights = weights();
+        let contract = AuxiliaryArtifactContract::new_with_numeric_dtype_contract(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+            numeric_dtype_contract(),
+        )
+        .unwrap();
+        let manifest = write_auxiliary_manifest(&vmfb, &contract, &resident_weights).unwrap();
+        let baseline = verify_auxiliary_manifest(&vmfb, &contract, &resident_weights).unwrap();
+
+        let changed = AuxiliaryArtifactContract::new_with_numeric_dtype_contract(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+            NumericDTypeContract {
+                reduction_compute: NumericDType::Bf16,
+                ..numeric_dtype_contract()
+            },
+        )
+        .unwrap();
+        write_auxiliary_manifest(&vmfb, &changed, &resident_weights).unwrap();
+        let changed_fingerprint =
+            verify_auxiliary_manifest(&vmfb, &changed, &resident_weights).unwrap();
+        assert_ne!(baseline, changed_fingerprint);
+
+        std::fs::remove_file(vmfb).ok();
+        std::fs::remove_file(manifest).ok();
+    }
+
+    #[test]
     fn cold_cache_compiles_once_then_reuses_and_rebuilds_stale_pair_once() {
         let vmfb = temp_vmfb("single-compile");
         let resident_weights = weights();
-        let contract =
-            AuxiliaryArtifactContract::new("aux.main", "config=v1", "compiler=v1").unwrap();
+        let contract = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+        )
+        .unwrap();
         let mut compile_count = 0usize;
         ensure_qualified_auxiliary_artifact(&vmfb, &contract, &resident_weights, |temporary| {
             compile_count += 1;
@@ -516,8 +876,12 @@ mod tests {
         .unwrap();
         assert_eq!(compile_count, 1);
 
-        let changed =
-            AuxiliaryArtifactContract::new("aux.main", "config=v2", "compiler=v1").unwrap();
+        let changed = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "aux.main",
+            "config=v2",
+            "compiler=v1",
+        )
+        .unwrap();
         ensure_qualified_auxiliary_artifact(&vmfb, &changed, &resident_weights, |temporary| {
             compile_count += 1;
             std::fs::write(temporary, b"vmfb-v2")
@@ -533,10 +897,228 @@ mod tests {
     }
 
     #[test]
+    fn numeric_dtype_contract_change_rebuilds_once_then_reuses() {
+        let vmfb = temp_vmfb("numeric-rebuild");
+        let resident_weights = weights();
+        let contract = AuxiliaryArtifactContract::new_with_numeric_dtype_contract(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+            numeric_dtype_contract(),
+        )
+        .unwrap();
+        let mut compile_count = 0usize;
+        ensure_qualified_auxiliary_artifact(&vmfb, &contract, &resident_weights, |temporary| {
+            compile_count += 1;
+            std::fs::write(temporary, b"vmfb-f32")
+                .map_err(|error| format!("write test VMFB: {error}"))
+        })
+        .unwrap();
+        assert_eq!(compile_count, 1);
+
+        let changed = AuxiliaryArtifactContract::new_with_numeric_dtype_contract(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+            NumericDTypeContract {
+                activation_carrier: NumericDType::Bf16,
+                ..numeric_dtype_contract()
+            },
+        )
+        .unwrap();
+        ensure_qualified_auxiliary_artifact(&vmfb, &changed, &resident_weights, |temporary| {
+            compile_count += 1;
+            std::fs::write(temporary, b"vmfb-bf16")
+                .map_err(|error| format!("write test VMFB: {error}"))
+        })
+        .unwrap();
+        assert_eq!(compile_count, 2);
+        assert_eq!(std::fs::read(&vmfb).unwrap(), b"vmfb-bf16");
+
+        ensure_qualified_auxiliary_artifact(&vmfb, &changed, &resident_weights, |_| {
+            compile_count += 1;
+            Err("qualified numeric cache must not compile".to_string())
+        })
+        .unwrap();
+        assert_eq!(compile_count, 2);
+
+        std::fs::remove_file(auxiliary_manifest_path(&vmfb)).ok();
+        std::fs::remove_file(vmfb).ok();
+    }
+
+    #[test]
+    fn v1_cache_migrates_to_numeric_dtype_contract_once() {
+        let vmfb = temp_vmfb("numeric-migrate");
+        let resident_weights = weights();
+        let v1_contract = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+        )
+        .unwrap();
+        let dtype_contract = AuxiliaryArtifactContract::new_with_numeric_dtype_contract(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+            numeric_dtype_contract(),
+        )
+        .unwrap();
+        let mut compile_count = 0usize;
+
+        ensure_qualified_auxiliary_artifact(&vmfb, &v1_contract, &resident_weights, |temporary| {
+            compile_count += 1;
+            std::fs::write(temporary, b"vmfb-v1")
+                .map_err(|error| format!("write test VMFB: {error}"))
+        })
+        .unwrap();
+        assert_eq!(compile_count, 1);
+
+        ensure_qualified_auxiliary_artifact(
+            &vmfb,
+            &dtype_contract,
+            &resident_weights,
+            |temporary| {
+                compile_count += 1;
+                std::fs::write(temporary, b"vmfb-v2")
+                    .map_err(|error| format!("write test VMFB: {error}"))
+            },
+        )
+        .unwrap();
+        assert_eq!(compile_count, 2);
+        assert_eq!(std::fs::read(&vmfb).unwrap(), b"vmfb-v2");
+
+        ensure_qualified_auxiliary_artifact(&vmfb, &dtype_contract, &resident_weights, |_| {
+            compile_count += 1;
+            Err("migrated numeric cache must not compile".to_string())
+        })
+        .unwrap();
+        assert_eq!(compile_count, 2);
+
+        std::fs::remove_file(auxiliary_manifest_path(&vmfb)).ok();
+        std::fs::remove_file(vmfb).ok();
+    }
+
+    #[test]
+    fn numeric_dtype_cache_refuses_legacy_downgrade() {
+        let vmfb = temp_vmfb("numeric-downgrade");
+        let resident_weights = weights();
+        let dtype_contract = AuxiliaryArtifactContract::new_with_numeric_dtype_contract(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+            numeric_dtype_contract(),
+        )
+        .unwrap();
+        let mut compile_count = 0usize;
+        ensure_qualified_auxiliary_artifact(
+            &vmfb,
+            &dtype_contract,
+            &resident_weights,
+            |temporary| {
+                compile_count += 1;
+                std::fs::write(temporary, b"vmfb-v2")
+                    .map_err(|error| format!("write test VMFB: {error}"))
+            },
+        )
+        .unwrap();
+        let manifest = auxiliary_manifest_path(&vmfb);
+        let manifest_before = std::fs::read(&manifest).unwrap();
+
+        let v1_contract = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+        )
+        .unwrap();
+        let error =
+            ensure_qualified_auxiliary_artifact(&vmfb, &v1_contract, &resident_weights, |_| {
+                compile_count += 1;
+                Err("downgrade must not compile".to_string())
+            })
+            .unwrap_err();
+        assert!(error.contains("refusing to replace"));
+        assert_eq!(compile_count, 1);
+        assert_eq!(std::fs::read(&vmfb).unwrap(), b"vmfb-v2");
+        assert_eq!(std::fs::read(&manifest).unwrap(), manifest_before);
+        assert!(verify_auxiliary_manifest(&vmfb, &dtype_contract, &resident_weights).is_ok());
+
+        std::fs::remove_file(manifest).ok();
+        std::fs::remove_file(vmfb).ok();
+    }
+
+    #[test]
+    fn unclassified_manifest_cannot_be_replaced_by_legacy_contract() {
+        let vmfb = temp_vmfb("numeric-unclassified");
+        std::fs::write(&vmfb, b"vmfb-v2").unwrap();
+        let resident_weights = weights();
+        let dtype_contract = AuxiliaryArtifactContract::new_with_numeric_dtype_contract(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+            numeric_dtype_contract(),
+        )
+        .unwrap();
+        let manifest = write_auxiliary_manifest(&vmfb, &dtype_contract, &resident_weights).unwrap();
+        let original = std::fs::read(&manifest).unwrap();
+        let original_text = String::from_utf8(original.clone()).unwrap();
+        let duplicate_schema = format!(
+            "{{\"schema\":\"{SCHEMA_V1}\",{}",
+            original_text.strip_prefix('{').unwrap()
+        )
+        .into_bytes();
+
+        let mut unknown_schema: serde_json::Value = serde_json::from_slice(&original).unwrap();
+        unknown_schema["schema"] = "mlxcel-xla-aux-artifact-v2-unknown".into();
+        let unknown_schema = serde_json::to_vec(&unknown_schema).unwrap();
+
+        let mut overflow_schema: serde_json::Value = serde_json::from_slice(&original).unwrap();
+        overflow_schema["schema"] = "mlxcel-xla-aux-artifact-v999999999999999999999".into();
+        let overflow_schema = serde_json::to_vec(&overflow_schema).unwrap();
+
+        let mut missing_schema: serde_json::Value = serde_json::from_slice(&original).unwrap();
+        missing_schema.as_object_mut().unwrap().remove("schema");
+        let missing_schema = serde_json::to_vec(&missing_schema).unwrap();
+
+        let v1_contract = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+        )
+        .unwrap();
+        for (case, bytes) in [
+            ("malformed", b"{".to_vec()),
+            ("duplicate schema", duplicate_schema),
+            ("unknown schema", unknown_schema),
+            ("overflow schema", overflow_schema),
+            ("missing schema", missing_schema),
+        ] {
+            std::fs::write(&manifest, &bytes).unwrap();
+            let mut compile_called = false;
+            let error =
+                ensure_qualified_auxiliary_artifact(&vmfb, &v1_contract, &resident_weights, |_| {
+                    compile_called = true;
+                    Ok(())
+                })
+                .unwrap_err();
+            assert!(!compile_called, "{case}");
+            assert!(error.contains("refusing to"), "{case}: {error}");
+            assert_eq!(std::fs::read(&vmfb).unwrap(), b"vmfb-v2", "{case}");
+            assert_eq!(std::fs::read(&manifest).unwrap(), bytes, "{case}");
+        }
+
+        std::fs::remove_file(manifest).ok();
+        std::fs::remove_file(vmfb).ok();
+    }
+
+    #[test]
     fn concurrent_loaders_publish_one_qualified_artifact() {
         let vmfb = Arc::new(temp_vmfb("concurrent"));
-        let contract =
-            AuxiliaryArtifactContract::new("aux.main", "config=v1", "compiler=v1").unwrap();
+        let contract = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "aux.main",
+            "config=v1",
+            "compiler=v1",
+        )
+        .unwrap();
         let compile_count = Arc::new(AtomicUsize::new(0));
         let ready = Arc::new(Barrier::new(8));
         let threads = (0..8)

--- a/src/lib/mlxcel-xla/src/aux_smoke.rs
+++ b/src/lib/mlxcel-xla/src/aux_smoke.rs
@@ -136,14 +136,14 @@ pub fn run_auxiliary_abi_smoke(device: &str) -> Result<AuxiliaryAbiSmokeReport, 
     std::fs::create_dir_all(&cache)
         .map_err(|error| format!("mkdir {}: {error}", cache.display()))?;
     let vmfb = compile_one(&compiler, SMOKE_MLIR, flags, &cache, "aux-smoke", 0)?;
-    let contract = AuxiliaryArtifactContract::new(
+    let contract = AuxiliaryArtifactContract::new_legacy_unqualified(
         "aux_smoke.main",
         "aux-smoke-config-v1",
         generation_identity(&compiler, flags)?,
     )?;
     write_auxiliary_manifest(&vmfb, &contract, &[weight()])?;
 
-    let wrong_contract = AuxiliaryArtifactContract::new(
+    let wrong_contract = AuxiliaryArtifactContract::new_legacy_unqualified(
         "aux_smoke.main",
         "aux-smoke-config-v2",
         contract.generation_identity.clone(),

--- a/src/lib/mlxcel-xla/src/lib.rs
+++ b/src/lib/mlxcel-xla/src/lib.rs
@@ -51,6 +51,9 @@ use mlxcel_core::session::{InferenceSession, PreparedPrefill, SessionCapabilitie
 
 mod context;
 #[cfg(any(feature = "iree", test))]
+#[allow(dead_code)]
+mod numeric_dtype_contract;
+#[cfg(any(feature = "iree", test))]
 #[cfg_attr(not(feature = "iree"), allow(dead_code))]
 mod prepared;
 mod prepared_deepstack;

--- a/src/lib/mlxcel-xla/src/numeric_dtype_contract.rs
+++ b/src/lib/mlxcel-xla/src/numeric_dtype_contract.rs
@@ -1,0 +1,176 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Canonical dtype/materialization identity for StableHLO/IREE artifacts.
+//!
+//! Shapes, model-family options, compiler identity, and emitted MLIR already
+//! participate in their respective artifact identities. This descriptor binds
+//! the dtype choices that otherwise look identical at those layers: where
+//! quantized weights are expanded, contraction operand/accumulator/result
+//! types, reduction compute type, and the activation carrier between operators.
+//!
+//! This is intentionally a subset of a complete operator numeric contract. It
+//! does not describe rounding placement, reduction association, operation
+//! ordering, or backend algorithm identity. A family cannot claim numeric
+//! qualification from this descriptor alone.
+
+const SCHEMA: &str = "mlxcel-xla-numeric-dtype-v1";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NumericDType {
+    F16,
+    Bf16,
+    F32,
+}
+
+impl NumericDType {
+    const fn identity(self) -> &'static str {
+        match self {
+            Self::F16 => "f16",
+            Self::Bf16 => "bf16",
+            Self::F32 => "f32",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WeightExecution {
+    Dense,
+    HostAffineDequantized,
+    PackedAffineInGraph,
+}
+
+impl WeightExecution {
+    const fn identity(self) -> &'static str {
+        match self {
+            Self::Dense => "dense",
+            Self::HostAffineDequantized => "host-affine-dequantized",
+            Self::PackedAffineInGraph => "packed-affine-in-graph",
+        }
+    }
+}
+
+/// Dtype and materialization choices that must match before VMFB reuse.
+///
+/// The type deliberately has no `Default`: adopting the versioned auxiliary
+/// manifest must be an explicit decision. This contract is necessary but not
+/// sufficient for a family to pass its bounded operator oracle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct NumericDTypeContract {
+    pub(crate) weight_execution: WeightExecution,
+    pub(crate) contraction_input: NumericDType,
+    pub(crate) contraction_accumulator: NumericDType,
+    pub(crate) contraction_output: NumericDType,
+    pub(crate) reduction_compute: NumericDType,
+    pub(crate) activation_carrier: NumericDType,
+}
+
+impl NumericDTypeContract {
+    #[must_use]
+    pub(crate) const fn new(
+        weight_execution: WeightExecution,
+        contraction_input: NumericDType,
+        contraction_accumulator: NumericDType,
+        contraction_output: NumericDType,
+        reduction_compute: NumericDType,
+        activation_carrier: NumericDType,
+    ) -> Self {
+        Self {
+            weight_execution,
+            contraction_input,
+            contraction_accumulator,
+            contraction_output,
+            reduction_compute,
+            activation_carrier,
+        }
+    }
+
+    /// Stable text used only as hash input; never use `Debug` output here.
+    #[must_use]
+    pub(crate) fn canonical_identity(self) -> String {
+        format!(
+            "{SCHEMA};weights={};dot-in={};dot-acc={};dot-out={};reduce={};carrier={}",
+            self.weight_execution.identity(),
+            self.contraction_input.identity(),
+            self.contraction_accumulator.identity(),
+            self.contraction_output.identity(),
+            self.reduction_compute.identity(),
+            self.activation_carrier.identity(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host_dequantized_f32() -> NumericDTypeContract {
+        NumericDTypeContract::new(
+            WeightExecution::HostAffineDequantized,
+            NumericDType::F32,
+            NumericDType::F32,
+            NumericDType::F32,
+            NumericDType::F32,
+            NumericDType::F32,
+        )
+    }
+
+    #[test]
+    fn canonical_identity_is_stable() {
+        assert_eq!(
+            host_dequantized_f32().canonical_identity(),
+            "mlxcel-xla-numeric-dtype-v1;weights=host-affine-dequantized;dot-in=f32;\
+             dot-acc=f32;dot-out=f32;reduce=f32;carrier=f32"
+        );
+    }
+
+    #[test]
+    fn every_numeric_field_changes_the_identity() {
+        let baseline = host_dequantized_f32();
+        let variants = [
+            NumericDTypeContract {
+                weight_execution: WeightExecution::Dense,
+                ..baseline
+            },
+            NumericDTypeContract {
+                weight_execution: WeightExecution::PackedAffineInGraph,
+                ..baseline
+            },
+            NumericDTypeContract {
+                contraction_input: NumericDType::F16,
+                ..baseline
+            },
+            NumericDTypeContract {
+                contraction_accumulator: NumericDType::Bf16,
+                ..baseline
+            },
+            NumericDTypeContract {
+                contraction_output: NumericDType::F16,
+                ..baseline
+            },
+            NumericDTypeContract {
+                reduction_compute: NumericDType::Bf16,
+                ..baseline
+            },
+            NumericDTypeContract {
+                activation_carrier: NumericDType::F16,
+                ..baseline
+            },
+        ];
+        let baseline_identity = baseline.canonical_identity();
+        for variant in variants {
+            assert_ne!(variant.canonical_identity(), baseline_identity);
+        }
+    }
+}

--- a/src/lib/mlxcel-xla/src/phi4_audio.rs
+++ b/src/lib/mlxcel-xla/src/phi4_audio.rs
@@ -339,7 +339,7 @@ fn load_audio_module(
         .map_err(|error| format!("mkdir {}: {error}", cache.display()))?;
     let vmfb = cached_vmfb_path(&compiler, graph, flags, &cache, artifact_name, frame_bucket);
     let weights = load_audio_weights(model_dir, config)?;
-    let contract = AuxiliaryArtifactContract::new(
+    let contract = AuxiliaryArtifactContract::new_legacy_unqualified(
         entry_name,
         config_identity(config, frame_bucket, precision),
         generation_identity(&compiler, flags, graph)?,
@@ -757,7 +757,7 @@ mod tests {
             shape: vec![1],
         }];
         let config = published_config();
-        let contract = AuxiliaryArtifactContract::new(
+        let contract = AuxiliaryArtifactContract::new_legacy_unqualified(
             "audio.main",
             config_identity(&config, 512, Precision::F32),
             "compiler=test;flags=cpu;stablehlo_sha256=v1",
@@ -779,7 +779,7 @@ mod tests {
         .unwrap();
         assert_eq!(compile_count, 1);
 
-        let stale_replacement = AuxiliaryArtifactContract::new(
+        let stale_replacement = AuxiliaryArtifactContract::new_legacy_unqualified(
             "audio.main",
             config_identity(&config, 512, Precision::F32),
             "compiler=test;flags=cpu;stablehlo_sha256=v2",
@@ -818,8 +818,12 @@ mod tests {
             ),
             "generation identity should contain the compiler executable's raw SHA-256 digest"
         );
-        let first_contract =
-            AuxiliaryArtifactContract::new("audio.main", "config=v1", &first_generation).unwrap();
+        let first_contract = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "audio.main",
+            "config=v1",
+            &first_generation,
+        )
+        .unwrap();
         let mut compile_count = 0usize;
         ensure_qualified_auxiliary_artifact(&vmfb, &first_contract, &weights, |temporary| {
             compile_count += 1;
@@ -832,8 +836,12 @@ mod tests {
         let second_generation =
             generation_identity_from_version(&compiler, &["--target=cpu"], "mlir", "v1").unwrap();
         assert_ne!(first_generation, second_generation);
-        let second_contract =
-            AuxiliaryArtifactContract::new("audio.main", "config=v1", second_generation).unwrap();
+        let second_contract = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "audio.main",
+            "config=v1",
+            second_generation,
+        )
+        .unwrap();
         ensure_qualified_auxiliary_artifact(&vmfb, &second_contract, &weights, |temporary| {
             compile_count += 1;
             std::fs::write(temporary, b"vmfb-b")

--- a/src/lib/mlxcel-xla/src/qwen2_vl_runtime.rs
+++ b/src/lib/mlxcel-xla/src/qwen2_vl_runtime.rs
@@ -557,7 +557,7 @@ fn compile_and_load(
     std::fs::create_dir_all(&cache)
         .map_err(|error| format!("mkdir {}: {error}", cache.display()))?;
     let (weights, checkpoint_schema) = load_weights(model_dir, config)?;
-    let contract = AuxiliaryArtifactContract::new(
+    let contract = AuxiliaryArtifactContract::new_legacy_unqualified(
         ENTRY_NAME,
         format!(
             "{};{};checkpoint_schema_sha256={}",

--- a/src/lib/mlxcel-xla/src/vision_runtime.rs
+++ b/src/lib/mlxcel-xla/src/vision_runtime.rs
@@ -580,7 +580,7 @@ fn compile_and_load(
     std::fs::create_dir_all(&cache)
         .map_err(|error| format!("mkdir {}: {error}", cache.display()))?;
     let (weights, checkpoint_schema) = load_weights(model_dir, &config.weight_specs())?;
-    let contract = AuxiliaryArtifactContract::new(
+    let contract = AuxiliaryArtifactContract::new_legacy_unqualified(
         ENTRY_NAME,
         format!(
             "{};{};checkpoint_schema_sha256={}",
@@ -918,8 +918,12 @@ mod tests {
         let first_generation =
             compiler_generation_identity_from_version(&compiler, &["--target=cuda"], "mlir", "v1")
                 .unwrap();
-        let first_contract =
-            AuxiliaryArtifactContract::new("vision.main", "config=v1", &first_generation).unwrap();
+        let first_contract = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "vision.main",
+            "config=v1",
+            &first_generation,
+        )
+        .unwrap();
         let mut compile_count = 0usize;
         ensure_qualified_auxiliary_artifact(&vmfb, &first_contract, &weights, |temporary| {
             compile_count += 1;
@@ -933,8 +937,12 @@ mod tests {
             compiler_generation_identity_from_version(&compiler, &["--target=cuda"], "mlir", "v1")
                 .unwrap();
         assert_ne!(first_generation, second_generation);
-        let second_contract =
-            AuxiliaryArtifactContract::new("vision.main", "config=v1", second_generation).unwrap();
+        let second_contract = AuxiliaryArtifactContract::new_legacy_unqualified(
+            "vision.main",
+            "config=v1",
+            second_generation,
+        )
+        .unwrap();
         ensure_qualified_auxiliary_artifact(&vmfb, &second_contract, &weights, |temporary| {
             compile_count += 1;
             std::fs::write(temporary, b"vmfb-b")


### PR DESCRIPTION
## Summary

- add a canonical `NumericDTypeContract` for weight materialization, contraction dtypes, reduction compute dtype, and activation carrier dtype
- add an opt-in `mlxcel-xla-aux-artifact-v2-numeric-dtype` manifest whose artifact fingerprint includes the dtype contract
- preserve the existing v1 manifest schema and digest ordering exactly for all current runtime callers
- make legacy use explicit with `new_legacy_unqualified` and reject newer, corrupt, ambiguous, or unclassified manifest replacement before deleting or recompiling cache artifacts
- parse persisted manifests strictly, including unknown fields, duplicate fields, and explicit `null` in the v2-only identity field

## Scope

This is the first non-exposing foundation slice of #932. It does not claim complete operator numeric qualification: rounding placement, reduction association, operation ordering, backend algorithm identity, shared emitter helpers, and deterministic micro-oracles remain follow-up work in #932.

No model family adopts the v2 contract in this PR, and no capability or production execution path is enabled.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p mlxcel-xla --features iree --lib`
- `cargo check -p mlxcel-xla --features iree`
- `cargo test -p mlxcel-xla --features iree --lib aux_manifest` — 12 passed
- `cargo test -p mlxcel-xla --features iree --lib numeric_dtype_contract` — focused contract tests passed
- `git diff --check`

Refs #932
