### PR TITLE
feat(xla): share contract-sensitive numeric emitter helpers

### DIFF
--- a/src/lib/mlxcel-xla/src/emitter/mod.rs
+++ b/src/lib/mlxcel-xla/src/emitter/mod.rs
@@ -57,7 +57,6 @@ mod gemma3n_schema;
 mod gemma3n_weights;
 mod model;
 mod moe;
-#[cfg(any(feature = "micro-oracle", test))]
 pub(crate) mod numeric_ops;
 mod phi4_audio;
 mod qwen2_vl;
@@ -1113,13 +1112,16 @@ mod tests {
                 .contains("position_mode == 1 ? positions_mrope_dims : positions_1d_dims")
         );
         assert!(
-            source
-                .contains("xla_ctx* c, int32_t position_mode, const xla_tensor_desc* embeddings,"),
+            source.contains(
+                "xla_ctx* c, int32_t adapter_mode, int32_t position_mode,\n    \
+                 const xla_tensor_desc* embeddings,"
+            ),
             "single DeepStack ABI must carry the explicit position mode"
         );
         assert!(
             source.contains(
-                "xla_ctx* c, int32_t slot, int32_t position_mode,\n    const xla_tensor_desc* embeddings,"
+                "xla_ctx* c, int32_t slot, int32_t adapter_mode, int32_t position_mode,\n    \
+                 const xla_tensor_desc* embeddings,"
             ),
             "ragged DeepStack ABI must carry the explicit position mode"
         );

--- a/src/lib/mlxcel-xla/src/emitter/numeric_ops.rs
+++ b/src/lib/mlxcel-xla/src/emitter/numeric_ops.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Semantically narrow emitters for operator-level numeric probes.
+//! Shared contract-sensitive numeric decompositions and bounded probes.
 //!
-//! These entry points deliberately expose every materialization boundary in
-//! their signature. They reuse the same [`Builder`] operations as production
-//! model emitters without applying graph-wide precision rewrites.
+//! Production emitters and the probe harness call the same helpers so their
+//! materialization order cannot drift independently. Probe entry points keep
+//! each contract boundary explicit and avoid graph-wide precision rewrites.
 
-use super::builder::{Builder, Ty};
+use super::builder::{Builder, Ty, Val};
 
 const MAX_EXACT_F32_INTEGER: usize = 1 << 24;
 
@@ -30,6 +30,12 @@ pub(crate) const RMS_NORM_MODULE: &str = "numeric_rms_norm";
 pub(crate) const RMS_NORM_ENTRY: &str = "numeric_rms_norm.main";
 pub(crate) const SOFTMAX_MODULE: &str = "numeric_attention_softmax";
 pub(crate) const SOFTMAX_ENTRY: &str = "numeric_attention_softmax.main";
+pub(crate) const LAYER_NORM_MODULE: &str = "numeric_layer_norm";
+pub(crate) const LAYER_NORM_ENTRY: &str = "numeric_layer_norm.main";
+pub(crate) const SILU_PROJECTION_MODULE: &str = "numeric_silu_projection";
+pub(crate) const SILU_PROJECTION_ENTRY: &str = "numeric_silu_projection.main";
+pub(crate) const GELU_PROJECTION_MODULE: &str = "numeric_gelu_projection";
+pub(crate) const GELU_PROJECTION_ENTRY: &str = "numeric_gelu_projection.main";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct DenseMatmulProbeSpec {
@@ -60,6 +66,156 @@ impl RowWiseProbeSpec {
         }
         Ok(self)
     }
+}
+
+fn validate_row_wise_inputs(operation: &str, value: &Val, parameters: &[&Val]) -> (usize, usize) {
+    assert_eq!(value.ty.shape.len(), 2, "{operation} input must be rank-2");
+    let rows = value.ty.shape[0];
+    let features = value.ty.shape[1];
+    assert!(
+        features <= MAX_EXACT_F32_INTEGER,
+        "{operation} feature count must be exactly representable as f32"
+    );
+    for parameter in parameters {
+        assert_eq!(
+            parameter.ty.shape,
+            [features],
+            "{operation} parameter must match the feature axis"
+        );
+        assert_eq!(
+            parameter.ty.elt, value.ty.elt,
+            "{operation} parameter dtype must match the input"
+        );
+    }
+    (rows, features)
+}
+
+/// Explicit row-wise LayerNorm decomposition shared by production vision
+/// emitters and bounded numeric probes.
+pub(crate) fn layer_norm_2d(
+    builder: &mut Builder,
+    value: &Val,
+    weight: &Val,
+    bias: &Val,
+    epsilon: f32,
+) -> Val {
+    let (rows, features) = validate_row_wise_inputs("LayerNorm", value, &[weight, bias]);
+    assert!(
+        epsilon.is_finite() && epsilon > 0.0,
+        "LayerNorm epsilon must be finite and positive"
+    );
+    let zero = builder.const_f32(0.0);
+    let width_scalar = builder.const_f32(features as f32);
+    let width_rows = builder.broadcast(&width_scalar, &[], vec![rows]);
+    let sum = builder.reduce_add(value, 1, &zero);
+    let mean = builder.divide(&sum, &width_rows);
+    let mean = builder.broadcast(&mean, &[0], vec![rows, features]);
+    let centered = builder.subtract(value, &mean);
+    let squared = builder.multiply(&centered, &centered);
+    let squared_sum = builder.reduce_add(&squared, 1, &zero);
+    let variance = builder.divide(&squared_sum, &width_rows);
+    let epsilon = builder.const_f32(epsilon);
+    let epsilon = builder.broadcast(&epsilon, &[], vec![rows]);
+    let variance = builder.add(&variance, &epsilon);
+    let inv_std = builder.rsqrt(&variance);
+    let inv_std = builder.broadcast(&inv_std, &[0], vec![rows, features]);
+    let normalized = builder.multiply(&centered, &inv_std);
+    let weight = builder.broadcast(weight, &[1], vec![rows, features]);
+    let bias = builder.broadcast(bias, &[1], vec![rows, features]);
+    let normalized = builder.multiply(&normalized, &weight);
+    builder.add(&normalized, &bias)
+}
+
+/// Explicit row-wise RMSNorm decomposition.
+pub(crate) fn rms_norm_2d(builder: &mut Builder, value: &Val, weight: &Val, epsilon: f32) -> Val {
+    let (rows, features) = validate_row_wise_inputs("RMSNorm", value, &[weight]);
+    assert!(
+        epsilon.is_finite() && epsilon > 0.0,
+        "RMSNorm epsilon must be finite and positive"
+    );
+    let zero = builder.const_f32(0.0);
+    let squared = builder.multiply(value, value);
+    let sum = builder.reduce_add(&squared, 1, &zero);
+    let count = builder.const_f32(features as f32);
+    let count = builder.broadcast(&count, &[], vec![rows]);
+    let mean = builder.divide(&sum, &count);
+    let epsilon = builder.const_f32(epsilon);
+    let epsilon = builder.broadcast(&epsilon, &[], vec![rows]);
+    let mean = builder.add(&mean, &epsilon);
+    let inverse_rms = builder.rsqrt(&mean);
+    let inverse_rms = builder.broadcast(&inverse_rms, &[0], value.ty.shape.clone());
+    let normalized = builder.multiply(value, &inverse_rms);
+    let weight = builder.broadcast(weight, &[1], value.ty.shape.clone());
+    builder.multiply(&normalized, &weight)
+}
+
+/// Exact-erf GELU decomposition used by vision projector paths.
+pub(crate) fn exact_gelu(builder: &mut Builder, value: &Val) -> Val {
+    let shape = value.ty.shape.clone();
+    let half = builder.const_f32(0.5);
+    let half = builder.broadcast(&half, &[], shape.clone());
+    let one = builder.const_f32(1.0);
+    let one = builder.broadcast(&one, &[], shape.clone());
+    let inv_sqrt_two = builder.const_f32(std::f32::consts::FRAC_1_SQRT_2);
+    let inv_sqrt_two = builder.broadcast(&inv_sqrt_two, &[], shape);
+    let scaled = builder.multiply(value, &inv_sqrt_two);
+    let erf = builder.erf(&scaled);
+    let cdf = builder.add(&one, &erf);
+    let half_value = builder.multiply(value, &half);
+    builder.multiply(&half_value, &cdf)
+}
+
+/// PyTorch tanh-approximation GELU decomposition.
+pub(crate) fn tanh_gelu(builder: &mut Builder, value: &Val) -> Val {
+    let shape = value.ty.shape.clone();
+    let half = builder.const_f32(0.5);
+    let half = builder.broadcast(&half, &[], shape.clone());
+    let one = builder.const_f32(1.0);
+    let one = builder.broadcast(&one, &[], shape.clone());
+    let coefficient = builder.const_f32(0.044_715);
+    let coefficient = builder.broadcast(&coefficient, &[], shape.clone());
+    let scale = builder.const_f32(0.797_884_6);
+    let scale = builder.broadcast(&scale, &[], shape);
+    let squared = builder.multiply(value, value);
+    let cubed = builder.multiply(&squared, value);
+    let nonlinear = builder.multiply(&coefficient, &cubed);
+    let inner = builder.add(value, &nonlinear);
+    let scaled = builder.multiply(&scale, &inner);
+    let tanh = builder.tanh(&scaled);
+    let cdf = builder.add(&one, &tanh);
+    let half_value = builder.multiply(value, &half);
+    builder.multiply(&half_value, &cdf)
+}
+
+/// SiLU decomposition with an explicit activation materialization boundary.
+pub(crate) fn silu(builder: &mut Builder, value: &Val) -> Val {
+    let one = builder.const_f32(1.0);
+    let one = builder.broadcast(&one, &[], value.ty.shape.clone());
+    let negative = builder.negate(value);
+    let exponential = builder.exponential(&negative);
+    let denominator = builder.add(&one, &exponential);
+    let sigmoid = builder.divide(&one, &denominator);
+    builder.multiply(value, &sigmoid)
+}
+
+/// Numerically stable softmax with an explicit reduction axis.
+pub(crate) fn stable_softmax(builder: &mut Builder, value: &Val, axis: usize) -> Val {
+    assert!(
+        axis < value.ty.shape.len(),
+        "softmax axis must be within the input rank"
+    );
+    let negative_infinity = builder.const_f32(f32::NEG_INFINITY);
+    let maximum = builder.reduce_max(value, axis, &negative_infinity);
+    let kept_axes = (0..value.ty.shape.len())
+        .filter(|candidate| *candidate != axis)
+        .collect::<Vec<_>>();
+    let maximum = builder.broadcast(&maximum, &kept_axes, value.ty.shape.clone());
+    let shifted = builder.subtract(value, &maximum);
+    let exponentials = builder.exponential(&shifted);
+    let zero = builder.const_f32(0.0);
+    let sum = builder.reduce_add(&exponentials, axis, &zero);
+    let sum = builder.broadcast(&sum, &kept_axes, value.ty.shape.clone());
+    builder.divide(&exponentials, &sum)
 }
 
 /// Emit `output[rows, outputs] = input[rows, contraction] @
@@ -135,20 +291,7 @@ pub(crate) fn emit_rms_norm_probe(spec: RowWiseProbeSpec, epsilon: f32) -> Resul
     let weight = Builder::arg(0, weight_ty.clone());
     let input = Builder::arg(1, input_ty.clone());
     let mut builder = Builder::new();
-    let zero = builder.const_f32(0.0);
-    let squared = builder.multiply(&input, &input);
-    let sum = builder.reduce_add(&squared, 1, &zero);
-    let count = builder.const_f32(spec.features as f32);
-    let count = builder.broadcast(&count, &[], vec![spec.rows]);
-    let mean = builder.divide(&sum, &count);
-    let epsilon = builder.const_f32(epsilon);
-    let epsilon = builder.broadcast(&epsilon, &[], vec![spec.rows]);
-    let mean = builder.add(&mean, &epsilon);
-    let inverse_rms = builder.rsqrt(&mean);
-    let inverse_rms = builder.broadcast(&inverse_rms, &[0], input_ty.shape.clone());
-    let normalized = builder.multiply(&input, &inverse_rms);
-    let weight = builder.broadcast(&weight, &[1], input_ty.shape.clone());
-    let output = builder.multiply(&normalized, &weight);
+    let output = rms_norm_2d(&mut builder, &input, &weight, epsilon);
     Ok(format!(
         "module @{RMS_NORM_MODULE} {{\n  \
          func.func public @main(%arg0: {weight_ty}, %arg1: {input_ty}) -> {input_ty} {{\n\
@@ -167,15 +310,7 @@ pub(crate) fn emit_softmax_probe(spec: RowWiseProbeSpec) -> Result<String, Strin
     let input_ty = Ty::f32(vec![spec.rows, spec.features]);
     let input = Builder::arg(1, input_ty.clone());
     let mut builder = Builder::new();
-    let negative_infinity = builder.const_f32(f32::NEG_INFINITY);
-    let maximum = builder.reduce_max(&input, 1, &negative_infinity);
-    let maximum = builder.broadcast(&maximum, &[0], input_ty.shape.clone());
-    let shifted = builder.subtract(&input, &maximum);
-    let exponentials = builder.exponential(&shifted);
-    let zero = builder.const_f32(0.0);
-    let sum = builder.reduce_add(&exponentials, 1, &zero);
-    let sum = builder.broadcast(&sum, &[0], input_ty.shape.clone());
-    let output = builder.divide(&exponentials, &sum);
+    let output = stable_softmax(&mut builder, &input, 1);
     Ok(format!(
         "module @{SOFTMAX_MODULE} {{\n  \
          func.func public @main(%arg0: {dummy_ty}, %arg1: {input_ty}) -> {input_ty} {{\n\
@@ -185,6 +320,77 @@ pub(crate) fn emit_softmax_probe(spec: RowWiseProbeSpec) -> Result<String, Strin
         body = builder.body(),
         output = output.name,
     ))
+}
+
+/// Emit row-wise f32 LayerNorm with resident affine weight and bias.
+pub(crate) fn emit_layer_norm_probe(
+    spec: RowWiseProbeSpec,
+    epsilon: f32,
+) -> Result<String, String> {
+    let spec = spec.validate("LayerNorm")?;
+    if spec.features > MAX_EXACT_F32_INTEGER {
+        return Err(format!(
+            "LayerNorm probe feature count {} exceeds the largest consecutive integer exactly \
+             representable as f32 ({MAX_EXACT_F32_INTEGER})",
+            spec.features
+        ));
+    }
+    if !epsilon.is_finite() || epsilon <= 0.0 {
+        return Err("LayerNorm probe epsilon must be finite and positive".to_string());
+    }
+    let parameter_ty = Ty::f32(vec![spec.features]);
+    let input_ty = Ty::f32(vec![spec.rows, spec.features]);
+    let weight = Builder::arg(0, parameter_ty.clone());
+    let bias = Builder::arg(1, parameter_ty.clone());
+    let input = Builder::arg(2, input_ty.clone());
+    let mut builder = Builder::new();
+    let output = layer_norm_2d(&mut builder, &input, &weight, &bias, epsilon);
+    Ok(format!(
+        "module @{LAYER_NORM_MODULE} {{\n  \
+         func.func public @main(%arg0: {parameter_ty}, %arg1: {parameter_ty}, %arg2: {input_ty}) \
+         -> {input_ty} {{\n\
+         {body}    return {output} : {input_ty}\n  }}\n}}\n",
+        parameter_ty = parameter_ty.render(),
+        input_ty = input_ty.render(),
+        body = builder.body(),
+        output = output.name,
+    ))
+}
+
+fn emit_activation_projection_probe(
+    spec: DenseMatmulProbeSpec,
+    module: &str,
+    activation: fn(&mut Builder, &Val) -> Val,
+) -> Result<String, String> {
+    let spec = spec.validate()?;
+    let weight_ty = Ty::f32(vec![spec.outputs, spec.contraction]);
+    let input_ty = Ty::f32(vec![spec.rows, spec.contraction]);
+    let output_ty = Ty::f32(vec![spec.rows, spec.outputs]);
+    let weight = Builder::arg(0, weight_ty.clone());
+    let input = Builder::arg(1, input_ty.clone());
+    let mut builder = Builder::new();
+    let projected = builder.linear_seq(&input, &weight);
+    let output = activation(&mut builder, &projected);
+    Ok(format!(
+        "module @{module} {{\n  \
+         func.func public @main(%arg0: {weight_ty}, %arg1: {input_ty}) -> {output_ty} {{\n\
+         {body}    return {output} : {output_ty}\n  }}\n}}\n",
+        weight_ty = weight_ty.render(),
+        input_ty = input_ty.render(),
+        output_ty = output_ty.render(),
+        body = builder.body(),
+        output = output.name,
+    ))
+}
+
+/// Emit dense projection followed by explicit SiLU materialization.
+pub(crate) fn emit_silu_projection_probe(spec: DenseMatmulProbeSpec) -> Result<String, String> {
+    emit_activation_projection_probe(spec, SILU_PROJECTION_MODULE, silu)
+}
+
+/// Emit dense projection followed by PyTorch tanh GELU materialization.
+pub(crate) fn emit_gelu_projection_probe(spec: DenseMatmulProbeSpec) -> Result<String, String> {
+    emit_activation_projection_probe(spec, GELU_PROJECTION_MODULE, tanh_gelu)
 }
 
 #[cfg(test)]
@@ -296,5 +502,58 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn layer_norm_probe_pins_center_variance_affine_order() {
+        let graph = emit_layer_norm_probe(
+            RowWiseProbeSpec {
+                rows: 2,
+                features: 4,
+            },
+            1e-5,
+        )
+        .unwrap();
+        assert!(graph.starts_with("module @numeric_layer_norm {"));
+        assert_eq!(
+            graph
+                .matches("applies stablehlo.add across dimensions = [1]")
+                .count(),
+            2
+        );
+        assert!(graph.contains("stablehlo.subtract"));
+        assert!(graph.contains("stablehlo.rsqrt"));
+        assert!(!graph.contains("stablehlo.convert"));
+    }
+
+    #[test]
+    fn activation_projection_probes_pin_matmul_before_activation() {
+        let spec = DenseMatmulProbeSpec {
+            rows: 2,
+            outputs: 3,
+            contraction: 4,
+        };
+        let silu_graph = emit_silu_projection_probe(spec).unwrap();
+        let silu_dot = silu_graph.find("stablehlo.dot_general").unwrap();
+        let silu_exp = silu_graph.find("stablehlo.exponential").unwrap();
+        assert!(silu_dot < silu_exp);
+        assert!(silu_graph.contains("stablehlo.negate"));
+
+        let gelu_graph = emit_gelu_projection_probe(spec).unwrap();
+        let gelu_dot = gelu_graph.find("stablehlo.dot_general").unwrap();
+        let gelu_tanh = gelu_graph.find("stablehlo.tanh").unwrap();
+        assert!(gelu_dot < gelu_tanh);
+        assert!(gelu_graph.contains("0x3D372713"));
+        assert!(!gelu_graph.contains("chlo.erf"));
+    }
+
+    #[test]
+    fn exact_gelu_uses_erf_not_tanh() {
+        let input = Builder::arg(0, Ty::f32(vec![2, 3]));
+        let mut builder = Builder::new();
+        let _ = exact_gelu(&mut builder, &input);
+        let body = builder.body();
+        assert!(body.contains("chlo.erf"));
+        assert!(!body.contains("stablehlo.tanh"));
     }
 }

--- a/src/lib/mlxcel-xla/src/emitter/qwen2_vl.rs
+++ b/src/lib/mlxcel-xla/src/emitter/qwen2_vl.rs
@@ -25,6 +25,7 @@ use std::path::Path;
 use serde_json::Value;
 
 use super::builder::{Builder, Ty, Val};
+use super::numeric_ops::{exact_gelu, layer_norm_2d as layer_norm, stable_softmax, tanh_gelu};
 
 /// Qualified flattened-patch capacities for the pinned Qwen2-VL image path.
 ///
@@ -520,67 +521,6 @@ fn linear_2d(builder: &mut Builder, value: &Val, weight: &Val, bias: &Val) -> Va
     bias_2d(builder, &value, bias)
 }
 
-fn layer_norm(builder: &mut Builder, value: &Val, weight: &Val, bias: &Val, epsilon: f32) -> Val {
-    let rows = value.ty.shape[0];
-    let width = value.ty.shape[1];
-    let zero = builder.const_f32(0.0);
-    let width_scalar = builder.const_f32(width as f32);
-    let width_rows = builder.broadcast(&width_scalar, &[], vec![rows]);
-    let sum = builder.reduce_add(value, 1, &zero);
-    let mean = builder.divide(&sum, &width_rows);
-    let mean = builder.broadcast(&mean, &[0], vec![rows, width]);
-    let centered = builder.subtract(value, &mean);
-    let squared = builder.multiply(&centered, &centered);
-    let squared_sum = builder.reduce_add(&squared, 1, &zero);
-    let variance = builder.divide(&squared_sum, &width_rows);
-    let epsilon = builder.const_f32(epsilon);
-    let epsilon = builder.broadcast(&epsilon, &[], vec![rows]);
-    let variance = builder.add(&variance, &epsilon);
-    let inv_std = builder.rsqrt(&variance);
-    let inv_std = builder.broadcast(&inv_std, &[0], vec![rows, width]);
-    let normalized = builder.multiply(&centered, &inv_std);
-    let weight = builder.broadcast(weight, &[1], vec![rows, width]);
-    let bias = builder.broadcast(bias, &[1], vec![rows, width]);
-    let normalized = builder.multiply(&normalized, &weight);
-    builder.add(&normalized, &bias)
-}
-
-fn exact_gelu(builder: &mut Builder, value: &Val) -> Val {
-    let shape = value.ty.shape.clone();
-    let half = builder.const_f32(0.5);
-    let half = builder.broadcast(&half, &[], shape.clone());
-    let one = builder.const_f32(1.0);
-    let one = builder.broadcast(&one, &[], shape.clone());
-    let inv_sqrt_two = builder.const_f32(std::f32::consts::FRAC_1_SQRT_2);
-    let inv_sqrt_two = builder.broadcast(&inv_sqrt_two, &[], shape);
-    let scaled = builder.multiply(value, &inv_sqrt_two);
-    let erf = builder.erf(&scaled);
-    let cdf = builder.add(&one, &erf);
-    let half_value = builder.multiply(value, &half);
-    builder.multiply(&half_value, &cdf)
-}
-
-fn tanh_gelu(builder: &mut Builder, value: &Val) -> Val {
-    let shape = value.ty.shape.clone();
-    let half = builder.const_f32(0.5);
-    let half = builder.broadcast(&half, &[], shape.clone());
-    let one = builder.const_f32(1.0);
-    let one = builder.broadcast(&one, &[], shape.clone());
-    let coefficient = builder.const_f32(0.044_715);
-    let coefficient = builder.broadcast(&coefficient, &[], shape.clone());
-    let scale = builder.const_f32(0.797_884_6);
-    let scale = builder.broadcast(&scale, &[], shape);
-    let squared = builder.multiply(value, value);
-    let cubed = builder.multiply(&squared, value);
-    let nonlinear = builder.multiply(&coefficient, &cubed);
-    let inner = builder.add(value, &nonlinear);
-    let scaled = builder.multiply(&scale, &inner);
-    let tanh = builder.tanh(&scaled);
-    let cdf = builder.add(&one, &tanh);
-    let half_value = builder.multiply(value, &half);
-    builder.multiply(&half_value, &cdf)
-}
-
 fn rotate_half(builder: &mut Builder, value: &Val) -> Val {
     let tokens = value.ty.shape[0];
     let heads = value.ty.shape[1];
@@ -655,15 +595,7 @@ fn attention(
     let attention_bias =
         builder.broadcast(attention_bias, &[1, 2], vec![config.heads, tokens, tokens]);
     let scores = builder.add(&scores, &attention_bias);
-    let negative_infinity = builder.const_f32(f32::NEG_INFINITY);
-    let maximum = builder.reduce_max(&scores, 2, &negative_infinity);
-    let maximum = builder.broadcast(&maximum, &[0, 1], vec![config.heads, tokens, tokens]);
-    let shifted = builder.subtract(&scores, &maximum);
-    let exponentials = builder.exponential(&shifted);
-    let zero = builder.const_f32(0.0);
-    let denominator = builder.reduce_add(&exponentials, 2, &zero);
-    let denominator = builder.broadcast(&denominator, &[0, 1], vec![config.heads, tokens, tokens]);
-    let probabilities = builder.divide(&exponentials, &denominator);
+    let probabilities = stable_softmax(builder, &scores, 2);
     let context = builder.dot_general(
         &probabilities,
         &v,

--- a/src/lib/mlxcel-xla/src/emitter/vision.rs
+++ b/src/lib/mlxcel-xla/src/emitter/vision.rs
@@ -22,6 +22,7 @@
 //! linear weights remain `[out, in]`.
 
 use super::builder::{Builder, Ty, Val};
+use super::numeric_ops::{exact_gelu, layer_norm_2d as layer_norm, stable_softmax, tanh_gelu};
 use super::vision_config::{LlavaVisionConfig, VisionActivation, VisionWeightSpec};
 
 struct Args {
@@ -128,67 +129,6 @@ fn linear_2d(builder: &mut Builder, value: &Val, weight: &Val, bias: &Val) -> Va
     bias_2d(builder, &value, bias)
 }
 
-fn layer_norm(builder: &mut Builder, value: &Val, weight: &Val, bias: &Val, epsilon: f32) -> Val {
-    let rows = value.ty.shape[0];
-    let width = value.ty.shape[1];
-    let zero = builder.const_f32(0.0);
-    let width_scalar = builder.const_f32(width as f32);
-    let width_rows = builder.broadcast(&width_scalar, &[], vec![rows]);
-    let sum = builder.reduce_add(value, 1, &zero);
-    let mean = builder.divide(&sum, &width_rows);
-    let mean = builder.broadcast(&mean, &[0], vec![rows, width]);
-    let centered = builder.subtract(value, &mean);
-    let squared = builder.multiply(&centered, &centered);
-    let squared_sum = builder.reduce_add(&squared, 1, &zero);
-    let variance = builder.divide(&squared_sum, &width_rows);
-    let epsilon = builder.const_f32(epsilon);
-    let epsilon = builder.broadcast(&epsilon, &[], vec![rows]);
-    let variance = builder.add(&variance, &epsilon);
-    let inv_std = builder.rsqrt(&variance);
-    let inv_std = builder.broadcast(&inv_std, &[0], vec![rows, width]);
-    let normalized = builder.multiply(&centered, &inv_std);
-    let weight = builder.broadcast(weight, &[1], vec![rows, width]);
-    let bias = builder.broadcast(bias, &[1], vec![rows, width]);
-    let normalized = builder.multiply(&normalized, &weight);
-    builder.add(&normalized, &bias)
-}
-
-fn exact_gelu(builder: &mut Builder, value: &Val) -> Val {
-    let shape = value.ty.shape.clone();
-    let half = builder.const_f32(0.5);
-    let half = builder.broadcast(&half, &[], shape.clone());
-    let one = builder.const_f32(1.0);
-    let one = builder.broadcast(&one, &[], shape.clone());
-    let inv_sqrt_two = builder.const_f32(std::f32::consts::FRAC_1_SQRT_2);
-    let inv_sqrt_two = builder.broadcast(&inv_sqrt_two, &[], shape);
-    let scaled = builder.multiply(value, &inv_sqrt_two);
-    let erf = builder.erf(&scaled);
-    let cdf = builder.add(&one, &erf);
-    let half_value = builder.multiply(value, &half);
-    builder.multiply(&half_value, &cdf)
-}
-
-fn tanh_gelu(builder: &mut Builder, value: &Val) -> Val {
-    let shape = value.ty.shape.clone();
-    let half = builder.const_f32(0.5);
-    let half = builder.broadcast(&half, &[], shape.clone());
-    let one = builder.const_f32(1.0);
-    let one = builder.broadcast(&one, &[], shape.clone());
-    let coefficient = builder.const_f32(0.044_715);
-    let coefficient = builder.broadcast(&coefficient, &[], shape.clone());
-    let scale = builder.const_f32(0.797_884_6);
-    let scale = builder.broadcast(&scale, &[], shape);
-    let squared = builder.multiply(value, value);
-    let cubed = builder.multiply(&squared, value);
-    let nonlinear = builder.multiply(&coefficient, &cubed);
-    let inner = builder.add(value, &nonlinear);
-    let scaled = builder.multiply(&scale, &inner);
-    let tanh = builder.tanh(&scaled);
-    let cdf = builder.add(&one, &tanh);
-    let half_value = builder.multiply(value, &half);
-    builder.multiply(&half_value, &cdf)
-}
-
 fn activate(builder: &mut Builder, value: &Val, activation: VisionActivation) -> Val {
     match activation {
         VisionActivation::ExactGelu => exact_gelu(builder, value),
@@ -228,15 +168,7 @@ fn attention(
     let scale = builder.const_f32((head_dim as f32).powf(-0.5));
     let scale = builder.broadcast(&scale, &[], vec![config.heads, tokens, tokens]);
     let scores = builder.multiply(&scores, &scale);
-    let negative_infinity = builder.const_f32(f32::NEG_INFINITY);
-    let maximum = builder.reduce_max(&scores, 2, &negative_infinity);
-    let maximum = builder.broadcast(&maximum, &[0, 1], vec![config.heads, tokens, tokens]);
-    let shifted = builder.subtract(&scores, &maximum);
-    let exponentials = builder.exponential(&shifted);
-    let zero = builder.const_f32(0.0);
-    let denominator = builder.reduce_add(&exponentials, 2, &zero);
-    let denominator = builder.broadcast(&denominator, &[0, 1], vec![config.heads, tokens, tokens]);
-    let probabilities = builder.divide(&exponentials, &denominator);
+    let probabilities = stable_softmax(builder, &scores, 2);
     let context = builder.dot_general(
         &probabilities,
         &v,

--- a/src/lib/mlxcel-xla/src/numeric_probe.rs
+++ b/src/lib/mlxcel-xla/src/numeric_probe.rs
@@ -26,9 +26,10 @@ use crate::aux::{
 };
 use crate::aux_manifest::{AuxiliaryArtifactContract, ensure_qualified_auxiliary_artifact};
 use crate::emitter::numeric_ops::{
-    DENSE_MATMUL_ENTRY, DenseMatmulProbeSpec, RESIDUAL_ADD_ENTRY, RMS_NORM_ENTRY, RowWiseProbeSpec,
-    SOFTMAX_ENTRY, emit_dense_matmul_probe, emit_residual_add_probe, emit_rms_norm_probe,
-    emit_softmax_probe,
+    DENSE_MATMUL_ENTRY, DenseMatmulProbeSpec, GELU_PROJECTION_ENTRY, LAYER_NORM_ENTRY,
+    RESIDUAL_ADD_ENTRY, RMS_NORM_ENTRY, RowWiseProbeSpec, SILU_PROJECTION_ENTRY, SOFTMAX_ENTRY,
+    emit_dense_matmul_probe, emit_gelu_projection_probe, emit_layer_norm_probe,
+    emit_residual_add_probe, emit_rms_norm_probe, emit_silu_projection_probe, emit_softmax_probe,
 };
 use crate::iree::{cached_vmfb_path, compile_one_to, iree_compile_bin, target_flags};
 use crate::numeric_dtype_contract::{NumericDType, WeightExecution};
@@ -48,9 +49,14 @@ const DENSE_OPERATION: &str = "micro-oracle.dense-matmul.f32";
 const ROWS: usize = 2;
 const FEATURES: usize = 4;
 const RMS_EPSILON: f32 = 1e-5;
+const LAYER_NORM_EPSILON: f32 = 1e-5;
+const PROJECTION_OUTPUTS: usize = 3;
 const RESIDUAL_OPERATION: &str = "micro-oracle.residual-add.f32";
 const RMS_NORM_OPERATION: &str = "micro-oracle.rms-norm.f32";
 const SOFTMAX_OPERATION: &str = "micro-oracle.attention-softmax.f32";
+const LAYER_NORM_OPERATION: &str = "micro-oracle.layer-norm.f32";
+const SILU_PROJECTION_OPERATION: &str = "micro-oracle.silu-projection.f32";
+const GELU_PROJECTION_OPERATION: &str = "micro-oracle.gelu-projection.f32";
 
 struct ProbeDefinition {
     operation: &'static str,
@@ -354,6 +360,129 @@ fn reference_softmax(operands: &[NumericTensor]) -> Result<NumericTensor, String
     NumericTensor::new("output", vec![ROWS, FEATURES], output)
 }
 
+fn layer_norm_operands() -> Result<Vec<NumericTensor>, String> {
+    Ok(vec![
+        NumericTensor::new(
+            "input",
+            vec![ROWS, FEATURES],
+            vec![1.0, -2.0, 3.0, -4.0, 0.25, 0.5, -0.75, 1.25],
+        )?,
+        NumericTensor::new("weight", vec![FEATURES], vec![0.5, 1.0, 1.5, -0.75])?,
+        NumericTensor::new("bias", vec![FEATURES], vec![0.25, -0.5, 0.75, 1.0])?,
+    ])
+}
+
+fn reference_layer_norm(operands: &[NumericTensor]) -> Result<NumericTensor, String> {
+    let [input, weight, bias] = operands else {
+        return Err(format!(
+            "LayerNorm reference requires 3 operands, got {}",
+            operands.len()
+        ));
+    };
+    if input.shape() != [ROWS, FEATURES]
+        || weight.shape() != [FEATURES]
+        || bias.shape() != [FEATURES]
+    {
+        return Err(format!(
+            "LayerNorm reference shape mismatch: input {:?}, weight {:?}, bias {:?}",
+            input.shape(),
+            weight.shape(),
+            bias.shape()
+        ));
+    }
+    let mut output = Vec::with_capacity(ROWS * FEATURES);
+    for row in input.values().chunks_exact(FEATURES) {
+        let mean = row.iter().copied().sum::<f32>() / FEATURES as f32;
+        let centered = row.iter().map(|value| value - mean).collect::<Vec<_>>();
+        let variance = centered
+            .iter()
+            .fold(0.0f32, |sum, value| sum + value * value)
+            / FEATURES as f32;
+        let inverse_std = (variance + LAYER_NORM_EPSILON).sqrt().recip();
+        output.extend(
+            centered
+                .into_iter()
+                .zip(weight.values())
+                .zip(bias.values())
+                .map(|((value, weight), bias)| value * inverse_std * weight + bias),
+        );
+    }
+    NumericTensor::new("output", vec![ROWS, FEATURES], output)
+}
+
+fn projection_operands() -> Result<Vec<NumericTensor>, String> {
+    Ok(vec![
+        NumericTensor::new(
+            "input",
+            vec![ROWS, FEATURES],
+            vec![1.0, -2.0, 0.5, 3.0, -0.25, 0.75, -1.5, 2.0],
+        )?,
+        NumericTensor::new(
+            "weight",
+            vec![PROJECTION_OUTPUTS, FEATURES],
+            vec![
+                0.5, -1.0, 2.0, 0.25, -2.0, 0.5, 0.75, -0.125, 1.25, 0.0, -0.5, 2.0,
+            ],
+        )?,
+    ])
+}
+
+fn reference_projection(operands: &[NumericTensor]) -> Result<Vec<f32>, String> {
+    let [input, weight] = operands else {
+        return Err(format!(
+            "activation projection reference requires 2 operands, got {}",
+            operands.len()
+        ));
+    };
+    if input.shape() != [ROWS, FEATURES] || weight.shape() != [PROJECTION_OUTPUTS, FEATURES] {
+        return Err(format!(
+            "activation projection reference shape mismatch: input {:?}, weight {:?}",
+            input.shape(),
+            weight.shape()
+        ));
+    }
+    let mut projected = Vec::with_capacity(ROWS * PROJECTION_OUTPUTS);
+    for row in 0..ROWS {
+        for output in 0..PROJECTION_OUTPUTS {
+            let mut accumulator = 0.0f32;
+            for feature in 0..FEATURES {
+                accumulator += input.values()[row * FEATURES + feature]
+                    * weight.values()[output * FEATURES + feature];
+            }
+            projected.push(accumulator);
+        }
+    }
+    Ok(projected)
+}
+
+fn reference_silu_projection(operands: &[NumericTensor]) -> Result<NumericTensor, String> {
+    let output = reference_projection(operands)?
+        .into_iter()
+        .map(|value| {
+            let sigmoid = 1.0f32 / (1.0f32 + (-value).exp());
+            value * sigmoid
+        })
+        .collect();
+    NumericTensor::new("output", vec![ROWS, PROJECTION_OUTPUTS], output)
+}
+
+fn reference_gelu_projection(operands: &[NumericTensor]) -> Result<NumericTensor, String> {
+    let output = reference_projection(operands)?
+        .into_iter()
+        .map(|value| {
+            let squared = value * value;
+            let cubed = squared * value;
+            let nonlinear = 0.044_715f32 * cubed;
+            let inner = value + nonlinear;
+            let scaled = 0.797_884_6f32 * inner;
+            let cdf = 1.0f32 + scaled.tanh();
+            let half_value = 0.5f32 * value;
+            half_value * cdf
+        })
+        .collect();
+    NumericTensor::new("output", vec![ROWS, PROJECTION_OUTPUTS], output)
+}
+
 fn dense_definition() -> Result<ProbeDefinition, String> {
     let operands = dense_operands()?.to_vec();
     Ok(ProbeDefinition {
@@ -481,6 +610,119 @@ fn softmax_definition() -> Result<ProbeDefinition, String> {
         candidate_algorithm: "iree-selected-attention-softmax-unobserved",
         reference: reference_softmax,
     })
+}
+
+fn layer_norm_definition() -> Result<ProbeDefinition, String> {
+    let operands = layer_norm_operands()?;
+    Ok(ProbeDefinition {
+        operation: LAYER_NORM_OPERATION,
+        entry: LAYER_NORM_ENTRY,
+        cache_key: "layer-norm-f32",
+        config_identity: format!(
+            "rows={ROWS};features={FEATURES};epsilon={LAYER_NORM_EPSILON:e};dtype=f32"
+        ),
+        mlir: emit_layer_norm_probe(
+            RowWiseProbeSpec {
+                rows: ROWS,
+                features: FEATURES,
+            },
+            LAYER_NORM_EPSILON,
+        )?,
+        operator_class: OperatorClass::LayerNorm,
+        rounding_boundaries: vec![
+            RoundingBoundary::OperatorInput,
+            RoundingBoundary::AccumulatorResult,
+            RoundingBoundary::BiasAdd,
+            RoundingBoundary::OperatorOutput,
+        ],
+        association: AssociationPolicy::BackendAlgorithm,
+        weights: vec![
+            resident_weight("layer_norm.weight", &operands[1]),
+            resident_weight("layer_norm.bias", &operands[2]),
+        ],
+        operands,
+        dynamic_operand_indices: vec![0],
+        output_shape: vec![ROWS, FEATURES],
+        comparison: ComparisonMode::AbsoluteRelative {
+            absolute: 2e-6,
+            relative: 2e-5,
+        },
+        reference_algorithm: "row-major-centered-square-sum-rsqrt-v1",
+        candidate_algorithm: "iree-selected-layer-norm-unobserved",
+        reference: reference_layer_norm,
+    })
+}
+
+fn activation_projection_definition(
+    operation: &'static str,
+    entry: &'static str,
+    cache_key: &'static str,
+    operator_class: OperatorClass,
+    candidate_algorithm: &'static str,
+    emitter: fn(DenseMatmulProbeSpec) -> Result<String, String>,
+    reference: fn(&[NumericTensor]) -> Result<NumericTensor, String>,
+) -> Result<ProbeDefinition, String> {
+    let operands = projection_operands()?;
+    let spec = DenseMatmulProbeSpec {
+        rows: ROWS,
+        outputs: PROJECTION_OUTPUTS,
+        contraction: FEATURES,
+    };
+    Ok(ProbeDefinition {
+        operation,
+        entry,
+        cache_key,
+        config_identity: format!(
+            "rows={ROWS};outputs={PROJECTION_OUTPUTS};contraction={FEATURES};dtype=f32"
+        ),
+        mlir: emitter(spec)?,
+        operator_class,
+        rounding_boundaries: vec![
+            RoundingBoundary::OperatorInput,
+            RoundingBoundary::AccumulatorResult,
+            RoundingBoundary::ActivationResult,
+            RoundingBoundary::OperatorOutput,
+        ],
+        association: AssociationPolicy::BackendAlgorithm,
+        weights: vec![resident_weight(
+            &format!("{cache_key}.weight"),
+            &operands[1],
+        )],
+        operands,
+        dynamic_operand_indices: vec![0],
+        output_shape: vec![ROWS, PROJECTION_OUTPUTS],
+        comparison: ComparisonMode::AbsoluteRelative {
+            absolute: 3e-6,
+            relative: 3e-5,
+        },
+        reference_algorithm: "row-major-projection-then-activation-v1",
+        candidate_algorithm,
+        reference,
+    })
+}
+
+fn silu_projection_definition() -> Result<ProbeDefinition, String> {
+    activation_projection_definition(
+        SILU_PROJECTION_OPERATION,
+        SILU_PROJECTION_ENTRY,
+        "silu-projection-f32",
+        OperatorClass::SiluProjection,
+        "iree-selected-silu-projection-unobserved",
+        emit_silu_projection_probe,
+        reference_silu_projection,
+    )
+}
+
+fn gelu_projection_definition() -> Result<ProbeDefinition, String> {
+    activation_projection_definition(
+        GELU_PROJECTION_OPERATION,
+        GELU_PROJECTION_ENTRY,
+        "gelu-projection-f32",
+        OperatorClass::GeluProjection,
+        "iree-selected-gelu-projection-unobserved",
+        emit_gelu_projection_probe,
+        reference_gelu_projection,
+    )
 }
 
 fn checked_output_bytes(shape: &[usize]) -> Result<usize, String> {
@@ -638,6 +880,9 @@ pub fn run_core_operator_probes(device: &str) -> Result<Vec<NumericOracleReport>
         residual_definition,
         rms_norm_definition,
         softmax_definition,
+        layer_norm_definition,
+        silu_projection_definition,
+        gelu_projection_definition,
     ]
     .into_iter()
     .map(|definition| execute_probe(device, definition()?))
@@ -686,5 +931,24 @@ mod tests {
         assert!(decode_f32(&[0, 0, 0]).is_err());
         assert!(checked_output_bytes(&[1, 0]).is_err());
         assert!(checked_output_bytes(&[usize::MAX, 2]).is_err());
+    }
+
+    #[test]
+    fn canonical_layer_norm_and_activation_projections_are_finite() {
+        let layer_norm = layer_norm_operands().unwrap();
+        assert!(
+            reference_layer_norm(&layer_norm)
+                .unwrap()
+                .values()
+                .iter()
+                .all(|value| value.is_finite())
+        );
+        let projection = projection_operands().unwrap();
+        for output in [
+            reference_silu_projection(&projection).unwrap(),
+            reference_gelu_projection(&projection).unwrap(),
+        ] {
+            assert!(output.values().iter().all(|value| value.is_finite()));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- centralize LayerNorm, RMSNorm, exact/tanh GELU, SiLU, and stable softmax decompositions so production vision emitters and bounded probes share the same materialization order
- route the Qwen2-VL and shared vision attention/normalization/activation paths through those helpers without changing capability predicates or tolerances
- expand the in-process CPU IREE suite from four to seven probes with LayerNorm, SiLU projection, and GELU projection contracts
- align the DeepStack ABI assertion with the already-shipped adapter-mode C signature

## Numeric evidence

The local-task CPU IREE suite passed all 7 operations and 48 output elements. Dense matmul, residual add, RMSNorm, attention softmax, LayerNorm, and SiLU projection were bit-identical to their canonical references. GELU projection had maximum absolute error 4.7683716e-7 within the unchanged 3e-6 absolute / 3e-5 relative contract. The pre-existing dense contract SHA-256 and VMFB fingerprint remained unchanged.

Every report remains claim=canonical-decomposition and production_qualified=false. This PR does not advertise or qualify any model family.

## Validation

- cargo fmt --all -- --check
- cargo check -p mlxcel-xla --features micro-oracle
- cargo test -p mlxcel-xla (241 passed, 11 ignored)
- cargo clippy -p mlxcel-xla --all-targets --features micro-oracle (repository-baseline warnings only)
- cargo run --quiet --example xla_numeric_probe --features xla-micro-oracle -- local-task
- git diff --check

Refs #932