### PR TITLE
feat(xla): add explicit CUDA prefix scan contract

### DIFF
--- a/src/lib/mlxcel-xla/src/emitter/numeric_ops.rs
+++ b/src/lib/mlxcel-xla/src/emitter/numeric_ops.rs
@@ -36,6 +36,8 @@ pub(crate) const SILU_PROJECTION_MODULE: &str = "numeric_silu_projection";
 pub(crate) const SILU_PROJECTION_ENTRY: &str = "numeric_silu_projection.main";
 pub(crate) const GELU_PROJECTION_MODULE: &str = "numeric_gelu_projection";
 pub(crate) const GELU_PROJECTION_ENTRY: &str = "numeric_gelu_projection.main";
+pub(crate) const PREFIX_SUM_MODULE: &str = "numeric_cuda_prefix_sum";
+pub(crate) const PREFIX_SUM_ENTRY: &str = "numeric_cuda_prefix_sum.main";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct DenseMatmulProbeSpec {
@@ -218,6 +220,127 @@ pub(crate) fn stable_softmax(builder: &mut Builder, value: &Val, axis: usize) ->
     builder.divide(&exponentials, &sum)
 }
 
+fn slice_axis(builder: &mut Builder, value: &Val, axis: usize, start: usize, limit: usize) -> Val {
+    let ranges = value
+        .ty
+        .shape
+        .iter()
+        .enumerate()
+        .map(|(current, &size)| {
+            if current == axis {
+                (start, limit)
+            } else {
+                (0, size)
+            }
+        })
+        .collect::<Vec<_>>();
+    builder.slice(value, &ranges)
+}
+
+fn zeros_like(builder: &mut Builder, value: &Val) -> Val {
+    let zero = builder.const_f32(0.0);
+    builder.broadcast(&zero, &[], value.ty.shape.clone())
+}
+
+fn inclusive_scan_32_f32(builder: &mut Builder, value: &Val, axis: usize) -> Val {
+    assert_eq!(value.ty.elt, "f32");
+    assert_eq!(value.ty.shape[axis], 32);
+    let zero = builder.const_f32(0.0);
+    let mut result = value.clone();
+    for offset in [1, 2, 4, 8, 16] {
+        let prior = slice_axis(builder, &result, axis, 0, 32 - offset);
+        let mut low = vec![0; result.ty.shape.len()];
+        let high = low.clone();
+        low[axis] = offset;
+        let prior = builder.pad(&prior, &zero, &low, &high);
+        result = builder.add(&result, &prior);
+    }
+    result
+}
+
+fn exclusive_from_inclusive_32_f32(builder: &mut Builder, inclusive: &Val, axis: usize) -> Val {
+    let prior = slice_axis(builder, inclusive, axis, 0, 31);
+    let zero = builder.const_f32(0.0);
+    let mut low = vec![0; inclusive.ty.shape.len()];
+    let high = low.clone();
+    low[axis] = 1;
+    builder.pad(&prior, &zero, &low, &high)
+}
+
+/// Match MLX CUDA's one-block contiguous inclusive-scan association schedule.
+///
+/// Each logical thread scans four adjacent values serially, each 32-thread
+/// warp uses staged shuffle-up additions, and the warp totals are scanned by
+/// the first warp. The helper accepts `[rows, width]` f32 input with a static
+/// width no larger than the kernel's 4,096-value one-block limit.
+pub(crate) fn mlx_cuda_prefix_sum_2d(builder: &mut Builder, value: &Val) -> Val {
+    assert_eq!(value.ty.elt, "f32");
+    assert_eq!(
+        value.ty.shape.len(),
+        2,
+        "CUDA prefix sum input must be rank-2"
+    );
+    let rows = value.ty.shape[0];
+    let width = value.ty.shape[1];
+    assert!(
+        (1..=4096).contains(&width),
+        "CUDA prefix sum supports one scan block"
+    );
+    let padded_width = width.div_ceil(128) * 128;
+    let padded = if padded_width == width {
+        value.clone()
+    } else {
+        let zero = builder.const_f32(0.0);
+        builder.pad(value, &zero, &[0, 0], &[0, padded_width - width])
+    };
+    let threads = padded_width / 4;
+    let warps = threads / 32;
+    let grouped = builder.reshape(&padded, vec![rows, threads, 4]);
+    let value0 = slice_axis(builder, &grouped, 2, 0, 1);
+    let value1 = slice_axis(builder, &grouped, 2, 1, 2);
+    let value2 = slice_axis(builder, &grouped, 2, 2, 3);
+    let value3 = slice_axis(builder, &grouped, 2, 3, 4);
+    let local0 = value0;
+    let local1 = builder.add(&value1, &local0);
+    let local2 = builder.add(&value2, &local1);
+    let local3 = builder.add(&value3, &local2);
+    let first_half = builder.concatenate(&local0, &local1, 2);
+    let second_half = builder.concatenate(&local2, &local3, 2);
+    let local = builder.concatenate(&first_half, &second_half, 2);
+
+    let thread_sums = builder.reshape(&local3, vec![rows, warps, 32]);
+    let thread_inclusive = inclusive_scan_32_f32(builder, &thread_sums, 2);
+    let thread_exclusive = exclusive_from_inclusive_32_f32(builder, &thread_inclusive, 2);
+
+    // The MLX kernel forms a warp total as the exclusive last-lane prefix plus
+    // the current last-lane value. Keep that distinct association boundary.
+    let prior_last = slice_axis(builder, &thread_exclusive, 2, 31, 32);
+    let current_last = slice_axis(builder, &thread_sums, 2, 31, 32);
+    let warp_totals = builder.add(&prior_last, &current_last);
+    let warp_totals = builder.reshape(&warp_totals, vec![rows, warps]);
+    let zero = builder.const_f32(0.0);
+    let warp_totals = builder.pad(&warp_totals, &zero, &[0, 0], &[0, 32 - warps]);
+    let warp_inclusive = inclusive_scan_32_f32(builder, &warp_totals, 1);
+    let warp_exclusive = exclusive_from_inclusive_32_f32(builder, &warp_inclusive, 1);
+    let warp_exclusive = slice_axis(builder, &warp_exclusive, 1, 0, warps);
+
+    let local = builder.reshape(&local, vec![rows, warps, 32, 4]);
+    let explicit_zero = zeros_like(builder, &local);
+    let local = builder.add(&local, &explicit_zero);
+    let warp_exclusive = builder.reshape(&warp_exclusive, vec![rows, warps, 1, 1]);
+    let warp_exclusive = builder.broadcast(&warp_exclusive, &[0, 1, 2, 3], local.ty.shape.clone());
+    let with_warp_prefix = builder.add(&local, &warp_exclusive);
+    let thread_exclusive = builder.reshape(&thread_exclusive, vec![rows, warps, 32, 1]);
+    let thread_exclusive = builder.broadcast(
+        &thread_exclusive,
+        &[0, 1, 2, 3],
+        with_warp_prefix.ty.shape.clone(),
+    );
+    let scanned = builder.add(&with_warp_prefix, &thread_exclusive);
+    let scanned = builder.reshape(&scanned, vec![rows, padded_width]);
+    slice_axis(builder, &scanned, 1, 0, width)
+}
+
 /// Emit `output[rows, outputs] = input[rows, contraction] @
 /// weight[outputs, contraction]^T` with f32 inputs, accumulation, and result.
 pub(crate) fn emit_dense_matmul_probe(spec: DenseMatmulProbeSpec) -> Result<String, String> {
@@ -393,6 +516,31 @@ pub(crate) fn emit_gelu_projection_probe(spec: DenseMatmulProbeSpec) -> Result<S
     emit_activation_projection_probe(spec, GELU_PROJECTION_MODULE, tanh_gelu)
 }
 
+/// Emit the explicit MLX CUDA one-block contiguous inclusive-scan schedule.
+pub(crate) fn emit_prefix_sum_probe(spec: RowWiseProbeSpec) -> Result<String, String> {
+    let spec = spec.validate("prefix sum")?;
+    if spec.features > 4096 {
+        return Err(format!(
+            "prefix sum probe width {} exceeds the one-block CUDA limit 4096",
+            spec.features
+        ));
+    }
+    let dummy_ty = Ty::f32(vec![1]);
+    let input_ty = Ty::f32(vec![spec.rows, spec.features]);
+    let input = Builder::arg(1, input_ty.clone());
+    let mut builder = Builder::new();
+    let output = mlx_cuda_prefix_sum_2d(&mut builder, &input);
+    Ok(format!(
+        "module @{PREFIX_SUM_MODULE} {{\n  \
+         func.func public @main(%arg0: {dummy_ty}, %arg1: {input_ty}) -> {input_ty} {{\n\
+         {body}    return {output} : {input_ty}\n  }}\n}}\n",
+        dummy_ty = dummy_ty.render(),
+        input_ty = input_ty.render(),
+        body = builder.body(),
+        output = output.name,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -555,5 +703,31 @@ mod tests {
         let body = builder.body();
         assert!(body.contains("chlo.erf"));
         assert!(!body.contains("stablehlo.tanh"));
+    }
+
+    #[test]
+    fn prefix_sum_probe_pins_cuda_hierarchical_association() {
+        let graph = emit_prefix_sum_probe(RowWiseProbeSpec {
+            rows: 2,
+            features: 130,
+        })
+        .unwrap();
+        assert!(graph.starts_with("module @numeric_cuda_prefix_sum {"));
+        assert_eq!(graph.matches("stablehlo.add").count(), 17);
+        assert_eq!(graph.matches("stablehlo.concatenate").count(), 3);
+        assert!(!graph.contains("stablehlo.reduce"));
+        assert!(!graph.contains("stablehlo.reduce_window"));
+        assert!(!graph.contains("stablehlo.convert"));
+    }
+
+    #[test]
+    fn prefix_sum_probe_rejects_multi_block_width() {
+        assert!(
+            emit_prefix_sum_probe(RowWiseProbeSpec {
+                rows: 1,
+                features: 4097,
+            })
+            .is_err()
+        );
     }
 }

--- a/src/lib/mlxcel-xla/src/numeric_probe.rs
+++ b/src/lib/mlxcel-xla/src/numeric_probe.rs
@@ -27,9 +27,10 @@ use crate::aux::{
 use crate::aux_manifest::{AuxiliaryArtifactContract, ensure_qualified_auxiliary_artifact};
 use crate::emitter::numeric_ops::{
     DENSE_MATMUL_ENTRY, DenseMatmulProbeSpec, GELU_PROJECTION_ENTRY, LAYER_NORM_ENTRY,
-    RESIDUAL_ADD_ENTRY, RMS_NORM_ENTRY, RowWiseProbeSpec, SILU_PROJECTION_ENTRY, SOFTMAX_ENTRY,
-    emit_dense_matmul_probe, emit_gelu_projection_probe, emit_layer_norm_probe,
-    emit_residual_add_probe, emit_rms_norm_probe, emit_silu_projection_probe, emit_softmax_probe,
+    PREFIX_SUM_ENTRY, RESIDUAL_ADD_ENTRY, RMS_NORM_ENTRY, RowWiseProbeSpec, SILU_PROJECTION_ENTRY,
+    SOFTMAX_ENTRY, emit_dense_matmul_probe, emit_gelu_projection_probe, emit_layer_norm_probe,
+    emit_prefix_sum_probe, emit_residual_add_probe, emit_rms_norm_probe,
+    emit_silu_projection_probe, emit_softmax_probe,
 };
 use crate::iree::{cached_vmfb_path, compile_one_to, iree_compile_bin, target_flags};
 use crate::numeric_dtype_contract::{NumericDType, WeightExecution};
@@ -51,12 +52,15 @@ const FEATURES: usize = 4;
 const RMS_EPSILON: f32 = 1e-5;
 const LAYER_NORM_EPSILON: f32 = 1e-5;
 const PROJECTION_OUTPUTS: usize = 3;
+const PREFIX_ROWS: usize = 2;
+const PREFIX_WIDTH: usize = 130;
 const RESIDUAL_OPERATION: &str = "micro-oracle.residual-add.f32";
 const RMS_NORM_OPERATION: &str = "micro-oracle.rms-norm.f32";
 const SOFTMAX_OPERATION: &str = "micro-oracle.attention-softmax.f32";
 const LAYER_NORM_OPERATION: &str = "micro-oracle.layer-norm.f32";
 const SILU_PROJECTION_OPERATION: &str = "micro-oracle.silu-projection.f32";
 const GELU_PROJECTION_OPERATION: &str = "micro-oracle.gelu-projection.f32";
+const PREFIX_SUM_OPERATION: &str = "micro-oracle.cuda-prefix-sum.f32";
 
 struct ProbeDefinition {
     operation: &'static str,
@@ -483,6 +487,106 @@ fn reference_gelu_projection(operands: &[NumericTensor]) -> Result<NumericTensor
     NumericTensor::new("output", vec![ROWS, PROJECTION_OUTPUTS], output)
 }
 
+fn prefix_sum_operands() -> Result<Vec<NumericTensor>, String> {
+    let mut values = Vec::with_capacity(PREFIX_ROWS * PREFIX_WIDTH);
+    for row in 0..PREFIX_ROWS {
+        let sign = if row == 0 { 1.0 } else { -1.0 };
+        for position in 0..PREFIX_WIDTH {
+            let thread = position / 4;
+            let lane = position % 4;
+            let value = match (thread % 3, lane) {
+                (1, 0) => 1.0,
+                (1, _) => 0.0,
+                (_, 0) => 100_000_000.0,
+                (_, 1) => 1.0,
+                (_, 2) => -100_000_000.0,
+                (_, 3) => 0.0,
+                _ => unreachable!(),
+            };
+            values.push(sign * value);
+        }
+    }
+    Ok(vec![NumericTensor::new(
+        "input",
+        vec![PREFIX_ROWS, PREFIX_WIDTH],
+        values,
+    )?])
+}
+
+fn inclusive_scan_32_reference(mut values: [f32; 32]) -> [f32; 32] {
+    for offset in [1, 2, 4, 8, 16] {
+        let prior = values;
+        for lane in offset..32 {
+            values[lane] = prior[lane] + prior[lane - offset];
+        }
+    }
+    values
+}
+
+fn reference_cuda_prefix_row(row: &[f32]) -> Vec<f32> {
+    let width = row.len();
+    let padded_width = width.div_ceil(128) * 128;
+    let threads = padded_width / 4;
+    let warps = threads / 32;
+    let mut padded = vec![0.0f32; padded_width];
+    padded[..width].copy_from_slice(row);
+    let mut local = vec![0.0f32; padded_width];
+    let mut thread_sums = vec![0.0f32; threads];
+    for (thread, thread_sum) in thread_sums.iter_mut().enumerate() {
+        let offset = thread * 4;
+        local[offset] = padded[offset];
+        local[offset + 1] = padded[offset + 1] + local[offset];
+        local[offset + 2] = padded[offset + 2] + local[offset + 1];
+        local[offset + 3] = padded[offset + 3] + local[offset + 2];
+        *thread_sum = local[offset + 3];
+    }
+
+    let mut thread_exclusive = vec![0.0f32; threads];
+    let mut warp_totals = [0.0f32; 32];
+    for (warp, warp_total) in warp_totals.iter_mut().enumerate().take(warps) {
+        let base = warp * 32;
+        let values: [f32; 32] = thread_sums[base..base + 32]
+            .try_into()
+            .expect("full CUDA warp");
+        let inclusive = inclusive_scan_32_reference(values);
+        thread_exclusive[base + 1..base + 32].copy_from_slice(&inclusive[..31]);
+        *warp_total = thread_exclusive[base + 31] + thread_sums[base + 31];
+    }
+    let warp_inclusive = inclusive_scan_32_reference(warp_totals);
+    let mut warp_exclusive = [0.0f32; 32];
+    warp_exclusive[1..].copy_from_slice(&warp_inclusive[..31]);
+
+    let mut output = Vec::with_capacity(width);
+    for (position, local_value) in local.iter().copied().enumerate().take(width) {
+        let thread = position / 4;
+        let warp = thread / 32;
+        let with_warp_prefix = local_value + warp_exclusive[warp];
+        output.push(with_warp_prefix + thread_exclusive[thread]);
+    }
+    output
+}
+
+fn reference_prefix_sum(operands: &[NumericTensor]) -> Result<NumericTensor, String> {
+    let [input] = operands else {
+        return Err(format!(
+            "CUDA prefix sum reference requires 1 operand, got {}",
+            operands.len()
+        ));
+    };
+    if input.shape() != [PREFIX_ROWS, PREFIX_WIDTH] {
+        return Err(format!(
+            "CUDA prefix sum reference shape mismatch: input {:?}",
+            input.shape()
+        ));
+    }
+    let output = input
+        .values()
+        .chunks_exact(PREFIX_WIDTH)
+        .flat_map(reference_cuda_prefix_row)
+        .collect();
+    NumericTensor::new("output", vec![PREFIX_ROWS, PREFIX_WIDTH], output)
+}
+
 fn dense_definition() -> Result<ProbeDefinition, String> {
     let operands = dense_operands()?.to_vec();
     Ok(ProbeDefinition {
@@ -725,6 +829,36 @@ fn gelu_projection_definition() -> Result<ProbeDefinition, String> {
     )
 }
 
+fn prefix_sum_definition() -> Result<ProbeDefinition, String> {
+    Ok(ProbeDefinition {
+        operation: PREFIX_SUM_OPERATION,
+        entry: PREFIX_SUM_ENTRY,
+        cache_key: "cuda-prefix-sum-f32",
+        config_identity: format!(
+            "rows={PREFIX_ROWS};width={PREFIX_WIDTH};values-per-thread=4;warp=32;block-limit=4096;dtype=f32"
+        ),
+        mlir: emit_prefix_sum_probe(RowWiseProbeSpec {
+            rows: PREFIX_ROWS,
+            features: PREFIX_WIDTH,
+        })?,
+        operator_class: OperatorClass::PrefixReduction,
+        rounding_boundaries: vec![
+            RoundingBoundary::OperatorInput,
+            RoundingBoundary::AccumulatorResult,
+            RoundingBoundary::OperatorOutput,
+        ],
+        association: AssociationPolicy::CudaOneBlockScan,
+        operands: prefix_sum_operands()?,
+        weights: vec![dummy_weight("cuda_prefix_sum")],
+        dynamic_operand_indices: vec![0],
+        output_shape: vec![PREFIX_ROWS, PREFIX_WIDTH],
+        comparison: ComparisonMode::ExactBits,
+        reference_algorithm: "mlx-cuda-one-block-contiguous-scan-v1",
+        candidate_algorithm: "explicit-mlx-cuda-one-block-contiguous-scan-v1",
+        reference: reference_prefix_sum,
+    })
+}
+
 fn checked_output_bytes(shape: &[usize]) -> Result<usize, String> {
     shape.iter().try_fold(size_of::<f32>(), |bytes, dimension| {
         if *dimension == 0 {
@@ -883,6 +1017,7 @@ pub fn run_core_operator_probes(device: &str) -> Result<Vec<NumericOracleReport>
         layer_norm_definition,
         silu_projection_definition,
         gelu_projection_definition,
+        prefix_sum_definition,
     ]
     .into_iter()
     .map(|definition| execute_probe(device, definition()?))
@@ -950,5 +1085,29 @@ mod tests {
         ] {
             assert!(output.values().iter().all(|value| value.is_finite()));
         }
+    }
+
+    #[test]
+    fn cuda_prefix_reference_is_hierarchical_not_naive_sequential() {
+        let operands = prefix_sum_operands().unwrap();
+        let output = reference_prefix_sum(&operands).unwrap();
+        assert!(output.values().iter().all(|value| value.is_finite()));
+
+        let mut naive = Vec::with_capacity(PREFIX_ROWS * PREFIX_WIDTH);
+        for row in operands[0].values().chunks_exact(PREFIX_WIDTH) {
+            let mut accumulator = 0.0f32;
+            naive.extend(row.iter().map(|value| {
+                accumulator += value;
+                accumulator
+            }));
+        }
+        assert!(
+            output
+                .values()
+                .iter()
+                .zip(naive)
+                .any(|(cuda, sequential)| cuda.to_bits() != sequential.to_bits()),
+            "cancellation-sensitive fixture must distinguish the CUDA block schedule"
+        );
     }
 }

--- a/src/lib/mlxcel-xla/src/operator_numeric_contract.rs
+++ b/src/lib/mlxcel-xla/src/operator_numeric_contract.rs
@@ -118,6 +118,7 @@ pub(crate) enum AssociationPolicy {
     Sequential,
     PairwiseTree,
     PrefixSequential,
+    CudaOneBlockScan,
     BackendAlgorithm,
 }
 
@@ -127,6 +128,7 @@ impl AssociationPolicy {
             Self::Sequential => "sequential",
             Self::PairwiseTree => "pairwise-tree",
             Self::PrefixSequential => "prefix-sequential",
+            Self::CudaOneBlockScan => "cuda-one-block-scan",
             Self::BackendAlgorithm => "backend-algorithm",
         }
     }
@@ -497,6 +499,32 @@ mod tests {
         assert!(first.canonical_identity().starts_with(SCHEMA));
         assert!(first.canonical_identity().contains("id=block.0"));
         assert!(first.canonical_identity().contains("algorithm=qmm_sm80_r2"));
+    }
+
+    #[test]
+    fn cuda_one_block_scan_association_is_explicit_identity() {
+        let scan = OperatorNumericContract::new(
+            "audio.cumulative_sum",
+            OperatorClass::PrefixReduction,
+            CheckpointDType::F32,
+            NumericDType::F32,
+            NumericDType::F32,
+            NumericDType::F32,
+            [
+                RoundingBoundary::OperatorInput,
+                RoundingBoundary::AccumulatorResult,
+                RoundingBoundary::OperatorOutput,
+            ],
+            AssociationPolicy::CudaOneBlockScan,
+            WeightExecution::Dense,
+            None,
+            backend(),
+        )
+        .unwrap();
+        let identity = OperatorNumericContractSet::new([scan])
+            .unwrap()
+            .canonical_identity();
+        assert!(identity.contains("association=cuda-one-block-scan"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an explicit cuda-one-block-scan association identity for operator-level numeric contracts
- extract the MLX CUDA contiguous inclusive-scan schedule into a shared f32 helper with four values per logical thread, 32-thread staged warp scans, and the 4,096-value one-block bound
- add a mutation-sensitive emitter test and a cancellation-sensitive width-130 reference that distinguishes this hierarchy from naive sequential accumulation
- extend the real in-process CPU IREE suite with the prefix-sum operation so the schedule can be validated independently of the blocked Gemma3n SSCP convolution

## Numeric evidence

The local-task CPU IREE suite passed all 8 operations and 308 output elements. The new prefix-sum probe passed all 260 values bit-exactly with operator contract SHA-256 c94424ce10b6be52ff653654c4b16f6e769d4dc6c19a592d5a0a5dfa54177f40. All seven existing operation contract hashes remained unchanged.

Every report remains claim=canonical-decomposition and production_qualified=false. This PR does not advertise or qualify Gemma3n audio or any other model family.

## Validation

- cargo fmt --all -- --check
- cargo check -p mlxcel-xla --features micro-oracle
- cargo test -p mlxcel-xla --features micro-oracle (276 passed, 12 ignored)
- cargo clippy -p mlxcel-xla --all-targets --features micro-oracle (repository-baseline warnings only)
- cargo run --quiet --example xla_numeric_probe --features xla-micro-oracle -- local-task
- git diff --check

Refs #932
Refs #878