### PR TITLE
fix: edit tap formula stanzas by name instead of line position

### DIFF
--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -95,10 +95,49 @@ jobs:
           cd homebrew-tap
           VERSION="${{ env.VERSION_NO_V }}"
 
-          gsed -i "s/^  version .*/  version \"${VERSION}\"/" Formula/mlxcel.rb
+          # Each stanza is matched by name, never by line position. The previous
+          # version of this step rewrote "whatever line follows the url" as the
+          # sha256, which held only while the url lived inside an `on_macos`
+          # block. Once the tap moved the url to the top level with `version`
+          # between url and sha256, that edit overwrote the `version` stanza and
+          # left the stale sha256 in place, producing a formula with no version
+          # and two sha256 lines. See lablup/homebrew-tap 9969ec4.
+          #
+          # The guards below assume mlxcel ships exactly one artifact, so the
+          # formula holds exactly one of each stanza. If that ever stops being
+          # true the run fails here instead of silently editing the wrong line.
+          for stanza in version url sha256; do
+            count=$(grep -c "^[[:space:]]*${stanza} " Formula/mlxcel.rb || true)
+            if [ "$count" -ne 1 ]; then
+              echo "::error::Expected exactly one \`${stanza}\` stanza in Formula/mlxcel.rb, found ${count}. Refusing to edit."
+              exit 1
+            fi
+          done
 
-          gsed -i "s|https://github.com/.*/mlxcel-macos-aarch64.zip|${mac_url}|" Formula/mlxcel.rb
-          gsed -i "/mlxcel-macos-aarch64.zip\"/!b;n;c\      sha256 \"${mac_sha}\"" Formula/mlxcel.rb
+          gsed -i "s|^\([[:space:]]*\)version .*|\1version \"${VERSION}\"|" Formula/mlxcel.rb
+          gsed -i "s|^\([[:space:]]*\)url .*|\1url \"${mac_url}\"|" Formula/mlxcel.rb
+          gsed -i "s|^\([[:space:]]*\)sha256 .*|\1sha256 \"${mac_sha}\"|" Formula/mlxcel.rb
+
+      - name: Validate updated formula
+        run: |
+          cd homebrew-tap
+          echo "=== Formula/mlxcel.rb ==="
+          cat Formula/mlxcel.rb
+
+          # Catches malformed output before it reaches the tap: a syntax error,
+          # a duplicated or misindented stanza, or a version/sha256 that did not
+          # take. `brew style` is the same check the tap is expected to pass.
+          ruby -c Formula/mlxcel.rb
+          brew style Formula/mlxcel.rb
+
+          grep -q "^  version \"${{ env.VERSION_NO_V }}\"$" Formula/mlxcel.rb || {
+            echo "::error::version stanza did not update to ${{ env.VERSION_NO_V }}."
+            exit 1
+          }
+          grep -q "^  sha256 \"${mac_sha}\"$" Formula/mlxcel.rb || {
+            echo "::error::sha256 stanza did not update to ${mac_sha}."
+            exit 1
+          }
 
       - name: Commit and push changes to tap
         run: |


### PR DESCRIPTION
## Problem

The bump step rewrote the sha256 by **line position**:

```sh
gsed -i "/mlxcel-macos-aarch64.zip\"/!b;n;c\      sha256 \"${mac_sha}\"" Formula/mlxcel.rb
```

It matched the url line, advanced one line (`n`), and replaced whatever it landed on (`c\`). That only held while the url sat inside an `on_macos` block with sha256 directly beneath it.

lablup/homebrew-tap `3da2813` moved the url to the top level so the formula would still load on Linux, which put `version` between url and sha256. The next bump (v0.4.3, `9969ec4`) therefore overwrote the `version` stanza with the new sha256 at a six-space indent and left the stale v0.4.2 sha256 below it:

```ruby
  url ".../v0.4.3/mlxcel-macos-aarch64.zip"
      sha256 "dea8a5c2..."   # new hash, wrong indent, replaced `version`
  sha256 "83a0b702..."       # stale v0.4.2 hash, and this is the one that wins
```

The formula lost its `version` stanza and carried two `sha256` lines, so `brew install mlxcel` failed the checksum. It stayed broken in the tap for three days because nothing validated the result.

## Fix

Each stanza is matched by name rather than by position. A guard first asserts the formula holds exactly one `version`, `url`, and `sha256` line, so any future layout these substitutions cannot express fails the run instead of corrupting the file.

A validation step then runs `ruby -c` and `brew style` on the result and greps back the version and sha256 it just wrote.

## Verification

Against the current `Formula/mlxcel.rb`, the guard counts 1 for each stanza, the substitutions produce the expected url/version/sha256, and `brew style` reports no offenses.

Replaying the broken v0.4.3 commit through the new step fails twice over:

| check | broken file |
|---|---|
| guard | `version -> 0`, `sha256 -> 2` (fails) |
| `brew style` | 2 offenses, `Layout/IndentationConsistency` |
| `ruby -c` | Syntax OK (passes) |

`ruby -c` alone passes on the broken file, which is why syntax checking is not sufficient on its own.

Note the check runs as `cd homebrew-tap && brew style Formula/mlxcel.rb` because brew only applies formula cops when the path lies under a `Formula` directory.

## Related

- lablup/homebrew-tap `10facb2` repairs the formula and cask that these bots reverted.
- lablup/backend.ai-go has a companion PR for its own stale cask and formula templates.