### PR TITLE
ci: restore the rust-toolchain pin and stop dependabot from bumping it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,14 @@ updates:
       time: "09:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
+    ignore:
+      # The tag on this action is the Rust toolchain version it installs, not a
+      # version of the action itself, so it has to track `rust-toolchain.toml`'s
+      # `channel` and cannot be bumped independently. Dependabot cannot know that
+      # and raised it to a Rust release that does not exist, which broke the
+      # cargo-fmt job on every Rust-touching PR until it was reverted. Bump both
+      # by hand, together.
+      - dependency-name: "dtolnay/rust-toolchain"
     labels:
       - "type:dependency"
       - "type:chore"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@1.100.0
+      # The tag on this action IS the toolchain version it installs, so it must
+      # track `rust-toolchain.toml`'s `channel` rather than be bumped on its own.
+      # Dependabot reads the tag as an ordinary version and will try to raise it;
+      # `.github/dependabot.yml` ignores this action for that reason.
+      - uses: dtolnay/rust-toolchain@1.93.1
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check


### PR DESCRIPTION
## What broke

`bdad23287` (a dependabot PR) raised `dtolnay/rust-toolchain` from `@1.93.1` to `@1.100.0` in the `cargo-fmt` job. For that action the git tag is the **Rust toolchain version it installs**, not a version of the action itself, so the job dies at `rustup toolchain install` with `error: could not download nonexistent rust version 1.100.0-x86_64-unknown-linux-gnu` and a 404. `cargo fmt` never runs.

The effect is repo-wide and unrelated to any PR's contents: `cargo-fmt` has been red on every Rust-touching pull request since that commit landed. It was observed independently on the branches for #947, #931, and the molmo XLA work, all with a locally clean `cargo fmt --all -- --check`. It did not show up as a red `main` because the later `main` run touched no Rust and the `changes` filter skipped the job.

## The fix

Restore `@1.93.1`, which is what `rust-toolchain.toml` pins. That file's own comment explains why the version is fixed rather than floating on `stable`: two checkouts formatted at different times otherwise pick up different rustfmt and clippy releases and diverge purely by timing.

The action tag and `rust-toolchain.toml` have to move together, and dependabot cannot know that, so the `github-actions` ecosystem now ignores `dtolnay/rust-toolchain`. The reason is recorded inline in both `.github/workflows/ci.yml` and `.github/dependabot.yml` so the next person to read either file sees why the pin looks stale and does not "helpfully" raise it again.

## Validation

`grep` confirms `ci.yml` now requests `@1.93.1` and `rust-toolchain.toml` declares `channel = "1.93.1"`. The real check is this PR's own `cargo-fmt` run: it exercises the changed workflow, so a green job here is direct evidence the toolchain resolves.

Closes #952
