### PR TITLE
fix(lora): make adapter weight fusion Conv1D-layout aware

### DIFF
--- a/src/distributed/pipeline/partial_loading_adapter_tests.rs
+++ b/src/distributed/pipeline/partial_loading_adapter_tests.rs
@@ -458,3 +458,121 @@ fn stage_filtered_fusion_is_noop_on_empty_stage_adapter() {
     let val = mlxcel_core::item_f32(&sum);
     assert!((val - 10.0).abs() < 1e-5, "base drifted: {val}");
 }
+
+// ---------------------------------------------------------------------------
+// apply_stage_lora_adapter — the pipeline-parallel entry point
+//
+// This path never goes through `load_model_with_adapter`, so it needs its own
+// coverage of the base-weight layout guard rather than inheriting the non-PP
+// path's.
+// ---------------------------------------------------------------------------
+
+fn ones_tensor(rows: usize, cols: usize) -> OwnedTensor {
+    let mut data = Vec::with_capacity(rows * cols * 4);
+    for _ in 0..rows * cols {
+        data.extend_from_slice(&1.0f32.to_le_bytes());
+    }
+    OwnedTensor {
+        dtype: safetensors::tensor::Dtype::F32,
+        shape: vec![rows, cols],
+        data,
+    }
+}
+
+/// Write an mlx-lm-style adapter directory: `lora_a` is `[in, rank]` and
+/// `lora_b` is `[rank, out]`, both all ones, so every delta entry is
+/// `scale * rank`.
+fn write_adapter_dir(dir: &std::path::Path, layer: &str, in_f: usize, rank: usize, out_f: usize) {
+    use std::collections::HashMap;
+
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("adapter_config.json"),
+        format!(
+            r#"{{"fine_tune_type": "lora", "lora_parameters": {{"rank": {rank}, "scale": 1.0}}}}"#
+        ),
+    )
+    .unwrap();
+
+    let mut tensors: HashMap<String, OwnedTensor> = HashMap::new();
+    tensors.insert(format!("{layer}.lora_a"), ones_tensor(in_f, rank));
+    tensors.insert(format!("{layer}.lora_b"), ones_tensor(rank, out_f));
+    safetensors::serialize_to_file(&tensors, None, &dir.join("adapters.safetensors")).unwrap();
+}
+
+fn sum_of(weights: &mlxcel_core::weights::WeightMap, key: &str) -> f32 {
+    let w = weights.get(key).unwrap();
+    mlxcel_core::eval(w);
+    let sum = mlxcel_core::sum_all(w);
+    mlxcel_core::eval(&sum);
+    mlxcel_core::item_f32(&sum)
+}
+
+#[test]
+fn stage_local_fusion_rejects_a_conv1d_layout_stage_weight_map() {
+    // A pipeline stage holding a raw HuggingFace GPT-2 export: `c_proj` is
+    // square, so the delta broadcasts and nothing downstream would notice the
+    // transposed accumulation. The stage path must refuse it just like the
+    // single-process path does.
+    let args = crate::models::gpt2::tests::tiny_args();
+    let mut base = crate::models::gpt2::tests::raw_hf_weights(&args, "transformer.");
+    let h = args.n_embd;
+
+    let tmp_dir = temp_dir("conv1d");
+    write_adapter_dir(&tmp_dir, "transformer.h.0.attn.c_proj", h, 2, h);
+
+    let filter = LayerFilter {
+        layer_range: 0..1,
+        has_embedding: true,
+        has_lm_head: true,
+    };
+
+    let key = "transformer.h.0.attn.c_proj.weight";
+    let before = sum_of(&base, key);
+
+    let err = match crate::lora::apply_stage_lora_adapter(&mut base, &tmp_dir, &filter) {
+        Ok(()) => panic!("a Conv1D-layout stage weight map must not fuse"),
+        Err(err) => err.to_string(),
+    };
+    assert!(err.contains("Conv1D"), "{err}");
+    assert!(err.contains(key), "{err}");
+
+    let after = sum_of(&base, key);
+    assert!(
+        (before - after).abs() < 1e-6,
+        "stage weights must be left untouched: {before} -> {after}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[test]
+fn stage_local_fusion_still_applies_to_an_out_in_stage_weight_map() {
+    // Positive control: the layout guard must not disturb the layout every
+    // other family (and every MLX conversion) actually ships.
+    use mlxcel_core::weights::WeightMap;
+
+    let mut base: WeightMap = WeightMap::new();
+    base.insert(
+        "model.layers.0.self_attn.q_proj.weight".into(),
+        mlxcel_core::ones(&[4, 4], mlxcel_core::dtype::FLOAT32),
+    );
+
+    let tmp_dir = temp_dir("outin");
+    write_adapter_dir(&tmp_dir, "model.layers.0.self_attn.q_proj", 4, 2, 4);
+
+    let filter = LayerFilter {
+        layer_range: 0..1,
+        has_embedding: false,
+        has_lm_head: false,
+    };
+
+    crate::lora::apply_stage_lora_adapter(&mut base, &tmp_dir, &filter)
+        .expect("stage fusion succeeds on an [out, in] weight map");
+
+    // 16 entries of 1.0, plus a delta of scale (1.0) * rank (2) everywhere.
+    let fused = sum_of(&base, "model.layers.0.self_attn.q_proj.weight");
+    assert!((fused - 48.0).abs() < 1e-4, "unexpected fused sum: {fused}");
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}

--- a/src/distributed/pipeline/partial_loading_adapter_tests.rs
+++ b/src/distributed/pipeline/partial_loading_adapter_tests.rs
@@ -460,7 +460,7 @@ fn stage_filtered_fusion_is_noop_on_empty_stage_adapter() {
 }
 
 // ---------------------------------------------------------------------------
-// apply_stage_lora_adapter — the pipeline-parallel entry point
+// apply_stage_lora_adapter: the pipeline-parallel entry point
 //
 // This path never goes through `load_model_with_adapter`, so it needs its own
 // coverage of the base-weight layout guard rather than inheriting the non-PP

--- a/src/lora/loader.rs
+++ b/src/lora/loader.rs
@@ -94,7 +94,24 @@ pub fn fuse_lora_weights(
 /// the filter will produce fusion updates — `base_weights` entries that are
 /// not referenced by any `lora_a` / `lora_b` pair are left untouched.
 ///
-/// Used by: [`fuse_lora_weights`], `apply_lora_adapters_in_place`
+/// # Layout
+///
+/// Every delta this produces is in `mlxcel_core` `Linear` layout,
+/// `[out_features, in_features]`. The base weight has to be in the same layout
+/// for the element-wise add to mean anything, and nothing upstream guarantees
+/// that: `load_model_with_adapter` fuses into the raw safetensors map and only
+/// afterwards constructs the model, which is where a family such as GPT-2
+/// transposes its on-disk `Conv1D` projections. Both mismatch cases are checked
+/// here, before any operand reaches MLX. See
+/// [`reject_conv1d_layout_fusion`] and the shape guard in the fusion loop.
+///
+/// # Errors
+///
+/// Returns an error, leaving `base_weights` untouched, when the base weight map
+/// stores its projections transposed, or when a resolved base weight and its
+/// delta disagree on shape.
+///
+/// Used by: [`fuse_lora_weights`], [`apply_stage_lora_adapter`]
 pub fn fuse_lora_weights_into(
     base_weights: &mut WeightMap,
     adapter_weights: &WeightMap,
@@ -118,6 +135,15 @@ pub fn fuse_lora_weights_into(
             lora_pairs.entry(base_name).or_insert((None, None)).1 = Some(mlxcel_core::copy(weight));
         }
         // Ignore other weights (like scales for DoRA)
+    }
+
+    // Refuse up front if the base weight map still stores its projections
+    // transposed. This has to be a whole-map verdict taken before the first
+    // `add`, because the square `attn.c_proj` is precisely the case where the
+    // two shapes agree and the corruption would be silent.
+    if !lora_pairs.is_empty() {
+        let adapter_layers: Vec<&str> = lora_pairs.keys().map(String::as_str).collect();
+        reject_conv1d_layout_fusion(base_weights, &adapter_layers)?;
     }
 
     // Fuse each LoRA pair with the corresponding base weight
@@ -145,6 +171,34 @@ pub fn fuse_lora_weights_into(
         // Compute the LoRA delta: scale * (lora_b @ lora_a)
         let delta = compute_lora_delta(&lora_a, &lora_b, scale)?;
 
+        // Never hand mismatched operands to `mlxcel_core::add`. MLX broadcasts,
+        // so a mismatch is not reliably an error: a base weight that is one
+        // broadcastable step away from the delta fuses cleanly and produces a
+        // silently wrong tensor. And where broadcasting genuinely fails, `add`
+        // is not declared fallible in the cxx bridge, so the MLX C++ exception
+        // is `std::terminate` and takes the process down instead of returning
+        // an error the caller can report.
+        let base_shape = mlxcel_core::array_shape(base_weight);
+        let delta_shape = mlxcel_core::array_shape(&delta);
+        if base_shape != delta_shape {
+            let is_transpose = base_shape.len() == 2
+                && delta_shape.len() == 2
+                && base_shape[0] == delta_shape[1]
+                && base_shape[1] == delta_shape[0];
+            let hint = if is_transpose {
+                " The two are exact transposes of each other, so this base weight is stored \
+                 transposed relative to the [out_features, in_features] layout every LoRA delta \
+                 uses. Fusion does not transpose an operand to make the shapes agree; convert the \
+                 checkpoint to [out_features, in_features] instead."
+            } else {
+                ""
+            };
+            anyhow::bail!(
+                "LoRA shape mismatch fusing adapter layer {base_name} into base weight \
+                 {base_weight_name}: base is {base_shape:?}, delta is {delta_shape:?}.{hint}"
+            );
+        }
+
         // Fuse: W_fused = W_base + delta
         let fused = mlxcel_core::add(base_weight, &delta);
 
@@ -152,6 +206,147 @@ pub fn fuse_lora_weights_into(
     }
 
     Ok(())
+}
+
+/// Suffixes of the transformer-block projections that a HuggingFace GPT-2
+/// export stores as a `Conv1D`, i.e. `[in_features, out_features]`, transposed
+/// relative to the `[out_features, in_features]` layout `Linear` weights and
+/// every LoRA delta use.
+///
+/// GPT-2 is the only family in this tree that ships checkpoints in that layout.
+/// `Gpt2Layout` (`src/models/gpt2.rs`) transposes them, but it does so at model
+/// construction, which runs *after* fusion on the `load_model_with_adapter`
+/// path, so fusion has to recognise the on-disk layout itself.
+const CONV1D_PROJECTION_SUFFIXES: [&str; 4] = [
+    ".attn.c_attn.weight",
+    ".attn.c_proj.weight",
+    ".mlp.c_fc.weight",
+    ".mlp.c_proj.weight",
+];
+
+/// Whether `key` names one of the [`CONV1D_PROJECTION_SUFFIXES`] projections of
+/// a transformer block, returning the suffix that matched.
+///
+/// The `h.<N>.` block index is required, not just the suffix: GPT-BigCode uses
+/// the same `c_attn` / `c_proj` / `c_fc` names while storing them `[out, in]`
+/// (`src/models/gpt_bigcode.rs`), and an unrelated `...c_proj.weight` elsewhere
+/// in a checkpoint must never be mistaken for a Conv1D projection.
+fn conv1d_projection_suffix(key: &str) -> Option<&'static str> {
+    CONV1D_PROJECTION_SUFFIXES.into_iter().find(|suffix| {
+        let Some(rest) = key.strip_suffix(suffix) else {
+            return false;
+        };
+        let Some((head, index)) = rest.rsplit_once("h.") else {
+            return false;
+        };
+        // `h.` has to start a path segment, so that `blah.0.attn.c_proj.weight`
+        // (which also contains the substring `h.`) is not read as block 0.
+        (head.is_empty() || head.ends_with('.'))
+            && !index.is_empty()
+            && index.bytes().all(|b| b.is_ascii_digit())
+    })
+}
+
+/// Evidence that a base weight map still stores its transformer-block
+/// projections in the HuggingFace `Conv1D` layout.
+struct Conv1dLayoutEvidence {
+    /// The fused QKV projection key the verdict was taken from.
+    key: String,
+    /// Its `[n_embd, 3 * n_embd]` shape.
+    shape: Vec<i32>,
+}
+
+/// Detect whether `base_weights` is still in the HuggingFace `Conv1D` layout.
+///
+/// The only usable signal is the fused QKV projection: `h.<N>.attn.c_attn.weight`
+/// is `[n_embd, 3 * n_embd]` on disk and `[3 * n_embd, n_embd]` once transposed,
+/// and the two can never be confused. That is what makes a whole-map verdict
+/// necessary as well as possible — the square `attn.c_proj` carries no layout
+/// signal of its own, so only its `c_attn` sibling can say which way round it is
+/// stored. This is the same probe `Gpt2Layout::detect` uses, minus the config,
+/// which fusion does not have.
+///
+/// Returns the lexicographically smallest matching key so the diagnostic is
+/// stable from run to run ([`WeightMap`] is a `HashMap`).
+fn detect_conv1d_projection_layout(base_weights: &WeightMap) -> Option<Conv1dLayoutEvidence> {
+    let mut evidence: Option<Conv1dLayoutEvidence> = None;
+
+    for (key, weight) in base_weights {
+        let Some(block) = key.strip_suffix(".attn.c_attn.weight") else {
+            continue;
+        };
+        if conv1d_projection_suffix(key).is_none() {
+            continue;
+        }
+        // A quantized projection is packed, so its stored shape matches neither
+        // float layout and carries no layout signal. `Gpt2Layout::detect`
+        // short-circuits on exactly this check.
+        if base_weights.contains_key(&format!("{block}.attn.c_attn.scales")) {
+            continue;
+        }
+        let shape = mlxcel_core::array_shape(weight);
+        let [rows, cols] = shape.as_slice() else {
+            continue;
+        };
+        // `i64` because `rows * 3` overflows `i32` for a hostile shape.
+        if *rows <= 0 || i64::from(*cols) != i64::from(*rows) * 3 {
+            continue;
+        }
+        if evidence.as_ref().is_none_or(|found| *key < found.key) {
+            evidence = Some(Conv1dLayoutEvidence {
+                key: key.clone(),
+                shape,
+            });
+        }
+    }
+
+    evidence
+}
+
+/// Refuse to fuse into a base weight map whose projections are still stored
+/// transposed, before any operand reaches MLX.
+///
+/// `adapter_layers` are the layer paths the adapter targets, i.e. the
+/// `lora_a` / `lora_b` key stems. Only targets that resolve to a projection
+/// actually stored in `Conv1D` layout are reported; an adapter that touches
+/// nothing transposed (an embedding-only adapter, say) fuses as before.
+///
+/// This deliberately does not repair anything. Transposing the delta would fix
+/// the non-square projections and leave the square `attn.c_proj` just as wrong,
+/// because a square weight gives no evidence about which orientation was
+/// intended. Reporting is the only honest outcome.
+fn reject_conv1d_layout_fusion(base_weights: &WeightMap, adapter_layers: &[&str]) -> Result<()> {
+    let Some(evidence) = detect_conv1d_projection_layout(base_weights) else {
+        return Ok(());
+    };
+
+    let mut affected: Vec<String> = Vec::new();
+    for layer in adapter_layers {
+        let resolved = find_base_weight_name(layer, base_weights)?;
+        if conv1d_projection_suffix(&resolved).is_some() && base_weights.contains_key(&resolved) {
+            affected.push(resolved);
+        }
+    }
+    if affected.is_empty() {
+        return Ok(());
+    }
+    affected.sort();
+
+    let Conv1dLayoutEvidence { key, shape } = evidence;
+    anyhow::bail!(
+        "LoRA fusion refused: this checkpoint still stores its transformer-block projections in \
+         the HuggingFace Conv1D layout [in_features, out_features], while every LoRA delta is \
+         [out_features, in_features]. Detected from {key} with shape {shape:?}, which is \
+         [n_embd, 3 * n_embd]. Adapter targets landing on a Conv1D-stored projection: {}. \
+         Adding the delta as it stands is not safe: the non-square projections cannot broadcast \
+         and abort the process inside MLX, and the square attention c_proj broadcasts cleanly \
+         while accumulating the transpose of the intended update, with no error anywhere. \
+         Transposing an operand is not a repair either, because a square projection carries no \
+         signal about which orientation was meant. Use a checkpoint whose projections are already \
+         stored [out_features, in_features], such as an mlx-community GPT-2 conversion, or load \
+         the model without the adapter.",
+        affected.join(", "),
+    );
 }
 
 /// Find the base weight name that corresponds to a LoRA layer name
@@ -292,7 +487,10 @@ pub fn apply_lora_adapters(base_weights: &WeightMap, adapter_path: &Path) -> Res
 /// place, and never materializes per-layer deltas for other stages.
 ///
 /// The caller is expected to pass the stage's [`LayerFilter`]. The
-/// adapter configuration is validated exactly as in the non-PP path.
+/// adapter configuration is validated exactly as in the non-PP path, and so is
+/// the base weight layout: this path never goes through
+/// `load_model_with_adapter`, but it shares [`fuse_lora_weights_into`], so it
+/// inherits the same layout and shape guards.
 ///
 /// Used by: pipeline stage initialization (family stage executors)
 pub fn apply_stage_lora_adapter(
@@ -342,67 +540,5 @@ pub fn apply_stage_lora_adapter(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_compute_lora_delta_mlx_format() {
-        // mlx-lm format: a=(in=4, rank=2), b=(rank=2, out=3)
-        // Result should be (out=3, in=4)
-        let lora_a = mlxcel_core::from_slice_f32(&[1.0f32; 8], &[4, 2]);
-        let lora_b = mlxcel_core::from_slice_f32(&[1.0f32; 6], &[2, 3]);
-        let scale = 1.0;
-
-        let delta = compute_lora_delta(&lora_a, &lora_b, scale).unwrap();
-        assert_eq!(mlxcel_core::array_shape(&delta), vec![3, 4]);
-    }
-
-    #[test]
-    fn test_compute_lora_delta_peft_format() {
-        // PEFT format: a=(rank=2, in=4), b=(out=3, rank=2)
-        // Result should be (out=3, in=4)
-        let lora_a = mlxcel_core::from_slice_f32(&[1.0f32; 8], &[2, 4]);
-        let lora_b = mlxcel_core::from_slice_f32(&[1.0f32; 6], &[3, 2]);
-        let scale = 1.0;
-
-        let delta = compute_lora_delta(&lora_a, &lora_b, scale).unwrap();
-        assert_eq!(mlxcel_core::array_shape(&delta), vec![3, 4]);
-    }
-
-    #[test]
-    fn test_fuse_lora_weights_basic() {
-        // Create base weights
-        let mut base_weights = WeightMap::new();
-        base_weights.insert(
-            "layer.weight".to_string(),
-            mlxcel_core::ones(&[3, 4], mlxcel_core::dtype::FLOAT32),
-        );
-
-        // Create adapter weights (mlx-lm format)
-        let mut adapter_weights = WeightMap::new();
-        adapter_weights.insert(
-            "layer.lora_a".to_string(),
-            mlxcel_core::ones(&[4, 2], mlxcel_core::dtype::FLOAT32),
-        );
-        adapter_weights.insert(
-            "layer.lora_b".to_string(),
-            mlxcel_core::ones(&[2, 3], mlxcel_core::dtype::FLOAT32),
-        );
-
-        let fused = fuse_lora_weights(&base_weights, &adapter_weights, 1.0).unwrap();
-
-        // Should have the same key
-        assert!(fused.contains_key("layer.weight"));
-        let fused_weight = fused.get("layer.weight").unwrap();
-        let shape = mlxcel_core::array_shape(fused_weight);
-        assert_eq!(shape, vec![3, 4]);
-
-        // Original was all 1s, delta should be scale * (lora_b.T @ lora_a.T) = 2s matrix
-        // So fused should be > 1.0
-        mlxcel_core::eval(fused_weight);
-        let sum = mlxcel_core::sum_all(fused_weight);
-        mlxcel_core::eval(&sum);
-        let sum_val = mlxcel_core::item_f32(&sum);
-        assert!(sum_val > 12.0); // 3*4 = 12 base + delta > 0
-    }
-}
+#[path = "loader_tests.rs"]
+mod tests;

--- a/src/lora/loader.rs
+++ b/src/lora/loader.rs
@@ -261,7 +261,7 @@ struct Conv1dLayoutEvidence {
 /// The only usable signal is the fused QKV projection: `h.<N>.attn.c_attn.weight`
 /// is `[n_embd, 3 * n_embd]` on disk and `[3 * n_embd, n_embd]` once transposed,
 /// and the two can never be confused. That is what makes a whole-map verdict
-/// necessary as well as possible — the square `attn.c_proj` carries no layout
+/// necessary as well as possible: the square `attn.c_proj` carries no layout
 /// signal of its own, so only its `c_attn` sibling can say which way round it is
 /// stored. This is the same probe `Gpt2Layout::detect` uses, minus the config,
 /// which fusion does not have.

--- a/src/lora/loader_tests.rs
+++ b/src/lora/loader_tests.rs
@@ -1,0 +1,385 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for LoRA delta computation and weight fusion.
+//!
+//! The layout tests run against the same GPT-2 checkpoint fixtures the model
+//! loader is tested with (`src/models/gpt2_tests.rs`), rather than against
+//! hand-rolled shapes. That matters here: the defect these tests cover is that
+//! a Conv1D-layout checkpoint has *plausible* shapes, so a fixture invented
+//! locally would be assuming the very thing under test. Reusing
+//! `raw_hf_weights` means the map is the one `Gpt2Layout::detect` is separately
+//! proven to classify as a raw HuggingFace export, and each test re-asserts that
+//! classification before exercising fusion.
+
+use super::*;
+use crate::models::gpt2::Gpt2Layout;
+use crate::models::gpt2::tests::{mlx_converted_weights, raw_hf_weights, tiny_args};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build an mlx-lm-convention adapter pair for `layer`: `lora_a` is
+/// `[in_features, rank]` and `lora_b` is `[rank, out_features]`, both all ones,
+/// so the resulting delta is `scale * rank` in every position and a fused sum is
+/// exactly predictable.
+fn lora_pair(layer: &str, in_features: i32, rank: i32, out_features: i32) -> WeightMap {
+    let mut adapter = WeightMap::new();
+    adapter.insert(
+        format!("{layer}.lora_a"),
+        mlxcel_core::ones(&[in_features, rank], mlxcel_core::dtype::FLOAT32),
+    );
+    adapter.insert(
+        format!("{layer}.lora_b"),
+        mlxcel_core::ones(&[rank, out_features], mlxcel_core::dtype::FLOAT32),
+    );
+    adapter
+}
+
+fn tensor_sum(weight: &MlxArray) -> f32 {
+    mlxcel_core::eval(weight);
+    let sum = mlxcel_core::sum_all(weight);
+    mlxcel_core::eval(&sum);
+    mlxcel_core::item_f32(&sum)
+}
+
+// ---------------------------------------------------------------------------
+// Delta orientation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compute_lora_delta_mlx_format() {
+    // mlx-lm format: a=(in=4, rank=2), b=(rank=2, out=3)
+    // Result should be (out=3, in=4)
+    let lora_a = mlxcel_core::from_slice_f32(&[1.0f32; 8], &[4, 2]);
+    let lora_b = mlxcel_core::from_slice_f32(&[1.0f32; 6], &[2, 3]);
+    let scale = 1.0;
+
+    let delta = compute_lora_delta(&lora_a, &lora_b, scale).unwrap();
+    assert_eq!(mlxcel_core::array_shape(&delta), vec![3, 4]);
+}
+
+#[test]
+fn test_compute_lora_delta_peft_format() {
+    // PEFT format: a=(rank=2, in=4), b=(out=3, rank=2)
+    // Result should be (out=3, in=4)
+    let lora_a = mlxcel_core::from_slice_f32(&[1.0f32; 8], &[2, 4]);
+    let lora_b = mlxcel_core::from_slice_f32(&[1.0f32; 6], &[3, 2]);
+    let scale = 1.0;
+
+    let delta = compute_lora_delta(&lora_a, &lora_b, scale).unwrap();
+    assert_eq!(mlxcel_core::array_shape(&delta), vec![3, 4]);
+}
+
+#[test]
+fn test_fuse_lora_weights_basic() {
+    // Create base weights
+    let mut base_weights = WeightMap::new();
+    base_weights.insert(
+        "layer.weight".to_string(),
+        mlxcel_core::ones(&[3, 4], mlxcel_core::dtype::FLOAT32),
+    );
+
+    // Create adapter weights (mlx-lm format)
+    let mut adapter_weights = WeightMap::new();
+    adapter_weights.insert(
+        "layer.lora_a".to_string(),
+        mlxcel_core::ones(&[4, 2], mlxcel_core::dtype::FLOAT32),
+    );
+    adapter_weights.insert(
+        "layer.lora_b".to_string(),
+        mlxcel_core::ones(&[2, 3], mlxcel_core::dtype::FLOAT32),
+    );
+
+    let fused = fuse_lora_weights(&base_weights, &adapter_weights, 1.0).unwrap();
+
+    // Should have the same key
+    assert!(fused.contains_key("layer.weight"));
+    let fused_weight = fused.get("layer.weight").unwrap();
+    let shape = mlxcel_core::array_shape(fused_weight);
+    assert_eq!(shape, vec![3, 4]);
+
+    // Original was all 1s, delta should be scale * (lora_b.T @ lora_a.T) = 2s matrix
+    // So fused should be > 1.0
+    assert!(tensor_sum(fused_weight) > 12.0); // 3*4 = 12 base + delta > 0
+}
+
+// ---------------------------------------------------------------------------
+// Conv1D projection recognition
+// ---------------------------------------------------------------------------
+
+#[test]
+fn conv1d_projection_suffix_matches_only_transformer_block_projections() {
+    for key in [
+        "h.0.attn.c_attn.weight",
+        "transformer.h.11.attn.c_proj.weight",
+        "model.h.3.mlp.c_fc.weight",
+        "model.transformer.h.7.mlp.c_proj.weight",
+    ] {
+        assert!(
+            conv1d_projection_suffix(key).is_some(),
+            "should match: {key}"
+        );
+    }
+
+    for key in [
+        // No block index at all.
+        "attn.c_proj.weight",
+        // `h.` is not a path segment here.
+        "blah.0.attn.c_proj.weight",
+        // A non-numeric block index.
+        "h.x.attn.c_proj.weight",
+        // Biases are 1-D and are never transposed at load.
+        "h.0.attn.c_proj.bias",
+        // A different family's projection.
+        "model.layers.0.self_attn.q_proj.weight",
+        "h.0.ln_1.weight",
+    ] {
+        assert!(
+            conv1d_projection_suffix(key).is_none(),
+            "should not match: {key}"
+        );
+    }
+}
+
+#[test]
+fn conv1d_layout_detection_reads_the_fused_qkv_projection() {
+    let args = tiny_args();
+
+    let raw = raw_hf_weights(&args, "");
+    let evidence = detect_conv1d_projection_layout(&raw).expect("raw export is Conv1D");
+    assert_eq!(evidence.key, "h.0.attn.c_attn.weight");
+    assert_eq!(
+        evidence.shape,
+        vec![args.n_embd as i32, 3 * args.n_embd as i32]
+    );
+
+    let converted = mlx_converted_weights(&args);
+    assert!(
+        detect_conv1d_projection_layout(&converted).is_none(),
+        "an already-transposed conversion must not be flagged"
+    );
+
+    // A checkpoint from any other family has no `c_attn` at all.
+    let mut other = WeightMap::new();
+    other.insert(
+        "model.layers.0.self_attn.q_proj.weight".into(),
+        mlxcel_core::ones(&[4, 4], mlxcel_core::dtype::FLOAT32),
+    );
+    assert!(detect_conv1d_projection_layout(&other).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Fusion against a real Conv1D-layout GPT-2 checkpoint
+// ---------------------------------------------------------------------------
+
+#[test]
+fn conv1d_checkpoint_rejects_fusion_into_the_square_attention_c_proj() {
+    // The case that produces no error today: base and delta are both
+    // [n_embd, n_embd], the add broadcasts, and the model silently runs
+    // `W + Dᵀ` after `conv1d_linear` transposes at construction time.
+    let args = tiny_args();
+    let mut base = raw_hf_weights(&args, "");
+    assert!(
+        Gpt2Layout::detect(&base, &args)
+            .expect("layout detected")
+            .conv1d,
+        "fixture must be a genuine raw HuggingFace Conv1D export"
+    );
+
+    let h = args.n_embd as i32;
+    let key = "h.0.attn.c_proj.weight";
+    let before = tensor_sum(base.get(key).unwrap());
+
+    // An mlxcel-convention adapter on the bare GPT-2 projection path, which is
+    // exactly the artifact that reaches this code.
+    let adapter = lora_pair("h.0.attn.c_proj", h, 2, h);
+    assert_eq!(
+        mlxcel_core::array_shape(base.get(key).unwrap()),
+        mlxcel_core::array_shape(
+            &compute_lora_delta(
+                adapter.get("h.0.attn.c_proj.lora_a").unwrap(),
+                adapter.get("h.0.attn.c_proj.lora_b").unwrap(),
+                1.0,
+            )
+            .unwrap()
+        ),
+        "the shapes agree, which is why a shape check alone cannot catch this"
+    );
+
+    let err = fuse_lora_weights_into(&mut base, &adapter, 1.0)
+        .expect_err("a Conv1D-layout square projection must not fuse")
+        .to_string();
+    assert!(err.contains("Conv1D"), "{err}");
+    assert!(err.contains(key), "{err}");
+    assert!(
+        err.contains("h.0.attn.c_attn.weight"),
+        "the error must name the evidence key: {err}"
+    );
+
+    let after = tensor_sum(base.get(key).unwrap());
+    assert!(
+        (before - after).abs() < 1e-6,
+        "the base weight must be left untouched: {before} -> {after}"
+    );
+}
+
+#[test]
+fn conv1d_checkpoint_rejects_every_non_square_projection_without_aborting() {
+    // On an unguarded build each of these reaches `mlxcel_core::add` with
+    // non-broadcastable operands, and the MLX C++ throw crosses a cxx shim that
+    // is not declared fallible, so the whole test binary dies with SIGABRT.
+    // Reaching the assertions at all is the evidence.
+    let args = tiny_args();
+    let h = args.n_embd as i32;
+    let ff = args.intermediate_size() as i32;
+
+    // (adapter layer, in_features, out_features) in Linear terms.
+    let cases = [
+        ("h.0.attn.c_attn", h, 3 * h),
+        ("h.0.mlp.c_fc", h, ff),
+        ("h.0.mlp.c_proj", ff, h),
+    ];
+
+    for (layer, in_features, out_features) in cases {
+        let mut base = raw_hf_weights(&args, "");
+        let adapter = lora_pair(layer, in_features, 2, out_features);
+
+        let err = match fuse_lora_weights_into(&mut base, &adapter, 0.5) {
+            Ok(()) => panic!("{layer} must not fuse"),
+            Err(err) => err.to_string(),
+        };
+        assert!(err.contains("Conv1D"), "{layer}: {err}");
+        assert!(err.contains(&format!("{layer}.weight")), "{layer}: {err}");
+    }
+}
+
+#[test]
+fn conv1d_checkpoint_reports_every_affected_projection_at_once() {
+    // A whole-adapter report, sorted, so the diagnostic does not depend on
+    // `WeightMap` iteration order.
+    let args = tiny_args();
+    let h = args.n_embd as i32;
+    let mut base = raw_hf_weights(&args, "transformer.");
+
+    let mut adapter = lora_pair("transformer.h.0.attn.c_proj", h, 2, h);
+    adapter.extend(lora_pair("transformer.h.0.attn.c_attn", h, 2, 3 * h));
+
+    let err = fuse_lora_weights_into(&mut base, &adapter, 1.0)
+        .expect_err("must not fuse")
+        .to_string();
+    assert!(
+        err.contains("transformer.h.0.attn.c_attn.weight, transformer.h.0.attn.c_proj.weight"),
+        "{err}"
+    );
+}
+
+#[test]
+fn conv1d_checkpoint_still_fuses_an_adapter_that_targets_nothing_transposed() {
+    // The verdict is whole-map, but the rejection is per-target: an adapter that
+    // never lands on a Conv1D-stored projection is unaffected.
+    let args = tiny_args();
+    let mut base = raw_hf_weights(&args, "");
+    let vocab = args.vocab_size as i32;
+    let h = args.n_embd as i32;
+    let before = tensor_sum(base.get("wte.weight").unwrap());
+
+    let rank = 2;
+    let adapter = lora_pair("wte", h, rank, vocab);
+    fuse_lora_weights_into(&mut base, &adapter, 0.5).expect("embedding fusion is unaffected");
+
+    let after = tensor_sum(base.get("wte.weight").unwrap());
+    let expected = before + 0.5 * rank as f32 * (vocab * h) as f32;
+    assert!(
+        (after - expected).abs() < 1e-2,
+        "after={after}, expected={expected}"
+    );
+}
+
+#[test]
+fn an_already_transposed_gpt2_checkpoint_still_fuses_correctly() {
+    // The guard must not misfire on the layout adapters are actually published
+    // against: an MLX conversion, whose projections are already [out, in].
+    let args = tiny_args();
+    let mut base = mlx_converted_weights(&args);
+    assert!(
+        !Gpt2Layout::detect(&base, &args)
+            .expect("layout detected")
+            .conv1d
+    );
+
+    let h = args.n_embd as i32;
+    let key = "model.h.0.attn.c_proj.weight";
+    let before = tensor_sum(base.get(key).unwrap());
+
+    let rank = 2;
+    let adapter = lora_pair("model.h.0.attn.c_proj", h, rank, h);
+    fuse_lora_weights_into(&mut base, &adapter, 0.5).expect("fusion succeeds");
+
+    // lora_a and lora_b are all ones, so every delta entry is scale * rank.
+    let after = tensor_sum(base.get(key).unwrap());
+    let expected = before + 0.5 * rank as f32 * (h * h) as f32;
+    assert!(
+        (after - expected).abs() < 1e-3,
+        "after={after}, expected={expected}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Generic shape guard (families with no Conv1D signal at all)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_transposed_base_weight_is_reported_instead_of_reaching_mlx_add() {
+    // No `c_attn` anywhere, so only the generic shape guard can catch this.
+    let mut base = WeightMap::new();
+    base.insert(
+        "model.layers.0.self_attn.q_proj.weight".into(),
+        mlxcel_core::ones(&[8, 4], mlxcel_core::dtype::FLOAT32),
+    );
+    // a=[in=8, rank=2], b=[rank=2, out=4] gives a [4, 8] delta.
+    let adapter = lora_pair("model.layers.0.self_attn.q_proj", 8, 2, 4);
+
+    let err = fuse_lora_weights_into(&mut base, &adapter, 1.0)
+        .expect_err("a transposed base weight must not fuse")
+        .to_string();
+    assert!(err.contains("[8, 4]") && err.contains("[4, 8]"), "{err}");
+    assert!(err.contains("transposes"), "{err}");
+    assert!(
+        err.contains("model.layers.0.self_attn.q_proj.weight"),
+        "{err}"
+    );
+
+    let unchanged = tensor_sum(base.get("model.layers.0.self_attn.q_proj.weight").unwrap());
+    assert!((unchanged - 32.0).abs() < 1e-6, "base drifted: {unchanged}");
+}
+
+#[test]
+fn a_mismatch_that_is_not_a_transpose_omits_the_transpose_hint() {
+    let mut base = WeightMap::new();
+    base.insert(
+        "model.layers.0.mlp.up_proj.weight".into(),
+        mlxcel_core::ones(&[8, 4], mlxcel_core::dtype::FLOAT32),
+    );
+    // a=[in=4, rank=2], b=[rank=2, out=4] gives a [4, 4] delta, which would
+    // broadcast against [8, 4] and silently corrupt every row.
+    let adapter = lora_pair("model.layers.0.mlp.up_proj", 4, 2, 4);
+
+    let err = fuse_lora_weights_into(&mut base, &adapter, 1.0)
+        .expect_err("a broadcastable mismatch must not fuse either")
+        .to_string();
+    assert!(err.contains("[8, 4]") && err.contains("[4, 4]"), "{err}");
+    assert!(!err.contains("transposes"), "{err}");
+}

--- a/src/models/gpt2.rs
+++ b/src/models/gpt2.rs
@@ -982,6 +982,10 @@ impl LanguageModel for Gpt2Model {
     }
 }
 
+// `pub(crate)` because the checkpoint-layout fixtures here are the canonical
+// description of a raw HuggingFace Conv1D export and an MLX conversion, and the
+// LoRA fusion tests (`src/lora/loader_tests.rs`) assert against the same maps
+// rather than re-deriving them.
 #[cfg(test)]
 #[path = "gpt2_tests.rs"]
-mod tests;
+pub(crate) mod tests;

--- a/src/models/gpt2_tests.rs
+++ b/src/models/gpt2_tests.rs
@@ -205,7 +205,7 @@ fn position_table_overflow_is_reported_exactly_at_the_boundary() {
 
 // Checkpoint layout detection.
 
-fn tiny_args() -> ModelArgs {
+pub(crate) fn tiny_args() -> ModelArgs {
     serde_json::from_str(
         r#"{
             "model_type": "gpt2",
@@ -248,7 +248,7 @@ fn zeros(shape: &[i32]) -> mlxcel_core::UniquePtr<mlxcel_core::MlxArray> {
 
 /// Raw HuggingFace GPT-2 export: no key prefix, Conv1D `[in, out]` weights,
 /// and the `h.N.attn.bias` causal-mask buffer present.
-fn raw_hf_weights(args: &ModelArgs, prefix: &str) -> WeightMap {
+pub(crate) fn raw_hf_weights(args: &ModelArgs, prefix: &str) -> WeightMap {
     let h = args.n_embd as i32;
     let ff = args.intermediate_size() as i32;
     let ctx = args.n_ctx as i32;
@@ -287,7 +287,7 @@ fn raw_hf_weights(args: &ModelArgs, prefix: &str) -> WeightMap {
 
 /// MLX conversion: `model.` prefix, weights already `[out, in]`, no mask
 /// buffer (the reference `sanitize` deleted it).
-fn mlx_converted_weights(args: &ModelArgs) -> WeightMap {
+pub(crate) fn mlx_converted_weights(args: &ModelArgs) -> WeightMap {
     let h = args.n_embd as i32;
     let ff = args.intermediate_size() as i32;
 


### PR DESCRIPTION
## Summary

LoRA weight fusion added a delta to a base tensor with no shape check and no notion of how the base was stored on disk. Deltas are always `[out_features, in_features]`; raw HuggingFace GPT-2 exports store their projections in the `Conv1D` layout `[in_features, out_features]`, and `Gpt2Layout` only transposes them at model construction, which runs after fusion on the `load_model_with_adapter` path. Fusion is now layout-aware and shape-checked, and it reports rather than guesses.

## The two failure modes this closes

The square attention `c_proj` (`[768, 768]` against a `[768, 768]` delta) broadcast cleanly, so the model silently ran `W + Dᵀ` instead of `W + D`. That is a different rank-r update of the same shape: no error, no warning, no shape anomaly, just wrong numbers. This is the case the issue was filed for, and it is the reason a shape check alone is not a fix.

The three non-square projections (`c_attn`, `c_fc`, MLP `c_proj`) could not broadcast, and `mlxcel_core::add` is not declared fallible in the cxx bridge, so the MLX C++ exception was an uncatchable `std::terminate` that killed the process instead of returning an error.

## What changed

- `src/lora/loader.rs`: `reject_conv1d_layout_fusion` takes a whole-map layout verdict before the first `add`. The verdict comes from the fused QKV projection, which is `[n_embd, 3 * n_embd]` on disk and `[3 * n_embd, n_embd]` once transposed and can never be confused; that sibling is the only evidence available, since the square `c_proj` carries no layout signal of its own. Quantized projections are skipped on the same `.scales` probe `Gpt2Layout::detect` uses, and the reported evidence key is the lexicographically smallest match so the diagnostic does not depend on `HashMap` order.
- `src/lora/loader.rs`: a shape guard compares base and delta before every `add` and returns an `anyhow::Error` naming the adapter layer, the base weight key and both shapes, with an added note when the two are exact transposes. This covers any future family that lands with a transposed on-disk layout.
- Nothing is auto-repaired. Transposing the delta would fix the non-square projections and leave the square one exactly as wrong, because a square weight carries no signal about which orientation was intended. Rejection is the only honest outcome, so the error says what to use instead.
- Both guards live in the shared primitive, so they cover the single-process path through `apply_lora_adapters` and the pipeline-parallel `apply_stage_lora_adapter`, which never goes through `load_model_with_adapter` and would have missed a fix applied at the loading layer.
- Both diagnostics are returned errors, not `tracing::warn!`, which is a no-op in the `mlxcel` CLI binary because only `src/server/startup.rs` installs a subscriber.
- Rejection is per-target, not blanket: an adapter that lands on nothing transposed (an embedding-only adapter, say) still fuses on a Conv1D checkpoint.
- `src/lora/loader_tests.rs` (new): the inline `mod tests` moved out to a sibling `_tests.rs` per the project convention, keeping `loader.rs` under the file-size limit, plus the new coverage.
- `src/models/gpt2.rs`, `src/models/gpt2_tests.rs`: the checkpoint-layout fixtures are now `pub(crate)` so the LoRA tests assert against the same maps instead of re-deriving them.

## Test plan

The layout tests fuse an mlxcel-convention (`.lora_a` / `.lora_b`) adapter against the raw HuggingFace GPT-2 fixtures from `src/models/gpt2_tests.rs`, reused rather than reinvented: a locally invented fixture would assume the very thing under test, whereas `raw_hf_weights` is the map `Gpt2Layout::detect` is separately proven to classify as a Conv1D export. Every layout test re-asserts that classification before touching fusion.

- [x] `conv1d_checkpoint_rejects_fusion_into_the_square_attention_c_proj` asserts base and delta shapes are equal before asserting the rejection, which is what demonstrates that a shape check alone cannot catch this case, and asserts the base tensor is left byte-unchanged.
- [x] `conv1d_checkpoint_rejects_every_non_square_projection_without_aborting` covers `c_attn`, `c_fc` and MLP `c_proj`. Reaching the assertions at all is the evidence: on an unguarded build each of these aborts the whole test binary with SIGABRT.
- [x] `an_already_transposed_gpt2_checkpoint_still_fuses_correctly` and `conv1d_checkpoint_still_fuses_an_adapter_that_targets_nothing_transposed` are positive controls asserting exact fused sums.
- [x] `stage_local_fusion_rejects_a_conv1d_layout_stage_weight_map` and `stage_local_fusion_still_applies_to_an_out_in_stage_weight_map` cover `apply_stage_lora_adapter` end to end through a real on-disk adapter directory.
- [x] `a_transposed_base_weight_is_reported_instead_of_reaching_mlx_add` and `a_mismatch_that_is_not_a_transpose_omits_the_transpose_hint` cover the generic guard on a family with no Conv1D signal.
- [x] `DEVELOPER_DIR=... cargo test --release --lib --features metal,accelerate lora` (20 passed)
- [x] `DEVELOPER_DIR=... cargo test --release --lib --features metal,accelerate partial_loading_adapter` (14 passed, including the pre-existing `stage_filtered_fusion_matches_full_fusion_on_stage_subset` parity test, so `[out, in]` behavior is unchanged)
- [x] `DEVELOPER_DIR=... cargo test --release --lib --features metal,accelerate models::gpt2` (25 passed)
- [x] `DEVELOPER_DIR=... cargo clippy --release --lib --tests --features metal,accelerate` (clean; the two `host_preprocessor` warnings are pre-existing on `main`)
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/ci/check_cross_repo_refs.py`

Closes #925
