### PR TITLE
fix(core): reject quantization params MLX would abort on, at load

### DIFF
--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -991,16 +991,32 @@ pub fn validate_quantization_params(group_size: i32, bits: i32) -> Result<(), St
              uncatchable abort at the first forward pass rather than a load error"
         ));
     }
-    if group_size < 1 {
+    if !(1..=MAX_QUANT_GROUP_SIZE).contains(&group_size) {
         return Err(format!(
-            "quantization.group_size ({group_size}) must be positive: it multiplies the scales \
-             width to reconstruct the input width inside every quantized kernel, and a \
-             non-positive value can match no real tensor, so MLX throws and that throw is an \
-             uncatchable abort rather than a load error"
+            "quantization.group_size ({group_size}) must be between 1 and {MAX_QUANT_GROUP_SIZE}: \
+             it multiplies the scales width to reconstruct the input width inside every quantized \
+             kernel, so a non-positive value can match no real tensor and an enormous one \
+             overflows that multiply. MLX evaluates scales.shape(-1) * group_size in C++ int, so \
+             an overflow there is undefined behavior reached before MLX can throw, and a throw \
+             would in any case cross the cxx bridge as an uncatchable abort rather than a load \
+             error"
         ));
     }
     Ok(())
 }
+
+/// Upper bound on a declared `group_size`.
+///
+/// This is an overflow bound, not an allowlist of the group sizes MLX supports.
+/// The largest group size any real checkpoint declares is 128 (MLX supports 16,
+/// 32, 64 and 128), and the widest model dimension in the supported set is under
+/// six figures, so 2^20 leaves four orders of magnitude of headroom over anything
+/// a genuine export can carry while keeping `num_groups * group_size` far inside
+/// i32 for any tensor that fits in memory. Without it, a declared `i32::MAX`
+/// survives to `quantized_matmul`, where MLX multiplies it by the scales width in
+/// C++ `int`: signed overflow, and therefore undefined behavior reached before
+/// the shape check that would have thrown.
+const MAX_QUANT_GROUP_SIZE: i32 = 1 << 20;
 
 /// Pick the quantization mode a `.biases`-carrying checkpoint implies.
 ///
@@ -1037,6 +1053,9 @@ pub fn infer_quantization_mode(has_biases: bool, group_size: i32, bits: i32) -> 
 ///   (per-path bit overrides, e.g. Qwen3.5/3.6 MoE gates); block-float trusts
 ///   the mode-fixed `bits` and re-derives `group_size` (e.g. minicpm-v mxfp4
 ///   stored at group_size 32 under a config default of 64),
+/// * returns `Err` for a declared `group_size` / `bits` pair that can describe
+///   no packing at all, before it looks at the shapes (issue #929) — see
+///   [`validate_quantization_params`],
 /// * returns `Err` with an actionable message when the affine shapes match no
 ///   valid bit width — the signature of a misdeclared / unsupported external
 ///   packing that must not be dequantized as standard affine and served as
@@ -1121,7 +1140,16 @@ pub fn reconcile_quantization_layout(
                 reconciled: false,
             });
         }
-        let in_features = packed_in * (32 / bits);
+        // `checked_mul` for symmetry with the affine path, which routes through
+        // `infer_quantization_bits`. `packed_in` comes from a real tensor so it
+        // cannot realistically overflow here, but an unchecked multiply in a
+        // config-driven load path is the wrong default.
+        let in_features = packed_in.checked_mul(32 / bits).ok_or_else(|| {
+            format!(
+                "Quantized weight shape overflow: packed_in={packed_in}, bits={bits}, \
+                 weight.shape={weight_shape:?}"
+            )
+        })?;
         if in_features % num_groups == 0 {
             let effective_group_size = in_features / num_groups;
             Ok(ReconciledQuant {
@@ -1174,6 +1202,7 @@ fn reconcile_quantization_layout_logged(
 /// The three tensor shapes a quantized weight is stored as, borrowed for
 /// validation. `biases` is `None` for the block-float modes, which carry no
 /// zero points.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QuantizedTensorShapes<'a> {
     pub weight: &'a [i32],
     pub scales: &'a [i32],
@@ -1196,9 +1225,17 @@ pub struct QuantizedTensorShapes<'a> {
 ///
 /// The width is reconstructed from the *effective* group size the loader will
 /// use, obtained from [`reconcile_quantization_layout`] rather than from the
-/// declared pair. Works for both a 2-D projection and a 3-D stacked expert
-/// tensor: only the last axis carries the packing, and the leading axes are
-/// required to agree between weight and scales.
+/// declared pair, and is checked twice: against the config width, and against
+/// the width the packed weight itself describes, which is MLX's own predicate
+/// and does not follow from the first check whenever the reconciler falls back
+/// to the declared `group_size`. Works for both a 2-D projection and a 3-D
+/// stacked expert tensor: only the last axis carries the packing, and the
+/// leading axes are required to agree between weight and scales.
+///
+/// Not covered: `validate_quantized_input` also rejects a `weight` whose dtype
+/// is not `uint32`. That is deliberately not checked here, because the in-tree
+/// test fixtures build packed weights as f32 and a dtype guard would reject them
+/// while a real checkpoint never trips it.
 ///
 /// `label` names the tensor in the rejection message; callers pass the weight
 /// prefix so the message points at a key the reader can find in the
@@ -1248,6 +1285,29 @@ pub fn validate_quantized_packing(
             described
                 .map(|d| d.to_string())
                 .unwrap_or_else(|| "an overflowing number of".to_string())
+        ));
+    }
+
+    // The check above compares only the SCALES side against the config. MLX
+    // compares the WEIGHT side against the scales side, and the two are not the
+    // same test: the block-float branch of the reconciler keeps the declared
+    // `group_size` in both of its fallbacks (`32 % bits != 0`, and
+    // `in_features % num_groups != 0`), so `groups * group_size` can hit the
+    // config width while the packed weight describes something else entirely.
+    // Mirror MLX's own predicate from `validate_quantized_input` in i64 so the
+    // multiply cannot wrap on a large plane. `layout.bits` is guaranteed
+    // non-zero because `reconcile_quantization_layout` bounds it above.
+    let packed_in = w_shape[w_shape.len() - 1];
+    let packed_width = i64::from(packed_in) * 32 / i64::from(layout.bits);
+    let claimed = i64::from(s_shape[s_shape.len() - 1]) * i64::from(layout.group_size);
+    if packed_width != claimed {
+        return Err(format!(
+            "unexpected {label}.weight shape {w_shape:?}: a packed width of {packed_in} at \
+             {}-bit describes an input width of {packed_width}, but {label}.scales {s_shape:?} at \
+             group_size {} describes {claimed}. MLX compares exactly these two in \
+             validate_quantized_input and throws on a mismatch, and that throw crosses the cxx \
+             bridge as an uncatchable abort at the first forward pass rather than a load error.",
+            layout.bits, layout.group_size
         ));
     }
 
@@ -4520,6 +4580,58 @@ mod tests {
         }
         assert!(validate_quantization_params(1, 1).is_ok());
         assert!(validate_quantization_params(1, 32).is_ok());
+
+        // `group_size` is bounded above as well, because it survives the
+        // block-float fallbacks unchanged and MLX multiplies it by the scales
+        // width in C++ `int`. An overflow there is undefined behavior reached
+        // before the shape check that would have thrown.
+        assert!(validate_quantization_params(MAX_QUANT_GROUP_SIZE, 4).is_ok());
+        for group_size in [MAX_QUANT_GROUP_SIZE + 1, i32::MAX] {
+            let err = validate_quantization_params(group_size, 4)
+                .expect_err("an unrepresentable group_size must be rejected");
+            assert!(err.contains("group_size"), "unhelpful error: {err}");
+        }
+    }
+
+    #[test]
+    fn quantized_packing_check_compares_the_weight_side_too() {
+        // The scales-side comparison alone is not MLX's test. The block-float
+        // reconciler keeps the declared group_size in both of its fallbacks, so
+        // `groups * group_size` can hit the config width while the packed weight
+        // describes something else. Here in_features = 8 * (32/4) = 64 does not
+        // divide by 3 groups, so the reconciler keeps group_size 32, the
+        // scales side reports 3 * 32 = 96 and matches the config, and only the
+        // weight side (8 * 32 / 4 = 64) catches it. MLX throws on exactly that.
+        let inconsistent = QuantizedTensorShapes {
+            weight: &[16, 8],
+            scales: &[16, 3],
+            biases: None,
+        };
+        let err = validate_quantized_packing("gate_proj", &inconsistent, 96, 32, 4, "mxfp4")
+            .expect_err("a packing MLX would reject must fail at load");
+        assert!(
+            err.contains("describes an input width of 64"),
+            "the message must name the weight-side width, got: {err}"
+        );
+
+        // The other block-float fallback, `32 % bits != 0`, keeps the declared
+        // group_size without inferring anything at all.
+        let odd_bits = QuantizedTensorShapes {
+            weight: &[16, 8],
+            scales: &[16, 3],
+            biases: None,
+        };
+        assert!(validate_quantized_packing("gate_proj", &odd_bits, 96, 32, 6, "mxfp4").is_err());
+
+        // A consistent block-float triple still passes: 32 packed columns at
+        // 4-bit describe 256, and 8 groups at group_size 32 describe 256.
+        let consistent = QuantizedTensorShapes {
+            weight: &[64, 32],
+            scales: &[64, 8],
+            biases: None,
+        };
+        validate_quantized_packing("gate_proj", &consistent, 256, 32, 4, "mxfp4")
+            .expect("a consistently packed mxfp4 tensor must load");
     }
 
     #[test]

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -262,15 +262,8 @@ impl QuantizedEmbedding {
         // thread an explicit mode (e.g. vision encoders, which always called
         // this affine default) load non-affine weights correctly instead of
         // aborting in quantized_matmul ("Biases must be provided for affine").
-        let mode = if weights.get(&format!("{}.biases", prefix)).is_some() {
-            "affine"
-        } else if bits == 8 {
-            "mxfp8"
-        } else if group_size == 16 {
-            "nvfp4"
-        } else {
-            "mxfp4"
-        };
+        let has_biases = weights.get(&format!("{}.biases", prefix)).is_some();
+        let mode = infer_quantization_mode(has_biases, group_size, bits);
         Self::from_weights_with_mode(weights, prefix, group_size, bits, mode)
     }
 
@@ -427,6 +420,21 @@ impl UnifiedEmbedding {
     /// Check if this is a quantized embedding
     pub fn is_quantized(&self) -> bool {
         matches!(self, Self::Quantized(_))
+    }
+
+    /// Borrow the quantized table, or `None` for the non-quantized variant.
+    ///
+    /// Load-time validators need the `scales` / `biases` shapes and the
+    /// *reconciled* `group_size` / `bits` to reconstruct the dequantized width
+    /// a packed table describes, which `is_quantized()` alone cannot give them.
+    ///
+    /// Used by: the shared `validate_embedding_table` guard (BailingMoe, Gpt2,
+    ///          GptBigCode, GptNeoX)
+    pub fn quantized(&self) -> Option<&QuantizedEmbedding> {
+        match self {
+            Self::Quantized(e) => Some(e),
+            Self::Regular(_) => None,
+        }
     }
 
     /// Produce an independent [`UnifiedEmbedding`] that shares the same
@@ -944,6 +952,77 @@ pub struct ReconciledQuant {
     pub reconciled: bool,
 }
 
+/// Reject declared quantization parameters that no tensor layout can describe,
+/// before they reach an MLX kernel.
+///
+/// MLX reconstructs a quantized matrix's unpacked input width as
+/// `w.shape(-1) * 32 / bits` and compares it against `scales.shape(-1) *
+/// group_size` (`validate_quantized_input`, reached from
+/// `extract_quantized_matmul_dims`, which gates `quantized_matmul`,
+/// `gather_qmm` and `dequantize` alike). At `bits == 0` that expression is a
+/// division by zero, which is undefined behavior with a platform split: on
+/// AArch64 the divide yields 0 and MLX throws `std::invalid_argument`, while on
+/// x86-64 the hardware raises `SIGFPE` and kills the process before any
+/// exception exists. Above 32 the quotient collapses toward zero and can match
+/// no real `scales` width, and a non-positive `group_size` makes the
+/// right-hand side unmatchable. Every one of those ends the process, because
+/// `quantized_matmul` and `dequantize` cross the cxx bridge as
+/// `UniquePtr<MlxArray>` rather than `Result`, so a C++ throw is an uncatchable
+/// `std::terminate` at the FIRST forward pass rather than a load error.
+///
+/// This is a bounds check rather than an allowlist of the widths MLX actually
+/// supports, and that is a real constraint rather than a stylistic preference:
+/// mlxcel deliberately re-derives an effective bit width from the tensor shapes
+/// when the declared one disagrees (see [`reconcile_quantization_layout`]), and
+/// an allowlist of `{2,3,4,5,6,8}` would reject the mixed-precision exports
+/// that behavior exists to serve. Only values that can describe no packing at
+/// all are refused.
+///
+/// Used by: every quantizing family through [`reconcile_quantization_layout`]
+///          (dense projections and quantized embeddings) and through
+///          `SwitchLinear::from_stacked_parts` (MoE experts), plus the
+///          family-level early diagnostics in BailingMoe, GptNeoX and Helium
+pub fn validate_quantization_params(group_size: i32, bits: i32) -> Result<(), String> {
+    if !(1..=32).contains(&bits) {
+        return Err(format!(
+            "quantization.bits ({bits}) must be between 1 and 32: MLX derives a quantized \
+             matrix's unpacked width as packed_in * 32 / bits, which divides by zero at 0 and \
+             collapses to zero above 32, and the resulting C++ throw crosses the cxx bridge as an \
+             uncatchable abort at the first forward pass rather than a load error"
+        ));
+    }
+    if group_size < 1 {
+        return Err(format!(
+            "quantization.group_size ({group_size}) must be positive: it multiplies the scales \
+             width to reconstruct the input width inside every quantized kernel, and a \
+             non-positive value can match no real tensor, so MLX throws and that throw is an \
+             uncatchable abort rather than a load error"
+        ));
+    }
+    Ok(())
+}
+
+/// Pick the quantization mode a `.biases`-carrying checkpoint implies.
+///
+/// Affine stores zero-point `biases`, so their absence means a block-float
+/// scheme (mxfp4 / nvfp4 / mxfp8) distinguished by bits and group size. Shared
+/// so the linear loader, the embedding loader, and the family-level weight
+/// validators cannot drift apart on which mode a given triple will load as.
+///
+/// Used by: UnifiedLinear::from_weights, QuantizedEmbedding::from_weights,
+///          BailingMoe weight validation
+pub fn infer_quantization_mode(has_biases: bool, group_size: i32, bits: i32) -> &'static str {
+    if has_biases {
+        "affine"
+    } else if bits == 8 {
+        "mxfp8"
+    } else if group_size == 16 {
+        "nvfp4"
+    } else {
+        "mxfp4"
+    }
+}
+
 /// Validate and reconcile caller-declared quantization params against the
 /// observed `weight` / `scales` tensor shapes for `mode`.
 ///
@@ -973,9 +1052,18 @@ pub fn reconcile_quantization_layout(
     bits: i32,
     mode: &str,
 ) -> Result<ReconciledQuant, String> {
+    // A `group_size` or `bits` that can describe no packing at all is refused
+    // outright (issue #929). This used to share the "insufficient shape info"
+    // early return below on a trust-the-caller basis, which handed the declared
+    // pair straight to the kernel and turned a hostile `config.json` into an
+    // uncatchable abort at the first forward pass. The two conditions are
+    // separate: degenerate *shapes* still stay permissive, degenerate *params*
+    // do not. See [`validate_quantization_params`].
+    validate_quantization_params(group_size, bits)?;
+
     // Insufficient shape info: trust the caller, mirroring the historical
     // early-return in `infer_quantization_bits` for empty / scalar shapes.
-    if weight_shape.is_empty() || scales_shape.is_empty() || group_size <= 0 || bits <= 0 {
+    if weight_shape.is_empty() || scales_shape.is_empty() {
         return Ok(ReconciledQuant {
             bits,
             group_size,
@@ -1083,6 +1171,99 @@ fn reconcile_quantization_layout_logged(
     Ok(layout)
 }
 
+/// The three tensor shapes a quantized weight is stored as, borrowed for
+/// validation. `biases` is `None` for the block-float modes, which carry no
+/// zero points.
+pub struct QuantizedTensorShapes<'a> {
+    pub weight: &'a [i32],
+    pub scales: &'a [i32],
+    pub biases: Option<&'a [i32]>,
+}
+
+/// Check a quantized tensor's packing against the input width `config.json`
+/// claims, and its `biases` against its `scales`.
+///
+/// Quantization packs the **input** axis only, so a row-count check says
+/// nothing about the input width: a checkpoint honestly packed for a different
+/// `hidden_size` is internally self-consistent and passes every other check.
+/// MLX reconstructs the width as `scales.shape(-1) * group_size` and
+/// `extract_quantized_matmul_dims` throws `std::invalid_argument` when it
+/// disagrees with the activation's last axis; `validate_quantized_input` throws
+/// again when `biases` and `scales` differ in shape. `quantized_matmul` and
+/// `gather_qmm` cross the cxx bridge as `UniquePtr<MlxArray>` rather than a
+/// `Result`, so either throw is an uncatchable `std::terminate` at the **first
+/// forward pass**, long after the checkpoint appeared to load.
+///
+/// The width is reconstructed from the *effective* group size the loader will
+/// use, obtained from [`reconcile_quantization_layout`] rather than from the
+/// declared pair. Works for both a 2-D projection and a 3-D stacked expert
+/// tensor: only the last axis carries the packing, and the leading axes are
+/// required to agree between weight and scales.
+///
+/// `label` names the tensor in the rejection message; callers pass the weight
+/// prefix so the message points at a key the reader can find in the
+/// checkpoint.
+///
+/// Used by: BailingMoe weight validation (token table, dense projections,
+///          stacked experts) and the shared `validate_embedding_table` guard
+///          (BailingMoe, Gpt2, GptBigCode, GptNeoX)
+pub fn validate_quantized_packing(
+    label: &str,
+    shapes: &QuantizedTensorShapes<'_>,
+    in_features: usize,
+    group_size: i32,
+    bits: i32,
+    mode: &str,
+) -> Result<(), String> {
+    let w_shape = shapes.weight;
+    let s_shape = shapes.scales;
+    if s_shape.len() != w_shape.len() || s_shape.len() < 2 {
+        return Err(format!(
+            "unexpected {label}.scales shape {s_shape:?}: must have the same rank as \
+             {label}.weight {w_shape:?} and be at least 2-D"
+        ));
+    }
+    if s_shape[..s_shape.len() - 1] != w_shape[..w_shape.len() - 1] {
+        return Err(format!(
+            "unexpected {label}.scales shape {s_shape:?}: every axis but the last must match \
+             {label}.weight {w_shape:?}"
+        ));
+    }
+
+    let layout = reconcile_quantization_layout(w_shape, s_shape, group_size, bits, mode)
+        .map_err(|e| format!("{label}: {e}"))?;
+
+    let groups = usize::try_from(s_shape[s_shape.len() - 1]).unwrap_or(0);
+    let effective_group_size = usize::try_from(layout.group_size).unwrap_or(0);
+    let described = groups.checked_mul(effective_group_size);
+    if described != Some(in_features) {
+        return Err(format!(
+            "unexpected {label}.scales shape {s_shape:?}: {groups} quantization groups at \
+             group_size {effective_group_size} describe an input width of {}, but the config says \
+             {in_features}. MLX reconstructs a quantized matrix's input width as \
+             scales.shape(-1) * group_size and throws when it disagrees with the activation, and \
+             that throw crosses the cxx bridge as an uncatchable abort at the first forward pass \
+             rather than a load error. Packing compresses the input axis only, so the row count is \
+             still correct and cannot catch this.",
+            described
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| "an overflowing number of".to_string())
+        ));
+    }
+
+    if let Some(bias_shape) = shapes.biases
+        && bias_shape != s_shape
+    {
+        return Err(format!(
+            "unexpected {label}.biases shape {bias_shape:?}: the affine zero points must have \
+             the same shape as {label}.scales ({s_shape:?}). MLX rejects a mismatch by \
+             throwing, which crosses the cxx bridge as an uncatchable abort at the first \
+             forward pass."
+        ));
+    }
+    Ok(())
+}
+
 /// Unified Linear layer that auto-detects quantization
 ///
 /// Checks for `.scales` key in weight map to determine whether to use
@@ -1123,15 +1304,8 @@ impl UnifiedLinear {
         // thread an explicit mode (e.g. vision encoders, which always called
         // this affine default) load non-affine weights correctly instead of
         // aborting in quantized_matmul ("Biases must be provided for affine").
-        let mode = if weights.get(&format!("{}.biases", prefix)).is_some() {
-            "affine"
-        } else if bits == 8 {
-            "mxfp8"
-        } else if group_size == 16 {
-            "nvfp4"
-        } else {
-            "mxfp4"
-        };
+        let has_biases = weights.get(&format!("{}.biases", prefix)).is_some();
+        let mode = infer_quantization_mode(has_biases, group_size, bits);
         Self::from_weights_with_mode(weights, prefix, group_size, bits, mode)
     }
 
@@ -4291,6 +4465,173 @@ mod tests {
         let layout = reconcile_quantization_layout(&[], &[], 64, 4, "affine").expect("noop");
         assert_eq!((layout.bits, layout.group_size), (4, 64));
         assert!(!layout.reconciled);
+    }
+
+    // -- hostile quantization params (issue #929) -----------------------
+
+    #[test]
+    fn reconcile_rejects_quantization_params_that_no_layout_can_describe() {
+        // These used to share the "insufficient shape info" early return and were
+        // handed to the kernel exactly as declared. MLX divides by `bits` in
+        // `validate_quantized_input`, so 0 is a division by zero and anything
+        // above 32 collapses the quotient to zero; a non-positive `group_size`
+        // makes the right-hand side unmatchable. All three end the process,
+        // because the throw crosses the cxx bridge as `std::terminate`.
+        for (group_size, bits, field, offender) in [
+            (64, 0, "bits", 0),
+            (64, -4, "bits", -4),
+            (64, 33, "bits", 33),
+            (0, 4, "group_size", 0),
+            (-64, 4, "group_size", -64),
+        ] {
+            let err =
+                reconcile_quantization_layout(&[32, 16], &[32, 2], group_size, bits, "affine")
+                    .expect_err(&format!(
+                        "group_size {group_size} / bits {bits} must be rejected"
+                    ));
+            assert!(
+                err.contains(field) && err.contains(&offender.to_string()),
+                "the message must name the offending field and value, got: {err}"
+            );
+        }
+
+        // Degenerate shapes must not launder a hostile pair. The old early return
+        // took both conditions at once, so an empty shape turned a `bits` of 0
+        // into a silent pass-through.
+        for mode in ["affine", "mxfp4"] {
+            assert!(
+                reconcile_quantization_layout(&[], &[], 64, 0, mode).is_err(),
+                "an empty shape must not excuse bits=0 in {mode} mode"
+            );
+            assert!(
+                reconcile_quantization_layout(&[32, 16], &[], 0, 4, mode).is_err(),
+                "an empty scales shape must not excuse group_size=0 in {mode} mode"
+            );
+        }
+
+        // The guard is a bounds check, not an allowlist: every pair a real export
+        // declares still reconciles as it did before, including the shape-derived
+        // overrides the mixed-precision path depends on.
+        for (group_size, bits) in [(32, 4), (64, 4), (128, 4), (64, 8), (64, 6), (16, 4)] {
+            assert!(
+                validate_quantization_params(group_size, bits).is_ok(),
+                "group_size {group_size} / bits {bits} is a real export and must be accepted"
+            );
+        }
+        assert!(validate_quantization_params(1, 1).is_ok());
+        assert!(validate_quantization_params(1, 32).is_ok());
+    }
+
+    #[test]
+    fn quantized_loaders_reject_hostile_params_at_load_not_at_the_first_forward() {
+        // The real load path, not the pure helper: both production entry points
+        // must surface a Rust error. If this guard regresses, the bad pair
+        // reaches `quantized_matmul` and the C++ throw aborts this whole test
+        // binary with SIGABRT rather than failing cleanly.
+        let mut weights = crate::weights::WeightMap::new();
+        insert_quantized_qkv_projection(&mut weights, "model.layers.0.self_attn.q_proj", 8);
+        insert_quantized_qkv_projection(&mut weights, "model.embed_tokens", 16);
+
+        // Positive control: the honest pair loads on both paths.
+        UnifiedLinear::from_weights(&weights, "model.layers.0.self_attn.q_proj", 64, 4)
+            .expect("a consistently packed projection must load");
+        UnifiedEmbedding::from_weights(&weights, "model.embed_tokens", 64, 4)
+            .expect("a consistently packed table must load");
+
+        for (group_size, bits, field) in [
+            (64, 0, "bits"),
+            (64, 33, "bits"),
+            (0, 4, "group_size"),
+            (-64, 4, "group_size"),
+        ] {
+            let err = UnifiedLinear::from_weights(
+                &weights,
+                "model.layers.0.self_attn.q_proj",
+                group_size,
+                bits,
+            )
+            .err()
+            .unwrap_or_else(|| {
+                panic!("UnifiedLinear must reject group_size {group_size} / bits {bits}")
+            });
+            assert!(err.contains(field), "unhelpful error: {err}");
+
+            let err =
+                UnifiedEmbedding::from_weights(&weights, "model.embed_tokens", group_size, bits)
+                    .err()
+                    .unwrap_or_else(|| {
+                        panic!("UnifiedEmbedding must reject group_size {group_size} / bits {bits}")
+                    });
+            assert!(err.contains(field), "unhelpful error: {err}");
+        }
+    }
+
+    #[test]
+    fn quantized_packing_check_reconstructs_the_width_mlx_will_compute() {
+        // 4-bit at group_size 64: packed_in 8 and 1 group both describe a 64-wide
+        // input, so the honest triple passes.
+        let honest = QuantizedTensorShapes {
+            weight: &[32, 8],
+            scales: &[32, 1],
+            biases: Some(&[32, 1]),
+        };
+        validate_quantized_packing("q_proj", &honest, 64, 64, 4, "affine")
+            .expect("a consistently packed projection must pass");
+
+        // A tensor honestly packed for a 128-wide input keeps exactly the right
+        // row count, which is why the row check cannot catch it.
+        let mispacked = QuantizedTensorShapes {
+            weight: &[32, 16],
+            scales: &[32, 2],
+            biases: Some(&[32, 2]),
+        };
+        let err = validate_quantized_packing("q_proj", &mispacked, 64, 64, 4, "affine")
+            .expect_err("a table packed for a different width must be rejected");
+        assert!(err.contains("input width"), "unhelpful error: {err}");
+
+        // Zero points must match the scales they belong to.
+        let bad_biases = QuantizedTensorShapes {
+            weight: &[32, 8],
+            scales: &[32, 1],
+            biases: Some(&[32, 2]),
+        };
+        let err = validate_quantized_packing("q_proj", &bad_biases, 64, 64, 4, "affine")
+            .expect_err("mis-shaped zero points must be rejected");
+        assert!(err.contains("same shape"), "unhelpful error: {err}");
+
+        // Rank and leading-axis agreement, which the width arithmetic assumes.
+        let bad_rank = QuantizedTensorShapes {
+            weight: &[32, 8],
+            scales: &[32],
+            biases: None,
+        };
+        assert!(validate_quantized_packing("q_proj", &bad_rank, 64, 64, 4, "affine").is_err());
+        let bad_rows = QuantizedTensorShapes {
+            weight: &[32, 8],
+            scales: &[16, 1],
+            biases: None,
+        };
+        assert!(validate_quantized_packing("q_proj", &bad_rows, 64, 64, 4, "affine").is_err());
+
+        // A 3-D stacked expert plane works the same way: only the last axis
+        // carries the packing.
+        let stacked = QuantizedTensorShapes {
+            weight: &[4, 32, 8],
+            scales: &[4, 32, 1],
+            biases: Some(&[4, 32, 1]),
+        };
+        validate_quantized_packing("switch_mlp.gate_proj", &stacked, 64, 64, 4, "affine")
+            .expect("a stacked expert plane must pass the same check");
+    }
+
+    #[test]
+    fn quantization_mode_inference_is_shared_by_the_linear_and_embedding_loaders() {
+        assert_eq!(infer_quantization_mode(true, 64, 4), "affine");
+        assert_eq!(infer_quantization_mode(true, 16, 8), "affine");
+        assert_eq!(infer_quantization_mode(false, 64, 8), "mxfp8");
+        assert_eq!(infer_quantization_mode(false, 16, 4), "nvfp4");
+        assert_eq!(infer_quantization_mode(false, 64, 4), "mxfp4");
+        assert_eq!(infer_quantization_mode(false, 32, 4), "mxfp4");
     }
 
     #[test]

--- a/src/models/bailing_moe.rs
+++ b/src/models/bailing_moe.rs
@@ -817,37 +817,21 @@ impl ModelArgs {
 
     /// Reject a `quantization` block that would abort an MLX kernel.
     ///
-    /// `group_size` and `bits` reach `quantized_matmul`, `gather_qmm` and
-    /// `dequantize` unreconciled when the tensor shapes carry too little
-    /// information to re-derive them. MLX's own `packed_in * 32 / bits` check
-    /// divides by zero at `bits == 0` and collapses to zero above 32, throwing
-    /// the same uncatchable `std::terminate` the rope guard exists to prevent.
-    ///
-    /// This is a range check rather than an allowlist on purpose: mlxcel
-    /// deliberately re-derives an effective bit width from the tensor shapes when
-    /// the declared one disagrees, and an allowlist would reject the
-    /// mixed-precision exports that behavior serves.
+    /// Kept as a family-level early diagnostic even though the shared loaders now
+    /// enforce the same bound (issue #929): failing here names Bailing MoE and
+    /// fires during `ModelArgs::validate`, before any tensor is touched, rather
+    /// than at the first quantized projection the loader happens to reach.
+    /// [`mlxcel_core::layers::validate_quantization_params`] carries the rationale
+    /// for the bound being a range rather than an allowlist.
     fn validate_quantization(&self) -> Result<(), String> {
         let Some(quantization) = self.quantization.as_ref() else {
             return Ok(());
         };
-        if quantization.bits < 1 || quantization.bits > 32 {
-            return Err(format!(
-                "Bailing MoE quantization.bits ({}) must be between 1 and 32; MLX derives the \
-                 unpacked width as packed_in * 32 / bits, which divides by zero at 0 and collapses \
-                 to zero above 32, and the resulting C++ throw crosses the cxx bridge as an \
-                 uncatchable abort",
-                quantization.bits
-            ));
-        }
-        if quantization.group_size < 1 {
-            return Err(format!(
-                "Bailing MoE quantization.group_size ({}) must be positive; it divides the input \
-                 axis inside every quantized kernel",
-                quantization.group_size
-            ));
-        }
-        Ok(())
+        mlxcel_core::layers::validate_quantization_params(
+            quantization.group_size,
+            quantization.bits,
+        )
+        .map_err(|e| format!("Bailing MoE config.json: {e}"))
     }
 
     /// Whether this config is one where mirroring upstream's unconditional
@@ -892,45 +876,29 @@ impl ModelArgs {
 /// scheme distinguished by bits and group size. Mirrored here rather than
 /// assumed, because the reconciliation below behaves differently per mode.
 fn quant_mode(weights: &WeightMap, prefix: &str, group_size: i32, bits: i32) -> &'static str {
-    if weights.contains_key(&format!("{prefix}.biases")) {
-        "affine"
-    } else if bits == 8 {
-        "mxfp8"
-    } else if group_size == 16 {
-        "nvfp4"
-    } else {
-        "mxfp4"
-    }
+    let has_biases = weights.contains_key(&format!("{prefix}.biases"));
+    mlxcel_core::layers::infer_quantization_mode(has_biases, group_size, bits)
 }
 
 /// Check a quantized tensor's packing against the input width `config.json`
 /// claims, and its `biases` against its `scales`.
 ///
-/// Quantization packs the **input** axis only, so a row-count check says nothing
-/// about the input width: a checkpoint honestly packed for a different
-/// `hidden_size` is internally self-consistent and passes every other check.
-/// MLX reconstructs the width as `scales.shape(-1) * group_size` and
-/// `extract_quantized_matmul_dims` throws `std::invalid_argument` when it
-/// disagrees with the activation's last axis; `validate_quantized_input` throws
-/// again when `biases` and `scales` differ in shape. `quantized_matmul` and
-/// `gather_qmm` cross the cxx bridge as `UniquePtr<MlxArray>` rather than a
-/// `Result`, so either throw is an uncatchable `std::terminate` at the **first
-/// forward pass**, long after the checkpoint appeared to load.
+/// Thin `WeightMap` adapter over
+/// [`mlxcel_core::layers::validate_quantized_packing`], which carries the
+/// reasoning and the rejection messages. This wrapper resolves the three
+/// tensors by key, skips silently when the tensor is not quantized, and picks
+/// the mode the loader will pick.
 ///
-/// The width is reconstructed from the *effective* group size the loader will
-/// use, obtained from `reconcile_quantization_layout` rather than from the
-/// declared pair. Works for both a 2-D projection and a 3-D stacked expert
-/// tensor: only the last axis carries the packing, and the leading axes are
-/// required to agree between weight and scales.
-///
-/// The `mode` fed into `reconcile_quantization_layout` is `quant_mode`'s guess
-/// from `.biases` presence, and that guess matches the loader exactly for every
-/// plain projection here (`UnifiedLinear::from_weights` picks its mode the same
-/// way). It does **not** match for the routed experts: `SwitchLinear::from_weights`
-/// (`src/models/switch_layers.rs:192`) pins `mode` to `"affine"` unconditionally,
-/// regardless of whether `.biases` is present, so a stacked or per-expert tensor
-/// quantized in a block-float scheme without zero-point `biases` would be
-/// reconciled here under the wrong mode. `validate_experts` inherits that gap.
+/// The `mode` fed into the shared reconciliation is `quant_mode`'s guess from
+/// `.biases` presence, and that guess matches the loader exactly for every
+/// plain projection here (`UnifiedLinear::from_weights` picks its mode through
+/// the same `infer_quantization_mode`). It does **not** match for the routed
+/// experts: `SwitchLinear::from_weights`
+/// (https://github.com/lablup/mlxcel/blob/main/src/models/switch_layers.rs) pins
+/// `mode` to `"affine"` unconditionally, regardless of whether `.biases` is
+/// present, so a stacked or per-expert tensor quantized in a block-float scheme
+/// without zero-point `biases` would be reconciled here under the wrong mode.
+/// `validate_experts` inherits that gap.
 fn validate_quantized_packing(
     weights: &WeightMap,
     prefix: &str,
@@ -946,55 +914,22 @@ fn validate_quantized_packing(
         .ok_or_else(|| format!("Weight not found: {prefix}.weight (but {prefix}.scales exists)"))?;
     let w_shape = mlxcel_core::array_shape(weight);
     let s_shape = mlxcel_core::array_shape(scales);
-    if s_shape.len() != w_shape.len() || s_shape.len() < 2 {
-        return Err(format!(
-            "unexpected {prefix}.scales shape {s_shape:?}: must have the same rank as \
-             {prefix}.weight {w_shape:?} and be at least 2-D"
-        ));
-    }
-    if s_shape[..s_shape.len() - 1] != w_shape[..w_shape.len() - 1] {
-        return Err(format!(
-            "unexpected {prefix}.scales shape {s_shape:?}: every axis but the last must match \
-             {prefix}.weight {w_shape:?}"
-        ));
-    }
+    let bias_shape = weights
+        .get(&format!("{prefix}.biases"))
+        .map(|biases| mlxcel_core::array_shape(biases));
 
-    let mode = quant_mode(weights, prefix, group_size, bits);
-    let layout = mlxcel_core::layers::reconcile_quantization_layout(
-        &w_shape, &s_shape, group_size, bits, mode,
+    mlxcel_core::layers::validate_quantized_packing(
+        prefix,
+        &mlxcel_core::layers::QuantizedTensorShapes {
+            weight: &w_shape,
+            scales: &s_shape,
+            biases: bias_shape.as_deref(),
+        },
+        in_features,
+        group_size,
+        bits,
+        quant_mode(weights, prefix, group_size, bits),
     )
-    .map_err(|e| format!("{prefix}: {e}"))?;
-
-    let groups = usize::try_from(s_shape[s_shape.len() - 1]).unwrap_or(0);
-    let effective_group_size = usize::try_from(layout.group_size).unwrap_or(0);
-    let described = groups.checked_mul(effective_group_size);
-    if described != Some(in_features) {
-        return Err(format!(
-            "unexpected {prefix}.scales shape {s_shape:?}: {groups} quantization groups at \
-             group_size {effective_group_size} describe an input width of {}, but the config says \
-             {in_features}. MLX reconstructs a quantized matrix's input width as \
-             scales.shape(-1) * group_size and throws when it disagrees with the activation, and \
-             that throw crosses the cxx bridge as an uncatchable abort at the first forward pass \
-             rather than a load error. Packing compresses the input axis only, so the row count is \
-             still correct and cannot catch this.",
-            described
-                .map(|d| d.to_string())
-                .unwrap_or_else(|| "an overflowing number of".to_string())
-        ));
-    }
-
-    if let Some(biases) = weights.get(&format!("{prefix}.biases")) {
-        let bias_shape = mlxcel_core::array_shape(biases);
-        if bias_shape != s_shape {
-            return Err(format!(
-                "unexpected {prefix}.biases shape {bias_shape:?}: the affine zero points must have \
-                 the same shape as {prefix}.scales ({s_shape:?}). MLX rejects a mismatch by \
-                 throwing, which crosses the cxx bridge as an uncatchable abort at the first \
-                 forward pass."
-            ));
-        }
-    }
-    Ok(())
 }
 
 /// Check one `[out_features, in_features]` projection against the config.

--- a/src/models/bailing_moe.rs
+++ b/src/models/bailing_moe.rs
@@ -1152,12 +1152,11 @@ pub fn validate_weights(weights: &WeightMap, args: &ModelArgs) -> Result<(), Str
     validate_norm(weights, "model.norm.weight", hidden)?;
 
     // The token table's row count is checked against `vocab_size` by
-    // `validate_embedding_table` in `from_weights`, which checks the width only
-    // on the float path because a packed width is not the model width. A packed
-    // table still has to describe `hidden_size` once unpacked, and MLX
-    // reconstructs that as `scales.shape(-1) * group_size`, so a table packed
-    // for a different width reaches the first RMSNorm as the wrong shape and
-    // throws there rather than at load. A no-op for an unquantized table.
+    // `validate_embedding_table` in `from_weights`, which since issue #929 also
+    // reconstructs the dequantized width through the same shared check this line
+    // calls. Kept as a redundant early diagnostic: it runs during
+    // `validate_weights`, ahead of the loader, and names the table rather than
+    // the constructor that reached it. A no-op for an unquantized table.
     validate_quantized_packing(weights, "model.word_embeddings", hidden, group_size, bits)?;
 
     // The output head, which nothing else checks. The axis that aborts the

--- a/src/models/bailing_moe_tests.rs
+++ b/src/models/bailing_moe_tests.rs
@@ -1665,8 +1665,10 @@ fn validate_weights_rejects_an_output_head_that_disagrees_with_the_config() {
         .unwrap_err_or_panic("a head packed for a different input width");
     assert!(err.contains("input width"), "{err}");
 
-    // The same reconstruction applied to the token table, whose width the
-    // shared `validate_embedding_table` deliberately leaves to the scales.
+    // The same reconstruction applied to the token table, whose width comes from
+    // the scales rather than the packed weight. `validate_weights` catches it
+    // here, ahead of the shared `validate_embedding_table` guard that catches the
+    // same thing at load time.
     let mut table = tiny_weights(&quant_args);
     table.insert(
         "model.word_embeddings.weight".into(),

--- a/src/models/gpt2.rs
+++ b/src/models/gpt2.rs
@@ -841,8 +841,15 @@ pub(crate) fn dim_eq(dim: i32, expected: usize) -> bool {
 /// their `config.json` is the whole point of passing them.
 ///
 /// A quantized table is packed along the last axis only, so its row count is
-/// still dimension 0; the width check is skipped for it because the packed width
-/// is a function of the bit depth rather than the model width.
+/// still dimension 0, but its stored width is a function of the bit depth rather
+/// than the model width and cannot be compared against `expected_cols` directly.
+/// The dequantized width is recoverable, and is checked (issue #929): MLX
+/// reconstructs it as `scales.shape(-1) * group_size`, so a table honestly
+/// packed for a different model width is internally self-consistent, passes the
+/// row check, and then feeds a wrong-width hidden state into `fast::layer_norm` /
+/// `fast::rms_norm`, which throws and crosses the cxx bridge as an uncatchable
+/// `std::terminate` at the first forward pass. The reconstruction is shared with
+/// the dense projections via `mlxcel_core::layers::validate_quantized_packing`.
 ///
 /// Used by: BailingMoe, Gpt2, GptBigCode, GptNeoX
 pub(crate) fn validate_embedding_table(
@@ -871,11 +878,39 @@ pub(crate) fn validate_embedding_table(
              behind an embedding lookup does not range-check a positive index."
         ));
     }
-    if !table.is_quantized() && !dim_eq(*cols, expected_cols) {
-        return Err(format!(
-            "{key}.weight is [{rows}, {cols}] but {width_field} is {expected_cols}; every \
-             embedding table must be the model width"
-        ));
+    match table.quantized() {
+        // The packed width says nothing on its own, so reconstruct the width MLX
+        // will compute from the scales and the reconciled group size. `group_size`
+        // and `bits` here are the values the loader already settled on, so this
+        // re-runs reconciliation on an already-reconciled pair, which is a no-op.
+        Some(quantized) => {
+            let scales_shape = mlxcel_core::array_shape(&quantized.scales);
+            let biases_shape = quantized
+                .biases
+                .as_ref()
+                .map(|biases| mlxcel_core::array_shape(biases));
+            mlxcel_core::layers::validate_quantized_packing(
+                key,
+                &mlxcel_core::layers::QuantizedTensorShapes {
+                    weight: &shape,
+                    scales: &scales_shape,
+                    biases: biases_shape.as_deref(),
+                },
+                expected_cols,
+                quantized.group_size,
+                quantized.bits,
+                &quantized.mode,
+            )
+            .map_err(|e| format!("{e} ({width_field} is {expected_cols})"))?;
+        }
+        None => {
+            if !dim_eq(*cols, expected_cols) {
+                return Err(format!(
+                    "{key}.weight is [{rows}, {cols}] but {width_field} is {expected_cols}; every \
+                     embedding table must be the model width"
+                ));
+            }
+        }
     }
     Ok(rows)
 }

--- a/src/models/gpt2.rs
+++ b/src/models/gpt2.rs
@@ -901,7 +901,7 @@ pub(crate) fn validate_embedding_table(
                 quantized.bits,
                 &quantized.mode,
             )
-            .map_err(|e| format!("{e} ({width_field} is {expected_cols})"))?;
+            .map_err(|e| format!("{e} (the model width came from {width_field})"))?;
         }
         None => {
             if !dim_eq(*cols, expected_cols) {

--- a/src/models/gpt2_tests.rs
+++ b/src/models/gpt2_tests.rs
@@ -588,6 +588,84 @@ fn from_weights_rejects_a_position_table_of_the_wrong_width() {
     assert!(err.contains("n_embd"), "unhelpful error: {err}");
 }
 
+/// Replace `wpe` with an affine-quantized table at 4 bits and group_size 8.
+///
+/// `groups` is how many quantization groups the scales claim, so the table
+/// describes a `groups * 8`-wide input. The honest value for the 8-wide tiny
+/// config is 1; anything else is a table packed for a different model width,
+/// which keeps exactly the right row count.
+fn quantize_position_table(args: &ModelArgs, weights: &mut WeightMap, groups: i32) {
+    let rows = args.n_positions as i32;
+    let packed_in = args.n_embd as i32 * 4 / 32; // 4-bit packs 8 values per uint32
+    weights.insert("wpe.weight".into(), ones(&[rows, packed_in]));
+    weights.insert("wpe.scales".into(), filled(&[rows, groups]));
+    weights.insert("wpe.biases".into(), filled(&[rows, groups]));
+}
+
+#[test]
+fn from_weights_rejects_a_quantized_position_table_of_the_wrong_dequantized_width() {
+    // Packing compresses the input axis only, so a table built for a different
+    // model width keeps exactly the right row count and the packed width alone
+    // says nothing without a bit depth. The width check used to be skipped
+    // outright for a quantized table, so the mismatch first surfaced as a
+    // wrong-width hidden state inside `fast::layer_norm`, whose throw crosses
+    // the cxx bridge as an uncatchable abort at the first forward pass.
+    let mut args = tiny_args();
+    args.quantization = Some(super::Quantization {
+        group_size: 8,
+        bits: 4,
+    });
+
+    // The positive control first, so the width check cannot be passing by
+    // rejecting everything quantized.
+    let mut weights = raw_hf_weights(&args, "");
+    quantize_position_table(&args, &mut weights, 1);
+    assert!(
+        Gpt2Model::from_weights(&weights, &args).is_ok(),
+        "a consistently packed position table must load"
+    );
+
+    let mut weights = raw_hf_weights(&args, "");
+    quantize_position_table(&args, &mut weights, 2);
+    let err = match Gpt2Model::from_weights(&weights, &args) {
+        Ok(_) => panic!("a quantized wpe packed for a different width must be rejected"),
+        Err(err) => err,
+    };
+    assert!(err.contains("input width"), "unhelpful error: {err}");
+    assert!(
+        err.contains("n_embd"),
+        "the message must name the field: {err}"
+    );
+}
+
+#[test]
+fn from_weights_rejects_a_quantization_block_that_would_abort_an_mlx_kernel() {
+    // GPT-2 carries no family-level `validate_quantization`, so this exercises
+    // the shared guard in `reconcile_quantization_layout` rather than a local
+    // copy: a `bits` of 0 divides by zero inside MLX's `validate_quantized_input`
+    // and a non-positive `group_size` can match no real tensor, and either throw
+    // crosses the cxx bridge as an uncatchable `std::terminate` at the first
+    // forward pass rather than a load error.
+    for (group_size, bits, field) in [
+        (8, 0, "bits"),
+        (8, -4, "bits"),
+        (8, 33, "bits"),
+        (0, 4, "group_size"),
+        (-8, 4, "group_size"),
+    ] {
+        let mut args = tiny_args();
+        args.quantization = Some(super::Quantization { group_size, bits });
+        let mut weights = raw_hf_weights(&args, "");
+        quantize_position_table(&args, &mut weights, 1);
+
+        let err = match Gpt2Model::from_weights(&weights, &args) {
+            Ok(_) => panic!("group_size {group_size} / bits {bits} must be rejected at load"),
+            Err(err) => err,
+        };
+        assert!(err.contains(field), "unhelpful error: {err}");
+    }
+}
+
 // Construction and forward.
 
 #[test]

--- a/src/models/gpt_neox.rs
+++ b/src/models/gpt_neox.rs
@@ -330,52 +330,22 @@ impl ModelArgs {
     /// Reject a `quantization` block that would abort the process inside an MLX
     /// quantized kernel.
     ///
-    /// `group_size` and `bits` are read straight out of `config.json` and are
-    /// threaded through [`load_linear`] and `UnifiedEmbedding::from_weights`
-    /// into MLX's `quantized_matmul` and `dequantize`. They are not reconciled
-    /// away first: `mlxcel_core::layers::reconcile_quantization_layout`
-    /// deliberately returns the declared pair unchanged when either is
-    /// non-positive (it treats that as "insufficient shape info, trust the
-    /// caller"), so a hostile value reaches the kernel exactly as written.
-    ///
-    /// MLX then computes `w.shape(-1) * 32 / bits` in `validate_quantized_input`.
-    /// At `bits == 0` that is a division by zero, and at `bits > 32` it is zero,
-    /// which cannot match the scales, so both end in a `std::invalid_argument`.
-    /// `quantized_matmul` crosses the cxx bridge as `UniquePtr<MlxArray>` rather
-    /// than a `Result`, so that throw is an uncatchable `std::terminate` at the
-    /// first forward pass rather than a load error, which is the same shape of
-    /// failure [`ModelArgs::validate_rope`] exists to prevent for `rope`.
-    ///
-    /// The bound is a range rather than an allowlist of the widths MLX actually
-    /// supports on purpose. mlxcel tolerates a declared bit width that disagrees
-    /// with the stored tensors and re-derives the effective one from the shapes,
-    /// so an allowlist would reject mixed-precision exports that load correctly
-    /// today. Only the values that cannot describe any packing at all are
-    /// refused.
+    /// Kept as a family-level early diagnostic even though the shared loaders now
+    /// enforce the same bound (issue #929): failing here names GPT-NeoX and fires
+    /// during [`ModelArgs::validate`], before any tensor is touched, rather than
+    /// at the first quantized projection the loader happens to reach.
+    /// [`mlxcel_core::layers::validate_quantization_params`] carries the rationale
+    /// for the bound being a range rather than an allowlist, and for why the throw
+    /// it prevents is an uncatchable `std::terminate` rather than a load error.
     fn validate_quantization(&self) -> Result<(), String> {
         let Some(quantization) = self.quantization.as_ref() else {
             return Ok(());
         };
-        if quantization.bits < 1 || quantization.bits > 32 {
-            return Err(format!(
-                "GPT-NeoX quantization.bits ({}) must be between 1 and 32; MLX derives the \
-                 unpacked width as `packed_in * 32 / bits`, which divides by zero at 0 and \
-                 collapses to zero above 32, and the resulting MLX C++ exception crossing the cxx \
-                 bridge is an uncatchable `std::terminate` at the first forward pass rather than a \
-                 load error",
-                quantization.bits
-            ));
-        }
-        if quantization.group_size < 1 {
-            return Err(format!(
-                "GPT-NeoX quantization.group_size ({}) must be positive; it is multiplied by the \
-                 scales width to check the packing, and a non-positive value can match no real \
-                 tensor, so MLX throws and that throw is an uncatchable `std::terminate` rather \
-                 than a load error",
-                quantization.group_size
-            ));
-        }
-        Ok(())
+        mlxcel_core::layers::validate_quantization_params(
+            quantization.group_size,
+            quantization.bits,
+        )
+        .map_err(|e| format!("GPT-NeoX config.json: {e}"))
     }
 
     /// Reject RoPE parameters that would abort the process at the first forward

--- a/src/models/gpt_neox_tests.rs
+++ b/src/models/gpt_neox_tests.rs
@@ -444,12 +444,12 @@ fn config_validation_rejects_a_layer_norm_eps_that_would_nan_every_hidden_state(
 
 #[test]
 fn config_validation_rejects_a_quantization_block_that_would_abort_an_mlx_kernel() {
-    // `group_size` and `bits` reach `quantized_matmul` and `dequantize`
-    // unchanged: `reconcile_quantization_layout` treats a non-positive pair as
-    // "insufficient shape info" and returns it as declared rather than
-    // correcting it. MLX then computes `packed_in * 32 / bits`, which divides by
-    // zero at 0 and collapses to zero above 32, and the throw that follows
-    // crosses the cxx bridge as an uncatchable `std::terminate`.
+    // MLX computes `packed_in * 32 / bits`, which divides by zero at 0 and
+    // collapses to zero above 32, and the throw that follows crosses the cxx
+    // bridge as an uncatchable `std::terminate`. Since issue #929
+    // `reconcile_quantization_layout` refuses such a pair itself, so this is the
+    // family-level early diagnostic rather than the only guard: it names GPT-NeoX
+    // and fires during config validation, before any tensor is touched.
     let hostile = [
         (r#""group_size": 64, "bits": 0"#, "bits"),
         (r#""group_size": 64, "bits": -4"#, "bits"),

--- a/src/models/helium.rs
+++ b/src/models/helium.rs
@@ -372,37 +372,21 @@ impl ModelArgs {
 
     /// Reject a `quantization` block that would abort an MLX kernel.
     ///
-    /// `group_size` and `bits` reach `quantized_matmul` and `dequantize`
-    /// unreconciled when the tensor shapes carry too little information to
-    /// re-derive them. MLX's own `packed_in * 32 / bits` check divides by zero at
-    /// `bits == 0` and collapses to zero above 32, throwing the same uncatchable
-    /// `std::terminate` the rope guard exists to prevent.
-    ///
-    /// This is a range check rather than an allowlist on purpose: mlxcel
-    /// deliberately re-derives an effective bit width from the tensor shapes when
-    /// the declared one disagrees, and an allowlist would reject the
-    /// mixed-precision exports that behavior serves.
+    /// Kept as a family-level early diagnostic even though the shared loaders now
+    /// enforce the same bound (issue #929): failing here names Helium and fires
+    /// during config validation, before any tensor is touched, rather than at the
+    /// first quantized projection the loader happens to reach.
+    /// [`mlxcel_core::layers::validate_quantization_params`] carries the rationale
+    /// for the bound being a range rather than an allowlist.
     fn validate_quantization(&self) -> Result<(), String> {
         let Some(quantization) = self.quantization.as_ref() else {
             return Ok(());
         };
-        if quantization.bits < 1 || quantization.bits > 32 {
-            return Err(format!(
-                "Helium quantization.bits ({}) must be between 1 and 32; MLX derives the unpacked \
-                 width as packed_in * 32 / bits, which divides by zero at 0 and collapses to zero \
-                 above 32, and the resulting C++ throw crosses the cxx bridge as an uncatchable \
-                 abort",
-                quantization.bits
-            ));
-        }
-        if quantization.group_size < 1 {
-            return Err(format!(
-                "Helium quantization.group_size ({}) must be positive; it divides the input axis \
-                 inside every quantized kernel",
-                quantization.group_size
-            ));
-        }
-        Ok(())
+        mlxcel_core::layers::validate_quantization_params(
+            quantization.group_size,
+            quantization.bits,
+        )
+        .map_err(|e| format!("Helium config.json: {e}"))
     }
 
     /// Build the `llama3::ModelArgs` that drives the shared dense decoder.

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -318,11 +318,31 @@ impl SwitchLinear {
                 let s_shape = mlxcel_core::array_shape(&scales);
                 let packed_in = *w_shape.last().unwrap_or(&0);
                 let num_groups = *s_shape.last().unwrap_or(&0);
-                let denom = num_groups * group_size;
-                let effective_bits = if denom > 0 && (packed_in * 32) % denom == 0 {
-                    let inferred = (packed_in * 32) / denom;
+
+                // A zero or absent last axis on either tensor used to be treated
+                // as "no layout signal, trust the caller", which let a plane of
+                // shape [E, out, 0] satisfy every arithmetic check below (0 == 0)
+                // and then abort inside `extract_quantized_matmul_dims` on the
+                // inner-dimension comparison. Present `.scales` means a real
+                // quantized tensor, so both axes must be real.
+                if packed_in < 1 || num_groups < 1 {
+                    return Err(format!(
+                        "{prefix}: stacked expert weight {w_shape:?} and scales {s_shape:?} must \
+                         both carry a positive last axis; a zero-length packed axis describes no \
+                         input width and aborts inside gather_qmm rather than failing at load"
+                    ));
+                }
+
+                // i64 throughout: `group_size` is bounded above by the guard, but
+                // `num_groups * group_size` is still a config-influenced multiply
+                // in a load path, and an unchecked i32 version wraps in release
+                // and panics in an overflow-checked build.
+                let denom = i64::from(num_groups) * i64::from(group_size);
+                let packed_bits = i64::from(packed_in) * 32;
+                let effective_bits = if denom > 0 && packed_bits % denom == 0 {
+                    let inferred = packed_bits / denom;
                     if (2..=8).contains(&inferred) {
-                        inferred
+                        i32::try_from(inferred).unwrap_or(bits)
                     } else {
                         bits
                     }
@@ -334,22 +354,32 @@ impl SwitchLinear {
                 // shapes solve to something outside the supported widths, which
                 // stores a triple MLX will reject. Refuse it here instead, using
                 // MLX's own predicate from `validate_quantized_input` so this
-                // fires exactly when the kernel would have thrown, and in i64 so
-                // the multiply cannot wrap on a large expert plane. Degenerate
-                // shapes (both last axes absent) evaluate to 0 == 0 and stay
-                // permissive, matching the dense reconciler.
-                let described = i64::from(packed_in) * 32 / i64::from(effective_bits);
-                let claimed = i64::from(num_groups) * i64::from(group_size);
-                if described != claimed {
+                // fires exactly when the kernel would have thrown.
+                let described = packed_bits / i64::from(effective_bits);
+                if described != denom {
                     return Err(format!(
                         "{prefix}: stacked expert weight {w_shape:?} and scales {s_shape:?} \
                          describe an input width of {described} at {effective_bits}-bit, but \
-                         {num_groups} groups at group_size {group_size} describe {claimed}. MLX \
+                         {num_groups} groups at group_size {group_size} describe {denom}. MLX \
                          checks exactly this in extract_quantized_matmul_dims before gather_qmm \
                          and throws on a mismatch, and that throw crosses the cxx bridge as an \
                          uncatchable abort at the first routed forward pass rather than a load \
                          error."
                     ));
+                }
+
+                // `validate_quantized_input` throws on a `biases` whose shape
+                // differs from `scales` as well, on the same infallible path.
+                if let Some(biases) = biases.as_ref() {
+                    let b_shape = mlxcel_core::array_shape(biases);
+                    if b_shape != s_shape {
+                        return Err(format!(
+                            "{prefix}: stacked expert biases {b_shape:?} must have the same shape \
+                             as the scales {s_shape:?}; MLX rejects a mismatch by throwing, which \
+                             crosses the cxx bridge as an uncatchable abort at the first routed \
+                             forward pass"
+                        ));
+                    }
                 }
 
                 Ok(Self::Quantized {
@@ -1184,6 +1214,27 @@ mod tests {
         let parts = sl.quantized_parts().expect("quantized");
         assert_eq!(parts.bits, 8);
         assert_eq!(parts.group_size, 64);
+
+        // A zero-length packed axis describes no input width. It used to satisfy
+        // every arithmetic check here (0 == 0) and then abort inside
+        // `extract_quantized_matmul_dims` on the inner-dimension comparison.
+        let empty_axis = stacked_quantized_experts(prefix, 3, 4, 0, 0);
+        let err = SwitchLinear::from_weights(&empty_axis, prefix, 64, 4)
+            .err()
+            .expect("a zero-length packed axis must fail at load");
+        assert!(err.contains("positive last axis"), "unhelpful error: {err}");
+
+        // MLX also throws when the zero points disagree in shape with the scales,
+        // on the same infallible path.
+        let mut bad_biases = stacked_quantized_experts(prefix, 3, 4, 8, 1);
+        bad_biases.insert(
+            format!("{prefix}.biases"),
+            mlxcel_core::from_slice_f32(&[0.0; 3 * 4 * 2], &[3, 4, 2]),
+        );
+        let err = SwitchLinear::from_weights(&bad_biases, prefix, 64, 4)
+            .err()
+            .expect("mis-shaped expert zero points must fail at load");
+        assert!(err.contains("same shape"), "unhelpful error: {err}");
     }
 
     #[test]

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -253,9 +253,9 @@ impl SwitchLinear {
             let biases = weights
                 .get(&format!("{}.biases", prefix))
                 .map(|w| mlxcel_core::copy(w));
-            return Ok(Self::from_stacked_parts(
-                weight, scales, biases, group_size, bits, mode,
-            ));
+            return Self::from_stacked_parts(
+                prefix, weight, scales, biases, group_size, bits, mode,
+            );
         }
 
         // Per-expert layout: `{root}.experts.{idx}.{proj}.{weight,scales,biases}`.
@@ -268,9 +268,9 @@ impl SwitchLinear {
         // this generic call site, so the shortfall cross-check is skipped
         // (`None`); callers that do carry one (DeepSeek v1) pass it through.
         if let Some((weight, scales, biases)) = stack_individual_experts(weights, prefix, None)? {
-            return Ok(Self::from_stacked_parts(
-                weight, scales, biases, group_size, bits, mode,
-            ));
+            return Self::from_stacked_parts(
+                prefix, weight, scales, biases, group_size, bits, mode,
+            );
         }
 
         Err(format!("Missing weight: {}", prefix))
@@ -280,16 +280,34 @@ impl SwitchLinear {
     /// optional scales/biases). Present scales select the quantized path and the
     /// per-tensor bit width is inferred from the packed-weight and scales shapes;
     /// absent scales select the non-quantized `Regular` path.
+    ///
+    /// This is the one quantized loader that does **not** go through
+    /// `reconcile_quantization_layout`, so it carries its own guards (issue
+    /// #929). The MoE path reaches MLX through `gather_qmm`, which shares
+    /// `extract_quantized_matmul_dims` (and therefore the `w.shape(-1) * 32 /
+    /// bits` division) with the dense `quantized_matmul` path, so a declared
+    /// `group_size` of 0 or a `bits` outside `1..=32` aborts the process at the
+    /// first routed forward pass exactly as it would for a dense projection.
+    /// Guarding only the reconciler would have left every quantized MoE
+    /// checkpoint exposed.
     fn from_stacked_parts(
+        prefix: &str,
         weight: UniquePtr<MlxArray>,
         scales: Option<UniquePtr<MlxArray>>,
         biases: Option<UniquePtr<MlxArray>>,
         group_size: i32,
         bits: i32,
         mode: &str,
-    ) -> Self {
+    ) -> Result<Self, String> {
         match scales {
             Some(scales) => {
+                // Bound the declared pair before anything derived from it is
+                // stored on the layer. `group_size` is never inferred on this
+                // path, so a declared 0 would otherwise zero the denominator
+                // below, skip inference entirely, and be handed to the kernel.
+                mlxcel_core::layers::validate_quantization_params(group_size, bits)
+                    .map_err(|e| format!("{prefix}: {e}"))?;
+
                 // Infer the actual bit width from the packed weight and scales
                 // shapes (group_size fixed): mixed-precision checkpoints such as
                 // dots.llm1 quantize some expert projections at 6-bit while the
@@ -312,16 +330,38 @@ impl SwitchLinear {
                     bits
                 };
 
-                Self::Quantized {
+                // The fallback above keeps the declared `bits` whenever the
+                // shapes solve to something outside the supported widths, which
+                // stores a triple MLX will reject. Refuse it here instead, using
+                // MLX's own predicate from `validate_quantized_input` so this
+                // fires exactly when the kernel would have thrown, and in i64 so
+                // the multiply cannot wrap on a large expert plane. Degenerate
+                // shapes (both last axes absent) evaluate to 0 == 0 and stay
+                // permissive, matching the dense reconciler.
+                let described = i64::from(packed_in) * 32 / i64::from(effective_bits);
+                let claimed = i64::from(num_groups) * i64::from(group_size);
+                if described != claimed {
+                    return Err(format!(
+                        "{prefix}: stacked expert weight {w_shape:?} and scales {s_shape:?} \
+                         describe an input width of {described} at {effective_bits}-bit, but \
+                         {num_groups} groups at group_size {group_size} describe {claimed}. MLX \
+                         checks exactly this in extract_quantized_matmul_dims before gather_qmm \
+                         and throws on a mismatch, and that throw crosses the cxx bridge as an \
+                         uncatchable abort at the first routed forward pass rather than a load \
+                         error."
+                    ));
+                }
+
+                Ok(Self::Quantized {
                     weight,
                     scales,
                     biases,
                     group_size,
                     bits: effective_bits,
                     mode: mode.to_string(),
-                }
+                })
             }
-            None => Self::Regular { weight },
+            None => Ok(Self::Regular { weight }),
         }
     }
 }
@@ -1024,6 +1064,126 @@ mod tests {
         );
         assert_eq!(parts.group_size, group);
         assert_eq!(parts.mode, "affine");
+    }
+
+    /// Affine 4-bit expert planes in the pre-stacked `switch_mlp` layout that
+    /// mlx-community conversions ship: `[num_experts, out, in/8]` weights with
+    /// `[num_experts, out, in/group_size]` scales and zero points.
+    fn stacked_quantized_experts(
+        prefix: &str,
+        experts: i32,
+        out: i32,
+        packed_in: i32,
+        num_groups: i32,
+    ) -> WeightMap {
+        let plane = |last: i32, value: f32| {
+            let n = (experts * out * last) as usize;
+            mlxcel_core::from_slice_f32(&vec![value; n], &[experts, out, last])
+        };
+        let mut weights = WeightMap::new();
+        weights.insert(format!("{prefix}.weight"), plane(packed_in, 0.0));
+        weights.insert(format!("{prefix}.scales"), plane(num_groups, 1.0));
+        weights.insert(format!("{prefix}.biases"), plane(num_groups, 0.0));
+        weights
+    }
+
+    #[test]
+    fn switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+        // The MoE loader never calls `reconcile_quantization_layout`, so the
+        // shared reconciler guard does not cover it. It reaches MLX through
+        // `gather_qmm`, which shares `extract_quantized_matmul_dims` (and its
+        // `w.shape(-1) * 32 / bits` division) with the dense path, so a hostile
+        // pair aborts the process at the first routed forward pass. If this
+        // guard regresses the C++ throw takes this whole test binary down with
+        // SIGABRT rather than failing cleanly.
+        let group = 64i32;
+        let in_dim = 64i32;
+        let packed_in = in_dim / 8; // 4-bit packs 8 weights per uint32 column
+        let num_groups = in_dim / group;
+        let root = "model.layers.0.mlp";
+        let stacked_prefix = format!("{root}.switch_mlp.gate_proj");
+
+        let hostile = [
+            (64, 0, "bits"),
+            (64, -4, "bits"),
+            (64, 33, "bits"),
+            (0, 4, "group_size"),
+            (-64, 4, "group_size"),
+        ];
+
+        // Pre-stacked layout.
+        let stacked = stacked_quantized_experts(&stacked_prefix, 3, 4, packed_in, num_groups);
+        SwitchLinear::from_weights(&stacked, &stacked_prefix, group, 4)
+            .expect("the honest pair must still load");
+        for (group_size, bits, field) in hostile {
+            let err = SwitchLinear::from_weights(&stacked, &stacked_prefix, group_size, bits)
+                .err()
+                .unwrap_or_else(|| {
+                    panic!("stacked experts must reject group_size {group_size} / bits {bits}")
+                });
+            assert!(err.contains(field), "unhelpful error: {err}");
+        }
+
+        // Per-expert layout, which reaches the same constructor through
+        // `stack_individual_experts` instead.
+        let mut per_expert = WeightMap::new();
+        for e in 0..3 {
+            for (leaf, last, value) in [
+                ("weight", packed_in, 0.0),
+                ("scales", num_groups, 1.0),
+                ("biases", num_groups, 0.0),
+            ] {
+                per_expert.insert(
+                    format!("{root}.experts.{e}.gate_proj.{leaf}"),
+                    mlxcel_core::from_slice_f32(&vec![value; (4 * last) as usize], &[4, last]),
+                );
+            }
+        }
+        SwitchLinear::from_weights(&per_expert, &stacked_prefix, group, 4)
+            .expect("the honest pair must still load from the per-expert layout");
+        for (group_size, bits, field) in hostile {
+            let err = SwitchLinear::from_weights(&per_expert, &stacked_prefix, group_size, bits)
+                .err()
+                .unwrap_or_else(|| {
+                    panic!("per-expert stacking must reject group_size {group_size} / bits {bits}")
+                });
+            assert!(err.contains(field), "unhelpful error: {err}");
+        }
+
+        // A non-quantized expert plane carries no packing at all, so the params
+        // are irrelevant there and must not be enforced.
+        let mut regular = WeightMap::new();
+        regular.insert(
+            format!("{stacked_prefix}.weight"),
+            mlxcel_core::from_slice_f32(&vec![0.0; 3 * 4 * 8], &[3, 4, 8]),
+        );
+        SwitchLinear::from_weights(&regular, &stacked_prefix, 0, 0)
+            .expect("a non-quantized expert plane must not be gated on quantization params");
+    }
+
+    #[test]
+    fn switch_linear_rejects_an_expert_plane_whose_packing_mlx_would_reject() {
+        // The bit-width inference falls back to the declared `bits` whenever the
+        // shapes solve to something outside the supported widths, which stores a
+        // triple MLX rejects in `extract_quantized_matmul_dims`. `packed_in * 32
+        // / bits` describes a 64-wide input here while 3 groups at group_size 64
+        // describe 192, so the checkpoint must fail at load rather than abort at
+        // the first routed forward pass.
+        let prefix = "model.layers.0.mlp.switch_mlp.gate_proj";
+        let weights = stacked_quantized_experts(prefix, 3, 4, 8, 3);
+        let err = SwitchLinear::from_weights(&weights, prefix, 64, 4)
+            .err()
+            .expect("an expert plane MLX would reject must fail at load");
+        assert!(err.contains("input width"), "unhelpful error: {err}");
+
+        // The mixed-precision inference the fallback exists for is untouched: a
+        // genuinely 8-bit plane under a 4-bit config default still reconciles.
+        let mixed = stacked_quantized_experts(prefix, 3, 4, 16, 1);
+        let sl = SwitchLinear::from_weights(&mixed, prefix, 64, 4)
+            .expect("a per-tensor bit override must still load");
+        let parts = sl.quantized_parts().expect("quantized");
+        assert_eq!(parts.bits, 8);
+        assert_eq!(parts.group_size, 64);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

An unvalidated `quantization` block in `config.json` reached MLX and terminated the process. `reconcile_quantization_layout` returned a non-positive `group_size` / `bits` pair unchanged on a trust-the-caller basis, and MLX reconstructs a quantized matrix's unpacked width as `w.shape(-1) * 32 / bits` in `validate_quantized_input`, so a declared `"bits": 0` is a division by zero and anything above 32 collapses the quotient to something no real `scales` width can match. `quantized_matmul`, `gather_qmm` and `dequantize` all cross the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`, so the C++ throw is an uncatchable `std::terminate` at the first forward pass rather than a load error: a repository with real `.scales` and `"bits": 0` loaded cleanly and took `mlxcel-server` down on the first request that touched a quantized projection. The second half of the issue is the same shape: `validate_embedding_table` skipped the width check for a quantized table, so a table honestly packed for a different model width kept exactly the right row count, passed load, and then fed a wrong-width hidden state into `fast::layer_norm` / `fast::rms_norm`.

Both are now rejected at load, on every quantizing family, dense and MoE.

## What changed

**`src/lib/mlxcel-core/src/layers.rs`**

- New `validate_quantization_params(group_size, bits)`: rejects `bits` outside `1..=32` and `group_size < 1`, with a message naming the offending field and value. It is a bounds check rather than an allowlist of the widths MLX supports, because mlxcel deliberately re-derives bit width from tensor shapes when the declared value disagrees, and an allowlist of `{2,3,4,5,6,8}` would reject the mixed-precision exports that behavior serves (the Qwen3.5/3.6 MoE per-path overrides, the minicpm-v mxfp4 group-size case).
- `reconcile_quantization_layout` calls it before anything else. The old early return folded "degenerate shapes" and "degenerate params" into one condition, which is what let an empty shape launder a hostile pair; the shape case stays permissive, the param case does not.
- New `validate_quantized_packing` plus `QuantizedTensorShapes`, hoisted verbatim (messages included) out of `bailing_moe.rs`. It reconstructs the input width the way MLX does, as `scales.shape(-1) * group_size` using the reconciled group size, and checks `.biases` shape equals `.scales` shape. Works for a 2-D projection and a 3-D stacked expert plane alike.
- New `infer_quantization_mode(has_biases, group_size, bits)`, deduplicating the identical mode-inference block that sat in `UnifiedLinear::from_weights`, `QuantizedEmbedding::from_weights` and `bailing_moe::quant_mode`.
- New `UnifiedEmbedding::quantized()` accessor, so a load-time validator can reach the scales shape and the reconciled params that `is_quantized()` alone cannot give it.

**`src/models/switch_layers.rs`** (the scope correction the issue records)

`SwitchLinear::from_stacked_parts` never calls the reconciler, re-derives bits itself and accepts the result only in `2..=8`, and never infers `group_size` at all, so a declared `0` zeroed the denominator, skipped inference entirely, and was stored on `SwitchLinear::Quantized` and handed to `gather_qmm`, which reaches the same `/bits` line through the same `extract_quantized_matmul_dims`. A reconciler-only guard would have left every quantized MoE checkpoint exposed. It is now fallible, takes the prefix so the error names the tensor, bounds the declared pair itself, and additionally refuses a stored triple that fails MLX's own predicate from `validate_quantized_input`, evaluated in i64 so the multiply cannot wrap on a large expert plane. That second check matters because the existing fallback to the declared `bits` whenever the shapes solve outside `2..=8` guaranteed a throw. The mixed-precision inference the fallback exists for is untouched (a genuinely 8-bit plane under a 4-bit config default still reconciles), degenerate shapes evaluate to `0 == 0` and stay permissive, and a non-quantized expert plane is not gated on quantization params at all.

The families that carry a local quantized expert type are unchanged and are not in this diff, and they are **not** covered by this PR. An earlier version of this body claimed they were, on the grounds that each loads `embed_tokens` through `UnifiedEmbedding::from_weights` first. That is wrong and has been retracted: `UnifiedEmbedding::from_weights` only reaches the reconciler when `.scales` exists, so a float embedding with quantized expert planes (the canonical gpt-oss shape) never touches a guarded loader; `gpt_oss` resolves quantization params per weight prefix, so a hostile pair scoped to the experts leaves every guarded loader with a valid one; and `mamba` / `mamba2` build `QuantizedEmbedding` by hand, bypassing the reconciler entirely. Those eighteen call sites are filed as #958.

**`src/models/gpt2.rs`**

`validate_embedding_table` no longer skips the width check for a quantized table. The dequantized width is recoverable at load, so the quantized case goes through the shared `validate_quantized_packing` and the four families behind that helper (BailingMoe, Gpt2, GptBigCode, GptNeoX) get the check instead of one family owning a private copy.

**`src/models/bailing_moe.rs`, `src/models/gpt_neox.rs`, `src/models/helium.rs`**

The three duplicated per-family bounds checks are folded into the shared guard and kept only as delegating early diagnostics that name the family and fire during config validation, before any tensor is touched. `bailing_moe::validate_quantized_packing` becomes a thin `WeightMap` adapter over the shared function. The tree-wide grep for `bits < 1 | bits > 32 | group_size < 1` now matches only `layers.rs`, down from three model files plus the shared crate.

## Notes

`bits == 0` is C++ undefined behavior and the targets diverge: on AArch64 the divide returns 0 so `std::invalid_argument` fires, while on x86-64 the hardware raises `SIGFPE` and kills the process before any exception exists. Only the AArch64 outcome is reachable from this machine; the x86-64 path is recorded in the doc comment rather than tested.

The regression tests deliberately drive the bad values through the real load path rather than the pure shape helpers, so a regression aborts the test binary with SIGABRT instead of failing cleanly. Every hostile case is paired with a positive control, so no guard can pass by rejecting everything quantized.


## Review follow-ups applied

A review of the first commit found two correctness holes in the guards this PR adds, both fixed in the second commit:

- `validate_quantized_packing` compared only the scales side against the config width, which is not MLX's test. MLX compares the scales side against `w.shape(-1) * 32 / bits`, and the block-float reconciler keeps the declared `group_size` in both of its fallbacks, so a triple could satisfy the config check while the packed weight described a different width and MLX still threw. Both sides are now compared, in i64.
- `group_size` was bounded below but not above. A declared `i32::MAX` survived the block-float fallback and reached `quantized_matmul`, where MLX multiplies it by the scales width in C++ `int`: signed overflow, and therefore undefined behavior reached before the shape check that would have thrown. It is now bounded at 2^20, an overflow bound rather than an allowlist, with the arithmetic that justifies it recorded on the constant.

Also from that review: the i32 `num_groups * group_size` in `from_stacked_parts` moved to i64 (it wrapped in release and panicked in an overflow-checked build), a zero or absent last axis is now rejected instead of satisfying `0 == 0` and aborting later, the MoE path gained the `biases`-shape check that is a second `validate_quantized_input` throw, and several documentation and message-wording items. The `weight` dtype condition from `validate_quantized_input` is deliberately still unchecked, with the reason recorded in the doc comment: the in-tree fixtures build packed weights as f32.

## Test plan

- [x] `cargo test --release --lib --features metal,accelerate models::switch_layers` (21 passed, including the two new MoE guards over both the pre-stacked and per-expert layouts)
- [x] `cargo test --release --lib --features metal,accelerate models::gpt2` (27 passed, including the quantized position-table width guard and the shared-guard load rejection)
- [x] `cargo test --release --lib --features metal,accelerate models::bailing_moe` (42 passed, unchanged messages after the hoist)
- [x] `cargo test --release --lib --features metal,accelerate models::gpt_neox` (32), `models::helium` (27), `models::gpt_bigcode` (20)
- [x] `cargo test --release -p mlxcel-core --lib --features metal,accelerate layers::tests` (61 passed, including the four new quantization tests)
- [x] MoE regression sweep: `models::{mixtral,qwen2_moe,olmoe,phimoe,deepseek,dots1,gemma4,minimax}` all green
- [x] `cargo clippy --release --lib --tests --features metal,accelerate` clean apart from the two warnings already on `main` in `src/multimodal/host_preprocessor.rs` and `host_preprocessor_export.rs`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --release -p mlxcel-core --lib layers::tests` re-run after the review fixes (62 passed, including the new weight-side packing test and the `group_size` upper bound), plus the full model sweep above
- [ ] Real quantized checkpoint load, to confirm normal loading is unaffected. Not run in this environment: the release binaries are not built here and the MoE reference checkpoint is 33.6 GB. Left for the follow-up validation pass. This matters more than usual for the embedding-table change, which converts one class of currently-loading-but-garbage-decoding tables (an affine table packed at group 32 under a config default of 64) into a load error.

Closes #929

