### PR TITLE
fix: recognize n_layer / n_embd and multi_query in KV estimation

### DIFF
--- a/src/execution/config_fields.rs
+++ b/src/execution/config_fields.rs
@@ -1,0 +1,213 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Single source of truth for the `config.json` field-name aliases the
+//! memory / KV estimators read.
+//!
+//! Checkpoints spell the same architectural quantity several ways: the modern
+//! HuggingFace `num_hidden_layers` / `hidden_size`, the MPT / OLMo `d_model`,
+//! and the OpenAI-era `n_layer` / `n_embd` that GPT-2 and GPT-BigCode still
+//! use. Every estimator has to accept all of them or it silently reports zero
+//! for a family whose config it cannot parse.
+//!
+//! Before this module the alias lists were copied into five independent
+//! `.or_else()` chains across `kv_arch`, `memory_estimate` (twice),
+//! `kv_cache_advisor`, and `quant_advisor`. A spelling added to one was not
+//! added to the others, which is exactly how the GPT-2 / GPT-BigCode gap
+//! (#927) reproduced in every one of them. Add a new alias here, once.
+//!
+//! Ordering inside each list is significant: the first present key wins, so
+//! the modern spellings lead and the legacy ones trail. Appending an alias
+//! therefore cannot change what an already-resolving config resolves to.
+
+use serde_json::Value;
+
+/// Transformer layer count.
+///
+/// `n_layer` (singular) is the OpenAI-era spelling carried by GPT-2 and
+/// GPT-BigCode configs; without it `classify` short-circuits and the whole KV
+/// estimate is reported as unavailable.
+pub(crate) const LAYER_COUNT_KEYS: &[&str] =
+    &["num_hidden_layers", "n_layers", "num_layers", "n_layer"];
+
+/// Model hidden size (embedding width).
+///
+/// `n_embd` is the matching OpenAI-era spelling. It is the fallback source for
+/// `head_dim` (`hidden / num_heads`) and the basis of the activation reserve.
+pub(crate) const HIDDEN_SIZE_KEYS: &[&str] =
+    &["hidden_size", "d_model", "dim", "model_dim", "n_embd"];
+
+/// Query (attention) head count.
+pub(crate) const NUM_HEADS_KEYS: &[&str] =
+    &["num_attention_heads", "num_heads", "n_heads", "n_head"];
+
+/// Numeric key/value head count, for grouped-query and multi-query attention.
+///
+/// This list is numeric only. GPT-BigCode carries none of these keys and
+/// instead signals multi-query attention with the boolean [`MULTI_QUERY_KEY`];
+/// use [`resolve_num_kv_heads`] rather than reading this list directly.
+pub(crate) const NUM_KV_HEADS_KEYS: &[&str] = &[
+    "num_key_value_heads",
+    "num_kv_heads",
+    "n_kv_heads",
+    "n_head_kv",
+    "multi_query_group_num",
+];
+
+/// Explicit per-head dimension, when the config states it outright.
+pub(crate) const HEAD_DIM_KEYS: &[&str] = &["head_dim", "head_size"];
+
+/// FFN intermediate width.
+pub(crate) const INTERMEDIATE_SIZE_KEYS: &[&str] =
+    &["intermediate_size", "ffn_dim", "ffn_hidden_size"];
+
+/// Boolean multi-query-attention flag (GPT-BigCode, Falcon).
+///
+/// `true` means exactly one key/value head shared across every query head.
+pub(crate) const MULTI_QUERY_KEY: &str = "multi_query";
+
+/// The decoder sub-object of a VLM config, or the config itself for text
+/// models. VLMs nest the language model under `text_config`.
+pub(crate) fn text_config(config: &Value) -> &Value {
+    config.get("text_config").unwrap_or(config)
+}
+
+/// First present `u64` among `keys` in `obj`.
+pub(crate) fn get_u64(obj: &Value, keys: &[&str]) -> Option<u64> {
+    keys.iter()
+        .find_map(|k| obj.get(*k).and_then(|v| v.as_u64()))
+}
+
+/// First present `f64` among `keys` in `obj`.
+pub(crate) fn get_f64(obj: &Value, keys: &[&str]) -> Option<f64> {
+    keys.iter()
+        .find_map(|k| obj.get(*k).and_then(|v| v.as_f64()))
+}
+
+/// Whether the config declares boolean multi-query attention.
+///
+/// Only a literal `true` counts. An absent flag, `false`, or a non-boolean
+/// value all mean "not multi-query", so a malformed config keeps the ordinary
+/// head-count behaviour instead of silently collapsing to one KV head.
+pub(crate) fn is_multi_query(text: &Value) -> bool {
+    text.get(MULTI_QUERY_KEY).and_then(Value::as_bool) == Some(true)
+}
+
+/// Resolve the number of key/value heads, honouring both the numeric fields
+/// and the boolean multi-query flag.
+///
+/// Precedence, highest first:
+///
+/// 1. An explicit numeric field from [`NUM_KV_HEADS_KEYS`]. A config that
+///    states a count means it, even if it also carries `multi_query`.
+/// 2. `multi_query: true`, which means exactly one shared KV head.
+/// 3. `num_heads`, the plain MHA fallback.
+///
+/// Step 2 exists because GPT-BigCode expresses MQA only as a boolean.
+/// `GptBigCodeArgs::n_kv_heads` (`src/models/gpt_bigcode.rs`) returns
+/// `if multi_query { 1 } else { n_head }`, and the runtime caches accordingly.
+/// Falling straight through to step 3 would claim `n_head` KV heads where one
+/// is cached and over-reserve the KV estimate by that whole factor: 16x for
+/// santacoder, 48x for a StarCoder-sized checkpoint.
+///
+/// Safe for the degenerate `multi_query: true` with `n_head: 0` shape that the
+/// model-side `validate` rejects at load: the result is 1 regardless of
+/// `num_heads`, and no caller divides by the returned value.
+pub(crate) fn resolve_num_kv_heads(text: &Value, num_heads: u64) -> u64 {
+    if let Some(kv) = get_u64(text, NUM_KV_HEADS_KEYS) {
+        return kv;
+    }
+    if is_multi_query(text) {
+        return 1;
+    }
+    num_heads
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn alias_lists_prefer_modern_spellings_over_legacy() {
+        // A config carrying both spellings must resolve to the modern one, so
+        // appending a legacy alias cannot move an existing estimate.
+        let cfg = json!({
+            "num_hidden_layers": 32,
+            "n_layer": 12,
+            "hidden_size": 4096,
+            "n_embd": 768,
+        });
+        assert_eq!(get_u64(&cfg, LAYER_COUNT_KEYS), Some(32));
+        assert_eq!(get_u64(&cfg, HIDDEN_SIZE_KEYS), Some(4096));
+    }
+
+    #[test]
+    fn openai_era_spellings_resolve() {
+        let cfg = json!({ "n_layer": 12, "n_embd": 768, "n_head": 12 });
+        assert_eq!(get_u64(&cfg, LAYER_COUNT_KEYS), Some(12));
+        assert_eq!(get_u64(&cfg, HIDDEN_SIZE_KEYS), Some(768));
+        assert_eq!(get_u64(&cfg, NUM_HEADS_KEYS), Some(12));
+    }
+
+    #[test]
+    fn multi_query_true_is_one_kv_head() {
+        let cfg = json!({ "n_head": 16, "multi_query": true });
+        assert!(is_multi_query(&cfg));
+        assert_eq!(resolve_num_kv_heads(&cfg, 16), 1);
+    }
+
+    #[test]
+    fn multi_query_false_or_absent_falls_back_to_mha() {
+        let explicit_false = json!({ "n_head": 16, "multi_query": false });
+        assert!(!is_multi_query(&explicit_false));
+        assert_eq!(resolve_num_kv_heads(&explicit_false, 16), 16);
+
+        let absent = json!({ "n_head": 16 });
+        assert!(!is_multi_query(&absent));
+        assert_eq!(resolve_num_kv_heads(&absent, 16), 16);
+    }
+
+    #[test]
+    fn numeric_kv_head_field_outranks_multi_query() {
+        let cfg = json!({
+            "num_attention_heads": 71,
+            "num_kv_heads": 8,
+            "multi_query": true,
+        });
+        assert_eq!(resolve_num_kv_heads(&cfg, 71), 8);
+    }
+
+    #[test]
+    fn non_boolean_multi_query_is_not_multi_query() {
+        let cfg = json!({ "n_head": 16, "multi_query": "true" });
+        assert!(!is_multi_query(&cfg));
+        assert_eq!(resolve_num_kv_heads(&cfg, 16), 16);
+    }
+
+    #[test]
+    fn multi_query_with_zero_heads_stays_at_one() {
+        let cfg = json!({ "n_head": 0, "multi_query": true });
+        assert_eq!(resolve_num_kv_heads(&cfg, 0), 1);
+    }
+
+    #[test]
+    fn text_config_unwraps_vlm_nesting() {
+        let vlm = json!({ "text_config": { "n_layer": 4 } });
+        assert_eq!(get_u64(text_config(&vlm), LAYER_COUNT_KEYS), Some(4));
+
+        let text_only = json!({ "n_layer": 4 });
+        assert_eq!(get_u64(text_config(&text_only), LAYER_COUNT_KEYS), Some(4));
+    }
+}

--- a/src/execution/kv_arch.rs
+++ b/src/execution/kv_arch.rs
@@ -47,6 +47,11 @@ use std::path::Path;
 use mlxcel_core::hardware::KV_CACHE_ALLOC_STEP;
 use serde_json::Value;
 
+use crate::execution::config_fields::{
+    HEAD_DIM_KEYS, HIDDEN_SIZE_KEYS, LAYER_COUNT_KEYS, NUM_HEADS_KEYS, get_u64,
+    resolve_num_kv_heads,
+};
+
 /// Which KV architecture [`estimate_kv_arch`] detected, for labelling output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KvArchKind {
@@ -119,12 +124,6 @@ fn elem_bytes(int8: bool) -> u64 {
     if int8 { 1 } else { 2 }
 }
 
-/// First present `u64` among `keys` in `obj`.
-fn get_u64(obj: &Value, keys: &[&str]) -> Option<u64> {
-    keys.iter()
-        .find_map(|k| obj.get(*k).and_then(|v| v.as_u64()))
-}
-
 fn get_str<'a>(obj: &'a Value, key: &str) -> Option<&'a str> {
     obj.get(key).and_then(|v| v.as_str())
 }
@@ -140,27 +139,18 @@ struct AttnDims {
 /// caller that a standard / sliding / hybrid KV figure cannot be computed. The
 /// MLA and pure-SSM paths do not call this — they size their cache from
 /// architecture-specific fields and need only the layer count.
+///
+/// Field names come from [`crate::execution::config_fields`], shared with the
+/// activation estimator and the KV-cache-mode advisor so the three never
+/// disagree about which spellings a config may use. The KV-head count goes
+/// through `resolve_num_kv_heads`, which honours GPT-BigCode's boolean
+/// `multi_query` as one shared head.
 fn attn_dims(text: &Value) -> Option<AttnDims> {
-    let num_heads = get_u64(
-        text,
-        &["num_attention_heads", "num_heads", "n_heads", "n_head"],
-    )
-    .unwrap_or(1)
-    .max(1);
-    let num_kv_heads = get_u64(
-        text,
-        &[
-            "num_key_value_heads",
-            "num_kv_heads",
-            "n_kv_heads",
-            "n_head_kv",
-            "multi_query_group_num",
-        ],
-    )
-    .unwrap_or(num_heads);
-    let head_dim = match get_u64(text, &["head_dim", "head_size"]) {
+    let num_heads = get_u64(text, NUM_HEADS_KEYS).unwrap_or(1).max(1);
+    let num_kv_heads = resolve_num_kv_heads(text, num_heads);
+    let head_dim = match get_u64(text, HEAD_DIM_KEYS) {
         Some(h) => h,
-        None => get_u64(text, &["hidden_size", "d_model", "dim", "model_dim"])?
+        None => get_u64(text, HIDDEN_SIZE_KEYS)?
             .checked_div(num_heads)
             .unwrap_or(64),
     };
@@ -241,7 +231,7 @@ fn count_attention_layers(text: &Value, num_layers: u64) -> Option<u64> {
 
 /// Classify a model's config into KV layer groups and an architecture kind.
 fn classify(text: &Value, model_type: &str) -> Option<(Vec<KvGroup>, KvArchKind)> {
-    let num_layers = get_u64(text, &["num_hidden_layers", "n_layers", "num_layers"])?;
+    let num_layers = get_u64(text, LAYER_COUNT_KEYS)?;
     let mt = model_type.to_ascii_lowercase();
 
     // 1. Pure SSM — no context-proportional KV cache (needs only the layer count).
@@ -254,12 +244,7 @@ fn classify(text: &Value, model_type: &str) -> Option<(Vec<KvGroup>, KvArchKind)
     //    but NOT `head_dim` (a config may omit it). V3/V3.2 cache the compressed
     //    latent + rope (shared across heads); V2 caches decompressed per-head.
     if let Some(kv_lora_rank) = get_u64(text, &["kv_lora_rank"]) {
-        let num_heads = get_u64(
-            text,
-            &["num_attention_heads", "num_heads", "n_heads", "n_head"],
-        )
-        .unwrap_or(1)
-        .max(1);
+        let num_heads = get_u64(text, NUM_HEADS_KEYS).unwrap_or(1).max(1);
         let rope = get_u64(text, &["qk_rope_head_dim"]).unwrap_or(64);
         if mt.contains("v3") || mt.contains("v32") {
             // Cached form: (kv_latent[kv_lora_rank] , k_pe[qk_rope_head_dim]).
@@ -789,6 +774,137 @@ mod tests {
     fn missing_architecture_fields_returns_none() {
         let cfg = json!({ "vocab_size": 32000 });
         assert!(estimate_kv_arch_from_config(&cfg, 4096, false, 1).is_none());
+    }
+
+    // ── OpenAI-era field naming: GPT-2 / GPT-BigCode (#927) ──────────────────
+
+    /// `models/gpt2` verbatim: `n_layer` / `n_embd` / `n_head`, no
+    /// `multi_query`, so plain MHA at head_dim 64.
+    #[test]
+    fn gpt2_n_layer_and_n_embd_classify_as_standard_mha() {
+        let cfg = json!({
+            "model_type": "gpt2",
+            "n_layer": 12,
+            "n_head": 12,
+            "n_embd": 768,
+            "vocab_size": 50257,
+        });
+        let e = est(&cfg, 8192);
+        assert_eq!(e.kind, KvArchKind::Standard);
+        // 12 layers × 2 (K+V) × 12 kv heads × 64 head_dim × 8192 × 2 bytes.
+        assert_eq!(e.total_bytes, 12 * 2 * 12 * 64 * 8192 * FP16);
+        assert_eq!(e.total_bytes, 301_989_888);
+        assert_eq!(e.marginal_bytes_per_token, 36_864);
+    }
+
+    /// `models/gpt_bigcode-santacoder` verbatim. The boolean `multi_query`
+    /// means ONE shared kv head; falling through to the `num_kv_heads =
+    /// num_heads` MHA default would over-reserve by 16x (1.50 GiB).
+    #[test]
+    fn gpt_bigcode_multi_query_is_one_kv_head() {
+        let cfg = json!({
+            "model_type": "gpt_bigcode",
+            "n_layer": 24,
+            "n_head": 16,
+            "n_embd": 2048,
+            "n_inner": 8192,
+            "multi_query": true,
+            "vocab_size": 49280,
+        });
+        let e = est(&cfg, 8192);
+        assert_eq!(e.kind, KvArchKind::Standard);
+        // 24 layers × 2 (K+V) × 1 kv head × 128 head_dim × 8192 × 2 bytes.
+        assert_eq!(e.total_bytes, 24 * 2 * 128 * 8192 * FP16);
+        assert_eq!(e.total_bytes, 100_663_296);
+        assert_eq!(e.marginal_bytes_per_token, 12_288);
+        // Explicitly below the alias-only-fix figure, which is the trap.
+        let mha_would_be = 24u64 * 2 * 16 * 128 * 8192 * FP16;
+        assert_eq!(mha_would_be, 1_610_612_736);
+        assert_eq!(e.total_bytes * 16, mha_would_be);
+    }
+
+    /// `multi_query: false` must degenerate to `n_head` kv heads, so the
+    /// branch cannot silently shrink a non-MQA checkpoint.
+    #[test]
+    fn gpt_bigcode_multi_query_false_is_full_mha() {
+        let cfg = json!({
+            "model_type": "gpt_bigcode",
+            "n_layer": 24,
+            "n_head": 16,
+            "n_embd": 2048,
+            "multi_query": false,
+        });
+        let e = est(&cfg, 8192);
+        assert_eq!(e.kind, KvArchKind::Standard);
+        assert_eq!(e.total_bytes, 24 * 2 * 16 * 128 * 8192 * FP16);
+    }
+
+    /// A StarCoder-sized head count: the over-reservation the `multi_query`
+    /// branch avoids scales with `n_head`, so it is 48x here, not 16x.
+    #[test]
+    fn gpt_bigcode_over_reservation_scales_with_n_head() {
+        let cfg = json!({
+            "model_type": "gpt_bigcode",
+            "n_layer": 40,
+            "n_head": 48,
+            "n_embd": 6144,
+            "multi_query": true,
+        });
+        let e = est(&cfg, 8192);
+        assert_eq!(e.total_bytes, 40 * 2 * 128 * 8192 * FP16);
+        let mha_would_be = 40u64 * 2 * 48 * 128 * 8192 * FP16;
+        assert_eq!(e.total_bytes * 48, mha_would_be);
+    }
+
+    /// An explicit numeric kv-head field outranks the boolean, so a config
+    /// carrying both is read the way it states.
+    #[test]
+    fn numeric_kv_heads_outrank_multi_query_flag() {
+        let cfg = json!({
+            "num_hidden_layers": 4,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "multi_query": true,
+        });
+        let e = est(&cfg, 1024);
+        assert_eq!(e.total_bytes, 4 * 2 * 8 * 128 * 1024 * FP16);
+    }
+
+    /// The three families verified on real checkpoints in #927 must keep
+    /// byte-identical estimates: appending aliases must not move them.
+    #[test]
+    fn modern_naming_families_are_unchanged() {
+        // models/pythia-1b (gpt_neox).
+        let pythia = json!({
+            "model_type": "gpt_neox",
+            "num_hidden_layers": 16,
+            "hidden_size": 2048,
+            "num_attention_heads": 8,
+        });
+        assert_eq!(est(&pythia, 8192).total_bytes, 1_073_741_824);
+
+        // models/helium-1-preview-2b-4bit.
+        let helium = json!({
+            "model_type": "helium",
+            "num_hidden_layers": 24,
+            "hidden_size": 2560,
+            "num_attention_heads": 20,
+            "num_key_value_heads": 20,
+            "head_dim": 128,
+        });
+        assert_eq!(est(&helium, 8192).total_bytes, 2_013_265_920);
+
+        // models/ling-lite-1.5 (bailing_moe): the sparse block changes only
+        // the FFN, so the attention stack is ordinary GQA.
+        let ling = json!({
+            "model_type": "bailing_moe",
+            "num_hidden_layers": 28,
+            "hidden_size": 2048,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+        });
+        assert_eq!(est(&ling, 8192).total_bytes, 469_762_048);
     }
 
     #[test]

--- a/src/execution/kv_cache_advisor.rs
+++ b/src/execution/kv_cache_advisor.rs
@@ -57,6 +57,7 @@ use std::path::Path;
 use mlxcel_core::cache::KVCacheMode;
 use mlxcel_core::cache::turbo::is_symmetric_turbo_allowed;
 
+use crate::execution::config_fields;
 use crate::execution::kv_arch::{KvArchKind, estimate_kv_arch_from_config};
 use crate::execution::memory_estimate::DEFAULT_CTX_LEN;
 
@@ -329,32 +330,21 @@ fn read_model_type(config: &serde_json::Value) -> String {
 /// attention-head count. Returns `None` when the required fields are absent or
 /// heads is zero.
 ///
-/// The hidden-size and head-count field-name lists mirror
-/// [`crate::execution::kv_arch`]'s `attn_dims` so the non-power-of-two guard
-/// derives the same head dim the classifier used. Without this, alternate
-/// config naming (OLMo / MPT-style `d_model` + `n_heads`) would make this
-/// return `None`, defaulting `turbo_ok` to `true` and slipping a
-/// non-power-of-two head dim past the guard.
+/// The hidden-size and head-count field-name lists come from
+/// [`crate::execution::config_fields`], the same source
+/// [`crate::execution::kv_arch`]'s `attn_dims` reads, so the non-power-of-two
+/// guard derives the same head dim the classifier used. Without that sharing,
+/// alternate config naming (OLMo / MPT-style `d_model` + `n_heads`, or the
+/// OpenAI-era `n_embd` + `n_head`) would make this return `None`, defaulting
+/// `turbo_ok` to `true` and slipping a non-power-of-two head dim past the
+/// guard.
 fn read_head_dim(config: &serde_json::Value) -> Option<u64> {
-    let text = config.get("text_config").unwrap_or(config);
-    if let Some(d) = text.get("head_dim").and_then(|v| v.as_u64()) {
+    let text = config_fields::text_config(config);
+    if let Some(d) = config_fields::get_u64(text, config_fields::HEAD_DIM_KEYS) {
         return Some(d);
     }
-    if let Some(d) = text.get("head_size").and_then(|v| v.as_u64()) {
-        return Some(d);
-    }
-    let hidden = text
-        .get("hidden_size")
-        .or_else(|| text.get("d_model"))
-        .or_else(|| text.get("dim"))
-        .or_else(|| text.get("model_dim"))
-        .and_then(|v| v.as_u64())?;
-    let heads = text
-        .get("num_attention_heads")
-        .or_else(|| text.get("num_heads"))
-        .or_else(|| text.get("n_heads"))
-        .or_else(|| text.get("n_head"))
-        .and_then(|v| v.as_u64())?;
+    let hidden = config_fields::get_u64(text, config_fields::HIDDEN_SIZE_KEYS)?;
+    let heads = config_fields::get_u64(text, config_fields::NUM_HEADS_KEYS)?;
     if heads == 0 {
         return None;
     }

--- a/src/execution/kv_cache_advisor_tests.rs
+++ b/src/execution/kv_cache_advisor_tests.rs
@@ -206,6 +206,52 @@ fn advise_classifies_standard_config_for_all_ranges() {
     assert_eq!(advices[2].suggested, KVCacheMode::Turbo4Delegated);
 }
 
+/// Both OpenAI-era families used to classify as unavailable, so
+/// `advise_kv_cache_modes_from_config` returned an empty vector and `mlxcel
+/// inspect` printed no KV-cache-mode section for them at all (#927).
+#[test]
+fn openai_era_naming_produces_advice() {
+    let gpt2 = serde_json::json!({
+        "model_type": "gpt2",
+        "n_layer": 12,
+        "n_head": 12,
+        "n_embd": 768,
+    });
+    let gpt_bigcode = serde_json::json!({
+        "model_type": "gpt_bigcode",
+        "n_layer": 24,
+        "n_head": 16,
+        "n_embd": 2048,
+        "multi_query": true,
+    });
+
+    for (name, cfg) in [("gpt2", gpt2), ("gpt_bigcode", gpt_bigcode)] {
+        let (kind, mt) =
+            arch_and_type_from_config(&cfg).unwrap_or_else(|| panic!("{name} should classify"));
+        assert_eq!(kind, KvArchKind::Standard, "{name} kind");
+        assert_eq!(mt, name, "{name} model_type");
+
+        let advices = advise_kv_cache_modes_from_config(&cfg);
+        assert_eq!(advices.len(), 3, "{name} advice count");
+        // head_dim is 64 (gpt2) / 128 (gpt_bigcode), both powers of two, so
+        // the Turbo guard does not downgrade the long-context suggestion.
+        assert_eq!(advices[2].suggested, KVCacheMode::Turbo4Delegated, "{name}");
+    }
+}
+
+/// `read_head_dim` derives from `n_embd` / `n_head` now that it shares the
+/// classifier's alias lists. Both families are powers of two, so nothing is
+/// downgraded, but the guard must be deriving a real value rather than
+/// defaulting permissively through `None`.
+#[test]
+fn openai_era_naming_derives_head_dim_for_turbo_guard() {
+    let gpt2 = serde_json::json!({ "n_embd": 768, "n_head": 12 });
+    assert_eq!(read_head_dim(&gpt2), Some(64));
+
+    let gpt_bigcode = serde_json::json!({ "n_embd": 2048, "n_head": 16 });
+    assert_eq!(read_head_dim(&gpt_bigcode), Some(128));
+}
+
 /// Computing advice must not change the runtime default. With no opt-in
 /// flags, the resolver still returns `Fp16`.
 #[test]

--- a/src/execution/memory_estimate.rs
+++ b/src/execution/memory_estimate.rs
@@ -56,6 +56,7 @@ use std::path::Path;
 use mlxcel_core::hardware::{HardwareCapabilities, KvCacheParams, get_hardware};
 use mlxcel_core::weights::weight_footprint_bytes;
 
+use super::config_fields;
 use super::quant_advisor::estimate_model_params_billions;
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -499,18 +500,19 @@ struct ActivationDims {
 /// VLM `text_config` nesting). `intermediate_size` falls back to `4 × hidden`
 /// (the common rule of thumb) and `vocab_size` to 0 (no logit buffer term)
 /// when absent. Returns `None` only when `hidden_size` is unavailable.
+///
+/// The alias lists come from [`crate::execution::config_fields`], shared with
+/// the KV classifier: a hidden-size spelling the classifier accepts but this
+/// function does not means a model reports a real KV figure next to a zero
+/// activation reserve.
 fn activation_dims_from_path(model_dir: &Path) -> Option<ActivationDims> {
     let config: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(model_dir.join("config.json")).ok()?).ok()?;
-    let text = config.get("text_config").unwrap_or(&config);
-    let lookup = |keys: &[&str]| -> Option<u64> {
-        keys.iter()
-            .find_map(|k| text.get(*k).and_then(|v| v.as_u64()))
-    };
-    let hidden = lookup(&["hidden_size", "d_model", "dim", "model_dim"])?;
-    let intermediate = lookup(&["intermediate_size", "ffn_dim", "ffn_hidden_size"])
+    let text = config_fields::text_config(&config);
+    let hidden = config_fields::get_u64(text, config_fields::HIDDEN_SIZE_KEYS)?;
+    let intermediate = config_fields::get_u64(text, config_fields::INTERMEDIATE_SIZE_KEYS)
         .unwrap_or_else(|| hidden.saturating_mul(4));
-    let vocab = lookup(&["vocab_size"]).unwrap_or(0);
+    let vocab = config_fields::get_u64(text, &["vocab_size"]).unwrap_or(0);
     Some(ActivationDims {
         hidden,
         intermediate,
@@ -707,6 +709,11 @@ fn parse_meminfo_kib(rest: &str) -> Option<u64> {
 /// back into the legacy recommendation engine without re-parsing
 /// `config.json` twice. Returns `None` when `config.json` is missing
 /// the architecture fields.
+///
+/// Field names and the KV-head resolution come from
+/// [`crate::execution::config_fields`], the same source
+/// [`crate::execution::kv_arch`] classifies from, so this cannot drift out of
+/// agreement with the classifier.
 pub fn kv_cache_params_from_path(
     model_dir: &Path,
     ctx_len: u64,
@@ -716,38 +723,13 @@ pub fn kv_cache_params_from_path(
     let config_path = model_dir.join("config.json");
     let config_str = std::fs::read_to_string(&config_path).ok()?;
     let config: serde_json::Value = serde_json::from_str(&config_str).ok()?;
-    let text_cfg = config.get("text_config").unwrap_or(&config);
+    let text_cfg = config_fields::text_config(&config);
 
-    let num_layers = text_cfg
-        .get("num_hidden_layers")
-        .or_else(|| text_cfg.get("n_layers"))
-        .or_else(|| text_cfg.get("num_layers"))
-        .and_then(|v| v.as_u64())?;
-    let hidden_size = text_cfg
-        .get("hidden_size")
-        .or_else(|| text_cfg.get("d_model"))
-        .or_else(|| text_cfg.get("dim"))
-        .or_else(|| text_cfg.get("model_dim"))
-        .and_then(|v| v.as_u64());
-    let num_heads = text_cfg
-        .get("num_attention_heads")
-        .or_else(|| text_cfg.get("num_heads"))
-        .or_else(|| text_cfg.get("n_heads"))
-        .or_else(|| text_cfg.get("n_head"))
-        .and_then(|v| v.as_u64())
-        .unwrap_or(1);
-    let num_kv_heads = text_cfg
-        .get("num_key_value_heads")
-        .or_else(|| text_cfg.get("num_kv_heads"))
-        .or_else(|| text_cfg.get("n_kv_heads"))
-        .or_else(|| text_cfg.get("n_head_kv"))
-        .or_else(|| text_cfg.get("multi_query_group_num"))
-        .and_then(|v| v.as_u64())
-        .unwrap_or(num_heads);
-    let explicit_head_dim = text_cfg
-        .get("head_dim")
-        .or_else(|| text_cfg.get("head_size"))
-        .and_then(|v| v.as_u64());
+    let num_layers = config_fields::get_u64(text_cfg, config_fields::LAYER_COUNT_KEYS)?;
+    let hidden_size = config_fields::get_u64(text_cfg, config_fields::HIDDEN_SIZE_KEYS);
+    let num_heads = config_fields::get_u64(text_cfg, config_fields::NUM_HEADS_KEYS).unwrap_or(1);
+    let num_kv_heads = config_fields::resolve_num_kv_heads(text_cfg, num_heads);
+    let explicit_head_dim = config_fields::get_u64(text_cfg, config_fields::HEAD_DIM_KEYS);
     let head_dim = if let Some(head_dim) = explicit_head_dim {
         head_dim
     } else if let Some(hidden_size) = hidden_size {
@@ -1173,6 +1155,100 @@ mod tests {
         let params = kv_cache_params_from_path(tmp.path(), 256, false, 1).unwrap();
         assert_eq!(params.head_dim, 256);
         assert_eq!(kv_cache_bytes_from_params(&params), 35 * 2 * 256 * 2 * 256);
+    }
+
+    // ── OpenAI-era field naming: GPT-2 / GPT-BigCode (#927) ──────────────────
+
+    fn write_config(dir: &Path, cfg: &serde_json::Value) {
+        std::fs::write(dir.join("config.json"), serde_json::to_string(cfg).unwrap()).unwrap();
+    }
+
+    /// `models/gpt2` verbatim.
+    fn gpt2_config() -> serde_json::Value {
+        serde_json::json!({
+            "model_type": "gpt2",
+            "n_layer": 12,
+            "n_head": 12,
+            "n_embd": 768,
+            "vocab_size": 50257,
+        })
+    }
+
+    /// `models/gpt_bigcode-santacoder` verbatim.
+    fn gpt_bigcode_config() -> serde_json::Value {
+        serde_json::json!({
+            "model_type": "gpt_bigcode",
+            "n_layer": 24,
+            "n_head": 16,
+            "n_embd": 2048,
+            "n_inner": 8192,
+            "multi_query": true,
+            "vocab_size": 49280,
+        })
+    }
+
+    /// Before #927 both families reported `KvSource::Unavailable` with 0 KV
+    /// bytes AND a 0-byte activation reserve, because the layer-count and
+    /// hidden-size lookups did not alias `n_layer` / `n_embd`.
+    #[test]
+    fn openai_era_naming_yields_nonzero_kv_and_activation() {
+        for (name, cfg, expected_kv) in [
+            ("gpt2", gpt2_config(), 301_989_888u64),
+            ("gpt_bigcode", gpt_bigcode_config(), 100_663_296u64),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            write_config(tmp.path(), &cfg);
+
+            let est = estimate_total_memory(tmp.path(), 8192, 1, QuantHint::Default, false);
+            assert_eq!(est.kv_source, KvSource::Config, "{name} kv source");
+            assert_eq!(est.kv_cache_bytes, expected_kv, "{name} kv bytes");
+            assert!(
+                !est.kv_detail.contains("unavailable"),
+                "{name} detail should not say unavailable, got {}",
+                est.kv_detail
+            );
+            assert!(
+                est.activation_bytes > 0,
+                "{name} activation reserve should be non-zero"
+            );
+        }
+    }
+
+    /// `kv_cache_params_from_path` duplicates the classifier's geometry for the
+    /// legacy recommendation engine; it must agree, boolean `multi_query`
+    /// included, or the two surfaces disagree by a factor of `n_head`.
+    #[test]
+    fn kv_params_agree_with_classifier_for_openai_era_naming() {
+        for (name, cfg, expected_kv_heads, expected_head_dim) in [
+            ("gpt2", gpt2_config(), 12u64, 64u64),
+            ("gpt_bigcode", gpt_bigcode_config(), 1u64, 128u64),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            write_config(tmp.path(), &cfg);
+
+            let params = kv_cache_params_from_path(tmp.path(), 8192, false, 1)
+                .unwrap_or_else(|| panic!("{name} params"));
+            assert_eq!(params.num_kv_heads, expected_kv_heads, "{name} kv heads");
+            assert_eq!(params.head_dim, expected_head_dim, "{name} head dim");
+
+            let est = estimate_total_memory(tmp.path(), 8192, 1, QuantHint::Default, false);
+            assert_eq!(
+                kv_cache_bytes_from_params(&params),
+                est.kv_cache_bytes,
+                "{name}: params and classifier must agree"
+            );
+        }
+    }
+
+    /// `paged_block_bytes` fed the server's `--kv-cache-budget auto` ceiling a
+    /// `None` for both families, leaving the pool unbounded.
+    #[test]
+    fn paged_block_bytes_resolves_for_openai_era_naming() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), &gpt_bigcode_config());
+        // 24 layers x 2 (K+V) x 1 kv head x 128 head_dim x 2 bytes = 12288/token
+        // across all layers, so 512 bytes per layer per token, x 16 tokens.
+        assert_eq!(paged_block_bytes(tmp.path(), 24, 16, false), Some(8192));
     }
 
     #[test]

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -18,6 +18,7 @@
 //! entry points easier to add without re-implementing environment parsing or
 //! generation defaults in multiple places.
 
+pub(crate) mod config_fields;
 pub mod kv_arch;
 pub mod kv_cache_advisor;
 pub mod memory_estimate;

--- a/src/execution/quant_advisor.rs
+++ b/src/execution/quant_advisor.rs
@@ -22,6 +22,7 @@ use std::path::Path;
 
 use mlxcel_core::hardware::{HardwareCapabilities, QuantRecommendation, recommend_quantization};
 
+use crate::execution::config_fields;
 use crate::execution::kv_cache_advisor::{
     KvCacheModeAdvice, advise_kv_cache_modes, print_kv_cache_advice,
 };
@@ -54,68 +55,49 @@ pub fn estimate_model_params_billions(model_path: &Path) -> Option<f64> {
     estimate_params_from_config(&config)
 }
 
+/// Field names come from [`crate::execution::config_fields`], shared with the
+/// KV classifier and the activation estimator so a spelling accepted by one is
+/// accepted by all of them.
 fn estimate_params_from_config(config: &serde_json::Value) -> Option<f64> {
     // Support models that wrap text config under a "text_config" key (VLMs).
-    let text_cfg = config.get("text_config").unwrap_or(config);
+    let text_cfg = config_fields::text_config(config);
 
-    let hidden_size = text_cfg
-        .get("hidden_size")
-        .or_else(|| text_cfg.get("d_model"))
-        .or_else(|| text_cfg.get("dim"))
-        .or_else(|| text_cfg.get("model_dim"))
-        .and_then(|v| v.as_f64())?;
+    let hidden_size = config_fields::get_f64(text_cfg, config_fields::HIDDEN_SIZE_KEYS)?;
 
-    let num_layers = text_cfg
-        .get("num_hidden_layers")
-        .or_else(|| text_cfg.get("n_layers"))
-        .or_else(|| text_cfg.get("num_layers"))
-        .and_then(|v| v.as_f64())?;
+    let num_layers = config_fields::get_f64(text_cfg, config_fields::LAYER_COUNT_KEYS)?;
 
-    let vocab_size = text_cfg
-        .get("vocab_size")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(32_000.0);
+    let vocab_size = config_fields::get_f64(text_cfg, &["vocab_size"]).unwrap_or(32_000.0);
 
     // FFN intermediate size — try several field names used across architectures.
-    let ffn_size = text_cfg
-        .get("intermediate_size")
-        .or_else(|| text_cfg.get("ffn_dim"))
-        .or_else(|| text_cfg.get("ffn_hidden_size"))
-        .and_then(|v| v.as_f64())
+    let ffn_size = config_fields::get_f64(text_cfg, config_fields::INTERMEDIATE_SIZE_KEYS)
         .unwrap_or(hidden_size * 4.0); // fallback: 4× hidden as a rule of thumb
 
     // Number of experts (MoE). For dense models this stays at 1.
-    let num_experts = text_cfg
-        .get("num_experts")
-        .or_else(|| text_cfg.get("num_local_experts"))
-        .or_else(|| text_cfg.get("n_routed_experts"))
-        .and_then(|v| v.as_f64())
-        .unwrap_or(1.0)
-        .max(1.0);
+    let num_experts = config_fields::get_f64(
+        text_cfg,
+        &["num_experts", "num_local_experts", "n_routed_experts"],
+    )
+    .unwrap_or(1.0)
+    .max(1.0);
 
     // Attention heads (used for GQA parameter correction, optional).
-    let num_heads = text_cfg
-        .get("num_attention_heads")
-        .or_else(|| text_cfg.get("num_heads"))
-        .or_else(|| text_cfg.get("n_heads"))
-        .or_else(|| text_cfg.get("n_head"))
-        .and_then(|v| v.as_f64())
+    let num_heads = config_fields::get_f64(text_cfg, config_fields::NUM_HEADS_KEYS)
         .unwrap_or(hidden_size / 64.0);
 
-    let kv_heads = text_cfg
-        .get("num_key_value_heads")
-        .or_else(|| text_cfg.get("num_kv_heads"))
-        .or_else(|| text_cfg.get("n_kv_heads"))
-        .or_else(|| text_cfg.get("n_head_kv"))
-        .or_else(|| text_cfg.get("multi_query_group_num"))
-        .and_then(|v| v.as_f64())
-        .unwrap_or(num_heads);
-
-    let head_dim = text_cfg
-        .get("head_dim")
-        .or_else(|| text_cfg.get("head_size"))
-        .and_then(|v| v.as_f64())
+    // A numeric KV-head field wins; failing that, GPT-BigCode's boolean
+    // `multi_query` means one shared KV head, which shrinks the K/V projection
+    // term below the MHA default.
+    let kv_heads = config_fields::get_f64(text_cfg, config_fields::NUM_KV_HEADS_KEYS)
         .unwrap_or_else(|| {
+            if config_fields::is_multi_query(text_cfg) {
+                1.0
+            } else {
+                num_heads
+            }
+        });
+
+    let head_dim =
+        config_fields::get_f64(text_cfg, config_fields::HEAD_DIM_KEYS).unwrap_or_else(|| {
             if num_heads > 0.0 && num_heads.is_finite() {
                 (hidden_size / num_heads).round()
             } else {


### PR DESCRIPTION
## Summary

`mlxcel inspect` reported `KV cache: 0 bytes (unavailable (config.json missing architecture fields))` and `Activation: 0 bytes` for GPT-2 and GPT-BigCode, because the estimators never aliased the OpenAI-era `n_layer` and `n_embd` field names. On the server path the same `None` propagated through `paged_block_bytes` to `src/server/model_worker.rs`, leaving the paged pool with no `--kv-cache-budget auto` admission ceiling. This teaches the estimators both spellings, adds the missing `multi_query` branch that the alias fix alone would have gotten wrong, and consolidates the five duplicated alias lists behind one module.

## The trap this avoids

Adding the two aliases on their own would have been worse than the zero it replaced. Every other family expresses grouped attention through a numeric `num_key_value_heads`, but GPT-BigCode signals it with the boolean `multi_query: true`, meaning exactly one shared kv head. The kv-head resolution read only numeric fields and otherwise fell back to `num_kv_heads = num_heads`, while `GptBigCodeArgs::n_kv_heads` (`src/models/gpt_bigcode.rs`) returns `if multi_query { 1 } else { n_head }` and the runtime caches accordingly.

| | kv heads used | Total at ctx 8192, fp16 |
|---|---|---|
| Before | (no estimate) | 0 bytes |
| Alias-only "fix" | 16 | 1,610,612,736 (1.50 GiB) |
| This PR | 1 | 100,663,296 (96 MiB) |

The over-reservation scales with `n_head`, so it is 48x for a StarCoder-sized checkpoint, not 16x. `resolve_num_kv_heads` now honors the boolean, ordered so an explicit numeric field still wins when a config carries both; `multi_query: false` and an absent flag both keep the existing MHA behavior.

## The duplication

The same alias lists were copied into five independent `.or_else()` chains, which is exactly why the gap reproduced in every one of them, and why a fix scoped to `kv_arch.rs` alone would have left `inspect` still printing `Activation: 0 bytes`. Rather than adding a sixth copy, new `src/execution/config_fields.rs` owns the lists and the kv-head resolution once, and all five call sites read from it. Legacy spellings are appended last in each list, so a config that already resolved cannot resolve differently.

## What changed

- `src/execution/config_fields.rs` (new): the alias constants (`LAYER_COUNT_KEYS`, `HIDDEN_SIZE_KEYS`, `NUM_HEADS_KEYS`, `NUM_KV_HEADS_KEYS`, `HEAD_DIM_KEYS`, `INTERMEDIATE_SIZE_KEYS`), the `text_config` / `get_u64` / `get_f64` helpers, and `resolve_num_kv_heads`, which implements the numeric-then-boolean-then-MHA precedence.
- `src/execution/kv_arch.rs`: `classify` and `attn_dims` (and the MLA head-count lookup) read the shared constants; `attn_dims` resolves kv heads through `resolve_num_kv_heads`.
- `src/execution/memory_estimate.rs`: `activation_dims_from_path` and `kv_cache_params_from_path` both read the shared constants; the latter also drops its duplicated kv-head fallback in favor of the shared resolution, so it cannot disagree with the classifier.
- `src/execution/kv_cache_advisor.rs`: `read_head_dim` reads the shared constants, making good on the promise its own doc comment already made. Its `None`-when-head-count-absent semantics are unchanged, so the permissive Turbo default is untouched for configs that genuinely lack a head count.
- `src/execution/quant_advisor.rs`: `estimate_params_from_config` was a fifth copy of the same lists; it now reads the shared constants and honors `multi_query` in its K/V projection term.
- `src/execution/mod.rs`: declares the new module.

## Before and after, real checkpoints

| Model | KV before | KV after | Activation before | Activation after |
|---|---|---|---|---|
| `models/gpt2` | 0 (unavailable) | 301,989,888 | 0 | 7,964,834 |
| `models/gpt_bigcode-santacoder` | 0 (unavailable) | 100,663,296 | 0 | 21,070,080 |

Both now report `KvSource::Config` with `standard attention (N layers, full context)`, and both produce a non-empty KV-cache-mode advice vector (3 entries) where they previously produced none.

## No regression

The three families the issue named as regression targets are byte-identical, confirmed against the real checkpoints:

| Model | KV at ctx 8192 fp16 |
|---|---|
| `models/pythia-1b` | 1,073,741,824 (unchanged) |
| `models/helium-1-preview-2b-4bit` | 2,013,265,920 (unchanged) |
| `models/ling-lite-1.5` | 469,762,048 (unchanged, verified config-only via `estimate_kv_arch`, no weights loaded) |

## Test plan

- [x] `cargo check --release --lib --tests --features metal,accelerate` clean; only the two warnings already on `main` in `src/multimodal/host_preprocessor.rs` and `host_preprocessor_export.rs`.
- [x] `cargo clippy --release --lib --tests --features metal,accelerate` produces nothing new; same two pre-existing warnings.
- [x] `cargo test --release --lib --features metal,accelerate execution::` passes 112, up from 93, with 19 new cases.
- [x] `cargo test --release --lib --features metal,accelerate models::gpt` passes 78.
- [x] `cargo test --release --lib --features metal,accelerate budget` passes 79 and `quant` passes 141.
- [x] `cargo fmt --all -- --check` clean.
- [x] Baseline reproduced with the pre-change binary: `mlxcel inspect` on `models/gpt2` and `models/gpt_bigcode-santacoder` both showed 0 KV and 0 activation, matching the issue exactly.
- [x] Post-change figures measured against the real checkpoints through `estimate_total_memory` and `advise_kv_cache_modes`, the same entry points `mlxcel inspect` calls. The release binary itself was not rebuilt here (that is the orchestrator's step), so the arithmetic is additionally pinned in unit tests using the verbatim config fields from both checkpoints.

New coverage: GPT-2 style naming classifying as standard MHA, GPT-BigCode `multi_query: true` yielding one kv head, `multi_query: false` degenerating to `n_head`, the 48x StarCoder-sized case, numeric fields outranking the boolean, a non-boolean `multi_query` value being ignored, the degenerate `multi_query: true` with `n_head: 0`, `kv_cache_params_from_path` agreeing with the classifier, `paged_block_bytes` resolving instead of returning `None`, the advisor returning advice for both families, and the three no-regression figures.

Closes #927
