### PR TITLE
perf: stack per-expert tensors from borrows instead of copies

### DIFF
--- a/src/models/phimoe.rs
+++ b/src/models/phimoe.rs
@@ -507,22 +507,31 @@ impl PhiMoeModel {
                     );
 
                     if weights.contains_key(&first_key) {
-                        let mut expert_arrays: Vec<UniquePtr<MlxArray>> = Vec::new();
+                        // Borrowed pointers, not copies (issue #948). The
+                        // intermediate `mlxcel_core::copy` here was a real
+                        // `mx::copy` primitive whose full-size output the
+                        // following `mx::stack` read once and discarded, so it
+                        // cost one redundant pass over the whole expert set at
+                        // the first forward. `weights` is only read and is not
+                        // mutated while the pointers are live; the stacked
+                        // result goes into the separate `new_weights` map and
+                        // keeps its inputs alive on its own, because the C++
+                        // `stack` shim copies each refcounted `mx::array`
+                        // handle into its own vector.
+                        let mut expert_ptrs: Vec<*const MlxArray> = Vec::new();
                         for e in 0..args.num_local_experts {
                             let key = format!(
                                 "{}.block_sparse_moe.experts.{}.{}.{}",
                                 prefix, e, orig_name, weight_type
                             );
                             if let Some(w) = weights.get(&key) {
-                                expert_arrays.push(mlxcel_core::copy(w));
+                                expert_ptrs
+                                    .push(w.as_ref().expect("weight map holds no null handles")
+                                        as *const MlxArray);
                             }
                         }
 
-                        if !expert_arrays.is_empty() {
-                            let expert_ptrs: Vec<*const MlxArray> = expert_arrays
-                                .iter()
-                                .map(|a| a.as_ref().unwrap() as *const _)
-                                .collect();
+                        if !expert_ptrs.is_empty() {
                             let stacked = mlxcel_core::stack(&expert_ptrs, 0);
                             let new_key = format!(
                                 "{}.block_sparse_moe.switch_mlp.{}.{}",

--- a/src/models/phimoe.rs
+++ b/src/models/phimoe.rs
@@ -508,16 +508,19 @@ impl PhiMoeModel {
 
                     if weights.contains_key(&first_key) {
                         // Borrowed pointers, not copies (issue #948). The
-                        // intermediate `mlxcel_core::copy` here was a real
-                        // `mx::copy` primitive whose full-size output the
-                        // following `mx::stack` read once and discarded, so it
-                        // cost one redundant pass over the whole expert set at
-                        // the first forward. `weights` is only read and is not
-                        // mutated while the pointers are live; the stacked
-                        // result goes into the separate `new_weights` map and
-                        // keeps its inputs alive on its own, because the C++
-                        // `stack` shim copies each refcounted `mx::array`
-                        // handle into its own vector.
+                        // intermediate `mlxcel_core::copy` produced a `Copy`
+                        // graph node per expert tensor that the following
+                        // `mx::stack` then consumed, and nothing else used, so
+                        // it was pure indirection. It was NOT redundant memory
+                        // traffic: `Copy::eval` is
+                        // `out.copy_shared_buffer(inputs[0])`, which aliases the
+                        // input buffer rather than materializing it. See the
+                        // longer note in `switch_layers.rs`. `weights` is only
+                        // read and is not mutated while the pointers are live;
+                        // the stacked result goes into the separate
+                        // `new_weights` map and keeps its inputs alive on its
+                        // own, because the C++ `stack` shim copies each
+                        // refcounted `mx::array` handle into its own vector.
                         let mut expert_ptrs: Vec<*const MlxArray> = Vec::new();
                         for e in 0..args.num_local_experts {
                             let key = format!(
@@ -552,6 +555,90 @@ impl PhiMoeModel {
         }
 
         Ok(new_weights)
+    }
+}
+
+#[cfg(test)]
+mod sanitize_tests {
+    use super::*;
+
+    /// Per-expert stacking builds its `stack` inputs from pointers borrowed out
+    /// of the source `WeightMap` rather than from `mlxcel_core::copy` results
+    /// (issue #948). Drop the source map before evaluating anything, so a stack
+    /// that held a borrow instead of a refcounted handle reads freed memory
+    /// rather than failing an assertion. Inline rather than in
+    /// `phimoe_tests.rs`, which is a sibling module and cannot reach the private
+    /// `sanitize_weights`; this mirrors how `deepseek_v3.rs` tests its own.
+    #[test]
+    fn stacked_experts_outlive_the_weight_map_they_were_borrowed_from() {
+        let args: ModelArgs = serde_json::from_str(
+            r#"{
+                "model_type": "phimoe",
+                "num_hidden_layers": 1,
+                "num_local_experts": 2,
+                "num_experts_per_tok": 2
+            }"#,
+        )
+        .expect("tiny config parses");
+
+        // w1 -> gate_proj, w3 -> up_proj, w2 -> down_proj.
+        let mut weights = WeightMap::new();
+        for e in 0..2 {
+            let base = (e + 1) as f32;
+            for (leaf, bump) in [("w1", 0.0), ("w2", 10.0), ("w3", 20.0)] {
+                weights.insert(
+                    format!("model.layers.0.block_sparse_moe.experts.{e}.{leaf}.weight"),
+                    mlxcel_core::from_slice_f32(
+                        &[
+                            base + bump,
+                            base + bump + 0.5,
+                            base + bump,
+                            base + bump + 0.5,
+                        ],
+                        &[2, 2],
+                    ),
+                );
+            }
+        }
+        // A non-expert weight, to pin that the passthrough branch still runs.
+        weights.insert(
+            "model.norm.weight".into(),
+            mlxcel_core::from_slice_f32(&[1.0, 1.0], &[2]),
+        );
+
+        let stacked = PhiMoeModel::sanitize_weights(&weights, &args).expect("stacking succeeds");
+        drop(weights);
+
+        for (proj, bump) in [("gate_proj", 0.0), ("down_proj", 10.0), ("up_proj", 20.0)] {
+            let key = format!("model.layers.0.block_sparse_moe.switch_mlp.{proj}.weight");
+            let tensor = stacked.get(&key).unwrap_or_else(|| panic!("missing {key}"));
+            mlxcel_core::eval(tensor);
+            assert_eq!(
+                mlxcel_core::array_shape(tensor),
+                vec![2, 2, 2],
+                "{key} must stack both experts"
+            );
+            for e in 0..2i32 {
+                let first = mlxcel_core::slice(tensor, &[e, 0, 0], &[e + 1, 1, 1]);
+                mlxcel_core::eval(&first);
+                assert_eq!(
+                    mlxcel_core::item_f32(&first),
+                    (e + 1) as f32 + bump,
+                    "{key} expert {e} landed at the wrong plane or read freed memory"
+                );
+            }
+        }
+
+        assert!(
+            stacked.contains_key("model.norm.weight"),
+            "non-expert weights must still be carried over"
+        );
+        assert!(
+            !stacked
+                .keys()
+                .any(|k| k.contains("block_sparse_moe.experts.")),
+            "the per-expert keys must not survive stacking"
+        );
     }
 }
 

--- a/src/models/phimoe.rs
+++ b/src/models/phimoe.rs
@@ -558,6 +558,68 @@ impl PhiMoeModel {
     }
 }
 
+// MoE Implementation Details.
+impl SparseMoeBlock {
+    pub fn from_weights(
+        weights: &WeightMap,
+        args: &ModelArgs,
+        prefix: &str,
+    ) -> Result<Self, String> {
+        let router = UnifiedLinear::from_weights(
+            weights,
+            &format!("{}.gate", prefix),
+            args.group_size(),
+            args.bits(),
+        )?;
+
+        let experts = crate::models::switch_layers::SwitchGLU::from_weights(
+            weights,
+            &format!("{}.switch_mlp", prefix),
+            args.group_size(),
+            args.bits(),
+        )?;
+
+        Ok(Self {
+            router,
+            experts,
+            num_experts_per_tok: args.num_experts_per_tok,
+        })
+    }
+}
+
+// Helper Functions.
+fn get_weight_copy(weights: &WeightMap, name: &str) -> Result<UniquePtr<MlxArray>, String> {
+    weights
+        .get(name)
+        .map(|w| mlxcel_core::copy(w))
+        .ok_or_else(|| format!("Weight not found: {}", name))
+}
+
+// LanguageModel trait implementation.
+impl LanguageModel for PhiMoeModel {
+    fn forward(
+        &self,
+        input_ids: &MlxArray,
+        caches: &mut [KVCache],
+        mask: Option<&MlxArray>,
+    ) -> UniquePtr<MlxArray> {
+        PhiMoeModel::forward(self, input_ids, caches, mask)
+    }
+
+    fn make_caches(&self) -> Vec<KVCache> {
+        PhiMoeModel::make_caches(self)
+    }
+
+    fn num_layers(&self) -> usize {
+        self.layers.len()
+    }
+
+    fn eos_token_ids(&self) -> Vec<i32> {
+        // PhiMoE EOS token (commonly <|endoftext|> = 32000)
+        vec![32000]
+    }
+}
+
 #[cfg(test)]
 mod sanitize_tests {
     use super::*;
@@ -639,67 +701,5 @@ mod sanitize_tests {
                 .any(|k| k.contains("block_sparse_moe.experts.")),
             "the per-expert keys must not survive stacking"
         );
-    }
-}
-
-// MoE Implementation Details.
-impl SparseMoeBlock {
-    pub fn from_weights(
-        weights: &WeightMap,
-        args: &ModelArgs,
-        prefix: &str,
-    ) -> Result<Self, String> {
-        let router = UnifiedLinear::from_weights(
-            weights,
-            &format!("{}.gate", prefix),
-            args.group_size(),
-            args.bits(),
-        )?;
-
-        let experts = crate::models::switch_layers::SwitchGLU::from_weights(
-            weights,
-            &format!("{}.switch_mlp", prefix),
-            args.group_size(),
-            args.bits(),
-        )?;
-
-        Ok(Self {
-            router,
-            experts,
-            num_experts_per_tok: args.num_experts_per_tok,
-        })
-    }
-}
-
-// Helper Functions.
-fn get_weight_copy(weights: &WeightMap, name: &str) -> Result<UniquePtr<MlxArray>, String> {
-    weights
-        .get(name)
-        .map(|w| mlxcel_core::copy(w))
-        .ok_or_else(|| format!("Weight not found: {}", name))
-}
-
-// LanguageModel trait implementation.
-impl LanguageModel for PhiMoeModel {
-    fn forward(
-        &self,
-        input_ids: &MlxArray,
-        caches: &mut [KVCache],
-        mask: Option<&MlxArray>,
-    ) -> UniquePtr<MlxArray> {
-        PhiMoeModel::forward(self, input_ids, caches, mask)
-    }
-
-    fn make_caches(&self) -> Vec<KVCache> {
-        PhiMoeModel::make_caches(self)
-    }
-
-    fn num_layers(&self) -> usize {
-        self.layers.len()
-    }
-
-    fn eos_token_ids(&self) -> Vec<i32> {
-        // PhiMoE EOS token (commonly <|endoftext|> = 32000)
-        vec![32000]
     }
 }

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -420,9 +420,17 @@ impl SwitchLinear {
 /// `SwitchGLU::from_weights_with_proj_names`) loads from the matching expert
 /// keys without any name baked in here.
 ///
-/// Used by: Qwen2Moe (Qwen1.5-MoE / Qwen2-MoE individual-expert checkpoints),
-///          Mixtral (`block_sparse_moe.experts.{idx}.{w1,w2,w3}` checkpoints),
-///          DeepSeek v1 (`baidu/Unlimited-OCR` raw per-expert checkpoint)
+/// Used by: every family behind the shared `SwitchGLU` / `SwitchLinear`, which
+///          reaches this through `SwitchLinear::from_weights_with_mode`
+///          whenever its checkpoint ships experts unstacked (BailingMoe,
+///          Cohere2Moe, Dots1, Gemma4, GraniteMoeHybrid, KimiLinear, Lfm2,
+///          Llada2Moe, LongcatFlashNgram, Mellum, MiniMax, MiniMaxM3Moe,
+///          Mistral4, Mixtral, Moondream3, OLMoE, PhiMoE, Qwen2Moe,
+///          SolarOpen), plus DeepSeek v1 (`src/models/deepseek.rs`), which
+///          calls it directly for the `baidu/Unlimited-OCR` raw per-expert
+///          checkpoint. The layouts that actually exercise it today are the
+///          Qwen1.5-MoE / Qwen2-MoE individual-expert exports, Mixtral's
+///          `block_sparse_moe.experts.{idx}.{w1,w2,w3}`, and Ling-lite.
 pub(crate) fn stack_individual_experts(
     weights: &WeightMap,
     prefix: &str,
@@ -477,24 +485,51 @@ fn stack_individual_experts_with_count(
     let has_scales = weights.contains_key(&expert_key(0, "scales"));
     let has_biases = weights.contains_key(&expert_key(0, "biases"));
 
-    let mut stacked_weight = Vec::new();
-    let mut stacked_scales = Vec::new();
-    let mut stacked_biases = Vec::new();
+    // Borrow the per-expert tensors instead of copying them (issue #948). The
+    // copies existed only to produce owned `UniquePtr`s for `stack_owned`, and
+    // contributed nothing: `mlxcel_core::copy` lowers to `mx::copy`, a real
+    // `Copy` primitive that allocates and writes a full-size output, and
+    // `mx::stack` then allocates its own output and reads each input exactly
+    // once, so every byte the copy wrote was read once by the concatenate and
+    // discarded. Both ops are lazy and nothing evaluates model parameters
+    // between construction and the first forward pass, so the waste landed as
+    // copy traffic at the first forward rather than as load-time allocation:
+    // 31.0 GB of it for `models/ling-lite-1.5`, whose 5376 per-expert BF16
+    // tensors are its entire routed payload.
+    //
+    // `ops::stack` already takes `*const MlxArray`, so no new borrowing entry
+    // point is needed. The pointers are collected and consumed inside the live
+    // `&WeightMap` borrow, and the map is only read; do not switch this to
+    // `remove`-based draining the way `src/models/olmoe.rs` does, because this
+    // helper is called from a `&WeightMap` context. The C++ `stack` shim copies
+    // each `a->inner` into its own `std::vector<array>` and `mx::array` is a
+    // refcounted handle, so the stacked node keeps its inputs alive
+    // independently of the map (pinned by
+    // `stacked_experts_outlive_the_weight_map_they_were_borrowed_from`).
+    let as_ptr = |array: &UniquePtr<MlxArray>| {
+        // Same contract as `ops::stack_owned`, which this replaces: a WeightMap
+        // never stores a null handle, and the previous `mlxcel_core::copy` call
+        // panicked identically on one via `UniquePtr`'s `Deref`.
+        array.as_ref().expect("weight map holds no null handles") as *const MlxArray
+    };
+    let mut weight_ptrs: Vec<*const MlxArray> = Vec::new();
+    let mut scales_ptrs: Vec<*const MlxArray> = Vec::new();
+    let mut biases_ptrs: Vec<*const MlxArray> = Vec::new();
     let mut idx = 0;
     while let Some(weight) = weights.get(&expert_key(idx, "weight")) {
-        stacked_weight.push(mlxcel_core::copy(weight));
+        weight_ptrs.push(as_ptr(weight));
         if has_scales {
-            stacked_scales.push(mlxcel_core::copy(weights.get(&expert_key(idx, "scales"))?));
+            scales_ptrs.push(as_ptr(weights.get(&expert_key(idx, "scales"))?));
         }
         if has_biases {
-            stacked_biases.push(mlxcel_core::copy(weights.get(&expert_key(idx, "biases"))?));
+            biases_ptrs.push(as_ptr(weights.get(&expert_key(idx, "biases"))?));
         }
         idx += 1;
     }
 
-    let weight = mlxcel_core::stack_owned(&stacked_weight, 0);
-    let scales = has_scales.then(|| mlxcel_core::stack_owned(&stacked_scales, 0));
-    let biases = has_biases.then(|| mlxcel_core::stack_owned(&stacked_biases, 0));
+    let weight = mlxcel_core::stack(&weight_ptrs, 0);
+    let scales = has_scales.then(|| mlxcel_core::stack(&scales_ptrs, 0));
+    let biases = has_biases.then(|| mlxcel_core::stack(&biases_ptrs, 0));
     Some((weight, scales, biases, idx))
 }
 
@@ -1115,6 +1150,57 @@ mod tests {
         weights.insert(format!("{prefix}.scales"), plane(num_groups, 1.0));
         weights.insert(format!("{prefix}.biases"), plane(num_groups, 0.0));
         weights
+    }
+
+    #[test]
+    fn stacked_experts_outlive_the_weight_map_they_were_borrowed_from() {
+        // The per-expert stack is now built from pointers borrowed out of the
+        // `WeightMap` rather than from copies (issue #948). That is only sound
+        // because the C++ `stack` shim copies each refcounted `mx::array` handle
+        // into its own vector, so the stacked graph node keeps its inputs alive
+        // on its own. Drop the map before evaluating anything to pin that: if
+        // the stack ever held a borrow instead of a handle, this reads freed
+        // memory rather than failing an assertion.
+        let root = "model.layers.0.mlp";
+        let prefix = format!("{root}.switch_mlp.gate_proj");
+        let mut weights = WeightMap::new();
+        for e in 0..3 {
+            let base = (e + 1) as f32;
+            weights.insert(
+                format!("{root}.experts.{e}.gate_proj.weight"),
+                mlxcel_core::from_slice_f32(&[base, base + 0.5, base + 1.0, base + 1.5], &[2, 2]),
+            );
+            weights.insert(
+                format!("{root}.experts.{e}.gate_proj.scales"),
+                mlxcel_core::from_slice_f32(&[base, base], &[2, 1]),
+            );
+        }
+
+        let (weight, scales, biases, found) =
+            stack_individual_experts_with_count(&weights, &prefix).expect("per-expert layout");
+        assert_eq!(found, 3, "the contiguous expert count must be unchanged");
+        let scales = scales.expect("expert 0 carries scales, so scales are stacked");
+        assert!(biases.is_none(), "expert 0 carries no biases");
+
+        // The whole point: the source map is gone before anything is evaluated.
+        drop(weights);
+        mlxcel_core::eval(&weight);
+        mlxcel_core::eval(&scales);
+
+        assert_eq!(mlxcel_core::array_shape(&weight), vec![3, 2, 2]);
+        assert_eq!(mlxcel_core::array_shape(&scales), vec![3, 2, 1]);
+
+        // Values, not just shapes: a stack that silently read the wrong memory
+        // would still have the right shape.
+        for e in 0..3i32 {
+            let first = mlxcel_core::slice(&weight, &[e, 0, 0], &[e + 1, 1, 1]);
+            mlxcel_core::eval(&first);
+            assert_eq!(
+                mlxcel_core::item_f32(&first),
+                (e + 1) as f32,
+                "expert {e} landed at the wrong plane or read freed memory"
+            );
+        }
     }
 
     #[test]

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -431,6 +431,13 @@ impl SwitchLinear {
 ///          checkpoint. The layouts that actually exercise it today are the
 ///          Qwen1.5-MoE / Qwen2-MoE individual-expert exports, Mixtral's
 ///          `block_sparse_moe.experts.{idx}.{w1,w2,w3}`, and Ling-lite.
+///
+/// PhiMoE and OLMoE are listed for completeness but normally pre-stack in their
+/// own `sanitize_weights`, so the shared loader sees `switch_mlp.{proj}.weight`
+/// and takes the pre-stacked branch. PhiMoE reaches this branch only for a
+/// checkpoint that ships experts unstacked under `gate_proj`/`up_proj`/
+/// `down_proj` names, because its sanitizer probes `experts.0.w1.weight` and
+/// falls through to a plain copy otherwise.
 pub(crate) fn stack_individual_experts(
     weights: &WeightMap,
     prefix: &str,
@@ -486,16 +493,23 @@ fn stack_individual_experts_with_count(
     let has_biases = weights.contains_key(&expert_key(0, "biases"));
 
     // Borrow the per-expert tensors instead of copying them (issue #948). The
-    // copies existed only to produce owned `UniquePtr`s for `stack_owned`, and
-    // contributed nothing: `mlxcel_core::copy` lowers to `mx::copy`, a real
-    // `Copy` primitive that allocates and writes a full-size output, and
-    // `mx::stack` then allocates its own output and reads each input exactly
-    // once, so every byte the copy wrote was read once by the concatenate and
-    // discarded. Both ops are lazy and nothing evaluates model parameters
-    // between construction and the first forward pass, so the waste landed as
-    // copy traffic at the first forward rather than as load-time allocation:
-    // 31.0 GB of it for `models/ling-lite-1.5`, whose 5376 per-expert BF16
-    // tensors are its entire routed payload.
+    // copies existed only to produce owned `UniquePtr`s for `stack_owned` and
+    // contributed nothing to the result, so building the stack from borrowed
+    // pointers drops one graph node per tensor: 5376 of them for
+    // `models/ling-lite-1.5`, whose per-expert projections are its entire routed
+    // payload.
+    //
+    // What that saves is graph metadata and eval scheduling, NOT memory traffic.
+    // Issue #948 framed this as ~31 GB of redundant copy traffic at the first
+    // forward, and that framing is wrong: `mlxcel_core::copy` lowers to
+    // `mx::copy`, whose `Copy::eval` is `out.copy_shared_buffer(inputs[0])`
+    // (`mlx/backend/common/common.cpp`, reached from both `Copy::eval_gpu` and
+    // `Copy::eval_cpu`). That aliases the input buffer; it allocates nothing and
+    // writes nothing. The materializing `copy_gpu(..., CopyType::General)` a few
+    // lines above it in the same file belongs to `Contiguous::eval_gpu`, which is
+    // a different primitive. So there was never a 31 GB transfer, and there was
+    // never a per-projection peak-memory transient either. Do not reintroduce
+    // that claim without re-reading the pinned MLX source.
     //
     // `ops::stack` already takes `*const MlxArray`, so no new borrowing entry
     // point is needed. The pointers are collected and consumed inside the live
@@ -1158,9 +1172,11 @@ mod tests {
         // `WeightMap` rather than from copies (issue #948). That is only sound
         // because the C++ `stack` shim copies each refcounted `mx::array` handle
         // into its own vector, so the stacked graph node keeps its inputs alive
-        // on its own. Drop the map before evaluating anything to pin that: if
-        // the stack ever held a borrow instead of a handle, this reads freed
-        // memory rather than failing an assertion.
+        // on its own. Dropping the map before evaluating anything exercises that
+        // ordering end to end. Treat it as a tripwire rather than a proof: a
+        // stack that held a borrow would be reading freed memory here, and freed
+        // memory often still reads back intact, so a pass is weaker evidence
+        // than the by-value `push_back` in the shim.
         let root = "model.layers.0.mlp";
         let prefix = format!("{root}.switch_mlp.gate_proj");
         let mut weights = WeightMap::new();


### PR DESCRIPTION
## Summary

`stack_individual_experts_with_count` called `mlxcel_core::copy` on every per-expert projection tensor before stacking it. The copies existed only to produce owned `UniquePtr` values for `stack_owned` and contributed nothing to the result, so the stack is now built from borrowed pointers instead. That removes one `Copy` graph node per per-expert tensor, 5376 of them for `models/ling-lite-1.5`.

## Correction to the issue's cost model, and to this PR's first draft

Issue #948 states that the copies cost about 31 GB of redundant memory traffic at the first forward pass for Ling-lite, plus a per-projection peak-memory transient of roughly 352 MiB. **That is wrong, and this PR originally repeated it.** Checked against the pinned MLX checkout:

- `mx::copy` builds a `Copy` node (`mlx/ops.cpp:303`).
- `Copy::eval_gpu` (`mlx/backend/gpu/primitives.cpp:64`) and `Copy::eval_cpu` (`mlx/backend/cpu/primitives.cpp:88`) both just call `Copy::eval`.
- `Copy::eval` (`mlx/backend/common/common.cpp:55`) is `out.copy_shared_buffer(inputs[0])`, which repoints `array_desc_->data` at the input's buffer. It allocates nothing and writes nothing.

The materializing `copy_gpu(..., CopyType::General)` a few lines above in that same file belongs to `Contiguous::eval_gpu`, a different primitive, which is the likely source of the original misreading.

So there was never 31 GB of traffic to save and never a 352 MiB transient to remove. What this change actually saves is graph metadata and eval-scheduling overhead for 5376 nodes. The change is still correct and still worth landing (it is strictly less indirection for identical numerics), it is just a much smaller win than the issue claims. The acceptance criterion that would have caught this is the before/after measurement, which is the one still unticked.

The corrected reasoning is now in the source comments rather than only here, since a wrong rationale in a comment is worse than a wrong PR body: the next reader trusts it. Both comments carry an explicit warning not to reintroduce the traffic claim without re-reading the pinned MLX source.

## What changed

**`src/models/switch_layers.rs`**

- `stack_individual_experts_with_count` collects `*const MlxArray` straight from `weights.get(...)` and calls `mlxcel_core::stack` instead of building `Vec<UniquePtr<MlxArray>>` via `copy` and calling `stack_owned`. No new borrowing entry point was needed: `ops::stack` already takes pointers and is public.
- The pointers are collected and consumed inside the live `&WeightMap` borrow, and the map is only read. This deliberately does **not** switch to the `remove`-based draining that `src/models/olmoe.rs` uses, because this helper is called from a `&WeightMap` context.
- New test `stacked_experts_outlive_the_weight_map_they_were_borrowed_from` drops the source map before evaluating the stacked array, then checks per-plane values, not just shapes. It is a tripwire rather than a proof, and its comment says so: freed memory usually reads back intact, so the real guarantee is the by-value `arrs.push_back(a->inner)` in the C++ `stack` shim (`src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp:2577`), which copies the refcounted `mx::array` handle so the stacked node holds its inputs independently of the map.
- The `Used by:` comment was stale, naming three families. It now lists the nineteen that reach the helper through the shared `SwitchGLU` / `SwitchLinear` plus DeepSeek v1's direct call at `deepseek.rs:857`, verified by grep, with a caveat that PhiMoE and OLMoE pre-stack in their own `sanitize_weights` and so normally take the pre-stacked branch instead.

**`src/models/phimoe.rs`**

Fixed in the same pass rather than deferred. It built `expert_arrays` with `mlxcel_core::copy` and then collected pointers from those copies, so it carried the identical redundant node over its own expert set. It is **not** a no-copy precedent, contrary to how it is sometimes described; only `olmoe.rs` is, because that one drains with `weights.remove` and never copies. A new inline `sanitize_tests` module covers the stacking path end to end (w1/w2/w3 to gate/down/up, source map dropped before eval, non-expert passthrough, per-expert keys gone), since `phimoe_tests.rs` is a sibling module and cannot reach the private `sanitize_weights`. This mirrors how `deepseek_v3.rs` tests its own.

## Decision on the pre-stacked branch

**Not included here. Follow-up #959 was filed for it and has now been closed, because the corrected cost model removes its justification.**

The adjacent pre-stacked branch copies the already-joined `[num_experts, ...]` tensors, and removing that copy would need a handle-sharing bridge shim (`std::make_unique<MlxArray>(a.inner)`, no primitive) that does not exist today, since `mlxcel_core::copy` is currently the only way to get an owned `UniquePtr` from a `&MlxArray`. That was worth scoping separately for two reasons: it adds cxx FFI surface, and it changes an invariant every existing `copy` caller gets for free, namely that the loaded layer holds a node independent of the `WeightMap` entry.

With `copy` now known to be buffer-sharing rather than materializing, the payoff for that shim is graph-node reduction only, across roughly thirteen family-local `SwitchLinear` implementations plus phimoe's two whole-map fallbacks. New FFI surface and an aliasing audit across thirteen model files is not a good trade for that, so #959 is closed with the evidence recorded rather than left open to mislead whoever picks it up. It can be reopened if someone measures a real cost.

## Scope note

The affected-family list is not every MoE family. Fourteen files define their own local `SwitchLinear` / `SwitchGLU` and never reach this branch (Qwen3-MoE and Qwen3-VL-MoE, Qwen3-Next and Qwen3.5, DeepSeek v1/v2/V3/V3.2, GLM4-MoE and GLM4-MoE-Lite, ERNIE 4.5 MoE, ExaOne MoE, Hunyuan-MoE, Llama 4, Jamba, gpt-oss, Step3p5). None of them has a per-expert stacking branch at all, so an unstacked checkpoint for those families fails to load rather than taking a slow path. Verified by grep, not assumed.

## Test plan

- [x] `cargo test --release --lib --features metal,accelerate models::switch_layers` (22 passed, including the new ownership test)
- [x] `cargo test --release --lib --features metal,accelerate models::phimoe` (5 passed, including the new `sanitize_tests` stacking test)
- [x] Shared-loader family sweep, all green: `models::{phimoe,olmoe,deepseek,mixtral,qwen2_moe,bailing_moe,dots1,gemma4,minimax,llada2_moe,granitemoehybrid,lfm2,mellum,solar_open,cohere2_moe,moondream3}`
- [x] `models::deepseek` still passes both direct `stack_individual_experts` tests, so the expert-count return value and the truncated-checkpoint error keep their contiguous-gather-until-first-gap semantics
- [x] `cargo clippy --release --lib --tests --features metal,accelerate` clean apart from the two warnings already on `main` in `src/multimodal/host_preprocessor.rs` and `host_preprocessor_export.rs`
- [x] `cargo fmt --all -- --check`
- [ ] Token-exact numerics on a real MoE checkpoint that takes the per-expert branch (`models/ling-lite-1.5` is the reference case). **Not run here**: the release binaries are not built in this environment and the checkpoint is 33.6 GB. Left for the follow-up validation pass. Numerics should be identical by construction, since the graph goes from `stack(copy(w_0..w_n))` to `stack(w_0..w_n)` and `Copy` aliases its input.
- [ ] Second real checkpoint from a different family on the same branch (a per-expert Mixtral or Qwen2-MoE export), same reason.
- [ ] First-forward wall time and peak memory before and after. Expect this to show little or nothing now that the cost model is corrected; peak in particular should be unchanged, not improved. Worth running precisely because it is the measurement that disproved the original claim.

Closes #948
