### PR TITLE
fix(multimodal): gate the Qwen2-VL prefill export on the feature that calls it

### DIFF
--- a/src/multimodal/host_preprocessor.rs
+++ b/src/multimodal/host_preprocessor.rs
@@ -44,10 +44,14 @@ mod export;
 use super::qwen_vl::insert_qwen_vl_image_tokens;
 use export::export_mlx_tensor;
 use export::{
-    build_prepared_prefill, export_llava_prefill, export_qwen2_vl_prefill, usize_to_i32,
-    validate_embedding_shape, validate_processor_shape, validate_projected_shape,
-    validate_sequence_capacity,
+    build_prepared_prefill, export_llava_prefill, usize_to_i32, validate_embedding_shape,
+    validate_processor_shape, validate_projected_shape, validate_sequence_capacity,
 };
+// Only the `xla-iree` Qwen2-VL prefill path calls this, so importing it
+// unconditionally leaves it unused in a default-feature build and `-D warnings`
+// turns that into a hard error. The gate has to match the single call site.
+#[cfg(any(feature = "xla-iree", test))]
+use export::export_qwen2_vl_prefill;
 
 /// Vision implementation selected for OpenXLA multimodal preprocessing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/multimodal/host_preprocessor_export.rs
+++ b/src/multimodal/host_preprocessor_export.rs
@@ -151,6 +151,11 @@ pub(super) fn export_llava_prefill(
     )
 }
 
+// Reachable in production only from the `xla-iree` Qwen2-VL prefill path, and
+// exercised by the module tests regardless, so the gate carries `test` too.
+// Without it a default-feature `cargo clippy --lib -- -D warnings` fails the
+// build on `function is never used`.
+#[cfg(any(feature = "xla-iree", test))]
 pub(super) fn export_qwen2_vl_prefill(
     logical_tokens: Vec<i32>,
     merged: InputEmbeddings,


### PR DESCRIPTION
## What breaks

`Pipeline Parallel CI / 2-host logical` fails on every PR that touches the pipeline-parallel paths. The pipeline-parallel step itself passes; only the trailing `Clippy on PP modules` step fails, and it fails on `src/multimodal/`, which such a PR typically does not touch at all.

`export_qwen2_vl_prefill` is imported at `src/multimodal/host_preprocessor.rs` and defined at `src/multimodal/host_preprocessor_export.rs` unconditionally, but its only non-test call site is inside a `#[cfg(feature = "xla-iree")]` block. The workflow runs `cargo clippy -p mlxcel --lib --tests -- -D warnings` with no features, so that call site compiles out, the import becomes unused, the function becomes dead, and `-D warnings` promotes both to errors.

It went unnoticed because the workflow is path-filtered to the pipeline-parallel modules and last ran on 2026-07-20, while the unconditional import arrived on 2026-07-24 in `edc0ebbb6`. The first PR to touch those paths since is where it surfaced.

## The fix

Gate the import and the definition on `any(feature = "xla-iree", test)`. The feature arm matches the single production call site; the `test` arm is needed because the module tests exercise the function irrespective of features, and dropping them would trade a lint failure for lost coverage.

## Validation

Reproduced the exact CI invocation locally. Before: two errors, `unused import: export_qwen2_vl_prefill` and `function export_qwen2_vl_prefill is never used`, and `could not compile mlxcel (lib)`. After: `Finished dev profile`, clean.

The normal development configuration is unaffected: `cargo clippy --release --lib --tests --features metal,accelerate` is clean, and the Qwen2-VL export tests still compile and pass. One unrelated test in that module, `xla_loader_keeps_text_and_unqualified_vlm_image_capability_false`, fails both before and after this change and also fails on `main`, so it is out of scope here.

## Why this is filed as its own PR

It is a repository-wide unblock rather than part of any feature branch, and it is the second breakage of this shape found this week after the `dtolnay/rust-toolchain` pin in #954: pre-existing on `main`, invisible because a path filter or a feature gate kept any run from exercising the failing combination. The nightly verification job added in #953 targets exactly that blind spot.
