### PR TITLE
fix(models): bound quantization params in the family-local MoE expert loaders

### DIFF
--- a/docs/adding-models.md
+++ b/docs/adding-models.md
@@ -156,6 +156,13 @@ that implementation and tighten the tests or benchmark notes accordingly.
      parallel entry list in `src/loading/config_backed.rs`.
 7. If LoRA/adapters are supported, verify `load_model_from_weights()` in `src/loading/mod.rs`.
    - Non-standard adapter paths should extend `src/loading/special.rs` instead of growing `load_model_from_weights()` directly.
+8. If the family carries a **quantized MoE expert type of its own** rather than
+   using `switch_layers::SwitchLinear`, bound the declared quantization pair at
+   the point the loader stores it:
+   `switch_layers::validate_expert_quantization_params(prefix, group_size, bits)?`.
+   The shared loader does this for you; a family-local `SwitchLinear` /
+   `SwitchGLU` / `ExpertLinear` does not inherit it. See
+   [Quantization Parameter Bounds](#quantization-parameter-bounds).
 
 ## VLM Checklist
 
@@ -201,6 +208,59 @@ Keep the model in an existing module when:
 
 If you are unsure, extend the existing family module first and split only when
 the test file or router starts to lose a clear boundary.
+
+## Quantization Parameter Bounds
+
+`config.json` is untrusted input: it arrives with a downloaded HuggingFace
+repository. A `group_size` or `bits` that no tensor layout can describe passes
+every Rust-side check and then violates an undocumented MLX precondition. MLX
+reconstructs a quantized matrix's unpacked width as `w.shape(-1) * 32 / bits`,
+so a declared `"bits": 0` is a division by zero and anything above 32 collapses
+the quotient. Because `gather_qmm`, `quantized_matmul`, `quantized_embedding`
+and `dequantize` all cross the cxx bridge as `UniquePtr<MlxArray>` rather than
+`Result`, the resulting C++ throw is an uncatchable `std::terminate` at the
+**first forward pass**, not a load error, and `catch_unwind` does not contain it
+(see [`docs/adr/0003-release-panic-unwind-with-core-thread-abort.md`](adr/0003-release-panic-unwind-with-core-thread-abort.md)).
+In `mlxcel-server` that is a remote denial of service triggered by loading a
+model.
+
+The rule is therefore: **bound the pair wherever it is stored, before anything
+derived from it is kept.** Not at the model's load boundary. The boundary does
+not dominate, because pipeline stage executors, `*StageModel::from_filtered_weights`
+entry points, VLM text wrappers and config-bridging helpers all build layers
+without ever calling the family's own model constructor, and several families
+build the quantized variant as a bare struct literal from another module.
+
+What already carries the bound, so you inherit it for free:
+
+| Loader | Covers |
+|--------|--------|
+| `reconcile_quantization_layout` | every `UnifiedLinear` / `UnifiedEmbedding` |
+| `SwitchLinear::from_stacked_parts` | MoE experts via the shared `switch_layers` loader |
+| `QuantizedMultiLinear::{new, from_weights}` | MLA `embed_q` / `unembed_out` |
+| `QuantizedEmbedding::new` | hand-built embeddings that skip the map loader |
+| `FusedQKVLinear::from_weights_separate_with_mode` | fused QKV projections |
+| `infer_mla_quantization_params` | the MLA `kv_b_proj` decomposition in `sanitize_weights` |
+
+What you must do yourself:
+
+- A **family-local quantized expert type**: call
+  `switch_layers::validate_expert_quantization_params(prefix, group_size, bits)?`
+  in the branch that builds the quantized variant. Gate only that branch: a bf16
+  expert plane carries no packing and must stay loadable at any declared pair.
+- A **per-prefix quantization block** (gpt-oss style, a map of overrides rather
+  than one triple): walk every entry during config validation as well, because
+  a bound on the top-level defaults says nothing about an individual override,
+  and vice versa.
+- Any **new by-hand constructor** that stores a pair and hands it to an MLX
+  quantized op: make it fallible and bound it, rather than trusting the caller.
+
+Add a regression test that drives the bad values through your real loader rather
+than through `validate_quantization_params` directly, and pair every hostile case
+with a positive control so a guard cannot pass by rejecting everything quantized.
+`switch_layers::insert_stacked_quantized_expert_plane` and
+`switch_layers::HOSTILE_QUANT_PARAMS` are the shared test fixtures; see any
+`src/models/*_tests.rs` guard test for the shape.
 
 ## Where Regressions Usually Happen
 

--- a/src/distributed/pipeline/stage_executor/deepseek_v3.rs
+++ b/src/distributed/pipeline/stage_executor/deepseek_v3.rs
@@ -81,7 +81,8 @@ impl DeepSeekV3StageExecutor {
         // split for layers inside the stage would still look for a
         // not-yet-decomposed key.
         let weights = models::load_text_weights(model_dir, None).map_err(anyhow::Error::msg)?;
-        let mut weights = models::DeepSeekV3Model::sanitize_weights_with_args(weights, &config);
+        let mut weights = models::DeepSeekV3Model::sanitize_weights_with_args(weights, &config)
+            .map_err(anyhow::Error::msg)?;
 
         // DeepSeek V3 does not tie word embeddings, so no tied-head adjustment
         // like the one in `LlamaStageExecutor::load` is needed here.

--- a/src/distributed/pipeline/stage_executor/glm_moe_dsa.rs
+++ b/src/distributed/pipeline/stage_executor/glm_moe_dsa.rs
@@ -39,7 +39,8 @@ impl GlmMoeDsaStageExecutor {
 
         let dsv32_args = args.to_dsv32_args();
         let mut weights = models::load_text_weights(model_dir, None).map_err(anyhow::Error::msg)?;
-        weights = DeepSeekV32Model::sanitize_weights_with_args(weights, &dsv32_args);
+        weights = DeepSeekV32Model::sanitize_weights_with_args(weights, &dsv32_args)
+            .map_err(anyhow::Error::msg)?;
 
         let mut effective_filter = filter.clone();
         if dsv32_args.tie_word_embeddings && filter.has_lm_head {

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -1847,7 +1847,15 @@ impl FusedQKVLinear {
 
     /// Load and concatenate separate q/k/v weights with explicit quantization mode.
     ///
-    /// Used by: Llama3, Qwen2/Qwen2.5, Phi3-style fused attention wrappers.
+    /// Bounds the declared `group_size` / `bits` pair before anything derived
+    /// from it is stored (issue #958): this loader never calls
+    /// `reconcile_quantization_layout`, so a declared `(0, 0)` was stored
+    /// verbatim on the fused `QuantizedWeight` otherwise.
+    ///
+    /// Used by (through [`Self::from_weights_separate`]): Llama3 (and Mistral,
+    /// the same `ModelType::Llama` path), Gemma, Gemma2, Gemma3, Gemma4, Qwen3,
+    /// Qwen3MoE, Qwen3VL, Qwen3VLMoE, Cohere2, Cohere2MoE, StarCoder2,
+    /// InternLM3, Jamba.
     /// Preserves both quantization `biases` and true linear `bias` tensors
     /// when present; Qwen2-family checkpoints require q/k/v linear bias for
     /// sane logits.

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -231,22 +231,47 @@ pub struct QuantizedEmbedding {
 }
 
 impl QuantizedEmbedding {
-    /// Create a new quantized embedding layer (affine mode)
+    /// Create a new quantized embedding layer (affine mode) from tensors the
+    /// caller already owns.
+    ///
+    /// Fallible on purpose (issue #958). This is the one way to build a
+    /// `QuantizedEmbedding` without going through
+    /// [`Self::from_weights_with_mode`], and therefore without
+    /// [`reconcile_quantization_layout`] and the bound it now carries. A caller
+    /// that hand-builds the layer is exactly the caller whose declared
+    /// `group_size` / `bits` have never been looked at, and the stored pair goes
+    /// straight to `quantized_embedding` / `quantized_matmul`, which cross the
+    /// cxx bridge as `UniquePtr<MlxArray>` rather than `Result`: a C++ throw
+    /// there is an uncatchable abort at the first forward pass rather than a
+    /// load error. Returning `Result` makes the bound impossible to skip for the
+    /// next family that builds one directly, which is the whole reason the
+    /// signature changed rather than the two existing call sites being patched.
+    ///
+    /// This bounds the declared pair only; it does not reconcile against the
+    /// tensor shapes the way `from_weights_with_mode` does, because the shapes
+    /// arrive here already detached from the prefix the reconciler names in its
+    /// divergence warning.
+    ///
+    /// Used by: Mamba, Mamba2 (both take the table out of the `WeightMap` by
+    ///          `remove`, under either the `backbone.embeddings` or the
+    ///          `model.embed_tokens` spelling, so neither can address the
+    ///          single-prefix map loader)
     pub fn new(
         weight: UniquePtr<MlxArray>,
         scales: UniquePtr<MlxArray>,
         biases: UniquePtr<MlxArray>,
         group_size: i32,
         bits: i32,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, String> {
+        validate_quantization_params(group_size, bits)?;
+        Ok(Self {
             weight,
             scales,
             biases: Some(biases),
             group_size,
             bits,
             mode: "affine".to_string(),
-        }
+        })
     }
 
     /// Load from weight map
@@ -980,8 +1005,14 @@ pub struct ReconciledQuant {
 ///
 /// Used by: every quantizing family through [`reconcile_quantization_layout`]
 ///          (dense projections and quantized embeddings) and through
-///          `SwitchLinear::from_stacked_parts` (MoE experts), plus the
-///          family-level early diagnostics in BailingMoe, GptNeoX and Helium
+///          `SwitchLinear::from_stacked_parts` (MoE experts); the by-hand
+///          constructors [`QuantizedEmbedding::new`],
+///          [`QuantizedMultiLinear::new`] and
+///          [`QuantizedMultiLinear::from_weights`], which never reach the
+///          reconciler; every family-local MoE expert loader through
+///          `crate::models::switch_layers::validate_expert_quantization_params`
+///          (issue #958); plus the family-level early diagnostics in BailingMoe,
+///          GptNeoX, Helium and GptOss
 pub fn validate_quantization_params(group_size: i32, bits: i32) -> Result<(), String> {
     if !(1..=32).contains(&bits) {
         return Err(format!(
@@ -2139,24 +2170,41 @@ pub struct QuantizedMultiLinear {
 }
 
 impl QuantizedMultiLinear {
-    /// Create a new quantized multi-linear layer
+    /// Create a new quantized multi-linear layer from tensors the caller
+    /// already owns.
+    ///
+    /// Fallible for the same reason as [`QuantizedEmbedding::new`] (issue
+    /// #958): the stored pair reaches `quantized_matmul` unmediated, and nothing
+    /// else on this path bounds it.
     pub fn new(
         weight: UniquePtr<MlxArray>,
         scales: UniquePtr<MlxArray>,
         biases: Option<UniquePtr<MlxArray>>,
         group_size: i32,
         bits: i32,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, String> {
+        validate_quantization_params(group_size, bits)?;
+        Ok(Self {
             weight,
             scales,
             biases,
             group_size,
             bits,
-        }
+        })
     }
 
     /// Load from weight map
+    ///
+    /// This loader stores the declared `group_size` / `bits` verbatim rather
+    /// than reconciling them against the tensor shapes, and the stored pair is
+    /// handed to `quantized_matmul` on every MLA forward, so it carries the
+    /// bound itself (issue #958). It sits in the same blind spot
+    /// `SwitchLinear::from_stacked_parts` did before #929: a shared quantized
+    /// loader that never calls [`reconcile_quantization_layout`], reached by
+    /// four families whose `embed_q` / `unembed_out` are the only tensors that
+    /// see these params.
+    ///
+    /// Used by: DeepSeek V3, DeepSeek V3.2, GLM4 MoE Lite, LongCat Flash NGram
     pub fn from_weights(
         weights: &crate::weights::WeightMap,
         prefix: &str,
@@ -2166,6 +2214,8 @@ impl QuantizedMultiLinear {
         let weight_name = format!("{}.weight", prefix);
         let scales_name = format!("{}.scales", prefix);
         let biases_name = format!("{}.biases", prefix);
+
+        validate_quantization_params(group_size, bits).map_err(|e| format!("{prefix}: {e}"))?;
 
         let weight = weights
             .get(&weight_name)

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -1036,6 +1036,79 @@ pub fn validate_quantization_params(group_size: i32, bits: i32) -> Result<(), St
     Ok(())
 }
 
+/// Recover the `group_size` / `bits` a packed MLA `kv_b_proj` was quantized
+/// with, from its tensor shapes and the declared `kv_lora_rank`.
+///
+/// The MLA decomposition in the LongCat Flash NGram and Youtu-VL sanitizers has
+/// to dequantize `kv_b_proj` before splitting it per head (splitting in
+/// quantized space would scramble the per-group scales), and the pair it needs
+/// is not declared anywhere: it is solved from `packed_in * 32 == bits *
+/// kv_lora_rank` and `kv_lora_rank == num_groups * group_size`.
+///
+/// Every input here is untrusted. `kv_lora_rank` is a `config.json` field and
+/// both axes come from the checkpoint, so the naive form of this arithmetic has
+/// three separate failure modes before the result is ever used: a
+/// `kv_lora_rank` of 0 and a zero-length scales axis are both Rust integer
+/// divisions by zero, which panic, and `packed_in * 32` overflows `i32` on a
+/// large axis, which wraps in release and panics in an overflow-checked build.
+/// Each is checked here, before the division that would trigger it, and the
+/// multiply is evaluated in `i64`. The solved pair is then bounded by
+/// [`validate_quantization_params`], because it feeds `dequantize`, which
+/// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`: a C++
+/// throw there is an uncatchable abort during weight sanitization rather than a
+/// load error (issue #958).
+///
+/// `prefix` names the offending tensor in every error.
+///
+/// Used by: LongCat Flash NGram, Youtu-VL (MLA `kv_b_proj` decomposition)
+pub fn infer_mla_quantization_params(
+    weight_shape: &[i32],
+    scales_shape: &[i32],
+    kv_lora_rank: i32,
+    prefix: &str,
+) -> Result<(i32, i32), String> {
+    let packed_in = *weight_shape.last().ok_or_else(|| {
+        format!("{prefix}: packed kv_b_proj weight has rank 0 and describes no input width")
+    })?;
+    let num_groups = *scales_shape.last().ok_or_else(|| {
+        format!("{prefix}: kv_b_proj scales have rank 0 and describe no group count")
+    })?;
+    if kv_lora_rank < 1 {
+        return Err(format!(
+            "{prefix}: kv_lora_rank ({kv_lora_rank}) must be positive; it is the divisor that \
+             recovers the packed bit width, so a zero panics and a negative solves to a bit width \
+             no packing can have"
+        ));
+    }
+    if num_groups < 1 {
+        return Err(format!(
+            "{prefix}: kv_b_proj scales must carry a positive last axis, got {num_groups}; it is \
+             the divisor that recovers the group size"
+        ));
+    }
+    if packed_in < 1 {
+        return Err(format!(
+            "{prefix}: packed kv_b_proj weight must carry a positive last axis, got {packed_in}; a \
+             zero-length packed axis describes no input width"
+        ));
+    }
+
+    // i64: `packed_in * 32` is a checkpoint-controlled multiply that wraps in
+    // release and panics in an overflow-checked build as an i32.
+    let bits = i64::from(packed_in) * 32 / i64::from(kv_lora_rank);
+    let group_size = kv_lora_rank / num_groups;
+    let bits = i32::try_from(bits).map_err(|_| {
+        format!(
+            "{prefix}: packed kv_b_proj weight {weight_shape:?} solves to a bit width of {bits} \
+             against kv_lora_rank {kv_lora_rank}, which no packing can have"
+        )
+    })?;
+
+    validate_quantization_params(group_size, bits)
+        .map_err(|e| format!("{prefix}: inferred quantization params are unusable: {e}"))?;
+    Ok((group_size, bits))
+}
+
 /// Upper bound on a declared `group_size`.
 ///
 /// This is an overflow bound, not an allowlist of the group sizes MLX supports.
@@ -4726,6 +4799,52 @@ mod tests {
         regular.insert("embed_q.weight".to_string(), plane(8));
         MultiLinear::from_weights(&regular, "embed_q", 0, 0)
             .expect("a non-quantized MultiLinear must not be gated on quantization params");
+    }
+
+    /// The MLA `kv_b_proj` pair is solved from shapes rather than declared, and
+    /// every input is untrusted: `kv_lora_rank` is a config field and both axes
+    /// are checkpoint data. The naive arithmetic panics on a zero divisor and
+    /// overflows `i32` on a large packed axis, both of which happen BEFORE any
+    /// bound on the solved pair could fire, so the divisor and overflow checks
+    /// have to come first (issue #958).
+    #[test]
+    fn mla_param_inference_checks_every_divisor_before_dividing() {
+        // Positive control: a real DeepSeek-shaped 4-bit kv_b_proj. packed_in
+        // 64 * 32 / kv_lora_rank 512 solves to 4 bits, and 512 / 8 groups
+        // solves to group_size 64.
+        assert_eq!(
+            infer_mla_quantization_params(&[256, 64], &[256, 8], 512, "kv_b_proj")
+                .expect("an honest MLA layout must solve"),
+            (64, 4)
+        );
+
+        // A zero `kv_lora_rank` is Rust integer division by zero, which panics
+        // rather than returning something the bound could reject.
+        let err = infer_mla_quantization_params(&[256, 64], &[256, 8], 0, "kv_b_proj")
+            .expect_err("kv_lora_rank 0 must be rejected, not divided by");
+        assert!(err.contains("kv_lora_rank"), "unhelpful error: {err}");
+
+        // Same for a zero-length scales axis, the other divisor.
+        let err = infer_mla_quantization_params(&[256, 64], &[256, 0], 512, "kv_b_proj")
+            .expect_err("a zero-length scales axis must be rejected, not divided by");
+        assert!(err.contains("positive last axis"), "unhelpful error: {err}");
+
+        // A rank-0 tensor has no last axis at all, which used to index out of
+        // bounds.
+        assert!(infer_mla_quantization_params(&[], &[256, 8], 512, "kv_b_proj").is_err());
+        assert!(infer_mla_quantization_params(&[256, 64], &[], 512, "kv_b_proj").is_err());
+
+        // `packed_in * 32` overflows i32 well before this axis is reachable in
+        // memory, so it is evaluated in i64 and the result bounded instead.
+        let err = infer_mla_quantization_params(&[1, i32::MAX], &[1, 8], 512, "kv_b_proj")
+            .expect_err("an overflowing packed axis must be rejected");
+        assert!(err.contains("bits"), "unhelpful error: {err}");
+
+        // A solved pair that lands outside anything MLX can describe is refused
+        // on the same path: 8 * 32 / 512 truncates to 0 bits.
+        let err = infer_mla_quantization_params(&[256, 8], &[256, 8], 512, "kv_b_proj")
+            .expect_err("a solved bit width of 0 must be rejected");
+        assert!(err.contains("bits"), "unhelpful error: {err}");
     }
 
     #[test]

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -4643,6 +4643,91 @@ mod tests {
         }
     }
 
+    /// The two by-hand constructors are the only way to build a quantized layer
+    /// without going through `reconcile_quantization_layout`, which is exactly
+    /// how `mamba` / `mamba2` reached `quantized_embedding` with an unbounded
+    /// pair (issue #958). They are fallible so the bound cannot be skipped, and
+    /// this drives the real constructors rather than the pure helper: if the
+    /// guard regresses, the pair reaches MLX and the C++ throw takes this whole
+    /// test binary down with SIGABRT instead of failing cleanly.
+    #[test]
+    fn hand_built_quantized_layers_bound_their_declared_params() {
+        // Honest affine 4-bit geometry: packed_in * 32 == bits * groups * gs,
+        // i.e. 8 * 32 == 4 * 1 * 64.
+        let plane = |last: i32| ffi::from_slice_f32(&vec![0.0; (4 * last) as usize], &[4, last]);
+
+        // Positive control first, so a guard that rejects everything quantized
+        // cannot pass this test.
+        QuantizedEmbedding::new(plane(8), plane(1), plane(1), 64, 4)
+            .expect("an honest affine pair must still build a quantized embedding");
+        QuantizedMultiLinear::new(plane(8), plane(1), Some(plane(1)), 64, 4)
+            .expect("an honest affine pair must still build a quantized MultiLinear");
+
+        for (group_size, bits, field) in [
+            (64, 0, "bits"),
+            (64, -4, "bits"),
+            (64, 33, "bits"),
+            (0, 4, "group_size"),
+            (-64, 4, "group_size"),
+        ] {
+            let err = QuantizedEmbedding::new(plane(8), plane(1), plane(1), group_size, bits)
+                .err()
+                .unwrap_or_else(|| {
+                    panic!("QuantizedEmbedding::new must reject {group_size} / {bits}")
+                });
+            assert!(err.contains(field), "unhelpful error: {err}");
+
+            let err =
+                QuantizedMultiLinear::new(plane(8), plane(1), Some(plane(1)), group_size, bits)
+                    .err()
+                    .unwrap_or_else(|| {
+                        panic!("QuantizedMultiLinear::new must reject {group_size} / {bits}")
+                    });
+            assert!(err.contains(field), "unhelpful error: {err}");
+        }
+    }
+
+    /// `QuantizedMultiLinear::from_weights` is a shared loader that stores the
+    /// declared pair verbatim and hands it to `quantized_matmul` on every MLA
+    /// forward, without ever calling the reconciler. It sat in the same blind
+    /// spot `SwitchLinear::from_stacked_parts` occupied before #929, and it is
+    /// reached by DeepSeek V3, DeepSeek V3.2, GLM4 MoE Lite and LongCat Flash
+    /// NGram through their `embed_q` / `unembed_out` (issue #958).
+    #[test]
+    fn multi_linear_loader_bounds_its_declared_params() {
+        let mut weights = crate::weights::WeightMap::new();
+        let plane =
+            |last: i32| ffi::from_slice_f32(&vec![0.0; (2 * 4 * last) as usize], &[2, 4, last]);
+        weights.insert("embed_q.weight".to_string(), plane(8));
+        weights.insert("embed_q.scales".to_string(), plane(1));
+        weights.insert("embed_q.biases".to_string(), plane(1));
+
+        QuantizedMultiLinear::from_weights(&weights, "embed_q", 64, 4)
+            .expect("an honest affine pair must still load");
+
+        for (group_size, bits, field) in [
+            (64, 0, "bits"),
+            (64, 33, "bits"),
+            (0, 4, "group_size"),
+            (-64, 4, "group_size"),
+        ] {
+            let err = QuantizedMultiLinear::from_weights(&weights, "embed_q", group_size, bits)
+                .err()
+                .unwrap_or_else(|| panic!("the loader must reject {group_size} / {bits}"));
+            assert!(
+                err.contains(field) && err.contains("embed_q"),
+                "the message must name both the field and the tensor, got: {err}"
+            );
+        }
+
+        // A non-quantized projection carries no packing, so the params are
+        // irrelevant there and must not be enforced.
+        let mut regular = crate::weights::WeightMap::new();
+        regular.insert("embed_q.weight".to_string(), plane(8));
+        MultiLinear::from_weights(&regular, "embed_q", 0, 0)
+            .expect("a non-quantized MultiLinear must not be gated on quantization params");
+    }
+
     #[test]
     fn quantized_packing_check_compares_the_weight_side_too() {
         // The scales-side comparison alone is not MLX's test. The block-float

--- a/src/lib/mlxcel-core/src/layers.rs
+++ b/src/lib/mlxcel-core/src/layers.rs
@@ -243,9 +243,12 @@ impl QuantizedEmbedding {
     /// straight to `quantized_embedding` / `quantized_matmul`, which cross the
     /// cxx bridge as `UniquePtr<MlxArray>` rather than `Result`: a C++ throw
     /// there is an uncatchable abort at the first forward pass rather than a
-    /// load error. Returning `Result` makes the bound impossible to skip for the
-    /// next family that builds one directly, which is the whole reason the
+    /// load error. Returning `Result` puts the bound on the path the next family
+    /// that builds one directly will take, which is the whole reason the
     /// signature changed rather than the two existing call sites being patched.
+    /// It is a strong default rather than an enforced invariant: the fields
+    /// above are `pub`, so a struct literal still bypasses this entirely.
+    /// Nothing in the tree does that today.
     ///
     /// This bounds the declared pair only; it does not reconcile against the
     /// tensor shapes the way `from_weights_with_mode` does, because the shapes
@@ -1060,7 +1063,8 @@ pub fn validate_quantization_params(group_size: i32, bits: i32) -> Result<(), St
 ///
 /// `prefix` names the offending tensor in every error.
 ///
-/// Used by: LongCat Flash NGram, Youtu-VL (MLA `kv_b_proj` decomposition)
+/// Used by: DeepSeek V3, DeepSeek V3.2, KimiLinear, LongCat Flash NGram,
+///          Youtu-VL (MLA `kv_b_proj` decomposition)
 pub fn infer_mla_quantization_params(
     weight_shape: &[i32],
     scales_shape: &[i32],
@@ -1106,6 +1110,25 @@ pub fn infer_mla_quantization_params(
 
     validate_quantization_params(group_size, bits)
         .map_err(|e| format!("{prefix}: inferred quantization params are unusable: {e}"))?;
+
+    // Both divisions truncate, so an in-range pair is not yet a consistent one:
+    // `packed_in 65 / kv_lora_rank 512` solves to 4 bits and passes the bound
+    // while describing an input width of 520 against the 512 the groups
+    // describe. `affine_dequantize` compares exactly that and throws, which is
+    // the same uncatchable abort one step later. Evaluated in i64 for the same
+    // reason the multiply above is.
+    let described = i64::from(packed_in) * 32 / i64::from(bits);
+    let denom = i64::from(num_groups) * i64::from(group_size);
+    if described != denom {
+        return Err(format!(
+            "{prefix}: packed kv_b_proj weight {weight_shape:?} and scales {scales_shape:?} \
+             describe an input width of {described} at {bits}-bit, but {num_groups} groups at \
+             group_size {group_size} describe {denom}. MLX checks exactly this inside dequantize \
+             and throws on a mismatch, and that throw crosses the cxx bridge as an uncatchable \
+             abort during weight sanitization rather than a load error."
+        ));
+    }
+
     Ok((group_size, bits))
 }
 
@@ -1870,6 +1893,20 @@ impl FusedQKVLinear {
                 .ok_or_else(|| format!("Scales not found: {}.scales", v_prefix))?;
 
             // Reconcile caller-supplied bits with actual tensor shapes (affine only).
+            // Bound the declared pair before anything derived from it is
+            // stored (issue #958). This loader never calls
+            // `reconcile_quantization_layout`, and `infer_quantization_bits`
+            // below early-returns the caller's `bits` unchanged whenever
+            // `group_size <= 0`, so a declared `(0, 0)` was stored verbatim on
+            // the fused `QuantizedWeight` and handed to `quantized_matmul` /
+            // `fused_qkv_project_split_norm_rope`. In every current family a
+            // sibling `UnifiedLinear` sees the same declared pair and its
+            // reconciler rejects it first, so this is a shadowed hole rather
+            // than a live one, but it is the same shape as the MoE hole #929
+            // left open and it is one line to close.
+            validate_quantization_params(group_size, bits)
+                .map_err(|e| format!("{q_prefix}: {e}"))?;
+
             // Fused QKV concatenates along axis 0, so q/k/v must share bits; infer from q.
             let effective_bits = if mode == "affine" {
                 let w_shape = ffi::array_shape(q_w);
@@ -2716,7 +2753,7 @@ impl Attention {
 /// - `unembed_out`: projects attention output from latent space to V dimensions
 ///
 /// Supports both quantized and non-quantized weights.
-/// Used by: DeepSeek V3, DeepSeek V3.2, GLM4 MoE Lite
+/// Used by: DeepSeek V3, DeepSeek V3.2, GLM4 MoE Lite, LongCat Flash NGram
 pub enum MultiLinear {
     Quantized(QuantizedMultiLinear),
     Regular(RegularMultiLinear),
@@ -4720,9 +4757,11 @@ mod tests {
     /// without going through `reconcile_quantization_layout`, which is exactly
     /// how `mamba` / `mamba2` reached `quantized_embedding` with an unbounded
     /// pair (issue #958). They are fallible so the bound cannot be skipped, and
-    /// this drives the real constructors rather than the pure helper: if the
-    /// guard regresses, the pair reaches MLX and the C++ throw takes this whole
-    /// test binary down with SIGABRT instead of failing cleanly.
+    /// this drives the real constructors rather than the pure helper, so the
+    /// guard is exercised where a checkpoint actually reaches it. Losing it turns
+    /// a rejected load into an uncatchable abort at the first forward pass in
+    /// production; here the assertions are on the constructor result, so a
+    /// regression fails cleanly rather than aborting the test binary.
     #[test]
     fn hand_built_quantized_layers_bound_their_declared_params() {
         // Honest affine 4-bit geometry: packed_in * 32 == bits * groups * gs,
@@ -4891,9 +4930,10 @@ mod tests {
     #[test]
     fn quantized_loaders_reject_hostile_params_at_load_not_at_the_first_forward() {
         // The real load path, not the pure helper: both production entry points
-        // must surface a Rust error. If this guard regresses, the bad pair
-        // reaches `quantized_matmul` and the C++ throw aborts this whole test
-        // binary with SIGABRT rather than failing cleanly.
+        // must surface a Rust error. Losing this guard turns a rejected load
+        // into an uncatchable abort at the first `quantized_matmul` in
+        // production; here the assertion is on the load result, so a regression
+        // fails cleanly.
         let mut weights = crate::weights::WeightMap::new();
         insert_quantized_qkv_projection(&mut weights, "model.layers.0.self_attn.q_proj", 8);
         insert_quantized_qkv_projection(&mut weights, "model.embed_tokens", 16);

--- a/src/loading/special.rs
+++ b/src/loading/special.rs
@@ -242,7 +242,8 @@ pub(crate) fn try_load_special_model_from_weights(
             let args: models::kimi_linear::KimiLinearConfig =
                 super::parse_model_config(config_str)?;
             let mut owned = copy_weight_map(weights);
-            owned = models::KimiLinearModel::sanitize_weights(owned, &args);
+            owned = models::KimiLinearModel::sanitize_weights(owned, &args)
+                .map_err(|err| anyhow::anyhow!("{}", err))?;
             let model = models::KimiLinearModel::from_weights(&owned, &args)
                 .map_err(|err| anyhow::anyhow!("{}", err))?;
             LoadedModel::KimiLinear(model)

--- a/src/loading/special.rs
+++ b/src/loading/special.rs
@@ -251,7 +251,8 @@ pub(crate) fn try_load_special_model_from_weights(
             let args: models::longcat_flash_ngram::LongcatFlashNgramConfig =
                 super::parse_model_config(config_str)?;
             let mut owned = copy_weight_map(weights);
-            owned = models::longcat_flash_ngram::sanitize_weights(owned, &args);
+            owned = models::longcat_flash_ngram::sanitize_weights(owned, &args)
+                .map_err(|err| anyhow::anyhow!("{}", err))?;
             let model = models::LongcatFlashNgramModel::from_weights(&owned, &args)
                 .map_err(|err| anyhow::anyhow!("{}", err))?;
             if model_type == ModelType::LongcatFlashNgram {

--- a/src/loading/vlm_kimi_vl.rs
+++ b/src/loading/vlm_kimi_vl.rs
@@ -95,7 +95,8 @@ pub(crate) fn load_kimi_vl_vlm(model_path: &Path) -> Result<LoadedModel> {
     // DeepSeek-V3 sanitize (expert stacking + MLA decomposition).
     let raw_weights = load_vlm_weights_common(model_path, None)?;
     let weights = remap_kimi_vl_weights(raw_weights);
-    let weights = DeepSeekV3Model::sanitize_weights_with_args(weights, &text_config);
+    let weights = DeepSeekV3Model::sanitize_weights_with_args(weights, &text_config)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     let text_model = DeepSeekV3Model::from_weights(&weights, &text_config)
         .map_err(|e| anyhow::anyhow!("Failed to load Kimi-VL text model: {e}"))?;

--- a/src/models/deepseek.rs
+++ b/src/models/deepseek.rs
@@ -22,6 +22,7 @@
 //! - routed_scaling_factor for expert outputs (default 1.0)
 //! - Top-k routing with softmax scoring
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
@@ -849,7 +850,7 @@ impl SwitchLinear {
             let biases = weights
                 .get(&format!("{}.biases", prefix))
                 .map(|w| mlxcel_core::copy(w));
-            return Ok(Self::from_stacked_parts(weight, scales, biases, args));
+            return Self::from_stacked_parts(prefix, weight, scales, biases, args);
         }
 
         // Per-expert layout: stack `{root}.experts.{idx}.{proj}` tensors.
@@ -860,7 +861,7 @@ impl SwitchLinear {
                 args.n_routed_experts,
             )?
         {
-            return Ok(Self::from_stacked_parts(weight, scales, biases, args));
+            return Self::from_stacked_parts(prefix, weight, scales, biases, args);
         }
 
         Err(format!("Weight not found: {}.weight", prefix))
@@ -868,27 +869,37 @@ impl SwitchLinear {
 
     /// Build a `SwitchLinear` from a stacked `[num_experts, ...]` weight,
     /// selecting the quantized path when scales are present.
+    ///
+    /// Fallible since issue #958: the quantized arm stores the declared
+    /// `group_size` / `bits` and hands them to `gather_qmm`, and this family
+    /// never reaches `reconcile_quantization_layout`, so the bound has to live
+    /// here. `prefix` is threaded in only so the error names the expert plane.
     fn from_stacked_parts(
+        prefix: &str,
         weight: UniquePtr<MlxArray>,
         scales: Option<UniquePtr<MlxArray>>,
         biases: Option<UniquePtr<MlxArray>>,
         args: &ModelArgs,
-    ) -> Self {
+    ) -> Result<Self, String> {
         let num_experts = mlxcel_core::array_shape(&weight)[0] as usize;
-        match (scales, biases) {
-            (Some(scales), Some(biases)) => Self::Quantized {
-                weight,
-                scales,
-                biases,
-                group_size: args.group_size(),
-                bits: args.bits(),
-                num_experts,
-            },
+        Ok(match (scales, biases) {
+            (Some(scales), Some(biases)) => {
+                let (group_size, bits) = (args.group_size(), args.bits());
+                validate_expert_quantization_params(prefix, group_size, bits)?;
+                Self::Quantized {
+                    weight,
+                    scales,
+                    biases,
+                    group_size,
+                    bits,
+                    num_experts,
+                }
+            }
             _ => Self::Regular {
                 weight,
                 num_experts,
             },
-        }
+        })
     }
 }
 

--- a/src/models/deepseek_tests.rs
+++ b/src/models/deepseek_tests.rs
@@ -112,9 +112,11 @@ fn quant_args(group_size: i32, bits: i32) -> ModelArgs {
 /// `SwitchLinear::from_stacked_parts` stores the declared pair verbatim on the
 /// quantized variant and hands it straight to `gather_qmm`, which crosses the
 /// cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++ throw there
-/// is an uncatchable `std::terminate`, so losing the bound would abort the
-/// whole test binary with SIGABRT at the first routed forward pass instead of
-/// failing cleanly at load. Issue #958.
+/// is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn deepseek_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
     // Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *

--- a/src/models/deepseek_tests.rs
+++ b/src/models/deepseek_tests.rs
@@ -98,3 +98,73 @@ fn switch_linear_accepts_full_expert_count() {
         .expect("stacking exactly n_routed_experts experts must succeed");
     assert_eq!(sl.num_experts(), 4);
 }
+
+/// The same minimal config with an explicit quantization pair. DeepSeek v1
+/// declares `group_size` / `bits` as flat top-level keys rather than a nested
+/// `quantization` block, so those are the two fields the guard reads.
+fn quant_args(group_size: i32, bits: i32) -> ModelArgs {
+    let mut args = test_args(None);
+    args.group_size = Some(group_size);
+    args.bits = Some(bits);
+    args
+}
+
+/// `SwitchLinear::from_stacked_parts` stores the declared pair verbatim on the
+/// quantized variant and hands it straight to `gather_qmm`, which crosses the
+/// cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++ throw there
+/// is an uncatchable `std::terminate`, so losing the bound would abort the
+/// whole test binary with SIGABRT at the first routed forward pass instead of
+/// failing cleanly at load. Issue #958.
+#[test]
+fn deepseek_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+    // Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+    // group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a
+    // plane MLX can actually describe.
+    const EXPERTS: i32 = 3;
+    const OUT: i32 = 4;
+    const PACKED_IN: i32 = 8;
+    const NUM_GROUPS: i32 = 1;
+    const GROUP_SIZE: i32 = 64;
+    const BITS: i32 = 4;
+    const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+
+    let mut weights = WeightMap::new();
+    crate::models::switch_layers::insert_stacked_quantized_expert_plane(
+        &mut weights,
+        PREFIX,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    SwitchLinear::from_weights(&weights, &quant_args(GROUP_SIZE, BITS), PREFIX)
+        .expect("honest 4-bit expert plane must load");
+
+    for (group_size, bits, field) in crate::models::switch_layers::HOSTILE_QUANT_PARAMS {
+        let err = match SwitchLinear::from_weights(&weights, &quant_args(group_size, bits), PREFIX)
+        {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+    }
+
+    // A bf16 expert plane carries no packing at all, so the declared pair is
+    // irrelevant there and must not gate the non-quantized fallback.
+    let mut regular = WeightMap::new();
+    regular.insert(
+        format!("{PREFIX}.weight"),
+        mlxcel_core::ones(&[EXPERTS, OUT, PACKED_IN], mlxcel_core::dtype::BFLOAT16),
+    );
+    SwitchLinear::from_weights(&regular, &quant_args(0, 0), PREFIX)
+        .expect("a bf16 expert plane must not be gated on quantization params");
+}

--- a/src/models/deepseek_v2.rs
+++ b/src/models/deepseek_v2.rs
@@ -1035,3 +1035,7 @@ impl LanguageModel for DeepSeekV2Model {
         vec![100001] // <|end▁of▁sentence|>
     }
 }
+
+#[cfg(test)]
+#[path = "deepseek_v2_tests.rs"]
+mod tests;

--- a/src/models/deepseek_v2.rs
+++ b/src/models/deepseek_v2.rs
@@ -22,6 +22,7 @@
 //! - MoE with group-limited greedy routing
 //! - Shared experts plus routed experts
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils::{repeat_kv, silu, slice_axis};
@@ -993,6 +994,10 @@ fn load_switch_linear(
     let weight = get_weight_copy(weights, &format!("{}.{}.weight", prefix, weight_name))?;
     let scales_key = format!("{}.{}.scales", prefix, weight_name);
     if weights.contains_key(&scales_key) {
+        // Bound the declared pair here, where it is stored: this family-local
+        // expert type never reaches `reconcile_quantization_layout` and hands
+        // the stored pair to `gather_qmm` (issue #958).
+        validate_expert_quantization_params(&format!("{prefix}.{weight_name}"), group_size, bits)?;
         let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());
         let biases = get_weight_copy(weights, &format!("{}.{}.biases", prefix, weight_name))?;
         Ok(SwitchLinear::Quantized {

--- a/src/models/deepseek_v2_tests.rs
+++ b/src/models/deepseek_v2_tests.rs
@@ -1,0 +1,95 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for the bound on declared quantization params that
+//! `deepseek_v2::load_switch_linear` applies before it stores them on a
+//! quantized expert plane (issue #958).
+
+use super::load_switch_linear;
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+use mlxcel_core::weights::WeightMap;
+
+/// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+/// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a plane
+/// MLX can actually describe.
+const EXPERTS: i32 = 3;
+const OUT: i32 = 4;
+const PACKED_IN: i32 = 8;
+const NUM_GROUPS: i32 = 1;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+/// This loader builds its keys as `{prefix}.{weight_name}.weight`, so the
+/// fixture is inserted under the joined path.
+const PREFIX: &str = "model.layers.0.mlp.switch_mlp";
+const WEIGHT_NAME: &str = "gate_proj";
+
+/// The pair this loader stores is handed straight to `gather_qmm`, which
+/// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
+/// throw there is an uncatchable `std::terminate`, so losing the bound would
+/// abort the whole test binary with SIGABRT at the first routed forward pass
+/// instead of failing cleanly at load. Issue #958.
+#[test]
+fn deepseek_v2_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+    let plane_prefix = format!("{PREFIX}.{WEIGHT_NAME}");
+    let mut weights = WeightMap::new();
+    insert_stacked_quantized_expert_plane(
+        &mut weights,
+        &plane_prefix,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    let experts = EXPERTS as usize;
+    match load_switch_linear(&weights, experts, PREFIX, WEIGHT_NAME, GROUP_SIZE, BITS) {
+        Ok(_) => {}
+        Err(e) => panic!("honest 4-bit expert plane must load: {e}"),
+    }
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let result = load_switch_linear(&weights, experts, PREFIX, WEIGHT_NAME, group_size, bits);
+        let err = match result {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+        assert!(
+            err.contains(&plane_prefix),
+            "the load error must name the offending tensor {plane_prefix}, got: {err}"
+        );
+    }
+
+    // A bf16 expert plane carries no packing and no `.scales`, so the declared
+    // pair is inert on the `gather_mm` path and must not gate the load.
+    let mut dense = WeightMap::new();
+    let n = (EXPERTS * OUT * PACKED_IN) as usize;
+    dense.insert(
+        format!("{plane_prefix}.weight"),
+        mlxcel_core::from_slice_f32(&vec![0.0f32; n], &[EXPERTS, OUT, PACKED_IN]),
+    );
+    match load_switch_linear(&dense, experts, PREFIX, WEIGHT_NAME, 0, 0) {
+        Ok(_) => {}
+        Err(e) => panic!("a non-quantized expert plane must load with an unset pair: {e}"),
+    }
+}

--- a/src/models/deepseek_v2_tests.rs
+++ b/src/models/deepseek_v2_tests.rs
@@ -37,9 +37,11 @@ const WEIGHT_NAME: &str = "gate_proj";
 
 /// The pair this loader stores is handed straight to `gather_qmm`, which
 /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
-/// throw there is an uncatchable `std::terminate`, so losing the bound would
-/// abort the whole test binary with SIGABRT at the first routed forward pass
-/// instead of failing cleanly at load. Issue #958.
+/// throw there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn deepseek_v2_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
     let plane_prefix = format!("{PREFIX}.{WEIGHT_NAME}");

--- a/src/models/deepseek_v3.rs
+++ b/src/models/deepseek_v3.rs
@@ -1884,4 +1884,78 @@ mod tests {
         mlxcel_core::eval(&mx);
         assert!(mlxcel_core::item_f32(&mx).is_finite());
     }
+
+    /// Smallest DeepSeek-V3 config that parses, varying only the declared
+    /// quantization pair. Built through serde rather than a struct literal so
+    /// the `#[serde(default)]` fields fill themselves in.
+    fn quant_config(group_size: i32, bits: i32) -> DeepSeekV3Config {
+        serde_json::from_value(serde_json::json!({
+            "vocab_size": 32,
+            "hidden_size": 8,
+            "intermediate_size": 8,
+            "moe_intermediate_size": 8,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "kv_lora_rank": 4,
+            "qk_rope_head_dim": 2,
+            "v_head_dim": 4,
+            "qk_nope_head_dim": 2,
+            "quantization": { "group_size": group_size, "bits": bits },
+        }))
+        .expect("test config must parse")
+    }
+
+    /// This `SwitchGLU` is unconditionally quantized: it stores the declared
+    /// pair and hands it to three `gather_qmm` calls, which cross the cxx
+    /// bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++ throw there
+    /// is an uncatchable `std::terminate`, so losing the bound would abort the
+    /// whole test binary with SIGABRT at the first routed forward pass instead
+    /// of failing cleanly at load. Issue #958. There is no non-quantized
+    /// fallback to exempt here, unlike the other families carrying this guard.
+    #[test]
+    fn deepseek_v3_switch_glu_rejects_quantization_params_that_would_abort_gather_qmm() {
+        // Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+        // group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is
+        // a plane MLX can actually describe.
+        const EXPERTS: i32 = 3;
+        const OUT: i32 = 4;
+        const PACKED_IN: i32 = 8;
+        const NUM_GROUPS: i32 = 1;
+        const GROUP_SIZE: i32 = 64;
+        const BITS: i32 = 4;
+        const PREFIX: &str = "model.layers.0.mlp.switch_mlp";
+
+        let mut weights = WeightMap::new();
+        for proj in ["gate_proj", "up_proj", "down_proj"] {
+            crate::models::switch_layers::insert_stacked_quantized_expert_plane(
+                &mut weights,
+                &format!("{PREFIX}.{proj}"),
+                EXPERTS,
+                OUT,
+                PACKED_IN,
+                NUM_GROUPS,
+            );
+        }
+
+        // Positive control first, so a guard that rejected every quantized
+        // plane could not pass this test.
+        SwitchGLU::from_weights(&weights, &quant_config(GROUP_SIZE, BITS), PREFIX)
+            .expect("honest 4-bit expert planes must load");
+
+        for (group_size, bits, field) in crate::models::switch_layers::HOSTILE_QUANT_PARAMS {
+            let err =
+                match SwitchGLU::from_weights(&weights, &quant_config(group_size, bits), PREFIX) {
+                    Ok(_) => panic!(
+                        "(group_size {group_size}, bits {bits}) must be refused at load, \
+                         not stored for gather_qmm"
+                    ),
+                    Err(e) => e,
+                };
+            assert!(
+                err.contains(field),
+                "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+            );
+        }
+    }
 }

--- a/src/models/deepseek_v3.rs
+++ b/src/models/deepseek_v3.rs
@@ -1977,4 +1977,85 @@ mod tests {
             );
         }
     }
+
+    /// The MLA `kv_b_proj` pair `DeepSeekV3Model::sanitize_weights` decomposes
+    /// is solved from `kv_lora_rank` and two tensor axes rather than declared,
+    /// and every input is untrusted: `kv_lora_rank` comes from `config.json`
+    /// and the axes from the checkpoint. Before issue #958 the naive
+    /// arithmetic divided by both without checking them, so a `kv_lora_rank`
+    /// of 0 panicked on integer division and a solved pair outside anything
+    /// MLX can describe reached `dequantize`, which crosses the cxx bridge as
+    /// `UniquePtr<MlxArray>` rather than `Result` and therefore aborts during
+    /// weight sanitization rather than failing the load.
+    ///
+    /// This drives the real `DeepSeekV3Model::sanitize_weights` rather than
+    /// the shared helper directly, so the guard is exercised where a
+    /// checkpoint reaches it. The assertions are on the returned `Result`, so
+    /// a regression fails cleanly here instead of aborting the test binary.
+    #[test]
+    fn quantized_kv_b_proj_rejects_a_kv_lora_rank_no_packing_can_describe() {
+        // Honest affine 4-bit geometry: packed_in * 32 == bits * num_groups *
+        // group_size (2 * 32 == 4 * 1 * 16). `test_config_dense_direct_q`
+        // gives num_attention_heads 2, qk_nope_head_dim 4, v_head_dim 4, so
+        // rows = 2 * 8 = 16.
+        let build = |cfg: &DeepSeekV3Config| {
+            let heads = cfg.num_attention_heads as i32;
+            let head_dim = (cfg.qk_nope_head_dim + cfg.v_head_dim) as i32;
+            let rows = heads * head_dim;
+            let mut weights = WeightMap::new();
+            for l in 0..cfg.num_hidden_layers {
+                let prefix = format!("model.layers.{l}.self_attn.kv_b_proj");
+                // UINT32, not a float ramp: `dequantize` rejects any other
+                // packed dtype by throwing, and that throw is the uncatchable
+                // abort this guard exists to keep out of the forward path.
+                weights.insert(
+                    format!("{prefix}.weight"),
+                    mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
+                );
+                insert_ramp(&mut weights, &format!("{prefix}.scales"), &[rows, 1]);
+                insert_ramp(&mut weights, &format!("{prefix}.biases"), &[rows, 1]);
+            }
+            weights
+        };
+
+        // Positive control first, so a guard that rejected every quantized
+        // kv_b_proj could not pass this test.
+        let mut honest = test_config_dense_direct_q();
+        honest.kv_lora_rank = 16;
+        let sanitized = DeepSeekV3Model::sanitize_weights(build(&honest), &honest)
+            .expect("an honest quantized kv_b_proj must still sanitize");
+        assert!(sanitized.contains_key("model.layers.0.self_attn.embed_q.weight"));
+
+        // A zero `kv_lora_rank` is Rust integer division by zero on the very
+        // first solve, so it has to be refused before the division rather
+        // than after.
+        let mut zero_rank = honest.clone();
+        zero_rank.kv_lora_rank = 0;
+        let err = DeepSeekV3Model::sanitize_weights(build(&zero_rank), &zero_rank)
+            .err()
+            .unwrap_or_else(|| panic!("kv_lora_rank 0 must be refused, not divided by"));
+        assert!(err.contains("kv_lora_rank"), "unhelpful error: {err}");
+
+        // A large `kv_lora_rank` truncates the solved bit width to 0, which
+        // is the divisor MLX would then divide by.
+        let mut wide_rank = honest.clone();
+        wide_rank.kv_lora_rank = 4096;
+        let err = DeepSeekV3Model::sanitize_weights(build(&wide_rank), &wide_rank)
+            .err()
+            .unwrap_or_else(|| panic!("a solved bit width of 0 must be refused"));
+        assert!(err.contains("bits"), "unhelpful error: {err}");
+
+        // A non-quantized kv_b_proj carries no packing, so the pair is never
+        // solved and the decomposition must stay unaffected.
+        let mut float_only = WeightMap::new();
+        let rows = honest.num_attention_heads as i32
+            * (honest.qk_nope_head_dim + honest.v_head_dim) as i32;
+        insert_ramp(
+            &mut float_only,
+            "model.layers.0.self_attn.kv_b_proj.weight",
+            &[rows, honest.kv_lora_rank as i32],
+        );
+        DeepSeekV3Model::sanitize_weights(float_only, &honest)
+            .expect("a float kv_b_proj must not be gated on quantization params");
+    }
 }

--- a/src/models/deepseek_v3.rs
+++ b/src/models/deepseek_v3.rs
@@ -2046,16 +2046,19 @@ mod tests {
         assert!(err.contains("bits"), "unhelpful error: {err}");
 
         // A non-quantized kv_b_proj carries no packing, so the pair is never
-        // solved and the decomposition must stay unaffected.
+        // solved and a `kv_lora_rank` that no packing could describe must not gate
+        // it. The tensor is built at `wide_rank`'s own width so it still satisfies
+        // the separate shape cross-check below the solve, which would otherwise
+        // reject this for an unrelated reason.
         let mut float_only = WeightMap::new();
-        let rows = honest.num_attention_heads as i32
-            * (honest.qk_nope_head_dim + honest.v_head_dim) as i32;
+        let rows = wide_rank.num_attention_heads as i32
+            * (wide_rank.qk_nope_head_dim + wide_rank.v_head_dim) as i32;
         insert_ramp(
             &mut float_only,
             "model.layers.0.self_attn.kv_b_proj.weight",
-            &[rows, honest.kv_lora_rank as i32],
+            &[rows, wide_rank.kv_lora_rank as i32],
         );
-        DeepSeekV3Model::sanitize_weights(float_only, &honest)
+        DeepSeekV3Model::sanitize_weights(float_only, &wide_rank)
             .expect("a float kv_b_proj must not be gated on quantization params");
     }
 }

--- a/src/models/deepseek_v3.rs
+++ b/src/models/deepseek_v3.rs
@@ -986,7 +986,7 @@ impl DeepSeekV3Model {
         let weights = crate::models::load_text_weights(model_dir, None)?;
 
         // Sanitize weights (stack expert weights if needed)
-        let weights = Self::sanitize_weights(weights, &config);
+        let weights = Self::sanitize_weights(weights, &config)?;
 
         // Create model
         let model = Self::from_weights(&weights, &config)?;
@@ -1000,11 +1000,17 @@ impl DeepSeekV3Model {
     /// filters out layers from other stages).
     ///
     /// Used by: DeepSeek V3 pipeline stage executor
-    pub fn sanitize_weights_with_args(weights: WeightMap, config: &DeepSeekV3Config) -> WeightMap {
+    pub fn sanitize_weights_with_args(
+        weights: WeightMap,
+        config: &DeepSeekV3Config,
+    ) -> Result<WeightMap, String> {
         Self::sanitize_weights(weights, config)
     }
 
-    fn sanitize_weights(mut weights: WeightMap, config: &DeepSeekV3Config) -> WeightMap {
+    fn sanitize_weights(
+        mut weights: WeightMap,
+        config: &DeepSeekV3Config,
+    ) -> Result<WeightMap, String> {
         // Remap pre-stacked weight names that omit the `.mlp.` segment.
         //
         // Some HuggingFace MLX shards for DeepSeek-V3 store pre-stacked MoE expert
@@ -1134,11 +1140,19 @@ impl DeepSeekV3Model {
                     .remove(&format!("{}.kv_b_proj.biases", prefix))
                     .unwrap();
 
-                let w_shape = mlxcel_core::array_shape(&w);
-                let s_shape = mlxcel_core::array_shape(&s);
-                let kv_lora_rank = config.kv_lora_rank as i32;
-                let inferred_bits = (w_shape[w_shape.len() - 1] * 32) / kv_lora_rank;
-                let inferred_gs = kv_lora_rank / s_shape[s_shape.len() - 1];
+                // Solve the packed pair from the shapes and bound it before it
+                // reaches `dequantize`. The shared helper checks each divisor
+                // before dividing: `kv_lora_rank` is a config field and the
+                // scales axis is checkpoint data, so the naive form panics on a
+                // zero divisor and overflows i32 on a large packed axis, both
+                // before the bound could fire (issue #958).
+                let (inferred_gs, inferred_bits) =
+                    mlxcel_core::layers::infer_mla_quantization_params(
+                        &mlxcel_core::array_shape(&w),
+                        &mlxcel_core::array_shape(&s),
+                        config.kv_lora_rank as i32,
+                        &format!("{prefix}.kv_b_proj"),
+                    )?;
 
                 unsafe {
                     mlxcel_core::dequantize(
@@ -1193,7 +1207,7 @@ impl DeepSeekV3Model {
             weights.remove(&key);
         }
 
-        weights
+        Ok(weights)
     }
 
     pub fn from_weights(weights: &WeightMap, args: &DeepSeekV3Config) -> Result<Self, String> {
@@ -1530,7 +1544,8 @@ mod tests {
             }
         }
 
-        let out = DeepSeekV3Model::sanitize_weights(weights, &config);
+        let out =
+            DeepSeekV3Model::sanitize_weights(weights, &config).expect("sanitize must succeed");
 
         // After sanitization, keys must have the `.mlp.` segment
         for l in 0..2usize {
@@ -1572,7 +1587,8 @@ mod tests {
             }
         }
 
-        let out = DeepSeekV3Model::sanitize_weights(weights, &config);
+        let out =
+            DeepSeekV3Model::sanitize_weights(weights, &config).expect("sanitize must succeed");
 
         // Canonical key must still be present
         for l in 0..2usize {
@@ -1722,7 +1738,7 @@ mod tests {
         // MTP trailer at the out-of-range index `num_hidden_layers` (= 2).
         insert_dense_layer_weights(&mut weights, &cfg, cfg.num_hidden_layers);
 
-        let out = DeepSeekV3Model::sanitize_weights(weights, &cfg);
+        let out = DeepSeekV3Model::sanitize_weights(weights, &cfg).expect("sanitize must succeed");
 
         for l in 0..cfg.num_hidden_layers {
             let embed_q = format!("model.layers.{l}.self_attn.embed_q.weight");
@@ -1746,7 +1762,8 @@ mod tests {
     fn from_weights_builds_all_num_hidden_layers() {
         let cfg = test_config_dense_direct_q();
         let weights = tiny_dense_model_weights(&cfg);
-        let weights = DeepSeekV3Model::sanitize_weights(weights, &cfg);
+        let weights =
+            DeepSeekV3Model::sanitize_weights(weights, &cfg).expect("sanitize must succeed");
         let model = DeepSeekV3Model::from_weights(&weights, &cfg)
             .expect("tiny dense direct-q model must load");
         assert_eq!(
@@ -1782,7 +1799,8 @@ mod tests {
         let cfg = test_config_dense_direct_q();
         let mut weights = WeightMap::new();
         insert_dense_layer_weights(&mut weights, &cfg, 0);
-        let weights = DeepSeekV3Model::sanitize_weights(weights, &cfg);
+        let weights =
+            DeepSeekV3Model::sanitize_weights(weights, &cfg).expect("sanitize must succeed");
         let attn = DeepSeekV3Attention::from_weights(&weights, &cfg, "model.layers.0.self_attn")
             .expect("tiny attention must load");
 
@@ -1909,10 +1927,11 @@ mod tests {
     /// This `SwitchGLU` is unconditionally quantized: it stores the declared
     /// pair and hands it to three `gather_qmm` calls, which cross the cxx
     /// bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++ throw there
-    /// is an uncatchable `std::terminate`, so losing the bound would abort the
-    /// whole test binary with SIGABRT at the first routed forward pass instead
-    /// of failing cleanly at load. Issue #958. There is no non-quantized
-    /// fallback to exempt here, unlike the other families carrying this guard.
+    /// is an uncatchable `std::terminate`,
+    /// so losing the bound turns a rejected load into an uncatchable abort at
+    /// the first routed forward pass in production. This test asserts on the
+    /// load result rather than running a forward pass, so a regression fails
+    /// cleanly here instead of aborting the test binary.
     #[test]
     fn deepseek_v3_switch_glu_rejects_quantization_params_that_would_abort_gather_qmm() {
         // Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *

--- a/src/models/deepseek_v3.rs
+++ b/src/models/deepseek_v3.rs
@@ -20,6 +20,7 @@
 //! - Shared experts + routed experts
 //! - First k layers are dense (no MoE)
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, MultiLinear, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils::{create_causal_mask, slice_axis, stack_arrays};
@@ -732,6 +733,12 @@ impl SwitchGLU {
     ) -> Result<Self, String> {
         let group_size = args.group_size();
         let bits = args.bits();
+
+        // This SwitchGLU is unconditionally quantized (it requires scales and
+        // biases for all three projections below) and hands the stored pair to
+        // three `gather_qmm` calls without ever reaching
+        // `reconcile_quantization_layout`, so the bound lives here (issue #958).
+        validate_expert_quantization_params(prefix, group_size, bits)?;
 
         // Load stacked expert weights
         let gate_weight = get_weight_copy(weights, &format!("{}.gate_proj.weight", prefix))?;

--- a/src/models/deepseek_v32.rs
+++ b/src/models/deepseek_v32.rs
@@ -830,19 +830,22 @@ impl DeepSeekV32Model {
             .map_err(|e| format!("Failed to parse config.json: {}", e))?;
 
         let weights = crate::models::load_text_weights(model_dir, None)?;
-        let weights = Self::sanitize_weights(weights, &args);
+        let weights = Self::sanitize_weights(weights, &args)?;
         let model = Self::from_weights(&weights, &args)?;
 
         Ok((model, args))
     }
 
     /// Public entry point for sanitizing weights with external args (used by GLM MoE DSA)
-    pub fn sanitize_weights_with_args(weights: WeightMap, args: &ModelArgs) -> WeightMap {
+    pub fn sanitize_weights_with_args(
+        weights: WeightMap,
+        args: &ModelArgs,
+    ) -> Result<WeightMap, String> {
         Self::sanitize_weights(weights, args)
     }
 
     /// Decompose kv_b_proj into embed_q and unembed_out for MLA, and stack expert weights
-    fn sanitize_weights(mut weights: WeightMap, args: &ModelArgs) -> WeightMap {
+    fn sanitize_weights(mut weights: WeightMap, args: &ModelArgs) -> Result<WeightMap, String> {
         // Remove multi-token prediction (MTP) layers beyond num_hidden_layers
         let mtp_layer = args.num_hidden_layers;
         weights.retain(|k, _| {
@@ -918,11 +921,19 @@ impl DeepSeekV32Model {
                 let b = weights
                     .remove(&format!("{}.kv_b_proj.biases", prefix))
                     .unwrap();
-                let w_shape = mlxcel_core::array_shape(&w);
-                let s_shape = mlxcel_core::array_shape(&s);
-                let kv_lora_rank = args.kv_lora_rank as i32;
-                let inferred_bits = (w_shape[w_shape.len() - 1] * 32) / kv_lora_rank;
-                let inferred_gs = kv_lora_rank / s_shape[s_shape.len() - 1];
+                // Solve the packed pair from the shapes and bound it before it
+                // reaches `dequantize`. The shared helper checks each divisor
+                // before dividing: `kv_lora_rank` is a config field and the
+                // scales axis is checkpoint data, so the naive form panics on a
+                // zero divisor and overflows i32 on a large packed axis, both
+                // before the bound could fire (issue #958).
+                let (inferred_gs, inferred_bits) =
+                    mlxcel_core::layers::infer_mla_quantization_params(
+                        &mlxcel_core::array_shape(&w),
+                        &mlxcel_core::array_shape(&s),
+                        args.kv_lora_rank as i32,
+                        &format!("{prefix}.kv_b_proj"),
+                    )?;
                 unsafe {
                     mlxcel_core::dequantize(
                         &w,
@@ -963,7 +974,7 @@ impl DeepSeekV32Model {
             weights.remove(&key);
         }
 
-        weights
+        Ok(weights)
     }
 
     pub fn from_weights(weights: &WeightMap, args: &ModelArgs) -> Result<Self, String> {

--- a/src/models/deepseek_v32.rs
+++ b/src/models/deepseek_v32.rs
@@ -41,6 +41,7 @@ mod indexer;
 mod deepseek_v32_tests;
 
 use crate::distributed::pipeline::{LayerFilter, StageExecutionOutput};
+use crate::models::switch_layers::validate_expert_quantization_params;
 use indexer::Indexer;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, MultiLinear, RMSNorm, UnifiedEmbedding, UnifiedLinear};
@@ -1230,6 +1231,13 @@ fn load_switch_linear(
     let is_quantized = weights.contains_key(&format!("{}.0.{}.scales", prefix, weight_name));
 
     if is_quantized {
+        // Bound the declared pair before any of the per-expert tensors are
+        // stacked: this family-local expert type never reaches
+        // `reconcile_quantization_layout` and hands the stored pair to
+        // `gather_qmm` (issue #958). The pair can also arrive from a GLM
+        // config, via `glm_moe_dsa::to_dsv32_args`, rather than a DeepSeek one.
+        validate_expert_quantization_params(&format!("{prefix}.{weight_name}"), group_size, bits)?;
+
         let mut expert_scales = Vec::with_capacity(num_experts);
         let mut expert_biases = Vec::with_capacity(num_experts);
 

--- a/src/models/deepseek_v32_tests.rs
+++ b/src/models/deepseek_v32_tests.rs
@@ -291,7 +291,8 @@ fn synthetic_mla_weights(args: &ModelArgs, prefix: &str, with_indexer: bool) -> 
 fn tiny_mla_attention(args: &ModelArgs, with_indexer: bool) -> super::MLAAttention {
     let prefix = "model.layers.0.self_attn";
     let weights = synthetic_mla_weights(args, prefix, with_indexer);
-    let weights = super::DeepSeekV32Model::sanitize_weights(weights, args);
+    let weights =
+        super::DeepSeekV32Model::sanitize_weights(weights, args).expect("sanitize must succeed");
     super::load_mla_attention(&weights, args, prefix).expect("tiny MLA attention must load")
 }
 
@@ -420,7 +421,8 @@ fn sanitize_strips_only_the_mtp_trailer_layer() {
     );
     weights.insert("model.norm.weight".to_string(), f32_weight(&[6]));
 
-    let sanitized = super::DeepSeekV32Model::sanitize_weights(weights, &args);
+    let sanitized =
+        super::DeepSeekV32Model::sanitize_weights(weights, &args).expect("sanitize must succeed");
     assert!(
         sanitized.contains_key("model.layers.0.input_layernorm.weight"),
         "real decoder layer 0 must be kept"
@@ -477,9 +479,11 @@ fn deepseek_v32_expert_weights(quantized: bool) -> WeightMap {
 
 /// The pair this loader stores is handed straight to `gather_qmm`, which crosses
 /// the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++ throw
-/// there is an uncatchable `std::terminate`, so losing the bound would abort the
-/// whole test binary with SIGABRT at the first routed forward pass instead of
-/// failing cleanly at load. Issue #958.
+/// there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn deepseek_v32_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
     let weights = deepseek_v32_expert_weights(true);

--- a/src/models/deepseek_v32_tests.rs
+++ b/src/models/deepseek_v32_tests.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit tests for the DeepSeek Sparse Attention (DSA) lightning indexer.
+//! Unit tests for the DeepSeek Sparse Attention (DSA) lightning indexer and for
+//! the bound on declared quantization params that `load_switch_linear` applies
+//! before it stacks a quantized expert plane (issue #958).
 
-use super::ModelArgs;
 use super::indexer::{Indexer, indexer_top_indices};
+use super::{ModelArgs, load_switch_linear};
+use crate::models::switch_layers::HOSTILE_QUANT_PARAMS;
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr};
 
@@ -430,4 +433,104 @@ fn sanitize_strips_only_the_mtp_trailer_layer() {
         sanitized.contains_key("model.norm.weight"),
         "non-layer keys must pass through"
     );
+}
+
+/// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+/// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a plane
+/// MLX can actually describe.
+const QUANT_EXPERTS: usize = 3;
+const QUANT_OUT: i32 = 4;
+const QUANT_PACKED_IN: i32 = 8;
+const QUANT_NUM_GROUPS: i32 = 1;
+const QUANT_GROUP_SIZE: i32 = 64;
+const QUANT_BITS: i32 = 4;
+
+const QUANT_PREFIX: &str = "model.layers.0.mlp.experts";
+const QUANT_WEIGHT_NAME: &str = "gate_proj";
+
+/// deepseek_v32 keeps the per-expert checkpoint layout
+/// (`{prefix}.{i}.{weight_name}.*`, stacked at load) rather than the pre-stacked
+/// `switch_mlp` plane, so the fixture is built expert by expert. Pass
+/// `quantized = false` to drop the `.scales` / `.biases` tensors and take the
+/// dense `gather_mm` path.
+fn deepseek_v32_expert_weights(quantized: bool) -> WeightMap {
+    let mut weights = WeightMap::new();
+    for expert_idx in 0..QUANT_EXPERTS {
+        let base = format!("{QUANT_PREFIX}.{expert_idx}.{QUANT_WEIGHT_NAME}");
+        weights.insert(
+            format!("{base}.weight"),
+            f32_weight(&[QUANT_OUT, QUANT_PACKED_IN]),
+        );
+        if quantized {
+            weights.insert(
+                format!("{base}.scales"),
+                f32_weight(&[QUANT_OUT, QUANT_NUM_GROUPS]),
+            );
+            weights.insert(
+                format!("{base}.biases"),
+                f32_weight(&[QUANT_OUT, QUANT_NUM_GROUPS]),
+            );
+        }
+    }
+    weights
+}
+
+/// The pair this loader stores is handed straight to `gather_qmm`, which crosses
+/// the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++ throw
+/// there is an uncatchable `std::terminate`, so losing the bound would abort the
+/// whole test binary with SIGABRT at the first routed forward pass instead of
+/// failing cleanly at load. Issue #958.
+#[test]
+fn deepseek_v32_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+    let weights = deepseek_v32_expert_weights(true);
+    let plane_prefix = format!("{QUANT_PREFIX}.{QUANT_WEIGHT_NAME}");
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    let control = load_switch_linear(
+        &weights,
+        QUANT_EXPERTS,
+        QUANT_PREFIX,
+        QUANT_WEIGHT_NAME,
+        QUANT_GROUP_SIZE,
+        QUANT_BITS,
+    );
+    match control {
+        Ok(_) => {}
+        Err(e) => panic!("honest 4-bit expert plane must load: {e}"),
+    }
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let result = load_switch_linear(
+            &weights,
+            QUANT_EXPERTS,
+            QUANT_PREFIX,
+            QUANT_WEIGHT_NAME,
+            group_size,
+            bits,
+        );
+        let err = match result {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+        assert!(
+            err.contains(&plane_prefix),
+            "the load error must name the offending tensor {plane_prefix}, got: {err}"
+        );
+    }
+
+    // A bf16 expert plane carries no packing and no `.scales`, so the declared
+    // pair is inert on the `gather_mm` path and must not gate the load.
+    let dense = deepseek_v32_expert_weights(false);
+    match load_switch_linear(&dense, QUANT_EXPERTS, QUANT_PREFIX, QUANT_WEIGHT_NAME, 0, 0) {
+        Ok(_) => {}
+        Err(e) => panic!("a non-quantized expert plane must load with an unset pair: {e}"),
+    }
 }

--- a/src/models/deepseek_v32_tests.rs
+++ b/src/models/deepseek_v32_tests.rs
@@ -605,14 +605,17 @@ fn quantized_kv_b_proj_rejects_a_kv_lora_rank_no_packing_can_describe() {
     assert!(err.contains("bits"), "unhelpful error: {err}");
 
     // A non-quantized kv_b_proj carries no packing, so the pair is never
-    // solved and the decomposition must stay unaffected.
+    // solved and a `kv_lora_rank` that no packing could describe must not gate
+    // it. The tensor is built at `wide_rank`'s own width so it still satisfies
+    // the separate shape cross-check below the solve, which would otherwise
+    // reject this for an unrelated reason.
     let mut float_only = WeightMap::new();
-    let rows =
-        honest.num_attention_heads as i32 * (honest.qk_nope_head_dim + honest.v_head_dim) as i32;
+    let rows = wide_rank.num_attention_heads as i32
+        * (wide_rank.qk_nope_head_dim + wide_rank.v_head_dim) as i32;
     float_only.insert(
         "model.layers.0.self_attn.kv_b_proj.weight".to_string(),
-        f32_weight(&[rows, honest.kv_lora_rank as i32]),
+        f32_weight(&[rows, wide_rank.kv_lora_rank as i32]),
     );
-    super::DeepSeekV32Model::sanitize_weights(float_only, &honest)
+    super::DeepSeekV32Model::sanitize_weights(float_only, &wide_rank)
         .expect("a float kv_b_proj must not be gated on quantization params");
 }

--- a/src/models/deepseek_v32_tests.rs
+++ b/src/models/deepseek_v32_tests.rs
@@ -538,3 +538,81 @@ fn deepseek_v32_switch_linear_rejects_quantization_params_that_would_abort_gathe
         Err(e) => panic!("a non-quantized expert plane must load with an unset pair: {e}"),
     }
 }
+
+/// The MLA `kv_b_proj` pair `DeepSeekV32Model::sanitize_weights` decomposes is
+/// solved from `kv_lora_rank` and two tensor axes rather than declared, and
+/// every input is untrusted: `kv_lora_rank` comes from `config.json` and the
+/// axes from the checkpoint. Before issue #958 the naive arithmetic divided by
+/// both without checking them, so a `kv_lora_rank` of 0 panicked on integer
+/// division and a solved pair outside anything MLX can describe reached
+/// `dequantize`, which crosses the cxx bridge as `UniquePtr<MlxArray>` rather
+/// than `Result` and therefore aborts during weight sanitization rather than
+/// failing the load.
+///
+/// This drives the real `DeepSeekV32Model::sanitize_weights` rather than the
+/// shared helper directly, so the guard is exercised where a checkpoint
+/// reaches it. The assertions are on the returned `Result`, so a regression
+/// fails cleanly here instead of aborting the test binary.
+#[test]
+fn quantized_kv_b_proj_rejects_a_kv_lora_rank_no_packing_can_describe() {
+    // Honest affine 4-bit geometry: packed_in * 32 == bits * num_groups *
+    // group_size (2 * 32 == 4 * 1 * 16).
+    let build = |args: &ModelArgs| {
+        let num_heads = args.num_attention_heads as i32;
+        let head_dim = (args.qk_nope_head_dim + args.v_head_dim) as i32;
+        let rows = num_heads * head_dim;
+        let mut weights = WeightMap::new();
+        for l in 0..args.num_hidden_layers {
+            let prefix = format!("model.layers.{l}.self_attn.kv_b_proj");
+            // UINT32, not a float weight: `dequantize` rejects any other
+            // packed dtype by throwing, and that throw is the uncatchable abort
+            // this guard exists to keep out of the forward path.
+            weights.insert(
+                format!("{prefix}.weight"),
+                mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
+            );
+            weights.insert(format!("{prefix}.scales"), f32_weight(&[rows, 1]));
+            weights.insert(format!("{prefix}.biases"), f32_weight(&[rows, 1]));
+        }
+        weights
+    };
+
+    // Positive control first, so a guard that rejected every quantized
+    // kv_b_proj could not pass this test.
+    let mut honest = tiny_mla_config(2048);
+    honest.kv_lora_rank = 16;
+    let sanitized = super::DeepSeekV32Model::sanitize_weights(build(&honest), &honest)
+        .expect("an honest quantized kv_b_proj must still sanitize");
+    assert!(sanitized.contains_key("model.layers.0.self_attn.embed_q.weight"));
+
+    // A zero `kv_lora_rank` is Rust integer division by zero on the very
+    // first solve, so it has to be refused before the division rather than
+    // after.
+    let mut zero_rank = honest.clone();
+    zero_rank.kv_lora_rank = 0;
+    let err = super::DeepSeekV32Model::sanitize_weights(build(&zero_rank), &zero_rank)
+        .err()
+        .unwrap_or_else(|| panic!("kv_lora_rank 0 must be refused, not divided by"));
+    assert!(err.contains("kv_lora_rank"), "unhelpful error: {err}");
+
+    // A large `kv_lora_rank` truncates the solved bit width to 0, which is
+    // the divisor MLX would then divide by.
+    let mut wide_rank = honest.clone();
+    wide_rank.kv_lora_rank = 4096;
+    let err = super::DeepSeekV32Model::sanitize_weights(build(&wide_rank), &wide_rank)
+        .err()
+        .unwrap_or_else(|| panic!("a solved bit width of 0 must be refused"));
+    assert!(err.contains("bits"), "unhelpful error: {err}");
+
+    // A non-quantized kv_b_proj carries no packing, so the pair is never
+    // solved and the decomposition must stay unaffected.
+    let mut float_only = WeightMap::new();
+    let rows =
+        honest.num_attention_heads as i32 * (honest.qk_nope_head_dim + honest.v_head_dim) as i32;
+    float_only.insert(
+        "model.layers.0.self_attn.kv_b_proj.weight".to_string(),
+        f32_weight(&[rows, honest.kv_lora_rank as i32]),
+    );
+    super::DeepSeekV32Model::sanitize_weights(float_only, &honest)
+        .expect("a float kv_b_proj must not be gated on quantization params");
+}

--- a/src/models/ernie4_5_moe.rs
+++ b/src/models/ernie4_5_moe.rs
@@ -21,6 +21,7 @@
 //! - RMSNorm layer normalization
 //! - Softmax routing for expert selection
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
@@ -838,6 +839,13 @@ impl SwitchLinear {
         let weight = get_weight_copy(weights, &format!("{}.weight", prefix))?;
         let scales_key = format!("{}.scales", prefix);
         if weights.contains_key(&scales_key) {
+            let (group_size, bits) = (args.group_size(), args.bits());
+            // Bound the declared pair here, where it is stored: this type never
+            // reaches `reconcile_quantization_layout` and hands the stored pair
+            // to `gather_qmm` (issue #958). The VLM sibling reaches the same
+            // enum through its own loader, which carries its own copy of this
+            // bound because it never calls this constructor.
+            validate_expert_quantization_params(prefix, group_size, bits)?;
             let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());
             let biases = get_weight_copy(weights, &format!("{}.biases", prefix))?;
             let shape = mlxcel_core::array_shape(&weight);
@@ -846,8 +854,8 @@ impl SwitchLinear {
                 weight,
                 scales,
                 biases,
-                group_size: args.group_size(),
-                bits: args.bits(),
+                group_size,
+                bits,
                 num_experts,
             })
         } else {

--- a/src/models/ernie4_5_moe.rs
+++ b/src/models/ernie4_5_moe.rs
@@ -911,3 +911,7 @@ impl LanguageModel for Ernie45MoeModel {
         vec![2]
     }
 }
+
+#[cfg(test)]
+#[path = "ernie4_5_moe_tests.rs"]
+mod tests;

--- a/src/models/ernie4_5_moe_tests.rs
+++ b/src/models/ernie4_5_moe_tests.rs
@@ -1,0 +1,102 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for the bound on declared quantization params that the
+//! ERNIE-4.5 MoE `SwitchLinear` loader applies before it stores them on a
+//! quantized expert plane (issue #958).
+
+use mlxcel_core::weights::WeightMap;
+
+use super::{ModelArgs, SwitchLinear};
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+
+/// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+/// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a plane
+/// MLX can actually describe.
+const EXPERTS: i32 = 3;
+const OUT: i32 = 4;
+const PACKED_IN: i32 = 8;
+const NUM_GROUPS: i32 = 1;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+
+/// Smallest ERNIE-4.5 MoE config that parses, varying only the declared
+/// quantization pair. ERNIE spells it as flat top-level `group_size` / `bits`
+/// keys rather than a nested `quantization` block. Built through serde rather
+/// than a struct literal so every `#[serde(default)]` field fills itself in.
+fn args_with(group_size: i32, bits: i32) -> ModelArgs {
+    serde_json::from_value(serde_json::json!({
+        "model_type": "ernie4_5_moe",
+        "hidden_size": 8,
+        "num_hidden_layers": 1,
+        "intermediate_size": 8,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "rms_norm_eps": 1e-5,
+        "vocab_size": 32,
+        "moe_num_experts": 3,
+        "group_size": group_size,
+        "bits": bits,
+    }))
+    .expect("test config must parse")
+}
+
+/// The pair this loader stores is handed straight to `gather_qmm`, which
+/// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
+/// throw there is an uncatchable `std::terminate`, so losing the bound would
+/// abort the whole test binary with SIGABRT at the first routed forward pass
+/// instead of failing cleanly at load. Issue #958.
+#[test]
+fn ernie4_5_moe_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+    let mut weights = WeightMap::new();
+    insert_stacked_quantized_expert_plane(
+        &mut weights,
+        PREFIX,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    SwitchLinear::from_weights(&weights, &args_with(GROUP_SIZE, BITS), PREFIX)
+        .expect("honest 4-bit expert plane must load");
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match SwitchLinear::from_weights(&weights, &args_with(group_size, bits), PREFIX) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+    }
+
+    // A bf16 expert plane carries no packing at all, so the declared pair is
+    // irrelevant there and must not gate the non-quantized fallback.
+    let mut regular = WeightMap::new();
+    regular.insert(
+        format!("{PREFIX}.weight"),
+        mlxcel_core::ones(&[EXPERTS, OUT, PACKED_IN], mlxcel_core::dtype::BFLOAT16),
+    );
+    SwitchLinear::from_weights(&regular, &args_with(0, 0), PREFIX)
+        .expect("a bf16 expert plane must not be gated on quantization params");
+}

--- a/src/models/ernie4_5_moe_tests.rs
+++ b/src/models/ernie4_5_moe_tests.rs
@@ -56,9 +56,11 @@ fn args_with(group_size: i32, bits: i32) -> ModelArgs {
 
 /// The pair this loader stores is handed straight to `gather_qmm`, which
 /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
-/// throw there is an uncatchable `std::terminate`, so losing the bound would
-/// abort the whole test binary with SIGABRT at the first routed forward pass
-/// instead of failing cleanly at load. Issue #958.
+/// throw there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn ernie4_5_moe_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
     let mut weights = WeightMap::new();

--- a/src/models/ernie4_5_moe_vl.rs
+++ b/src/models/ernie4_5_moe_vl.rs
@@ -1199,9 +1199,11 @@ mod tests {
 
     /// The pair this loader stores is handed straight to `gather_qmm`, which
     /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A
-    /// C++ throw there is an uncatchable `std::terminate`, so losing the bound
-    /// would abort the whole test binary with SIGABRT at the first routed
-    /// forward pass instead of failing cleanly at load. Issue #958.
+    /// C++ throw there is an uncatchable `std::terminate`,
+    /// so losing the bound turns a rejected load into an uncatchable abort at
+    /// the first routed forward pass in production. This test asserts on the
+    /// load result rather than running a forward pass, so a regression fails
+    /// cleanly here instead of aborting the test binary.
     #[test]
     fn ernie4_5_moe_vl_switch_linear_rejects_params_that_would_abort_gather_qmm() {
         use crate::models::switch_layers::{

--- a/src/models/ernie4_5_moe_vl.rs
+++ b/src/models/ernie4_5_moe_vl.rs
@@ -1184,4 +1184,78 @@ mod tests {
             );
         }
     }
+
+    /// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+    /// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a
+    /// plane MLX can actually describe.
+    const QUANT_EXPERTS: i32 = 3;
+    const QUANT_OUT: i32 = 4;
+    const QUANT_PACKED_IN: i32 = 8;
+    const QUANT_NUM_GROUPS: i32 = 1;
+    const QUANT_GROUP_SIZE: i32 = 64;
+    const QUANT_BITS: i32 = 4;
+
+    const QUANT_PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+
+    /// The pair this loader stores is handed straight to `gather_qmm`, which
+    /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A
+    /// C++ throw there is an uncatchable `std::terminate`, so losing the bound
+    /// would abort the whole test binary with SIGABRT at the first routed
+    /// forward pass instead of failing cleanly at load. Issue #958.
+    #[test]
+    fn ernie4_5_moe_vl_switch_linear_rejects_params_that_would_abort_gather_qmm() {
+        use crate::models::switch_layers::{
+            HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane,
+        };
+
+        let mut weights = WeightMap::new();
+        insert_stacked_quantized_expert_plane(
+            &mut weights,
+            QUANT_PREFIX,
+            QUANT_EXPERTS,
+            QUANT_OUT,
+            QUANT_PACKED_IN,
+            QUANT_NUM_GROUPS,
+        );
+
+        // Positive control first, so a guard that rejected every quantized
+        // plane could not pass this test.
+        match load_switch_linear(&weights, QUANT_PREFIX, QUANT_GROUP_SIZE, QUANT_BITS) {
+            Ok(_) => {}
+            Err(e) => panic!("honest 4-bit expert plane must load: {e}"),
+        }
+
+        for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+            let err = match load_switch_linear(&weights, QUANT_PREFIX, group_size, bits) {
+                Ok(_) => panic!(
+                    "(group_size {group_size}, bits {bits}) must be refused at load, \
+                     not stored for gather_qmm"
+                ),
+                Err(e) => e,
+            };
+            assert!(
+                err.contains(field),
+                "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+            );
+            assert!(
+                err.contains(QUANT_PREFIX),
+                "the load error must name the offending tensor {QUANT_PREFIX}, got: {err}"
+            );
+        }
+
+        // A bf16 expert plane carries no packing and no `.scales`, so the
+        // declared pair is inert on the `gather_mm` path and must not gate the
+        // load.
+        let mut dense = WeightMap::new();
+        let shape = [QUANT_EXPERTS, QUANT_OUT, QUANT_PACKED_IN];
+        let n = (QUANT_EXPERTS * QUANT_OUT * QUANT_PACKED_IN) as usize;
+        dense.insert(
+            format!("{QUANT_PREFIX}.weight"),
+            mlxcel_core::from_slice_f32(&vec![0.0f32; n], &shape),
+        );
+        match load_switch_linear(&dense, QUANT_PREFIX, 0, 0) {
+            Ok(_) => {}
+            Err(e) => panic!("a non-quantized expert plane must load with an unset pair: {e}"),
+        }
+    }
 }

--- a/src/models/ernie4_5_moe_vl.rs
+++ b/src/models/ernie4_5_moe_vl.rs
@@ -47,6 +47,7 @@
 
 use crate::models::ernie4_5_moe::{DenseMLP, SwitchGLU, SwitchLinear};
 use crate::models::qwen_mrope_state::MRopeState;
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::cache::SequenceId;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
@@ -475,6 +476,12 @@ fn load_switch_linear(
     let num_experts = mlxcel_core::array_shape(&weight)[0] as usize;
     let scales_key = format!("{prefix}.scales");
     if let Some(scales) = weights.get(&scales_key) {
+        // This builds `ernie4_5_moe::SwitchLinear::Quantized` as a bare struct
+        // literal rather than through `ernie4_5_moe::SwitchLinear::from_weights`,
+        // so the bound that loader carries does not apply here (issue #958).
+        // The pair also arrives from `Ernie45MoeVlTextConfig`, whose accessors
+        // fall back to 0 rather than 64/4 when no `quantization` block exists.
+        validate_expert_quantization_params(prefix, gs, bits)?;
         let biases_key = format!("{prefix}.biases");
         let biases = weights
             .get(&biases_key)

--- a/src/models/exaone_moe.rs
+++ b/src/models/exaone_moe.rs
@@ -22,6 +22,7 @@
 //! - Shared experts alongside routed experts
 //! - RotatingKVCache for sliding window layers
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, RotatingKVCache, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils;
@@ -1020,6 +1021,10 @@ fn load_switch_linear(
     let weight = get_weight_copy(weights, &format!("{}.weight", prefix))?;
     let scales_key = format!("{}.scales", prefix);
     if weights.contains_key(&scales_key) {
+        // Bound the declared pair here, where it is stored: this family-local
+        // expert type never reaches `reconcile_quantization_layout` and hands
+        // the stored pair to `gather_qmm` (issue #958).
+        validate_expert_quantization_params(prefix, group_size, bits)?;
         let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());
         let biases = get_weight_copy(weights, &format!("{}.biases", prefix))?;
         Ok(SwitchLinear::Quantized {

--- a/src/models/exaone_moe.rs
+++ b/src/models/exaone_moe.rs
@@ -1176,3 +1176,7 @@ mod exaone_moe_mask_tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "exaone_moe_tests.rs"]
+mod tests;

--- a/src/models/exaone_moe_tests.rs
+++ b/src/models/exaone_moe_tests.rs
@@ -34,9 +34,11 @@ const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
 
 /// The pair this loader stores is handed straight to `gather_qmm`, which
 /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
-/// throw there is an uncatchable `std::terminate`, so losing the bound would
-/// abort the whole test binary with SIGABRT at the first routed forward pass
-/// instead of failing cleanly at load. Issue #958.
+/// throw there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn exaone_moe_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
     let mut weights = WeightMap::new();

--- a/src/models/exaone_moe_tests.rs
+++ b/src/models/exaone_moe_tests.rs
@@ -1,0 +1,89 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for the bound on declared quantization params that
+//! `exaone_moe::load_switch_linear` applies before it stores them on a
+//! quantized expert plane (issue #958).
+
+use super::load_switch_linear;
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+use mlxcel_core::weights::WeightMap;
+
+/// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+/// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a plane
+/// MLX can actually describe.
+const EXPERTS: i32 = 3;
+const OUT: i32 = 4;
+const PACKED_IN: i32 = 8;
+const NUM_GROUPS: i32 = 1;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+
+/// The pair this loader stores is handed straight to `gather_qmm`, which
+/// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
+/// throw there is an uncatchable `std::terminate`, so losing the bound would
+/// abort the whole test binary with SIGABRT at the first routed forward pass
+/// instead of failing cleanly at load. Issue #958.
+#[test]
+fn exaone_moe_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+    let mut weights = WeightMap::new();
+    insert_stacked_quantized_expert_plane(
+        &mut weights,
+        PREFIX,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    match load_switch_linear(&weights, PREFIX, GROUP_SIZE, BITS) {
+        Ok(_) => {}
+        Err(e) => panic!("honest 4-bit expert plane must load: {e}"),
+    }
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match load_switch_linear(&weights, PREFIX, group_size, bits) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+        assert!(
+            err.contains(PREFIX),
+            "the load error must name the offending tensor {PREFIX}, got: {err}"
+        );
+    }
+
+    // A bf16 expert plane carries no packing and no `.scales`, so the declared
+    // pair is inert on the `gather_mm` path and must not gate the load.
+    let mut dense = WeightMap::new();
+    let n = (EXPERTS * OUT * PACKED_IN) as usize;
+    dense.insert(
+        format!("{PREFIX}.weight"),
+        mlxcel_core::from_slice_f32(&vec![0.0f32; n], &[EXPERTS, OUT, PACKED_IN]),
+    );
+    match load_switch_linear(&dense, PREFIX, 0, 0) {
+        Ok(_) => {}
+        Err(e) => panic!("a non-quantized expert plane must load with an unset pair: {e}"),
+    }
+}

--- a/src/models/glm4_moe.rs
+++ b/src/models/glm4_moe.rs
@@ -26,6 +26,7 @@
 //!   expert-stacked switch_mlp.gate_proj/up_proj when the checkpoint is not
 //!   pre-fused, e.g. real GLM-4.5V MoE)
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils::slice_axis;
@@ -445,6 +446,13 @@ impl SwitchLinear {
         let weight = get_weight_copy(weights, &format!("{}.weight", prefix))?;
         let scales_key = format!("{}.scales", prefix);
         if weights.contains_key(&scales_key) {
+            let (group_size, bits) = (args.group_size(), args.bits());
+            // Bound the declared pair here, where it is stored: this type never
+            // reaches `reconcile_quantization_layout` and hands the stored pair
+            // to `gather_qmm` (issue #958). `ModelArgs::group_size` resolves the
+            // flat key first and the nested `quantization_config` second, so
+            // either spelling is covered by bounding the resolved value.
+            validate_expert_quantization_params(prefix, group_size, bits)?;
             let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());
             let biases = get_weight_copy(weights, &format!("{}.biases", prefix))?;
             let shape = mlxcel_core::array_shape(&weight);
@@ -453,8 +461,8 @@ impl SwitchLinear {
                 weight,
                 scales,
                 biases,
-                group_size: args.group_size(),
-                bits: args.bits(),
+                group_size,
+                bits,
                 num_experts,
             })
         } else {
@@ -499,6 +507,10 @@ impl SwitchLinear {
 
         let gate_scales_key = format!("{}.scales", gate_prefix);
         if weights.contains_key(&gate_scales_key) {
+            let (group_size, bits) = (args.group_size(), args.bits());
+            // Second storage point for the same variant, reached by the
+            // GLM-4(.5)V MoE separate-gate/up layout (issue #958).
+            validate_expert_quantization_params(gate_prefix, group_size, bits)?;
             let gate_scales = get_weight_ref(weights, &gate_scales_key)?;
             let up_scales = get_weight_ref(weights, &format!("{}.scales", up_prefix))?;
             let scales = mlxcel_core::concatenate(gate_scales, up_scales, EXPERT_OUT_AXIS);
@@ -511,8 +523,8 @@ impl SwitchLinear {
                 weight,
                 scales,
                 biases,
-                group_size: args.group_size(),
-                bits: args.bits(),
+                group_size,
+                bits,
                 num_experts,
             })
         } else {

--- a/src/models/glm4_moe.rs
+++ b/src/models/glm4_moe.rs
@@ -1414,4 +1414,130 @@ mod tests {
         assert_eq!(args.group_size(), 64);
         assert_eq!(args.bits(), 4);
     }
+
+    /// Smallest GLM4-MoE config that parses, varying only the declared
+    /// quantization pair. The flat top-level keys are used because
+    /// `ModelArgs::group_size` resolves them ahead of the nested
+    /// `quantization_config`, so this is the value the loader actually stores.
+    fn quant_args(group_size: i32, bits: i32) -> ModelArgs {
+        serde_json::from_value(serde_json::json!({
+            "model_type": "glm4_moe",
+            "vocab_size": 32,
+            "hidden_size": 8,
+            "intermediate_size": 8,
+            "max_position_embeddings": 16,
+            "moe_intermediate_size": 4,
+            "num_attention_heads": 2,
+            "num_hidden_layers": 1,
+            "num_key_value_heads": 1,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "partial_rotary_factor": 0.5,
+            "n_routed_experts": 3,
+            "num_experts_per_tok": 1,
+            "routed_scaling_factor": 1.0,
+            "norm_topk_prob": true,
+            "first_k_dense_replace": 0,
+            "group_size": group_size,
+            "bits": bits,
+        }))
+        .expect("test config must parse")
+    }
+
+    /// The pair this family stores is handed straight to `gather_qmm`, which
+    /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A
+    /// C++ throw there is an uncatchable `std::terminate`, so losing the bound
+    /// would abort the whole test binary with SIGABRT at the first routed
+    /// forward pass instead of failing cleanly at load. Issue #958.
+    ///
+    /// Both storage points are driven here: the pre-stacked loader, and the
+    /// GLM-4(.5)V separate-gate/up fusion path that the VLM text wrapper
+    /// reaches without ever going through the pre-stacked one.
+    #[test]
+    fn glm4_moe_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+        // Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+        // group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is
+        // a plane MLX can actually describe.
+        const EXPERTS: i32 = 3;
+        const OUT: i32 = 4;
+        const PACKED_IN: i32 = 8;
+        const NUM_GROUPS: i32 = 1;
+        const GROUP_SIZE: i32 = 64;
+        const BITS: i32 = 4;
+        const DOWN_PREFIX: &str = "model.layers.0.mlp.switch_mlp.down_proj";
+        const GATE_PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+        const UP_PREFIX: &str = "model.layers.0.mlp.switch_mlp.up_proj";
+
+        let mut weights = WeightMap::new();
+        for prefix in [DOWN_PREFIX, GATE_PREFIX, UP_PREFIX] {
+            crate::models::switch_layers::insert_stacked_quantized_expert_plane(
+                &mut weights,
+                prefix,
+                EXPERTS,
+                OUT,
+                PACKED_IN,
+                NUM_GROUPS,
+            );
+        }
+
+        // Positive control first, so a guard that rejected every quantized
+        // plane could not pass this test.
+        SwitchLinear::from_weights(&weights, &quant_args(GROUP_SIZE, BITS), DOWN_PREFIX)
+            .expect("honest 4-bit expert plane must load through the pre-stacked path");
+        SwitchLinear::from_separate_gate_up(
+            &weights,
+            &quant_args(GROUP_SIZE, BITS),
+            GATE_PREFIX,
+            UP_PREFIX,
+        )
+        .expect("honest 4-bit expert planes must load through the fusion path");
+
+        for (group_size, bits, field) in crate::models::switch_layers::HOSTILE_QUANT_PARAMS {
+            let args = quant_args(group_size, bits);
+
+            let err = match SwitchLinear::from_weights(&weights, &args, DOWN_PREFIX) {
+                Ok(_) => panic!(
+                    "(group_size {group_size}, bits {bits}) must be refused at load, \
+                     not stored for gather_qmm"
+                ),
+                Err(e) => e,
+            };
+            assert!(
+                err.contains(field),
+                "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+            );
+
+            let fused_err = match SwitchLinear::from_separate_gate_up(
+                &weights,
+                &args,
+                GATE_PREFIX,
+                UP_PREFIX,
+            ) {
+                Ok(_) => panic!(
+                    "the fusion path must refuse (group_size {group_size}, bits {bits}) \
+                     at load, not store it for gather_qmm"
+                ),
+                Err(e) => e,
+            };
+            assert!(
+                fused_err.contains(field),
+                "(group_size {group_size}, bits {bits}) must be blamed on {field}, \
+                 got: {fused_err}"
+            );
+        }
+
+        // A bf16 expert plane carries no packing at all, so the declared pair
+        // is irrelevant there and must not gate either non-quantized fallback.
+        let mut regular = WeightMap::new();
+        for prefix in [DOWN_PREFIX, GATE_PREFIX, UP_PREFIX] {
+            regular.insert(
+                format!("{prefix}.weight"),
+                mlxcel_core::ones(&[EXPERTS, OUT, PACKED_IN], mlxcel_core::dtype::BFLOAT16),
+            );
+        }
+        SwitchLinear::from_weights(&regular, &quant_args(0, 0), DOWN_PREFIX)
+            .expect("a bf16 expert plane must not be gated on quantization params");
+        SwitchLinear::from_separate_gate_up(&regular, &quant_args(0, 0), GATE_PREFIX, UP_PREFIX)
+            .expect("a bf16 fused expert plane must not be gated on quantization params");
+    }
 }

--- a/src/models/glm4_moe.rs
+++ b/src/models/glm4_moe.rs
@@ -1446,9 +1446,11 @@ mod tests {
 
     /// The pair this family stores is handed straight to `gather_qmm`, which
     /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A
-    /// C++ throw there is an uncatchable `std::terminate`, so losing the bound
-    /// would abort the whole test binary with SIGABRT at the first routed
-    /// forward pass instead of failing cleanly at load. Issue #958.
+    /// C++ throw there is an uncatchable `std::terminate`,
+    /// so losing the bound turns a rejected load into an uncatchable abort at
+    /// the first routed forward pass in production. This test asserts on the
+    /// load result rather than running a forward pass, so a regression fails
+    /// cleanly here instead of aborting the test binary.
     ///
     /// Both storage points are driven here: the pre-stacked loader, and the
     /// GLM-4(.5)V separate-gate/up fusion path that the VLM text wrapper

--- a/src/models/glm4_moe_lite.rs
+++ b/src/models/glm4_moe_lite.rs
@@ -925,3 +925,7 @@ impl LanguageModel for Glm4MoeLiteModel {
         vec![154820, 154827, 154829]
     }
 }
+
+#[cfg(test)]
+#[path = "glm4_moe_lite_tests.rs"]
+mod tests;

--- a/src/models/glm4_moe_lite.rs
+++ b/src/models/glm4_moe_lite.rs
@@ -22,6 +22,7 @@
 //! - Sparse MoE with grouped expert selection
 //! - Sigmoid routing with e_score_correction_bias
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, MultiLinear, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils::{create_causal_mask, slice_axis};
@@ -480,6 +481,11 @@ impl SwitchLinear {
         let weight = get_weight_copy(weights, &format!("{}.weight", prefix))?;
         let scales_key = format!("{}.scales", prefix);
         if weights.contains_key(&scales_key) {
+            // Bound the declared pair here, where it is stored: this type never
+            // reaches `reconcile_quantization_layout` and hands the stored pair
+            // to `gather_qmm` (issue #958). The pipeline stage executor builds
+            // these planes without going through `Glm4MoeLiteModel::from_weights`.
+            validate_expert_quantization_params(prefix, group_size, bits)?;
             let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());
             let biases = get_weight_copy(weights, &format!("{}.biases", prefix))?;
             Ok(Self::Quantized {

--- a/src/models/glm4_moe_lite_tests.rs
+++ b/src/models/glm4_moe_lite_tests.rs
@@ -34,9 +34,11 @@ const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
 
 /// The pair this loader stores is handed straight to `gather_qmm`, which
 /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
-/// throw there is an uncatchable `std::terminate`, so losing the bound would
-/// abort the whole test binary with SIGABRT at the first routed forward pass
-/// instead of failing cleanly at load. Issue #958.
+/// throw there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn glm4_moe_lite_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
     let mut weights = WeightMap::new();

--- a/src/models/glm4_moe_lite_tests.rs
+++ b/src/models/glm4_moe_lite_tests.rs
@@ -1,0 +1,89 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for the bound on declared quantization params that
+//! `glm4_moe_lite::SwitchLinear::from_weights` applies before it stores them on
+//! a quantized expert plane (issue #958).
+
+use super::SwitchLinear;
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+use mlxcel_core::weights::WeightMap;
+
+/// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+/// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a plane
+/// MLX can actually describe.
+const EXPERTS: i32 = 3;
+const OUT: i32 = 4;
+const PACKED_IN: i32 = 8;
+const NUM_GROUPS: i32 = 1;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+
+/// The pair this loader stores is handed straight to `gather_qmm`, which
+/// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
+/// throw there is an uncatchable `std::terminate`, so losing the bound would
+/// abort the whole test binary with SIGABRT at the first routed forward pass
+/// instead of failing cleanly at load. Issue #958.
+#[test]
+fn glm4_moe_lite_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+    let mut weights = WeightMap::new();
+    insert_stacked_quantized_expert_plane(
+        &mut weights,
+        PREFIX,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    match SwitchLinear::from_weights(&weights, PREFIX, GROUP_SIZE, BITS) {
+        Ok(_) => {}
+        Err(e) => panic!("honest 4-bit expert plane must load: {e}"),
+    }
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match SwitchLinear::from_weights(&weights, PREFIX, group_size, bits) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+        assert!(
+            err.contains(PREFIX),
+            "the load error must name the offending tensor {PREFIX}, got: {err}"
+        );
+    }
+
+    // A bf16 expert plane carries no packing and no `.scales`, so the declared
+    // pair is inert on the `gather_mm` path and must not gate the load.
+    let mut dense = WeightMap::new();
+    let n = (EXPERTS * OUT * PACKED_IN) as usize;
+    dense.insert(
+        format!("{PREFIX}.weight"),
+        mlxcel_core::from_slice_f32(&vec![0.0f32; n], &[EXPERTS, OUT, PACKED_IN]),
+    );
+    match SwitchLinear::from_weights(&dense, PREFIX, 0, 0) {
+        Ok(_) => {}
+        Err(e) => panic!("a non-quantized expert plane must load with an unset pair: {e}"),
+    }
+}

--- a/src/models/glm_moe_dsa.rs
+++ b/src/models/glm_moe_dsa.rs
@@ -256,7 +256,7 @@ impl GlmMoeDsaModel {
 
         let dsv32_args = args.to_dsv32_args();
         let weights = crate::models::load_text_weights(model_dir, None)?;
-        let weights = DeepSeekV32Model::sanitize_weights_with_args(weights, &dsv32_args);
+        let weights = DeepSeekV32Model::sanitize_weights_with_args(weights, &dsv32_args)?;
         let inner = DeepSeekV32Model::from_weights(&weights, &dsv32_args)?;
 
         Ok((Self { inner }, args))

--- a/src/models/gpt_oss.rs
+++ b/src/models/gpt_oss.rs
@@ -25,6 +25,7 @@
 //!
 //! Reference: mlx-lm gpt_oss.py
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::layers::{KVCache, RMSNorm, RotatingKVCache, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
 use mlxcel_core::weights::WeightMap;
@@ -116,6 +117,36 @@ impl Quantization {
         self.defaults()
     }
 
+    /// Reject any `quantization` entry that would abort an MLX kernel.
+    ///
+    /// gpt-oss is the one family whose `quantization` block is a map of
+    /// per-weight-prefix overrides rather than a single triple, so a bound on
+    /// the top-level defaults alone says nothing about what an individual
+    /// projection will load with, and vice versa. This walks the top-level pair
+    /// and every override in one pass, so a hostile pair scoped to a single
+    /// prefix is refused during config validation even when the defaults are
+    /// valid, before any tensor is touched (issue #958).
+    ///
+    /// Entries whose value is not an object are the top-level scalars
+    /// themselves (`group_size`, `bits`, `mode`) and are covered by the
+    /// `defaults()` check rather than iterated as overrides.
+    fn validate(&self) -> Result<(), String> {
+        let Quantization::Full(map) = self;
+        let (gs, bits, _) = self.defaults();
+        mlxcel_core::layers::validate_quantization_params(gs, bits)
+            .map_err(|e| format!("GptOss config.json quantization: {e}"))?;
+        for key in map.keys() {
+            let Some(value) = map.get(key) else { continue };
+            if !value.is_object() {
+                continue;
+            }
+            let (gs, bits, _) = self.params_for(key);
+            mlxcel_core::layers::validate_quantization_params(gs, bits)
+                .map_err(|e| format!("GptOss config.json quantization.{key}: {e}"))?;
+        }
+        Ok(())
+    }
+
     /// Top-level defaults
     fn defaults(&self) -> (i32, i32, String) {
         let Quantization::Full(map) = self;
@@ -131,6 +162,22 @@ impl Quantization {
 }
 
 impl ModelArgs {
+    /// Reject a `quantization` block that would abort an MLX kernel.
+    ///
+    /// Family-level early diagnostic, in the same shape as the BailingMoe,
+    /// GptNeoX and Helium ones added by #929: it names gpt-oss and fires during
+    /// config validation, before any tensor is touched. The authoritative bound
+    /// still lives at each storage point (`ExpertLinear::from_weights` and the
+    /// shared reconciler behind `UnifiedLinear` / `UnifiedEmbedding`); this
+    /// exists because gpt-oss is the only family whose per-prefix overrides can
+    /// each carry their own hostile pair (issue #958).
+    pub fn validate_quantization(&self) -> Result<(), String> {
+        let Some(quantization) = self.quantization.as_ref() else {
+            return Ok(());
+        };
+        quantization.validate()
+    }
+
     /// Default group_size (top-level)
     pub fn group_size(&self) -> i32 {
         self.quantization
@@ -366,6 +413,17 @@ impl ExpertLinear {
 
         let scales_key = format!("{}.scales", prefix);
         if weights.contains_key(&scales_key) {
+            // Bound the declared pair here, where it is stored: `ExpertLinear`
+            // never reaches `reconcile_quantization_layout` and hands the stored
+            // pair to `gather_qmm` (issue #958). Unlike every sibling projection
+            // in this family, the expert pair comes from `Quantization::defaults`
+            // rather than from `quant_for`, so the per-prefix overrides that the
+            // guarded `UnifiedLinear` / `UnifiedEmbedding` loaders see do not
+            // describe it, and a valid override on `model.embed_tokens` (the
+            // shape every real gpt-oss checkpoint ships) leaves a hostile
+            // top-level pair reaching the experts alone.
+            validate_expert_quantization_params(prefix, group_size, bits)?;
+
             let scales = weights
                 .get(&scales_key)
                 .map(|w| mlxcel_core::copy(w))
@@ -967,6 +1025,8 @@ impl GptOssModel {
     }
 
     pub fn from_weights(weights: &WeightMap, args: &ModelArgs) -> Result<Self, String> {
+        args.validate_quantization()?;
+
         // Embedding may have different quantization than the top-level default
         let (embed_gs, embed_bits, _embed_mode) = args.quant_for("model.embed_tokens");
         let embed_tokens =
@@ -1110,6 +1170,8 @@ impl GptOssStageModel {
         filter: &LayerFilter,
         stage_index: usize,
     ) -> Result<Self, String> {
+        args.validate_quantization()?;
+
         let (embed_gs, embed_bits, _embed_mode) = args.quant_for("model.embed_tokens");
         let embed_tokens = if filter.has_embedding {
             Some(UnifiedEmbedding::from_weights(

--- a/src/models/gpt_oss.rs
+++ b/src/models/gpt_oss.rs
@@ -1372,4 +1372,141 @@ mod tests {
             assert_eq!(mlxcel_core::array_dtype(&out), dtype);
         }
     }
+
+    /// `ExpertLinear` stores the declared pair and hands it to `gather_qmm`
+    /// without ever reaching `reconcile_quantization_layout`, so a hostile pair
+    /// used to abort the process at the first routed forward pass rather than
+    /// failing at load (issue #958). This drives the real loader, so a
+    /// regression takes this whole test binary down with SIGABRT rather than
+    /// failing cleanly.
+    #[test]
+    fn gpt_oss_expert_linear_rejects_params_that_would_abort_gather_qmm() {
+        let prefix = "model.layers.0.mlp.experts.gate_up_proj";
+        let mut weights = WeightMap::new();
+        crate::models::switch_layers::insert_stacked_quantized_expert_plane(
+            &mut weights,
+            prefix,
+            3,
+            4,
+            8,
+            1,
+        );
+
+        // Positive control first, so a guard that rejects everything quantized
+        // cannot pass this test.
+        ExpertLinear::from_weights(&weights, prefix, 64, 4, "affine")
+            .expect("an honest affine pair must still load");
+
+        for (group_size, bits, field) in crate::models::switch_layers::HOSTILE_QUANT_PARAMS {
+            let err = ExpertLinear::from_weights(&weights, prefix, group_size, bits, "affine")
+                .err()
+                .unwrap_or_else(|| {
+                    panic!("ExpertLinear must reject group_size {group_size} / bits {bits}")
+                });
+            assert!(err.contains(field), "unhelpful error: {err}");
+        }
+
+        // A bf16 expert plane carries no packing at all, so the params are
+        // irrelevant there and must not be enforced.
+        let mut regular = WeightMap::new();
+        regular.insert(
+            format!("{prefix}.weight"),
+            mlxcel_core::from_slice_f32(&vec![0.0; 3 * 4 * 8], &[3, 4, 8]),
+        );
+        ExpertLinear::from_weights(&regular, prefix, 0, 0, "affine")
+            .expect("a non-quantized expert plane must not be gated on quantization params");
+    }
+
+    /// gpt-oss is the one family whose `quantization` block is a map of
+    /// per-weight-prefix overrides, so a bound on the top-level defaults says
+    /// nothing about what an individual projection loads with, and vice versa.
+    /// The canonical mxfp4 checkpoint carries a valid `model.embed_tokens`
+    /// override, which is exactly what let a hostile top-level pair reach the
+    /// experts alone while every reconciler-guarded loader saw a good one.
+    #[test]
+    fn gpt_oss_config_validation_walks_every_per_prefix_override() {
+        let args_from = |quantization: serde_json::Value| -> ModelArgs {
+            serde_json::from_value(serde_json::json!({
+                "model_type": "gpt_oss",
+                "vocab_size": 32,
+                "hidden_size": 8,
+                "intermediate_size": 8,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 4,
+                "num_local_experts": 2,
+                "num_experts_per_tok": 1,
+                "rms_norm_eps": 1e-5,
+                "rope_theta": 150000.0,
+                "sliding_window": 8,
+                "quantization": quantization,
+            }))
+            .expect("test config must parse")
+        };
+
+        // Positive control: the real gpt-oss-20b-mxfp4 shape, mxfp4 experts on
+        // the top-level defaults with affine overrides for everything else.
+        args_from(serde_json::json!({
+            "group_size": 32,
+            "bits": 4,
+            "mode": "mxfp4",
+            "model.embed_tokens": { "group_size": 64, "bits": 4, "mode": "affine" },
+            "model.layers.0.mlp.router": { "group_size": 64, "bits": 8 },
+        }))
+        .validate_quantization()
+        .expect("the canonical gpt-oss quantization block must still validate");
+
+        // A hostile pair scoped to a single prefix must be refused even though
+        // the top-level defaults are perfectly valid.
+        for (group_size, bits, field) in crate::models::switch_layers::HOSTILE_QUANT_PARAMS {
+            let err = args_from(serde_json::json!({
+                "group_size": 32,
+                "bits": 4,
+                "mode": "mxfp4",
+                "model.layers.0.mlp.experts.gate_up_proj": {
+                    "group_size": group_size,
+                    "bits": bits,
+                },
+            }))
+            .validate_quantization()
+            .expect_err("a hostile per-prefix override must be rejected");
+            assert!(
+                err.contains(field) && err.contains("gate_up_proj"),
+                "the message must name both the field and the override, got: {err}"
+            );
+
+            // And the mirror case: valid overrides, hostile top-level defaults.
+            // This is the shape that actually reaches the experts, because they
+            // read `Quantization::defaults` rather than `quant_for`.
+            let err = args_from(serde_json::json!({
+                "group_size": group_size,
+                "bits": bits,
+                "model.embed_tokens": { "group_size": 64, "bits": 4, "mode": "affine" },
+            }))
+            .validate_quantization()
+            .expect_err("hostile top-level defaults must be rejected");
+            assert!(err.contains(field), "unhelpful error: {err}");
+        }
+
+        // A config with no `quantization` block at all is not gated.
+        let args: ModelArgs = serde_json::from_value(serde_json::json!({
+            "model_type": "gpt_oss",
+            "vocab_size": 32,
+            "hidden_size": 8,
+            "intermediate_size": 8,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "num_local_experts": 2,
+            "num_experts_per_tok": 1,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 150000.0,
+            "sliding_window": 8,
+        }))
+        .expect("test config must parse");
+        args.validate_quantization()
+            .expect("a bf16 checkpoint declares no quantization and must not be gated");
+    }
 }

--- a/src/models/gpt_oss.rs
+++ b/src/models/gpt_oss.rs
@@ -1376,9 +1376,11 @@ mod tests {
     /// `ExpertLinear` stores the declared pair and hands it to `gather_qmm`
     /// without ever reaching `reconcile_quantization_layout`, so a hostile pair
     /// used to abort the process at the first routed forward pass rather than
-    /// failing at load (issue #958). This drives the real loader, so a
-    /// regression takes this whole test binary down with SIGABRT rather than
-    /// failing cleanly.
+    /// failing at load (issue #958). This drives the real loader rather than the
+    /// pure bounds helper, so the guard is exercised where a checkpoint actually
+    /// reaches it. The assertions are on the load result and no forward pass is
+    /// run, so a regression fails cleanly here rather than aborting the test
+    /// binary.
     #[test]
     fn gpt_oss_expert_linear_rejects_params_that_would_abort_gather_qmm() {
         let prefix = "model.layers.0.mlp.experts.gate_up_proj";

--- a/src/models/hunyuan_moe.rs
+++ b/src/models/hunyuan_moe.rs
@@ -21,6 +21,7 @@
 //! - Per-layer moe_intermediate_size and moe_topk
 //! - Cross-Layer Attention (CLA) support (optional KV sharing)
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
@@ -284,6 +285,11 @@ impl SwitchLinear {
         let weight = get_weight_copy(weights, &format!("{}.weight", prefix))?;
         let scales_key = format!("{}.scales", prefix);
         if weights.contains_key(&scales_key) {
+            // Bound the declared pair here, where it is stored: this
+            // family-local expert type never reaches
+            // `reconcile_quantization_layout` and hands the stored pair to
+            // `gather_qmm` (issue #958).
+            validate_expert_quantization_params(prefix, group_size, bits)?;
             let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());
             let biases = get_weight_copy(weights, &format!("{}.biases", prefix))?;
             Ok(Self::Quantized {

--- a/src/models/hunyuan_moe.rs
+++ b/src/models/hunyuan_moe.rs
@@ -991,3 +991,7 @@ impl LanguageModel for HunyuanMoeModel {
         vec![127960] // Hunyuan EOS token from config
     }
 }
+
+#[cfg(test)]
+#[path = "hunyuan_moe_tests.rs"]
+mod tests;

--- a/src/models/hunyuan_moe_tests.rs
+++ b/src/models/hunyuan_moe_tests.rs
@@ -34,9 +34,11 @@ const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
 
 /// The pair this loader stores is handed straight to `gather_qmm`, which
 /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
-/// throw there is an uncatchable `std::terminate`, so losing the bound would
-/// abort the whole test binary with SIGABRT at the first routed forward pass
-/// instead of failing cleanly at load. Issue #958.
+/// throw there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn hunyuan_moe_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
     let mut weights = WeightMap::new();

--- a/src/models/hunyuan_moe_tests.rs
+++ b/src/models/hunyuan_moe_tests.rs
@@ -1,0 +1,89 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for the bound on declared quantization params that
+//! `hunyuan_moe::SwitchLinear::from_weights` applies before it stores them on a
+//! quantized expert plane (issue #958).
+
+use super::SwitchLinear;
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+use mlxcel_core::weights::WeightMap;
+
+/// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+/// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a plane
+/// MLX can actually describe.
+const EXPERTS: i32 = 3;
+const OUT: i32 = 4;
+const PACKED_IN: i32 = 8;
+const NUM_GROUPS: i32 = 1;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+
+/// The pair this loader stores is handed straight to `gather_qmm`, which
+/// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
+/// throw there is an uncatchable `std::terminate`, so losing the bound would
+/// abort the whole test binary with SIGABRT at the first routed forward pass
+/// instead of failing cleanly at load. Issue #958.
+#[test]
+fn hunyuan_moe_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+    let mut weights = WeightMap::new();
+    insert_stacked_quantized_expert_plane(
+        &mut weights,
+        PREFIX,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    match SwitchLinear::from_weights(&weights, PREFIX, GROUP_SIZE, BITS) {
+        Ok(_) => {}
+        Err(e) => panic!("honest 4-bit expert plane must load: {e}"),
+    }
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match SwitchLinear::from_weights(&weights, PREFIX, group_size, bits) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+        assert!(
+            err.contains(PREFIX),
+            "the load error must name the offending tensor {PREFIX}, got: {err}"
+        );
+    }
+
+    // A bf16 expert plane carries no packing and no `.scales`, so the declared
+    // pair is inert on the `gather_mm` path and must not gate the load.
+    let mut dense = WeightMap::new();
+    let n = (EXPERTS * OUT * PACKED_IN) as usize;
+    dense.insert(
+        format!("{PREFIX}.weight"),
+        mlxcel_core::from_slice_f32(&vec![0.0f32; n], &[EXPERTS, OUT, PACKED_IN]),
+    );
+    match SwitchLinear::from_weights(&dense, PREFIX, 0, 0) {
+        Ok(_) => {}
+        Err(e) => panic!("a non-quantized expert plane must load with an unset pair: {e}"),
+    }
+}

--- a/src/models/kimi_linear.rs
+++ b/src/models/kimi_linear.rs
@@ -24,6 +24,7 @@
 
 use crate::models::gated_delta::{gated_delta_update, scaled_fast_rms_norm_no_weight};
 use crate::models::switch_layers::SwitchGLU;
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::dtype;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
@@ -212,6 +213,13 @@ impl MultiLinear {
             .map(|w| mlxcel_core::copy(w));
 
         let is_quantized = scales.is_some();
+        if is_quantized {
+            // KimiLinear keeps a private `MultiLinear` rather than using
+            // `mlxcel_core::layers::MultiLinear`, so it does not inherit the
+            // bound that loader now carries. The stored pair goes straight to
+            // `quantized_matmul` on every MLA forward (issue #958).
+            validate_expert_quantization_params(prefix, group_size, bits)?;
+        }
 
         Ok(Self {
             weight,

--- a/src/models/kimi_linear.rs
+++ b/src/models/kimi_linear.rs
@@ -1101,7 +1101,7 @@ impl KimiLinearModel {
 
         println!("[KimiLinear] Loading weights...");
         let weights = crate::models::load_text_weights(model_dir, None)?;
-        let weights = Self::sanitize_weights(weights, &config);
+        let weights = Self::sanitize_weights(weights, &config)?;
 
         println!("[KimiLinear] Building model...");
         let model = Self::from_weights(&weights, &config)?;
@@ -1110,7 +1110,10 @@ impl KimiLinearModel {
         Ok((model, config))
     }
 
-    pub fn sanitize_weights(mut weights: WeightMap, config: &KimiLinearConfig) -> WeightMap {
+    pub fn sanitize_weights(
+        mut weights: WeightMap,
+        config: &KimiLinearConfig,
+    ) -> Result<WeightMap, String> {
         // Remove mtp weights
         let mtp_keys: Vec<String> = weights
             .keys()
@@ -1278,11 +1281,18 @@ impl KimiLinearModel {
                     let biases = weights
                         .remove(&format!("{}.kv_b_proj.biases", attn_prefix))
                         .unwrap();
-                    let w_shape = mlxcel_core::array_shape(&w);
-                    let dims = config.kv_lora_rank as i32;
-                    let bits = (w_shape[w_shape.len() - 1] * 32) / dims;
-                    let s_shape = mlxcel_core::array_shape(&scales);
-                    let group_size = dims / s_shape[s_shape.len() - 1];
+                    // Solve the packed pair from the shapes and bound it
+                    // before it reaches `dequantize`. The shared helper checks
+                    // each divisor before dividing: `kv_lora_rank` is a config
+                    // field and the scales axis is checkpoint data, so the naive
+                    // form panics on a zero divisor and overflows i32 on a large
+                    // packed axis, both before the bound could fire (issue #958).
+                    let (group_size, bits) = mlxcel_core::layers::infer_mla_quantization_params(
+                        &mlxcel_core::array_shape(&w),
+                        &mlxcel_core::array_shape(&scales),
+                        config.kv_lora_rank as i32,
+                        &format!("{attn_prefix}.kv_b_proj"),
+                    )?;
                     unsafe {
                         mlxcel_core::dequantize(
                             &w,
@@ -1317,7 +1327,7 @@ impl KimiLinearModel {
             }
         }
 
-        weights
+        Ok(weights)
     }
 
     pub fn from_weights(weights: &WeightMap, config: &KimiLinearConfig) -> Result<Self, String> {

--- a/src/models/kimi_linear.rs
+++ b/src/models/kimi_linear.rs
@@ -1400,3 +1400,7 @@ impl LanguageModel for KimiLinearModel {
         self.forward(input_ids, &mut caches)
     }
 }
+
+#[cfg(test)]
+#[path = "kimi_linear_tests.rs"]
+mod tests;

--- a/src/models/kimi_linear_tests.rs
+++ b/src/models/kimi_linear_tests.rs
@@ -1,0 +1,84 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for the bound on declared quantization params that
+//! `kimi_linear::MultiLinear::from_weights` applies before it stores them on a
+//! quantized per-head MLA projection (issue #958).
+
+use super::MultiLinear;
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+use mlxcel_core::weights::WeightMap;
+
+/// Honest 4-bit geometry: `packed_in * 32 == bits * num_groups * group_size`
+/// (8 * 32 == 4 * 1 * 64), so the positive control below is a projection MLX can
+/// actually describe. `MultiLinear` is a per-head projection rather than an
+/// expert plane, but its tensors carry the same `[heads, out, packed_in]` /
+/// `[heads, out, num_groups]` shapes the shared fixture helper builds.
+const HEADS: i32 = 3;
+const OUT: i32 = 4;
+const PACKED_IN: i32 = 8;
+const NUM_GROUPS: i32 = 1;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+const PREFIX: &str = "model.layers.0.self_attn.embed_q";
+
+/// The pair this loader stores is handed straight to `quantized_matmul`, which
+/// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
+/// throw there is an uncatchable `std::terminate`, so losing the bound would
+/// abort the whole test binary with SIGABRT at the first MLA forward pass
+/// instead of failing cleanly at load. Issue #958.
+#[test]
+fn kimi_linear_multi_linear_rejects_quantization_params_that_would_abort_quantized_matmul() {
+    let mut weights = WeightMap::new();
+    insert_stacked_quantized_expert_plane(&mut weights, PREFIX, HEADS, OUT, PACKED_IN, NUM_GROUPS);
+
+    // Positive control first, so a guard that rejected every quantized
+    // projection could not pass this test.
+    match MultiLinear::from_weights(&weights, PREFIX, GROUP_SIZE, BITS) {
+        Ok(_) => {}
+        Err(e) => panic!("honest 4-bit per-head projection must load: {e}"),
+    }
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match MultiLinear::from_weights(&weights, PREFIX, group_size, bits) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for quantized_matmul"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+        assert!(
+            err.contains(PREFIX),
+            "the load error must name the offending tensor {PREFIX}, got: {err}"
+        );
+    }
+
+    // A bf16 projection carries no packing and no `.scales`, so the declared
+    // pair is inert on the dense `matmul` path and must not gate the load.
+    let mut dense = WeightMap::new();
+    let n = (HEADS * OUT * PACKED_IN) as usize;
+    dense.insert(
+        format!("{PREFIX}.weight"),
+        mlxcel_core::from_slice_f32(&vec![0.0f32; n], &[HEADS, OUT, PACKED_IN]),
+    );
+    match MultiLinear::from_weights(&dense, PREFIX, 0, 0) {
+        Ok(_) => {}
+        Err(e) => panic!("a non-quantized per-head projection must load with an unset pair: {e}"),
+    }
+}

--- a/src/models/kimi_linear_tests.rs
+++ b/src/models/kimi_linear_tests.rs
@@ -16,7 +16,7 @@
 //! `kimi_linear::MultiLinear::from_weights` applies before it stores them on a
 //! quantized per-head MLA projection (issue #958).
 
-use super::MultiLinear;
+use super::{KimiLinearConfig, KimiLinearModel, LinearAttnConfig, MultiLinear};
 use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
 use mlxcel_core::weights::WeightMap;
 
@@ -82,5 +82,136 @@ fn kimi_linear_multi_linear_rejects_quantization_params_that_would_abort_quantiz
     match MultiLinear::from_weights(&dense, PREFIX, 0, 0) {
         Ok(_) => {}
         Err(e) => panic!("a non-quantized per-head projection must load with an unset pair: {e}"),
+    }
+}
+
+/// A minimal config where every layer is an MLA layer (`kda_layers` empty, so
+/// `is_linear_layer` is always false) and MoE stacking is inert (`num_experts`
+/// 0), so `sanitize_weights` only exercises the `kv_b_proj` decomposition this
+/// test targets.
+fn mla_config(kv_lora_rank: usize) -> KimiLinearConfig {
+    KimiLinearConfig {
+        model_type: "kimi_linear".to_string(),
+        vocab_size: 32,
+        hidden_size: 32,
+        num_hidden_layers: 1,
+        num_attention_heads: 4,
+        num_key_value_heads: 4,
+        intermediate_size: 64,
+        head_dim: 8,
+        rope_theta: 10000.0,
+        rms_norm_eps: 1e-6,
+        linear_attn_config: LinearAttnConfig {
+            kda_layers: vec![],
+            num_heads: 4,
+            head_dim: 8,
+            short_conv_kernel_size: 4,
+        },
+        num_experts: 0,
+        moe_intermediate_size: 0,
+        kv_lora_rank,
+        tie_word_embeddings: true,
+        qk_nope_head_dim: Some(4),
+        qk_rope_head_dim: Some(4),
+        v_head_dim: Some(4),
+        mla_use_nope: false,
+        num_experts_per_token: 1,
+        num_shared_experts: 0,
+        moe_router_activation_func: "sigmoid".to_string(),
+        moe_renormalize: true,
+        routed_scaling_factor: 1.0,
+        first_k_dense_replace: 0,
+        moe_layer_freq: 1,
+        use_grouped_topk: true,
+        num_expert_group: 1,
+        topk_group: 1,
+        quantization: None,
+    }
+}
+
+/// The MLA `kv_b_proj` pair `KimiLinearModel::sanitize_weights` decomposes is
+/// solved from `kv_lora_rank` and two tensor axes rather than declared, and
+/// every input is untrusted: `kv_lora_rank` comes from `config.json` and the
+/// axes from the checkpoint. Before issue #958 the naive arithmetic divided by
+/// both without checking them, so a `kv_lora_rank` of 0 panicked on integer
+/// division and a solved pair outside anything MLX can describe reached
+/// `dequantize`, which crosses the cxx bridge as `UniquePtr<MlxArray>` rather
+/// than `Result` and therefore aborts during weight sanitization rather than
+/// failing the load.
+///
+/// This drives the real `KimiLinearModel::sanitize_weights` rather than the
+/// shared helper directly, so the guard is exercised where a checkpoint
+/// reaches it. The assertions are on the returned `Result`, so a regression
+/// fails cleanly here instead of aborting the test binary.
+#[test]
+fn kimi_linear_sanitize_rejects_a_kv_lora_rank_no_packing_can_describe() {
+    // Honest affine 4-bit geometry: packed_in * 32 == bits * num_groups *
+    // group_size (2 * 32 == 4 * 1 * 16), with num_heads 4 and
+    // qk_nope_head_dim = v_head_dim = 4 so rows = 4 * 8 = 32.
+    let build = |config: &KimiLinearConfig| {
+        let rows = (config.num_attention_heads * (config.qk_nope() + config.v_head())) as i32;
+        let mut weights = WeightMap::new();
+        for layer_idx in 0..config.num_hidden_layers {
+            let prefix = format!("model.layers.{layer_idx}.self_attn.kv_b_proj");
+            // UINT32, not a float dtype: `dequantize` rejects any other packed
+            // dtype by throwing, and that throw is the uncatchable abort this
+            // guard exists to keep out of the forward path. A float fixture here
+            // takes the test binary down on the positive control.
+            weights.insert(
+                format!("{prefix}.weight"),
+                mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
+            );
+            weights.insert(
+                format!("{prefix}.scales"),
+                mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
+            );
+            weights.insert(
+                format!("{prefix}.biases"),
+                mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
+            );
+        }
+        weights
+    };
+
+    // Positive control first, so a guard that rejected every quantized
+    // kv_b_proj could not pass this test.
+    let honest = mla_config(16);
+    let sanitized = match KimiLinearModel::sanitize_weights(build(&honest), &honest) {
+        Ok(w) => w,
+        Err(e) => panic!("an honest quantized kv_b_proj must still sanitize: {e}"),
+    };
+    assert!(sanitized.contains_key("model.layers.0.self_attn.embed_q.weight"));
+
+    // A zero `kv_lora_rank` is Rust integer division by zero on the very
+    // first solve, so it has to be refused before the division rather than
+    // after.
+    let zero_rank = mla_config(0);
+    let err = KimiLinearModel::sanitize_weights(build(&zero_rank), &zero_rank)
+        .err()
+        .unwrap_or_else(|| panic!("kv_lora_rank 0 must be refused, not divided by"));
+    assert!(err.contains("kv_lora_rank"), "unhelpful error: {err}");
+
+    // A large `kv_lora_rank` truncates the solved bit width to 0, which is
+    // the divisor MLX would then divide by.
+    let wide_rank = mla_config(4096);
+    let err = KimiLinearModel::sanitize_weights(build(&wide_rank), &wide_rank)
+        .err()
+        .unwrap_or_else(|| panic!("a solved bit width of 0 must be refused"));
+    assert!(err.contains("bits"), "unhelpful error: {err}");
+
+    // A non-quantized kv_b_proj carries no packing, so the pair is never
+    // solved and the decomposition must stay unaffected.
+    let mut float_only = WeightMap::new();
+    let rows = (honest.num_attention_heads * (honest.qk_nope() + honest.v_head())) as i32;
+    float_only.insert(
+        "model.layers.0.self_attn.kv_b_proj.weight".to_string(),
+        mlxcel_core::zeros(
+            &[rows, honest.kv_lora_rank as i32],
+            mlxcel_core::dtype::FLOAT32,
+        ),
+    );
+    match KimiLinearModel::sanitize_weights(float_only, &honest) {
+        Ok(_) => {}
+        Err(e) => panic!("a float kv_b_proj must not be gated on quantization params: {e}"),
     }
 }

--- a/src/models/kimi_linear_tests.rs
+++ b/src/models/kimi_linear_tests.rs
@@ -200,17 +200,20 @@ fn kimi_linear_sanitize_rejects_a_kv_lora_rank_no_packing_can_describe() {
     assert!(err.contains("bits"), "unhelpful error: {err}");
 
     // A non-quantized kv_b_proj carries no packing, so the pair is never
-    // solved and the decomposition must stay unaffected.
+    // solved and a `kv_lora_rank` that no packing could describe must not gate
+    // it. The tensor is built at `wide_rank`'s own width so it still satisfies
+    // the separate shape cross-check below the solve, which would otherwise
+    // reject this for an unrelated reason.
     let mut float_only = WeightMap::new();
-    let rows = (honest.num_attention_heads * (honest.qk_nope() + honest.v_head())) as i32;
+    let rows = (wide_rank.num_attention_heads * (wide_rank.qk_nope() + wide_rank.v_head())) as i32;
     float_only.insert(
         "model.layers.0.self_attn.kv_b_proj.weight".to_string(),
         mlxcel_core::zeros(
-            &[rows, honest.kv_lora_rank as i32],
+            &[rows, wide_rank.kv_lora_rank as i32],
             mlxcel_core::dtype::FLOAT32,
         ),
     );
-    match KimiLinearModel::sanitize_weights(float_only, &honest) {
+    match KimiLinearModel::sanitize_weights(float_only, &wide_rank) {
         Ok(_) => {}
         Err(e) => panic!("a float kv_b_proj must not be gated on quantization params: {e}"),
     }

--- a/src/models/kimi_linear_tests.rs
+++ b/src/models/kimi_linear_tests.rs
@@ -36,9 +36,11 @@ const PREFIX: &str = "model.layers.0.self_attn.embed_q";
 
 /// The pair this loader stores is handed straight to `quantized_matmul`, which
 /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
-/// throw there is an uncatchable `std::terminate`, so losing the bound would
-/// abort the whole test binary with SIGABRT at the first MLA forward pass
-/// instead of failing cleanly at load. Issue #958.
+/// throw there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn kimi_linear_multi_linear_rejects_quantization_params_that_would_abort_quantized_matmul() {
     let mut weights = WeightMap::new();

--- a/src/models/llama4.rs
+++ b/src/models/llama4.rs
@@ -1856,3 +1856,7 @@ impl LanguageModel for Llama4Wrapper {
         vec![200001, 200007, 200008]
     }
 }
+
+#[cfg(test)]
+#[path = "llama4_tests.rs"]
+mod tests;

--- a/src/models/llama4.rs
+++ b/src/models/llama4.rs
@@ -23,6 +23,7 @@ use crate::models::llama4_helpers::{
 use crate::models::model_owned::{
     ModelOwnedSequenceState, dispatch_paged_decode_from_backing_caches,
 };
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::cache::{CachePool, SequenceId, SequenceStateLayout};
 use mlxcel_core::generate::{DecodeBatchContext, LanguageModel};
 use mlxcel_core::layers::{ChunkedKVCache, KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
@@ -1578,6 +1579,12 @@ impl SwitchLinear {
         let weight = get_weight_copy(weights, &format!("{}.weight", prefix))?;
         let scales_key = format!("{}.scales", prefix);
         if weights.contains_key(&scales_key) {
+            let (group_size, bits) = (args.group_size(), args.bits());
+            // Bound the declared pair here, where it is stored: this type never
+            // reaches `reconcile_quantization_layout` and hands the stored pair
+            // to `gather_qmm` (issue #958). The pipeline stage executor builds
+            // these planes without going through `Llama4CxxModel::from_weights`.
+            validate_expert_quantization_params(prefix, group_size, bits)?;
             let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());
             let biases = get_weight_copy(weights, &format!("{}.biases", prefix))?;
             let shape = mlxcel_core::array_shape(&weight);
@@ -1586,8 +1593,8 @@ impl SwitchLinear {
                 weight,
                 scales,
                 biases,
-                group_size: args.group_size(),
-                bits: args.bits(),
+                group_size,
+                bits,
                 num_experts,
             })
         } else {

--- a/src/models/llama4_tests.rs
+++ b/src/models/llama4_tests.rs
@@ -1,0 +1,108 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for the bound on declared quantization params that the
+//! Llama 4 `SwitchLinear` loader applies before it stores them on a quantized
+//! expert plane (issue #958).
+
+use mlxcel_core::weights::WeightMap;
+
+use super::{SwitchLinear, TextArgs};
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+
+/// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+/// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a plane
+/// MLX can actually describe.
+const EXPERTS: i32 = 3;
+const OUT: i32 = 4;
+const PACKED_IN: i32 = 8;
+const NUM_GROUPS: i32 = 1;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+const PREFIX: &str = "language_model.model.layers.0.feed_forward.experts.gate_proj";
+
+/// Smallest Llama 4 text config that parses, varying only the declared
+/// quantization pair. Llama 4 spells it as flat top-level `group_size` / `bits`
+/// keys rather than a nested `quantization` block. Built through serde rather
+/// than a struct literal so every `#[serde(default)]` field fills itself in.
+fn args_with(group_size: i32, bits: i32) -> TextArgs {
+    serde_json::from_value(serde_json::json!({
+        "model_type": "llama4",
+        "hidden_size": 8,
+        "num_hidden_layers": 1,
+        "intermediate_size": 8,
+        "intermediate_size_mlp": 8,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "rms_norm_eps": 1e-5,
+        "vocab_size": 32,
+        "head_dim": 4,
+        "max_position_embeddings": 16,
+        "attention_chunk_size": 8,
+        "interleave_moe_layer_step": 1,
+        "num_local_experts": 3,
+        "num_experts_per_tok": 1,
+        "group_size": group_size,
+        "bits": bits,
+    }))
+    .expect("test config must parse")
+}
+
+/// The pair this loader stores is handed straight to `gather_qmm`, which
+/// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
+/// throw there is an uncatchable `std::terminate`, so losing the bound would
+/// abort the whole test binary with SIGABRT at the first routed forward pass
+/// instead of failing cleanly at load. Issue #958.
+#[test]
+fn llama4_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+    let mut weights = WeightMap::new();
+    insert_stacked_quantized_expert_plane(
+        &mut weights,
+        PREFIX,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    SwitchLinear::from_weights(&weights, &args_with(GROUP_SIZE, BITS), PREFIX)
+        .expect("honest 4-bit expert plane must load");
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match SwitchLinear::from_weights(&weights, &args_with(group_size, bits), PREFIX) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+    }
+
+    // A bf16 expert plane carries no packing at all, so the declared pair is
+    // irrelevant there and must not gate the non-quantized fallback.
+    let mut regular = WeightMap::new();
+    regular.insert(
+        format!("{PREFIX}.weight"),
+        mlxcel_core::ones(&[EXPERTS, OUT, PACKED_IN], mlxcel_core::dtype::BFLOAT16),
+    );
+    SwitchLinear::from_weights(&regular, &args_with(0, 0), PREFIX)
+        .expect("a bf16 expert plane must not be gated on quantization params");
+}

--- a/src/models/llama4_tests.rs
+++ b/src/models/llama4_tests.rs
@@ -62,9 +62,11 @@ fn args_with(group_size: i32, bits: i32) -> TextArgs {
 
 /// The pair this loader stores is handed straight to `gather_qmm`, which
 /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
-/// throw there is an uncatchable `std::terminate`, so losing the bound would
-/// abort the whole test binary with SIGABRT at the first routed forward pass
-/// instead of failing cleanly at load. Issue #958.
+/// throw there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn llama4_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
     let mut weights = WeightMap::new();

--- a/src/models/longcat_flash_ngram.rs
+++ b/src/models/longcat_flash_ngram.rs
@@ -1158,3 +1158,126 @@ pub fn sanitize_weights(
 
     Ok(weights)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal config that exercises only the `kv_b_proj` MLA decomposition:
+    /// `n_routed_experts` is set but never triggers the MoE stacking branch,
+    /// which is gated on the presence of `mlp.experts.0.*` keys that this
+    /// fixture never inserts.
+    fn mla_config(kv_lora_rank: usize) -> LongcatFlashNgramConfig {
+        let json = format!(
+            r#"{{
+            "model_type": "longcat_flash",
+            "hidden_size": 8,
+            "ffn_hidden_size": 8,
+            "moe_topk": 1,
+            "expert_ffn_hidden_size": 8,
+            "n_routed_experts": 1,
+            "zero_expert_num": 0,
+            "num_layers": 1,
+            "vocab_size": 16,
+            "max_position_embeddings": 64,
+            "num_attention_heads": 2,
+            "kv_lora_rank": {kv_lora_rank},
+            "q_lora_rank": 8,
+            "qk_rope_head_dim": 2,
+            "qk_nope_head_dim": 4,
+            "v_head_dim": 4,
+            "routed_scaling_factor": 1.0,
+            "rms_norm_eps": 1e-6,
+            "rope_theta": 10000.0
+        }}"#
+        );
+        serde_json::from_str(&json).expect("parse tiny longcat_flash config")
+    }
+
+    /// The MLA `kv_b_proj` pair `sanitize_weights` decomposes is solved from
+    /// `kv_lora_rank` and two tensor axes rather than declared, and every
+    /// input is untrusted: `kv_lora_rank` comes from `config.json` and the
+    /// axes from the checkpoint. Before issue #958 the naive arithmetic
+    /// divided by both without checking them, so a `kv_lora_rank` of 0
+    /// panicked on integer division and a solved pair outside anything MLX
+    /// can describe reached `dequantize`, which crosses the cxx bridge as
+    /// `UniquePtr<MlxArray>` rather than `Result` and therefore aborts during
+    /// weight sanitization rather than failing the load.
+    ///
+    /// `sanitize_weights` decomposes both dual sub-attentions (`self_attn.0`
+    /// and `self_attn.1`) per layer; this fixture only builds `self_attn.0`,
+    /// and `self_attn.1` is skipped by the loader's own "no `kv_b_proj`
+    /// present" check, which is not what this test targets.
+    #[test]
+    fn sanitize_rejects_a_kv_lora_rank_no_packing_can_describe() {
+        // Honest affine 4-bit geometry: packed_in * 32 == bits * num_groups *
+        // group_size (2 * 32 == 4 * 1 * 16), with num_attention_heads 2 and
+        // qk_nope_head_dim = v_head_dim = 4, so rows = 2 * 8 = 16.
+        let build = |args: &LongcatFlashNgramConfig| {
+            let heads = args.num_attention_heads as i32;
+            let head_dim = (args.qk_nope_head_dim + args.v_head_dim) as i32;
+            let rows = heads * head_dim;
+            let mut weights = WeightMap::new();
+            for l in 0..args.num_layers {
+                let prefix = format!("model.layers.{l}.self_attn.0.kv_b_proj");
+                // UINT32, not a float dtype: `dequantize` rejects any other
+                // packed dtype by throwing, and that throw is the uncatchable
+                // abort this guard exists to keep out of the forward path. A
+                // float fixture here takes the test binary down on the positive
+                // control.
+                weights.insert(
+                    format!("{prefix}.weight"),
+                    mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
+                );
+                weights.insert(
+                    format!("{prefix}.scales"),
+                    mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
+                );
+                weights.insert(
+                    format!("{prefix}.biases"),
+                    mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
+                );
+            }
+            weights
+        };
+
+        // Positive control first, so a guard that rejected every quantized
+        // kv_b_proj could not pass this test.
+        let honest = mla_config(16);
+        let sanitized = sanitize_weights(build(&honest), &honest)
+            .expect("an honest quantized kv_b_proj must still sanitize");
+        assert!(sanitized.contains_key("model.layers.0.self_attn.0.embed_q.weight"));
+
+        // A zero `kv_lora_rank` is Rust integer division by zero on the very
+        // first solve, so it has to be refused before the division rather
+        // than after.
+        let zero_rank = mla_config(0);
+        let err = sanitize_weights(build(&zero_rank), &zero_rank)
+            .err()
+            .unwrap_or_else(|| panic!("kv_lora_rank 0 must be refused, not divided by"));
+        assert!(err.contains("kv_lora_rank"), "unhelpful error: {err}");
+
+        // A large `kv_lora_rank` truncates the solved bit width to 0, which
+        // is the divisor MLX would then divide by.
+        let wide_rank = mla_config(4096);
+        let err = sanitize_weights(build(&wide_rank), &wide_rank)
+            .err()
+            .unwrap_or_else(|| panic!("a solved bit width of 0 must be refused"));
+        assert!(err.contains("bits"), "unhelpful error: {err}");
+
+        // A non-quantized kv_b_proj carries no packing, so the pair is never
+        // solved and the decomposition must stay unaffected.
+        let mut float_only = WeightMap::new();
+        let rows = honest.num_attention_heads as i32
+            * (honest.qk_nope_head_dim + honest.v_head_dim) as i32;
+        float_only.insert(
+            "model.layers.0.self_attn.0.kv_b_proj.weight".to_string(),
+            mlxcel_core::zeros(
+                &[rows, honest.kv_lora_rank as i32],
+                mlxcel_core::dtype::FLOAT32,
+            ),
+        );
+        sanitize_weights(float_only, &honest)
+            .expect("a float kv_b_proj must not be gated on quantization params");
+    }
+}

--- a/src/models/longcat_flash_ngram.rs
+++ b/src/models/longcat_flash_ngram.rs
@@ -1097,24 +1097,20 @@ pub fn sanitize_weights(
                 let b = weights
                     .remove(&format!("{prefix}.kv_b_proj.biases"))
                     .unwrap();
-                let w_shape = mlxcel_core::array_shape(&w);
-                let s_shape = mlxcel_core::array_shape(&s);
-                let kv_lora_rank = args.kv_lora_rank as i32;
-                let inferred_bits = (w_shape[w_shape.len() - 1] * 32) / kv_lora_rank;
-                let inferred_gs = kv_lora_rank / s_shape[s_shape.len() - 1];
-
-                // The inferred pair is a quotient of a config field and a tensor
-                // axis, so it can still land outside anything MLX can describe,
-                // and `dequantize` crosses the cxx bridge as
-                // `UniquePtr<MlxArray>` rather than `Result`: a throw here would
-                // abort during weight sanitization rather than fail the load
-                // (issue #958). This is why the function is fallible.
-                mlxcel_core::layers::validate_quantization_params(inferred_gs, inferred_bits)
-                    .map_err(|e| {
-                        format!(
-                            "{prefix}.kv_b_proj: inferred quantization params are unusable: {e}"
-                        )
-                    })?;
+                // Solve the packed pair from the shapes and bound it before it
+                // reaches `dequantize`. The shared helper also checks each
+                // divisor before dividing: `kv_lora_rank` is a config field and
+                // the scales axis is checkpoint data, so the naive form panics
+                // on a zero divisor and overflows i32 on a large packed axis,
+                // both before the bound could fire. This is why the function is
+                // fallible (issue #958).
+                let (inferred_gs, inferred_bits) =
+                    mlxcel_core::layers::infer_mla_quantization_params(
+                        &mlxcel_core::array_shape(&w),
+                        &mlxcel_core::array_shape(&s),
+                        args.kv_lora_rank as i32,
+                        &format!("{prefix}.kv_b_proj"),
+                    )?;
 
                 unsafe {
                     mlxcel_core::dequantize(

--- a/src/models/longcat_flash_ngram.rs
+++ b/src/models/longcat_flash_ngram.rs
@@ -1266,18 +1266,21 @@ mod tests {
         assert!(err.contains("bits"), "unhelpful error: {err}");
 
         // A non-quantized kv_b_proj carries no packing, so the pair is never
-        // solved and the decomposition must stay unaffected.
+        // solved and a `kv_lora_rank` that no packing could describe must not gate
+        // it. The tensor is built at `wide_rank`'s own width so it still satisfies
+        // the separate shape cross-check below the solve, which would otherwise
+        // reject this for an unrelated reason.
         let mut float_only = WeightMap::new();
-        let rows = honest.num_attention_heads as i32
-            * (honest.qk_nope_head_dim + honest.v_head_dim) as i32;
+        let rows = wide_rank.num_attention_heads as i32
+            * (wide_rank.qk_nope_head_dim + wide_rank.v_head_dim) as i32;
         float_only.insert(
             "model.layers.0.self_attn.0.kv_b_proj.weight".to_string(),
             mlxcel_core::zeros(
-                &[rows, honest.kv_lora_rank as i32],
+                &[rows, wide_rank.kv_lora_rank as i32],
                 mlxcel_core::dtype::FLOAT32,
             ),
         );
-        sanitize_weights(float_only, &honest)
+        sanitize_weights(float_only, &wide_rank)
             .expect("a float kv_b_proj must not be gated on quantization params");
     }
 }

--- a/src/models/longcat_flash_ngram.rs
+++ b/src/models/longcat_flash_ngram.rs
@@ -912,7 +912,7 @@ impl LongcatFlashNgramModel {
             .map_err(|e| format!("Failed to parse config: {e}"))?;
 
         let mut weights = crate::models::load_text_weights(path, None)?;
-        weights = sanitize_weights(weights, &args);
+        weights = sanitize_weights(weights, &args)?;
 
         let model = Self::from_weights(&weights, &args)?;
         Ok((model, args.vocab_size))
@@ -1036,7 +1036,10 @@ impl LanguageModel for LongcatFlashNgramModel {
 }
 
 // Weight sanitization.
-pub fn sanitize_weights(mut weights: WeightMap, args: &LongcatFlashNgramConfig) -> WeightMap {
+pub fn sanitize_weights(
+    mut weights: WeightMap,
+    args: &LongcatFlashNgramConfig,
+) -> Result<WeightMap, String> {
     // Stack MoE expert weights into SwitchGLU format
     for l in 0..args.num_layers {
         let prefix = format!("model.layers.{l}");
@@ -1099,6 +1102,20 @@ pub fn sanitize_weights(mut weights: WeightMap, args: &LongcatFlashNgramConfig) 
                 let kv_lora_rank = args.kv_lora_rank as i32;
                 let inferred_bits = (w_shape[w_shape.len() - 1] * 32) / kv_lora_rank;
                 let inferred_gs = kv_lora_rank / s_shape[s_shape.len() - 1];
+
+                // The inferred pair is a quotient of a config field and a tensor
+                // axis, so it can still land outside anything MLX can describe,
+                // and `dequantize` crosses the cxx bridge as
+                // `UniquePtr<MlxArray>` rather than `Result`: a throw here would
+                // abort during weight sanitization rather than fail the load
+                // (issue #958). This is why the function is fallible.
+                mlxcel_core::layers::validate_quantization_params(inferred_gs, inferred_bits)
+                    .map_err(|e| {
+                        format!(
+                            "{prefix}.kv_b_proj: inferred quantization params are unusable: {e}"
+                        )
+                    })?;
+
                 unsafe {
                     mlxcel_core::dequantize(
                         &w,
@@ -1143,5 +1160,5 @@ pub fn sanitize_weights(mut weights: WeightMap, args: &LongcatFlashNgramConfig) 
         );
     }
 
-    weights
+    Ok(weights)
 }

--- a/src/models/mamba.rs
+++ b/src/models/mamba.rs
@@ -538,6 +538,13 @@ impl MambaModel {
             .remove("backbone.embeddings.biases")
             .or_else(|| weights.remove("model.embed_tokens.biases"));
 
+        // The table is taken out of the map by `remove`, under either the
+        // `backbone.embeddings` or the `model.embed_tokens` spelling, so this
+        // cannot go through the single-prefix `UnifiedEmbedding::from_weights`
+        // and therefore never reaches `reconcile_quantization_layout`. The bound
+        // that loader carries lives in `QuantizedEmbedding::new` instead (issue
+        // #958); without it a declared `"bits": 0` was stored here and divided
+        // by inside `quantized_embedding` at the first token.
         let embeddings = if let (Some(scales), Some(biases)) = (embed_scales, embed_biases) {
             UnifiedEmbedding::Quantized(mlxcel_core::layers::QuantizedEmbedding::new(
                 embed_weight,
@@ -545,7 +552,7 @@ impl MambaModel {
                 biases,
                 group_size,
                 bits,
-            ))
+            )?)
         } else {
             UnifiedEmbedding::Regular(mlxcel_core::layers::Embedding::new(embed_weight))
         };

--- a/src/models/mamba2.rs
+++ b/src/models/mamba2.rs
@@ -767,6 +767,13 @@ impl Mamba2Model {
             .remove("backbone.embeddings.biases")
             .or_else(|| weights.remove("model.embed_tokens.biases"));
 
+        // The table is taken out of the map by `remove`, under either the
+        // `backbone.embeddings` or the `model.embed_tokens` spelling, so this
+        // cannot go through the single-prefix `UnifiedEmbedding::from_weights`
+        // and therefore never reaches `reconcile_quantization_layout`. The bound
+        // that loader carries lives in `QuantizedEmbedding::new` instead (issue
+        // #958); without it a declared `"bits": 0` was stored here and divided
+        // by inside `quantized_embedding` at the first token.
         let embeddings = if let (Some(scales), Some(biases)) = (embed_scales, embed_biases) {
             UnifiedEmbedding::Quantized(mlxcel_core::layers::QuantizedEmbedding::new(
                 embed_weight,
@@ -774,7 +781,7 @@ impl Mamba2Model {
                 biases,
                 group_size,
                 bits,
-            ))
+            )?)
         } else {
             UnifiedEmbedding::Regular(mlxcel_core::layers::Embedding::new(embed_weight))
         };

--- a/src/models/mamba2_tests.rs
+++ b/src/models/mamba2_tests.rs
@@ -98,3 +98,85 @@ fn mamba2_cache_snapshot_restore_round_trips_state_shapes() {
     assert_eq!(mlxcel_core::array_shape(conv), vec![1, 3, 8]);
     assert_eq!(mlxcel_core::array_shape(ssm), vec![1, 2, 4, 8]);
 }
+
+/// Mamba2 hand-builds its `QuantizedEmbedding` for the same reason Mamba does
+/// (the table is taken out of the map by `remove`, under either the
+/// `backbone.embeddings` or the `model.embed_tokens` spelling), so it bypassed
+/// `reconcile_quantization_layout` and stored the declared pair verbatim. The
+/// pair then reached `quantized_embedding`, which crosses the cxx bridge as
+/// `UniquePtr<MlxArray>` rather than `Result`, so the C++ throw was an
+/// uncatchable abort at the first token rather than a load error (issue #958).
+///
+/// This drives the real `Mamba2Model::from_weights`, so a regression takes this
+/// whole test binary down with SIGABRT rather than failing cleanly.
+#[test]
+fn mamba2_rejects_quantization_params_that_would_abort_the_embedding_lookup() {
+    use super::{Mamba2Config, Mamba2Model};
+    use mlxcel_core::weights::WeightMap;
+
+    // `num_hidden_layers: 0` plus tied embeddings reduces the load to the
+    // embedding table and the final norm, so the honest case loads all the way
+    // through rather than stopping at an unrelated missing weight.
+    let config_with = |group_size: i32, bits: i32| -> Mamba2Config {
+        serde_json::from_value(serde_json::json!({
+            "model_type": "mamba2",
+            "vocab_size": 8,
+            "hidden_size": 8,
+            "num_heads": 2,
+            "head_dim": 4,
+            "state_size": 4,
+            "num_hidden_layers": 0,
+            "conv_kernel": 4,
+            "n_groups": 1,
+            "tie_word_embeddings": true,
+            "quantization": { "group_size": group_size, "bits": bits },
+        }))
+        .expect("test config must parse")
+    };
+
+    // Honest affine 4-bit geometry: packed_in * 32 == bits * groups * gs,
+    // i.e. 1 * 32 == 4 * 1 * 8. The table is [vocab, packed_in].
+    let build_weights = || {
+        let mut weights = WeightMap::new();
+        weights.insert(
+            "backbone.embeddings.weight".to_string(),
+            mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
+        );
+        weights.insert(
+            "backbone.embeddings.scales".to_string(),
+            mlxcel_core::from_slice_f32(&[1.0; 8], &[8, 1]),
+        );
+        weights.insert(
+            "backbone.embeddings.biases".to_string(),
+            mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
+        );
+        weights.insert(
+            "backbone.norm_f.weight".to_string(),
+            mlxcel_core::from_slice_f32(&[1.0; 8], &[8]),
+        );
+        weights
+    };
+
+    // Positive control first, so a guard that rejects everything quantized
+    // cannot pass this test.
+    Mamba2Model::from_weights(config_with(8, 4), build_weights())
+        .expect("an honest affine pair must still load a quantized Mamba2 embedding");
+
+    for (group_size, bits, field) in crate::models::switch_layers::HOSTILE_QUANT_PARAMS {
+        let err = Mamba2Model::from_weights(config_with(group_size, bits), build_weights())
+            .err()
+            .unwrap_or_else(|| {
+                panic!("Mamba2 must reject group_size {group_size} / bits {bits} at load")
+            })
+            .to_string();
+        assert!(err.contains(field), "unhelpful error: {err}");
+    }
+
+    // A float embedding table carries no packing, so the params are irrelevant
+    // there and must not be enforced.
+    let mut regular = build_weights();
+    regular.remove("backbone.embeddings.scales");
+    regular.remove("backbone.embeddings.biases");
+    Mamba2Model::from_weights(config_with(0, 0), regular)
+        .expect("a float embedding table must not be gated on quantization params");
+}

--- a/src/models/mamba2_tests.rs
+++ b/src/models/mamba2_tests.rs
@@ -107,8 +107,10 @@ fn mamba2_cache_snapshot_restore_round_trips_state_shapes() {
 /// `UniquePtr<MlxArray>` rather than `Result`, so the C++ throw was an
 /// uncatchable abort at the first token rather than a load error (issue #958).
 ///
-/// This drives the real `Mamba2Model::from_weights`, so a regression takes this
-/// whole test binary down with SIGABRT rather than failing cleanly.
+/// This drives the real `Mamba2Model::from_weights` rather than the pure bounds
+/// helper, so the guard is exercised where a checkpoint actually reaches it. The
+/// assertions are on the load result and no forward pass is run, so a regression
+/// fails cleanly here rather than aborting the test binary.
 #[test]
 fn mamba2_rejects_quantization_params_that_would_abort_the_embedding_lookup() {
     use super::{Mamba2Config, Mamba2Model};

--- a/src/models/mamba_tests.rs
+++ b/src/models/mamba_tests.rs
@@ -102,3 +102,85 @@ fn mamba_cache_snapshot_restore_round_trips_state_shapes() {
     assert_eq!(mlxcel_core::array_shape(conv), vec![1, 3, 4]);
     assert_eq!(mlxcel_core::array_shape(ssm), vec![1, 2, 4, 8]);
 }
+
+/// Mamba takes its embedding table out of the `WeightMap` by `remove`, under
+/// either the `backbone.embeddings` or the `model.embed_tokens` spelling, so it
+/// cannot address the single-prefix `UnifiedEmbedding::from_weights` and never
+/// reaches `reconcile_quantization_layout`. Before issue #958 the declared pair
+/// was stored verbatim on a hand-built `QuantizedEmbedding` and divided by
+/// inside `quantized_embedding` at the first token, which crosses the cxx
+/// bridge as `UniquePtr<MlxArray>` rather than `Result` and therefore aborts the
+/// process instead of failing the load.
+///
+/// This drives the real `MambaModel::from_weights`, so a regression takes this
+/// whole test binary down with SIGABRT rather than failing cleanly.
+#[test]
+fn mamba_rejects_quantization_params_that_would_abort_the_embedding_lookup() {
+    use super::{MambaConfig, MambaModel};
+    use mlxcel_core::weights::WeightMap;
+
+    // `num_hidden_layers: 0` plus tied embeddings reduces the load to the
+    // embedding table and the final norm, so the honest case loads all the way
+    // through rather than stopping at an unrelated missing weight.
+    let config_with = |group_size: i32, bits: i32| -> MambaConfig {
+        serde_json::from_value(serde_json::json!({
+            "model_type": "mamba",
+            "vocab_size": 8,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "state_size": 4,
+            "num_hidden_layers": 0,
+            "conv_kernel": 4,
+            "time_step_rank": 1,
+            "tie_word_embeddings": true,
+            "quantization": { "group_size": group_size, "bits": bits },
+        }))
+        .expect("test config must parse")
+    };
+
+    // Honest affine 4-bit geometry: packed_in * 32 == bits * groups * gs,
+    // i.e. 1 * 32 == 4 * 1 * 8. The table is [vocab, packed_in].
+    let build_weights = || {
+        let mut weights = WeightMap::new();
+        weights.insert(
+            "backbone.embeddings.weight".to_string(),
+            mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
+        );
+        weights.insert(
+            "backbone.embeddings.scales".to_string(),
+            mlxcel_core::from_slice_f32(&[1.0; 8], &[8, 1]),
+        );
+        weights.insert(
+            "backbone.embeddings.biases".to_string(),
+            mlxcel_core::from_slice_f32(&[0.0; 8], &[8, 1]),
+        );
+        weights.insert(
+            "backbone.norm_f.weight".to_string(),
+            mlxcel_core::from_slice_f32(&[1.0; 8], &[8]),
+        );
+        weights
+    };
+
+    // Positive control first, so a guard that rejects everything quantized
+    // cannot pass this test.
+    MambaModel::from_weights(config_with(8, 4), build_weights())
+        .expect("an honest affine pair must still load a quantized Mamba embedding");
+
+    for (group_size, bits, field) in crate::models::switch_layers::HOSTILE_QUANT_PARAMS {
+        let err = MambaModel::from_weights(config_with(group_size, bits), build_weights())
+            .err()
+            .unwrap_or_else(|| {
+                panic!("Mamba must reject group_size {group_size} / bits {bits} at load")
+            })
+            .to_string();
+        assert!(err.contains(field), "unhelpful error: {err}");
+    }
+
+    // A float embedding table carries no packing, so the params are irrelevant
+    // there and must not be enforced.
+    let mut regular = build_weights();
+    regular.remove("backbone.embeddings.scales");
+    regular.remove("backbone.embeddings.biases");
+    MambaModel::from_weights(config_with(0, 0), regular)
+        .expect("a float embedding table must not be gated on quantization params");
+}

--- a/src/models/mamba_tests.rs
+++ b/src/models/mamba_tests.rs
@@ -112,8 +112,10 @@ fn mamba_cache_snapshot_restore_round_trips_state_shapes() {
 /// bridge as `UniquePtr<MlxArray>` rather than `Result` and therefore aborts the
 /// process instead of failing the load.
 ///
-/// This drives the real `MambaModel::from_weights`, so a regression takes this
-/// whole test binary down with SIGABRT rather than failing cleanly.
+/// This drives the real `MambaModel::from_weights` rather than the pure bounds
+/// helper, so the guard is exercised where a checkpoint actually reaches it. The
+/// assertions are on the load result and no forward pass is run, so a regression
+/// fails cleanly here rather than aborting the test binary.
 #[test]
 fn mamba_rejects_quantization_params_that_would_abort_the_embedding_lookup() {
     use super::{MambaConfig, MambaModel};

--- a/src/models/nemotron_h.rs
+++ b/src/models/nemotron_h.rs
@@ -22,6 +22,7 @@
 // - Mixed cache: MambaCache for M blocks, KVCache for * blocks
 // - relu^2 activation for MLP/MoE
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, Linear, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils::{create_causal_mask, relu_squared, silu, slice_axis, stack_arrays};
@@ -2410,7 +2411,21 @@ impl NemotronHModel {
                             norm_topk_prob: config.norm_topk_prob.unwrap_or(false),
                         },
                         switch_mlp: SwitchMLP {
+                            // `QuantizedSwitchLinear` has no named constructor:
+                            // the variant is built as a struct literal here, so
+                            // the bound goes with each literal rather than into
+                            // a loader (issue #958). This type never reaches
+                            // `reconcile_quantization_layout` and hands the
+                            // stored pair to `gather_qmm`. Only the quantized
+                            // arms are gated; a bf16 expert plane carries no
+                            // packing and must stay loadable at any declared
+                            // pair.
                             fc1: if let Some(scales) = fc1_scales {
+                                validate_expert_quantization_params(
+                                    &format!("{}.switch_mlp.fc1", mixer_prefix),
+                                    group_size,
+                                    bits,
+                                )?;
                                 QuantizedSwitchLinear::Quantized {
                                     weight: fc1_weight,
                                     scales,
@@ -2425,6 +2440,11 @@ impl NemotronHModel {
                                 QuantizedSwitchLinear::Regular { weight: fc1_weight }
                             },
                             fc2: if let Some(scales) = fc2_scales {
+                                validate_expert_quantization_params(
+                                    &format!("{}.switch_mlp.fc2", mixer_prefix),
+                                    group_size,
+                                    bits,
+                                )?;
                                 QuantizedSwitchLinear::Quantized {
                                     weight: fc2_weight,
                                     scales,

--- a/src/models/nemotron_h_tests.rs
+++ b/src/models/nemotron_h_tests.rs
@@ -483,8 +483,10 @@ fn nemotron_h_conv_state_shape_plateaus_after_50_steps() {
 /// checkpoint. `UnifiedEmbedding::from_weights` only enters its quantized
 /// branch when `.scales` exists, so nothing here touches the reconciler.
 ///
-/// It drives the real model loader, so a regression takes this whole test
-/// binary down with SIGABRT rather than failing cleanly.
+/// It drives the real model loader rather than the pure bounds helper, so the
+/// guard is exercised where a checkpoint actually reaches it. The assertions are
+/// on the load result and no forward pass is run, so a regression fails cleanly
+/// here rather than aborting the test binary.
 #[test]
 fn nemotron_h_rejects_expert_quantization_params_that_would_abort_gather_qmm() {
     use super::{BlockType, NemotronHConfig, NemotronHModel};

--- a/src/models/nemotron_h_tests.rs
+++ b/src/models/nemotron_h_tests.rs
@@ -468,3 +468,124 @@ fn nemotron_h_conv_state_shape_plateaus_after_50_steps() {
         );
     }
 }
+
+/// `QuantizedSwitchLinear` has no named constructor: `NemotronHModel::from_weights`
+/// builds the quantized variant as a bare struct literal, storing the declared
+/// `group_size` / `bits` and handing them to `gather_qmm` without ever reaching
+/// `reconcile_quantization_layout` (issue #958). `gather_qmm` crosses the cxx
+/// bridge as `UniquePtr<MlxArray>` rather than `Result`, so a hostile pair used
+/// to abort the process at the first routed forward pass rather than failing at
+/// load.
+///
+/// This fixture is deliberately the shape the issue calls out as the one no
+/// guarded loader covers: a float `backbone.embeddings` and a float `lm_head`
+/// with quantized expert planes as the ONLY quantized tensors in the
+/// checkpoint. `UnifiedEmbedding::from_weights` only enters its quantized
+/// branch when `.scales` exists, so nothing here touches the reconciler.
+///
+/// It drives the real model loader, so a regression takes this whole test
+/// binary down with SIGABRT rather than failing cleanly.
+#[test]
+fn nemotron_h_rejects_expert_quantization_params_that_would_abort_gather_qmm() {
+    use super::{BlockType, NemotronHConfig, NemotronHModel};
+    use mlxcel_core::weights::WeightMap;
+
+    const HIDDEN: i32 = 8;
+    const EXPERTS: i32 = 2;
+    const FF: i32 = 4;
+    // Honest affine 4-bit geometry: packed_in * 32 == bits * groups * gs,
+    // i.e. 1 * 32 == 4 * 1 * 8.
+    const PACKED_IN: i32 = 1;
+    const NUM_GROUPS: i32 = 1;
+
+    let config_with = |group_size: i32, bits: i32| -> NemotronHConfig {
+        let mut config: NemotronHConfig = serde_json::from_value(serde_json::json!({
+            "model_type": "nemotron_h",
+            "vocab_size": 8,
+            "hidden_size": HIDDEN,
+            "intermediate_size": FF,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "mamba_num_heads": 1,
+            "mamba_head_dim": 4,
+            "ssm_state_size": 4,
+            "conv_kernel": 4,
+            "n_groups": 1,
+            "n_routed_experts": EXPERTS,
+            "num_experts_per_tok": 1,
+            "moe_intermediate_size": FF,
+            "hybrid_override_pattern": "E",
+            "quantization": { "group_size": group_size, "bits": bits },
+        }))
+        .expect("test config must parse");
+        config.post_init().expect("test config must pass post_init");
+        config
+    };
+
+    let build_weights = || {
+        let mut weights = WeightMap::new();
+        let float = |shape: &[i32]| {
+            let n: i32 = shape.iter().product();
+            mlxcel_core::from_slice_f32(&vec![0.0; n as usize], shape)
+        };
+        // Float embedding and lm_head: no `.scales`, so neither reaches the
+        // reconciler and neither can stand in for the expert-plane bound.
+        weights.insert(
+            "backbone.embeddings.weight".to_string(),
+            float(&[8, HIDDEN]),
+        );
+        weights.insert("lm_head.weight".to_string(), float(&[8, HIDDEN]));
+        weights.insert("backbone.norm_f.weight".to_string(), float(&[HIDDEN]));
+        weights.insert(
+            "backbone.layers.0.norm.weight".to_string(),
+            float(&[HIDDEN]),
+        );
+        weights.insert(
+            "backbone.layers.0.mixer.gate.weight".to_string(),
+            float(&[EXPERTS, HIDDEN]),
+        );
+        for fc in ["fc1", "fc2"] {
+            let prefix = format!("backbone.layers.0.mixer.switch_mlp.{fc}");
+            crate::models::switch_layers::insert_stacked_quantized_expert_plane(
+                &mut weights,
+                &prefix,
+                EXPERTS,
+                FF,
+                PACKED_IN,
+                NUM_GROUPS,
+            );
+        }
+        weights
+    };
+
+    // Positive control first, so a guard that rejects everything quantized
+    // cannot pass this test.
+    NemotronHModel::from_weights(config_with(8, 4), build_weights(), vec![BlockType::MoE])
+        .expect("an honest affine pair must still load quantized Nemotron-H experts");
+
+    for (group_size, bits, field) in crate::models::switch_layers::HOSTILE_QUANT_PARAMS {
+        let err = NemotronHModel::from_weights(
+            config_with(group_size, bits),
+            build_weights(),
+            vec![BlockType::MoE],
+        )
+        .err()
+        .unwrap_or_else(|| {
+            panic!("Nemotron-H must reject group_size {group_size} / bits {bits} at load")
+        })
+        .to_string();
+        assert!(err.contains(field), "unhelpful error: {err}");
+    }
+
+    // A bf16 expert plane carries no packing at all, so the params are
+    // irrelevant there and must not be enforced.
+    let mut regular = build_weights();
+    for fc in ["fc1", "fc2"] {
+        let prefix = format!("backbone.layers.0.mixer.switch_mlp.{fc}");
+        regular.remove(&format!("{prefix}.scales"));
+        regular.remove(&format!("{prefix}.biases"));
+    }
+    NemotronHModel::from_weights(config_with(0, 0), regular, vec![BlockType::MoE])
+        .expect("a non-quantized expert plane must not be gated on quantization params");
+}

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -23,6 +23,7 @@
 //! - Standard RoPE positional embeddings
 //! - RMSNorm normalization
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{FusedQKVLinear, KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
@@ -983,6 +984,10 @@ impl SwitchLinear {
         let weight = get_weight_copy(weights, &format!("{}.weight", prefix))?;
         let scales_key = format!("{}.scales", prefix);
         if weights.contains_key(&scales_key) {
+            let (group_size, bits) = (args.group_size(), args.bits());
+            // This type never reaches `reconcile_quantization_layout`, so the
+            // declared pair is bounded here, where it is stored (issue #958).
+            validate_expert_quantization_params(prefix, group_size, bits)?;
             let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());
             let biases = get_weight_copy(weights, &format!("{}.biases", prefix))?;
             let shape = mlxcel_core::array_shape(&weight);
@@ -991,8 +996,8 @@ impl SwitchLinear {
                 weight,
                 scales,
                 biases,
-                group_size: args.group_size(),
-                bits: args.bits(),
+                group_size,
+                bits,
                 num_experts,
             })
         } else {

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -1042,3 +1042,7 @@ impl LanguageModel for Qwen3MoeModel {
         true
     }
 }
+
+#[cfg(test)]
+#[path = "qwen3_moe_tests.rs"]
+mod tests;

--- a/src/models/qwen3_moe_tests.rs
+++ b/src/models/qwen3_moe_tests.rs
@@ -1,0 +1,105 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for the bound on declared quantization params that the
+//! Qwen3-MoE `SwitchLinear` loader applies before it stores them on a quantized
+//! expert plane (issue #958).
+
+use mlxcel_core::weights::WeightMap;
+
+use super::{ModelArgs, SwitchLinear};
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+
+/// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+/// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a plane
+/// MLX can actually describe.
+const EXPERTS: i32 = 3;
+const OUT: i32 = 4;
+const PACKED_IN: i32 = 8;
+const NUM_GROUPS: i32 = 1;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+
+/// Smallest Qwen3-MoE config that parses, varying only the declared
+/// quantization pair. Qwen3-MoE carries it in a nested `quantization` block.
+/// Built through serde rather than a struct literal so every
+/// `#[serde(default)]` field fills itself in.
+fn args_with(group_size: i32, bits: i32) -> ModelArgs {
+    serde_json::from_value(serde_json::json!({
+        "model_type": "qwen3_moe",
+        "vocab_size": 32,
+        "hidden_size": 8,
+        "intermediate_size": 8,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_experts": 3,
+        "num_experts_per_tok": 1,
+        "decoder_sparse_step": 1,
+        "moe_intermediate_size": 8,
+        "rms_norm_eps": 1e-5,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "quantization": { "group_size": group_size, "bits": bits },
+    }))
+    .expect("test config must parse")
+}
+
+/// The pair this loader stores is handed straight to `gather_qmm`, which
+/// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
+/// throw there is an uncatchable `std::terminate`, so losing the bound would
+/// abort the whole test binary with SIGABRT at the first routed forward pass
+/// instead of failing cleanly at load. Issue #958.
+#[test]
+fn qwen3_moe_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+    let mut weights = WeightMap::new();
+    insert_stacked_quantized_expert_plane(
+        &mut weights,
+        PREFIX,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    SwitchLinear::from_weights(&weights, &args_with(GROUP_SIZE, BITS), PREFIX)
+        .expect("honest 4-bit expert plane must load");
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match SwitchLinear::from_weights(&weights, &args_with(group_size, bits), PREFIX) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+    }
+
+    // A bf16 expert plane carries no packing at all, so the declared pair is
+    // irrelevant there and must not gate the non-quantized fallback.
+    let mut regular = WeightMap::new();
+    regular.insert(
+        format!("{PREFIX}.weight"),
+        mlxcel_core::ones(&[EXPERTS, OUT, PACKED_IN], mlxcel_core::dtype::BFLOAT16),
+    );
+    SwitchLinear::from_weights(&regular, &args_with(0, 0), PREFIX)
+        .expect("a bf16 expert plane must not be gated on quantization params");
+}

--- a/src/models/qwen3_moe_tests.rs
+++ b/src/models/qwen3_moe_tests.rs
@@ -59,9 +59,11 @@ fn args_with(group_size: i32, bits: i32) -> ModelArgs {
 
 /// The pair this loader stores is handed straight to `gather_qmm`, which
 /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
-/// throw there is an uncatchable `std::terminate`, so losing the bound would
-/// abort the whole test binary with SIGABRT at the first routed forward pass
-/// instead of failing cleanly at load. Issue #958.
+/// throw there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn qwen3_moe_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
     let mut weights = WeightMap::new();

--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -2153,3 +2153,7 @@ mod cache_tests {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "qwen3_next_tests.rs"]
+mod tests;

--- a/src/models/qwen3_next.rs
+++ b/src/models/qwen3_next.rs
@@ -39,6 +39,7 @@ use crate::models::gated_delta::{
     GatedDeltaCache, RMSNormGated, gated_delta_update, scaled_fast_rms_norm_no_weight,
 };
 use crate::models::model_owned::ModelOwnedSequenceState;
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::cache::{SequenceId, SequenceStateLayout};
 use mlxcel_core::dtype;
 use mlxcel_core::generate::LanguageModel;
@@ -989,6 +990,15 @@ impl SwitchLinear {
             .ok_or_else(|| format!("Missing weight: {}", prefix))?;
         let scales_key = format!("{}.scales", prefix);
         if weights.contains_key(&scales_key) {
+            let (group_size, bits) = (config.group_size(), config.bits());
+            // Bound the declared pair here, where it is stored: this type never
+            // reaches `reconcile_quantization_layout` and hands the stored pair
+            // to `gather_qmm` (issue #958). It is reached with three different
+            // config sources (Qwen3Next, Qwen3.5 through
+            // `to_qwen3next_config`, and the synthesized bridge config in
+            // `audio/qwen3_omni_moe/talker.rs`), so bounding the producer would
+            // not have covered it.
+            validate_expert_quantization_params(prefix, group_size, bits)?;
             let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());
             let biases = weights
                 .get(&format!("{}.biases", prefix))
@@ -998,8 +1008,8 @@ impl SwitchLinear {
                 weight,
                 scales,
                 biases,
-                group_size: config.group_size(),
-                bits: config.bits(),
+                group_size,
+                bits,
             })
         } else {
             Ok(Self::Regular { weight })

--- a/src/models/qwen3_next_tests.rs
+++ b/src/models/qwen3_next_tests.rs
@@ -64,9 +64,11 @@ fn config_with(group_size: i32, bits: i32) -> Qwen3NextConfig {
 
 /// The pair this loader stores is handed straight to `gather_qmm`, which
 /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
-/// throw there is an uncatchable `std::terminate`, so losing the bound would
-/// abort the whole test binary with SIGABRT at the first routed forward pass
-/// instead of failing cleanly at load. Issue #958.
+/// throw there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 ///
 /// Three config sources reach this one loader (Qwen3-Next, Qwen3.5 through
 /// `to_qwen3next_config`, and the synthesized bridge config in the Qwen3-Omni

--- a/src/models/qwen3_next_tests.rs
+++ b/src/models/qwen3_next_tests.rs
@@ -1,0 +1,116 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for the bound on declared quantization params that the
+//! Qwen3-Next `SwitchLinear` loader applies before it stores them on a
+//! quantized expert plane (issue #958).
+
+use mlxcel_core::weights::WeightMap;
+
+use super::{Qwen3NextConfig, SwitchLinear};
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+
+/// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+/// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a plane
+/// MLX can actually describe.
+const EXPERTS: i32 = 3;
+const OUT: i32 = 4;
+const PACKED_IN: i32 = 8;
+const NUM_GROUPS: i32 = 1;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+
+/// Smallest Qwen3-Next config that parses, varying only the declared
+/// quantization pair. Qwen3-Next carries it in a nested `quantization` block.
+/// Built through serde rather than a struct literal so every
+/// `#[serde(default)]` field fills itself in.
+fn config_with(group_size: i32, bits: i32) -> Qwen3NextConfig {
+    serde_json::from_value(serde_json::json!({
+        "model_type": "qwen3_next",
+        "hidden_size": 8,
+        "num_hidden_layers": 1,
+        "intermediate_size": 8,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "linear_num_value_heads": 2,
+        "linear_num_key_heads": 1,
+        "linear_key_head_dim": 4,
+        "linear_value_head_dim": 4,
+        "linear_conv_kernel_dim": 4,
+        "num_experts": 3,
+        "num_experts_per_tok": 1,
+        "decoder_sparse_step": 1,
+        "moe_intermediate_size": 8,
+        "shared_expert_intermediate_size": 8,
+        "vocab_size": 32,
+        "quantization": { "group_size": group_size, "bits": bits },
+    }))
+    .expect("test config must parse")
+}
+
+/// The pair this loader stores is handed straight to `gather_qmm`, which
+/// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
+/// throw there is an uncatchable `std::terminate`, so losing the bound would
+/// abort the whole test binary with SIGABRT at the first routed forward pass
+/// instead of failing cleanly at load. Issue #958.
+///
+/// Three config sources reach this one loader (Qwen3-Next, Qwen3.5 through
+/// `to_qwen3next_config`, and the synthesized bridge config in the Qwen3-Omni
+/// talker), which is why the bound lives at the storage point rather than at
+/// any single producer.
+#[test]
+fn qwen3_next_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+    let mut weights = WeightMap::new();
+    insert_stacked_quantized_expert_plane(
+        &mut weights,
+        PREFIX,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    SwitchLinear::from_weights(&weights, &config_with(GROUP_SIZE, BITS), PREFIX)
+        .expect("honest 4-bit expert plane must load");
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match SwitchLinear::from_weights(&weights, &config_with(group_size, bits), PREFIX)
+        {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+    }
+
+    // A bf16 expert plane carries no packing at all, so the declared pair is
+    // irrelevant there and must not gate the non-quantized fallback.
+    let mut regular = WeightMap::new();
+    regular.insert(
+        format!("{PREFIX}.weight"),
+        mlxcel_core::ones(&[EXPERTS, OUT, PACKED_IN], mlxcel_core::dtype::BFLOAT16),
+    );
+    SwitchLinear::from_weights(&regular, &config_with(0, 0), PREFIX)
+        .expect("a bf16 expert plane must not be gated on quantization params");
+}

--- a/src/models/qwen3_vl_moe.rs
+++ b/src/models/qwen3_vl_moe.rs
@@ -28,6 +28,7 @@
 //! Reference: https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/qwen3_vl_moe/language.py
 
 use crate::models::qwen_mrope_state::MRopeState;
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::cache::SequenceId;
 use mlxcel_core::layers::{FusedQKVLinear, KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::weights::WeightMap;
@@ -662,6 +663,12 @@ fn load_switch_linear(
     let weight = get_weight_copy(weights, &format!("{}.weight", prefix))?;
     let scales_key = format!("{}.scales", prefix);
     if weights.contains_key(&scales_key) {
+        // This builds `qwen3_moe::SwitchLinear::Quantized` as a bare struct
+        // literal rather than through `qwen3_moe::SwitchLinear::from_weights`,
+        // so the bound that loader carries does not apply here (issue #958).
+        // The pair also arrives from `Qwen3VLMoeConfig`, whose accessors fall
+        // back to 0 rather than 64/4 when no `quantization` block was inherited.
+        validate_expert_quantization_params(prefix, group_size, bits)?;
         let shape = mlxcel_core::array_shape(&weight);
         let num_experts = shape[0] as usize;
         let scales = mlxcel_core::copy(weights.get(&scales_key).unwrap());

--- a/src/models/qwen3_vl_moe.rs
+++ b/src/models/qwen3_vl_moe.rs
@@ -1326,3 +1326,7 @@ mod deepstack_injection_tests {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "qwen3_vl_moe_tests.rs"]
+mod tests;

--- a/src/models/qwen3_vl_moe_tests.rs
+++ b/src/models/qwen3_vl_moe_tests.rs
@@ -1,0 +1,89 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for the bound on declared quantization params that
+//! `qwen3_vl_moe::load_switch_linear` applies before it stores them on a
+//! quantized expert plane (issue #958).
+
+use super::load_switch_linear;
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+use mlxcel_core::weights::WeightMap;
+
+/// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+/// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a plane
+/// MLX can actually describe.
+const EXPERTS: i32 = 3;
+const OUT: i32 = 4;
+const PACKED_IN: i32 = 8;
+const NUM_GROUPS: i32 = 1;
+const GROUP_SIZE: i32 = 64;
+const BITS: i32 = 4;
+
+const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
+
+/// The pair this loader stores is handed straight to `gather_qmm`, which
+/// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
+/// throw there is an uncatchable `std::terminate`, so losing the bound would
+/// abort the whole test binary with SIGABRT at the first routed forward pass
+/// instead of failing cleanly at load. Issue #958.
+#[test]
+fn qwen3_vl_moe_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
+    let mut weights = WeightMap::new();
+    insert_stacked_quantized_expert_plane(
+        &mut weights,
+        PREFIX,
+        EXPERTS,
+        OUT,
+        PACKED_IN,
+        NUM_GROUPS,
+    );
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    match load_switch_linear(&weights, PREFIX, GROUP_SIZE, BITS) {
+        Ok(_) => {}
+        Err(e) => panic!("honest 4-bit expert plane must load: {e}"),
+    }
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match load_switch_linear(&weights, PREFIX, group_size, bits) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+        assert!(
+            err.contains(PREFIX),
+            "the load error must name the offending tensor {PREFIX}, got: {err}"
+        );
+    }
+
+    // A bf16 expert plane carries no packing and no `.scales`, so the declared
+    // pair is inert on the `gather_mm` path and must not gate the load.
+    let mut dense = WeightMap::new();
+    let n = (EXPERTS * OUT * PACKED_IN) as usize;
+    dense.insert(
+        format!("{PREFIX}.weight"),
+        mlxcel_core::from_slice_f32(&vec![0.0f32; n], &[EXPERTS, OUT, PACKED_IN]),
+    );
+    match load_switch_linear(&dense, PREFIX, 0, 0) {
+        Ok(_) => {}
+        Err(e) => panic!("a non-quantized expert plane must load with an unset pair: {e}"),
+    }
+}

--- a/src/models/qwen3_vl_moe_tests.rs
+++ b/src/models/qwen3_vl_moe_tests.rs
@@ -34,9 +34,11 @@ const PREFIX: &str = "model.layers.0.mlp.switch_mlp.gate_proj";
 
 /// The pair this loader stores is handed straight to `gather_qmm`, which
 /// crosses the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
-/// throw there is an uncatchable `std::terminate`, so losing the bound would
-/// abort the whole test binary with SIGABRT at the first routed forward pass
-/// instead of failing cleanly at load. Issue #958.
+/// throw there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn qwen3_vl_moe_switch_linear_rejects_quantization_params_that_would_abort_gather_qmm() {
     let mut weights = WeightMap::new();

--- a/src/models/step3p5.rs
+++ b/src/models/step3p5.rs
@@ -23,6 +23,7 @@
 //! - Per-layer rope_theta and partial_rotary_factor
 //! - SwitchGLU experts with shared expert
 
+use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, RotatingKVCache, UnifiedEmbedding, UnifiedLinear};
 use mlxcel_core::utils::{create_causal_mask, create_sliding_window_prefill_mask};
@@ -769,6 +770,12 @@ impl Step3p5SwitchGLU {
         bits: i32,
         swiglu_limit: Option<f32>,
     ) -> Result<Self, String> {
+        // This SwitchGLU is unconditionally quantized (it requires scales and
+        // biases for all three projections below) and hands the stored pair to
+        // three `gather_qmm` calls without ever reaching
+        // `reconcile_quantization_layout`, so the bound lives here (issue #958).
+        validate_expert_quantization_params(prefix, group_size, bits)?;
+
         let gate_weight = get_weight_copy(weights, &format!("{}.gate_proj.weight", prefix))?;
         let gate_scales = get_weight_copy(weights, &format!("{}.gate_proj.scales", prefix))?;
         let gate_biases = get_weight_copy(weights, &format!("{}.gate_proj.biases", prefix))?;

--- a/src/models/step3p5_tests.rs
+++ b/src/models/step3p5_tests.rs
@@ -264,9 +264,11 @@ fn load_step3p5_switch_glu(
 
 /// The pair this loader stores is handed to three `gather_qmm` calls, which
 /// cross the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
-/// throw there is an uncatchable `std::terminate`, so losing the bound would
-/// abort the whole test binary with SIGABRT at the first routed forward pass
-/// instead of failing cleanly at load. Issue #958.
+/// throw there is an uncatchable `std::terminate`,
+/// so losing the bound turns a rejected load into an uncatchable abort at the
+/// first routed forward pass in production. This test asserts on the load
+/// result rather than running a forward pass, so a regression fails cleanly
+/// here instead of aborting the test binary.
 #[test]
 fn step3p5_switch_glu_rejects_quantization_params_that_would_abort_gather_qmm() {
     let weights = step3p5_quantized_switch_glu_weights();

--- a/src/models/step3p5_tests.rs
+++ b/src/models/step3p5_tests.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{Cache, Step3p5Config, Step3p5Model};
+use super::{Cache, Step3p5Config, Step3p5Model, Step3p5SwitchGLU};
+use crate::models::switch_layers::{HOSTILE_QUANT_PARAMS, insert_stacked_quantized_expert_plane};
+use mlxcel_core::weights::WeightMap;
 
 fn parse_config(json: serde_json::Value) -> Step3p5Config {
     serde_json::from_value(json).expect("valid Step3p5Config")
@@ -218,4 +220,79 @@ fn resolve_eos_treats_null_top_level_as_absent_and_uses_text_config() {
         "text_config": { "eos_token_id": 7 }
     });
     assert_eq!(Step3p5Config::resolve_step3p7_eos_token_ids(&cfg), vec![7]);
+}
+
+/// Honest 4-bit expert geometry: `packed_in * 32 == bits * num_groups *
+/// group_size` (8 * 32 == 4 * 1 * 64), so the positive control below is a plane
+/// MLX can actually describe.
+const QUANT_EXPERTS: i32 = 3;
+const QUANT_OUT: i32 = 4;
+const QUANT_PACKED_IN: i32 = 8;
+const QUANT_NUM_GROUPS: i32 = 1;
+const QUANT_GROUP_SIZE: i32 = 64;
+const QUANT_BITS: i32 = 4;
+
+const QUANT_PREFIX: &str = "model.layers.0.mlp.switch_mlp";
+
+/// Build the three projection planes `Step3p5SwitchGLU::from_weights` requires.
+/// This SwitchGLU is unconditionally quantized, so there is no dense fallback to
+/// exercise: every plane carries `.scales` and `.biases`.
+fn step3p5_quantized_switch_glu_weights() -> WeightMap {
+    let mut weights = WeightMap::new();
+    for proj in ["gate_proj", "up_proj", "down_proj"] {
+        insert_stacked_quantized_expert_plane(
+            &mut weights,
+            &format!("{QUANT_PREFIX}.{proj}"),
+            QUANT_EXPERTS,
+            QUANT_OUT,
+            QUANT_PACKED_IN,
+            QUANT_NUM_GROUPS,
+        );
+    }
+    weights
+}
+
+/// Drive the real loader with only the declared pair varying. `swiglu_limit` is
+/// `None` here: it plays no part in the bound.
+fn load_step3p5_switch_glu(
+    weights: &WeightMap,
+    group_size: i32,
+    bits: i32,
+) -> Result<Step3p5SwitchGLU, String> {
+    Step3p5SwitchGLU::from_weights(weights, QUANT_PREFIX, group_size, bits, None)
+}
+
+/// The pair this loader stores is handed to three `gather_qmm` calls, which
+/// cross the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`. A C++
+/// throw there is an uncatchable `std::terminate`, so losing the bound would
+/// abort the whole test binary with SIGABRT at the first routed forward pass
+/// instead of failing cleanly at load. Issue #958.
+#[test]
+fn step3p5_switch_glu_rejects_quantization_params_that_would_abort_gather_qmm() {
+    let weights = step3p5_quantized_switch_glu_weights();
+
+    // Positive control first, so a guard that rejected every quantized plane
+    // could not pass this test.
+    match load_step3p5_switch_glu(&weights, QUANT_GROUP_SIZE, QUANT_BITS) {
+        Ok(_) => {}
+        Err(e) => panic!("honest 4-bit expert plane must load: {e}"),
+    }
+
+    for (group_size, bits, field) in HOSTILE_QUANT_PARAMS {
+        let err = match load_step3p5_switch_glu(&weights, group_size, bits) {
+            Ok(_) => panic!(
+                "(group_size {group_size}, bits {bits}) must be refused at load, \
+                 not stored for gather_qmm"
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains(field),
+            "(group_size {group_size}, bits {bits}) must be blamed on {field}, got: {err}"
+        );
+        assert!(
+            err.contains(QUANT_PREFIX),
+            "the load error must name the offending tensor {QUANT_PREFIX}, got: {err}"
+        );
+    }
 }

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -128,6 +128,94 @@ pub(crate) fn fused_moe_max_dff_from(env: Option<&str>, metal_available: bool) -
         })
 }
 
+/// Bound a declared `group_size` / `bits` pair before a family-local expert
+/// loader stores it on a quantized expert plane (issue #958).
+///
+/// [`SwitchLinear::from_stacked_parts`] below carries this bound for every
+/// family that routes its experts through the shared loader. Eighteen other
+/// families keep their own quantized expert type instead (a local
+/// `SwitchLinear` / `SwitchGLU` / `ExpertLinear` / `QuantizedSwitchLinear`), and
+/// those types store the declared pair verbatim and hand it to `gather_qmm`,
+/// which reaches the same `w.shape(-1) * 32 / bits` division inside
+/// `extract_quantized_matmul_dims`. Because `gather_qmm` crosses the cxx bridge
+/// as `UniquePtr<MlxArray>` rather than `Result`, the resulting C++ throw is an
+/// uncatchable `std::terminate` at the first routed forward pass rather than a
+/// load error. See [`mlxcel_core::layers::validate_quantization_params`] for why
+/// the bound is a range rather than an allowlist of the widths MLX supports.
+///
+/// The check belongs here, at the point the pair is stored, rather than once at
+/// each family's model-level `from_weights`. A load-boundary check does not
+/// dominate these constructions: the pipeline stage executors
+/// (`distributed/pipeline/stage_executor/{glm4,deepseek_v3,llama4}.rs`), the
+/// `*StageModel::from_filtered_weights` entry points, the VLM text wrappers
+/// (`glm4v_moe`, `ernie4_5_moe_vl`, `loading/vlm_step3p7.rs`), `glm_moe_dsa` and
+/// `audio/qwen3_omni_moe/talker.rs` all build expert planes without ever calling
+/// the family's own model constructor, and three families build the quantized
+/// variant as a bare struct literal from a different module entirely. The pair
+/// also arrives from more than one config type per expert enum, so bounding the
+/// producer would not cover it either.
+///
+/// `prefix` names the offending tensor so the load error points at the weight
+/// rather than at the config alone.
+///
+/// Used by: Qwen3MoE, Qwen3VLMoE, DeepSeek, DeepSeekV2, DeepSeekV3, DeepSeekV32,
+///          GLM4MoE, GLM4MoELite, Ernie45MoE, Ernie45MoEVL, ExaoneMoE,
+///          HunyuanMoE, Llama4, NemotronH, Qwen3Next (and Qwen3.5 through it),
+///          Step3p5, GptOss, KimiLinear
+pub(crate) fn validate_expert_quantization_params(
+    prefix: &str,
+    group_size: i32,
+    bits: i32,
+) -> Result<(), String> {
+    mlxcel_core::layers::validate_quantization_params(group_size, bits)
+        .map_err(|e| format!("{prefix}: {e}"))
+}
+
+/// Insert one affine expert plane in the pre-stacked `switch_mlp` layout that
+/// mlx-community conversions ship: a `[experts, out, packed_in]` packed weight
+/// with `[experts, out, num_groups]` scales and zero points.
+///
+/// Shared by the per-family quantization-bound tests (issue #958) so each of
+/// them drives its own real expert loader over the same honest tensor layout,
+/// and the only thing that varies between the hostile case and its positive
+/// control is the declared `group_size` / `bits` pair.
+///
+/// Used by: the guard tests of every family listed on
+///          [`validate_expert_quantization_params`]
+#[cfg(test)]
+pub(crate) fn insert_stacked_quantized_expert_plane(
+    weights: &mut WeightMap,
+    prefix: &str,
+    experts: i32,
+    out: i32,
+    packed_in: i32,
+    num_groups: i32,
+) {
+    let plane = |last: i32, value: f32| {
+        let n = (experts * out * last) as usize;
+        mlxcel_core::from_slice_f32(&vec![value; n], &[experts, out, last])
+    };
+    weights.insert(format!("{prefix}.weight"), plane(packed_in, 0.0));
+    weights.insert(format!("{prefix}.scales"), plane(num_groups, 1.0));
+    weights.insert(format!("{prefix}.biases"), plane(num_groups, 0.0));
+}
+
+/// The `group_size` / `bits` pairs no tensor layout can describe, paired with
+/// the config field each one must be blamed on.
+///
+/// `bits` outside `1..=32` divides by zero or collapses the reconstructed input
+/// width to zero; a non-positive `group_size` makes the right-hand side of MLX's
+/// width comparison unmatchable. Every family's guard test walks this list so
+/// they cannot drift apart on which values count as hostile.
+#[cfg(test)]
+pub(crate) const HOSTILE_QUANT_PARAMS: [(i32, i32, &str); 5] = [
+    (64, 0, "bits"),
+    (64, -4, "bits"),
+    (64, 33, "bits"),
+    (0, 4, "group_size"),
+    (-64, 4, "group_size"),
+];
+
 /// Per-expert 3D linear layer (falls back to gather_mm for non-quantized models)
 /// Supports affine, mxfp4, nvfp4, and mxfp8 quantization modes.
 pub enum SwitchLinear {
@@ -1146,8 +1234,9 @@ mod tests {
     }
 
     /// Affine 4-bit expert planes in the pre-stacked `switch_mlp` layout that
-    /// mlx-community conversions ship: `[num_experts, out, in/8]` weights with
-    /// `[num_experts, out, in/group_size]` scales and zero points.
+    /// mlx-community conversions ship, as a standalone map. Thin wrapper over
+    /// the module-level [`super::insert_stacked_quantized_expert_plane`], which
+    /// the per-family guard tests share.
     fn stacked_quantized_experts(
         prefix: &str,
         experts: i32,
@@ -1155,14 +1244,15 @@ mod tests {
         packed_in: i32,
         num_groups: i32,
     ) -> WeightMap {
-        let plane = |last: i32, value: f32| {
-            let n = (experts * out * last) as usize;
-            mlxcel_core::from_slice_f32(&vec![value; n], &[experts, out, last])
-        };
         let mut weights = WeightMap::new();
-        weights.insert(format!("{prefix}.weight"), plane(packed_in, 0.0));
-        weights.insert(format!("{prefix}.scales"), plane(num_groups, 1.0));
-        weights.insert(format!("{prefix}.biases"), plane(num_groups, 0.0));
+        super::insert_stacked_quantized_expert_plane(
+            &mut weights,
+            prefix,
+            experts,
+            out,
+            packed_in,
+            num_groups,
+        );
         weights
     }
 

--- a/src/models/switch_layers.rs
+++ b/src/models/switch_layers.rs
@@ -132,16 +132,22 @@ pub(crate) fn fused_moe_max_dff_from(env: Option<&str>, metal_available: bool) -
 /// loader stores it on a quantized expert plane (issue #958).
 ///
 /// [`SwitchLinear::from_stacked_parts`] below carries this bound for every
-/// family that routes its experts through the shared loader. Eighteen other
-/// families keep their own quantized expert type instead (a local
-/// `SwitchLinear` / `SwitchGLU` / `ExpertLinear` / `QuantizedSwitchLinear`), and
-/// those types store the declared pair verbatim and hand it to `gather_qmm`,
-/// which reaches the same `w.shape(-1) * 32 / bits` division inside
+/// family that routes its experts through the shared loader. Seventeen families
+/// keep their own quantized expert type instead (a local `SwitchLinear` /
+/// `SwitchGLU` / `ExpertLinear` / `QuantizedSwitchLinear`), and those types
+/// store the declared pair verbatim and hand it to `gather_qmm`, which reaches
+/// the same `w.shape(-1) * 32 / bits` division inside
 /// `extract_quantized_matmul_dims`. Because `gather_qmm` crosses the cxx bridge
 /// as `UniquePtr<MlxArray>` rather than `Result`, the resulting C++ throw is an
 /// uncatchable `std::terminate` at the first routed forward pass rather than a
 /// load error. See [`mlxcel_core::layers::validate_quantization_params`] for why
 /// the bound is a range rather than an allowlist of the widths MLX supports.
+///
+/// KimiLinear is the one caller below that is not an expert plane: it keeps a
+/// private `MultiLinear` for MLA rather than using
+/// [`mlxcel_core::layers::MultiLinear`], so it does not inherit the bound that
+/// loader carries, and its stored pair reaches `quantized_matmul` on the same
+/// infallible bridge.
 ///
 /// The check belongs here, at the point the pair is stored, rather than once at
 /// each family's model-level `from_weights`. A load-boundary check does not

--- a/src/models/youtu_vl_lm_sanitize.rs
+++ b/src/models/youtu_vl_lm_sanitize.rs
@@ -80,6 +80,15 @@ pub fn sanitize_text_weights(
             let inferred_bits = (w_shape[w_shape.len() - 1] * 32) / kv_lora_rank;
             let inferred_gs = kv_lora_rank / s_shape[s_shape.len() - 1];
 
+            // The inferred pair is a quotient of a config field and a tensor
+            // axis, so it can still land outside anything MLX can describe, and
+            // `dequantize` crosses the cxx bridge as `UniquePtr<MlxArray>`
+            // rather than `Result`: a throw here would abort during weight
+            // sanitization rather than fail the load (issue #958).
+            mlxcel_core::layers::validate_quantization_params(inferred_gs, inferred_bits).map_err(
+                |e| format!("{prefix}.kv_b_proj: inferred quantization params are unusable: {e}"),
+            )?;
+
             unsafe {
                 mlxcel_core::dequantize(
                     &w,

--- a/src/models/youtu_vl_lm_sanitize.rs
+++ b/src/models/youtu_vl_lm_sanitize.rs
@@ -75,18 +75,17 @@ pub fn sanitize_text_weights(
                 )
             })?;
 
-            let w_shape = mlxcel_core::array_shape(&w);
-            let s_shape = mlxcel_core::array_shape(&s);
-            let inferred_bits = (w_shape[w_shape.len() - 1] * 32) / kv_lora_rank;
-            let inferred_gs = kv_lora_rank / s_shape[s_shape.len() - 1];
-
-            // The inferred pair is a quotient of a config field and a tensor
-            // axis, so it can still land outside anything MLX can describe, and
-            // `dequantize` crosses the cxx bridge as `UniquePtr<MlxArray>`
-            // rather than `Result`: a throw here would abort during weight
-            // sanitization rather than fail the load (issue #958).
-            mlxcel_core::layers::validate_quantization_params(inferred_gs, inferred_bits).map_err(
-                |e| format!("{prefix}.kv_b_proj: inferred quantization params are unusable: {e}"),
+            // Solve the packed pair from the shapes and bound it before it
+            // reaches `dequantize`. The shared helper also checks each divisor
+            // before dividing: `kv_lora_rank` is a config field and the scales
+            // axis is checkpoint data, so the naive form panics on a zero
+            // divisor and overflows i32 on a large packed axis, both before the
+            // bound could fire (issue #958).
+            let (inferred_gs, inferred_bits) = mlxcel_core::layers::infer_mla_quantization_params(
+                &mlxcel_core::array_shape(&w),
+                &mlxcel_core::array_shape(&s),
+                kv_lora_rank,
+                &format!("{prefix}.kv_b_proj"),
             )?;
 
             unsafe {

--- a/src/models/youtu_vl_lm_tests.rs
+++ b/src/models/youtu_vl_lm_tests.rs
@@ -183,3 +183,97 @@ fn kv_b_proj_decompose_returns_error_when_biases_missing() {
         "error message should identify the layer; got: {msg}"
     );
 }
+
+/// The MLA `kv_b_proj` pair is solved from `kv_lora_rank` and two tensor axes
+/// rather than declared, and every input is untrusted: `kv_lora_rank` comes from
+/// `config.json` and the axes from the checkpoint. Before issue #958 the naive
+/// arithmetic divided by both without checking them, so a `kv_lora_rank` of 0
+/// panicked on integer division and a solved pair outside anything MLX can
+/// describe reached `dequantize`, which crosses the cxx bridge as
+/// `UniquePtr<MlxArray>` rather than `Result` and therefore aborts during weight
+/// sanitization rather than failing the load.
+///
+/// This drives the real `sanitize_text_weights` rather than the shared helper
+/// directly, so the guard is exercised where a checkpoint reaches it. The
+/// assertions are on the returned `Result`, so a regression fails cleanly here
+/// rather than aborting the test binary.
+#[test]
+fn quantized_kv_b_proj_rejects_a_kv_lora_rank_no_packing_can_describe() {
+    // Honest affine 4-bit geometry for the positive control: the packed axis is
+    // kv_lora_rank / 8 and the scales axis is kv_lora_rank / group_size, so
+    // packed_in * 32 == bits * num_groups * group_size holds (2 * 32 == 4 * 1 * 16).
+    let build = |config: &YoutuTextConfig| {
+        let num_heads = config.num_attention_heads;
+        let head_dim = config.qk_nope_head_dim + config.v_head_dim;
+        let rows = (num_heads * head_dim) as i32;
+        let mut weights = WeightMap::new();
+        for layer_idx in 0..config.num_hidden_layers {
+            let prefix = format!("model.layers.{}.self_attn.kv_b_proj", layer_idx);
+            // UINT32, not FLOAT32: `dequantize` rejects any other packed dtype
+            // by throwing, and that throw is the uncatchable abort this guard
+            // exists to keep out of the forward path. A float fixture here would
+            // take the test binary down on the positive control.
+            weights.insert(
+                format!("{prefix}.weight"),
+                mlxcel_core::zeros(&[rows, 2], mlxcel_core::dtype::UINT32),
+            );
+            weights.insert(
+                format!("{prefix}.scales"),
+                mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
+            );
+            weights.insert(
+                format!("{prefix}.biases"),
+                mlxcel_core::zeros(&[rows, 1], mlxcel_core::dtype::FLOAT32),
+            );
+        }
+        weights
+    };
+
+    // Positive control first, so a guard that rejected every quantized
+    // kv_b_proj could not pass this test.
+    let honest = minimal_config();
+    let sanitized = match sanitize_text_weights(build(&honest), &honest) {
+        Ok(w) => w,
+        Err(e) => panic!("an honest quantized kv_b_proj must still sanitize: {e}"),
+    };
+    assert!(sanitized.contains_key("model.layers.0.self_attn.embed_q.weight"));
+
+    // A zero `kv_lora_rank` is Rust integer division by zero on the very first
+    // solve, so it has to be refused before the division rather than after.
+    let mut zero_rank = minimal_config();
+    zero_rank.kv_lora_rank = 0;
+    let err = sanitize_text_weights(build(&zero_rank), &zero_rank)
+        .err()
+        .unwrap_or_else(|| panic!("kv_lora_rank 0 must be refused, not divided by"));
+    assert!(err.contains("kv_lora_rank"), "unhelpful error: {err}");
+
+    // A large `kv_lora_rank` truncates the solved bit width to 0, which is the
+    // divisor MLX would then divide by.
+    let mut wide_rank = minimal_config();
+    wide_rank.kv_lora_rank = 4096;
+    let err = sanitize_text_weights(build(&wide_rank), &wide_rank)
+        .err()
+        .unwrap_or_else(|| panic!("a solved bit width of 0 must be refused"));
+    assert!(err.contains("bits"), "unhelpful error: {err}");
+
+    // A non-quantized kv_b_proj carries no packing, so the pair is never solved
+    // and a `kv_lora_rank` that no packing could describe must not gate it. The
+    // tensor is built at `wide_rank`'s own width so it still satisfies the
+    // separate shape cross-check below the solve, which is what would otherwise
+    // reject this for an unrelated reason.
+    let mut float_only = WeightMap::new();
+    let rows = (wide_rank.num_attention_heads * (wide_rank.qk_nope_head_dim + wide_rank.v_head_dim))
+        as i32;
+    for layer_idx in 0..wide_rank.num_hidden_layers {
+        float_only.insert(
+            format!("model.layers.{}.self_attn.kv_b_proj.weight", layer_idx),
+            mlxcel_core::zeros(
+                &[rows, wide_rank.kv_lora_rank as i32],
+                mlxcel_core::dtype::FLOAT32,
+            ),
+        );
+    }
+    if let Err(e) = sanitize_text_weights(float_only, &wide_rank) {
+        panic!("a float kv_b_proj must not be gated on quantization params: {e}");
+    }
+}


### PR DESCRIPTION
## Summary

#929 (PR #956) bounded the declared `quantization` pair at the two shared loaders, `reconcile_quantization_layout` and `SwitchLinear::from_stacked_parts`. The families that keep their own quantized expert type never reach either, so a config-derived `"bits": 0` was still stored verbatim and handed to `gather_qmm`, which reaches the same `w.shape(-1) * 32 / bits` division inside `extract_quantized_matmul_dims`. `gather_qmm`, `quantized_matmul` and `dequantize` cross the cxx bridge as `UniquePtr<MlxArray>` rather than `Result`, so the C++ throw is an uncatchable `std::terminate` at the first routed forward pass rather than a load error.

Every one of those call sites is now bounded at load.

## Approach: why the storage point rather than the load boundary

The issue asked me to evaluate whether a single call at each family's load boundary covers the same ground more cheaply. I traced it, and it does not. The bound goes at the point the pair is stored, and that choice is forced rather than stylistic:

- **The load boundary is duplicated in at least a dozen places.** The pipeline stage executors for glm4, glm4_moe_lite, deepseek_v3 and llama4 call `TransformerBlock::from_weights` / `DecoderLayer::from_weights` directly in a loop, never entering the family's `Model::from_weights`. `DeepSeekV32StageModel::from_filtered_weights`, `Qwen3NextStageModel::from_filtered_weights`, `Qwen35StageModel::from_filtered_weights` and `GptOssStageModel::from_filtered_weights` are second in-file boundaries that each re-derive `group_size` / `bits` independently. The VLM text wrappers `glm4v_moe`, `ernie4_5_moe_vl` and `loading/vlm_step3p7.rs` build expert planes through their own chains, and `glm_moe_dsa::to_dsv32_args` feeds a GLM config into the deepseek_v32 loader.
- **Three families build the quantized variant as a bare struct literal from a different module**, which no boundary check can reach at all: `qwen3_vl_moe.rs` builds `qwen3_moe::SwitchLinear::Quantized` directly, `ernie4_5_moe_vl.rs` builds `ernie4_5_moe::SwitchLinear::Quantized` directly, and `nemotron_h.rs` has no named constructor for `QuantizedSwitchLinear` at all.
- **The pair arrives from more than one config type per expert enum**, so bounding the producer would not have covered it either. `qwen3_next::SwitchLinear` is fed by `Qwen3NextConfig`, by `Qwen35Config` through `to_qwen3next_config`, and by a config synthesized from `Qwen3OmniSpeechConfig` in `audio/qwen3_omni_moe/talker.rs`.
- **The cost is roughly equal anyway.** There are about as many load boundaries as storage points, so the boundary version buys nothing in call-site count while requiring a whole-program reachability argument that a new `pub` caller silently invalidates.

Two of those config types also default to `group_size: 0, bits: 0` rather than 64/4 when no `quantization` block was inherited (`Qwen3VLMoeConfig` and `Ernie45MoeVlTextConfig`), which is the hostile pair itself, latent behind the fact that such a checkpoint currently has no `.scales`.

New `switch_layers::validate_expert_quantization_params(prefix, group_size, bits)` delegates to `mlxcel_core::layers::validate_quantization_params` and prefixes the tensor name, so every family reports the same bound with the offending plane named. Only the quantized arms are gated; a bf16 expert plane carries no packing and stays loadable at any declared pair.

## Should `QuantizedEmbedding::new` be fallible? Yes

`QuantizedEmbedding::new` and `QuantizedMultiLinear::new` now return `Result<Self, String>`. They are the only ways to build a quantized layer without going through `from_weights_with_mode`, and therefore without the reconciler and the bound it carries. A caller that hand-builds one is exactly the caller whose declared pair has never been looked at.

That is also why `mamba` / `mamba2` needed only a `?` rather than being routed through `from_weights_with_mode`. Routing them would not have been behavior-preserving: both take the table out of the map by `remove`, under either the `backbone.embeddings` or the `model.embed_tokens` spelling, so neither can address a single-prefix map loader; `from_weights_with_mode` additionally reconciles against the tensor shapes and stores the reconciled pair rather than the declared one, treats `.biases` as optional where mamba requires both, and would need the `.or_else()` prefix fallback re-expressed at the call site. Making `new` fallible fixes both families with one line each *and* closes the door for the next family, which routing them would not have done. `QuantizedMultiLinear::new` had no callers at all, so making it fallible was free and pre-emptive.

## Verified inventory versus the issue's scope list

The issue's list is accurate except for one entry, and it misses four call sites.

**Confirmed as listed** (17): `qwen3_moe`, `qwen3_vl_moe`, `deepseek`, `deepseek_v2`, `deepseek_v3`, `deepseek_v32`, `glm4_moe`, `glm4_moe_lite`, `ernie4_5_moe`, `exaone_moe`, `hunyuan_moe`, `llama4`, `nemotron_h`, `qwen3_next` (and `qwen3_5` through it), `step3p5`, `gpt_oss`, plus `mamba` / `mamba2`.

**Does not match**: `jamba`. Its `SwitchLinear` enum is `#[allow(dead_code)]` and the `Quantized` variant is never constructed anywhere in the tree; only `Regular` is built, at three sites. There is no constructor to bound and no reachable `gather_qmm`. Left unchanged and recorded here rather than given a guard with no call site.

**Missed by the issue** (4), all the same defect and all fixed here:

- `mlxcel_core::layers::QuantizedMultiLinear::from_weights` is a **shared** loader in mlxcel-core that stores the declared pair verbatim and hands it to `quantized_matmul` on every MLA forward, without ever calling the reconciler. It sits in exactly the blind spot `from_stacked_parts` occupied before #929, and it is reached by DeepSeek V3, DeepSeek V3.2, GLM4 MoE Lite and LongCat Flash NGram through their `embed_q` / `unembed_out`. This is the highest-value item in the diff: one fix covers four families that #956 and this issue both missed.
- `src/models/ernie4_5_moe_vl.rs` has its own `load_switch_linear` that does not call the `ernie4_5_moe` constructor the issue lists, so fixing that family alone would have left the VLM sibling open.
- `src/models/kimi_linear.rs` keeps a private `MultiLinear` (distinct from the mlxcel-core one) that feeds `quantized_matmul` directly.
- `longcat_flash_ngram::sanitize_weights` and `youtu_vl_lm_sanitize::sanitize_text_weights` derive a pair from `kv_lora_rank` and a tensor axis during MLA `kv_b_proj` decomposition and hand it to `dequantize`. Same uncatchable abort, during weight sanitization rather than at first forward. longcat's sanitizer becomes fallible for the check, a two-caller cascade.

## The gpt-oss case is real but not for the reason the issue gives

The issue says a hostile pair scoped to the expert prefix leaves the global defaults valid. The code is the mirror image of that: `MLPBlock::from_weights` reads `Quantization::defaults()` for the experts, **not** `quant_for`, so a per-prefix override on the expert prefix never reaches them. The gap is the other direction, and it is worse. The canonical `gpt-oss-20b-mxfp4` config carries valid per-prefix overrides for `model.embed_tokens`, the four attention projections and the router, with the mxfp4 expert parameters living in the top-level defaults. So a hostile top-level pair reaches the experts alone while every reconciler-guarded loader in the model sees a good per-prefix pair. Verified against the real config in `models/gpt-oss-20b-mxfp4/config.json`.

Handled two ways: the authoritative bound at `ExpertLinear::from_weights`, plus a family-level early diagnostic `ModelArgs::validate_quantization` that walks the top-level pair and every per-prefix override in one pass at both gpt_oss load boundaries. The test covers both directions.

## On scope: the issue's Scope section is incomplete, not wrong

Every family the issue names is real and every one except jamba got a guard. What the Scope section does not capture is that the same defect exists on a second axis it never looks at: the MLA `kv_b_proj` decomposition. Five sanitizers (DeepSeek V3, DeepSeek V3.2, KimiLinear, LongCat Flash NGram, Youtu-VL) each carry a byte-identical copy of arithmetic that solves a quantization pair from `kv_lora_rank` and a tensor axis and hands it straight to `dequantize`. That is the same uncatchable-abort class from the same untrusted `config.json`, differing only in that the pair is derived rather than declared.

It belongs in this PR rather than a follow-up for three reasons. First, four of the five files were already being modified here for their expert loaders, so splitting would have meant two PRs touching the same functions. Second, the first commit's guard on two of those sites was placed after the division it needed to protect, which is a defect this PR introduced and therefore has to fix. Third, the fix is a single shared helper that all five call, so landing it piecemeal would have left copies diverging mid-series.

What was deliberately NOT folded in is filed rather than left as an observation: #973 (the `mode` string is bounded nowhere and reaches `gather_qmm` as an unvalidated string, flagged independently by both reviewers), #974 (Jamba never builds a quantized expert plane at all, which is why the issue named it but there was nothing to guard), #975 (`deepseek::ModelArgs` silently drops an inherited `quantization` block), and #976 (mamba / mamba2 treat a scales-without-biases embedding as non-quantized).

## Review follow-ups applied

Two review passes over the first two commits found four things, all fixed in the third and fourth commits:

- **Three more MLA `kv_b_proj` sites had the identical defect and were missed.** `DeepSeekV3Model::sanitize_weights`, `DeepSeekV32Model::sanitize_weights` and `KimiLinearModel::sanitize_weights` each solve the packed pair from `kv_lora_rank` and a tensor axis and hand it to `dequantize`, exactly like the LongCat and Youtu sanitizers the first commit converted. There were five copies of that arithmetic, not two. All five now share `infer_mla_quantization_params`, and the three new ones cascade fallibility through `sanitize_weights_with_args` into `loading/vlm_kimi_vl.rs`, `loading/special.rs`, `models/glm_moe_dsa.rs` and the deepseek_v3 and glm_moe_dsa pipeline stage executors.
- **The bound was placed after the division it needed to protect.** `inferred_bits = (packed_in * 32) / kv_lora_rank` divides by a `config.json` field and `inferred_gs = kv_lora_rank / num_groups` by a checkpoint axis. Rust integer division by zero panics, so a `kv_lora_rank` of 0 or a zero-length scales axis took the process down before the guard could reject anything, and `packed_in * 32` wraps `i32` in release. The shared helper now checks each divisor before dividing, evaluates the multiply in `i64`, rejects a rank-0 tensor instead of indexing out of bounds, and additionally verifies the solved pair against MLX's own predicate, because both divisions truncate and an in-range pair is not yet a describable one.
- **`FusedQKVLinear::from_weights_separate_with_mode` is another unguarded shared loader.** It never calls the reconciler, and `infer_quantization_bits` early-returns the caller's `bits` unchanged whenever `group_size <= 0`, so a declared `(0, 0)` was stored verbatim on the fused `QuantizedWeight`. Shadowed in every current family by a sibling `UnifiedLinear` that sees the same pair and rejects it first, so this was not a live hole, but it is the same shape as the one #929 left open and it is one line.
- **The tests' SIGABRT claim was false and is corrected.** The comment in sixteen files said a regression would take the test binary down with SIGABRT. That is what happens in production; these tests assert on the load result and never run a forward pass, so a regression fails cleanly at the assertion. The wording would have misled whoever next debugs a failure here. The `QuantizedEmbedding::new` doc made a similar overclaim (the fallible signature does not make the bound impossible to skip, because the fields are `pub`) and now says so.

Also from review: the `MultiLinear` enum `Used by:` list gained LongCat Flash NGram, and `FusedQKVLinear::from_weights_separate_with_mode` had a stale list naming a Phi3 caller that does not exist while omitting eleven that do. Both corrected against grep.

A finalizer pass then found two more things, fixed in the sixth commit:

- **The five MLA sanitizers were covered only by the pure-helper unit test**, which contradicts this PR's own stated test philosophy. All five now have a test driving the real `sanitize_weights` / `sanitize_text_weights`. LongCat Flash NGram had no `#[cfg(test)]` block at all before this, and DeepSeek V3's inline module had no quantized-MLA case. One trap is worth recording: unlike the expert-plane tests, which stop at the loader's `Result`, these drive a sanitizer that actually evaluates the dequantize, so the packed fixture must be `UINT32`. A float fixture aborts the whole test binary with SIGABRT on the positive control, which is what the first draft of all five did and what running them caught. The reason is now recorded at each fixture.
- **`docs/adding-models.md` never mentioned the convention**, so the next family ported with a local quantized expert type would silently reintroduce the bug. It gains a `Quantization Parameter Bounds` section stating the rule and why the load boundary does not dominate, a table of what already carries the bound so a porter inherits it for free, and a checklist item pointing at it.

Both reviewers independently flagged that `quantization.mode` is bounded nowhere and reaches `gather_qmm` as an unvalidated string, which is the same abort class. That is a different config field and a different fix (an allowlist, which already exists at `gemma4::SUPPORTED_QUANT_SCHEMES` but is wired only into gemma4), so it is filed as a follow-up rather than folded in here.

## Test plan

Both acceptance criteria on testing hold, and the second one needs a correction to how the issue phrases it.

**Real load path, not a pure helper.** Every test calls the family's own loader (`SwitchLinear::from_weights`, `load_switch_linear`, `ExpertLinear::from_weights`, `Step3p5SwitchGLU::from_weights`, `MultiLinear::from_weights`) over a synthetic `WeightMap` carrying an honestly packed expert plane, so the guard is exercised at the point a real checkpoint reaches it. Four go further and drive the whole model constructor: `MambaModel::from_weights`, `Mamba2Model::from_weights` and `NemotronHModel::from_weights` (the last including its C++ model registration), plus the gpt_oss config walk over the real gpt-oss-20b-mxfp4 quantization shape.

**Positive control first, always.** Each test loads the honest pair before it tries any hostile one, and every test whose loader has a non-quantized branch additionally asserts that a bf16 plane with no `.scales` still loads under a hostile pair. A guard that rejected everything quantized, or that gated the float path, fails on those two assertions before it reaches the hostile loop.

The issue expects a regression to surface as a SIGABRT from the test binary. It does not, and that is better rather than worse: these tests assert on the load `Result` and never run a forward pass, so a lost guard fails cleanly at the assertion instead of aborting. SIGABRT is what happens in production, which is the thing being prevented. The doc comments that repeated the issue's phrasing were corrected in the fourth commit, because they would have misled whoever next debugs a failure here.

- [x] `cargo test --release --lib --features metal,accelerate quantization_params` (19 passed: the 18 new per-family guards plus the existing switch_layers one)
- [x] `cargo test --release --lib --features metal,accelerate models::gpt_oss` (3 passed, including the per-prefix config walk over the real gpt-oss-20b-mxfp4 quantization shape)
- [x] `cargo test --release --lib --features metal,accelerate models::ernie4_5_moe_vl` (5), `models::mamba` (8), `models::nemotron_h` (19)
- [x] `cargo test --release -p mlxcel-core --lib --features metal,accelerate layers::tests` (65 passed, including the two tests for the fallible by-hand constructors and the shared MultiLinear loader, plus the MLA divisor and overflow test)
- [x] Affected-family sweep, all green: `deepseek` (28), `deepseek_v2` (1), `deepseek_v3` (24), `deepseek_v32` (12), `glm4_moe` (7), `glm4_moe_lite` (1), `ernie4_5_moe` (6), `exaone_moe` (3), `hunyuan_moe` (1), `jamba` (4), `llama4` (1), `qwen3_next` (8), `qwen3_5` (5), `step3p5` (12), `qwen3_moe` (1), `qwen3_vl_moe` (2), `kimi_linear` (1), `longcat_flash_ngram`, `youtu_vl_lm` (3)
- [x] MoE regression sweep for the families this does NOT change, to confirm the shared-helper additions are inert for them: `switch_layers` (22), `mixtral`, `qwen2_moe`, `olmoe`, `phimoe` (5), `dots1` (9), `gemma4` (90), `minimax` (15), `bailing_moe` (42)
- [x] `cargo test --release --lib --features metal,accelerate kv_b_proj` (5 passed: one per MLA sanitizer, each driving the real `sanitize_weights` / `sanitize_text_weights` rather than the shared helper)
- [x] `cargo test --release --lib --features metal,accelerate models::` (774 passed, 0 failed), `loading::` (220), `distributed::` (1268)
- [x] Anti-vacuity check, run empirically rather than argued: the guard in `qwen3_moe::SwitchLinear::from_weights` was temporarily replaced with `let _ = validate_expert_quantization_params(..)` and the suite re-run. The test failed on exactly the intended assertion (`(group_size 64, bits 0) must be refused at load, not stored for gather_qmm` at `qwen3_moe_tests.rs:86`) rather than passing for some other reason, and passed again once the guard was restored. No hostile pair in `HOSTILE_QUANT_PARAMS` is rejected by any pre-existing check, so these tests detect a regression rather than merely accompanying one.
- [x] `cargo clippy --release --lib --tests --features metal,accelerate` clean
- [x] `cargo fmt --all -- --check`
- [ ] Real quantized checkpoint load, to confirm normal loading is unaffected. Not run here: the release binaries are not built in this session and the reference MoE checkpoints are large. Left for the follow-up validation pass, which should cover `gpt-oss-20b-mxfp4` (the per-prefix case), `deepseek-v2-lite-4bit` (the shared `QuantizedMultiLinear` MLA path), and one of `qwen3-30b-a3b-4bit` / `mixtral-8x7b-4bit` / `nemotron-h-30b-4bit`.

The pre-existing `multimodal::host_preprocessor::tests::xla_loader_keeps_text_and_unqualified_vlm_image_capability_false` failure on `main` is tracked as #966 and is unrelated to this change.

## Notes

Two adjacent findings turned up during the trace that are **not** fixed here, because both are separate defects rather than this one. Both are filed rather than left as observations, as #975 and #976 respectively:

- `deepseek::ModelArgs` has no `quantization` field, only flat top-level `group_size` / `bits`. The three DeepSeek-OCR loaders in `loading/vlm_deepseekocr.rs` inject the root `quantization` object into `language_config` before deserializing, so serde drops it and `group_size()` / `bits()` silently fall back to 64/4 regardless of what the checkpoint declares. `DeepSeekModel::load` has the same shape. The contrast is `vlm_deepseek_vl2.rs`, which does the identical inheritance into `deepseek_v2::ModelArgs` and works because that config has the nested field.
- `mamba` / `mamba2` treat an embedding table with `.scales` but no `.biases` as non-quantized and fall through to `Embedding::new`, which would read packed uint32 data as a float table. Only reachable for a block-float embedding export, which no current mamba checkpoint ships.

Closes #958





