### PR TITLE
fix(server): enforce disaggregated router chat guards (#979)

### DIFF
--- a/src/server/router_front.rs
+++ b/src/server/router_front.rs
@@ -634,6 +634,23 @@ async fn route_chat(state: Arc<RouterState>, request: ChatCompletionRequest) -> 
         return Ok(resp);
     }
 
+    // The router and single-node chat fronts share these guards so invalid
+    // tool choices and oversized tool arrays cannot reach template rendering.
+    if let Err(message) = super::routes::chat::validate_chat_tool_inputs(&request) {
+        return Ok(ErrorResponse::new(message, "invalid_request_error").into_response());
+    }
+
+    // PrefillRequestFrame cannot carry a compiled structured-output
+    // constraint to the decode node. Reject rather than return unconstrained
+    // output for a request that explicitly asked for structured output.
+    if request.response_format.is_some() {
+        return Ok(ErrorResponse::new(
+            "the disaggregated router does not support response_format (structured output) on /v1/chat/completions",
+            "invalid_request_error",
+        )
+        .into_response());
+    }
+
     // Render the chat template and reject multimodal requests (the
     // disaggregated path is text-only for pool-backed Fp16 families).
     let prepared = super::chat_request::prepare_chat_request_with_cache(

--- a/src/server/router_front_tests.rs
+++ b/src/server/router_front_tests.rs
@@ -25,6 +25,163 @@
 
 use super::*;
 
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use crate::distributed::tcp_transport::TcpTransportConfig;
+
+async fn router_test_state() -> Arc<RouterState> {
+    let transport = Arc::new(
+        TcpTransport::bind(TcpTransportConfig {
+            bind_address: "127.0.0.1:0".to_string(),
+            ..TcpTransportConfig::default()
+        })
+        .await
+        .expect("bind router test transport"),
+    );
+    let reply_to = transport.local_addr().expect("router transport address");
+    let config = ServerConfig {
+        prefill_peers: vec!["127.0.0.1:9".parse().expect("prefill address")],
+        ..ServerConfig::default()
+    };
+
+    Arc::new(
+        RouterState::build(
+            Arc::new(config),
+            transport,
+            reply_to,
+            Arc::new(ChatTemplateProcessor::with_template(
+                "{% for message in messages %}{{ message.content }}{% endfor %}".to_string(),
+            )),
+            Arc::new(MlxcelTokenizer::stub()),
+        )
+        .expect("build router test state"),
+    )
+}
+
+async fn post_router_json(path: &str, body: Value) -> Response {
+    create_router_app(router_test_state().await)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&body).expect("serialize request"),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("router response")
+}
+
+async fn error_message(response: Response) -> String {
+    let bytes = to_bytes(response.into_body(), 64 * 1024)
+        .await
+        .expect("read response body");
+    let body: Value = serde_json::from_slice(&bytes).expect("JSON error response");
+    body["error"]["message"]
+        .as_str()
+        .expect("error message")
+        .to_string()
+}
+
+fn chat_request() -> Value {
+    json!({
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hello"}]
+    })
+}
+
+#[tokio::test]
+async fn router_chat_rejects_response_format_before_rendering() {
+    let mut body = chat_request();
+    body["response_format"] = json!({
+        "type": "json_schema",
+        "json_schema": {
+            "name": "answer",
+            "strict": true,
+            "schema": {"type": "object"}
+        }
+    });
+
+    let response = post_router_json("/v1/chat/completions", body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        error_message(response).await,
+        "the disaggregated router does not support response_format (structured output) on /v1/chat/completions"
+    );
+}
+
+#[tokio::test]
+async fn router_chat_rejects_more_than_max_tools_before_rendering() {
+    let mut body = chat_request();
+    body["tools"] = Value::Array(
+        (0..=super::super::routes::chat::MAX_TOOLS)
+            .map(|i| {
+                json!({
+                    "type": "function",
+                    "function": {"name": format!("tool_{i}")}
+                })
+            })
+            .collect(),
+    );
+
+    let response = post_router_json("/v1/chat/completions", body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        error_message(response).await,
+        "Too many tools: 129. Maximum allowed is 128."
+    );
+}
+
+#[tokio::test]
+async fn router_chat_rejects_invalid_tool_choice_before_rendering() {
+    let mut body = chat_request();
+    body["tool_choice"] = json!("sometimes");
+
+    let response = post_router_json("/v1/chat/completions", body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        error_message(response).await,
+        "Invalid tool_choice value: 'sometimes'. Must be 'auto', 'none', 'required', or a function object."
+    );
+}
+
+#[tokio::test]
+async fn router_completion_existing_unsupported_option_guards_are_unchanged() {
+    let cases = [
+        (
+            json!({"model": "test-model", "prompt": "hello", "logprobs": 1}),
+            "the disaggregated router does not support logprobs on /v1/completions",
+        ),
+        (
+            json!({
+                "model": "test-model",
+                "prompt": "hello",
+                "response_format": {"type": "json_schema"}
+            }),
+            "the disaggregated router does not support response_format (structured output) on /v1/completions",
+        ),
+        (
+            json!({
+                "model": "test-model",
+                "prompt": "hello",
+                "thinking_budget_tokens": 32
+            }),
+            "the disaggregated router does not support reasoning/thinking budgets on /v1/completions",
+        ),
+    ];
+
+    for (body, expected_message) in cases {
+        let response = post_router_json("/v1/completions", body).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_message(response).await, expected_message);
+    }
+}
+
 #[test]
 fn text_only_router_rejects_declared_media_even_when_resolution_drops_it() {
     let invalid_image = super::super::media::MediaRequestMetadata::new(1, 0, 0, 0, 0, 0);

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -256,34 +256,10 @@ pub async fn chat_completions(
         .into_response();
     }
 
-    // Validate tool_choice values
-    if let Some(ref tc) = request.tool_choice {
-        match tc {
-            crate::server::types::request::ToolChoice::Mode(mode) => {
-                if !["auto", "none", "required"].contains(&mode.as_str()) {
-                    return ErrorResponse::new(
-                        format!("Invalid tool_choice value: '{mode}'. Must be 'auto', 'none', 'required', or a function object."),
-                        "invalid_request_error",
-                    )
-                    .into_response();
-                }
-            }
-            crate::server::types::request::ToolChoice::Specific(_) => {}
-        }
-    }
-
-    // Enforce tools array size limit to prevent DoS via template rendering
-    if let Some(ref tools) = request.tools
-        && tools.len() > MAX_TOOLS
-    {
-        return ErrorResponse::new(
-            format!(
-                "Too many tools: {}. Maximum allowed is {MAX_TOOLS}.",
-                tools.len()
-            ),
-            "invalid_request_error",
-        )
-        .into_response();
+    // Keep tool validation shared with the disaggregated router front so both
+    // paths reject invalid and oversized requests before template rendering.
+    if let Err(message) = validate_chat_tool_inputs(&request) {
+        return ErrorResponse::new(message, "invalid_request_error").into_response();
     }
 
     // validate thinking_budget_tokens early so malformed values
@@ -1011,10 +987,33 @@ pub(crate) fn validate_xtc_params(
 }
 
 /// Maximum number of tools allowed in a single request.
-///
-/// Enforced in `chat_completions()` to prevent DoS via large tool definitions
-/// being rendered through the Jinja2 chat template.
 pub(crate) const MAX_TOOLS: usize = 128;
+
+/// Validate the chat tool fields shared by single-node and router fronts.
+///
+/// Both callers run this before chat-template rendering so an invalid
+/// `tool_choice` or oversized tool list cannot reach Jinja2. Error strings are
+/// intentionally kept byte-identical to the original single-node guards.
+pub(crate) fn validate_chat_tool_inputs(request: &ChatCompletionRequest) -> Result<(), String> {
+    if let Some(crate::server::types::request::ToolChoice::Mode(mode)) = &request.tool_choice
+        && !["auto", "none", "required"].contains(&mode.as_str())
+    {
+        return Err(format!(
+            "Invalid tool_choice value: '{mode}'. Must be 'auto', 'none', 'required', or a function object."
+        ));
+    }
+
+    if let Some(tools) = &request.tools
+        && tools.len() > MAX_TOOLS
+    {
+        return Err(format!(
+            "Too many tools: {}. Maximum allowed is {MAX_TOOLS}.",
+            tools.len()
+        ));
+    }
+
+    Ok(())
+}
 
 /// Suffixes that a rendered chat prompt uses to leave the model inside an
 /// open thinking block. Each corresponds to a family-specific reasoning


### PR DESCRIPTION
## Summary

Reject unsupported or unsafe chat options at the disaggregated router boundary before template rendering, while sharing tool validation with the single-node chat route to prevent future drift.

## What changed

- Share byte-identical tool-choice and tool-count validation between single-node and disaggregated chat fronts.
- Reject response_format on /v1/chat/completions because the prefill/decode wire protocol cannot carry the compiled constraint.
- Add model-free HTTP route tests for all three chat guards and the unchanged completions guards for logprobs, structured output, and thinking budgets.

## Test plan

- [x] cargo test --lib server::router_front::tests::router_
- [x] cargo test --lib server::routes::chat::tests::tools_
- [x] cargo check --lib --tests
- [x] cargo clippy --lib --tests -- -D warnings
- [x] cargo fmt --all -- --check

Closes #979