### PR TITLE
fix: stop generation when structured matcher completes (#978)

### DIFF
--- a/src/server/batch/scheduler.rs
+++ b/src/server/batch/scheduler.rs
@@ -2400,19 +2400,23 @@ impl BatchScheduler {
 
     /// advance the matcher state by the just-sampled token.
     ///
-    /// Returns `Ok(())` on success, `Err(msg)` when `consume_token` fails or
-    /// the matcher is in an error state. The caller transitions the sequence
-    /// to `Finished(Error(msg))` on error.
+    /// Returns `Ok(true)` when the consumed token completes the structured
+    /// output, `Ok(false)` when decoding must continue, and `Err(msg)` when
+    /// `consume_token` fails or the matcher is in an error state. The caller
+    /// transitions the sequence to `Finished(Stop)` on completion or
+    /// `Finished(Error(msg))` on error.
     fn consume_structured_token(
         constraint: &std::sync::Arc<
             std::sync::Mutex<crate::server::structured::StructuredOutputConstraint>,
         >,
         token: i32,
-    ) -> Result<(), String> {
+    ) -> Result<bool, String> {
         let mut guard = constraint
             .lock()
             .map_err(|e| format!("structured-output constraint poisoned: {e}"))?;
-        guard.consume_token(token).map_err(|e| e.to_string())
+        guard
+            .consume_token_and_check_stopped(token)
+            .map_err(|e| e.to_string())
     }
 
     /// send a clean SSE error event and transition the sequence
@@ -5542,22 +5546,27 @@ impl BatchScheduler {
         // If consume_token errors, transition the sequence to Finished(Error)
         // and surface a clean SSE error event rather than leaking
         // non-conforming output.
-        if let Some(constraint) = seq.structured.clone()
-            && let Err(msg) = Self::consume_structured_token(&constraint, sampled_first_token)
-        {
-            let _ = seq
-                .response_tx
-                .send(GenerateEvent::Error(format!("structured output: {msg}")));
-            if let Err(err) = seq
-                .state
-                .transition_to(SequenceState::Finished(FinishReason::Error(msg)))
-            {
-                tracing::error!("State transition error: {err}");
+        let structured_stopped = if let Some(constraint) = seq.structured.clone() {
+            match Self::consume_structured_token(&constraint, sampled_first_token) {
+                Ok(stopped) => stopped,
+                Err(msg) => {
+                    let _ = seq
+                        .response_tx
+                        .send(GenerateEvent::Error(format!("structured output: {msg}")));
+                    if let Err(err) = seq
+                        .state
+                        .transition_to(SequenceState::Finished(FinishReason::Error(msg)))
+                    {
+                        tracing::error!("State transition error: {err}");
+                    }
+                    self.prompt_cache_seq_ctx.remove(&seq.seq_id);
+                    self.release_sequence_caches(seq.seq_id);
+                    return;
+                }
             }
-            self.prompt_cache_seq_ctx.remove(&seq.seq_id);
-            self.release_sequence_caches(seq.seq_id);
-            return;
-        }
+        } else {
+            false
+        };
 
         // thinking-budget override. Qwen3 chat templates prime
         // `<think>\n`, so the first prefill-completion token is already
@@ -5637,10 +5646,17 @@ impl BatchScheduler {
             let _ = seq.response_tx.send(event);
         }
 
-        if seq.generated_tokens.len() >= seq.max_tokens {
+        let prefill_finish_reason = if structured_stopped {
+            Some(FinishReason::Stop)
+        } else if seq.generated_tokens.len() >= seq.max_tokens {
+            Some(FinishReason::Length)
+        } else {
+            None
+        };
+        if let Some(finish_reason) = prefill_finish_reason {
             if let Err(err) = seq
                 .state
-                .transition_to(SequenceState::Finished(FinishReason::Length))
+                .transition_to(SequenceState::Finished(finish_reason))
             {
                 tracing::error!("State transition error: {err}");
             }
@@ -5662,7 +5678,7 @@ impl BatchScheduler {
                 prompt_tokens = seq.prompt_tokens.len(),
                 cached_tokens = cached,
                 generation_time_ms = result.generation_time_ms,
-                "prompt-cache: request completed (max-tokens): \
+                "prompt-cache: request completed during prefill: \
                  cached={}/{} prompt tokens, total {}ms",
                 cached,
                 seq.prompt_tokens.len(),
@@ -6539,16 +6555,21 @@ impl BatchScheduler {
             // If `consume_token` fails (matcher hit an error state),
             // transition the sequence to `Finished(Error)` and skip
             // emission so non-conforming output never reaches the client.
-            if let Some(constraint) = constraint_clone
-                && let Err(msg) = Self::consume_structured_token(&constraint, sampled_token)
-            {
-                Self::abort_sequence_with_error(
-                    self.active_batch.get_mut(seq_id),
-                    "structured output",
-                    &msg,
-                );
-                continue;
-            }
+            let structured_stopped = if let Some(constraint) = constraint_clone {
+                match Self::consume_structured_token(&constraint, sampled_token) {
+                    Ok(stopped) => stopped,
+                    Err(msg) => {
+                        Self::abort_sequence_with_error(
+                            self.active_batch.get_mut(seq_id),
+                            "structured output",
+                            &msg,
+                        );
+                        continue;
+                    }
+                }
+            } else {
+                false
+            };
 
             let seq = match self.active_batch.get_mut(seq_id) {
                 Some(s) => s,
@@ -6580,7 +6601,16 @@ impl BatchScheduler {
                 let _ = seq.response_tx.send(event);
             }
 
-            if seq.generated_tokens.len() >= seq.max_tokens
+            if structured_stopped
+                && let Err(err) = seq
+                    .state
+                    .transition_to(SequenceState::Finished(FinishReason::Stop))
+            {
+                tracing::error!("State transition error: {err}");
+            }
+
+            if !seq.state.is_finished()
+                && seq.generated_tokens.len() >= seq.max_tokens
                 && let Err(err) = seq
                     .state
                     .transition_to(SequenceState::Finished(FinishReason::Length))
@@ -6884,16 +6914,21 @@ impl BatchScheduler {
         // advance the matcher state with the *pre-override*
         // sampled token. See the parallel comment in
         // `execute_batched_decode` for why this must not be `token_val`.
-        if let Some(constraint) = constraint_clone
-            && let Err(msg) = Self::consume_structured_token(&constraint, sampled_token)
-        {
-            Self::abort_sequence_with_error(
-                self.active_batch.get_mut(seq_id),
-                "structured output",
-                &msg,
-            );
-            return;
-        }
+        let structured_stopped = if let Some(constraint) = constraint_clone {
+            match Self::consume_structured_token(&constraint, sampled_token) {
+                Ok(stopped) => stopped,
+                Err(msg) => {
+                    Self::abort_sequence_with_error(
+                        self.active_batch.get_mut(seq_id),
+                        "structured output",
+                        &msg,
+                    );
+                    return;
+                }
+            }
+        } else {
+            false
+        };
 
         let seq = match self.active_batch.get_mut(seq_id) {
             Some(s) => s,
@@ -6925,7 +6960,16 @@ impl BatchScheduler {
             let _ = seq.response_tx.send(event);
         }
 
-        if seq.generated_tokens.len() >= seq.max_tokens
+        if structured_stopped
+            && let Err(err) = seq
+                .state
+                .transition_to(SequenceState::Finished(FinishReason::Stop))
+        {
+            tracing::error!("State transition error: {err}");
+        }
+
+        if !seq.state.is_finished()
+            && seq.generated_tokens.len() >= seq.max_tokens
             && let Err(err) = seq
                 .state
                 .transition_to(SequenceState::Finished(FinishReason::Length))

--- a/src/server/structured.rs
+++ b/src/server/structured.rs
@@ -425,6 +425,20 @@ impl StructuredOutputConstraint {
         Ok(())
     }
 
+    /// Consume one sampled token and report whether it completes the grammar.
+    ///
+    /// Scheduler call sites use this combined operation so a terminal matcher
+    /// becomes a normal stop immediately after its schema-closing token. This
+    /// avoids attempting another decode step, where a stopped matcher has no
+    /// mask to apply.
+    pub fn consume_token_and_check_stopped(
+        &mut self,
+        token: i32,
+    ) -> Result<bool, StructuredOutputError> {
+        self.consume_token(token)?;
+        Ok(self.is_stopped())
+    }
+
     /// Returns `true` when the matcher has reached a terminal accepting state.
     /// Once true, subsequent tokens would either be EOS or cause an error.
     pub fn is_stopped(&self) -> bool {
@@ -745,9 +759,8 @@ pub fn apply_structured_mask_to_logits(
             // silently emitting an arbitrary token.
             return Err(StructuredOutputError::Matcher(
                 "structured-output matcher returned an empty mask: \
-                 no token can extend the partial output without violating \
-                 the schema. The model is stuck — this is usually a sign that \
-                 the schema is too restrictive for the supplied prompt."
+                 no matcher-allowed token is reachable in the model's logits \
+                 vocabulary for the current constrained-decoding state."
                     .to_string(),
             ));
         }

--- a/tests/structured_outputs.rs
+++ b/tests/structured_outputs.rs
@@ -20,11 +20,51 @@
 //! compilation or the per-step `compute_mask` / `consume_token` plumbing
 //! that the scheduler relies on for constrained decoding.
 //!
-//! End-to-end tests against a real model live in
-//! `tests/structured_outputs_real_model.rs` (gated behind a fixture path
-//! environment variable so CI can opt in only when a model is available).
+//! Real-model checks in this file are ignored unless their local fixtures are
+//! available; one of them exercises the complete `/v1/chat/completions` path.
 
+mod common;
+
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use common::{repo_binary_path, repo_model_dir};
 use serde_json::json;
+
+fn reserve_http_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_server_health(client: &reqwest::Client, base_url: &str) {
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        if let Ok(response) = client.get(format!("{base_url}/health")).send().await
+            && response.status().is_success()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    panic!("mlxcel-server did not become healthy at {base_url}");
+}
+
+fn spawn_test_server(args: &[&str]) -> Child {
+    Command::new(repo_binary_path("mlxcel-server"))
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mlxcel-server")
+}
+
+fn stop_test_server(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
 
 /// Build a byte-level HuggingFace tokenizer from a precomputed JSON
 /// representation. Hermetic (no external file dependency) and small enough
@@ -203,6 +243,62 @@ fn matcher_consume_then_recompute_succeeds() {
         .expect("post-consume mask must be available");
 }
 
+#[test]
+fn long_uniform_integer_array_reaches_a_clean_terminal_state() {
+    let hf = build_byte_level_tokenizer();
+    let mlxcel = mlxcel_tokenizer_from_hf(hf);
+    let constraint = mlxcel::server::structured::build_json_schema_constraint(
+        &mlxcel,
+        json!({
+            "type": "object",
+            "properties": {
+                "values": {
+                    "type": "array",
+                    "items": {"type": "integer"}
+                }
+            },
+            "required": ["values"],
+            "additionalProperties": false
+        }),
+    )
+    .expect("unbounded integer-array schema compiles");
+
+    let output = serde_json::to_string(&json!({"values": vec![7; 40]}))
+        .expect("uniform-array fixture serializes");
+    let mut guard = constraint.lock().expect("uncontended");
+    let vocab_size = guard.vocab_size();
+    let logits = mlxcel_core::from_slice_f32(&vec![0.0f32; vocab_size], &[1, vocab_size as i32]);
+
+    for (step, token) in output.bytes().enumerate() {
+        assert!(
+            !guard.is_stopped(),
+            "matcher stopped before byte {step} of the schema-conforming output"
+        );
+        let masked = mlxcel::server::structured::apply_structured_mask_to_logits(
+            &mut guard, &logits, vocab_size,
+        )
+        .unwrap_or_else(|err| panic!("mask failed at byte {step} ({token:#04x}): {err}"));
+        let host = read_f32_array_to_vec(&masked);
+        assert!(
+            host[token as usize].is_finite(),
+            "schema-conforming byte {step} ({token:#04x}) was masked out"
+        );
+        let stopped = guard
+            .consume_token_and_check_stopped(token as i32)
+            .unwrap_or_else(|err| panic!("consume failed at byte {step} ({token:#04x}): {err}"));
+        assert_eq!(
+            stopped,
+            step + 1 == output.len(),
+            "completion signal changed at byte {step}"
+        );
+    }
+
+    assert!(
+        guard.is_stopped(),
+        "the matcher must report completion after the closing object token so the scheduler can finish without applying another empty mask"
+    );
+}
+
 /// End-to-end test against a real local model. Constrains generation to a
 /// simple JSON schema and verifies the resulting output parses back as JSON
 /// matching the schema's required keys.
@@ -290,6 +386,97 @@ fn end_to_end_constrained_chat_completion_emits_schema_conforming_json() {
     assert!(
         ["forest", "desert", "ocean", "urban", "unknown"].contains(&habitat),
         "habitat must match enum, got {habitat}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires local Gemma 4 weights and the mlxcel-server binary"]
+async fn chat_completions_long_uniform_array_succeeds_end_to_end() {
+    let model_dir = repo_model_dir("gemma-4-12b-it-4bit");
+    let binary = repo_binary_path("mlxcel-server");
+    if !model_dir.exists() || !binary.exists() {
+        eprintln!(
+            "skipping: model or server binary missing (model={}, binary={})",
+            model_dir.display(),
+            binary.display()
+        );
+        return;
+    }
+
+    let port = reserve_http_port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let port_arg = port.to_string();
+    let model_arg = model_dir.to_string_lossy().to_string();
+    let mut child = spawn_test_server(&[
+        "--model",
+        &model_arg,
+        "--alias",
+        "issue-978",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        &port_arg,
+        "--no-warmup",
+    ]);
+
+    let client = reqwest::Client::new();
+    wait_for_server_health(&client, &base_url).await;
+    let response = client
+        .post(format!("{base_url}/v1/chat/completions"))
+        .json(&json!({
+            "model": "issue-978",
+            "messages": [{
+                "role": "user",
+                "content": "Return the values array containing the number 7 repeated 40 times."
+            }],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "vals",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "values": {
+                                "type": "array",
+                                "items": {"type": "integer"}
+                            }
+                        },
+                        "required": ["values"],
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "temperature": 0,
+            "seed": 42,
+            "max_tokens": 400,
+            "max_pattern_size": 0,
+            "stream": false
+        }))
+        .send()
+        .await
+        .expect("send structured chat request");
+    let status = response.status();
+    let body = response.text().await.expect("read chat response");
+    stop_test_server(&mut child);
+
+    assert!(
+        status.is_success(),
+        "chat request failed ({status}): {body}"
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_str(&body).expect("chat response is valid JSON");
+    let content = envelope["choices"][0]["message"]["content"]
+        .as_str()
+        .expect("chat response has assistant content");
+    let generated: serde_json::Value =
+        serde_json::from_str(content).expect("assistant content is valid JSON");
+    let values = generated["values"]
+        .as_array()
+        .expect("assistant content has a values array");
+    assert_eq!(values.len(), 40, "assistant returned: {content}");
+    assert!(
+        values.iter().all(|value| value.as_i64() == Some(7)),
+        "assistant returned: {content}"
     );
 }
 


### PR DESCRIPTION
## Summary

Stop structured generation as soon as the matcher reaches its terminal accepting state, preserving the schema-closing token instead of attempting one more decode step and surfacing an empty-mask server error.

## What changed

- Return the matcher completion state from token consumption and handle it as `FinishReason::Stop` in prefill, batched decode, and sequential decode.
- Replace the misleading empty-mask message with engine-state wording that does not blame the caller schema.
- Cover a 40-element uniform integer array through the real mask/consume path and the full Gemma 4 `/v1/chat/completions` route.

## Test plan

- [x] `cargo test --test structured_outputs`
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo build --bin mlxcel-server --features cuda`
- [x] `cargo test --features cuda --test structured_outputs chat_completions_long_uniform_array_succeeds_end_to_end -- --ignored --exact --nocapture`

Closes #978
