### PR TITLE
feat(core): fused paged-attention decode v2 with CSR page table and cross-CTA split-KV

### DIFF
--- a/docs/adr/0001-paged-attention-gather-vs-fused-kernel.md
+++ b/docs/adr/0001-paged-attention-gather-vs-fused-kernel.md
@@ -178,6 +178,16 @@ Retire `paged_decode_attention_pooled` and `select_pooled_paged_dispatch` (with 
 
 #634 ports the fused kernel (`src/lib/mlx-cpp/turbo/paged_attention.cpp`) from Metal-only `mx.fast.metal_kernel` to a `mx.fast.cuda_kernel` body with the same split-K flash-decoding scheme and grid geometry; the reduction changes from `simd_sum` to a `__shfl_xor_sync` butterfly all-reduce. The Metal-measured batch>=4/ctx<=4096 gate above does not carry over: on CUDA the fused kernel's win grows with context rather than losing it, so `select_pooled_paged_dispatch` dispatches native for any single-slab layer (any batch, any context) and still declines multi-slab layers per the #235 constraint. The entry point stays the library-only surface this ADR retired above; #634 does not reopen server wiring. See `docs/benchmark_results/paged-attention-cuda-port-gb10-2026-07-10.md` for the GB10 kernel A/B and parity numbers.
 
+## Addendum (2026-07-31): paged decode v2 (#898)
+
+Both the "what reopens this" bullets above are about the same root cause: the v1 kernel splits KV *inside* one threadgroup, so one CTA serves one `(batch, query head)` pair no matter how long the context is. Parallelism does not grow with context, which is why the win island is confined to short contexts and why the single-slab constraint bites.
+
+Issue #898 lands "paged decode v2" as a library capability that attacks the first cause. KV is split across CTAs instead: each request's page range is cut into chunks of `pages_per_chunk` pages, one CTA per `(chunk, kv head, q-head group)` produces an online-softmax partial, and a generic variable-length merge kernel combines the partials. Parallelism becomes `num_chunks * kv_heads * q_groups` and grows with context. The block table becomes a CSR view (`indices` / `indptr` / `last_page_len`, plus a `first_page_offset` extension for sliding-window sequences that start mid-page), so there is no gather pre-pass and one launch covers the whole batch. A host-side plan binary-searches the chunk size against an occupancy-derived CTA target and caches the flat index arrays across decode steps.
+
+Scope of #898: library only. `MLXCEL_PAGED_ATTENTION_V2=1` selects it inside `PagedBlockPool::paged_decode_fused`; with the variable unset nothing changes and v1 remains the only path any caller reaches. The single-slab constraint from #235 is unchanged, so v2 does not by itself reopen the wire-in question, and the correctness harness (`examples/paged_decode_v2_correctness.rs`) drives the kernels against a hand-built page table for that reason. Production dispatch is issue #899, the three-way performance comparison is in `examples/page_gather_microbench.rs` (gather vs fused v1 vs fused v2), and the merge kernel is reused unchanged by the cascade-attention issue #903.
+
+Correctness on an M1 Ultra: 68 configurations against the gather-then-SDPA reference across head dims 64/128, GQA 1/4/8, page sizes 16/32/64, contexts 512 to 32768, and batches 1/4/8, worst relative deviation 5.2e-4 against a 2e-2 tolerance.
+
 ## References
 
 - Epic #116, unified KV cache.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,7 +126,9 @@ Release builds use `panic = "unwind"` (issue #375), so the deliberate audio work
   called through the C++ bridge. Each one carries a Metal JIT source and, where
   ported, a CUDA counterpart selected at runtime by
   `mlx::core::metal::is_available()`: TurboQuant Sparse-V and delegated SDPA,
-  paged-attention decode, and Gumbel-max sampling.
+  paged-attention decode (v1, plus the v2 cross-CTA split-KV and merge kernels
+  driven from `src/lib/mlxcel-core/src/paged_v2/` and selected by
+  `MLXCEL_PAGED_ATTENTION_V2=1`), and Gumbel-max sampling.
 - CUDA kernel behavior is mostly inherited from MLX; `mlxcel` passes the CUDA
   architecture list through `MLX_CUDA_ARCHITECTURES` at build time.
 

--- a/docs/benchmark_results/paged-decode-v2-m1ultra-2026-07-31.md
+++ b/docs/benchmark_results/paged-decode-v2-m1ultra-2026-07-31.md
@@ -1,0 +1,122 @@
+# Fused paged decode v2: Apple M1 Ultra, 2026-07-31
+
+Validation run for issue #898 (epic #909). Three-way comparison of the production
+gather-then-SDPA path, the fused v1 kernel, and the new fused v2 kernel.
+
+**Both required outcomes are met.** v2 is at or above v1 across the sweep, and it
+beats gather-then-SDPA at both ADR-0001 trigger points. One cell outside those
+trigger points goes the other way and is called out below, because it constrains
+the dispatch policy in issue #899.
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Hardware | Apple M1 Ultra, 20 cores (16P + 4E), 128 GB unified memory |
+| OS | macOS 26.5.2 (Darwin 25.5.0) |
+| Backend | Metal, f16 KV pool |
+| mlxcel | 0.4.3, branch `feature/issue-898-paged-decode-v2`, base `f0ee1046` |
+| MLX pin | `b7c3dd6d27f45b5365b08a840310187dc503f1db` |
+| Harness | `examples/page_gather_microbench.rs`, warmup 10, iters 30, warm mode |
+| Geometry | head_dim 128, 32 q heads, 8 kv heads (GQA 4), block_size 32 |
+| Load average | 3.5 to 3.9 during the sweep |
+
+CUDA was not available. The CUDA JIT bodies are structural transliterations that
+have never been compiled or executed.
+
+## Method
+
+batch {1, 4, 8} x context {1024, 4096, 16384, 32768}, three repetitions of the
+full sweep. Medians are reported; the per-cell spread across repetitions is given
+so that small differences are not read as signal.
+
+## v2 versus gather-then-SDPA (the production path)
+
+Above 1.00 means v2 is faster. Median of three repetitions, with the observed
+range.
+
+| batch | ctx 1024 | ctx 4096 | ctx 16384 | ctx 32768 |
+|---|---|---|---|---|
+| 1 | **0.91x** (0.90-0.98) | 1.08x (1.02-1.21) | 1.29x (1.20-1.30) | 1.47x (1.44-1.51) |
+| 4 | 1.41x (1.39-1.44) | 2.04x (2.00-2.09) | 2.78x (2.78-2.78) | 3.08x (3.07-3.14) |
+| 8 | 1.47x (1.18-1.49) | 2.00x (1.98-2.00) | 2.27x (2.24-2.27) | 2.32x (2.32-2.34) |
+
+The batched cells are tight enough to trust: `batch 4 / ctx 16384` returned 2.78x
+in all three repetitions, and no batched cell at 4096 or above varied by more
+than 0.07. The short-context cells at batch 1 and batch 8 are the noisy ones,
+which is the same pattern every measurement in this epic has shown on this host.
+
+### ADR-0001 trigger points
+
+ADR-0001 set the trigger for building a fused path at "single-sequence context
+past ~16384, or any sustained batched decode", and measured gather overhead at
+~48% for batch 4 at 1024 tokens, rising to 2x-3x past 4096.
+
+- **Batched decode, batch 4, every context measured**: 1.41x to 3.08x. Met.
+- **Single sequence at 16384 and above**: 1.29x and 1.47x. Met.
+
+The 2x-3x figure ADR-0001 predicted for batch 4 past 4096 tokens is reproduced
+almost exactly: 2.04x at 4096, 2.78x at 16384, 3.08x at 32768.
+
+## v2 versus v1
+
+| batch | ctx 1024 | ctx 4096 | ctx 16384 | ctx 32768 |
+|---|---|---|---|---|
+| 1 | 1.12x | 1.63x | 2.98x | **4.11x** |
+| 4 | 1.10x | 1.31x | 1.80x | 1.97x |
+| 8 | **1.02x** | 1.12x | 1.29x | 1.34x |
+
+v2 is at or above v1 in every cell. The weakest is `batch 8 / ctx 1024` at 1.02x
+median, where one repetition returned 0.99x; that cell is parity within noise
+rather than a regression, and it is the only cell where any repetition fell below
+1.00.
+
+The batch-1 column is the point of the whole exercise. v1 keeps its KV split
+inside a single threadgroup, so one CTA serves one `(batch, q_head)` pair no
+matter how long the context is, and adding context adds no parallelism. The raw
+numbers show that directly: at batch 1, v1 costs 465us at 1K, 1620us at 16K and
+3023us at 32K, while gather-then-SDPA costs 353us, 699us and 1063us. **v1 is
+slower than the path it was supposed to replace at batch 1**, by up to 2.8x at
+32K. v2's cross-CTA split removes that limit and is 4.11x faster than v1 there.
+
+## The cell that constrains issue #899
+
+At **batch 1 / context 1024**, v2 is slower than gather-then-SDPA: 0.91x median,
+0.90x to 0.98x across repetitions, so it is below parity in all three. The plan
+picks `pages_per_chunk = 2` there, giving 16 chunks over a 32-page sequence, and
+the merge pass plus the workspace round trip costs more than the whole attention
+does at that size.
+
+This does not violate the issue's requirements, which scope the gather comparison
+to the ADR trigger points, and 1024 tokens at batch 1 is the cheapest decode shape
+there is. It does mean **issue #899 must not dispatch v2 unconditionally**. The
+production selector needs a floor, either on context length or on total CTA count,
+below which the gather path stays. The plan already computes the chunk count, so
+the cheapest form of that gate is to keep gather when the plan degenerates to few
+pages per chunk at batch 1.
+
+## Plan behaviour observed
+
+`pages_per_chunk` scales with the work while the chunk count stays pinned at 16,
+which is the binary search hitting its CTA target: 2 at batch 1 / 1K, 68 at batch
+1 / 32K, 341 at batch 4 / 32K, 1023 at batch 8 / 32K. The merge pass was active in
+every configuration measured.
+
+## Correctness (from the issue's harness, run separately)
+
+68 configurations, zero failures at the 2e-2 tolerance: the 24-config committed
+default (worst max relative error 5.24e-4), 12 long-context configurations at
+16384 and 32768 over block sizes 16/32/64 (worst 4.43e-4), and 32 forced-merge
+configurations up to 1408 chunks and 45056 CTAs (worst 5.24e-4). Worst relative
+RMS across all of them was 3.05e-4, roughly 65x inside the tolerance.
+
+## Open items
+
+- **CUDA is entirely unvalidated.** Never compiled, never run. Both JIT bodies and
+  the `DEFAULT_TARGET_CTAS` constant need a GB10 pass.
+- **The committed correctness default covers 24 of the issue's 216 configurations**;
+  `--full` covers the rest and was not run to completion here.
+- Sliding-window and softcap variants keep their existing fallbacks. `first_page_offset`
+  lets the page table express a trimmed window, but v2 applies no windowing mask of
+  its own, which issue #899 must handle when it routes those families.
+- Speculative and MTP multi-token verify steps stay on their current path by design.

--- a/examples/page_gather_microbench.rs
+++ b/examples/page_gather_microbench.rs
@@ -85,9 +85,7 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use mlxcel_core::cache::PagedCsrView;
-use mlxcel_core::paged_v2::{
-    PagedDecodeGeometry, PagedDecodePlan, V2Context, device_target_ctas,
-};
+use mlxcel_core::paged_v2::{PagedDecodeGeometry, PagedDecodePlan, V2Context, device_target_ctas};
 use mlxcel_core::{
     MlxArray, UniquePtr, astype, bench_rotation::Rotation, eval, fast_scaled_dot_product_attention,
     from_slice_i32, paged_attention_decode, reshape, slice_update, synchronize_default, take,

--- a/examples/page_gather_microbench.rs
+++ b/examples/page_gather_microbench.rs
@@ -24,6 +24,26 @@
 //! * (B) a fused Metal paged-attention kernel that reads scattered blocks
 //!   directly with no gather copy.
 //!
+//! ## Three-way fused comparison (issue #898)
+//!
+//! The sweep now also times both fused kernels against the gather path, which
+//! is the comparison issue #898 asks for:
+//!
+//! * `fused_v1` (#123): split-K inside one threadgroup, so one CTA serves one
+//!   `(batch, query head)` pair and parallelism does not grow with context.
+//! * `fused_v2` (#898): cross-CTA split-KV over a CSR page table plus a
+//!   variable-length merge, so parallelism grows with context.
+//!
+//! Both read the same layout-A pools the layout-A gather reads, so all three
+//! see the identical scatter pattern, and both consume an f32 query cast once
+//! outside the timed region rather than charged to one of them. The v2 plan is
+//! also built outside the timed region because that is the production model: it
+//! is plain data that stays valid across decode steps.
+//!
+//! The reported ratios are the issue's acceptance bars: `v2/v1 >= 1.0` across
+//! the whole sweep, and `v2/gatherA > 1.0` at the ADR 0001 trigger points
+//! (batch 4 at `ctx >= 1024`, single-sequence at `ctx >= 16384`).
+//!
 //! The bench is fully synthetic: it allocates fake K/V with `zeros` (values do
 //! not matter, only timing) and times three decode-step attention paths plus a
 //! per-step block-append (`slice_update`) across a sweep of context lengths,
@@ -64,13 +84,19 @@
 use std::time::{Duration, Instant};
 
 use clap::Parser;
+use mlxcel_core::cache::PagedCsrView;
+use mlxcel_core::paged_v2::{
+    PagedDecodeGeometry, PagedDecodePlan, V2Context, device_target_ctas,
+};
 use mlxcel_core::{
-    MlxArray, UniquePtr, bench_rotation::Rotation, eval, fast_scaled_dot_product_attention,
-    from_slice_i32, reshape, slice_update, synchronize_default, take, transpose_axes, zeros,
+    MlxArray, UniquePtr, astype, bench_rotation::Rotation, eval, fast_scaled_dot_product_attention,
+    from_slice_i32, paged_attention_decode, reshape, slice_update, synchronize_default, take,
+    transpose_axes, zeros,
 };
 
 // MLX dtype ids (see src/lib/mlxcel-core/cpp/mlx_cxx_bridge.cpp:50-51).
 const F16: i32 = 9;
+const F32: i32 = mlxcel_core::dtype::FLOAT32;
 
 #[derive(Parser, Debug)]
 #[command(name = "page_gather_microbench")]
@@ -349,6 +375,15 @@ struct Row {
     gather_b_sdpa: Duration,
     sliceupd_a: Duration,
     sliceupd_b: Duration,
+    /// Fused paged-attention decode v1 (#123): split-K inside one threadgroup.
+    fused_v1: Duration,
+    /// Fused paged-attention decode v2 (#898): cross-CTA split-KV plus merge.
+    fused_v2: Duration,
+    /// Chunk size the v2 plan chose for this configuration.
+    v2_pages_per_chunk: i32,
+    /// Chunks the v2 plan emitted, and whether a merge launch was needed.
+    v2_chunks: usize,
+    v2_merge: bool,
 }
 
 impl Row {
@@ -378,6 +413,23 @@ impl Row {
     }
     fn overhead_b_pct(&self) -> f64 {
         (self.gather_b_sdpa_us() - self.contig_sdpa_us()) / self.contig_sdpa_us() * 100.0
+    }
+    fn fused_v1_us(&self) -> f64 {
+        per_call_us(self.fused_v1, self.iters)
+    }
+    fn fused_v2_us(&self) -> f64 {
+        per_call_us(self.fused_v2, self.iters)
+    }
+    /// Speedup of v2 over v1. The issue's acceptance bar is `>= 1.0` across the
+    /// whole sweep.
+    fn v2_over_v1(&self) -> f64 {
+        self.fused_v1_us() / self.fused_v2_us().max(f64::MIN_POSITIVE)
+    }
+    /// Speedup of v2 over the production gather-then-SDPA path (layout A). The
+    /// issue's acceptance bar is `> 1.0` at the ADR 0001 trigger points: batch
+    /// 4 at `ctx >= 1024`, and single-sequence at `ctx >= 16384`.
+    fn v2_over_gather(&self) -> f64 {
+        self.gather_a_sdpa_us() / self.fused_v2_us().max(f64::MIN_POSITIVE)
     }
     /// Which memory this row measured: `warm` (single reused buffer) or
     /// `cold-l2` (rotating buffers). Recorded per row because the rotation
@@ -551,6 +603,81 @@ fn run_config(
         slice_update(&pool_k_b[i], &new_block_b, &[0, 0, 0, 0], &[hkv, 1, bs, d])
     });
 
+    // ── Paths 5 and 6: the fused paged-attention kernels (#123 v1, #898 v2) ──
+    //
+    // Both launchers read Q in f32 and emit f32 deterministically, so the cast
+    // is hoisted out of the timed region rather than charged to one of them.
+    // Both read layout-A pools, the same buffers the layout-A gather above
+    // reads, so all three paths see the identical scatter pattern.
+    let q_f32 = astype(&q, F32);
+    eval(&q_f32);
+
+    // v1 block-table metadata: every sequence's rows concatenated, offsets into
+    // it, and the visible window as absolute positions.
+    let row_offsets: Vec<i32> = (0..=batch).map(|r| (r * nb) as i32).collect();
+    let logical_starts = vec![0i32; batch];
+    let visible_lens = vec![t_pad; batch];
+    let rows_arr = from_slice_i32(&ids, &[total_blocks as i32]);
+    let off_arr = from_slice_i32(&row_offsets, &[b + 1]);
+    let ls_arr = from_slice_i32(&logical_starts, &[b]);
+    let vl_arr = from_slice_i32(&visible_lens, &[b]);
+    for arr in [&rows_arr, &off_arr, &ls_arr, &vl_arr] {
+        eval(arr);
+    }
+
+    // v2 CSR view over the same pages. `indptr` is the same prefix-sum array v1
+    // uses as `row_offsets`; every sequence occupies whole pages here, so
+    // `last_page_len` is the page size and no request starts mid-page.
+    let view = PagedCsrView {
+        page_size: bs,
+        indices: ids.clone(),
+        indptr: row_offsets.clone(),
+        last_page_len: vec![bs; batch],
+        first_page_offset: vec![0; batch],
+        seq_lens: visible_lens.clone(),
+        rope_offsets: visible_lens.clone(),
+    };
+    view.validate().expect("microbench CSR view is consistent");
+    let geometry = PagedDecodeGeometry {
+        q_heads: hq,
+        kv_heads: hkv,
+        head_dim: d,
+        page_size: bs,
+    };
+    // The plan is built once, outside the timed region, because that is the
+    // production model: it is plain data that stays valid across decode steps
+    // until a request crosses a page boundary.
+    let plan = PagedDecodePlan::heuristic(geometry, &view.page_counts(), device_target_ctas());
+    plan.validate().expect("microbench plan is well formed");
+    let v2_ctxs: Vec<V2Context<'_>> = (0..rot_count)
+        .map(|i| {
+            V2Context::build(&q_f32, &pool_k_a[i], &pool_v_a[i], &view, geometry, scale)
+                .expect("v2 context builds")
+        })
+        .collect();
+    synchronize_default();
+
+    let mut rot = Rotation::new(rot_count);
+    let fused_v1 = time_body(warmup, iters, || {
+        let i = rot.next_index();
+        paged_attention_decode(
+            &q_f32,
+            &pool_k_a[i],
+            &pool_v_a[i],
+            &rows_arr,
+            &off_arr,
+            &ls_arr,
+            &vl_arr,
+            scale,
+            0,
+        )
+    });
+    let mut rot = Rotation::new(rot_count);
+    let fused_v2 = time_body(warmup, iters, || {
+        let i = rot.next_index();
+        v2_ctxs[i].launch(&plan).expect("v2 launch")
+    });
+
     Row {
         batch,
         ctx,
@@ -566,6 +693,11 @@ fn run_config(
         gather_b_sdpa,
         sliceupd_a,
         sliceupd_b,
+        fused_v1,
+        fused_v2,
+        v2_pages_per_chunk: plan.pages_per_chunk,
+        v2_chunks: plan.num_chunks,
+        v2_merge: plan.needs_merge,
     }
 }
 
@@ -627,10 +759,17 @@ fn main() {
                 fmt_per_call("gatherB_sdpa", row.gather_b_sdpa, row.iters);
                 fmt_per_call("sliceupd_A", row.sliceupd_a, row.iters);
                 fmt_per_call("sliceupd_B", row.sliceupd_b, row.iters);
+                fmt_per_call("fused_v1", row.fused_v1, row.iters);
+                fmt_per_call("fused_v2", row.fused_v2, row.iters);
                 println!(
-                    "  overheadA={:.1}%  overheadB={:.1}%",
+                    "  overheadA={:.1}%  overheadB={:.1}%  v2/v1={:.2}x  v2/gatherA={:.2}x  (v2 plan: ppc={} chunks={} merge={})",
                     row.overhead_a_pct(),
-                    row.overhead_b_pct()
+                    row.overhead_b_pct(),
+                    row.v2_over_v1(),
+                    row.v2_over_gather(),
+                    row.v2_pages_per_chunk,
+                    row.v2_chunks,
+                    row.v2_merge,
                 );
                 println!();
                 rows.push(row);
@@ -641,7 +780,7 @@ fn main() {
     // Aligned human-readable summary table.
     println!("=== summary (per-call microseconds) ===");
     println!(
-        "{:>5} {:>7} {:>7} {:>5} {:>7} | {:>12} {:>12} {:>12} {:>12} {:>12} {:>11} {:>11} | {:>10} {:>10}",
+        "{:>5} {:>7} {:>7} {:>5} {:>7} | {:>12} {:>12} {:>12} {:>12} {:>12} {:>11} {:>11} | {:>10} {:>10} | {:>10} {:>10} {:>8} {:>10}",
         "B",
         "ctx",
         "ctxpad",
@@ -656,10 +795,14 @@ fn main() {
         "sliceupd_B",
         "overheadA%",
         "overheadB%",
+        "fused_v1",
+        "fused_v2",
+        "v2/v1",
+        "v2/gatherA",
     );
     for r in &rows {
         println!(
-            "{:>5} {:>7} {:>7} {:>5} {:>7.2} | {:>12.3} {:>12.3} {:>12.3} {:>12.3} {:>12.3} {:>11.3} {:>11.3} | {:>10.1} {:>10.1}  {} x{}",
+            "{:>5} {:>7} {:>7} {:>5} {:>7.2} | {:>12.3} {:>12.3} {:>12.3} {:>12.3} {:>12.3} {:>11.3} {:>11.3} | {:>10.1} {:>10.1} | {:>10.3} {:>10.3} {:>7.2}x {:>9.2}x  {} x{}",
             r.batch,
             r.ctx,
             r.ctx_pad,
@@ -674,6 +817,10 @@ fn main() {
             r.sliceupd_b_us(),
             r.overhead_a_pct(),
             r.overhead_b_pct(),
+            r.fused_v1_us(),
+            r.fused_v2_us(),
+            r.v2_over_v1(),
+            r.v2_over_gather(),
             r.mode_tag(),
             r.rotation,
         );
@@ -681,15 +828,15 @@ fn main() {
     println!();
 
     // Machine-readable CSV block (one line per config, each prefixed `CSV:`).
-    // `mode` and `rotation` are appended (issue #906), so column-indexed
-    // readers of the historical schema keep working while a recorded result
-    // always states which memory it measured.
+    // Columns are only ever appended, so column-indexed readers of an older
+    // schema keep working: `mode` and `rotation` came with issue #906, and the
+    // fused-kernel columns with issue #898.
     println!(
-        "CSV:batch,ctx,ctx_pad,block,frag_pct,contig_sdpa_us,gatherA_only_us,gatherA_sdpa_us,gatherB_only_us,gatherB_sdpa_us,sliceupd_a_us,sliceupd_b_us,overhead_a_pct,overhead_b_pct,mode,rotation"
+        "CSV:batch,ctx,ctx_pad,block,frag_pct,contig_sdpa_us,gatherA_only_us,gatherA_sdpa_us,gatherB_only_us,gatherB_sdpa_us,sliceupd_a_us,sliceupd_b_us,overhead_a_pct,overhead_b_pct,mode,rotation,fused_v1_us,fused_v2_us,v2_over_v1,v2_over_gather_a,v2_pages_per_chunk,v2_chunks,v2_merge"
     );
     for r in &rows {
         println!(
-            "CSV:{},{},{},{},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{},{}",
+            "CSV:{},{},{},{},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{},{},{:.3},{:.3},{:.4},{:.4},{},{},{}",
             r.batch,
             r.ctx,
             r.ctx_pad,
@@ -706,6 +853,13 @@ fn main() {
             r.overhead_b_pct(),
             r.mode_tag(),
             r.rotation,
+            r.fused_v1_us(),
+            r.fused_v2_us(),
+            r.v2_over_v1(),
+            r.v2_over_gather(),
+            r.v2_pages_per_chunk,
+            r.v2_chunks,
+            r.v2_merge,
         );
     }
 }

--- a/examples/paged_decode_v2_correctness.rs
+++ b/examples/paged_decode_v2_correctness.rs
@@ -351,20 +351,15 @@ fn run_config(
         PagedDecodePlan::heuristic(geometry, &page_counts, target)
     };
     plan.validate().expect("plan is well formed");
-    let ctx_arrays = mlxcel_core::paged_v2::V2Context::build(
-        &q_f32, &pool_k, &pool_v, &view, geometry, scale,
-    )
-    .expect("v2 context builds");
+    let ctx_arrays =
+        mlxcel_core::paged_v2::V2Context::build(&q_f32, &pool_k, &pool_v, &view, geometry, scale)
+            .expect("v2 context builds");
     let got = to_vec_f32(&ctx_arrays.launch(&plan).expect("v2 launch"));
 
     // Reference: gather-then-SDPA, one request at a time.
     let mut want: Vec<f32> = Vec::with_capacity(batch * hq as usize * head_dim);
     for r in 0..batch {
-        let q_row = slice(
-            &q_f16,
-            &[r as i32, 0, 0, 0],
-            &[r as i32 + 1, hq, 1, dim],
-        );
+        let q_row = slice(&q_f16, &[r as i32, 0, 0, 0], &[r as i32 + 1, hq, 1, dim]);
         let begin = indptr[r] as usize;
         let end = indptr[r + 1] as usize;
         let out = reference_for_request(

--- a/examples/paged_decode_v2_correctness.rs
+++ b/examples/paged_decode_v2_correctness.rs
@@ -1,0 +1,516 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Correctness matrix for paged-attention decode v2 (issue #898).
+//!
+//! Compares the v2 kernels elementwise against the gather-then-SDPA reference
+//! (ADR 0001 strategy A, the same reference v1 is validated against) over a
+//! sweep of head dimensions, GQA ratios, page sizes, contexts, and batch sizes,
+//! with a randomized partial last page per request.
+//!
+//! ## What it drives, and what it deliberately does not
+//!
+//! The harness builds the pool tensors and the CSR page table directly and
+//! calls [`mlxcel_core::paged_v2::run_decode_v2`], rather than going through
+//! `PagedBlockPool`. That is not a shortcut around the pool: the pool allocates
+//! physical rows in 32-block slabs, and both fused kernels read one contiguous
+//! buffer per side, so any context past ~1024 tokens at page size 32 is
+//! multi-slab and *declined* by v1 and v2 alike. A pool-driven matrix could
+//! therefore only test the short-context corner. The CSR builder itself is
+//! covered by `cache::paged_csr` unit tests, and the pool entry point by
+//! `paged_v2::launch` unit tests; this harness covers the kernels at scale.
+//!
+//! Physical pages are assigned in reverse order out of a pool with 2x slack, so
+//! the page table is genuinely scattered and a kernel that ignored `indices`
+//! would fail immediately rather than accidentally pass on a contiguous layout.
+//!
+//! ## The committed default is a subset
+//!
+//! The issue's full matrix is head_dim {64, 128} x GQA {1, 4, 8} x block
+//! {16, 32, 64} x context {512, 4096, 16384, 32768} x batch {1, 4, 8}: 216
+//! configurations, several of which allocate gigabytes. The default sweep here
+//! is the 24-configuration subset
+//!
+//!   head_dim {64, 128} x GQA {1, 4, 8} x block {32} x context {512, 4096}
+//!   x batch {1, 4}
+//!
+//! which runs in seconds. `--full` expands to the complete matrix; the axis
+//! flags override any subset in between. Always state which sweep produced a
+//! recorded number.
+//!
+//! Run:
+//!
+//! ```text
+//! cargo run --release --features metal,accelerate \
+//!     --example paged_decode_v2_correctness
+//!
+//! # The full 216-configuration matrix (allocates up to several GB).
+//! cargo run --release --features metal,accelerate \
+//!     --example paged_decode_v2_correctness -- --full
+//!
+//! # One axis at a time.
+//! cargo run --release --features metal,accelerate \
+//!     --example paged_decode_v2_correctness -- \
+//!     --contexts 16384,32768 --batches 1 --blocks 32
+//! ```
+
+use clap::Parser;
+use mlxcel_core::cache::PagedCsrView;
+use mlxcel_core::paged_v2::{PagedDecodeGeometry, PagedDecodePlan, device_target_ctas};
+use mlxcel_core::{
+    MlxArray, UniquePtr, astype, eval, fast_scaled_dot_product_attention, from_slice_f32, reshape,
+    slice, synchronize_default, take, transpose_axes,
+};
+
+const F16: i32 = mlxcel_core::dtype::FLOAT16;
+const F32: i32 = mlxcel_core::dtype::FLOAT32;
+
+#[derive(Parser, Debug)]
+#[command(name = "paged_decode_v2_correctness")]
+struct Args {
+    /// Query heads. The GQA ratio divides this to give the KV head count.
+    #[arg(long, default_value = "32")]
+    q_heads: i32,
+
+    /// Comma-separated head dimensions.
+    #[arg(long, default_value = "64,128")]
+    head_dims: String,
+
+    /// Comma-separated GQA ratios (`q_heads / kv_heads`).
+    #[arg(long, default_value = "1,4,8")]
+    gqa: String,
+
+    /// Comma-separated page (block) sizes.
+    #[arg(long, default_value = "32")]
+    blocks: String,
+
+    /// Comma-separated context lengths.
+    #[arg(long, default_value = "512,4096")]
+    contexts: String,
+
+    /// Comma-separated batch sizes.
+    #[arg(long, default_value = "1,4")]
+    batches: String,
+
+    /// Expand to the full matrix from issue #898 (216 configurations, several
+    /// of them multi-gigabyte). Overrides every axis flag.
+    #[arg(long)]
+    full: bool,
+
+    /// Relative-error ceiling. The issue's suggested f16-KV tolerance is 2e-2.
+    #[arg(long, default_value = "2e-2")]
+    tolerance: f32,
+
+    /// Also force `pages_per_chunk = 1` for every configuration, which puts
+    /// every request through the merge kernel with a maximally ragged grouping.
+    #[arg(long)]
+    force_merge: bool,
+
+    /// Seed for the synthetic K/V/Q values.
+    #[arg(long, default_value = "20260898")]
+    seed: u64,
+}
+
+fn parse_list(s: &str) -> Vec<usize> {
+    s.split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(|t| {
+            t.parse::<usize>()
+                .unwrap_or_else(|_| panic!("invalid list value: {t:?}"))
+        })
+        .collect()
+}
+
+/// Deterministic pseudo-random values in [-0.5, 0.5). Distinct values keep the
+/// softmax non-degenerate, and the fixed seed makes any failure reproducible.
+fn pseudo_f32(seed: u64, n: usize) -> Vec<f32> {
+    let mut s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1) | 1;
+    (0..n)
+        .map(|_| {
+            s ^= s >> 12;
+            s ^= s << 25;
+            s ^= s >> 27;
+            let u = (s.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 40) as f32;
+            u / (1u64 << 24) as f32 - 0.5
+        })
+        .collect()
+}
+
+fn f16(vals: &[f32], shape: &[i32]) -> UniquePtr<MlxArray> {
+    astype(&from_slice_f32(vals, shape), F16)
+}
+
+fn to_vec_f32(a: &MlxArray) -> Vec<f32> {
+    let f = astype(a, F32);
+    eval(&f);
+    mlxcel_core::array_to_raw_bytes(&f)
+        .chunks_exact(4)
+        .map(|c| f32::from_ne_bytes(c.try_into().unwrap()))
+        .collect()
+}
+
+/// One measured configuration.
+struct Row {
+    head_dim: usize,
+    gqa: usize,
+    block: usize,
+    ctx: usize,
+    batch: usize,
+    pages_per_chunk: i32,
+    num_chunks: usize,
+    total_ctas: usize,
+    needs_merge: bool,
+    max_rel: f32,
+    rms_rel: f32,
+    pass: bool,
+}
+
+/// Max and RMS deviation, both relative to the reference's own scale. A plain
+/// absolute bound would be meaningless for an output whose magnitude depends on
+/// the value distribution.
+fn deviations(got: &[f32], want: &[f32]) -> (f32, f32) {
+    assert_eq!(got.len(), want.len(), "output length mismatch");
+    let peak = want.iter().fold(0.0f32, |a, v| a.max(v.abs())).max(1e-6);
+    let mut max_abs = 0.0f32;
+    let mut sq_err = 0.0f64;
+    let mut sq_ref = 0.0f64;
+    for (g, w) in got.iter().zip(want) {
+        let d = (g - w).abs();
+        max_abs = max_abs.max(d);
+        sq_err += f64::from(d) * f64::from(d);
+        sq_ref += f64::from(*w) * f64::from(*w);
+    }
+    let n = got.len().max(1) as f64;
+    let rms_err = (sq_err / n).sqrt();
+    let rms_ref = (sq_ref / n).sqrt().max(1e-12);
+    (max_abs / peak, (rms_err / rms_ref) as f32)
+}
+
+/// Gather-then-SDPA reference for one request: take its pages out of the pool,
+/// restore token order, slice the visible window, and run fused SDPA.
+fn reference_for_request(
+    pool_k: &MlxArray,
+    pool_v: &MlxArray,
+    q_row: &MlxArray,
+    rows: &[i32],
+    first_offset: i32,
+    seq_len: i32,
+    block: i32,
+    hkv: i32,
+    dim: i32,
+    scale: f32,
+) -> UniquePtr<MlxArray> {
+    let ids = from_slice_i32_local(rows);
+    let span = rows.len() as i32 * block;
+    let gather = |pool: &MlxArray| -> UniquePtr<MlxArray> {
+        let g = take(pool, &ids, 0); // [pages, block, Hkv, D]
+        let g = reshape(&g, &[1, span, hkv, dim]);
+        let g = transpose_axes(&g, &[0, 2, 1, 3]); // [1, Hkv, span, D]
+        slice(
+            &g,
+            &[0, 0, first_offset, 0],
+            &[1, hkv, first_offset + seq_len, dim],
+        )
+    };
+    let k = gather(pool_k);
+    let v = gather(pool_v);
+    // SAFETY: thin FFI wrapper over the MLX fast SDPA kernel; the null mask
+    // pointer is the documented "no mask" sentinel and q/k/v outlive the call.
+    unsafe { fast_scaled_dot_product_attention(q_row, &k, &v, scale, std::ptr::null()) }
+}
+
+fn from_slice_i32_local(v: &[i32]) -> UniquePtr<MlxArray> {
+    mlxcel_core::from_slice_i32(v, &[v.len() as i32])
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_config(
+    q_heads: i32,
+    head_dim: usize,
+    gqa: usize,
+    block: usize,
+    ctx: usize,
+    batch: usize,
+    tolerance: f32,
+    force_merge: bool,
+    seed: u64,
+) -> Row {
+    let dim = head_dim as i32;
+    let hq = q_heads;
+    let hkv = hq / gqa as i32;
+    let bs = block as i32;
+    let scale = 1.0 / (head_dim as f32).sqrt();
+
+    // Per-request visible length: `ctx` for request 0, then a randomized
+    // partial tail so the last page is only partly valid and every request has
+    // a different page count.
+    let jitter = pseudo_f32(seed ^ 0xC0FFEE, batch);
+    let seq_lens: Vec<usize> = (0..batch)
+        .map(|r| {
+            if r == 0 {
+                ctx
+            } else {
+                // jitter is in [-0.5, 0.5), so this lands in [0.55, 1.0] of ctx.
+                let frac = (0.75 + jitter[r] * 0.5).clamp(0.55, 1.0);
+                ((ctx as f32 * frac) as usize).max(1)
+            }
+        })
+        .collect();
+    // Half the requests start mid-page, exercising `first_page_offset`.
+    let first_offsets: Vec<usize> = (0..batch)
+        .map(|r| if r % 2 == 1 { (r * 7) % block } else { 0 })
+        .collect();
+
+    let page_counts: Vec<usize> = seq_lens
+        .iter()
+        .zip(&first_offsets)
+        .map(|(&len, &off)| (len + off).div_ceil(block))
+        .collect();
+    let total_pages: usize = page_counts.iter().sum();
+    // 2x slack, and reverse assignment, so physical rows are scattered.
+    let pool_blocks = (total_pages * 2).max(1);
+
+    let pool_elems = pool_blocks * block * hkv as usize * head_dim;
+    let pool_k = f16(
+        &pseudo_f32(seed, pool_elems),
+        &[pool_blocks as i32, bs, hkv, dim],
+    );
+    let pool_v = f16(
+        &pseudo_f32(seed ^ 0x5EED, pool_elems),
+        &[pool_blocks as i32, bs, hkv, dim],
+    );
+    let q_f16 = f16(
+        &pseudo_f32(seed ^ 0x51D, batch * hq as usize * head_dim),
+        &[batch as i32, hq, 1, dim],
+    );
+    let q_f32 = astype(&q_f16, F32);
+    eval(&pool_k);
+    eval(&pool_v);
+    eval(&q_f16);
+    synchronize_default();
+
+    // CSR page table with reverse-order physical rows.
+    let mut indices: Vec<i32> = Vec::with_capacity(total_pages);
+    let mut indptr: Vec<i32> = vec![0];
+    let mut last_page_len: Vec<i32> = Vec::with_capacity(batch);
+    let mut first_page_offset: Vec<i32> = Vec::with_capacity(batch);
+    let mut lens_i32: Vec<i32> = Vec::with_capacity(batch);
+    let mut assigned = 0usize;
+    for r in 0..batch {
+        for _ in 0..page_counts[r] {
+            indices.push((pool_blocks - 1 - assigned) as i32);
+            assigned += 1;
+        }
+        indptr.push(indices.len() as i32);
+        let total = first_offsets[r] + seq_lens[r];
+        let lpl = total - (page_counts[r] - 1) * block;
+        last_page_len.push(lpl as i32);
+        first_page_offset.push(first_offsets[r] as i32);
+        lens_i32.push(seq_lens[r] as i32);
+    }
+    let view = PagedCsrView {
+        page_size: bs,
+        indices: indices.clone(),
+        indptr: indptr.clone(),
+        last_page_len,
+        first_page_offset,
+        seq_lens: lens_i32,
+        rope_offsets: seq_lens.iter().map(|&l| l as i32).collect(),
+    };
+    view.validate().expect("hand-built CSR view is consistent");
+
+    // v2 output.
+    let geometry = PagedDecodeGeometry {
+        q_heads: hq,
+        kv_heads: hkv,
+        head_dim: dim,
+        page_size: bs,
+    };
+    let target = device_target_ctas();
+    let plan = if force_merge {
+        PagedDecodePlan::with_chunk_size(
+            geometry,
+            &page_counts,
+            1,
+            target,
+            mlxcel_core::autotune::Source::Default,
+        )
+    } else {
+        PagedDecodePlan::heuristic(geometry, &page_counts, target)
+    };
+    plan.validate().expect("plan is well formed");
+    let ctx_arrays = mlxcel_core::paged_v2::V2Context::build(
+        &q_f32, &pool_k, &pool_v, &view, geometry, scale,
+    )
+    .expect("v2 context builds");
+    let got = to_vec_f32(&ctx_arrays.launch(&plan).expect("v2 launch"));
+
+    // Reference: gather-then-SDPA, one request at a time.
+    let mut want: Vec<f32> = Vec::with_capacity(batch * hq as usize * head_dim);
+    for r in 0..batch {
+        let q_row = slice(
+            &q_f16,
+            &[r as i32, 0, 0, 0],
+            &[r as i32 + 1, hq, 1, dim],
+        );
+        let begin = indptr[r] as usize;
+        let end = indptr[r + 1] as usize;
+        let out = reference_for_request(
+            &pool_k,
+            &pool_v,
+            &q_row,
+            &indices[begin..end],
+            first_offsets[r] as i32,
+            seq_lens[r] as i32,
+            bs,
+            hkv,
+            dim,
+            scale,
+        );
+        want.extend(to_vec_f32(&out));
+    }
+
+    let (max_rel, rms_rel) = deviations(&got, &want);
+    Row {
+        head_dim,
+        gqa,
+        block,
+        ctx,
+        batch,
+        pages_per_chunk: plan.pages_per_chunk,
+        num_chunks: plan.num_chunks,
+        total_ctas: plan.total_ctas,
+        needs_merge: plan.needs_merge,
+        max_rel,
+        rms_rel,
+        pass: max_rel <= tolerance,
+    }
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let (head_dims, gqas, blocks, contexts, batches) = if args.full {
+        (
+            vec![64usize, 128],
+            vec![1usize, 4, 8],
+            vec![16usize, 32, 64],
+            vec![512usize, 4096, 16384, 32768],
+            vec![1usize, 4, 8],
+        )
+    } else {
+        (
+            parse_list(&args.head_dims),
+            parse_list(&args.gqa),
+            parse_list(&args.blocks),
+            parse_list(&args.contexts),
+            parse_list(&args.batches),
+        )
+    };
+
+    println!("=== paged decode v2 correctness matrix (issue #898) ===");
+    println!(
+        "q_heads={} tolerance={:.1e} force_merge={} seed={} target_ctas={}",
+        args.q_heads,
+        args.tolerance,
+        args.force_merge,
+        args.seed,
+        device_target_ctas()
+    );
+    println!(
+        "sweep: head_dim {head_dims:?} x gqa {gqas:?} x block {blocks:?} x ctx {contexts:?} x batch {batches:?} = {} configs",
+        head_dims.len() * gqas.len() * blocks.len() * contexts.len() * batches.len()
+    );
+    println!("reference: gather-then-SDPA over the same pool (ADR 0001 strategy A)");
+    println!();
+
+    let mut rows: Vec<Row> = Vec::new();
+    for &head_dim in &head_dims {
+        for &gqa in &gqas {
+            if args.q_heads % gqa as i32 != 0 {
+                println!("skip: gqa {gqa} does not divide q_heads {}", args.q_heads);
+                continue;
+            }
+            for &block in &blocks {
+                for &ctx in &contexts {
+                    for &batch in &batches {
+                        let row = run_config(
+                            args.q_heads,
+                            head_dim,
+                            gqa,
+                            block,
+                            ctx,
+                            batch,
+                            args.tolerance,
+                            args.force_merge,
+                            args.seed,
+                        );
+                        println!(
+                            "  d={:<4} gqa={:<2} blk={:<3} ctx={:<6} B={:<2} ppc={:<5} chunks={:<6} ctas={:<7} merge={:<5} max_rel={:.3e} rms_rel={:.3e} {}",
+                            row.head_dim,
+                            row.gqa,
+                            row.block,
+                            row.ctx,
+                            row.batch,
+                            row.pages_per_chunk,
+                            row.num_chunks,
+                            row.total_ctas,
+                            row.needs_merge,
+                            row.max_rel,
+                            row.rms_rel,
+                            if row.pass { "PASS" } else { "FAIL" }
+                        );
+                        rows.push(row);
+                    }
+                }
+            }
+        }
+    }
+
+    println!();
+    println!(
+        "CSV:head_dim,gqa,block,ctx,batch,pages_per_chunk,num_chunks,total_ctas,needs_merge,max_rel,rms_rel,pass"
+    );
+    for r in &rows {
+        println!(
+            "CSV:{},{},{},{},{},{},{},{},{},{:.6e},{:.6e},{}",
+            r.head_dim,
+            r.gqa,
+            r.block,
+            r.ctx,
+            r.batch,
+            r.pages_per_chunk,
+            r.num_chunks,
+            r.total_ctas,
+            r.needs_merge,
+            r.max_rel,
+            r.rms_rel,
+            r.pass
+        );
+    }
+
+    let failed = rows.iter().filter(|r| !r.pass).count();
+    let worst_max = rows.iter().fold(0.0f32, |a, r| a.max(r.max_rel));
+    let worst_rms = rows.iter().fold(0.0f32, |a, r| a.max(r.rms_rel));
+    println!();
+    println!(
+        "{} configurations, {failed} failing; worst max_rel {worst_max:.3e}, worst rms_rel {worst_rms:.3e}, tolerance {:.1e}",
+        rows.len(),
+        args.tolerance
+    );
+    if failed > 0 {
+        std::process::exit(1);
+    }
+}

--- a/src/lib/mlx-cpp/turbo/CMakeLists.txt
+++ b/src/lib/mlx-cpp/turbo/CMakeLists.txt
@@ -39,6 +39,7 @@ set(MLXCEL_TURBO_KERNEL_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/sparse_v_sdpa.h
     ${CMAKE_CURRENT_SOURCE_DIR}/turbo4_delegated_sdpa.h
     ${CMAKE_CURRENT_SOURCE_DIR}/paged_attention.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/paged_attention_v2.h
     ${CMAKE_CURRENT_SOURCE_DIR}/sampling.h
     ${CMAKE_CURRENT_SOURCE_DIR}/fused_norm.h
     ${CMAKE_CURRENT_SOURCE_DIR}/fused_rope_append.h)
@@ -47,6 +48,8 @@ set(MLXCEL_TURBO_KERNEL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/sparse_v_sdpa.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/turbo4_delegated_sdpa.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/paged_attention.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/paged_attention_v2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/paged_attention_v2_merge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sampling.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fused_norm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fused_rope_append.cpp)

--- a/src/lib/mlx-cpp/turbo/paged_attention_v2.cpp
+++ b/src/lib/mlx-cpp/turbo/paged_attention_v2.cpp
@@ -1,0 +1,650 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paged_attention_v2.h"
+
+#include <mlx/fast.h>
+#include <mlx/ops.h>
+
+// Backend availability probes for the Metal-vs-CUDA kernel gate, same contract
+// as `paged_attention.cpp`: both headers are backend-agnostic, so
+// `is_available()` always resolves and returns false for the absent backend.
+#include <mlx/backend/cuda/cuda.h>
+#include <mlx/backend/metal/metal.h>
+
+#include <mutex>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace mlxcel::turbo {
+
+namespace {
+
+// Body of the v2 partial kernel (Metal). `mlx::core::fast::metal_kernel` wraps
+// this with the declaration, buffer arguments, and template substitution.
+//
+// One threadgroup owns one `(chunk, kv head, q-head group)` triple:
+//
+//   - grid z  : flat chunk index, i.e. one `(request, tile)` pair from the plan.
+//   - grid y  : `kv_head * QGroups + q_group`, so the query heads of one KV head
+//               are split into `QGroups` CTAs of `QHeads` heads each and the KV
+//               element loaded by this CTA is reused across all of them.
+//   - 32 lanes: partition the head dimension, `DimsPerThread` dims per lane, so
+//               the QK dot product is a barrier-free `simd_sum`.
+//   - NumWarps: stripe the chunk's tokens, merged at the end through
+//               threadgroup memory (the same flash rescale v1 performs).
+//
+// Scores are computed in base 2: `log2(e)` is folded into the attention scale
+// so the online softmax uses `exp2`, and the emitted LSE is
+// `max_2 + log2(sum exp2(score_2 - max_2))`. The merge kernel consumes exactly
+// those units.
+//
+// Template constants:
+//   Dim           - head dimension D.
+//   PageSize      - tokens per pool page (compile-time so `/` and `%` become
+//                   shifts for the power-of-two page sizes in use).
+//   NRep          - Hq / Hkv (grouped-query replication factor).
+//   QHeads        - query heads this CTA owns; divides NRep.
+//   QGroups       - NRep / QHeads.
+//   DimsPerThread - ceil(Dim / 32).
+//   NumWarps      - SIMD groups per threadgroup.
+//
+// Buffers (order matches the launcher's input vector):
+//   q                 [B, Hq, 1, Dim]                    f32
+//   k_pool            [num_blocks, PageSize, Hkv, Dim]   f16
+//   v_pool            [num_blocks, PageSize, Hkv, Dim]   f16
+//   indices           [total_pages]                      i32
+//   indptr            [B + 1]                            i32
+//   last_page_len     [B]                                i32
+//   first_page_offset [B]                                i32
+//   request_indices   [num_chunks]                       i32
+//   kv_tile_indices   [num_chunks]                       i32
+//   params            [1]                                i32 (pages_per_chunk)
+//   scale             [1]                                f32
+//   out_v             [num_chunks, Hq, Dim]              f32
+//   out_lse           [num_chunks, Hq]                   f32
+constexpr const char* PAGED_ATTENTION_V2_PARTIAL_SOURCE = R"(
+    uint lane = thread_position_in_threadgroup.x;    // 0 .. 31 (within SIMD grp)
+    uint sg = thread_position_in_threadgroup.y;      // 0 .. NumWarps-1
+    uint yblk = threadgroup_position_in_grid.y;      // kv_head * QGroups + qgrp
+    uint chunk = threadgroup_position_in_grid.z;     // flat (request, tile) id
+
+    uint dim = (uint)Dim;
+    uint dpt = (uint)DimsPerThread;
+    uint d0 = lane * dpt;                            // first dim of this lane
+    uint page_size = (uint)PageSize;
+
+    uint hq_count = (uint)q_shape[1];                // Hq
+    uint hkv_count = (uint)k_pool_shape[2];          // Hkv
+
+    uint kv_head = yblk / (uint)QGroups;
+    uint q_group = yblk - kv_head * (uint)QGroups;
+    if (kv_head >= hkv_count) {
+        kv_head = 0;                                 // defensive
+    }
+    uint q_base = kv_head * (uint)NRep + q_group * (uint)QHeads;
+
+    int req_i = request_indices[chunk];
+    int tile_i = kv_tile_indices[chunk];
+    uint r = req_i > 0 ? (uint)req_i : 0u;
+    uint tile = tile_i > 0 ? (uint)tile_i : 0u;
+
+    // CSR page range and visible-token window of this request.
+    uint page_begin = (uint)indptr[r];
+    uint page_end = (uint)indptr[r + 1];
+    uint npages = page_end > page_begin ? page_end - page_begin : 0u;
+    uint fpo = (uint)first_page_offset[r];
+    uint lpl = (uint)last_page_len[r];
+    uint seq_len = 0u;
+    if (npages > 0u) {
+        uint total = (npages - 1u) * page_size + lpl;
+        seq_len = total > fpo ? total - fpo : 0u;
+    }
+
+    // Token half-open range [t_begin, t_end) this chunk covers, derived from
+    // its page range so the arithmetic matches the host plan exactly.
+    uint ppc = (uint)params[0];
+    uint chunk_page_end = page_begin + (tile + 1u) * ppc;
+    if (chunk_page_end > page_end) {
+        chunk_page_end = page_end;
+    }
+    uint t_begin = tile * ppc * page_size;
+    t_begin = t_begin > fpo ? t_begin - fpo : 0u;
+    uint t_end;
+    if (chunk_page_end >= page_end) {
+        t_end = seq_len;
+    } else {
+        uint span = (chunk_page_end - page_begin) * page_size;
+        t_end = span > fpo ? span - fpo : 0u;
+    }
+    if (t_end > seq_len) {
+        t_end = seq_len;
+    }
+
+    // Stage this lane's Q slice for every query head this CTA owns.
+    float q_reg[QHeads * DimsPerThread];
+    for (uint g = 0; g < (uint)QHeads; g++) {
+        uint h = q_base + g;
+        for (uint j = 0; j < dpt; j++) {
+            uint d = d0 + j;
+            q_reg[g * dpt + j] = (h < hq_count && d < dim)
+                ? q[(r * hq_count + h) * dim + d]
+                : 0.0f;
+        }
+    }
+
+    // Per-head online softmax state for this warp's token stripe.
+    float m[QHeads];
+    float l[QHeads];
+    float acc[QHeads * DimsPerThread];
+    for (uint g = 0; g < (uint)QHeads; g++) {
+        m[g] = -INFINITY;
+        l[g] = 0.0f;
+        for (uint j = 0; j < dpt; j++) {
+            acc[g * dpt + j] = 0.0f;
+        }
+    }
+
+    // log2(e) folded into the scale: the whole softmax then runs on exp2.
+    float scale_v = scale[0] * 1.4426950408889634f;
+    uint stride_kv = hkv_count * dim;
+
+    for (uint t = t_begin + sg; t < t_end; t += (uint)NumWarps) {
+        uint abs_pos = fpo + t;
+        uint page_off = abs_pos / page_size;
+        uint entry = abs_pos - page_off * page_size;
+        uint row = (uint)indices[page_begin + page_off];
+        uint base = (row * page_size + entry) * stride_kv + kv_head * dim;
+
+        float k_reg[DimsPerThread];
+        float v_reg[DimsPerThread];
+        for (uint j = 0; j < dpt; j++) {
+            uint d = d0 + j;
+            k_reg[j] = (d < dim) ? (float)k_pool[base + d] : 0.0f;
+            v_reg[j] = (d < dim) ? (float)v_pool[base + d] : 0.0f;
+        }
+
+        for (uint g = 0; g < (uint)QHeads; g++) {
+            float partial = 0.0f;
+            for (uint j = 0; j < dpt; j++) {
+                partial += q_reg[g * dpt + j] * k_reg[j];
+            }
+            float score = simd_sum(partial) * scale_v;  // full q . k_t, no barrier
+            float m_new = fmax(m[g], score);
+            float corr = exp2(m[g] - m_new);
+            float p = exp2(score - m_new);
+            l[g] = l[g] * corr + p;
+            for (uint j = 0; j < dpt; j++) {
+                acc[g * dpt + j] = acc[g * dpt + j] * corr + p * v_reg[j];
+            }
+            m[g] = m_new;
+        }
+    }
+
+    // Publish every warp's partial, then warp 0 merges them and writes the
+    // chunk's normalized output plus its LSE.
+    threadgroup float tg_m[NumWarps * QHeads];
+    threadgroup float tg_l[NumWarps * QHeads];
+    threadgroup float tg_acc[NumWarps * QHeads * Dim];
+
+    for (uint g = 0; g < (uint)QHeads; g++) {
+        for (uint j = 0; j < dpt; j++) {
+            uint d = d0 + j;
+            if (d < dim) {
+                tg_acc[(sg * (uint)QHeads + g) * dim + d] = acc[g * dpt + j];
+            }
+        }
+        if (lane == 0u) {
+            tg_m[sg * (uint)QHeads + g] = m[g];
+            tg_l[sg * (uint)QHeads + g] = l[g];
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (sg == 0u) {
+        for (uint g = 0; g < (uint)QHeads; g++) {
+            uint h = q_base + g;
+            if (h >= hq_count) {
+                continue;
+            }
+            float m_g = tg_m[g];
+            for (uint s = 1; s < (uint)NumWarps; s++) {
+                m_g = fmax(m_g, tg_m[s * (uint)QHeads + g]);
+            }
+            // An all-empty chunk leaves m_g at -inf; skip the rescale so no
+            // (-inf) - (-inf) NaN can reach the output.
+            float l_g = 0.0f;
+            if (m_g > -INFINITY) {
+                for (uint s = 0; s < (uint)NumWarps; s++) {
+                    uint idx = s * (uint)QHeads + g;
+                    l_g += tg_l[idx] * exp2(tg_m[idx] - m_g);
+                }
+            }
+            float inv_l = l_g > 0.0f ? (1.0f / l_g) : 0.0f;
+            uint out_base = (chunk * hq_count + h) * dim;
+            for (uint j = 0; j < dpt; j++) {
+                uint d = d0 + j;
+                if (d < dim) {
+                    float a = 0.0f;
+                    if (l_g > 0.0f) {
+                        for (uint s = 0; s < (uint)NumWarps; s++) {
+                            uint idx = s * (uint)QHeads + g;
+                            a += tg_acc[idx * dim + d] * exp2(tg_m[idx] - m_g);
+                        }
+                    }
+                    out_v[out_base + d] = a * inv_l;
+                }
+            }
+            if (lane == 0u) {
+                out_lse[chunk * hq_count + h] =
+                    l_g > 0.0f ? (m_g + log2(l_g)) : -INFINITY;
+            }
+        }
+    }
+)";
+
+// CUDA port of the v2 partial kernel.
+//
+// **Unvalidated.** Issue #898 was implemented on an Apple Silicon host with no
+// CUDA hardware and no `nvcc`, so this body has never been compiled or run. It
+// is a structural transliteration of the Metal source above: same thread
+// mapping, same chunk arithmetic, same accumulation order. The only substantive
+// differences are the ones the two languages force:
+//
+//   - `simd_sum` becomes a butterfly `__shfl_xor_sync` all-reduce, so every
+//     lane ends up with the full dot product exactly as `simd_sum` leaves it.
+//   - `threadgroup` becomes `__shared__` and the barrier becomes
+//     `__syncthreads()`. No thread returns early before that barrier, so no
+//     warp can be stranded.
+//   - `exp2`/`log2`/`fmax` become `exp2f`/`log2f`/`fmaxf`.
+//
+// Grid mapping: MLX ceil-divides the Metal-style total-thread grid by the
+// threadgroup tuple (backend/cuda/custom_kernel.cpp), so grid
+// `(32, NumWarps * Hkv * QGroups, num_chunks)` over threadgroup
+// `(32, NumWarps, 1)` yields blocks `(1, Hkv * QGroups, num_chunks)` with
+// `blockDim = (32, NumWarps, 1)`. Every field divides exactly, so no padded
+// threads are launched.
+constexpr const char* PAGED_ATTENTION_V2_PARTIAL_CUDA_SOURCE = R"(
+    uint32_t lane = threadIdx.x;                      // 0 .. 31 (within warp)
+    uint32_t sg = threadIdx.y;                        // 0 .. NumWarps-1
+    uint32_t yblk = blockIdx.y;                       // kv_head * QGroups + qgrp
+    uint32_t chunk = blockIdx.z;                      // flat (request, tile) id
+
+    uint32_t dim = (uint32_t)Dim;
+    uint32_t dpt = (uint32_t)DimsPerThread;
+    uint32_t d0 = lane * dpt;
+    uint32_t page_size = (uint32_t)PageSize;
+
+    uint32_t hq_count = (uint32_t)q_shape[1];
+    uint32_t hkv_count = (uint32_t)k_pool_shape[2];
+
+    uint32_t kv_head = yblk / (uint32_t)QGroups;
+    uint32_t q_group = yblk - kv_head * (uint32_t)QGroups;
+    if (kv_head >= hkv_count) {
+        kv_head = 0;
+    }
+    uint32_t q_base = kv_head * (uint32_t)NRep + q_group * (uint32_t)QHeads;
+
+    int req_i = request_indices[chunk];
+    int tile_i = kv_tile_indices[chunk];
+    uint32_t r = req_i > 0 ? (uint32_t)req_i : 0u;
+    uint32_t tile = tile_i > 0 ? (uint32_t)tile_i : 0u;
+
+    uint32_t page_begin = (uint32_t)indptr[r];
+    uint32_t page_end = (uint32_t)indptr[r + 1];
+    uint32_t npages = page_end > page_begin ? page_end - page_begin : 0u;
+    uint32_t fpo = (uint32_t)first_page_offset[r];
+    uint32_t lpl = (uint32_t)last_page_len[r];
+    uint32_t seq_len = 0u;
+    if (npages > 0u) {
+        uint32_t total = (npages - 1u) * page_size + lpl;
+        seq_len = total > fpo ? total - fpo : 0u;
+    }
+
+    uint32_t ppc = (uint32_t)params[0];
+    uint32_t chunk_page_end = page_begin + (tile + 1u) * ppc;
+    if (chunk_page_end > page_end) {
+        chunk_page_end = page_end;
+    }
+    uint32_t t_begin = tile * ppc * page_size;
+    t_begin = t_begin > fpo ? t_begin - fpo : 0u;
+    uint32_t t_end;
+    if (chunk_page_end >= page_end) {
+        t_end = seq_len;
+    } else {
+        uint32_t span = (chunk_page_end - page_begin) * page_size;
+        t_end = span > fpo ? span - fpo : 0u;
+    }
+    if (t_end > seq_len) {
+        t_end = seq_len;
+    }
+
+    float q_reg[QHeads * DimsPerThread];
+    for (uint32_t g = 0; g < (uint32_t)QHeads; g++) {
+        uint32_t h = q_base + g;
+        for (uint32_t j = 0; j < dpt; j++) {
+            uint32_t d = d0 + j;
+            q_reg[g * dpt + j] = (h < hq_count && d < dim)
+                ? q[(r * hq_count + h) * dim + d]
+                : 0.0f;
+        }
+    }
+
+    float m[QHeads];
+    float l[QHeads];
+    float acc[QHeads * DimsPerThread];
+    for (uint32_t g = 0; g < (uint32_t)QHeads; g++) {
+        m[g] = -INFINITY;
+        l[g] = 0.0f;
+        for (uint32_t j = 0; j < dpt; j++) {
+            acc[g * dpt + j] = 0.0f;
+        }
+    }
+
+    float scale_v = scale[0] * 1.4426950408889634f;
+    uint32_t stride_kv = hkv_count * dim;
+
+    for (uint32_t t = t_begin + sg; t < t_end; t += (uint32_t)NumWarps) {
+        uint32_t abs_pos = fpo + t;
+        uint32_t page_off = abs_pos / page_size;
+        uint32_t entry = abs_pos - page_off * page_size;
+        uint32_t row = (uint32_t)indices[page_begin + page_off];
+        uint32_t base = (row * page_size + entry) * stride_kv + kv_head * dim;
+
+        float k_reg[DimsPerThread];
+        float v_reg[DimsPerThread];
+        for (uint32_t j = 0; j < dpt; j++) {
+            uint32_t d = d0 + j;
+            k_reg[j] = (d < dim) ? (float)k_pool[base + d] : 0.0f;
+            v_reg[j] = (d < dim) ? (float)v_pool[base + d] : 0.0f;
+        }
+
+        for (uint32_t g = 0; g < (uint32_t)QHeads; g++) {
+            float partial = 0.0f;
+            for (uint32_t j = 0; j < dpt; j++) {
+                partial += q_reg[g * dpt + j] * k_reg[j];
+            }
+            #pragma unroll
+            for (int o = 16; o > 0; o >>= 1) {
+                partial += __shfl_xor_sync(0xffffffffu, partial, o);
+            }
+            float score = partial * scale_v;
+            float m_new = fmaxf(m[g], score);
+            float corr = exp2f(m[g] - m_new);
+            float p = exp2f(score - m_new);
+            l[g] = l[g] * corr + p;
+            for (uint32_t j = 0; j < dpt; j++) {
+                acc[g * dpt + j] = acc[g * dpt + j] * corr + p * v_reg[j];
+            }
+            m[g] = m_new;
+        }
+    }
+
+    __shared__ float tg_m[NumWarps * QHeads];
+    __shared__ float tg_l[NumWarps * QHeads];
+    __shared__ float tg_acc[NumWarps * QHeads * Dim];
+
+    for (uint32_t g = 0; g < (uint32_t)QHeads; g++) {
+        for (uint32_t j = 0; j < dpt; j++) {
+            uint32_t d = d0 + j;
+            if (d < dim) {
+                tg_acc[(sg * (uint32_t)QHeads + g) * dim + d] = acc[g * dpt + j];
+            }
+        }
+        if (lane == 0u) {
+            tg_m[sg * (uint32_t)QHeads + g] = m[g];
+            tg_l[sg * (uint32_t)QHeads + g] = l[g];
+        }
+    }
+    __syncthreads();
+
+    if (sg == 0u) {
+        for (uint32_t g = 0; g < (uint32_t)QHeads; g++) {
+            uint32_t h = q_base + g;
+            if (h >= hq_count) {
+                continue;
+            }
+            float m_g = tg_m[g];
+            for (uint32_t s = 1; s < (uint32_t)NumWarps; s++) {
+                m_g = fmaxf(m_g, tg_m[s * (uint32_t)QHeads + g]);
+            }
+            float l_g = 0.0f;
+            if (m_g > -INFINITY) {
+                for (uint32_t s = 0; s < (uint32_t)NumWarps; s++) {
+                    uint32_t idx = s * (uint32_t)QHeads + g;
+                    l_g += tg_l[idx] * exp2f(tg_m[idx] - m_g);
+                }
+            }
+            float inv_l = l_g > 0.0f ? (1.0f / l_g) : 0.0f;
+            uint32_t out_base = (chunk * hq_count + h) * dim;
+            for (uint32_t j = 0; j < dpt; j++) {
+                uint32_t d = d0 + j;
+                if (d < dim) {
+                    float a = 0.0f;
+                    if (l_g > 0.0f) {
+                        for (uint32_t s = 0; s < (uint32_t)NumWarps; s++) {
+                            uint32_t idx = s * (uint32_t)QHeads + g;
+                            a += tg_acc[idx * dim + d] * exp2f(tg_m[idx] - m_g);
+                        }
+                    }
+                    out_v[out_base + d] = a * inv_l;
+                }
+            }
+            if (lane == 0u) {
+                out_lse[chunk * hq_count + h] =
+                    l_g > 0.0f ? (m_g + log2f(l_g)) : -INFINITY;
+            }
+        }
+    }
+)";
+
+// Apple Silicon SIMD width; the warp width on CUDA.
+constexpr int PAGED_V2_SIMD_WIDTH = 32;
+
+// Threadgroup-memory budget for `tg_acc`, matching the ~28 KB v1 ceiling.
+constexpr int PAGED_V2_TG_BUDGET_BYTES = 28672;
+
+// Largest number of query heads one CTA may own. Beyond this the per-thread
+// accumulator dominates the register file even at small head dims.
+constexpr int PAGED_V2_MAX_Q_HEADS = 8;
+
+// Register budget for the accumulator: `QHeads * DimsPerThread` floats.
+constexpr int PAGED_V2_MAX_ACC_FLOATS = 32;
+
+const std::vector<std::string>& partial_input_names() {
+    static const std::vector<std::string> names = {
+        "q",
+        "k_pool",
+        "v_pool",
+        "indices",
+        "indptr",
+        "last_page_len",
+        "first_page_offset",
+        "request_indices",
+        "kv_tile_indices",
+        "params",
+        "scale"};
+    return names;
+}
+
+const std::vector<std::string>& partial_output_names() {
+    static const std::vector<std::string> names = {"out_v", "out_lse"};
+    return names;
+}
+
+// Thread-safe lazy-initialised holders for the two JIT-compiled bodies, using
+// the `std::call_once` pattern of `paged_attention.cpp` / `sparse_v_sdpa.cpp`:
+// the server reaches first use concurrently from per-request blocking workers,
+// and `call_once` re-runs the initializer if MLX device lookup throws.
+struct PagedV2PartialHolder {
+    std::optional<mlx::core::fast::CustomKernelFunction> kernel;
+    std::once_flag init_flag;
+    bool cuda;
+
+    explicit PagedV2PartialHolder(bool use_cuda) : cuda(use_cuda) {}
+
+    mlx::core::fast::CustomKernelFunction& get() {
+        std::call_once(init_flag, [this] {
+            kernel = cuda
+                ? mlx::core::fast::cuda_kernel(
+                      "mlxcel_paged_attention_v2_partial",
+                      partial_input_names(),
+                      partial_output_names(),
+                      std::string(PAGED_ATTENTION_V2_PARTIAL_CUDA_SOURCE))
+                : mlx::core::fast::metal_kernel(
+                      "mlxcel_paged_attention_v2_partial",
+                      partial_input_names(),
+                      partial_output_names(),
+                      std::string(PAGED_ATTENTION_V2_PARTIAL_SOURCE));
+        });
+        return *kernel;
+    }
+};
+
+inline PagedV2PartialHolder& get_partial_kernel(bool cuda) {
+    static PagedV2PartialHolder metal_holder(false);
+    static PagedV2PartialHolder cuda_holder(true);
+    return cuda ? cuda_holder : metal_holder;
+}
+
+} // namespace
+
+int paged_attention_v2_q_heads_per_cta(int dim, int n_rep) {
+    if (n_rep < 1) {
+        n_rep = 1;
+    }
+    int dims_per_thread = dim > 0
+        ? (dim + PAGED_V2_SIMD_WIDTH - 1) / PAGED_V2_SIMD_WIDTH
+        : 1;
+    int reg_cap = PAGED_V2_MAX_ACC_FLOATS / dims_per_thread;
+    if (reg_cap < 1) {
+        reg_cap = 1;
+    }
+    int cap = reg_cap < PAGED_V2_MAX_Q_HEADS ? reg_cap : PAGED_V2_MAX_Q_HEADS;
+    if (cap > n_rep) {
+        cap = n_rep;
+    }
+    // Largest divisor of `n_rep` at or below the cap, so the query heads of one
+    // KV head partition exactly and the kernel never launches a ragged group.
+    for (int q = cap; q >= 1; q--) {
+        if (n_rep % q == 0) {
+            return q;
+        }
+    }
+    return 1;
+}
+
+int paged_attention_v2_num_warps(int dim, int q_heads_per_cta) {
+    if (dim <= 0 || q_heads_per_cta <= 0) {
+        return 1;
+    }
+    int budget = PAGED_V2_TG_BUDGET_BYTES / (q_heads_per_cta * dim * 4);
+    if (budget > 8) {
+        budget = 8;
+    }
+    int warps = 1;
+    while (warps * 2 <= budget) {
+        warps *= 2;
+    }
+    return warps;
+}
+
+std::vector<mlx::core::array> paged_attention_decode_v2_partial(
+    const mlx::core::array& q,
+    const mlx::core::array& k_pool,
+    const mlx::core::array& v_pool,
+    const mlx::core::array& indices,
+    const mlx::core::array& indptr,
+    const mlx::core::array& last_page_len,
+    const mlx::core::array& first_page_offset,
+    const mlx::core::array& request_indices,
+    const mlx::core::array& kv_tile_indices,
+    const mlx::core::array& params,
+    float scale) {
+    using mlx::core::Dtype;
+    using mlx::core::Shape;
+    using mlx::core::fast::TemplateArg;
+
+    const auto& q_shape = q.shape();       // [B, Hq, 1, Dim]
+    const auto& kp_shape = k_pool.shape(); // [num_blocks, PageSize, Hkv, Dim]
+
+    int hq = q_shape[1];
+    int dim = q_shape[3];
+    int page_size = kp_shape[1];
+    int hkv = kp_shape[2];
+    int n_rep = hkv > 0 ? hq / hkv : 1;
+    if (n_rep < 1) {
+        n_rep = 1;
+    }
+    int num_chunks = static_cast<int>(request_indices.size());
+
+    int q_heads = paged_attention_v2_q_heads_per_cta(dim, n_rep);
+    int q_groups = n_rep / q_heads;
+    int dims_per_thread = (dim + PAGED_V2_SIMD_WIDTH - 1) / PAGED_V2_SIMD_WIDTH;
+    int num_warps = paged_attention_v2_num_warps(dim, q_heads);
+
+    const bool use_cuda = !mlx::core::metal::is_available();
+    auto& kernel = get_partial_kernel(use_cuda).get();
+
+    std::vector<std::pair<std::string, TemplateArg>> template_args = {
+        {"Dim", dim},
+        {"PageSize", page_size},
+        {"NRep", n_rep},
+        {"QHeads", q_heads},
+        {"QGroups", q_groups},
+        {"DimsPerThread", dims_per_thread},
+        {"NumWarps", num_warps},
+    };
+
+    // Pack scale into a 1-element f32 array (metal_kernel inputs must be
+    // arrays; ScalarArg is reserved for the precompiled-kernel path).
+    auto scale_arr =
+        mlx::core::full(mlx::core::Shape{1}, scale, mlx::core::float32);
+
+    std::vector<mlx::core::array> inputs = {
+        q,
+        k_pool,
+        v_pool,
+        indices,
+        indptr,
+        last_page_len,
+        first_page_offset,
+        request_indices,
+        kv_tile_indices,
+        params,
+        scale_arr,
+    };
+    std::vector<Shape> output_shapes = {
+        Shape{num_chunks, hq, dim},
+        Shape{num_chunks, hq},
+    };
+    std::vector<Dtype> output_dtypes = {mlx::core::float32, mlx::core::float32};
+
+    return kernel(
+        inputs,
+        output_shapes,
+        output_dtypes,
+        std::make_tuple(
+            PAGED_V2_SIMD_WIDTH, num_warps * hkv * q_groups, num_chunks), // grid
+        std::make_tuple(PAGED_V2_SIMD_WIDTH, num_warps, 1), // threadgroup
+        template_args,
+        std::nullopt,
+        false,
+        {});
+}
+
+} // namespace mlxcel::turbo

--- a/src/lib/mlx-cpp/turbo/paged_attention_v2.h
+++ b/src/lib/mlx-cpp/turbo/paged_attention_v2.h
@@ -1,0 +1,164 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Fused paged-attention decode kernel v2: CSR page table, cross-CTA split-KV,
+// and a variable-length merge kernel (issue #898).
+//
+// ## Why a second kernel
+//
+// The v1 kernel (`paged_attention.h` / `paged_attention.cpp`) splits the KV
+// range *inside one threadgroup*: grid `(32, NumSplits, B*Hq)` over threadgroup
+// `(32, NumSplits, 1)`, where `NumSplits` is bounded by the threadgroup-memory
+// budget. One CTA therefore serves one `(batch, query head)` pair no matter how
+// long the context is, so a small batch with a long context leaves most of the
+// GPU idle and adding context adds no parallelism.
+//
+// v2 moves the KV split *across* CTAs. Each request's page range is cut into
+// chunks of `pages_per_chunk` pages; each `(chunk, kv head, q-head group)`
+// triple is one CTA that computes an online-softmax partial over its chunk and
+// writes `(normalized partial V, LSE)` into a workspace. A second, deliberately
+// generic kernel merges the partials of each output row with the closed-form
+// flash rescale. Parallelism is now `num_chunks * Hkv * q_groups`, which the
+// host-side plan (`PagedDecodePlan`, Rust side) sizes to the device.
+//
+// ## Layouts
+//
+// The pool layout is unchanged from v1 (layout A of ADR 0001):
+//
+//   k_pool, v_pool : [num_blocks, page_size, n_kv_heads, head_dim]  f16
+//
+// The block table is a CSR view of the batch instead of v1's
+// `rows`/`row_offsets`/`logical_starts`/`visible_lens` quadruple:
+//
+//   indices           [total_pages] i32  flat physical pool rows
+//   indptr            [B + 1]       i32  prefix sums delimiting each request
+//   last_page_len     [B]           i32  valid entries in the final page
+//   first_page_offset [B]           i32  first visible entry in the first page
+//
+// `first_page_offset` is the mlxcel extension to the standard three-array CSR
+// layout: a sequence trimmed by a sliding window starts mid-page
+// (`PagedLayerState::logical_start`), which the canonical layout cannot express.
+// Request `r`'s visible length is therefore
+// `(pages - 1) * page_size + last_page_len[r] - first_page_offset[r]`, and its
+// token `i` lives at page `indptr[r] + (first_page_offset[r] + i) / page_size`,
+// entry `(first_page_offset[r] + i) % page_size`.
+//
+// ## Merge-kernel contract (reused unchanged by the cascade issue #903)
+//
+// `paged_attention_merge_states` is intentionally agnostic to paging. It takes
+//
+//   v_in     [N, H, D] f32   partial outputs, each already normalized by its
+//                            own softmax denominator
+//   lse_in   [N, H]    f32   matching log-sum-exp values, in **log2 units**
+//   o_indptr [M + 1]   i32   variable-length grouping: output row `o` merges
+//                            partial rows `[o_indptr[o], o_indptr[o + 1])`
+//
+// and returns `(v_out [M, H, D] f32, lse_out [M, H] f32)` using
+//
+//   m = max(lse_a, lse_b); w_a = exp2(lse_a - m); w_b = exp2(lse_b - m)
+//   out = (w_a * v_a + w_b * v_b) / (w_a + w_b)
+//   lse_out = log2(w_a + w_b) + m
+//
+// generalized to a variable-length group. The algebra is associative and
+// commutative, so a shared-prefix (cascade) decomposition can feed the same
+// kernel with a different `o_indptr` and nothing else. An empty group, and a
+// partial whose `lse` is `-inf` (an empty chunk), both contribute nothing;
+// an output row with no finite partial yields zeros and `lse_out = -inf`.
+//
+// **LSE units are log2, not natural log.** The partial kernel folds `log2(e)`
+// into the attention scale so its online softmax runs on `exp2`, and it emits
+// `lse = max_2 + log2(sum exp2(score_2 - max_2))`. A consumer that wants the
+// natural-log LSE multiplies by `ln(2)`.
+//
+// ## Backends
+//
+// Metal and CUDA JIT bodies live in one translation unit and are selected at
+// runtime, following the dual-source pattern of `paged_attention.cpp`. The CUDA
+// bodies are structurally parallel ports of the Metal ones and are
+// **unvalidated**: issue #898 was implemented on an Apple Silicon host with no
+// CUDA hardware and no `nvcc`, so they have never been compiled or run.
+
+#include <vector>
+
+#include <mlx/array.h>
+
+namespace mlxcel::turbo {
+
+// Query heads one CTA processes together, for a head dimension and GQA group
+// size `n_rep = Hq / Hkv`.
+//
+// One CTA reads each KV element once and reuses it across every query head it
+// owns, so a larger value amortizes the KV read; the accumulator
+// `acc[QHeads * DimsPerThread]` lives in registers, so too large a value
+// spills. The returned value always divides `n_rep`, so the query heads of one
+// KV head partition exactly into `n_rep / result` CTA groups with no ragged
+// remainder. Exposed so the Rust plan derives its CTA count from the same
+// source of truth as the launcher.
+int paged_attention_v2_q_heads_per_cta(int dim, int n_rep);
+
+// SIMD groups (warps) per CTA for a head dimension and CTA query-head count.
+//
+// Bounded by the `tg_acc[NumWarps * QHeads * Dim]` threadgroup-memory budget
+// (the same ~28 KB ceiling v1 uses) and capped at 8; always a power of two.
+// Warps stripe the chunk's tokens, so this is a second, intra-CTA token split
+// on top of the cross-CTA chunk split.
+int paged_attention_v2_num_warps(int dim, int q_heads_per_cta);
+
+// Run the v2 partial kernel over one batch's CSR page table.
+//
+// Inputs:
+// - `q`:                 `[B, Hq, 1, head_dim]` f32.
+// - `k_pool` / `v_pool`: `[num_blocks, page_size, Hkv, head_dim]` f16.
+// - `indices`:           `[total_pages]` i32 flat physical pool rows.
+// - `indptr`:            `[B + 1]` i32 per-request page-range prefix sums.
+// - `last_page_len`:     `[B]` i32 valid entries in each request's last page.
+// - `first_page_offset`: `[B]` i32 first visible entry in the first page.
+// - `request_indices`:   `[num_chunks]` i32 request id of each chunk.
+// - `kv_tile_indices`:   `[num_chunks]` i32 chunk index within its request.
+// - `params`:            `[1]` i32, `params[0] = pages_per_chunk`.
+// - `scale`:             attention scale applied to the QK dot product.
+//
+// Returns `{partial_v [num_chunks, Hq, head_dim] f32,
+//           lse [num_chunks, Hq] f32}`.
+//
+// When the plan emitted exactly one chunk per request (in request order), the
+// partial output *is* the final answer: `partial_v` reshapes to
+// `[B, Hq, 1, head_dim]` and no merge launch is needed. That is the "write O
+// directly" case, decided on the host so no output element is ever left
+// unwritten.
+std::vector<mlx::core::array> paged_attention_decode_v2_partial(
+    const mlx::core::array& q,
+    const mlx::core::array& k_pool,
+    const mlx::core::array& v_pool,
+    const mlx::core::array& indices,
+    const mlx::core::array& indptr,
+    const mlx::core::array& last_page_len,
+    const mlx::core::array& first_page_offset,
+    const mlx::core::array& request_indices,
+    const mlx::core::array& kv_tile_indices,
+    const mlx::core::array& params,
+    float scale);
+
+// Variable-length merge over attention states. See the merge-kernel contract
+// above; `v_in` is `[N, H, D]` f32, `lse_in` is `[N, H]` f32 in log2 units, and
+// `o_indptr` is `[M + 1]` i32. Returns `{v_out [M, H, D] f32,
+// lse_out [M, H] f32}`.
+std::vector<mlx::core::array> paged_attention_merge_states(
+    const mlx::core::array& v_in,
+    const mlx::core::array& lse_in,
+    const mlx::core::array& o_indptr);
+
+} // namespace mlxcel::turbo

--- a/src/lib/mlx-cpp/turbo/paged_attention_v2_merge.cpp
+++ b/src/lib/mlx-cpp/turbo/paged_attention_v2_merge.cpp
@@ -1,0 +1,229 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Variable-length attention-state merge kernel (issue #898).
+//
+// Split out of `paged_attention_v2.cpp` because it is the reusable half: the
+// cascade-attention issue #903 consumes it unchanged, driving it with a
+// different `o_indptr` and nothing else. It knows nothing about pages, block
+// tables, or GQA; it merges `(V, LSE)` states. See `paged_attention_v2.h` for
+// the full contract, including the log2 LSE units.
+
+#include "paged_attention_v2.h"
+
+#include <mlx/fast.h>
+#include <mlx/ops.h>
+
+#include <mlx/backend/cuda/cuda.h>
+#include <mlx/backend/metal/metal.h>
+
+#include <mutex>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace mlxcel::turbo {
+
+namespace {
+
+// Body of the merge kernel (Metal).
+//
+// One thread owns one `(output row, head, dim)` element and walks that row's
+// partial list once, keeping a running `(max, denominator, weighted sum)`. The
+// LSE values are re-read per thread rather than staged in threadgroup memory:
+// they are `H` floats per partial against `H * D` for the values, so the extra
+// traffic is 1/D of the V traffic and lands in cache, and in exchange the
+// kernel needs no threadgroup memory and no barrier, which is what keeps it
+// usable for an arbitrary grouping.
+//
+// Grid `(Dim, H, M)` over threadgroup `(Dim, 1, 1)`: one threadgroup per
+// `(output row, head)`.
+//
+// Buffers:
+//   v_in     [N, H, Dim]  f32   partials, each already softmax-normalized
+//   lse_in   [N, H]       f32   matching LSE, log2 units
+//   o_indptr [M + 1]      i32   output row o merges [o_indptr[o], o_indptr[o+1])
+//   out_v    [M, H, Dim]  f32
+//   out_lse  [M, H]       f32
+constexpr const char* PAGED_ATTENTION_MERGE_SOURCE = R"(
+    uint d = thread_position_in_threadgroup.x;       // 0 .. Dim-1
+    uint h = threadgroup_position_in_grid.y;         // head
+    uint o = threadgroup_position_in_grid.z;         // output row
+
+    uint dim = (uint)Dim;
+    uint heads = (uint)v_in_shape[1];
+    if (d >= dim || h >= heads) {
+        return;
+    }
+
+    uint begin = (uint)o_indptr[o];
+    uint end = (uint)o_indptr[o + 1];
+
+    float m = -INFINITY;
+    float l = 0.0f;
+    float acc = 0.0f;
+    for (uint i = begin; i < end; i++) {
+        float s = lse_in[i * heads + h];
+        // Skips -inf (an empty chunk) and any NaN, so an empty partial can
+        // never poison the rescale with (-inf) - (-inf).
+        if (!(s > -INFINITY)) {
+            continue;
+        }
+        float m_new = fmax(m, s);
+        float corr = exp2(m - m_new);
+        float w = exp2(s - m_new);
+        l = l * corr + w;
+        acc = acc * corr + w * v_in[(i * heads + h) * dim + d];
+        m = m_new;
+    }
+
+    out_v[(o * heads + h) * dim + d] = l > 0.0f ? (acc / l) : 0.0f;
+    if (d == 0u) {
+        out_lse[o * heads + h] = l > 0.0f ? (m + log2(l)) : -INFINITY;
+    }
+)";
+
+// CUDA port of the merge kernel.
+//
+// **Unvalidated**: no CUDA hardware and no `nvcc` were available for issue
+// #898. Structurally identical to the Metal body; `exp2`/`log2`/`fmax` become
+// `exp2f`/`log2f`/`fmaxf` and the thread indices come from `threadIdx` /
+// `blockIdx`. MLX ceil-divides the total-thread grid by the threadgroup tuple,
+// so grid `(Dim, H, M)` over threadgroup `(Dim, 1, 1)` yields blocks
+// `(1, H, M)` with `blockDim = (Dim, 1, 1)`. The kernel has no barrier, so the
+// early `return` on the guard is safe.
+constexpr const char* PAGED_ATTENTION_MERGE_CUDA_SOURCE = R"(
+    uint32_t d = threadIdx.x;
+    uint32_t h = blockIdx.y;
+    uint32_t o = blockIdx.z;
+
+    uint32_t dim = (uint32_t)Dim;
+    uint32_t heads = (uint32_t)v_in_shape[1];
+    if (d >= dim || h >= heads) {
+        return;
+    }
+
+    uint32_t begin = (uint32_t)o_indptr[o];
+    uint32_t end = (uint32_t)o_indptr[o + 1];
+
+    float m = -INFINITY;
+    float l = 0.0f;
+    float acc = 0.0f;
+    for (uint32_t i = begin; i < end; i++) {
+        float s = lse_in[i * heads + h];
+        if (!(s > -INFINITY)) {
+            continue;
+        }
+        float m_new = fmaxf(m, s);
+        float corr = exp2f(m - m_new);
+        float w = exp2f(s - m_new);
+        l = l * corr + w;
+        acc = acc * corr + w * v_in[(i * heads + h) * dim + d];
+        m = m_new;
+    }
+
+    out_v[(o * heads + h) * dim + d] = l > 0.0f ? (acc / l) : 0.0f;
+    if (d == 0u) {
+        out_lse[o * heads + h] = l > 0.0f ? (m + log2f(l)) : -INFINITY;
+    }
+)";
+
+const std::vector<std::string>& merge_input_names() {
+    static const std::vector<std::string> names = {"v_in", "lse_in", "o_indptr"};
+    return names;
+}
+
+const std::vector<std::string>& merge_output_names() {
+    static const std::vector<std::string> names = {"out_v", "out_lse"};
+    return names;
+}
+
+struct PagedMergeHolder {
+    std::optional<mlx::core::fast::CustomKernelFunction> kernel;
+    std::once_flag init_flag;
+    bool cuda;
+
+    explicit PagedMergeHolder(bool use_cuda) : cuda(use_cuda) {}
+
+    mlx::core::fast::CustomKernelFunction& get() {
+        std::call_once(init_flag, [this] {
+            kernel = cuda
+                ? mlx::core::fast::cuda_kernel(
+                      "mlxcel_paged_attention_merge_states",
+                      merge_input_names(),
+                      merge_output_names(),
+                      std::string(PAGED_ATTENTION_MERGE_CUDA_SOURCE))
+                : mlx::core::fast::metal_kernel(
+                      "mlxcel_paged_attention_merge_states",
+                      merge_input_names(),
+                      merge_output_names(),
+                      std::string(PAGED_ATTENTION_MERGE_SOURCE));
+        });
+        return *kernel;
+    }
+};
+
+inline PagedMergeHolder& get_merge_kernel(bool cuda) {
+    static PagedMergeHolder metal_holder(false);
+    static PagedMergeHolder cuda_holder(true);
+    return cuda ? cuda_holder : metal_holder;
+}
+
+} // namespace
+
+std::vector<mlx::core::array> paged_attention_merge_states(
+    const mlx::core::array& v_in,
+    const mlx::core::array& lse_in,
+    const mlx::core::array& o_indptr) {
+    using mlx::core::Dtype;
+    using mlx::core::Shape;
+    using mlx::core::fast::TemplateArg;
+
+    const auto& v_shape = v_in.shape(); // [N, H, Dim]
+    int heads = v_shape[1];
+    int dim = v_shape[2];
+    int num_outputs = static_cast<int>(o_indptr.size()) - 1;
+    if (num_outputs < 0) {
+        num_outputs = 0;
+    }
+
+    const bool use_cuda = !mlx::core::metal::is_available();
+    auto& kernel = get_merge_kernel(use_cuda).get();
+
+    std::vector<std::pair<std::string, TemplateArg>> template_args = {
+        {"Dim", dim},
+    };
+
+    std::vector<mlx::core::array> inputs = {v_in, lse_in, o_indptr};
+    std::vector<Shape> output_shapes = {
+        Shape{num_outputs, heads, dim},
+        Shape{num_outputs, heads},
+    };
+    std::vector<Dtype> output_dtypes = {mlx::core::float32, mlx::core::float32};
+
+    return kernel(
+        inputs,
+        output_shapes,
+        output_dtypes,
+        std::make_tuple(dim, heads, num_outputs), // grid
+        std::make_tuple(dim, 1, 1),               // threadgroup
+        template_args,
+        std::nullopt,
+        false,
+        {});
+}
+
+} // namespace mlxcel::turbo

--- a/src/lib/mlxcel-core/build.rs
+++ b/src/lib/mlxcel-core/build.rs
@@ -56,6 +56,13 @@ fn main() {
         // table with no separate gather copy; the gather-then-SDPA path stays
         // the correctness reference and fallback.
         .file("../mlx-cpp/turbo/paged_attention.cpp")
+        // Paged-attention decode v2 (#898): CSR page table plus cross-CTA
+        // split-KV in `paged_attention_v2.cpp`, and the variable-length
+        // attention-state merge kernel in `paged_attention_v2_merge.cpp`. The
+        // merge half is split out because the cascade issue #903 reuses it
+        // unchanged. v1 above stays intact and remains the default path.
+        .file("../mlx-cpp/turbo/paged_attention_v2.cpp")
+        .file("../mlx-cpp/turbo/paged_attention_v2_merge.cpp")
         // Softmax-free Gumbel-max categorical sampling kernel launcher (#900).
         // Replaces the `random::categorical` normalization pass plus the
         // `argpartition` sort on the no-filter sampling path with one
@@ -181,6 +188,10 @@ fn main() {
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/paged_attention.h");
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/paged_attention.cpp");
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/paged_attention.metal");
+
+    println!("cargo:rerun-if-changed=../mlx-cpp/turbo/paged_attention_v2.h");
+    println!("cargo:rerun-if-changed=../mlx-cpp/turbo/paged_attention_v2.cpp");
+    println!("cargo:rerun-if-changed=../mlx-cpp/turbo/paged_attention_v2_merge.cpp");
     // Gumbel-max categorical sampling kernel launcher (#900).
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/sampling.h");
     println!("cargo:rerun-if-changed=../mlx-cpp/turbo/sampling.cpp");

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_bridge.h
@@ -2022,6 +2022,54 @@ std::unique_ptr<MlxArray> paged_attention_decode(
 // the threadgroup-memory budget (issue #906).
 int32_t paged_attention_num_splits_cap(int32_t dim);
 
+// Paged-attention decode v2 partial kernel (issue #898). Wraps
+// `mlxcel::turbo::paged_attention_decode_v2_partial`: cross-CTA split-KV over a
+// CSR page table, one CTA per `(chunk, kv head, q-head group)`. `q` is
+// `[B, Hq, 1, D]` f32; `k_pool` / `v_pool` are `[num_blocks, page_size, Hkv,
+// D]` f16; `indices` / `indptr` / `last_page_len` / `first_page_offset` are the
+// CSR view; `request_indices` / `kv_tile_indices` / `params` come from the
+// host-side plan. Both outputs come back through out-params because cxx cannot
+// return a tuple of `unique_ptr`: `partial_v_out` is
+// `[num_chunks, Hq, D]` f32 and `lse_out` is `[num_chunks, Hq]` f32 in log2
+// units.
+void paged_attention_decode_v2_partial(
+    const MlxArray& q,
+    const MlxArray& k_pool,
+    const MlxArray& v_pool,
+    const MlxArray& indices,
+    const MlxArray& indptr,
+    const MlxArray& last_page_len,
+    const MlxArray& first_page_offset,
+    const MlxArray& request_indices,
+    const MlxArray& kv_tile_indices,
+    const MlxArray& params,
+    float scale,
+    std::unique_ptr<MlxArray>& partial_v_out,
+    std::unique_ptr<MlxArray>& lse_out);
+
+// Variable-length attention-state merge kernel (issue #898). Wraps
+// `mlxcel::turbo::paged_attention_merge_states`. `v_in` is `[N, H, D]` f32
+// (each partial already softmax-normalized), `lse_in` is `[N, H]` f32 in log2
+// units, and `o_indptr` is `[M + 1]` i32 grouping partial rows into output
+// rows. Returns `[M, H, D]` f32 and `[M, H]` f32 through the out-params. The
+// cascade-attention issue #903 reuses this kernel unchanged.
+void paged_attention_merge_states(
+    const MlxArray& v_in,
+    const MlxArray& lse_in,
+    const MlxArray& o_indptr,
+    std::unique_ptr<MlxArray>& v_out,
+    std::unique_ptr<MlxArray>& lse_out);
+
+// Query heads one v2 CTA processes together, forwarded from
+// `mlxcel::turbo::paged_attention_v2_q_heads_per_cta` (issue #898). Always
+// divides `n_rep`. The Rust plan derives its CTA count from this so the plan
+// and the launcher cannot drift.
+int32_t paged_attention_v2_q_heads_per_cta(int32_t dim, int32_t n_rep);
+
+// SIMD groups per v2 CTA, forwarded from
+// `mlxcel::turbo::paged_attention_v2_num_warps` (issue #898).
+int32_t paged_attention_v2_num_warps(int32_t dim, int32_t q_heads_per_cta);
+
 // Fused residual-add + RMSNorm kernel launcher (issue #905).
 //
 // Wraps `mlxcel::turbo::fused_add_rms_norm`. Computes `new_residual = x +

--- a/src/lib/mlxcel-core/cpp/mlx_cxx_ext.cpp
+++ b/src/lib/mlxcel-core/cpp/mlx_cxx_ext.cpp
@@ -6,6 +6,7 @@
 #include "sparse_v_sdpa.h"          // fused Sparse-V SDPA kernel.
 #include "turbo4_delegated_sdpa.h"  // fused Turbo4Delegated SDPA kernel.
 #include "paged_attention.h"        // fused paged-attention decode kernel (#123).
+#include "paged_attention_v2.h"     // paged decode v2 + merge kernels (#898).
 #include "fused_norm.h"             // fused residual-add + RMSNorm kernel (#905).
 #include "fused_rope_append.h"      // fused q/k RoPE + KV-append layout (#905).
 
@@ -227,6 +228,62 @@ std::unique_ptr<MlxArray> paged_attention_decode(
 int32_t paged_attention_num_splits_cap(int32_t dim) {
     return static_cast<int32_t>(
         mlxcel::turbo::paged_attention_num_splits_cap(static_cast<int>(dim)));
+}
+
+// Paged-attention decode v2 (issue #898). Implementation in
+// `src/lib/mlx-cpp/turbo/paged_attention_v2.cpp` (partial kernel) and
+// `paged_attention_v2_merge.cpp` (merge kernel); forwarded here so the symbols
+// show up in the cxx-bridge ABI. Two outputs each, so both use out-params.
+void paged_attention_decode_v2_partial(
+    const MlxArray& q,
+    const MlxArray& k_pool,
+    const MlxArray& v_pool,
+    const MlxArray& indices,
+    const MlxArray& indptr,
+    const MlxArray& last_page_len,
+    const MlxArray& first_page_offset,
+    const MlxArray& request_indices,
+    const MlxArray& kv_tile_indices,
+    const MlxArray& params,
+    float scale,
+    std::unique_ptr<MlxArray>& partial_v_out,
+    std::unique_ptr<MlxArray>& lse_out) {
+    auto outs = mlxcel::turbo::paged_attention_decode_v2_partial(
+        q.inner,
+        k_pool.inner,
+        v_pool.inner,
+        indices.inner,
+        indptr.inner,
+        last_page_len.inner,
+        first_page_offset.inner,
+        request_indices.inner,
+        kv_tile_indices.inner,
+        params.inner,
+        scale);
+    partial_v_out = std::make_unique<MlxArray>(std::move(outs[0]));
+    lse_out = std::make_unique<MlxArray>(std::move(outs[1]));
+}
+
+void paged_attention_merge_states(
+    const MlxArray& v_in,
+    const MlxArray& lse_in,
+    const MlxArray& o_indptr,
+    std::unique_ptr<MlxArray>& v_out,
+    std::unique_ptr<MlxArray>& lse_out) {
+    auto outs = mlxcel::turbo::paged_attention_merge_states(
+        v_in.inner, lse_in.inner, o_indptr.inner);
+    v_out = std::make_unique<MlxArray>(std::move(outs[0]));
+    lse_out = std::make_unique<MlxArray>(std::move(outs[1]));
+}
+
+int32_t paged_attention_v2_q_heads_per_cta(int32_t dim, int32_t n_rep) {
+    return static_cast<int32_t>(mlxcel::turbo::paged_attention_v2_q_heads_per_cta(
+        static_cast<int>(dim), static_cast<int>(n_rep)));
+}
+
+int32_t paged_attention_v2_num_warps(int32_t dim, int32_t q_heads_per_cta) {
+    return static_cast<int32_t>(mlxcel::turbo::paged_attention_v2_num_warps(
+        static_cast<int>(dim), static_cast<int>(q_heads_per_cta)));
 }
 
 // Fused residual-add + RMSNorm kernel launcher (issue #905). Implementation in

--- a/src/lib/mlxcel-core/src/autotune/mod.rs
+++ b/src/lib/mlxcel-core/src/autotune/mod.rs
@@ -60,23 +60,22 @@
 //! `mlxcel tune` wrote but never profiles at runtime; `MLXCEL_AUTOTUNE=1`
 //! additionally profiles on the first use of a bucket.
 //!
-//! ## Extension point for paged decode v2 (issue #898)
+//! ## Extension point for paged decode v2 (issue #898, now occupied)
 //!
 //! Issue #898's paged-decode v2 plan chooses a `kv_chunk_size`, which is
-//! exactly the shape-dependent knob this module exists for. The seam is
-//! deliberately left as a seam rather than a speculative implementation: when
-//! #898 lands its plan builder, it should
+//! exactly the shape-dependent knob this module exists for. That seam is now
+//! filled by [`ops::paged_decode_v2_chunk`], which does precisely what this
+//! note prescribed:
 //!
-//! 1. register its op under [`OP_PAGED_DECODE_V2_KV_CHUNK`],
-//! 2. implement [`TunableOp`] over its own candidate chunk sizes with
-//!    `default_tactic` returning whatever heuristic the plan would have used,
-//! 3. call [`resolve`] once per plan build and read the chunk size out of
+//! 1. registers its op under [`OP_PAGED_DECODE_V2_KV_CHUNK`],
+//! 2. implements [`TunableOp`] over its own candidate chunk sizes with
+//!    `default_tactic` returning the plan's binary-search heuristic,
+//! 3. calls [`resolve`] once per plan build and reads the chunk size out of
 //!    [`Resolution::tactic`] via [`Tactic::param`].
 //!
-//! No code here needs to change for that: the key, the store, and the harness
-//! are op-agnostic. Do not pre-build the v2 candidate set here; the feasible
-//! chunk sizes depend on the v2 plan's own memory accounting, which does not
-//! exist yet.
+//! No code here changed for it: the key, the store, and the harness are
+//! op-agnostic, and the feasible chunk sizes are enumerated by the v2 plan's
+//! own accounting rather than being pre-built here.
 
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};

--- a/src/lib/mlxcel-core/src/autotune/ops/mod.rs
+++ b/src/lib/mlxcel-core/src/autotune/ops/mod.rs
@@ -17,20 +17,25 @@
 //! | Op | Backend | Knob | Status |
 //! |----|---------|------|--------|
 //! | [`paged_decode_splits`] | Metal + CUDA | v1 paged-decode `NumSplits` launch shape | Wired end to end; the Apple-Silicon-tunable op. |
+//! | [`paged_decode_v2_chunk`] | Metal + CUDA | v2 paged-decode `pages_per_chunk` | Wired end to end (issue #898); reachable only when `MLXCEL_PAGED_ATTENTION_V2=1` selects the v2 path. |
 //! | [`cuda_kernel_knobs::QmmTileOp`] | CUDA | Blackwell qmm CTA `tile_m` | Wired, **unvalidated** (no CUDA host was available). |
 //! | [`cuda_kernel_knobs::QmvMultirowOp`] | CUDA | multirow-qmv row-window ceiling | Wired, **unvalidated** (no CUDA host was available). |
 //!
-//! A fourth consumer, issue #898's paged-decode v2 `kv_chunk_size`, is
-//! deliberately absent: #898 is not implemented yet and its feasible chunk
-//! sizes depend on the v2 plan's own memory accounting. The seam it should
-//! plug into is documented in [`crate::autotune`] under
-//! [`crate::autotune::OP_PAGED_DECODE_V2_KV_CHUNK`]; no code here needs to
-//! change to accept it.
+//! [`paged_decode_v2_chunk`] is the consumer the reserved
+//! [`crate::autotune::OP_PAGED_DECODE_V2_KV_CHUNK`] name was held for. Nothing
+//! in the autotuner itself changed to accept it, as that module's extension
+//! note predicted: it registers under the reserved name, enumerates its own
+//! feasible chunk sizes, and returns the plan's binary-search heuristic as its
+//! default tactic.
 
 pub mod cuda_kernel_knobs;
 pub mod paged_decode_splits;
+pub mod paged_decode_v2_chunk;
 
 pub use cuda_kernel_knobs::{
     QmmShape, QmmTileOp, QmvMultirowOp, QmvShape, apply_tuned_cuda_kernel_env,
 };
 pub use paged_decode_splits::{DecodeShape, PagedDecodeSplitsOp, resolve_num_splits};
+pub use paged_decode_v2_chunk::{
+    PagedDecodeV2ChunkOp, V2ChunkShape, chunk_candidates, resolve_pages_per_chunk,
+};

--- a/src/lib/mlxcel-core/src/autotune/ops/paged_decode_v2_chunk.rs
+++ b/src/lib/mlxcel-core/src/autotune/ops/paged_decode_v2_chunk.rs
@@ -301,7 +301,10 @@ mod tests {
         assert_eq!(c.first(), Some(&1));
         assert!(c.contains(&24), "the heuristic must be measurable: {c:?}");
         assert!(c.contains(&64), "the ceiling must be measurable: {c:?}");
-        assert!(c.windows(2).all(|w| w[0] < w[1]), "sorted and deduped: {c:?}");
+        assert!(
+            c.windows(2).all(|w| w[0] < w[1]),
+            "sorted and deduped: {c:?}"
+        );
     }
 
     #[test]

--- a/src/lib/mlxcel-core/src/autotune/ops/paged_decode_v2_chunk.rs
+++ b/src/lib/mlxcel-core/src/autotune/ops/paged_decode_v2_chunk.rs
@@ -1,0 +1,346 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Autotuned `pages_per_chunk` for paged decode v2 (issues #906, #898).
+//!
+//! This is the consumer issue #906 reserved
+//! [`crate::autotune::OP_PAGED_DECODE_V2_KV_CHUNK`] for, plugged in exactly as
+//! that module's extension note prescribes: register under the reserved name,
+//! implement [`TunableOp`] over the feasible chunk sizes, and read the winner
+//! out of the resolution.
+//!
+//! ## Why the chunk size is a tuned knob and not a formula
+//!
+//! [`crate::paged_v2::plan`] derives its default by binary-searching for the
+//! largest chunk size whose CTA count still reaches an occupancy target. That
+//! target is derived from a device-scale proxy, not measured, and the real
+//! optimum trades three costs the proxy does not model: the partial kernel's
+//! per-chunk fixed work, the merge kernel's per-partial traffic, and the tail
+//! effect of a chunk count that is not a multiple of the device's resident CTA
+//! capacity. Those are per-shape, which is what the shape-bucketed cache is for.
+//!
+//! ## Feasible set
+//!
+//! Powers of two between [`crate::paged_v2::min_pages_per_chunk`] (the grid-z
+//! bound) and [`crate::paged_v2::max_pages_per_chunk`] (above which every
+//! request is one chunk and larger values are the same plan), plus the
+//! heuristic value itself. Including the heuristic matters: the profiler only
+//! switches away from the default when the win clears its noise margin, which
+//! requires the default to have been measured.
+//!
+//! ## Cost when the autotuner is off
+//!
+//! [`resolve_pages_per_chunk`] returns the heuristic after one `OnceLock` read
+//! and one mode read: no cache read, no lock, no filesystem access. Since
+//! paged decode v2 is itself off by default in issue #898, the whole path is
+//! unreachable in a default process.
+
+use std::sync::OnceLock;
+
+use crate::autotune::bucket::{ShapeBucket, powers_of_two_up_to, round_up_pow2};
+use crate::autotune::tactic::{Tactic, TunableOp, TuneError};
+use crate::autotune::{OP_PAGED_DECODE_V2_KV_CHUNK, Source, mode};
+use crate::paged_v2::plan::{PagedDecodePlan, max_pages_per_chunk, min_pages_per_chunk};
+use crate::paged_v2::{PagedDecodeGeometry, V2Context};
+
+/// Explicit operator override, matching the `MLXCEL_PAGED_DECODE_SPLITS` /
+/// `MLXCEL_QMM_TILE_*` escape-hatch convention. Wins over any tuned or cached
+/// value.
+pub const CHUNK_ENV: &str = "MLXCEL_PAGED_DECODE_V2_CHUNK";
+
+/// Tactic parameter index for the chunk size.
+const PARAM_PAGES_PER_CHUNK: usize = 0;
+
+/// The explicit [`CHUNK_ENV`] value, read once.
+///
+/// A non-positive or unparseable value is ignored with a warning rather than
+/// clamped, so a typo degrades to the heuristic instead of pinning an arbitrary
+/// chunk size. The plan clamps whatever survives into the feasible range, so an
+/// over-large value is safe.
+fn env_pages_per_chunk() -> Option<i32> {
+    static VALUE: OnceLock<Option<i32>> = OnceLock::new();
+    *VALUE.get_or_init(|| {
+        let raw = std::env::var(CHUNK_ENV).ok()?;
+        match raw.trim().parse::<i32>() {
+            Ok(v) if v >= 1 => Some(v),
+            _ => {
+                tracing::warn!(
+                    "{CHUNK_ENV}={raw:?} is not a positive integer; ignoring it and using the planned chunk size"
+                );
+                None
+            }
+        }
+    })
+}
+
+/// Candidate chunk sizes for a `[min, max]` feasible range plus the heuristic.
+///
+/// Sorted and deduplicated so the profiler's report reads in order and no
+/// candidate is measured twice.
+#[must_use]
+pub fn chunk_candidates(min_pages: i32, max_pages: i32, heuristic: i32) -> Vec<i64> {
+    let lo = min_pages.max(1);
+    let hi = max_pages.max(lo);
+    let mut out: Vec<i64> = powers_of_two_up_to(hi.max(0) as u32)
+        .into_iter()
+        .map(i64::from)
+        .filter(|&v| v >= i64::from(lo))
+        .collect();
+    for extra in [i64::from(hi), i64::from(heuristic.clamp(lo, hi))] {
+        if !out.contains(&extra) {
+            out.push(extra);
+        }
+    }
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+/// Launch shape of one v2 decode, used as cache-key material.
+///
+/// `batch` and `max_pages` are bucketed because they drift continuously during
+/// serving; the head counts, head dim, and page size are model or pool
+/// constants that each change the kernel specialization or the feasible range,
+/// so merging them across buckets would mix incomparable regimes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct V2ChunkShape {
+    pub batch: usize,
+    pub geometry: PagedDecodeGeometry,
+    /// Largest per-request page count in the batch.
+    pub max_pages: usize,
+}
+
+impl V2ChunkShape {
+    #[must_use]
+    pub fn bucket(&self) -> ShapeBucket {
+        ShapeBucket::from_exact(&[
+            round_up_pow2(self.batch),
+            self.geometry.q_heads.max(0) as u32,
+            self.geometry.kv_heads.max(0) as u32,
+            self.geometry.head_dim.max(0) as u32,
+            self.geometry.page_size.max(0) as u32,
+            round_up_pow2(self.max_pages),
+        ])
+    }
+}
+
+/// [`TunableOp`] over a real v2 launch.
+///
+/// Profiling re-runs the actual partial (and, where the tactic implies one,
+/// merge) launch against the actual pool and page table rather than a synthetic
+/// stand-in, so the measurement includes the real scatter pattern and the real
+/// merge width. The context is borrowed, so no arrays are rebuilt per candidate
+/// and the sweep times the kernels rather than the setup.
+pub struct PagedDecodeV2ChunkOp<'a> {
+    ctx: &'a V2Context<'a>,
+    page_counts: &'a [usize],
+    target_ctas: usize,
+    heuristic: i32,
+    min_pages: i32,
+    max_pages: i32,
+    shape: V2ChunkShape,
+}
+
+impl<'a> PagedDecodeV2ChunkOp<'a> {
+    #[must_use]
+    pub fn new(
+        ctx: &'a V2Context<'a>,
+        page_counts: &'a [usize],
+        target_ctas: usize,
+        heuristic: i32,
+    ) -> Self {
+        let max_pages = max_pages_per_chunk(page_counts);
+        Self {
+            ctx,
+            page_counts,
+            target_ctas,
+            heuristic,
+            min_pages: min_pages_per_chunk(page_counts),
+            max_pages,
+            shape: V2ChunkShape {
+                batch: page_counts.len(),
+                geometry: ctx.geometry,
+                max_pages: max_pages.max(0) as usize,
+            },
+        }
+    }
+
+    fn plan_for(&self, pages_per_chunk: i32, source: Source) -> PagedDecodePlan {
+        PagedDecodePlan::with_chunk_size(
+            self.ctx.geometry,
+            self.page_counts,
+            pages_per_chunk,
+            self.target_ctas,
+            source,
+        )
+    }
+}
+
+impl TunableOp for PagedDecodeV2ChunkOp<'_> {
+    fn op_name(&self) -> &str {
+        OP_PAGED_DECODE_V2_KV_CHUNK
+    }
+
+    fn runner_id(&self) -> String {
+        // The launcher picks the Metal or CUDA JIT body from the live backend,
+        // and the two are different kernels; keep their tactics apart.
+        if crate::metal_is_available() {
+            "metal".to_string()
+        } else {
+            "cuda".to_string()
+        }
+    }
+
+    fn dtype_tag(&self) -> String {
+        // Both kernels accumulate and emit f32 regardless of the pool dtype
+        // (the caller casts around them), so the tactic is dtype-invariant.
+        "f32".to_string()
+    }
+
+    fn bucket(&self) -> ShapeBucket {
+        self.shape.bucket()
+    }
+
+    fn candidates(&self, _bucket: &ShapeBucket) -> Vec<Tactic> {
+        chunk_candidates(self.min_pages, self.max_pages, self.heuristic)
+            .into_iter()
+            .map(|v| Tactic::scalar("pages_per_chunk", v))
+            .collect()
+    }
+
+    fn default_tactic(&self, _bucket: &ShapeBucket) -> Tactic {
+        Tactic::scalar("pages_per_chunk", i64::from(self.heuristic))
+    }
+
+    fn env_override(&self) -> Option<Tactic> {
+        env_pages_per_chunk().map(|v| Tactic::scalar("pages_per_chunk", i64::from(v)))
+    }
+
+    fn run(&self, tactic: &Tactic) -> Result<(), TuneError> {
+        let chunk = tactic
+            .param(PARAM_PAGES_PER_CHUNK)
+            .ok_or_else(|| TuneError::infeasible(tactic, "tactic carries no chunk size"))?;
+        let chunk = i32::try_from(chunk)
+            .map_err(|_| TuneError::infeasible(tactic, "chunk size out of range"))?;
+        if chunk < self.min_pages || chunk > self.max_pages {
+            return Err(TuneError::infeasible(
+                tactic,
+                format!(
+                    "chunk size outside the feasible [{}, {}]",
+                    self.min_pages, self.max_pages
+                ),
+            ));
+        }
+        let plan = self.plan_for(chunk, Source::Tuned);
+        let out = self
+            .ctx
+            .launch(&plan)
+            .map_err(|e| TuneError::failed(tactic, e))?;
+        crate::eval(&out);
+        Ok(())
+    }
+}
+
+/// Resolve the chunk size for one v2 launch, with the full precedence chain
+/// (env override, cached tactic, profiled tactic, heuristic).
+///
+/// Returns the size and where it came from, so the plan records its own
+/// provenance. Never fails: every error path in the autotuner falls back to
+/// `heuristic`, which is what the plan would have used on its own.
+#[must_use]
+pub fn resolve_pages_per_chunk(
+    ctx: &V2Context<'_>,
+    page_counts: &[usize],
+    target_ctas: usize,
+    heuristic: i32,
+) -> (i32, Source) {
+    if let Some(v) = env_pages_per_chunk() {
+        return (v, Source::EnvOverride);
+    }
+    if !mode().reads_cache() {
+        return (heuristic, Source::Default);
+    }
+    let op = PagedDecodeV2ChunkOp::new(ctx, page_counts, target_ctas, heuristic);
+    let resolution = crate::autotune::resolve(&op);
+    if resolution.source.is_default() {
+        return (heuristic, resolution.source);
+    }
+    match resolution.param(PARAM_PAGES_PER_CHUNK) {
+        Some(v) if v >= 1 => (i32::try_from(v).unwrap_or(heuristic), resolution.source),
+        _ => (heuristic, Source::Default),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn geometry() -> PagedDecodeGeometry {
+        PagedDecodeGeometry {
+            q_heads: 32,
+            kv_heads: 8,
+            head_dim: 128,
+            page_size: 32,
+        }
+    }
+
+    #[test]
+    fn candidates_span_the_feasible_range_and_include_the_heuristic() {
+        let c = chunk_candidates(1, 64, 24);
+        assert_eq!(c.first(), Some(&1));
+        assert!(c.contains(&24), "the heuristic must be measurable: {c:?}");
+        assert!(c.contains(&64), "the ceiling must be measurable: {c:?}");
+        assert!(c.windows(2).all(|w| w[0] < w[1]), "sorted and deduped: {c:?}");
+    }
+
+    #[test]
+    fn candidates_respect_a_raised_floor() {
+        // A grid-z-bounded batch cannot use fine chunks at all.
+        let c = chunk_candidates(16, 64, 16);
+        assert!(c.iter().all(|&v| v >= 16), "{c:?}");
+    }
+
+    #[test]
+    fn candidates_never_empty_for_a_degenerate_range() {
+        let c = chunk_candidates(1, 1, 1);
+        assert_eq!(c, vec![1]);
+        let c = chunk_candidates(8, 4, 8);
+        assert!(!c.is_empty(), "{c:?}");
+    }
+
+    #[test]
+    fn the_bucket_separates_shapes_that_are_not_comparable() {
+        let a = V2ChunkShape {
+            batch: 4,
+            geometry: geometry(),
+            max_pages: 128,
+        };
+        let mut other = geometry();
+        other.head_dim = 64;
+        let b = V2ChunkShape {
+            batch: 4,
+            geometry: other,
+            max_pages: 128,
+        };
+        assert_ne!(a.bucket(), b.bucket());
+
+        // Nearby contexts share a bucket, which is the point of bucketing.
+        let c = V2ChunkShape {
+            batch: 4,
+            geometry: geometry(),
+            max_pages: 100,
+        };
+        assert_eq!(a.bucket(), c.bucket());
+    }
+}

--- a/src/lib/mlxcel-core/src/cache.rs
+++ b/src/lib/mlxcel-core/src/cache.rs
@@ -78,6 +78,9 @@
 pub mod batch_quant;
 mod detach;
 mod paged;
+/// CSR page-table view of a decode batch, consumed by the paged decode v2
+/// kernels (issue #898).
+pub mod paged_csr;
 mod paged_detach;
 #[cfg(test)]
 #[path = "cache/paged_pool_tests.rs"]
@@ -103,6 +106,7 @@ pub use paged::{
     GatheredKv, PagedBlockId, PagedBlockPool, PagedCacheStats, PagedKvLayout, PagedLayerState,
     PagedSequenceState,
 };
+pub use paged_csr::{PagedCsrView, build_paged_csr_view};
 pub use paged_detach::DetachedPagedCacheSet;
 pub use ring::RingSlidingKVCache;
 

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -1572,6 +1572,27 @@ impl PagedBlockPool {
         )))
     }
 
+    /// The layer's K and V pool tensors when it occupies exactly one slab.
+    ///
+    /// Both fused decode kernels (v1 and v2) read one contiguous pool buffer
+    /// per side, so a layer that has grown past a single slab (#235) cannot be
+    /// handed over at all; `None` is the decline signal every caller answers by
+    /// falling back to the gather path. `None` also covers a layer whose pool
+    /// storage has not been allocated yet.
+    ///
+    /// Public so that the paged decode v2 correctness harness under
+    /// `examples/` can drive the kernels directly against a synthetic pool.
+    #[must_use]
+    pub fn single_slab_tensors(&self, layer_idx: usize) -> Option<(&MlxArray, &MlxArray)> {
+        match (
+            self.pool_k.get(layer_idx).map(Vec::as_slice),
+            self.pool_v.get(layer_idx).map(Vec::as_slice),
+        ) {
+            (Some([k]), Some([v])) => Some((k, v)),
+            _ => None,
+        }
+    }
+
     /// CSR page-table view of `states` for one layer (issue #898).
     ///
     /// This is the metadata the v2 decode kernels consume in place of v1's
@@ -1604,6 +1625,61 @@ impl PagedBlockPool {
         })
     }
 
+    /// Paged decode v2 over the pool: CSR page table, cross-CTA split-KV, and
+    /// the variable-length merge (issue #898).
+    ///
+    /// The v2 counterpart of [`Self::paged_decode_fused`], with the same
+    /// contract: `q` is `[B, Hq, 1, head_dim]`, `states[b]` is sequence b's
+    /// per-layer state, and the result is `[B, Hq, 1, head_dim]` in `q`'s
+    /// dtype. Returns `None` whenever v2 cannot serve the shape (multi-slab
+    /// layer, no visible tokens, or a geometry the kernel declines), which the
+    /// caller answers by falling back to v1 or to gather.
+    ///
+    /// Reachable only through [`Self::paged_decode_fused`] under
+    /// `MLXCEL_PAGED_ATTENTION_V2=1`, or directly by the correctness harness.
+    /// Production dispatch is issue #899.
+    pub fn paged_decode_fused_v2(
+        &self,
+        q: &MlxArray,
+        states: &[&PagedSequenceState],
+        layer_idx: usize,
+        scale: f32,
+    ) -> Result<Option<UniquePtr<MlxArray>>, String> {
+        // Same single-slab restriction as v1: both kernels read one contiguous
+        // pool buffer per side, so a layer that has grown past one slab (#235)
+        // is declined rather than stitched.
+        let Some((pool_k, pool_v)) = self.single_slab_tensors(layer_idx) else {
+            return Ok(None);
+        };
+
+        let view = self.paged_csr_view(states, layer_idx)?;
+        if !view.any_visible() {
+            return Ok(None);
+        }
+
+        // The kernels read Q and emit their output in f32 deterministically
+        // (they never re-specialise by dtype). Cast Q in and the result back to
+        // Q's dtype so v2 is directly comparable with v1 and with gather.
+        let q_dtype = ffi::array_dtype(q);
+        let q_f32 = if q_dtype == crate::dtype::FLOAT32 {
+            None
+        } else {
+            Some(ffi::astype(q, crate::dtype::FLOAT32))
+        };
+        let q_in: &MlxArray = q_f32.as_deref().unwrap_or(q);
+
+        let Some(out_f32) = crate::paged_v2::run_decode_v2(q_in, pool_k, pool_v, &view, scale)?
+        else {
+            return Ok(None);
+        };
+        let out = if q_dtype == crate::dtype::FLOAT32 {
+            out_f32
+        } else {
+            ffi::astype(&out_f32, q_dtype)
+        };
+        Ok(Some(out))
+    }
+
     /// Fused paged-attention decode over the pool via the native Metal kernel
     /// (epic #116 Phase 6, #123).
     ///
@@ -1627,6 +1703,17 @@ impl PagedBlockPool {
         layer_idx: usize,
         scale: f32,
     ) -> Result<Option<UniquePtr<MlxArray>>, String> {
+        // Paged decode v2 (#898), off by default. `v2_enabled()` is one
+        // `OnceLock` load, so with `MLXCEL_PAGED_ATTENTION_V2` unset nothing
+        // below this line differs from the pre-#898 path: no v2 array is built
+        // and neither v2 kernel is JIT-compiled. When v2 declines the shape it
+        // returns `None` and the v1 path below runs unchanged.
+        if crate::paged_v2::v2_enabled()
+            && let Some(out) = self.paged_decode_fused_v2(q, states, layer_idx, scale)?
+        {
+            return Ok(Some(out));
+        }
+
         // The fused kernel reads one contiguous pool buffer per side. With
         // chunked slabs (#235) a layer that has grown past one slab cannot be
         // handed over as a single buffer, so decline and let the caller use

--- a/src/lib/mlxcel-core/src/cache/paged.rs
+++ b/src/lib/mlxcel-core/src/cache/paged.rs
@@ -1572,6 +1572,38 @@ impl PagedBlockPool {
         )))
     }
 
+    /// CSR page-table view of `states` for one layer (issue #898).
+    ///
+    /// This is the metadata the v2 decode kernels consume in place of v1's
+    /// `rows` / `row_offsets` / `logical_starts` / `visible_lens` quadruple; see
+    /// [`crate::cache::paged_csr`] for the layout and why it carries a
+    /// `first_page_offset`. Only pages holding visible tokens are emitted, and
+    /// shared (refcounted) blocks resolve to the same physical row in every
+    /// request that references them.
+    ///
+    /// Pure metadata: no MLX arrays are built here, so a caller may cache the
+    /// view across decode steps for as long as the batch composition and the
+    /// block tables are unchanged.
+    pub fn paged_csr_view(
+        &self,
+        states: &[&PagedSequenceState],
+        layer_idx: usize,
+    ) -> Result<crate::cache::paged_csr::PagedCsrView, String> {
+        let mut layers: Vec<&PagedLayerState> = Vec::with_capacity(states.len());
+        for state in states {
+            layers.push(state.layer(layer_idx).ok_or_else(|| {
+                format!(
+                    "PagedBlockPool::paged_csr_view: layer {layer_idx} out of range for {} layers",
+                    state.layers.len()
+                )
+            })?);
+        }
+        let rows = self.block_rows.get(layer_idx);
+        crate::cache::paged_csr::build_paged_csr_view(self.layout.block_size, &layers, |block_id| {
+            rows.and_then(|map| map.get(&block_id).copied())
+        })
+    }
+
     /// Fused paged-attention decode over the pool via the native Metal kernel
     /// (epic #116 Phase 6, #123).
     ///

--- a/src/lib/mlxcel-core/src/cache/paged_csr.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_csr.rs
@@ -175,7 +175,9 @@ impl PagedCsrView {
         for r in 0..b {
             let pages = i64::from(self.indptr[r + 1] - self.indptr[r]);
             if pages < 0 {
-                return Err(format!("PagedCsrView: request {r} has a negative page span"));
+                return Err(format!(
+                    "PagedCsrView: request {r} has a negative page span"
+                ));
             }
             let seq_len = i64::from(self.seq_lens[r]);
             let fpo = i64::from(self.first_page_offset[r]);

--- a/src/lib/mlxcel-core/src/cache/paged_csr.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_csr.rs
@@ -1,0 +1,302 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! CSR page-table view of an active decode batch (issue #898).
+//!
+//! The v1 fused kernel takes the block table as four arrays
+//! (`rows` / `row_offsets` / `logical_starts` / `visible_lens`) in which `rows`
+//! carries *every* block a sequence still owns, visible or not, and the kernel
+//! offsets into it by absolute token position. That works, but it cannot
+//! express "start this request's page list here", which is what a cross-CTA
+//! chunk split needs in order to address a chunk by page range.
+//!
+//! The v2 kernels take the standard compressed-sparse-row layout instead:
+//!
+//! | array | shape | meaning |
+//! |-------|-------|---------|
+//! | `indices` | `[total_pages]` | flat physical pool rows, requests concatenated |
+//! | `indptr` | `[B + 1]` | prefix sums delimiting each request's pages |
+//! | `last_page_len` | `[B]` | valid entries in the request's final page |
+//! | `first_page_offset` | `[B]` | first visible entry in the request's first page |
+//!
+//! `first_page_offset` is the mlxcel extension to the canonical three-array
+//! form. A sequence trimmed by a sliding window keeps
+//! [`PagedLayerState::logical_start`] mid-page, and the canonical layout (which
+//! assumes every request starts at entry 0 of its first page) cannot say so.
+//! With it, request `r`'s visible token `i` resolves to
+//!
+//! ```text
+//! abs   = first_page_offset[r] + i
+//! page  = indices[indptr[r] + abs / page_size]
+//! entry = abs % page_size
+//! ```
+//!
+//! and its visible length is
+//! `(pages - 1) * page_size + last_page_len[r] - first_page_offset[r]`.
+//! [`PagedCsrView::validate`] asserts exactly that identity.
+//!
+//! Only pages that contain visible tokens are emitted. A sliding window that
+//! has retired the first three pages of a request drops them from `indices`
+//! rather than carrying them and skipping them in the kernel, so the plan's
+//! page counts are the real work counts.
+//!
+//! Shared (refcounted) blocks need no special handling: two requests that share
+//! a prefix resolve the same [`PagedBlockId`] to the same physical row, so the
+//! row simply appears in both requests' slices of `indices`. That is what makes
+//! the same view usable for the cascade decomposition in issue #903.
+
+use super::paged::{PagedBlockId, PagedLayerState};
+
+/// Flat CSR page table for one layer of one decode batch, plus the per-request
+/// scalars the v2 kernels and the RoPE position need.
+///
+/// Plain data: no MLX arrays, no borrows of the pool. It is cheap to build, to
+/// compare, and to cache across decode steps while the batch composition is
+/// unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PagedCsrView {
+    /// Tokens per pool page (the pool's `block_size`).
+    pub page_size: i32,
+    /// Flat physical pool rows, requests concatenated in block-table order.
+    pub indices: Vec<i32>,
+    /// `[B + 1]` prefix sums into [`Self::indices`].
+    pub indptr: Vec<i32>,
+    /// `[B]` valid entries in each request's final page (`0` when the request
+    /// has no visible tokens).
+    pub last_page_len: Vec<i32>,
+    /// `[B]` index of the first visible entry inside each request's first page.
+    pub first_page_offset: Vec<i32>,
+    /// `[B]` visible token count, derived and kept so the plan does not
+    /// recompute it.
+    pub seq_lens: Vec<i32>,
+    /// `[B]` RoPE position offset: the absolute position the *next* token of
+    /// this request will occupy, which is the request's total written length
+    /// ([`PagedLayerState::len`]) and not its visible length. A sliding window
+    /// trims the visible window from the front without rewinding positions, so
+    /// these two differ exactly when `logical_start > 0`.
+    pub rope_offsets: Vec<i32>,
+}
+
+impl PagedCsrView {
+    /// Number of requests in the batch.
+    #[must_use]
+    pub fn batch(&self) -> usize {
+        self.seq_lens.len()
+    }
+
+    /// Total pages across the batch (`indices.len()`).
+    #[must_use]
+    pub fn total_pages(&self) -> usize {
+        self.indices.len()
+    }
+
+    /// Pages belonging to request `b`, or `0` when out of range.
+    #[must_use]
+    pub fn pages_for(&self, b: usize) -> usize {
+        match (self.indptr.get(b), self.indptr.get(b + 1)) {
+            (Some(&begin), Some(&end)) if end >= begin => (end - begin) as usize,
+            _ => 0,
+        }
+    }
+
+    /// Per-request page counts, the input the chunk plan sizes itself from.
+    #[must_use]
+    pub fn page_counts(&self) -> Vec<usize> {
+        (0..self.batch()).map(|b| self.pages_for(b)).collect()
+    }
+
+    /// Largest visible context in the batch.
+    #[must_use]
+    pub fn max_seq_len(&self) -> usize {
+        self.seq_lens.iter().copied().max().unwrap_or(0).max(0) as usize
+    }
+
+    /// Whether any request has a visible token. An all-empty batch has nothing
+    /// for the kernel to do, and the caller falls back rather than launching an
+    /// empty grid.
+    #[must_use]
+    pub fn any_visible(&self) -> bool {
+        self.seq_lens.iter().any(|&l| l > 0)
+    }
+
+    /// Check the structural invariants the v2 kernels rely on.
+    ///
+    /// Cheap (one pass over the batch, not over the pages) and called on every
+    /// build, because every one of these violations is a silent out-of-bounds
+    /// read inside the kernel rather than an error.
+    pub fn validate(&self) -> Result<(), String> {
+        let b = self.batch();
+        if self.page_size <= 0 {
+            return Err(format!(
+                "PagedCsrView: page_size must be positive, got {}",
+                self.page_size
+            ));
+        }
+        if self.indptr.len() != b + 1 {
+            return Err(format!(
+                "PagedCsrView: indptr has {} entries, expected batch + 1 = {}",
+                self.indptr.len(),
+                b + 1
+            ));
+        }
+        if self.last_page_len.len() != b
+            || self.first_page_offset.len() != b
+            || self.rope_offsets.len() != b
+        {
+            return Err(format!(
+                "PagedCsrView: per-request arrays disagree on batch size (last_page_len {}, first_page_offset {}, rope_offsets {}, seq_lens {b})",
+                self.last_page_len.len(),
+                self.first_page_offset.len(),
+                self.rope_offsets.len()
+            ));
+        }
+        if self.indptr.first() != Some(&0) {
+            return Err("PagedCsrView: indptr must start at 0".to_string());
+        }
+        if self.indptr.last().copied().unwrap_or(0) as usize != self.indices.len() {
+            return Err(format!(
+                "PagedCsrView: indptr ends at {:?} but indices has {} entries",
+                self.indptr.last(),
+                self.indices.len()
+            ));
+        }
+        let page_size = self.page_size;
+        for r in 0..b {
+            let pages = i64::from(self.indptr[r + 1] - self.indptr[r]);
+            if pages < 0 {
+                return Err(format!("PagedCsrView: request {r} has a negative page span"));
+            }
+            let seq_len = i64::from(self.seq_lens[r]);
+            let fpo = i64::from(self.first_page_offset[r]);
+            let lpl = i64::from(self.last_page_len[r]);
+            if pages == 0 {
+                if seq_len != 0 || fpo != 0 || lpl != 0 {
+                    return Err(format!(
+                        "PagedCsrView: request {r} has no pages but seq_len {seq_len}, first_page_offset {fpo}, last_page_len {lpl}"
+                    ));
+                }
+                continue;
+            }
+            if fpo < 0 || fpo >= i64::from(page_size) {
+                return Err(format!(
+                    "PagedCsrView: request {r} first_page_offset {fpo} outside [0, {page_size})"
+                ));
+            }
+            if lpl < 1 || lpl > i64::from(page_size) {
+                return Err(format!(
+                    "PagedCsrView: request {r} last_page_len {lpl} outside [1, {page_size}]"
+                ));
+            }
+            let expected = (pages - 1) * i64::from(page_size) + lpl - fpo;
+            if expected != seq_len {
+                return Err(format!(
+                    "PagedCsrView: request {r} seq_len {seq_len} contradicts its page geometry (pages {pages}, page_size {page_size}, last_page_len {lpl}, first_page_offset {fpo} => {expected})"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Build the CSR view for one layer of a decode batch.
+///
+/// `row_of` resolves a [`PagedBlockId`] to its physical pool row for the layer
+/// in question; it is a closure so this builder stays free of the pool's
+/// private storage and is directly testable against a synthetic mapping.
+/// [`crate::cache::PagedBlockPool::paged_csr_view`] is the production caller.
+///
+/// Errors when a layer's `len` outruns its retained blocks (the same
+/// front/back asymmetry guard `gather_visible` and `paged_decode_fused` apply)
+/// or when a visible block has no pool row, which means it was never written.
+pub fn build_paged_csr_view<F>(
+    page_size: usize,
+    layers: &[&PagedLayerState],
+    mut row_of: F,
+) -> Result<PagedCsrView, String>
+where
+    F: FnMut(PagedBlockId) -> Option<usize>,
+{
+    if page_size == 0 {
+        return Err("build_paged_csr_view: page_size must be > 0".to_string());
+    }
+    let batch = layers.len();
+    let mut view = PagedCsrView {
+        page_size: page_size as i32,
+        indices: Vec::new(),
+        indptr: Vec::with_capacity(batch + 1),
+        last_page_len: Vec::with_capacity(batch),
+        first_page_offset: Vec::with_capacity(batch),
+        seq_lens: Vec::with_capacity(batch),
+        rope_offsets: Vec::with_capacity(batch),
+    };
+    view.indptr.push(0);
+
+    for (r, layer) in layers.iter().enumerate() {
+        let n_blocks = layer.block_ids.len();
+        if layer.len > n_blocks * page_size {
+            return Err(format!(
+                "build_paged_csr_view: request {r} len {} exceeds {n_blocks} blocks * page_size {page_size}",
+                layer.len
+            ));
+        }
+        let visible = layer.visible_len();
+        // `rope_offsets` records the absolute next-token position, so it is the
+        // written length even for a front-trimmed sequence.
+        view.rope_offsets.push(clamp_i32(layer.len));
+        if visible == 0 {
+            view.indptr.push(view.indices.len() as i32);
+            view.last_page_len.push(0);
+            view.first_page_offset.push(0);
+            view.seq_lens.push(0);
+            continue;
+        }
+
+        let first_page = layer.logical_start / page_size;
+        let last_page = (layer.len - 1) / page_size;
+        for page in first_page..=last_page {
+            let block_id = *layer.block_ids.get(page).ok_or_else(|| {
+                format!(
+                    "build_paged_csr_view: request {r} visible page {page} is past its {n_blocks} retained blocks"
+                )
+            })?;
+            let row = row_of(block_id).ok_or_else(|| {
+                format!(
+                    "build_paged_csr_view: request {r} block {block_id} has no pool row (was it written?)"
+                )
+            })?;
+            view.indices.push(clamp_i32(row));
+        }
+        view.indptr.push(view.indices.len() as i32);
+        view.last_page_len
+            .push(clamp_i32((layer.len - 1) % page_size + 1));
+        view.first_page_offset
+            .push(clamp_i32(layer.logical_start % page_size));
+        view.seq_lens.push(clamp_i32(visible));
+    }
+
+    view.validate()?;
+    Ok(view)
+}
+
+/// Saturating `usize -> i32`. Every field of the view is an i32 because the
+/// kernels read them as i32; a pool large enough to overflow would have failed
+/// allocation long before, and saturating keeps the conversion total instead of
+/// wrapping into a negative index.
+fn clamp_i32(v: usize) -> i32 {
+    i32::try_from(v).unwrap_or(i32::MAX)
+}
+
+#[cfg(test)]
+#[path = "paged_csr_tests.rs"]
+mod paged_csr_tests;

--- a/src/lib/mlxcel-core/src/cache/paged_csr_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_csr_tests.rs
@@ -197,10 +197,8 @@ fn len_outrunning_the_block_table_is_rejected() {
 #[test]
 fn an_unwritten_block_is_rejected_rather_than_read() {
     let a = layer(&[0, 1], 8, 0);
-    let err = build_paged_csr_view(4, &[&a], |id| {
-        if id.as_u64() == 1 { None } else { Some(0) }
-    })
-    .unwrap_err();
+    let err = build_paged_csr_view(4, &[&a], |id| if id.as_u64() == 1 { None } else { Some(0) })
+        .unwrap_err();
     assert!(err.contains("no pool row"), "unexpected error: {err}");
 }
 

--- a/src/lib/mlxcel-core/src/cache/paged_csr_tests.rs
+++ b/src/lib/mlxcel-core/src/cache/paged_csr_tests.rs
@@ -1,0 +1,330 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the CSR page-table view (issue #898).
+//!
+//! Two layers of coverage:
+//!
+//! 1. The pure builder against synthetic [`PagedLayerState`]s, where the block
+//!    tables, the shared rows, and the trimmed windows can be constructed
+//!    exactly. This is where the page-geometry identity is pinned.
+//! 2. The pool method [`PagedBlockPool::paged_csr_view`] against a real pool,
+//!    so the row resolution and the refcounted-block path are exercised
+//!    end to end.
+
+use super::*;
+use crate::cache::paged::{PagedBlockPool, PagedKvLayout, PagedSequenceState};
+
+/// Synthetic layer state: block ids `ids`, written length `len`, visible window
+/// starting at `logical_start`.
+fn layer(ids: &[u64], len: usize, logical_start: usize) -> PagedLayerState {
+    PagedLayerState {
+        block_ids: ids.iter().copied().map(PagedBlockId::from_raw).collect(),
+        len,
+        logical_start,
+    }
+}
+
+/// Identity row mapping: block id `n` lives at pool row `n`.
+fn identity_rows(id: PagedBlockId) -> Option<usize> {
+    Some(id.as_u64() as usize)
+}
+
+fn build(page_size: usize, layers: &[&PagedLayerState]) -> PagedCsrView {
+    build_paged_csr_view(page_size, layers, identity_rows).expect("view builds")
+}
+
+// ---------------------------------------------------------------------------
+// Pure builder
+// ---------------------------------------------------------------------------
+
+#[test]
+fn full_pages_produce_a_dense_csr() {
+    // 3 full pages of 4 tokens, nothing trimmed.
+    let a = layer(&[7, 8, 9], 12, 0);
+    let view = build(4, &[&a]);
+
+    assert_eq!(view.indices, vec![7, 8, 9]);
+    assert_eq!(view.indptr, vec![0, 3]);
+    assert_eq!(view.first_page_offset, vec![0]);
+    assert_eq!(view.last_page_len, vec![4]);
+    assert_eq!(view.seq_lens, vec![12]);
+    assert_eq!(view.rope_offsets, vec![12]);
+    assert_eq!(view.page_counts(), vec![3]);
+    assert_eq!(view.max_seq_len(), 12);
+    assert!(view.any_visible());
+}
+
+#[test]
+fn partial_last_page_reports_its_valid_entries() {
+    // 9 tokens over 4-token pages: 2 full pages plus 1 valid entry.
+    let a = layer(&[0, 1, 2], 9, 0);
+    let view = build(4, &[&a]);
+
+    assert_eq!(view.indptr, vec![0, 3]);
+    assert_eq!(view.last_page_len, vec![1]);
+    assert_eq!(view.seq_lens, vec![9]);
+}
+
+#[test]
+fn a_full_final_page_reports_page_size_not_zero() {
+    // The `(len - 1) % page_size + 1` form exists so an exactly-full final page
+    // reports `page_size`; a plain `len % page_size` would report 0 and make
+    // the kernel skip the whole page.
+    for page_size in [16usize, 32, 64] {
+        let a = layer(&[0, 1], 2 * page_size, 0);
+        let view = build(page_size, &[&a]);
+        assert_eq!(view.last_page_len, vec![page_size as i32]);
+        assert_eq!(view.seq_lens, vec![2 * page_size as i32]);
+    }
+}
+
+#[test]
+fn a_trimmed_window_drops_retired_pages_and_offsets_into_the_first() {
+    // Sliding window trimmed the first 6 of 12 tokens (page size 4): pages 0 is
+    // fully retired, page 1 starts at entry 2.
+    let a = layer(&[10, 11, 12], 12, 6);
+    let view = build(4, &[&a]);
+
+    assert_eq!(view.indices, vec![11, 12], "retired page 0 is not emitted");
+    assert_eq!(view.first_page_offset, vec![2]);
+    assert_eq!(view.last_page_len, vec![4]);
+    assert_eq!(view.seq_lens, vec![6]);
+    // The absolute position of the next token is unaffected by the trim.
+    assert_eq!(view.rope_offsets, vec![12]);
+}
+
+#[test]
+fn geometry_identity_holds_across_a_randomized_sweep() {
+    // (pages - 1) * page_size + last_page_len - first_page_offset == seq_len is
+    // the identity the kernel's token->page arithmetic inverts, so sweep it.
+    let mut state = 0x243f_6a88_85a3_08d3u64;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    for _ in 0..500 {
+        let page_size = [16usize, 32, 64][(next() % 3) as usize];
+        let len = 1 + (next() % 400) as usize;
+        let logical_start = (next() % len as u64) as usize;
+        let n_blocks = len.div_ceil(page_size);
+        let ids: Vec<u64> = (0..n_blocks as u64).collect();
+        let l = layer(&ids, len, logical_start);
+        let view = build(page_size, &[&l]);
+        // `validate` already asserts the identity; re-derive it here so the
+        // test fails on the identity itself rather than on a helper.
+        let pages = view.pages_for(0) as i64;
+        let expected = (pages - 1) * page_size as i64 + i64::from(view.last_page_len[0])
+            - i64::from(view.first_page_offset[0]);
+        assert_eq!(expected, i64::from(view.seq_lens[0]));
+        assert_eq!(view.seq_lens[0] as usize, len - logical_start);
+    }
+}
+
+#[test]
+fn shared_blocks_appear_in_every_owner() {
+    // Two requests share a two-page prefix (blocks 3 and 4) and diverge after.
+    let a = layer(&[3, 4, 5], 12, 0);
+    let b = layer(&[3, 4, 6], 10, 0);
+    let view = build(4, &[&a, &b]);
+
+    assert_eq!(view.indices, vec![3, 4, 5, 3, 4, 6]);
+    assert_eq!(view.indptr, vec![0, 3, 6]);
+    assert_eq!(view.seq_lens, vec![12, 10]);
+    assert_eq!(view.last_page_len, vec![4, 2]);
+    assert_eq!(view.page_counts(), vec![3, 3]);
+}
+
+#[test]
+fn an_empty_request_contributes_no_pages() {
+    let a = layer(&[1, 2], 8, 0);
+    let empty = layer(&[], 0, 0);
+    let c = layer(&[3], 3, 0);
+    let view = build(4, &[&a, &empty, &c]);
+
+    assert_eq!(view.indptr, vec![0, 2, 2, 3]);
+    assert_eq!(view.seq_lens, vec![8, 0, 3]);
+    assert_eq!(view.last_page_len, vec![4, 0, 3]);
+    assert_eq!(view.first_page_offset, vec![0, 0, 0]);
+    assert_eq!(view.pages_for(1), 0);
+    assert!(view.any_visible());
+}
+
+#[test]
+fn a_fully_trimmed_request_is_empty_but_keeps_its_rope_offset() {
+    // logical_start == len: every token retired. The request contributes no
+    // pages, but its next token still lands at absolute position `len`.
+    let a = layer(&[0, 1], 8, 8);
+    let view = build(4, &[&a]);
+
+    assert!(view.indices.is_empty());
+    assert_eq!(view.seq_lens, vec![0]);
+    assert_eq!(view.rope_offsets, vec![8]);
+    assert!(!view.any_visible());
+}
+
+#[test]
+fn all_empty_batch_reports_no_visible_tokens() {
+    let a = layer(&[], 0, 0);
+    let b = layer(&[], 0, 0);
+    let view = build(32, &[&a, &b]);
+    assert!(!view.any_visible());
+    assert_eq!(view.total_pages(), 0);
+    assert_eq!(view.max_seq_len(), 0);
+}
+
+#[test]
+fn len_outrunning_the_block_table_is_rejected() {
+    // Two 4-token pages cannot hold 12 tokens.
+    let a = layer(&[0, 1], 12, 0);
+    let err = build_paged_csr_view(4, &[&a], identity_rows).unwrap_err();
+    assert!(err.contains("exceeds"), "unexpected error: {err}");
+}
+
+#[test]
+fn an_unwritten_block_is_rejected_rather_than_read() {
+    let a = layer(&[0, 1], 8, 0);
+    let err = build_paged_csr_view(4, &[&a], |id| {
+        if id.as_u64() == 1 { None } else { Some(0) }
+    })
+    .unwrap_err();
+    assert!(err.contains("no pool row"), "unexpected error: {err}");
+}
+
+#[test]
+fn zero_page_size_is_rejected() {
+    let a = layer(&[0], 1, 0);
+    let err = build_paged_csr_view(0, &[&a], identity_rows).unwrap_err();
+    assert!(err.contains("page_size"), "unexpected error: {err}");
+}
+
+#[test]
+fn validate_rejects_a_hand_corrupted_view() {
+    let a = layer(&[0, 1], 8, 0);
+    let mut view = build(4, &[&a]);
+    view.seq_lens[0] = 7; // contradicts the page geometry
+    let err = view.validate().unwrap_err();
+    assert!(err.contains("contradicts"), "unexpected error: {err}");
+
+    let mut view = build(4, &[&a]);
+    view.indptr.pop();
+    assert!(view.validate().is_err());
+
+    let mut view = build(4, &[&a]);
+    view.last_page_len[0] = 0;
+    assert!(view.validate().is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Through a real pool
+// ---------------------------------------------------------------------------
+
+const H: i32 = 2;
+const D: i32 = 3;
+
+fn fp16_pool(block_size: usize) -> PagedBlockPool {
+    let layout =
+        PagedKvLayout::uniform(1, block_size, block_size * H as usize * D as usize * 2).unwrap();
+    PagedBlockPool::new(layout)
+}
+
+fn write_all_blocks(pool: &mut PagedBlockPool, state: &PagedSequenceState, block_size: usize) {
+    let ids = state.layer(0).unwrap().block_ids.clone();
+    for id in ids {
+        let k = crate::ffi::zeros(&[1, H, block_size as i32, D], crate::dtype::FLOAT16);
+        let v = crate::ffi::zeros(&[1, H, block_size as i32, D], crate::dtype::FLOAT16);
+        pool.write_block(id, 0, 0, &k, &v).unwrap();
+    }
+}
+
+#[test]
+fn pool_view_resolves_physical_rows_in_block_table_order() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size);
+    let mut state = PagedSequenceState::new(pool.layout());
+    pool.append_tokens(&mut state, 0, 10).unwrap();
+    write_all_blocks(&mut pool, &state, block_size);
+
+    let view = pool.paged_csr_view(&[&state], 0).unwrap();
+    assert_eq!(view.page_size, block_size as i32);
+    assert_eq!(view.indptr, vec![0, 3]);
+    assert_eq!(view.seq_lens, vec![10]);
+    assert_eq!(view.last_page_len, vec![2]);
+    assert_eq!(view.first_page_offset, vec![0]);
+    // Rows are assigned in first-write order, which is block-table order here.
+    assert_eq!(view.indices, vec![0, 1, 2]);
+}
+
+#[test]
+fn pool_view_shares_rows_between_prefix_sharing_sequences() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size);
+
+    let mut a = PagedSequenceState::new(pool.layout());
+    pool.append_tokens(&mut a, 0, 8).unwrap();
+    write_all_blocks(&mut pool, &a, block_size);
+
+    // Fork: b adopts a's two blocks (refcount bump) and appends its own.
+    let mut b = PagedSequenceState::new(pool.layout());
+    let shared = a.layer(0).unwrap().block_ids.clone();
+    for id in &shared {
+        pool.retain_block(*id).unwrap();
+    }
+    {
+        let layer_b = b.layer_mut(0).unwrap();
+        layer_b.block_ids = shared.clone();
+        layer_b.len = 8;
+    }
+    pool.append_tokens(&mut b, 0, 2).unwrap();
+    write_all_blocks(&mut pool, &b, block_size);
+
+    let view = pool.paged_csr_view(&[&a, &b], 0).unwrap();
+    assert_eq!(view.indptr, vec![0, 2, 5]);
+    // Both requests resolve the shared prefix to the same physical rows.
+    assert_eq!(view.indices[0..2], view.indices[2..4]);
+    assert_eq!(view.seq_lens, vec![8, 10]);
+    assert_eq!(view.last_page_len, vec![4, 2]);
+    for id in &shared {
+        assert_eq!(pool.refcount(*id), 2);
+    }
+}
+
+#[test]
+fn pool_view_after_a_trim_drops_retired_pages() {
+    let block_size = 4usize;
+    let mut pool = fp16_pool(block_size);
+    let mut state = PagedSequenceState::new(pool.layout());
+    pool.append_tokens(&mut state, 0, 12).unwrap();
+    write_all_blocks(&mut pool, &state, block_size);
+
+    // Retire the first 6 tokens from the front.
+    state.layer_mut(0).unwrap().logical_start = 6;
+
+    let view = pool.paged_csr_view(&[&state], 0).unwrap();
+    assert_eq!(view.pages_for(0), 2);
+    assert_eq!(view.first_page_offset, vec![2]);
+    assert_eq!(view.seq_lens, vec![6]);
+    assert_eq!(view.rope_offsets, vec![12]);
+}
+
+#[test]
+fn pool_view_rejects_an_out_of_range_layer() {
+    let mut pool = fp16_pool(4);
+    let mut state = PagedSequenceState::new(pool.layout());
+    pool.append_tokens(&mut state, 0, 4).unwrap();
+    let err = pool.paged_csr_view(&[&state], 7).unwrap_err();
+    assert!(err.contains("out of range"), "unexpected error: {err}");
+}

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -1331,6 +1331,59 @@ mod ffi {
         /// and thread-count budgets.
         fn paged_attention_num_splits_cap(dim: i32) -> i32;
 
+        /// Paged-attention decode v2 partial kernel (issue #898).
+        ///
+        /// Cross-CTA split-KV over a CSR page table: one CTA per `(chunk, kv
+        /// head, q-head group)` computes an online-softmax partial over its
+        /// chunk. `q` is `[B, Hq, 1, D]` f32 and the pools are `[num_blocks,
+        /// page_size, Hkv, D]` f16, as in v1. `indices` / `indptr` /
+        /// `last_page_len` / `first_page_offset` are the CSR view of the batch;
+        /// `request_indices` / `kv_tile_indices` / `params` (`params[0] =
+        /// pages_per_chunk`) come from [`crate::paged_v2::PagedDecodePlan`].
+        ///
+        /// Writes `partial_v_out` `[num_chunks, Hq, D]` f32 and `lse_out`
+        /// `[num_chunks, Hq]` f32. The LSE is in **log2 units**. When the plan
+        /// emitted one chunk per request, `partial_v_out` is already the final
+        /// answer and reshapes to `[B, Hq, 1, D]`.
+        fn paged_attention_decode_v2_partial(
+            q: &MlxArray,
+            k_pool: &MlxArray,
+            v_pool: &MlxArray,
+            indices: &MlxArray,
+            indptr: &MlxArray,
+            last_page_len: &MlxArray,
+            first_page_offset: &MlxArray,
+            request_indices: &MlxArray,
+            kv_tile_indices: &MlxArray,
+            params: &MlxArray,
+            scale: f32,
+            partial_v_out: &mut UniquePtr<MlxArray>,
+            lse_out: &mut UniquePtr<MlxArray>,
+        );
+
+        /// Variable-length attention-state merge kernel (issue #898).
+        ///
+        /// Merges `v_in` `[N, H, D]` f32 (each partial already normalized by
+        /// its own softmax denominator) and `lse_in` `[N, H]` f32 (log2 units)
+        /// into `[M, H, D]` / `[M, H]`, where output row `o` covers partial
+        /// rows `[o_indptr[o], o_indptr[o + 1])`. Deliberately paging-agnostic:
+        /// the cascade-attention issue #903 reuses it unchanged.
+        fn paged_attention_merge_states(
+            v_in: &MlxArray,
+            lse_in: &MlxArray,
+            o_indptr: &MlxArray,
+            v_out: &mut UniquePtr<MlxArray>,
+            lse_out: &mut UniquePtr<MlxArray>,
+        );
+
+        /// Query heads one v2 CTA processes together (issue #898). Always
+        /// divides `n_rep`, so the plan's CTA count and the launcher's grid
+        /// cannot drift.
+        fn paged_attention_v2_q_heads_per_cta(dim: i32, n_rep: i32) -> i32;
+
+        /// SIMD groups per v2 CTA (issue #898).
+        fn paged_attention_v2_num_warps(dim: i32, q_heads_per_cta: i32) -> i32;
+
         /// Fused residual-add + RMSNorm kernel (issue #905).
         ///
         /// Computes `new_residual = x + residual` and

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -3168,6 +3168,13 @@ pub mod autotune;
 // Public so that the harnesses under `examples/` can defeat cache warming.
 pub mod bench_rotation;
 
+// Paged-attention decode v2: CSR page table, cross-CTA split-KV, and the
+// variable-length merge kernel (issue #898). Default off; selected by
+// `MLXCEL_PAGED_ATTENTION_V2=1` inside `PagedBlockPool::paged_decode_fused`.
+// Public so that the correctness harness under `examples/` and the follow-up
+// production wiring (#899) can drive the plan and the launch directly.
+pub mod paged_v2;
+
 // Crate-wide helpers for `#[cfg(test)]` paths. Provides the single shared
 // `ENV_LOCK` that every env-mutating test in this crate must acquire; see `test_support::env_lock` for the rationale. `pub(crate)` so
 // that test modules at any depth (e.g. `crate::lang_analyzer::cache::tests`)

--- a/src/lib/mlxcel-core/src/paged_v2/launch.rs
+++ b/src/lib/mlxcel-core/src/paged_v2/launch.rs
@@ -1,0 +1,233 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Run step for paged decode v2 (issue #898).
+//!
+//! Turns a [`PagedCsrView`] plus a [`PagedDecodePlan`] into MLX arrays and the
+//! one or two kernel launches they imply:
+//!
+//! 1. The partial kernel always runs, producing `(partial_v, lse)` over the
+//!    plan's chunks.
+//! 2. The merge kernel runs only when some request has more than one chunk.
+//!    When every request fits in a single chunk the partial output already *is*
+//!    the answer (the plan emits chunks in request order, so chunk `r` is
+//!    request `r`), and it is reshaped rather than merged. That is the issue's
+//!    "write O directly" case, decided on the host so no output element can be
+//!    left unwritten by a kernel that skipped it.
+//!
+//! The workspace is the partial kernel's output arrays. An MLX custom kernel
+//! cannot write through a caller-owned buffer (outputs are values in the graph),
+//! so "caller-provided workspace" becomes "MLX-allocated outputs whose exact
+//! size the plan states up front" via [`PagedDecodePlan::workspace_bytes`].
+
+use cxx::UniquePtr;
+
+use crate::autotune::Source;
+use crate::cache::paged_csr::PagedCsrView;
+use crate::ffi;
+use crate::ffi::MlxArray;
+use crate::paged_v2::plan::{PagedDecodeGeometry, PagedDecodePlan, device_target_ctas};
+
+/// Everything a v2 launch needs except the plan.
+///
+/// Holds the CSR arrays because they are plan-independent: the autotuner
+/// profiles several plans against one context, and rebuilding the page table
+/// per candidate would measure array construction instead of the kernel.
+pub struct V2Context<'a> {
+    /// `[B, Hq, 1, D]` f32 decode query.
+    pub q: &'a MlxArray,
+    /// `[num_blocks, page_size, Hkv, D]` f16 pool tensors.
+    pub k_pool: &'a MlxArray,
+    pub v_pool: &'a MlxArray,
+    pub indices: UniquePtr<MlxArray>,
+    pub indptr: UniquePtr<MlxArray>,
+    pub last_page_len: UniquePtr<MlxArray>,
+    pub first_page_offset: UniquePtr<MlxArray>,
+    pub scale: f32,
+    pub geometry: PagedDecodeGeometry,
+}
+
+impl<'a> V2Context<'a> {
+    /// Materialize the CSR view as MLX arrays.
+    pub fn build(
+        q: &'a MlxArray,
+        k_pool: &'a MlxArray,
+        v_pool: &'a MlxArray,
+        view: &PagedCsrView,
+        geometry: PagedDecodeGeometry,
+        scale: f32,
+    ) -> Result<Self, String> {
+        view.validate()?;
+        let batch = view.batch() as i32;
+        Ok(Self {
+            q,
+            k_pool,
+            v_pool,
+            indices: ffi::from_slice_i32(&view.indices, &[view.indices.len() as i32]),
+            indptr: ffi::from_slice_i32(&view.indptr, &[batch + 1]),
+            last_page_len: ffi::from_slice_i32(&view.last_page_len, &[batch]),
+            first_page_offset: ffi::from_slice_i32(&view.first_page_offset, &[batch]),
+            scale,
+            geometry,
+        })
+    }
+
+    /// Launch the plan and return `[B, Hq, 1, D]` f32.
+    pub fn launch(&self, plan: &PagedDecodePlan) -> Result<UniquePtr<MlxArray>, String> {
+        plan.validate()?;
+        let n = i32::try_from(plan.num_chunks)
+            .map_err(|_| format!("paged decode v2: {} chunks overflows i32", plan.num_chunks))?;
+        let request_indices = ffi::from_slice_i32(&plan.request_indices, &[n]);
+        let kv_tile_indices = ffi::from_slice_i32(&plan.kv_tile_indices, &[n]);
+        let params = ffi::from_slice_i32(&[plan.pages_per_chunk], &[1]);
+
+        let mut partial_v = UniquePtr::null();
+        let mut lse = UniquePtr::null();
+        ffi::paged_attention_decode_v2_partial(
+            self.q,
+            self.k_pool,
+            self.v_pool,
+            &self.indices,
+            &self.indptr,
+            &self.last_page_len,
+            &self.first_page_offset,
+            &request_indices,
+            &kv_tile_indices,
+            &params,
+            self.scale,
+            &mut partial_v,
+            &mut lse,
+        );
+
+        let batch = i32::try_from(plan.batch)
+            .map_err(|_| format!("paged decode v2: batch {} overflows i32", plan.batch))?;
+        let hq = self.geometry.q_heads;
+        let dim = self.geometry.head_dim;
+
+        if !plan.needs_merge {
+            // One chunk per request, emitted in request order: the partial
+            // output is [B, Hq, D] already normalized.
+            return Ok(ffi::reshape(&partial_v, &[batch, hq, 1, dim]));
+        }
+
+        let o_indptr = ffi::from_slice_i32(&plan.o_indptr, &[batch + 1]);
+        let mut merged_v = UniquePtr::null();
+        let mut merged_lse = UniquePtr::null();
+        ffi::paged_attention_merge_states(
+            &partial_v,
+            &lse,
+            &o_indptr,
+            &mut merged_v,
+            &mut merged_lse,
+        );
+        Ok(ffi::reshape(&merged_v, &[batch, hq, 1, dim]))
+    }
+}
+
+/// Geometry implied by a query and a pool tensor.
+///
+/// `q` is `[B, Hq, 1, D]` and the pool is `[num_blocks, page_size, Hkv, D]`,
+/// the layout-A shapes v1 already uses.
+pub fn geometry_from_shapes(q: &MlxArray, k_pool: &MlxArray) -> Result<(usize, PagedDecodeGeometry), String> {
+    let q_shape = ffi::array_shape(q);
+    let pool_shape = ffi::array_shape(k_pool);
+    if q_shape.len() != 4 || pool_shape.len() != 4 {
+        return Err(format!(
+            "paged decode v2: expected 4-D q and pool, got {q_shape:?} and {pool_shape:?}"
+        ));
+    }
+    let batch = q_shape[0].max(0) as usize;
+    let geometry = PagedDecodeGeometry {
+        q_heads: q_shape[1],
+        kv_heads: pool_shape[2],
+        head_dim: q_shape[3],
+        page_size: pool_shape[1],
+    };
+    if geometry.head_dim != pool_shape[3] {
+        return Err(format!(
+            "paged decode v2: q head_dim {} disagrees with pool head_dim {}",
+            geometry.head_dim, pool_shape[3]
+        ));
+    }
+    Ok((batch, geometry))
+}
+
+/// Full v2 decode over one layer's pool.
+///
+/// Returns `Ok(None)` when v2 declines the shape (a geometry it cannot serve,
+/// or a batch with no visible tokens at all), which the caller answers by
+/// falling back exactly as it would if the fused kernel were unavailable.
+/// `Ok(Some(out))` is `[B, Hq, 1, D]` f32.
+pub fn run_decode_v2(
+    q: &MlxArray,
+    k_pool: &MlxArray,
+    v_pool: &MlxArray,
+    view: &PagedCsrView,
+    scale: f32,
+) -> Result<Option<UniquePtr<MlxArray>>, String> {
+    if !view.any_visible() {
+        return Ok(None);
+    }
+    let (batch, geometry) = geometry_from_shapes(q, k_pool)?;
+    if batch != view.batch() {
+        return Err(format!(
+            "paged decode v2: q batch {batch} disagrees with the {} requests in the page view",
+            view.batch()
+        ));
+    }
+    if geometry.page_size != view.page_size {
+        return Err(format!(
+            "paged decode v2: pool page_size {} disagrees with the view's {}",
+            geometry.page_size, view.page_size
+        ));
+    }
+    if let Err(reason) = geometry.check() {
+        tracing::debug!("paged decode v2 declines this shape: {reason}");
+        return Ok(None);
+    }
+
+    let ctx = V2Context::build(q, k_pool, v_pool, view, geometry, scale)?;
+    let page_counts = view.page_counts();
+    let plan = resolve_plan(&ctx, &page_counts);
+    if let Err(reason) = plan.validate() {
+        tracing::debug!("paged decode v2 declines this plan: {reason}");
+        return Ok(None);
+    }
+    ctx.launch(&plan).map(Some)
+}
+
+/// Pick the plan for this launch: the autotuned chunk size when one is
+/// available, the binary-search heuristic otherwise.
+///
+/// With `MLXCEL_AUTOTUNE` unset (the default) this is one env read behind a
+/// `OnceLock` plus the heuristic, with no cache read, no lock, and no
+/// filesystem access.
+pub fn resolve_plan(ctx: &V2Context<'_>, page_counts: &[usize]) -> PagedDecodePlan {
+    let target = device_target_ctas();
+    let heuristic = PagedDecodePlan::heuristic(ctx.geometry, page_counts, target);
+    let (chunk, source) = crate::autotune::ops::paged_decode_v2_chunk::resolve_pages_per_chunk(
+        ctx,
+        page_counts,
+        target,
+        heuristic.pages_per_chunk,
+    );
+    if chunk == heuristic.pages_per_chunk && source == Source::Default {
+        return heuristic;
+    }
+    PagedDecodePlan::with_chunk_size(ctx.geometry, page_counts, chunk, target, source)
+}
+
+#[cfg(test)]
+#[path = "launch_tests.rs"]
+mod launch_tests;

--- a/src/lib/mlxcel-core/src/paged_v2/launch.rs
+++ b/src/lib/mlxcel-core/src/paged_v2/launch.rs
@@ -139,7 +139,10 @@ impl<'a> V2Context<'a> {
 ///
 /// `q` is `[B, Hq, 1, D]` and the pool is `[num_blocks, page_size, Hkv, D]`,
 /// the layout-A shapes v1 already uses.
-pub fn geometry_from_shapes(q: &MlxArray, k_pool: &MlxArray) -> Result<(usize, PagedDecodeGeometry), String> {
+pub fn geometry_from_shapes(
+    q: &MlxArray,
+    k_pool: &MlxArray,
+) -> Result<(usize, PagedDecodeGeometry), String> {
     let q_shape = ffi::array_shape(q);
     let pool_shape = ffi::array_shape(k_pool);
     if q_shape.len() != 4 || pool_shape.len() != 4 {

--- a/src/lib/mlxcel-core/src/paged_v2/launch_tests.rs
+++ b/src/lib/mlxcel-core/src/paged_v2/launch_tests.rs
@@ -1,0 +1,522 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! GPU correctness tests for the paged decode v2 launch (issue #898).
+//!
+//! Deliberately small so they run inside the normal unit-test budget; the wide
+//! matrix (head dims, GQA ratios, block sizes, contexts to 32K, batches) lives
+//! in `examples/paged_decode_v2_correctness.rs`, which is opt-in.
+//!
+//! The reference here is a host-side attention computed in f64 from the same
+//! values that were written into the pool, not another GPU path. That makes a
+//! failure attributable: a mismatch is the kernel, not a disagreement between
+//! two kernels that could both be wrong. The pools are f32 so no quantization
+//! sits between the reference and the kernel, and one test additionally checks
+//! the realistic f16-pool case against the gather-then-SDPA reference.
+
+use super::*;
+use crate::cache::{PagedBlockPool, PagedKvLayout, PagedSequenceState};
+use crate::dtype;
+use crate::ffi;
+use crate::ffi::MlxArray;
+use crate::paged_v2::plan::PagedDecodePlan;
+use cxx::UniquePtr;
+
+/// xorshift64* in [-1, 1). Deterministic so a failure reproduces exactly.
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+    fn next_f32(&mut self) -> f32 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        let unit = ((self.0 >> 40) as f32) / (1u32 << 24) as f32;
+        unit * 2.0 - 1.0
+    }
+}
+
+/// One synthetic decode batch: the pool, the sequence states, and the host copy
+/// of every value written, so a reference can be computed without reading back
+/// from the GPU.
+struct Batch {
+    pool: PagedBlockPool,
+    states: Vec<PagedSequenceState>,
+    /// Per request, `[token][head][dim]` flattened as `((t * hkv) + h) * d + i`.
+    k: Vec<Vec<f32>>,
+    v: Vec<Vec<f32>>,
+    /// `[B][Hq * D]` decode query.
+    q: Vec<Vec<f32>>,
+    lens: Vec<usize>,
+    starts: Vec<usize>,
+    hq: i32,
+    hkv: i32,
+    dim: i32,
+    page_size: usize,
+}
+
+impl Batch {
+    /// Build a batch with the given per-request written lengths and visible
+    /// window starts. `dtype` is the pool dtype (f32 for exact tests, f16 for
+    /// the realistic one).
+    fn new(
+        page_size: usize,
+        hq: i32,
+        hkv: i32,
+        dim: i32,
+        lens: &[usize],
+        starts: &[usize],
+        pool_dtype: i32,
+        seed: u64,
+    ) -> Self {
+        let layout = PagedKvLayout::uniform(
+            1,
+            page_size,
+            page_size * hkv as usize * dim as usize * 2,
+        )
+        .unwrap();
+        let mut pool = PagedBlockPool::new(layout);
+        let mut rng = Rng::new(seed);
+        let mut states = Vec::new();
+        let mut k_all = Vec::new();
+        let mut v_all = Vec::new();
+        let mut q_all = Vec::new();
+
+        for (r, &len) in lens.iter().enumerate() {
+            let mut state = PagedSequenceState::new(pool.layout());
+            if len > 0 {
+                pool.append_tokens(&mut state, 0, len).unwrap();
+            }
+            let mut k_seq = vec![0.0f32; len * hkv as usize * dim as usize];
+            let mut v_seq = vec![0.0f32; len * hkv as usize * dim as usize];
+            for value in k_seq.iter_mut() {
+                *value = rng.next_f32();
+            }
+            for value in v_seq.iter_mut() {
+                *value = rng.next_f32();
+            }
+
+            // Write page by page in the `[1, Hkv, n_slots, D]` layout
+            // `write_block` accepts.
+            let block_ids = state.layer(0).unwrap().block_ids.clone();
+            for (p, block_id) in block_ids.iter().enumerate() {
+                let t0 = p * page_size;
+                let n_slots = (len - t0).min(page_size);
+                let mut kb = vec![0.0f32; hkv as usize * n_slots * dim as usize];
+                let mut vb = vec![0.0f32; hkv as usize * n_slots * dim as usize];
+                for h in 0..hkv as usize {
+                    for s in 0..n_slots {
+                        for i in 0..dim as usize {
+                            let src = ((t0 + s) * hkv as usize + h) * dim as usize + i;
+                            let dst = (h * n_slots + s) * dim as usize + i;
+                            kb[dst] = k_seq[src];
+                            vb[dst] = v_seq[src];
+                        }
+                    }
+                }
+                let shape = [1, hkv, n_slots as i32, dim];
+                let k_arr = cast(&ffi::from_slice_f32(&kb, &shape), pool_dtype);
+                let v_arr = cast(&ffi::from_slice_f32(&vb, &shape), pool_dtype);
+                pool.write_block(*block_id, 0, 0, &k_arr, &v_arr).unwrap();
+            }
+
+            state.layer_mut(0).unwrap().logical_start = starts[r];
+            states.push(state);
+            k_all.push(k_seq);
+            v_all.push(v_seq);
+
+            let mut q_seq = vec![0.0f32; hq as usize * dim as usize];
+            for value in q_seq.iter_mut() {
+                *value = rng.next_f32();
+            }
+            q_all.push(q_seq);
+        }
+
+        Self {
+            pool,
+            states,
+            k: k_all,
+            v: v_all,
+            q: q_all,
+            lens: lens.to_vec(),
+            starts: starts.to_vec(),
+            hq,
+            hkv,
+            dim,
+            page_size,
+        }
+    }
+
+    fn state_refs(&self) -> Vec<&PagedSequenceState> {
+        self.states.iter().collect()
+    }
+
+    fn q_array(&self, dtype_id: i32) -> UniquePtr<MlxArray> {
+        let flat: Vec<f32> = self.q.iter().flat_map(|s| s.iter().copied()).collect();
+        let arr = ffi::from_slice_f32(&flat, &[self.q.len() as i32, self.hq, 1, self.dim]);
+        cast(&arr, dtype_id)
+    }
+
+    fn scale(&self) -> f32 {
+        1.0 / (self.dim as f32).sqrt()
+    }
+
+    /// Host attention over the visible window, in f64.
+    fn reference(&self) -> Vec<f32> {
+        let hq = self.hq as usize;
+        let hkv = self.hkv as usize;
+        let dim = self.dim as usize;
+        let n_rep = hq / hkv;
+        let scale = f64::from(self.scale());
+        let mut out = vec![0.0f32; self.lens.len() * hq * dim];
+        for (r, &len) in self.lens.iter().enumerate() {
+            let start = self.starts[r];
+            for h in 0..hq {
+                let kv_head = h / n_rep;
+                let mut scores: Vec<f64> = Vec::with_capacity(len - start);
+                for t in start..len {
+                    let mut dot = 0.0f64;
+                    for i in 0..dim {
+                        let q = f64::from(self.q[r][h * dim + i]);
+                        let k = f64::from(self.k[r][(t * hkv + kv_head) * dim + i]);
+                        dot += q * k;
+                    }
+                    scores.push(dot * scale);
+                }
+                let out_base = (r * hq + h) * dim;
+                if scores.is_empty() {
+                    continue; // an empty window contributes zeros
+                }
+                let m = scores.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+                let mut denom = 0.0f64;
+                let mut acc = vec![0.0f64; dim];
+                for (idx, t) in (start..len).enumerate() {
+                    let p = (scores[idx] - m).exp();
+                    denom += p;
+                    for i in 0..dim {
+                        acc[i] += p * f64::from(self.v[r][(t * hkv + kv_head) * dim + i]);
+                    }
+                }
+                for i in 0..dim {
+                    out[out_base + i] = (acc[i] / denom) as f32;
+                }
+            }
+        }
+        out
+    }
+
+    /// Geometry the plan is built against.
+    fn geometry(&self) -> PagedDecodeGeometry {
+        PagedDecodeGeometry {
+            q_heads: self.hq,
+            kv_heads: self.hkv,
+            head_dim: self.dim,
+            page_size: self.page_size as i32,
+        }
+    }
+}
+
+fn cast(a: &MlxArray, dtype_id: i32) -> UniquePtr<MlxArray> {
+    if dtype_id == dtype::FLOAT32 {
+        ffi::astype(a, dtype::FLOAT32)
+    } else {
+        ffi::astype(a, dtype_id)
+    }
+}
+
+fn to_vec_f32(a: &MlxArray) -> Vec<f32> {
+    let f = ffi::astype(a, dtype::FLOAT32);
+    ffi::eval(&f);
+    ffi::array_to_raw_bytes(&f)
+        .chunks_exact(4)
+        .map(|c| f32::from_ne_bytes(c.try_into().unwrap()))
+        .collect()
+}
+
+/// Max absolute deviation relative to the reference's own scale, which is the
+/// tolerance form the issue asks for (a plain absolute bound would be
+/// meaningless for an output whose magnitude depends on the value distribution).
+fn max_rel_error(got: &[f32], want: &[f32]) -> f32 {
+    assert_eq!(got.len(), want.len(), "output length mismatch");
+    let scale = want
+        .iter()
+        .fold(0.0f32, |acc, v| acc.max(v.abs()))
+        .max(1e-6);
+    got.iter()
+        .zip(want)
+        .fold(0.0f32, |acc, (g, w)| acc.max((g - w).abs() / scale))
+}
+
+/// Run v2 with an explicit chunk size, bypassing the heuristic so a test can
+/// pin the single-chunk and the many-chunk paths independently.
+fn run_with_chunk(batch: &Batch, pages_per_chunk: i32) -> Vec<f32> {
+    let q = batch.q_array(dtype::FLOAT32);
+    let view = batch.pool.paged_csr_view(&batch.state_refs(), 0).unwrap();
+    let (pool_k, pool_v) = batch.pool.single_slab_tensors(0).expect("single-slab pool");
+    let ctx = V2Context::build(
+        &q,
+        pool_k,
+        pool_v,
+        &view,
+        batch.geometry(),
+        batch.scale(),
+    )
+    .unwrap();
+    let plan = PagedDecodePlan::with_chunk_size(
+        batch.geometry(),
+        &view.page_counts(),
+        pages_per_chunk,
+        128,
+        crate::autotune::Source::Default,
+    );
+    plan.validate().unwrap();
+    let out = ctx.launch(&plan).unwrap();
+    to_vec_f32(&out)
+}
+
+// ---------------------------------------------------------------------------
+// Correctness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_chunk_matches_a_host_reference() {
+    let batch = Batch::new(16, 4, 2, 64, &[40, 33], &[0, 0], dtype::FLOAT32, 0x51);
+    let got = run_with_chunk(&batch, 64); // one chunk per request, no merge
+    let err = max_rel_error(&got, &batch.reference());
+    assert!(err < 2e-3, "single-chunk relative error {err}");
+}
+
+#[test]
+fn many_chunks_merge_to_the_same_answer() {
+    let batch = Batch::new(16, 4, 2, 64, &[40, 33], &[0, 0], dtype::FLOAT32, 0x51);
+    // One page per chunk: 3 chunks for request 0, 3 for request 1, so the merge
+    // kernel is exercised with a variable-length grouping.
+    let merged = run_with_chunk(&batch, 1);
+    let err = max_rel_error(&merged, &batch.reference());
+    assert!(err < 2e-3, "merged relative error {err}");
+
+    // And the two paths agree with each other, which is the property #899's
+    // dispatch will rely on when it switches chunk sizes at runtime.
+    let single = run_with_chunk(&batch, 64);
+    let cross = max_rel_error(&merged, &single);
+    assert!(cross < 2e-3, "single-chunk vs merged deviation {cross}");
+}
+
+#[test]
+fn chunk_size_does_not_change_the_answer() {
+    let batch = Batch::new(32, 8, 2, 64, &[200, 97, 128], &[0, 0, 0], dtype::FLOAT32, 0xbeef);
+    let want = batch.reference();
+    for ppc in [1, 2, 3, 4, 7, 16, 64] {
+        let got = run_with_chunk(&batch, ppc);
+        let err = max_rel_error(&got, &want);
+        assert!(err < 2e-3, "pages_per_chunk {ppc} relative error {err}");
+    }
+}
+
+#[test]
+fn gqa_groups_read_the_right_kv_head() {
+    // n_rep = 8: the CTA's q-head group split is exercised, and a mis-mapped
+    // KV head would show up as a large error rather than a subtle one.
+    let batch = Batch::new(16, 8, 1, 64, &[70], &[0], dtype::FLOAT32, 0x1234);
+    for ppc in [1, 5, 32] {
+        let err = max_rel_error(&run_with_chunk(&batch, ppc), &batch.reference());
+        assert!(err < 2e-3, "gqa pages_per_chunk {ppc} relative error {err}");
+    }
+}
+
+#[test]
+fn a_trimmed_window_attends_only_to_visible_tokens() {
+    // logical_start lands mid-page, so first_page_offset is non-zero and the
+    // retired pages are absent from the CSR view entirely.
+    let batch = Batch::new(16, 4, 2, 64, &[100, 64], &[37, 16], dtype::FLOAT32, 0x77);
+    for ppc in [1, 2, 8] {
+        let err = max_rel_error(&run_with_chunk(&batch, ppc), &batch.reference());
+        assert!(err < 2e-3, "trimmed pages_per_chunk {ppc} relative error {err}");
+    }
+}
+
+#[test]
+fn an_empty_request_yields_zeros_without_poisoning_its_neighbours() {
+    // Request 1 is fully trimmed: its chunk produces an all-empty partial
+    // (lse = -inf), which must merge to zeros rather than NaN.
+    let batch = Batch::new(16, 4, 2, 64, &[48, 32, 40], &[0, 32, 5], dtype::FLOAT32, 0x99);
+    let want = batch.reference();
+    for ppc in [1, 4] {
+        let got = run_with_chunk(&batch, ppc);
+        assert!(got.iter().all(|v| v.is_finite()), "output has non-finite values");
+        let hq_d = (batch.hq * batch.dim) as usize;
+        assert!(
+            got[hq_d..2 * hq_d].iter().all(|&v| v == 0.0),
+            "the empty request should read back as zeros"
+        );
+        let err = max_rel_error(&got, &want);
+        assert!(err < 2e-3, "empty-request pages_per_chunk {ppc} relative error {err}");
+    }
+}
+
+#[test]
+fn f16_pools_match_the_gather_reference() {
+    // The realistic dtype: f16 pool, f16 query, compared against the
+    // gather-then-SDPA path the tree already trusts (ADR 0001 strategy A).
+    let batch = Batch::new(32, 8, 2, 128, &[300, 129], &[0, 0], dtype::FLOAT16, 0x2026);
+    let q = batch.q_array(dtype::FLOAT16);
+    let want = to_vec_f32(
+        &crate::layers::paged_decode_attention_pooled_fallback(
+            &q,
+            &batch.pool,
+            &batch.state_refs(),
+            0,
+            batch.scale(),
+        )
+        .unwrap(),
+    );
+    let got = to_vec_f32(
+        &batch
+            .pool
+            .paged_decode_fused_v2(&q, &batch.state_refs(), 0, batch.scale())
+            .unwrap()
+            .expect("v2 serves this shape"),
+    );
+    let err = max_rel_error(&got, &want);
+    assert!(err <= 2e-2, "f16 relative error {err} vs the gather reference");
+}
+
+#[test]
+fn the_entry_point_declines_a_batch_with_no_visible_tokens() {
+    let batch = Batch::new(16, 4, 2, 64, &[32], &[32], dtype::FLOAT32, 0x5);
+    let q = batch.q_array(dtype::FLOAT32);
+    let out = batch
+        .pool
+        .paged_decode_fused_v2(&q, &batch.state_refs(), 0, batch.scale())
+        .unwrap();
+    assert!(out.is_none(), "an all-empty batch must decline, not launch");
+}
+
+// ---------------------------------------------------------------------------
+// The merge kernel on its own (the piece issue #903 reuses unchanged)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn merge_kernel_matches_the_closed_form() {
+    // Three output rows over 6 partials with a ragged grouping, including an
+    // empty partial (lse = -inf) and a row with a single partial.
+    let heads = 3usize;
+    let dim = 8usize;
+    let indptr = vec![0i32, 3, 4, 6];
+    let n = 6usize;
+    let mut rng = Rng::new(0xfeed);
+    let v: Vec<f32> = (0..n * heads * dim).map(|_| rng.next_f32()).collect();
+    let mut lse: Vec<f32> = (0..n * heads).map(|_| rng.next_f32() * 4.0).collect();
+    lse[heads] = f32::NEG_INFINITY; // an empty chunk inside row 0
+
+    let v_arr = ffi::from_slice_f32(&v, &[n as i32, heads as i32, dim as i32]);
+    let lse_arr = ffi::from_slice_f32(&lse, &[n as i32, heads as i32]);
+    let indptr_arr = ffi::from_slice_i32(&indptr, &[indptr.len() as i32]);
+    let mut out_v = UniquePtr::null();
+    let mut out_lse = UniquePtr::null();
+    ffi::paged_attention_merge_states(&v_arr, &lse_arr, &indptr_arr, &mut out_v, &mut out_lse);
+    let got_v = to_vec_f32(&out_v);
+    let got_lse = to_vec_f32(&out_lse);
+
+    for o in 0..indptr.len() - 1 {
+        let begin = indptr[o] as usize;
+        let end = indptr[o + 1] as usize;
+        for h in 0..heads {
+            let finite: Vec<usize> = (begin..end).filter(|&i| lse[i * heads + h].is_finite()).collect();
+            let m = finite
+                .iter()
+                .map(|&i| f64::from(lse[i * heads + h]))
+                .fold(f64::NEG_INFINITY, f64::max);
+            let mut denom = 0.0f64;
+            for &i in &finite {
+                denom += (f64::from(lse[i * heads + h]) - m).exp2();
+            }
+            for d in 0..dim {
+                let mut acc = 0.0f64;
+                for &i in &finite {
+                    let w = (f64::from(lse[i * heads + h]) - m).exp2();
+                    acc += w * f64::from(v[(i * heads + h) * dim + d]);
+                }
+                let want = if denom > 0.0 { acc / denom } else { 0.0 };
+                let got = f64::from(got_v[(o * heads + h) * dim + d]);
+                assert!(
+                    (got - want).abs() < 1e-5,
+                    "row {o} head {h} dim {d}: got {got} want {want}"
+                );
+            }
+            let want_lse = if denom > 0.0 {
+                m + denom.log2()
+            } else {
+                f64::NEG_INFINITY
+            };
+            let got = f64::from(got_lse[o * heads + h]);
+            assert!(
+                (got - want_lse).abs() < 1e-4,
+                "row {o} head {h} lse: got {got} want {want_lse}"
+            );
+        }
+    }
+}
+
+#[test]
+fn merge_kernel_returns_zeros_for_an_all_empty_row() {
+    let heads = 2usize;
+    let dim = 4usize;
+    let indptr = vec![0i32, 2];
+    let v = vec![1.0f32; 2 * heads * dim];
+    let lse = vec![f32::NEG_INFINITY; 2 * heads];
+    let v_arr = ffi::from_slice_f32(&v, &[2, heads as i32, dim as i32]);
+    let lse_arr = ffi::from_slice_f32(&lse, &[2, heads as i32]);
+    let indptr_arr = ffi::from_slice_i32(&indptr, &[2]);
+    let mut out_v = UniquePtr::null();
+    let mut out_lse = UniquePtr::null();
+    ffi::paged_attention_merge_states(&v_arr, &lse_arr, &indptr_arr, &mut out_v, &mut out_lse);
+    assert!(to_vec_f32(&out_v).iter().all(|&x| x == 0.0));
+    assert!(to_vec_f32(&out_lse).iter().all(|x| x.is_infinite() && *x < 0.0));
+}
+
+#[test]
+fn merge_is_associative_across_regroupings() {
+    // The property issue #903 depends on: merging (a, b) then c equals merging
+    // a then (b, c), so a cascade can decompose the same partials differently.
+    let heads = 2usize;
+    let dim = 8usize;
+    let n = 4usize;
+    let mut rng = Rng::new(0xabcd);
+    let v: Vec<f32> = (0..n * heads * dim).map(|_| rng.next_f32()).collect();
+    let lse: Vec<f32> = (0..n * heads).map(|_| rng.next_f32() * 3.0).collect();
+    let v_arr = ffi::from_slice_f32(&v, &[n as i32, heads as i32, dim as i32]);
+    let lse_arr = ffi::from_slice_f32(&lse, &[n as i32, heads as i32]);
+
+    let merge = |ptr: &[i32], v_in: &MlxArray, lse_in: &MlxArray| {
+        let arr = ffi::from_slice_i32(ptr, &[ptr.len() as i32]);
+        let mut ov = UniquePtr::null();
+        let mut ol = UniquePtr::null();
+        ffi::paged_attention_merge_states(v_in, lse_in, &arr, &mut ov, &mut ol);
+        (ov, ol)
+    };
+
+    // One shot over all four.
+    let (all_v, _) = merge(&[0, 4], &v_arr, &lse_arr);
+    // Two-stage: (0,1) and (2,3), then merge the two results.
+    let (stage_v, stage_lse) = merge(&[0, 2, 4], &v_arr, &lse_arr);
+    let (two_v, _) = merge(&[0, 2], &stage_v, &stage_lse);
+
+    let a = to_vec_f32(&all_v);
+    let b = to_vec_f32(&two_v);
+    let err = max_rel_error(&b, &a);
+    assert!(err < 1e-5, "regrouped merge deviates by {err}");
+}

--- a/src/lib/mlxcel-core/src/paged_v2/launch_tests.rs
+++ b/src/lib/mlxcel-core/src/paged_v2/launch_tests.rs
@@ -72,6 +72,7 @@ impl Batch {
     /// Build a batch with the given per-request written lengths and visible
     /// window starts. `dtype` is the pool dtype (f32 for exact tests, f16 for
     /// the realistic one).
+    #[allow(clippy::too_many_arguments)]
     fn new(
         page_size: usize,
         hq: i32,
@@ -82,12 +83,9 @@ impl Batch {
         pool_dtype: i32,
         seed: u64,
     ) -> Self {
-        let layout = PagedKvLayout::uniform(
-            1,
-            page_size,
-            page_size * hkv as usize * dim as usize * 2,
-        )
-        .unwrap();
+        let layout =
+            PagedKvLayout::uniform(1, page_size, page_size * hkv as usize * dim as usize * 2)
+                .unwrap();
         let mut pool = PagedBlockPool::new(layout);
         let mut rng = Rng::new(seed);
         let mut states = Vec::new();
@@ -206,12 +204,12 @@ impl Batch {
                 for (idx, t) in (start..len).enumerate() {
                     let p = (scores[idx] - m).exp();
                     denom += p;
-                    for i in 0..dim {
-                        acc[i] += p * f64::from(self.v[r][(t * hkv + kv_head) * dim + i]);
+                    for (i, slot) in acc.iter_mut().enumerate() {
+                        *slot += p * f64::from(self.v[r][(t * hkv + kv_head) * dim + i]);
                     }
                 }
-                for i in 0..dim {
-                    out[out_base + i] = (acc[i] / denom) as f32;
+                for (i, value) in acc.iter().enumerate() {
+                    out[out_base + i] = (value / denom) as f32;
                 }
             }
         }
@@ -266,15 +264,7 @@ fn run_with_chunk(batch: &Batch, pages_per_chunk: i32) -> Vec<f32> {
     let q = batch.q_array(dtype::FLOAT32);
     let view = batch.pool.paged_csr_view(&batch.state_refs(), 0).unwrap();
     let (pool_k, pool_v) = batch.pool.single_slab_tensors(0).expect("single-slab pool");
-    let ctx = V2Context::build(
-        &q,
-        pool_k,
-        pool_v,
-        &view,
-        batch.geometry(),
-        batch.scale(),
-    )
-    .unwrap();
+    let ctx = V2Context::build(&q, pool_k, pool_v, &view, batch.geometry(), batch.scale()).unwrap();
     let plan = PagedDecodePlan::with_chunk_size(
         batch.geometry(),
         &view.page_counts(),
@@ -317,7 +307,16 @@ fn many_chunks_merge_to_the_same_answer() {
 
 #[test]
 fn chunk_size_does_not_change_the_answer() {
-    let batch = Batch::new(32, 8, 2, 64, &[200, 97, 128], &[0, 0, 0], dtype::FLOAT32, 0xbeef);
+    let batch = Batch::new(
+        32,
+        8,
+        2,
+        64,
+        &[200, 97, 128],
+        &[0, 0, 0],
+        dtype::FLOAT32,
+        0xbeef,
+    );
     let want = batch.reference();
     for ppc in [1, 2, 3, 4, 7, 16, 64] {
         let got = run_with_chunk(&batch, ppc);
@@ -344,7 +343,10 @@ fn a_trimmed_window_attends_only_to_visible_tokens() {
     let batch = Batch::new(16, 4, 2, 64, &[100, 64], &[37, 16], dtype::FLOAT32, 0x77);
     for ppc in [1, 2, 8] {
         let err = max_rel_error(&run_with_chunk(&batch, ppc), &batch.reference());
-        assert!(err < 2e-3, "trimmed pages_per_chunk {ppc} relative error {err}");
+        assert!(
+            err < 2e-3,
+            "trimmed pages_per_chunk {ppc} relative error {err}"
+        );
     }
 }
 
@@ -352,18 +354,33 @@ fn a_trimmed_window_attends_only_to_visible_tokens() {
 fn an_empty_request_yields_zeros_without_poisoning_its_neighbours() {
     // Request 1 is fully trimmed: its chunk produces an all-empty partial
     // (lse = -inf), which must merge to zeros rather than NaN.
-    let batch = Batch::new(16, 4, 2, 64, &[48, 32, 40], &[0, 32, 5], dtype::FLOAT32, 0x99);
+    let batch = Batch::new(
+        16,
+        4,
+        2,
+        64,
+        &[48, 32, 40],
+        &[0, 32, 5],
+        dtype::FLOAT32,
+        0x99,
+    );
     let want = batch.reference();
     for ppc in [1, 4] {
         let got = run_with_chunk(&batch, ppc);
-        assert!(got.iter().all(|v| v.is_finite()), "output has non-finite values");
+        assert!(
+            got.iter().all(|v| v.is_finite()),
+            "output has non-finite values"
+        );
         let hq_d = (batch.hq * batch.dim) as usize;
         assert!(
             got[hq_d..2 * hq_d].iter().all(|&v| v == 0.0),
             "the empty request should read back as zeros"
         );
         let err = max_rel_error(&got, &want);
-        assert!(err < 2e-3, "empty-request pages_per_chunk {ppc} relative error {err}");
+        assert!(
+            err < 2e-3,
+            "empty-request pages_per_chunk {ppc} relative error {err}"
+        );
     }
 }
 
@@ -391,7 +408,10 @@ fn f16_pools_match_the_gather_reference() {
             .expect("v2 serves this shape"),
     );
     let err = max_rel_error(&got, &want);
-    assert!(err <= 2e-2, "f16 relative error {err} vs the gather reference");
+    assert!(
+        err <= 2e-2,
+        "f16 relative error {err} vs the gather reference"
+    );
 }
 
 #[test]
@@ -435,7 +455,9 @@ fn merge_kernel_matches_the_closed_form() {
         let begin = indptr[o] as usize;
         let end = indptr[o + 1] as usize;
         for h in 0..heads {
-            let finite: Vec<usize> = (begin..end).filter(|&i| lse[i * heads + h].is_finite()).collect();
+            let finite: Vec<usize> = (begin..end)
+                .filter(|&i| lse[i * heads + h].is_finite())
+                .collect();
             let m = finite
                 .iter()
                 .map(|&i| f64::from(lse[i * heads + h]))
@@ -485,7 +507,11 @@ fn merge_kernel_returns_zeros_for_an_all_empty_row() {
     let mut out_lse = UniquePtr::null();
     ffi::paged_attention_merge_states(&v_arr, &lse_arr, &indptr_arr, &mut out_v, &mut out_lse);
     assert!(to_vec_f32(&out_v).iter().all(|&x| x == 0.0));
-    assert!(to_vec_f32(&out_lse).iter().all(|x| x.is_infinite() && *x < 0.0));
+    assert!(
+        to_vec_f32(&out_lse)
+            .iter()
+            .all(|x| x.is_infinite() && *x < 0.0)
+    );
 }
 
 #[test]

--- a/src/lib/mlxcel-core/src/paged_v2/mod.rs
+++ b/src/lib/mlxcel-core/src/paged_v2/mod.rs
@@ -1,0 +1,123 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Paged-attention decode v2: CSR page table, cross-CTA split-KV, and a
+//! variable-length merge (issue #898).
+//!
+//! ## What v1 cannot do
+//!
+//! The v1 fused kernel (`src/lib/mlx-cpp/turbo/paged_attention.cpp`, entered
+//! through [`crate::cache::PagedBlockPool::paged_decode_fused`]) splits the KV
+//! range inside a single threadgroup. One CTA serves one `(batch, query head)`
+//! pair no matter how long the context is, so a small batch with a long context
+//! leaves most of the GPU idle and adding context adds no parallelism. ADR 0001
+//! measures what the gather-then-SDPA fallback costs instead: ~56% over the
+//! contiguous-SDPA lower bound at 16384 tokens and ~67% at 32768.
+//!
+//! ## What v2 does
+//!
+//! Four composable pieces, following the flash-decoding lineage:
+//!
+//! 1. **CSR page table** ([`crate::cache::paged_csr`]): the whole batch's block
+//!    tables flattened into `indices` / `indptr` / `last_page_len` (plus the
+//!    mlxcel `first_page_offset` extension for sliding-window sequences). No
+//!    gather pre-pass, one launch for the batch.
+//! 2. **Cross-CTA split-KV** ([`plan`], kernel in `paged_attention_v2.cpp`):
+//!    each request's page range is cut into chunks assigned to different CTAs,
+//!    each producing an online-softmax partial. One CTA covers all query heads
+//!    of one KV head group, so KV is read once per group.
+//! 3. **Variable-length merge** (`paged_attention_v2_merge.cpp`): partial
+//!    states merge through the closed-form `exp2`/`log2` rescale under an
+//!    `o_indptr` grouping. Deliberately paging-agnostic so issue #903's cascade
+//!    decomposition reuses it unchanged.
+//! 4. **Host-side plan** ([`PagedDecodePlan`]): binary-searches the chunk size
+//!    for an occupancy-derived CTA target and emits the flat index arrays as
+//!    plain data that can be cached across decode steps.
+//!
+//! ## Default off
+//!
+//! This issue lands v2 as a library capability. `MLXCEL_PAGED_ATTENTION_V2=1`
+//! selects it inside
+//! [`crate::cache::PagedBlockPool::paged_decode_fused`]; with the variable
+//! unset the entry point is one `OnceLock` read away from the exact v1 code it
+//! ran before, no v2 array is built, and no v2 kernel is JIT-compiled. v1 is
+//! left fully intact for comparison. Production wiring (scheduler, server
+//! defaults, dispatch thresholds) is issue #899.
+//!
+//! ## Not covered
+//!
+//! Sliding-window and softcap variants keep their documented fallbacks, and
+//! speculative multi-token verify stays on its current path: both are out of
+//! scope per the issue. `first_page_offset` means the *page table* copes with a
+//! trimmed window, but v2 applies no windowing mask of its own.
+
+use std::sync::OnceLock;
+
+pub mod launch;
+pub mod plan;
+
+pub use launch::{V2Context, geometry_from_shapes, resolve_plan, run_decode_v2};
+pub use plan::{
+    MAX_CHUNKS, PagedDecodeGeometry, PagedDecodePlan, TARGET_CTAS_ENV, chunks_for_batch,
+    chunks_for_request, device_target_ctas, max_pages_per_chunk, min_pages_per_chunk,
+    search_pages_per_chunk,
+};
+
+/// Environment variable selecting the v2 decode path. Default off.
+pub const V2_ENV: &str = "MLXCEL_PAGED_ATTENTION_V2";
+
+/// Pure parse of a [`V2_ENV`] value.
+///
+/// Accepts the tree's usual on spellings. Anything else, including an unset
+/// variable, is off; a typo therefore degrades to v1 rather than silently
+/// enabling a path the operator did not ask for.
+#[must_use]
+pub fn parse_v2_enabled(value: Option<&str>) -> bool {
+    matches!(
+        value.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("1" | "true" | "on" | "yes")
+    )
+}
+
+/// Whether the v2 decode path is selected, read once per process.
+///
+/// One `OnceLock` load on the decode hot path when off, which is what keeps the
+/// default path byte-identical to pre-#898 behavior.
+#[must_use]
+pub fn v2_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| parse_v2_enabled(std::env::var(V2_ENV).ok().as_deref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn v2_is_off_unless_explicitly_enabled() {
+        assert!(!parse_v2_enabled(None));
+        assert!(!parse_v2_enabled(Some("")));
+        assert!(!parse_v2_enabled(Some("0")));
+        assert!(!parse_v2_enabled(Some("off")));
+        assert!(!parse_v2_enabled(Some("2")));
+        assert!(!parse_v2_enabled(Some("maybe")));
+    }
+
+    #[test]
+    fn v2_accepts_the_usual_on_spellings() {
+        for v in ["1", "true", "TRUE", "on", "ON", "yes", " yes "] {
+            assert!(parse_v2_enabled(Some(v)), "{v:?} should enable v2");
+        }
+    }
+}

--- a/src/lib/mlxcel-core/src/paged_v2/plan.rs
+++ b/src/lib/mlxcel-core/src/paged_v2/plan.rs
@@ -262,7 +262,9 @@ impl PagedDecodePlan {
     /// f32 elements of the partial-V workspace the run step will allocate.
     #[must_use]
     pub fn workspace_partial_v_elems(&self) -> usize {
-        self.num_chunks * self.geometry.q_heads.max(0) as usize * self.geometry.head_dim.max(0) as usize
+        self.num_chunks
+            * self.geometry.q_heads.max(0) as usize
+            * self.geometry.head_dim.max(0) as usize
     }
 
     /// f32 elements of the LSE workspace.
@@ -395,7 +397,8 @@ pub fn search_pages_per_chunk(
     let lo_bound = min_pages_per_chunk(page_counts);
     let hi_bound = max_pages_per_chunk(page_counts).max(lo_bound);
     let per_chunk = ctas_per_chunk.max(1);
-    let reaches = |ppc: i32| chunks_for_batch(page_counts, ppc).saturating_mul(per_chunk) >= target_ctas;
+    let reaches =
+        |ppc: i32| chunks_for_batch(page_counts, ppc).saturating_mul(per_chunk) >= target_ctas;
 
     if !reaches(lo_bound) {
         // Not even the finest feasible split saturates the device; take it and

--- a/src/lib/mlxcel-core/src/paged_v2/plan.rs
+++ b/src/lib/mlxcel-core/src/paged_v2/plan.rs
@@ -1,0 +1,456 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Host-side plan for paged decode v2 (issue #898).
+//!
+//! The plan answers one question: how many pages does each CTA cover? Every
+//! other field is a consequence of that choice, precomputed so the run step
+//! does no arithmetic beyond indexing.
+//!
+//! ## Why a chunk size needs choosing at all
+//!
+//! Total CTAs are `num_chunks * kv_heads * q_groups`, and `num_chunks` is
+//! `sum_r ceil(pages_r / pages_per_chunk)`. Small chunks mean many CTAs (good
+//! occupancy, more merge work and more partials to write); large chunks mean
+//! few CTAs (no merge at all when every request fits in one, but a long serial
+//! token sweep and an idle GPU). The right value therefore depends on the batch
+//! composition and the device, which is why it is computed per plan rather than
+//! fixed.
+//!
+//! ## The search
+//!
+//! `num_chunks` is non-increasing in `pages_per_chunk`, so
+//! [`search_pages_per_chunk`] binary-searches for the **largest** chunk size
+//! whose CTA count still reaches the device target. Largest, not smallest:
+//! among the sizes that saturate the device, the one with the fewest chunks
+//! does the least merge work. If even one page per chunk cannot reach the
+//! target (a tiny batch at short context), the search returns 1 and the device
+//! is simply not saturable at this shape.
+//!
+//! ## Autotuner seam
+//!
+//! [`crate::autotune::OP_PAGED_DECODE_V2_KV_CHUNK`] was reserved by issue #906
+//! for exactly this knob. [`crate::autotune::ops::paged_decode_v2_chunk`]
+//! implements [`crate::autotune::tactic::TunableOp`] over the candidate chunk
+//! sizes with `default_tactic` returning the heuristic below, so with the
+//! autotuner off (the default) the plan is bit-for-bit what the heuristic
+//! chose, and with a tuned entry present the measured value wins.
+
+use std::sync::OnceLock;
+
+use crate::autotune::Source;
+use crate::ffi;
+
+/// Environment override for the device CTA target used by the heuristic.
+///
+/// Distinct from `MLXCEL_PAGED_DECODE_V2_CHUNK`, which pins the chunk size
+/// itself: this one moves the occupancy target the search aims at, which is the
+/// knob to turn when the derived device parallelism is wrong.
+pub const TARGET_CTAS_ENV: &str = "MLXCEL_PAGED_DECODE_V2_TARGET_CTAS";
+
+/// CTAs the heuristic aims to keep resident per GPU parallelism unit.
+///
+/// Deliberately generous: a decode CTA is memory-bound and short-lived, so
+/// oversubscribing hides launch and tail effects. It is a starting point, not a
+/// measured optimum; the autotuner exists to replace the whole choice.
+const CTAS_PER_UNIT: usize = 8;
+
+/// CTA target when no device parallelism can be derived (any non-Apple host
+/// today, including CUDA).
+///
+/// **Unvalidated on CUDA.** A CUDA-specific target should come from the SM
+/// count; deriving it needs a CUDA host, which issue #898 did not have. Until
+/// then a fixed target keeps the plan well-defined and the env override keeps
+/// it adjustable.
+const DEFAULT_TARGET_CTAS: usize = 512;
+
+/// Floor on the derived target so a small or misdetected parallelism figure
+/// cannot collapse the plan to a single chunk.
+const MIN_TARGET_CTAS: usize = 64;
+
+/// Largest chunk count the plan will emit.
+///
+/// CUDA caps `gridDim.z` at 65535 and the v2 partial kernel puts the chunk
+/// index there. Metal has no such cap, but the plan is device-independent data,
+/// so it holds the tighter bound on both backends rather than producing a plan
+/// that is only valid on one.
+pub const MAX_CHUNKS: usize = 65535;
+
+/// Static launch geometry a plan is built against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PagedDecodeGeometry {
+    /// Query heads (`Hq`).
+    pub q_heads: i32,
+    /// Key/value heads (`Hkv`).
+    pub kv_heads: i32,
+    /// Head dimension.
+    pub head_dim: i32,
+    /// Tokens per pool page.
+    pub page_size: i32,
+}
+
+impl PagedDecodeGeometry {
+    /// GQA replication factor `Hq / Hkv`.
+    #[must_use]
+    pub fn n_rep(&self) -> i32 {
+        if self.kv_heads > 0 {
+            (self.q_heads / self.kv_heads).max(1)
+        } else {
+            1
+        }
+    }
+
+    /// Query heads one CTA owns, from the C++ launcher so the plan's CTA count
+    /// and the kernel's grid cannot drift.
+    #[must_use]
+    pub fn q_heads_per_cta(&self) -> i32 {
+        ffi::paged_attention_v2_q_heads_per_cta(self.head_dim, self.n_rep()).max(1)
+    }
+
+    /// CTA groups the query heads of one KV head split into.
+    #[must_use]
+    pub fn q_groups(&self) -> i32 {
+        (self.n_rep() / self.q_heads_per_cta()).max(1)
+    }
+
+    /// CTAs launched per chunk: one per `(kv head, q-head group)`.
+    #[must_use]
+    pub fn ctas_per_chunk(&self) -> usize {
+        (self.kv_heads.max(1) as usize) * (self.q_groups() as usize)
+    }
+
+    /// SIMD groups per CTA, from the C++ launcher. Reported so a plan dump
+    /// states the whole launch shape.
+    #[must_use]
+    pub fn num_warps(&self) -> i32 {
+        ffi::paged_attention_v2_num_warps(self.head_dim, self.q_heads_per_cta()).max(1)
+    }
+
+    /// Whether the v2 kernels can serve this geometry.
+    ///
+    /// The kernel partitions the query heads of one KV head into equal CTA
+    /// groups, so `Hq` must be a multiple of `Hkv`; everything else is a
+    /// positivity check. A geometry that fails here is not an error, it is a
+    /// decline: the caller falls back to v1 or to gather.
+    pub fn check(&self) -> Result<(), String> {
+        if self.q_heads <= 0 || self.kv_heads <= 0 || self.head_dim <= 0 || self.page_size <= 0 {
+            return Err(format!(
+                "paged decode v2: non-positive geometry (q_heads {}, kv_heads {}, head_dim {}, page_size {})",
+                self.q_heads, self.kv_heads, self.head_dim, self.page_size
+            ));
+        }
+        if self.q_heads % self.kv_heads != 0 {
+            return Err(format!(
+                "paged decode v2: q_heads {} is not a multiple of kv_heads {}",
+                self.q_heads, self.kv_heads
+            ));
+        }
+        if self.n_rep() % self.q_heads_per_cta() != 0 {
+            return Err(format!(
+                "paged decode v2: q_heads_per_cta {} does not divide n_rep {}",
+                self.q_heads_per_cta(),
+                self.n_rep()
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// A built plan: plain data, cacheable and reusable across decode steps for as
+/// long as the batch composition (per-request page counts) and the geometry are
+/// unchanged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PagedDecodePlan {
+    /// Geometry the plan was built for.
+    pub geometry: PagedDecodeGeometry,
+    /// Requests in the batch.
+    pub batch: usize,
+    /// The chosen knob: pages one CTA covers.
+    pub pages_per_chunk: i32,
+    /// `[num_chunks]` request id of each chunk, ascending.
+    pub request_indices: Vec<i32>,
+    /// `[num_chunks]` chunk index within its request.
+    pub kv_tile_indices: Vec<i32>,
+    /// `[batch + 1]` merge grouping: output row `r` merges partial rows
+    /// `[o_indptr[r], o_indptr[r + 1])`. Fed straight to the merge kernel.
+    pub o_indptr: Vec<i32>,
+    /// Total chunks (`request_indices.len()`).
+    pub num_chunks: usize,
+    /// Whether any request needs more than one chunk. When false the partial
+    /// kernel's output is already the answer and no merge is launched.
+    pub needs_merge: bool,
+    /// `num_chunks * ctas_per_chunk`, the parallelism this plan actually
+    /// produces.
+    pub total_ctas: usize,
+    /// The occupancy target the search aimed at.
+    pub target_ctas: usize,
+    /// Where `pages_per_chunk` came from.
+    pub chunk_source: Source,
+}
+
+impl PagedDecodePlan {
+    /// Build a plan for an explicit chunk size.
+    ///
+    /// Every request gets at least one chunk, including a request with no
+    /// visible tokens: its chunk produces an all-empty partial (`lse = -inf`)
+    /// which merges to zeros, so the output always has one row per request and
+    /// the caller never has to reassemble a ragged batch.
+    #[must_use]
+    pub fn with_chunk_size(
+        geometry: PagedDecodeGeometry,
+        page_counts: &[usize],
+        pages_per_chunk: i32,
+        target_ctas: usize,
+        chunk_source: Source,
+    ) -> Self {
+        let ppc = pages_per_chunk.max(1);
+        let batch = page_counts.len();
+        let mut request_indices: Vec<i32> = Vec::with_capacity(batch);
+        let mut kv_tile_indices: Vec<i32> = Vec::with_capacity(batch);
+        let mut o_indptr: Vec<i32> = Vec::with_capacity(batch + 1);
+        o_indptr.push(0);
+        let mut needs_merge = false;
+        for (r, &pages) in page_counts.iter().enumerate() {
+            let chunks = chunks_for_request(pages, ppc);
+            if chunks > 1 {
+                needs_merge = true;
+            }
+            for tile in 0..chunks {
+                request_indices.push(r as i32);
+                kv_tile_indices.push(tile as i32);
+            }
+            o_indptr.push(request_indices.len() as i32);
+        }
+        let num_chunks = request_indices.len();
+        Self {
+            geometry,
+            batch,
+            pages_per_chunk: ppc,
+            request_indices,
+            kv_tile_indices,
+            o_indptr,
+            num_chunks,
+            needs_merge,
+            total_ctas: num_chunks * geometry.ctas_per_chunk(),
+            target_ctas,
+            chunk_source,
+        }
+    }
+
+    /// Build a plan with the heuristic chunk size for `target_ctas`.
+    #[must_use]
+    pub fn heuristic(
+        geometry: PagedDecodeGeometry,
+        page_counts: &[usize],
+        target_ctas: usize,
+    ) -> Self {
+        let ppc = search_pages_per_chunk(page_counts, geometry.ctas_per_chunk(), target_ctas);
+        Self::with_chunk_size(geometry, page_counts, ppc, target_ctas, Source::Default)
+    }
+
+    /// f32 elements of the partial-V workspace the run step will allocate.
+    #[must_use]
+    pub fn workspace_partial_v_elems(&self) -> usize {
+        self.num_chunks * self.geometry.q_heads.max(0) as usize * self.geometry.head_dim.max(0) as usize
+    }
+
+    /// f32 elements of the LSE workspace.
+    #[must_use]
+    pub fn workspace_lse_elems(&self) -> usize {
+        self.num_chunks * self.geometry.q_heads.max(0) as usize
+    }
+
+    /// Total workspace bytes.
+    ///
+    /// MLX owns the allocation (the workspace is the partial kernel's output
+    /// arrays, since an MLX custom kernel cannot write through a caller-owned
+    /// buffer), so this is a budgeting figure for the scheduler in issue #899,
+    /// not a pointer the caller passes in.
+    #[must_use]
+    pub fn workspace_bytes(&self) -> usize {
+        (self.workspace_partial_v_elems() + self.workspace_lse_elems()) * std::mem::size_of::<f32>()
+    }
+
+    /// Whether this plan can still serve a batch with these page counts.
+    ///
+    /// The plan is cacheable across decode steps, and a decode step appends one
+    /// token per request, which changes a page count only when it crosses a
+    /// page boundary. This is the cheap check a cache holder makes before
+    /// reusing a plan.
+    #[must_use]
+    pub fn matches(&self, geometry: &PagedDecodeGeometry, page_counts: &[usize]) -> bool {
+        if self.geometry != *geometry || self.batch != page_counts.len() {
+            return false;
+        }
+        page_counts.iter().enumerate().all(|(r, &pages)| {
+            let chunks = chunks_for_request(pages, self.pages_per_chunk);
+            let begin = self.o_indptr[r] as usize;
+            let end = self.o_indptr[r + 1] as usize;
+            end - begin == chunks
+        })
+    }
+
+    /// Structural check of the emitted arrays. Cheap relative to a launch and
+    /// run on every build, because a malformed plan is an out-of-bounds read
+    /// inside the kernel.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.o_indptr.len() != self.batch + 1 {
+            return Err(format!(
+                "PagedDecodePlan: o_indptr has {} entries, expected batch + 1 = {}",
+                self.o_indptr.len(),
+                self.batch + 1
+            ));
+        }
+        if self.request_indices.len() != self.num_chunks
+            || self.kv_tile_indices.len() != self.num_chunks
+        {
+            return Err("PagedDecodePlan: chunk arrays disagree on length".to_string());
+        }
+        if self.o_indptr.last().copied().unwrap_or(0) as usize != self.num_chunks {
+            return Err("PagedDecodePlan: o_indptr does not end at num_chunks".to_string());
+        }
+        if self.num_chunks > MAX_CHUNKS {
+            return Err(format!(
+                "PagedDecodePlan: {} chunks exceeds the {MAX_CHUNKS} grid limit",
+                self.num_chunks
+            ));
+        }
+        if !self.needs_merge && self.num_chunks != self.batch {
+            return Err(
+                "PagedDecodePlan: a merge-free plan must have exactly one chunk per request"
+                    .to_string(),
+            );
+        }
+        self.geometry.check()
+    }
+}
+
+/// Chunks one request needs. Always at least one, so every request owns an
+/// output row even when it has no visible tokens.
+#[must_use]
+pub fn chunks_for_request(pages: usize, pages_per_chunk: i32) -> usize {
+    let ppc = pages_per_chunk.max(1) as usize;
+    pages.div_ceil(ppc).max(1)
+}
+
+/// Total chunks for a batch at a given chunk size.
+#[must_use]
+pub fn chunks_for_batch(page_counts: &[usize], pages_per_chunk: i32) -> usize {
+    page_counts
+        .iter()
+        .map(|&pages| chunks_for_request(pages, pages_per_chunk))
+        .sum()
+}
+
+/// Largest chunk size worth considering: any larger value produces the same
+/// single-chunk-per-request plan.
+#[must_use]
+pub fn max_pages_per_chunk(page_counts: &[usize]) -> i32 {
+    let max_pages = page_counts.iter().copied().max().unwrap_or(0).max(1);
+    i32::try_from(max_pages).unwrap_or(i32::MAX)
+}
+
+/// Smallest chunk size that keeps the chunk count under [`MAX_CHUNKS`].
+///
+/// `num_chunks = sum_r ceil(pages_r / ppc) <= total_pages / ppc + batch`, so
+/// `ppc >= total_pages / (MAX_CHUNKS - batch)` suffices. A batch at or beyond
+/// `MAX_CHUNKS` requests cannot be served at all and is rejected by
+/// [`PagedDecodePlan::validate`] rather than silently truncated here.
+#[must_use]
+pub fn min_pages_per_chunk(page_counts: &[usize]) -> i32 {
+    let batch = page_counts.len();
+    if batch >= MAX_CHUNKS {
+        return i32::MAX;
+    }
+    let total_pages: usize = page_counts.iter().sum();
+    let headroom = MAX_CHUNKS - batch;
+    let needed = total_pages.div_ceil(headroom).max(1);
+    i32::try_from(needed).unwrap_or(i32::MAX)
+}
+
+/// Binary-search the largest chunk size whose CTA count still reaches
+/// `target_ctas`.
+///
+/// `chunks_for_batch` is non-increasing in the chunk size, so the predicate
+/// "reaches the target" is monotone and the search is well-defined. The result
+/// is clamped up by [`min_pages_per_chunk`] so the returned plan is always
+/// launchable.
+#[must_use]
+pub fn search_pages_per_chunk(
+    page_counts: &[usize],
+    ctas_per_chunk: usize,
+    target_ctas: usize,
+) -> i32 {
+    let lo_bound = min_pages_per_chunk(page_counts);
+    let hi_bound = max_pages_per_chunk(page_counts).max(lo_bound);
+    let per_chunk = ctas_per_chunk.max(1);
+    let reaches = |ppc: i32| chunks_for_batch(page_counts, ppc).saturating_mul(per_chunk) >= target_ctas;
+
+    if !reaches(lo_bound) {
+        // Not even the finest feasible split saturates the device; take it and
+        // accept the under-occupancy rather than adding merge work for nothing.
+        return lo_bound;
+    }
+    let mut lo = lo_bound;
+    let mut hi = hi_bound;
+    while lo < hi {
+        // Round the midpoint up so `lo` can advance and the loop terminates.
+        let mid = lo + (hi - lo + 1) / 2;
+        if reaches(mid) {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    lo
+}
+
+/// Device CTA target for the heuristic.
+///
+/// Read once per process. `MLXCEL_PAGED_DECODE_V2_TARGET_CTAS` wins; otherwise
+/// Apple hosts derive it from the reported parallelism and everything else
+/// takes [`DEFAULT_TARGET_CTAS`].
+///
+/// The Apple figure is `hardware::gpu_core_count`, which is the
+/// performance-core proxy the tree already uses as a device-scale signal (see
+/// [`crate::autotune::device_label`]), not a true GPU core count. It scales
+/// with the part, which is what the target needs, but it is not calibrated;
+/// treat the derived target as a starting point that the autotuner or the env
+/// override supersedes.
+#[must_use]
+pub fn device_target_ctas() -> usize {
+    static TARGET: OnceLock<usize> = OnceLock::new();
+    *TARGET.get_or_init(|| {
+        if let Ok(raw) = std::env::var(TARGET_CTAS_ENV) {
+            match raw.trim().parse::<usize>() {
+                Ok(v) if v >= 1 => return v,
+                _ => tracing::warn!(
+                    "{TARGET_CTAS_ENV}={raw:?} is not a positive integer; using the derived target"
+                ),
+            }
+        }
+        if crate::metal_is_available() {
+            let hw = crate::hardware::get_hardware();
+            (hw.gpu_core_count as usize)
+                .saturating_mul(CTAS_PER_UNIT)
+                .max(MIN_TARGET_CTAS)
+        } else {
+            DEFAULT_TARGET_CTAS
+        }
+    })
+}
+
+#[cfg(test)]
+#[path = "plan_tests.rs"]
+mod plan_tests;

--- a/src/lib/mlxcel-core/src/paged_v2/plan_tests.rs
+++ b/src/lib/mlxcel-core/src/paged_v2/plan_tests.rs
@@ -1,0 +1,328 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the paged decode v2 plan (issue #898).
+//!
+//! The plan is pure arithmetic over page counts, so these tests need no GPU.
+//! They pin the three properties the kernels depend on: the chunk arrays and
+//! the merge `indptr` agree, the binary search really returns the largest
+//! saturating chunk size, and the emitted chunk count always stays inside the
+//! grid bound.
+
+use super::*;
+
+fn geometry() -> PagedDecodeGeometry {
+    PagedDecodeGeometry {
+        q_heads: 32,
+        kv_heads: 8,
+        head_dim: 128,
+        page_size: 32,
+    }
+}
+
+fn plan(page_counts: &[usize], ppc: i32) -> PagedDecodePlan {
+    PagedDecodePlan::with_chunk_size(geometry(), page_counts, ppc, 128, Source::Default)
+}
+
+// ---------------------------------------------------------------------------
+// Chunk arithmetic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_request_owns_at_least_one_chunk() {
+    // A request with no visible tokens still needs an output row, so it still
+    // gets a chunk. Its partial comes back empty and merges to zeros.
+    assert_eq!(chunks_for_request(0, 8), 1);
+    assert_eq!(chunks_for_request(1, 8), 1);
+    assert_eq!(chunks_for_request(8, 8), 1);
+    assert_eq!(chunks_for_request(9, 8), 2);
+    assert_eq!(chunks_for_request(17, 8), 3);
+}
+
+#[test]
+fn chunk_count_is_non_increasing_in_chunk_size() {
+    // The binary search relies on this monotonicity.
+    let counts = vec![37usize, 4, 128, 0, 71];
+    let mut previous = usize::MAX;
+    for ppc in 1..=140 {
+        let n = chunks_for_batch(&counts, ppc);
+        assert!(
+            n <= previous,
+            "chunk count grew from {previous} to {n} at pages_per_chunk {ppc}"
+        );
+        previous = n;
+    }
+    assert_eq!(chunks_for_batch(&counts, 128), counts.len());
+}
+
+// ---------------------------------------------------------------------------
+// Plan structure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plan_arrays_agree_with_the_merge_indptr() {
+    let counts = vec![10usize, 3, 0];
+    let p = plan(&counts, 4);
+    // 10 pages -> 3 chunks, 3 pages -> 1, 0 pages -> 1.
+    assert_eq!(p.num_chunks, 5);
+    assert_eq!(p.request_indices, vec![0, 0, 0, 1, 2]);
+    assert_eq!(p.kv_tile_indices, vec![0, 1, 2, 0, 0]);
+    assert_eq!(p.o_indptr, vec![0, 3, 4, 5]);
+    assert!(p.needs_merge);
+    p.validate().expect("plan is well formed");
+}
+
+#[test]
+fn one_chunk_per_request_needs_no_merge() {
+    let counts = vec![10usize, 3, 7];
+    let p = plan(&counts, 16);
+    assert_eq!(p.num_chunks, 3);
+    assert!(!p.needs_merge);
+    // Chunks are emitted in request order, which is what lets the run step
+    // reshape the partial output straight into [B, Hq, 1, D].
+    assert_eq!(p.request_indices, vec![0, 1, 2]);
+    assert_eq!(p.kv_tile_indices, vec![0, 0, 0]);
+    assert_eq!(p.o_indptr, vec![0, 1, 2, 3]);
+    p.validate().expect("plan is well formed");
+}
+
+#[test]
+fn total_ctas_counts_every_kv_head_and_q_group() {
+    let counts = vec![64usize];
+    let p = plan(&counts, 8);
+    assert_eq!(p.num_chunks, 8);
+    assert_eq!(p.total_ctas, 8 * geometry().ctas_per_chunk());
+}
+
+#[test]
+fn workspace_size_matches_the_kernel_outputs() {
+    let counts = vec![10usize, 10];
+    let p = plan(&counts, 4);
+    let g = geometry();
+    assert_eq!(
+        p.workspace_partial_v_elems(),
+        p.num_chunks * g.q_heads as usize * g.head_dim as usize
+    );
+    assert_eq!(p.workspace_lse_elems(), p.num_chunks * g.q_heads as usize);
+    assert_eq!(
+        p.workspace_bytes(),
+        (p.workspace_partial_v_elems() + p.workspace_lse_elems()) * 4
+    );
+}
+
+#[test]
+fn matches_tracks_page_growth_across_decode_steps() {
+    // A decode step appends one token, which changes a page count only when it
+    // crosses a page boundary. The plan stays valid until then.
+    let counts = vec![8usize, 8];
+    let p = plan(&counts, 4);
+    assert!(p.matches(&geometry(), &[8, 8]));
+    assert!(p.matches(&geometry(), &[8, 7]), "same chunk count, still valid");
+    assert!(!p.matches(&geometry(), &[9, 8]), "9 pages needs a third chunk");
+    assert!(!p.matches(&geometry(), &[8]), "batch composition changed");
+    let mut other = geometry();
+    other.head_dim = 64;
+    assert!(!p.matches(&other, &[8, 8]), "geometry changed");
+}
+
+#[test]
+fn validate_rejects_corrupted_plans() {
+    let counts = vec![10usize, 3];
+    let mut p = plan(&counts, 4);
+    p.o_indptr.pop();
+    assert!(p.validate().is_err());
+
+    let mut p = plan(&counts, 4);
+    p.request_indices.pop();
+    assert!(p.validate().is_err());
+
+    let mut p = plan(&counts, 16);
+    assert!(!p.needs_merge);
+    p.num_chunks += 1;
+    p.request_indices.push(0);
+    p.kv_tile_indices.push(1);
+    assert!(
+        p.validate().is_err(),
+        "a merge-free plan with more chunks than requests must be rejected"
+    );
+}
+
+#[test]
+fn validate_rejects_a_geometry_the_kernel_cannot_serve() {
+    let bad = PagedDecodeGeometry {
+        q_heads: 12,
+        kv_heads: 8, // 12 % 8 != 0
+        head_dim: 128,
+        page_size: 32,
+    };
+    let p = PagedDecodePlan::with_chunk_size(bad, &[4], 4, 128, Source::Default);
+    assert!(p.validate().is_err());
+}
+
+// ---------------------------------------------------------------------------
+// The search
+// ---------------------------------------------------------------------------
+
+#[test]
+fn search_returns_the_largest_chunk_size_that_reaches_the_target() {
+    // 1 request, 64 pages, 8 CTAs per chunk, target 64 CTAs => 8 chunks needed
+    // => 8 pages per chunk. 9 pages would give 8 chunks too (ceil(64/9) = 8),
+    // and 10 would give 7, so the largest saturating value is 9.
+    let counts = vec![64usize];
+    let ppc = search_pages_per_chunk(&counts, 8, 64);
+    assert_eq!(chunks_for_batch(&counts, ppc) * 8, 64);
+    assert!(
+        chunks_for_batch(&counts, ppc + 1) * 8 < 64,
+        "pages_per_chunk {ppc} was not maximal"
+    );
+}
+
+#[test]
+fn search_is_exhaustively_maximal_over_a_sweep() {
+    // Brute-force the same predicate the binary search encodes.
+    for &counts in &[
+        &[1usize, 1, 1, 1][..],
+        &[64, 64, 64, 64][..],
+        &[1024][..],
+        &[0, 0, 512][..],
+        &[7, 13, 29, 31][..],
+    ] {
+        for &per_chunk in &[1usize, 4, 8, 32] {
+            for &target in &[1usize, 16, 64, 128, 512, 4096] {
+                let got = search_pages_per_chunk(counts, per_chunk, target);
+                let lo = min_pages_per_chunk(counts);
+                let hi = max_pages_per_chunk(counts).max(lo);
+                let reaches =
+                    |p: i32| chunks_for_batch(counts, p).saturating_mul(per_chunk) >= target;
+                let expected = if reaches(lo) {
+                    (lo..=hi).filter(|&p| reaches(p)).max().unwrap_or(lo)
+                } else {
+                    lo
+                };
+                assert_eq!(
+                    got, expected,
+                    "counts {counts:?} per_chunk {per_chunk} target {target}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn search_falls_back_to_the_finest_split_when_the_target_is_unreachable() {
+    // 1 request of 2 pages against a target no split can reach.
+    let counts = vec![2usize];
+    let ppc = search_pages_per_chunk(&counts, 1, 10_000);
+    assert_eq!(ppc, 1);
+    assert_eq!(chunks_for_batch(&counts, ppc), 2);
+}
+
+#[test]
+fn search_never_exceeds_the_grid_bound() {
+    // A pathological batch: many requests, each long enough that a one-page
+    // chunk would blow past MAX_CHUNKS. The floor keeps the plan launchable.
+    let counts = vec![4096usize; 64];
+    let ppc = search_pages_per_chunk(&counts, 1, usize::MAX);
+    let p = plan(&counts, ppc);
+    assert!(
+        p.num_chunks <= MAX_CHUNKS,
+        "{} chunks exceeds the grid bound",
+        p.num_chunks
+    );
+    p.validate().expect("bounded plan is valid");
+}
+
+#[test]
+fn min_pages_per_chunk_bounds_the_chunk_count() {
+    for counts in [
+        vec![1_000_000usize],
+        vec![100_000usize; 8],
+        vec![1usize; 1000],
+        vec![0usize; 16],
+    ] {
+        let lo = min_pages_per_chunk(&counts);
+        assert!(
+            chunks_for_batch(&counts, lo) <= MAX_CHUNKS,
+            "counts of len {} at pages_per_chunk {lo} produced {} chunks",
+            counts.len(),
+            chunks_for_batch(&counts, lo)
+        );
+    }
+}
+
+#[test]
+fn heuristic_plan_records_its_target_and_source() {
+    let counts = vec![32usize, 32];
+    let p = PagedDecodePlan::heuristic(geometry(), &counts, 256);
+    assert_eq!(p.target_ctas, 256);
+    assert_eq!(p.chunk_source, Source::Default);
+    p.validate().expect("heuristic plan is valid");
+}
+
+// ---------------------------------------------------------------------------
+// Geometry helpers (these consult the C++ launcher, so they pin the contract
+// the plan and the kernel share)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn q_heads_per_cta_always_divides_n_rep() {
+    for &q_heads in &[1i32, 2, 4, 8, 16, 32, 64] {
+        for &kv_heads in &[1i32, 2, 4, 8] {
+            if q_heads % kv_heads != 0 {
+                continue;
+            }
+            for &head_dim in &[64i32, 128, 256] {
+                let g = PagedDecodeGeometry {
+                    q_heads,
+                    kv_heads,
+                    head_dim,
+                    page_size: 32,
+                };
+                let per_cta = g.q_heads_per_cta();
+                assert!(per_cta >= 1);
+                assert_eq!(
+                    g.n_rep() % per_cta,
+                    0,
+                    "q_heads_per_cta {per_cta} does not divide n_rep {} (dim {head_dim})",
+                    g.n_rep()
+                );
+                assert_eq!(g.q_groups() * per_cta, g.n_rep());
+                g.check().expect("supported geometry");
+            }
+        }
+    }
+}
+
+#[test]
+fn num_warps_stays_inside_the_threadgroup_budget() {
+    for &head_dim in &[64i32, 128, 256] {
+        for &q_per_cta in &[1i32, 2, 4, 8] {
+            let g = PagedDecodeGeometry {
+                q_heads: q_per_cta,
+                kv_heads: 1,
+                head_dim,
+                page_size: 32,
+            };
+            let warps = ffi::paged_attention_v2_num_warps(head_dim, q_per_cta);
+            assert!(warps >= 1 && warps <= 8, "warps {warps} out of range");
+            assert!(
+                (warps as u32).is_power_of_two(),
+                "warps {warps} is not a power of two"
+            );
+            let bytes = warps as usize * q_per_cta as usize * head_dim as usize * 4;
+            assert!(bytes <= 28672, "tg_acc would need {bytes} bytes");
+            let _ = g;
+        }
+    }
+}

--- a/src/lib/mlxcel-core/src/paged_v2/plan_tests.rs
+++ b/src/lib/mlxcel-core/src/paged_v2/plan_tests.rs
@@ -128,8 +128,14 @@ fn matches_tracks_page_growth_across_decode_steps() {
     let counts = vec![8usize, 8];
     let p = plan(&counts, 4);
     assert!(p.matches(&geometry(), &[8, 8]));
-    assert!(p.matches(&geometry(), &[8, 7]), "same chunk count, still valid");
-    assert!(!p.matches(&geometry(), &[9, 8]), "9 pages needs a third chunk");
+    assert!(
+        p.matches(&geometry(), &[8, 7]),
+        "same chunk count, still valid"
+    );
+    assert!(
+        !p.matches(&geometry(), &[9, 8]),
+        "9 pages needs a third chunk"
+    );
     assert!(!p.matches(&geometry(), &[8]), "batch composition changed");
     let mut other = geometry();
     other.head_dim = 64;
@@ -315,7 +321,7 @@ fn num_warps_stays_inside_the_threadgroup_budget() {
                 page_size: 32,
             };
             let warps = ffi::paged_attention_v2_num_warps(head_dim, q_per_cta);
-            assert!(warps >= 1 && warps <= 8, "warps {warps} out of range");
+            assert!((1..=8).contains(&warps), "warps {warps} out of range");
             assert!(
                 (warps as u32).is_power_of_two(),
                 "warps {warps} is not a power of two"


### PR DESCRIPTION
## Summary

Builds paged-attention decode v2 as a library capability: a CSR page table, a cross-CTA split-KV partial kernel, a generic variable-length merge kernel, a host-side plan wired into the autotuner seam issue #906 reserved, and an env-gated entry point. v1 is untouched and remains the only path any caller reaches unless `MLXCEL_PAGED_ATTENTION_V2=1` is set.

The structural problem v1 has is that its KV split happens inside one threadgroup, so one CTA serves one `(batch, query head)` pair no matter how long the context is. A small batch with a long context leaves most of the GPU idle, and adding context adds no parallelism. v2 moves the split across CTAs: parallelism becomes `num_chunks * kv_heads * q_groups` and grows with context.

## What changed

**1. CSR view builder.** `src/lib/mlxcel-core/src/cache/paged_csr.rs` plus `PagedBlockPool::paged_csr_view`. The layout is the standard `indices` / `indptr` / `last_page_len` triple plus a `first_page_offset` extension: the canonical form assumes every request starts at entry 0 of its first page, which a sliding-window sequence with a non-zero `logical_start` violates. Carrying the offset lets the view drop fully retired pages instead of emitting them and skipping them inside the kernel, so the plan's page counts are the real work counts. `validate` asserts the geometry identity `(pages - 1) * page_size + last_page_len - first_page_offset == seq_len` on every build, because each way it can fail is an out-of-bounds read in the kernel rather than an error. `rope_offsets` records the absolute next-token position (the written length), which differs from the visible length exactly when a front trim has happened. Shared refcounted blocks need no special case: two requests that share a prefix resolve the same block id to the same physical row, so the row appears in both slices of `indices`. 17 unit tests, including a 500-case randomized geometry sweep and prefix sharing through a real pool with refcount assertions.

**2. Kernel v2.** `src/lib/mlx-cpp/turbo/paged_attention_v2.cpp`, Metal plus CUDA JIT strings in one translation unit with runtime backend selection, following the dual-source pattern of `paged_attention.cpp`. One CTA owns one `(chunk, kv head, q-head group)` triple: grid z is the flat chunk index, grid y is `kv_head * QGroups + q_group`, 32 lanes partition the head dimension, and `NumWarps` warps stripe the chunk's tokens. The CTA reads each KV element once and reuses it across every query head of its group. Scores run in base 2 (`log2(e)` folded into the attention scale) so the online softmax is `exp2`, and the emitted LSE is in log2 units. Two helpers, `paged_attention_v2_q_heads_per_cta` and `paged_attention_v2_num_warps`, are exported to Rust so the plan's CTA count and the launcher's grid are derived from one source and cannot drift.

**3. Merge kernel.** `src/lib/mlx-cpp/turbo/paged_attention_v2_merge.cpp`, split into its own translation unit because it is the reusable half. It takes `v_in [N, H, D]` (each partial already normalized by its own softmax denominator), `lse_in [N, H]` in log2 units, and an `o_indptr [M + 1]`, and returns `(v_out [M, H, D], lse_out [M, H])` using the closed-form `exp2`/`log2` rescale generalized to a variable-length group. One thread owns one `(output row, head, dim)` element and walks its partial list once, so there is no threadgroup memory and no barrier, which is what keeps it usable for an arbitrary grouping. A partial with `lse = -inf` (an empty chunk) contributes nothing, and an output row with no finite partial yields zeros and `lse_out = -inf` rather than NaN.

**4. Plan.** `src/lib/mlxcel-core/src/paged_v2/plan.rs`. `PagedDecodePlan` binary-searches `pages_per_chunk`: the chunk count is non-increasing in the chunk size, so the search takes the largest chunk size whose CTA count still reaches the device target, because among the sizes that saturate the device that one does the least merge work. A floor derived from the 65535 grid-z bound keeps every emitted plan launchable on both backends. It is plain data with a `matches` predicate, so a caller can hold it across decode steps and only rebuild when a request crosses a page boundary. Every request gets at least one chunk, including a fully trimmed one, so the output always has exactly one row per request. `autotune::ops::paged_decode_v2_chunk` occupies the `OP_PAGED_DECODE_V2_KV_CHUNK` seam: it enumerates the feasible chunk sizes (powers of two inside the plan's own bounds, plus the heuristic so the default is measurable), returns the binary-search value as its default tactic, and its `run` performs a real launch against the borrowed context so profiling measures the kernels rather than array construction. Nothing in the autotuner core changed to accept it.

**5. Entry point and flag.** `paged_v2::run_decode_v2` plus `PagedBlockPool::paged_decode_fused_v2`, reached from `paged_decode_fused` behind `MLXCEL_PAGED_ATTENTION_V2=1`. The merge kernel runs only when some request has more than one chunk; when every request fits in one chunk the plan emits chunks in request order and the partial output is already the answer, so it is reshaped rather than merged. That "write O directly" case is decided on the host, which is what keeps it safe: an MLX custom kernel's output array is uninitialized, so a kernel that skipped elements would leave garbage rather than produce a fast path.

**6. Correctness harness.** `examples/paged_decode_v2_correctness.rs`, and a three-way extension of `examples/page_gather_microbench.rs` (gather-then-SDPA vs fused v1 vs fused v2) that reports `v2/v1` and `v2/gatherA` next to the v2 plan that produced them.

## Deliberate scope decisions

**CUDA is unvalidated.** The implementing host is an Apple M1 Ultra with no CUDA hardware and no `nvcc`. Both CUDA JIT bodies are structural transliterations of the Metal ones (same thread mapping, same chunk arithmetic, same accumulation order; `simd_sum` becomes a `__shfl_xor_sync` butterfly, `threadgroup` becomes `__shared__`, `exp2`/`log2`/`fmax` become the `f` variants) and are marked unvalidated in the source. They have never been compiled or run. The same applies to `DEFAULT_TARGET_CTAS`: a CUDA target should come from the SM count, which needs a CUDA host to derive.

**Default off, v1 intact.** With the env unset the entry point is one `OnceLock` read away from the exact pre-#898 code, no v2 array is built, and neither v2 kernel is JIT-compiled. Verified by running the full `ffi_tests` module (93 tests, which includes the v1 fused-vs-gather parity tests) both with the variable unset and with it set to 1: 93 pass either way, so v2 also satisfies the parity assertions v1 does when it takes over the path.

**No benchmarks were run.** The three-way microbench is written but not measured here; these paths are bandwidth-bound and a loaded host produces misleading numbers. It was smoke-tested for launch correctness only (one configuration, two iterations), and no timing from that run is recorded anywhere. `docs/benchmark_results/paged-decode-v2-<hw>-<date>.md` is therefore not in this PR and should be written from a serialized run on a quiet machine.

**The kernel lives in two new files, not in `paged_attention.cpp`.** The issue names that file, but it is already 534 lines and the project's 500-line ceiling would be badly broken by adding ~880 lines to it. The split also puts the merge kernel, which issue #903 reuses unchanged, in its own translation unit.

**The harness builds its page table by hand rather than driving `PagedBlockPool`.** That is forced, not a shortcut: the pool allocates physical rows in 32-block slabs and both fused kernels read one contiguous buffer per side, so any context past ~1024 tokens at page size 32 is multi-slab and declined by v1 and v2 alike. A pool-driven matrix could only cover the short-context corner. The pool path is covered instead by the `cache::paged_csr` and `paged_v2::launch` unit tests.

## Correctness results (Apple M1 Ultra, Metal)

The committed default sweep is a 24-configuration subset (head_dim {64,128} x GQA {1,4,8} x block {32} x ctx {512,4096} x batch {1,4}), not the issue's full 216. The full matrix is available behind `--full`, and the axis flags select anything in between. What was actually run here is 68 configurations across three sweeps, all passing against the 2e-2 tolerance:

- The 24-configuration default: worst max relative deviation 5.24e-4, worst relative RMS 3.05e-4.
- 12 long-context configurations (head_dim 128, GQA 4, block {16,32,64}, ctx {16384,32768}, batch {1,4}): worst max relative deviation 4.43e-4.
- 32 force-merge configurations with `pages_per_chunk = 1` (head_dim {64,128}, GQA {1,8}, block {16,64}, ctx {512,4096}, batch {1,8}), reaching 1408 chunks and 45056 CTAs: worst max relative deviation 5.24e-4.

Block sizes 16 and 64 and batch 8 are covered by the second and third sweeps rather than by the committed default.

## Test plan

- [x] `cargo test --release -p mlxcel-core --lib --features metal,accelerate paged_v2::` passes 30/30 (19 plan tests including an exhaustive brute-force check that the binary search really is maximal, 11 GPU tests against a host-side f64 reference computed from the same values written into the pool).
- [x] `cargo test --release -p mlxcel-core --lib --features metal,accelerate cache::paged_csr` passes 17/17.
- [x] `cargo test --release -p mlxcel-core --lib --features metal,accelerate cache::` passes 433/433.
- [x] `cargo test --release -p mlxcel-core --lib --features metal,accelerate autotune::` passes 55/55.
- [x] `cargo test --release -p mlxcel-core --lib --features metal,accelerate ffi_tests::` passes 93/93 with `MLXCEL_PAGED_ATTENTION_V2` unset and 93/93 with it set to 1.
- [x] `cargo test --release --test autotuner_outcome --features metal,accelerate` passes 2/2.
- [x] `cargo run --release --features metal,accelerate --example paged_decode_v2_correctness` and two additional sweeps: 68 configurations, 0 failing.
- [x] `cargo clippy -p mlxcel-core --lib --tests --features metal,accelerate -- -D warnings` clean, and the same for both touched examples.
- [x] `cargo fmt --all -- --check` clean.

Not run: the full `cargo test -p mlxcel-core` suite, which exceeds this environment's watchdog. The pre-existing `fused_moe_parity_tests::fused_moe_geglu_kernel_matches_references_gemma4_shape` failure tracked as #964 is untouched by this PR.

## Notes for the follow-ups

- **#899 (production wiring):** the plan is cacheable, and `PagedDecodePlan::matches` is the cheap predicate for reuse. `workspace_bytes` is the budgeting figure; the workspace is MLX-allocated (an MLX custom kernel cannot write through a caller-owned buffer, so "caller-provided workspace" became "outputs whose exact size the plan states up front"). The single-slab constraint from #235 still applies and is the first thing to lift for real contexts. `device_target_ctas` derives its Apple figure from `hardware::gpu_core_count`, which is the performance-core proxy the tree already uses as a device-scale signal rather than a true GPU core count; it scales with the part but is not calibrated, so treat it as a starting point that `MLXCEL_PAGED_DECODE_V2_TARGET_CTAS` or the autotuner supersedes.
- **#903 (cascade):** the merge kernel is reused unchanged. Its contract is `(v_in [N, H, D] normalized partials, lse_in [N, H] in log2 units, o_indptr [M + 1])` returning `(v_out, lse_out)`, with `lse_out` also in log2 units so a cascade can feed one merge's output into the next. `merge_is_associative_across_regroupings` in `paged_v2::launch_tests` pins exactly that property. Note the log2 units: a consumer wanting the natural-log LSE multiplies by `ln(2)`.

Closes #898
