### PR TITLE
fix(server): clamp client token budgets (#980)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ mlxcel run
 
 The default model, and other thinking-capable checkpoints such as Qwen-style `<think>` models, write a chain-of-thought before the final answer. `generate` and `run` hide it from the terminal by default so only the answer prints; pass `--show-reasoning` to also print the reasoning, dimmed on a terminal. The raw `<|channel>thought` / `<channel|>` or `<think>` / `</think>` markers never print either way.
 
-Output length follows llama.cpp: with no `-n/--max-tokens` (default `-1`), `generate` / `run` keep generating until the model emits an end-of-sequence token or fills its context window. The server's `--n-predict` default (`-1`) behaves the same per request. Pass an explicit `-n N` (or `--n-predict N`) to cap output at exactly `N` tokens.
+Output length follows llama.cpp: with no `-n/--max-tokens` (default `-1`), `generate` / `run` keep generating until the model emits an end-of-sequence token or fills its context window. The server's `--n-predict` default (`-1`) behaves the same per request. Pass an explicit `-n N` (or `--n-predict N`) to cap output at exactly `N` tokens. HTTP `max_tokens` and native `/completion` `n_predict` overrides are silently clamped to the effective per-slot context window; when `--ctx-size` is unset, the resolved server default is the cap. With the default `--n-predict -1`, that value comes from the checkpoint context window, or 4096 when unavailable.
 
 ```bash
 # One-off generation (omit -n to run until EOS / context window; -n N caps it).

--- a/src/server/max_tokens_route_tests.rs
+++ b/src/server/max_tokens_route_tests.rs
@@ -1,0 +1,197 @@
+use std::path::PathBuf;
+use std::sync::{Arc, mpsc};
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use super::{
+    AppState, ChatTemplateProcessor, ModelProvider, ServerConfig, ServerGenerateOptions, create_app,
+};
+use crate::tokenizer::MlxcelTokenizer;
+
+fn route_test_app(config: ServerConfig) -> (axum::Router, mpsc::Receiver<ServerGenerateOptions>) {
+    let (options_tx, options_rx) = mpsc::channel();
+    let provider = Arc::new(ModelProvider::recording_for_route_tests(options_tx));
+    let batch_metrics = provider.batch_metrics().clone();
+    let state = AppState::new(
+        provider,
+        config,
+        ChatTemplateProcessor::with_template(
+            "{% for message in messages %}{{ message.content }}{% endfor %}".to_string(),
+        ),
+        MlxcelTokenizer::stub(),
+        PathBuf::from("route-test-model"),
+        batch_metrics,
+    );
+    (create_app(state), options_rx)
+}
+
+async fn post_json(app: axum::Router, path: &str, body: Value) -> StatusCode {
+    app.oneshot(
+        Request::builder()
+            .method(Method::POST)
+            .uri(path)
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("route test request"),
+    )
+    .await
+    .expect("route test response")
+    .status()
+}
+
+fn capped_config() -> ServerConfig {
+    ServerConfig {
+        context_size: 64,
+        default_max_tokens: 32,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn explicit_over_cap_budget_is_clamped_on_all_generation_routes() {
+    let cases = [
+        (
+            "/v1/chat/completions",
+            json!({
+                "model": "route-test-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 1024
+            }),
+        ),
+        (
+            "/v1/completions",
+            json!({
+                "model": "route-test-model",
+                "prompt": "hello",
+                "max_tokens": 1024
+            }),
+        ),
+        (
+            "/completion",
+            json!({
+                "prompt": "hello",
+                "n_predict": 1024
+            }),
+        ),
+    ];
+
+    for (path, body) in cases {
+        let (app, options_rx) = route_test_app(capped_config());
+        assert_eq!(post_json(app, path, body).await, StatusCode::OK, "{path}");
+        assert_eq!(
+            options_rx
+                .recv()
+                .expect("route dispatched generation options")
+                .max_tokens,
+            64,
+            "{path}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn below_cap_budget_is_unchanged_on_all_generation_routes() {
+    let cases = [
+        (
+            "/v1/chat/completions",
+            json!({
+                "model": "route-test-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 17
+            }),
+        ),
+        (
+            "/v1/completions",
+            json!({
+                "model": "route-test-model",
+                "prompt": "hello",
+                "max_tokens": 17
+            }),
+        ),
+        (
+            "/completion",
+            json!({
+                "prompt": "hello",
+                "n_predict": 17
+            }),
+        ),
+    ];
+
+    for (path, body) in cases {
+        let (app, options_rx) = route_test_app(capped_config());
+        assert_eq!(post_json(app, path, body).await, StatusCode::OK, "{path}");
+        assert_eq!(
+            options_rx
+                .recv()
+                .expect("route dispatched generation options")
+                .max_tokens,
+            17,
+            "{path}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn absent_native_n_predict_uses_resolved_server_default() {
+    let (app, options_rx) = route_test_app(capped_config());
+
+    assert_eq!(
+        post_json(app, "/completion", json!({"prompt": "hello"})).await,
+        StatusCode::OK
+    );
+    assert_eq!(
+        options_rx
+            .recv()
+            .expect("native route dispatched generation options")
+            .max_tokens,
+        32
+    );
+}
+
+#[tokio::test]
+async fn reasoning_budget_is_validated_against_clamped_route_budget() {
+    let cases = [
+        (
+            "/v1/chat/completions",
+            json!({
+                "model": "route-test-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 1024,
+                "thinking_budget_tokens": 65
+            }),
+        ),
+        (
+            "/v1/completions",
+            json!({
+                "model": "route-test-model",
+                "prompt": "hello",
+                "max_tokens": 1024,
+                "thinking_budget_tokens": 65
+            }),
+        ),
+        (
+            "/completion",
+            json!({
+                "prompt": "hello",
+                "n_predict": 1024,
+                "thinking_budget_tokens": 65
+            }),
+        ),
+    ];
+
+    for (path, body) in cases {
+        let (app, options_rx) = route_test_app(capped_config());
+        assert_eq!(
+            post_json(app, path, body).await,
+            StatusCode::BAD_REQUEST,
+            "{path}"
+        );
+        assert!(
+            options_rx.try_recv().is_err(),
+            "{path} must reject before model dispatch"
+        );
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -92,3 +92,6 @@ pub use startup::{
     resolve_parallel_context_size, start_server,
 };
 pub use state::{AppState, BatchMetrics, Metrics, ModelMediaSupport};
+
+#[cfg(test)]
+mod max_tokens_route_tests;

--- a/src/server/model_provider.rs
+++ b/src/server/model_provider.rs
@@ -1419,5 +1419,8 @@ impl Drop for ModelProvider {
 }
 
 #[cfg(test)]
+include!("model_provider_test_support.rs");
+
+#[cfg(test)]
 #[path = "model_provider_tests.rs"]
 mod tests;

--- a/src/server/model_provider_test_support.rs
+++ b/src/server/model_provider_test_support.rs
@@ -1,0 +1,50 @@
+impl ModelProvider {
+    /// Build a model-free provider that records the options dispatched by HTTP
+    /// route tests and immediately returns an empty successful generation.
+    pub(crate) fn recording_for_route_tests(
+        options_tx: mpsc::Sender<ServerGenerateOptions>,
+    ) -> Self {
+        let (request_tx, request_rx) = mpsc::channel::<ModelRequest>();
+        let loaded = Arc::new(AtomicBool::new(true));
+        let batch_metrics = Arc::new(BatchMetrics::new());
+        let batch_observability = Arc::new(BatchObservability::new());
+        let worker_handle = thread::spawn(move || {
+            while let Ok(request) = request_rx.recv() {
+                match request {
+                    ModelRequest::Generate {
+                        options,
+                        response_tx,
+                        ..
+                    } => {
+                        let _ = options_tx.send(options);
+                        let _ = response_tx.send(GenerateEvent::Done(GenerationResult {
+                            text: String::new(),
+                            prompt_tokens: 0,
+                            completion_tokens: 0,
+                            generation_time_ms: 0,
+                            prompt_eval_ms: 0,
+                            generation_only_ms: 0,
+                            finish_reason: "stop".to_string(),
+                            logprobs: None,
+                            cached_tokens: 0,
+                        }));
+                    }
+                    ModelRequest::Shutdown => break,
+                }
+            }
+        });
+
+        Self {
+            request_tx,
+            model_id: "route-test-model".to_string(),
+            created_at: 0,
+            loaded,
+            batch_metrics,
+            batch_observability,
+            prompt_cache: None,
+            prompt_tokenizer: None,
+            decode_hang_timeout: DECODE_HANG_TIMEOUT,
+            _worker_handle: worker_handle,
+        }
+    }
+}

--- a/src/server/request_options.rs
+++ b/src/server/request_options.rs
@@ -268,7 +268,7 @@ pub(crate) fn build_server_generate_options(
     );
 
     ServerGenerateOptions {
-        max_tokens: overrides.max_tokens.unwrap_or(config.default_max_tokens),
+        max_tokens: resolve_server_max_tokens(config, overrides.max_tokens),
         sampling,
         stop_sequences: overrides.stop_sequences,
         priority: overrides.priority,
@@ -288,6 +288,26 @@ pub(crate) fn build_server_generate_options(
         // carry no image parts and always leave it `None`.
         image_soft_tokens: None,
     }
+}
+
+/// Resolve the generation budget shared by every server route.
+///
+/// Explicit client budgets are silently clamped to the effective per-slot
+/// context window when `--ctx-size` supplied one. When the context size is
+/// model-derived (`config.context_size == 0`), the startup-resolved server
+/// default is the cap; that default comes from the checkpoint context window
+/// for the `-n -1` sentinel, with 4096 as the final fallback. An omitted
+/// request budget keeps the configured server default unchanged.
+pub(crate) fn resolve_server_max_tokens(config: &ServerConfig, requested: Option<usize>) -> usize {
+    let Some(requested) = requested else {
+        return config.default_max_tokens;
+    };
+    let cap = if config.context_size > 0 {
+        config.context_size
+    } else {
+        config.default_max_tokens
+    };
+    requested.min(cap)
 }
 
 #[cfg(test)]

--- a/src/server/request_options_tests.rs
+++ b/src/server/request_options_tests.rs
@@ -15,7 +15,7 @@
 use super::{
     LOOP_DETECTION_RECOMMENDED, RequestOptionOverrides, build_server_generate_options,
     carries_loop_amplifier, chat_carries_loop_amplifier, loop_detection_from_request,
-    resolve_loop_detection,
+    resolve_loop_detection, resolve_server_max_tokens,
 };
 use crate::server::ServerConfig;
 use crate::server::types::request::{ChatCompletionRequest, FunctionDefinition, Tool};
@@ -173,6 +173,48 @@ fn build_server_generate_options_applies_request_overrides() {
     assert_eq!(options.sampling.xtc_probability, 0.7);
     assert_eq!(options.sampling.xtc_threshold, 0.2);
     assert_eq!(options.stop_sequences, Some(vec!["stop".to_string()]));
+}
+
+#[test]
+fn explicit_max_tokens_clamps_to_per_slot_context_size() {
+    let config = ServerConfig {
+        context_size: 128,
+        default_max_tokens: 64,
+        ..Default::default()
+    };
+
+    assert_eq!(resolve_server_max_tokens(&config, Some(1024)), 128);
+    let options = build_server_generate_options(
+        &config,
+        RequestOptionOverrides {
+            max_tokens: Some(1024),
+            ..Default::default()
+        },
+    );
+    assert_eq!(options.max_tokens, 128);
+}
+
+#[test]
+fn explicit_max_tokens_clamps_to_default_without_explicit_context() {
+    let config = ServerConfig {
+        context_size: 0,
+        default_max_tokens: 768,
+        ..Default::default()
+    };
+
+    assert_eq!(resolve_server_max_tokens(&config, Some(4096)), 768);
+}
+
+#[test]
+fn below_cap_and_absent_max_tokens_are_unchanged() {
+    let config = ServerConfig {
+        context_size: 128,
+        default_max_tokens: 64,
+        ..Default::default()
+    };
+
+    assert_eq!(resolve_server_max_tokens(&config, Some(32)), 32);
+    assert_eq!(resolve_server_max_tokens(&config, None), 64);
 }
 
 // -- loop detection (issue #432) --

--- a/src/server/routes/anthropic.rs
+++ b/src/server/routes/anthropic.rs
@@ -60,7 +60,7 @@ use crate::server::types::anthropic_stream::{
 use super::chat::{
     MAX_TOOLS, build_generate_options, build_prompt_cache_request_context, parse_priority_header,
 };
-use crate::server::request_options::chat_carries_loop_amplifier;
+use crate::server::request_options::{chat_carries_loop_amplifier, resolve_server_max_tokens};
 
 /// POST /v1/messages
 pub async fn anthropic_messages(
@@ -98,11 +98,8 @@ pub async fn anthropic_messages(
     }
 
     // Resolve the thinking budget exactly as the chat / responses routes do.
-    let effective_max_tokens = translated
-        .chat_request
-        .params
-        .max_tokens
-        .unwrap_or(state.config.default_max_tokens);
+    let effective_max_tokens =
+        resolve_server_max_tokens(&state.config, translated.chat_request.params.max_tokens);
     let raw_budget = pick_budget_alias(
         translated.chat_request.params.thinking_budget_tokens,
         translated.chat_request.params.thinking_token_budget,

--- a/src/server/routes/chat.rs
+++ b/src/server/routes/chat.rs
@@ -36,6 +36,7 @@ use crate::server::prompt_cache::key::{
 };
 use crate::server::request_options::{
     RequestOptionOverrides, build_server_generate_options, chat_carries_loop_amplifier,
+    resolve_server_max_tokens,
 };
 use crate::server::streaming::sse_channel;
 use crate::server::structured::{StructuredOutputError, build_constraint_from_response_format};
@@ -264,10 +265,7 @@ pub async fn chat_completions(
 
     // validate thinking_budget_tokens early so malformed values
     // surface as 400 before any generation work begins.
-    let effective_max_tokens = request
-        .params
-        .max_tokens
-        .unwrap_or(state.config.default_max_tokens);
+    let effective_max_tokens = resolve_server_max_tokens(&state.config, request.params.max_tokens);
     let raw_budget = pick_budget_alias(
         request.params.thinking_budget_tokens,
         request.params.thinking_token_budget,

--- a/src/server/routes/completions.rs
+++ b/src/server/routes/completions.rs
@@ -31,6 +31,7 @@ use mlxcel_core::sampling::{LogprobsConfig, TokenLogprobData};
 use crate::server::AppState;
 use crate::server::batch::RequestPriority;
 use crate::server::config::ReasoningBudgetOverride;
+use crate::server::request_options::resolve_server_max_tokens;
 use crate::server::streaming::sse_channel;
 use crate::server::structured::build_constraint_from_response_format;
 use crate::server::thinking_budget::{pick_budget_alias, resolve_request_budget};
@@ -161,10 +162,7 @@ pub async fn completions(
     }
 
     // validate thinking_budget_tokens early.
-    let effective_max_tokens = request
-        .params
-        .max_tokens
-        .unwrap_or(state.config.default_max_tokens);
+    let effective_max_tokens = resolve_server_max_tokens(&state.config, request.params.max_tokens);
     let raw_budget = pick_budget_alias(
         request.params.thinking_budget_tokens,
         request.params.thinking_token_budget,

--- a/src/server/routes/native_completion.rs
+++ b/src/server/routes/native_completion.rs
@@ -29,7 +29,9 @@ use axum::{
 
 use crate::server::batch::RequestPriority;
 use crate::server::config::ReasoningBudgetOverride;
-use crate::server::request_options::{RequestOptionOverrides, build_server_generate_options};
+use crate::server::request_options::{
+    RequestOptionOverrides, build_server_generate_options, resolve_server_max_tokens,
+};
 use crate::server::streaming::sse_channel;
 use crate::server::thinking_budget::{pick_budget_alias, resolve_request_budget};
 use crate::server::types::{
@@ -68,7 +70,7 @@ pub async fn native_completion(
 
     // validate thinking_budget_tokens early (semantics match
     // /v1/chat/completions but the cap is checked against n_predict).
-    let effective_n_predict = request.n_predict.unwrap_or(state.config.default_max_tokens);
+    let effective_n_predict = resolve_server_max_tokens(&state.config, request.n_predict);
     let raw_budget = pick_budget_alias(
         request.thinking_budget_tokens,
         request.thinking_token_budget,

--- a/src/server/routes/responses.rs
+++ b/src/server/routes/responses.rs
@@ -62,7 +62,7 @@ use super::chat::{
     build_generate_options, build_prompt_cache_request_context, parse_priority_header,
     validate_xtc_params,
 };
-use crate::server::request_options::chat_carries_loop_amplifier;
+use crate::server::request_options::{chat_carries_loop_amplifier, resolve_server_max_tokens};
 
 /// POST /v1/responses
 pub async fn create_response(
@@ -125,11 +125,8 @@ pub async fn create_response(
     };
 
     // Resolve thinking budget the same way the chat path does.
-    let effective_max_tokens = translated
-        .chat_request
-        .params
-        .max_tokens
-        .unwrap_or(state.config.default_max_tokens);
+    let effective_max_tokens =
+        resolve_server_max_tokens(&state.config, translated.chat_request.params.max_tokens);
     let raw_budget = pick_budget_alias(
         translated.chat_request.params.thinking_budget_tokens,
         translated.chat_request.params.thinking_token_budget,

--- a/src/server/types/request.rs
+++ b/src/server/types/request.rs
@@ -566,7 +566,8 @@ pub struct Message {
 #[serde(default)]
 #[derive(Default)]
 pub struct SamplingParams {
-    /// Maximum number of tokens to generate
+    /// Maximum number of tokens to generate. Server routes silently clamp an
+    /// explicit value to the effective per-slot context window.
     pub max_tokens: Option<usize>,
     /// Sampling temperature (0.0 = greedy, higher = more random)
     pub temperature: Option<f32>,
@@ -940,7 +941,8 @@ impl ChatCompletionRequest {
 pub struct NativeCompletionRequest {
     /// Input prompt
     pub prompt: String,
-    /// Maximum number of tokens to predict
+    /// Maximum number of tokens to predict. The server silently clamps an
+    /// explicit value to the effective per-slot context window.
     pub n_predict: Option<usize>,
     /// Whether to stream the response
     pub stream: Option<bool>,


### PR DESCRIPTION
## Summary

Silently clamp explicit client generation budgets to the effective per-slot context window so oversized `max_tokens` and `n_predict` values cannot reach the scheduler unchanged.

## What changed

- Added a shared server budget resolver that uses the per-slot `context_size` when configured and the resolved server default otherwise.
- Applied the effective clamped budget consistently to reasoning-token validation across chat, completion, native, Messages, and Responses routes.
- Added actual Axum route tests for `/v1/chat/completions`, `/v1/completions`, and `/completion`, including over-cap, below-cap, omitted native budget, and reasoning-budget behavior.
- Documented the silent-clamp policy and fallback source in the README and request type documentation.

## Test plan

- [x] `cargo test --lib server::request_options::tests`
- [x] `cargo test --lib server::max_tokens_route_tests`
- [x] `cargo check --lib --tests --quiet`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --lib --tests -- -D warnings`

## Review

- [x] Implementation review: complete and integrated; no unresolved findings.
- [x] Security/performance review: constant-time clamp with no production allocation or concurrency changes; no unresolved findings.
- [x] Finalizer review: acceptance coverage, documentation, formatting, compile, and lint gates are complete.

Closes #980
