### PR TITLE
fix(multimodal): pin the Qwen2-VL XLA loader contract and document all three outcomes

### DIFF
--- a/src/multimodal/host_preprocessor.rs
+++ b/src/multimodal/host_preprocessor.rs
@@ -132,16 +132,38 @@ pub trait HostMultimodalPreprocessor {
 
 /// Load the image preprocessor supported by the OpenXLA host-first path.
 ///
-/// `Ok(None)` is the conservative result for text-only checkpoints and VLM
-/// families whose processor/position contract has not been qualified for XLA
-/// yet. Once a checkpoint is identified as the supported LLaVA family, missing
-/// or malformed processor/projector weights are startup errors rather than a
-/// capability downgrade.
+/// Three outcomes are possible, one per axis this loader decides on:
+///
+/// - `Ok(None)` is the conservative result for text-only checkpoints and VLM
+///   families whose processor/position contract has not been qualified for XLA
+///   yet.
+/// - `Ok(Some(preprocessor))` is returned for a qualified family that can run
+///   its vision path in this build. LLaVA reaches this even without the
+///   `xla-iree` feature, because it has a complete MLX host vision tower and
+///   projector to fall back to; only an explicit
+///   `MLXCEL_XLA_VISION_BACKEND=iree` makes feature absence fatal there.
+/// - `Err(..)` is returned for a qualified family this build cannot serve
+///   images for. That covers missing or malformed processor/projector weights
+///   on an identified LLaVA checkpoint, and Qwen2-VL in a build without
+///   `xla-iree`.
+///
+/// The Qwen2-VL asymmetry with LLaVA is deliberate, not an oversight. Qwen2-VL
+/// has no MLX vision fallback, which is the same reason
+/// `MLXCEL_XLA_VISION_BACKEND=host` is rejected for it below, so without
+/// `xla-iree` no code path can embed its images. `Ok(None)` there would be
+/// indistinguishable from a text-only checkpoint and would start a session that
+/// silently ignores every image. Failing takes away nothing that worked:
+/// `xla-iree` also enables `mlxcel-xla/iree`, and without that the session's
+/// `prefill` and `decode_step` return `mlxcel_xla::NOT_WIRED`, so an
+/// `xla-backend`-only build cannot generate from any checkpoint at all. Both
+/// callers (`backend::xla::create_session` and the server's image-preprocess
+/// stage) turn this error into a startup failure, so the message carries the
+/// rebuild instruction the operator needs.
 ///
 /// # Errors
 ///
-/// Returns a typed configuration or weight-loading error for a supported LLaVA
-/// checkpoint that cannot construct its complete host preprocessor.
+/// Returns a typed configuration or weight-loading error for a qualified
+/// checkpoint that cannot construct a complete image path in this build.
 pub fn load_xla_image_preprocessor(
     model_path: &Path,
 ) -> Result<Option<Box<dyn HostMultimodalPreprocessor>>, HostPreprocessorError> {
@@ -172,10 +194,17 @@ pub fn load_xla_image_preprocessor(
             );
             return Ok(Some(Box::new(preprocessor)));
         }
+        // No MLX fallback exists for this family, so an image-capable session
+        // cannot be built here. Report it as a build-configuration error with
+        // the remedy attached: both callers surface this string verbatim, so
+        // the rebuild instruction is the only actionable part the operator
+        // gets.
         #[cfg(not(feature = "xla-iree"))]
         {
             return Err(HostPreprocessorError::InvalidConfig(
-                "Qwen2-VL XLA image execution requires the xla-iree feature".to_string(),
+                "Qwen2-VL XLA image execution requires the xla-iree feature; rebuild mlxcel with \
+                 `--features xla-iree` (this family has no MLX vision fallback)"
+                    .to_string(),
             ));
         }
     }

--- a/src/multimodal/host_preprocessor_tests.rs
+++ b/src/multimodal/host_preprocessor_tests.rs
@@ -67,7 +67,12 @@ fn iree_vision_contract_policy_is_explicit_and_strict() {
 
 #[test]
 fn xla_loader_keeps_text_and_unqualified_vlm_image_capability_false() {
-    for model_type in ["llama", "qwen2_vl"] {
+    // `llama` is text-only and `mllama` is a VLM family whose processor and
+    // position contract has never been qualified for XLA. Both are capability
+    // downgrades rather than errors. `qwen2_vl` is deliberately not in this set:
+    // it is qualified, so a build that cannot run it is an error instead, pinned
+    // by `xla_loader_rejects_qwen2_vl_without_the_iree_feature` below.
+    for model_type in ["llama", "mllama"] {
         let model_dir = tempfile::tempdir().unwrap();
         std::fs::write(
             model_dir.path().join("config.json"),
@@ -80,6 +85,37 @@ fn xla_loader_keeps_text_and_unqualified_vlm_image_capability_false() {
             "{model_type} is not a qualified LLaVA host/runtime pair"
         );
     }
+}
+
+/// Qwen2-VL is qualified for the XLA vision path but has no MLX fallback, so a
+/// build without `xla-iree` has no way to embed its images. The loader reports
+/// that as a build-configuration error instead of downgrading capability to
+/// `Ok(None)`, which would be indistinguishable from a text-only checkpoint and
+/// would start a session that silently ignores images. Gated to the build the
+/// contract is about: with `xla-iree` the same config takes the IREE load path.
+#[cfg(not(feature = "xla-iree"))]
+#[test]
+fn xla_loader_rejects_qwen2_vl_without_the_iree_feature() {
+    let model_dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        model_dir.path().join("config.json"),
+        r#"{"model_type":"qwen2_vl"}"#,
+    )
+    .unwrap();
+    let error = load_xla_image_preprocessor(model_dir.path())
+        .err()
+        .expect("qwen2_vl without xla-iree must fail startup, not downgrade image capability");
+    let HostPreprocessorError::InvalidConfig(message) = &error else {
+        panic!("expected a build-configuration error, got {error:?}");
+    };
+    assert!(
+        message.contains("requires the xla-iree feature"),
+        "the message must name the missing feature: {message}"
+    );
+    assert!(
+        message.contains("--features xla-iree"),
+        "the message must carry the actionable rebuild instruction: {message}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What was broken

`multimodal::host_preprocessor::tests::xla_loader_keeps_text_and_unqualified_vlm_image_capability_false` has failed deterministically on `main` since `edc0ebbb6` (#915). It loops over `["llama", "qwen2_vl"]` asserting `load_xla_image_preprocessor(...)` returns `Ok(None)`, but #915 made `qwen2_vl` return `Err(InvalidConfig("Qwen2-VL XLA image execution requires the xla-iree feature"))` when the feature is absent, so the `.unwrap()` panics. That commit edited the same test file, adding an import and two export tests, and left this loop untouched, so the contract and the test that pins it diverged inside a single change to a single file.

This is the third deterministically-failing test found on `main` in one week, after the two repaired in #946 and #953. It is the first one the nightly verification job added in #953 should catch on its own.

## Which side is right

The production behavior stays; the test changes. The reasoning, recorded here so it is not relitigated:

Qwen2-VL has no MLX vision fallback. The arm immediately above already rejects `MLXCEL_XLA_VISION_BACKEND=host` for it with exactly that reason, so in a build without `xla-iree` there is no code path that can embed its images. `Ok(None)` for such a checkpoint is indistinguishable from a text-only checkpoint, so a session would start with every image silently ignored, which is a worse outcome than a named failure at load.

Failing at load also takes away nothing that worked. `xla-iree = ["xla-backend", "mlxcel-xla/iree"]`, and without `mlxcel-xla/iree` the session's `prefill` and `decode_step` return `mlxcel_xla::NOT_WIRED`, whose text is "the OpenXLA inference session was built without the `iree` feature; rebuild ...". An `xla-backend`-only build cannot generate from any checkpoint at all, so there is no working configuration being broken here.

Feature absence already errors elsewhere in the same function: an explicit `MLXCEL_XLA_VISION_BACKEND=iree` returns `Err` for the same reason.

## The counter-argument, addressed rather than dropped

Without `xla-iree`, LLaVA does **not** error. Unless the policy is explicitly `iree` it falls through to the host preprocessor and returns `Ok(Some(host))`. Qwen2-VL is the only family where a missing compile-time feature is fatal, and that asymmetry deserved an answer rather than silence.

It is deliberate and now documented where a reader will find it: LLaVA has a complete MLX host vision tower and projector to fall back to, Qwen2-VL has none. The doc comment on `load_xla_image_preprocessor` previously described only two of the three outcomes the function implements, which is precisely how the contract drifted from its test. It now covers all three (`Ok(None)`, `Ok(Some)`, `Err`), states which families reach each and why, and records the `NOT_WIRED` reasoning.

## Changes

The capability-false loop drops `qwen2_vl` and gains `mllama`, so it still covers an unqualified VLM family rather than degrading to a text-only-only test, with an inline comment explaining why `qwen2_vl` is deliberately absent and where its contract is pinned instead.

A new `xla_loader_rejects_qwen2_vl_without_the_iree_feature`, gated `#[cfg(not(feature = "xla-iree"))]` because with the feature the same config takes the IREE load path, asserts the error variant and that its message both names the missing feature and carries the `--features xla-iree` rebuild instruction. Both callers surface this string verbatim into a startup failure, so the instruction is the only actionable part an operator receives; the error text was extended to carry it.

## Validation

`cargo test --release --lib --features metal,accelerate multimodal::host_preprocessor` goes from `11 passed; 1 failed` to `13 passed; 0 failed`. `cargo fmt --all -- --check` and the cross-repo-ref guard are clean.

No production behavior changes: the only non-test edits are the doc comment and the error string.

Closes #966
