### PR TITLE
fix(models): read the nested quantization block in deepseek::ModelArgs

### DIFF
--- a/src/models/deepseek.rs
+++ b/src/models/deepseek.rs
@@ -22,6 +22,7 @@
 //! - routed_scaling_factor for expert outputs (default 1.0)
 //! - Top-k routing with softmax scoring
 
+use crate::models::deepseek_v2::Quantization;
 use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
@@ -66,6 +67,15 @@ pub struct ModelArgs {
     #[serde(default)]
     pub attention_bias: bool,
 
+    // MLX-style nested `"quantization": {"group_size": .., "bits": ..}` block:
+    // present in a plain `deepseek` config.json and inherited into
+    // `language_config` by the DeepSeek-OCR loaders (vlm_deepseekocr.rs).
+    // Takes precedence over the flat keys below.
+    #[serde(default)]
+    pub quantization: Option<Quantization>,
+
+    // Flat top-level spelling, kept as a fallback for checkpoints that
+    // declare `group_size` / `bits` directly on the (sub-)config root.
     #[serde(default)]
     pub group_size: Option<i32>,
 
@@ -95,11 +105,19 @@ impl ModelArgs {
     }
 
     pub fn group_size(&self) -> i32 {
-        self.group_size.unwrap_or(64)
+        self.quantization
+            .as_ref()
+            .map(|q| q.group_size)
+            .or(self.group_size)
+            .unwrap_or(64)
     }
 
     pub fn bits(&self) -> i32 {
-        self.bits.unwrap_or(4)
+        self.quantization
+            .as_ref()
+            .map(|q| q.bits)
+            .or(self.bits)
+            .unwrap_or(4)
     }
 }
 

--- a/src/models/deepseek_tests.rs
+++ b/src/models/deepseek_tests.rs
@@ -40,6 +40,7 @@ fn test_args(n_routed_experts: Option<usize>) -> ModelArgs {
         first_k_dense_replace: 0,
         routed_scaling_factor: 1.0,
         attention_bias: false,
+        quantization: None,
         group_size: None,
         bits: None,
     }
@@ -99,9 +100,10 @@ fn switch_linear_accepts_full_expert_count() {
     assert_eq!(sl.num_experts(), 4);
 }
 
-/// The same minimal config with an explicit quantization pair. DeepSeek v1
-/// declares `group_size` / `bits` as flat top-level keys rather than a nested
-/// `quantization` block, so those are the two fields the guard reads.
+/// The same minimal config with an explicit quantization pair, in the flat
+/// top-level spelling. DeepSeek v1 accepts both a nested `quantization` block
+/// (preferred) and flat `group_size` / `bits` keys; the guard reads the
+/// resolved pair either way.
 fn quant_args(group_size: i32, bits: i32) -> ModelArgs {
     let mut args = test_args(None);
     args.group_size = Some(group_size);
@@ -169,4 +171,85 @@ fn deepseek_switch_linear_rejects_quantization_params_that_would_abort_gather_qm
     );
     SwitchLinear::from_weights(&regular, &quant_args(0, 0), PREFIX)
         .expect("a bf16 expert plane must not be gated on quantization params");
+}
+
+/// Minimal `language_config` JSON in the shape the DeepSeek-OCR checkpoints
+/// ship: required structural fields only, no quantization declaration.
+fn minimal_language_config() -> serde_json::Value {
+    serde_json::json!({
+        "model_type": "deepseek",
+        "vocab_size": 8,
+        "hidden_size": 8,
+        "intermediate_size": 8,
+        "num_hidden_layers": 0,
+        "num_attention_heads": 1,
+        "num_key_value_heads": 1,
+        "max_position_embeddings": 16,
+    })
+}
+
+/// #975: the DeepSeek-OCR loaders (`src/loading/vlm_deepseekocr.rs`) inherit
+/// the root `quantization` object into `language_config` before deserializing
+/// into `ModelArgs`. The struct used to lack the nested field, so serde
+/// silently dropped the block and `group_size()` / `bits()` fell back to
+/// 64 / 4 regardless of what the checkpoint declared. This drives the same
+/// insert the loaders perform and asserts the declared pair survives.
+#[test]
+fn model_args_reads_inherited_nested_quantization_block() {
+    let mut lc = minimal_language_config();
+    let full_config = serde_json::json!({
+        "quantization": {"group_size": 32, "bits": 8, "mode": "affine"}
+    });
+    let obj = lc.as_object_mut().unwrap();
+    if !obj.contains_key("quantization")
+        && let Some(q) = full_config.get("quantization")
+    {
+        obj.insert("quantization".to_string(), q.clone());
+    }
+
+    let args: ModelArgs = serde_json::from_value(lc).expect("language_config must deserialize");
+    assert_eq!(args.group_size(), 32);
+    assert_eq!(args.bits(), 8);
+}
+
+/// A checkpoint that spells the pair as flat top-level keys must keep loading
+/// with those values.
+#[test]
+fn model_args_reads_flat_quantization_keys() {
+    let mut lc = minimal_language_config();
+    let obj = lc.as_object_mut().unwrap();
+    obj.insert("group_size".to_string(), serde_json::json!(128));
+    obj.insert("bits".to_string(), serde_json::json!(8));
+
+    let args: ModelArgs = serde_json::from_value(lc).expect("flat spelling must deserialize");
+    assert_eq!(args.group_size(), 128);
+    assert_eq!(args.bits(), 8);
+}
+
+/// When both spellings are present the nested block wins, matching the
+/// documented precedence on `ModelArgs`.
+#[test]
+fn model_args_nested_quantization_beats_flat_keys() {
+    let mut lc = minimal_language_config();
+    let obj = lc.as_object_mut().unwrap();
+    obj.insert(
+        "quantization".to_string(),
+        serde_json::json!({"group_size": 32, "bits": 8}),
+    );
+    obj.insert("group_size".to_string(), serde_json::json!(128));
+    obj.insert("bits".to_string(), serde_json::json!(4));
+
+    let args: ModelArgs = serde_json::from_value(lc).expect("mixed spelling must deserialize");
+    assert_eq!(args.group_size(), 32);
+    assert_eq!(args.bits(), 8);
+}
+
+/// No declaration at all keeps the family defaults, which is what the two
+/// in-tree DeepSeek-OCR checkpoints rely on.
+#[test]
+fn model_args_defaults_without_quantization_declaration() {
+    let args: ModelArgs = serde_json::from_value(minimal_language_config())
+        .expect("undeclared quantization must deserialize");
+    assert_eq!(args.group_size(), 64);
+    assert_eq!(args.bits(), 4);
 }

--- a/src/vision/unlimited_ocr_tests.rs
+++ b/src/vision/unlimited_ocr_tests.rs
@@ -170,6 +170,7 @@ fn build_wrapper() -> UnlimitedOcrVlModel {
         first_k_dense_replace: 0,
         routed_scaling_factor: 1.0,
         attention_bias: false,
+        quantization: None,
         group_size: None,
         bits: None,
     };


### PR DESCRIPTION
## Summary

`deepseek::ModelArgs` silently dropped the MLX-style nested `"quantization": {"group_size": .., "bits": ..}` block — the struct only declared flat top-level `group_size` / `bits` fields, so the inheritance the three DeepSeek-OCR loaders perform in `vlm_deepseekocr.rs` accomplished nothing and the accessors always fell back to `64` / `4`. This adds the nested field (reusing `deepseek_v2::Quantization`, whose presence is why the byte-identical inheritance in `vlm_deepseek_vl2.rs` already worked) and makes `group_size()` / `bits()` prefer nested-then-flat-then-default.

## Related issues

Closes #975

## Type of change

- [x] `fix` — bug fix

## Test plan

- New regression tests in `src/models/deepseek_tests.rs`:
  - `model_args_reads_inherited_nested_quantization_block` — drives the same `language_config` insert the OCR loaders perform (including the extra `"mode"` key real checkpoints carry) and asserts the declared pair survives deserialization.
  - `model_args_reads_flat_quantization_keys` — the flat spelling keeps loading with its declared values.
  - `model_args_nested_quantization_beats_flat_keys` — pins the documented precedence.
  - `model_args_defaults_without_quantization_declaration` — no declaration keeps 64 / 4, which is what the two in-tree DeepSeek-OCR checkpoints rely on.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --features metal,accelerate -- -D warnings`
- [x] `cargo test --profile test-fast --features metal,accelerate models::deepseek` / `vision::unlimited_ocr` — 7 + 3 passed (full `--release` suite not run on this machine; see notes)
- [ ] Validated with a real checkpoint: not run — no Metal toolchain on this machine (CPU-only build via `MLXCEL_BUILD_METAL=OFF`). Both in-tree OCR checkpoints declare exactly `{group_size: 64, bits: 4}`, i.e. the fallback values, so the resolved pair — and therefore OCR output — is unchanged for them by construction. Happy to run the confirmation if a maintainer prefers it before merge.

## Notes for reviewers

- `DeepSeekModel::load` needs no change: it deserializes the whole `config.json` into `ModelArgs`, so a plain `deepseek` checkpoint's nested block is now picked up through the same field.
- Issue #975's optional item 3 (factoring the ~dozen private `Quantization` copies under `src/models/` into one shared struct) is deliberately left out — that's a cross-family refactor and a separate PR per the one-logical-change rule. Reusing `deepseek_v2::Quantization` here at least stops these two siblings from diverging again.
- One nuance inherited from `deepseek_v2`: `Quantization`'s fields are required, so a `quantization` block missing `group_size`/`bits` now fails deserialization instead of being ignored. That matches `deepseek_v2`'s existing behavior for the same block and MLX exports always write both keys.

## Checklist

- [x] PR title uses a Conventional Commits prefix
- [x] One logical change per PR
- [ ] Updated `docs/` — not needed (no user-facing behavior change for in-tree checkpoints)
- [ ] Updated `// Used by: ...` comments — no shared function modified
- [x] No secrets, credentials, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)