### PR TITLE
test(autotune): stop pinning the rep-scaling test to an exact ceiling

### DIFF
--- a/src/lib/mlxcel-core/src/autotune/autotune_tests.rs
+++ b/src/lib/mlxcel-core/src/autotune/autotune_tests.rs
@@ -362,18 +362,42 @@ fn timed_repetitions_scale_inversely_with_launch_cost() {
         min_improvement: 0.02,
     };
 
+    // `FakeOp::run` sleeps, and `thread::sleep` only ever overshoots its
+    // request, so a loaded host inflates the measured per-iteration cost and
+    // lowers the realized rep count. Asserting the exact ceiling made this test
+    // pass in isolation and fail under full-suite parallelism, where 1200+
+    // tests contend; the property under test is that effort scales inversely
+    // with launch cost, not that a cheap launch lands on one particular number.
     let cheap = FakeOp::new("fake_cheap_launch", vec![(1, 100)]);
     let cheap_result = profile(&cheap, cfg).expect("cheap sweep produced a result");
-    assert_eq!(
-        cheap_result.reps, 64,
-        "a ~100us launch fits a 50ms budget far more than 64 times"
+    assert!(
+        cheap_result.reps >= 4 * cfg.reps,
+        "a ~100us launch should sample far above the {} floor inside a 50ms budget, got {}",
+        cfg.reps,
+        cheap_result.reps
+    );
+    assert!(
+        cheap_result.reps <= cfg.max_reps,
+        "the ceiling must still bound the sweep, got {} > {}",
+        cheap_result.reps,
+        cfg.max_reps
     );
 
+    // The costly direction is robust to load in a way the cheap one is not:
+    // overshooting a 20ms sleep only exhausts the budget sooner, so the floor
+    // is reached under any amount of contention.
     let costly = FakeOp::new("fake_costly_launch", vec![(1, 20_000)]);
     let costly_result = profile(&costly, cfg).expect("costly sweep produced a result");
     assert_eq!(
-        costly_result.reps, 5,
+        costly_result.reps, cfg.reps,
         "a 20ms launch exhausts the budget in three, so the floor applies"
+    );
+
+    assert!(
+        cheap_result.reps > costly_result.reps,
+        "cheap {} should outsample costly {}",
+        cheap_result.reps,
+        costly_result.reps
     );
 }
 


### PR DESCRIPTION
## Summary

`autotune::autotune_tests::timed_repetitions_scale_inversely_with_launch_cost` is flaky. It passes in isolation and fails under full-suite parallelism, where more than 1200 tests contend for the machine. This replaces the load-sensitive assertion with the property the test actually exists to check.

## Cause

`FakeOp::run` simulates launch cost with `std::thread::sleep`, which can overshoot its requested duration but never undershoot it. Under contention a declared 100us launch measures far slower, so the fixed 50ms sample budget buys fewer repetitions and the realized count lands below the ceiling. The test then failed its `assert_eq!(reps, 64)`. Nothing in the autotuner is wrong; the assertion was measuring host load rather than the behaviour under test.

## Fix

The property is that sampling effort scales inversely with launch cost, not that a cheap launch reaches one specific number. The test now asserts that shape: the cheap launch samples well above the floor and stays within the ceiling, the costly launch reaches the floor exactly, and cheap outsamples costly. The costly direction keeps its equality deliberately, because overshooting a 20ms sleep only exhausts the budget sooner, so the floor is reached under any amount of load and that assertion cannot go flaky in the same way.

## Verification

Run on Apple M1 Ultra with `--features metal,accelerate`, both in isolation and under the full-suite condition that originally exposed the failure.

- `cargo test --release -p mlxcel-core --lib --features metal,accelerate autotune::` gives 55 passed.
- `cargo test -p mlxcel-core --release --features metal,accelerate` gives 1203 passed, 1 failed, where the single remaining failure is the pre-existing `fused_moe_parity_tests::fused_moe_geglu_kernel_matches_references_gemma4_shape` tracked in #964 and unrelated to this change.
- `cargo clippy -p mlxcel-core --lib --tests --features metal,accelerate -- -D warnings` and `cargo fmt --all -- --check` are clean.

## Context

Introduced by #906 and found while validating a later sub-issue of epic #909, where it was the only new failure in an otherwise clean regression run. Worth fixing rather than tolerating, because this repository's CI does not run the test suite, so a local full-suite run is the project's real gate and an intermittent failure there costs someone a misattributed investigation.

Refs #906, #909
