### PR TITLE
feat(core): matrix-absorbed MLA decode over a compressed-latent KV cache

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Current GitHub-facing docs:
 13. `python-client.md`: the `mlxcel` Python client over the OpenAI-compatible server, covering managed and connect modes, streaming, chat, structured output, the `openai_client` escape hatch, async usage, and troubleshooting.
 14. `audio-preprocessing.md` — shared model-input WAV normalization, loaded family policy, resource limits, cancellation, metrics, and current XLA capability boundary.
 15. `speculative-acceptance.md` — speculative-decoding acceptance rules, which rule each code path runs, the distribution-preservation guarantee and its RNG dependency, the kill switch, and how to read the active rule off a log.
+16. `mla-absorbed-decode.md` — DeepSeek-family matrix-absorbed MLA decode over a compressed-latent KV cache: the identity, the cache layout, the flags, and what is and is not verified.
 
 ## Architecture Decision Records
 

--- a/docs/benchmark_results/mla-absorbed-decode-m1ultra-2026-08-02.md
+++ b/docs/benchmark_results/mla-absorbed-decode-m1ultra-2026-08-02.md
@@ -1,0 +1,131 @@
+# MLA matrix-absorbed decode: Apple M1 Ultra, 2026-08-02
+
+Validation run for issue #907 (epic #909).
+
+**Outcome: the memory reduction is structural and large (8.89x), and decode speed
+crosses over from a loss to a substantial win as context grows.** The path ships
+opt-in (`MLXCEL_MLA_ABSORBED`, default off) because no MLA checkpoint was
+available to satisfy the issue's pinned-oracle token-parity gate.
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Hardware | Apple M1 Ultra, 20 cores (16P + 4E), 128 GB unified memory |
+| OS | macOS 26.5.2 (Darwin 25.5.0) |
+| Backend | Metal |
+| mlxcel | 0.4.3, branch `feature/issue-907-mla-absorbed-decode`, base `649f0a52` |
+| Harness | `examples/mla_absorbed_decode_bench.rs`, 64 steps, 16 warmup |
+| Geometry | heads 16, kv_lora_rank 512, qk_nope 128, qk_rope 64, v_head 128, 27 layers |
+| Load average | 7.7 during the sweep, from unrelated concurrent work |
+
+**No CUDA was written for this issue at all**, deliberately, so it adds nothing
+to the epic's stock of uncompiled CUDA.
+
+## Every row proves its own path
+
+Each measurement prints counters read from `mla::stats`, sampled and reset around
+the timed region, and the harness warns on any row whose counters disagree with
+its label. This exists because three separate measurements earlier in this epic
+turned out to be comparing a path against itself. The counters below are quoted
+from the run, not asserted.
+
+- `decompressed` rows: `decompressed=64 absorbed_composed=0 absorbed_split_kv=0`
+- `absorbed` rows: `decompressed=0 absorbed_composed=64 absorbed_split_kv=0`
+- `split_kv` rows: `decompressed=0 absorbed_composed=0 absorbed_split_kv=64`
+
+## Memory
+
+| Quantity | Decompressed | Latent | Ratio |
+|---|---|---|---|
+| KV bytes / token / layer | 10240 | 1152 | **8.89x** |
+| KV bytes / token, 27 layers | 276480 | 31104 | 8.89x |
+| Max context under a 16 GiB KV budget | 62137 tokens | **552336 tokens** | 8.89x |
+
+This is arithmetic on the cache layout rather than a timing, so it does not carry
+the measurement caveats the latency numbers do. The fold costs 4.0 MiB per layer
+in f16, 108 MiB over 27 layers, paid once at load.
+
+## Decode latency
+
+| batch | context | decompressed | absorbed | absorbed vs decompressed | split_kv |
+|---|---|---|---|---|---|
+| 1 | 4096 | 0.5449 ms | 0.6409 ms | **0.85x** | 1.1026 ms |
+| 4 | 4096 | 1.0987 ms | 1.2782 ms | **0.86x** | 1.3369 ms |
+| 1 | 16384 | 0.9993 ms | 0.8434 ms | **1.18x** | 1.2962 ms |
+| 4 | 16384 | 3.5449 ms | 2.6618 ms | **1.33x** | 2.7411 ms |
+| 1 | 32768 | 1.9613 ms | 1.0891 ms | **1.80x** | 1.5940 ms |
+| 4 | 32768 | 5.8391 ms | 4.2186 ms | **1.38x** | 4.3312 ms |
+
+### Reading
+
+**There is a crossover, and it is where the mechanism says it should be.**
+Absorption replaces reading a decompressed K and V per token with reading one
+latent vector, at the cost of a larger per-step matmul against the folded
+projection. At 4096 tokens the KV traffic is small enough that the extra matmul
+dominates and absorption loses by 14-15%. By 16384 the traffic dominates and
+absorption wins, and by 32768 at batch 1 it is 1.80x faster. Anyone enabling this
+flag on short contexts should expect it to cost them; the flag is worth setting
+for long-context serving, which is also where the 8.89x memory reduction matters.
+
+**`split_kv` is slower than plain `absorbed` in every configuration measured.**
+That is expected and was stated in advance: Stage 2's partial computation is
+composed MLX ops rather than a fused kernel, so it pays the split without the
+kernel that would make splitting pay off. It ships as a correct implementation
+that exercises and validates reuse of the #898 merge kernel, not as a speed path.
+The fused partial kernel the issue scopes for Stage 2 was not written.
+
+## Reuse of the #898 merge kernel
+
+The merge kernel from issue #898 was reused with no edit to
+`paged_attention_v2_merge.cpp`, `paged_attention_v2.h`, the FFI signature, or the
+C++ launcher, and **its contract held unchanged**. MLA maps onto it as
+`H = num_heads`, `D = kv_lora_rank`, `M = batch`, `N = batch * chunks`, with a
+request-major `o_indptr`.
+
+One clause of that contract fails silently and is now pinned by a test: the LSE
+inputs must be in log2 units, because a natural-log LSE still merges and returns
+a plausible but wrong average rather than erroring.
+`merge_rejects_natural_log_lse_units` asserts the natural-log variant does not
+match a host f64 reference while the log2 variant does. Issue #903 reuses the same
+kernel and should keep that test passing.
+
+## What is verified, and what is not
+
+**Verified**, on synthetic tensors with MLA geometry against a host f64
+pre-absorption reference: the absorption identity in f32 and f16; causal-mask
+survival through the rope score, with a positive control so the test cannot pass
+on a no-op mask; the up-projection direction; `(ckv, kpe)` round-trip through a
+real `KVCache` across the append boundary; trimmability for speculative decode;
+split and merge at four chunk lengths and against unsplit Stage 1; and a 6-token
+prefill plus 4 decode steps through `deepseek_v2`'s own `MLAAttention::forward`
+matching step-for-step through `o_proj`.
+
+**Not verified: anything on a real MLA checkpoint.** No DeepSeek-family model is
+available on this host and a V3-class checkpoint does not fit in 128 GB. The
+issue's pinned-oracle token-parity gate is therefore **not satisfied**, which is
+the reason the flag defaults to off. The f16 tolerance is 6e-3, which is expected
+drift given absorption reassociates a sum over 512 elements into one over 128, but
+whether that clears a production sign-off bar is a judgement that needs a real
+checkpoint.
+
+## Premise correction
+
+The issue states that the MLA families cache decompressed K/V. That is true for
+`deepseek_v2`, `minicpm3` and `dots1`, but **not** for `deepseek_v3` and
+`deepseek_v32`, which have shipped matrix absorption for some time, decomposing
+`kv_b_proj` in `sanitize_weights` and caching `(kv_latent, k_pe)`. The actual gap
+was the V2 family plus the transform existing twice with no shared home. This work
+builds the shared module and moves V2 onto it; V3 and V3.2 are untouched.
+
+## Open items
+
+- Fused Stage 2 partial kernel, which is what would make split-KV a speed path.
+- MiniCPM3 and dots1 wiring; converging V3/V3.2 onto the shared module.
+- Real-checkpoint token parity, blocking any default-on change.
+- `deepseek_v2` passes a null mask when `mask == None && l > 1`, i.e. non-causal
+  prefill, mirroring a bug `deepseek_v3.rs` already carries a comment about. It
+  was mirrored exactly here to preserve byte-parity with the baseline rather than
+  fixed, and is worth its own issue.
+- Fold memory is roughly 113 MiB for V2-Lite and about 2 GB for a V3-class model,
+  reported by the harness rather than mitigated.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -215,6 +215,8 @@ variables below are useful for service-level defaults and A/B experiments. See
 | `MLXCEL_TURBO4_DELEGATED_FP16_FAST_PATH` | truthy enables | off | **Advanced.** Keeps a unified FP16 V working set in delegated mode for speed experiments while maintaining packed sidecars. |
 | `MLXCEL_TURBO4_DELEGATED_FP16_SIDECARS` | `predecode`, `eager`, `lazy`, `on-demand` | `predecode` | Sidecar maintenance policy for the delegated FP16 fast path. |
 | `MLXCEL_ENABLE_DIRECT_PREFILL_CACHE_STORE` | presence enables | off | **Advanced.** Installs the incoming prefill tensor directly as the initial KV cache buffer when applicable. |
+| `MLXCEL_MLA_ABSORBED` | `1`/`true`/`on`/`yes` enables | off | DeepSeek-family matrix-absorbed MLA decode. Caches the compressed latent `(ckv, kpe)` instead of the decompressed per-head K/V, cutting the KV cache from `num_heads * (qk_head_dim + v_head_dim)` to `kv_lora_rank + qk_rope_head_dim` bytes per token per layer. Costs fixed weight memory: `kv_b_proj` is dequantized at load and kept dense. Currently wired for `deepseek_v2`; `deepseek_v3` / `deepseek_v32` already absorb unconditionally and ignore this. Declines (and keeps the decompressed path) for any non-FP16 KV cache mode and for paged-backed caches. Prints one stdout line at load stating how many layers folded. See [MLA absorbed decode](mla-absorbed-decode.md). |
+| `MLXCEL_MLA_SPLIT_KV` | `1`/`true`/`on`/`yes` enables | off | **Advanced.** Cuts the latent range into chunks whose partial softmax states are merged by the issue #898 merge kernel. Requires `MLXCEL_MLA_ABSORBED`; ignored without it. The partial producer is currently composed from MLX ops, so this is a correctness path rather than a speed path. |
 
 ## Video and local-media variables
 

--- a/docs/mla-absorbed-decode.md
+++ b/docs/mla-absorbed-decode.md
@@ -1,0 +1,110 @@
+# MLA matrix-absorbed decode
+
+Multi-head latent attention (MLA) is the DeepSeek-family attention that compresses K and V into a single latent vector per token. This page covers mlxcel's matrix-absorbed decode path, which serves attention directly against that latent instead of up-projecting it first.
+
+Status: opt-in, off by default. Verified on synthetic tensors with MLA geometry. Not yet verified against a real DeepSeek checkpoint.
+
+## The identity
+
+MLA stores one latent `c` of width `kv_lora_rank` (512 in every shipping checkpoint) plus a shared rope stream `k_pe` of width `qk_rope_head_dim` (64). `kv_b_proj` up-projects `c` into per-head keys and values. Naming its two row blocks `W_UK` and `W_UV`:
+
+```
+score:  q_nope . (W_UK c)  ==  (W_UK^T q_nope) . c
+output: attn @ (W_UV c)    ==  (attn @ c) @ W_UV
+```
+
+Folding `W_UK` into the query projection and `W_UV` after the attention removes the up-projection from the decode graph without changing the arithmetic. Attention then runs against `c` with `num_heads` query heads sharing one latent KV head, and the score becomes the sum of two dot products, one over `kv_lora_rank` and one over `qk_rope_head_dim`.
+
+## What it buys
+
+The KV cache stops scaling with head count.
+
+| Geometry | Decompressed bytes/token/layer (f16) | Latent bytes/token/layer (f16) | Ratio |
+|---|---|---|---|
+| DeepSeek-V2-Lite (16 heads) | 10240 | 1152 | 8.9x |
+| DeepSeek-V3 (128 heads) | 81920 | 1152 | 71.1x |
+
+These come from `mlxcel_core::mla::decompressed_bytes_per_token` and `latent_bytes_per_token`, which are the same functions the benchmark harness prints, so the table cannot drift from the code.
+
+The cost is fixed weight memory. The absorbed contractions are dense batched matmuls and MLX has no batched quantized matmul that keeps a 3-D per-head quantized operand, so the fold dequantizes `kv_b_proj` at load time and holds it dense. For DeepSeek-V2-Lite that is about 113 MiB in f16 across 27 layers against about 28 MiB for the 4-bit original. The trade only pays off past the context length where the cache saving exceeds it; the harness prints both numbers so the crossover is visible.
+
+## Flags
+
+| Variable | Effect |
+|---|---|
+| `MLXCEL_MLA_ABSORBED=1` | Cache `(ckv, kpe)` and run absorbed decode (Stage 1). Default off. |
+| `MLXCEL_MLA_SPLIT_KV=1` | Additionally cut the latent range into chunks and merge the partial states (Stage 2). Implies the above; ignored without it. |
+
+Both accept `1`, `true`, `on`, `yes` in any case. Anything else, including an unset variable, is off, so a typo degrades to the decompressed path rather than silently enabling one nobody asked for.
+
+With `MLXCEL_MLA_ABSORBED` unset, no fold is built, no weight is dequantized, and the family runs the pre-existing decompressed path unchanged.
+
+## Where it applies
+
+| Family | Before this work | Now |
+|---|---|---|
+| `deepseek_v2` | Decompressed cache | Absorbed under the flag |
+| `deepseek_v3` | Already absorbed (`embed_q` / `unembed_out` decomposition in `sanitize_weights`) | Unchanged |
+| `deepseek_v32` | Already absorbed, same decomposition | Unchanged |
+| `minicpm3` | Decompressed cache | Unchanged, still decompressed |
+| `dots1` | Decompressed cache | Unchanged, still decompressed |
+
+V3 and V3.2 have carried their own copy of the absorption transform since before this work. The shared `mlxcel_core::mla` module is where they can converge, and where MiniCPM3 and dots1 can be folded next.
+
+## Cache layout and what stays working
+
+The latent cache is a `KVCache` in FP16 mode whose two slots hold asymmetric tensors:
+
+| Slot | Holds | Shape |
+|---|---|---|
+| `keys` | `ckv` | `[B, 1, L, kv_lora_rank]` |
+| `values` | `kpe` | `[B, 1, L, qk_rope_head_dim]` |
+
+The FP16 update path already reads each side's head dimension from its own shape, so this needs no new cache type. That matters: a genuinely new type would force the family into the `ModelOwnedSequenceState` escape hatch the SSM hybrids use, which costs batching, the paged decode backend, and the generic prompt-cache donation path. Instead `offset`, `live_start`, `trim`, `trim_front`, `nbytes`, and `can_trim_prompt_cache` all keep their existing meanings on latent rows.
+
+The slot assignment matches what `src/models/deepseek_v3.rs` has always done, so V2 folded onto the shared type and V3's existing code describe the same buffer.
+
+Declined, with a message, falling back to the decompressed path:
+
+- Any non-FP16 KV cache mode (`int8`, `fp16+turbo4`, `turbo4`, `fp16+turbo3`, `turbo4-delegated`). Their per-token quantization is calibrated for a per-head K/V row, not for a 512-wide latent whose reconstruction error is amplified by every query head that reads it.
+- Paged backing. The pool allocates `[num_blocks, page_size, Hkv, head_dim]` with one head dimension for both sides, which the asymmetric `(512, 64)` split cannot fill.
+
+The decline is decided per cache, and the answer is fixed for a cache's lifetime, so a run that declines on the first step declines on every step and a cache never mixes the two layouts.
+
+## Prefill
+
+Prefill stays on the decompressed path and up-projects the live latent window through the still-loaded `kv_b_proj`. Absorption is a decode transform: it trades one up-projection of the whole window for a fold applied to every query, which only wins when the cached window is large relative to the number of queries.
+
+Keeping the original `kv_b_proj` for this means the absorbed prefill is the same arithmetic on the same quantized weight the decompressed path uses. The cost is that a chunked prefill re-up-projects the rows it already handled on the previous chunk, because the cache no longer holds them decompressed.
+
+Speculative and MTP multi-token verify steps take this same path, so they keep working against the latent cache rather than falling back.
+
+## Stage 2: split-KV
+
+Absorbed decode is one query row per head against the whole cached window, so parallelism is bounded by `batch * num_heads` and adding context adds none. Stage 2 cuts the latent range into chunks whose partial softmax states are combined afterwards, the same observation issue #898 made about paged decode.
+
+The merge is issue #898's `paged_attention_merge_states`, reused with no change to the kernel, the FFI signature, or the C++ launcher. Its contract is deliberately paging-agnostic: `v_in [N, H, D]` partials already divided by their own denominator, `lse_in [N, H]` in **log2** units, and `o_indptr [M + 1]` grouping. MLA fits it as `H = num_heads`, `D = kv_lora_rank`, `M = batch`, `N = batch * chunks`.
+
+The log2 requirement is the one clause that fails silently. A natural-log LSE still merges and returns a plausible wrong weighted average, so the conversion is a named constant (`mla::split_kv::LOG2_E`) and `merge_rejects_natural_log_lse_units` is a negative control that asserts the natural-log variant does *not* match the reference.
+
+The partial producer is currently composed from MLX ops. It is correct and it is the reference a fused partial kernel would be validated against, but it runs `C` small matmuls where Stage 1 runs one large one, so it is expected to be slower than Stage 1. Do not quote a Stage 2 throughput number before a fused partial kernel exists.
+
+## Benchmark
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-26.6.0.app/Contents/Developer
+cargo run --release --features metal,accelerate --example mla_absorbed_decode_bench -- \
+    --contexts 4096,16384,32768 --batches 1,4 --steps 64 --warmup 16
+```
+
+It measures one MLA attention block per decode step over three arms and prints the KV-memory table. Synthetic tensors, not a real checkpoint, so the numbers are the throughput of the layer that changed, not end-to-end model throughput.
+
+Every row ends in a `paths=` field from `mlxcel_core::mla::stats`, taken and reset around the measured region, and the harness prints a `WARNING` on any row whose counters disagree with the arm's label. **Do not report a row whose `paths=` field does not name its own arm.** Issue #899 shipped a fused decode path that never activated and whose before/after benchmark compared the fallback against itself; that null looked clean and was nearly accepted.
+
+For a real checkpoint, `MLXCEL_MLA_ABSORBED=1 mlxcel generate -m models/<deepseek> ...` prints one line at load stating how many layers folded and the bytes/token before and after. A run whose line reads `0/27 layers` is running the fallback. The line goes to stdout rather than through `tracing` because the `mlxcel` CLI installs no tracing subscriber, so a `tracing::info!` on this path emits nothing at any `RUST_LOG`.
+
+## Related
+
+- `src/lib/mlxcel-core/src/mla/` for the implementation.
+- `src/lib/mlxcel-core/src/paged_v2/` for the merge kernel and its contract.
+- [`docs/turbo-kv-cache.md`](turbo-kv-cache.md) for the KV cache modes this path declines.

--- a/examples/mla_absorbed_decode_bench.rs
+++ b/examples/mla_absorbed_decode_bench.rs
@@ -1,0 +1,407 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Decode-step benchmark for matrix-absorbed MLA (issue #907).
+//!
+//! ## What this measures, and what it does not
+//!
+//! One MLA attention block per step, on synthetic tensors with MLA geometry: the
+//! per-step cache append, the attention over the whole cached window, and the
+//! folds around it. It does **not** run a real DeepSeek checkpoint. MLA is a
+//! DeepSeek-family feature and no MLA checkpoint fits the development host, so
+//! quoting these numbers as end-to-end model throughput would be wrong. They are
+//! the throughput of the layer that changed, which is where the whole effect
+//! lives: nothing else in the model differs between the arms.
+//!
+//! ## Three arms
+//!
+//! * `decompressed` reproduces the pre-#907 path: `kv_b_proj` up-projects the
+//!   new token, the per-head K and V go into the cache, and SDPA reads
+//!   `num_heads * (qk_head_dim + v_head_dim)` per cached token.
+//! * `absorbed` is Stage 1: the cache holds `(ckv, kpe)` and SDPA reads
+//!   `kv_lora_rank + qk_rope_head_dim` per cached token, for one latent head.
+//! * `split_kv` is Stage 2: the same latent cache, with the range cut into
+//!   chunks whose partial states are merged by issue #898's
+//!   `paged_attention_merge_states`. Its partial producer is composed from MLX
+//!   ops, so it is expected to be *slower* than Stage 1 here; the arm exists to
+//!   show the decomposition running end to end and to be the baseline a fused
+//!   partial kernel is measured against.
+//!
+//! ## Proving which path an arm ran
+//!
+//! Every arm prints `paths=...` from `mlxcel_core::mla::stats`, taken and reset
+//! around the measured region. Issue #899 shipped a fused decode path that never
+//! activated and whose benchmark compared the fallback against itself; an arm
+//! here whose counter for its own path is 0 is visibly not measuring what its
+//! name says. Do not report a number from an arm whose `paths=` line disagrees
+//! with its label.
+//!
+//! Run (Metal):
+//!
+//! ```text
+//! cargo run --release --features metal,accelerate \
+//!     --example mla_absorbed_decode_bench
+//!
+//! # The issue's grid.
+//! cargo run --release --features metal,accelerate \
+//!     --example mla_absorbed_decode_bench -- \
+//!     --contexts 4096,16384,32768 --batches 1,4 --steps 64 --warmup 16
+//!
+//! # DeepSeek-V3 geometry (128 heads) instead of V2-Lite's 16.
+//! cargo run --release --features metal,accelerate \
+//!     --example mla_absorbed_decode_bench -- --heads 128 --layers 61
+//! ```
+
+use clap::Parser;
+use mlxcel_core::cache::KVCache;
+use mlxcel_core::mla::{
+    MlaAbsorbedProjections, MlaGeometry, MlaLatentCache, MlaSplitPlan, absorbed_decode,
+    absorbed_decode_split_kv, decompressed_bytes_per_token, latent_bytes_per_token, stats,
+};
+use mlxcel_core::{MlxArray, UniquePtr};
+
+const F16: i32 = mlxcel_core::dtype::FLOAT16;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "mla_absorbed_decode_bench",
+    about = "Decode throughput and KV memory for absorbed MLA (issue #907)"
+)]
+struct Args {
+    /// Cached context lengths to sweep.
+    #[arg(long, value_delimiter = ',', default_value = "4096,16384")]
+    contexts: Vec<i32>,
+    /// Batch sizes to sweep.
+    #[arg(long, value_delimiter = ',', default_value = "1,4")]
+    batches: Vec<i32>,
+    /// Measured decode steps per arm.
+    #[arg(long, default_value_t = 32)]
+    steps: usize,
+    /// Unmeasured warmup steps per arm.
+    #[arg(long, default_value_t = 8)]
+    warmup: usize,
+    /// Query heads. 16 is DeepSeek-V2-Lite, 128 is DeepSeek-V3.
+    #[arg(long, default_value_t = 16)]
+    heads: usize,
+    /// kv_lora_rank.
+    #[arg(long, default_value_t = 512)]
+    rank: usize,
+    /// qk_nope_head_dim.
+    #[arg(long, default_value_t = 128)]
+    nope: usize,
+    /// qk_rope_head_dim.
+    #[arg(long, default_value_t = 64)]
+    rope: usize,
+    /// v_head_dim.
+    #[arg(long, default_value_t = 128)]
+    v_dim: usize,
+    /// Decoder layers, for the whole-model KV memory table.
+    #[arg(long, default_value_t = 27)]
+    layers: usize,
+    /// KV memory budget in GiB for the max-servable-context table.
+    #[arg(long, default_value_t = 16.0)]
+    kv_budget_gib: f64,
+    /// Skip the split-KV arm.
+    #[arg(long)]
+    no_split: bool,
+}
+
+/// xorshift64* in [-1, 1), so a run is reproducible.
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+    fn vec(&mut self, n: usize, amplitude: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| {
+                self.0 ^= self.0 << 13;
+                self.0 ^= self.0 >> 7;
+                self.0 ^= self.0 << 17;
+                let unit = ((self.0 >> 40) as f32) / (1u32 << 24) as f32;
+                (unit * 2.0 - 1.0) * amplitude
+            })
+            .collect()
+    }
+    fn array(&mut self, shape: &[i32], amplitude: f32) -> UniquePtr<MlxArray> {
+        let n: usize = shape.iter().map(|d| *d as usize).product();
+        let a = mlxcel_core::from_slice_f32(&self.vec(n, amplitude), shape);
+        mlxcel_core::astype(&a, F16)
+    }
+}
+
+fn main() {
+    let args = Args::parse();
+    let geometry = MlaGeometry {
+        num_heads: args.heads,
+        kv_lora_rank: args.rank,
+        qk_nope_head_dim: args.nope,
+        qk_rope_head_dim: args.rope,
+        v_head_dim: args.v_dim,
+    };
+    if let Err(e) = geometry.check() {
+        eprintln!("{e}");
+        std::process::exit(2);
+    }
+    let scale = (geometry.q_head_dim() as f32).powf(-0.5);
+
+    println!("# MLA absorbed decode (issue #907)");
+    println!(
+        "geometry: heads={} kv_lora_rank={} qk_nope={} qk_rope={} v_head={} layers={}",
+        geometry.num_heads,
+        geometry.kv_lora_rank,
+        geometry.qk_nope_head_dim,
+        geometry.qk_rope_head_dim,
+        geometry.v_head_dim,
+        args.layers
+    );
+    print_kv_memory_table(&geometry, args.layers, args.kv_budget_gib);
+
+    let mut rng = Rng::new(0x907_907);
+    // One dense `kv_b_proj` shared by both arms, so the decompressed arm and the
+    // fold describe the same model.
+    let kv_b_rows = (geometry.num_heads * geometry.kv_b_rows_per_head()) as i32;
+    let kv_b = rng.array(&[kv_b_rows, geometry.kv_lora_rank as i32], 0.05);
+    let kv_b_t = mlxcel_core::transpose(&kv_b);
+    let proj = MlaAbsorbedProjections::from_dense(&kv_b, geometry).expect("fold kv_b_proj");
+    println!(
+        "fold: {} dense elements per layer ({:.1} MiB in f16), {:.1} MiB over {} layers",
+        proj.element_count(),
+        (proj.element_count() * 2) as f64 / (1024.0 * 1024.0),
+        (proj.element_count() * 2 * args.layers) as f64 / (1024.0 * 1024.0),
+        args.layers
+    );
+
+    println!();
+    println!(
+        "{:<14} {:>7} {:>8} {:>11} {:>11} {:>10}  {}",
+        "arm", "batch", "context", "ms/step", "steps/s", "KV MiB", "paths"
+    );
+
+    for &context in &args.contexts {
+        for &batch in &args.batches {
+            let _ = stats::take();
+            run_arm(
+                "decompressed",
+                batch,
+                context,
+                &args,
+                geometry,
+                scale,
+                &mut rng,
+                Arm::Decompressed { kv_b_t: &kv_b_t },
+            );
+            run_arm(
+                "absorbed",
+                batch,
+                context,
+                &args,
+                geometry,
+                scale,
+                &mut rng,
+                Arm::Absorbed { proj: &proj },
+            );
+            if !args.no_split {
+                run_arm(
+                    "split_kv",
+                    batch,
+                    context,
+                    &args,
+                    geometry,
+                    scale,
+                    &mut rng,
+                    Arm::SplitKv { proj: &proj },
+                );
+            }
+        }
+    }
+}
+
+enum Arm<'a> {
+    /// `kv_b_t` is `kv_b_proj^T`, `[kv_lora_rank, H * (qk_nope + v)]`, so the
+    /// arm's per-step up-projection is one matmul rather than a linear layer.
+    Decompressed {
+        kv_b_t: &'a MlxArray,
+    },
+    Absorbed {
+        proj: &'a MlaAbsorbedProjections,
+    },
+    SplitKv {
+        proj: &'a MlaAbsorbedProjections,
+    },
+}
+
+impl Arm<'_> {
+    fn expected_path(&self) -> &'static str {
+        match self {
+            Arm::Decompressed { .. } => "decompressed",
+            Arm::Absorbed { .. } => "absorbed_composed",
+            Arm::SplitKv { .. } => "absorbed_split_kv",
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_arm(
+    label: &str,
+    batch: i32,
+    context: i32,
+    args: &Args,
+    geometry: MlaGeometry,
+    scale: f32,
+    rng: &mut Rng,
+    arm: Arm<'_>,
+) {
+    let heads = geometry.num_heads as i32;
+    let rank = geometry.kv_lora_rank as i32;
+    let rope = geometry.qk_rope_head_dim as i32;
+    let nope = geometry.qk_nope_head_dim as i32;
+    let v_dim = geometry.v_head_dim as i32;
+
+    let mut cache = KVCache::new();
+    // Prefill the cache to `context` in the layout this arm decodes against.
+    match arm {
+        Arm::Decompressed { .. } => {
+            let keys = rng.array(&[batch, heads, context, nope + rope], 0.5);
+            let values = rng.array(&[batch, heads, context, v_dim], 0.5);
+            cache.update(keys, values);
+        }
+        Arm::Absorbed { .. } | Arm::SplitKv { .. } => {
+            let ckv = rng.array(&[batch, 1, context, rank], 0.5);
+            let kpe = rng.array(&[batch, 1, context, rope], 0.5);
+            cache.update(ckv, kpe);
+        }
+    }
+    cache.eval_state();
+    let kv_mib = cache.nbytes() as f64 / (1024.0 * 1024.0);
+
+    // Per-step inputs, generated once: the benchmark measures attention, not
+    // random-number generation.
+    let q_nope = rng.array(&[batch, heads, 1, nope], 0.5);
+    let q_pe = rng.array(&[batch, heads, 1, rope], 0.5);
+    let new_latent = rng.array(&[batch, 1, 1, rank], 0.5);
+    let new_kpe = rng.array(&[batch, 1, 1, rope], 0.5);
+    mlxcel_core::eval(&q_nope);
+    mlxcel_core::eval(&q_pe);
+    mlxcel_core::eval(&new_latent);
+    mlxcel_core::eval(&new_kpe);
+
+    let step = |cache: &mut KVCache| {
+        match arm {
+            Arm::Decompressed { kv_b_t } => {
+                // What the pre-#907 path pays per token: up-project the new
+                // latent into per-head K and V, then attend over the
+                // decompressed window.
+                let latent_2d = mlxcel_core::reshape(&new_latent, &[batch, 1, rank]);
+                let kv = mlxcel_core::matmul(&latent_2d, kv_b_t);
+                let kv = mlxcel_core::reshape(&kv, &[batch, 1, heads, nope + v_dim]);
+                let kv = mlxcel_core::transpose_axes(&kv, &[0, 2, 1, 3]);
+                let k_nope = mlxcel_core::utils::slice_axis(&kv, -1, 0, nope);
+                let values = mlxcel_core::utils::slice_axis(&kv, -1, nope, -1);
+                let k_pe = mlxcel_core::utils::repeat_kv(&new_kpe, heads);
+                let keys = mlxcel_core::concatenate(&k_nope, &k_pe, -1);
+                let queries = mlxcel_core::concatenate(&q_nope, &q_pe, -1);
+                let (keys, values) = cache.update_and_fetch(keys, values);
+                stats::record(mlxcel_core::mla::MlaDecodePath::Decompressed);
+                mlxcel_core::causal_attention(&queries, &keys, &values, scale, 0.0, 0)
+            }
+            Arm::Absorbed { proj } => {
+                let mut view = MlaLatentCache::wrap(cache, geometry).expect("fp16 non-paged cache");
+                let (ckv, kpe) = view
+                    .update_and_fetch(mlxcel_core::copy(&new_latent), mlxcel_core::copy(&new_kpe));
+                absorbed_decode(&q_nope, &q_pe, &ckv, &kpe, proj, scale, None)
+            }
+            Arm::SplitKv { proj } => {
+                let mut view = MlaLatentCache::wrap(cache, geometry).expect("fp16 non-paged cache");
+                let (ckv, kpe) = view
+                    .update_and_fetch(mlxcel_core::copy(&new_latent), mlxcel_core::copy(&new_kpe));
+                let kv_len = view.seq_len();
+                let plan = MlaSplitPlan::heuristic(
+                    batch as usize,
+                    geometry.num_heads,
+                    kv_len,
+                    mlxcel_core::paged_v2::device_target_ctas(),
+                );
+                absorbed_decode_split_kv(&q_nope, &q_pe, &ckv, &kpe, proj, scale, &plan)
+                    .expect("split-kv decode")
+            }
+        }
+    };
+
+    for _ in 0..args.warmup {
+        let out = step(&mut cache);
+        mlxcel_core::eval(&out);
+    }
+    mlxcel_core::synchronize_default();
+    let _ = stats::take();
+
+    let start = std::time::Instant::now();
+    for _ in 0..args.steps {
+        let out = step(&mut cache);
+        mlxcel_core::eval(&out);
+    }
+    mlxcel_core::synchronize_default();
+    let elapsed = start.elapsed().as_secs_f64();
+    let counts = stats::take();
+
+    let ms = elapsed * 1000.0 / args.steps as f64;
+    println!(
+        "{:<14} {:>7} {:>8} {:>11.4} {:>11.1} {:>10.1}  {}",
+        label,
+        batch,
+        context,
+        ms,
+        args.steps as f64 / elapsed,
+        kv_mib,
+        counts.summary()
+    );
+    let expected = arm.expected_path();
+    if !counts
+        .summary()
+        .contains(&format!("{expected}={}", args.steps))
+    {
+        println!(
+            "  WARNING: arm \"{label}\" expected {expected}={} but recorded {}. \
+             Do not report this row.",
+            args.steps,
+            counts.summary()
+        );
+    }
+}
+
+/// The issue's KV-memory table: bytes per token per layer before and after, and
+/// the context a fixed budget then buys.
+fn print_kv_memory_table(geometry: &MlaGeometry, layers: usize, budget_gib: f64) {
+    let before = decompressed_bytes_per_token(geometry, 2);
+    let after = latent_bytes_per_token(geometry, 2);
+    let budget = budget_gib * 1024.0 * 1024.0 * 1024.0;
+    let ctx = |per_token_per_layer: usize| -> u64 {
+        (budget / (per_token_per_layer * layers) as f64) as u64
+    };
+    println!(
+        "kv bytes/token/layer: decompressed={before} latent={after} ({:.2}x reduction)",
+        before as f64 / after.max(1) as f64
+    );
+    println!(
+        "kv bytes/token (all {layers} layers): decompressed={} latent={}",
+        before * layers,
+        after * layers
+    );
+    println!(
+        "max context under a {budget_gib:.0} GiB KV budget: decompressed={} tokens latent={} tokens",
+        ctx(before),
+        ctx(after)
+    );
+}

--- a/examples/mla_absorbed_decode_bench.rs
+++ b/examples/mla_absorbed_decode_bench.rs
@@ -186,8 +186,8 @@ fn main() {
 
     println!();
     println!(
-        "{:<14} {:>7} {:>8} {:>11} {:>11} {:>10}  {}",
-        "arm", "batch", "context", "ms/step", "steps/s", "KV MiB", "paths"
+        "{:<14} {:>7} {:>8} {:>11} {:>11} {:>10}  paths",
+        "arm", "batch", "context", "ms/step", "steps/s", "KV MiB"
     );
 
     for &context in &args.contexts {

--- a/src/lib/mlxcel-core/src/lib.rs
+++ b/src/lib/mlxcel-core/src/lib.rs
@@ -3196,6 +3196,14 @@ pub mod bench_rotation;
 // production wiring (#899) can drive the plan and the launch directly.
 pub mod paged_v2;
 
+// Matrix-absorbed MLA decode over a compressed-latent KV cache (issue #907).
+// Default off; selected by `MLXCEL_MLA_ABSORBED=1` at family load time. Public
+// so the DeepSeek-family model code in the `mlxcel` crate and the benchmark
+// harness under `examples/` can build the fold, wrap the latent cache, and
+// drive both decode paths directly. Stage 2 reuses issue #898's merge kernel
+// unchanged; see `mla::split_kv`.
+pub mod mla;
+
 // Crate-wide helpers for `#[cfg(test)]` paths. Provides the single shared
 // `ENV_LOCK` that every env-mutating test in this crate must acquire; see `test_support::env_lock` for the rationale. `pub(crate)` so
 // that test modules at any depth (e.g. `crate::lang_analyzer::cache::tests`)

--- a/src/lib/mlxcel-core/src/mla/absorb.rs
+++ b/src/lib/mlxcel-core/src/mla/absorb.rs
@@ -1,0 +1,215 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Load-time fold of `kv_b_proj` into the query and output paths (issue #907).
+//!
+//! `kv_b_proj` is one `[num_heads * (qk_nope_head_dim + v_head_dim),
+//! kv_lora_rank]` matrix that up-projects the latent into per-head K and V. A
+//! linear layer computes `y = x @ W^T`, so for latent row `c`
+//!
+//! ```text
+//!   k_nope[h, d] = sum_r W[h * rows_per_head + d, r] * c[r]
+//!   v[h, e]      = sum_r W[h * rows_per_head + qk_nope + e, r] * c[r]
+//! ```
+//!
+//! Naming the two row blocks `W_UK[h, d, r]` and `W_UV[h, e, r]`, the two
+//! absorption identities follow directly:
+//!
+//! ```text
+//!   q_nope[h] . k_nope[h] = sum_r (sum_d q_nope[h, d] W_UK[h, d, r]) c[r]
+//!   sum_t a[t] v[h]       = sum_r (sum_t a[t] c[t, r]) W_UV[h, e, r]
+//! ```
+//!
+//! so the fold stores `W_UK` as `[1, H, qk_nope, r]` (right operand of the
+//! query contraction) and `W_UV` transposed to `[1, H, r, v_head]` (right
+//! operand of the output contraction). The leading `1` is the batch axis MLX
+//! broadcasts against a `[B, H, L, ...]` left operand, so both applications are
+//! a single batched `matmul` with no per-head loop.
+//!
+//! Nothing here mutates the checkpoint on disk. This is the same class of
+//! load-time repack as `src/models/sanitize.rs`, applied to an already-loaded
+//! [`crate::layers::UnifiedLinear`] rather than to the weight map, so a family
+//! can fold without restructuring its loader.
+
+use cxx::UniquePtr;
+
+use crate::ffi::{self, MlxArray};
+use crate::layers::UnifiedLinear;
+use crate::mla::MlaGeometry;
+
+/// `kv_b_proj` folded into a query-side and an output-side operand.
+///
+/// Both tensors are dense: the contractions are batched matmuls, and MLX has no
+/// batched quantized matmul that would keep a 3-D per-head quantized operand.
+/// [`MlaAbsorbedProjections::element_count`] is the fixed weight-memory price
+/// that buys the per-token cache reduction.
+pub struct MlaAbsorbedProjections {
+    /// `W_UK` as `[1, num_heads, qk_nope_head_dim, kv_lora_rank]`.
+    w_uk: UniquePtr<MlxArray>,
+    /// `W_UV^T` as `[1, num_heads, kv_lora_rank, v_head_dim]`.
+    w_uv: UniquePtr<MlxArray>,
+    geometry: MlaGeometry,
+}
+
+impl MlaAbsorbedProjections {
+    /// Fold an already-loaded `kv_b_proj`.
+    ///
+    /// Dequantizes when the layer is quantized, using the group size and bit
+    /// width the loader already reconciled against the tensor shapes, so this
+    /// path cannot disagree with what `quantized_matmul` would have used.
+    ///
+    /// Declines (as `Err`) rather than panicking, so a caller can fall back to
+    /// the decompressed path for one family or one layer.
+    pub fn from_kv_b_proj(
+        kv_b_proj: &UnifiedLinear,
+        geometry: MlaGeometry,
+    ) -> Result<Self, String> {
+        geometry.check()?;
+        let dense = match kv_b_proj {
+            UnifiedLinear::Regular(linear) => {
+                if linear.bias.is_some() {
+                    return Err(
+                        "mla: kv_b_proj carries a bias, which the absorption identity does not \
+                         cover; keeping the decompressed path"
+                            .to_string(),
+                    );
+                }
+                ffi::copy(&linear.weight)
+            }
+            UnifiedLinear::Quantized { weight, bias } => {
+                if bias.is_some() {
+                    return Err(
+                        "mla: kv_b_proj carries a bias, which the absorption identity does not \
+                         cover; keeping the decompressed path"
+                            .to_string(),
+                    );
+                }
+                let biases_ptr = weight
+                    .biases
+                    .as_ref()
+                    .map(|b| &**b as *const MlxArray)
+                    .unwrap_or(std::ptr::null());
+                // SAFETY: `biases_ptr` is either null (block-float modes, which
+                // the bridge accepts) or a pointer into `weight.biases`, which
+                // outlives this call.
+                let dequantized = unsafe {
+                    ffi::dequantize(
+                        &weight.weight,
+                        &weight.scales,
+                        biases_ptr,
+                        weight.group_size,
+                        weight.bits,
+                        &weight.mode,
+                    )
+                };
+                match weight.global_scale.as_ref() {
+                    // NVFP4's per-tensor `weight_scale_2` is a scalar, and
+                    // `(x @ W^T) * s2 == x @ (W * s2)^T`, so folding it into the
+                    // dense weight here reproduces what `quantized_matmul`
+                    // applies on its output.
+                    Some(scale) => ffi::multiply(&dequantized, scale),
+                    None => dequantized,
+                }
+            }
+        };
+        Self::from_dense(&dense, geometry)
+    }
+
+    /// Fold a dense `[H * (qk_nope + v_head), kv_lora_rank]` `kv_b_proj`.
+    ///
+    /// Split out from [`Self::from_kv_b_proj`] so the identity can be tested on
+    /// a synthetic matrix without constructing a quantized layer.
+    pub fn from_dense(weight: &MlxArray, geometry: MlaGeometry) -> Result<Self, String> {
+        geometry.check()?;
+        let shape = ffi::array_shape(weight);
+        if shape.len() != 2 {
+            return Err(format!(
+                "mla: kv_b_proj must be 2-D [H*(qk_nope+v), kv_lora_rank], got {shape:?}"
+            ));
+        }
+        let heads = geometry.num_heads as i32;
+        let rows_per_head = geometry.kv_b_rows_per_head() as i32;
+        let nope = geometry.qk_nope_head_dim as i32;
+        let v_dim = geometry.v_head_dim as i32;
+        let rank = geometry.kv_lora_rank as i32;
+        if shape[0] != heads * rows_per_head || shape[1] != rank {
+            return Err(format!(
+                "mla: kv_b_proj shape {shape:?} disagrees with geometry \
+                 [{heads}*{rows_per_head}, {rank}]"
+            ));
+        }
+
+        // [H*(nope+v), r] -> [H, nope+v, r], then the two row blocks.
+        let w3 = ffi::reshape(weight, &[heads, rows_per_head, rank]);
+        let w_uk = ffi::slice(&w3, &[0, 0, 0], &[heads, nope, rank]);
+        let w_uv = ffi::slice(&w3, &[0, nope, 0], &[heads, rows_per_head, rank]);
+
+        // `contiguous` after the slice and the swap: both produce strided views,
+        // and a strided operand forces MLX to materialize a copy on every
+        // decode step instead of once here.
+        let w_uk = ffi::contiguous(&ffi::reshape(&w_uk, &[1, heads, nope, rank]), false);
+        let w_uv = ffi::swap_axes(&w_uv, -1, -2);
+        let w_uv = ffi::contiguous(&ffi::reshape(&w_uv, &[1, heads, rank, v_dim]), false);
+
+        ffi::eval(&w_uk);
+        ffi::eval(&w_uv);
+        Ok(Self {
+            w_uk,
+            w_uv,
+            geometry,
+        })
+    }
+
+    /// `W_UK` as `[1, H, qk_nope_head_dim, kv_lora_rank]`.
+    #[must_use]
+    pub fn w_uk(&self) -> &MlxArray {
+        &self.w_uk
+    }
+
+    /// `W_UV^T` as `[1, H, kv_lora_rank, v_head_dim]`.
+    #[must_use]
+    pub fn w_uv(&self) -> &MlxArray {
+        &self.w_uv
+    }
+
+    /// The geometry this fold was built for.
+    #[must_use]
+    pub const fn geometry(&self) -> MlaGeometry {
+        self.geometry
+    }
+
+    /// Dense elements held by the fold, for one layer.
+    ///
+    /// Equal to the element count of `kv_b_proj` itself: the fold is a
+    /// partition of its rows, not a copy of the whole with extra. Reported so
+    /// the benchmark can state the fixed weight cost against the per-token
+    /// cache saving instead of leaving it implicit.
+    #[must_use]
+    pub const fn element_count(&self) -> usize {
+        self.geometry.num_heads * self.geometry.kv_b_rows_per_head() * self.geometry.kv_lora_rank
+    }
+}
+
+impl std::fmt::Debug for MlaAbsorbedProjections {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MlaAbsorbedProjections")
+            .field("geometry", &self.geometry)
+            .field("elements", &self.element_count())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+#[path = "absorb_tests.rs"]
+mod absorb_tests;

--- a/src/lib/mlxcel-core/src/mla/absorb_tests.rs
+++ b/src/lib/mlxcel-core/src/mla/absorb_tests.rs
@@ -1,0 +1,142 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the `kv_b_proj` fold (issue #907).
+//!
+//! The fold is a pure reshape-and-slice of the checkpoint matrix, so the tests
+//! check that the two halves land in the right place and that a shape or
+//! geometry that does not describe the matrix is refused rather than
+//! reinterpreted.
+
+use super::*;
+use crate::dtype;
+use crate::mla::testkit::{MlaFixture, TINY, to_vec_f32};
+
+#[test]
+fn fold_splits_kv_b_proj_into_the_two_identity_operands() {
+    let fx = MlaFixture::new(TINY, 1, 1, 4, 0xA11A);
+    let weight = fx.kv_b_array(dtype::FLOAT32);
+    let proj = MlaAbsorbedProjections::from_dense(&weight, TINY).unwrap();
+
+    let h = TINY.num_heads;
+    let r = TINY.kv_lora_rank;
+    let nope = TINY.qk_nope_head_dim;
+    let v = TINY.v_head_dim;
+    let rows = TINY.kv_b_rows_per_head();
+
+    assert_eq!(
+        crate::ffi::array_shape(proj.w_uk()),
+        vec![1, h as i32, nope as i32, r as i32]
+    );
+    assert_eq!(
+        crate::ffi::array_shape(proj.w_uv()),
+        vec![1, h as i32, r as i32, v as i32]
+    );
+
+    // W_UK[h, d, i] == kv_b[h * rows + d, i], no transpose.
+    let w_uk = to_vec_f32(proj.w_uk());
+    for head in 0..h {
+        for d in 0..nope {
+            for i in 0..r {
+                assert_eq!(
+                    w_uk[(head * nope + d) * r + i],
+                    fx.kv_b[(head * rows + d) * r + i],
+                    "w_uk mismatch at head {head} row {d} col {i}"
+                );
+            }
+        }
+    }
+
+    // W_UV is stored transposed: w_uv[h, i, e] == kv_b[h * rows + nope + e, i].
+    let w_uv = to_vec_f32(proj.w_uv());
+    for head in 0..h {
+        for i in 0..r {
+            for e in 0..v {
+                assert_eq!(
+                    w_uv[(head * r + i) * v + e],
+                    fx.kv_b[(head * rows + nope + e) * r + i],
+                    "w_uv mismatch at head {head} rank {i} value dim {e}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn fold_reports_the_weight_memory_it_costs() {
+    let fx = MlaFixture::new(TINY, 1, 1, 4, 7);
+    let proj = MlaAbsorbedProjections::from_dense(&fx.kv_b_array(dtype::FLOAT32), TINY).unwrap();
+    // Exactly kv_b_proj's own element count: the fold partitions its rows.
+    assert_eq!(
+        proj.element_count(),
+        TINY.num_heads * TINY.kv_b_rows_per_head() * TINY.kv_lora_rank
+    );
+    assert_eq!(proj.element_count(), fx.kv_b.len());
+}
+
+#[test]
+fn fold_refuses_a_geometry_that_does_not_describe_the_matrix() {
+    let fx = MlaFixture::new(TINY, 1, 1, 4, 11);
+    let weight = fx.kv_b_array(dtype::FLOAT32);
+
+    // A head count the matrix cannot be partitioned by. Reinterpreting it would
+    // silently mix one head's rows into another's fold, which produces plausible
+    // numbers and wrong tokens.
+    let mut wrong = TINY;
+    wrong.num_heads = TINY.num_heads + 1;
+    let err = MlaAbsorbedProjections::from_dense(&weight, wrong).unwrap_err();
+    assert!(err.contains("disagrees with geometry"), "{err}");
+
+    // A rank that is not the matrix's second axis.
+    let mut wrong_rank = TINY;
+    wrong_rank.kv_lora_rank = TINY.kv_lora_rank * 2;
+    let err = MlaAbsorbedProjections::from_dense(&weight, wrong_rank).unwrap_err();
+    assert!(err.contains("disagrees with geometry"), "{err}");
+}
+
+#[test]
+fn fold_refuses_a_non_matrix_weight() {
+    let three_d = crate::ffi::zeros(&[2, 3, 4], dtype::FLOAT32);
+    let err = MlaAbsorbedProjections::from_dense(&three_d, TINY).unwrap_err();
+    assert!(err.contains("must be 2-D"), "{err}");
+}
+
+#[test]
+fn fold_refuses_a_biased_kv_b_proj() {
+    // DeepSeek's kv_b_proj has no bias, and the absorption identity has no term
+    // for one: `q . (Wc + b)` does not factor through the latent. A checkpoint
+    // that grew one must fall back rather than drop the bias.
+    let fx = MlaFixture::new(TINY, 1, 1, 4, 13);
+    let rows = (TINY.num_heads * TINY.kv_b_rows_per_head()) as i32;
+    let linear = crate::layers::UnifiedLinear::Regular(crate::layers::Linear::new(
+        fx.kv_b_array(dtype::FLOAT32),
+        Some(crate::ffi::zeros(&[rows], dtype::FLOAT32)),
+    ));
+    let err = MlaAbsorbedProjections::from_kv_b_proj(&linear, TINY).unwrap_err();
+    assert!(err.contains("bias"), "{err}");
+}
+
+#[test]
+fn fold_accepts_an_unquantized_kv_b_proj_layer() {
+    let fx = MlaFixture::new(TINY, 1, 1, 4, 17);
+    let linear = crate::layers::UnifiedLinear::Regular(crate::layers::Linear::new(
+        fx.kv_b_array(dtype::FLOAT32),
+        None,
+    ));
+    let proj = MlaAbsorbedProjections::from_kv_b_proj(&linear, TINY).unwrap();
+    assert_eq!(proj.geometry(), TINY);
+    let direct = MlaAbsorbedProjections::from_dense(&fx.kv_b_array(dtype::FLOAT32), TINY).unwrap();
+    assert_eq!(to_vec_f32(proj.w_uk()), to_vec_f32(direct.w_uk()));
+    assert_eq!(to_vec_f32(proj.w_uv()), to_vec_f32(direct.w_uv()));
+}

--- a/src/lib/mlxcel-core/src/mla/cache.rs
+++ b/src/lib/mlxcel-core/src/mla/cache.rs
@@ -1,0 +1,241 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compressed-latent MLA KV cache (issue #907).
+//!
+//! ## Why this is a view over [`KVCache`], not a new cache type
+//!
+//! `LanguageModel::make_caches` returns `Vec<KVCache>` and `forward` takes
+//! `&mut [KVCache]`, so a genuinely new cache type forces every family that
+//! uses it into the `ModelOwnedSequenceState` escape hatch that the SSM hybrids
+//! use, which in turn costs `supports_batching`, the paged decode backend, and
+//! the generic prompt-cache donation path. That is a large regression to pay
+//! for a change that only alters *what* the two per-layer tensors contain.
+//!
+//! The FP16 update path stores keys and values as independent `[B, H, L, D]`
+//! buffers and reads each one's head dimension from its own shape (see
+//! `KVCache::update_fp16`), so a cache whose "keys" are `[B, 1, L,
+//! kv_lora_rank]` and whose "values" are `[B, 1, L, qk_rope_head_dim]` is
+//! already expressible. This type is the named, checked view of that packing:
+//!
+//! | slot     | holds | shape                              |
+//! |----------|-------|------------------------------------|
+//! | `keys`   | `ckv` | `[B, 1, L, kv_lora_rank]`          |
+//! | `values` | `kpe` | `[B, 1, L, qk_rope_head_dim]`      |
+//!
+//! The slot assignment matches what `src/models/deepseek_v3.rs` has always
+//! done (`cache.update_and_fetch(kv_latent, k_pe)`), so V2 folded onto this
+//! type and V3's existing code describe the same buffer layout.
+//!
+//! Everything `KVCache` provides keeps working unchanged: `offset` and
+//! `live_start` stay the RoPE position and live-window start, `trim` and
+//! `trim_front` operate on the latent rows exactly as they did on the
+//! decompressed rows, `nbytes` measures the real (now much smaller) buffers,
+//! and speculative decode's `can_trim_prompt_cache` still reports trimmable.
+//!
+//! ## Modes this declines
+//!
+//! Only `KVCacheMode::Fp16` and non-paged backing. The INT8 and Turbo3/Turbo4
+//! modes quantize along the head dimension with a per-token scale, which is
+//! calibrated for a per-head K/V row, not for a 512-wide shared latent whose
+//! reconstruction error is amplified by every one of the `num_heads` query
+//! heads that read it. The paged pool allocates `[num_blocks, page_size, Hkv,
+//! head_dim]` tensors with one head dim for both sides, which the asymmetric
+//! `(512, 64)` split cannot fill. Both are declined at wrap time with a
+//! message rather than silently mis-served.
+
+use cxx::UniquePtr;
+
+use crate::cache::{KVCache, KVCacheMode};
+use crate::ffi::MlxArray;
+use crate::mla::MlaGeometry;
+
+/// Bytes one token of the compressed-latent cache costs, per layer.
+///
+/// One latent "head" of `kv_lora_rank` plus the shared rope stream of
+/// `qk_rope_head_dim`, independent of `num_heads`.
+#[must_use]
+pub const fn latent_bytes_per_token(geometry: &MlaGeometry, bytes_per_element: usize) -> usize {
+    (geometry.kv_lora_rank + geometry.qk_rope_head_dim) * bytes_per_element
+}
+
+/// Bytes one token of the decompressed cache costs, per layer.
+///
+/// The pre-absorption layout: `num_heads` keys of `qk_nope + qk_rope` (the
+/// shared rope stream is repeated into every head) and `num_heads` values of
+/// `v_head_dim`.
+#[must_use]
+pub const fn decompressed_bytes_per_token(
+    geometry: &MlaGeometry,
+    bytes_per_element: usize,
+) -> usize {
+    geometry.num_heads * (geometry.q_head_dim() + geometry.v_head_dim) * bytes_per_element
+}
+
+/// A [`KVCache`] used as a compressed-latent MLA cache.
+///
+/// Borrowed rather than owned so a family keeps handing `&mut [KVCache]`
+/// around and wraps per layer at the point of use.
+pub struct MlaLatentCache<'a> {
+    inner: &'a mut KVCache,
+    geometry: MlaGeometry,
+}
+
+impl<'a> MlaLatentCache<'a> {
+    /// View `cache` as a latent cache, or explain why it cannot be.
+    pub fn wrap(cache: &'a mut KVCache, geometry: MlaGeometry) -> Result<Self, String> {
+        geometry.check()?;
+        if cache.mode != KVCacheMode::Fp16 {
+            return Err(format!(
+                "mla: absorbed decode needs an FP16 KV cache; this cache is {} and its per-token \
+                 quantization is calibrated for per-head K/V rows, not a shared latent",
+                cache.mode
+            ));
+        }
+        if cache.is_paged_backed() {
+            return Err(
+                "mla: absorbed decode cannot use a paged-backed cache; the pool's \
+                 [blocks, page_size, Hkv, head_dim] layout has one head dim for both sides and \
+                 the latent split is asymmetric"
+                    .to_string(),
+            );
+        }
+        Ok(Self {
+            inner: cache,
+            geometry,
+        })
+    }
+
+    /// Live token count, i.e. `offset - live_start`.
+    #[must_use]
+    pub fn seq_len(&self) -> i32 {
+        self.inner.seq_len()
+    }
+
+    /// Monotonic write position, the RoPE position for the next token.
+    #[must_use]
+    pub fn offset(&self) -> i32 {
+        self.inner.offset
+    }
+
+    /// The geometry this view was wrapped for.
+    #[must_use]
+    pub const fn geometry(&self) -> MlaGeometry {
+        self.geometry
+    }
+
+    /// Append one step's latent and rope rows, and read the whole live window
+    /// back.
+    ///
+    /// `ckv` is `[B, 1, L, kv_lora_rank]` and `kpe` is `[B, 1, L,
+    /// qk_rope_head_dim]`, both already normalized and rotated respectively by
+    /// the caller. Returns `(ckv_all, kpe_all)` over the live window.
+    pub fn update_and_fetch(
+        &mut self,
+        ckv: UniquePtr<MlxArray>,
+        kpe: UniquePtr<MlxArray>,
+    ) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
+        self.inner.update_and_fetch(ckv, kpe)
+    }
+
+    /// Bytes per token this cache costs, at the element size it stores.
+    #[must_use]
+    pub const fn bytes_per_token(&self, bytes_per_element: usize) -> usize {
+        latent_bytes_per_token(&self.geometry, bytes_per_element)
+    }
+}
+
+impl std::fmt::Debug for MlaLatentCache<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MlaLatentCache")
+            .field("geometry", &self.geometry)
+            .field("seq_len", &self.seq_len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LITE: MlaGeometry = MlaGeometry {
+        num_heads: 16,
+        kv_lora_rank: 512,
+        qk_nope_head_dim: 128,
+        qk_rope_head_dim: 64,
+        v_head_dim: 128,
+    };
+
+    /// DeepSeek-V3 geometry: 128 heads make the decompressed layout eight times
+    /// worse again while the latent side does not move at all, which is the
+    /// whole point of the accounting.
+    const V3: MlaGeometry = MlaGeometry {
+        num_heads: 128,
+        kv_lora_rank: 512,
+        qk_nope_head_dim: 128,
+        qk_rope_head_dim: 64,
+        v_head_dim: 128,
+    };
+
+    #[test]
+    fn latent_bytes_per_token_is_the_issue_s_576_floats() {
+        assert_eq!(latent_bytes_per_token(&LITE, 1), 576);
+        assert_eq!(latent_bytes_per_token(&LITE, 2), 1152);
+        // Independent of head count, unlike the decompressed layout.
+        assert_eq!(
+            latent_bytes_per_token(&V3, 2),
+            latent_bytes_per_token(&LITE, 2)
+        );
+    }
+
+    #[test]
+    fn decompressed_bytes_per_token_scales_with_head_count() {
+        // 16 heads * (192 key + 128 value) = 5120 elements.
+        assert_eq!(decompressed_bytes_per_token(&LITE, 1), 5120);
+        assert_eq!(decompressed_bytes_per_token(&V3, 1), 40960);
+    }
+
+    #[test]
+    fn absorption_reduces_the_per_token_cache_by_the_head_count_ratio() {
+        let before = decompressed_bytes_per_token(&LITE, 2) as f64;
+        let after = latent_bytes_per_token(&LITE, 2) as f64;
+        assert!(
+            (before / after - 8.888).abs() < 0.01,
+            "DeepSeek-V2-Lite ratio was {}",
+            before / after
+        );
+        let before_v3 = decompressed_bytes_per_token(&V3, 2) as f64;
+        let after_v3 = latent_bytes_per_token(&V3, 2) as f64;
+        assert!(
+            (before_v3 / after_v3 - 71.1).abs() < 0.1,
+            "DeepSeek-V3 ratio was {}",
+            before_v3 / after_v3
+        );
+    }
+
+    #[test]
+    fn wrap_declines_a_quantized_kv_cache() {
+        let mut cache = KVCache::new_with_mode(KVCacheMode::Int8);
+        let err = MlaLatentCache::wrap(&mut cache, LITE).unwrap_err();
+        assert!(err.contains("FP16"), "{err}");
+    }
+
+    #[test]
+    fn wrap_accepts_the_default_fp16_cache() {
+        let mut cache = KVCache::new();
+        let view = MlaLatentCache::wrap(&mut cache, LITE).unwrap();
+        assert_eq!(view.seq_len(), 0);
+        assert_eq!(view.bytes_per_token(2), 1152);
+    }
+}

--- a/src/lib/mlxcel-core/src/mla/cache.rs
+++ b/src/lib/mlxcel-core/src/mla/cache.rs
@@ -93,8 +93,19 @@ pub struct MlaLatentCache<'a> {
 }
 
 impl<'a> MlaLatentCache<'a> {
-    /// View `cache` as a latent cache, or explain why it cannot be.
-    pub fn wrap(cache: &'a mut KVCache, geometry: MlaGeometry) -> Result<Self, String> {
+    /// Whether `cache` can hold a latent, without borrowing it mutably.
+    ///
+    /// Separate from [`Self::wrap`] because a caller that wants to fall back to
+    /// the decompressed path on failure cannot ask `wrap` first: the borrow
+    /// checker keeps the `&mut` alive through the `Err` arm of a `Result`
+    /// carrying the borrow's lifetime, so the fallback could not touch the
+    /// cache. Asking this first keeps the fallback expressible.
+    ///
+    /// The answer is stable for the life of a cache (mode and backing are set
+    /// at construction), so a family that takes the fallback on step one takes
+    /// it on every step, and the cache never ends up holding a mix of latent
+    /// and decompressed rows.
+    pub fn supports(cache: &KVCache, geometry: MlaGeometry) -> Result<(), String> {
         geometry.check()?;
         if cache.mode != KVCacheMode::Fp16 {
             return Err(format!(
@@ -111,6 +122,12 @@ impl<'a> MlaLatentCache<'a> {
                     .to_string(),
             );
         }
+        Ok(())
+    }
+
+    /// View `cache` as a latent cache, or explain why it cannot be.
+    pub fn wrap(cache: &'a mut KVCache, geometry: MlaGeometry) -> Result<Self, String> {
+        Self::supports(cache, geometry)?;
         Ok(Self {
             inner: cache,
             geometry,

--- a/src/lib/mlxcel-core/src/mla/cache.rs
+++ b/src/lib/mlxcel-core/src/mla/cache.rs
@@ -246,6 +246,39 @@ mod tests {
         let mut cache = KVCache::new_with_mode(KVCacheMode::Int8);
         let err = MlaLatentCache::wrap(&mut cache, LITE).unwrap_err();
         assert!(err.contains("FP16"), "{err}");
+        // `supports` must give the same answer, since the fallback branch in a
+        // family reads it instead of `wrap`.
+        assert!(MlaLatentCache::supports(&cache, LITE).is_err());
+    }
+
+    #[test]
+    fn a_latent_cache_stays_trimmable_for_speculative_decode() {
+        // Speculative decode gates on `can_trim_prompt_cache` and then rejects
+        // the tokens the draft got wrong with `trim`. Both operate on the
+        // sequence axis, which is axis 2 in the latent layout exactly as in the
+        // decompressed one, so a rejected draft token removes one latent row.
+        // If that were not true, a rejection would silently corrupt the cache.
+        const G: MlaGeometry = MlaGeometry {
+            num_heads: 4,
+            kv_lora_rank: 32,
+            qk_nope_head_dim: 16,
+            qk_rope_head_dim: 8,
+            v_head_dim: 12,
+        };
+        let mut cache = KVCache::new();
+        {
+            let mut view = MlaLatentCache::wrap(&mut cache, G).unwrap();
+            let ckv = crate::ffi::zeros(&[1, 1, 6, 32], crate::dtype::FLOAT16);
+            let kpe = crate::ffi::zeros(&[1, 1, 6, 8], crate::dtype::FLOAT16);
+            view.update_and_fetch(ckv, kpe);
+            assert_eq!(view.seq_len(), 6);
+        }
+        assert!(crate::cache::can_trim_prompt_cache(std::slice::from_ref(
+            &cache
+        )));
+        assert_eq!(cache.trim(2), 2);
+        let view = MlaLatentCache::wrap(&mut cache, G).unwrap();
+        assert_eq!(view.seq_len(), 4);
     }
 
     #[test]

--- a/src/lib/mlxcel-core/src/mla/decode.rs
+++ b/src/lib/mlxcel-core/src/mla/decode.rs
@@ -1,0 +1,150 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Stage 1 absorbed MLA decode, composed from MLX ops (issue #907).
+//!
+//! The absorbed score is `scale * (q_absorbed . ckv + q_pe . kpe)`. Only the
+//! first term has the shape of a normal attention score against the cached
+//! tensor; the second is a second contraction against a differently shaped
+//! cache stream. Rather than hand-rolling the softmax, this splits the score
+//! the way `src/models/deepseek_v3.rs` already does:
+//!
+//! ```text
+//!   out = SDPA(q_absorbed, ckv, ckv, scale, mask = scale * q_pe @ kpe^T + causal)
+//! ```
+//!
+//! SDPA computes `softmax(scale * q @ k^T + mask) @ v`, and the rope term is
+//! additive in exactly that position, so the identity is exact and the fused
+//! MLX attention kernel does the softmax and the value accumulation. The cost
+//! is materializing the `[B, H, L, S]` rope score, which at decode is one row
+//! per head. That is `H * S` floats against the `S * kv_lora_rank` the kernel
+//! reads from the cache, i.e. `H / kv_lora_rank` of the KV traffic, so for
+//! every shipping geometry (16 or 128 heads against rank 512) the extra term is
+//! a fraction of the read the absorption just saved.
+//!
+//! `ckv` is passed as both K and V. That is not a shortcut: under absorption
+//! the key and the value genuinely are the same latent, which is what makes the
+//! cache one tensor instead of two.
+
+use cxx::UniquePtr;
+
+use crate::ffi::{self, MlxArray};
+use crate::layers::attention;
+use crate::mla::absorb::MlaAbsorbedProjections;
+use crate::mla::stats::{self, MlaDecodePath};
+
+/// Fold `W_UK` into the query: `[B, H, L, qk_nope] -> [B, H, L, kv_lora_rank]`.
+///
+/// The right operand is `[1, H, qk_nope, r]`, so MLX broadcasts the leading
+/// batch axis and contracts per head in one batched matmul.
+#[must_use]
+pub fn absorb_queries(q_nope: &MlxArray, proj: &MlaAbsorbedProjections) -> UniquePtr<MlxArray> {
+    ffi::matmul(q_nope, proj.w_uk())
+}
+
+/// Fold `W_UV` after the attention: `[B, H, L, kv_lora_rank] -> [B, H, L, v]`.
+#[must_use]
+pub fn unabsorb_output(o_latent: &MlxArray, proj: &MlaAbsorbedProjections) -> UniquePtr<MlxArray> {
+    ffi::matmul(o_latent, proj.w_uv())
+}
+
+/// The rope half of the score, shaped as an additive SDPA mask.
+///
+/// `q_pe` is `[B, H, L, P]` and `kpe` is `[B, 1, S, P]`; the result is
+/// `[B, H, L, S]`, already multiplied by `scale` because SDPA applies its own
+/// `scale` only to the `q @ k^T` term. `extra` (a causal or padding mask) is
+/// added on top when present, so the caller hands SDPA one mask rather than
+/// two.
+#[must_use]
+pub fn rope_score_mask(
+    q_pe: &MlxArray,
+    kpe: &MlxArray,
+    scale: f32,
+    extra: Option<&MlxArray>,
+) -> UniquePtr<MlxArray> {
+    // Scale through a same-dtype scalar array rather than a host-side f32
+    // multiply so an f16 query stays f16 and the mask matches SDPA's dtype
+    // expectation, mirroring `deepseek_v3.rs`.
+    let scale_scalar = ffi::full_f32(&[1], scale, ffi::array_dtype(q_pe));
+    let q_pe_scaled = ffi::multiply(q_pe, &scale_scalar);
+    let kpe_t = ffi::transpose_axes(kpe, &[0, 1, 3, 2]);
+    let scores = ffi::matmul(&q_pe_scaled, &kpe_t);
+    match extra {
+        Some(m) => ffi::add(&scores, m),
+        None => scores,
+    }
+}
+
+/// One absorbed MLA attention call over the latent cache.
+///
+/// * `q_nope` `[B, H, L, qk_nope_head_dim]` (not yet absorbed)
+/// * `q_pe`   `[B, H, L, qk_rope_head_dim]` (already rotated)
+/// * `ckv`    `[B, 1, S, kv_lora_rank]` (the whole live latent window)
+/// * `kpe`    `[B, 1, S, qk_rope_head_dim]` (already rotated)
+/// * `mask`   additive `[.., L, S]` causal or padding mask, or `None`
+///
+/// Returns `[B, H, L, v_head_dim]`, the per-head attention output in the
+/// original value space, ready for the family's `o_proj`.
+///
+/// Records [`MlaDecodePath::AbsorbedComposed`] for a single-token step and
+/// [`MlaDecodePath::AbsorbedPrefill`] otherwise, so a benchmark arm can prove
+/// which path it ran instead of inferring it from the flag it was given.
+#[must_use]
+pub fn absorbed_decode(
+    q_nope: &MlxArray,
+    q_pe: &MlxArray,
+    ckv: &MlxArray,
+    kpe: &MlxArray,
+    proj: &MlaAbsorbedProjections,
+    scale: f32,
+    mask: Option<&MlxArray>,
+) -> UniquePtr<MlxArray> {
+    let q_len = ffi::array_shape(q_nope).get(2).copied().unwrap_or(0);
+    stats::record(if q_len == 1 {
+        MlaDecodePath::AbsorbedComposed
+    } else {
+        MlaDecodePath::AbsorbedPrefill
+    });
+
+    let q_absorbed = absorb_queries(q_nope, proj);
+    let rope_mask = rope_score_mask(q_pe, kpe, scale, mask);
+    let o_latent = attention(&q_absorbed, ckv, ckv, scale, Some(&rope_mask), 0.0, 0);
+    unabsorb_output(&o_latent, proj)
+}
+
+/// Up-project the latent back into per-head `K_nope` and `V`.
+///
+/// The inverse direction of the fold, kept here because it is the reference the
+/// parity tests compare against and the fallback a prefill path can use when it
+/// does not want to keep the original `kv_b_proj` loaded. Returns
+/// `(k_nope [B, H, S, qk_nope], v [B, H, S, v_head_dim])` from
+/// `ckv [B, 1, S, kv_lora_rank]`.
+///
+/// The `W_UK` operand is transposed at call time. That is fine for prefill and
+/// for tests, and is precisely why the decode path stores its own
+/// already-transposed copy instead of doing this per step.
+#[must_use]
+pub fn expand_latent(
+    ckv: &MlxArray,
+    proj: &MlaAbsorbedProjections,
+) -> (UniquePtr<MlxArray>, UniquePtr<MlxArray>) {
+    let w_uk_t = ffi::swap_axes(proj.w_uk(), -1, -2);
+    let k_nope = ffi::matmul(ckv, &w_uk_t);
+    let v = ffi::matmul(ckv, proj.w_uv());
+    (k_nope, v)
+}
+
+#[cfg(test)]
+#[path = "decode_tests.rs"]
+mod decode_tests;

--- a/src/lib/mlxcel-core/src/mla/decode_tests.rs
+++ b/src/lib/mlxcel-core/src/mla/decode_tests.rs
@@ -1,0 +1,213 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Parity tests for Stage 1 absorbed MLA decode (issue #907).
+//!
+//! The gate the issue asks for is that absorption is *mathematically exact*, so
+//! the reference is the pre-absorption computation itself: up-project the latent
+//! into per-head K and V, concatenate the rope stream into every head, and run
+//! dense attention. That reference is computed on the host in f64 by
+//! [`MlaFixture::decompressed_reference`], which is the same arithmetic
+//! `deepseek_v2::MLAAttention::forward` performs today.
+//!
+//! Synthetic tensors only. No MLA checkpoint fits the development host, so
+//! these tests prove the identity and its implementation, not token parity on a
+//! real DeepSeek model.
+
+use super::*;
+use crate::dtype;
+use crate::mla::absorb::MlaAbsorbedProjections;
+use crate::mla::testkit::{MlaFixture, TINY, max_rel_error, serial, to_vec_f32};
+use crate::mla::{MlaGeometry, cache::MlaLatentCache};
+
+/// f32 end to end: the only error left is the GPU's own accumulation order
+/// against the host's f64, so the bound is tight enough that a genuinely wrong
+/// operand cannot hide under it.
+const F32_TOL: f32 = 2e-5;
+
+/// f16 latent and weights, which is what a real checkpoint stores. Looser
+/// because the absorbed score sums `kv_lora_rank` products where the
+/// decompressed one sums `qk_nope_head_dim`, so the two reassociate differently.
+const F16_TOL: f32 = 6e-3;
+
+/// Runs one absorbed step. Callers hold [`serial`] for the whole test body,
+/// because this records into the process-global dispatch counters.
+fn run_absorbed(fx: &MlaFixture, dt: i32, causal: bool) -> Vec<f32> {
+    let proj = MlaAbsorbedProjections::from_dense(&fx.kv_b_array(dt), fx.geometry).unwrap();
+    let mask = causal.then(|| fx.causal_mask(dt));
+    let out = absorbed_decode(
+        &fx.q_nope_array(dt),
+        &fx.q_pe_array(dt),
+        &fx.ckv_array(dt),
+        &fx.kpe_array(dt),
+        &proj,
+        fx.scale,
+        mask.as_deref(),
+    );
+    to_vec_f32(&out)
+}
+
+#[test]
+fn absorbed_decode_matches_the_decompressed_reference_in_f32() {
+    let _guard = serial();
+    let fx = MlaFixture::new(TINY, 2, 1, 37, 0xD00D);
+    let got = run_absorbed(&fx, dtype::FLOAT32, false);
+    let want = fx.decompressed_reference(false);
+    let err = max_rel_error(&got, &want);
+    assert!(err < F32_TOL, "absorbed decode drifted by {err}");
+}
+
+#[test]
+fn absorbed_decode_matches_the_decompressed_reference_in_f16() {
+    let _guard = serial();
+    let fx = MlaFixture::new(TINY, 2, 1, 37, 0xBEEF);
+    let got = run_absorbed(&fx, dtype::FLOAT16, false);
+    let want = fx.decompressed_reference(false);
+    let err = max_rel_error(&got, &want);
+    assert!(err < F16_TOL, "absorbed decode drifted by {err} in f16");
+}
+
+#[test]
+fn absorbed_attention_respects_an_additive_causal_mask() {
+    let _guard = serial();
+    // The rope half of the score is passed to SDPA *as* the mask, so a caller's
+    // causal mask has to be folded into it. If it were dropped, a multi-token
+    // step would be fully bidirectional and every layer above the first would
+    // write future-contaminated latents into the cache. That is exactly the bug
+    // deepseek_v3.rs carries a comment about; this pins it for the shared path.
+    let fx = MlaFixture::new(TINY, 2, 4, 12, 0xCA5E);
+    let got = run_absorbed(&fx, dtype::FLOAT32, true);
+    let want = fx.decompressed_reference(true);
+    let err = max_rel_error(&got, &want);
+    assert!(err < F32_TOL, "masked absorbed attention drifted by {err}");
+
+    // Positive control: without the mask the same fixture must NOT match the
+    // causal reference, otherwise the test above would pass on a no-op mask.
+    let unmasked = run_absorbed(&fx, dtype::FLOAT32, false);
+    assert!(
+        max_rel_error(&unmasked, &want) > 1e-2,
+        "the causal mask made no difference, so the masked test proves nothing"
+    );
+}
+
+#[test]
+fn expand_latent_reproduces_the_up_projection() {
+    // The prefill direction of the same fold. `k_nope` and `v` must equal what
+    // `kv_b_proj` would have produced, or prefill and decode disagree about the
+    // cache contents.
+    let fx = MlaFixture::new(TINY, 1, 1, 5, 0x3417);
+    let proj = MlaAbsorbedProjections::from_dense(&fx.kv_b_array(dtype::FLOAT32), TINY).unwrap();
+    let (k_nope, v) = expand_latent(&fx.ckv_array(dtype::FLOAT32), &proj);
+
+    let h = TINY.num_heads;
+    let r = TINY.kv_lora_rank;
+    let nope = TINY.qk_nope_head_dim;
+    let v_dim = TINY.v_head_dim;
+    let rows = TINY.kv_b_rows_per_head();
+    assert_eq!(
+        crate::ffi::array_shape(&k_nope),
+        vec![1, h as i32, fx.kv_len as i32, nope as i32]
+    );
+
+    let got_k = to_vec_f32(&k_nope);
+    let got_v = to_vec_f32(&v);
+    for head in 0..h {
+        for t in 0..fx.kv_len {
+            let c = &fx.ckv[t * r..][..r];
+            for d in 0..nope {
+                let w = &fx.kv_b[(head * rows + d) * r..][..r];
+                let want: f64 = (0..r).map(|i| w[i] as f64 * c[i] as f64).sum();
+                let got = got_k[(head * fx.kv_len + t) * nope + d] as f64;
+                assert!(
+                    (got - want).abs() < 1e-4,
+                    "k_nope[{head}][{t}][{d}] {got} != {want}"
+                );
+            }
+            for e in 0..v_dim {
+                let w = &fx.kv_b[(head * rows + nope + e) * r..][..r];
+                let want: f64 = (0..r).map(|i| w[i] as f64 * c[i] as f64).sum();
+                let got = got_v[(head * fx.kv_len + t) * v_dim + e] as f64;
+                assert!(
+                    (got - want).abs() < 1e-4,
+                    "v[{head}][{t}][{e}] {got} != {want}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn latent_cache_round_trips_the_two_asymmetric_streams() {
+    // The packing claim in `mla::cache`: an FP16 KVCache holds a 512-wide "key"
+    // and a 64-wide "value" without either shape leaking into the other. This
+    // is what makes the whole design possible without a new cache type, so it is
+    // tested against the cache rather than assumed from reading it.
+    let geometry = MlaGeometry {
+        num_heads: 4,
+        kv_lora_rank: 32,
+        qk_nope_head_dim: 16,
+        qk_rope_head_dim: 8,
+        v_head_dim: 12,
+    };
+    let mut cache = crate::cache::KVCache::new();
+    let mut view = MlaLatentCache::wrap(&mut cache, geometry).unwrap();
+
+    let prefill = MlaFixture::new(geometry, 1, 1, 5, 0x77);
+    let (ckv_all, kpe_all) = view.update_and_fetch(
+        prefill.ckv_array(dtype::FLOAT16),
+        prefill.kpe_array(dtype::FLOAT16),
+    );
+    assert_eq!(crate::ffi::array_shape(&ckv_all), vec![1, 1, 5, 32]);
+    assert_eq!(crate::ffi::array_shape(&kpe_all), vec![1, 1, 5, 8]);
+    assert_eq!(view.seq_len(), 5);
+
+    let step = MlaFixture::new(geometry, 1, 1, 1, 0x78);
+    let (ckv_all, kpe_all) = view.update_and_fetch(
+        step.ckv_array(dtype::FLOAT16),
+        step.kpe_array(dtype::FLOAT16),
+    );
+    assert_eq!(crate::ffi::array_shape(&ckv_all), vec![1, 1, 6, 32]);
+    assert_eq!(crate::ffi::array_shape(&kpe_all), vec![1, 1, 6, 8]);
+    assert_eq!(view.seq_len(), 6);
+
+    // The appended rows must be the ones just written, at the tail.
+    let ckv_host = to_vec_f32(&ckv_all);
+    for (i, want) in step.ckv.iter().enumerate() {
+        let got = ckv_host[5 * 32 + i];
+        assert!(
+            (got - want).abs() < 1e-2,
+            "latent tail row {i}: {got} != {want}"
+        );
+    }
+}
+
+#[test]
+fn stage_1_records_the_path_it_took() {
+    let _guard = serial();
+    // The #899 trap: a benchmark arm that silently ran the fallback. A decode
+    // step must land on `absorbed_composed` and a multi-token step on
+    // `absorbed_prefill`, so an arm's counters name what actually ran.
+    let _ = crate::mla::stats::take();
+    let decode = MlaFixture::new(TINY, 1, 1, 8, 0x91);
+    run_absorbed(&decode, dtype::FLOAT32, false);
+    let counts = crate::mla::stats::take();
+    assert_eq!(counts.absorbed_composed, 1, "{}", counts.summary());
+    assert_eq!(counts.absorbed_prefill, 0, "{}", counts.summary());
+
+    let prefill = MlaFixture::new(TINY, 1, 3, 8, 0x92);
+    run_absorbed(&prefill, dtype::FLOAT32, true);
+    let counts = crate::mla::stats::take();
+    assert_eq!(counts.absorbed_prefill, 1, "{}", counts.summary());
+    assert_eq!(counts.absorbed_composed, 0, "{}", counts.summary());
+}

--- a/src/lib/mlxcel-core/src/mla/mod.rs
+++ b/src/lib/mlxcel-core/src/mla/mod.rs
@@ -1,0 +1,242 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Matrix-absorbed MLA decode over a compressed-latent KV cache (issue #907).
+//!
+//! ## The identity
+//!
+//! DeepSeek-family MLA compresses K and V into one latent `c` of width
+//! `kv_lora_rank` (512 in every shipping checkpoint) plus a shared rope stream
+//! `k_pe` of width `qk_rope_head_dim` (64). The porting-style implementation
+//! up-projects `c` through `kv_b_proj` into full per-head K and V and caches
+//! *those*, so the cache costs `num_heads * (qk_head_dim + v_head_dim)` per
+//! token. Absorption removes the up-projection from the decode graph instead of
+//! removing it from the math:
+//!
+//! ```text
+//!   score:  q_nope . (W_UK c)  ==  (W_UK^T q_nope) . c
+//!   output: attn @ (W_UV c)    ==  (attn @ c) @ W_UV
+//! ```
+//!
+//! Folding `W_UK` into the query and `W_UV` after the attention lets decode run
+//! directly against `c`, so the cache holds `kv_lora_rank + qk_rope_head_dim`
+//! floats per token (576) for **one** latent head rather than the decompressed
+//! per-head K/V. For DeepSeek-V2-Lite (16 heads, 192 + 128 per head) that is
+//! 5120 -> 576 floats per token per layer, an 8.9x reduction; see
+//! [`cache::latent_bytes_per_token`] and [`cache::decompressed_bytes_per_token`],
+//! which are the functions the issue's KV-memory table is computed from.
+//!
+//! The absorbed score is the sum of two dot products, `q_absorbed . ckv` over
+//! `kv_lora_rank` and `q_pe . kpe` over `qk_rope_head_dim`, and the attention
+//! output lives in the latent space with `num_heads` query heads sharing the
+//! single latent "KV head" (an MQA shape with `head_dim = kv_lora_rank`).
+//!
+//! ## Stages
+//!
+//! * **Stage 1** ([`decode::absorbed_decode`]) composes the two contractions
+//!   out of MLX ops. No custom kernel; the win is cache bandwidth and cache
+//!   memory, not arithmetic.
+//! * **Stage 2** ([`split_kv`]) cuts the latent range into chunks that produce
+//!   `(partial_v, lse)` states and merges them with issue #898's
+//!   `paged_attention_merge_states`, reused unchanged. Small batch times long
+//!   context is exactly the shape a single-CTA-per-request decode cannot fill,
+//!   which is what the split buys.
+//!
+//! Prefill deliberately stays on the decompressed path: absorption trades a
+//! `[L, r] -> [L, H*(nope+v)]` up-projection done once for an
+//! `[H, nope, r]` fold applied to every query, which is a win only when `L` is
+//! large relative to the number of queries. Prefill also still *writes* the
+//! latent cache, so a prefill and a decode step see the same cache.
+//!
+//! ## Gate
+//!
+//! Off unless `MLXCEL_MLA_ABSORBED` is set to one of the tree's usual on
+//! spellings ([`absorbed_enabled`]). With it unset nothing in this module is
+//! constructed, no weight is dequantized, and the families keep the byte-identical
+//! decompressed path.
+//!
+//! ## Cost of the fold
+//!
+//! `W_UK` and `W_UV` are slices of `kv_b_proj`, which ships quantized in every
+//! mlx-community MLA checkpoint. The absorbed query and output contractions are
+//! dense batched matmuls, so the fold dequantizes `kv_b_proj` at load time and
+//! keeps it dense: `num_heads * (qk_nope_head_dim + v_head_dim) * kv_lora_rank`
+//! elements per layer. On DeepSeek-V2-Lite that is 2.1 M elements per layer, so
+//! ~113 MB in f16 across 27 layers against ~28 MB for the 4-bit original. The
+//! trade is fixed weight memory for per-token cache memory, and it only pays off
+//! past a context length where the cache saving exceeds it; the benchmark
+//! harness reports both numbers so the crossover is visible rather than assumed.
+
+use std::sync::OnceLock;
+
+pub mod absorb;
+pub mod cache;
+pub mod decode;
+pub mod split_kv;
+pub mod stats;
+
+#[cfg(test)]
+pub(crate) mod testkit;
+
+pub use absorb::MlaAbsorbedProjections;
+pub use cache::{MlaLatentCache, decompressed_bytes_per_token, latent_bytes_per_token};
+pub use decode::{absorb_queries, absorbed_decode};
+pub use split_kv::{MlaSplitPlan, absorbed_decode_split_kv};
+pub use stats::{MlaDecodePath, MlaDispatchCounts};
+
+/// Environment variable selecting the absorbed MLA decode path. Default off.
+pub const ABSORBED_ENV: &str = "MLXCEL_MLA_ABSORBED";
+
+/// Environment variable selecting the Stage 2 split-KV decode path.
+///
+/// Only consulted when [`ABSORBED_ENV`] is already on, since split-KV operates
+/// on the latent cache that only the absorbed path maintains.
+pub const SPLIT_KV_ENV: &str = "MLXCEL_MLA_SPLIT_KV";
+
+/// Pure parse of an on/off environment value.
+///
+/// Accepts the tree's usual on spellings; anything else, including an unset
+/// variable, is off, so a typo degrades to the decompressed path rather than
+/// silently enabling one the operator did not ask for. Same policy as
+/// [`crate::paged_v2::parse_v2_enabled`].
+#[must_use]
+pub fn parse_enabled(value: Option<&str>) -> bool {
+    matches!(
+        value.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("1" | "true" | "on" | "yes")
+    )
+}
+
+/// Whether the absorbed MLA decode path is selected, read once per process.
+#[must_use]
+pub fn absorbed_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| parse_enabled(std::env::var(ABSORBED_ENV).ok().as_deref()))
+}
+
+/// Whether the Stage 2 split-KV decode path is selected, read once per process.
+///
+/// Implies [`absorbed_enabled`]: split-KV reads the `(ckv, kpe)` cache, which
+/// only exists when absorption is on.
+#[must_use]
+pub fn split_kv_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| parse_enabled(std::env::var(SPLIT_KV_ENV).ok().as_deref()))
+        && absorbed_enabled()
+}
+
+/// The per-layer MLA shape the absorbed path needs.
+///
+/// Every field is read straight off the family `ModelArgs`; the type exists so
+/// the fold, the cache accounting, and the decode graph cannot disagree about
+/// which of the four head dimensions is which.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MlaGeometry {
+    /// Query heads. All of them share the single latent KV head.
+    pub num_heads: usize,
+    /// Latent width, `kv_lora_rank`. 512 in every shipping checkpoint.
+    pub kv_lora_rank: usize,
+    /// Non-rope part of the query/key head dim, the part absorption folds.
+    pub qk_nope_head_dim: usize,
+    /// Rope part of the query/key head dim, carried uncompressed beside the
+    /// latent because RoPE does not commute with the up-projection.
+    pub qk_rope_head_dim: usize,
+    /// Value head dim, the width the output fold restores.
+    pub v_head_dim: usize,
+}
+
+impl MlaGeometry {
+    /// Rows of `kv_b_proj` that belong to one head: `qk_nope + v`.
+    #[must_use]
+    pub const fn kv_b_rows_per_head(&self) -> usize {
+        self.qk_nope_head_dim + self.v_head_dim
+    }
+
+    /// Full query/key head dim, `qk_nope + qk_rope`. The scale denominator.
+    #[must_use]
+    pub const fn q_head_dim(&self) -> usize {
+        self.qk_nope_head_dim + self.qk_rope_head_dim
+    }
+
+    /// Reject a geometry the absorbed path cannot serve.
+    ///
+    /// Returned as `Err` rather than asserted so a loader can decline
+    /// absorption for one family and keep the decompressed path, which is the
+    /// behaviour the issue asks for while the flag is still opt-in.
+    pub fn check(&self) -> Result<(), String> {
+        for (name, value) in [
+            ("num_heads", self.num_heads),
+            ("kv_lora_rank", self.kv_lora_rank),
+            ("qk_nope_head_dim", self.qk_nope_head_dim),
+            ("qk_rope_head_dim", self.qk_rope_head_dim),
+            ("v_head_dim", self.v_head_dim),
+        ] {
+            if value == 0 {
+                return Err(format!("mla: {name} must be non-zero, got 0"));
+            }
+        }
+        if self.kv_lora_rank > i32::MAX as usize {
+            return Err(format!(
+                "mla: kv_lora_rank {} overflows i32",
+                self.kv_lora_rank
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LITE: MlaGeometry = MlaGeometry {
+        num_heads: 16,
+        kv_lora_rank: 512,
+        qk_nope_head_dim: 128,
+        qk_rope_head_dim: 64,
+        v_head_dim: 128,
+    };
+
+    #[test]
+    fn absorption_is_off_unless_explicitly_enabled() {
+        assert!(!parse_enabled(None));
+        assert!(!parse_enabled(Some("")));
+        assert!(!parse_enabled(Some("0")));
+        assert!(!parse_enabled(Some("off")));
+        assert!(!parse_enabled(Some("2")));
+        assert!(!parse_enabled(Some("absorbed")));
+    }
+
+    #[test]
+    fn absorption_accepts_the_usual_on_spellings() {
+        for v in ["1", "true", "TRUE", "on", "ON", "yes", " yes "] {
+            assert!(parse_enabled(Some(v)), "{v:?} should enable absorption");
+        }
+    }
+
+    #[test]
+    fn geometry_derives_the_two_composite_widths() {
+        assert_eq!(LITE.kv_b_rows_per_head(), 256);
+        assert_eq!(LITE.q_head_dim(), 192);
+        LITE.check().unwrap();
+    }
+
+    #[test]
+    fn geometry_rejects_a_zero_dimension() {
+        let mut g = LITE;
+        g.kv_lora_rank = 0;
+        let err = g.check().unwrap_err();
+        assert!(err.contains("kv_lora_rank"), "{err}");
+    }
+}

--- a/src/lib/mlxcel-core/src/mla/split_kv.rs
+++ b/src/lib/mlxcel-core/src/mla/split_kv.rs
@@ -1,0 +1,321 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Stage 2: split-KV absorbed MLA decode over the latent cache (issue #907).
+//!
+//! ## Why split at all
+//!
+//! Absorbed decode is one query row per head against `S` latent rows. However
+//! that work is expressed, the parallelism available without a split is bounded
+//! by `batch * num_heads`, and adding context adds none: it makes each unit of
+//! work longer. Small batch times long context is exactly the shape that leaves
+//! the machine idle, which is the same observation issue #898 made about paged
+//! decode. The fix is the same: cut the KV range into chunks that are reduced
+//! independently and combine the partial softmax states afterwards.
+//!
+//! ## The merge kernel is #898's, unchanged
+//!
+//! [`crate::ffi::paged_attention_merge_states`] takes
+//!
+//! ```text
+//!   v_in     [N, H, D] f32   partials, each already divided by its own denominator
+//!   lse_in   [N, H]    f32   matching log-sum-exp, in log2 units
+//!   o_indptr [M + 1]   i32   output row o merges partial rows [o_indptr[o], o_indptr[o+1])
+//! ```
+//!
+//! and knows nothing about pages, block tables, or GQA. Its contract note calls
+//! that out explicitly, and `paged_v2::launch_tests::merge_is_associative_across_regroupings`
+//! pins the property this path depends on: the result does not depend on how the
+//! partials were grouped, only on which partials a row covers.
+//!
+//! MLA fits the contract without changing it. `H` is `num_heads` (all of which
+//! share the single latent KV head), `D` is `kv_lora_rank`, `M` is the batch,
+//! and `N` is `batch * chunks`. Nothing in this module edits the merge kernel,
+//! the FFI signature, or the C++ launcher. Two contract details are load-bearing
+//! and are honoured here rather than worked around: the LSE must be in **log2**
+//! units (this module multiplies a natural-log `logsumexp` by `log2(e)`, see
+//! [`LOG2_E`]), and a partial with `-inf` LSE contributes nothing (which is what
+//! makes a trailing short chunk safe).
+//!
+//! ## What produces the partials
+//!
+//! The partial producer here is composed from MLX ops, one chunk at a time. It
+//! is correct, it exercises the full split-and-merge decomposition, and it is
+//! the reference a fused partial kernel is validated against. It is **not** a
+//! speed win on its own: `C` small matmuls do the same arithmetic as one large
+//! one with `C` times the launch overhead. Ship the fused partial kernel before
+//! quoting a Stage 2 throughput number.
+
+use cxx::UniquePtr;
+
+use crate::ffi::{self, MlxArray};
+use crate::mla::absorb::MlaAbsorbedProjections;
+use crate::mla::decode::{absorb_queries, unabsorb_output};
+use crate::mla::stats::{self, MlaDecodePath};
+
+/// `log2(e)`. Converts a natural-log `logsumexp` into the merge kernel's log2
+/// units, which is the single most likely thing to get silently wrong when
+/// reusing #898's kernel from a new caller: a natural-log LSE still merges, it
+/// just weights the partials by `e^(lse)` raised to `log2(e)` and produces a
+/// plausible-looking wrong answer.
+pub const LOG2_E: f32 = std::f32::consts::LOG2_E;
+
+/// The smallest chunk worth cutting. Below this the per-chunk fixed cost
+/// dominates the reduction it performs.
+pub const MIN_CHUNK_LEN: i32 = 128;
+
+/// How the latent range is cut for one decode step.
+///
+/// Uniform: a dense (non-paged) KV cache is rectangular, so every request in
+/// the batch has the same live length and therefore the same chunk count. That
+/// is what lets [`Self::o_indptr`] be an arithmetic sequence instead of a
+/// per-request scan. A ragged batch would need per-request chunk counts, which
+/// the merge kernel already supports through `o_indptr`; only this plan would
+/// change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MlaSplitPlan {
+    /// Live latent rows per request.
+    pub kv_len: i32,
+    /// Rows per chunk. The last chunk of each request may be shorter.
+    pub chunk_len: i32,
+    /// Chunks per request, `ceil(kv_len / chunk_len)`.
+    pub num_chunks: usize,
+    /// Requests in the batch.
+    pub batch: usize,
+}
+
+impl MlaSplitPlan {
+    /// Cut `kv_len` so the batch produces at least `target_ctas` independent
+    /// units, without going below [`MIN_CHUNK_LEN`].
+    ///
+    /// `batch * num_heads` units already exist before any split, so the split
+    /// only needs to make up the shortfall; a batch that already saturates the
+    /// device gets one chunk and the merge is skipped entirely.
+    #[must_use]
+    pub fn heuristic(batch: usize, num_heads: usize, kv_len: i32, target_ctas: usize) -> Self {
+        let batch = batch.max(1);
+        let kv_len = kv_len.max(0);
+        let existing = batch.saturating_mul(num_heads.max(1));
+        let wanted_chunks = target_ctas.div_ceil(existing.max(1)).max(1);
+        let chunk_len = if kv_len <= 0 {
+            MIN_CHUNK_LEN
+        } else {
+            let by_target = (kv_len as usize).div_ceil(wanted_chunks) as i32;
+            by_target.max(MIN_CHUNK_LEN)
+        };
+        let num_chunks = if kv_len <= 0 {
+            0
+        } else {
+            (kv_len as usize).div_ceil(chunk_len as usize)
+        };
+        Self {
+            kv_len,
+            chunk_len,
+            num_chunks,
+            batch,
+        }
+    }
+
+    /// A plan with an explicit chunk length, for tests and for an autotuner.
+    #[must_use]
+    pub fn with_chunk_len(batch: usize, kv_len: i32, chunk_len: i32) -> Self {
+        let batch = batch.max(1);
+        let kv_len = kv_len.max(0);
+        let chunk_len = chunk_len.max(1);
+        Self {
+            kv_len,
+            chunk_len,
+            num_chunks: if kv_len <= 0 {
+                0
+            } else {
+                (kv_len as usize).div_ceil(chunk_len as usize)
+            },
+            batch,
+        }
+    }
+
+    /// Whether the merge launch is needed at all.
+    ///
+    /// One chunk per request means the partial already is the answer, the same
+    /// "write O directly" case `paged_v2::launch` decides on the host.
+    #[must_use]
+    pub const fn needs_merge(&self) -> bool {
+        self.num_chunks > 1
+    }
+
+    /// Total partial rows, `batch * num_chunks`.
+    #[must_use]
+    pub const fn num_partials(&self) -> usize {
+        self.batch * self.num_chunks
+    }
+
+    /// The merge kernel's `o_indptr`: `[0, C, 2C, ..., B*C]`.
+    ///
+    /// Request-major, so partial rows for one request are contiguous, which is
+    /// what the grouping means.
+    #[must_use]
+    pub fn o_indptr(&self) -> Vec<i32> {
+        (0..=self.batch)
+            .map(|b| (b * self.num_chunks) as i32)
+            .collect()
+    }
+
+    /// Half-open row range of chunk `c`, clamped to `kv_len`.
+    #[must_use]
+    pub fn chunk_range(&self, c: usize) -> (i32, i32) {
+        let start = (c as i32).saturating_mul(self.chunk_len).min(self.kv_len);
+        let stop = (start.saturating_add(self.chunk_len)).min(self.kv_len);
+        (start, stop)
+    }
+
+    /// Reject a plan the split path cannot serve.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.batch == 0 {
+            return Err("mla split: batch must be non-zero".to_string());
+        }
+        if self.kv_len <= 0 || self.num_chunks == 0 {
+            return Err("mla split: no visible latent rows to split".to_string());
+        }
+        if self.chunk_len <= 0 {
+            return Err(format!(
+                "mla split: chunk_len {} must be positive",
+                self.chunk_len
+            ));
+        }
+        let covered = (self.num_chunks as i64) * (self.chunk_len as i64);
+        if covered < self.kv_len as i64 {
+            return Err(format!(
+                "mla split: {} chunks of {} cover {covered} rows, short of kv_len {}",
+                self.num_chunks, self.chunk_len, self.kv_len
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Absorbed single-token decode, split across latent chunks and merged with
+/// issue #898's `paged_attention_merge_states`.
+///
+/// * `q_nope` `[B, H, 1, qk_nope_head_dim]`, `q_pe` `[B, H, 1, qk_rope_head_dim]`
+/// * `ckv` `[B, 1, S, kv_lora_rank]`, `kpe` `[B, 1, S, qk_rope_head_dim]`
+///
+/// Returns `[B, H, 1, v_head_dim]`. Decode only: a multi-token step needs a
+/// causal mask per chunk, which the partial format has no place for.
+pub fn absorbed_decode_split_kv(
+    q_nope: &MlxArray,
+    q_pe: &MlxArray,
+    ckv: &MlxArray,
+    kpe: &MlxArray,
+    proj: &MlaAbsorbedProjections,
+    scale: f32,
+    plan: &MlaSplitPlan,
+) -> Result<UniquePtr<MlxArray>, String> {
+    plan.validate()?;
+    let q_shape = ffi::array_shape(q_nope);
+    if q_shape.len() != 4 || q_shape[2] != 1 {
+        return Err(format!(
+            "mla split: expected a single-token query [B, H, 1, D], got {q_shape:?}"
+        ));
+    }
+    let batch = q_shape[0];
+    let heads = q_shape[1];
+    if batch as usize != plan.batch {
+        return Err(format!(
+            "mla split: query batch {batch} disagrees with the plan's {}",
+            plan.batch
+        ));
+    }
+    let rank = proj.geometry().kv_lora_rank as i32;
+
+    stats::record(MlaDecodePath::AbsorbedSplitKv);
+
+    let q_absorbed = absorb_queries(q_nope, proj);
+    let scale_scalar = ffi::full_f32(&[1], scale, ffi::array_dtype(&q_absorbed));
+
+    let mut partial_v = Vec::with_capacity(plan.num_chunks);
+    let mut partial_lse = Vec::with_capacity(plan.num_chunks);
+    let ckv_shape = ffi::array_shape(ckv);
+    let kpe_shape = ffi::array_shape(kpe);
+
+    for c in 0..plan.num_chunks {
+        let (start, stop) = plan.chunk_range(c);
+        let ckv_c = ffi::slice(
+            ckv,
+            &[0, 0, start, 0],
+            &[ckv_shape[0], ckv_shape[1], stop, ckv_shape[3]],
+        );
+        let kpe_c = ffi::slice(
+            kpe,
+            &[0, 0, start, 0],
+            &[kpe_shape[0], kpe_shape[1], stop, kpe_shape[3]],
+        );
+
+        // scores = scale * (q_absorbed . ckv + q_pe . kpe), [B, H, 1, chunk]
+        let latent = ffi::matmul(&q_absorbed, &ffi::transpose_axes(&ckv_c, &[0, 1, 3, 2]));
+        let rope = ffi::matmul(q_pe, &ffi::transpose_axes(&kpe_c, &[0, 1, 3, 2]));
+        let scores = ffi::multiply(&ffi::add(&latent, &rope), &scale_scalar);
+        let scores = ffi::astype(&scores, crate::dtype::FLOAT32);
+
+        // The merge kernel wants each partial already divided by its own
+        // denominator, and the matching LSE in log2 units.
+        let probs = ffi::softmax_precise(&scores, -1);
+        let lse_ln = ffi::logsumexp_axis(&scores, -1, false);
+        let lse_log2 = ffi::multiply(&lse_ln, &ffi::full_f32(&[1], LOG2_E, crate::dtype::FLOAT32));
+
+        let probs_k = ffi::astype(&probs, ffi::array_dtype(&ckv_c));
+        let v_c = ffi::matmul(&probs_k, &ckv_c);
+        let v_c = ffi::astype(&v_c, crate::dtype::FLOAT32);
+
+        // [B, H, 1, D] -> [B, H, D] and [B, H, 1] -> [B, H]: the merge kernel's
+        // partial layout has no query axis.
+        partial_v.push(ffi::reshape(&v_c, &[batch, heads, rank]));
+        partial_lse.push(ffi::reshape(&lse_log2, &[batch, heads]));
+    }
+
+    let merged = if plan.needs_merge() {
+        // Stack to [C, B, H, D], move the request axis outermost, then flatten
+        // to [B*C, H, D] so each request's chunks are contiguous, which is what
+        // `o_indptr` groups over.
+        let v_stacked = crate::ops::stack_owned(&partial_v, 0);
+        let v_in = ffi::reshape(
+            &ffi::contiguous(&ffi::transpose_axes(&v_stacked, &[1, 0, 2, 3]), false),
+            &[batch * plan.num_chunks as i32, heads, rank],
+        );
+        let lse_stacked = crate::ops::stack_owned(&partial_lse, 0);
+        let lse_in = ffi::reshape(
+            &ffi::contiguous(&ffi::transpose_axes(&lse_stacked, &[1, 0, 2]), false),
+            &[batch * plan.num_chunks as i32, heads],
+        );
+        let o_indptr_host = plan.o_indptr();
+        let o_indptr = ffi::from_slice_i32(&o_indptr_host, &[o_indptr_host.len() as i32]);
+
+        let mut v_out = UniquePtr::null();
+        let mut lse_out = UniquePtr::null();
+        ffi::paged_attention_merge_states(&v_in, &lse_in, &o_indptr, &mut v_out, &mut lse_out);
+        v_out
+    } else {
+        // One chunk per request: the partial is the answer, no merge launch.
+        partial_v.pop().ok_or_else(|| {
+            "mla split: validate() accepted a plan that produced no partials".to_string()
+        })?
+    };
+
+    let o_latent = ffi::reshape(&merged, &[batch, heads, 1, rank]);
+    let o_latent = ffi::astype(&o_latent, ffi::array_dtype(ckv));
+    Ok(unabsorb_output(&o_latent, proj))
+}
+
+#[cfg(test)]
+#[path = "split_kv_tests.rs"]
+mod split_kv_tests;

--- a/src/lib/mlxcel-core/src/mla/split_kv_tests.rs
+++ b/src/lib/mlxcel-core/src/mla/split_kv_tests.rs
@@ -1,0 +1,266 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for Stage 2 split-KV absorbed decode (issue #907).
+//!
+//! Two things are under test and they fail for different reasons:
+//!
+//! 1. The **decomposition**: splitting the latent range and merging the partial
+//!    states must reproduce the unsplit answer for any chunk length.
+//! 2. The **reuse of issue #898's merge kernel**: its contract is honoured
+//!    rather than approximated. The load-bearing clause is that `lse_in` is in
+//!    **log2** units, and a natural-log LSE does not fail loudly, it produces a
+//!    plausible wrong weighted average. `merge_rejects_natural_log_lse_units`
+//!    is the negative control that pins it.
+
+use super::*;
+use crate::dtype;
+use crate::mla::absorb::MlaAbsorbedProjections;
+use crate::mla::testkit::{MlaFixture, TINY, max_rel_error, serial, to_vec_f32};
+
+const F32_TOL: f32 = 3e-5;
+
+fn run_split(fx: &MlaFixture, chunk_len: i32) -> Vec<f32> {
+    let proj =
+        MlaAbsorbedProjections::from_dense(&fx.kv_b_array(dtype::FLOAT32), fx.geometry).unwrap();
+    let plan = MlaSplitPlan::with_chunk_len(fx.batch, fx.kv_len as i32, chunk_len);
+    let out = absorbed_decode_split_kv(
+        &fx.q_nope_array(dtype::FLOAT32),
+        &fx.q_pe_array(dtype::FLOAT32),
+        &fx.ckv_array(dtype::FLOAT32),
+        &fx.kpe_array(dtype::FLOAT32),
+        &proj,
+        fx.scale,
+        &plan,
+    )
+    .unwrap();
+    to_vec_f32(&out)
+}
+
+#[test]
+fn split_kv_matches_the_decompressed_reference_at_every_chunk_length() {
+    let _guard = serial();
+    // 37 rows: 8 gives a ragged last chunk of 5, 16 gives 5, 37 gives exactly
+    // one chunk (the no-merge case), 64 exceeds the range entirely.
+    let fx = MlaFixture::new(TINY, 2, 1, 37, 0x5911);
+    let want = fx.decompressed_reference(false);
+    for chunk_len in [8, 16, 37, 64] {
+        let got = run_split(&fx, chunk_len);
+        let err = max_rel_error(&got, &want);
+        assert!(err < F32_TOL, "chunk_len {chunk_len} drifted by {err}");
+    }
+}
+
+#[test]
+fn split_kv_agrees_with_the_unsplit_stage_1_path() {
+    let _guard = serial();
+    // The regrouping property `paged_v2::launch_tests::merge_is_associative_across_regroupings`
+    // pins for the kernel, restated at the MLA caller: how the range was cut
+    // must not change the answer.
+    let fx = MlaFixture::new(TINY, 3, 1, 40, 0x9E77);
+    let proj = MlaAbsorbedProjections::from_dense(&fx.kv_b_array(dtype::FLOAT32), TINY).unwrap();
+    let unsplit = to_vec_f32(&crate::mla::decode::absorbed_decode(
+        &fx.q_nope_array(dtype::FLOAT32),
+        &fx.q_pe_array(dtype::FLOAT32),
+        &fx.ckv_array(dtype::FLOAT32),
+        &fx.kpe_array(dtype::FLOAT32),
+        &proj,
+        fx.scale,
+        None,
+    ));
+    for chunk_len in [5, 10, 13] {
+        let got = run_split(&fx, chunk_len);
+        let err = max_rel_error(&got, &unsplit);
+        assert!(err < F32_TOL, "chunk_len {chunk_len} drifted by {err}");
+    }
+}
+
+#[test]
+fn split_kv_records_its_own_path() {
+    let _guard = serial();
+    let _ = crate::mla::stats::take();
+    let fx = MlaFixture::new(TINY, 1, 1, 20, 0x4242);
+    run_split(&fx, 8);
+    let counts = crate::mla::stats::take();
+    assert_eq!(counts.absorbed_split_kv, 1, "{}", counts.summary());
+    assert_eq!(counts.absorbed_composed, 0, "{}", counts.summary());
+}
+
+#[test]
+fn split_kv_declines_a_multi_token_step() {
+    let _guard = serial();
+    let fx = MlaFixture::new(TINY, 1, 3, 20, 0x1234);
+    let proj = MlaAbsorbedProjections::from_dense(&fx.kv_b_array(dtype::FLOAT32), TINY).unwrap();
+    let plan = MlaSplitPlan::with_chunk_len(1, 20, 8);
+    let err = match absorbed_decode_split_kv(
+        &fx.q_nope_array(dtype::FLOAT32),
+        &fx.q_pe_array(dtype::FLOAT32),
+        &fx.ckv_array(dtype::FLOAT32),
+        &fx.kpe_array(dtype::FLOAT32),
+        &proj,
+        fx.scale,
+        &plan,
+    ) {
+        Ok(_) => panic!("split-KV accepted a 3-token step; it has no per-chunk causal mask"),
+        Err(e) => e,
+    };
+    assert!(err.contains("single-token"), "{err}");
+}
+
+/// Directly exercise issue #898's merge kernel with MLA-shaped partials, and
+/// show that the log2 unit conversion is the thing making it correct.
+#[test]
+fn merge_rejects_natural_log_lse_units() {
+    let _guard = serial();
+    const HEADS: usize = 3;
+    const DIM: usize = 5;
+    const A: usize = 4;
+    const B: usize = 6;
+
+    let mut rng = crate::mla::testkit::Rng::new(0xFEED);
+    // Scores deliberately biased so the two chunks have very different
+    // denominators; with equal denominators a wrong weighting would cancel.
+    let scores_a: Vec<f64> = (0..HEADS * A)
+        .map(|_| rng.next_f32() as f64 * 2.0)
+        .collect();
+    let scores_b: Vec<f64> = (0..HEADS * B)
+        .map(|_| rng.next_f32() as f64 * 2.0 + 3.0)
+        .collect();
+    let vals_a: Vec<f64> = (0..A * DIM).map(|_| rng.next_f32() as f64).collect();
+    let vals_b: Vec<f64> = (0..B * DIM).map(|_| rng.next_f32() as f64).collect();
+
+    // Host truth: one softmax over the concatenated range.
+    let mut truth = vec![0.0f32; HEADS * DIM];
+    for h in 0..HEADS {
+        let all: Vec<f64> = scores_a[h * A..(h + 1) * A]
+            .iter()
+            .chain(&scores_b[h * B..(h + 1) * B])
+            .copied()
+            .collect();
+        let m = all.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let exps: Vec<f64> = all.iter().map(|s| (s - m).exp()).collect();
+        let denom: f64 = exps.iter().sum();
+        for d in 0..DIM {
+            let acc: f64 = (0..A).map(|t| exps[t] * vals_a[t * DIM + d]).sum::<f64>()
+                + (0..B)
+                    .map(|t| exps[A + t] * vals_b[t * DIM + d])
+                    .sum::<f64>();
+            truth[h * DIM + d] = (acc / denom) as f32;
+        }
+    }
+
+    // Two partials, each normalized by its own denominator, plus its LSE.
+    let mut v_in = vec![0.0f32; 2 * HEADS * DIM];
+    let mut lse_ln = vec![0.0f32; 2 * HEADS];
+    for (chunk, (scores, vals, n)) in [(&scores_a, &vals_a, A), (&scores_b, &vals_b, B)]
+        .into_iter()
+        .enumerate()
+    {
+        for h in 0..HEADS {
+            let s = &scores[h * n..(h + 1) * n];
+            let m = s.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            let exps: Vec<f64> = s.iter().map(|x| (x - m).exp()).collect();
+            let denom: f64 = exps.iter().sum();
+            for d in 0..DIM {
+                let acc: f64 = (0..n).map(|t| exps[t] * vals[t * DIM + d]).sum();
+                v_in[(chunk * HEADS + h) * DIM + d] = (acc / denom) as f32;
+            }
+            lse_ln[chunk * HEADS + h] = (m + denom.ln()) as f32;
+        }
+    }
+
+    let v_arr = crate::ffi::from_slice_f32(&v_in, &[2, HEADS as i32, DIM as i32]);
+    let indptr = crate::ffi::from_slice_i32(&[0, 2], &[2]);
+
+    let merge = |lse: &[f32]| {
+        let lse_arr = crate::ffi::from_slice_f32(lse, &[2, HEADS as i32]);
+        let mut out_v = cxx::UniquePtr::null();
+        let mut out_lse = cxx::UniquePtr::null();
+        crate::ffi::paged_attention_merge_states(
+            &v_arr,
+            &lse_arr,
+            &indptr,
+            &mut out_v,
+            &mut out_lse,
+        );
+        to_vec_f32(&out_v)
+    };
+
+    let lse_log2: Vec<f32> = lse_ln.iter().map(|x| x * LOG2_E).collect();
+    let good = merge(&lse_log2);
+    assert!(
+        max_rel_error(&good, &truth) < 1e-5,
+        "log2 LSE merge drifted by {}",
+        max_rel_error(&good, &truth)
+    );
+
+    // The negative control. A natural-log LSE is silently accepted by the
+    // kernel and produces a different, plausible answer, which is exactly why
+    // the conversion is a named constant with a comment rather than an inline
+    // multiply.
+    let bad = merge(&lse_ln);
+    assert!(
+        max_rel_error(&bad, &truth) > 1e-3,
+        "natural-log LSE happened to agree, so this control proves nothing"
+    );
+}
+
+#[test]
+fn plan_covers_the_range_and_groups_request_major() {
+    let plan = MlaSplitPlan::with_chunk_len(3, 37, 16);
+    assert_eq!(plan.num_chunks, 3);
+    assert_eq!(plan.num_partials(), 9);
+    assert!(plan.needs_merge());
+    assert_eq!(plan.o_indptr(), vec![0, 3, 6, 9]);
+    assert_eq!(plan.chunk_range(0), (0, 16));
+    assert_eq!(plan.chunk_range(1), (16, 32));
+    assert_eq!(plan.chunk_range(2), (32, 37));
+    plan.validate().unwrap();
+}
+
+#[test]
+fn plan_with_one_chunk_skips_the_merge() {
+    let plan = MlaSplitPlan::with_chunk_len(2, 100, 128);
+    assert_eq!(plan.num_chunks, 1);
+    assert!(!plan.needs_merge());
+    assert_eq!(plan.chunk_range(0), (0, 100));
+    plan.validate().unwrap();
+}
+
+#[test]
+fn plan_rejects_an_empty_range() {
+    let plan = MlaSplitPlan::with_chunk_len(1, 0, 16);
+    let err = plan.validate().unwrap_err();
+    assert!(err.contains("no visible latent rows"), "{err}");
+}
+
+#[test]
+fn heuristic_stops_splitting_once_the_batch_fills_the_device() {
+    // 8 requests * 128 heads already exceeds any plausible CTA target, so the
+    // split must not fragment the range for nothing.
+    let saturated = MlaSplitPlan::heuristic(8, 128, 32768, 512);
+    assert_eq!(saturated.num_chunks, 1, "{saturated:?}");
+
+    // Batch 1, 16 heads, 32K context: the shape a single-CTA-per-request decode
+    // cannot fill, so the split must actually cut.
+    let starved = MlaSplitPlan::heuristic(1, 16, 32768, 512);
+    assert!(starved.num_chunks > 1, "{starved:?}");
+    assert!(starved.chunk_len >= MIN_CHUNK_LEN, "{starved:?}");
+    starved.validate().unwrap();
+
+    // Never below the floor, however starved.
+    let tiny = MlaSplitPlan::heuristic(1, 1, 64, 4096);
+    assert!(tiny.chunk_len >= MIN_CHUNK_LEN, "{tiny:?}");
+    assert_eq!(tiny.num_chunks, 1, "{tiny:?}");
+}

--- a/src/lib/mlxcel-core/src/mla/stats.rs
+++ b/src/lib/mlxcel-core/src/mla/stats.rs
@@ -1,0 +1,189 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Which MLA attention path each step actually took (issue #907).
+//!
+//! Issue #899 shipped a fused decode path that never activated, and the
+//! before/after benchmark compared the fallback against itself and produced a
+//! clean-looking null. The counters here exist so that cannot repeat: every MLA
+//! attention call records the path it took, and the benchmark harness prints
+//! the snapshot for each arm. An arm that claims "absorbed" while
+//! `absorbed_composed` is 0 is visibly a measurement of the fallback.
+//!
+//! `tracing` is deliberately not used. The `mlxcel` CLI installs no tracing
+//! subscriber at all (only `src/server/startup.rs` does), so a `tracing::info!`
+//! from a CLI-reachable path emits nothing no matter what `RUST_LOG` says.
+//! Counters plus an explicit print in the harness are observable everywhere.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The MLA attention paths a step can take.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MlaDecodePath {
+    /// Cache holds decompressed per-head K/V; dense SDPA. The pre-#907 path and
+    /// the default.
+    Decompressed,
+    /// Cache holds `(ckv, kpe)`; prefill up-projects the cached latent and runs
+    /// dense SDPA. Absorption is a decode transform, so multi-token steps land
+    /// here even with the flag on.
+    AbsorbedPrefill,
+    /// Stage 1: absorbed single-token decode built from composed MLX ops.
+    AbsorbedComposed,
+    /// Stage 2: absorbed decode split across latent chunks, merged with issue
+    /// #898's `paged_attention_merge_states`.
+    AbsorbedSplitKv,
+}
+
+impl MlaDecodePath {
+    /// Stable label for printed output and test assertions.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Decompressed => "decompressed",
+            Self::AbsorbedPrefill => "absorbed_prefill",
+            Self::AbsorbedComposed => "absorbed_composed",
+            Self::AbsorbedSplitKv => "absorbed_split_kv",
+        }
+    }
+}
+
+/// Every path, in report order.
+pub const MLA_DECODE_PATHS: [MlaDecodePath; 4] = [
+    MlaDecodePath::Decompressed,
+    MlaDecodePath::AbsorbedPrefill,
+    MlaDecodePath::AbsorbedComposed,
+    MlaDecodePath::AbsorbedSplitKv,
+];
+
+static DECOMPRESSED: AtomicU64 = AtomicU64::new(0);
+static ABSORBED_PREFILL: AtomicU64 = AtomicU64::new(0);
+static ABSORBED_COMPOSED: AtomicU64 = AtomicU64::new(0);
+static ABSORBED_SPLIT_KV: AtomicU64 = AtomicU64::new(0);
+
+fn counter(path: MlaDecodePath) -> &'static AtomicU64 {
+    match path {
+        MlaDecodePath::Decompressed => &DECOMPRESSED,
+        MlaDecodePath::AbsorbedPrefill => &ABSORBED_PREFILL,
+        MlaDecodePath::AbsorbedComposed => &ABSORBED_COMPOSED,
+        MlaDecodePath::AbsorbedSplitKv => &ABSORBED_SPLIT_KV,
+    }
+}
+
+/// Record one MLA attention call on `path`.
+///
+/// `Relaxed` because the counters are diagnostics: they are read after the
+/// measured region, never used to order anything.
+#[inline]
+pub fn record(path: MlaDecodePath) {
+    counter(path).fetch_add(1, Ordering::Relaxed);
+}
+
+/// Per-path call counts.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MlaDispatchCounts {
+    pub decompressed: u64,
+    pub absorbed_prefill: u64,
+    pub absorbed_composed: u64,
+    pub absorbed_split_kv: u64,
+}
+
+impl MlaDispatchCounts {
+    /// Count for one path.
+    #[must_use]
+    pub const fn get(&self, path: MlaDecodePath) -> u64 {
+        match path {
+            MlaDecodePath::Decompressed => self.decompressed,
+            MlaDecodePath::AbsorbedPrefill => self.absorbed_prefill,
+            MlaDecodePath::AbsorbedComposed => self.absorbed_composed,
+            MlaDecodePath::AbsorbedSplitKv => self.absorbed_split_kv,
+        }
+    }
+
+    /// Total recorded calls.
+    #[must_use]
+    pub const fn total(&self) -> u64 {
+        self.decompressed + self.absorbed_prefill + self.absorbed_composed + self.absorbed_split_kv
+    }
+
+    /// One-line `path=count` summary, in [`MLA_DECODE_PATHS`] order.
+    ///
+    /// This is what a benchmark arm prints so its executed path is provable
+    /// from the transcript rather than inferred from the flag it was given.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        MLA_DECODE_PATHS
+            .iter()
+            .map(|p| format!("{}={}", p.label(), self.get(*p)))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+/// Read the counters without clearing them.
+#[must_use]
+pub fn snapshot() -> MlaDispatchCounts {
+    MlaDispatchCounts {
+        decompressed: DECOMPRESSED.load(Ordering::Relaxed),
+        absorbed_prefill: ABSORBED_PREFILL.load(Ordering::Relaxed),
+        absorbed_composed: ABSORBED_COMPOSED.load(Ordering::Relaxed),
+        absorbed_split_kv: ABSORBED_SPLIT_KV.load(Ordering::Relaxed),
+    }
+}
+
+/// Read the counters and reset them to zero.
+///
+/// A benchmark calls this between arms so each arm's summary describes only
+/// that arm.
+#[must_use]
+pub fn take() -> MlaDispatchCounts {
+    MlaDispatchCounts {
+        decompressed: DECOMPRESSED.swap(0, Ordering::Relaxed),
+        absorbed_prefill: ABSORBED_PREFILL.swap(0, Ordering::Relaxed),
+        absorbed_composed: ABSORBED_COMPOSED.swap(0, Ordering::Relaxed),
+        absorbed_split_kv: ABSORBED_SPLIT_KV.swap(0, Ordering::Relaxed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_are_distinct_and_stable() {
+        let mut seen = std::collections::HashSet::new();
+        for p in MLA_DECODE_PATHS {
+            assert!(seen.insert(p.label()), "duplicate label {}", p.label());
+        }
+        assert_eq!(MlaDecodePath::AbsorbedComposed.label(), "absorbed_composed");
+        assert_eq!(MlaDecodePath::AbsorbedSplitKv.label(), "absorbed_split_kv");
+    }
+
+    #[test]
+    fn summary_names_every_path_so_a_zero_is_visible() {
+        let counts = MlaDispatchCounts {
+            decompressed: 7,
+            ..Default::default()
+        };
+        let s = counts.summary();
+        for p in MLA_DECODE_PATHS {
+            assert!(s.contains(p.label()), "{s} is missing {}", p.label());
+        }
+        // The trap this exists to catch: an "absorbed" arm whose absorbed
+        // counter is zero must read as zero, not be omitted.
+        assert!(s.contains("absorbed_composed=0"), "{s}");
+        assert_eq!(counts.total(), 7);
+        assert_eq!(counts.get(MlaDecodePath::Decompressed), 7);
+    }
+}

--- a/src/lib/mlxcel-core/src/mla/testkit.rs
+++ b/src/lib/mlxcel-core/src/mla/testkit.rs
@@ -1,0 +1,302 @@
+// Copyright 2025-2026 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Synthetic MLA fixtures and a host-side f64 reference (issue #907).
+//!
+//! MLA is a DeepSeek-family feature and no MLA checkpoint fits on the
+//! development host, so every test in this module family runs on synthetic
+//! tensors with MLA geometry. That is a real limitation and it is stated here
+//! rather than implied: these tests prove the absorption identity, the cache
+//! packing, and the split-and-merge decomposition, and they do not prove that a
+//! real DeepSeek checkpoint produces identical tokens.
+//!
+//! The reference is computed on the host in f64 from the same values that were
+//! uploaded, following `paged_v2::launch_tests`. A mismatch is then attributable
+//! to the path under test rather than to a disagreement between two GPU paths
+//! that could both be wrong.
+
+use cxx::UniquePtr;
+
+use crate::dtype;
+use crate::ffi::{self, MlxArray};
+use crate::mla::MlaGeometry;
+
+/// Serializes MLA tests that inspect [`crate::mla::stats`].
+///
+/// The dispatch counters are process-global by design (a benchmark reads them
+/// after a measured region), so a test that asserts an exact count has to be
+/// the only MLA test running. Every helper below that executes a decode path
+/// takes this, which costs nothing: these tests are milliseconds each.
+static SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire the MLA test serialization lock, ignoring poisoning so one failing
+/// test does not cascade into every other one.
+pub fn serial() -> std::sync::MutexGuard<'static, ()> {
+    SERIAL.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// xorshift64* in [-1, 1). Deterministic so a failure reproduces exactly.
+pub struct Rng(u64);
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+
+    pub fn next_f32(&mut self) -> f32 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        let unit = ((self.0 >> 40) as f32) / (1u32 << 24) as f32;
+        unit * 2.0 - 1.0
+    }
+
+    pub fn vec(&mut self, n: usize, amplitude: f32) -> Vec<f32> {
+        (0..n).map(|_| self.next_f32() * amplitude).collect()
+    }
+}
+
+/// Read an array back to the host as f32.
+pub fn to_vec_f32(a: &MlxArray) -> Vec<f32> {
+    let f = ffi::astype(a, dtype::FLOAT32);
+    ffi::eval(&f);
+    ffi::array_to_raw_bytes(&f)
+        .chunks_exact(4)
+        .map(|c| f32::from_ne_bytes(c.try_into().unwrap()))
+        .collect()
+}
+
+/// Max absolute deviation relative to the reference's own scale.
+pub fn max_rel_error(got: &[f32], want: &[f32]) -> f32 {
+    assert_eq!(got.len(), want.len(), "output length mismatch");
+    let scale = want
+        .iter()
+        .fold(0.0f32, |acc, v| acc.max(v.abs()))
+        .max(1e-6);
+    got.iter()
+        .zip(want)
+        .fold(0.0f32, |acc, (g, w)| acc.max((g - w).abs() / scale))
+}
+
+/// One synthetic MLA layer plus a decode (or short prefill) step, held on the
+/// host so the reference needs no device readback.
+pub struct MlaFixture {
+    pub geometry: MlaGeometry,
+    pub batch: usize,
+    pub q_len: usize,
+    pub kv_len: usize,
+    pub scale: f32,
+    /// `[H * (qk_nope + v), kv_lora_rank]`, row-major.
+    pub kv_b: Vec<f32>,
+    /// `[B, kv_len, kv_lora_rank]`.
+    pub ckv: Vec<f32>,
+    /// `[B, kv_len, qk_rope_head_dim]`.
+    pub kpe: Vec<f32>,
+    /// `[B, H, q_len, qk_nope_head_dim]`.
+    pub q_nope: Vec<f32>,
+    /// `[B, H, q_len, qk_rope_head_dim]`.
+    pub q_pe: Vec<f32>,
+}
+
+impl MlaFixture {
+    pub fn new(
+        geometry: MlaGeometry,
+        batch: usize,
+        q_len: usize,
+        kv_len: usize,
+        seed: u64,
+    ) -> Self {
+        let mut rng = Rng::new(seed);
+        let h = geometry.num_heads;
+        let r = geometry.kv_lora_rank;
+        let nope = geometry.qk_nope_head_dim;
+        let p = geometry.qk_rope_head_dim;
+        // Amplitudes kept modest so an f16 fixture does not saturate: the
+        // absorbed score sums `r` products where the decompressed one sums
+        // `nope`, so an aggressive amplitude would test float range, not the
+        // identity.
+        Self {
+            geometry,
+            batch,
+            q_len,
+            kv_len,
+            scale: (geometry.q_head_dim() as f32).powf(-0.5),
+            kv_b: rng.vec(h * geometry.kv_b_rows_per_head() * r, 0.5),
+            ckv: rng.vec(batch * kv_len * r, 0.5),
+            kpe: rng.vec(batch * kv_len * p, 0.5),
+            q_nope: rng.vec(batch * h * q_len * nope, 0.5),
+            q_pe: rng.vec(batch * h * q_len * p, 0.5),
+        }
+    }
+
+    /// `kv_b_proj` as `[H*(qk_nope+v), kv_lora_rank]` in `dt`.
+    pub fn kv_b_array(&self, dt: i32) -> UniquePtr<MlxArray> {
+        let rows = (self.geometry.num_heads * self.geometry.kv_b_rows_per_head()) as i32;
+        let a = ffi::from_slice_f32(&self.kv_b, &[rows, self.geometry.kv_lora_rank as i32]);
+        ffi::astype(&a, dt)
+    }
+
+    /// `ckv` as `[B, 1, kv_len, kv_lora_rank]` in `dt`, the cache's key slot.
+    pub fn ckv_array(&self, dt: i32) -> UniquePtr<MlxArray> {
+        let a = ffi::from_slice_f32(
+            &self.ckv,
+            &[
+                self.batch as i32,
+                1,
+                self.kv_len as i32,
+                self.geometry.kv_lora_rank as i32,
+            ],
+        );
+        ffi::astype(&a, dt)
+    }
+
+    /// `kpe` as `[B, 1, kv_len, qk_rope_head_dim]` in `dt`, the value slot.
+    pub fn kpe_array(&self, dt: i32) -> UniquePtr<MlxArray> {
+        let a = ffi::from_slice_f32(
+            &self.kpe,
+            &[
+                self.batch as i32,
+                1,
+                self.kv_len as i32,
+                self.geometry.qk_rope_head_dim as i32,
+            ],
+        );
+        ffi::astype(&a, dt)
+    }
+
+    /// `q_nope` as `[B, H, q_len, qk_nope_head_dim]` in `dt`.
+    pub fn q_nope_array(&self, dt: i32) -> UniquePtr<MlxArray> {
+        let a = ffi::from_slice_f32(
+            &self.q_nope,
+            &[
+                self.batch as i32,
+                self.geometry.num_heads as i32,
+                self.q_len as i32,
+                self.geometry.qk_nope_head_dim as i32,
+            ],
+        );
+        ffi::astype(&a, dt)
+    }
+
+    /// `q_pe` as `[B, H, q_len, qk_rope_head_dim]` in `dt`.
+    pub fn q_pe_array(&self, dt: i32) -> UniquePtr<MlxArray> {
+        let a = ffi::from_slice_f32(
+            &self.q_pe,
+            &[
+                self.batch as i32,
+                self.geometry.num_heads as i32,
+                self.q_len as i32,
+                self.geometry.qk_rope_head_dim as i32,
+            ],
+        );
+        ffi::astype(&a, dt)
+    }
+
+    /// The pre-absorption answer, computed on the host in f64.
+    ///
+    /// Up-projects the latent into per-head K and V exactly as
+    /// `deepseek_v2::MLAAttention::forward` does today, concatenates the rope
+    /// stream into every head, and runs dense attention. Returns
+    /// `[B, H, q_len, v_head_dim]` flattened row-major.
+    ///
+    /// `causal` applies the prefill mask, where query `l` sees cache rows
+    /// `0 ..= kv_len - q_len + l`.
+    pub fn decompressed_reference(&self, causal: bool) -> Vec<f32> {
+        let h = self.geometry.num_heads;
+        let r = self.geometry.kv_lora_rank;
+        let nope = self.geometry.qk_nope_head_dim;
+        let p = self.geometry.qk_rope_head_dim;
+        let v = self.geometry.v_head_dim;
+        let rows = self.geometry.kv_b_rows_per_head();
+        let scale = self.scale as f64;
+        let mut out = vec![0.0f32; self.batch * h * self.q_len * v];
+
+        for b in 0..self.batch {
+            for head in 0..h {
+                // Up-project this head's K_nope and V from the latent.
+                let mut k_nope = vec![0.0f64; self.kv_len * nope];
+                let mut val = vec![0.0f64; self.kv_len * v];
+                for t in 0..self.kv_len {
+                    let c = &self.ckv[(b * self.kv_len + t) * r..][..r];
+                    for d in 0..nope {
+                        let w = &self.kv_b[(head * rows + d) * r..][..r];
+                        k_nope[t * nope + d] =
+                            (0..r).map(|i| w[i] as f64 * c[i] as f64).sum::<f64>();
+                    }
+                    for e in 0..v {
+                        let w = &self.kv_b[(head * rows + nope + e) * r..][..r];
+                        val[t * v + e] = (0..r).map(|i| w[i] as f64 * c[i] as f64).sum::<f64>();
+                    }
+                }
+
+                for l in 0..self.q_len {
+                    let qn = &self.q_nope[((b * h + head) * self.q_len + l) * nope..][..nope];
+                    let qp = &self.q_pe[((b * h + head) * self.q_len + l) * p..][..p];
+                    let visible = if causal {
+                        self.kv_len - self.q_len + l + 1
+                    } else {
+                        self.kv_len
+                    };
+
+                    let mut scores = vec![f64::NEG_INFINITY; self.kv_len];
+                    for (t, score) in scores.iter_mut().enumerate().take(visible) {
+                        let nope_dot: f64 =
+                            (0..nope).map(|d| qn[d] as f64 * k_nope[t * nope + d]).sum();
+                        let kp = &self.kpe[(b * self.kv_len + t) * p..][..p];
+                        let pe_dot: f64 = (0..p).map(|d| qp[d] as f64 * kp[d] as f64).sum();
+                        *score = scale * (nope_dot + pe_dot);
+                    }
+
+                    let m = scores.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+                    let exps: Vec<f64> = scores.iter().map(|s| (s - m).exp()).collect();
+                    let denom: f64 = exps.iter().sum();
+                    for e in 0..v {
+                        let acc: f64 = (0..visible).map(|t| exps[t] * val[t * v + e]).sum();
+                        out[((b * h + head) * self.q_len + l) * v + e] = (acc / denom) as f32;
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Additive causal mask `[1, 1, q_len, kv_len]` matching
+    /// [`Self::decompressed_reference`]`(true)`.
+    pub fn causal_mask(&self, dt: i32) -> UniquePtr<MlxArray> {
+        let mut data = vec![0.0f32; self.q_len * self.kv_len];
+        for l in 0..self.q_len {
+            let visible = self.kv_len - self.q_len + l + 1;
+            for (t, cell) in data[l * self.kv_len..(l + 1) * self.kv_len]
+                .iter_mut()
+                .enumerate()
+            {
+                if t >= visible {
+                    *cell = f32::NEG_INFINITY;
+                }
+            }
+        }
+        let a = ffi::from_slice_f32(&data, &[1, 1, self.q_len as i32, self.kv_len as i32]);
+        ffi::astype(&a, dt)
+    }
+}
+
+/// A small geometry with every dimension distinct, so a transposed or swapped
+/// operand cannot pass by coincidence.
+pub const TINY: MlaGeometry = MlaGeometry {
+    num_heads: 4,
+    kv_lora_rank: 32,
+    qk_nope_head_dim: 16,
+    qk_rope_head_dim: 8,
+    v_head_dim: 12,
+};

--- a/src/models/deepseek_v2.rs
+++ b/src/models/deepseek_v2.rs
@@ -439,10 +439,12 @@ impl MLAAttention {
         // because the KV cache mode is a runtime flag; the answer is stable for
         // the life of a cache, so a run that declines on step one declines on
         // every step and the cache never mixes the two layouts.
-        if let Some(proj) = self.absorbed.as_ref() {
-            if MlaLatentCache::supports(cache, self.geometry()).is_ok() {
-                return self.forward_absorbed(&q_nope, &q_pe, ckv, k_pe, proj, cache, mask, b, l);
-            }
+        if let Some(proj) = self
+            .absorbed
+            .as_ref()
+            .filter(|_| MlaLatentCache::supports(cache, self.geometry()).is_ok())
+        {
+            return self.forward_absorbed(&q_nope, &q_pe, ckv, k_pe, proj, cache, mask, b, l);
         }
         mla::stats::record(MlaDecodePath::Decompressed);
 

--- a/src/models/deepseek_v2.rs
+++ b/src/models/deepseek_v2.rs
@@ -25,6 +25,9 @@
 use crate::models::switch_layers::validate_expert_quantization_params;
 use mlxcel_core::generate::LanguageModel;
 use mlxcel_core::layers::{KVCache, RMSNorm, UnifiedEmbedding, UnifiedLinear};
+use mlxcel_core::mla::{
+    self, MlaAbsorbedProjections, MlaDecodePath, MlaGeometry, MlaLatentCache, MlaSplitPlan,
+};
 use mlxcel_core::utils::{repeat_kv, silu, slice_axis};
 use mlxcel_core::weights::WeightMap;
 use mlxcel_core::{MlxArray, UniquePtr, concatenate};
@@ -366,9 +369,33 @@ struct MLAAttention {
     scale: f32,
 
     rope: YarnRoPE,
+
+    /// `kv_b_proj` folded into the query and output paths (issue #907).
+    ///
+    /// `Some` only when `MLXCEL_MLA_ABSORBED` is on and the fold succeeded. The
+    /// original `kv_b_proj` above stays loaded either way: prefill up-projects
+    /// through it so the absorbed prefill is the same arithmetic on the same
+    /// quantized weight the decompressed path uses, which keeps prefill parity
+    /// exact and leaves the fold responsible only for decode.
+    absorbed: Option<MlaAbsorbedProjections>,
+
+    /// Why the fold was declined, if it was, so the loader can say so once
+    /// instead of the operator inferring it from a flag that did nothing.
+    absorb_note: Option<String>,
 }
 
 impl MLAAttention {
+    /// This layer's MLA shape.
+    fn geometry(&self) -> MlaGeometry {
+        MlaGeometry {
+            num_heads: self.num_heads,
+            kv_lora_rank: self.kv_lora_rank,
+            qk_nope_head_dim: self.qk_nope_head_dim,
+            qk_rope_head_dim: self.qk_rope_head_dim,
+            v_head_dim: self.v_head_dim,
+        }
+    }
+
     fn forward(
         &self,
         x: &MlxArray,
@@ -404,9 +431,23 @@ impl MLAAttention {
         let k_pe = mlxcel_core::reshape(&k_pe, &[b, l, 1, self.qk_rope_head_dim as i32]);
         let k_pe = mlxcel_core::transpose_axes(&k_pe, &[0, 2, 1, 3]);
 
+        // The compressed latent, before any up-projection.
+        let ckv = self.kv_a_layernorm.forward(&compressed);
+
+        // Absorbed path (issue #907): cache `(ckv, kpe)` instead of the
+        // decompressed per-head K/V. Declined per cache rather than per model
+        // because the KV cache mode is a runtime flag; the answer is stable for
+        // the life of a cache, so a run that declines on step one declines on
+        // every step and the cache never mixes the two layouts.
+        if let Some(proj) = self.absorbed.as_ref() {
+            if MlaLatentCache::supports(cache, self.geometry()).is_ok() {
+                return self.forward_absorbed(&q_nope, &q_pe, ckv, k_pe, proj, cache, mask, b, l);
+            }
+        }
+        mla::stats::record(MlaDecodePath::Decompressed);
+
         // Decompress KV
-        let kv = self.kv_a_layernorm.forward(&compressed);
-        let kv = self.kv_b_proj.forward(&kv);
+        let kv = self.kv_b_proj.forward(&ckv);
         let kv = mlxcel_core::reshape(&kv, &[b, l, self.num_heads as i32, -1]);
         let kv = mlxcel_core::transpose_axes(&kv, &[0, 2, 1, 3]);
 
@@ -444,6 +485,93 @@ impl MLAAttention {
         let output = mlxcel_core::transpose_axes(&output, &[0, 2, 1, 3]);
         let output = mlxcel_core::reshape(&output, &[b, l, -1]);
 
+        self.o_proj.forward(&output)
+    }
+
+    /// Attention over the compressed-latent cache (issue #907).
+    ///
+    /// Decode runs absorbed, directly against the latent. Prefill up-projects
+    /// the whole live latent window through the still-loaded `kv_b_proj` and
+    /// runs the same dense SDPA the decompressed path runs, which is what keeps
+    /// prefill numerically identical to the baseline. The cost of that choice
+    /// is that a chunked prefill re-up-projects the rows it already
+    /// up-projected on the previous chunk; absorption is scoped as a decode win
+    /// and this is where the scope is paid for.
+    #[allow(clippy::too_many_arguments)]
+    fn forward_absorbed(
+        &self,
+        q_nope: &MlxArray,
+        q_pe: &MlxArray,
+        ckv: UniquePtr<MlxArray>,
+        k_pe: UniquePtr<MlxArray>,
+        proj: &MlaAbsorbedProjections,
+        cache: &mut KVCache,
+        mask: Option<&MlxArray>,
+        b: i32,
+        l: i32,
+    ) -> UniquePtr<MlxArray> {
+        let geometry = self.geometry();
+        // Rope position is the pre-update live length, exactly as above.
+        let offset = cache.seq_len();
+        let q_pe = self.rope.forward(q_pe, offset);
+        let k_pe = self.rope.forward(&k_pe, offset);
+
+        // [B, L, kv_lora_rank] -> [B, 1, L, kv_lora_rank]: one latent "head".
+        let ckv = mlxcel_core::expand_dims(&ckv, 1);
+
+        let mut view = MlaLatentCache::wrap(cache, geometry)
+            .expect("supports() was checked immediately before this wrap");
+        let (ckv_all, kpe_all) = view.update_and_fetch(ckv, k_pe);
+        let kv_len = view.seq_len();
+
+        let output = if l == 1 {
+            // Stage 2 first when asked for, Stage 1 otherwise. A split plan that
+            // declines falls through to Stage 1 rather than failing the step.
+            let split = if mla::split_kv_enabled() {
+                let plan = MlaSplitPlan::heuristic(
+                    b.max(0) as usize,
+                    self.num_heads,
+                    kv_len,
+                    mlxcel_core::paged_v2::device_target_ctas(),
+                );
+                mla::absorbed_decode_split_kv(
+                    q_nope, &q_pe, &ckv_all, &kpe_all, proj, self.scale, &plan,
+                )
+                .ok()
+            } else {
+                None
+            };
+            split.unwrap_or_else(|| {
+                // Decode sees the whole cache, so no mask, matching the
+                // `causal_attention` call the decompressed path makes here.
+                mla::absorbed_decode(q_nope, &q_pe, &ckv_all, &kpe_all, proj, self.scale, None)
+            })
+        } else {
+            mla::stats::record(MlaDecodePath::AbsorbedPrefill);
+            // Up-project the live latent window back into per-head K and V.
+            // `kv_b_proj` wants `[B, S, kv_lora_rank]`, the shape before the
+            // latent head axis was added.
+            let ckv_2d = mlxcel_core::reshape(&ckv_all, &[b, kv_len, self.kv_lora_rank as i32]);
+            let kv = self.kv_b_proj.forward(&ckv_2d);
+            let kv = mlxcel_core::reshape(&kv, &[b, kv_len, self.num_heads as i32, -1]);
+            let kv = mlxcel_core::transpose_axes(&kv, &[0, 2, 1, 3]);
+            let k_nope = slice_axis(&kv, -1, 0, self.qk_nope_head_dim as i32);
+            let values = slice_axis(&kv, -1, self.qk_nope_head_dim as i32, -1);
+
+            let keys = concatenate(&k_nope, &repeat_kv(&kpe_all, self.num_heads as i32), -1);
+            let queries = concatenate(q_nope, &q_pe, -1);
+            // Same mask policy as the decompressed path above, deliberately:
+            // this change must not alter which steps are causal.
+            let mask_ptr = mask.map(|m| m as *const _).unwrap_or(std::ptr::null());
+            unsafe {
+                mlxcel_core::layers::attention_from_ptr(
+                    &queries, &keys, &values, self.scale, mask_ptr, 0.0, 0,
+                )
+            }
+        };
+
+        let output = mlxcel_core::transpose_axes(&output, &[0, 2, 1, 3]);
+        let output = mlxcel_core::reshape(&output, &[b, l, -1]);
         self.o_proj.forward(&output)
     }
 }
@@ -735,12 +863,56 @@ impl DeepSeekV2Model {
             None
         };
 
+        report_absorption(&layers, args);
+
         Ok(Self {
             embed_tokens,
             layers,
             norm,
             lm_head,
         })
+    }
+}
+
+/// State the absorbed-decode decision on stdout, once per load.
+///
+/// Silent unless `MLXCEL_MLA_ABSORBED` is set, so the default path prints
+/// nothing. When it is set, this is the only place that says whether the fold
+/// actually took: `tracing` would not do, because the `mlxcel` CLI installs no
+/// subscriber and a `tracing::info!` from this path emits nothing at any
+/// `RUST_LOG`. A run whose flag is on but whose output says `0/27 layers` is
+/// visibly running the fallback, which is how issue #899's silent null is
+/// avoided here.
+fn report_absorption(layers: &[DecoderLayer], args: &ModelArgs) {
+    if !mla::absorbed_enabled() {
+        return;
+    }
+    let total = layers.len();
+    let folded = layers
+        .iter()
+        .filter(|l| l.self_attn.absorbed.is_some())
+        .count();
+    let geometry = MlaGeometry {
+        num_heads: args.num_attention_heads,
+        kv_lora_rank: args.kv_lora_rank,
+        qk_nope_head_dim: args.qk_nope_head_dim,
+        qk_rope_head_dim: args.qk_rope_head_dim,
+        v_head_dim: args.v_head_dim,
+    };
+    let before = mla::decompressed_bytes_per_token(&geometry, 2);
+    let after = mla::latent_bytes_per_token(&geometry, 2);
+    println!(
+        "mla: absorbed decode folded {folded}/{total} layers; KV cache {before} -> {after} \
+         bytes/token/layer ({:.1}x), split-kv={}",
+        before as f64 / after.max(1) as f64,
+        mla::split_kv_enabled()
+    );
+    if folded != total {
+        let reason = layers
+            .iter()
+            .find_map(|l| l.self_attn.absorb_note.as_deref())
+            .unwrap_or("no reason recorded");
+        println!("mla: absorption declined, keeping the decompressed path: {reason}");
     }
 }
 
@@ -840,6 +1012,27 @@ fn load_mla_attention(
         scale *= ms * ms;
     }
 
+    let kv_b_proj =
+        UnifiedLinear::from_weights(weights, &format!("{}.kv_b_proj", prefix), group_size, bits)?;
+
+    // Fold `kv_b_proj` for absorbed decode (issue #907). Only under the flag,
+    // so an unset environment does no dequantization and allocates nothing.
+    let geometry = MlaGeometry {
+        num_heads: args.num_attention_heads,
+        kv_lora_rank: args.kv_lora_rank,
+        qk_nope_head_dim: args.qk_nope_head_dim,
+        qk_rope_head_dim: args.qk_rope_head_dim,
+        v_head_dim: args.v_head_dim,
+    };
+    let (absorbed, absorb_note) = if mla::absorbed_enabled() {
+        match MlaAbsorbedProjections::from_kv_b_proj(&kv_b_proj, geometry) {
+            Ok(proj) => (Some(proj), None),
+            Err(reason) => (None, Some(reason)),
+        }
+    } else {
+        (None, None)
+    };
+
     Ok(MLAAttention {
         q_proj,
         q_a_proj,
@@ -855,23 +1048,20 @@ fn load_mla_attention(
             get_weight_copy(weights, &format!("{}.kv_a_layernorm.weight", prefix))?,
             1e-6,
         ),
-        kv_b_proj: UnifiedLinear::from_weights(
-            weights,
-            &format!("{}.kv_b_proj", prefix),
-            group_size,
-            bits,
-        )?,
+        kv_b_proj,
+        absorbed,
+        absorb_note,
         o_proj: UnifiedLinear::from_weights(
             weights,
             &format!("{}.o_proj", prefix),
             group_size,
             bits,
         )?,
-        num_heads: args.num_attention_heads,
-        kv_lora_rank: args.kv_lora_rank,
-        qk_nope_head_dim: args.qk_nope_head_dim,
-        qk_rope_head_dim: args.qk_rope_head_dim,
-        v_head_dim: args.v_head_dim,
+        num_heads: geometry.num_heads,
+        kv_lora_rank: geometry.kv_lora_rank,
+        qk_nope_head_dim: geometry.qk_nope_head_dim,
+        qk_rope_head_dim: geometry.qk_rope_head_dim,
+        v_head_dim: geometry.v_head_dim,
         q_head_dim,
         scale,
         rope: YarnRoPE::new(

--- a/src/models/deepseek_v2_tests.rs
+++ b/src/models/deepseek_v2_tests.rs
@@ -95,3 +95,196 @@ fn deepseek_v2_switch_linear_rejects_quantization_params_that_would_abort_gather
         Err(e) => panic!("a non-quantized expert plane must load with an unset pair: {e}"),
     }
 }
+
+// Absorbed MLA decode wiring (issue #907).
+//
+// The parity gate the issue asks for is that `MLXCEL_MLA_ABSORBED=1` changes
+// the cache layout and the decode graph but not the numbers. Proving that on a
+// real DeepSeek checkpoint is not possible here (no MLA checkpoint fits the
+// development host), so this drives the family's own `MLAAttention::forward`
+// on synthetic weights: same weights, same inputs, one attention with the fold
+// and one without, compared through the full block including `o_proj`.
+//
+// The flag itself cannot be toggled inside one process (`absorbed_enabled` is a
+// `OnceLock`), so the test sets the folded field directly. That is the same
+// state the loader produces when the flag is on, and it is reachable because
+// this test module is compiled inside `deepseek_v2`.
+
+use super::{KVCache, MLAAttention, ModelArgs, load_mla_attention};
+use mlxcel_core::mla::{MlaAbsorbedProjections, MlaGeometry};
+use mlxcel_core::{MlxArray, UniquePtr};
+
+const HIDDEN: usize = 64;
+const ATTN_PREFIX: &str = "model.layers.0.self_attn";
+
+fn mla_test_args() -> ModelArgs {
+    // Small but with every head dimension distinct, so a swapped operand cannot
+    // pass by coincidence.
+    serde_json::from_str(
+        r#"{
+            "model_type": "deepseek_v2",
+            "hidden_size": 64,
+            "num_attention_heads": 4,
+            "num_hidden_layers": 1,
+            "kv_lora_rank": 32,
+            "qk_nope_head_dim": 16,
+            "qk_rope_head_dim": 8,
+            "v_head_dim": 12,
+            "rope_theta": 10000.0
+        }"#,
+    )
+    .expect("mla test args")
+}
+
+fn xorshift(state: &mut u64, n: usize, amplitude: f32) -> Vec<f32> {
+    (0..n)
+        .map(|_| {
+            *state ^= *state << 13;
+            *state ^= *state >> 7;
+            *state ^= *state << 17;
+            let unit = ((*state >> 40) as f32) / (1u32 << 24) as f32;
+            (unit * 2.0 - 1.0) * amplitude
+        })
+        .collect()
+}
+
+fn mla_test_weights(args: &ModelArgs, seed: u64) -> WeightMap {
+    let mut state = seed | 1;
+    let mut weights = WeightMap::new();
+    let h = args.num_attention_heads as i32;
+    let q_head_dim = args.q_head_dim() as i32;
+    let hidden = HIDDEN as i32;
+    let mut put = |name: &str, shape: &[i32], amplitude: f32| {
+        let n: usize = shape.iter().map(|d| *d as usize).product();
+        weights.insert(
+            format!("{ATTN_PREFIX}.{name}"),
+            mlxcel_core::from_slice_f32(&xorshift(&mut state, n, amplitude), shape),
+        );
+    };
+    put("q_proj.weight", &[h * q_head_dim, hidden], 0.2);
+    put(
+        "kv_a_proj_with_mqa.weight",
+        &[(args.kv_lora_rank + args.qk_rope_head_dim) as i32, hidden],
+        0.2,
+    );
+    put("kv_a_layernorm.weight", &[args.kv_lora_rank as i32], 1.0);
+    put(
+        "kv_b_proj.weight",
+        &[
+            h * (args.qk_nope_head_dim + args.v_head_dim) as i32,
+            args.kv_lora_rank as i32,
+        ],
+        0.2,
+    );
+    put("o_proj.weight", &[hidden, h * args.v_head_dim as i32], 0.2);
+    weights
+}
+
+fn to_vec_f32(a: &MlxArray) -> Vec<f32> {
+    let f = mlxcel_core::astype(a, mlxcel_core::dtype::FLOAT32);
+    mlxcel_core::eval(&f);
+    mlxcel_core::array_to_raw_bytes(&f)
+        .chunks_exact(4)
+        .map(|c| f32::from_ne_bytes(c.try_into().unwrap()))
+        .collect()
+}
+
+/// Prefill `prompt` tokens then decode `steps` single tokens, returning every
+/// step's block output so a divergence at any step is caught, not just the last.
+fn run_block(attn: &MLAAttention, hidden_states: &[UniquePtr<MlxArray>]) -> Vec<Vec<f32>> {
+    let mut cache = KVCache::new();
+    hidden_states
+        .iter()
+        .map(|x| to_vec_f32(&attn.forward(x, None, &mut cache)))
+        .collect()
+}
+
+#[test]
+fn absorbed_mla_attention_matches_the_decompressed_block_step_for_step() {
+    let args = mla_test_args();
+    let weights = mla_test_weights(&args, 0x907);
+    let geometry = MlaGeometry {
+        num_heads: args.num_attention_heads,
+        kv_lora_rank: args.kv_lora_rank,
+        qk_nope_head_dim: args.qk_nope_head_dim,
+        qk_rope_head_dim: args.qk_rope_head_dim,
+        v_head_dim: args.v_head_dim,
+    };
+
+    let baseline = load_mla_attention(&weights, &args, ATTN_PREFIX).expect("load baseline");
+    assert!(
+        baseline.absorbed.is_none(),
+        "the loader must not fold when MLXCEL_MLA_ABSORBED is unset"
+    );
+
+    let mut absorbed = load_mla_attention(&weights, &args, ATTN_PREFIX).expect("load absorbed");
+    absorbed.absorbed =
+        Some(MlaAbsorbedProjections::from_kv_b_proj(&absorbed.kv_b_proj, geometry).expect("fold"));
+
+    // A 6-token prefill followed by 4 decode steps, so the test covers the
+    // cache-append boundary and the rope offsets, not just one isolated call.
+    let mut state = 0xABCDu64;
+    let mut inputs = Vec::new();
+    inputs.push(mlxcel_core::from_slice_f32(
+        &xorshift(&mut state, 6 * HIDDEN, 0.5),
+        &[1, 6, HIDDEN as i32],
+    ));
+    for _ in 0..4 {
+        inputs.push(mlxcel_core::from_slice_f32(
+            &xorshift(&mut state, HIDDEN, 0.5),
+            &[1, 1, HIDDEN as i32],
+        ));
+    }
+
+    let want = run_block(&baseline, &inputs);
+    let got = run_block(&absorbed, &inputs);
+    assert_eq!(want.len(), got.len());
+
+    for (step, (w, g)) in want.iter().zip(&got).enumerate() {
+        let scale = w.iter().fold(0.0f32, |acc, v| acc.max(v.abs())).max(1e-6);
+        let err = w
+            .iter()
+            .zip(g)
+            .fold(0.0f32, |acc, (a, b)| acc.max((a - b).abs() / scale));
+        // f32 fixtures, so the only difference is the accumulation order of the
+        // two mathematically identical contractions.
+        assert!(err < 1e-4, "step {step} drifted by {err}");
+    }
+}
+
+#[test]
+fn absorbed_attention_leaves_a_much_smaller_cache_behind() {
+    // The point of the change, measured on the family's own cache rather than
+    // asserted from the arithmetic in `mla::cache`.
+    let args = mla_test_args();
+    let weights = mla_test_weights(&args, 0x908);
+    let geometry = MlaGeometry {
+        num_heads: args.num_attention_heads,
+        kv_lora_rank: args.kv_lora_rank,
+        qk_nope_head_dim: args.qk_nope_head_dim,
+        qk_rope_head_dim: args.qk_rope_head_dim,
+        v_head_dim: args.v_head_dim,
+    };
+    let baseline = load_mla_attention(&weights, &args, ATTN_PREFIX).unwrap();
+    let mut absorbed = load_mla_attention(&weights, &args, ATTN_PREFIX).unwrap();
+    absorbed.absorbed =
+        Some(MlaAbsorbedProjections::from_kv_b_proj(&absorbed.kv_b_proj, geometry).unwrap());
+
+    let x = mlxcel_core::from_slice_f32(&vec![0.1f32; 32 * HIDDEN], &[1, 32, HIDDEN as i32]);
+
+    let mut base_cache = KVCache::new();
+    let _ = baseline.forward(&x, None, &mut base_cache);
+    base_cache.eval_state();
+
+    let mut latent_cache = KVCache::new();
+    let _ = absorbed.forward(&x, None, &mut latent_cache);
+    latent_cache.eval_state();
+
+    // 4 heads * (24 key + 12 value) = 144 elements vs 32 + 8 = 40.
+    assert!(
+        base_cache.nbytes() > latent_cache.nbytes() * 3,
+        "decompressed cache {} bytes vs latent {} bytes; absorption did not take",
+        base_cache.nbytes(),
+        latent_cache.nbytes()
+    );
+}


### PR DESCRIPTION
## Summary

Adds `mlxcel_core::mla`, a shared matrix-absorbed MLA implementation over a compressed-latent KV cache, and wires `deepseek_v2` onto it behind `MLXCEL_MLA_ABSORBED` (default off). Stage 1 (cache format plus absorbed decode from composed MLX ops) and Stage 2 (split-KV reusing issue #898's merge kernel unchanged) both land here; Stage 2's partial producer is composed from MLX ops, not a fused kernel, and is not a speed path.

## A correction to the issue's premise, up front

The issue says the MLA families cache the decompressed K/V. That is true for `deepseek_v2`, `minicpm3`, and `dots1`. It is **not** true for `deepseek_v3` and `deepseek_v32`: both have carried matrix absorption since before this work, decomposing `kv_b_proj` into `embed_q` / `unembed_out` in `sanitize_weights` and caching `(kv_latent, k_pe)` with the rope score passed to SDPA as an additive mask. So the actual gap was V2, MiniCPM3, and dots1, plus the fact that the transform existed twice with no shared home. This PR builds that shared home and moves V2 onto it. V3/V3.2 are untouched (converging them is a follow-up with real regression risk that deserves its own PR), and MiniCPM3/dots1 are untouched and still decompressed.

## What changed

- `src/lib/mlxcel-core/src/mla/absorb.rs`: load-time fold of `kv_b_proj` into `W_UK [1, H, qk_nope, r]` for the query path and `W_UV^T [1, H, r, v_head]` for the output path. Dequantizes when quantized (including the NVFP4 `global_scale` sidecar, folded as a scalar since `(x @ W^T) * s2 == x @ (W * s2)^T`), refuses a biased layer because the identity has no term for a bias, and refuses a geometry that does not partition the matrix. Nothing on disk is touched.
- `src/lib/mlxcel-core/src/mla/cache.rs`: `MlaLatentCache`, a checked view over `KVCache` that puts `ckv` in the key slot and `kpe` in the value slot. `supports()` is split out of `wrap()` so a caller can fall back (the borrow checker keeps the `&mut` alive through the `Err` arm of a `Result` carrying that borrow's lifetime, which would otherwise make the fallback unexpressible). Also the `latent_bytes_per_token` / `decompressed_bytes_per_token` accounting the KV-memory table is computed from.
- `src/lib/mlxcel-core/src/mla/decode.rs`: Stage 1. `SDPA(q_absorbed, ckv, ckv, scale, mask = scale * q_pe @ kpe^T + causal)`. The rope half of the score is additive in exactly SDPA's mask position, so the identity is exact and MLX's fused attention kernel still does the softmax and the value accumulation. Same shape `deepseek_v3.rs` already uses.
- `src/lib/mlxcel-core/src/mla/split_kv.rs`: Stage 2. `MlaSplitPlan` cuts the latent range; each chunk produces a normalized partial and its log2 LSE; `paged_attention_merge_states` merges them.
- `src/lib/mlxcel-core/src/mla/stats.rs`: per-path call counters and a `path=count` summary.
- `src/models/deepseek_v2.rs`: `MLAAttention` gains an optional fold and a `forward_absorbed` branch; `load_mla_attention` builds the fold only under the flag; `report_absorption` prints the load-time decision.
- `examples/mla_absorbed_decode_bench.rs`: three-arm decode benchmark plus the KV-memory table.
- `docs/mla-absorbed-decode.md`, indexed from `docs/README.md`, plus both variables in `docs/environment-variables.md`.

## Why the cache is a view over `KVCache` and not a new type

`LanguageModel::make_caches` returns `Vec<KVCache>` and `forward` takes `&mut [KVCache]`, so a genuinely new cache type forces the family into the `ModelOwnedSequenceState` escape hatch the SSM hybrids use, which costs `supports_batching`, the paged decode backend, and the generic prompt-cache donation path. The FP16 update path already stores keys and values as independent `[B, H, L, D]` buffers reading each side's head dim from its own shape, so a 512-wide "key" beside a 64-wide "value" is already expressible. `offset`, `live_start`, `trim`, `trim_front`, `nbytes`, and `can_trim_prompt_cache` therefore keep their existing meanings on latent rows, and the slot assignment matches what `deepseek_v3.rs` has always done so both describe the same buffer.

## How #898's merge kernel is reused, and whether its contract held

Reused verbatim. No change to `paged_attention_v2_merge.cpp`, to `paged_attention_v2.h`, to the `ffi::paged_attention_merge_states` signature, or to the C++ launcher. MLA fits the documented contract as `H = num_heads`, `D = kv_lora_rank`, `M = batch`, `N = batch * chunks`, and `o_indptr` request-major. The contract held unchanged; the only thing the new caller had to honour rather than discover is the **log2 LSE** clause, which is the one that fails silently: a natural-log LSE still merges and returns a plausible wrong weighted average. It is a named constant (`split_kv::LOG2_E`) with a comment, and `merge_rejects_natural_log_lse_units` is a negative control that asserts the natural-log variant does *not* match a host f64 reference while the log2 variant does. `split_kv_matches_the_decompressed_reference_at_every_chunk_length` restates, at the MLA caller, the regrouping property `paged_v2::launch_tests::merge_is_associative_across_regroupings` pins for the kernel.

## Verified vs unverified

**Verified, on synthetic tensors with MLA geometry against a host-side f64 reference that performs the pre-absorption computation:** the absorption identity in f32 and f16; that the additive causal mask survives being merged into the rope score (with a positive control asserting the mask actually changes the answer, so the masked test cannot pass on a no-op); the up-projection direction of the fold; the `(ckv, kpe)` packing round-tripping through a real `KVCache` including the append boundary; that a latent cache stays trimmable so speculative decode's reject path removes one latent row per token; the split-and-merge decomposition at four chunk lengths and against the unsplit Stage 1 answer; the log2 LSE negative control; and, through `deepseek_v2`'s own `MLAAttention::forward`, that a 6-token prefill plus 4 decode steps produce the same block output (through `o_proj`) with and without the fold, step for step, and that the resulting cache is more than 3x smaller.

**Not verified:** anything against a real MLA checkpoint. No DeepSeek-family checkpoint is available on this host (the locally available models are Llama-3.1-8B, Llama-3.2-1B, Qwen2.5-0.5B, Qwen3-0.6B, and gemma-3-1b, none of them MLA, and a DeepSeek-V3-class checkpoint does not fit in 128 GB). So the issue's token-parity gate on pinned DeepSeek oracles is **not** satisfied by this PR, and the flag stays default-off for exactly that reason. Nothing here should be read as real-model validation.

**No benchmarks were run.** The harness is written and smoke-tested for correctness on a toy geometry only; all throughput numbers are for the reviewer to produce.

## CUDA

No CUDA was written in this PR, so there is no new unvalidated CUDA to declare. Stage 2 reuses #898's merge kernel, which already ships a structurally parallel CUDA port that #898 declared unvalidated; that status is unchanged. The issue asked for a fused MLA partial kernel with CUDA first, and that is deliberately not in this PR: a fused partial kernel is the thing that would make Stage 2 faster, and it should be written after Stage 1's measurements justify it (as the issue itself scopes it) and against a host that can validate at least one of the two backends. The interactions the issue lists are unaffected: `kv_a_layernorm` is untouched, so the CUDA RMSNorm overlay (#829) sits where it sat; nothing here assumes CUDA graph replay.

## How to run the benchmark, and how to prove which path it took

```
export DEVELOPER_DIR=/Applications/Xcode-26.6.0.app/Contents/Developer
cargo run --release --features metal,accelerate --example mla_absorbed_decode_bench -- \
    --contexts 4096,16384,32768 --batches 1,4 --steps 64 --warmup 16
```

Three arms per (context, batch): `decompressed`, `absorbed`, `split_kv`. Every row ends in a `paths=` field read from `mlxcel_core::mla::stats`, taken and reset around the measured region, and the harness prints a `WARNING` on any row whose counters disagree with its arm's label. A correct run looks like `decompressed=64 absorbed_prefill=0 absorbed_composed=0 absorbed_split_kv=0` on the first arm and `... absorbed_composed=64 ...` on the second; an "absorbed" row reading `absorbed_composed=0` is measuring the fallback and must not be reported. `split_kv` is expected to be slower than `absorbed` here, because its partials are composed from MLX ops rather than fused; that arm exists to show the decomposition running, not to be quoted.

For a real checkpoint, `MLXCEL_MLA_ABSORBED=1 mlxcel generate -m models/<deepseek> ...` prints one stdout line at load stating how many layers folded and the bytes/token before and after. A run whose line reads `0/N layers` is running the fallback. Both signals go to stdout rather than through `tracing` because the `mlxcel` CLI installs no tracing subscriber, so `tracing::info!` on this path emits nothing at any `RUST_LOG`.

## Test plan

- [x] `cargo test --release -p mlxcel-core --lib --features metal,accelerate mla::` — 33 passed, 0 failed
- [x] `cargo test --release -p mlxcel-core --lib --features metal,accelerate paged_v2::` — 55 passed, 0 failed (the reused merge kernel and its regrouping property)
- [x] `cargo test --release --lib --features metal,accelerate models::deepseek` — 32 passed, 0 failed (V2 wiring parity plus the untouched V3 / V3.2 suites)
- [x] `cargo clippy -p mlxcel-core --lib --tests --features metal,accelerate -- -D warnings` — clean
- [x] `cargo clippy --lib --tests --example mla_absorbed_decode_bench --features metal,accelerate -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `python3 scripts/ci/check_cross_repo_refs.py` — exit 0
- [x] Benchmark harness smoke-run on a toy geometry: all three arms execute and each reports its own path

The full `cargo test -p mlxcel-core` sweep was not run: it exceeds this environment's watchdog. Its known pre-existing failure on this base commit is `fused_moe_parity_tests::fused_moe_geglu_kernel_matches_references_gemma4_shape` (tracked as #964), untouched here.

## Left out, deliberately

Fused Stage 2 partial kernel (Metal and CUDA). MiniCPM3 and dots1 wiring. Converging `deepseek_v3` / `deepseek_v32` onto the shared module. Absorbed prefill (prefill up-projects through the still-loaded `kv_b_proj`, which keeps prefill arithmetic identical to the baseline but makes a chunked prefill re-up-project rows it already handled). Paged-backed and non-FP16 latent caches, both declined with a message. Any default-on change: the flag stays off until real-checkpoint token parity exists.

Closes #907
