### PR TITLE
fix(tests): honor CARGO_TARGET_DIR and clap's singular alias label

### DIFF
--- a/tests/cli_help_consistency.rs
+++ b/tests/cli_help_consistency.rs
@@ -40,7 +40,7 @@
 use std::process::Command;
 
 mod common;
-use common::repo_binary_path;
+use common::{binary_resolution_report, repo_binary_path};
 
 const HEADING: &str = "KV Cache (TurboQuant) Options";
 
@@ -95,9 +95,12 @@ fn help_output(bin_name: &str, args: &[&str]) -> String {
     for key in ENV_TO_CLEAR_FOR_HELP {
         cmd.env_remove(key);
     }
-    let output = cmd
-        .output()
-        .unwrap_or_else(|e| panic!("failed to spawn {} from {:?}: {e}", bin_name, path));
+    let output = cmd.output().unwrap_or_else(|e| {
+        panic!(
+            "failed to spawn {bin_name} from {path:?}: {e}\n{}",
+            binary_resolution_report(bin_name)
+        )
+    });
     assert!(
         output.status.success(),
         "{} {:?} exited with status {:?}: stderr=\n{}",
@@ -358,9 +361,12 @@ fn help_output_for_speculative(bin_name: &str, args: &[&str]) -> String {
     for key in SPECULATIVE_ENV_TO_CLEAR_FOR_HELP {
         cmd.env_remove(key);
     }
-    let output = cmd
-        .output()
-        .unwrap_or_else(|e| panic!("failed to spawn {} from {:?}: {e}", bin_name, path));
+    let output = cmd.output().unwrap_or_else(|e| {
+        panic!(
+            "failed to spawn {bin_name} from {path:?}: {e}\n{}",
+            binary_resolution_report(bin_name)
+        )
+    });
     assert!(
         output.status.success(),
         "{} {:?} exited with status {:?}: stderr=\n{}",
@@ -467,28 +473,232 @@ fn speculative_flag_signatures_match_across_binaries() {
 // discovers the alternate spelling without reading the source. Unit tests
 // in `src/main_tests.rs` and `src/bin/mlx_server.rs` cover that the
 // aliases resolve to the identical parsed value.
+
+/// Leading-space count of a help line.
+fn indent_width(line: &str) -> usize {
+    line.len() - line.trim_start_matches(' ').len()
+}
+
+/// Slice the `--help` entry clap rendered for `flag_signature`: the signature
+/// line plus every following line indented deeper than it, which is the
+/// flag's description and its bracketed annotations. Stops before the next
+/// flag entry (same or shallower indent) and before the next section heading.
+///
+/// Scoping to one entry matters: the prose on `--draft-model` names the
+/// alternate spelling in its own description, so a whole-help substring search
+/// for the alias name would pass even with the `visible_alias` removed.
+fn flag_help_entry<'a>(help: &'a str, flag_signature: &str) -> Option<&'a str> {
+    let mut offset = 0usize;
+    let mut entry_start = None;
+    for line in help.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        // clap renders long-only flags as `      --flag <VALUE>` and flags
+        // carrying a short form as `  -s, --flag <VALUE>`; accept both.
+        let starts_entry = trimmed.starts_with(flag_signature)
+            || trimmed.split_once(", ").is_some_and(|(short, rest)| {
+                short.starts_with('-') && rest.starts_with(flag_signature)
+            });
+        if starts_entry {
+            entry_start = Some(offset);
+            break;
+        }
+        offset += line.len();
+    }
+    let start = entry_start?;
+    let rest = &help[start..];
+
+    let mut lines = rest.split_inclusive('\n');
+    let signature_line = lines.next()?;
+    let signature_indent = indent_width(signature_line);
+
+    let mut consumed = signature_line.len();
+    let mut body_indent: Option<usize> = None;
+    for line in lines {
+        if line.trim().is_empty() {
+            consumed += line.len();
+            continue;
+        }
+        let indent = indent_width(line);
+        match body_indent {
+            // The first non-blank line fixes the body indent. A line no
+            // deeper than the signature means this flag has no body at all.
+            None if indent <= signature_indent => break,
+            None => body_indent = Some(indent),
+            Some(body) if indent < body => break,
+            Some(_) => {}
+        }
+        consumed += line.len();
+    }
+    Some(&rest[..consumed])
+}
+
+/// Alias names clap documented for one flag entry, parsed out of its
+/// `[alias: ...]` / `[aliases: ...]` annotation.
+///
+/// Both labels are accepted because the label is not part of the contract:
+/// `clap_builder` renders `[alias: ...]` for exactly one visible alias and
+/// `[aliases: ...]` for two or more (the `pluralize` call in its help
+/// template, added in 4.6.2). Pinning the singular literal instead would
+/// break again the moment a second alias is added to any of these flags.
+/// What the contract needs is the alias NAME, and that it is carried by a
+/// real clap alias annotation rather than by prose.
+fn documented_aliases(entry: &str) -> Vec<String> {
+    for label in ["[aliases: ", "[alias: "] {
+        let Some(start) = entry.find(label) else {
+            continue;
+        };
+        let inner_start = start + label.len();
+        let Some(len) = entry[inner_start..].find(']') else {
+            continue;
+        };
+        return entry[inner_start..inner_start + len]
+            .split(',')
+            // The annotation wraps across lines when it is long, so collapse
+            // whitespace rather than trimming spaces only.
+            .map(|alias| alias.split_whitespace().collect::<Vec<_>>().join(" "))
+            .filter(|alias| !alias.is_empty())
+            .collect();
+    }
+    Vec::new()
+}
+
+/// Assert one binary's `--help` documents `alias` as a clap alias of the flag
+/// rendered as `flag_signature`.
+fn assert_flag_documents_alias(label: &str, help: &str, flag_signature: &str, alias: &str) {
+    let entry = flag_help_entry(help, flag_signature).unwrap_or_else(|| {
+        panic!("{label} --help has no flag entry for {flag_signature:?}.\nHelp was:\n{help}")
+    });
+    let aliases = documented_aliases(entry);
+    assert!(
+        aliases.iter().any(|documented| documented == alias),
+        "{label} --help must document {flag_signature:?} with a {alias:?} alias (issue #464). \
+         The alias annotation clap rendered for that flag listed {aliases:?}.\n\
+         Entry was:\n{entry}"
+    );
+}
+
 #[test]
 fn drafter_flag_aliases_are_documented_on_both_binaries() {
     let serve_help = help_output("mlxcel", &["serve", "--help"]);
     let server_help = help_output("mlxcel-server", &["--help"]);
 
-    assert!(
-        serve_help.contains("--draft-model <PATH>")
-            && serve_help.contains("[aliases: --model-draft]"),
-        "mlxcel serve --help must document --draft-model with a --model-draft alias.\nHelp was:\n{serve_help}"
+    assert_flag_documents_alias(
+        "mlxcel serve",
+        &serve_help,
+        "--draft-model <PATH>",
+        "--model-draft",
     );
-    assert!(
-        serve_help.contains("--draft-max <DRAFT_MAX>") && serve_help.contains("[aliases: --draft]"),
-        "mlxcel serve --help must document --draft-max with a --draft alias.\nHelp was:\n{serve_help}"
+    assert_flag_documents_alias(
+        "mlxcel serve",
+        &serve_help,
+        "--draft-max <DRAFT_MAX>",
+        "--draft",
     );
 
+    assert_flag_documents_alias(
+        "mlxcel-server",
+        &server_help,
+        "--model-draft <PATH>",
+        "--draft-model",
+    );
+    assert_flag_documents_alias(
+        "mlxcel-server",
+        &server_help,
+        "--draft <DRAFT>",
+        "--draft-max",
+    );
+}
+
+/// Guard for the guard: the alias assertion above must reject an entry whose
+/// clap alias annotation is missing, even when the alias name still appears
+/// in that flag's prose. `--draft-model`'s real help does exactly that, so a
+/// whole-help substring search would not catch a dropped `visible_alias`.
+#[test]
+fn documented_aliases_ignores_alias_names_that_only_appear_in_prose() {
+    let without_annotation = "      --draft-model <PATH>\n          \
+        Accepts the mlx-lm-style `--draft-model` spelling (primary) and the \
+        llama-server-style `--model-draft` spelling.\n\n          [default: none]\n";
     assert!(
-        server_help.contains("--model-draft <PATH>")
-            && server_help.contains("[aliases: --draft-model]"),
-        "mlxcel-server --help must document --model-draft with a --draft-model alias.\nHelp was:\n{server_help}"
+        documented_aliases(without_annotation).is_empty(),
+        "prose mentioning an alias must not count as a documented alias"
+    );
+
+    let singular =
+        "      --draft-max <DRAFT_MAX>\n          Max draft tokens\n\n          [alias: --draft]\n";
+    assert_eq!(documented_aliases(singular), vec!["--draft".to_string()]);
+
+    let plural = "      --draft-max <DRAFT_MAX>\n          Max draft tokens\n\n          [aliases: --draft, --n-draft]\n";
+    assert_eq!(
+        documented_aliases(plural),
+        vec!["--draft".to_string(), "--n-draft".to_string()]
+    );
+}
+
+/// Mutation check on the real help text: dropping a `visible_alias` from the
+/// CLI removes exactly one rendered `[alias: ...]` / `[aliases: ...]`
+/// annotation, so cut that annotation out of the live `mlxcel serve --help`
+/// and confirm the alias is then undocumented. Answers "would a build that
+/// dropped one of the four aliases still fail?" against real output, without
+/// rebuilding the CLI with the attribute removed.
+///
+/// `--draft-model` is the interesting case: its own description names
+/// `--model-draft` in prose, so this also shows the prose alone does not
+/// satisfy the contract.
+#[test]
+fn removing_the_rendered_alias_annotation_leaves_the_alias_undocumented() {
+    let serve_help = help_output("mlxcel", &["serve", "--help"]);
+    let entry = flag_help_entry(&serve_help, "--draft-model <PATH>")
+        .expect("mlxcel serve --help has no --draft-model entry");
+    assert_eq!(
+        documented_aliases(entry),
+        vec!["--model-draft".to_string()],
+        "precondition: the live help must document exactly the one alias"
+    );
+
+    let annotation_start = entry
+        .find("[alias")
+        .expect("precondition: the entry carries an alias annotation");
+    let annotation_end = annotation_start
+        + entry[annotation_start..]
+            .find(']')
+            .expect("alias annotation is unterminated")
+        + 1;
+    let without_annotation = format!("{}{}", &entry[..annotation_start], &entry[annotation_end..]);
+
+    assert!(
+        without_annotation.contains("--model-draft"),
+        "precondition: the alias name still appears in the flag's prose"
     );
     assert!(
-        server_help.contains("--draft <DRAFT>") && server_help.contains("[aliases: --draft-max]"),
-        "mlxcel-server --help must document --draft with a --draft-max alias.\nHelp was:\n{server_help}"
+        documented_aliases(&without_annotation).is_empty(),
+        "a dropped visible_alias must leave the alias undocumented, but the \
+         assertion still found: {:?}",
+        documented_aliases(&without_annotation)
+    );
+}
+
+/// The entry slicer must not spill into the neighbouring flag: an alias
+/// annotation on the *next* flag must never satisfy the assertion for this
+/// one.
+#[test]
+fn flag_help_entry_stops_at_the_next_flag() {
+    let help = "Options:\n      \
+        --draft-model <PATH>\n          Path to drafter checkpoint\n\n      \
+        --draft-max <DRAFT_MAX>\n          Max draft tokens\n\n          [alias: --draft]\n\n\
+        Other Options:\n      --unrelated\n";
+
+    let entry = flag_help_entry(help, "--draft-model <PATH>").expect("entry not found");
+    assert!(entry.contains("Path to drafter checkpoint"));
+    assert!(
+        !entry.contains("--draft-max"),
+        "entry leaked into the next flag:\n{entry}"
+    );
+    assert!(documented_aliases(entry).is_empty());
+
+    let entry = flag_help_entry(help, "--draft-max <DRAFT_MAX>").expect("entry not found");
+    assert_eq!(documented_aliases(entry), vec!["--draft".to_string()]);
+    assert!(
+        !entry.contains("Other Options:"),
+        "entry leaked into the next section:\n{entry}"
     );
 }

--- a/tests/cli_help_consistency.rs
+++ b/tests/cli_help_consistency.rs
@@ -615,6 +615,34 @@ fn cli_binaries_resolve_to_the_path_cargo_built_them_at() {
     }
 }
 
+/// Coverage for the other candidate `binary_path_candidates` produces: a
+/// binary the compile-time match arm does not name by hand must still
+/// resolve, derived from this test binary's own `deps/` location rather than
+/// a `CARGO_BIN_EXE_*` constant. `speculative_bench` is the live example, a
+/// real fourth `[[bin]]` target in `Cargo.toml` that no `CARGO_BIN_EXE_*` case
+/// names and that no other integration test spawns, so nothing else in the
+/// suite exercises this branch, including the `deps`-parent layout check
+/// added alongside it.
+#[test]
+fn resolve_repo_binary_derives_the_path_for_a_binary_the_compile_time_case_does_not_name() {
+    let (resolved, report) = resolve_repo_binary("speculative_bench");
+
+    // Same profile directory the compile-time candidates live in, just a
+    // name `binary_path_candidates` does not special-case.
+    let profile_dir = Path::new(env!("CARGO_BIN_EXE_mlxcel"))
+        .parent()
+        .expect("CARGO_BIN_EXE_mlxcel has a parent directory");
+    assert_eq!(
+        resolved,
+        profile_dir.join("speculative_bench"),
+        "speculative_bench must resolve next to the binaries CARGO_BIN_EXE_* names.\n{report}"
+    );
+    assert!(
+        resolved.exists(),
+        "speculative_bench was not built.\n{report}"
+    );
+}
+
 #[test]
 fn drafter_flag_aliases_are_documented_on_both_binaries() {
     let serve_help = help_output("mlxcel", &["serve", "--help"]);

--- a/tests/cli_help_consistency.rs
+++ b/tests/cli_help_consistency.rs
@@ -37,10 +37,11 @@
 //! When a future flag or mode is added to either shared group, all three
 //! binaries fail the test together, no drift is possible.
 
+use std::path::Path;
 use std::process::Command;
 
 mod common;
-use common::{binary_resolution_report, repo_binary_path};
+use common::resolve_repo_binary;
 
 const HEADING: &str = "KV Cache (TurboQuant) Options";
 
@@ -89,18 +90,15 @@ const ENV_TO_CLEAR_FOR_HELP: &[&str] = &["LLAMA_ARG_CACHE_TYPE_K", "LLAMA_ARG_CA
 /// Run `--help` on a binary and return the resulting stdout. Panics with a
 /// descriptive message when the binary fails to execute.
 fn help_output(bin_name: &str, args: &[&str]) -> String {
-    let path = repo_binary_path(bin_name);
+    let (path, resolution) = resolve_repo_binary(bin_name);
     let mut cmd = Command::new(&path);
     cmd.args(args);
     for key in ENV_TO_CLEAR_FOR_HELP {
         cmd.env_remove(key);
     }
-    let output = cmd.output().unwrap_or_else(|e| {
-        panic!(
-            "failed to spawn {bin_name} from {path:?}: {e}\n{}",
-            binary_resolution_report(bin_name)
-        )
-    });
+    let output = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn {bin_name} from {path:?}: {e}\n{resolution}"));
     assert!(
         output.status.success(),
         "{} {:?} exited with status {:?}: stderr=\n{}",
@@ -355,18 +353,15 @@ fn extract_speculative_block(help: &str) -> &str {
 /// Run `--help` on a binary with the speculative env vars cleared and
 /// return stdout.
 fn help_output_for_speculative(bin_name: &str, args: &[&str]) -> String {
-    let path = repo_binary_path(bin_name);
+    let (path, resolution) = resolve_repo_binary(bin_name);
     let mut cmd = Command::new(&path);
     cmd.args(args);
     for key in SPECULATIVE_ENV_TO_CLEAR_FOR_HELP {
         cmd.env_remove(key);
     }
-    let output = cmd.output().unwrap_or_else(|e| {
-        panic!(
-            "failed to spawn {bin_name} from {path:?}: {e}\n{}",
-            binary_resolution_report(bin_name)
-        )
-    });
+    let output = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn {bin_name} from {path:?}: {e}\n{resolution}"));
     assert!(
         output.status.success(),
         "{} {:?} exited with status {:?}: stderr=\n{}",
@@ -484,6 +479,10 @@ fn indent_width(line: &str) -> usize {
 /// flag's description and its bracketed annotations. Stops before the next
 /// flag entry (same or shallower indent) and before the next section heading.
 ///
+/// `flag_signature` must be the complete rendered signature including the
+/// value name, for example `--draft-model <PATH>`, because the anchor line is
+/// matched in full.
+///
 /// Scoping to one entry matters: the prose on `--draft-model` names the
 /// alternate spelling in its own description, so a whole-help substring search
 /// for the alias name would pass even with the `visible_alias` removed.
@@ -491,12 +490,17 @@ fn flag_help_entry<'a>(help: &'a str, flag_signature: &str) -> Option<&'a str> {
     let mut offset = 0usize;
     let mut entry_start = None;
     for line in help.split_inclusive('\n') {
-        let trimmed = line.trim_start();
-        // clap renders long-only flags as `      --flag <VALUE>` and flags
-        // carrying a short form as `  -s, --flag <VALUE>`; accept both.
-        let starts_entry = trimmed.starts_with(flag_signature)
+        let trimmed = line.trim();
+        // clap's long help puts the signature alone on its line, as
+        // `      --flag <VALUE>` for a long-only flag or `  -s, --flag <VALUE>`
+        // for one carrying a short form. Match the whole line rather than a
+        // prefix: `--metrics` is a prefix of the separate `--metrics-port
+        // <PORT>` entry, and a description line that merely mentions the flag
+        // would otherwise anchor the slice on prose. A short form is always
+        // exactly two characters, which rules out a hyphen-bulleted line.
+        let starts_entry = trimmed == flag_signature
             || trimmed.split_once(", ").is_some_and(|(short, rest)| {
-                short.starts_with('-') && rest.starts_with(flag_signature)
+                short.len() == 2 && short.starts_with('-') && rest == flag_signature
             });
         if starts_entry {
             entry_start = Some(offset);
@@ -535,6 +539,12 @@ fn flag_help_entry<'a>(help: &'a str, flag_signature: &str) -> Option<&'a str> {
 /// Alias names clap documented for one flag entry, parsed out of its
 /// `[alias: ...]` / `[aliases: ...]` annotation.
 ///
+/// The annotation must START a line, which is how clap renders it (on its own
+/// line at the description indent). A bare substring search would also accept
+/// a bracketed span someone wrote by hand inside a doc comment, and the help
+/// output already contains such spans on other flags, so the anchor is what
+/// keeps a prose `[alias: --foo]` from silently satisfying the contract.
+///
 /// Both labels are accepted because the label is not part of the contract:
 /// `clap_builder` renders `[alias: ...]` for exactly one visible alias and
 /// `[aliases: ...]` for two or more (the `pluralize` call in its help
@@ -543,21 +553,27 @@ fn flag_help_entry<'a>(help: &'a str, flag_signature: &str) -> Option<&'a str> {
 /// What the contract needs is the alias NAME, and that it is carried by a
 /// real clap alias annotation rather than by prose.
 fn documented_aliases(entry: &str) -> Vec<String> {
-    for label in ["[aliases: ", "[alias: "] {
-        let Some(start) = entry.find(label) else {
-            continue;
-        };
-        let inner_start = start + label.len();
-        let Some(len) = entry[inner_start..].find(']') else {
-            continue;
-        };
-        return entry[inner_start..inner_start + len]
-            .split(',')
-            // The annotation wraps across lines when it is long, so collapse
-            // whitespace rather than trimming spaces only.
-            .map(|alias| alias.split_whitespace().collect::<Vec<_>>().join(" "))
-            .filter(|alias| !alias.is_empty())
-            .collect();
+    let mut offset = 0usize;
+    for line in entry.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        let trimmed_offset = offset + (line.len() - trimmed.len());
+        offset += line.len();
+        for label in ["[aliases: ", "[alias: "] {
+            if !trimmed.starts_with(label) {
+                continue;
+            }
+            let inner_start = trimmed_offset + label.len();
+            let Some(len) = entry[inner_start..].find(']') else {
+                continue;
+            };
+            return entry[inner_start..inner_start + len]
+                .split(',')
+                // The annotation wraps across lines when it is long, so
+                // collapse whitespace rather than trimming spaces only.
+                .map(|alias| alias.split_whitespace().collect::<Vec<_>>().join(" "))
+                .filter(|alias| !alias.is_empty())
+                .collect();
+        }
     }
     Vec::new()
 }
@@ -575,6 +591,28 @@ fn assert_flag_documents_alias(label: &str, help: &str, flag_signature: &str, al
          The alias annotation clap rendered for that flag listed {aliases:?}.\n\
          Entry was:\n{entry}"
     );
+}
+
+/// Regression test for the defect that actually took the nightly down: the
+/// CLI binaries must be resolved from the path cargo built them at, never from
+/// a `<manifest>/target/<profile>/` reconstruction. `CARGO_BIN_EXE_*` accounts
+/// for `CARGO_TARGET_DIR`, the profile name, and the target triple, so this
+/// holds for a plain run, for the nightly's external target directory, for
+/// `--profile test-fast`, and for a cross build (issue #962).
+#[test]
+fn cli_binaries_resolve_to_the_path_cargo_built_them_at() {
+    for (name, built_by_cargo) in [
+        ("mlxcel", env!("CARGO_BIN_EXE_mlxcel")),
+        ("mlxcel-server", env!("CARGO_BIN_EXE_mlxcel-server")),
+    ] {
+        let (resolved, report) = resolve_repo_binary(name);
+        assert_eq!(
+            resolved,
+            Path::new(built_by_cargo),
+            "{name} must resolve to the binary cargo built, not a reconstructed path.\n{report}"
+        );
+        assert!(resolved.exists(), "{name} was not built.\n{report}");
+    }
 }
 
 #[test]
@@ -632,6 +670,25 @@ fn documented_aliases_ignores_alias_names_that_only_appear_in_prose() {
         documented_aliases(plural),
         vec!["--draft".to_string(), "--n-draft".to_string()]
     );
+
+    // A bracketed span written by hand mid-sentence must not count either.
+    // The real help already carries prose brackets on other flags (for
+    // example `[llama-server alias for --prefill-chunk-size]`), so an
+    // unanchored substring search would let a doc comment satisfy the
+    // contract with no `visible_alias` attribute behind it.
+    let inline_prose =
+        "      --draft-max <DRAFT_MAX>\n          Max draft tokens [alias: --draft] per step\n";
+    assert!(
+        documented_aliases(inline_prose).is_empty(),
+        "a bracketed span inside prose must not count as a clap alias annotation"
+    );
+
+    // The annotation still parses when clap wraps it across lines.
+    let wrapped = "      --draft-max <DRAFT_MAX>\n          Max draft tokens\n\n          [aliases: --draft,\n           --n-draft]\n";
+    assert_eq!(
+        documented_aliases(wrapped),
+        vec!["--draft".to_string(), "--n-draft".to_string()]
+    );
 }
 
 /// Mutation check on the real help text: dropping a `visible_alias` from the
@@ -665,15 +722,21 @@ fn removing_the_rendered_alias_annotation_leaves_the_alias_undocumented() {
         + 1;
     let without_annotation = format!("{}{}", &entry[..annotation_start], &entry[annotation_end..]);
 
+    // Splice the mutated entry back into the full help so the whole
+    // resolution path runs, not just the annotation parser.
+    let mutated_help = serve_help.replace(entry, &without_annotation);
+    let mutated_entry = flag_help_entry(&mutated_help, "--draft-model <PATH>")
+        .expect("the flag entry itself must survive the mutation");
+
     assert!(
-        without_annotation.contains("--model-draft"),
+        mutated_entry.contains("--model-draft"),
         "precondition: the alias name still appears in the flag's prose"
     );
     assert!(
-        documented_aliases(&without_annotation).is_empty(),
+        documented_aliases(mutated_entry).is_empty(),
         "a dropped visible_alias must leave the alias undocumented, but the \
-         assertion still found: {:?}",
-        documented_aliases(&without_annotation)
+         assertion still found: {:?}\nEntry was:\n{mutated_entry}",
+        documented_aliases(mutated_entry)
     );
 }
 
@@ -701,4 +764,32 @@ fn flag_help_entry_stops_at_the_next_flag() {
         !entry.contains("Other Options:"),
         "entry leaked into the next section:\n{entry}"
     );
+
+    // A signature that is only a prefix of a real entry must not resolve to
+    // it. `--draft` is a prefix of `--draft-max <DRAFT_MAX>`, and in the live
+    // help `--metrics` is a prefix of the separate `--metrics-port <PORT>`.
+    assert!(
+        flag_help_entry(help, "--draft").is_none(),
+        "a prefix of another flag's signature must not match its entry"
+    );
+}
+
+/// A hyphen-bulleted description line must not be mistaken for a flag entry.
+/// The short-form branch of the matcher accepts `-s, --flag <VALUE>`, and
+/// without the two-character constraint a bullet such as `- foo, --draft-max
+/// <DRAFT_MAX> ...` would anchor the entry on prose and pick up whatever
+/// followed it.
+#[test]
+fn flag_help_entry_ignores_hyphen_bulleted_prose() {
+    let help = "Options:\n      \
+        --other <VALUE>\n          Describes something:\n          \
+        - see also, --draft-max <DRAFT_MAX> for the token budget\n\n      \
+        --draft-max <DRAFT_MAX>\n          Max draft tokens\n\n          [alias: --draft]\n";
+
+    let entry = flag_help_entry(help, "--draft-max <DRAFT_MAX>").expect("entry not found");
+    assert!(
+        entry.starts_with("      --draft-max <DRAFT_MAX>"),
+        "matcher anchored on a prose bullet instead of the flag entry:\n{entry}"
+    );
+    assert_eq!(documented_aliases(entry), vec!["--draft".to_string()]);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[allow(dead_code)]
 pub fn repo_model_dir(name: &str) -> PathBuf {
@@ -19,20 +19,118 @@ pub fn repo_model_dir(name: &str) -> PathBuf {
     primary
 }
 
-#[allow(dead_code)]
-pub fn repo_binary_path(name: &str) -> PathBuf {
-    let env_key = format!("CARGO_BIN_EXE_{name}");
-    if let Some(path) = std::env::var_os(&env_key) {
-        return PathBuf::from(path);
+/// Candidate locations for one of the crate's binaries, most authoritative
+/// first. Each entry carries a short label naming where the path came from so
+/// a failure can be diagnosed from the panic message alone.
+///
+/// The list exists because `<manifest>/target/<profile>/<name>` is not where
+/// the binaries live whenever `CARGO_TARGET_DIR` is set. Both `release.yml`
+/// and `nightly-verify.yml` set it to `$HOME/.cargo-target/mlxcel` so the
+/// self-hosted runner keeps a warm build cache outside the checkout, which is
+/// how every test in `tests/cli_help_consistency.rs` came to fail on CI with
+/// `No such file or directory` while passing locally (see issue #962).
+fn binary_path_candidates(name: &str) -> Vec<(&'static str, PathBuf)> {
+    let mut candidates: Vec<(&'static str, PathBuf)> = Vec::new();
+
+    // 1. Runtime override. Cargo never sets this at test runtime, so it only
+    //    fires when a harness or an operator points the tests at a
+    //    pre-built binary on purpose.
+    if let Some(path) = std::env::var_os(format!("CARGO_BIN_EXE_{name}")) {
+        candidates.push(("CARGO_BIN_EXE_* (runtime env)", PathBuf::from(path)));
     }
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // 2. The compile-time path cargo hands every integration test target. It
+    //    already accounts for the profile, the target triple, and
+    //    `CARGO_TARGET_DIR`, so it needs no reconstruction and cannot drift.
+    let compile_time: Option<&'static str> = match name {
+        "mlxcel" => Some(env!("CARGO_BIN_EXE_mlxcel")),
+        "mlxcel-server" => Some(env!("CARGO_BIN_EXE_mlxcel-server")),
+        "mlxcel-bench-decode" => Some(env!("CARGO_BIN_EXE_mlxcel-bench-decode")),
+        _ => None,
+    };
+    if let Some(path) = compile_time {
+        candidates.push(("CARGO_BIN_EXE_* (compile time)", PathBuf::from(path)));
+    }
+
+    // 3. Derived from this test binary's own location. Integration tests are
+    //    linked into `<target-dir>/[<triple>/]<profile>/deps/`, so the profile
+    //    directory holding the package binaries is two levels up. This covers
+    //    binaries not named above without hardcoding a target directory.
+    let derived_profile_dir = std::env::current_exe().ok().and_then(|test_exe| {
+        test_exe
+            .parent()
+            .and_then(|deps| deps.parent())
+            .map(Path::to_path_buf)
+    });
+    if let Some(profile_dir) = derived_profile_dir {
+        candidates.push(("derived from current_exe()", profile_dir.join(name)));
+    }
+
+    // 4. Last resort: reconstruct from `CARGO_TARGET_DIR` when set, else from
+    //    the manifest directory. Kept so a stripped-down invocation still has
+    //    something to try, not relied on by the paths above.
+    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target"));
     let profile = if cfg!(debug_assertions) {
         "debug"
     } else {
         "release"
     };
-    manifest_dir.join("target").join(profile).join(name)
+    candidates.push((
+        "reconstructed from CARGO_TARGET_DIR / CARGO_MANIFEST_DIR",
+        target_dir.join(profile).join(name),
+    ));
+
+    candidates
+}
+
+/// Resolve the path to one of the crate's binaries for an integration test.
+///
+/// Returns the first candidate from [`binary_path_candidates`] that exists on
+/// disk, falling back to the most authoritative candidate when none do. The
+/// caller-visible behaviour of returning a path unconditionally is preserved
+/// so the existing `if !binary.exists() { skip }` guards in the real-model
+/// integration tests keep working; [`binary_resolution_report`] supplies the
+/// diagnostics for the paths that spawn unconditionally.
+#[allow(dead_code)]
+pub fn repo_binary_path(name: &str) -> PathBuf {
+    let candidates = binary_path_candidates(name);
+    for (_, path) in &candidates {
+        if path.exists() {
+            return path.clone();
+        }
+    }
+    candidates
+        .into_iter()
+        .next()
+        .map(|(_, path)| path)
+        .unwrap_or_else(|| PathBuf::from(name))
+}
+
+/// Human-readable account of how [`repo_binary_path`] resolved `name`, for
+/// use in panic messages when spawning the binary fails. Names every
+/// candidate, whether it exists, and the target directory the reconstruction
+/// fallback derived, so a CI failure is diagnosable without reproducing the
+/// environment.
+#[allow(dead_code)]
+pub fn binary_resolution_report(name: &str) -> String {
+    let mut report = format!("binary resolution for {name:?}:\n");
+    for (source, path) in binary_path_candidates(name) {
+        let state = if path.exists() { "exists" } else { "missing" };
+        report.push_str(&format!("  [{state}] {source}: {}\n", path.display()));
+    }
+    let configured_target_dir = std::env::var_os("CARGO_TARGET_DIR").map(PathBuf::from);
+    report.push_str(&match configured_target_dir {
+        Some(dir) => format!("  CARGO_TARGET_DIR is set to {}", dir.display()),
+        None => format!(
+            "  CARGO_TARGET_DIR is unset; reconstruction assumed {}",
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("target")
+                .display()
+        ),
+    });
+    report
 }
 
 #[allow(dead_code)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 #[allow(dead_code)]
@@ -20,28 +21,36 @@ pub fn repo_model_dir(name: &str) -> PathBuf {
 }
 
 /// Candidate locations for one of the crate's binaries, most authoritative
-/// first. Each entry carries a short label naming where the path came from so
-/// a failure can be diagnosed from the panic message alone.
+/// first, each labelled with where the path came from so a failure is
+/// diagnosable from the panic message alone.
 ///
-/// The list exists because `<manifest>/target/<profile>/<name>` is not where
-/// the binaries live whenever `CARGO_TARGET_DIR` is set. Both `release.yml`
-/// and `nightly-verify.yml` set it to `$HOME/.cargo-target/mlxcel` so the
-/// self-hosted runner keeps a warm build cache outside the checkout, which is
-/// how every test in `tests/cli_help_consistency.rs` came to fail on CI with
-/// `No such file or directory` while passing locally (see issue #962).
+/// The list is deliberately short, and every entry is a signal cargo itself
+/// produces. What used to be here, `<manifest>/target/<profile>/<name>`, is
+/// gone: it is wrong whenever `CARGO_TARGET_DIR` is set, which is how every
+/// test in `tests/cli_help_consistency.rs` came to fail on CI with `No such
+/// file or directory` while passing locally (issue #962). `release.yml` and
+/// `nightly-verify.yml` both set it to `$HOME/.cargo-target/mlxcel` so the
+/// self-hosted runner keeps a warm build cache outside the checkout. It is
+/// also silently wrong under `--target`, where the binaries live under an
+/// extra triple segment it cannot know, and its `cfg!(debug_assertions)`
+/// profile guess is only a proxy for the real profile name. A candidate that
+/// can hand back a stale binary from an unrelated build is worse than no
+/// candidate at all.
+///
+/// The runtime environment is deliberately not consulted either. Cargo never
+/// sets `CARGO_BIN_EXE_*` at test runtime, so the previous `var_os` lookup was
+/// dead code, and honouring it would let a stale exported value win over the
+/// binary cargo just built, which is the same shape as the bug this ordering
+/// exists to fix.
 fn binary_path_candidates(name: &str) -> Vec<(&'static str, PathBuf)> {
     let mut candidates: Vec<(&'static str, PathBuf)> = Vec::new();
 
-    // 1. Runtime override. Cargo never sets this at test runtime, so it only
-    //    fires when a harness or an operator points the tests at a
-    //    pre-built binary on purpose.
-    if let Some(path) = std::env::var_os(format!("CARGO_BIN_EXE_{name}")) {
-        candidates.push(("CARGO_BIN_EXE_* (runtime env)", PathBuf::from(path)));
-    }
-
-    // 2. The compile-time path cargo hands every integration test target. It
+    // 1. The compile-time path cargo hands every integration test target. It
     //    already accounts for the profile, the target triple, and
-    //    `CARGO_TARGET_DIR`, so it needs no reconstruction and cannot drift.
+    //    `CARGO_TARGET_DIR`, and cargo builds the binary before running the
+    //    test, so for the binaries named here it is authoritative and needs no
+    //    reconstruction. This is the same mechanism `tests/surgery_cli.rs` and
+    //    `tests/lang_bias.rs` already use directly.
     let compile_time: Option<&'static str> = match name {
         "mlxcel" => Some(env!("CARGO_BIN_EXE_mlxcel")),
         "mlxcel-server" => Some(env!("CARGO_BIN_EXE_mlxcel-server")),
@@ -52,85 +61,91 @@ fn binary_path_candidates(name: &str) -> Vec<(&'static str, PathBuf)> {
         candidates.push(("CARGO_BIN_EXE_* (compile time)", PathBuf::from(path)));
     }
 
-    // 3. Derived from this test binary's own location. Integration tests are
-    //    linked into `<target-dir>/[<triple>/]<profile>/deps/`, so the profile
-    //    directory holding the package binaries is two levels up. This covers
-    //    binaries not named above without hardcoding a target directory.
+    // 2. Derived from this test binary's own location, covering any binary not
+    //    named above. Integration tests link into
+    //    `<target-dir>/[<triple>/]<profile>/deps/`, so the directory holding
+    //    the package binaries is two levels up. The `deps` check enforces that
+    //    layout rather than assuming it: a test binary running from a copied
+    //    location (a nextest archive, an extracted CI artifact) must not spawn
+    //    whatever sibling file happens to share the binary's name.
     let derived_profile_dir = std::env::current_exe().ok().and_then(|test_exe| {
         test_exe
             .parent()
-            .and_then(|deps| deps.parent())
+            .filter(|deps| deps.file_name() == Some(OsStr::new("deps")))
+            .and_then(Path::parent)
             .map(Path::to_path_buf)
     });
     if let Some(profile_dir) = derived_profile_dir {
         candidates.push(("derived from current_exe()", profile_dir.join(name)));
     }
 
-    // 4. Last resort: reconstruct from `CARGO_TARGET_DIR` when set, else from
-    //    the manifest directory. Kept so a stripped-down invocation still has
-    //    something to try, not relied on by the paths above.
-    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target"));
-    let profile = if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    };
-    candidates.push((
-        "reconstructed from CARGO_TARGET_DIR / CARGO_MANIFEST_DIR",
-        target_dir.join(profile).join(name),
-    ));
-
     candidates
 }
 
-/// Resolve the path to one of the crate's binaries for an integration test.
+/// Resolve one of the crate's binaries, returning both the path and a report
+/// of how it was chosen.
 ///
-/// Returns the first candidate from [`binary_path_candidates`] that exists on
-/// disk, falling back to the most authoritative candidate when none do. The
-/// caller-visible behaviour of returning a path unconditionally is preserved
-/// so the existing `if !binary.exists() { skip }` guards in the real-model
-/// integration tests keep working; [`binary_resolution_report`] supplies the
-/// diagnostics for the paths that spawn unconditionally.
+/// Both halves come from a single pass over the candidates, so the report can
+/// never contradict the choice it is explaining, and the caller stats the
+/// filesystem once rather than twice.
 #[allow(dead_code)]
-pub fn repo_binary_path(name: &str) -> PathBuf {
+pub fn resolve_repo_binary(name: &str) -> (PathBuf, String) {
     let candidates = binary_path_candidates(name);
-    for (_, path) in &candidates {
-        if path.exists() {
-            return path.clone();
-        }
-    }
-    candidates
-        .into_iter()
-        .next()
-        .map(|(_, path)| path)
-        .unwrap_or_else(|| PathBuf::from(name))
-}
+    let selected = candidates
+        .iter()
+        .position(|(_, path)| path.exists())
+        .or(if candidates.is_empty() { None } else { Some(0) });
 
-/// Human-readable account of how [`repo_binary_path`] resolved `name`, for
-/// use in panic messages when spawning the binary fails. Names every
-/// candidate, whether it exists, and the target directory the reconstruction
-/// fallback derived, so a CI failure is diagnosable without reproducing the
-/// environment.
-#[allow(dead_code)]
-pub fn binary_resolution_report(name: &str) -> String {
     let mut report = format!("binary resolution for {name:?}:\n");
-    for (source, path) in binary_path_candidates(name) {
-        let state = if path.exists() { "exists" } else { "missing" };
-        report.push_str(&format!("  [{state}] {source}: {}\n", path.display()));
+    if candidates.is_empty() {
+        report.push_str(
+            "  (no candidate: this binary is not one the helper names, and the \
+             running test binary is not inside a cargo `deps` directory)\n",
+        );
     }
-    let configured_target_dir = std::env::var_os("CARGO_TARGET_DIR").map(PathBuf::from);
-    report.push_str(&match configured_target_dir {
-        Some(dir) => format!("  CARGO_TARGET_DIR is set to {}", dir.display()),
-        None => format!(
-            "  CARGO_TARGET_DIR is unset; reconstruction assumed {}",
+    for (index, (source, path)) in candidates.iter().enumerate() {
+        let state = if path.exists() { "exists" } else { "missing" };
+        let marker = if Some(index) == selected {
+            " <- selected"
+        } else {
+            ""
+        };
+        report.push_str(&format!(
+            "  [{state}] {source}: {}{marker}\n",
+            path.display()
+        ));
+    }
+    report.push_str(&match std::env::var_os("CARGO_TARGET_DIR") {
+        Some(dir) => format!(
+            "  CARGO_TARGET_DIR is set to {}",
+            PathBuf::from(dir).display()
+        ),
+        None => "  CARGO_TARGET_DIR is unset".to_string(),
+    });
+
+    let path = selected
+        .map(|index| candidates[index].1.clone())
+        // Nothing to go on. Hand back a path that deliberately does not exist,
+        // so the caller's spawn fails with this report attached, rather than a
+        // bare name, which would be resolved through `PATH`.
+        .unwrap_or_else(|| {
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("target")
-                .display()
-        ),
-    });
-    report
+                .join(name)
+        });
+    (path, report)
+}
+
+/// Path to one of the crate's binaries.
+///
+/// Returns the first candidate that exists, and otherwise the most
+/// authoritative one. It still returns a path unconditionally, so the
+/// `if !binary.exists() { skip }` guards in the real-model integration tests
+/// keep compiling and behaving the same way. Callers that spawn without such a
+/// guard should use [`resolve_repo_binary`] and put the report in their panic.
+#[allow(dead_code)]
+pub fn repo_binary_path(name: &str) -> PathBuf {
+    resolve_repo_binary(name).0
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary

Two independent defects kept the nightly `make verify` job red. Both surface in `tests/cli_help_consistency.rs`; one of them lives in the helper that 13 integration test files share. Neither is a defect in the CLI itself, so nothing operator-facing changes.

## Defect A: the binary-path helper ignored `CARGO_TARGET_DIR`

This is the one CI actually hits, and it does not reproduce locally. `repo_binary_path` in `tests/common/mod.rs` read `CARGO_BIN_EXE_<name>` with `std::env::var_os` (a compile-time variable that is never set at test runtime, so that branch was dead) and then reconstructed `CARGO_MANIFEST_DIR/target/<profile>/<name>`. `nightly-verify.yml` and `release.yml` both set `CARGO_TARGET_DIR=$HOME/.cargo-target/mlxcel` so the self-hosted runner keeps a warm build cache outside the checkout, so cargo put the binaries there while the tests looked for them in the workspace. Every test in the file failed at the `Command::output()` call with `No such file or directory`.

Cargo does expose a better signal than reconstruction, and the rest of this test suite already uses it: `tests/surgery_cli.rs`, `tests/lang_bias.rs`, `tests/pipeline_cli_real_models.rs` and six other files call `env!("CARGO_BIN_EXE_mlxcel")` directly, `tests/surgery_cli.rs:47` even spelling out why. That compile-time variable already accounts for the profile, the target triple, and `CARGO_TARGET_DIR`, and cargo guarantees the binary is built before the integration test runs. `tests/common/mod.rs` was the outlier.

Resolution is now built from cargo-produced signals only, in this order:

1. The compile-time `env!("CARGO_BIN_EXE_<name>")` for the three binaries the tests spawn (`mlxcel`, `mlxcel-server`, `mlxcel-bench-decode`). All four bin targets are unconditional, so these cannot fail to compile.
2. A profile directory derived from `std::env::current_exe()`, for any binary not named above. Integration tests link into `<target-dir>/[<triple>/]<profile>/deps/`, so the package binaries sit two levels up. The candidate verifies the parent really is `deps` rather than assuming it, so a test binary running from a copied location cannot spawn an unrelated sibling that happens to share the name.

Two things were deliberately dropped rather than fixed. The runtime `CARGO_BIN_EXE_*` lookup is gone: cargo never sets it at test runtime, and keeping it as an override hook would let a stale exported value beat the binary cargo just built, which is the same shape as the bug this ordering exists to fix. The `<manifest>/target/<profile>/<name>` reconstruction is gone too: beyond the `CARGO_TARGET_DIR` bug, it cannot know the target triple under `--target`, and its `cfg!(debug_assertions)` profile guess is wrong for a custom profile such as `--profile test-fast` (`Makefile:236`), so it could hand back a stale binary from an unrelated build. A candidate that can be silently wrong is worse than no candidate.

`resolve_repo_binary` returns the chosen path and a diagnostic report from a single pass, marking which candidate it selected, so the report cannot contradict the choice it is explaining. Both spawn sites in the help test fold it into their panic, so the next occurrence is diagnosable from the panic alone. `repo_binary_path` keeps its signature and still returns a path unconditionally, so the `if !binary.exists() { skip }` guards in the real-model tests keep compiling and behaving as before.

One nuance worth recording rather than glossing: because the compile-time candidate is essentially always present under `cargo test`, those `exists()` guards now almost always see a real path. That is a no-op in both environments that matter, since every one of them is preceded by a `repo_model_dir(...).exists()` guard and the nightly runner carries no model weights, so the model guard fires first there and locally the binary guard already passed.

## Defect B: the alias assertion pinned a string clap no longer emits

`drafter_flag_aliases_are_documented_on_both_binaries` asserted on the literal `[aliases: X]` four times. `clap_builder` computes that label as `pluralize(als.len(), "", "es")`, so it renders `[alias: X]` for exactly one visible alias and `[aliases: ...]` only for two or more. Each of the four flags carries exactly one `visible_alias`, so all four render singular. The `pluralize` call arrived in `clap_builder` 4.6.2, which entered `Cargo.lock` on 2026-07-20 in `3ccb693a3` (#828); the test was written on 2026-07-01 in `a89f28aa4` (#602) against the older rendering. This is a dependency-bump regression, not a behavior change: both binaries still declare and still document all four aliases, so the #464 contract holds.

The fix is to the test. Adding a second alias so clap emits the plural would change the operator-facing CLI to satisfy a test string, which is the wrong direction.

### Which assertion form, and why

The replacement locates the flag's own help entry, parses the alias names out of whatever alias annotation clap rendered there, and matches on the name. Concretely, `assert_flag_documents_alias(label, help, "--draft-model <PATH>", "--model-draft")`.

The two candidate shapes named in the issue each fail on their own:

- **Accept either `[alias:` or `[aliases:` on the whole help output.** Too loose in the wrong dimension. It does not say *which* flag carries the alias, so an alias annotation anywhere in a 600-plus-line help page would satisfy it.
- **Search for the alias name near its flag.** Too loose in a way that silently un-pins the contract. `--draft-model`'s own description reads "the llama-server-style `--model-draft` spelling (alias, matches `mlxcel-server`)". The alias name is already in that entry's prose, so this assertion would pass with the `visible_alias` attribute deleted. This is exactly the failure mode the issue warns about, and it is not hypothetical for this specific flag.

Combining the two removes both problems: the alias name must appear, it must be inside a real clap alias annotation rather than prose, and that annotation must belong to the flag under assertion. What is deliberately *not* pinned is clap's `alias`/`aliases` label, which is presentation, nor the alias count, so adding a second alias to any of these flags will not break the test.

Both halves of that are anchored rather than substring-matched, because unanchored matching left two live gaps:

- The entry anchor matches the whole trimmed signature line, not a prefix. Measured on the live help, a prefix match on `--metrics` also hits the separate `--metrics-port <PORT>` entry and an example command line in `after_long_help`, and the short-form branch requires a real two-character short flag so a hyphen-bulleted description line cannot anchor the slice on prose.
- The alias annotation must begin a line, which is how clap always renders it. A bare substring search would also accept a bracketed span written by hand in a doc comment, and the help already carries such spans on other flags (`[llama-server alias for --prefill-chunk-size]`), so that gap was a live foot-gun rather than a theoretical one.

Six tests cover the machinery itself, so the guard is guarded: prose-only entries and inline prose brackets do not count, both label spellings and a wrapped annotation parse, the slicer stops at the next flag and at the next section, a prefix sibling does not resolve, a hyphen-bulleted line is not mistaken for an entry, and cutting the rendered annotation out of the live `mlxcel serve --help` leaves the alias undocumented.

Defect A also gets the regression test it never had. `cli_binaries_resolve_to_the_path_cargo_built_them_at` asserts the resolved path is the one cargo built rather than a reconstruction, which holds under `CARGO_TARGET_DIR`, a custom profile, and a cross build alike, and `resolve_repo_binary_derives_the_path_for_a_binary_the_compile_time_case_does_not_name` covers the other candidate through `speculative_bench`, the one `[[bin]]` target no `CARGO_BIN_EXE_*` case names.

## What changed

- `tests/common/mod.rs`: `binary_path_candidates` (private) feeding a new `resolve_repo_binary` that returns path plus diagnostics from one snapshot; `repo_binary_path` reduced to a thin wrapper so its 28 existing call sites are untouched.
- `tests/cli_help_consistency.rs`: both spawn panics carry the resolution report; `drafter_flag_aliases_are_documented_on_both_binaries` rewritten on new `flag_help_entry` / `documented_aliases` / `assert_flag_documents_alias` helpers; eight new tests.

## Test plan

- [x] `cargo test --release --features metal,accelerate --test cli_help_consistency`: 17 passed, 0 failed.
- [x] The same command with `CARGO_TARGET_DIR` pointed at a directory outside the checkout, matching what the nightly sets: 17 passed. The new resolution test makes this self-verifying, and the rebuilt test binary embeds `<CARGO_TARGET_DIR>/release/mlxcel` as its compile-time path.
- [x] #464 contract still pinned, demonstrated twice on real rebuilds rather than only synthetically. Removing `visible_alias = "model-draft"` from `src/main.rs:905` fails the `--draft-model <PATH>` assertion; removing `visible_alias = "draft-max"` from `src/bin/mlx_server.rs:282` fails the `--draft <DRAFT>` assertion. Both report an empty alias list next to prose that still names the alias. Sources restored afterwards.
- [x] `cargo clippy --release --all-targets --features metal,accelerate -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [x] `cargo test --release --features metal,accelerate --no-fail-fast` over the whole root package, three times.

## What the `--no-fail-fast` run surfaced

`cargo test` is fail-fast, so the nightly stopped at `cli_help_consistency` and the other integration targets never ran on CI. The point of this run was to find out what that stop had been hiding.

Nothing in this PR's family. The final run is green end to end: across 73 result lines (lib, four bin unit targets, 67 integration targets, doc-tests), **5219 passed, 0 failed, 274 ignored**, exit 0, zero compiler warnings. The lib suite is green at 4813 passed, and `cli_help_consistency` is green at 17.

One unrelated flake did turn up, and it is filed as #997 rather than folded in. `text_only_forward_produces_finite_logits` failed in `tests/granite4_vision_parity.rs:100` and `tests/hunyuan_vl_parity.rs:105` on the second of three whole-suite runs, and was green on the first and third. Run on its own, either target passes 3 out of 3 attempts. Both are real-model tests that load a checkpoint from `models/` and assert the maximum logit of a text-only forward pass is finite; neither spawns a binary, and both reach only `common::repo_model_dir`, which this PR does not touch, so the change is not a plausible cause. It does not belong here on scope either: both tests self-skip when the checkpoint directory is absent, and the nightly runner carries no model weights, so they never execute on the run this issue is about. Chasing a non-finite logit in two VLM forward paths is a different investigation from a test-harness path bug, so it gets its own issue.

## `make verify` status

- `make verify-fmt` (`cargo fmt --all -- --check`): green.
- `make verify-test` (`cargo test --release --features metal,accelerate`): green, run as the `--no-fail-fast` superset above.
- `make verify-clippy`: the CI target is `cargo clippy --all-targets --features metal,accelerate -- -D warnings`, which is the *debug* profile. This machine has no `target/debug` at all, so running it verbatim triggers a cold MLX C++ debug build. It was run in the release profile instead, clean. The lint set does not vary by profile, this PR touches only test code, and `verify-clippy` was already green on the 2026-07-31 nightly after #961, so the remaining risk is the profile substitution alone.

Closes #962
