### PR TITLE
fix(speculative): correct the draft KV cache rewind arithmetic

### DIFF
--- a/docs/speculative-acceptance.md
+++ b/docs/speculative-acceptance.md
@@ -206,26 +206,30 @@ nearly deterministic: if `q(t*) ~ 1` then `min(p(t*), q(t*)) = p(t*)` and
 `p(t*) q(t*) ~ p(t*)`, so the two rules accept at the same rate and this change
 buys nothing. The gain appears when `q` is diffuse. Measured on
 Llama-3.1-8B-Instruct-4bit with a Llama-3.2-1B-Instruct drafter, 200 tokens,
-`--num-draft-tokens 4`, one trajectory each:
+`--num-draft-tokens 4`, `--no-chat-template`, `--seed 1234`, one trajectory
+each:
 
 | Temperature | `closed_form_sum_min` | `closed_form_sum_prod` | Ratio | measured `per_position_acceptance` |
 |---|---|---|---|---|
-| 0.7 | 0.2808 | 0.2740 | 1.02x | 0.2902 |
-| 1.0 | 0.1738 | 0.1613 | 1.08x | 0.1735 |
-| 1.5 | 0.6809 | 0.0494 | 13.8x | 0.6966 |
+| 0.7 | 0.7422 | 0.5823 | 1.27x | 0.5870 |
+| 1.0 | 0.7983 | 0.6071 | 1.31x | 0.6000 |
+| 1.5 | 0.7808 | 0.0002 | very large | 0.0000 |
 
-The measured value sits on `sum_min` at every temperature, which is the
-correctness result. The *ratio* column is the throughput headroom, and on this
-pair at 0.7 there is essentially none: the 1B drafter is close to deterministic
-there. Between-trajectory variance in the agreement profile is large (two
-200-token runs at the same temperature differed by nearly 2x in `sum_min`), so
-a single short throughput run at 0.7 on this pair measures noise, not the
-change. Read `closed_form_sum_min / closed_form_sum_prod` first: it is the
-upper bound on what any throughput measurement can show.
+These runs take the default sampler-match rule, so the measured value sits on
+`sum_prod`, not on `sum_min`: `sum_min` is the ceiling the opt-in rule would
+reach, and the *ratio* column is the throughput headroom between the two. At
+0.7 and 1.0 the headroom is about 1.3x. At 1.5 both distributions are diffuse
+enough that an independent target draw essentially never lands on the drafter's
+token, so sampler-match accepts nothing at all while the coupling ceiling is
+still 0.78. That row is the shape of the argument for the opt-in rule.
 
-The temperature 1.5 row is a real measurement of the mechanism but comes from a
-degenerate high-temperature trajectory where both models agree on repetitive
-text; do not read it as a typical production number.
+Read `closed_form_sum_min / closed_form_sum_prod` before any throughput number:
+it is the upper bound on what a throughput measurement can show.
+
+These figures were re-measured after the draft-cache rewind fix (#994). The
+earlier ones on this page were taken while the draft KV cache was trimmed two
+entries too many per rejecting round, which starved the drafter and dragged
+both closed forms down along with the measured rate.
 
 ## Measuring the change
 
@@ -283,7 +287,15 @@ In `src/lib/mlxcel-core/src/speculative/`:
   tolerance: one emitted token outside a `top_k = 2` target's support fails.
 * `distribution_tests.rs::temperature_zero_stream_is_byte_identical_to_greedy_target_only`
   — zero tolerance on greedy output.
-* `distribution_tests.rs::kv_cache_length_is_exact_in_both_termination_regimes`
-  — cache rewind arithmetic, pinned in the all-reject and all-accept regimes.
+* `distribution_tests.rs::kv_cache_length_is_exact_in_both_termination_regimes`:
+  main-cache rewind arithmetic, pinned in the all-reject and all-accept regimes.
+* `distribution_tests.rs::draft_cache_tracks_the_emitted_sequence_in_every_acceptance_regime`:
+  draft-cache rewind arithmetic. Asserts `draft offset + tokens owed == main
+  offset` across the all-reject, all-accept and mixed regimes, which is the
+  statement that the drafter conditions on exactly the prefix the target does.
+* `distribution_tests.rs::a_fully_accepted_round_owes_its_last_proposal_and_the_next_round_pays_it`:
+  the one entry no trim can supply. A fully-accepted round's last proposal is
+  emitted without ever being forwarded through the draft model, so it is carried
+  in `pending_draft_context` and replayed at the head of the next round.
 * `stochastic_accept_tests.rs` — the accept rate against `min(1, p/q)`, the
   residual against `normalize(relu(p - q))`, and the `sum min(p, q)` optimum.

--- a/src/lib/mlxcel-core/src/speculative/distribution_tests.rs
+++ b/src/lib/mlxcel-core/src/speculative/distribution_tests.rs
@@ -827,70 +827,166 @@ fn closed_form_acceptance_matches_the_hand_computed_values() {
     );
 }
 
-/// Documents a **pre-existing** draft-cache defect that predates issue #902 and
-/// affects every acceptance rule identically.
+/// The draft cache must track the emitted sequence exactly, in the same
+/// deterministic regimes `kv_cache_length_is_exact_in_both_termination_regimes`
+/// pins for the main cache.
 ///
-/// The draft loop forwards `num_draft` tokens (`current_token`, `d_0`, ...,
-/// `d_{n-2}`), so the draft cache gains `n` entries per round. It should end
-/// the round holding `current_token, d_0..d_{a-1}`, that is `a + 1` new
-/// entries, so the correct trim is `n - a - 1 == rejected - 1`. The code trims
-/// `min(rejected + 1, n)`, two entries too many, and the shortfall is never
-/// recovered: for `num_draft = 4` the cache falls behind by 1, 2, 2, 2, 1
-/// tokens at `accepted` 0..4 respectively, every round, forever.
+/// The draft loop forwards `current_token, d_0, ..., d_{k-2}` for `k`
+/// proposals, one fewer new token than the verify pass, so keeping
+/// `d_0..d_{a-1}` means trimming `(k - 1) - a == rejected - 1`. When `a == k`
+/// the arithmetic runs off the other end: `d_{k-1}` was emitted but never
+/// forwarded through the draft model, and no trim can put it into the cache.
+/// It is parked in `pending_draft_context` and replayed at the head of the next
+/// round's first draft forward. The single statement covering both is
 ///
-/// At `accepted == 0` the draft cache does not advance at all. The drafter then
-/// proposes from a frozen prefix while the target advances, its proposals
-/// degrade, acceptance falls further, and the loop reinforces itself. This is
-/// the most likely explanation for observed acceptance around 0.23 on an
-/// 8B/1B pair against the 0.6-0.8 reported upstream.
+/// ```text
+/// draft cache offset + tokens owed == main cache offset
+/// ```
 ///
-/// This test pins the current, wrong behavior so the defect is visible and so
-/// whoever fixes it gets a failing test rather than silence. Fixing it is out
-/// of scope for #902: it changes token streams and belongs in its own issue.
+/// which says the drafter conditions on exactly the prefix the target does.
+/// This replaces `draft_cache_falls_behind_the_main_cache_every_round_pre_existing_defect`,
+/// which pinned the broken arithmetic (`min(rejected + 1, k)`) so a fix would
+/// surface as a failing test rather than silence. Under that trim the draft
+/// cache fell behind by 1 to 2 entries every round and never recovered; at
+/// `accepted == 0` it did not advance at all, so the drafter proposed forever
+/// from the prompt alone.
 #[test]
-fn draft_cache_falls_behind_the_main_cache_every_round_pre_existing_defect() {
-    let target = greedy_target();
-    let draft = always_rejecting_draft();
+fn draft_cache_tracks_the_emitted_sequence_in_every_acceptance_regime() {
     const PROMPT: i32 = 2;
     const N: usize = 24;
+    let target = greedy_target();
 
-    for num_draft in [1usize, 4] {
+    // Regime 1: total disagreement. Every round rejects at position 0, so
+    // `rejected == num_draft` and the draft trim runs at its largest. Nothing
+    // is ever accepted, so nothing is ever owed and the two caches must agree
+    // exactly. This is the regime the old trim froze completely.
+    for num_draft in [1usize, 3, 5] {
         let mut generator = SpeculativeGenerator::new(1, 1);
         let (tokens, _) = generator.generate(
             &target,
-            &draft,
+            &always_rejecting_draft(),
             &[PROMPT],
             N,
             num_draft,
             &SamplingConfig::greedy(),
         );
         assert_eq!(tokens.len(), N);
-
         let main_offset = generator.main_caches[0].offset;
-        let draft_offset = generator.draft_caches[0].offset;
-
-        // Every round rejects at position 0, so `accepted == 0` throughout and
-        // the draft cache never advances past the single prompt token.
-        assert_eq!(
-            draft_offset, 1,
-            "num_draft={num_draft}: draft cache should hold the prompt plus every \
-             emitted token except the pending one ({}), but it is frozen at {} \
-             because the trim is `min(rejected + 1, n)` instead of `rejected - 1`",
-            main_offset, draft_offset
-        );
         assert_eq!(
             main_offset as usize,
             1 + tokens.len() - 1,
-            "num_draft={num_draft}: the main cache does track the sequence, which is \
-             what makes the draft cache's drift a defect rather than a convention"
+            "all-reject num_draft={num_draft}: the main cache must track the \
+             sequence, otherwise there is no moving reference to compare the \
+             draft cache against"
         );
         assert!(
-            main_offset > draft_offset,
-            "the drafter is conditioning on {} tokens while the target conditions on {}",
-            draft_offset,
-            main_offset
+            generator.pending_draft_context.is_none(),
+            "all-reject num_draft={num_draft}: nothing was ever accepted, so the \
+             draft model can owe nothing"
         );
+        for (layer, cache) in generator.draft_caches.iter().enumerate() {
+            assert_eq!(
+                cache.offset, main_offset,
+                "all-reject num_draft={num_draft} layer {layer}: draft cache holds \
+                 {} entries against the target's {main_offset}. A short draft cache \
+                 degrades the drafter's proposals, which lowers acceptance, which \
+                 shortens the cache further.",
+                cache.offset
+            );
+        }
     }
+
+    // Regime 2: total agreement. Every proposal is accepted, so most rounds end
+    // with `d_{k-1}` emitted but never forwarded through the draft model. That
+    // entry cannot be trimmed into place, so the debt is what closes the gap.
+    // Regime 3: the mixed drafter agrees on exactly one token in six, so a
+    // single run walks the accept, reject and full-accept branches repeatedly
+    // and lands on whichever terminal state `max_tokens` happens to produce.
+    for (label, draft) in [("all-accept", greedy_target()), ("mixed", mixed_draft())] {
+        for num_draft in [1usize, 2, 3, 4] {
+            let mut generator = SpeculativeGenerator::new(1, 1);
+            let (tokens, _) = generator.generate(
+                &target,
+                &draft,
+                &[PROMPT],
+                N,
+                num_draft,
+                &SamplingConfig::greedy(),
+            );
+            assert_eq!(tokens.len(), N);
+            let main_offset = generator.main_caches[0].offset;
+            let owed = i32::from(generator.pending_draft_context.is_some());
+            for (layer, cache) in generator.draft_caches.iter().enumerate() {
+                assert_eq!(
+                    cache.offset + owed,
+                    main_offset,
+                    "{label} num_draft={num_draft} layer {layer}: draft cache holds \
+                     {} entries and owes {owed}, against the target's {main_offset}. \
+                     The drafter must condition on exactly the prefix the target does.",
+                    cache.offset
+                );
+            }
+        }
+    }
+}
+
+/// The debt is a genuine one-token shortfall that trimming cannot fix, not a
+/// bookkeeping flourish: a fully-accepted round must actually record it, and
+/// the next round must actually clear it by replaying the token.
+///
+/// Without this the `+ owed` term above could be vacuously zero and the
+/// invariant test would pass on a generator that never accepts anything.
+#[test]
+fn a_fully_accepted_round_owes_its_last_proposal_and_the_next_round_pays_it() {
+    const PROMPT: i32 = 2;
+    let target = greedy_target();
+    let agreeing = greedy_target();
+
+    // The prefill emits one token and a fully-accepted `num_draft = 2` round
+    // emits three more (`d_0`, `d_1`, bonus), so a 4-token budget stops exactly
+    // at a round boundary with the debt live.
+    let mut generator = SpeculativeGenerator::new(1, 1);
+    let (tokens, _) = generator.generate(
+        &target,
+        &agreeing,
+        &[PROMPT],
+        4,
+        2,
+        &SamplingConfig::greedy(),
+    );
+    assert_eq!(tokens.len(), 4);
+    assert_eq!(
+        generator.pending_draft_context,
+        Some(tokens[tokens.len() - 2]),
+        "the last accepted proposal is the token the draft loop never forwarded, \
+         so it is the one that must be owed"
+    );
+    assert_eq!(
+        generator.draft_caches[0].offset + 1,
+        generator.main_caches[0].offset,
+        "the debt must be exactly one entry"
+    );
+
+    // Three more emitted tokens is a second full round. The first round's debt
+    // is replayed at the head of the second round's first draft forward, so the
+    // draft cache catches up to the second round's own debt instead of staying
+    // two entries behind.
+    let mut generator = SpeculativeGenerator::new(1, 1);
+    let (tokens, _) = generator.generate(
+        &target,
+        &agreeing,
+        &[PROMPT],
+        7,
+        2,
+        &SamplingConfig::greedy(),
+    );
+    assert_eq!(tokens.len(), 7);
+    assert_eq!(
+        generator.draft_caches[0].offset + 1,
+        generator.main_caches[0].offset,
+        "the second round must clear the first round's debt; a draft cache two \
+         entries behind means the replay never happened"
+    );
 }
 
 /// The **default** rule (sampler-match, the rule that shipped before #902) must

--- a/src/lib/mlxcel-core/src/speculative/mod.rs
+++ b/src/lib/mlxcel-core/src/speculative/mod.rs
@@ -33,6 +33,20 @@
 //! sampling, which preserves the target model's distribution exactly; see
 //! [`stochastic_accept`].
 //!
+//! ## Cache invariant
+//!
+//! Both models must condition on the same prefix, or the drafter proposes
+//! against a context the target has already moved past and acceptance decays.
+//! At every round boundary the main and draft KV caches therefore hold the
+//! prompt plus every emitted token except the pending `current_token`, which
+//! the next round forwards itself. The two caches rewind by different amounts
+//! to get there: the verify pass forwards one token more than the draft loop
+//! does, so on a round that rejects, the draft trim is one *less* than the main
+//! trim. The one entry that cannot be reached by trimming at all is the last
+//! proposal on a fully-accepted round, which the draft loop never forwarded;
+//! it is carried in [`SpeculativeGenerator::pending_draft_context`] and
+//! replayed at the head of the next round's first draft forward.
+//!
 //! ## Sibling modules
 //!
 //! - [`mtp`] — Multi-Token Prediction (MTP) round-loop generator for the
@@ -233,6 +247,23 @@ pub struct SpeculativeGenerator {
     /// collapses. See [`Self::compose_target_sampling`] and
     /// [`Self::draft_sampling`] — only the former injects the cached bias.
     token_bias: TokenBiasMap,
+    /// The one emitted token the draft model's KV cache does not hold yet.
+    ///
+    /// A round's draft loop forwards `current_token, d_0, ..., d_{k-2}` for
+    /// `k` proposals: the last proposal `d_{k-1}` is *sampled from* the
+    /// forward of `d_{k-2}` and is never itself forwarded. When verification
+    /// accepts and emits it, it joins the sequence while the draft cache has
+    /// no entry for it, and no amount of trimming can put it there. It is
+    /// parked here and replayed at the head of the next round's first draft
+    /// forward, which costs no extra forward pass because that forward simply
+    /// becomes two tokens wide.
+    ///
+    /// `None` at every other round boundary. Reset by [`Self::reset`].
+    ///
+    /// Mirrors the `draft_y` concatenation in upstream mlx-lm
+    /// `speculative_generate_step`
+    /// (<https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py>).
+    pending_draft_context: Option<i32>,
 }
 
 impl SpeculativeGenerator {
@@ -246,6 +277,7 @@ impl SpeculativeGenerator {
             acceptance: SpeculativeAcceptanceStats::default(),
             stochastic_acceptance: None,
             token_bias: TokenBiasMap::default(),
+            pending_draft_context: None,
         }
     }
 
@@ -327,6 +359,7 @@ impl SpeculativeGenerator {
         }
         self.generated_tokens.clear();
         self.acceptance = SpeculativeAcceptanceStats::default();
+        self.pending_draft_context = None;
     }
 
     /// Get the generated tokens
@@ -534,7 +567,23 @@ impl SpeculativeGenerator {
             let mut draft_token = current_token;
 
             for _ in 0..num_draft {
-                let draft_input = ffi::from_slice_i32(&[draft_token], &[1, 1]);
+                // A previous round that accepted its last proposal left the
+                // draft model one token behind the sequence (see
+                // `pending_draft_context`). Replay that token at the head of
+                // this round's first draft forward rather than spending a
+                // separate pass on it: the sampler's `slice_last_logits`
+                // pre-step already reads the final position, so the proposal
+                // sampled here is the one conditioned on the full replayed
+                // prefix, and the round still costs `num_draft` forwards. The
+                // draft model sees a 2-token block with no explicit mask,
+                // exactly as it does during chunked prefill and as the target
+                // does during verification, so the same causal-prefill
+                // contract covers it. `take` empties the slot, so only the
+                // first iteration of the round can replay.
+                let draft_input = match self.pending_draft_context.take() {
+                    Some(owed) => ffi::from_slice_i32(&[owed, draft_token], &[1, 2]),
+                    None => ffi::from_slice_i32(&[draft_token], &[1, 1]),
+                };
                 let draft_logits = draft_model.forward(&draft_input, &mut self.draft_caches, None);
                 // Axis B: draft sampler MUST NOT see the bias. See
                 // `draft_sampling` for the rationale.
@@ -717,6 +766,18 @@ impl SpeculativeGenerator {
                         token_history.push(draft_token);
                     }
 
+                    // `d_{k-1}` is the only proposal the draft loop never
+                    // forwards, so emitting it leaves the draft cache one entry
+                    // short of the sequence. Park it for the next round's first
+                    // draft forward. Recorded here rather than beside the bonus
+                    // token below so it is also right on the round that stops on
+                    // `max_tokens`, and so an accepted-EOS proposal (which
+                    // breaks above, before this push) never records a debt for a
+                    // token that was never emitted.
+                    if i + 1 == draft_tokens.len() {
+                        self.pending_draft_context = Some(draft_token);
+                    }
+
                     if self.generated_tokens.len() >= max_tokens {
                         done = true;
                         break;
@@ -773,24 +834,31 @@ impl SpeculativeGenerator {
             self.acceptance.proposed_draft_tokens += draft_tokens.len();
             self.acceptance.accepted_draft_tokens += accepted;
 
-            // Step 4: Rewind caches for rejected tokens
+            // Step 4: rewind whatever this round forwarded past the tokens it
+            // actually kept.
+            //
+            // Write `k` for `draft_tokens.len()` and `a` for `accepted`. Both
+            // caches must end the round holding the prompt plus every emitted
+            // token except the next round's `current_token`, which the next
+            // round forwards itself.
             let rejected = draft_tokens.len() - accepted;
             if rejected > 0 {
-                // Rewind main model caches: we forwarded all verify_tokens but
-                // only accepted `accepted` draft tokens + 1 (the divergence token from main)
-                // Main model cache has current_token + all draft tokens = verify_tokens.len() positions
-                // We need to keep: accepted + 1 (for the token we're continuing from)
-                // So trim: draft_tokens.len() - accepted
-                let main_trim = rejected as i32;
-                trim_caches(&mut self.main_caches, main_trim);
+                // Main: the verify forward appended `current_token, d_0..d_{k-1}`.
+                // The round keeps `d_0..d_{a-1}` and emits one replacement that
+                // becomes the next `current_token`, so the cache must end at
+                // `d_{a-1}`. Trim the rejected tail, `k - a == rejected`.
+                trim_caches(&mut self.main_caches, rejected as i32);
 
-                // Rewind draft model caches: drafted all draft_tokens
-                // Need to trim all rejected + 1 (because draft went past accepted)
-                let draft_trim = (rejected + 1) as i32;
-                trim_caches(
-                    &mut self.draft_caches,
-                    draft_trim.min(draft_tokens.len() as i32),
-                );
+                // Draft: after its loop the draft cache holds the prompt, every
+                // emitted token, and `d_0..d_{k-2}`: the loop feeds
+                // `current_token` and then every proposal except the last, plus
+                // any replayed `pending_draft_context`. It must also end at
+                // `d_{a-1}`, so the trim is `(k - 1) - a == rejected - 1`, one
+                // less than the main cache's and never negative here because
+                // `rejected >= 1`. Trimming `rejected + 1` instead, as this did
+                // before, left the drafter conditioning on a prefix that fell
+                // one to two tokens further behind on every single round.
+                trim_caches(&mut self.draft_caches, (rejected - 1) as i32);
             }
 
             // Periodic cache clearing, backend-aware cadence (#627): disabled by

--- a/src/lib/mlxcel-core/src/speculative/mod.rs
+++ b/src/lib/mlxcel-core/src/speculative/mod.rs
@@ -202,8 +202,9 @@ impl SpeculativeAcceptanceStats {
             let n = self.positions_tested as f64;
             line.push_str(&format!(
                 "\n[Speculative acceptance diagnostic] closed_form_sum_min={:.4} \
-                 closed_form_sum_prod={:.4} (measured per-position acceptance must sit at \
-                 sum_min, and sum_min >= sum_prod always)",
+                 closed_form_sum_prod={:.4} (the measured per-position acceptance sits at \
+                 sum_prod under the default sampler-match rule and at sum_min under the \
+                 opt-in acceptance-optimal rule; sum_min >= sum_prod always)",
                 self.closed_form_sum_min / n,
                 self.closed_form_sum_prod / n,
             ));


### PR DESCRIPTION
## Summary

The draft model's KV cache was rewound by `min(rejected + 1, k)` on every rejecting round, two entries more than the round had to give back, and the shortfall was never recovered. The drafter's context fell monotonically behind the emitted sequence, its proposals decayed, acceptance fell, and the loop reinforced itself. This corrects the trim to `rejected - 1` and resolves the fully-accepted case, which the trim cannot reach at all.

## The arithmetic

Write `k` for `draft_tokens.len()` and `a` for `accepted`.

The draft loop forwards `current_token, d_0, ..., d_{k-2}`: the input to iteration `j` is the token iteration `j - 1` produced, so the last proposal `d_{k-1}` is *sampled from* the forward of `d_{k-2}` and is never itself forwarded. The verify pass forwards `current_token, d_0, ..., d_{k-1}`, one token more.

Both caches must end the round holding the prompt plus every emitted token except the next round's `current_token`, which the next round forwards itself. So the main trim is `k - a == rejected` (unchanged, and it was already right) and the draft trim is `(k - 1) - a == rejected - 1`, exactly one less. This matches upstream mlx-lm [`speculative_generate_step`](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py), whose `_rewind_cache` trims `num_draft - num_accept` from the target cache and `max(num_draft - num_accept - 1, 0)` from the draft cache.

### The all-accepted case, and why clamping at zero is wrong

At `a == k` the formula gives `-1`, and the issue asks for this to be resolved rather than clamped. Clamping is wrong because the sign is telling the truth: the cache is genuinely **missing** an entry rather than holding a spare one. `d_{k-1}` was accepted and emitted, so it is part of the sequence, but the draft loop never forwarded it. A trim of `-1` would have to *insert* it, which `KVCache::trim` cannot do, and a trim of `0` leaves the drafter one token behind for the rest of the run, accumulating one entry per fully-accepted round.

The entry has to be supplied, and there are two ways to do it: a separate one-token catch-up forward, or fold it into the next forward the draft model was going to make anyway. This PR takes the second. `d_{k-1}` is parked in a new `SpeculativeGenerator::pending_draft_context` and replayed at the head of the next round's first draft forward, making that forward two tokens wide instead of one. The round still costs `num_draft` draft forwards rather than `num_draft + 1`, and the sampler's `slice_last_logits` pre-step already reads the final position, so the proposal sampled there is the one conditioned on the full replayed prefix. The draft model sees a multi-token block with no explicit mask, which is the same contract it already meets during chunked prefill and the target already meets during verification. Upstream handles the same case the same way, with `draft_y = concatenate([draft_tokens[-1:], draft_y])`.

The debt is recorded where the token is pushed to `generated_tokens`, not beside the bonus token, so it is also correct on the round that stops on `max_tokens`, and so an accepted-EOS proposal (which breaks before the push) never records a debt for a token that was never emitted.

All three regimes and all three acceptance rules are covered: the trim runs after the accept loop and never reads the rule, so sampler-match, greedy-argmax and stochastic are affected identically.

## What changed

- `src/lib/mlxcel-core/src/speculative/mod.rs`
  - Draft trim corrected from `min(rejected + 1, k)` to `rejected - 1`; main trim unchanged.
  - New private field `pending_draft_context: Option<i32>`, cleared by `reset`, set when a round emits its last proposal, consumed by `take()` at the first draft forward of the next round.
  - Module-level `## Cache invariant` section stating the invariant both caches must satisfy at a round boundary.
- `src/lib/mlxcel-core/src/speculative/distribution_tests.rs`
  - `draft_cache_falls_behind_the_main_cache_every_round_pre_existing_defect` (which deliberately asserted the wrong values) replaced by `draft_cache_tracks_the_emitted_sequence_in_every_acceptance_regime`, asserting `draft offset + tokens owed == main offset` per layer across the all-reject, all-accept and mixed regimes at `num_draft` 1 through 5.
  - New `a_fully_accepted_round_owes_its_last_proposal_and_the_next_round_pays_it`, which pins that the debt is a real one-token shortfall and that the next round clears it by replaying rather than staying two entries behind. Without it the `+ owed` term could be vacuously zero.
- `docs/speculative-acceptance.md`: re-measured entropy table, corrected the claim that the measured rate sits on `sum_min` under the default rule (it sits on `sum_prod`), removed the now-obsolete note about 2x between-trajectory variance, and listed the two new regression guards.

## Measurements

`models/meta-llama-3.1-8b-instruct-4bit` target, `models/llama-3.2-1b-instruct` drafter, `--num-draft-tokens 4 --temp 0.7 --no-chat-template -n 200`, `MLXCEL_SPECULATIVE_ACCEPT_DIAG=1`, default sampler-match rule, five seeds. A raw continuation prompt is used rather than a chat-templated one because the Llama 3.1 chat template emits a tool call and hits EOS after ~65 tokens on some seeds, which mixes trajectory length into the spread being measured.

| seed | `per_position_acceptance` before | after | `closed_form_sum_min` before | after | tok/s before | after |
|---|---|---|---|---|---|---|
| 1234 | 0.0452 | 0.6854 | 0.0913 | 0.7780 | 18.46 | 42.99 |
| 2345 | 0.1768 | 0.6721 | 0.2109 | 0.7945 | 21.29 | 43.41 |
| 3456 | 0.1878 | 0.5676 | 0.2084 | 0.7468 | 21.40 | 36.08 |
| 4567 | 0.1667 | 0.6505 | 0.2204 | 0.7737 | 20.85 | 42.54 |
| 5678 | 0.2205 | 0.6813 | 0.2823 | 0.7787 | 21.99 | 43.82 |
| **mean** | **0.159** | **0.651** | **0.203** | **0.774** | **20.80** | **41.77** |

Measured per-position acceptance moves from 0.159 to 0.651, into the 0.6 to 0.8 band the issue cites for a comparable pair, and throughput doubles.

### Run-to-run spread of `closed_form_sum_min`

`closed_form_sum_min` is `sum_x min(p(x), q(x))` averaged over tested positions. It is a property of the model pair, so it should barely move between runs; the issue reports 0.221 and 0.396 on two 200-token runs, a 1.8x spread, as evidence of the feedback loop.

- Before: 0.0913 to 0.2823, a **3.09x** spread.
- After: 0.7468 to 0.7945, a **1.06x** spread.

The spread collapsing is the direct evidence that the feedback loop is gone. Under the defect the drift rate depended on the acceptance rate, so two runs that diverged early ended up in different regimes; with the drafter kept level with the target, every trajectory measures the same underlying quantity.

Secondary confirmation from the same runs: `positions_tested / rounds` was about 1.2 before (nearly every round rejecting at position 0, the frozen-drafter signature) and about 2.4 after, and rounds per 200 emitted tokens fell from about 167 to about 80.

## Temperature-0 equivalence

The issue expects temperature-0 output to change. **It does not**, and that is worth stating as a finding rather than glossing.

Two prompts, `num_draft` 1 and 4, 128 tokens, compared against a drafterless greedy reference produced by the same binary with no `--draft-model`:

| comparison | result |
|---|---|
| before, speculative vs drafterless greedy | identical, all 4 combinations |
| after, speculative vs drafterless greedy | identical, all 4 combinations |
| before vs after, speculative | identical, all 4 combinations |

At temperature 0 the emitted token is the target's argmax whether the proposal is accepted (the argmax equals the proposal, by definition of the accept test) or rejected (the argmax is emitted as the replacement). The drafter therefore cannot move the stream at all; it only changes how many target forwards it takes to produce it. The verify batch shape does change with the proposals, which leaves room for f16 jitter, but none was observed on either prompt at either block size. Speculative decoding remains output-equivalent to plain greedy at temperature 0, before and after.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --release --all-targets --features metal,accelerate -- -D warnings` clean. Run in the release profile deliberately: `make verify-clippy` uses the debug profile, which would trigger a cold MLX C++ build in this environment.
- [x] `cargo test --release --features metal,accelerate --no-fail-fast -- --test-threads=1`. One failure, `granite4_vision_parity::text_only_forward_produces_finite_logits`, which is pre-existing and already tracked by #997. Confirmed unrelated: the test performs a single `LanguageModel::forward` on a VLM and never constructs a `SpeculativeGenerator`, and pre-fix and post-fix binaries produce byte-identical degenerate output on that checkpoint.
- [x] `cargo test --release --features metal,accelerate -p mlxcel-core speculative::distribution_tests:: -- --test-threads=1`: 15 passed, 0 failed.
- [x] **Negative control**: with the trim reverted to `rejected + 1` and the debt recording removed, both new tests fail (`draft cache holds 1 entries against the target's 24` in the all-reject regime, and `left: None, right: Some(5)` for the debt), while the other 13 in the file still pass. The new gate has teeth against exactly the defect it describes.
- [x] Real-checkpoint acceptance and throughput measurements above, five seeds each arm.
- [x] Real-checkpoint temperature-0 equivalence against a drafterless greedy reference, both prompts, `num_draft` 1 and 4.
- [x] `python3 scripts/ci/check_cross_repo_refs.py` clean.

Closes #994
